### PR TITLE
fix(collector): stamp event ts in UTC, not local wall-clock

### DIFF
--- a/scripts/collector/claude/tailer.py
+++ b/scripts/collector/claude/tailer.py
@@ -117,8 +117,9 @@ def classify(raw: str) -> tuple[str, str] | None:
 # Timestamp conversion: ISO8601 (…Z) -> ClickHouse DateTime64(3) local string
 # --------------------------------------------------------------------------- #
 def to_ch_ts(iso: str | None) -> str | None:
-    """Convert a transcript ISO timestamp to emit's '%Y-%m-%d %H:%M:%S.%3N' local
-    format. Returns None if it cannot be parsed (caller then lets emit auto-fill)."""
+    """Convert a transcript ISO timestamp to emit's '%Y-%m-%d %H:%M:%S.%3N' UTC
+    format (matches emit's `date -u`). Returns None if it cannot be parsed
+    (caller then lets emit auto-fill)."""
     if not iso:
         return None
     s = iso.strip()
@@ -129,7 +130,7 @@ def to_ch_ts(iso: str | None) -> str | None:
     except ValueError:
         return None
     if dt.tzinfo is not None:
-        dt = dt.astimezone()  # to local time
+        dt = dt.astimezone(_dt.timezone.utc)  # normalize to the UTC instant
     return dt.strftime("%Y-%m-%d %H:%M:%S.") + f"{dt.microsecond // 1000:03d}"
 
 

--- a/scripts/collector/claude/tests/test_tailer.py
+++ b/scripts/collector/claude/tests/test_tailer.py
@@ -147,11 +147,12 @@ def test_event_mapping_fields(tmp_path):
 
 
 def test_ts_conversion_to_ch_format():
-    out = T.to_ch_ts("2026-06-24T01:25:00.759Z")
-    # local-time string in CH DateTime64(3) format: 'YYYY-MM-DD HH:MM:SS.mmm'
-    assert len(out) == len("2026-06-24 01:25:00.759")
-    assert out[4] == "-" and out[10] == " " and out[19] == "."
-    assert out.endswith(".759")
+    # Stored as the UTC instant (tz-less DateTime64), NOT shifted to local.
+    # Input is UTC (…Z) → unchanged wall-clock.
+    assert T.to_ch_ts("2026-06-24T01:25:00.759Z") == "2026-06-24 01:25:00.759"
+    # An offset input normalizes to the SAME UTC instant (proves no local shift).
+    assert T.to_ch_ts("2026-06-24T06:25:00.759+05:00") == "2026-06-24 01:25:00.759"
+    assert T.to_ch_ts("2026-06-23T20:25:00.759-05:00") == "2026-06-24 01:25:00.759"
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/collector/emit
+++ b/scripts/collector/emit
@@ -39,8 +39,10 @@ CUR="$SPOOL_DIR/current.log"
 # Bounded best-effort: never let telemetry break an interactive shell.
 mkdir -p "$SPOOL_DIR" 2>/dev/null || exit 0
 
-# Millisecond timestamp in ClickHouse DateTime64(3) local format.
-_ts() { date +"%Y-%m-%d %H:%M:%S.%3N"; }
+# Millisecond timestamp for the tz-less ClickHouse DateTime64(3), as the UTC
+# instant — so now()/Grafana $__timeFilter range comparisons (UTC) align.
+# (Hour-of-day is bucketed back to local tz in the dashboard queries.)
+_ts() { date -u +"%Y-%m-%d %H:%M:%S.%3N"; }
 
 line="v1"
 have_ts=0

--- a/scripts/collector/keylog/spool_emit.py
+++ b/scripts/collector/keylog/spool_emit.py
@@ -39,8 +39,9 @@ def default_spool_dir() -> Path:
 
 
 def _ts_now() -> str:
-    # %3N has no portable strftime equivalent; build milliseconds explicitly.
-    now = datetime.datetime.now()
+    # UTC instant for the tz-less DateTime64 (matches emit's `date -u`); %3N has
+    # no portable strftime equivalent so build milliseconds explicitly.
+    now = datetime.datetime.now(datetime.timezone.utc)
     return now.strftime("%Y-%m-%d %H:%M:%S.") + f"{now.microsecond // 1000:03d}"
 
 

--- a/scripts/collector/keylog/tests/test_emit_roundtrip.py
+++ b/scripts/collector/keylog/tests/test_emit_roundtrip.py
@@ -44,6 +44,18 @@ def test_ts_and_host_autofilled():
     assert "host" in line  # host present as a plain token
 
 
+def test_ts_now_is_utc():
+    # The autofilled ts must be the UTC instant (matches emit's `date -u`), so
+    # Grafana $__timeFilter / now() (UTC) range comparisons align — not local.
+    import datetime as _dt
+    before = _dt.datetime.now(_dt.timezone.utc)
+    parsed = _dt.datetime.strptime(SE._ts_now(), "%Y-%m-%d %H:%M:%S.%f").replace(
+        tzinfo=_dt.timezone.utc
+    )
+    after = _dt.datetime.now(_dt.timezone.utc)
+    assert before - _dt.timedelta(seconds=2) <= parsed <= after + _dt.timedelta(seconds=2)
+
+
 def test_emit_appends_to_spool(tmp_path):
     spool = tmp_path / "spool"
     written = SE.emit(

--- a/scripts/collector/tests/test_collector.py
+++ b/scripts/collector/tests/test_collector.py
@@ -404,6 +404,28 @@ def test_emit_to_daemon_roundtrip_arbitrary_content(tmp_path):
 
 
 @pytest.mark.skipif(not EMIT.exists(), reason="emit script missing")
+def test_emit_ts_is_utc(tmp_path):
+    # emit auto-fills ts as the UTC instant (`date -u`), so it lands inside the
+    # UTC window we bracket around the call — a local-time stamp on a non-UTC
+    # host would be offset out of this window.
+    import datetime as _dt
+    spool = tmp_path / "spool"
+    env = dict(os.environ, ACTIVITY_SPOOL_DIR=str(spool))
+    before = _dt.datetime.now(_dt.timezone.utc)
+    rc = subprocess.run(
+        ["bash", str(EMIT), "source=zsh", "kind=command", "b64:text=tz"],
+        env=env, capture_output=True, text=True,
+    )
+    after = _dt.datetime.now(_dt.timezone.utc)
+    assert rc.returncode == 0, rc.stderr
+    ev = C.parse_line((spool / "current.log").read_text().splitlines()[0])
+    parsed = _dt.datetime.strptime(ev["ts"], "%Y-%m-%d %H:%M:%S.%f").replace(
+        tzinfo=_dt.timezone.utc
+    )
+    assert before - _dt.timedelta(seconds=2) <= parsed <= after + _dt.timedelta(seconds=2)
+
+
+@pytest.mark.skipif(not EMIT.exists(), reason="emit script missing")
 def test_emit_concurrent_appends_dont_interleave(tmp_path):
     spool = tmp_path / "spool"
     env = dict(os.environ, ACTIVITY_SPOOL_DIR=str(spool))


### PR DESCRIPTION
The validation harness found it: ts was local wall-clock in a tz-less DateTime64 (CH server UTC), so Grafana `$__timeFilter`/`now()` range filters were offset ~5-6h. Now all sources (emit `date -u`, keylog/receiver `_ts_now`, claude `to_ch_ts`) stamp the UTC instant. Format unchanged. 146 tests pass; live-confirmed emit ts == `date -u` (host is CDT, UTC-5). Dashboard hour-of-day re-bucketed to local tz separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)