### PR TITLE
e2e: clawgate end-to-end on 0.7.57

### DIFF
--- a/claudedocs/e2e-0757.md
+++ b/claudedocs/e2e-0757.md
@@ -1,0 +1,1 @@
+clawgate end-to-end on 0.7.57 — safe to delete.


### PR DESCRIPTION
Trivial e2e verification of the clawgate loop on 0.7.57. Safe to delete.