### PR TITLE
fix(repo-cos): stop two prescan marker false positives

### DIFF
--- a/scripts/repo-cos/prescan.py
+++ b/scripts/repo-cos/prescan.py
@@ -29,6 +29,11 @@ from pathlib import Path
 
 # ---- tunables (kept as module constants so tests can reference them) ----------
 MARKER_RE = re.compile(r"\b(TODO|FIXME|HACK|XXX|BUG)\b")
+# Quote chars that, when they immediately flank a marker token on BOTH sides
+# (`'XXX'`, `"XXX"`, `` `XXX` ``), mark it as a data/enum string literal rather than a
+# real comment marker — e.g. a SQL `WHEN 16 THEN RETURN 'XXX';`. See
+# `_has_unquoted_marker` below.
+_MARKER_QUOTE_CHARS = frozenset("'\"`")
 # Skipped/xfail test patterns across the languages in Zach's repos. Kept as literal
 # substrings/regex fragments — intentionally broad-but-cheap (a false positive is a
 # candidate the LLM can drop, not a correctness bug).
@@ -146,6 +151,25 @@ def _reref(c: Candidate, repo: str) -> Candidate:
     return Candidate(repo=repo, kind=c.kind, file=c.file, line=c.line, text=c.text)
 
 
+def _has_unquoted_marker(line: str) -> bool:
+    """True iff `line` has at least one marker token (TODO/FIXME/HACK/XXX/BUG) that is
+    NOT immediately wrapped in matching quotes.
+
+    A marker whose char-before and char-after are the SAME quote char (`'XXX'`, `"XXX"`,
+    `` `XXX` ``) is a data/enum string literal (e.g. a SQL `RETURN 'XXX';`), not a
+    comment marker. We suppress a line only when EVERY marker occurrence on it is
+    quote-wrapped — a single un-wrapped hit (an ordinary `# TODO: fix`, where the char
+    before is a space) keeps the line. Uses `finditer` so a line mixing a quoted literal
+    and a real marker (`RETURN 'XXX';  -- TODO real`) still survives on the real one."""
+    for m in MARKER_RE.finditer(line):
+        before = line[m.start() - 1] if m.start() > 0 else ""
+        after = line[m.end()] if m.end() < len(line) else ""
+        if before in _MARKER_QUOTE_CHARS and before == after:
+            continue  # quote-wrapped → string/enum literal, not a marker
+        return True   # an un-wrapped marker occurrence — this is a real hit
+    return False      # no markers, or all of them quote-wrapped → suppress
+
+
 def _rg_markers(root: Path) -> list[Candidate]:
     globs = []
     for d in PRUNE_DIRS:
@@ -168,6 +192,15 @@ def _rg_markers(root: Path) -> list[Candidate]:
         path, lno, content = parts
         if not lno.isdigit():
             continue
+        # Align with `_walk_markers`: only scan text/code files in SCAN_EXTS. rg walks
+        # EVERY file (it ignores SCAN_EXTS), so without this the two code paths disagree
+        # and results go non-deterministic depending on whether `rg` is installed — e.g.
+        # `.md` docs (RULES.md's "no TODO comments", handoff notes) leak only under rg.
+        if Path(path).suffix not in SCAN_EXTS:
+            continue
+        # Skip marker tokens that are just quoted string/enum literals (`RETURN 'XXX'`).
+        if not _has_unquoted_marker(content):
+            continue
         rel = _rel(root, Path(path))
         res.append(Candidate("", "marker", rel, int(lno), content.strip()[:200]))
     return res
@@ -183,7 +216,9 @@ def _walk_markers(root: Path) -> list[Candidate]:
                 for i, line in enumerate(fh, 1):
                     if len(line) > MAX_LINE_LEN:
                         continue
-                    if MARKER_RE.search(line):
+                    # Real marker only if some occurrence isn't a quoted literal
+                    # (skips SQL enums like `RETURN 'XXX';`). See `_has_unquoted_marker`.
+                    if _has_unquoted_marker(line):
                         res.append(Candidate(
                             "", "marker", _rel(root, p), i, line.strip()[:200]))
         except (OSError, UnicodeError):

