### PR TITLE
feat(keylog): detect true espanso usage at capture time (direct + Ctrl+Space)

### DIFF
--- a/claude/commands/espanso-audit.md
+++ b/claude/commands/espanso-audit.md
@@ -7,7 +7,9 @@ allowed-tools: Bash, Read, Edit, Write
 
 # /espanso-audit — tune the espanso workflow snippets from real usage
 
-Goal: kill the hand-rebuilt "which snippets do I actually use" archaeology. Deterministic miner over `~/.claude/projects/**/*.jsonl` on both hosts + a fixed interpretation recipe.
+Goal: kill the hand-rebuilt "which snippets do I actually use" archaeology. **Two signals** (espanso erases both trigger AND expansion on firing, so neither alone suffices):
+- **PRIMARY — keylog TRUE fires.** The X11 keylogger's `EspansoDetector` (`scripts/collector/keylog/espanso_detect.py`) detects espanso usage AT CAPTURE TIME from raw keystrokes and writes one `source=keys, kind=espanso` row per fire to ClickHouse. This is the real per-trigger fire count (direct + Ctrl+Space-search). **FORWARD-ONLY** — no data before the detector deployed. Honest caveat: "keystrokes ended with a trigger" ≈ "espanso fired" except in per-app-disabled contexts.
+- **SECONDARY — transcript miner (ADD-CANDIDATES).** Its unique durable value is the inverse view: recurring SHORT phrases you hand-type that are NOT yet snippets (candidates to ADD). Its per-trigger "hits" CONFLATE fire vs hand-typing → ambiguous cross-check only, not truth.
 
 Args: `$ARGUMENTS` (optional `--since YYYY-MM-DD`).
 
@@ -24,21 +26,28 @@ espanso runs on **BOTH hosts** since 2026-07-06 / PR #83 (the workbench was un-g
 
 2. **Sync the miner first.** `scripts/session-analysis/espanso-usage.py`'s `SNIPPETS` dict drifts from the live config. Diff it against the `services.espanso` block in `nix/home.nix` and update detection substrings BEFORE running, or counts will be wrong. Pick a *distinctive* substring of each expansion; mark snippets whose expansion equals a phrase the user hand-types as `ambiguous=True` (their counts conflate snippet + manual typing).
 
