### PR TITLE
fix(espanso,dunst): un-gate from serverMode — enable on the graphical workbench

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -3,10 +3,17 @@
 let
   home = config.home.homeDirectory;
   workspace = "${home}/workspace";
-  # Headless/server mode: `touch ~/.server-mode` to disable graphical-session
-  # services (dunst, espanso) that can't start without X/i3 and otherwise make
-  # every `home-manager switch` report "degraded / Failed services".
+  # Server mode: `touch ~/.server-mode`. Historically this ALSO gated the graphical
+  # services (dunst, espanso) off — but the workbench carries the marker to enable
+  # its server-side tasks (mail-actions-archive, repo-cos) while STILL running a full
+  # X/i3 desktop, so gating the desktop bits on serverMode wrongly disabled them
+  # there (same trap the i3 bar hit — see graphical.nix). serverMode now gates ONLY
+  # server-side task enablement; graphical services key off `graphical` below.
   serverMode = builtins.pathExists "${home}/.server-mode";
+  # Graphical host = runs X/i3 (both current NixOS hosts do; only a genuinely headless
+  # box would not). Approximated as isNixOS, mirroring graphical.nix — deliberately NOT
+  # !serverMode, which is true on the graphical workbench.
+  graphical = isNixOS;
   # Host discriminator for the graphical config (i3 + i3status-rust bar). Evaluated
   # per-host under `--impure`: the laptop has an intel_backlight, the workbench does
   # not. Threaded into ./graphical.nix via _module.args below. Drives battery/backlight
@@ -32,7 +39,7 @@ in
 
   # Espanso text expander service (X11/i3)
   services.espanso = {
-    enable = !serverMode;
+    enable = graphical;
     package = pkgs.espanso;
     x11Support = true;
     waylandSupport = false;
@@ -107,7 +114,7 @@ in
 
   # Notification daemon (Gruvbox-themed)
   services.dunst = {
-    enable = !serverMode;
+    enable = graphical;
     settings = {
       global = {
         font = "Monospace 10";


### PR DESCRIPTION
## Symptom
`ctrl+space` did nothing on the **workbench** — espanso wasn't installed there at all (binary not in PATH, no systemd unit, only `packages/` rendered).

## Root cause
`serverMode` (the `~/.server-mode` marker) was doing two contradictory jobs on the workbench:
- gating graphical services **off** — `espanso`/`dunst` had `enable = !serverMode`, premised on "server mode ⇒ no X/i3";
- gating workbench server tasks **on** — `mail-actions-archive` + `repo-cos` are `mkIf serverMode`.

But the workbench **runs a full X/i3 desktop** (`DISPLAY=:0`, i3 up). So the marker must stay (or the mail-archiver/repo-cos gates silently break), yet keeping it wrongly disabled espanso. The i3 bar already escaped this exact trap (`graphical.nix` un-gates from serverMode); espanso/dunst never did.

## Fix
Add a `graphical` predicate (`= isNixOS`, the same graphical proxy `graphical.nix` uses) and key `espanso`/`dunst` off it instead of `!serverMode`. `serverMode` now gates **only** server-side task enablement — the mail-archive/repo-cos gates are untouched.

`rm ~/.server-mode` was explicitly rejected as the fix: it would silently disable `mail-actions-archive` + `repo-cos` (both `mkIf serverMode`).

## Verified on the workbench
`home-manager switch --flake . --impure` →
- `espanso.service` + `dunst` **active**; `espanso status` = "espanso is running"
- espanso in PATH; `base.yml` renders all 32 triggers; `default.yml` carries `search_shortcut: CTRL+SPACE`
- `nix-instantiate --parse` OK

Laptop is unaffected (it had no marker, so `!serverMode` was already true → same as `graphical`).

**Not machine-verifiable:** the actual `ctrl+space` keystroke → search popup, and a live trigger expansion — for Zach to confirm interactively on the workbench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)