### PR TITLE
clawgate manual validation — add claudedocs/manual-validation.md

### DIFF
--- a/claudedocs/manual-validation.md
+++ b/claudedocs/manual-validation.md
@@ -1,0 +1,1 @@
+clawgate manual validation — dispatched via the Tasks board. Safe to delete.


### PR DESCRIPTION
Adds `claudedocs/manual-validation.md` as a manual validation file per clawgate task workflow.