### PR TITLE
feat(mail-actions): daily systemd user timer for the invoice archiver

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -486,4 +486,58 @@ in
       WantedBy = [ "graphical-session.target" ];
     };
   };
+
+  # Mail-actions invoice archiver — daily DETERMINISTIC pass (no LLM). Scans the
+  # homelab Postgres `mail` table for invoice PDFs and uploads them + JSON
+  # sidecars to the minio-archive bucket `taxes-{year}-invoices`. Idempotent: a
+  # clean run reports 0 new candidates once the existing invoices are archived.
+  #
+  # It reaches the cluster via `kubectl port-forward` (pulling MinIO creds + the
+  # PG DSN from k8s secrets itself), and runs its Python under nix-shell for the
+  # archive-path deps. Type=oneshot, fired by the timer below.
+  #
+  # A user service runs with a minimal environment, so PATH/NIX_PATH must be
+  # explicit (cf. the activity-collector units above): kubectl + nix (nix-shell)
+  # + bash/coreutils on PATH, and NIX_PATH so `nix-shell -p` can resolve
+  # <nixpkgs>. KUBECONFIG points at the homelab admin config. The logic lives in
+  # the committed wrapper (scripts/mail-actions/run-archive.sh) to keep the unit
+  # clean and version-controlled.
+  systemd.user.services.mail-actions-archive = {
+    Unit = {
+      Description = "Mail-actions invoice archiver → minio-archive (deterministic, daily)";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+    };
+    Service = {
+      Type = "oneshot";
+      Environment = [
+        "PATH=${lib.makeBinPath [ pkgs.kubectl pkgs.nix pkgs.bash pkgs.coreutils pkgs.gnused pkgs.gnugrep pkgs.gawk ]}"
+        # `nix-shell -p` resolves <nixpkgs> from NIX_PATH; the minimal user-unit
+        # env does not carry it. Mirror the system channel the login shell uses.
+        "NIX_PATH=nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos"
+        "KUBECONFIG=%h/workspace/homelab-talos/homelab-kubeconfig"
+        # nix-shell needs a HOME for its caches; %h is exported by systemd but be
+        # explicit for the nested invocation.
+        "HOME=%h"
+      ];
+      ExecStart = "${pkgs.bash}/bin/bash %h/workspace/devrc/scripts/mail-actions/run-archive.sh";
+      # Re-run the unit when the wrapper changes (cf. X-Restart-Triggers above).
+      X-Restart-Triggers = [ "${../scripts/mail-actions/run-archive.sh}" ];
+    };
+  };
+
+  # Timer: fire the archiver daily at 06:00 local. Persistent=true catches up a
+  # single missed run (e.g. host asleep at 06:00) on the next wake.
+  systemd.user.timers.mail-actions-archive = {
+    Unit = {
+      Description = "Daily timer for the mail-actions invoice archiver";
+    };
+    Timer = {
+      OnCalendar = "*-*-* 06:00:00";
+      Persistent = true;
+    };
+    Install = {
+      WantedBy = [ "timers.target" ];
+    };
+  };
 }

--- a/scripts/mail-actions/run-archive.sh
+++ b/scripts/mail-actions/run-archive.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Deterministic invoice-archive pass for the systemd user timer.
+#
+# Scans the homelab Postgres `mail` table for invoice PDFs and uploads them
+# (+ JSON sidecars) to the minio-archive bucket `taxes-{year}-invoices`. This
+# is the NO-LLM path: it reaches the cluster via `kubectl port-forward`, pulling
+# MinIO creds + the PG DSN from k8s secrets itself, so KUBECONFIG + kubectl +
+# network are the only external requirements. Idempotent — already-archived
+# invoices are skipped (a clean run reports 0 new candidates).
+#
+# Run by hand or via systemd:  systemctl --user start mail-actions-archive.service
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# KUBECONFIG defaults to the homelab admin config; the unit also sets it, but
+# keep a default so the wrapper works when invoked from an interactive shell.
+export KUBECONFIG="${KUBECONFIG:-${HOME}/workspace/homelab-talos/homelab-kubeconfig}"
+
+# nix-shell pulls the archive path's deps: psycopg2 (_db.py), minio (_minio.py),
+# requests (llm.py imports it lazily — included to be safe). kubectl is provided
+# on PATH by the unit (systemd) or the login shell (interactive).
+exec nix-shell -p 'python3.withPackages(p:[p.psycopg2 p.minio p.requests])' \
+  --run "python ${SCRIPT_DIR}/extract.py archive-invoices"


### PR DESCRIPTION
## What

Schedules the **deterministic invoice-archive pass** (`scripts/mail-actions/extract.py archive-invoices`) to run **daily on the workbench** via a home-manager `systemd.user.timer` (06:00 local, `Persistent = true` to catch up a missed run).

The archiver is a no-LLM pass: it scans the homelab Postgres `mail` table for invoice PDFs and uploads them + JSON sidecars to the `minio-archive` bucket `taxes-{year}-invoices`. It pulls MinIO creds + the PG DSN from k8s secrets itself via `kubectl port-forward`, so `KUBECONFIG` + `kubectl` + network are the only external requirements. It is idempotent — a clean run reports 0 new candidates.

## Changes

- **`scripts/mail-actions/run-archive.sh`** — committed wrapper (`/usr/bin/env bash`) that sets `KUBECONFIG` and runs the archive command under `nix-shell` with the archive-path deps (`psycopg2` for `_db.py`, `minio` for `_minio.py`, `requests` for the lazy `llm.py` import). Keeps the nix unit clean and the logic version-controlled.
- **`nix/home.nix`** — adds `systemd.user.services.mail-actions-archive` (`Type=oneshot`) + `systemd.user.timers.mail-actions-archive`, mirroring the existing `activity-collector` user-service pattern:
  - explicit `PATH` (kubectl, nix, bash/coreutils) — a user unit inherits no login PATH,
  - `NIX_PATH` so `nix-shell -p` can resolve `<nixpkgs>`,
  - `KUBECONFIG=%h/workspace/homelab-talos/homelab-kubeconfig`,
  - `X-Restart-Triggers` pinned to the wrapper so a script edit re-runs the unit on switch.

## Verification

- `home-manager switch --flake . --impure` applied cleanly; `Starting units: mail-actions-archive.timer`.
- `systemctl --user list-timers` shows next run `Tue 2026-06-30 06:00:00 CDT`.
- **Manual trigger under systemd ran green:** `systemctl --user start mail-actions-archive.service` → `code=exited, status=0/SUCCESS`; journal:
  ```
  ARCHIVE RUN — scanned 3661 rows
    candidates:       0
    PDFs uploaded:    0
    sidecars written: 0
  ```
  0 candidates is the idempotent expected result (the existing invoices are already archived) — it proves `KUBECONFIG` + `kubectl port-forward` + the `nix-shell` deps all resolve under the minimal systemd user-service environment, not just an interactive shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)