### PR TITLE
feat(bar): disk pill left-click → all-disks view

### DIFF
--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -33,12 +33,16 @@ let
     critical_mem = 92;
     interval = 10;
   };
+  # Bar shows "/" only; left-click expands to all real filesystems (disk-detail).
   diskBlock = {
     block = "disk_space";
     path = "/";
     format = " $icon $available ";
     info_type = "available";
     interval = 60;
+    click = [
+      { button = "left"; cmd = "alacritty --class float,float -e ${scriptsDir}/disk-detail"; }
+    ];
   };
   # net: NO `device` set on purpose. i3status-rust auto-follows the default-route
   # interface, so the one config is correct on BOTH hosts (workbench is wired on
@@ -292,6 +296,10 @@ lib.mkIf isNixOS {
   };
   home.file.".config/i3status-rust/scripts/vpn-detail" = {
     source = ../scripts/i3blocks-vpn-detail;
+    executable = true;
+  };
+  home.file.".config/i3status-rust/scripts/disk-detail" = {
+    source = ../scripts/disk-detail;
     executable = true;
   };
   home.file.".config/i3status-rust/scripts/i3blocks-rigcontrol" = {

--- a/scripts/disk-detail
+++ b/scripts/disk-detail
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# All-disks view for the bar's disk block (left-click → floating alacritty).
+# Shows every real filesystem (pseudo/overlay/tmpfs mounts filtered out) so the
+# single "/" figure on the bar can be expanded to the full mount picture on demand.
+set -u
+
+echo "Filesystems  ($(date '+%Y-%m-%d %H:%M'))"
+echo
+df -h --output=source,fstype,size,used,avail,pcent,target \
+  -x tmpfs -x devtmpfs -x efivarfs -x squashfs -x overlay -x ramfs -x autofs
+echo
+read -rp "Press enter to close..."


### PR DESCRIPTION
The disk block only surfaces `/`. This adds a **left-click** that opens a floating alacritty running the new `scripts/disk-detail` — `df -h` across every real filesystem (pseudo/overlay/tmpfs/squashfs filtered out), press-enter to close. Mirrors the VPN block's detail-view idiom.

## Changes
- `nix/graphical.nix`: `diskBlock` gets a `click` → `alacritty --class float,float -e .../disk-detail`; symlink the script into `scriptsDir` via `home.file`.
- `scripts/disk-detail`: new viewer (tracked so the flake sees it).

## Verified (workbench)
- `home-manager switch` clean; generated `config-top.toml` has the `[[block.click]]`.
- Script runs and prints the full mount table (7 real disks, no tmpfs noise).
- Bar restarted in place (`i3-msg restart`) and is live on the new config.

Applies to both hosts (`diskBlock` is in the shared blocks list); reaches the laptop via `ship.sh` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)