### PR TITLE
feat(initiatives): restore --plan override + guard tests

### DIFF
--- a/scripts/session-analysis/tests/test_tmux_session_restore.py
+++ b/scripts/session-analysis/tests/test_tmux_session_restore.py
@@ -9,6 +9,7 @@ claim-based unique-session assignment (no two windows share a session, uncertain
 picker), and cheat-sheet rendering. tmux/grep/capture-pane I/O is stubbed.
 """
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -118,3 +119,28 @@ def test_cheat_sheet_shows_resume_command_and_picker_fallback():
     assert "claude --resume abc" in txt
     assert "Vapor:2" in txt and "main:8:1" in txt
     assert "pick from the list" in txt           # empty id -> picker guidance
+
+
+# --------------------------------------------------------------------------- #
+# restore — custom plan path + no-clobber guard
+# --------------------------------------------------------------------------- #
+def test_cmd_restore_reads_custom_plan_and_renders_send(tmp_path, monkeypatch, capsys):
+    plan = tmp_path / "p.json"
+    plan.write_text(json.dumps([{"session": "s", "window": "1", "codename": "Vapor",
+                                 "cwd": "/r", "session_id": "abc", "title": "t", "hint": ""}]))
+    monkeypatch.setattr(tsr, "tmux_session_exists", lambda n: True)
+    monkeypatch.setattr(tsr, "window_state", lambda t: (True, "zsh"))  # bare shell
+    rc = tsr.cmd_restore(dry_run=True, plan_path=plan)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "claude --resume abc" in out and "would send" in out
+
+
+def test_cmd_restore_skips_window_already_running_claude(tmp_path, monkeypatch, capsys):
+    plan = tmp_path / "p.json"
+    plan.write_text(json.dumps([{"session": "s", "window": "1", "codename": "Vapor",
+                                 "cwd": "/r", "session_id": "abc", "title": "t", "hint": ""}]))
+    monkeypatch.setattr(tsr, "tmux_session_exists", lambda n: True)
+    monkeypatch.setattr(tsr, "window_state", lambda t: (True, "claude"))  # already running
+    tsr.cmd_restore(dry_run=True, plan_path=plan)
+    assert "claude already running" in capsys.readouterr().out

--- a/scripts/tmux-session-restore.py
+++ b/scripts/tmux-session-restore.py
@@ -231,11 +231,12 @@ def window_state(target: str) -> tuple[bool, str]:
     return (bool(out.strip()), out.strip())
 
 
-def cmd_restore(dry_run: bool = False) -> int:
-    if not PLAN.exists():
-        print("no restore plan — run `save` before rebooting", file=sys.stderr)
+def cmd_restore(dry_run: bool = False, plan_path: Path | None = None) -> int:
+    src = plan_path or PLAN
+    if not src.exists():
+        print(f"no restore plan at {src} — run `save` before rebooting", file=sys.stderr)
         return 1
-    plan = json.loads(PLAN.read_text())
+    plan = json.loads(src.read_text())
     tag = "[dry-run] would " if dry_run else ""
     sent = skipped = 0
     for e in plan:
@@ -272,10 +273,17 @@ def main(argv: list[str]) -> int:
     if argv[:1] == ["show"]:
         return cmd_show()
     if argv[:1] == ["restore"]:
-        return cmd_restore(dry_run="--dry-run" in argv[1:] or "-n" in argv[1:])
+        rest = argv[1:]
+        dry = "--dry-run" in rest or "-n" in rest
+        plan_path = None
+        if "--plan" in rest:
+            i = rest.index("--plan")
+            if i + 1 < len(rest):
+                plan_path = Path(os.path.expanduser(rest[i + 1]))
+        return cmd_restore(dry_run=dry, plan_path=plan_path)
     print(__doc__.strip().split("\n\n")[0])
-    print("\nusage: tmux-session-restore.py {save | restore [--dry-run] | show}",
-          file=sys.stderr)
+    print("\nusage: tmux-session-restore.py "
+          "{save | restore [--dry-run] [--plan PATH] | show}", file=sys.stderr)
     return 2
 
 


### PR DESCRIPTION
Follow-up to #69. Adds `restore [--plan PATH]` to replay a specific saved plan (also what let me validate the send-path against a throwaway bare-shell window without touching the real plan). Tests cover the custom-plan read and the no-clobber guard.

Validated the full restore chain live:
- `claude --resume <id>` loads the **correct** conversation (~1s)
- a garbage id is rejected (`No conversation found`, rc=1)
- dry-run against a bare shell renders `cd <cwd> && claude --resume <id>`; a window already running claude is skipped

104 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)