### PR TITLE
feat(bar): always-visible notifs bell + distinct alert triangle glyph

### DIFF
--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -308,10 +308,11 @@ let
     [ memoryBlock diskBlock netBlock cpuBlock temperatureBlock ]
     ++ lib.optional (!isLaptop) gpuBlock
     ++ lib.optional isLaptop batteryBlock
-    ++ [ soundBlock notifsBlock ]
+    ++ [ soundBlock ]
     ++ lib.optionals (!isLaptop) [ alertsBlock civitaiBlock mailBlock clawgateBlock mediaBlock airvpnBlock ]
     ++ [ timeBlock ]
-    ++ lib.optionals (!isLaptop) [ agentOpsBlock rigcontrolBlock ];
+    ++ lib.optionals (!isLaptop) [ agentOpsBlock rigcontrolBlock ]
+    ++ [ notifsBlock ];
 in
 lib.mkIf isNixOS {
   programs.i3status-rust = {

--- a/scripts/i3status-alerts
+++ b/scripts/i3status-alerts
@@ -7,17 +7,24 @@ never blocks the bar.
 
 CALM rendering (colour == "look at me"):
   missing / stale / error / count<=0  -> empty, invisible block
-  count > 0                           -> `bell` icon + count, coloured (Critical
-                                          if any critical is firing, else Warning
-                                          — the state comes from the cache)
+  count > 0                           -> `󰀪` alert glyph + count, coloured
+                                          (Critical if any critical is firing,
+                                          else Warning — state comes from cache)
 Click (wired in graphical.nix) opens Grafana.
+
+The leading glyph is the nf-md-alert triangle (rendered from the bar font),
+deliberately DISTINCT from the notifications-pill bell so a firing alert never
+reads as an unseen notification.
 """
 import json
 import os
 import sys
 
 NAME = "alerts"
-ICON = "bell"
+# nf-md-alert 󰀪 (U+F002A) — a warning triangle, rendered in the bar's
+# JetBrainsMono Nerd Font. Prepended to the text (not the i3status-rust `icon`
+# field) because the material-nf icon set has no alert/warning glyph.
+ALERT_GLYPH = "\U000f002a"
 _VALID_STATES = ("Idle", "Info", "Good", "Warning", "Critical")
 _EMPTY = {"text": "", "state": "Idle"}
 
@@ -36,7 +43,7 @@ def load(path):
         return None
 
 
-def render(payload, icon: str = ICON, red_above: int = 0) -> dict:
+def render(payload, glyph: str = ALERT_GLYPH, red_above: int = 0) -> dict:
     """Pure: cache payload (or None) -> i3status-rust block dict.
 
     Hide-at-zero + fail-safe: None / malformed / stale / error / count<=0 all
@@ -62,8 +69,8 @@ def render(payload, icon: str = ICON, red_above: int = 0) -> dict:
         state = payload.get("state")
         if state not in _VALID_STATES or state == "Idle":
             state = "Critical"
-    return {"icon": icon, "text": str(count),
-            "short_text": str(count), "state": state}
+    text = "%s %d" % (glyph, count)
+    return {"text": text, "short_text": text, "state": state}
 
 
 def _red_above_arg() -> int:

--- a/scripts/i3status-civitai
+++ b/scripts/i3status-civitai
@@ -11,17 +11,26 @@ prod can be told apart from the homelab alert count at a glance.
 
 CALM rendering (colour == "look at me"):
   missing / stale / error / count<=0  -> empty, invisible block
-  count > 0                           -> `bell` icon + `civ <count>`, coloured
-                                          (Critical if any critical is firing,
-                                          else the cache's state)
+  count > 0                           -> `󰀪` alert glyph + `civ <count>`,
+                                          coloured (Critical if any critical is
+                                          firing, else the cache's state)
 Click (wired in graphical.nix) opens the civitai Grafana.
+
+The leading glyph is the nf-md-alert triangle (rendered from the bar font),
+deliberately DISTINCT from the notifications-pill bell so a firing alert never
+reads as an unseen notification. Same glyph as the homelab alerts block; the
+`civ` label is what tells the two count blocks apart.
 """
 import json
 import os
 import sys
 
 NAME = "civitai"
-ICON = "bell"
+# nf-md-alert 󰀪 (U+F002A) — a warning triangle, rendered in the bar's
+# JetBrainsMono Nerd Font. Prepended to the text (not the i3status-rust `icon`
+# field) because the material-nf icon set has no alert/warning glyph. Same
+# glyph as i3status-alerts (differentiated by the `civ` LABEL below).
+ALERT_GLYPH = "\U000f002a"
 LABEL = "civ"
 _VALID_STATES = ("Idle", "Info", "Good", "Warning", "Critical")
 _EMPTY = {"text": "", "state": "Idle"}
@@ -41,7 +50,7 @@ def load(path):
         return None
 
 
-def render(payload, icon: str = ICON, red_above: int = 0) -> dict:
+def render(payload, glyph: str = ALERT_GLYPH, red_above: int = 0) -> dict:
     """Pure: cache payload (or None) -> i3status-rust block dict.
 
     Hide-at-zero + fail-safe: None / malformed / stale / error / count<=0 all
@@ -68,9 +77,8 @@ def render(payload, icon: str = ICON, red_above: int = 0) -> dict:
         state = payload.get("state")
         if state not in _VALID_STATES or state == "Idle":
             state = "Critical"
-    text = "%s %d" % (LABEL, count)
-    return {"icon": icon, "text": text,
-            "short_text": text, "state": state}
+    text = "%s %s %d" % (glyph, LABEL, count)
+    return {"text": text, "short_text": text, "state": state}
 
 
 def _red_above_arg() -> int:

--- a/scripts/i3status-notifs
+++ b/scripts/i3status-notifs
@@ -7,8 +7,8 @@ do-not-disturb state and the unseen-notification badge into one bell:
   * DND paused        -> muted bell  󰂛  (nf-md-bell_off), neutral (state Idle)
   * unseen count N>0  -> 󰂚 N          (nf-md-bell), RED (Critical) iff any unseen
                          entry is urgency CRITICAL, else neutral (Idle)
-  * nothing unseen    -> empty/invisible (hide-at-zero, exactly like the count
-                         blocks + the retired i3status-dnd did at rest)
+  * nothing unseen    -> plain neutral bell 󰂚 (nf-md-bell), ALWAYS visible so it
+                         stays the click-target for the notification center
 
 Data source is 100% LOCAL via `dunstctl` — no poller, no network, instant.
 
@@ -115,9 +115,11 @@ def max_id(entries) -> int:
 def render(paused: bool, count: int, critical: bool) -> dict:
     """Pure: (paused, unseen-count, has-critical) -> i3status-rust block dict.
 
-    Precedence: DND (muted bell) > unseen badge > empty/hidden. The badge is
+    Precedence: DND (muted bell) > unseen badge > plain bell. The badge is
     RED only when an unseen entry is CRITICAL; otherwise neutral (Idle) so a
-    routine notification never reads as an alarm.
+    routine notification never reads as an alarm. The idle case renders a plain
+    neutral bell (always visible) rather than an empty block, so the pill stays
+    the click-target for the notification center.
     """
     if paused:
         return {"text": " %s " % MUTED_GLYPH,
@@ -126,7 +128,8 @@ def render(paused: bool, count: int, critical: bool) -> dict:
         state = "Critical" if critical else "Idle"
         return {"text": " %s %d " % (BELL_GLYPH, count),
                 "short_text": " %s %d " % (BELL_GLYPH, count), "state": state}
-    return dict(_EMPTY)
+    return {"text": " %s " % BELL_GLYPH,
+            "short_text": " %s " % BELL_GLYPH, "state": "Idle"}
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_bar_status.py
+++ b/scripts/tests/test_bar_status.py
@@ -407,18 +407,29 @@ def test_mock_run_malformed_clawgate_writes_stale(tmp_path, monkeypatch):
 # --------------------------------------------------------------------------- #
 # block scripts: render() — hide-at-zero + colour-when->0 + fail-safe
 # --------------------------------------------------------------------------- #
+# icon = the i3status-rust named icon for count-only blocks, or None for the
+# alert blocks (which carry a literal nf-md-alert glyph in the text instead).
 BLOCKS = [
     ("clawgate", clawgate_block, "tasks", "Warning"),
     ("mail", mail_block, "mail", "Warning"),
-    ("alerts", alerts_block, "bell", "Critical"),
-    ("civitai", civitai_block, "bell", "Critical"),
+    ("alerts", alerts_block, None, "Critical"),
+    ("civitai", civitai_block, None, "Critical"),
 ]
 
 
 def _expected_text(mod, count):
-    # i3status-civitai prefixes the count with its `civ` LABEL; the others don't.
+    # The alert blocks (i3status-alerts / -civitai) prepend a literal nf-md-alert
+    # GLYPH to the text; i3status-civitai additionally prefixes the `civ` LABEL.
+    # The count-only blocks (clawgate/mail) carry neither.
+    parts = []
+    glyph = getattr(mod, "ALERT_GLYPH", None)
+    if glyph:
+        parts.append(glyph)
     label = getattr(mod, "LABEL", None)
-    return ("%s %d" % (label, count)) if label else str(count)
+    if label:
+        parts.append(label)
+    parts.append(str(count))
+    return " ".join(parts)
 
 
 @pytest.mark.parametrize("name,mod,icon,default_state", BLOCKS)
@@ -432,7 +443,12 @@ def test_block_hides_at_zero(name, mod, icon, default_state):
 def test_block_visible_and_coloured_when_positive(name, mod, icon, default_state):
     out = mod.render({"count": 3, "state": default_state})
     exp = _expected_text(mod, 3)
-    assert out["icon"] == icon
+    if getattr(mod, "ALERT_GLYPH", None):
+        # alert blocks carry the glyph in the text, NOT the i3status-rust `icon`
+        assert "icon" not in out
+        assert mod.ALERT_GLYPH in out["text"]
+    else:
+        assert out["icon"] == icon
     assert out["text"] == exp and out["short_text"] == exp
     assert out["state"] == default_state
 
@@ -442,8 +458,10 @@ def test_civitai_block_labels_count_distinctly():
     # its text carries the `civ` label prefix, alerts' does not.
     civ = civitai_block.render({"count": 317, "state": "Critical"})
     hl = alerts_block.render({"count": 317, "state": "Critical"})
-    assert civ["text"] == "civ 317" and civ["state"] == "Critical"
-    assert hl["text"] == "317"
+    assert civ["text"] == "%s civ 317" % civitai_block.ALERT_GLYPH
+    assert civ["state"] == "Critical"
+    assert hl["text"] == "%s 317" % alerts_block.ALERT_GLYPH
+    assert "civ" not in hl["text"]
     assert civ["text"] != hl["text"]
 
 
@@ -456,7 +474,7 @@ def test_red_above_neutral_at_or_below_baseline(name, mod):
     for count in (25, 30):  # <= red_above=30
         out = mod.render({"count": count, "state": "Critical"}, red_above=30)
         assert out["state"] == "Idle"          # visible but NOT coloured
-        assert out["icon"] == "bell"           # still shown (not hidden)
+        assert mod.ALERT_GLYPH in out["text"]  # still shown (not hidden)
         assert str(count) in out["text"]
 
 
@@ -532,11 +550,13 @@ def test_block_subprocess_missing_file_is_invisible(tmp_path, script, cachefile)
     assert json.loads(r.stdout) == {"text": "", "state": "Idle"}
 
 
+# icon=None => alert blocks (glyph in text, no `icon` field); the given `text`
+# is the trailing (glyph-stripped) portion the rendered text must end with.
 @pytest.mark.parametrize("script,cachefile,icon,text", [
     ("i3status-clawgate", "clawgate.json", "tasks", "2"),
     ("i3status-mail", "mail.json", "mail", "2"),
-    ("i3status-alerts", "alerts.json", "bell", "2"),
-    ("i3status-civitai", "civitai.json", "bell", "civ 2"),
+    ("i3status-alerts", "alerts.json", None, "2"),
+    ("i3status-civitai", "civitai.json", None, "civ 2"),
 ])
 def test_block_subprocess_positive_renders(tmp_path, script, cachefile, icon, text):
     (tmp_path / cachefile).write_text(json.dumps(
@@ -546,7 +566,11 @@ def test_block_subprocess_positive_renders(tmp_path, script, cachefile, icon, te
                        capture_output=True, text=True, env=env)
     assert r.returncode == 0
     out = json.loads(r.stdout)
-    assert out["icon"] == icon and out["text"] == text
+    if icon is None:
+        assert "icon" not in out
+        assert out["text"].endswith(text)
+    else:
+        assert out["icon"] == icon and out["text"] == text
 
 
 @pytest.mark.parametrize("script,cachefile", [

--- a/scripts/tests/test_notifs.py
+++ b/scripts/tests/test_notifs.py
@@ -157,9 +157,16 @@ def test_render_unseen_noncritical_is_neutral_bell():
     assert b["state"] == "Idle"
 
 
-def test_render_zero_is_empty_hidden():
+def test_render_zero_is_plain_bell():
+    # idle (nothing unseen, DND off) now renders a plain neutral bell — ALWAYS
+    # visible so it stays the click-target for the notification center.
     b = nf.render(paused=False, count=0, critical=False)
-    assert b == {"text": "", "state": "Idle"}
+    assert nf.BELL_GLYPH in b["text"]
+    assert nf.MUTED_GLYPH not in b["text"]
+    assert not any(ch.isdigit() for ch in b["text"])   # no count badge
+    assert b["state"] == "Idle"
+    assert b == {"text": " %s " % nf.BELL_GLYPH,
+                 "short_text": " %s " % nf.BELL_GLYPH, "state": "Idle"}
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Three focused i3status-rust status-bar changes so the notifications pill reads clearly and no longer visually collides with the Grafana alert-count blocks.

## Changes
1. **notifs pill always visible** (`scripts/i3status-notifs`) — the idle case (nothing unseen, DND off) previously rendered an empty/invisible block; it now renders a **plain neutral bell** `󰂚` (nf-md-bell) so the pill is always present as the click-target for the notification center. Precedence unchanged: muted bell `󰂛` > unseen badge `󰂚 N` (red iff critical) > plain bell `󰂚`.
2. **alert blocks get a distinct glyph** (`scripts/i3status-alerts`, `scripts/i3status-civitai`) — both used `ICON = "bell"`, now visually confused with the notifs bell. Swapped for a literal **nf-md-alert triangle** `󰀪` (U+F002A) prepended to the text. The material-nf icon set has no alert/warning named icon (only `bell`/`bell-slash`/`notification`), so the glyph goes in the text — the same pattern the notifs pill already uses, guaranteeing it renders in JetBrainsMono Nerd Font rather than tofu. Same glyph on both blocks; civitai keeps its `civ` label to tell the two counts apart. Hide-at-zero, `--red-above` colouring, and counts are all unchanged.
3. **notifs moved to far right** (`nix/graphical.nix`) — `notifsBlock` moved from early in the list (`[ soundBlock notifsBlock ]`) to the very END, so the bell is the right-most block on BOTH hosts.

## Evidence
- `nix-instantiate --parse nix/graphical.nix` → PARSE OK.
- `pytest scripts/tests/` → **307 passed** (updated the notifs idle-render test to assert the plain bell; the alert-block tests now assert the glyph-in-text + absence of the `icon` field).
- `home-manager switch --flake . --impure` → rc 0.
- Standalone runs: notifs idle → `{"text":" 󰂚 ", "state":"Idle"}` (plain bell, no count); alerts count=7 (< red-above 34) → neutral `󰀪 7`; civitai count=412 (> red-above 340) → Critical `󰀪 civ 412`.
- **Live bar screenshot** (workbench, after `i3-msg restart`): homelab alerts render `△ 26` (neutral triangle), civitai renders `⚠ civ 383` on red, both clearly distinct from the bell; the notifs bell sits at the **far right**. (Live currently shows the badge `󰂚 1` because there is 1 unseen notification; the plain-bell idle state is confirmed via the standalone render path above.)

## Not verified
Could not physically click the notif-center target; placement + render confirmed visually/programmatically only. Not deployed to the laptop (single-host switch only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)