### PR TITLE
feat(espanso): remove dead :whn + sync usage miner

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -64,7 +64,8 @@ in
           { trigger = "reocmmend"; replace = "recommend"; }
 
           # Workflows
-          { trigger = ":whn"; replace = "write the handoff to continue in next session"; label = "Write handoff for next session"; search_terms = ["handoff" "session"]; }
+          # (:whn removed 2026-07-06 — 0 fires over the audit window, superseded by
+          #  /handoff + :eos which ends "…then write the handoff to proceed in next session")
           { trigger = ":eos"; replace = "review work done this session and identify skills that may need updating, then update those skills and any relevant docs, then write the handoff to proceed in next session"; label = "End-of-session ritual: review → update skills/docs → handoff"; search_terms = ["end" "session" "wrap" "handoff" "skills" "review" "update" "docs" "ritual"]; }
           { trigger = ":acq"; replace = "ask me clarifying questions and recommend anything you think would be useful to include"; label = "Ask clarifying questions + recommend additions"; search_terms = ["ask" "clarify" "clarifying" "questions" "recommend" "elicit" "scope" "include"]; }
           { trigger = ":rns"; replace = "recommend next steps"; label = "Recommend next steps"; search_terms = ["next" "recommend" "steps" "whats next"]; }

--- a/scripts/session-analysis/espanso-usage.py
+++ b/scripts/session-analysis/espanso-usage.py
@@ -51,9 +51,12 @@ SNIPPETS = {
     ":cpk":   ("path", ["datapacket-talos/prod-kubeconfig"], [], False),
     ":subk":  ("path", ["submodel-dc-03-a-kubeconfig"], [], False),
     # workflow prompts (current expansions)
-    ":whn":     ("prompt", ["write the handoff to continue in next session"], [], False),
-    ":rau":     ("prompt", ["adversarially audit the pr for bugs"], [], False),
-    ":aep":     ("prompt", ["adversarially audit each pr"], [], False),
+    # :whn removed 2026-07-06 (dead + superseded by /handoff + :eos).
+    ":eos":     ("prompt", ["identify skills that may need updating"], [], False),
+    ":acq":     ("prompt", ["recommend anything you think would be useful to include"], [], False),
+    # :aep expansion starts "dispatch subagent to adversarially audit the PR for
+    # bugs, regressions, edge cases, race conditions…" — match a distinctive tail.
+    ":aep":     ("prompt", ["regressions, edge cases, race conditions"], [], False),
     ":rns":     ("prompt", ["recommend next steps"], ["ranked by leverage"], True),
     ":rnx":     ("prompt", ["recommend next steps ranked by leverage"], [], False),
     # NOTE: PR (espanso-shorten-unfired-snippets, 2026-06-30) reverted these to


### PR DESCRIPTION
## What

Espanso snippet usage audit (`/espanso-audit`, window `--since 2026-06-30`, both hosts summed).

**Config change — remove `:whn`:** fired **0×** on either host over the window, with **no hand-typed demand** in the transcript data. It's superseded by the `/handoff` slash command and `:eos` (**46 fires**), whose expansion ends "…then write the handoff to proceed in next session". Clean dead+redundant removal.

**Miner re-sync** (`scripts/session-analysis/espanso-usage.py`) — the `SNIPPETS` detection dict had drifted from the live config:
- **add `:eos` / `:acq`** — added 2026-06-30, never mirrored into the miner (they're the audit's two new *wins*: 46 and 36 fires)
- **fix stale `:aep` substring** — miner looked for `"adversarially audit each pr"`, but the live expansion says `"…adversarially audit the PR for bugs, regressions, edge cases, race conditions…"`; it was silently reading **0**. Now matches the real tail.
- **drop `:rau`** — removed trigger whose substring is now a substring of `:aep`'s expansion (would double-count)

## Kept (for the record)
- All path snippets — high use, untouched.
- `:mdc` (0 fires vs 16 hand-typed "merged and deployed") and `:wn` (1 fire vs 17 hand-typed "whats next") left on the watch-list — failed transfer, but harmless; revisit next audit.

## Validation
- `nix-instantiate --parse nix/home.nix` → OK
- No trigger is a prefix of another (pre-existing `:date`/`:datetime` overlap is espanso-longest-match safe)
- Post-merge: `scripts/ship.sh` to converge both hosts; final keystroke-expansion check is manual on the laptop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)