### PR TITLE
fix(tmux): cross-machine clipboard via OSC 52

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,6 +1,24 @@
+# ============================================
+# System clipboard via OSC 52 (works across SSH + nested tmux)
+# ============================================
+# set-clipboard on: tmux's OWN copy-mode yanks emit the OSC 52 escape so the
+# selection lands in the clipboard of the OUTER terminal emulator (the laptop's
+# alacritty) — even from a tmux on the headless workbench reached over SSH.
+# The default 'external' only RELAYS OSC 52 from apps inside tmux; it does NOT
+# emit for copy-mode copies, which is why `y` only ever hit the local (invisible
+# on the headless workbench) xclip selection and the copy appeared to vanish.
+set -s set-clipboard on
+# Advertise the OSC 52 (Ms) capability for every outer terminal regardless of
+# the reported TERM, so the escape is emitted whether the outer term identifies
+# as alacritty / xterm / screen.
+set -ga terminal-features '*:clipboard'
+
 bind-key -T copy-mode-vi v send-keys -X begin-selection
-bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel 'xclip -in -selection clipboard'
-bind -T copy-mode-vi Enter send -X copy-pipe-and-cancel 'xclip -in -selection clipboard'
+# No external command needed: set-clipboard on makes these emit OSC 52, setting
+# the laptop's system clipboard directly (and locally, via alacritty, the X
+# CLIPBOARD selection too — so GUI paste on the laptop also works).
+bind -T copy-mode-vi y send-keys -X copy-selection-and-cancel
+bind -T copy-mode-vi Enter send-keys -X copy-selection-and-cancel
 
 # Fast navigation in copy mode
 bind -T copy-mode-vi C-k send-keys -X -N 4 cursor-up
@@ -248,10 +266,13 @@ set -g message-style 'bg=#282828,fg=#ebdbb2'
 # ============================================
 # Named Buffers (1/2/3)
 # ============================================
-# Copy to register 1/2/3 in copy-mode (also to system clipboard)
-bind -T copy-mode-vi 1 send-keys -X copy-pipe-and-cancel "tee >(xclip -in -selection clipboard) | tmux set-buffer -b b1"
-bind -T copy-mode-vi 2 send-keys -X copy-pipe-and-cancel "tee >(xclip -in -selection clipboard) | tmux set-buffer -b b2"
-bind -T copy-mode-vi 3 send-keys -X copy-pipe-and-cancel "tee >(xclip -in -selection clipboard) | tmux set-buffer -b b3"
+# Copy to register 1/2/3 in copy-mode. load-buffer -b bN - reads the selection
+# from stdin into the named buffer (the old `set-buffer -b bN` ignored stdin and
+# saved empty buffers); set-clipboard on additionally emits OSC 52 to the system
+# clipboard, so no separate xclip pipe is needed.
+bind -T copy-mode-vi 1 send-keys -X copy-pipe-and-cancel "tmux load-buffer -b b1 -"
+bind -T copy-mode-vi 2 send-keys -X copy-pipe-and-cancel "tmux load-buffer -b b2 -"
+bind -T copy-mode-vi 3 send-keys -X copy-pipe-and-cancel "tmux load-buffer -b b3 -"
 
 # Paste from named buffers (prefix + Alt-1/2/3)
 bind M-1 paste-buffer -b b1

--- a/nix/programs/alacritty/default.nix
+++ b/nix/programs/alacritty/default.nix
@@ -8,6 +8,14 @@
       duration = 0;
     };
 
+    # Honor OSC 52 *copy* requests so tmux (incl. over SSH from the workbench)
+    # can set this laptop's system clipboard. "OnlyCopy" is alacritty's default
+    # but pinned here so the clipboard path can't silently break on a default
+    # change; paste-via-OSC52 stays disabled (it's a security footgun).
+    terminal = {
+      osc52 = "OnlyCopy";
+    };
+
     # Gruvbox Dark theme
     colors = {
       primary = {


### PR DESCRIPTION
## Problem
Copying in a tmux on the headless workbench (reached over SSH from the laptop) never reached the laptop's system clipboard, forcing a manual copy → browser → recopy → paste bridge.

## Root cause
`set-clipboard` defaulted to `external`: tmux only *relays* OSC 52 from apps running inside it and never *emits* OSC 52 for its own copy-mode yanks. So `y`/`Enter` only hit the local `xclip` selection — invisible on the headless workbench — and the copy appeared to vanish.

## Fix
- `set -s set-clipboard on` — copy-mode yanks now emit OSC 52, which rides up through SSH to the laptop's alacritty and sets the **laptop** clipboard. Works from both laptop-local and workbench-over-SSH tmux.
- `set -ga terminal-features '*:clipboard'` — emit the `Ms` escape regardless of the outer terminal's reported `TERM`.
- `y`/`Enter` → `copy-selection-and-cancel` (drop the redundant, headless-broken `xclip` pipe; OSC 52 also covers local GUI paste on the laptop).
- Named buffers `1/2/3`: `set-buffer` ignored stdin and saved **empty** buffers → `load-buffer -b bN -` now actually captures the selection.
- alacritty `terminal.osc52 = "OnlyCopy"` — pin the default so the clipboard path can't silently break; paste-via-OSC52 stays off (security).

## Test
In a workbench tmux pane (SSHed from the laptop):
\`\`\`bash
printf '\033]52;c;%s\a' "$(printf 'OSC52_WORKS' | base64)"
\`\`\`
then Ctrl+V on the laptop → `OSC52_WORKS`. Real path: copy-mode select + `y`, paste on the laptop.

Verified live on the workbench: `set-clipboard on`, `*:clipboard` feature active, cleaned bindings loaded. End-to-end laptop-clipboard leg requires the laptop deploy (ship.sh) + a human paste to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)