### PR TITLE
feat(espanso): add :ds, drop dead :wn/:mdc from usage audit

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -75,6 +75,7 @@ in
           #  /handoff + :eos which ends "…then write the handoff to proceed in next session")
           { trigger = ":eos"; replace = "review work done this session and identify skills that may need updating, then dispatch subagent to update those skills and any relevant docs, then write the handoff to proceed in next session"; label = "End-of-session ritual: review → update skills/docs → handoff"; search_terms = ["end" "session" "wrap" "handoff" "skills" "review" "update" "docs" "ritual"]; }
           { trigger = ":acq"; replace = "ask me clarifying questions and recommend anything you think would be useful to include"; label = "Ask clarifying questions + recommend additions"; search_terms = ["ask" "clarify" "clarifying" "questions" "recommend" "elicit" "scope" "include"]; }
+          { trigger = ":ds"; replace = "dispatch subagent to "; label = "Dispatch subagent to…"; search_terms = ["dispatch" "subagent" "delegate"]; }
           { trigger = ":rns"; replace = "recommend next steps"; label = "Recommend next steps"; search_terms = ["next" "recommend" "steps" "whats next"]; }
           { trigger = ":rnx"; replace = "recommend next steps ranked by leverage (impact vs effort); call out the single highest-value move and any quick wins"; label = "Recommend next steps, ranked by leverage"; search_terms = ["next" "recommend" "steps" "ranked" "leverage" "impact" "deep"]; }
           { trigger = ":pst"; replace = "proceed, use subagent, ensure test coverage"; label = "Proceed with subagent + test coverage"; search_terms = ["proceed" "subagent" "test" "coverage" "verify" "dispatch" "yes"]; }
@@ -82,8 +83,6 @@ in
           { trigger = ":nday"; replace = "it's the next day, check"; label = "Next-day re-check"; search_terms = ["next day" "check" "days" "resume" "morning"]; }
           { trigger = ":fhrs"; replace = "it's been a few hours, check"; label = "Few-hours re-check"; search_terms = ["hours" "check" "elapsed" "resume"]; }
           { trigger = ":fdays"; replace = "it's been a few days, check"; label = "Few-days re-check"; search_terms = ["days" "check" "elapsed" "resume"]; }
-          { trigger = ":mdc"; replace = "merged and deployed, check"; label = "Merged & deployed — check"; search_terms = ["merged" "deployed" "check" "verify"]; }
-          { trigger = ":wn"; replace = "what's next"; label = "What's next"; search_terms = ["next" "whats next" "what next"]; }
           { trigger = ":cont"; replace = "continue from where you left off"; label = "Continue from where you left off"; search_terms = ["continue" "resume" "left off"]; }
           { trigger = ":pec"; replace = "push an empty commit"; label = "Push an empty commit"; search_terms = ["push" "empty" "commit" "trigger" "ci"]; }
           { trigger = ":aep"; replace = "dispatch subagent to adversarially audit the PR for bugs, regressions, edge cases, race conditions, security holes, error/failure handling, backward-compat and data-integrity risks, leaked secrets, hidden assumptions, and second-order consequences — cite evidence from the diff, rank findings by severity, and propose a fix for each"; label = "Audit PR"; search_terms = ["audit" "each" "prs" "subagents" "risks" "regressions" "review"]; }

--- a/scripts/session-analysis/espanso-usage.py
+++ b/scripts/session-analysis/espanso-usage.py
@@ -9,6 +9,7 @@ user messages, and surface recurring phrases that are not yet snippets.
 SNIPPETS is synced to the live config in nix/home.nix (PRs #4/#5, 2026-06-23:
 :rns shortened, :rau/:mdc/:nday/... steer-extended, :aep/:cont/:pec/:wn/:rnx/
 :fhrs/:fdays added, :usd removed).
