### PR TITLE
feat(collector): X11 full-content keylogger + Chrome MV3 browser collector

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -220,6 +220,20 @@ in
     executable = true;
   };
 
+  # GUI activity collectors (keylogger + browser receiver). The whole module
+  # dir is symlinked recursively so the daemons can import their sibling modules
+  # (keymap/chunker/winctx/spool_emit). The browser receiver reuses keylog's
+  # spool_emit (single source of truth for the v1 line format), so keylog/ must
+  # be present even on a browser-only host.
+  home.file.".config/activity-collector/keylog" = {
+    source = ../scripts/collector/keylog;
+    recursive = true;
+  };
+  home.file.".config/activity-collector/browser-ext" = {
+    source = ../scripts/collector/browser-ext;
+    recursive = true;
+  };
+
   # Global Claude Code behavioural config — single source of truth for both
   # hosts (these were drifting when edited per-host). Synced via scripts/ship.sh.
   # NOTE: now read-only symlinks into the nix store → edit `devrc/claude/*.md`
@@ -277,6 +291,62 @@ in
       ];
       EnvironmentFile = "-%h/.config/activity-collector/env";
       ExecStart = "${pkgs.python312}/bin/python3 %h/.config/activity-collector/collector.py";
+      Restart = "always";
+      RestartSec = 10;
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
+
+  # X11 full-content keystroke collector. Captures globally via the RECORD
+  # extension (python-xlib) as the logged-in user — needs the X session, so it
+  # is gated on graphical-session.target (NOT started in headless/server mode).
+  # Writes typing units into the same spool the activity-collector ships.
+  # NOTE: staged but NOT enabled here; enablement is a deliberate converge step.
+  systemd.user.services.keylog = {
+    Unit = {
+      Description = "X11 full-content keystroke collector → activity spool";
+      # Requires a live X session (RECORD + active-window context).
+      After = [ "graphical-session.target" ];
+      PartOf = [ "graphical-session.target" ];
+    };
+    Service = {
+      Type = "simple";
+      # python3 WITH python-xlib (the X RECORD plumbing). DISPLAY is borrowed
+      # from the running session; i3 is not systemd-integrated, so import the
+      # graphical env if available.
+      Environment = [
+        "PATH=${lib.makeBinPath [ (pkgs.python312.withPackages (ps: [ ps.xlib ])) pkgs.coreutils ]}"
+      ];
+      ExecStart = "${pkgs.python312.withPackages (ps: [ ps.xlib ])}/bin/python3 %h/.config/activity-collector/keylog/keylog.py";
+      Restart = "always";
+      RestartSec = 10;
+    };
+    Install = {
+      WantedBy = [ "graphical-session.target" ];
+    };
+  };
+
+  # Browser-activity receiver: localhost HTTP bridge that the MV3 extension
+  # POSTs to; writes browser nav/focus events into the activity spool. Loopback
+  # only, stdlib-only python. No X dependency (the extension lives in the
+  # browser), but it is only useful alongside a running browser, so it tracks
+  # default.target like the collector. Staged but NOT enabled.
+  systemd.user.services.browser-activity-receiver = {
+    Unit = {
+      Description = "Browser-activity receiver (localhost → activity spool)";
+      After = [ "network.target" ];
+    };
+    Service = {
+      Type = "simple";
+      Environment = [
+        "PATH=${lib.makeBinPath [ pkgs.python312 pkgs.coreutils ]}"
+        # Bind loopback only; keep off any external interface.
+        "BROWSER_RECEIVER_HOST=127.0.0.1"
+        "BROWSER_RECEIVER_PORT=8787"
+      ];
+      ExecStart = "${pkgs.python312}/bin/python3 %h/.config/activity-collector/browser-ext/receiver.py";
       Restart = "always";
       RestartSec = 10;
     };

--- a/scripts/collector/browser-ext/README.md
+++ b/scripts/collector/browser-ext/README.md
@@ -1,0 +1,69 @@
+# browser-ext — Chrome MV3 browser-activity collector
+
+Tracks the active tab (full URL + title), active-duration, and focus/idle
+transitions, and POSTs each event to a localhost receiver that writes it into
+the activity-collector spool (v1 emit format) for the existing daemon to ship.
+
+Full URL capture, local-only — consistent with the full-content self-instrumentation
+choice. Nothing leaves the host from here; shipping is the daemon's decision and
+is gated on an authenticated ClickHouse.
+
+## Components
+- `manifest.json` — MV3 manifest. Permissions: `tabs`, `webNavigation`, `idle`;
+  host permission for `http://127.0.0.1:8787/*` only.
+- `service_worker.js` — background worker. Listens on `chrome.tabs.onActivated`,
+  `chrome.webNavigation.onCommitted`, `chrome.tabs.onUpdated` (title), 
+  `chrome.windows.onFocusChanged`, and `chrome.idle.onStateChanged`. Computes
+  active-duration across tab switches (persisted in `chrome.storage.session` so
+  it survives MV3 worker suspension) and POSTs events to the receiver.
+- `receiver.py` — stdlib `http.server` bound to `127.0.0.1:8787`. Accepts
+  `POST /event`, maps the JSON to a v1 spool record, appends to the spool.
+  Shares `../keylog/spool_emit.py` (single source of truth for the line format).
+
+## localhost endpoint contract
+`POST http://127.0.0.1:8787/event`, `Content-Type: application/json`:
+
+```json
+{ "kind": "nav" | "focus",
+  "url":   "https://full/url",      // full URL (nav events)
+  "title": "tab title",
+  "active_ms": 1234,                  // ms the previous tab was focused
+  "state": "focused|blurred|idle|active|locked",  // focus events
+  "ts": 1719240000000 }              // client epoch ms
+```
+
+Receiver writes:
+```
+source=browser  kind=<nav|focus>  text=<url>  app=<chromium|brave>
+payload={"title":…,"active_ms":…,"state":…,"client_ts":…}
+```
+`GET /health` → `{"ok":true}`.
+
+## Load unpacked (chromium / brave)
+1. Start the receiver:
+   `nix-shell -p python3 --run "python3 scripts/collector/browser-ext/receiver.py"`
+   (or enable the staged `browser-activity-receiver` user service).
+2. Open `chrome://extensions` (or `brave://extensions`).
+3. Toggle **Developer mode** (top-right).
+4. **Load unpacked** → select `scripts/collector/browser-ext/`.
+5. Browse. Switch tabs / navigate; `GET http://127.0.0.1:8787/health` confirms the
+   receiver is up, and `tail -f $ACTIVITY_SPOOL_DIR/current.log` shows records.
+
+To point at a TEST spool while validating:
+`ACTIVITY_SPOOL_DIR=/tmp/activity-test-spool python3 receiver.py`
+
+## Config (receiver env)
+- `ACTIVITY_SPOOL_DIR` — spool dir (default `~/.local/state/activity/spool`).
+- `BROWSER_RECEIVER_HOST` / `BROWSER_RECEIVER_PORT` — bind (default `127.0.0.1:8787`).
+  Keep the host on loopback.
+- `BROWSER_APP` — app label written to records (default `chromium`; set `brave`).
+
+## Verification status
+- Receiver: fully unit-tested (event→fields, real loopback POST→spool round-trip
+  through `collector.parse_line`, arbitrary content incl. unicode/quotes/newlines/
+  a fake password, bad-JSON 400, wrong-path 404). See `tests/test_receiver.py`.
+- Manifest + service-worker logic: validated (manifest JSON parses, MV3 schema
+  fields present; `buildEvent` payload shape mirrored by the receiver test).
+- The end-to-end **load-unpacked in a real browser** step is a MANUAL step (MV3
+  service workers are not reliably driveable headlessly). Follow "Load unpacked"
+  above to complete it.

--- a/scripts/collector/browser-ext/manifest.json
+++ b/scripts/collector/browser-ext/manifest.json
@@ -1,0 +1,12 @@
+{
+  "manifest_version": 3,
+  "name": "Activity Collector (browser)",
+  "version": "1.0.0",
+  "description": "Self-instrumentation: reports active tab URL/title, active-duration, and focus/idle transitions to a localhost activity collector. Full URL capture, local-only.",
+  "permissions": ["tabs", "webNavigation", "idle", "storage"],
+  "host_permissions": ["http://127.0.0.1:8787/*"],
+  "background": {
+    "service_worker": "service_worker.js",
+    "type": "module"
+  }
+}

--- a/scripts/collector/browser-ext/receiver.py
+++ b/scripts/collector/browser-ext/receiver.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""receiver — localhost bridge: browser extension → activity-collector spool.
+
+A tiny stdlib http.server that accepts the MV3 extension's POSTs at
+`/event` and writes each as a v1 emit-format record into the local spool, so the
+existing collector daemon ships browser activity unchanged. Bound to 127.0.0.1
+only — it must never be reachable off-host.
+
+Incoming JSON (from service_worker.js buildEvent):
+    { kind: "nav"|"focus", url, title, active_ms, state, ts }
+
+Emitted spool record (v1 contract):
+    source=browser  kind=<nav|focus>  text=<url>  app=<browser>
+    payload=<json: title, active_ms, state>
+
+Why a separate service (not folded into collector.py): the collector daemon's
+job is rotate→ship→ClickHouse and it has NO inbound network surface by design;
+bolting an HTTP listener onto it would couple a privileged shipper to an
+attacker-reachable socket. The receiver is a thin, separately-restartable
+write-only adapter — failure of one does not take down the other. It shares the
+spool_emit module with the keylogger so the v1 line format has a single source
+of truth.
+
+Config (env):
+    ACTIVITY_SPOOL_DIR    spool dir (default ~/.local/state/activity/spool)
+    BROWSER_RECEIVER_HOST  bind host (default 127.0.0.1 — keep loopback)
+    BROWSER_RECEIVER_PORT  bind port (default 8787)
+    BROWSER_APP            app label for records (default "chromium")
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+# spool_emit lives in the sibling keylog/ dir (single source of truth for the
+# v1 line format). Add it to the path.
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent / "keylog"))
+import spool_emit as SE  # noqa: E402
+
+MAX_BODY = 64 * 1024  # a nav event is tiny; cap to avoid abuse.
+
+
+def event_to_fields(evt: dict, app_default: str) -> dict:
+    """Map an incoming extension event dict → v1 emit fields.
+
+    `text` is the full URL (full-content choice). title/active_ms/state go into
+    payload JSON. `app` is the browser label (chromium/brave). Robust to missing
+    keys — anything absent becomes empty/0.
+    """
+    kind = evt.get("kind") or "nav"
+    if kind not in ("nav", "focus"):
+        kind = "nav"
+    payload = {
+        "title": evt.get("title", "") or "",
+        "active_ms": int(evt.get("active_ms") or 0),
+        "state": evt.get("state", "") or "",
+    }
+    if evt.get("ts"):
+        payload["client_ts"] = evt["ts"]
+    return {
+        "source": "browser",
+        "kind": kind,
+        "text": evt.get("url", "") or "",
+        "app": evt.get("app") or app_default,
+        "project": "",
+        "session": "",
+        "payload": json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
+    }
+
+
+def make_handler(spool_dir: Path, app_default: str):
+    class Handler(BaseHTTPRequestHandler):
+        # Silence default stderr logging spam; the daemon journal is enough.
+        def log_message(self, *a):  # noqa: A003
+            pass
+
+        def _reply(self, code: int, body: bytes = b""):
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            # The page making the fetch is a privileged extension worker; still,
+            # only loopback is bound. Allow the extension origin generically.
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            if body:
+                self.wfile.write(body)
+
+        def do_OPTIONS(self):
+            self.send_response(204)
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type")
+            self.end_headers()
+
+        def do_GET(self):
+            if self.path == "/health":
+                self._reply(200, b'{"ok":true}')
+            else:
+                self._reply(404)
+
+        def do_POST(self):
+            if self.path != "/event":
+                self._reply(404)
+                return
+            try:
+                length = int(self.headers.get("Content-Length") or 0)
+            except ValueError:
+                self._reply(400)
+                return
+            if length <= 0 or length > MAX_BODY:
+                self._reply(400)
+                return
+            raw = self.rfile.read(length)
+            try:
+                evt = json.loads(raw.decode("utf-8"))
+                if not isinstance(evt, dict):
+                    raise ValueError("not an object")
+            except (ValueError, UnicodeDecodeError):
+                self._reply(400, b'{"error":"bad json"}')
+                return
+            fields = event_to_fields(evt, app_default)
+            SE.emit(fields, spool_dir=spool_dir)
+            self._reply(200, b'{"ok":true}')
+
+    return Handler
+
+
+def main(argv=None) -> int:
+    spool_dir = SE.default_spool_dir()
+    host = os.environ.get("BROWSER_RECEIVER_HOST", "127.0.0.1")
+    port = int(os.environ.get("BROWSER_RECEIVER_PORT", "8787"))
+    app_default = os.environ.get("BROWSER_APP", "chromium")
+
+    handler = make_handler(spool_dir, app_default)
+    server = ThreadingHTTPServer((host, port), handler)
+    print(
+        f"browser-receiver: listening on http://{host}:{port}/event "
+        f"spool={spool_dir} app={app_default}",
+        file=sys.stderr, flush=True,
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/collector/browser-ext/service_worker.js
+++ b/scripts/collector/browser-ext/service_worker.js
@@ -1,0 +1,109 @@
+// service_worker.js — MV3 background worker for the activity browser collector.
+//
+// Tracks the active tab (URL + title), how long it stayed active, and
+// focus/idle transitions, then POSTs each event to the localhost receiver
+// (http://127.0.0.1:8787/event). The receiver bridges these into the existing
+// activity-collector spool in the v1 emit format. FULL URL capture — consistent
+// with the full-content self-instrumentation choice; nothing leaves localhost
+// here (the daemon decides shipping).
+//
+// Event kinds:
+//   nav   — the active tab navigated / changed; carries url, title, active_ms
+//            (how long the PREVIOUS active tab was focused before this switch).
+//   focus — window/idle focus transition (browser focused/blurred, idle/active).
+//
+// MV3 service workers are ephemeral (the browser may suspend them). We persist
+// the "current active tab + since-timestamp" in chrome.storage.session so an
+// active-duration can still be computed across a worker restart.
+
+const ENDPOINT = "http://127.0.0.1:8787/event";
+const STORE_KEY = "active_state";
+
+// --- pure payload builder (kept tiny + mirrored by the receiver test) ----- //
+export function buildEvent(kind, { url, title, active_ms, state }) {
+  return {
+    kind, // "nav" | "focus"
+    url: url || "",
+    title: title || "",
+    active_ms: Number.isFinite(active_ms) ? Math.max(0, Math.round(active_ms)) : 0,
+    state: state || "", // for focus events: focused|blurred|idle|active|locked
+    ts: Date.now(),
+  };
+}
+
+async function post(event) {
+  try {
+    await fetch(ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(event),
+    });
+  } catch (e) {
+    // Receiver down (service not running) — drop silently; telemetry is
+    // best-effort and must never disrupt browsing.
+  }
+}
+
+async function getState() {
+  const o = await chrome.storage.session.get(STORE_KEY);
+  return o[STORE_KEY] || { tabId: null, url: "", title: "", since: Date.now() };
+}
+
+async function setState(s) {
+  await chrome.storage.session.set({ [STORE_KEY]: s });
+}
+
+// Compute active_ms for the outgoing (previous) tab, emit a nav event for the
+// NEW active tab, and record the new active state.
+async function onActive({ url, title, tabId }) {
+  const prev = await getState();
+  const now = Date.now();
+  const active_ms = prev.since ? now - prev.since : 0;
+  await post(buildEvent("nav", { url, title, active_ms }));
+  await setState({ tabId, url, title, since: now });
+}
+
+async function tabInfo(tabId) {
+  try {
+    const t = await chrome.tabs.get(tabId);
+    return { url: t.url || t.pendingUrl || "", title: t.title || "", tabId };
+  } catch {
+    return { url: "", title: "", tabId };
+  }
+}
+
+// --- chrome event wiring --------------------------------------------------- //
+chrome.tabs.onActivated.addListener(async ({ tabId }) => {
+  await onActive(await tabInfo(tabId));
+});
+
+// Navigation within the active tab (committed top-frame loads).
+chrome.webNavigation.onCommitted.addListener(async (d) => {
+  if (d.frameId !== 0) return; // top frame only
+  const info = await tabInfo(d.tabId);
+  const cur = await getState();
+  if (cur.tabId !== null && cur.tabId !== d.tabId) return; // not the active tab
+  await onActive(info);
+});
+
+// Title can arrive after commit; refresh stored title without a duration reset.
+chrome.tabs.onUpdated.addListener(async (tabId, changeInfo) => {
+  if (!changeInfo.title) return;
+  const cur = await getState();
+  if (cur.tabId === tabId) {
+    cur.title = changeInfo.title;
+    await setState(cur);
+  }
+});
+
+// Window focus changes (browser gained/lost OS focus).
+chrome.windows.onFocusChanged.addListener(async (windowId) => {
+  const focused = windowId !== chrome.windows.WINDOW_ID_NONE;
+  await post(buildEvent("focus", { state: focused ? "focused" : "blurred" }));
+});
+
+// Idle / active / locked transitions.
+chrome.idle.setDetectionInterval(60);
+chrome.idle.onStateChanged.addListener(async (state) => {
+  await post(buildEvent("focus", { state }));
+});

