### PR TITLE
fix(ship): land each host ON the main branch, not just main's commit

### DIFF
--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -10,27 +10,38 @@
 # It does NOT run `sudo nixos-rebuild` (needs an interactive password);
 # system/i3 changes are surfaced as a remaining manual step, not attempted.
 #
-# Verifier (cheap + automatic): each host ends at HEAD == origin/main AND
-# `home-manager switch` exits 0. Diverged local history (un-pushed commits)
-# is reported and that host's switch is skipped — never auto-rebased.
+# Verifier (cheap + automatic): each host ends ON the `main` BRANCH at
+# HEAD == origin/main AND `home-manager switch` exits 0. It is not enough for
+# HEAD to merely equal main's commit — a feature branch whose tip is an
+# ancestor of origin/main could be fast-forwarded to that commit and pass a
+# commit-only check while leaving the host stranded on the feature branch with
+# a stale local `main`. So we explicitly `git checkout main` and land there.
+# Diverged local `main` (un-pushed commits) is reported and that host's switch
+# is skipped — never auto-rebased.
 #
 # Usage:
 #   scripts/ship.sh              # converge local (workbench) + laptop
 #   scripts/ship.sh --no-laptop  # local only
 #   scripts/ship.sh --no-local   # laptop only
+#   scripts/ship.sh --no-switch  # land on main + verify git state, SKIP home-manager (test/dry-run)
 #
-# Env overrides: LAPTOP_SSH (default zach@10.42.0.100), REPO_PATH
+# Env overrides:
+#   LAPTOP_SSH    laptop ssh target (default zach@10.42.0.100)
+#   SHIP_REPO     repo path the CONVERGE routine operates on (default $HOME/workspace/devrc)
+#   SHIP_NO_SWITCH=1  same as --no-switch: run full git-landing logic, skip home-manager switch
 set -uo pipefail
 
 LAPTOP_SSH="${LAPTOP_SSH:-zach@10.42.0.100}"
-REPO_PATH="${REPO_PATH:-$HOME/workspace/devrc}"
+SHIP_REPO="${SHIP_REPO:-$HOME/workspace/devrc}"
+SHIP_NO_SWITCH="${SHIP_NO_SWITCH:-0}"
 DO_LOCAL=1
 DO_LAPTOP=1
 for a in "$@"; do
   case "$a" in
     --no-laptop) DO_LAPTOP=0 ;;
     --no-local)  DO_LOCAL=0 ;;
-    -h|--help)   sed -n '2,28p' "$0"; exit 0 ;;
+    --no-switch) SHIP_NO_SWITCH=1 ;;
+    -h|--help)   sed -n '2,33p' "$0"; exit 0 ;;
     *) echo "unknown arg: $a" >&2; exit 2 ;;
   esac
 done
@@ -39,44 +50,72 @@ done
 # bash -c, remote via ssh). Single source of truth for the sequence.
 CONVERGE='
 set -uo pipefail
-repo="$HOME/workspace/devrc"
+repo="${SHIP_REPO:-$HOME/workspace/devrc}"
+no_switch="${SHIP_NO_SWITCH:-0}"
 cd "$repo" || { echo "[$(hostname)] no repo at $repo"; exit 3; }
 host=$(hostname)
 git fetch origin -q || { echo "[$host] git fetch failed"; exit 4; }
-head=$(git rev-parse HEAD)
 target=$(git rev-parse origin/main)
