### PR TITLE
chore(media): genericize cosmetic *arr/Whisparr/Stash naming in bar tools

### DIFF
--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -227,9 +227,9 @@ let
   # and reads `CA ↓.. ↑..` (the static SERVER_COUNTRIES=Canada label + qBit speed).
   # CALM: hidden when connected+idle; shows speeds while transferring; RED when the
   # tunnel is `firewalled` (forwarded port down); soft-yellow `qBit?` on poller-
-  # stale. Left-click opens the media-menu rofi action launcher (open *arr UIs /
-  # pause-resume / force-start / VPN reconnect / Whisparr search / float the live
-  # `media-detail --watch` TUI); right-click opens the qBit WebUI directly. The menu
+  # stale. Left-click opens the media-menu rofi action launcher (open the service
+  # UIs / pause-resume / force-start / VPN reconnect / search all missing / float
+  # the live `media-detail --watch` TUI); right-click opens the qBit WebUI directly. The menu
   # reads ~/.config/bar/media.env (0600) for creds — NOT baked into the store.
   mediaBlock = {
     block = "custom";

--- a/scripts/bar-status-poll
+++ b/scripts/bar-status-poll
@@ -620,8 +620,8 @@ def fetch_civitai() -> dict:
 def _media_creds() -> dict:
     """Read ~/.config/bar/media.env by EXPLICIT PATH (mirrors _clawgate_creds).
 
-    Kept OUT of git / the nix-store (it holds the qBit password + *arr API keys),
-    so it is read straight off disk at 0600. MEDIA_ENV overrides the path (tests)."""
+    Kept OUT of git / the nix-store (it holds the qBit password + media-service API
+    keys), so it is read straight off disk at 0600. MEDIA_ENV overrides the path (tests)."""
     env = {}
     path = os.environ.get("MEDIA_ENV") or os.path.expanduser("~/.config/bar/media.env")
     with open(path) as f:
@@ -656,7 +656,7 @@ def _qbit_login(url: str, user: str, pw: str, timeout: float = 3.0):
 
 def fetch_media() -> dict:
     """Authed qBittorrent /transfer/info -> parse_media. Single short-timeout call
-    (the pill is speed-only); the secondary *arr metrics live in media-detail."""
+    (the pill is speed-only); the secondary media-service metrics live in media-detail."""
     creds = _media_creds()
     url = creds.get("QBIT_URL", "http://qbittorrent.workbench.lan").rstrip("/")
     user = creds.get("QBIT_USER", "admin")

--- a/scripts/media-detail
+++ b/scripts/media-detail
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """Right-click detail popup for the i3status-rust `media` block (a float terminal).
 
-Best-effort secondary metrics for the *arr media stack — the stuff decision 4
+Best-effort secondary metrics for the media stack — the stuff decision 4
 keeps OFF the bar pill (which is qBit VPN + speed only) and behind this popup:
   * qBit AirVPN tunnel: connection_status, forwarded port, ↓/↑ speed, active/total
     torrents
-  * Whisparr download queue size
-  * Stash scene count
-  * Prowlarr indexer count + health warnings
+  * Downloader queue size
+  * Library item count
+  * Indexer count + health warnings
 
 Every call is short-timeout and individually wrapped: an unreachable service
 prints a dim `unavailable` line instead of aborting the popup. Credentials/keys
@@ -98,16 +98,16 @@ def qbit_section(c, out):
         out.append(("  torrents", "unavailable"))
 
 
-def arr_section(c, out):
-    # Whisparr queue
+def services_section(c, out):
+    # Downloader queue
     wurl = c.get("WHISPARR_URL", "http://whisparr.workbench.lan").rstrip("/")
     wkey = c.get("WHISPARR_KEY", "")
     try:
         q = _get_json("%s/api/v3/queue?pageSize=1&apikey=%s" % (wurl, wkey))
-        out.append(("Whisparr queue", "%s item(s)" % q.get("totalRecords", "?")))
+        out.append(("Downloader queue", "%s item(s)" % q.get("totalRecords", "?")))
     except Exception:
-        out.append(("Whisparr queue", "unavailable"))
-    # Stash scene count (GraphQL)
+        out.append(("Downloader queue", "unavailable"))
+    # Library item count (GraphQL)
     surl = c.get("STASH_URL", "http://stash.workbench.lan").rstrip("/")
     skey = c.get("STASH_KEY", "")
     try:
@@ -117,28 +117,28 @@ def arr_section(c, out):
         if skey:
             hdr["ApiKey"] = skey
         r = _get_json(surl + "/graphql", headers=hdr, data=body)
-        out.append(("Stash scenes",
+        out.append(("Library items",
                     str(r["data"]["findScenes"]["count"])))
     except Exception:
-        out.append(("Stash scenes", "unavailable"))
-    # Prowlarr indexers + health
+        out.append(("Library items", "unavailable"))
+    # Indexer count + health
     purl = c.get("PROWLARR_URL", "http://prowlarr.workbench.lan").rstrip("/")
     pkey = c.get("PROWLARR_KEY", "")
     try:
         idx = _get_json("%s/api/v1/indexer?apikey=%s" % (purl, pkey))
-        out.append(("Prowlarr indexers", "%d configured" % len(idx)))
+        out.append(("Indexers", "%d configured" % len(idx)))
     except Exception:
-        out.append(("Prowlarr indexers", "unavailable"))
+        out.append(("Indexers", "unavailable"))
     try:
         health = _get_json("%s/api/v1/health?apikey=%s" % (purl, pkey))
         n = len(health) if isinstance(health, list) else 0
-        out.append(("Prowlarr health",
+        out.append(("Indexer health",
                     "OK" if n == 0 else "%d warning(s)" % n))
         for h in (health if isinstance(health, list) else [])[:4]:
             if isinstance(h, dict) and h.get("message"):
                 out.append(("  ·", h["message"][:70]))
     except Exception:
-        out.append(("Prowlarr health", "unavailable"))
+        out.append(("Indexer health", "unavailable"))
 
 
 def render(c, title_suffix="") -> None:
@@ -146,7 +146,7 @@ def render(c, title_suffix="") -> None:
     rows = []
     qbit_section(c, rows)
     rows.append(("", ""))
-    arr_section(c, rows)
+    services_section(c, rows)
     print("\n  \033[1mMedia stack — detail\033[0m  (qBit via gluetun AirVPN · CA)%s\n"
           % title_suffix)
     for k, v in rows:

--- a/scripts/media-menu
+++ b/scripts/media-menu
@@ -2,18 +2,19 @@
 """Interactive rofi action menu for the i3status-rust `media` block (right-click).
 
 Left-click on the pill still opens the qBit WebUI; RIGHT-click now opens THIS
-rofi menu — an actions launcher for the *arr media stack (qBittorrent behind the
-gluetun AirVPN sidecar + Whisparr / Stash / Prowlarr on the workbench cluster).
+rofi menu — an actions launcher for the media stack (qBittorrent behind the
+gluetun AirVPN sidecar + the downloader / indexer / library services on the
+workbench cluster).
 
 The rofi `-mesg` header shows a LIVE status line fetched with a short timeout
 (`🟢 AirVPN CA ↓.. ↑.. · N active`); a down/unreachable cluster degrades to an
 error line in the header instead of hanging. Menu:
-  * Open qBittorrent / Whisparr / Stash / Prowlarr -> xdg-open the *.workbench.lan URLs
+  * Open qBittorrent / Downloader / Library / Indexer -> xdg-open the *.workbench.lan URLs
   * ⏸ Pause all / ▶ Resume all torrents          -> instant, reversible (no confirm)
-  * 🚀 Force-start Whisparr grabs                  -> setForceStart the `whisparr`-category hashes
+  * 🚀 Force-start grabs                           -> setForceStart the downloader-category hashes
   * 🔁 Reconnect / verify VPN                      -> re-check tunnel; offer a confirm-gated
                                                        `kubectl rollout restart deploy/qbittorrent`
-  * 🔍 Whisparr: search all missing               -> POST /command MissingMoviesSearch (confirm-gated)
+  * 🔍 Search all missing                          -> POST /command MissingMoviesSearch (confirm-gated)
   * 📊 Full status -> TUI                          -> float terminal running `media-detail --watch`
 
 Design mirrors scripts/bar-status-poll + scripts/media-detail:
@@ -22,7 +23,7 @@ Design mirrors scripts/bar-status-poll + scripts/media-detail:
   * qBit auth reuses the login flow (qBit 5.x sets a QBT_SID_<port> cookie, not the
     legacy SID=; capture the whole first cookie pair and send it straight back).
   * Every network call is short-timeout + best-effort; nothing hangs the menu.
-  * The pure/mockable logic (header formatter, whisparr-hash filter, qBit action
+  * The pure/mockable logic (header formatter, grab-hash filter, qBit action
     URL/param construction) is factored out and unit-tested in
     scripts/tests/test_media_menu.py. `--dry-run ACTION` / `--dump-menu` exercise
     an action / the menu without touching the network or rofi.
@@ -48,18 +49,18 @@ ROFI_THEME = "gruvbox-dark-hard"   # matches the $mod+d launcher in nix/i3/confi
 # Menu: (label shown in rofi, action id). Order = top->bottom.
 MENU = [
     ("Open qBittorrent", "open-qbit"),
-    ("Open Whisparr", "open-whisparr"),
-    ("Open Stash", "open-stash"),
-    ("Open Prowlarr", "open-prowlarr"),
+    ("Open Downloader", "open-downloader"),
+    ("Open Library", "open-library"),
+    ("Open Indexer", "open-indexer"),
     ("⏸  Pause all torrents", "pause"),
     ("▶  Resume all torrents", "resume"),
-    ("🚀 Force-start Whisparr grabs", "forcestart"),
+    ("🚀 Force-start grabs", "forcestart"),
     ("🔁 Reconnect / verify VPN", "vpn"),
-    ("🔍 Whisparr: search all missing", "whisparr-search"),
+    ("🔍 Search all missing", "search-all"),
     ("📊 Full status → TUI", "status"),
 ]
 # Actions that need a yes/no confirm (destructive / mass-grab).
-CONFIRM = {"vpn-restart", "whisparr-search"}
+CONFIRM = {"vpn-restart", "search-all"}
 
 
 # --------------------------------------------------------------------------- #
@@ -143,8 +144,8 @@ def active_count(torrents) -> int:
                and t.get("state") in ACTIVE_STATES)
 
 
-def whisparr_hashes(torrents, category="whisparr") -> list:
-    """Hashes of torrents in the given qBit category (default 'whisparr')."""
+def grab_hashes(torrents, category="whisparr") -> list:
+    """Hashes of torrents in the given qBit category (default download category)."""
     if not isinstance(torrents, list):
         return []
     return [t["hash"] for t in torrents
@@ -170,8 +171,8 @@ def qbit_action_request(action, hashes="all"):
     raise ValueError("unknown qbit action: %s" % action)
 
 
-def whisparr_command_request(name="MissingMoviesSearch"):
-    """(path, json-body) for a Whisparr v3 command (Radarr-style API)."""
+def downloader_command_request(name="MissingMoviesSearch"):
+    """(path, json-body) for a v3 downloader command (Radarr-style API)."""
     return "/api/v3/command", {"name": name}
 
 
@@ -316,17 +317,17 @@ def do_pause_resume(qb, action):
 
 
 def do_forcestart(qb):
-    """Force-start the whisparr-category grabs (setForceStart value=true)."""
+    """Force-start the download-category grabs (setForceStart value=true)."""
     if not qb.ok:
         notify("qBit unreachable", "Could not reach qBittorrent.")
         return
     try:
-        hashes = whisparr_hashes(qb.torrents_info())
+        hashes = grab_hashes(qb.torrents_info())
     except Exception as e:
         notify("Force-start failed", str(e)[:120])
         return
     if not hashes:
-        notify("Force-start Whisparr", "No whisparr-category grabs to force.")
+        notify("Force-start grabs", "No grabs to force.")
         return
     try:
         code = qb.action("forcestart", hashes=hashes)
@@ -334,7 +335,7 @@ def do_forcestart(qb):
         notify("Force-start failed", str(e)[:120])
         return
     if code == 200:
-        notify("Force-started Whisparr grabs", "%d torrent(s)" % len(hashes))
+        notify("Force-started grabs", "%d torrent(s)" % len(hashes))
     else:
         notify("Force-start -> HTTP %s" % code, "unexpected response")
 
@@ -383,20 +384,20 @@ def restart_qbit():
         notify("Restart failed", str(e)[:160])
 
 
-def do_whisparr_search(c):
+def do_search_all(c):
     """POST /api/v3/command {name: MissingMoviesSearch} (confirm-gated by caller)."""
     url = _url(c, "WHISPARR_URL", "http://whisparr.workbench.lan")
     key = c.get("WHISPARR_KEY", "")
-    path, body = whisparr_command_request("MissingMoviesSearch")
+    path, body = downloader_command_request("MissingMoviesSearch")
     data = json.dumps(body).encode()
     hdr = {"Content-Type": "application/json"}
     if key:
         hdr["X-Api-Key"] = key
     try:
         status, _ = _http(url + path, headers=hdr, data=data, timeout=8)
-        notify("Whisparr: search all missing", "command queued (HTTP %s)" % status)
+        notify("Search all missing", "command queued (HTTP %s)" % status)
     except Exception as e:
-        notify("Whisparr search failed", str(e)[:140])
+        notify("Search failed", str(e)[:140])
 
 
 def do_status_tui():
@@ -432,11 +433,11 @@ def build_header(qb):
 def dispatch(action, c, qb):
     if action == "open-qbit":
         xdg_open(_url(c, "QBIT_URL", "http://qbittorrent.workbench.lan"))
-    elif action == "open-whisparr":
+    elif action == "open-downloader":
         xdg_open(_url(c, "WHISPARR_URL", "http://whisparr.workbench.lan"))
-    elif action == "open-stash":
+    elif action == "open-library":
         xdg_open(_url(c, "STASH_URL", "http://stash.workbench.lan"))
-    elif action == "open-prowlarr":
+    elif action == "open-indexer":
         xdg_open(_url(c, "PROWLARR_URL", "http://prowlarr.workbench.lan"))
     elif action in ("pause", "resume"):
         do_pause_resume(qb, action)
@@ -444,9 +445,9 @@ def dispatch(action, c, qb):
         do_forcestart(qb)
     elif action == "vpn":
         do_vpn(qb)
-    elif action == "whisparr-search":
-        if rofi_confirm("Search ALL missing in Whisparr (mass grab)?"):
-            do_whisparr_search(c)
+    elif action == "search-all":
+        if rofi_confirm("Search ALL missing (mass grab)?"):
+            do_search_all(c)
     elif action == "status":
         do_status_tui()
 
@@ -475,16 +476,16 @@ def dry_run(action) -> str:
         path, params = qbit_action_request(action, hashes="all")
         return "DRY-RUN %s: POST %s %s" % (
             action, path, urllib.parse.urlencode(params))
-    if action == "whisparr-search":
-        path, body = whisparr_command_request("MissingMoviesSearch")
-        return "DRY-RUN whisparr-search: POST %s %s" % (path, json.dumps(body))
+    if action == "search-all":
+        path, body = downloader_command_request("MissingMoviesSearch")
+        return "DRY-RUN search-all: POST %s %s" % (path, json.dumps(body))
     raise ValueError("no dry-run for action: %s" % action)
 
 
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(description="rofi action menu for the media block")
     ap.add_argument("--dry-run", metavar="ACTION",
-                    choices=["pause", "resume", "forcestart", "whisparr-search"],
+                    choices=["pause", "resume", "forcestart", "search-all"],
                     help="print the constructed request for ACTION; no network, no rofi")
     ap.add_argument("--dump-menu", action="store_true",
                     help="print the menu entries (label\\taction) and exit")

--- a/scripts/tests/test_media_menu.py
+++ b/scripts/tests/test_media_menu.py
@@ -3,9 +3,9 @@
 All OFFLINE: rofi/network/cluster are never touched. rofi UI itself isn't
 unit-testable, so the LOGIC is factored into pure functions and tested here:
   - the live-status header formatter (connected / firewalled / unreachable),
-  - the whisparr-category hash filter + active-torrent counter,
+  - the download-category hash filter + active-torrent counter,
   - qBit action URL/param construction (incl. the 5.x pause->stop / resume->start
-    rename) and the Whisparr command request,
+    rename) and the downloader command request,
 and the `--dry-run ACTION` / `--dump-menu` CLI paths are exercised via subprocess
 (no network). Mirrors scripts/tests/test_bar_status.py.
 
@@ -73,22 +73,22 @@ def test_header_non_dict_payload_never_raises():
 
 
 # --------------------------------------------------------------------------- #
-# whisparr filter + active counter
+# grab-category filter + active counter
 # --------------------------------------------------------------------------- #
-def test_whisparr_hashes_filters_by_category():
+def test_grab_hashes_filters_by_category():
     torrents = [
         {"hash": "aaa", "category": "whisparr"},
-        {"hash": "bbb", "category": "prowlarr"},
+        {"hash": "bbb", "category": "other"},
         {"hash": "ccc", "category": "whisparr"},
         {"category": "whisparr"},              # no hash -> skipped
         "junk",                                # non-dict -> skipped
     ]
-    assert mm.whisparr_hashes(torrents) == ["aaa", "ccc"]
+    assert mm.grab_hashes(torrents) == ["aaa", "ccc"]
 
 
-def test_whisparr_hashes_empty_on_bad_input():
-    assert mm.whisparr_hashes(None) == []
-    assert mm.whisparr_hashes("x") == []
+def test_grab_hashes_empty_on_bad_input():
+    assert mm.grab_hashes(None) == []
+    assert mm.grab_hashes("x") == []
 
 
 def test_active_count_counts_only_transferring_states():
@@ -103,7 +103,7 @@ def test_active_count_counts_only_transferring_states():
 
 
 # --------------------------------------------------------------------------- #
-# qBit action / whisparr command construction (5.x rename)
+# qBit action / downloader command construction (5.x rename)
 # --------------------------------------------------------------------------- #
 def test_pause_maps_to_stop_endpoint():
     path, params = mm.qbit_action_request("pause")
@@ -133,8 +133,8 @@ def test_join_hashes():
     assert mm.join_hashes(["a", "b", "c"]) == "a|b|c"
 
 
-def test_whisparr_command_request():
-    path, body = mm.whisparr_command_request()
+def test_downloader_command_request():
+    path, body = mm.downloader_command_request()
     assert path == "/api/v3/command"
     assert body == {"name": "MissingMoviesSearch"}
 
@@ -142,7 +142,7 @@ def test_whisparr_command_request():
 def test_confirm_gated_actions_are_the_risky_two():
     # restart + mass-grab must be behind a confirm; instant/reversible ones must not.
     assert "vpn-restart" in mm.CONFIRM
-    assert "whisparr-search" in mm.CONFIRM
+    assert "search-all" in mm.CONFIRM
     assert "pause" not in mm.CONFIRM and "resume" not in mm.CONFIRM
 
 
@@ -160,7 +160,7 @@ def test_dump_menu_lists_all_entries():
     assert r.returncode == 0
     assert "open-qbit" in r.stdout
     assert "Pause all torrents\tpause" in r.stdout
-    assert "whisparr-search" in r.stdout
+    assert "search-all" in r.stdout
     assert len(r.stdout.strip().splitlines()) == len(mm.MENU)
 
 
@@ -176,7 +176,7 @@ def test_dry_run_resume_hits_start_endpoint():
     assert "POST /api/v2/torrents/start" in r.stdout
 
 
-def test_dry_run_whisparr_search():
-    r = _run("--dry-run", "whisparr-search")
+def test_dry_run_search_all():
+    r = _run("--dry-run", "search-all")
     assert "/api/v3/command" in r.stdout
     assert "MissingMoviesSearch" in r.stdout


### PR DESCRIPTION
## Why
`devrc` is a **public** repo. The media bar tools' *naming* (rofi labels, comments, docstrings, function/test names) revealed an adult-media-by-implication setup via "Whisparr / Stash / *arr / scene" wording. This genericizes the **cosmetic** surface to a neutral "downloader / indexer / library" framing.

## Guarantee: no behavior change
All **functional** identifiers are preserved verbatim:
- `media.env` env-var names: `WHISPARR_URL`/`WHISPARR_KEY`, `STASH_URL`/`STASH_KEY`, `PROWLARR_URL`/`PROWLARR_KEY`, `QBIT_*`, `MEDIA_*`
- the qBit `whisparr` category default string
- default hosts `*.workbench.lan`
- API paths / commands: `MissingMoviesSearch`, `findScenes`, `/api/v3/command`, qBit endpoints

## Cosmetic genericizations
- **media-menu**: menu labels (Open Whisparr/Stash/Prowlarr → Downloader/Library/Indexer; "Force-start Whisparr grabs" → "Force-start grabs"; "Whisparr: search all missing" → "Search all missing"); internal action ids; functions `whisparr_hashes`→`grab_hashes`, `whisparr_command_request`→`downloader_command_request`, `do_whisparr_search`→`do_search_all`; notify/docstring prose.
- **media-detail**: `arr_section`→`services_section`; row labels → Downloader queue / Library items / Indexers / Indexer health.
- **test_media_menu.py**: test + assertion names updated to match.
- **graphical.nix**, **bar-status-poll**: "*arr"/"Whisparr" comment wording → generic.

## Verification
- `pytest scripts/tests/` → **286 passed**
- `media-menu --dump-menu` + `--dry-run {pause,resume,forcestart,search-all}` → correct endpoints, unchanged
- `i3status-media` against a synthesized cache → correct render
- `media-detail` offline path → generic labels, same env/endpoints

## Residual exposure (deliberately left — functional, cannot change here)
The env-var **names** (`WHISPARR_URL` etc.), the qBit **`whisparr` category**, and the `whisparr/stash/prowlarr.workbench.lan` **hostnames** remain visible because they map to live on-host config (`media.env`, qBit categories, traefik IngressRoutes). Fully hiding them requires a coordinated rename of those external configs — a separate infra task, intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)