### PR TITLE
fix(i3): free Alt+w for tmux scratch11 (Wheat)

### DIFF
--- a/nix/system/i3config.nix
+++ b/nix/system/i3config.nix
@@ -62,7 +62,8 @@ bindsym $mod+Shift+Right move right
 bindsym $mod+f fullscreen toggle
 
 # Layouts
-bindsym $mod+w layout tabbed
+# tabbed moved off $mod+w (was) so Alt+w passes through to tmux scratch11 (Wheat)
+bindsym $mod+Shift+t layout tabbed
 bindsym $mod+e layout toggle split
 bindsym $mod+equal exec --no-startup-id ~/workspace/devrc/scripts/i3-grid
 


### PR DESCRIPTION
## Problem

After #1 added 12 tmux scratch slots, `M-w` (scratch11 / Wheat) did nothing while `M-W` (scratch12 / Walnut) worked.

Root cause: i3's `bindsym $mod+w layout tabbed` (`$mod` = `Mod1` = Alt) grabs **Alt+w** globally — before it reaches Alacritty/tmux. `Alt+Shift+w` is unbound in i3, so scratch12 passed through fine. No other scratch key collides (`$mod+g/v/p/o/n` are unbound in i3).

## Fix

Move `layout tabbed` to `$mod+Shift+t` (free in i3), freeing Alt+w for the tmux scratch toggle. One-line change, preserves the `w`/`W` = Wheat/Walnut mnemonic pair.

## Deploy (laptop only — main host is headless, no i3)

`nix/system/i3config.nix` is a NixOS system config, deployed separately from home-manager:
1. `git pull` on the laptop
2. `sudo cp nix/system/i3config.nix /etc/nixos/i3config.nix`
3. `sudo nixos-rebuild switch`
4. `i3-msg reload` (from user shell)

## Verification

- Static: only `$mod+w` → `$mod+Shift+t` changed; `$mod+Shift+t` confirmed free in i3 config.
- **Pending live:** after deploy on laptop, `M-w` should open the Wheat popup (scratch11); `$mod+Shift+t` toggles tabbed layout. Needs an interactive keypress to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)