+
+# 1) Stash any WIP (incl. untracked, which an upcoming checkout could clobber)
+#    so we can safely land on the `main` branch.
+dirty=0
+if ! git diff --quiet \
+   || ! git diff --cached --quiet \
+   || [ -n "$(git ls-files --others --exclude-standard)" ]; then
+  dirty=1
+  git stash push -q -u -m ship-auto || { echo "[$host] stash failed"; exit 5; }
+fi
+
+# 2) Land on the `main` branch (not merely main'"'"'s commit). Create a local
+#    main tracking origin/main if it does not exist yet.
+branch=$(git symbolic-ref --quiet --short HEAD || echo "")
+if [ "$branch" != "main" ]; then
+  if git checkout main -q 2>/dev/null || git checkout -B main origin/main -q; then :; else
+    echo "[$host] could not checkout main"
+    [ "$dirty" = 1 ] && git stash pop -q
+    exit 9
+  fi
+fi
+
+# 3) Fast-forward main to origin/main. A non-ff (diverged / un-pushed commits
+#    on main) is reported and skipped — never auto-rebased, never switched.
+head=$(git rev-parse HEAD)
 if [ "$head" != "$target" ]; then
-  if git merge-base --is-ancestor "$head" "$target"; then
-    dirty=0
-    if ! git diff --quiet || ! git diff --cached --quiet; then
-      dirty=1; git stash push -q -u -m ship-auto || { echo "[$host] stash failed"; exit 5; }
-    fi
-    if ! git pull --ff-only origin main -q; then
-      echo "[$host] fast-forward pull failed"
-      [ "$dirty" = 1 ] && git stash pop -q
-      exit 6
-    fi
-    if [ "$dirty" = 1 ] && ! git stash pop -q; then
-      echo "[$host] STASH POP CONFLICT — local changes kept in stash, resolve manually"
-      exit 7
-    fi
-    echo "[$host] fast-forwarded $head -> $target"
+  if git merge --ff-only origin/main -q; then
+    echo "[$host] fast-forwarded main $head -> $target"
   else
-    echo "[$host] not a fast-forward to origin/main (feature branch or un-pushed commits) — skipping switch"
+    echo "[$host] main not a fast-forward to origin/main (un-pushed/diverged commits) — skipping switch"
+    [ "$dirty" = 1 ] && git stash pop -q
     exit 8
   fi
 else
-  echo "[$host] already at origin/main ($target)"
+  echo "[$host] main already at origin/main ($target)"
 fi
-log=$(mktemp /tmp/ship-hm.XXXXXX.log)
-if ! home-manager switch --flake "$repo" --impure >"$log" 2>&1; then
-  echo "[$host] home-manager switch FAILED:"; tail -4 "$log"; exit 9
+
+# 4) Restore WIP.
+if [ "$dirty" = 1 ] && ! git stash pop -q; then
+  echo "[$host] STASH POP CONFLICT — local changes kept in stash, resolve manually"
+  exit 7
 fi
-now=$(git rev-parse HEAD)
-if [ "$now" = "$target" ]; then
-  echo "[$host] ✅ VERIFIED — at origin/main + switched"
+
+# 5) home-manager switch (skippable for tests/dry-run).
+if [ "$no_switch" = 1 ]; then
+  echo "[$host] (SHIP_NO_SWITCH) skipping home-manager switch"
 else
-  echo "[$host] ❌ VERIFY FAILED — HEAD=$now != origin/main=$target"; exit 11
+  log=$(mktemp /tmp/ship-hm.XXXXXX.log)
+  if ! home-manager switch --flake "$repo" --impure >"$log" 2>&1; then
+    echo "[$host] home-manager switch FAILED:"; tail -4 "$log"; exit 9
+  fi
+fi
+
+# 6) Verify: must be ON branch main AND HEAD == origin/main.
+now=$(git rev-parse HEAD)
+nowbranch=$(git symbolic-ref --quiet --short HEAD || echo "DETACHED")
+if [ "$now" = "$target" ] && [ "$nowbranch" = "main" ]; then
+  echo "[$host] ✅ VERIFIED — on branch main at origin/main + switched"
+else
+  echo "[$host] ❌ VERIFY FAILED — branch=$nowbranch HEAD=$now origin/main=$target"; exit 11
 fi
 '
 
@@ -84,13 +123,14 @@ rc=0
 
 if [ "$DO_LOCAL" = 1 ]; then
   echo "=== local (workbench) ==="
