### PR TITLE
feat(espanso): tune prompt snippets from session-usage mining

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -50,15 +50,22 @@ in
 
           # hot singles
           { trigger = "dashbaord"; replace = "dashboard"; }
+          { trigger = "reocmmend"; replace = "recommend"; }
 
           # Workflows
           { trigger = ":whn"; replace = "write the handoff to continue in next session"; label = "Write handoff for next session"; search_terms = ["handoff" "session"]; }
-          { trigger = ":rau"; replace = "dispatch a subagent to audit the PR for risks, regressions, assumptions, gaps, bugs, issues, behaviour changes, leaks, second-order consequences"; label = "PR audit checklist tail"; search_terms = ["review" "audit" "pr" "risks" "regressions" "subagent"]; }
-          { trigger = ":rns"; replace = "recommend next steps, improvements, extension, evaluation, evolution, iteration"; label = "Recommend next steps & evolution"; search_terms = ["next" "recommend" "steps" "improvements" "extension" "evaluation" "evolution" "iteration"]; }
+          { trigger = ":rau"; replace = "dispatch a subagent to audit the PR for risks, regressions, assumptions, gaps, edge cases, bugs, issues, behaviour changes, leaks, second-order consequences"; label = "PR audit checklist tail"; search_terms = ["review" "audit" "pr" "risks" "regressions" "subagent"]; }
+          { trigger = ":rns"; replace = "recommend next steps"; label = "Recommend next steps"; search_terms = ["next" "recommend" "steps" "whats next"]; }
           { trigger = ":pst"; replace = "proceed, use subagent, ensure test coverage"; label = "Proceed with subagent + test coverage"; search_terms = ["proceed" "subagent" "test" "coverage" "dispatch" "yes"]; }
           { trigger = ":kickoff"; replace = "give me the kickoff message to copy paste to next session"; label = "Kickoff message for next session"; search_terms = ["kickoff" "kick off" "next session" "copy paste" "handoff" "message"]; }
-          { trigger = ":usd"; replace = "update the skills and project docs then write the handoff to proceed in next session"; label = "Update skills + docs + write handoff"; search_terms = ["update" "skill" "skills" "docs" "documentation" "handoff" "session"]; }
           { trigger = ":nday"; replace = "it's the next day, check"; label = "Next-day check-in"; search_terms = ["next day" "check" "days" "resume" "morning"]; }
+          { trigger = ":fhrs"; replace = "it's been a few hours, check"; label = "Few-hours check-in"; search_terms = ["hours" "check" "elapsed" "resume"]; }
+          { trigger = ":fdays"; replace = "it's been a few days, check"; label = "Few-days check-in"; search_terms = ["days" "check" "elapsed" "resume"]; }
+          { trigger = ":mdc"; replace = "merged and deployed, check"; label = "Merged and deployed, check"; search_terms = ["merged" "deployed" "check" "verify"]; }
+          { trigger = ":wn"; replace = "what's next"; label = "What's next"; search_terms = ["next" "whats next" "what next"]; }
+          { trigger = ":cont"; replace = "continue from where you left off."; label = "Continue from where you left off"; search_terms = ["continue" "resume" "left off"]; }
+          { trigger = ":pec"; replace = "push an empty commit"; label = "Push an empty commit"; search_terms = ["push" "empty" "commit" "trigger" "ci"]; }
+          { trigger = ":aep"; replace = "dispatch subagents to audit each PR for risks, regressions, assumptions, gaps, edge cases, bugs, issues, behaviour changes, leaks, second-order consequences"; label = "Audit each PR (one subagent per PR)"; search_terms = ["audit" "each" "prs" "subagents" "risks" "regressions" "review"]; }
 
           { trigger = ":cc"; replace = "${workspace}/civit/civitai "; label = "civitai main repo path"; search_terms = ["civitai" "repo" "web"]; }
           { trigger = ":cdp"; replace = "${workspace}/civit/datapacket-talos "; label = "civitai datapacket-talos path"; search_terms = ["civitai"]; }

