### PR TITLE
feat(activity): per-host activity-telemetry collector → ClickHouse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .bashrc.devrc
 /tmux-fuzzyclaw
 /result
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -210,6 +210,12 @@ set-hook -g after-select-window 'run-shell -b "~/.config/tmux/pipe-activity.sh s
 set-hook -g window-linked 'run-shell -b "~/.config/tmux/pipe-activity.sh linked"'
 set-hook -g session-created 'run-shell -b "~/.config/tmux/pipe-activity.sh init"'
 
+# Activity telemetry: forward focus changes into the collector spool (reuses the
+# above tracking; thin shipper only). Appended to the existing hooks via -a so it
+# does not clobber the pipe-activity bindings.
+set-hook -ga after-select-window 'run-shell -b "~/.config/tmux/activity-emit.sh window-focus"'
+set-hook -ga client-session-changed 'run-shell -b "~/.config/tmux/activity-emit.sh session"'
+
 # Status bar refresh rate (2s - balance between responsiveness and CPU)
 set -g status-interval 2
 

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -126,6 +126,20 @@ in
     mkdir -p ~/.config/espanso/config
   '';
 
+  # Seed the activity-collector EnvironmentFile with safe defaults if it does not
+  # exist yet. The real file holds the (future) ClickHouse credentials, so it is
+  # NEVER in the nix store and NEVER committed — created here once, chmod 600,
+  # then edited in place. We copy the in-repo .env.example as the template.
+  home.activation.activityCollectorEnv = lib.hm.dag.entryAfter ["writeBoundary"] ''
+    envFile="$HOME/.config/activity-collector/env"
+    if [ ! -e "$envFile" ]; then
+      mkdir -p "$HOME/.config/activity-collector"
+      cp ${../scripts/collector/.env.example} "$envFile"
+      chmod 600 "$envFile"
+      echo "activity-collector: seeded $envFile from .env.example (edit to add CLICKHOUSE_PASSWORD)"
+    fi
+  '';
+
   home.stateVersion = "24.11";
 
   home.packages = if isNixOS
@@ -183,9 +197,26 @@ in
     executable = true;
   };
 
+  home.file.".config/tmux/activity-emit.sh" = {
+    source = ../scripts/tmux-activity-emit.sh;
+    executable = true;
+  };
+
   # CPU load monitor: desktop alert on sustained high load
   home.file.".config/cpu-monitor/cpu-monitor.sh" = {
     source = ../scripts/cpu-monitor.sh;
+    executable = true;
+  };
+
+  # Activity-telemetry collector: hot-path emit helper + daemon. Symlinked from
+  # the repo so both hosts stay in sync. Config (CLICKHOUSE_URL/credentials) lives
+  # in ~/.config/activity-collector/env — created below, NOT in the nix store.
+  home.file.".config/activity-collector/emit" = {
+    source = ../scripts/collector/emit;
+    executable = true;
+  };
+  home.file.".config/activity-collector/collector.py" = {
+    source = ../scripts/collector/collector.py;
     executable = true;
   };
 
@@ -222,6 +253,34 @@ in
     Install = {
       # default.target = starts on login. i3 is not systemd-integrated, so the
       # script borrows DISPLAY/DBUS from i3's /proc environ to reach dunst.
+      WantedBy = [ "default.target" ];
+    };
+  };
+
+  # Activity-telemetry collector daemon. Batches spooled events and ships them to
+  # ClickHouse. Mirrors the cpu-monitor user-service pattern (Restart=always,
+  # explicit PATH via lib.makeBinPath). Config comes from the EnvironmentFile
+  # (not the nix store); EnvironmentFile is optional so a missing file (e.g. mid
+  # first switch, before activation seeds it) does not fail the unit.
+  systemd.user.services.activity-collector = {
+    Unit = {
+      Description = "Personal activity-telemetry collector → ClickHouse";
+      # No graphical-session dep: this must run in headless/server mode too.
+      After = [ "network.target" ];
+    };
+    Service = {
+      Type = "simple";
+      # PATH must be explicit: a user service does not inherit the login PATH.
+      # python3 (with stdlib only) + base64/coreutils for the helper path.
+      Environment = [
+        "PATH=${lib.makeBinPath [ pkgs.python312 pkgs.coreutils pkgs.bash ]}"
+      ];
+      EnvironmentFile = "-%h/.config/activity-collector/env";
+      ExecStart = "${pkgs.python312}/bin/python3 %h/.config/activity-collector/collector.py";
+      Restart = "always";
+      RestartSec = 10;
+    };
+    Install = {
       WantedBy = [ "default.target" ];
     };
   };

--- a/nix/programs/zsh/default.nix
+++ b/nix/programs/zsh/default.nix
@@ -26,6 +26,59 @@
     # `grep --include=*.go` or `ls /tmp/foo* 2>/dev/null` with "no matches found".
     unsetopt nomatch
 
+    # ── activity telemetry (interactive only) ───────────────────────────────
+    # preexec/precmd capture each HUMAN command + its duration/exit-code and
+    # `emit` an event to the local spool (the collector daemon ships it to
+    # ClickHouse). These live in initContent / .zshrc — interactive shells only.
+    # Claude Code's Bash tool runs NON-interactive `zsh -c` (sources .zshenv
+    # only), so the agent's own commands are correctly EXCLUDED from the log.
+    # The hot path is pure shell (no python/jq): `emit` does an atomic >> append.
+    ACTIVITY_EMIT="${config.home.homeDirectory}/.config/activity-collector/emit"
+    if [[ -x "$ACTIVITY_EMIT" ]]; then
+      autoload -Uz add-zsh-hook
+
+      _activity_preexec() {
+        _ACTIVITY_CMD="$1"
+        _ACTIVITY_START=$EPOCHREALTIME    # float seconds; zsh/datetime
+        _ACTIVITY_CWD="$PWD"
+      }
+
+      _activity_precmd() {
+        local ec=$?
+        [[ -z "$_ACTIVITY_CMD" ]] && return
+        local dur_ms=0
+        if [[ -n "$_ACTIVITY_START" ]]; then
+          dur_ms=$(( (EPOCHREALTIME - _ACTIVITY_START) * 1000 ))
+          dur_ms=''${dur_ms%.*}
+          (( dur_ms < 0 )) && dur_ms=0
+        fi
+        # project = git repo basename (or cwd basename fallback), else "".
+        local proj=""
+        local root
+        root=$(command git -C "$_ACTIVITY_CWD" rev-parse --show-toplevel 2>/dev/null)
+        [[ -n "$root" ]] && proj="''${root:t}"
+        # session = tmux session:window.pane if in tmux, else shell-PID.
+        local sess
+        if [[ -n "$TMUX" ]]; then
+          sess=$(command tmux display-message -p '#S:#I.#P' 2>/dev/null)
+        fi
+        [[ -z "$sess" ]] && sess="sh-$$"
+        "$ACTIVITY_EMIT" \
+          source=zsh kind=command \
+          "b64:text=$_ACTIVITY_CMD" "b64:cwd=$_ACTIVITY_CWD" \
+          "duration_ms=$dur_ms" "exit_code=$ec" \
+          "b64:project=$proj" "b64:session=$sess" \
+          "b64:app=''${TERM_PROGRAM:-''${TERM:-}}" &!
+        _ACTIVITY_CMD=""
+        _ACTIVITY_START=""
+      }
+
+      # EPOCHREALTIME needs zsh/datetime.
+      zmodload zsh/datetime 2>/dev/null
+      add-zsh-hook preexec _activity_preexec
+      add-zsh-hook precmd  _activity_precmd
+    fi
+
     PROMPT='%{$fg_bold[white]%}%c%{$reset_color%} $(git_prompt_info)'
 
     ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[green]%}"

