### PR TITLE
fix(validation): raise duration garbage bound 24h->7d (real multi-day claude sessions)

### DIFF
--- a/scripts/validation/invariants.py
+++ b/scripts/validation/invariants.py
@@ -23,7 +23,7 @@ from typing import Callable
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from chquery import CHClient, CHConn  # noqa: E402
 
-DURATION_SANITY_CAP = 24 * 60 * 60 * 1000  # >24h in one command = garbage
+DURATION_SANITY_CAP = 7 * 24 * 60 * 60 * 1000  # >7d in one command = garbage (multi-day interactive `claude --resume` sessions legitimately run >24h)
 # Slack for the local-vs-UTC timezone offset on the "no future ts" check.
 FUTURE_SLACK_HOURS = 26  # > max |tz offset| (14h) + margin
 # Oldest plausible ts: the table TTL is 180d, but data only started 2026; guard
@@ -225,8 +225,8 @@ def build_invariants(table: str = "activity.events") -> list[Invariant]:
         # at the top of this module). Its replacement is `derived_attention_consistent`.
         Invariant(
             "duration_ms_capped",
-            # Raw duration is PRESERVED (a multi-hour interactive `claude` is real);
-            # only flag values above the 24h garbage bound.
+            # Raw duration is PRESERVED (a multi-DAY interactive `claude --resume`
+            # is real — observed 40h+); only flag values above the 7d garbage bound.
             f"SELECT count() FROM {table} WHERE duration_ms > {DURATION_SANITY_CAP}",
             eval_zero_violations(f"duration_ms > {DURATION_SANITY_CAP}ms (garbage)"),
         ),


### PR DESCRIPTION
The `duration_ms_capped` invariant was flagging legitimate long-running `claude --resume` sessions (observed 40-41h) as garbage, causing `OVERALL: FAIL` on otherwise-healthy telemetry. Multi-day interactive Claude sessions are normal on this setup.

**Change:** `DURATION_SANITY_CAP` 24h → 7d (`scripts/validation/invariants.py`). Still catches true clock-skew / stuck-timer garbage (`duration_ms` is UInt32, ~49.7d ceiling); raw durations remain preserved.

**Verified:** python tests 70/70; live harness `duration_ms_capped PASS` → `OVERALL: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)