--- a/scripts/collector/browser-ext/tests/test_receiver.py
+++ b/scripts/collector/browser-ext/tests/test_receiver.py
@@ -1,0 +1,159 @@
+"""Tests for the browser receiver: event→fields mapping, POST→spool over a real
+loopback socket, and round-trip through the existing collector.parse_line, incl.
+arbitrary content (quotes / newlines / unicode / a fake password in the URL)."""
+import json
+import sys
+import threading
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+EXT = Path(__file__).resolve().parent.parent      # browser-ext
+COLLECTOR = EXT.parent                              # scripts/collector
+KEYLOG = COLLECTOR / "keylog"
+sys.path.insert(0, str(EXT))
+sys.path.insert(0, str(KEYLOG))
+sys.path.insert(0, str(COLLECTOR))
+
+import receiver as R  # noqa: E402
+import collector as C  # noqa: E402
+
+
+def test_event_to_fields_nav():
+    f = R.event_to_fields(
+        {"kind": "nav", "url": "https://x.test/a?b=c", "title": "Hi",
+         "active_ms": 1234, "ts": 99},
+        "chromium",
+    )
+    assert f["source"] == "browser"
+    assert f["kind"] == "nav"
+    assert f["text"] == "https://x.test/a?b=c"
+    assert f["app"] == "chromium"
+    pl = json.loads(f["payload"])
+    assert pl["title"] == "Hi"
+    assert pl["active_ms"] == 1234
+    assert pl["client_ts"] == 99
+
+
+def test_event_to_fields_focus_and_defaults():
+    f = R.event_to_fields({"kind": "focus", "state": "idle"}, "brave")
+    assert f["kind"] == "focus"
+    assert f["text"] == ""
+    assert f["app"] == "brave"
+    assert json.loads(f["payload"])["state"] == "idle"
+
+
+def test_unknown_kind_coerced_to_nav():
+    f = R.event_to_fields({"kind": "weird"}, "chromium")
+    assert f["kind"] == "nav"
+
+
+def test_fields_roundtrip_through_parse_line():
+    f = R.event_to_fields(
+        {"kind": "nav", "url": "https://site/x", "title": "T", "active_ms": 5},
+        "chromium",
+    )
+    line = __import__("spool_emit").build_line(f)
+    ev = C.parse_line(line)
+    assert ev["source"] == "browser"
+    assert ev["text"] == "https://site/x"
+    assert json.loads(ev["payload"])["active_ms"] == 5
+
+
+def _serve(spool_dir, app="chromium"):
+    handler = R.make_handler(spool_dir, app)
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    return srv
+
+
+def _post(srv, obj):
+    port = srv.server_address[1]
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}/event",
+        data=json.dumps(obj).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=5) as r:
+        return r.status, r.read()
+
+
+def test_post_writes_spool_record(tmp_path):
+    spool = tmp_path / "spool"
+    srv = _serve(spool)
+    try:
+        status, _ = _post(srv, {
+            "kind": "nav",
+            "url": "https://example.test/path?token=password123!",
+            "title": 'weird "quoted"\ttab\nnewline 你好',
+            "active_ms": 4200,
+        })
+        assert status == 200
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+    cur = spool / "current.log"
+    lines = [l for l in cur.read_text(encoding="utf-8").splitlines() if l]
+    assert len(lines) == 1
+    ev = C.parse_line(lines[0])
+    assert ev is not None
+    assert ev["source"] == "browser"
+    assert ev["text"] == "https://example.test/path?token=password123!"
+    pl = json.loads(ev["payload"])
+    assert pl["title"] == 'weird "quoted"\ttab\nnewline 你好'
+    assert pl["active_ms"] == 4200
+
+
+def test_post_arbitrary_url_content_survives(tmp_path):
+    spool = tmp_path / "spool"
+    srv = _serve(spool)
+    nasty_url = "https://h/p?q=a%20b&x=\"';\n\t你好&pw=password123!"
+    try:
+        _post(srv, {"kind": "nav", "url": nasty_url, "title": "t"})
+    finally:
+        srv.shutdown()
+        srv.server_close()
+    ev = C.parse_line((spool / "current.log").read_text().splitlines()[0])
+    assert ev["text"] == nasty_url
+
+
+def test_bad_json_returns_400(tmp_path):
+    spool = tmp_path / "spool"
+    srv = _serve(spool)
+    try:
+        port = srv.server_address[1]
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/event",
+            data=b"not json{{{",
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            urllib.request.urlopen(req, timeout=5)
+            assert False, "expected HTTP 400"
+        except urllib.error.HTTPError as e:
+            assert e.code == 400
+    finally:
+        srv.shutdown()
+        srv.server_close()
+    # No spool record written.
+    cur = spool / "current.log"
+    assert not cur.exists() or cur.read_text() == ""
+
+
+def test_wrong_path_404(tmp_path):
+    srv = _serve(tmp_path / "spool")
+    try:
+        port = srv.server_address[1]
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/nope", timeout=5)
+            assert False
+        except urllib.error.HTTPError as e:
+            assert e.code == 404
+    finally:
+        srv.shutdown()
+        srv.server_close()

