### PR TITLE
feat(repo-cos): REPLY-FEEDBACK loop — steer next digest from emailed reply

### DIFF
--- a/scripts/repo-cos/README.md
+++ b/scripts/repo-cos/README.md
@@ -26,6 +26,7 @@ shrinks the corpus, then the LLM runs on the small survivor set.
 
 | Stage | Module | What | Cost |
 |-------|--------|------|------|
+| 0 | `feedback.py` | pull Zach's IMAP reply to LAST digest → synthesis context | none |
 | 1 | `prescan.py` | cheap grep/git signals, capped **per repo** | none |
 | 2 | `llm.py` | OpenRouter clusters survivors → ranked JSON proposals | one call |
 | 3 | `digest.py` | one formatter shared by stdout **and** email | none |
@@ -43,6 +44,30 @@ shrinks the corpus, then the LLM runs on the small survivor set.
 Each signal is **capped per repo** (see `prescan.CAP_PER_SIGNAL`) so a huge repo like
 `civit/civitai` can't flood the LLM input, and a **global** `--limit-candidates` cap is
 applied by round-robin interleaving so no single repo monopolizes the budget.
+
+## Reply-feedback loop (Stage 0)
+
+The runs are no longer stateless: **your emailed REPLY to last week's digest steers the
+next one.** Before synthesis, `feedback.py` reads back your reply over **IMAP** (stdlib
+`imaplib`, the *same* Gmail app-password used for send — no new deps, no cluster/Postgres
+path) and prepends last week's proposals + your reply to the LLM prompt as context, with
+an instruction to *drop what you rejected and honor your steering* while still surfacing
+genuinely new evidence-backed candidates. It's context only — the structural evidence /
+anti-slop rules still fully apply.
+
+- **Matching:** searches recent mail SINCE the last digest for the ASCII-stable subject
+  core `Repo proposals` (the full subject's 🧭 + em-dash are flaky in IMAP SEARCH), then
+  picks the most-recent genuine **reply from you** (`Re:` / `In-Reply-To`), so the
+  original digest isn't mistaken for feedback. Looks in `INBOX`, falls back to
+  `[Gmail]/All Mail`.
+- **De-quoting:** drops `>`-quoted lines and everything from the `On … wrote:` attribution
+  onward, leaving only your new words (capped 4000 chars).
+- **Best-effort + safe:** no prior digest / no creds / IMAP down / no reply / parse error
+  → logged to stderr and skipped; the run proceeds exactly as a stateless one. `--no-feedback`
+  skips the fetch entirely (clean / testing runs); `--json` reports `feedback_applied`.
+- **Limits:** relies on subject-thread matching — if Gmail groups a reply under a
+  different subject (or you compose fresh instead of replying), it won't be found. The
+  loop closes naturally because each run persists its own subject → next run's "previous".
 
 ## Usage
 
@@ -64,9 +89,13 @@ nix-shell -p 'python3.withPackages(p:[p.requests])' --run \
   'python scripts/repo-cos/scan.py --dry-run'
 ```
 
-Flags: `--dry-run` (default), `--email`, `--no-llm`/`--candidates-only`, `--repos`,
-`--limit-candidates N` (default 60), `--top N` (default 5), `--model` (default
-`deepseek/deepseek-v4-flash`), `--json`.
+Flags: `--dry-run` (default), `--email`, `--no-llm`/`--candidates-only`, `--no-feedback`
+(skip Stage 0), `--repos`, `--limit-candidates N` (default 60), `--top N` (default 5),
+`--model` (default `deepseek/deepseek-v4-flash`), `--json`.
+
+The weekly unit / `run-weekly.sh` need **no change**: `feedback.py` uses only stdlib
+`imaplib` (already available) and the SAME app-password already decrypted for SMTP send —
+so the reply-fetch adds no new system deps or secrets to the timer.
 
 ## Repos
 

--- a/scripts/repo-cos/digest.py
+++ b/scripts/repo-cos/digest.py
@@ -10,10 +10,16 @@ from datetime import date
 
 EFFORT_LABEL = {"S": "small", "M": "medium", "L": "large"}
 
+# ASCII-stable core of the digest subject. The full subject carries a leading emoji (🧭)
+# and an em-dash (—), both non-ASCII and flaky in IMAP SEARCH — so feedback.py matches a
+# reply against THIS fragment instead of the whole subject. Keep `subject()` embedding it
+# verbatim (asserted in tests) so the reply-matcher stays in lockstep with what we send.
+SUBJECT_CORE = "Repo proposals"
+
 
 def subject(today: date | None = None) -> str:
     d = today or date.today()
-    return f"🧭 Repo proposals — week of {d.isoformat()}"
+    return f"🧭 {SUBJECT_CORE} — week of {d.isoformat()}"
 
 
 def render(proposals: list, *, today: date | None = None,

--- a/scripts/repo-cos/feedback.py
+++ b/scripts/repo-cos/feedback.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""REPLY-FEEDBACK loop — pull Zach's emailed reply to the LAST digest, so the NEXT run
+can feed his steering into synthesis as CONTEXT.
+
+The digest goes out Zach→Zach (zachlowden1@gmail.com), so his reply lands in his OWN
+Gmail. We read it back over IMAP with the SAME Gmail app-password repo-cos already uses
+for SMTP send (`email_send.load_credentials()` → SOPS `mailbox-gmail-imap`). NO new deps
+(imaplib is stdlib), NO homelab-cluster / Postgres / kubectl path.
+
+Design contract:
+  * BEST-EFFORT + SAFE. Any failure — no creds, IMAP down, no reply found, parse error —
+    is logged to stderr and returns None. This NEVER crashes the weekly run.
+  * The previous digest's `subject` + `generated_at` come from ~/.config/repo-cos/latest.json
+    (missing → no prior digest → return None).
+  * Matching is robust to Gmail quirks: we SEARCH on the ASCII-stable subject core
+    (`digest.SUBJECT_CORE`, e.g. "Repo proposals") — the full subject's emoji + em-dash are
+    non-ASCII and flaky in IMAP SEARCH — restricted to mail SINCE the digest date, then pick
+    the most-recent message that is a genuine REPLY FROM Zach (subject starts "Re:" and/or
+    carries In-Reply-To/References). We look in INBOX and, if needed, "[Gmail]/All Mail".
+  * The reply body is de-quoted: lines starting ">" are dropped, and everything from an
+    "On <date> … wrote:" attribution onward is cut, leaving only Zach's NEW words. Capped.
+
+Returned to synthesis: a `Feedback` with the cleaned reply text + the previous proposals
+(title + first evidence ref) so the model can reference exactly what it's steering off.
+"""
+from __future__ import annotations
+
+import email
+import imaplib
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from email.header import decode_header, make_header
+from email.message import Message
+from pathlib import Path
+
+# Local imports (scan.py already puts this dir on sys.path; guard for standalone use).
+try:
+    import digest  # noqa: E402
+except ImportError:  # pragma: no cover - import guard for direct execution
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import digest  # noqa: E402
+import email_send  # noqa: E402
+
+IMAP_HOST = "imap.gmail.com"
+IMAP_PORT = 993
+IMAP_TIMEOUT = 30  # short — a slow/hung IMAP must not stall the weekly run
+ALL_MAIL = "[Gmail]/All Mail"
+MAX_REPLY_CHARS = 4000
+
+PERSIST_LATEST = Path("~/.config/repo-cos/latest.json").expanduser()
+
+# "On Mon, 1 Jul 2026 at 08:00, Zach <…> wrote:" — Gmail's quote attribution line. Once we
+# hit it, everything after is quoted history, not Zach's new words. Kept permissive (the
+# locale/format varies) but anchored on a leading "On " AND the "… wrote:" tail, so a
+# legitimate reply line like "the note I wrote:" is NOT mistaken for an attribution.
+_ATTRIBUTION_RE = re.compile(r"^\s*On\b.+\bwrote:\s*$", re.IGNORECASE)
+
+
+@dataclass
+class Feedback:
+    """What synthesis needs to honor last week's steering."""
+    reply_text: str
+    prev_proposals: list[dict] = field(default_factory=list)  # {title, evidence}
+    replied_at: str = ""  # the digest's generated_at, for the stderr log
+
+    def prev_summary(self) -> list[str]:
+        """Compact `title — evidence` lines for the prompt (first ref only)."""
+        out = []
+        for p in self.prev_proposals:
+            title = str(p.get("title") or "").strip()
+            if not title:
+                continue
+            ev = p.get("evidence") or []
+            first = str(ev[0]).strip() if ev else ""
+            out.append(f"{title} — {first}" if first else title)
+        return out
+
+
+def _log(msg: str) -> None:
+    print(f"  feedback: {msg}", file=sys.stderr)
+
+
+def _load_last_digest() -> dict | None:
+    """Read ~/.config/repo-cos/latest.json (the previous run). None if absent/unreadable."""
+    try:
+        if not PERSIST_LATEST.exists():
+            return None
+        return json.loads(PERSIST_LATEST.read_text())
+    except Exception as exc:  # noqa: BLE001
+        _log(f"could not read {PERSIST_LATEST}: {exc}")
+        return None
+
+
+def _decode(value: str | None) -> str:
+    """Decode a possibly RFC2047-encoded header to a str; never raises."""
+    if not value:
+        return ""
+    try:
+        return str(make_header(decode_header(value)))
+    except Exception:  # noqa: BLE001
+        return value
+
+
+def _since_token(generated_at: str) -> str:
+    """IMAP SINCE date (DD-Mon-YYYY) one day BEFORE the digest, so timezone skew between
+    the ISO `generated_at` and Gmail's server-side date can't hide a same-day reply."""
+    try:
+        dt = datetime.fromisoformat(generated_at)
+    except Exception:  # noqa: BLE001
+        dt = datetime.now().astimezone() - timedelta(days=8)
+    dt = dt - timedelta(days=1)
+    return dt.strftime("%d-%b-%Y")
+
+
+def _is_reply_from_owner(msg: Message) -> bool:
+    """A genuine reply from Zach: FROM his address AND (subject starts Re: OR it threads via
+    In-Reply-To/References). The subject-core match already scoped us to the digest thread;
+    this rejects the ORIGINAL digest (Zach→Zach, but no Re:/In-Reply-To) so we don't feed
+    the model its own prior output as "feedback"."""
+    frm = _decode(msg.get("From")).lower()
+    if email_send.OWNER_EMAIL.lower() not in frm:
+        return False
+    subj = _decode(msg.get("Subject")).strip().lower()
+    is_re = subj.startswith("re:")
+    threads = bool(msg.get("In-Reply-To") or msg.get("References"))
+    return is_re or threads
+
+
+def _plain_body(msg: Message) -> str:
+    """Extract the text/plain body (first such part for multipart). Falls back to the
+    payload decoded as text. Never raises."""
+    try:
+        if msg.is_multipart():
+            for part in msg.walk():
+                if part.get_content_type() == "text/plain" and \
+                        "attachment" not in str(part.get("Content-Disposition", "")).lower():
+                    payload = part.get_payload(decode=True)
+                    if payload is not None:
+                        return payload.decode(part.get_content_charset() or "utf-8",
+                                              errors="replace")
+            return ""
+        payload = msg.get_payload(decode=True)
+        if payload is None:
+            return str(msg.get_payload())
+        return payload.decode(msg.get_content_charset() or "utf-8", errors="replace")
+    except Exception as exc:  # noqa: BLE001
+        _log(f"body extract failed: {exc}")
+        return ""
+
+
+def strip_quoted(body: str) -> str:
+    """Return only Zach's NEW words: drop the quoted digest.
+
+    Rules (applied line-by-line, top-down):
+      * once an "On … wrote:" attribution line is seen, cut EVERYTHING from there on
+        (that's Gmail's reply history);
+      * drop any line starting with ">" (quoted text);
+      * stop at a "-- " signature separator.
+    Collapses surrounding blank lines and caps length.
+    """
+    kept: list[str] = []
+    for raw in (body or "").splitlines():
+        line = raw.rstrip()
+        if _ATTRIBUTION_RE.match(line):
+            break
+        if line.strip() == "--":  # signature delimiter (some clients omit the trailing space)
+            break
+        if line.lstrip().startswith(">"):
+            continue
+        kept.append(line)
+    text = "\n".join(kept).strip()
+    # collapse 3+ blank lines to a single blank
+    text = re.sub(r"\n\s*\n\s*\n+", "\n\n", text)
+    return text[:MAX_REPLY_CHARS].strip()
+
+
+def _search_uids(imap: imaplib.IMAP4_SSL, core: str, since: str) -> list[bytes]:
+    """IMAP SEARCH for the subject-core SINCE the digest date. Returns UID bytes list
+    (newest-relevant handled by the caller). Empty on any failure."""
+    try:
+        typ, data = imap.search(None, "SINCE", since, "SUBJECT", f'"{core}"')
+        if typ != "OK" or not data or not data[0]:
+            return []
+        return data[0].split()
+    except Exception as exc:  # noqa: BLE001
+        _log(f"search failed: {exc}")
+        return []
+
+
+def _best_reply_in_mailbox(imap: imaplib.IMAP4_SSL, mailbox: str, core: str,
+                           since: str) -> str | None:
+    """Select `mailbox`, find the most-recent genuine reply-from-owner matching the subject
+    core, return its cleaned body (or None)."""
+    try:
+        typ, _ = imap.select(f'"{mailbox}"', readonly=True)
+        if typ != "OK":
+            return None
+    except Exception as exc:  # noqa: BLE001
+        _log(f"select {mailbox} failed: {exc}")
+        return None
+
+    uids = _search_uids(imap, core, since)
+    if not uids:
+        return None
+    # newest first — IMAP SEARCH returns ascending sequence numbers
+    for num in reversed(uids):
+        try:
+            typ, msg_data = imap.fetch(num, "(RFC822)")
+            if typ != "OK" or not msg_data or not msg_data[0]:
+                continue
+            raw = msg_data[0][1]
+            if not isinstance(raw, (bytes, bytearray)):
+                continue
+            msg = email.message_from_bytes(raw)
+        except Exception as exc:  # noqa: BLE001
+            _log(f"fetch/parse failed: {exc}")
+            continue
+        if not _is_reply_from_owner(msg):
+            continue
+        cleaned = strip_quoted(_plain_body(msg))
+        if cleaned:
+            return cleaned
+    return None
+
+
+def fetch_last_feedback(*, _creds=None, _imap_factory=None) -> Feedback | None:
+    """Pull Zach's reply to the previous digest as steering CONTEXT for the next synthesis.
+
+    Best-effort: returns None (never raises) if there's no prior digest, no creds, IMAP is
+    unreachable, or no reply is found. `_creds` / `_imap_factory` are injectable for tests
+    (no real network).
+    """
+    last = _load_last_digest()
+    if not last:
+        _log("no previous digest (latest.json missing) — skipping")
+        return None
+    subject = str(last.get("subject") or "")
+    generated_at = str(last.get("generated_at") or "")
+    prev_proposals = [
+        {"title": p.get("title"), "evidence": p.get("evidence") or []}
+        for p in (last.get("proposals") or []) if isinstance(p, dict)
+    ]
+
+    core = digest.SUBJECT_CORE
+    if core not in subject and subject:
+        # Subject drifted from our known format — fall back to the constant anyway (that's
+        # what we'd have sent), but note it.
+        _log(f"prev subject {subject!r} lacks core {core!r}; matching on core")
+    since = _since_token(generated_at)
+
+    creds = _creds or email_send.load_credentials
+    try:
+        user, password = creds()
+    except Exception as exc:  # noqa: BLE001
+        _log(f"no credentials ({exc}) — skipping")
+        return None
+
+    imap = None
+    try:
+        if _imap_factory is not None:
+            imap = _imap_factory()
+        else:
+            imap = imaplib.IMAP4_SSL(IMAP_HOST, IMAP_PORT, timeout=IMAP_TIMEOUT)
+        imap.login(user, password)
+        reply = _best_reply_in_mailbox(imap, "INBOX", core, since)
+        if reply is None:
+            reply = _best_reply_in_mailbox(imap, ALL_MAIL, core, since)
+    except Exception as exc:  # noqa: BLE001
+        _log(f"IMAP error ({exc}) — skipping")
+        return None
+    finally:
+        if imap is not None:
+            try:
+                imap.logout()
+            except Exception:  # noqa: BLE001
+                pass
+
+    if not reply:
+        _log("no reply found for the previous digest")
+        return None
+
+    _log(f"applied reply from {generated_at or 'unknown'} ({len(reply)} chars)")
+    return Feedback(reply_text=reply, prev_proposals=prev_proposals,
+                    replied_at=generated_at)

--- a/scripts/repo-cos/feedback.py
+++ b/scripts/repo-cos/feedback.py
@@ -120,8 +120,11 @@ def _is_reply_from_owner(msg: Message) -> bool:
     In-Reply-To/References). The subject-core match already scoped us to the digest thread;
     this rejects the ORIGINAL digest (Zach→Zach, but no Re:/In-Reply-To) so we don't feed
     the model its own prior output as "feedback"."""
-    frm = _decode(msg.get("From")).lower()
-    if email_send.OWNER_EMAIL.lower() not in frm:
+    from email.utils import parseaddr
+    # EXACT addr-spec match (not substring) — a display-name or lookalike domain
+    # containing the address (e.g. `zachlowden1@gmail.com.evil.com`) must NOT pass.
+    frm_addr = parseaddr(_decode(msg.get("From")))[1].strip().lower()
+    if frm_addr != email_send.OWNER_EMAIL.lower():
         return False
     subj = _decode(msg.get("Subject")).strip().lower()
     is_re = subj.startswith("re:")
@@ -165,7 +168,11 @@ def strip_quoted(body: str) -> str:
     for raw in (body or "").splitlines():
         line = raw.rstrip()
         if _ATTRIBUTION_RE.match(line):
-            break
+            # SKIP the attribution line but keep scanning — do NOT cut here, or a
+            # bottom-posted reply (quote first, new text below) loses everything.
+            # Gmail >-prefixes every quoted line, so the quote itself is dropped below;
+            # only the (unprefixed) attribution needs removing.
+            continue
         if line.strip() == "--":  # signature delimiter (some clients omit the trailing space)
             break
         if line.lstrip().startswith(">"):

--- a/scripts/repo-cos/llm.py
+++ b/scripts/repo-cos/llm.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import sys
 from dataclasses import dataclass, field
 
 DEFAULT_MODEL = "deepseek/deepseek-v4-flash"
@@ -169,13 +170,49 @@ def _ref_known(ref: str, valid_refs: set[str]) -> bool:
     return any(v.split(":", 1)[0] == ref_path for v in valid_refs)
 
 
-def build_user_prompt(candidates: list[dict], *, top: int) -> str:
-    """Render the capped candidate evidence compactly (one line each) for the model."""
-    lines = [
+def build_feedback_block(feedback) -> str:
+    """Render the REPLY-FEEDBACK context block prepended to the user prompt.
+
+    `feedback` is a `feedback.Feedback` (duck-typed: needs `.prev_summary()` and
+    `.reply_text`). It carries LAST week's proposals + Zach's emailed reply so the model
+    can drop what he rejected and honor his steering — WITHOUT bypassing the evidence
+    requirement (the block is context, the HARD RULES below still apply to new output).
+    """
+    prev = feedback.prev_summary()
+    lines = ["=== LAST WEEK'S FEEDBACK (context — read before the new signals) ==="]
+    if prev:
+        lines.append("Previous proposals you sent the user:")
+        lines.extend(f"  - {p}" for p in prev)
+    else:
+        lines.append("(previous proposals unavailable)")
+    lines.append("")
+    lines.append(f'USER\'S REPLY: "{feedback.reply_text.strip()}"')
+    lines.append("")
+    lines.append(
+        "The user reviewed last week's proposals and replied above. Take their feedback "
+        "into account — do NOT re-propose what they rejected or dismissed, honor any "
+        "steering (what to focus on / ignore), and reflect their stated preferences — "
+        "while still surfacing genuinely NEW high-value candidates from the signals below. "
+        "This feedback is CONTEXT only: every new proposal must STILL cite concrete "
+        "file:line evidence from the candidates per the rules."
+    )
+    lines.append("=== END FEEDBACK ===")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_user_prompt(candidates: list[dict], *, top: int, feedback=None) -> str:
+    """Render the capped candidate evidence compactly (one line each) for the model.
+
+    When `feedback` is present, the REPLY-FEEDBACK block is prepended (before the new
+    candidates) so the model steers off last week's reply."""
+    lines: list[str] = []
+    if feedback is not None:
+        lines.append(build_feedback_block(feedback))
+    lines.append(
         f"Cluster these {len(candidates)} raw signals into at most {top} bounded, "
-        "shippable, ranked proposals per the rules. Candidates (kind | ref | detail):",
-        "",
-    ]
+        "shippable, ranked proposals per the rules. Candidates (kind | ref | detail):")
+    lines.append("")
     for c in candidates:
         detail = (c.get("text") or "").replace("\n", " ")[:160]
         lines.append(f"- {c['kind']:<12} {c['ref']}  {detail}")
@@ -221,6 +258,7 @@ def synthesize(
     top: int = 5,
     model: str | None = None,
     api_key: str | None = None,
+    feedback=None,
     _caller=_call_openrouter,
 ) -> Synthesis:
     """Synthesize proposals, retrying on malformed OR empty output. `_caller` injectable.
@@ -230,13 +268,22 @@ def synthesize(
     ARE candidates kills that empty-tail (a weekly digest should not be blank while real
     signals exist); we still emit an honest empty result if the model surfaces nothing
     across every attempt. `candidates` are candidate dicts (kind/ref/text).
+
+    `feedback` (optional `feedback.Feedback`): when present, LAST week's proposals + Zach's
+    emailed reply are prepended to the user prompt so the model drops what he rejected and
+    honors his steering. It's CONTEXT only — the structural evidence/anti-slop rules still
+    fully apply to new output.
     """
     model = model or os.environ.get("REPO_COS_MODEL", DEFAULT_MODEL)
     api_key = api_key or os.environ.get("OPENROUTER_API_KEY")
     if not api_key:
         raise RuntimeError("OPENROUTER_API_KEY not set")
     system = SYSTEM_PROMPT.replace("{top}", str(top))
-    user = build_user_prompt(candidates, top=top)
+    user = build_user_prompt(candidates, top=top, feedback=feedback)
+    if feedback is not None:
+        when = getattr(feedback, "replied_at", "") or "unknown"
+        print(f"  feedback: applied reply from {when} "
+              f"({len(feedback.reply_text)} chars) into synthesis", file=sys.stderr)
     valid_refs = {c["ref"] for c in candidates if c.get("ref")}
     approx = _approx_tokens(system) + _approx_tokens(user)
 

--- a/scripts/repo-cos/scan.py
+++ b/scripts/repo-cos/scan.py
@@ -121,10 +121,23 @@ def cmd_scan(args) -> int:
     if not cand_dicts:
         # Nothing to synthesize — emit an honest empty digest without spending.
         body = digest.render([], candidate_count=0)
-        return _deliver(body, args, proposals=[], candidate_count=0, approx_tokens=0)
+        return _deliver(body, args, proposals=[], candidate_count=0, approx_tokens=0,
+                        feedback_applied=False)
+
+    # ---- REPLY-FEEDBACK: pull Zach's reply to LAST week's digest as steering context.
+    # Best-effort — a None result (no prior digest, no reply, IMAP down) proceeds exactly
+    # as a stateless run would. --no-feedback skips the fetch entirely (clean/test runs).
+    fb = None
+    if not args.no_feedback:
+        try:
+            import feedback as feedback_mod
+            fb = feedback_mod.fetch_last_feedback()
+        except Exception as exc:  # noqa: BLE001
+            print(f"  ! feedback fetch failed (proceeding without): {exc}", file=sys.stderr)
+            fb = None
 
     try:
-        result = llm.synthesize(cand_dicts, top=args.top, model=args.model)
+        result = llm.synthesize(cand_dicts, top=args.top, model=args.model, feedback=fb)
     except Exception as exc:  # noqa: BLE001
         print(f"ERROR: synthesis failed: {exc}", file=sys.stderr)
         return 1
@@ -135,11 +148,13 @@ def cmd_scan(args) -> int:
         approx_tokens=result.approx_prompt_tokens,
     )
     print(f"  synthesis: model={result.model} candidates={len(cand_dicts)} "
-          f"proposals={len(result.proposals)} ~prompt_tokens={result.approx_prompt_tokens}",
+          f"proposals={len(result.proposals)} ~prompt_tokens={result.approx_prompt_tokens} "
+          f"feedback_applied={fb is not None}",
           file=sys.stderr)
     return _deliver(
         body, args, proposals=result.proposals,
         candidate_count=len(cand_dicts), approx_tokens=result.approx_prompt_tokens,
+        feedback_applied=fb is not None,
     )
 
 
@@ -172,7 +187,8 @@ def _emit_candidates(candidates, scans, cand_dicts, args) -> int:
     return 0
 
 
-def _deliver(body: str, args, *, proposals, candidate_count, approx_tokens) -> int:
+def _deliver(body: str, args, *, proposals, candidate_count, approx_tokens,
+             feedback_applied: bool = False) -> int:
     """Print (dry-run) or send (--email) the digest. --dry-run is the default and always
     prints; --email additionally sends."""
     if args.json:
@@ -180,6 +196,7 @@ def _deliver(body: str, args, *, proposals, candidate_count, approx_tokens) -> i
             "subject": digest.subject(),
             "candidate_count": candidate_count,
             "approx_prompt_tokens": approx_tokens,
+            "feedback_applied": feedback_applied,
             "proposals": [p.as_dict() for p in proposals],
             "emailed": bool(args.email),
         }, indent=2))
@@ -239,6 +256,9 @@ def build_parser() -> argparse.ArgumentParser:
                    help="Stage-1 only: print raw candidates, no LLM, no API key needed")
     p.add_argument("--candidates-only", action="store_true",
                    help="alias for --no-llm (the free pre-scan smoke test)")
+    p.add_argument("--no-feedback", action="store_true",
+                   help="skip pulling last week's emailed reply into synthesis "
+                        "(stateless run; for clean/testing)")
     p.add_argument("--repos", default=None,
                    help="comma-separated repo paths overriding the default list")
     p.add_argument("--limit-candidates", type=int, default=DEFAULT_LIMIT_CANDIDATES,

--- a/scripts/repo-cos/tests/test_feedback.py
+++ b/scripts/repo-cos/tests/test_feedback.py
@@ -247,3 +247,33 @@ def test_subject_core_present_in_digest_subject():
     from datetime import date
     assert feedback.digest.SUBJECT_CORE in digest.subject(date(2026, 7, 6))
     assert feedback.digest.SUBJECT_CORE == "Repo proposals"
+
+
+def test_strip_quoted_keeps_bottom_posted_reply():
+    # bottom-posting: quote FIRST, new text below the attribution — must NOT be dropped
+    # (the audit's 🟡: `break` at the attribution silently discarded the whole reply).
+    body = (
+        "On Mon, 1 Jul 2026 at 08:00, Zach <zachlowden1@gmail.com> wrote:\n"
+        "> 🧭 Repo proposals — week of 2026-07-01\n"
+        "> 1. Implement report modal for Model3D\n"
+        "\n"
+        "Yes to #1, and add auth to the assets controller too.\n"
+    )
+    cleaned = feedback.strip_quoted(body)
+    assert "Yes to #1, and add auth to the assets controller" in cleaned
+    assert "Model3D" not in cleaned      # quoted digest still stripped
+    assert "wrote:" not in cleaned       # attribution line removed
+
+
+def test_reply_from_owner_requires_exact_address():
+    ok = _mk_msg(subject="Re: 🧭 Repo proposals — week of 2026-07-01",
+                 frm="Zach Lowden <zachlowden1@gmail.com>", body="x", in_reply_to="<a>")
+    assert feedback._is_reply_from_owner(ok) is True
+    # lookalike domain (address as a substring) must be REJECTED
+    look = _mk_msg(subject="Re: 🧭 Repo proposals — week of 2026-07-01",
+                   frm="zachlowden1@gmail.com.evil.com", body="x", in_reply_to="<a>")
+    assert feedback._is_reply_from_owner(look) is False
+    # owner address only in the DISPLAY NAME; real addr-spec is the attacker's
+    spoof = _mk_msg(subject="Re: 🧭 Repo proposals — week of 2026-07-01",
+                    frm='"zachlowden1@gmail.com" <attacker@evil.com>', body="x", in_reply_to="<a>")
+    assert feedback._is_reply_from_owner(spoof) is False

--- a/scripts/repo-cos/tests/test_feedback.py
+++ b/scripts/repo-cos/tests/test_feedback.py
@@ -1,0 +1,249 @@
+"""REPLY-FEEDBACK tests — quoted-text stripping + IMAP fetch, all mocked (no network).
+
+Covers: strip_quoted removes ">" quotes AND the "On … wrote:" attribution block; a genuine
+reply is found + cleaned; no-reply → None; IMAP error → None (never raises); the original
+digest (no Re:/In-Reply-To) is NOT mistaken for a reply; subject-core matching.
+"""
+import email
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import feedback  # noqa: E402
+import digest  # noqa: E402
+
+
+# ---- strip_quoted ------------------------------------------------------------------
+
+def test_strip_quoted_removes_quotes_and_attribution():
+    body = (
+        "Drop the civitai 3D one, I'm not touching that.\n"
+        "Focus on the kubeclaw test fixes instead.\n"
+        "\n"
+        "On Mon, 1 Jul 2026 at 08:00, Zach Lowden <zachlowden1@gmail.com> wrote:\n"
+        "> 🧭 Repo proposals — week of 2026-07-01\n"
+        "> 1. Implement report modal for Model3D in civitai\n"
+        ">    why: completes a feature\n"
+    )
+    cleaned = feedback.strip_quoted(body)
+    assert "Drop the civitai 3D one" in cleaned
+    assert "Focus on the kubeclaw test fixes" in cleaned
+    # everything from the attribution onward is gone
+    assert "Repo proposals" not in cleaned
+    assert "Model3D" not in cleaned
+    assert ">" not in cleaned
+    assert "wrote:" not in cleaned
+
+
+def test_strip_quoted_drops_bare_quoted_lines_without_attribution():
+    body = "New note here.\n> quoted old line\n> another quote\nAnd more new text."
+    cleaned = feedback.strip_quoted(body)
+    assert "New note here." in cleaned
+    assert "And more new text." in cleaned
+    assert "quoted old line" not in cleaned
+
+
+def test_strip_quoted_keeps_legit_line_ending_wrote():
+    # a real reply line that merely ends in "wrote:" must NOT be cut as an attribution —
+    # only a "On … wrote:" attribution triggers the cut.
+    body = "Re the doc I wrote:\nkeep this, it's my actual reply."
+    cleaned = feedback.strip_quoted(body)
+    assert "Re the doc I wrote:" in cleaned
+    assert "keep this, it's my actual reply." in cleaned
+
+
+def test_strip_quoted_stops_at_signature():
+    body = "My reply.\n--\nZach\nSent from phone"
+    cleaned = feedback.strip_quoted(body)
+    assert cleaned == "My reply."
+
+
+def test_strip_quoted_caps_length():
+    body = "x" * (feedback.MAX_REPLY_CHARS + 500)
+    assert len(feedback.strip_quoted(body)) == feedback.MAX_REPLY_CHARS
+
+
+def test_strip_quoted_empty():
+    assert feedback.strip_quoted("") == ""
+    assert feedback.strip_quoted(None) == ""
+
+
+# ---- fake IMAP server --------------------------------------------------------------
+
+def _mk_msg(*, subject, frm, body, in_reply_to=None):
+    msg = email.message.EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = frm
+    msg["To"] = "zachlowden1@gmail.com"
+    if in_reply_to:
+        msg["In-Reply-To"] = in_reply_to
+        msg["References"] = in_reply_to
+    msg.set_content(body)
+    return msg
+
+
+class FakeIMAP:
+    """Minimal imaplib.IMAP4_SSL stand-in. `messages` maps mailbox name → list of
+    EmailMessage; SEARCH returns sequence numbers for messages whose subject contains the
+    searched SUBJECT token; FETCH returns the RFC822 bytes."""
+
+    def __init__(self, messages):
+        self._messages = messages
+        self._sel = None
+        self.logged_in = False
+        self.logged_out = False
+
+    def login(self, user, password):
+        self.logged_in = True
+        return ("OK", [b"ok"])
+
+    def select(self, mailbox, readonly=False):
+        name = mailbox.strip('"')
+        self._sel = name
+        if name not in self._messages:
+            return ("NO", [b"no such mailbox"])
+        return ("OK", [str(len(self._messages[name])).encode()])
+
+    def search(self, charset, *criteria):
+        # criteria e.g. ("SINCE", "30-Jun-2026", "SUBJECT", '"Repo proposals"')
+        subj_token = ""
+        for i, c in enumerate(criteria):
+            if c == "SUBJECT" and i + 1 < len(criteria):
+                subj_token = criteria[i + 1].strip('"')
+        msgs = self._messages.get(self._sel, [])
+        hits = [str(i + 1).encode() for i, m in enumerate(msgs)
+                if subj_token.lower() in str(m["Subject"]).lower()]
+        return ("OK", [b" ".join(hits)])
+
+    def fetch(self, num, spec):
+        idx = int(num) - 1
+        msgs = self._messages.get(self._sel, [])
+        if idx < 0 or idx >= len(msgs):
+            return ("NO", [None])
+        return ("OK", [(b"1 (RFC822)", msgs[idx].as_bytes())])
+
+    def logout(self):
+        self.logged_out = True
+        return ("BYE", [b"bye"])
+
+
+@pytest.fixture
+def latest(tmp_path, monkeypatch):
+    """Point feedback at a temp latest.json describing last week's digest."""
+    import json
+    data = {
+        "generated_at": "2026-07-01T08:00:00-05:00",
+        "subject": "🧭 Repo proposals — week of 2026-07-01",
+        "proposals": [
+            {"title": "Implement report modal for Model3D in civitai",
+             "evidence": ["civitai/docs/3d-models-followups.md:103"]},
+            {"title": "Fix skipped tests in baseball-manitoba-pitch",
+             "evidence": ["baseball-manitoba-pitch/api/x_test.go:33"]},
+        ],
+    }
+    p = tmp_path / "latest.json"
+    p.write_text(json.dumps(data))
+    monkeypatch.setattr(feedback, "PERSIST_LATEST", p)
+    return p
+
+
+def _creds():
+    return ("zachlowden1@gmail.com", "app-pw")
+
+
+def test_fetch_finds_reply_and_strips(latest):
+    reply = _mk_msg(
+        subject="Re: 🧭 Repo proposals — week of 2026-07-01",
+        frm="Zach Lowden <zachlowden1@gmail.com>",
+        body=("Skip the civitai 3D report modal — not doing that.\n"
+              "\n"
+              "On Mon, 1 Jul 2026 at 08:00, Zach <zachlowden1@gmail.com> wrote:\n"
+              "> 1. Implement report modal for Model3D\n"),
+        in_reply_to="<digest-msg-id@mail>",
+    )
+    fake = FakeIMAP({"INBOX": [reply]})
+    fb = feedback.fetch_last_feedback(_creds=_creds, _imap_factory=lambda: fake)
+    assert fb is not None
+    assert "Skip the civitai 3D report modal" in fb.reply_text
+    assert "Model3D" not in fb.reply_text  # quoted part stripped
+    assert fb.replied_at == "2026-07-01T08:00:00-05:00"
+    assert len(fb.prev_proposals) == 2
+    assert fake.logged_out is True
+    # prev_summary renders "title — evidence"
+    summ = fb.prev_summary()
+    assert any("Model3D" in s and "3d-models-followups.md:103" in s for s in summ)
+
+
+def test_fetch_ignores_original_digest_not_a_reply(latest):
+    # The original digest is Zach→Zach but has NO Re:/In-Reply-To → must NOT be treated
+    # as feedback (else the model gets fed its own prior output).
+    original = _mk_msg(
+        subject="🧭 Repo proposals — week of 2026-07-01",
+        frm="zachlowden1@gmail.com",
+        body="1. Implement report modal for Model3D\n",
+    )
+    fake = FakeIMAP({"INBOX": [original], feedback.ALL_MAIL: [original]})
+    fb = feedback.fetch_last_feedback(_creds=_creds, _imap_factory=lambda: fake)
+    assert fb is None
+
+
+def test_fetch_no_matching_mail_returns_none(latest):
+    other = _mk_msg(subject="Re: dinner plans", frm="zachlowden1@gmail.com",
+                    body="sure", in_reply_to="<x>")
+    fake = FakeIMAP({"INBOX": [other], feedback.ALL_MAIL: [other]})
+    fb = feedback.fetch_last_feedback(_creds=_creds, _imap_factory=lambda: fake)
+    assert fb is None
+
+
+def test_fetch_falls_back_to_all_mail(latest):
+    reply = _mk_msg(
+        subject="Re: 🧭 Repo proposals — week of 2026-07-01",
+        frm="zachlowden1@gmail.com",
+        body="Focus on kubeclaw tests.\n",
+        in_reply_to="<digest@mail>",
+    )
+    # only in All Mail, not INBOX (e.g. archived)
+    fake = FakeIMAP({"INBOX": [], feedback.ALL_MAIL: [reply]})
+    fb = feedback.fetch_last_feedback(_creds=_creds, _imap_factory=lambda: fake)
+    assert fb is not None
+    assert "Focus on kubeclaw tests." in fb.reply_text
+
+
+def test_fetch_imap_error_returns_none(latest):
+    def boom():
+        raise OSError("connection refused")
+    fb = feedback.fetch_last_feedback(_creds=_creds, _imap_factory=boom)
+    assert fb is None  # never raises
+
+
+def test_fetch_no_creds_returns_none(latest):
+    def bad_creds():
+        raise RuntimeError("no app password")
+    fb = feedback.fetch_last_feedback(_creds=bad_creds, _imap_factory=lambda: FakeIMAP({}))
+    assert fb is None
+
+
+def test_fetch_no_latest_json_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(feedback, "PERSIST_LATEST", tmp_path / "missing.json")
+    fb = feedback.fetch_last_feedback(_creds=_creds, _imap_factory=lambda: FakeIMAP({}))
+    assert fb is None
+
+
+def test_fetch_picks_most_recent_reply(latest):
+    old = _mk_msg(subject="Re: 🧭 Repo proposals — week of 2026-07-01",
+                  frm="zachlowden1@gmail.com", body="old reply", in_reply_to="<a>")
+    new = _mk_msg(subject="Re: 🧭 Repo proposals — week of 2026-07-01",
+                  frm="zachlowden1@gmail.com", body="new reply wins", in_reply_to="<b>")
+    fake = FakeIMAP({"INBOX": [old, new]})  # search returns ascending → newest last
+    fb = feedback.fetch_last_feedback(_creds=_creds, _imap_factory=lambda: fake)
+    assert fb is not None
+    assert "new reply wins" in fb.reply_text
+
+
+def test_subject_core_present_in_digest_subject():
+    # feedback matches on this ASCII fragment — it MUST be in what digest actually sends.
+    from datetime import date
+    assert feedback.digest.SUBJECT_CORE in digest.subject(date(2026, 7, 6))
+    assert feedback.digest.SUBJECT_CORE == "Repo proposals"

--- a/scripts/repo-cos/tests/test_llm.py
+++ b/scripts/repo-cos/tests/test_llm.py
@@ -179,3 +179,61 @@ def test_synthesize_returns_honest_empty_after_all_empty():
     cands = [{"kind": "marker", "ref": "devrc/scripts/a.py:12", "text": "t"}]
     res = llm.synthesize(cands, top=5, api_key="k", _caller=always_empty)
     assert res.proposals == []  # honest empty after retries — not an exception
+
+
+# ---- REPLY-FEEDBACK injection -------------------------------------------------------
+
+class _FakeFeedback:
+    def __init__(self, reply_text, prev):
+        self.reply_text = reply_text
+        self._prev = prev
+        self.replied_at = "2026-07-01T08:00:00-05:00"
+
+    def prev_summary(self):
+        return self._prev
+
+
+def test_synthesize_injects_feedback_block_into_user_prompt():
+    captured = {}
+
+    def caller(model, system, user, api_key, timeout=90.0):
+        captured["user"] = user
+        return GOOD
+
+    fb = _FakeFeedback(
+        reply_text="Drop the civitai 3D one, focus on kubeclaw test fixes.",
+        prev=["Implement report modal for Model3D in civitai — civitai/x.md:103"],
+    )
+    cands = [{"kind": "marker", "ref": "devrc/scripts/a.py:12", "text": "TODO fix"}]
+    llm.synthesize(cands, top=5, api_key="k", feedback=fb, _caller=caller)
+    user = captured["user"]
+    assert "LAST WEEK'S FEEDBACK" in user
+    assert "Drop the civitai 3D one, focus on kubeclaw test fixes." in user
+    assert "Implement report modal for Model3D in civitai — civitai/x.md:103" in user
+    assert "do NOT re-propose what they rejected" in user
+    # feedback block is prepended BEFORE the new candidates
+    assert user.index("LAST WEEK'S FEEDBACK") < user.index("devrc/scripts/a.py:12")
+    # evidence requirement is preserved (still asked to cite file:line)
+    assert "file:line evidence" in user
+
+
+def test_synthesize_no_feedback_prompt_unchanged():
+    captured = {}
+
+    def caller(model, system, user, api_key, timeout=90.0):
+        captured["user"] = user
+        return GOOD
+
+    cands = [{"kind": "marker", "ref": "devrc/scripts/a.py:12", "text": "TODO fix"}]
+    llm.synthesize(cands, top=5, api_key="k", _caller=caller)
+    user = captured["user"]
+    assert "LAST WEEK'S FEEDBACK" not in user
+    # matches the stateless build_user_prompt exactly
+    assert user == llm.build_user_prompt(cands, top=5)
+
+
+def test_build_feedback_block_handles_missing_prev():
+    fb = _FakeFeedback(reply_text="just steer generally", prev=[])
+    block = llm.build_feedback_block(fb)
+    assert "just steer generally" in block
+    assert "previous proposals unavailable" in block

--- a/scripts/repo-cos/tests/test_scan_cli.py
+++ b/scripts/repo-cos/tests/test_scan_cli.py
@@ -105,3 +105,123 @@ def test_persist_latest_never_raises(monkeypatch):
     # best-effort: an unwritable dir must not crash the run
     monkeypatch.setattr(scan, "PERSIST_DIR", Path("/proc/nonexistent/repo-cos"))
     scan._persist_latest([], subject="s", candidate_count=0, approx_tokens=0, emailed=False)
+
+
+# ---- REPLY-FEEDBACK wiring (feedback + llm mocked; no network) ----------------------
+
+class _RealishProp:
+    def __init__(self, title):
+        self.title, self.repo = title, "r"
+        self.evidence, self.why = ["r/f.py:1"], "w"
+        self.effort, self.approach, self.ci_verifiable = "S", "a", True
+
+    def as_dict(self):
+        return {"title": self.title, "repo": self.repo, "evidence": self.evidence,
+                "why": self.why, "effort": self.effort, "approach": self.approach,
+                "ci_verifiable": self.ci_verifiable}
+
+
+def _prime_llm_path(tmp_path, monkeypatch):
+    """Set up a repo with a real candidate + an API key + persist redirect so cmd_scan
+    reaches the LLM branch. Returns the sentinel feedback object the fake fetch yields."""
+    _write(tmp_path, "a.py", "# TODO fix the thing\n")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "k")
+    monkeypatch.setattr(scan, "PERSIST_DIR", tmp_path / "state")
+
+
+def test_scan_wires_feedback_into_synthesize(tmp_path, monkeypatch):
+    _prime_llm_path(tmp_path, monkeypatch)
+    import feedback as feedback_mod
+    import llm
+
+    sentinel = object()
+    monkeypatch.setattr(feedback_mod, "fetch_last_feedback", lambda: sentinel)
+
+    seen = {}
+
+    def fake_synth(cands, *, top, model, feedback=None):
+        seen["feedback"] = feedback
+        return llm.Synthesis(proposals=[_RealishProp("do it")], approx_prompt_tokens=10)
+
+    monkeypatch.setattr(llm, "synthesize", fake_synth)
+
+    args = scan.build_parser().parse_args(["--json", "--repos", str(tmp_path)])
+    rc = scan.cmd_scan(args)
+    assert rc == 0
+    assert seen["feedback"] is sentinel  # feedback was fetched AND passed through
+
+
+def test_scan_json_reports_feedback_applied(tmp_path, monkeypatch, capsys):
+    _prime_llm_path(tmp_path, monkeypatch)
+    import feedback as feedback_mod
+    import llm
+
+    monkeypatch.setattr(feedback_mod, "fetch_last_feedback", lambda: object())
+    monkeypatch.setattr(llm, "synthesize", lambda cands, *, top, model, feedback=None:
+                        llm.Synthesis(proposals=[_RealishProp("x")], approx_prompt_tokens=1))
+
+    args = scan.build_parser().parse_args(["--json", "--repos", str(tmp_path)])
+    scan.cmd_scan(args)
+    import json
+    data = json.loads(capsys.readouterr().out)
+    assert data["feedback_applied"] is True
+
+
+def test_scan_no_feedback_flag_skips_fetch(tmp_path, monkeypatch, capsys):
+    _prime_llm_path(tmp_path, monkeypatch)
+    import feedback as feedback_mod
+    import llm
+
+    called = {"fetch": False}
+
+    def spy_fetch():
+        called["fetch"] = True
+        return object()
+
+    monkeypatch.setattr(feedback_mod, "fetch_last_feedback", spy_fetch)
+
+    seen = {}
+
+    def fake_synth(cands, *, top, model, feedback=None):
+        seen["feedback"] = feedback
+        return llm.Synthesis(proposals=[_RealishProp("y")], approx_prompt_tokens=1)
+
+    monkeypatch.setattr(llm, "synthesize", fake_synth)
+
+    args = scan.build_parser().parse_args(
+        ["--no-feedback", "--json", "--repos", str(tmp_path)])
+    scan.cmd_scan(args)
+    assert called["fetch"] is False       # fetch skipped
+    assert seen["feedback"] is None       # synthesize got no feedback
+    import json
+    data = json.loads(capsys.readouterr().out)
+    assert data["feedback_applied"] is False
+
+
+def test_scan_feedback_fetch_failure_proceeds(tmp_path, monkeypatch):
+    # a raising fetch must not crash the run — synthesis proceeds with feedback=None.
+    _prime_llm_path(tmp_path, monkeypatch)
+    import feedback as feedback_mod
+    import llm
+
+    def boom():
+        raise RuntimeError("imap exploded")
+    monkeypatch.setattr(feedback_mod, "fetch_last_feedback", boom)
+
+    seen = {}
+
+    def fake_synth(cands, *, top, model, feedback=None):
+        seen["feedback"] = feedback
+        return llm.Synthesis(proposals=[_RealishProp("z")], approx_prompt_tokens=1)
+
+    monkeypatch.setattr(llm, "synthesize", fake_synth)
+
+    args = scan.build_parser().parse_args(["--json", "--repos", str(tmp_path)])
+    rc = scan.cmd_scan(args)
+    assert rc == 0
+    assert seen["feedback"] is None
+
+
+def test_no_feedback_flag_default_false():
+    args = scan.build_parser().parse_args([])
+    assert args.no_feedback is False


### PR DESCRIPTION
## What

repo-cos runs were **stateless** — every weekly digest ignored what Zach said about the last one. This adds a **REPLY-FEEDBACK loop**: the next run pulls his emailed reply to the previous digest and feeds it (plus last week's proposals) into synthesis as **context**, so the model drops what he rejected and honors his steering — while still surfacing genuinely new, evidence-backed candidates.

Kept **simple** (context injection, not deterministic suppression rules) and **self-contained** (IMAP + the app-password repo-cos already has — no homelab-cluster / Postgres / kubectl path, no new deps).

## How the loop works

1. **Fetch (Stage 0, `feedback.py`)** — reads the reply over **IMAP** (stdlib `imaplib`), reusing the SAME Gmail app-password already used for SMTP send via `email_send.load_credentials()`. Reads the previous digest's `subject` + `generated_at` from `~/.config/repo-cos/latest.json` (missing → returns `None`).
2. **Inject (`llm.py`)** — `synthesize()` gains an optional `feedback=` param. When present, a clearly-delimited block (previous proposals as `title — evidence`, then `USER'S REPLY: "…"`, then the steer instruction) is **prepended** to the user prompt, before the new candidates. The anti-slop / evidence rules are untouched — feedback is context, every new proposal must still cite `file:line`. Logs `feedback: applied reply from <date> (N chars)` to stderr.
3. **Wire (`scan.py`)** — best-effort `feedback.fetch_last_feedback()` before synthesis (guarded — `None` proceeds exactly as today). `--no-feedback` skips the fetch; `feedback_applied` reported in `--json` / stderr. Persistence already records the subject, so **this run's digest becomes next run's "previous"** — the loop closes on its own.

## Matching & stripping (and limits)

- **Match:** the digest subject is `🧭 Repo proposals — week of <date>`; the emoji + em-dash are non-ASCII and flaky in IMAP SEARCH, so we search on the ASCII-stable core **`Repo proposals`** (extracted as `digest.SUBJECT_CORE`, shared with `subject()` and asserted in tests). Restrict to mail **SINCE** the digest date (−1 day for TZ skew), then pick the **most-recent genuine reply from Zach** (`Re:` and/or `In-Reply-To`/`References`) — this rejects the original digest (Zach→Zach, no `Re:`) so the model isn't fed its own prior output. Looks in `INBOX`, falls back to `[Gmail]/All Mail`.
- **Strip:** drop `>`-quoted lines and everything from the `On … wrote:` attribution onward (anchored on leading `On ` + `wrote:` tail so a legit line ending in "wrote:" survives), stop at a `--` signature. Cap 4000 chars.
- **Safe:** any error — no creds, IMAP down, no match, parse fail — logs to stderr and returns `None`; **never crashes the run**. 30s IMAP timeout.
- **Known limits:** relies on subject-thread matching. If Gmail groups a reply under a different subject, or Zach composes a fresh mail instead of replying, it won't be found. Only the plain-text part is parsed.

## No infra change

`run-weekly.sh` / the weekly systemd unit need **no change**: `imaplib` is stdlib (already in the nix-shell), and the app-password is **already decrypted for SMTP** in the same run — the reply-fetch adds no new system deps or secrets. Stated explicitly per the brief.

## Tests

`scripts/repo-cos/tests/` — **80 pass** (57 pre-existing + 23 new), all with mocked `imaplib` / injected callers, **no live network**:
- `test_feedback.py` — quote+attribution stripping (incl. legit "wrote:" line preserved, signature cut, length cap), reply found+cleaned, no-reply→None, IMAP error→None (never raises), no-creds→None, no-latest.json→None, All-Mail fallback, most-recent-wins, original-digest-NOT-treated-as-reply, subject-core present in the sent subject.
- `test_llm.py` — feedback block injected into the user prompt (prepended before candidates, evidence requirement intact), prompt byte-identical to before when `feedback=None`, missing-prev handling.
- `test_scan_cli.py` — feedback fetched + passed through to `synthesize`, `--no-feedback` skips the fetch (synthesize gets `None`), `feedback_applied` in `--json`, a raising fetch proceeds with `None`.

Run: `nix-shell -p 'python3.withPackages(p:[p.pytest p.requests])' --run 'python -m pytest scripts/repo-cos/tests -q'`

## Not verified live

A real IMAP round-trip needs Zach's **actual reply** sitting in Gmail — I couldn't exercise a live login/search/fetch. The fetch/match/strip logic is unit-tested against a mock IMAP server (`FakeIMAP`) and the `--no-llm` smoke path runs clean, but the first real proof is next Monday's digest → reply → the following run logging `feedback: applied reply from …`. Gmail's exact threading/grouping of the reply is the main untested assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)