### PR TITLE
chore(flake): bump nixpkgs + home-manager (2026-04 → 2026-07)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775080052,
-        "narHash": "sha256-jAB4ZZbx8ECu9GcE/PUUwT+wpooZ0Ssmn2imB8PVTdM=",
+        "lastModified": 1784129366,
+        "narHash": "sha256-N5JiyICSeQF14x+OQebNyPpYowOT9Rs1iKyeCylSzOA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6267895e9898399f0ce2fe79b645e9ee4858aaff",
+        "rev": "165228b0efefc3e635e5174020c40ea64271dc25",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775064974,
-        "narHash": "sha256-fp7+8MzxHrIixIIVvyORI2XpqpQnxf8NodmEHy8rczg=",
+        "lastModified": 1784210874,
+        "narHash": "sha256-x8i+HYAulduMlM63oxWJj5tAm+Sc/W756wUzcV5p24w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6ebfbc38bdc6b22822a6f991f2d922306f33cfbc",
+        "rev": "59682e0069f0ed0a452e2179a7f4c1f247027b9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Routine `nix flake update` landing just the lock. No other files touched.

## Version deltas

| input | old | new | date |
|---|---|---|---|
| nixpkgs | `6ebfbc3` | `59682e0` | 2026-04-01 → 2026-07-16 |
| home-manager | `6267895` | `165228b` | 2026-04-01 → 2026-07-15 |

(~3.5 months of nixpkgs-unstable.)

## Validation

`home-manager switch --flake ~/workspace/devrc --impure` on the workbench — **clean build, exit 0**. The exact failing-path check for a lock bump is that the config still evaluates + activates; it did.

## Deprecation warnings observed (not acted on)

Two eval warnings from newer home-manager, both because `home.stateVersion < 26.05` keeps the legacy default:

- `programs.neovim.withRuby` default changed `true` → `false`
- `programs.neovim.withPython3` default changed `true` → `false`

Current behavior is preserved (legacy default still applied). No functional change; silence later by setting them explicitly or bumping `stateVersion`. Also: 391 unread `home-manager news` items accumulated over the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)