### PR TITLE
fix(mail-actions): invoices never become actions; one action per thread

### DIFF
--- a/scripts/mail-actions/_db.py
+++ b/scripts/mail-actions/_db.py
@@ -206,6 +206,20 @@ class MailDB:
                 r["raw"] = r["raw"].tobytes()
         return rows
 
+    def fetch_raw(self, mail_id: int) -> bytes | None:
+        """The raw RFC822 bytes for one mail, or None if absent.
+
+        Called ONLY for the (few) Stage-1 survivors during a run, so the whole
+        backlog's `raw` column is never pulled into memory. psycopg2 hands bytea
+        back as a memoryview; convert to plain bytes for the email parser."""
+        with self._c.cursor() as cur:
+            cur.execute("SELECT raw FROM mail WHERE id = %s", (mail_id,))
+            row = cur.fetchone()
+        if not row or row[0] is None:
+            return None
+        raw = row[0]
+        return raw.tobytes() if isinstance(raw, memoryview) else bytes(raw)
+
     def amount_for_mail(self, mail_id: int) -> str | None:
         """Best-effort: the `amount` from a mail_actions row for this mail, if one
         exists (the action pipeline may have extracted it). None otherwise — including

--- a/scripts/mail-actions/extract.py
+++ b/scripts/mail-actions/extract.py
@@ -8,8 +8,10 @@ Pipeline (see scripts/mail-actions/README.md for the full picture):
   Stage 4  surface to clawgate       (clawgate.py, optional, --emit-clawgate)
 
 Delta/idempotency: a row is only touched while `mail.processed_at IS NULL`. Every
-processed row is labelled ('bulk' | 'fyi' | 'action-required') and stamped, so a
-re-run is a no-op over already-seen mail.
+processed row is labelled ('bulk' | 'fyi' | 'action-required' | 'invoice' |
+'superseded') and stamped, so a re-run is a no-op over already-seen mail.
+  invoice    — an invoice (auto-paid; captured by the archiver, never an action)
+  superseded — an older message of a thread already represented by a newer one
 
 Subcommands:
   run               run the action-required pipeline (filter → LLM → persist)
@@ -34,6 +36,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+import archive  # noqa: E402  (sibling module, reuse the invoice definition — do NOT duplicate)
 import filter as f  # noqa: E402  (sibling module, not a package)
 import llm  # noqa: E402
 
@@ -59,6 +62,53 @@ def _partition(rows):
         )
         (dropped if res.drop else survivors).append((r, res))
     return dropped, survivors
+
+
+def thread_key(headers: dict | None, message_id: str | None) -> str:
+    """Stable key grouping every message of one email thread together.
+
+    Resolution order (RFC 5322 threading), case-insensitive on header names:
+      1. `References` — a whitespace-separated list of <msg-id>s; return the FIRST
+         (the thread root, which every reply carries).
+      2. `In-Reply-To` — the parent's msg-id, stripped of angle brackets.
+      3. the mail's own `message_id`, stripped.
+
+    A thread root has neither References nor In-Reply-To, and its own message_id is
+    exactly what replies put in References[0], so the root and all its replies map to
+    the same key. Returns "" only when nothing identifying is present."""
+    hdrs = headers or {}
+    # Case-insensitive header lookup (header dicts in this pipeline aren't normalized).
+    lower = {str(k).lower(): v for k, v in hdrs.items()}
+
+    refs = lower.get("references")
+    if refs and str(refs).strip():
+        ids = str(refs).split()
+        if ids:
+            return ids[0].strip().strip("<>")
+
+    in_reply_to = lower.get("in-reply-to")
+    if in_reply_to and str(in_reply_to).strip():
+        # In-Reply-To is normally a single id, but tolerate extra tokens.
+        first = str(in_reply_to).split()[0]
+        return first.strip().strip("<>")
+
+    return (message_id or "").strip().strip("<>")
+
+
+def _is_invoice(db, r) -> bool:
+    """True iff this survivor is an invoice by the SAME definition the archiver uses:
+    load the mail's raw bytes, parse PDF attachments, and test
+    `archive.is_archive_candidate`. Called only for survivors (few), so the whole
+    backlog's `raw` is never loaded. A None/empty raw → not an invoice (no PDFs)."""
+    raw = db.fetch_raw(r["id"])
+    if not raw:
+        return False
+    atts = archive.extract_pdf_attachments(raw)
+    return archive.is_archive_candidate(
+        from_addr=r.get("from_addr"),
+        subject=r.get("subject"),
+        attachments=atts,
+    )
 
 
 def cmd_run(args) -> int:
