### PR TITLE
feat(browser-ext): capture scroll engagement per page view

### DIFF
--- a/scripts/collector/browser-ext/README.md
+++ b/scripts/collector/browser-ext/README.md
@@ -1,24 +1,47 @@
 # browser-ext — Chrome MV3 browser-activity collector
 
-Tracks the active tab (full URL + title), active-duration, and focus/idle
-transitions, and POSTs each event to a localhost receiver that writes it into
-the activity-collector spool (v1 emit format) for the existing daemon to ship.
+Tracks the active tab (full URL + title), active-duration, scroll engagement,
+and focus/idle transitions, and POSTs each event to a localhost receiver that
+writes it into the activity-collector spool (v1 emit format) for the existing
+daemon to ship.
 
 Full URL capture, local-only — consistent with the full-content self-instrumentation
 choice. Nothing leaves the host from here; shipping is the daemon's decision and
 is gated on an authenticated ClickHouse.
 
 ## Components
-- `manifest.json` — MV3 manifest. Permissions: `tabs`, `webNavigation`, `idle`;
-  host permission for `http://127.0.0.1:8787/*` only.
+- `manifest.json` — MV3 manifest. Permissions: `tabs`, `webNavigation`, `idle`,
+  `storage`. Host permission for `http://127.0.0.1:8787/*` only. **A
+  `content_scripts` entry injects `content_scroll.js` into all `http(s)://*`
+  pages** for scroll capture — this broadens the extension's host access to ALL
+  sites (intended; the script only reads scroll geometry and never touches page
+  content, and nothing leaves localhost).
 - `service_worker.js` — background worker. Listens on `chrome.tabs.onActivated`,
-  `chrome.webNavigation.onCommitted`, `chrome.tabs.onUpdated` (title), 
-  `chrome.windows.onFocusChanged`, and `chrome.idle.onStateChanged`. Computes
-  active-duration across tab switches (persisted in `chrome.storage.session` so
-  it survives MV3 worker suspension) and POSTs events to the receiver.
+  `chrome.webNavigation.onCommitted`, `chrome.tabs.onUpdated` (title),
+  `chrome.windows.onFocusChanged`, `chrome.idle.onStateChanged`,
+  `chrome.runtime.onMessage` (scroll updates), and `chrome.tabs.onRemoved`.
+  Computes active-duration across tab switches and stores per-tab scroll metrics
+  (both persisted in `chrome.storage.session` so they survive MV3 worker
+  suspension); folds the LEAVING tab's scroll metrics into its `nav` event.
+- `content_scroll.js` — content script (all http/https pages). Thin DOM/chrome
+  wiring: throttled `scroll` listener → pure tracker → throttled
+  `chrome.runtime.sendMessage` updates + a final flush on
+  `visibilitychange`/`pagehide`. Best-effort; swallows errors when the SW is
+  asleep.
+- `scroll_track.js` — PURE scroll-engagement accumulator (no `window`/`document`/
+  `chrome`, no `Date.now()`; loaded by the content script via dynamic `import()`
+  and listed in `web_accessible_resources`). Unit-tested in plain Node.
 - `receiver.py` — stdlib `http.server` bound to `127.0.0.1:8787`. Accepts
   `POST /event`, maps the JSON to a v1 spool record, appends to the spool.
   Shares `../keylog/spool_emit.py` (single source of truth for the line format).
+
+### Scroll metrics (per page view, on the `nav` event)
+- `scroll_pct` — MAX reading depth reached, `round(100*(scrollY+innerHeight)/
+  max(1, scrollHeight))` clamped 0–100; monotonic per view (scrolling back up
+  does not lower it).
+- `scroll_ms` — accumulated ACTIVE-scroll time: sum of scrolling bursts, where
+  consecutive throttled samples <1s apart extend the current burst (idle reading
+  time between scrolls is not counted).
 
 ## localhost endpoint contract
 `POST http://127.0.0.1:8787/event`, `Content-Type: application/json`:
@@ -28,6 +51,8 @@ is gated on an authenticated ClickHouse.
   "url":   "https://full/url",      // full URL (nav events)
   "title": "tab title",
   "active_ms": 1234,                  // ms the previous tab was focused