-  HOME="$HOME" bash -c "$CONVERGE" || rc=$?
+  SHIP_REPO="$SHIP_REPO" SHIP_NO_SWITCH="$SHIP_NO_SWITCH" bash -c "$CONVERGE" || rc=$?
   echo
 fi
 
 if [ "$DO_LAPTOP" = 1 ]; then
   echo "=== laptop ($LAPTOP_SSH) ==="
-  if ssh -o ConnectTimeout=10 "$LAPTOP_SSH" "$CONVERGE"; then :; else
+  # Pass the switch toggle remotely; SHIP_REPO stays host-default ($HOME/workspace/devrc).
+  if ssh -o ConnectTimeout=10 "$LAPTOP_SSH" "SHIP_NO_SWITCH=$SHIP_NO_SWITCH; $CONVERGE"; then :; else
     laprc=$?
     rc=$laprc
     echo "[laptop] converge exited $laprc"

--- a/scripts/tests/ship-converge.test.sh
+++ b/scripts/tests/ship-converge.test.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# ship-converge.test.sh — exercises the CONVERGE landing logic of scripts/ship.sh
+# against THROWAWAY temp git repos. Does NOT touch ~/workspace/devrc and never
+# runs `home-manager switch` (SHIP_NO_SWITCH=1).
+#
+# Each scenario builds: a bare `origin` whose `main` is ahead by >=1 commit, and
+# a working clone placed in some pre-state, then runs ship.sh --no-local
+# --no-laptop-equivalent by invoking only the local converge with the temp repo
+# via SHIP_REPO + SHIP_NO_SWITCH=1, and asserts post-state branch==main &&
+# HEAD==origin/main (or the diverged exit code for scenario d).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SHIP="$SCRIPT_DIR/../ship.sh"
+
+FAILS=0
+PASS() { echo "PASS: $1"; }
+FAIL() { echo "FAIL: $1"; FAILS=$((FAILS + 1)); }
+
+# Run ship.sh against a temp repo with home-manager skipped, local only.
+# Captures output + exit code into globals OUT / RC.
+run_ship() {
+  local repo="$1"
+  OUT=$(SHIP_REPO="$repo" SHIP_NO_SWITCH=1 bash "$SHIP" --no-laptop 2>&1)
+  RC=$?
+}
+
+# Build a throwaway origin (bare) + working clone. The clone starts checked out
+# on `main` at a commit that is one BEHIND origin/main (origin advanced after
+# clone), so origin/main is always >=1 ahead. Echoes the working repo path.
+make_repo() {
+  local root origin work
+  root=$(mktemp -d /tmp/ship-test.XXXXXX)
+  origin="$root/origin.git"
+  work="$root/work"
+
+  git init -q --bare "$origin"
+  # seed origin via a builder clone
+  local builder="$root/builder"
+  git clone -q "$origin" "$builder"
+  git -C "$builder" config user.email t@t && git -C "$builder" config user.name t
+  git -C "$builder" checkout -q -b main
+  echo base > "$builder/f"
+  echo stable > "$builder/stable.txt"   # tracked file the ahead-commit never touches
+  git -C "$builder" add f stable.txt && git -C "$builder" commit -q -m base
+  git -C "$builder" push -q -u origin main
+
+  # working clone at the base commit (so far == origin/main)
+  git clone -q "$origin" "$work"
+  git -C "$work" config user.email t@t && git -C "$work" config user.name t
+  git -C "$work" checkout -q main
+
+  # advance origin/main by one commit (origin is now ahead of work)
+  echo more >> "$builder/f"
+  git -C "$builder" commit -qam ahead
+  git -C "$builder" push -q origin main
+
+  echo "$work"
+}
+
+git_branch() { git -C "$1" symbolic-ref --quiet --short HEAD || echo DETACHED; }
+git_head()   { git -C "$1" rev-parse HEAD; }
+origin_main() { git -C "$1" rev-parse origin/main; }
+
+assert_landed() {
+  local repo="$1" name="$2"
+  git -C "$repo" fetch origin -q
+  local b h t
+  b=$(git_branch "$repo"); h=$(git_head "$repo"); t=$(origin_main "$repo")
+  if [ "$b" = main ] && [ "$h" = "$t" ]; then
+    PASS "$name (landed on main @ origin/main)"
+  else
+    FAIL "$name — branch=$b HEAD=$h origin/main=$t"
+    echo "  --- ship output ---"; echo "$OUT" | sed 's/^/  /'
+  fi
+}
+
+# (a) host on a feature branch that is an ancestor of origin/main -> must land on main
+scenario_a() {
+  local repo; repo=$(make_repo)
+  git -C "$repo" checkout -q -b feat/ancestor   # tip == base, ancestor of origin/main
+  run_ship "$repo"
+  assert_landed "$repo" "a: feature branch (ancestor of origin/main)"
+}
+
+# (b) already on main but behind -> fast-forwards, stays on main
+scenario_b() {
+  local repo; repo=$(make_repo)   # already on main, behind
+  run_ship "$repo"
+  assert_landed "$repo" "b: on main but behind"
+}
+
+# (c) feature branch with dirty tracked + untracked WIP -> lands on main AND WIP restored
+scenario_c() {
+  local repo; repo=$(make_repo)
+  git -C "$repo" checkout -q -b feat/wip
+  # Dirty a tracked file (stable.txt) that upstream's ahead-commit never touches,
+  # so the post-landing pop is clean — plus an untracked file.
+  echo "tracked change" >> "$repo/stable.txt"  # dirty tracked
+  echo "untracked content" > "$repo/newfile"   # untracked
+  run_ship "$repo"
+  # landing assertion
+  git -C "$repo" fetch origin -q
+  local b h t ok=1
+  b=$(git_branch "$repo"); h=$(git_head "$repo"); t=$(origin_main "$repo")
+  [ "$b" = main ] && [ "$h" = "$t" ] || ok=0
+  # WIP restored: tracked change still present, untracked file present
+  grep -q "tracked change" "$repo/stable.txt" || ok=0
+  { [ -f "$repo/newfile" ] && grep -q "untracked content" "$repo/newfile"; } || ok=0
+  # no stash left behind
+  [ -z "$(git -C "$repo" stash list)" ] || ok=0
+  if [ "$ok" = 1 ]; then
+    PASS "c: dirty tracked+untracked WIP -> landed on main, WIP popped"
+  else
+    FAIL "c: branch=$b HEAD=$h origin/main=$t stash='$(git -C "$repo" stash list)'"
+    echo "  --- ship output ---"; echo "$OUT" | sed 's/^/  /'
+  fi
+}
+
+# (d) main with a diverged un-pushed commit -> skips with diverged exit 8, WIP restored, not mid-stash
+scenario_d() {
+  local repo; repo=$(make_repo)
+  # commit on local main that diverges from origin/main (origin advanced separately)
+  echo "local-only" > "$repo/local.txt"
+  git -C "$repo" add local.txt && git -C "$repo" commit -q -m "local divergent commit"
+  # add WIP to confirm it is restored, not stranded in stash
+  echo "wip tracked" >> "$repo/f"
+  echo "wip untracked" > "$repo/wip-untracked"
+  run_ship "$repo"
+  local ok=1
+  [ "$RC" = 8 ] || ok=0
+  # should still be on main (never left it), with the local commit intact
+  [ "$(git_branch "$repo")" = main ] || ok=0
+  git -C "$repo" log -1 --format=%s | grep -q "local divergent commit" || ok=0
+  # WIP restored (popped), not left in stash
+  grep -q "wip tracked" "$repo/f" || ok=0
+  [ -f "$repo/wip-untracked" ] || ok=0
+  [ -z "$(git -C "$repo" stash list)" ] || ok=0
+  if [ "$ok" = 1 ]; then
+    PASS "d: diverged un-pushed main -> exit 8, WIP restored, not mid-stash"
+  else
+    FAIL "d: rc=$RC branch=$(git_branch "$repo") stash='$(git -C "$repo" stash list)'"
+    echo "  --- ship output ---"; echo "$OUT" | sed 's/^/  /'
+  fi
+}
+
+echo "=== ship.sh CONVERGE landing-logic tests ==="
+scenario_a
+scenario_b
+scenario_c
+scenario_d
+echo "==="
+if [ "$FAILS" = 0 ]; then
+  echo "ALL PASS"
+  exit 0
+else
+  echo "$FAILS scenario(s) FAILED"
+  exit 1
+fi


