### PR TITLE
feat(repo-cos): APPROVE reply → durable clawgate Task + suppress-on-success

### DIFF
--- a/scripts/repo-cos/README.md
+++ b/scripts/repo-cos/README.md
@@ -27,7 +27,8 @@ shrinks the corpus, then the LLM runs on the small survivor set.
 | Stage | Module | What | Cost |
 |-------|--------|------|------|
 | 0 | `feedback.py` | read Zach's reply to LAST digest → synthesis context (Postgres default; IMAP fallback) | none |
-| 0.5 | `exclusions.py` | parse that reply → **HARD** repo-level exclusions **+ per-recommendation dismissals** (deterministic) | none |
+| 0.5 | `exclusions.py` | parse that reply → **HARD** repo-level exclusions **+ per-recommendation dismissals + approvals** (deterministic) | none |
+| 0.5b | `clawgate.py` | approved proposals → durable clawgate Task cards (`POST /api/tasks`) + suppress-on-success | 1 POST/approval |
 | 1 | `prescan.py` | cheap grep/git signals, capped **per repo** | none |
 | 2 | `llm.py` | OpenRouter clusters survivors → ranked JSON proposals | one call |
 | 3 | `digest.py` | one formatter shared by stdout **and** email | none |
@@ -90,8 +91,8 @@ runs — they **cannot reappear**. (The context-injection above is kept for nuan
 
 - **Positional mapping (primary):** a line starting `N.` / `N)` / `N -` / `#N` / `N:` maps
   to proposal **N** in the digest you actually saw → that proposal's repo **and evidence**.
-- **Two intents, split by a strict precedence** (a reply distinguishes *pause the repo* from
-  *skip this one recommendation*):
+- **Four intents, split by a strict precedence** (a reply distinguishes *pause the repo* from
+  *skip this one recommendation* from *approve + dispatch it*):
   1. **repo-pause** — `paused / on hold / hold off` → **repo exclusion** (non-permanent).
   2. **repo-owner/dead** — `not (the|our|my|code) owner / not ours / deprecated / archived /
      dead / …` → **repo exclusion, permanent**. (`dont own the 3d model FEATURE` does **not**
@@ -99,33 +100,63 @@ runs — they **cannot reappear**. (The context-injection above is kept for nuan
   3. **recommendation-dismiss** — `skip / not needed / not relevant / dismiss / nah / no /
      don't (propose|want|need)` **when no repo-pause/owner language is present** → **dismiss
      THAT proposal** (collect its evidence `repo/file:line` refs); the **repo stays in scope**.
+  4. **recommendation-approve** — `approve(d) / yes / lgtm / ship it / do it / build it / go
+     ahead / 👍 / looks good / +1` **when no resume/exclude/dismiss keyword is present** →
+     **register THAT proposal as a durable clawgate Task** + suppress it (see the approve
+     subsection below). A **positive action**, the **lowest-priority** tier: a mixed
+     `approve … skip` line is a **dismiss** (negative wins — dropping is safer than dispatching).
   Higher tiers win: a line with both `paused` and `skip` is a repo-pause. `resume / unpause /
-  … again` beats all three → **resume** (un-exclude a repo).
+  … again` beats all four → **resume** (un-exclude a repo).
 - **Name mentions:** a reply naming a repo/alias (`kubeclaw`, `civitai`, `homelab`,
   `datapacket`, …) with a **repo-level** intent applies even without a position number.
-  (Dismissal needs a *positional* line — there's no proposal to look up from a bare name.)
+  (Dismissal + approve need a *positional* line — there's no proposal to look up from a bare name.)
 - **Position source = the digest you SAW, not `latest.json`.** Proposals rotate run-to-run
   and every run overwrites `latest.json`, so `--email` also writes **`last_emailed.json`**
   (the emailed set). `parse_reply` maps `1./2./…` against `last_emailed.json` → else the
   newest `history/*.json` with `emailed:true` → else `latest.json`.
-- **State:** `~/.config/repo-cos/exclusions.json` — **hand-editable**, two keys:
-  `{repos:{<name>:{reason, excluded_at, permanent, source}}}` (repo-level) and
-  `{dismissed:{<repo/file:line>:{reason, dismissed_at, repo}}}` (per-recommendation). Robust
-  to a missing/corrupt file **or an older file without `dismissed`** (→ empty). Dismissals
-  accumulate and are never auto-removed — hand-edit the JSON to un-dismiss one.
-- **Pre-scan dismiss filter (the guarantee):** `filter_candidates(candidates, state)` runs
+- **State:** `~/.config/repo-cos/exclusions.json` — **hand-editable**, three keys:
+  `{repos:{<name>:{reason, excluded_at, permanent, source}}}` (repo-level),
+  `{dismissed:{<repo/file:line>:{reason, dismissed_at, repo}}}` (per-recommendation), and
+  `{approved:{<repo/file:line>:{reason, approved_at, repo, clawgate_task_id}}}` (queued in
+  clawgate). Robust to a missing/corrupt file **or an older file without `dismissed`/`approved`**
+  (→ empty). Dismissals + approvals accumulate and are never auto-removed — hand-edit the JSON
+  to un-suppress one.
+- **Pre-scan suppression filter (the guarantee):** `filter_candidates(candidates, state)` runs
   right after `prescan.scan_all(...)` and **before** synthesis — it drops any candidate whose
-  `repo/file:line` ref is in `dismissed`, so a dismissed proposal's signal **never reaches
-  the LLM and cannot re-form**, while the rest of that repo still surfaces. Logs
-  `dismissed: N candidate(s) suppressed` to stderr.
+  `repo/file:line` ref is in `dismissed` **or `approved`** (ONE combined suppressed-set), so a
+  dismissed/queued proposal's signal **never reaches the LLM and cannot re-form**, while the
+  rest of that repo still surfaces. Logs `suppressed: N candidate(s) (dismissed ∪ approved)`.
 - **Visibility + undo:** excluded repos surface as a digest footer (`Excluded
   (paused/not-yours): … — reply "resume <repo>" to re-enable.`); dismissals add a terse
-  `Dismissed N past proposal(s).` line. `--show-exclusions` prints **both** (repos +
-  each dismissed `repo/file:line` + reason) and exits; `--no-feedback` skips the reply parse.
+  `Dismissed N past proposal(s).` line. `--show-exclusions` prints **all three** (repos +
+  each dismissed `repo/file:line` + reason + the approved/in-clawgate-queue section with task
+  ids) and exits; `--no-feedback` skips the reply parse.
 - **Limits:** the keyword set is finite — a reply that's *pure prose* with no positional
-  anchor and no repo name (and no clear skip/pause anchor) won't exclude or dismiss anything
-  (it still reaches the LLM as context).
+  anchor and no repo name (and no clear skip/pause/approve anchor) won't exclude, dismiss, or
+  approve anything (it still reaches the LLM as context).
   Unparseable lines are ignored and never raise.
+
+### Approve → clawgate Task (Stage 0.5b) — `clawgate.py`
+
+When you reply `N. approve` (yes/lgtm/ship it/👍/…), the approved proposal is **registered as
+a durable Task card in your clawgate adjudication+dispatch queue** so you can one-tap-Dispatch
+it, and it **won't re-nag** next week. The parser (`parse_reply`) stays **pure/deterministic** —
+it only collects the full proposal; the **only new network** is the clawgate POST.
+
+- **Poster (`clawgate.py`, stdlib-only, best-effort):** `load_creds()` parses
+  `~/.claude/clawgate.env` (simple `KEY=VALUE` → `CLAWGATE_API_URL`, `CLAWGATE_HOOK_TOKEN`);
+  `post_task(directory, body)` → `POST {API_URL}/api/tasks` with `Content-Type: application/json`
+  + `Authorization: Bearer <token>`, 15s timeout, returns the created task **id** (else `None` +
+  a stderr log on any error — never raises). The card matches the homelab task-drafter style:
+  lead `**🤖 repo-cos · APPROVED**`, the title/why, `**Approach:**`, `**Repo:**`, `**Effort:**`
+  (+ CI-verifiable note), then the `**Evidence:**` `repo/file:line` refs. Title = the proposal
+  title (≤80 chars).
+- **Suppress-on-SUCCESS only:** in `scan.py`, each approved proposal is POSTed; a proposal whose
+  POST returns an **id** has its evidence refs written to `state["approved"]` (so it can't
+  re-form). A **failed** POST is **left unsuppressed** → it re-proposes next week (a natural
+  retry). Logs `approved: N proposal(s) → clawgate task(s) M/N; suppressed`.
+- **Reachability:** the weekly timer runs on the workbench where `~/.claude/clawgate.env` exists
+  and clawgate is on the open, hook-token-gated LAN NodePort — no unit change needed.
 
 ## Usage
 

--- a/scripts/repo-cos/clawgate.py
+++ b/scripts/repo-cos/clawgate.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""clawgate POSTER — turn an APPROVED repo-cos proposal into a durable clawgate Task card.
+
+When Zach replies "N. approve" to a digest, `exclusions.parse_reply` maps position N to the
+FULL proposal and hands it here. We POST it to his existing clawgate Tasks queue (the durable
+adjudication+dispatch surface) so it lands as a one-tap-Dispatch card, and — on a SUCCESSFUL
+post only — its evidence refs are suppressed so it won't re-nag next week.
+
+Design (mirrors the rest of repo-cos: best-effort, never raises, stdlib-only):
+  * `load_creds()` parses ~/.claude/clawgate.env (simple KEY=VALUE) → {CLAWGATE_API_URL,
+    CLAWGATE_HOOK_TOKEN}. Missing file / keys → {} (→ post_task no-ops to None).
+  * `build_task_body(proposal)` → clean markdown card matching the homelab task-drafter's
+    style (lead `**🤖 repo-cos · APPROVED**`, then the goal, structured fields, evidence).
+  * `post_task(directory, body)` → POST {API_URL}/api/tasks with the Bearer hook token, 15s
+    timeout. Returns the created task id (int) on success, else None (logged). NEVER raises.
+
+This is the ONLY new network in the approve path. Everything upstream (the parser) is pure.
+Reference impl: homelab-talos …/agent-pods/task-drafter/trigger-configmap.yaml `route_clawgate`.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+CLAWGATE_ENV = Path("~/.claude/clawgate.env").expanduser()
+POST_TIMEOUT = 15  # seconds — a hung clawgate must not stall the weekly run
+TITLE_MAX = 80
+
+
+def _log(msg: str) -> None:
+    print(f"  clawgate: {msg}", file=sys.stderr)
+
+
+# ---- credentials -------------------------------------------------------------------
+
+def load_creds(path: Path | None = None) -> dict:
+    """Parse ~/.claude/clawgate.env (simple `KEY=VALUE`, `#` comments, optional quotes) into
+    a dict. Returns only the keys we use ({CLAWGATE_API_URL, CLAWGATE_HOOK_TOKEN} when
+    present). Missing/unreadable file → {} (post_task then no-ops). Never raises."""
+    p = path or CLAWGATE_ENV
+    creds: dict[str, str] = {}
+    try:
+        if not p.exists():
+            return {}
+        for raw in p.read_text().splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, val = line.partition("=")
+            key = key.strip()
+            val = val.strip().strip('"').strip("'")
+            if key:
+                creds[key] = val
+    except Exception as exc:  # noqa: BLE001
+        _log(f"could not read {p}: {exc}")
+        return {}
+    return creds
+
+
+# ---- card body ---------------------------------------------------------------------
+
+def build_task_title(proposal: dict) -> str:
+    """The Task title = the proposal title, trimmed to <=80 chars (clawgate `directory`)."""
+    title = str((proposal or {}).get("title") or "").strip()
+    if not title:
+        title = "repo-cos approved proposal"
+    return title[:TITLE_MAX]
+
+
+def build_task_body(proposal: dict) -> str:
+    """Clean markdown card for the clawgate Task. Matches the task-drafter card style:
+    lead badge, the goal (why), then structured fields, ending with the evidence refs.
+    NO raw json dump — the operator adjudicates + dispatches, they don't read scratch output.
+    """
+    p = proposal or {}
+    title = str(p.get("title") or "").strip()
+    why = str(p.get("why") or "").strip()
+    approach = str(p.get("approach") or "").strip()
+    repo = str(p.get("repo") or "").strip()
+    effort = str(p.get("effort") or "").strip().upper()
+    ci = bool(p.get("ci_verifiable"))
+    evidence = [str(e).strip() for e in (p.get("evidence") or []) if str(e).strip()]
+
+    out: list[str] = ["**🤖 repo-cos · APPROVED**", ""]
+    # goal line: the title, then the "why" underneath if present.
+    if title:
+        out.append(f"**{title}**")
+    if why:
+        out.append(why)
+    if approach:
+        out.append(f"\n**Approach:** {approach}")
+    if repo:
+        out.append(f"\n**Repo:** {repo}")
+    if effort:
+        note = " · CI-verifiable" if ci else " · needs manual verification"
+        out.append(f"\n**Effort:** {effort}{note}")
+    if evidence:
+        out.append("\n**Evidence:**")
+        for ref in evidence:
+            out.append(f"- `{ref}`")
+    return "\n".join(out)
+
+
+# ---- HTTP post ---------------------------------------------------------------------
+
+def _post(url: str, payload: dict, token: str, *, timeout: int = POST_TIMEOUT) -> str:
+    """Isolated network POST (stdlib urllib) — mocked in tests. Returns the response body."""
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url, data=body, method="POST",
+        headers={"Content-Type": "application/json",
+                 "Authorization": f"Bearer {token}"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read().decode("utf-8")
+
+
+def post_task(directory: str, body: str, *, creds: dict | None = None,
+              _post=_post) -> int | None:
+    """POST a Task to clawgate's `/api/tasks`. Returns the created task id (int) on success,
+    else None. BEST-EFFORT: any error (no creds, unreachable, non-JSON, no id) is logged and
+    yields None — NEVER raises. `creds`/`_post` are injectable for tests (no real network)."""
+    c = creds if creds is not None else load_creds()
+    api = (c.get("CLAWGATE_API_URL") or "").rstrip("/")
+    token = c.get("CLAWGATE_HOOK_TOKEN") or ""
+    if not api or not token:
+        _log("CLAWGATE_API_URL/CLAWGATE_HOOK_TOKEN not set (~/.claude/clawgate.env) — skipping")
+        return None
+
+    url = f"{api}/api/tasks"
+    payload = {"directory": directory, "body": body}
+    try:
+        raw = _post(url, payload, token)
+    except urllib.error.HTTPError as exc:  # noqa: PERF203
+        _log(f"POST {url} failed: HTTP {exc.code} {exc.reason}")
+        return None
+    except Exception as exc:  # noqa: BLE001
+        _log(f"POST {url} failed: {exc}")
+        return None
+
+    # Parse the {"id": <n>} response. A 2xx with no parseable id still counts as a failure
+    # for suppression purposes — we only suppress when we have a concrete task id to record.
+    try:
+        obj = json.loads(raw)
+        tid = obj.get("id")
+        if isinstance(tid, bool) or not isinstance(tid, int):
+            _log(f"POST {url} returned no integer id (got {raw[:120]!r}) — not suppressing")
+            return None
+        return tid
+    except Exception as exc:  # noqa: BLE001
+        _log(f"POST {url} succeeded but response unparseable ({exc}) — not suppressing")
+        return None

--- a/scripts/repo-cos/exclusions.py
+++ b/scripts/repo-cos/exclusions.py
@@ -20,19 +20,35 @@ Two distinct intents (a real conflation this fixes):
   feature, skip" (about a FEATURE) wrongly excluded all of civitai. The parser now classifies
   per line with a strict precedence: repo-pause > repo-owner/dead > recommendation-dismiss.
 
+A THIRD intent — "APPROVE this recommendation":
+  * "N. approve" (yes/lgtm/ship it/👍/…) is a POSITIVE action: register the FULL proposal as a
+    durable clawgate Task (Zach's adjudication+dispatch queue) AND suppress it so it can't
+    re-nag. The parser stays PURE — it only collects the approved proposal(s); the network POST
+    lives in `clawgate.py` and the suppression (a NEW "approved" state section) is applied by
+    `scan.py` ONLY when the POST returns a task id (a failed POST re-proposes next week = a
+    natural retry). Approve is the LOWEST-priority tier: resume > repo-exclude > dismiss >
+    approve, so a mixed "approve but skip" line is a DISMISS (negative wins — dropping is safer
+    than dispatching).
+
 Design (mirrors the rest of repo-cos: deterministic, no LLM, best-effort, never raises):
   * `parse_reply(reply_text, emailed_proposals)` →
-      {"exclude":[...], "resume":[...], "dismiss":[{evidence, reason, repo}]}
+      {"exclude":[...], "resume":[...], "dismiss":[{evidence, reason, repo}], "approve":[{prop}]}
     using POSITIONAL line mapping (`1.`, `2)`, `#3`, `4:` → proposal N) + a fixed keyword
     set + explicit repo-name/alias mentions. A dismiss line collects proposal N's `evidence`
-    (repo/file:line refs) so the exact recommendation can be suppressed. NO model call.
-  * State persists to ~/.config/repo-cos/exclusions.json (hand-editable by Zach) under two
-    top-level keys: "repos" (repo-level exclusions) and "dismissed" (per-recommendation,
-    keyed by the normalized evidence ref → {reason, dismissed_at, repo}).
+    (repo/file:line refs) so the exact recommendation can be suppressed; an approve line
+    collects proposal N's FULL dict (title/repo/evidence/why/approach/effort/ci_verifiable).
+    NO model call, NO network.
+  * State persists to ~/.config/repo-cos/exclusions.json (hand-editable by Zach) under three
+    top-level keys: "repos" (repo-level exclusions), "dismissed" (per-recommendation, keyed by
+    the normalized evidence ref → {reason, dismissed_at, repo}), and "approved" (per-evidence-
+    ref → {reason, approved_at, repo, clawgate_task_id}).
   * `apply(state, parsed)` merges excludes / drops resumes / accumulates dismissals.
+    `apply_approvals(state, approved, task_ids)` records approved evidence (ONLY the entries
+    with a real clawgate task id) into state["approved"] — scan.py drives this after POSTing.
     `filter_repos(repos, state)` drops excluded repos (match on realpath OR basename).
-    `filter_candidates(candidates, state)` drops dismissed candidates by evidence ref BEFORE
-    the LLM — the guarantee a skipped proposal can't re-form from the same signal.
+    `filter_candidates(candidates, state)` drops candidates whose ref is dismissed OR approved
+    (one combined suppressed-set) BEFORE the LLM — the guarantee a skipped/queued proposal
+    can't re-form from the same signal.
   * Position mapping resolves against the LAST EMAILED digest (`last_emailed.json`, else the
     most-recent history entry with emailed=true, else latest.json) — because proposals
     ROTATE run-to-run and every run overwrites latest.json, so "1./2./…" must map to the
@@ -134,6 +150,28 @@ _DISMISS_RE = re.compile(
     re.IGNORECASE | re.VERBOSE,
 )
 
+# Tier 4 — "approve THIS recommendation" → register a durable clawgate Task + suppress it so
+# it can't re-nag. APPROVE is a POSITIVE action and the LOWEST-priority tier: it only fires
+# when NO resume / repo-exclude / dismiss keyword is present on the line. A mixed line like
+# "approve but skip the test" is treated as a DISMISS (negative wins — dropping a proposal is
+# safer than dispatching one Zach also said to skip). "yes"/"lgtm"/"+1" are word-bounded so
+# "yes" doesn't fire inside "eyes"; a bare "no" is a DISMISS signal (tier 3), never approve.
+_APPROVE_RE = re.compile(
+    r"""
+      \b approved? \b
+    | \b yes \b
+    | \b lgtm \b
+    | ship \s+ it
+    | do \s+ it
+    | build \s+ (?:it|this)
+    | go \s+ ahead
+    | \U0001F44D                                          # 👍 emoji
+    | looks \s+ good
+    | \+ 1                                                # "+1"
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
 # Phrasings that mean "resume" (un-exclude / bring back). A resume beats an exclude on the
 # same line (Zach would only say "resume" about something already paused).
 _RESUME_RE = re.compile(
@@ -158,13 +196,13 @@ _POSITIONAL_RE = re.compile(r"^\s*(?:#\s*)?(\d{1,3})\s*(?:[.)\-:]|\s|$)")
 # ---- state (exclusions.json) -------------------------------------------------------
 
 def _empty_state() -> dict:
-    return {"repos": {}, "dismissed": {}}
+    return {"repos": {}, "dismissed": {}, "approved": {}}
 
 
 def load_state(path: Path | None = None) -> dict:
-    """Load exclusions.json → {"repos": {...}, "dismissed": {...}}. Robust:
-    missing/corrupt/wrong-shape file → an empty state; an OLDER file with no "dismissed"
-    key loads clean with an empty dismissed dict. Never raises."""
+    """Load exclusions.json → {"repos": {...}, "dismissed": {...}, "approved": {...}}. Robust:
+    missing/corrupt/wrong-shape file → an empty state; an OLDER file with no "dismissed"/
+    "approved" key loads clean with those defaulted to empty dicts. Never raises."""
     p = path or EXCLUSIONS_FILE
     try:
         if not p.exists():
@@ -178,6 +216,9 @@ def load_state(path: Path | None = None) -> dict:
         # missing OR wrong-shaped "dismissed" key).
         if not isinstance(obj.get("dismissed"), dict):
             obj["dismissed"] = {}
+        # older files predate the approve feature → default to empty.
+        if not isinstance(obj.get("approved"), dict):
+            obj["approved"] = {}
         return obj
     except Exception as exc:  # noqa: BLE001
         _log(f"could not read {p} ({exc}); starting empty")
@@ -309,9 +350,10 @@ def parse_reply(reply_text: str, emailed_proposals: list[dict] | None,
                 *, alias_map: dict[str, str] | None = None) -> dict:
     """Parse Zach's reply into
         {"exclude": [{repo, reason, permanent}], "resume": [repo],
-         "dismiss": [{evidence: [refs], reason, repo}]}.
+         "dismiss": [{evidence: [refs], reason, repo}],
+         "approve": [{title, repo, evidence, why, approach, effort, ci_verifiable}]}.
 
-    DETERMINISTIC — no LLM. Line-by-line, with a STRICT intent precedence:
+    DETERMINISTIC — no LLM, no network. Line-by-line, with a STRICT intent precedence:
       * RESUME beats everything (Zach only says "resume" about something paused).
       * a POSITIONAL line ('1.', '2)', '#3', '4:') → proposal N in `emailed_proposals`
         (1-indexed) → its repo AND its evidence. This is the primary mechanism.
@@ -319,20 +361,26 @@ def parse_reply(reply_text: str, emailed_proposals: list[dict] | None,
       * TIER 2 repo-owner/dead (not owner/deprecated/archived) → repo exclusion (permanent).
       * TIER 3 skip/dismiss (skip/not needed/dismiss/no…) WHEN no tier-1/2 language →
         DISMISS that one proposal: collect proposal N's `evidence` refs; the repo STAYS.
+      * TIER 4 approve/yes/lgtm/ship-it/👍 (a POSITIVE action, LOWEST priority) WHEN no
+        resume/exclude/dismiss keyword is present → APPROVE that proposal: collect proposal N's
+        FULL dict so scan.py can POST it to clawgate. A mixed "approve … skip" line is a DISMISS
+        (negative beats approve). Approve needs a positional match (the full proposal to queue).
       * an explicit repo-NAME/alias mention (non-positional) with repo-level intent applies
-        likewise (name-mentions cannot dismiss — there's no proposal to look up).
+        likewise (name-mentions cannot dismiss/approve — there's no proposal to look up).
     Unparseable lines are ignored (they still reach the LLM via context injection). Never
     raises."""
-    parsed = {"exclude": [], "resume": [], "dismiss": []}
+    parsed = {"exclude": [], "resume": [], "dismiss": [], "approve": []}
     if not reply_text:
         return parsed
     props = emailed_proposals or []
 
     # de-dupe: last write wins per repo; resume beats exclude. Dismissals accumulate keyed
-    # by evidence ref so re-touching the same proposal doesn't duplicate.
+    # by evidence ref so re-touching the same proposal doesn't duplicate. Approvals accumulate
+    # keyed by the proposal's FIRST evidence ref (a proposal's identity for suppression).
     excl: dict[str, dict] = {}
     resume: set[str] = set()
     dismiss: dict[str, dict] = {}  # ref -> {evidence:[ref], reason, repo}
+    approve: dict[str, dict] = {}  # first-ref -> full proposal dict
 
     for raw in reply_text.splitlines():
         line = raw.strip()
@@ -369,6 +417,20 @@ def parse_reply(reply_text: str, emailed_proposals: list[dict] | None,
                 continue  # no evidence to key on (e.g. a name-only line) → can't dismiss
             for ref in refs:
                 dismiss[ref] = {"evidence": [ref], "reason": line, "repo": repo}
+            continue
+        if _APPROVE_RE.search(line):
+            # TIER 4 — APPROVE (positive, lowest priority; only reached when NO negative/resume
+            # keyword matched above, so "approve but skip" already fell to dismiss). Collect the
+            # FULL proposal so scan.py can POST it to clawgate. Needs a positional match (a
+            # name-only line has no proposal to queue). Keyed by the first evidence ref =
+            # the proposal's suppression identity; a proposal with NO evidence can't be
+            # suppressed, so it's skipped (mirrors the anti-slop no-evidence rule).
+            if not prop:
+                continue
+            full = _approve_payload(prop, line)
+            if not full["evidence"]:
+                continue
+            approve[full["evidence"][0]] = full
 
     # resume wins over exclude for the same repo
     for r in resume:
@@ -386,7 +448,23 @@ def parse_reply(reply_text: str, emailed_proposals: list[dict] | None,
     for g in grouped.values():
         g["evidence"] = sorted(set(g["evidence"]))
     parsed["dismiss"] = list(grouped.values())
+    parsed["approve"] = list(approve.values())
     return parsed
+
+
+def _approve_payload(prop: dict, line: str) -> dict:
+    """The FULL proposal an approve line queues, with normalized evidence refs (so suppression
+    keys compare equal to fresh candidate refs). Carries the reason line for the audit trail."""
+    return {
+        "title": str(prop.get("title") or "").strip(),
+        "repo": str(prop.get("repo") or "").strip(),
+        "evidence": _proposal_evidence(prop),
+        "why": str(prop.get("why") or "").strip(),
+        "approach": str(prop.get("approach") or "").strip(),
+        "effort": str(prop.get("effort") or "").strip(),
+        "ci_verifiable": bool(prop.get("ci_verifiable")),
+        "reason": line,
+    }
 
 
 def _proposal_evidence(prop: dict | None) -> list[str]:
@@ -434,6 +512,7 @@ def apply(state: dict, parsed: dict, *, source: str = "reply",
     dict. Caller persists via save_state."""
     repos = state.setdefault("repos", {})
     dismissed = state.setdefault("dismissed", {})
+    state.setdefault("approved", {})  # ensure the key exists for older loaded states
     ts = now or datetime.now().astimezone().isoformat(timespec="seconds")
 
     for entry in parsed.get("exclude", []):
@@ -470,6 +549,42 @@ def apply(state: dict, parsed: dict, *, source: str = "reply",
                 "dismissed_at": prev.get("dismissed_at") or ts,
             }
 
+    return state
+
+
+def apply_approvals(state: dict, approvals: list[dict], task_ids: dict,
+                    *, now: str | None = None) -> dict:
+    """Record SUCCESSFULLY-posted approvals into state["approved"] so they can't re-nag.
+
+    `approvals` are the full proposal dicts from parse_reply's "approve" list. `task_ids` maps
+    a proposal's FIRST evidence ref → the clawgate task id returned by post_task (None if the
+    POST failed). SUPPRESS-ON-SUCCESS ONLY: a proposal is written to state["approved"] ONLY
+    when its task id is a real int — a failed POST is left UNSUPPRESSED so the proposal
+    re-surfaces next week (a natural retry). Each of the proposal's evidence refs is stored
+    (keyed by the normalized ref, same space as "dismissed") → {reason, approved_at, repo,
+    clawgate_task_id}. Returns the mutated state. Never raises."""
+    approved = state.setdefault("approved", {})
+    ts = now or datetime.now().astimezone().isoformat(timespec="seconds")
+    for prop in approvals or []:
+        evidence = prop.get("evidence") or []
+        if not evidence:
+            continue
+        tid = (task_ids or {}).get(evidence[0])
+        if not isinstance(tid, int) or isinstance(tid, bool):
+            continue  # POST failed / no id → do NOT suppress (re-propose next week = retry)
+        reason = prop.get("reason") or ""
+        repo = prop.get("repo") or ""
+        for ref in evidence:
+            key = _canon_ref(ref)
+            if not key:
+                continue
+            prev = approved.get(key) or {}
+            approved[key] = {
+                "reason": reason or prev.get("reason") or "",
+                "repo": repo or prev.get("repo") or "",
+                "approved_at": prev.get("approved_at") or ts,
+                "clawgate_task_id": tid,
+            }
     return state
 
 
@@ -510,15 +625,18 @@ def _canon_ref(ref) -> str:
 
 def filter_candidates(candidates: list, state: dict) -> tuple[list, list]:
     """Split prescan candidates into (kept, dropped) — drop any whose `.ref` matches a
-    dismissed recommendation in state["dismissed"]. Compared on the NORMALIZED repo/file:line
-    ref, so a dismissed proposal's evidence and the fresh candidate produced by the same
-    signal collapse to the same key. This is the GUARANTEE a dismissed proposal can't re-form:
-    its signal never reaches the LLM. Candidates are prescan.Candidate objects (have `.ref`)
-    OR dicts with a "ref" key. Never raises."""
+    SUPPRESSED recommendation: dismissed (state["dismissed"]) OR approved-and-queued
+    (state["approved"]). ONE combined suppressed-set — approved items are already in the
+    clawgate queue, so re-proposing them would double-nag. Compared on the NORMALIZED
+    repo/file:line ref, so a suppressed proposal's evidence and the fresh candidate produced by
+    the same signal collapse to the same key. This is the GUARANTEE a skipped/queued proposal
+    can't re-form: its signal never reaches the LLM. Candidates are prescan.Candidate objects
+    (have `.ref`) OR dicts with a "ref" key. Never raises."""
     dismissed = (state or {}).get("dismissed") or {}
-    if not dismissed:
+    approved = (state or {}).get("approved") or {}
+    if not dismissed and not approved:
         return list(candidates), []
-    keys = {_canon_ref(k) for k in dismissed}
+    keys = {_canon_ref(k) for k in dismissed} | {_canon_ref(k) for k in approved}
     kept, dropped = [], []
     for c in candidates:
         ref = c.ref if hasattr(c, "ref") else (c.get("ref") if isinstance(c, dict) else "")
@@ -541,6 +659,23 @@ def dismissed_entries(state: dict) -> list[dict]:
             "reason": (e.get("reason") or "").strip(),
             "repo": e.get("repo") or "",
             "dismissed_at": e.get("dismissed_at") or "",
+        })
+    return out
+
+
+def approved_entries(state: dict) -> list[dict]:
+    """Sorted list of approved (in-clawgate-queue) recommendations for --show-exclusions:
+    [{ref, reason, repo, approved_at, clawgate_task_id}, …]."""
+    a = (state or {}).get("approved") or {}
+    out = []
+    for ref in sorted(a):
+        e = a[ref] or {}
+        out.append({
+            "ref": ref,
+            "reason": (e.get("reason") or "").strip(),
+            "repo": e.get("repo") or "",
+            "approved_at": e.get("approved_at") or "",
+            "clawgate_task_id": e.get("clawgate_task_id"),
         })
     return out
 
@@ -598,7 +733,8 @@ def format_state(state: dict) -> str:
     REPO-level exclusions AND per-recommendation dismissals."""
     repos = (state or {}).get("repos") or {}
     dismissed = dismissed_entries(state)
-    if not repos and not dismissed:
+    approved = approved_entries(state)
+    if not repos and not dismissed and not approved:
         return ("repo-cos exclusions: none.\n(Excluded repos + dismissed recommendations come "
                 "from your emailed reply; hand-edit ~/.config/repo-cos/exclusions.json to "
                 "adjust.)")
@@ -631,6 +767,19 @@ def format_state(state: dict) -> str:
             lines.append(f"  {d['ref']}  [since {when}]")
             if d["reason"]:
                 lines.append(f"      reason: {d['reason']}")
+        lines.append("")
+
+    if approved:
+        lines.append(f"repo-cos approved (in clawgate queue): {len(approved)} proposal(s) "
+                     "dispatched to Tasks (suppressed from re-proposing).")
+        lines.append("")
+        for a in approved:
+            when = a["approved_at"] or "?"
+            tid = a["clawgate_task_id"]
+            tag = f", clawgate task #{tid}" if tid is not None else ""
+            lines.append(f"  {a['ref']}  [since {when}{tag}]")
+            if a["reason"]:
+                lines.append(f"      reason: {a['reason']}")
         lines.append("")
 
     lines.append('Reply "resume <repo>" to re-enable a repo; edit '

--- a/scripts/repo-cos/scan.py
+++ b/scripts/repo-cos/scan.py
@@ -130,8 +130,16 @@ def cmd_scan(args) -> int:
                 alias_map = exclusions.build_alias_map(DEFAULT_REPOS)
                 parsed = exclusions.parse_reply(fb.reply_text, emailed_props,
                                                 alias_map=alias_map)
-                if parsed["exclude"] or parsed["resume"] or parsed.get("dismiss"):
+                if (parsed["exclude"] or parsed["resume"] or parsed.get("dismiss")
+                        or parsed.get("approve")):
                     exclusions.apply(excl_state, parsed, source="reply")
+                    # ---- APPROVE → clawgate Task (the ONLY new network in this path) ----
+                    # For each approved proposal, POST a durable Task card to clawgate and
+                    # SUPPRESS-ON-SUCCESS ONLY: a proposal whose POST returned a task id is
+                    # recorded in excl_state["approved"] so it can't re-nag; a FAILED POST is
+                    # left unsuppressed → it re-proposes next week (a natural retry).
+                    if parsed.get("approve"):
+                        _post_approvals_to_clawgate(parsed["approve"], excl_state)
                     exclusions.save_state(excl_state)
                     if parsed["exclude"]:
                         names = ", ".join(e["repo"] for e in parsed["exclude"])
@@ -168,13 +176,15 @@ def cmd_scan(args) -> int:
 
     candidates, scans = prescan.scan_all(repos, args.limit_candidates)
 
-    # ---- DISMISSED-RECOMMENDATION FILTER (drop suppressed proposals BEFORE the LLM) ----
-    # A recommendation Zach replied "skip" to (its evidence refs live in excl_state
-    # ["dismissed"]) is removed here so its signal never reaches synthesis and cannot
-    # re-form as the same proposal — while the rest of that repo still surfaces.
+    # ---- SUPPRESSED-RECOMMENDATION FILTER (drop suppressed proposals BEFORE the LLM) ----
+    # A recommendation Zach replied "skip" (→ excl_state["dismissed"]) OR "approve" (→
+    # excl_state["approved"], already queued in clawgate) to is removed here so its signal
+    # never reaches synthesis and cannot re-form as the same proposal — while the rest of that
+    # repo still surfaces. ONE combined suppressed-set (dismissed ∪ approved).
     candidates, dropped = exclusions.filter_candidates(candidates, excl_state)
     if dropped:
-        print(f"  dismissed: {len(dropped)} candidate(s) suppressed", file=sys.stderr)
+        print(f"  suppressed: {len(dropped)} candidate(s) (dismissed ∪ approved)",
+              file=sys.stderr)
     dismissed_recs = exclusions.dismissed_entries(excl_state)
     cand_dicts = [c.as_dict() for c in candidates]
 
@@ -231,6 +241,38 @@ def cmd_scan(args) -> int:
         feedback_applied=fb is not None, excluded_repos=excluded_names,
         dismissed_count=len(dismissed_recs),
     )
+
+
+def _post_approvals_to_clawgate(approvals, excl_state, *, _clawgate=None) -> None:
+    """POST each approved proposal to clawgate as a durable Task, then SUPPRESS-ON-SUCCESS.
+
+    For every approved proposal (full dict from parse_reply), build a card + POST it. Collect
+    {first-evidence-ref → task_id-or-None} and hand it to `exclusions.apply_approvals`, which
+    records ONLY the ones with a real task id into excl_state["approved"] — a failed POST is
+    left unsuppressed so it re-proposes next week. Best-effort; never raises (mirrors the rest
+    of the reply path). `_clawgate` is injectable for tests (no real network)."""
+    clawgate = _clawgate
+    if clawgate is None:
+        import clawgate as clawgate  # noqa: PLC0414
+    task_ids: dict = {}
+    posted = 0
+    for prop in approvals:
+        evidence = prop.get("evidence") or []
+        if not evidence:
+            continue
+        try:
+            directory = clawgate.build_task_title(prop)
+            body = clawgate.build_task_body(prop)
+            tid = clawgate.post_task(directory, body)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  ! clawgate post failed (proceeding): {exc}", file=sys.stderr)
+            tid = None
+        task_ids[evidence[0]] = tid
+        if isinstance(tid, int) and not isinstance(tid, bool):
+            posted += 1
+    exclusions.apply_approvals(excl_state, approvals, task_ids)
+    print(f"  approved: {len(approvals)} proposal(s) → clawgate task(s) {posted}/"
+          f"{len(approvals)}; suppressed", file=sys.stderr)
 
 
 def _emit_candidates(candidates, scans, cand_dicts, args, *, dismissed_recs=None) -> int:

--- a/scripts/repo-cos/tests/test_approve.py
+++ b/scripts/repo-cos/tests/test_approve.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""APPROVE → clawgate Task tests — the third reply intent.
+
+When Zach replies "N. approve" (yes/lgtm/ship it/👍/…) to a digest proposal, repo-cos:
+  1. maps position N → the FULL proposal (title/repo/evidence/why/approach/effort/ci_verifiable),
+  2. POSTs a durable Task card to his clawgate adjudication+dispatch queue, and
+  3. SUPPRESS-ON-SUCCESS: only when the POST returns a task id, records the proposal's evidence
+     in state["approved"] so it can't re-nag next week; a FAILED POST is left unsuppressed.
+
+Covers: the deterministic parser (approve tier + its precedence vs dismiss), the clawgate poster
+(payload/header/creds/failure), suppress-on-success in scan.py, filter_candidates dropping
+approved refs, and --show-exclusions visibility. NO network, NO LLM (clawgate is fully mocked).
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import clawgate  # noqa: E402
+import exclusions  # noqa: E402
+import prescan  # noqa: E402
+import scan  # noqa: E402
+
+
+# The 5-proposal digest Zach ACTUALLY SAW. Positions 1-5.
+EMAILED = [
+    {"repo": "devrc", "title": "Unskip collector tests",
+     "evidence": ["devrc/scripts/collector/collector.py:88"],
+     "why": "3 collector tests are skipped", "approach": "unskip + fix the fixtures",
+     "effort": "S", "ci_verifiable": True},
+    {"repo": "civitai", "title": "Remove 3d-model dead code",
+     "evidence": ["civitai/docs/3d-models-followups.md:103", "civitai/src/3d/model.ts:44"],
+     "why": "dead feature", "approach": "delete the module", "effort": "M",
+     "ci_verifiable": False},
+    {"repo": "civitai", "title": "Add missing handler test",
+     "evidence": ["civitai/src/api/handler.ts:210"], "why": "untested path",
+     "approach": "add a unit test", "effort": "S", "ci_verifiable": True},
+    {"repo": "datapacket-talos", "title": "Fix skipped net test",
+     "evidence": ["datapacket-talos/test/net_test.go:8"], "why": "skipped",
+     "approach": "unskip", "effort": "S", "ci_verifiable": True},
+    {"repo": "kubeclaw-embed", "title": "Split large main.go",
+     "evidence": ["kubeclaw-embed/main.go:0"], "why": "1200-line file",
+     "approach": "extract packages", "effort": "L", "ci_verifiable": False},
+]
+
+DEFAULT_REPOS = [
+    "~/workspace/devrc",
+    "~/workspace/kubeclaw-embed",
+    "~/workspace/civit/civitai",
+    "~/workspace/civit/datapacket-talos",
+]
+
+
+def _alias():
+    return exclusions.build_alias_map(DEFAULT_REPOS)
+
+
+# ==== 1. PARSER: approve intent ======================================================
+
+def test_approve_collects_full_proposal():
+    parsed = exclusions.parse_reply("1. approve\n", EMAILED, alias_map=_alias())
+    assert len(parsed["approve"]) == 1
+    p = parsed["approve"][0]
+    assert p["title"] == "Unskip collector tests"
+    assert p["repo"] == "devrc"
+    assert p["evidence"] == ["devrc/scripts/collector/collector.py:88"]
+    assert p["why"] == "3 collector tests are skipped"
+    assert p["approach"] == "unskip + fix the fixtures"
+    assert p["effort"] == "S"
+    assert p["ci_verifiable"] is True
+    # approve does NOT touch exclude/resume/dismiss.
+    assert parsed["exclude"] == [] and parsed["resume"] == [] and parsed["dismiss"] == []
+
+
+def test_lgtm_is_approve():
+    parsed = exclusions.parse_reply("2. lgtm\n", EMAILED, alias_map=_alias())
+    assert [p["title"] for p in parsed["approve"]] == ["Remove 3d-model dead code"]
+    # a proposal's ALL evidence refs are carried (for suppression of every signal).
+    assert parsed["approve"][0]["evidence"] == [
+        "civitai/docs/3d-models-followups.md:103", "civitai/src/3d/model.ts:44"]
+
+
+def test_yes_ship_it_is_approve():
+    parsed = exclusions.parse_reply("3. yes ship it\n", EMAILED, alias_map=_alias())
+    assert [p["repo"] for p in parsed["approve"]] == ["civitai"]
+    assert parsed["approve"][0]["evidence"] == ["civitai/src/api/handler.ts:210"]
+
+
+def test_thumbsup_and_plus_one_and_do_it_approve():
+    for kw in ("👍", "+1", "do it", "go ahead", "build it", "looks good"):
+        parsed = exclusions.parse_reply(f"4. {kw}\n", EMAILED, alias_map=_alias())
+        assert [p["repo"] for p in parsed["approve"]] == ["datapacket-talos"], kw
+
+
+def test_mixed_approve_and_skip_is_dismiss_negative_wins():
+    # "approve but skip the test" — the NEGATIVE (skip) beats approve. Dropping a proposal Zach
+    # also said to skip is safer than dispatching it.
+    parsed = exclusions.parse_reply("4. approve but skip the test\n", EMAILED, alias_map=_alias())
+    assert parsed["approve"] == []
+    refs = {r for d in parsed["dismiss"] for r in d["evidence"]}
+    assert refs == {"datapacket-talos/test/net_test.go:8"}
+
+
+def test_approve_does_not_exclude_or_dismiss_repo():
+    parsed = exclusions.parse_reply("1. approve\n", EMAILED, alias_map=_alias())
+    assert parsed["exclude"] == []
+    assert parsed["dismiss"] == []
+    # the repo stays fully in scope; only the ONE proposal is queued.
+
+
+def test_bare_approve_no_emailed_proposals_is_noop():
+    # position 1 with NO emailed digest → no proposal to queue → no-op (mirrors dismiss).
+    parsed = exclusions.parse_reply("1. approve\n", [], alias_map=_alias())
+    assert parsed["approve"] == []
+    assert parsed == {"exclude": [], "resume": [], "dismiss": [], "approve": []}
+
+
+def test_approve_name_only_line_cannot_queue():
+    # a name mention with no position carries no proposal → approve can't fire.
+    parsed = exclusions.parse_reply("approve the civitai thing\n", EMAILED, alias_map=_alias())
+    assert parsed["approve"] == []
+
+
+def test_resume_beats_approve_on_same_line():
+    parsed = exclusions.parse_reply("1. resume this, approve it\n", EMAILED, alias_map=_alias())
+    assert parsed["resume"] == ["devrc"]
+    assert parsed["approve"] == []
+
+
+def test_pause_beats_approve_on_same_line():
+    # "approve but this is paused" → the repo-pause wins (higher tier than approve).
+    parsed = exclusions.parse_reply("1. approve, though it's paused\n", EMAILED,
+                                    alias_map=_alias())
+    assert {e["repo"] for e in parsed["exclude"]} == {"devrc"}
+    assert parsed["approve"] == []
+
+
+def test_multiple_approvals_in_one_reply():
+    reply = "1. approve\n3. lgtm\n"
+    parsed = exclusions.parse_reply(reply, EMAILED, alias_map=_alias())
+    assert {p["title"] for p in parsed["approve"]} == {
+        "Unskip collector tests", "Add missing handler test"}
+
+
+# ==== 2. CLAWGATE POSTER (mock urllib — NO network) ==================================
+
+def test_load_creds_parses_env_fixture(tmp_path):
+    envf = tmp_path / "clawgate.env"
+    envf.write_text(
+        "# a comment\n"
+        "CLAWGATE_API_URL=http://192.168.50.250:30302\n"
+        'CLAWGATE_HOOK_TOKEN="tok-123"\n'
+        "\n"
+        "OTHER=ignored\n")
+    creds = clawgate.load_creds(envf)
+    assert creds["CLAWGATE_API_URL"] == "http://192.168.50.250:30302"
+    assert creds["CLAWGATE_HOOK_TOKEN"] == "tok-123"   # quotes stripped
+
+
+def test_load_creds_missing_file_is_empty(tmp_path):
+    assert clawgate.load_creds(tmp_path / "nope.env") == {}
+
+
+def test_build_task_body_and_title():
+    prop = EMAILED[0]
+    title = clawgate.build_task_title(prop)
+    body = clawgate.build_task_body(prop)
+    assert title == "Unskip collector tests"
+    assert body.startswith("**🤖 repo-cos · APPROVED**")
+    assert "Unskip collector tests" in body
+    assert "3 collector tests are skipped" in body
+    assert "**Approach:** unskip + fix the fixtures" in body
+    assert "**Repo:** devrc" in body
+    assert "**Effort:** S" in body and "CI-verifiable" in body
+    assert "`devrc/scripts/collector/collector.py:88`" in body
+
+
+def test_build_task_title_truncated_to_80():
+    long = {"title": "x" * 200}
+    assert len(clawgate.build_task_title(long)) == 80
+
+
+def test_post_task_builds_payload_and_bearer_header(monkeypatch):
+    seen = {}
+
+    def fake_post(url, payload, token, timeout=15):
+        seen["url"] = url
+        seen["payload"] = payload
+        seen["token"] = token
+        return json.dumps({"id": 4242})
+
+    creds = {"CLAWGATE_API_URL": "http://cg:30302/", "CLAWGATE_HOOK_TOKEN": "tok-xyz"}
+    tid = clawgate.post_task("My task", "**body**", creds=creds, _post=fake_post)
+    assert tid == 4242
+    assert seen["url"] == "http://cg:30302/api/tasks"     # trailing slash collapsed
+    assert seen["payload"] == {"directory": "My task", "body": "**body**"}
+    assert seen["token"] == "tok-xyz"
+
+
+def test_post_task_sends_content_type_and_authorization(monkeypatch):
+    # exercise the real _post wiring by capturing the urllib.request.Request it builds.
+    import urllib.request
+    captured = {}
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return json.dumps({"id": 7}).encode()
+
+    def fake_urlopen(req, timeout=None):
+        captured["headers"] = req.headers
+        captured["data"] = req.data
+        captured["method"] = req.get_method()
+        captured["url"] = req.full_url
+        return _Resp()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    creds = {"CLAWGATE_API_URL": "http://cg:30302", "CLAWGATE_HOOK_TOKEN": "tok-abc"}
+    tid = clawgate.post_task("t", "b", creds=creds)
+    assert tid == 7
+    # urllib title-cases header keys.
+    assert captured["headers"]["Content-type"] == "application/json"
+    assert captured["headers"]["Authorization"] == "Bearer tok-abc"
+    assert captured["method"] == "POST"
+    assert json.loads(captured["data"]) == {"directory": "t", "body": "b"}
+
+
+def test_post_task_no_creds_returns_none():
+    assert clawgate.post_task("t", "b", creds={}) is None
+    assert clawgate.post_task("t", "b", creds={"CLAWGATE_API_URL": "http://x"}) is None
+
+
+def test_post_task_failure_returns_none_never_raises():
+    def boom(url, payload, token, timeout=15):
+        raise OSError("connection refused")
+
+    creds = {"CLAWGATE_API_URL": "http://cg", "CLAWGATE_HOOK_TOKEN": "t"}
+    # must NOT raise
+    assert clawgate.post_task("t", "b", creds=creds, _post=boom) is None
+
+
+def test_post_task_non_integer_id_is_failure():
+    def no_id(url, payload, token, timeout=15):
+        return json.dumps({"ok": True})   # no "id"
+
+    creds = {"CLAWGATE_API_URL": "http://cg", "CLAWGATE_HOOK_TOKEN": "t"}
+    assert clawgate.post_task("t", "b", creds=creds, _post=no_id) is None
+
+
+def test_post_task_unparseable_response_is_failure():
+    def junk(url, payload, token, timeout=15):
+        return "<html>oops</html>"
+
+    creds = {"CLAWGATE_API_URL": "http://cg", "CLAWGATE_HOOK_TOKEN": "t"}
+    assert clawgate.post_task("t", "b", creds=creds, _post=junk) is None
+
+
+# ==== 3. SUPPRESS-ON-SUCCESS (exclusions.apply_approvals) ============================
+
+def test_apply_approvals_success_suppresses():
+    state = {"repos": {}, "dismissed": {}, "approved": {}}
+    approvals = exclusions.parse_reply("2. lgtm\n", EMAILED, alias_map=_alias())["approve"]
+    first_ref = approvals[0]["evidence"][0]
+    exclusions.apply_approvals(state, approvals, {first_ref: 99},
+                               now="2026-07-02T08:00:00-05:00")
+    # BOTH of proposal #2's evidence refs are suppressed, tagged with the task id.
+    assert set(state["approved"]) == {
+        "civitai/docs/3d-models-followups.md:103", "civitai/src/3d/model.ts:44"}
+    e = state["approved"]["civitai/src/3d/model.ts:44"]
+    assert e["clawgate_task_id"] == 99
+    assert e["repo"] == "civitai"
+    assert e["approved_at"] == "2026-07-02T08:00:00-05:00"
+
+
+def test_apply_approvals_failed_post_not_suppressed():
+    state = {"repos": {}, "dismissed": {}, "approved": {}}
+    approvals = exclusions.parse_reply("1. approve\n", EMAILED, alias_map=_alias())["approve"]
+    first_ref = approvals[0]["evidence"][0]
+    # post_task returned None (failure) → NOT suppressed → re-proposes next week.
+    exclusions.apply_approvals(state, approvals, {first_ref: None})
+    assert state["approved"] == {}
+
+
+def test_apply_approvals_mixed_success_and_failure():
+    state = {"repos": {}, "dismissed": {}, "approved": {}}
+    approvals = exclusions.parse_reply("1. approve\n3. lgtm\n", EMAILED,
+                                       alias_map=_alias())["approve"]
+    by_repo = {p["repo"]: p for p in approvals}
+    task_ids = {
+        by_repo["devrc"]["evidence"][0]: 11,         # success
+        by_repo["civitai"]["evidence"][0]: None,     # failure
+    }
+    exclusions.apply_approvals(state, approvals, task_ids)
+    # only the devrc one is suppressed.
+    assert set(state["approved"]) == {"devrc/scripts/collector/collector.py:88"}
+
+
+# ==== 4. filter_candidates drops approved refs (combined suppressed-set) =============
+
+def _cand(repo, file, line):
+    return prescan.Candidate(repo=repo, kind="marker", file=file, line=line, text="x")
+
+
+def test_filter_candidates_drops_approved_ref():
+    state = {"repos": {}, "dismissed": {},
+             "approved": {"devrc/scripts/collector/collector.py:88":
+                          {"repo": "devrc", "clawgate_task_id": 5}}}
+    cands = [
+        _cand("devrc", "scripts/collector/collector.py", 88),   # approved → dropped
+        _cand("devrc", "scripts/other.py", 3),                  # kept
+    ]
+    kept, dropped = exclusions.filter_candidates(cands, state)
+    assert [c.ref for c in dropped] == ["devrc/scripts/collector/collector.py:88"]
+    assert [c.ref for c in kept] == ["devrc/scripts/other.py:3"]
+
+
+def test_filter_candidates_combines_dismissed_and_approved():
+    state = {"repos": {},
+             "dismissed": {"a/x.py:1": {"repo": "a"}},
+             "approved": {"b/y.py:2": {"repo": "b", "clawgate_task_id": 7}}}
+    cands = [_cand("a", "x.py", 1), _cand("b", "y.py", 2), _cand("c", "z.py", 3)]
+    kept, dropped = exclusions.filter_candidates(cands, state)
+    assert {c.ref for c in dropped} == {"a/x.py:1", "b/y.py:2"}
+    assert [c.ref for c in kept] == ["c/z.py:3"]
+
+
+# ==== 5. --show-exclusions shows the approved section ================================
+
+def test_approved_entries_sorted():
+    state = {"approved": {
+        "b/y.py:2": {"repo": "b", "clawgate_task_id": 2, "approved_at": "t2", "reason": "lgtm"},
+        "a/x.py:1": {"repo": "a", "clawgate_task_id": 1, "approved_at": "t1", "reason": "approve"},
+    }}
+    got = exclusions.approved_entries(state)
+    assert [e["ref"] for e in got] == ["a/x.py:1", "b/y.py:2"]
+    assert got[0]["clawgate_task_id"] == 1
+
+
+def test_format_state_shows_approved_section():
+    state = {"repos": {}, "dismissed": {}, "approved": {
+        "devrc/scripts/collector/collector.py:88": {
+            "repo": "devrc", "clawgate_task_id": 4242,
+            "approved_at": "2026-07-02T08:00:00-05:00", "reason": "1. approve"}}}
+    out = exclusions.format_state(state)
+    assert "clawgate queue" in out.lower()
+    assert "devrc/scripts/collector/collector.py:88" in out
+    assert "4242" in out
+
+
+# ==== 6. scan.py integration (mock clawgate + prescan + llm + feedback) ==============
+
+class _RealishProp:
+    def __init__(self, title, repo="r", evidence=None):
+        self.title, self.repo = title, repo
+        self.evidence = evidence or [f"{repo}/f.py:1"]
+        self.why, self.effort, self.approach, self.ci_verifiable = "w", "S", "a", True
+
+    def as_dict(self):
+        return {"title": self.title, "repo": self.repo, "evidence": self.evidence,
+                "why": self.why, "effort": self.effort, "approach": self.approach,
+                "ci_verifiable": self.ci_verifiable}
+
+
+class _FB:
+    def __init__(self, text):
+        self.reply_text = text
+        self.prev_proposals = []
+        self.replied_at = "2026-07-02T08:00:00-05:00"
+
+    def prev_summary(self):
+        return []
+
+
+def _prime_scan(tmp_path, monkeypatch, devrc_dir):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "k")
+    monkeypatch.setattr(scan, "PERSIST_DIR", tmp_path / "state")
+    monkeypatch.setattr(exclusions, "EXCLUSIONS_FILE", tmp_path / "exclusions.json")
+    monkeypatch.setattr(exclusions, "LAST_EMAILED_FILE", tmp_path / "last_emailed.json")
+    monkeypatch.setattr(exclusions, "HISTORY_DIR", tmp_path / "history")
+    monkeypatch.setattr(exclusions, "LATEST_FILE", tmp_path / "latest.json")
+    monkeypatch.setattr(scan, "DEFAULT_REPOS", [str(devrc_dir)])
+
+
+def test_scan_approve_posts_and_suppresses_repo_kept(tmp_path, monkeypatch):
+    """An approve reply → post_task called with the card + the proposal's evidence suppressed
+    in state["approved"], while the repo is NOT excluded and its OTHER candidates still pass."""
+    dev = tmp_path / "devrc"
+    dev.mkdir()
+    (dev / "collector.py").write_text("x\n" * 4 + "# TODO fix collector\n")   # line 5
+    (dev / "other.py").write_text("# TODO other\n")                            # line 1
+    _prime_scan(tmp_path, monkeypatch, dev)
+
+    # emitted digest: position 1 = a devrc proposal whose evidence is collector.py:5
+    (tmp_path / "last_emailed.json").write_text(json.dumps({"proposals": [
+        {"repo": "devrc", "title": "collector", "evidence": ["devrc/collector.py:5"],
+         "why": "todo", "approach": "fix", "effort": "S", "ci_verifiable": True}]}))
+
+    import feedback as feedback_mod
+    import llm
+    monkeypatch.setattr(feedback_mod, "fetch_last_feedback",
+                        lambda: _FB("1. approve\n"))
+
+    posted = {}
+
+    class _FakeClawgate:
+        @staticmethod
+        def build_task_title(p):
+            return p["title"]
+
+        @staticmethod
+        def build_task_body(p):
+            return "**🤖 repo-cos · APPROVED**\n" + p["title"]
+
+        @staticmethod
+        def post_task(directory, body):
+            posted["directory"] = directory
+            posted["body"] = body
+            return 4242
+
+    # inject the fake clawgate into scan's poster helper via monkeypatching the module import.
+    import clawgate as clawgate_mod
+    monkeypatch.setattr(clawgate_mod, "build_task_title", _FakeClawgate.build_task_title)
+    monkeypatch.setattr(clawgate_mod, "build_task_body", _FakeClawgate.build_task_body)
+    monkeypatch.setattr(clawgate_mod, "post_task", _FakeClawgate.post_task)
+
+    seen = {}
+
+    def fake_synth(cands, *, top, model, feedback=None):
+        seen["refs"] = {c["ref"] for c in cands}
+        return llm.Synthesis(proposals=[_RealishProp("ok", "devrc")], approx_prompt_tokens=1)
+    monkeypatch.setattr(llm, "synthesize", fake_synth)
+
+    args = scan.build_parser().parse_args(["--json", "--repos", str(dev)])
+    rc = scan.cmd_scan(args)
+    assert rc == 0
+    # 1) post_task was called with the approved proposal's card.
+    assert posted["directory"] == "collector"
+    assert posted["body"].startswith("**🤖 repo-cos · APPROVED**")
+    # 2) the approved candidate did NOT reach synthesis; the other devrc candidate did.
+    assert "devrc/collector.py:5" not in seen["refs"]
+    assert "devrc/other.py:1" in seen["refs"]
+    # 3) the repo is NOT excluded; the ref IS in state["approved"] with the task id.
+    st = exclusions.load_state(tmp_path / "exclusions.json")
+    assert st["repos"] == {}
+    assert "devrc/collector.py:5" in st["approved"]
+    assert st["approved"]["devrc/collector.py:5"]["clawgate_task_id"] == 4242
+
+
+def test_scan_approve_failed_post_not_suppressed(tmp_path, monkeypatch):
+    """post_task returns None (clawgate unreachable) → the proposal is NOT suppressed, so it
+    re-proposes next week (its candidate still reaches synthesis)."""
+    dev = tmp_path / "devrc"
+    dev.mkdir()
+    (dev / "collector.py").write_text("x\n" * 4 + "# TODO fix collector\n")   # line 5
+    _prime_scan(tmp_path, monkeypatch, dev)
+    (tmp_path / "last_emailed.json").write_text(json.dumps({"proposals": [
+        {"repo": "devrc", "title": "collector", "evidence": ["devrc/collector.py:5"],
+         "effort": "S", "ci_verifiable": True}]}))
+
+    import feedback as feedback_mod
+    import llm
+    monkeypatch.setattr(feedback_mod, "fetch_last_feedback", lambda: _FB("1. approve\n"))
+
+    import clawgate as clawgate_mod
+    monkeypatch.setattr(clawgate_mod, "build_task_title", lambda p: p["title"])
+    monkeypatch.setattr(clawgate_mod, "build_task_body", lambda p: "body")
+    monkeypatch.setattr(clawgate_mod, "post_task", lambda d, b: None)   # FAILURE
+
+    seen = {}
+
+    def fake_synth(cands, *, top, model, feedback=None):
+        seen["refs"] = {c["ref"] for c in cands}
+        return llm.Synthesis(proposals=[_RealishProp("ok", "devrc")], approx_prompt_tokens=1)
+    monkeypatch.setattr(llm, "synthesize", fake_synth)
+
+    args = scan.build_parser().parse_args(["--json", "--repos", str(dev)])
+    rc = scan.cmd_scan(args)
+    assert rc == 0
+    # NOT suppressed → the candidate still reached synthesis (re-proposes).
+    assert "devrc/collector.py:5" in seen["refs"]
+    st = exclusions.load_state(tmp_path / "exclusions.json")
+    assert st["approved"] == {}

--- a/scripts/repo-cos/tests/test_exclusions.py
+++ b/scripts/repo-cos/tests/test_exclusions.py
@@ -110,22 +110,25 @@ def test_parse_reply_resume_beats_exclude_same_repo():
     assert all(e["repo"] != "homelab-talos" for e in parsed["exclude"])
 
 
-_EMPTY_PARSED = {"exclude": [], "resume": [], "dismiss": []}
+_EMPTY_PARSED = {"exclude": [], "resume": [], "dismiss": [], "approve": []}
 
 
 def test_parse_reply_unparseable_and_empty_never_raise():
     assert exclusions.parse_reply("", EMAILED, alias_map=_alias()) == _EMPTY_PARSED
     assert exclusions.parse_reply(None, EMAILED, alias_map=_alias()) == _EMPTY_PARSED
-    # prose with no positional/name anchor → nothing excluded (falls through to LLM context)
-    prose = "Great work this week, keep the momentum going on everything!\n"
+    # prose with no positional/name anchor → nothing excluded (falls through to LLM context).
+    # NOTE: "looks good" is an APPROVE keyword, but with no positional anchor there's no
+    # proposal to queue, so approve can't fire either → still a full no-op.
+    prose = "Great work this week, looks good, keep the momentum going on everything!\n"
     parsed = exclusions.parse_reply(prose, EMAILED, alias_map=_alias())
     assert parsed == _EMPTY_PARSED
 
 
 def test_parse_reply_positional_no_intent_is_ignored():
-    # "1. looks good" — a bare positional line with NO exclude/resume/dismiss keyword does
-    # nothing (no skip/pause/no anchor).
-    parsed = exclusions.parse_reply("1. looks good, ship it\n", EMAILED, alias_map=_alias())
+    # a bare positional line with NO exclude/resume/dismiss/approve keyword does nothing.
+    # (Previously used "looks good, ship it" — those are now APPROVE keywords, so this must
+    # be a line with genuinely no intent.)
+    parsed = exclusions.parse_reply("1. sounds about right\n", EMAILED, alias_map=_alias())
     assert parsed == _EMPTY_PARSED
 
 
@@ -190,19 +193,19 @@ def test_state_load_save_roundtrip(tmp_path):
 
 
 def test_load_state_missing_file_is_empty(tmp_path):
-    assert exclusions.load_state(tmp_path / "nope.json") == {"repos": {}, "dismissed": {}}
+    assert exclusions.load_state(tmp_path / "nope.json") == {"repos": {}, "dismissed": {}, "approved": {}}
 
 
 def test_load_state_corrupt_file_is_empty(tmp_path):
     p = tmp_path / "exclusions.json"
     p.write_text("{ this is not json ")
-    assert exclusions.load_state(p) == {"repos": {}, "dismissed": {}}
+    assert exclusions.load_state(p) == {"repos": {}, "dismissed": {}, "approved": {}}
 
 
 def test_load_state_wrong_shape_is_normalized(tmp_path):
     p = tmp_path / "exclusions.json"
     p.write_text(json.dumps(["not", "a", "dict"]))
-    assert exclusions.load_state(p) == {"repos": {}, "dismissed": {}}
+    assert exclusions.load_state(p) == {"repos": {}, "dismissed": {}, "approved": {}}
     p.write_text(json.dumps({"repos": "not-a-dict"}))
     assert exclusions.load_state(p)["repos"] == {}
 


### PR DESCRIPTION
## APPROVE → clawgate Task

Today a `1. approve` reply to a repo-cos proposal is a **no-op** (the parser only knew
pause/skip/dismiss/resume). This adds an **APPROVE** intent that:

1. maps position N → the **full proposal** (title/repo/evidence/why/approach/effort/ci_verifiable),
2. **POSTs a durable Task card** to Zach's clawgate adjudication+dispatch queue (`POST /api/tasks`),
   so an approved proposal lands as a **one-tap-Dispatch** card, and
3. **suppress-on-SUCCESS**: only when the POST returns a task id, the proposal's evidence refs are
   recorded in a new `state["approved"]` section so it **won't re-nag** next week.

### Parser (`exclusions.py` — pure/deterministic, NO network)
- New APPROVE keyword tier: `approve(d) / yes / lgtm / ship it / do it / build it|this / go ahead /
  👍 / looks good / +1` (word-bounded, so `buildkite`/`yesterday`/`noodles` don't false-fire).
- **Precedence:** `resume > repo-exclude (pause/owner) > dismiss (skip) > approve`. Approve is a
  **positive** action and the **lowest** tier — a mixed `approve … skip` line is a **dismiss**
  (negative wins; dropping is safer than dispatching). Approve needs a **positional** match (there's
  a full proposal to queue); a bare `approve` with no emailed digest is a no-op.
- `parse_reply` now returns `{"exclude","resume","dismiss","approve":[{proposal}]}`.

### clawgate poster (new `clawgate.py` — stdlib `urllib`, best-effort, never raises)
- `load_creds()` parses `~/.claude/clawgate.env` (simple `KEY=VALUE` → `CLAWGATE_API_URL`,
  `CLAWGATE_HOOK_TOKEN`).
- `post_task(directory, body)` → `POST {API}/api/tasks`, `Content-Type: application/json` +
  `Authorization: Bearer <token>`, 15s timeout → task **id** | **None** on any error (logged).
- **Card format** matches the homelab task-drafter (`route_clawgate`):
  ```
  **🤖 repo-cos · APPROVED**

  **<title>**
  <why>

  **Approach:** …
  **Repo:** <repo>
  **Effort:** S/M/L · CI-verifiable | needs manual verification
  **Evidence:**
  - `repo/file:line`
  ```
  Title = the proposal title (≤80 chars).

### scan.py
- After parsing the reply, each approved proposal is POSTed. **Suppress-on-success ONLY**: a returned
  id → evidence written to `state["approved"]` (`repo/file:line → {reason, approved_at, repo,
  clawgate_task_id}`); a **failed** POST is **left unsuppressed** → re-proposes next week (a natural
  retry). Logs `approved: N proposal(s) → clawgate task(s) M/N; suppressed`.
- `filter_candidates` now drops candidates in **dismissed ∪ approved** (one combined suppressed-set)
  before the LLM — reuses the same `_canon_ref` normalization as dismissal so `approved` refs compare
  equal to fresh prescan candidate refs.
- `--show-exclusions` gains an **"Approved (in clawgate queue)"** section (each `repo/file:line` +
  reason + `clawgate_task_id`).

### State
`exclusions.json` grows a third top-level key `approved`; `load_state` tolerates older files without
it (defaults to `{}`). No transport change to send / reply-read — the **only new network** is the
best-effort clawgate POST.

### Deploy
The weekly `run-weekly.sh` needs **no change** — it runs on the workbench where
`~/.claude/clawgate.env` exists, and clawgate is on the open, hook-token-gated LAN NodePort.

### Tests
`nix-shell -p 'python3.withPackages(p:[p.pytest p.requests p.psycopg2])' --run 'python -m pytest scripts/repo-cos/tests -q'`
→ **189 passed** (159 pre-existing kept green; +30 new in `test_approve.py`).
- Parser: `1. approve` / `2. lgtm` / `3. yes ship it` → approve list has that position's proposal;
  `4. approve but skip the test` → dismiss wins; bare `1. approve` with no emailed proposals → no-op;
  approve does NOT exclude/dismiss the repo; resume/pause beat approve on a mixed line.
- Poster: payload + Bearer header built correctly (mocked `urllib` — no network); creds parsed from a
  fixture env file; POST failure / non-int id / unparseable body → `None` (never raises).
- Suppress-on-success: mocked `post_task` → id → evidence lands in `state["approved"]`; → `None` → NOT
  suppressed. `filter_candidates` drops approved refs (and combined with dismissed).
- scan.py integration (clawgate + prescan + llm + feedback mocked): approve reply → `post_task` called
  + evidence suppressed + repo NOT excluded + the repo's other candidates still reach synthesis; a
  failed POST leaves the candidate reaching synthesis.

*(4 pre-existing shape assertions in `test_exclusions.py` were updated for the new `approve`/`approved`
keys; one test whose premise was `"looks good, ship it" is a no-op` was corrected — those are now
APPROVE keywords.)*

### Honest limits
- **Approve needs a positional line** (`N. approve`) — a bare name mention carries no proposal to queue.
- **clawgate must be reachable** at POST time; a **failed POST re-proposes** next week (by design — a
  natural retry, no lost approval).
- The `~/.claude/clawgate.env` creds must be present on the host running the scan (they are, on the
  workbench weekly timer).

### Live verification
During development the real no-creds/reachability path was exercised against **live clawgate** and
created a real Task (id #38) — confirming the end-to-end POST works; that test card was then **deleted**
via `DELETE /tasks/38`. After merge, a live re-run of Zach's `1. approve` reply (row 49613 → the devrc
collector-tests proposal) will POST a real clawgate Task + suppress it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
