### PR TITLE
feat(repo-cos): recommendation-level dismissal (skip a proposal, keep the repo)

### DIFF
--- a/scripts/repo-cos/README.md
+++ b/scripts/repo-cos/README.md
@@ -27,7 +27,7 @@ shrinks the corpus, then the LLM runs on the small survivor set.
 | Stage | Module | What | Cost |
 |-------|--------|------|------|
 | 0 | `feedback.py` | read Zach's reply to LAST digest → synthesis context (Postgres default; IMAP fallback) | none |
-| 0.5 | `exclusions.py` | parse that reply → **HARD** repo-level exclusions (deterministic) | none |
+| 0.5 | `exclusions.py` | parse that reply → **HARD** repo-level exclusions **+ per-recommendation dismissals** (deterministic) | none |
 | 1 | `prescan.py` | cheap grep/git signals, capped **per repo** | none |
 | 2 | `llm.py` | OpenRouter clusters survivors → ranked JSON proposals | one call |
 | 3 | `digest.py` | one formatter shared by stdout **and** email | none |
@@ -89,26 +89,42 @@ runs — they **cannot reappear**. (The context-injection above is kept for nuan
 *adds* the hard layer.)
 
 - **Positional mapping (primary):** a line starting `N.` / `N)` / `N -` / `#N` / `N:` maps
-  to proposal **N** in the digest you actually saw → that proposal's repo.
-- **Keyword intent (deterministic set):** `paused / skip / ignore / stop / drop / remove /
-  don't / do not / won't / leave it / not (mine|ours|relevant|interested) / no / archived /
-  deprecated` → **exclude**. `not (the|code) owner` / `deprecated` / `archived` → the
-  exclusion is **permanent** (vs. `paused`, which is undoable). `resume / unpause /
-  un-exclude / re-enable / reactivate / bring back / … again` + a repo ref → **resume**
-  (un-exclude).
+  to proposal **N** in the digest you actually saw → that proposal's repo **and evidence**.
+- **Two intents, split by a strict precedence** (a reply distinguishes *pause the repo* from
+  *skip this one recommendation*):
+  1. **repo-pause** — `paused / on hold / hold off` → **repo exclusion** (non-permanent).
+  2. **repo-owner/dead** — `not (the|our|my|code) owner / not ours / deprecated / archived /
+     dead / …` → **repo exclusion, permanent**. (`dont own the 3d model FEATURE` does **not**
+     match — that's `dont own`, not `not owner`, and about a feature → falls to dismiss.)
+  3. **recommendation-dismiss** — `skip / not needed / not relevant / dismiss / nah / no /
+     don't (propose|want|need)` **when no repo-pause/owner language is present** → **dismiss
+     THAT proposal** (collect its evidence `repo/file:line` refs); the **repo stays in scope**.
+  Higher tiers win: a line with both `paused` and `skip` is a repo-pause. `resume / unpause /
+  … again` beats all three → **resume** (un-exclude a repo).
 - **Name mentions:** a reply naming a repo/alias (`kubeclaw`, `civitai`, `homelab`,
-  `datapacket`, …) with an exclude/resume intent applies even without a position number.
+  `datapacket`, …) with a **repo-level** intent applies even without a position number.
+  (Dismissal needs a *positional* line — there's no proposal to look up from a bare name.)
 - **Position source = the digest you SAW, not `latest.json`.** Proposals rotate run-to-run
   and every run overwrites `latest.json`, so `--email` also writes **`last_emailed.json`**
   (the emailed set). `parse_reply` maps `1./2./…` against `last_emailed.json` → else the
   newest `history/*.json` with `emailed:true` → else `latest.json`.
-- **State:** `~/.config/repo-cos/exclusions.json` (`{repos:{<name>:{reason, excluded_at,
-  permanent, source}}}`) — **hand-editable**. Robust to a missing/corrupt file (→ empty).
-- **Visibility + undo:** excluded repos are surfaced as a digest footer (`Excluded
-  (paused/not-yours): … — reply "resume <repo>" to re-enable.`). `--show-exclusions` prints
-  the current state and exits; `--no-feedback` skips the reply parse too.
+- **State:** `~/.config/repo-cos/exclusions.json` — **hand-editable**, two keys:
+  `{repos:{<name>:{reason, excluded_at, permanent, source}}}` (repo-level) and
+  `{dismissed:{<repo/file:line>:{reason, dismissed_at, repo}}}` (per-recommendation). Robust
+  to a missing/corrupt file **or an older file without `dismissed`** (→ empty). Dismissals
+  accumulate and are never auto-removed — hand-edit the JSON to un-dismiss one.
+- **Pre-scan dismiss filter (the guarantee):** `filter_candidates(candidates, state)` runs
+  right after `prescan.scan_all(...)` and **before** synthesis — it drops any candidate whose
+  `repo/file:line` ref is in `dismissed`, so a dismissed proposal's signal **never reaches
+  the LLM and cannot re-form**, while the rest of that repo still surfaces. Logs
+  `dismissed: N candidate(s) suppressed` to stderr.
+- **Visibility + undo:** excluded repos surface as a digest footer (`Excluded
+  (paused/not-yours): … — reply "resume <repo>" to re-enable.`); dismissals add a terse
+  `Dismissed N past proposal(s).` line. `--show-exclusions` prints **both** (repos +
+  each dismissed `repo/file:line` + reason) and exits; `--no-feedback` skips the reply parse.
 - **Limits:** the keyword set is finite — a reply that's *pure prose* with no positional
-  anchor and no repo name won't exclude anything (it still reaches the LLM as context).
+  anchor and no repo name (and no clear skip/pause anchor) won't exclude or dismiss anything
+  (it still reaches the LLM as context).
   Unparseable lines are ignored and never raise.
 
 ## Usage

--- a/scripts/repo-cos/digest.py
+++ b/scripts/repo-cos/digest.py
@@ -32,17 +32,29 @@ def _excluded_footer(excluded_repos: list | None) -> str | None:
             'reply "resume <repo>" to re-enable.')
 
 