### PR DESCRIPTION
## The bug
`ship.sh`'s `CONVERGE` routine ran `git pull --ff-only origin main` against **whatever branch was checked out** and verified success only via `HEAD == origin/main` (commit equality). A host sitting on a feature branch whose tip is an ancestor of `origin/main` would have that *feature branch* fast-forwarded to main's commit — the commit check then passed and ship reported `✅ VERIFIED`, but the host was left **on the feature branch** (e.g. `feat/activity-collector-slice`) with a stale local `main`. This actually happened.

## The fix
`CONVERGE` now lands on the `main` **branch**, not just its commit:
1. `git fetch origin`.
2. Detect dirty state including **untracked** files (`git ls-files --others --exclude-standard`), so the upcoming checkout can't fail on would-be-overwritten untracked files; stash with `-u` if dirty.
3. `git checkout main` (fallback `git checkout -B main origin/main` if local `main` absent); on failure restore stash + exit 9.
4. `git merge --ff-only origin/main`; a diverged/un-pushed `main` is reported and skipped (exit 8) after restoring the stash — never auto-rebased, never switched.
5. Pop the stash (exit 7 on pop conflict — unchanged).
6. `home-manager switch` (unchanged, now skippable — see below).
7. Verifier now requires **branch == main AND HEAD == origin/main**; failure message shows the branch.

