### PR TITLE
fix(activity): restart collector services on script-only changes

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -304,6 +304,12 @@ in
       ExecStart = "${pkgs.python312}/bin/python3 %h/.config/activity-collector/collector.py";
       Restart = "always";
       RestartSec = 10;
+      # Restart on a script-only change. sd-switch only restarts a unit when the
+      # unit definition itself changes; the script is symlinked-by-path, so a
+      # code edit alone leaves the daemon running STALE code until a manual
+      # `systemctl --user restart`. Pinning the script's store path here makes the
+      # unit definition change whenever the code changes → switch restarts it.
+      X-Restart-Triggers = [ "${../scripts/collector/collector.py}" ];
     };
     Install = {
       WantedBy = [ "default.target" ];
@@ -368,6 +374,8 @@ in
       ExecStart = "${pkgs.python312.withPackages (ps: [ ps.xlib ])}/bin/python3 %h/.config/activity-collector/keylog/keylog.py";
       Restart = "always";
       RestartSec = 10;
+      # Restart on a script-only change (see activity-collector for rationale).
+      X-Restart-Triggers = [ "${../scripts/collector/keylog}" ];
     };
     Install = {
       WantedBy = [ "graphical-session.target" ];
@@ -395,6 +403,10 @@ in
       ExecStart = "${pkgs.python312}/bin/python3 %h/.config/activity-collector/browser-ext/receiver.py";
       Restart = "always";
       RestartSec = 10;
+      # Restart on a script-only change (see activity-collector for rationale).
+      # Tracks browser-ext AND keylog, because the receiver reuses keylog's
+      # spool_emit (single source of truth for the v1 line format).
+      X-Restart-Triggers = [ "${../scripts/collector/browser-ext}" "${../scripts/collector/keylog}" ];
     };
     Install = {
       WantedBy = [ "default.target" ];


### PR DESCRIPTION
## What
Add `X-Restart-Triggers` to the three long-running activity-telemetry user services (`activity-collector`, `keylog`, `browser-activity-receiver`) so a **script-only** change restarts them on `home-manager switch`.

## Why
The collector scripts are symlinked into place **by path**. `sd-switch` only restarts a unit when its *unit definition* changes — a code-only edit doesn't, so the daemons kept running **stale code** until a manual `systemctl --user restart`. This bit the telemetry build twice (a switch silently left old collector code live). Documented as a known gotcha in the `activity` skill; this closes it.

The fix pins each daemon's script store path in `X-Restart-Triggers`; when the script content changes the store path changes → the unit definition changes → switch restarts it. The browser receiver also tracks `keylog` since it reuses keylog's `spool_emit`. `claude-activity-source` is intentionally omitted — it's a 5-min timer oneshot that re-runs fresh code on its next firing.

## Verification
Reproduced the **exact** failing path on the workbench:
- Comment-only edit to `collector.py` → `home-manager switch` now logs `Stopping/Starting activity-collector.service` and the daemon gets a new `MainPID` (before this change: no restart, stale code).
- Reverted the probe; collector healthy and shipping to ClickHouse on fresh code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