+def _dismissed_footer(dismissed_count: int | None) -> str | None:
+    """Terse footer line surfacing how many past proposals were dismissed (skipped) — the
+    repos stay in scope, only those specific recommendations are suppressed. None when zero."""
+    n = int(dismissed_count or 0)
+    if n <= 0:
+        return None
+    return f"Dismissed {n} past proposal(s) (repos kept in scope)."
+
+
 def render(proposals: list, *, today: date | None = None,
            candidate_count: int | None = None,
            approx_tokens: int | None = None,
-           excluded_repos: list | None = None) -> str:
+           excluded_repos: list | None = None,
+           dismissed_count: int | None = None) -> str:
     """Render proposals (llm.Proposal objects) into a compact skimmable digest.
 
     Empty proposal list is handled explicitly (honest 'nothing surfaced' message rather
     than a blank email). `excluded_repos` (deterministically dropped from the scan) is
-    surfaced as a footer so Zach sees the state and can reply "resume <repo>" to undo it."""
+    surfaced as a footer so Zach sees the state and can reply "resume <repo>" to undo it.
+    `dismissed_count` (per-recommendation dismissals) is surfaced as a terse footer line."""
     d = today or date.today()
     excl_footer = _excluded_footer(excluded_repos)
+    dism_footer = _dismissed_footer(dismissed_count)
     lines: list[str] = [subject(d), ""]
     if candidate_count is not None:
         meta = f"From {candidate_count} deterministic signal(s)"
@@ -58,9 +70,12 @@ def render(proposals: list, *, today: date | None = None,
     if not proposals:
         lines.append("No bounded, evidence-backed proposals surfaced this run.")
         lines.append("(That is a valid outcome — the bar is deliberately high.)")
-        if excl_footer:
+        if excl_footer or dism_footer:
             lines.append("")
-            lines.append(excl_footer)
+            if excl_footer:
+                lines.append(excl_footer)
+            if dism_footer:
+                lines.append(dism_footer)
         return "\n".join(lines)
 
     for i, p in enumerate(proposals, 1):
@@ -76,8 +91,11 @@ def render(proposals: list, *, today: date | None = None,
             lines.append(f"     - {ref}")
         lines.append("")
 
-    if excl_footer:
-        lines.append(excl_footer)
+    if excl_footer or dism_footer:
+        if excl_footer:
+            lines.append(excl_footer)
+        if dism_footer:
+            lines.append(dism_footer)
         lines.append("")
 
     lines.append("—")

--- a/scripts/repo-cos/exclusions.py
+++ b/scripts/repo-cos/exclusions.py
@@ -9,13 +9,30 @@ Why this exists (a real failure this fixes):
   EXCLUSIONS. This module makes them a HARD, DETERMINISTIC filter that DROPS those repos
   from the scan BEFORE the LLM ever sees them — so an excluded repo CANNOT reappear.
 
+Two distinct intents (a real conflation this fixes):
+  * "pause this repo" — the WHOLE project is on hold → REPO-level exclusion (existing).
+    Signals: pause/paused/on hold/hold off; and not-owner/deprecated/archived (permanent).
+  * "skip this recommendation" — the repo is FINE, he just doesn't want THIS one proposal →
+    the repo STAYS in scope, but that single proposal must never resurface. Signals:
+    skip/not needed/not relevant/dismiss/nah/no/don't-propose WHEN no repo-pause/owner
+    language is present. This is RECOMMENDATION-level DISMISSAL.
+  Before this split, ANY skip keyword dropped the whole repo — so "we dont own the 3d model
+  feature, skip" (about a FEATURE) wrongly excluded all of civitai. The parser now classifies
+  per line with a strict precedence: repo-pause > repo-owner/dead > recommendation-dismiss.
+
 Design (mirrors the rest of repo-cos: deterministic, no LLM, best-effort, never raises):
-  * `parse_reply(reply_text, emailed_proposals)` → {"exclude":[...], "resume":[...]} using
-    POSITIONAL line mapping (`1.`, `2)`, `#3`, `4:` → proposal N's repo) + a fixed keyword
-    set + explicit repo-name/alias mentions. NO model call.
-  * State persists to ~/.config/repo-cos/exclusions.json (hand-editable by Zach).
-  * `apply(state, parsed)` merges excludes / drops resumes. `filter_repos(repos, state)`
-    drops excluded repos (match on realpath OR basename).
+  * `parse_reply(reply_text, emailed_proposals)` →
+      {"exclude":[...], "resume":[...], "dismiss":[{evidence, reason, repo}]}
+    using POSITIONAL line mapping (`1.`, `2)`, `#3`, `4:` → proposal N) + a fixed keyword
+    set + explicit repo-name/alias mentions. A dismiss line collects proposal N's `evidence`
+    (repo/file:line refs) so the exact recommendation can be suppressed. NO model call.
+  * State persists to ~/.config/repo-cos/exclusions.json (hand-editable by Zach) under two
+    top-level keys: "repos" (repo-level exclusions) and "dismissed" (per-recommendation,
+    keyed by the normalized evidence ref → {reason, dismissed_at, repo}).
+  * `apply(state, parsed)` merges excludes / drops resumes / accumulates dismissals.
+    `filter_repos(repos, state)` drops excluded repos (match on realpath OR basename).
+    `filter_candidates(candidates, state)` drops dismissed candidates by evidence ref BEFORE
+    the LLM — the guarantee a skipped proposal can't re-form from the same signal.
   * Position mapping resolves against the LAST EMAILED digest (`last_emailed.json`, else the
     most-recent history entry with emailed=true, else latest.json) — because proposals
     ROTATE run-to-run and every run overwrites latest.json, so "1./2./…" must map to the
@@ -45,10 +62,27 @@ def _log(msg: str) -> None:
 
 # ---- keyword sets (deterministic; case-insensitive) --------------------------------
 #
-# An EXCLUDE intent on a line drops that line's repo. A subset of phrasings mean the repo
-# is PERMANENTLY out of scope (we don't own it / it's dead) vs. merely paused.
+# Each numbered-reply line is classified into ONE intent with a strict precedence:
+#   1. REPO-PAUSE     (pause/paused/on hold/hold off)        → repo exclusion, non-permanent
+#   2. REPO-OWNER/DEAD (not owner / deprecated / archived)   → repo exclusion, PERMANENT
+#   3. RECOMMENDATION-DISMISS (skip/not needed/dismiss/no…)  → drop THAT proposal, keep repo
+# Higher tiers win: "kubeclaw is paused" is repo-pause even though it lacks skip words; a line
+# with BOTH "paused" and "skip" is a repo-pause (the whole project is on hold). Only a line
+# whose sole intent is skip/dismiss (no pause/owner language) dismisses a single proposal.
 
-# Phrasings that mean "not ours / dead" → permanent exclusion.
+# Tier 1 — "the whole repo is on hold" → REPO-level, non-permanent.
+_REPO_PAUSE_RE = re.compile(
+    r"""
+      \b paused? \b
+    | on \s+ hold
+    | \b hold \s+ off \b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Tier 2 — "not ours / dead" → REPO-level, PERMANENT. NOTE the owner alternative is
+# `not (the|our|my|code) owner` — it does NOT fire on "dont own the 3d model FEATURE"
+# (that's "dont own", not "not owner", and about a feature), which must fall to dismiss.
 _PERMANENT_RE = re.compile(
     r"""
       not \s+ (?:the|our|my|code)? \s* owner            # "not the code owner", "not owner"
@@ -61,28 +95,41 @@ _PERMANENT_RE = re.compile(
     re.IGNORECASE | re.VERBOSE,
 )
 
-# Phrasings that mean "exclude" (paused / skip / ignore / drop / …). Non-permanent unless a
-# _PERMANENT_RE phrase also matches. Ordering doesn't matter — any match = exclude intent.
+# Any REPO-level exclude intent = tier 1 OR tier 2 (plus a few legacy synonyms that clearly
+# mean "drop the whole repo": ignore/stop/drop/remove/exclude/leave-it). Skip/no/don't were
+# REMOVED from here — they are now recommendation-DISMISS signals (tier 3), not repo drops.
 _EXCLUDE_RE = re.compile(
     r"""
       \b paused? \b
-    | \b skip (?:ping|ped)? \b
+    | on \s+ hold
+    | \b hold \s+ off \b
     | \b ignore \b
     | \b stop \b
-    | \b drop \b
     | \b remove \b
     | \b exclude \b
-    | \b won'? t \b                                       # won't, wont
-    | \b do \s* n'? t \b                                  # don't, dont, do not
-    | \b do \s+ not \b
     | leave \s+ (?:it|this|that)                          # "leave it", "leave this"
-    | not \s+ (?:relevant|interested|mine|ours)
+    | not \s+ (?:interested|mine|ours)                    # "not relevant" is a DISMISS signal
     | not \s+ (?:the|our|my|code)? \s* owner
     | (?:code[\s-]?owner)
     | \b deprecated \b
     | \b archived \b
     | \b (?:dead|abandoned|retired|sunset) \b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Tier 3 — "skip THIS recommendation" → dismiss one proposal, repo STAYS in scope. Only
+# considered when NO repo-pause/owner language is present (enforced by precedence in
+# parse_reply). "not relevant"/"not interested" here mean the PROPOSAL, not the repo.
+_DISMISS_RE = re.compile(
+    r"""
+      \b skip (?:ping|ped)? \b
+    | \b dismiss (?:ed|ing)? \b
+    | not \s+ needed
+    | not \s+ relevant
+    | \b nah \b
     | \b no \b                                            # bare "no"
+    | do \s* n'? t \s+ (?:propose|want|need)              # don't propose/want/need
     """,
     re.IGNORECASE | re.VERBOSE,
 )
@@ -110,23 +157,31 @@ _POSITIONAL_RE = re.compile(r"^\s*(?:#\s*)?(\d{1,3})\s*(?:[.)\-:]|\s|$)")
 
 # ---- state (exclusions.json) -------------------------------------------------------
 
+def _empty_state() -> dict:
+    return {"repos": {}, "dismissed": {}}
+
+
 def load_state(path: Path | None = None) -> dict:
-    """Load exclusions.json → {"repos": {key: {...}}}. Robust: missing/corrupt/wrong-shape
-    file → an empty state. Never raises."""
+    """Load exclusions.json → {"repos": {...}, "dismissed": {...}}. Robust:
+    missing/corrupt/wrong-shape file → an empty state; an OLDER file with no "dismissed"
+    key loads clean with an empty dismissed dict. Never raises."""
     p = path or EXCLUSIONS_FILE
     try:
         if not p.exists():
-            return {"repos": {}}
+            return _empty_state()
         obj = json.loads(p.read_text())
         if not isinstance(obj, dict):
-            return {"repos": {}}
-        repos = obj.get("repos")
-        if not isinstance(repos, dict):
+            return _empty_state()
+        if not isinstance(obj.get("repos"), dict):
             obj["repos"] = {}
+        # older files predate the dismiss feature → default to empty (robust to a
+        # missing OR wrong-shaped "dismissed" key).
+        if not isinstance(obj.get("dismissed"), dict):
+            obj["dismissed"] = {}
         return obj
     except Exception as exc:  # noqa: BLE001
         _log(f"could not read {p} ({exc}); starting empty")
-        return {"repos": {}}
+        return _empty_state()
 
 
 def save_state(state: dict, path: Path | None = None) -> None:
@@ -252,45 +307,68 @@ def _find_named_repo(line: str, alias_map: dict[str, str]) -> str | None:
 
 def parse_reply(reply_text: str, emailed_proposals: list[dict] | None,
                 *, alias_map: dict[str, str] | None = None) -> dict:
-    """Parse Zach's reply into {"exclude": [{repo, reason, permanent}], "resume": [repo]}.
+    """Parse Zach's reply into
+        {"exclude": [{repo, reason, permanent}], "resume": [repo],
+         "dismiss": [{evidence: [refs], reason, repo}]}.
 
-    DETERMINISTIC — no LLM. Line-by-line:
+    DETERMINISTIC — no LLM. Line-by-line, with a STRICT intent precedence:
+      * RESUME beats everything (Zach only says "resume" about something paused).
       * a POSITIONAL line ('1.', '2)', '#3', '4:') → proposal N in `emailed_proposals`
-        (1-indexed) → its repo. This is the primary mechanism (Zach replies positionally).
-      * an EXCLUDE-intent keyword on the line → exclude that repo (permanent if a
-        _PERMANENT_RE phrase matches, e.g. 'not the code owner', 'deprecated').
-      * a RESUME-intent keyword + a repo ref (positional OR name) → add to `resume`.
-      * an explicit repo-NAME/alias mention (non-positional) with intent → apply likewise.
+        (1-indexed) → its repo AND its evidence. This is the primary mechanism.
+      * TIER 1 repo-pause (paused/on hold) → repo exclusion (non-permanent).
+      * TIER 2 repo-owner/dead (not owner/deprecated/archived) → repo exclusion (permanent).
+      * TIER 3 skip/dismiss (skip/not needed/dismiss/no…) WHEN no tier-1/2 language →
+        DISMISS that one proposal: collect proposal N's `evidence` refs; the repo STAYS.
+      * an explicit repo-NAME/alias mention (non-positional) with repo-level intent applies
+        likewise (name-mentions cannot dismiss — there's no proposal to look up).
     Unparseable lines are ignored (they still reach the LLM via context injection). Never
     raises."""
-    parsed = {"exclude": [], "resume": []}
+    parsed = {"exclude": [], "resume": [], "dismiss": []}
     if not reply_text:
         return parsed
     props = emailed_proposals or []
 
-    # de-dupe: last write wins per repo, resume beats exclude.
+    # de-dupe: last write wins per repo; resume beats exclude. Dismissals accumulate keyed
+    # by evidence ref so re-touching the same proposal doesn't duplicate.
     excl: dict[str, dict] = {}
     resume: set[str] = set()
+    dismiss: dict[str, dict] = {}  # ref -> {evidence:[ref], reason, repo}
 
     for raw in reply_text.splitlines():
         line = raw.strip()
         if not line:
             continue
 
-        repo = _line_repo(line, props, alias_map)
+        repo, prop = _line_repo(line, props, alias_map)
         if not repo:
             continue
 
-        is_resume = bool(_RESUME_RE.search(line))
-        is_exclude = bool(_EXCLUDE_RE.search(line))
-
-        if is_resume:
+        # RESUME first — un-pauses a repo regardless of any other keyword on the line.
+        if _RESUME_RE.search(line):
             resume.add(repo)
             excl.pop(repo, None)
             continue
-        if is_exclude:
-            permanent = bool(_PERMANENT_RE.search(line))
-            excl[repo] = {"repo": repo, "reason": line, "permanent": permanent}
+
+        # Precedence: repo-pause > repo-owner/dead > recommendation-dismiss.
+        if _REPO_PAUSE_RE.search(line):
+            excl[repo] = {"repo": repo, "reason": line, "permanent": False}
+            continue
+        if _PERMANENT_RE.search(line):
+            excl[repo] = {"repo": repo, "reason": line, "permanent": True}
+            continue
+        if _EXCLUDE_RE.search(line):
+            # a legacy repo-level synonym (ignore/stop/remove/exclude/leave-it/not-relevant)
+            excl[repo] = {"repo": repo, "reason": line,
+                          "permanent": bool(_PERMANENT_RE.search(line))}
+            continue
+        if _DISMISS_RE.search(line):
+            # RECOMMENDATION-level: suppress THIS proposal, keep the repo. Needs the
+            # proposal's evidence — only available via a positional match.
+            refs = _proposal_evidence(prop)
+            if not refs:
+                continue  # no evidence to key on (e.g. a name-only line) → can't dismiss
+            for ref in refs:
+                dismiss[ref] = {"evidence": [ref], "reason": line, "repo": repo}
 
     # resume wins over exclude for the same repo
     for r in resume:
@@ -298,35 +376,64 @@ def parse_reply(reply_text: str, emailed_proposals: list[dict] | None,
 
     parsed["exclude"] = list(excl.values())
     parsed["resume"] = sorted(resume)
+    # collapse per-ref dismiss entries back to per-proposal {evidence:[...], reason, repo}
+    # grouped by (reason, repo) so one skip line yields ONE dismiss with all its refs.
+    grouped: dict[tuple, dict] = {}
+    for ref, d in dismiss.items():
+        k = (d["reason"], d["repo"])
+        grouped.setdefault(k, {"evidence": [], "reason": d["reason"], "repo": d["repo"]})
+        grouped[k]["evidence"].append(ref)
+    for g in grouped.values():
+        g["evidence"] = sorted(set(g["evidence"]))
+    parsed["dismiss"] = list(grouped.values())
     return parsed
 
 
-def _line_repo(line: str, props: list[dict],
-               alias_map: dict[str, str] | None) -> str | None:
-    """Resolve the repo a line refers to: positional index first, else a named alias.
+def _proposal_evidence(prop: dict | None) -> list[str]:
+    """The normalized evidence refs of a proposal (its `evidence` list). Each ref is
+    canonicalized to match how prescan emits candidate refs (repo/file:line)."""
+    if not prop:
+        return []
+    ev = prop.get("evidence") or []
+    out = []
+    for r in ev:
+        c = _canon_ref(r)
+        if c:
+            out.append(c)
+    return out
 
-    Positional takes precedence (it's the primary channel), but if the positional index is
-    out of range we still fall through to an alias mention on the same line — so "4. kubeclaw
-    is paused" excludes kubeclaw even if position 4 didn't exist."""
+
+def _line_repo(line: str, props: list[dict],
+               alias_map: dict[str, str] | None) -> tuple[str | None, dict | None]:
+    """Resolve (repo, proposal) a line refers to: positional index first, else a named alias.
+
+    Positional takes precedence (it's the primary channel) and also yields the PROPOSAL dict
+    (needed for evidence on a dismiss). If the positional index is out of range we still fall
+    through to an alias mention on the same line — so "9. civitai is paused" excludes civitai
+    even though position 9 didn't exist (name-mentions carry no proposal → dismiss can't fire
+    on them)."""
     m = _POSITIONAL_RE.match(line)
     if m:
         n = int(m.group(1))
         if 1 <= n <= len(props):
-            repo = str((props[n - 1] or {}).get("repo") or "").strip()
+            prop = props[n - 1] or {}
+            repo = str(prop.get("repo") or "").strip()
             if repo:
-                return repo
+                return repo, prop
     if alias_map:
-        return _find_named_repo(line, alias_map)
-    return None
+        return _find_named_repo(line, alias_map), None
+    return None, None
 
 
 # ---- apply + filter ----------------------------------------------------------------
 
 def apply(state: dict, parsed: dict, *, source: str = "reply",
           now: str | None = None) -> dict:
-    """Merge `parsed` into `state`: add/refresh excludes, remove resumes. Returns the same
-    (mutated) state dict. Caller persists via save_state."""
+    """Merge `parsed` into `state`: add/refresh REPO excludes, remove resumes, and ACCUMULATE
+    per-recommendation dismissals into state["dismissed"]. Returns the same (mutated) state
+    dict. Caller persists via save_state."""
     repos = state.setdefault("repos", {})
+    dismissed = state.setdefault("dismissed", {})
     ts = now or datetime.now().astimezone().isoformat(timespec="seconds")
 
     for entry in parsed.get("exclude", []):
@@ -346,6 +453,23 @@ def apply(state: dict, parsed: dict, *, source: str = "reply",
     for key in parsed.get("resume", []):
         repos.pop(_canon_key(key), None)
 
+    # Accumulate dismissed recommendations, keyed by the normalized evidence ref so the
+    # pre-scan filter can compare directly against a candidate's ref. Never removed here —
+    # a dismissed proposal must stay suppressed (hand-edit the JSON to un-dismiss).
+    for d in parsed.get("dismiss", []):
+        reason = d.get("reason") or ""
+        repo = d.get("repo") or ""
+        for ref in d.get("evidence") or []:
+            key = _canon_ref(ref)
+            if not key:
+                continue
+            prev = dismissed.get(key) or {}
+            dismissed[key] = {
+                "reason": reason or prev.get("reason") or "",
+                "repo": repo or prev.get("repo") or "",
+                "dismissed_at": prev.get("dismissed_at") or ts,
+            }
+
     return state
 
 
@@ -360,6 +484,65 @@ def _canon_key(ref) -> str:
     if "/" in ref or ref.startswith("~"):
         return os.path.basename(os.path.normpath(os.path.expanduser(ref)))
     return ref
+
+
+def _canon_ref(ref) -> str:
+    """Canonical DISMISSED-evidence key = the `repo/file:line` reference, normalized to match
+    how prescan emits a candidate's `.ref` (see prescan.Candidate.ref: `{repo}/{file}` with a
+    `:{line}` suffix only when line>0). We only strip surrounding whitespace and collapse any
+    accidental duplicate/leading slashes in the path segment — the format is otherwise already
+    the comparison form, so a proposal's evidence ref and a fresh candidate's ref compare
+    equal (e.g. 'civitai/docs/3d-models-followups.md:103')."""
+    ref = str(ref or "").strip()
+    if not ref:
+        return ""
+    # split the optional ':line' suffix (only the LAST colon that precedes a pure integer),
+    # normalize the path part, re-attach. Windows-style drive colons don't occur here.
+    line = ""
+    if ":" in ref:
+        head, _, tail = ref.rpartition(":")
+        if head and tail.isdigit():
+            ref, line = head, tail
+    # collapse redundant separators in the path portion (e.g. 'repo//a.py' → 'repo/a.py')
+    ref = re.sub(r"/{2,}", "/", ref).strip("/")
+    return f"{ref}:{line}" if line else ref
+
+
+def filter_candidates(candidates: list, state: dict) -> tuple[list, list]:
+    """Split prescan candidates into (kept, dropped) — drop any whose `.ref` matches a
+    dismissed recommendation in state["dismissed"]. Compared on the NORMALIZED repo/file:line
+    ref, so a dismissed proposal's evidence and the fresh candidate produced by the same
+    signal collapse to the same key. This is the GUARANTEE a dismissed proposal can't re-form:
+    its signal never reaches the LLM. Candidates are prescan.Candidate objects (have `.ref`)
+    OR dicts with a "ref" key. Never raises."""
+    dismissed = (state or {}).get("dismissed") or {}
+    if not dismissed:
+        return list(candidates), []
+    keys = {_canon_ref(k) for k in dismissed}
+    kept, dropped = [], []
+    for c in candidates:
+        ref = c.ref if hasattr(c, "ref") else (c.get("ref") if isinstance(c, dict) else "")
+        if _canon_ref(ref) in keys:
+            dropped.append(c)
+        else:
+            kept.append(c)
+    return kept, dropped
+
+
+def dismissed_entries(state: dict) -> list[dict]:
+    """Sorted list of dismissed recommendations for --show-exclusions / the digest footer:
+    [{ref, reason, repo, dismissed_at}, …]."""
+    d = (state or {}).get("dismissed") or {}
+    out = []
+    for ref in sorted(d):
+        e = d[ref] or {}
+        out.append({
+            "ref": ref,
+            "reason": (e.get("reason") or "").strip(),
+            "repo": e.get("repo") or "",
+            "dismissed_at": e.get("dismissed_at") or "",
+        })
+    return out
 
 
 def filter_repos(repos: list[str], state: dict) -> tuple[list[str], list[str]]:
@@ -411,23 +594,45 @@ def excluded_names(state: dict) -> list[str]:
 
 
 def format_state(state: dict) -> str:
-    """Pretty one-block summary of the current exclusion state for --show-exclusions."""
+    """Pretty one-block summary of the current exclusion state for --show-exclusions —
+    REPO-level exclusions AND per-recommendation dismissals."""
     repos = (state or {}).get("repos") or {}
-    if not repos:
-        return "repo-cos exclusions: none.\n(Excluded repos come from your emailed reply; " \
-               "hand-edit ~/.config/repo-cos/exclusions.json to adjust.)"
-    lines = [f"repo-cos exclusions: {len(repos)} repo(s) currently dropped from the scan.",
-             ""]
-    for key in sorted(repos):
-        e = repos[key] or {}
-        perm = "permanent" if e.get("permanent") else "paused"
-        src = e.get("source") or "?"
-        when = e.get("excluded_at") or "?"
-        reason = (e.get("reason") or "").strip()
-        lines.append(f"  {key}  [{perm}, {src}, since {when}]")
-        if reason:
-            lines.append(f"      reason: {reason}")
-    lines.append("")
-    lines.append('Reply "resume <repo>" to re-enable one, or edit '
-                 "~/.config/repo-cos/exclusions.json.")
+    dismissed = dismissed_entries(state)
+    if not repos and not dismissed:
+        return ("repo-cos exclusions: none.\n(Excluded repos + dismissed recommendations come "
+                "from your emailed reply; hand-edit ~/.config/repo-cos/exclusions.json to "
+                "adjust.)")
+
+    lines: list[str] = []
+    if repos:
+        lines.append(f"repo-cos exclusions: {len(repos)} repo(s) currently dropped from the "
+                     "scan.")
+        lines.append("")
+        for key in sorted(repos):
+            e = repos[key] or {}
+            perm = "permanent" if e.get("permanent") else "paused"
+            src = e.get("source") or "?"
+            when = e.get("excluded_at") or "?"
+            reason = (e.get("reason") or "").strip()
+            lines.append(f"  {key}  [{perm}, {src}, since {when}]")
+            if reason:
+                lines.append(f"      reason: {reason}")
+        lines.append("")
+    else:
+        lines.append("repo-cos exclusions: no repos paused.")
+        lines.append("")
+
+    if dismissed:
+        lines.append(f"repo-cos dismissed recommendations: {len(dismissed)} suppressed "
+                     "proposal(s) (repo kept in scope).")
+        lines.append("")
+        for d in dismissed:
+            when = d["dismissed_at"] or "?"
+            lines.append(f"  {d['ref']}  [since {when}]")
+            if d["reason"]:
+                lines.append(f"      reason: {d['reason']}")
+        lines.append("")
+
+    lines.append('Reply "resume <repo>" to re-enable a repo; edit '
+                 "~/.config/repo-cos/exclusions.json to un-dismiss a recommendation.")
     return "\n".join(lines)

--- a/scripts/repo-cos/feedback.py
+++ b/scripts/repo-cos/feedback.py
@@ -118,14 +118,23 @@ def _log(msg: str) -> None:
 
 
 def _load_last_digest() -> dict | None:
-    """Read ~/.config/repo-cos/latest.json (the previous run). None if absent/unreadable."""
-    try:
-        if not PERSIST_LATEST.exists():
-            return None
-        return json.loads(PERSIST_LATEST.read_text())
-    except Exception as exc:  # noqa: BLE001
-        _log(f"could not read {PERSIST_LATEST}: {exc}")
-        return None
+    """The 'previous digest' the reply threads to. Prefer last_emailed.json (only --email
+    writes it) over latest.json: EVERY run — including dry-runs — overwrites latest.json, so
+    its `generated_at` drifts to 'now' and would exclude the reply (found live: after one
+    dry-run the reply became unfindable). last_emailed.json holds the digest Zach actually
+    got + saw, and stays put until the next real send. Normalize `emailed_at`→`generated_at`
+    so callers (cutoff + positional mapping) read one field."""
+    emailed = PERSIST_LATEST.with_name("last_emailed.json")
+    for p in (emailed, PERSIST_LATEST):
+        try:
+            if p.exists():
+                d = json.loads(p.read_text())
+                if isinstance(d, dict) and d.get("proposals") is not None:
+                    d.setdefault("generated_at", d.get("emailed_at"))
+                    return d
+        except Exception as exc:  # noqa: BLE001
+            _log(f"could not read {p}: {exc}")
+    return None
 
 
 def _decode(value: str | None) -> str:

--- a/scripts/repo-cos/scan.py
+++ b/scripts/repo-cos/scan.py
@@ -130,7 +130,7 @@ def cmd_scan(args) -> int:
                 alias_map = exclusions.build_alias_map(DEFAULT_REPOS)
                 parsed = exclusions.parse_reply(fb.reply_text, emailed_props,
                                                 alias_map=alias_map)
-                if parsed["exclude"] or parsed["resume"]:
+                if parsed["exclude"] or parsed["resume"] or parsed.get("dismiss"):
                     exclusions.apply(excl_state, parsed, source="reply")
                     exclusions.save_state(excl_state)
                     if parsed["exclude"]:
@@ -138,6 +138,11 @@ def cmd_scan(args) -> int:
                         print(f"  exclusions: reply excluded {names}", file=sys.stderr)
                     if parsed["resume"]:
                         print(f"  exclusions: reply resumed {', '.join(parsed['resume'])}",
+                              file=sys.stderr)
+                    if parsed.get("dismiss"):
+                        nrefs = sum(len(d.get("evidence") or []) for d in parsed["dismiss"])
+                        print(f"  exclusions: reply dismissed {len(parsed['dismiss'])} "
+                              f"recommendation(s) ({nrefs} evidence ref(s)); repos kept",
                               file=sys.stderr)
             except Exception as exc:  # noqa: BLE001
                 print(f"  ! exclusion parse failed (proceeding): {exc}", file=sys.stderr)
@@ -162,6 +167,15 @@ def cmd_scan(args) -> int:
         return 2
 
     candidates, scans = prescan.scan_all(repos, args.limit_candidates)
+
+    # ---- DISMISSED-RECOMMENDATION FILTER (drop suppressed proposals BEFORE the LLM) ----
+    # A recommendation Zach replied "skip" to (its evidence refs live in excl_state
+    # ["dismissed"]) is removed here so its signal never reaches synthesis and cannot
+    # re-form as the same proposal — while the rest of that repo still surfaces.
+    candidates, dropped = exclusions.filter_candidates(candidates, excl_state)
+    if dropped:
+        print(f"  dismissed: {len(dropped)} candidate(s) suppressed", file=sys.stderr)
+    dismissed_recs = exclusions.dismissed_entries(excl_state)
     cand_dicts = [c.as_dict() for c in candidates]
 
     scan_errors = [(s.repo, s.error) for s in scans if s.error]
@@ -170,7 +184,8 @@ def cmd_scan(args) -> int:
 
     # ---- Stage-1-only smoke mode: no LLM, no key, no spend. ----
     if args.no_llm or args.candidates_only:
-        return _emit_candidates(candidates, scans, cand_dicts, args)
+        return _emit_candidates(candidates, scans, cand_dicts, args,
+                                dismissed_recs=dismissed_recs)
 
     # ---- Stage 2: LLM synthesis over survivors. ----
     import llm
@@ -183,9 +198,11 @@ def cmd_scan(args) -> int:
 
     if not cand_dicts:
         # Nothing to synthesize — emit an honest empty digest without spending.
-        body = digest.render([], candidate_count=0, excluded_repos=excluded_names)
+        body = digest.render([], candidate_count=0, excluded_repos=excluded_names,
+                             dismissed_count=len(dismissed_recs))
         return _deliver(body, args, proposals=[], candidate_count=0, approx_tokens=0,
-                        feedback_applied=False, excluded_repos=excluded_names)
+                        feedback_applied=False, excluded_repos=excluded_names,
+                        dismissed_count=len(dismissed_recs))
 
     # `fb` (Zach's reply) was already fetched up front — reused here as synthesis CONTEXT
     # (nuance the deterministic exclusion layer can't express). The reply is passed through
@@ -201,24 +218,29 @@ def cmd_scan(args) -> int:
         candidate_count=len(cand_dicts),
         approx_tokens=result.approx_prompt_tokens,
         excluded_repos=excluded_names,
+        dismissed_count=len(dismissed_recs),
     )
     print(f"  synthesis: model={result.model} candidates={len(cand_dicts)} "
           f"proposals={len(result.proposals)} ~prompt_tokens={result.approx_prompt_tokens} "
-          f"feedback_applied={fb is not None} excluded={len(excluded_names)}",
+          f"feedback_applied={fb is not None} excluded={len(excluded_names)} "
+          f"dismissed={len(dismissed_recs)}",
           file=sys.stderr)
     return _deliver(
         body, args, proposals=result.proposals,
         candidate_count=len(cand_dicts), approx_tokens=result.approx_prompt_tokens,
         feedback_applied=fb is not None, excluded_repos=excluded_names,
+        dismissed_count=len(dismissed_recs),
     )
 
 
-def _emit_candidates(candidates, scans, cand_dicts, args) -> int:
+def _emit_candidates(candidates, scans, cand_dicts, args, *, dismissed_recs=None) -> int:
+    dismissed_recs = dismissed_recs or []
     if args.json:
         print(json.dumps({
             "repos": [{"repo": s.repo, "path": s.path, "error": s.error,
                        "candidate_count": len(s.candidates)} for s in scans],
             "capped_total": len(cand_dicts),
+            "dismissed_count": len(dismissed_recs),
             "candidates": cand_dicts,
         }, indent=2))
         return 0
@@ -227,6 +249,12 @@ def _emit_candidates(candidates, scans, cand_dicts, args) -> int:
     for s in scans:
         tag = f" [ERROR: {s.error}]" if s.error else ""
         print(f"  {s.repo}: {len(s.candidates)} raw candidate(s){tag}")
+    if dismissed_recs:
+        print(f"\n  dismissed: {len(dismissed_recs)} recommendation(s) suppressed "
+              "(repos kept):")
+        for d in dismissed_recs:
+            reason = f" — {d['reason']}" if d.get("reason") else ""
+            print(f"    {d['ref']}{reason}")
     print()
     # group the capped set by repo for readability
     by_repo: dict[str, list] = {}
@@ -243,7 +271,8 @@ def _emit_candidates(candidates, scans, cand_dicts, args) -> int:
 
 
 def _deliver(body: str, args, *, proposals, candidate_count, approx_tokens,
-             feedback_applied: bool = False, excluded_repos=None) -> int:
+             feedback_applied: bool = False, excluded_repos=None,
+             dismissed_count: int = 0) -> int:
     """Print (dry-run) or send (--email) the digest. --dry-run is the default and always
     prints; --email additionally sends."""
     excluded_repos = list(excluded_repos or [])
@@ -254,6 +283,7 @@ def _deliver(body: str, args, *, proposals, candidate_count, approx_tokens,
             "approx_prompt_tokens": approx_tokens,
             "feedback_applied": feedback_applied,
             "excluded_repos": excluded_repos,
+            "dismissed_count": int(dismissed_count),
             "proposals": [p.as_dict() for p in proposals],
             "emailed": bool(args.email),
         }, indent=2))

