### PR TITLE
feat(bar): disk pill click → rofi gauge list, not a raw df dump

### DIFF
--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -33,7 +33,8 @@ let
     critical_mem = 92;
     interval = 10;
   };
-  # Bar shows "/" only; left-click expands to all real filesystems (disk-detail).
+  # Bar shows "/" only; left-click opens a rofi gauge list of all real filesystems
+  # (disk-detail — mirrors the media/vpn detail idiom, not a raw df terminal dump).
   diskBlock = {
     block = "disk_space";
     path = "/";
@@ -41,7 +42,7 @@ let
     info_type = "available";
     interval = 60;
     click = [
-      { button = "left"; cmd = "alacritty --class float,float -e ${scriptsDir}/disk-detail"; }
+      { button = "left"; cmd = "${scriptsDir}/disk-detail"; }
     ];
   };
   # net: NO `device` set on purpose. i3status-rust auto-follows the default-route

--- a/scripts/disk-detail
+++ b/scripts/disk-detail
@@ -1,12 +1,183 @@
-#!/usr/bin/env bash
-# All-disks view for the bar's disk block (left-click → floating alacritty).
-# Shows every real filesystem (pseudo/overlay/tmpfs mounts filtered out) so the
-# single "/" figure on the bar can be expanded to the full mount picture on demand.
-set -u
+#!/usr/bin/env python3
+"""All-disks view for the i3status-rust `disk_space` block (left-click).
 
-echo "Filesystems  ($(date '+%Y-%m-%d %H:%M'))"
-echo
-df -h --output=source,fstype,size,used,avail,pcent,target \
-  -x tmpfs -x devtmpfs -x efivarfs -x squashfs -x overlay -x ramfs -x autofs
-echo
-read -rp "Press enter to close..."
+The bar pill only shows `/`; a left-click opens THIS rofi list — one row per real
+filesystem with a colored usage gauge, mirroring the media/vpn block detail idiom
+(gruvbox-dark-hard theme, pango-markup rows) instead of a raw `df` terminal dump.
+Selecting a row opens that mountpoint in the file manager (xdg-open); Esc dismisses.
+
+Pseudo/overlay/tmpfs mounts are filtered out so only real disks show. Everything is
+best-effort — a launcher must never crash loudly.
+
+The pure/mockable logic (df parse, human sizes, gauge + row formatting) is factored
+out and unit-tested in scripts/tests/test_disk_detail.py; `--dump` prints the rows
+without touching rofi.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+ROFI_THEME = "gruvbox-dark-hard"   # matches media-menu / the $mod+d launcher
+BAR_WIDTH = 12                     # gauge cells
+
+# gruvbox-dark-hard palette (usage-tier colors for the gauge).
+GREEN, YELLOW, RED, FG, DIM = "#b8bb26", "#fabd2f", "#fb4934", "#ebdbb2", "#928374"
+
+# Pseudo filesystems that aren't real disks — never show these.
+SKIP_FSTYPES = frozenset({
+    "tmpfs", "devtmpfs", "efivarfs", "squashfs", "overlay",
+    "ramfs", "autofs", "fuse.portal", "fuse.gvfsd-fuse", "nsfs",
+})
+
+
+# --------------------------------------------------------------------------- #
+# Pure / mockable logic (unit-tested against fixtures — NO subprocess)
+# --------------------------------------------------------------------------- #
+def human(n) -> str:
+    """Compact human size from a byte count: '957M', '1.8T', '641G'."""
+    try:
+        n = float(n)
+    except (TypeError, ValueError):
+        return "?"
+    for unit in ("B", "K", "M", "G", "T", "P"):
+        if n < 1024 or unit == "P":
+            if unit == "B":
+                return "%dB" % int(n)
+            return ("%.1f%s" % (n, unit)).replace(".0%s" % unit, unit)
+        n /= 1024.0
+    return "?"
+
+
+def parse_df(output: str) -> list:
+    """Parse `df -B1 --output=source,fstype,size,used,avail,target` into dicts.
+
+    Skips the header line and pseudo filesystems (SKIP_FSTYPES). Each dict has
+    source/fstype/size/used/avail/target (bytes as ints) + a derived pct (0-100).
+    Malformed rows are dropped rather than raising.
+    """
+    disks = []
+    for line in output.splitlines():
+        parts = line.split(None, 5)
+        if len(parts) < 6 or parts[0] == "Filesystem":
+            continue
+        source, fstype, size, used, avail, target = parts
+        if fstype in SKIP_FSTYPES:
+            continue
+        try:
+            size_i, used_i, avail_i = int(size), int(used), int(avail)
+        except ValueError:
+            continue
+        pct = round(100 * used_i / size_i) if size_i > 0 else 0
+        disks.append({
+            "source": source, "fstype": fstype, "size": size_i,
+            "used": used_i, "avail": avail_i, "target": target, "pct": pct,
+        })
+    return disks
+
+
+def gauge_color(pct: int) -> str:
+    """Usage-tier color: green <70, yellow 70-89, red >=90."""
+    if pct >= 90:
+        return RED
+    if pct >= 70:
+        return YELLOW
+    return GREEN
+
+
+def gauge(pct: int, width: int = BAR_WIDTH) -> str:
+    """A `width`-cell block gauge: filled '█' up to pct, '░' for the remainder."""
+    pct = max(0, min(100, int(pct)))
+    filled = round(width * pct / 100)
+    return "█" * filled + "░" * (width - filled)
+
+
+def _trunc(s: str, n: int) -> str:
+    """Left-truncate a long mountpoint to width n with a leading ellipsis."""
+    return s if len(s) <= n else "…" + s[-(n - 1):]
+
+
+def format_row(d: dict) -> str:
+    """One pango-markup rofi row: mountpoint · colored gauge · pct · free/size.
+
+    Requires a monospace font (forced via -theme-str) for column alignment.
+    """
+    target = _trunc(d["target"], 24).ljust(24)
+    color = gauge_color(d["pct"])
+    bar = "<span foreground='%s'>%s</span>" % (color, gauge(d["pct"]))
+    pct = "<span foreground='%s'>%3d%%</span>" % (color, d["pct"])
+    free = human(d["avail"]).rjust(6)
+    size = human(d["size"])
+    return ("<span foreground='%s'>%s</span> %s %s  "
+            "%s free <span foreground='%s'>/ %s</span>"
+            % (FG, target, bar, pct, free, DIM, size))
+
+
+def build_rows(disks: list) -> list:
+    """(markup_row, mountpoint) pairs, disks ordered as given (df order)."""
+    return [(format_row(d), d["target"]) for d in disks]
+
+
+# --------------------------------------------------------------------------- #
+# Side-effecting (subprocess / rofi — not unit-tested)
+# --------------------------------------------------------------------------- #
+def read_disks() -> list:
+    """Run df and parse it; [] on any failure."""
+    try:
+        out = subprocess.run(
+            ["df", "-B1", "--output=source,fstype,size,used,avail,target"],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            text=True, timeout=10).stdout
+    except Exception:
+        return []
+    return parse_df(out)
+
+
+def rofi_pick(rows: list) -> int | None:
+    """Show the gauge list in rofi; return the selected index, or None if cancelled."""
+    theme_str = ("element-text { font: \"JetBrainsMono Nerd Font Mono 11\"; } "
+                 "listview { lines: %d; }" % max(1, len(rows)))
+    argv = [
+        "rofi", "-dmenu", "-i", "-no-custom", "-markup-rows", "-format", "i",
+        "-p", "Disks", "-theme", ROFI_THEME, "-theme-str", theme_str,
+    ]
+    try:
+        r = subprocess.run(argv, input="\n".join(m for m, _ in rows),
+                           text=True, stdout=subprocess.PIPE)
+    except Exception:
+        return None
+    if r.returncode != 0:
+        return None
+    sel = r.stdout.strip()
+    return int(sel) if sel.isdigit() else None
+
+
+def xdg_open(path: str) -> None:
+    try:
+        subprocess.Popen(["xdg-open", path], stdout=subprocess.DEVNULL,
+                         stderr=subprocess.DEVNULL)
+    except Exception:
+        pass
+
+
+def main(argv=None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    disks = read_disks()
+    rows = build_rows(disks)
+    if "--dump" in argv:   # offline: print rows, no rofi
+        for markup, target in rows:
+            print("%s\t%s" % (target, markup))
+        return 0
+    if not rows:
+        return 0
+    idx = rofi_pick(rows)
+    if idx is not None and 0 <= idx < len(rows):
+        xdg_open(rows[idx][1])
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:   # a launcher must never crash loudly
+        sys.exit(0)

--- a/scripts/tests/test_disk_detail.py
+++ b/scripts/tests/test_disk_detail.py
@@ -1,0 +1,140 @@
+"""Unit tests for scripts/disk-detail — the rofi gauge list for the disk block.
+
+All OFFLINE: rofi/df/xdg-open are never touched. The rofi UI isn't unit-testable,
+so the LOGIC is factored into pure functions and tested here:
+  - `df -B1` parse (header/pseudo-fs filtering, pct derivation, malformed rows),
+  - human byte formatting, the usage gauge + its color tiers,
+  - the pango-markup row builder,
+and the `--dump` CLI path is exercised via subprocess. Mirrors test_media_menu.py.
+
+    run:  pytest scripts/tests/test_disk_detail.py
+"""
+import importlib.machinery
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+
+
+def _load(name, modname):
+    loader = importlib.machinery.SourceFileLoader(modname, str(SCRIPTS / name))
+    spec = importlib.util.spec_from_loader(modname, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+dd = _load("disk-detail", "disk_detail")
+
+TB = 1024 ** 4
+GB = 1024 ** 3
+
+# A representative `df -B1 --output=source,fstype,size,used,avail,target` block:
+# a real ext4 root, a vfat /boot, and two pseudo mounts that MUST be filtered.
+DF_SAMPLE = """\
+Filesystem     Type       1B-blocks         Used      Available Mounted on
+/dev/nvme0n1p2 ext4  1979120929792 1160000000000  700000000000 /
+/dev/nvme0n1p1 vfat     1071624192     69206016    1002418176 /boot
+tmpfs          tmpfs   16000000000       500000   15999500000 /run
+efivarfs       efivarfs      131072        12288        118784 /sys/firmware/efi/efivars
+"""
+
+
+# --------------------------------------------------------------------------- #
+# parse_df
+# --------------------------------------------------------------------------- #
+def test_parse_df_keeps_real_drops_pseudo_and_header():
+    disks = dd.parse_df(DF_SAMPLE)
+    assert [d["target"] for d in disks] == ["/", "/boot"]
+    assert all(d["fstype"] not in dd.SKIP_FSTYPES for d in disks)
+
+
+def test_parse_df_derives_pct_from_used_over_size():
+    root = dd.parse_df(DF_SAMPLE)[0]
+    assert root["pct"] == round(100 * 1160000000000 / 1979120929792)  # ~59
+
+
+def test_parse_df_skips_malformed_and_zero_size():
+    bad = "Filesystem Type 1B-blocks Used Available Mounted on\n" \
+          "/dev/x ext4 notanumber 1 1 /x\n" \
+          "/dev/y ext4 0 0 0 /y\n"
+    disks = dd.parse_df(bad)
+    # malformed row dropped entirely; zero-size row kept but pct guarded to 0
+    assert [d["target"] for d in disks] == ["/y"]
+    assert disks[0]["pct"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# human
+# --------------------------------------------------------------------------- #
+def test_human_scales_units():
+    assert dd.human(500) == "500B"
+    assert dd.human(1536) == "1.5K"
+    assert dd.human(2 * GB) == "2G"
+    assert dd.human(1.8 * TB).endswith("T")
+
+
+def test_human_bad_input():
+    assert dd.human(None) == "?"
+    assert dd.human("x") == "?"
+
+
+# --------------------------------------------------------------------------- #
+# gauge + color tiers
+# --------------------------------------------------------------------------- #
+def test_gauge_width_and_fill():
+    g = dd.gauge(50, width=10)
+    assert len(g) == 10
+    assert g.count("█") == 5 and g.count("░") == 5
+
+
+def test_gauge_clamps_out_of_range():
+    assert dd.gauge(-5, width=8) == "░" * 8
+    assert dd.gauge(150, width=8) == "█" * 8
+
+
+def test_gauge_color_tiers():
+    assert dd.gauge_color(10) == dd.GREEN
+    assert dd.gauge_color(69) == dd.GREEN
+    assert dd.gauge_color(70) == dd.YELLOW
+    assert dd.gauge_color(89) == dd.YELLOW
+    assert dd.gauge_color(90) == dd.RED
+    assert dd.gauge_color(99) == dd.RED
+
+
+# --------------------------------------------------------------------------- #
+# format_row / build_rows
+# --------------------------------------------------------------------------- #
+def test_format_row_has_markup_and_pct():
+    d = {"target": "/", "pct": 59, "avail": 700 * GB, "size": 1.8 * TB}
+    row = dd.format_row(d)
+    assert "<span" in row and "59%" in row
+    assert dd.GREEN in row  # 59% -> green tier
+
+
+def test_format_row_truncates_long_mountpoint():
+    d = {"target": "/home/zach/workspace/very/deep/nested/mount",
+         "pct": 5, "avail": GB, "size": 2 * GB}
+    row = dd.format_row(d)
+    assert "…" in row
+
+
+def test_build_rows_pairs_markup_with_mountpoint():
+    disks = dd.parse_df(DF_SAMPLE)
+    rows = dd.build_rows(disks)
+    assert [t for _, t in rows] == ["/", "/boot"]
+    assert all("<span" in m for m, _ in rows)
+
+
+# --------------------------------------------------------------------------- #
+# --dump CLI (offline, no rofi)
+# --------------------------------------------------------------------------- #
+def test_dump_cli_runs_without_rofi():
+    r = subprocess.run([sys.executable, str(SCRIPTS / "disk-detail"), "--dump"],
+                       stdout=subprocess.PIPE, text=True, timeout=15)
+    assert r.returncode == 0
+    # every emitted line is "<mountpoint>\t<markup>"; real disks carry a gauge span
+    for line in r.stdout.splitlines():
+        assert "\t" in line


### PR DESCRIPTION
Follow-up to #98. The first cut opened a floating terminal with a raw `df` dump — ugly and off the bar's house style (its other detail views are rofi menus).

## Now
Left-clicking the disk pill opens a **rofi list** (gruvbox-dark-hard, pango-markup, monospace-forced for column alignment) — one row per real filesystem:

```
/                        ███████░░░░░  60%    640G free / 1.8T
/boot                    █░░░░░░░░░░░   6%  956.2M free / 1022M
…ome/zach/workspace/fast ███████░░░░░  59%    1.3T free / 3.6T
```

- Color-tiered usage gauge — green <70%, yellow 70–89%, red ≥90%.
- Human free/total; long mountpoints left-truncated with a leading ellipsis.
- Selecting a disk opens its mountpoint (`xdg-open`); Esc dismisses.
- Pseudo/overlay/tmpfs mounts filtered out.

## Changes
- `scripts/disk-detail`: rewritten Python (rofi launcher), replaces the terminal viewer.
- `nix/graphical.nix`: click cmd drops the `alacritty` wrapper (rofi draws its own window).
- `scripts/tests/test_disk_detail.py`: 12 unit tests over the pure logic (df parse, human sizes, gauge + color tiers, row builder, `--dump` CLI).

## Verified (workbench)
- `pytest` — 12 passed.
- `home-manager switch` clean; TOML click cmd → the script; symlink resolves to the new content; bar restarted in place and live.
- `--dump` renders all 7 real disks correctly, no tmpfs noise.

Applies to both hosts; reaches the laptop via `ship.sh` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)