### PR TITLE
feat(initiatives): tmux ids carry the window (<session>-<window>)

### DIFF
--- a/scripts/session-analysis/initiative-scan.py
+++ b/scripts/session-analysis/initiative-scan.py
@@ -1044,26 +1044,42 @@ def _num(v, default=0):
 # Live tmux sessions (I/O, optional) — which scratch session hosts an initiative
 # --------------------------------------------------------------------------- #
 def collect_tmux_panes() -> list[dict]:
-    """Every live tmux pane as [{session, cwd, command, title}] (empty if no server).
+    """Every live tmux pane as [{session, window, cwd, command, title}] (empty if no
+    server).
 
-    Zach runs many `scratch*`-named tmux sessions in parallel, one per in-flight
-    initiative; a claude pane sets its title to the session's summary line. We read
-    those titles to link the DURABLE initiative ledger to what's actually open right
-    now (the ephemeral Alt+i view). Best-effort: `_run` returns "" when the tmux
-    binary is missing or no server is running, so this yields [] and callers degrade.
+    Zach runs many named scratchpad tmux sessions in parallel (`8`, `scratch7`,
+    `wheat`), each often with SEVERAL windows on DIFFERENT initiatives; a claude pane
+    sets its title to that window's session-summary line. We capture the window index
+    too so the ledger can point at `<session>-<window>` (e.g. `8-1` vs `8-3`), the
+    exact unit `tmux select-window -t 8:1` navigates to — a bare session id can't
+    disambiguate two initiatives in one session. Best-effort: `_run` returns "" when
+    the tmux binary is missing or no server is running, so this yields [] and callers
+    degrade to [no session].
     """
     out = _run(["tmux", "list-panes", "-a", "-F",
-                "#{session_name}\t#{pane_current_path}\t#{pane_current_command}\t#{pane_title}"])
+                "#{session_name}\t#{window_index}\t#{pane_current_path}"
+                "\t#{pane_current_command}\t#{pane_title}"])
     panes: list[dict] = []
     for ln in out.splitlines():
         if not ln.strip():
             continue
         parts = ln.split("\t")
-        while len(parts) < 4:
+        while len(parts) < 5:
             parts.append("")
-        panes.append({"session": parts[0], "cwd": parts[1],
-                      "command": parts[2], "title": parts[3]})
+        panes.append({"session": parts[0], "window": parts[1], "cwd": parts[2],
+                      "command": parts[3], "title": parts[4]})
     return panes
+
+
+def pane_id(pane: dict) -> str:
+    """`<session>-<window>` display id for a pane, e.g. `8-1`, `wheat-3`.
+
+    Falls back to the bare session name if a window index is somehow absent, so the id
+    is never a dangling `session-`.
+    """
+    session = pane.get("session", "")
+    window = str(pane.get("window", "")).strip()
+    return f"{session}-{window}" if window else session
 
 
 def best_title_match(pane_toks: set[str], initiatives: list[dict]) -> dict | None:
@@ -1108,9 +1124,10 @@ def match_tmux_to_initiatives(initiatives: list[dict], panes: list[dict],
     Each pane's cwd is resolved to its repo (`resolve_cwd_repo`), and its title is
     matched ONLY against initiatives in that repo (`best_title_match`) — so a pane in
     devrc can't match a civit initiative that happens to share a word. Mutates each
-    initiative's `tmux_sessions` (a set of session names). A claude pane that resolves
-    to no initiative is returned as unmatched (live work the ledger doesn't cover),
-    with its session/title/repo — the honest mirror of the "no session" gap.
+    initiative's `tmux_sessions` (a set of `<session>-<window>` ids, e.g. `8-1`). A
+    claude pane that resolves to no initiative is returned as unmatched (live work the
+    ledger doesn't cover), with its id/title/repo — the honest mirror of the "no
+    session" gap.
     """
     for ini in initiatives:
         ini.setdefault("tmux_sessions", set())
