### PR TITLE
fix(activity): idle-aware browser active_ms, i3 workspace fallback, Brave app label

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -440,6 +440,9 @@ in
         # Bind loopback only; keep off any external interface.
         "BROWSER_RECEIVER_HOST=127.0.0.1"
         "BROWSER_RECEIVER_PORT=8787"
+        # The browser is Brave (Chromium-based); label records accordingly so
+        # they don't masquerade as generic chromium.
+        "BROWSER_APP=brave"
       ];
       ExecStart = "${pkgs.python312}/bin/python3 %h/.config/activity-collector/browser-ext/receiver.py";
       Restart = "always";

--- a/scripts/collector/browser-ext/README.md
+++ b/scripts/collector/browser-ext/README.md
@@ -64,6 +64,12 @@ To point at a TEST spool while validating:
   a fake password, bad-JSON 400, wrong-path 404). See `tests/test_receiver.py`.
 - Manifest + service-worker logic: validated (manifest JSON parses, MV3 schema
   fields present; `buildEvent` payload shape mirrored by the receiver test).
+- Active-time accounting: the idle/blur-aware accumulator lives in the PURE
+  `active_time.js` (no `chrome.*`, no `Date.now()` — all timestamps passed in)
+  and is unit-tested in `tests/active_time.test.mjs`. Run with Node's built-in
+  runner; pass a glob (a bare directory positional is treated as a module on
+  Node ≥22, so glob or run from inside the dir):
+  `nix-shell -p nodejs --run "node --test 'scripts/collector/browser-ext/tests/**/*.test.mjs'"`.
 - The end-to-end **load-unpacked in a real browser** step is a MANUAL step (MV3
   service workers are not reliably driveable headlessly). Follow "Load unpacked"
   above to complete it.

--- a/scripts/collector/browser-ext/active_time.js
+++ b/scripts/collector/browser-ext/active_time.js
@@ -1,0 +1,85 @@
+// active_time.js — PURE active-time accounting for the browser collector.
+//
+// Problem this solves: previously active_ms was `now - since` over the whole
+// span a tab was the focused tab — INCLUDING time the browser was blurred or
+// the user was idle/locked. A chrome://newtab "focused" for 22 min while the
+// user was elsewhere logged 22 min of fake engagement. The harness
+// per_host_hour_active_cap caught it (68.9 min "active" in a 42-min window).
+//
+// Fix: an accumulator that ONLY accrues wall-clock while the browser is focused
+// AND the user is not idle/locked. Idle/blur banks the elapsed active time and
+// PAUSES; active/focus resumes by re-anchoring `since` to now. When a tab
+// change emits a nav event, take() returns banked + (active ? now-since : 0),
+// clamped to a 1-hour cap, and resets for the next tab.
+//
+// PURE: no chrome.*, no Date.now() — every method takes `now` (ms epoch) from
+// the caller. State is a plain serializable object so service_worker.js can
+// persist it across MV3 worker suspension via chrome.storage.session.
+
+// Belt-and-suspenders per-event cap: even an edge-case miss (e.g. a missed
+// idle/blur transition) can never log an absurd active_ms.
+export const ACTIVE_CAP_MS = 3_600_000; // 1 hour
+
+// Fresh accumulator state.
+//   banked: ms of active time accrued and "banked" (paused spans summed)
+//   since:  epoch ms anchor of the in-progress active span, or null if paused
+//           (browser blurred or user idle/locked)
+export function freshState(now = 0, active = false) {
+  return { banked: 0, since: active ? now : null };
+}
+
+// Normalize an arbitrary stored object back into a valid state (defensive
+// against a partially-written / legacy chrome.storage.session blob).
+export function fromStored(o) {
+  if (!o || typeof o !== "object") return freshState();
+  const banked = Number.isFinite(o.banked) ? Math.max(0, o.banked) : 0;
+  const since = Number.isFinite(o.since) ? o.since : null;
+  return { banked, since };
+}
+
+// Currently accruing? (true between an onActive and the next onIdle/onBlur)
+export function isActive(state) {
+  return state.since !== null;
+}
+
+// Transition to active/focused: start (or continue) accruing. If already
+// accruing this is a no-op — we must NOT reset `since` (that would drop the
+// in-progress span). Idempotent so duplicate active/focus signals are safe.
+export function onActive(state, now) {
+  if (state.since === null) state.since = now;
+  return state;
+}
+
+// Transition to idle / locked / blurred: bank the in-progress span and pause.
+// Idempotent: if already paused, nothing to bank.
+export function onInactive(state, now) {
+  if (state.since !== null) {
+    state.banked += Math.max(0, now - state.since);
+    state.since = null;
+  }
+  return state;
+}
+
+// Aliases for the two inactive causes — same accounting, clearer call sites.
+export const onIdle = onInactive;
+export const onBlur = onInactive;
+
+// Current accumulated active ms WITHOUT mutating (banked + in-progress span),
+// uncapped — useful for inspection/tests.
+export function activeMs(state, now) {
+  const live = state.since !== null ? Math.max(0, now - state.since) : 0;
+  return state.banked + live;
+}
+
+// Bank everything up to `now`, return the capped active_ms, and RESET the
+// accumulator for the next tab. If still active at `now`, the new span is
+// re-anchored to `now` (so continuous engagement across a tab switch keeps
+// accruing); if paused, it stays paused.
+export function take(state, now) {
+  const total = activeMs(state, now);
+  const capped = Math.min(ACTIVE_CAP_MS, Math.max(0, Math.round(total)));
+  const stillActive = state.since !== null;
+  state.banked = 0;
+  state.since = stillActive ? now : null;
+  return capped;
+}

