### PR TITLE
feat(i3): wire second monitor + fix DDC blackout bus detection

### DIFF
--- a/nix/i3/config.nix
+++ b/nix/i3/config.nix
@@ -25,11 +25,23 @@ let
 
       # Float the rig-control (yad) popup as a compact centered window instead of tiling it
       for_window [class="Yad" title="Rig Controls"] floating enable, move position center'';
+
+  # Workbench-only: dual-monitor layout. The 1920x1080 (HDMI-0) sits to the LEFT of
+  # the 3440x1440 ultrawide (DP-0, primary), bottom-aligned (both on the same desk, so
+  # the shorter panel gets a 360px dead zone at its top). Restored on every i3 start;
+  # hotplug mid-session still needs a manual re-run of this xrandr.
+  monitorLayout =
+    if isLaptop then ""
+    else ''
+
+      # Dual-monitor layout: 1080p (HDMI-0) left of the ultrawide (DP-0, primary)
+      exec --no-startup-id xrandr --output DP-0 --primary --mode 3440x1440 --rate 143.92 --pos 1920x0 --output HDMI-0 --mode 1920x1080 --pos 0x360'';
 in
 ''
 set $mod Mod1
 
 font pango:monospace 8
+${monitorLayout}
 
 # NetworkManager applet
 exec --no-startup-id nm-applet

--- a/scripts/monitor-blackout.sh
+++ b/scripts/monitor-blackout.sh
@@ -18,10 +18,18 @@ DDC=$(command -v ddcutil) || { echo "ddcutil not found on PATH" >&2; exit 1; }
 UNIT=monitor-blackout-restore
 STATE="${XDG_RUNTIME_DIR:-/tmp}/monitor-blackout.state"   # "bus:brightness"
 
-# First DDC/CI-capable display's i2c bus number.
+# First DDC/CI bus that actually ANSWERS a brightness (VCP 0x10) read.
+# With >1 monitor connected, some panels enumerate an i2c bus but EIO on read
+# (e.g. the ASUS VK278 over HDMI), so a blind "first bus" grabs a dead one and
+# the blackout fails. Probe each detected bus and return the first that responds.
 detect_bus() {
-  "$DDC" detect --brief 2>/dev/null \
-    | grep -m1 -o 'i2c-[0-9]\+' | grep -o '[0-9]\+$'
+  local b
+  for b in $("$DDC" detect --brief 2>/dev/null | grep -o 'i2c-[0-9]\+' | grep -o '[0-9]\+$'); do
+    if "$DDC" --bus "$b" getvcp 10 --brief >/dev/null 2>&1; then
+      printf '%s\n' "$b"; return 0
+    fi
+  done
+  return 1
 }
 
 get_brightness() { # $1=bus  -> current VCP 0x10 value


### PR DESCRIPTION
## What
Wire the newly connected 1080p ASUS monitor into i3, and fix the bar's monitor-blackout button which broke once a second DDC display appeared.

## Changes
- **`nix/i3/config.nix`** — workbench-gated `monitorLayout` xrandr exec: the 1920×1080 ASUS (HDMI-0) is placed to the **left** of the 3440×1440 ultrawide (DP-0, kept primary), bottom-aligned, restored on every i3 start. Gated `isLaptop == false` (the laptop has different outputs), mirroring the existing `rigControlFloat` pattern.
- **`scripts/monitor-blackout.sh`** — `detect_bus` now probes each DDC bus and returns the first that actually answers a VCP 0x10 read, instead of blindly taking the first enumerated bus.

## Why the blackout broke
The second monitor added DDC bus `i2c-4` (ASUS VK278) which enumerates *first* but `EIO`s on every read. The old `detect_bus` (`grep -m1`) grabbed that dead bus, so `get_brightness` failed and the bar button silently did nothing. The new probe skips it and self-heals to the working ultrawide (bus 5) regardless of enumeration order or monitor count.

## Verification
- Both outputs live via xrandr; i3 auto-assigned a workspace to HDMI-0.
- `detect_bus → 5` (LG ultrawide) confirmed.
- Blackout triggered end-to-end via the real `rig-control.sh blackout` path: brightness `60 → 0`, state saved, 8h auto-restore timer armed.
- ⚠️ The xrandr exec line is **not yet verified on a fresh i3 start** (only fires on i3 start/restart); layout is currently live from the manual apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)