### PR TITLE
feat(ci): gate the Python suite via nix flake check + blocking pre-push

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,17 +9,62 @@
     };
   };
 
-  outputs = { nixpkgs, home-manager, ... }: {
-    homeConfigurations."zach" = home-manager.lib.homeManagerConfiguration {
-      pkgs = nixpkgs.legacyPackages.x86_64-linux;
-      extraSpecialArgs = { isNixOS = true; };
-      modules = [
-        ./nix/home.nix
-        {
-          home.username = "zach";
-          home.homeDirectory = "/home/zach";
-        }
-      ];
+  outputs = { self, nixpkgs, home-manager, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+    in
+    {
+      homeConfigurations."zach" = home-manager.lib.homeManagerConfiguration {
+        pkgs = nixpkgs.legacyPackages.${system};
+        extraSpecialArgs = { isNixOS = true; };
+        modules = [
+          ./nix/home.nix
+          {
+            home.username = "zach";
+            home.homeDirectory = "/home/zach";
+          }
+        ];
+      };
+
+      # ---------------------------------------------------------------------
+      # Test gate. `nix flake check` (and any future CI / `ship.sh --check`)
+      # runs the HERMETIC Python suite in the nix sandbox: pinned python312,
+      # NO network, NO /home. Every third-party call in the gated suites
+      # (psycopg2 / requests / minio HTTP) is mocked, so nothing reaches a live
+      # DB or the network — see scripts/run-tests.sh for the exact dir list.
+      #
+      # Deps below cover the modules-under-test's import-time requirements
+      # (requests/psycopg2/minio/pyyaml); the tests themselves mock the I/O.
+      # ---------------------------------------------------------------------
+      checks.${system}.pytests =
+        let
+          pyEnv = pkgs.python312.withPackages (ps: with ps; [
+            pytest
+            requests
+            psycopg2
+            minio
+            pyyaml
+          ]);
+        in
+        pkgs.runCommandLocal "devrc-pytests"
+          {
+            # ripgrep: one repo-cos prescan test skipif's without it on PATH.
+            nativeBuildInputs = [ pyEnv pkgs.bash pkgs.ripgrep ];
+          }
+          ''
+            cp -r ${./.} src
+            chmod -R u+w src
+            # Some suites exec real repo scripts (e.g. scripts/collector/emit)
+            # by path; their `#!/usr/bin/env bash` shebang can't resolve in the
+            # sandbox (no /usr/bin/env). Rewrite shebangs to store paths so those
+            # legitimately-hermetic tests can run. (Does NOT touch test logic.)
+            patchShebangs src/scripts
+            export HOME="$TMPDIR/home"
+            mkdir -p "$HOME"
+            cd src
+            bash scripts/run-tests.sh --set hermetic .
+            touch "$out"
+          '';
     };
-  };
 }

--- a/githooks/README.md
+++ b/githooks/README.md
@@ -1,19 +1,39 @@
-# githooks — auto-run the PR adversarial audit on push
+# githooks — pre-push test gate + adversarial-audit-on-push
 
-Version-controlled, global git hooks. Today this is one feature:
+Version-controlled, global git hooks. Two features, in order on every push:
 
-**Auto-run `/audit-pr` on push of a feature branch, route only 🔴/🟡 findings to
-your phone (clawgate), never block the push.** It replaces the hand-typed
-"dispatch a subagent to audit this PR for risks/regressions/…" ritual.
+1. **Blocking test gate (devrc only).** Run the devrc Python suite before the
+   push and **block the push if any test fails.** No-op for every other repo.
+2. **Auto-run `/audit-pr` on push of a feature branch**, route only 🔴/🟡
+   findings to your phone (clawgate), **never block the push.** Replaces the
+   hand-typed "dispatch a subagent to audit this PR for risks/…" ritual.
 
 ## Files
 
 | File | Role |
 |---|---|
-| `pre-push` | Global dispatcher. Chains to any repo-local pre-push first (never clobbers it), then fires the audit **backgrounded** so the push is never delayed. |
+| `pre-push` | Global dispatcher. Chains to any repo-local pre-push first (never clobbers it), runs the **blocking test gate**, then fires the audit **backgrounded** so the push is never delayed. |
+| `tests-on-push.sh` | SYNCHRONOUS blocking worker: self-detects devrc, runs `scripts/run-tests.sh --set all` (via nix-shell if needed), **blocks the push on failure**. No-op for non-devrc repos. |
 | `audit-on-push.sh` | The backgrounded worker: branch + diff-size + flag gates, then headless `claude -p "/audit-pr current"`, then routes 🔴/🟡 to clawgate. |
 | `install.sh` | Sets `git config --global core.hooksPath` to this dir. `--uninstall` reverts. |
 | `audit-on-push.env.example` | Config template → copy to `~/.claude/audit-on-push.env`. |
+
+## Test gate (`tests-on-push.sh`)
+
+The hermetic subset of the suite is enforced independently by
+`nix flake check` (`flake.nix` → `checks.x86_64-linux.pytests`, run offline in
+the nix sandbox — see `scripts/run-tests.sh` for the exact dir list). This
+pre-push worker is the **dev-host tier**: it runs the FULLER set (`--set all`)
+before the push so any dev-host-only suites are exercised too, and it BLOCKS a
+push whose tests fail.
+
+- **devrc only** — the worker exits 0 immediately for any repo that isn't the
+  devrc flake, so the global hook never starts running pytest on unrelated repos.
+- **Escape hatch** — `DEVRC_SKIP_TESTS=1 git push …` skips the gate (the flake
+  check / CI still enforce the hermetic subset).
+- **Graceful degrade** — if neither an ambient pytest nor `nix-shell` is
+  available it warns and allows the push (never wedges pushes on a broken env);
+  the hard gate is `nix flake check` / CI.
 
 ## Install (safe — changes nothing about your push UX)
 

--- a/githooks/README.md
+++ b/githooks/README.md
@@ -13,7 +13,7 @@ Version-controlled, global git hooks. Two features, in order on every push:
 | File | Role |
 |---|---|
 | `pre-push` | Global dispatcher. Chains to any repo-local pre-push first (never clobbers it), runs the **blocking test gate**, then fires the audit **backgrounded** so the push is never delayed. |
-| `tests-on-push.sh` | SYNCHRONOUS blocking worker: self-detects devrc, runs `scripts/run-tests.sh --set all` (via nix-shell if needed), **blocks the push on failure**. No-op for non-devrc repos. |
+| `tests-on-push.sh` | SYNCHRONOUS worker: self-detects devrc, filters on changed files, runs `scripts/run-tests.sh --set all` in a **pinned nix-shell**, and (mode `on`) **blocks the push on a genuine test failure**. Infra-can't-prepare-env → warn + allow. No-op for non-devrc repos. |
 | `audit-on-push.sh` | The backgrounded worker: branch + diff-size + flag gates, then headless `claude -p "/audit-pr current"`, then routes 🔴/🟡 to clawgate. |
 | `install.sh` | Sets `git config --global core.hooksPath` to this dir. `--uninstall` reverts. |
 | `audit-on-push.env.example` | Config template → copy to `~/.claude/audit-on-push.env`. |
@@ -24,26 +24,54 @@ The hermetic subset of the suite is enforced independently by
 `nix flake check` (`flake.nix` → `checks.x86_64-linux.pytests`, run offline in
 the nix sandbox — see `scripts/run-tests.sh` for the exact dir list). This
 pre-push worker is the **dev-host tier**: it runs the FULLER set (`--set all`)
-before the push so any dev-host-only suites are exercised too, and it BLOCKS a
-push whose tests fail.
+before the push so any dev-host-only suites are exercised too, and (mode `on`)
+BLOCKS a push whose tests genuinely fail.
+
+**Mode** — `TESTS_ON_PUSH`, from env or `~/.claude/audit-on-push.env` (parallels
+the audit's flag):
+
+- `off` — skip the gate entirely.
+- `shadow` — run the tests, report the result, **never block** (warn-only).
+- `on` / `enforce` — run the tests, **block** the push on a genuine failure.
+  **Default (devrc only).**
+
+Behaviour, all failing in the **safe direction**:
 
 - **devrc only** — the worker exits 0 immediately for any repo that isn't the
   devrc flake, so the global hook never starts running pytest on unrelated repos.
-- **Escape hatch** — `DEVRC_SKIP_TESTS=1 git push …` skips the gate (the flake
-  check / CI still enforce the hermetic subset).
-- **Graceful degrade** — if neither an ambient pytest nor `nix-shell` is
-  available it warns and allows the push (never wedges pushes on a broken env);
-  the hard gate is `nix flake check` / CI.
+- **Changed-files filter** — the gate only runs when the pushed commits touch
+  `scripts/`, `flake.nix`, or `flake.lock`; docs-only / nix-non-flake pushes skip
+  it. Any ambiguity (new branch whose base can't be resolved, unparseable stdin,
+  a `git diff` error) **fails toward RUNNING** — it never silently skips a code
+  push.
+- **Infra flakiness degrades, never blocks** — the env is a **pinned nix-shell**
+  (never a trusted ambient pytest — the modules import requests/psycopg2/minio/
+  yaml at collection). Env preparation is a **separate step** from the pytest
+  run: if the env can't be built (offline, uncached, substituter hiccup, disk
+  full, no `nix-shell`) the worker **warns and allows the push** (exit 0). Only
+  tests that actually executed and failed block.
+- **Escape hatch** — `DEVRC_SKIP_TESTS=1 git push …` skips the gate for one push
+  regardless of mode (the flake check / CI still enforce the hermetic subset).
 
-## Install (safe — changes nothing about your push UX)
+> **flake-check gotcha:** `nix flake check` only sees **git-tracked** files. A
+> **new** test file must be `git add`ed before the check (or the pre-push gate,
+> which copies via the flake) will run it — an untracked new test is invisible.
+
+## Install
 
 ```bash
 ~/workspace/devrc/githooks/install.sh
 ```
 
-This sets the **global** `core.hooksPath` and seeds `~/.claude/audit-on-push.env`
-with `AUDIT_ON_PUSH=shadow`. In shadow mode it runs the audit and logs what it
-*would* send, but **sends nothing**. Your pushes are unchanged.
+This sets the **global** `core.hooksPath` and seeds `~/.claude/audit-on-push.env`.
+Two independent knobs, seeded from the example:
+
+- **Audit** (`AUDIT_ON_PUSH=shadow`) — logs what it *would* send, sends nothing;
+  the audit side changes nothing about your push UX until you flip it to `on`.
+- **Test gate** (`TESTS_ON_PUSH=on`) — **in the devrc repo, pushes now run the
+  Python suite and block on a genuine failure.** It is a no-op in every other
+  repo. Set `TESTS_ON_PUSH=shadow` (warn-only) or `off` to change that, or
+  `DEVRC_SKIP_TESTS=1 git push …` to skip a single push.
 
 ## Flag states (`~/.claude/audit-on-push.env`)
 

--- a/githooks/audit-on-push.env.example
+++ b/githooks/audit-on-push.env.example
@@ -6,6 +6,16 @@
 #   on     — actually POST 🔴/🟡 findings to clawgate (your phone)
 AUDIT_ON_PUSH=shadow
 
+# --- Test gate (devrc only; tests-on-push.sh) --------------------------------
+# Runs the devrc Python suite on pre-push. States:
+#   off             — skip the gate entirely
+#   shadow          — run the tests, report the result, NEVER block (warn-only)
+#   on / enforce    — run the tests, BLOCK the push on a genuine failure (default)
+# Infra flakiness (offline / uncached nix env / no nix-shell) always DEGRADES to
+# a warning and allows the push — only a real pytest failure blocks. Per-push
+# override: `DEVRC_SKIP_TESTS=1 git push …`.
+TESTS_ON_PUSH=on
+
 # Skip the audit when the pushed diff (HEAD vs merge-base with the default
 # branch) changes fewer than this many lines.
 AUDIT_MIN_LINES=40

--- a/githooks/install.sh
+++ b/githooks/install.sh
@@ -6,8 +6,12 @@
 # pre-push dispatcher runs for every repo that does NOT override core.hooksPath
 # locally. It composes with repo-local .git/hooks/pre-push (chains to it first).
 #
-# Default flag is SHADOW — installing changes NOTHING about your push UX until
-# you flip AUDIT_ON_PUSH=on. Disable entirely with: githooks/install.sh --uninstall
+# The AUDIT flag defaults to SHADOW (installing changes nothing about the audit
+# side of your push UX until you flip AUDIT_ON_PUSH=on). The TEST GATE, however,
+# defaults to ON *in the devrc repo only* — devrc pushes will run the Python
+# suite and block on a genuine failure (TESTS_ON_PUSH; DEVRC_SKIP_TESTS=1 to
+# override a single push). It is a no-op in every other repo.
+# Disable everything with: githooks/install.sh --uninstall
 #
 set -euo pipefail
 
@@ -24,7 +28,7 @@ if [ "${1:-}" = "--uninstall" ]; then
   exit 0
 fi
 
-chmod +x "$DIR/pre-push" "$DIR/audit-on-push.sh" 2>/dev/null || true
+chmod +x "$DIR/pre-push" "$DIR/audit-on-push.sh" "$DIR/tests-on-push.sh" 2>/dev/null || true
 
 prev="$(git config --global --get core.hooksPath || true)"
 if [ -n "$prev" ] && [ "$prev" != "$DIR" ]; then
@@ -45,8 +49,15 @@ fi
 echo "installed: global core.hooksPath -> $DIR"
 echo "active hooks: $(ls "$DIR" | grep -vE '\.(sh|md|example)$' | tr '\n' ' ')"
 echo
-echo "Flag is SHADOW by default (logs what it WOULD send, sends nothing)."
+echo "Audit flag is SHADOW by default (logs what it WOULD send, sends nothing)."
 echo "  watch shadow decisions: tail -f ~/.claude/audit-on-push.log"
 echo "  go live:  echo 'AUDIT_ON_PUSH=on' >> ~/.claude/audit-on-push.env"
 echo "  back off: set AUDIT_ON_PUSH=off in ~/.claude/audit-on-push.env"
+echo
+echo "Test gate is ON by default IN DEVRC ONLY (devrc pushes run the Python"
+echo "suite + block on a genuine failure; no-op elsewhere)."
+echo "  warn-only: set TESTS_ON_PUSH=shadow in ~/.claude/audit-on-push.env"
+echo "  disable:   set TESTS_ON_PUSH=off   in ~/.claude/audit-on-push.env"
+echo "  skip one push: DEVRC_SKIP_TESTS=1 git push …"
+echo
 echo "  uninstall global hook: $DIR/install.sh --uninstall"

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -77,8 +77,11 @@ done
 # hermetic subset independently (flake.nix checks.pytests).
 TESTS_WORKER="$(dirname "$SELF")/tests-on-push.sh"
 if [ -x "$TESTS_WORKER" ]; then
-  "$TESTS_WORKER" "$REPO_ROOT"
-  tests_rc=$?
+  # Replay the ref-update lines so the worker's changed-files filter can decide
+  # whether this push touches code. Capture the worker's status via PIPESTATUS
+  # (a bare $? after the pipe would read printf's, not the worker's).
+  printf '%s' "$STDIN_DATA" | "$TESTS_WORKER" "$REPO_ROOT"
+  tests_rc="${PIPESTATUS[1]}"
   if [ "$tests_rc" -ne 0 ]; then
     exit "$tests_rc"
   fi

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -3,13 +3,18 @@
 # Global pre-push dispatcher (devrc-managed, version-controlled).
 #
 # Installed via a GLOBAL core.hooksPath that points at this directory
-# (githooks/install.sh). Two jobs, in order:
+# (githooks/install.sh). Three jobs, in order:
 #
 #   1. COMPOSE — chain to any repo-local pre-push hook first, so this global
 #      hook never clobbers a repo's own gate (e.g. the datapacket-talos
 #      gitops-gate at .githooks/pre-push). If a repo-local hook exists AND
 #      blocks (non-zero), we propagate that block and STOP — the local gate
 #      wins and the audit is skipped for that push.
+#
+#   1.5 TEST GATE — run the devrc Python suite (githooks/tests-on-push.sh)
+#      SYNCHRONOUSLY and BLOCK the push on failure. No-op for every repo except
+#      devrc, so it is safe as a global hook. Independent of `nix flake check`,
+#      which enforces the hermetic subset offline in the nix sandbox.
 #
 #   2. AUDIT — fire the adversarial PR audit (githooks/audit-on-push.sh) in the
 #      BACKGROUND, fully detached, so the push is never delayed or blocked. All
@@ -64,6 +69,20 @@ for candidate in \
   fi
   break   # one repo-local hook is enough; don't double-run
 done
+
+# --- 1.5 Blocking test gate (devrc only; no-op elsewhere) --------------------
+# Run the devrc Python suite BEFORE the push and block on failure. The worker
+# self-detects devrc and exits 0 for every other repo, so this is safe as a
+# GLOBAL hook. This is the dev-host tier; `nix flake check` enforces the
+# hermetic subset independently (flake.nix checks.pytests).
+TESTS_WORKER="$(dirname "$SELF")/tests-on-push.sh"
+if [ -x "$TESTS_WORKER" ]; then
+  "$TESTS_WORKER" "$REPO_ROOT"
+  tests_rc=$?
+  if [ "$tests_rc" -ne 0 ]; then
+    exit "$tests_rc"
+  fi
+fi
 
 # --- 2. Fire the audit in the background, fully detached ---------------------
 # Never block the push: redirect all fds, disown, and hand stdin via a heredoc

--- a/githooks/tests-on-push.sh
+++ b/githooks/tests-on-push.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# tests-on-push.sh — SYNCHRONOUS, BLOCKING test gate for the global pre-push hook.
+#
+# Unlike audit-on-push.sh (backgrounded, never blocks), THIS worker runs the
+# devrc Python test suite BEFORE the push completes and BLOCKS the push if any
+# test fails. It is the dev-host tier of the test gate; the hermetic subset is
+# ALSO enforced by `nix flake check` (flake.nix `checks.pytests`) / CI. Here we
+# run the FULLER set (`--set all`) so any dev-host-only suites get exercised too.
+#
+# GLOBAL-hook safety: this worker is a no-op for every repo EXCEPT devrc. It
+# self-detects devrc (scripts/run-tests.sh present AND flake.nix is the DEVRC
+# flake) and exits 0 immediately otherwise, so installing the global hook never
+# starts running pytest on unrelated repos.
+#
+# Escape hatch: `DEVRC_SKIP_TESTS=1 git push …` skips the gate (logged to stderr).
+#
+# Exit: 0 = passed or not-applicable (push proceeds); non-zero = tests failed
+# (push is BLOCKED).
+
+set -uo pipefail
+
+REPO_ROOT="${1:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
+[ -n "$REPO_ROOT" ] || exit 0
+
+RUNNER="$REPO_ROOT/scripts/run-tests.sh"
+FLAKE="$REPO_ROOT/flake.nix"
+
+# --- Applicability gate: devrc only -----------------------------------------
+[ -f "$RUNNER" ] || exit 0
+[ -f "$FLAKE" ] && grep -q 'DEVRC' "$FLAKE" 2>/dev/null || exit 0
+
+if [ "${DEVRC_SKIP_TESTS:-0}" = "1" ]; then
+  echo "pre-push: DEVRC_SKIP_TESTS=1 set — skipping the test gate (flake check / CI still enforce it)." >&2
+  exit 0
+fi
+
+echo "pre-push: running devrc test suite (blocking gate)…" >&2
+
+run_suite() {
+  bash "$RUNNER" --set all "$REPO_ROOT"
+}
+
+# Prefer an already-usable pytest; else provide deps via nix-shell (matches the
+# per-README invocation). If neither is available, DEGRADE to a warning rather
+# than wedge every push — the hermetic flake check / CI is the hard gate.
+if python -c 'import pytest' >/dev/null 2>&1; then
+  run_suite
+  rc=$?
+elif command -v nix-shell >/dev/null 2>&1; then
+  nix-shell -p "python312.withPackages(ps: with ps; [pytest requests psycopg2 minio pyyaml])" \
+    --run "bash '$RUNNER' --set all '$REPO_ROOT'"
+  rc=$?
+else
+  echo "pre-push: WARNING — no pytest and no nix-shell available; cannot run the test gate locally." >&2
+  echo "pre-push: push allowed to proceed; rely on 'nix flake check' / CI for the hermetic gate." >&2
+  exit 0
+fi
+
+if [ "$rc" -ne 0 ]; then
+  echo "" >&2
+  echo "pre-push: ❌ devrc test suite FAILED (rc=$rc) — push BLOCKED." >&2
+  echo "pre-push: fix the failing tests, or 'DEVRC_SKIP_TESTS=1 git push …' to override." >&2
+  exit "$rc"
+fi
+
+echo "pre-push: ✅ devrc test suite passed." >&2
+exit 0

--- a/githooks/tests-on-push.sh
+++ b/githooks/tests-on-push.sh
@@ -1,22 +1,36 @@
 #!/usr/bin/env bash
 #
-# tests-on-push.sh — SYNCHRONOUS, BLOCKING test gate for the global pre-push hook.
+# tests-on-push.sh — SYNCHRONOUS test gate for the global pre-push hook.
 #
 # Unlike audit-on-push.sh (backgrounded, never blocks), THIS worker runs the
-# devrc Python test suite BEFORE the push completes and BLOCKS the push if any
-# test fails. It is the dev-host tier of the test gate; the hermetic subset is
-# ALSO enforced by `nix flake check` (flake.nix `checks.pytests`) / CI. Here we
-# run the FULLER set (`--set all`) so any dev-host-only suites get exercised too.
+# devrc Python test suite BEFORE the push completes and — in enforce mode —
+# BLOCKS the push if a test genuinely fails. It is the dev-host tier of the test
+# gate; the hermetic subset is ALSO enforced by `nix flake check` (flake.nix
+# `checks.pytests`) / CI. Here we run the FULLER set (`--set all`).
 #
-# GLOBAL-hook safety: this worker is a no-op for every repo EXCEPT devrc. It
-# self-detects devrc (scripts/run-tests.sh present AND flake.nix is the DEVRC
-# flake) and exits 0 immediately otherwise, so installing the global hook never
-# starts running pytest on unrelated repos.
+# It reads the pushed ref updates on STDIN (git's pre-push protocol:
+#   <local_ref> <local_sha> <remote_ref> <remote_sha>  per line)
+# so it can skip the gate for pushes that don't touch Python/tests/flake.
 #
-# Escape hatch: `DEVRC_SKIP_TESTS=1 git push …` skips the gate (logged to stderr).
+# DESIGN PRINCIPLES (fail in the SAFE direction):
+#   * GLOBAL-hook safe — no-op for every repo except devrc (self-detected).
+#   * Infra flakiness DEGRADES, never blocks — if the test ENV can't be prepared
+#     (offline, uncached, substituter hiccup, disk full, no nix-shell) we WARN
+#     loudly and allow the push. Only a genuine pytest failure (tests executed,
+#     >=1 failed) blocks — and only in enforce mode.
+#   * Changed-files filter fails TOWARD running — any ambiguity (new branch we
+#     can't resolve, unparseable stdin, diff error) RUNS the suite.
 #
-# Exit: 0 = passed or not-applicable (push proceeds); non-zero = tests failed
-# (push is BLOCKED).
+# MODE (parallels the audit's flag) — TESTS_ON_PUSH, from env or the shared
+# ~/.claude/audit-on-push.env (override the path with TESTS_ON_PUSH_CONF_FILE):
+#   off             — skip the gate entirely.
+#   shadow          — run the tests, REPORT the result, NEVER block (warn-only).
+#   on / enforce    — run the tests, BLOCK the push on a genuine failure. DEFAULT.
+#
+# Escape hatch: `DEVRC_SKIP_TESTS=1 git push …` skips the gate regardless of mode.
+#
+# Exit: 0 = passed, skipped, degraded, or not-applicable (push proceeds);
+#       non-zero = tests genuinely failed in enforce mode (push BLOCKED).
 
 set -uo pipefail
 
@@ -28,41 +42,130 @@ FLAKE="$REPO_ROOT/flake.nix"
 
 # --- Applicability gate: devrc only -----------------------------------------
 [ -f "$RUNNER" ] || exit 0
-[ -f "$FLAKE" ] && grep -q 'DEVRC' "$FLAKE" 2>/dev/null || exit 0
+{ [ -f "$FLAKE" ] && grep -q 'DEVRC' "$FLAKE" 2>/dev/null; } || exit 0
 
+# --- Per-push escape hatch ---------------------------------------------------
 if [ "${DEVRC_SKIP_TESTS:-0}" = "1" ]; then
-  echo "pre-push: DEVRC_SKIP_TESTS=1 set — skipping the test gate (flake check / CI still enforce it)." >&2
+  echo "pre-push: DEVRC_SKIP_TESTS=1 — skipping the test gate (flake check / CI still enforce it)." >&2
   exit 0
 fi
 
-echo "pre-push: running devrc test suite (blocking gate)…" >&2
+# --- Mode (env overrides file; default enforce) ------------------------------
+CONF="${TESTS_ON_PUSH_CONF_FILE:-$HOME/.claude/audit-on-push.env}"
+if [ -z "${TESTS_ON_PUSH:-}" ] && [ -f "$CONF" ]; then
+  # shellcheck disable=SC1090
+  . "$CONF" 2>/dev/null || true
+fi
+MODE="${TESTS_ON_PUSH:-on}"
+case "$MODE" in
+  off)
+    echo "pre-push: TESTS_ON_PUSH=off — test gate disabled." >&2
+    exit 0 ;;
+  shadow|on|enforce) : ;;
+  *)
+    echo "pre-push: unknown TESTS_ON_PUSH='$MODE' — treating as 'on'." >&2
+    MODE=on ;;
+esac
 
