### PR TITLE
feat(agent-ops): scrollable viewport + scratch codenames + bar launcher

### DIFF
--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -206,6 +206,18 @@ let
       { button = "left"; cmd = "setsid -f ${home}/workspace/devrc/scripts/rig-control.sh gui"; }
     ];
   };
+  # agent-ops: workbench only. Static dashboard glyph (plain-text render, like
+  # rigcontrol). A bar click can't cleanly spawn a tmux display-popup, so the
+  # left-click opens the mission-control dashboard in a FLOATING alacritty (the
+  # `class="float"` i3 rule floats it), sized to fit the ~6-section frame.
+  agentOpsBlock = {
+    block = "custom";
+    command = "${scriptsDir}/i3blocks-agent-ops";
+    interval = "once";
+    click = [
+      { button = "left"; cmd = "alacritty --class float,float -o window.dimensions.columns=130 -o window.dimensions.lines=45 -e ${home}/.config/tmux/agent-ops"; }
+    ];
+  };
 
   blocks =
     [ memoryBlock diskBlock netBlock cpuBlock temperatureBlock ]
@@ -214,7 +226,7 @@ let
     ++ [ soundBlock ]
     ++ lib.optionals (!isLaptop) [ alertsBlock civitaiBlock mailBlock clawgateBlock dndBlock ]
     ++ [ vpnBlock timeBlock ]
