### PR TITLE
fix(browser-ext): make scroll capture actually work (scroll_pct stuck at 0)

### DIFF
--- a/scripts/collector/browser-ext/README.md
+++ b/scripts/collector/browser-ext/README.md
@@ -12,10 +12,17 @@ is gated on an authenticated ClickHouse.
 ## Components
 - `manifest.json` — MV3 manifest. Permissions: `tabs`, `webNavigation`, `idle`,
   `storage`. Host permission for `http://127.0.0.1:8787/*` only. **A
-  `content_scripts` entry injects `content_scroll.js` into all `http(s)://*`
-  pages** for scroll capture — this broadens the extension's host access to ALL
-  sites (intended; the script only reads scroll geometry and never touches page
-  content, and nothing leaves localhost).
+  `content_scripts` entry injects TWO scripts — `scroll_track.js` then
+  `content_scroll.js`, in that order — into all `http(s)://*` pages** for scroll
+  capture. **Load order matters:** content scripts of the same extension share
+  ONE isolated-world global scope, so the first script (`scroll_track.js`)
+  publishes its factory on `globalThis.__activityScrollTracker` and the second
+  (`content_scroll.js`) reads it synchronously — no dynamic `import()` and no
+  `web_accessible_resources`. (The old dynamic-import-of-a-web-accessible-resource
+  path was CSP-fragile and failed silently, leaving `scroll_pct` stuck at 0.)
+  Injecting content scripts broadens host access to ALL sites (intended; the
+  scripts only read scroll geometry, never page content, and nothing leaves
+  localhost).
 - `service_worker.js` — background worker. Listens on `chrome.tabs.onActivated`,
   `chrome.webNavigation.onCommitted`, `chrome.tabs.onUpdated` (title),
   `chrome.windows.onFocusChanged`, `chrome.idle.onStateChanged`,
@@ -23,14 +30,26 @@ is gated on an authenticated ClickHouse.
   Computes active-duration across tab switches and stores per-tab scroll metrics
   (both persisted in `chrome.storage.session` so they survive MV3 worker
   suspension); folds the LEAVING tab's scroll metrics into its `nav` event.
-- `content_scroll.js` — content script (all http/https pages). Thin DOM/chrome
-  wiring: throttled `scroll` listener → pure tracker → throttled
-  `chrome.runtime.sendMessage` updates + a final flush on
-  `visibilitychange`/`pagehide`. Best-effort; swallows errors when the SW is
-  asleep.
-- `scroll_track.js` — PURE scroll-engagement accumulator (no `window`/`document`/
-  `chrome`, no `Date.now()`; loaded by the content script via dynamic `import()`
-  and listed in `web_accessible_resources`). Unit-tested in plain Node.
+- `content_scroll.js` — content script (all http/https pages), injected SECOND.
+  Thin DOM/chrome wiring: a **capture-phase, document-level** `scroll` listener
+  (`document.addEventListener("scroll", …, { capture: true, passive: true })`)
+  so scroll from ANY element is caught — including SPA inner containers
+  (Discord/Gmail/Grafana) that scroll a `div` rather than the document and never
+  bubble a `window`-level scroll event. It derives `(pos, viewport, total)` from
+  the scrolled element via the pure `deriveScrollGeometry` helper, feeds throttled
+  samples to the tracker (which keeps the MAX depth across all qualifying
+  scrollers this view), and sends throttled `chrome.runtime.sendMessage` updates
+  + a final flush on `visibilitychange`/`pagehide`. Best-effort; swallows errors
+  when the SW is asleep.
+- `scroll_track.js` — PURE scroll accounting, injected FIRST as a CLASSIC
+  (non-ESM) script. No `window`/`document`/`chrome`, no `Date.now()`; no
+  top-level `export`/`import`. It publishes its factory on the shared isolated-
+  world global (`globalThis.__activityScrollTracker`) plus a pure
+  `deriveScrollGeometry(target, doc, win)` helper and the `MIN_SCROLLABLE_RATIO`
+  trivial-scroller threshold (1.3 — an inner container must overflow its own
+  viewport by ≥1.3× to count, so tiny dropdowns/menus don't report 100% depth).
+  Unit-tested in plain Node (the test loads it for its side effect and reads the
+  global).
 - `receiver.py` — stdlib `http.server` bound to `127.0.0.1:8787`. Accepts
   `POST /event`, maps the JSON to a v1 spool record, appends to the spool.
   Shares `../keylog/spool_emit.py` (single source of truth for the line format).
@@ -97,8 +116,10 @@ To point at a TEST spool while validating:
   `nix-shell -p nodejs --run "node --test 'scripts/collector/browser-ext/tests/**/*.test.mjs'"`.
 - Scroll engagement: the PURE `scroll_track.js` (same no-`chrome`/no-`Date.now()`
   discipline) is unit-tested in `tests/scroll_track.test.mjs` (max-depth
-  monotonicity, 0–100 clamp, burst accrual with the >1s gap rule, snapshot/reset).
-  `content_scroll.js` (DOM/chrome wiring) and the SW message→nav fold are NOT
+  monotonicity, 0–100 clamp, burst accrual with the >1s gap rule, snapshot/reset,
+  the classic-script global-publish, and `deriveScrollGeometry`'s document vs
+  inner-container branches + the trivial-scroller guard threshold). The remaining
+  `content_scroll.js` DOM/listener wiring and the SW message→nav fold are NOT
   exercised headlessly — verify in the load-unpacked step below.
 - The end-to-end **load-unpacked in a real browser** step is a MANUAL step (MV3
   service workers are not reliably driveable headlessly). Follow "Load unpacked"

