### PR TITLE
refactor(tmux): generate scratchpad popup bindings from the slot table

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -77,90 +77,13 @@ set -g popup-border-lines rounded
 set -g popup-border-style 'fg=#504945'
 set -g popup-style 'bg=#282828'
 
-# Persistent scratch terminal toggle (Alt+g, no prefix for speed)
-# State survives dismissal — running processes keep going
-bind -n M-g if-shell -F '#{==:#{session_name},scratch}' \
-    { detach-client } \
-    { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
-        -S 'fg=#b8bb26' -T ' grove ' \
-        -E 'tmux attach-session -t scratch || tmux new-session -s scratch' }
-
-# Second persistent scratch terminal toggle (Alt+Shift+G)
-bind -n M-G if-shell -F '#{==:#{session_name},scratch2}' \
-    { detach-client } \
-    { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
-        -S 'fg=#d79921' -T ' Gold ' \
-        -E 'tmux attach-session -t scratch2 || tmux new-session -s scratch2' }
-
-# Third persistent scratch terminal toggle (Alt+v)
-bind -n M-v if-shell -F '#{==:#{session_name},scratch3}' \
-    { detach-client } \
-    { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
-        -S 'fg=#b16286' -T ' violet ' \
-        -E 'tmux attach-session -t scratch3 || tmux new-session -s scratch3' }
-
-# Fourth persistent scratch terminal toggle (Alt+Shift+V)
-bind -n M-V if-shell -F '#{==:#{session_name},scratch4}' \
-    { detach-client } \
-    { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
-        -S 'fg=#83a598' -T ' Vapor ' \
-        -E 'tmux attach-session -t scratch4 || tmux new-session -s scratch4' }
-
-# Fifth persistent scratch terminal toggle (Alt+p)
-bind -n M-p if-shell -F '#{==:#{session_name},scratch5}' \
-    { detach-client } \
-    { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
-        -S 'fg=#cc241d' -T ' poppy ' \
-        -E 'tmux attach-session -t scratch5 || tmux new-session -s scratch5' }
-
-# Sixth persistent scratch terminal toggle (Alt+Shift+P)
-bind -n M-P if-shell -F '#{==:#{session_name},scratch6}' \
-    { detach-client } \
-    { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
-        -S 'fg=#689d6a' -T ' Pool ' \
-        -E 'tmux attach-session -t scratch6 || tmux new-session -s scratch6' }
-
-# Seventh persistent scratch terminal toggle (Alt+o)
-bind -n M-o if-shell -F '#{==:#{session_name},scratch7}' \
-    { detach-client } \
-    { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
-        -S 'fg=#fe8019' -T ' orange ' \
-        -E 'tmux attach-session -t scratch7 || tmux new-session -s scratch7' }
-
-# Eighth persistent scratch terminal toggle (Alt+Shift+O)
-bind -n M-O if-shell -F '#{==:#{session_name},scratch8}' \
-    { detach-client } \
-    { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
-        -S 'fg=#d3869b' -T ' Orchid ' \
-        -E 'tmux attach-session -t scratch8 || tmux new-session -s scratch8' }
-
-# Ninth persistent scratch terminal toggle (Alt+n)
-bind -n M-n if-shell -F '#{==:#{session_name},scratch9}' \
-    { detach-client } \
-    { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
-        -S 'fg=#458588' -T ' navy ' \
-        -E 'tmux attach-session -t scratch9 || tmux new-session -s scratch9' }
-
-# Tenth persistent scratch terminal toggle (Alt+Shift+N)
-bind -n M-N if-shell -F '#{==:#{session_name},scratch10}' \
-    { detach-client } \
-    { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
-        -S 'fg=#928374' -T ' Nickel ' \
-        -E 'tmux attach-session -t scratch10 || tmux new-session -s scratch10' }
-
-# Eleventh persistent scratch terminal toggle (Alt+w)
-bind -n M-w if-shell -F '#{==:#{session_name},scratch11}' \
-    { detach-client } \
-    { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
-        -S 'fg=#ebdbb2' -T ' wheat ' \
-        -E 'tmux attach-session -t scratch11 || tmux new-session -s scratch11' }
-
-# Twelfth persistent scratch terminal toggle (Alt+Shift+W)
-bind -n M-W if-shell -F '#{==:#{session_name},scratch12}' \
-    { detach-client } \
-    { display-popup -d "#{pane_current_path}" -xC -yC -w 80% -h 80% \
-        -S 'fg=#af3a03' -T ' Walnut ' \
-        -E 'tmux attach-session -t scratch12 || tmux new-session -s scratch12' }
+# Persistent scratchpad toggles (Alt+<key>: grove/Gold/violet/Vapor/…) — one popup
+# per slot: detach if already inside it, else pop up (colored border + codename
+# title) attaching or creating its session. These 12 bindings are GENERATED at
+# home-manager build time from the canonical slot table (scripts/tmux-scratch-slots.sh)
+# and appended to this config by nix/programs/tmux/default.nix — so the palette +
+# codenames live in ONE place, not re-hardcoded per binding here. Edit the slot table,
+# not this file, to add/rename a scratchpad.
 
 # Scratchpad picker (Alt+Shift+T) — toggle/create named scratchpads
 bind -n M-T display-popup -E -w 80% -h 80% -S 'fg=#d65d0e' -T ' scratchpads ' \

