### PR TITLE
repo-cos: approved Task carries its dispatch repo (clawgate 0.7.45 pre-fill)

### DIFF
--- a/scripts/repo-cos/clawgate.py
+++ b/scripts/repo-cos/clawgate.py
@@ -11,8 +11,13 @@ Design (mirrors the rest of repo-cos: best-effort, never raises, stdlib-only):
     CLAWGATE_HOOK_TOKEN}. Missing file / keys → {} (→ post_task no-ops to None).
   * `build_task_body(proposal)` → clean markdown card matching the homelab task-drafter's
     style (lead `**🤖 repo-cos · APPROVED**`, then the goal, structured fields, evidence).
-  * `post_task(directory, body)` → POST {API_URL}/api/tasks with the Bearer hook token, 15s
-    timeout. Returns the created task id (int) on success, else None (logged). NEVER raises.
+  * `resolve_repo_fullname(repo_name)` → the proposal's local repo basename → its GitHub
+    `owner/name` (from `git remote get-url origin`), so the Task carries a dispatch-ready
+    `repo` pre-fill. Best-effort/stdlib-only; unknown/unparseable → "" (repo left unset).
+  * `post_task(directory, body, *, repo="", model="")` → POST {API_URL}/api/tasks with the
+    Bearer hook token, 15s timeout. The payload carries the resolved `repo` (and `model`)
+    ONLY when non-empty — a bare call still sends exactly {"directory","body"} (back-compat).
+    Returns the created task id (int) on success, else None (logged). NEVER raises.
 
 This is the ONLY new network in the approve path. Everything upstream (the parser) is pure.
 Reference impl: homelab-talos …/agent-pods/task-drafter/trigger-configmap.yaml `route_clawgate`.
@@ -20,6 +25,7 @@ Reference impl: homelab-talos …/agent-pods/task-drafter/trigger-configmap.yaml
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 import urllib.error
 import urllib.request
@@ -58,6 +64,84 @@ def load_creds(path: Path | None = None) -> dict:
         _log(f"could not read {p}: {exc}")
         return {}
     return creds
+
+
+# ---- repo → GitHub full-name resolver ----------------------------------------------
+
+def _git_remote(path: str, *, timeout: int = 10) -> str:
+    """Run `git -C <path> remote get-url origin`, returning the stripped stdout, or "" on any
+    failure (non-zero, missing git, timeout, …). Isolated + injectable so tests never shell
+    out. Never raises."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", path, "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _log(f"git remote for {path} failed: {exc}")
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return (proc.stdout or "").strip()
+
+
+def _parse_github_fullname(url: str) -> str:
+    """Parse a git remote URL to `owner/name`. Strips a leading `git@github.com:`,
+    `https://github.com/`, `http://github.com/`, or `ssh://git@github.com/`, and a trailing
+    `.git`. Anything we don't recognize as a GitHub remote → "" (best-effort)."""
+    u = (url or "").strip()
+    if not u:
+        return ""
+    for prefix in ("git@github.com:", "ssh://git@github.com/",
+                   "https://github.com/", "http://github.com/"):
+        if u.startswith(prefix):
+            u = u[len(prefix):]
+            break
+    else:
+        return ""  # not a GitHub remote we can map
+    if u.endswith(".git"):
+        u = u[:-4]
+    parts = [seg for seg in u.strip("/").split("/") if seg]
+    if len(parts) != 2:
+        return ""
+    return f"{parts[0]}/{parts[1]}"
+
+
+def resolve_repo_fullname(repo_name: str, *, repos=None, _run=None) -> str:
+    """Map a proposal's repo BASENAME (e.g. `civitai`, `devrc`) → its GitHub `owner/name` by
+    reading `git remote get-url origin` on the matching local path. A naive basename is WRONG
+    (e.g. `datapacket-talos → civitai/talos-infra`), so we always resolve from the remote.
+
+    `repos` defaults to `scan.DEFAULT_REPOS` (a list of `~`-relative paths); `_run` defaults to
+    `_git_remote` — both injectable so the function is pure/testable (no real fs/git needed).
+    BEST-EFFORT, stdlib-only, NEVER raises: unknown name / no matching path / no remote /
+    unparseable → "" (the Task's repo is then left unset → clawgate's dispatch default)."""
+    name = (repo_name or "").strip()
+    if not name:
+        return ""
+    try:
+        if repos is None:
+            import scan  # lazy — avoids a top-level cycle; picks up monkeypatched value
+            repos = scan.DEFAULT_REPOS
+        run = _run if _run is not None else _git_remote
+
+        path = None
+        for entry in repos or []:
+            p = str(Path(str(entry)).expanduser())
+            if Path(p).name == name:
+                path = p
+                break
+        if path is None:
+            _log(f"no local repo path matches {name!r} — Task repo left unset")
+            return ""
+
+        full = _parse_github_fullname(run(path))
+        if not full:
+            _log(f"could not resolve GitHub full-name for {name!r} — Task repo left unset")
+        return full
+    except Exception as exc:  # noqa: BLE001
+        _log(f"resolve_repo_fullname({name!r}) failed: {exc}")
+        return ""
 
 
 # ---- card body ---------------------------------------------------------------------