--- a/scripts/collector/browser-ext/content_scroll.js
+++ b/scripts/collector/browser-ext/content_scroll.js
@@ -1,26 +1,34 @@
 // content_scroll.js — thin DOM/chrome wiring around the pure scroll_track.js.
 //
 // Injected (as a CLASSIC content script — MV3 declarative content scripts are
-// not ES modules) into all http/https pages. It dynamically imports the pure
-// tracker from the extension package (scroll_track.js is listed in
-// web_accessible_resources so the page-world import URL resolves), watches
-// `scroll`, feeds throttled samples into the tracker, and reports the running
-// {scroll_pct, scroll_ms} to the service worker so the SW can fold those
-// reading-engagement metrics into the page view's `nav` event.
+// not ES modules) into all http/https pages. The pure tracker is injected as a
+// SIBLING content script (scroll_track.js, listed FIRST in manifest's `js` array)
+// which publishes its factory on the shared isolated-world global as
+// `globalThis.__activityScrollTracker`. Content scripts of the same extension
+// share one isolated-world global, so we read the factory directly — NO dynamic
+// import / web_accessible_resources (that path was CSP-fragile and failed
+// silently, leaving scroll_pct stuck at 0).
+//
+// We listen at the DOCUMENT level in the CAPTURE phase so scroll from ANY
+// element bubbles to us — including SPA inner containers (Discord/Gmail/Grafana)
+// that scroll a div rather than the document. We feed throttled samples into the
+// tracker and report the running {scroll_pct, scroll_ms} to the service worker
+// so the SW can fold those reading-engagement metrics into the page view's `nav`
+// event.
 //
 // We deliberately DO NOT emit a per-scroll event stream — only a low-rate
 // running update plus a final flush when the page is hidden/unloaded.
 //
-// Best-effort throughout: the dynamic import or chrome.runtime.sendMessage may
-// fail because the MV3 worker is asleep or the page/extension context is being
-// torn down — we swallow every error; the SW picks up a later update or the
-// leaving tab simply reports 0.
+// Best-effort throughout: chrome.runtime.sendMessage may fail because the MV3
+// worker is asleep or the page/extension context is being torn down — we swallow
+// every error; the SW picks up a later update or the leaving tab simply reports 0.
 
 (() => {
   const SCROLL_THROTTLE_MS = 250; // min spacing between processed scroll samples
   const REPORT_THROTTLE_MS = 2000; // min spacing between sendMessage updates
 
   let tracker = null;
+  let deriveScrollGeometry = null; // pure geometry helper from the sibling module
   let lastSampleTs = 0;
   let lastReportTs = 0;
   let pendingReport = false;
@@ -47,19 +55,21 @@
     }
   }
 