--- a/scripts/repo-cos/tests/test_dismiss.py
+++ b/scripts/repo-cos/tests/test_dismiss.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+"""Recommendation-level DISMISSAL tests — the repo-vs-recommendation split.
+
+The headline case is Zach's EXACT real reply (positional, against the last emailed digest):
+    1. approve
+    2. we dont own the 3d model feature, skip
+    3. not needed, skip
+    4. skip
+    5. kubeclaw is paused
+Correct interpretation: #2,#3 (civitai) + #4 (datapacket) → DISMISS those recommendations
+but KEEP the repos; #5 (kubeclaw-embed) → PAUSE the repo; #1 → approve (no-op). The old
+repo-only parser wrongly excluded civitai/datapacket entirely.
+
+Covers: parse_reply precedence, the dismissed-evidence store + persistence, filter_candidates
+(ref-format matching prescan), and scan.py integration (a dismissed proposal's candidates are
+suppressed BEFORE synthesis while the repo's OTHER candidates still pass). No network, no LLM.
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import exclusions  # noqa: E402
+import prescan  # noqa: E402
+import digest  # noqa: E402
+import scan  # noqa: E402
+
+
+# The 5-proposal digest Zach ACTUALLY SAW. Positions 1-5 → repos
+# devrc, civitai, civitai, datapacket-talos, kubeclaw-embed.
+EMAILED = [
+    {"repo": "devrc", "title": "Pin flake input",
+     "evidence": ["devrc/flake.lock:12"]},
+    {"repo": "civitai", "title": "Remove 3d-model dead code",
+     "evidence": ["civitai/docs/3d-models-followups.md:103",
+                  "civitai/src/3d/model.ts:44"]},
+    {"repo": "civitai", "title": "Add missing test",
+     "evidence": ["civitai/src/api/handler.ts:210"]},
+    {"repo": "datapacket-talos", "title": "Fix skipped test",
+     "evidence": ["datapacket-talos/test/net_test.go:8"]},
+    {"repo": "kubeclaw-embed", "title": "Split large file",
+     "evidence": ["kubeclaw-embed/main.go:0"]},
+]
+
+# Zach's exact reply.
+ZACH_REPLY = (
+    "1. approve\n"
+    "2. we dont own the 3d model feature, skip\n"
+    "3. not needed, skip\n"
+    "4. skip\n"
+    "5. kubeclaw is paused\n"
+)
+
+DEFAULT_REPOS = [
+    "~/workspace/devrc",
+    "~/workspace/kubeclaw-embed",
+    "~/workspace/civit/civitai",
+    "~/workspace/civit/datapacket-talos",
+]
+
+
+def _alias():
+    return exclusions.build_alias_map(DEFAULT_REPOS)
+
+
+# ---- headline: Zach's exact reply ---------------------------------------------------
+
+def test_zach_exact_reply_splits_dismiss_from_pause():
+    parsed = exclusions.parse_reply(ZACH_REPLY, EMAILED, alias_map=_alias())
+
+    # #5 kubeclaw is paused → REPO exclusion (non-permanent), and it's the ONLY exclude.
+    excluded = {e["repo"] for e in parsed["exclude"]}
+    assert excluded == {"kubeclaw-embed"}
+    kub = next(e for e in parsed["exclude"] if e["repo"] == "kubeclaw-embed")
+    assert kub["permanent"] is False
+
+    # civitai + datapacket-talos stay in scope (NOT excluded) — the real bug being fixed.
+    assert "civitai" not in excluded
+    assert "datapacket-talos" not in excluded
+
+    # #2, #3 (civitai) and #4 (datapacket) → dismissed recommendations, keyed by evidence.
+    dismissed_refs = set()
+    for d in parsed["dismiss"]:
+        dismissed_refs.update(d["evidence"])
+    assert dismissed_refs == {
+        # #2 both evidence refs
+        "civitai/docs/3d-models-followups.md:103",
+        "civitai/src/3d/model.ts:44",
+        # #3
+        "civitai/src/api/handler.ts:210",
+        # #4
+        "datapacket-talos/test/net_test.go:8",
+    }
+    # #1 "approve" contributed nothing.
+    assert not any("flake.lock" in r for r in dismissed_refs)
+    assert parsed["resume"] == []
+
+
+def test_zach_exact_reply_dismiss_carries_repo_and_reason():
+    parsed = exclusions.parse_reply(ZACH_REPLY, EMAILED, alias_map=_alias())
+    by_repo = {}
+    for d in parsed["dismiss"]:
+        by_repo.setdefault(d["repo"], []).extend(d["evidence"])
+    assert set(by_repo) == {"civitai", "datapacket-talos"}
+    # each dismiss entry keeps the reason line it came from
+    reasons = " ".join(d["reason"] for d in parsed["dismiss"])
+    assert "skip" in reasons
+
+
+# ---- precedence -------------------------------------------------------------------
+
+def test_precedence_paused_is_repo_not_dismiss():
+    # "kubeclaw is paused" → repo exclusion, NOT a dismissal, even at a position with evidence.
+    parsed = exclusions.parse_reply("5. kubeclaw is paused\n", EMAILED, alias_map=_alias())
+    assert {e["repo"] for e in parsed["exclude"]} == {"kubeclaw-embed"}
+    assert parsed["dismiss"] == []
+
+
+def test_precedence_not_code_owner_is_repo_permanent():
+    # "not the code owner" → repo exclusion, PERMANENT, not a dismissal.
+    parsed = exclusions.parse_reply("2. not the code owner\n", EMAILED, alias_map=_alias())
+    excl = parsed["exclude"]
+    assert len(excl) == 1
+    assert excl[0]["repo"] == "civitai"
+    assert excl[0]["permanent"] is True
+    assert parsed["dismiss"] == []
+
+
+def test_precedence_not_needed_skip_is_dismiss():
+    # "not needed, skip" → dismiss the proposal, repo stays.
+    parsed = exclusions.parse_reply("3. not needed, skip\n", EMAILED, alias_map=_alias())
+    assert parsed["exclude"] == []
+    refs = {r for d in parsed["dismiss"] for r in d["evidence"]}
+    assert refs == {"civitai/src/api/handler.ts:210"}
+
+
+def test_precedence_dont_own_feature_skip_is_dismiss_not_owner():
+    # THE key case: "we dont own the 3d model feature, skip" is about a FEATURE — it must NOT
+    # match the owner-permanent regex (that's "not owner", not "dont own") and must NOT
+    # exclude the repo. It's a recommendation dismissal.
+    parsed = exclusions.parse_reply(
+        "2. we dont own the 3d model feature, skip\n", EMAILED, alias_map=_alias())
+    assert parsed["exclude"] == []          # repo NOT excluded
+    refs = {r for d in parsed["dismiss"] for r in d["evidence"]}
+    assert refs == {
+        "civitai/docs/3d-models-followups.md:103",
+        "civitai/src/3d/model.ts:44",
+    }
+
+
+def test_bare_skip_is_dismiss():
+    parsed = exclusions.parse_reply("4. skip\n", EMAILED, alias_map=_alias())
+    assert parsed["exclude"] == []
+    refs = {r for d in parsed["dismiss"] for r in d["evidence"]}
+    assert refs == {"datapacket-talos/test/net_test.go:8"}
+
+
+def test_not_relevant_is_dismiss_not_repo():
+    # "not relevant" targets the PROPOSAL, not the repo → dismiss, repo stays.
+    parsed = exclusions.parse_reply("3. not relevant\n", EMAILED, alias_map=_alias())
+    assert parsed["exclude"] == []
+    refs = {r for d in parsed["dismiss"] for r in d["evidence"]}
+    assert refs == {"civitai/src/api/handler.ts:210"}
+
+
+def test_not_ours_is_repo_permanent_not_dismiss():
+    # "not ours" (vs "not needed"/"not relevant") is a REPO ownership statement → permanent.
+    parsed = exclusions.parse_reply("3. not ours\n", EMAILED, alias_map=_alias())
+    assert parsed["dismiss"] == []
+    excl = parsed["exclude"]
+    assert len(excl) == 1 and excl[0]["repo"] == "civitai" and excl[0]["permanent"] is True
+
+
+def test_dismiss_without_evidence_is_noop():
+    # position 1 (devrc) has evidence, but a name-only line (no position) can't dismiss —
+    # there's no proposal to look up.
+    parsed = exclusions.parse_reply("skip the civitai thing\n", EMAILED, alias_map=_alias())
+    # "civitai" alias resolves the repo, but with no positional proposal there's no evidence,
+    # so nothing to dismiss (and skip is not a repo-pause) → no-op.
+    assert parsed["dismiss"] == []
+    assert parsed["exclude"] == []
+
+
+def test_resume_beats_dismiss_on_same_line():
+    parsed = exclusions.parse_reply("2. resume this, don't skip\n", EMAILED, alias_map=_alias())
+    assert parsed["resume"] == ["civitai"]
+    assert parsed["dismiss"] == []
+
+
+# ---- apply + persistence ----------------------------------------------------------
+
+def test_apply_merges_dismiss_into_state():
+    state = {"repos": {}, "dismissed": {}}
+    parsed = exclusions.parse_reply(ZACH_REPLY, EMAILED, alias_map=_alias())
+    exclusions.apply(state, parsed, source="reply", now="2026-07-02T08:00:00-05:00")
+    assert set(state["dismissed"]) == {
+        "civitai/docs/3d-models-followups.md:103",
+        "civitai/src/3d/model.ts:44",
+        "civitai/src/api/handler.ts:210",
+        "datapacket-talos/test/net_test.go:8",
+    }
+    e = state["dismissed"]["civitai/src/api/handler.ts:210"]
+    assert e["repo"] == "civitai"
+    assert e["dismissed_at"] == "2026-07-02T08:00:00-05:00"
+    assert "skip" in e["reason"]
+    # and only kubeclaw-embed is a repo exclusion
+    assert set(state["repos"]) == {"kubeclaw-embed"}
+
+
+def test_apply_dismiss_accumulates_across_calls():
+    state = {"repos": {}, "dismissed": {}}
+    exclusions.apply(state, {"exclude": [], "resume": [],
+                             "dismiss": [{"evidence": ["a/x.py:1"], "reason": "skip", "repo": "a"}]},
+                     now="2026-07-01T00:00:00Z")
+    exclusions.apply(state, {"exclude": [], "resume": [],
+                             "dismiss": [{"evidence": ["b/y.py:2"], "reason": "skip", "repo": "b"}]},
+                     now="2026-07-02T00:00:00Z")
+    assert set(state["dismissed"]) == {"a/x.py:1", "b/y.py:2"}
+    # re-touching an existing ref keeps its original dismissed_at
+    exclusions.apply(state, {"exclude": [], "resume": [],
+                             "dismiss": [{"evidence": ["a/x.py:1"], "reason": "skip again", "repo": "a"}]},
+                     now="2026-07-03T00:00:00Z")
+    assert state["dismissed"]["a/x.py:1"]["dismissed_at"] == "2026-07-01T00:00:00Z"
+
+
+def test_dismiss_state_roundtrips(tmp_path):
+    p = tmp_path / "exclusions.json"
+    state = {"repos": {}, "dismissed": {}}
+    parsed = exclusions.parse_reply(ZACH_REPLY, EMAILED, alias_map=_alias())
+    exclusions.apply(state, parsed, source="reply", now="2026-07-02T08:00:00-05:00")
+    exclusions.save_state(state, p)
+
+    loaded = exclusions.load_state(p)
+    assert set(loaded["dismissed"]) == set(state["dismissed"])
+    assert set(loaded["repos"]) == {"kubeclaw-embed"}
+
+
+def test_apply_with_older_state_missing_dismissed_key():
+    # apply must tolerate a state dict with no "dismissed" (older file already loaded).
+    state = {"repos": {"kubeclaw-embed": {"permanent": False}}}
+    exclusions.apply(state, {"exclude": [], "resume": [],
+                             "dismiss": [{"evidence": ["a/x.py:1"], "reason": "skip", "repo": "a"}]})
+    assert state["dismissed"]["a/x.py:1"]["repo"] == "a"
+
+
+# ---- filter_candidates ------------------------------------------------------------
+
+def _cand(repo, file, line):
+    return prescan.Candidate(repo=repo, kind="marker", file=file, line=line, text="x")
+
+
+def test_filter_candidates_drops_dismissed_ref():
+    state = {"repos": {}, "dismissed": {
+        "civitai/src/api/handler.ts:210": {"reason": "skip", "repo": "civitai"}}}
+    cands = [
+        _cand("civitai", "src/api/handler.ts", 210),   # dismissed → dropped
+        _cand("civitai", "src/other.ts", 5),           # kept (same repo, diff proposal)
+        _cand("datapacket-talos", "test/net_test.go", 8),  # kept
+    ]
+    kept, dropped = exclusions.filter_candidates(cands, state)
+    assert [c.ref for c in dropped] == ["civitai/src/api/handler.ts:210"]
+    assert {c.ref for c in kept} == {
+        "civitai/src/other.ts:5", "datapacket-talos/test/net_test.go:8"}
+
+
+def test_filter_candidates_ref_format_matches_prescan():
+    # the dismissed key stored from a proposal's evidence must equal a FRESH candidate's .ref
+    # so a re-scan of the same signal is suppressed. Build the candidate the way prescan does.
+    cand = _cand("civitai", "docs/3d-models-followups.md", 103)
+    assert cand.ref == "civitai/docs/3d-models-followups.md:103"
+    state = {"repos": {}, "dismissed": {cand.ref: {"reason": "skip", "repo": "civitai"}}}
+    kept, dropped = exclusions.filter_candidates([cand], state)
+    assert kept == [] and len(dropped) == 1
+
+
+def test_filter_candidates_file_level_ref_no_line():
+    # a large_file/churn candidate has line 0 → ref has no ':line' suffix; dismissal by that
+    # bare ref still matches.
+    cand = _cand("kubeclaw-embed", "main.go", 0)
+    assert cand.ref == "kubeclaw-embed/main.go"
+    state = {"repos": {}, "dismissed": {"kubeclaw-embed/main.go": {"repo": "kubeclaw-embed"}}}
+    kept, dropped = exclusions.filter_candidates([cand], state)
+    assert kept == [] and len(dropped) == 1
+
+
+def test_filter_candidates_empty_dismissed_keeps_all():
+    cands = [_cand("a", "x.py", 1), _cand("b", "y.py", 2)]
+    kept, dropped = exclusions.filter_candidates(cands, {"repos": {}, "dismissed": {}})
+    assert kept == cands and dropped == []
+
+
+def test_filter_candidates_accepts_dicts():
+    state = {"dismissed": {"a/x.py:1": {}}}
+    cands = [{"ref": "a/x.py:1"}, {"ref": "a/y.py:2"}]
+    kept, dropped = exclusions.filter_candidates(cands, state)
+    assert dropped == [{"ref": "a/x.py:1"}]
+    assert kept == [{"ref": "a/y.py:2"}]
+
+
+# ---- end-to-end: parse → apply → filter (the guarantee) ---------------------------
+
+def test_dismiss_then_rescan_suppresses_same_signal():
+    # Simulate the full loop: Zach dismisses #3 (civitai handler test). On the NEXT scan the
+    # same signal re-surfaces as a candidate — filter_candidates must drop it while civitai's
+    # other candidates survive.
+    state = {"repos": {}, "dismissed": {}}
+    parsed = exclusions.parse_reply("3. not needed, skip\n", EMAILED, alias_map=_alias())
+    exclusions.apply(state, parsed)
+
+    fresh = [
+        _cand("civitai", "src/api/handler.ts", 210),   # the dismissed one
+        _cand("civitai", "src/new_feature.ts", 12),    # a NEW civitai candidate
+    ]
+    kept, dropped = exclusions.filter_candidates(fresh, state)
+    assert [c.ref for c in dropped] == ["civitai/src/api/handler.ts:210"]
+    assert [c.ref for c in kept] == ["civitai/src/new_feature.ts:12"]
+
+
+# ---- visibility: dismissed_entries + format_state + digest footer -----------------
+
+def test_dismissed_entries_sorted():
+    state = {"dismissed": {
+        "b/y.py:2": {"reason": "skip", "repo": "b", "dismissed_at": "t2"},
+        "a/x.py:1": {"reason": "nah", "repo": "a", "dismissed_at": "t1"},
+    }}
+    got = exclusions.dismissed_entries(state)
+    assert [e["ref"] for e in got] == ["a/x.py:1", "b/y.py:2"]
+    assert got[0]["reason"] == "nah"
+
+
+def test_format_state_shows_dismissed():
+    state = {"repos": {}, "dismissed": {
+        "civitai/src/api/handler.ts:210": {"reason": "3. not needed, skip",
+                                           "repo": "civitai",
+                                           "dismissed_at": "2026-07-02T08:00:00-05:00"}}}
+    out = exclusions.format_state(state)
+    assert "dismissed" in out.lower()
+    assert "civitai/src/api/handler.ts:210" in out
+    assert "not needed" in out
+
+
+def test_digest_dismissed_footer():
+    from datetime import date
+    body = digest.render([], today=date(2026, 7, 2), dismissed_count=3)
+    assert "Dismissed 3 past proposal(s)" in body
+
+
+def test_digest_no_dismissed_footer_when_zero():
+    from datetime import date
+    body = digest.render([], today=date(2026, 7, 2), dismissed_count=0)
+    assert "Dismissed" not in body
+
+
+# ---- scan.py integration (mock prescan + llm + feedback) --------------------------
+
+class _RealishProp:
+    def __init__(self, title, repo="r", evidence=None):
+        self.title, self.repo = title, repo
+        self.evidence = evidence or [f"{repo}/f.py:1"]
+        self.why, self.effort, self.approach, self.ci_verifiable = "w", "S", "a", True
+
+    def as_dict(self):
+        return {"title": self.title, "repo": self.repo, "evidence": self.evidence,
+                "why": self.why, "effort": self.effort, "approach": self.approach,
+                "ci_verifiable": self.ci_verifiable}
+
+
+class _FB:
+    def __init__(self, text):
+        self.reply_text = text
+        self.prev_proposals = []
+        self.replied_at = "2026-07-02T08:00:00-05:00"
+
+    def prev_summary(self):
+        return []
+
+
+def test_scan_dismiss_filters_candidate_but_keeps_repo(tmp_path, monkeypatch):
+    """A reply dismissing proposal X → X's evidence candidate is filtered out BEFORE
+    synthesis, while the repo's OTHER candidates still pass and the repo is NOT excluded."""
+    civ = tmp_path / "civitai"
+    civ.mkdir()
+    # two markers in civitai: one is the dismissed proposal's evidence, one is unrelated.
+    (civ / "handler.ts").write_text("x\n" * 4 + "// TODO handler\n")   # line 5
+    (civ / "other.ts").write_text("// TODO other\n")                    # line 1
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "k")
+    monkeypatch.setattr(scan, "PERSIST_DIR", tmp_path / "state")
+    monkeypatch.setattr(exclusions, "EXCLUSIONS_FILE", tmp_path / "exclusions.json")
+    monkeypatch.setattr(exclusions, "LAST_EMAILED_FILE", tmp_path / "last_emailed.json")
+    monkeypatch.setattr(exclusions, "HISTORY_DIR", tmp_path / "history")
+    monkeypatch.setattr(exclusions, "LATEST_FILE", tmp_path / "latest.json")
+    monkeypatch.setattr(scan, "DEFAULT_REPOS", [str(civ)])
+
+    # the emailed digest: position 1 = a civitai proposal whose evidence is handler.ts:5
+    (tmp_path / "last_emailed.json").write_text(json.dumps({"proposals": [
+        {"repo": "civitai", "title": "handler",
+         "evidence": ["civitai/handler.ts:5"]}]}))
+
+    import feedback as feedback_mod
+    import llm
+    monkeypatch.setattr(feedback_mod, "fetch_last_feedback",
+                        lambda: _FB("1. not needed, skip\n"))
+
+    seen = {}
+    orig = scan.prescan.scan_all
+
+    def spy_scan_all(repos, limit, caps=None):
+        return orig(repos, limit, caps)
+    monkeypatch.setattr(scan.prescan, "scan_all", spy_scan_all)
+
+    def fake_synth(cands, *, top, model, feedback=None):
+        seen["refs"] = {c["ref"] for c in cands}
+        return llm.Synthesis(proposals=[_RealishProp("ok", "civitai")], approx_prompt_tokens=1)
+    monkeypatch.setattr(llm, "synthesize", fake_synth)
+
+    args = scan.build_parser().parse_args(["--json", "--repos", str(civ)])
+    rc = scan.cmd_scan(args)
+    assert rc == 0
+    # the dismissed candidate did NOT reach synthesis; the other civitai candidate did.
+    assert "civitai/handler.ts:5" not in seen["refs"]
+    assert "civitai/other.ts:1" in seen["refs"]
+    # the repo was NOT excluded (state has no repos entry, dismissed has the ref)
+    st = exclusions.load_state(tmp_path / "exclusions.json")
+    assert st["repos"] == {}
+    assert "civitai/handler.ts:5" in st["dismissed"]
+
+
+def test_scan_dismiss_reports_count_in_json(tmp_path, monkeypatch, capsys):
+    civ = tmp_path / "civitai"
+    civ.mkdir()
+    (civ / "handler.ts").write_text("x\n" * 4 + "// TODO handler\n")   # line 5
+    (civ / "other.ts").write_text("// TODO other\n")
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "k")
+    monkeypatch.setattr(scan, "PERSIST_DIR", tmp_path / "state")
+    monkeypatch.setattr(exclusions, "EXCLUSIONS_FILE", tmp_path / "exclusions.json")
+    monkeypatch.setattr(exclusions, "LAST_EMAILED_FILE", tmp_path / "last_emailed.json")
+    monkeypatch.setattr(exclusions, "HISTORY_DIR", tmp_path / "history")
+    monkeypatch.setattr(exclusions, "LATEST_FILE", tmp_path / "latest.json")
+    monkeypatch.setattr(scan, "DEFAULT_REPOS", [str(civ)])
+    (tmp_path / "last_emailed.json").write_text(json.dumps({"proposals": [
+        {"repo": "civitai", "title": "handler", "evidence": ["civitai/handler.ts:5"]}]}))
+
+    import feedback as feedback_mod
+    import llm
+    monkeypatch.setattr(feedback_mod, "fetch_last_feedback",
+                        lambda: _FB("1. skip\n"))
+    monkeypatch.setattr(llm, "synthesize",
+                        lambda cands, *, top, model, feedback=None:
+                        llm.Synthesis(proposals=[_RealishProp("ok", "civitai")], approx_prompt_tokens=1))
+
+    args = scan.build_parser().parse_args(["--json", "--repos", str(civ)])
+    scan.cmd_scan(args)
+    data = json.loads(capsys.readouterr().out)
+    assert data["dismissed_count"] == 1
+    # repo NOT in excluded_repos (the whole point)
+    assert "civitai" not in data["excluded_repos"]
+
+
+def test_scan_persisted_dismiss_filters_on_no_llm_smoke(tmp_path, monkeypatch, capsys):
+    """A persisted dismissal drops the candidate even on the free --no-llm smoke path
+    (no feedback fetch)."""
+    civ = tmp_path / "civitai"
+    civ.mkdir()
+    (civ / "handler.ts").write_text("x\n" * 4 + "// TODO handler\n")   # line 5
+    (civ / "other.ts").write_text("// TODO other\n")
+
+    monkeypatch.setattr(exclusions, "EXCLUSIONS_FILE", tmp_path / "exclusions.json")
+    (tmp_path / "exclusions.json").write_text(json.dumps(
+        {"repos": {}, "dismissed": {"civitai/handler.ts:5": {"repo": "civitai"}}}))
+
+    import feedback as feedback_mod
+    called = {"fetch": False}
+
+    def spy_fetch():
+        called["fetch"] = True
+        return _FB("1. skip\n")
+    monkeypatch.setattr(feedback_mod, "fetch_last_feedback", spy_fetch)
+
+    args = scan.build_parser().parse_args(["--no-llm", "--json", "--repos", str(civ)])
+    rc = scan.cmd_scan(args)
+    data = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert called["fetch"] is False       # no network on the free smoke path
+    assert data["dismissed_count"] == 1
+    refs = {c["ref"] for c in data["candidates"]}
+    assert "civitai/handler.ts:5" not in refs   # dismissed candidate suppressed
+    assert "civitai/other.ts:1" in refs         # the rest of the repo still surfaces

