### PR TITLE
feat(rig): monitor blackout + chassis-RGB control panel (yad + i3blocks button)

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -145,7 +145,7 @@ in
 
   home.packages = if isNixOS
   then
-    userPackages ++ [pkgs.autorandr pkgs.ddcutil]
+    userPackages ++ [pkgs.autorandr pkgs.ddcutil pkgs.yad]
   else
     userPackages;
 

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -145,7 +145,7 @@ in
 
   home.packages = if isNixOS
   then
-    userPackages ++ [pkgs.autorandr]
+    userPackages ++ [pkgs.autorandr pkgs.ddcutil]
   else
     userPackages;
 

--- a/nix/system/apply-rig-controls.sh
+++ b/nix/system/apply-rig-controls.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Stage the "rig controls" i3blocks button into /etc/nixos.
+# Run with: sudo bash nix/system/apply-rig-controls.sh
+#
+# Idempotent + drift-safe: it APPENDS to the live i3blocks.nix / i3config.nix only
+# if the entries are missing, so it never clobbers live-only changes. It does NOT
+# run nixos-rebuild — review the diffs first, then rebuild yourself.
+set -euo pipefail
+
+DEVRC_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+NIXOS_DIR="/etc/nixos"
+SCRIPTS_DIR="$NIXOS_DIR/i3blocks-scripts"
+BLOCKS="$NIXOS_DIR/i3blocks.nix"
+I3CONF="$NIXOS_DIR/i3config.nix"
+
+echo "=== Staging rig-controls into $NIXOS_DIR ==="
+
+# 1. Install the launcher block script (plain dir, no rebuild needed for this part).
+echo "[1/3] Installing i3blocks-scripts/rigcontrol..."
+install -m 0755 "$DEVRC_DIR/scripts/i3blocks-rigcontrol" "$SCRIPTS_DIR/rigcontrol"
+
+# 2. Add the [rigcontrol] block to i3blocks.nix (insert before the closing '' line).
+echo "[2/3] Ensuring [rigcontrol] block in i3blocks.nix..."
+if grep -q '\[rigcontrol\]' "$BLOCKS"; then
+  echo "      already present — skipping"
+else
+  tmp="$(mktemp)"
+  head -n -1 "$BLOCKS" > "$tmp"
+  cat >> "$tmp" <<'BLOCK'
+
+[rigcontrol]
+command=$SCRIPT_DIR/rigcontrol
+interval=once
+BLOCK
+  tail -n 1 "$BLOCKS" >> "$tmp"   # re-append the closing ''
+  install -m 0644 "$tmp" "$BLOCKS"
+  rm -f "$tmp"
+fi
+
+# 3. Add the yad float rule to i3config.nix (insert before the closing '' line).
+echo "[3/3] Ensuring yad float rule in i3config.nix..."
+if grep -q 'title="Rig Controls"' "$I3CONF"; then
+  echo "      already present — skipping"
+else
+  tmp="$(mktemp)"
+  head -n -1 "$I3CONF" > "$tmp"
+  cat >> "$tmp" <<'RULE'
+
+# Float the rig-control (yad) popup as a compact centered window instead of tiling it
+for_window [class="Yad" title="Rig Controls"] floating enable, move position center
+RULE
+  tail -n 1 "$I3CONF" >> "$tmp"
+  install -m 0644 "$tmp" "$I3CONF"
+  rm -f "$tmp"
+fi
+
+cat <<'DONE'
+
+=== Staged. Next steps (review, then apply): ===
+  1. sudo diff -u <(git -C ~/workspace/devrc show HEAD:nix/system/i3blocks.nix) /etc/nixos/i3blocks.nix   # sanity-check
+  2. sudo nixos-rebuild switch
+  3. i3-msg restart          # reload the bar + float rule (saves/restores your layout)
+
+A new ⚙ block appears on the bar — left-click it to open the Rig Controls panel.
+DONE

--- a/nix/system/i3blocks.nix
+++ b/nix/system/i3blocks.nix
@@ -1,4 +1,8 @@
 ''
+[rigcontrol]
+command=$SCRIPT_DIR/rigcontrol
+interval=once
+
 [dictation]
 command=$SCRIPT_DIR/dictation
 interval=once

--- a/nix/system/i3config.nix
+++ b/nix/system/i3config.nix
@@ -18,6 +18,9 @@ bindsym Shift+XF86MonBrightnessDown exec --no-startup-id brightnessctl set 1%-
 
 floating_modifier $mod
 
+# Float the rig-control (yad) popup as a compact centered window instead of tiling it
+for_window [class="Yad" title="Rig Controls"] floating enable, move position center
+
 # Terminal
 bindsym $mod+Return exec [ ! "$I3CONFIG_DEFAULT_TERMINAL" = "" ] && $I3CONFIG_DEFAULT_TERMINAL || i3-sensible-terminal
 