--- a/scripts/collector/browser-ext/service_worker.js
+++ b/scripts/collector/browser-ext/service_worker.js
@@ -13,8 +13,15 @@
 //   focus — window/idle focus transition (browser focused/blurred, idle/active).
 //
 // MV3 service workers are ephemeral (the browser may suspend them). We persist
-// the "current active tab + since-timestamp" in chrome.storage.session so an
-// active-duration can still be computed across a worker restart.
+// the "current active tab + active-time accumulator" in chrome.storage.session
+// so active-duration accounting survives a worker restart.
+//
+// active_ms is now IDLE/BLUR-AWARE: the accumulator in active_time.js only
+// accrues wall-clock while the browser is focused AND the user is not
+// idle/locked, so a tab "focused" while the user walked away no longer logs
+// that away-time as engagement. (Pure module — no chrome.* — unit-tested.)
+
+import * as AT from "./active_time.js";
 
 const ENDPOINT = "http://127.0.0.1:8787/event";
 const STORE_KEY = "active_state";
@@ -44,23 +51,43 @@ async function post(event) {
   }
 }
 
+// Stored shape: { tabId, url, title, accum } where `accum` is the pure
+// active_time accumulator state ({ banked, since }). A fresh worker assumes the
+// browser is active (it just ran an event) — the next idle/blur will correct.
 async function getState() {
   const o = await chrome.storage.session.get(STORE_KEY);
-  return o[STORE_KEY] || { tabId: null, url: "", title: "", since: Date.now() };
+  const s = o[STORE_KEY];
+  if (!s) {
+    return { tabId: null, url: "", title: "", accum: AT.freshState(Date.now(), true) };
+  }
+  s.accum = AT.fromStored(s.accum);
+  return s;
 }
 
 async function setState(s) {
   await chrome.storage.session.set({ [STORE_KEY]: s });
 }
 
