### PR TITLE
chore: add manual e2e marker file for 0.7.52

### DIFF
--- a/claudedocs/manual-e2e-0752.md
+++ b/claudedocs/manual-e2e-0752.md
@@ -1,0 +1,1 @@
+clawgate manual e2e on 0.7.52 — safe to delete.


### PR DESCRIPTION
Non-destructive change to exercise the clawgate task workflow.

Adds `claudedocs/manual-e2e-0752.md` — safe to delete.