### PR TITLE
feat(initiatives): tmux ids show the scratchpad codename (scratch4 → Vapor)

### DIFF
--- a/scripts/session-analysis/initiative-scan.py
+++ b/scripts/session-analysis/initiative-scan.py
@@ -1071,13 +1071,44 @@ def collect_tmux_panes() -> list[dict]:
     return panes
 
 
-def pane_id(pane: dict) -> str:
-    """`<session>-<window>` display id for a pane, e.g. `8-1`, `wheat-3`.
+# The scratchpad codename map lives in ONE place — the `SLOTS` table of
+# scripts/tmux-scratch-monitor.sh, which mirrors the tmux/i3 hotkey bindings
+# ($mod+Shift+V → session `scratch4` → codename `Vapor`). We parse it at runtime so
+# the report speaks the SAME names Zach navigates by, and never drifts from a copy.
+SCRATCH_MONITOR = Path(__file__).resolve().parent.parent / "tmux-scratch-monitor.sh"
+# A SLOTS entry: "V:scratch4:#83a598:Vapor"  (key : session : hex-color : codename).
+_SLOT_RE = re.compile(r'"([^":]+):([^":]+):(#[0-9a-fA-F]{6}):([^":]+)"')
 
+
+def load_scratch_codenames(path: str | os.PathLike | None = None) -> dict[str, str]:
+    """Parse `{session: codename}` from tmux-scratch-monitor.sh's SLOTS table.
+
+    Returns e.g. {"scratch4": "Vapor", "scratch11": "wheat", …}. Empty dict on any
+    failure (file missing / unreadable) so callers degrade to raw session names — the
+    codename layer is a display nicety, never a hard dependency.
+    """
+    p = Path(path) if path is not None else SCRATCH_MONITOR
+    try:
+        text = p.read_text()
+    except OSError:
+        return {}
+    mapping: dict[str, str] = {}
+    for _key, session, _color, name in _SLOT_RE.findall(text):
+        mapping[session] = name
+    return mapping
+
+
+def pane_id(pane: dict, codenames: dict[str, str] | None = None) -> str:
+    """`<session>-<window>` display id for a pane, e.g. `8-1`, `Vapor-2`.
+
+    The tmux session name is translated to its scratchpad CODENAME when one exists
+    (`scratch4` → `Vapor`), so the id matches what Zach sees on his hotkey-bound
+    scratchpads; sessions with no codename (plain numeric `8`) keep their raw name.
     Falls back to the bare session name if a window index is somehow absent, so the id
     is never a dangling `session-`.
     """
     session = pane.get("session", "")
+    session = (codenames or {}).get(session, session)
     window = str(pane.get("window", "")).strip()
     return f"{session}-{window}" if window else session
 
@@ -1118,7 +1149,8 @@ def best_title_match(pane_toks: set[str], initiatives: list[dict]) -> dict | Non
 
 def match_tmux_to_initiatives(initiatives: list[dict], panes: list[dict],
                               repos: list[str],
-                              wt_map: dict[str, str] | None = None) -> list[dict]:
+                              wt_map: dict[str, str] | None = None,
+                              codenames: dict[str, str] | None = None) -> list[dict]:
     """Attach live tmux sessions to initiatives; return unmatched claude panes.
 
     Each pane's cwd is resolved to its repo (`resolve_cwd_repo`), and its title is
