### PR TITLE
refactor(tmux): single source of truth for the scratchpad slot table

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -177,6 +177,11 @@ in
     source = ../scripts/tmux-task-resume.sh;
     executable = true;
   };
+  # Canonical scratchpad slot table (session<->hotkey<->color<->codename), sourced by
+  # scratch-monitor/initiatives/status; must sit beside them under ~/.config/tmux/.
+  home.file.".config/tmux/scratch-slots.sh" = {
+    source = ../scripts/tmux-scratch-slots.sh;
+  };
   home.file.".config/tmux/scratch-picker.sh" = {
     source = ../scripts/tmux-scratch-picker.sh;
     executable = true;

--- a/scripts/session-analysis/initiative-scan.py
+++ b/scripts/session-analysis/initiative-scan.py
@@ -1071,29 +1071,30 @@ def collect_tmux_panes() -> list[dict]:
     return panes
 
 
-# The scratchpad codename map lives in ONE place — the `SLOTS` table of
-# scripts/tmux-scratch-monitor.sh, which mirrors the tmux/i3 hotkey bindings
-# ($mod+Shift+V → session `scratch4` → codename `Vapor`). We parse it at runtime so
-# the report speaks the SAME names Zach navigates by, and never drifts from a copy.
-SCRATCH_MONITOR = Path(__file__).resolve().parent.parent / "tmux-scratch-monitor.sh"
-# A SLOTS entry: "V:scratch4:#83a598:Vapor"  (key : session : hex-color : codename).
+# The scratchpad codename map lives in ONE place — the `SCRATCH_SLOTS` table of
+# scripts/tmux-scratch-slots.sh, the single source of truth also sourced by the tmux
+# HUD / dashboard / status-left, mirroring the tmux/i3 hotkey bindings ($mod+Shift+V
+# → session `scratch4` → codename `Vapor`). We parse it at runtime so the report
+# speaks the SAME names Zach navigates by, and never drifts from a copy.
+SCRATCH_SLOTS_FILE = Path(__file__).resolve().parent.parent / "tmux-scratch-slots.sh"
+# A SCRATCH_SLOTS entry: "scratch4:V:#83a598:Vapor" (session:key:hex-color:codename).
 _SLOT_RE = re.compile(r'"([^":]+):([^":]+):(#[0-9a-fA-F]{6}):([^":]+)"')
 
 
 def load_scratch_codenames(path: str | os.PathLike | None = None) -> dict[str, str]:
-    """Parse `{session: codename}` from tmux-scratch-monitor.sh's SLOTS table.
+    """Parse `{session: codename}` from tmux-scratch-slots.sh's SCRATCH_SLOTS table.
 
     Returns e.g. {"scratch4": "Vapor", "scratch11": "wheat", …}. Empty dict on any
     failure (file missing / unreadable) so callers degrade to raw session names — the
     codename layer is a display nicety, never a hard dependency.
     """
-    p = Path(path) if path is not None else SCRATCH_MONITOR
+    p = Path(path) if path is not None else SCRATCH_SLOTS_FILE
     try:
         text = p.read_text()
     except OSError:
         return {}
     mapping: dict[str, str] = {}
-    for _key, session, _color, name in _SLOT_RE.findall(text):
+    for session, _key, _color, name in _SLOT_RE.findall(text):
         mapping[session] = name
     return mapping
 

--- a/scripts/session-analysis/tests/test_initiative_scan.py
+++ b/scripts/session-analysis/tests/test_initiative_scan.py
@@ -869,13 +869,13 @@ def test_pane_id_translates_scratch_codename():
 
 
 def test_load_scratch_codenames_parses_slots(tmp_path):
-    # Mirrors the real tmux-scratch-monitor.sh SLOTS format.
-    script = tmp_path / "tmux-scratch-monitor.sh"
+    # Mirrors the real tmux-scratch-slots.sh SCRATCH_SLOTS format (session:key:color:name).
+    script = tmp_path / "tmux-scratch-slots.sh"
     script.write_text(
-        'SLOTS=(\n'
-        '    "g:scratch:#b8bb26:grove"\n'
-        '    "V:scratch4:#83a598:Vapor"\n'
-        '    "w:scratch11:#ebdbb2:wheat"\n'
+        'SCRATCH_SLOTS=(\n'
+        '    "scratch:g:#b8bb26:grove"\n'
+        '    "scratch4:V:#83a598:Vapor"\n'
+        '    "scratch11:w:#ebdbb2:wheat"\n'
         ')\n'
         'printf "unrelated:line:#nothex:x"\n')  # must not be parsed as a slot
     codes = isc.load_scratch_codenames(script)
@@ -887,8 +887,8 @@ def test_load_scratch_codenames_missing_file_is_empty():
 
 
 def test_load_scratch_codenames_real_file_has_vapor():
-    # Guards against the on-disk SLOTS format drifting away from the parser.
-    codes = isc.load_scratch_codenames()  # the repo's real tmux-scratch-monitor.sh
+    # Guards against the on-disk SCRATCH_SLOTS format drifting away from the parser.
+    codes = isc.load_scratch_codenames()  # the repo's real tmux-scratch-slots.sh
     assert codes.get("scratch4") == "Vapor"
     assert codes.get("scratch11") == "wheat"
 

--- a/scripts/tmux-initiatives.sh
+++ b/scripts/tmux-initiatives.sh
@@ -17,15 +17,12 @@ REFRESH=${REFRESH:-3}
 STALE_DAYS=${STALE_DAYS:-7}
 STALE_SECS=$((STALE_DAYS * 86400))
 
-# session : slot-key : color : title  (parallel order to scratch-status.sh)
-SLOTS=(
-    "scratch:g:#b8bb26:grove"
-    "scratch2:G:#d79921:Gold"
-    "scratch3:v:#b16286:violet"
-    "scratch4:V:#83a598:Vapor"
-    "scratch5:p:#cc241d:poppy"
-    "scratch6:P:#689d6a:Pool"
-)
+# Scratchpad slot table (session:key:color:name) — sourced from the ONE source of
+# truth in scratch-slots.sh (was a stale 6-entry copy here; now all 12).
+_d="$(dirname "$0")"
+if   [ -f "$_d/scratch-slots.sh" ];      then . "$_d/scratch-slots.sh"
+elif [ -f "$_d/tmux-scratch-slots.sh" ]; then . "$_d/tmux-scratch-slots.sh"
+fi
 
 ICON_RUN="🔄"
 ICON_PAUSE="⏸"
@@ -171,7 +168,7 @@ render() {
     fi
 
     local rendered=""
-    for slot in "${SLOTS[@]}"; do
+    for slot in "${SCRATCH_SLOTS[@]}"; do
         IFS=':' read -r sess key color title <<< "$slot"
         render_group "$sess" "$key" "$title" "$color" "$data" "$now"
         rendered+=" $sess "

--- a/scripts/tmux-scratch-monitor.sh
+++ b/scripts/tmux-scratch-monitor.sh
@@ -10,21 +10,13 @@
 
 REFRESH=${REFRESH:-2}
 
-# slot key : session : color : title  (parallel order to .tmux.conf)
-SLOTS=(
-    "g:scratch:#b8bb26:grove"
-    "G:scratch2:#d79921:Gold"
-    "v:scratch3:#b16286:violet"
-    "V:scratch4:#83a598:Vapor"
-    "p:scratch5:#cc241d:poppy"
-    "P:scratch6:#689d6a:Pool"
-    "o:scratch7:#fe8019:orange"
-    "O:scratch8:#d3869b:Orchid"
-    "n:scratch9:#458588:navy"
-    "N:scratch10:#928374:Nickel"
-    "w:scratch11:#ebdbb2:wheat"
-    "W:scratch12:#af3a03:Walnut"
-)
+# The scratchpad slot table (session:key:color:name) is the ONE source of truth in
+# scratch-slots.sh — sourced here so this HUD, the Alt+i dashboard, the status-left
+# legend, and initiative-scan.py can't drift.
+_d="$(dirname "$0")"
+if   [ -f "$_d/scratch-slots.sh" ];      then . "$_d/scratch-slots.sh"
+elif [ -f "$_d/tmux-scratch-slots.sh" ]; then . "$_d/tmux-scratch-slots.sh"
+fi
 
 hex_to_rgb() {
     local h="${1#\#}"
@@ -35,7 +27,7 @@ render() {
     local rows cols per_section nslots
     rows=$(tput lines 2>/dev/null || echo 40)
     cols=$(tput cols 2>/dev/null || echo 80)
-    nslots=${#SLOTS[@]}
+    nslots=${#SCRATCH_SLOTS[@]}
 
     # Reserve 1 header line + 1 blank line per section + 1 footer line.
     # Available content = rows - (nslots headers + nslots blanks + 1 footer)
@@ -44,8 +36,8 @@ render() {
 
     printf '\033[H\033[2J'  # clear + home
 
-    for slot in "${SLOTS[@]}"; do
-        IFS=':' read -r key sess color name <<< "$slot"
+    for slot in "${SCRATCH_SLOTS[@]}"; do
+        IFS=':' read -r sess key color name <<< "$slot"
         IFS=' ' read -r r g b <<< "$(hex_to_rgb "$color")"
 
         if tmux has-session -t "$sess" 2>/dev/null; then

--- a/scripts/tmux-scratch-slots.sh
+++ b/scripts/tmux-scratch-slots.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Canonical scratchpad slot table — THE single source of truth for the
+# session <-> hotkey <-> color <-> codename mapping, mirroring the tmux/i3
+# scratchpad bindings ($mod+Shift+V -> tmux session `scratch4` -> codename `Vapor`).
+#
+# This file is SOURCED (not executed). Consumers — keep in sync by reading THIS,
+# never a private copy:
+#   - tmux-scratch-monitor.sh   (Alt+m HUD)
+#   - tmux-initiatives.sh       (Alt+i dashboard)
+#   - tmux-scratch-status.sh    (status-left legend)
+#   - scripts/session-analysis/initiative-scan.py  (parses this file's entries)
+#
+# Field order per entry:  session:key:color:name
+#   session — tmux session name (also the emit key)
+#   key     — hotkey letter ($mod+Shift+<key>)
+#   color   — hex, matches the popup border color in .tmux.conf
+#   name    — human codename shown in the HUD / ledger
+# Consumers source this by looking in their own dir for the deployed name first,
+# then the repo name (they run from ~/.config/tmux/ deployed, or scripts/ in-repo):
+#   _d="$(dirname "$0")"
+#   if   [ -f "$_d/scratch-slots.sh" ];      then . "$_d/scratch-slots.sh"
+#   elif [ -f "$_d/tmux-scratch-slots.sh" ]; then . "$_d/tmux-scratch-slots.sh"; fi
+SCRATCH_SLOTS=(
+    "scratch:g:#b8bb26:grove"
+    "scratch2:G:#d79921:Gold"
+    "scratch3:v:#b16286:violet"
+    "scratch4:V:#83a598:Vapor"
+    "scratch5:p:#cc241d:poppy"
+    "scratch6:P:#689d6a:Pool"
+    "scratch7:o:#fe8019:orange"
+    "scratch8:O:#d3869b:Orchid"
+    "scratch9:n:#458588:navy"
+    "scratch10:N:#928374:Nickel"
+    "scratch11:w:#ebdbb2:wheat"
+    "scratch12:W:#af3a03:Walnut"
+)

--- a/scripts/tmux-scratch-status.sh
+++ b/scripts/tmux-scratch-status.sh
@@ -13,6 +13,14 @@
 #   g ●G v V p P    — Gold (scratch2) has a waiting prompt
 #   g G v V p P     — slot dimmed (gray) when session doesn't exist
 
+# Scratchpad slot table (session:key:color:name) — sourced from the ONE source of
+# truth in scratch-slots.sh, then joined for awk (the name field is ignored here).
+_d="$(dirname "$0")"
+if   [ -f "$_d/scratch-slots.sh" ];      then . "$_d/scratch-slots.sh"
+elif [ -f "$_d/tmux-scratch-slots.sh" ]; then . "$_d/tmux-scratch-slots.sh"
+fi
+slots_str="$(printf '%s ' "${SCRATCH_SLOTS[@]}")"
+
 # Sessions with at least one window waiting for input, space-padded for
 # substring matching in awk. Empty if jq / task files are missing.
 waiting=""
@@ -27,10 +35,10 @@ if command -v jq >/dev/null 2>&1 && compgen -G "$HOME/.tmux/tasks/*.json" >/dev/
 fi
 
 tmux list-sessions -F '#{session_name}' 2>/dev/null \
-  | awk -v waiting="$waiting" '
+  | awk -v waiting="$waiting" -v slots_str="$slots_str" '
     BEGIN {
-        # slot key : session : color (matches popup -s border color in .tmux.conf)
-        n = split("scratch:g:#b8bb26 scratch2:G:#d79921 scratch3:v:#b16286 scratch4:V:#83a598 scratch5:p:#cc241d scratch6:P:#689d6a scratch7:o:#fe8019 scratch8:O:#d3869b scratch9:n:#458588 scratch10:N:#928374 scratch11:w:#ebdbb2 scratch12:W:#af3a03", slots, " ")
+        # session:key:color:name from scratch-slots.sh (name unused here).
+        n = split(slots_str, slots, " ")
         for (i = 1; i <= n; i++) {
             split(slots[i], p, ":")
             sess[i]      = p[1]


### PR DESCRIPTION
## What

The scratchpad `session ↔ hotkey ↔ color ↔ codename` table was duplicated across **four** consumers in **three** formats, and had drifted:
- `tmux-initiatives.sh` (Alt+i) carried only **6 of 12** slots
- `tmux-scratch-status.sh` dropped the codename field
- field order differed (`key:session` in monitor vs `session:key` in the others)

Adding a slot or renaming a codename meant editing four places (and forgetting one, as happened).

## How

One canonical file — **`scripts/tmux-scratch-slots.sh`** — defines `SCRATCH_SLOTS` (`session:key:color:name`). Consumers read it:
- **shell HUDs** (`scratch-monitor`, `initiatives`, `scratch-status`) `source` it. `home.nix` deploys it as `~/.config/tmux/scratch-slots.sh`, beside the scripts, and each sources `$(dirname "$0")/scratch-slots.sh` (falling back to the repo name so it works run-in-place too).
- **`initiative-scan.py`** parses it (regex over the quoted entries), repointed from the old monitor script; group order updated for `session:key`.

The Alt+i dashboard now shows all 12 slots (drift fixed). No behavior change for monitor/status/ledger.

## Verification

- `bash -n` clean on all four scripts.
- `status.sh` / `scratch-monitor.sh` / `initiatives.sh` render 12 slots from **both** the repo dir and the deployed `~/.config/tmux/` path (after `home-manager switch` on this host).
- Live `initiative-scan --tmux` resolves `Vapor-2`/`navy-1`/`Gold-2`/`orange-1` + `main:` markers — i.e. the ledger reads the same table.
- **88 python tests pass** (test fixture + real-file guard updated to the new `session:key:color:name` format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)