### PR TITLE
feat: add .gitattributes for line-ending normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Normalize all text files to LF — only affects future checkouts
+* text=auto eol=lf
+
+# Explicit text + LF for known text types
+*.sh    text eol=lf
+*.bash  text eol=lf
+*.nix   text eol=lf
+*.py    text eol=lf
+*.lua   text eol=lf
+
+# Binary / generated markers
+*.png     binary
+*.jpg     binary
+*.jpeg    binary
+*.lock    linguist-generated=true
+flake.lock linguist-generated=true


### PR DESCRIPTION
Adds `.gitattributes` at repo root to normalize line endings and mark generated/binary files, keeping this polyglot dotfiles repo (Nix, shell, Python, Lua) consistent across checkouts.

**Changes:**
- `* text=auto eol=lf` — normalize all text to LF on checkout
- Explicit `*.sh`, `*.bash`, `*.nix`, `*.py`, `*.lua` → `text eol=lf`
- Binary markers for `*.png`, `*.jpg`, `*.jpeg` → `binary`
- `*.lock` / `flake.lock` → `linguist-generated=true` (excluded from language stats)

**Safety:** Adds one new dotfile; changes no existing config or scripts. Fully reversible (close PR / delete file).