### PR TITLE
chore(pkgs): drop gotop (redundant dupe of btop)

### DIFF
--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -10,7 +10,6 @@ with pkgs; [
   tmux
   vim
   fzf
-  gotop
   btop          # vitals-block left-click (float terminal) — memory/cpu/temp/gpu
   ncdu          # disk-block right-click — ncdu on the fullest mount
   wget


### PR DESCRIPTION
Removes `gotop` from the user profile — it has no keybind/bar/tmux/neovim wiring, never appears in shell telemetry, and duplicates `btop` (which *is* wired to the vitals-block left-click).

Validated: `home-manager switch --flake ~/workspace/devrc --impure` passes; `gotop` is off PATH afterward.

Not touched: `tig` — although flagged as "unused" by the same telemetry pass, it actually powers the `tig-explorer.vim` neovim plugin, so it stays pending a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)