-  function onScroll() {
+  function onScroll(event) {
     if (!tracker) return;
     const t = now();
     if (t - lastSampleTs < SCROLL_THROTTLE_MS) return;
+
+    // Derive (pos, viewport, total) from whatever element actually scrolled —
+    // document root OR an SPA inner container — using the pure helper the
+    // sibling tracker module published (single source of the trivial-scroller
+    // threshold). null = trivial/unknown scroller → don't sample or throttle.
+    const geo = deriveScrollGeometry(event && event.target, document, window);
+    if (!geo) return;
     lastSampleTs = t;
 
-    const doc = document.documentElement || document.body || {};
-    tracker.onScroll(
-      window.scrollY || window.pageYOffset || 0,
-      window.innerHeight || 0,
-      doc.scrollHeight || 0,
-      t,
-    );
+    // tracker keeps the MAX depth across all qualifying scrollers this view.
+    tracker.onScroll(geo.pos, geo.viewport, geo.total, t);
 
     pendingReport = true;
     // Low-rate running update while the user keeps scrolling.
@@ -79,18 +89,27 @@
     report();
   }
 
-  // Load the pure tracker, then wire up DOM listeners. If the import fails the
-  // page is simply un-instrumented (telemetry is best-effort).
-  import(chrome.runtime.getURL("scroll_track.js"))
-    .then(({ createScrollTracker }) => {
-      tracker = createScrollTracker();
-      window.addEventListener("scroll", onScroll, { passive: true });
-      document.addEventListener("visibilitychange", () => {
-        if (document.visibilityState === "hidden") flush();
-      });
-      window.addEventListener("pagehide", flush);
-    })
-    .catch(() => {
-      // Could not load the tracker module — leave the page un-instrumented.
+  // Build the tracker synchronously from the shared global the sibling content
+  // script (scroll_track.js) published. If it's missing (load order broke, or
+  // the page blocked injection), no-op — the page is simply un-instrumented.
+  const createScrollTracker = globalThis.__activityScrollTracker;
+  const derive =
+    createScrollTracker && createScrollTracker.deriveScrollGeometry;
+  if (
+    typeof createScrollTracker === "function" &&
+    typeof derive === "function"
+  ) {
+    tracker = createScrollTracker();
+    deriveScrollGeometry = derive;
+    // Capture-phase, document-level: catches scroll from ANY element, including
+    // SPA inner containers that don't bubble a window-level scroll event.
+    document.addEventListener("scroll", onScroll, {
+      capture: true,
+      passive: true,
     });
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState === "hidden") flush();
+    });
+    window.addEventListener("pagehide", flush);
+  }
 })();

--- a/scripts/collector/browser-ext/manifest.json
+++ b/scripts/collector/browser-ext/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Activity Collector (browser)",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Self-instrumentation: reports active tab URL/title, active-duration, scroll engagement, and focus/idle transitions to a localhost activity collector. Full URL capture, local-only.",
   "permissions": ["tabs", "webNavigation", "idle", "storage"],
   "host_permissions": ["http://127.0.0.1:8787/*"],
@@ -18,15 +18,9 @@
   "content_scripts": [
     {
       "matches": ["http://*/*", "https://*/*"],
-      "js": ["content_scroll.js"],
+      "js": ["scroll_track.js", "content_scroll.js"],
       "run_at": "document_idle",
       "all_frames": false
-    }
-  ],
-  "web_accessible_resources": [
-    {
-      "resources": ["scroll_track.js"],
-      "matches": ["http://*/*", "https://*/*"]
     }
   ]
 }