-// Compute active_ms for the outgoing (previous) tab, emit a nav event for the
-// NEW active tab, and record the new active state.
-async function onActive({ url, title, tabId }) {
+// Apply an accumulator transition (onActive/onBlur/onIdle) to the persisted
+// state in one read-modify-write. Keeps the active-time bookkeeping in sync
+// with focus/idle signals without emitting a nav event.
+async function applyAccum(fn, now) {
+  const cur = await getState();
+  fn(cur.accum, now);
+  await setState(cur);
+}
+
+// A tab change / navigation: bank the active time for the OUTGOING tab, emit a
+// nav event carrying that (capped, idle/blur-excluded) active_ms, then reset
+// the accumulator for the new tab. take() re-anchors the in-progress span to
+// `now` if still active, so continuous engagement across a switch keeps
+// accruing.
+async function onTabChange({ url, title, tabId }) {
   const prev = await getState();
   const now = Date.now();
-  const active_ms = prev.since ? now - prev.since : 0;
+  const active_ms = AT.take(prev.accum, now);
   await post(buildEvent("nav", { url, title, active_ms }));
-  await setState({ tabId, url, title, since: now });
+  await setState({ tabId, url, title, accum: prev.accum });
 }
 
 async function tabInfo(tabId) {
@@ -74,7 +101,7 @@ async function tabInfo(tabId) {
 
 // --- chrome event wiring --------------------------------------------------- //
 chrome.tabs.onActivated.addListener(async ({ tabId }) => {
-  await onActive(await tabInfo(tabId));
+  await onTabChange(await tabInfo(tabId));
 });
 
 // Navigation within the active tab (committed top-frame loads).
@@ -83,7 +110,7 @@ chrome.webNavigation.onCommitted.addListener(async (d) => {
   const info = await tabInfo(d.tabId);
   const cur = await getState();
   if (cur.tabId !== null && cur.tabId !== d.tabId) return; // not the active tab
-  await onActive(info);
+  await onTabChange(info);
 });
 
 // Title can arrive after commit; refresh stored title without a duration reset.
@@ -96,14 +123,20 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo) => {
   }
 });
 
-// Window focus changes (browser gained/lost OS focus).
+// Window focus changes (browser gained/lost OS focus). Blur PAUSES the active-
+// time accumulator (banks the elapsed span); refocus RESUMES it.
 chrome.windows.onFocusChanged.addListener(async (windowId) => {
   const focused = windowId !== chrome.windows.WINDOW_ID_NONE;
+  const now = Date.now();
+  await applyAccum(focused ? AT.onActive : AT.onBlur, now);
   await post(buildEvent("focus", { state: focused ? "focused" : "blurred" }));
 });
 
-// Idle / active / locked transitions.
+// Idle / active / locked transitions. "active" resumes accrual; "idle"/"locked"
+// pause it (banking the active span) so away-time isn't counted as engagement.
 chrome.idle.setDetectionInterval(60);
 chrome.idle.onStateChanged.addListener(async (state) => {
+  const now = Date.now();
+  await applyAccum(state === "active" ? AT.onActive : AT.onIdle, now);
   await post(buildEvent("focus", { state }));
 });

