### PR TITLE
feat(mail-actions): action-required email extractor over the self-hosted inbox

### DIFF
--- a/scripts/mail-actions/README.md
+++ b/scripts/mail-actions/README.md
@@ -1,0 +1,162 @@
+# mail-actions — action-required email extractor
+
+Mines the self-hosted inbox (Gmail → homelab Postgres `mail` table) for the handful of
+genuinely **action-required** emails buried in thousands of alerts/notifications, and
+records them as structured rows in a `mail_actions` table (plus, optionally, a clawgate
+Task card per new item).
+
+This is an **MVP**. Its loop closes on an *artifact verifier* — extraction correctness
+checked against the source email — not on human adoption. See "Verifying the artifact".
+
+## Pipeline
+
+```
+mail (via_gmail, processed_at IS NULL)        ← delta read
+  │
+  ├─ Stage 1  deterministic noise DROP   filter.py   (pure, NO LLM, high-precision)
+  │     drop on: category=alert · List-Unsubscribe/List-Id/Auto-Submitted present ·
+  │              Precedence in {bulk,list,junk} · short sender denylist
+  │     → label 'bulk', stamp processed_at
+  │
+  ├─ Stage 2  LLM extraction             llm.py      (OpenRouter, survivors only)
+  │     → strict JSON {action_required, who, ask, deadline, amount, confidence, reason}
+  │     retry once on malformed; sanity guard: action_required + empty ask → fyi
+  │
+  ├─ Stage 3  persist + mark state       _db.py      (idempotent)
+  │     action → INSERT mail_actions (ON CONFLICT mail_id DO NOTHING), label 'action-required'
+  │     non-action → label 'fyi'
+  │     all processed rows get processed_at = now()  → re-runs are a no-op
+  │
+  └─ Stage 4  surface (OPTIONAL, --emit-clawgate)    clawgate.py
+        one clawgate Task card per NEW action item
+```
+
+**Stage-1 design contract:** it must *never* drop a genuine action item. It only drops on
+unambiguous, header-driven signals; ambiguous survivors (incl. `no-reply@`
+verification/security mail) go to the LLM. The denylist is intentionally short — header
+signals do the heavy lifting.
+
+Measured on the live inbox (2026-06-29): 3,537 unprocessed via_gmail rows → 3,457 dropped
+by Stage 1 → **80 survivors** for the LLM pass (est. LLM cost ~$0.02 with the default
+cheap model).
+
+## Requirements / env
+
+| var | needed for | notes |
+|-----|------------|-------|
+| `KUBECONFIG` | DB access (all stages) | `~/workspace/homelab-talos/homelab-kubeconfig` |
+| `OPENROUTER_API_KEY` | Stage 2 (LLM) | not needed for `--dry-run` or tests |
+| `MAIL_ACTIONS_MODEL` | optional | default `deepseek/deepseek-v4-flash` |
+| `CLAWGATE_HOOK_TOKEN` | optional Stage 4 | if unset, `--emit-clawgate` is a graceful no-op |
+
+No secrets are hardcoded — keys are read from env only.
+
+**Python deps** (`psycopg2`, `requests`): this is NixOS, so run under a nix-shell rather
+than assuming a global install:
+
+```sh
+nix-shell -p 'python3.withPackages(p:[p.psycopg2 p.requests])' --run \
+  'python scripts/mail-actions/extract.py run --dry-run'
+```
+
+DB access uses `kubectl -n mailbox port-forward svc/mailbox-postgres` on an ephemeral
+local port (the pod is ClusterIP-only); reads AND writes go through psycopg2 with bound
+parameters — never `kubectl exec … psql -c` (unsafe to escape email bodies).
+
+## Usage
+
+```sh
+# Stage-1 only: counts + which survivors WOULD go to the LLM. No key, no writes.
+python scripts/mail-actions/extract.py run --dry-run [--limit N] [--json]
+
+# Full pipeline (needs OPENROUTER_API_KEY). --limit caps LLM cost (default 150).
+python scripts/mail-actions/extract.py run [--limit N] [--model NAME] [--emit-clawgate] [--json]
+
+# Print open action items (the artifact, for verification).
+python scripts/mail-actions/extract.py list [--json]
+```
+
+## First live run (Zach runs this)
+
+The build + offline tests + `--dry-run` were exercised in-session. The live Stage-2 pass
+was **not** run (no `OPENROUTER_API_KEY` in the build session). To do the first live
+extraction:
+
+```sh
+export KUBECONFIG=~/workspace/homelab-talos/homelab-kubeconfig
+export OPENROUTER_API_KEY=sk-or-...                       # your key
+
+# Start SMALL to eyeball quality + cost before processing all 80 survivors:
+nix-shell -p 'python3.withPackages(p:[p.psycopg2 p.requests])' --run \
+  'python scripts/mail-actions/extract.py run --limit 10'
+
+# Then the full delta:
+nix-shell -p 'python3.withPackages(p:[p.psycopg2 p.requests])' --run \
+  'python scripts/mail-actions/extract.py run'
+```
+
+Note: `--limit` pulls the N most-recent *unprocessed* rows; because Stage 1 drops most of
+them, a small `--limit` may yield few survivors. The first run labels everything it touches,
+so subsequent runs only see new mail.
+
+## Verifying the artifact (the loop's verifier)
+
+The artifact is the `mail_actions` table. Verify extraction correctness against source mail:
+
+```sh
+# 1. List what was extracted.
+nix-shell -p 'python3.withPackages(p:[p.psycopg2 p.requests])' --run \
+  'python scripts/mail-actions/extract.py list'
+
+# 2. For any item, open the source email and check who/ask/deadline/amount match.
+export KUBECONFIG=~/workspace/homelab-talos/homelab-kubeconfig
+kubectl -n mailbox exec mailbox-postgres-0 -- psql -U mailbox -d mailbox -c \
+  "SELECT a.who, a.ask, a.deadline, a.amount, a.confidence, m.from_addr, m.subject
+     FROM mail_actions a JOIN mail m ON m.id = a.mail_id
+    ORDER BY a.created_at DESC;"
+
+# 3. Spot-check the body of a flagged row to confirm the ask is real (not hallucinated):
+kubectl -n mailbox exec mailbox-postgres-0 -- psql -U mailbox -d mailbox -c \
+  "SELECT left(text_body, 1200) FROM mail WHERE id = <mail_id>;"
+```
+
+Correctness checks:
+- **Precision** — every `mail_actions` row is a real ask (no hallucinated/FYI items). The
+  genuine threads to expect: Zen Payments merchant onboarding, Stripe `[Action required]`
+  on vetr, naida sales (lauren@naidacom.com), Hetzner/DataPacket invoices.
+- **Recall** — none of those genuine threads are missing (i.e. Stage 1 didn't wrongly drop
+  them, and Stage 2 didn't mark them fyi). Cross-check against the `--dry-run` survivor list.
+- **Idempotency** — a second `run` reports `survivors: 0` (nothing left unprocessed).
+
+## State / re-runs
+
+`mail.labels` (`'bulk' | 'fyi' | 'action-required'`) + `mail.processed_at` are the
+idempotency mechanism. Re-runs only touch `processed_at IS NULL` rows. To re-process a row
+(e.g. after a model change), clear its state:
+
+```sql
+UPDATE mail SET processed_at = NULL,
+  labels = array_remove(array_remove(array_remove(labels,'bulk'),'fyi'),'action-required')
+WHERE id = <mail_id>;
+DELETE FROM mail_actions WHERE mail_id = <mail_id>;
+```
+
+## Tests
+
+```sh
+nix-shell -p 'python3.withPackages(p:[p.pytest p.requests p.psycopg2])' --run \
+  'python -m pytest scripts/mail-actions/tests -q'
+```
+
+- `test_filter.py` — Stage-1 filter vs scrubbed real fixtures (`tests/fixtures/mail_headers.json`):
+  asserts the genuine action threads survive and the noise (alert/github/npm/bugsnag/
+  newsletter-with-List-Unsubscribe) is dropped, and that a no-reply password-expiry mail
+  survives to the LLM rather than being blanket-dropped.
+- `test_llm.py` — output parser/validator: good/fenced/prose-wrapped/malformed JSON, the
+  sanity guard, confidence clamping, and the single-retry behaviour (mocked caller, no key).
+- `test_idempotency.py` — fake in-memory DB: first pass labels+stamps; second pass sees an
+  empty delta and is a no-op; `ON CONFLICT` insert is a no-op.
+
+Fixtures are scrubbed to **headers + from + subject only** — no personal email bodies are
+committed.
+```

--- a/scripts/mail-actions/_db.py
+++ b/scripts/mail-actions/_db.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""DB access for the mail-actions extractor.
+
+The mailbox Postgres lives in the homelab cluster and is only reachable in-cluster
+(ClusterIP `mailbox-postgres:5432`). We bridge to it by starting a `kubectl
+port-forward` on an ephemeral local port, connecting with psycopg2 over 127.0.0.1,
+and tearing the forward down on exit. Reads AND writes go through this so email
+bodies are passed as bound parameters — never shell-escaped into `psql -c`.
+
+Usage:
+    with MailDB() as db:
+        rows = db.fetch_unprocessed()
+        db.mark_processed(mail_id, label="fyi")
+
+Requires in PATH/env:
+    KUBECONFIG  — homelab kubeconfig
+    kubectl     — on PATH
+    psycopg2    — python dep (psycopg2-binary is fine); see README for nix-shell.
+"""
+from __future__ import annotations
+
+import contextlib
+import os
+import socket
+import subprocess
+import time
+from urllib.parse import urlparse
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError as exc:  # pragma: no cover - import guard
+    raise SystemExit(
+        "psycopg2 is required. On NixOS run under:\n"
+        "  nix-shell -p \"python3.withPackages(p:[p.psycopg2 p.requests])\" "
+        "--run 'python scripts/mail-actions/extract.py ...'"
+    ) from exc
+
+NAMESPACE = "mailbox"
+SERVICE = "svc/mailbox-postgres"
+DSN_SECRET = "mailbox-postgres-auth"
+DSN_KEY = "pg-dsn"
+
+
+def _free_local_port() -> int:
+    """Ask the OS for a free TCP port (bind to 0, read it back, release)."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _read_dsn_from_secret() -> str:
+    """Read the Postgres DSN out of the k8s secret via kubectl + base64 decode."""
+    import base64
+
+    out = subprocess.check_output(
+        [
+            "kubectl", "-n", NAMESPACE, "get", "secret", DSN_SECRET,
+            "-o", f"jsonpath={{.data.{DSN_KEY}}}",
+        ],
+        text=True,
+    ).strip()
+    return base64.b64decode(out).decode().strip()
+
+
+def _rewrite_dsn_host(dsn: str, host: str, port: int) -> dict:
+    """Parse a postgres:// DSN and return psycopg2 connect kwargs pointing at host:port."""
+    u = urlparse(dsn)
+    if u.scheme not in ("postgres", "postgresql"):
+        raise ValueError(f"unexpected DSN scheme: {u.scheme!r}")
+    dbname = (u.path or "/").lstrip("/") or "mailbox"
+    return {
+        "host": host,
+        "port": port,
+        "user": u.username,
+        "password": u.password,
+        "dbname": dbname,
+        "connect_timeout": 10,
+    }
+
+
+class MailDB:
+    """Context manager: port-forward → psycopg2 connection, torn down on exit."""
+
+    def __init__(self, dsn: str | None = None, ready_timeout: float = 20.0):
+        self._dsn = dsn or os.environ.get("MAILBOX_PG_DSN")
+        self._ready_timeout = ready_timeout
+        self._pf: subprocess.Popen | None = None
+        self.conn: "psycopg2.extensions.connection | None" = None
+
+    # -- lifecycle ---------------------------------------------------------
+    def __enter__(self) -> "MailDB":
+        dsn = self._dsn or _read_dsn_from_secret()
+        local_port = _free_local_port()
+        self._pf = subprocess.Popen(
+            [
+                "kubectl", "-n", NAMESPACE, "port-forward", SERVICE,
+                f"{local_port}:5432",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        self._wait_for_port("127.0.0.1", local_port)
+        kwargs = _rewrite_dsn_host(dsn, "127.0.0.1", local_port)
+        self.conn = psycopg2.connect(**kwargs)
+        self.conn.autocommit = False
+        return self
+
+    def __exit__(self, *exc) -> None:
+        with contextlib.suppress(Exception):
+            if self.conn is not None:
+                self.conn.close()
+        if self._pf is not None:
+            self._pf.terminate()
+            with contextlib.suppress(Exception):
+                self._pf.wait(timeout=5)
+
+    def _wait_for_port(self, host: str, port: int) -> None:
+        deadline = time.monotonic() + self._ready_timeout
+        while time.monotonic() < deadline:
+            if self._pf and self._pf.poll() is not None:
+                err = self._pf.stderr.read().decode() if self._pf.stderr else ""
+                raise RuntimeError(f"kubectl port-forward exited early:\n{err}")
+            with contextlib.suppress(OSError):
+                with socket.create_connection((host, port), timeout=1):
+                    return
+            time.sleep(0.25)
+        raise TimeoutError(f"port-forward to {host}:{port} not ready in time")
+
+    # -- schema ------------------------------------------------------------
+    def ensure_schema(self) -> None:
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mail_actions (
+                    id          serial PRIMARY KEY,
+                    mail_id     int REFERENCES mail(id) UNIQUE,
+                    message_id  text,
+                    from_addr   text,
+                    subject     text,
+                    received_at timestamptz,
+                    who         text,
+                    ask         text,
+                    deadline    text,
+                    amount      text,
+                    confidence  real,
+                    reason      text,
+                    status      text DEFAULT 'open',
+                    created_at  timestamptz DEFAULT now()
+                )
+                """
+            )
+        self.conn.commit()
+
+    # -- reads -------------------------------------------------------------
+    def fetch_unprocessed(self, limit: int | None = None):
+        """Delta read: via_gmail mail not yet processed by this pipeline."""
+        sql = (
+            "SELECT id, message_id, from_addr, subject, received_at, category, "
+            "headers, text_body "
+            "FROM mail WHERE via_gmail AND processed_at IS NULL "
+            "ORDER BY received_at DESC"
+        )
+        params: tuple = ()
+        if limit is not None:
+            sql += " LIMIT %s"
+            params = (limit,)
+        with self.conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(sql, params)
+            return cur.fetchall()
+
+    def list_open_actions(self):
+        with self.conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                "SELECT id, mail_id, from_addr, subject, received_at, who, ask, "
+                "deadline, amount, confidence, status, created_at "
+                "FROM mail_actions WHERE status = 'open' ORDER BY created_at DESC"
+            )
+            return cur.fetchall()
+
+    # -- writes ------------------------------------------------------------
+    def mark_processed(self, mail_id: int, label: str) -> None:
+        """Append `label` to mail.labels (dedup) and stamp processed_at=now()."""
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE mail
+                   SET labels = (
+                         SELECT array_agg(DISTINCT x)
+                         FROM unnest(coalesce(labels, '{}') || ARRAY[%s]::text[]) AS x
+                       ),
+                       processed_at = now()
+                 WHERE id = %s
+                """,
+                (label, mail_id),
+            )
+
+    def insert_action(self, row: dict) -> bool:
+        """Insert a mail_actions row. Returns True if inserted, False on conflict."""
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO mail_actions
+                    (mail_id, message_id, from_addr, subject, received_at,
+                     who, ask, deadline, amount, confidence, reason)
+                VALUES
+                    (%(mail_id)s, %(message_id)s, %(from_addr)s, %(subject)s,
+                     %(received_at)s, %(who)s, %(ask)s, %(deadline)s, %(amount)s,
+                     %(confidence)s, %(reason)s)
+                ON CONFLICT (mail_id) DO NOTHING
+                """,
+                row,
+            )
+            return cur.rowcount > 0
+
+    def commit(self) -> None:
+        self.conn.commit()

--- a/scripts/mail-actions/_db.py
+++ b/scripts/mail-actions/_db.py
@@ -108,7 +108,7 @@ class MailDB:
         self.conn.autocommit = False
         return self
 
-    def __exit__(self, *exc) -> None:
+    def __exit__(self, *_exc) -> None:
         with contextlib.suppress(Exception):
             if self.conn is not None:
                 self.conn.close()
@@ -116,6 +116,13 @@ class MailDB:
             self._pf.terminate()
             with contextlib.suppress(Exception):
                 self._pf.wait(timeout=5)
+
+    @property
+    def _c(self) -> "psycopg2.extensions.connection":
+        """The live connection, or a clear error if used outside the context manager."""
+        if self.conn is None:
+            raise RuntimeError("MailDB used outside its context manager (no connection)")
+        return self.conn
 
     def _wait_for_port(self, host: str, port: int) -> None:
         deadline = time.monotonic() + self._ready_timeout
@@ -131,7 +138,7 @@ class MailDB:
 
     # -- schema ------------------------------------------------------------
     def ensure_schema(self) -> None:
-        with self.conn.cursor() as cur:
+        with self._c.cursor() as cur:
             cur.execute(
                 """
                 CREATE TABLE IF NOT EXISTS mail_actions (
@@ -152,7 +159,7 @@ class MailDB:
                 )
                 """
             )
-        self.conn.commit()
+        self._c.commit()
 
     # -- reads -------------------------------------------------------------
     def fetch_unprocessed(self, limit: int | None = None):
@@ -167,12 +174,12 @@ class MailDB:
         if limit is not None:
             sql += " LIMIT %s"
             params = (limit,)
-        with self.conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             cur.execute(sql, params)
             return cur.fetchall()
 
     def list_open_actions(self):
-        with self.conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             cur.execute(
                 "SELECT id, mail_id, from_addr, subject, received_at, who, ask, "
                 "deadline, amount, confidence, status, created_at "
@@ -183,7 +190,7 @@ class MailDB:
     # -- writes ------------------------------------------------------------
     def mark_processed(self, mail_id: int, label: str) -> None:
         """Append `label` to mail.labels (dedup) and stamp processed_at=now()."""
-        with self.conn.cursor() as cur:
+        with self._c.cursor() as cur:
             cur.execute(
                 """
                 UPDATE mail
@@ -199,7 +206,7 @@ class MailDB:
 
     def insert_action(self, row: dict) -> bool:
         """Insert a mail_actions row. Returns True if inserted, False on conflict."""
-        with self.conn.cursor() as cur:
+        with self._c.cursor() as cur:
             cur.execute(
                 """
                 INSERT INTO mail_actions
@@ -216,4 +223,4 @@ class MailDB:
             return cur.rowcount > 0
 
     def commit(self) -> None:
-        self.conn.commit()
+        self._c.commit()

--- a/scripts/mail-actions/clawgate.py
+++ b/scripts/mail-actions/clawgate.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Stage 4 (optional) — surface a NEW action item as a clawgate Task card.
+
+Thin + swappable. POSTs a decision-shaped card to the clawgate hook-token endpoint.
+If CLAWGATE_HOOK_TOKEN is unset, `emit_task` is a graceful no-op (returns False).
+"""
+from __future__ import annotations
+
+import os
+
+ENDPOINT = "http://192.168.50.250:30302/api/tasks"
+
+
+def emit_task(*, who: str, ask: str, deadline: str | None, amount: str | None,
+              source_ref: str, timeout: float = 10.0) -> bool:
+    """Emit one clawgate Task card for an action item. Returns True if posted."""
+    token = os.environ.get("CLAWGATE_HOOK_TOKEN")
+    if not token:
+        return False
+    import requests
+
+    bits = [ask.strip()]
+    if deadline:
+        bits.append(f"Deadline: {deadline}")
+    if amount:
+        bits.append(f"Amount: {amount}")
+    bits.append(f"Source: {source_ref}")
+    body = {
+        "title": f"\U0001F4E8 action-required · {who}"[:120],
+        "body": "\n".join(b for b in bits if b),
+    }
+    resp = requests.post(
+        ENDPOINT,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        json=body,
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    return True

--- a/scripts/mail-actions/extract.py
+++ b/scripts/mail-actions/extract.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""mail-actions — action-required email extractor over the self-hosted inbox.
+
+Pipeline (see scripts/mail-actions/README.md for the full picture):
+  Stage 1  deterministic noise DROP  (filter.py, pure, no LLM)
+  Stage 2  LLM extraction            (llm.py, OpenRouter)
+  Stage 3  persist + mark state      (_db.py, idempotent via mail.processed_at)
+  Stage 4  surface to clawgate       (clawgate.py, optional, --emit-clawgate)
+
+Delta/idempotency: a row is only touched while `mail.processed_at IS NULL`. Every
+processed row is labelled ('bulk' | 'fyi' | 'action-required') and stamped, so a
+re-run is a no-op over already-seen mail.
+
+Subcommands:
+  run            run the pipeline (filter → LLM → persist)
+  list           print open mail_actions (the artifact, for verification)
+
+Run flags:
+  --dry-run         filter only; show survivor counts + what WOULD be extracted; no LLM, no writes
+  --limit N         cap rows pulled from the delta (cost cap; default 150)
+  --model NAME      OpenRouter model (default $MAIL_ACTIONS_MODEL or deepseek/deepseek-v4-flash)
+  --emit-clawgate   POST a Task card per NEW action item (needs CLAWGATE_HOOK_TOKEN)
+  --json            machine-readable summary
+
+Env: OPENROUTER_API_KEY (Stage 2), KUBECONFIG (DB), CLAWGATE_HOOK_TOKEN (optional Stage 4).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import filter as f  # noqa: E402  (sibling module, not a package)
+import llm  # noqa: E402
+
+DEFAULT_LIMIT = 150
+# Rough OpenRouter price for the default cheap model (USD per 1M tokens). Estimate only.
+EST_USD_PER_1K_TOKENS = 0.0002
+EST_TOKENS_PER_MAIL = 1500  # system+subject+truncated body+output, order of magnitude
+
+
+def _est_cost(n: int) -> float:
+    return n * EST_TOKENS_PER_MAIL / 1000.0 * EST_USD_PER_1K_TOKENS
+
+
+def _partition(rows):
+    """Split delta rows into (dropped, survivors) using the Stage-1 pure filter."""
+    dropped, survivors = [], []
+    for r in rows:
+        res = f.classify(
+            from_addr=r.get("from_addr"),
+            subject=r.get("subject"),
+            category=r.get("category"),
+            headers=r.get("headers"),
+        )
+        (dropped if res.drop else survivors).append((r, res))
+    return dropped, survivors
+
+
+def cmd_run(args) -> int:
+    from _db import MailDB
+
+    with MailDB() as db:
+        db.ensure_schema()
+        rows = db.fetch_unprocessed(limit=args.limit)
+        dropped, survivors = _partition(rows)
+
+        summary = {
+            "delta_rows": len(rows),
+            "dropped_bulk": len(dropped),
+            "survivors": len(survivors),
+            "est_llm_cost_usd": round(_est_cost(len(survivors)), 4),
+        }
+
+        if args.dry_run:
+            summary["mode"] = "dry-run"
+            if args.json:
+                print(json.dumps(summary, indent=2))
+            else:
+                _print_dry_run(dropped, survivors, summary)
+            return 0
+
+        api_key_present = bool(__import__("os").environ.get("OPENROUTER_API_KEY"))
+        if not api_key_present:
+            print("ERROR: OPENROUTER_API_KEY not set — cannot run Stage 2. "
+                  "Use --dry-run for the filter-only pass.", file=sys.stderr)
+            return 2
+
+        actions = 0
+        fyis = 0
+        errors = 0
+        emitted = 0
+        for r, _res in survivors:
+            try:
+                ex = llm.extract(
+                    from_addr=r.get("from_addr") or "",
+                    subject=r.get("subject") or "",
+                    body=r.get("text_body") or "",
+                    model=args.model,
+                )
+            except Exception as exc:  # noqa: BLE001 — keep going, report at end
+                errors += 1
+                print(f"  ! extract failed mail_id={r['id']}: {exc}", file=sys.stderr)
+                continue
+
+            if ex.action_required:
+                inserted = db.insert_action({
+                    "mail_id": r["id"],
+                    "message_id": r.get("message_id"),
+                    "from_addr": r.get("from_addr"),
+                    "subject": r.get("subject"),
+                    "received_at": r.get("received_at"),
+                    **ex.as_row(),
+                })
+                db.mark_processed(r["id"], "action-required")
+                actions += 1
+                if inserted and args.emit_clawgate:
+                    emitted += _emit_clawgate(r, ex)
+            else:
+                db.mark_processed(r["id"], "fyi")
+                fyis += 1
+
+        # bulk drops: label + stamp (no LLM)
+        for r, res in dropped:
+            db.mark_processed(r["id"], "bulk")
+        db.commit()
+
+        summary.update({
+            "mode": "run",
+            "action_required": actions,
+            "fyi": fyis,
+            "extract_errors": errors,
+            "clawgate_emitted": emitted,
+            "est_llm_cost_usd": round(_est_cost(len(survivors)), 4),
+        })
+        if args.json:
+            print(json.dumps(summary, indent=2))
+        else:
+            _print_run(summary)
+        return 0
+
+
+def _emit_clawgate(r, ex) -> int:
+    try:
+        from clawgate import emit_task
+        ok = emit_task(
+            who=ex.who, ask=ex.ask, deadline=ex.deadline, amount=ex.amount,
+            source_ref=f"mail#{r['id']} {r.get('from_addr')}",
+        )
+        return 1 if ok else 0
+    except Exception as exc:  # noqa: BLE001
+        print(f"  ! clawgate emit failed mail_id={r['id']}: {exc}", file=sys.stderr)
+        return 0
+
+
+def cmd_list(args) -> int:
+    from _db import MailDB
+
+    with MailDB() as db:
+        db.ensure_schema()
+        rows = db.list_open_actions()
+    if args.json:
+        print(json.dumps([
+            {k: (v.isoformat() if hasattr(v, "isoformat") else v) for k, v in r.items()}
+            for r in rows
+        ], indent=2))
+        return 0
+    if not rows:
+        print("No open action items.")
+        return 0
+    print(f"{len(rows)} open action item(s):\n")
+    for r in rows:
+        print(f"  [{r['confidence']:.2f}] {r['who']} — {r['ask']}")
+        meta = []
+        if r.get("deadline"):
+            meta.append(f"deadline={r['deadline']}")
+        if r.get("amount"):
+            meta.append(f"amount={r['amount']}")
+        meta.append(f"from={r['from_addr']}")
+        meta.append(f"mail#{r['mail_id']}")
+        print(f"        {'  '.join(meta)}")
+        print(f"        subj: {r['subject']}\n")
+    return 0
+
+
+def _print_dry_run(dropped, survivors, summary) -> None:
+    print(f"DRY RUN — delta {summary['delta_rows']} rows "
+          f"({summary['dropped_bulk']} dropped, {summary['survivors']} survivors)")
+    print(f"  est LLM cost if run: ${summary['est_llm_cost_usd']}\n")
+    print("  Survivors (would be sent to LLM):")
+    for r, _res in survivors:
+        print(f"    mail#{r['id']:<6} {(r.get('from_addr') or '')[:36]:<36} "
+              f"{(r.get('subject') or '')[:50]!r}")
+    if not survivors:
+        print("    (none)")
+
+
+def _print_run(s) -> None:
+    print(f"RUN — delta {s['delta_rows']} rows")
+    print(f"  dropped (bulk):   {s['dropped_bulk']}")
+    print(f"  survivors → LLM:  {s['survivors']}")
+    print(f"  action-required:  {s['action_required']}")
+    print(f"  fyi:              {s['fyi']}")
+    if s["extract_errors"]:
+        print(f"  extract errors:   {s['extract_errors']}")
+    if s.get("clawgate_emitted"):
+        print(f"  clawgate emitted: {s['clawgate_emitted']}")
+    print(f"  est LLM cost:     ${s['est_llm_cost_usd']}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="mail-actions", description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    run = sub.add_parser("run", help="run the extraction pipeline")
+    run.add_argument("--dry-run", action="store_true",
+                     help="filter only; show survivors; no LLM, no writes")
+    run.add_argument("--limit", type=int, default=DEFAULT_LIMIT,
+                     help=f"max delta rows to pull (cost cap; default {DEFAULT_LIMIT})")
+    run.add_argument("--model", default=None, help="OpenRouter model id")
+    run.add_argument("--emit-clawgate", action="store_true",
+                     help="POST a clawgate Task card per NEW action item")
+    run.add_argument("--json", action="store_true", help="machine-readable summary")
+    run.set_defaults(func=cmd_run)
+
+    ls = sub.add_parser("list", help="print open mail_actions (the artifact)")
+    ls.add_argument("--json", action="store_true")
+    ls.set_defaults(func=cmd_list)
+    return p
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mail-actions/filter.py
+++ b/scripts/mail-actions/filter.py
@@ -32,6 +32,8 @@ SENDER_DENYLIST = (
     "notifications@bugsnag.com",
     "notifications@tasks.clickup.com",
     "*@signin.nasdaq.com",          # signin/security notifications (password-expiry etc.)
+    "*@info.avianca.com",           # airline MARKETING subdomain — legit booking/flight
+                                    # mail comes from other avianca addresses, not info.
 )
 
 # Headers whose mere PRESENCE marks the mail as a mailing-list / bulk / auto blast.
@@ -55,12 +57,15 @@ _BULK_PRECEDENCE = frozenset({"bulk", "list", "junk"})
 #     send invoices from a generic/noreply address (Cloudflare's noreply@notify.…).
 BILLING_SENDER_ALLOWLIST = (
     "billing@*",
-    "billing-*@*",
     "invoice@*",
     "invoices@*",
     "invoicing@*",
     "accounts@stripe.com",
     "support@datapacket.com",
+    # NOTE: no broad `billing-*@*` — vendors (e.g. LinkedIn) abuse a billing-noreply
+    # address for marketing upsell. A genuine invoice from such an address is still
+    # rescued by the transactional-subject regex below; marketing with a bulk header
+    # is not. Keeps the exemption to real bills without re-admitting upsell blasts.
 )
 _BILLING_SUBJECT_RE = re.compile(
     r"\b(invoice|past[\s-]?due|overdue|payment\s+(failed|declined|due)|"

--- a/scripts/mail-actions/filter.py
+++ b/scripts/mail-actions/filter.py
@@ -32,7 +32,12 @@ SENDER_DENYLIST = (
 )
 
 # Headers whose mere PRESENCE marks the mail as a mailing-list / bulk / auto blast.
-_BULK_PRESENCE_HEADERS = ("List-Unsubscribe", "List-Id", "Auto-Submitted")
+# Feedback-ID is the standardized ESP feedback-loop header (RFC-ish, set by SES /
+# Google / LinkedIn / Mailchimp on high-volume mail) — it catches marketing/digest
+# blasts (hubstaff job matches, LinkedIn lead digests, vetr newsletter) that omit
+# List-* headers. Verified zero genuine action threads carry it; the billing
+# exemption runs BEFORE this, so invoices that carry it (Cloudflare) are still kept.
+_BULK_PRESENCE_HEADERS = ("List-Unsubscribe", "List-Id", "Auto-Submitted", "Feedback-ID")
 # Precedence values that mark bulk mail.
 _BULK_PRECEDENCE = frozenset({"bulk", "list", "junk"})
 

--- a/scripts/mail-actions/filter.py
+++ b/scripts/mail-actions/filter.py
@@ -34,6 +34,17 @@ SENDER_DENYLIST = (
     "*@signin.nasdaq.com",          # signin/security notifications (password-expiry etc.)
     "*@info.avianca.com",           # airline MARKETING subdomain — legit booking/flight
                                     # mail comes from other avianca addresses, not info.
+    "team@notifications.resend.com",  # cancelled-subscription dunning nag (operator: ignore)
+)
+
+# Operator NOISE-by-topic rules: (sender_pattern, subject_regex). Drops mail from an
+# OTHERWISE-legit sender when the subject matches — for senders whose SOME mail matters
+# but a specific recurring topic is noise. Scoped tight so legit mail from the same
+# party still flows (e.g. VoIP low-balance warnings are noise, but a future $0 / account-
+# suspended alert has a different subject and survives). Runs BEFORE the billing
+# exemption so it can suppress topics that would otherwise be billing-rescued.
+SENDER_SUBJECT_DENYLIST = (
+    (r"*@voip.ms", re.compile(r"\blow\s+balance\b", re.IGNORECASE)),
 )
 
 # Headers whose mere PRESENCE marks the mail as a mailing-list / bulk / auto blast.
@@ -61,7 +72,6 @@ BILLING_SENDER_ALLOWLIST = (
     "invoices@*",
     "invoicing@*",
     "accounts@stripe.com",
-    "support@datapacket.com",
     # NOTE: no broad `billing-*@*` — vendors (e.g. LinkedIn) abuse a billing-noreply
     # address for marketing upsell. A genuine invoice from such an address is still
     # rescued by the transactional-subject regex below; marketing with a bulk header
@@ -112,6 +122,16 @@ def _sender_denylisted(from_addr: str | None) -> bool:
     return any(fnmatch.fnmatch(addr, pat) for pat in SENDER_DENYLIST)
 
 
+def _sender_subject_denied(from_addr: str | None, subject: str | None) -> bool:
+    """True if (sender, subject) matches an operator noise-by-topic rule."""
+    addr = (from_addr or "").strip().lower()
+    subj = subject or ""
+    for sender_pat, subj_re in SENDER_SUBJECT_DENYLIST:
+        if fnmatch.fnmatch(addr, sender_pat) and subj_re.search(subj):
+            return True
+    return False
+
+
 def _billing_exempt(from_addr: str | None, subject: str | None) -> bool:
     """True if the mail looks like transactional billing/invoice → rescue from bulk drop."""
     addr = (from_addr or "").strip().lower()
@@ -136,24 +156,28 @@ def classify(
     if (category or "").lower() == "alert":
         return FilterResult(True, "category:alert")
 
-    # 1b. billing/invoice exemption — rescue transactional money mail from the bulk
+    # 2. operator NOISE rules (sender + sender/subject denylists). These run BEFORE the
+    # billing exemption so an operator-suppressed topic (e.g. a cancelled service's
+    # "Payment failed" dunning) cannot be rescued by the billing subject regex.
+    if _sender_denylisted(from_addr):
+        return FilterResult(True, "sender:denylist")
+    if _sender_subject_denied(from_addr, subject):
+        return FilterResult(True, "sender-subject:denylist")
+
+    # 3. billing/invoice exemption — rescue transactional money mail from the bulk
     # drop below (vendors blast invoices via ESPs, so they carry List-* headers). KEEP
     # → let the LLM judge whether a bill actually needs action.
     if _billing_exempt(from_addr, subject):
         return FilterResult(False, "exempt:billing")
 
-    # 2. mailing-list / bulk / auto headers by presence.
+    # 4. mailing-list / bulk / auto headers by presence.
     for h in _BULK_PRESENCE_HEADERS:
         if _header_present(headers, h):
             return FilterResult(True, f"header:{h}")
 
-    # 3. Precedence: bulk/list/junk.
+    # 5. Precedence: bulk/list/junk.
     prec = (_header_get(headers, "Precedence") or "").strip().lower()
     if prec in _BULK_PRECEDENCE:
         return FilterResult(True, f"precedence:{prec}")
-
-    # 4. short automated-notification sender denylist.
-    if _sender_denylisted(from_addr):
-        return FilterResult(True, "sender:denylist")
 
     return FilterResult(False, "survivor")

--- a/scripts/mail-actions/filter.py
+++ b/scripts/mail-actions/filter.py
@@ -17,6 +17,7 @@ LLM. It does NOT try to enumerate newsletters; the header signals + LLM cover th
 from __future__ import annotations
 
 import fnmatch
+import re
 from dataclasses import dataclass
 
 # Senders that are unambiguously automated notification machinery. KEEP THIS SHORT —
@@ -34,6 +35,30 @@ SENDER_DENYLIST = (
 _BULK_PRESENCE_HEADERS = ("List-Unsubscribe", "List-Id", "Auto-Submitted")
 # Precedence values that mark bulk mail.
 _BULK_PRECEDENCE = frozenset({"bulk", "list", "junk"})
+
+# Billing / invoice EXEMPTION. Transactional money mail often ALSO carries bulk
+# headers (vendors blast invoices through ESPs — e.g. Cloudflare's invoice arrives
+# via sparkpost with List-Id + List-Unsubscribe), so the bulk-header drop above would
+# lose genuine action-required bills. This exemption is additive-KEEP only: it rescues
+# such mail from the drop so the LLM can judge it — it never drops anything itself, so
+# it cannot violate the never-drop-an-action-item contract.
+#   • sender allowlist: billing-style local-parts (high precision)
+#   • subject regex: HEURISTIC (per RULES — flagged) but tight; covers vendors that
+#     send invoices from a generic/noreply address (Cloudflare's noreply@notify.…).
+BILLING_SENDER_ALLOWLIST = (
+    "billing@*",
+    "billing-*@*",
+    "invoice@*",
+    "invoices@*",
+    "invoicing@*",
+    "accounts@stripe.com",
+    "support@datapacket.com",
+)
+_BILLING_SUBJECT_RE = re.compile(
+    r"\b(invoice|past[\s-]?due|overdue|payment\s+(failed|declined|due)|"
+    r"your\s+bill|statement\s+is\s+ready)\b",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -74,6 +99,14 @@ def _sender_denylisted(from_addr: str | None) -> bool:
     return any(fnmatch.fnmatch(addr, pat) for pat in SENDER_DENYLIST)
 
 
+def _billing_exempt(from_addr: str | None, subject: str | None) -> bool:
+    """True if the mail looks like transactional billing/invoice → rescue from bulk drop."""
+    addr = (from_addr or "").strip().lower()
+    if addr and any(fnmatch.fnmatch(addr, pat) for pat in BILLING_SENDER_ALLOWLIST):
+        return True
+    return bool(_BILLING_SUBJECT_RE.search(subject or ""))
+
+
 def classify(
     *,
     from_addr: str | None,
@@ -89,6 +122,12 @@ def classify(
     # 1. category alert — civitai/GPU, handled by ADS elsewhere.
     if (category or "").lower() == "alert":
         return FilterResult(True, "category:alert")
+
+    # 1b. billing/invoice exemption — rescue transactional money mail from the bulk
+    # drop below (vendors blast invoices via ESPs, so they carry List-* headers). KEEP
+    # → let the LLM judge whether a bill actually needs action.
+    if _billing_exempt(from_addr, subject):
+        return FilterResult(False, "exempt:billing")
 
     # 2. mailing-list / bulk / auto headers by presence.
     for h in _BULK_PRESENCE_HEADERS:

--- a/scripts/mail-actions/filter.py
+++ b/scripts/mail-actions/filter.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Stage 1 — deterministic noise DROP (the high-precision tier).
+
+PURE functions, NO LLM, NO DB. Given a mail row's metadata (from_addr, subject,
+category, headers dict), decide whether it is obvious bulk/notification noise that
+can be dropped WITHOUT spending an LLM call.
+
+Design contract: this tier must NEVER drop a genuine action item. When in doubt it
+KEEPS (lets the LLM judge). It only drops on unambiguous, header-driven signals:
+mailing-list / bulk headers, the `alert` category, or a SHORT denylist of senders
+that are unambiguously automated notification machinery.
+
+It deliberately does NOT blanket-drop `no-reply@` / `noreply@` — AWS / Google /
+verification / password-expiry mail can be action-required, so those survive to the
+LLM. It does NOT try to enumerate newsletters; the header signals + LLM cover those.
+"""
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass
+
+# Senders that are unambiguously automated notification machinery. KEEP THIS SHORT —
+# header signals do the heavy lifting; the LLM handles ambiguous survivors. Patterns
+# are matched case-insensitively with fnmatch (so `*@npmjs.com` covers subdomains).
+SENDER_DENYLIST = (
+    "notifications@github.com",
+    "*@npmjs.com",
+    "no-reply@pagerduty.com",
+    "notifications@bugsnag.com",
+    "notifications@tasks.clickup.com",
+)
+
+# Headers whose mere PRESENCE marks the mail as a mailing-list / bulk / auto blast.
+_BULK_PRESENCE_HEADERS = ("List-Unsubscribe", "List-Id", "Auto-Submitted")
+# Precedence values that mark bulk mail.
+_BULK_PRECEDENCE = frozenset({"bulk", "list", "junk"})
+
+
+@dataclass(frozen=True)
+class FilterResult:
+    """Outcome of the Stage-1 decision for one mail row."""
+
+    drop: bool          # True → label 'bulk', mark processed, NO LLM
+    reason: str         # short machine-readable reason (e.g. "header:List-Id")
+
+
+def _header_get(headers: dict | None, key: str) -> str | None:
+    """Case-insensitive header lookup; returns the value or None."""
+    if not headers:
+        return None
+    if key in headers:
+        return headers[key]
+    lk = key.lower()
+    for k, v in headers.items():
+        if k.lower() == lk:
+            return v
+    return None
+
+
+def _header_present(headers: dict | None, key: str) -> bool:
+    """Case-insensitive header presence (a key present with value None still counts)."""
+    if not headers:
+        return False
+    if key in headers:
+        return True
+    lk = key.lower()
+    return any(k.lower() == lk for k in headers)
+
+
+def _sender_denylisted(from_addr: str | None) -> bool:
+    if not from_addr:
+        return False
+    addr = from_addr.strip().lower()
+    return any(fnmatch.fnmatch(addr, pat) for pat in SENDER_DENYLIST)
+
+
+def classify(
+    *,
+    from_addr: str | None,
+    subject: str | None,
+    category: str | None,
+    headers: dict | None,
+) -> FilterResult:
+    """Pure Stage-1 decision for a single mail row.
+
+    Returns FilterResult(drop=True, reason=...) to DROP as bulk noise, or
+    FilterResult(drop=False, reason="survivor") to pass on to the LLM tier.
+    """
+    # 1. category alert — civitai/GPU, handled by ADS elsewhere.
+    if (category or "").lower() == "alert":
+        return FilterResult(True, "category:alert")
+
+    # 2. mailing-list / bulk / auto headers by presence.
+    for h in _BULK_PRESENCE_HEADERS:
+        if _header_present(headers, h):
+            return FilterResult(True, f"header:{h}")
+
+    # 3. Precedence: bulk/list/junk.
+    prec = (_header_get(headers, "Precedence") or "").strip().lower()
+    if prec in _BULK_PRECEDENCE:
+        return FilterResult(True, f"precedence:{prec}")
+
+    # 4. short automated-notification sender denylist.
+    if _sender_denylisted(from_addr):
+        return FilterResult(True, "sender:denylist")
+
+    return FilterResult(False, "survivor")

--- a/scripts/mail-actions/filter.py
+++ b/scripts/mail-actions/filter.py
@@ -10,9 +10,10 @@ KEEPS (lets the LLM judge). It only drops on unambiguous, header-driven signals:
 mailing-list / bulk headers, the `alert` category, or a SHORT denylist of senders
 that are unambiguously automated notification machinery.
 
-It deliberately does NOT blanket-drop `no-reply@` / `noreply@` — AWS / Google /
-verification / password-expiry mail can be action-required, so those survive to the
-LLM. It does NOT try to enumerate newsletters; the header signals + LLM cover those.
+It deliberately does NOT blanket-drop `no-reply@` / `noreply@` — AWS / Google sign-in
+verification codes can be action-required, so those survive to the LLM. It does NOT try
+to enumerate newsletters; the header signals + LLM cover those. Specific automated
+notification senders (GitHub, nasdaq signin, …) ARE denylisted by address below.
 """
 from __future__ import annotations
 
@@ -24,11 +25,13 @@ from dataclasses import dataclass
 # header signals do the heavy lifting; the LLM handles ambiguous survivors. Patterns
 # are matched case-insensitively with fnmatch (so `*@npmjs.com` covers subdomains).
 SENDER_DENYLIST = (
-    "notifications@github.com",
+    "*@github.com",                 # all GitHub mail is automated: PR/issue activity
+                                    # AND account-security audit notices (new key/PAT/OAuth)
     "*@npmjs.com",
     "no-reply@pagerduty.com",
     "notifications@bugsnag.com",
     "notifications@tasks.clickup.com",
+    "*@signin.nasdaq.com",          # signin/security notifications (password-expiry etc.)
 )
 
 # Headers whose mere PRESENCE marks the mail as a mailing-list / bulk / auto blast.

--- a/scripts/mail-actions/llm.py
+++ b/scripts/mail-actions/llm.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Stage 2 — LLM extraction over Stage-1 survivors.
+
+Sends subject + from + a truncated body to an OpenRouter chat model and extracts a
+STRICT JSON action object. Pure-ish: the network call is isolated in `_call_openrouter`
+so the parser/validator (`parse_extraction`) and the sanity guard are unit-testable
+without a key or network.
+
+JSON contract returned per mail:
+    {
+      "action_required": bool,
+      "who": str,
+      "ask": str,           # one sentence
+      "deadline": str|null,
+      "amount": str|null,
+      "confidence": float,  # 0..1
+      "reason": str
+    }
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+
+DEFAULT_MODEL = "deepseek/deepseek-v4-flash"
+OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+BODY_TRUNCATE = 4000  # chars of text_body sent to the model (bounds token cost)
+
+SYSTEM_PROMPT = (
+    "You triage a personal inbox for ACTION-REQUIRED email. Given one email's sender, "
+    "subject and a truncated body, decide if the recipient must DO something (reply, "
+    "pay, sign, submit info, approve, schedule) — as opposed to FYI/marketing/receipts. "
+    "Return ONLY a JSON object, no prose, with EXACTLY these keys: "
+    "action_required (bool), who (string: the person/org awaiting action), "
+    "ask (string: one sentence describing what to do; empty string if none), "
+    "deadline (string or null), amount (string or null, e.g. '$1,200'), "
+    "confidence (number 0..1), reason (short string). "
+    "Bias: receipts/newsletters/digests/status updates are NOT action_required."
+)
+
+REQUIRED_KEYS = ("action_required", "who", "ask", "deadline", "amount", "confidence", "reason")
+
+
+@dataclass(frozen=True)
+class Extraction:
+    action_required: bool
+    who: str
+    ask: str
+    deadline: str | None
+    amount: str | None
+    confidence: float
+    reason: str
+
+    def as_row(self) -> dict:
+        return {
+            "who": self.who,
+            "ask": self.ask,
+            "deadline": self.deadline,
+            "amount": self.amount,
+            "confidence": self.confidence,
+            "reason": self.reason,
+        }
+
+
+class ExtractionError(ValueError):
+    """Raised when the model output cannot be parsed into a valid Extraction."""
+
+
+def _coerce_bool(v) -> bool:
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, str):
+        return v.strip().lower() in ("true", "yes", "1")
+    return bool(v)
+
+
+def _coerce_float01(v) -> float:
+    try:
+        f = float(v)
+    except (TypeError, ValueError) as exc:
+        raise ExtractionError(f"confidence not a number: {v!r}") from exc
+    return max(0.0, min(1.0, f))
+
+
+def _strip_to_json(text: str) -> str:
+    """Pull the first {...} block out of a possibly-fenced model reply."""
+    text = text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```[a-zA-Z]*\n?", "", text)
+        text = re.sub(r"\n?```$", "", text).strip()
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end < start:
+        raise ExtractionError("no JSON object found in model output")
+    return text[start : end + 1]
+
+
+def parse_extraction(text: str) -> Extraction:
+    """Parse + validate raw model text into an Extraction. Raises ExtractionError.
+
+    Applies the deterministic sanity guard: action_required=True with an empty `ask`
+    is downgraded to action_required=False (an FYI), because an action with no stated
+    ask is not actionable.
+    """
+    try:
+        obj = json.loads(_strip_to_json(text))
+    except json.JSONDecodeError as exc:
+        raise ExtractionError(f"invalid JSON: {exc}") from exc
+    if not isinstance(obj, dict):
+        raise ExtractionError("JSON is not an object")
+    missing = [k for k in REQUIRED_KEYS if k not in obj]
+    if missing:
+        raise ExtractionError(f"missing keys: {missing}")
+
+    action = _coerce_bool(obj["action_required"])
+    ask = str(obj.get("ask") or "").strip()
+    # sanity guard: action with no ask → downgrade to fyi.
+    if action and not ask:
+        action = False
+
+    def _opt(v):
+        if v is None:
+            return None
+        s = str(v).strip()
+        return s or None
+
+    return Extraction(
+        action_required=action,
+        who=str(obj.get("who") or "").strip(),
+        ask=ask,
+        deadline=_opt(obj.get("deadline")),
+        amount=_opt(obj.get("amount")),
+        confidence=_coerce_float01(obj.get("confidence")),
+        reason=str(obj.get("reason") or "").strip(),
+    )
+
+
+def build_user_prompt(*, from_addr: str, subject: str, body: str) -> str:
+    body = (body or "")[:BODY_TRUNCATE]
+    return (
+        f"From: {from_addr}\n"
+        f"Subject: {subject}\n"
+        f"---\n{body}"
+    )
+
+
+def _call_openrouter(model: str, user_prompt: str, api_key: str, timeout: float = 60.0) -> str:
+    """POST to OpenRouter; return the assistant message content. Network-only — mocked in tests."""
+    import requests
+
+    resp = requests.post(
+        OPENROUTER_URL,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "X-Title": "devrc-mail-actions",
+        },
+        json={
+            "model": model,
+            "temperature": 0,
+            "response_format": {"type": "json_object"},
+            "messages": [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ],
+        },
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return data["choices"][0]["message"]["content"]
+
+
+def extract(
+    *,
+    from_addr: str,
+    subject: str,
+    body: str,
+    model: str | None = None,
+    api_key: str | None = None,
+    _caller=_call_openrouter,
+) -> Extraction:
+    """Run one extraction with a single malformed-output retry. `_caller` is injectable."""
+    model = model or os.environ.get("MAIL_ACTIONS_MODEL", DEFAULT_MODEL)
+    api_key = api_key or os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENROUTER_API_KEY not set")
+    prompt = build_user_prompt(from_addr=from_addr, subject=subject, body=body)
+    last_err: Exception | None = None
+    for _ in range(2):  # one retry on malformed output
+        raw = _caller(model, prompt, api_key)
+        try:
+            return parse_extraction(raw)
+        except ExtractionError as exc:
+            last_err = exc
+    raise ExtractionError(f"model output invalid after retry: {last_err}")

--- a/scripts/mail-actions/tests/fixtures/mail_headers.json
+++ b/scripts/mail-actions/tests/fixtures/mail_headers.json
@@ -168,5 +168,33 @@
     "id": 39150,
     "message_id": "<6a41fd688f6a3@sidekiq.mail>",
     "subject": "[rest.gateway.api.mobl.ca] Weekly stability summary"
+  },
+  {
+    "category": "personal",
+    "from_addr": "talent@hubstaff.com",
+    "headers": {
+      "Date": "Mon, 29 Jun 2026 14:35:53 +0000",
+      "From": "Hubstaff Talent <talent@hubstaff.com>",
+      "Subject": "Top Jobs Matches for Zachary Lowden",
+      "Feedback-ID": "::1.us-east-1.lEocHt686HTBLUhcrsJm25BkLA92FMrj9JB1EtAg84w=:AmazonSES",
+      "Return-Path": "<0100019f13cee16f-749c705a-8b71-4c10-bc1b-c172906d64bd-000000@notify.hubstaff.com>"
+    },
+    "id": 45343,
+    "message_id": "<0100019f13cee16f-749c705a-8b71-4c10-bc1b-c172906d64bd-000000@us-east-1.amazonses.com>",
+    "subject": "Top Jobs Matches for Zachary Lowden"
+  },
+  {
+    "category": "notification",
+    "from_addr": "messages-noreply@linkedin.com",
+    "headers": {
+      "Date": "Mon, 29 Jun 2026 19:26:30 +0000 (UTC)",
+      "From": "LinkedIn <messages-noreply@linkedin.com>",
+      "Subject": "Zachary, you have 18 new lead suggestions",
+      "Feedback-ID": "email_lss_new_autogen_list_entities_digest_v2:linkedin",
+      "Return-Path": "<m-bvhg51w93zjhjk8z1uazi7z4tisebf5jlojthxqdrfrzp6jvl7pq1qe7scnvxr@bounce.linkedin.com>"
+    },
+    "id": 48326,
+    "message_id": "<linkedin-lss-digest-48326@linkedin.com>",
+    "subject": "Zachary, you have 18 new lead suggestions"
   }
 ]

