### PR TITLE
feat(activity): add i3 window/workspace focus telemetry source

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -244,6 +244,12 @@ in
     source = ../scripts/collector/browser-ext;
     recursive = true;
   };
+  # i3 focus collector. Reuses keylog's spool_emit (the v1 line format), so
+  # keylog/ must be present alongside it (it always is — shipped above).
+  home.file.".config/activity-collector/i3" = {
+    source = ../scripts/collector/i3;
+    recursive = true;
+  };
 
   # Global Claude Code behavioural config — single source of truth for both
   # hosts (these were drifting when edited per-host). Synced via scripts/ship.sh.
@@ -376,6 +382,41 @@ in
       RestartSec = 10;
       # Restart on a script-only change (see activity-collector for rationale).
       X-Restart-Triggers = [ "${../scripts/collector/keylog}" ];
+    };
+    Install = {
+      WantedBy = [ "graphical-session.target" ];
+    };
+  };
+
+  # i3 focus collector. Subscribes to i3's IPC event stream and emits a
+  # source=i3 record on every window-focus / workspace-focus change — capturing
+  # attention even when the user is only READING (the keylogger only records
+  # focus context WHEN typing). Needs a live i3 IPC socket, so it is gated on
+  # graphical-session.target (laptop-only, NOT started in headless/server mode),
+  # exactly like keylog. Writes into the same spool the activity-collector ships,
+  # reusing keylog's spool_emit (single source of truth for the v1 line format).
+  systemd.user.services.i3-source = {
+    Unit = {
+      Description = "i3 window/workspace focus collector → activity spool";
+      # Requires a live i3 (IPC socket); tracks the graphical session.
+      After = [ "graphical-session.target" ];
+      PartOf = [ "graphical-session.target" ];
+    };
+    Service = {
+      Type = "simple";
+      # python3 WITH i3ipc (the IPC client). WM_CLASS/title come straight from
+      # the i3ipc container, so no Xlib is needed. I3SOCK is auto-discovered by
+      # i3ipc from the running session.
+      Environment = [
+        "PATH=${lib.makeBinPath [ (pkgs.python312.withPackages (ps: [ ps.i3ipc ])) pkgs.coreutils ]}"
+      ];
+      ExecStart = "${pkgs.python312.withPackages (ps: [ ps.i3ipc ])}/bin/python3 %h/.config/activity-collector/i3/i3source.py";
+      Restart = "always";
+      RestartSec = 10;
+      # Restart on a script-only change (see activity-collector for rationale).
+      # Tracks i3/ AND keylog/, because i3source reuses keylog's spool_emit
+      # (single source of truth for the v1 line format).
+      X-Restart-Triggers = [ "${../scripts/collector/i3}" "${../scripts/collector/keylog}" ];
     };
     Install = {
       WantedBy = [ "graphical-session.target" ];

--- a/scripts/collector/i3/README.md
+++ b/scripts/collector/i3/README.md
@@ -1,0 +1,71 @@
+# i3source — i3 window/workspace focus collector
+
+Subscribes to i3's **IPC event stream** (`i3ipc`) and emits ONE `source=i3`
+record on EVERY window-focus and workspace-focus change — **independent of
+typing**. The keylogger only captures focus context *when the user types*; time
+spent **reading** a window without typing was invisible. This daemon fixes that
+so per-app / per-workspace attention and context-switching become accurate.
+
+GUI / **laptop-only** — needs a live i3 IPC socket (`I3SOCK`). It writes into the
+same spool the activity-collector ships, reusing the keylogger's `spool_emit`
+(single source of truth for the v1 line format).
+
+## What it captures
+- **window::focus** — the window the user switched focus to:
+  ```
+  source=i3  kind=window-focus  text=<title>  app=<WM_CLASS>
+  payload={"title":<title>,"workspace":<workspace name>}
+  ```
+- **workspace::focus** — the workspace the user switched to:
+  ```
+  source=i3  kind=workspace-focus  text=<workspace name>
+  payload={"workspace":<workspace name>}
+  ```
+
+Field names mirror the keylogger's `winctx` (`app`=WM_CLASS, payload
+`title`/`workspace`) so `source=i3` and `source=keys` rows **union cleanly** in
+queries. WM_CLASS / title come straight from the i3ipc container — **no Xlib
+round-trip**.
+
+## No dwell field (by design)
+The daemon does **NOT** store an `active_ms`/dwell value. Dwell is computed
+downstream from the **gap between consecutive focus events** (the dashboard's
+deep-work / context-switch panels already work off timestamps). Storing a raw
+dwell would re-introduce the "walked-away-for-hours" inflation that was just
+fixed — so we emit bare focus-change events with an accurate `ts`.
+
+## Robustness
+- No reachable i3 IPC socket → log and exit non-zero; systemd (`Restart=always`,
+  `RestartSec=10`) retries without a tight crash-loop.
+- When i3 restarts, `i3.main()` returns/raises → we exit so systemd brings us
+  back and we **re-subscribe** against the fresh i3.
+- A `spool_emit` failure is swallowed (best-effort telemetry never kills the
+  daemon).
+
+## Files
+- `i3source.py` — the daemon. `build_record(event)` is a **pure** function
+  (i3ipc-event-like → v1 spool fields) so it is unit-tested with synthetic
+  objects, NO live i3/X; `main()` wires `i3ipc` → `build_record` → `spool_emit`.
+  The `import i3ipc` is guarded inside `main()` so the pure function is testable
+  without the package installed.
+
+## Dependency
+`i3ipc` (nixpkgs `python312Packages.i3ipc`). The systemd `i3-source` user
+service builds its python env with it.
+
+## Run / debug
+```sh
+# Needs a live i3 (I3SOCK). Point at a TEST spool while validating:
+nix-shell -p 'python3.withPackages(ps: [ps.i3ipc])' --run \
+  "ACTIVITY_SPOOL_DIR=/tmp/activity-test-spool python3 scripts/collector/i3/i3source.py"
+tail -f /tmp/activity-test-spool/current.log
+```
+The `i3-source` user service (After/WantedBy `graphical-session.target`) runs it
+against the real spool once enabled via a converge step.
+
+## Tests
+```sh
+nix-shell -p python312Packages.pytest --run "pytest scripts/collector/i3/tests"
+```
+Cover window-focus (normal + missing WM_CLASS/title) and workspace-focus →
+correct `source`/`kind`/`app`/`text`/payload, pure (no network, no X, no i3).

--- a/scripts/collector/i3/i3source.py
+++ b/scripts/collector/i3/i3source.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""i3source — i3 window/workspace focus collector for the activity pipeline.
+
+Subscribes to i3's IPC event stream (via the `i3ipc` Python library) and emits
+ONE `source=i3` record on EVERY window-focus and workspace-focus change —
+independent of typing. The keylogger only annotates focus context WHEN the user
+types; time spent READING a window without typing was invisible. This daemon
+closes that gap so per-app / per-workspace attention and context-switching are
+accurate.
+
+Emitted spool records (v1 contract, shipped unchanged by the collector daemon):
+
+    source=i3  kind=window-focus     text=<title>  app=<WM_CLASS>
+        payload={"title":<title>,"workspace":<ws name/num>}
+    source=i3  kind=workspace-focus  text=<ws name>
+        payload={"workspace":<ws name>}
+
+Field names mirror the keylogger's winctx (`app`=WM_CLASS, payload `title` /
+`workspace`) so i3 and keys events union cleanly in queries.
+
+NO DWELL FIELD. We do NOT store an `active_ms`/dwell value: dwell is computed
+downstream from the gap between consecutive focus events (the dashboard's
+deep-work / context-switch panels already work off timestamps). Storing a raw
+dwell would re-introduce the "walked-away-for-hours" inflation that was just
+fixed; we emit bare focus-change events with an accurate `ts`.
+
+GUI / laptop-only — needs a live i3 IPC socket (`I3SOCK`). Shares `spool_emit`
+with the keylogger (single source of truth for the v1 line format).
+
+Config (env)
+------------
+  ACTIVITY_SPOOL_DIR   spool dir (default ~/.local/state/activity/spool)
+  I3SOCK               i3 IPC socket (auto-discovered by i3ipc if unset)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# spool_emit lives in the sibling keylog/ dir (single source of truth for the
+# v1 line format). Use the INVOKED path — do NOT .resolve(): home-manager
+# symlinks each deployed file to a flat /nix/store object, so resolving discards
+# the i3/ ↔ keylog/ sibling layout and breaks this import at runtime.
+_HERE = Path(__file__).parent
+sys.path.insert(0, str(_HERE.parent / "keylog"))
+import spool_emit as SE  # noqa: E402
+
+SOURCE = "i3"
+
+
+def _text(v) -> str:
+    """Coerce an i3ipc string-ish value to a plain str, empty on None."""
+    if v is None:
+        return ""
+    return str(v)
+
+
+def _con_app(con) -> str:
+    """WM_CLASS of a container — prefer class, fall back to instance.
+
+    Mirrors winctx._wm_class (which prefers the class name). i3ipc parses these
+    straight from the window_properties, so no Xlib round-trip is needed.
+    """
+    cls = getattr(con, "window_class", None)
+    if cls:
+        return _text(cls)
+    inst = getattr(con, "window_instance", None)
+    return _text(inst)
+
+
+def _con_title(con) -> str:
+    """Window title — i3 mirrors _NET_WM_NAME into `name` (and window_title)."""
+    name = getattr(con, "name", None)
+    if name:
+        return _text(name)
+    return _text(getattr(con, "window_title", None))
+
+
+def _con_workspace_name(con) -> str:
+    """Name of the workspace containing this container, best-effort.
+
+    `Con.workspace()` walks up to the enclosing workspace node; on a bare/synthetic
+    container (or one above the workspace level) it may be absent or return None,
+    in which case we yield an empty string rather than raising.
+    """
+    ws_fn = getattr(con, "workspace", None)
+    if not callable(ws_fn):
+        return ""
+    try:
+        ws = ws_fn()
+    except Exception:
+        return ""
+    if ws is None:
+        return ""
+    return _text(getattr(ws, "name", None))
+
+
+def _json(obj) -> str:
+    import json
+    return json.dumps(obj, ensure_ascii=False, separators=(",", ":"))
+
+
+def build_record(event) -> dict | None:
+    """Pure: map an i3ipc-event-like object → v1 spool fields (or None to skip).
+
+    Handles WINDOW events (`change == 'focus'`, has `.container`) and WORKSPACE
+    events (`change == 'focus'`, has `.current`). Any other change/shape returns
+    None so the caller emits nothing. No i3 / X / network — unit-testable with
+    synthetic event objects.
+    """
+    change = getattr(event, "change", None)
+    if change != "focus":
+        return None
+
+    # Window-focus: the event carries the focused container.
+    con = getattr(event, "container", None)
+    if con is not None:
+        title = _con_title(con)
+        workspace = _con_workspace_name(con)
+        return {
+            "source": SOURCE,
+            "kind": "window-focus",
+            "text": title,
+            "app": _con_app(con),
+            "project": "",
+            "session": "",
+            "payload": _json({"title": title, "workspace": workspace}),
+        }
+
+    # Workspace-focus: the newly-focused workspace is `.current`.
+    cur = getattr(event, "current", None)
+    if cur is not None:
+        ws_name = _con_title(cur)  # workspace name lives in `name`
+        return {
+            "source": SOURCE,
+            "kind": "workspace-focus",
+            "text": ws_name,
+            "app": "",
+            "project": "",
+            "session": "",
+            "payload": _json({"workspace": ws_name}),
+        }
+
+    return None
+
+
+def _safe_emit(fields: dict, spool_dir: Path) -> None:
+    """Emit one record; a spool failure must never kill the daemon."""
+    try:
+        SE.emit(fields, spool_dir=spool_dir)
+    except Exception as exc:  # best-effort telemetry
+        print(f"i3source: emit failed: {exc}", file=sys.stderr, flush=True)
+
+
+def main(argv=None) -> int:
+    # Import i3ipc lazily so the pure build_record stays testable without the
+    # package installed (mirrors how keylog guards its Xlib import behind use).
+    try:
+        from i3ipc import Connection, Event
+    except Exception as exc:
+        print(f"i3source: i3ipc unavailable: {exc}", file=sys.stderr, flush=True)
+        return 1
+
+    spool_dir = SE.default_spool_dir()
+
+    try:
+        i3 = Connection()
+    except Exception as exc:
+        # No reachable i3 IPC socket (no I3SOCK / i3 not running). Exit non-zero
+        # so systemd (Restart=always, RestartSec) retries without a tight loop.
+        print(f"i3source: cannot connect to i3 IPC: {exc}", file=sys.stderr, flush=True)
+        return 1
+
+    def _on_event(_conn, event):
+        fields = build_record(event)
+        if fields is not None:
+            _safe_emit(fields, spool_dir)
+
+    i3.on(Event.WINDOW_FOCUS, _on_event)
+    i3.on(Event.WORKSPACE_FOCUS, _on_event)
+
+    print(f"i3source: spool={spool_dir} — subscribed to window/workspace focus",
+          file=sys.stderr, flush=True)
+
+    try:
+        # Blocks dispatching events until i3 exits/restarts (main loop returns or
+        # raises). Either way we fall through and exit so systemd restarts us and
+        # we re-subscribe against the fresh i3.
+        i3.main()
+    except KeyboardInterrupt:
+        return 0
+    except Exception as exc:
+        print(f"i3source: event loop ended: {exc}", file=sys.stderr, flush=True)
+        return 1
+    # Clean return from i3.main() means i3 went away (restart/exit). Non-zero so
+    # systemd brings us back to re-subscribe.
+    print("i3source: i3 connection closed — exiting for restart", file=sys.stderr, flush=True)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/collector/i3/tests/test_build_record.py
+++ b/scripts/collector/i3/tests/test_build_record.py
@@ -1,0 +1,177 @@
+"""Unit tests for i3source.build_record — pure mapping of i3ipc-event-like
+objects → v1 spool fields. No live i3, no X, no network: synthetic event/con
+objects duck-type the i3ipc WindowEvent/WorkspaceEvent + Con shapes.
+
+Also round-trips a built record through the existing collector.parse_line to
+prove `source=i3` events ship unchanged through the daemon.
+"""
+import json
+import sys
+from pathlib import Path
+
+I3 = Path(__file__).resolve().parent.parent       # scripts/collector/i3
+COLLECTOR = I3.parent                              # scripts/collector
+KEYLOG = COLLECTOR / "keylog"
+sys.path.insert(0, str(I3))
+sys.path.insert(0, str(KEYLOG))
+sys.path.insert(0, str(COLLECTOR))
+
+import i3source as M  # noqa: E402
+import collector as C  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic i3ipc-shaped objects (duck-typed; no i3ipc import needed)
+# --------------------------------------------------------------------------- #
+class FakeWorkspace:
+    def __init__(self, name):
+        self.name = name
+
+
+class FakeCon:
+    """Duck-types i3ipc.Con: window_class/instance/name + a workspace() method."""
+    def __init__(self, window_class=None, window_instance=None, name=None,
+                 window_title=None, workspace_name=None):
+        self.window_class = window_class
+        self.window_instance = window_instance
+        self.name = name
+        self.window_title = window_title
+        self._workspace_name = workspace_name
+
+    def workspace(self):
+        if self._workspace_name is None:
+            return None
+        return FakeWorkspace(self._workspace_name)
+
+
+class FakeWindowEvent:
+    def __init__(self, change, container):
+        self.change = change
+        self.container = container
+        # workspace events carry .current; a window event does not.
+        self.current = None
+
+
+class FakeWorkspaceEvent:
+    def __init__(self, change, current):
+        self.change = change
+        self.current = current
+        self.container = None
+
+
+# --------------------------------------------------------------------------- #
+# window-focus
+# --------------------------------------------------------------------------- #
+def test_window_focus_normal():
+    ev = FakeWindowEvent(
+        "focus",
+        FakeCon(window_class="firefox", window_instance="Navigator",
+                name="GitHub - Mozilla Firefox", workspace_name="2:web"),
+    )
+    f = M.build_record(ev)
+    assert f is not None
+    assert f["source"] == "i3"
+    assert f["kind"] == "window-focus"
+    assert f["app"] == "firefox"
+    assert f["text"] == "GitHub - Mozilla Firefox"
+    pl = json.loads(f["payload"])
+    assert pl["title"] == "GitHub - Mozilla Firefox"
+    assert pl["workspace"] == "2:web"
+    # No dwell / active_ms field is ever emitted.
+    assert "active_ms" not in f
+    assert "active_ms" not in pl
+
+
+def test_window_focus_missing_class_falls_back_to_instance():
+    ev = FakeWindowEvent(
+        "focus",
+        FakeCon(window_class=None, window_instance="xterm",
+                name="zsh", workspace_name="1"),
+    )
+    f = M.build_record(ev)
+    assert f["app"] == "xterm"
+    assert f["text"] == "zsh"
+
+
+def test_window_focus_missing_class_and_title_graceful_empties():
+    ev = FakeWindowEvent(
+        "focus",
+        FakeCon(window_class=None, window_instance=None,
+                name=None, window_title=None, workspace_name=None),
+    )
+    f = M.build_record(ev)
+    assert f["source"] == "i3"
+    assert f["kind"] == "window-focus"
+    assert f["app"] == ""
+    assert f["text"] == ""
+    pl = json.loads(f["payload"])
+    assert pl["title"] == ""
+    assert pl["workspace"] == ""
+
+
+def test_window_focus_title_falls_back_to_window_title():
+    ev = FakeWindowEvent(
+        "focus",
+        FakeCon(window_class="code", name=None, window_title="main.py — code",
+                workspace_name="3"),
+    )
+    f = M.build_record(ev)
+    assert f["text"] == "main.py — code"
+
+
+# --------------------------------------------------------------------------- #
+# workspace-focus
+# --------------------------------------------------------------------------- #
+def test_workspace_focus():
+    ev = FakeWorkspaceEvent("focus", FakeWorkspace("4:chat"))
+    f = M.build_record(ev)
+    assert f is not None
+    assert f["source"] == "i3"
+    assert f["kind"] == "workspace-focus"
+    assert f["app"] == ""
+    assert f["text"] == "4:chat"
+    pl = json.loads(f["payload"])
+    assert pl["workspace"] == "4:chat"
+    assert "title" not in pl
+
+
+# --------------------------------------------------------------------------- #
+# non-focus changes are skipped
+# --------------------------------------------------------------------------- #
+def test_non_focus_window_change_skipped():
+    ev = FakeWindowEvent("title", FakeCon(window_class="firefox", name="x"))
+    assert M.build_record(ev) is None
+
+
+def test_non_focus_workspace_change_skipped():
+    ev = FakeWorkspaceEvent("init", FakeWorkspace("9"))
+    assert M.build_record(ev) is None
+
+
+def test_focus_event_with_no_container_or_current_skipped():
+    class Bare:
+        change = "focus"
+        container = None
+        current = None
+    assert M.build_record(Bare()) is None
+
+
+# --------------------------------------------------------------------------- #
+# round-trip through the existing collector.parse_line
+# --------------------------------------------------------------------------- #
+def test_window_focus_roundtrips_through_parse_line():
+    import spool_emit as SE
+    ev = FakeWindowEvent(
+        "focus",
+        FakeCon(window_class="Alacritty", name='nvim "weird\ttitle" 你好',
+                workspace_name="2"),
+    )
+    f = M.build_record(ev)
+    line = SE.build_line(f)
+    parsed = C.parse_line(line)
+    assert parsed is not None
+    assert parsed["source"] == "i3"
+    assert parsed["kind"] == "window-focus"
+    assert parsed["app"] == "Alacritty"
+    assert parsed["text"] == 'nvim "weird\ttitle" 你好'
+    assert json.loads(parsed["payload"])["workspace"] == "2"