--- a/scripts/repo-cos/tests/test_exclusions.py
+++ b/scripts/repo-cos/tests/test_exclusions.py
@@ -110,19 +110,23 @@ def test_parse_reply_resume_beats_exclude_same_repo():
     assert all(e["repo"] != "homelab-talos" for e in parsed["exclude"])
 
 
+_EMPTY_PARSED = {"exclude": [], "resume": [], "dismiss": []}
+
+
 def test_parse_reply_unparseable_and_empty_never_raise():
-    assert exclusions.parse_reply("", EMAILED, alias_map=_alias()) == {"exclude": [], "resume": []}
-    assert exclusions.parse_reply(None, EMAILED, alias_map=_alias()) == {"exclude": [], "resume": []}
+    assert exclusions.parse_reply("", EMAILED, alias_map=_alias()) == _EMPTY_PARSED
+    assert exclusions.parse_reply(None, EMAILED, alias_map=_alias()) == _EMPTY_PARSED
     # prose with no positional/name anchor → nothing excluded (falls through to LLM context)
     prose = "Great work this week, keep the momentum going on everything!\n"
     parsed = exclusions.parse_reply(prose, EMAILED, alias_map=_alias())
-    assert parsed == {"exclude": [], "resume": []}
+    assert parsed == _EMPTY_PARSED
 
 
 def test_parse_reply_positional_no_intent_is_ignored():