--- a/scripts/i3blocks-rigcontrol
+++ b/scripts/i3blocks-rigcontrol
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# i3blocks launcher block for the rig-control yad panel.
+#   interval=once  -> renders the icon at startup; i3blocks re-runs this on click
+#                     with $BLOCK_BUTTON set (1=left, 2=middle, 3=right).
+# Left-click opens the control panel, detached so it outlives this block run.
+RIG="$HOME/workspace/devrc/scripts/rig-control.sh"
+
+case "${BLOCK_BUTTON:-}" in
+  1) setsid -f "$RIG" gui >/dev/null 2>&1 ;;   # left-click -> open panel
+esac
+
+echo "⚙"

--- a/scripts/monitor-blackout.sh
+++ b/scripts/monitor-blackout.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Black out the external monitor WITHOUT powering it off, by driving the
+# DDC/CI backlight (VCP feature 0x10 "Brightness") to 0. The panel stays
+# awake (no DPMS, no signal loss) — it just emits no light.
+#
+# NOTE: unlike a DPMS blank, this does NOT wake on keypress/mouse. Restore
+# happens either automatically after the timer fires, or by re-running with
+# `restore`.
+#
+# Usage:
+#   monitor-blackout.sh           # black out now, auto-restore after 8h
+#   monitor-blackout.sh 2h        # black out now, auto-restore after 2h (systemd time span)
+#   monitor-blackout.sh restore   # restore prior brightness now, cancel pending timer
+#   monitor-blackout.sh status    # show pending restore timer, if any
+set -euo pipefail
+
+DDC=$(command -v ddcutil) || { echo "ddcutil not found on PATH" >&2; exit 1; }
+UNIT=monitor-blackout-restore
+STATE="${XDG_RUNTIME_DIR:-/tmp}/monitor-blackout.state"   # "bus:brightness"
+
+# First DDC/CI-capable display's i2c bus number.
+detect_bus() {
+  "$DDC" detect --brief 2>/dev/null \
+    | grep -m1 -o 'i2c-[0-9]\+' | grep -o '[0-9]\+$'
+}
+
+get_brightness() { # $1=bus  -> current VCP 0x10 value
+  "$DDC" --bus "$1" getvcp 10 --brief 2>/dev/null | awk '{print $4}'
+}
+
+cancel_timer() {
+  systemctl --user stop    "${UNIT}.timer"   2>/dev/null || true
+  systemctl --user reset-failed "${UNIT}.service" "${UNIT}.timer" 2>/dev/null || true
+}
+
+blackout() {
+  local dur="${1:-8h}" bus cur
+  bus=$(detect_bus); [ -n "${bus:-}" ] || { echo "no DDC/CI monitor detected" >&2; exit 1; }
+  cur=$(get_brightness "$bus"); [ -n "${cur:-}" ] || { echo "could not read brightness on bus $bus" >&2; exit 1; }
+  printf '%s:%s\n' "$bus" "$cur" > "$STATE"
+
+  "$DDC" --bus "$bus" setvcp 10 0
+
+  cancel_timer
+  # Schedule restore as a transient user timer so it survives this shell exiting.
+  # Absolute $DDC path is baked in so no PATH is needed when the timer fires.
+  systemd-run --user --unit="$UNIT" --on-active="$dur" --timer-property=AccuracySec=1s \
+    "$DDC" --bus "$bus" setvcp 10 "$cur" >/dev/null
+  echo "Monitor blacked out (bus $bus, was $cur/100). Auto-restore in $dur — or: $0 restore"
+}
+
+restore() {
+  cancel_timer
+  local bus="" cur=""
+  [ -f "$STATE" ] && IFS=: read -r bus cur < "$STATE" || true
+  bus="${bus:-$(detect_bus)}"; cur="${cur:-60}"
+  [ -n "$bus" ] || { echo "no DDC/CI monitor detected" >&2; exit 1; }
+  "$DDC" --bus "$bus" setvcp 10 "$cur"
+  rm -f "$STATE"
+  echo "Monitor restored (bus $bus -> $cur/100)."
+}
+
+status() {
+  if systemctl --user is-active --quiet "${UNIT}.timer"; then
+    systemctl --user list-timers "${UNIT}.timer" --no-pager 2>/dev/null | sed -n '1,2p'
+  else
+    echo "No pending restore timer."
+  fi
+}
+
+case "${1:-}" in
+  restore) restore ;;
+  status)  status ;;
+  "")      blackout 8h ;;
+  *)       blackout "$1" ;;
+esac

