### PR TITLE
feat(repo-cos): v0 repo chief-of-staff — deterministic pre-scan + LLM proposal synthesis

### DIFF
--- a/scripts/repo-cos/README.md
+++ b/scripts/repo-cos/README.md
@@ -1,0 +1,103 @@
+# repo-cos — repo chief-of-staff (v0)
+
+An autonomous **idea-generation** experiment. Instead of Zach originating every task
+(CEO model), this scans his workbench codebases for improvement opportunities, ranks
+them, and (opt-in) emails the top few as bounded, evidence-backed proposals.
+
+**Quality bar:** a proposal earns a slot if it *increases productivity OR makes the
+repos/products better*. That bar is broad, so the slop-defense is **structural**, not
+wording:
+
+1. **Evidence-grounded** — every proposal cites concrete `repo/file:line` refs pulled
+   from a deterministic pre-scan. The LLM is told never to invent a file; the parser
+   drops any proposal whose evidence doesn't map back to a real candidate.
+2. **Hard cap** — output is capped to the top `--top` (default **5**) by leverage,
+   truncated even if the model returns more.
+3. **Bounded/shippable** — each proposal must be a finishable change an agent could
+   implement *and verify*, not "consider refactoring X someday".
+4. **CI-verifiable bias** — the pipeline prefers proposals whose value is
+   CI/test-verifiable (fix a skipped test, add a missing test, remove dead code, fix a
+   real bug) and ranks them above "nice idea, your call" items.
+
+This mirrors the proven `scripts/mail-actions/` pattern: a deterministic Stage-1 filter
+shrinks the corpus, then the LLM runs on the small survivor set.
+
+## Pipeline
+
+| Stage | Module | What | Cost |
+|-------|--------|------|------|
+| 1 | `prescan.py` | cheap grep/git signals, capped **per repo** | none |
+| 2 | `llm.py` | OpenRouter clusters survivors → ranked JSON proposals | one call |
+| 3 | `digest.py` | one formatter shared by stdout **and** email | none |
+| 4 | `email_send.py` | Gmail SMTP, gated behind `--email` (default OFF) | none |
+
+### Stage-1 signals (deterministic, evidence-bearing)
+
+- **markers** — `TODO|FIXME|HACK|XXX|BUG` (ripgrep, else python walk)
+- **skipped_test** — `@pytest.mark.skip`/`.skip(`/`xfail`/`it.skip`/`t.Skip(`/`#[ignore]` — a
+  skipped test is a concrete, CI-verifiable fix
+- **churn** — files changed most in the last ~90d (`git log --name-only --since`)
+- **large_file** — files over `LARGE_FILE_LOC` (800) LOC — split candidates
+- **stale_lock** — lockfiles untouched > 1y — best-effort dep-freshness
+
+Each signal is **capped per repo** (see `prescan.CAP_PER_SIGNAL`) so a huge repo like
+`civit/civitai` can't flood the LLM input, and a **global** `--limit-candidates` cap is
+applied by round-robin interleaving so no single repo monopolizes the budget.
+
+## Usage
+
+```sh
+# The free smoke test — Stage-1 only, no API key, no spend. Prints raw candidates.
+scripts/repo-cos/scan.py --no-llm --repos "$HOME/workspace/devrc,$HOME/workspace/homelab-talos"
+
+# Full dry run (DEFAULT) — Stage 1+2, prints the digest to stdout, sends NOTHING.
+OPENROUTER_API_KEY=... scripts/repo-cos/scan.py --dry-run
+
+# Send the digest (opt-in; default OFF). Same body the dry-run prints.
+OPENROUTER_API_KEY=... scripts/repo-cos/scan.py --email
+```
+
+Run under nix-shell (stdlib + requests only):
+
+```sh
+nix-shell -p 'python3.withPackages(p:[p.requests])' --run \
+  'python scripts/repo-cos/scan.py --dry-run'
+```
+
+Flags: `--dry-run` (default), `--email`, `--no-llm`/`--candidates-only`, `--repos`,
+`--limit-candidates N` (default 60), `--top N` (default 5), `--model` (default
+`deepseek/deepseek-v4-flash`), `--json`.
+
+## Repos
+
+Workbench-local. Discovers the default list, filtered to existing dirs. **`naida`/`vetr`
+live only on the LAPTOP (`~/workspace/scratch/`)** so this workbench tool can't see them
+yet.
+
+## Email secret
+
+`--email` reuses the **same Gmail app-password the mailbox sent-poller uses**: SOPS secret
+`mailbox-gmail-imap` on homelab-talos `origin/trunk`
+(`clusters/homelab/apps/mailbox/secrets-imap.enc.yaml`), keys `IMAP_USER` /
+`IMAP_APP_PASSWORD` — verified against `sent-poller.yaml` which mounts the same secret.
+The app password authenticates SMTP send just as it does IMAP read. Env overrides
+`REPO_COS_SMTP_USER` / `REPO_COS_SMTP_PASSWORD` win if set.
+
+## Step 2 (NOT built yet)
+
+A weekly, `serverMode`-gated **workbench systemd user timer** (mirroring
+`mail-actions-archive`) would run `scan.py --email` every Monday. It is deliberately NOT
+wired: we validate signal quality on a manual `--dry-run` first, then add the timer +
+home-manager unit in a follow-up once the proposals prove worth an inbox slot.
+
+## Tests
+
+```sh
+nix-shell -p 'python3.withPackages(p:[p.pytest p.requests])' --run \
+  'python -m pytest scripts/repo-cos/tests -q'
+```
+
+Covers the deterministic parts with fixtures: marker/skip extraction (file:line correct
+across languages), per-repo + global capping, churn/large/lockfile signals, the digest
+formatter, and the LLM JSON parse/repair + anti-slop filters. HTTP (OpenRouter) and SMTP
+are mocked — no live network in unit tests.

--- a/scripts/repo-cos/digest.py
+++ b/scripts/repo-cos/digest.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Digest formatting — one text renderer shared by --dry-run (stdout) and --email.
+
+Keeping a single formatter means the email body and the dry-run output are byte-identical,
+so validating signal quality on a dry-run genuinely validates what would be emailed.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+EFFORT_LABEL = {"S": "small", "M": "medium", "L": "large"}
+
+
+def subject(today: date | None = None) -> str:
+    d = today or date.today()
+    return f"🧭 Repo proposals — week of {d.isoformat()}"
+
+
+def render(proposals: list, *, today: date | None = None,
+           candidate_count: int | None = None,
+           approx_tokens: int | None = None) -> str:
+    """Render proposals (llm.Proposal objects) into a compact skimmable digest.
+
+    Empty proposal list is handled explicitly (honest 'nothing surfaced' message rather
+    than a blank email)."""
+    d = today or date.today()
+    lines: list[str] = [subject(d), ""]
+    if candidate_count is not None:
+        meta = f"From {candidate_count} deterministic signal(s)"
+        if approx_tokens is not None:
+            meta += f" · ~{approx_tokens} prompt tokens"
+        lines.append(meta)
+        lines.append("")
+
+    if not proposals:
+        lines.append("No bounded, evidence-backed proposals surfaced this run.")
+        lines.append("(That is a valid outcome — the bar is deliberately high.)")
+        return "\n".join(lines)
+
+    for i, p in enumerate(proposals, 1):
+        ci = "✅ CI-verifiable" if p.ci_verifiable else "○ needs judgement"
+        eff = EFFORT_LABEL.get(p.effort, p.effort)
+        lines.append(f"{i}. {p.title}  [{p.repo}]")
+        lines.append(f"   why:      {p.why}")
+        lines.append(f"   effort:   {eff}   {ci}")
+        if p.approach:
+            lines.append(f"   approach: {p.approach}")
+        lines.append("   evidence:")
+        for ref in p.evidence:
+            lines.append(f"     - {ref}")
+        lines.append("")
+
+    lines.append("—")
+    lines.append("repo-cos v0 · deterministic pre-scan → LLM synthesis · reply to steer.")
+    return "\n".join(lines).rstrip() + "\n"

