### PR TITLE
feat(bar): separate civitai-prod alerts count block in the i3 bar

### DIFF
--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -136,6 +136,20 @@ let
       { button = "left"; cmd = "xdg-open http://grafana.homelab.lan"; }
     ];
   };
+  # civitai DataPacket prod alerts — a SEPARATE block from the homelab alertsBlock
+  # (Zach's request). Renders `civ <count>` so it reads distinctly on the bar; the
+  # poller reaches the client cluster's Alertmanager through CIVITAI_KUBECONFIG.
+  # Click opens the civitai Grafana.
+  civitaiBlock = {
+    block = "custom";
+    command = "${scriptsDir}/i3status-civitai";
+    json = true;
+    interval = 30;
+    signal = 14;
+    click = [
+      { button = "left"; cmd = "xdg-open https://grafana-new.civitai.com"; }
+    ];
+  };
   mailBlock = {
     block = "custom";
     command = "${scriptsDir}/i3status-mail";
@@ -182,7 +196,7 @@ let
     ++ lib.optional (!isLaptop) gpuBlock
     ++ lib.optional isLaptop batteryBlock
     ++ [ soundBlock ]
-    ++ lib.optionals (!isLaptop) [ alertsBlock mailBlock clawgateBlock ]
+    ++ lib.optionals (!isLaptop) [ alertsBlock civitaiBlock mailBlock clawgateBlock ]
     ++ [ vpnBlock timeBlock ]
     ++ lib.optional (!isLaptop) rigcontrolBlock;
 in
@@ -246,6 +260,10 @@ lib.mkIf isNixOS {
     source = ../scripts/i3status-alerts;
     executable = true;
   };
+  home.file.".config/i3status-rust/scripts/i3status-civitai" = lib.mkIf (!isLaptop) {
+    source = ../scripts/i3status-civitai;
+    executable = true;
+  };
 
   # bar-status poller — WORKBENCH ONLY (!isLaptop). Every ~45s it queries clawgate
   # (pending Tasks), the homelab Postgres (open mail_actions), and Alertmanager
@@ -262,7 +280,7 @@ lib.mkIf isNixOS {
   # repo paths itself (no .zshenv handles under systemd).
   systemd.user.services.bar-status-poll = lib.mkIf (!isLaptop) {
     Unit = {
-      Description = "Poll clawgate/mail/alerts → ~/.cache/bar-status for the i3 bar";
+      Description = "Poll clawgate/mail/alerts/civitai → ~/.cache/bar-status for the i3 bar";
       After = [ "network-online.target" ];
       Wants = [ "network-online.target" ];
     };
@@ -276,6 +294,9 @@ lib.mkIf isNixOS {
       Environment = [
         "PATH=${lib.makeBinPath [ pollPyEnv pkgs.kubectl pkgs.procps pkgs.coreutils ]}"
         "KUBECONFIG=%h/workspace/homelab-talos/homelab-kubeconfig"
+        # civitai (CLIENT) prod cluster kubeconfig — the civitai alerts source
+        # port-forwards through THIS, never the homelab KUBECONFIG above.
+        "CIVITAI_KUBECONFIG=%h/workspace/civit/datapacket-talos/prod-kubeconfig"
         "DEVRC_DIR=%h/workspace/devrc"
         "HOMELAB_DIR=%h/workspace/homelab-talos"
         "HOME=%h"

--- a/scripts/bar-status-poll
+++ b/scripts/bar-status-poll
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Decoupled status poller for the i3status-rust bar (workbench only).
 
-Every ~45s (a home-manager systemd user timer) this queries three remote/local
-sources and writes a tiny JSON status file per source to
-    ~/.cache/bar-status/{clawgate,mail,alerts}.json
+Every ~45s (a home-manager systemd user timer) this queries a handful of
+remote/local sources and writes a tiny JSON status file per source to
+    ~/.cache/bar-status/{clawgate,mail,alerts,civitai}.json
 that the *instant* i3status-rust block scripts (i3status-clawgate / -mail /
--alerts) read. The bar never queries a remote system per tick — it only reads a
+-alerts / -civitai) read. The bar never queries a remote system per tick — it only reads a
 local file — so a slow or down source can never hang or break the bar.
 
 Fully FAIL-SAFE: a down/slow source writes a {"state":"stale"} marker (never
@@ -26,6 +26,11 @@ Sources
              InfoInhibitor) from Alertmanager /api/v2/alerts, reached through a
              short bounded `kubectl port-forward`. homelab is REQUIRED; the
              production cluster is best-effort (added only if reachable).
+  civitai  : the SAME firing-alert filter, but against the civitai DataPacket
+             prod cluster (a CLIENT prod cluster) via its own kubeconfig
+             (CIVITAI_KUBECONFIG). Deliberately a SEPARATE block/count from the
+             homelab `alerts` source, so a large standing client-prod count never
+             swamps the homelab number.
 
 Parse is deliberately separated from fetch so the parse_* functions are unit
 tested against mock inputs (scripts/tests/test_bar_status.py). Drive the whole
@@ -59,10 +64,15 @@ IGNORE_ALERTNAMES = frozenset({"Watchdog", "InfoInhibitor"})
 
 # Real-time signal offset per source: the block's `signal = N` in graphical.nix
 # must match, so `pkill -RTMIN+N i3status-rs` refreshes exactly that block.
-SIGNALS = {"clawgate": 11, "mail": 12, "alerts": 13}
+SIGNALS = {"clawgate": 11, "mail": 12, "alerts": 13, "civitai": 14}
 
 DEVRC_DIR = os.environ.get("DEVRC_DIR") or os.path.expanduser("~/workspace/devrc")
 HOMELAB_DIR = os.environ.get("HOMELAB_DIR") or os.path.expanduser("~/workspace/homelab-talos")
+# civitai DataPacket prod cluster kubeconfig (a CLIENT prod cluster). The alerts
+# source reaches its Alertmanager through THIS kubeconfig, never the poller's env
+# KUBECONFIG (which points at homelab).
+CIVITAI_KUBECONFIG = os.environ.get("CIVITAI_KUBECONFIG") or os.path.expanduser(
+    "~/workspace/civit/datapacket-talos/prod-kubeconfig")
 
 
 # ---------------------------------------------------------------------------
@@ -260,6 +270,23 @@ def fetch_alerts() -> dict:
     return parse_alerts(alerts)
 
 
+def fetch_civitai() -> dict:
+    """Firing alerts on the civitai DataPacket prod cluster (CLIENT infra).
+
+    Same Alertmanager service name as homelab, so _pf_alerts clones directly —
+    but reached through the civitai kubeconfig (CIVITAI_KUBECONFIG), NOT the
+    poller's env KUBECONFIG (homelab). _pf_alerts binds a fresh free local port,
+    so this can never collide with the homelab/production port-forwards, and its
+    finally-block terminates the forward every call (no leak). Kept SEPARATE from
+    homelab alerts by request, so the counts don't merge into one block. Missing
+    kubeconfig / unreachable cluster -> stale (block renders empty), never crash.
+    """
+    if not os.path.exists(CIVITAI_KUBECONFIG):
+        return stale("civitai kubeconfig missing")
+    alerts = _pf_alerts(CIVITAI_KUBECONFIG)  # raises -> stale on failure
+    return parse_alerts(alerts)
+
+
 # ---------------------------------------------------------------------------
 # Orchestration
 # ---------------------------------------------------------------------------
@@ -313,12 +340,15 @@ def main(argv=None) -> int:
                     help="parse this JSON file as the /api/tasks payload")
     ap.add_argument("--mock-alerts", metavar="FILE",
                     help="parse this JSON file as the Alertmanager alert list")
+    ap.add_argument("--mock-civitai", metavar="FILE",
+                    help="parse this JSON file as the civitai Alertmanager alert list")
     ap.add_argument("--mock-mail", metavar="N", type=int,
                     help="use N as the open-mail_actions count")
     args = ap.parse_args(argv)
 
     mocking = any(x is not None for x in
-                  (args.mock_clawgate, args.mock_alerts, args.mock_mail))
+                  (args.mock_clawgate, args.mock_alerts, args.mock_civitai,
+                   args.mock_mail))
 
     if mocking:
         if args.mock_clawgate is not None:
@@ -329,12 +359,16 @@ def main(argv=None) -> int:
         if args.mock_alerts is not None:
             with open(args.mock_alerts) as f:
                 run_source("alerts", lambda: parse_alerts(json.load(f)))
+        if args.mock_civitai is not None:
+            with open(args.mock_civitai) as f:
+                run_source("civitai", lambda: parse_alerts(json.load(f)))
         return 0
 
     # Live poll: each source is independent + fail-safe.
     run_source("clawgate", fetch_clawgate)
     run_source("mail", fetch_mail)
     run_source("alerts", fetch_alerts)
+    run_source("civitai", fetch_civitai)
     return 0
 
 

--- a/scripts/i3status-civitai
+++ b/scripts/i3status-civitai
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""i3status-rust custom block: firing civitai-prod alert count (CLIENT cluster).
+
+Reads the cache file written by scripts/bar-status-poll (the `civitai` source)
+and emits ONE i3status-rust JSON line. INSTANT local file read — never touches
+the network, never blocks the bar.
+
+Kept a SEPARATE block from i3status-alerts (homelab) by design, and made VISUALLY
+DISTINCT from it — a `civ` text label prefixes the count (`civ 317`) so civitai
+prod can be told apart from the homelab alert count at a glance.
+
+CALM rendering (colour == "look at me"):
+  missing / stale / error / count<=0  -> empty, invisible block
+  count > 0                           -> `bell` icon + `civ <count>`, coloured
+                                          (Critical if any critical is firing,
+                                          else the cache's state)
+Click (wired in graphical.nix) opens the civitai Grafana.
+"""
+import json
+import os
+import sys
+
+NAME = "civitai"
+ICON = "bell"
+LABEL = "civ"
+_VALID_STATES = ("Idle", "Info", "Good", "Warning", "Critical")
+_EMPTY = {"text": "", "state": "Idle"}
+
+
+def cache_path() -> str:
+    base = os.environ.get("BAR_STATUS_DIR") or os.path.join(
+        os.path.expanduser("~"), ".cache", "bar-status")
+    return os.path.join(base, NAME + ".json")
+
+
+def load(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def render(payload, icon: str = ICON) -> dict:
+    """Pure: cache payload (or None) -> i3status-rust block dict.
+
+    Hide-at-zero + fail-safe: None / malformed / stale / error / count<=0 all
+    map to the empty (invisible) block — never a crash. Visible text carries a
+    `civ ` label prefix so it reads distinctly from the homelab alerts block.
+    """
+    if not isinstance(payload, dict):
+        return dict(_EMPTY)
+    if payload.get("error") or payload.get("state") == "stale":
+        return dict(_EMPTY)
+    try:
+        count = int(payload.get("count", 0))
+    except (TypeError, ValueError):
+        return dict(_EMPTY)
+    if count <= 0:
+        return dict(_EMPTY)
+    state = payload.get("state")
+    if state not in _VALID_STATES or state == "Idle":
+        state = "Critical"
+    text = "%s %d" % (LABEL, count)
+    return {"icon": icon, "text": text,
+            "short_text": text, "state": state}
+
+
+def main() -> int:
+    sys.stdout.write(json.dumps(render(load(cache_path()))) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        sys.stdout.write(json.dumps(_EMPTY) + "\n")
+        sys.exit(0)

--- a/scripts/tests/test_bar_status.py
+++ b/scripts/tests/test_bar_status.py
@@ -39,6 +39,7 @@ poll = _load("bar-status-poll", "bar_status_poll")
 clawgate_block = _load("i3status-clawgate", "i3status_clawgate")
 mail_block = _load("i3status-mail", "i3status_mail")
 alerts_block = _load("i3status-alerts", "i3status_alerts")
+civitai_block = _load("i3status-civitai", "i3status_civitai")
 
 
 # --------------------------------------------------------------------------- #
@@ -147,6 +148,64 @@ def test_parse_alerts_malformed_toplevel_raises():
 
 
 # --------------------------------------------------------------------------- #
+# poller: civitai source (separate CLIENT-prod alerts block, own kubeconfig)
+# --------------------------------------------------------------------------- #
+def test_civitai_uses_distinct_signal():
+    # signal 14 must be free of the existing three so pkill -RTMIN+14 refreshes
+    # exactly the civitai block (11/12/13 are clawgate/mail/alerts).
+    assert poll.SIGNALS["civitai"] == 14
+    assert 14 not in {poll.SIGNALS["clawgate"], poll.SIGNALS["mail"],
+                      poll.SIGNALS["alerts"]}
+
+
+def test_civitai_parses_same_severity_filter_as_alerts():
+    # civitai reuses parse_alerts, so warn|critical count + Critical state hold.
+    alerts = [
+        _alert("KubeJobFailed", "critical"),
+        _alert("CPUThrottlingHigh", "warning"),
+        _alert("Watchdog", "none"),          # excluded (housekeeping)
+        _alert("InfoInhibitor", "none"),     # excluded (housekeeping)
+        _alert("SomeInfo", "info"),          # excluded (severity)
+    ]
+    out = poll.parse_alerts(alerts)
+    assert out["count"] == 2 and out["state"] == "Critical"
+
+
+def test_civitai_fetch_stale_when_kubeconfig_missing(monkeypatch):
+    # Missing client kubeconfig -> stale (never spawns kubectl, never crashes).
+    monkeypatch.setattr(poll, "CIVITAI_KUBECONFIG", "/no/such/kubeconfig")
+    out = poll.source("civitai", poll.fetch_civitai)
+    assert out["state"] == "stale" and out["count"] == 0
+    assert out["source"] == "civitai"
+
+
+def test_mock_run_writes_civitai(tmp_path, monkeypatch):
+    monkeypatch.setenv("BAR_STATUS_DIR", str(tmp_path))
+    monkeypatch.setattr(poll, "signal_bar", lambda name: None)
+    alerts_f = tmp_path / "civ.json"
+    alerts_f.write_text(json.dumps([
+        _alert("KubeJobFailed", "critical"),
+        _alert("CPUThrottlingHigh", "warning"),
+    ]))
+    rc = poll.main(["--mock-civitai", str(alerts_f)])
+    assert rc == 0
+    civ = json.loads((tmp_path / "civitai.json").read_text())
+    assert civ["count"] == 2 and civ["state"] == "Critical"
+    assert civ["source"] == "civitai"
+
+
+def test_mock_run_malformed_civitai_writes_stale(tmp_path, monkeypatch):
+    monkeypatch.setenv("BAR_STATUS_DIR", str(tmp_path))
+    monkeypatch.setattr(poll, "signal_bar", lambda name: None)
+    bad = tmp_path / "bad.json"
+    bad.write_text('{"not":"a list"}')
+    rc = poll.main(["--mock-civitai", str(bad)])
+    assert rc == 0
+    civ = json.loads((tmp_path / "civitai.json").read_text())
+    assert civ["state"] == "stale" and civ["count"] == 0
+
+
+# --------------------------------------------------------------------------- #
 # poller: source() fail-safe wrapper turns any exception into a stale marker
 # --------------------------------------------------------------------------- #
 def test_source_wraps_exception_as_stale():
@@ -209,7 +268,14 @@ BLOCKS = [
     ("clawgate", clawgate_block, "tasks", "Warning"),
     ("mail", mail_block, "mail", "Warning"),
     ("alerts", alerts_block, "bell", "Critical"),
+    ("civitai", civitai_block, "bell", "Critical"),
 ]
+
+
+def _expected_text(mod, count):
+    # i3status-civitai prefixes the count with its `civ` LABEL; the others don't.
+    label = getattr(mod, "LABEL", None)
+    return ("%s %d" % (label, count)) if label else str(count)
 
 
 @pytest.mark.parametrize("name,mod,icon,default_state", BLOCKS)
@@ -222,9 +288,20 @@ def test_block_hides_at_zero(name, mod, icon, default_state):
 @pytest.mark.parametrize("name,mod,icon,default_state", BLOCKS)
 def test_block_visible_and_coloured_when_positive(name, mod, icon, default_state):
     out = mod.render({"count": 3, "state": default_state})
+    exp = _expected_text(mod, 3)
     assert out["icon"] == icon
-    assert out["text"] == "3" and out["short_text"] == "3"
+    assert out["text"] == exp and out["short_text"] == exp
     assert out["state"] == default_state
+
+
+def test_civitai_block_labels_count_distinctly():
+    # The civitai block must be visually distinguishable from homelab alerts:
+    # its text carries the `civ` label prefix, alerts' does not.
+    civ = civitai_block.render({"count": 317, "state": "Critical"})
+    hl = alerts_block.render({"count": 317, "state": "Critical"})
+    assert civ["text"] == "civ 317" and civ["state"] == "Critical"
+    assert hl["text"] == "317"
+    assert civ["text"] != hl["text"]
 
 
 @pytest.mark.parametrize("name,mod,icon,default_state", BLOCKS)
@@ -261,6 +338,7 @@ def test_block_defaults_state_when_missing_or_idle(name, mod, icon, default_stat
     ("i3status-clawgate", "clawgate.json"),
     ("i3status-mail", "mail.json"),
     ("i3status-alerts", "alerts.json"),
+    ("i3status-civitai", "civitai.json"),
 ])
 def test_block_subprocess_missing_file_is_invisible(tmp_path, script, cachefile):
     env = dict(os.environ, BAR_STATUS_DIR=str(tmp_path))
@@ -270,12 +348,13 @@ def test_block_subprocess_missing_file_is_invisible(tmp_path, script, cachefile)
     assert json.loads(r.stdout) == {"text": "", "state": "Idle"}
 
 
-@pytest.mark.parametrize("script,cachefile,icon", [
-    ("i3status-clawgate", "clawgate.json", "tasks"),
-    ("i3status-mail", "mail.json", "mail"),
-    ("i3status-alerts", "alerts.json", "bell"),
+@pytest.mark.parametrize("script,cachefile,icon,text", [
+    ("i3status-clawgate", "clawgate.json", "tasks", "2"),
+    ("i3status-mail", "mail.json", "mail", "2"),
+    ("i3status-alerts", "alerts.json", "bell", "2"),
+    ("i3status-civitai", "civitai.json", "bell", "civ 2"),
 ])
-def test_block_subprocess_positive_renders(tmp_path, script, cachefile, icon):
+def test_block_subprocess_positive_renders(tmp_path, script, cachefile, icon, text):
     (tmp_path / cachefile).write_text(json.dumps(
         {"count": 2, "state": "Warning", "detail": "x"}))
     env = dict(os.environ, BAR_STATUS_DIR=str(tmp_path))
@@ -283,13 +362,14 @@ def test_block_subprocess_positive_renders(tmp_path, script, cachefile, icon):
                        capture_output=True, text=True, env=env)
     assert r.returncode == 0
     out = json.loads(r.stdout)
-    assert out["icon"] == icon and out["text"] == "2"
+    assert out["icon"] == icon and out["text"] == text
 
 
 @pytest.mark.parametrize("script,cachefile", [
     ("i3status-clawgate", "clawgate.json"),
     ("i3status-mail", "mail.json"),
     ("i3status-alerts", "alerts.json"),
+    ("i3status-civitai", "civitai.json"),
 ])
 def test_block_subprocess_corrupt_json_is_invisible(tmp_path, script, cachefile):
     (tmp_path / cachefile).write_text("{ this is not json ")


### PR DESCRIPTION
## What

Adds a **separate** "civitai prod alerts" count block to the workbench i3status-rust bar, mirroring the just-merged homelab alerts source but kept as its own block/count (per request) so a large standing client-prod number never swamps the homelab one.

- **`scripts/bar-status-poll`** — new `civitai` source (`fetch_civitai`): the SAME `warning|critical` severity filter (excludes `Watchdog`/`InfoInhibitor`, active-only) as the homelab `alerts` source, but port-forwards to the **civitai DataPacket prod** Alertmanager (`monitoring/kube-prometheus-stack-alertmanager:9093`) through a new **`CIVITAI_KUBECONFIG`** env (default `~/workspace/civit/datapacket-talos/prod-kubeconfig`) — NOT the poller's homelab `KUBECONFIG`. Reuses `_pf_alerts`, which binds a fresh **free** local port and terminates the forward in a `finally` every call (no port collision, no leak). New realtime signal **14**. Fully fail-safe: missing kubeconfig / unreachable cluster → `stale` marker → block renders empty, never crashes the poller.
- **`scripts/i3status-civitai`** — new block script cloned from `i3status-alerts`, reads `~/.cache/bar-status/civitai.json`. Renders **`civ <count>`** (label prefix) so it is visually distinct from the homelab alerts block at a glance. Hide-at-zero, red (Critical) when >0.
- **`nix/graphical.nix`** — `civitaiBlock` (workbench-only, `signal = 14`, click → `xdg-open https://grafana-new.civitai.com`), placed right after the homelab `alertsBlock`; `CIVITAI_KUBECONFIG` added to the `bar-status-poll` service `Environment`; the `i3status-civitai` symlink `lib.mkIf (!isLaptop)` like the other three.
- **`scripts/tests/test_bar_status.py`** — civitai coverage: severity/count parse, distinct signal (14 ≠ 11/12/13), missing-kubeconfig → stale (no kubectl spawned), mock-run cache write + malformed → stale, `civ` label distinctness vs homelab, and subprocess render (hide-at-zero / positive / corrupt-json).

## ⚠ Standing client-prod access (by design)

This wires the workbench poller to **continuously port-forward into a CLIENT prod cluster (civitai DataPacket prod) every ~45s**. It reads only `GET /api/v2/alerts` (read-only), the forward is bounded and torn down every cycle, and the whole source is fail-safe + gated by the `TimeoutStartSec=90` cgroup kill. It uses Zach's existing admin kubeconfig — same trust level as the homelab alerts source already in the bar — but it is worth calling out explicitly since it is client infrastructure and the count sits red on the bar continuously.

## Verification

**Unit-tested (offline, mocked):** 60/60 pass — `nix-shell -p python312Packages.pytest python312Packages.psycopg2 --run "python3 -m pytest scripts/tests/test_bar_status.py -q"`. Covers parse/severity, hide-at-zero, fail-safe (stale/error/malformed/missing), the `civ` label, distinct signal.

**Verified live against the real civitai Alertmanager (workbench):**
- `home-manager build` + `switch` clean (switch auto-restarted `bar-status-poll.service` via X-Restart-Triggers).
- Poller wrote `~/.cache/bar-status/civitai.json` = `{"count": 314, "state": "Critical", "detail": "314 firing (64 critical)", ...}`, perms `0600`, timer `active`. Independent direct Alertmanager query at the same moment: 316 firing / 64 crit — matches within normal live churn (±2 over a few minutes; critical count exact).
- Standalone `i3status-rs config-top.toml` emits the block (`civ 319`); live bar renders **`⚠ 23`** (homelab) and **`⚠ civ 320`** (civitai) side by side, both red, distinguishable via the `civ` label. Reloaded with `pkill -SIGUSR2 i3status-rs`.
- **No port-forward leaks**: after multiple poll cycles, `pgrep kubectl port-forward` shows only Zach's pre-existing forwards (prometheus/grafana/flipt) — none to alertmanager, none on the poller's ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)