### PR TITLE
feat(tmux): agent-ops mission-control dashboard popup (prefix+A)

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -126,6 +126,13 @@ bind-key g display-popup -E -w 90% -h 90% -d "#{pane_current_path}" \
 bind-key K display-popup -E -w 95% -h 95% \
     -T ' k9s ' k9s
 
+# Agent-ops "mission control" popup (prefix+A) — blocked-on-me / live Claude
+# sessions / in-flight PRs / momentum / health / recently-done, consolidated
+# from the existing deterministic sources (bar-status cache + tmux process scan
+# + cached initiative-scan). Read-only; instant-open; dismiss with q/Esc.
+bind-key A display-popup -E -w 90% -h 85% -S 'fg=#fabd2f' \
+    -T ' agent-ops ' '~/.config/tmux/agent-ops'
+
 # Hide scratch session from session switcher (prefix+s)
 bind-key s choose-tree -Zs -f '#{?#{m:scratch*,#{session_name}},0,1}'
 

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -251,6 +251,13 @@ in
     source = ../scripts/tmux-initiatives.sh;
     executable = true;
   };
+  # agent-ops "mission control" popup (prefix+A). Renders over the existing
+  # deterministic sources (bar-status cache + a live tmux/process scan + a
+  # TTL-cached initiative-scan) — see scripts/agent-ops.
+  home.file.".config/tmux/agent-ops" = {
+    source = ../scripts/agent-ops;
+    executable = true;
+  };
 
   home.file.".config/tmux/activity-emit.sh" = {
     source = ../scripts/tmux-activity-emit.sh;

--- a/scripts/agent-ops
+++ b/scripts/agent-ops
@@ -1,0 +1,669 @@
+#!/usr/bin/env python3
+"""agent-ops — tmux "mission-control" agent operations dashboard.
+
+One hotkey-away tmux popup (prefix+A → display-popup) that live-renders
+"what are my agents doing / what's blocked on me", consolidating signals that
+are otherwise scattered across the i3 bar, slash-commands, tmux, and clawgate.
+
+It is a RENDER LAYER over EXISTING deterministic sources — it never re-implements
+scanning and never invokes an LLM / slash-command. Fully fail-safe: any missing,
+slow, or malformed source degrades to a graceful "—"/"n/a" line, never a hang or
+a crash.
+
+Sections (priority order) and their sources
+  1. Blocked on me   ~/.cache/bar-status/{clawgate,mail}.json  (polled every 45s
+                     by scripts/bar-status-poll). clawgate optionally enriched
+                     with task TITLES via its API (bounded, fail-safe, optional).
+  2. Active runs     LIVE Claude Code sessions running in tmux — enumerate panes
+                     (`tmux list-panes -a`) and, per pane, walk the pane's process
+                     tree looking for the Claude Code CLI (comm matches /claude/,
+                     e.g. the nix-wrapped `.claude-wrapped`). The dashboard's own
+                     pane is excluded. NOT fuzzyclaw's ~/.tmux/tasks/*.json (stale).
+  3. In flight PRs   initiative-scan.py --json (open_prs across workspace repos).
+  4. Momentum        initiative-scan.py --json (●active / ◐slowing / ○stalled +
+                     next-step).
+  5. Health          ~/.cache/bar-status/{alerts,civitai}.json.
+  6. Recently done   initiative-scan.py --json (merged PRs).
+
+initiative-scan is SLOW (hits `gh` across repos) so it is NEVER run on the popup
+refresh path: its --json output is cached to ~/.cache/agent-ops/initiative-scan.json
+with a TTL; the popup renders the last-cached copy immediately with a freshness
+indicator and kicks a background refresh when stale. The file-backed + tmux-scan
+sections render instantly and auto-refresh every few seconds.
+
+fetch is deliberately separated from render so the pure aggregation/render
+functions are unit-tested against mock inputs (scripts/tests/test_agent_ops.py).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+# ---------------------------------------------------------------------------
+# Palette (gruvbox, truecolor)
+# ---------------------------------------------------------------------------
+FG = "#ebdbb2"
+DIM = "#928374"
+DIMMER = "#665c54"
+RED = "#fb4934"
+GREEN = "#b8bb26"
+YELLOW = "#fabd2f"
+BLUE = "#83a598"
+PURPLE = "#d3869b"
+AQUA = "#8ec07c"
+ORANGE = "#fe8019"
+
+RESET = "\033[0m"
+BOLD = "\033[1m"
+
+
+def fg(hex_color: str) -> str:
+    h = hex_color.lstrip("#")
+    return "\033[38;2;%d;%d;%dm" % (int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def paint(text: str, color: str, bold: bool = False) -> str:
+    return "%s%s%s%s" % (BOLD if bold else "", fg(color), text, RESET)
+
+
+# ---------------------------------------------------------------------------
+# Paths / constants
+# ---------------------------------------------------------------------------
+HOME = os.path.expanduser("~")
+BAR_STATUS_DIR = os.path.join(HOME, ".cache", "bar-status")
+CACHE_DIR = os.path.join(HOME, ".cache", "agent-ops")
+ISCAN_CACHE = os.path.join(CACHE_DIR, "initiative-scan.json")
+ISCAN_LOCK = os.path.join(CACHE_DIR, "refresh.lock")
+ISCAN_TTL = 120          # seconds — render last-cached, refresh in background if older
+ISCAN_LOCK_TTL = 240     # a refresh older than this is presumed dead
+DEVRC_DIR = os.environ.get("DEVRC_DIR") or os.path.join(HOME, "workspace", "devrc")
+ISCAN_SCRIPT = os.path.join(DEVRC_DIR, "scripts", "session-analysis", "initiative-scan.py")
+CLAWGATE_ENV = os.path.join(HOME, ".claude", "clawgate.env")
+
+REFRESH = float(os.environ.get("AGENT_OPS_REFRESH", "4"))
+CLAUDE_RE = re.compile(r"claude", re.IGNORECASE)
+# MCP servers & tool subprocesses claude always keeps as children — not a busy signal.
+_MCP_HINT = re.compile(r"claude", re.IGNORECASE)
+
+
+# ===========================================================================
+# FETCH — file / process / network sources (impure; thin, injectable)
+# ===========================================================================
+def read_json(path: str):
+    """Load a JSON file; return its parsed value or None (never raises)."""
+    try:
+        with open(path, "r") as fh:
+            return json.load(fh)
+    except Exception:
+        return None
+
+
+def file_age_secs(path: str, now: float | None = None):
+    try:
+        return (now or time.time()) - os.path.getmtime(path)
+    except Exception:
+        return None
+
+
+def list_tmux_panes_raw() -> str:
+    """Raw `tmux list-panes -a` output (pipe-delimited). '' on any failure."""
+    fmt = ("#{pane_id}|#{pane_pid}|#{session_name}|#{window_index}|"
+           "#{window_name}|#{pane_current_path}|#{pane_current_command}")
+    try:
+        out = subprocess.run(
+            ["tmux", "list-panes", "-a", "-F", fmt],
+            capture_output=True, text=True, timeout=3)
+        return out.stdout if out.returncode == 0 else ""
+    except Exception:
+        return ""
+
+
+def _read_proc(pid: int):
+    """Read (comm, ppid, state, age_secs) for a pid from /proc. None if gone."""
+    try:
+        with open("/proc/%d/stat" % pid, "r") as fh:
+            data = fh.read()
+        # comm is in parens and may contain spaces/parens: split on the LAST ')'.
+        rparen = data.rfind(")")
+        lparen = data.find("(")
+        comm = data[lparen + 1:rparen]
+        rest = data[rparen + 2:].split()
+        state = rest[0]                      # field 3
+        ppid = int(rest[1])                  # field 4
+        starttime = int(rest[19])            # field 22 (clock ticks since boot)
+        hz = os.sysconf("SC_CLK_TCK")
+        with open("/proc/uptime", "r") as fh:
+            uptime = float(fh.read().split()[0])
+        age = uptime - (starttime / hz) if hz else None
+        return {"comm": comm, "ppid": ppid, "state": state, "age_secs": age}
+    except Exception:
+        return None
+
+
+def build_proc_index(reader=_read_proc) -> dict:
+    """Snapshot every visible process into {pid: {comm,ppid,state,age_secs,children:[]}}.
+
+    `reader(pid)` is injectable so classify_claude_sessions can be unit-tested
+    against a mock process tree without touching /proc.
+    """
+    index: dict[int, dict] = {}
+    try:
+        pids = [int(d) for d in os.listdir("/proc") if d.isdigit()]
+    except Exception:
+        return index
+    for pid in pids:
+        info = reader(pid)
+        if info is None:
+            continue
+        entry = index.setdefault(pid, {})
+        entry.update(info)
+        entry.setdefault("children", [])
+    # link children
+    for pid, info in list(index.items()):
+        ppid = info.get("ppid")
+        if ppid in index and ppid != pid:
+            index[ppid]["children"].append(pid)
+    return index
+
+
+def own_pid_chain(reader=_read_proc) -> set:
+    """PIDs of this process and its ancestors (so we can exclude our own pane)."""
+    chain = set()
+    pid = os.getpid()
+    for _ in range(64):
+        if pid <= 0 or pid in chain:
+            break
+        chain.add(pid)
+        info = reader(pid)
+        if not info:
+            break
+        pid = info.get("ppid", 0)
+    return chain
+
+
+def enrich_clawgate_titles(timeout=2.5):
+    """Best-effort: fetch operator-pending task titles from the clawgate API.
+
+    Returns a list of "#<id> <title>" strings, or [] on ANY failure (no creds,
+    unreachable, slow, malformed). Purely additive — never blocks the section.
+    """
+    try:
+        env = {}
+        with open(CLAWGATE_ENV, "r") as fh:
+            for line in fh:
+                line = line.strip()
+                if "=" in line and not line.startswith("#"):
+                    k, v = line.split("=", 1)
+                    env[k.strip()] = v.strip()
+        base = env.get("CLAWGATE_API_URL")
+        token = env.get("CLAWGATE_HOOK_TOKEN")
+        if not base or not token:
+            return []
+        import urllib.request
+        req = urllib.request.Request(base.rstrip("/") + "/api/tasks",
+                                     headers={"Authorization": "Bearer " + token})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            tasks = json.loads(resp.read().decode("utf-8"))
+        return clawgate_pending_titles(tasks)
+    except Exception:
+        return []
+
+
+# ===========================================================================
+# PURE aggregation — unit-tested
+# ===========================================================================
+_PENDING_STATES = frozenset({"open", "ready_for_review"})
+
+
+def clawgate_pending_titles(tasks, pending=_PENDING_STATES) -> list:
+    """Map /api/tasks payload → ['#<id> <title>', …] for operator-pending tasks."""
+    if not isinstance(tasks, list):
+        return []
+    out = []
+    for t in tasks:
+        if isinstance(t, dict) and t.get("status") in pending:
+            title = (t.get("title") or "").strip() or "(no title)"
+            out.append("#%s %s" % (t.get("id"), title))
+    return out
+
+
+def parse_panes(raw: str) -> list:
+    """Split raw `tmux list-panes -a` output into pane dicts. Tolerates junk."""
+    panes = []
+    for line in raw.splitlines():
+        parts = line.split("|")
+        if len(parts) != 7:
+            continue
+        pid = parts[1]
+        if not pid.isdigit():
+            continue
+        panes.append({
+            "pane_id": parts[0],
+            "pane_pid": int(pid),
+            "session": parts[2],
+            "window_index": parts[3],
+            "window_name": parts[4].rstrip(" ●").strip(),
+            "path": parts[5],
+            "command": parts[6],
+        })
+    return panes
+
+
+def _descendants(pid: int, proc_index: dict) -> list:
+    """BFS every descendant pid of `pid` (inclusive) using the children map."""
+    seen, stack, out = set(), [pid], []
+    while stack:
+        p = stack.pop()
+        if p in seen:
+            continue
+        seen.add(p)
+        out.append(p)
+        stack.extend(proc_index.get(p, {}).get("children", []))
+    return out
+
+
+def _basename_repo(path: str, root_resolver) -> str:
+    root = root_resolver(path) if path else None
+    if root:
+        return os.path.basename(root.rstrip("/"))
+    return os.path.basename((path or "").rstrip("/")) or "?"
+
+
+def default_git_root(path: str):
+    """Walk up `path` until a .git entry is found. Pure filesystem, no subprocess."""
+    try:
+        cur = os.path.abspath(path)
+    except Exception:
+        return None
+    for _ in range(40):
+        if os.path.exists(os.path.join(cur, ".git")):
+            return cur
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            return None
+        cur = parent
+    return None
+
+
+def classify_claude_sessions(panes, proc_index, own_pids=frozenset(),
+                             root_resolver=default_git_root) -> list:
+    """Return the live Claude-Code sessions among `panes`.
+
+    A pane is a Claude session if its foreground command matches /claude/ OR any
+    process in its tree has a comm matching /claude/ (e.g. `.claude-wrapped`).
+    The dashboard's OWN pane (any pane whose tree contains one of `own_pids`) is
+    excluded. Pure given an injected `proc_index` + `root_resolver`.
+    """
+    sessions = []
+    for pane in panes:
+        tree = _descendants(pane["pane_pid"], proc_index)
+        if own_pids and any(p in own_pids for p in tree):
+            continue  # our own dashboard pane
+        claude_pid = None
+        for p in tree:
+            comm = proc_index.get(p, {}).get("comm", "")
+            if CLAUDE_RE.search(comm):
+                claude_pid = p
+                break
+        is_claude = claude_pid is not None or CLAUDE_RE.search(pane.get("command", ""))
+        if not is_claude:
+            continue
+        info = proc_index.get(claude_pid, {}) if claude_pid else {}
+        state = info.get("state")
+        busy = None if state is None else (state == "R")
+        sessions.append({
+            "pane_id": pane["pane_id"],
+            "repo": _basename_repo(pane["path"], root_resolver),
+            "session": pane["session"],
+            "window_index": pane["window_index"],
+            "window_name": pane.get("window_name", ""),
+            "busy": busy,
+            "age_secs": info.get("age_secs"),
+        })
+    # Group ordering: by repo, then session, then window.
+    sessions.sort(key=lambda s: (s["repo"], s["session"],
+                                 _int_or(s["window_index"])))
+    return sessions
+
+
+def _int_or(v, default=0):
+    try:
+        return int(v)
+    except Exception:
+        return default
+
+
+def flatten_initiatives(scan) -> list:
+    """Flatten initiative-scan --json `by_repo` into a single list. []-safe."""
+    if not isinstance(scan, dict):
+        return []
+    by_repo = scan.get("by_repo")
+    if not isinstance(by_repo, dict):
+        return []
+    out = []
+    for items in by_repo.values():
+        if isinstance(items, list):
+            out.extend(i for i in items if isinstance(i, dict))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+def rel_age(secs) -> str:
+    if secs is None:
+        return "?"
+    secs = int(secs)
+    if secs < 60:
+        return "%ds" % secs
+    if secs < 3600:
+        return "%dm" % (secs // 60)
+    if secs < 86400:
+        return "%dh" % (secs // 3600)
+    return "%dd" % (secs // 86400)
+
+
+def _truncate(text: str, width: int) -> str:
+    text = (text or "").replace("\n", " ")
+    if width <= 1 or len(text) <= width:
+        return text
+    return text[:width - 1] + "…"
+
+
+MOMENTUM_GLYPH = {"active": ("●", GREEN), "slowing": ("◐", YELLOW),
+                  "stalled": ("○", DIM)}
+MOMENTUM_RANK = {"active": 0, "slowing": 1, "stalled": 2}
+
+
+# ===========================================================================
+# PURE render — each returns a list[str] of (ANSI) lines. Unit-tested.
+# ===========================================================================
+def _header(title: str, color: str, note: str = "") -> str:
+    line = "%s %s" % (paint("▸", color, bold=True), paint(title.upper(), color, bold=True))
+    if note:
+        line += "  " + paint(note, DIMMER)
+    return line
+
+
+def render_blocked(clawgate, mail, titles=None) -> list:
+    lines = [_header("Blocked on me", RED)]
+    cg_count = (clawgate or {}).get("count")
+    if clawgate is None:
+        lines.append("   " + paint("clawgate  — n/a", DIMMER))
+    else:
+        col = YELLOW if (cg_count or 0) > 0 else DIM
+        detail = clawgate.get("detail") or clawgate.get("state") or ""
+        lines.append("   %s  %s  %s" % (
+            paint("clawgate", BLUE),
+            paint("%s" % (cg_count if cg_count is not None else "?"), col, bold=True),
+            paint(_truncate(detail, 60), DIM)))
+        for t in (titles or [])[:6]:
+            lines.append("      " + paint("• " + _truncate(t, 66), YELLOW))
+    if mail is None:
+        lines.append("   " + paint("mail      — n/a", DIMMER))
+    else:
+        m_count = mail.get("count")
+        col = YELLOW if (m_count or 0) > 0 else DIM
+        detail = mail.get("detail") or mail.get("state") or ""
+        lines.append("   %s      %s  %s" % (
+            paint("mail", BLUE),
+            paint("%s" % (m_count if m_count is not None else "?"), col, bold=True),
+            paint(_truncate(detail, 60), DIM)))
+    return lines
+
+
+def render_active_runs(sessions) -> list:
+    lines = [_header("Active agent runs", AQUA,
+                     "%d live Claude session(s) in tmux" % len(sessions))]
+    if not sessions:
+        lines.append("   " + paint("— no live Claude sessions detected", DIMMER))
+        return lines
+    for s in sessions:
+        if s["busy"] is True:
+            glyph, gcol = "▶", GREEN
+        elif s["busy"] is False:
+            glyph, gcol = "●", BLUE
+        else:
+            glyph, gcol = "●", DIM
+        loc = "%s:%s" % (s["session"], s["window_index"])
+        age = rel_age(s["age_secs"]) if s["age_secs"] is not None else ""
+        lines.append("   %s  %s  %s  %s" % (
+            paint(glyph, gcol),
+            paint("%-18s" % _truncate(s["repo"], 18), FG, bold=True),
+            paint("%-14s" % _truncate(loc, 14), DIM),
+            paint(age, DIMMER)))
+    return lines
+
+
+def render_prs(initiatives, freshness="") -> list:
+    lines = [_header("In flight — PRs", PURPLE, freshness)]
+    rows = []
+    for ini in initiatives:
+        for pr in ini.get("open_prs") or []:
+            if isinstance(pr, dict):
+                rows.append((os.path.basename(ini.get("repo", "").rstrip("/")),
+                             pr.get("number"), pr.get("title", "")))
+    if not rows:
+        lines.append("   " + paint("— no open PRs", DIMMER))
+        return lines
+    for repo, num, title in rows[:8]:
+        lines.append("   %s  %s  %s" % (
+            paint("#%s" % num, YELLOW, bold=True),
+            paint("%-16s" % _truncate(repo, 16), BLUE),
+            paint(_truncate(title, 48), FG)))
+    return lines
+
+
+def render_momentum(initiatives, freshness="", limit=7) -> list:
+    lines = [_header("Momentum", BLUE, freshness)]
+    active = [i for i in initiatives if i.get("momentum") in ("active", "slowing")]
+    active.sort(key=lambda i: (MOMENTUM_RANK.get(i.get("momentum"), 9),
+                               -(i.get("last_touch") or 0)))
+    if not active:
+        lines.append("   " + paint("— nothing active", DIMMER))
+        return lines
+    for ini in active[:limit]:
+        glyph, gcol = MOMENTUM_GLYPH.get(ini.get("momentum"), ("·", DIM))
+        title = ini.get("title") or ini.get("slug") or "?"
+        age = rel_age((time.time() - ini["last_touch"]) if ini.get("last_touch") else None)
+        lines.append("   %s  %s  %s" % (
+            paint(glyph, gcol, bold=True),
+            paint("%-42s" % _truncate(title, 42), FG),
+            paint(age, DIMMER)))
+        ns = ini.get("next_step")
+        if ns:
+            lines.append("      " + paint("→ " + _truncate(ns, 62), DIM))
+    return lines
+
+
+def render_health(alerts, civitai) -> list:
+    lines = [_header("Health", ORANGE)]
+
+    def _row(label, data):
+        if data is None:
+            return "   %s  %s" % (paint("%-9s" % label, BLUE), paint("— n/a", DIMMER))
+        count = data.get("count")
+        state = (data.get("state") or "").lower()
+        col = RED if state in ("critical",) else (YELLOW if (count or 0) > 0 else GREEN)
+        detail = data.get("detail") or data.get("state") or ""
+        return "   %s  %s  %s" % (
+            paint("%-9s" % label, BLUE),
+            paint("%s" % (count if count is not None else "?"), col, bold=True),
+            paint(_truncate(detail, 56), DIM))
+
+    lines.append(_row("homelab", alerts))
+    lines.append(_row("civitai", civitai))
+    return lines
+
+
+def render_done(initiatives, freshness="", limit=6) -> list:
+    lines = [_header("Recently done", GREEN, freshness)]
+    merged = [i for i in initiatives if (i.get("merged_prs") or 0) > 0]
+    merged.sort(key=lambda i: -(i.get("last_commit") or i.get("last_touch") or 0))
+    if not merged:
+        lines.append("   " + paint("— no recently merged PRs", DIMMER))
+        return lines
+    for ini in merged[:limit]:
+        title = ini.get("title") or ini.get("slug") or "?"
+        age = rel_age((time.time() - ini["last_commit"]) if ini.get("last_commit") else None)
+        lines.append("   %s  %s  %s" % (
+            paint("✓%d" % ini["merged_prs"], GREEN, bold=True),
+            paint("%-42s" % _truncate(title, 42), FG),
+            paint(age, DIMMER)))
+    return lines
+
+
+# ===========================================================================
+# initiative-scan cache + background refresh
+# ===========================================================================
+def initiatives_freshness(now=None, cache=ISCAN_CACHE, lock=ISCAN_LOCK) -> str:
+    age = file_age_secs(cache, now)
+    if age is None:
+        note = "no cache yet"
+    else:
+        note = "updated %s ago" % rel_age(age)
+    lock_age = file_age_secs(lock, now)
+    if lock_age is not None and lock_age < ISCAN_LOCK_TTL:
+        note += " · refreshing…"
+    return note
+
+
+def maybe_refresh_initiatives(now=None):
+    """Kick a detached background `initiative-scan --json` refresh if the cache is
+    stale (older than TTL) and no live refresh is already running. Never blocks."""
+    now = now or time.time()
+    try:
+        os.makedirs(CACHE_DIR, exist_ok=True)
+    except Exception:
+        return
+    cache_age = file_age_secs(ISCAN_CACHE, now)
+    if cache_age is not None and cache_age < ISCAN_TTL:
+        return  # fresh enough
+    lock_age = file_age_secs(ISCAN_LOCK, now)
+    if lock_age is not None and lock_age < ISCAN_LOCK_TTL:
+        return  # a refresh is already in flight
+    if not os.path.exists(ISCAN_SCRIPT):
+        return
+    try:
+        open(ISCAN_LOCK, "w").close()
+    except Exception:
+        return
+    tmp = ISCAN_CACHE + ".tmp"
+    cmd = ("'%s' --json > '%s' 2>/dev/null && mv '%s' '%s'; rm -f '%s'" %
+           (ISCAN_SCRIPT, tmp, tmp, ISCAN_CACHE, ISCAN_LOCK))
+    try:
+        subprocess.Popen(["/usr/bin/env", "bash", "-c", cmd],
+                         stdin=subprocess.DEVNULL,
+                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                         start_new_session=True)
+    except Exception:
+        try:
+            os.remove(ISCAN_LOCK)
+        except Exception:
+            pass
+
+
+# ===========================================================================
+# Frame assembly + interactive loop
+# ===========================================================================
+def build_frame(width: int) -> str:
+    """Assemble one full-screen frame from all sources. Pure of terminal I/O."""
+    clawgate = read_json(os.path.join(BAR_STATUS_DIR, "clawgate.json"))
+    mail = read_json(os.path.join(BAR_STATUS_DIR, "mail.json"))
+    alerts = read_json(os.path.join(BAR_STATUS_DIR, "alerts.json"))
+    civitai = read_json(os.path.join(BAR_STATUS_DIR, "civitai.json"))
+
+    titles = []
+    if clawgate and (clawgate.get("count") or 0) > 0:
+        titles = enrich_clawgate_titles()
+
+    panes = parse_panes(list_tmux_panes_raw())
+    proc_index = build_proc_index()
+    sessions = classify_claude_sessions(panes, proc_index, own_pids=own_pid_chain())
+
+    maybe_refresh_initiatives()
+    scan = read_json(ISCAN_CACHE)
+    initiatives = flatten_initiatives(scan)
+    fresh = initiatives_freshness()
+
+    blocks = [
+        render_blocked(clawgate, mail, titles),
+        render_active_runs(sessions),
+        render_prs(initiatives, fresh),
+        render_momentum(initiatives, fresh),
+        render_health(alerts, civitai),
+        render_done(initiatives, fresh),
+    ]
+    lines = []
+    title = paint(" agent-ops ", YELLOW, bold=True)
+    clock = paint(time.strftime("%H:%M:%S"), DIMMER)
+    lines.append("%s  %s" % (title, clock))
+    lines.append("")
+    for block in blocks:
+        lines.extend(block)
+        lines.append("")
+    lines.append(paint("[q/Esc: close · refresh %ss]" % int(REFRESH), DIMMER))
+    return "\n".join(lines)
+
+
+def _run_interactive():
+    import select
+    import termios
+    import tty
+
+    fd = sys.stdin.fileno()
+    old = None
+    try:
+        old = termios.tcgetattr(fd)
+        tty.setcbreak(fd)
+    except Exception:
+        old = None
+
+    sys.stdout.write("\033[?25l")  # hide cursor
+    try:
+        while True:
+            size = shutil.get_terminal_size((100, 40))
+            frame = build_frame(size.columns)
+            sys.stdout.write("\033[H\033[2J" + frame)
+            sys.stdout.flush()
+            r, _, _ = select.select([sys.stdin], [], [], REFRESH)
+            if r:
+                ch = sys.stdin.read(1)
+                if ch in ("q", "Q"):
+                    break
+                if ch == "\x1b":  # Esc — swallow any CSI trailer, then quit
+                    r2, _, _ = select.select([sys.stdin], [], [], 0.05)
+                    if not r2:
+                        break
+    except KeyboardInterrupt:
+        pass
+    finally:
+        sys.stdout.write("\033[?25h\n")  # show cursor
+        sys.stdout.flush()
+        if old is not None:
+            try:
+                termios.tcsetattr(fd, termios.TCSADRAIN, old)
+            except Exception:
+                pass
+
+
+def main(argv=None):
+    argv = argv if argv is not None else sys.argv[1:]
+    if "--once" in argv:
+        # Non-interactive single frame — handy for capture-pane / debugging.
+        print(build_frame(shutil.get_terminal_size((100, 40)).columns))
+        return 0
+    if not sys.stdout.isatty():
+        print(build_frame(shutil.get_terminal_size((100, 40)).columns))
+        return 0
+    _run_interactive()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_agent_ops.py
+++ b/scripts/tests/test_agent_ops.py
@@ -1,0 +1,310 @@
+"""Unit tests for scripts/agent-ops — the tmux agent-ops dashboard.
+
+Exercises the PURE aggregation + render functions against mock inputs (mock
+bar-status JSONs, a mock tmux-pane list + process tree, mock initiative-scan
+--json). fetch is separated from render, so nothing here touches /proc, tmux,
+the network, or the filesystem sources. Also asserts fail-safe: missing /
+malformed / empty inputs degrade to a graceful "—"/"n/a" line, never an
+exception.
+"""
+import importlib.util
+import os
+import re
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SCRIPT = os.path.join(_HERE, "..", "agent-ops")
+
+# agent-ops has no .py extension → load it by explicit path.
+_spec = importlib.util.spec_from_loader(
+    "agent_ops", importlib.machinery.SourceFileLoader("agent_ops", _SCRIPT))
+ao = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ao)
+
+_ANSI = re.compile(r"\033\[[0-9;]*m")
+
+
+def plain(lines):
+    """Strip ANSI so assertions read the visible text."""
+    if isinstance(lines, str):
+        return _ANSI.sub("", lines)
+    return [_ANSI.sub("", ln) for ln in lines]
+
+
+# ---------------------------------------------------------------------------
+# clawgate_pending_titles
+# ---------------------------------------------------------------------------
+def test_clawgate_titles_filters_pending_only():
+    tasks = [
+        {"id": 1, "status": "open", "title": "ship X"},
+        {"id": 2, "status": "in_progress", "title": "running Y"},
+        {"id": 3, "status": "ready_for_review", "title": "review Z"},
+        {"id": 4, "status": "done", "title": "old"},
+    ]
+    out = ao.clawgate_pending_titles(tasks)
+    assert out == ["#1 ship X", "#3 review Z"]
+
+
+def test_clawgate_titles_failsafe_on_junk():
+    assert ao.clawgate_pending_titles(None) == []
+    assert ao.clawgate_pending_titles({"not": "a list"}) == []
+    # tolerates junk elements + missing title
+    out = ao.clawgate_pending_titles(["x", 3, {"id": 9, "status": "open"}])
+    assert out == ["#9 (no title)"]
+
+
+# ---------------------------------------------------------------------------
+# parse_panes
+# ---------------------------------------------------------------------------
+def test_parse_panes_wellformed_and_junk():
+    raw = "\n".join([
+        "%0|16060|main|1|devrc ●|/home/zach/workspace/devrc|claude",
+        "%1|16095|main|2|dp|/home/zach/workspace/civit/datapacket-talos|zsh",
+        "garbage line without pipes",
+        "%2|notanint|x|1|w|/p|zsh",       # bad pid → dropped
+    ])
+    panes = ao.parse_panes(raw)
+    assert len(panes) == 2
+    assert panes[0]["pane_pid"] == 16060
+    assert panes[0]["window_name"] == "devrc"   # trailing ' ●' stripped
+    assert panes[1]["command"] == "zsh"
+
+
+def test_parse_panes_empty():
+    assert ao.parse_panes("") == []
+
+
+# ---------------------------------------------------------------------------
+# classify_claude_sessions — the live-Claude detector
+# ---------------------------------------------------------------------------
+def _proc_index():
+    """Mock tree:
+      16060 zsh(claude pane) -> 108149 .claude-wrapped -> 200 npm(mcp)  [INCLUDE]
+      16095 zsh(plain pane)                                              [EXCLUDE]
+      500   zsh(dashboard's own pane) -> 999 (our pid)                   [EXCLUDE]
+    """
+    return {
+        16060: {"comm": "zsh", "ppid": 1, "state": "S", "age_secs": 100,
+                "children": [108149]},
+        108149: {"comm": ".claude-wrapped", "ppid": 16060, "state": "R",
+                 "age_secs": 90, "children": [200]},
+        200: {"comm": "npm exec mcp", "ppid": 108149, "state": "S",
+              "age_secs": 80, "children": []},
+        16095: {"comm": "zsh", "ppid": 1, "state": "S", "age_secs": 100,
+                "children": []},
+        500: {"comm": "zsh", "ppid": 1, "state": "S", "age_secs": 5,
+              "children": [999]},
+        999: {"comm": "python3", "ppid": 500, "state": "R", "age_secs": 5,
+              "children": []},
+    }
+
+
+def _panes():
+    return [
+        {"pane_id": "%0", "pane_pid": 16060, "session": "main", "window_index": "1",
+         "window_name": "devrc", "path": "/home/zach/workspace/devrc", "command": "claude"},
+        {"pane_id": "%1", "pane_pid": 16095, "session": "main", "window_index": "2",
+         "window_name": "dp", "path": "/home/zach/ws/dp", "command": "zsh"},
+        {"pane_id": "%9", "pane_pid": 500, "session": "main", "window_index": "9",
+         "window_name": "self", "path": "/home/zach/workspace/devrc", "command": "python3"},
+    ]
+
+
+def test_classify_includes_claude_excludes_plain_and_own():
+    sessions = ao.classify_claude_sessions(
+        _panes(), _proc_index(), own_pids={999},
+        root_resolver=lambda p: p)  # treat path as its own root
+    # the plain zsh pane and the dashboard's own pane are both excluded
+    ids = [s["pane_id"] for s in sessions]
+    assert ids == ["%0"]
+    s = sessions[0]
+    assert s["repo"] == "devrc"
+    assert s["session"] == "main" and s["window_index"] == "1"
+    assert s["busy"] is True          # .claude-wrapped state == R
+    assert s["age_secs"] == 90
+
+
+def test_classify_detects_via_foreground_command_when_tree_missing():
+    # No proc_index entry at all → falls back to pane_current_command == 'claude'.
+    panes = [{"pane_id": "%0", "pane_pid": 7, "session": "s", "window_index": "1",
+              "window_name": "w", "path": "/repo", "command": "claude"}]
+    sessions = ao.classify_claude_sessions(panes, {}, root_resolver=lambda p: p)
+    assert len(sessions) == 1
+    assert sessions[0]["busy"] is None      # no proc info → unknown, not a crash
+
+
+def test_classify_empty_and_ordering():
+    assert ao.classify_claude_sessions([], {}) == []
+    # ordering: sort by (repo, session, window_index)
+    panes = [
+        {"pane_id": "%b", "pane_pid": 2, "session": "z", "window_index": "5",
+         "window_name": "", "path": "/b", "command": "claude"},
+        {"pane_id": "%a", "pane_pid": 1, "session": "a", "window_index": "1",
+         "window_name": "", "path": "/a", "command": "claude"},
+    ]
+    sessions = ao.classify_claude_sessions(panes, {}, root_resolver=lambda p: p)
+    assert [s["repo"] for s in sessions] == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# flatten_initiatives
+# ---------------------------------------------------------------------------
+def _scan():
+    return {"by_repo": {
+        "/home/zach/workspace/devrc": [
+            {"repo": "/home/zach/workspace/devrc", "slug": "one", "title": "Init One",
+             "momentum": "active", "last_touch": 2000, "next_step": "do the thing",
+             "open_prs": [{"number": 70, "title": "restore plan override"}],
+             "merged_prs": 0, "last_commit": 1900},
+            {"repo": "/home/zach/workspace/devrc", "slug": "two", "title": "Init Two",
+             "momentum": "stalled", "last_touch": 1000, "next_step": None,
+             "open_prs": [], "merged_prs": 2, "last_commit": 1500},
+        ],
+        "/home/zach/workspace/homelab": [
+            {"repo": "/home/zach/workspace/homelab", "slug": "three", "title": "Init Three",
+             "momentum": "slowing", "last_touch": 1800, "next_step": "wire it up",
+             "open_prs": [], "merged_prs": 0, "last_commit": None},
+            "junk-not-a-dict",
+        ],
+    }}
+
+
+def test_flatten_initiatives_and_failsafe():
+    items = ao.flatten_initiatives(_scan())
+    assert len(items) == 3          # junk string dropped
+    assert ao.flatten_initiatives(None) == []
+    assert ao.flatten_initiatives({}) == []
+    assert ao.flatten_initiatives({"by_repo": "nope"}) == []
+
+
+# ---------------------------------------------------------------------------
+# render_blocked
+# ---------------------------------------------------------------------------
+def test_render_blocked_counts_and_titles():
+    cg = {"count": 2, "state": "Warning", "detail": "2 awaiting"}
+    mail = {"count": 0, "detail": "inbox clear"}
+    out = plain(ao.render_blocked(cg, mail, titles=["#1 ship X", "#3 review Z"]))
+    body = "\n".join(out)
+    assert "BLOCKED ON ME" in body
+    assert "clawgate" in body and "2 awaiting" in body
+    assert "ship X" in body and "review Z" in body
+    assert "inbox clear" in body
+
+
+def test_render_blocked_failsafe_missing():
+    out = plain(ao.render_blocked(None, None))
+    body = "\n".join(out)
+    assert "clawgate  — n/a" in body
+    assert "mail      — n/a" in body
+
+
+# ---------------------------------------------------------------------------
+# render_active_runs
+# ---------------------------------------------------------------------------
+def test_render_active_runs_rows_and_glyph():
+    sessions = [
+        {"pane_id": "%0", "repo": "devrc", "session": "main", "window_index": "1",
+         "window_name": "devrc", "busy": True, "age_secs": 3600},
+        {"pane_id": "%1", "repo": "homelab", "session": "s", "window_index": "2",
+         "window_name": "h", "busy": False, "age_secs": 90},
+    ]
+    out = plain(ao.render_active_runs(sessions))
+    body = "\n".join(out)
+    assert "2 live Claude session(s)" in body
+    assert "devrc" in body and "main:1" in body and "1h" in body
+    assert "homelab" in body and "s:2" in body
+
+
+def test_render_active_runs_empty():
+    out = plain(ao.render_active_runs([]))
+    assert any("no live Claude sessions" in ln for ln in out)
+
+
+# ---------------------------------------------------------------------------
+# render_prs / render_momentum / render_done
+# ---------------------------------------------------------------------------
+def test_render_prs_lists_open_prs():
+    items = ao.flatten_initiatives(_scan())
+    out = plain(ao.render_prs(items, "updated 1m ago"))
+    body = "\n".join(out)
+    assert "#70" in body and "restore plan override" in body
+    assert "updated 1m ago" in body
+
+
+def test_render_prs_empty():
+    out = plain(ao.render_prs([]))
+    assert any("no open PRs" in ln for ln in out)
+
+
+def test_render_momentum_orders_active_first_and_shows_next_step():
+    items = ao.flatten_initiatives(_scan())
+    out = plain(ao.render_momentum(items))
+    body = "\n".join(out)
+    # stalled 'two' must NOT appear; active/slowing do
+    assert "Init One" in body and "Init Three" in body
+    assert "Init Two" not in body
+    # active ('Init One') is rendered before slowing ('Init Three')
+    assert body.index("Init One") < body.index("Init Three")
+    assert "do the thing" in body and "wire it up" in body
+
+
+def test_render_momentum_empty():
+    out = plain(ao.render_momentum([]))
+    assert any("nothing active" in ln for ln in out)
+
+
+def test_render_done_lists_merged():
+    items = ao.flatten_initiatives(_scan())
+    out = plain(ao.render_done(items))
+    body = "\n".join(out)
+    assert "Init Two" in body and "✓2" in body
+
+
+def test_render_done_empty():
+    out = plain(ao.render_done([]))
+    assert any("no recently merged" in ln for ln in out)
+
+
+# ---------------------------------------------------------------------------
+# render_health
+# ---------------------------------------------------------------------------
+def test_render_health_counts_and_failsafe():
+    alerts = {"count": 22, "state": "Critical", "detail": "22 firing (15 critical)"}
+    out = plain(ao.render_health(alerts, None))
+    body = "\n".join(out)
+    assert "homelab" in body and "22 firing" in body
+    assert "civitai" in body and "n/a" in body
+
+
+# ---------------------------------------------------------------------------
+# freshness
+# ---------------------------------------------------------------------------
+def test_initiatives_freshness_no_cache(tmp_path):
+    note = ao.initiatives_freshness(cache=str(tmp_path / "nope.json"),
+                                    lock=str(tmp_path / "nolock"))
+    assert "no cache yet" in note
+
+
+def test_initiatives_freshness_refreshing(tmp_path):
+    cache = tmp_path / "c.json"
+    lock = tmp_path / "l"
+    cache.write_text("{}")
+    lock.write_text("")
+    note = ao.initiatives_freshness(cache=str(cache), lock=str(lock))
+    assert "updated" in note and "refreshing" in note
+
+
+# ---------------------------------------------------------------------------
+# build_frame smoke test — must never raise even with everything missing
+# ---------------------------------------------------------------------------
+def test_build_frame_failsafe(monkeypatch):
+    monkeypatch.setattr(ao, "read_json", lambda p: None)
+    monkeypatch.setattr(ao, "list_tmux_panes_raw", lambda: "")
+    monkeypatch.setattr(ao, "build_proc_index", lambda: {})
+    monkeypatch.setattr(ao, "own_pid_chain", lambda: set())
+    monkeypatch.setattr(ao, "maybe_refresh_initiatives", lambda *a, **k: None)
+    monkeypatch.setattr(ao, "enrich_clawgate_titles", lambda *a, **k: [])
+    frame = ao.build_frame(100)
+    body = plain(frame)
+    for section in ("BLOCKED ON ME", "ACTIVE AGENT RUNS", "IN FLIGHT",
+                    "MOMENTUM", "HEALTH", "RECENTLY DONE"):
+        assert section in body


### PR DESCRIPTION
## What

A tmux **mission-control agent-ops dashboard** — one hotkey-away `display-popup` (**prefix+A**) that live-renders *"what are my agents doing / what's blocked on me"*, consolidating signals otherwise scattered across the i3 bar, slash-commands, tmux, and clawgate.

It is a **render layer over EXISTING deterministic sources** — no LLM, no slash-command, no re-scanning. Fully fail-safe: any missing / slow / malformed source degrades to a graceful `—`/`n/a` line, never a hang or crash.

## Sections & sources

| # | Section | Source |
|---|---------|--------|
| 1 | **Blocked on me** | `~/.cache/bar-status/{clawgate,mail}.json` (polled every 45s by `bar-status-poll`); clawgate optionally enriched with task **titles** via its API (bounded 2.5s, fail-safe) |
| 2 | **Active agent runs** | **LIVE Claude Code sessions in tmux** — enumerate panes (`tmux list-panes -a`) and walk each pane's `/proc` tree for a `claude` comm (the nix-wrapped `.claude-wrapped`). The dashboard's own pane is excluded. **NOT** fuzzyclaw's stale `~/.tmux/tasks/*.json`. |
| 3/4/6 | **In flight — PRs / Momentum / Recently done** | `session-analysis/initiative-scan.py --json`, TTL-cached to `~/.cache/agent-ops/` |
| 5 | **Health** | `~/.cache/bar-status/{alerts,civitai}.json` |

### Live Claude-session detection
`pgrep -x claude` misses it — Claude Code is nix-wrapped, so the pane-shell's child comm is `.claude-wrapped` (not `claude`), and MCP servers are *always* children so child-presence is not a busy signal. Detection: a pane is a Claude session if its foreground command matches `/claude/` **or** any process in its tree has a comm matching `/claude/`. Per session: repo (git root basename of `pane_current_path`), `session:window`, process age, and a best-effort busy glyph (`▶` if the claude proc is in `R` state, else `●`). The dashboard's own pane is excluded by walking each pane's tree for our PID chain.

### initiative-scan caching (never blocks the popup)
`initiative-scan --json` is slow (hits `gh` across the workspace repos), so it is **never** run on the refresh path. Its output is cached to `~/.cache/agent-ops/initiative-scan.json` with a 120s TTL; the popup renders the last-cached copy immediately with a freshness indicator (`updated Nm ago · refreshing…`) and kicks a **detached background refresh** when stale (lock-guarded). **`build_frame` returns in 31ms even with a stale cache.** No new systemd daemon.

## Keybind — collision check
**prefix+A** ("agents"). Verified free: the 12 scratchpad popups use **Alt** (`M-…`) bindings; `prefix+o` (select-window :16) and `prefix+g` (lazygit) are taken, `prefix+A` is not. `tmux list-keys -T prefix` confirms it binds to the popup and nothing else. Wired via a `home.file` symlink to `~/.config/tmux/agent-ops`, matching the existing tmux-script pattern.

## Tests
`scripts/tests/test_agent_ops.py` — **22 tests, all passing**. fetch is separated from render; the pure aggregation/render functions are tested against mock bar-status JSONs, a **mock tmux-pane list + process tree** (a non-Claude pane that must be excluded + a Claude pane via `.claude-wrapped` that must be included + the own-pane exclusion + ordering), and a mock `initiative-scan --json`. Asserts each section's rows/ordering/counts **and** fail-safe (missing/malformed/empty → graceful `—`, never an exception).

```
nix-shell -p python312Packages.pytest --run "cd \$DEVRC && python3 -m pytest scripts/tests/test_agent_ops.py -q"
22 passed
```

## Verified live (workbench)
- `nix-instantiate --parse nix/home.nix` OK; `home-manager switch` applied; symlink + keybind confirmed (`list-keys`), bound tilde-path executes.
- Opened the interactive dashboard for real in a tmux pane and `capture-pane`'d it — **all 5 sections populate from real data**, including the **active-runs section correctly detecting 23 live Claude sessions** across `datapacket-talos`, `devrc`, `homelab-talos` with their repos + `session:window` + age (incl. *this* session). Momentum/Done/PRs render from the background-built cache with freshness stamps.
- Fast-open confirmed (31ms with stale cache; does not block on `gh`).

**Honest split:** section aggregation/render + fail-safe are unit-tested; live population + detection + fast-open are verified via `capture-pane` of the identical rendered TUI + the switch-installed keybind. A `maim` screenshot of the overlay itself was not captured — the workbench had a fullscreen game grabbing focus over the backgrounded popup window, and forcing a window-raise over it would have disrupted the user; the `capture-pane` output is the exact same rendered frame. **"In flight — PRs"** currently shows *"no open PRs"* — that is the real state (`initiative-scan` returned empty `open_prs` across all repos this run), rendered fail-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)