### PR TITLE
fix(repo-cos): don't flag conditional test.skip() runtime guards

### DIFF
--- a/scripts/repo-cos/prescan.py
+++ b/scripts/repo-cos/prescan.py
@@ -40,6 +40,14 @@ _MARKER_QUOTE_CHARS = frozenset("'\"`")
 SKIP_PATTERNS: tuple[tuple[str, re.Pattern], ...] = (
     ("pytest.skip", re.compile(r"@pytest\.mark\.(skip|skipif|xfail)")),
     ("pytest.skip-call", re.compile(r"pytest\.skip\(")),
+    # NB: `(it|describe|test).skip(` is overloaded. The *block-modifier* form
+    # (`it.skip('name', fn)`, `describe.skip('suite', ...)`) is a genuinely DISABLED
+    # test → a CI-verifiable "enable me" candidate → flag it. But the *conditional*
+    # form (`test.skip(<condition>, 'reason')`, e.g. `test.skip(!dockerAvailable(), …)`)
+    # is a runtime guard: the test RUNS when the condition is false (Docker present in
+    # CI) and skips gracefully otherwise — NOT disabled, must never be flagged.
+    # This broad regex matches BOTH forms; `_is_conditional_js_skip` post-filters out
+    # the conditional one in `scan_skipped_tests` (see it for the first-arg heuristic).
     ("js.skip", re.compile(r"\b(it|describe|test)\.skip\(")),
     ("js.xfail", re.compile(r"\.(only)\(")),  # .only leaves the rest un-run — same smell
     ("go.skip", re.compile(r"\bt\.Skip(f|Now)?\(")),
@@ -228,6 +236,43 @@ def _walk_markers(root: Path) -> list[Candidate]:
 
 # ---- signal: skipped/xfail tests ---------------------------------------------
 
+# Matches the JS `.skip(` head so we can inspect its first argument. Kept separate from
+# the SKIP_PATTERNS entry (which is used only for the yes/no match) so `.end()` lands
+# exactly after the `(`.
+_JS_SKIP_HEAD_RE = re.compile(r"\b(?:it|describe|test)\.skip\(")
+
+
+def _is_conditional_js_skip(line: str) -> bool:
+    """True when a JS `(it|describe|test).skip(...)` is the *conditional* runtime-guard
+    form — `test.skip(<condition>, 'reason')` — rather than a genuinely-disabled block.
+
+    Playwright/Jest overload `.skip(` two ways, and only one is a real "enable me" fix:
+      • block modifier / disabled test — first arg is the test NAME (a string literal)
+        or a function: `it.skip('renders', () => {})`, `describe.skip('suite', ...)`,
+        or the bare `describe.skip()`. Genuinely disabled → a CI-verifiable candidate
+        → the caller FLAGS it.
+      • conditional guard — first arg is a boolean expression: `test.skip(!dockerAvailable(),
+        'needs Docker')`, `test.skip(process.env.CI, ...)`, `it.skip(isSlow, ...)`. The
+        test RUNS when the condition is false (e.g. Docker present in CI) and skips
+        gracefully otherwise — NOT disabled, so it must NEVER be flagged.
+
+    Heuristic (line-based, no parse): look at the first non-space char after `.skip(`.
+    A string-literal quote (`'`, `"`, `` ` ``) ⇒ the arg is a test name ⇒ disabled block
+    ⇒ NOT conditional. An empty arg list (`)` immediately) ⇒ bare block modifier ⇒ NOT
+    conditional. Anything else (identifier / call / `!expr` / boolean) ⇒ conditional
+    guard ⇒ True. Conservative on purpose: a missed disabled test is only a dropped
+    candidate, but a flagged conditional guard is the false positive we must avoid."""
+    m = _JS_SKIP_HEAD_RE.search(line)
+    if not m:
+        return False
+    rest = line[m.end():].lstrip()
+    if not rest or rest[0] == ")":
+        return False  # `.skip()` — bare block modifier, treat as disabled block
+    if rest[0] in "'\"`":
+        return False  # first arg is a string-literal test name → disabled block
+    return True       # first arg is a condition expression → conditional runtime guard
+
+
 def scan_skipped_tests(root: Path, repo: str, cap: int) -> list[Candidate]:
     """Line-scan for skip/xfail/ignore markers across languages. A skipped test is a
     concrete, CI-verifiable fix — bias the LLM toward these."""
@@ -245,6 +290,10 @@ def scan_skipped_tests(root: Path, repo: str, cap: int) -> list[Candidate]:
                 continue
             for label, pat in SKIP_PATTERNS:
                 if pat.search(line):
+                    # A conditional `test.skip(<cond>, …)` is a runtime guard that runs
+                    # in CI, not a disabled test — never a candidate. See the helper.
+                    if label == "js.skip" and _is_conditional_js_skip(line):
+                        continue
                     res.append(Candidate(
                         repo, "skipped_test", _rel(root, p), i,
                         f"[{label}] {line.strip()[:180]}"))

--- a/scripts/repo-cos/tests/test_prescan.py
+++ b/scripts/repo-cos/tests/test_prescan.py
@@ -154,6 +154,62 @@ def test_skipped_js_detected(tmp_path):
     assert any(c.line == 2 and "js.skip" in c.text for c in cands)
 
 
+# ---- skipped JS: conditional guard vs disabled block --------------------------
+# Playwright/Jest `test.skip(cond, reason)` is a RUNTIME GUARD (runs when cond is
+# false, e.g. Docker present in CI) — not a disabled test. Motivated by a real false
+# positive: prescan flagged 7 clawgate e2e specs guarded by
+# `test.skip(!dockerAvailable(), 'full-mode specs need Docker …')` as "enable me".
+
+def test_conditional_js_skip_helper():
+    # Conditional runtime guards — first arg is a condition expression → NOT flagged.
+    assert prescan._is_conditional_js_skip(
+        "  test.skip(!dockerAvailable(), 'needs Docker');") is True
+    assert prescan._is_conditional_js_skip(
+        "test.skip(process.env.CI, 'flaky in CI');") is True
+    assert prescan._is_conditional_js_skip("  it.skip(isSlow, () => {});") is True
+    # Disabled test blocks — first arg is a string-literal name → conditional? no.
+    assert prescan._is_conditional_js_skip("  it.skip('renders the widget', () => {})") is False
+    assert prescan._is_conditional_js_skip('describe.skip("auth suite", () => {})') is False
+    assert prescan._is_conditional_js_skip("test.skip(`name`, async () => {})") is False
+    # Bare block modifier with no arg → disabled block, not conditional.
+    assert prescan._is_conditional_js_skip("describe.skip()") is False
+    # A line without a JS skip → False (helper only speaks to js.skip).
+    assert prescan._is_conditional_js_skip("x = 1") is False
+
+
+def test_conditional_js_skip_not_flagged(tmp_path):
+    # The real clawgate case + sibling condition forms must NOT become candidates.
+    _write(tmp_path, "e2e.spec.ts",
+           "test('full mode', () => {\n"
+           "  test.skip(!dockerAvailable(), 'full-mode specs need Docker');\n"
+           "  test.skip(process.env.CI, 'slow in CI');\n"
+           "  it.skip(isSlow, () => {});\n"
+           "});\n")
+    cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=10)
+    assert cands == []
+
+
+def test_disabled_js_test_still_flagged(tmp_path):
+    # String-literal / bare disabled forms remain CI-verifiable "enable me" candidates.
+    _write(tmp_path, "widget.test.ts",
+           "it.skip('renders the widget', () => {});\n"
+           "describe.skip('auth suite', () => {});\n"
+           "test.skip('name', async () => {});\n")
+    cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=10)
+    lines = {c.line for c in cands}
+    assert lines == {1, 2, 3}
+    assert all("js.skip" in c.text for c in cands)
+
+
+def test_mixed_conditional_and_disabled_js(tmp_path):
+    # In one file: a conditional guard is dropped but the disabled test survives.
+    _write(tmp_path, "mix.spec.ts",
+           "test.skip(!dockerAvailable(), 'guard');\n"
+           "it.skip('disabled thing', () => {});\n")
+    cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=10)
+    assert [c.line for c in cands] == [2]
+
+
 def test_skipped_go_detected(tmp_path):
     _write(tmp_path, "x_test.go", "func TestFoo(t *testing.T) {\n\tt.Skip(\"wip\")\n}\n")
     cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=10)


