### PR TITLE
feat(repo-cos): deterministic reply→repo-exclusion layer

### DIFF
--- a/scripts/repo-cos/README.md
+++ b/scripts/repo-cos/README.md
@@ -27,6 +27,7 @@ shrinks the corpus, then the LLM runs on the small survivor set.
 | Stage | Module | What | Cost |
 |-------|--------|------|------|
 | 0 | `feedback.py` | pull Zach's IMAP reply to LAST digest → synthesis context | none |
+| 0.5 | `exclusions.py` | parse that reply → **HARD** repo-level exclusions (deterministic) | none |
 | 1 | `prescan.py` | cheap grep/git signals, capped **per repo** | none |
 | 2 | `llm.py` | OpenRouter clusters survivors → ranked JSON proposals | one call |
 | 3 | `digest.py` | one formatter shared by stdout **and** email | none |
@@ -69,6 +70,38 @@ anti-slop rules still fully apply.
   different subject (or you compose fresh instead of replying), it won't be found. The
   loop closes naturally because each run persists its own subject → next run's "previous".
 
+## Deterministic repo-exclusion layer (Stage 0.5) — `exclusions.py`
+
+Context-injection alone proved **too weak**: a reply that said `1. this project is paused
+/ … / 5. we are not the code owner for that repo` was *ignored* — the model re-proposed
+the exact paused repos. So a reply that scopes out a repo now becomes a **HARD,
+DETERMINISTIC filter** (no LLM) that DROPS those repos from the scan before synthesis ever
+runs — they **cannot reappear**. (The context-injection above is kept for nuance; this
+*adds* the hard layer.)
+
+- **Positional mapping (primary):** a line starting `N.` / `N)` / `N -` / `#N` / `N:` maps
+  to proposal **N** in the digest you actually saw → that proposal's repo.
+- **Keyword intent (deterministic set):** `paused / skip / ignore / stop / drop / remove /
+  don't / do not / won't / leave it / not (mine|ours|relevant|interested) / no / archived /
+  deprecated` → **exclude**. `not (the|code) owner` / `deprecated` / `archived` → the
+  exclusion is **permanent** (vs. `paused`, which is undoable). `resume / unpause /
+  un-exclude / re-enable / reactivate / bring back / … again` + a repo ref → **resume**
+  (un-exclude).
+- **Name mentions:** a reply naming a repo/alias (`kubeclaw`, `civitai`, `homelab`,
+  `datapacket`, …) with an exclude/resume intent applies even without a position number.
+- **Position source = the digest you SAW, not `latest.json`.** Proposals rotate run-to-run
+  and every run overwrites `latest.json`, so `--email` also writes **`last_emailed.json`**
+  (the emailed set). `parse_reply` maps `1./2./…` against `last_emailed.json` → else the
+  newest `history/*.json` with `emailed:true` → else `latest.json`.
+- **State:** `~/.config/repo-cos/exclusions.json` (`{repos:{<name>:{reason, excluded_at,
+  permanent, source}}}`) — **hand-editable**. Robust to a missing/corrupt file (→ empty).
+- **Visibility + undo:** excluded repos are surfaced as a digest footer (`Excluded
+  (paused/not-yours): … — reply "resume <repo>" to re-enable.`). `--show-exclusions` prints
+  the current state and exits; `--no-feedback` skips the reply parse too.
+- **Limits:** the keyword set is finite — a reply that's *pure prose* with no positional
+  anchor and no repo name won't exclude anything (it still reaches the LLM as context).
+  Unparseable lines are ignored and never raise.
+
 ## Usage
 
 ```sh
@@ -90,8 +123,9 @@ nix-shell -p 'python3.withPackages(p:[p.requests])' --run \
 ```
 
 Flags: `--dry-run` (default), `--email`, `--no-llm`/`--candidates-only`, `--no-feedback`
-(skip Stage 0), `--repos`, `--limit-candidates N` (default 60), `--top N` (default 5),
-`--model` (default `deepseek/deepseek-v4-flash`), `--json`.
+(skip Stage 0 **and** the exclusion parse), `--show-exclusions` (print exclusion state +
+exit), `--repos`, `--limit-candidates N` (default 60), `--top N` (default 5), `--model`
+(default `deepseek/deepseek-v4-flash`), `--json`.
 
 The weekly unit / `run-weekly.sh` need **no change**: `feedback.py` uses only stdlib
 `imaplib` (already available) and the SAME app-password already decrypted for SMTP send —

--- a/scripts/repo-cos/digest.py
+++ b/scripts/repo-cos/digest.py
@@ -22,25 +22,45 @@ def subject(today: date | None = None) -> str:
     return f"🧭 {SUBJECT_CORE} — week of {d.isoformat()}"
 
 