-    # "1. looks good" — a bare positional line with NO exclude/resume keyword does nothing.
+    # "1. looks good" — a bare positional line with NO exclude/resume/dismiss keyword does
+    # nothing (no skip/pause/no anchor).
     parsed = exclusions.parse_reply("1. looks good, ship it\n", EMAILED, alias_map=_alias())
-    assert parsed == {"exclude": [], "resume": []}
+    assert parsed == _EMPTY_PARSED
 
 
 def test_parse_reply_out_of_range_position_falls_through_to_name():
@@ -186,21 +190,30 @@ def test_state_load_save_roundtrip(tmp_path):
 
 
 def test_load_state_missing_file_is_empty(tmp_path):
-    assert exclusions.load_state(tmp_path / "nope.json") == {"repos": {}}
+    assert exclusions.load_state(tmp_path / "nope.json") == {"repos": {}, "dismissed": {}}
 
 
 def test_load_state_corrupt_file_is_empty(tmp_path):
     p = tmp_path / "exclusions.json"
     p.write_text("{ this is not json ")
-    assert exclusions.load_state(p) == {"repos": {}}
+    assert exclusions.load_state(p) == {"repos": {}, "dismissed": {}}
 
 
 def test_load_state_wrong_shape_is_normalized(tmp_path):
     p = tmp_path / "exclusions.json"
     p.write_text(json.dumps(["not", "a", "dict"]))
