### PR TITLE
fix(i3): quote the $mod+i agent-ops exec so it doesn't error

### DIFF
--- a/nix/i3/config.nix
+++ b/nix/i3/config.nix
@@ -186,9 +186,11 @@ bindsym $mod+b exec --no-startup-id brave
 # agent-ops "mission control" dashboard — real open PRs, live agent runs (task +
 # codename + busy), momentum, health. Floats via the class="float" rule above; the
 # SAME launch the i3-bar button uses. Dashboard renders the deterministic caches.
-bindsym $mod+i exec --no-startup-id alacritty --class float,float \
-    -o window.dimensions.columns=130 -o window.dimensions.lines=45 \
-    -e ~/.config/tmux/agent-ops
+# NOTE: the exec command MUST be quoted as a single string. Unquoted (and/or with
+# `\` line-continuation), i3's command parser chokes on the alacritty flags at
+# key-press time and pops an error nagbar — even though it partly runs. Quoting
+# hands the whole string to `sh -c` as one command.
+bindsym $mod+i exec --no-startup-id "alacritty --class float,float -o window.dimensions.columns=130 -o window.dimensions.lines=45 -e ~/.config/tmux/agent-ops"
 
 # Quick workspace switching
 bindsym $mod+Tab workspace back_and_forth


### PR DESCRIPTION
`$mod+i` popped an i3 error nagbar: the binding's `exec` command was unquoted and `\`-continued across 3 lines, so i3's command parser choked on the alacritty flags at key-press time (it even partly ran the command). Quoting the whole command into a single string hands it to `sh -c` as one unit.

**Verified live:** `get_config` now shows one clean quoted binding; `i3-msg reload` + running the exec through i3 both return `success:true` with no parser error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)