### PR TITLE
feat(i3-bar): GPU block + decoupled clawgate/mail/alerts status counts

### DIFF
--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -20,6 +20,11 @@ let
   home = config.home.homeDirectory;
   scriptsDir = "${home}/.config/i3status-rust/scripts";
 
+  # Python env for the decoupled bar-status poller (workbench systemd user timer):
+  # psycopg2 for the homelab Postgres open-mail_actions count; clawgate + Alertmanager
+  # go over stdlib urllib, so psycopg2 is the only non-stdlib dep.
+  pollPyEnv = pkgs.python312.withPackages (ps: [ ps.psycopg2 ]);
+
   # Built-in blocks (order = left → right on the bar).
   memoryBlock = {
     block = "memory";
@@ -75,6 +80,23 @@ let
     chip = "k10temp-*";
     inputs = [ "Tctl" ];
   });
+  # nvidia_gpu: workbench only (RTX 5080). The block's state is TEMPERATURE-driven
+  # (idle/good/info/warning are UPPER bounds; temp ≤ idle → neutral). Keep it CALM
+  # like temperatureBlock: the 5080 idles ~45°C and sits ~65-78°C under sustained
+  # load, so collapse idle/good/info onto ONE neutral ceiling (82) and only colour
+  # yellow 82-88 / red >88 (edge temp; the throttle zone is higher still). Utilization
+  # + power still render in the text at every load — only the COLOUR waits for heat.
+  # Needs nvidia-smi on PATH (it is, in the graphical session).
+  gpuBlock = {
+    block = "nvidia_gpu";
+    gpu_id = 0;
+    format = " $icon $utilization $temperature $power ";
+    interval = 5;
+    idle = 82;
+    good = 82;
+    info = 82;
+    warning = 88;
+  };
   batteryBlock = {
     block = "battery";
     format = " $icon $percentage ";
@@ -95,6 +117,43 @@ let
     click = [
       { button = "left"; cmd = "${scriptsDir}/i3status-vpn-menu"; }
       { button = "right"; cmd = "alacritty --class float,float -e ${scriptsDir}/vpn-detail"; }
+    ];
+  };
+  # Decoupled status-count blocks (workbench only). These NEVER query a remote
+  # system per bar tick — they read a small JSON cache file written every ~45s by
+  # the bar-status-poll systemd user timer (see below) and render it instantly, so
+  # a slow/down source can never hang the bar. CALM: each is empty+invisible at
+  # zero / stale / error, and only appears (icon + count, coloured) when >0. The
+  # `signal` matches SIGNALS in bar-status-poll so the poller can `pkill -RTMIN+N
+  # i3status-rs` to refresh exactly this block the instant it writes.
+  alertsBlock = {
+    block = "custom";
+    command = "${scriptsDir}/i3status-alerts";
+    json = true;
+    interval = 30;
+    signal = 13;
+    click = [
+      { button = "left"; cmd = "xdg-open http://grafana.homelab.lan"; }
+    ];
+  };
+  mailBlock = {
+    block = "custom";
+    command = "${scriptsDir}/i3status-mail";
+    json = true;
+    interval = 30;
+    signal = 12;
+    click = [
+      { button = "left"; cmd = "alacritty --class float,float -e ${home}/workspace/devrc/scripts/mail-triage"; }
+    ];
+  };
+  clawgateBlock = {
+    block = "custom";
+    command = "${scriptsDir}/i3status-clawgate";
+    json = true;
+    interval = 30;
+    signal = 11;
+    click = [
+      { button = "left"; cmd = "xdg-open http://192.168.50.250:30302"; }
     ];
   };
   timeBlock = {
@@ -120,8 +179,11 @@ let
 
   blocks =
     [ memoryBlock diskBlock netBlock cpuBlock temperatureBlock ]
+    ++ lib.optional (!isLaptop) gpuBlock
     ++ lib.optional isLaptop batteryBlock
-    ++ [ soundBlock vpnBlock timeBlock ]
+    ++ [ soundBlock ]
+    ++ lib.optionals (!isLaptop) [ alertsBlock mailBlock clawgateBlock ]
+    ++ [ vpnBlock timeBlock ]
     ++ lib.optional (!isLaptop) rigcontrolBlock;
 in
 lib.mkIf isNixOS {
@@ -163,5 +225,74 @@ lib.mkIf isNixOS {
   home.file.".config/i3status-rust/scripts/i3blocks-rigcontrol" = {
     source = ../scripts/i3blocks-rigcontrol;
     executable = true;
+  };
+
+  # Decoupled status-count block scripts (workbench blocks reference these by
+  # scriptsDir path). They only read ~/.cache/bar-status/*.json — instant, never
+  # network. The poller itself (scripts/bar-status-poll) is NOT symlinked here: it
+  # is run from the repo working tree by the systemd unit below so it can resolve
+  # its sibling scripts/mail-actions/_db.py (cf. mail-actions/run-archive.sh).
+  home.file.".config/i3status-rust/scripts/i3status-clawgate" = {
+    source = ../scripts/i3status-clawgate;
+    executable = true;
+  };
+  home.file.".config/i3status-rust/scripts/i3status-mail" = {
+    source = ../scripts/i3status-mail;
+    executable = true;
+  };
+  home.file.".config/i3status-rust/scripts/i3status-alerts" = {
+    source = ../scripts/i3status-alerts;
+    executable = true;
+  };
+
+  # bar-status poller — WORKBENCH ONLY (!isLaptop). Every ~45s it queries clawgate
+  # (pending Tasks), the homelab Postgres (open mail_actions), and Alertmanager
+  # (firing alerts, homelab required + production best-effort) and writes a small
+  # JSON status file per source to ~/.cache/bar-status/, then signals i3status-rs
+  # to refresh the matching block. Fully fail-safe: a down source writes a 'stale'
+  # marker (the block renders empty) and never wedges. Laptop is excluded: it is
+  # nebula-only with no direct LAN path to these homelab endpoints, exactly like
+  # mail-actions-archive / repo-cos in home.nix.
+  #
+  # A user service runs with a minimal env, so PATH must be explicit: the pinned
+  # python (psycopg2) + kubectl (the mail + Alertmanager port-forwards) + procps
+  # (pkill signals the bar) + coreutils. It resolves the kubeconfig/clawgate.env/
+  # repo paths itself (no .zshenv handles under systemd).
+  systemd.user.services.bar-status-poll = lib.mkIf (!isLaptop) {
+    Unit = {
+      Description = "Poll clawgate/mail/alerts → ~/.cache/bar-status for the i3 bar";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+    };
+    Service = {
+      Type = "oneshot";
+      Environment = [
+        "PATH=${lib.makeBinPath [ pollPyEnv pkgs.kubectl pkgs.procps pkgs.coreutils ]}"
+        "KUBECONFIG=%h/workspace/homelab-talos/homelab-kubeconfig"
+        "DEVRC_DIR=%h/workspace/devrc"
+        "HOMELAB_DIR=%h/workspace/homelab-talos"
+        "HOME=%h"
+      ];
+      ExecStart = "${pollPyEnv}/bin/python3 %h/workspace/devrc/scripts/bar-status-poll";
+      # Re-run the unit when the poller changes (cf. X-Restart-Triggers in home.nix).
+      X-Restart-Triggers = [ "${../scripts/bar-status-poll}" ];
+    };
+  };
+
+  # Timer: fire the poller ~every 45s. OnUnitActiveSec re-arms after each run so a
+  # slow poll never overlaps itself; OnStartupSec gives one prompt run after login;
+  # Persistent catches up a single missed run after sleep.
+  systemd.user.timers.bar-status-poll = lib.mkIf (!isLaptop) {
+    Unit = {
+      Description = "Periodic timer for the i3 bar-status poller";
+    };
+    Timer = {
+      OnStartupSec = "20s";
+      OnUnitActiveSec = "45s";
+      Persistent = true;
+    };
+    Install = {
+      WantedBy = [ "timers.target" ];
+    };
   };
 }

--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -232,15 +232,17 @@ lib.mkIf isNixOS {
   # network. The poller itself (scripts/bar-status-poll) is NOT symlinked here: it
   # is run from the repo working tree by the systemd unit below so it can resolve
   # its sibling scripts/mail-actions/_db.py (cf. mail-actions/run-archive.sh).
-  home.file.".config/i3status-rust/scripts/i3status-clawgate" = {
+  # The clawgate/mail/alerts block scripts + poller are workbench-only, so their
+  # symlinks are !isLaptop-gated too (they'd be dead files on the laptop otherwise).
+  home.file.".config/i3status-rust/scripts/i3status-clawgate" = lib.mkIf (!isLaptop) {
     source = ../scripts/i3status-clawgate;
     executable = true;
   };
-  home.file.".config/i3status-rust/scripts/i3status-mail" = {
+  home.file.".config/i3status-rust/scripts/i3status-mail" = lib.mkIf (!isLaptop) {
     source = ../scripts/i3status-mail;
     executable = true;
   };
-  home.file.".config/i3status-rust/scripts/i3status-alerts" = {
+  home.file.".config/i3status-rust/scripts/i3status-alerts" = lib.mkIf (!isLaptop) {
     source = ../scripts/i3status-alerts;
     executable = true;
   };
@@ -266,6 +268,11 @@ lib.mkIf isNixOS {
     };
     Service = {
       Type = "oneshot";
+      # Hard ceiling so a half-hung kubectl (nebula up, API server not answering)
+      # can't wedge the poller forever: systemd kills the cgroup (reaping any stuck
+      # kubectl child) and the timer re-arms. Without this, Type=oneshot defaults to
+      # TimeoutStartSec=infinity and OnUnitActiveSec only re-fires once inactive.
+      TimeoutStartSec = 90;
       Environment = [
         "PATH=${lib.makeBinPath [ pollPyEnv pkgs.kubectl pkgs.procps pkgs.coreutils ]}"
         "KUBECONFIG=%h/workspace/homelab-talos/homelab-kubeconfig"
@@ -280,8 +287,8 @@ lib.mkIf isNixOS {
   };
 
   # Timer: fire the poller ~every 45s. OnUnitActiveSec re-arms after each run so a
-  # slow poll never overlaps itself; OnStartupSec gives one prompt run after login;
-  # Persistent catches up a single missed run after sleep.
+  # slow poll never overlaps itself; OnStartupSec gives one prompt run after login.
+  # (No Persistent — it only applies to OnCalendar timers, not monotonic ones.)
   systemd.user.timers.bar-status-poll = lib.mkIf (!isLaptop) {
     Unit = {
       Description = "Periodic timer for the i3 bar-status poller";
@@ -289,7 +296,6 @@ lib.mkIf isNixOS {
     Timer = {
       OnStartupSec = "20s";
       OnUnitActiveSec = "45s";
-      Persistent = true;
     };
     Install = {
       WantedBy = [ "timers.target" ];

--- a/scripts/bar-status-poll
+++ b/scripts/bar-status-poll
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Decoupled status poller for the i3status-rust bar (workbench only).
+
+Every ~45s (a home-manager systemd user timer) this queries three remote/local
+sources and writes a tiny JSON status file per source to
+    ~/.cache/bar-status/{clawgate,mail,alerts}.json
+that the *instant* i3status-rust block scripts (i3status-clawgate / -mail /
+-alerts) read. The bar never queries a remote system per tick — it only reads a
+local file — so a slow or down source can never hang or break the bar.
+
+Fully FAIL-SAFE: a down/slow source writes a {"state":"stale"} marker (never
+crashes the poller); the block scripts render a stale/missing file as an empty
+(invisible) block, honouring the bar's CALM principle (colour == "look at me";
+steady state is neutral / invisible). After writing each file the poller signals
+i3status-rs (RTMIN+N) so the corresponding block refreshes immediately.
+
+Sources
+  clawgate : GET $CLAWGATE_API_URL/api/tasks with the bearer CLAWGATE_HOOK_TOKEN
+             (both from ~/.claude/clawgate.env) -> count tasks awaiting the
+             operator (status in {open, ready_for_review}).
+  mail     : open rows in the homelab Postgres `mail_actions` table, via
+             mail-actions/_db.py (kubectl port-forward + psycopg2). That module
+             is loaded by EXPLICIT PATH, never via sys.path — its sibling llm.py
+             must not shadow anything (per CLAUDE.md).
+  alerts   : firing alerts (severity warning|critical, excluding Watchdog /
+             InfoInhibitor) from Alertmanager /api/v2/alerts, reached through a
+             short bounded `kubectl port-forward`. homelab is REQUIRED; the
+             production cluster is best-effort (added only if reachable).
+
+Parse is deliberately separated from fetch so the parse_* functions are unit
+tested against mock inputs (scripts/tests/test_bar_status.py). Drive the whole
+write+signal path against fixtures without any live endpoint:
+    bar-status-poll --mock-clawgate tasks.json --mock-alerts alerts.json --mock-mail 3
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+# clawgate task statuses that mean "the operator still has to act": a freshly
+# posted task awaiting dispatch (open) or a finished agent run awaiting review
+# (ready_for_review). in_progress = an agent is working = not on the human.
+PENDING_TASK_STATES = frozenset({"open", "ready_for_review"})
+
+# Alertmanager: only real, actionable severities count; Watchdog is the
+# always-firing dead-man's switch and InfoInhibitor is an inhibition helper.
+REAL_ALERT_SEVERITIES = frozenset({"warning", "critical"})
+IGNORE_ALERTNAMES = frozenset({"Watchdog", "InfoInhibitor"})
+
+# Real-time signal offset per source: the block's `signal = N` in graphical.nix
+# must match, so `pkill -RTMIN+N i3status-rs` refreshes exactly that block.
+SIGNALS = {"clawgate": 11, "mail": 12, "alerts": 13}
+
+DEVRC_DIR = os.environ.get("DEVRC_DIR") or os.path.expanduser("~/workspace/devrc")
+HOMELAB_DIR = os.environ.get("HOMELAB_DIR") or os.path.expanduser("~/workspace/homelab-talos")
+
+
+# ---------------------------------------------------------------------------
+# Pure parse functions (unit-tested against mock inputs)
+# ---------------------------------------------------------------------------
+def parse_clawgate(tasks, pending_states=PENDING_TASK_STATES) -> dict:
+    """Map the /api/tasks list to a status dict. Counts operator-pending tasks.
+
+    Raises ValueError if the top-level payload is not a list (the caller turns
+    that into a 'stale' marker); tolerates junk list *elements*.
+    """
+    if not isinstance(tasks, list):
+        raise ValueError("clawgate /api/tasks payload is not a list")
+    pending = [
+        t for t in tasks
+        if isinstance(t, dict) and t.get("status") in pending_states
+    ]
+    count = len(pending)
+    if count:
+        ids = ", ".join("#%s" % t.get("id") for t in pending[:6])
+        detail = "%d task(s) awaiting: %s" % (count, ids)
+        state = "Warning"
+    else:
+        detail = "no pending tasks"
+        state = "Idle"
+    return {"count": count, "state": state, "detail": detail}
+
+
+def parse_mail(open_count) -> dict:
+    """Map an open-mail_actions count to a status dict."""
+    n = int(open_count)
+    if n < 0:
+        n = 0
+    return {
+        "count": n,
+        "state": "Warning" if n else "Idle",
+        "detail": ("%d open mail action(s)" % n) if n else "inbox clear",
+    }
+
+
+def parse_alerts(alerts) -> dict:
+    """Map an Alertmanager /api/v2/alerts list to a status dict.
+
+    Counts firing (active) alerts of severity warning|critical, excluding the
+    Watchdog / InfoInhibitor housekeeping alerts. State is Critical if any
+    critical is firing, else Warning if any warning, else neutral.
+    Raises ValueError if the payload is not a list; tolerates junk elements.
+    """
+    if not isinstance(alerts, list):
+        raise ValueError("alertmanager payload is not a list")
+    real = []
+    for a in alerts:
+        if not isinstance(a, dict):
+            continue
+        labels = a.get("labels")
+        if not isinstance(labels, dict):
+            continue
+        if labels.get("alertname") in IGNORE_ALERTNAMES:
+            continue
+        sev = labels.get("severity")
+        if sev not in REAL_ALERT_SEVERITIES:
+            continue
+        status = a.get("status")
+        if isinstance(status, dict):
+            st = status.get("state")
+            if st and st != "active":
+                continue
+        real.append(sev)
+    count = len(real)
+    crit = sum(1 for s in real if s == "critical")
+    if count == 0:
+        return {"count": 0, "state": "Idle", "detail": "no firing alerts"}
+    if crit:
+        return {"count": count, "state": "Critical",
+                "detail": "%d firing (%d critical)" % (count, crit)}
+    return {"count": count, "state": "Warning",
+            "detail": "%d firing (warning)" % count}
+
+
+def stale(reason: str, err=None) -> dict:
+    """A neutral 'source unavailable' marker; the block renders it as empty."""
+    d = {"count": 0, "state": "stale", "detail": reason}
+    if err is not None:
+        d["error"] = str(err)[:200]
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Low-level helpers
+# ---------------------------------------------------------------------------
+def _free_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _wait_port(host: str, port: int, timeout: float, proc=None) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc is not None and proc.poll() is not None:
+            raise RuntimeError("kubectl port-forward exited early")
+        with contextlib.suppress(OSError):
+            with socket.create_connection((host, port), timeout=1):
+                return
+        time.sleep(0.2)
+    raise TimeoutError("port-forward to %s:%d not ready in time" % (host, port))
+
+
+def _http_json(url: str, headers=None, timeout: float = 3.0):
+    req = urllib.request.Request(url, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode())
+
+
+# ---------------------------------------------------------------------------
+# Fetch functions (network / cluster; wrapped by source() so failures -> stale)
+# ---------------------------------------------------------------------------
+def _clawgate_creds():
+    env = {}
+    with open(os.path.expanduser("~/.claude/clawgate.env")) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            env[k.strip()] = v.strip()
+    url = env.get("CLAWGATE_API_URL", "http://192.168.50.250:30302").rstrip("/")
+    token = env["CLAWGATE_HOOK_TOKEN"]
+    return token, url
+
+
+def fetch_clawgate() -> dict:
+    token, url = _clawgate_creds()
+    tasks = _http_json(url + "/api/tasks",
+                       headers={"Authorization": "Bearer " + token}, timeout=3)
+    return parse_clawgate(tasks)
+
+
+def _load_maildb():
+    """Load mail-actions/_db.py by explicit path (NOT via sys.path — its sibling
+    llm.py must not shadow anything; CLAUDE.md gotcha)."""
+    import importlib.util
+    path = os.path.join(DEVRC_DIR, "scripts", "mail-actions", "_db.py")
+    spec = importlib.util.spec_from_file_location("_bar_maildb", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def fetch_mail() -> dict:
+    mod = _load_maildb()
+    with mod.MailDB() as db:
+        rows = db.list_open_actions()
+    return parse_mail(len(rows))
+
+
+def _kubeconfig(name: str) -> str:
+    return os.path.join(HOMELAB_DIR, name)
+
+
+def _pf_alerts(kubeconfig: str, timeout: float = 6.0):
+    """Bounded kubectl port-forward to Alertmanager; returns the raw alert list."""
+    port = _free_port()
+    env = dict(os.environ, KUBECONFIG=kubeconfig)
+    pf = subprocess.Popen(
+        ["kubectl", "-n", "monitoring", "port-forward",
+         "svc/kube-prometheus-stack-alertmanager", "%d:9093" % port],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env,
+    )
+    try:
+        _wait_port("127.0.0.1", port, 8.0, proc=pf)
+        data = _http_json(
+            "http://127.0.0.1:%d/api/v2/alerts"
+            "?active=true&silenced=false&inhibited=false" % port,
+            timeout=timeout,
+        )
+        return data if isinstance(data, list) else []
+    finally:
+        pf.terminate()
+        with contextlib.suppress(Exception):
+            pf.wait(timeout=3)
+
+
+def fetch_alerts() -> dict:
+    homelab = _kubeconfig("homelab-kubeconfig")   # REQUIRED
+    alerts = _pf_alerts(homelab)                   # raises -> stale on failure
+    prod = _kubeconfig("production-kubeconfig")    # best-effort
+    if os.path.exists(prod):
+        try:
+            alerts = list(alerts) + _pf_alerts(prod)
+        except Exception:
+            pass  # production is optional; homelab already counted
+    return parse_alerts(alerts)
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+def source(name: str, fn) -> dict:
+    """Run a fetch fail-safe: any exception becomes a 'stale' marker."""
+    try:
+        payload = fn()
+    except Exception as e:  # noqa: BLE001 — the point is to never propagate
+        payload = stale("%s unavailable" % name, e)
+    payload["ts"] = int(time.time())
+    payload["source"] = name
+    return payload
+
+
+def cache_dir() -> str:
+    return os.environ.get("BAR_STATUS_DIR") or os.path.join(
+        os.path.expanduser("~"), ".cache", "bar-status")
+
+
+def write_status(name: str, payload: dict) -> str:
+    d = cache_dir()
+    os.makedirs(d, exist_ok=True)
+    path = os.path.join(d, name + ".json")
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(payload, f)
+    os.replace(tmp, path)
+    return path
+
+
+def signal_bar(name: str) -> None:
+    n = SIGNALS.get(name)
+    if n is None:
+        return
+    with contextlib.suppress(Exception):
+        subprocess.run(["pkill", "-RTMIN+%d" % n, "i3status-rs"],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def run_source(name: str, fn) -> dict:
+    payload = source(name, fn)
+    write_status(name, payload)
+    signal_bar(name)
+    return payload
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="i3status-rust bar-status poller")
+    ap.add_argument("--mock-clawgate", metavar="FILE",
+                    help="parse this JSON file as the /api/tasks payload")
+    ap.add_argument("--mock-alerts", metavar="FILE",
+                    help="parse this JSON file as the Alertmanager alert list")
+    ap.add_argument("--mock-mail", metavar="N", type=int,
+                    help="use N as the open-mail_actions count")
+    args = ap.parse_args(argv)
+
+    mocking = any(x is not None for x in
+                  (args.mock_clawgate, args.mock_alerts, args.mock_mail))
+
+    if mocking:
+        if args.mock_clawgate is not None:
+            with open(args.mock_clawgate) as f:
+                run_source("clawgate", lambda: parse_clawgate(json.load(f)))
+        if args.mock_mail is not None:
+            run_source("mail", lambda: parse_mail(args.mock_mail))
+        if args.mock_alerts is not None:
+            with open(args.mock_alerts) as f:
+                run_source("alerts", lambda: parse_alerts(json.load(f)))
+        return 0
+
+    # Live poll: each source is independent + fail-safe.
+    run_source("clawgate", fetch_clawgate)
+    run_source("mail", fetch_mail)
+    run_source("alerts", fetch_alerts)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:  # noqa: BLE001 — a poller must never crash the timer loudly
+        sys.exit(0)

--- a/scripts/bar-status-poll
+++ b/scripts/bar-status-poll
@@ -286,6 +286,7 @@ def write_status(name: str, payload: dict) -> str:
     tmp = path + ".tmp"
     with open(tmp, "w") as f:
         json.dump(payload, f)
+    os.chmod(tmp, 0o600)  # contents are infra alert counts / task ids — keep them non-world-readable
     os.replace(tmp, path)
     return path
 

--- a/scripts/i3status-alerts
+++ b/scripts/i3status-alerts
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""i3status-rust custom block: firing cluster-alert count.
+
+Reads the cache file written by scripts/bar-status-poll and emits ONE
+i3status-rust JSON line. INSTANT local file read — never touches the network,
+never blocks the bar.
+
+CALM rendering (colour == "look at me"):
+  missing / stale / error / count<=0  -> empty, invisible block
+  count > 0                           -> `bell` icon + count, coloured (Critical
+                                          if any critical is firing, else Warning
+                                          — the state comes from the cache)
+Click (wired in graphical.nix) opens Grafana.
+"""
+import json
+import os
+import sys
+
+NAME = "alerts"
+ICON = "bell"
+_VALID_STATES = ("Idle", "Info", "Good", "Warning", "Critical")
+_EMPTY = {"text": "", "state": "Idle"}
+
+
+def cache_path() -> str:
+    base = os.environ.get("BAR_STATUS_DIR") or os.path.join(
+        os.path.expanduser("~"), ".cache", "bar-status")
+    return os.path.join(base, NAME + ".json")
+
+
+def load(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def render(payload, icon: str = ICON) -> dict:
+    """Pure: cache payload (or None) -> i3status-rust block dict.
+
+    Hide-at-zero + fail-safe: None / malformed / stale / error / count<=0 all
+    map to the empty (invisible) block — never a crash.
+    """
+    if not isinstance(payload, dict):
+        return dict(_EMPTY)
+    if payload.get("error") or payload.get("state") == "stale":
+        return dict(_EMPTY)
+    try:
+        count = int(payload.get("count", 0))
+    except (TypeError, ValueError):
+        return dict(_EMPTY)
+    if count <= 0:
+        return dict(_EMPTY)
+    state = payload.get("state")
+    if state not in _VALID_STATES or state == "Idle":
+        state = "Critical"
+    return {"icon": icon, "text": str(count),
+            "short_text": str(count), "state": state}
+
+
+def main() -> int:
+    sys.stdout.write(json.dumps(render(load(cache_path()))) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        sys.stdout.write(json.dumps(_EMPTY) + "\n")
+        sys.exit(0)

--- a/scripts/i3status-clawgate
+++ b/scripts/i3status-clawgate
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""i3status-rust custom block: clawgate operator-pending task count.
+
+Reads the cache file written by scripts/bar-status-poll and emits ONE
+i3status-rust JSON line. This is INSTANT (a local file read) and never touches
+the network, so it can never block the bar.
+
+CALM rendering (colour == "look at me"):
+  missing / stale / error / count<=0  -> empty, invisible block
+  count > 0                           -> `tasks` icon + count, coloured (state
+                                          from the cache; default Warning)
+Click (wired in graphical.nix) opens the clawgate UI.
+"""
+import json
+import os
+import sys
+
+NAME = "clawgate"
+ICON = "tasks"
+_VALID_STATES = ("Idle", "Info", "Good", "Warning", "Critical")
+_EMPTY = {"text": "", "state": "Idle"}
+
+
+def cache_path() -> str:
+    base = os.environ.get("BAR_STATUS_DIR") or os.path.join(
+        os.path.expanduser("~"), ".cache", "bar-status")
+    return os.path.join(base, NAME + ".json")
+
+
+def load(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def render(payload, icon: str = ICON) -> dict:
+    """Pure: cache payload (or None) -> i3status-rust block dict.
+
+    Hide-at-zero + fail-safe: None / malformed / stale / error / count<=0 all
+    map to the empty (invisible) block — never a crash.
+    """
+    if not isinstance(payload, dict):
+        return dict(_EMPTY)
+    if payload.get("error") or payload.get("state") == "stale":
+        return dict(_EMPTY)
+    try:
+        count = int(payload.get("count", 0))
+    except (TypeError, ValueError):
+        return dict(_EMPTY)
+    if count <= 0:
+        return dict(_EMPTY)
+    state = payload.get("state")
+    if state not in _VALID_STATES or state == "Idle":
+        state = "Warning"
+    return {"icon": icon, "text": str(count),
+            "short_text": str(count), "state": state}
+
+
+def main() -> int:
+    sys.stdout.write(json.dumps(render(load(cache_path()))) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        sys.stdout.write(json.dumps(_EMPTY) + "\n")
+        sys.exit(0)

--- a/scripts/i3status-mail
+++ b/scripts/i3status-mail
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""i3status-rust custom block: open mail-actions count.
+
+Reads the cache file written by scripts/bar-status-poll and emits ONE
+i3status-rust JSON line. INSTANT local file read — never touches the network,
+never blocks the bar.
+
+CALM rendering (colour == "look at me"):
+  missing / stale / error / count<=0  -> empty, invisible block
+  count > 0                           -> `mail` icon + count, coloured (state
+                                          from the cache; default Warning)
+Click (wired in graphical.nix) opens the mail-actions triage list.
+"""
+import json
+import os
+import sys
+
+NAME = "mail"
+ICON = "mail"
+_VALID_STATES = ("Idle", "Info", "Good", "Warning", "Critical")
+_EMPTY = {"text": "", "state": "Idle"}
+
+
+def cache_path() -> str:
+    base = os.environ.get("BAR_STATUS_DIR") or os.path.join(
+        os.path.expanduser("~"), ".cache", "bar-status")
+    return os.path.join(base, NAME + ".json")
+
+
+def load(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def render(payload, icon: str = ICON) -> dict:
+    """Pure: cache payload (or None) -> i3status-rust block dict.
+
+    Hide-at-zero + fail-safe: None / malformed / stale / error / count<=0 all
+    map to the empty (invisible) block — never a crash.
+    """
+    if not isinstance(payload, dict):
+        return dict(_EMPTY)
+    if payload.get("error") or payload.get("state") == "stale":
+        return dict(_EMPTY)
+    try:
+        count = int(payload.get("count", 0))
+    except (TypeError, ValueError):
+        return dict(_EMPTY)
+    if count <= 0:
+        return dict(_EMPTY)
+    state = payload.get("state")
+    if state not in _VALID_STATES or state == "Idle":
+        state = "Warning"
+    return {"icon": icon, "text": str(count),
+            "short_text": str(count), "state": state}
+
+
+def main() -> int:
+    sys.stdout.write(json.dumps(render(load(cache_path()))) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        sys.stdout.write(json.dumps(_EMPTY) + "\n")
+        sys.exit(0)

--- a/scripts/mail-triage
+++ b/scripts/mail-triage
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Interactive triage view for the mail bar-block's click action.
+#
+# Prints the open mail_actions queue (`extract.py list`) and holds the terminal
+# open. Reaches the homelab Postgres itself (kubectl port-forward + psycopg2),
+# so KUBECONFIG + kubectl + nix-shell are the only requirements — same shape as
+# scripts/mail-actions/run-archive.sh. Referenced by absolute repo path from the
+# i3status-rust click (like scripts/rig-control.sh), so its own directory resolves
+# the sibling mail-actions/extract.py.
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export KUBECONFIG="${KUBECONFIG:-${HOME}/workspace/homelab-talos/homelab-kubeconfig}"
+
+nix-shell -p 'python3.withPackages(p:[p.psycopg2 p.requests])' kubectl --run \
+  "python ${DIR}/mail-actions/extract.py list" || true
+
+read -rsp $'\nPress any key to close…\n' -n1

--- a/scripts/tests/test_bar_status.py
+++ b/scripts/tests/test_bar_status.py
@@ -1,0 +1,300 @@
+"""Unit tests for the bar-status poller + the three i3status-rust block scripts.
+
+All OFFLINE — no network, no cluster, no Postgres. Every test feeds a MOCK input
+(mock clawgate /api/tasks JSON, a mock open-mail count, a mock Alertmanager alert
+list) and asserts:
+  - correct count parsing per source,
+  - correct i3status-rust JSON (icon / text / state),
+  - HIDE-AT-ZERO (count 0 -> empty, invisible block),
+  - FAIL-SAFE (malformed / empty / stale input -> neutral empty block, never a
+    crash).
+
+The scripts are extensionless (`bar-status-poll`, `i3status-clawgate`, ...), so
+they are loaded via importlib.machinery.SourceFileLoader.
+
+    run:  pytest scripts/tests/test_bar_status.py
+"""
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+
+
+def _load(name, modname):
+    loader = importlib.machinery.SourceFileLoader(modname, str(SCRIPTS / name))
+    spec = importlib.util.spec_from_loader(modname, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+poll = _load("bar-status-poll", "bar_status_poll")
+clawgate_block = _load("i3status-clawgate", "i3status_clawgate")
+mail_block = _load("i3status-mail", "i3status_mail")
+alerts_block = _load("i3status-alerts", "i3status_alerts")
+
+
+# --------------------------------------------------------------------------- #
+# poller parse: clawgate
+# --------------------------------------------------------------------------- #
+def test_parse_clawgate_counts_only_pending_states():
+    tasks = [
+        {"id": 1, "status": "open"},
+        {"id": 2, "status": "ready_for_review"},
+        {"id": 3, "status": "in_progress"},   # agent working -> NOT operator-pending
+        {"id": 4, "status": "complete"},
+        {"id": 5, "status": "dismissed"},
+    ]
+    out = poll.parse_clawgate(tasks)
+    assert out["count"] == 2
+    assert out["state"] == "Warning"
+    assert "#1" in out["detail"] and "#2" in out["detail"]
+
+
+def test_parse_clawgate_zero_is_neutral():
+    out = poll.parse_clawgate([{"id": 9, "status": "complete"}])
+    assert out["count"] == 0
+    assert out["state"] == "Idle"
+
+
+def test_parse_clawgate_empty_list():
+    out = poll.parse_clawgate([])
+    assert out == {"count": 0, "state": "Idle", "detail": "no pending tasks"}
+
+
+def test_parse_clawgate_tolerates_junk_elements():
+    out = poll.parse_clawgate([None, "x", 3, {"status": "open", "id": 7}])
+    assert out["count"] == 1
+
+
+def test_parse_clawgate_malformed_toplevel_raises():
+    # A non-list top level is a broken response -> raise (caller -> stale marker).
+    with pytest.raises(ValueError):
+        poll.parse_clawgate({"error": "nope"})
+
+
+# --------------------------------------------------------------------------- #
+# poller parse: mail
+# --------------------------------------------------------------------------- #
+def test_parse_mail_positive():
+    out = poll.parse_mail(3)
+    assert out["count"] == 3 and out["state"] == "Warning"
+
+
+def test_parse_mail_zero_neutral():
+    out = poll.parse_mail(0)
+    assert out["count"] == 0 and out["state"] == "Idle"
+    assert out["detail"] == "inbox clear"
+
+
+def test_parse_mail_negative_clamped():
+    assert poll.parse_mail(-5)["count"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# poller parse: alerts
+# --------------------------------------------------------------------------- #
+def _alert(name, sev, state="active"):
+    return {"labels": {"alertname": name, "severity": sev},
+            "status": {"state": state}}
+
+
+def test_parse_alerts_counts_warn_and_crit_excludes_housekeeping():
+    alerts = [
+        _alert("KubeJobFailed", "critical"),
+        _alert("CPUThrottlingHigh", "warning"),
+        _alert("NodeDiskIOSaturation", "critical"),
+        _alert("Watchdog", "none"),          # excluded
+        _alert("InfoInhibitor", "none"),     # excluded
+        _alert("SomeInfo", "info"),          # excluded (severity)
+    ]
+    out = poll.parse_alerts(alerts)
+    assert out["count"] == 3
+    assert out["state"] == "Critical"      # >=1 critical
+    assert "3 firing" in out["detail"] and "2 critical" in out["detail"]
+
+
+def test_parse_alerts_warning_only_is_warning():
+    out = poll.parse_alerts([_alert("CPUThrottlingHigh", "warning")])
+    assert out["count"] == 1 and out["state"] == "Warning"
+
+
+def test_parse_alerts_none_firing_neutral():
+    out = poll.parse_alerts([_alert("Watchdog", "none")])
+    assert out == {"count": 0, "state": "Idle", "detail": "no firing alerts"}
+
+
+def test_parse_alerts_skips_non_active_state():
+    out = poll.parse_alerts([_alert("KubeJobFailed", "critical", state="suppressed")])
+    assert out["count"] == 0
+
+
+def test_parse_alerts_tolerates_junk():
+    out = poll.parse_alerts([None, {}, {"labels": "x"}, _alert("X", "warning")])
+    assert out["count"] == 1
+
+
+def test_parse_alerts_malformed_toplevel_raises():
+    with pytest.raises(ValueError):
+        poll.parse_alerts({"data": []})
+
+
+# --------------------------------------------------------------------------- #
+# poller: source() fail-safe wrapper turns any exception into a stale marker
+# --------------------------------------------------------------------------- #
+def test_source_wraps_exception_as_stale():
+    def boom():
+        raise RuntimeError("endpoint down")
+    out = poll.source("clawgate", boom)
+    assert out["state"] == "stale"
+    assert out["count"] == 0
+    assert "endpoint down" in out["error"]
+    assert out["source"] == "clawgate" and "ts" in out
+
+
+def test_source_success_stamps_meta():
+    out = poll.source("mail", lambda: poll.parse_mail(2))
+    assert out["count"] == 2 and out["source"] == "mail" and "ts" in out
+
+
+# --------------------------------------------------------------------------- #
+# poller: --mock end-to-end writes cache files + is fail-safe
+# --------------------------------------------------------------------------- #
+def test_mock_run_writes_all_three(tmp_path, monkeypatch):
+    monkeypatch.setenv("BAR_STATUS_DIR", str(tmp_path))
+    # Silence the bar-signal (no i3status-rs in the test env anyway).
+    monkeypatch.setattr(poll, "signal_bar", lambda name: None)
+
+    tasks_f = tmp_path / "tasks.json"
+    tasks_f.write_text(json.dumps([{"id": 1, "status": "open"},
+                                   {"id": 2, "status": "ready_for_review"}]))
+    alerts_f = tmp_path / "alerts.json"
+    alerts_f.write_text(json.dumps([_alert("KubeJobFailed", "critical")]))
+
+    rc = poll.main(["--mock-clawgate", str(tasks_f),
+                    "--mock-mail", "4",
+                    "--mock-alerts", str(alerts_f)])
+    assert rc == 0
+
+    cg = json.loads((tmp_path / "clawgate.json").read_text())
+    ml = json.loads((tmp_path / "mail.json").read_text())
+    al = json.loads((tmp_path / "alerts.json").read_text())
+    assert cg["count"] == 2 and cg["state"] == "Warning"
+    assert ml["count"] == 4 and ml["state"] == "Warning"
+    assert al["count"] == 1 and al["state"] == "Critical"
+
+
+def test_mock_run_malformed_clawgate_writes_stale(tmp_path, monkeypatch):
+    monkeypatch.setenv("BAR_STATUS_DIR", str(tmp_path))
+    monkeypatch.setattr(poll, "signal_bar", lambda name: None)
+    bad = tmp_path / "bad.json"
+    bad.write_text('{"not":"a list"}')
+    rc = poll.main(["--mock-clawgate", str(bad)])
+    assert rc == 0
+    cg = json.loads((tmp_path / "clawgate.json").read_text())
+    assert cg["state"] == "stale" and cg["count"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# block scripts: render() — hide-at-zero + colour-when->0 + fail-safe
+# --------------------------------------------------------------------------- #
+BLOCKS = [
+    ("clawgate", clawgate_block, "tasks", "Warning"),
+    ("mail", mail_block, "mail", "Warning"),
+    ("alerts", alerts_block, "bell", "Critical"),
+]
+
+
+@pytest.mark.parametrize("name,mod,icon,default_state", BLOCKS)
+def test_block_hides_at_zero(name, mod, icon, default_state):
+    out = mod.render({"count": 0, "state": "Idle"})
+    assert out == {"text": "", "state": "Idle"}
+    assert "icon" not in out            # truly invisible: no icon either
+
+
+@pytest.mark.parametrize("name,mod,icon,default_state", BLOCKS)
+def test_block_visible_and_coloured_when_positive(name, mod, icon, default_state):
+    out = mod.render({"count": 3, "state": default_state})
+    assert out["icon"] == icon
+    assert out["text"] == "3" and out["short_text"] == "3"
+    assert out["state"] == default_state
+
+
+@pytest.mark.parametrize("name,mod,icon,default_state", BLOCKS)
+def test_block_stale_is_invisible(name, mod, icon, default_state):
+    assert mod.render({"count": 5, "state": "stale"}) == {"text": "", "state": "Idle"}
+
+
+@pytest.mark.parametrize("name,mod,icon,default_state", BLOCKS)
+def test_block_error_marker_is_invisible(name, mod, icon, default_state):
+    assert mod.render({"count": 5, "state": "Warning", "error": "x"}) == \
+        {"text": "", "state": "Idle"}
+
+
+@pytest.mark.parametrize("name,mod,icon,default_state", BLOCKS)
+def test_block_none_and_malformed_are_invisible(name, mod, icon, default_state):
+    for bad in (None, [], "x", 3, {"count": "NaN"}, {}):
+        out = mod.render(bad)
+        assert out == {"text": "", "state": "Idle"}
+
+
+@pytest.mark.parametrize("name,mod,icon,default_state", BLOCKS)
+def test_block_defaults_state_when_missing_or_idle(name, mod, icon, default_state):
+    # A positive count with a missing/Idle state must still colour (never neutral).
+    out = mod.render({"count": 1})
+    assert out["state"] == default_state
+    out2 = mod.render({"count": 1, "state": "Idle"})
+    assert out2["state"] == default_state
+
+
+# --------------------------------------------------------------------------- #
+# block scripts: end-to-end subprocess against a fixture cache dir
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("script,cachefile", [
+    ("i3status-clawgate", "clawgate.json"),
+    ("i3status-mail", "mail.json"),
+    ("i3status-alerts", "alerts.json"),
+])
+def test_block_subprocess_missing_file_is_invisible(tmp_path, script, cachefile):
+    env = dict(os.environ, BAR_STATUS_DIR=str(tmp_path))
+    r = subprocess.run([sys.executable, str(SCRIPTS / script)],
+                       capture_output=True, text=True, env=env)
+    assert r.returncode == 0
+    assert json.loads(r.stdout) == {"text": "", "state": "Idle"}
+
+
+@pytest.mark.parametrize("script,cachefile,icon", [
+    ("i3status-clawgate", "clawgate.json", "tasks"),
+    ("i3status-mail", "mail.json", "mail"),
+    ("i3status-alerts", "alerts.json", "bell"),
+])
+def test_block_subprocess_positive_renders(tmp_path, script, cachefile, icon):
+    (tmp_path / cachefile).write_text(json.dumps(
+        {"count": 2, "state": "Warning", "detail": "x"}))
+    env = dict(os.environ, BAR_STATUS_DIR=str(tmp_path))
+    r = subprocess.run([sys.executable, str(SCRIPTS / script)],
+                       capture_output=True, text=True, env=env)
+    assert r.returncode == 0
+    out = json.loads(r.stdout)
+    assert out["icon"] == icon and out["text"] == "2"
+
+
+@pytest.mark.parametrize("script,cachefile", [
+    ("i3status-clawgate", "clawgate.json"),
+    ("i3status-mail", "mail.json"),
+    ("i3status-alerts", "alerts.json"),
+])
+def test_block_subprocess_corrupt_json_is_invisible(tmp_path, script, cachefile):
+    (tmp_path / cachefile).write_text("{ this is not json ")
+    env = dict(os.environ, BAR_STATUS_DIR=str(tmp_path))
+    r = subprocess.run([sys.executable, str(SCRIPTS / script)],
+                       capture_output=True, text=True, env=env)
+    assert r.returncode == 0
+    assert json.loads(r.stdout) == {"text": "", "state": "Idle"}


### PR DESCRIPTION
## What

Four new blocks on the i3status-rust bar (**workbench only**, `!isLaptop`), all following the bar's CALM principle — colour means "look at me", steady state is neutral/invisible.

### 1. GPU block (`nvidia_gpu`, RTX 5080)
Shows `$icon $utilization $temperature $power`. State is **temperature-driven** and collapsed to one neutral ceiling: neutral ≤82° → yellow 82-88 → red >88, so it stays neutral through normal load and only colours when actually hot. No poller needed.

### 2. Decoupled poller + 3 count blocks
`scripts/bar-status-poll` (home-manager **systemd user timer**, ~45s) queries three sources and writes tiny JSON status files to `~/.cache/bar-status/`:
- **clawgate** — pending Tasks (`status ∈ {open, ready_for_review}`) via `~/.claude/clawgate.env` bearer.
- **mail** — open `mail_actions` in the homelab Postgres via `mail-actions/_db.py` (loaded by **explicit path**, no `sys.path` shadowing).
- **alerts** — firing alerts (severity `warning|critical`, excluding `Watchdog`/`InfoInhibitor`) from **Alertmanager `/api/v2/alerts`** via a bounded `kubectl port-forward`; **homelab required, production best-effort**.

The bar blocks (`i3status-{clawgate,mail,alerts}`) only **read** those files — instant, never network — so a slow/down source can never hang the bar. Each is **empty+invisible at zero/stale/error** and appears (icon + count, coloured) only when >0. The poller signals `i3status-rs` (`RTMIN+11/12/13`) to refresh on write. **Fail-safe**: a down source writes a `stale` marker, never crashes.

**Clicks**: alerts → Grafana, mail → `mail-triage` terminal (`extract.py list`), clawgate → the clawgate LAN UI.

## Tests
`scripts/tests/test_bar_status.py` — **45 cases, all offline** (mock inputs): count parsing, i3status JSON (icon/text/state), **hide-at-zero**, and **fail-safe** (malformed/empty/stale → neutral empty, never a crash) for all four paths. All pass.

## Verified live (workbench)
- `nix-instantiate --parse` OK; `home-manager build` + `switch` OK.
- Poller timer active; the systemd service writes all three cache files (clawgate 0, mail 0, alerts **23 firing / 15 critical** — real).
- `i3status-rs` render inspected: GPU ` 󰍹 30% 44° 124W ` (neutral), alerts ` 󰂜 23 ` in a **red** pill (Critical), clawgate + mail **invisible** at zero.
- Injected nonzero clawgate/mail → both show **yellow (Warning)** pills with icon+count; reverted via the real poller. Bar reloaded with `pkill -SIGUSR2` (no `i3-msg restart`); VPN/time/rig blocks intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)