--- a/scripts/collector/browser-ext/scroll_track.js
+++ b/scripts/collector/browser-ext/scroll_track.js
@@ -16,55 +16,119 @@
 // Date.now(); every method takes `now` (ms) from the caller, and state is plain
 // so content_scroll.js stays a thin DOM/chrome wrapper that's trivially
 // unit-testable in plain Node.
+//
+// LOADING MODEL: this is a CLASSIC (non-ESM) script. It is injected as the FIRST
+// content script (before content_scroll.js) and publishes its factory on the
+// shared isolated-world global as `globalThis.__activityScrollTracker`. There is
+// NO top-level `export`/`import` — dynamic import of a web-accessible resource
+// from a content script is CSP-fragile and was failing silently (the tracker was
+// never created → scroll_pct stuck at 0). content_scroll.js reads the global
+// directly. The test loads this file for its side effect and reads the global.
 
-// Gap (ms) at/above which two scroll samples are treated as separate bursts.
-export const GAP_MS = 1000;
+(function () {
+  "use strict";
 
-// Build a fresh per-page-view scroll tracker. `gapMs` overridable for tests.
-export function createScrollTracker(gapMs = GAP_MS) {
-  let maxPct = 0;     // max depth reached this view (monotonic)
-  let scrollMs = 0;   // accumulated active-scroll time across bursts
-  let lastTs = null;  // timestamp of the previous in-burst sample, or null
+  // Gap (ms) at/above which two scroll samples are treated as separate bursts.
+  const GAP_MS = 1000;
 
-  function clampPct(p) {
-    if (!Number.isFinite(p)) return 0;
-    if (p < 0) return 0;
-    if (p > 100) return 100;
-    return Math.round(p);
+  // Build a fresh per-page-view scroll tracker. `gapMs` overridable for tests.
+  function createScrollTracker(gapMs = GAP_MS) {
+    let maxPct = 0;     // max depth reached this view (monotonic)
+    let scrollMs = 0;   // accumulated active-scroll time across bursts
+    let lastTs = null;  // timestamp of the previous in-burst sample, or null
+
+    function clampPct(p) {
+      if (!Number.isFinite(p)) return 0;
+      if (p < 0) return 0;
+      if (p > 100) return 100;
+      return Math.round(p);
+    }
+
+    return {
+      // Feed one (throttled) scroll sample. `now` is a monotonic-ish ms timestamp.
+      // Returns the current snapshot for convenience.
+      onScroll(scrollY, innerHeight, scrollHeight, now) {
+        const denom = Math.max(1, Number(scrollHeight) || 0);
+        const reached =
+          ((Number(scrollY) || 0) + (Number(innerHeight) || 0)) / denom * 100;
+        const pct = clampPct(reached);
+        if (pct > maxPct) maxPct = pct;
+
+        if (Number.isFinite(now)) {
+          if (lastTs !== null) {
+            const delta = now - lastTs;
+            // Only accrue time for samples that continue the current burst; a gap
+            // ≥ gapMs (or a non-advancing/backwards clock) starts a new burst.
+            if (delta > 0 && delta < gapMs) scrollMs += delta;
+          }
+          lastTs = now;
+        }
+        return this.snapshot();
+      },
+
+      // Stable, non-mutating read of the current running metrics. Idempotent.
+      snapshot() {
+        return { scroll_pct: maxPct, scroll_ms: Math.round(scrollMs) };
+      },
+
+      // Clear all state for a fresh page view.
+      reset() {
+        maxPct = 0;
+        scrollMs = 0;
+        lastTs = null;
+      },
+    };
   }
 
-  return {
-    // Feed one (throttled) scroll sample. `now` is a monotonic-ish ms timestamp.
-    // Returns the current snapshot for convenience.
-    onScroll(scrollY, innerHeight, scrollHeight, now) {
-      const denom = Math.max(1, Number(scrollHeight) || 0);
-      const reached =
-        ((Number(scrollY) || 0) + (Number(innerHeight) || 0)) / denom * 100;
-      const pct = clampPct(reached);
-      if (pct > maxPct) maxPct = pct;
+  // Minimum overflow ratio (scrollHeight / clientHeight) for an inner container
+  // to count as a real scroller. Below this it's a trivial overflow — a tiny
+  // dropdown / autocomplete menu that would otherwise report ~100% depth the
+  // instant it scrolls a few pixels. Kept here as the single source of truth.
+  const MIN_SCROLLABLE_RATIO = 1.3;
 
-      if (Number.isFinite(now)) {
-        if (lastTs !== null) {
-          const delta = now - lastTs;
-          // Only accrue time for samples that continue the current burst; a gap
-          // ≥ gapMs (or a non-advancing/backwards clock) starts a new burst.
-          if (delta > 0 && delta < gapMs) scrollMs += delta;
-        }
-        lastTs = now;
-      }
-      return this.snapshot();
-    },
+  // PURE: derive (pos, viewport, total) for whatever element actually scrolled.
+  // `target` is a scroll event's target; `doc`/`win` are the document and window
+  // (injected so this stays testable without a real DOM). Returns null when the
+  // scroller is the *document* (handled by the documentEl branch) is unreadable,
+  // or when an inner container is a trivial overflow that shouldn't be sampled.
+  //
+  //   - Document scroll: target is the document / <html> / <body>. Use the
+  //     scrolling element's scrollTop/scrollHeight and the window's innerHeight.
+  //   - Inner-container scroll: read the element's own scrollTop / clientHeight /
+  //     scrollHeight, after the trivial-scroller guard.
+  function deriveScrollGeometry(target, doc, win, minRatio = MIN_SCROLLABLE_RATIO) {
+    if (!doc) return null;
+    const documentEl = doc.documentElement || null;
+    const bodyEl = doc.body || null;
 
-    // Stable, non-mutating read of the current running metrics. Idempotent.
-    snapshot() {
-      return { scroll_pct: maxPct, scroll_ms: Math.round(scrollMs) };
-    },
+    if (target === doc || target === documentEl || target === bodyEl) {
+      const el = doc.scrollingElement || documentEl || {};
+      return {
+        pos: el.scrollTop || 0,
+        viewport: (win && win.innerHeight) || 0,
+        total: el.scrollHeight || 0,
+      };
+    }
 
-    // Clear all state for a fresh page view.
-    reset() {
-      maxPct = 0;
-      scrollMs = 0;
-      lastTs = null;
-    },
-  };
-}
+    if (target && typeof target.scrollTop === "number") {
+      const viewport = target.clientHeight || 0;
+      const total = target.scrollHeight || 0;
+      // Trivial-scroller guard: require the element to overflow its own
+      // viewport by at least `minRatio`× before it counts as deep reading.
+      if (viewport <= 0 || total < viewport * minRatio) return null;
+      return { pos: target.scrollTop || 0, viewport, total };
+    }
+
+    return null;
+  }
+
+  // Expose the GAP_MS constant + the threshold + the pure geometry helper on the
+  // factory so callers/tests can read them without separate ESM named exports.
+  createScrollTracker.GAP_MS = GAP_MS;
+  createScrollTracker.MIN_SCROLLABLE_RATIO = MIN_SCROLLABLE_RATIO;
+  createScrollTracker.deriveScrollGeometry = deriveScrollGeometry;
+
+  // Publish on the shared isolated-world global. Idempotent: if both content
+  // scripts somehow run twice we just re-point at the same factory.
+  globalThis.__activityScrollTracker = createScrollTracker;
+})();

--- a/scripts/collector/browser-ext/tests/scroll_track.test.mjs
+++ b/scripts/collector/browser-ext/tests/scroll_track.test.mjs
@@ -5,7 +5,20 @@
 // Run: nix-shell -p nodejs --run "node --test scripts/collector/browser-ext/tests/"
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createScrollTracker, GAP_MS } from "../scroll_track.js";
+
+// scroll_track.js is now a CLASSIC (non-ESM) content script: it assigns its
+// factory to globalThis.__activityScrollTracker as a side effect (no exports).
+// Load it for that side effect, then read the global — exactly how the sibling
+// content_scroll.js content script consumes it in the shared isolated world.
+await import("../scroll_track.js");
+const createScrollTracker = globalThis.__activityScrollTracker;
+const GAP_MS = createScrollTracker.GAP_MS;
+
+// The classic script must have published the factory on the global.
+test("scroll_track publishes its factory on the global", () => {
+  assert.equal(typeof globalThis.__activityScrollTracker, "function");
+  assert.equal(typeof GAP_MS, "number");
+});
 
 // (a) scroll_pct is the MAX depth reached — it goes UP, never back down when you
 // scroll back toward the top.
