### PR TITLE
feat(zsh): pre-export repo roots + kubeconfigs for agent shells

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ Personal dev-environment config (zsh, tmux, neovim, i3, scripts) for the workben
 - **Bash tool runs NON-interactive zsh** (`zsh -c`) → sources `.zshenv` only, NOT `.zshrc`/`initContent`. Shell tweaks Claude needs at runtime must go in home-manager `programs.zsh.envExtra` (→ `.zshenv`). `unsetopt nomatch` lives there so unmatched globs pass through literally instead of aborting with "no matches found".
 - zsh reserves `status` — use `rc=`/`out=`, never `status=$(...)`.
 - Use `git -C <path>` and absolute paths — never `cd <repo> && …` (triggers approval prompts and can run untrusted hooks).
+- **Canonical env handles are pre-exported in `.zshenv`** (via `envExtra`) so you don't re-`cd`/`export` on every call — non-interactive `zsh -c` doesn't persist state. Use them directly (each is existence-guarded, absent on hosts without that checkout): repo roots `$DEVRC` `$HOMELAB` `$DATAPACKET` `$CIVITAI` (e.g. `git -C $DATAPACKET status`); kubeconfigs `$KC_HOMELAB` `$KC_WORKBENCH` `$KC_DPPROD` `$KC_NEBULA` (e.g. `KUBECONFIG=$KC_DPPROD kubectl get pods`). There is deliberately **no default `KUBECONFIG`** — pick a cluster per command so a bare `kubectl` can't hit prod.
 
 ## Applying changes
 - **Deploy to BOTH hosts (after merge):** `scripts/ship.sh` — converges workbench + laptop to `origin/main` (stash → ff-pull → `home-manager switch` → pop → verify HEAD==origin/main) in one idempotent call. Use this instead of hand-running the per-host dance; `--no-laptop`/`--no-local` to scope. Covers home-manager only (not `sudo nixos-rebuild`).

--- a/nix/programs/zsh/default.nix
+++ b/nix/programs/zsh/default.nix
@@ -11,6 +11,25 @@
   # command with "no matches found" — the single largest source of session command errors.
   envExtra = ''
     unsetopt nomatch
+
+    # ── Canonical repo roots + kubeconfigs for agent shells ─────────────────
+    # Claude Code's Bash tool runs NON-interactive `zsh -c`, which sources ONLY
+    # .zshenv and does NOT persist shell state between calls. So agents were
+    # re-typing `cd <repo> && …` / `export KUBECONFIG=…` on ~50% of Bash calls
+    # (measured: ~3.8k plumbing turns/week). Exporting stable handles ONCE here
+    # lets a call be `git -C $DATAPACKET …` / `KUBECONFIG=$KC_DPPROD kubectl …`
+    # with no per-call setup. Existence-guarded so the laptop (no civit
+    # checkouts) and any missing file stay clean — no stale vars.
+    # NO default KUBECONFIG on purpose: a merged/default one lets a bare
+    # `kubectl` hit prod. Pick a cluster explicitly per command.
+    [[ -d $HOME/workspace/devrc ]]                  && export DEVRC=$HOME/workspace/devrc
+    [[ -d $HOME/workspace/homelab-talos ]]          && export HOMELAB=$HOME/workspace/homelab-talos
+    [[ -d $HOME/workspace/civit/datapacket-talos ]] && export DATAPACKET=$HOME/workspace/civit/datapacket-talos
+    [[ -d $HOME/workspace/civit/civitai ]]          && export CIVITAI=$HOME/workspace/civit/civitai
+    [[ -f $HOME/workspace/homelab-talos/homelab-kubeconfig ]]       && export KC_HOMELAB=$HOME/workspace/homelab-talos/homelab-kubeconfig
+    [[ -f $HOME/workspace/homelab-talos/workbench-kubeconfig ]]     && export KC_WORKBENCH=$HOME/workspace/homelab-talos/workbench-kubeconfig
+    [[ -f $HOME/workspace/civit/datapacket-talos/prod-kubeconfig ]] && export KC_DPPROD=$HOME/workspace/civit/datapacket-talos/prod-kubeconfig
+    [[ -f $HOME/.kube/homelab-nebula.yaml ]]        && export KC_NEBULA=$HOME/.kube/homelab-nebula.yaml
   '';
 
   initContent = let


### PR DESCRIPTION
## Why

Analysis of the last week of Claude Code transcripts (71 sessions, 11.8k tool calls) found the single largest avoidable turn-sink is **shell-context plumbing**: ~50% of all Bash calls begin with `cd` or `export`, and the per-repo path / per-cluster `KUBECONFIG` get re-set on nearly every call — roughly **3.8k plumbing turns in one week**.

Root cause is structural: the Bash tool runs **non-interactive `zsh -c`**, which sources only `.zshenv` and doesn't persist shell state between calls, so every turn re-establishes the same handful of repo paths + kubeconfigs before doing real work.

## What

Pre-export stable, existence-guarded handles once in `programs.zsh.envExtra` (→ `.zshenv`, the only file non-interactive shells read):

- **repo roots:** `$DEVRC` `$HOMELAB` `$DATAPACKET` `$CIVITAI`
- **kubeconfigs:** `$KC_HOMELAB` `$KC_WORKBENCH` `$KC_DPPROD` `$KC_NEBULA`

A call becomes `git -C $DATAPACKET status` / `KUBECONFIG=$KC_DPPROD kubectl get pods` with no per-call setup. Documented in `CLAUDE.md` so agents adopt them.

## Safety / design

- **Existence-guarded** (`[[ -d ]]` / `[[ -f ]]`) — the laptop (no civit checkouts) and any absent file stay clean, no stale vars pointing at nothing.
- **No default `KUBECONFIG`** on purpose — a merged/default one would let a bare `kubectl` hit prod. Cluster is chosen explicitly per command.
- Reversible (env-only; removing the lines restores prior behavior).

## Verification

- `nix-instantiate --parse` OK; `home-manager switch` clean.
- Reproduced the exact failing path — fresh `zsh -c` post-switch resolves all four repo roots + the three present kubeconfigs; `KC_NEBULA` correctly empty here (laptop-only file); `git -C $DATAPACKET rev-parse` works with zero `cd`/`export`.

## Follow-up (not in this PR)

`envExtra` makes the vars available in every shell, but the high-volume agents run in the **civit/homelab repos**, which read *their own* CLAUDE.md. Getting them to adopt the handles needs a one-line pointer in `datapacket-talos` / `civitai` / `homelab-talos` CLAUDE.md — those are client repos, so left to Zach's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)