--- a/scripts/rig-control.sh
+++ b/scripts/rig-control.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# rig-control — a tiny yad control panel (and CLI) for two workbench toggles:
+#   * chassis RGB on/off  (MSI motherboard headers, OpenRGB device 2 — scoped so
+#                          the keyboard/mouse are never touched)
+#   * monitor blackout / restore  (DDC-CI backlight; delegates to monitor-blackout.sh)
+#
+# Usage:
+#   rig-control            # open the yad panel (default)
+#   rig-control rgb-on
+#   rig-control rgb-off
+#   rig-control blackout   # 8h auto-restore
+#   rig-control restore
+set -euo pipefail
+
+SELF="$(readlink -f "$0")"
+DIR="$(dirname "$SELF")"
+
+# --- chassis RGB (OpenRGB device 2 only) ------------------------------------
+RGB_DEVICE="${RIG_RGB_DEVICE:-2}"
+RGB_ON_MODE="${RIG_RGB_ON_MODE:-static}"
+RGB_ON_COLOR="${RIG_RGB_ON_COLOR:-FFFFFF}"   # change to taste (hex, no #), or set a mode like "Rainbow wave"
+
+notify() { command -v notify-send >/dev/null 2>&1 && notify-send -t 2500 "rig-control" "$1" 2>/dev/null || true; }
+
+rgb_on() {
+  openrgb --device "$RGB_DEVICE" --mode "$RGB_ON_MODE" --color "$RGB_ON_COLOR" >/dev/null 2>&1
+  notify "Chassis RGB on ($RGB_ON_MODE $RGB_ON_COLOR)"
+}
+rgb_off() {
+  openrgb --device "$RGB_DEVICE" --mode static --color 000000 >/dev/null 2>&1
+  notify "Chassis RGB off"
+}
+
+# --- monitor (delegate to the DDC-CI blackout script) -----------------------
+blackout() { "$DIR/monitor-blackout.sh" 8h && notify "Monitor blacked out (auto-restore 8h)"; }
+restore()  { "$DIR/monitor-blackout.sh" restore && notify "Monitor restored"; }
+
+# --- GUI --------------------------------------------------------------------
+gui() {
+  # yad form with in-dialog action buttons (FBTN): clicking runs a command and
+  # leaves the panel open, so it behaves like a little control surface.
+  yad --title="Rig Controls" --window-icon=preferences-desktop \
+      --form --columns=1 --width=280 --center --on-top \
+      --text="<b>Chassis RGB &amp; Monitor</b>" \
+      --field="🌈   Chassis RGB — On:FBTN"    "bash -c '$SELF rgb-on'" \
+      --field="⚫   Chassis RGB — Off:FBTN"   "bash -c '$SELF rgb-off'" \
+      --field="🖥️   Monitor — Blackout (8h):FBTN" "bash -c '$SELF blackout'" \
+      --field="☀️   Monitor — Restore:FBTN"   "bash -c '$SELF restore'" \
+      --button="Close:0"
+}
+
+case "${1:-gui}" in
+  rgb-on)   rgb_on ;;
+  rgb-off)  rgb_off ;;
+  blackout) blackout ;;
+  restore)  restore ;;
+  gui|"")   gui ;;
+  *) echo "usage: rig-control [rgb-on|rgb-off|blackout|restore|gui]" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
## What
A little **Rig Controls** panel + a one-click bar button for two workbench toggles.

**User-level (works now after `home-manager switch`):**
- `scripts/rig-control.sh` — a `yad` popup with four in-panel buttons:
  - 🌈 Chassis RGB On / ⚫ Off — OpenRGB **device 2 only** (motherboard headers; keyboard & mouse never touched)
  - 🖥 Monitor Blackout (8h) / ☀ Restore — DDC-CI backlight, delegates to `monitor-blackout.sh`
  - Also a headless CLI: `rig-control rgb-on|rgb-off|blackout|restore`
- `scripts/monitor-blackout.sh` — drop the monitor's DDC-CI backlight to 0 (dark, still powered, no signal loss), auto-restore after 8h via a transient `systemd --user` timer. `restore`/`status` subcommands.
- Declares `pkgs.ddcutil` + `pkgs.yad`.

**System-level i3 bar button (needs `sudo nixos-rebuild` — staged, not auto-applied):**
- `scripts/i3blocks-rigcontrol` — ⚙ launcher block, left-click opens the panel
- `nix/system/i3blocks.nix` — `[rigcontrol]` block
- `nix/system/i3config.nix` — float rule so the popup is a compact centered window (`class="Yad" title="Rig Controls"`)
- `nix/system/apply-rig-controls.sh` — **idempotent, drift-safe** staging into `/etc/nixos` (append-if-missing; prints review + rebuild steps, does not auto-rebuild)

### Apply the bar button
```
sudo bash nix/system/apply-rig-controls.sh   # stages into /etc/nixos idempotently
sudo nixos-rebuild switch
i3-msg restart
```

## Verified
- Panel renders on `:0` (screenshotted), all 4 buttons + Close present
- RGB dispatch (device 2) exit 0; yad `WM_CLASS="yad","Yad"` / title confirmed via `xprop` (→ correct float criteria)
- `monitor-blackout.sh`: bus detection, VCP read, write round-trip, real +3s timer-fired restore
- `/etc/nixos` insert logic dry-run on copies → both files still parse as valid Nix
- **Not** verified: the actual `nixos-rebuild` (no sudo from the tooling) — that step is yours.

## Caveats
- Backlight-to-0 does **not** wake on input (by request) — restore via timer/button.
- RGB "on" defaults to static white; change `RIG_RGB_ON_COLOR`/`RIG_RGB_ON_MODE` in `rig-control.sh` (e.g. a `Rainbow wave` mode) to taste.
- Notifications only show when dunst is running (not in server mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)