### PR TITLE
fix(tmux): lowercase scratch names for lowercase-key slots

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -100,7 +100,7 @@ bind -n M-P if-shell -F '#{==:#{session_name},scratch6}' \
 bind -n M-o if-shell -F '#{==:#{session_name},scratch7}' \
     { detach-client } \
     { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
-        -S 'fg=#fe8019' -T ' Orange ' \
+        -S 'fg=#fe8019' -T ' orange ' \
         -E 'tmux attach-session -t scratch7 || tmux new-session -s scratch7' }
 
 # Eighth persistent scratch terminal toggle (Alt+Shift+O)
@@ -114,7 +114,7 @@ bind -n M-O if-shell -F '#{==:#{session_name},scratch8}' \
 bind -n M-n if-shell -F '#{==:#{session_name},scratch9}' \
     { detach-client } \
     { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
-        -S 'fg=#458588' -T ' Navy ' \
+        -S 'fg=#458588' -T ' navy ' \
         -E 'tmux attach-session -t scratch9 || tmux new-session -s scratch9' }
 
 # Tenth persistent scratch terminal toggle (Alt+Shift+N)
@@ -128,7 +128,7 @@ bind -n M-N if-shell -F '#{==:#{session_name},scratch10}' \
 bind -n M-w if-shell -F '#{==:#{session_name},scratch11}' \
     { detach-client } \
     { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
-        -S 'fg=#ebdbb2' -T ' Wheat ' \
+        -S 'fg=#ebdbb2' -T ' wheat ' \
         -E 'tmux attach-session -t scratch11 || tmux new-session -s scratch11' }
 
 # Twelfth persistent scratch terminal toggle (Alt+Shift+W)

--- a/scripts/tmux-scratch-monitor.sh
+++ b/scripts/tmux-scratch-monitor.sh
@@ -18,11 +18,11 @@ SLOTS=(
     "V:scratch4:#83a598:Vapor"
     "p:scratch5:#cc241d:poppy"
     "P:scratch6:#689d6a:Pool"
-    "o:scratch7:#fe8019:Orange"
+    "o:scratch7:#fe8019:orange"
     "O:scratch8:#d3869b:Orchid"
-    "n:scratch9:#458588:Navy"
+    "n:scratch9:#458588:navy"
     "N:scratch10:#928374:Nickel"
-    "w:scratch11:#ebdbb2:Wheat"
+    "w:scratch11:#ebdbb2:wheat"
     "W:scratch12:#af3a03:Walnut"
 )
 


### PR DESCRIPTION
Follow-up nit to #1. The 6 original slots follow a case convention — lowercase Alt key gets a lowercase name (`grove`/`violet`/`poppy`), Shift key gets an Uppercase name (`Gold`/`Vapor`/`Pool`). Slots 7/9/11 broke it with capitalized names.

- `Orange` → `orange` (`M-o`)
- `Navy` → `navy` (`M-n`)
- `Wheat` → `wheat` (`M-w`)

Shift variants (`Orchid`/`Nickel`/`Walnut`) already matched. Changed the popup `-T` titles in `.tmux.conf` and the `SLOTS` array in `tmux-scratch-monitor.sh`. The status legend uses only the key letter, so no change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)