--- a/scripts/collector/keylog/README.md
+++ b/scripts/collector/keylog/README.md
@@ -1,0 +1,69 @@
+# keylog — X11 full-content keystroke collector
+
+Captures ALL keystrokes globally via the X11 **RECORD** extension (python-xlib),
+maps keycode → keysym → character honoring modifier state (Shift / CapsLock /
+AltGr), buffers them into typing units, annotates each with active-window
+context, and emits them into the activity-collector spool in the v1 contract so
+the existing daemon ships them unchanged.
+
+**Full content, NO redaction** — an explicit self-instrumentation choice by the
+machine owner. Records stay in the LOCAL spool until an authenticated ClickHouse
+is in place; nothing here ships them off-host.
+
+## How it captures without root / `input` group
+XRecord operates at the X-protocol level: as the logged-in user owning the X
+session, the daemon asks the X server to stream `KeyPress`/`KeyRelease` events
+for `AllClients`. No `/dev/input` access, no `input` group, no setuid. It uses
+two display connections — one blocked inside `record_enable_context`, one for
+keymap + window-context queries (you cannot issue normal requests on the record
+connection while it records).
+
+## Files
+- `keymap.py` — pure keysym→char mapping (Latin-1 + Unicode keysyms + named keys),
+  modifier resolution (`resolve_char`, `group_index`, `shift_active`). Unit-tested.
+- `chunker.py` — buffers keystrokes into typing units. Flush boundaries:
+  **focus change**, **Enter** (`\n`), **idle timeout** (default 2 s), **max length**
+  (default 4096). BackSpace edits the standing buffer. Pure + clock-injectable.
+- `winctx.py` — active-window context via Xlib: WM_CLASS (app), `_NET_WM_NAME`
+  (title), active window id (session key), i3/EWMH workspace.
+- `spool_emit.py` — builds + appends a v1 spool line byte-compatible with the
+  `emit` bash helper (free text base64-encoded; `ts`/`host` auto-filled). Shared
+  with the browser receiver.
+- `keylog.py` — the daemon: wires XRecord → keymap → chunker → winctx → spool.
+
+## Chunking choice (why not one event per keystroke)
+One spool row per keystroke would ship thousands of useless one-char rows. The
+chunker accumulates characters and flushes ONE `kind=typing` event at a natural
+boundary — focus change (typing moved windows), Enter (a line/command/message was
+submitted), an idle pause (default 2 s of no typing = a unit), or a 4096-char
+guard. BackSpace pops the last buffered char so the captured `text` reflects what
+actually stood, not raw keystrokes. Emitted record:
+
+```
+source=keys  kind=typing  text=<captured chunk>  app=<wm_class>  project=""
+session=<active window id>  payload={"title":…,"workspace":…,"flush":<reason>}
+```
+(`project` is empty — a CWD is not knowable from an X key event.)
+
+## Config (env)
+- `ACTIVITY_SPOOL_DIR`  — spool dir (default `~/.local/state/activity/spool`).
+- `KEYLOG_IDLE_SECONDS` — idle gap that closes a unit (default `2.0`).
+- `KEYLOG_MAX_CHARS`    — hard cap per unit (default `4096`).
+- `KEYLOG_POLL_SECONDS` — idle-timer poll interval (default `0.5`).
+
+## Run / debug
+```sh
+# Needs an X session (DISPLAY). Point at a TEST spool while validating:
+nix-shell -p 'python3.withPackages(ps: [ps.xlib])' --run \
+  "ACTIVITY_SPOOL_DIR=/tmp/activity-test-spool DISPLAY=:0 python3 scripts/collector/keylog/keylog.py"
+tail -f /tmp/activity-test-spool/current.log
+```
+The staged `keylog` user service (After/WantedBy `graphical-session.target`)
+runs it against the real spool once enabled via a converge step.
+
+## Tests
+```sh
+nix-shell -p python312Packages.pytest --run "pytest scripts/collector/keylog/tests"
+```
+Cover keymap/modifier→char, chunking boundaries, and v1 emit-format correctness
+(round-trips through the existing `collector.parse_line`).