+def _excluded_footer(excluded_repos: list | None) -> str | None:
+    """The digest footer line that surfaces the deterministic exclusion state so Zach can
+    SEE what's paused and undo it. None when nothing is excluded."""
+    names = [str(r).strip() for r in (excluded_repos or []) if str(r).strip()]
+    if not names:
+        return None
+    return (f'Excluded (paused/not-yours): {", ".join(names)} — '
+            'reply "resume <repo>" to re-enable.')
+
+
 def render(proposals: list, *, today: date | None = None,
            candidate_count: int | None = None,
-           approx_tokens: int | None = None) -> str:
+           approx_tokens: int | None = None,
+           excluded_repos: list | None = None) -> str:
     """Render proposals (llm.Proposal objects) into a compact skimmable digest.
 
     Empty proposal list is handled explicitly (honest 'nothing surfaced' message rather
-    than a blank email)."""
+    than a blank email). `excluded_repos` (deterministically dropped from the scan) is
+    surfaced as a footer so Zach sees the state and can reply "resume <repo>" to undo it."""
     d = today or date.today()
+    excl_footer = _excluded_footer(excluded_repos)
     lines: list[str] = [subject(d), ""]
     if candidate_count is not None:
         meta = f"From {candidate_count} deterministic signal(s)"
         if approx_tokens is not None:
             meta += f" · ~{approx_tokens} prompt tokens"
+        if excluded_repos:
+            n = len([r for r in excluded_repos if str(r).strip()])
+            if n:
+                meta += f" · {n} repo(s) excluded"
         lines.append(meta)
         lines.append("")
 
     if not proposals:
         lines.append("No bounded, evidence-backed proposals surfaced this run.")
         lines.append("(That is a valid outcome — the bar is deliberately high.)")
+        if excl_footer:
+            lines.append("")
+            lines.append(excl_footer)
         return "\n".join(lines)
 
     for i, p in enumerate(proposals, 1):
@@ -54,6 +74,10 @@ def render(proposals: list, *, today: date | None = None,
         lines.append("   evidence:")
         for ref in p.evidence:
             lines.append(f"     - {ref}")
+        lines.append("")
+
+    if excl_footer:
+        lines.append(excl_footer)
         lines.append("")
 
     lines.append("—")

--- a/scripts/repo-cos/exclusions.py
+++ b/scripts/repo-cos/exclusions.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""DETERMINISTIC repo-exclusion layer — turn Zach's emailed reply into a HARD filter.
+
+Why this exists (a real failure this fixes):
+  repo-cos already feeds Zach's reply to the previous digest into synthesis as CONTEXT
+  (`feedback.py` → `llm.build_feedback_block`). That is too weak — the model IGNORED a
+  reply that said "1. this project is paused / … / 5. we are not the code owner for that
+  repo" and re-proposed the exact paused repos. His replies are really REPO-LEVEL SCOPE
+  EXCLUSIONS. This module makes them a HARD, DETERMINISTIC filter that DROPS those repos
+  from the scan BEFORE the LLM ever sees them — so an excluded repo CANNOT reappear.
+
+Design (mirrors the rest of repo-cos: deterministic, no LLM, best-effort, never raises):
+  * `parse_reply(reply_text, emailed_proposals)` → {"exclude":[...], "resume":[...]} using
+    POSITIONAL line mapping (`1.`, `2)`, `#3`, `4:` → proposal N's repo) + a fixed keyword
+    set + explicit repo-name/alias mentions. NO model call.
+  * State persists to ~/.config/repo-cos/exclusions.json (hand-editable by Zach).
+  * `apply(state, parsed)` merges excludes / drops resumes. `filter_repos(repos, state)`
+    drops excluded repos (match on realpath OR basename).
+  * Position mapping resolves against the LAST EMAILED digest (`last_emailed.json`, else the
+    most-recent history entry with emailed=true, else latest.json) — because proposals
+    ROTATE run-to-run and every run overwrites latest.json, so "1./2./…" must map to the
+    digest Zach ACTUALLY SAW, not whatever's current.
+
+The context-injection path (feedback.py → llm) is KEPT for nuance; this ADDS a hard layer.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+PERSIST_DIR = Path("~/.config/repo-cos").expanduser()
+EXCLUSIONS_FILE = PERSIST_DIR / "exclusions.json"
+LAST_EMAILED_FILE = PERSIST_DIR / "last_emailed.json"
+LATEST_FILE = PERSIST_DIR / "latest.json"
+HISTORY_DIR = PERSIST_DIR / "history"
+
+
+def _log(msg: str) -> None:
+    print(f"  exclusions: {msg}", file=sys.stderr)
+
+
+# ---- keyword sets (deterministic; case-insensitive) --------------------------------
+#
+# An EXCLUDE intent on a line drops that line's repo. A subset of phrasings mean the repo
+# is PERMANENTLY out of scope (we don't own it / it's dead) vs. merely paused.
+
+# Phrasings that mean "not ours / dead" → permanent exclusion.
+_PERMANENT_RE = re.compile(
+    r"""
+      not \s+ (?:the|our|my|code)? \s* owner            # "not the code owner", "not owner"
+    | (?:code[\s-]?owner)                                 # "not codeowner"
+    | not \s+ (?:mine|ours)                               # "not mine", "not ours"
+    | \b deprecated \b
+    | \b archived \b
+    | \b (?:dead|abandoned|retired|sunset) \b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Phrasings that mean "exclude" (paused / skip / ignore / drop / …). Non-permanent unless a
+# _PERMANENT_RE phrase also matches. Ordering doesn't matter — any match = exclude intent.
+_EXCLUDE_RE = re.compile(
+    r"""
+      \b paused? \b
+    | \b skip (?:ping|ped)? \b
+    | \b ignore \b
+    | \b stop \b
+    | \b drop \b
+    | \b remove \b
+    | \b exclude \b
+    | \b won'? t \b                                       # won't, wont
+    | \b do \s* n'? t \b                                  # don't, dont, do not
+    | \b do \s+ not \b
+    | leave \s+ (?:it|this|that)                          # "leave it", "leave this"
+    | not \s+ (?:relevant|interested|mine|ours)
+    | not \s+ (?:the|our|my|code)? \s* owner
+    | (?:code[\s-]?owner)
+    | \b deprecated \b
+    | \b archived \b
+    | \b (?:dead|abandoned|retired|sunset) \b
+    | \b no \b                                            # bare "no"
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Phrasings that mean "resume" (un-exclude / bring back). A resume beats an exclude on the
+# same line (Zach would only say "resume" about something already paused).
+_RESUME_RE = re.compile(
+    r"""
+      \b resume \b
+    | \b un[\s-]? pause \b                                # unpause, un-pause
+    | \b un[\s-]? exclude \b
+    | \b re[\s-]? enable \b
+    | \b reactivate \b
+    | bring \s+ back
+    | \b restart \b
+    | start \s+ .*? \b again \b
+    | \b again \b                                         # "do X again"
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# A leading positional anchor: "1." "2)" "3 -" "#4" "5:" (optionally indented). Group 1 = N.
+_POSITIONAL_RE = re.compile(r"^\s*(?:#\s*)?(\d{1,3})\s*(?:[.)\-:]|\s|$)")
+
+
+# ---- state (exclusions.json) -------------------------------------------------------
+
+def load_state(path: Path | None = None) -> dict:
+    """Load exclusions.json → {"repos": {key: {...}}}. Robust: missing/corrupt/wrong-shape
+    file → an empty state. Never raises."""
+    p = path or EXCLUSIONS_FILE
+    try:
+        if not p.exists():
+            return {"repos": {}}
+        obj = json.loads(p.read_text())
+        if not isinstance(obj, dict):
+            return {"repos": {}}
+        repos = obj.get("repos")
+        if not isinstance(repos, dict):
+            obj["repos"] = {}
+        return obj
+    except Exception as exc:  # noqa: BLE001
+        _log(f"could not read {p} ({exc}); starting empty")
+        return {"repos": {}}
+
+
+def save_state(state: dict, path: Path | None = None) -> None:
+    """Persist exclusions.json. Best-effort — never fails the run."""
+    p = path or EXCLUSIONS_FILE
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(state, indent=2, sort_keys=True))
+    except Exception as exc:  # noqa: BLE001
+        _log(f"could not save {p}: {exc}")
+
+
+# ---- emitted-digest resolution (position mapping source) ---------------------------
+
+def load_last_emailed(*, last_emailed: Path | None = None,
+                      history_dir: Path | None = None,
+                      latest: Path | None = None) -> dict | None:
+    """Resolve the digest Zach ACTUALLY SAW, for positional mapping. Order:
+        1. last_emailed.json (written on every --email send), else
+        2. the most-recent history/*.json entry with "emailed": true, else
+        3. latest.json (best-effort fallback).
+    Returns the parsed digest dict (with a "proposals" list) or None. Never raises."""
+    le = last_emailed or LAST_EMAILED_FILE
+    hd = history_dir or HISTORY_DIR
+    lt = latest or LATEST_FILE
+
+    try:
+        if le.exists():
+            obj = json.loads(le.read_text())
+            if isinstance(obj, dict) and obj.get("proposals") is not None:
+                return obj
+    except Exception as exc:  # noqa: BLE001
+        _log(f"could not read {le}: {exc}")
+
+    # most-recent history entry that was emailed
+    try:
+        if hd.is_dir():
+            for f in sorted(hd.glob("*.json"), reverse=True):
+                try:
+                    obj = json.loads(f.read_text())
+                except Exception:  # noqa: BLE001
+                    continue
+                if isinstance(obj, dict) and obj.get("emailed") is True:
+                    return obj
+    except Exception as exc:  # noqa: BLE001
+        _log(f"could not scan history {hd}: {exc}")
+
+    try:
+        if lt.exists():
+            obj = json.loads(lt.read_text())
+            if isinstance(obj, dict):
+                return obj
+    except Exception as exc:  # noqa: BLE001
+        _log(f"could not read {lt}: {exc}")
+    return None
+
+
+def write_last_emailed(proposals, *, subject: str, generated_at: str,
+                       path: Path | None = None) -> None:
+    """Snapshot the EMAILED proposals so a later reply's positional refs map to what Zach
+    saw (not the next run's rotated set). Best-effort. `proposals` are objects with
+    `.as_dict()` OR plain dicts."""
+    p = path or LAST_EMAILED_FILE
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        out = []
+        for pr in proposals:
+            out.append(pr.as_dict() if hasattr(pr, "as_dict") else dict(pr))
+        payload = {
+            "emailed_at": generated_at,
+            "subject": subject,
+            "proposals": out,
+        }
+        p.write_text(json.dumps(payload, indent=2))
+    except Exception as exc:  # noqa: BLE001
+        _log(f"could not write {p}: {exc}")
+
+
+# ---- alias map (repo-name mentions → repo key) -------------------------------------
+
+def build_alias_map(default_repos: list[str]) -> dict[str, str]:
+    """alias(lowercased) → repo basename. Built from each default repo's basename plus a
+    few obvious short forms, so a reply naming 'kubeclaw' / 'civitai' / 'homelab' /
+    'datapacket' maps to the right repo even without a position number."""
+    amap: dict[str, str] = {}
+    for r in default_repos:
+        base = Path(r).expanduser().name
+        if not base:
+            continue
+        amap[base.lower()] = base
+        # a short form = the part before the first '-' (e.g. baseball-manitoba-pitch →
+        # baseball, civitai-orchestration → civitai) — only when it's distinctive.
+        head = base.split("-", 1)[0].lower()
+        if head and head not in amap:
+            amap[head] = base
+    # explicit obvious short names (only added if the corresponding repo is present).
+    def _has(sub: str) -> str | None:
+        for r in default_repos:
+            b = Path(r).expanduser().name
+            if sub in b.lower():
+                return b
+        return None
+    for short, needle in (("homelab", "homelab"), ("datapacket", "datapacket"),
+                          ("civit", "civitai"), ("promptver", "promptver"),
+                          ("baseball", "baseball"), ("kubeclaw", "kubeclaw")):
+        b = _has(needle)
+        if b and short not in amap:
+            amap[short] = b
+    return amap
+
+
+def _find_named_repo(line: str, alias_map: dict[str, str]) -> str | None:
+    """Return the repo basename named in `line` via the alias map (longest alias first, so
+    'civitai-orchestration' beats 'civitai'), else None."""
+    low = line.lower()
+    for alias in sorted(alias_map, key=len, reverse=True):
+        if re.search(rf"\b{re.escape(alias)}\b", low):
+            return alias_map[alias]
+    return None
+
+
+# ---- the deterministic parser ------------------------------------------------------
+
+def parse_reply(reply_text: str, emailed_proposals: list[dict] | None,
+                *, alias_map: dict[str, str] | None = None) -> dict:
+    """Parse Zach's reply into {"exclude": [{repo, reason, permanent}], "resume": [repo]}.
+
+    DETERMINISTIC — no LLM. Line-by-line:
+      * a POSITIONAL line ('1.', '2)', '#3', '4:') → proposal N in `emailed_proposals`
+        (1-indexed) → its repo. This is the primary mechanism (Zach replies positionally).
+      * an EXCLUDE-intent keyword on the line → exclude that repo (permanent if a
+        _PERMANENT_RE phrase matches, e.g. 'not the code owner', 'deprecated').
+      * a RESUME-intent keyword + a repo ref (positional OR name) → add to `resume`.
+      * an explicit repo-NAME/alias mention (non-positional) with intent → apply likewise.
+    Unparseable lines are ignored (they still reach the LLM via context injection). Never
+    raises."""
+    parsed = {"exclude": [], "resume": []}
+    if not reply_text:
+        return parsed
+    props = emailed_proposals or []
+
+    # de-dupe: last write wins per repo, resume beats exclude.
+    excl: dict[str, dict] = {}
+    resume: set[str] = set()
+
+    for raw in reply_text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+
+        repo = _line_repo(line, props, alias_map)
+        if not repo:
+            continue
+
+        is_resume = bool(_RESUME_RE.search(line))
+        is_exclude = bool(_EXCLUDE_RE.search(line))
+
+        if is_resume:
+            resume.add(repo)
+            excl.pop(repo, None)
+            continue
+        if is_exclude:
+            permanent = bool(_PERMANENT_RE.search(line))
+            excl[repo] = {"repo": repo, "reason": line, "permanent": permanent}
+
+    # resume wins over exclude for the same repo
+    for r in resume:
+        excl.pop(r, None)
+
+    parsed["exclude"] = list(excl.values())
+    parsed["resume"] = sorted(resume)
+    return parsed
+
+
+def _line_repo(line: str, props: list[dict],
+               alias_map: dict[str, str] | None) -> str | None:
+    """Resolve the repo a line refers to: positional index first, else a named alias.
+
+    Positional takes precedence (it's the primary channel), but if the positional index is
+    out of range we still fall through to an alias mention on the same line — so "4. kubeclaw
+    is paused" excludes kubeclaw even if position 4 didn't exist."""
+    m = _POSITIONAL_RE.match(line)
+    if m:
+        n = int(m.group(1))
+        if 1 <= n <= len(props):
+            repo = str((props[n - 1] or {}).get("repo") or "").strip()
+            if repo:
+                return repo
+    if alias_map:
+        return _find_named_repo(line, alias_map)
+    return None
+
+
+# ---- apply + filter ----------------------------------------------------------------
+
+def apply(state: dict, parsed: dict, *, source: str = "reply",
+          now: str | None = None) -> dict:
+    """Merge `parsed` into `state`: add/refresh excludes, remove resumes. Returns the same
+    (mutated) state dict. Caller persists via save_state."""
+    repos = state.setdefault("repos", {})
+    ts = now or datetime.now().astimezone().isoformat(timespec="seconds")
+
+    for entry in parsed.get("exclude", []):
+        key = str(entry.get("repo") or "").strip()
+        if not key:
+            continue
+        prev = repos.get(key) or {}
+        repos[key] = {
+            "reason": entry.get("reason") or prev.get("reason") or "",
+            # once permanent, stays permanent even if a later paused-line re-touches it
+            "permanent": bool(entry.get("permanent") or prev.get("permanent")),
+            "excluded_at": prev.get("excluded_at") or ts,
+            "refreshed_at": ts,
+            "source": source,
+        }
+
+    for key in parsed.get("resume", []):
+        repos.pop(str(key).strip(), None)
+
+    return state
+
+
+def filter_repos(repos: list[str], state: dict) -> tuple[list[str], list[str]]:
+    """Split `repos` (paths or names) into (kept, excluded). A repo is excluded if its
+    realpath OR basename matches an excluded key (also compared by realpath/basename), so
+    '~/workspace/civit/civitai-orchestration' and a bare 'civitai-orchestration' both hit."""
+    keys = (state or {}).get("repos") or {}
+    if not keys:
+        return list(repos), []
+
+    # normalize excluded keys to a set of {realpath, basename} tokens.
+    excl_tokens: set[str] = set()
+    for k in keys:
+        excl_tokens.update(_tokens(k))
+
+    kept, excluded = [], []
+    for r in repos:
+        if _tokens(r) & excl_tokens:
+            excluded.append(r)
+        else:
+            kept.append(r)
+    return kept, excluded
+
+
+def _tokens(ref: str) -> set[str]:
+    """Comparison tokens for a repo ref: its basename and (if it looks like a path) its
+    expanded realpath. A bare name yields just the basename; a path yields both."""
+    ref = (ref or "").strip()
+    if not ref:
+        return set()
+    toks = set()
+    base = Path(ref).name
+    if base:
+        toks.add(base)
+    # only realpath-ify things that look like paths (contain a separator or ~)
+    if os.sep in ref or ref.startswith("~"):
+        try:
+            toks.add(os.path.realpath(Path(ref).expanduser()))
+        except Exception:  # noqa: BLE001
+            pass
+    return toks
+
+
+# ---- human-readable state (for --show-exclusions and the digest footer) ------------
+
+def excluded_names(state: dict) -> list[str]:
+    """Sorted list of excluded repo keys."""
+    return sorted((state or {}).get("repos") or {})
+
+
+def format_state(state: dict) -> str:
+    """Pretty one-block summary of the current exclusion state for --show-exclusions."""
+    repos = (state or {}).get("repos") or {}
+    if not repos:
+        return "repo-cos exclusions: none.\n(Excluded repos come from your emailed reply; " \
+               "hand-edit ~/.config/repo-cos/exclusions.json to adjust.)"
+    lines = [f"repo-cos exclusions: {len(repos)} repo(s) currently dropped from the scan.",
+             ""]
+    for key in sorted(repos):
+        e = repos[key] or {}
+        perm = "permanent" if e.get("permanent") else "paused"
+        src = e.get("source") or "?"
+        when = e.get("excluded_at") or "?"
+        reason = (e.get("reason") or "").strip()
+        lines.append(f"  {key}  [{perm}, {src}, since {when}]")
+        if reason:
+            lines.append(f"      reason: {reason}")
+    lines.append("")
+    lines.append('Reply "resume <repo>" to re-enable one, or edit '
+                 "~/.config/repo-cos/exclusions.json.")
+    return "\n".join(lines)

