### PR TITLE
refactor(tmux): collapse status.sh awk to one color-format printf

### DIFF
--- a/scripts/tmux-scratch-status.sh
+++ b/scripts/tmux-scratch-status.sh
@@ -52,11 +52,14 @@ tmux list-sessions -F '#{session_name}' 2>/dev/null \
         for (i = 1; i <= n; i++) {
             s = sess[i]
             if (s in exists) {
-                marker = (index(waiting, " " s " ") > 0) ? "●" : ""
-                printf "%s#[fg=%s,bold]%s%s#[default]", sep, color[s], marker, key[s]
+                style  = color[s] ",bold"                              # slot color, bold
+                marker = (index(waiting, " " s " ") > 0) ? "●" : ""    # waiting indicator
             } else {
-                printf "%s#[fg=#504945]%s#[default]", sep, key[s]
+                style  = "#504945"                                     # dim: session not started
+                marker = ""
             }
+            # Single color-format printf for both states (deduped).
+            printf "%s#[fg=%s]%s%s#[default]", sep, style, marker, key[s]
             sep = " "
         }
     }


### PR DESCRIPTION
Follow-up dedup to #63. The `scratch-status.sh` awk END block repeated the `#[fg=…]…#[default]` color-format wrapper across two `printf` lines (live slot vs dim/absent). Folded the difference into a `style` var (`<color>,bold` or the dim `#504945`) + `marker`, leaving a single color-format `printf`.

Pure refactor — the rendered status-left legend is **byte-identical** (verified via `diff` of the before/after output). Shell-only; `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)