@@ -1125,9 +1142,9 @@ def match_tmux_to_initiatives(initiatives: list[dict], panes: list[dict],
         eligible = by_repo.get(repo, []) if repo is not None else []
         ini = best_title_match(ptoks, eligible) if ptoks else None
         if ini is not None:
-            ini["tmux_sessions"].add(pane["session"])
+            ini["tmux_sessions"].add(pane_id(pane))
         elif pane.get("command", "") == "claude":
-            unmatched.append({"session": pane.get("session", ""),
+            unmatched.append({"id": pane_id(pane),
                               "title": pane.get("title", ""),
                               "repo": repo})
     return unmatched
@@ -1275,16 +1292,23 @@ def build_report(days: int, repos: list[str] | None = None,
 
 
 def _tmux_session_sort_key(name: str) -> tuple:
-    """Order session names naturally: '1','2','8' before 'scratch2','scratch10'.
+    """Order `<session>-<window>` ids naturally: '1','8-1','8-3','scratch2','scratch10'.
 
-    Splits into (non-digit prefix, numeric suffix) so a numeric tail sorts by VALUE
-    ('scratch2' < 'scratch10'), and pure-numeric names ('8') sort ahead of prefixed
-    ones — matching how the sessions read in `tmux list-sessions`.
+    Peels a trailing `-<window>` (greedy, so a dashed session like
+    `scratch-1774833757-1` splits at the LAST dash), then sorts the session part by
+    (non-digit prefix, numeric suffix) so a numeric tail sorts by VALUE
+    ('scratch2' < 'scratch10') and pure-numeric sessions ('8') sort ahead of prefixed
+    ones — with the window index as the final tiebreak ('8-1' before '8-3').
     """
-    m = re.match(r"^(.*?)(\d*)$", name)
-    prefix = m.group(1) if m else name
+    win = -1
+    session = name
+    mw = re.match(r"^(.*)-(\d+)$", name)
+    if mw:
+        session, win = mw.group(1), int(mw.group(2))
+    m = re.match(r"^(.*?)(\d*)$", session)
+    prefix = m.group(1) if m else session
     num = int(m.group(2)) if (m and m.group(2)) else -1
-    return (prefix, num, name)
+    return (prefix, num, win, name)
 
 
 # --------------------------------------------------------------------------- #
@@ -1363,14 +1387,14 @@ def render(report: dict, now: float | None = None) -> str:
             out.append("   (open work the ledger doesn't cover — a new thread, or a "
                        "handoff not yet written)")
             seen = set()
-            for u in sorted(unmatched, key=lambda u: _tmux_session_sort_key(u.get("session", ""))):
-                key = (u.get("session"), u.get("title"))
+            for u in sorted(unmatched, key=lambda u: _tmux_session_sort_key(u.get("id", ""))):
+                key = (u.get("id"), u.get("title"))
                 if key in seen:
                     continue
                 seen.add(key)
                 repo = _short_repo(u["repo"]) if u.get("repo") else "?"
                 title = (u.get("title") or "").strip() or "(untitled)"
-                out.append(f"  [{u.get('session', '?')}]  {title[:80]}   ({repo})")
+                out.append(f"  [{u.get('id', '?')}]  {title[:80]}   ({repo})")
 
     if not report["telemetry_available"]:
         out.append("\n(NOTE: telemetry OFF — CLICKHOUSE_* unset or unreachable. "

--- a/scripts/session-analysis/tests/test_initiative_scan.py
+++ b/scripts/session-analysis/tests/test_initiative_scan.py
@@ -778,14 +778,15 @@ def test_match_tmux_attaches_session_scoped_by_repo():
         {"slug": "clawgate-chat-polish", "title": "clawgate chat polish", "repo": devrc},
     ]
     panes = [
-        {"session": "scratch4", "cwd": civit, "command": "claude",
+        {"session": "scratch4", "window": "2", "cwd": civit, "command": "claude",
          "title": "Wire Faro to main civitai app with Zach review"},
-        {"session": "1", "cwd": devrc, "command": "claude",
+        {"session": "1", "window": "3", "cwd": devrc, "command": "claude",
          "title": "clawgate chat polish soak"},
     ]
     unmatched = isc.match_tmux_to_initiatives(inis, panes, [devrc, civit])
-    assert inis[0]["tmux_sessions"] == {"scratch4"}
-    assert inis[1]["tmux_sessions"] == {"1"}
+    # id is <session>-<window>, so two initiatives in one session stay distinguishable.
+    assert inis[0]["tmux_sessions"] == {"scratch4-2"}
+    assert inis[1]["tmux_sessions"] == {"1-3"}
     assert unmatched == []
 
 
@@ -793,38 +794,67 @@ def test_match_tmux_wrong_repo_does_not_cross_credit():
     # A 'faro' pane whose cwd is devrc must NOT credit the civit faro initiative.
     devrc, civit = "/home/u/workspace/devrc", "/home/u/workspace/civit/dp"
     inis = [{"slug": "faro-rum-widening", "title": "Faro RUM widening", "repo": civit}]
-    panes = [{"session": "scratchX", "cwd": devrc, "command": "claude",
+    panes = [{"session": "scratchX", "window": "1", "cwd": devrc, "command": "claude",
               "title": "Wire Faro to civitai app"}]
     unmatched = isc.match_tmux_to_initiatives(inis, panes, [devrc, civit])
     assert inis[0]["tmux_sessions"] == set()
     # devrc has no matching initiative -> the claude pane is surfaced as unmatched.
     assert len(unmatched) == 1
-    assert unmatched[0]["session"] == "scratchX"
+    assert unmatched[0]["id"] == "scratchX-1"
     assert unmatched[0]["repo"] == devrc
 
 
 def test_match_tmux_non_claude_unmatched_pane_ignored():
     # A plain zsh pane in an unknown dir is neither matched nor reported as unmatched.
     inis = [{"slug": "x", "title": "X", "repo": "/r"}]
-    panes = [{"session": "scratch5", "cwd": "/home/u/taxes/2025", "command": "zsh",
-              "title": "nixos"}]
+    panes = [{"session": "scratch5", "window": "1", "cwd": "/home/u/taxes/2025",
+              "command": "zsh", "title": "nixos"}]
     unmatched = isc.match_tmux_to_initiatives(inis, panes, ["/r"])
     assert inis[0]["tmux_sessions"] == set()
     assert unmatched == []
 
 
-def test_match_tmux_multiple_panes_one_initiative():
+def test_match_tmux_two_windows_same_session_two_initiatives():
+    # The core reason for window granularity: one session, two windows, two distinct
+    # initiatives -> each initiative points at its OWN <session>-<window>.
     civit = "/home/u/workspace/civit/dp"
-    inis = [{"slug": "sysredis-buffer", "title": "sysRedis buffer soft-dependency",
-             "repo": civit}]
+    inis = [
+        {"slug": "sysredis-buffer", "title": "sysRedis buffer soft-dependency",
+         "repo": civit},
+        {"slug": "sysredis-wedge-latency", "title": "sysRedis wedge latency",
+         "repo": civit},
+    ]
     panes = [
-        {"session": "8", "cwd": civit, "command": "claude",
+        {"session": "8", "window": "1", "cwd": civit, "command": "claude",
+         "title": "Monitor sysredis wedge fixes"},
+        {"session": "8", "window": "3", "cwd": civit, "command": "claude",
          "title": "Continue sysredis buffer soft-dependency work"},
-        {"session": "8", "cwd": civit, "command": "claude",
+    ]
+    isc.match_tmux_to_initiatives(inis, panes, [civit])
+    assert inis[0]["tmux_sessions"] == {"8-3"}   # buffer -> window 3
+    assert inis[1]["tmux_sessions"] == {"8-1"}   # wedge  -> window 1
+
+
+def test_match_tmux_same_window_dedups():
+    # Two panes in the SAME window matching one initiative dedup to one id.
+    civit = "/home/u/workspace/civit/dp"
+    inis = [{"slug": "sysredis-buffer", "title": "sysRedis buffer", "repo": civit}]
+    panes = [
+        {"session": "8", "window": "2", "cwd": civit, "command": "claude",
+         "title": "Continue sysredis buffer work"},
+        {"session": "8", "window": "2", "cwd": civit, "command": "claude",
          "title": "Monitor sysredis buffer fixes"},
     ]
     isc.match_tmux_to_initiatives(inis, panes, [civit])
-    assert inis[0]["tmux_sessions"] == {"8"}
+    assert inis[0]["tmux_sessions"] == {"8-2"}
+
+
+def test_pane_id_formats_session_window():
+    assert isc.pane_id({"session": "8", "window": "1"}) == "8-1"
+    assert isc.pane_id({"session": "wheat", "window": "3"}) == "wheat-3"
+    # Missing window -> bare session, never a dangling 'session-'.
+    assert isc.pane_id({"session": "scratch7", "window": ""}) == "scratch7"
+    assert isc.pane_id({"session": "scratch7"}) == "scratch7"
 
 
 def test_tmux_session_sort_key_natural_order():
@@ -833,16 +863,24 @@ def test_tmux_session_sort_key_natural_order():
         "1", "8", "scratch", "scratch2", "scratch10"]
 
 
+def test_tmux_session_sort_key_orders_windows_within_session():
+    names = ["8-3", "8-1", "8-10", "1-2", "scratch2-1"]
+    assert sorted(names, key=isc._tmux_session_sort_key) == [
+        "1-2", "8-1", "8-3", "8-10", "scratch2-1"]
+
+
 # --------------------------------------------------------------------------- #
 # collect_tmux_panes — parsing the tab-delimited tmux output
 # --------------------------------------------------------------------------- #
 def test_collect_tmux_panes_parses_and_handles_empty_title(monkeypatch):
-    out = ("1\t/home/u/workspace/devrc\tclaude\tContinue clawgate loop\n"
-           "scratch5\t/home/u/taxes/2025\tzsh\t\n")  # empty title -> ""
+    out = ("1\t1\t/home/u/workspace/devrc\tclaude\tContinue clawgate loop\n"
+           "scratch5\t2\t/home/u/taxes/2025\tzsh\t\n")  # empty title -> ""
     monkeypatch.setattr(isc, "_run", lambda cmd, timeout=20.0: out)
     panes = isc.collect_tmux_panes()
-    assert panes[0] == {"session": "1", "cwd": "/home/u/workspace/devrc",
+    assert panes[0] == {"session": "1", "window": "1",
+                        "cwd": "/home/u/workspace/devrc",
                         "command": "claude", "title": "Continue clawgate loop"}
+    assert panes[1]["window"] == "2"
     assert panes[1]["title"] == ""
 
 
@@ -866,23 +904,23 @@ def test_build_report_tmux_annotates_and_lists_unmatched(tmp_path, monkeypatch):
     monkeypatch.setattr(isc, "session_genesis_refs", lambda root, d: [])
 
     panes = [
-        {"session": "scratch9", "cwd": str(repo), "command": "claude",
+        {"session": "scratch9", "window": "1", "cwd": str(repo), "command": "claude",
          "title": "Resume mail automation extractor work"},
-        {"session": "scratch2", "cwd": str(repo), "command": "claude",
+        {"session": "scratch2", "window": "4", "cwd": str(repo), "command": "claude",
          "title": "Some brand new unrelated exploration thread"},
     ]
     report = isc.build_report(14, repos=[str(repo)], client=None,
                               now=2_000.0, include_tmux=True, panes=panes)
     assert report["tmux_enabled"] is True
     ini = report["by_repo"][str(repo)][0]
-    assert ini["tmux_sessions"] == ["scratch9"]
-    # The unrelated pane is surfaced as live-but-unmatched.
-    assert any(u["session"] == "scratch2" for u in report["tmux_unmatched"])
+    assert ini["tmux_sessions"] == ["scratch9-1"]
+    # The unrelated pane is surfaced as live-but-unmatched, by its <session>-<window>.
+    assert any(u["id"] == "scratch2-4" for u in report["tmux_unmatched"])
 
     txt = isc.render(report, now=2_000.0)
-    assert "[tmux:scratch9]" in txt
+    assert "[tmux:scratch9-1]" in txt
     assert "live claude sessions — no matched initiative" in txt
-    assert "scratch2" in txt
+    assert "scratch2-4" in txt
 
 
 def test_build_report_tmux_no_session_marker(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

Follow-up to #58. The tmux linkage now identifies **`<session>-<window>`** (e.g. `8-1`, `wheat-3`) instead of a bare session name.

**Why:** a single named scratchpad session commonly runs several windows on *different* initiatives. Session `8` has `sysredis-wedge` in window 1 and `sysredis-buffer` in window 3 — previously both showed `[tmux:8]`, indistinguishable. Now:
```
●ACTIVE sysredis-wedge-and-latency-observability   …  [tmux:8-1]
●ACTIVE sysredis-buffer-and-soft-dependency        …  [tmux:8-3]
```
`<session>-<window>` is the exact unit `tmux select-window -t 8:1` navigates to.

## How

- `collect_tmux_panes` also reads `#{window_index}`.
- `pane_id()` formats `<session>-<window>` (falls back to bare session if a window index is somehow absent — never a dangling `session-`).
- The natural sort key peels a trailing `-<window>` greedily (so a dashed session like `scratch-1774833757-1` splits at the *last* dash) and orders windows within a session (`8-1` before `8-3` before `8-10`).
- Same-window panes dedup; two windows in one session stay distinct.

## Verification

Ran live: `sysredis-wedge→8-1`, `sysredis-buffer→8-3`, session `2` fans into `2-1` (notifications) / `2-3` (grafana) / `2-4` (support), with `2-2` (drafter) in the unmatched footer. **81 tests pass** (3 new: two-windows-one-session, same-window dedup, `pane_id` formatting, window sort ordering; existing tmux tests updated to the id form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)