### PR TITLE
feat(i3-bar): quiet colors — VPN-off + normal CPU no longer painted

### DIFF
--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -49,6 +49,10 @@ let
     block = "cpu";
     format = " $icon $utilization ";
     interval = 2;
+    # info_cpu defaults to 30 → the block goes blue (Info) at any moderate load.
+    # Pin it to warning so CPU stays neutral until it actually needs attention:
+    # neutral <85, warning 85-95, critical >95.
+    info_cpu = 85;
     warning_cpu = 85;
     critical_cpu = 95;
   };

--- a/scripts/i3status-vpn-status
+++ b/scripts/i3status-vpn-status
@@ -6,10 +6,11 @@
 # i3status-vpn-menu, wired via [[block.click]] in the i3status-rust config.
 # Refreshed on demand with:  pkill -RTMIN+10 i3status-rs  (block signal = 10)
 #
-# State mapping from the old i3blocks colors:
-#   connected  -> Good      (was default/green)
-#   not on VPN -> Critical  (was #FF0000 red)
-#   API error  -> Warning   (was #FFA500 orange)
+# State mapping (colors reserved for things needing attention — the VPN is toggled
+# deliberately, so on/off are both neutral; the icon + text carry the state):
+#   connected  -> Idle     (neutral)
+#   not on VPN -> Idle     (neutral)
+#   API error  -> Warning  (this one is unexpected → worth flagging)
 set -uo pipefail
 
 TIMEOUT=${TIMEOUT:-3}
@@ -51,7 +52,7 @@ if [[ "${is_mullvad:-False}" == "True" ]]; then
     else
         short="${city:0:3}"
     fi
-    emit "VPN ${city}" "VPN ${short}" "Good" | tee "$CACHE_FILE"
+    emit "VPN ${city}" "VPN ${short}" "Idle" | tee "$CACHE_FILE"
 else
-    emit "VPN OFF" "VPN !" "Critical" | tee "$CACHE_FILE"
+    emit "VPN OFF" "VPN !" "Idle" | tee "$CACHE_FILE"
 fi


### PR DESCRIPTION
Colors should signal attention. VPN off (deliberate toggle) and CPU at moderate load (info_cpu defaults to 30) were painting the bar during normal use.

- VPN on/off → **Idle** (neutral); the lock icon + text carry state. API-error stays Warning.
- CPU **info_cpu=85** (=warning) → neutral <85, warning 85-95, critical >95.

**Verified live:** at rest all blocks neutral `#282828`; a CPU stress spike to 99% correctly turns red (critical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)