### PR TITLE
feat: add .editorconfig with polyglot defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig — cross-editor consistency
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[*.{sh,bash}]
+indent_size = 2
+
+[*.nix]
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Adds a single `.editorconfig` at repo root with sane cross-editor defaults for this polyglot dotfiles repo:

- **`[*]`** — utf-8, lf, trailing-whitespace trim, final newline, 2-space indent
- **`[*.py]`** — 4-space indent
- **`[*.{sh,bash}]`** — 2-space indent
- **`[*.nix]`** — 2-space indent
- **`[Makefile]`** — tab indent

Additive only — no existing files touched. Fully reversible.