### PR TITLE
fix(keylog): keep search-mode alive when espanso's window steals focus

### DIFF
--- a/scripts/collector/keylog/espanso_detect.py
+++ b/scripts/collector/keylog/espanso_detect.py
@@ -45,6 +45,15 @@ _BACKSPACE = "\b"
 # mislabeling it as a method=search row. Past this cap we treat search-mode as
 # a misfire and abort it WITHOUT emitting.
 SEARCH_TERM_MAX = 64
+# espanso's Ctrl+Space search bar opens as its OWN X window that STEALS focus.
+# On NixOS its WM_CLASS is observed as ".espanso-wrapped"; other packagings use
+# variants, so match by substring rather than the exact class.
+ESPANSO_SEARCH_WM_CLASS = ".espanso-wrapped"
+
+
+def _is_espanso_search_window(app) -> bool:
+    """True when `app` is espanso's own search window (which steals X focus)."""
+    return "espanso" in (app or "").lower()
 
 
 @dataclass
@@ -80,9 +89,13 @@ class EspansoDetector:
         try:
             # Focus change: typing moved to another window. Flush an open search
             # under the OLD context, then reset the direct ring (no cross-window
-            # false match).
+            # false match). EXCEPTION: espanso's Ctrl+Space search bar opens as
+            # its OWN window (.espanso-wrapped) and steals focus — while in
+            # search-mode a focus change TO that window is EXPECTED, so keep
+            # search alive and keep accumulating the term. Only a focus change
+            # to a genuinely different NON-espanso window closes the search.
             if self._app is not None and (app != self._app or session != self._session):
-                if self._search:
+                if self._search and not _is_espanso_search_window(app):
                     ev = self._close_search("focus")
                     if ev is not None:
                         out.append(ev)

--- a/scripts/collector/keylog/espanso_detect.py
+++ b/scripts/collector/keylog/espanso_detect.py
@@ -80,6 +80,13 @@ class EspansoDetector:
         # search-mode state
         self._search = False
         self._search_term: list[str] = []
+        # Origin context captured when search OPENS (before espanso's window
+        # steals focus). Emitting from these — not the live self._app, which by
+        # close time is ".espanso-wrapped" — attributes the event to the window
+        # the user was actually working in when they hit Ctrl+Space.
+        self._search_app = ""
+        self._search_session = ""
+        self._search_workspace = ""
         self._last_ts = 0.0
 
     # -- direct-trigger + search feed ------------------------------------- #
@@ -139,6 +146,11 @@ class EspansoDetector:
         """Enter search-mode (called when keylog sees the Ctrl+Space shortcut)."""
         try:
             self._app, self._session, self._workspace = app, session, workspace
+            # Snapshot the ORIGIN context now — before espanso's search window
+            # steals focus and the adopted self._app becomes ".espanso-wrapped".
+            self._search_app = app
+            self._search_session = session
+            self._search_workspace = workspace
             self._last_ts = now
             self._ring.clear()
             self._search = True
@@ -223,10 +235,13 @@ class EspansoDetector:
             return None
         trigger = self._attribute(term)
         label = (self.ts.meta.get(trigger) or {}).get("label", "") if trigger else ""
+        # Attribute to the ORIGIN window (captured at feed_search_open), NOT the
+        # live self._app — after the focus steal that would be ".espanso-wrapped",
+        # which is identical for every search and tells us nothing about context.
         return EspansoEvent(
             trigger=trigger, method="search", inferred=True, search_term=term,
-            app=self._app or "", session=self._session or "",
-            workspace=self._workspace, label=label or "",
+            app=self._search_app or "", session=self._search_session or "",
+            workspace=self._search_workspace, label=label or "",
         )
 
     def _attribute(self, term):

--- a/scripts/collector/keylog/tests/test_espanso_detect.py
+++ b/scripts/collector/keylog/tests/test_espanso_detect.py
@@ -238,6 +238,94 @@ def test_search_short_unattributed_term_emits_trigger_none():
     assert evs[0].search_term == "zzzzz"
 
 
