### PR TITLE
feat(mail-actions): invoice archiver → PDF + JSON sidecar to homelab MinIO

### DIFF
--- a/scripts/mail-actions/README.md
+++ b/scripts/mail-actions/README.md
@@ -141,12 +141,92 @@ WHERE id = <mail_id>;
 DELETE FROM mail_actions WHERE mail_id = <mail_id>;
 ```
 
+## Invoice archiver (`archive-invoices`)
+
+A **separate, deterministic** loop (no LLM) that mines the inbox for **PDF invoice
+attachments** and archives them — plus a JSON metadata sidecar — to a homelab MinIO
+bucket, so a downstream tax agent can reconcile them.
+
+It is **independent of the action-required pipeline above**: scope is *all* invoices
+across the full backlog, regardless of `processed_at`. A paid invoice the LLM marked
+`fyi` is still a tax document. Idempotency uses a **dedicated `invoice-archived`
+label** (NOT `processed_at`) — a mail may be both fyi-processed AND archived.
+
+```
+mail (via_gmail, raw IS NOT NULL, NOT labelled 'invoice-archived')   ← delta read
+  │
+  ├─ parse raw RFC822 (stdlib email) → PDF attachments (content-type OR .pdf name)
+  │
+  ├─ candidate iff ≥1 PDF AND (filter._billing_exempt(from,subject)  ← reused, not duped
+  │                            OR an attachment named /invoice|receipt|statement/i)
+  │
+  ├─ per PDF → upload to  s3://taxes-{YEAR}-invoices/{vendor}/{YYYY-MM-DD}-{file}
+  │            + a .json sidecar {vendor, from_addr, date, amount, subject,
+  │                               message_id, mail_id}  (amount best-effort, may be null)
+  │
+  └─ AFTER all of a mail's PDFs+sidecars upload OK → label mail 'invoice-archived'
+        (on any upload error: NOT labelled → retried next run; error counted, keep going)
+```
+
+- `year` = year of `date_header` (else `received_at`). `vendor` = registrable domain of
+  the sender — last two dotted labels (`billing@hetzner.com` → `hetzner.com`,
+  `noreply@notify.cloudflare.com` → `cloudflare.com`); a HEURISTIC that is wrong for
+  multi-label public suffixes (`co.uk`), noted in `archive.py`.
+- `amount` is best-effort: it is *not* extracted here (the PDF / tax agent is
+  authoritative); if a `mail_actions` row already carries an amount for that mail it is
+  passed through, else `null`.
+- MinIO is reached the same way Postgres is: `kubectl -n minio-archive port-forward
+  svc/minio 0:80` on an ephemeral local port, then the `minio` python client at
+  `http://127.0.0.1:<port>` with **path-style** addressing (`_minio.py`).
+
+### Env
+
+| var | needed for | notes |
+|-----|------------|-------|
+| `KUBECONFIG` | DB + MinIO | `~/workspace/homelab-talos/homelab-kubeconfig` |
+| `MINIO_ARCHIVE_ACCESS_KEY` / `MINIO_ARCHIVE_SECRET_KEY` | MinIO auth (optional) | if unset, read from k8s secret `minio-archive-config` key `config.env` (parses `export MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD`) |
+| `MINIO_ARCHIVE_ENDPOINT` | optional | use a verbatim S3 endpoint (e.g. an in-cluster runner) instead of starting a port-forward |
+
+No secrets are hardcoded.
+
+### Usage
+
+```sh
+export KUBECONFIG=~/workspace/homelab-talos/homelab-kubeconfig
+
+# Dry-run: list invoice candidates + their target bucket/key + detected PDF names.
+# NO uploads, NO label writes, NO bucket creation.
+nix-shell -p 'python3.withPackages(p:[p.minio p.psycopg2 p.requests])' --run \
+  'python scripts/mail-actions/extract.py archive-invoices --dry-run [--limit N] [--json]'
+
+# Live: upload PDFs + JSON sidecars, create buckets as needed, label archived mail.
+nix-shell -p 'python3.withPackages(p:[p.minio p.psycopg2 p.requests])' --run \
+  'python scripts/mail-actions/extract.py archive-invoices [--limit N] [--json]'
+```
+
+### Verify
+
+```sh
+# A second --dry-run after a live run reports 0 candidates (idempotency).
+# List what landed (the `mc` client; alias `archive` set up to the tenant):
+mc ls --recursive archive/taxes-2026-invoices
+# or via the python client / MinIO console.
+```
+
 ## Tests
 
 ```sh
-nix-shell -p 'python3.withPackages(p:[p.pytest p.requests p.psycopg2])' --run \
+nix-shell -p 'python3.withPackages(p:[p.pytest p.requests p.psycopg2 p.minio])' --run \
   'python -m pytest scripts/mail-actions/tests -q'
 ```