--- a/scripts/validation/invariants.py
+++ b/scripts/validation/invariants.py
@@ -37,7 +37,7 @@ FUTURE_SLACK_HOURS = 26  # > max |tz offset| (14h) + margin
 OLDEST_PLAUSIBLE = "2025-01-01 00:00:00"
 
 EXPECTED_HOSTS = {"workbench", "laptop"}
-EXPECTED_SOURCES = {"zsh", "tmux", "keys", "browser", "claude"}
+EXPECTED_SOURCES = {"zsh", "tmux", "keys", "browser", "claude", "i3"}
 
 
 @dataclass

--- a/scripts/validation/tests/test_invariants.py
+++ b/scripts/validation/tests/test_invariants.py
@@ -23,9 +23,17 @@ def test_zero_violations_evaluator():
 def test_unexpected_set_evaluator_clean():
     ev = I.eval_unexpected_set(I.EXPECTED_SOURCES, "source")
     rows = [{"value": "zsh", "count": 10}, {"value": "browser", "count": 5},
-            {"value": "claude", "count": 2}]
+            {"value": "claude", "count": 2}, {"value": "i3", "count": 7}]
     passed, detail = ev(rows)
     assert passed is True
+
+
+def test_i3_is_an_expected_source():
+    # The i3 focus collector is a first-class source; once its events land the
+    # expected_sources invariant must not flag them.
+    assert "i3" in I.EXPECTED_SOURCES
+    ev = I.eval_unexpected_set(I.EXPECTED_SOURCES, "source")
+    assert ev([{"value": "i3", "count": 3}])[0] is True
 
 
 def test_unexpected_set_evaluator_catches_bad():