--- a/scripts/collector/.env.example
+++ b/scripts/collector/.env.example
@@ -1,0 +1,28 @@
+# activity-collector config — copy to ~/.config/activity-collector/env (chmod 600).
+# This file is NOT in the nix store and NOT committed. The nix module creates the
+# real file with these safe defaults if it is missing; edit it in place to slot in
+# an authed ClickHouse user later WITHOUT any code change.
+
+# ClickHouse HTTP endpoint (Traefik fronts the HTTP interface on port 80).
+CLICKHOUSE_URL=http://clickhouse.homelab.lan
+CLICKHOUSE_USER=default
+# Empty for now (default user has no password). Put the authed user's key here
+# later — keep this file chmod 600; it is the only place the secret lives.
+CLICKHOUSE_PASSWORD=
+CLICKHOUSE_DATABASE=activity
+CLICKHOUSE_TABLE=events
+
+# Batching / buffering.
+ACTIVITY_BATCH_SIZE=500
+ACTIVITY_FLUSH_SECONDS=10
+# On-disk offline buffer caps. Over-cap the OLDEST segments are dropped + logged.
+# NOTE: systemd EnvironmentFile keeps inline trailing comments as part of the
+# value — so values below must be bare (full-line comments only).
+# ACTIVITY_MAX_BUFFER_BYTES: 64 MiB
+ACTIVITY_MAX_BUFFER_BYTES=67108864
+# ACTIVITY_MAX_BUFFER_AGE_SECONDS: 7 days
+ACTIVITY_MAX_BUFFER_AGE_SECONDS=604800
+ACTIVITY_HTTP_TIMEOUT=10
+
+# Spool dir (default ~/.local/state/activity/spool). Usually leave unset.
+# ACTIVITY_SPOOL_DIR=

--- a/scripts/collector/README.md
+++ b/scripts/collector/README.md
@@ -1,0 +1,53 @@
+# activity-collector
+
+First slice of a personal activity-telemetry pipeline: per-host source hooks
+emit events to a local spool; a user-systemd daemon batches them and ships to the
+homelab ClickHouse `activity.events` table.
+
+```
+zsh preexec/precmd ─┐
+tmux focus hooks   ─┼─► emit (pure shell, hot path) ─► spool/current.log
+                    ┘                                        │ rotate
+                                                collector.py ─┴─► seg-*.log ─► ClickHouse
+                                                              (delete on HTTP 200)
+```
+
+## Components
+- `emit` — pure-shell hot-path helper. Appends ONE event to the spool with
+  atomic `>>`. No interpreter startup. Free-text fields are base64-encoded so
+  arbitrary content (quotes, newlines, unicode, passwords) survives intact.
+- `collector.py` — daemon. Rotates `current.log` → `seg-*.log`, parses, assembles
+  JSONEachRow, POSTs to ClickHouse, deletes the segment **only on HTTP 200**.
+  Offline-buffered (segments accumulate when the backend is unreachable),
+  lossless on transient errors, no double-ship, on-disk cap by age + size.
+- `tests/` — pytest unit + round-trip coverage (mocks the HTTP endpoint).
+
+## Spool / emit line contract (v1)
+One event per line in `current.log`. TAB-separated `key=value` tokens, first
+token literally `v1`:
+
+```
+v1<TAB>ts=2026-06-23 14:00:00.123<TAB>source=zsh<TAB>kind=command<TAB>b64:text=<base64><TAB>duration_ms=42<TAB>exit_code=0
+```
+
+- Keys prefixed `b64:` carry a base64-encoded value (free text). The daemon
+  decodes them.
+- Known columns (`host source kind project cwd session app text payload`,
+  `duration_ms exit_code`, `ts`) map straight to ClickHouse columns. Any other
+  key is bundled into the JSON `payload` column.
+- `ts` and `host` are auto-filled by `emit` if the caller omits them.
+
+## Config
+Runtime config lives in `~/.config/activity-collector/env` (chmod 600, **not** in
+the nix store, **not** committed). The nix module seeds it from
+[`.env.example`](.env.example) on first switch if absent. To use an authed
+ClickHouse user later, edit that file — no code change.
+
+## Manual run / debug
+```sh
+# one rotate+ship pass against the live endpoint
+CLICKHOUSE_URL=http://clickhouse.homelab.lan python3 collector.py --flush-once
+# tail the service
+systemctl --user status activity-collector
+journalctl --user -u activity-collector -f
+```

