### PR TITLE
feat(initiatives): --tmux column links initiatives to live tmux sessions

### DIFF
--- a/claude/commands/initiatives.md
+++ b/claude/commands/initiatives.md
@@ -1,7 +1,7 @@
 ---
 name: initiatives
-description: "Show the cross-repo initiative + progress ledger (initiative-scan): every ongoing initiative, its momentum (●active / ◐slowing / ○stalled), last-touched, commits/PRs, and next-step — fused deterministically from handoff docs + git + activity telemetry. Use for 'what am I working on', 'what's in flight across my projects', 'what's stalled', 'where did I leave X'."
-argument-hint: "[--days N] [--repo PATH] [--json] — optional; defaults to --days 14"
+description: "Show the cross-repo initiative + progress ledger (initiative-scan): every ongoing initiative, its momentum (●active / ◐slowing / ○stalled), last-touched, commits/PRs, next-step, and the live tmux session hosting it — fused deterministically from handoff docs + git + activity telemetry + live tmux. Use for 'what am I working on', 'what's in flight across my projects', 'what's stalled', 'where did I leave X', 'which session is X in'."
+argument-hint: "[--days N] [--repo PATH] [--json] [--tmux] — optional; defaults to --days 14 --tmux"
 allowed-tools: Bash
 ---
 
@@ -21,10 +21,11 @@ Runs the read-only `initiative-scan` report and presents it. This is the durable
    ```
    - **Host note:** `192.168.50.94:30123` is the workbench LAN endpoint. On the **laptop** (no `~/.server-mode` marker, nebula-only) that's unreachable → the report runs **telemetry-OFF** (still useful from handoff + git). To get telemetry there, point `CLICKHOUSE_URL` at the laptop's nebula CH endpoint — see the `activity` skill.
 
-2. **Run the scan** (substitute `$ARGUMENTS`, or `--days 14` if none):
+2. **Run the scan** (substitute `$ARGUMENTS`, or `--days 14 --tmux` if none):
    ```bash
    nix-shell -p 'python3.withPackages(p:[p.requests])' --run \
