### PR TITLE
fix(cpu-monitor): ignore logd + comma separator (space broke systemd env)

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -362,10 +362,11 @@ in
         "PATH=${lib.makeBinPath [ pkgs.coreutils pkgs.gawk pkgs.procps pkgs.gnugrep pkgs.libnotify ]}"
         # This laptop runs hot at idle (cooling needs attention); warn early.
         "CPU_MON_TEMP_THRESHOLD=88"
-        # Never alert on these (games / expected heavy apps): case-insensitive
-        # substring match on the busy process's command. Space-separated — add
-        # more here (e.g. "anno steam wine proton") as needed.
-        "CPU_MON_IGNORE=anno"
+        # Never alert on these (games / Android stack / expected heavy apps):
+        # case-insensitive substring match on the busy process's command.
+        # COMMA-separated (a space gets split by systemd's Environment= parsing
+        # and silently drops entries). Add more, e.g. "anno,logd,steam,lmkd".
+        "CPU_MON_IGNORE=anno,logd"
       ];
       ExecStart = "${pkgs.bash}/bin/bash %h/.config/cpu-monitor/cpu-monitor.sh";
       Restart = "always";

--- a/scripts/cpu-monitor.sh
+++ b/scripts/cpu-monitor.sh
@@ -40,17 +40,19 @@ TEMP_THRESHOLD=${CPU_MON_TEMP_THRESHOLD:-95}
 TEMP_SUSTAIN=${CPU_MON_TEMP_SUSTAIN:-3}
 TEMP_HYSTERESIS=5   # recover only once temp drops this far below the threshold
 
-# Process comms to NEVER alert on — expected heavy hitters (games etc.) whose
-# high CPU is not a problem. Case-insensitive SUBSTRING match against the busy
-# process's command (so "anno" also catches "Anno1800.exe" under Proton).
-# Space-separated; extend via CPU_MON_IGNORE in the systemd service.
-IGNORE=${CPU_MON_IGNORE:-anno}
+# Process comms to NEVER alert on — expected heavy hitters (games, the Android
+# stack, etc.) whose high CPU is not a problem. Case-insensitive SUBSTRING match
+# against the busy process's command (so "anno" also catches "Anno1800.exe" under
+# Proton). COMMA-separated — a space would be split by systemd's Environment=
+# parsing and silently drop entries. Extend via CPU_MON_IGNORE in the service.
+IGNORE=${CPU_MON_IGNORE:-anno,logd}
 
-# is_ignored <comm> -> 0 if it matches any IGNORE entry (case-insensitive substring)
+# is_ignored <comm> -> 0 if it matches any IGNORE entry (case-insensitive substring).
+# Accepts comma- or space-separated IGNORE.
 is_ignored() {
   local comm_lc want_lc
   comm_lc=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
-  for want_lc in $(printf '%s' "$IGNORE" | tr '[:upper:] ' '[:lower:]\n'); do
+  for want_lc in $(printf '%s' "$IGNORE" | tr ',' ' ' | tr '[:upper:]' '[:lower:]'); do
     [ -n "$want_lc" ] || continue
     case "$comm_lc" in *"$want_lc"*) return 0 ;; esac
   done


### PR DESCRIPTION
Adds `logd` (Android/Waydroid logging daemon, seen pegging CPU next to Anno) to the CPU-alert ignore list — **and fixes a bug in the prior change**: a space-separated `CPU_MON_IGNORE` was split by systemd's `Environment=` parsing, silently dropping everything after the first entry (live env was just `anno`). Now comma-separated; `is_ignored` accepts commas.

**Verified:** live env `CPU_MON_IGNORE=anno,logd` intact; anno/Anno1800.exe/logd suppressed; systemd-logind/lmkd/system_server/claude still alert (no false positives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)