### PR TITLE
feat(tmux): add scratch slots 7-12 to increase capacity

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -96,6 +96,48 @@ bind -n M-P if-shell -F '#{==:#{session_name},scratch6}' \
         -S 'fg=#689d6a' -T ' Pool ' \
         -E 'tmux attach-session -t scratch6 || tmux new-session -s scratch6' }
 
+# Seventh persistent scratch terminal toggle (Alt+o)
+bind -n M-o if-shell -F '#{==:#{session_name},scratch7}' \
+    { detach-client } \
+    { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
+        -S 'fg=#fe8019' -T ' Orange ' \
+        -E 'tmux attach-session -t scratch7 || tmux new-session -s scratch7' }
+
+# Eighth persistent scratch terminal toggle (Alt+Shift+O)
+bind -n M-O if-shell -F '#{==:#{session_name},scratch8}' \
+    { detach-client } \
+    { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
+        -S 'fg=#d3869b' -T ' Orchid ' \
+        -E 'tmux attach-session -t scratch8 || tmux new-session -s scratch8' }
+
+# Ninth persistent scratch terminal toggle (Alt+n)
+bind -n M-n if-shell -F '#{==:#{session_name},scratch9}' \
+    { detach-client } \
+    { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
+        -S 'fg=#458588' -T ' Navy ' \
+        -E 'tmux attach-session -t scratch9 || tmux new-session -s scratch9' }
+
+# Tenth persistent scratch terminal toggle (Alt+Shift+N)
+bind -n M-N if-shell -F '#{==:#{session_name},scratch10}' \
+    { detach-client } \
+    { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
+        -S 'fg=#928374' -T ' Nickel ' \
+        -E 'tmux attach-session -t scratch10 || tmux new-session -s scratch10' }
+
+# Eleventh persistent scratch terminal toggle (Alt+w)
+bind -n M-w if-shell -F '#{==:#{session_name},scratch11}' \
+    { detach-client } \
+    { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
+        -S 'fg=#ebdbb2' -T ' Wheat ' \
+        -E 'tmux attach-session -t scratch11 || tmux new-session -s scratch11' }
+
+# Twelfth persistent scratch terminal toggle (Alt+Shift+W)
+bind -n M-W if-shell -F '#{==:#{session_name},scratch12}' \
+    { detach-client } \
+    { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
+        -S 'fg=#af3a03' -T ' Walnut ' \
+        -E 'tmux attach-session -t scratch12 || tmux new-session -s scratch12' }
+
 # Scratchpad picker (Alt+Shift+T) — toggle/create named scratchpads
 bind -n M-T display-popup -E -w 80% -h 80% -S 'fg=#d65d0e' -T ' scratchpads ' \
     ~/.config/tmux/scratch-picker.sh
@@ -186,7 +228,7 @@ set -g window-status-activity-style 'bg=default'
 set -g status-left '#{?client_prefix,#[bg=#d79921],#[bg=#83a598]}#[fg=#282828,bold] #S #[default] #(~/.config/tmux/scratch-status.sh) '
 # Batch idle-color updater runs once per status-interval (replaces per-window #() calls)
 set -g status-right '#(~/.config/tmux/idle-update.sh)#(~/.config/tmux/claude-counters.sh) #[fg=#ebdbb2]%H:%M #[fg=#282828,bg=#83a598] #H '
-set -g status-left-length 55
+set -g status-left-length 90
 set -g status-right-length 70
 
 # Pane borders

--- a/scripts/tmux-scratch-monitor.sh
+++ b/scripts/tmux-scratch-monitor.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Monitor popup: live HUD of the last N lines from all 6 scratch sessions.
+# Monitor popup: live HUD of the last N lines from all 12 scratch sessions.
 # Bound to Alt+m. Auto-refreshes every REFRESH seconds. Dismiss with q/Esc.
 #
 # Each section renders:
 #   ── grove                    (header in slot color; dim if session not started)
 #   <last per_section lines of capture-pane>
 #
-# Per-section line count adapts to popup height so all 6 fit without scroll.
+# Per-section line count adapts to popup height so all slots fit without scroll.
 
 REFRESH=${REFRESH:-2}
 