--- a/scripts/collector/keylog/chunker.py
+++ b/scripts/collector/keylog/chunker.py
@@ -1,0 +1,121 @@
+"""chunker — buffer keystrokes into sensible typing units before emitting.
+
+Why chunk: emitting one spool event per keystroke is wasteful (the daemon would
+ship thousands of one-char rows) and useless for analysis. Instead we accumulate
+characters into a buffer and flush a single "typing" event when a natural
+boundary is reached:
+
+  * focus change   — typing moved to a different window/app (caller drives this)
+  * Enter (\\n)     — a line / message / command was submitted
+  * idle timeout   — N seconds without a keystroke (a pause = a unit)
+  * max length     — guard so a single never-paused stream still bounds memory
+
+BackSpace ("\\b") edits the buffer in place (pops the last char) so the captured
+text reflects what was actually left standing, not raw keystrokes. This is the
+deliberate chunking policy; full content, no redaction.
+
+The chunker is pure + clock-injectable so it unit-tests without real time.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Chunk:
+    text: str
+    app: str
+    title: str
+    session: str
+    workspace: str
+    reason: str  # why it flushed: enter|idle|focus|maxlen|close
+
+
+@dataclass
+class Chunker:
+    idle_seconds: float = 2.0
+    max_chars: int = 4096
+    _buf: list[str] = field(default_factory=list)
+    _app: str = ""
+    _title: str = ""
+    _session: str = ""
+    _workspace: str = ""
+    _last_ts: float = 0.0
+
+    def _ctx(self, reason: str) -> Chunk:
+        return Chunk(
+            text="".join(self._buf),
+            app=self._app, title=self._title,
+            session=self._session, workspace=self._workspace,
+            reason=reason,
+        )
+
+    def _reset(self) -> None:
+        self._buf = []
+
+    def feed(self, char: str, *, app: str, title: str, session: str,
+             workspace: str, now: float) -> list[Chunk]:
+        """Feed one resolved character with its window context + timestamp.
+
+        Returns a list of Chunks to emit (0, 1, or 2 — e.g. a focus change that
+        flushes the prior buffer AND an immediate Enter would flush twice).
+        """
+        out: list[Chunk] = []
+
+        # Idle flush: a gap since the last keystroke closes the current unit
+        # BEFORE recording the new context, so the pause boundary is honored.
+        if self._buf and (now - self._last_ts) >= self.idle_seconds:
+            out.append(self._ctx("idle"))
+            self._reset()
+
+        # Focus change: typing moved to a different window. Flush what we had
+        # under the OLD context, then adopt the new one.
+        focus_changed = (
+            self._buf
+            and (app != self._app or session != self._session)
+        )
+        if focus_changed:
+            out.append(self._ctx("focus"))
+            self._reset()
+
+        # Adopt the (possibly new) context for the buffer we are about to grow.
+        self._app, self._title = app, title
+        self._session, self._workspace = session, workspace
+        self._last_ts = now
+
+        # BackSpace edits the standing buffer.
+        if char == "\b":
+            if self._buf:
+                self._buf.pop()
+            return out
+
+        self._buf.append(char)
+
+        # Enter submits a unit (the newline is kept in the text).
+        if char == "\n":
+            out.append(self._ctx("enter"))
+            self._reset()
+            return out
+
+        # Length guard.
+        if len(self._buf) >= self.max_chars:
+            out.append(self._ctx("maxlen"))
+            self._reset()
+
+        return out
+
+    def flush_idle(self, now: float) -> list[Chunk]:
+        """Called by the daemon's idle timer: flush if the buffer has aged out."""
+        if self._buf and (now - self._last_ts) >= self.idle_seconds:
+            c = self._ctx("idle")
+            self._reset()
+            return [c]
+        return []
+
+    def flush_now(self, reason: str = "close") -> list[Chunk]:
+        """Force-flush whatever is buffered (e.g. on shutdown)."""
+        if self._buf:
+            c = self._ctx(reason)
+            self._reset()
+            return [c]
+        return []