-    assert exclusions.load_state(p) == {"repos": {}}
+    assert exclusions.load_state(p) == {"repos": {}, "dismissed": {}}
     p.write_text(json.dumps({"repos": "not-a-dict"}))
     assert exclusions.load_state(p)["repos"] == {}
+
+
+def test_load_state_older_file_without_dismissed_key_loads_clean(tmp_path):
+    # a pre-dismiss exclusions.json (only "repos") must load with an empty "dismissed".
+    p = tmp_path / "exclusions.json"
+    p.write_text(json.dumps({"repos": {"kubeclaw-embed": {"permanent": False}}}))
+    st = exclusions.load_state(p)
+    assert st["repos"] == {"kubeclaw-embed": {"permanent": False}}
+    assert st["dismissed"] == {}
 
 
 def test_apply_resume_removes_excluded(tmp_path):


### PR DESCRIPTION
## Problem

repo-cos only did **REPO-level** exclusion: any reply keyword like `skip`/`paused` dropped the **whole repo**. But Zach distinguishes two intents when replying to the weekly digest:

- **"pause this repo"** — the whole project is on hold → exclude the repo (existing behavior).
- **"skip this recommendation"** — the repo is fine, he just doesn't want *this* proposal → the repo **stays in scope**, but that one proposal must not resurface.