@@ -1142,9 +1174,9 @@ def match_tmux_to_initiatives(initiatives: list[dict], panes: list[dict],
         eligible = by_repo.get(repo, []) if repo is not None else []
         ini = best_title_match(ptoks, eligible) if ptoks else None
         if ini is not None:
-            ini["tmux_sessions"].add(pane_id(pane))
+            ini["tmux_sessions"].add(pane_id(pane, codenames))
         elif pane.get("command", "") == "claude":
-            unmatched.append({"id": pane_id(pane),
+            unmatched.append({"id": pane_id(pane, codenames),
                               "title": pane.get("title", ""),
                               "repo": repo})
     return unmatched
@@ -1254,7 +1286,9 @@ def build_report(days: int, repos: list[str] | None = None,
         # An explicitly-injected pane list (tests) always activates, even when empty.
         if panes is not None or live_panes:
             tmux_active = True
-            tmux_unmatched = match_tmux_to_initiatives(initiatives, live_panes, repos, wt_map)
+            codenames = load_scratch_codenames()
+            tmux_unmatched = match_tmux_to_initiatives(initiatives, live_panes, repos,
+                                                       wt_map, codenames)
 
     # Compute momentum from the MAX of every touch signal.
     for ini in initiatives:

--- a/scripts/session-analysis/tests/test_initiative_scan.py
+++ b/scripts/session-analysis/tests/test_initiative_scan.py
@@ -857,6 +857,48 @@ def test_pane_id_formats_session_window():
     assert isc.pane_id({"session": "scratch7"}) == "scratch7"
 
 
+def test_pane_id_translates_scratch_codename():
+    # A scratchpad session shows its hotkey codename; a plain numeric session doesn't.
+    codes = {"scratch4": "Vapor", "scratch11": "wheat"}
+    assert isc.pane_id({"session": "scratch4", "window": "2"}, codes) == "Vapor-2"
+    assert isc.pane_id({"session": "scratch11", "window": "1"}, codes) == "wheat-1"
+    assert isc.pane_id({"session": "8", "window": "3"}, codes) == "8-3"  # no codename
+
+
+def test_load_scratch_codenames_parses_slots(tmp_path):
+    # Mirrors the real tmux-scratch-monitor.sh SLOTS format.
+    script = tmp_path / "tmux-scratch-monitor.sh"
+    script.write_text(
+        'SLOTS=(\n'
+        '    "g:scratch:#b8bb26:grove"\n'
+        '    "V:scratch4:#83a598:Vapor"\n'
+        '    "w:scratch11:#ebdbb2:wheat"\n'
+        ')\n'
+        'printf "unrelated:line:#nothex:x"\n')  # must not be parsed as a slot
+    codes = isc.load_scratch_codenames(script)
+    assert codes == {"scratch": "grove", "scratch4": "Vapor", "scratch11": "wheat"}
+
+
+def test_load_scratch_codenames_missing_file_is_empty():
+    assert isc.load_scratch_codenames("/no/such/file.sh") == {}
+
+
+def test_load_scratch_codenames_real_file_has_vapor():
+    # Guards against the on-disk SLOTS format drifting away from the parser.
+    codes = isc.load_scratch_codenames()  # the repo's real tmux-scratch-monitor.sh
+    assert codes.get("scratch4") == "Vapor"
+    assert codes.get("scratch11") == "wheat"
+
+
+def test_match_tmux_uses_codenames_end_to_end():
+    civit = "/home/u/workspace/civit/dp"
+    inis = [{"slug": "faro-rum-widening", "title": "Faro RUM widening", "repo": civit}]
+    panes = [{"session": "scratch4", "window": "2", "cwd": civit, "command": "claude",
+              "title": "Wire Faro to civitai app"}]
+    isc.match_tmux_to_initiatives(inis, panes, [civit], codenames={"scratch4": "Vapor"})
+    assert inis[0]["tmux_sessions"] == {"Vapor-2"}
+
+
 def test_tmux_session_sort_key_natural_order():
     names = ["scratch10", "scratch2", "8", "1", "scratch"]
     assert sorted(names, key=isc._tmux_session_sort_key) == [
@@ -902,6 +944,8 @@ def test_build_report_tmux_annotates_and_lists_unmatched(tmp_path, monkeypatch):
     monkeypatch.setattr(isc, "gh_open_prs", lambda r: [])
     monkeypatch.setattr(isc, "gh_merged_prs", lambda r, d: [])
     monkeypatch.setattr(isc, "session_genesis_refs", lambda root, d: [])
+    # Isolate the window/unmatched logic from the real codename table (tested apart).
+    monkeypatch.setattr(isc, "load_scratch_codenames", lambda *a, **k: {})
 
     panes = [
         {"session": "scratch9", "window": "1", "cwd": str(repo), "command": "claude",
@@ -921,6 +965,26 @@ def test_build_report_tmux_annotates_and_lists_unmatched(tmp_path, monkeypatch):
     assert "[tmux:scratch9-1]" in txt
     assert "live claude sessions — no matched initiative" in txt
     assert "scratch2-4" in txt
+
+
+def test_build_report_tmux_applies_codenames(tmp_path, monkeypatch):
+    # End-to-end: a scratch4 pane renders under its Vapor codename in the report.
+    repo = tmp_path / "myrepo"
+    (repo / "claudedocs").mkdir(parents=True)
+    (repo / "claudedocs" / "handoff-mail-automation-2026-06-30.md").write_text(NEXT_DOC)
+    monkeypatch.setattr(isc, "git_branches", lambda r: ["main"])
+    monkeypatch.setattr(isc, "git_default_branch", lambda r: "main")
+    monkeypatch.setattr(isc, "gh_open_prs", lambda r: [])
+    monkeypatch.setattr(isc, "gh_merged_prs", lambda r, d: [])
+    monkeypatch.setattr(isc, "session_genesis_refs", lambda root, d: [])
+    monkeypatch.setattr(isc, "load_scratch_codenames", lambda *a, **k: {"scratch4": "Vapor"})
+
+    panes = [{"session": "scratch4", "window": "2", "cwd": str(repo),
+              "command": "claude", "title": "Resume mail automation extractor work"}]
+    report = isc.build_report(14, repos=[str(repo)], client=None,
+                              now=2_000.0, include_tmux=True, panes=panes)
+    assert report["by_repo"][str(repo)][0]["tmux_sessions"] == ["Vapor-2"]
+    assert "[tmux:Vapor-2]" in isc.render(report, now=2_000.0)
 
 
 def test_build_report_tmux_no_session_marker(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

Follow-up to #58/#59. The tmux linkage now shows the **scratchpad codename** Zach navigates by, not the raw tmux session name:
```
●ACTIVE faro-rum-widening         …  [tmux:Vapor-2]     (was scratch4-2)
●ACTIVE tekton-control-plane-ha   …  [tmux:navy-1]      (was scratch9-1)
●ACTIVE app-blocks-dev-tunnel     …  [tmux:Gold-2]      (was scratch2-2)
```

**Why:** the scratchpads are bound to hotkeys (`$mod+Shift+V` → session `scratch4` → codename **Vapor**), so `scratch4-2` was meaningless — the session is "Vapor 1" on screen.

## How

The `session ↔ codename` map already exists in one place: the `SLOTS` table of `scripts/tmux-scratch-monitor.sh` (mirrors the tmux/i3 bindings). Rather than hardcode a third copy, `load_scratch_codenames()` **parses that file at runtime**, so the ledger and the Alt+m HUD can't drift. `pane_id()` translates the session before formatting; sessions with no codename (plain numeric `8`/`2`/`1`) keep their raw id. Missing/unreadable script → empty map → raw names (graceful).

## Verification

Live run: `faro→Vapor-2`, `tekton→navy-1`, `dev-tunnel→Gold-2`, `cli-arc→orange-1`; unmatched footer shows `Orchid`/`Pool`/`Walnut`/`Nickel`/`violet`/`wheat`. (Amusingly `[wheat-1]` is the session that requested this.) Numeric non-scratchpad sessions stay `8-3`/`2-1`.

**87 tests pass** (6 new): SLOTS parsing, missing-file fallback, a guard against the on-disk SLOTS format drifting from the parser, `pane_id` codename translation, and `match_tmux`/`build_report` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)