All existing behavior preserved: `--no-laptop`/`--no-local`, per-host echo lines, exit codes (3/4/5/6/7/8/9/11), `set -uo pipefail`, ssh-vs-local symmetry.

## New env/flag (testability)
- `SHIP_NO_SWITCH=1` / `--no-switch` — run the full git-landing logic + post-checks but skip the heavy `home-manager switch` (for tests/dry-run).
- `SHIP_REPO` — point `CONVERGE` at an arbitrary repo (defaults to `$HOME/workspace/devrc`), so the test can target a throwaway repo.

Both documented in the usage header.

## Test
`scripts/tests/ship-converge.test.sh` exercises the landing logic against **throwaway temp git repos** (never touches `~/workspace/devrc`, never runs home-manager) via `SHIP_REPO=<tmp> SHIP_NO_SWITCH=1`. Scenarios:
- (a) feature branch that's an ancestor of origin/main → lands on `main`
- (b) on `main` but behind → fast-forwards, stays on `main`
- (c) feature branch with dirty tracked + untracked WIP → lands on `main` AND WIP popped
- (d) `main` with a diverged un-pushed commit → exit 8, WIP restored, not left mid-stash

```
=== ship.sh CONVERGE landing-logic tests ===
PASS: a: feature branch (ancestor of origin/main) (landed on main @ origin/main)
PASS: b: on main but behind (landed on main @ origin/main)
PASS: c: dirty tracked+untracked WIP -> landed on main, WIP popped
PASS: d: diverged un-pushed main -> exit 8, WIP restored, not mid-stash
===
ALL PASS
```

`bash -n scripts/ship.sh` → OK. `shellcheck` → only SC2016 (intentional deferred-expansion of the single-quoted CONVERGE routine, matching the pre-existing design) and SC2001 style notes; no real warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)