--- a/scripts/collector/keylog/keylog.py
+++ b/scripts/collector/keylog/keylog.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""keylog — X11 full-content keystroke collector for the activity pipeline.
+
+Captures ALL KeyPress events globally via the X11 RECORD extension (python-xlib),
+WITHOUT needing root or the `input` group — it works at the X-protocol level as
+the logged-in user. Each key is mapped keycode → keysym → character honoring
+modifier state (Shift / CapsLock / AltGr), buffered into typing units by
+`chunker`, annotated with active-window context (WM_CLASS / _NET_WM_NAME /
+workspace), and emitted into the local spool in the v1 contract so the existing
+collector daemon ships it unchanged.
+
+FULL CONTENT, NO REDACTION — this is an explicit self-instrumentation choice by
+the machine owner. Records must NOT leave the local spool until an authenticated
+ClickHouse is in place.
+
+Architecture
+------------
+RECORD runs on a SECOND display connection (the "record" connection) which is
+blocked inside `record.enable_context`; a separate "local" connection serves
+keymap + window-context queries (you cannot issue normal requests on the record
+connection while it is recording). A wall-clock idle flush is achieved by
+enabling the context in a background thread and polling an idle timer on the
+main thread.
+
+Config (env)
+------------
+  ACTIVITY_SPOOL_DIR      spool dir (default ~/.local/state/activity/spool)
+  KEYLOG_IDLE_SECONDS     idle gap that closes a typing unit (default 2.0)
+  KEYLOG_MAX_CHARS        hard cap per unit (default 4096)
+  KEYLOG_POLL_SECONDS     idle-timer poll interval (default 0.5)
+"""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+# Sibling modules (this dir is not a package).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import keymap as KM        # noqa: E402
+import spool_emit as SE    # noqa: E402
+from chunker import Chunker  # noqa: E402
+from winctx import WindowContext, WinCtx  # noqa: E402
+
+SOURCE = "keys"
+KIND = "typing"
+
+
+def _emit_chunk(chunk, spool_dir: Path) -> str:
+    """Map a Chunker.Chunk → the v1 emit fields and append to the spool."""
+    import json
+    payload = json.dumps(
+        {"title": chunk.title, "workspace": chunk.workspace, "flush": chunk.reason},
+        ensure_ascii=False, separators=(",", ":"),
+    )
+    fields = {
+        "source": SOURCE,
+        "kind": KIND,
+        "text": chunk.text,
+        "app": chunk.app,
+        "project": "",          # cwd/project not available from an X key event
+        "session": chunk.session,
+        "payload": payload,
+    }
+    return SE.emit(fields, spool_dir=spool_dir)
+
+
+class KeyLogger:
+    def __init__(self, spool_dir: Path, idle_seconds: float, max_chars: int):
+        self.spool_dir = spool_dir
+        self.chunker = Chunker(idle_seconds=idle_seconds, max_chars=max_chars)
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._ctx = None
+
+        from Xlib import display
+        from Xlib.ext import record  # noqa: F401  (presence check)
+
+        # Two connections: one drives RECORD (blocks), one answers queries.
+        self.local_dpy = display.Display()
+        self.record_dpy = display.Display()
+        if not self.record_dpy.has_extension("RECORD"):
+            raise RuntimeError("X server lacks the RECORD extension")
+        self.winctx = WindowContext(self.local_dpy)
+
+    # -- keysym/char resolution on the LOCAL connection ------------------- #
+    def _keysyms(self, keycode: int, group: int):
+        """Return (lower, upper) keysyms for a keycode's active group.
+
+        python-xlib caches the keymap at connect time; tools like xdotool remap
+        a keycode on the fly (XChangeKeyboardMapping) to inject unicode, so a
+        cached lookup returns 0 for the freshly-remapped code. On a 0 result we
+        do a fresh, uncached `get_keyboard_mapping` for that single keycode and
+        also refresh the local cache so subsequent lookups are fast.
+        """
+        lower = self.local_dpy.keycode_to_keysym(keycode, group * 2 + 0)
+        upper = self.local_dpy.keycode_to_keysym(keycode, group * 2 + 1)
+        if lower == 0 and upper == 0:
+            try:
+                # Uncached server query for just this keycode — catches keycodes
+                # remapped after our connection cached the keymap.
+                km = self.local_dpy.get_keyboard_mapping(keycode, 1)
+                if km and len(km[0]) > group * 2 + 1:
+                    row = km[0]
+                    lower = row[group * 2 + 0]
+                    upper = row[group * 2 + 1]
+            except Exception:
+                pass
+        return lower, upper
+
+    def _char_for(self, keycode: int, state: int) -> str | None:
+        group = KM.group_index(state)
+        lower, upper = self._keysyms(keycode, group)
+        if upper == 0:
+            upper = lower
+        return KM.resolve_char(lower, upper, state)
+
+    # -- RECORD callback -------------------------------------------------- #
+    def _handle(self, reply):
+        from Xlib import X
+        from Xlib.ext import record
+        from Xlib.protocol import rq
+        if reply.category != record.FromServer:
+            return
+        if reply.client_swapped or not reply.data or reply.data[0] < 2:
+            return
+        data = reply.data
+        while len(data):
+            event, data = rq.EventField(None).parse_binary_value(
+                data, self.record_dpy.display, None, None
+            )
+            if event.type != X.KeyPress:
+                continue
+            char = self._char_for(event.detail, event.state)
+            if char is None:
+                continue
+            ctx = self._safe_ctx()
+            now = time.time()
+            with self._lock:
+                chunks = self.chunker.feed(
+                    char, app=ctx.app, title=ctx.title,
+                    session=ctx.window_id, workspace=ctx.workspace, now=now,
+                )
+            for ch in chunks:
+                _emit_chunk(ch, self.spool_dir)
+
+    def _safe_ctx(self) -> WinCtx:
+        try:
+            return self.winctx.current()
+        except Exception:
+            return WinCtx()
+
+    # -- idle flusher (wall clock) --------------------------------------- #
+    def _idle_loop(self, poll: float):
+        while not self._stop.wait(poll):
+            now = time.time()
+            with self._lock:
+                chunks = self.chunker.flush_idle(now)
+            for ch in chunks:
+                _emit_chunk(ch, self.spool_dir)
+
+    def run(self, poll_seconds: float = 0.5):
+        from Xlib import X
+        from Xlib.ext import record
+
+        ctx = self.record_dpy.record_create_context(
+            0,
+            [record.AllClients],
+            [{
+                "core_requests": (0, 0),
+                "core_replies": (0, 0),
+                "ext_requests": (0, 0, 0, 0),
+                "ext_replies": (0, 0, 0, 0),
+                "delivered_events": (0, 0),
+                "device_events": (X.KeyPress, X.KeyRelease),
+                "errors": (0, 0),
+                "client_started": False,
+                "client_died": False,
+            }],
+        )
+        self._ctx = ctx
+        idle = threading.Thread(target=self._idle_loop, args=(poll_seconds,), daemon=True)
+        idle.start()
+        try:
+            # Blocks here, dispatching to _handle, until disable_context.
+            self.record_dpy.record_enable_context(ctx, self._handle)
+        finally:
+            self._stop.set()
+            try:
+                self.record_dpy.record_free_context(ctx)
+            except Exception:
+                pass
+            # Flush whatever was buffered at shutdown.
+            with self._lock:
+                for ch in self.chunker.flush_now():
+                    _emit_chunk(ch, self.spool_dir)
+
+    def stop(self):
+        # record_enable_context blocks on the record connection; disabling must
+        # be issued from a DIFFERENT connection. The local connection serves.
+        self._stop.set()
+        try:
+            if self._ctx is not None:
+                self.local_dpy.record_disable_context(self._ctx)
+                self.local_dpy.flush()
+        except Exception:
+            pass
+
+
+def main(argv=None) -> int:
+    spool_dir = SE.default_spool_dir()
+    idle_seconds = float(os.environ.get("KEYLOG_IDLE_SECONDS", "2.0"))
+    max_chars = int(os.environ.get("KEYLOG_MAX_CHARS", "4096"))
+    poll = float(os.environ.get("KEYLOG_POLL_SECONDS", "0.5"))
+
+    logger = KeyLogger(spool_dir, idle_seconds, max_chars)
+    print(
+        f"keylog: spool={spool_dir} idle={idle_seconds}s max_chars={max_chars}",
+        file=sys.stderr, flush=True,
+    )
+    try:
+        logger.run(poll_seconds=poll)
+    except KeyboardInterrupt:
+        logger.stop()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/collector/keylog/keymap.py
+++ b/scripts/collector/keylog/keymap.py
@@ -1,0 +1,100 @@
+"""keymap — pure keycode/keysym → character mapping honoring modifier state.
+
+Separated from the X plumbing so it is unit-testable WITHOUT an X server: the
+mapping logic takes a keysym + modifier flags and returns the character (or a
+named token for non-printing keys). The live keylogger feeds it keysyms it gets
+from `display.keycode_to_keysym(keycode, group_index)`; tests feed it keysyms
+directly.
+
+Keysym → character rules (X11):
+  * Latin-1 keysyms 0x20..0xff map straight to that code point.
+  * Unicode keysyms have the 0x01000000 bit set: char = keysym & 0x00ffffff.
+  * A small table covers the editing/whitespace keys we care about (Return,
+    Tab, space, BackSpace, …) as named tokens.
+"""
+from __future__ import annotations
+
+# keysym constants we special-case (values from X11/keysymdef.h).
+XK_BackSpace = 0xFF08
+XK_Tab = 0xFF09
+XK_Return = 0xFF0D
+XK_Escape = 0xFF1B
+XK_Delete = 0xFFFF
+XK_space = 0x0020
+
+# Named non-printing keys → a stable token. Return/Tab/space resolve to their
+# literal character (they belong in captured text); the rest are control keys
+# the chunker may act on but that do not contribute glyphs.
+_NAMED = {
+    XK_Return: "\n",
+    XK_Tab: "\t",
+    XK_space: " ",
+    XK_BackSpace: "\b",
+}
+
+UNICODE_KEYSYM_FLAG = 0x01000000
+
+
+def keysym_to_char(keysym: int) -> str | None:
+    """Return the character a keysym produces, or None if it is non-printing.
+
+    Return/Tab/space resolve to their literal characters; BackSpace resolves to
+    "\\b" so the chunker can apply it as an edit. Other control/navigation keys
+    (arrows, F-keys, modifiers) return None.
+    """
+    if keysym == 0:
+        return None
+    if keysym in _NAMED:
+        return _NAMED[keysym]
+    # Latin-1 printable range.
+    if 0x20 <= keysym <= 0x7E or 0xA0 <= keysym <= 0xFF:
+        return chr(keysym)
+    # Unicode keysyms: high bit set, low 24 bits are the code point.
+    if keysym & UNICODE_KEYSYM_FLAG:
+        cp = keysym & 0x00FFFFFF
+        if cp >= 0x20:
+            try:
+                return chr(cp)
+            except (ValueError, OverflowError):
+                return None
+    return None
+
+
+def group_index(state: int, mod_altgr: int = 0x80) -> int:
+    """Pick the keyboard group (0 = base, 1 = AltGr/level-3) from modifier state.
+
+    AltGr on most layouts is reported as Mod5 (mask 0x80). When it is held we use
+    keysym group 1 so AltGr combinations resolve correctly.
+    """
+    return 1 if (state & mod_altgr) else 0
+
+
+def shift_active(state: int, keysym_lower: int, keysym_upper: int,
+                 shift_mask: int = 0x01, lock_mask: int = 0x02) -> bool:
+    """Decide whether the SHIFTED keysym applies, honoring Shift + CapsLock.
+
+    CapsLock only affects keys that are alphabetic (lower != upper as letters);
+    for those, Lock XORs with Shift. For non-letters Lock is ignored (standard
+    X behaviour), so only Shift matters.
+    """
+    shift = bool(state & shift_mask)
+    lock = bool(state & lock_mask)
+    is_letter = (
+        keysym_lower != keysym_upper
+        and (chr(keysym_lower).isalpha() if 0x20 <= keysym_lower <= 0x10FFFF else False)
+    )
+    if is_letter:
+        return shift ^ lock
+    return shift
+
+
+def resolve_char(keysym_lower: int, keysym_upper: int, state: int,
+                 shift_mask: int = 0x01, lock_mask: int = 0x02) -> str | None:
+    """Resolve the final character for a key given its lower/upper keysyms (the
+    two level-0/level-1 keysyms for the active group) and the modifier `state`.
+
+    Returns the produced character, or None for non-printing keys.
+    """
+    use_upper = shift_active(state, keysym_lower, keysym_upper, shift_mask, lock_mask)
+    keysym = keysym_upper if use_upper else keysym_lower
+    return keysym_to_char(keysym)

--- a/scripts/collector/keylog/spool_emit.py
+++ b/scripts/collector/keylog/spool_emit.py
@@ -1,0 +1,85 @@
+"""spool_emit — build + append a v1 spool line, byte-compatible with `emit`.
+
+Both GUI collectors (keylogger, browser receiver) write directly to the spool
+in Python rather than shelling out to the `emit` bash helper per event (these
+are not the latency-critical shell hot path, and a per-event fork is wasteful).
+This module reproduces the EXACT v1 line contract so the existing collector
+daemon (`collector.parse_line`) ships the records unchanged:
+
+    v1<TAB>ts=<...><TAB>source=<s><TAB>kind=<k><TAB>b64:text=<b64>...
+
+  * Free-text fields go through `b64:<key>=` base64 (no-wrap) so arbitrary bytes
+    (quotes, newlines, tabs, unicode, "passwords") survive intact.
+  * Plain scalar keys (ts, source, kind, host, integers) are written verbatim.
+  * `ts` (ClickHouse DateTime64(3) local format) and `host` are auto-filled if
+    the caller omits them — mirroring the bash `emit`.
+  * Append is a single newline-terminated `write`, opened O_APPEND, so
+    concurrent writers do not interleave for sub-PIPE_BUF lines.
+"""
+from __future__ import annotations
+
+import base64
+import datetime
+import os
+import socket
+from pathlib import Path
+
+CURRENT_NAME = "current.log"
+# Keys written as plain scalars; everything else free-text is base64-encoded.
+_PLAIN_KEYS = {"ts", "host", "source", "kind", "duration_ms", "exit_code"}
+
+
+def default_spool_dir() -> Path:
+    """Resolve the spool dir the same way emit/collector do."""
+    env = os.environ.get("ACTIVITY_SPOOL_DIR")
+    if env:
+        return Path(env)
+    state = os.environ.get("XDG_STATE_HOME") or (Path.home() / ".local/state")
+    return Path(state) / "activity" / "spool"
+
+
+def _ts_now() -> str:
+    # %3N has no portable strftime equivalent; build milliseconds explicitly.
+    now = datetime.datetime.now()
+    return now.strftime("%Y-%m-%d %H:%M:%S.") + f"{now.microsecond // 1000:03d}"
+
+
+def build_line(fields: dict[str, object]) -> str:
+    """Build a v1 spool line from a field dict.
+
+    Plain-scalar keys (_PLAIN_KEYS) are emitted verbatim; every other key is
+    treated as free text and base64-encoded under a `b64:` prefix. `ts`/`host`
+    are auto-filled when absent.
+    """
+    parts = ["v1"]
+    have_ts = "ts" in fields
+    have_host = "host" in fields
+    for key, val in fields.items():
+        if key in _PLAIN_KEYS:
+            parts.append(f"{key}={val}")
+        else:
+            enc = base64.b64encode(str(val).encode("utf-8")).decode("ascii")
+            parts.append(f"b64:{key}={enc}")
+    if not have_ts:
+        parts.append(f"ts={_ts_now()}")
+    if not have_host:
+        parts.append(f"host={os.environ.get('HOST') or socket.gethostname()}")
+    return "\t".join(parts)
+
+
+def emit(fields: dict[str, object], spool_dir: Path | None = None) -> str:
+    """Append one event to <spool_dir>/current.log. Returns the written line.
+
+    Best-effort + bounded: telemetry must never crash its caller, so spool I/O
+    errors are swallowed (the line is still returned for tests).
+    """
+    line = build_line(fields)
+    d = spool_dir or default_spool_dir()
+    try:
+        d.mkdir(parents=True, exist_ok=True)
+        # O_APPEND single write == atomic for sub-PIPE_BUF lines.
+        with open(d / CURRENT_NAME, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+    except OSError:
+        pass
+    return line

--- a/scripts/collector/keylog/tests/test_chunker.py
+++ b/scripts/collector/keylog/tests/test_chunker.py
@@ -1,0 +1,91 @@
+"""Unit tests for the keystroke chunker: focus / enter / idle / backspace / maxlen."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from chunker import Chunker  # noqa: E402
+
+
+def feed(ch, c, t, app="xterm", title="T", session="w1", ws="1"):
+    return ch.feed(c, app=app, title=title, session=session, workspace=ws, now=t)
+
+
+def test_enter_flushes_unit_including_newline():
+    ch = Chunker(idle_seconds=10)
+    assert feed(ch, "h", 1) == []
+    assert feed(ch, "i", 1) == []
+    out = feed(ch, "\n", 1)
+    assert len(out) == 1
+    assert out[0].text == "hi\n"
+    assert out[0].reason == "enter"
+
+
+def test_idle_timeout_flushes():
+    ch = Chunker(idle_seconds=2)
+    feed(ch, "a", 0)
+    feed(ch, "b", 1)               # within idle window, no flush
+    out = ch.flush_idle(now=5)     # 4s since last key > 2s
+    assert len(out) == 1
+    assert out[0].text == "ab"
+    assert out[0].reason == "idle"
+    # Buffer cleared.
+    assert ch.flush_idle(now=10) == []
+
+
+def test_idle_flush_on_next_feed():
+    ch = Chunker(idle_seconds=2)
+    feed(ch, "a", 0)
+    out = feed(ch, "b", 10)        # 10s gap → flushes "a" before recording "b"
+    assert [c.text for c in out] == ["a"]
+    assert out[0].reason == "idle"
+    fin = ch.flush_now()
+    assert fin[0].text == "b"
+
+
+def test_focus_change_flushes_under_old_context():
+    ch = Chunker(idle_seconds=100)
+    feed(ch, "x", 1, app="xterm", session="w1")
+    feed(ch, "y", 1, app="xterm", session="w1")
+    out = feed(ch, "z", 1, app="firefox", session="w2")
+    assert len(out) == 1
+    assert out[0].text == "xy"
+    assert out[0].app == "xterm"      # flushed under the OLD context
+    assert out[0].reason == "focus"
+    # The new char is buffered under the new context.
+    fin = ch.flush_now()
+    assert fin[0].text == "z"
+    assert fin[0].app == "firefox"
+
+
+def test_backspace_edits_buffer():
+    ch = Chunker(idle_seconds=100)
+    feed(ch, "h", 1)
+    feed(ch, "x", 1)
+    feed(ch, "\b", 1)   # delete the "x"
+    feed(ch, "i", 1)
+    out = ch.flush_now()
+    assert out[0].text == "hi"
+
+
+def test_backspace_on_empty_is_noop():
+    ch = Chunker(idle_seconds=100)
+    assert feed(ch, "\b", 1) == []
+    assert ch.flush_now() == []
+
+
+def test_maxlen_flushes():
+    ch = Chunker(idle_seconds=100, max_chars=3)
+    feed(ch, "a", 1)
+    feed(ch, "b", 1)
+    out = feed(ch, "c", 1)
+    assert len(out) == 1
+    assert out[0].text == "abc"
+    assert out[0].reason == "maxlen"
+
+
+def test_unicode_and_specials_preserved():
+    ch = Chunker(idle_seconds=100)
+    for c in "你好!@#":
+        feed(ch, c, 1)
+    out = ch.flush_now()
+    assert out[0].text == "你好!@#"