--- a/scripts/repo-cos/tests/test_prescan.py
+++ b/scripts/repo-cos/tests/test_prescan.py
@@ -4,9 +4,12 @@ per-repo capping, churn/large/lockfile signals, and global interleave cap.
 All fixtures are built on a real temp directory tree (tmp_path) so the file-walk,
 line-numbering, and ordering are exercised end-to-end without any network or git remote.
 """
+import shutil
 import sys
 import time
 from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import prescan  # noqa: E402
@@ -57,6 +60,80 @@ def test_walk_markers_ignores_binary_exts(tmp_path):
     _write(tmp_path, "img.png", "TODO not code\n")
     cands = prescan._walk_markers(tmp_path)
     assert cands == []
+
+
+# ---- markers: quoted-literal suppression (false positive class 1) -------------
+
+def test_quoted_marker_helper_suppresses_string_literals():
+    # A marker token flanked by matching quotes on both sides is a data/enum literal.
+    assert prescan._has_unquoted_marker("WHEN 16 THEN RETURN 'XXX';") is False
+    assert prescan._has_unquoted_marker('const k = "XXX";') is False
+    assert prescan._has_unquoted_marker("label = `TODO`") is False
+    # An ordinary comment marker (char before is a space, not a quote) survives.
+    assert prescan._has_unquoted_marker("# TODO: real thing") is True
+    assert prescan._has_unquoted_marker("// FIXME later") is True
+    # Mixed quote chars on either side must NOT count as wrapped.
+    assert prescan._has_unquoted_marker("x = 'XXX\"") is True
+
+
+def test_quoted_marker_not_flagged_in_scan(tmp_path):
+    # SQL enum literals must not become marker candidates.
+    _write(tmp_path, "enum.sql",
+           "SELECT CASE code\n  WHEN 16 THEN RETURN 'XXX'\n  WHEN 17 THEN 'ok'\nEND;\n")
+    _write(tmp_path, "consts.js", 'const placeholder = "XXX";\nconst tag = `TODO`;\n')
+    cands = prescan.scan_markers(tmp_path, "repo", cap=10)
+    assert cands == []
+
+
+def test_line_with_quoted_and_real_marker_still_flagged(tmp_path):
+    # A quoted XXX literal AND a genuine trailing comment marker → the real one survives.
+    _write(tmp_path, "q.sql",
+           "WHEN 16 THEN RETURN 'XXX';  -- real comment TODO here\n")
+    cands = prescan.scan_markers(tmp_path, "repo", cap=10)
+    assert len(cands) == 1
+    assert cands[0].line == 1
+    assert "TODO" in cands[0].text
+
+
+def test_genuine_marker_still_flagged(tmp_path):
+    _write(tmp_path, "real.py", "def f():\n    pass  # TODO: real thing\n")
+    cands = prescan.scan_markers(tmp_path, "repo", cap=10)
+    assert len(cands) == 1
+    assert cands[0].line == 2
+
+
+# ---- markers: .md leak parity between rg and walk paths (false positive class 2)
+
+def test_walk_markers_ignores_md_files(tmp_path):
+    # `.md` is not in SCAN_EXTS — the walk path must never scan RULES.md / handoff docs.
+    _write(tmp_path, "RULES.md", "- no TODO comments for core functionality\n")
+    _write(tmp_path, "src.py", "# TODO real\n")
+    cands = prescan._walk_markers(tmp_path)
+    files = {c.file for c in cands}
+    assert "src.py" in files
+    assert "RULES.md" not in files
+
+
+@pytest.mark.skipif(shutil.which("rg") is None, reason="ripgrep not on PATH")
+def test_rg_markers_ignores_md_files(tmp_path):
+    # rg walks EVERY file (ignores SCAN_EXTS); the SCAN_EXTS filter must exclude `.md`
+    # so the rg path agrees with the walk path (deterministic regardless of rg presence).
+    _write(tmp_path, "RULES.md", "- no TODO comments for core functionality\n")
+    _write(tmp_path, "src.py", "# TODO real\n")
+    cands = prescan._rg_markers(tmp_path)
+    files = {c.file for c in cands}
+    assert "src.py" in files
+    assert "RULES.md" not in files
+
+
+def test_scan_markers_excludes_md_either_path(tmp_path):
+    # End-to-end via whichever backend (rg or walk) the env resolves to.
+    _write(tmp_path, "doc.md", "TODO write this section\n")
+    _write(tmp_path, "code.py", "# TODO real\n")
+    cands = prescan.scan_markers(tmp_path, "repo", cap=10)
+    files = {c.file for c in cands}
+    assert "code.py" in files
+    assert "doc.md" not in files
 
 
 # ---- skipped tests ------------------------------------------------------------


### PR DESCRIPTION
## Problem

Two spurious `marker` candidates surfaced in a weekly repo-cos digest, both from `scripts/repo-cos/prescan.py`:

1. **Quoted string literal matched as a marker.** A civitai SQL enum `WHEN 16 THEN RETURN 'XXX';` was flagged as an "XXX placeholder bug" — the marker regex `\b(TODO|FIXME|HACK|XXX|BUG)\b` matched `XXX` inside a quoted string literal.
2. **`.md` docs leaked as stale TODO markers.** `devrc/claude/RULES.md:90` (the rule text *"no TODO comments for core functionality"*), `devrc/CLAUDE.md:26`, and datapacket handoff `*.md` docs were flagged. Root cause: `.md` is **not** in `SCAN_EXTS`, so the python-walk path (`_walk_markers`) never scans it — but `_rg_markers` (used whenever `rg` is on PATH, i.e. the workbench) runs ripgrep across **all** files and ignored `SCAN_EXTS`. The two backends disagreed, making the result non-deterministic depending on whether `rg` is installed.

## Fix

- **Fix A — align `_rg_markers` with `SCAN_EXTS`.** The ripgrep path now drops any candidate whose `Path(path).suffix` is not in `SCAN_EXTS`, matching `_walk_markers`. Existing `PRUNE_DIRS` exclusion globs are kept.
- **Fix B — skip quote-wrapped markers.** A shared `_has_unquoted_marker(line)` helper suppresses a marker token only when it is immediately flanked by **matching** quotes on both sides (`'XXX'`, `"XXX"`, `` `XXX` ``). Applied in **both** backends. It uses `MARKER_RE.finditer`, so a line mixing a quoted literal and a real marker (`RETURN 'XXX';  -- TODO real`) still survives on the un-wrapped occurrence — a line is dropped only when *every* marker occurrence is quote-wrapped. Ordinary comments (`# TODO: fix`, space before the token) are untouched.

## Tests

Adds 7 unit tests to `scripts/repo-cos/tests/test_prescan.py`: quoted `'XXX'`/`"XXX"`/`` `TODO` `` suppression, the mixed quoted+real-marker line still flagged, genuine `# TODO` still flagged, and `.md` exclusion on the rg path (skipped if `rg` absent), the walk path, and end-to-end. Full suite: 203 → 210 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)