--- a/scripts/repo-cos/scan.py
+++ b/scripts/repo-cos/scan.py
@@ -53,6 +53,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import digest  # noqa: E402
+import exclusions  # noqa: E402
 import prescan  # noqa: E402
 
 # Workbench-local default repos. naida/vetr are laptop-only (~/workspace/scratch/) —
@@ -92,9 +93,71 @@ def resolve_repos(override: str | None) -> list[str]:
 
 
 def cmd_scan(args) -> int:
+    # --show-exclusions: print the current deterministic exclusion state and exit.
+    if getattr(args, "show_exclusions", False):
+        print(exclusions.format_state(exclusions.load_state()))
+        return 0
+
+    # ---- DETERMINISTIC EXCLUSIONS (load first; a reply can add to them before scan) ----
+    # Load the persisted exclusion state. If a reply was fetched (see below), it's parsed
+    # into repo-level exclusions and applied BEFORE the scan — so excluded repos are never
+    # scanned or synthesized and CANNOT reappear no matter what the LLM does.
+    excl_state = exclusions.load_state()
+
+    # ---- REPLY-FEEDBACK: fetch Zach's reply to LAST week's digest ONCE, up front.
+    # It serves two masters: (1) the DETERMINISTIC exclusion parse below, and (2) the
+    # existing context-injection into synthesis (passed through as `fb`). Best-effort — a
+    # None result (no prior digest, no reply, IMAP down) proceeds as a stateless run would.
+    # --no-feedback skips the fetch (and the exclusion parse) entirely. The Stage-1-only
+    # smoke modes (--no-llm/--candidates-only) skip the fetch too — they must stay free +
+    # network-less — but the ALREADY-PERSISTED exclusion filter below still applies to them.
+    fb = None
+    stage1_only = args.no_llm or args.candidates_only
+    if not args.no_feedback and not stage1_only:
+        try:
+            import feedback as feedback_mod
+            fb = feedback_mod.fetch_last_feedback()
+        except Exception as exc:  # noqa: BLE001
+            print(f"  ! feedback fetch failed (proceeding without): {exc}", file=sys.stderr)
+            fb = None
+
+        if fb is not None:
+            # Parse the reply into HARD exclusions against the digest Zach ACTUALLY SAW
+            # (the last EMAILED one — proposals rotate + latest.json is overwritten each run).
+            try:
+                emailed = exclusions.load_last_emailed()
+                emailed_props = (emailed or {}).get("proposals") or []
+                alias_map = exclusions.build_alias_map(DEFAULT_REPOS)
+                parsed = exclusions.parse_reply(fb.reply_text, emailed_props,
+                                                alias_map=alias_map)
+                if parsed["exclude"] or parsed["resume"]:
+                    exclusions.apply(excl_state, parsed, source="reply")
+                    exclusions.save_state(excl_state)
+                    if parsed["exclude"]:
+                        names = ", ".join(e["repo"] for e in parsed["exclude"])
+                        print(f"  exclusions: reply excluded {names}", file=sys.stderr)
+                    if parsed["resume"]:
+                        print(f"  exclusions: reply resumed {', '.join(parsed['resume'])}",
+                              file=sys.stderr)
+            except Exception as exc:  # noqa: BLE001
+                print(f"  ! exclusion parse failed (proceeding): {exc}", file=sys.stderr)
+
     repos = resolve_repos(args.repos)
     if not repos:
         print("ERROR: no repos to scan (none of the defaults exist and --repos empty).",
+              file=sys.stderr)
+        return 2
+
+    # Drop excluded repos deterministically — they never reach the scan or the LLM.
+    repos, excluded = exclusions.filter_repos(repos, excl_state)
+    excluded_names = exclusions.excluded_names(excl_state)
+    if excluded:
+        names = ", ".join(Path(r).name for r in excluded)
+        print(f"  excluding {len(excluded)} repo(s): {names} "
+              f"(reply 'resume <repo>' to re-enable)", file=sys.stderr)
+    if not repos:
+        print("ERROR: no repos to scan (all resolved repos are excluded — "
+              "reply 'resume <repo>' or edit ~/.config/repo-cos/exclusions.json).",
               file=sys.stderr)
         return 2
 
