### PR TITLE
chore(tmux): promote laptop-local tweaks to main

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,3 +1,9 @@
+# True-color passthrough (TERM inside tmux is tmux-256color; outer TERM = alacritty)
+set -ag terminal-overrides ",alacritty:RGB,xterm-256color:RGB"
+
+# Keep window indices contiguous when one is closed
+set -g renumber-windows on
+
 # ============================================
 # System clipboard via OSC 52 (works across SSH + nested tmux)
 # ============================================


### PR DESCRIPTION
Lifts two settings that were carried as uncommitted local drift on the laptop (and were never in main, so they re-conflicted on every `ship`) into the shared `.tmux.conf`:

- `terminal-overrides ",alacritty:RGB,xterm-256color:RGB"` — true-color passthrough.
- `renumber-windows on` — keep window indices contiguous after a close.

Both are host-agnostic (the workbench is reached via alacritty over SSH, so it benefits from the same true-color override). Follow-up to #38; converging both hosts after merge eliminates the laptop's `.tmux.conf` drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)