@@ -18,6 +18,12 @@ SLOTS=(
     "V:scratch4:#83a598:Vapor"
     "p:scratch5:#cc241d:poppy"
     "P:scratch6:#689d6a:Pool"
+    "o:scratch7:#fe8019:Orange"
+    "O:scratch8:#d3869b:Orchid"
+    "n:scratch9:#458588:Navy"
+    "N:scratch10:#928374:Nickel"
+    "w:scratch11:#ebdbb2:Wheat"
+    "W:scratch12:#af3a03:Walnut"
 )
 
 hex_to_rgb() {
@@ -26,13 +32,14 @@ hex_to_rgb() {
 }
 
 render() {
-    local rows cols per_section
+    local rows cols per_section nslots
     rows=$(tput lines 2>/dev/null || echo 40)
     cols=$(tput cols 2>/dev/null || echo 80)
+    nslots=${#SLOTS[@]}
 
     # Reserve 1 header line + 1 blank line per section + 1 footer line.
-    # Available content = rows - (6 headers + 6 blanks + 1 footer) = rows - 13
-    per_section=$(( (rows - 13) / 6 ))
+    # Available content = rows - (nslots headers + nslots blanks + 1 footer)
+    per_section=$(( (rows - (2 * nslots + 1)) / nslots ))
     [[ $per_section -lt 2 ]] && per_section=2
 
     printf '\033[H\033[2J'  # clear + home

--- a/scripts/tmux-scratch-status.sh
+++ b/scripts/tmux-scratch-status.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Scratch slot indicator for tmux status-left.
-# Renders the 6 scratch slots as their hotkey letter, colored to match the
+# Renders the 12 scratch slots as their hotkey letter, colored to match the
 # popup border color set in .tmux.conf, so the status bar acts as a legend
 # mapping popup color -> hotkey.
 #
@@ -30,7 +30,7 @@ tmux list-sessions -F '#{session_name}' 2>/dev/null \
   | awk -v waiting="$waiting" '
     BEGIN {
         # slot key : session : color (matches popup -s border color in .tmux.conf)
-        n = split("scratch:g:#b8bb26 scratch2:G:#d79921 scratch3:v:#b16286 scratch4:V:#83a598 scratch5:p:#cc241d scratch6:P:#689d6a", slots, " ")
+        n = split("scratch:g:#b8bb26 scratch2:G:#d79921 scratch3:v:#b16286 scratch4:V:#83a598 scratch5:p:#cc241d scratch6:P:#689d6a scratch7:o:#fe8019 scratch8:O:#d3869b scratch9:n:#458588 scratch10:N:#928374 scratch11:w:#ebdbb2 scratch12:W:#af3a03", slots, " ")
         for (i = 1; i <= n; i++) {
             split(slots[i], p, ":")
             sess[i]      = p[1]


### PR DESCRIPTION
## What

Extends the colored/named tmux scratch toggles from **6 → 12** to add parallel-scratch capacity. The existing 6 (grove/Gold/violet/Vapor/poppy/Pool) proved that *distinct color + mnemonic name per key* makes slots instantly memorable; this adds 3 more letters, each with a lowercase + Shift variant.

| Key | Session | Name | Color | Hue gap filled |
|-----|---------|------|-------|----------------|
| `M-o` | scratch7 | Orange | `#fe8019` | orange |
| `M-O` | scratch8 | Orchid | `#d3869b` | pink/magenta |
| `M-n` | scratch9 | Navy | `#458588` | deep blue |
| `M-N` | scratch10 | Nickel | `#928374` | gray |
| `M-w` | scratch11 | Wheat | `#ebdbb2` | light/cream |
| `M-W` | scratch12 | Walnut | `#af3a03` | brown |

Colors were chosen to fill **unused hue regions** so the status-bar legend stays a readable color→key map. Keys avoid `M-b`/`M-f` so they don't shadow shell word-motion inside scratch shells.

## Changes (the 3 slot-definition sync points)

- **`.tmux.conf`** — 6 new toggle blocks mirroring the existing pattern; bump `status-left-length` 55→90 so the now-12-letter legend isn't truncated behind a long session name.
- **`scripts/tmux-scratch-status.sh`** — extend the awk slot table to 12.
- **`scripts/tmux-scratch-monitor.sh`** — add the 6 slots; generalize per-section height math from hardcoded `/6` to `${#SLOTS[@]}` so the monitor HUD adapts to slot count.

The `M-T` picker and `M-[` recent-toggle need no change (they already glob `scratch*`).

## Verification

- `bash -n` passes on both scripts; `scratch-status.sh` renders correctly (6 active colored, 7–12 dim/not-started).
- `tmux source-file` parses the edited config with no syntax error; all 6 new root binds register → scratch7–12.
- **Not yet verified live:** the status-bar legend showing the new letters requires `home-manager switch --flake . --impure` to relink the updated script, plus an interactive key press to confirm each popup opens in its color. Hand-off check below.

### Post-merge live check
1. `home-manager switch --flake . --impure`
2. Press `M-o`, `M-O`, `M-n`, `M-N`, `M-w`, `M-W` — each opens a popup with the right border color/title.
3. Status legend shows `g G v V p P o O n N w W`, new letters lighting up as their sessions get created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)