### PR TITLE
Add .shellcheckrc for consistent ShellCheck across the repo

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,21 @@
+# ShellCheck configuration for devrc
+# https://github.com/koalaman/shellcheck/wiki/Options
+
+# Default dialect — most scripts use #!/usr/bin/env bash
+shell=bash
+
+# Follow sourced files when they exist in the repo
+external-sources=true
+
+# Broadly-safe disables for personal/dotfiles scripts.
+# Each is annotated; no correctness checks are suppressed.
+
+# SC1091: Not following (file not found) — dotfiles often source
+# machine-specific files that exist only at runtime on a given host.
+disable=SC1091
+
+# SC2312: Consider invoking this command separately to avoid hiding
+# return codes — common in concise personal scripts where the pipe
+# pattern is intentional and the exit code of the first command is
+# not critical (e.g. command | grep | while read).
+disable=SC2312


### PR DESCRIPTION
## Summary

Adds a `.shellcheckrc` at the repo root so ShellCheck runs consistently across all shell scripts.

## What is included

- **`shell=bash`** — sets default dialect (all scripts use `#!/usr/bin/env bash`)
- **`external-sources=true`** — follows `source`d files that exist in the repo
- **`disable=SC1091`** — non-followable sourced paths (machine-specific files in dotfiles)
- **`disable=SC2312`** — pipe return-code masking in concise personal scripts

Each disable has an inline comment explaining why it is safe.

## Scope

- ✅ Adds one new config dotfile
- ✅ Changes no scripts or existing config
- ✅ Fully reversible (close PR / delete file)
- ✅ Verifier: `test -f .shellcheckrc && grep -q 'shell=bash' .shellcheckrc`