--- a/nix/programs/tmux/default.nix
+++ b/nix/programs/tmux/default.nix
@@ -1,10 +1,39 @@
 { pkgs, ... }:
+let
+  inherit (pkgs) lib;
+  # Generate the 12 scratchpad popup toggles from the canonical slot table
+  # (scripts/tmux-scratch-slots.sh) instead of hardcoding them — with their
+  # per-slot color + codename — in .tmux.conf. One source of truth: the same file
+  # the tmux HUDs source and initiative-scan.py parses. Add/rename a scratchpad by
+  # editing the slot table only.
+  slotsText = builtins.readFile ../../../scripts/tmux-scratch-slots.sh;
+  # Slot entries look like:  "scratch4:V:#83a598:Vapor"  (session:key:color:name).
+  slotRe = "[[:space:]]*\"([^\":]+):([^\":]+):(#[0-9a-fA-F]+):([^\"]+)\"[[:space:]]*";
+  slotLines = builtins.filter (l: builtins.match slotRe l != null)
+    (lib.splitString "\n" slotsText);
+  parse = l: let m = builtins.match slotRe l; in {
+    sess = builtins.elemAt m 0;
+    key = builtins.elemAt m 1;
+    color = builtins.elemAt m 2;
+    name = builtins.elemAt m 3;
+  };
+  # Byte-identical (per tmux's normalization) to the former hand-written bindings —
+  # verified via a `tmux list-keys` diff before the cutover.
+  mkBind = s: "bind -n M-${s.key} if-shell -F '#{==:#{session_name},${s.sess}}'"
+    + " { detach-client }"
+    + " { display-popup -d \"#{pane_current_path}\" -xC -yC -w 80% -h 80%"
+    + " -S 'fg=${s.color}' -T ' ${s.name} '"
+    + " -E 'tmux attach-session -t ${s.sess} || tmux new-session -s ${s.sess}' }";
+  scratchBindings = builtins.concatStringsSep "\n" (map (s: mkBind (parse s)) slotLines);
+in
 {
   enable = true;
   prefix = "C-a";
   keyMode = "vi";
   baseIndex = 1;
-  extraConfig = builtins.readFile ../../../.tmux.conf;
+  extraConfig = builtins.readFile ../../../.tmux.conf
+    + "\n# --- generated scratchpad popup toggles (see nix/programs/tmux/default.nix) ---\n"
+    + scratchBindings + "\n";
   plugins = with pkgs.tmuxPlugins; [
     resurrect
     {


### PR DESCRIPTION
## What

Follow-up dedup to #63/#64. The 12 `Alt+<key>` scratchpad popup toggles were the **last copy of the palette living outside the canonical table** — each `bind` in `.tmux.conf` hardcoded its slot's color (`-S 'fg=#83a598'`) and codename (`-T ' Vapor '`).

Now they're **generated at build time** from `scripts/tmux-scratch-slots.sh`:
- `nix/programs/tmux/default.nix` reads the slot file, parses the `SCRATCH_SLOTS` entries in **pure nix** (`builtins.match`, no IFD), and appends the 12 `bind -n M-<key> … display-popup …` lines to `extraConfig`.
- The 12 static bindings are removed from `.tmux.conf`, replaced by a pointer comment.

Every consumer now reads the one table: the 3 tmux HUDs (source it), `initiative-scan.py` (parses it), and the popup bindings (generated from it). Add/rename a scratchpad → edit the slot table only.

## Byte-identical, verified

The generated bindings normalize (via `tmux list-keys`) to **exactly** the former hand-written ones:
- diffed `list-keys` of static vs. bash-generated single-line form → identical;
- confirmed the pure-nix generation produces the same text (`toFile` + diff);
- after `home-manager switch` on this host, sourced the **deployed** config and diffed `list-keys` against the original static snapshot → **identical**.

`nix-instantiate --parse` clean; switch succeeds (used `pkgs.lib` since this module is imported with only `pkgs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)