--- a/scripts/collector/keylog/tests/test_emit_roundtrip.py
+++ b/scripts/collector/keylog/tests/test_emit_roundtrip.py
@@ -1,0 +1,70 @@
+"""Round-trip: spool_emit builds a v1 line that collector.parse_line accepts,
+with arbitrary content (quotes / newlines / unicode / a fake password) surviving
+intact — proving the keylogger output ships unchanged through the existing daemon.
+"""
+import json
+import sys
+from pathlib import Path
+
+KEYLOG = Path(__file__).resolve().parent.parent
+COLLECTOR = KEYLOG.parent  # scripts/collector
+sys.path.insert(0, str(KEYLOG))
+sys.path.insert(0, str(COLLECTOR))
+
+import spool_emit as SE  # noqa: E402
+import collector as C    # noqa: E402
+
+
+def test_build_line_roundtrips_through_parse_line():
+    line = SE.build_line({
+        "source": "keys", "kind": "typing",
+        "text": "hello", "app": "xterm", "session": "w1",
+        "payload": json.dumps({"title": "t", "workspace": "2"}),
+    })
+    ev = C.parse_line(line)
+    assert ev is not None
+    assert ev["source"] == "keys"
+    assert ev["kind"] == "typing"
+    assert ev["text"] == "hello"
+    assert ev["app"] == "xterm"
+    assert json.loads(ev["payload"])["workspace"] == "2"
+
+
+def test_arbitrary_content_survives():
+    nasty = 'rm -rf "$X"\twith\ttabs\nand a newline \\back\\slash 你好 password123!'
+    line = SE.build_line({"source": "keys", "kind": "typing", "text": nasty})
+    ev = C.parse_line(line)
+    assert ev["text"] == nasty
+
+
+def test_ts_and_host_autofilled():
+    line = SE.build_line({"source": "keys", "kind": "typing", "text": "x"})
+    ev = C.parse_line(line)
+    assert "ts" in ev
+    assert "host" in line  # host present as a plain token
+
+
+def test_emit_appends_to_spool(tmp_path):
+    spool = tmp_path / "spool"
+    written = SE.emit(
+        {"source": "keys", "kind": "typing", "text": "你好 probe!"},
+        spool_dir=spool,
+    )
+    cur = spool / "current.log"
+    assert cur.exists()
+    lines = [l for l in cur.read_text(encoding="utf-8").splitlines() if l]
+    assert lines == [written]
+    ev = C.parse_line(lines[0])
+    assert ev["text"] == "你好 probe!"
+
+
+def test_plain_keys_not_base64(tmp_path):
+    line = SE.build_line({
+        "source": "keys", "kind": "typing",
+        "duration_ms": 5, "text": "z",
+    })
+    # source/kind/duration_ms are plain; text is base64.
+    assert "source=keys" in line
+    assert "kind=typing" in line
+    assert "duration_ms=5" in line
+    assert "b64:text=" in line