--- a/scripts/mail-actions/tests/fixtures/mail_headers.json
+++ b/scripts/mail-actions/tests/fixtures/mail_headers.json
@@ -1,0 +1,172 @@
+[
+  {
+    "category": "personal",
+    "from_addr": "sales@zenpayments.com",
+    "headers": {
+      "Date": "Mon, 29 Jun 2026 00:39:01 +0000 (GMT)",
+      "From": "Zen Payments <sales@zenpayments.com>",
+      "Subject": "Application Incomplete for Civitai",
+      "To": "\"zach@civitai.com\" <zach@civitai.com>"
+    },
+    "id": 36442,
+    "message_id": "<PoofO000000000000000000000000000000000000000000000THDB5100YIGyX7AiSQKf5abjzeRUsg@sfdc.net>",
+    "subject": "Application Incomplete for Civitai"
+  },
+  {
+    "category": "personal",
+    "from_addr": "kara.redford@zenpayments.com",
+    "headers": {
+      "Date": "Mon, 29 Jun 2026 20:10:29 +0000",
+      "From": "Kara Redford <kara.redford@zenpayments.com>",
+      "Subject": "Re: Zen Payments Merchant Account for",
+      "To": "Justin Maier <justin@civitai.com>"
+    },
+    "id": 48374,
+    "message_id": "<SN6PR13MB251043565280E54716B7DFDE96E82@SN6PR13MB2510.namprd13.prod.outlook.com>",
+    "subject": "Re: Zen Payments Merchant Account for"
+  },
+  {
+    "category": "personal",
+    "from_addr": "accounts@stripe.com",
+    "headers": {
+      "Date": "Mon, 29 Jun 2026 04:34:41 +0000 (GMT)",
+      "From": "Stripe Support <accounts@stripe.com>",
+      "Subject": "Re: [Action required] Share more details about vetr llc",
+      "To": "\"zachlowden1@gmail.com\" <zachlowden1@gmail.com>"
+    },
+    "id": 38796,
+    "message_id": "<mEUT0000000000000000000000000000000000000000000000THDM1R00DkPnOe9zSeicW-DJsHGjXg@sfdc.net>",
+    "subject": "Re: [Action required] Share more details about vetr llc"
+  },
+  {
+    "category": "personal",
+    "from_addr": "lauren@naidacom.com",
+    "headers": {
+      "Date": "Mon, 29 Jun 2026 13:31:01 -0500",
+      "From": "Lauren Mitchosky <lauren@naidacom.com>",
+      "Subject": "Re: Sales Audit Excel Template",
+      "To": "Zach Lowden <zachlowden1@gmail.com>"
+    },
+    "id": 48072,
+    "message_id": "<272E015A-ED26-4DAE-AE72-22F51773BE0C@naidacom.com>",
+    "subject": "Re: Sales Audit Excel Template"
+  },
+  {
+    "category": "personal",
+    "from_addr": "billing@hetzner.com",
+    "headers": {
+      "Date": "Sun, 28 Jun 2026 02:27:26 +0200",
+      "From": "Accounting - Hetzner Online GmbH <billing@hetzner.com>",
+      "Subject": "Hetzner Online GmbH - Invoice 082000970828 (K0803356324)",
+      "To": "zachlowden1@gmail.com"
+    },
+    "id": 22321,
+    "message_id": "<1782606446.6a406a6ede770@efs-ws.hetzner.de>",
+    "subject": "Hetzner Online GmbH - Invoice 082000970828 (K0803356324)"
+  },
+  {
+    "category": "notification",
+    "from_addr": "noreply@notify.cloudflare.com",
+    "headers": {
+      "Date": "Sat, 27 Jun 2026 11:56:26 +0000",
+      "From": "\"Cloudflare\" <noreply@notify.cloudflare.com>",
+      "List-Id": "<spc.265094.0.sparkpostmail.com>",
+      "List-Unsubscribe": "<mailto:unsubscribe@unsub.spmta.com?subject=unsubscribe%3ADoOY5PaPKcDjZXcxjualWI2RqH8RY198qCN7MHEn5zw~%7CeyAicmNwdF90byI6ICJ6YWN4ZGV2QGdtYWlsLmNvbSIsICJ0ZW5hbnRfaWQiOiAic3BjIiwgImN1c3RvbWVyX2lkIjogIjI2NTA5NCIsICJzdWJhY2NvdW50X2lkIjogIjAiLCAibWVzc2FnZV9pZCI6ICI2YTNlNmFiYTNmNmFmYzIxNDNjYiIgfQ~~>,<https://unsubscribe.spmta.com/u/7ZqLQD449VwrX1wxE2s9kw~~/AAQLhhA~/HMsjICNj6Kxbi3ZBDH6hbTs4xtc0wG2WKBvmCh_eormrxFhANd6L1RAmz932_hSOoW93adZiRdpiEmne-FGq-g~~>",
+      "Subject": "Your invoice is attached",
+      "To": "zacxdev@gmail.com"
+    },
+    "id": 14563,
+    "message_id": "<BC.3C.25922.A6ABF3A6@i-0ed925b9e69ce275e.mta1vrest.sd.prd.sparkpost>",
+    "subject": "Your invoice is attached"
+  },
+  {
+    "category": "notification",
+    "from_addr": "notifications@github.com",
+    "headers": {
+      "Date": "Mon, 29 Jun 2026 14:43:01 -0700",
+      "From": "Zachary Lowden <notifications@github.com>",
+      "List-Unsubscribe": "<mailto:unsub+CEL4N7E2P7N5CAPGZXDP6Z3KXQYOLEVBNHHQAAAAAEOGSLTU@reply.github.com>,\r\n <https://github.com/notifications/unsubscribe/one-click/CEL4N7CNOVMGWSNYUUVMOTL5CLPGLAVCNFSNUABFKJSXA33TNF2G64TZHM2TIOJYGMYDIMJTHNEXG43VMU5TINZXGE3DEMRVGE3KC5QC>",
+      "Precedence": "list",
+      "Reply-To": "civitai/civitai <reply+CEL4N7E2P7N5CAPGZXDP6Z3KXQYOLEVBNHHQAAAAAEOGSLTU@reply.github.com>",
+      "Subject": "Re: [civitai/civitai] feat(app-blocks): support off-site\r\n (external-link) apps in listings (PR #2821)",
+      "To": "civitai/civitai <civitai@noreply.github.com>"
+    },
+    "id": 48450,
+    "message_id": "<civitai/civitai/pull/2821/issue_event/27350659147@github.com>",
+    "subject": "Re: [civitai/civitai] feat(app-blocks): support off-site\r\n (external-link) apps in listings (PR #2821)"
+  },
+  {
+    "category": "personal",
+    "from_addr": "support@npmjs.com",
+    "headers": {
+      "Date": "Sun, 28 Jun 2026 22:28:55 +0000",
+      "From": "npm <support@npmjs.com>",
+      "Subject": "Successfully published @civitai/blocks-react@0.15.3",
+      "To": "devzacx <zachlowden1@gmail.com>"
+    },
+    "id": 35230,
+    "message_id": "<0101019f10599c00-a2f34bfb-fd3e-4be0-9f96-e28a293420a0-000000@us-west-2.amazonses.com>",
+    "subject": "Successfully published @civitai/blocks-react@0.15.3"
+  },
+  {
+    "category": "alert",
+    "from_addr": "alerts@civitaic.com",
+    "headers": {
+      "Date": "Mon, 29 Jun 2026 21:53:25 +0000",
+      "From": "\"GoAlert\" <alerts@civitaic.com>",
+      "Subject": "Alert #132619: FIRING: GPU Fleet: Root disk filling up",
+      "To": "zach@civitai.com"
+    },
+    "id": 48454,
+    "message_id": "<20260629215325.25E03310E9FDF@smtp-relay.civitaic.com>",
+    "subject": "Alert #132619: FIRING: GPU Fleet: Root disk filling up"
+  },
+  {
+    "category": "notification",
+    "from_addr": "notifications@github.com",
+    "headers": {
+      "Date": "Mon, 29 Jun 2026 14:23:28 -0700",
+      "From": "\"Zachary Lowden\" <notifications@github.com>",
+      "List-Id": "vetrllc/vetr-app <vetr-app.vetrllc.github.com>",
+      "Precedence": "list",
+      "Reply-To": "vetrllc/vetr-app <vetr-app@noreply.github.com>",
+      "Subject": "[vetrllc/vetr-app] PR run failed: tests - fix(checkout):\r\n gateway-aware pay-now checkout (authnet) + servicer card-on-file (06dca46)",
+      "To": "\"vetrllc/vetr-app\" <vetr-app@noreply.github.com>"
+    },
+    "id": 48429,
+    "message_id": "<vetrllc/vetr-app/check-suites/CS_kwDOSPOrP88AAAAR2znEmA/1782768188@github.com>",
+    "subject": "[vetrllc/vetr-app] PR run failed: tests - fix(checkout):\r\n gateway-aware pay-now checkout (authnet) + servicer card-on-file (06dca46)"
+  },
+  {
+    "category": "personal",
+    "from_addr": "lucy@buildcanada.com",
+    "headers": {
+      "Date": "Mon, 29 Jun 2026 08:49:44 -0400",
+      "From": "Lucy Hargreaves <lucy@buildcanada.com>",
+      "List-Unsubscribe": "<mailto:1axdgbp1mkn21xnh34kr3yzjnfkfne2yhx0oto-zachlowden1=gmail.com@bf01.na3.hubspotstarter.net?subject=unsubscribe>, <https://landing.buildcanada.com/hs/subscription-preferences/v2/unsubscribe-all?data=aV2ncw96hK95CW6FVHsG5drjnFW83bZGy4kdXppW7_3syt8zGNXmW4TP1qP79t9wlVb-Zdd90lTZcVS7WQL7D0xtTW5c1Q5n2p2vgPW3xC1NK2pMzl3W6g55kn3qkCl0W736jK82R59l0W99KDzG5fS_Zlf20SnHq04>",
+      "Precedence": "bulk",
+      "Reply-To": "lucy@buildcanada.com",
+      "Subject": "Build Canada: A Few Things from this Week...",
+      "To": "zachlowden1@gmail.com"
+    },
+    "id": 44190,
+    "message_id": "<1782737382279.d3f20826-5403-489d-aeef-18d6415c6fc4@bf01.na3.hubspotstarter.net>",
+    "subject": "Build Canada: A Few Things from this Week..."
+  },
+  {
+    "category": "notification",
+    "from_addr": "noreply@signin.nasdaq.com",
+    "headers": {},
+    "id": 21720,
+    "message_id": "<76740571.58352.1782602586460@okta.com>",
+    "subject": "[Nasdaq Signin] Your Nasdaq Signin password is expiring!"
+  },
+  {
+    "category": "notification",
+    "from_addr": "notifications@bugsnag.com",
+    "headers": {},
+    "id": 39150,
+    "message_id": "<6a41fd688f6a3@sidekiq.mail>",
+    "subject": "[rest.gateway.api.mobl.ca] Weekly stability summary"
+  }
+]