@@ -118,11 +202,15 @@ def _post(url: str, payload: dict, token: str, *, timeout: int = POST_TIMEOUT) -
         return resp.read().decode("utf-8")
 
 
-def post_task(directory: str, body: str, *, creds: dict | None = None,
-              _post=_post) -> int | None:
+def post_task(directory: str, body: str, *, repo: str = "", model: str = "",
+              creds: dict | None = None, _post=_post) -> int | None:
     """POST a Task to clawgate's `/api/tasks`. Returns the created task id (int) on success,
     else None. BEST-EFFORT: any error (no creds, unreachable, non-JSON, no id) is logged and
-    yields None — NEVER raises. `creds`/`_post` are injectable for tests (no real network)."""
+    yields None — NEVER raises. `creds`/`_post` are injectable for tests (no real network).
+
+    `repo` (a GitHub `owner/name`) and `model` pre-fill the Task's dispatch config; each is
+    added to the payload ONLY when non-empty, so a bare call still sends exactly the old
+    2-key {"directory","body"} payload (backward-compatible)."""
     c = creds if creds is not None else load_creds()
     api = (c.get("CLAWGATE_API_URL") or "").rstrip("/")
     token = c.get("CLAWGATE_HOOK_TOKEN") or ""
@@ -132,6 +220,10 @@ def post_task(directory: str, body: str, *, creds: dict | None = None,
 
     url = f"{api}/api/tasks"
     payload = {"directory": directory, "body": body}
+    if repo:
+        payload["repo"] = repo
+    if model:
+        payload["model"] = model
     try:
         raw = _post(url, payload, token)
     except urllib.error.HTTPError as exc:  # noqa: PERF203

--- a/scripts/repo-cos/scan.py
+++ b/scripts/repo-cos/scan.py
@@ -263,7 +263,8 @@ def _post_approvals_to_clawgate(approvals, excl_state, *, _clawgate=None) -> Non
         try:
             directory = clawgate.build_task_title(prop)
             body = clawgate.build_task_body(prop)
-            tid = clawgate.post_task(directory, body)
+            repo = clawgate.resolve_repo_fullname(prop.get("repo") or "")
+            tid = clawgate.post_task(directory, body, repo=repo)
         except Exception as exc:  # noqa: BLE001
             print(f"  ! clawgate post failed (proceeding): {exc}", file=sys.stderr)
             tid = None

--- a/scripts/repo-cos/tests/test_approve.py
+++ b/scripts/repo-cos/tests/test_approve.py
@@ -260,6 +260,137 @@ def test_post_task_unparseable_response_is_failure():
     assert clawgate.post_task("t", "b", creds=creds, _post=junk) is None
 
 
+# ==== 2b. REPO RESOLVER + dispatch-config payload ====================================
+
+# fake repos whose BASENAMES we control — no real fs/git needed.
+_FAKE_REPOS = ["~/ws/devrc", "~/ws/civit/civitai", "~/ws/kubeclaw-cloud"]
+
+
+def test_resolve_repo_fullname_ssh_remote():
+    def run(path):
+        assert path.endswith("/ws/civit/civitai")   # ~ expanded, basename matched
+        return "git@github.com:Owner/Repo.git"
+    assert clawgate.resolve_repo_fullname("civitai", repos=_FAKE_REPOS, _run=run) == "Owner/Repo"
+
+
+def test_resolve_repo_fullname_https_remote_with_git_suffix():
+    run = lambda p: "https://github.com/Owner/Repo.git"
+    assert clawgate.resolve_repo_fullname("devrc", repos=_FAKE_REPOS, _run=run) == "Owner/Repo"
+
+
+def test_resolve_repo_fullname_https_remote_no_git_suffix():
+    run = lambda p: "https://github.com/Owner/Repo"
+    assert clawgate.resolve_repo_fullname("devrc", repos=_FAKE_REPOS, _run=run) == "Owner/Repo"
+
+
+def test_resolve_repo_fullname_ssh_scheme_remote():
+    run = lambda p: "ssh://git@github.com/Owner/Repo.git"
+    assert clawgate.resolve_repo_fullname("devrc", repos=_FAKE_REPOS, _run=run) == "Owner/Repo"
+
+
+def test_resolve_repo_fullname_unknown_name_returns_empty():
+    # a name whose basename matches nothing in repos → "" (never shells out).
+    called = []
+    run = lambda p: called.append(p) or "git@github.com:Owner/Repo.git"
+    assert clawgate.resolve_repo_fullname("nope", repos=_FAKE_REPOS, _run=run) == ""
+    assert called == []          # short-circuits before running git
+
+
+def test_resolve_repo_fullname_empty_name_returns_empty():
+    assert clawgate.resolve_repo_fullname("", repos=_FAKE_REPOS, _run=lambda p: "x") == ""
+    assert clawgate.resolve_repo_fullname(None, repos=_FAKE_REPOS, _run=lambda p: "x") == ""
+
+
+def test_resolve_repo_fullname_run_raises_returns_empty():
+    def boom(path):
+        raise OSError("git not found")
+    assert clawgate.resolve_repo_fullname("devrc", repos=_FAKE_REPOS, _run=boom) == ""
+
+
+def test_resolve_repo_fullname_empty_remote_returns_empty():
+    # _run returning "" (no remote / non-zero exit) → "".
+    assert clawgate.resolve_repo_fullname("devrc", repos=_FAKE_REPOS, _run=lambda p: "") == ""
+
+
+def test_resolve_repo_fullname_non_github_remote_returns_empty():
+    run = lambda p: "https://gitlab.com/Owner/Repo.git"
+    assert clawgate.resolve_repo_fullname("devrc", repos=_FAKE_REPOS, _run=run) == ""
+
+
+def test_git_remote_wrapper_non_zero_returns_empty(monkeypatch):
+    import subprocess
+
+    class _Proc:
+        returncode = 1
+        stdout = ""
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc())
+    assert clawgate._git_remote("/nope") == ""
+
+
+def test_post_task_includes_repo_when_passed():
+    seen = {}
+
+    def fake_post(url, payload, token, timeout=15):
+        seen["payload"] = payload
+        return json.dumps({"id": 5})
+
+    creds = {"CLAWGATE_API_URL": "http://cg", "CLAWGATE_HOOK_TOKEN": "t"}
+    tid = clawgate.post_task("d", "b", repo="Owner/Repo", creds=creds, _post=fake_post)
+    assert tid == 5
+    assert seen["payload"] == {"directory": "d", "body": "b", "repo": "Owner/Repo"}
+
+
+def test_post_task_includes_model_when_passed():
+    seen = {}
+    fake_post = lambda u, payload, t, timeout=15: (seen.update(payload=payload)
+                                                   or json.dumps({"id": 6}))
+    creds = {"CLAWGATE_API_URL": "http://cg", "CLAWGATE_HOOK_TOKEN": "t"}
+    clawgate.post_task("d", "b", repo="O/R", model="opus", creds=creds, _post=fake_post)
+    assert seen["payload"] == {"directory": "d", "body": "b", "repo": "O/R", "model": "opus"}
+
+
+def test_post_task_omits_repo_and_model_when_absent():
+    # BACKWARD-COMPAT GUARD: a bare call must send EXACTLY the old 2-key payload.
+    seen = {}
+    fake_post = lambda u, payload, t, timeout=15: (seen.update(payload=payload)
+                                                   or json.dumps({"id": 7}))
+    creds = {"CLAWGATE_API_URL": "http://cg", "CLAWGATE_HOOK_TOKEN": "t"}
+    clawgate.post_task("d", "b", creds=creds, _post=fake_post)
+    assert seen["payload"] == {"directory": "d", "body": "b"}
+
+
+def test_post_approvals_passes_resolved_repo_to_post_task():
+    """The caller wiring: _post_approvals_to_clawgate resolves the repo full-name and threads
+    it into post_task(repo=...). Inject a fake clawgate module via the `_clawgate` param."""
+    import types
+    captured = {}
+
+    def _resolve(name):
+        captured["resolve_arg"] = name
+        return "Owner/Repo"
+
+    def _post_task(directory, body, *, repo="", model=""):
+        captured["directory"] = directory
+        captured["repo"] = repo
+        return 4242
+
+    fake_cg = types.SimpleNamespace(
+        build_task_title=lambda p: p["title"],
+        build_task_body=lambda p: "body",
+        resolve_repo_fullname=_resolve,
+        post_task=_post_task,
+    )
+    approvals = [{"repo": "civitai", "title": "T",
+                  "evidence": ["civitai/src/x.ts:1"]}]
+    state = {"repos": {}, "dismissed": {}, "approved": {}}
+    scan._post_approvals_to_clawgate(approvals, state, _clawgate=fake_cg)
+
+    assert captured["resolve_arg"] == "civitai"
+    assert captured["repo"] == "Owner/Repo"
+    # suppress-on-success still records the evidence with the returned task id.
+    assert "civitai/src/x.ts:1" in state["approved"]
+
+
 # ==== 3. SUPPRESS-ON-SUCCESS (exclusions.apply_approvals) ============================
 
 def test_apply_approvals_success_suppresses():
@@ -417,9 +548,10 @@ def test_scan_approve_posts_and_suppresses_repo_kept(tmp_path, monkeypatch):
             return "**🤖 repo-cos · APPROVED**\n" + p["title"]
 
         @staticmethod
-        def post_task(directory, body):
+        def post_task(directory, body, *, repo="", model=""):
             posted["directory"] = directory
             posted["body"] = body
+            posted["repo"] = repo
             return 4242
 
     # inject the fake clawgate into scan's poster helper via monkeypatching the module import.
@@ -469,7 +601,7 @@ def test_scan_approve_failed_post_not_suppressed(tmp_path, monkeypatch):
     import clawgate as clawgate_mod
     monkeypatch.setattr(clawgate_mod, "build_task_title", lambda p: p["title"])
     monkeypatch.setattr(clawgate_mod, "build_task_body", lambda p: "body")
-    monkeypatch.setattr(clawgate_mod, "post_task", lambda d, b: None)   # FAILURE
+    monkeypatch.setattr(clawgate_mod, "post_task", lambda d, b, **kw: None)   # FAILURE
 
     seen = {}
 


### PR DESCRIPTION
## What
When Zach approves a repo-cos proposal, the durable clawgate Task it creates now carries a **dispatch `repo`** so the Task's Dispatch button in clawgate is a pre-filled confirm (clawgate 0.7.45 gave Tasks a dispatch config).

## Why the remote resolution matters
The proposal's `repo` is a local basename (`civitai`, `devrc`). The dispatch field needs the GitHub `owner/name`, which is **not** the basename in general — e.g. `datapacket-talos → civitai/talos-infra`, `kubeclaw-cloud → ZacxDev/clankup`, `devrc → innovation-upstream/devrc`. So `resolve_repo_fullname()` maps basename → local path (`scan.DEFAULT_REPOS`) → `git remote get-url origin` → `owner/name`.

## Changes
- `clawgate.py`: `resolve_repo_fullname()` (+ `_git_remote`/`_parse_github_fullname` helpers, best-effort/stdlib-only, unknown → `""`); `post_task(..., repo="", model="")` adds `repo`/`model` to the payload **only when non-empty** (backward-compatible — a bare call still sends `{"directory","body"}`).
- `scan.py`: `_post_approvals_to_clawgate` resolves + passes `repo`.
- `tests/test_approve.py`: +14 tests (resolver forms, backward-compat guard, caller wiring). **203 pass.**

## Verification
- Suite: 203 passed.
- Live end-to-end against the running clawgate: `resolve_repo_fullname("devrc") → innovation-upstream/devrc`; `post_task(..., repo=…)` → Task stored with `repo='innovation-upstream/devrc'` (read back via `GET /api/tasks/{id}`, then deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)