+
+- `test_archive.py` — invoice archiver, all offline (no DB/MinIO/network): PDF
+  attachment extraction from a synthetic `multipart/mixed` RFC822 message; candidate
+  detection (billing-sender, invoice-filename signal, negative cases); bucket/vendor/
+  object-key derivation incl. sanitization + message_id fallback; sidecar JSON shape;
+  the `invoice-archived` idempotency predicate; and the `archive-invoices` orchestration
+  with a **mocked MinIO client + fake DB** (upload+label, dry-run writes nothing, an
+  upload error skips the label so the mail retries).
 
 - `test_filter.py` — Stage-1 filter vs scrubbed real fixtures (`tests/fixtures/mail_headers.json`):
   asserts the genuine action threads survive and the noise (alert/github/npm/bugsnag/

--- a/scripts/mail-actions/_db.py
+++ b/scripts/mail-actions/_db.py
@@ -38,6 +38,8 @@ except ImportError as exc:  # pragma: no cover - import guard
 
 NAMESPACE = "mailbox"
 SERVICE = "svc/mailbox-postgres"
+# Idempotency label for the invoice archiver (distinct from action-triage state).
+ARCHIVED_LABEL = "invoice-archived"
 DSN_SECRET = "mailbox-postgres-auth"
 DSN_KEY = "pg-dsn"
 
@@ -178,6 +180,46 @@ class MailDB:
             cur.execute(sql, params)
             return cur.fetchall()
 
+    def fetch_unarchived(self, limit: int | None = None):
+        """Invoice-archiver delta: via_gmail mail with a raw message that has NOT yet
+        been archived (no 'invoice-archived' label). Independent of processed_at — a
+        mail may be both fyi-processed AND not-yet-archived. Returns the row INCLUDING
+        the `raw` bytea, converted from psycopg2's memoryview to plain bytes.
+        """
+        sql = (
+            "SELECT id, message_id, from_addr, subject, received_at, date_header, "
+            "raw "
+            "FROM mail "
+            "WHERE via_gmail AND raw IS NOT NULL "
+            "AND NOT (%s = ANY(coalesce(labels, '{}'))) "
+            "ORDER BY received_at DESC"
+        )
+        params: tuple = (ARCHIVED_LABEL,)
+        if limit is not None:
+            sql += " LIMIT %s"
+            params = (ARCHIVED_LABEL, limit)
+        with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+        for r in rows:
+            if isinstance(r.get("raw"), memoryview):
+                r["raw"] = r["raw"].tobytes()
+        return rows
+
+    def amount_for_mail(self, mail_id: int) -> str | None:
+        """Best-effort: the `amount` from a mail_actions row for this mail, if one
+        exists (the action pipeline may have extracted it). None otherwise — including
+        when the mail_actions table has never been created (action pipeline unrun)."""
+        with self._c.cursor() as cur:
+            cur.execute("SELECT to_regclass('public.mail_actions')")
+            if cur.fetchone()[0] is None:
+                return None
+            cur.execute(
+                "SELECT amount FROM mail_actions WHERE mail_id = %s", (mail_id,)
+            )
+            row = cur.fetchone()
+        return row[0] if row else None
+
     def list_open_actions(self):
         with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             cur.execute(
@@ -199,6 +241,24 @@ class MailDB:
                          FROM unnest(coalesce(labels, '{}') || ARRAY[%s]::text[]) AS x
                        ),
                        processed_at = now()
+                 WHERE id = %s
+                """,
+                (label, mail_id),
+            )
+
+    def add_label(self, mail_id: int, label: str) -> None:
+        """Append `label` to mail.labels (dedup) WITHOUT touching processed_at.
+
+        Distinct from mark_processed: archival state (`invoice-archived`) is
+        orthogonal to action-triage state, so it must not stamp processed_at."""
+        with self._c.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE mail
+                   SET labels = (
+                         SELECT array_agg(DISTINCT x)
+                         FROM unnest(coalesce(labels, '{}') || ARRAY[%s]::text[]) AS x
+                       )
                  WHERE id = %s
                 """,
                 (label, mail_id),

--- a/scripts/mail-actions/_db.py
+++ b/scripts/mail-actions/_db.py
@@ -212,7 +212,8 @@ class MailDB:
         when the mail_actions table has never been created (action pipeline unrun)."""
         with self._c.cursor() as cur:
             cur.execute("SELECT to_regclass('public.mail_actions')")
-            if cur.fetchone()[0] is None:
+            reg = cur.fetchone()
+            if reg is None or reg[0] is None:
                 return None
             cur.execute(
                 "SELECT amount FROM mail_actions WHERE mail_id = %s", (mail_id,)

--- a/scripts/mail-actions/_minio.py
+++ b/scripts/mail-actions/_minio.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""MinIO (S3) access for the mail-actions invoice archiver.
+
+The homelab MinIO "archive" tenant is reachable only in-cluster (the `minio`
+ClusterIP service in namespace `minio-archive`, port 80 → container 9000). We
+bridge to it exactly the way `_db.py` bridges to Postgres: start a
+`kubectl port-forward` on an ephemeral local port, talk to an S3 client at
+`http://127.0.0.1:<port>` with **path-style** addressing (MinIO requires it),
+and tear the forward down on exit.
+
+Credentials resolve, in order:
+  1. env  — MINIO_ARCHIVE_ENDPOINT / MINIO_ARCHIVE_ACCESS_KEY / MINIO_ARCHIVE_SECRET_KEY
+            (if ACCESS+SECRET are set, no kubectl/secret read is needed; ENDPOINT
+            overrides the port-forward and is used verbatim)
+  2. k8s secret `minio-archive-config`, key `config.env` — parsed for the
+     `export MINIO_ROOT_USER=...` / `export MINIO_ROOT_PASSWORD=...` shell lines.
+
+No secrets are hardcoded. See README for the nix-shell run command.
+
+Usage:
+    with MinioArchive() as mc:
+        mc.ensure_bucket("taxes-2026-invoices")
+        mc.put_object("taxes-2026-invoices", "hetzner.com/2026-06-28-inv.pdf",
+                      data_bytes, "application/pdf")
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import re
+import socket
+import subprocess
+import time
+from urllib.parse import urlparse
+
+try:
+    from minio import Minio
+    from minio.error import S3Error
+except ImportError as exc:  # pragma: no cover - import guard
+    raise SystemExit(
+        "minio is required. On NixOS run under:\n"
+        "  nix-shell -p \"python3.withPackages(p:[p.minio p.psycopg2 p.requests])\" "
+        "--run 'python scripts/mail-actions/extract.py archive-invoices ...'"
+    ) from exc
+
+NAMESPACE = "minio-archive"
+SERVICE = "svc/minio"
+SERVICE_PORT = 80
+CONFIG_SECRET = "minio-archive-config"
+CONFIG_KEY = "config.env"
+
+# Parse `export KEY=value` (optionally quoted) out of a shell config.env blob.
+_EXPORT_RE = re.compile(
+    r"""^\s*export\s+(?P<key>\w+)\s*=\s*(?P<val>"[^"]*"|'[^']*'|[^\s#]+)""",
+    re.MULTILINE,
+)
+
+
+def _free_local_port() -> int:
+    """Ask the OS for a free TCP port (bind to 0, read it back, release)."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def parse_config_env(blob: str) -> dict:
+    """Extract `export KEY=value` shell assignments into a plain dict (quotes stripped)."""
+    out: dict[str, str] = {}
+    for m in _EXPORT_RE.finditer(blob):
+        val = m.group("val")
+        if len(val) >= 2 and val[0] in "\"'" and val[-1] == val[0]:
+            val = val[1:-1]
+        out[m.group("key")] = val
+    return out
+
+
+def _read_creds_from_secret() -> tuple[str, str]:
+    """Read MINIO_ROOT_USER / MINIO_ROOT_PASSWORD from the k8s secret's config.env."""
+    import base64
+
+    raw = subprocess.check_output(
+        [
+            "kubectl", "-n", NAMESPACE, "get", "secret", CONFIG_SECRET,
+            "-o", f"jsonpath={{.data.{CONFIG_KEY.replace('.', '\\.')}}}",
+        ],
+        text=True,
+    ).strip()
+    blob = base64.b64decode(raw).decode()
+    env = parse_config_env(blob)
+    user = env.get("MINIO_ROOT_USER")
+    password = env.get("MINIO_ROOT_PASSWORD")
+    if not user or not password:
+        raise RuntimeError(
+            f"secret {CONFIG_SECRET}/{CONFIG_KEY} missing MINIO_ROOT_USER/PASSWORD"
+        )
+    return user, password
+
+
+class MinioArchive:
+    """Context manager: (optional) port-forward → minio S3 client, torn down on exit.
+
+    If MINIO_ARCHIVE_ENDPOINT is set, that endpoint is used verbatim and NO
+    port-forward is started (useful for tests or an in-cluster runner). Otherwise a
+    `kubectl port-forward svc/minio 0:80` is started and the client points at it.
+    """
+
+    def __init__(
+        self,
+        access_key: str | None = None,
+        secret_key: str | None = None,
+        endpoint: str | None = None,
+        ready_timeout: float = 20.0,
+    ):
+        self._access_key = access_key or os.environ.get("MINIO_ARCHIVE_ACCESS_KEY")
+        self._secret_key = secret_key or os.environ.get("MINIO_ARCHIVE_SECRET_KEY")
+        self._endpoint = endpoint or os.environ.get("MINIO_ARCHIVE_ENDPOINT")
+        self._ready_timeout = ready_timeout
+        self._pf: subprocess.Popen | None = None
+        self.client: "Minio | None" = None
+
+    # -- lifecycle ---------------------------------------------------------
+    def __enter__(self) -> "MinioArchive":
+        if not (self._access_key and self._secret_key):
+            self._access_key, self._secret_key = _read_creds_from_secret()
+
+        if self._endpoint:
+            # Explicit endpoint: use verbatim, no port-forward.
+            host, secure = self._split_endpoint(self._endpoint)
+        else:
+            local_port = _free_local_port()
+            self._pf = subprocess.Popen(
+                [
+                    "kubectl", "-n", NAMESPACE, "port-forward", SERVICE,
+                    f"{local_port}:{SERVICE_PORT}",
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
+            self._wait_for_port("127.0.0.1", local_port)
+            host, secure = f"127.0.0.1:{local_port}", False
+
+        self.client = Minio(
+            host,
+            access_key=self._access_key,
+            secret_key=self._secret_key,
+            secure=secure,
+        )
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        if self._pf is not None:
+            self._pf.terminate()
+            with contextlib.suppress(Exception):
+                self._pf.wait(timeout=5)
+
+    @staticmethod
+    def _split_endpoint(endpoint: str) -> tuple[str, bool]:
+        """'http://127.0.0.1:9000' → ('127.0.0.1:9000', False); bare host:port → (host, False)."""
+        if "://" in endpoint:
+            u = urlparse(endpoint)
+            return u.netloc, u.scheme == "https"
+        return endpoint, False
+
+    @property
+    def _c(self) -> "Minio":
+        if self.client is None:
+            raise RuntimeError("MinioArchive used outside its context manager (no client)")
+        return self.client
+
+    def _wait_for_port(self, host: str, port: int) -> None:
+        deadline = time.monotonic() + self._ready_timeout
+        while time.monotonic() < deadline:
+            if self._pf and self._pf.poll() is not None:
+                err = self._pf.stderr.read().decode() if self._pf.stderr else ""
+                raise RuntimeError(f"kubectl port-forward exited early:\n{err}")
+            with contextlib.suppress(OSError):
+                with socket.create_connection((host, port), timeout=1):
+                    return
+            time.sleep(0.25)
+        raise TimeoutError(f"port-forward to {host}:{port} not ready in time")
+
+    # -- operations --------------------------------------------------------
+    def ensure_bucket(self, bucket: str) -> bool:
+        """Create `bucket` if it does not exist. Returns True if it was created."""
+        if self._c.bucket_exists(bucket):
+            return False
+        self._c.make_bucket(bucket)
+        return True
+
+    def put_object(
+        self, bucket: str, key: str, data: bytes, content_type: str
+    ) -> None:
+        """Upload `data` to bucket/key with the given content type."""
+        self._c.put_object(
+            bucket, key, io.BytesIO(data), length=len(data),
+            content_type=content_type,
+        )
+
+    def object_exists(self, bucket: str, key: str) -> bool:
+        """True if bucket/key already exists (best-effort; False if bucket absent)."""
+        try:
+            self._c.stat_object(bucket, key)
+            return True
+        except S3Error:
+            return False

--- a/scripts/mail-actions/archive.py
+++ b/scripts/mail-actions/archive.py
@@ -56,9 +56,11 @@ def extract_pdf_attachments(raw: bytes) -> list[PdfAttachment]:
         if not is_pdf:
             continue
         payload = part.get_payload(decode=True)
-        if payload is None:
+        if not isinstance(payload, (bytes, bytearray)):
             continue
-        out.append(PdfAttachment(filename=fname, data=payload))
+        # fname may be None when a PDF is detected by content-type alone; key
+        # derivation falls back to message_id for an empty filename.
+        out.append(PdfAttachment(filename=fname or "", data=bytes(payload)))
     return out
 
 

--- a/scripts/mail-actions/archive.py
+++ b/scripts/mail-actions/archive.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Invoice archiver — pure logic for extracting PDF invoices from raw RFC822 mail
+and deriving their MinIO destination + metadata sidecar.
+
+This module is deliberately PURE (no DB, no MinIO, no network): it operates on the
+raw bytes of a message and on mail-row metadata, and returns structured results. The
+orchestration (fetch from Postgres, upload to MinIO, label state) lives in
+`extract.py`'s `archive-invoices` subcommand so the side-effecting code stays thin
+and the decision logic stays unit-testable offline.
+
+Scope decision (see README): archive ALL invoices across the full backlog,
+independent of the action-required triage pipeline — a paid invoice the LLM marks
+'fyi' is still a tax document. Idempotency is the dedicated `invoice-archived`
+label, NOT `processed_at` (archival is orthogonal to action-triage).
+"""
+from __future__ import annotations
+
+import email
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from email.message import Message
+from email.utils import parsedate_to_datetime
+
+import filter as f  # noqa: E402  (sibling module, reuse the billing logic — do NOT duplicate)
+
+ARCHIVED_LABEL = "invoice-archived"
+
+# Filename signal: an attachment whose name looks like a financial document. Used as
+# an ALTERNATIVE candidate signal to the billing-sender/subject exemption, so an
+# invoice from a non-allowlisted sender (named `invoice_123.pdf`) is still captured.
+_INVOICE_FILENAME_RE = re.compile(r"invoice|receipt|statement", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class PdfAttachment:
+    """One PDF attachment extracted from a message."""
+
+    filename: str | None  # as declared in the message (may be None / missing)
+    data: bytes
+
+
+def extract_pdf_attachments(raw: bytes) -> list[PdfAttachment]:
+    """Parse raw RFC822 bytes and return every PDF attachment (by content-type OR
+    a `.pdf` filename). Inline/body parts and non-PDFs are ignored."""
+    msg: Message = email.message_from_bytes(raw)
+    out: list[PdfAttachment] = []
+    for part in msg.walk():
+        if part.is_multipart():
+            continue
+        ctype = (part.get_content_type() or "").lower()
+        fname = part.get_filename()
+        is_pdf = ctype == "application/pdf" or (
+            bool(fname) and fname.lower().endswith(".pdf")
+        )
+        if not is_pdf:
+            continue
+        payload = part.get_payload(decode=True)
+        if payload is None:
+            continue
+        out.append(PdfAttachment(filename=fname, data=payload))
+    return out
+
+
+def is_archive_candidate(
+    *, from_addr: str | None, subject: str | None, attachments: list[PdfAttachment]
+) -> bool:
+    """A mail is an archive candidate iff it has >=1 PDF attachment AND
+    (it looks like billing per filter._billing_exempt OR any attachment filename
+    matches /invoice|receipt|statement/i)."""
+    if not attachments:
+        return False
+    if f._billing_exempt(from_addr, subject):
+        return True
+    return any(
+        a.filename and _INVOICE_FILENAME_RE.search(a.filename) for a in attachments
+    )
+
+
+def invoice_date(
+    date_header: "str | datetime | None", received_at: datetime | None
+) -> datetime:
+    """Best-effort invoice date: use `date_header` (a datetime, or an RFC2822 string
+    we parse) if possible, else fall back to `received_at`, else now(UTC). Returns a
+    tz-aware-or-naive datetime usable for `.year` and `strftime`.
+
+    NOTE: the Postgres `date_header` column is typed timestamptz, so psycopg2 hands it
+    back as a `datetime` already; we still accept a string for synthetic/test inputs."""
+    if isinstance(date_header, datetime):
+        return date_header
+    if date_header:
+        try:
+            dt = parsedate_to_datetime(date_header)
+            if dt is not None:
+                return dt
+        except (TypeError, ValueError, IndexError):
+            pass
+    if received_at is not None:
+        return received_at
+    return datetime.now(timezone.utc)
+
+
+def bucket_for(dt: datetime) -> str:
+    """`taxes-{year}-invoices` bucket name for a given date."""
+    return f"taxes-{dt.year}-invoices"
+
+
+def vendor_domain(from_addr: str | None) -> str:
+    """Registrable domain of the sender, as a coarse vendor key.
+
+    HEURISTIC: takes the last two dotted labels of the address domain
+    (`billing@hetzner.com` → `hetzner.com`; `noreply@notify.cloudflare.com` →
+    `cloudflare.com`). This is WRONG for multi-label public suffixes such as
+    `co.uk` / `com.au` (`x@a.co.uk` → `co.uk` instead of `a.co.uk`) — a full fix
+    needs the Public Suffix List, which is out of scope here. Falls back to
+    `unknown-vendor` when no domain is present.
+    """
+    if not from_addr or "@" not in from_addr:
+        return "unknown-vendor"
+    domain = from_addr.rsplit("@", 1)[1].strip().lower().rstrip(".")
+    labels = [p for p in domain.split(".") if p]
+    if len(labels) >= 2:
+        return ".".join(labels[-2:])
+    return domain or "unknown-vendor"
+
+
+def _sanitize_filename(name: str) -> str:
+    """Strip path separators and collapse whitespace into single spaces, trim ends."""
+    # Drop any directory components (handles both / and \ path separators).
+    base = re.split(r"[\\/]", name)[-1]
+    base = re.sub(r"\s+", " ", base).strip()
+    return base
+
+
+def object_key(
+    *, vendor: str, dt: datetime, filename: str | None, message_id: str | None
+) -> str:
+    """`{vendor}/{YYYY-MM-DD}-{sanitized_filename}`.
+
+    If `filename` is missing/blank, derive a stable name from `message_id`
+    (angle brackets + unsafe chars stripped) with a `.pdf` suffix."""
+    date_str = dt.strftime("%Y-%m-%d")
+    if filename and filename.strip():
+        safe = _sanitize_filename(filename)
+    else:
+        mid = (message_id or "").strip().strip("<>")
+        mid = re.sub(r"[^A-Za-z0-9._@-]", "_", mid) or "message"
+        safe = f"{mid}.pdf"
+    return f"{vendor}/{date_str}-{safe}"
+
+
+def sidecar_metadata(
+    *,
+    vendor: str,
+    from_addr: str | None,
+    dt: datetime,
+    amount: str | None,
+    subject: str | None,
+    message_id: str | None,
+    mail_id: int,
+) -> dict:
+    """The JSON metadata sidecar written next to each archived PDF.
+
+    `amount` is best-effort and may be None: the archiver does NOT call the LLM; the
+    authoritative amount lives in the PDF / is resolved by the downstream tax agent.
+    A pre-existing `mail_actions` row's amount (if any) is passed through here.
+    """
+    return {
+        "vendor": vendor,
+        "from_addr": from_addr,
+        "date": dt.strftime("%Y-%m-%d"),
+        "amount": amount,
+        "subject": subject,
+        "message_id": message_id,
+        "mail_id": mail_id,
+    }

--- a/scripts/mail-actions/extract.py
+++ b/scripts/mail-actions/extract.py
@@ -12,8 +12,9 @@ processed row is labelled ('bulk' | 'fyi' | 'action-required') and stamped, so a
 re-run is a no-op over already-seen mail.
 
 Subcommands:
-  run            run the pipeline (filter → LLM → persist)
-  list           print open mail_actions (the artifact, for verification)
+  run               run the action-required pipeline (filter → LLM → persist)
+  archive-invoices  extract PDF invoices from mail → upload PDF+JSON to MinIO
+  list              print open mail_actions (the artifact, for verification)
 
 Run flags:
   --dry-run         filter only; show survivor counts + what WOULD be extracted; no LLM, no writes
@@ -156,6 +157,149 @@ def _emit_clawgate(r, ex) -> int:
         return 0
 
 
+def cmd_archive(args) -> int:
+    """Invoice archiver: scan ALL via_gmail mail (independent of processed_at), extract
+    PDF invoice attachments, upload each + a JSON sidecar to a per-year MinIO bucket,
+    and label the mail `invoice-archived` only after ALL its PDFs upload OK.
+    """
+    import json as _json
+
+    import archive as a
+    from _db import MailDB
+
+    summary = {
+        "scanned": 0, "candidates": 0, "pdfs_uploaded": 0, "sidecars": 0,
+        "buckets_touched": [], "errors": 0, "labeled": 0,
+    }
+    buckets_seen: set[str] = set()
+    candidates_out: list[dict] = []
+
+    with MailDB() as db:
+        rows = db.fetch_unarchived(limit=args.limit)
+        summary["scanned"] = len(rows)
+
+        # Identify candidates (pure) first — used by both dry-run and live.
+        candidates = []
+        for r in rows:
+            atts = a.extract_pdf_attachments(r["raw"] or b"")
+            if not a.is_archive_candidate(
+                from_addr=r.get("from_addr"), subject=r.get("subject"),
+                attachments=atts,
+            ):
+                continue
+            dt = a.invoice_date(r.get("date_header"), r.get("received_at"))
+            vendor = a.vendor_domain(r.get("from_addr"))
+            bucket = a.bucket_for(dt)
+            candidates.append((r, atts, dt, vendor, bucket))
+        summary["candidates"] = len(candidates)
+
+        if args.dry_run:
+            for r, atts, dt, vendor, bucket in candidates:
+                keys = [
+                    a.object_key(vendor=vendor, dt=dt, filename=att.filename,
+                                 message_id=r.get("message_id"))
+                    for att in atts
+                ]
+                buckets_seen.add(bucket)
+                candidates_out.append({
+                    "mail_id": r["id"], "from_addr": r.get("from_addr"),
+                    "subject": r.get("subject"), "bucket": bucket,
+                    "pdf_filenames": [att.filename for att in atts],
+                    "object_keys": keys,
+                })
+            summary["buckets_touched"] = sorted(buckets_seen)
+            summary["mode"] = "dry-run"
+            if args.json:
+                print(_json.dumps(
+                    {"summary": summary, "candidates": candidates_out}, indent=2,
+                    default=str,
+                ))
+            else:
+                _print_archive_dry_run(candidates_out, summary)
+            return 0
+
+        # Live: upload PDFs + sidecars, then label.
+        from _minio import MinioArchive
+
+        with MinioArchive() as mc:
+            ensured: set[str] = set()
+            for r, atts, dt, vendor, bucket in candidates:
+                amount = None
+                try:
+                    amount = db.amount_for_mail(r["id"])
+                except Exception:  # noqa: BLE001 — amount is best-effort, never fatal
+                    amount = None
+
+                mail_ok = True
+                for att in atts:
+                    key = a.object_key(
+                        vendor=vendor, dt=dt, filename=att.filename,
+                        message_id=r.get("message_id"),
+                    )
+                    try:
+                        if bucket not in ensured:
+                            if mc.ensure_bucket(bucket):
+                                pass
+                            ensured.add(bucket)
+                        buckets_seen.add(bucket)
+                        mc.put_object(bucket, key, att.data, "application/pdf")
+                        summary["pdfs_uploaded"] += 1
+                        sidecar = a.sidecar_metadata(
+                            vendor=vendor, from_addr=r.get("from_addr"), dt=dt,
+                            amount=amount, subject=r.get("subject"),
+                            message_id=r.get("message_id"), mail_id=r["id"],
+                        )
+                        body = _json.dumps(sidecar, indent=2, default=str).encode()
+                        mc.put_object(bucket, key + ".json", body, "application/json")
+                        summary["sidecars"] += 1
+                    except Exception as exc:  # noqa: BLE001 — report, skip labeling, keep going
+                        mail_ok = False
+                        summary["errors"] += 1
+                        print(f"  ! upload failed mail_id={r['id']} key={key}: {exc}",
+                              file=sys.stderr)
+
+                # Label ONLY if every PDF+sidecar for this mail uploaded successfully.
+                if mail_ok and atts:
+                    db.add_label(r["id"], a.ARCHIVED_LABEL)
+                    db.commit()
+                    summary["labeled"] += 1
+
+        summary["buckets_touched"] = sorted(buckets_seen)
+        summary["mode"] = "run"
+        if args.json:
+            print(_json.dumps(summary, indent=2, default=str))
+        else:
+            _print_archive_run(summary)
+        return 0
+
+
+def _print_archive_dry_run(candidates, summary) -> None:
+    print(f"DRY RUN — scanned {summary['scanned']} unarchived via_gmail rows → "
+          f"{summary['candidates']} invoice candidate(s)")
+    if summary["buckets_touched"]:
+        print(f"  buckets that WOULD be touched: {', '.join(summary['buckets_touched'])}")
+    print()
+    for c in candidates:
+        print(f"  mail#{c['mail_id']:<6} {(c['from_addr'] or '')[:36]:<36} "
+              f"{(c['subject'] or '')[:46]!r}")
+        for fn, key in zip(c["pdf_filenames"], c["object_keys"]):
+            print(f"      PDF {fn!r}")
+            print(f"       → s3://{c['bucket']}/{key}  (+ .json sidecar)")
+    if not candidates:
+        print("  (no invoice candidates)")
+
+
+def _print_archive_run(s) -> None:
+    print(f"ARCHIVE RUN — scanned {s['scanned']} rows")
+    print(f"  candidates:       {s['candidates']}")
+    print(f"  PDFs uploaded:    {s['pdfs_uploaded']}")
+    print(f"  sidecars written: {s['sidecars']}")
+    print(f"  mails labeled:    {s['labeled']}")
+    print(f"  buckets touched:  {', '.join(s['buckets_touched']) or '(none)'}")
+    if s["errors"]:
+        print(f"  upload errors:    {s['errors']}")
+
+
 def cmd_list(args) -> int:
     from _db import MailDB
 
@@ -226,6 +370,17 @@ def build_parser() -> argparse.ArgumentParser:
                      help="POST a clawgate Task card per NEW action item")
     run.add_argument("--json", action="store_true", help="machine-readable summary")
     run.set_defaults(func=cmd_run)
+
+    arch = sub.add_parser(
+        "archive-invoices",
+        help="extract PDF invoices from mail → upload PDF+JSON sidecar to MinIO",
+    )
+    arch.add_argument("--dry-run", action="store_true",
+                      help="list candidates + target bucket/key; NO uploads, NO label writes")
+    arch.add_argument("--limit", type=int, default=None,
+                      help="max unarchived rows to scan (default: all)")
+    arch.add_argument("--json", action="store_true", help="machine-readable summary")
+    arch.set_defaults(func=cmd_archive)
 
     ls = sub.add_parser("list", help="print open mail_actions (the artifact)")
     ls.add_argument("--json", action="store_true")

--- a/scripts/mail-actions/tests/test_archive.py
+++ b/scripts/mail-actions/tests/test_archive.py
@@ -1,0 +1,420 @@
+"""Invoice-archiver tests — all offline, no DB, no MinIO, no network.
+
+Covers (per the build spec):
+  - PDF attachment extraction from a synthetic multipart/mixed RFC822 message;
+    and a message with no attachment → none.
+  - Candidate detection: billing+PDF → yes; non-billing+invoice-named PDF → yes
+    (filename signal); non-billing + non-invoice PDF → no; no PDF → no.
+  - Bucket derivation, vendor-domain extraction, object-key sanitization
+    (spaces, slashes, missing-filename → message_id fallback).
+  - Sidecar JSON shape/keys.
+  - Idempotency SQL predicate: a row already carrying `invoice-archived` is excluded
+    by fetch_unarchived's WHERE clause (predicate logic tested against a fake set).
+  - The MinIO client MOCKED in the archive subcommand orchestration — no live upload.
+"""
+import json
+import sys
+import types
+from datetime import datetime, timezone
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import archive as a  # noqa: E402
+import extract  # noqa: E402
+
+FAKE_PDF = b"%PDF-1.4\nfake invoice body\n%%EOF\n"
+
+
+# --------------------------------------------------------------------------- #
+# Message builders
+# --------------------------------------------------------------------------- #
+def _msg_with_pdf(from_addr, subject, filename, ctype="application/pdf"):
+    m = MIMEMultipart("mixed")
+    m["From"] = from_addr
+    m["Subject"] = subject
+    m["Date"] = "Sun, 28 Jun 2026 08:20:00 +0000"
+    m["Message-ID"] = "<abc123@example.com>"
+    m.attach(MIMEText("See attached invoice.", "plain"))
+    subtype = ctype.split("/", 1)[1] if "/" in ctype else "octet-stream"
+    part = MIMEApplication(FAKE_PDF, _subtype=subtype)
+    if filename is not None:
+        part.add_header("Content-Disposition", "attachment", filename=filename)
+    m.attach(part)
+    return m.as_bytes()
+
+
+def _msg_no_attachment(from_addr, subject):
+    m = MIMEMultipart("mixed")
+    m["From"] = from_addr
+    m["Subject"] = subject
+    m.attach(MIMEText("Just text, no files.", "plain"))
+    return m.as_bytes()
+
+
+# --------------------------------------------------------------------------- #
+# Attachment extraction
+# --------------------------------------------------------------------------- #
+def test_extract_pdf_attachment_returns_filename_and_bytes():
+    raw = _msg_with_pdf("billing@hetzner.com", "Your invoice",
+                        "Hetzner_2026-06-28.pdf")
+    atts = a.extract_pdf_attachments(raw)
+    assert len(atts) == 1
+    assert atts[0].filename == "Hetzner_2026-06-28.pdf"
+    assert atts[0].data == FAKE_PDF
+
+
+def test_extract_pdf_by_content_type_without_pdf_suffix():
+    # filename lacks .pdf but content-type is application/pdf → still extracted.
+    raw = _msg_with_pdf("billing@hetzner.com", "inv", "document")
+    atts = a.extract_pdf_attachments(raw)
+    assert len(atts) == 1
+    assert atts[0].data == FAKE_PDF
+
+
+def test_extract_no_attachment_returns_empty():
+    raw = _msg_no_attachment("a@b.com", "hello")
+    assert a.extract_pdf_attachments(raw) == []
+
+
+def test_extract_ignores_non_pdf_attachment():
+    raw = _msg_with_pdf("a@b.com", "s", "photo.png", ctype="image/png")
+    assert a.extract_pdf_attachments(raw) == []
+
+
+# --------------------------------------------------------------------------- #
+# Candidate detection
+# --------------------------------------------------------------------------- #
+def _atts(filename):
+    return [a.PdfAttachment(filename=filename, data=FAKE_PDF)]
+
+
+def test_candidate_billing_sender_plus_pdf():
+    assert a.is_archive_candidate(
+        from_addr="billing@hetzner.com", subject="Your monthly bill",
+        attachments=_atts("statement.pdf"),
+    )
+
+
+def test_candidate_non_billing_but_invoice_named_pdf():
+    # filename signal rescues a non-billing sender.
+    assert a.is_archive_candidate(
+        from_addr="someone@randomco.com", subject="hi",
+        attachments=_atts("invoice_x.pdf"),
+    )
+
+
+def test_not_candidate_non_billing_non_invoice_pdf():
+    assert not a.is_archive_candidate(
+        from_addr="someone@randomco.com", subject="trip photos",
+        attachments=_atts("vacation.pdf"),
+    )
+
+
+def test_not_candidate_no_pdf():
+    assert not a.is_archive_candidate(
+        from_addr="billing@hetzner.com", subject="invoice", attachments=[],
+    )
+
+
+def test_candidate_billing_subject_regex_signal():
+    # non-allowlisted sender, no invoice-named file, but transactional subject.
+    assert a.is_archive_candidate(
+        from_addr="noreply@notify.cloudflare.com", subject="Your invoice is ready",
+        attachments=_atts("statement-june.pdf"),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Bucket / vendor / key derivation
+# --------------------------------------------------------------------------- #
+def test_bucket_for_year():
+    assert a.bucket_for(datetime(2026, 6, 28)) == "taxes-2026-invoices"
+    assert a.bucket_for(datetime(2024, 1, 1)) == "taxes-2024-invoices"
+
+
+def test_vendor_domain_two_label():
+    assert a.vendor_domain("billing@hetzner.com") == "hetzner.com"
+
+
+def test_vendor_domain_subdomain_collapsed():
+    assert a.vendor_domain("noreply@notify.cloudflare.com") == "cloudflare.com"
+
+
+def test_vendor_domain_missing():
+    assert a.vendor_domain(None) == "unknown-vendor"
+    assert a.vendor_domain("garbage") == "unknown-vendor"
+
+
+def test_object_key_basic():
+    key = a.object_key(
+        vendor="hetzner.com", dt=datetime(2026, 6, 28),
+        filename="Hetzner_2026.pdf", message_id="<x@y>",
+    )
+    assert key == "hetzner.com/2026-06-28-Hetzner_2026.pdf"
+
+
+def test_object_key_sanitizes_spaces_and_slashes():
+    key = a.object_key(
+        vendor="acme.com", dt=datetime(2026, 6, 28),
+        filename="../../etc/  weird   invoice .pdf", message_id="<x@y>",
+    )
+    # path components stripped, whitespace collapsed.
+    assert key == "acme.com/2026-06-28-weird invoice .pdf"
+    assert "/" not in key.split("/", 1)[1]  # no slash inside the object portion
+
+
+def test_object_key_missing_filename_uses_message_id():
+    key = a.object_key(
+        vendor="acme.com", dt=datetime(2026, 6, 28),
+        filename=None, message_id="<msg-42@mail.acme.com>",
+    )
+    assert key == "acme.com/2026-06-28-msg-42@mail.acme.com.pdf"
+
+
+def test_object_key_missing_both_filename_and_msgid():
+    key = a.object_key(vendor="acme.com", dt=datetime(2026, 6, 28),
+                       filename="", message_id=None)
+    assert key == "acme.com/2026-06-28-message.pdf"
+
+
+# --------------------------------------------------------------------------- #
+# invoice_date
+# --------------------------------------------------------------------------- #
+def test_invoice_date_from_header():
+    dt = a.invoice_date("Sun, 28 Jun 2026 08:20:00 +0000", None)
+    assert dt.year == 2026 and dt.month == 6 and dt.day == 28
+
+
+def test_invoice_date_accepts_datetime_passthrough():
+    # Postgres timestamptz comes back as a datetime, not a string.
+    dt_in = datetime(2026, 6, 28, 8, 20, tzinfo=timezone.utc)
+    assert a.invoice_date(dt_in, None) is dt_in
+
+
+def test_invoice_date_falls_back_to_received_at():
+    rcv = datetime(2025, 3, 1, tzinfo=timezone.utc)
+    assert a.invoice_date(None, rcv) == rcv
+    assert a.invoice_date("not a date", rcv) == rcv
+
+
+# --------------------------------------------------------------------------- #
+# Sidecar shape
+# --------------------------------------------------------------------------- #
+def test_sidecar_metadata_shape():
+    sc = a.sidecar_metadata(
+        vendor="hetzner.com", from_addr="billing@hetzner.com",
+        dt=datetime(2026, 6, 28), amount="$5.00", subject="Invoice",
+        message_id="<x@y>", mail_id=22321,
+    )
+    assert set(sc) == {
+        "vendor", "from_addr", "date", "amount", "subject", "message_id", "mail_id",
+    }
+    assert sc["vendor"] == "hetzner.com"
+    assert sc["date"] == "2026-06-28"
+    assert sc["amount"] == "$5.00"
+    assert sc["mail_id"] == 22321
+    # must be JSON-serializable
+    json.loads(json.dumps(sc))
+
+
+def test_sidecar_amount_nullable():
+    sc = a.sidecar_metadata(
+        vendor="v", from_addr="a@b.com", dt=datetime(2026, 1, 1), amount=None,
+        subject="s", message_id="<m>", mail_id=1,
+    )
+    assert sc["amount"] is None
+
+
+# --------------------------------------------------------------------------- #
+# Idempotency predicate — a row already labeled invoice-archived is excluded.
+# --------------------------------------------------------------------------- #
+def _predicate(row):
+    """Mirror of fetch_unarchived's WHERE clause in Python, for unit testing the
+    selection logic without a live DB:
+        via_gmail AND raw IS NOT NULL AND NOT ('invoice-archived' = ANY(labels))
+    """
+    labels = row.get("labels") or []
+    return (
+        bool(row.get("via_gmail"))
+        and row.get("raw") is not None
+        and a.ARCHIVED_LABEL not in labels
+    )
+
+
+def test_idempotency_excludes_already_archived_row():
+    archived = {"via_gmail": True, "raw": b"x", "labels": ["fyi", "invoice-archived"]}
+    fresh = {"via_gmail": True, "raw": b"x", "labels": ["fyi"]}
+    no_raw = {"via_gmail": True, "raw": None, "labels": []}
+    not_gmail = {"via_gmail": False, "raw": b"x", "labels": []}
+
+    assert _predicate(archived) is False  # already archived → excluded
+    assert _predicate(fresh) is True       # not yet archived → included
+    assert _predicate(no_raw) is False     # no raw message → excluded
+    assert _predicate(not_gmail) is False  # not via_gmail → excluded
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration with MOCKED MinIO + fake DB (no live upload, no network).
+# --------------------------------------------------------------------------- #
+class FakeMinio:
+    """Captures put_object / ensure_bucket calls; mirrors MinioArchive's surface."""
+
+    def __init__(self):
+        self.buckets = set()
+        self.objects = {}  # (bucket, key) -> (bytes, content_type)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def ensure_bucket(self, bucket):
+        created = bucket not in self.buckets
+        self.buckets.add(bucket)
+        return created
+
+    def put_object(self, bucket, key, data, content_type):
+        self.objects[(bucket, key)] = (data, content_type)
+
+
+class FakeMailDB:
+    """Mirrors _db.MailDB's archiver surface; tracks labels in memory."""
+
+    def __init__(self, rows):
+        self._rows = [dict(r) for r in rows]
+        for r in self._rows:
+            r.setdefault("labels", [])
+        self.labeled = []
+        self.commits = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def fetch_unarchived(self, limit=None):
+        out = [
+            dict(r) for r in self._rows
+            if r.get("via_gmail") and r.get("raw") is not None
+            and a.ARCHIVED_LABEL not in (r.get("labels") or [])
+        ]
+        return out[:limit] if limit is not None else out
+
+    def amount_for_mail(self, mail_id):
+        return None
+
+    def add_label(self, mail_id, label):
+        self.labeled.append((mail_id, label))
+
+    def commit(self):
+        self.commits += 1
+
+
+def _archive_rows():
+    return [
+        # candidate: billing sender + PDF
+        {"id": 22321, "message_id": "<h@x>", "from_addr": "billing@hetzner.com",
+         "subject": "Your Hetzner invoice", "received_at": None,
+         "date_header": "Sun, 28 Jun 2026 08:20:00 +0000", "via_gmail": True,
+         "raw": _msg_with_pdf("billing@hetzner.com", "Your Hetzner invoice",
+                              "Hetzner_2026-06-28.pdf"), "labels": ["fyi"]},
+        # NOT a candidate: no pdf
+        {"id": 99, "message_id": "<n@x>", "from_addr": "friend@gmail.com",
+         "subject": "lunch?", "received_at": None, "date_header": None,
+         "via_gmail": True, "raw": _msg_no_attachment("friend@gmail.com", "lunch?"),
+         "labels": []},
+        # already archived → excluded by fetch
+        {"id": 7, "message_id": "<a@x>", "from_addr": "billing@hetzner.com",
+         "subject": "old invoice", "received_at": None, "date_header": None,
+         "via_gmail": True, "raw": _msg_with_pdf("billing@hetzner.com", "old",
+                                                 "old.pdf"),
+         "labels": ["invoice-archived"]},
+    ]
+
+
+def test_cmd_archive_uploads_and_labels(monkeypatch, capsys):
+    fake_db = FakeMailDB(_archive_rows())
+    fake_mc = FakeMinio()
+
+    import _db
+    import _minio
+    monkeypatch.setattr(_db, "MailDB", lambda *aa, **kk: fake_db)
+    monkeypatch.setattr(_minio, "MinioArchive", lambda *aa, **kk: fake_mc)
+
+    args = types.SimpleNamespace(dry_run=False, limit=None, json=True)
+    rc = extract.cmd_archive(args)
+    assert rc == 0
+
+    # one candidate (hetzner) → one PDF + one sidecar uploaded, bucket created, labeled.
+    assert ("taxes-2026-invoices",
+            "hetzner.com/2026-06-28-Hetzner_2026-06-28.pdf") in fake_mc.objects
+    sidecar_key = ("taxes-2026-invoices",
+                   "hetzner.com/2026-06-28-Hetzner_2026-06-28.pdf.json")
+    assert sidecar_key in fake_mc.objects
+    sc_bytes, sc_ct = fake_mc.objects[sidecar_key]
+    assert sc_ct == "application/json"
+    sc = json.loads(sc_bytes)
+    assert sc["mail_id"] == 22321 and sc["vendor"] == "hetzner.com"
+
+    assert fake_db.labeled == [(22321, "invoice-archived")]
+    out = capsys.readouterr().out
+    summary = json.loads(out)
+    assert summary["candidates"] == 1
+    assert summary["pdfs_uploaded"] == 1
+    assert summary["sidecars"] == 1
+    assert summary["labeled"] == 1
+    assert summary["errors"] == 0
+
+
+def test_cmd_archive_dry_run_no_uploads_no_labels(monkeypatch, capsys):
+    fake_db = FakeMailDB(_archive_rows())
+    fake_mc = FakeMinio()
+
+    import _db
+    import _minio
+    monkeypatch.setattr(_db, "MailDB", lambda *aa, **kk: fake_db)
+    # If dry-run wrongly instantiates MinIO, this would surface; make it explode.
+    monkeypatch.setattr(_minio, "MinioArchive",
+                        lambda *aa, **kk: (_ for _ in ()).throw(
+                            AssertionError("dry-run must not touch MinIO")))
+
+    args = types.SimpleNamespace(dry_run=True, limit=None, json=True)
+    rc = extract.cmd_archive(args)
+    assert rc == 0
+
+    assert fake_db.labeled == []  # no label writes
+    assert fake_mc.objects == {}  # no uploads
+    out = json.loads(capsys.readouterr().out)
+    assert out["summary"]["candidates"] == 1
+    assert out["summary"]["mode"] == "dry-run"
+    assert out["candidates"][0]["mail_id"] == 22321
+    assert out["candidates"][0]["bucket"] == "taxes-2026-invoices"
+
+
+def test_cmd_archive_upload_error_skips_label(monkeypatch, capsys):
+    fake_db = FakeMailDB(_archive_rows())
+
+    class ExplodingMinio(FakeMinio):
+        def put_object(self, bucket, key, data, content_type):
+            raise RuntimeError("simulated S3 failure")
+
+    import _db
+    import _minio
+    monkeypatch.setattr(_db, "MailDB", lambda *aa, **kk: fake_db)
+    monkeypatch.setattr(_minio, "MinioArchive", lambda *aa, **kk: ExplodingMinio())
+
+    args = types.SimpleNamespace(dry_run=False, limit=None, json=True)
+    rc = extract.cmd_archive(args)
+    assert rc == 0
+
+    # upload failed → mail NOT labeled (so it retries next run), error counted.
+    assert fake_db.labeled == []
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["errors"] >= 1
+    assert summary["labeled"] == 0


### PR DESCRIPTION
## What

Adds an `archive-invoices` subcommand to the **mail-actions** tool that mines the self-hosted inbox for **PDF invoice attachments** and uploads each one — plus a JSON metadata sidecar — to a per-year homelab MinIO bucket (`taxes-{YEAR}-invoices`), so a downstream tax agent can reconcile.

Deterministic, **no LLM**. It is **independent of the action-required pipeline**: it scans *all* `via_gmail` mail that has a raw message (regardless of `processed_at`), skipping only mail already carrying the dedicated **`invoice-archived`** label. A paid invoice the LLM marked `fyi` is still a tax document, so archival is orthogonal to action-triage — they use separate state.

## How

- **`archive.py`** (pure, no I/O) — PDF attachment extraction via the stdlib `email` module (content-type `application/pdf` OR a `.pdf` filename); candidate detection that **reuses `filter._billing_exempt`** (not duplicated) OR an attachment filename matching `/invoice|receipt|statement/i`; bucket/vendor/object-key derivation; sidecar shape.
- **`_minio.py`** — `MinioArchive` context manager mirroring `_db.py`'s pattern: `kubectl -n minio-archive port-forward svc/minio 0:80` → `minio` python client at `http://127.0.0.1:<port>` with **path-style** addressing. Creds from env (`MINIO_ARCHIVE_*`) or parsed from the `minio-archive-config` secret's `config.env`. No hardcoded secrets.
- **`_db.py`** — `fetch_unarchived` (delta read incl. `raw` bytea → bytes; excludes `invoice-archived`), `add_label` (appends a label **without** touching `processed_at`), `amount_for_mail` (best-effort, table-existence-guarded).
- **`extract.py`** — `archive-invoices [--dry-run] [--limit N] [--json]`. Labels a mail **only after** all of its PDFs + sidecars upload successfully; an upload error skips the label (so the mail retries next run), is counted, and the run continues.

Object layout:
```
s3://taxes-{YEAR}-invoices/{vendor}/{YYYY-MM-DD}-{sanitized_filename}        # the PDF
s3://taxes-{YEAR}-invoices/{vendor}/{YYYY-MM-DD}-{sanitized_filename}.json   # sidecar
```
Sidecar JSON: `{vendor, from_addr, date, amount, subject, message_id, mail_id}` (`amount` best-effort, may be `null` — the archiver does not call the LLM).

## Tests

26 new offline tests in `tests/test_archive.py` (MinIO client mocked, fake DB, no network): PDF extraction from a synthetic `multipart/mixed` message; candidate detection (billing-sender / invoice-filename / negative cases); bucket + vendor-domain + object-key sanitization (spaces, slashes, missing-filename → `message_id` fallback); sidecar shape; the `invoice-archived` idempotency predicate; and the orchestration (upload+label, dry-run writes nothing, upload-error skips the label). Full suite: **66 passed**.

## Verified live

- `--dry-run` against real mail found the **2 expected invoices** — Hetzner (mail#22321) → `hetzner.com/2026-06-28-Hetzner_2026-06-28_082000970828.pdf`, Cloudflare (mail#14563) → `cloudflare.com/2026-06-27-cloudflare-invoice-2026-06-28.pdf`.
- A **live run** uploaded both PDFs (50KB / 32KB) + JSON sidecars to `taxes-2026-invoices` and labelled both mails `invoice-archived`.
- A **second `--dry-run` reports 0 candidates** (idempotent); the labels are `{invoice-archived}` only, confirming `processed_at` / other labels are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)