### PR TITLE
feat(validation): retire broken active_ms, add i3-derived attention guard

### DIFF
--- a/scripts/validation/README.md
+++ b/scripts/validation/README.md
@@ -36,10 +36,40 @@ validate.py     — runner (invariants + reconcile always; replay+assert with --
   asserts each equals the replay's expected value (counts, active_ms, switches,
   deep-work, **timezone hour-bucket**).
 - **`invariants.py`** — SQL sanity checks over all rows: no future ts (with a
-  tz-slack window — see below), `duration_ms >= 0`, active_ms/duration_ms within
-  a plausible cap, per-(host,hour) active time ≤ 60min, only expected
-  host/source values, ts not clock-skewed-ancient. Surfaces ingestion lag as a
-  collector-health proxy.
+  tz-slack window — see below), `duration_ms >= 0`, `duration_ms` within the 24h
+  garbage cap, only expected host/source values, ts not clock-skewed-ancient,
+  and the **`derived_attention_consistent`** check (see *Retired metric* below).
+  Surfaces ingestion lag as a collector-health proxy.
+
+### Retired metric: browser extension `active_ms`
+The browser extension's per-page `active_ms` was **structurally wrong on the i3
+host** and has been **retired** (no longer trusted or displayed):
+`chrome.idle` measures *system-wide* input — so typing in the terminal kept the
+browser counted as "active" — and `chrome.windows.onFocusChanged` blur is
+unreliable on i3. It counted time-spent-in-OTHER-apps as browser engagement (a
+10-min stretch focused entirely on Alacritty logged as ~60 min of Brave
+"active"; 2026-06-27 11:00–12:00 UTC read ~144 min "active" against only 12.4 min
+of actual i3 Brave focus). Because the metric is **retired, not hidden**, its two
+guards — `active_ms_capped` and `per_host_hour_active_cap` — and their constants
+(`ACTIVE_MS_CAP`, `ACTIVE_CAP_WINDOW_HOURS`) were **removed**: there is nothing
+to guard once the metric isn't trusted/shown.
+
+**Replacement — true per-domain browser attention (i3-derived):** computed
+downstream by intersecting **i3 Brave-focused intervals** (the OS-level truth of
+when the browser actually had focus; dwell-capped at 30 min, matching the
+dashboard's i3-dwell panels) with the **active-tab domain timeline** from
+browser `nav` events (`domain(text)` from each nav's ts to the next nav's ts),
+summing the overlap per domain. Brave only (the extension runs only in Brave;
+Chromium focus has no domain data → excluded); laptop-only. This powers the
+dashboard panel **"Browser attention by domain (i3-derived, s)"**.
+
+The new **`derived_attention_consistent`** invariant is its deterministic guard:
+over a trailing 48h window it asserts the derived metric's two structural bounds
+(which the broken `active_ms` violated): (1) sum-per-domain attention ≤ total i3
+Brave dwell (+2% tol) — an intersection is a subset of the i3 Brave intervals —
+and (2) no single domain exceeds wall-clock. Vacuously PASSes on a host with no
+GUI data. The extension still emits the vestigial `active_ms` (stripping it needs
+an operator Brave reload — a deferred follow-up), but nothing consumes it.
 - **`reconcile.py`** — for a recent window, diffs each source against an
   independent existing record: zsh ↔ `~/.zsh_history`, browser ↔ Chrome/Brave
   `History` sqlite (read from a copy — the live DB is locked), tmux ↔

--- a/scripts/validation/invariants.py
+++ b/scripts/validation/invariants.py
@@ -23,30 +23,40 @@ from typing import Callable
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from chquery import CHClient, CHConn  # noqa: E402
 
-# active_ms (browser/keys) is IDLE-AWARE engagement time, so a single event over
-# this is an idle-detection bug. duration_ms (zsh command wall-clock) is NOT
-# idle-aware — a long interactive command (claude/vim/ssh held open for hours)
-# legitimately exceeds it — so raw duration is preserved and only gets the high
-# SANITY bound below (catches clock-skew/parse garbage, not real long sessions).
-ACTIVE_MS_CAP = 6 * 60 * 60 * 1000  # 6h of engagement in one event = implausible
 DURATION_SANITY_CAP = 24 * 60 * 60 * 1000  # >24h in one command = garbage
 # Slack for the local-vs-UTC timezone offset on the "no future ts" check.
 FUTURE_SLACK_HOURS = 26  # > max |tz offset| (14h) + margin
 # Oldest plausible ts: the table TTL is 180d, but data only started 2026; guard
 # against an epoch-0 / 1970 clock-skew bug.
 OLDEST_PLAUSIBLE = "2025-01-01 00:00:00"
-# Trailing window for the per-(host,hour) active-time HEALTH invariant ONLY.
-# This telemetry store is APPEND-ONLY and raw rows are intentionally NEVER
-# mutated (a documented project decision), so any historical hours inflated by a
-# *fixed* bug (e.g. the active_ms read-modify-write race) would otherwise keep
-# this all-time scan RED forever — long after the code is corrected and
-# deployed. Windowing it to recent ingestion makes it a CURRENT-health signal:
-# it recovers as the bad hours age out, while still catching any NEW inflation
-# promptly. This is NOT weakening the check to hide a live bug — the race is
-# fixed in the extension; this only lets a legitimately-recovered system report
-# green. All the OTHER invariants stay all-time (they guard immutable
-# correctness properties, not transient ingestion health).
-ACTIVE_CAP_WINDOW_HOURS = 48
+
+# RETIRED METRIC — browser extension `active_ms` (and its guards) ----------------
+# The browser extension's per-page `active_ms` is STRUCTURALLY WRONG on the i3
+# host and is NO LONGER a trusted or displayed metric. `chrome.idle` measures
+# *system-wide* input (so typing in the terminal kept the browser counted as
+# "active") and `chrome.windows.onFocusChanged` blur is unreliable on i3 — so the
+# extension counted time-spent-in-OTHER-apps as browser engagement (a 10-min
+# stretch focused entirely on Alacritty logged as ~60 min of Brave "active";
+# 2026-06-27 11:00-12:00 UTC read ~144 min "active" against only 12.4 min of
+# actual i3 Brave focus). The two invariants that guarded `active_ms`
+# (`active_ms_capped`, `per_host_hour_active_cap`) and their constants
+# (`ACTIVE_MS_CAP`, `ACTIVE_CAP_WINDOW_HOURS`) have therefore been REMOVED — the
+# metric is being RETIRED, not silenced: there is nothing left to guard once it's
+# no longer trusted/shown. True per-domain browser attention is now DERIVED
+# downstream by intersecting i3 Brave-focused intervals with the active-tab
+# domain timeline (see `derived_attention_consistent` below + the dashboard panel
+# "Browser attention by domain (i3-derived, s)"). The vestigial `active_ms` field
+# is still emitted by the extension (stripping it needs an operator Brave reload);
+# that is a deferred follow-up and does not affect correctness here.
+
+# Dwell cap applied to a single i3 focus interval, matching the dashboard's
+# i3-dwell panels (an idle focus must not inflate attention). 30 minutes in ms.
+DWELL_CAP_MS = 30 * 60 * 1000
+# Tolerance for the derived-attention <= i3-Brave-dwell bound (boundary straddle /
+# rounding). 2% of the dwell.
+DERIVED_ATTENTION_TOL = 0.02
+# Trailing window for the derived-attention consistency check (current-health).
+DERIVED_ATTENTION_WINDOW_HOURS = 48
 
 EXPECTED_HOSTS = {"workbench", "laptop"}
 EXPECTED_SOURCES = {"zsh", "tmux", "keys", "browser", "claude", "i3"}
@@ -92,23 +102,104 @@ def eval_unexpected_set(allowed: set, label: str):
     return _ev
 
 
-def eval_per_host_hour_cap(rows, cap_ms: int = 60 * 60 * 1000):
-    """PASS iff no (host,hour) bucket sums more active time than the wall clock.
+def eval_derived_attention(rows):
+    """PASS iff the DERIVED per-domain browser attention is internally consistent.
 
-    rows: [{host, hour, active_ms}, ...]. Summed active time within any one
-    clock-hour bucket cannot exceed 60 minutes of real time (a sanity bound on
-    double-counted / runaway active_ms). A small overshoot tolerance covers the
-    bucket-boundary case where a single long dwell straddles the hour edge.
+    This is the replacement guard for the retired `active_ms` invariants. It
+    checks the new i3-derived attention metric (intersection of i3 Brave-focused
+    intervals with the active-tab domain timeline) against two structural bounds
+    that the intersection MUST satisfy by construction:
+
+      1. No single domain's attention exceeds wall-clock for the window
+         (an interval intersection can never exceed elapsed real time).
+      2. The SUM of per-domain Brave attention is <= total i3 Brave dwell for the
+         same window (the intersection is a subset of the i3 Brave intervals), up
+         to a small tolerance for boundary-straddle/rounding.
+
+    rows: a single-row result
+      [{derived_total_ms, brave_dwell_ms, max_domain_ms, wallclock_ms}].
+    If there's no browser/i3 data in the window (e.g. headless workbench) the
+    metric is vacuously consistent -> PASS.
     """
-    tol = int(cap_ms * 0.05)
-    over = []
-    for r in rows or []:
-        ams = int(r.get("active_ms") or 0)
-        if ams > cap_ms + tol:
-            over.append(f"{r.get('host')}@{r.get('hour')}={ams}ms")
-    if over:
-        return (False, f"per-(host,hour) active time over 60min: {', '.join(over)}")
-    return (True, "per-(host,hour) active time within 60min")
+    if not rows:
+        return (True, "derived attention: no rows in window (vacuous PASS)")
+    r = rows[0]
+    derived_total = int(r.get("derived_total_ms") or 0)
+    brave_dwell = int(r.get("brave_dwell_ms") or 0)
+    max_domain = int(r.get("max_domain_ms") or 0)
+    wallclock = int(r.get("wallclock_ms") or 0)
+    problems = []
+    if wallclock and max_domain > wallclock:
+        problems.append(
+            f"max-domain {max_domain}ms exceeds wall-clock {wallclock}ms")
+    bound = int(brave_dwell * (1 + DERIVED_ATTENTION_TOL))
+    if derived_total > bound:
+        problems.append(
+            f"sum-per-domain {derived_total}ms exceeds i3 Brave dwell "
+            f"{brave_dwell}ms (+{int(DERIVED_ATTENTION_TOL*100)}% tol)")
+    if problems:
+        return (False, "derived attention inconsistent: " + "; ".join(problems))
+    return (True,
+            f"derived attention consistent: sum={derived_total}ms <= "
+            f"brave_dwell={brave_dwell}ms, max_domain={max_domain}ms <= "
+            f"wallclock={wallclock}ms")
+
+
+# --------------------------------------------------------------------------- #
+# Derived-attention SQL (the replacement guard for the retired active_ms checks)
+# --------------------------------------------------------------------------- #
+def derived_attention_sql(table: str = "activity.events",
+                          window_hours: int = DERIVED_ATTENTION_WINDOW_HOURS,
+                          cap_ms: int = DWELL_CAP_MS) -> str:
+    """SQL computing the i3-derived per-domain browser attention summary.
+
+    Intersects i3 Brave-focused intervals (dwell-capped) with the active-tab
+    domain timeline (from browser `nav` events; the URL is in `text`), and
+    returns ONE row of structural aggregates the evaluator can bound:
+
+      derived_total_ms  sum of intersection across all domains
+      brave_dwell_ms    total i3 Brave dwell over the window (the upper bound)
+      max_domain_ms     largest single-domain attention (must be <= wall-clock)
+      wallclock_ms      elapsed real time of the window
+
+    The interval END for each i3 focus uses leadInFrame over ALL i3 focus events
+    (the next focus of anything), then keeps only Brave rows — so a Brave
+    interval ends when focus LEAVES Brave, not at the next Brave focus. Restricted
+    to host='laptop' (the only GUI host with i3 + browser); Brave only (the
+    extension runs only in Brave, so Chromium focus has no domain data).
+    """
+    w = f"ts > now() - INTERVAL {window_hours} HOUR"
+    return (
+        "WITH brave AS ( "
+        "SELECT bs, be FROM ( "
+        "SELECT toUnixTimestamp64Milli(ts) AS bs, app, "
+        "least((leadInFrame(toUnixTimestamp64Milli(ts), 1, toUnixTimestamp64Milli(ts)) "
+        "OVER (PARTITION BY host ORDER BY ts ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)), "
+        f"toUnixTimestamp64Milli(ts) + {cap_ms}) AS be "
+        f"FROM {table} WHERE source = 'i3' AND kind = 'window-focus' "
+        f"AND host = 'laptop' AND {w} "
+        ") WHERE app = 'Brave-browser' "
+        "), dom AS ( "
+        f"SELECT d, ds, least(de, ds + {cap_ms}) AS de FROM ( "
+        "SELECT if(domain(text) != '', domain(text), netloc(text)) AS d, "
+        "toUnixTimestamp64Milli(ts) AS ds, "
+        f"(leadInFrame(toUnixTimestamp64Milli(ts), 1, toUnixTimestamp64Milli(ts) + {cap_ms}) "
+        "OVER (PARTITION BY host ORDER BY ts ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)) AS de "
+        f"FROM {table} WHERE source = 'browser' AND kind = 'nav' AND text != '' "
+        f"AND host = 'laptop' AND {w} "
+        ") ), "
+        "per_domain AS ( "
+        "SELECT dom.d AS d, "
+        "sum(greatest(0, least(be, de) - greatest(bs, ds))) AS attn_ms "
+        "FROM brave CROSS JOIN dom WHERE be > ds AND de > bs "
+        "GROUP BY dom.d HAVING attn_ms > 0 "
+        ") "
+        "SELECT "
+        "toInt64(ifNull((SELECT sum(attn_ms) FROM per_domain), 0)) AS derived_total_ms, "
+        "toInt64(ifNull((SELECT sum(be - bs) FROM brave), 0)) AS brave_dwell_ms, "
+        "toInt64(ifNull((SELECT max(attn_ms) FROM per_domain), 0)) AS max_domain_ms, "
+        f"toInt64({window_hours} * 3600 * 1000) AS wallclock_ms"
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -129,17 +220,13 @@ def build_invariants(table: str = "activity.events") -> list[Invariant]:
             f"SELECT count() FROM {table} WHERE toInt64(duration_ms) < 0",
             eval_zero_violations("duration_ms < 0"),
         ),
-        Invariant(
-            "active_ms_capped",
-            "SELECT count() FROM " + table + " WHERE "
-            f"toUInt32OrZero(JSONExtractString(payload, 'active_ms')) > {ACTIVE_MS_CAP}",
-            eval_zero_violations(f"active_ms > {ACTIVE_MS_CAP}ms cap"),
-        ),
+        # NOTE: `active_ms_capped` was REMOVED here — the browser extension's
+        # `active_ms` is a retired, untrusted metric (see the RETIRED METRIC note
+        # at the top of this module). Its replacement is `derived_attention_consistent`.
         Invariant(
             "duration_ms_capped",
             # Raw duration is PRESERVED (a multi-hour interactive `claude` is real);
-            # only flag values above the 24h garbage bound. Long durations no longer
-            # inflate active time — per_host_hour_active_cap now sums active_ms only.
+            # only flag values above the 24h garbage bound.
             f"SELECT count() FROM {table} WHERE duration_ms > {DURATION_SANITY_CAP}",
             eval_zero_violations(f"duration_ms > {DURATION_SANITY_CAP}ms (garbage)"),
         ),
@@ -158,25 +245,24 @@ def build_invariants(table: str = "activity.events") -> list[Invariant]:
             f"SELECT source AS value, count() AS count FROM {table} GROUP BY source",
             eval_unexpected_set(EXPECTED_SOURCES, "source"),
         ),
+        # NOTE: `per_host_hour_active_cap` was REMOVED here — it guarded the
+        # retired `active_ms` metric (see the RETIRED METRIC note at the top).
+        # `derived_attention_consistent` below is its structural replacement.
         Invariant(
-            "per_host_hour_active_cap",
-            # Engagement time per (host, clock-hour) — IDLE-AWARE active_ms ONLY.
-            # duration_ms (command wall-clock) is deliberately excluded: it is not
-            # active engagement, and a long interactive command (claude) would
-            # otherwise falsely blow past the 60min/hour bound.
-            #
-            # TRAILING WINDOW (this invariant only): see ACTIVE_CAP_WINDOW_HOURS
-            # above — the append-only store never rewrites bad historical hours,
-            # so this health check is windowed to recent ingestion rather than
-            # scanning all-time, letting a fixed+deployed system recover to green
-            # while still catching NEW inflation. NB: `ts` is the host LOCAL wall
-            # clock and now() is UTC, so the window edge is fuzzy by the tz offset
-            # — acceptable for a 48h health window (we only need "recent").
-            "SELECT host, toStartOfHour(ts) AS hour, "
-            "sum(toUInt32OrZero(JSONExtractString(payload, 'active_ms'))) AS active_ms "
-            f"FROM {table} WHERE ts > now() - INTERVAL {ACTIVE_CAP_WINDOW_HOURS} HOUR "
-            "GROUP BY host, hour",
-            eval_per_host_hour_cap,
+            "derived_attention_consistent",
+            # The replacement guard. Asserts the NEW i3-derived per-domain browser
+            # attention is internally consistent: sum-per-domain <= total i3 Brave
+            # dwell (the intersection is a subset of the i3 Brave intervals) and no
+            # single domain exceeds wall-clock. Trailing-windowed (current-health,
+            # like the metric it replaces): the append-only store never rewrites
+            # history, but the DERIVED metric is bounded BY CONSTRUCTION so it can
+            # never go inconsistent unless the query/data shape regresses — this
+            # catches such a regression promptly. NB: `ts` is host-LOCAL and now()
+            # is UTC, so the window edge is fuzzy by the tz offset — fine for a
+            # recent-health window. Vacuously PASSes when there's no GUI data
+            # (e.g. the headless workbench has no i3/browser rows).
+            derived_attention_sql(table),
+            eval_derived_attention,
         ),
     ]
 
@@ -187,7 +273,7 @@ def run_invariants(client: CHClient) -> list[Result]:
     for inv in build_invariants(table):
         try:
             # Multi-row evaluators expect rows(); scalar evaluators expect a number.
-            if inv.name in ("expected_hosts", "expected_sources", "per_host_hour_active_cap"):
+            if inv.name in ("expected_hosts", "expected_sources", "derived_attention_consistent"):
                 data = client.rows(inv.sql)
             else:
                 data = client.scalar(inv.sql)

--- a/scripts/validation/tests/test_invariants.py
+++ b/scripts/validation/tests/test_invariants.py
@@ -51,45 +51,77 @@ def test_unexpected_set_ignores_empty_value():
     assert ev(rows)[0] is True
 
 
-def test_per_host_hour_cap_clean():
-    rows = [
-        {"host": "workbench", "hour": "2026-06-24 07:00:00", "active_ms": 60 * 60 * 1000},
-        {"host": "laptop", "hour": "2026-06-24 08:00:00", "active_ms": 1234},
-    ]
-    assert I.eval_per_host_hour_cap(rows)[0] is True
+# --------------------------------------------------------------------------- #
+# Derived-attention consistency (the replacement guard for the retired active_ms
+# invariants — see the RETIRED METRIC note in invariants.py).
+# --------------------------------------------------------------------------- #
+def test_derived_attention_clean():
+    # sum-per-domain <= brave dwell and max-domain <= wall-clock -> PASS.
+    rows = [{"derived_total_ms": 18_000_000, "brave_dwell_ms": 20_000_000,
+             "max_domain_ms": 3_000_000, "wallclock_ms": 172_800_000}]
+    passed, detail = I.eval_derived_attention(rows)
+    assert passed is True, detail
 
 
-def test_per_host_hour_cap_catches_overflow():
-    rows = [
-        {"host": "workbench", "hour": "2026-06-24 07:00:00", "active_ms": 90 * 60 * 1000},
-    ]
-    passed, detail = I.eval_per_host_hour_cap(rows)
+def test_derived_attention_catches_sum_over_dwell():
+    # The intersection can NEVER exceed total i3 Brave dwell — this is the core
+    # structural property that the broken active_ms metric violated (20x inflated).
+    rows = [{"derived_total_ms": 40_000_000, "brave_dwell_ms": 20_000_000,
+             "max_domain_ms": 5_000_000, "wallclock_ms": 172_800_000}]
+    passed, detail = I.eval_derived_attention(rows)
     assert passed is False
-    assert "workbench" in detail
+    assert "Brave dwell" in detail
 
 
-def test_per_host_hour_cap_tolerates_small_overshoot():
-    # 60min + 2% < 5% tolerance -> still PASS (boundary-straddle case)
-    rows = [{"host": "h", "hour": "x", "active_ms": int(60 * 60 * 1000 * 1.02)}]
-    assert I.eval_per_host_hour_cap(rows)[0] is True
+def test_derived_attention_catches_domain_over_wallclock():
+    rows = [{"derived_total_ms": 1000, "brave_dwell_ms": 1000,
+             "max_domain_ms": 200_000_000, "wallclock_ms": 172_800_000}]
+    passed, detail = I.eval_derived_attention(rows)
+    assert passed is False
+    assert "wall-clock" in detail
 
 
-def test_per_host_hour_cap_query_is_windowed():
-    # The active-time HEALTH invariant must scan only a trailing window, not
-    # all-time — the append-only store never rewrites bad historical hours, so an
-    # all-time scan would stay RED forever after a fixed+deployed bug. Every
-    # OTHER invariant must stay all-time (no such WHERE-ts window).
+def test_derived_attention_tolerates_small_overshoot():
+    # sum at +1% (< 2% tolerance) for boundary-straddle/rounding -> PASS.
+    dwell = 20_000_000
+    rows = [{"derived_total_ms": int(dwell * 1.01), "brave_dwell_ms": dwell,
+             "max_domain_ms": 1000, "wallclock_ms": 172_800_000}]
+    assert I.eval_derived_attention(rows)[0] is True
+
+
+def test_derived_attention_vacuous_when_no_data():
+    # Headless host / empty window: no rows -> vacuously consistent.
+    assert I.eval_derived_attention([])[0] is True
+    assert I.eval_derived_attention(
+        [{"derived_total_ms": 0, "brave_dwell_ms": 0,
+          "max_domain_ms": 0, "wallclock_ms": 172_800_000}])[0] is True
+
+
+def test_derived_attention_query_is_windowed_and_brave_only():
+    # The derived-attention check is trailing-windowed (current-health) and
+    # restricted to Brave + the laptop GUI host. Every OTHER invariant stays
+    # all-time (they guard immutable correctness, not transient health).
     invs = {inv.name: inv for inv in I.build_invariants("activity.events")}
-    cap = invs["per_host_hour_active_cap"]
-    assert f"INTERVAL {I.ACTIVE_CAP_WINDOW_HOURS} HOUR" in cap.sql
-    assert "WHERE ts > now() -" in cap.sql
-    assert I.ACTIVE_CAP_WINDOW_HOURS == 48
-    # No other invariant should carry a trailing ts window (they guard immutable
-    # correctness, not transient health).
+    da = invs["derived_attention_consistent"]
+    assert f"INTERVAL {I.DERIVED_ATTENTION_WINDOW_HOURS} HOUR" in da.sql
+    assert "now() - INTERVAL" in da.sql
+    assert "Brave-browser" in da.sql
+    assert "host = 'laptop'" in da.sql
+    assert I.DERIVED_ATTENTION_WINDOW_HOURS == 48
     for name, inv in invs.items():
-        if name == "per_host_hour_active_cap":
+        if name == "derived_attention_consistent":
             continue
         assert "now() - INTERVAL" not in inv.sql, f"{name} unexpectedly windowed"
+
+
+def test_retired_active_ms_invariants_are_gone():
+    # The broken active_ms metric is RETIRED — its guards must no longer exist.
+    names = {inv.name for inv in I.build_invariants("activity.events")}
+    assert "active_ms_capped" not in names
+    assert "per_host_hour_active_cap" not in names
+    assert not hasattr(I, "ACTIVE_MS_CAP")
+    assert not hasattr(I, "ACTIVE_CAP_WINDOW_HOURS")
+    assert not hasattr(I, "eval_per_host_hour_cap")
 
 
 # --------------------------------------------------------------------------- #
@@ -106,8 +138,9 @@ class FakeClient:
         return 0  # no violations
 
     def rows(self, sql):
-        if "GROUP BY host, hour" in sql:
-            return [{"host": "workbench", "hour": "2026-06-24 07:00:00", "active_ms": 1000}]
+        if "per_domain" in sql:  # derived_attention_consistent
+            return [{"derived_total_ms": 18_000_000, "brave_dwell_ms": 20_000_000,
+                     "max_domain_ms": 3_000_000, "wallclock_ms": 172_800_000}]
         if "GROUP BY source" in sql:
             return [{"value": "zsh", "count": 5}]
         if "GROUP BY host" in sql:
@@ -118,10 +151,10 @@ class FakeClient:
 def test_run_invariants_all_pass_on_clean_data():
     results = I.run_invariants(FakeClient())
     names = {r.name for r in results}
-    # all the documented invariants present
-    assert {"no_future_ts", "duration_ms_nonneg", "active_ms_capped",
+    # all the documented invariants present (active_ms guards retired)
+    assert {"no_future_ts", "duration_ms_nonneg", "duration_ms_capped",
             "ts_not_ancient", "expected_hosts", "expected_sources",
-            "per_host_hour_active_cap"} <= names
+            "derived_attention_consistent"} <= names
     assert all(r.passed for r in results), [r.detail for r in results if not r.passed]
 
 
@@ -130,8 +163,9 @@ class FailClient(FakeClient):
         return 7  # violations everywhere
 
     def rows(self, sql):
-        if "GROUP BY host, hour" in sql:
-            return [{"host": "h", "hour": "x", "active_ms": 99 * 60 * 1000}]
+        if "per_domain" in sql:  # derived attention inconsistent (sum > dwell)
+            return [{"derived_total_ms": 40_000_000, "brave_dwell_ms": 20_000_000,
+                     "max_domain_ms": 5_000_000, "wallclock_ms": 172_800_000}]
         if "GROUP BY source" in sql:
             return [{"value": "evil-source", "count": 1}]
         if "GROUP BY host" in sql:
@@ -145,7 +179,7 @@ def test_run_invariants_catches_violations():
     assert "no_future_ts" in failed
     assert "expected_sources" in failed
     assert "expected_hosts" in failed
-    assert "per_host_hour_active_cap" in failed
+    assert "derived_attention_consistent" in failed
 
 
 def test_run_invariants_query_error_is_fail():


### PR DESCRIPTION
## What

Retires the browser extension's `active_ms` from the validation harness and adds a deterministic guard for its **i3-derived replacement** metric. Pairs with homelab-infra PR (dashboard panel swap).

## Why — `active_ms` is structurally wrong on i3

The extension's per-page `active_ms` cannot be trusted on this host:
- `chrome.idle` measures **system-wide** input → typing in the terminal kept the browser counted as "active".
- `chrome.windows.onFocusChanged` blur is unreliable on i3.

Net: time spent in OTHER apps was logged as browser engagement. The **2026-06-27 11:00–12:00 UTC** hour read **~144 min** of "active" against only **12.4 min** of actual i3 Brave focus.

## Changes

- **Removed** the two invariants that guarded `active_ms` — `active_ms_capped` and `per_host_hour_active_cap` — plus their constants (`ACTIVE_MS_CAP`, `ACTIVE_CAP_WINDOW_HOURS`) and the `eval_per_host_hour_cap` evaluator. This is a **retirement** (there is nothing left to guard once the metric is no longer trusted/displayed), **not** a silenced failing check — the rationale is documented in code comments + the README.
- **Added** `derived_attention_consistent`: a deterministic replacement guard. Over a trailing 48h window it asserts the new i3-derived per-domain attention's two structural bounds (the broken metric violated both): (1) sum-per-domain attention ≤ total i3 Brave dwell (+2% tol) — an interval intersection is a subset of the i3 Brave intervals — and (2) no single domain exceeds wall-clock. Vacuously passes on a GUI-less host (e.g. headless workbench).
- **Tests + README** updated: documents the retirement, the new derived metric (intersection of i3 Brave-focused intervals with the active-tab domain timeline), and its guard.

## Validation

**Python tests:** `71 passed`.

**Live harness** (`validate.py` against ClickHouse, reader creds): `OVERALL: PASS`, with the new invariant green:
```
derived_attention_consistent  PASS  derived attention consistent: sum=18919622ms <= brave_dwell=20556303ms, max_domain=3424745ms <= wallclock=172800000ms
```

**Derived-metric sanity (live, 7d):** derived total **315.3 min** ≤ Brave i3 dwell **342.6 min**; max single domain 57.1 min ≪ wall-clock. Target hour **11:00–12:00 UTC: 144 min (broken) → ~11.9 min** (≈ 12.4 min i3 Brave dwell).

## Deferred follow-up (NOT in this PR)

The extension still emits the vestigial `active_ms` + `focus`/idle events that drove the broken metric. Stripping them from the extension would reduce noise but requires a **manual laptop Brave reload** (operator-only, and the operator is mid-work-session), so it is **deferred** — recommended as a separate follow-up, not part of this change. Nothing consumes `active_ms` anymore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