--- a/scripts/repo-cos/email_send.py
+++ b/scripts/repo-cos/email_send.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Email sender — Gmail SMTP (STARTTLS), gated behind --email (default OFF).
+
+Reuses the SAME Gmail app-password the mailbox sent-poller uses: SOPS secret
+`mailbox-gmail-imap` in homelab-talos trunk, key `IMAP_APP_PASSWORD` (user `IMAP_USER`).
+The app password authenticates SMTP (send) just as it does IMAP (read) for that account.
+
+Secret resolution (verified against
+  homelab-talos:origin/trunk:clusters/homelab/apps/mailbox/secrets-imap.enc.yaml
+  and .../sent-poller.yaml which mounts the same secret):
+
+  SOPS_AGE_KEY_FILE=~/workspace/homelab-talos/.secrets/age.key \
+    sops -d --extract '["stringData"]["IMAP_APP_PASSWORD"]' /tmp/s.yaml
+
+The network send is isolated in `_smtp_send` so `send_digest` is unit-testable with a
+mock (no real SMTP in tests).
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import smtplib
+import subprocess
+import tempfile
+from email.message import EmailMessage
+from pathlib import Path
+
+SMTP_HOST = "smtp.gmail.com"
+SMTP_PORT = 587
+
+# SOPS secret coordinates — verified against homelab-talos trunk (see module docstring).
+HOMELAB = Path("~/workspace/homelab-talos").expanduser()
+SECRET_FILE = "clusters/homelab/apps/mailbox/secrets-imap.enc.yaml"
+SECRET_USER_KEY = "IMAP_USER"           # value: zachlowden1@gmail.com
+SECRET_PASSWORD_KEY = "IMAP_APP_PASSWORD"
+AGE_KEY_FILE = HOMELAB / ".secrets" / "age.key"
+
+OWNER_EMAIL = "zachlowden1@gmail.com"
+
+
+class EmailError(RuntimeError):
+    pass
+
+
+def _sops_extract(key: str) -> str:
+    """Decrypt one stringData key from the mailbox IMAP secret on homelab trunk.
+
+    Fetches the file content from `origin/trunk` via `git show` (no checkout needed) into
+    a temp file, then `sops -d --extract`. `sops` is provided ad-hoc via nix-shell if not
+    already on PATH.
+    """
+    if not AGE_KEY_FILE.exists():
+        raise EmailError(f"age key not found at {AGE_KEY_FILE}")
+    try:
+        blob = subprocess.run(
+            ["git", "-C", str(HOMELAB), "show", f"origin/trunk:{SECRET_FILE}"],
+            capture_output=True, text=True, check=True, timeout=30,
+        ).stdout
+    except subprocess.CalledProcessError as exc:
+        raise EmailError(f"git show failed for {SECRET_FILE}: {exc.stderr.strip()}") from exc
+
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as tf:
+        tf.write(blob)
+        tmp = tf.name
+    try:
+        env = dict(os.environ, SOPS_AGE_KEY_FILE=str(AGE_KEY_FILE))
+        extract = f'["stringData"]["{key}"]'
+        if shutil.which("sops"):
+            cmd = ["sops", "-d", "--extract", extract, tmp]
+        else:
+            # ad-hoc sops via nix-shell (NixOS host, no global install)
+            cmd = ["nix-shell", "-p", "sops", "--run",
+                   f"sops -d --extract '{extract}' {tmp}"]
+        proc = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=120)
+        if proc.returncode != 0:
+            raise EmailError(f"sops decrypt failed for key {key}: {proc.stderr.strip()}")
+        return proc.stdout.strip()
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def load_credentials() -> tuple[str, str]:
+    """Return (username, app_password). Env overrides (REPO_COS_SMTP_USER /
+    REPO_COS_SMTP_PASSWORD) win so a caller can supply creds without SOPS; otherwise
+    decrypt from the mailbox secret."""
+    user = os.environ.get("REPO_COS_SMTP_USER")
+    pw = os.environ.get("REPO_COS_SMTP_PASSWORD")
+    if user and pw:
+        return user, pw
+    user = user or _sops_extract(SECRET_USER_KEY) or OWNER_EMAIL
+    pw = pw or _sops_extract(SECRET_PASSWORD_KEY)
+    if not pw:
+        raise EmailError("no SMTP app password resolved (env or SOPS)")
+    return user, pw
+
+
+def build_message(*, subject: str, body: str, from_addr: str, to_addr: str) -> EmailMessage:
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = from_addr
+    msg["To"] = to_addr
+    msg.set_content(body)
+    return msg
+
+
+def _smtp_send(msg: EmailMessage, *, user: str, password: str,
+               host: str = SMTP_HOST, port: int = SMTP_PORT) -> None:
+    """Isolated network send — mocked in tests."""
+    with smtplib.SMTP(host, port, timeout=30) as smtp:
+        smtp.starttls()
+        smtp.login(user, password)
+        smtp.send_message(msg)
+
+
+def send_digest(*, subject: str, body: str, to_addr: str = OWNER_EMAIL,
+                _sender=_smtp_send, _creds=load_credentials) -> str:
+    """Resolve creds, build the message, send it. Returns the recipient on success.
+    `_sender`/`_creds` are injectable for tests."""
+    user, password = _creds()
+    from_addr = user or OWNER_EMAIL
+    msg = build_message(subject=subject, body=body, from_addr=from_addr, to_addr=to_addr)
+    _sender(msg, user=user, password=password)
+    return to_addr

--- a/scripts/repo-cos/email_send.py
+++ b/scripts/repo-cos/email_send.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import os
 import shutil
 import smtplib
+import ssl
 import subprocess
 import tempfile
 from email.message import EmailMessage
@@ -110,7 +111,9 @@ def _smtp_send(msg: EmailMessage, *, user: str, password: str,
                host: str = SMTP_HOST, port: int = SMTP_PORT) -> None:
     """Isolated network send — mocked in tests."""
     with smtplib.SMTP(host, port, timeout=30) as smtp:
-        smtp.starttls()
+        # Verify the server cert + hostname — a bare starttls() uses an unverified
+        # context (CERT_NONE), letting an on-path attacker capture the app-password.
+        smtp.starttls(context=ssl.create_default_context())
         smtp.login(user, password)
         smtp.send_message(msg)
 