--- a/scripts/collector/browser-ext/tests/active_time.test.mjs
+++ b/scripts/collector/browser-ext/tests/active_time.test.mjs
@@ -1,0 +1,110 @@
+// Pure, deterministic tests for active_time.js (the idle/blur-aware active-time
+// accumulator). No chrome stubs, no Date.now() — all timestamps are passed in.
+//
+// Run: nix-shell -p nodejs --run "node --test scripts/collector/browser-ext/tests/"
+import test from "node:test";
+import assert from "node:assert/strict";
+import * as AT from "../active_time.js";
+
+// (a) accrues while active
+test("accrues wall-clock while active", () => {
+  const s = AT.freshState(0, true); // active at t=0
+  assert.equal(AT.activeMs(s, 1000), 1000);
+  assert.equal(AT.activeMs(s, 5000), 5000);
+});
+
+// (b) does NOT accrue across an idle period: idle@t1 → active@t2 contributes 0
+test("idle period contributes zero active time", () => {
+  const s = AT.freshState(0, true);
+  AT.onIdle(s, 1000);            // bank [0,1000] = 1000, pause
+  AT.onActive(s, 21_000);       // resume after 20s idle (away)
+  // The 20s of idle [1000, 21000] must NOT count.
+  assert.equal(AT.take(s, 22_000), 1000 + 1000); // 1000 banked + [21000,22000]
+});
+
+// (c) does NOT accrue while blurred
+test("blurred span contributes zero active time", () => {
+  const s = AT.freshState(0, true);
+  AT.onBlur(s, 2000);           // bank [0,2000] = 2000, pause
+  // 10 minutes blurred...
+  assert.equal(AT.activeMs(s, 602_000), 2000); // nothing accrued while paused
+});
+
+// (d) resumes correctly after idle→active
+test("resumes accrual after idle then active", () => {
+  const s = AT.freshState(0, true);
+  AT.onIdle(s, 3000);           // banked 3000
+  AT.onActive(s, 10_000);       // resume
+  assert.equal(AT.activeMs(s, 12_000), 3000 + 2000); // 3000 + [10000,12000]
+});
+
+// (e) the 1h cap clamps an absurd value (edge-case missed transition)
+test("take() clamps to the 1-hour cap", () => {
+  const s = AT.freshState(0, true);
+  // Two hours of "active" with no idle/blur signal at all (a missed transition).
+  const got = AT.take(s, 7_200_000);
+  assert.equal(got, AT.ACTIVE_CAP_MS);
+  assert.equal(AT.ACTIVE_CAP_MS, 3_600_000);
+});
+
+// (f) take() resets state (banked cleared; re-anchored if still active)
+test("take() resets the accumulator and re-anchors if active", () => {
+  const s = AT.freshState(0, true);
+  AT.onIdle(s, 1000);           // banked 1000
+  AT.onActive(s, 5000);         // resume
+  const first = AT.take(s, 6000); // 1000 + [5000,6000] = 2000
+  assert.equal(first, 2000);
+  assert.equal(s.banked, 0);
+  // Still active, so re-anchored to 6000: the next span starts fresh.
+  assert.equal(AT.activeMs(s, 6500), 500);
+  const second = AT.take(s, 7000); // [6000,7000] = 1000
+  assert.equal(second, 1000);
+});
+
+// take() while paused stays paused and resets banked
+test("take() while paused returns banked and stays paused", () => {
+  const s = AT.freshState(0, true);
+  AT.onBlur(s, 4000);           // banked 4000, paused
+  const got = AT.take(s, 9000); // paused → no live span
+  assert.equal(got, 4000);
+  assert.equal(s.banked, 0);
+  assert.equal(AT.isActive(s), false);
+  // Stays at 0 until a fresh onActive.
+  assert.equal(AT.activeMs(s, 99_000), 0);
+});
+
+// onActive is idempotent — duplicate active/focus signals must not drop the
+// in-progress span by re-anchoring.
+test("onActive is idempotent (does not reset an in-progress span)", () => {
+  const s = AT.freshState(0, true);
+  AT.onActive(s, 5000);  // already active — should be a no-op, keep since=0
+  assert.equal(AT.activeMs(s, 10_000), 10_000);
+});
+
+// onInactive is idempotent — a second idle/blur while paused banks nothing.
+test("onInactive is idempotent while paused", () => {
+  const s = AT.freshState(0, true);
+  AT.onIdle(s, 1000);   // banked 1000
+  AT.onIdle(s, 5000);   // already paused — no extra bank
+  assert.equal(s.banked, 1000);
+});
+
+// fromStored normalizes garbage / partial blobs back to a valid state.
+test("fromStored normalizes bad input", () => {
+  assert.deepEqual(AT.fromStored(undefined), { banked: 0, since: null });
+  assert.deepEqual(AT.fromStored({ banked: -5, since: "x" }), { banked: 0, since: null });
+  assert.deepEqual(AT.fromStored({ banked: 100, since: 200 }), { banked: 100, since: 200 });
+});
+
+// A realistic scenario matching the harness finding: a tab "focused" 42 min of
+// wall-clock but the user was idle/away for most of it → active_ms reflects
+// only the genuinely-active spans, well under the window.
+test("real-world: long-focused-but-idle tab logs only active spans", () => {
+  const s = AT.freshState(0, true);
+  AT.onActive(s, 0);
+  // 5 min active, then idle for 30 min, then 7 min active.
+  AT.onIdle(s, 5 * 60_000);            // banked 5 min
+  AT.onActive(s, 35 * 60_000);         // back after 30 min away
+  const active = AT.take(s, 42 * 60_000); // + 7 min
+  assert.equal(active, (5 + 7) * 60_000); // 12 min, NOT 42
+});

--- a/scripts/collector/i3/i3source.py
+++ b/scripts/collector/i3/i3source.py
@@ -100,13 +100,20 @@ def _json(obj) -> str:
     return json.dumps(obj, ensure_ascii=False, separators=(",", ":"))
 
 