--- a/scripts/session-analysis/espanso-usage.py
+++ b/scripts/session-analysis/espanso-usage.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Mine Claude transcripts for espanso snippet usage + snippet candidates.
+
+espanso expands a trigger to its replacement BEFORE Claude sees it, so
+transcripts contain the replacement text, never the trigger. We detect usage
+by matching each snippet's distinctive expansion substring in human-typed
+user messages, and surface recurring phrases that are not yet snippets.
+"""
+import json, os, re, glob, collections
+
+ROOT = os.path.expanduser("~/.claude/projects")
+
+# trigger -> (kind, distinctive lowercased match substrings; None = not text-detectable)
+SNIPPETS = {
+    ":date":     ("date", None),
+    ":time":     ("date", None),
+    ":datetime": ("date", None),
+    ":iso":      ("date", None),
+    ":hlt":      ("path", ["homelab-talos"]),
+    ":kuc":      ("path", ["workspace/kubeclaw"]),
+    ":nixos":    ("path", ["/etc/nixos/configuration.nix"]),
+    ":cc":       ("path", ["civit/civitai "]),
+    ":cdp":      ("path", ["civit/datapacket-talos"]),
+    ":cgf":      ("path", ["civitai-gpu-fleet"]),
+    ":cmo":      ("path", ["civitai-orchestration"]),
+    ":csc":      ("path", ["civitai-spine-controller"]),
+    ":cpk":      ("path", ["datapacket-talos/prod-kubeconfig"]),
+    ":subk":     ("path", ["submodel-dc-03-a-kubeconfig"]),
+    ":whn":      ("prompt", ["write the handoff to continue in next session"]),
+    ":rau":      ("prompt", ["audit the pr for risks, regressions"]),
+    ":rns":      ("prompt", ["recommend next steps, improvements, extension"]),
+    ":pst":      ("prompt", ["proceed, use subagent, ensure test coverage"]),
+    ":kickoff":  ("prompt", ["kickoff message to copy paste to next session"]),
+    ":usd":      ("prompt", ["update the skills and project docs then write the handoff"]),
+    ":nday":     ("prompt", ["it's the next day, check"]),
+    ":uuid":     ("util", None),
+    ":clip":     ("util", None),
+    "dashbaord": ("typo", None),
+}
+
+counts = {t: 0 for t in SNIPPETS}
+sessions_hit = {t: set() for t in SNIPPETS}
+last_seen = {t: None for t in SNIPPETS}
+
+# snippet-candidate mining
+short_msgs = collections.Counter()        # exact normalized short messages
+phrase_counter = collections.Counter()    # recurring 3-6 word phrases
+total_user_msgs = 0
+
+KNOWN_EXPANSIONS = [m for _, subs in SNIPPETS.values() if subs for m in subs]
+
+def human_text(o):
+    """Return human-typed text from a user record, or None if it's a tool
+    result / slash-command wrapper / interrupt / system reminder."""
+    if o.get("type") != "user":
+        return None
+    m = o.get("message", {})
+    c = m.get("content")
+    if isinstance(c, list):
+        parts = []
+        for b in c:
+            if isinstance(b, dict):
+                if b.get("type") == "tool_result":
+                    return None
+                if b.get("type") == "text":
+                    parts.append(b.get("text", ""))
+        txt = "\n".join(parts)
+    elif isinstance(c, str):
+        txt = c
+    else:
+        return None
+    s = txt.strip()
+    if not s:
+        return None
+    low = s.lower()
+    if s.startswith("<command-") or "<local-command-stdout>" in s \
+       or s.startswith("[request interrupted") or low.startswith("caveat:") \
+       or s.startswith("<system-reminder") or "tool_use_id" in s:
+        return None
+    return s
+
+WORD = re.compile(r"[a-z][a-z'\-]+")
+
+def norm(s):
+    return " ".join(s.lower().split())
+
+for fp in glob.glob(os.path.join(ROOT, "**", "*.jsonl"), recursive=True):
+    sid = os.path.basename(fp)[:8]
+    try:
+        with open(fp, errors="ignore") as fh:
+            for line in fh:
+                if '"type":"user"' not in line and '"type": "user"' not in line:
+                    continue
+                try:
+                    o = json.loads(line)
+                except Exception:
+                    continue
+                s = human_text(o)
+                if s is None:
+                    continue
+                total_user_msgs += 1
+                low = s.lower()
+                ts = o.get("timestamp", "")[:10]
+                # snippet usage
+                for t, (kind, subs) in SNIPPETS.items():
+                    if not subs:
+                        continue
+                    if any(sub in low for sub in subs):
+                        counts[t] += 1
+                        sessions_hit[t].add(sid)
+                        if ts and (last_seen[t] is None or ts > last_seen[t]):
+                            last_seen[t] = ts
+                # candidate mining: only on shortish human messages
+                if len(s) <= 140 and not s.startswith("/"):
+                    n = norm(s)
+                    # skip if it's a known expansion
+                    if not any(e in n for e in KNOWN_EXPANSIONS):
+                        if len(n) >= 3:
+                            short_msgs[n] += 1
+                        words = WORD.findall(n)
+                        for k in (4, 5):
+                            for i in range(len(words) - k + 1):
+                                phrase_counter[" ".join(words[i:i+k])] += 1
+    except Exception:
+        continue
+
+print(f"# Total human user messages scanned: {total_user_msgs}\n")
+
+print("## Espanso snippet usage (text-detectable)\n")
+print(f"{'trigger':12} {'kind':7} {'hits':>6} {'sessions':>9}  last-seen")
+order = sorted(SNIPPETS, key=lambda t: (-counts[t], t))
+for t in order:
+    kind, subs = SNIPPETS[t]
+    if subs is None:
+        print(f"{t:12} {kind:7} {'   n/a':>6} {'      n/a':>9}  (not text-detectable)")
+    else:
+        print(f"{t:12} {kind:7} {counts[t]:>6} {len(sessions_hit[t]):>9}  {last_seen[t] or '-'}")
+
+print("\n## Recurring short user messages NOT already snippets (top 40)\n")
+STOP_EXACT = {"yes", "ok", "okay", "y", "continue", "go", "proceed", "do it",
+              "yes do it", "no", "thanks", "thank you", "good", "nice", "next",
+              "stop", "wait", "k", "yep", "yes please", "sure", "perfect"}
+for msg, n in short_msgs.most_common(120):
+    if n < 4:
+        break
+    if msg in STOP_EXACT:
+        continue
+    if len(msg) < 8:
+        continue
+    print(f"{n:4}  {msg[:110]}")
+
+print("\n## Recurring 4-5 word phrases (top 40, candidate building blocks)\n")
+GENERIC = re.compile(r"^(the|a|to|of|in|and|for|is|it|that|this|you|i|we|on|with)\b")
+shown = 0
+for ph, n in phrase_counter.most_common(400):
+    if n < 8:
+        break
+    # skip phrases that are mostly filler
+    if any(e.startswith(ph[:15]) for e in KNOWN_EXPANSIONS):
+        continue
+    print(f"{n:4}  {ph}")
+    shown += 1
+    if shown >= 40:
+        break

--- a/scripts/task-spec-drafter/README.md
+++ b/scripts/task-spec-drafter/README.md
@@ -35,6 +35,45 @@ clawgate. **SHADOW by default** — it writes the queue + logs "would send" and
    flags `NEEDS-DECISION` rather than draft a confident, possibly-harmful task
    (the meili-cron lesson). Drafting is gated behind verification, by construction.
 
+## Model + the deterministic safety-escalation gate
+
+The per-ticket reasoning pass runs on **Haiku by default** (`DRAFTER_MODEL=haiku`;
+override to `sonnet`/`opus` or a full id). Haiku is ~cents not dollars per ticket.
+
+**Why a structural gate is mandatory.** A measured test showed Haiku runs the
+verify tools fine but **lacks the judgment to flag intent-ambiguity**: it
+confidently mis-drafted the safety-critical "Civitai Link on `.red`" cert ticket
+as a high-confidence `TASK` with **no** `safety_flag` (Opus correctly said
+`NEEDS-DECISION`), and missed it even with more tool turns. So we **do not trust
+the model's self-assessment** for the dangerous classes. The fix is structural
+(code), not prompt/model.
+
+**What the gate does** (`safety_gate()` in `drafter.sh`). After the model emits
+its record, a deterministic step scans the **ticket text (title + body + all
+comments) AND the model's own verification/spec text** for risk keywords
+(word-boundary, case-insensitive). If any RISK category matches, it **overrides
+the model**: forces `classification = NEEDS-DECISION`, `spec.autonomy =
+needs-Zach`, blanks the dispatchable spec, downgrades a `high` confidence to
+`medium`, and stamps `safety_flag` + audit fields (`gate_fired`,
+`gate_categories`, `gate_override_from`). It runs independently of what the model
+returned — even an `ERROR`/timeout record passes through it.
+
+Risk categories (tune the regexes at the top of `drafter.sh`):
+
+| Category | Keywords (abbrev.) |
+|---|---|
+| **security/secrets** | cert, tls, ssl, mtls, mta-sts, secret, token, credential, password, auth, authn/authz, rbac, vuln, cve, disclosure, exploit, x509, `.red` |
+| **money** | buzz, currency, payment, refund, withdraw, payout, billing, invoice, stripe, paypal, subscription, chargeback, wallet, merch |
+| **destructive/prod-mutation** | delete, drop, truncate, migration, rollback, restore, prod/production, scale down, evict, wipe, purge, destroy, drop table, force push |
+
+The gate is intentionally **conservative (escalate-on-touch)**: `migration` /
+`delete` / `prod` are common dev words, so the destructive category fires often.
+That bias is the point — a false escalation costs one human glance; a false
+auto-dispatch on a `.red`-cert / Blue-Buzz-currency / prod-`delete` ticket is the
+harm this exists to prevent. Verified to catch both Opus-safety-rule cases (the
+`.red` cert ticket → security, the Blue-Buzz currency ticket → money) **even
+though Haiku alone did not flag them.**
+
 ## Files (all in devrc — harness artifacts, NOT a project repo)
 
 | File | Purpose |

--- a/scripts/task-spec-drafter/drafter.sh
+++ b/scripts/task-spec-drafter/drafter.sh
@@ -31,6 +31,10 @@
 #   on     — run + actually POST the triage summary to clawgate
 #
 # Other knobs:
+#   DRAFTER_MODEL         model for the headless claude -p pass (def haiku). Alias
+#                         (haiku|sonnet|opus) or full id. Haiku is the cheap shadow
+#                         default; the deterministic safety gate (below) compensates
+#                         for Haiku's measured intent-ambiguity blind spot.
 #   DRAFTER_MAX_TICKETS   cap tickets processed per run (def 0 = all)
 #   DRAFTER_TIMEOUT       seconds budget per ticket's claude -p call (def 240)
 #   DRAFTER_OUT_DIR       where shadow queues are written (def ~/.claude/task-spec-drafter)
@@ -53,6 +57,7 @@ DRAFTER_CONF="${DRAFTER_CONF_FILE:-$HOME/.claude/task-spec-drafter.env}"
 [ -f "$DRAFTER_CONF" ]  && { set -a; . "$DRAFTER_CONF"  2>/dev/null || true; set +a; }
 
 DRAFTER_MODE="${DRAFTER_MODE:-shadow}"
+DRAFTER_MODEL="${DRAFTER_MODEL:-haiku}"
 DRAFTER_MAX_TICKETS="${DRAFTER_MAX_TICKETS:-0}"
 DRAFTER_TIMEOUT="${DRAFTER_TIMEOUT:-240}"
 DRAFTER_OUT_DIR="${DRAFTER_OUT_DIR:-$HOME/.claude/task-spec-drafter}"
@@ -73,6 +78,67 @@ DRAFTER_ALLOWED_TOOLS="${DRAFTER_ALLOWED_TOOLS:-Read,Glob,Grep,WebFetch,Bash(nod
 
 mkdir -p "$DRAFTER_OUT_DIR" 2>/dev/null || true
 log() { printf '[%s] %s\n' "$(date '+%F %T')" "$*" | tee -a "$DRAFTER_LOG_FILE" >&2; }
+
+# === DETERMINISTIC SAFETY-ESCALATION GATE ==================================
+# Structural (regex/keyword) escalation that does NOT trust the model's
+# self-assessment. A measured test showed Haiku runs the verify tools fine but
+# lacks the judgment to flag intent-ambiguity (it confidently mis-drafted the
+# safety-critical "Civitai Link on .red" cert ticket as a high-confidence TASK
+# with no safety_flag; Opus correctly said NEEDS-DECISION). So for the dangerous
+# classes we pin the label in code, not in the prompt.
+#
+# Rule: scan the ticket text (title + body + comments) AND the model's own
+# verification/spec text. If it matches a RISK category, FORCE the record to
+# classification=NEEDS-DECISION, autonomy=needs-Zach, never auto-dispatch,
+# overriding whatever the model returned, and stamp safety_flag + gate_fired.
+#
+# Categories (word-boundary, case-insensitive). Tune the lists here.
+GATE_RE_SECURITY='\b(cert|certs|tls|ssl|mtls|mta-?sts|secret|secrets|token|tokens|credential|credentials|password|passwd|auth|authn|authz|rbac|vuln|vulnerability|cve|disclosure|exploit|x\.509|x509|\.red)\b'
+GATE_RE_MONEY='\b(buzz|currency|payment|payments|refund|refunds|withdraw|withdrawal|payout|payouts|billing|invoice|stripe|paypal|subscription|chargeback|wallet|merch)\b'
+GATE_RE_DESTRUCTIVE='\b(delete|deletes|deletion|drop|truncate|migration|migrations|rollback|restore|prod|production|scale ?down|scale-down|evict|eviction|wipe|purge|destroy|terraform destroy|drop table|force ?push)\b'
+
+# safety_gate <ticket_text_file> <model_json>  -> prints possibly-rewritten json
+# Returns the json on stdout. Sets nothing else.
+safety_gate() {
+  local txt_file="$1" json="$2"
+  # Combine ticket text with the model's verification/recommendation/spec so the
+  # gate sees both the raw inbound and whatever reality the model surfaced.
+  local model_text
+  model_text="$(printf '%s' "$json" | jq -r '[.title,.verification,.recommendation,.spec.goal,.spec.done]|map(select(.!=null))|join(" ")' 2>/dev/null)"
+  local scan
+  scan="$(printf '%s\n%s' "$(cat "$txt_file" 2>/dev/null)" "$model_text")"
+
+  local cats=""
+  printf '%s' "$scan" | grep -Eiq "$GATE_RE_SECURITY"     && cats="${cats}security/secrets, "
+  printf '%s' "$scan" | grep -Eiq "$GATE_RE_MONEY"        && cats="${cats}money, "
+  printf '%s' "$scan" | grep -Eiq "$GATE_RE_DESTRUCTIVE"  && cats="${cats}destructive/prod-mutation, "
+  cats="${cats%, }"
+
+  if [ -z "$cats" ]; then
+    # no risk match: pass through, just mark gate_fired=false for audit
+    printf '%s' "$json" | jq -c '. + {gate_fired:false}'
+    return 0
+  fi
+
+  # RISK match: force escalation, overriding the model. Preserve the model's
+  # original classification for audit (gate_override_from), blank the spec
+  # (it is no longer a dispatchable TASK), and stamp/extend the safety_flag.
+  printf '%s' "$json" | jq -c \
+    --arg cats "$cats" '
+      . as $orig
+      | .gate_fired = true
+      | .gate_categories = ($cats | split(", "))
+      | .gate_override_from = ($orig.classification // "?")
+      | .classification = "NEEDS-DECISION"
+      | (.confidence) = (if (.confidence=="high") then "medium" else (.confidence // "low") end)
+      | .spec = {goal:"",done:"",owner:(.spec.owner // ""),autonomy:"needs-Zach"}
+      | .recommendation = ((.recommendation // "") | if .=="" then "" else . + " " end) + "ESCALATED by deterministic safety gate (" + $cats + "): risk keywords present; needs Zach. Do NOT auto-dispatch."
+      | .safety_flag = (
+          (if (($orig.safety_flag // "")|length>0) then ($orig.safety_flag + " | ") else "" end)
+          + "deterministic gate fired [" + $cats + "]: structural risk match — intent must be verified by a human before any action (model self-assessment not trusted for these classes)."
+        )
+    '
+}
 
 RUN_TS="$(date '+%Y%m%dT%H%M%S')"
 QUEUE_JSONL="$DRAFTER_OUT_DIR/queue-$RUN_TS.jsonl"
@@ -98,7 +164,7 @@ command -v curl   >/dev/null 2>&1 || { log "FATAL: curl missing"; exit 1; }
 CU_TOKEN="$(node -e "const a=require('$CLICKUP_ACCOUNTS');const acc=a.accounts[a.defaultAccount];process.stdout.write(acc.apiToken)" 2>/dev/null)"
 [ -n "$CU_TOKEN" ] || { log "FATAL: could not read ClickUp token from $CLICKUP_ACCOUNTS"; exit 1; }
 
-log "=== run $RUN_TS mode=$DRAFTER_MODE view=$CLICKUP_VIEW_ID ==="
+log "=== run $RUN_TS mode=$DRAFTER_MODE model=$DRAFTER_MODEL view=$CLICKUP_VIEW_ID ==="
 
 # --- fetch the triage queue (paginated /view/<id>/task) --------------------
 fetch_queue() {
@@ -136,10 +202,22 @@ fi
 N=0; FAIL=0
 PROMPT_BODY="$(cat "$PROMPT_FILE")"
 
+GATE_HITS=0
+TICKET_TXT="$DRAFTER_OUT_DIR/.ticket-text.$$"
 while IFS=$'\t' read -r TID TSTATUS TNAME <&3; do
   [ -n "$TID" ] || continue
   N=$((N+1))
   log "[$N/$TOTAL] $TID  ($TSTATUS)  ${TNAME:0:60}"
+
+  # Gather the ticket text (title + body + comments) for the DETERMINISTIC safety
+  # gate. Read-only clickup CLI; failures degrade to title-only (the title still
+  # catches the .red cert + buzz/currency cases). This text is independent of the
+  # model — the gate must not depend on the model surfacing the risk.
+  {
+    printf '%s\n' "$TNAME"
+    node "$CLICKUP_CLI" get "$TID" 2>/dev/null
+    node "$CLICKUP_CLI" comments "$TID" --threads 2>/dev/null
+  } > "$TICKET_TXT" 2>/dev/null || printf '%s\n' "$TNAME" > "$TICKET_TXT"
 
   PROMPT="$PROMPT_BODY
 
@@ -170,14 +248,15 @@ Run the five-step pipeline on ticket $TID now and output ONLY the json block."
   RAW="$(timeout "$DRAFTER_TIMEOUT" \
     env KUBECONFIG="$PROD_KUBECONFIG" \
     claude -p "$PROMPT" \
+      --model "$DRAFTER_MODEL" \
       --allowedTools "$DRAFTER_ALLOWED_TOOLS" \
       </dev/null 2>>"$DRAFTER_LOG_FILE")"
   RC=$?
   if [ $RC -ne 0 ]; then
     log "  ! claude rc=$RC (timeout/error) — emitting error record"
-    jq -nc --arg id "$TID" --arg t "$TNAME" --arg s "$TSTATUS" \
-      '{ticket_id:$id,title:$t,status:$s,classification:"ERROR",confidence:"low",verification:"claude pass failed (timeout/error)",correlations:[],recommendation:"re-run",spec:{goal:"",done:"",owner:"",autonomy:""},safety_flag:""}' \
-      >> "$QUEUE_JSONL"
+    ERR_JSON="$(jq -nc --arg id "$TID" --arg t "$TNAME" --arg s "$TSTATUS" \
+      '{ticket_id:$id,title:$t,status:$s,classification:"ERROR",confidence:"low",verification:"claude pass failed (timeout/error)",correlations:[],recommendation:"re-run",spec:{goal:"",done:"",owner:"",autonomy:""},safety_flag:""}')"
+    safety_gate "$TICKET_TXT" "$ERR_JSON" >> "$QUEUE_JSONL"
     FAIL=$((FAIL+1))
     continue
   fi
@@ -187,26 +266,37 @@ Run the five-step pipeline on ticket $TID now and output ONLY the json block."
     /```json/{f=1;next} /```/{if(f){f=0}} f{print}')"
   [ -n "$JSON" ] || JSON="$(printf '%s' "$RAW" | sed -n '/^[[:space:]]*{/,/^[[:space:]]*}[[:space:]]*$/p')"
   if printf '%s' "$JSON" | jq -e . >/dev/null 2>&1; then
-    printf '%s' "$JSON" | jq -c --arg id "$TID" '. + {ticket_id:$id}' >> "$QUEUE_JSONL"
-    CLS="$(printf '%s' "$JSON" | jq -r '.classification // "?"')"
-    log "  -> $CLS"
+    # Normalize, then run the DETERMINISTIC safety gate (overrides the model for
+    # risk classes — Haiku's self-assessment is not trusted here).
+    NORM="$(printf '%s' "$JSON" | jq -c --arg id "$TID" '. + {ticket_id:$id}')"
+    MODEL_CLS="$(printf '%s' "$NORM" | jq -r '.classification // "?"')"
+    GATED="$(safety_gate "$TICKET_TXT" "$NORM")"
+    printf '%s\n' "$GATED" >> "$QUEUE_JSONL"
+    if [ "$(printf '%s' "$GATED" | jq -r '.gate_fired')" = "true" ]; then
+      GATE_HITS=$((GATE_HITS+1))
+      GCATS="$(printf '%s' "$GATED" | jq -r '.gate_categories|join(",")')"
+      log "  -> $MODEL_CLS  ⛔ GATE FIRED [$GCATS] -> forced NEEDS-DECISION (needs-Zach)"
+    else
+      log "  -> $MODEL_CLS"
+    fi
   else
     log "  ! unparseable output — emitting error record"
-    jq -nc --arg id "$TID" --arg t "$TNAME" --arg s "$TSTATUS" \
-      '{ticket_id:$id,title:$t,status:$s,classification:"ERROR",confidence:"low",verification:"unparseable claude output",correlations:[],recommendation:"re-run",spec:{goal:"",done:"",owner:"",autonomy:""},safety_flag:""}' \
-      >> "$QUEUE_JSONL"
+    ERR_JSON="$(jq -nc --arg id "$TID" --arg t "$TNAME" --arg s "$TSTATUS" \
+      '{ticket_id:$id,title:$t,status:$s,classification:"ERROR",confidence:"low",verification:"unparseable claude output",correlations:[],recommendation:"re-run",spec:{goal:"",done:"",owner:"",autonomy:""},safety_flag:""}')"
+    safety_gate "$TICKET_TXT" "$ERR_JSON" >> "$QUEUE_JSONL"
     FAIL=$((FAIL+1))
   fi
 done 3<<< "$QUEUE_TSV"
+rm -f "$TICKET_TXT" 2>/dev/null || true
 
 PROCESSED="$N"
-log "processed=$PROCESSED parse_failures=$FAIL queue=$QUEUE_JSONL"
+log "processed=$PROCESSED parse_failures=$FAIL gate_escalations=$GATE_HITS queue=$QUEUE_JSONL"
 
 # --- build the human summary (counts by class + the genuine/decision items) -
 {
   echo "# Task-spec drafter — shadow queue $RUN_TS"
   echo
-  echo "Source: ClickUp triage view \`$CLICKUP_VIEW_ID\` · processed $PROCESSED of $TOTAL · mode=$DRAFTER_MODE"
+  echo "Source: ClickUp triage view \`$CLICKUP_VIEW_ID\` · processed $PROCESSED of $TOTAL · model=$DRAFTER_MODEL · mode=$DRAFTER_MODE · deterministic-gate escalations: $GATE_HITS"
   echo
   echo "## Classification counts"
   echo

--- a/scripts/task-spec-drafter/task-spec-drafter.env.example
+++ b/scripts/task-spec-drafter/task-spec-drafter.env.example
@@ -7,6 +7,13 @@
 #   on     — actually POST the triage summary to clawgate (your phone)
 DRAFTER_MODE=shadow
 
+# Model for the per-ticket headless `claude -p` pass. Alias (haiku|sonnet|opus)
+# or a full model id. Default is haiku (cheap). The deterministic safety gate in
+# drafter.sh compensates for Haiku's measured intent-ambiguity blind spot, so the
+# dangerous classes (security/secrets, money, destructive/prod-mutation) are
+# force-escalated to NEEDS-DECISION in code regardless of the model.
+DRAFTER_MODEL=haiku
+
 # Cap tickets processed per run (0 = all). Useful for cheap test runs.
 DRAFTER_MAX_TICKETS=0
 


### PR DESCRIPTION
## Method

Mined **8,984 human messages across 1,705 transcripts** (`scripts/session-analysis/espanso-usage.py`, added here). espanso expands a trigger to its replacement *before* Claude sees it, so usage is detected by matching each snippet's distinctive expansion in user messages.

## Changes

**Fix**
- **`:rns`**: was the verbose *"recommend next steps, improvements, extension, evaluation, evolution, iteration"* (**5 uses**), while the short *"recommend next steps"* was hand-typed **~60×** (+ "whats next" 43×, "recommend" 57×). Repointed to the short form.
- **`:rau`**: added *"edge cases"* — hand-typed audit variants consistently include it; the snippet didn't.

**Remove**
- **`:usd`** — 1 use in 1 session over ~18 months. Dead.

**Add** (high-frequency phrases with no snippet)
| Trigger | Expansion | Manual uses |
|---|---|--:|
| `:mdc` | merged and deployed, check | ~47 |
| `:wn` | what's next | 43 |
| `:aep` | audit each PR, one subagent per PR (plural of `:rau`) | ~18 |
| `:cont` | continue from where you left off. | 9 |
| `:pec` | push an empty commit | 7 |
| `:fhrs` | it's been a few hours, check | 6 |
| `:fdays` | it's been a few days, check | 5 |
| `reocmmend` | → recommend (typo autocorrect) | 4 |

Triggers are prefix-collision-safe (espanso longest-match; avoided the `:rau`/`:nday` prefix-shadow class that bit `:cmo` historically): `:aep` not `:raup`, `:fhrs`/`:fdays` not `:nhrs`/`:ndays`.

## Notes
- Paths all earn their keep (`:cdp` 813 hits / 229 sessions down to rare-but-zero-maintenance) — no path removals.
- `:date`/`:datetime` have a pre-existing prefix overlap; espanso longest-match tolerates it, left as-is.
- espanso is disabled on the headless main host (server-mode); this deploys/runs on the laptop.

## Verification
- `home-manager build` passes; collision + duplicate check clean for all 31 triggers.
- **Pending live:** after deploy on the laptop, type e.g. `:mdc`/`:rns`/`:aep` and confirm the expansion fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)