-run_suite() {
-  bash "$RUNNER" --set all "$REPO_ROOT"
+# --- Changed-files filter (fail TOWARD running) ------------------------------
+# Read git's ref-update lines from stdin. RUN the suite iff any pushed commit
+# touches Python/tests/flake. Any ambiguity -> RUN (return 0).
+#   return 0 = RUN the gate ; return 1 = SKIP (no code touched)
+CODE_RE='^(scripts/|flake\.nix$|flake\.lock$)'
+is_all_zeros() { case "$1" in *[!0]*) return 1 ;; *) return 0 ;; esac; }
+
+should_run_by_files() {
+  local stdin_data="$1"
+  [ -n "$stdin_data" ] || return 0            # no stdin -> can't tell -> RUN
+  local saw_diff=0 matched=0
+  local local_ref local_sha remote_ref remote_sha rest
+  while IFS=' ' read -r local_ref local_sha remote_ref remote_sha rest; do
+    [ -n "$local_ref" ] || continue           # blank line
+    # malformed line (missing a field) -> RUN
+    if [ -z "$local_sha" ] || [ -z "$remote_sha" ]; then
+      return 0
+    fi
+    # pure delete (local sha all-zeros): no content pushed -> nothing to test
+    if is_all_zeros "$local_sha"; then
+      continue
+    fi
+    local range
+    if is_all_zeros "$remote_sha"; then
+      # new branch on the remote: diff against merge-base with origin/main.
+      local base
+      base="$(git -C "$REPO_ROOT" merge-base origin/main "$local_sha" 2>/dev/null || true)"
+      if [ -n "$base" ]; then
+        range="$base..$local_sha"
+      else
+        return 0                              # can't resolve a base -> RUN
+      fi
+    else
+      range="$remote_sha..$local_sha"
+    fi
+    local files
+    if ! files="$(git -C "$REPO_ROOT" diff --name-only "$range" 2>/dev/null)"; then
+      return 0                                # diff failed -> RUN
+    fi
+    saw_diff=1
+    if printf '%s\n' "$files" | grep -qE "$CODE_RE"; then
+      matched=1
+    fi
+  done <<EOF
+$stdin_data
+EOF
+  [ "$saw_diff" = 1 ] || return 0             # never computed a diff -> RUN
+  [ "$matched" = 1 ] && return 0 || return 1
 }
 