### PR DESCRIPTION
## What
Adds a **6th activity-pipeline source** (`source=i3`) alongside zsh/tmux/keys/browser/claude. A daemon subscribes to i3's IPC event stream (`i3ipc`) and emits **one record on every window-focus and workspace-focus change — independent of typing**.

## Why
i3 focus context was only captured *when the user types* (the keylogger annotates keystrokes with the focused window's WM_CLASS/title/workspace). Time spent **reading/looking at a window without typing was invisible**, so per-app/per-workspace attention and context-switching were undercounted. This daemon emits bare focus-change events so dwell can be computed downstream from timestamp gaps.

## What's in it
- **`scripts/collector/i3/i3source.py`** — the daemon.
  - `build_record(event)` is a **pure** function (i3ipc-event-like → v1 spool fields), unit-tested with no live i3/X/network. `main()` wires `i3ipc` → `build_record` → keylog's shared `spool_emit`.
  - `import i3ipc` is **lazy** (inside `main()`), so the pure function is testable without the package.
  - `spool_emit` imported via the **invoked path, not `.resolve()`** (same fix the browser receiver carries — home-manager flattens the symlink and `.resolve()` would break the sibling import).
  - Field names mirror `winctx` (`app`=WM_CLASS, payload `title`/`workspace`) so `source=i3` and `source=keys` **union cleanly** in queries. WM_CLASS/title come straight from the i3ipc container — **no Xlib needed**.
  - **NO dwell field** — dwell is computed downstream from the gap between focus events; storing a raw dwell would re-introduce the "walked-away-for-hours" inflation that was just fixed.
  - Robust: missing i3 socket / i3 restart → exit non-zero so `Restart=always` re-subscribes; `spool_emit` failures are swallowed.
- **`scripts/collector/i3/README.md`** — contract, dependency, GUI/laptop-only.
- **`scripts/collector/i3/tests/`** — 9 unit tests for `build_record` (normal window focus, missing WM_CLASS→instance fallback, missing class+title→empties, title→window_title fallback, workspace focus, non-focus skips, parse_line round-trip).
- **`nix/home.nix`** — `home.file` symlink + **`i3-source`** user service (gated on `graphical-session.target`, laptop-only; `Restart=always` `RestartSec=10`; python env `python312.withPackages (ps: [ ps.i3ipc ])`; `X-Restart-Triggers` on `i3/` + `keylog/`).
- **`scripts/validation/`** — `"i3"` added to `EXPECTED_SOURCES` (else the `expected_sources` invariant FAILs once i3 events land) + test coverage.

## Validation
- `nix-instantiate --parse nix/home.nix` — clean.
- i3 unit tests: **9 passed** (run with NO i3ipc in env — proves the pure path needs no package).
- validation tests: **67 passed**.
- `build_record` additionally verified against **real i3ipc `WindowEvent`/`WorkspaceEvent`** objects (field names confirmed: `.container.window_class`/`.name`, `.current.name`, `Con.workspace()`).

## Not in scope (handled separately by the owner)
No `home-manager switch` / `ship.sh` deploy; no `~/.claude` / skill-doc edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)