### PR TITLE
feat(dunst): harden notifications + edge-triggered toasts from bar-status-poll

### DIFF
--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -174,6 +174,18 @@ let
       { button = "left"; cmd = "xdg-open http://192.168.50.250:30302"; }
     ];
   };
+  # DND indicator (workbench only): a small muted glyph that appears ONLY while
+  # dunst is paused (quiet mode), hidden otherwise — same calm hide-at-zero idea
+  # as the count blocks. Reads `dunstctl is-paused` (instant, local). signal 15
+  # is sent by the `$mod+Shift+n` toggle for instant feedback; the short interval
+  # is a backstop.
+  dndBlock = {
+    block = "custom";
+    command = "${scriptsDir}/i3status-dnd";
+    json = true;
+    interval = 5;
+    signal = 15;
+  };
   timeBlock = {
     block = "time";
     interval = 10;
@@ -200,7 +212,7 @@ let
     ++ lib.optional (!isLaptop) gpuBlock
     ++ lib.optional isLaptop batteryBlock
     ++ [ soundBlock ]
-    ++ lib.optionals (!isLaptop) [ alertsBlock civitaiBlock mailBlock clawgateBlock ]
+    ++ lib.optionals (!isLaptop) [ alertsBlock civitaiBlock mailBlock clawgateBlock dndBlock ]
     ++ [ vpnBlock timeBlock ]
     ++ lib.optional (!isLaptop) rigcontrolBlock;
 in
@@ -275,6 +287,10 @@ lib.mkIf isNixOS {
     source = ../scripts/i3status-civitai;
     executable = true;
   };
+  home.file.".config/i3status-rust/scripts/i3status-dnd" = lib.mkIf (!isLaptop) {
+    source = ../scripts/i3status-dnd;
+    executable = true;
+  };
 
   # bar-status poller — WORKBENCH ONLY (!isLaptop). Every ~45s it queries clawgate
   # (pending Tasks), the homelab Postgres (open mail_actions), and Alertmanager
@@ -303,7 +319,12 @@ lib.mkIf isNixOS {
       # TimeoutStartSec=infinity and OnUnitActiveSec only re-fires once inactive.
       TimeoutStartSec = 90;
       Environment = [
-        "PATH=${lib.makeBinPath [ pollPyEnv pkgs.kubectl pkgs.procps pkgs.coreutils ]}"
+        # systemd -> systemd-run, which launches the edge-toast as a DETACHED
+        # transient --user service so a clickable dunstify outlives this oneshot's
+        # cgroup teardown. procps -> pgrep (borrow DISPLAY/DBUS from i3 for the
+        # toast). bash/dunstify/xdg-open resolve from the user-manager PATH inside
+        # that transient unit, so they need not be on the poller's own PATH.
+        "PATH=${lib.makeBinPath [ pollPyEnv pkgs.kubectl pkgs.procps pkgs.coreutils pkgs.systemd ]}"
         "KUBECONFIG=%h/workspace/homelab-talos/homelab-kubeconfig"
         # civitai (CLIENT) prod cluster kubeconfig — the civitai alerts source
         # port-forwards through THIS, never the homelab KUBECONFIG above.

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -112,31 +112,61 @@ in
   #   vSync = true;
   # };
 
-  # Notification daemon (Gruvbox-themed)
+  # Notification daemon (Gruvbox-themed, CALM). Value formats verified parse-clean
+  # against dunst 1.13.2 (the running version): `width`/`offset` take a paren-tuple
+  # `(min, max)` / `(x, y)` (v1.11- used NxN); the home-manager module quotes string
+  # values, and dunst strips those quotes before enum/tuple parsing (confirmed via a
+  # control reload that DID warn on a bogus value but not on these). After a switch,
+  # re-inspect ~/.config/dunst/dunstrc + `journalctl --user -u dunst` for warnings.
   services.dunst = {
     enable = graphical;
     settings = {
       global = {
-        font = "Monospace 10";
+        # Match the i3 bar font so nerd-font glyphs in notification bodies render.
+        font = "JetBrainsMono Nerd Font 10";
         frame_color = "#504945";
         separator_color = "frame";
         corner_radius = 4;
+        # Placement: top-right, offset down far enough to clear the ~24-34px top bar.
+        origin = "top-right";
+        offset = "(12, 40)";
+        # Bounded, content-sized width (grows to 420px max, never wider).
+        width = "(0, 420)";
+        # Cap the visible stack + keep a recall buffer (dunstctl history-pop).
+        notification_limit = 4;
+        history_length = 40;
+        stack_duplicates = true;      # collapse repeats into one with a counter
+        show_indicators = false;      # no "(x more)" / action hints — calmer
+        # Mouse: left dismisses the current toast, middle fires its action then
+        # dismisses, right opens the dunst context menu.
+        mouse_left_click = "close_current";
+        mouse_middle_click = "do_action, close_current";
+        mouse_right_click = "context";
       };
       urgency_low = {
         background = "#282828";
         foreground = "#ebdbb2";
+        frame_color = "#504945";
         timeout = 5;
       };
       urgency_normal = {
         background = "#282828";
         foreground = "#ebdbb2";
-        frame_color = "#83a598";
+        frame_color = "#83a598";      # gruvbox blue accent
         timeout = 10;
       };
       urgency_critical = {
-        background = "#cc241d";
+        background = "#cc241d";        # gruvbox red bg
         foreground = "#ebdbb2";
-        timeout = 0;
+        frame_color = "#fb4934";       # bright-red frame
+        timeout = 0;                   # sticky until dismissed
+      };
+      # Native fullscreen DND: a filterless rule matches all notifications and,
+      # while any window is fullscreen (video/games/screen-share), hides the
+      # visible stack + holds new toasts, re-showing them once fullscreen ends.
+      # The biggest calm win — no helper needed, dunst does this itself.
+      fullscreen_pushback = {
+        fullscreen = "pushback";
       };
     };
   };

--- a/nix/i3/config.nix
+++ b/nix/i3/config.nix
@@ -189,6 +189,11 @@ bindsym $mod+Tab workspace back_and_forth
 # Scratchpad
 bindsym $mod+minus move scratchpad
 
+# Notifications (dunst). dunstctl ships with the dunst package on PATH.
+bindsym $mod+n exec --no-startup-id dunstctl history-pop            # recall last dismissed
+bindsym $mod+Shift+n exec --no-startup-id dunstctl set-paused toggle && pkill -RTMIN+15 i3status-rs # manual DND (quiet mode) + refresh the DND bar block
+bindsym $mod+grave exec --no-startup-id dunstctl close-all          # clear the whole stack
+
 # Thin borders
 default_border pixel 2
 ''

--- a/scripts/bar-status-poll
+++ b/scripts/bar-status-poll
@@ -161,6 +161,174 @@ def stale(reason: str, err=None) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Edge-triggered desktop toasts (the calm-bar complement)
+# ---------------------------------------------------------------------------
+# The count blocks show STEADY STATE silently; a toast fires exactly ONCE on the
+# RISING EDGE (something NEW crosses the line), then stays quiet until it drops
+# back and crosses again. This poller is a systemd *oneshot* — nothing survives
+# in memory between runs — so the per-source latch is persisted to a sidecar file
+# (~/.cache/bar-status/<src>.toast-state). Thresholds match the block's
+# --red-above in graphical.nix (homelab 30 / civitai 340), env-tunable so the two
+# never drift. clawgate/mail use threshold 0 (the 0 -> >0 rule). Complements
+# clawgate's mobile push: push = away from desk, toast = at the desk.
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def edge_decision(latched: bool, count: int, threshold: int):
+    """Pure rising-edge latch → (should_toast, new_latched).
+
+    Fires once when `count` crosses strictly ABOVE `threshold` while the latch is
+    clear; stays quiet while it remains above (already latched — never re-toasts
+    steady state); clears the latch once `count` falls back to/below `threshold`
+    so the NEXT crossing can re-fire. threshold=0 gives the 0 -> >0 rule.
+    """
+    if count > threshold:
+        return (not latched), True
+    return False, False
+
+
+def _latch_path(name: str) -> str:
+    return os.path.join(cache_dir(), name + ".toast-state")
+
+
+def read_latch(name: str) -> bool:
+    """Persisted per-source latch; any error (missing/corrupt) -> False."""
+    try:
+        with open(_latch_path(name)) as f:
+            return bool(json.load(f).get("latched"))
+    except Exception:
+        return False
+
+
+def write_latch(name: str, latched: bool) -> None:
+    """Persist the latch (best-effort, atomic); never raises."""
+    try:
+        d = cache_dir()
+        os.makedirs(d, exist_ok=True)
+        path = _latch_path(name)
+        tmp = path + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump({"latched": bool(latched)}, f)
+        os.replace(tmp, path)
+    except Exception:
+        pass
+
+
+def _borrow_desktop_env(env: dict) -> dict:
+    """Fill DISPLAY/DBUS_SESSION_BUS_ADDRESS/XAUTHORITY from a running i3's
+    /proc/<pid>/environ when this (systemd) context lacks them — the same trick
+    scripts/cpu-monitor.sh uses so notifications reach the desktop from a headless
+    service context. Best-effort; returns the (possibly augmented) env dict."""
+    need = [k for k in ("DISPLAY", "DBUS_SESSION_BUS_ADDRESS", "XAUTHORITY")
+            if not env.get(k)]
+    if not need:
+        return env
+    try:
+        r = subprocess.run(["pgrep", "-u", str(os.getuid()), "-x", "i3"],
+                           stdout=subprocess.PIPE, timeout=3)
+        pids = r.stdout.decode().split()
+        if not pids:
+            return env
+        with open("/proc/%s/environ" % pids[0], "rb") as f:
+            raw = f.read().decode("utf-8", "replace")
+        for kv in raw.split("\0"):
+            k, sep, v = kv.partition("=")
+            if sep and k in need and v:
+                env[k] = v
+    except Exception:
+        pass
+    return env
+
+
+def fire_toast(urgency, summary, body, action_cmd=None, runner=None) -> bool:
+    """Best-effort edge toast. Launches dunstify inside a DETACHED transient
+    --user service (systemd-run) so it OUTLIVES this oneshot poller's cgroup
+    teardown — systemd kills the poller's cgroup on exit, and a plain child
+    dunstify (which blocks on -A waiting for the click) would die with it. With
+    action_cmd the toast carries a clickable 'Open' action that runs it (verified:
+    dunstctl action / middle-click -> the action key -> the command). Reaches the
+    desktop over the session bus, borrowing DISPLAY/DBUS from i3 if this context
+    lacks them. Returns True if dispatched, False if skipped (no session bus, e.g.
+    headless/laptop). FAIL-SAFE: never raises, never slows the poll."""
+    try:
+        env = _borrow_desktop_env(dict(os.environ))
+        if not env.get("DBUS_SESSION_BUS_ADDRESS"):
+            return False  # no reachable session bus -> silently skip
+        script = 'a=$(dunstify -a bar-status -u "$1"%s "$2" "$3")' % (
+            " -A open,Open" if action_cmd else "")
+        if action_cmd:
+            script += '; [ "$a" = open ] && sh -c "$4"'
+        argv = ["systemd-run", "--user", "--collect", "--quiet"]
+        for k in ("DISPLAY", "DBUS_SESSION_BUS_ADDRESS", "XAUTHORITY"):
+            if env.get(k):
+                argv.append("--setenv=%s=%s" % (k, env[k]))
+        argv += ["bash", "-c", script, "bar-status", urgency, summary, body]
+        if action_cmd:
+            argv.append(action_cmd)
+        run = runner or (lambda a: subprocess.run(
+            a, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=6))
+        run(argv)
+        return True
+    except Exception:
+        return False
+
+
+def _toast_specs() -> dict:
+    """Per-source rising-edge toast config, resolved at call time (thresholds are
+    env-tunable and MUST match the block's --red-above in graphical.nix). The
+    action opens the SAME target as the block's left-click, so a middle-click on
+    the toast is a shortcut to the dashboard/UI."""
+    return {
+        "alerts": {"threshold": _env_int("ALERTS_TOAST_ABOVE", 30),
+                   "urgency": "normal", "summary": "⚠ Homelab alerts firing",
+                   "action": "xdg-open http://grafana.homelab.lan"},
+        "civitai": {"threshold": _env_int("CIVITAI_TOAST_ABOVE", 340),
+                    "urgency": "normal", "summary": "⚠ civitai prod alerts firing",
+                    "action": "xdg-open https://grafana-new.civitai.com"},
+        "clawgate": {"threshold": 0, "urgency": "normal",
+                     "summary": "clawgate: task awaiting",
+                     "action": "xdg-open http://192.168.50.250:30302"},
+        "mail": {"threshold": 0, "urgency": "low",
+                 "summary": "New mail action", "action": None},
+    }
+
+
+def evaluate_edge_toast(name, payload, spec, fire=None,
+                        read=None, write=None):
+    """Rising-edge gate for one source: read the persisted latch, decide via
+    edge_decision, fire a toast on the rising edge ONLY, persist the new latch.
+    SKIPS (leaving the latch untouched) for stale/error/malformed payloads so a
+    source blackout never resets the latch or fires a spurious toast. Returns
+    (should_toast, new_latched), or None when skipped. Pure/offline + fail-safe:
+    the decision is deterministic and the toast side-effect is injectable, so a
+    dunstify failure can never crash the poll."""
+    fire = fire or fire_toast
+    read = read or read_latch
+    write = write or write_latch
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("state") == "stale" or payload.get("error"):
+        return None
+    try:
+        count = int(payload.get("count", 0))
+    except (TypeError, ValueError):
+        return None
+    latched = read(name)
+    should, new = edge_decision(latched, count, spec["threshold"])
+    if new != latched:
+        write(name, new)
+    if should:
+        body = str(payload.get("detail") or ("%d" % count))
+        fire(spec["urgency"], spec["summary"], body,
+             action_cmd=spec.get("action"))
+    return should, new
+
+
+# ---------------------------------------------------------------------------
 # Low-level helpers
 # ---------------------------------------------------------------------------
 def _free_port() -> int:
@@ -364,11 +532,16 @@ def main(argv=None) -> int:
                 run_source("civitai", lambda: parse_alerts(json.load(f)))
         return 0
 
-    # Live poll: each source is independent + fail-safe.
-    run_source("clawgate", fetch_clawgate)
-    run_source("mail", fetch_mail)
-    run_source("alerts", fetch_alerts)
-    run_source("civitai", fetch_civitai)
+    # Live poll: each source is independent + fail-safe. After writing each
+    # source's status the poller evaluates a RISING-EDGE toast (fires once when a
+    # source crosses its baseline; steady state stays silent). The toast step is
+    # wrapped so a desktop-notify failure can never break or slow the poll.
+    specs = _toast_specs()
+    for name, fn in (("clawgate", fetch_clawgate), ("mail", fetch_mail),
+                     ("alerts", fetch_alerts), ("civitai", fetch_civitai)):
+        payload = run_source(name, fn)
+        with contextlib.suppress(Exception):
+            evaluate_edge_toast(name, payload, specs[name])
     return 0
 
 

--- a/scripts/i3status-dnd
+++ b/scripts/i3status-dnd
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""i3status-rust custom block: dunst DND (paused / quiet-mode) indicator.
+
+Queries `dunstctl is-paused` (instant, local — never network) and shows a small
+muted glyph ONLY while notifications are paused; hidden (empty, invisible)
+otherwise — the same CALM hide-at-zero idea as the count blocks. Toggled by
+`$mod+Shift+n` (dunstctl set-paused toggle), which also signals this block
+(RTMIN+15) for instant feedback. Wired workbench-only in graphical.nix.
+
+Fully FAIL-SAFE: any dunstctl error -> treated as "not paused" -> empty block,
+never a crash (a broken query must not wedge the bar).
+"""
+import json
+import subprocess
+import sys
+
+# nf-md-bell_off glyph (renders in the bar's JetBrainsMono Nerd Font).
+MUTED_GLYPH = "\U000f009b"
+_EMPTY = {"text": "", "state": "Idle"}
+
+
+def _default_runner():
+    return subprocess.run(
+        ["dunstctl", "is-paused"], capture_output=True, text=True, timeout=2)
+
+
+def is_paused(runner=_default_runner) -> bool:
+    """True iff dunst reports paused. Fail-safe: any error -> False."""
+    try:
+        out = runner()
+        return (out.stdout or "").strip().lower() == "true"
+    except Exception:
+        return False
+
+
+def render(paused: bool) -> dict:
+    """Pure: paused-bool -> i3status-rust block dict (hidden unless paused)."""
+    if not paused:
+        return dict(_EMPTY)
+    return {"text": " %s muted " % MUTED_GLYPH,
+            "short_text": " %s " % MUTED_GLYPH, "state": "Info"}
+
+
+def main() -> int:
+    sys.stdout.write(json.dumps(render(is_paused())) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        sys.stdout.write(json.dumps(_EMPTY) + "\n")
+        sys.exit(0)

--- a/scripts/tests/test_bar_status.py
+++ b/scripts/tests/test_bar_status.py
@@ -419,3 +419,193 @@ def test_block_subprocess_corrupt_json_is_invisible(tmp_path, script, cachefile)
                        capture_output=True, text=True, env=env)
     assert r.returncode == 0
     assert json.loads(r.stdout) == {"text": "", "state": "Idle"}
+
+
+# --------------------------------------------------------------------------- #
+# poller: edge_decision — the PURE rising-edge latch (given prev latch + count +
+# threshold -> (should_toast, new_latch)). Offline, deterministic, no side effects.
+# --------------------------------------------------------------------------- #
+def test_edge_decision_rising_edge_fires_once():
+    # not latched, count crosses above threshold -> fire + latch.
+    assert poll.edge_decision(False, 31, 30) == (True, True)
+
+
+def test_edge_decision_steady_state_does_not_retoast():
+    # already latched + still above -> NO re-toast, stays latched.
+    assert poll.edge_decision(True, 40, 30) == (False, True)
+    assert poll.edge_decision(True, 31, 30) == (False, True)
+
+
+def test_edge_decision_at_or_below_threshold_resets_latch():
+    # count == threshold is NOT "above" -> latch clears (so next crossing fires).
+    assert poll.edge_decision(True, 30, 30) == (False, False)
+    assert poll.edge_decision(True, 5, 30) == (False, False)
+    assert poll.edge_decision(False, 30, 30) == (False, False)
+
+
+def test_edge_decision_re_fires_after_drop_and_recross():
+    # full cycle: fire -> steady -> drop (reset) -> re-cross fires again.
+    should1, latch1 = poll.edge_decision(False, 31, 30)   # rising edge
+    assert (should1, latch1) == (True, True)
+    should2, latch2 = poll.edge_decision(latch1, 35, 30)  # steady above
+    assert (should2, latch2) == (False, True)
+    should3, latch3 = poll.edge_decision(latch2, 10, 30)  # dropped -> reset
+    assert (should3, latch3) == (False, False)
+    should4, latch4 = poll.edge_decision(latch3, 31, 30)  # re-cross -> fires
+    assert (should4, latch4) == (True, True)
+
+
+def test_edge_decision_threshold_zero_is_zero_to_positive():
+    # clawgate/mail rule: threshold 0 -> any count>0 is the rising edge.
+    assert poll.edge_decision(False, 1, 0) == (True, True)     # 0 -> 1 fires
+    assert poll.edge_decision(True, 3, 0) == (False, True)     # still >0, quiet
+    assert poll.edge_decision(True, 0, 0) == (False, False)    # back to 0, reset
+    assert poll.edge_decision(False, 0, 0) == (False, False)   # stays at 0
+
+
+# --------------------------------------------------------------------------- #
+# poller: latch persistence across invocations (sidecar file)
+# --------------------------------------------------------------------------- #
+def test_latch_defaults_false_when_absent(tmp_path, monkeypatch):
+    monkeypatch.setenv("BAR_STATUS_DIR", str(tmp_path))
+    assert poll.read_latch("alerts") is False
+
+
+def test_latch_round_trips(tmp_path, monkeypatch):
+    monkeypatch.setenv("BAR_STATUS_DIR", str(tmp_path))
+    poll.write_latch("alerts", True)
+    assert poll.read_latch("alerts") is True
+    poll.write_latch("alerts", False)
+    assert poll.read_latch("alerts") is False
+
+
+def test_latch_corrupt_file_reads_false(tmp_path, monkeypatch):
+    monkeypatch.setenv("BAR_STATUS_DIR", str(tmp_path))
+    (tmp_path / "alerts.toast-state").write_text("{ not json")
+    assert poll.read_latch("alerts") is False
+
+
+# --------------------------------------------------------------------------- #
+# poller: evaluate_edge_toast — the decision + latch + fire orchestration.
+# fire/read/write are injected so this stays fully OFFLINE (no dunstify, no disk).
+# --------------------------------------------------------------------------- #
+def _latch_store(initial=False):
+    """An in-memory latch backend + a fire-recorder for evaluate_edge_toast."""
+    state = {"latched": initial}
+    fired = []
+    return (state, fired,
+            lambda name: state["latched"],
+            lambda name, v: state.__setitem__("latched", v),
+            lambda *a, **k: fired.append((a, k)) or True)
+
+
+ALERTS_SPEC = {"threshold": 30, "urgency": "normal", "summary": "s",
+               "action": "xdg-open http://x"}
+MAIL_SPEC = {"threshold": 0, "urgency": "low", "summary": "m", "action": None}
+
+
+def test_eval_fires_once_on_rising_edge():
+    state, fired, rd, wr, fr = _latch_store(initial=False)
+    out = poll.evaluate_edge_toast(
+        "alerts", {"count": 31, "state": "Critical", "detail": "31 firing"},
+        ALERTS_SPEC, fire=fr, read=rd, write=wr)
+    assert out == (True, True)
+    assert state["latched"] is True
+    assert len(fired) == 1
+    # body carries the source detail; action is the block's target.
+    args, kw = fired[0]
+    assert "31 firing" in args[2]
+    assert kw["action_cmd"] == "xdg-open http://x"
+
+
+def test_eval_steady_state_does_not_refire():
+    state, fired, rd, wr, fr = _latch_store(initial=True)
+    out = poll.evaluate_edge_toast(
+        "alerts", {"count": 45, "state": "Critical"},
+        ALERTS_SPEC, fire=fr, read=rd, write=wr)
+    assert out == (False, True)
+    assert fired == []                       # no toast on steady state
+
+
+def test_eval_drop_resets_latch_no_fire():
+    state, fired, rd, wr, fr = _latch_store(initial=True)
+    out = poll.evaluate_edge_toast(
+        "alerts", {"count": 5, "state": "Warning"},
+        ALERTS_SPEC, fire=fr, read=rd, write=wr)
+    assert out == (False, False)
+    assert state["latched"] is False
+    assert fired == []
+
+
+def test_eval_zero_to_positive_fires_for_mail_and_clawgate():
+    state, fired, rd, wr, fr = _latch_store(initial=False)
+    out = poll.evaluate_edge_toast(
+        "mail", {"count": 2, "state": "Warning", "detail": "2 open"},
+        MAIL_SPEC, fire=fr, read=rd, write=wr)
+    assert out == (True, True) and len(fired) == 1
+    assert fired[0][1]["action_cmd"] is None        # mail toast has no action
+
+
+def test_eval_skips_stale_and_error_payloads_without_touching_latch():
+    for payload in ({"count": 99, "state": "stale"},
+                    {"count": 99, "state": "Critical", "error": "boom"}):
+        state, fired, rd, wr, fr = _latch_store(initial=False)
+        out = poll.evaluate_edge_toast("alerts", payload, ALERTS_SPEC,
+                                       fire=fr, read=rd, write=wr)
+        assert out is None
+        assert fired == [] and state["latched"] is False
+
+
+def test_eval_skips_malformed_payloads():
+    for bad in (None, [], "x", 3, {"count": "NaN"}):
+        state, fired, rd, wr, fr = _latch_store(initial=False)
+        out = poll.evaluate_edge_toast("alerts", bad, ALERTS_SPEC,
+                                       fire=fr, read=rd, write=wr)
+        assert out is None and fired == []
+
+
+def test_eval_is_failsafe_when_fire_raises():
+    # A dunstify/notify failure must NOT crash the decision path: evaluate_edge_
+    # toast still latches, and the exception is swallowed by the caller's wrapper.
+    def boom(*a, **k):
+        raise RuntimeError("no display")
+    state, fired, rd, wr, _ = _latch_store(initial=False)
+    with pytest.raises(RuntimeError):
+        # evaluate itself does not swallow (the live main() wraps it) — but the
+        # latch is written BEFORE the fire, so state is consistent even on failure.
+        poll.evaluate_edge_toast("alerts", {"count": 31, "state": "Critical"},
+                                 ALERTS_SPEC, fire=boom, read=rd, write=wr)
+    assert state["latched"] is True             # latch persisted before the fire
+
+
+# --------------------------------------------------------------------------- #
+# poller: fire_toast is fully fail-safe (offline) — a broken toast never raises
+# --------------------------------------------------------------------------- #
+def test_fire_toast_skips_without_session_bus(monkeypatch):
+    # No session bus reachable (headless / laptop) -> skip, return False, no raise.
+    monkeypatch.setattr(poll, "_borrow_desktop_env", lambda env: {})
+    assert poll.fire_toast("normal", "s", "b", action_cmd="xdg-open x") is False
+
+
+def test_fire_toast_swallows_launcher_failure(monkeypatch):
+    monkeypatch.setattr(poll, "_borrow_desktop_env",
+                        lambda env: {"DBUS_SESSION_BUS_ADDRESS": "unix:x"})
+
+    def boom(argv):
+        raise OSError("systemd-run missing")
+    assert poll.fire_toast("normal", "s", "b", runner=boom) is False
+
+
+def test_fire_toast_dispatches_with_action(monkeypatch):
+    monkeypatch.setattr(poll, "_borrow_desktop_env",
+                        lambda env: {"DBUS_SESSION_BUS_ADDRESS": "unix:x",
+                                     "DISPLAY": ":0"})
+    captured = {}
+    assert poll.fire_toast("normal", "sum", "body", action_cmd="xdg-open URL",
+                           runner=lambda a: captured.update(argv=a)) is True
+    argv = captured["argv"]
+    assert argv[0] == "systemd-run" and "--user" in argv
+    assert "bash" in argv and argv[-1] == "xdg-open URL"       # action is last arg
+    joined = " ".join(argv)
+    assert "-A open,Open" in joined                            # clickable action
+    assert "--setenv=DISPLAY=:0" in argv


### PR DESCRIPTION
Two calm-desktop notification improvements. **Verified live** on the workbench (dunst 1.13.2 running under i3/X11).

## Part 1 — harden dunst (declarative, `services.dunst.settings`)
- **global**: `JetBrainsMono Nerd Font 10` (matches the bar so nerd glyphs in bodies render), `origin=top-right` + `offset=(12,40)` to clear the top bar, bounded dynamic `width=(0,420)`, `notification_limit=4`, `history_length=40`, `stack_duplicates`, `show_indicators=false`, sensible left/middle/right mouse actions.
- **per-urgency** gruvbox tuning: normal blue-accent frame `#83a598`; critical `#cc241d` bg / `#fb4934` frame / sticky `timeout=0`.
- **native fullscreen DND**: a filterless rule with `fullscreen=pushback` holds + hides toasts while any window is fullscreen, re-showing after — no helper needed (the biggest calm win). Screen-share auto-DND intentionally **deferred** (needs the user's screen-share tool).
- **i3 binds**: `$mod+n` history-pop · `$mod+Shift+n` set-paused toggle (also signals the DND bar block) · `$mod+grave` close-all.
- **optional DND bar block** (`i3status-dnd`, workbench-only): a muted glyph shown only while dunst is paused, hidden otherwise (same calm hide-at-zero idea).

Value formats (paren-tuple `width`/`offset`, enums, comma mouse-action lists) were **verified parse-clean against 1.13.2** via a control reload before switching: the HM module quotes string values and dunst strips those quotes before enum/tuple parsing. Generated `~/.config/dunst/dunstrc` inspected post-switch → zero parse warnings.

## Part 2 — edge-triggered toasts from `bar-status-poll`
The count blocks show steady state silently; a toast now fires **once** on the rising edge when something new crosses the line.
- Pure `edge_decision(latched, count, threshold) -> (should_toast, new_latch)`: fires on the strict rising edge, never re-toasts steady state, resets when it drops back to/below threshold.
- State persisted per-source to a sidecar `~/.cache/bar-status/<src>.toast-state` (the poller is a systemd oneshot — nothing survives in memory).
- Thresholds reuse the block's `--red-above` (homelab **30** / civitai **340**, env-tunable via `ALERTS_TOAST_ABOVE`/`CIVITAI_TOAST_ABOVE`); clawgate/mail use **0** (0→>0). Mail is `low` urgency.
- `stale`/`error` payloads are **skipped** (latch untouched) so a source blackout never resets or spuriously fires.
- `fire_toast` launches dunstify in a **detached transient `--user` service** (`systemd-run`) so a clickable *Open* action (xdg-open the same target as the block's click) outlives the oneshot's cgroup teardown; DISPLAY/DBUS borrowed from i3 like `cpu-monitor.sh`. Fully **fail-safe** — never raises or slows the poll.

## Tests
+28 pytest cases (**88 pass**): `edge_decision` (rising-once / steady / drop-reset / 0→>0), latch persistence, `evaluate_edge_toast` orchestration (incl. stale+malformed skip and fail-safe when the fire raises), and `fire_toast` fail-safe (no-bus skip, launcher failure, action argv shape).

## Live verification (workbench)
- dunstrc generated + reloaded parse-clean (control test confirmed dunst *would* warn on a bad value).
- normal / critical / low `notify-send` render top-right below the bar (critical red+sticky). *(screenshot)*
- `history-pop` recalls (displayed 0→1); `set-paused toggle` works + DND bar block shows "muted". *(screenshot)*
- fullscreen pushback: while fullscreen displayed=0 / waiting=1 (held); after leaving displayed=1 (re-shown).
- edge toast driven through the real `fire_toast`→`systemd-run`→`dunstify` path from a **DISPLAY-cleared service-like context**: cycle1 rising-edge fired (displayed 0→1), cycle2 steady-state did NOT re-toast, cycle3 drop reset the latch. Click→`xdg-open` branch verified separately via `dunstctl action`. *(screenshot)*
- live systemd poller re-ran clean (exit 0, all caches written); current counts below thresholds → correctly no toast.
- i3 keybinds confirmed present in the running i3's loaded config after `i3-msg reload`.

**Unit-tested vs verified-live**: decision/latch/fail-safe logic is unit-tested and offline; dunst config, keybinds, DND block, fullscreen pushback, and the real toast path are verified live per above. The stale `/etc/i3.conf`-forcing note in graphical.nix turned out inaccurate — i3 already loads `~/.config/i3/config`, so the binds are live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)