-# Prefer an already-usable pytest; else provide deps via nix-shell (matches the
-# per-README invocation). If neither is available, DEGRADE to a warning rather
-# than wedge every push — the hermetic flake check / CI is the hard gate.
-if python -c 'import pytest' >/dev/null 2>&1; then
-  run_suite
-  rc=$?
-elif command -v nix-shell >/dev/null 2>&1; then
-  nix-shell -p "python312.withPackages(ps: with ps; [pytest requests psycopg2 minio pyyaml])" \
-    --run "bash '$RUNNER' --set all '$REPO_ROOT'"
-  rc=$?
-else
-  echo "pre-push: WARNING — no pytest and no nix-shell available; cannot run the test gate locally." >&2
-  echo "pre-push: push allowed to proceed; rely on 'nix flake check' / CI for the hermetic gate." >&2
+STDIN_DATA="$(cat 2>/dev/null || true)"
+if ! should_run_by_files "$STDIN_DATA"; then
+  echo "pre-push: no Python/test/flake changes in this push — skipping the test gate." >&2
   exit 0
 fi
 
-if [ "$rc" -ne 0 ]; then
+# --- Prepare the test env (DEGRADE, don't block, on failure) -----------------
+# The env is PINNED (nix-shell); we never trust an ambient pytest — the modules
+# under test import requests/psycopg2/minio/yaml at collection time, so a stray
+# bare-pytest venv on PATH would ImportError and wrongly block the push.
+PY_ENV="python312.withPackages(ps: with ps; [pytest requests psycopg2 minio pyyaml])"
+
+degrade() {
   echo "" >&2
-  echo "pre-push: ❌ devrc test suite FAILED (rc=$rc) — push BLOCKED." >&2
-  echo "pre-push: fix the failing tests, or 'DEVRC_SKIP_TESTS=1 git push …' to override." >&2
-  exit "$rc"
+  echo "pre-push: ⚠ skipping test gate — could not prepare the test env: $1" >&2
+  echo "pre-push: push ALLOWED to proceed; the hermetic gate is 'nix flake check' / CI." >&2
+  exit 0
+}
+
+if ! command -v nix-shell >/dev/null 2>&1; then
+  degrade "nix-shell not found on PATH"
 fi
 