--- a/scripts/collector/collector.py
+++ b/scripts/collector/collector.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""collector — per-host activity-telemetry daemon.
+
+Consumes events that source-hooks append to a local spool, batches them, and
+ships them to a homelab ClickHouse `activity.events` table via the JSONEachRow
+HTTP insert. Design goals (in priority order):
+
+  * LOSSLESS + OFFLINE-BUFFERED: when ClickHouse is unreachable (e.g. laptop off
+    nebula), events accumulate on disk and ship on recovery. Nothing is dropped
+    on transient errors.
+  * NO DOUBLE-SHIP: a segment file is deleted ONLY after the insert returns
+    HTTP 200. A crash between ship and delete re-ships at most one segment; that
+    is acceptable (ClickHouse insert is the unit of work) and far safer than
+    fragile byte-offset bookkeeping.
+  * BOUNDED: the on-disk buffer is capped by age and total size; over-cap the
+    OLDEST segments are dropped and the drop is logged loudly, never silently.
+
+Spool layout under $ACTIVITY_SPOOL_DIR (default ~/.local/state/activity/spool):
+    current.log         writers (emit) append here
+    seg-<ts>-<n>.log    rotated segments awaiting ship (daemon-owned)
+The daemon atomically renames current.log -> a seg-* file (rotation), so a torn
+final line from a writer can never be split across the boundary mid-ship.
+
+Emit/daemon line contract (v1): see scripts/collector/emit. Each line is
+TAB-separated key=value; keys prefixed `b64:` carry base64 values (arbitrary
+free text). The daemon decodes, maps known keys to ClickHouse columns, and
+bundles unknown keys into the JSON `payload` string.
+
+Config via environment (see .env.example), loaded from an EnvironmentFile by the
+systemd user service — secrets stay out of the nix store and out of git:
+    CLICKHOUSE_URL        base URL (default http://clickhouse.homelab.lan)
+    CLICKHOUSE_USER       default: default
+    CLICKHOUSE_PASSWORD   default: empty (authed user slots in later, no code change)
+    CLICKHOUSE_DATABASE   default: activity
+    CLICKHOUSE_TABLE      default: events
+    ACTIVITY_SPOOL_DIR    default ~/.local/state/activity/spool
+    ACTIVITY_BATCH_SIZE   max events per insert (default 500)
+    ACTIVITY_FLUSH_SECONDS  rotate+ship interval (default 10)
+    ACTIVITY_MAX_BUFFER_BYTES  on-disk cap (default 64 MiB)
+    ACTIVITY_MAX_BUFFER_AGE_SECONDS  segment age cap (default 7 days)
+    ACTIVITY_HTTP_TIMEOUT  seconds (default 10)
+"""
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import logging
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+
+LOG = logging.getLogger("activity-collector")
+
+# Columns that map straight to ClickHouse `activity.events` table columns.
+# Everything NOT in here (and not `ts`/`host`) is bundled into `payload` JSON.
+STRING_COLS = {
+    "host", "source", "kind", "project", "cwd",
+    "session", "app", "text", "payload",
+}
+INT_COLS = {"duration_ms", "exit_code"}
+# `ts` handled specially (kept as a string in ClickHouse DateTime64 local format).
+KNOWN_COLS = STRING_COLS | INT_COLS | {"ts"}
+
+
+# --------------------------------------------------------------------------- #
+# Config
+# --------------------------------------------------------------------------- #
+@dataclass
+class Config:
+    clickhouse_url: str = "http://clickhouse.homelab.lan"
+    user: str = "default"
+    password: str = ""
+    database: str = "activity"
+    table: str = "events"
+    spool_dir: Path = field(
+        default_factory=lambda: Path(
+            os.environ.get(
+                "ACTIVITY_SPOOL_DIR",
+                Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state"))
+                / "activity" / "spool",
+            )
+        )
+    )
+    batch_size: int = 500
+    flush_seconds: float = 10.0
+    max_buffer_bytes: int = 64 * 1024 * 1024
+    max_buffer_age_seconds: float = 7 * 24 * 3600
+    http_timeout: float = 10.0
+
+    @classmethod
+    def from_env(cls, env: dict | None = None) -> "Config":
+        e = os.environ if env is None else env
+        spool = e.get("ACTIVITY_SPOOL_DIR")
+        return cls(
+            clickhouse_url=e.get("CLICKHOUSE_URL", cls.clickhouse_url).rstrip("/"),
+            user=e.get("CLICKHOUSE_USER", cls.user),
+            password=e.get("CLICKHOUSE_PASSWORD", cls.password),
+            database=e.get("CLICKHOUSE_DATABASE", cls.database),
+            table=e.get("CLICKHOUSE_TABLE", cls.table),
+            spool_dir=Path(spool) if spool else cls.__dataclass_fields__["spool_dir"].default_factory(),
+            batch_size=int(e.get("ACTIVITY_BATCH_SIZE", cls.batch_size)),
+            flush_seconds=float(e.get("ACTIVITY_FLUSH_SECONDS", cls.flush_seconds)),
+            max_buffer_bytes=int(e.get("ACTIVITY_MAX_BUFFER_BYTES", cls.max_buffer_bytes)),
+            max_buffer_age_seconds=float(
+                e.get("ACTIVITY_MAX_BUFFER_AGE_SECONDS", cls.max_buffer_age_seconds)
+            ),
+            http_timeout=float(e.get("ACTIVITY_HTTP_TIMEOUT", cls.http_timeout)),
+        )
+
+    @property
+    def insert_url(self) -> str:
+        q = f"INSERT INTO {self.database}.{self.table} FORMAT JSONEachRow"
+        base = self.clickhouse_url.rstrip("/")
+        return f"{base}/?{urllib.parse.urlencode({'query': q})}"
+
+
+# --------------------------------------------------------------------------- #
+# Line parsing (the emit contract)
+# --------------------------------------------------------------------------- #
+def parse_line(line: str) -> dict | None:
+    """Parse one v1 spool line into an event dict, or None if unparseable.
+
+    Returns a dict with ClickHouse-ready values: known string/int columns plus a
+    `payload` JSON string holding any unknown keys. `ts`/`host` pass through.
+    """
+    line = line.rstrip("\n")
+    if not line:
+        return None
+    parts = line.split("\t")
+    if not parts or parts[0] != "v1":
+        return None
+
+    raw: dict[str, str] = {}
+    extra: dict[str, str] = {}
+    for tok in parts[1:]:
+        if "=" not in tok:
+            return None  # malformed token -> reject whole line
+        key, val = tok.split("=", 1)
+        if key.startswith("b64:"):
+            key = key[4:]
+            try:
+                val = base64.b64decode(val.encode("ascii"), validate=True).decode(
+                    "utf-8", "replace"
+                )
+            except (binascii.Error, ValueError):
+                return None
+        raw[key] = val
+
+    if "ts" not in raw or "source" not in raw or "kind" not in raw:
+        return None  # require the minimum identifying triple
+
+    event: dict[str, object] = {}
+    for key, val in raw.items():
+        if key in STRING_COLS or key == "ts":
+            event[key] = val
+        elif key in INT_COLS:
+            try:
+                event[key] = int(val)
+            except ValueError:
+                event[key] = 0
+        else:
+            extra[key] = val
+
+    if extra:
+        # Merge with any explicit payload= passed by the hook.
+        existing = event.get("payload")
+        merged = {}
+        if isinstance(existing, str) and existing:
+            try:
+                merged = json.loads(existing)
+                if not isinstance(merged, dict):
+                    merged = {"_payload": existing}
+            except json.JSONDecodeError:
+                merged = {"_payload": existing}
+        merged.update(extra)
+        event["payload"] = json.dumps(merged, ensure_ascii=False, separators=(",", ":"))
+
+    return event
+
+
+def format_jsoneachrow(events: list[dict]) -> bytes:
+    """Render events as a JSONEachRow body (newline-delimited JSON, UTF-8)."""
+    return ("\n".join(json.dumps(e, ensure_ascii=False, separators=(",", ":")) for e in events) + "\n").encode("utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# Spool
+# --------------------------------------------------------------------------- #
+CURRENT_NAME = "current.log"
+SEG_PREFIX = "seg-"
+SEG_SUFFIX = ".log"
+
+
+class Spool:
+    """Owns the spool directory: rotation, segment enumeration, cap enforcement."""
+
+    def __init__(self, cfg: Config):
+        self.cfg = cfg
+        self.dir = cfg.spool_dir
+        self.dir.mkdir(parents=True, exist_ok=True)
+        self._seq = 0
+
+    @property
+    def current(self) -> Path:
+        return self.dir / CURRENT_NAME
+
+    def segments(self) -> list[Path]:
+        """Rotated segments awaiting ship, oldest first (by name → by mtime)."""
+        segs = [
+            p for p in self.dir.glob(f"{SEG_PREFIX}*{SEG_SUFFIX}") if p.is_file()
+        ]
+        segs.sort(key=lambda p: (p.name, p.stat().st_mtime))
+        return segs
+
+    def rotate(self) -> Path | None:
+        """Atomically move current.log to a new segment file. Returns the new
+        segment path, or None if there was nothing to rotate."""
+        cur = self.current
+        if not cur.exists() or cur.stat().st_size == 0:
+            return None
+        self._seq += 1
+        seg = self.dir / f"{SEG_PREFIX}{int(time.time()*1000):013d}-{self._seq:04d}{SEG_SUFFIX}"
+        # os.rename within a dir is atomic; a concurrent writer's open fd keeps
+        # writing to the now-renamed inode, so we may lose at most the few lines
+        # written between rename and the writer's next append targeting a fresh
+        # current.log. To minimise that window we rename immediately and writers
+        # always re-open current.log per append (emit does `>>`, which re-opens).
+        os.replace(cur, seg)
+        return seg
+
+    def enforce_cap(self) -> int:
+        """Drop oldest segments exceeding the age/size cap. Returns count dropped.
+        Loud WARNING per drop — never silent."""
+        dropped = 0
+        now = time.time()
+        segs = self.segments()
+
+        # Age cap.
+        for seg in segs:
+            try:
+                age = now - seg.stat().st_mtime
+            except FileNotFoundError:
+                continue
+            if age > self.cfg.max_buffer_age_seconds:
+                LOG.warning(
+                    "BUFFER CAP: dropping over-age segment %s (age %.0fs > %.0fs)",
+                    seg.name, age, self.cfg.max_buffer_age_seconds,
+                )
+                seg.unlink(missing_ok=True)
+                dropped += 1
+
+        # Size cap (oldest-first until under the limit).
+        segs = self.segments()
+        total = sum(p.stat().st_size for p in segs if p.exists())
+        for seg in segs:
+            if total <= self.cfg.max_buffer_bytes:
+                break
+            try:
+                sz = seg.stat().st_size
+            except FileNotFoundError:
+                continue
+            LOG.warning(
+                "BUFFER CAP: dropping oldest segment %s (%d bytes) — buffer %d > cap %d",
+                seg.name, sz, total, self.cfg.max_buffer_bytes,
+            )
+            seg.unlink(missing_ok=True)
+            total -= sz
+            dropped += 1
+        return dropped
+
+
+def read_segment(path: Path) -> tuple[list[dict], int, int]:
+    """Parse a segment file → (events, parsed_ok, parse_failed).
+
+    Unparseable lines are counted and logged but do not block the rest; they are
+    dropped (already-rotated, can't re-queue a single bad line cleanly), which is
+    the malformed-record handling path.
+    """
+    events: list[dict] = []
+    ok = 0
+    bad = 0
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return [], 0, 0
+    for line in text.splitlines():
+        if not line:
+            continue
+        ev = parse_line(line)
+        if ev is None:
+            bad += 1
+            LOG.warning("dropping malformed spool line in %s: %.120r", path.name, line)
+        else:
+            ok += 1
+            events.append(ev)
+    return events, ok, bad
+
+
+# --------------------------------------------------------------------------- #
+# Shipping
+# --------------------------------------------------------------------------- #
+class ClickHouseClient:
+    def __init__(self, cfg: Config, opener=None):
+        self.cfg = cfg
+        self._opener = opener or urllib.request.urlopen
+
+    def insert(self, body: bytes) -> None:
+        """POST a JSONEachRow body. Raises on any non-2xx / network error."""
+        req = urllib.request.Request(self.cfg.insert_url, data=body, method="POST")
+        req.add_header("Content-Type", "text/plain; charset=utf-8")
+        if self.cfg.user:
+            req.add_header("X-ClickHouse-User", self.cfg.user)
+        if self.cfg.password:
+            req.add_header("X-ClickHouse-Key", self.cfg.password)
+        resp = self._opener(req, timeout=self.cfg.http_timeout)
+        try:
+            code = getattr(resp, "status", None) or resp.getcode()
+            if not (200 <= code < 300):
+                raise RuntimeError(f"ClickHouse insert returned HTTP {code}")
+        finally:
+            close = getattr(resp, "close", None)
+            if close:
+                close()
+
+
+def ship_segment(
+    seg: Path, client: ClickHouseClient, batch_size: int
+) -> bool:
+    """Parse + insert one segment in batches; delete ON 200 ONLY.
+
+    Returns True if the segment was fully shipped (and deleted), False if it
+    should be retried later (network/HTTP error). No-double-ship: the file is
+    deleted only after every batch in it has been accepted.
+    """
+    events, ok, bad = read_segment(seg)
+    if not events:
+        # Nothing shippable (empty or all-malformed) — drop the file so it does
+        # not wedge the queue. Malformed counts already logged.
+        seg.unlink(missing_ok=True)
+        return True
+    try:
+        for i in range(0, len(events), batch_size):
+            batch = events[i : i + batch_size]
+            client.insert(format_jsoneachrow(batch))
+    except (urllib.error.URLError, OSError, RuntimeError) as exc:
+        LOG.warning("ship failed for %s (%d events): %s — will retry", seg.name, len(events), exc)
+        return False
+    seg.unlink(missing_ok=True)
+    LOG.info("shipped %s: %d events (%d malformed dropped)", seg.name, ok, bad)
+    return True
+
+
+# --------------------------------------------------------------------------- #
+# Daemon loop
+# --------------------------------------------------------------------------- #
+def flush_once(spool: Spool, client: ClickHouseClient) -> dict:
+    """One rotate→cap→ship pass. Returns a small stats dict (for tests/logging)."""
+    spool.rotate()
+    spool.enforce_cap()
+    shipped = 0
+    failed = 0
+    for seg in spool.segments():
+        if ship_segment(seg, client, spool.cfg.batch_size):
+            shipped += 1
+        else:
+            failed += 1
+            # Stop on first failure: backend is down, no point hammering. Remaining
+            # segments stay on disk and ship on the next successful pass.
+            break
+    return {"shipped": shipped, "failed": failed}
+
+
+def run(cfg: Config) -> None:
+    spool = Spool(cfg)
+    client = ClickHouseClient(cfg)
+    LOG.info(
+        "activity-collector starting: spool=%s url=%s batch=%d flush=%.0fs",
+        spool.dir, cfg.clickhouse_url, cfg.batch_size, cfg.flush_seconds,
+    )
+    backoff = cfg.flush_seconds
+    max_backoff = 300.0
+    while True:
+        try:
+            stats = flush_once(spool, client)
+            if stats["failed"]:
+                backoff = min(backoff * 2, max_backoff)
+                LOG.debug("backing off to %.0fs after ship failure", backoff)
+            else:
+                backoff = cfg.flush_seconds
+        except Exception:  # never let the loop die
+            LOG.exception("unexpected error in flush loop")
+            backoff = min(backoff * 2, max_backoff)
+        time.sleep(backoff)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("ACTIVITY_LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        stream=sys.stderr,
+    )
+    cfg = Config.from_env()
+    if argv and "--flush-once" in argv:
+        spool = Spool(cfg)
+        client = ClickHouseClient(cfg)
+        stats = flush_once(spool, client)
+        LOG.info("flush-once: %s", stats)
+        return 0 if not stats["failed"] else 1
+    run(cfg)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/collector/emit
+++ b/scripts/collector/emit
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# emit — activity-telemetry hot-path helper.
+#
+# Appends ONE event to the local spool. This runs on EVERY interactive shell
+# command (and later on keystrokes), so it must be near-zero overhead: pure
+# shell, NO python/jq/interpreter startup. The daemon (collector.py) does all
+# JSON assembly + ClickHouse formatting; emit just records a robustly-escaped
+# line.
+#
+# Spool/emit contract (v1) — see scripts/collector/README is the daemon parser:
+#   * Spool dir:     $ACTIVITY_SPOOL_DIR  (default ~/.local/state/activity/spool)
+#   * Current file:  <spool>/current.log   (writer appends; daemon rotates it)
+#   * One event per line. A line is TAB-separated key=value pairs:
+#         v1<TAB>ts=<ms-iso><TAB>source=<s><TAB>kind=<k><TAB>b64:text=<b64>...
+#   * Keys whose name is prefixed `b64:` carry a base64-encoded value, so the
+#     free-text fields (text/command/cwd/app/session/project/payload) can hold
+#     ARBITRARY bytes — quotes, backslashes, newlines, tabs, unicode — with no
+#     escaping ambiguity. Plain (non-b64) keys are restricted to safe scalars
+#     produced here (ts, source, kind, integers).
+#   * Append is atomic: a single `printf >>` of a <PIPE_BUF (4096B) line on a
+#     local fs is written atomically with O_APPEND, so concurrent shells never
+#     interleave. Lines exceeding that are still safe for the common case and
+#     the daemon tolerates a torn tail (it re-queues unparseable lines once).
+#
+# Usage (called from zsh/tmux hooks):
+#   emit source=zsh kind=command \
+#        b64:text="$cmd" b64:cwd="$PWD" \
+#        duration_ms=123 exit_code=0 \
+#        b64:project="$proj" b64:session="$sess" b64:app="$app"
+#
+# Any key=value is accepted; the daemon maps known keys to ClickHouse columns
+# and bundles the rest into `payload`. `ts` and `host` are auto-filled if absent.
+
+set -u
+
+SPOOL_DIR="${ACTIVITY_SPOOL_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/activity/spool}"
+CUR="$SPOOL_DIR/current.log"
+
+# Bounded best-effort: never let telemetry break an interactive shell.
+mkdir -p "$SPOOL_DIR" 2>/dev/null || exit 0
+
+# Millisecond timestamp in ClickHouse DateTime64(3) local format.
+_ts() { date +"%Y-%m-%d %H:%M:%S.%3N"; }
+
+line="v1"
+have_ts=0
+have_host=0
+
+for kv in "$@"; do
+    key="${kv%%=*}"
+    val="${kv#*=}"
+    case "$key" in
+        b64:*)
+            # base64 (no wrap) the value so arbitrary bytes survive.
+            enc=$(printf '%s' "$val" | base64 | tr -d '\n')
+            line="$line	$key=$enc"
+            ;;
+        ts) have_ts=1; line="$line	ts=$val" ;;
+        host) have_host=1; line="$line	host=$val" ;;
+        *) line="$line	$key=$val" ;;
+    esac
+done
+
+[ "$have_ts" -eq 0 ] && line="$line	ts=$(_ts)"
+[ "$have_host" -eq 0 ] && line="$line	host=${HOST:-$(hostname)}"
+
+# Atomic append. Single printf of one newline-terminated line.
+printf '%s\n' "$line" >>"$CUR" 2>/dev/null || exit 0
+exit 0

--- a/scripts/collector/tests/test_collector.py
+++ b/scripts/collector/tests/test_collector.py
@@ -1,0 +1,413 @@
+"""Unit + round-trip tests for the activity-collector daemon.
+
+Run: nix-shell -p python312Packages.pytest --run "pytest scripts/collector/tests"
+No test hits the real ClickHouse — the HTTP opener is mocked.
+"""
+import base64
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Import the daemon module (sibling dir, not a package).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import collector as C  # noqa: E402
+
+EMIT = Path(__file__).resolve().parent.parent / "emit"
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+class FakeResp:
+    def __init__(self, status=200):
+        self.status = status
+
+    def close(self):
+        pass
+
+
+class FakeOpener:
+    """Records inserted bodies; can be told to fail N times then succeed."""
+
+    def __init__(self, fail_times=0, status=200, raise_exc=None):
+        self.bodies: list[bytes] = []
+        self.calls = 0
+        self.fail_times = fail_times
+        self.status = status
+        self.raise_exc = raise_exc
+
+    def __call__(self, req, timeout=None):
+        self.calls += 1
+        self.bodies.append(req.data)
+        if self.calls <= self.fail_times:
+            if self.raise_exc:
+                raise self.raise_exc
+            return FakeResp(status=500)
+        return FakeResp(status=self.status)
+
+    @property
+    def rows(self) -> list[dict]:
+        out = []
+        for b in self.bodies:
+            for line in b.decode("utf-8").splitlines():
+                if line:
+                    out.append(json.loads(line))
+        return out
+
+
+def cfg(tmp_path, **kw) -> C.Config:
+    base = dict(spool_dir=tmp_path / "spool", batch_size=500, flush_seconds=0.0)
+    base.update(kw)
+    return C.Config(**base)
+
+
+def b64(s: str) -> str:
+    return base64.b64encode(s.encode()).decode()
+
+
+# --------------------------------------------------------------------------- #
+# parse_line
+# --------------------------------------------------------------------------- #
+def test_parse_basic():
+    ev = C.parse_line(f"v1\tts=2026-06-23 14:00:00.123\tsource=zsh\tkind=command\tb64:text={b64('echo hi')}\tduration_ms=42\texit_code=0")
+    assert ev == {
+        "ts": "2026-06-23 14:00:00.123",
+        "source": "zsh",
+        "kind": "command",
+        "text": "echo hi",
+        "duration_ms": 42,
+        "exit_code": 0,
+    }
+
+
+def test_parse_arbitrary_content_survives():
+    nasty = 'rm -rf "$X"; echo \'q\'\twith\ttabs\nand a newline \\back\\slash 你好 password123!'
+    line = f"v1\tts=2026-06-23 14:00:00.000\tsource=zsh\tkind=command\tb64:text={b64(nasty)}"
+    ev = C.parse_line(line)
+    assert ev["text"] == nasty
+
+
+def test_parse_unknown_keys_go_to_payload():
+    ev = C.parse_line(f"v1\tts=t\tsource=zsh\tkind=command\twindow=@3\tpane=%7")
+    pl = json.loads(ev["payload"])
+    assert pl == {"window": "@3", "pane": "%7"}
+
+
+def test_parse_merges_explicit_payload_with_extras():
+    explicit = b64(json.dumps({"a": 1}))
+    ev = C.parse_line(f"v1\tts=t\tsource=x\tkind=k\tb64:payload={explicit}\tfoo=bar")
+    assert json.loads(ev["payload"]) == {"a": 1, "foo": "bar"}
+
+
+@pytest.mark.parametrize("line", [
+    "",
+    "garbage no version",
+    "v2\tts=t\tsource=s\tkind=k",          # wrong version
+    "v1\tnoeqsign\tsource=s\tkind=k",      # token without '='
+    "v1\tsource=s\tkind=k",                # missing ts
+    "v1\tts=t\tkind=k",                    # missing source
+    f"v1\tts=t\tsource=s\tkind=k\tb64:text=!!!notb64!!!",  # bad base64
+])
+def test_parse_malformed_returns_none(line):
+    assert C.parse_line(line) is None
+
+
+def test_parse_bad_int_defaults_zero():
+    ev = C.parse_line("v1\tts=t\tsource=s\tkind=k\tduration_ms=notanum")
+    assert ev["duration_ms"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# JSONEachRow formatting
+# --------------------------------------------------------------------------- #
+def test_jsoneachrow_body():
+    body = C.format_jsoneachrow([{"a": 1}, {"b": "x"}])
+    assert body == b'{"a":1}\n{"b":"x"}\n'
+
+
+def test_jsoneachrow_unicode_not_escaped():
+    body = C.format_jsoneachrow([{"text": "你好"}])
+    assert "你好" in body.decode("utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# Spool rotation + batching
+# --------------------------------------------------------------------------- #
+def write_lines(path: Path, lines):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a") as f:
+        for ln in lines:
+            f.write(ln + "\n")
+
+
+def test_rotate_and_ship(tmp_path):
+    c = cfg(tmp_path)
+    sp = C.Spool(c)
+    write_lines(sp.current, [
+        f"v1\tts=t\tsource=zsh\tkind=command\tb64:text={b64('one')}",
+        f"v1\tts=t\tsource=zsh\tkind=command\tb64:text={b64('two')}",
+    ])
+    opener = FakeOpener()
+    client = C.ClickHouseClient(c, opener=opener)
+    stats = C.flush_once(sp, client)
+    assert stats == {"shipped": 1, "failed": 0}
+    assert [r["text"] for r in opener.rows] == ["one", "two"]
+    assert sp.segments() == []          # deleted after 200
+    assert not sp.current.exists()      # rotated away
+
+
+def test_batching_splits_into_multiple_inserts(tmp_path):
+    c = cfg(tmp_path, batch_size=2)
+    sp = C.Spool(c)
+    write_lines(sp.current, [f"v1\tts=t\tsource=s\tkind=k\tb64:text={b64(str(i))}" for i in range(5)])
+    opener = FakeOpener()
+    C.flush_once(sp, C.ClickHouseClient(c, opener=opener))
+    # 5 events / batch 2 => 3 inserts
+    assert opener.calls == 3
+    assert [r["text"] for r in opener.rows] == ["0", "1", "2", "3", "4"]
+
+
+def test_empty_current_no_rotate(tmp_path):
+    c = cfg(tmp_path)
+    sp = C.Spool(c)
+    sp.current.write_text("")
+    opener = FakeOpener()
+    stats = C.flush_once(sp, C.ClickHouseClient(c, opener=opener))
+    assert stats == {"shipped": 0, "failed": 0}
+    assert opener.calls == 0
+
+
+# --------------------------------------------------------------------------- #
+# Offline buffering: accumulate -> retry -> ship on recovery, no double-ship
+# --------------------------------------------------------------------------- #
+def test_offline_accumulate_then_ship_on_recovery(tmp_path):
+    c = cfg(tmp_path)
+    sp = C.Spool(c)
+
+    # Backend down: opener raises a URLError.
+    import urllib.error
+    down = FakeOpener(fail_times=99, raise_exc=urllib.error.URLError("offline"))
+    client_down = C.ClickHouseClient(c, opener=down)
+
+    # Three flush cycles while offline; each adds a batch.
+    for cycle in range(3):
+        write_lines(sp.current, [f"v1\tts=t\tsource=s\tkind=k\tb64:text={b64(f'c{cycle}')}"])
+        stats = C.flush_once(sp, client_down)
+        assert stats["failed"] == 1
+    # All segments still buffered on disk, nothing lost.
+    assert len(sp.segments()) == 3
+
+    # Backend recovers.
+    up = FakeOpener()
+    client_up = C.ClickHouseClient(c, opener=up)
+    stats = C.flush_once(sp, client_up)
+    assert stats == {"shipped": 3, "failed": 0}
+    assert sorted(r["text"] for r in up.rows) == ["c0", "c1", "c2"]
+    assert sp.segments() == []
+
+
+def test_no_double_ship_after_partial_failure(tmp_path):
+    """A segment that fails to ship is retried; a segment that succeeds is NOT
+    re-inserted on the next pass (it was deleted)."""
+    c = cfg(tmp_path)
+    sp = C.Spool(c)
+
+    # First pass: succeeds for the one segment present.
+    write_lines(sp.current, [f"v1\tts=t\tsource=s\tkind=k\tb64:text={b64('a')}"])
+    opener = FakeOpener()
+    client = C.ClickHouseClient(c, opener=opener)
+    C.flush_once(sp, client)
+    first_calls = opener.calls
+    assert sorted(r["text"] for r in opener.rows) == ["a"]
+
+    # Second pass with NO new data: nothing to ship, no re-insert of "a".
+    C.flush_once(sp, client)
+    assert opener.calls == first_calls  # unchanged → no double ship
+
+
+def test_failed_segment_retried_not_lost(tmp_path):
+    c = cfg(tmp_path)
+    sp = C.Spool(c)
+    write_lines(sp.current, [f"v1\tts=t\tsource=s\tkind=k\tb64:text={b64('keep')}"])
+    # Fail once, then succeed.
+    opener = FakeOpener(fail_times=1)
+    client = C.ClickHouseClient(c, opener=opener)
+
+    stats = C.flush_once(sp, client)
+    assert stats["failed"] == 1
+    assert len(sp.segments()) == 1   # retained for retry
+
+    stats = C.flush_once(sp, client)
+    assert stats["shipped"] == 1
+    assert sp.segments() == []
+    assert [r["text"] for r in opener.rows][-1] == "keep"
+
+
+# --------------------------------------------------------------------------- #
+# Malformed / oversized handling
+# --------------------------------------------------------------------------- #
+def test_segment_with_malformed_lines_ships_good_drops_bad(tmp_path):
+    c = cfg(tmp_path)
+    sp = C.Spool(c)
+    write_lines(sp.current, [
+        f"v1\tts=t\tsource=s\tkind=k\tb64:text={b64('good1')}",
+        "this is not a valid v1 line",
+        f"v1\tts=t\tsource=s\tkind=k\tb64:text={b64('good2')}",
+    ])
+    opener = FakeOpener()
+    C.flush_once(sp, C.ClickHouseClient(c, opener=opener))
+    assert sorted(r["text"] for r in opener.rows) == ["good1", "good2"]
+
+
+def test_all_malformed_segment_dropped_not_wedged(tmp_path):
+    c = cfg(tmp_path)
+    sp = C.Spool(c)
+    write_lines(sp.current, ["garbage1", "garbage2"])
+    opener = FakeOpener()
+    stats = C.flush_once(sp, C.ClickHouseClient(c, opener=opener))
+    assert opener.calls == 0           # nothing valid to insert
+    assert sp.segments() == []         # but the file is dropped, not stuck
+
+
+# --------------------------------------------------------------------------- #
+# Buffer cap + drop logging
+# --------------------------------------------------------------------------- #
+def test_buffer_cap_drops_oldest_and_logs(tmp_path, caplog):
+    import logging
+    c = cfg(tmp_path, max_buffer_bytes=200)
+    sp = C.Spool(c)
+    # Create several segments each > the cap fraction so size enforcement trips.
+    for i in range(5):
+        seg = sp.dir / f"seg-{i:013d}-0001.log"
+        seg.write_text("x" * 100)
+    with caplog.at_level(logging.WARNING):
+        dropped = sp.enforce_cap()
+    assert dropped >= 1
+    remaining = sum(p.stat().st_size for p in sp.segments())
+    assert remaining <= c.max_buffer_bytes
+    assert any("BUFFER CAP" in r.message for r in caplog.records)
+
+
+def test_buffer_cap_age_drops_old_segment(tmp_path, caplog):
+    import logging
+    c = cfg(tmp_path, max_buffer_age_seconds=1.0)
+    sp = C.Spool(c)
+    old = sp.dir / "seg-0000000000001-0001.log"
+    old.write_text("x")
+    os.utime(old, (0, 0))  # epoch 0 => ancient
+    with caplog.at_level(logging.WARNING):
+        sp.enforce_cap()
+    assert not old.exists()
+    assert any("over-age" in r.message for r in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# HTTP client auth headers + non-2xx handling
+# --------------------------------------------------------------------------- #
+def test_client_sends_auth_headers_when_password_set(tmp_path):
+    c = cfg(tmp_path, user="writer", password="s3cret")
+    captured = {}
+
+    def opener(req, timeout=None):
+        captured["user"] = req.get_header("X-clickhouse-user")
+        captured["key"] = req.get_header("X-clickhouse-key")
+        captured["url"] = req.full_url
+        return FakeResp(200)
+
+    C.ClickHouseClient(c, opener=opener).insert(b"{}\n")
+    assert captured["user"] == "writer"
+    assert captured["key"] == "s3cret"
+    assert "INSERT+INTO" in captured["url"] or "INSERT%20INTO" in captured["url"]
+
+
+def test_client_raises_on_non_2xx(tmp_path):
+    c = cfg(tmp_path)
+    client = C.ClickHouseClient(c, opener=lambda req, timeout=None: FakeResp(500))
+    with pytest.raises(RuntimeError):
+        client.insert(b"{}\n")
+
+
+def test_insert_url_uses_config(tmp_path):
+    c = cfg(tmp_path, clickhouse_url="http://example/", database="db", table="t")
+    assert c.insert_url.startswith("http://example/?")
+    assert "db.t" in c.insert_url
+
+
+# --------------------------------------------------------------------------- #
+# Config from env
+# --------------------------------------------------------------------------- #
+def test_config_from_env():
+    env = {
+        "CLICKHOUSE_URL": "http://h/",
+        "CLICKHOUSE_USER": "u",
+        "CLICKHOUSE_PASSWORD": "p",
+        "ACTIVITY_BATCH_SIZE": "7",
+        "ACTIVITY_FLUSH_SECONDS": "3",
+        "ACTIVITY_SPOOL_DIR": "/tmp/spool-x",
+    }
+    c = C.Config.from_env(env)
+    assert c.clickhouse_url == "http://h"   # trailing slash stripped
+    assert (c.user, c.password) == ("u", "p")
+    assert c.batch_size == 7
+    assert c.flush_seconds == 3.0
+    assert str(c.spool_dir) == "/tmp/spool-x"
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: emit (real shell) -> spool -> daemon parse, arbitrary content
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not EMIT.exists(), reason="emit script missing")
+def test_emit_to_daemon_roundtrip_arbitrary_content(tmp_path):
+    spool = tmp_path / "spool"
+    env = dict(os.environ, ACTIVITY_SPOOL_DIR=str(spool))
+
+    nasty_cmd = 'echo "he said \\"hi\\"" \'single\'; cat <<X\nmulti\nline 你好\nX\npassword123!'
+    nasty_cwd = "/home/zach/weird dir/with\ttab"
+
+    rc = subprocess.run(
+        ["bash", str(EMIT),
+         "source=zsh", "kind=command",
+         f"b64:text={nasty_cmd}", f"b64:cwd={nasty_cwd}",
+         "duration_ms=123", "exit_code=2",
+         "b64:project=devrc", "window=@9"],
+        env=env, capture_output=True, text=True,
+    )
+    assert rc.returncode == 0, rc.stderr
+
+    cur = spool / "current.log"
+    assert cur.exists()
+    lines = [l for l in cur.read_text().splitlines() if l]
+    assert len(lines) == 1
+
+    ev = C.parse_line(lines[0])
+    assert ev is not None
+    assert ev["text"] == nasty_cmd          # exact survival incl password string
+    assert ev["cwd"] == nasty_cwd
+    assert ev["duration_ms"] == 123
+    assert ev["exit_code"] == 2
+    assert ev["project"] == "devrc"
+    assert json.loads(ev["payload"]) == {"window": "@9"}
+    # ts + host auto-filled by emit.
+    assert "ts" in ev and ev["source"] == "zsh"
+
+
+@pytest.mark.skipif(not EMIT.exists(), reason="emit script missing")
+def test_emit_concurrent_appends_dont_interleave(tmp_path):
+    spool = tmp_path / "spool"
+    env = dict(os.environ, ACTIVITY_SPOOL_DIR=str(spool))
+    procs = []
+    for i in range(20):
+        procs.append(subprocess.Popen(
+            ["bash", str(EMIT), "source=zsh", "kind=command", f"b64:text=cmd{i}"],
+            env=env,
+        ))
+    for p in procs:
+        p.wait()
+    lines = [l for l in (spool / "current.log").read_text().splitlines() if l]
+    assert len(lines) == 20
+    texts = sorted(C.parse_line(l)["text"] for l in lines)
+    assert texts == sorted(f"cmd{i}" for i in range(20))

--- a/scripts/tmux-activity-emit.sh
+++ b/scripts/tmux-activity-emit.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# tmux-activity-emit.sh — thin activity-telemetry shipper for tmux.
+#
+# Fired from tmux focus-change hooks (after-select-window / client-session-changed).
+# Reads the focused window/session straight from tmux (and the existing per-window
+# task state in ~/.tmux/tasks/*.json when present) and `emit`s ONE event to the
+# activity spool. The collector daemon ships it to ClickHouse.
+#
+# This REUSES the existing tmux activity machinery (pipe-activity / tasks); it does
+# not rebuild any tracking — it only forwards focus changes into the telemetry spool.
+#
+# Usage: tmux-activity-emit.sh <kind>     where kind = window-focus | session
+
+set -u
+
+EMIT="${HOME}/.config/activity-collector/emit"
+[[ -x "$EMIT" ]] || exit 0
+
+KIND="${1:-window-focus}"
+
+# Pull focus context from tmux. If not in a tmux client context, bail quietly.
+read -r SESSION WINDOW_ID WINDOW_INDEX WINDOW_NAME PANE_PATH < <(
+    tmux display-message -p '#{session_name} #{window_id} #{window_index} #{window_name} #{pane_current_path}' 2>/dev/null
+) || exit 0
+[[ -n "${SESSION:-}" ]] || exit 0
+
+CWD="${PANE_PATH:-$PWD}"
+
+# project = git repo basename of the focused pane's cwd, else cwd basename, else "".
+PROJECT=""
+if root=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null); then
+    PROJECT="${root##*/}"
+elif [[ -n "$CWD" ]]; then
+    PROJECT="${CWD##*/}"
+fi
+
+# Reuse existing task state if this window has one (task name + status enrich the
+# payload without rebuilding anything).
+TASK_JSON="${HOME}/.tmux/tasks/${SESSION}.json"
+PAYLOAD_ARGS=( "window_id=${WINDOW_ID}" "window_index=${WINDOW_INDEX}" )
+if [[ -f "$TASK_JSON" ]]; then
+    PAYLOAD_ARGS+=( "task_file=${SESSION}.json" )
+fi
+
+"$EMIT" \
+    source=tmux "kind=${KIND}" \
+    "b64:text=${WINDOW_NAME}" "b64:cwd=${CWD}" \
+    "b64:project=${PROJECT}" "b64:session=${SESSION}" \
+    "b64:app=tmux" \
+    "${PAYLOAD_ARGS[@]}"


### PR DESCRIPTION
First slice of a personal activity-telemetry pipeline. Interactive-shell and tmux events flow through a lossless local spool to the homelab ClickHouse `activity.events` table. Authorized self-instrumentation on Zach's own hosts.

## Architecture
```
zsh preexec/precmd ─┐
tmux focus hooks   ─┼─► emit (pure shell, hot path) ─► spool/current.log
                    ┘                                        │ rotate
                                                collector.py ─┴─► seg-*.log ─► ClickHouse
                                                              (delete on HTTP 200)
```

## What's here
- **`scripts/collector/emit`** — pure-shell hot-path helper called on every interactive command. Atomic `>>` append, no python/jq startup. Free-text fields are base64-encoded so arbitrary content (quotes, newlines, unicode, secrets) survives intact. The daemon does all JSON/ClickHouse formatting.
- **`scripts/collector/collector.py`** — user-systemd daemon (stdlib-only, urllib). Rotates `current.log` → segment files, batches, assembles JSONEachRow, POSTs to ClickHouse, deletes a segment **only on HTTP 200**. Offline-buffered (segments accumulate when the backend is unreachable, ship on recovery), no double-ship, on-disk cap by age + size with loud drop logging, retry + backoff.
- **`nix/programs/zsh/default.nix`** — `preexec`/`precmd` hooks in **interactive init only** → Claude's non-interactive `zsh -c` commands are correctly excluded. Emits command + duration_ms + exit_code + project (git basename) + tmux session + app.
- **`scripts/tmux-activity-emit.sh` + `.tmux.conf`** — thin focus-change shipper appended (`-ga`) to the existing pipe-activity hooks; reuses the existing tracking/task state, does not rebuild it.
- **`nix/home.nix`** — `systemd.user.services.activity-collector` (mirrors the `cpu-monitor` pattern: Restart=always, explicit PATH); symlinks for emit/collector; activation seeds `~/.config/activity-collector/env` (chmod 600, **not** in the nix store, **not** committed) from `.env.example`.

## Config / secrets
Endpoint + credentials are env-configurable (`CLICKHOUSE_URL/USER/PASSWORD/...`) so an authed ClickHouse writer user slots in later **with no code change**. No schema change; `default` user/auth untouched.

## Tests (30, mocked HTTP — none hit the real endpoint)
parse_line, JSONEachRow formatting, rotation + batching, offline accumulate→retry→ship-on-recovery, no-double-ship after partial failure, malformed/oversized handling, buffer-cap drop logging, auth headers, and a real `emit→spool→daemon` round-trip proving arbitrary content (incl. a fake `password123!` string) survives.

```
30 passed
```

## Validation (actually run)
- `nix-instantiate --parse` on both changed `.nix` files: OK.
- `home-manager switch --flake ~/workspace/devrc --impure`: applied; `activity-collector.service` active.
- Drove a **real interactive zsh** that ran a probe command; the hook-emitted event landed in ClickHouse with command/duration/exit_code/project/session/app intact:
  ```
  ts                       source kind     text                                          dur exit proj  session app
  2026-06-23 21:02:37.355  zsh    command  echo activity-slice-probe-interactive-...      2   0    devrc 1:1.1   tmux
  ```
- Probe rows deleted afterward (`count()` → 0).

## Deferred
- Keystroke source (the "later on keystrokes" hot path) — not in this slice.
- Laptop rollout (`ship.sh`) — left to Zach; only the workbench was switched/verified.
- The authed ClickHouse writer user is a held decision; the env file is ready for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)