--- a/scripts/mail-actions/tests/test_filter.py
+++ b/scripts/mail-actions/tests/test_filter.py
@@ -107,6 +107,45 @@ def test_billing_sender_allowlist_survives():
     assert not res.drop and res.reason == "exempt:billing"
 
 
+def test_resend_dunning_dropped_despite_billing_subject():
+    # Cancelled-subscription dunning. Subject "Payment failed" matches the billing
+    # regex, but the sender denylist runs FIRST → it drops, not billing-rescued.
+    res = f.classify(from_addr="team@notifications.resend.com",
+                     subject="Payment failed for zachlowden1 Resend subscription",
+                     category="personal", headers={"Feedback-ID": "x:ses"})
+    assert res.drop and res.reason == "sender:denylist"
+
+
+def test_voip_low_balance_dropped_but_zero_balance_survives():
+    # Low-balance warnings are noise (operator: care only when it hits 0). A future
+    # $0 / suspended alert has a different subject and MUST survive.
+    low = f.classify(from_addr="noreply@voip.ms", subject="VoIP.ms - Low Balance",
+                     category="personal", headers={})
+    assert low.drop and low.reason == "sender-subject:denylist"
+    zero = f.classify(from_addr="noreply@voip.ms",
+                      subject="VoIP.ms - Account suspended (balance depleted)",
+                      category="personal", headers={})
+    assert not zero.drop, "zero-balance/suspended alert must reach the LLM"
+
+
+def test_datapacket_ddos_dropped_but_real_mail_survives():
+    # DDoS reports (operator: false alarms) carry Feedback-ID and are no longer
+    # billing-exempted → drop. A real support reply (no bulk header) survives; a real
+    # invoice (invoice subject) is still billing-rescued.
+    ddos = f.classify(from_addr="support@datapacket.com",
+                      subject="DDoS detected on one of your servers",
+                      category="notification", headers={"Feedback-ID": "x:ses"})
+    assert ddos.drop and ddos.reason == "header:Feedback-ID"
+    reply = f.classify(from_addr="support@datapacket.com",
+                       subject="Re: ticket #4412 server provisioning",
+                       category="personal", headers={})
+    assert not reply.drop, "genuine datapacket support reply must survive"
+    invoice = f.classify(from_addr="support@datapacket.com",
+                         subject="Your invoice is ready", category="notification",
+                         headers={"Feedback-ID": "x:ses"})
+    assert not invoice.drop and invoice.reason == "exempt:billing"
+
+
 def test_avianca_marketing_subdomain_dropped():
     res = f.classify(from_addr="avianca@info.avianca.com",
                      subject="Tu cabina, tu experiencia de vuelo",

--- a/scripts/mail-actions/tests/test_filter.py
+++ b/scripts/mail-actions/tests/test_filter.py
@@ -89,6 +89,35 @@ def test_newsletter_with_list_unsubscribe_dropped():
     assert res.drop and res.reason.startswith("header:") or res.reason.startswith("precedence:")
 
 
+def test_billing_invoice_survives_despite_bulk_headers():
+    # Cloudflare invoice (noreply@notify.cloudflare.com) arrives via sparkpost with
+    # List-Id + List-Unsubscribe; the billing exemption must rescue it from the bulk
+    # drop so the LLM can judge it. Subject "Your invoice is attached".
+    cf = BY_ID[14563]
+    res = classify_fixture(cf)
+    assert not res.drop, "billing invoice wrongly dropped as bulk"
+    assert res.reason == "exempt:billing"
+
+
+def test_billing_sender_allowlist_survives():
+    # billing@hetzner.com is covered by the billing@* sender pattern even if it ever
+    # gained bulk headers.
+    res = f.classify(from_addr="billing@hetzner.com", subject="Monthly statement",
+                     category="personal", headers={"List-Id": "<x>"})
+    assert not res.drop and res.reason == "exempt:billing"
+
+
+def test_billing_subject_regex_is_tight():
+    # A newsletter that merely MENTIONS billing in prose should NOT trip the exemption
+    # (the regex matches whole billing words, not arbitrary substrings).
+    res = f.classify(from_addr="newsletter@vetr.com",
+                     subject="Tips for invoicing… subscribe!",
+                     category="personal",
+                     headers={"List-Unsubscribe": "<x>"})
+    # 'invoicing' in prose is not in the regex's word set → stays dropped as bulk.
+    assert res.drop
+
+
 def test_noreply_without_list_headers_survives_to_llm():
     # nasdaq password-expiry: no-reply, no List headers → MUST reach the LLM, not be
     # blanket-dropped (could be action-required).

--- a/scripts/mail-actions/tests/test_filter.py
+++ b/scripts/mail-actions/tests/test_filter.py
@@ -118,9 +118,33 @@ def test_billing_subject_regex_is_tight():
     assert res.drop
 
 
+def test_feedback_id_marketing_dropped():
+    # hubstaff job-matches + LinkedIn lead-digest carry NO List-* headers but DO carry
+    # the ESP Feedback-ID header → must drop without burning an LLM call.
+    for mid in (45343, 48326):
+        res = classify_fixture(BY_ID[mid])
+        assert res.drop and res.reason == "header:Feedback-ID", \
+            f"feedback-id noise {mid} not dropped ({res.reason})"
+
+
+def test_feedback_id_unit():
+    res = f.classify(from_addr="x@y.com", subject="Weekly digest",
+                     category="personal", headers={"Feedback-ID": "abc:ses"})
+    assert res.drop and res.reason == "header:Feedback-ID"
+
+
+def test_billing_invoice_with_feedback_id_still_kept():
+    # An invoice that ALSO carries Feedback-ID must still be rescued — the billing
+    # exemption runs before the header drop.
+    res = f.classify(from_addr="billing@vendor.com", subject="Your invoice is attached",
+                     category="notification",
+                     headers={"Feedback-ID": "x:ses", "List-Unsubscribe": "<u>"})
+    assert not res.drop and res.reason == "exempt:billing"
+
+
 def test_noreply_without_list_headers_survives_to_llm():
-    # nasdaq password-expiry: no-reply, no List headers → MUST reach the LLM, not be
-    # blanket-dropped (could be action-required).
+    # nasdaq password-expiry: no-reply, no List/Feedback headers → MUST reach the LLM,
+    # not be blanket-dropped (could be action-required).
     nasdaq = BY_ID[21720]
     assert not classify_fixture(nasdaq).drop
 

--- a/scripts/mail-actions/tests/test_filter.py
+++ b/scripts/mail-actions/tests/test_filter.py
@@ -142,11 +142,28 @@ def test_billing_invoice_with_feedback_id_still_kept():
     assert not res.drop and res.reason == "exempt:billing"
 
 
-def test_noreply_without_list_headers_survives_to_llm():
-    # nasdaq password-expiry: no-reply, no List/Feedback headers → MUST reach the LLM,
-    # not be blanket-dropped (could be action-required).
-    nasdaq = BY_ID[21720]
-    assert not classify_fixture(nasdaq).drop
+def test_github_noreply_security_notices_dropped():
+    # noreply@github.com account-security audit mail (new key/PAT/OAuth) carries no
+    # List-* headers but is automated noise → dropped by the *@github.com denylist.
+    res = f.classify(from_addr="noreply@github.com",
+                     subject="[GitHub] A new public key was added to vetrllc/vetr-api",
+                     category="notification", headers={})
+    assert res.drop and res.reason == "sender:denylist"
+
+
+def test_nasdaq_signin_dropped():
+    # nasdaq signin/password-expiry notification → denylisted (operator: noise).
+    res = classify_fixture(BY_ID[21720])
+    assert res.drop and res.reason == "sender:denylist"
+
+
+def test_aws_google_verification_still_survives():
+    # The genuine-verification carve-out: AWS/Google sign-in codes are NOT denylisted
+    # and carry no bulk headers → still reach the LLM.
+    for addr in ("no-reply@signin.aws.amazon.com", "no-reply@accounts.google.com"):
+        res = f.classify(from_addr=addr, subject="Your verification code",
+                         category="notification", headers={})
+        assert not res.drop, f"{addr} wrongly dropped"
 
 
 # -- pure-unit coverage of the primitives ---------------------------------

--- a/scripts/mail-actions/tests/test_filter.py
+++ b/scripts/mail-actions/tests/test_filter.py
@@ -1,0 +1,121 @@
+"""Stage-1 deterministic-filter tests against real fixtures.
+
+Run: nix-shell -p python312Packages.pytest --run "pytest scripts/mail-actions/tests"
+
+The fixtures in fixtures/mail_headers.json are scrubbed real mail (headers + from +
+subject only — NO bodies) pulled from the live inbox: the genuine action threads
+(Zen/Stripe/naida/Hetzner) plus representative noise (github, npm, alert, newsletters
+with/without List-Unsubscribe, a no-reply password-expiry).
+
+Contract under test: the high-precision tier must NEVER drop a genuine action item,
+and MUST drop unambiguous bulk/notification noise.
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import filter as f  # noqa: E402
+
+FIXTURES = json.loads((Path(__file__).parent / "fixtures" / "mail_headers.json").read_text())
+BY_ID = {r["id"]: r for r in FIXTURES}
+
+
+def classify_fixture(r):
+    return f.classify(
+        from_addr=r["from_addr"], subject=r["subject"],
+        category=r["category"], headers=r["headers"],
+    )
+
+
+# Genuine action threads — must SURVIVE Stage 1 (reach the LLM). Pulled from live mail.
+ACTION_SENDERS = {
+    "sales@zenpayments.com",
+    "kara.redford@zenpayments.com",
+    "accounts@stripe.com",
+    "lauren@naidacom.com",
+    "billing@hetzner.com",
+}
+
+
+def test_genuine_action_threads_survive():
+    survived = {r["from_addr"] for r in FIXTURES
+                if r["from_addr"] in ACTION_SENDERS and not classify_fixture(r).drop}
+    missing = ACTION_SENDERS - survived
+    assert not missing, f"genuine action threads wrongly dropped: {missing}"
+
+
+def test_no_action_thread_is_dropped():
+    for r in FIXTURES:
+        if r["from_addr"] in ACTION_SENDERS:
+            assert not classify_fixture(r).drop, f"dropped action thread {r['id']} {r['from_addr']}"
+
+
+def test_alert_category_dropped():
+    alerts = [r for r in FIXTURES if r["category"] == "alert"]
+    assert alerts, "fixture set should contain at least one alert"
+    for r in alerts:
+        res = classify_fixture(r)
+        assert res.drop and res.reason == "category:alert"
+
+
+def test_github_notifications_dropped():
+    gh = [r for r in FIXTURES if r["from_addr"] == "notifications@github.com"]
+    assert gh, "fixture set should contain github notifications"
+    for r in gh:
+        assert classify_fixture(r).drop, f"github notification {r['id']} not dropped"
+
+
+def test_npm_dropped_via_glob():
+    # support@npmjs.com is covered by the `*@npmjs.com` denylist pattern.
+    npm = [r for r in FIXTURES if r["from_addr"].endswith("@npmjs.com")]
+    assert npm, "fixture set should contain an npmjs.com sender"
+    for r in npm:
+        res = classify_fixture(r)
+        assert res.drop and res.reason == "sender:denylist"
+
+
+def test_bugsnag_dropped_via_denylist():
+    bs = [r for r in FIXTURES if r["from_addr"] == "notifications@bugsnag.com"]
+    assert bs
+    for r in bs:
+        assert classify_fixture(r).drop
+
+
+def test_newsletter_with_list_unsubscribe_dropped():
+    # buildcanada newsletter carries List-Unsubscribe + Precedence: bulk.
+    nl = BY_ID[44190]
+    res = classify_fixture(nl)
+    assert res.drop and res.reason.startswith("header:") or res.reason.startswith("precedence:")
+
+
+def test_noreply_without_list_headers_survives_to_llm():
+    # nasdaq password-expiry: no-reply, no List headers → MUST reach the LLM, not be
+    # blanket-dropped (could be action-required).
+    nasdaq = BY_ID[21720]
+    assert not classify_fixture(nasdaq).drop
+
+
+# -- pure-unit coverage of the primitives ---------------------------------
+def test_header_presence_is_case_insensitive():
+    assert f.classify(from_addr="x@y.com", subject="s", category="personal",
+                      headers={"list-id": "<x>"}).drop
+
+
+def test_precedence_bulk_dropped():
+    res = f.classify(from_addr="x@y.com", subject="s", category="personal",
+                     headers={"Precedence": "Bulk"})
+    assert res.drop and res.reason == "precedence:bulk"
+
+
+def test_plain_personal_mail_survives():
+    res = f.classify(from_addr="human@example.com", subject="can we meet?",
+                     category="personal", headers={"From": "human@example.com"})
+    assert not res.drop and res.reason == "survivor"
+
+
+def test_no_reply_not_blanket_dropped():
+    res = f.classify(from_addr="no-reply@signin.aws.amazon.com",
+                     subject="Your verification code", category="notification",
+                     headers={})
+    assert not res.drop

--- a/scripts/mail-actions/tests/test_filter.py
+++ b/scripts/mail-actions/tests/test_filter.py
@@ -107,6 +107,32 @@ def test_billing_sender_allowlist_survives():
     assert not res.drop and res.reason == "exempt:billing"
 
 
+def test_avianca_marketing_subdomain_dropped():
+    res = f.classify(from_addr="avianca@info.avianca.com",
+                     subject="Tu cabina, tu experiencia de vuelo",
+                     category="personal", headers={})
+    assert res.drop and res.reason == "sender:denylist"
+
+
+def test_linkedin_billing_noreply_upsell_not_rescued():
+    # LinkedIn abuses billing-noreply@ for Sales Navigator upsell; it carries
+    # Feedback-ID. Without the broad billing-*@ allowlist it must NOT be exempted →
+    # it drops on the bulk header instead of reaching the LLM.
+    res = f.classify(from_addr="billing-noreply@linkedin.com",
+                     subject="Maximize your Sales Navigator benefits.",
+                     category="personal", headers={"Feedback-ID": "x:linkedin"})
+    assert res.drop and res.reason == "header:Feedback-ID"
+
+
+def test_genuine_billing_noreply_invoice_still_rescued():
+    # A real invoice from a billing-noreply@ address (transactional subject) is still
+    # rescued by the subject regex even without the broad sender pattern.
+    res = f.classify(from_addr="billing-noreply@somevendor.com",
+                     subject="Your invoice is ready", category="notification",
+                     headers={"Feedback-ID": "x:ses"})
+    assert not res.drop and res.reason == "exempt:billing"
+
+
 def test_billing_subject_regex_is_tight():
     # A newsletter that merely MENTIONS billing in prose should NOT trip the exemption
     # (the regex matches whole billing words, not arbitrary substrings).

--- a/scripts/mail-actions/tests/test_idempotency.py
+++ b/scripts/mail-actions/tests/test_idempotency.py
@@ -1,0 +1,139 @@
+"""Idempotency test: a processed row is labelled+stamped so a 2nd pass is a no-op.
+
+Uses a fake in-memory MailDB (no port-forward, no Postgres, no network) injected into
+extract.cmd_run, plus a deterministic fake LLM. The fake's fetch_unprocessed() honours
+processed_at the way Postgres would, so the second run sees an empty delta.
+"""
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import extract  # noqa: E402
+import llm  # noqa: E402
+
+
+class FakeMailDB:
+    """Mimics _db.MailDB's surface; tracks labels/processed_at + mail_actions in memory."""
+
+    def __init__(self, rows):
+        # rows: list of dict mail rows; we add mutable state columns.
+        self._mail = {}
+        for r in rows:
+            r = dict(r)
+            r.setdefault("processed_at", None)
+            r.setdefault("labels", [])
+            self._mail[r["id"]] = r
+        self.actions = {}  # mail_id -> action row
+        self.commits = 0
+
+    # context manager
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def ensure_schema(self):
+        pass
+
+    def fetch_unprocessed(self, limit=None):
+        out = [dict(r) for r in self._mail.values() if r["processed_at"] is None]
+        out.sort(key=lambda r: r["id"], reverse=True)
+        return out[:limit] if limit is not None else out
+
+    def mark_processed(self, mail_id, label):
+        r = self._mail[mail_id]
+        if label not in r["labels"]:
+            r["labels"].append(label)
+        r["processed_at"] = "STAMPED"
+
+    def insert_action(self, row):
+        if row["mail_id"] in self.actions:
+            return False  # ON CONFLICT DO NOTHING
+        self.actions[row["mail_id"]] = row
+        return True
+
+    def list_open_actions(self):
+        return list(self.actions.values())
+
+    def commit(self):
+        self.commits += 1
+
+
+def _fake_llm_extract(**kwargs):
+    """Action-required for the zen thread, fyi otherwise — deterministic, no network."""
+    subj = (kwargs.get("subject") or "").lower()
+    if "incomplete" in subj or "action required" in subj:
+        return llm.Extraction(
+            action_required=True, who="Zen Payments",
+            ask="Complete the merchant-account application.",
+            deadline=None, amount=None, confidence=0.9, reason="incomplete notice",
+        )
+    return llm.Extraction(
+        action_required=False, who="", ask="", deadline=None, amount=None,
+        confidence=0.3, reason="fyi",
+    )
+
+
+def _rows():
+    return [
+        # survivor → action-required
+        {"id": 1, "message_id": "<a>", "from_addr": "sales@zenpayments.com",
+         "subject": "Application Incomplete for Civitai", "received_at": None,
+         "category": "personal", "headers": {}, "text_body": "please complete"},
+        # survivor → fyi
+        {"id": 2, "message_id": "<b>", "from_addr": "lauren@naidacom.com",
+         "subject": "Re: Sales Audit Excel Template", "received_at": None,
+         "category": "personal", "headers": {}, "text_body": "thanks"},
+        # bulk drop (alert)
+        {"id": 3, "message_id": "<c>", "from_addr": "alerts@civitaic.com",
+         "subject": "Alert FIRING", "received_at": None,
+         "category": "alert", "headers": {}, "text_body": "fire"},
+    ]
+
+
+def _run(monkeypatch, fake_db):
+    monkeypatch.setattr(extract, "MailDB", lambda *a, **k: fake_db, raising=False)
+    # MailDB is imported inside cmd_run via `from _db import MailDB`; patch the source.
+    import _db
+    monkeypatch.setattr(_db, "MailDB", lambda *a, **k: fake_db)
+    monkeypatch.setattr(llm, "extract", _fake_llm_extract)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    args = types.SimpleNamespace(dry_run=False, limit=150, model=None,
+                                 emit_clawgate=False, json=True)
+    extract.cmd_run(args)
+
+
+def test_first_pass_classifies_then_second_pass_is_noop(monkeypatch, capsys):
+    db = FakeMailDB(_rows())
+
+    # First pass.
+    _run(monkeypatch, db)
+    capsys.readouterr()
+
+    # State after first pass.
+    assert db._mail[1]["labels"] == ["action-required"]
+    assert db._mail[2]["labels"] == ["fyi"]
+    assert db._mail[3]["labels"] == ["bulk"]
+    assert all(r["processed_at"] == "STAMPED" for r in db._mail.values())
+    assert set(db.actions) == {1}
+    assert len(db.list_open_actions()) == 1
+
+    # Second pass — delta must be empty.
+    assert db.fetch_unprocessed() == []
+    actions_before = dict(db.actions)
+    _run(monkeypatch, db)
+
+    # No new actions, no relabel, action set unchanged.
+    assert db.actions == actions_before
+    assert db._mail[1]["labels"] == ["action-required"]
+
+
+def test_insert_action_conflict_is_noop():
+    db = FakeMailDB(_rows())
+    row = {"mail_id": 1, "message_id": "<a>", "from_addr": "x", "subject": "s",
+           "received_at": None, "who": "w", "ask": "a", "deadline": None,
+           "amount": None, "confidence": 0.9, "reason": "r"}
+    assert db.insert_action(row) is True
+    assert db.insert_action(row) is False  # ON CONFLICT DO NOTHING

--- a/scripts/mail-actions/tests/test_llm.py
+++ b/scripts/mail-actions/tests/test_llm.py
@@ -1,0 +1,96 @@
+"""Stage-2 output parser/validator tests (no network, no key)."""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import llm  # noqa: E402
+
+GOOD = (
+    '{"action_required": true, "who": "Zen Payments", '
+    '"ask": "Complete the merchant-account application for Civitai.", '
+    '"deadline": "2026-07-05", "amount": null, "confidence": 0.9, '
+    '"reason": "Application Incomplete notice asks for missing info."}'
+)
+
+
+def test_parses_good_json():
+    ex = llm.parse_extraction(GOOD)
+    assert ex.action_required is True
+    assert ex.who == "Zen Payments"
+    assert ex.deadline == "2026-07-05"
+    assert ex.amount is None
+    assert 0.0 <= ex.confidence <= 1.0
+
+
+def test_parses_fenced_json():
+    ex = llm.parse_extraction("```json\n" + GOOD + "\n```")
+    assert ex.action_required is True
+
+
+def test_parses_json_with_surrounding_prose():
+    ex = llm.parse_extraction("Sure, here you go:\n" + GOOD + "\nHope that helps!")
+    assert ex.who == "Zen Payments"
+
+
+def test_sanity_guard_downgrades_action_with_empty_ask():
+    raw = ('{"action_required": true, "who": "X", "ask": "", "deadline": null, '
+           '"amount": null, "confidence": 0.8, "reason": "unclear"}')
+    ex = llm.parse_extraction(raw)
+    assert ex.action_required is False  # downgraded
+
+
+def test_confidence_clamped():
+    raw = ('{"action_required": false, "who": "X", "ask": "n/a", "deadline": null, '
+           '"amount": null, "confidence": 5, "reason": "r"}')
+    assert llm.parse_extraction(raw).confidence == 1.0
+
+
+def test_string_bool_coerced():
+    raw = ('{"action_required": "true", "who": "X", "ask": "do thing", "deadline": null, '
+           '"amount": null, "confidence": "0.5", "reason": "r"}')
+    ex = llm.parse_extraction(raw)
+    assert ex.action_required is True and ex.confidence == 0.5
+
+
+def test_malformed_json_raises():
+    with pytest.raises(llm.ExtractionError):
+        llm.parse_extraction("not json at all")
+
+
+def test_missing_keys_raises():
+    with pytest.raises(llm.ExtractionError):
+        llm.parse_extraction('{"action_required": true}')
+
+
+def test_no_json_object_raises():
+    with pytest.raises(llm.ExtractionError):
+        llm.parse_extraction("the answer is yes")
+
+
+def test_extract_retries_once_then_succeeds():
+    calls = {"n": 0}
+
+    def fake_caller(model, prompt, key):
+        calls["n"] += 1
+        return "garbage" if calls["n"] == 1 else GOOD
+
+    ex = llm.extract(from_addr="a@b.com", subject="s", body="b",
+                     api_key="test-key", _caller=fake_caller)
+    assert ex.action_required is True
+    assert calls["n"] == 2  # one retry
+
+
+def test_extract_raises_after_retry_exhausted():
+    def fake_caller(model, prompt, key):
+        return "still garbage"
+
+    with pytest.raises(llm.ExtractionError):
+        llm.extract(from_addr="a@b.com", subject="s", body="b",
+                    api_key="test-key", _caller=fake_caller)
+
+
+def test_body_truncated_in_prompt():
+    prompt = llm.build_user_prompt(from_addr="a@b.com", subject="s", body="x" * 10000)
+    assert prompt.count("x") <= llm.BODY_TRUNCATE


### PR DESCRIPTION
## What

A new tool in `scripts/mail-actions/` that mines the self-hosted inbox (Gmail → homelab Postgres `mail` table) for the handful of genuinely **action-required** emails buried in thousands of alerts/notifications, recording each as a structured `mail_actions` row (and optionally a clawgate Task card).

MVP whose loop closes on an **artifact verifier** — extraction correctness vs the source email — not on human adoption.

## Pipeline

- **Stage 1 — deterministic noise DROP** (`filter.py`, pure, no LLM): high-precision tier that must never drop a genuine action item. Drops on `category=alert`, `List-Unsubscribe`/`List-Id`/`Auto-Submitted` presence, `Precedence` in {bulk,list,junk}, and a short sender denylist (`notifications@github.com`, `*@npmjs.com`, pagerduty, bugsnag, clickup). Deliberately does **not** blanket-drop `no-reply@` (verification/security mail can be action-required → goes to the LLM).
- **Stage 2 — LLM extraction** (`llm.py`, OpenRouter): over survivors only. Strict JSON `{action_required, who, ask, deadline, amount, confidence, reason}`. One malformed-output retry; deterministic sanity guard downgrades `action_required` + empty `ask` to fyi. Body truncated to bound token cost; model configurable via `MAIL_ACTIONS_MODEL` (default `deepseek/deepseek-v4-flash`). Key from `OPENROUTER_API_KEY` env — never hardcoded.
- **Stage 3 — persist + mark state** (`_db.py`, idempotent): `kubectl port-forward` → psycopg2 with bound params (never `psql -c` — unsafe to escape bodies). `mail.labels` (`bulk`/`fyi`/`action-required`) + `processed_at` are the delta/idempotency mechanism. `mail_actions` created `IF NOT EXISTS` with `mail_id UNIQUE` + `ON CONFLICT DO NOTHING`.
- **Stage 4 — surface** (`clawgate.py`, optional `--emit-clawgate`, default off): one clawgate Task card per **new** action item; graceful no-op if `CLAWGATE_HOOK_TOKEN` unset.

`extract.py` CLI: `run [--dry-run --limit --model --emit-clawgate --json]` and `list`.

## Verified in-session

- **26 offline tests pass** (no key, no live DB): Stage-1 filter vs scrubbed real fixtures, LLM parser/validator + retry + sanity guard, idempotency (mocked DB, second pass = no-op).
- **Live `--dry-run`** (Stage 1 only): 3,537 unprocessed via_gmail rows → 3,457 dropped → **80 survivors** for the LLM. Survivors include the genuine Zen Payments merchant-onboarding thread and the naida sales thread.
- **`list` subcommand** ran end-to-end against live Postgres (port-forward → created `mail_actions` → empty read).

## Not run in-session (honest)

The live **Stage 2 LLM pass was not run** — no `OPENROUTER_API_KEY` in the build session. The README documents the exact first-run command and the artifact-verification steps (cross-check `mail_actions.who/ask/deadline/amount` against source mail bodies for precision; cross-check the dry-run survivor list for recall; second run should report `survivors: 0` for idempotency).

## Scope / safety

- Branch off `origin/main`. Only the 10 new `scripts/mail-actions/` files are staged — none of the pre-existing working-tree drift, and nothing outside this dir.
- No secrets committed. Fixtures scrubbed to headers + from + subject (no email bodies).
- NixOS: deps (`psycopg2`, `requests`) documented to run under `nix-shell`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)