@@ -86,4 +99,95 @@ test("scroll_ms ignores non-advancing timestamps", () => {
   t.onScroll(50, 500, 2000, 900);  // backwards → delta < 0, +0
   t.onScroll(60, 500, 2000, 900);  // same ts → delta 0, +0
   assert.equal(t.snapshot().scroll_ms, 0);
+});
+
+// ---------------------------------------------------------------------------
+// deriveScrollGeometry — pure element→geometry derivation used by the content
+// script's capture-phase document scroll listener (root cause #2). Tested with
+// minimal mock document/window objects (no real DOM).
+// ---------------------------------------------------------------------------
+const deriveScrollGeometry = createScrollTracker.deriveScrollGeometry;
+const MIN_RATIO = createScrollTracker.MIN_SCROLLABLE_RATIO;
+
+// Build a fake document whose scrollingElement carries the given geometry.
+function mockDoc(scrollTop, scrollHeight) {
+  const documentElement = { scrollTop: 0, scrollHeight: 0, clientHeight: 0 };
+  const body = {};
+  const doc = {
+    documentElement,
+    body,
+    scrollingElement: { scrollTop, scrollHeight },
+  };
+  return doc;
+}
+
+test("deriveScrollGeometry reads document scroll via scrollingElement + innerHeight", () => {
+  const doc = mockDoc(800, 5000);
+  const win = { innerHeight: 900 };
+  // target === document → document-scroll branch.
+  assert.deepEqual(deriveScrollGeometry(doc, doc, win), {
+    pos: 800,
+    viewport: 900,
+    total: 5000,
+  });
+  // target === <html> and === <body> resolve through the same branch.
+  assert.deepEqual(deriveScrollGeometry(doc.documentElement, doc, win), {
+    pos: 800,
+    viewport: 900,
+    total: 5000,
+  });
+  assert.deepEqual(deriveScrollGeometry(doc.body, doc, win), {
+    pos: 800,
+    viewport: 900,
+    total: 5000,
+  });
+});
+
+test("deriveScrollGeometry reads an inner container's own geometry", () => {
+  const doc = mockDoc(0, 0);
+  const win = { innerHeight: 900 };
+  // A real SPA inner scroller (e.g. Discord message list): tall content in a
+  // short viewport. 300px viewport / 3000px content → qualifies (ratio 10).
+  const el = { scrollTop: 1200, clientHeight: 300, scrollHeight: 3000 };
+  assert.deepEqual(deriveScrollGeometry(el, doc, win), {
+    pos: 1200,
+    viewport: 300,
+    total: 3000,
+  });
+});
+
+test("deriveScrollGeometry guards against trivial scrollers (tiny dropdowns)", () => {
+  const doc = mockDoc(0, 0);
+  const win = { innerHeight: 900 };
+  // Just below the ratio threshold → ignored (returns null).
+  const tiny = {
+    scrollTop: 5,
+    clientHeight: 100,
+    scrollHeight: Math.floor(100 * MIN_RATIO) - 1, // < 1.3× → trivial
+  };
+  assert.equal(deriveScrollGeometry(tiny, doc, win), null);
+
+  // At/above the threshold → qualifies.
+  const ok = {
+    scrollTop: 5,
+    clientHeight: 100,
+    scrollHeight: Math.ceil(100 * MIN_RATIO) + 1, // ≥ 1.3× → real scroller
+  };
+  assert.deepEqual(deriveScrollGeometry(ok, doc, win), {
+    pos: 5,
+    viewport: 100,
+    total: Math.ceil(100 * MIN_RATIO) + 1,
+  });
+
+  // A zero-height element can never qualify (avoids divide-by-trivial).
+  const zero = { scrollTop: 0, clientHeight: 0, scrollHeight: 1000 };
+  assert.equal(deriveScrollGeometry(zero, doc, win), null);
+});
+
+test("deriveScrollGeometry returns null for an unknown / non-scrollable target", () => {
+  const doc = mockDoc(0, 0);
+  const win = { innerHeight: 900 };
+  assert.equal(deriveScrollGeometry({}, doc, win), null); // no scrollTop number
+  assert.equal(deriveScrollGeometry(null, doc, win), null);
+  assert.equal(deriveScrollGeometry(doc, doc, undefined).viewport, 0); // no win → 0 viewport
 });


