### PR TITLE
feat(collector): ACTIVITY_HOST override to disambiguate hosts

### DIFF
--- a/scripts/collector/.env.example
+++ b/scripts/collector/.env.example
@@ -24,5 +24,10 @@ ACTIVITY_MAX_BUFFER_BYTES=67108864
 ACTIVITY_MAX_BUFFER_AGE_SECONDS=604800
 ACTIVITY_HTTP_TIMEOUT=10
 
+# Per-host label stamped on every shipped event. REQUIRED to disambiguate hosts:
+# both machines are hostname `nixos`, so without this all events collide on
+# host=nixos. Set distinctly per host, e.g. workbench / laptop.
+ACTIVITY_HOST=workbench
+
 # Spool dir (default ~/.local/state/activity/spool). Usually leave unset.
 # ACTIVITY_SPOOL_DIR=

--- a/scripts/collector/collector.py
+++ b/scripts/collector/collector.py
@@ -92,6 +92,9 @@ class Config:
     max_buffer_bytes: int = 64 * 1024 * 1024
     max_buffer_age_seconds: float = 7 * 24 * 3600
     http_timeout: float = 10.0
+    # Per-host label. Both machines are hostname `nixos`, so emit's host=$(hostname)
+    # collides — set ACTIVITY_HOST=workbench/laptop per host to disambiguate.
+    host_override: str = ""
 
     @classmethod
     def from_env(cls, env: dict | None = None) -> "Config":
@@ -111,6 +114,7 @@ class Config:
                 e.get("ACTIVITY_MAX_BUFFER_AGE_SECONDS", cls.max_buffer_age_seconds)
             ),
             http_timeout=float(e.get("ACTIVITY_HTTP_TIMEOUT", cls.http_timeout)),
+            host_override=e.get("ACTIVITY_HOST", cls.host_override),
         )
 
     @property
@@ -123,11 +127,13 @@ class Config:
 # --------------------------------------------------------------------------- #
 # Line parsing (the emit contract)
 # --------------------------------------------------------------------------- #
-def parse_line(line: str) -> dict | None:
+def parse_line(line: str, host_override: str = "") -> dict | None:
     """Parse one v1 spool line into an event dict, or None if unparseable.
 
     Returns a dict with ClickHouse-ready values: known string/int columns plus a
-    `payload` JSON string holding any unknown keys. `ts`/`host` pass through.
+    `payload` JSON string holding any unknown keys. `ts` passes through; `host`
+    is forced to `host_override` when set (both machines are hostname `nixos`, so
+    emit's value collides — the daemon stamps the real per-host label).
     """
     line = line.rstrip("\n")
     if not line:
@@ -180,6 +186,9 @@ def parse_line(line: str) -> dict | None:
                 merged = {"_payload": existing}
         merged.update(extra)
         event["payload"] = json.dumps(merged, ensure_ascii=False, separators=(",", ":"))
+
+    if host_override:
+        event["host"] = host_override
 
     return event
 
@@ -275,7 +284,7 @@ class Spool:
         return dropped
 
 
-def read_segment(path: Path) -> tuple[list[dict], int, int]:
+def read_segment(path: Path, host_override: str = "") -> tuple[list[dict], int, int]:
     """Parse a segment file → (events, parsed_ok, parse_failed).
 
     Unparseable lines are counted and logged but do not block the rest; they are
@@ -292,7 +301,7 @@ def read_segment(path: Path) -> tuple[list[dict], int, int]:
     for line in text.splitlines():
         if not line:
             continue
-        ev = parse_line(line)
+        ev = parse_line(line, host_override)
         if ev is None:
             bad += 1
             LOG.warning("dropping malformed spool line in %s: %.120r", path.name, line)
@@ -338,7 +347,7 @@ def ship_segment(
     should be retried later (network/HTTP error). No-double-ship: the file is
     deleted only after every batch in it has been accepted.
     """
-    events, ok, bad = read_segment(seg)
+    events, ok, bad = read_segment(seg, client.cfg.host_override)
     if not events:
         # Nothing shippable (empty or all-malformed) — drop the file so it does
         # not wedge the queue. Malformed counts already logged.

--- a/scripts/collector/tests/test_collector.py
+++ b/scripts/collector/tests/test_collector.py
@@ -91,6 +91,14 @@ def test_parse_arbitrary_content_survives():
     assert ev["text"] == nasty
 
 
+def test_host_override_replaces_emit_host():
+    # emit stamps host=nixos on both machines; the daemon's ACTIVITY_HOST wins.
+    line = f"v1\tts=t\tsource=zsh\tkind=command\thost=nixos\tb64:text={b64('echo hi')}"
+    assert C.parse_line(line)["host"] == "nixos"            # passthrough when unset
+    assert C.parse_line(line, "laptop")["host"] == "laptop"  # override wins
+    assert C.parse_line(line, "workbench")["host"] == "workbench"
+
+
 def test_parse_unknown_keys_go_to_payload():
     ev = C.parse_line(f"v1\tts=t\tsource=zsh\tkind=command\twindow=@3\tpane=%7")
     pl = json.loads(ev["payload"])


### PR DESCRIPTION
Both machines are hostname `nixos` → all activity.events rows collide on `host=nixos`, making per-host analysis impossible. The collector now stamps `host` from `ACTIVITY_HOST` (per-host EnvironmentFile) when set, overriding emit's value at the single shipping point (`read_segment`→`parse_line`). Set `ACTIVITY_HOST=workbench`/`laptop` per host. 31 tests pass (added override test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)