+# -- FIX 3: espanso search window steals X focus -----------------------------
+# espanso's Ctrl+Space search bar opens as its OWN window (WM_CLASS
+# .espanso-wrapped) and STEALS X focus. The FIRST query char therefore arrives
+# under app=".espanso-wrapped", a focus change from the original window. That
+# must NOT close search-mode with an empty term (the live bug: the search path
+# produced ZERO events because search died before the query was typed).
+ESPANSO_WIN = ".espanso-wrapped"
+
+
+def test_focus_steal_by_espanso_window_keeps_search_and_attributes():
+    # Ctrl+Space recorded under Alacritty; espanso's window then steals focus and
+    # the query "leverage" is typed INTO .espanso-wrapped; Enter closes it.
+    d = _det()
+    d.feed_search_open(app="Alacritty", session="win-term", now=0.0)
+    # Query chars arrive under the STOLEN focus (espanso's own window).
+    evs = _type(d, "leverage", app=ESPANSO_WIN, session="win-esp", now=1.0)
+    assert evs == []  # accumulates, nothing emitted mid-term
+    out = list(d.feed_char("\n", app=ESPANSO_WIN, session="win-esp", now=9.0))
+    assert len(out) == 1
+    ev = out[0]
+    assert ev.method == "search"
+    assert ev.inferred is True
+    assert ev.search_term == "leverage"
+    assert ev.trigger == ":rnx"  # "leverage" uniquely maps to :rnx
+
+
+def test_focus_steal_ambiguous_term_still_emits_trigger_none():
+    # Same focus-steal path, but an ambiguous term ("date" ⊂ :date and :datetime)
+    # → trigger=None yet the event is still emitted (real search, unattributed).
+    d = _det()
+    d.feed_search_open(app="Alacritty", session="win-term", now=0.0)
+    _type(d, "date", app=ESPANSO_WIN, session="win-esp", now=1.0)
+    out = list(d.feed_char("\n", app=ESPANSO_WIN, session="win-esp", now=6.0))
+    assert len(out) == 1
+    assert out[0].trigger is None
+    assert out[0].search_term == "date"
+    assert out[0].method == "search"
+
+
+def test_focus_steal_multichar_window_hop_accumulates_full_term():
+    # Every char of the term lands under the espanso window (no per-char focus
+    # thrash re-closing search); the FULL term survives to attribution.
+    d = _det()
+    d.feed_search_open(app="Alacritty", session="win-term", now=0.0)
+    for i, ch in enumerate("clarify"):
+        assert d.feed_char(ch, app=ESPANSO_WIN, session="win-esp", now=1 + i) == []
+    out = list(d.feed_char("\n", app=ESPANSO_WIN, session="win-esp", now=20.0))
+    assert len(out) == 1
+    assert out[0].search_term == "clarify"
+
+
+def test_focus_change_to_nonespanso_window_still_closes_search():
+    # A focus change to a genuinely DIFFERENT non-espanso window (e.g. the
+    # browser) is a real abandon: search closes under the OLD context and does
+    # NOT keep accumulating into the new window.
+    d = _det()
+    d.feed_search_open(app="Alacritty", session="win-term", now=0.0)
+    _type(d, "today", app="Alacritty", session="win-term", now=1.0)
+    # Focus jumps to Brave before Enter → close under the old context.
+    out = list(d.feed_char("x", app="Brave-browser", session="win-brave", now=10.0))
+    assert len(out) == 1
+    assert out[0].method == "search"
+    assert out[0].search_term == "today"  # the "x" did NOT get appended
+    assert out[0].app == "Alacritty"      # closed under the window search began in
+    # Search-mode is off; the stray "x" and a following Enter emit nothing more.
+    assert list(d.feed_char("\n", app="Brave-browser", session="win-brave", now=11.0)) == []
+
+
+def test_espanso_focus_steal_does_not_break_direct_fires():
+    # Regression: after a focus-steal search completes, direct triggers under a
+    # normal window still fire (search state fully reset).
+    d = _det()
+    d.feed_search_open(app="Alacritty", session="win-term", now=0.0)
+    _type(d, "leverage", app=ESPANSO_WIN, session="win-esp", now=1.0)
+    list(d.feed_char("\n", app=ESPANSO_WIN, session="win-esp", now=9.0))
+    evs = _type(d, ":date", app="Alacritty", session="win-term", now=20.0)
+    assert [e.trigger for e in evs] == [":date"]
+
+
+def test_empty_close_still_suppressed_under_espanso_focus_steal():
+    # Focus steal to the espanso window, then Escape with nothing typed → still a
+    # phantom empty close → suppressed (prior fix preserved through this path).
+    d = _det()
+    d.feed_search_open(app="Alacritty", session="win-term", now=0.0)
+    out = list(d.feed_char("\x1b", app=ESPANSO_WIN, session="win-esp", now=1.0))
+    assert out == []
+
+
 # -- FIX 2: caret-navigation resets the direct ring --------------------------
 def test_notify_navigation_resets_direct_ring():
     # ":da" then a caret move then "te" → ":date" was NOT typed contiguously,