-def build_record(event) -> dict | None:
+def build_record(event, current_workspace: str = "") -> dict | None:
     """Pure: map an i3ipc-event-like object → v1 spool fields (or None to skip).
 
     Handles WINDOW events (`change == 'focus'`, has `.container`) and WORKSPACE
     events (`change == 'focus'`, has `.current`). Any other change/shape returns
     None so the caller emits nothing. No i3 / X / network — unit-testable with
     synthetic event objects.
+
+    `current_workspace` is the daemon's tracked currently-focused workspace
+    (maintained from workspace::focus events). It's used as a FALLBACK for
+    window-focus records: i3's WindowEvent container's `.workspace()` frequently
+    fails to resolve (yielding ""), leaving window-focus events with an empty
+    workspace. When the container can't resolve its own workspace we stamp the
+    tracked one instead.
     """
     change = getattr(event, "change", None)
     if change != "focus":
@@ -116,7 +123,7 @@ def build_record(event) -> dict | None:
     con = getattr(event, "container", None)
     if con is not None:
         title = _con_title(con)
-        workspace = _con_workspace_name(con)
+        workspace = _con_workspace_name(con) or current_workspace
         return {
             "source": SOURCE,
             "kind": "window-focus",
@@ -142,6 +149,23 @@ def build_record(event) -> dict | None:
         }
 
     return None
+
+
+def _focused_workspace_name(i3) -> str:
+    """Best-effort current workspace name from a live i3 Connection.
+
+    Uses get_workspaces() (a flat list with a `.focused` flag) — robust across
+    i3ipc versions and cheap. Any failure yields "" so startup never crashes on
+    a transient IPC hiccup; the tracker self-corrects on the first
+    workspace::focus event.
+    """
+    try:
+        for ws in i3.get_workspaces():
+            if getattr(ws, "focused", False):
+                return _text(getattr(ws, "name", None))
+    except Exception:
+        return ""
+    return ""
 
 
 def _safe_emit(fields: dict, spool_dir: Path) -> None:
@@ -171,8 +195,22 @@ def main(argv=None) -> int:
         print(f"i3source: cannot connect to i3 IPC: {exc}", file=sys.stderr, flush=True)
         return 1
 
+    # Track the currently-focused workspace so window-focus events (whose
+    # container often can't resolve its own .workspace()) can still be stamped
+    # with one. Seed it from the live tree, then keep it current on every
+    # workspace::focus.
+    tracker = {"ws": _focused_workspace_name(i3)}
+
     def _on_event(_conn, event):
-        fields = build_record(event)
+        # Update the tracker BEFORE building so a workspace-focus event's own
+        # record is unaffected (it reads from .current), while the next
+        # window-focus picks up the freshly-focused workspace.
+        if getattr(event, "current", None) is not None and \
+                getattr(event, "change", None) == "focus":
+            ws = _con_title(event.current)
+            if ws:
+                tracker["ws"] = ws
+        fields = build_record(event, current_workspace=tracker["ws"])
         if fields is not None:
             _safe_emit(fields, spool_dir)
 

--- a/scripts/collector/i3/tests/test_build_record.py
+++ b/scripts/collector/i3/tests/test_build_record.py
@@ -159,6 +159,48 @@ def test_focus_event_with_no_container_or_current_skipped():
 # --------------------------------------------------------------------------- #
 # round-trip through the existing collector.parse_line
 # --------------------------------------------------------------------------- #
