### PR TITLE
feat(mail-actions): thread-aware action reconciliation (supersede + auto-close)

### DIFF
--- a/scripts/mail-actions/README.md
+++ b/scripts/mail-actions/README.md
@@ -141,6 +141,60 @@ WHERE id = <mail_id>;
 DELETE FROM mail_actions WHERE mail_id = <mail_id>;
 ```
 
+## Thread reconciliation (auto-supersede + auto-close)
+
+Beyond the within-run thread-dedup (one action per thread per run), `run` keeps the
+`mail_actions` table in sync with how a thread evolves over time, using the
+`mail_actions.thread_key` column (the RFC 5322 thread root; see `thread_key()`).
+
+**Feature 1 — cross-run supersede (works today, no setup).** When a NEWER message of a
+thread becomes an action, the older OPEN action for that same thread is set
+`status='superseded'` before the new row is inserted, so the reply's action is the
+single live one. A timestamp guard (`received_at <`) means an older message can never
+retire a newer open action. This fires across runs (it reads existing rows), not just
+within one run.
+
+**Feature 2 — auto-close on the OWNER's reply (needs operator setup; see below).** At
+the START of each `run`, any OPEN action whose thread the **owner** has since replied in
+is set `status='done'` (owner reply ⇒ handled). Matching is by `thread_key`, with a
+timestamp guard so only actions that PREDATE the owner's reply are closed (a stale owner
+message can't close a fresh action from a later inbound reply). Legacy rows with a NULL
+`thread_key` are skipped. The run also defensively labels any inbound survivor whose
+sender is an owner address `sent` and never sends it to the LLM.
+
+Owner addresses come from `MAIL_ACTIONS_OWNER_ADDRS` (comma-separated), defaulting to
+`zachlowden1@gmail.com,zach@civitai.com,zacxdev@gmail.com`.
+
+### Operator prerequisite for Feature 2 (auto-close) — REQUIRED, not built here
+
+Feature 2 only fires when the owner's **sent** replies actually land in the `mail`
+table. **Gmail does not cleanly auto-forward Sent mail** — Gmail filters act on
+*received* mail, so a normal "forward to inbox.zacx.dev" filter never sees your
+outbound replies. Until you arrange for sent mail to reach the inbox, **Feature 2 is
+inert** (Feature 1 works regardless). Two ways to wire it up:
+
+- **BCC habit / client rule:** BCC `<anything>@inbox.zacx.dev` on replies you want
+  auto-closed (a send-time client rule or a manual habit). This is the simplest path.
+- **Apps Script:** a small Google Apps Script that forwards messages under the `Sent`
+  label to `inbox.zacx.dev` on a timer.
+
+**`via_gmail` caveat:** BCC'd / forwarded sent mail often arrives with
+`via_gmail=false`. That is *deliberately* why the reconcile pass scans owner mail with
+`SELECT … FROM mail WHERE lower(from_addr) = ANY(%s)` and does **NOT** restrict to
+`via_gmail` — otherwise the owner's own replies would be invisible to it.
+
+### Migration / backfill
+
+`ensure_schema` adds `thread_key text` to the live table via
+`ALTER TABLE mail_actions ADD COLUMN IF NOT EXISTS thread_key text` (idempotent).
+Pre-existing rows keep `thread_key = NULL` and are skipped by Feature 2 until the
+operator backfills them, e.g.:
+
+```sql
+-- backfill thread_key for existing open actions from their source mail's headers
+-- (done by the operator during verification; new rows get it automatically)
+```
+
 ## Invoice archiver (`archive-invoices`)
 
 A **separate, deterministic** loop (no LLM) that mines the inbox for **PDF invoice
@@ -236,6 +290,19 @@ nix-shell -p 'python3.withPackages(p:[p.pytest p.requests p.psycopg2 p.minio])' 
   sanity guard, confidence clamping, and the single-retry behaviour (mocked caller, no key).
 - `test_idempotency.py` — fake in-memory DB: first pass labels+stamps; second pass sees an
   empty delta and is a no-op; `ON CONFLICT` insert is a no-op.
+- `test_db_schema.py` — SQL-level (mock psycopg2 connection): `ensure_schema` emits the
+  `ADD COLUMN IF NOT EXISTS thread_key` migration; `insert_action` carries `thread_key`;
+  `supersede_open_actions`/`close_actions_done`/`fetch_open_actions_min`/
+  `fetch_owner_messages` emit the expected SQL incl. the `received_at <` timestamp guard
+  and the `via_gmail`-unrestricted owner scan; empty-list/empty-addrs short-circuits.
+- `test_reconcile.py` — fake in-memory DB with the reconcile surface, synthetic
+  `References` chains. Feature 1: a newer message supersedes an existing older open
+  action, but does NOT supersede a newer one (timestamp guard); summary counts it.
+  Feature 2 (`reconcile_owner_replies`): an owner reply AFTER the action closes it; an
+  owner message OLDER than the action does not; an unrelated thread does not; a legacy
+  NULL-`thread_key` action is skipped; runs at the start of `cmd_run` and counts.
+  Owner-from inbound survivor → labeled `sent`, no LLM. `owner_addrs()` env override +
+  default.
 
 Fixtures are scrubbed to **headers + from + subject only** — no personal email bodies are
 committed.

--- a/scripts/mail-actions/_db.py
+++ b/scripts/mail-actions/_db.py
@@ -157,9 +157,17 @@ class MailDB:
                     confidence  real,
                     reason      text,
                     status      text DEFAULT 'open',
+                    thread_key  text,
                     created_at  timestamptz DEFAULT now()
                 )
                 """
+            )
+            # Idempotent migration for the existing live table (created before the
+            # thread_key column). Legacy rows keep thread_key NULL (parent backfills
+            # during verification); the reconcile pass skips NULL-keyed rows.
+            cur.execute(
+                "ALTER TABLE mail_actions "
+                "ADD COLUMN IF NOT EXISTS thread_key text"
             )
         self._c.commit()
 
@@ -280,22 +288,86 @@ class MailDB:
             )
 
     def insert_action(self, row: dict) -> bool:
-        """Insert a mail_actions row. Returns True if inserted, False on conflict."""
+        """Insert a mail_actions row. Returns True if inserted, False on conflict.
+
+        `thread_key` is optional in `row` (defaults to NULL) so older callers keep
+        working; cmd_run always supplies it now."""
+        params = dict(row)
+        params.setdefault("thread_key", None)
         with self._c.cursor() as cur:
             cur.execute(
                 """
                 INSERT INTO mail_actions
                     (mail_id, message_id, from_addr, subject, received_at,
-                     who, ask, deadline, amount, confidence, reason)
+                     who, ask, deadline, amount, confidence, reason, thread_key)
                 VALUES
                     (%(mail_id)s, %(message_id)s, %(from_addr)s, %(subject)s,
                      %(received_at)s, %(who)s, %(ask)s, %(deadline)s, %(amount)s,
-                     %(confidence)s, %(reason)s)
+                     %(confidence)s, %(reason)s, %(thread_key)s)
                 ON CONFLICT (mail_id) DO NOTHING
                 """,
-                row,
+                params,
             )
             return cur.rowcount > 0
+
+    def supersede_open_actions(self, thread_key: str, before_received_at) -> int:
+        """Retire OPEN actions of `thread_key` that predate `before_received_at`.
+
+        Called just before inserting a newer message's action for the same thread:
+        the stale open action is marked 'superseded' so the reply's action becomes the
+        single live one. The `received_at <` guard means an older message can never
+        retire a newer still-open action. Returns the number of rows superseded."""
+        with self._c.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE mail_actions
+                   SET status = 'superseded'
+                 WHERE thread_key = %s
+                   AND status = 'open'
+                   AND received_at < %s
+                """,
+                (thread_key, before_received_at),
+            )
+            return cur.rowcount
+
+    def close_actions_done(self, action_ids: list[int]) -> int:
+        """Mark the given action rows 'done' (the owner replied → handled).
+
+        No-op on an empty list. Returns the number of rows closed."""
+        if not action_ids:
+            return 0
+        with self._c.cursor() as cur:
+            cur.execute(
+                "UPDATE mail_actions SET status = 'done' WHERE id = ANY(%s)",
+                (list(action_ids),),
+            )
+            return cur.rowcount
+
+    def fetch_open_actions_min(self):
+        """Minimal projection of OPEN actions for the owner-reply reconcile pass:
+        id, thread_key, received_at. thread_key may be NULL on legacy rows (the
+        caller skips those — they can't be thread-matched)."""
+        with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                "SELECT id, thread_key, received_at "
+                "FROM mail_actions WHERE status = 'open'"
+            )
+            return cur.fetchall()
+
+    def fetch_owner_messages(self, owner_addrs: list[str]):
+        """Mail rows authored by an owner address (any of `owner_addrs`, compared
+        case-insensitively). Deliberately NOT restricted to via_gmail — the owner's
+        forwarded/BCC'd sent mail may have via_gmail=false. Returns id, headers,
+        message_id, received_at so the caller can compute each one's thread_key."""
+        if not owner_addrs:
+            return []
+        with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                "SELECT id, headers, message_id, received_at "
+                "FROM mail WHERE lower(from_addr) = ANY(%s)",
+                (list(owner_addrs),),
+            )
+            return cur.fetchall()
 
     def commit(self) -> None:
         self._c.commit()

--- a/scripts/mail-actions/extract.py
+++ b/scripts/mail-actions/extract.py
@@ -9,9 +9,18 @@ Pipeline (see scripts/mail-actions/README.md for the full picture):
 
 Delta/idempotency: a row is only touched while `mail.processed_at IS NULL`. Every
 processed row is labelled ('bulk' | 'fyi' | 'action-required' | 'invoice' |
-'superseded') and stamped, so a re-run is a no-op over already-seen mail.
+'superseded' | 'sent') and stamped, so a re-run is a no-op over already-seen mail.
   invoice    — an invoice (auto-paid; captured by the archiver, never an action)
   superseded — an older message of a thread already represented by a newer one
+  sent       — the owner's own mail (from an owner address); never an action
+
+Thread reconciliation (on the mail_actions.thread_key column):
+  Feature 1 (cross-run supersede) — when a NEWER message's action is inserted, the
+    older OPEN action for the same thread is set status='superseded' (the other party
+    replied → the stale ask is no longer the live one).
+  Feature 2 (auto-close on owner reply) — at the START of a run, any OPEN action whose
+    thread the OWNER has since replied in (owner reply received_at > action) is set
+    status='done'. Inert until the owner's sent mail lands in `mail` (see README).
 
 Subcommands:
   run               run the action-required pipeline (filter → LLM → persist)
@@ -31,6 +40,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -95,6 +105,62 @@ def thread_key(headers: dict | None, message_id: str | None) -> str:
     return (message_id or "").strip().strip("<>")
 
 
+# Owner addresses: a reply from any of these means the action is handled (Feature 2),
+# and an inbound survivor authored by one is the owner's own mail, never an action.
+DEFAULT_OWNER_ADDRS = "zachlowden1@gmail.com,zach@civitai.com,zacxdev@gmail.com"
+
+
+def owner_addrs() -> set[str]:
+    """Normalized (lowercase, stripped) owner addresses from
+    $MAIL_ACTIONS_OWNER_ADDRS (comma-separated), else the built-in default."""
+    raw = os.environ.get("MAIL_ACTIONS_OWNER_ADDRS") or DEFAULT_OWNER_ADDRS
+    return {a.strip().lower() for a in raw.split(",") if a.strip()}
+
+
+def reconcile_owner_replies(db, owners: set[str]) -> int:
+    """Auto-close OPEN actions whose thread the OWNER has since replied in.
+
+    thread_key isn't computable in SQL, so the grouping is done here in Python:
+      1. pull OPEN actions (id, thread_key, received_at); skip NULL-keyed legacy rows;
+      2. pull every mail authored by an owner address (regardless of via_gmail — the
+         owner's BCC'd/forwarded sent mail may be via_gmail=false) and key each;
+      3. close an action iff some owner message shares its thread_key AND arrived
+         AFTER the action (the timestamp guard stops a stale owner message closing a
+         fresh action from a later inbound reply).
+    Returns the number of actions closed."""
+    open_actions = db.fetch_open_actions_min()
+    if not open_actions:
+        return 0
+    owner_msgs = db.fetch_owner_messages(sorted(owners))
+
+    # thread_key -> latest owner-reply received_at seen for that thread.
+    owner_latest: dict[str, object] = {}
+    for m in owner_msgs:
+        tkey = thread_key(m.get("headers"), m.get("message_id"))
+        if not tkey:
+            continue
+        ts = m.get("received_at")
+        if ts is None:
+            continue
+        cur = owner_latest.get(tkey)
+        if cur is None or ts > cur:
+            owner_latest[tkey] = ts
+
+    to_close: list[int] = []
+    for a in open_actions:
+        tkey = a.get("thread_key")
+        if not tkey:  # legacy row with no thread_key — can't be matched.
+            continue
+        owner_ts = owner_latest.get(tkey)
+        a_ts = a.get("received_at")
+        if owner_ts is None or a_ts is None:
+            continue
+        if owner_ts > a_ts:  # owner replied AFTER the action arrived → handled.
+            to_close.append(a["id"])
+
+    return db.close_actions_done(to_close)
+
+
 def _is_invoice(db, r) -> bool:
     """True iff this survivor is an invoice by the SAME definition the archiver uses:
     load the mail's raw bytes, parse PDF attachments, and test
@@ -114,8 +180,17 @@ def _is_invoice(db, r) -> bool:
 def cmd_run(args) -> int:
     from _db import MailDB
 
+    owners = owner_addrs()
+
     with MailDB() as db:
         db.ensure_schema()
+
+        # Feature 2: BEFORE fetching new survivors, close any open action whose thread
+        # the owner has since replied in (owner reply = handled). Skipped on --dry-run
+        # since it writes. Inert until the owner's sent mail actually lands in `mail`
+        # (see README "Auto-close on owner reply (Feature 2)").
+        closed = 0 if args.dry_run else reconcile_owner_replies(db, owners)
+
         rows = db.fetch_unprocessed(limit=args.limit)
         dropped, survivors = _partition(rows)
 
@@ -123,6 +198,7 @@ def cmd_run(args) -> int:
             "delta_rows": len(rows),
             "dropped_bulk": len(dropped),
             "survivors": len(survivors),
+            "closed": closed,
             "est_llm_cost_usd": round(_est_cost(len(survivors)), 4),
         }
 
@@ -144,6 +220,7 @@ def cmd_run(args) -> int:
         fyis = 0
         invoices = 0
         superseded = 0
+        sent = 0
         errors = 0
         emitted = 0
         seen_threads: set[str] = set()
@@ -151,8 +228,19 @@ def cmd_run(args) -> int:
         # DESC), so the FIRST survivor seen for a thread is the latest message — the
         # one we keep; older messages of an already-seen thread are superseded.
         for r, _res in survivors:
-            # (1) thread-dedup: an older message of a thread we've already represented.
             tkey = thread_key(r.get("headers"), r.get("message_id"))
+
+            # (0) owner's own mail is never an action — label 'sent', skip the LLM.
+            # Owner mail is usually NOT via_gmail (so it won't appear here), but guard
+            # defensively in case a forwarded/BCC'd copy does.
+            if (r.get("from_addr") or "").strip().lower() in owners:
+                db.mark_processed(r["id"], "sent")
+                sent += 1
+                if tkey:
+                    seen_threads.add(tkey)
+                continue
+
+            # (1) thread-dedup: an older message of a thread we've already represented.
             if tkey and tkey in seen_threads:
                 db.mark_processed(r["id"], "superseded")
                 superseded += 1
@@ -181,12 +269,20 @@ def cmd_run(args) -> int:
                 continue
 
             if ex.action_required:
+                # Feature 1: a NEWER message's action retires the older OPEN action for
+                # this thread (cross-run, persisted). Guarded by received_at so an older
+                # message can't supersede a newer open action.
+                if tkey:
+                    superseded += db.supersede_open_actions(
+                        thread_key=tkey, before_received_at=r.get("received_at"),
+                    )
                 inserted = db.insert_action({
                     "mail_id": r["id"],
                     "message_id": r.get("message_id"),
                     "from_addr": r.get("from_addr"),
                     "subject": r.get("subject"),
                     "received_at": r.get("received_at"),
+                    "thread_key": tkey or None,
                     **ex.as_row(),
                 })
                 db.mark_processed(r["id"], "action-required")
@@ -208,6 +304,8 @@ def cmd_run(args) -> int:
             "fyi": fyis,
             "invoice": invoices,
             "superseded": superseded,
+            "sent": sent,
+            "closed": closed,
             "extract_errors": errors,
             "clawgate_emitted": emitted,
             "est_llm_cost_usd": round(_est_cost(len(survivors)), 4),
@@ -425,6 +523,8 @@ def _print_run(s) -> None:
     print(f"  fyi:              {s['fyi']}")
     print(f"  invoice:          {s.get('invoice', 0)}")
     print(f"  superseded:       {s.get('superseded', 0)}")
+    print(f"  sent (owner):     {s.get('sent', 0)}")
+    print(f"  closed (owner):   {s.get('closed', 0)}")
     if s["extract_errors"]:
         print(f"  extract errors:   {s['extract_errors']}")
     if s.get("clawgate_emitted"):

--- a/scripts/mail-actions/tests/test_db_schema.py
+++ b/scripts/mail-actions/tests/test_db_schema.py
@@ -1,0 +1,156 @@
+"""SQL-level tests for the new _db.MailDB methods, using a mock psycopg2 connection.
+
+Offline: no port-forward, no Postgres. We hand MailDB a fake connection whose
+cursor records every executed (sql, params) so we can assert on the emitted SQL —
+the thread_key migration, the supersede/close/insert statements, and the timestamp
+guard living in the WHERE clause (not just in Python)."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import _db  # noqa: E402
+
+
+class FakeCursor:
+    def __init__(self, conn):
+        self._conn = conn
+        self.rowcount = 0
+        self._result = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, sql, params=None):
+        self._conn.executed.append((" ".join(sql.split()), params))
+        # let a test preload a rowcount/result for the next fetch
+        self.rowcount = self._conn.next_rowcount
+        self._result = self._conn.next_result
+
+    def fetchall(self):
+        return self._result
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+
+class FakeConn:
+    def __init__(self):
+        self.executed = []
+        self.commits = 0
+        self.next_rowcount = 0
+        self.next_result = []
+
+    def cursor(self, cursor_factory=None):
+        return FakeCursor(self)
+
+    def commit(self):
+        self.commits += 1
+
+
+def _db_with_conn():
+    db = _db.MailDB(dsn="postgres://u:p@h/mailbox")
+    db.conn = FakeConn()
+    return db, db.conn
+
+
+def _sqls(conn):
+    return [sql for sql, _ in conn.executed]
+
+
+def test_ensure_schema_issues_add_column_migration():
+    db, conn = _db_with_conn()
+    db.ensure_schema()
+    sqls = _sqls(conn)
+    # The CREATE TABLE carries thread_key ...
+    assert any("CREATE TABLE IF NOT EXISTS mail_actions" in s and "thread_key text" in s
+               for s in sqls)
+    # ... AND the idempotent migration for the pre-existing live table is issued.
+    assert any("ALTER TABLE mail_actions ADD COLUMN IF NOT EXISTS thread_key text" in s
+               for s in sqls)
+    assert conn.commits == 1
+
+
+def test_insert_action_includes_thread_key_column_and_param():
+    db, conn = _db_with_conn()
+    conn.next_rowcount = 1
+    ok = db.insert_action({
+        "mail_id": 1, "message_id": "<m>", "from_addr": "a@b.com", "subject": "s",
+        "received_at": 100, "who": "w", "ask": "a", "deadline": None, "amount": None,
+        "confidence": 0.9, "reason": "r", "thread_key": "tk1",
+    })
+    assert ok is True
+    sql, params = conn.executed[-1]
+    assert "thread_key" in sql
+    assert "%(thread_key)s" in sql
+    assert params["thread_key"] == "tk1"
+
+
+def test_insert_action_defaults_thread_key_null_when_absent():
+    db, conn = _db_with_conn()
+    conn.next_rowcount = 1
+    db.insert_action({
+        "mail_id": 2, "message_id": "<m>", "from_addr": "a@b.com", "subject": "s",
+        "received_at": 100, "who": "w", "ask": "a", "deadline": None, "amount": None,
+        "confidence": 0.9, "reason": "r",
+    })
+    _sql, params = conn.executed[-1]
+    assert params["thread_key"] is None
+
+
+def test_supersede_open_actions_sql_has_timestamp_guard():
+    db, conn = _db_with_conn()
+    conn.next_rowcount = 1
+    n = db.supersede_open_actions(thread_key="tk1", before_received_at=300)
+    assert n == 1
+    sql, params = conn.executed[-1]
+    assert "UPDATE mail_actions SET status = 'superseded'" in sql
+    assert "thread_key = %s" in sql
+    assert "status = 'open'" in sql
+    assert "received_at < %s" in sql  # the timestamp guard
+    assert params == ("tk1", 300)
+
+
+def test_close_actions_done_sql_and_empty_noop():
+    db, conn = _db_with_conn()
+    # empty → no SQL, returns 0
+    assert db.close_actions_done([]) == 0
+    assert conn.executed == []
+    # non-empty → ANY(%s) update
+    conn.next_rowcount = 2
+    n = db.close_actions_done([5, 6])
+    assert n == 2
+    sql, params = conn.executed[-1]
+    assert "UPDATE mail_actions SET status = 'done'" in sql
+    assert "id = ANY(%s)" in sql
+    assert params == ([5, 6],)
+
+
+def test_fetch_open_actions_min_projection():
+    db, conn = _db_with_conn()
+    conn.next_result = [{"id": 1, "thread_key": "tk", "received_at": 100}]
+    rows = db.fetch_open_actions_min()
+    assert rows == [{"id": 1, "thread_key": "tk", "received_at": 100}]
+    sql, _ = conn.executed[-1]
+    assert "FROM mail_actions WHERE status = 'open'" in sql
+    assert "thread_key" in sql
+
+
+def test_fetch_owner_messages_not_restricted_to_via_gmail():
+    db, conn = _db_with_conn()
+    conn.next_result = [{"id": 9, "headers": {}, "message_id": "<x>", "received_at": 1}]
+    rows = db.fetch_owner_messages(["zach@civitai.com"])
+    assert rows and rows[0]["id"] == 9
+    sql, params = conn.executed[-1]
+    assert "FROM mail WHERE lower(from_addr) = ANY(%s)" in sql
+    assert "via_gmail" not in sql  # owner sent mail may be via_gmail=false
+    assert params == (["zach@civitai.com"],)
+
+
+def test_fetch_owner_messages_empty_addrs_short_circuits():
+    db, conn = _db_with_conn()
+    assert db.fetch_owner_messages([]) == []
+    assert conn.executed == []

--- a/scripts/mail-actions/tests/test_idempotency.py
+++ b/scripts/mail-actions/tests/test_idempotency.py
@@ -55,11 +55,51 @@ class FakeMailDB:
     def insert_action(self, row):
         if row["mail_id"] in self.actions:
             return False  # ON CONFLICT DO NOTHING
-        self.actions[row["mail_id"]] = row
+        r = dict(row)
+        r.setdefault("thread_key", None)
+        r.setdefault("status", "open")
+        r.setdefault("id", row["mail_id"])
+        self.actions[row["mail_id"]] = r
         return True
 
+    def supersede_open_actions(self, thread_key, before_received_at):
+        n = 0
+        for a in self.actions.values():
+            if (a.get("thread_key") == thread_key and a.get("status") == "open"
+                    and a.get("received_at") is not None
+                    and before_received_at is not None
+                    and a["received_at"] < before_received_at):
+                a["status"] = "superseded"
+                n += 1
+        return n
+
+    def close_actions_done(self, action_ids):
+        ids = set(action_ids)
+        n = 0
+        for a in self.actions.values():
+            if a.get("id") in ids and a.get("status") == "open":
+                a["status"] = "done"
+                n += 1
+        return n
+
+    def fetch_open_actions_min(self):
+        return [
+            {"id": a["id"], "thread_key": a.get("thread_key"),
+             "received_at": a.get("received_at")}
+            for a in self.actions.values() if a.get("status") == "open"
+        ]
+
+    def fetch_owner_messages(self, owner_addrs):
+        addrs = {a.lower() for a in owner_addrs}
+        return [
+            {"id": r["id"], "headers": r.get("headers"),
+             "message_id": r.get("message_id"), "received_at": r.get("received_at")}
+            for r in self._mail.values()
+            if (r.get("from_addr") or "").strip().lower() in addrs
+        ]
+
     def list_open_actions(self):
-        return list(self.actions.values())
+        return [a for a in self.actions.values() if a.get("status") == "open"]
 
     def commit(self):
         self.commits += 1

--- a/scripts/mail-actions/tests/test_reconcile.py
+++ b/scripts/mail-actions/tests/test_reconcile.py
@@ -1,0 +1,331 @@
+"""Thread-aware reconciliation tests (Feature 1 supersede + Feature 2 owner-close).
+
+All offline: a fake in-memory MailDB that implements the new reconcile surface
+(supersede_open_actions, close_actions_done, fetch_open_actions_min,
+fetch_owner_messages) and a counting fake llm.extract. No Postgres, no LLM.
+
+Synthetic References chains exercise thread_key grouping the same way real Gmail
+threads do (root has no threading headers; replies carry References starting with the
+root's message_id)."""
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import extract  # noqa: E402
+import llm  # noqa: E402
+
+
+class FakeMailDB:
+    """In-memory MailDB with the full reconcile surface.
+
+    `mail` rows are inbound/owner messages; `actions` are mail_actions rows that the
+    test can preload (with thread_key/status/received_at/id) to model existing state."""
+
+    def __init__(self, rows, actions=None):
+        self._mail = {}
+        for r in rows:
+            r = dict(r)
+            r.setdefault("processed_at", None)
+            r.setdefault("labels", [])
+            r.setdefault("raw", None)
+            self._mail[r["id"]] = r
+        # actions keyed by mail_id (the live table's UNIQUE col); each carries its own id.
+        self.actions = {}
+        for a in (actions or []):
+            a = dict(a)
+            a.setdefault("status", "open")
+            a.setdefault("thread_key", None)
+            a.setdefault("id", a["mail_id"])
+            self.actions[a["mail_id"]] = a
+        self.commits = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def ensure_schema(self):
+        pass
+
+    def fetch_unprocessed(self, limit=None):
+        out = [dict(r) for r in self._mail.values() if r["processed_at"] is None]
+        out.sort(key=lambda r: (r.get("received_at") or 0), reverse=True)
+        return out[:limit] if limit is not None else out
+
+    def fetch_raw(self, mail_id):
+        return self._mail[mail_id].get("raw")
+
+    def mark_processed(self, mail_id, label):
+        r = self._mail[mail_id]
+        if label not in r["labels"]:
+            r["labels"].append(label)
+        r["processed_at"] = "STAMPED"
+
+    def insert_action(self, row):
+        if row["mail_id"] in self.actions:
+            return False
+        a = dict(row)
+        a.setdefault("thread_key", None)
+        a.setdefault("status", "open")
+        a.setdefault("id", row["mail_id"])
+        self.actions[row["mail_id"]] = a
+        return True
+
+    def supersede_open_actions(self, thread_key, before_received_at):
+        n = 0
+        for a in self.actions.values():
+            if (a.get("thread_key") == thread_key and a.get("status") == "open"
+                    and a.get("received_at") is not None
+                    and before_received_at is not None
+                    and a["received_at"] < before_received_at):
+                a["status"] = "superseded"
+                n += 1
+        return n
+
+    def close_actions_done(self, action_ids):
+        ids = set(action_ids)
+        n = 0
+        for a in self.actions.values():
+            if a.get("id") in ids and a.get("status") == "open":
+                a["status"] = "done"
+                n += 1
+        return n
+
+    def fetch_open_actions_min(self):
+        return [
+            {"id": a["id"], "thread_key": a.get("thread_key"),
+             "received_at": a.get("received_at")}
+            for a in self.actions.values() if a.get("status") == "open"
+        ]
+
+    def fetch_owner_messages(self, owner_addrs):
+        addrs = {a.lower() for a in owner_addrs}
+        return [
+            {"id": r["id"], "headers": r.get("headers"),
+             "message_id": r.get("message_id"), "received_at": r.get("received_at")}
+            for r in self._mail.values()
+            if (r.get("from_addr") or "").strip().lower() in addrs
+        ]
+
+    def commit(self):
+        self.commits += 1
+
+
+class CountingLLM:
+    def __init__(self, action_required=True):
+        self.calls = []
+        self._ar = action_required
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._ar:
+            return llm.Extraction(
+                action_required=True, who="W", ask="do thing", deadline=None,
+                amount=None, confidence=0.9, reason="r",
+            )
+        return llm.Extraction(
+            action_required=False, who="", ask="", deadline=None, amount=None,
+            confidence=0.2, reason="fyi",
+        )
+
+
+def _run(monkeypatch, fake_db, fake_llm, json=False):
+    import _db
+    monkeypatch.setattr(_db, "MailDB", lambda *a, **k: fake_db)
+    monkeypatch.setattr(llm, "extract", fake_llm)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    args = types.SimpleNamespace(dry_run=False, limit=150, model=None,
+                                 emit_clawgate=False, json=json)
+    rc = extract.cmd_run(args)
+    assert rc == 0
+
+
+# --- Feature 1: cross-run thread supersede -------------------------------------
+
+def test_feature1_newer_msg_supersedes_existing_older_open_action(monkeypatch):
+    # An OPEN action already exists for thread "M0" from an OLDER message (ts=100).
+    # A new reply (ts=300, References starts <M0>) arrives → its action is inserted and
+    # the older open action is superseded by the timestamp-guarded UPDATE.
+    rows = [
+        {"id": 3, "message_id": "<M2>", "from_addr": "lauren@naidacom.com",
+         "subject": "Re: thread", "received_at": 300, "category": "personal",
+         "headers": {"References": "<M0> <M1>"}, "text_body": "reply2"},
+    ]
+    existing = [
+        {"mail_id": 1, "id": 1, "thread_key": "M0", "received_at": 100,
+         "status": "open"},
+    ]
+    db = FakeMailDB(rows, actions=existing)
+    fake_llm = CountingLLM(action_required=True)
+    _run(monkeypatch, db, fake_llm)
+
+    assert db.actions[1]["status"] == "superseded"   # older open action retired
+    assert db.actions[3]["status"] == "open"          # the reply's new action is live
+    assert db.actions[3]["thread_key"] == "M0"        # stored on the new row
+
+
+def test_feature1_does_not_supersede_a_newer_open_action(monkeypatch):
+    # An OPEN action exists for thread "M0" from a NEWER message (ts=500). An OLDER
+    # reply (ts=300) of the same thread is processed → its action is inserted but the
+    # newer open action is NOT superseded (received_at < guard fails).
+    rows = [
+        {"id": 3, "message_id": "<M2>", "from_addr": "lauren@naidacom.com",
+         "subject": "Re: thread", "received_at": 300, "category": "personal",
+         "headers": {"References": "<M0> <M1>"}, "text_body": "older reply"},
+    ]
+    existing = [
+        {"mail_id": 9, "id": 9, "thread_key": "M0", "received_at": 500,
+         "status": "open"},
+    ]
+    db = FakeMailDB(rows, actions=existing)
+    fake_llm = CountingLLM(action_required=True)
+    _run(monkeypatch, db, fake_llm)
+
+    assert db.actions[9]["status"] == "open"   # newer open action untouched
+    assert db.actions[3]["status"] == "open"   # the older reply's action still inserts
+
+
+def test_feature1_summary_counts_cross_run_supersede(monkeypatch, capsys):
+    import json as _json
+    rows = [
+        {"id": 3, "message_id": "<M2>", "from_addr": "x@y.com", "subject": "Re: t",
+         "received_at": 300, "category": "personal",
+         "headers": {"References": "<M0>"}, "text_body": "reply"},
+    ]
+    existing = [
+        {"mail_id": 1, "id": 1, "thread_key": "M0", "received_at": 100,
+         "status": "open"},
+    ]
+    db = FakeMailDB(rows, actions=existing)
+    _run(monkeypatch, db, CountingLLM(action_required=True), json=True)
+    summary = _json.loads(capsys.readouterr().out)
+    assert summary["superseded"] == 1
+    assert summary["action_required"] == 1
+
+
+# --- Feature 2: auto-close on owner reply --------------------------------------
+
+OWNER = "zachlowden1@gmail.com"
+
+
+def test_feature2_owner_reply_after_action_closes_it():
+    # Open action on thread "M0" arrived at ts=100. Owner replied in the same thread at
+    # ts=200 (References starts <M0>) → the action is closed (done).
+    rows = [
+        {"id": 50, "from_addr": OWNER, "message_id": "<own1>", "received_at": 200,
+         "headers": {"References": "<M0>"}},
+    ]
+    existing = [
+        {"mail_id": 1, "id": 1, "thread_key": "M0", "received_at": 100,
+         "status": "open"},
+    ]
+    db = FakeMailDB(rows, actions=existing)
+    closed = extract.reconcile_owner_replies(db, {OWNER})
+    assert closed == 1
+    assert db.actions[1]["status"] == "done"
+
+
+def test_feature2_owner_reply_older_than_action_does_not_close():
+    # Owner message PREDATES the action (ts 50 < 100) → must NOT close (timestamp guard:
+    # a stale owner message can't close a fresh action from a later inbound reply).
+    rows = [
+        {"id": 51, "from_addr": OWNER, "message_id": "<own2>", "received_at": 50,
+         "headers": {"References": "<M0>"}},
+    ]
+    existing = [
+        {"mail_id": 1, "id": 1, "thread_key": "M0", "received_at": 100,
+         "status": "open"},
+    ]
+    db = FakeMailDB(rows, actions=existing)
+    closed = extract.reconcile_owner_replies(db, {OWNER})
+    assert closed == 0
+    assert db.actions[1]["status"] == "open"
+
+
+def test_feature2_owner_reply_unrelated_thread_does_not_close():
+    rows = [
+        {"id": 52, "from_addr": OWNER, "message_id": "<own3>", "received_at": 200,
+         "headers": {"References": "<OTHER>"}},
+    ]
+    existing = [
+        {"mail_id": 1, "id": 1, "thread_key": "M0", "received_at": 100,
+         "status": "open"},
+    ]
+    db = FakeMailDB(rows, actions=existing)
+    closed = extract.reconcile_owner_replies(db, {OWNER})
+    assert closed == 0
+    assert db.actions[1]["status"] == "open"
+
+
+def test_feature2_legacy_null_thread_key_action_skipped():
+    # A legacy open action with thread_key=NULL can't be thread-matched → never closed,
+    # even if an owner message shares no key with it.
+    rows = [
+        {"id": 53, "from_addr": OWNER, "message_id": "<own4>", "received_at": 200,
+         "headers": {"References": "<M0>"}},
+    ]
+    existing = [
+        {"mail_id": 1, "id": 1, "thread_key": None, "received_at": 100,
+         "status": "open"},
+    ]
+    db = FakeMailDB(rows, actions=existing)
+    closed = extract.reconcile_owner_replies(db, {OWNER})
+    assert closed == 0
+    assert db.actions[1]["status"] == "open"
+
+
+def test_feature2_runs_at_start_of_cmd_run_and_counts(monkeypatch, capsys):
+    import json as _json
+    # Owner reply (ts=200) on thread M0 closes the pre-existing open action (ts=100).
+    # No inbound survivors, so the LLM is never called.
+    rows = [
+        {"id": 50, "from_addr": OWNER, "message_id": "<own1>", "received_at": 200,
+         "category": "personal", "headers": {"References": "<M0>"},
+         "text_body": "my reply", "processed_at": "STAMPED"},  # already processed → not a survivor
+    ]
+    existing = [
+        {"mail_id": 1, "id": 1, "thread_key": "M0", "received_at": 100,
+         "status": "open"},
+    ]
+    db = FakeMailDB(rows, actions=existing)
+    fake_llm = CountingLLM(action_required=True)
+    _run(monkeypatch, db, fake_llm, json=True)
+    summary = _json.loads(capsys.readouterr().out)
+    assert summary["closed"] == 1
+    assert db.actions[1]["status"] == "done"
+    assert fake_llm.calls == []   # reconcile-only run, no extraction
+
+
+# --- owner-from inbound survivor → labeled 'sent', no LLM ----------------------
+
+def test_owner_from_survivor_labeled_sent_no_llm(monkeypatch):
+    # A survivor whose from_addr is an owner address must be labeled 'sent' and never
+    # reach the LLM (defensive guard for forwarded/BCC'd owner mail that is via_gmail).
+    rows = [
+        {"id": 60, "from_addr": OWNER, "message_id": "<mine@x>",
+         "subject": "my own mail", "received_at": 100, "category": "personal",
+         "headers": {}, "text_body": "I wrote this"},
+    ]
+    db = FakeMailDB(rows)
+    fake_llm = CountingLLM(action_required=True)
+    _run(monkeypatch, db, fake_llm)
+
+    assert fake_llm.calls == []
+    assert db._mail[60]["labels"] == ["sent"]
+    assert db.actions == {}
+
+
+def test_owner_addrs_env_override(monkeypatch):
+    monkeypatch.setenv("MAIL_ACTIONS_OWNER_ADDRS", " Foo@Bar.com , baz@qux.io ")
+    assert extract.owner_addrs() == {"foo@bar.com", "baz@qux.io"}
+
+
+def test_owner_addrs_default(monkeypatch):
+    monkeypatch.delenv("MAIL_ACTIONS_OWNER_ADDRS", raising=False)
+    got = extract.owner_addrs()
+    assert "zachlowden1@gmail.com" in got
+    assert "zach@civitai.com" in got
+    assert "zacxdev@gmail.com" in got

--- a/scripts/mail-actions/tests/test_run_routing.py
+++ b/scripts/mail-actions/tests/test_run_routing.py
@@ -77,8 +77,48 @@ class FakeMailDB:
     def insert_action(self, row):
         if row["mail_id"] in self.actions:
             return False
-        self.actions[row["mail_id"]] = row
+        r = dict(row)
+        r.setdefault("thread_key", None)
+        r.setdefault("status", "open")
+        r.setdefault("id", row["mail_id"])  # use mail_id as a stable action id
+        self.actions[row["mail_id"]] = r
         return True
+
+    def supersede_open_actions(self, thread_key, before_received_at):
+        n = 0
+        for a in self.actions.values():
+            if (a.get("thread_key") == thread_key and a.get("status") == "open"
+                    and a.get("received_at") is not None
+                    and before_received_at is not None
+                    and a["received_at"] < before_received_at):
+                a["status"] = "superseded"
+                n += 1
+        return n
+
+    def close_actions_done(self, action_ids):
+        ids = set(action_ids)
+        n = 0
+        for a in self.actions.values():
+            if a.get("id") in ids and a.get("status") == "open":
+                a["status"] = "done"
+                n += 1
+        return n
+
+    def fetch_open_actions_min(self):
+        return [
+            {"id": a["id"], "thread_key": a.get("thread_key"),
+             "received_at": a.get("received_at")}
+            for a in self.actions.values() if a.get("status") == "open"
+        ]
+
+    def fetch_owner_messages(self, owner_addrs):
+        addrs = {a.lower() for a in owner_addrs}
+        return [
+            {"id": r["id"], "headers": r.get("headers"),
+             "message_id": r.get("message_id"), "received_at": r.get("received_at")}
+            for r in self._mail.values()
+            if (r.get("from_addr") or "").strip().lower() in addrs
+        ]
 
     def commit(self):
         self.commits += 1


### PR DESCRIPTION
Adds a `mail_actions.thread_key` column and two cross-run reconciliation passes keyed on it, so the action table tracks how an email thread evolves over time (beyond the existing within-run thread-dedup).

## Feature 1 — cross-run thread supersede (works today, no setup)
When a NEWER message of a thread becomes an action, the older OPEN action for that same thread is set `status='superseded'` *before* the new row is inserted, so the reply's action is the single live one. Timestamp-guarded (`received_at <`) so an older message can never retire a newer open action. Persists across runs (reads existing rows).

## Feature 2 — auto-close on the OWNER's reply (needs operator setup)
At the START of each run, any OPEN action whose thread an owner address has since replied in is set `status='done'` (owner reply ⇒ handled). Matching is done in Python (thread_key isn't SQL-computable), with a timestamp guard (only close actions PREDATING the owner reply) and legacy NULL-`thread_key` rows skipped. Owner addresses: `MAIL_ACTIONS_OWNER_ADDRS` (default `zachlowden1@gmail.com,zach@civitai.com,zacxdev@gmail.com`). Inbound survivors authored by an owner are labeled `sent` and never sent to the LLM.

The owner-mail scan is deliberately **NOT** restricted to `via_gmail` — BCC'd/forwarded sent mail is often `via_gmail=false`.

**Operator prerequisite (documented, not built):** Feature 2 is inert until the owner's sent replies land in the `mail` table. Gmail does not auto-forward Sent mail; the README documents the BCC-to-`inbox.zacx.dev` / Apps-Script options and the `via_gmail` caveat. **Feature 1 works regardless.**

## Schema
- `ensure_schema`: `thread_key text` in `CREATE TABLE` + idempotent `ALTER TABLE mail_actions ADD COLUMN IF NOT EXISTS thread_key text` (live-table migration). Legacy rows keep `thread_key` NULL (operator backfills).
- `insert_action` stores `thread_key`.
- New `_db` methods: `supersede_open_actions`, `close_actions_done`, `fetch_open_actions_min`, `fetch_owner_messages`.

## Tests
19 new, all offline (mocked DB/LLM, no live calls):
- `test_db_schema.py` — SQL-level via a mock psycopg2 connection: the ADD COLUMN migration, `insert_action` thread_key param, and the new methods' SQL incl. the `received_at <` timestamp guard and the `via_gmail`-unrestricted owner scan.
- `test_reconcile.py` — Feature 1 (supersede older, not newer; summary count); Feature 2 (`reconcile_owner_replies`: close on later owner reply; no-close on older owner msg / unrelated thread / legacy NULL key; runs at cmd_run start); owner-from survivor → `sent`, no LLM; `owner_addrs()` env+default.

Full suite: **100 passed** (81 prior + 19 new). The live pipeline/DB/LLM were NOT run — verified offline only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)