-echo "pre-push: ✅ devrc test suite passed." >&2
-exit 0
+echo "pre-push: preparing test env (nix-shell)…" >&2
+prep_out="$(nix-shell -p "$PY_ENV" --run 'python --version' 2>&1)"
+prep_rc=$?
+if [ "$prep_rc" -ne 0 ]; then
+  degrade "nix-shell env build failed (rc=$prep_rc): $(printf '%s' "$prep_out" | tail -1)"
+fi
+
+# --- Run the suite (this env is now cached; a failure here is a REAL failure) -
+echo "pre-push: running devrc test suite (mode=$MODE)…" >&2
+nix-shell -p "$PY_ENV" --run "bash '$RUNNER' --set all '$REPO_ROOT'"
+run_rc=$?
+
+if [ "$run_rc" -eq 0 ]; then
+  echo "pre-push: ✅ devrc test suite passed." >&2
+  exit 0
+fi
+
+# Tests EXECUTED and at least one failed.
+if [ "$MODE" = "shadow" ]; then
+  echo "" >&2
+  echo "pre-push: ⚠ devrc test suite FAILED (rc=$run_rc) — SHADOW mode, push NOT blocked." >&2
+  echo "pre-push: flip TESTS_ON_PUSH=on in ~/.claude/audit-on-push.env to enforce." >&2
+  exit 0
+fi
+
+echo "" >&2
+echo "pre-push: ❌ devrc test suite FAILED (rc=$run_rc) — push BLOCKED." >&2
+echo "pre-push: fix the failing tests, or 'DEVRC_SKIP_TESTS=1 git push …' to override." >&2
+exit "$run_rc"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -28,7 +28,7 @@ SET="hermetic"
 ROOT=""
 while [ $# -gt 0 ]; do
   case "$1" in
-    --set) SET="${2:-}"; shift 2 ;;
+    --set) SET="${2:-hermetic}"; shift; [ $# -gt 0 ] && shift ;;
     --set=*) SET="${1#*=}"; shift ;;
     *) ROOT="$1"; shift ;;
   esac

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# devrc test-suite runner — the single source of truth for "run the Python tests".
+#
+# Used by BOTH:
+#   1. the flake check  (nix flake check / nix build .#checks.x86_64-linux.pytests)
+#      — runs the HERMETIC set in the nix sandbox (no network, pinned python).
+#   2. githooks/pre-push — runs the fuller set on the dev host before a push.
+#
+# The caller is responsible for putting a pytest-capable `python` on PATH (the
+# flake check does this via the derivation's buildInputs; the pre-push hook wraps
+# this in a nix-shell with the deps). This script only ORCHESTRATES: each test
+# dir gets its own `python -m pytest` invocation because the suites rely on a
+# per-directory sys.path (bare `import collector` / `import extract` etc. would
+# collide if collected together under one rootdir).
+#
+# Usage:
+#   scripts/run-tests.sh [--set hermetic|all] [ROOT]
+#     --set hermetic  (default) — dirs safe to run offline in the nix sandbox.
+#     --set all                 — hermetic + any dirs deferred to the dev host.
+#   ROOT defaults to the git repo root (or the script's parent-parent).
+#
+# Exit non-zero if ANY selected suite fails. Prints a per-dir + total summary.
+
+set -uo pipefail
+
+SET="hermetic"
+ROOT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --set) SET="${2:-}"; shift 2 ;;
+    --set=*) SET="${1#*=}"; shift ;;
+    *) ROOT="$1"; shift ;;
+  esac
+done
+
+if [ -z "$ROOT" ]; then
+  ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null || true)"
+  [ -n "$ROOT" ] || ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+cd "$ROOT" || { echo "run-tests: cannot cd to ROOT=$ROOT" >&2; exit 2; }
+
+# --- HERMETIC set --------------------------------------------------------------
+# Verified to pass in the offline nix sandbox: every third-party call
+# (psycopg2 / requests / minio HTTP) is mocked, so no live DB or network is
+# reached. See flake.nix `checks.pytests` and the PR body for the audit.
+HERMETIC_DIRS=(
+  scripts/tests
+  scripts/collector/tests
+  scripts/collector/keylog/tests
+  scripts/collector/claude/tests
+  scripts/collector/i3/tests
+  scripts/collector/browser-ext/tests
+  scripts/validation/tests
+  scripts/session-analysis/tests
+  scripts/session-analysis/session_insight/tests
+  scripts/mail-actions/tests
+  scripts/repo-cos/tests
+)
+
+# --- DEV-HOST-ONLY set ---------------------------------------------------------
+# Dirs deferred to the pre-push tier (empty today — nothing here currently needs
+# a live DB/network at runtime; kept so a future DB-bound suite has a home that
+# does NOT block the hermetic flake gate).
+DEVHOST_DIRS=()
+
+DIRS=("${HERMETIC_DIRS[@]}")
+if [ "$SET" = "all" ]; then
+  DIRS+=("${DEVHOST_DIRS[@]}")
+fi
+
+# A writable, self-consistent HOME so the claude-hooks nudge cache-write path
+# works in the sandbox (the hook derives HOME via expanduser; the test derives
+# it the same way, so the value only has to be writable — not "real").
+export HOME="${HOME:-/tmp}"
+if [ ! -w "$HOME" ]; then
+  export HOME="$(mktemp -d)"
+fi
+
+fail=0
+declare -a RESULTS
+run_pytest() {
+  local d="$1"
+  echo "=== pytest $d ==="
+  if python -m pytest "$d" -q -p no:cacheprovider --no-header; then
+    RESULTS+=("PASS  $d")
+  else
+    RESULTS+=("FAIL  $d")
+    fail=1
+  fi
+  echo
+}
+
+for d in "${DIRS[@]}"; do
+  run_pytest "$d"
+done
+
+# The claude-hooks nudge test is a hand-rolled script (asserts + sys.exit, not
+# pytest-collectable) — run it directly. Hermetic (pure string logic + a
+# subprocess of the hook itself). Always part of the hermetic set.
+HOOK_TEST="scripts/claude-hooks/tests/test_shell_env_nudge.py"
+if [ -f "$HOOK_TEST" ]; then
+  echo "=== script $HOOK_TEST ==="
+  if python "$HOOK_TEST"; then
+    RESULTS+=("PASS  $HOOK_TEST (script)")
+  else
+    RESULTS+=("FAIL  $HOOK_TEST (script)")
+    fail=1
+  fi
+  echo
+fi
+
+echo "======================== SUMMARY ($SET set) ========================"
+for r in "${RESULTS[@]}"; do echo "  $r"; done
+if [ "$fail" -ne 0 ]; then
+  echo "RESULT: FAIL"
+else
+  echo "RESULT: PASS"
+fi
+exit "$fail"


