### PR TITLE
feat(bar): red-above threshold on alert blocks (neutral at standing backlog)

### DIFF
--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -128,7 +128,9 @@ let
   # i3status-rs` to refresh exactly this block the instant it writes.
   alertsBlock = {
     block = "custom";
-    command = "${scriptsDir}/i3status-alerts";
+    # --red-above: neutral at/below the standing homelab backlog (~23), red only
+    # when the firing count climbs ABOVE it (something new). Tune as the baseline drifts.
+    command = "${scriptsDir}/i3status-alerts --red-above 30";
     json = true;
     interval = 30;
     signal = 13;
@@ -142,7 +144,9 @@ let
   # Click opens the civitai Grafana.
   civitaiBlock = {
     block = "custom";
-    command = "${scriptsDir}/i3status-civitai";
+    # --red-above: neutral at/below the standing civitai-prod backlog (~312), red
+    # only above it. Big client cluster, so the baseline is high; tune as it drifts.
+    command = "${scriptsDir}/i3status-civitai --red-above 340";
     json = true;
     interval = 30;
     signal = 14;

--- a/scripts/i3status-alerts
+++ b/scripts/i3status-alerts
@@ -36,11 +36,15 @@ def load(path):
         return None
 
 
-def render(payload, icon: str = ICON) -> dict:
+def render(payload, icon: str = ICON, red_above: int = 0) -> dict:
     """Pure: cache payload (or None) -> i3status-rust block dict.
 
     Hide-at-zero + fail-safe: None / malformed / stale / error / count<=0 all
     map to the empty (invisible) block — never a crash.
+
+    red_above: the standing-backlog baseline. count <= red_above shows the count
+    but NEUTRAL (no colour); red is reserved for the count climbing ABOVE the
+    known backlog (i.e. something new firing). red_above=0 => colour whenever >0.
     """
     if not isinstance(payload, dict):
         return dict(_EMPTY)
@@ -52,15 +56,30 @@ def render(payload, icon: str = ICON) -> dict:
         return dict(_EMPTY)
     if count <= 0:
         return dict(_EMPTY)
-    state = payload.get("state")
-    if state not in _VALID_STATES or state == "Idle":
-        state = "Critical"
+    if count <= red_above:
+        state = "Idle"
+    else:
+        state = payload.get("state")
+        if state not in _VALID_STATES or state == "Idle":
+            state = "Critical"
     return {"icon": icon, "text": str(count),
             "short_text": str(count), "state": state}
 
 
+def _red_above_arg() -> int:
+    """Parse `--red-above N` from argv (default 0 = colour whenever count>0)."""
+    argv = sys.argv[1:]
+    if "--red-above" in argv:
+        try:
+            return int(argv[argv.index("--red-above") + 1])
+        except (IndexError, ValueError):
+            return 0
+    return 0
+
+
 def main() -> int:
-    sys.stdout.write(json.dumps(render(load(cache_path()))) + "\n")
+    sys.stdout.write(
+        json.dumps(render(load(cache_path()), red_above=_red_above_arg())) + "\n")
     return 0
 
 

--- a/scripts/i3status-civitai
+++ b/scripts/i3status-civitai
@@ -41,12 +41,16 @@ def load(path):
         return None
 
 
-def render(payload, icon: str = ICON) -> dict:
+def render(payload, icon: str = ICON, red_above: int = 0) -> dict:
     """Pure: cache payload (or None) -> i3status-rust block dict.
 
     Hide-at-zero + fail-safe: None / malformed / stale / error / count<=0 all
     map to the empty (invisible) block — never a crash. Visible text carries a
     `civ ` label prefix so it reads distinctly from the homelab alerts block.
+
+    red_above: the standing-backlog baseline. count <= red_above shows the count
+    but NEUTRAL (no colour); red is reserved for the count climbing ABOVE the
+    known backlog. red_above=0 => colour whenever >0.
     """
     if not isinstance(payload, dict):
         return dict(_EMPTY)
@@ -58,16 +62,31 @@ def render(payload, icon: str = ICON) -> dict:
         return dict(_EMPTY)
     if count <= 0:
         return dict(_EMPTY)
-    state = payload.get("state")
-    if state not in _VALID_STATES or state == "Idle":
-        state = "Critical"
+    if count <= red_above:
+        state = "Idle"
+    else:
+        state = payload.get("state")
+        if state not in _VALID_STATES or state == "Idle":
+            state = "Critical"
     text = "%s %d" % (LABEL, count)
     return {"icon": icon, "text": text,
             "short_text": text, "state": state}
 
 
+def _red_above_arg() -> int:
+    """Parse `--red-above N` from argv (default 0 = colour whenever count>0)."""
+    argv = sys.argv[1:]
+    if "--red-above" in argv:
+        try:
+            return int(argv[argv.index("--red-above") + 1])
+        except (IndexError, ValueError):
+            return 0
+    return 0
+
+
 def main() -> int:
-    sys.stdout.write(json.dumps(render(load(cache_path()))) + "\n")
+    sys.stdout.write(
+        json.dumps(render(load(cache_path()), red_above=_red_above_arg())) + "\n")
     return 0
 
 

--- a/scripts/tests/test_bar_status.py
+++ b/scripts/tests/test_bar_status.py
@@ -304,6 +304,47 @@ def test_civitai_block_labels_count_distinctly():
     assert civ["text"] != hl["text"]
 
 
+# red_above threshold — neutral at/below the standing backlog, red only above it.
+ALERT_BLOCKS = [("alerts", alerts_block), ("civitai", civitai_block)]
+
+
+@pytest.mark.parametrize("name,mod", ALERT_BLOCKS)
+def test_red_above_neutral_at_or_below_baseline(name, mod):
+    for count in (25, 30):  # <= red_above=30
+        out = mod.render({"count": count, "state": "Critical"}, red_above=30)
+        assert out["state"] == "Idle"          # visible but NOT coloured
+        assert out["icon"] == "bell"           # still shown (not hidden)
+        assert str(count) in out["text"]
+
+
+@pytest.mark.parametrize("name,mod", ALERT_BLOCKS)
+def test_red_above_colours_when_over_baseline(name, mod):
+    out = mod.render({"count": 31, "state": "Critical"}, red_above=30)
+    assert out["state"] == "Critical"          # above the baseline -> red
+
+
+@pytest.mark.parametrize("name,mod", ALERT_BLOCKS)
+def test_red_above_zero_is_backward_compatible(name, mod):
+    # default (no threshold) still colours whenever count > 0
+    assert mod.render({"count": 1, "state": "Critical"})["state"] == "Critical"
+
+
+@pytest.mark.parametrize("name,mod", ALERT_BLOCKS)
+def test_red_above_still_hides_at_zero(name, mod):
+    assert mod.render({"count": 0, "state": "Idle"}, red_above=30) == \
+        {"text": "", "state": "Idle"}
+
+
+@pytest.mark.parametrize("name,mod", ALERT_BLOCKS)
+def test_red_above_arg_parsing(name, mod, monkeypatch):
+    monkeypatch.setattr(sys, "argv", [name, "--red-above", "42"])
+    assert mod._red_above_arg() == 42
+    monkeypatch.setattr(sys, "argv", [name])            # absent -> 0
+    assert mod._red_above_arg() == 0
+    monkeypatch.setattr(sys, "argv", [name, "--red-above", "nan"])  # junk -> 0
+    assert mod._red_above_arg() == 0
+
+
 @pytest.mark.parametrize("name,mod,icon,default_state", BLOCKS)
 def test_block_stale_is_invisible(name, mod, icon, default_state):
     assert mod.render({"count": 5, "state": "stale"}) == {"text": "", "state": "Idle"}


### PR DESCRIPTION
The homelab (~23) and civitai-prod (~312) alert pills were permanently red — "red = attention" became wallpaper. Adds `--red-above N` to the alert block scripts: **count ≤ N → neutral (count still shown); count > N → red**. Set homelab `--red-above 30`, civitai `--red-above 340` (just above current baselines), so a pill only reddens when something NEW fires above the known backlog. Default `--red-above 0` preserves old behaviour.

**Verified live:** both pills now neutral (`🔔 23`, `🔔 civ 313`). **70/70 tests** (added threshold + arg-parse coverage). Thresholds are one-line-tunable in `nix/graphical.nix` as the baselines drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)