### PR TITLE
feat(bar): GPU icon → expansion_card (was a monitor glyph)

### DIFF
--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -211,7 +211,14 @@ lib.mkIf isNixOS {
       theme = "gruvbox-dark";
       # JetBrainsMono Nerd Font (declared below) provides the glyphs, so use the
       # Material-Design nerd-font icon set + the theme's default powerline separators.
-      icons = "material-nf";
+      # Icon set in TABLE form (not the `icons = "..."` shortcut) so we can override
+      # a single icon — the shortcut + an [icons.overrides] table conflict and drop
+      # ALL icons back to text. material-nf maps `gpu` to nf-md-monitor (a display);
+      # the RTX 5080 is not a monitor → nf-md-expansion_card (a graphics card).
+      settings.icons = {
+        icons = "material-nf";
+        overrides.gpu = "󰢮";
+      };
       inherit blocks;
     };
   };


### PR DESCRIPTION
The `nvidia_gpu` block's icon in material-nf is nf-md-monitor (a *display*) — wrong for the RTX 5080. Override `gpu` → nf-md-expansion_card (a graphics card).

Note: the icon set had to move from the `icons = "material-nf"` shortcut to the `[icons]` **table form** — the shortcut plus an `[icons.overrides]` table conflict and silently drop **all** icons to text labels (caught live).

**Verified live:** icons intact, GPU block renders the card glyph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)