### PR TITLE
chore(tmux): promote laptop-local tmux tweaks to main

### DIFF
--- a/nix/programs/tmux/default.nix
+++ b/nix/programs/tmux/default.nix
@@ -31,16 +31,26 @@ in
   prefix = "C-a";
   keyMode = "vi";
   baseIndex = 1;
+  terminal = "tmux-256color";
+  escapeTime = 0;
+  historyLimit = 50000;
+  focusEvents = true;
   extraConfig = builtins.readFile ../../../.tmux.conf
     + "\n# --- generated scratchpad popup toggles (see nix/programs/tmux/default.nix) ---\n"
     + scratchBindings + "\n";
   plugins = with pkgs.tmuxPlugins; [
-    resurrect
+    {
+      plugin = resurrect;
+      extraConfig = ''
+        set -g @resurrect-capture-pane-contents 'on'
+        set -g @resurrect-strategy-nvim 'session'
+      '';
+    }
     {
       plugin = continuum;
       extraConfig = ''
         set -g @continuum-restore 'on'
-        set -g @continuum-save-interval '5'
+        set -g @continuum-save-interval '15'
       '';
     }
     {


### PR DESCRIPTION
The laptop carried these tmux settings as **uncommitted local drift** — they were never on `main`, so `ship.sh` re-conflicted on `nix/programs/tmux/default.nix` every run. Promoting them to `main` so both hosts share them and the drift ends:

- `terminal = "tmux-256color"`, `escapeTime = 0`, `historyLimit = 50000`, `focusEvents = true`
- resurrect: `@resurrect-capture-pane-contents 'on'`, `@resurrect-strategy-nvim 'session'`
- continuum `@continuum-save-interval` `5` → `15`

Verified: `home-manager switch` on the workbench deploys all of them alongside the generated scratchpad bindings (`grep` of the deployed config confirms `tmux-256color`, `history-limit 50000`, `escape-time 0`, `capture-pane-contents on`, `save-interval '15'`, and 12 generated bindings).

Follow-up (manual): the laptop's now-redundant local edit to this file gets reset to match `main` so it stops diverging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)