### PR TITLE
feat(bar): live agent-ops count, vitals→btop, disk→ncdu, single-source thresholds

### DIFF
--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -41,7 +41,10 @@ let
   # Built-in blocks (order = left → right on the bar).
   memoryBlock = {
     block = "memory";
-    format = " $icon $mem_used_percents ";
+    # Show RAM *used* as a size (e.g. "6.5GB"), NOT a percentage — a bare % here
+    # collided visually with the cpu block's % (they read as two CPU items). A size
+    # for RAM + a % for CPU are instantly distinct. warning/critical still key off %.
+    format = " $icon $mem_used ";
     warning_mem = 80;
     critical_mem = 92;
     interval = 10;

--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -29,7 +29,9 @@ let
 
   # Floating btop for the vitals-block left-clicks (memory/cpu/temperature/gpu).
   # `float,float` matches the existing i3 float rule so it opens as a float.
-  btopCmd = "alacritty --class float,float -e btop";
+  # Explicit dimensions are REQUIRED — btop refuses to render ("terminal size too
+  # small") in the default float size; matches the agentOps popup sizing idiom.
+  btopCmd = "alacritty --class float,float -o window.dimensions.columns=160 -o window.dimensions.lines=45 -e btop";
 
   # Python env for the decoupled bar-status poller (workbench systemd user timer):
   # psycopg2 for the homelab Postgres open-mail_actions count; clawgate + Alertmanager

--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -20,6 +20,17 @@ let
   home = config.home.homeDirectory;
   scriptsDir = "${home}/.config/i3status-rust/scripts";
 
+  # Count-block red thresholds — SINGLE SOURCE for both the pill (--red-above) and
+  # the poller's rising-edge toast (ALERTS_TOAST_ABOVE / CIVITAI_TOAST_ABOVE in the
+  # systemd Environment below). Defining them once here stops the pill and its
+  # toast from drifting apart (they did: pill 34 vs toast default 30 for alerts).
+  alertsRedAbove = 34;
+  civitaiRedAbove = 340;
+
+  # Floating btop for the vitals-block left-clicks (memory/cpu/temperature/gpu).
+  # `float,float` matches the existing i3 float rule so it opens as a float.
+  btopCmd = "alacritty --class float,float -e btop";
+
   # Python env for the decoupled bar-status poller (workbench systemd user timer):
   # psycopg2 for the homelab Postgres open-mail_actions count; clawgate + Alertmanager
   # go over stdlib urllib, so psycopg2 is the only non-stdlib dep.
@@ -32,6 +43,9 @@ let
     warning_mem = 80;
     critical_mem = 92;
     interval = 10;
+    click = [
+      { button = "left"; cmd = btopCmd; }
+    ];
   };
   # Bar shows "/" only; left-click opens a rofi gauge list of all real filesystems
   # (disk-detail — mirrors the media/vpn detail idiom, not a raw df terminal dump).
@@ -43,6 +57,8 @@ let
     interval = 60;
     click = [
       { button = "left"; cmd = "${scriptsDir}/disk-detail"; }
+      # Right-click drills into the FULLEST real mount with ncdu (float terminal).
+      { button = "right"; cmd = "alacritty --class float,float -e ${scriptsDir}/disk-explore"; }
     ];
   };
   # net: NO `device` set on purpose. i3status-rust auto-follows the default-route
@@ -65,6 +81,9 @@ let
     info_cpu = 85;
     warning_cpu = 85;
     critical_cpu = 95;
+    click = [
+      { button = "left"; cmd = btopCmd; }
+    ];
   };
   # temperature: per-host chip. Workbench is AMD (k10temp; Tctl = CPU package temp).
   # Laptop is Intel (coretemp). Validated on workbench via `sensors -u k10temp-*`.
@@ -79,6 +98,9 @@ let
     idle = 78;
     info = 88;
     warning = 95;