+2026-07-15: :ds added; :wn/:mdc removed (dead — hand-typed short forms won).
 
 Caveats baked in:
 - Some expansions are now IDENTICAL to phrases you hand-type (:rns="recommend
@@ -54,6 +55,9 @@ SNIPPETS = {
     # :whn removed 2026-07-06 (dead + superseded by /handoff + :eos).
     ":eos":     ("prompt", ["identify skills that may need updating"], [], False),
     ":acq":     ("prompt", ["recommend anything you think would be useful to include"], [], False),
+    # :ds="dispatch subagent to " is a phrase-PREFIX the user also hand-types, so
+    # its count conflates snippet-expansion with manual typing (ambiguous=True).
+    ":ds":      ("prompt", ["dispatch subagent to"], [], True),
     # :aep expansion starts "dispatch subagent to adversarially audit the PR for
     # bugs, regressions, edge cases, race conditions…" — match a distinctive tail.
     ":aep":     ("prompt", ["regressions, edge cases, race conditions"], [], False),
@@ -67,8 +71,6 @@ SNIPPETS = {
     ":nday":    ("prompt", ["it's the next day, check"], [], True),
     ":fhrs":    ("prompt", ["it's been a few hours, check"], [], True),
     ":fdays":   ("prompt", ["it's been a few days, check"], [], True),
-    ":mdc":     ("prompt", ["merged and deployed, check"], [], True),
-    ":wn":      ("prompt", ["what's next"], [], True),
     ":cont":    ("prompt", ["continue from where you left off"], [], True),
     ":pec":     ("prompt", ["push an empty commit"], [], True),
     # utilities / typo-correction — output not distinguishable

--- a/scripts/session-analysis/espanso-usage.py
+++ b/scripts/session-analysis/espanso-usage.py
@@ -57,7 +57,10 @@ SNIPPETS = {
     ":acq":     ("prompt", ["recommend anything you think would be useful to include"], [], False),
     # :ds="dispatch subagent to " is a phrase-PREFIX the user also hand-types, so
     # its count conflates snippet-expansion with manual typing (ambiguous=True).
-    ":ds":      ("prompt", ["dispatch subagent to"], [], True),
+    # "dispatch subagent to" is also a substring of the :aep/:eos expansions —
+    # exclude their distinctive tails so those fires don't inflate the :ds count
+    # (mirrors the :rns/:rnx overlap guard).
+    ":ds":      ("prompt", ["dispatch subagent to"], ["adversarially audit the PR", "identify skills that may need updating"], True),
     # :aep expansion starts "dispatch subagent to adversarially audit the PR for
     # bugs, regressions, edge cases, race conditions…" — match a distinctive tail.
     ":aep":     ("prompt", ["regressions, edge cases, race conditions"], [], False),


### PR DESCRIPTION
Espanso snippet tuning from the usage audit (2026-06-24 → 2026-07-15, both hosts). Mines Claude transcripts for which expansions actually fire vs. which short phrases get hand-typed.

## Changes
- **ADD `:ds`** → `dispatch subagent to ` (trailing space; a prefix building block). `"dispatch subagent to "` is a 35+×/window hand-typed phrase-prefix with no snippet — worth a trigger.
- **REMOVE `:wn`** (`what's next`) — 4 fires vs 37 hand-typed "whats next"; apostrophe mismatch, habit never formed.
- **REMOVE `:mdc`** (`merged and deployed, check`) — 1 fire vs 44 hand-typed "merged and deployed"; the short form is typed directly.
- **Miner re-synced** (`scripts/session-analysis/espanso-usage.py`): added `:ds` (flagged `ambiguous=True` — the expansion is a phrase-prefix the user also hand-types, so its count conflates snippet + manual typing), removed `:wn`/`:mdc`, updated the docstring changelog.

## Validation
- `nix-instantiate --parse nix/home.nix` → PARSE_OK
- Prefix-collision check: `:ds` is not a prefix of any other trigger and no other trigger is a prefix of `:ds` → NO_COLLISION (`:date`/`:datetime`/`:fdays` etc. don't share the `:ds` prefix)
- Miner runs clean and now lists `:ds` (AMBIGUOUS) with `:wn`/`:mdc` gone
- `ast.parse` of the miner → OK

Deployment (`home-manager switch` / `ship.sh`) handled after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)