### PR TITLE
refactor(espanso): drop dead :cont/:pec, repoint :aep to /audit-pr

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -83,9 +83,7 @@ in
           { trigger = ":nday"; replace = "it's the next day, check"; label = "Next-day re-check"; search_terms = ["next day" "check" "days" "resume" "morning"]; }
           { trigger = ":fhrs"; replace = "it's been a few hours, check"; label = "Few-hours re-check"; search_terms = ["hours" "check" "elapsed" "resume"]; }
           { trigger = ":fdays"; replace = "it's been a few days, check"; label = "Few-days re-check"; search_terms = ["days" "check" "elapsed" "resume"]; }
-          { trigger = ":cont"; replace = "continue from where you left off"; label = "Continue from where you left off"; search_terms = ["continue" "resume" "left off"]; }
-          { trigger = ":pec"; replace = "push an empty commit"; label = "Push an empty commit"; search_terms = ["push" "empty" "commit" "trigger" "ci"]; }
-          { trigger = ":aep"; replace = "dispatch subagent to adversarially audit the PR for bugs, regressions, edge cases, race conditions, security holes, error/failure handling, backward-compat and data-integrity risks, leaked secrets, hidden assumptions, and second-order consequences — cite evidence from the diff, rank findings by severity, and propose a fix for each"; label = "Audit PR"; search_terms = ["audit" "each" "prs" "subagents" "risks" "regressions" "review"]; }
+          { trigger = ":aep"; replace = "/audit-pr "; label = "Audit PR (→ /audit-pr)"; search_terms = ["audit" "pr" "review" "adversarial"]; }
 
           { trigger = ":cc"; replace = "${workspace}/civit/civitai "; label = "civitai main repo path"; search_terms = ["civitai" "repo" "web"]; }
           { trigger = ":cdp"; replace = "${workspace}/civit/datapacket-talos "; label = "civitai datapacket-talos path"; search_terms = ["civitai"]; }

--- a/scripts/session-analysis/espanso-usage.py
+++ b/scripts/session-analysis/espanso-usage.py
@@ -10,6 +10,8 @@ SNIPPETS is synced to the live config in nix/home.nix (PRs #4/#5, 2026-06-23:
 :rns shortened, :rau/:mdc/:nday/... steer-extended, :aep/:cont/:pec/:wn/:rnx/
 :fhrs/:fdays added, :usd removed).
 2026-07-15: :ds added; :wn/:mdc removed (dead — hand-typed short forms won).
+2026-07-15b: :cont/:pec removed (dead); :aep repointed to /audit-pr
+  (slash-command shortcut, no longer text-detectable).
 
 Caveats baked in:
 - Some expansions are now IDENTICAL to phrases you hand-type (:rns="recommend
@@ -61,9 +63,10 @@ SNIPPETS = {
     # exclude their distinctive tails so those fires don't inflate the :ds count
     # (mirrors the :rns/:rnx overlap guard).
     ":ds":      ("prompt", ["dispatch subagent to"], ["adversarially audit the PR", "identify skills that may need updating"], True),
-    # :aep expansion starts "dispatch subagent to adversarially audit the PR for
-    # bugs, regressions, edge cases, race conditions…" — match a distinctive tail.
-    ":aep":     ("prompt", ["regressions, edge cases, race conditions"], [], False),
+    # :aep repointed to the /audit-pr slash command (PR-quality audit, 2026-07-15)
+    # — slash-command invocations aren't captured as human text, so it's no longer
+    # transcript-detectable.
+    ":aep":     ("prompt", None, [], False),
     ":rns":     ("prompt", ["recommend next steps"], ["ranked by leverage"], True),
     ":rnx":     ("prompt", ["recommend next steps ranked by leverage"], [], False),
     # NOTE: PR (espanso-shorten-unfired-snippets, 2026-06-30) reverted these to
@@ -74,8 +77,6 @@ SNIPPETS = {
     ":nday":    ("prompt", ["it's the next day, check"], [], True),
     ":fhrs":    ("prompt", ["it's been a few hours, check"], [], True),
     ":fdays":   ("prompt", ["it's been a few days, check"], [], True),
-    ":cont":    ("prompt", ["continue from where you left off"], [], True),
-    ":pec":     ("prompt", ["push an empty commit"], [], True),
     # utilities / typo-correction — output not distinguishable
     ":uuid":     ("util", None, [], False),
     ":clip":     ("util", None, [], False),


### PR DESCRIPTION
Espanso quality-audit cleanup (evidence from reading real sessions via `find-session`):

- **Remove `:cont`** (`continue from where you left off`) — 0 genuine fires; superseded by `/resume`.
- **Remove `:pec`** (`push an empty commit`) — snippet form unused; the phrase only lives as Claude's own runbook prose, never as a hand-fired expansion.
- **Repoint `:aep`** — was a long adversarial-audit paragraph duplicating the `/audit-pr` skill prompt. Now expands to `/audit-pr ` (trailing space) so the skill is the single source of truth. `:aep` is only ever used as a standalone message.

Miner `scripts/session-analysis/espanso-usage.py` re-synced: `:cont`/`:pec` entries dropped; `:aep` set to not-text-detectable (slash-command invocations are recorded as `<command-…>` blocks that the miner's `human_text()` filter drops, so the old substring can never match again). Docstring changelog updated.

Validation:
- `nix-instantiate --parse nix/home.nix` → PARSE_OK
- No new trigger prefix-collisions (`:date`/`:datetime` is pre-existing, untouched)
- `ast.parse(espanso-usage.py)` → AST_OK
- Miner run: `:cont`/`:pec` gone from table; `:aep` now shows `n/a` / "not text-detectable".

🤖 Generated with [Claude Code](https://claude.com/claude-code)