+    click = [
+      { button = "left"; cmd = btopCmd; }
+    ];
   } // (if isLaptop then {
     chip = "coretemp-*";
   } else {
@@ -101,6 +123,9 @@ let
     good = 82;
     info = 82;
     warning = 88;
+    click = [
+      { button = "left"; cmd = btopCmd; }
+    ];
   };
   batteryBlock = {
     block = "battery";
@@ -136,7 +161,7 @@ let
     # --red-above: neutral at/below the standing homelab backlog (~24-27 as of
     # 2026-07-11, all known noise), red only when the count climbs ABOVE it. Tune as
     # the baseline drifts. (civitai's stays low deliberately — its growth is real.)
-    command = "${scriptsDir}/i3status-alerts --red-above 34";
+    command = "${scriptsDir}/i3status-alerts --red-above ${toString alertsRedAbove}";
     json = true;
     interval = 30;
     signal = 13;
@@ -152,7 +177,7 @@ let
     block = "custom";
     # --red-above: neutral at/below the standing civitai-prod backlog (~312), red
     # only above it. Big client cluster, so the baseline is high; tune as it drifts.
-    command = "${scriptsDir}/i3status-civitai --red-above 340";
+    command = "${scriptsDir}/i3status-civitai --red-above ${toString civitaiRedAbove}";
     json = true;
     interval = 30;
     signal = 14;
@@ -234,14 +259,17 @@ let
       { button = "left"; cmd = "setsid -f ${home}/workspace/devrc/scripts/rig-control.sh gui"; }
     ];
   };