-3. **Run on both hosts** (workbench locally; pipe the script over SSH to the laptop so it reads the laptop's transcripts):
+3. **PRIMARY: keylog TRUE fires (do this first).** Export the ClickHouse reader creds (`CLICKHOUSE_URL/USER/PASSWORD` from SOPS — see the header of `espanso-usage.py` / `activity-scan.py`), then:
    ```bash
-   python3 /home/zach/workspace/devrc/scripts/session-analysis/espanso-usage.py --since DATE --host workbench
-   ssh -o ConnectTimeout=5 zach@10.42.0.100 'python3 - --since DATE --host laptop' < /home/zach/workspace/devrc/scripts/session-analysis/espanso-usage.py
+   python3 /home/zach/workspace/devrc/scripts/session-analysis/espanso-usage.py --since DATE --source keys
    ```
+   This is the authoritative per-trigger fire count (direct + search). If it prints "(no keylog espanso events yet — detection is forward-only …)" the detector hasn't collected enough since deploy — fall back to the transcript signal and note the window is short. The keylog rows are host-tagged in CH (`host` column) so a single query already covers both hosts; no SSH needed for this signal.
 
-4. **Combine + interpret.** Present one merged table (workbench + laptop hits summed). Then apply the recipe:
+4. **SECONDARY: transcript ADD-CANDIDATES.** Run the transcript miner on both hosts for the "phrases with no snippet" view (the per-trigger transcript hits are an AMBIGUOUS cross-check, not truth — prefer the keylog fires above):
+   ```bash
+   python3 /home/zach/workspace/devrc/scripts/session-analysis/espanso-usage.py --since DATE --source transcript --host workbench
+   ssh -o ConnectTimeout=5 zach@10.42.0.100 'python3 - --since DATE --source transcript --host laptop' < /home/zach/workspace/devrc/scripts/session-analysis/espanso-usage.py
+   ```
+   (`--source both` — the default — shows keylog first, then the transcript sections.)
+
+5. **Combine + interpret.** Use the keylog fire counts as the usage truth; use the transcript ADD-CANDIDATES for what to add. Then apply the recipe:
    - **Paths** (`:cc :cdp :hlt …`) — almost always earn their keep; rarely touch.
    - **The recurring lesson:** a workflow snippet that expands to a **long steering paragraph goes UNFIRED** — the user hand-types the short phrase instead. Cross-reference each zero/low-fire prompt snippet against the "recurring short user messages" section: if the short form of its intent is being hand-typed a lot, that's the signal. (Measured 2026-06-23 `:rns`, again 2026-06-30 → PR #37.)
    - **Verdict per snippet:** keep-long (used + sticks, e.g. `:eos`/`:acq`), **shorten back** to the hand-typed form (zero fires + short-form demand — option (a); steering already lives in RULES.md / `/verify` / `/audit-pr`), repoint-to-skill (option (b)), remove (dead, no demand), or add (high-frequency phrase with no snippet).
    - Honest caveat to always state: keyword-packing is a probabilistic nudge, and new triggers need habit-formation time — but **zero fires + active short-form hand-typing** is strong signal the trigger→habit transfer failed.
 
-5. **Implement (if the user picks changes).** Edit the `services.espanso` block in `nix/home.nix` on a feature branch. Re-sync the miner's `SNIPPETS` to whatever you changed (so the next run detects them). Validate: `nix-instantiate --parse nix/home.nix` + check no trigger is a prefix of another (espanso longest-matches, but avoid surprises). PR → merge → **`scripts/ship.sh`** converges both hosts.
+6. **Implement (if the user picks changes).** Edit the `services.espanso` block in `nix/home.nix` on a feature branch. The keylog detector auto-parses the LIVE config, so new/changed triggers are detected on the next `home-manager switch` with NO code change — but still re-sync the transcript miner's `SNIPPETS` (the ADD-CANDIDATE cross-check) to whatever you changed. Validate: `nix-instantiate --parse nix/home.nix` + check no trigger is a prefix of another (espanso longest-matches; the keylog detector mirrors that, emitting the shorter prefix). PR → merge → **`scripts/ship.sh`** converges both hosts.
 
-6. **Verify honestly.** After ship, confirm each host's deployed `~/.config/espanso/match/base.yml` carries the new replace strings (note: home-manager emits `replace` before `trigger`) and `systemctl --user is-active espanso` (both hosts now run it). The one thing you **cannot** verify over SSH is the actual keystroke expansion — hand that final check to the user (type a trigger, watch it expand).
+7. **Verify honestly.** After ship, confirm each host's deployed `~/.config/espanso/match/base.yml` carries the new replace strings (note: home-manager emits `replace` before `trigger`) and `systemctl --user is-active espanso` (both hosts now run it). The one thing you **cannot** verify over SSH is the actual keystroke expansion — hand that final check to the user (type a trigger, watch it expand).
 
 Notes:
 - Edit `claude/commands/*.md` and `nix/home.nix` in the repo, NOT `~/.claude/*` (read-only nix-store symlinks). New command/script files must be `git add`ed before a switch (flakes only see tracked files).

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -479,9 +479,9 @@ in
       # from the running session; i3 is not systemd-integrated, so import the
       # graphical env if available.
       Environment = [
-        "PATH=${lib.makeBinPath [ (pkgs.python312.withPackages (ps: [ ps.xlib ])) pkgs.coreutils ]}"
+        "PATH=${lib.makeBinPath [ (pkgs.python312.withPackages (ps: [ ps.xlib ps.pyyaml ])) pkgs.coreutils ]}"
       ];
-      ExecStart = "${pkgs.python312.withPackages (ps: [ ps.xlib ])}/bin/python3 %h/.config/activity-collector/keylog/keylog.py";
+      ExecStart = "${pkgs.python312.withPackages (ps: [ ps.xlib ps.pyyaml ])}/bin/python3 %h/.config/activity-collector/keylog/keylog.py";
       Restart = "always";
       RestartSec = 10;
       # Restart on a script-only change (see activity-collector for rationale).

--- a/scripts/collector/keylog/espanso_detect.py
+++ b/scripts/collector/keylog/espanso_detect.py
@@ -1,0 +1,209 @@
+"""espanso_detect — detect true espanso usage from live keystrokes.
+
+Because espanso erases both the trigger and the expansion (backspace + clipboard
+paste) the ONLY place espanso usage is observable is the raw keystroke stream,
+BEFORE espanso reacts. `EspansoDetector` watches that stream (fed per-key by the
+keylogger, in parallel with the chunker) and emits an `EspansoEvent` the moment
+a trigger completes — the deterministic, forward-only usage signal.
+
+Two detection paths:
+
+  1. DIRECT triggers (deterministic). A bounded recent-char ring mirrors what
+     espanso itself sees. When the ring ENDS WITH a known trigger we emit and
+     CLEAR the ring — exactly as espanso consumes the trigger on firing. Because
+     we check after every char and clear on match, the trigger that completes
+     FIRST wins: typing ":datetime" emits ":date" (mirrors espanso's prefix
+     behaviour), and ":datetime" never forms. Clearing also means espanso's
+     trailing backspaces are no-ops (no double-emit), while a genuinely retyped
+     trigger fills the ring again and fires again.
+
+  2. Ctrl+Space SEARCH UI (best-effort attribution). On the search shortcut the
+     keylogger calls `feed_search_open`; subsequent chars accumulate as the
+     search TERM (not the direct ring) until a close boundary (Enter, Escape,
+     focus change, or idle). We fuzzy-attribute the term to a snippet; a unique
+     match is attributed, zero/multiple → trigger=None, but the search-open +
+     term are recorded regardless. Search events are always `inferred=True`.
+
+Honest limitation: "ring ends with a trigger" ≈ "espanso fired", EXCEPT in
+per-app espanso-disabled contexts (still far better than phrase-counting). The
+detector NEVER raises out of `feed_*`; the crash-guard also lives at the call
+site in keylog.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+# Chars that terminate the search term when in search mode.
+_ENTER = "\n"
+_ESCAPE = "\x1b"
+_BACKSPACE = "\b"
+
+
+@dataclass
+class EspansoEvent:
+    trigger: str | None      # the fired trigger, or None (search w/o unique match)
+    method: str              # "direct" | "search"
+    inferred: bool           # True for all search attributions
+    search_term: str | None  # the typed search query (search method only)
+    app: str
+    session: str
+    workspace: str = ""
+    label: str = ""
+
+
+class EspansoDetector:
+    def __init__(self, trigger_set):
+        self.ts = trigger_set
+        # Ring long enough to hold the longest trigger; >=1 so it is never empty.
+        self._maxlen = max(getattr(trigger_set, "max_len", 0), 1)
+        self._ring: list[str] = []
+        self._app = None
+        self._session = None
+        self._workspace = ""
+        # search-mode state
+        self._search = False
+        self._search_term: list[str] = []
+        self._last_ts = 0.0
+
+    # -- direct-trigger + search feed ------------------------------------- #
+    def feed_char(self, char, *, app, session, now, workspace="") -> list:
+        """Feed one resolved character. Returns a list of EspansoEvents (0 or 1)."""
+        out: list = []
+        try:
+            # Focus change: typing moved to another window. Flush an open search
+            # under the OLD context, then reset the direct ring (no cross-window
+            # false match).
+            if self._app is not None and (app != self._app or session != self._session):
+                if self._search:
+                    ev = self._close_search("focus")
+                    if ev is not None:
+                        out.append(ev)
+                self._ring.clear()
+            self._app, self._session, self._workspace = app, session, workspace
+            self._last_ts = now
+
+            if self._search:
+                self._feed_search_char(char, out)
+                return out
+
+            # -- direct ring --
+            if char == _BACKSPACE:
+                if self._ring:
+                    self._ring.pop()
+                return out
+            self._ring.append(char)
+            if len(self._ring) > self._maxlen:
+                del self._ring[0:len(self._ring) - self._maxlen]
+            ev = self._match_direct(app, session, now, workspace)
+            if ev is not None:
+                out.append(ev)
+            return out
+        except Exception:
+            return out
+
+    def feed_search_open(self, *, app, session, now, workspace="") -> None:
+        """Enter search-mode (called when keylog sees the Ctrl+Space shortcut)."""
+        try:
+            self._app, self._session, self._workspace = app, session, workspace
+            self._last_ts = now
+            self._ring.clear()
+            self._search = True
+            self._search_term = []
+        except Exception:
+            pass
+
+    def flush_idle(self, now, idle_seconds) -> list:
+        """Close an idle, unterminated search (called by keylog's idle loop)."""
+        out: list = []
+        try:
+            if self._search and (now - self._last_ts) >= idle_seconds:
+                ev = self._close_search("idle")
+                if ev is not None:
+                    out.append(ev)
+        except Exception:
+            pass
+        return out
+
+    def flush_now(self) -> list:
+        """Force-close an open search (e.g. on shutdown)."""
+        out: list = []
+        try:
+            if self._search:
+                ev = self._close_search("close")
+                if ev is not None:
+                    out.append(ev)
+        except Exception:
+            pass
+        return out
+
+    # -- internals -------------------------------------------------------- #
+    def _feed_search_char(self, char, out: list) -> None:
+        if char == _ENTER:
+            ev = self._close_search("enter")
+            if ev is not None:
+                out.append(ev)
+        elif char == _ESCAPE:
+            ev = self._close_search("escape")
+            if ev is not None:
+                out.append(ev)
+        elif char == _BACKSPACE:
+            if self._search_term:
+                self._search_term.pop()
+        else:
+            self._search_term.append(char)
+
+    def _match_direct(self, app, session, now, workspace):
+        if not self.ts.triggers:
+            return None
+        s = "".join(self._ring)
+        # Emit the SHORTEST trigger the ring ends with (the one that completed
+        # first / at the current char), mirroring espanso's prefix behaviour.
+        best = None
+        for trig in self.ts.triggers:
+            if trig and s.endswith(trig) and (best is None or len(trig) < len(best)):
+                best = trig
+        if best is None:
+            return None
+        # espanso consumes the trigger on firing → clear so trailing backspaces
+        # are no-ops and a longer overlapping trigger cannot also match.
+        self._ring.clear()
+        label = (self.ts.meta.get(best) or {}).get("label", "") or ""
+        return EspansoEvent(
+            trigger=best, method="direct", inferred=False, search_term=None,
+            app=app, session=session, workspace=workspace, label=label,
+        )
+
+    def _close_search(self, reason):
+        term = "".join(self._search_term)
+        self._search = False
+        self._search_term = []
+        trigger = self._attribute(term)
+        label = (self.ts.meta.get(trigger) or {}).get("label", "") if trigger else ""
+        return EspansoEvent(
+            trigger=trigger, method="search", inferred=True, search_term=term,
+            app=self._app or "", session=self._session or "",
+            workspace=self._workspace, label=label or "",
+        )
+
+    def _attribute(self, term):
+        """Fuzzy-attribute a search term to exactly one snippet, else None."""
+        t = (term or "").strip().lower()
+        if not t:
+            return None
+        matched = [trig for trig in self.ts.triggers if self._term_matches(t, trig)]
+        return matched[0] if len(matched) == 1 else None
+
+    def _term_matches(self, term, trig):
+        meta = self.ts.meta.get(trig) or {}
+        if term in trig.lower():
+            return True
+        label = (meta.get("label") or "").lower()
+        for w in _WORD_RE.findall(label):
+            if term in w:
+                return True
+        for st in meta.get("search_terms") or []:
+            if isinstance(st, str) and term in st.lower():
+                return True
+        return False

--- a/scripts/collector/keylog/espanso_detect.py
+++ b/scripts/collector/keylog/espanso_detect.py
@@ -39,6 +39,12 @@ _WORD_RE = re.compile(r"[a-z0-9]+")
 _ENTER = "\n"
 _ESCAPE = "\x1b"
 _BACKSPACE = "\b"
+# A real espanso search query is short. Ctrl+Space is NOT espanso-exclusive
+# (IDE completion, emacs set-mark, IME), so a non-espanso Ctrl+Space would
+# otherwise enter search-mode and accumulate ordinary typed text unbounded,
+# mislabeling it as a method=search row. Past this cap we treat search-mode as
+# a misfire and abort it WITHOUT emitting.
+SEARCH_TERM_MAX = 64
 
 
 @dataclass
@@ -103,6 +109,19 @@ class EspansoDetector:
         except Exception:
             return out
 
+    def notify_navigation(self) -> None:
+        """Caret-navigation / editing key (arrow, Home/End, PageUp/Down, Delete).
+
+        Such a key breaks contiguously-typed text, and espanso resets its own
+        buffer on it. Clear the DIRECT ring so a trigger split by a caret move
+        (":da" → arrow → "te") cannot assemble into a phantom ":date". Search
+        state is deliberately left untouched. Never raises.
+        """
+        try:
+            self._ring.clear()
+        except Exception:
+            pass
+
     def feed_search_open(self, *, app, session, now, workspace="") -> None:
         """Enter search-mode (called when keylog sees the Ctrl+Space shortcut)."""
         try:
@@ -153,6 +172,12 @@ class EspansoDetector:
                 self._search_term.pop()
         else:
             self._search_term.append(char)
+            if len(self._search_term) > SEARCH_TERM_MAX:
+                # Way past a plausible espanso query → this was a non-espanso
+                # Ctrl+Space and we've been mislabeling typed text. Abort
+                # search-mode WITHOUT emitting and reset search state.
+                self._search = False
+                self._search_term = []
 
     def _match_direct(self, app, session, now, workspace):
         if not self.ts.triggers:
@@ -179,6 +204,10 @@ class EspansoDetector:
         term = "".join(self._search_term)
         self._search = False
         self._search_term = []
+        # No real query was typed (accidental Ctrl+Space then Escape/idle/focus)
+        # → suppress the phantom empty trigger=None row rather than emit it.
+        if not term.strip():
+            return None
         trigger = self._attribute(term)
         label = (self.ts.meta.get(trigger) or {}).get("label", "") if trigger else ""
         return EspansoEvent(

--- a/scripts/collector/keylog/espanso_triggers.py
+++ b/scripts/collector/keylog/espanso_triggers.py
@@ -1,0 +1,153 @@
+"""espanso_triggers — parse the live espanso config into a trigger model.
+
+espanso, on firing a trigger, BACKSPACES the trigger away and inserts the
+replacement via a CLIPBOARD paste — so BOTH the trigger and its expansion are
+ERASED from the keystroke stream the chunker reconstructs. Espanso usage is
+therefore invisible in stored `text` and must be detected AT CAPTURE TIME from
+the user's real keystrokes (which arrive before espanso reacts). This module
+loads the trigger set the detector matches against.
+
+Pure + testable: `load_triggers` accepts file PATHS or pre-loaded dicts. It is
+robust to home-manager's `replace:`-before-`trigger:` key ordering, to snippets
+missing a `label`/`search_terms`, and to a MISSING/unparseable config — in which
+case it returns an empty TriggerSet (never raises), so the keylogger's detector
+is inert and typing capture behaves exactly as before.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+try:  # PyYAML is added to the keylog python env in nix/home.nix; degrade if absent.
+    import yaml as _yaml
+except Exception:  # pragma: no cover - exercised only where PyYAML is missing
+    _yaml = None
+
+# espanso's default search shortcut on this host is CTRL+SPACE (see
+# ~/.config/espanso/config/default.yml). Fall back to it when unspecified.
+_DEFAULT_SHORTCUT = (True, 0x20)  # (ctrl_required, keysym)
+
+# Named keys → X11 keysym, for parsing the `search_shortcut` value.
+_KEY_KEYSYMS = {
+    "SPACE": 0x20,
+    "TAB": 0xFF09,
+    "ENTER": 0xFF0D,
+    "RETURN": 0xFF0D,
+    "ESC": 0xFF1B,
+    "ESCAPE": 0xFF1B,
+}
+_MODIFIERS = {"CTRL", "CONTROL", "ALT", "SHIFT", "META", "SUPER", "CMD"}
+
+
+@dataclass
+class TriggerSet:
+    """The parsed espanso model the detector consumes.
+
+    triggers        — every trigger string (e.g. ":date", "dashbaord").
+    meta            — trigger -> {label, search_terms, replace}.
+    search_shortcut — (ctrl_required: bool, keysym: int) for the Ctrl+Space
+                      search UI; keysym is an X11 keysym so keylog can compare it
+                      against a KeyPress at the keysym level.
+    """
+
+    triggers: list[str] = field(default_factory=list)
+    meta: dict = field(default_factory=dict)
+    search_shortcut: tuple = _DEFAULT_SHORTCUT
+
+    @property
+    def max_len(self) -> int:
+        return max((len(t) for t in self.triggers), default=0)
+
+
+def parse_search_shortcut(value) -> tuple:
+    """Parse a `search_shortcut` string like "CTRL+SPACE" → (ctrl, keysym)."""
+    if not value or not isinstance(value, str):
+        return _DEFAULT_SHORTCUT
+    parts = [p.strip().upper() for p in value.split("+") if p.strip()]
+    if not parts:
+        return _DEFAULT_SHORTCUT
+    ctrl = any(p in ("CTRL", "CONTROL") for p in parts)
+    keysym = None
+    for p in parts:
+        if p in _MODIFIERS:
+            continue
+        if p in _KEY_KEYSYMS:
+            keysym = _KEY_KEYSYMS[p]
+        elif len(p) == 1:
+            keysym = ord(p.lower())  # Latin-1 keysym == code point
+    if keysym is None:
+        return _DEFAULT_SHORTCUT
+    return (ctrl, keysym)
+
+
+def _load_yaml(source, *, is_path: bool):
+    """Return a parsed dict from a path or an already-loaded dict; {} on any error."""
+    if source is None:
+        return {}
+    if isinstance(source, dict):
+        return source
+    if not is_path:
+        return {}
+    if _yaml is None:
+        return {}
+    try:
+        with open(source, encoding="utf-8") as fh:
+            data = _yaml.safe_load(fh)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _extract_matches(base: dict) -> list[dict]:
+    out = []
+    for m in base.get("matches") or []:
+        if isinstance(m, dict):
+            out.append(m)
+    return out
+
+
+def load_triggers(base_yml_path=None, default_yml_path=None) -> TriggerSet:
+    """Load the espanso trigger model from the match + config files.
+
+    Both args accept a path (str/PathLike) OR a pre-loaded dict (for tests). A
+    missing/unparseable file yields an empty contribution — never raises.
+    """
+    base = _load_yaml(base_yml_path, is_path=not isinstance(base_yml_path, dict))
+    default = _load_yaml(default_yml_path, is_path=not isinstance(default_yml_path, dict))
+
+    triggers: list[str] = []
+    meta: dict = {}
+    seen: set = set()
+
+    for m in _extract_matches(base):
+        # A match may carry `trigger` (str) or `triggers` (list); handle both,
+        # regardless of key order (home-manager emits `replace:` before `trigger:`).
+        trigs = []
+        if isinstance(m.get("trigger"), str):
+            trigs.append(m["trigger"])
+        raw_multi = m.get("triggers")
+        if isinstance(raw_multi, list):
+            trigs.extend([t for t in raw_multi if isinstance(t, str)])
+        if not trigs:
+            continue
+        label = m.get("label") if isinstance(m.get("label"), str) else ""
+        st = m.get("search_terms")
+        search_terms = [s for s in st if isinstance(s, str)] if isinstance(st, list) else []
+        replace = m.get("replace") if isinstance(m.get("replace"), str) else ""
+        for t in trigs:
+            if t in seen:
+                continue
+            seen.add(t)
+            triggers.append(t)
+            meta[t] = {"label": label, "search_terms": search_terms, "replace": replace}
+
+    shortcut = parse_search_shortcut(default.get("search_shortcut"))
+    return TriggerSet(triggers=triggers, meta=meta, search_shortcut=shortcut)
+
+
+def standard_config_paths():
+    """The live espanso config paths (rendered by home-manager)."""
+    import os
+
+    base = os.path.expanduser("~/.config/espanso/match/base.yml")
+    default = os.path.expanduser("~/.config/espanso/config/default.yml")
+    return base, default

--- a/scripts/collector/keylog/keylog.py
+++ b/scripts/collector/keylog/keylog.py
@@ -43,9 +43,18 @@ import keymap as KM        # noqa: E402
 import spool_emit as SE    # noqa: E402
 from chunker import Chunker  # noqa: E402
 from winctx import WindowContext, WinCtx  # noqa: E402
+from espanso_detect import EspansoDetector  # noqa: E402
+from espanso_triggers import (  # noqa: E402
+    TriggerSet, load_triggers, standard_config_paths,
+)
 
 SOURCE = "keys"
 KIND = "typing"
+KIND_ESPANSO = "espanso"
+
+# X ControlMask (1<<2); espanso's search shortcut is Ctrl+Space on this host.
+CONTROL_MASK = 0x04
+XK_ESCAPE = 0xFF1B
 
 
 def _emit_chunk(chunk, spool_dir: Path) -> str:
@@ -67,10 +76,48 @@ def _emit_chunk(chunk, spool_dir: Path) -> str:
     return SE.emit(fields, spool_dir=spool_dir)
 
 
+def _emit_espanso(ev, spool_dir: Path) -> str:
+    """Map an EspansoEvent → the v1 emit fields and append to the spool.
+
+    The trigger goes in `text` (base64'd like typing); method / inferred /
+    search_term / label / workspace ride in the JSON `payload`. `kind=espanso`
+    is a plain scalar so the report can filter on it cheaply.
+    """
+    import json
+    payload = json.dumps(
+        {
+            "method": ev.method,
+            "inferred": ev.inferred,
+            "search_term": ev.search_term,
+            "label": ev.label,
+            "workspace": ev.workspace,
+        },
+        ensure_ascii=False, separators=(",", ":"),
+    )
+    fields = {
+        "source": SOURCE,
+        "kind": KIND_ESPANSO,
+        "text": ev.trigger or "",
+        "app": ev.app,
+        "project": "",
+        "session": ev.session,
+        "payload": payload,
+    }
+    return SE.emit(fields, spool_dir=spool_dir)
+
+
 class KeyLogger:
     def __init__(self, spool_dir: Path, idle_seconds: float, max_chars: int):
         self.spool_dir = spool_dir
         self.chunker = Chunker(idle_seconds=idle_seconds, max_chars=max_chars)
+        # Espanso usage detector (forward-only, deterministic). A missing or
+        # unparseable espanso config yields an empty trigger set → the detector
+        # is inert and typing capture behaves exactly as before.
+        try:
+            base_p, default_p = standard_config_paths()
+            self.detector = EspansoDetector(load_triggers(base_p, default_p))
+        except Exception:
+            self.detector = EspansoDetector(TriggerSet())
         self._lock = threading.Lock()
         self._stop = threading.Event()
         self._ctx = None
@@ -134,10 +181,52 @@ class KeyLogger:
             if event.type != X.KeyPress:
                 continue
             char = self._char_for(event.detail, event.state)
-            if char is None:
-                continue
             ctx = self._safe_ctx()
             now = time.time()
+
+            # -- espanso: search-shortcut / Escape (keysym-level, fully guarded).
+            # A detector bug must NEVER kill keystroke capture, so every detector
+            # call here is wrapped in try/except.
+            try:
+                base_ks = self.local_dpy.keycode_to_keysym(event.detail, 0)
+            except Exception:
+                base_ks = 0
+            try:
+                ctrl_req, sc_keysym = self.detector.ts.search_shortcut
+                is_shortcut = (
+                    base_ks == sc_keysym
+                    and (not ctrl_req or bool(event.state & CONTROL_MASK))
+                )
+            except Exception:
+                is_shortcut = False
+            if is_shortcut:
+                # Ctrl+Space opens the espanso search UI — enter search-mode and
+                # do NOT also feed this as a normal char.
+                try:
+                    with self._lock:
+                        self.detector.feed_search_open(
+                            app=ctx.app, session=ctx.window_id,
+                            now=now, workspace=ctx.workspace,
+                        )
+                except Exception:
+                    pass
+                continue
+            if char is None:
+                # Escape closes an open espanso search; otherwise it is a
+                # non-printing key the chunker already ignores.
+                if base_ks == XK_ESCAPE:
+                    try:
+                        with self._lock:
+                            evs = self.detector.feed_char(
+                                "\x1b", app=ctx.app, session=ctx.window_id,
+                                now=now, workspace=ctx.workspace,
+                            )
+                    except Exception:
+                        evs = []
+                    for ev in evs:
+                        _emit_espanso(ev, self.spool_dir)
+                continue
+
             with self._lock:
                 chunks = self.chunker.feed(
                     char, app=ctx.app, title=ctx.title,
@@ -145,6 +234,18 @@ class KeyLogger:
                 )
             for ch in chunks:
                 _emit_chunk(ch, self.spool_dir)
+
+            # Feed the detector in parallel with the chunker (guarded).
+            try:
+                with self._lock:
+                    evs = self.detector.feed_char(
+                        char, app=ctx.app, session=ctx.window_id,
+                        now=now, workspace=ctx.workspace,
+                    )
+            except Exception:
+                evs = []
+            for ev in evs:
+                _emit_espanso(ev, self.spool_dir)
 
     def _safe_ctx(self) -> WinCtx:
         try:
@@ -160,6 +261,14 @@ class KeyLogger:
                 chunks = self.chunker.flush_idle(now)
             for ch in chunks:
                 _emit_chunk(ch, self.spool_dir)
+            # Close an idle, unterminated espanso search (guarded).
+            try:
+                with self._lock:
+                    evs = self.detector.flush_idle(now, self.chunker.idle_seconds)
+            except Exception:
+                evs = []
+            for ev in evs:
+                _emit_espanso(ev, self.spool_dir)
 
     def run(self, poll_seconds: float = 0.5):
         from Xlib import X
@@ -196,6 +305,13 @@ class KeyLogger:
             with self._lock:
                 for ch in self.chunker.flush_now():
                     _emit_chunk(ch, self.spool_dir)
+            try:
+                with self._lock:
+                    evs = self.detector.flush_now()
+            except Exception:
+                evs = []
+            for ev in evs:
+                _emit_espanso(ev, self.spool_dir)
 
     def stop(self):
         # record_enable_context blocks on the record connection; disabling must

--- a/scripts/collector/keylog/keylog.py
+++ b/scripts/collector/keylog/keylog.py
@@ -56,6 +56,23 @@ KIND_ESPANSO = "espanso"
 CONTROL_MASK = 0x04
 XK_ESCAPE = 0xFF1B
 
+# Caret-navigation / editing keysyms. These reposition the caret or delete
+# forward, breaking contiguously-typed text — espanso resets its buffer on
+# them, so the detector's direct ring must reset too (else ":da" → arrow →
+# "te" would assemble a ":date" that was never typed contiguously). They carry
+# no printable char, so we detect them from the base keysym BEFORE the
+# char-is-None drop. NOTE: mouse-click caret repositioning is NOT captured
+# (device_events are KeyPress/KeyRelease only) → a documented residual
+# false-positive vector.
+NAV_KEYSYMS = frozenset({
+    0xFF50,                          # Home
+    0xFF51, 0xFF52, 0xFF53, 0xFF54,  # Left / Up / Right / Down
+    0xFF55,                          # Prior (PageUp)
+    0xFF56,                          # Next  (PageDown)
+    0xFF57,                          # End
+    0xFFFF,                          # Delete
+})
+
 
 def _emit_chunk(chunk, spool_dir: Path) -> str:
     """Map a Chunker.Chunk → the v1 emit fields and append to the spool."""
@@ -211,6 +228,17 @@ class KeyLogger:
                 except Exception:
                     pass
                 continue
+            if base_ks in NAV_KEYSYMS:
+                # Caret moved / forward-delete → reset the direct ring so a
+                # trigger split by the navigation cannot assemble. Search-mode
+                # is left as-is. Guarded like every other detector call; these
+                # keys carry no char so they drop below and never reach the
+                # chunker (chunker behaviour is byte-for-byte unchanged).
+                try:
+                    with self._lock:
+                        self.detector.notify_navigation()
+                except Exception:
+                    pass
             if char is None:
                 # Escape closes an open espanso search; otherwise it is a
                 # non-printing key the chunker already ignores.

--- a/scripts/collector/keylog/tests/test_emit_roundtrip.py
+++ b/scripts/collector/keylog/tests/test_emit_roundtrip.py
@@ -80,3 +80,45 @@ def test_plain_keys_not_base64(tmp_path):
     assert "kind=typing" in line
     assert "duration_ms=5" in line
     assert "b64:text=" in line
+
+
+def test_espanso_event_line_roundtrips():
+    """An EspansoEvent → spool line carries kind=espanso (plain scalar) and the
+    trigger + method/inferred/search_term survive base64 round-trip through
+    collector.parse_line — proving the report can read TRUE espanso fires."""
+    import keylog as KL
+
+    class _Ev:
+        trigger = ":rnx"
+        method = "direct"
+        inferred = False
+        search_term = None
+        label = "Recommend next steps, ranked by leverage"
+        workspace = "3"
+        app = "kitty"
+        session = "win-9"
+
+    line = SE.build_line({
+        "source": "keys", "kind": KL.KIND_ESPANSO,
+        "text": _Ev.trigger, "app": _Ev.app, "project": "",
+        "session": _Ev.session,
+        "payload": json.dumps({
+            "method": _Ev.method, "inferred": _Ev.inferred,
+            "search_term": _Ev.search_term, "label": _Ev.label,
+            "workspace": _Ev.workspace,
+        }),
+    })
+    # kind is a plain scalar; text/payload are base64.
+    assert "kind=espanso" in line
+    assert "b64:text=" in line
+    assert "b64:payload=" in line
+
+    ev = C.parse_line(line)
+    assert ev is not None
+    assert ev["kind"] == "espanso"
+    assert ev["text"] == ":rnx"
+    pl = json.loads(ev["payload"])
+    assert pl["method"] == "direct"
+    assert pl["inferred"] is False
+    assert pl["search_term"] is None
+    assert pl["workspace"] == "3"

--- a/scripts/collector/keylog/tests/test_espanso_detect.py
+++ b/scripts/collector/keylog/tests/test_espanso_detect.py
@@ -179,7 +179,82 @@ def test_empty_trigger_set_is_inert():
     d = EspansoDetector(ET.TriggerSet())
     assert _type(d, ":date anything :rnx") == []
     d.feed_search_open(app=APP, session=SESS, now=0.0)
+    # An empty search close is a phantom → suppressed (no trigger=None row).
     evs = list(d.feed_char("\n", app=APP, session=SESS, now=1.0))
-    # Search still records the open even with no snippets to attribute.
+    assert evs == []
+
+
+# -- FIX 1: bounded search-mode + phantom-empty suppression ------------------
+def test_search_term_over_cap_aborts_without_emitting():
+    # A non-espanso Ctrl+Space that keeps typing past the cap is a misfire:
+    # search-mode aborts silently (no method=search row for ordinary text).
+    from espanso_detect import SEARCH_TERM_MAX
+    d = _det()
+    d.feed_search_open(app=APP, session=SESS, now=0.0)
+    long_term = "x" * (SEARCH_TERM_MAX + 5)
+    assert _type(d, long_term, now=1.0) == []
+    # search-mode is off again; a subsequent close produces nothing.
+    assert list(d.feed_char("\n", app=APP, session=SESS, now=200.0)) == []
+    # And the direct ring is live again (typed text is no longer swallowed).
+    assert [e.trigger for e in _type(d, ":date", now=300.0)] == [":date"]
+
+
+def test_ctrl_space_then_empty_close_suppresses_phantom():
+    # Accidental Ctrl+Space then Escape with nothing typed → NO phantom row.
+    d = _det()
+    d.feed_search_open(app=APP, session=SESS, now=0.0)
+    evs = list(d.feed_char("\x1b", app=APP, session=SESS, now=1.0))
+    assert evs == []
+
+
+def test_search_whitespace_only_close_suppressed():
+    d = _det()
+    d.feed_search_open(app=APP, session=SESS, now=0.0)
+    _type(d, "   ", now=1.0)
+    evs = list(d.feed_char("\n", app=APP, session=SESS, now=5.0))
+    assert evs == []
+
+
+def test_search_short_attributed_term_still_emits():
+    # Short term that uniquely attributes → event as before (unchanged).
+    d = _det()
+    d.feed_search_open(app=APP, session=SESS, now=0.0)
+    _type(d, "leverage", now=1.0)
+    evs = list(d.feed_char("\n", app=APP, session=SESS, now=9.0))
+    assert len(evs) == 1
+    assert evs[0].trigger == ":rnx"
+    assert evs[0].inferred is True
+
+
+def test_search_short_unattributed_term_emits_trigger_none():
+    # Short term matching nothing → legit "real search we couldn't attribute".
+    d = _det()
+    d.feed_search_open(app=APP, session=SESS, now=0.0)
+    _type(d, "zzzzz", now=1.0)
+    evs = list(d.feed_char("\n", app=APP, session=SESS, now=6.0))
     assert len(evs) == 1
     assert evs[0].trigger is None
+    assert evs[0].inferred is True
+    assert evs[0].search_term == "zzzzz"
+
+
+# -- FIX 2: caret-navigation resets the direct ring --------------------------
+def test_notify_navigation_resets_direct_ring():
+    # ":da" then a caret move then "te" → ":date" was NOT typed contiguously,
+    # so nothing fires (mirrors espanso resetting its buffer on nav keys).
+    d = _det()
+    assert _type(d, ":da") == []
+    d.notify_navigation()
+    evs = _type(d, "te", now=10.0)
+    assert evs == []
+
+
+def test_notify_navigation_leaves_search_mode_intact():
+    # A nav key during search must NOT drop the accumulated term.
+    d = _det()
+    d.feed_search_open(app=APP, session=SESS, now=0.0)
+    _type(d, "today", now=1.0)
+    d.notify_navigation()
+    evs = list(d.feed_char("\n", app=APP, session=SESS, now=8.0))
+    assert len(evs) == 1
+    assert evs[0].search_term == "today"

--- a/scripts/collector/keylog/tests/test_espanso_detect.py
+++ b/scripts/collector/keylog/tests/test_espanso_detect.py
@@ -1,0 +1,185 @@
+"""Unit tests for EspansoDetector: direct triggers + Ctrl+Space search UI.
+
+The detector reconstructs espanso firings from the raw keystroke stream (the
+only place they are observable, since espanso erases both trigger and expansion).
+These tests pin the documented semantics: prefix collisions, no double-emit on
+espanso's trailing backspaces, focus-reset, and best-effort search attribution.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import espanso_triggers as ET       # noqa: E402
+from espanso_detect import EspansoDetector  # noqa: E402
+
+# A representative slice of the live config. :date is a prefix of :datetime
+# (prefix-collision case); the workflow triggers carry labels/search_terms used
+# by the fuzzy search-attribution tests.
+BASE = {"matches": [
+    {"label": "Today's date", "replace": "{{d}}",
+     "search_terms": ["today", "calendar"], "trigger": ":date"},
+    {"label": "Date and time", "replace": "{{dt}}",
+     "search_terms": ["timestamp"], "trigger": ":datetime"},
+    {"label": "Recommend next steps ranked by leverage", "replace": "...",
+     "search_terms": ["ranked", "leverage"], "trigger": ":rnx"},
+    {"label": "Dispatch subagent", "replace": "...",
+     "search_terms": ["dispatch", "delegate"], "trigger": ":ds"},
+]}
+DEFAULT = {"search_shortcut": "CTRL+SPACE"}
+
+APP, SESS = "kitty", "win-1"
+
+
+def _det():
+    return EspansoDetector(ET.load_triggers(BASE, DEFAULT))
+
+
+def _type(det, s, *, app=APP, session=SESS, now=0.0):
+    """Feed a string char-by-char, returning ALL emitted events."""
+    out = []
+    for i, ch in enumerate(s):
+        out.extend(det.feed_char(ch, app=app, session=session, now=now + i))
+    return out
+
+
+# -- direct triggers ---------------------------------------------------------
+def test_direct_trigger_at_buffer_end():
+    d = _det()
+    evs = _type(d, ":date")
+    assert len(evs) == 1
+    assert evs[0].trigger == ":date"
+    assert evs[0].method == "direct"
+    assert evs[0].inferred is False
+    assert evs[0].app == APP and evs[0].session == SESS
+
+
+def test_trigger_after_other_chars():
+    d = _det()
+    evs = _type(d, "foo:rnx")
+    assert [e.trigger for e in evs] == [":rnx"]
+
+
+def test_prefix_collision_emits_shorter_first():
+    # Typing ":datetime" must emit ":date" (mirrors espanso firing on the prefix);
+    # ":datetime" never forms because firing consumes the trigger.
+    d = _det()
+    evs = _type(d, ":datetime")
+    assert [e.trigger for e in evs] == [":date"]
+
+
+def test_backspaces_after_trigger_do_not_reemit_but_retype_does():
+    d = _det()
+    evs1 = _type(d, ":date")
+    assert [e.trigger for e in evs1] == [":date"]
+    # espanso backspaces the trigger away → no-ops on the (cleared) ring.
+    evs2 = _type(d, "\b\b\b\b\b", now=10.0)
+    assert evs2 == []
+    # A genuinely retyped trigger fires again.
+    evs3 = _type(d, ":date", now=20.0)
+    assert [e.trigger for e in evs3] == [":date"]
+
+
+def test_plain_typing_emits_nothing():
+    d = _det()
+    assert _type(d, "hello world, no triggers here") == []
+
+
+def test_focus_change_resets_ring():
+    d = _det()
+    # ":da" under window A, then "te" under window B → the ":date" sequence is
+    # broken across the focus boundary, so nothing fires.
+    out = []
+    for i, ch in enumerate(":da"):
+        out.extend(d.feed_char(ch, app="A", session="wA", now=i))
+    for i, ch in enumerate("te"):
+        out.extend(d.feed_char(ch, app="B", session="wB", now=10 + i))
+    assert out == []
+
+
+# -- Ctrl+Space search UI ----------------------------------------------------
+def test_search_open_term_then_enter_emits_one_search_event():
+    d = _det()
+    d.feed_search_open(app=APP, session=SESS, now=0.0)
+    assert _type(d, "today", now=1.0) == []          # accumulates, no emit yet
+    evs = list(d.feed_char("\n", app=APP, session=SESS, now=6.0))
+    assert len(evs) == 1
+    ev = evs[0]
+    assert ev.method == "search"
+    assert ev.inferred is True
+    assert ev.search_term == "today"
+
+
+def test_search_term_does_not_feed_direct_ring():
+    # Typing ":date" WHILE in search-mode must NOT fire a direct event.
+    d = _det()
+    d.feed_search_open(app=APP, session=SESS, now=0.0)
+    evs = _type(d, ":date", now=1.0)
+    assert evs == []  # captured as a search term, not a direct trigger
+
+
+def test_search_fuzzy_unique_match_attributes():
+    d = _det()
+    d.feed_search_open(app=APP, session=SESS, now=0.0)
+    _type(d, "leverage", now=1.0)  # matches ONLY :rnx (label + search_terms)
+    evs = list(d.feed_char("\n", app=APP, session=SESS, now=9.0))
+    assert len(evs) == 1
+    assert evs[0].trigger == ":rnx"
+    assert evs[0].inferred is True
+    assert evs[0].search_term == "leverage"
+
+
+def test_search_fuzzy_zero_match_still_emits_with_term():
+    d = _det()
+    d.feed_search_open(app=APP, session=SESS, now=0.0)
+    _type(d, "zzzzz", now=1.0)
+    evs = list(d.feed_char("\n", app=APP, session=SESS, now=6.0))
+    assert len(evs) == 1
+    assert evs[0].trigger is None
+    assert evs[0].search_term == "zzzzz"
+
+
+def test_search_fuzzy_multiple_match_is_ambiguous():
+    # "date" is a substring of BOTH :date and :datetime → ambiguous → trigger None.
+    d = _det()
+    d.feed_search_open(app=APP, session=SESS, now=0.0)
+    _type(d, "date", now=1.0)
+    evs = list(d.feed_char("\n", app=APP, session=SESS, now=5.0))
+    assert len(evs) == 1
+    assert evs[0].trigger is None
+    assert evs[0].search_term == "date"
+
+
+def test_search_flush_on_idle_without_enter():
+    d = _det()
+    d.feed_search_open(app=APP, session=SESS, now=0.0)
+    _type(d, "today", now=1.0)
+    # No Enter; the idle sweep closes it.
+    evs = d.flush_idle(now=100.0, idle_seconds=2.0)
+    assert len(evs) == 1
+    assert evs[0].method == "search"
+    assert evs[0].search_term == "today"
+    # Not idle yet → nothing.
+    assert EspansoDetector(ET.load_triggers(BASE, DEFAULT)).flush_idle(0, 2) == []
+
+
+def test_search_flush_on_focus_change_without_enter():
+    d = _det()
+    d.feed_search_open(app="A", session="wA", now=0.0)
+    for i, ch in enumerate("today"):
+        d.feed_char(ch, app="A", session="wA", now=1 + i)
+    # Focus moves to another window before Enter → search closes and emits.
+    evs = d.feed_char("x", app="B", session="wB", now=10.0)
+    assert len(evs) == 1
+    assert evs[0].method == "search"
+    assert evs[0].search_term == "today"
+    assert evs[0].app == "A"  # attributed to the window where search happened
+
+
+def test_empty_trigger_set_is_inert():
+    d = EspansoDetector(ET.TriggerSet())
+    assert _type(d, ":date anything :rnx") == []
+    d.feed_search_open(app=APP, session=SESS, now=0.0)
+    evs = list(d.feed_char("\n", app=APP, session=SESS, now=1.0))
+    # Search still records the open even with no snippets to attribute.
+    assert len(evs) == 1
+    assert evs[0].trigger is None

--- a/scripts/collector/keylog/tests/test_espanso_triggers.py
+++ b/scripts/collector/keylog/tests/test_espanso_triggers.py
@@ -1,0 +1,108 @@
+"""Unit tests for espanso_triggers: parse the config into the trigger model.
+
+Covers replace-before-trigger key ordering, snippets with/without search_terms,
+`search_shortcut` parsing, and graceful handling of a missing file.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import espanso_triggers as ET  # noqa: E402
+
+# A base.yml shaped exactly like home-manager renders it: `replace:` appears
+# BEFORE `trigger:`, and some matches omit label / search_terms.
+BASE = {
+    "matches": [
+        {  # replace-before-trigger ordering, full metadata
+            "label": "Today's date",
+            "replace": "{{mydate}}",
+            "search_terms": ["today", "calendar"],
+            "trigger": ":date",
+        },
+        {  # trigger with NO label and NO search_terms
+            "replace": "dashboard",
+            "trigger": "dashbaord",
+        },
+        {  # date+time — a superstring of :date, exercises the prefix collision
+            "label": "Date and time",
+            "replace": "{{mydt}}",
+            "search_terms": ["timestamp"],
+            "trigger": ":datetime",
+        },
+    ]
+}
+DEFAULT = {"backend": "Clipboard", "search_shortcut": "CTRL+SPACE"}
+
+
+def test_parses_all_triggers_regardless_of_key_order():
+    ts = ET.load_triggers(BASE, DEFAULT)
+    assert set(ts.triggers) == {":date", "dashbaord", ":datetime"}
+    assert ts.max_len == len(":datetime")
+
+
+def test_meta_label_and_search_terms():
+    ts = ET.load_triggers(BASE, DEFAULT)
+    assert ts.meta[":date"]["label"] == "Today's date"
+    assert ts.meta[":date"]["search_terms"] == ["today", "calendar"]
+    assert ts.meta[":date"]["replace"] == "{{mydate}}"
+
+
+def test_meta_defaults_when_missing():
+    ts = ET.load_triggers(BASE, DEFAULT)
+    # dashbaord has no label / search_terms in the config.
+    assert ts.meta["dashbaord"]["label"] == ""
+    assert ts.meta["dashbaord"]["search_terms"] == []
+    assert ts.meta["dashbaord"]["replace"] == "dashboard"
+
+
+def test_search_shortcut_ctrl_space():
+    ts = ET.load_triggers(BASE, DEFAULT)
+    ctrl, keysym = ts.search_shortcut
+    assert ctrl is True
+    assert keysym == 0x20  # space keysym
+
+
+def test_search_shortcut_parse_variants():
+    assert ET.parse_search_shortcut("CTRL+SPACE") == (True, 0x20)
+    assert ET.parse_search_shortcut("ALT+SPACE") == (False, 0x20)
+    assert ET.parse_search_shortcut("CTRL+E") == (True, ord("e"))
+    # Unparseable / empty → the CTRL+SPACE default.
+    assert ET.parse_search_shortcut("") == (True, 0x20)
+    assert ET.parse_search_shortcut(None) == (True, 0x20)
+
+
+def test_missing_file_yields_empty_no_raise():
+    ts = ET.load_triggers("/no/such/base.yml", "/no/such/default.yml")
+    assert ts.triggers == []
+    assert ts.meta == {}
+    # search_shortcut still defaults sanely (detector stays inert either way).
+    assert ts.search_shortcut == (True, 0x20)
+    assert ts.max_len == 0
+
+
+def test_triggers_plural_list_supported():
+    base = {"matches": [{"replace": "x", "triggers": [":a", ":b"]}]}
+    ts = ET.load_triggers(base, {})
+    assert set(ts.triggers) == {":a", ":b"}
+
+
+def test_path_based_load_roundtrip(tmp_path):
+    """A real YAML file on disk parses identically (needs PyYAML)."""
+    import pytest
+    if ET._yaml is None:
+        pytest.skip("PyYAML not available in this interpreter")
+    base_f = tmp_path / "base.yml"
+    default_f = tmp_path / "default.yml"
+    base_f.write_text(
+        "matches:\n"
+        "- replace: '{{mydate}}'\n"
+        "  search_terms:\n  - today\n"
+        "  trigger: ':date'\n"
+        "  label: Today's date\n",
+        encoding="utf-8",
+    )
+    default_f.write_text("search_shortcut: CTRL+SPACE\n", encoding="utf-8")
+    ts = ET.load_triggers(str(base_f), str(default_f))
+    assert ts.triggers == [":date"]
+    assert ts.meta[":date"]["search_terms"] == ["today"]
+    assert ts.search_shortcut == (True, 0x20)

--- a/scripts/session-analysis/espanso-usage.py
+++ b/scripts/session-analysis/espanso-usage.py
@@ -11,8 +11,10 @@ text. That breaks naive counting two different ways, hence two signals:
      emits one `source=keys, kind=espanso` row per fire into ClickHouse. This is
      the real per-trigger fire count, split direct vs Ctrl+Space-search. It is
      FORWARD-ONLY: there is no historical data before the detector was deployed.
-     Honest caveat: "keystrokes ended with a trigger" ≈ "espanso fired", except
-     in per-app espanso-disabled contexts — still far better than phrase-counting.
+     Honest caveat: direct fires are high-fidelity but can rarely over-count if a
+     trigger string is assembled via a mouse-repositioned caret (key events only)
+     or in a per-app espanso-disabled context; search rows are best-effort /
+     inferred. Still far better than phrase-counting.
 
   2. SECONDARY — transcript miner (ADD-CANDIDATES).  Because the expansion IS
      what Claude sees, mining `~/.claude/projects/**/*.jsonl` cannot reliably

--- a/scripts/session-analysis/espanso-usage.py
+++ b/scripts/session-analysis/espanso-usage.py
@@ -1,40 +1,125 @@
 #!/usr/bin/env python3
-"""Mine Claude transcripts for espanso snippet usage + snippet candidates.
+"""Espanso usage audit — TWO complementary signals.
 
-espanso expands a trigger to its replacement BEFORE Claude sees it, so
-transcripts contain the replacement text, never the trigger. We detect usage
-by matching each snippet's distinctive expansion substring in human-typed
-user messages, and surface recurring phrases that are not yet snippets.
+Espanso, on firing, BACKSPACES the trigger away and pastes the replacement via
+the CLIPBOARD, so BOTH the trigger and its expansion are ERASED from any stored
+text. That breaks naive counting two different ways, hence two signals:
 
-SNIPPETS is synced to the live config in nix/home.nix (PRs #4/#5, 2026-06-23:
-:rns shortened, :rau/:mdc/:nday/... steer-extended, :aep/:cont/:pec/:wn/:rnx/
-:fhrs/:fdays added, :usd removed).
-2026-07-15: :ds added; :wn/:mdc removed (dead — hand-typed short forms won).
-2026-07-15b: :cont/:pec removed (dead); :aep repointed to /audit-pr
-  (slash-command shortcut, no longer text-detectable).
+  1. PRIMARY — keylog (TRUE fires).  The X11 keylogger's `EspansoDetector`
+     (scripts/collector/keylog/espanso_detect.py) detects espanso usage AT
+     CAPTURE TIME from the raw keystroke stream, BEFORE espanso reacts, and
+     emits one `source=keys, kind=espanso` row per fire into ClickHouse. This is
+     the real per-trigger fire count, split direct vs Ctrl+Space-search. It is
+     FORWARD-ONLY: there is no historical data before the detector was deployed.
+     Honest caveat: "keystrokes ended with a trigger" ≈ "espanso fired", except
+     in per-app espanso-disabled contexts — still far better than phrase-counting.
 
-Caveats baked in:
-- Some expansions are now IDENTICAL to phrases you hand-type (:rns="recommend
-  next steps", :wn="what's next", :pec="push an empty commit"). Their counts
-  CONFLATE snippet-expansion with manual typing and are flagged ambiguous.
-- :rns vs :rnx overlap ("recommend next steps" is a prefix of the :rnx text);
-  handled via an exclude substring so :rns doesn't double-count :rnx.
+  2. SECONDARY — transcript miner (ADD-CANDIDATES).  Because the expansion IS
+     what Claude sees, mining `~/.claude/projects/**/*.jsonl` cannot reliably
+     tell a snippet fire from hand-typing (the two produce identical text). Its
+     durable, UNIQUE value is the inverse view: recurring SHORT phrases you type
+     that are NOT yet snippets — i.e. candidates to ADD. The per-trigger
+     "hits" it reports are kept only as a rough, ambiguous cross-check.
 
-Usage: espanso-usage.py [--since YYYY-MM-DD] [--root PATH] [--host LABEL]
+Credentials for the keylog signal (read-only reader, from env — NEVER hardcoded;
+same pattern as activity-scan.py / validation/chquery.py):
+  export CLICKHOUSE_URL=http://192.168.50.94:30123
+  export CLICKHOUSE_USER=activity_reader
+  export CLICKHOUSE_PASSWORD=<reader-password>   # from SOPS
+
+Usage: espanso-usage.py [--since YYYY-MM-DD] [--source keys|transcript|both]
+                        [--root PATH] [--host LABEL]
+  --source   which signal(s) to show (default: both; keylog shown first)
 """
 import json, os, re, glob, collections, sys
+from pathlib import Path
 
 # --- args ---
 SINCE = None
 ROOT = os.path.expanduser("~/.claude/projects")
 HOST = ""
+SOURCE = "both"
 _a = sys.argv[1:]
 while _a:
     k = _a.pop(0)
-    if k == "--since":  SINCE = _a.pop(0)
-    elif k == "--root": ROOT = os.path.expanduser(_a.pop(0))
-    elif k == "--host": HOST = _a.pop(0)
+    if k == "--since":    SINCE = _a.pop(0)
+    elif k == "--root":   ROOT = os.path.expanduser(_a.pop(0))
+    elif k == "--host":   HOST = _a.pop(0)
+    elif k == "--source": SOURCE = _a.pop(0)
+    else:
+        sys.stderr.write(f"unknown arg: {k}\n"); sys.exit(2)
+if SOURCE not in ("keys", "transcript", "both"):
+    sys.stderr.write("--source must be keys|transcript|both\n"); sys.exit(2)
 
+
+# --------------------------------------------------------------------------- #
+# PRIMARY signal — keylog TRUE fires from ClickHouse (source=keys, kind=espanso)
+# --------------------------------------------------------------------------- #
+def keylog_section(since):
+    """Print the per-trigger TRUE-fire table from the keylog espanso rows.
+
+    Degrades gracefully: if ClickHouse is unreachable OR there are zero espanso
+    rows yet (detection is forward-only), print a clear note and return — the
+    transcript section still runs.
+    """
+    print("## PRIMARY — keylog TRUE fires (source=keys, kind=espanso)\n")
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "validation"))
+        import chquery as Q  # noqa: E402
+        conn = Q.CHConn.from_env()
+        client = Q.CHClient(conn)
+    except Exception as e:
+        print(f"(keylog signal unavailable — {e.__class__.__name__}: {e})")
+        print("(set CLICKHOUSE_URL/USER/PASSWORD; detection is forward-only)\n")
+        return
+    where = "source = 'keys' AND kind = 'espanso'"
+    if since:
+        where += f" AND ts >= {Q.sql_quote(since)}"
+    sql = (
+        "SELECT text AS trigger, "
+        "JSONExtractString(payload, 'method') AS method, "
+        "JSONExtractBool(payload, 'inferred') AS inferred, "
+        "count() AS fires "
+        f"FROM {conn.fq_table} WHERE {where} "
+        "GROUP BY trigger, method, inferred ORDER BY fires DESC, trigger"
+    )
+    try:
+        rows = client.rows(sql)
+    except Exception as e:
+        print(f"(ClickHouse query failed — {e.__class__.__name__}: {e})")
+        print("(no keylog espanso events yet — detection is forward-only; "
+              "collecting since deploy)\n")
+        return
+    if not rows:
+        print("(no keylog espanso events yet — detection is forward-only; "
+              "collecting since deploy)\n")
+        return
+    # Aggregate per trigger with a direct/search split.
+    per = collections.defaultdict(lambda: {"direct": 0, "search": 0, "inferred": False})
+    total = 0
+    for r in rows:
+        trig = r.get("trigger") or "(unattributed search)"
+        method = r.get("method") or "direct"
+        fires = int(r.get("fires") or 0)
+        total += fires
+        bucket = per[trig]
+        bucket["direct" if method == "direct" else "search"] += fires
+        if r.get("inferred"):
+            bucket["inferred"] = True
+    print(f"# total fires: {total}\n")
+    print(f"{'trigger':22} {'direct':>7} {'search':>7} {'total':>7}  note")
+    order = sorted(per, key=lambda t: (-(per[t]['direct'] + per[t]['search']), t))
+    for t in order:
+        b = per[t]
+        tot = b["direct"] + b["search"]
+        note = "search=inferred attribution" if b["search"] else ""
+        print(f"{t:22} {b['direct']:>7} {b['search']:>7} {tot:>7}  {note}")
+    print()
+
+
+# --------------------------------------------------------------------------- #
+# SECONDARY signal — transcript miner (ADD-CANDIDATES + ambiguous cross-check)
+# --------------------------------------------------------------------------- #
 # trigger -> (kind, [include substrs] | None, [exclude substrs], ambiguous?)
 # include=None => not text-detectable (date/clipboard/typo-correction).
 SNIPPETS = {
@@ -54,24 +139,12 @@ SNIPPETS = {
     ":cpk":   ("path", ["datapacket-talos/prod-kubeconfig"], [], False),
     ":subk":  ("path", ["submodel-dc-03-a-kubeconfig"], [], False),
     # workflow prompts (current expansions)
-    # :whn removed 2026-07-06 (dead + superseded by /handoff + :eos).
     ":eos":     ("prompt", ["identify skills that may need updating"], [], False),
     ":acq":     ("prompt", ["recommend anything you think would be useful to include"], [], False),
-    # :ds="dispatch subagent to " is a phrase-PREFIX the user also hand-types, so
-    # its count conflates snippet-expansion with manual typing (ambiguous=True).
-    # "dispatch subagent to" is also a substring of the :aep/:eos expansions —
-    # exclude their distinctive tails so those fires don't inflate the :ds count
-    # (mirrors the :rns/:rnx overlap guard).
     ":ds":      ("prompt", ["dispatch subagent to"], ["adversarially audit the PR", "identify skills that may need updating"], True),
-    # :aep repointed to the /audit-pr slash command (PR-quality audit, 2026-07-15)
-    # — slash-command invocations aren't captured as human text, so it's no longer
-    # transcript-detectable.
     ":aep":     ("prompt", None, [], False),
     ":rns":     ("prompt", ["recommend next steps"], ["ranked by leverage"], True),
     ":rnx":     ("prompt", ["recommend next steps ranked by leverage"], [], False),
-    # NOTE: PR (espanso-shorten-unfired-snippets, 2026-06-30) reverted these to
-    # their short hand-typed forms — option (a) — so their counts now CONFLATE
-    # snippet-expansion with manual typing (ambiguous=True), the accepted trade.
     ":pst":     ("prompt", ["proceed, use subagent, ensure test coverage"], [], True),
     ":kickoff": ("prompt", ["kickoff message to copy paste to next session"], [], False),
     ":nday":    ("prompt", ["it's the next day, check"], [], True),
@@ -84,16 +157,13 @@ SNIPPETS = {
     "reocmmend": ("typo", None, [], False),
 }
 
-counts = {t: 0 for t in SNIPPETS}
-sessions_hit = {t: set() for t in SNIPPETS}
-last_seen = {t: None for t in SNIPPETS}
-
-short_msgs = collections.Counter()
-phrase_counter = collections.Counter()
-total_user_msgs = 0
-files_scanned = 0
-
+WORD = re.compile(r"[a-z][a-z'\-]+")
 KNOWN_EXPANSIONS = [m for _, subs, _, _ in SNIPPETS.values() if subs for m in subs]
+
+
+def norm(s):
+    return " ".join(s.lower().split())
+
 
 def human_text(o):
     if o.get("type") != "user":
@@ -123,86 +193,107 @@ def human_text(o):
         return None
     return s
 
-WORD = re.compile(r"[a-z][a-z'\-]+")
-def norm(s):
-    return " ".join(s.lower().split())
 
-for fp in glob.glob(os.path.join(ROOT, "**", "*.jsonl"), recursive=True):
-    files_scanned += 1
-    sid = os.path.basename(fp)[:8]
-    try:
-        with open(fp, errors="ignore") as fh:
-            for line in fh:
-                if '"type":"user"' not in line and '"type": "user"' not in line:
-                    continue
-                try:
-                    o = json.loads(line)
-                except Exception:
-                    continue
-                ts = o.get("timestamp", "")[:10]
-                if SINCE and ts and ts < SINCE:
-                    continue
-                s = human_text(o)
-                if s is None:
-                    continue
-                total_user_msgs += 1
-                low = s.lower()
-                for t, (kind, subs, excl, _amb) in SNIPPETS.items():
-                    if not subs:
+def transcript_section(since, root, host):
+    counts = {t: 0 for t in SNIPPETS}
+    sessions_hit = {t: set() for t in SNIPPETS}
+    last_seen = {t: None for t in SNIPPETS}
+    short_msgs = collections.Counter()
+    phrase_counter = collections.Counter()
+    total_user_msgs = 0
+    files_scanned = 0
+
+    for fp in glob.glob(os.path.join(root, "**", "*.jsonl"), recursive=True):
+        files_scanned += 1
+        sid = os.path.basename(fp)[:8]
+        try:
+            with open(fp, errors="ignore") as fh:
+                for line in fh:
+                    if '"type":"user"' not in line and '"type": "user"' not in line:
                         continue
-                    if any(sub in low for sub in subs) and not any(e in low for e in excl):
-                        counts[t] += 1
-                        sessions_hit[t].add(sid)
-                        if ts and (last_seen[t] is None or ts > last_seen[t]):
-                            last_seen[t] = ts
-                if len(s) <= 140 and not s.startswith("/"):
-                    n = norm(s)
-                    if not any(e in n for e in KNOWN_EXPANSIONS):
-                        if len(n) >= 3:
-                            short_msgs[n] += 1
-                        words = WORD.findall(n)
-                        for k in (4, 5):
-                            for i in range(len(words) - k + 1):
-                                phrase_counter[" ".join(words[i:i+k])] += 1
-    except Exception:
-        continue
+                    try:
+                        o = json.loads(line)
+                    except Exception:
+                        continue
+                    ts = o.get("timestamp", "")[:10]
+                    if since and ts and ts < since:
+                        continue
+                    s = human_text(o)
+                    if s is None:
+                        continue
+                    total_user_msgs += 1
+                    low = s.lower()
+                    for t, (kind, subs, excl, _amb) in SNIPPETS.items():
+                        if not subs:
+                            continue
+                        if any(sub in low for sub in subs) and not any(e in low for e in excl):
+                            counts[t] += 1
+                            sessions_hit[t].add(sid)
+                            if ts and (last_seen[t] is None or ts > last_seen[t]):
+                                last_seen[t] = ts
+                    if len(s) <= 140 and not s.startswith("/"):
+                        n = norm(s)
+                        if not any(e in n for e in KNOWN_EXPANSIONS):
+                            if len(n) >= 3:
+                                short_msgs[n] += 1
+                            words = WORD.findall(n)
+                            for k in (4, 5):
+                                for i in range(len(words) - k + 1):
+                                    phrase_counter[" ".join(words[i:i+k])] += 1
+        except Exception:
+            continue
 
-hdr = f"# espanso usage"
-if HOST:  hdr += f" — host={HOST}"
-if SINCE: hdr += f" — since {SINCE}"
-print(hdr)
-print(f"# files scanned: {files_scanned}   human user messages: {total_user_msgs}\n")
+    print(f"# transcript files scanned: {files_scanned}   "
+          f"human user messages: {total_user_msgs}\n")
 
-print("## Espanso snippet usage (text-detectable)\n")
-print(f"{'trigger':12} {'kind':7} {'hits':>6} {'sessions':>9}  {'last-seen':10} note")
-order = sorted(SNIPPETS, key=lambda t: (-counts[t], t))
-for t in order:
-    kind, subs, excl, amb = SNIPPETS[t]
-    if subs is None:
-        print(f"{t:12} {kind:7} {'   n/a':>6} {'      n/a':>9}  {'-':10} not text-detectable")
-    else:
-        note = "AMBIGUOUS (conflates hand-typing)" if amb else ""
-        print(f"{t:12} {kind:7} {counts[t]:>6} {len(sessions_hit[t]):>9}  {(last_seen[t] or '-'):10} {note}")
+    print("## SECONDARY — transcript ADD-CANDIDATES (short phrases, no snippet)\n")
+    STOP_EXACT = {"yes", "ok", "okay", "y", "continue", "go", "proceed", "do it",
+                  "yes do it", "no", "thanks", "thank you", "good", "nice", "next",
+                  "stop", "wait", "k", "yep", "yes please", "sure", "perfect"}
+    print("### Recurring short user messages NOT already snippets (>=3 hits)\n")
+    for msg, n in short_msgs.most_common(120):
+        if n < 3:
+            break
+        if msg in STOP_EXACT or len(msg) < 8:
+            continue
+        print(f"{n:4}  {msg[:110]}")
 
-print("\n## Recurring short user messages NOT already snippets (>=3 hits)\n")
-STOP_EXACT = {"yes", "ok", "okay", "y", "continue", "go", "proceed", "do it",
-              "yes do it", "no", "thanks", "thank you", "good", "nice", "next",
-              "stop", "wait", "k", "yep", "yes please", "sure", "perfect"}
-for msg, n in short_msgs.most_common(120):
-    if n < 3:
-        break
-    if msg in STOP_EXACT or len(msg) < 8:
-        continue
-    print(f"{n:4}  {msg[:110]}")
+    print("\n### Recurring 4-5 word phrases (candidate building blocks, >=6 hits)\n")
+    shown = 0
+    for ph, n in phrase_counter.most_common(400):
+        if n < 6:
+            break
+        if any(e.startswith(ph[:15]) for e in KNOWN_EXPANSIONS):
+            continue
+        print(f"{n:4}  {ph}")
+        shown += 1
+        if shown >= 40:
+            break
 
-print("\n## Recurring 4-5 word phrases (candidate building blocks, >=6 hits)\n")
-shown = 0
-for ph, n in phrase_counter.most_common(400):
-    if n < 6:
-        break
-    if any(e.startswith(ph[:15]) for e in KNOWN_EXPANSIONS):
-        continue
-    print(f"{n:4}  {ph}")
-    shown += 1
-    if shown >= 40:
-        break
+    print("\n### Ambiguous transcript cross-check (CONFLATES fire + hand-typing)\n")
+    print(f"{'trigger':12} {'kind':7} {'hits':>6} {'sessions':>9}  {'last-seen':10} note")
+    order = sorted(SNIPPETS, key=lambda t: (-counts[t], t))
+    for t in order:
+        kind, subs, excl, amb = SNIPPETS[t]
+        if subs is None:
+            print(f"{t:12} {kind:7} {'   n/a':>6} {'      n/a':>9}  {'-':10} not text-detectable")
+        else:
+            note = "AMBIGUOUS (conflates hand-typing)" if amb else ""
+            print(f"{t:12} {kind:7} {counts[t]:>6} {len(sessions_hit[t]):>9}  {(last_seen[t] or '-'):10} {note}")
+
+
+# --------------------------------------------------------------------------- #
+def main():
+    hdr = "# espanso usage"
+    if HOST:  hdr += f" — host={HOST}"
+    if SINCE: hdr += f" — since {SINCE}"
+    print(hdr + "\n")
+
+    if SOURCE in ("keys", "both"):
+        keylog_section(SINCE)
+    if SOURCE in ("transcript", "both"):
+        transcript_section(SINCE, ROOT, HOST)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

The X11 keylogger reconstructs typed text from KeyPress events. But espanso, on firing a trigger, (a) **backspaces the trigger away** and (b) inserts the replacement via a **clipboard paste** — so BOTH the trigger and the expansion are **erased** from the stored `text`. Verified empirically: over 7 days / ~20k `keys` chunks, ZERO contain any trigger (`:acq`/`:rnx`/…) or its expansion, even for actively-used snippets. **Espanso usage is invisible in stored data** and must be detected AT CAPTURE TIME from the raw keystrokes, which arrive *before* espanso reacts. This is **forward-only** — no backfill is possible.

## Design — two detection paths, fed per-key alongside the (unchanged) chunker

**`espanso_triggers.py`** — parse the LIVE espanso config into a `TriggerSet` (all snippets: paths/dates/utils/workflows). Robust to home-manager's `replace:`-before-`trigger:` ordering, missing `label`/`search_terms`, and a missing/unparseable config (→ empty set, detector inert). Parses `search_shortcut` (`CTRL+SPACE` → `(ctrl=True, keysym=0x20)`).

**`espanso_detect.py` — `EspansoDetector`** (correctness-critical, its own state):
- **DIRECT** (deterministic): a bounded recent-char ring; when it ends with a known trigger → emit and **clear** (mirrors espanso consuming the trigger on firing). Consequences, all tested:
  - prefix collision: typing `:datetime` emits `:date` (the shorter prefix completes first; espanso mirror)
  - espanso's trailing backspaces are no-ops → **no double-emit**; a genuinely retyped trigger fires again
  - focus change resets the ring (no cross-window false match)
- **SEARCH** (Ctrl+Space UI, best-effort): capture the typed term; fuzzy-attribute to a snippet (term is a substring of the trigger / a label word / a search_term). **Unique** match → attribute; zero/multiple → `trigger=None` but the open+term are still recorded. Always `inferred=True`. Closes on Enter / Escape / focus-change / idle.

**`keylog.py`** wiring: load triggers at startup; detect the search shortcut at the keysym level (space + `ControlMask` 0x04) and route Escape to close search; feed every other resolved char to BOTH the chunker AND `detector.feed_char`. Fires emit as `source=keys, kind=espanso` (plain scalar `kind`), trigger in `text`, `{method,inferred,search_term,label,workspace}` in the JSON payload (both base64'd by spool_emit).

**Reporting** (`espanso-usage.py`): new keylog-**PRIMARY** mode queries ClickHouse for true per-trigger fires (direct vs search) via the shared `chquery` reader-creds-from-env pattern; `--source keys|transcript|both` (default both, keylog first). The transcript miner is reframed as the **SECONDARY** add-candidate signal ("short phrases you hand-type with no snippet"). Degrades gracefully: CH unreachable OR zero espanso rows → clear "(no keylog espanso events yet — forward-only; collecting since deploy)" note, transcript section still runs.

**`nix/home.nix`**: add `ps.pyyaml` to the keylog python env (both the `PATH=` makeBinPath and `ExecStart`).

**`/espanso-audit` recipe**: PRIMARY step is now keylog TRUE fires; transcript miner is the secondary add-candidate cross-check.

## Safety rails

- **Every** detector call in `keylog._handle` / idle / shutdown is `try/except Exception: pass` guarded → a detector bug can **never** kill keystroke capture.
- Missing/unparseable espanso config → empty trigger set → keylog behaves **exactly** as today.
- **Forward-only**; no historical data.
- Honest false-positive note (in report output + here): "buffer ends with a trigger" ≈ "espanso fired," **except** in per-app espanso-disabled contexts — still far better than phrase-counting.

## Tests

`45 passed` (existing chunker/keymap/emit-roundtrip untouched + new coverage):
- `test_espanso_triggers.py` — replace-before-trigger ordering, with/without search_terms, `CTRL+SPACE` + variants, missing file → empty (no raise), plural `triggers:`, real-YAML path round-trip.
- `test_espanso_detect.py` — direct at buffer end; trigger after other chars (`foo:rnx`); prefix collision (`:datetime`→`:date`); backspace no-reemit + retype re-emits; plain typing → 0; focus-reset; search open→term→Enter; search-term doesn't feed direct ring; fuzzy unique/zero/multiple; idle + focus-change flush without Enter; empty-set inert.
- `test_emit_roundtrip.py` — EspansoEvent → spool line has plain `kind=espanso`, base64 text/payload decode back to trigger + method/inferred/search_term.

`nix-instantiate --parse nix/home.nix` → PARSE_OK. Each new `.py` AST-parses.

**NOT deployed, NOT merged** — handed back for review. The one thing unit tests can't cover is the live X-level keysym capture of Ctrl+Space / a real fire; that needs an on-host check after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