--- a/scripts/collector/keylog/tests/test_keymap.py
+++ b/scripts/collector/keylog/tests/test_keymap.py
@@ -1,0 +1,64 @@
+"""Unit tests for keymap: keysym → char honoring Shift / CapsLock / AltGr."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import keymap as KM  # noqa: E402
+
+# keysym constants for the layouts under test.
+A_LOWER, A_UPPER = 0x0061, 0x0041          # a / A
+ONE, EXCL = 0x0031, 0x0021                 # 1 / !
+RETURN, TAB, SPACE, BS = 0xFF0D, 0xFF09, 0x0020, 0xFF08
+LEFT = 0xFF51                              # arrow (non-printing)
+E_ACUTE = 0x00E9                           # é (latin-1)
+
+
+def test_latin1_printable():
+    assert KM.keysym_to_char(A_LOWER) == "a"
+    assert KM.keysym_to_char(EXCL) == "!"
+    assert KM.keysym_to_char(E_ACUTE) == "é"
+
+
+def test_named_keys_resolve_to_literals():
+    assert KM.keysym_to_char(RETURN) == "\n"
+    assert KM.keysym_to_char(TAB) == "\t"
+    assert KM.keysym_to_char(SPACE) == " "
+    assert KM.keysym_to_char(BS) == "\b"
+
+
+def test_nonprinting_returns_none():
+    assert KM.keysym_to_char(LEFT) is None
+    assert KM.keysym_to_char(0) is None
+
+
+def test_unicode_keysym():
+    # Unicode keysym = 0x01000000 | codepoint. 你 = U+4F60.
+    ni = 0x01000000 | 0x4F60
+    assert KM.keysym_to_char(ni) == "你"
+    euro = 0x01000000 | 0x20AC
+    assert KM.keysym_to_char(euro) == "€"
+
+
+def test_shift_uppercases_letter():
+    # Shift held (state bit 0) → upper keysym.
+    assert KM.resolve_char(A_LOWER, A_UPPER, state=0x01) == "A"
+    assert KM.resolve_char(A_LOWER, A_UPPER, state=0x00) == "a"
+
+
+def test_capslock_uppercases_letter_only():
+    # CapsLock (bit 1) on a letter → upper.
+    assert KM.resolve_char(A_LOWER, A_UPPER, state=0x02) == "A"
+    # CapsLock + Shift → cancels back to lower.
+    assert KM.resolve_char(A_LOWER, A_UPPER, state=0x03) == "a"
+
+
+def test_capslock_does_not_affect_digits():
+    # CapsLock must NOT shift "1" to "!"; only Shift does.
+    assert KM.resolve_char(ONE, EXCL, state=0x02) == "1"
+    assert KM.resolve_char(ONE, EXCL, state=0x00) == "1"
+    assert KM.resolve_char(ONE, EXCL, state=0x01) == "!"
+
+
+def test_group_index_altgr():
+    assert KM.group_index(state=0x00) == 0
+    assert KM.group_index(state=0x80) == 1  # Mod5 / AltGr

--- a/scripts/collector/keylog/winctx.py
+++ b/scripts/collector/keylog/winctx.py
@@ -1,0 +1,115 @@
+"""winctx — active-window context (app / title / workspace) via Xlib.
+
+Reads the EWMH `_NET_ACTIVE_WINDOW` from the root, then that window's WM_CLASS
+(app) and `_NET_WM_NAME` (UTF-8 title), falling back to WM_NAME. i3 workspace is
+read best-effort from `_NET_DESKTOP_NAMES` + `_NET_CURRENT_DESKTOP` (cheap; no i3
+IPC dependency). All lookups are wrapped — a transient window race must never
+crash the keylogger; we just return empty context.
+
+Kept thin and dependency-light so the keylogger can import it; it needs a live
+Xlib display so it is exercised in the on-host synthetic verification, not the
+pure unit tests.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class WinCtx:
+    app: str = ""        # WM_CLASS instance/class
+    title: str = ""      # _NET_WM_NAME / WM_NAME
+    window_id: str = ""   # active window id as a stable session key
+    workspace: str = ""  # i3/EWMH desktop name
+
+
+class WindowContext:
+    def __init__(self, display):
+        from Xlib import X  # noqa: F401  (import guarded behind a live display)
+
+        self._d = display
+        self._root = display.screen().root
+        self._atom = display.intern_atom
+        self._NET_ACTIVE_WINDOW = self._atom("_NET_ACTIVE_WINDOW")
+        self._NET_WM_NAME = self._atom("_NET_WM_NAME")
+        self._UTF8_STRING = self._atom("UTF8_STRING")
+        self._NET_CURRENT_DESKTOP = self._atom("_NET_CURRENT_DESKTOP")
+        self._NET_DESKTOP_NAMES = self._atom("_NET_DESKTOP_NAMES")
+
+    def _prop(self, win, atom, prop_type):
+        try:
+            r = win.get_full_property(atom, prop_type)
+            return r.value if r else None
+        except Exception:
+            return None
+
+    def _active_window(self):
+        from Xlib import X
+        val = self._prop(self._root, self._NET_ACTIVE_WINDOW, X.AnyPropertyType)
+        if val:
+            try:
+                wid = int(val[0])
+                if wid:
+                    return self._d.create_resource_object("window", wid), wid
+            except Exception:
+                pass
+        # Fallback: input focus.
+        try:
+            f = self._d.get_input_focus().focus
+            return f, getattr(f, "id", 0)
+        except Exception:
+            return None, 0
+
+    def _title(self, win) -> str:
+        v = self._prop(win, self._NET_WM_NAME, self._UTF8_STRING)
+        if v:
+            return _to_text(v)
+        from Xlib import X
+        v = self._prop(win, self._atom("WM_NAME"), X.AnyPropertyType)
+        return _to_text(v) if v else ""
+
+    def _wm_class(self, win) -> str:
+        try:
+            cls = win.get_wm_class()
+            if cls:
+                # (instance, class) — prefer the class name.
+                return cls[1] or cls[0] or ""
+        except Exception:
+            pass
+        return ""
+
+    def _workspace(self) -> str:
+        from Xlib import X
+        cur = self._prop(self._root, self._NET_CURRENT_DESKTOP, X.AnyPropertyType)
+        names = self._prop(self._root, self._NET_DESKTOP_NAMES, self._UTF8_STRING)
+        if cur is None:
+            return ""
+        idx = int(cur[0])
+        if names:
+            parts = _to_text(names).split("\x00")
+            parts = [p for p in parts if p != ""]
+            if 0 <= idx < len(parts):
+                return parts[idx]
+        return str(idx)
+
+    def current(self) -> WinCtx:
+        win, wid = self._active_window()
+        if win is None:
+            return WinCtx()
+        return WinCtx(
+            app=self._wm_class(win),
+            title=self._title(win),
+            window_id=str(wid),
+            workspace=self._workspace(),
+        )
+
+
+def _to_text(v) -> str:
+    if isinstance(v, bytes):
+        return v.decode("utf-8", "replace").rstrip("\x00")
+    if isinstance(v, str):
+        return v.rstrip("\x00")
+    try:
+        return bytes(v).decode("utf-8", "replace").rstrip("\x00")
+    except Exception:
+        return str(v)