-  # agent-ops: workbench only. Static dashboard glyph (plain-text render, like
-  # rigcontrol). A bar click can't cleanly spawn a tmux display-popup, so the
-  # left-click opens the mission-control dashboard in a FLOATING alacritty (the
-  # `class="float"` i3 rule floats it), sized to fit the ~6-section frame.
+  # agent-ops: workbench only. LIVE count of Claude-Code-in-tmux runs — renders
+  # `󰕮 N` (N>0) / bare `󰕮` (N==0), always neutral (running agents are steady
+  # state, not "blocked on you"). json render, recounts every 15s via a local
+  # tmux+/proc scan (reuses agent-ops's tested detector) — NO poller/cache/signal
+  # needed since it's local + cheap. The left-click still opens the mission-control
+  # dashboard in a FLOATING alacritty (the `class="float"` i3 rule floats it).
   agentOpsBlock = {
     block = "custom";
-    command = "${scriptsDir}/i3blocks-agent-ops";
-    interval = "once";
+    command = "${scriptsDir}/i3status-agent-ops";
+    json = true;
+    interval = 15;
     click = [
       { button = "left"; cmd = "alacritty --class float,float -o window.dimensions.columns=130 -o window.dimensions.lines=45 -e ${home}/.config/tmux/agent-ops"; }
     ];
@@ -303,12 +331,17 @@ lib.mkIf isNixOS {
     source = ../scripts/disk-detail;
     executable = true;
   };
+  # disk-explore: the disk block's right-click — ncdu on the fullest real mount.
+  home.file.".config/i3status-rust/scripts/disk-explore" = {
+    source = ../scripts/disk-explore;
+    executable = true;
+  };
   home.file.".config/i3status-rust/scripts/i3blocks-rigcontrol" = {
     source = ../scripts/i3blocks-rigcontrol;
     executable = true;
   };
-  home.file.".config/i3status-rust/scripts/i3blocks-agent-ops" = {
-    source = ../scripts/i3blocks-agent-ops;
+  home.file.".config/i3status-rust/scripts/i3status-agent-ops" = {
+    source = ../scripts/i3status-agent-ops;
     executable = true;
   };
 
@@ -397,6 +430,11 @@ lib.mkIf isNixOS {
         "CIVITAI_KUBECONFIG=%h/workspace/civit/datapacket-talos/prod-kubeconfig"
         "DEVRC_DIR=%h/workspace/devrc"
         "HOMELAB_DIR=%h/workspace/homelab-talos"
+        # Rising-edge toast thresholds — SAME source as the pills' --red-above
+        # (alertsRedAbove/civitaiRedAbove) so pill colour + toast fire on one line.
+        # The poller's _env_int(..., 30/340) defaults are now pure fallback.
+        "ALERTS_TOAST_ABOVE=${toString alertsRedAbove}"
+        "CIVITAI_TOAST_ABOVE=${toString civitaiRedAbove}"
         "HOME=%h"
       ];
       ExecStart = "${pollPyEnv}/bin/python3 %h/workspace/devrc/scripts/bar-status-poll";

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -11,6 +11,8 @@ with pkgs; [
   vim
   fzf
   gotop
+  btop          # vitals-block left-click (float terminal) — memory/cpu/temp/gpu
+  ncdu          # disk-block right-click — ncdu on the fullest mount
   wget
   gcc
   bat

--- a/scripts/disk-explore
+++ b/scripts/disk-explore
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Disk block right-click: open `ncdu` on the FULLEST real filesystem.
+
+Pairs with the disk block's left-click (disk-detail's rofi gauge list). Where the
+left-click LISTS all mounts, the right-click drills straight into the one that is
+most full — `ncdu <mountpoint>` in the float terminal (wired in graphical.nix) so
+you can immediately see what is eating the space.
+
+Reuses disk-detail's tested `parse_df` (loaded by path — disk-detail has no .py
+extension) to pick the real mount with the highest usage pct; pseudo/overlay/tmpfs
+mounts are already filtered there. Fail-safe: any failure (df missing, no real
+mounts, malformed) → default to `/`. A launcher must never crash loudly.
+
+`--dry-run` prints the chosen mountpoint instead of exec'ing ncdu (offline test /
+debug path).
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import os
+import subprocess
+import sys
+
+# disk-detail sits next to this script (in the repo AND in the deployed
+# ~/.config/i3status-rust/scripts/ dir) — load it by path to reuse parse_df.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_DISK_DETAIL = os.path.join(_HERE, "disk-detail")
+
+
+def _load_disk_detail(path=_DISK_DETAIL):
+    """Load the disk-detail module (parse_df + read_disks). None on failure."""
+    try:
+        loader = importlib.machinery.SourceFileLoader("disk_detail_ex", path)
+        spec = importlib.util.spec_from_loader("disk_detail_ex", loader)
+        mod = importlib.util.module_from_spec(spec)
+        loader.exec_module(mod)
+        return mod
+    except Exception:
+        return None
+
+
+def fullest_mount(disks, default: str = "/") -> str:
+    """Pick the mountpoint of the real filesystem with the highest usage pct.
+
+    `disks` is disk-detail.parse_df output (pseudo-fs already filtered). Empty /
+    malformed / no valid target → `default`. Pure + fail-safe; a tie keeps the
+    first (df order)."""
+    best = None
+    best_pct = -1
+    for d in disks or []:
+        if not isinstance(d, dict):
+            continue
+        target = d.get("target")
+        if not target:
+            continue
+        try:
+            pct = int(d.get("pct", 0))
+        except (TypeError, ValueError):
+            continue
+        if pct > best_pct:
+            best_pct = pct
+            best = target
+    return best or default
+
+
+def pick_mount() -> str:
+    """Read the live df (via disk-detail) and return the fullest mount, or `/`."""
+    dd = _load_disk_detail()
+    if dd is None:
+        return "/"
+    try:
+        disks = dd.read_disks()
+    except Exception:
+        disks = []
+    return fullest_mount(disks)
+
+
+def main(argv=None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    mount = pick_mount()
+    if "--dry-run" in argv:
+        print(mount)
+        return 0
+    try:
+        os.execvp("ncdu", ["ncdu", mount])
+    except Exception:
+        # ncdu missing / exec failed — don't leave a dead terminal crash-dumping.
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:  # a launcher must never crash loudly
+        sys.exit(0)

--- a/scripts/i3blocks-agent-ops
+++ b/scripts/i3blocks-agent-ops
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# i3blocks launcher block for the agent-ops mission-control dashboard.
-#   interval=once -> renders the icon once at startup (static launcher).
-# Plain-text stdout (json defaults false), exactly like i3blocks-rigcontrol — the
-# glyph is a material-design nerd-font `md-view_dashboard` (U+F056E), verified
-# present in JetBrainsMono Nerd Font (the bar font) so it never renders as tofu.
-# The left-click (wired in graphical.nix, since i3status-rust custom blocks do NOT
-# set $BLOCK_BUTTON) opens agent-ops in a floating terminal.
-echo "󰕮"

--- a/scripts/i3status-agent-ops
+++ b/scripts/i3status-agent-ops
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""i3status-rust custom block: LIVE count of Claude-Code-in-tmux runs.
+
+Renders the agent-ops dashboard glyph `󰕮` (nf-md-view_dashboard) with a live
+count of how many Claude Code sessions are currently running in tmux:
+  N == 0  ->  `󰕮`      (bare glyph — it is ALSO the dashboard launcher, so it
+                        must ALWAYS show; the left-click is wired in graphical.nix)
+  N  > 0  ->  `󰕮 N`
+
+State is ALWAYS neutral/Idle — running agents are the normal steady state, NOT
+"blocked on you" (CALM bar: colour == "look at me", and nothing here demands
+attention). Local + cheap (a tmux + /proc scan), so this block needs NO poller /
+cache / signal — it just recounts on its own `interval`.
+
+Counting REUSES agent-ops's tested pure detector (parse_panes +
+build_proc_index + classify_claude_sessions + own_pid_chain) rather than forking
+it — the module is loaded from the deployed ~/.config/tmux/agent-ops (fallback:
+the in-repo copy) so there is exactly ONE Claude-session detector. This block's
+own process tree is excluded (own_pid_chain), exactly as the dashboard excludes
+its own pane.
+
+Fail-safe: ANY error (agent-ops missing, tmux/proc unavailable, malformed) →
+emit the bare glyph and exit 0. A bar block must never crash loudly.
+
+The pure `count_live_sessions` wrapper is unit-tested against fixture tmux/proc
+data in scripts/tests/test_agent_ops_count.py (mirrors test_agent_ops.py).
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+
+GLYPH = "\U000f056e"  # 󰕮 nf-md-view_dashboard (verified present in the bar font)
+_BARE = {"text": GLYPH, "state": "Idle"}
+
+# Deployed copy first (always symlinked on a live host), then the in-repo copy.
+_AGENT_OPS_PATHS = (
+    os.path.join(os.path.expanduser("~"), ".config", "tmux", "agent-ops"),
+    os.path.join(
+        os.environ.get("DEVRC_DIR", os.path.join(
+            os.path.expanduser("~"), "workspace", "devrc")),
+        "scripts", "agent-ops"),
+)
+
+
+def load_agent_ops(paths=_AGENT_OPS_PATHS):
+    """Load the agent-ops module by explicit path (it has no .py extension).
+
+    Returns the module or None if no copy is loadable (→ caller renders the bare
+    glyph). Import is side-effect-free: agent-ops guards its main() under
+    `if __name__ == '__main__'`."""
+    for p in paths:
+        if not os.path.exists(p):
+            continue
+        try:
+            loader = importlib.machinery.SourceFileLoader("agent_ops_live", p)
+            spec = importlib.util.spec_from_loader("agent_ops_live", loader)
+            mod = importlib.util.module_from_spec(spec)
+            loader.exec_module(mod)
+            return mod
+        except Exception:
+            continue
+    return None
+
+
+def count_live_sessions(ao, list_panes=None, build_index=None,
+                        own_chain=None) -> int:
+    """Number of live Claude-Code-in-tmux runs via agent-ops's pure detector.
+
+    The three impure fetchers (tmux pane list, /proc index, own-pid chain) are
+    injectable so this is unit-testable against fixtures without touching tmux or
+    /proc. `ao` is the loaded agent-ops module; None → 0. Never raises."""
+    if ao is None:
+        return 0
+    try:
+        list_panes = list_panes or ao.list_tmux_panes_raw
+        build_index = build_index or ao.build_proc_index
+        own_chain = own_chain or ao.own_pid_chain
+        panes = ao.parse_panes(list_panes())
+        proc_index = build_index()
+        own = own_chain()
+        return len(ao.classify_claude_sessions(panes, proc_index, own_pids=own))
+    except Exception:
+        return 0
+
+
+def render(count: int) -> dict:
+    """Pure: live-session count → i3status-rust block dict. Glyph always shows;
+    the count is appended only when >0. State stays neutral/Idle always."""
+    try:
+        n = int(count)
+    except (TypeError, ValueError):
+        n = 0
+    text = "%s %d" % (GLYPH, n) if n > 0 else GLYPH
+    return {"text": text, "state": "Idle"}
+
+
+def main() -> int:
+    ao = load_agent_ops()
+    n = count_live_sessions(ao)
+    sys.stdout.write(json.dumps(render(n)) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        sys.stdout.write(json.dumps(_BARE) + "\n")
+        sys.exit(0)

--- a/scripts/tests/test_agent_ops_count.py
+++ b/scripts/tests/test_agent_ops_count.py
@@ -1,0 +1,121 @@
+"""Unit tests for scripts/i3status-agent-ops — the LIVE agent-ops count block.
+
+Exercises the pure `count_live_sessions` wrapper + the `render` formatter. The
+wrapper delegates to agent-ops's real pure detector (parse_panes +
+classify_claude_sessions), so it is driven here with INJECTED fixture fetchers
+(a mock tmux-pane raw dump + a mock /proc index + an own-pid chain) — nothing
+touches tmux or /proc. Mirrors test_agent_ops.py's fixtures + fail-safe stance.
+"""
+import importlib.machinery
+import importlib.util
+import json
+import os
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SCRIPTS = os.path.join(_HERE, "..")
+
+
+def _load(name, modname):
+    loader = importlib.machinery.SourceFileLoader(
+        modname, os.path.join(_SCRIPTS, name))
+    spec = importlib.util.spec_from_loader(modname, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+iao = _load("i3status-agent-ops", "i3status_agent_ops")
+ao = _load("agent-ops", "agent_ops_for_count")
+
+
+# A raw `tmux list-panes -a` dump matching agent-ops's pipe format:
+#   pane_id|pane_pid|session|window_index|window_name|path|command|title
+_RAW_PANES = "\n".join([
+    "%0|16060|main|1|devrc ●|/home/zach/workspace/devrc|zsh|⠐ Ship the block",
+    "%1|16095|dp|2|dp|/home/zach/ws/dp|zsh|",              # plain zsh → not claude
+    "%9|500|main|9|self|/home/zach/workspace/devrc|python3|agent-ops",  # own pane
+])
+
+# Mock /proc tree: two claude panes + a plain zsh + the block's own tree.
+#   16060 zsh -> 108149 .claude-wrapped            [INCLUDE]
+#   16095 zsh                                        [EXCLUDE — no claude]
+#   500   zsh -> 999 (this block's pid)             [EXCLUDE — own tree]
+_PROC = {
+    16060: {"comm": "zsh", "ppid": 1, "state": "S", "age_secs": 100,
+            "children": [108149]},
+    108149: {"comm": ".claude-wrapped", "ppid": 16060, "state": "R",
+             "age_secs": 90, "children": []},
+    16095: {"comm": "zsh", "ppid": 1, "state": "S", "age_secs": 100,
+            "children": []},
+    500: {"comm": "zsh", "ppid": 1, "state": "S", "age_secs": 5,
+          "children": [999]},
+    999: {"comm": "python3", "ppid": 500, "state": "R", "age_secs": 5,
+          "children": []},
+}
+
+
+def test_count_uses_real_detector_excludes_plain_and_own():
+    # Only the one real Claude pane (%0) counts; the plain zsh pane and this
+    # block's own pane (containing pid 999) are excluded.
+    n = iao.count_live_sessions(
+        ao,
+        list_panes=lambda: _RAW_PANES,
+        build_index=lambda: _PROC,
+        own_chain=lambda: {999},
+    )
+    assert n == 1
+
+
+def test_count_zero_when_no_claude_panes():
+    raw = "%1|16095|dp|2|dp|/home/zach/ws/dp|zsh|"
+    n = iao.count_live_sessions(
+        ao, list_panes=lambda: raw, build_index=lambda: _PROC,
+        own_chain=lambda: set())
+    assert n == 0
+
+
+def test_count_two_live_claude_sessions():
+    raw = "\n".join([
+        "%0|16060|main|1|a|/r1|claude|⠐ one",
+        "%1|16095|main|2|b|/r2|claude|✳ two",
+    ])
+    n = iao.count_live_sessions(
+        ao, list_panes=lambda: raw, build_index=lambda: {},
+        own_chain=lambda: set())
+    assert n == 2          # detected via foreground command == 'claude'
+
+
+def test_count_failsafe_none_module_and_raising_fetchers():
+    assert iao.count_live_sessions(None) == 0    # no agent-ops module → 0
+
+    def boom():
+        raise RuntimeError("tmux gone")
+
+    # any fetcher raising degrades to 0, never propagates
+    assert iao.count_live_sessions(
+        ao, list_panes=boom, build_index=lambda: {},
+        own_chain=lambda: set()) == 0
+
+
+def test_render_bare_glyph_at_zero():
+    out = iao.render(0)
+    assert out["state"] == "Idle"
+    assert out["text"] == iao.GLYPH        # glyph only, no count
+    assert " " not in out["text"]
+
+
+def test_render_glyph_and_count_when_positive():
+    out = iao.render(3)
+    assert out["state"] == "Idle"          # neutral even with runs active
+    assert out["text"] == "%s 3" % iao.GLYPH
+
+
+def test_render_failsafe_non_int():
+    out = iao.render(None)
+    assert out["text"] == iao.GLYPH and out["state"] == "Idle"
+
+
+def test_render_emits_valid_json():
+    line = json.dumps(iao.render(2))
+    parsed = json.loads(line)
+    assert parsed["state"] == "Idle" and "2" in parsed["text"]

--- a/scripts/tests/test_disk_explore.py
+++ b/scripts/tests/test_disk_explore.py
@@ -1,0 +1,68 @@
+"""Unit tests for scripts/disk-explore — the disk block's right-click (ncdu on
+the fullest mount).
+
+OFFLINE: ncdu/df are never touched. The pure `fullest_mount` picker is tested
+against fixture parse_df output (reusing disk-detail's real parse_df), plus the
+`--dry-run` CLI path via subprocess. Mirrors test_disk_detail.py.
+"""
+import importlib.machinery
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+
+
+def _load(name, modname):
+    loader = importlib.machinery.SourceFileLoader(modname, str(SCRIPTS / name))
+    spec = importlib.util.spec_from_loader(modname, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+de = _load("disk-explore", "disk_explore")
+dd = _load("disk-detail", "disk_detail_for_explore")
+
+# Real ext4 root (59%), a nearly-full data mount (91%), a vfat /boot (7%).
+DF_SAMPLE = """\
+Filesystem     Type       1B-blocks         Used      Available Mounted on
+/dev/nvme0n1p2 ext4  1979120929792 1160000000000  700000000000 /
+/dev/sda1      ext4  4000000000000 3640000000000  360000000000 /data
+/dev/nvme0n1p1 vfat     1071624192     69206016    1002418176 /boot
+tmpfs          tmpfs   16000000000       500000   15999500000 /run
+"""
+
+
+def test_fullest_mount_picks_highest_pct():
+    disks = dd.parse_df(DF_SAMPLE)
+    assert de.fullest_mount(disks) == "/data"      # 91% > 59% > 7%
+
+
+def test_fullest_mount_defaults_when_empty():
+    assert de.fullest_mount([]) == "/"
+    assert de.fullest_mount(None) == "/"
+
+
+def test_fullest_mount_custom_default_and_junk():
+    # junk entries / missing target / bad pct are skipped, not crashed on
+    disks = ["x", {"pct": 80}, {"target": "", "pct": 99},
+             {"target": "/keep", "pct": "notanint"}]
+    assert de.fullest_mount(disks, default="/fallback") == "/fallback"
+
+
+def test_fullest_mount_single_real_mount():
+    disks = dd.parse_df(
+        "Filesystem Type 1B-blocks Used Available Mounted on\n"
+        "/dev/x ext4 1000 500 500 /only\n")
+    assert de.fullest_mount(disks) == "/only"
+
+
+def test_dry_run_cli_prints_a_mountpoint():
+    r = subprocess.run([sys.executable, str(SCRIPTS / "disk-explore"),
+                        "--dry-run"], stdout=subprocess.PIPE, text=True,
+                       timeout=15)
+    assert r.returncode == 0
+    out = r.stdout.strip()
+    assert out.startswith("/")            # a real mountpoint (fullest, or the / default)


### PR DESCRIPTION
Four cohesive improvements to the i3status-rust status bar, focused on the agent-facing layer.

## Changes

### 1. Agent-ops `󰕮` glyph → LIVE count of Claude-in-tmux runs (highest value)
`scripts/i3blocks-agent-ops` was a static `echo "󰕮"` (`interval = "once"`) — a dead launcher. Rewritten (`scripts/i3status-agent-ops`, Python) to emit i3status-rust **json**: `󰕮 N` when N>0 live Claude runs, bare `󰕮` at zero (the glyph always shows — it's also the dashboard launcher). **State stays neutral/Idle always** — running agents are normal steady state, not "blocked on you" (CALM: colour == look-at-me). Counts via a **local tmux+/proc scan reusing agent-ops's tested pure detector** (`parse_panes` + `build_proc_index` + `classify_claude_sessions` + `own_pid_chain`) — no fork, loaded from the deployed `~/.config/tmux/agent-ops`. Local + cheap → no poller/cache/signal; block is `json = true; interval = 15`. Fail-safe: any error → bare glyph, exit 0. Left-click (opens the dashboard) unchanged. `git mv` rename for consistency with the other live json blocks.

### 2. Single-source the count thresholds (fixes a real drift bug)
`graphical.nix` passed `--red-above 34` (alerts) / `--red-above 340` (civitai) but the poller's toast defaults were **30** / 340 — so the homelab-alerts pill reddened at 34 while its toast fired at 30. Added `alertsRedAbove = 34; civitaiRedAbove = 340;` `let` bindings used in BOTH the pill `--red-above` and the poller systemd `Environment` (`ALERTS_TOAST_ABOVE` / `CIVITAI_TOAST_ABOVE`). The poller's `_env_int(..., 30/340)` code defaults are now pure fallback and can't drift.

### 3. Vitals click → floating btop
`memory` / `cpu` / `temperature` / `gpu` blocks get a left-click → `alacritty --class float,float -e btop`. Added `pkgs.btop`.

### 4. Disk right-click → ncdu on the fullest mount
New `scripts/disk-explore` reuses `disk-detail`'s `parse_df` to pick the real mount with the highest usage pct → `ncdu <mount>` in a float terminal (fail-safe default `/`). Wired as the disk block's right-click (pairs with the left-click gauge list). Added `pkgs.ncdu`.

## Tests
- New pure functions unit-tested: `scripts/tests/test_agent_ops_count.py` (count wrapper + render, driven with injected fixture tmux/proc data via agent-ops's real detector) and `scripts/tests/test_disk_explore.py` (`fullest_mount` picker + `--dry-run` CLI).
- Full suite: **188 passed**.

## Verified
- `nix-instantiate --parse nix/graphical.nix` → PARSE OK.
- `home-manager switch --flake . --impure` → rc 0.
- Generated `config-top.toml`: agent-ops block is json + interval 15; four btop left-clicks; disk right-click → disk-explore; `--red-above 34` / `340` intact.
- Poller systemd env now carries `ALERTS_TOAST_ABOVE=34` / `CIVITAI_TOAST_ABOVE=340` (confirmed via `systemctl --user show`).
- Ran both new scripts standalone: agent-ops emits valid json (`{"text": "󰕮 27", "state": "Idle"}`); disk-explore `--dry-run` → `/` (correct — `/` is the fullest real mount at 59%, first in df order among the tie).
- `DISPLAY=:0 i3-msg restart` → i3status-rs respawned on the new config.

**Not verified (can't physically click the bar):** the actual click actions (btop/ncdu/dashboard launching) were verified only at the config + script level — the `cmd` strings resolve, the scripts run, and btop/ncdu are on PATH, but the interactive click was not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)