--- a/scripts/collector/keylog/tests/test_espanso_detect.py
+++ b/scripts/collector/keylog/tests/test_espanso_detect.py
@@ -262,6 +262,10 @@ def test_focus_steal_by_espanso_window_keeps_search_and_attributes():
     assert ev.inferred is True
     assert ev.search_term == "leverage"
     assert ev.trigger == ":rnx"  # "leverage" uniquely maps to :rnx
+    # Attributed to the ORIGIN window (where Ctrl+Space was pressed), NOT the
+    # ".espanso-wrapped" window that stole focus mid-search.
+    assert ev.app == "Alacritty"
+    assert ev.session == "win-term"
 
 
 def test_focus_steal_ambiguous_term_still_emits_trigger_none():
@@ -275,6 +279,7 @@ def test_focus_steal_ambiguous_term_still_emits_trigger_none():
     assert out[0].trigger is None
     assert out[0].search_term == "date"
     assert out[0].method == "search"
+    assert out[0].app == "Alacritty"  # origin window preserved
 
 
 def test_focus_steal_multichar_window_hop_accumulates_full_term():
@@ -287,6 +292,7 @@ def test_focus_steal_multichar_window_hop_accumulates_full_term():
     out = list(d.feed_char("\n", app=ESPANSO_WIN, session="win-esp", now=20.0))
     assert len(out) == 1
     assert out[0].search_term == "clarify"
+    assert out[0].app == "Alacritty"  # origin window preserved
 
 
 def test_focus_change_to_nonespanso_window_still_closes_search():


### PR DESCRIPTION
## The bug (confirmed live)

`EspansoDetector.feed_char` treated **any** focus/window change as a close-boundary for search-mode. But espanso's Ctrl+Space search bar opens as its **own window** (WM_CLASS `.espanso-wrapped`) and **steals X focus**. So the real sequence is:

1. User presses Ctrl+Space → keylog calls `feed_search_open` recording the original window (e.g. `Alacritty`).
2. espanso's search window grabs focus.
3. The **first query keystroke** arrives with `app='.espanso-wrapped'` → `feed_char` saw a focus change → `_close_search("focus")` fired with an **empty term** → suppressed.
4. Search-mode was dead before the query was typed; the user's query (e.g. "clarify") landed in `.espanso-wrapped` and matched nothing.

Net: the Ctrl+Space search UI produced **zero** `kind=espanso method=search` events.

### Live evidence
The direct-trigger path worked, but the search term "cla" landed in app `.espanso-wrapped` and **no** `method=search` row was produced.

## The fix

In `feed_char`'s focus-change branch: while in search-mode, a focus change **to espanso's own search window** must NOT close search — it's expected. Keep search-mode alive and keep accumulating the term. Close on focus change only to a genuinely different **non-espanso** window (a real abandon).

- New module constant `ESPANSO_SEARCH_WM_CLASS = ".espanso-wrapped"` (observed NixOS class) + `_is_espanso_search_window(app)` matching `"espanso" in app.lower()` so non-nix variants are covered too.
- On a focus change to the espanso window during search: adopt the new context (so subsequent same-window keystrokes don't repeatedly look like focus changes) but do NOT close and do NOT clear the term. Direct-ring clear on focus change is preserved (irrelevant during search).
- All existing close boundaries preserved: Enter/Escape, idle, term-length cap, and focus change to a genuinely different non-espanso window.

### keylog.py sanity-check
Confirmed the keylog-level Ctrl+Space detection (`base_ks == sc_keysym` for SPACE=0x20 AND `event.state & CONTROL_MASK` where `CONTROL_MASK=0x04`) genuinely fires and routes to `feed_search_open` with the original window context, then `continue` (space not double-fed). No second defect found there — the bug was entirely in `feed_char`.

## Tests

New tests model the focus steal (the gap that let this ship): focus-steal + unique attribution (`leverage`→`:rnx`), focus-steal + ambiguous term (`date`→`trigger=None`, still emitted), multi-char window hop accumulates the full term, genuine non-espanso focus-change still closes under the old context (does NOT keep accumulating), direct fires unaffected after a focus-steal search, and empty/phantom suppression preserved through the steal path.

**Full keylog suite: 57 passed, 1 skipped.** Both changed files AST-parse; `nix-instantiate --parse nix/home.nix` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)