### PR TITLE
fix(collector): browser receiver import breaks under home-manager symlinks

### DIFF
--- a/scripts/collector/browser-ext/receiver.py
+++ b/scripts/collector/browser-ext/receiver.py
@@ -36,8 +36,10 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 # spool_emit lives in the sibling keylog/ dir (single source of truth for the
-# v1 line format). Add it to the path.
-_HERE = Path(__file__).resolve().parent
+# v1 line format). Use the INVOKED path — do NOT .resolve(): home-manager
+# symlinks each deployed file to a flat /nix/store object, so resolving discards
+# the browser-ext/ ↔ keylog/ sibling layout and breaks this import at runtime.
+_HERE = Path(__file__).parent
 sys.path.insert(0, str(_HERE.parent / "keylog"))
 import spool_emit as SE  # noqa: E402
 


### PR DESCRIPTION
browser-activity-receiver crash-looped on the laptop after cutover: `ModuleNotFoundError: No module named 'spool_emit'`. `receiver.py` used `Path(__file__).resolve()` to find the sibling `keylog/` dir, but home-manager symlinks each deployed file to a flat /nix/store object, so resolving broke the `../keylog` lookup. Use the unresolved invocation path. Verified post-merge by re-switching the laptop (receiver active + listening on 127.0.0.1:8787).

🤖 Generated with [Claude Code](https://claude.com/claude-code)