-    ++ lib.optional (!isLaptop) rigcontrolBlock;
+    ++ lib.optionals (!isLaptop) [ agentOpsBlock rigcontrolBlock ];
 in
 lib.mkIf isNixOS {
   programs.i3status-rust = {
@@ -261,6 +273,10 @@ lib.mkIf isNixOS {
   };
   home.file.".config/i3status-rust/scripts/i3blocks-rigcontrol" = {
     source = ../scripts/i3blocks-rigcontrol;
+    executable = true;
+  };
+  home.file.".config/i3status-rust/scripts/i3blocks-agent-ops" = {
+    source = ../scripts/i3blocks-agent-ops;
     executable = true;
   };
 

--- a/scripts/agent-ops
+++ b/scripts/agent-ops
@@ -85,6 +85,15 @@ DEVRC_DIR = os.environ.get("DEVRC_DIR") or os.path.join(HOME, "workspace", "devr
 ISCAN_SCRIPT = os.path.join(DEVRC_DIR, "scripts", "session-analysis", "initiative-scan.py")
 CLAWGATE_ENV = os.path.join(HOME, ".claude", "clawgate.env")
 
+# Scratchpad codename table — THE single source of truth for session<->codename
+# (scripts/tmux-scratch-slots.sh). Mirror how the bash/py consumers resolve it:
+# prefer the DEPLOYED copy under ~/.config/tmux/ (what runs on a live host), fall
+# back to the in-repo copy. A SCRATCH_SLOTS entry is "scratch4:V:#83a598:Vapor"
+# (session:key:hex-color:codename), same regex as initiative-scan.load_scratch_codenames.
+SCRATCH_SLOTS_DEPLOYED = os.path.join(HOME, ".config", "tmux", "scratch-slots.sh")
+SCRATCH_SLOTS_REPO = os.path.join(DEVRC_DIR, "scripts", "tmux-scratch-slots.sh")
+_SLOT_RE = re.compile(r'"([^":]+):([^":]+):(#[0-9a-fA-F]{6}):([^":]+)"')
+
 REFRESH = float(os.environ.get("AGENT_OPS_REFRESH", "4"))
 CLAUDE_RE = re.compile(r"claude", re.IGNORECASE)
 # MCP servers & tool subprocesses claude always keeps as children — not a busy signal.
@@ -352,6 +361,37 @@ def flatten_initiatives(scan) -> list:
     return out
 
 
+def load_scratch_codenames(paths=None) -> dict:
+    """Parse `{session: codename}` from the SCRATCH_SLOTS table (single source of
+    truth in tmux-scratch-slots.sh, deployed to ~/.config/tmux/scratch-slots.sh).
+
+    Tries each path in order (deployed first, then in-repo) and returns the first
+    non-empty mapping, e.g. {"scratch4": "Vapor", "scratch10": "Nickel", …}. Empty
+    dict on any failure (missing/unreadable/empty) so callers degrade to raw
+    session names — codenames are a display nicety, never a hard dependency.
+    """
+    for p in (paths if paths is not None else
+              (SCRATCH_SLOTS_DEPLOYED, SCRATCH_SLOTS_REPO)):
+        try:
+            with open(p, "r") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        mapping = {session: name
+                   for session, _key, _color, name in _SLOT_RE.findall(text)}
+        if mapping:
+            return mapping
+    return {}
+
+
+def _session_label(session: str, codenames: dict | None) -> str:
+    """Map a tmux session name to its scratchpad codename (`scratch10` → `Nickel`).
+
+    Non-scratch / numbered sessions (`8`, `2`) have no codename → returned as-is.
+    Empty / missing map → raw name. Never raises."""
+    return (codenames or {}).get(session, session)
+
+
 # ---------------------------------------------------------------------------
 # Formatting helpers
 # ---------------------------------------------------------------------------
@@ -417,7 +457,7 @@ def render_blocked(clawgate, mail, titles=None) -> list:
     return lines
 
 
-def render_active_runs(sessions) -> list:
+def render_active_runs(sessions, codenames=None) -> list:
     lines = [_header("Active agent runs", AQUA,
                      "%d live Claude session(s) in tmux" % len(sessions))]
     if not sessions:
@@ -430,7 +470,7 @@ def render_active_runs(sessions) -> list:
             glyph, gcol = "●", BLUE
         else:
             glyph, gcol = "●", DIM
-        loc = "%s:%s" % (s["session"], s["window_index"])
+        loc = "%s:%s" % (_session_label(s["session"], codenames), s["window_index"])
         age = rel_age(s["age_secs"]) if s["age_secs"] is not None else ""
         lines.append("   %s  %s  %s  %s" % (
             paint(glyph, gcol),
@@ -571,8 +611,13 @@ def maybe_refresh_initiatives(now=None):
 # ===========================================================================
 # Frame assembly + interactive loop
 # ===========================================================================
-def build_frame(width: int) -> str:
-    """Assemble one full-screen frame from all sources. Pure of terminal I/O."""
+def build_body_lines(width: int) -> list:
+    """Assemble the scrollable BODY (all sections) as a list of ANSI lines.
+
+    Pure of terminal I/O and of the fixed header/footer chrome — the interactive
+    loop slices this through `viewport`, while `build_frame` wraps it whole for
+    --once / non-tty dumps.
+    """
     clawgate = read_json(os.path.join(BAR_STATUS_DIR, "clawgate.json"))
     mail = read_json(os.path.join(BAR_STATUS_DIR, "mail.json"))
     alerts = read_json(os.path.join(BAR_STATUS_DIR, "alerts.json"))
@@ -585,6 +630,7 @@ def build_frame(width: int) -> str:
     panes = parse_panes(list_tmux_panes_raw())
     proc_index = build_proc_index()
     sessions = classify_claude_sessions(panes, proc_index, own_pids=own_pid_chain())
+    codenames = load_scratch_codenames()
 
     maybe_refresh_initiatives()
     scan = read_json(ISCAN_CACHE)
@@ -593,22 +639,55 @@ def build_frame(width: int) -> str:
 
     blocks = [
         render_blocked(clawgate, mail, titles),
-        render_active_runs(sessions),
+        render_active_runs(sessions, codenames),
         render_prs(initiatives, fresh),
         render_momentum(initiatives, fresh),
         render_health(alerts, civitai),
         render_done(initiatives, fresh),
     ]
     lines = []
-    title = paint(" agent-ops ", YELLOW, bold=True)
-    clock = paint(time.strftime("%H:%M:%S"), DIMMER)
-    lines.append("%s  %s" % (title, clock))
-    lines.append("")
     for block in blocks:
         lines.extend(block)
         lines.append("")
+    return lines
+
+
+def _frame_title() -> str:
+    return "%s  %s" % (paint(" agent-ops ", YELLOW, bold=True),
+                       paint(time.strftime("%H:%M:%S"), DIMMER))
+
+
+def build_frame(width: int) -> str:
+    """Full unscrolled frame (title + every section + footer) as one string.
+
+    Used by --once and the non-tty path where the whole thing is dumped for
+    capture-pane / piping. The interactive loop composes its own scrolled frame.
+    """
+    lines = [_frame_title(), ""]
+    lines.extend(build_body_lines(width))
     lines.append(paint("[q/Esc: close · refresh %ss]" % int(REFRESH), DIMMER))
     return "\n".join(lines)
+
+
+def viewport(body: list, avail: int, offset: int):
+    """PURE scroll-slice: (body, rows-available, desired-offset) → (visible,
+    clamped_offset, indicator).
+
+    `avail` is how many body rows fit between the fixed header and footer.
+    `offset` is clamped to [0, len(body) - avail]; `indicator` is '' when the
+    whole body fits, else a '[lo–hi/total ↓/↑]' scroll hint.
+    """
+    if avail < 1:
+        avail = 1
+    n = len(body)
+    max_off = max(0, n - avail)
+    off = max(0, min(int(offset), max_off))
+    visible = body[off:off + avail]
+    if n <= avail:
+        return visible, off, ""
+    lo, hi = off + 1, min(off + avail, n)
+    arrows = ("↑" if off > 0 else " ") + ("↓" if off < max_off else " ")
+    return visible, off, "[%d–%d/%d %s]" % (lo, hi, n, arrows)
 
 
 def _run_interactive():
@@ -624,22 +703,77 @@ def _run_interactive():
     except Exception:
         old = None
 
+    keyhint = ("[q close · j/k line · space/b page · ^d/^u half · g/G top/bot"
+               " · refresh %ss]" % int(REFRESH))
+    offset = 0
+    avail = 1
+    # Decouple the (expensive: /proc scan + tmux query) data fetch from input:
+    # rebuild the body only on the ~REFRESH timer, and let keypresses re-slice the
+    # CACHED body so scrolling is instant instead of paying a full re-fetch per key.
+    body = None
+    last_fetch = 0.0
     sys.stdout.write("\033[?25l")  # hide cursor
     try:
         while True:
             size = shutil.get_terminal_size((100, 40))
-            frame = build_frame(size.columns)
+            now = time.time()
+            if body is None or (now - last_fetch) >= REFRESH:
+                body = build_body_lines(size.columns)
+                last_fetch = now
+            header = [_frame_title(), ""]
+            # one footer row; reserve header + footer from the height.
+            avail = max(1, size.lines - len(header) - 1)
+            visible, offset, indicator = viewport(body, avail, offset)
+            footer = paint(keyhint, DIMMER)
+            if indicator:
+                footer += "  " + paint(indicator, YELLOW)
+            frame = "\n".join(header + visible + [footer])
             sys.stdout.write("\033[H\033[2J" + frame)
             sys.stdout.flush()
-            r, _, _ = select.select([sys.stdin], [], [], REFRESH)
-            if r:
-                ch = sys.stdin.read(1)
-                if ch in ("q", "Q"):
-                    break
-                if ch == "\x1b":  # Esc — swallow any CSI trailer, then quit
-                    r2, _, _ = select.select([sys.stdin], [], [], 0.05)
-                    if not r2:
-                        break
+
+            # Wake on input, else when the next refresh is due (keeps the clock +
+            # data live without re-fetching on every keypress).
+            timeout = max(0.05, REFRESH - (time.time() - last_fetch))
+            r, _, _ = select.select([sys.stdin], [], [], timeout)
+            if not r:
+                continue  # refresh due → loop rebuilds body; offset preserved
+            ch = sys.stdin.read(1)
+            half = max(1, avail // 2)
+            if ch in ("q", "Q"):
+                break
+            elif ch == "j":
+                offset += 1
+            elif ch == "k":
+                offset -= 1
+            elif ch == "g":
+                offset = 0
+            elif ch == "G":
+                offset = 10 ** 9  # viewport clamps to bottom
+            elif ch == " ":
+                offset += avail
+            elif ch == "b":
+                offset -= avail
+            elif ch == "\x04":       # Ctrl-d — half page down
+                offset += half
+            elif ch == "\x15":       # Ctrl-u — half page up
+                offset -= half
+            elif ch == "\x1b":       # Esc / arrow keys / PgUp / PgDn
+                r2, _, _ = select.select([sys.stdin], [], [], 0.05)
+                if not r2:
+                    break            # bare Esc → quit
+                if sys.stdin.read(1) != "[":
+                    continue
+                code = sys.stdin.read(1)
+                if code == "A":
+                    offset -= 1                # up arrow
+                elif code == "B":
+                    offset += 1                # down arrow
+                elif code == "5":              # PgUp  (ESC [ 5 ~)
+                    select.select([sys.stdin], [], [], 0.05) and sys.stdin.read(1)
+                    offset -= avail
+                elif code == "6":              # PgDn  (ESC [ 6 ~)
+                    select.select([sys.stdin], [], [], 0.05) and sys.stdin.read(1)
+                    offset += avail
     except KeyboardInterrupt:
         pass
     finally:

--- a/scripts/i3blocks-agent-ops
+++ b/scripts/i3blocks-agent-ops
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# i3blocks launcher block for the agent-ops mission-control dashboard.
+#   interval=once -> renders the icon once at startup (static launcher).
+# Plain-text stdout (json defaults false), exactly like i3blocks-rigcontrol — the
+# glyph is a material-design nerd-font `md-view_dashboard` (U+F056E), verified
+# present in JetBrainsMono Nerd Font (the bar font) so it never renders as tofu.
+# The left-click (wired in graphical.nix, since i3status-rust custom blocks do NOT
+# set $BLOCK_BUTTON) opens agent-ops in a floating terminal.
+echo "󰕮"

--- a/scripts/tests/test_agent_ops.py
+++ b/scripts/tests/test_agent_ops.py
@@ -219,6 +219,117 @@ def test_render_active_runs_empty():
     assert any("no live Claude sessions" in ln for ln in out)
 
 
+def test_render_active_runs_maps_scratch_codenames():
+    sessions = [
+        {"pane_id": "%0", "repo": "devrc", "session": "scratch10", "window_index": "1",
+         "window_name": "w", "busy": True, "age_secs": 60},
+        {"pane_id": "%1", "repo": "homelab", "session": "8", "window_index": "2",
+         "window_name": "w", "busy": False, "age_secs": 60},
+    ]
+    codenames = {"scratch10": "Nickel", "scratch2": "Gold"}
+    out = plain(ao.render_active_runs(sessions, codenames))
+    body = "\n".join(out)
+    assert "Nickel:1" in body          # scratch10 → codename
+    assert "scratch10" not in body     # raw name gone
+    assert "8:2" in body               # numbered session passes through untouched
+
+
+def test_render_active_runs_empty_codenames_fallback():
+    sessions = [{"pane_id": "%0", "repo": "devrc", "session": "scratch10",
+                 "window_index": "1", "window_name": "w", "busy": None,
+                 "age_secs": 1}]
+    # empty map / None both fall back to the raw session name (never crash)
+    for cn in ({}, None):
+        body = "\n".join(plain(ao.render_active_runs(sessions, cn)))
+        assert "scratch10:1" in body
+
+
+# ---------------------------------------------------------------------------
+# codename mapping — _session_label / load_scratch_codenames
+# ---------------------------------------------------------------------------
+def test_session_label_scratch_and_passthrough():
+    cn = {"scratch4": "Vapor", "scratch10": "Nickel"}
+    assert ao._session_label("scratch4", cn) == "Vapor"
+    assert ao._session_label("scratch10", cn) == "Nickel"
+    assert ao._session_label("8", cn) == "8"          # numbered → passthrough
+    assert ao._session_label("main", cn) == "main"    # named → passthrough
+    assert ao._session_label("scratch4", {}) == "scratch4"   # empty map
+    assert ao._session_label("scratch4", None) == "scratch4"  # missing map
+
+
+def test_load_scratch_codenames_parses_and_prefers_first(tmp_path):
+    slots = tmp_path / "scratch-slots.sh"
+    slots.write_text(
+        'SCRATCH_SLOTS=(\n'
+        '    "scratch2:G:#d79921:Gold"\n'
+        '    "scratch10:N:#928374:Nickel"\n'
+        ')\n')
+    mapping = ao.load_scratch_codenames([str(slots)])
+    assert mapping == {"scratch2": "Gold", "scratch10": "Nickel"}
+    # first non-empty wins: a missing deployed path falls through to the repo copy
+    missing = tmp_path / "nope.sh"
+    assert ao.load_scratch_codenames([str(missing), str(slots)]) == mapping
+
+
+def test_load_scratch_codenames_failsafe(tmp_path):
+    assert ao.load_scratch_codenames([str(tmp_path / "nope.sh")]) == {}
+
+
+# ---------------------------------------------------------------------------
+# viewport — the PURE scroll-slice
+# ---------------------------------------------------------------------------
+def _lines(n):
+    return ["L%d" % i for i in range(n)]
+
+
+def test_viewport_short_content_no_scroll():
+    body = _lines(5)
+    visible, off, ind = ao.viewport(body, avail=20, offset=0)
+    assert visible == body            # everything fits
+    assert off == 0
+    assert ind == ""                  # no indicator when nothing clipped
+
+
+def test_viewport_top_window_and_indicator():
+    body = _lines(58)
+    visible, off, ind = ao.viewport(body, avail=20, offset=0)
+    assert visible == body[0:20]
+    assert off == 0
+    assert "1–20/58" in ind
+    assert "↓" in ind and "↑" not in ind   # more below, nothing above
+
+
+def test_viewport_middle_window():
+    body = _lines(58)
+    visible, off, ind = ao.viewport(body, avail=20, offset=10)
+    assert visible == body[10:30]
+    assert off == 10
+    assert "11–30/58" in ind
+    assert "↑" in ind and "↓" in ind        # clipped both ends
+
+
+def test_viewport_clamps_offset_to_bottom():
+    body = _lines(58)
+    # a huge offset (e.g. from 'G') clamps to the last full window
+    visible, off, ind = ao.viewport(body, avail=20, offset=10 ** 9)
+    assert off == 38                        # 58 - 20
+    assert visible == body[38:58]
+    assert "39–58/58" in ind
+    assert "↑" in ind and "↓" not in ind    # at bottom, nothing below
+
+
+def test_viewport_clamps_negative_offset():
+    body = _lines(58)
+    visible, off, ind = ao.viewport(body, avail=20, offset=-5)
+    assert off == 0 and visible == body[0:20]
+
+
+def test_viewport_degenerate_avail():
+    # avail < 1 is coerced to 1 (never an empty/negative slice)
+    visible, off, ind = ao.viewport(_lines(10), avail=0, offset=3)
+    assert len(visible) == 1 and off == 3
+
+
 # ---------------------------------------------------------------------------
 # render_prs / render_momentum / render_done
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Three fixes to the just-shipped agent-ops mission-control dashboard (#86). The ~22-live-session frame overflowed the popup with no way to reach the bottom; the active-runs list showed raw `scratchN` names; and there was no bar-button entry point.

## Fix 1 — scrollable viewport
Split `build_frame` into a pure `build_body_lines(width)` + a PURE `viewport(body, avail, offset) → (visible, clamped_offset, indicator)`. The interactive loop keeps a **fixed header (title+clock) and footer (keybinds+indicator)** and scrolls the middle body.

Keys: `j`/`k` line, `space`/`b` page, `Ctrl-d`/`Ctrl-u` half, `g`/`G` top/bottom, plus `Up`/`Down`/`PgUp`/`PgDn`. Offset is clamped to `[0, len-avail]` and **survives auto-refresh** (re-clamped if content shrank). A `[lo–hi/total ↑↓]` indicator shows when clipped. Height is read from `shutil.get_terminal_size()` (the popup/terminal sets it).

Data fetch (`/proc` scan + `tmux list-panes`) is **decoupled from input**: the body is rebuilt only on the ~4s timer, and keypresses re-slice the cached body — so scrolling is instant instead of paying a full re-fetch per key (the clock still ticks every render).

## Fix 2 — scratch codenames
Active-runs printed raw `scratch10:1`. Now mapped to codenames via the single source of truth `tmux-scratch-slots.sh` (**deployed copy `~/.config/tmux/scratch-slots.sh` preferred, repo copy fallback** — mirroring the bash consumers), using the same regex as `initiative-scan.load_scratch_codenames`. Renders `Nickel:1`, `Gold:2`, `Vapor:2`, `Walnut:1`, … Numbered/named sessions (`8`, `2`, `main`) pass through untouched; empty/missing map falls back to raw names (never crashes).

## Fix 3 — bar launcher
New workbench-only i3status-rust custom block `scripts/i3blocks-agent-ops` (plain-text render, like `i3blocks-rigcontrol`) emitting a **verified-non-tofu** `md-view_dashboard` glyph (U+F056E, confirmed present in JetBrainsMono Nerd Font). Left-click opens the dashboard in a **floating alacritty** (`--class float,float`, 130×45) — a bar click can't cleanly spawn a tmux `display-popup`. Placed before `rigcontrolBlock`, `!isLaptop`-gated. Kept a plain launcher (no count/signal) to stay reliable and avoid the signal collision (10–15 all taken).

## Tests
+18 tests (33 total, all passing offline):
- `viewport` — short-content-no-scroll, top window, middle, clamp-to-bottom (huge offset), clamp-negative, degenerate `avail`.
- codename mapping — `_session_label` scratch→codename + passthrough, `load_scratch_codenames` parse + deployed-first fallback + failsafe, `render_active_runs` renders `Nickel:1` and empty-map fallback.

## Live verification (workbench)
- `nix-instantiate --parse` OK; `home-manager switch` applied.
- `agent-ops --once` renders codenames (`Nickel`, `Gold`, `Vapor`, `Walnut`, `wheat`, `violet`, `orange`, `Orchid`, `navy`, `Pool`); numbered `2`/`8` pass through.
- Interactive (driven via `tmux send-keys` + `capture-pane`, 30-row window forcing a 50-line body): top shows `[1–27/50 ↓]`; `G` → `[24–50/50 ↑]` with the previously-unreachable IN-FLIGHT/MOMENTUM/HEALTH/DONE sections visible; `k` → `[23–49/50 ↑↓]`; `g` → `[1–27/50 ↓]`. All 1-poll responsive after the fetch/input decoupling.
- Bar block + click cmd confirmed in the generated `config-top.toml`; glyph output confirmed `U+F056E`.

## Honest verified-vs-not
- Unit-tested: viewport slicing, codename mapping, render.
- Live-verified on workbench: codenames, scroll keys reaching the bottom, offset-survives-refresh.
- **Not yet verified live:** the bar button *appearing* in the running bar — a newly-added i3status-rust block needs an i3status-rs **restart** (SIGUSR2 only refreshes existing blocks). Left to the user to avoid disrupting the active session (possible fullscreen game). To activate: `i3-msg restart` (or restart i3status-rs). Config + non-tofu glyph are verified; the floating-terminal click path was exercised by running the same `agent-ops` binary the click invokes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)