+# --------------------------------------------------------------------------- #
+# current_workspace fallback (Fix 2): window-focus whose container can't resolve
+# its own workspace gets stamped with the daemon's tracked workspace.
+# --------------------------------------------------------------------------- #
+def test_window_focus_uses_tracked_workspace_when_container_unresolved():
+    ev = FakeWindowEvent(
+        "focus",
+        FakeCon(window_class="Alacritty", name="zsh", workspace_name=None),
+    )
+    f = M.build_record(ev, current_workspace="3:code")
+    pl = json.loads(f["payload"])
+    assert pl["workspace"] == "3:code"
+
+
+def test_window_focus_prefers_container_workspace_over_tracked():
+    # When the container DOES resolve, that wins over the tracker.
+    ev = FakeWindowEvent(
+        "focus",
+        FakeCon(window_class="firefox", name="x", workspace_name="2:web"),
+    )
+    f = M.build_record(ev, current_workspace="9:stale")
+    assert json.loads(f["payload"])["workspace"] == "2:web"
+
+
+def test_window_focus_empty_when_neither_container_nor_tracker_resolve():
+    ev = FakeWindowEvent(
+        "focus",
+        FakeCon(window_class="x", name="y", workspace_name=None),
+    )
+    f = M.build_record(ev)  # current_workspace defaults to ""
+    assert json.loads(f["payload"])["workspace"] == ""
+
+
+def test_workspace_focus_still_sets_from_current():
+    # A workspace-focus record reads its workspace from .current, regardless of
+    # any tracked value passed in.
+    ev = FakeWorkspaceEvent("focus", FakeWorkspace("4:chat"))
+    f = M.build_record(ev, current_workspace="ignored")
+    assert f["kind"] == "workspace-focus"
+    assert json.loads(f["payload"])["workspace"] == "4:chat"
+
+
 def test_window_focus_roundtrips_through_parse_line():
     import spool_emit as SE
     ev = FakeWindowEvent(


### PR DESCRIPTION
Three fixes to the activity-telemetry collector, with test coverage.

## Fix 1 (primary) — browser `active_ms` is now idle/blur-aware
Previously `onActive()` set `active_ms = now - since`, the full wall-clock a tab
was the focused tab — including time the browser was blurred or the user was
idle/locked. A `chrome://newtab` "focused" 22 min while the user was away logged
22 min of fake engagement (harness `per_host_hour_active_cap` flagged 68.9 min
"active" in a 42-min window).

Active-time accounting is factored into a **pure** module
`scripts/collector/browser-ext/active_time.js` — no `chrome.*`, no `Date.now()`
(timestamps are passed in), importable/testable in plain Node. It's a small
accumulator `{banked, since}`:
- `onActive(now)` starts/continues accruing (idempotent — never drops an
  in-progress span).
- `onIdle/onBlur(now)` bank the elapsed active span and **pause**.
- `take(now)` returns `banked + (active ? now-since : 0)`, **clamped to a 1-hour
  cap** (belt-and-suspenders), and resets — re-anchoring to `now` if still active
  so continuous engagement across a tab switch keeps accruing.

`service_worker.js` imports it and wires `chrome.idle` (`active`→resume,
`idle`/`locked`→pause), `chrome.windows.onFocusChanged` (focus→resume,
blur→pause), and the tab/nav handlers (`take()` on each nav). State persists
across MV3 worker suspension via `chrome.storage.session` (now stores `accum`
instead of a bare `since`).

## Fix 2 — i3 `window-focus` events carried an empty `workspace`
The WindowEvent container's `.workspace()` often doesn't resolve. `i3source.py`
now tracks the focused workspace in the daemon (seeded via `get_workspaces()`,
updated on every `workspace::focus`) and `build_record(event, current_workspace=)`
uses it as a fallback for window-focus records. Workspace-focus records still read
their workspace from `.current`.

## Fix 3 — browser events mislabeled `app=chromium` (it's Brave)
The receiver already honors `BROWSER_APP` (no code change). Added
`BROWSER_APP=brave` to the `browser-activity-receiver` systemd user service env
in `nix/home.nix`.

## Tests
- **JS (new):** `scripts/collector/browser-ext/tests/active_time.test.mjs`
  (`node:test`/`node:assert`) — 11/11 pass. Covers: accrues while active; idle
  period contributes 0; blurred contributes 0; resume after idle→active; 1h cap
  clamps; `take()` resets/re-anchors; idempotent active/idle; `fromStored`
  normalization; real-world idle-heavy tab (42-min wall-clock → 12-min active).
- **Receiver pytest:** 8/8 still green.
- **i3 pytest:** 13/13 (was 9, +4 covering the `current_workspace` fallback and
  that workspace-focus still reads `.current`).
- `nix-instantiate --parse nix/home.nix` — clean.

### Note on the JS run command
On Node ≥22 a **bare directory** positional to `node --test` is treated as a
module (`Cannot find module .../tests`), not a discovery root. Use a glob (or run
from inside the dir):
`nix-shell -p nodejs --run "node --test 'scripts/collector/browser-ext/tests/**/*.test.mjs'"`.
Documented in the browser-ext README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)