### PR DESCRIPTION
## Problem
Live verification showed the browser extension's `scroll_pct` was **always 0** — even on a plain document-scroll page (Wikipedia). The content script wasn't capturing scroll at all. Two root causes.

## Root cause 1 — dynamic import failed silently (primary)
`content_scroll.js` loaded the tracker via `import(chrome.runtime.getURL("scroll_track.js"))`. Dynamic import of a web-accessible resource from a content script is CSP-fragile; the `.catch()` swallowed the failure, so the tracker was never created.

**Fix:** global-sharing pattern, no dynamic import.
- `scroll_track.js` is now a **classic (non-ESM)** script that publishes its factory on `globalThis.__activityScrollTracker` (no top-level `export`/`import`).
- `manifest.json` injects **both** scripts as content scripts, in order: `["scroll_track.js", "content_scroll.js"]`. Same-extension content scripts share one isolated-world global, so `content_scroll.js` reads the global synchronously.
- **`web_accessible_resources` removed** (no longer needed). Version bumped to **1.3.0**.
- `content_scroll.js` creates the tracker synchronously from the global; no-ops if the global is missing.

## Root cause 2 — only document scroll observed (SPA inner-scroll missed)
The listener was on `window`, so SPAs that scroll an inner container (Discord/Gmail/Grafana) never registered.