His actual reply (positional, against `last_emailed.json`):

```
1. approve
2. we dont own the 3d model feature, skip
3. not needed, skip
4. skip
5. kubeclaw is paused
```

Correct interpretation: **#2,#3 (civitai) + #4 (datapacket-talos) = dismiss those recommendations, keep the repos**; **#5 (kubeclaw-embed) = pause the repo**; #1 = approve (no-op). The old repo-only parser wrongly excluded civitai + datapacket-talos entirely.

## Parser precedence (`exclusions.py` `parse_reply`)

Each numbered reply line is classified into **one** intent with a strict precedence (resume beats all):

1. **repo-pause** — `paused` / `on hold` / `hold off` → repo exclusion (non-permanent).
2. **repo-owner/dead** — `not (the|our|my|code) owner` / `not ours` / `deprecated` / `archived` / `dead|abandoned|…` → repo exclusion (**permanent**).
3. **recommendation-dismiss** — `skip` / `not needed` / `not relevant` / `dismiss` / `nah` / `no` / `don't (propose|want|need)`, **only when no tier-1/2 language is present** → dismiss that one proposal, repo stays.

Key: `"we dont own the 3d model FEATURE, skip"` does **not** match the owner regex (it's `dont own`, not `not owner`, and it's about a feature) → it correctly falls to **dismiss**. `parse_reply` now returns `{exclude, resume, dismiss:[{evidence, reason, repo}]}`; a dismiss line collects that position's proposal `evidence` (`repo/file:line` refs) via positional lookup against the emailed digest.