### PR DESCRIPTION
## Problem

`scripts/repo-cos/prescan.py` emits `skipped_test` candidates — a skipped test is a concrete, CI-verifiable fix the weekly digest can propose ("enable me"). Its `js.skip` matcher (`\b(it|describe|test)\.skip\(`) flagged **7 clawgate e2e specs** guarded by:

```ts
test.skip(!dockerAvailable(), 'full-mode specs need Docker for a throwaway Postgres');
```

That's a **false positive**. Playwright/Jest overload `.skip(` two ways:

- **Block modifier / disabled test** — first arg is the test NAME (a string literal) or a function: `it.skip('renders', () => {})`, `describe.skip('suite', ...)`. Genuinely disabled → a real "enable me" candidate.
- **Conditional guard** — first arg is a boolean expression: `test.skip(!dockerAvailable(), …)`, `test.skip(process.env.CI, …)`. The test **RUNS** when the condition is false (Docker present in CI) and skips gracefully otherwise. It is *not* disabled — proposing to "enable" it is a no-op / regression.

The old matcher couldn't tell them apart.

## Fix

Keep the broad regex match, then post-filter with a new helper `_is_conditional_js_skip(line)` that inspects the first non-space char after `.skip(`:

- string-literal quote (`'` `"` `` ` ``) → first arg is a test name → **disabled block → FLAG**
- empty arg list (`.skip()`) → bare block modifier → **disabled block → FLAG**
- anything else (identifier / call / `!expr` / boolean) → **conditional guard → DROP**

Line-based and deterministic (the scanner is line-oriented, no parse). Conservative by design: a missed disabled test is only a dropped candidate, but a flagged conditional guard is the false positive we must avoid. `.only(` detection and all non-JS patterns (pytest / go / rust / unittest) are unchanged.

## Tests

Added 4 test functions under `scripts/repo-cos/tests/test_prescan.py`:

- helper unit coverage (conditional vs disabled vs bare vs non-JS)
- the real clawgate case + `process.env.CI` / `isSlow` guards → **not flagged**
- `it.skip('renders', …)`, `describe.skip('suite', …)`, `test.skip('name', …)` → **still flagged**
- mixed file: conditional dropped, disabled survives

Non-JS regression guards (`@pytest.mark.skip`, `t.Skip(`, `#[ignore]`) already covered and unchanged.

**210 → 214 tests, all passing.**

```
python -m pytest scripts/repo-cos/tests -q
214 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)