**Fix:** capture-phase, document-level listener — `document.addEventListener("scroll", onScroll, { capture: true, passive: true })`.
- Element derivation: document/`<html>`/`<body>` target → `document.scrollingElement` + `window.innerHeight`; otherwise the target element's `scrollTop`/`clientHeight`/`scrollHeight`.
- **Trivial-scroller guard:** ignore elements whose `scrollHeight < 1.3× clientHeight` (tiny dropdowns/menus shouldn't report 100% depth). Tracker keeps the MAX depth across qualifying scrollers per view.
- The element→geometry derivation + guard is a pure `deriveScrollGeometry(target, doc, win)` on the shared module, so it's unit-tested without a real DOM.

## Tests / checks (all green)
- `node --test` — **23 pass** (existing scroll_track assertions kept + global-publish + `deriveScrollGeometry` document/inner-container/guard cases; `active_time.test.mjs` still green).
- `pytest tests/` — **12 pass** (receiver scroll_pct/scroll_ms mapping unaffected).
- `manifest.json` parses; `nix-instantiate --parse nix/home.nix` clean; `node --check` clean on both JS files.

The remaining `content_scroll.js` DOM/listener wiring and the SW message→nav fold are still manual (load-unpacked) — MV3 service workers aren't reliably driveable headlessly. The `nav` fold via `putScroll`/`takeScroll` in `service_worker.js` was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)