-     'python ~/workspace/devrc/scripts/session-analysis/initiative-scan.py --days 14'
+     'python ~/workspace/devrc/scripts/session-analysis/initiative-scan.py --days 14 --tmux'
    ```
+   - **`--tmux`** links each initiative to the live tmux session(s) hosting it — `[tmux:8,scratch7]` vs `[no session]` — by matching the claude pane's title (its session summary) against the initiative slug/title, scoped by the pane's cwd→repo. It also lists **live claude sessions with no matched initiative** (open work the ledger doesn't cover). Best-effort: on a host with no tmux server the column is silently omitted. This is the durable ledger fused with the live Alt+i view. Drop `--tmux` if `$ARGUMENTS` explicitly overrides.
 
-3. **Present the output as-is** — it's already a ranked, skimmable report grouped by repo. Optionally lead with a one-line read: which initiatives are ●ACTIVE vs the most notable ○stalled one, and any next-step that looks owed. **Do not editorialize beyond the data** — momentum is *recency of touch, NOT % done*, and initiative↔commit linking is heuristic (see the script's honesty note).
+3. **Present the output as-is** — it's already a ranked, skimmable report grouped by repo. Optionally lead with a one-line read: which initiatives are ●ACTIVE vs the most notable ○stalled one, and any next-step that looks owed. **Do not editorialize beyond the data** — momentum is *recency of touch, NOT % done*, and both initiative↔commit and initiative↔tmux-session linking are heuristic (see the script's honesty notes; a multi-topic pane title may attach to one of several co-hosted initiatives).

--- a/scripts/session-analysis/initiative-scan.py
+++ b/scripts/session-analysis/initiative-scan.py
@@ -49,10 +49,14 @@ Populate the password from SOPS (homelab-talos trunk):
       sops -d --extract '["stringData"]["reader-password"]' /tmp/s.yaml); rm -f /tmp/s.yaml
 
 Usage:
-  initiative-scan.py [--days N] [--json] [--repo PATH]
+  initiative-scan.py [--days N] [--json] [--repo PATH] [--tmux]
   --days   trailing window in days (default 14)
   --json   machine-readable output (the raw per-initiative data)
   --repo   restrict to a single repo path (default: auto-discover under ~/workspace)
+  --tmux   link each initiative to the live tmux session(s) hosting it (matches the
+           claude pane title against the initiative slug/title, scoped by the pane's
+           cwd→repo); also lists live claude sessions with no matched initiative.
+           Best-effort: no tmux server -> initiatives simply show [no session].
 
 HONESTY NOTE: this measures ACTIVITY, RECENCY, and EFFORT (commits / sessions /
 telemetry events / handoff freshness) plus the human-written "Next steps" line —
@@ -208,20 +212,79 @@ def _flatten_md(s: str) -> str:
     return " ".join(s.split())
 
 
+# Ultra-common tokens that would over-match if used as an initiative fingerprint.
+STOP_TOKENS = {"the", "and", "for", "wip", "tmp", "fix", "feat", "v2", "ha"}
+
+
 def slug_tokens(slug: str) -> list[str]:
     """Meaningful tokens of a slug for fuzzy branch/genesis matching.
 
     Drops date tokens and ultra-short/stop tokens that would over-match.
     """
-    stop = {"the", "and", "for", "wip", "tmp", "fix", "feat", "v2", "ha"}
     toks = []
     for t in re.split(r"[-_/]", slug.lower()):
         if not t or DATE_RE.fullmatch(t) or t.isdigit():
             continue
-        if len(t) < 3 or t in stop:
+        if len(t) < 3 or t in STOP_TOKENS:
             continue
         toks.append(t)
     return toks
+
+
+# Generic session-summary / action verbs that lead tmux pane titles ("Resume …",
+# "Monitor …", "Continue …") and prose handoff titles — never a TOPIC identifier, so
+# they must not carry a pane→initiative match (a "Resume session <id>" pane wrongly
+# hitting a `…-resume` slug). Applied ONLY to free text (`text_tokens`), NOT to
+# `slug_tokens`, so branch/git/telemetry attribution stays byte-identical.
+TITLE_STOP = {
+    "resume", "continue", "monitor", "review", "audit", "update", "check",
+    "implement", "assess", "revive", "identify", "finish", "run", "get", "wire",
+    "build", "work", "session", "task", "tasks", "add", "use",
+}
+
+
+def text_tokens(s: str) -> list[str]:
+    """Meaningful tokens of FREE TEXT (a handoff title, a tmux pane title).
+
+    Same filters as `slug_tokens` (drop dates / digits / short / stop tokens) but
+    splits on any non-alphanumeric run instead of only slug separators, so a prose
+    string like a live tmux pane title ("Continue clawgate agent loop soak testing")
+    tokenizes the same way a slug does and the two can be compared on word equality.
+    Additionally drops `TITLE_STOP` action verbs — noise in a session summary that
+    would otherwise link a pane on a generic word (see TITLE_STOP).
+    """
+    toks = []
+    for t in re.split(r"[^a-z0-9]+", s.lower()):
+        if not t or DATE_RE.fullmatch(t) or t.isdigit():
+            continue
+        if len(t) < 3 or t in STOP_TOKENS or t in TITLE_STOP:
+            continue
+        toks.append(t)
+    return toks
+
+
+def resolve_cwd_repo(cwd: str | None, repos: list[str],
+                     wt_map: dict[str, str] | None = None) -> str | None:
+    """Map a working directory to its CANONICAL repo, or None.
+
+    A cwd inside a discovered repo (realpath-prefix containment) resolves to that
+    repo; a cwd inside a linked worktree resolves via `wt_map` to the worktree's
+    canonical repo (shrinking the `(unknown repo)` bucket). Longest-prefix-first so
+    the most specific repo / worktree wins. Shared by telemetry cwd attribution and
+    tmux pane→initiative matching so both agree on what repo a dir belongs to.
+    """
+    if not cwd:
+        return None
+    wt_map = wt_map or {}
+    rp = os.path.realpath(cwd)
+    for r in sorted(repos, key=len, reverse=True):
+        rr = os.path.realpath(r)
+        if rp == rr or rp.startswith(rr + "/"):
+            return r
+    for wt in sorted(wt_map.keys(), key=len, reverse=True):
+        if rp == wt or rp.startswith(wt + "/"):
+            return wt_map[wt]
+    return None
 
 
 def branch_tokens(branch: str) -> list[str]:
@@ -924,24 +987,9 @@ def attribute_telemetry(initiatives: list[dict], rows: list[dict] | None,
         return catchall
 
     wt_map = worktree_map or {}
-    # Linked-worktree paths, longest-first, so the most specific prefix wins.
-    wt_paths = sorted(wt_map.keys(), key=len, reverse=True)
-    repos_by_len = sorted(repos, key=len, reverse=True)
 
     def cwd_repo(cwd: str | None) -> str | None:
-        if not cwd:
-            return None
-        rp = os.path.realpath(cwd)
-        # A canonical repo is the most direct match.
-        for r in repos_by_len:
-            rr = os.path.realpath(r)
-            if rp == rr or rp.startswith(rr + "/"):
-                return r
-        # Else a linked-worktree path -> its canonical repo.
-        for wt in wt_paths:
-            if rp == wt or rp.startswith(wt + "/"):
-                return wt_map[wt]
-        return None
+        return resolve_cwd_repo(cwd, repos, wt_map)
 
     # Initiatives indexed by their repo, so matching is scoped to the row's repo.
     inis_by_repo: dict[str, list[dict]] = {}
@@ -990,6 +1038,99 @@ def _num(v, default=0):
         return int(s) if s.lstrip("-").isdigit() else float(s)
     except (ValueError, TypeError):
         return default
+
+
+# --------------------------------------------------------------------------- #
+# Live tmux sessions (I/O, optional) — which scratch session hosts an initiative
+# --------------------------------------------------------------------------- #
+def collect_tmux_panes() -> list[dict]:
+    """Every live tmux pane as [{session, cwd, command, title}] (empty if no server).
+
+    Zach runs many `scratch*`-named tmux sessions in parallel, one per in-flight
+    initiative; a claude pane sets its title to the session's summary line. We read
+    those titles to link the DURABLE initiative ledger to what's actually open right
+    now (the ephemeral Alt+i view). Best-effort: `_run` returns "" when the tmux
+    binary is missing or no server is running, so this yields [] and callers degrade.
+    """
+    out = _run(["tmux", "list-panes", "-a", "-F",
+                "#{session_name}\t#{pane_current_path}\t#{pane_current_command}\t#{pane_title}"])
+    panes: list[dict] = []
+    for ln in out.splitlines():
+        if not ln.strip():
+            continue
+        parts = ln.split("\t")
+        while len(parts) < 4:
+            parts.append("")
+        panes.append({"session": parts[0], "cwd": parts[1],
+                      "command": parts[2], "title": parts[3]})
+    return panes
+
+
+def best_title_match(pane_toks: set[str], initiatives: list[dict]) -> dict | None:
+    """Pick the initiative whose slug/title best overlaps a pane title's tokens.
+
+    Scored as (# slug-token overlaps, # extra title-token overlaps). Slug tokens are
+    the initiative fingerprint (clawgate, sysredis, wedge, tekton, bitdex); the pane
+    title is first stripped of generic action verbs (`TITLE_STOP` in `text_tokens`),
+    so a pane can't be linked on "resume"/"review"/"monitor" alone — that stripping,
+    not any weighting, is what kills the generic-word false positives. A candidate
+    qualifies with ≥1 slug-token overlap, OR ≥2 title-token overlaps. Best by
+    (slug_overlap, title_overlap), then longer slug, then lexically, for determinism.
+    A more-specific sibling wins on count: a "sysRedis wedge" pane beats plain
+    "sysRedis" siblings (2 slug tokens vs 1). None when nothing clears the bar.
+
+    LIMITATION: a genuinely multi-topic pane title is attributed to its single
+    strongest match and may miss a co-hosted sibling; bag-of-words can't disambiguate.
+    Heuristic — read it as "which session is likely on this", not a proof.
+    """
+    best: dict | None = None
+    best_key: tuple = (0, 0, 0, "")
+    for ini in initiatives:
+        slug_t = set(slug_tokens(ini.get("slug", "")))
+        title_t = set(text_tokens(ini.get("title") or ""))
+        slug_overlap = len(pane_toks & slug_t)
+        title_overlap = len(pane_toks & (title_t - slug_t))
+        if slug_overlap == 0 and title_overlap < 2:
+            continue
+        key = (slug_overlap, title_overlap,
+               len(ini.get("slug", "")), ini.get("slug", ""))
+        if key > best_key:
+            best_key = key
+            best = ini
+    return best
+
+
+def match_tmux_to_initiatives(initiatives: list[dict], panes: list[dict],
+                              repos: list[str],
+                              wt_map: dict[str, str] | None = None) -> list[dict]:
+    """Attach live tmux sessions to initiatives; return unmatched claude panes.
+
+    Each pane's cwd is resolved to its repo (`resolve_cwd_repo`), and its title is
+    matched ONLY against initiatives in that repo (`best_title_match`) — so a pane in
+    devrc can't match a civit initiative that happens to share a word. Mutates each
+    initiative's `tmux_sessions` (a set of session names). A claude pane that resolves
+    to no initiative is returned as unmatched (live work the ledger doesn't cover),
+    with its session/title/repo — the honest mirror of the "no session" gap.
+    """
+    for ini in initiatives:
+        ini.setdefault("tmux_sessions", set())
+    by_repo: dict[str, list[dict]] = {}
+    for ini in initiatives:
+        by_repo.setdefault(ini["repo"], []).append(ini)
+
+    unmatched: list[dict] = []
+    for pane in panes:
+        ptoks = set(text_tokens(pane.get("title", "")))
+        repo = resolve_cwd_repo(pane.get("cwd"), repos, wt_map)
+        eligible = by_repo.get(repo, []) if repo is not None else []
+        ini = best_title_match(ptoks, eligible) if ptoks else None
+        if ini is not None:
+            ini["tmux_sessions"].add(pane["session"])
+        elif pane.get("command", "") == "claude":
+            unmatched.append({"session": pane.get("session", ""),
+                              "title": pane.get("title", ""),
+                              "repo": repo})
+    return unmatched
 
 
 # --------------------------------------------------------------------------- #
@@ -1065,10 +1206,13 @@ def attribute_git(initiatives: list[dict], days: int) -> None:
 # --------------------------------------------------------------------------- #
 def build_report(days: int, repos: list[str] | None = None,
                  client=None, projects_root: str = PROJECTS_ROOT,
-                 now: float | None = None) -> dict:
+                 now: float | None = None, include_tmux: bool = False,
+                 panes: list[dict] | None = None) -> dict:
     """Fuse the three sources into a ranked, per-repo report dict.
 
     `client` may be None (telemetry skipped). `repos` None -> auto-discover.
+    `include_tmux` links live tmux sessions to initiatives; `panes` overrides the
+    live `collect_tmux_panes()` read (for tests / reproducibility).
     """
     repos = repos if repos is not None else discover_repos()
     initiatives = load_initiatives(repos)
@@ -1081,8 +1225,19 @@ def build_report(days: int, repos: list[str] | None = None,
     telemetry_available = telem_rows is not None
     # Resolve cwds living in linked worktrees back to their canonical repo so
     # worktree telemetry attributes to the parent and `(unknown repo)` shrinks.
-    wt_map = worktree_canonical_map(repos) if telem_rows else {}
+    wt_map = worktree_canonical_map(repos) if (telem_rows or include_tmux) else {}
     catchall = attribute_telemetry(initiatives, telem_rows, repos, wt_map)
+
+    tmux_unmatched: list[dict] = []
+    tmux_active = False
+    if include_tmux:
+        live_panes = panes if panes is not None else collect_tmux_panes()
+        # A live read that finds NO panes = no tmux server on this host -> suppress the
+        # column entirely (annotating every initiative "[no session]" would be noise).
+        # An explicitly-injected pane list (tests) always activates, even when empty.
+        if panes is not None or live_panes:
+            tmux_active = True
+            tmux_unmatched = match_tmux_to_initiatives(initiatives, live_panes, repos, wt_map)
 
     # Compute momentum from the MAX of every touch signal.
     for ini in initiatives:
@@ -1096,6 +1251,12 @@ def build_report(days: int, repos: list[str] | None = None,
 
     initiatives = sort_initiatives(initiatives)
 
+    # Sets aren't JSON-serializable and the renderer wants a stable order.
+    if tmux_active:
+        for ini in initiatives:
+            ini["tmux_sessions"] = sorted(ini.get("tmux_sessions", set()),
+                                          key=_tmux_session_sort_key)
+
     by_repo: dict[str, list[dict]] = {}
     for ini in initiatives:
         by_repo.setdefault(ini["repo"], []).append(ini)
@@ -1103,12 +1264,27 @@ def build_report(days: int, repos: list[str] | None = None,
     return {
         "days": days,
         "telemetry_available": telemetry_available,
+        "tmux_enabled": tmux_active,
+        "tmux_unmatched": tmux_unmatched,
         "repos": repos,
         "by_repo": by_repo,
         "catchall": {k: {"events": v["events"], "last": v["last"],
                          "branches": sorted(v["branches"])}
                      for k, v in catchall.items()},
     }
+
+
+def _tmux_session_sort_key(name: str) -> tuple:
+    """Order session names naturally: '1','2','8' before 'scratch2','scratch10'.
+
+    Splits into (non-digit prefix, numeric suffix) so a numeric tail sorts by VALUE
+    ('scratch2' < 'scratch10'), and pure-numeric names ('8') sort ahead of prefixed
+    ones — matching how the sessions read in `tmux list-sessions`.
+    """
+    m = re.match(r"^(.*?)(\d*)$", name)
+    prefix = m.group(1) if m else name
+    num = int(m.group(2)) if (m and m.group(2)) else -1
+    return (prefix, num, name)
 
 
 # --------------------------------------------------------------------------- #
@@ -1147,6 +1323,9 @@ def render(report: dict, now: float | None = None) -> str:
                     f"   merged-PR:{ini.get('merged_prs', 0)}")
             if report["telemetry_available"]:
                 head += f"   ev:{ini.get('telem_events', 0)}"
+            if report.get("tmux_enabled"):
+                sess = ini.get("tmux_sessions") or []
+                head += f"   [tmux:{','.join(sess)}]" if sess else "   [no session]"
             out.append(head)
             if ini.get("title") and ini["title"] != ini["slug"]:
                 out.append(f"        “{ini['title']}”")
@@ -1177,6 +1356,22 @@ def render(report: dict, now: float | None = None) -> str:
         out.append(f"  ·trunk·  unsegmented trunk/main work"
                    f"   touched {rel_age(ca['last'], now)}   ev:{ca['events']}")
 
+    if report.get("tmux_enabled"):
+        unmatched = report.get("tmux_unmatched") or []
+        if unmatched:
+            out.append("\n## live claude sessions — no matched initiative")
+            out.append("   (open work the ledger doesn't cover — a new thread, or a "
+                       "handoff not yet written)")
+            seen = set()
+            for u in sorted(unmatched, key=lambda u: _tmux_session_sort_key(u.get("session", ""))):
+                key = (u.get("session"), u.get("title"))
+                if key in seen:
+                    continue
+                seen.add(key)
+                repo = _short_repo(u["repo"]) if u.get("repo") else "?"
+                title = (u.get("title") or "").strip() or "(untitled)"
+                out.append(f"  [{u.get('session', '?')}]  {title[:80]}   ({repo})")
+
     if not report["telemetry_available"]:
         out.append("\n(NOTE: telemetry OFF — CLICKHOUSE_* unset or unreachable. "
                    "Momentum/recency here come from commits + sessions + handoff mtime only.)")
@@ -1199,6 +1394,8 @@ def parse_args(argv=None) -> argparse.Namespace:
     p.add_argument("--days", type=int, default=14, help="trailing window in days (default 14)")
     p.add_argument("--json", action="store_true", help="machine-readable output")
     p.add_argument("--repo", default=None, help="restrict to a single repo path")
+    p.add_argument("--tmux", action="store_true",
+                   help="link each initiative to the live tmux session(s) hosting it")
     return p.parse_args(argv)
 
 
@@ -1224,7 +1421,7 @@ def main(argv=None) -> int:
     except RuntimeError:
         client = None  # telemetry optional — degrade gracefully
 
-    report = build_report(a.days, repos=repos, client=client)
+    report = build_report(a.days, repos=repos, client=client, include_tmux=a.tmux)
 
     if a.json:
         print(json.dumps(report, indent=2, default=str))

--- a/scripts/session-analysis/tests/test_initiative_scan.py
+++ b/scripts/session-analysis/tests/test_initiative_scan.py
@@ -663,3 +663,264 @@ def test_render_emits_trunk_catchall(monkeypatch, tmp_path):
     txt = isc.render(report, now=2_000_000_000.0)
     assert "unsegmented trunk/main work" in txt
     assert "ev:99" in txt
+
+
+# --------------------------------------------------------------------------- #
+# text_tokens — free-text tokenization (prose titles, tmux pane titles)
+# --------------------------------------------------------------------------- #
+def test_text_tokens_splits_prose_like_slugs():
+    # Prose splits on any non-alnum run; same short/stop/date filters as slug_tokens.
+    # 'Continue' is a TITLE_STOP action verb -> dropped; topic words survive.
+    assert isc.text_tokens("Continue clawgate agent loop soak testing") == [
+        "clawgate", "agent", "loop", "soak", "testing"]
+
+
+def test_text_tokens_drops_action_verbs_keeps_topic():
+    # Session-summary verbs ('Resume','Monitor','Build') are noise; the topic remains.
+    assert isc.text_tokens("Resume Monitor Build sysredis buffer") == [
+        "sysredis", "buffer"]
+
+
+def test_text_tokens_drops_stopwords_dates_and_short():
+    # 'and' is a stop word, '2026-07-05' a date, 'go' too short -> all dropped.
+    assert isc.text_tokens("Faro and RUM 2026-07-05 go widen") == [
+        "faro", "rum", "widen"]
+
+
+# --------------------------------------------------------------------------- #
+# resolve_cwd_repo — cwd -> canonical repo (shared by telemetry + tmux)
+# --------------------------------------------------------------------------- #
+def test_resolve_cwd_repo_prefix_match():
+    repos = ["/home/u/workspace/devrc", "/home/u/workspace/civit/dp"]
+    assert isc.resolve_cwd_repo("/home/u/workspace/devrc/scripts", repos) == \
+        "/home/u/workspace/devrc"
+    # Longest-prefix wins: the nested repo, not a shorter accidental prefix.
+    assert isc.resolve_cwd_repo("/home/u/workspace/civit/dp", repos) == \
+        "/home/u/workspace/civit/dp"
+
+
+def test_resolve_cwd_repo_unknown_is_none():
+    assert isc.resolve_cwd_repo("/home/u/taxes/2025", ["/home/u/workspace/devrc"]) is None
+    assert isc.resolve_cwd_repo(None, ["/r"]) is None
+
+
+def test_resolve_cwd_repo_via_worktree_map():
+    repos = ["/home/u/workspace/civit/dp"]
+    wt_map = {"/home/u/workspace/civit/dp-sandbox": "/home/u/workspace/civit/dp"}
+    assert isc.resolve_cwd_repo("/home/u/workspace/civit/dp-sandbox/x", repos, wt_map) == \
+        "/home/u/workspace/civit/dp"
+
+
+# --------------------------------------------------------------------------- #
+# best_title_match — pane title tokens -> most-specific initiative
+# --------------------------------------------------------------------------- #
+def test_best_title_match_by_slug_token():
+    inis = [{"slug": "faro-rum-widening", "title": "Faro RUM widening ramp"}]
+    toks = set(isc.text_tokens("Wire Faro to main civitai app with Zach review"))
+    assert isc.best_title_match(toks, inis) is inis[0]
+
+
+def test_best_title_match_prefers_more_slug_overlap():
+    # A pane naming agent+loop+clawgate should credit agent-loop-close (3 slug
+    # tokens overlap), NOT the chat-polish sibling (only 'clawgate' overlaps).
+    inis = [
+        {"slug": "clawgate-agent-loop-close", "title": "clawgate: the agent loop closes"},
+        {"slug": "clawgate-chat-polish", "title": "clawgate agent-chat polish"},
+    ]
+    toks = set(isc.text_tokens("Continue clawgate agent loop production soak testing"))
+    assert isc.best_title_match(toks, inis)["slug"] == "clawgate-agent-loop-close"
+
+
+def test_best_title_match_needs_distinctive_overlap():
+    # One generic title-only word ('review') must NOT link — no slug-token overlap
+    # and fewer than two title-token overlaps.
+    inis = [{"slug": "faro-rum-widening", "title": "Faro RUM review ramp"}]
+    toks = set(isc.text_tokens("Audit PR 355 review"))
+    assert isc.best_title_match(toks, inis) is None
+
+
+def test_best_title_match_empty_when_no_initiatives():
+    assert isc.best_title_match({"clawgate"}, []) is None
+
+
+def test_best_title_match_generic_shared_word_does_not_link():
+    # 'session' is shared across many initiatives -> low IDF -> a pane that overlaps
+    # ONLY on 'session' must not link (the scratch8 "Resume session <id>" false hit).
+    inis = [
+        {"slug": "app-blocks-dev-live-session", "title": "App Blocks dev live session"},
+        {"slug": "app-blocks-session", "title": "App Blocks session civitai"},
+        {"slug": "app-blocks-review-session", "title": "App Blocks review session"},
+    ]
+    toks = set(isc.text_tokens("Resume session 868k8b9f6"))
+    assert isc.best_title_match(toks, inis) is None
+
+
+def test_best_title_match_distinctive_token_beats_generic(monkeypatch):
+    # 'tekton' is unique (idf 1.0); 'app'/'blocks' are shared (low idf). A pane
+    # naming tekton links to the tekton initiative, not an app-blocks sibling that
+    # only shares generic words.
+    inis = [
+        {"slug": "tekton-control-plane-ha", "title": "tekton control plane ha"},
+        {"slug": "app-blocks-ux", "title": "App Blocks UX readiness"},
+        {"slug": "app-blocks-followups", "title": "App Blocks follow-ups"},
+    ]
+    toks = set(isc.text_tokens("Review cordoned build node and Tekton pipelines"))
+    assert isc.best_title_match(toks, inis)["slug"] == "tekton-control-plane-ha"
+
+
+# --------------------------------------------------------------------------- #
+# match_tmux_to_initiatives — attach live sessions, scoped by repo
+# --------------------------------------------------------------------------- #
+def test_match_tmux_attaches_session_scoped_by_repo():
+    devrc, civit = "/home/u/workspace/devrc", "/home/u/workspace/civit/dp"
+    inis = [
+        {"slug": "faro-rum-widening", "title": "Faro RUM widening", "repo": civit},
+        {"slug": "clawgate-chat-polish", "title": "clawgate chat polish", "repo": devrc},
+    ]
+    panes = [
+        {"session": "scratch4", "cwd": civit, "command": "claude",
+         "title": "Wire Faro to main civitai app with Zach review"},
+        {"session": "1", "cwd": devrc, "command": "claude",
+         "title": "clawgate chat polish soak"},
+    ]
+    unmatched = isc.match_tmux_to_initiatives(inis, panes, [devrc, civit])
+    assert inis[0]["tmux_sessions"] == {"scratch4"}
+    assert inis[1]["tmux_sessions"] == {"1"}
+    assert unmatched == []
+
+
+def test_match_tmux_wrong_repo_does_not_cross_credit():
+    # A 'faro' pane whose cwd is devrc must NOT credit the civit faro initiative.
+    devrc, civit = "/home/u/workspace/devrc", "/home/u/workspace/civit/dp"
+    inis = [{"slug": "faro-rum-widening", "title": "Faro RUM widening", "repo": civit}]
+    panes = [{"session": "scratchX", "cwd": devrc, "command": "claude",
+              "title": "Wire Faro to civitai app"}]
+    unmatched = isc.match_tmux_to_initiatives(inis, panes, [devrc, civit])
+    assert inis[0]["tmux_sessions"] == set()
+    # devrc has no matching initiative -> the claude pane is surfaced as unmatched.
+    assert len(unmatched) == 1
+    assert unmatched[0]["session"] == "scratchX"
+    assert unmatched[0]["repo"] == devrc
+
+
+def test_match_tmux_non_claude_unmatched_pane_ignored():
+    # A plain zsh pane in an unknown dir is neither matched nor reported as unmatched.
+    inis = [{"slug": "x", "title": "X", "repo": "/r"}]
+    panes = [{"session": "scratch5", "cwd": "/home/u/taxes/2025", "command": "zsh",
+              "title": "nixos"}]
+    unmatched = isc.match_tmux_to_initiatives(inis, panes, ["/r"])
+    assert inis[0]["tmux_sessions"] == set()
+    assert unmatched == []
+
+
+def test_match_tmux_multiple_panes_one_initiative():
+    civit = "/home/u/workspace/civit/dp"
+    inis = [{"slug": "sysredis-buffer", "title": "sysRedis buffer soft-dependency",
+             "repo": civit}]
+    panes = [
+        {"session": "8", "cwd": civit, "command": "claude",
+         "title": "Continue sysredis buffer soft-dependency work"},
+        {"session": "8", "cwd": civit, "command": "claude",
+         "title": "Monitor sysredis buffer fixes"},
+    ]
+    isc.match_tmux_to_initiatives(inis, panes, [civit])
+    assert inis[0]["tmux_sessions"] == {"8"}
+
+
+def test_tmux_session_sort_key_natural_order():
+    names = ["scratch10", "scratch2", "8", "1", "scratch"]
+    assert sorted(names, key=isc._tmux_session_sort_key) == [
+        "1", "8", "scratch", "scratch2", "scratch10"]
+
+
+# --------------------------------------------------------------------------- #
+# collect_tmux_panes — parsing the tab-delimited tmux output
+# --------------------------------------------------------------------------- #
+def test_collect_tmux_panes_parses_and_handles_empty_title(monkeypatch):
+    out = ("1\t/home/u/workspace/devrc\tclaude\tContinue clawgate loop\n"
+           "scratch5\t/home/u/taxes/2025\tzsh\t\n")  # empty title -> ""
+    monkeypatch.setattr(isc, "_run", lambda cmd, timeout=20.0: out)
+    panes = isc.collect_tmux_panes()
+    assert panes[0] == {"session": "1", "cwd": "/home/u/workspace/devrc",
+                        "command": "claude", "title": "Continue clawgate loop"}
+    assert panes[1]["title"] == ""
+
+
+def test_collect_tmux_panes_empty_when_no_server(monkeypatch):
+    monkeypatch.setattr(isc, "_run", lambda cmd, timeout=20.0: "")
+    assert isc.collect_tmux_panes() == []
+
+
+# --------------------------------------------------------------------------- #
+# build_report + render with --tmux (panes injected for hermeticity)
+# --------------------------------------------------------------------------- #
+def test_build_report_tmux_annotates_and_lists_unmatched(tmp_path, monkeypatch):
+    repo = tmp_path / "myrepo"
+    (repo / "claudedocs").mkdir(parents=True)
+    (repo / "claudedocs" / "handoff-mail-automation-2026-06-30.md").write_text(NEXT_DOC)
+
+    monkeypatch.setattr(isc, "git_branches", lambda r: ["main"])
+    monkeypatch.setattr(isc, "git_default_branch", lambda r: "main")
+    monkeypatch.setattr(isc, "gh_open_prs", lambda r: [])
+    monkeypatch.setattr(isc, "gh_merged_prs", lambda r, d: [])
+    monkeypatch.setattr(isc, "session_genesis_refs", lambda root, d: [])
+
+    panes = [
+        {"session": "scratch9", "cwd": str(repo), "command": "claude",
+         "title": "Resume mail automation extractor work"},
+        {"session": "scratch2", "cwd": str(repo), "command": "claude",
+         "title": "Some brand new unrelated exploration thread"},
+    ]
+    report = isc.build_report(14, repos=[str(repo)], client=None,
+                              now=2_000.0, include_tmux=True, panes=panes)
+    assert report["tmux_enabled"] is True
+    ini = report["by_repo"][str(repo)][0]
+    assert ini["tmux_sessions"] == ["scratch9"]
+    # The unrelated pane is surfaced as live-but-unmatched.
+    assert any(u["session"] == "scratch2" for u in report["tmux_unmatched"])
+
+    txt = isc.render(report, now=2_000.0)
+    assert "[tmux:scratch9]" in txt
+    assert "live claude sessions — no matched initiative" in txt
+    assert "scratch2" in txt
+
+
+def test_build_report_tmux_no_session_marker(tmp_path, monkeypatch):
+    repo = tmp_path / "r"
+    (repo / "claudedocs").mkdir(parents=True)
+    (repo / "claudedocs" / "handoff-lonely.md").write_text(
+        "# Handoff: lonely\n## Next steps\n1. go\n")
+    monkeypatch.setattr(isc, "git_branches", lambda r: ["main"])
+    monkeypatch.setattr(isc, "git_default_branch", lambda r: "main")
+    monkeypatch.setattr(isc, "gh_open_prs", lambda r: [])
+    monkeypatch.setattr(isc, "gh_merged_prs", lambda r, d: [])
+    monkeypatch.setattr(isc, "session_genesis_refs", lambda root, d: [])
+
+    # No panes at all -> initiative shows [no session].
+    report = isc.build_report(14, repos=[str(repo)], client=None,
+                              now=2_000.0, include_tmux=True, panes=[])
+    txt = isc.render(report, now=2_000.0)
+    assert "[no session]" in txt
+
+
+def test_build_report_tmux_suppressed_when_no_server(tmp_path, monkeypatch):
+    # --tmux on a host with NO tmux server (live read yields []) suppresses the column
+    # entirely rather than tagging every initiative "[no session]".
+    repo = tmp_path / "r"
+    (repo / "claudedocs").mkdir(parents=True)
+    (repo / "claudedocs" / "handoff-lonely.md").write_text(
+        "# Handoff: lonely\n## Next steps\n1. go\n")
+    monkeypatch.setattr(isc, "git_branches", lambda r: ["main"])
+    monkeypatch.setattr(isc, "git_default_branch", lambda r: "main")
+    monkeypatch.setattr(isc, "gh_open_prs", lambda r: [])
+    monkeypatch.setattr(isc, "gh_merged_prs", lambda r, d: [])
+    monkeypatch.setattr(isc, "session_genesis_refs", lambda root, d: [])
+    monkeypatch.setattr(isc, "collect_tmux_panes", lambda: [])  # no server
+
+    # panes=None -> live read path; collect returns [] -> column disabled.
+    report = isc.build_report(14, repos=[str(repo)], client=None,
+                              now=2_000.0, include_tmux=True)
+    assert report["tmux_enabled"] is False
+    txt = isc.render(report, now=2_000.0)
+    assert "[no session]" not in txt
+    assert "[tmux:" not in txt


### PR DESCRIPTION
## What

`/initiatives` (and `initiative-scan.py --tmux`) now links each initiative to the **live tmux session(s) hosting it** — the durable handoff+git+telemetry ledger fused with the ephemeral Alt+i view.

Each initiative line gains an annotation:
```
●ACTIVE  tekton-control-plane-ha  touched 16m  …  [tmux:scratch9]
◐slowing sysredis-wedge-and-latency-observability  …  [tmux:8]
○stalled app-blocks-launch  …  [no session]
```
plus a footer listing **live claude sessions with no matched initiative** (open work the ledger doesn't yet cover — a new thread or an unwritten handoff).

## How it matches

- Reads every tmux pane's `session_name / cwd / current_command / pane_title`. A claude pane's title is its session summary, which is the signal.
- Tokenizes the title and picks the best initiative by **slug/title token overlap**, **scoped by the pane's cwd→repo** so a devrc pane can't match a civit initiative that merely shares a word. The cwd→repo resolver is factored out and now shared with telemetry attribution.
- **`TITLE_STOP`** strips generic session-action verbs (resume/review/monitor/continue/audit/…) from pane titles so a pane can't be linked on a non-topic word (killed false positives like "Resume session \<id\>" → a `…-resume` slug).
- A more-specific sibling wins on token count ("sysRedis **wedge**" beats plain "sysRedis").
- No tmux server on the host ⇒ column silently omitted (graceful on the laptop).

## Verification

Ran live against the workbench's 17 tmux sessions: **8 clearly-correct matches** (tekton→scratch9, sysredis-wedge→8, sysredis-buffer→8, faro→scratch4, notifications→2, dev-tunnel→scratch2, bitdex→scratch7, clawgate-agent-loop→1), opaque `Resume session 868k8b9f6` correctly **unmatched**. Remaining soft matches are all sessions that genuinely host the initiative.

**78 tests pass (22 new)** covering `text_tokens`/`TITLE_STOP`, `resolve_cwd_repo`, `best_title_match` (slug-specificity, generic-word suppression, repo scoping), `collect_tmux_panes` parsing, natural session sort, and end-to-end `build_report`/`render` with injected panes + the no-server suppression path.

Linking is **heuristic** and labeled as such — a multi-topic pane title may attach to one of several co-hosted initiatives (bag-of-words can't disambiguate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)