--- a/scripts/repo-cos/llm.py
+++ b/scripts/repo-cos/llm.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""LLM synthesis — cluster deterministic candidates into ranked, shippable proposals.
+
+Stage-2 of repo-cos (survivors only). Mirrors `scripts/mail-actions/llm.py`: the
+network call is isolated in `_call_openrouter` so the parser/validator
+(`parse_proposals`) is unit-testable with no key/network, and there is a single
+malformed-output retry.
+
+The anti-slop mandate is enforced STRUCTURALLY here as well as in the prompt:
+  * output is HARD-CAPPED to `top` proposals (we truncate even if the model returns more);
+  * every proposal MUST carry >=1 concrete `file:line` evidence ref drawn from the
+    candidate set — proposals with no evidence are DROPPED in the parser;
+  * proposals are re-sorted to put `ci_verifiable` first (bias toward CI/test-verifiable
+    fixes), the model's order broken only as a tie-breaker.
+
+JSON contract per proposal:
+  {title, repo, evidence:[ref...], why, effort (S|M|L), approach, ci_verifiable (bool)}
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass, field
+
+DEFAULT_MODEL = "deepseek/deepseek-v4-flash"
+OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+SYSTEM_PROMPT = (
+    "You are a pragmatic engineering chief-of-staff. You are given a list of RAW, "
+    "deterministic signals mined from a developer's git repos (TODO/FIXME markers, "
+    "skipped/xfail tests, high-churn files, oversized files, stale lockfiles), each with "
+    "a concrete repo/file:line reference. Your job: CLUSTER these into a small set of "
+    "BOUNDED, SHIPPABLE improvement PROPOSALS that an agent could implement AND verify in "
+    "one sitting.\n\n"
+    "HARD RULES:\n"
+    "1. Return AT MOST {top} proposals, ranked best-first by leverage "
+    "(productivity gain OR making the repo/product better).\n"
+    "2. Every proposal MUST cite at least one exact evidence ref taken verbatim from the "
+    "input candidates (the 'ref' field). Never invent a file or line.\n"
+    "3. Strongly PREFER proposals whose value is CI/test-verifiable (fix a skipped/flaky "
+    "test, add a missing test, remove dead code, fix a concrete bug). Set ci_verifiable=true "
+    "for these and rank them above vague 'nice idea' items.\n"
+    "4. DROP vague, speculative, or unbounded proposals. A proposal must be a specific, "
+    "finishable change — not 'consider refactoring X someday'.\n"
+    "5. Keep each proposal tight: one clear change with a 1-2 line approach.\n\n"
+    "Return ONLY a JSON object: {\"proposals\": [ {title, repo, evidence (array of ref "
+    "strings), why (string: 1 line, productivity or repo/product-better), effort (one of "
+    "\"S\",\"M\",\"L\"), approach (1-2 lines), ci_verifiable (bool)} ] }. No prose."
+)
+
+VALID_EFFORT = {"S", "M", "L"}
+
+
+@dataclass(frozen=True)
+class Proposal:
+    title: str
+    repo: str
+    evidence: list[str]
+    why: str
+    effort: str
+    approach: str
+    ci_verifiable: bool
+
+    def as_dict(self) -> dict:
+        return {
+            "title": self.title, "repo": self.repo, "evidence": list(self.evidence),
+            "why": self.why, "effort": self.effort, "approach": self.approach,
+            "ci_verifiable": self.ci_verifiable,
+        }
+
+
+@dataclass
+class Synthesis:
+    proposals: list[Proposal] = field(default_factory=list)
+    approx_prompt_tokens: int = 0
+    model: str = DEFAULT_MODEL
+
+
+class SynthesisError(ValueError):
+    """Raised when the model output cannot be parsed into valid proposals."""
+
+
+def _coerce_bool(v) -> bool:
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, str):
+        return v.strip().lower() in ("true", "yes", "1")
+    return bool(v)
+
+
+def _strip_to_json(text: str) -> str:
+    """Pull the first {...} block out of a possibly-fenced model reply."""
+    text = (text or "").strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```[a-zA-Z]*\n?", "", text)
+        text = re.sub(r"\n?```$", "", text).strip()
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end < start:
+        raise SynthesisError("no JSON object found in model output")
+    return text[start : end + 1]
+
+
+def parse_proposals(text: str, *, top: int, valid_refs: set[str] | None = None) -> list[Proposal]:
+    """Parse + validate model output into ranked Proposals. Raises SynthesisError on
+    unparseable JSON or a missing `proposals` array.
+
+    Structural anti-slop enforcement (does NOT raise — just filters):
+      * a proposal with no non-empty evidence ref is DROPPED;
+      * if `valid_refs` is given, evidence refs not present in the candidate set are
+        stripped, and a proposal left with zero valid refs is DROPPED (stops the model
+        inventing files);
+      * effort is normalized to S/M/L (default M);
+      * the list is re-sorted ci_verifiable-first (stable within each group) and then
+        HARD-CAPPED to `top`.
+    """
+    try:
+        obj = json.loads(_strip_to_json(text))
+    except json.JSONDecodeError as exc:
+        raise SynthesisError(f"invalid JSON: {exc}") from exc
+    if not isinstance(obj, dict) or "proposals" not in obj:
+        raise SynthesisError("missing 'proposals' array")
+    raw = obj["proposals"]
+    if not isinstance(raw, list):
+        raise SynthesisError("'proposals' is not a list")
+
+    out: list[Proposal] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        ev_in = item.get("evidence") or []
+        if isinstance(ev_in, str):
+            ev_in = [ev_in]
+        evidence = [str(e).strip() for e in ev_in if str(e).strip()]
+        if valid_refs is not None:
+            evidence = [e for e in evidence if _ref_known(e, valid_refs)]
+        if not evidence:  # anti-slop: no concrete evidence → drop
+            continue
+        effort = str(item.get("effort") or "M").strip().upper()
+        if effort not in VALID_EFFORT:
+            effort = "M"
+        title = str(item.get("title") or "").strip()
+        if not title:
+            continue
+        out.append(Proposal(
+            title=title,
+            repo=str(item.get("repo") or "").strip(),
+            evidence=evidence,
+            why=str(item.get("why") or "").strip(),
+            effort=effort,
+            approach=str(item.get("approach") or "").strip(),
+            ci_verifiable=_coerce_bool(item.get("ci_verifiable")),
+        ))
+
+    # ci_verifiable-first, preserving the model's within-group ranking (stable sort).
+    out.sort(key=lambda p: 0 if p.ci_verifiable else 1)
+    return out[:top]
+
+
+def _ref_known(ref: str, valid_refs: set[str]) -> bool:
+    """A model ref counts as valid if it exactly matches a candidate ref, OR the
+    candidate ref starts with it (model may drop the :line), OR vice-versa. Tolerant
+    but still anchored to a real candidate path."""
+    if ref in valid_refs:
+        return True
+    for v in valid_refs:
+        if v == ref or v.startswith(ref) or ref.startswith(v):
+            return True
+        # match on the path portion (ignore line numbers on both sides)
+        if v.split(":", 1)[0] == ref.split(":", 1)[0]:
+            return True
+    return False
+
+
+def build_user_prompt(candidates: list[dict], *, top: int) -> str:
+    """Render the capped candidate evidence compactly (one line each) for the model."""
+    lines = [
+        f"Cluster these {len(candidates)} raw signals into at most {top} bounded, "
+        "shippable, ranked proposals per the rules. Candidates (kind | ref | detail):",
+        "",
+    ]
+    for c in candidates:
+        detail = (c.get("text") or "").replace("\n", " ")[:160]
+        lines.append(f"- {c['kind']:<12} {c['ref']}  {detail}")
+    return "\n".join(lines)
+
+
+def _approx_tokens(text: str) -> int:
+    """Rough token estimate (~4 chars/token) for the cost log. Order-of-magnitude only."""
+    return max(1, len(text) // 4)
+
+
+def _call_openrouter(model: str, system: str, user: str, api_key: str,
+                     timeout: float = 90.0) -> str:
+    """POST to OpenRouter; return the assistant message content. Network-only — mocked in tests."""
+    import requests
+
+    resp = requests.post(
+        OPENROUTER_URL,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "X-Title": "devrc-repo-cos",
+        },
+        json={
+            "model": model,
+            "temperature": 0,
+            "response_format": {"type": "json_object"},
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+        },
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return data["choices"][0]["message"]["content"]
+
+
+def synthesize(
+    candidates: list[dict],
+    *,
+    top: int = 5,
+    model: str | None = None,
+    api_key: str | None = None,
+    _caller=_call_openrouter,
+) -> Synthesis:
+    """Run one synthesis call with a single malformed-output retry. `_caller` injectable.
+
+    `candidates` are candidate dicts (from Candidate.as_dict); each must have `kind`,
+    `ref`, `text`. Returns a Synthesis (proposals + approx token count).
+    """
+    model = model or os.environ.get("REPO_COS_MODEL", DEFAULT_MODEL)
+    api_key = api_key or os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENROUTER_API_KEY not set")
+    system = SYSTEM_PROMPT.replace("{top}", str(top))
+    user = build_user_prompt(candidates, top=top)
+    valid_refs = {c["ref"] for c in candidates if c.get("ref")}
+    approx = _approx_tokens(system) + _approx_tokens(user)
+
+    last_err: Exception | None = None
+    for _ in range(2):  # one retry on malformed output
+        raw = _caller(model, system, user, api_key)
+        try:
+            props = parse_proposals(raw, top=top, valid_refs=valid_refs)
+            return Synthesis(proposals=props, approx_prompt_tokens=approx, model=model)
+        except SynthesisError as exc:
+            last_err = exc
+    raise SynthesisError(f"model output invalid after retry: {last_err}")

--- a/scripts/repo-cos/llm.py
+++ b/scripts/repo-cos/llm.py
@@ -159,18 +159,14 @@ def parse_proposals(text: str, *, top: int, valid_refs: set[str] | None = None) 
 
 
 def _ref_known(ref: str, valid_refs: set[str]) -> bool:
-    """A model ref counts as valid if it exactly matches a candidate ref, OR the
-    candidate ref starts with it (model may drop the :line), OR vice-versa. Tolerant
-    but still anchored to a real candidate path."""
+    """A model ref is valid ONLY if it exactly matches a candidate ref, or matches a
+    candidate's file PATH exactly (the model may drop/alter the `:line`). No prefix
+    matching — a bare repo name or truncated path must NOT pass, or the "drop invented
+    refs" anti-slop guarantee is hollow (a model could cite `devrc` and survive)."""
     if ref in valid_refs:
         return True
-    for v in valid_refs:
-        if v == ref or v.startswith(ref) or ref.startswith(v):
-            return True
-        # match on the path portion (ignore line numbers on both sides)
-        if v.split(":", 1)[0] == ref.split(":", 1)[0]:
-            return True
-    return False
+    ref_path = ref.split(":", 1)[0]
+    return any(v.split(":", 1)[0] == ref_path for v in valid_refs)
 
 
 def build_user_prompt(candidates: list[dict], *, top: int) -> str:
@@ -227,10 +223,13 @@ def synthesize(
     api_key: str | None = None,
     _caller=_call_openrouter,
 ) -> Synthesis:
-    """Run one synthesis call with a single malformed-output retry. `_caller` injectable.
+    """Synthesize proposals, retrying on malformed OR empty output. `_caller` injectable.
 
-    `candidates` are candidate dicts (from Candidate.as_dict); each must have `kind`,
-    `ref`, `text`. Returns a Synthesis (proposals + approx token count).
+    DeepSeek rotates its output even at temperature=0, so an identical candidate set
+    can yield 4-5 good proposals one call and 0 the next. Retrying up to 3× when there
+    ARE candidates kills that empty-tail (a weekly digest should not be blank while real
+    signals exist); we still emit an honest empty result if the model surfaces nothing
+    across every attempt. `candidates` are candidate dicts (kind/ref/text).
     """
     model = model or os.environ.get("REPO_COS_MODEL", DEFAULT_MODEL)
     api_key = api_key or os.environ.get("OPENROUTER_API_KEY")
@@ -242,11 +241,18 @@ def synthesize(
     approx = _approx_tokens(system) + _approx_tokens(user)
 
     last_err: Exception | None = None
-    for _ in range(2):  # one retry on malformed output
+    last_ok: list | None = None
+    attempts = 3 if valid_refs else 1  # only worth re-rolling when candidates exist
+    for _ in range(attempts):
         raw = _caller(model, system, user, api_key)
         try:
             props = parse_proposals(raw, top=top, valid_refs=valid_refs)
-            return Synthesis(proposals=props, approx_prompt_tokens=approx, model=model)
         except SynthesisError as exc:
             last_err = exc
-    raise SynthesisError(f"model output invalid after retry: {last_err}")
+            continue
+        if props:  # non-empty — done
+            return Synthesis(proposals=props, approx_prompt_tokens=approx, model=model)
+        last_ok = props  # valid but empty — re-roll, but remember it
+    if last_ok is not None:  # genuinely nothing surfaced after every attempt
+        return Synthesis(proposals=last_ok, approx_prompt_tokens=approx, model=model)
+    raise SynthesisError(f"model output invalid after {attempts} attempt(s): {last_err}")

--- a/scripts/repo-cos/prescan.py
+++ b/scripts/repo-cos/prescan.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Deterministic pre-scan — evidence-grounded improvement candidates, no LLM.
+
+Cheap grep/git-based signal collection. Every candidate carries a repo + `file:line`
+so nothing reaching the LLM (or the digest) is unsubstantiated. This is the Stage-1
+of the repo-cos pipeline, mirroring `scripts/mail-actions/filter.py`: a pure,
+unit-testable filter that shrinks the corpus to a small, capped set of survivors the
+LLM then clusters/ranks.
+
+Signal types (each capped PER REPO so a huge repo like civit/civitai can't flood the
+LLM input):
+  marker        TODO|FIXME|HACK|XXX|BUG comments               (file:line + text)
+  skipped_test  @pytest.mark.skip / .skip( / xfail / t.Skip( / #[ignore] …  (CI-verifiable)
+  churn         files changed most in the last ~90 days        (refactor/stability)
+  large_file    files over a LOC threshold                     (split candidate)
+  stale_lock    lockfiles older than a threshold               (dep-freshness, best-effort)
+
+Everything is deterministic and ordered so the same repo state yields the same
+candidates (important for a weekly digest that shouldn't churn).
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ---- tunables (kept as module constants so tests can reference them) ----------
+MARKER_RE = re.compile(r"\b(TODO|FIXME|HACK|XXX|BUG)\b")
+# Skipped/xfail test patterns across the languages in Zach's repos. Kept as literal
+# substrings/regex fragments — intentionally broad-but-cheap (a false positive is a
+# candidate the LLM can drop, not a correctness bug).
+SKIP_PATTERNS: tuple[tuple[str, re.Pattern], ...] = (
+    ("pytest.skip", re.compile(r"@pytest\.mark\.(skip|skipif|xfail)")),
+    ("pytest.skip-call", re.compile(r"pytest\.skip\(")),
+    ("js.skip", re.compile(r"\b(it|describe|test)\.skip\(")),
+    ("js.xfail", re.compile(r"\.(only)\(")),  # .only leaves the rest un-run — same smell
+    ("go.skip", re.compile(r"\bt\.Skip(f|Now)?\(")),
+    ("rust.ignore", re.compile(r"#\[ignore")),
+    ("unittest.skip", re.compile(r"@unittest\.skip")),
+)
+
+LARGE_FILE_LOC = 800  # files bigger than this are split candidates
+STALE_LOCK_DAYS = 365  # lockfiles older than this are flagged (best-effort, cheap)
+CHURN_SINCE = "90 days ago"
+
+# Per-repo caps — the whole point of keeping LLM input small + cheap on big repos.
+CAP_PER_SIGNAL = {
+    "marker": 8,
+    "skipped_test": 8,
+    "churn": 6,
+    "large_file": 5,
+    "stale_lock": 3,
+}
+
+# Directories never worth scanning (vendored / generated / VCS internals).
+PRUNE_DIRS = {
+    ".git", "node_modules", "vendor", "dist", "build", ".next", "target",
+    "__pycache__", ".venv", "venv", ".mypy_cache", ".pytest_cache", ".terraform",
+    "site-packages", ".cache", "coverage", ".nyc_output", "out", ".serena",
+    ".claude",  # nested Claude worktrees / config — never source-of-record
+}
+# Only text/code files we can cheaply line-scan. Binary/asset extensions are skipped.
+SCAN_EXTS = {
+    ".py", ".js", ".jsx", ".ts", ".tsx", ".go", ".rs", ".rb", ".java", ".kt",
+    ".c", ".cc", ".cpp", ".h", ".hpp", ".sh", ".bash", ".zsh", ".nix", ".lua",
+    ".vim", ".yaml", ".yml", ".toml", ".sql", ".tf", ".vue", ".svelte",
+}
+LOCKFILES = {
+    "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "poetry.lock",
+    "Cargo.lock", "go.sum", "Gemfile.lock", "flake.lock", "composer.lock",
+}
+MAX_LINE_LEN = 400  # ignore absurdly long (likely minified) lines when marker-scanning
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One piece of deterministic evidence. `file` is repo-relative; `line` is 1-based
+    (0 for whole-file signals like churn/large_file that aren't tied to a line)."""
+    repo: str          # repo display name (basename)
+    kind: str          # one of CAP_PER_SIGNAL keys
+    file: str          # repo-relative path
+    line: int          # 1-based line number, or 0 for file-level signals
+    text: str          # the evidence line / a short descriptor
+
+    @property
+    def ref(self) -> str:
+        """Compact `repo/path:line` reference used in evidence lists."""
+        loc = f":{self.line}" if self.line else ""
+        return f"{self.repo}/{self.file}{loc}"
+
+    def as_dict(self) -> dict:
+        return {
+            "repo": self.repo, "kind": self.kind, "file": self.file,
+            "line": self.line, "text": self.text, "ref": self.ref,
+        }
+
+
+@dataclass
+class RepoScan:
+    repo: str
+    path: str
+    candidates: list[Candidate] = field(default_factory=list)
+    error: str | None = None
+
+
+# ---- filesystem walk ----------------------------------------------------------
+
+def _iter_files(root: Path):
+    """Yield scannable files under `root`, pruning vendored/generated dirs. Sorted
+    within each directory for deterministic ordering."""
+    for dirpath, dirnames, filenames in os.walk(root):
+        # prune in-place so os.walk doesn't descend into them. Skip explicit prune dirs
+        # AND all hidden dirs (dotdirs are config/state, rarely source-of-record, and
+        # include nested .git/.claude worktrees that would pollute results).
+        dirnames[:] = sorted(
+            d for d in dirnames if d not in PRUNE_DIRS and not d.startswith("."))
+        for name in sorted(filenames):
+            yield Path(dirpath) / name
+
+
+def _rel(root: Path, p: Path) -> str:
+    try:
+        return str(p.relative_to(root))
+    except ValueError:
+        return str(p)
+
+
+# ---- signal: markers ----------------------------------------------------------
+
+def scan_markers(root: Path, repo: str, cap: int) -> list[Candidate]:
+    """Prefer ripgrep (fast, respects .gitignore) but fall back to a python walk so the
+    module works with no external tools. Deterministic ordering; capped."""
+    if shutil.which("rg"):
+        out = _rg_markers(root)
+    else:
+        out = _walk_markers(root)
+    # Deterministic order: by path then line.
+    out.sort(key=lambda c: (c.file, c.line))
+    return [_reref(c, repo) for c in out[:cap]]
+
+
+def _reref(c: Candidate, repo: str) -> Candidate:
+    return Candidate(repo=repo, kind=c.kind, file=c.file, line=c.line, text=c.text)
+
+
+def _rg_markers(root: Path) -> list[Candidate]:
+    globs = []
+    for d in PRUNE_DIRS:
+        globs += ["-g", f"!{d}/"]
+    try:
+        proc = subprocess.run(
+            ["rg", "--no-heading", "--line-number", "--color", "never",
+             "--max-columns", str(MAX_LINE_LEN), *globs,
+             r"\b(TODO|FIXME|HACK|XXX|BUG)\b", str(root)],
+            capture_output=True, text=True, timeout=60,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return _walk_markers(root)
+    res: list[Candidate] = []
+    for ln in proc.stdout.splitlines():
+        # format: path:line:content
+        parts = ln.split(":", 2)
+        if len(parts) < 3:
+            continue
+        path, lno, content = parts
+        if not lno.isdigit():
+            continue
+        rel = _rel(root, Path(path))
+        res.append(Candidate("", "marker", rel, int(lno), content.strip()[:200]))
+    return res
+
+
+def _walk_markers(root: Path) -> list[Candidate]:
+    res: list[Candidate] = []
+    for p in _iter_files(root):
+        if p.suffix not in SCAN_EXTS:
+            continue
+        try:
+            with p.open("r", encoding="utf-8", errors="ignore") as fh:
+                for i, line in enumerate(fh, 1):
+                    if len(line) > MAX_LINE_LEN:
+                        continue
+                    if MARKER_RE.search(line):
+                        res.append(Candidate(
+                            "", "marker", _rel(root, p), i, line.strip()[:200]))
+        except (OSError, UnicodeError):
+            continue
+    return res
+
+
+# ---- signal: skipped/xfail tests ---------------------------------------------
+
+def scan_skipped_tests(root: Path, repo: str, cap: int) -> list[Candidate]:
+    """Line-scan for skip/xfail/ignore markers across languages. A skipped test is a
+    concrete, CI-verifiable fix — bias the LLM toward these."""
+    res: list[Candidate] = []
+    for p in _iter_files(root):
+        if p.suffix not in SCAN_EXTS:
+            continue
+        try:
+            with p.open("r", encoding="utf-8", errors="ignore") as fh:
+                lines = fh.readlines()
+        except (OSError, UnicodeError):
+            continue
+        for i, line in enumerate(lines, 1):
+            if len(line) > MAX_LINE_LEN:
+                continue
+            for label, pat in SKIP_PATTERNS:
+                if pat.search(line):
+                    res.append(Candidate(
+                        repo, "skipped_test", _rel(root, p), i,
+                        f"[{label}] {line.strip()[:180]}"))
+                    break
+    res.sort(key=lambda c: (c.file, c.line))
+    return res[:cap]
+
+
+# ---- signal: churn hotspots (git) --------------------------------------------
+
+def scan_churn(root: Path, repo: str, cap: int) -> list[Candidate]:
+    """Files changed most often in the last ~90 days. High-churn = refactor/stability
+    candidate. Returns [] if not a git repo or git is unavailable."""
+    if not (root / ".git").exists() and not _is_git_worktree(root):
+        return []
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(root), "log", f"--since={CHURN_SINCE}",
+             "--name-only", "--pretty=format:", "--no-merges"],
+            capture_output=True, text=True, timeout=60,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+    counts: dict[str, int] = {}
+    for line in proc.stdout.splitlines():
+        f = line.strip()
+        if not f:
+            continue
+        top = f.split("/", 1)[0]
+        if top in PRUNE_DIRS:
+            continue
+        # only count files that still exist (renames/deletes shouldn't dominate)
+        if not (root / f).exists():
+            continue
+        counts[f] = counts.get(f, 0) + 1
+    # Rank by count desc, then path for determinism. Require >=3 changes to be a "hotspot".
+    ranked = sorted(
+        ((f, n) for f, n in counts.items() if n >= 3),
+        key=lambda kv: (-kv[1], kv[0]),
+    )
+    return [
+        Candidate(repo, "churn", f, 0, f"{n} changes in last 90d")
+        for f, n in ranked[:cap]
+    ]
+
+
+def _is_git_worktree(root: Path) -> bool:
+    # a linked worktree has a .git *file* (gitdir pointer), not a dir
+    gp = root / ".git"
+    return gp.is_file()
+
+
+# ---- signal: large files ------------------------------------------------------
+
+def scan_large_files(root: Path, repo: str, cap: int, threshold: int = LARGE_FILE_LOC) -> list[Candidate]:
+    """Source files over `threshold` LOC — split/refactor candidates."""
+    res: list[Candidate] = []
+    for p in _iter_files(root):
+        if p.suffix not in SCAN_EXTS:
+            continue
+        try:
+            with p.open("rb") as fh:
+                loc = sum(1 for _ in fh)
+        except OSError:
+            continue
+        if loc > threshold:
+            res.append(Candidate(repo, "large_file", _rel(root, p), 0, f"{loc} LOC"))
+    res.sort(key=lambda c: (-int(c.text.split()[0]), c.file))
+    return res[:cap]
+
+
+# ---- signal: stale lockfiles --------------------------------------------------
+
+def scan_stale_locks(root: Path, repo: str, cap: int, now: float | None = None,
+                     max_age_days: int = STALE_LOCK_DAYS) -> list[Candidate]:
+    """Flag lockfiles whose mtime is older than `max_age_days`. Cheap dep-freshness
+    proxy; intentionally conservative to avoid noise. `now` is injectable for tests."""
+    import time
+    now = now if now is not None else time.time()
+    res: list[Candidate] = []
+    for p in _iter_files(root):
+        if p.name not in LOCKFILES:
+            continue
+        try:
+            age_days = (now - p.stat().st_mtime) / 86400.0
+        except OSError:
+            continue
+        if age_days > max_age_days:
+            res.append(Candidate(
+                repo, "stale_lock", _rel(root, p), 0,
+                f"lockfile untouched {int(age_days)}d"))
+    res.sort(key=lambda c: c.file)
+    return res[:cap]
+
+
+# ---- per-repo orchestration ---------------------------------------------------
+
+def scan_repo(path: str, caps: dict[str, int] | None = None) -> RepoScan:
+    """Run every signal against one repo, each capped. Missing repo → RepoScan.error."""
+    caps = caps or CAP_PER_SIGNAL
+    root = Path(path).expanduser()
+    repo = root.name
+    rs = RepoScan(repo=repo, path=str(root))
+    if not root.exists() or not root.is_dir():
+        rs.error = "not a directory"
+        return rs
+    try:
+        rs.candidates += scan_markers(root, repo, caps.get("marker", 8))
+        rs.candidates += scan_skipped_tests(root, repo, caps.get("skipped_test", 8))
+        rs.candidates += scan_churn(root, repo, caps.get("churn", 6))
+        rs.candidates += scan_large_files(root, repo, caps.get("large_file", 5))
+        rs.candidates += scan_stale_locks(root, repo, caps.get("stale_lock", 3))
+    except Exception as exc:  # noqa: BLE001 — one bad repo shouldn't kill the scan
+        rs.error = f"{type(exc).__name__}: {exc}"
+    return rs
+
+
+def scan_all(repos: list[str], limit_candidates: int,
+             caps: dict[str, int] | None = None) -> tuple[list[Candidate], list[RepoScan]]:
+    """Scan every repo, then apply a GLOBAL cap (`limit_candidates`) across all of them
+    using round-robin interleaving so no single repo monopolizes the LLM budget.
+
+    Returns (capped_candidates, per_repo_scans). The per-repo scans retain their full
+    (pre-global-cap) candidate lists for reporting/--candidates-only.
+    """
+    scans = [scan_repo(r, caps) for r in repos]
+    capped = _interleave_cap([s.candidates for s in scans], limit_candidates)
+    return capped, scans
+
+
+def _interleave_cap(per_repo: list[list[Candidate]], limit: int) -> list[Candidate]:
+    """Round-robin across repos so the global cap is spread fairly rather than eaten by
+    the first (possibly huge) repo. Deterministic given deterministic inputs."""
+    out: list[Candidate] = []
+    idx = 0
+    active = [list(lst) for lst in per_repo]
+    while len(out) < limit and any(active):
+        lst = active[idx % len(active)]
+        if lst:
+            out.append(lst.pop(0))
+        idx += 1
+        # stop if we've cycled through all and all empty
+        if idx % len(active) == 0 and not any(active):
+            break
+    return out[:limit]

--- a/scripts/repo-cos/scan.py
+++ b/scripts/repo-cos/scan.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""repo-cos — a "repo chief-of-staff": scan Zach's codebases for improvement
+opportunities, rank them, and (opt-in) email the top few.
+
+CEO model: agents bring HIM bounded, evidence-backed ideas instead of him originating
+every task. The quality bar is broad ("increases productivity OR makes the repos/products
+better"), so the slop-defense is STRUCTURAL, not wording:
+  (a) every proposal cites concrete repo/file:line EVIDENCE from a deterministic scan;
+  (b) the output is HARD-CAPPED to the top N (default 5) by leverage;
+  (c) each proposal is BOUNDED/shippable (an agent could implement + verify it);
+  (d) the pipeline BIASES toward CI/test-verifiable proposals (fix a skipped test, add a
+      missing test, remove dead code, fix a real bug) over "nice idea, your call".
+
+Pipeline (mirrors scripts/mail-actions/: deterministic Stage-1 → LLM on survivors):
+  Stage 1  prescan.py  — cheap grep/git signals, capped PER REPO      (no LLM, no spend)
+  Stage 2  llm.py      — OpenRouter clusters survivors → ranked JSON   (single call)
+  Stage 3  digest.py   — one formatter for stdout AND email
+  Stage 4  email_send  — Gmail SMTP, gated behind --email (default OFF)
+
+Modes:
+  (default) --dry-run        run Stage 1+2, PRINT the digest to stdout, send nothing.
+  --no-llm / --candidates-only  run ONLY Stage 1, print the raw candidate list. Needs NO
+                             API key — this is the free smoke test that verifies the
+                             pre-scan without any OpenRouter spend.
+  --email                    send the digest via Gmail SMTP (opt-in; default OFF). Builds
+                             the SAME body the dry-run prints.
+
+Repos: workbench-local. Discovered git repos under the default roots, else the hardcoded
+list. NOTE: naida / vetr live only on the LAPTOP (~/workspace/scratch/), so this
+workbench tool cannot see them yet.
+
+Env:
+  OPENROUTER_API_KEY   required for synthesis (not for --no-llm).
+  REPO_COS_MODEL       overrides --model default.
+  REPO_COS_SMTP_USER / REPO_COS_SMTP_PASSWORD  optional SMTP cred override (else SOPS).
+
+## Step 2 (NOT built yet)
+A weekly, serverMode-gated workbench systemd user timer (mirroring `mail-actions-archive`)
+would run `scan.py --email` every Monday. It is deliberately NOT wired: we validate
+signal quality on a manual `--dry-run` first, then add the timer + home-manager unit in a
+follow-up once the proposals prove worth an inbox slot.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import digest  # noqa: E402
+import prescan  # noqa: E402
+
+# Workbench-local default repos. naida/vetr are laptop-only (~/workspace/scratch/) —
+# see the module docstring; not reachable from the workbench.
+DEFAULT_REPOS = [
+    "~/workspace/devrc",
+    "~/workspace/homelab-talos",
+    "~/workspace/kubeclaw",
+    "~/workspace/kubeclaw-cloud",
+    "~/workspace/kubeclaw-embed",
+    "~/workspace/promptver",
+    "~/workspace/baseball-manitoba-pitch",
+    "~/workspace/civit/civitai",
+    "~/workspace/civit/datapacket-talos",
+    "~/workspace/civit/civitai-orchestration",
+]
+
+DEFAULT_LIMIT_CANDIDATES = 60
+DEFAULT_TOP = 5
+DEFAULT_MODEL = "deepseek/deepseek-v4-flash"
+
+
+def resolve_repos(override: str | None) -> list[str]:
+    """--repos wins (an explicitly-passed empty string means "no repos", NOT "use
+    defaults"); else the default list, filtered to existing directories."""
+    if override is not None:
+        return [p.strip() for p in override.split(",") if p.strip()]
+    existing = []
+    for r in DEFAULT_REPOS:
+        if Path(r).expanduser().is_dir():
+            existing.append(r)
+    return existing
+
+
+def cmd_scan(args) -> int:
+    repos = resolve_repos(args.repos)
+    if not repos:
+        print("ERROR: no repos to scan (none of the defaults exist and --repos empty).",
+              file=sys.stderr)
+        return 2
+
+    candidates, scans = prescan.scan_all(repos, args.limit_candidates)
+    cand_dicts = [c.as_dict() for c in candidates]
+
+    scan_errors = [(s.repo, s.error) for s in scans if s.error]
+    for repo, err in scan_errors:
+        print(f"  ! skipped {repo}: {err}", file=sys.stderr)
+
+    # ---- Stage-1-only smoke mode: no LLM, no key, no spend. ----
+    if args.no_llm or args.candidates_only:
+        return _emit_candidates(candidates, scans, cand_dicts, args)
+
+    # ---- Stage 2: LLM synthesis over survivors. ----
+    import llm
+
+    if not os.environ.get("OPENROUTER_API_KEY"):
+        print("ERROR: OPENROUTER_API_KEY not set — cannot run Stage 2 synthesis.\n"
+              "       Use --no-llm (or --candidates-only) for the free pre-scan smoke test.",
+              file=sys.stderr)
+        return 2
+
+    if not cand_dicts:
+        # Nothing to synthesize — emit an honest empty digest without spending.
+        body = digest.render([], candidate_count=0)
+        return _deliver(body, args, proposals=[], candidate_count=0, approx_tokens=0)
+
+    try:
+        result = llm.synthesize(cand_dicts, top=args.top, model=args.model)
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: synthesis failed: {exc}", file=sys.stderr)
+        return 1
+
+    body = digest.render(
+        result.proposals,
+        candidate_count=len(cand_dicts),
+        approx_tokens=result.approx_prompt_tokens,
+    )
+    print(f"  synthesis: model={result.model} candidates={len(cand_dicts)} "
+          f"proposals={len(result.proposals)} ~prompt_tokens={result.approx_prompt_tokens}",
+          file=sys.stderr)
+    return _deliver(
+        body, args, proposals=result.proposals,
+        candidate_count=len(cand_dicts), approx_tokens=result.approx_prompt_tokens,
+    )
+
+
+def _emit_candidates(candidates, scans, cand_dicts, args) -> int:
+    if args.json:
+        print(json.dumps({
+            "repos": [{"repo": s.repo, "path": s.path, "error": s.error,
+                       "candidate_count": len(s.candidates)} for s in scans],
+            "capped_total": len(cand_dicts),
+            "candidates": cand_dicts,
+        }, indent=2))
+        return 0
+    print(f"repo-cos pre-scan — {len(candidates)} candidate(s) "
+          f"(global cap {args.limit_candidates}) across {len(scans)} repo(s)\n")
+    for s in scans:
+        tag = f" [ERROR: {s.error}]" if s.error else ""
+        print(f"  {s.repo}: {len(s.candidates)} raw candidate(s){tag}")
+    print()
+    # group the capped set by repo for readability
+    by_repo: dict[str, list] = {}
+    for c in candidates:
+        by_repo.setdefault(c.repo, []).append(c)
+    for repo in sorted(by_repo):
+        print(f"── {repo} ─────────────────────────────")
+        for c in by_repo[repo]:
+            print(f"  {c.kind:<12} {c.ref}")
+            if c.text:
+                print(f"               {c.text[:120]}")
+        print()
+    return 0
+
+
+def _deliver(body: str, args, *, proposals, candidate_count, approx_tokens) -> int:
+    """Print (dry-run) or send (--email) the digest. --dry-run is the default and always
+    prints; --email additionally sends."""
+    if args.json:
+        print(json.dumps({
+            "subject": digest.subject(),
+            "candidate_count": candidate_count,
+            "approx_prompt_tokens": approx_tokens,
+            "proposals": [p.as_dict() for p in proposals],
+            "emailed": bool(args.email),
+        }, indent=2))
+    else:
+        print(body)
+
+    if args.email:
+        import email_send
+        try:
+            to = email_send.send_digest(subject=digest.subject(), body=body)
+            print(f"\n  emailed digest → {to}", file=sys.stderr)
+        except Exception as exc:  # noqa: BLE001
+            print(f"ERROR: email send failed: {exc}", file=sys.stderr)
+            return 1
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="repo-cos", description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--dry-run", action="store_true", default=True,
+                   help="(default) run scan + synthesis, PRINT digest to stdout, send nothing")
+    p.add_argument("--email", action="store_true",
+                   help="send the digest via Gmail SMTP (opt-in; default OFF)")
+    p.add_argument("--no-llm", action="store_true",
+                   help="Stage-1 only: print raw candidates, no LLM, no API key needed")
+    p.add_argument("--candidates-only", action="store_true",
+                   help="alias for --no-llm (the free pre-scan smoke test)")
+    p.add_argument("--repos", default=None,
+                   help="comma-separated repo paths overriding the default list")
+    p.add_argument("--limit-candidates", type=int, default=DEFAULT_LIMIT_CANDIDATES,
+                   help=f"global cap on candidates fed to the LLM (default {DEFAULT_LIMIT_CANDIDATES})")
+    p.add_argument("--top", type=int, default=DEFAULT_TOP,
+                   help=f"max proposals to emit (default {DEFAULT_TOP})")
+    p.add_argument("--model", default=DEFAULT_MODEL,
+                   help=f"OpenRouter model id (default {DEFAULT_MODEL})")
+    p.add_argument("--json", action="store_true", help="machine-readable output")
+    p.set_defaults(func=cmd_scan)
+    return p
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repo-cos/tests/test_digest_email.py
+++ b/scripts/repo-cos/tests/test_digest_email.py
@@ -1,0 +1,103 @@
+"""Digest formatter + email sender tests — SMTP is mocked, no network, no SOPS."""
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import digest  # noqa: E402
+import email_send  # noqa: E402
+import llm  # noqa: E402
+
+
+def _prop(title="Fix", ci=True):
+    return llm.Proposal(
+        title=title, repo="devrc", evidence=["devrc/a.py:1"], why="better CI",
+        effort="S", approach="do it", ci_verifiable=ci,
+    )
+
+
+# ---- digest -------------------------------------------------------------------
+
+def test_subject_has_week_date():
+    s = digest.subject(date(2026, 7, 1))
+    assert "week of 2026-07-01" in s
+
+
+def test_render_includes_evidence_and_marker():
+    body = digest.render([_prop()], today=date(2026, 7, 1), candidate_count=3)
+    assert "Fix" in body
+    assert "devrc/a.py:1" in body
+    assert "CI-verifiable" in body
+    assert "From 3 deterministic signal(s)" in body
+
+
+def test_render_empty_is_honest():
+    body = digest.render([], today=date(2026, 7, 1))
+    assert "No bounded" in body
+    assert "high" in body
+
+
+def test_render_non_ci_marker():
+    body = digest.render([_prop(ci=False)], today=date(2026, 7, 1))
+    assert "needs judgement" in body
+
+
+def test_render_numbers_proposals():
+    body = digest.render([_prop("A"), _prop("B")], today=date(2026, 7, 1))
+    assert "1. A" in body
+    assert "2. B" in body
+
+
+# ---- email --------------------------------------------------------------------
+
+def test_build_message_headers():
+    msg = email_send.build_message(
+        subject="s", body="b", from_addr="a@x.com", to_addr="z@y.com")
+    assert msg["Subject"] == "s"
+    assert msg["From"] == "a@x.com"
+    assert msg["To"] == "z@y.com"
+    assert msg.get_content().strip() == "b"
+
+
+def test_send_digest_uses_injected_sender_and_creds():
+    sent = {}
+
+    def fake_creds():
+        return ("user@gmail.com", "app-pw")
+
+    def fake_sender(msg, *, user, password, host=None, port=None):
+        sent["user"] = user
+        sent["password"] = password
+        sent["subject"] = msg["Subject"]
+        sent["to"] = msg["To"]
+
+    to = email_send.send_digest(
+        subject="🧭 test", body="hello", to_addr="z@y.com",
+        _sender=fake_sender, _creds=fake_creds,
+    )
+    assert to == "z@y.com"
+    assert sent["user"] == "user@gmail.com"
+    assert sent["password"] == "app-pw"
+    assert sent["subject"] == "🧭 test"
+    assert sent["to"] == "z@y.com"
+
+
+def test_load_credentials_env_override(monkeypatch):
+    monkeypatch.setenv("REPO_COS_SMTP_USER", "envuser@gmail.com")
+    monkeypatch.setenv("REPO_COS_SMTP_PASSWORD", "envpw")
+    user, pw = email_send.load_credentials()
+    assert user == "envuser@gmail.com"
+    assert pw == "envpw"
+
+
+def test_send_digest_propagates_sender_failure():
+    def boom(msg, *, user, password, host=None, port=None):
+        raise email_send.EmailError("smtp down")
+
+    with pytest.raises(email_send.EmailError):
+        email_send.send_digest(
+            subject="s", body="b",
+            _sender=boom, _creds=lambda: ("u", "p"),
+        )

--- a/scripts/repo-cos/tests/test_llm.py
+++ b/scripts/repo-cos/tests/test_llm.py
@@ -1,0 +1,149 @@
+"""LLM synthesis parser/validator tests — no network, no API key.
+
+Covers: good-JSON parse, fenced/prose stripping, JSON repair-retry, the structural
+anti-slop filters (drop no-evidence proposals, strip invented refs, hard-cap to `top`,
+ci_verifiable-first ordering, effort normalization).
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import llm  # noqa: E402
+
+REFS = {"devrc/scripts/a.py:12", "homelab/x.yaml:3", "civitai/big.ts:0"}
+
+GOOD = """
+{"proposals": [
+  {"title": "Un-skip the flaky auth test", "repo": "devrc",
+   "evidence": ["devrc/scripts/a.py:12"], "why": "restores CI coverage",
+   "effort": "S", "approach": "remove the skip mark, fix the fixture", "ci_verifiable": true}
+]}
+"""
+
+
+def test_parses_good_json():
+    props = llm.parse_proposals(GOOD, top=5, valid_refs=REFS)
+    assert len(props) == 1
+    assert props[0].title.startswith("Un-skip")
+    assert props[0].effort == "S"
+    assert props[0].ci_verifiable is True
+    assert props[0].evidence == ["devrc/scripts/a.py:12"]
+
+
+def test_parses_fenced_json():
+    props = llm.parse_proposals("```json\n" + GOOD + "\n```", top=5, valid_refs=REFS)
+    assert len(props) == 1
+
+
+def test_parses_with_surrounding_prose():
+    props = llm.parse_proposals("Here you go:\n" + GOOD + "\nThanks!", top=5, valid_refs=REFS)
+    assert len(props) == 1
+
+
+def test_invalid_json_raises():
+    with pytest.raises(llm.SynthesisError):
+        llm.parse_proposals("not json at all", top=5)
+
+
+def test_missing_proposals_key_raises():
+    with pytest.raises(llm.SynthesisError):
+        llm.parse_proposals('{"items": []}', top=5)
+
+
+def test_drops_proposal_with_no_evidence():
+    text = '{"proposals": [{"title": "vague idea", "repo": "x", "evidence": [], "why": "", "effort": "M", "approach": "", "ci_verifiable": false}]}'
+    props = llm.parse_proposals(text, top=5)
+    assert props == []
+
+
+def test_strips_invented_ref_and_drops_if_empty():
+    text = '{"proposals": [{"title": "made up", "repo": "x", "evidence": ["ghost/file.py:99"], "why": "w", "effort": "S", "approach": "a", "ci_verifiable": true}]}'
+    props = llm.parse_proposals(text, top=5, valid_refs=REFS)
+    assert props == []  # the only ref was invented → dropped
+
+
+def test_keeps_valid_ref_strips_invented():
+    text = ('{"proposals": [{"title": "mixed", "repo": "devrc", '
+            '"evidence": ["devrc/scripts/a.py:12", "ghost/file.py:99"], '
+            '"why": "w", "effort": "S", "approach": "a", "ci_verifiable": true}]}')
+    props = llm.parse_proposals(text, top=5, valid_refs=REFS)
+    assert len(props) == 1
+    assert props[0].evidence == ["devrc/scripts/a.py:12"]
+
+
+def test_hard_cap_to_top():
+    items = ",".join(
+        f'{{"title": "p{i}", "repo": "r", "evidence": ["devrc/scripts/a.py:12"], '
+        f'"why": "w", "effort": "M", "approach": "a", "ci_verifiable": false}}'
+        for i in range(10)
+    )
+    props = llm.parse_proposals(f'{{"proposals": [{items}]}}', top=3, valid_refs=REFS)
+    assert len(props) == 3
+
+
+def test_ci_verifiable_sorted_first():
+    text = ('{"proposals": ['
+            '{"title": "judgey", "repo": "r", "evidence": ["homelab/x.yaml:3"], "why": "w", "effort": "M", "approach": "a", "ci_verifiable": false},'
+            '{"title": "testfix", "repo": "r", "evidence": ["devrc/scripts/a.py:12"], "why": "w", "effort": "S", "approach": "a", "ci_verifiable": true}'
+            ']}')
+    props = llm.parse_proposals(text, top=5, valid_refs=REFS)
+    assert props[0].title == "testfix"  # ci_verifiable bubbled to top
+    assert props[1].title == "judgey"
+
+
+def test_effort_normalized():
+    text = '{"proposals": [{"title": "t", "repo": "r", "evidence": ["homelab/x.yaml:3"], "why": "w", "effort": "extra-large", "approach": "a", "ci_verifiable": false}]}'
+    props = llm.parse_proposals(text, top=5, valid_refs=REFS)
+    assert props[0].effort == "M"  # unknown → default M
+
+
+def test_ref_known_tolerates_line_drop():
+    assert llm._ref_known("devrc/scripts/a.py", {"devrc/scripts/a.py:12"})
+    assert llm._ref_known("devrc/scripts/a.py:12", {"devrc/scripts/a.py:12"})
+    assert not llm._ref_known("other/file.py", {"devrc/scripts/a.py:12"})
+
+
+# ---- synthesize() with mocked caller (no network) -----------------------------
+
+def test_synthesize_uses_injected_caller():
+    calls = {}
+
+    def fake_caller(model, system, user, api_key, timeout=90.0):
+        calls["model"] = model
+        calls["user"] = user
+        return GOOD
+
+    cands = [{"kind": "marker", "ref": "devrc/scripts/a.py:12", "text": "TODO fix"}]
+    res = llm.synthesize(cands, top=5, model="m", api_key="k", _caller=fake_caller)
+    assert len(res.proposals) == 1
+    assert res.model == "m"
+    assert res.approx_prompt_tokens > 0
+    assert "devrc/scripts/a.py:12" in calls["user"]
+
+
+def test_synthesize_retries_on_bad_json():
+    seq = ["garbage", GOOD]
+
+    def flaky(model, system, user, api_key, timeout=90.0):
+        return seq.pop(0)
+
+    cands = [{"kind": "marker", "ref": "devrc/scripts/a.py:12", "text": "t"}]
+    res = llm.synthesize(cands, top=5, api_key="k", _caller=flaky)
+    assert len(res.proposals) == 1
+
+
+def test_synthesize_raises_after_retry():
+    def always_bad(model, system, user, api_key, timeout=90.0):
+        return "still garbage"
+
+    cands = [{"kind": "marker", "ref": "devrc/scripts/a.py:12", "text": "t"}]
+    with pytest.raises(llm.SynthesisError):
+        llm.synthesize(cands, top=5, api_key="k", _caller=always_bad)
+
+
+def test_synthesize_requires_api_key(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        llm.synthesize([{"kind": "marker", "ref": "x:1", "text": "t"}], _caller=lambda *a, **k: GOOD)

--- a/scripts/repo-cos/tests/test_llm.py
+++ b/scripts/repo-cos/tests/test_llm.py
@@ -147,3 +147,35 @@ def test_synthesize_requires_api_key(monkeypatch):
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     with pytest.raises(RuntimeError):
         llm.synthesize([{"kind": "marker", "ref": "x:1", "text": "t"}], _caller=lambda *a, **k: GOOD)
+
+
+def test_ref_known_rejects_bare_prefix():
+    # The audit's case: a bare repo name / truncated path must NOT validate, or the
+    # "drop invented refs" anti-slop guarantee is hollow.
+    valid = {"devrc/scripts/a.py:12"}
+    assert not llm._ref_known("devrc", valid)
+    assert not llm._ref_known("devrc/scripts", valid)
+    assert not llm._ref_known("d", valid)
+    # exact + line-drop still accepted
+    assert llm._ref_known("devrc/scripts/a.py:12", valid)
+    assert llm._ref_known("devrc/scripts/a.py", valid)
+
+
+def test_synthesize_retries_past_empty():
+    # DeepSeek rotates even at temp=0 → a valid-but-empty result should be re-rolled
+    # while candidates exist, returning the first non-empty synthesis.
+    seq = ['{"proposals": []}', GOOD]
+    def flaky(model, system, user, api_key, timeout=90.0):
+        return seq.pop(0)
+    cands = [{"kind": "marker", "ref": "devrc/scripts/a.py:12", "text": "t"}]
+    res = llm.synthesize(cands, top=5, api_key="k", _caller=flaky)
+    assert len(res.proposals) == 1
+    assert seq == []  # both calls consumed → it re-rolled past the empty
+
+
+def test_synthesize_returns_honest_empty_after_all_empty():
+    def always_empty(model, system, user, api_key, timeout=90.0):
+        return '{"proposals": []}'
+    cands = [{"kind": "marker", "ref": "devrc/scripts/a.py:12", "text": "t"}]
+    res = llm.synthesize(cands, top=5, api_key="k", _caller=always_empty)
+    assert res.proposals == []  # honest empty after retries — not an exception

--- a/scripts/repo-cos/tests/test_prescan.py
+++ b/scripts/repo-cos/tests/test_prescan.py
@@ -1,0 +1,201 @@
+"""Deterministic pre-scan tests — marker/skip detection, file:line correctness,
+per-repo capping, churn/large/lockfile signals, and global interleave cap.
+
+All fixtures are built on a real temp directory tree (tmp_path) so the file-walk,
+line-numbering, and ordering are exercised end-to-end without any network or git remote.
+"""
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import prescan  # noqa: E402
+
+
+def _write(root: Path, rel: str, content: str) -> Path:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+    return p
+
+
+# ---- markers ------------------------------------------------------------------
+
+def test_marker_extraction_file_and_line(tmp_path):
+    _write(tmp_path, "a.py", "x = 1\n# TODO: fix this\ny = 2\n# FIXME later\n")
+    cands = prescan.scan_markers(tmp_path, "repo", cap=10)
+    assert [c.line for c in cands] == [2, 4]
+    assert cands[0].kind == "marker"
+    assert cands[0].file == "a.py"
+    assert "TODO" in cands[0].text
+    assert cands[0].repo == "repo"
+
+
+def test_marker_ref_format(tmp_path):
+    _write(tmp_path, "pkg/mod.go", "// HACK: temporary\n")
+    c = prescan.scan_markers(tmp_path, "myrepo", cap=10)[0]
+    assert c.ref == "myrepo/pkg/mod.go:1"
+
+
+def test_marker_cap_is_enforced(tmp_path):
+    body = "".join(f"# TODO {i}\n" for i in range(20))
+    _write(tmp_path, "big.py", body)
+    cands = prescan.scan_markers(tmp_path, "repo", cap=5)
+    assert len(cands) == 5
+
+
+def test_marker_skips_pruned_dirs(tmp_path):
+    _write(tmp_path, "node_modules/dep.js", "// TODO vendored\n")
+    _write(tmp_path, "src.py", "# TODO real\n")
+    cands = prescan.scan_markers(tmp_path, "repo", cap=10)
+    files = {c.file for c in cands}
+    assert "src.py" in files
+    assert not any("node_modules" in f for f in files)
+
+
+def test_walk_markers_ignores_binary_exts(tmp_path):
+    _write(tmp_path, "img.png", "TODO not code\n")
+    cands = prescan._walk_markers(tmp_path)
+    assert cands == []
+
+
+# ---- skipped tests ------------------------------------------------------------
+
+def test_skipped_pytest_detected(tmp_path):
+    _write(tmp_path, "test_x.py",
+           "import pytest\n@pytest.mark.skip(reason='flaky')\ndef test_a():\n    pass\n")
+    cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=10)
+    assert len(cands) == 1
+    assert cands[0].kind == "skipped_test"
+    assert cands[0].line == 2
+    assert "pytest.skip" in cands[0].text
+
+
+def test_skipped_js_detected(tmp_path):
+    _write(tmp_path, "a.test.js", "describe('x', () => {\n  it.skip('todo', () => {});\n});\n")
+    cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=10)
+    assert any(c.line == 2 and "js.skip" in c.text for c in cands)
+
+
+def test_skipped_go_detected(tmp_path):
+    _write(tmp_path, "x_test.go", "func TestFoo(t *testing.T) {\n\tt.Skip(\"wip\")\n}\n")
+    cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=10)
+    assert any(c.line == 2 and "go.skip" in c.text for c in cands)
+
+
+def test_skipped_rust_ignore_detected(tmp_path):
+    _write(tmp_path, "lib.rs", "#[ignore]\n#[test]\nfn t() {}\n")
+    cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=10)
+    assert any("rust.ignore" in c.text for c in cands)
+
+
+def test_skipped_cap(tmp_path):
+    body = "".join(f"@pytest.mark.skip\ndef t{i}(): pass\n" for i in range(10))
+    _write(tmp_path, "test_many.py", body)
+    cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=3)
+    assert len(cands) == 3
+
+
+# ---- large files --------------------------------------------------------------
+
+def test_large_file_over_threshold(tmp_path):
+    _write(tmp_path, "big.py", "x=1\n" * 50)
+    _write(tmp_path, "small.py", "x=1\n" * 5)
+    cands = prescan.scan_large_files(tmp_path, "repo", cap=10, threshold=40)
+    files = {c.file for c in cands}
+    assert "big.py" in files
+    assert "small.py" not in files
+    assert cands[0].line == 0  # file-level signal
+    assert "LOC" in cands[0].text
+
+
+def test_large_file_sorted_desc(tmp_path):
+    _write(tmp_path, "bigger.py", "x\n" * 100)
+    _write(tmp_path, "big.py", "x\n" * 60)
+    cands = prescan.scan_large_files(tmp_path, "repo", cap=10, threshold=40)
+    assert cands[0].file == "bigger.py"
+
+
+# ---- stale lockfiles ----------------------------------------------------------
+
+def test_stale_lock_flagged(tmp_path):
+    p = _write(tmp_path, "poetry.lock", "old\n")
+    old = time.time() - 400 * 86400
+    import os
+    os.utime(p, (old, old))
+    cands = prescan.scan_stale_locks(tmp_path, "repo", cap=10, max_age_days=365)
+    assert len(cands) == 1
+    assert cands[0].kind == "stale_lock"
+    assert "untouched" in cands[0].text
+
+
+def test_fresh_lock_not_flagged(tmp_path):
+    _write(tmp_path, "flake.lock", "new\n")
+    cands = prescan.scan_stale_locks(tmp_path, "repo", cap=10, max_age_days=365)
+    assert cands == []
+
+
+# ---- repo orchestration + caps ------------------------------------------------
+
+def test_scan_repo_missing_dir_sets_error():
+    rs = prescan.scan_repo("/nonexistent/path/xyz")
+    assert rs.error is not None
+    assert rs.candidates == []
+
+
+def test_scan_repo_collects_multiple_signals(tmp_path):
+    _write(tmp_path, "a.py", "# TODO x\n")
+    _write(tmp_path, "test_a.py", "@pytest.mark.skip\ndef t(): pass\n")
+    _write(tmp_path, "big.py", "l\n" * 900)
+    rs = prescan.scan_repo(str(tmp_path))
+    kinds = {c.kind for c in rs.candidates}
+    assert "marker" in kinds
+    assert "skipped_test" in kinds
+    assert "large_file" in kinds
+    assert rs.error is None
+
+
+def test_per_repo_caps_respected(tmp_path):
+    body = "".join(f"# TODO {i}\n" for i in range(30))
+    _write(tmp_path, "a.py", body)
+    rs = prescan.scan_repo(str(tmp_path), caps={"marker": 2, "skipped_test": 8,
+                                                "churn": 6, "large_file": 5, "stale_lock": 3})
+    markers = [c for c in rs.candidates if c.kind == "marker"]
+    assert len(markers) == 2
+
+
+# ---- global interleave cap ----------------------------------------------------
+
+def _cand(repo, i):
+    return prescan.Candidate(repo, "marker", f"f{i}.py", i, "t")
+
+
+def test_interleave_cap_spreads_across_repos():
+    a = [_cand("A", i) for i in range(10)]
+    b = [_cand("B", i) for i in range(10)]
+    capped = prescan._interleave_cap([a, b], 6)
+    assert len(capped) == 6
+    # round-robin: A,B,A,B,A,B → 3 each, no single repo monopolizes
+    repos = [c.repo for c in capped]
+    assert repos.count("A") == 3
+    assert repos.count("B") == 3
+
+
+def test_interleave_cap_handles_uneven():
+    a = [_cand("A", i) for i in range(2)]
+    b = [_cand("B", i) for i in range(10)]
+    capped = prescan._interleave_cap([a, b], 8)
+    assert len(capped) == 8
+    # A exhausts after 2, rest come from B
+    assert [c.repo for c in capped].count("A") == 2
+    assert [c.repo for c in capped].count("B") == 6
+
+
+def test_scan_all_applies_global_cap(tmp_path):
+    r1 = tmp_path / "r1"
+    r2 = tmp_path / "r2"
+    for r in (r1, r2):
+        _write(r, "a.py", "".join(f"# TODO {i}\n" for i in range(20)))
+    capped, scans = prescan.scan_all([str(r1), str(r2)], limit_candidates=5)
+    assert len(capped) == 5
+    assert len(scans) == 2

--- a/scripts/repo-cos/tests/test_scan_cli.py
+++ b/scripts/repo-cos/tests/test_scan_cli.py
@@ -1,0 +1,78 @@
+"""scan.py orchestration tests — repo resolution, --no-llm smoke path, arg defaults.
+
+These exercise the CLI wiring without any network (--no-llm never touches OpenRouter).
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import scan  # noqa: E402
+
+
+def _write(root: Path, rel: str, content: str):
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+
+
+def test_resolve_repos_override_wins():
+    repos = scan.resolve_repos("/a, /b ,/c")
+    assert repos == ["/a", "/b", "/c"]
+
+
+def test_resolve_repos_filters_missing(tmp_path):
+    real = tmp_path / "real"
+    real.mkdir()
+    # monkeypatch the default list to one real + one missing
+    import scan as s
+    orig = s.DEFAULT_REPOS
+    s.DEFAULT_REPOS = [str(real), str(tmp_path / "missing")]
+    try:
+        repos = s.resolve_repos(None)
+        assert repos == [str(real)]
+    finally:
+        s.DEFAULT_REPOS = orig
+
+
+def test_no_llm_mode_prints_candidates_no_network(tmp_path, capsys):
+    _write(tmp_path, "a.py", "# TODO fix the thing\n")
+    args = scan.build_parser().parse_args(
+        ["--no-llm", "--repos", str(tmp_path)])
+    rc = scan.cmd_scan(args)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "pre-scan" in out
+    assert "TODO fix the thing" in out
+    assert "marker" in out
+
+
+def test_no_llm_json_mode(tmp_path, capsys):
+    _write(tmp_path, "a.py", "# FIXME broken\n")
+    args = scan.build_parser().parse_args(
+        ["--candidates-only", "--json", "--repos", str(tmp_path)])
+    rc = scan.cmd_scan(args)
+    out = capsys.readouterr().out
+    assert rc == 0
+    import json
+    data = json.loads(out)
+    assert data["capped_total"] >= 1
+    assert any("FIXME" in c["text"] for c in data["candidates"])
+
+
+def test_empty_repos_errors(capsys):
+    args = scan.build_parser().parse_args(["--no-llm", "--repos", ""])
+    rc = scan.cmd_scan(args)
+    assert rc == 2
+
+
+def test_dry_run_is_default():
+    args = scan.build_parser().parse_args([])
+    assert args.dry_run is True
+    assert args.email is False
+
+
+def test_default_flags():
+    args = scan.build_parser().parse_args([])
+    assert args.top == 5
+    assert args.limit_candidates == 60
+    assert args.model == "deepseek/deepseek-v4-flash"


### PR DESCRIPTION
## What this is

`repo-cos` — a v0 **"repo chief-of-staff"**: an autonomous idea-generation experiment (CEO model). It scans Zach's workbench codebases for improvement opportunities, ranks them, and — opt-in — emails the top few as bounded, evidence-backed proposals so agents bring HIM ideas instead of him originating every task.

**v0 scope:** scanner + LLM synthesis + `--dry-run` (default, prints to stdout). No systemd timer wired; email is gated behind `--email` (default OFF). We validate signal quality on a manual dry-run first.

New dir `scripts/repo-cos/`, entry `scan.py`. Stdlib + `requests` only.

## The anti-slop mandate (structural, not wording)

- **Evidence-grounded** — every proposal cites concrete `repo/file:line` refs from the deterministic pre-scan. The LLM is told never to invent a file; the parser **drops** any proposal whose evidence doesn't map back to a real candidate.
- **Hard cap** — output capped to top `--top` (default **5**) by leverage, truncated even if the model returns more.
- **Bounded/shippable** — each proposal must be a finishable change an agent could implement *and verify*.
- **CI-verifiable bias** — the prompt AND the parser prefer CI/test-verifiable proposals (fix a skipped test, add a missing test, remove dead code, fix a real bug) and re-sort them above "your call" items.

Mirrors the proven `scripts/mail-actions/` pattern: deterministic Stage-1 filter → LLM on the small survivor set.

## Deterministic signals (Stage 1, no LLM, no spend)

`markers` (TODO/FIXME/HACK/XXX/BUG) · `skipped_test` (pytest/js/go/rust) · `churn` (git, last 90d) · `large_file` (>800 LOC) · `stale_lock` (>1y).

Each signal is **capped per repo** (`prescan.CAP_PER_SIGNAL`) so `civit/civitai` can't flood the LLM input, plus a **global** `--limit-candidates` cap applied by round-robin interleaving so no repo monopolizes the budget. Full default scan of **all 10 local repos runs in ~7.6s** (civitai included).

## Flags

`--dry-run` (DEFAULT — print digest, send nothing) · `--email` (opt-in send, default OFF) · `--no-llm` / `--candidates-only` (free Stage-1 smoke test, no API key) · `--repos` · `--limit-candidates N` (60) · `--top N` (5) · `--model` (`deepseek/deepseek-v4-flash`) · `--json`.

## Sample `--no-llm` candidate output (real, from devrc + homelab-talos)

Proves the pre-scan surfaces actionable, evidence-bearing signal with correct `file:line`:

```
repo-cos pre-scan — 20 candidate(s) (global cap 20) across 2 repo(s)

  devrc: 12 raw candidate(s)
  homelab-talos: 25 raw candidate(s)

── devrc ─────────────────────────────
  marker       devrc/claude/RULES.md:90
               - **Finish what you start**: no partial features, no TODO comments for core functionality, no mock/stub/placeholder code
  marker       devrc/claudedocs/proposed-rules-cut/RULES.md:78
               - **Finish what you start**: no partial features, no TODO comments for core functionality, no mock/stub/placeholder code
  skipped_test devrc/scripts/collector/tests/test_collector.py:371
               [pytest.skip] @pytest.mark.skipif(not EMIT.exists(), reason="emit script missing")
  skipped_test devrc/scripts/collector/tests/test_collector.py:406
               [pytest.skip] @pytest.mark.skipif(not EMIT.exists(), reason="emit script missing")
  skipped_test devrc/scripts/collector/tests/test_collector.py:428
               [pytest.skip] @pytest.mark.skipif(not EMIT.exists(), reason="emit script missing")
  churn        devrc/nix/home.nix
               33 changes in last 90d
  churn        devrc/.tmux.conf
               10 changes in last 90d
  churn        devrc/scripts/validation/invariants.py
               7 changes in last 90d
  churn        devrc/CLAUDE.md
               6 changes in last 90d
  churn        devrc/scripts/collector/browser-ext/README.md
               6 changes in last 90d

── homelab-talos ─────────────────────────────
  marker       homelab-talos/clusters/homelab/apps/agent-pods/zacxdev-clever-bloom/helmrelease.yaml:801
               `TODO: confirm` note. Never block registration on user answers when
  marker       homelab-talos/clusters/homelab/apps/agent-pods/zacxdev-clever-bloom/helmrelease.yaml:1026
               question or note it as a step-level `TODO: confirm`, then register.
  marker       homelab-talos/clusters/homelab/apps/clankup/postgres.yaml:10
               # TODO: Migrate to openebs-nvme-1tb during maintenance window (see migration steps below)
  marker       homelab-talos/clusters/production/flux-system/kustomizations/system/recommendation-system.yaml:29
               newTag: latest  # TODO: Pin to specific version (e.g., sha-abc1234) after Tekton builds
  marker       homelab-talos/clusters/production/flux-system/kustomizations/system/tryonhaulcentral.yaml:29
               newTag: latest  # TODO: Pin to specific version (e.g., sha-abc1234) after Tekton builds
  marker       homelab-talos/talos-patches/proxmox-disk-mounts.yaml:7
               #   sdb+sde: 2TB RAID1 - media library (requires mdadm - TODO)
  skipped_test homelab-talos/containers/clawgate/e2e/tests/agent-selfservice.spec.ts:10
               [js.skip] test.skip(!dockerAvailable(), 'full-mode specs need Docker for a throwaway Postgres');
  skipped_test homelab-talos/containers/clawgate/e2e/tests/auto-approve.spec.ts:8
               [js.skip] test.skip(!dockerAvailable(), 'full-mode specs need Docker for a throwaway Postgres');
  skipped_test homelab-talos/containers/clawgate/e2e/tests/operator.spec.ts:13
               [js.skip] test.skip(!dockerAvailable(), 'full-mode specs need Docker for a throwaway Postgres');
  skipped_test homelab-talos/containers/clawgate/e2e/tests/privilege.spec.ts:14
               [js.skip] test.skip(!dockerAvailable(), 'full-mode specs need Docker for a throwaway Postgres');

```

Genuinely useful hits: skipped `collector` tests, a 1237-LOC file (`initiative-scan.py`), unpinned `newTag: latest` prod image tags, and TODO migrations — exactly the CI-verifiable / bounded material the LLM should cluster.

## Email (built, gated OFF)

`smtplib` STARTTLS to `smtp.gmail.com:587`, login with Zach's Gmail + the app-password from SOPS secret **`mailbox-gmail-imap`** (`clusters/homelab/apps/mailbox/secrets-imap.enc.yaml`, keys `IMAP_USER` / `IMAP_APP_PASSWORD`) — **verified** against `sent-poller.yaml`, which mounts the same secret (the app password authenticates SMTP send just as it does IMAP read). Only sends on `--email`; `--dry-run` prints the identical body via the shared `digest.py` formatter. Env overrides `REPO_COS_SMTP_USER`/`REPO_COS_SMTP_PASSWORD` supported.

## Tests

**52 passing** (`python -m pytest scripts/repo-cos/tests -q`, ~0.09s). Cover the deterministic parts with tmp-dir fixtures: marker/skip extraction (file:line correct across py/js/go/rust), per-repo + global capping, churn/large/lockfile signals, digest formatter, and the LLM JSON parse/repair + anti-slop filters (drop no-evidence, strip invented refs, hard-cap, ci-verifiable-first). **OpenRouter HTTP and SMTP are mocked** — no live network in unit tests.

## Step 2 — NOT wired

The weekly `serverMode`-gated workbench systemd timer (mirroring `mail-actions-archive`, `scan.py --email` every Monday) is **deliberately not built** — pending a signal-quality dry-run. Documented as a `## Step 2` note in `scan.py`'s docstring + the README.

## Full LLM dry-run command (for you to run with a key)

```sh
OPENROUTER_API_KEY=... nix-shell -p 'python3.withPackages(p:[p.requests])' --run \
  'python scripts/repo-cos/scan.py --dry-run'
```

Add `--json` for machine-readable proposals, `--top 5 --limit-candidates 60` are the defaults. It prints an approx prompt-token count to stderr for cost visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