@@ -92,9 +142,32 @@ def cmd_run(args) -> int:
 
         actions = 0
         fyis = 0
+        invoices = 0
+        superseded = 0
         errors = 0
         emitted = 0
+        seen_threads: set[str] = set()
+        # Survivors arrive most-recent-first (fetch_unprocessed ORDER BY received_at
+        # DESC), so the FIRST survivor seen for a thread is the latest message — the
+        # one we keep; older messages of an already-seen thread are superseded.
         for r, _res in survivors:
+            # (1) thread-dedup: an older message of a thread we've already represented.
+            tkey = thread_key(r.get("headers"), r.get("message_id"))
+            if tkey and tkey in seen_threads:
+                db.mark_processed(r["id"], "superseded")
+                superseded += 1
+                continue
+            if tkey:
+                seen_threads.add(tkey)
+
+            # (2) invoice check: invoices are auto-paid + captured by the archiver for
+            # tax records — they are never action items, so skip the LLM entirely.
+            if _is_invoice(db, r):
+                db.mark_processed(r["id"], "invoice")
+                invoices += 1
+                continue
+
+            # (3) otherwise: LLM extraction as before.
             try:
                 ex = llm.extract(
                     from_addr=r.get("from_addr") or "",
@@ -133,6 +206,8 @@ def cmd_run(args) -> int:
             "mode": "run",
             "action_required": actions,
             "fyi": fyis,
+            "invoice": invoices,
+            "superseded": superseded,
             "extract_errors": errors,
             "clawgate_emitted": emitted,
             "est_llm_cost_usd": round(_est_cost(len(survivors)), 4),
@@ -348,6 +423,8 @@ def _print_run(s) -> None:
     print(f"  survivors → LLM:  {s['survivors']}")
     print(f"  action-required:  {s['action_required']}")
     print(f"  fyi:              {s['fyi']}")
+    print(f"  invoice:          {s.get('invoice', 0)}")
+    print(f"  superseded:       {s.get('superseded', 0)}")
     if s["extract_errors"]:
         print(f"  extract errors:   {s['extract_errors']}")
     if s.get("clawgate_emitted"):

--- a/scripts/mail-actions/tests/test_idempotency.py
+++ b/scripts/mail-actions/tests/test_idempotency.py
@@ -42,6 +42,10 @@ class FakeMailDB:
         out.sort(key=lambda r: r["id"], reverse=True)
         return out[:limit] if limit is not None else out
 
+    def fetch_raw(self, mail_id):
+        # The idempotency-test rows have no PDF/raw → never invoices.
+        return self._mail[mail_id].get("raw")
+
     def mark_processed(self, mail_id, label):
         r = self._mail[mail_id]
         if label not in r["labels"]:

--- a/scripts/mail-actions/tests/test_run_routing.py
+++ b/scripts/mail-actions/tests/test_run_routing.py
@@ -1,0 +1,247 @@
+"""Run-loop routing tests for cmd_run's thread-dedup + invoice short-circuit.
+
+All offline: a fake in-memory MailDB (incl. fetch_raw) and a counting fake
+llm.extract — no Postgres, no MinIO, no OpenRouter. Verifies:
+  - a 3-message thread → exactly ONE llm.extract call (the most-recent) + two
+    `superseded` labels;
+  - an invoice survivor → ZERO llm.extract calls + an `invoice` label;
+  - a normal lone survivor → one llm.extract call + an action (or fyi) label;
+  - the run summary reports the new invoice / superseded counters.
+"""
+import sys
+import types
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import archive  # noqa: E402
+import extract  # noqa: E402
+import llm  # noqa: E402
+
+FAKE_PDF = b"%PDF-1.4\nfake invoice body\n%%EOF\n"
+
+
+def _raw_with_pdf(from_addr, subject, filename):
+    m = MIMEMultipart("mixed")
+    m["From"] = from_addr
+    m["Subject"] = subject
+    m["Message-ID"] = "<inv@x>"
+    m.attach(MIMEText("See attached invoice.", "plain"))
+    part = MIMEApplication(FAKE_PDF, _subtype="pdf")
+    part.add_header("Content-Disposition", "attachment", filename=filename)
+    m.attach(part)
+    return m.as_bytes()
+
+
+class FakeMailDB:
+    """Mirrors _db.MailDB's run surface, in memory; rows may carry a `raw` value."""
+
+    def __init__(self, rows):
+        self._mail = {}
+        for r in rows:
+            r = dict(r)
+            r.setdefault("processed_at", None)
+            r.setdefault("labels", [])
+            r.setdefault("raw", None)
+            self._mail[r["id"]] = r
+        self.actions = {}
+        self.commits = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def ensure_schema(self):
+        pass
+
+    def fetch_unprocessed(self, limit=None):
+        out = [dict(r) for r in self._mail.values() if r["processed_at"] is None]
+        # Most-recent-first; rows here use received_at as the sort key (DESC).
+        out.sort(key=lambda r: (r.get("received_at") or 0), reverse=True)
+        return out[:limit] if limit is not None else out
+
+    def fetch_raw(self, mail_id):
+        return self._mail[mail_id].get("raw")
+
+    def mark_processed(self, mail_id, label):
+        r = self._mail[mail_id]
+        if label not in r["labels"]:
+            r["labels"].append(label)
+        r["processed_at"] = "STAMPED"
+
+    def insert_action(self, row):
+        if row["mail_id"] in self.actions:
+            return False
+        self.actions[row["mail_id"]] = row
+        return True
+
+    def commit(self):
+        self.commits += 1
+
+
+class CountingLLM:
+    """Records every llm.extract call; returns action-required by default."""
+
+    def __init__(self, action_required=True):
+        self.calls = []
+        self._ar = action_required
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._ar:
+            return llm.Extraction(
+                action_required=True, who="W", ask="do thing", deadline=None,
+                amount=None, confidence=0.9, reason="r",
+            )
+        return llm.Extraction(
+            action_required=False, who="", ask="", deadline=None, amount=None,
+            confidence=0.2, reason="fyi",
+        )
+
+
+def _run(monkeypatch, fake_db, fake_llm):
+    import _db
+    monkeypatch.setattr(_db, "MailDB", lambda *a, **k: fake_db)
+    monkeypatch.setattr(llm, "extract", fake_llm)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    args = types.SimpleNamespace(dry_run=False, limit=150, model=None,
+                                 emit_clawgate=False, json=False)
+    rc = extract.cmd_run(args)
+    assert rc == 0
+
+
+def test_thread_dedup_one_llm_call_two_superseded(monkeypatch, capsys):
+    # 3 messages of one thread, plus a lone unrelated survivor. received_at orders
+    # them so the thread's NEWEST (reply2, id=3) is processed first.
+    rows = [
+        {"id": 1, "message_id": "<M0>", "from_addr": "lauren@naidacom.com",
+         "subject": "Sales Audit Excel Template", "received_at": 100,
+         "category": "personal", "headers": {}, "text_body": "root"},
+        {"id": 2, "message_id": "<M1>", "from_addr": "lauren@naidacom.com",
+         "subject": "Re: Sales Audit Excel Template", "received_at": 200,
+         "category": "personal", "headers": {"References": "<M0>"},
+         "text_body": "reply1"},
+        {"id": 3, "message_id": "<M2>", "from_addr": "lauren@naidacom.com",
+         "subject": "Re: Sales Audit Excel Template", "received_at": 300,
+         "category": "personal", "headers": {"References": "<M0> <M1>"},
+         "text_body": "reply2"},
+    ]
+    db = FakeMailDB(rows)
+    fake_llm = CountingLLM(action_required=True)
+    _run(monkeypatch, db, fake_llm)
+
+    # Exactly one LLM call, for the most-recent message (reply2, id=3).
+    assert len(fake_llm.calls) == 1
+    assert fake_llm.calls[0]["body"] == "reply2"
+    # The newest got an action; the older two are superseded.
+    assert db._mail[3]["labels"] == ["action-required"]
+    assert db._mail[2]["labels"] == ["superseded"]
+    assert db._mail[1]["labels"] == ["superseded"]
+    assert set(db.actions) == {3}
+
+
+def test_invoice_survivor_skips_llm_and_labels_invoice(monkeypatch, capsys):
+    rows = [
+        {"id": 10, "message_id": "<inv@x>", "from_addr": "billing@hetzner.com",
+         "subject": "Your invoice", "received_at": 100, "category": "personal",
+         "headers": {}, "text_body": "invoice body",
+         "raw": _raw_with_pdf("billing@hetzner.com", "Your invoice",
+                              "invoice_123.pdf")},
+    ]
+    db = FakeMailDB(rows)
+    fake_llm = CountingLLM(action_required=True)
+    # Sanity: the same definition the archiver uses flags this as a candidate.
+    assert archive.is_archive_candidate(
+        from_addr="billing@hetzner.com", subject="Your invoice",
+        attachments=archive.extract_pdf_attachments(rows[0]["raw"]),
+    )
+    _run(monkeypatch, db, fake_llm)
+
+    assert fake_llm.calls == []                  # LLM never called
+    assert db._mail[10]["labels"] == ["invoice"]
+    assert db.actions == {}                       # no action row
+
+
+def test_invoice_via_monkeypatched_candidate(monkeypatch):
+    # Alternate path: force is_archive_candidate True regardless of attachments.
+    rows = [
+        {"id": 11, "message_id": "<x@x>", "from_addr": "x@y.com",
+         "subject": "anything", "received_at": 100, "category": "personal",
+         "headers": {}, "text_body": "body", "raw": b"%PDF-1.4 stub"},
+    ]
+    db = FakeMailDB(rows)
+    fake_llm = CountingLLM(action_required=True)
+    monkeypatch.setattr(archive, "is_archive_candidate", lambda **kw: True)
+    _run(monkeypatch, db, fake_llm)
+
+    assert fake_llm.calls == []
+    assert db._mail[11]["labels"] == ["invoice"]
+
+
+def test_normal_lone_survivor_one_llm_call_action(monkeypatch):
+    rows = [
+        {"id": 20, "message_id": "<lone@x>", "from_addr": "sales@zenpayments.com",
+         "subject": "Application Incomplete", "received_at": 100,
+         "category": "personal", "headers": {}, "text_body": "complete it"},
+    ]
+    db = FakeMailDB(rows)
+    fake_llm = CountingLLM(action_required=True)
+    _run(monkeypatch, db, fake_llm)
+
+    assert len(fake_llm.calls) == 1
+    assert db._mail[20]["labels"] == ["action-required"]
+    assert set(db.actions) == {20}
+
+
+def test_normal_lone_survivor_fyi(monkeypatch):
+    rows = [
+        {"id": 21, "message_id": "<lone2@x>", "from_addr": "a@b.com",
+         "subject": "fyi note", "received_at": 100, "category": "personal",
+         "headers": {}, "text_body": "nothing to do"},
+    ]
+    db = FakeMailDB(rows)
+    fake_llm = CountingLLM(action_required=False)
+    _run(monkeypatch, db, fake_llm)
+
+    assert len(fake_llm.calls) == 1
+    assert db._mail[21]["labels"] == ["fyi"]
+    assert db.actions == {}
+
+
+def test_summary_reports_invoice_and_superseded_counters(monkeypatch, capsys):
+    rows = [
+        # thread of two (one superseded) ...
+        {"id": 1, "message_id": "<T0>", "from_addr": "a@b.com", "subject": "t",
+         "received_at": 100, "category": "personal", "headers": {},
+         "text_body": "root"},
+        {"id": 2, "message_id": "<T1>", "from_addr": "a@b.com", "subject": "Re: t",
+         "received_at": 200, "category": "personal",
+         "headers": {"References": "<T0>"}, "text_body": "reply"},
+        # ... plus an invoice
+        {"id": 3, "message_id": "<inv@x>", "from_addr": "billing@hetzner.com",
+         "subject": "Invoice", "received_at": 300, "category": "personal",
+         "headers": {}, "text_body": "inv",
+         "raw": _raw_with_pdf("billing@hetzner.com", "Invoice", "invoice.pdf")},
+    ]
+    db = FakeMailDB(rows)
+    fake_llm = CountingLLM(action_required=True)
+
+    import json as _json
+    import _db
+    monkeypatch.setattr(_db, "MailDB", lambda *a, **k: db)
+    monkeypatch.setattr(llm, "extract", fake_llm)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    args = types.SimpleNamespace(dry_run=False, limit=150, model=None,
+                                 emit_clawgate=False, json=True)
+    extract.cmd_run(args)
+    summary = _json.loads(capsys.readouterr().out)
+
+    assert summary["invoice"] == 1
+    assert summary["superseded"] == 1
+    assert summary["action_required"] == 1   # the thread's newest (T1)
+    assert summary["survivors"] == 3

--- a/scripts/mail-actions/tests/test_thread_key.py
+++ b/scripts/mail-actions/tests/test_thread_key.py
@@ -1,0 +1,71 @@
+"""Tests for extract.thread_key — the RFC 5322 thread-grouping key.
+
+Pure logic, no DB, no network. Verifies the resolution order
+(References[0] → In-Reply-To → own message_id) and that a synthetic root + its
+two replies all collapse to the same key (the real naida-thread shape).
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import extract  # noqa: E402
+
+
+def test_references_returns_first_id_thread_root():
+    # References is a whitespace-separated list of <msg-id>s; the FIRST is the root.
+    k = extract.thread_key(
+        {"References": "<root@x> <mid@x> <latest@x>"}, message_id="<latest@x>"
+    )
+    assert k == "root@x"
+
+
+def test_references_single_id():
+    k = extract.thread_key({"References": "<only@x>"}, message_id="<reply@x>")
+    assert k == "only@x"
+
+
+def test_in_reply_to_fallback_when_no_references():
+    k = extract.thread_key({"In-Reply-To": "<parent@x>"}, message_id="<self@x>")
+    assert k == "parent@x"
+
+
+def test_own_message_id_fallback_when_no_threading_headers():
+    k = extract.thread_key({}, message_id="<self@x>")
+    assert k == "self@x"
+
+
+def test_own_message_id_fallback_when_headers_none():
+    k = extract.thread_key(None, message_id="<self@x>")
+    assert k == "self@x"
+
+
+def test_header_lookup_is_case_insensitive():
+    assert extract.thread_key({"references": "<r@x> <m@x>"}, "<m@x>") == "r@x"
+    assert extract.thread_key({"IN-REPLY-TO": "<p@x>"}, "<s@x>") == "p@x"
+
+
+def test_angle_brackets_stripped_everywhere():
+    assert extract.thread_key({}, message_id="<bare@x>") == "bare@x"
+    assert extract.thread_key({"In-Reply-To": "<p@x>"}, "<s@x>") == "p@x"
+
+
+def test_empty_references_falls_through_to_in_reply_to():
+    k = extract.thread_key(
+        {"References": "   ", "In-Reply-To": "<p@x>"}, message_id="<s@x>"
+    )
+    assert k == "p@x"
+
+
+def test_three_message_thread_collapses_to_one_key():
+    # The real naida-thread shape: a root with no threading headers, then two replies
+    # whose References lists start with the root's message_id.
+    root = {"headers": {}, "message_id": "<M0>"}
+    reply1 = {"headers": {"References": "<M0>"}, "message_id": "<M1>"}
+    reply2 = {"headers": {"References": "<M0> <M1>"}, "message_id": "<M2>"}
+
+    keys = {
+        extract.thread_key(m["headers"], m["message_id"])
+        for m in (root, reply1, reply2)
+    }
+    assert keys == {"M0"}


### PR DESCRIPTION
Two fixes to the **mail-actions** action pipeline (`scripts/mail-actions/`), targeting false/duplicate action items in `cmd_run`.

## FIX 1 — invoices never become action items
Auto-paid invoices were surfacing as false actions (e.g. *"Pay Cloudflare \$2.28"*). They're tax records captured by the invoice archiver, never something to action.

For each Stage-1 survivor, BEFORE the LLM, the mail is now tested with the **same definition the archiver uses**: load the mail's `raw`, parse PDF attachments, and check `archive.is_archive_candidate(...)`. A match → label `invoice`, skip the LLM.

- New `_db.fetch_raw(mail_id) -> bytes | None` (`SELECT raw … WHERE id=%s`, memoryview→bytes). Called **only for survivors** (few), so the whole backlog's `raw` is never bulk-loaded.
- `archive` imported as a sibling module like the others.
- Non-invoice billing mail (a *payment-failed* on an active service, a Stripe *action-required* with no PDF) has no qualifying PDF, so it still reaches the LLM as a possible action.

## FIX 2 — one action per thread
A 3-message conversation (the real naida "Sales Audit Excel Template" thread) was surfacing as 3 separate actions.

New `thread_key(headers, message_id)` groups a thread per RFC 5322:
1. `References` (whitespace-separated `<msg-id>` list, case-insensitive) → first id (the root);
2. else `In-Reply-To` (stripped of `<>`);
3. else the mail's own `message_id`.

A thread root carries neither threading header and its own `message_id` is exactly what replies put in `References[0]`, so root + replies map to one key.

In `cmd_run`, survivors arrive **newest-first** (`fetch_unprocessed ORDER BY received_at DESC`). A `set()` of seen keys is tracked: the first survivor per thread is kept; any later (older) survivor of an already-seen thread is labelled `superseded` and skips the LLM. The 3 naida messages collapse to ONE action (the latest); the older two become `superseded`.

## Per-survivor order in the loop
1. thread-dedup (older-in-seen-thread → `superseded`, skip)
2. invoice check (invoice → `invoice`, skip LLM)
3. else LLM as today

Run summary gains `invoice` + `superseded` counts (printed and in `--json`).

## Tests (offline — mock LLM + in-memory DB, no Postgres/MinIO/OpenRouter)
- `tests/test_thread_key.py` (9): References→root (multi-id returns first), In-Reply-To fallback, own-message_id fallback, case-insensitive headers, and a synthetic root + 2 replies all yielding the same key.
- `tests/test_run_routing.py` (6): a 3-message thread → exactly **one** `llm.extract` call (the newest) + two `superseded`; an invoice survivor (real PDF, and a monkeypatched-candidate variant) → **zero** LLM calls + an `invoice` label; a normal lone survivor → one LLM call + action/fyi; and the summary's new counters.
- Existing `tests/test_idempotency.py` updated with a no-op `fetch_raw`; all prior tests stay green.

**Suite: 81 passed** (was 66) under `nix-shell -p 'python3.withPackages(p:[p.pytest p.requests p.psycopg2 p.minio])'`.

Not run against the live pipeline / DB — that verification (reset + rerun) is done separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)