+  "scroll_pct": 88,                   // max reading depth % of the leaving page
+  "scroll_ms": 12500,                 // active-scroll time on the leaving page
   "state": "focused|blurred|idle|active|locked",  // focus events
   "ts": 1719240000000 }              // client epoch ms
 ```
@@ -35,7 +60,7 @@ is gated on an authenticated ClickHouse.
 Receiver writes:
 ```
 source=browser  kind=<nav|focus>  text=<url>  app=<chromium|brave>
-payload={"title":…,"active_ms":…,"state":…,"client_ts":…}
+payload={"title":…,"active_ms":…,"state":…,"scroll_pct":…,"scroll_ms":…,"client_ts":…}
 ```
 `GET /health` → `{"ok":true}`.
 
@@ -70,6 +95,11 @@ To point at a TEST spool while validating:
   runner; pass a glob (a bare directory positional is treated as a module on
   Node ≥22, so glob or run from inside the dir):
   `nix-shell -p nodejs --run "node --test 'scripts/collector/browser-ext/tests/**/*.test.mjs'"`.
+- Scroll engagement: the PURE `scroll_track.js` (same no-`chrome`/no-`Date.now()`
+  discipline) is unit-tested in `tests/scroll_track.test.mjs` (max-depth
+  monotonicity, 0–100 clamp, burst accrual with the >1s gap rule, snapshot/reset).
+  `content_scroll.js` (DOM/chrome wiring) and the SW message→nav fold are NOT
+  exercised headlessly — verify in the load-unpacked step below.
 - The end-to-end **load-unpacked in a real browser** step is a MANUAL step (MV3
   service workers are not reliably driveable headlessly). Follow "Load unpacked"
   above to complete it.

--- a/scripts/collector/browser-ext/content_scroll.js
+++ b/scripts/collector/browser-ext/content_scroll.js
@@ -1,0 +1,96 @@
+// content_scroll.js — thin DOM/chrome wiring around the pure scroll_track.js.
+//
+// Injected (as a CLASSIC content script — MV3 declarative content scripts are
+// not ES modules) into all http/https pages. It dynamically imports the pure
+// tracker from the extension package (scroll_track.js is listed in
+// web_accessible_resources so the page-world import URL resolves), watches
+// `scroll`, feeds throttled samples into the tracker, and reports the running
+// {scroll_pct, scroll_ms} to the service worker so the SW can fold those
+// reading-engagement metrics into the page view's `nav` event.
+//
+// We deliberately DO NOT emit a per-scroll event stream — only a low-rate
+// running update plus a final flush when the page is hidden/unloaded.
+//
+// Best-effort throughout: the dynamic import or chrome.runtime.sendMessage may
+// fail because the MV3 worker is asleep or the page/extension context is being
+// torn down — we swallow every error; the SW picks up a later update or the
+// leaving tab simply reports 0.
+
+(() => {
+  const SCROLL_THROTTLE_MS = 250; // min spacing between processed scroll samples
+  const REPORT_THROTTLE_MS = 2000; // min spacing between sendMessage updates
+
+  let tracker = null;
+  let lastSampleTs = 0;
+  let lastReportTs = 0;
+  let pendingReport = false;
+
+  function now() {
+    return Date.now();
+  }
+
+  // Best-effort: tell the SW the current running metrics. Swallows the
+  // "receiving end does not exist" / "Extension context invalidated"
+  // rejections that happen when the worker is suspended or the page unloads.
+  function report() {
+    if (!tracker) return;
+    const snap = tracker.snapshot();
+    try {
+      const p = chrome.runtime.sendMessage({
+        kind: "scroll",
+        scroll_pct: snap.scroll_pct,
+        scroll_ms: snap.scroll_ms,
+      });
+      if (p && typeof p.then === "function") p.then(() => {}, () => {});
+    } catch (_e) {
+      // chrome.runtime gone (context invalidated) — nothing to do.
+    }
+  }
+
+  function onScroll() {
+    if (!tracker) return;
+    const t = now();
+    if (t - lastSampleTs < SCROLL_THROTTLE_MS) return;
+    lastSampleTs = t;
+
+    const doc = document.documentElement || document.body || {};
+    tracker.onScroll(
+      window.scrollY || window.pageYOffset || 0,
+      window.innerHeight || 0,
+      doc.scrollHeight || 0,
+      t,
+    );
+
+    pendingReport = true;
+    // Low-rate running update while the user keeps scrolling.
+    if (t - lastReportTs >= REPORT_THROTTLE_MS) {
+      lastReportTs = t;
+      pendingReport = false;
+      report();
+    }
+  }
+
+  // Final flush when the page becomes hidden or is being unloaded, so the last
+  // burst of scrolling isn't lost between the throttle window and tab-leave.
+  function flush() {
+    if (!tracker) return;
+    pendingReport = false;
+    lastReportTs = now();
+    report();
+  }
+
+  // Load the pure tracker, then wire up DOM listeners. If the import fails the
+  // page is simply un-instrumented (telemetry is best-effort).
+  import(chrome.runtime.getURL("scroll_track.js"))
+    .then(({ createScrollTracker }) => {
+      tracker = createScrollTracker();
+      window.addEventListener("scroll", onScroll, { passive: true });
+      document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "hidden") flush();
+      });
+      window.addEventListener("pagehide", flush);
+    })
+    .catch(() => {
+      // Could not load the tracker module — leave the page un-instrumented.
+    });
+})();

--- a/scripts/collector/browser-ext/manifest.json
+++ b/scripts/collector/browser-ext/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Activity Collector (browser)",
-  "version": "1.1.0",
-  "description": "Self-instrumentation: reports active tab URL/title, active-duration, and focus/idle transitions to a localhost activity collector. Full URL capture, local-only.",
+  "version": "1.2.0",
+  "description": "Self-instrumentation: reports active tab URL/title, active-duration, scroll engagement, and focus/idle transitions to a localhost activity collector. Full URL capture, local-only.",
   "permissions": ["tabs", "webNavigation", "idle", "storage"],
   "host_permissions": ["http://127.0.0.1:8787/*"],
   "icons": {
@@ -14,5 +14,19 @@
   "background": {
     "service_worker": "service_worker.js",
     "type": "module"
-  }
+  },
+  "content_scripts": [
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "js": ["content_scroll.js"],
+      "run_at": "document_idle",
+      "all_frames": false
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["scroll_track.js"],
+      "matches": ["http://*/*", "https://*/*"]
+    }
+  ]
 }

--- a/scripts/collector/browser-ext/receiver.py
+++ b/scripts/collector/browser-ext/receiver.py
@@ -49,9 +49,10 @@ MAX_BODY = 64 * 1024  # a nav event is tiny; cap to avoid abuse.
 def event_to_fields(evt: dict, app_default: str) -> dict:
     """Map an incoming extension event dict → v1 emit fields.
 
-    `text` is the full URL (full-content choice). title/active_ms/state go into
-    payload JSON. `app` is the browser label (chromium/brave). Robust to missing
-    keys — anything absent becomes empty/0.
+    `text` is the full URL (full-content choice). title/active_ms/state plus
+    scroll engagement (scroll_pct/scroll_ms) go into payload JSON. `app` is the
+    browser label (chromium/brave). Robust to missing keys — anything absent
+    becomes empty/0.
     """
     kind = evt.get("kind") or "nav"
     if kind not in ("nav", "focus"):
@@ -60,6 +61,10 @@ def event_to_fields(evt: dict, app_default: str) -> dict:
         "title": evt.get("title", "") or "",
         "active_ms": int(evt.get("active_ms") or 0),
         "state": evt.get("state", "") or "",
+        # Scroll engagement for this page view (nav events). Default 0 when the
+        # extension didn't send them (focus events, older client, no scrolling).
+        "scroll_pct": int(evt.get("scroll_pct") or 0),
+        "scroll_ms": int(evt.get("scroll_ms") or 0),
     }
     if evt.get("ts"):
         payload["client_ts"] = evt["ts"]

--- a/scripts/collector/browser-ext/scroll_track.js
+++ b/scripts/collector/browser-ext/scroll_track.js
@@ -1,0 +1,70 @@
+// scroll_track.js — PURE scroll-engagement accounting for the browser collector.
+//
+// Tracks, for a SINGLE page view, two reading-engagement metrics from throttled
+// scroll samples:
+//
+//   scroll_pct — MAX reading depth reached, as a percent of the document:
+//                round(100 * (scrollY + innerHeight) / max(1, scrollHeight)),
+//                clamped 0–100. It only ever goes UP within a view — scrolling
+//                back toward the top does NOT lower it.
+//   scroll_ms  — accumulated ACTIVE-scroll time: the sum of "scrolling bursts".
+//                Consecutive throttled samples < GAP_MS apart extend the current
+//                burst (their inter-sample delta is added); a gap ≥ GAP_MS ends
+//                the burst, so idle reading time between scrolls is NOT counted.
+//
+// Mirrors active_time.js's design: PURE — no window/document/chrome, no
+// Date.now(); every method takes `now` (ms) from the caller, and state is plain
+// so content_scroll.js stays a thin DOM/chrome wrapper that's trivially
+// unit-testable in plain Node.
+
+// Gap (ms) at/above which two scroll samples are treated as separate bursts.
+export const GAP_MS = 1000;
+
+// Build a fresh per-page-view scroll tracker. `gapMs` overridable for tests.
+export function createScrollTracker(gapMs = GAP_MS) {
+  let maxPct = 0;     // max depth reached this view (monotonic)
+  let scrollMs = 0;   // accumulated active-scroll time across bursts
+  let lastTs = null;  // timestamp of the previous in-burst sample, or null
+
+  function clampPct(p) {
+    if (!Number.isFinite(p)) return 0;
+    if (p < 0) return 0;
+    if (p > 100) return 100;
+    return Math.round(p);
+  }
+
+  return {
+    // Feed one (throttled) scroll sample. `now` is a monotonic-ish ms timestamp.
+    // Returns the current snapshot for convenience.
+    onScroll(scrollY, innerHeight, scrollHeight, now) {
+      const denom = Math.max(1, Number(scrollHeight) || 0);
+      const reached =
+        ((Number(scrollY) || 0) + (Number(innerHeight) || 0)) / denom * 100;
+      const pct = clampPct(reached);
+      if (pct > maxPct) maxPct = pct;
+
+      if (Number.isFinite(now)) {
+        if (lastTs !== null) {
+          const delta = now - lastTs;
+          // Only accrue time for samples that continue the current burst; a gap
+          // ≥ gapMs (or a non-advancing/backwards clock) starts a new burst.
+          if (delta > 0 && delta < gapMs) scrollMs += delta;
+        }
+        lastTs = now;
+      }
+      return this.snapshot();
+    },
+
+    // Stable, non-mutating read of the current running metrics. Idempotent.
+    snapshot() {
+      return { scroll_pct: maxPct, scroll_ms: Math.round(scrollMs) };
+    },
+
+    // Clear all state for a fresh page view.
+    reset() {
+      maxPct = 0;
+      scrollMs = 0;
+      lastTs = null;
+    },
+  };
+}

--- a/scripts/collector/browser-ext/service_worker.js
+++ b/scripts/collector/browser-ext/service_worker.js
@@ -25,15 +25,21 @@ import * as AT from "./active_time.js";
 
 const ENDPOINT = "http://127.0.0.1:8787/event";
 const STORE_KEY = "active_state";
+// Per-tab scroll engagement, keyed by tab id, persisted across worker
+// suspension. Shape: { [tabId]: { scroll_pct, scroll_ms } }. Reported by the
+// content_scroll.js content script and folded into the tab's nav event on leave.
+const SCROLL_KEY = "scroll_by_tab";
 
 // --- pure payload builder (kept tiny + mirrored by the receiver test) ----- //
-export function buildEvent(kind, { url, title, active_ms, state }) {
+export function buildEvent(kind, { url, title, active_ms, state, scroll_pct, scroll_ms }) {
   return {
     kind, // "nav" | "focus"
     url: url || "",
     title: title || "",
     active_ms: Number.isFinite(active_ms) ? Math.max(0, Math.round(active_ms)) : 0,
     state: state || "", // for focus events: focused|blurred|idle|active|locked
+    scroll_pct: Number.isFinite(scroll_pct) ? Math.max(0, Math.min(100, Math.round(scroll_pct))) : 0,
+    scroll_ms: Number.isFinite(scroll_ms) ? Math.max(0, Math.round(scroll_ms)) : 0,
     ts: Date.now(),
   };
 }
@@ -68,6 +74,42 @@ async function setState(s) {
   await chrome.storage.session.set({ [STORE_KEY]: s });
 }
 
+// --- per-tab scroll engagement (from content_scroll.js) -------------------- //
+// Read/write the persisted {tabId: {scroll_pct, scroll_ms}} map. Always returns
+// a plain object — never throws on an empty / missing / corrupt blob.
+async function getScrollMap() {
+  try {
+    const o = await chrome.storage.session.get(SCROLL_KEY);
+    const m = o[SCROLL_KEY];
+    return m && typeof m === "object" ? m : {};
+  } catch {
+    return {};
+  }
+}
+
+// Store the latest metrics for a tab. content_scroll reports the running
+// (monotonic) snapshot, so last-writer-wins is correct.
+async function putScroll(tabId, scroll_pct, scroll_ms) {
+  if (!Number.isFinite(tabId)) return;
+  const m = await getScrollMap();
+  m[tabId] = {
+    scroll_pct: Number.isFinite(scroll_pct) ? Math.max(0, Math.min(100, Math.round(scroll_pct))) : 0,
+    scroll_ms: Number.isFinite(scroll_ms) ? Math.max(0, Math.round(scroll_ms)) : 0,
+  };
+  await chrome.storage.session.set({ [SCROLL_KEY]: m });
+}
+
+// Pop (read + clear) a tab's scroll metrics; defaults to zeros when absent.
+async function takeScroll(tabId) {
+  const m = await getScrollMap();
+  const v = (Number.isFinite(tabId) && m[tabId]) || { scroll_pct: 0, scroll_ms: 0 };
+  if (Number.isFinite(tabId) && tabId in m) {
+    delete m[tabId];
+    await chrome.storage.session.set({ [SCROLL_KEY]: m });
+  }
+  return { scroll_pct: v.scroll_pct || 0, scroll_ms: v.scroll_ms || 0 };
+}
+
 // Apply an accumulator transition (onActive/onBlur/onIdle) to the persisted
 // state in one read-modify-write. Keeps the active-time bookkeeping in sync
 // with focus/idle signals without emitting a nav event.
@@ -86,7 +128,10 @@ async function onTabChange({ url, title, tabId }) {
   const prev = await getState();
   const now = Date.now();
   const active_ms = AT.take(prev.accum, now);
-  await post(buildEvent("nav", { url, title, active_ms }));
+  // Fold in (and clear) the LEAVING tab's reading-engagement metrics. Robust to
+  // an empty map: a tab with no scroll data reports scroll_pct:0, scroll_ms:0.
+  const { scroll_pct, scroll_ms } = await takeScroll(prev.tabId);
+  await post(buildEvent("nav", { url, title, active_ms, scroll_pct, scroll_ms }));
   await setState({ tabId, url, title, accum: prev.accum });
 }
 
@@ -102,6 +147,22 @@ async function tabInfo(tabId) {
 // --- chrome event wiring --------------------------------------------------- //
 chrome.tabs.onActivated.addListener(async ({ tabId }) => {
   await onTabChange(await tabInfo(tabId));
+});
+
+// Scroll-engagement updates from content_scroll.js. Store the latest running
+// {scroll_pct, scroll_ms} per sender tab; it's folded into that tab's nav event
+// when the tab is left. Best-effort — never throws back into the page.
+chrome.runtime.onMessage.addListener((msg, sender) => {
+  if (!msg || msg.kind !== "scroll") return;
+  const tabId = sender && sender.tab ? sender.tab.id : undefined;
+  putScroll(tabId, msg.scroll_pct, msg.scroll_ms).catch(() => {});
+  // No async response; return nothing so the channel closes immediately.
+});
+
+// A closed tab can never emit a nav event, so its stored scroll metrics would
+// leak in the map forever — drop them on tab removal.
+chrome.tabs.onRemoved.addListener(async (tabId) => {
+  await takeScroll(tabId);
 });
 
 // Navigation within the active tab (committed top-frame loads).

--- a/scripts/collector/browser-ext/tests/scroll_track.test.mjs
+++ b/scripts/collector/browser-ext/tests/scroll_track.test.mjs
@@ -1,0 +1,89 @@
+// Pure, deterministic tests for scroll_track.js (the scroll-engagement
+// accumulator). No window/document/chrome, no Date.now() — all scroll geometry
+// and timestamps are passed in.
+//
+// Run: nix-shell -p nodejs --run "node --test scripts/collector/browser-ext/tests/"
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createScrollTracker, GAP_MS } from "../scroll_track.js";
+
+// (a) scroll_pct is the MAX depth reached — it goes UP, never back down when you
+// scroll back toward the top.
+test("scroll_pct tracks max depth and never decreases", () => {
+  const t = createScrollTracker();
+  // 1000px doc, 500px viewport. At top: (0+500)/1000 = 50%.
+  assert.equal(t.onScroll(0, 500, 1000, 100).scroll_pct, 50);
+  // Scroll to bottom: (500+500)/1000 = 100%.
+  assert.equal(t.onScroll(500, 500, 1000, 200).scroll_pct, 100);
+  // Scroll back up to top: depth READ stays at the max (100), not 50.
+  assert.equal(t.onScroll(0, 500, 1000, 300).scroll_pct, 100);
+});
+
+// scroll_pct rounds: (200+500)/1000 = 70%.
+test("scroll_pct rounds the depth percent", () => {
+  const t = createScrollTracker();
+  assert.equal(t.onScroll(200, 500, 1000, 0).scroll_pct, 70);
+  // 333/1000 viewport+offset → (250+333)/1000 = 58.3 → 58.
+  assert.equal(t.onScroll(250, 333, 1000, 250).scroll_pct, 70); // max stays 70
+  assert.equal(t.onScroll(750, 333, 1000, 500).scroll_pct, 100); // 1083 → clamp
+});
+
+// (b) depth clamps to 100 even when content+viewport overshoot scrollHeight.
+test("scroll_pct clamps to 100", () => {
+  const t = createScrollTracker();
+  // Overshoot: (900+500)/1000 = 140% → clamp to 100.
+  assert.equal(t.onScroll(900, 500, 1000, 0).scroll_pct, 100);
+  // A zero / tiny scrollHeight uses max(1, …) and still clamps sanely.
+  const t2 = createScrollTracker();
+  assert.equal(t2.onScroll(0, 0, 0, 0).scroll_pct, 0);
+  assert.equal(t2.onScroll(10, 5, 0, 1).scroll_pct, 100);
+});
+
+// (c) scroll_ms accumulates WITHIN a burst but NOT across a >=1s gap.
+test("scroll_ms accumulates within a burst, not across a gap", () => {
+  const t = createScrollTracker();
+  // Burst: samples 250ms apart → deltas count.
+  t.onScroll(0, 500, 2000, 0);      // first sample: no prior, +0
+  t.onScroll(50, 500, 2000, 250);   // +250
+  t.onScroll(100, 500, 2000, 500);  // +250  → 500 so far
+  assert.equal(t.snapshot().scroll_ms, 500);
+  // Gap >= GAP_MS ends the burst: this delta must NOT be added.
+  t.onScroll(150, 500, 2000, 500 + GAP_MS + 10); // gap 1010ms → +0
+  assert.equal(t.snapshot().scroll_ms, 500);
+  // New burst resumes accruing from the next in-window sample.
+  t.onScroll(200, 500, 2000, 500 + GAP_MS + 10 + 200); // +200
+  assert.equal(t.snapshot().scroll_ms, 700);
+});
+
+// A delta exactly at GAP_MS is treated as a gap (boundary is exclusive).
+test("scroll_ms treats a delta == GAP_MS as a new burst", () => {
+  const t = createScrollTracker();
+  t.onScroll(0, 500, 2000, 0);
+  t.onScroll(10, 500, 2000, GAP_MS); // delta == GAP_MS → not counted
+  assert.equal(t.snapshot().scroll_ms, 0);
+});
+
+// (d) snapshot() is stable/idempotent and reset() clears all state.
+test("snapshot is stable and reset clears state", () => {
+  const t = createScrollTracker();
+  t.onScroll(500, 500, 1000, 0);   // 100%
+  t.onScroll(500, 500, 1000, 250); // +250 ms
+  const a = t.snapshot();
+  const b = t.snapshot();
+  assert.deepEqual(a, b);                       // stable
+  assert.deepEqual(a, { scroll_pct: 100, scroll_ms: 250 });
+  t.reset();
+  assert.deepEqual(t.snapshot(), { scroll_pct: 0, scroll_ms: 0 });
+  // After reset, the next sample has no prior anchor (no carried-over delta).
+  t.onScroll(0, 500, 1000, 9999);
+  assert.deepEqual(t.snapshot(), { scroll_pct: 50, scroll_ms: 0 });
+});
+
+// A backwards / non-advancing clock never subtracts or adds negative time.
+test("scroll_ms ignores non-advancing timestamps", () => {
+  const t = createScrollTracker();
+  t.onScroll(0, 500, 2000, 1000);
+  t.onScroll(50, 500, 2000, 900);  // backwards → delta < 0, +0
+  t.onScroll(60, 500, 2000, 900);  // same ts → delta 0, +0
+  assert.equal(t.snapshot().scroll_ms, 0);
+});

--- a/scripts/collector/browser-ext/tests/test_receiver.py
+++ b/scripts/collector/browser-ext/tests/test_receiver.py
@@ -49,6 +49,26 @@ def test_unknown_kind_coerced_to_nav():
     assert f["kind"] == "nav"
 
 
+def test_event_to_fields_carries_scroll_metrics():
+    f = R.event_to_fields(
+        {"kind": "nav", "url": "https://x.test/a", "title": "T",
+         "active_ms": 10, "scroll_pct": 73, "scroll_ms": 4200},
+        "chromium",
+    )
+    pl = json.loads(f["payload"])
+    assert pl["scroll_pct"] == 73
+    assert pl["scroll_ms"] == 4200
+
+
+def test_event_to_fields_scroll_defaults_to_zero():
+    # An event WITHOUT scroll metrics (focus event / older client) still maps,
+    # defaulting both to 0.
+    f = R.event_to_fields({"kind": "nav", "url": "https://x.test/a"}, "chromium")
+    pl = json.loads(f["payload"])
+    assert pl["scroll_pct"] == 0
+    assert pl["scroll_ms"] == 0
+
+
 def test_fields_roundtrip_through_parse_line():
     f = R.event_to_fields(
         {"kind": "nav", "url": "https://site/x", "title": "T", "active_ms": 5},
@@ -106,6 +126,42 @@ def test_post_writes_spool_record(tmp_path):
     pl = json.loads(ev["payload"])
     assert pl["title"] == 'weird "quoted"\ttab\nnewline 你好'
     assert pl["active_ms"] == 4200
+
+
+def test_post_scroll_metrics_land_in_spool(tmp_path):
+    spool = tmp_path / "spool"
+    srv = _serve(spool)
+    try:
+        status, _ = _post(srv, {
+            "kind": "nav",
+            "url": "https://example.test/article",
+            "title": "Long read",
+            "active_ms": 90000,
+            "scroll_pct": 88,
+            "scroll_ms": 12500,
+        })
+        assert status == 200
+    finally:
+        srv.shutdown()
+        srv.server_close()
+    ev = C.parse_line((spool / "current.log").read_text().splitlines()[0])
+    pl = json.loads(ev["payload"])
+    assert pl["scroll_pct"] == 88
+    assert pl["scroll_ms"] == 12500
+
+
+def test_post_without_scroll_metrics_defaults_zero(tmp_path):
+    spool = tmp_path / "spool"
+    srv = _serve(spool)
+    try:
+        _post(srv, {"kind": "nav", "url": "https://example.test/x", "title": "t"})
+    finally:
+        srv.shutdown()
+        srv.server_close()
+    ev = C.parse_line((spool / "current.log").read_text().splitlines()[0])
+    pl = json.loads(ev["payload"])
+    assert pl["scroll_pct"] == 0
+    assert pl["scroll_ms"] == 0
 
 
 def test_post_arbitrary_url_content_survives(tmp_path):


### PR DESCRIPTION
Add scroll-depth + active-scroll-time telemetry to the MV3 browser-activity collector, folded into the existing `nav` event (no high-volume per-scroll stream).

## Metrics (per page view, on the `nav` event for the LEAVING tab)
- **`scroll_pct`** — MAX reading depth reached: `round(100*(scrollY+innerHeight)/max(1, scrollHeight))`, clamped 0–100, monotonic within a view (scrolling back up does not lower it).
- **`scroll_ms`** — accumulated ACTIVE-scroll time: sum of scrolling bursts, where consecutive throttled samples <1s apart extend the current burst; idle reading time between scrolls is not counted.

## Changes
- **`scroll_track.js`** (new) — PURE accumulator: no `window`/`document`/`chrome`, no `Date.now()` (caller passes `now`); `onScroll/snapshot/reset`. Mirrors `active_time.js`'s design so it's unit-testable in plain Node.
- **`content_scroll.js`** (new) — thin DOM/chrome wiring: throttled (~250ms) `scroll` sampling → tracker → throttled (~2s) `chrome.runtime.sendMessage` updates + a final flush on `visibilitychange`(hidden)/`pagehide`. Best-effort; swallows errors (SW may be asleep). Loads the pure module via dynamic `import()` (MV3 declarative content scripts are NOT ES modules; `scroll_track.js` is in `web_accessible_resources`).
- **`service_worker.js`** — `chrome.runtime.onMessage` stores latest `{scroll_pct,scroll_ms}` per `sender.tab.id` in `chrome.storage.session`; `onTabChange` folds the LEAVING tab's metrics into its `nav` event then clears them; `onRemoved` drops stale entries for closed tabs. `buildEvent` carries both through (default 0; clamped). Robust to an empty map.
- **`manifest.json`** — `content_scripts` injecting `content_scroll.js` into `["http://*/*","https://*/*"]` (`run_at: document_idle`, `all_frames: false`); `web_accessible_resources` for `scroll_track.js`; **version 1.1.0 → 1.2.0**.
- **`receiver.py`** — `event_to_fields` carries `scroll_pct`/`scroll_ms` into the `payload` (default 0, robust to missing keys).

## ⚠️ Permission broadening
The `content_scripts` entry broadens the extension's host access from `127.0.0.1:8787` only to **ALL `http(s)://` sites** (required to observe scroll on every page). Intended and expected. The content script only reads scroll geometry, never page content, and nothing leaves localhost (the daemon gates shipping).

## Design note (storage choice)
Per-tab scroll state uses `chrome.storage.session` (not an in-memory map) to match the rest of the worker and survive MV3 worker suspension between the last scroll report and tab-leave. `onTabRemoved` prevents map growth from closed tabs.

## Tests
- `tests/scroll_track.test.mjs` (Node `node:test`): max-depth monotonicity, 0–100 clamp, burst accrual + the `>=1s` gap rule (incl. boundary + backwards-clock), `snapshot()` stability, `reset()`.
- `tests/test_receiver.py`: scroll metrics map through `event_to_fields` and POST→spool round-trip; absent metrics default to 0. Existing receiver + `active_time` tests unchanged.

**JS 18 pass** (8 new + 10 existing), **Python 12 pass** (4 new + 8 existing). `manifest.json` parses; `nix-instantiate --parse nix/home.nix` clean (no nix change).

NOT verified: load-unpacked in a real browser (content-script injection, SW message→nav fold) — MV3 SWs aren't reliably driveable headlessly; manual step per the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)