### PR TITLE
chore: add .editorconfig for consistent editor defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Adds a root `.editorconfig` with conservative defaults suitable for a dotfiles repo:

- `root = true` — stop at repo root, don't merge parent configs
- UTF-8, LF line endings
- Final newline, trim trailing whitespace
- Space-based 2-space indentation (shell/nix friendly)

No existing files were changed. Fully reversible.