### PR DESCRIPTION
## Problem (audit gap #1)

The repo has ~1050 pytest tests across 11 dirs, but **nothing ran them before code shipped to both hosts**: no CI, no `nix flake check` test, `scripts/ship.sh` gates on `nix build` only, and `githooks/pre-push` fires an LLM audit — not the suite. A logic bug in `collector.py` / `mail-actions` / `repo-cos` could ship silently. This closes it.

## Design

Two tiers, sharing one runner (`scripts/run-tests.sh`, `--set hermetic|all`):

1. **Hermetic gate — `nix flake check`** (`flake.nix` → `checks.x86_64-linux.pytests`). Runs the suite in the nix sandbox: pinned `python312`, **no network, no /home**. This is the portable hard gate a future CI / `ship.sh --check` can call. The sandbox is what makes "hermetic" real — it empirically rejects anything that reaches out.
2. **Dev-host tier — `githooks/pre-push` + `tests-on-push.sh`.** Runs the fuller set (`--set all`) **synchronously and blocks the push on failure**. devrc-only (no-op for every other repo, so it's safe as the global hook), `DEVRC_SKIP_TESTS=1` escape hatch, degrades to a warning if neither pytest nor nix-shell is available. Composed into the existing dispatcher **before** the backgrounded audit — does not clobber it.

**Tradeoff:** the suites rely on a *per-directory* `sys.path` (bare `import collector` / `import extract` would collide under one rootdir), so the runner invokes pytest once per dir rather than a single collection. Slightly more orchestration, but it mirrors how the READMEs already document running them and keeps each suite isolated.

Two sandbox findings, both fixed honestly (no skips/xfails added):
- Tests that `exec` real repo scripts (`collector/emit`) failed rc=255 because the sandbox has no `/usr/bin/env` to resolve their shebang → `patchShebangs`. Legitimately hermetic (temp spool, no network); it was purely a shebang-resolution artifact.
- One `repo-cos` prescan test `skipif`s without ripgrep on PATH → added `pkgs.ripgrep` to the sandbox so it runs.

## Coverage: gated hermetically vs deferred

**All 11 pytest dirs + the claude-hooks script test are gated hermetically** — every gated suite mocks its `psycopg2` / `requests` / `minio` I/O, so no live DB or network is reached (proven by passing in the offline sandbox). The dev-host `--set all` tier currently equals the hermetic set (`DEVHOST_DIRS` is empty); the split exists so a future genuinely DB-bound suite has a home that doesn't block the hermetic gate.

## Green baseline (offline nix sandbox)

| Dir | Result |
|---|---|
| scripts/tests | 307 passed |
| scripts/collector/tests | 32 passed |
| scripts/collector/keylog/tests | 58 passed |
| scripts/collector/claude/tests | 40 passed |
| scripts/collector/i3/tests | 13 passed |
| scripts/collector/browser-ext/tests | 13 passed |
| scripts/validation/tests | 91 passed |
| scripts/session-analysis/tests | 125 passed |
| scripts/session-analysis/session_insight/tests | 56 passed, **1 skipped** |
| scripts/mail-actions/tests | 100 passed |
| scripts/repo-cos/tests | 214 passed |
| scripts/claude-hooks (script) | passed |

**Total: 1049 passed, 1 skipped, 0 failed.** The single skip is a **pre-existing** `skipif` on a host-vendored `~/.claude/hooks/bash-guard.py` that's absent in the sandbox — the test's own designed behavior, not coverage dropped here.

## Proof the gate catches a failure

Injected `assert 1 == 2` into a tracked hermetic test and rebuilt:

```
> FAILED scripts/validation/tests/test_activity_scan.py::test_GATE_PROOF_deliberate_failure
> 1 failed, 91 passed
>   FAIL  scripts/validation/tests
> RESULT: FAIL
error: builder for '/nix/store/…-devrc-pytests.drv' failed with exit code 1
```

`nix build .#checks.x86_64-linux.pytests` returned non-zero. Reverted → back to green. `nix flake check` evaluates and recognizes the check.

## Nothing disabled

No test was skipped, xfail'd, or deleted to make the gate green. Both sandbox failures were root-caused and fixed at the environment level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)