### PR TITLE
feat(session-analysis): initiative-scan — durable cross-session initiative tracker

### DIFF
--- a/scripts/session-analysis/initiative-scan.py
+++ b/scripts/session-analysis/initiative-scan.py
@@ -1,0 +1,930 @@
+#!/usr/bin/env python3
+"""initiative-scan — durable, cross-session tracker of in-flight *initiatives*.
+
+The gap this fills: Zach runs many multi-session work threads ("initiatives") —
+"App Blocks soft-launch", "sysRedis HA", "mail-automation", "dp-prod 500-floor".
+Each is anchored by a handoff doc (`claudedocs/handoff-<slug>.md`) and spans many
+Claude Code sessions over days. The existing `tmux-initiatives.sh` (Alt+i) shows
+only LIVE tmux sessions — ephemeral, lost on reboot. This is the durable analogue:
+a re-runnable, deterministic, read-only report of every initiative + its momentum +
+its next step, so you can stop searching for your own in-flight work.
+
+It FUSES three existing data sources (all already present, nothing new written):
+
+  1. HANDOFF DOCS = the initiative registry.
+     Glob `claudedocs/handoff-*.md` across the active repos under ~/workspace (and
+     one nested level, e.g. ~/workspace/civit/*). Each doc is one initiative; per
+     doc we parse the slug (filename), title (first `# ` heading), the doc's own
+     date (filename date suffix/prefix, else file mtime), the first ranked item
+     under "## Next steps", and any "## Open investigations" sub-headings.
+     Multiple dated docs sharing a base slug = the SAME initiative (clustered;
+     newest doc is current state).
+
+  2. GIT per repo — attributes progress events by fuzzy-matching the slug against
+     branch names + recent commit/PR activity. Per initiative (best-effort, within
+     the window): # commits on matching branch(es), merged PRs, OPEN PRs whose head
+     branch matches. Linking is HEURISTIC — when a commit/PR can't be attributed,
+     it is NOT force-fit.
+
+  3. ACTIVITY TELEMETRY (ClickHouse `activity.events`, source='claude') — gives
+     recency / momentum / effort. Each event carries `payload.gitBranch`, plus
+     top-level `ts`, `cwd`, `kind`. Per initiative (branch slug <-> repo): event
+     count + last-touched ts in the window. OPTIONAL: if CLICKHOUSE_* is unset or
+     the endpoint is unreachable, the report degrades gracefully (telemetry columns
+     blank) and is still produced from handoff + git.
+
+  Plus Claude transcripts (~/.claude/projects/**/*.jsonl) — a session whose genesis
+  message names `handoff-<slug>.md` is counted toward that initiative (# sessions +
+  last-session-touched), reusing the genesis-parsing approach of extract_genesis.py.
+
+Credentials (read-only reader, from env — NEVER hardcoded). Same block as
+activity-scan.py:
+  export CLICKHOUSE_URL=http://192.168.50.94:30123    # workbench LAN endpoint
+  export CLICKHOUSE_USER=activity_reader
+  export CLICKHOUSE_PASSWORD=<reader-password>
+Populate the password from SOPS (homelab-talos trunk):
+  git -C ~/workspace/homelab-talos fetch origin trunk -q
+  git -C ~/workspace/homelab-talos show origin/trunk:clusters/homelab/apps/activity/secrets.enc.yaml > /tmp/s.yaml
+  export CLICKHOUSE_PASSWORD=$(SOPS_AGE_KEY_FILE=~/workspace/homelab-talos/.secrets/age.key \
+      sops -d --extract '["stringData"]["reader-password"]' /tmp/s.yaml); rm -f /tmp/s.yaml
+
+Usage:
+  initiative-scan.py [--days N] [--json] [--repo PATH]
+  --days   trailing window in days (default 14)
+  --json   machine-readable output (the raw per-initiative data)
+  --repo   restrict to a single repo path (default: auto-discover under ~/workspace)
+
+HONESTY NOTE: this measures ACTIVITY, RECENCY, and EFFORT (commits / sessions /
+telemetry events / handoff freshness) plus the human-written "Next steps" line —
+it does NOT estimate semantic % completion. "Momentum" is recency of touch, not
+progress toward done. Initiative<->commit/PR/session linking is HEURISTIC slug
+matching against branch names and genesis text; unattributable activity is surfaced
+honestly as "unsegmented trunk/main work" per repo rather than dropped or
+mis-credited. Read it as a descriptive instrument, not a project-management verdict.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Reuse the shared ClickHouse client + creds-from-env (no new deps).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "validation"))
+import chquery as Q  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Constants / tuning
+# --------------------------------------------------------------------------- #
+WORKSPACE = os.path.expanduser("~/workspace")
+PROJECTS_ROOT = os.path.expanduser("~/.claude/projects")
+DAY = 86400
+
+# Momentum buckets (seconds since most-recent touch).
+ACTIVE_MAX = 2 * DAY   # < 2d  -> active
+SLOWING_MAX = 7 * DAY  # 2-7d  -> slowing; >= 7d -> stalled
+MOMENTUM_RANK = {"active": 0, "slowing": 1, "stalled": 2, "unknown": 3}
+
+# Branches that carry work NOT attributable to any single initiative.
+TRUNK_BRANCHES = {"main", "master", "trunk", "develop", "HEAD"}
+
+# Reused transcript-cleaning regexes (mirrors extract_genesis.py).
+SYS_REMINDER = re.compile(r"<system-reminder>.*?</system-reminder>", re.S)
+COMMAND_STDOUT = re.compile(r"<local-command-stdout>.*?</local-command-stdout>", re.S)
+COMMAND_NAME = re.compile(r"<command-name>(.*?)</command-name>", re.S)
+COMMAND_ARGS = re.compile(r"<command-args>(.*?)</command-args>", re.S)
+HARNESS = ("<task-notification>", "<task-reminder>", "<post-tool-use", "<bash-",
+           "<user-prompt-submit", "<local-command-stdout>")
+
+# A YYYY-MM-DD date anywhere in a handoff filename stem.
+DATE_RE = re.compile(r"(\d{4}-\d{2}-\d{2})")
+# "## Next steps" with any trailing decoration (the template varies a little).
+NEXT_STEPS_RE = re.compile(r"^##+\s+next steps\b", re.I)
+OPEN_INV_RE = re.compile(r"^##+\s+open investigations\b", re.I)
+ANY_H2_RE = re.compile(r"^##\s+")
+# A leading list marker: "1. ", "1) ", "- ", "* ".
+LIST_ITEM_RE = re.compile(r"^\s*(?:\d+[.)]|[-*])\s+(.*\S)\s*$")
+H3_RE = re.compile(r"^###\s+(.*\S)\s*$")
+
+
+# --------------------------------------------------------------------------- #
+# Pure logic (unit-tested without live infra)
+# --------------------------------------------------------------------------- #
+def parse_handoff_filename(name: str) -> tuple[str, str | None]:
+    """Split a handoff filename into (base_slug, date_or_None).
+
+    Handles the real-world variants seen in the corpus:
+      handoff-activity-telemetry-2026-06-27.md -> ("activity-telemetry", "2026-06-27")
+      handoff-2026-06-25-clawgate-tasks.md     -> ("clawgate-tasks", "2026-06-25")
+      handoff-app-blocks-launch.md             -> ("app-blocks-launch", None)
+      handoff-2026-05-25.md                    -> ("2026-05-25", "2026-05-25")  # date IS the slug
+    The base_slug is what clusters dated variants into one initiative.
+    """
+    stem = name
+    if stem.endswith(".md"):
+        stem = stem[:-3]
+    if stem.startswith("handoff-"):
+        stem = stem[len("handoff-"):]
+    elif stem.startswith("handoff"):
+        stem = stem[len("handoff"):].lstrip("-")
+
+    m = DATE_RE.search(stem)
+    date = m.group(1) if m else None
+    if not date:
+        return (stem.strip("-") or stem, None)
+
+    # Strip the date token (and an adjacent separator) to get the base slug.
+    base = (stem[:m.start()] + stem[m.end():]).strip("-")
+    base = re.sub(r"-{2,}", "-", base)
+    if not base:
+        # The whole slug was the date (e.g. handoff-2026-05-25.md).
+        base = date
+    return (base, date)
+
+
+def parse_handoff_title(text: str) -> str | None:
+    """First top-level `# ` heading, sans a trailing ` — YYYY-MM-DD` date tail."""
+    for line in text.splitlines():
+        if line.startswith("# "):
+            title = line[2:].strip()
+            # Drop a trailing date tail the template appends ("— 2026-06-27").
+            title = re.sub(r"\s*[—-]\s*\d{4}-\d{2}-\d{2}\s*$", "", title).strip()
+            return title or None
+    return None
+
+
+def parse_next_step(text: str) -> str | None:
+    """First ranked item under the `## Next steps` section (template-aware).
+
+    Returns the item's text with leading list marker stripped and inline markdown
+    bold (`**...**`) flattened. None if there's no Next-steps section or no items.
+    """
+    lines = text.splitlines()
+    in_section = False
+    for line in lines:
+        if NEXT_STEPS_RE.match(line):
+            in_section = True
+            continue
+        if in_section:
+            # A new H2 ends the section.
+            if ANY_H2_RE.match(line):
+                break
+            m = LIST_ITEM_RE.match(line)
+            if m:
+                return _flatten_md(m.group(1))
+    return None
+
+
+def parse_open_investigations(text: str) -> list[str]:
+    """The `### ` sub-headings under `## Open investigations` (each = one open bug)."""
+    lines = text.splitlines()
+    in_section = False
+    out: list[str] = []
+    for line in lines:
+        if OPEN_INV_RE.match(line):
+            in_section = True
+            continue
+        if in_section:
+            if ANY_H2_RE.match(line):
+                break
+            m = H3_RE.match(line)
+            if m:
+                out.append(_flatten_md(m.group(1)))
+    return out
+
+
+def _flatten_md(s: str) -> str:
+    """Strip inline bold/italic/code markers; collapse whitespace."""
+    s = re.sub(r"\*\*(.+?)\*\*", r"\1", s)
+    s = re.sub(r"`(.+?)`", r"\1", s)
+    s = re.sub(r"(?<!\*)\*(?!\*)(.+?)\*", r"\1", s)
+    return " ".join(s.split())
+
+
+def slug_tokens(slug: str) -> list[str]:
+    """Meaningful tokens of a slug for fuzzy branch/genesis matching.
+
+    Drops date tokens and ultra-short/stop tokens that would over-match.
+    """
+    stop = {"the", "and", "for", "wip", "tmp", "fix", "feat", "v2", "ha"}
+    toks = []
+    for t in re.split(r"[-_/]", slug.lower()):
+        if not t or DATE_RE.fullmatch(t) or t.isdigit():
+            continue
+        if len(t) < 3 or t in stop:
+            continue
+        toks.append(t)
+    return toks
+
+
+def branch_matches_slug(branch: str, slug: str) -> bool:
+    """Heuristic: does a git branch / telemetry gitBranch belong to this slug?
+
+    A branch matches if, after stripping a `type/` prefix (feat/, fix/, chore/...),
+    it shares a strong token overlap with the slug. We require that EITHER the
+    branch tail contains the full base slug as a substring, OR >=2 slug tokens (or
+    all of them, if the slug has <2 tokens) appear in the branch. Trunk/main never
+    match a specific initiative.
+    """
+    if not branch:
+        return False
+    b = branch.lower()
+    if b in {x.lower() for x in TRUNK_BRANCHES}:
+        return False
+    tail = b.split("/", 1)[1] if "/" in b else b
+    base = slug.lower()
+    if base and base in tail:
+        return True
+    toks = slug_tokens(slug)
+    if not toks:
+        return False
+    hit = sum(1 for t in toks if t in b)
+    need = 2 if len(toks) >= 2 else len(toks)
+    return hit >= need
+
+
+def classify_momentum(last_ts: float | None, now: float | None = None) -> str:
+    """Momentum bucket from the most-recent touch (epoch seconds).
+
+    active  : touched < 2d ago
+    slowing : 2d <= age < 7d
+    stalled : age >= 7d
+    unknown : no touch evidence at all
+    Boundaries: exactly 2d -> slowing, exactly 7d -> stalled.
+    """
+    if last_ts is None:
+        return "unknown"
+    now = time.time() if now is None else now
+    age = now - last_ts
+    if age < ACTIVE_MAX:
+        return "active"
+    if age < SLOWING_MAX:
+        return "slowing"
+    return "stalled"
+
+
+def newest_touch(*timestamps) -> float | None:
+    """Max of several optional epoch-second timestamps (Nones ignored)."""
+    vals = [t for t in timestamps if t is not None]
+    return max(vals) if vals else None
+
+
+def rel_age(ts: float | None, now: float | None = None) -> str:
+    """Human relative age: '5h', '3d', '2w' — or '-' if unknown."""
+    if ts is None:
+        return "-"
+    now = time.time() if now is None else now
+    s = max(0, now - ts)
+    if s < 3600:
+        return f"{int(s // 60)}m"
+    if s < DAY:
+        return f"{int(s // 3600)}h"
+    if s < 14 * DAY:
+        return f"{int(s // DAY)}d"
+    return f"{int(s // (7 * DAY))}w"
+
+
+def cluster_handoffs(docs: list[dict]) -> list[dict]:
+    """Group parsed handoff docs by (repo, base_slug); newest doc = current state.
+
+    `docs` items have: repo, slug, date (str|None), mtime (float), title, next_step,
+    open_investigations, path. Returns one initiative dict per cluster, carrying the
+    newest doc's parsed fields + a list of all member doc paths/dates.
+    """
+    groups: dict[tuple, list[dict]] = {}
+    for d in docs:
+        groups.setdefault((d["repo"], d["slug"]), []).append(d)
+
+    initiatives = []
+    for (repo, slug), members in groups.items():
+        members.sort(key=_doc_sort_key, reverse=True)
+        cur = members[0]
+        initiatives.append({
+            "repo": repo,
+            "slug": slug,
+            "title": cur["title"],
+            "date": cur["date"],
+            "doc_mtime": cur["mtime"],
+            "next_step": cur["next_step"],
+            "open_investigations": cur["open_investigations"],
+            "current_doc": cur["path"],
+            "docs": [{"path": m["path"], "date": m["date"]} for m in members],
+        })
+    return initiatives
+
+
+def _doc_sort_key(m: dict) -> tuple:
+    """Order a slug's docs newest-first: prefer filename date, fall back to mtime."""
+    if m["date"]:
+        try:
+            d = datetime.strptime(m["date"], "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            return (d.timestamp(), m["mtime"])
+        except ValueError:
+            pass
+    return (m["mtime"], m["mtime"])
+
+
+def sort_initiatives(initiatives: list[dict]) -> list[dict]:
+    """Sort by momentum (active->stalled->unknown) then recency (newest first)."""
+    return sorted(
+        initiatives,
+        key=lambda i: (MOMENTUM_RANK.get(i.get("momentum", "unknown"), 9),
+                       -(i.get("last_touch") or 0)),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Handoff discovery + parsing (I/O)
+# --------------------------------------------------------------------------- #
+def discover_repos(workspace: str = WORKSPACE) -> list[str]:
+    """Dirs under ~/workspace (and one nested level) that hold handoff docs."""
+    repos = set()
+    patterns = [
+        os.path.join(workspace, "*", "claudedocs", "handoff-*.md"),
+        os.path.join(workspace, "*", "*", "claudedocs", "handoff-*.md"),
+    ]
+    for pat in patterns:
+        for p in glob.glob(pat):
+            repos.add(os.path.dirname(os.path.dirname(p)))
+    return sorted(repos)
+
+
+def read_handoff(path: str) -> dict:
+    """Parse one handoff doc into its initiative-registry fields."""
+    name = os.path.basename(path)
+    slug, date = parse_handoff_filename(name)
+    try:
+        text = Path(path).read_text(errors="replace")
+    except Exception:
+        text = ""
+    return {
+        "path": path,
+        "repo": os.path.dirname(os.path.dirname(path)),
+        "slug": slug,
+        "date": date,
+        "mtime": _safe_mtime(path),
+        "title": parse_handoff_title(text) or slug,
+        "next_step": parse_next_step(text),
+        "open_investigations": parse_open_investigations(text),
+    }
+
+
+def _safe_mtime(path: str) -> float:
+    try:
+        return os.path.getmtime(path)
+    except OSError:
+        return 0.0
+
+
+def load_initiatives(repos: list[str]) -> list[dict]:
+    """Discover + parse + cluster handoffs across the given repos."""
+    docs = []
+    for repo in repos:
+        for path in sorted(glob.glob(os.path.join(repo, "claudedocs", "handoff-*.md"))):
+            docs.append(read_handoff(path))
+    return cluster_handoffs(docs)
+
+
+# --------------------------------------------------------------------------- #
+# git / gh (I/O) — best-effort, read-only
+# --------------------------------------------------------------------------- #
+def _run(cmd: list[str], timeout: float = 20.0) -> str:
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+    return out.stdout if out.returncode == 0 else ""
+
+
+def git_branches(repo: str) -> list[str]:
+    out = _run(["git", "-C", repo, "branch", "-a", "--format=%(refname:short)"])
+    names = []
+    for ln in out.splitlines():
+        ln = ln.strip()
+        if not ln:
+            continue
+        if ln.startswith("origin/"):
+            ln = ln[len("origin/"):]
+        names.append(ln)
+    return names
+
+
+def git_default_branch(repo: str) -> str | None:
+    """The repo's default branch short name (origin/HEAD target), e.g. 'main'/'trunk'."""
+    out = _run(["git", "-C", repo, "symbolic-ref", "--quiet",
+                "refs/remotes/origin/HEAD"]).strip()
+    if out:
+        # refs/remotes/origin/trunk -> trunk
+        return out.rsplit("/", 1)[-1]
+    for cand in ("main", "trunk", "master"):
+        if _run(["git", "-C", repo, "rev-parse", "--verify", "--quiet",
+                 f"origin/{cand}"]).strip():
+            return cand
+    return None
+
+
+def git_commits_in_window(repo: str, branch: str, since_days: int,
+                          default_branch: str | None = None) -> tuple[int, float | None]:
+    """(# commits UNIQUE to `branch` within window, last-commit epoch | None).
+
+    Critically excludes commits reachable from the default branch (`--not <default>`)
+    so a feature branch is credited only with ITS OWN work — otherwise every branch
+    counts the entire trunk history in the window (thousands of commits), grossly
+    inflating + double-counting attribution. If `branch` IS the default, return (0, None)
+    (default-branch work is the unsegmented catch-all, not an initiative).
+    """
+    if default_branch and branch.lower() == default_branch.lower():
+        return (0, None)
+    cmd = ["git", "-C", repo, "log", branch, "--no-merges",
+           f"--since={since_days} days ago", "--format=%ct"]
+    if default_branch and default_branch.lower() != branch.lower():
+        # Only commits NOT already on the default branch.
+        cmd += ["--not", default_branch, f"origin/{default_branch}"]
+    out = _run(cmd)
+    epochs = [int(x) for x in out.split() if x.strip().isdigit()]
+    if not epochs:
+        return (0, None)
+    return (len(epochs), float(max(epochs)))
+
+
+def gh_open_prs(repo: str) -> list[dict]:
+    """OPEN PRs as [{number, title, headRefName}] — empty on any failure."""
+    out = _run([
+        "gh", "pr", "list", "-R", _repo_slug(repo) or repo, "--state", "open",
+        "--json", "number,title,headRefName", "--limit", "100",
+    ], timeout=30.0)
+    if not out.strip():
+        out = _run([
+            "gh", "pr", "list", "--state", "open",
+            "--json", "number,title,headRefName", "--limit", "100",
+        ], timeout=30.0)
+    try:
+        return json.loads(out) if out.strip() else []
+    except json.JSONDecodeError:
+        return []
+
+
+def gh_merged_prs(repo: str, since_days: int) -> list[dict]:
+    """Merged PRs as [{number, title, headRefName, mergedAt}] within the window."""
+    out = _run([
+        "gh", "pr", "list", "-R", _repo_slug(repo) or repo, "--state", "merged",
+        "--json", "number,title,headRefName,mergedAt", "--limit", "200",
+    ], timeout=30.0)
+    if not out.strip():
+        out = _run([
+            "gh", "pr", "list", "--state", "merged",
+            "--json", "number,title,headRefName,mergedAt", "--limit", "200",
+        ], timeout=30.0)
+    try:
+        prs = json.loads(out) if out.strip() else []
+    except json.JSONDecodeError:
+        return []
+    cutoff = time.time() - since_days * DAY
+    keep = []
+    for pr in prs:
+        ts = _iso_to_epoch(pr.get("mergedAt"))
+        if ts is not None and ts >= cutoff:
+            pr["_mergedEpoch"] = ts
+            keep.append(pr)
+    return keep
+
+
+def _repo_slug(repo: str) -> str | None:
+    """owner/name from the origin remote, for `gh -R` (None if undeterminable)."""
+    url = _run(["git", "-C", repo, "config", "--get", "remote.origin.url"]).strip()
+    if not url:
+        return None
+    m = re.search(r"[:/]([^/:]+/[^/]+?)(?:\.git)?$", url)
+    return m.group(1) if m else None
+
+
+def _iso_to_epoch(s: str | None) -> float | None:
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00")).timestamp()
+    except (ValueError, AttributeError):
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Claude transcripts (I/O) — sessions referencing a handoff
+# --------------------------------------------------------------------------- #
+def _clean_turn(raw: str) -> str:
+    cmd = COMMAND_NAME.search(raw)
+    if cmd:
+        cargs = COMMAND_ARGS.search(raw)
+        return ("/" + cmd.group(1).strip() + " " + (cargs.group(1).strip() if cargs else "")).strip()
+    t = SYS_REMINDER.sub("", raw)
+    t = COMMAND_STDOUT.sub("", t).strip()
+    return t
+
+
+def session_genesis_refs(projects_root: str, since_days: int) -> list[dict]:
+    """For each transcript touched in the window, return its genesis text + mtime.
+
+    [{text, mtime}] over the FIRST genuine user turn per session. Used to attribute
+    a session to an initiative when the genesis names `handoff-<slug>.md`.
+    """
+    cutoff = time.time() - since_days * DAY
+    out = []
+    for path in glob.glob(os.path.join(projects_root, "**", "*.jsonl"), recursive=True):
+        if "/subagents/" in path or "/wf_" in path:
+            continue
+        mt = _safe_mtime(path)
+        if mt < cutoff:
+            continue
+        text = _first_user_turn(path)
+        if text:
+            out.append({"text": text, "mtime": mt})
+    return out
+
+
+def _first_user_turn(path: str) -> str | None:
+    try:
+        with open(path, errors="replace") as f:
+            lines = f.readlines()
+    except OSError:
+        return None
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if obj.get("type") != "user" or obj.get("isMeta") or obj.get("isSidechain"):
+            continue
+        msg = obj.get("message") or {}
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        raw = None
+        if isinstance(content, str):
+            raw = content
+        elif isinstance(content, list):
+            for b in content:
+                if isinstance(b, dict) and b.get("type") == "text":
+                    raw = b.get("text", "")
+                    break
+        if not raw:
+            continue
+        txt = _clean_turn(raw)
+        if not txt or txt.lstrip().startswith(HARNESS):
+            continue
+        if txt.startswith("[Request interrupted") or txt.startswith("Caveat: The messages below"):
+            continue
+        return txt
+    return None
+
+
+def attribute_sessions(initiatives: list[dict], genesis: list[dict]) -> None:
+    """Mutate each initiative with session_count + last_session (epoch).
+
+    A session belongs to an initiative when its genesis text mentions
+    `handoff-<slug>` (slug or any dated variant filename of the cluster). Counted
+    per initiative independently — a genesis naming two handoffs counts for both.
+    """
+    for ini in initiatives:
+        names = {os.path.basename(d["path"]).lower() for d in ini["docs"]}
+        names.add(f"handoff-{ini['slug'].lower()}")
+        count = 0
+        last = None
+        for g in genesis:
+            low = g["text"].lower()
+            if any(n in low for n in names):
+                count += 1
+                last = newest_touch(last, g["mtime"])
+        ini["session_count"] = count
+        ini["last_session"] = last
+
+
+# --------------------------------------------------------------------------- #
+# Telemetry (I/O, optional)
+# --------------------------------------------------------------------------- #
+def q_branch_activity(win: int) -> str:
+    """Per gitBranch (+cwd): claude-source event count + last ts, within window."""
+    return (
+        "SELECT JSONExtractString(toString(payload),'gitBranch') AS branch, "
+        "any(cwd) AS cwd, count() AS n, max(ts) AS last_ts "
+        "FROM activity.events "
+        f"WHERE source='claude' AND ts>now()-{win} "
+        "GROUP BY branch ORDER BY n DESC LIMIT 500"
+    )
+
+
+def fetch_telemetry(client, days: int) -> list[dict] | None:
+    """Branch-keyed claude activity, or None if telemetry is unavailable."""
+    try:
+        return client.rows(q_branch_activity(days * DAY))
+    except Exception as e:  # noqa: BLE001 — telemetry is strictly optional
+        print(f"  (telemetry skipped: {e})", file=sys.stderr)
+        return None
+
+
+def ch_ts_to_epoch(s) -> float | None:
+    """ClickHouse `max(ts)` (a wall-clock 'YYYY-MM-DD HH:MM:SS' string) -> epoch.
+
+    `ts` is stored as host LOCAL wall-clock with NO column tz (see chquery header),
+    so interpret it in the local zone for relative-age math.
+    """
+    if s is None:
+        return None
+    if isinstance(s, (int, float)):
+        return float(s)
+    txt = str(s).strip()
+    for fmt in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"):
+        try:
+            return datetime.strptime(txt, fmt).timestamp()
+        except ValueError:
+            continue
+    return None
+
+
+def attribute_telemetry(initiatives: list[dict], rows: list[dict] | None,
+                        repos: list[str]) -> dict:
+    """Attribute branch-activity rows to initiatives; return per-repo trunk catch-all.
+
+    Mutates each initiative with telem_events + telem_last (epoch). Returns
+    {repo: {"events": n, "last": epoch, "branches": set}} for trunk/main + any
+    activity that didn't match a known initiative branch.
+    """
+    for ini in initiatives:
+        ini.setdefault("telem_events", 0)
+        ini.setdefault("telem_last", None)
+    catchall: dict = {}
+    if not rows:
+        return catchall
+
+    def cwd_repo(cwd: str | None) -> str | None:
+        if not cwd:
+            return None
+        for r in sorted(repos, key=len, reverse=True):
+            if cwd == r or cwd.startswith(r + "/"):
+                return r
+        return None
+
+    for row in rows:
+        branch = (row.get("branch") or "").strip()
+        n = _num(row.get("n"))
+        last = ch_ts_to_epoch(row.get("last_ts"))
+        repo = cwd_repo(row.get("cwd"))
+
+        if branch.lower() in {b.lower() for b in TRUNK_BRANCHES} or not branch:
+            key = repo or "(unknown repo)"
+            c = catchall.setdefault(key, {"events": 0, "last": None, "branches": set()})
+            c["events"] += n
+            c["last"] = newest_touch(c["last"], last)
+            if branch:
+                c["branches"].add(branch)
+            continue
+
+        matched = False
+        for ini in initiatives:
+            if branch_matches_slug(branch, ini["slug"]):
+                ini["telem_events"] += n
+                ini["telem_last"] = newest_touch(ini["telem_last"], last)
+                matched = True
+        if not matched:
+            # Real branch but no handoff — surface as unsegmented work too.
+            key = repo or "(unknown repo)"
+            c = catchall.setdefault(key, {"events": 0, "last": None, "branches": set()})
+            c["events"] += n
+            c["last"] = newest_touch(c["last"], last)
+            c["branches"].add(branch)
+    return catchall
+
+
+def _num(v, default=0):
+    if v is None:
+        return default
+    if isinstance(v, (int, float)):
+        return v
+    try:
+        s = str(v).strip()
+        return int(s) if s.lstrip("-").isdigit() else float(s)
+    except (ValueError, TypeError):
+        return default
+
+
+# --------------------------------------------------------------------------- #
+# git attribution per initiative
+# --------------------------------------------------------------------------- #
+def attribute_git(initiatives: list[dict], days: int) -> None:
+    """Mutate each initiative with commit/PR fields. Caches per-repo gh calls."""
+    branch_cache: dict[str, list[str]] = {}
+    default_cache: dict[str, str | None] = {}
+    open_pr_cache: dict[str, list[dict]] = {}
+    merged_pr_cache: dict[str, list[dict]] = {}
+
+    for ini in initiatives:
+        repo = ini["repo"]
+        if repo not in branch_cache:
+            # Dedup branch names (origin/x + x normalize to the same tail).
+            branch_cache[repo] = sorted(set(git_branches(repo)))
+            default_cache[repo] = git_default_branch(repo)
+            open_pr_cache[repo] = gh_open_prs(repo)
+            merged_pr_cache[repo] = gh_merged_prs(repo, days)
+
+        default_branch = default_cache[repo]
+        matching_branches = [b for b in branch_cache[repo]
+                             if branch_matches_slug(b, ini["slug"])]
+        commits = 0
+        last_commit = None
+        for b in matching_branches:
+            c, lc = git_commits_in_window(repo, b, days, default_branch)
+            commits += c
+            last_commit = newest_touch(last_commit, lc)
+
+        open_prs = [{"number": p["number"], "title": p.get("title", "")}
+                    for p in open_pr_cache[repo]
+                    if branch_matches_slug(p.get("headRefName", ""), ini["slug"])]
+        merged = [p for p in merged_pr_cache[repo]
+                  if branch_matches_slug(p.get("headRefName", ""), ini["slug"])]
+
+        ini["matching_branches"] = matching_branches
+        ini["commits"] = commits
+        ini["last_commit"] = last_commit
+        ini["open_prs"] = open_prs
+        ini["merged_prs"] = len(merged)
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+def build_report(days: int, repos: list[str] | None = None,
+                 client=None, projects_root: str = PROJECTS_ROOT,
+                 now: float | None = None) -> dict:
+    """Fuse the three sources into a ranked, per-repo report dict.
+
+    `client` may be None (telemetry skipped). `repos` None -> auto-discover.
+    """
+    repos = repos if repos is not None else discover_repos()
+    initiatives = load_initiatives(repos)
+
+    attribute_git(initiatives, days)
+    genesis = session_genesis_refs(projects_root, days)
+    attribute_sessions(initiatives, genesis)
+
+    telem_rows = fetch_telemetry(client, days) if client is not None else None
+    telemetry_available = telem_rows is not None
+    catchall = attribute_telemetry(initiatives, telem_rows, repos)
+
+    # Compute momentum from the MAX of every touch signal.
+    for ini in initiatives:
+        ini["last_touch"] = newest_touch(
+            ini.get("last_commit"),
+            ini.get("telem_last"),
+            ini.get("last_session"),
+            ini.get("doc_mtime"),
+        )
+        ini["momentum"] = classify_momentum(ini["last_touch"], now)
+
+    initiatives = sort_initiatives(initiatives)
+
+    by_repo: dict[str, list[dict]] = {}
+    for ini in initiatives:
+        by_repo.setdefault(ini["repo"], []).append(ini)
+
+    return {
+        "days": days,
+        "telemetry_available": telemetry_available,
+        "repos": repos,
+        "by_repo": by_repo,
+        "catchall": {k: {"events": v["events"], "last": v["last"],
+                         "branches": sorted(v["branches"])}
+                     for k, v in catchall.items()},
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Render
+# --------------------------------------------------------------------------- #
+MOMENTUM_TAG = {
+    "active": "●ACTIVE ",
+    "slowing": "◐slowing",
+    "stalled": "○stalled",
+    "unknown": "·unknown",
+}
+
+
+def render(report: dict, now: float | None = None) -> str:
+    days = report["days"]
+    out: list[str] = []
+    out.append(f"=== initiative-scan: trailing {days}d "
+               f"({'telemetry ON' if report['telemetry_available'] else 'telemetry OFF — handoff+git only'}) ===")
+    out.append("   Look for: what's in flight (●active <2d / ◐slowing 2-7d / ○stalled >7d), "
+               "its momentum + next step. Momentum = recency of touch, NOT % done.")
+
+    repo_names = sorted(report["by_repo"].keys()) or report.get("repos", [])
+    for repo in repo_names:
+        inis = report["by_repo"].get(repo, [])
+        short = _short_repo(repo)
+        out.append(f"\n## {short}   ({len(inis)} initiative{'s' if len(inis) != 1 else ''})")
+        if not inis:
+            out.append("   (handoffs present but none parsed)")
+        for ini in inis:
+            tag = MOMENTUM_TAG.get(ini["momentum"], "?")
+            head = (f"  {tag}  {ini['slug']}"
+                    f"   touched {rel_age(ini.get('last_touch'), now)}"
+                    f"   sess:{ini.get('session_count', 0)}"
+                    f"   commits:{ini.get('commits', 0)}"
+                    f"   merged-PR:{ini.get('merged_prs', 0)}")
+            if report["telemetry_available"]:
+                head += f"   ev:{ini.get('telem_events', 0)}"
+            out.append(head)
+            if ini.get("title") and ini["title"] != ini["slug"]:
+                out.append(f"        “{ini['title']}”")
+            for pr in ini.get("open_prs", []):
+                out.append(f"        OPEN PR #{pr['number']}: {pr['title'][:80]}")
+            ns = ini.get("next_step")
+            out.append(f"        next: {ns[:160]}" if ns else "        next: (no Next-steps item parsed)")
+            oi = ini.get("open_investigations") or []
+            if oi:
+                out.append(f"        open-investigations: {len(oi)} — {oi[0][:90]}")
+            if len(ini.get("docs", [])) > 1:
+                out.append(f"        ({len(ini['docs'])} dated handoffs; "
+                           f"current: {os.path.basename(ini['current_doc'])})")
+
+        ca = report["catchall"].get(repo)
+        if ca and ca["events"]:
+            out.append(f"  ·trunk·  unsegmented trunk/main work"
+                       f"   touched {rel_age(ca['last'], now)}"
+                       f"   ev:{ca['events']}")
+            out.append("        (telemetry not attributable to any handoff — surfaced honestly, not dropped)")
+
+    extra = [k for k in report["catchall"] if k not in repo_names]
+    for k in sorted(extra):
+        ca = report["catchall"][k]
+        if not ca["events"]:
+            continue
+        out.append(f"\n## {_short_repo(k)}   (no handoffs)")
+        out.append(f"  ·trunk·  unsegmented trunk/main work"
+                   f"   touched {rel_age(ca['last'], now)}   ev:{ca['events']}")
+
+    if not report["telemetry_available"]:
+        out.append("\n(NOTE: telemetry OFF — CLICKHOUSE_* unset or unreachable. "
+                   "Momentum/recency here come from commits + sessions + handoff mtime only.)")
+    return "\n".join(out)
+
+
+def _short_repo(repo: str) -> str:
+    home = os.path.expanduser("~")
+    if not repo:
+        return repo
+    return repo.replace(home + "/workspace/", "").replace(home, "~")
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Durable cross-session initiative tracker (handoff docs + git + telemetry).")
+    p.add_argument("--days", type=int, default=14, help="trailing window in days (default 14)")
+    p.add_argument("--json", action="store_true", help="machine-readable output")
+    p.add_argument("--repo", default=None, help="restrict to a single repo path")
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    a = parse_args(argv)
+    if a.days <= 0:
+        print("error: --days must be positive", file=sys.stderr)
+        return 2
+
+    if a.repo:
+        repo = os.path.abspath(os.path.expanduser(a.repo))
+        if not os.path.isdir(os.path.join(repo, "claudedocs")):
+            print(f"error: {repo} has no claudedocs/ dir", file=sys.stderr)
+            return 2
+        repos = [repo]
+    else:
+        repos = discover_repos()
+
+    client = None
+    try:
+        conn = Q.CHConn.from_env()
+        client = Q.CHClient(conn)
+    except RuntimeError:
+        client = None  # telemetry optional — degrade gracefully
+
+    report = build_report(a.days, repos=repos, client=client)
+
+    if a.json:
+        print(json.dumps(report, indent=2, default=str))
+    else:
+        print(render(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/session-analysis/initiative-scan.py
+++ b/scripts/session-analysis/initiative-scan.py
@@ -224,30 +224,80 @@ def slug_tokens(slug: str) -> list[str]:
     return toks
 
 
-def branch_matches_slug(branch: str, slug: str) -> bool:
-    """Heuristic: does a git branch / telemetry gitBranch belong to this slug?
+def branch_tokens(branch: str) -> list[str]:
+    """Tokenize a branch name the SAME way slugs are tokenized.
 
-    A branch matches if, after stripping a `type/` prefix (feat/, fix/, chore/...),
-    it shares a strong token overlap with the slug. We require that EITHER the
-    branch tail contains the full base slug as a substring, OR >=2 slug tokens (or
-    all of them, if the slug has <2 tokens) appear in the branch. Trunk/main never
-    match a specific initiative.
+    Strips an `origin/` remote prefix and a leading `type/` segment (feat/, fix/,
+    chore/, zach/, …) then tokenizes the remainder with `slug_tokens`. Tokenizing
+    both sides identically is what lets us compare on WORD equality instead of
+    substrings (the source of the `app-blocks`⊂`app-blocks-followups` and
+    `mail-actions`⊂`email-fractions-redesign` false matches).
+    """
+    if not branch:
+        return []
+    b = branch.lower()
+    if b.startswith("origin/"):
+        b = b[len("origin/"):]
+    # Drop a single leading type/owner segment so feat/x and x tokenize alike.
+    tail = b.split("/", 1)[1] if "/" in b else b
+    return slug_tokens(tail)
+
+
+def branch_matches_slug(branch: str, slug: str) -> bool:
+    """Does a git branch / telemetry gitBranch belong to this slug?
+
+    Rule (WORD equality, not substring): tokenize both the branch and the slug
+    with the SAME tokenizer, then require EVERY slug token to equal a branch
+    token — i.e. the slug's token set is a subset of the branch's token set. A
+    branch may carry extra tokens (a `feat/` prefix, a `-collector` suffix) and
+    still match, but a token must match a WHOLE word, so:
+      - `app-blocks` does NOT match `app-blocks-followups` (extra token on the
+        BRANCH is fine, but here `followups` is unrelated and the SIBLING slug
+        `app-blocks-followups` is the better, more-specific match — see
+        best_matching_initiative);
+      - `mail-actions` does NOT match `email-fractions-redesign`
+        (`mail`≠`email`, `actions`≠`fractions`);
+      - `app-api` does NOT match `mapper-rapid`.
+    Trunk/main never match a specific initiative.
+
+    NOTE: this is the LOW-LEVEL predicate (does the slug fit inside the branch?).
+    When several initiatives' slugs all fit one branch (siblings sharing a common
+    prefix), use `best_matching_initiative` to award credit to the single
+    longest / most-specific slug instead of every sibling.
     """
     if not branch:
         return False
-    b = branch.lower()
-    if b in {x.lower() for x in TRUNK_BRANCHES}:
+    if branch.lower() in {x.lower() for x in TRUNK_BRANCHES}:
         return False
-    tail = b.split("/", 1)[1] if "/" in b else b
-    base = slug.lower()
-    if base and base in tail:
-        return True
-    toks = slug_tokens(slug)
-    if not toks:
+    slug_toks = slug_tokens(slug)
+    if not slug_toks:
         return False
-    hit = sum(1 for t in toks if t in b)
-    need = 2 if len(toks) >= 2 else len(toks)
-    return hit >= need
+    btoks = set(branch_tokens(branch))
+    if not btoks:
+        return False
+    return set(slug_toks).issubset(btoks)
+
+
+def best_matching_initiative(branch: str, initiatives: list[dict]) -> dict | None:
+    """Pick the single most-specific initiative whose slug matches `branch`.
+
+    Among all initiatives whose slug fits the branch (`branch_matches_slug`),
+    return the one with the MOST slug tokens (longest / most-specific), so a
+    branch like `app-blocks-followups` is credited to the `app-blocks-followups`
+    initiative, NOT also to the broader `app-blocks` sibling. Ties (equal token
+    count) are broken by the longer raw slug, then lexically, for determinism.
+    None if nothing matches.
+    """
+    candidates = [ini for ini in initiatives
+                  if branch_matches_slug(branch, ini.get("slug", ""))]
+    if not candidates:
+        return None
+    return max(
+        candidates,
+        key=lambda ini: (len(slug_tokens(ini.get("slug", ""))),
+                         len(ini.get("slug", "")),
+                         ini.get("slug", "")),
+    )
 
 
 def classify_momentum(last_ts: float | None, now: float | None = None) -> str:
@@ -403,17 +453,63 @@ def _run(cmd: list[str], timeout: float = 20.0) -> str:
     return out.stdout if out.returncode == 0 else ""
 
 
+def _ref_exists(repo: str, ref: str) -> bool:
+    """True iff `ref` resolves in `repo` (local or remote-tracking)."""
+    if not ref:
+        return False
+    try:
+        out = subprocess.run(
+            ["git", "-C", repo, "rev-parse", "--verify", "--quiet", ref],
+            capture_output=True, text=True, timeout=20.0)
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return out.returncode == 0
+
+
+def _resolve_branch_ref(repo: str, branch: str) -> str | None:
+    """Pick an existing ref for a branch token: prefer local, else origin/<branch>.
+
+    `branch` may already carry an `origin/` prefix (from `git branch -a`). Returns
+    the first ref that actually resolves, or None if neither the local branch nor
+    its remote-tracking counterpart exists (so callers can report "unknown" rather
+    than fataling git → a silent 0).
+    """
+    if not branch:
+        return None
+    bare = branch[len("origin/"):] if branch.startswith("origin/") else branch
+    for cand in (bare, f"origin/{bare}", branch):
+        if _ref_exists(repo, cand):
+            return cand
+    return None
+
+
 def git_branches(repo: str) -> list[str]:
+    """Branch SHORT names. Keeps the `origin/` prefix on remote-only branches so
+    a branch existing solely as `origin/feat/x` stays resolvable (stripping it to
+    `feat/x` would later fatal `git log feat/x`). Local branches (no prefix) are
+    preferred — when both a local `x` and `origin/x` exist they dedup to `x`.
+    """
     out = _run(["git", "-C", repo, "branch", "-a", "--format=%(refname:short)"])
-    names = []
+    local: set[str] = set()
+    remote: set[str] = set()
     for ln in out.splitlines():
         ln = ln.strip()
         if not ln:
             continue
         if ln.startswith("origin/"):
-            ln = ln[len("origin/"):]
-        names.append(ln)
-    return names
+            tail = ln[len("origin/"):]
+            if tail == "HEAD" or tail.startswith("HEAD"):
+                continue  # the origin/HEAD -> origin/<default> alias, not a branch
+            remote.add(ln)
+        else:
+            local.add(ln)
+    names = set(local)
+    local_tails = local
+    for r in remote:
+        tail = r[len("origin/"):]
+        if tail not in local_tails:
+            names.add(r)  # remote-only branch — keep the origin/ prefix
+    return sorted(names)
 
 
 def git_default_branch(repo: str) -> str | None:
@@ -431,22 +527,42 @@ def git_default_branch(repo: str) -> str | None:
 
 
 def git_commits_in_window(repo: str, branch: str, since_days: int,
-                          default_branch: str | None = None) -> tuple[int, float | None]:
+                          default_branch: str | None = None
+                          ) -> tuple[int | None, float | None]:
     """(# commits UNIQUE to `branch` within window, last-commit epoch | None).
 
-    Critically excludes commits reachable from the default branch (`--not <default>`)
+    Count is None when the branch can't be resolved to ANY existing ref (neither
+    local nor `origin/<branch>`) — a clearly-distinguished "unknown", NOT a silent
+    0, so a fresh clone / remote-only branch doesn't masquerade as "no work".
+
+    Critically excludes commits reachable from the default branch (`--not <ref>`)
     so a feature branch is credited only with ITS OWN work — otherwise every branch
     counts the entire trunk history in the window (thousands of commits), grossly
-    inflating + double-counting attribution. If `branch` IS the default, return (0, None)
-    (default-branch work is the unsegmented catch-all, not an initiative).
+    inflating + double-counting attribution. Each `--not` ref is guarded with
+    `git rev-parse --verify`, so a missing local `main` (repo on `trunk`, or a
+    remote-only default) no longer fatals git rc=128 → a swallowed "" → false 0.
+    If `branch` IS the default, return (0, None) (default-branch work is the
+    unsegmented catch-all, not an initiative).
     """
     if default_branch and branch.lower() == default_branch.lower():
         return (0, None)
-    cmd = ["git", "-C", repo, "log", branch, "--no-merges",
+
+    target = _resolve_branch_ref(repo, branch)
+    if target is None:
+        # Neither the branch nor its remote exists — report unknown, not 0.
+        return (None, None)
+
+    cmd = ["git", "-C", repo, "log", target, "--no-merges",
            f"--since={since_days} days ago", "--format=%ct"]
     if default_branch and default_branch.lower() != branch.lower():
-        # Only commits NOT already on the default branch.
-        cmd += ["--not", default_branch, f"origin/{default_branch}"]
+        # Only commits NOT already on the default branch — but ONLY include
+        # exclusion refs that actually exist (else git fatals and we'd undercount).
+        excludes = []
+        for ref in (default_branch, f"origin/{default_branch}"):
+            if _ref_exists(repo, ref) and ref not in excludes:
+                excludes.append(ref)
+        if excludes:
+            cmd += ["--not", *excludes]
     out = _run(cmd)
     epochs = [int(x) for x in out.split() if x.strip().isdigit()]
     if not epochs:
@@ -611,13 +727,20 @@ def attribute_sessions(initiatives: list[dict], genesis: list[dict]) -> None:
 # Telemetry (I/O, optional)
 # --------------------------------------------------------------------------- #
 def q_branch_activity(win: int) -> str:
-    """Per gitBranch (+cwd): claude-source event count + last ts, within window."""
+    """Per (gitBranch, cwd): claude-source event count + last ts, within window.
+
+    Grouping by BOTH branch and cwd (not `GROUP BY branch` with `any(cwd)`) keeps
+    each repo's activity tied to its own working dir — otherwise every repo's
+    `main`/`trunk`, and any branch name reused across repos (`feat/api`,
+    `fix/bug`), collapse into one row attributed to one arbitrary cwd, and
+    attribution double-credits unrelated repos.
+    """
     return (
         "SELECT JSONExtractString(toString(payload),'gitBranch') AS branch, "
-        "any(cwd) AS cwd, count() AS n, max(ts) AS last_ts "
+        "cwd AS cwd, count() AS n, max(ts) AS last_ts "
         "FROM activity.events "
         f"WHERE source='claude' AND ts>now()-{win} "
-        "GROUP BY branch ORDER BY n DESC LIMIT 500"
+        "GROUP BY branch, cwd ORDER BY n DESC LIMIT 500"
     )
 
 
@@ -631,10 +754,15 @@ def fetch_telemetry(client, days: int) -> list[dict] | None:
 
 
 def ch_ts_to_epoch(s) -> float | None:
-    """ClickHouse `max(ts)` (a wall-clock 'YYYY-MM-DD HH:MM:SS' string) -> epoch.
+    """ClickHouse `max(ts)` (a 'YYYY-MM-DD HH:MM:SS[.fff]' string) -> epoch.
 
-    `ts` is stored as host LOCAL wall-clock with NO column tz (see chquery header),
-    so interpret it in the local zone for relative-age math.
+    `ts` is stored in UTC — `scripts/collector/emit` stamps it with `date -u`
+    (see scripts/collector/tests/test_collector.py::test_emit_ts_is_utc and the
+    root CLAUDE.md "ts is UTC" note). The column is a bare DateTime64(3) with NO
+    attached timezone, so the wall-clock string we read back IS the UTC instant.
+    We therefore parse it as UTC — NOT local — or every relative-age/momentum
+    computation is skewed by the host's UTC offset (~5h here), wrongly pushing
+    initiatives toward slowing/stalled.
     """
     if s is None:
         return None
@@ -643,7 +771,7 @@ def ch_ts_to_epoch(s) -> float | None:
     txt = str(s).strip()
     for fmt in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"):
         try:
-            return datetime.strptime(txt, fmt).timestamp()
+            return datetime.strptime(txt, fmt).replace(tzinfo=timezone.utc).timestamp()
         except ValueError:
             continue
     return None
@@ -652,6 +780,14 @@ def ch_ts_to_epoch(s) -> float | None:
 def attribute_telemetry(initiatives: list[dict], rows: list[dict] | None,
                         repos: list[str]) -> dict:
     """Attribute branch-activity rows to initiatives; return per-repo trunk catch-all.
+
+    Each row carries (branch, cwd). The cwd is mapped to its repo by path
+    containment, and a row is only credited to an initiative WHOSE repo matches
+    that cwd's repo — so a branch token reused across repos (`feat/api` in repo A
+    and repo B) never cross-credits, and an arbitrary `any(cwd)` no longer
+    collapses every repo's `main` into one. Within the matching repo, credit goes
+    to the SINGLE most-specific initiative (`best_matching_initiative`), so
+    sibling slugs don't all share the same event count.
 
     Mutates each initiative with telem_events + telem_last (epoch). Returns
     {repo: {"events": n, "last": epoch, "branches": set}} for trunk/main + any
@@ -672,6 +808,11 @@ def attribute_telemetry(initiatives: list[dict], rows: list[dict] | None,
                 return r
         return None
 
+    # Initiatives indexed by their repo, so matching is scoped to the row's repo.
+    inis_by_repo: dict[str, list[dict]] = {}
+    for ini in initiatives:
+        inis_by_repo.setdefault(ini["repo"], []).append(ini)
+
     for row in rows:
         branch = (row.get("branch") or "").strip()
         n = _num(row.get("n"))
@@ -687,14 +828,15 @@ def attribute_telemetry(initiatives: list[dict], rows: list[dict] | None,
                 c["branches"].add(branch)
             continue
 
-        matched = False
-        for ini in initiatives:
-            if branch_matches_slug(branch, ini["slug"]):
-                ini["telem_events"] += n
-                ini["telem_last"] = newest_touch(ini["telem_last"], last)
-                matched = True
-        if not matched:
-            # Real branch but no handoff — surface as unsegmented work too.
+        # Only initiatives in THIS row's repo are eligible (no cross-repo credit).
+        eligible = inis_by_repo.get(repo, []) if repo is not None else []
+        ini = best_matching_initiative(branch, eligible)
+        if ini is not None:
+            ini["telem_events"] += n
+            ini["telem_last"] = newest_touch(ini["telem_last"], last)
+        else:
+            # Real branch but no matching handoff in its repo — surface as
+            # unsegmented work too (honest, not dropped, not mis-credited).
             key = repo or "(unknown repo)"
             c = catchall.setdefault(key, {"events": 0, "last": None, "branches": set()})
             c["events"] += n
@@ -719,42 +861,68 @@ def _num(v, default=0):
 # git attribution per initiative
 # --------------------------------------------------------------------------- #
 def attribute_git(initiatives: list[dict], days: int) -> None:
-    """Mutate each initiative with commit/PR fields. Caches per-repo gh calls."""
+    """Mutate each initiative with commit/PR fields. Caches per-repo gh calls.
+
+    A branch / PR head is awarded to the SINGLE most-specific initiative in its
+    repo (`best_matching_initiative`), so sibling slugs sharing a common prefix
+    (`app-blocks` vs `app-blocks-followups`) no longer all claim the same branch
+    and end up with identical commit/PR counts.
+    """
     branch_cache: dict[str, list[str]] = {}
     default_cache: dict[str, str | None] = {}
     open_pr_cache: dict[str, list[dict]] = {}
     merged_pr_cache: dict[str, list[dict]] = {}
 
+    # Group initiatives by repo so "best match" is decided within a repo's own slugs.
+    by_repo: dict[str, list[dict]] = {}
     for ini in initiatives:
-        repo = ini["repo"]
+        by_repo.setdefault(ini["repo"], []).append(ini)
+        ini["matching_branches"] = []
+        ini["commits"] = 0
+        ini["commits_unknown"] = False
+        ini["last_commit"] = None
+        ini["open_prs"] = []
+        ini["merged_prs"] = 0
+
+    for repo, repo_inis in by_repo.items():
         if repo not in branch_cache:
             # Dedup branch names (origin/x + x normalize to the same tail).
             branch_cache[repo] = sorted(set(git_branches(repo)))
             default_cache[repo] = git_default_branch(repo)
             open_pr_cache[repo] = gh_open_prs(repo)
             merged_pr_cache[repo] = gh_merged_prs(repo, days)
-
         default_branch = default_cache[repo]
-        matching_branches = [b for b in branch_cache[repo]
-                             if branch_matches_slug(b, ini["slug"])]
-        commits = 0
-        last_commit = None
-        for b in matching_branches:
+
+        # Each branch → its single best initiative (most-specific slug).
+        for b in branch_cache[repo]:
+            ini = best_matching_initiative(b, repo_inis)
+            if ini is None:
+                continue
+            ini["matching_branches"].append(b)
             c, lc = git_commits_in_window(repo, b, days, default_branch)
-            commits += c
-            last_commit = newest_touch(last_commit, lc)
+            if c is None:
+                ini["commits_unknown"] = True  # unresolvable ref — don't fake 0
+                continue
+            ini["commits"] += c
+            ini["last_commit"] = newest_touch(ini["last_commit"], lc)
 
-        open_prs = [{"number": p["number"], "title": p.get("title", "")}
-                    for p in open_pr_cache[repo]
-                    if branch_matches_slug(p.get("headRefName", ""), ini["slug"])]
-        merged = [p for p in merged_pr_cache[repo]
-                  if branch_matches_slug(p.get("headRefName", ""), ini["slug"])]
+        # Each PR head → its single best initiative, same rule.
+        for p in open_pr_cache[repo]:
+            ini = best_matching_initiative(p.get("headRefName", ""), repo_inis)
+            if ini is not None:
+                ini["open_prs"].append({"number": p["number"], "title": p.get("title", "")})
+        merged_counts: dict[int, int] = {}
+        for p in merged_pr_cache[repo]:
+            ini = best_matching_initiative(p.get("headRefName", ""), repo_inis)
+            if ini is not None:
+                merged_counts[id(ini)] = merged_counts.get(id(ini), 0) + 1
+        for ini in repo_inis:
+            ini["merged_prs"] = merged_counts.get(id(ini), 0)
 
-        ini["matching_branches"] = matching_branches
-        ini["commits"] = commits
-        ini["last_commit"] = last_commit
-        ini["open_prs"] = open_prs
-        ini["merged_prs"] = len(merged)
+    for ini in initiatives:
+        # "commits:?" only when we have NO confident count at all (every matching
+        # branch was unresolvable) — a partial count stays a number.
+        ini["commits_unknown"] = ini["commits_unknown"] and ini["commits"] == 0
 
 
 # --------------------------------------------------------------------------- #
@@ -833,10 +1001,11 @@ def render(report: dict, now: float | None = None) -> str:
             out.append("   (handoffs present but none parsed)")
         for ini in inis:
             tag = MOMENTUM_TAG.get(ini["momentum"], "?")
+            commits_str = "?" if ini.get("commits_unknown") else str(ini.get("commits", 0))
             head = (f"  {tag}  {ini['slug']}"
                     f"   touched {rel_age(ini.get('last_touch'), now)}"
                     f"   sess:{ini.get('session_count', 0)}"
-                    f"   commits:{ini.get('commits', 0)}"
+                    f"   commits:{commits_str}"
                     f"   merged-PR:{ini.get('merged_prs', 0)}")
             if report["telemetry_available"]:
                 head += f"   ev:{ini.get('telem_events', 0)}"

--- a/scripts/session-analysis/tests/test_initiative_scan.py
+++ b/scripts/session-analysis/tests/test_initiative_scan.py
@@ -9,7 +9,6 @@ clustering, momentum classification (2d/7d boundaries), and slug<->branch matchi
 The git/gh/ClickHouse calls are stubbed where the orchestration is exercised.
 """
 import importlib.util
-import os
 import sys
 from pathlib import Path
 
@@ -271,11 +270,168 @@ def test_commits_feature_branch_uses_not_default(monkeypatch):
         seen["cmd"] = cmd
         return "1700000000\n1699990000\n"
 
+    # The branch + both default refs resolve (local main present alongside origin).
+    monkeypatch.setattr(isc, "_ref_exists", lambda repo, ref: True)
     monkeypatch.setattr(isc, "_run", fake_run)
     n, last = isc.git_commits_in_window("/r", "feat/x", 14, "trunk")
     assert n == 2 and last == 1700000000.0
     # The --not <default> exclusion must be present so trunk history isn't counted.
     assert "--not" in seen["cmd"] and "trunk" in seen["cmd"]
+
+
+# --------------------------------------------------------------------------- #
+# Robust git refs (#2/#3): missing local default + remote-only branch
+# --------------------------------------------------------------------------- #
+def test_commits_missing_local_default_does_not_fatal(monkeypatch):
+    # Repo on `trunk` with no local `main`: only `feat/x` and `origin/trunk`
+    # exist. The exclusion set must drop the missing `trunk` local ref instead of
+    # passing it to git (which would fatal rc=128 → swallowed "" → a false 0).
+    existing = {"feat/x", "origin/trunk"}
+    monkeypatch.setattr(isc, "_ref_exists", lambda repo, ref: ref in existing)
+
+    seen = {}
+
+    def fake_run(cmd, timeout=20.0):
+        seen["cmd"] = cmd
+        return "1700000000\n1699990000\n1699980000\n"
+
+    monkeypatch.setattr(isc, "_run", fake_run)
+    n, last = isc.git_commits_in_window("/r", "feat/x", 14, "trunk")
+    # Counts correctly (3), NOT a false 0; the missing local `trunk` is excluded
+    # from --not but `origin/trunk` is kept.
+    assert n == 3 and last == 1700000000.0
+    assert "--not" in seen["cmd"]
+    assert "origin/trunk" in seen["cmd"]
+    # The non-existent bare `trunk` ref must NOT have been passed to git.
+    idx = seen["cmd"].index("--not")
+    assert "trunk" not in seen["cmd"][idx:]
+
+
+def test_commits_unresolvable_branch_reports_unknown(monkeypatch):
+    # Neither `feat/ghost` nor `origin/feat/ghost` exists → (None, None) "unknown",
+    # never a silent (0, None) that masquerades as "no work".
+    monkeypatch.setattr(isc, "_ref_exists", lambda repo, ref: False)
+    monkeypatch.setattr(isc, "_run", lambda cmd, timeout=20.0: "")
+    assert isc.git_commits_in_window("/r", "feat/ghost", 14, "main") == (None, None)
+
+
+def test_commits_remote_only_branch_resolves_to_origin(monkeypatch):
+    # A branch existing ONLY as origin/feat/y must resolve (and git log it) via
+    # its remote-tracking ref, not fatal on a non-existent local `feat/y`.
+    existing = {"origin/feat/y", "main", "origin/main"}
+    monkeypatch.setattr(isc, "_ref_exists", lambda repo, ref: ref in existing)
+
+    seen = {}
+
+    def fake_run(cmd, timeout=20.0):
+        seen["cmd"] = cmd
+        return "1700000000\n"
+
+    monkeypatch.setattr(isc, "_run", fake_run)
+    n, last = isc.git_commits_in_window("/r", "origin/feat/y", 14, "main")
+    assert n == 1 and last == 1700000000.0
+    # git log was invoked against the resolved origin/feat/y ref.
+    assert "origin/feat/y" in seen["cmd"]
+
+
+def test_git_branches_keeps_remote_only_branch(monkeypatch):
+    # `feat/local` exists both places (dedups to bare); `feat/remote` is remote-only
+    # (keeps the origin/ prefix so a later `git log` can resolve it). origin/HEAD
+    # alias is dropped.
+    out = ("main\nfeat/local\norigin/main\norigin/feat/local\n"
+           "origin/feat/remote\norigin/HEAD\n")
+    monkeypatch.setattr(isc, "_run", lambda cmd, timeout=20.0: out)
+    names = isc.git_branches("/r")
+    assert "feat/local" in names           # bare (local preferred)
+    assert "origin/feat/local" not in names  # deduped away
+    assert "origin/feat/remote" in names   # remote-only keeps prefix
+    assert "main" in names
+    assert not any(n.endswith("HEAD") for n in names)
+
+
+# --------------------------------------------------------------------------- #
+# Word-equality branch matching (#5): no substring false positives
+# --------------------------------------------------------------------------- #
+def test_longer_slug_not_matched_by_shorter_branch():
+    # The `app-blocks-followups` slug must NOT match the plain `feat/app-blocks`
+    # branch: {app,blocks,followups} ⊄ {app,blocks}. (The sibling-credit direction —
+    # `app-blocks` matching the LONGER branch — is handled by best_matching_initiative,
+    # tested in test_best_match_prefers_most_specific_sibling.)
+    assert not isc.branch_matches_slug("feat/app-blocks", "app-blocks-followups")
+
+
+def test_mail_actions_does_not_match_email_fractions():
+    # The classic false positive: mail⊂email, actions⊂fractions under substrings.
+    # Word equality kills it: {mail,actions} ⊄ {email,fractions,redesign}.
+    assert not isc.branch_matches_slug("feat/email-fractions-redesign", "mail-actions")
+
+
+def test_app_api_does_not_match_mapper_rapid():
+    assert not isc.branch_matches_slug("feat/mapper-rapid", "app-api")
+
+
+def test_exact_feature_branch_still_matches():
+    assert isc.branch_matches_slug(
+        "zach/civitai-auth-observability", "civitai-auth-observability")
+
+
+def test_best_match_prefers_most_specific_sibling():
+    # Branch app-blocks-followups fits BOTH slugs; credit the specific one only.
+    inis = [
+        {"slug": "app-blocks", "repo": "/r"},
+        {"slug": "app-blocks-followups", "repo": "/r"},
+    ]
+    best = isc.best_matching_initiative("feat/app-blocks-followups", inis)
+    assert best is not None and best["slug"] == "app-blocks-followups"
+    # And the plain `app-blocks` branch goes to the broad one (followups not present).
+    best2 = isc.best_matching_initiative("feat/app-blocks", inis)
+    assert best2 is not None and best2["slug"] == "app-blocks"
+
+
+def test_siblings_do_not_share_identical_commit_counts(monkeypatch):
+    # Two sibling initiatives + per-branch distinct commit counts: each branch is
+    # awarded to its single best initiative, so the counts must DIFFER (the bug was
+    # both siblings claiming every app-blocks-* branch → identical totals).
+    inis = [
+        {"slug": "app-blocks", "repo": "/r"},
+        {"slug": "app-blocks-followups", "repo": "/r"},
+    ]
+    monkeypatch.setattr(isc, "git_branches", lambda r: [
+        "feat/app-blocks", "feat/app-blocks-followups"])
+    monkeypatch.setattr(isc, "git_default_branch", lambda r: "main")
+    monkeypatch.setattr(isc, "gh_open_prs", lambda r: [])
+    monkeypatch.setattr(isc, "gh_merged_prs", lambda r, d: [])
+
+    def fake_commits(repo, branch, days, default=None):
+        return ({"feat/app-blocks": 4,
+                 "feat/app-blocks-followups": 9}.get(branch, 0), 1000.0)
+
+    monkeypatch.setattr(isc, "git_commits_in_window", fake_commits)
+    isc.attribute_git(inis, 14)
+    by_slug = {i["slug"]: i["commits"] for i in inis}
+    assert by_slug == {"app-blocks": 4, "app-blocks-followups": 9}
+
+
+# --------------------------------------------------------------------------- #
+# Cross-repo telemetry isolation (#4)
+# --------------------------------------------------------------------------- #
+def test_telemetry_same_branch_token_does_not_cross_repo():
+    # Two initiatives in different repos, same branch token `feat/api`. Activity in
+    # repo A's cwd must credit ONLY repo A's initiative, not repo B's.
+    inis = [
+        {"slug": "api", "repo": "/home/u/workspace/repoA"},
+        {"slug": "api", "repo": "/home/u/workspace/repoB"},
+    ]
+    rows = [
+        {"branch": "feat/api", "cwd": "/home/u/workspace/repoA/sub", "n": 7,
+         "last_ts": "2026-06-30 10:00:00"},
+    ]
+    isc.attribute_telemetry(inis, rows, [
+        "/home/u/workspace/repoA", "/home/u/workspace/repoB"])
+    a = next(i for i in inis if i["repo"].endswith("repoA"))
+    b = next(i for i in inis if i["repo"].endswith("repoB"))
+    assert a["telem_events"] == 7
+    assert b["telem_events"] == 0  # no cross-credit into the other repo
 
 
 # --------------------------------------------------------------------------- #
@@ -327,12 +483,32 @@ def test_attribute_telemetry_none_rows_is_safe():
     assert inis[0]["telem_last"] is None
 
 
-def test_ch_ts_to_epoch_roundtrip():
-    import datetime as _dt
-    ep = isc.ch_ts_to_epoch("2026-06-30 12:34:56")
-    assert ep == _dt.datetime(2026, 6, 30, 12, 34, 56).timestamp()
+def test_ch_ts_to_epoch_is_utc_not_local():
+    # #1: the ClickHouse `ts` column is UTC (emit uses `date -u`), so the wall-clock
+    # string must convert as UTC — NOT the host's local zone, or every relative-age
+    # is skewed by the UTC offset. Build the expected epoch with calendar.timegm so
+    # the assertion is independent of the machine's TZ.
+    import calendar
+    expected = calendar.timegm((2026, 6, 30, 12, 34, 56, 0, 0, 0))
+    assert isc.ch_ts_to_epoch("2026-06-30 12:34:56") == float(expected)
+    # Fractional-seconds variant the column actually returns must also parse as UTC.
+    assert isc.ch_ts_to_epoch("2026-06-30 12:34:56.789") == float(expected) + 0.789
     assert isc.ch_ts_to_epoch(None) is None
     assert isc.ch_ts_to_epoch("garbage") is None
+
+
+def test_ch_ts_to_epoch_independent_of_local_tz(monkeypatch):
+    # Force a non-UTC TZ and confirm the result is unchanged (proves UTC parsing).
+    import calendar
+    import time as _time
+    expected = float(calendar.timegm((2026, 1, 15, 8, 0, 0, 0, 0, 0)))
+    monkeypatch.setenv("TZ", "America/New_York")
+    _time.tzset()
+    try:
+        assert isc.ch_ts_to_epoch("2026-01-15 08:00:00") == expected
+    finally:
+        monkeypatch.delenv("TZ", raising=False)
+        _time.tzset()
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/session-analysis/tests/test_initiative_scan.py
+++ b/scripts/session-analysis/tests/test_initiative_scan.py
@@ -1,0 +1,394 @@
+"""Unit tests for initiative-scan PURE logic (no live ClickHouse / git / gh).
+
+Run:
+  nix-shell -p 'python3.withPackages(p:[p.pytest p.requests])' \
+      --run 'python -m pytest scripts/session-analysis/tests -q'
+
+Covers: handoff filename/title/next-step/open-investigations parsing, dated-variant
+clustering, momentum classification (2d/7d boundaries), and slug<->branch matching.
+The git/gh/ClickHouse calls are stubbed where the orchestration is exercised.
+"""
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+# Load initiative-scan.py (a hyphenated, non-importable filename) by path.
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "initiative-scan.py"
+# chquery lives in ../../validation — the script adds it to sys.path on import.
+sys.path.insert(0, str(HERE.parent.parent / "validation"))
+_spec = importlib.util.spec_from_file_location("initiative_scan", SCRIPT)
+isc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(isc)
+
+
+DAY = 86400
+
+
+# --------------------------------------------------------------------------- #
+# Handoff filename parsing — slug + date extraction (all real-world variants)
+# --------------------------------------------------------------------------- #
+def test_filename_date_suffix():
+    assert isc.parse_handoff_filename("handoff-activity-telemetry-2026-06-27.md") == (
+        "activity-telemetry", "2026-06-27")
+
+
+def test_filename_date_prefix():
+    # Date appears as a prefix (handoff-<date>-<slug>.md) — slug is the tail.
+    assert isc.parse_handoff_filename("handoff-2026-06-25-clawgate-tasks.md") == (
+        "clawgate-tasks", "2026-06-25")
+
+
+def test_filename_no_date():
+    assert isc.parse_handoff_filename("handoff-app-blocks-launch.md") == (
+        "app-blocks-launch", None)
+
+
+def test_filename_date_is_the_slug():
+    # handoff-2026-05-25.md — the whole slug IS the date; keep it as the slug.
+    assert isc.parse_handoff_filename("handoff-2026-05-25.md") == (
+        "2026-05-25", "2026-05-25")
+
+
+# --------------------------------------------------------------------------- #
+# Title parsing
+# --------------------------------------------------------------------------- #
+def test_title_strips_date_tail():
+    text = "# Handoff: activity-telemetry + mail — 2026-06-27\n\n## Goal\nx\n"
+    assert isc.parse_handoff_title(text) == "Handoff: activity-telemetry + mail"
+
+
+def test_title_none_when_absent():
+    assert isc.parse_handoff_title("no heading here\njust prose\n") is None
+
+
+# --------------------------------------------------------------------------- #
+# Next-steps extraction
+# --------------------------------------------------------------------------- #
+NEXT_DOC = """# Handoff: mail-automation — 2026-06-30
+
+## Goal
+Automate the inbox.
+
+## Next steps (ranked)
+1. **Ship the extractor** on the live mail table — highest leverage.
+2. Lower: rotate the OpenRouter key.
+
+## Gotchas
+- something
+"""
+
+
+def test_next_step_first_ranked_item_flattened():
+    step = isc.parse_next_step(NEXT_DOC)
+    assert step == "Ship the extractor on the live mail table — highest leverage."
+
+
+def test_next_step_handles_decorated_heading():
+    doc = "## Next steps (ranked) — what's LEFT\n1. Do the thing\n\n## End\n"
+    assert isc.parse_next_step(doc) == "Do the thing"
+
+
+def test_next_step_dash_bullets():
+    doc = "## Next steps\n- first bullet item\n- second\n"
+    assert isc.parse_next_step(doc) == "first bullet item"
+
+
+def test_next_step_none_without_section():
+    assert isc.parse_next_step("## Goal\nstuff\n## Gotchas\nx\n") is None
+
+
+def test_next_step_section_ends_at_next_h2():
+    # No list items before the next H2 -> None (don't bleed into Gotchas).
+    doc = "## Next steps\n\n## Gotchas\n1. not a next step\n"
+    assert isc.parse_next_step(doc) is None
+
+
+# --------------------------------------------------------------------------- #
+# Open-investigations section (newer template)
+# --------------------------------------------------------------------------- #
+OPEN_INV_DOC = """# Handoff: dp-prod-500-floor — 2026-06-20
+
+## Goal
+Hold the 500 floor.
+
+## Open investigations — live diagnosis state
+### 500s spike on the edge nodes during canary
+- Symptom: ...
+### nginx frame-ancestors blocks the embed
+- Observed: ...
+
+## Next steps (ranked)
+1. Re-run the canary with the new floor.
+"""
+
+
+def test_open_investigations_extracted():
+    inv = isc.parse_open_investigations(OPEN_INV_DOC)
+    assert inv == [
+        "500s spike on the edge nodes during canary",
+        "nginx frame-ancestors blocks the embed",
+    ]
+
+
+def test_open_investigations_empty_when_absent():
+    assert isc.parse_open_investigations(NEXT_DOC) == []
+
+
+def test_open_inv_doc_still_parses_next_step():
+    assert isc.parse_next_step(OPEN_INV_DOC) == "Re-run the canary with the new floor."
+
+
+# --------------------------------------------------------------------------- #
+# Dated-variant clustering
+# --------------------------------------------------------------------------- #
+def _doc(repo, slug, date, mtime, title="t", next_step="ns", path=None):
+    return {
+        "repo": repo, "slug": slug, "date": date, "mtime": mtime,
+        "title": title, "next_step": next_step, "open_investigations": [],
+        "path": path or f"{repo}/claudedocs/handoff-{slug}-{date}.md",
+    }
+
+
+def test_cluster_merges_dated_variants_newest_wins():
+    docs = [
+        _doc("/r", "app-blocks", "2026-06-26", 100.0, next_step="old step"),
+        _doc("/r", "app-blocks", "2026-06-27", 200.0, next_step="new step"),
+    ]
+    inis = isc.cluster_handoffs(docs)
+    assert len(inis) == 1
+    ini = inis[0]
+    assert ini["slug"] == "app-blocks"
+    assert ini["date"] == "2026-06-27"          # newest by filename date
+    assert ini["next_step"] == "new step"       # current state = newest doc
+    assert len(ini["docs"]) == 2                # both members retained
+
+
+def test_cluster_distinct_slugs_stay_separate():
+    docs = [
+        _doc("/r", "mail-automation", "2026-06-30", 100.0),
+        _doc("/r", "qa-automation", "2026-06-29", 90.0),
+    ]
+    inis = isc.cluster_handoffs(docs)
+    assert {i["slug"] for i in inis} == {"mail-automation", "qa-automation"}
+
+
+def test_cluster_dateless_doc_uses_mtime():
+    docs = [
+        _doc("/r", "remote-approval", None, 50.0, next_step="A"),
+        _doc("/r", "remote-approval", None, 80.0, next_step="B"),
+    ]
+    inis = isc.cluster_handoffs(docs)
+    assert len(inis) == 1
+    assert inis[0]["next_step"] == "B"          # higher mtime wins
+
+
+# --------------------------------------------------------------------------- #
+# Momentum classification — boundaries at 2d / 7d
+# --------------------------------------------------------------------------- #
+def test_momentum_active_under_2d():
+    now = 1_000_000.0
+    assert isc.classify_momentum(now - (2 * DAY - 1), now) == "active"
+
+
+def test_momentum_boundary_2d_is_slowing():
+    now = 1_000_000.0
+    assert isc.classify_momentum(now - 2 * DAY, now) == "slowing"
+
+
+def test_momentum_slowing_under_7d():
+    now = 1_000_000.0
+    assert isc.classify_momentum(now - (7 * DAY - 1), now) == "slowing"
+
+
+def test_momentum_boundary_7d_is_stalled():
+    now = 1_000_000.0
+    assert isc.classify_momentum(now - 7 * DAY, now) == "stalled"
+
+
+def test_momentum_unknown_when_no_touch():
+    assert isc.classify_momentum(None, 1_000_000.0) == "unknown"
+
+
+def test_newest_touch_picks_max_ignoring_none():
+    assert isc.newest_touch(None, 10.0, 5.0, None) == 10.0
+    assert isc.newest_touch(None, None) is None
+
+
+# --------------------------------------------------------------------------- #
+# Slug <-> branch matching (heuristic)
+# --------------------------------------------------------------------------- #
+def test_branch_full_slug_substring():
+    assert isc.branch_matches_slug("feat/mail-automation", "mail-automation")
+
+
+def test_branch_type_prefix_stripped():
+    assert isc.branch_matches_slug("fix/app-blocks-launch", "app-blocks-launch")
+
+
+def test_branch_token_overlap_two_tokens():
+    # >=2 shared meaningful tokens is enough even without the full slug substring.
+    # branch carries "activity" + "telemetry"; slug reorders/extends them.
+    assert isc.branch_matches_slug("feat/activity-telemetry-collector", "telemetry-activity-i3")
+
+
+def test_branch_no_match_single_weak_token():
+    # Only one token overlaps ("source"); not enough.
+    assert not isc.branch_matches_slug("feat/scroll-source", "activity-telemetry")
+
+
+def test_trunk_branches_never_match():
+    for b in ("main", "master", "trunk", "develop"):
+        assert not isc.branch_matches_slug(b, "mail-automation")
+
+
+def test_short_slug_requires_all_tokens():
+    # A single-token slug must match that token.
+    assert isc.branch_matches_slug("feat/clawgate", "clawgate")
+    assert not isc.branch_matches_slug("feat/clawgate", "sysredis")
+
+
+def test_slug_tokens_drops_dates_and_stopwords():
+    toks = isc.slug_tokens("activity-telemetry-2026-06-27")
+    assert "activity" in toks and "telemetry" in toks
+    assert "2026" not in toks and "06" not in toks
+
+
+# --------------------------------------------------------------------------- #
+# Commit-window attribution excludes the default branch (anti-inflation)
+# --------------------------------------------------------------------------- #
+def test_commits_default_branch_returns_zero(monkeypatch):
+    # The default branch itself is the unsegmented catch-all, never an initiative.
+    monkeypatch.setattr(isc, "_run", lambda cmd, timeout=20.0: "9999\n8888\n")
+    assert isc.git_commits_in_window("/r", "trunk", 14, "trunk") == (0, None)
+
+
+def test_commits_feature_branch_uses_not_default(monkeypatch):
+    seen = {}
+
+    def fake_run(cmd, timeout=20.0):
+        seen["cmd"] = cmd
+        return "1700000000\n1699990000\n"
+
+    monkeypatch.setattr(isc, "_run", fake_run)
+    n, last = isc.git_commits_in_window("/r", "feat/x", 14, "trunk")
+    assert n == 2 and last == 1700000000.0
+    # The --not <default> exclusion must be present so trunk history isn't counted.
+    assert "--not" in seen["cmd"] and "trunk" in seen["cmd"]
+
+
+# --------------------------------------------------------------------------- #
+# Session attribution (genesis text -> initiative)
+# --------------------------------------------------------------------------- #
+def test_attribute_sessions_matches_handoff_filename():
+    inis = [{
+        "slug": "mail-automation",
+        "docs": [{"path": "/r/claudedocs/handoff-mail-automation-2026-06-30.md", "date": "2026-06-30"}],
+    }]
+    genesis = [
+        {"text": "continue the work, read handoff-mail-automation-2026-06-30.md first", "mtime": 500.0},
+        {"text": "unrelated session about something else", "mtime": 600.0},
+        {"text": "pick up handoff-mail-automation per the slug", "mtime": 700.0},
+    ]
+    isc.attribute_sessions(inis, genesis)
+    assert inis[0]["session_count"] == 2
+    assert inis[0]["last_session"] == 700.0
+
+
+def test_attribute_sessions_zero_when_unreferenced():
+    inis = [{"slug": "ghost-initiative", "docs": [
+        {"path": "/r/claudedocs/handoff-ghost-initiative.md", "date": None}]}]
+    isc.attribute_sessions(inis, [{"text": "nothing relevant", "mtime": 1.0}])
+    assert inis[0]["session_count"] == 0
+    assert inis[0]["last_session"] is None
+
+
+# --------------------------------------------------------------------------- #
+# Telemetry attribution + trunk catch-all (no live CH)
+# --------------------------------------------------------------------------- #
+def test_attribute_telemetry_segments_and_catchall():
+    inis = [{"slug": "mail-automation", "repo": "/home/u/workspace/devrc"}]
+    rows = [
+        {"branch": "feat/mail-automation", "cwd": "/home/u/workspace/devrc", "n": 12, "last_ts": "2026-06-30 10:00:00"},
+        {"branch": "main", "cwd": "/home/u/workspace/devrc", "n": 40, "last_ts": "2026-06-30 09:00:00"},
+        {"branch": "feat/unknown-thing", "cwd": "/home/u/workspace/devrc", "n": 5, "last_ts": "2026-06-29 09:00:00"},
+    ]
+    catchall = isc.attribute_telemetry(inis, rows, ["/home/u/workspace/devrc"])
+    assert inis[0]["telem_events"] == 12
+    # main (40) + unmatched feat/unknown-thing (5) -> 45 unsegmented.
+    assert catchall["/home/u/workspace/devrc"]["events"] == 45
+
+
+def test_attribute_telemetry_none_rows_is_safe():
+    inis = [{"slug": "x", "repo": "/r"}]
+    assert isc.attribute_telemetry(inis, None, ["/r"]) == {}
+    assert inis[0]["telem_events"] == 0
+    assert inis[0]["telem_last"] is None
+
+
+def test_ch_ts_to_epoch_roundtrip():
+    import datetime as _dt
+    ep = isc.ch_ts_to_epoch("2026-06-30 12:34:56")
+    assert ep == _dt.datetime(2026, 6, 30, 12, 34, 56).timestamp()
+    assert isc.ch_ts_to_epoch(None) is None
+    assert isc.ch_ts_to_epoch("garbage") is None
+
+
+# --------------------------------------------------------------------------- #
+# build_report orchestration with stubbed I/O (no git/gh/CH/transcripts)
+# --------------------------------------------------------------------------- #
+def test_build_report_end_to_end_no_telemetry(tmp_path, monkeypatch):
+    # A fake repo with one dated handoff.
+    repo = tmp_path / "myrepo"
+    (repo / "claudedocs").mkdir(parents=True)
+    doc = repo / "claudedocs" / "handoff-mail-automation-2026-06-30.md"
+    doc.write_text(NEXT_DOC)
+
+    # Stub the external-process + transcript I/O so the test is hermetic.
+    monkeypatch.setattr(isc, "git_branches", lambda r: ["feat/mail-automation", "main"])
+    monkeypatch.setattr(isc, "git_default_branch", lambda r: "main")
+    monkeypatch.setattr(isc, "git_commits_in_window", lambda r, b, d, db=None: (3, 1_000.0))
+    monkeypatch.setattr(isc, "gh_open_prs", lambda r: [
+        {"number": 42, "title": "mail extractor", "headRefName": "feat/mail-automation"}])
+    monkeypatch.setattr(isc, "gh_merged_prs", lambda r, d: [])
+    monkeypatch.setattr(isc, "session_genesis_refs", lambda root, d: [])
+
+    now = 2_000.0  # last_commit at 1000 -> age 1000s -> active
+    report = isc.build_report(2, repos=[str(repo)], client=None, now=now)
+
+    assert report["telemetry_available"] is False
+    inis = report["by_repo"][str(repo)]
+    assert len(inis) == 1
+    ini = inis[0]
+    assert ini["slug"] == "mail-automation"
+    assert ini["commits"] == 3
+    assert ini["momentum"] == "active"
+    assert ini["open_prs"] == [{"number": 42, "title": "mail extractor"}]
+    assert ini["next_step"].startswith("Ship the extractor")
+
+    # Render must not raise and must include the slug + telemetry-off note.
+    txt = isc.render(report, now=now)
+    assert "mail-automation" in txt
+    assert "telemetry OFF" in txt
+
+
+def test_render_emits_trunk_catchall(monkeypatch, tmp_path):
+    repo = tmp_path / "r2"
+    (repo / "claudedocs").mkdir(parents=True)
+    (repo / "claudedocs" / "handoff-thing.md").write_text("# Handoff: thing\n## Next steps\n1. go\n")
+    monkeypatch.setattr(isc, "git_branches", lambda r: ["main"])
+    monkeypatch.setattr(isc, "git_default_branch", lambda r: "main")
+    monkeypatch.setattr(isc, "gh_open_prs", lambda r: [])
+    monkeypatch.setattr(isc, "gh_merged_prs", lambda r, d: [])
+    monkeypatch.setattr(isc, "session_genesis_refs", lambda root, d: [])
+
+    class FakeClient:
+        def rows(self, sql):
+            return [{"branch": "main", "cwd": str(repo), "n": 99, "last_ts": "2026-06-30 10:00:00"}]
+
+    report = isc.build_report(14, repos=[str(repo)], client=FakeClient(), now=2_000_000_000.0)
+    assert report["telemetry_available"] is True
+    txt = isc.render(report, now=2_000_000_000.0)
+    assert "unsegmented trunk/main work" in txt
+    assert "ev:99" in txt

--- a/scripts/validation/chquery.py
+++ b/scripts/validation/chquery.py
@@ -20,13 +20,17 @@ thing, all unit-testable WITHOUT a live ClickHouse:
      suite can verify the math independently of ClickHouse, and so the live
      assertions compare CH's answer against an independent computation.
 
-Timezone note (load-bearing): emit/spool_emit stamp `ts` with the host's LOCAL
-wall clock (`date +"%Y-%m-%d %H:%M:%S.%3N"`), and the `ts` column is a bare
-DateTime64(3) with NO column timezone. ClickHouse `toHour(ts)` therefore returns
-the LOCAL hour of the stored wall-clock value, which is what the heatmap wants.
-But `now()` / `today()` on the (UTC) server are in UTC, so any `ts <= now()`
-style comparison mixes a local wall-clock against a UTC clock. `hour_of_day()`
-here mirrors CH's behaviour: it reads the literal hour off the wall-clock string.
+Timezone note (load-bearing): emit/spool_emit stamp `ts` in UTC
+(`date -u +"%Y-%m-%d %H:%M:%S.%3N"` — see scripts/collector/tests/
+test_collector.py::test_emit_ts_is_utc), and the `ts` column is a bare
+DateTime64(3) with NO column timezone, so the stored wall-clock value IS the
+UTC instant. ClickHouse `toHour(ts)` therefore returns the UTC hour, and
+`now()` / `today()` on the (UTC) server are also UTC — so `ts <= now()`-style
+comparisons are apples-to-apples in UTC. The Grafana dashboard buckets/displays
+in the browser's local zone, but the raw column is UTC. `hour_of_day()` here
+mirrors CH's behaviour: it reads the literal (UTC) hour off the wall-clock
+string. (Earlier revisions of this header wrongly claimed `ts` was host-LOCAL —
+that was never true; emit has always used `date -u`.)
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## What this is

`scripts/session-analysis/initiative-scan.py` — a deterministic, read-only report that tracks ongoing **initiatives** (multi-session work threads, each anchored by a `claudedocs/handoff-*.md`) and their **progress / momentum / next step**.

It fills the gap left by `tmux-initiatives.sh` (Alt+i), which only shows *live tmux sessions* — ephemeral, lost on reboot. This is the durable, re-runnable analogue, in the style of `activity-scan.py` / `toil-scan.py`: ranked, skimmable, grouped by repo, momentum-tagged, with a "what to look for" header per section.

## The three sources it fuses

1. **Handoff docs = the initiative registry.** Globs `claudedocs/handoff-*.md` across active repos under `~/workspace` (+ one nested level, e.g. `~/workspace/civit/*`). Per doc it parses: slug (filename — handles date-suffix, date-prefix, no-date, and date-is-the-slug variants), title (first `# `), date, the first ranked item under `## Next steps`, and any `## Open investigations` sub-headings. **Dated variants of one base slug cluster into a single initiative** (newest doc = current state).
2. **git per repo** — fuzzy slug↔branch matching for `# commits` / `merged PRs` / `open PRs`. Commit counts **exclude the default branch** (`--not <default>`), so a feature branch is credited only with *its own* work — without this, every branch counted the whole trunk history in the window (I caught it crediting `app-blocks` with 5830 commits; correct count is 3).
3. **Activity telemetry** (ClickHouse `activity.events`, `source='claude'`) — recency / momentum / effort, keyed by `payload.gitBranch` + `cwd`. **Optional**: if `CLICKHOUSE_*` is unset or the endpoint is unreachable, the report degrades gracefully (telemetry columns drop) and is still produced from handoff + git. Reuses the `validation/chquery.py` client + the SOPS creds pattern verbatim from `activity-scan.py`.

Plus Claude transcripts (`~/.claude/projects/**/*.jsonl`): a session whose genesis names `handoff-<slug>.md` counts toward that initiative (`# sessions` + last-session-touched), reusing the genesis-parsing of `extract_genesis.py`.

**Momentum** = recency of the MAX touch across commit / telemetry / session / handoff-mtime: `●active <2d`, `◐slowing 2–7d`, `○stalled >7d`. Sorted by momentum then recency. A per-repo catch-all surfaces **unsegmented trunk/main work** honestly rather than dropping or mis-attributing it.

## Honesty caveats (read these)

- It measures **activity / recency / effort + the human-written next-step**, NOT semantic % completion. "Momentum" is recency of touch, not progress toward done.
- Initiative↔commit/PR/session linking is **heuristic slug matching**. Two real consequences visible in the sample below:
  - The `app-blocks` slug is a prefix of every `app-blocks-*` variant, so its 10 sibling handoffs share the same `commits:3 / merged-PR:7` (the slug genuinely substring-matches all those branches). Documented fuzziness, not a bug.
  - devrc's active initiatives show `ev:0` because the work flowed on branches like `feat/mail-actions-extractor` while the handoff slug is `mail-automation` — the heuristic correctly **does not force** that match. Those still attribute via genesis (`sess:1`) and via the trunk catch-all (`ev:115`).
- The trunk catch-all is large (dp-talos `ev:1195`, an unattributable-cwd bucket `ev:826`) — that's the "≈half of telemetry is on trunk/main and doesn't segment" the design called out, surfaced rather than hidden.
- Read-only throughout: no writes, no mutations, no network except the ClickHouse reader.

## Real sample output (live run, `--days 14`, telemetry ON)

Run end-to-end against live ClickHouse (workbench endpoint, reader creds via the SOPS pattern in the script header). Trimmed for length; the `app-blocks-*` block is elided (11 near-identical rows).

```
=== initiative-scan: trailing 14d (telemetry ON) ===
   Look for: what's in flight (●active <2d / ◐slowing 2-7d / ○stalled >7d), its momentum + next step. Momentum = recency of touch, NOT % done.

## civit/datapacket-talos   (24 initiatives)
  ●ACTIVE   app-blocks   touched 0m   sess:14   commits:3   merged-PR:7   ev:0
        “Handoff: App Blocks — picker + OAuth CLI + Gen Matrix live (2026-06-19)”
        next: (no Next-steps item parsed)
  ●ACTIVE   dp-prod-500-floor-resume   touched 3m   sess:1   commits:0   merged-PR:0   ev:0
        “Handoff: dp-prod 500-floor resume + redis fleet-wedge”
        next: #2816 empirical bake-check — multi-hour post-18:50 window (recipe above). Code+deploy already confirmed; this is just the statistical "0".
   …(9 more app-blocks-* variants, each commits:3 merged-PR:7 — shared by slug-prefix fuzziness)…
  ●ACTIVE   civitai-app-starters-blocks   touched 4h   sess:0   commits:5   merged-PR:9   ev:9
  ●ACTIVE   open-pr-sweep   touched 1d   sess:1   commits:0   merged-PR:0   ev:0
        next: Merge #226 (docs) — safe, no verify needed.
  ◐slowing  civitai-auth-observability   touched 3d   sess:0   commits:0   merged-PR:1   ev:19
  ◐slowing  grafana-alert-provisioning-drift   touched 4d   sess:1   commits:1   merged-PR:1   ev:0
  ◐slowing  sysredis-ha-cutover-complete   touched 4d   sess:0   commits:0   merged-PR:0   ev:0
        next: fal.ai 403 (active user impact): owner of civitai-orchestration to verify the fal.ai key/account …
  ○stalled  2026-05-25   touched 5w   sess:0   commits:0   merged-PR:0   ev:0
  ·trunk·  unsegmented trunk/main work   touched 0m   ev:1195
        (telemetry not attributable to any handoff — surfaced honestly, not dropped)

## devrc   (5 initiatives)
  ●ACTIVE   mail-automation   touched 10m   sess:1   commits:0   merged-PR:0   ev:0
        “Handoff — email-automation layer (`mail-actions`) shipped + closed”
        next: Next close-the-loop run should pick a NEW thread — this loop is closed. …
  ●ACTIVE   qa-automation   touched 6h   sess:1   commits:0   merged-PR:0   ev:0
        next: THE ORIGINAL UNTOUCHED THREAD — email automation on the live mail table …
  ●ACTIVE   activity-telemetry   touched 20h   sess:2   commits:0   merged-PR:0   ev:0
        “Handoff: activity-telemetry + self-hosted mail”
        (2 dated handoffs; current: handoff-activity-telemetry-2026-06-27.md)
  ●ACTIVE   task-spec-drafter   touched 23h   sess:1   commits:0   merged-PR:0   ev:0
  ◐slowing  productivity-tooling   touched 3d   sess:1   commits:0   merged-PR:0   ev:0
  ·trunk·  unsegmented trunk/main work   touched 13h   ev:115
        (telemetry not attributable to any handoff — surfaced honestly, not dropped)

## homelab-talos   (2 initiatives)
  ●ACTIVE   harness-tuning   touched 9m   sess:1   commits:0   merged-PR:0   ev:0
        next: spine-controller: decide fix-forward vs rollback. …
  ●ACTIVE   clawgate-authelia-tasks-queue   touched 1d   sess:1   commits:0   merged-PR:0   ev:0
  ·trunk·  unsegmented trunk/main work   touched 4d   ev:3

## learn-clawd   (1 initiative)
  ○stalled  remote-approval   touched 3w   sess:0   commits:0   merged-PR:0   ev:0

## (unknown repo)   (no handoffs)
  ·trunk·  unsegmented trunk/main work   touched 0m   ev:826
```

I also ran it **without** telemetry (`CLICKHOUSE_*` unset) to confirm graceful degradation — header reads `telemetry OFF — handoff+git only`, the `ev:` column drops, and it footers a NOTE explaining momentum then comes from commits + sessions + handoff mtime only. `--repo <path>`, `--json`, and the `--days 0` guard (exit 2) all verified.

## How to run

```bash
# handoff + git only (no creds needed)
nix-shell -p "python3.withPackages(p:[p.requests])" \
  --run "python scripts/session-analysis/initiative-scan.py --days 14"

# with telemetry — reader creds via SOPS (homelab-talos trunk), as in the script header
git -C ~/workspace/homelab-talos show origin/trunk:clusters/homelab/apps/activity/secrets.enc.yaml > /tmp/s.yaml
export CLICKHOUSE_PASSWORD=$(SOPS_AGE_KEY_FILE=~/workspace/homelab-talos/.secrets/age.key \
    sops -d --extract '["stringData"]["reader-password"]' /tmp/s.yaml); rm -f /tmp/s.yaml
export CLICKHOUSE_URL=http://192.168.50.94:30123 CLICKHOUSE_USER=activity_reader
nix-shell -p "python3.withPackages(p:[p.requests])" \
  --run "python scripts/session-analysis/initiative-scan.py --days 14"

# flags: --days N (default 14) · --json · --repo <path>
```

## Tests

```bash
nix-shell -p "python3.withPackages(p:[p.pytest p.requests])" \
  --run 'python -m pytest scripts/session-analysis/tests -q'
# -> 39 passed
```

`scripts/session-analysis/tests/test_initiative_scan.py` covers the pure logic with all I/O (git / gh / ClickHouse / transcripts) stubbed: handoff filename/title/next-step parsing, the **Open-investigations** section, **dated-variant clustering**, momentum classification at the **2d / 7d boundaries**, slug↔branch matching, the **default-branch commit exclusion**, telemetry attribution + trunk catch-all, and an end-to-end `build_report` + `render` pass (telemetry on and off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