### PR DESCRIPTION
Two GUI activity collectors feeding the existing activity-collector spool in the **v1 emit format**, so the daemon (collector.py) ships them unchanged. **Local-spool only — nothing ships to ClickHouse** (gated on the authed store, PR #67).

Stacked on `feat/activity-collector-slice` (depends on its emit/collector foundation).

## Deliverable 1 — X11 full-content keylogger (`scripts/collector/keylog/`)
- Global capture via the **X11 RECORD extension** (python-xlib) as the logged-in user — no root, no `input` group.
- `keycode -> keysym -> char` honoring Shift / CapsLock / AltGr; Latin-1 + Unicode keysyms. A fresh keymap re-query catches keycodes remapped on the fly (how xdotool/IMEs inject unicode) that a cached lookup misses.
- Chunker buffers keystrokes into typing units — flush on **focus-change / Enter / idle (2s) / maxlen (4096)**; BackSpace edits the standing buffer. (Rationale: one row per keystroke is useless + wasteful.)
- Active-window context attached: WM_CLASS (app), `_NET_WM_NAME` (title), active window id (session), EWMH/i3 workspace.
- Emits `source=keys kind=typing text=<chunk> app=<wm_class> project="" session=<win id> payload={title,workspace,flush}`.

**Verified on the live X session with SYNTHETIC xdotool input only** (no real keystrokes): the exact probe `keylog-probe-AbC123 !@# 你好` + Enter round-tripped through the spool in correct v1 format. Test capture shredded after.

## Deliverable 2 — Chrome MV3 browser collector (`scripts/collector/browser-ext/`)
- MV3 extension: `chrome.tabs` / `webNavigation` / `windows` / `idle` + `storage.session` (active-duration survives SW suspension). Full URL capture. POSTs nav/focus events to a loopback receiver.
- `receiver.py`: stdlib `http.server` on `127.0.0.1:8787`, maps events to v1 spool records (shares `keylog/spool_emit`). Kept as a separate service so the privileged shipper has no inbound socket.

**Verified end-to-end in chromium on the live session**: loaded unpacked, navigated example.com -> example.org; `nav` + `focus` records landed in the spool, with `active_ms` correctly computed across navigations (11404ms). (Initial run surfaced a missing `storage` permission — fixed.)

## Tests (29, all green)
keymap/modifier->char, chunking boundaries, emit-format round-trip through the real `collector.parse_line`, receiver POST->spool incl. arbitrary content (quotes/newlines/unicode/a fake `password123!`).

## Nix wiring (staged, NOT switched)
`home.file` symlinks for both module dirs + two `systemd.user.services`: `keylog` (gated on `graphical-session.target`; needs X) and `browser-activity-receiver` (loopback). Validated via `nix eval` of the activation config; **not** enabled — enablement is a deliberate converge step.

## Safety
Nothing shipped to ClickHouse. All test captures/spools used `/tmp` dirs and were shredded; no keylogger left running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)