## Dismissed-evidence store + pre-scan filter

- **Store:** `~/.config/repo-cos/exclusions.json` gains a top-level `"dismissed"` key — `{repo/file:line: {reason, dismissed_at, repo}}`. `load_state`/`save_state` handle both `repos` and `dismissed`; **robust to an older file without the `dismissed` key** (→ empty). `apply()` **accumulates** dismissals (never auto-removed — hand-edit the JSON to un-dismiss).
- **Pre-scan filter (the guarantee):** `filter_candidates(candidates, state)` drops any candidate whose normalized `repo/file:line` ref is in `dismissed`. Wired into `scan.py` right after `prescan.scan_all(...)` and **before** synthesis — so a dismissed proposal's signal **never reaches the LLM and cannot re-form**, while the rest of that repo still surfaces. Logs `dismissed: N candidate(s) suppressed` to stderr. Ref normalization matches prescan's actual `Candidate.ref` (`{repo}/{file}` + `:{line}` only when line>0), verified in tests.

## How it fixes the repo-vs-recommendation conflation

Before: one keyword set, one action (drop the repo). Now the intent is classified per line, and a *skip* on a specific proposal suppresses only that proposal's evidence — the repo keeps producing its other candidates. civitai and datapacket-talos stay in scope; only their skipped proposals are dismissed.

## Visibility

`--show-exclusions` now prints dismissed recommendations (count + each `repo/file:line` + reason) alongside repo exclusions; the digest footer adds a terse `Dismissed N past proposal(s) (repos kept in scope).` line.

## Tests

- **+26 new** (`tests/test_dismiss.py`): Zach's exact reply against a 5-proposal fixture; precedence (`paused`→repo, `not the code owner`→repo permanent, `not needed, skip`→dismiss, `dont own the 3d model feature, skip`→dismiss not owner); `apply`+persistence (accumulate, round-trip, older file w/o `dismissed`); `filter_candidates` (drop dismissed, keep others, ref-format matches prescan, file-level ref w/ no line, dicts); scan.py integration (a dismissed proposal's candidate filtered before synthesis while the repo's other candidates pass; `--no-llm` smoke still filters w/o feedback fetch).
- Existing `test_exclusions.py` updated for the new `{exclude,resume,dismiss}` / `{repos,dismissed}` shapes.
- **159 passed** (`nix-shell -p 'python3.withPackages(p:[p.pytest p.requests p.psycopg2])' --run 'python -m pytest scripts/repo-cos/tests -q'`).

Also verified via a real `scan.py --no-llm` invocation: a persisted dismissal suppresses `civitai/handler.ts:5` before output while `civitai/other.ts:1` still surfaces and the repo is kept.

## Honest limits

Deterministic keyword + positional only (no LLM). A reply with **no clear skip/pause anchor** (pure prose, no position, no repo name) falls through and dismisses/excludes nothing (it still reaches the LLM as context). Dismissal requires a *positional* line — a bare name-mention has no proposal to look up evidence from. Dismissals are permanent until hand-edited out of the JSON.

## Live re-apply note

No transport (relay + Postgres) change. Zach's reply is still in Postgres (row 49613) and `last_emailed.json` holds the digest, so **after merge a live re-run will retroactively apply the correct dismissals** (civitai + datapacket recommendations dismissed, repos kept; kubeclaw-embed paused) — the orchestrator can verify live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)