@@ -120,22 +183,13 @@ def cmd_scan(args) -> int:
 
     if not cand_dicts:
         # Nothing to synthesize — emit an honest empty digest without spending.
-        body = digest.render([], candidate_count=0)
+        body = digest.render([], candidate_count=0, excluded_repos=excluded_names)
         return _deliver(body, args, proposals=[], candidate_count=0, approx_tokens=0,
-                        feedback_applied=False)
+                        feedback_applied=False, excluded_repos=excluded_names)
 
-    # ---- REPLY-FEEDBACK: pull Zach's reply to LAST week's digest as steering context.
-    # Best-effort — a None result (no prior digest, no reply, IMAP down) proceeds exactly
-    # as a stateless run would. --no-feedback skips the fetch entirely (clean/test runs).
-    fb = None
-    if not args.no_feedback:
-        try:
-            import feedback as feedback_mod
-            fb = feedback_mod.fetch_last_feedback()
-        except Exception as exc:  # noqa: BLE001
-            print(f"  ! feedback fetch failed (proceeding without): {exc}", file=sys.stderr)
-            fb = None
-
+    # `fb` (Zach's reply) was already fetched up front — reused here as synthesis CONTEXT
+    # (nuance the deterministic exclusion layer can't express). The reply is passed through
+    # unchanged; the exclusion filter already ran on the repo list above.
     try:
         result = llm.synthesize(cand_dicts, top=args.top, model=args.model, feedback=fb)
     except Exception as exc:  # noqa: BLE001
@@ -146,15 +200,16 @@ def cmd_scan(args) -> int:
         result.proposals,
         candidate_count=len(cand_dicts),
         approx_tokens=result.approx_prompt_tokens,
+        excluded_repos=excluded_names,
     )
     print(f"  synthesis: model={result.model} candidates={len(cand_dicts)} "
           f"proposals={len(result.proposals)} ~prompt_tokens={result.approx_prompt_tokens} "
-          f"feedback_applied={fb is not None}",
+          f"feedback_applied={fb is not None} excluded={len(excluded_names)}",
           file=sys.stderr)
     return _deliver(
         body, args, proposals=result.proposals,
         candidate_count=len(cand_dicts), approx_tokens=result.approx_prompt_tokens,
-        feedback_applied=fb is not None,
+        feedback_applied=fb is not None, excluded_repos=excluded_names,
     )
 
 
@@ -188,15 +243,17 @@ def _emit_candidates(candidates, scans, cand_dicts, args) -> int:
 
 
 def _deliver(body: str, args, *, proposals, candidate_count, approx_tokens,
-             feedback_applied: bool = False) -> int:
+             feedback_applied: bool = False, excluded_repos=None) -> int:
     """Print (dry-run) or send (--email) the digest. --dry-run is the default and always
     prints; --email additionally sends."""
+    excluded_repos = list(excluded_repos or [])
     if args.json:
         print(json.dumps({
             "subject": digest.subject(),
             "candidate_count": candidate_count,
             "approx_prompt_tokens": approx_tokens,
             "feedback_applied": feedback_applied,
+            "excluded_repos": excluded_repos,
             "proposals": [p.as_dict() for p in proposals],
             "emailed": bool(args.email),
         }, indent=2))
@@ -208,9 +265,16 @@ def _deliver(body: str, args, *, proposals, candidate_count, approx_tokens,
     if args.email:
         import email_send
         try:
-            to = email_send.send_digest(subject=digest.subject(), body=body)
+            subj = digest.subject()
+            to = email_send.send_digest(subject=subj, body=body)
             print(f"\n  emailed digest → {to}", file=sys.stderr)
             emailed = True
+            # Snapshot the EMAILED proposals so a later reply's positional refs ("1./2./…")
+            # map to what Zach SAW — not the next run's rotated set. Best-effort.
+            from datetime import datetime
+            exclusions.write_last_emailed(
+                proposals, subject=subj,
+                generated_at=datetime.now().astimezone().isoformat(timespec="seconds"))
         except Exception as exc:  # noqa: BLE001
             print(f"ERROR: email send failed: {exc}", file=sys.stderr)
             rc = 1
@@ -257,8 +321,10 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--candidates-only", action="store_true",
                    help="alias for --no-llm (the free pre-scan smoke test)")
     p.add_argument("--no-feedback", action="store_true",
-                   help="skip pulling last week's emailed reply into synthesis "
-                        "(stateless run; for clean/testing)")
+                   help="skip pulling last week's emailed reply into synthesis AND the "
+                        "deterministic exclusion parse (stateless run; for clean/testing)")
+    p.add_argument("--show-exclusions", action="store_true",
+                   help="print the current deterministic repo-exclusion state and exit")
     p.add_argument("--repos", default=None,
                    help="comma-separated repo paths overriding the default list")
     p.add_argument("--limit-candidates", type=int, default=DEFAULT_LIMIT_CANDIDATES,

--- a/scripts/repo-cos/tests/test_exclusions.py
+++ b/scripts/repo-cos/tests/test_exclusions.py
@@ -1,0 +1,491 @@
+"""Deterministic repo-exclusion layer tests — parse_reply, filter_repos, state
+persistence, last-emailed resolution, and scan.py integration. No network, no LLM.
+
+The headline case: the EXACT reply that made the context-injection loop fail in practice —
+Zach replied "1. this project is paused / … / 5. we are not the code owner for that repo"
+and the model re-proposed the paused repos. Here that reply becomes a HARD filter.
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import exclusions  # noqa: E402
+import digest  # noqa: E402
+import scan  # noqa: E402
+
+
+# The digest Zach ACTUALLY SAW (5 emailed proposals). Positions 1-5 map to these repos.
+EMAILED = [
+    {"repo": "kubeclaw-cloud", "title": "Wire embed auth", "evidence": ["kubeclaw-cloud/a.go:1"]},
+    {"repo": "baseball-manitoba-pitch", "title": "Fix skip", "evidence": ["baseball-manitoba-pitch/x_test.go:3"]},
+    {"repo": "homelab-talos", "title": "Pin latest tag", "evidence": ["homelab-talos/d.yaml:9"]},
+    {"repo": "kubeclaw-cloud", "title": "Dead code", "evidence": ["kubeclaw-cloud/b.go:22"]},
+    {"repo": "civitai-orchestration", "title": "Add test", "evidence": ["civitai-orchestration/c.py:7"]},
+]
+
+# The exact real-world reply that the LLM-context path ignored.
+SAMPLE_REPLY = (
+    "1. this project is paused\n"
+    "2. this project is also paused\n"
+    "3. those services are paused\n"
+    "4. kubeclaw is paused\n"
+    "5. we are not the code owner for that repo\n"
+)
+
+DEFAULT_REPOS = [
+    "~/workspace/devrc",
+    "~/workspace/homelab-talos",
+    "~/workspace/kubeclaw",
+    "~/workspace/kubeclaw-cloud",
+    "~/workspace/promptver",
+    "~/workspace/baseball-manitoba-pitch",
+    "~/workspace/civit/civitai",
+    "~/workspace/civit/datapacket-talos",
+    "~/workspace/civit/civitai-orchestration",
+]
+
+
+def _alias():
+    return exclusions.build_alias_map(DEFAULT_REPOS)
+
+
+# ---- parse_reply: the headline sample -----------------------------------------------
+
+def test_parse_reply_exact_sample_excludes_all_paused_repos():
+    parsed = exclusions.parse_reply(SAMPLE_REPLY, EMAILED, alias_map=_alias())
+    excluded = {e["repo"] for e in parsed["exclude"]}
+    # positions 1-5 → these repos (kubeclaw-cloud appears at #1 and #4, deduped)
+    assert excluded == {
+        "kubeclaw-cloud", "baseball-manitoba-pitch",
+        "homelab-talos", "civitai-orchestration",
+    }
+    assert parsed["resume"] == []
+
+
+def test_parse_reply_not_code_owner_is_permanent():
+    parsed = exclusions.parse_reply(SAMPLE_REPLY, EMAILED, alias_map=_alias())
+    by_repo = {e["repo"]: e for e in parsed["exclude"]}
+    # #5 "we are not the code owner" → civitai-orchestration, permanent
+    assert by_repo["civitai-orchestration"]["permanent"] is True
+    # paused ones are NOT permanent
+    assert by_repo["baseball-manitoba-pitch"]["permanent"] is False
+    assert by_repo["homelab-talos"]["permanent"] is False
+
+
+def test_parse_reply_positional_and_keyword_both_hit_kubeclaw():
+    # line 4 "kubeclaw is paused" is BOTH positional #4 (→kubeclaw-cloud) AND names kubeclaw.
+    # Positional wins here (#4 → kubeclaw-cloud), and the repo is excluded either way.
+    parsed = exclusions.parse_reply("4. kubeclaw is paused\n", EMAILED, alias_map=_alias())
+    assert {e["repo"] for e in parsed["exclude"]} == {"kubeclaw-cloud"}
+
+
+def test_parse_reply_name_only_exclude_no_number():
+    # explicit repo-name exclusion without any position number
+    parsed = exclusions.parse_reply("civitai is deprecated, drop it\n", None,
+                                    alias_map=_alias())
+    excl = parsed["exclude"]
+    assert len(excl) == 1
+    assert excl[0]["repo"] == "civitai"
+    assert excl[0]["permanent"] is True  # "deprecated" → permanent
+
+
+def test_parse_reply_resume_moves_to_resume_list():
+    # 'kubeclaw' names the kubeclaw repo exactly (kubeclaw-cloud is a distinct repo).
+    parsed = exclusions.parse_reply("resume kubeclaw\n", None, alias_map=_alias())
+    assert parsed["resume"] == ["kubeclaw"]
+    assert parsed["exclude"] == []
+
+
+def test_parse_reply_resume_positional():
+    parsed = exclusions.parse_reply("2. resume this one\n", EMAILED, alias_map=_alias())
+    assert parsed["resume"] == ["baseball-manitoba-pitch"]
+
+
+def test_parse_reply_resume_beats_exclude_same_repo():
+    # a resume line and an exclude line for the same repo → resume wins
+    reply = "3. paused\n3. actually resume this\n"
+    parsed = exclusions.parse_reply(reply, EMAILED, alias_map=_alias())
+    assert parsed["resume"] == ["homelab-talos"]
+    assert all(e["repo"] != "homelab-talos" for e in parsed["exclude"])
+
+
+def test_parse_reply_unparseable_and_empty_never_raise():
+    assert exclusions.parse_reply("", EMAILED, alias_map=_alias()) == {"exclude": [], "resume": []}
+    assert exclusions.parse_reply(None, EMAILED, alias_map=_alias()) == {"exclude": [], "resume": []}
+    # prose with no positional/name anchor → nothing excluded (falls through to LLM context)
+    prose = "Great work this week, keep the momentum going on everything!\n"
+    parsed = exclusions.parse_reply(prose, EMAILED, alias_map=_alias())
+    assert parsed == {"exclude": [], "resume": []}
+
+
+def test_parse_reply_positional_no_intent_is_ignored():
+    # "1. looks good" — a bare positional line with NO exclude/resume keyword does nothing.
+    parsed = exclusions.parse_reply("1. looks good, ship it\n", EMAILED, alias_map=_alias())
+    assert parsed == {"exclude": [], "resume": []}
+
+
+def test_parse_reply_out_of_range_position_falls_through_to_name():
+    # position 9 doesn't exist, but the line names civitai → still excluded via alias
+    parsed = exclusions.parse_reply("9. civitai is paused\n", EMAILED, alias_map=_alias())
+    assert {e["repo"] for e in parsed["exclude"]} == {"civitai"}
+
+
+def test_parse_reply_various_numbering_styles():
+    for line in ["1) paused", "2 - paused", "#3 paused", "4: paused"]:
+        parsed = exclusions.parse_reply(line + "\n", EMAILED, alias_map=_alias())
+        assert len(parsed["exclude"]) == 1, line
+
+
+# ---- filter_repos -------------------------------------------------------------------
+
+def test_filter_repos_matches_path_and_basename():
+    state = {"repos": {"civitai-orchestration": {"permanent": True}}}
+    repos = [
+        "~/workspace/civit/civitai-orchestration",  # full path, excluded key is basename
+        "~/workspace/devrc",                          # kept
+    ]
+    kept, excluded = exclusions.filter_repos(repos, state)
+    assert kept == ["~/workspace/devrc"]
+    assert excluded == ["~/workspace/civit/civitai-orchestration"]
+
+
+def test_filter_repos_bare_basename_excluded():
+    state = {"repos": {"homelab-talos": {}}}
+    kept, excluded = exclusions.filter_repos(
+        ["homelab-talos", "kubeclaw"], state)
+    assert kept == ["kubeclaw"]
+    assert excluded == ["homelab-talos"]
+
+
+def test_filter_repos_empty_state_keeps_all():
+    repos = ["~/workspace/devrc", "~/workspace/kubeclaw"]
+    kept, excluded = exclusions.filter_repos(repos, {"repos": {}})
+    assert kept == repos
+    assert excluded == []
+
+
+# ---- persistence round-trip ---------------------------------------------------------
+
+def test_state_load_save_roundtrip(tmp_path):
+    p = tmp_path / "exclusions.json"
+    state = {"repos": {}}
+    parsed = exclusions.parse_reply(SAMPLE_REPLY, EMAILED, alias_map=_alias())
+    exclusions.apply(state, parsed, source="reply", now="2026-07-01T08:00:00-05:00")
+    exclusions.save_state(state, p)
+
+    loaded = exclusions.load_state(p)
+    assert set(loaded["repos"]) == {
+        "kubeclaw-cloud", "baseball-manitoba-pitch",
+        "homelab-talos", "civitai-orchestration",
+    }
+    coe = loaded["repos"]["civitai-orchestration"]
+    assert coe["permanent"] is True
+    assert coe["source"] == "reply"
+    assert coe["excluded_at"] == "2026-07-01T08:00:00-05:00"
+
+
+def test_load_state_missing_file_is_empty(tmp_path):
+    assert exclusions.load_state(tmp_path / "nope.json") == {"repos": {}}
+
+
+def test_load_state_corrupt_file_is_empty(tmp_path):
+    p = tmp_path / "exclusions.json"
+    p.write_text("{ this is not json ")
+    assert exclusions.load_state(p) == {"repos": {}}
+
+
+def test_load_state_wrong_shape_is_normalized(tmp_path):
+    p = tmp_path / "exclusions.json"
+    p.write_text(json.dumps(["not", "a", "dict"]))
+    assert exclusions.load_state(p) == {"repos": {}}
+    p.write_text(json.dumps({"repos": "not-a-dict"}))
+    assert exclusions.load_state(p)["repos"] == {}
+
+
+def test_apply_resume_removes_excluded(tmp_path):
+    state = {"repos": {"kubeclaw-cloud": {"permanent": False, "source": "reply"}}}
+    exclusions.apply(state, {"exclude": [], "resume": ["kubeclaw-cloud"]})
+    assert "kubeclaw-cloud" not in state["repos"]
+
+
+def test_apply_permanent_sticks_across_refresh():
+    # a repo excluded as permanent, then re-touched by a "paused" line, stays permanent.
+    state = {"repos": {}}
+    exclusions.apply(state, {"exclude": [{"repo": "r", "reason": "not owner", "permanent": True}],
+                             "resume": []})
+    exclusions.apply(state, {"exclude": [{"repo": "r", "reason": "paused", "permanent": False}],
+                             "resume": []})
+    assert state["repos"]["r"]["permanent"] is True
+
+
+# ---- load_last_emailed resolution order ---------------------------------------------
+
+def test_load_last_emailed_prefers_last_emailed_file(tmp_path):
+    le = tmp_path / "last_emailed.json"
+    hd = tmp_path / "history"
+    lt = tmp_path / "latest.json"
+    hd.mkdir()
+    le.write_text(json.dumps({"proposals": [{"repo": "from-last-emailed"}]}))
+    (hd / "20260101-000000.json").write_text(json.dumps({"emailed": True, "proposals": [{"repo": "from-history"}]}))
+    lt.write_text(json.dumps({"proposals": [{"repo": "from-latest"}]}))
+    got = exclusions.load_last_emailed(last_emailed=le, history_dir=hd, latest=lt)
+    assert got["proposals"][0]["repo"] == "from-last-emailed"
+
+
+def test_load_last_emailed_falls_back_to_history_emailed_true(tmp_path):
+    le = tmp_path / "missing.json"
+    hd = tmp_path / "history"
+    lt = tmp_path / "latest.json"
+    hd.mkdir()
+    # an older emailed=false and a newer emailed=true — the newest emailed=true wins
+    (hd / "20260101-000000.json").write_text(json.dumps({"emailed": False, "proposals": [{"repo": "old-not-emailed"}]}))
+    (hd / "20260601-000000.json").write_text(json.dumps({"emailed": True, "proposals": [{"repo": "newest-emailed"}]}))
+    lt.write_text(json.dumps({"proposals": [{"repo": "from-latest"}]}))
+    got = exclusions.load_last_emailed(last_emailed=le, history_dir=hd, latest=lt)
+    assert got["proposals"][0]["repo"] == "newest-emailed"
+
+
+def test_load_last_emailed_falls_back_to_latest(tmp_path):
+    le = tmp_path / "missing.json"
+    hd = tmp_path / "history"
+    lt = tmp_path / "latest.json"
+    hd.mkdir()
+    # history exists but nothing was emailed → fall back to latest.json
+    (hd / "20260101-000000.json").write_text(json.dumps({"emailed": False, "proposals": [{"repo": "x"}]}))
+    lt.write_text(json.dumps({"proposals": [{"repo": "from-latest"}]}))
+    got = exclusions.load_last_emailed(last_emailed=le, history_dir=hd, latest=lt)
+    assert got["proposals"][0]["repo"] == "from-latest"
+
+
+def test_load_last_emailed_none_when_nothing(tmp_path):
+    got = exclusions.load_last_emailed(
+        last_emailed=tmp_path / "a.json",
+        history_dir=tmp_path / "h",
+        latest=tmp_path / "b.json")
+    assert got is None
+
+
+# ---- digest footer ------------------------------------------------------------------
+
+def test_digest_footer_lists_excluded():
+    from datetime import date
+    body = digest.render([], today=date(2026, 7, 1),
+                         excluded_repos=["kubeclaw-cloud", "homelab-talos"])
+    assert "Excluded (paused/not-yours): kubeclaw-cloud, homelab-talos" in body
+    assert 'resume <repo>' in body
+
+
+def test_digest_no_footer_when_none():
+    from datetime import date
+    body = digest.render([], today=date(2026, 7, 1), excluded_repos=[])
+    assert "Excluded" not in body
+
+
+# ---- scan.py integration (feedback + llm mocked; no network) -------------------------
+
+class _RealishProp:
+    def __init__(self, title, repo="r"):
+        self.title, self.repo = title, repo
+        self.evidence, self.why = [f"{repo}/f.py:1"], "w"
+        self.effort, self.approach, self.ci_verifiable = "S", "a", True
+
+    def as_dict(self):
+        return {"title": self.title, "repo": self.repo, "evidence": self.evidence,
+                "why": self.why, "effort": self.effort, "approach": self.approach,
+                "ci_verifiable": self.ci_verifiable}
+
+
+class _FB:
+    def __init__(self, text):
+        self.reply_text = text
+        self.prev_proposals = []
+        self.replied_at = "2026-07-01T08:00:00-05:00"
+
+    def prev_summary(self):
+        return []
+
+
+def _two_repos(tmp_path):
+    keep = tmp_path / "keepme"
+    drop = tmp_path / "dropme"
+    (keep).mkdir()
+    (drop).mkdir()
+    (keep / "a.py").write_text("# TODO fix keep\n")
+    (drop / "b.py").write_text("# TODO fix drop\n")
+    return keep, drop
+
+
+def test_scan_reply_excludes_repo_from_synthesis(tmp_path, monkeypatch):
+    """A reply naming 'dropme' → that repo is filtered out and NEVER reaches scan_all/synth."""
+    keep, drop = _two_repos(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "k")
+    monkeypatch.setattr(scan, "PERSIST_DIR", tmp_path / "state")
+    # point the exclusions module's state + last_emailed at temp files
+    monkeypatch.setattr(exclusions, "EXCLUSIONS_FILE", tmp_path / "exclusions.json")
+    monkeypatch.setattr(exclusions, "LAST_EMAILED_FILE", tmp_path / "last_emailed.json")
+    monkeypatch.setattr(exclusions, "HISTORY_DIR", tmp_path / "history")
+    monkeypatch.setattr(exclusions, "LATEST_FILE", tmp_path / "latest.json")
+    # a last_emailed digest where position 1 = the 'dropme' repo
+    (tmp_path / "last_emailed.json").write_text(json.dumps(
+        {"proposals": [{"repo": "dropme", "title": "x", "evidence": ["dropme/b.py:1"]}]}))
+    # DEFAULT_REPOS-derived alias map: include dropme so name-mention also works
+    monkeypatch.setattr(scan, "DEFAULT_REPOS", [str(keep), str(drop)])
+
+    import feedback as feedback_mod
+    import llm
+    monkeypatch.setattr(feedback_mod, "fetch_last_feedback",
+                        lambda: _FB("1. this project is paused\n"))
+
+    seen = {}
+    orig_scan_all = scan.prescan.scan_all
+
+    def spy_scan_all(repos, limit, caps=None):
+        seen["repos"] = list(repos)
+        return orig_scan_all(repos, limit, caps)
+
+    monkeypatch.setattr(scan.prescan, "scan_all", spy_scan_all)
+    monkeypatch.setattr(llm, "synthesize",
+                        lambda cands, *, top, model, feedback=None:
+                        llm.Synthesis(proposals=[_RealishProp("ok", "keepme")], approx_prompt_tokens=1))
+
+    args = scan.build_parser().parse_args(
+        ["--json", "--repos", f"{keep},{drop}"])
+    rc = scan.cmd_scan(args)
+    assert rc == 0
+    # the excluded repo must NOT have been scanned
+    assert str(keep) in seen["repos"]
+    assert str(drop) not in seen["repos"]
+
+
+def test_scan_reply_excludes_repo_reports_in_json(tmp_path, monkeypatch, capsys):
+    keep, drop = _two_repos(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "k")
+    monkeypatch.setattr(scan, "PERSIST_DIR", tmp_path / "state")
+    monkeypatch.setattr(exclusions, "EXCLUSIONS_FILE", tmp_path / "exclusions.json")
+    monkeypatch.setattr(exclusions, "LAST_EMAILED_FILE", tmp_path / "last_emailed.json")
+    monkeypatch.setattr(exclusions, "HISTORY_DIR", tmp_path / "history")
+    monkeypatch.setattr(exclusions, "LATEST_FILE", tmp_path / "latest.json")
+    (tmp_path / "last_emailed.json").write_text(json.dumps(
+        {"proposals": [{"repo": "dropme"}]}))
+    monkeypatch.setattr(scan, "DEFAULT_REPOS", [str(keep), str(drop)])
+
+    import feedback as feedback_mod
+    import llm
+    monkeypatch.setattr(feedback_mod, "fetch_last_feedback",
+                        lambda: _FB("1. paused\n"))
+    monkeypatch.setattr(llm, "synthesize",
+                        lambda cands, *, top, model, feedback=None:
+                        llm.Synthesis(proposals=[_RealishProp("ok", "keepme")], approx_prompt_tokens=1))
+
+    args = scan.build_parser().parse_args(["--json", "--repos", f"{keep},{drop}"])
+    scan.cmd_scan(args)
+    data = json.loads(capsys.readouterr().out)
+    assert "dropme" in data["excluded_repos"]
+
+
+def test_scan_no_feedback_skips_exclusion_parse(tmp_path, monkeypatch):
+    keep, drop = _two_repos(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "k")
+    monkeypatch.setattr(scan, "PERSIST_DIR", tmp_path / "state")
+    monkeypatch.setattr(exclusions, "EXCLUSIONS_FILE", tmp_path / "exclusions.json")
+    monkeypatch.setattr(exclusions, "LAST_EMAILED_FILE", tmp_path / "last_emailed.json")
+    monkeypatch.setattr(exclusions, "HISTORY_DIR", tmp_path / "history")
+    monkeypatch.setattr(exclusions, "LATEST_FILE", tmp_path / "latest.json")
+
+    import feedback as feedback_mod
+    import llm
+    called = {"fetch": False}
+
+    def spy_fetch():
+        called["fetch"] = True
+        return _FB("1. paused\n")
+    monkeypatch.setattr(feedback_mod, "fetch_last_feedback", spy_fetch)
+
+    seen = {}
+    orig_scan_all = scan.prescan.scan_all
+
+    def spy_scan_all(repos, limit, caps=None):
+        seen["repos"] = list(repos)
+        return orig_scan_all(repos, limit, caps)
+    monkeypatch.setattr(scan.prescan, "scan_all", spy_scan_all)
+    monkeypatch.setattr(llm, "synthesize",
+                        lambda cands, *, top, model, feedback=None:
+                        llm.Synthesis(proposals=[_RealishProp("ok", "keepme")], approx_prompt_tokens=1))
+
+    args = scan.build_parser().parse_args(
+        ["--no-feedback", "--json", "--repos", f"{keep},{drop}"])
+    scan.cmd_scan(args)
+    assert called["fetch"] is False        # fetch skipped
+    # both repos scanned (nothing excluded)
+    assert str(keep) in seen["repos"] and str(drop) in seen["repos"]
+
+
+def test_show_exclusions_prints_and_exits(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(exclusions, "EXCLUSIONS_FILE", tmp_path / "exclusions.json")
+    (tmp_path / "exclusions.json").write_text(json.dumps(
+        {"repos": {"kubeclaw-cloud": {"permanent": False, "source": "reply",
+                                      "excluded_at": "2026-07-01T08:00:00-05:00",
+                                      "reason": "1. paused"}}}))
+    args = scan.build_parser().parse_args(["--show-exclusions"])
+    rc = scan.cmd_scan(args)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "kubeclaw-cloud" in out
+    assert "paused" in out
+
+
+def test_show_exclusions_empty_state(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(exclusions, "EXCLUSIONS_FILE", tmp_path / "nope.json")
+    args = scan.build_parser().parse_args(["--show-exclusions"])
+    rc = scan.cmd_scan(args)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "none" in out.lower()
+
+
+def test_show_exclusions_flag_default_false():
+    args = scan.build_parser().parse_args([])
+    assert args.show_exclusions is False
+
+
+def test_no_llm_smoke_does_not_fetch_feedback_but_still_filters(tmp_path, monkeypatch, capsys):
+    """The free Stage-1 smoke test must stay network-less (no IMAP fetch), yet a persisted
+    exclusion still drops the repo from the candidate scan."""
+    keep, drop = _two_repos(tmp_path)
+    monkeypatch.setattr(exclusions, "EXCLUSIONS_FILE", tmp_path / "exclusions.json")
+    (tmp_path / "exclusions.json").write_text(json.dumps({"repos": {drop.name: {}}}))
+
+    import feedback as feedback_mod
+    called = {"fetch": False}
+
+    def spy_fetch():
+        called["fetch"] = True
+        return _FB("1. paused\n")
+    monkeypatch.setattr(feedback_mod, "fetch_last_feedback", spy_fetch)
+
+    args = scan.build_parser().parse_args(
+        ["--no-llm", "--json", "--repos", f"{keep},{drop}"])
+    rc = scan.cmd_scan(args)
+    data = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert called["fetch"] is False  # no IMAP on the free smoke path
+    # the persisted exclusion still filtered the repo out of the candidate scan
+    scanned = {r["repo"] for r in data["repos"]}
+    assert drop.name not in scanned
+    assert keep.name in scanned
+
+
+def test_scan_all_excluded_errors(tmp_path, monkeypatch):
+    # if every resolved repo is excluded, cmd_scan errors cleanly (rc 2), no synthesis.
+    keep, drop = _two_repos(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "k")
+    monkeypatch.setattr(scan, "PERSIST_DIR", tmp_path / "state")
+    monkeypatch.setattr(exclusions, "EXCLUSIONS_FILE", tmp_path / "exclusions.json")
+    # pre-seed BOTH repos as excluded
+    (tmp_path / "exclusions.json").write_text(json.dumps(
+        {"repos": {keep.name: {}, drop.name: {}}}))
+    args = scan.build_parser().parse_args(
+        ["--no-feedback", "--json", "--repos", f"{keep},{drop}"])
+    rc = scan.cmd_scan(args)
+    assert rc == 2


### PR DESCRIPTION
## Why (real failure this fixes)

repo-cos emails weekly repo-improvement proposals; Zach can reply to steer the next run. A reply-feedback loop already existed (`feedback.py` IMAP-reads the reply → injects it into the LLM prompt as context) — but it **failed in practice**. Zach replied:

```
1. this project is paused
2. this project is also paused
3. those services are paused
4. kubeclaw is paused
5. we are not the code owner for that repo
```

…and the model **ignored it** — re-proposed the exact paused repos. Context-injection is too weak. His replies are really **repo-level scope exclusions**, so they now become a **HARD, DETERMINISTIC** filter that drops those repos from the scan *before synthesis* — they cannot reappear. The existing context-injection is kept for nuance; this **adds** a deterministic layer.

## The mechanism (`exclusions.py`, no LLM)

- **Positional mapping (primary):** a line starting `N.` / `N)` / `N -` / `#N` / `N:` maps to proposal **N** in the emailed digest → that proposal's repo. (Zach replies positionally.)
- **Deterministic keyword set:**
  - *Exclude:* `paused / skip / ignore / stop / drop / remove / exclude / don't / do not / won't / leave it / not (mine|ours|relevant|interested) / no / archived / deprecated / dead`.
  - *Permanent* (vs. undoable "paused"): `not (the|code) owner`, `deprecated`, `archived`, `dead/abandoned/retired`.
  - *Resume:* `resume / unpause / un-exclude / re-enable / reactivate / bring back / restart / … again` + a repo ref → moves the repo to the resume list (un-excludes).
- **Name mentions:** a reply naming a repo/alias (`kubeclaw`, `civitai`, `homelab`, `datapacket`, `baseball`, …) with an exclude/resume intent applies even without a position number. (Line 4 "kubeclaw is paused" is both positional #4 and a name — either path excludes it.)
- **Resume beats exclude** on the same repo; **permanent sticks** across a later "paused" re-touch.

## The emailed-digest position-mapping fix (rotation bug)

Proposals **rotate** run-to-run and every run **overwrites `latest.json`**, so a reply's `1./2./…` must map against the digest Zach **actually saw** = the last *emailed* one, not whatever's current. On `--email` sends we now also write `~/.config/repo-cos/last_emailed.json`. `load_last_emailed()` resolves in order: **`last_emailed.json`** → newest `history/*.json` with `emailed:true` → `latest.json`.

## Wiring (`scan.py`)

- Reply is fetched **once** up front (reusing `feedback.fetch_last_feedback()`), then `parse_reply` → `apply` → `save`. All best-effort (any error → stderr, proceed).
- After `resolve_repos`, excluded repos are dropped via `filter_repos` (matches realpath **or** basename, so `~/workspace/civit/civitai-orchestration` and a bare `civitai-orchestration` both hit) → the scan/synthesis only sees kept repos.
- `--show-exclusions` prints the current state + exits; `--no-feedback` skips the parse; the free `--no-llm` smoke path stays network-less but still honors already-persisted exclusions.
- The reply is still passed to `synthesize(feedback=…)` unchanged, for nuance.

## Visibility / undo

`exclusions.json` (`{repos:{<name>:{reason, excluded_at, permanent, source}}}`) is **hand-editable** and robust to a missing/corrupt file. The digest gains a footer — `Excluded (paused/not-yours): … — reply "resume <repo>" to re-enable.` — plus an "N repo(s) excluded" count in the header.

## How resume works

Reply `resume <repo>` (or `N. resume this`) → the repo is removed from `exclusions.json` and re-enters the next scan. Or hand-edit / delete the key in `exclusions.json`.

## Tests

+34 new (`tests/test_exclusions.py`), **116 total, all green** (82 existing untouched). Covers: the **exact** real reply → the 4 repos excluded with `civitai-orchestration` permanent; positional + keyword + name-only + resume + resume-beats-exclude + out-of-range-falls-through-to-name + numbering styles; `filter_repos` path/basename; persistence round-trip + corrupt/missing/wrong-shape; `load_last_emailed` resolution order; digest footer; scan integration (excluded repo never reaches `scan_all`/synthesis; JSON reports it; `--no-feedback` skips; all-excluded → rc 2; `--no-llm` doesn't fetch but still filters); `--show-exclusions`.

Run: `nix-shell -p 'python3.withPackages(p:[p.pytest p.requests])' --run 'python -m pytest scripts/repo-cos/tests -q'`

## Honest limits

- The keyword set is **finite** — a reply that's **pure prose** with no positional anchor and no repo name won't exclude anything (it still reaches the LLM as context via the existing injection). This is intentional: silence-by-default beats over-eager exclusion.
- Name-alias resolution prefers the longest match; `kubeclaw` (bare) resolves to the `kubeclaw` repo, distinct from `kubeclaw-cloud` (which needs a position or its full name).
- No change to the systemd unit / `run-weekly.sh` — stdlib + requests only, no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)