### PR TITLE
feat(scripts): deterministic post-agent verification gate + /verify-agent

### DIFF
--- a/claude/commands/verify-agent.md
+++ b/claude/commands/verify-agent.md
@@ -18,6 +18,13 @@ This is the **cheap mechanical structural gate**. It is NOT `/audit-pr`
 (adversarial LLM review) and NOT the `verify` skill (e2e behaviour). Use those
 too when warranted — this one is the fast, always-run floor.
 
+> **⚠ Trust / arbitrary code execution.** The gate runs the TARGET repo's OWN
+> build/test commands and honours a repo-local `.verify-agent.json` — that is
+> code execution BY DESIGN. Do **not** point it at a repo whose contents or
+> `.verify-agent.json` you do not trust; it will execute them. Per this repo's
+> CLAUDE.md, agent-handed worktrees and fuzzyclaw task data are **UNTRUSTED** —
+> treat a worktree you did not create the same way (glance at it first).
+
 ## Run
 
 `$ARGUMENTS` → optional TARGET path (default: cwd / the worktree just handed
@@ -32,35 +39,57 @@ scripts/verify-agent-work <TARGET> --json
 ```
 
 Prefer `--json` so you parse the structured verdict; drop it for the readable
-table. Pass `--strict` to treat a dirty tree / unpushed commits / stale deps as
-hard failures (default: those are WARN, only real gate failures are FAIL).
+table. Pass `--strict` to ALSO treat a dirty tree / unpushed commits as hard
+failures (default: those are WARN). Note an **INCOMPLETE** stack is ALWAYS a
+hard non-pass, strict or not.
+
+## Verdict / exit-code semantics
+
+| verdict | exit | meaning |
+|---|---|---|
+| `PASS` | 0 | every DETECTED stack's gate ran and passed (WARNs allowed unless `--strict`); or no stack present (nothing to verify) |
+| `FAIL` | 1 | a gate actually ran and failed (typecheck/test/build/vet/lint red), or `--strict` + a WARN |
+| `INCOMPLETE` | 1 | a DETECTED stack's gate could NOT run — missing toolchain, no resolvable gate command (e.g. a monorepo with no root script + no runnable member), or deps not installed. **This is NOT a pass** |
+
+The core guarantee: a **detected** stack that was not actually verified never
+reads as green. A repo with **no** stack present is a legitimate PASS.
 
 ## What it checks (per stack actually present — never hard-fails a missing one)
 
 - **TypeScript/JS** (`package.json`): the true `typecheck` script or `tsc
-  --noEmit` (NEVER `build`) **and** the `test` script; detects pnpm/npm/yarn/bun.
-- **Go** (`go.mod`): `go build ./...` + `go vet ./...` + `go test -race ./...`.
-- **Python** (`pyproject`/`requirements`): `ruff check` + `pytest` when configured.
+  --noEmit` (NEVER `build`) **and** the `test` script; detects pnpm/npm/yarn/bun;
+  fans out across workspace members for a monorepo with no root script. A
+  detected TS stack with no runnable gate ⇒ **INCOMPLETE**.
+- **Go** (`go.mod`): `go build ./...` + `go vet ./...` + `go test ./...`
+  (adds `-race` when cgo + a C compiler are available; falls back without `-race`
+  and says so otherwise). Nested `go.mod` modules are each built too.
+- **Python** (`pyproject`/`requirements`): `ruff check` + `pytest` when configured;
+  a detected python project with neither ⇒ **INCOMPLETE**.
 - **Nix** (`flake.nix`): `nix-instantiate --parse` by default; `nix flake check`
   if the repo's `.verify-agent.json` opts in.
 - **Git completeness**: uncommitted/untracked, unpushed vs upstream, open PR
   (best-effort `gh`) — the "committed but stopped" tell.
 - **Stale-worktree footgun**: a broken/missing `node_modules` is reported as an
-  ENV issue and the TS gates are SKIPPED, so false "cannot find module" errors
-  are attributed correctly rather than read as real code errors.
+  ENV issue (WARN) AND the TS gate becomes **INCOMPLETE** — the typecheck genuinely
+  didn't run, so a false "cannot find module" flood is attributed correctly
+  rather than read as real code errors, and it does not count as green.
 
-Exit code is non-zero on any hard failure.
+Exit code is non-zero on any hard non-pass (FAIL or INCOMPLETE).
 
 ## Then
 
-1. **Read the verdict, not the agent's summary.** If `verdict: FAIL`, the agent's
-   "done" claim is wrong regardless of what its prose said — surface the failing
-   check(s) and their output; fix or hand back before merging.
-2. **WARN on git completeness** (dirty tree / unpushed) against a "done" claim →
+1. **Read the verdict, not the agent's summary.** `verdict: FAIL` **or
+   `INCOMPLETE`** means the agent's "done" claim is not verified regardless of
+   its prose — surface the failing/unverified check(s) and their output; fix,
+   run the gate where the toolchain exists, or hand back before merging.
+2. **INCOMPLETE** → the gate could not actually verify a detected stack. Do not
+   treat it as a pass: run it in an environment with the toolchain, install deps,
+   add a gate/`skip` in `.verify-agent.json`, or verify by hand.
+3. **WARN on git completeness** (dirty tree / unpushed) against a "done" claim →
    reconcile: did the agent actually finish and push? Commit/push or flag it.
-3. **`env:node_modules` WARN** → the errors are environmental; re-install deps in
+4. **`env:node_modules` WARN** → the errors are environmental; re-install deps in
    that worktree, don't chase them as code bugs.
-4. **PASS** is the mechanical floor, not proof of behaviour — for a nontrivial
+5. **PASS** is the mechanical floor, not proof of behaviour — for a nontrivial
    runtime change still drive the actual flow (`verify` skill) before claiming
    it works.
 

--- a/claude/commands/verify-agent.md
+++ b/claude/commands/verify-agent.md
@@ -1,0 +1,68 @@
+---
+name: verify-agent
+description: "Deterministic post-agent verification gate: re-run the AUTHORITATIVE build/typecheck/test/vet gate + git-completeness + stale-deps checks against a repo/worktree, and READ that verdict instead of trusting an agent's 'done' claim."
+argument-hint: "[TARGET path] [--strict] — default: cwd. e.g. '~/workspace/civitai', '. --strict'"
+allowed-tools: Bash, Read
+---
+
+# /verify-agent — mechanical gate over an agent's "done" claim
+
+An agent (subagent/dispatched Task) just reported "build green / committed / done."
+Do **not** take that prose at face value — the recurring failures are: a proxy
+command hid a real error (`vite build` does NOT typecheck), the agent "committed
+but stopped" (dirty tree / unpushed commits), or a stale worktree `node_modules`
+symlink produced a flood of false "cannot find module" errors. Run the
+deterministic gate and read ITS output.
+
+This is the **cheap mechanical structural gate**. It is NOT `/audit-pr`
+(adversarial LLM review) and NOT the `verify` skill (e2e behaviour). Use those
+too when warranted — this one is the fast, always-run floor.
+
+## Run
+
+`$ARGUMENTS` → optional TARGET path (default: cwd / the worktree just handed
+back) + optional flags passed through (`--strict`, `--no-gh`, `--timeout N`).
+
+The script is `scripts/verify-agent-work` in this repo (devrc). Invoke it against
+the target. It needs a `python3`; if the bare call reports no interpreter, wrap
+it in `nix-shell -p python3 --run "…"`.
+
+```
+scripts/verify-agent-work <TARGET> --json
+```
+
+Prefer `--json` so you parse the structured verdict; drop it for the readable
+table. Pass `--strict` to treat a dirty tree / unpushed commits / stale deps as
+hard failures (default: those are WARN, only real gate failures are FAIL).
+
+## What it checks (per stack actually present — never hard-fails a missing one)
+
+- **TypeScript/JS** (`package.json`): the true `typecheck` script or `tsc
+  --noEmit` (NEVER `build`) **and** the `test` script; detects pnpm/npm/yarn/bun.
+- **Go** (`go.mod`): `go build ./...` + `go vet ./...` + `go test -race ./...`.
+- **Python** (`pyproject`/`requirements`): `ruff check` + `pytest` when configured.
+- **Nix** (`flake.nix`): `nix-instantiate --parse` by default; `nix flake check`
+  if the repo's `.verify-agent.json` opts in.
+- **Git completeness**: uncommitted/untracked, unpushed vs upstream, open PR
+  (best-effort `gh`) — the "committed but stopped" tell.
+- **Stale-worktree footgun**: a broken/missing `node_modules` is reported as an
+  ENV issue and the TS gates are SKIPPED, so false "cannot find module" errors
+  are attributed correctly rather than read as real code errors.
+
+Exit code is non-zero on any hard failure.
+
+## Then
+
+1. **Read the verdict, not the agent's summary.** If `verdict: FAIL`, the agent's
+   "done" claim is wrong regardless of what its prose said — surface the failing
+   check(s) and their output; fix or hand back before merging.
+2. **WARN on git completeness** (dirty tree / unpushed) against a "done" claim →
+   reconcile: did the agent actually finish and push? Commit/push or flag it.
+3. **`env:node_modules` WARN** → the errors are environmental; re-install deps in
+   that worktree, don't chase them as code bugs.
+4. **PASS** is the mechanical floor, not proof of behaviour — for a nontrivial
+   runtime change still drive the actual flow (`verify` skill) before claiming
+   it works.
+
+Provenance honesty: this gate proves the authoritative checks pass and the tree
+is complete; it does NOT prove the feature behaves correctly.

--- a/scripts/tests/test_verify_agent_work.py
+++ b/scripts/tests/test_verify_agent_work.py
@@ -1,0 +1,501 @@
+"""Unit tests for scripts/verify-agent-work — the post-agent verification gate.
+
+All HERMETIC — temp dirs / fixture git repos, no network, no cluster, no real
+build. The gate's subprocess-running layer (`run_gate`) is bypassed by
+injecting a fake `gate_runner` into `verify()`, so no toolchain is required.
+
+The script is extensionless, so it is loaded via SourceFileLoader.
+
+    run:  pytest scripts/tests/test_verify_agent_work.py
+"""
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+
+
+def _load(name, modname):
+    loader = importlib.machinery.SourceFileLoader(modname, str(SCRIPTS / name))
+    spec = importlib.util.spec_from_loader(modname, loader)
+    mod = importlib.util.module_from_spec(spec)
+    # register before exec so @dataclass (with `from __future__ import
+    # annotations`) can resolve the module via sys.modules on py>=3.12.
+    sys.modules[modname] = mod
+    loader.exec_module(mod)
+    return mod
+
+
+vaw = _load("verify-agent-work", "verify_agent_work")
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+
+
+def write(path: Path, content: str = "{}"):
+    path.write_text(content)
+
+
+def git(repo: Path, *args):
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True
+    )
+
+
+def init_repo(repo: Path):
+    git(repo, "init", "-q", "-b", "main")
+    git(repo, "config", "user.email", "t@t.dev")
+    git(repo, "config", "user.name", "t")
+    git(repo, "config", "commit.gpgsign", "false")
+
+
+def commit_all(repo: Path, msg="c"):
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", msg)
+
+
+# --------------------------------------------------------------------------- #
+# stack detection
+# --------------------------------------------------------------------------- #
+
+
+def test_detect_ts_stack(tmp_path):
+    write(tmp_path / "package.json", json.dumps({"scripts": {"test": "jest"}}))
+    stacks = vaw.detect_stacks(tmp_path)
+    assert set(stacks) == {"ts"}
+    assert stacks["ts"]["scripts"] == {"test": "jest"}
+
+
+def test_detect_go_stack(tmp_path):
+    write(tmp_path / "go.mod", "module x\n\ngo 1.22\n")
+    assert set(vaw.detect_stacks(tmp_path)) == {"go"}
+
+
+def test_detect_python_stack(tmp_path):
+    write(tmp_path / "pyproject.toml", "[tool.ruff]\n[tool.pytest.ini_options]\n")
+    stacks = vaw.detect_stacks(tmp_path)
+    assert set(stacks) == {"python"}
+    assert stacks["python"]["has_ruff"] is True
+    assert stacks["python"]["has_pytest"] is True
+
+
+def test_detect_nix_stack(tmp_path):
+    write(tmp_path / "flake.nix", "{ }\n")
+    assert set(vaw.detect_stacks(tmp_path)) == {"nix"}
+
+
+def test_detect_mixed_stack(tmp_path):
+    write(tmp_path / "package.json", "{}")
+    write(tmp_path / "go.mod", "module x\n")
+    write(tmp_path / "flake.nix", "{ }\n")
+    assert set(vaw.detect_stacks(tmp_path)) == {"ts", "go", "nix"}
+
+
+def test_detect_no_stack(tmp_path):
+    (tmp_path / "README.md").write_text("# hi")
+    assert vaw.detect_stacks(tmp_path) == {}
+
+
+def test_expects_node_modules_flag(tmp_path):
+    write(tmp_path / "package.json", json.dumps({"dependencies": {"left-pad": "1"}}))
+    assert vaw.detect_stacks(tmp_path)["ts"]["expects_node_modules"] is True
+    write(tmp_path / "package.json", json.dumps({"name": "x"}))
+    assert vaw.detect_stacks(tmp_path)["ts"]["expects_node_modules"] is False
+
+
+@pytest.mark.parametrize(
+    "lockfile,expected",
+    [
+        ("pnpm-lock.yaml", "pnpm"),
+        ("yarn.lock", "yarn"),
+        ("package-lock.json", "npm"),
+        ("bun.lockb", "bun"),
+    ],
+)
+def test_detect_package_manager(tmp_path, lockfile, expected):
+    write(tmp_path / lockfile, "")
+    assert vaw.detect_package_manager(tmp_path) == expected
+
+
+def test_detect_package_manager_default_npm(tmp_path):
+    assert vaw.detect_package_manager(tmp_path) == "npm"
+
+
+# --------------------------------------------------------------------------- #
+# node_modules footgun
+# --------------------------------------------------------------------------- #
+
+
+def test_node_modules_missing_warns(tmp_path):
+    write(tmp_path / "package.json", json.dumps({"dependencies": {"x": "1"}}))
+    meta = vaw.detect_stacks(tmp_path)["ts"]
+    chk = vaw.check_node_modules(tmp_path, meta)
+    assert chk is not None
+    assert chk.status == vaw.WARN
+    assert "absent" in chk.summary
+
+
+def test_node_modules_broken_symlink_warns(tmp_path):
+    write(tmp_path / "package.json", json.dumps({"dependencies": {"x": "1"}}))
+    (tmp_path / "node_modules").symlink_to(tmp_path / "does-not-exist")
+    meta = vaw.detect_stacks(tmp_path)["ts"]
+    chk = vaw.check_node_modules(tmp_path, meta)
+    assert chk is not None
+    assert chk.status == vaw.WARN
+    assert "BROKEN symlink" in chk.summary
+
+
+def test_node_modules_present_ok(tmp_path):
+    write(tmp_path / "package.json", json.dumps({"dependencies": {"x": "1"}}))
+    (tmp_path / "node_modules").mkdir()
+    meta = vaw.detect_stacks(tmp_path)["ts"]
+    assert vaw.check_node_modules(tmp_path, meta) is None
+
+
+def test_node_modules_not_required_when_no_deps(tmp_path):
+    write(tmp_path / "package.json", json.dumps({"name": "x"}))
+    meta = vaw.detect_stacks(tmp_path)["ts"]
+    assert vaw.check_node_modules(tmp_path, meta) is None
+
+
+# --------------------------------------------------------------------------- #
+# git state
+# --------------------------------------------------------------------------- #
+
+
+def test_git_state_not_a_repo(tmp_path):
+    assert vaw.git_state(tmp_path) == {"is_repo": False}
+
+
+def test_git_state_clean(tmp_path):
+    init_repo(tmp_path)
+    write(tmp_path / "f.txt", "hi")
+    commit_all(tmp_path)
+    st = vaw.git_state(tmp_path)
+    assert st["is_repo"] is True
+    assert st["dirty"] is False
+    assert st["branch"] == "main"
+
+
+def test_git_state_dirty_untracked(tmp_path):
+    init_repo(tmp_path)
+    write(tmp_path / "f.txt", "hi")
+    commit_all(tmp_path)
+    write(tmp_path / "new.txt", "x")  # untracked
+    st = vaw.git_state(tmp_path)
+    assert st["dirty"] is True
+    assert st["untracked"] == 1
+    assert st["tracked_changes"] == 0
+
+
+def test_git_state_dirty_modified(tmp_path):
+    init_repo(tmp_path)
+    write(tmp_path / "f.txt", "hi")
+    commit_all(tmp_path)
+    write(tmp_path / "f.txt", "changed")  # tracked modification
+    st = vaw.git_state(tmp_path)
+    assert st["dirty"] is True
+    assert st["tracked_changes"] == 1
+
+
+def test_git_state_ahead_of_upstream(tmp_path):
+    # bare "remote" + a clone, commit ahead → ahead==1.
+    remote = tmp_path / "remote.git"
+    remote.mkdir()
+    git(remote, "init", "-q", "--bare", "-b", "main")
+    work = tmp_path / "work"
+    subprocess.run(["git", "clone", "-q", str(remote), str(work)], check=True)
+    git(work, "config", "user.email", "t@t.dev")
+    git(work, "config", "user.name", "t")
+    git(work, "config", "commit.gpgsign", "false")
+    write(work / "a.txt", "1")
+    commit_all(work)
+    git(work, "push", "-q", "-u", "origin", "main")
+    write(work / "b.txt", "2")
+    commit_all(work)  # local commit, not pushed
+    st = vaw.git_state(work)
+    assert st["upstream"] is not None
+    assert st["ahead"] == 1
+    assert st["behind"] == 0
+
+
+def test_git_state_no_upstream_has_commits(tmp_path):
+    init_repo(tmp_path)
+    write(tmp_path / "f.txt", "hi")
+    commit_all(tmp_path)
+    st = vaw.git_state(tmp_path)
+    assert st["upstream"] is None
+    assert st["has_commits"] is True
+
+
+# --------------------------------------------------------------------------- #
+# check_git verdicts
+# --------------------------------------------------------------------------- #
+
+
+def _by_name(checks):
+    return {c.name: c for c in checks}
+
+
+def test_check_git_clean_passes(tmp_path):
+    init_repo(tmp_path)
+    write(tmp_path / "f.txt", "hi")
+    commit_all(tmp_path)
+    checks = _by_name(vaw.check_git(vaw.git_state(tmp_path), tmp_path, use_gh=False))
+    assert checks["git:clean-tree"].status == vaw.PASS
+
+
+def test_check_git_dirty_warns(tmp_path):
+    init_repo(tmp_path)
+    write(tmp_path / "f.txt", "hi")  # uncommitted
+    checks = _by_name(vaw.check_git(vaw.git_state(tmp_path), tmp_path, use_gh=False))
+    assert checks["git:clean-tree"].status == vaw.WARN
+    assert checks["git:pushed"].status == vaw.SKIP  # no commits yet
+
+
+def test_check_git_no_upstream_warns(tmp_path):
+    init_repo(tmp_path)
+    write(tmp_path / "f.txt", "hi")
+    commit_all(tmp_path)
+    checks = _by_name(vaw.check_git(vaw.git_state(tmp_path), tmp_path, use_gh=False))
+    assert checks["git:pushed"].status == vaw.WARN  # committed but not pushed
+
+
+# --------------------------------------------------------------------------- #
+# gate plan
+# --------------------------------------------------------------------------- #
+
+
+def _plan_names(specs):
+    return [s.name for s in specs]
+
+
+def test_plan_ts_typecheck_and_test(tmp_path):
+    write(
+        tmp_path / "package.json",
+        json.dumps({"scripts": {"typecheck": "tsc --noEmit", "test": "jest"}}),
+    )
+    write(tmp_path / "pnpm-lock.yaml", "")
+    stacks = vaw.detect_stacks(tmp_path)
+    specs, skips = vaw.build_gate_plan(tmp_path, stacks, {}, node_ok=True)
+    names = _plan_names(specs)
+    assert "ts:typecheck" in names
+    assert "ts:test" in names
+    tc = next(s for s in specs if s.name == "ts:typecheck")
+    assert tc.cmd == ["pnpm", "run", "typecheck"]
+
+
+def test_plan_ts_tsc_fallback_when_no_script(tmp_path):
+    write(tmp_path / "package.json", json.dumps({"dependencies": {"x": "1"}}))
+    write(tmp_path / "tsconfig.json", "{}")
+    write(tmp_path / "node_modules" / ".keep", "") if False else (tmp_path / "node_modules").mkdir()
+    stacks = vaw.detect_stacks(tmp_path)
+    specs, skips = vaw.build_gate_plan(tmp_path, stacks, {}, node_ok=True)
+    tc = next(s for s in specs if s.name == "ts:typecheck")
+    assert tc.cmd == ["npx", "--no-install", "tsc", "--noEmit"]
+    # no test script → skipped
+    assert any(s.name == "ts:test" and s.status == vaw.SKIP for s in skips)
+
+
+def test_plan_ts_skipped_when_node_not_ok(tmp_path):
+    write(tmp_path / "package.json", json.dumps({"scripts": {"typecheck": "tsc"}}))
+    stacks = vaw.detect_stacks(tmp_path)
+    specs, skips = vaw.build_gate_plan(tmp_path, stacks, {}, node_ok=False)
+    assert _plan_names(specs) == []  # nothing runs
+    skip_names = {s.name for s in skips}
+    assert {"ts:typecheck", "ts:test"} <= skip_names
+    assert all(s.status == vaw.SKIP for s in skips)
+
+
+def test_plan_go(tmp_path):
+    write(tmp_path / "go.mod", "module x\n")
+    stacks = vaw.detect_stacks(tmp_path)
+    specs, _ = vaw.build_gate_plan(tmp_path, stacks, {}, node_ok=True)
+    names = _plan_names(specs)
+    assert names == ["go:build", "go:vet", "go:test"]
+    test_spec = next(s for s in specs if s.name == "go:test")
+    assert "go test -race ./..." in " ".join(test_spec.cmd)
+
+
+def test_plan_nix_default_parse(tmp_path):
+    write(tmp_path / "flake.nix", "{ }\n")
+    stacks = vaw.detect_stacks(tmp_path)
+    specs, _ = vaw.build_gate_plan(tmp_path, stacks, {}, node_ok=True)
+    assert _plan_names(specs) == ["nix:parse"]
+    assert specs[0].cmd[0] == "nix-instantiate"
+
+
+def test_plan_config_override_and_skip(tmp_path):
+    write(tmp_path / "flake.nix", "{ }\n")
+    write(tmp_path / "go.mod", "module x\n")
+    cfg = {"skip": ["go"], "nix": {"check": "nix flake check"}}
+    stacks = vaw.detect_stacks(tmp_path)
+    specs, _ = vaw.build_gate_plan(tmp_path, stacks, cfg, node_ok=True)
+    names = _plan_names(specs)
+    assert "nix:check" in names  # override applied
+    assert not any(n.startswith("go:") for n in names)  # go skipped
+
+
+def test_plan_python(tmp_path):
+    write(tmp_path / "pyproject.toml", "[tool.ruff]\n[tool.pytest.ini_options]\n")
+    stacks = vaw.detect_stacks(tmp_path)
+    specs, _ = vaw.build_gate_plan(tmp_path, stacks, {}, node_ok=True)
+    names = _plan_names(specs)
+    assert "python:lint" in names
+    assert "python:test" in names
+
+
+# --------------------------------------------------------------------------- #
+# config loading
+# --------------------------------------------------------------------------- #
+
+
+def test_load_config_present(tmp_path):
+    write(tmp_path / ".verify-agent.json", json.dumps({"skip": ["nix"]}))
+    assert vaw.load_config(tmp_path) == {"skip": ["nix"]}
+
+
+def test_load_config_absent(tmp_path):
+    assert vaw.load_config(tmp_path) == {}
+
+
+def test_load_config_malformed(tmp_path):
+    write(tmp_path / ".verify-agent.json", "not json{")
+    assert vaw.load_config(tmp_path) == {}
+
+
+# --------------------------------------------------------------------------- #
+# output truncation
+# --------------------------------------------------------------------------- #
+
+
+def test_truncate_keeps_tail(tmp_path):
+    text = "\n".join(str(i) for i in range(100))
+    out = vaw._truncate(text, max_lines=10)
+    assert "truncated" in out
+    assert out.strip().endswith("99")
+    assert "0\n" not in out.split("truncated")[1][:5]  # early lines gone
+
+
+def test_truncate_short_untouched():
+    assert vaw._truncate("a\nb\nc", max_lines=10) == "a\nb\nc"
+
+
+# --------------------------------------------------------------------------- #
+# end-to-end verify() with an injected fake gate runner (no real build)
+# --------------------------------------------------------------------------- #
+
+
+def _fake_runner(results_by_name):
+    def runner(spec, timeout):
+        status = results_by_name.get(spec.name, vaw.PASS)
+        return vaw.Check(spec.name, status, f"fake {spec.name}")
+    return runner
+
+
+def test_verify_all_pass_exit_zero(tmp_path):
+    init_repo(tmp_path)
+    write(tmp_path / "go.mod", "module x\n")
+    commit_all(tmp_path)
+    # detach upstream noise: no upstream → git:pushed WARN, but WARN != fail
+    res = vaw.verify(
+        tmp_path, use_gh=False, gate_runner=_fake_runner({})
+    )
+    assert res.verdict == vaw.PASS
+    assert res.exit_code == 0
+    names = {c.name for c in res.checks}
+    assert {"go:build", "go:vet", "go:test"} <= names
+
+
+def test_verify_gate_fail_exit_one(tmp_path):
+    init_repo(tmp_path)
+    write(tmp_path / "go.mod", "module x\n")
+    commit_all(tmp_path)
+    res = vaw.verify(
+        tmp_path, use_gh=False, gate_runner=_fake_runner({"go:test": vaw.FAIL})
+    )
+    assert res.verdict == vaw.FAIL
+    assert res.exit_code == 1
+
+
+def test_verify_warn_not_fail_by_default(tmp_path):
+    init_repo(tmp_path)
+    write(tmp_path / "f.txt", "hi")  # dirty → WARN
+    res = vaw.verify(tmp_path, use_gh=False, gate_runner=_fake_runner({}))
+    assert any(c.status == vaw.WARN for c in res.checks)
+    assert res.exit_code == 0  # WARN alone does not fail
+
+
+def test_verify_strict_promotes_warn(tmp_path):
+    init_repo(tmp_path)
+    write(tmp_path / "f.txt", "hi")  # dirty → WARN
+    res = vaw.verify(
+        tmp_path, use_gh=False, strict=True, gate_runner=_fake_runner({})
+    )
+    assert res.exit_code == 1  # strict promotes WARN
+
+
+def test_verify_node_modules_footgun_skips_ts(tmp_path):
+    init_repo(tmp_path)
+    write(tmp_path / "package.json", json.dumps({"dependencies": {"x": "1"}}))
+    commit_all(tmp_path)
+    res = vaw.verify(tmp_path, use_gh=False, gate_runner=_fake_runner({}))
+    by = _by_name(res.checks)
+    assert by["env:node_modules"].status == vaw.WARN
+    assert by["ts:typecheck"].status == vaw.SKIP
+    assert by["ts:test"].status == vaw.SKIP
+    assert res.exit_code == 0  # env issue is a WARN, not a code failure
+
+
+def test_verify_no_stack_still_runs_git(tmp_path):
+    init_repo(tmp_path)
+    write(tmp_path / "README.md", "hi")
+    commit_all(tmp_path)
+    res = vaw.verify(tmp_path, use_gh=False, gate_runner=_fake_runner({}))
+    assert res.stacks == []
+    assert any(c.name == "git:clean-tree" for c in res.checks)
+
+
+# --------------------------------------------------------------------------- #
+# JSON output shape + exit codes
+# --------------------------------------------------------------------------- #
+
+
+def test_json_shape(tmp_path):
+    init_repo(tmp_path)
+    write(tmp_path / "go.mod", "module x\n")
+    commit_all(tmp_path)
+    res = vaw.verify(tmp_path, use_gh=False, gate_runner=_fake_runner({"go:build": vaw.FAIL}))
+    d = res.to_dict()
+    assert set(d) >= {"target", "verdict", "exit_code", "stacks", "checks"}
+    assert d["verdict"] == vaw.FAIL
+    assert d["exit_code"] == 1
+    assert isinstance(d["checks"], list)
+    for c in d["checks"]:
+        assert "name" in c and "status" in c and "summary" in c
+    # round-trips through json
+    assert json.loads(json.dumps(d))["verdict"] == vaw.FAIL
+
+
+def test_main_bad_target_exit_two(capsys):
+    rc = vaw.main(["/nonexistent/path/xyz", "--no-gh"])
+    assert rc == 2
+
+
+def test_main_json_smoke(tmp_path, capsys):
+    init_repo(tmp_path)
+    write(tmp_path / "README.md", "hi")
+    commit_all(tmp_path)
+    rc = vaw.main([str(tmp_path), "--json", "--no-gh"])
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed["target"].endswith(tmp_path.name)
+    assert rc == parsed["exit_code"]

--- a/scripts/tests/test_verify_agent_work.py
+++ b/scripts/tests/test_verify_agent_work.py
@@ -296,33 +296,107 @@ def test_plan_ts_typecheck_and_test(tmp_path):
 def test_plan_ts_tsc_fallback_when_no_script(tmp_path):
     write(tmp_path / "package.json", json.dumps({"dependencies": {"x": "1"}}))
     write(tmp_path / "tsconfig.json", "{}")
-    write(tmp_path / "node_modules" / ".keep", "") if False else (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules").mkdir()
     stacks = vaw.detect_stacks(tmp_path)
-    specs, skips = vaw.build_gate_plan(tmp_path, stacks, {}, node_ok=True)
+    specs, aux = vaw.build_gate_plan(tmp_path, stacks, {}, node_ok=True)
     tc = next(s for s in specs if s.name == "ts:typecheck")
     assert tc.cmd == ["npx", "--no-install", "tsc", "--noEmit"]
-    # no test script → skipped
-    assert any(s.name == "ts:test" and s.status == vaw.SKIP for s in skips)
+    # a runnable gate (typecheck) resolved → stack is NOT incomplete even though
+    # there's no test script.
+    assert not any(c.status == vaw.INCOMPLETE for c in aux)
 
 
-def test_plan_ts_skipped_when_node_not_ok(tmp_path):
+def test_plan_ts_no_runnable_gate_is_incomplete(tmp_path):
+    # package.json with deps but NO typecheck/test script and NO tsconfig →
+    # nothing authoritative to run → INCOMPLETE, never a silent green.
+    write(tmp_path / "package.json", json.dumps({"dependencies": {"x": "1"}}))
+    (tmp_path / "node_modules").mkdir()
+    stacks = vaw.detect_stacks(tmp_path)
+    specs, aux = vaw.build_gate_plan(tmp_path, stacks, {}, node_ok=True)
+    assert _plan_names(specs) == []
+    ts_aux = [c for c in aux if c.name == "ts"]
+    assert ts_aux and ts_aux[0].status == vaw.INCOMPLETE
+
+
+def test_plan_ts_incomplete_when_node_not_ok(tmp_path):
     write(tmp_path / "package.json", json.dumps({"scripts": {"typecheck": "tsc"}}))
     stacks = vaw.detect_stacks(tmp_path)
-    specs, skips = vaw.build_gate_plan(tmp_path, stacks, {}, node_ok=False)
+    specs, aux = vaw.build_gate_plan(tmp_path, stacks, {}, node_ok=False)
     assert _plan_names(specs) == []  # nothing runs
-    skip_names = {s.name for s in skips}
-    assert {"ts:typecheck", "ts:test"} <= skip_names
-    assert all(s.status == vaw.SKIP for s in skips)
+    ts_aux = [c for c in aux if c.name == "ts"]
+    assert ts_aux and ts_aux[0].status == vaw.INCOMPLETE
 
 
-def test_plan_go(tmp_path):
+def test_plan_monorepo_no_root_script_resolves_members(tmp_path):
+    # workspace root with NO root typecheck/test script → fan out to members.
+    write(
+        tmp_path / "package.json",
+        json.dumps({"private": True, "workspaces": ["packages/*"]}),
+    )
+    pkg_a = tmp_path / "packages" / "a"
+    pkg_a.mkdir(parents=True)
+    write(pkg_a / "package.json", json.dumps({"scripts": {"typecheck": "tsc"}}))
+    stacks = vaw.detect_stacks(tmp_path)
+    assert stacks["ts"]["is_workspace_root"] is True
+    specs, aux = vaw.build_gate_plan(tmp_path, stacks, {}, node_ok=True)
+    names = _plan_names(specs)
+    assert any(n.startswith("ts:typecheck[a]") for n in names)
+    assert not any(c.status == vaw.INCOMPLETE for c in aux)
+
+
+def test_plan_monorepo_no_runnable_member_is_incomplete(tmp_path):
+    # workspace root, members have no scripts/tsconfig → nothing runs → INCOMPLETE.
+    write(
+        tmp_path / "package.json",
+        json.dumps({"private": True, "workspaces": ["packages/*"]}),
+    )
+    pkg_a = tmp_path / "packages" / "a"
+    pkg_a.mkdir(parents=True)
+    write(pkg_a / "package.json", json.dumps({"name": "a"}))
+    stacks = vaw.detect_stacks(tmp_path)
+    specs, aux = vaw.build_gate_plan(tmp_path, stacks, {}, node_ok=True)
+    assert _plan_names(specs) == []
+    assert any(c.name == "ts" and c.status == vaw.INCOMPLETE for c in aux)
+
+
+def test_plan_pnpm_workspace_detected(tmp_path):
+    write(tmp_path / "package.json", json.dumps({"private": True}))
+    write(tmp_path / "pnpm-workspace.yaml", "packages:\n  - 'apps/*'\n  - 'libs/*'\n")
+    globs = vaw.detect_stacks(tmp_path)["ts"]["workspace_globs"]
+    assert "apps/*" in globs and "libs/*" in globs
+
+
+def test_plan_go_race_when_cgo(tmp_path):
     write(tmp_path / "go.mod", "module x\n")
     stacks = vaw.detect_stacks(tmp_path)
-    specs, _ = vaw.build_gate_plan(tmp_path, stacks, {}, node_ok=True)
-    names = _plan_names(specs)
-    assert names == ["go:build", "go:vet", "go:test"]
+    # force cgo/race ON via config so the assertion is deterministic
+    specs, _ = vaw.build_gate_plan(tmp_path, stacks, {"go": {"race": True}}, node_ok=True)
+    assert _plan_names(specs) == ["go:build", "go:vet", "go:test"]
     test_spec = next(s for s in specs if s.name == "go:test")
     assert "go test -race ./..." in " ".join(test_spec.cmd)
+
+
+def test_plan_go_no_race_when_cgo_unavailable(tmp_path):
+    write(tmp_path / "go.mod", "module x\n")
+    stacks = vaw.detect_stacks(tmp_path)
+    specs, aux = vaw.build_gate_plan(tmp_path, stacks, {"go": {"race": False}}, node_ok=True)
+    test_spec = next(s for s in specs if s.name == "go:test")
+    cmd = " ".join(test_spec.cmd)
+    assert "-race" not in cmd
+    assert "go test ./..." in cmd
+    assert any(c.name == "go:race" and c.status == vaw.SKIP for c in aux)
+
+
+def test_plan_nested_go_modules(tmp_path):
+    write(tmp_path / "go.mod", "module root\n")
+    nested = tmp_path / "sub" / "svc"
+    nested.mkdir(parents=True)
+    write(nested / "go.mod", "module svc\n")
+    stacks = vaw.detect_stacks(tmp_path)
+    specs, _ = vaw.build_gate_plan(tmp_path, stacks, {"go": {"race": True}}, node_ok=True)
+    names = _plan_names(specs)
+    assert "go:build" in names  # root module
+    assert any("[sub/svc]" in n for n in names)  # nested module covered
 
 
 def test_plan_nix_default_parse(tmp_path):
@@ -443,25 +517,87 @@ def test_verify_strict_promotes_warn(tmp_path):
     assert res.exit_code == 1  # strict promotes WARN
 
 
-def test_verify_node_modules_footgun_skips_ts(tmp_path):
+def test_verify_node_modules_footgun_is_incomplete_nonzero(tmp_path):
+    # broken node_modules for a DETECTED TS stack: the typecheck genuinely did
+    # not run → INCOMPLETE + non-zero, NOT a silent green. The env WARN explains
+    # WHY (attributes a 'cannot find module' flood to env, not code).
     init_repo(tmp_path)
     write(tmp_path / "package.json", json.dumps({"dependencies": {"x": "1"}}))
     commit_all(tmp_path)
     res = vaw.verify(tmp_path, use_gh=False, gate_runner=_fake_runner({}))
     by = _by_name(res.checks)
     assert by["env:node_modules"].status == vaw.WARN
-    assert by["ts:typecheck"].status == vaw.SKIP
-    assert by["ts:test"].status == vaw.SKIP
-    assert res.exit_code == 0  # env issue is a WARN, not a code failure
+    assert by["ts"].status == vaw.INCOMPLETE
+    assert res.verdict == vaw.INCOMPLETE
+    assert res.exit_code == 1
 
 
-def test_verify_no_stack_still_runs_git(tmp_path):
+def test_verify_incomplete_makes_nonzero(tmp_path):
+    # a detected stack whose gate returns INCOMPLETE (e.g. missing toolchain)
+    # must never count as an overall PASS.
+    init_repo(tmp_path)
+    write(tmp_path / "go.mod", "module x\n")
+    commit_all(tmp_path)
+    res = vaw.verify(
+        tmp_path, use_gh=False, gate_runner=_fake_runner({"go:build": vaw.INCOMPLETE})
+    )
+    assert res.verdict == vaw.INCOMPLETE
+    assert res.exit_code == 1
+
+
+def test_verify_no_stack_present_is_pass(tmp_path):
+    # the legitimate PASS: nothing to verify → PASS / exit 0.
     init_repo(tmp_path)
     write(tmp_path / "README.md", "hi")
     commit_all(tmp_path)
     res = vaw.verify(tmp_path, use_gh=False, gate_runner=_fake_runner({}))
     assert res.stacks == []
     assert any(c.name == "git:clean-tree" for c in res.checks)
+    assert res.verdict == vaw.PASS
+    assert res.exit_code == 0
+
+
+# --------------------------------------------------------------------------- #
+# run_gate: missing-toolchain / exit-127 → INCOMPLETE (real subprocess)
+# --------------------------------------------------------------------------- #
+
+
+def test_run_gate_pass_real(tmp_path):
+    spec = vaw.GateSpec("probe", ["true"], tmp_path, tool="true")
+    chk = vaw.run_gate(spec)
+    assert chk.status == vaw.PASS
+
+
+def test_run_gate_fail_real(tmp_path):
+    spec = vaw.GateSpec("probe", ["bash", "-c", "echo boom >&2; exit 3"], tmp_path, tool="bash")
+    chk = vaw.run_gate(spec)
+    assert chk.status == vaw.FAIL
+    assert "boom" in chk.output
+
+
+def test_run_gate_missing_tool_is_incomplete(tmp_path):
+    spec = vaw.GateSpec("ts:typecheck", ["pnpm", "run", "typecheck"], tmp_path,
+                        tool="definitely-not-a-real-tool-xyz")
+    chk = vaw.run_gate(spec)
+    assert chk.status == vaw.INCOMPLETE
+    assert "not found" in chk.summary
+
+
+def test_run_gate_exit127_is_incomplete(tmp_path):
+    # inner tool missing under a `bash -c` wrapper (tool=bash exists) → 127.
+    spec = vaw.GateSpec("go:build", ["bash", "-c", "definitely-not-a-real-tool-xyz build"],
+                        tmp_path, tool="bash")
+    chk = vaw.run_gate(spec)
+    assert chk.status == vaw.INCOMPLETE
+
+
+def test_python_no_gate_is_incomplete(tmp_path):
+    # requirements.txt but no ruff, no pytest config, no tests dir → INCOMPLETE.
+    write(tmp_path / "requirements.txt", "requests\n")
+    stacks = vaw.detect_stacks(tmp_path)
+    specs, aux = vaw.build_gate_plan(tmp_path, stacks, {}, node_ok=True)
+    assert _plan_names(specs) == []
+    assert any(c.name == "python" and c.status == vaw.INCOMPLETE for c in aux)
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/verify-agent-work
+++ b/scripts/verify-agent-work
@@ -1,0 +1,716 @@
+#!/usr/bin/env python3
+"""verify-agent-work — deterministic, repo-aware post-agent verification gate.
+
+Zach works entirely through dispatched subagents. The recurring failure this
+gate closes: an agent claims "build green / committed / done" but
+
+  (a) a proxy command hid a real error (`vite build` does NOT typecheck — a
+      green build hid live `tsc` errors),
+  (b) the agent "committed but stopped before finishing" (dirty tree / unpushed
+      commits contradict the "done" claim), or
+  (c) a stale worktree `node_modules` symlink produced a flood of false
+      "cannot find module" LSP errors that were mistaken for real code errors.
+
+This is the CHEAP MECHANICAL structural gate: it re-runs the AUTHORITATIVE
+per-stack check CI would run (never a proxy) plus git-completeness and the
+stale-deps footgun, and prints ONE PASS/FAIL verdict whose output Claude reads
+INSTEAD of trusting the agent's prose. It is NOT an LLM/adversarial review
+(that's `/audit-pr`) and NOT e2e/behaviour verification (that's the `verify`
+skill).
+
+Read-only except for running the target repo's own build/test commands; it
+never writes to the repo, never commits, never installs anything.
+
+Usage:
+  verify-agent-work [TARGET] [--json] [--strict] [--no-gh] [--timeout SECS]
+    TARGET     repo / worktree path to verify (default: cwd).
+    --json     emit a structured result to stdout (machine-readable).
+    --strict   promote WARN checks (dirty tree / unpushed / stale deps) to
+               hard failures (non-zero exit).
+    --no-gh    skip the best-effort `gh` open-PR lookup.
+    --timeout  per-gate-command timeout in seconds (default: 600).
+
+Exit code: 0 when every hard check PASSed, 1 on any hard FAIL (a real gate
+failure — typecheck/test/build/vet/lint). WARN checks do not fail the exit code
+unless --strict. 2 on a usage/setup error (bad target).
+
+Config (optional): a repo-local `.verify-agent.json` (in TARGET root) can
+override the command run for a stack or skip a stack entirely:
+  {
+    "skip": ["nix"],
+    "ts":     {"typecheck": "pnpm run typecheck", "test": "pnpm test"},
+    "go":     {"build": "go build ./...", "vet": "go vet ./...", "test": "go test ./..."},
+    "python": {"lint": "ruff check .", "test": "pytest -q"},
+    "nix":    {"check": "nix flake check"}
+  }
+Any key omitted keeps the auto-detected default; a stack in "skip" is not run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+
+# --------------------------------------------------------------------------- #
+# result model
+# --------------------------------------------------------------------------- #
+
+PASS = "PASS"
+FAIL = "FAIL"
+WARN = "WARN"
+SKIP = "SKIP"
+
+# WARN checks are advisory by default; --strict promotes them to hard failures.
+_HARD_FAIL = {FAIL}
+
+
+@dataclass
+class Check:
+    name: str
+    status: str
+    summary: str
+    detail: str = ""
+    output: str = ""
+
+    def to_dict(self) -> dict:
+        d = {"name": self.name, "status": self.status, "summary": self.summary}
+        if self.detail:
+            d["detail"] = self.detail
+        if self.output:
+            d["output"] = self.output
+        return d
+
+
+@dataclass
+class Result:
+    target: str
+    stacks: list = field(default_factory=list)
+    checks: list = field(default_factory=list)
+    strict: bool = False
+
+    @property
+    def hard_fail(self) -> bool:
+        fail_states = set(_HARD_FAIL)
+        if self.strict:
+            fail_states.add(WARN)
+        return any(c.status in fail_states for c in self.checks)
+
+    @property
+    def exit_code(self) -> int:
+        return 1 if self.hard_fail else 0
+
+    @property
+    def verdict(self) -> str:
+        return FAIL if self.hard_fail else PASS
+
+    def to_dict(self) -> dict:
+        return {
+            "target": self.target,
+            "verdict": self.verdict,
+            "exit_code": self.exit_code,
+            "strict": self.strict,
+            "stacks": self.stacks,
+            "checks": [c.to_dict() for c in self.checks],
+        }
+
+
+# --------------------------------------------------------------------------- #
+# stack detection (pure, filesystem-only)
+# --------------------------------------------------------------------------- #
+
+
+def detect_stacks(path: Path) -> dict:
+    """Return {stack: metadata} for every stack whose marker files are present.
+
+    Only stacks actually present in TARGET are returned — a repo that
+    legitimately lacks one is never hard-failed for its absence.
+    """
+    stacks: dict = {}
+
+    pkg = path / "package.json"
+    if pkg.is_file():
+        meta: dict = {"scripts": {}, "expects_node_modules": False}
+        try:
+            data = json.loads(pkg.read_text())
+            meta["scripts"] = data.get("scripts", {}) or {}
+            meta["expects_node_modules"] = bool(
+                data.get("dependencies") or data.get("devDependencies")
+            )
+        except (json.JSONDecodeError, OSError):
+            meta["parse_error"] = True
+        meta["has_tsconfig"] = (path / "tsconfig.json").is_file()
+        meta["package_manager"] = detect_package_manager(path)
+        stacks["ts"] = meta
+
+    if (path / "go.mod").is_file():
+        stacks["go"] = {}
+
+    py_markers = [
+        (path / "pyproject.toml").is_file(),
+        (path / "requirements.txt").is_file(),
+        (path / "setup.py").is_file(),
+        (path / "setup.cfg").is_file(),
+    ]
+    if any(py_markers):
+        pymeta: dict = {"has_pytest": _detect_pytest(path), "has_ruff": _detect_ruff(path)}
+        stacks["python"] = pymeta
+
+    if (path / "flake.nix").is_file():
+        stacks["nix"] = {}
+
+    return stacks
+
+
+def detect_package_manager(path: Path) -> str:
+    if (path / "pnpm-lock.yaml").is_file():
+        return "pnpm"
+    if (path / "yarn.lock").is_file():
+        return "yarn"
+    if (path / "package-lock.json").is_file():
+        return "npm"
+    # bun / others fall through to npm as the safe default runner.
+    if (path / "bun.lockb").is_file():
+        return "bun"
+    return "npm"
+
+
+def _detect_pytest(path: Path) -> bool:
+    if (path / "tests").is_dir() or (path / "test").is_dir():
+        return True
+    pp = path / "pyproject.toml"
+    if pp.is_file():
+        try:
+            txt = pp.read_text()
+        except OSError:
+            return False
+        if "[tool.pytest" in txt or "pytest" in txt:
+            return True
+    if (path / "pytest.ini").is_file() or (path / "tox.ini").is_file():
+        return True
+    return False
+
+
+def _detect_ruff(path: Path) -> bool:
+    if (path / "ruff.toml").is_file() or (path / ".ruff.toml").is_file():
+        return True
+    pp = path / "pyproject.toml"
+    if pp.is_file():
+        try:
+            return "[tool.ruff" in pp.read_text()
+        except OSError:
+            return False
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# config
+# --------------------------------------------------------------------------- #
+
+
+def load_config(path: Path) -> dict:
+    cfg = path / ".verify-agent.json"
+    if not cfg.is_file():
+        return {}
+    try:
+        data = json.loads(cfg.read_text())
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+# --------------------------------------------------------------------------- #
+# stale-worktree node_modules footgun
+# --------------------------------------------------------------------------- #
+
+
+def check_node_modules(path: Path, ts_meta: dict) -> Optional[Check]:
+    """Attribute a missing/broken node_modules to the ENVIRONMENT, not to code.
+
+    Returns a WARN Check when node_modules is unusable (so a flood of "cannot
+    find module" is NOT mistaken for real code errors), or None when it is
+    usable / not required. When it returns a Check the caller SKIPS the TS
+    typecheck/test gates.
+    """
+    if not ts_meta.get("expects_node_modules"):
+        return None  # nothing to install → no footgun
+    nm = path / "node_modules"
+    if nm.is_symlink():
+        target = os.path.realpath(nm)
+        if not os.path.exists(target):
+            return Check(
+                "env:node_modules",
+                WARN,
+                "node_modules is a BROKEN symlink (stale worktree footgun)",
+                detail=(
+                    f"{nm} -> {os.readlink(nm)} (target missing). Any "
+                    "'cannot find module' errors are an ENV issue, not code. "
+                    "Re-install deps in this worktree."
+                ),
+            )
+        return None  # symlink resolves — usable
+    if not nm.exists():
+        return Check(
+            "env:node_modules",
+            WARN,
+            "node_modules absent though package.json declares deps",
+            detail=(
+                "Dependencies are not installed in this target. Typecheck/test "
+                "were SKIPPED — a 'cannot find module' flood here is an ENV "
+                "issue, not real code errors. Install deps, then re-run."
+            ),
+        )
+    return None  # real directory present → usable
+
+
+# --------------------------------------------------------------------------- #
+# git-completeness ("committed but stopped" failure)
+# --------------------------------------------------------------------------- #
+
+
+def _git(path: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(path), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def git_state(path: Path) -> dict:
+    """Read-only snapshot of the target's git state."""
+    inside = _git(path, "rev-parse", "--is-inside-work-tree")
+    if inside.returncode != 0 or inside.stdout.strip() != "true":
+        return {"is_repo": False}
+
+    st: dict = {"is_repo": True}
+    st["branch"] = _git(path, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+
+    porcelain = _git(path, "status", "--porcelain").stdout
+    lines = [ln for ln in porcelain.splitlines() if ln.strip()]
+    st["untracked"] = sum(1 for ln in lines if ln.startswith("??"))
+    st["tracked_changes"] = sum(1 for ln in lines if not ln.startswith("??"))
+    st["dirty"] = bool(lines)
+
+    upstream = _git(path, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+    if upstream.returncode == 0 and upstream.stdout.strip():
+        st["upstream"] = upstream.stdout.strip()
+        counts = _git(path, "rev-list", "--left-right", "--count", "@{u}...HEAD")
+        if counts.returncode == 0 and counts.stdout.strip():
+            behind, ahead = counts.stdout.split()
+            st["behind"] = int(behind)
+            st["ahead"] = int(ahead)
+        else:
+            st["behind"] = 0
+            st["ahead"] = 0
+    else:
+        st["upstream"] = None
+        # No upstream: are there any commits at all that would need pushing?
+        head = _git(path, "rev-parse", "--verify", "HEAD")
+        st["has_commits"] = head.returncode == 0
+    return st
+
+
+def check_git(state: dict, path: Path, use_gh: bool = True) -> list:
+    if not state.get("is_repo"):
+        return [Check("git", SKIP, "target is not a git repository")]
+
+    checks = []
+    branch = state.get("branch", "?")
+
+    # clean tree — a dirty tree contradicts a "done / committed" claim.
+    if state.get("dirty"):
+        parts = []
+        if state.get("tracked_changes"):
+            parts.append(f"{state['tracked_changes']} uncommitted change(s)")
+        if state.get("untracked"):
+            parts.append(f"{state['untracked']} untracked file(s)")
+        checks.append(
+            Check(
+                "git:clean-tree",
+                WARN,
+                "working tree is DIRTY — contradicts a 'done/committed' claim",
+                detail=f"[{branch}] " + ", ".join(parts),
+            )
+        )
+    else:
+        checks.append(Check("git:clean-tree", PASS, f"working tree clean [{branch}]"))
+
+    # pushed — unpushed commits are the "committed but stopped" tell.
+    if state.get("upstream"):
+        ahead = state.get("ahead", 0)
+        behind = state.get("behind", 0)
+        if ahead:
+            checks.append(
+                Check(
+                    "git:pushed",
+                    WARN,
+                    f"{ahead} commit(s) NOT pushed to {state['upstream']}",
+                    detail=(
+                        f"[{branch}] ahead {ahead}"
+                        + (f", behind {behind}" if behind else "")
+                    ),
+                )
+            )
+        else:
+            checks.append(
+                Check("git:pushed", PASS, f"in sync with {state['upstream']}")
+            )
+    else:
+        if state.get("has_commits"):
+            checks.append(
+                Check(
+                    "git:pushed",
+                    WARN,
+                    "branch has NO upstream — commits are not pushed anywhere",
+                    detail=f"[{branch}] set an upstream and push, or confirm intentional",
+                )
+            )
+        else:
+            checks.append(Check("git:pushed", SKIP, "no commits / no upstream yet"))
+
+    # open PR (best-effort, informational).
+    if use_gh:
+        checks.append(_check_pr(path, branch))
+    return checks
+
+
+def _check_pr(path: Path, branch: str) -> Check:
+    try:
+        res = subprocess.run(
+            [
+                "gh", "pr", "list", "--head", branch, "--state", "open",
+                "--json", "number,url,title",
+            ],
+            cwd=str(path),
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return Check("git:pr", SKIP, "gh unavailable — open-PR lookup skipped")
+    if res.returncode != 0:
+        return Check("git:pr", SKIP, "gh open-PR lookup failed (no repo/auth?)")
+    try:
+        prs = json.loads(res.stdout or "[]")
+    except json.JSONDecodeError:
+        return Check("git:pr", SKIP, "gh returned unparseable output")
+    if prs:
+        pr = prs[0]
+        return Check(
+            "git:pr", PASS, f"open PR #{pr['number']} for {branch}", detail=pr["url"]
+        )
+    return Check("git:pr", WARN, f"no open PR for branch {branch}")
+
+
+# --------------------------------------------------------------------------- #
+# per-stack authoritative gate plan
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class GateSpec:
+    name: str
+    cmd: list
+    cwd: Path
+
+
+def build_gate_plan(
+    path: Path, stacks: dict, config: dict, node_ok: bool
+) -> tuple:
+    """Return (specs, skips) — the authoritative commands to run + SKIP checks.
+
+    Pure: computes WHAT to run without running anything (so tests can assert
+    the plan). `node_ok` gates the TS commands so stale-deps failures are not
+    surfaced as code errors.
+    """
+    skip_stacks = set(config.get("skip", []) or [])
+    specs: list = []
+    skips: list = []
+
+    def ov(stack: str, key: str) -> Optional[str]:
+        return (config.get(stack) or {}).get(key)
+
+    # -- TypeScript / JS ---------------------------------------------------- #
+    if "ts" in stacks and "ts" not in skip_stacks:
+        meta = stacks["ts"]
+        pm = meta.get("package_manager", "npm")
+        scripts = meta.get("scripts", {})
+        if not node_ok:
+            skips.append(
+                Check(
+                    "ts:typecheck",
+                    SKIP,
+                    "skipped — node_modules not installed (see env:node_modules)",
+                )
+            )
+            skips.append(
+                Check(
+                    "ts:test",
+                    SKIP,
+                    "skipped — node_modules not installed (see env:node_modules)",
+                )
+            )
+        else:
+            # AUTHORITATIVE typecheck — the repo's `typecheck` script if it has
+            # one, else `tsc --noEmit` when a tsconfig exists. Never `build`
+            # (a bundler build does NOT typecheck).
+            tc = ov("ts", "typecheck")
+            if tc:
+                specs.append(GateSpec("ts:typecheck", _shell(tc), path))
+            elif "typecheck" in scripts:
+                specs.append(GateSpec("ts:typecheck", _run_script(pm, "typecheck"), path))
+            elif meta.get("has_tsconfig"):
+                specs.append(GateSpec("ts:typecheck", _exec_tsc(pm), path))
+            else:
+                skips.append(
+                    Check("ts:typecheck", SKIP, "no typecheck script / tsconfig.json")
+                )
+
+            tt = ov("ts", "test")
+            if tt:
+                specs.append(GateSpec("ts:test", _shell(tt), path))
+            elif "test" in scripts:
+                specs.append(GateSpec("ts:test", _run_script(pm, "test"), path))
+            else:
+                skips.append(Check("ts:test", SKIP, "no test script"))
+
+    # -- Go ----------------------------------------------------------------- #
+    if "go" in stacks and "go" not in skip_stacks:
+        for key, default in (
+            ("build", "go build ./..."),
+            ("vet", "go vet ./..."),
+            ("test", "go test -race ./..."),
+        ):
+            cmd = ov("go", key) or default
+            specs.append(GateSpec(f"go:{key}", _shell(cmd), path))
+
+    # -- Python ------------------------------------------------------------- #
+    if "python" in stacks and "python" not in skip_stacks:
+        meta = stacks["python"]
+        lint = ov("python", "lint")
+        if lint:
+            specs.append(GateSpec("python:lint", _shell(lint), path))
+        elif meta.get("has_ruff"):
+            specs.append(GateSpec("python:lint", ["ruff", "check", "."], path))
+        else:
+            skips.append(Check("python:lint", SKIP, "no ruff config"))
+
+        test = ov("python", "test")
+        if test:
+            specs.append(GateSpec("python:test", _shell(test), path))
+        elif meta.get("has_pytest"):
+            specs.append(GateSpec("python:test", ["python", "-m", "pytest", "-q"], path))
+        else:
+            skips.append(Check("python:test", SKIP, "no pytest config detected"))
+
+    # -- Nix ---------------------------------------------------------------- #
+    if "nix" in stacks and "nix" not in skip_stacks:
+        chk = ov("nix", "check")
+        if chk:
+            # user opted into the fuller (slow) gate, e.g. `nix flake check`.
+            specs.append(GateSpec("nix:check", _shell(chk), path))
+        else:
+            # default: the CHEAP authoritative parse — fast, side-effect-free.
+            # `nix flake check` is the fuller gate; enable it via config.
+            specs.append(
+                GateSpec(
+                    "nix:parse",
+                    ["nix-instantiate", "--parse", str(path / "flake.nix")],
+                    path,
+                )
+            )
+
+    return specs, skips
+
+
+def _shell(cmd: str) -> list:
+    return ["bash", "-c", cmd]
+
+
+def _run_script(pm: str, script: str) -> list:
+    if pm == "npm":
+        return ["npm", "run", script]
+    # pnpm / yarn / bun: `<pm> run <script>` is universally valid.
+    return [pm, "run", script]
+
+
+def _exec_tsc(pm: str) -> list:
+    if pm == "pnpm":
+        return ["pnpm", "exec", "tsc", "--noEmit"]
+    if pm == "yarn":
+        return ["yarn", "tsc", "--noEmit"]
+    if pm == "bun":
+        return ["bunx", "tsc", "--noEmit"]
+    return ["npx", "--no-install", "tsc", "--noEmit"]
+
+
+# --------------------------------------------------------------------------- #
+# gate execution
+# --------------------------------------------------------------------------- #
+
+_MAX_OUTPUT_LINES = 40
+
+
+def _truncate(text: str, max_lines: int = _MAX_OUTPUT_LINES) -> str:
+    text = text.rstrip("\n")
+    if not text:
+        return ""
+    lines = text.splitlines()
+    if len(lines) <= max_lines:
+        return text
+    hidden = len(lines) - max_lines
+    tail = lines[-max_lines:]
+    return f"... [{hidden} earlier line(s) truncated] ...\n" + "\n".join(tail)
+
+
+def run_gate(spec: GateSpec, timeout: int = 600) -> Check:
+    try:
+        res = subprocess.run(
+            spec.cmd,
+            cwd=str(spec.cwd),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        tool = spec.cmd[0]
+        return Check(
+            spec.name,
+            WARN,
+            f"tool not found: {tool} — toolchain missing, gate not run",
+        )
+    except subprocess.TimeoutExpired:
+        return Check(
+            spec.name, FAIL, f"TIMEOUT after {timeout}s: {' '.join(spec.cmd)}"
+        )
+    combined = (res.stdout or "") + (res.stderr or "")
+    if res.returncode == 0:
+        return Check(spec.name, PASS, f"$ {' '.join(spec.cmd)}")
+    return Check(
+        spec.name,
+        FAIL,
+        f"exit {res.returncode}: $ {' '.join(spec.cmd)}",
+        output=_truncate(combined),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# orchestration
+# --------------------------------------------------------------------------- #
+
+
+def verify(
+    target: Path,
+    use_gh: bool = True,
+    strict: bool = False,
+    timeout: int = 600,
+    gate_runner: Callable[[GateSpec, int], Check] = run_gate,
+) -> Result:
+    target = target.resolve()
+    result = Result(target=str(target), strict=strict)
+
+    stacks = detect_stacks(target)
+    result.stacks = sorted(stacks.keys())
+    config = load_config(target)
+
+    # 1. env footgun (stale node_modules) — attributed to ENV, not code.
+    node_ok = True
+    if "ts" in stacks:
+        nm_check = check_node_modules(target, stacks["ts"])
+        if nm_check is not None:
+            result.checks.append(nm_check)
+            node_ok = False
+
+    # 2. git completeness.
+    result.checks.extend(check_git(git_state(target), target, use_gh=use_gh))
+
+    # 3. authoritative per-stack gates.
+    specs, skips = build_gate_plan(target, stacks, config, node_ok)
+    result.checks.extend(skips)
+    for spec in specs:
+        result.checks.append(gate_runner(spec, timeout))
+
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# rendering
+# --------------------------------------------------------------------------- #
+
+_ICON = {PASS: "PASS", FAIL: "FAIL", WARN: "WARN", SKIP: "skip"}
+
+
+def render_text(result: Result) -> str:
+    lines = []
+    lines.append(f"verify-agent-work: {result.target}")
+    lines.append(
+        f"stacks: {', '.join(result.stacks) if result.stacks else '(none detected)'}"
+    )
+    lines.append("")
+    for c in result.checks:
+        lines.append(f"  [{_ICON.get(c.status, c.status):4}] {c.name:20} {c.summary}")
+        if c.detail:
+            lines.append(f"         {c.detail}")
+        if c.output:
+            for oln in c.output.splitlines():
+                lines.append(f"         | {oln}")
+    lines.append("")
+    n_fail = sum(1 for c in result.checks if c.status == FAIL)
+    n_warn = sum(1 for c in result.checks if c.status == WARN)
+    if result.verdict == PASS:
+        verdict = f"VERDICT: PASS ({n_warn} warning(s))"
+    else:
+        reason = f"{n_fail} hard failure(s)"
+        if result.strict and n_warn:
+            reason += f" + {n_warn} warning(s) [strict]"
+        verdict = f"VERDICT: FAIL — {reason}. Do NOT trust an agent 'done' claim over this."
+    lines.append(verdict)
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# cli
+# --------------------------------------------------------------------------- #
+
+
+def main(argv: Optional[list] = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="verify-agent-work",
+        description="Deterministic post-agent verification gate.",
+    )
+    p.add_argument("target", nargs="?", default=".", help="repo/worktree path (default: cwd)")
+    p.add_argument("--json", action="store_true", help="emit structured JSON")
+    p.add_argument("--strict", action="store_true", help="promote WARN to hard fail")
+    p.add_argument("--no-gh", action="store_true", help="skip the gh open-PR lookup")
+    p.add_argument("--timeout", type=int, default=600, help="per-gate timeout (s)")
+    args = p.parse_args(argv)
+
+    target = Path(args.target)
+    if not target.exists():
+        print(f"verify-agent-work: target does not exist: {target}", file=sys.stderr)
+        return 2
+    if not target.is_dir():
+        print(f"verify-agent-work: target is not a directory: {target}", file=sys.stderr)
+        return 2
+
+    result = verify(
+        target,
+        use_gh=not args.no_gh,
+        strict=args.strict,
+        timeout=args.timeout,
+    )
+
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2))
+    else:
+        print(render_text(result))
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify-agent-work
+++ b/scripts/verify-agent-work
@@ -13,37 +13,53 @@ gate closes: an agent claims "build green / committed / done" but
 
 This is the CHEAP MECHANICAL structural gate: it re-runs the AUTHORITATIVE
 per-stack check CI would run (never a proxy) plus git-completeness and the
-stale-deps footgun, and prints ONE PASS/FAIL verdict whose output Claude reads
-INSTEAD of trusting the agent's prose. It is NOT an LLM/adversarial review
-(that's `/audit-pr`) and NOT e2e/behaviour verification (that's the `verify`
-skill).
+stale-deps footgun, and prints ONE verdict whose output Claude reads INSTEAD of
+trusting the agent's prose. It is NOT an LLM/adversarial review (that's
+`/audit-pr`) and NOT e2e/behaviour verification (that's the `verify` skill).
 
-Read-only except for running the target repo's own build/test commands; it
-never writes to the repo, never commits, never installs anything.
+CORE INVARIANT (anti-false-green): a stack that is DETECTED but whose
+authoritative gate did NOT actually execute is reported as INCOMPLETE and makes
+the overall verdict non-PASS with a non-zero exit — a gate that could not run is
+never silently counted as green. A repo with NO stack present (nothing to
+verify) is still a legitimate PASS. The distinction is *detected-but-unrun*
+(bad, non-zero) vs *not-present* (fine).
+
+SECURITY / TRUST: this gate runs the TARGET repo's OWN build/test commands and
+honours a repo-local `.verify-agent.json` — that is arbitrary code execution BY
+DESIGN. Do NOT run it against a repo whose contents or `.verify-agent.json` you
+do not trust; it will execute them. Per this repo's CLAUDE.md, agent-handed
+worktrees and fuzzyclaw task data are UNTRUSTED — treat a worktree you did not
+create the same way (inspect before verifying).
+
+Read-only w.r.t. the repo contents (never writes/commits/installs), except for
+running those build/test commands.
 
 Usage:
   verify-agent-work [TARGET] [--json] [--strict] [--no-gh] [--timeout SECS]
     TARGET     repo / worktree path to verify (default: cwd).
     --json     emit a structured result to stdout (machine-readable).
-    --strict   promote WARN checks (dirty tree / unpushed / stale deps) to
-               hard failures (non-zero exit).
+    --strict   ALSO promote advisory WARN checks (dirty tree / unpushed) to
+               hard failures. (INCOMPLETE is ALWAYS a hard non-pass, strict or
+               not.)
     --no-gh    skip the best-effort `gh` open-PR lookup.
     --timeout  per-gate-command timeout in seconds (default: 600).
 
-Exit code: 0 when every hard check PASSed, 1 on any hard FAIL (a real gate
-failure — typecheck/test/build/vet/lint). WARN checks do not fail the exit code
-unless --strict. 2 on a usage/setup error (bad target).
+Exit code:
+  0  every detected stack's gate ran and PASSed (WARNs allowed unless --strict).
+  1  any hard non-pass — a gate FAILed, or a detected stack was INCOMPLETE
+     (gate could not run), or (with --strict) any WARN.
+  2  usage/setup error (bad target).
 
 Config (optional): a repo-local `.verify-agent.json` (in TARGET root) can
 override the command run for a stack or skip a stack entirely:
   {
     "skip": ["nix"],
     "ts":     {"typecheck": "pnpm run typecheck", "test": "pnpm test"},
-    "go":     {"build": "go build ./...", "vet": "go vet ./...", "test": "go test ./..."},
-    "python": {"lint": "ruff check .", "test": "pytest -q"},
-    "nix":    {"check": "nix flake check"}
+    "go":     {"build": "go build ./...", "vet": "go vet ./...", "test": "go test ./...", "race": false},
+    "python": {"lint": "ruff check .", "test": "pytest -q"}, "nix": {"check": "nix flake check"}
   }
-Any key omitted keeps the auto-detected default; a stack in "skip" is not run.
+Any key omitted keeps the auto-detected default; a stack in "skip" is not run
+(and does not count against the verdict).
 """
 
 from __future__ import annotations
@@ -51,6 +67,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
 from dataclasses import dataclass, field
@@ -63,11 +80,13 @@ from typing import Callable, Optional
 
 PASS = "PASS"
 FAIL = "FAIL"
+INCOMPLETE = "INCOMPLETE"  # detected stack, gate could NOT run → hard non-pass
 WARN = "WARN"
 SKIP = "SKIP"
 
-# WARN checks are advisory by default; --strict promotes them to hard failures.
-_HARD_FAIL = {FAIL}
+# States that make the overall verdict a hard non-pass (non-zero exit).
+# INCOMPLETE is unconditional; WARN only under --strict.
+_NONPASS = {FAIL, INCOMPLETE}
 
 
 @dataclass
@@ -94,12 +113,15 @@ class Result:
     checks: list = field(default_factory=list)
     strict: bool = False
 
+    def _statuses(self) -> set:
+        return {c.status for c in self.checks}
+
     @property
     def hard_fail(self) -> bool:
-        fail_states = set(_HARD_FAIL)
+        fail_states = set(_NONPASS)
         if self.strict:
             fail_states.add(WARN)
-        return any(c.status in fail_states for c in self.checks)
+        return bool(self._statuses() & fail_states)
 
     @property
     def exit_code(self) -> int:
@@ -107,7 +129,14 @@ class Result:
 
     @property
     def verdict(self) -> str:
-        return FAIL if self.hard_fail else PASS
+        s = self._statuses()
+        if FAIL in s:
+            return FAIL
+        if INCOMPLETE in s:
+            return INCOMPLETE
+        if self.strict and WARN in s:
+            return FAIL
+        return PASS
 
     def to_dict(self) -> dict:
         return {
@@ -136,6 +165,7 @@ def detect_stacks(path: Path) -> dict:
     pkg = path / "package.json"
     if pkg.is_file():
         meta: dict = {"scripts": {}, "expects_node_modules": False}
+        data: dict = {}
         try:
             data = json.loads(pkg.read_text())
             meta["scripts"] = data.get("scripts", {}) or {}
@@ -146,6 +176,8 @@ def detect_stacks(path: Path) -> dict:
             meta["parse_error"] = True
         meta["has_tsconfig"] = (path / "tsconfig.json").is_file()
         meta["package_manager"] = detect_package_manager(path)
+        meta["workspace_globs"] = _collect_workspace_globs(path, data)
+        meta["is_workspace_root"] = bool(meta["workspace_globs"])
         stacks["ts"] = meta
 
     if (path / "go.mod").is_file():
@@ -158,8 +190,10 @@ def detect_stacks(path: Path) -> dict:
         (path / "setup.cfg").is_file(),
     ]
     if any(py_markers):
-        pymeta: dict = {"has_pytest": _detect_pytest(path), "has_ruff": _detect_ruff(path)}
-        stacks["python"] = pymeta
+        stacks["python"] = {
+            "has_pytest": _detect_pytest(path),
+            "has_ruff": _detect_ruff(path),
+        }
 
     if (path / "flake.nix").is_file():
         stacks["nix"] = {}
@@ -174,10 +208,53 @@ def detect_package_manager(path: Path) -> str:
         return "yarn"
     if (path / "package-lock.json").is_file():
         return "npm"
-    # bun / others fall through to npm as the safe default runner.
     if (path / "bun.lockb").is_file():
         return "bun"
-    return "npm"
+    return "npm"  # safe default runner
+
+
+def _collect_workspace_globs(path: Path, pkg_data: dict) -> list:
+    """Workspace member globs from package.json / pnpm-workspace.yaml / lerna."""
+    globs: list = []
+    ws = pkg_data.get("workspaces")
+    if isinstance(ws, list):
+        globs += [g for g in ws if isinstance(g, str)]
+    elif isinstance(ws, dict):
+        globs += [g for g in ws.get("packages", []) if isinstance(g, str)]
+
+    pw = path / "pnpm-workspace.yaml"
+    if pw.is_file():
+        globs += _parse_pnpm_workspace(pw)
+
+    lerna = path / "lerna.json"
+    if lerna.is_file():
+        try:
+            ld = json.loads(lerna.read_text())
+            globs += [g for g in ld.get("packages", []) if isinstance(g, str)]
+        except (json.JSONDecodeError, OSError):
+            pass
+    return globs
+
+
+def _parse_pnpm_workspace(pw: Path) -> list:
+    """Minimal YAML: collect `- glob` entries under a top-level `packages:` key."""
+    globs: list = []
+    in_pkgs = False
+    try:
+        lines = pw.read_text().splitlines()
+    except OSError:
+        return globs
+    for line in lines:
+        s = line.strip()
+        if s.startswith("packages:"):
+            in_pkgs = True
+            continue
+        if in_pkgs:
+            if s.startswith("- "):
+                globs.append(s[2:].strip().strip("'\""))
+            elif s and not s.startswith("#") and line[:1] not in (" ", "\t"):
+                in_pkgs = False  # left the packages block
+    return globs
 
 
 def _detect_pytest(path: Path) -> bool:
@@ -234,8 +311,8 @@ def check_node_modules(path: Path, ts_meta: dict) -> Optional[Check]:
 
     Returns a WARN Check when node_modules is unusable (so a flood of "cannot
     find module" is NOT mistaken for real code errors), or None when it is
-    usable / not required. When it returns a Check the caller SKIPS the TS
-    typecheck/test gates.
+    usable / not required. When it returns a Check the TS gate is treated as
+    INCOMPLETE (it genuinely could not run) — never as a green SKIP.
     """
     if not ts_meta.get("expects_node_modules"):
         return None  # nothing to install → no footgun
@@ -260,9 +337,9 @@ def check_node_modules(path: Path, ts_meta: dict) -> Optional[Check]:
             WARN,
             "node_modules absent though package.json declares deps",
             detail=(
-                "Dependencies are not installed in this target. Typecheck/test "
-                "were SKIPPED — a 'cannot find module' flood here is an ENV "
-                "issue, not real code errors. Install deps, then re-run."
+                "Dependencies are not installed in this target. A 'cannot find "
+                "module' flood here is an ENV issue, not real code errors. "
+                "Install deps, then re-run."
             ),
         )
     return None  # real directory present → usable
@@ -272,13 +349,21 @@ def check_node_modules(path: Path, ts_meta: dict) -> Optional[Check]:
 # git-completeness ("committed but stopped" failure)
 # --------------------------------------------------------------------------- #
 
+_GIT_TIMEOUT = 30
+
 
 def _git(path: Path, *args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        ["git", "-C", str(path), *args],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        return subprocess.run(
+            ["git", "-C", str(path), *args],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        # bounded so a hung/absent git can't wedge the gate; caller treats a
+        # non-zero rc as "unknown".
+        return subprocess.CompletedProcess(args, returncode=124, stdout="", stderr="")
 
 
 def git_state(path: Path) -> dict:
@@ -309,7 +394,6 @@ def git_state(path: Path) -> dict:
             st["ahead"] = 0
     else:
         st["upstream"] = None
-        # No upstream: are there any commits at all that would need pushing?
         head = _git(path, "rev-parse", "--verify", "HEAD")
         st["has_commits"] = head.returncode == 0
     return st
@@ -322,7 +406,6 @@ def check_git(state: dict, path: Path, use_gh: bool = True) -> list:
     checks = []
     branch = state.get("branch", "?")
 
-    # clean tree — a dirty tree contradicts a "done / committed" claim.
     if state.get("dirty"):
         parts = []
         if state.get("tracked_changes"):
@@ -340,7 +423,6 @@ def check_git(state: dict, path: Path, use_gh: bool = True) -> list:
     else:
         checks.append(Check("git:clean-tree", PASS, f"working tree clean [{branch}]"))
 
-    # pushed — unpushed commits are the "committed but stopped" tell.
     if state.get("upstream"):
         ahead = state.get("ahead", 0)
         behind = state.get("behind", 0)
@@ -373,7 +455,6 @@ def check_git(state: dict, path: Path, use_gh: bool = True) -> list:
         else:
             checks.append(Check("git:pushed", SKIP, "no commits / no upstream yet"))
 
-    # open PR (best-effort, informational).
     if use_gh:
         checks.append(_check_pr(path, branch))
     return checks
@@ -417,115 +498,12 @@ class GateSpec:
     name: str
     cmd: list
     cwd: Path
+    tool: str = ""  # binary that must exist on PATH for this gate to run
 
 
-def build_gate_plan(
-    path: Path, stacks: dict, config: dict, node_ok: bool
-) -> tuple:
-    """Return (specs, skips) — the authoritative commands to run + SKIP checks.
-
-    Pure: computes WHAT to run without running anything (so tests can assert
-    the plan). `node_ok` gates the TS commands so stale-deps failures are not
-    surfaced as code errors.
-    """
-    skip_stacks = set(config.get("skip", []) or [])
-    specs: list = []
-    skips: list = []
-
-    def ov(stack: str, key: str) -> Optional[str]:
-        return (config.get(stack) or {}).get(key)
-
-    # -- TypeScript / JS ---------------------------------------------------- #
-    if "ts" in stacks and "ts" not in skip_stacks:
-        meta = stacks["ts"]
-        pm = meta.get("package_manager", "npm")
-        scripts = meta.get("scripts", {})
-        if not node_ok:
-            skips.append(
-                Check(
-                    "ts:typecheck",
-                    SKIP,
-                    "skipped — node_modules not installed (see env:node_modules)",
-                )
-            )
-            skips.append(
-                Check(
-                    "ts:test",
-                    SKIP,
-                    "skipped — node_modules not installed (see env:node_modules)",
-                )
-            )
-        else:
-            # AUTHORITATIVE typecheck — the repo's `typecheck` script if it has
-            # one, else `tsc --noEmit` when a tsconfig exists. Never `build`
-            # (a bundler build does NOT typecheck).
-            tc = ov("ts", "typecheck")
-            if tc:
-                specs.append(GateSpec("ts:typecheck", _shell(tc), path))
-            elif "typecheck" in scripts:
-                specs.append(GateSpec("ts:typecheck", _run_script(pm, "typecheck"), path))
-            elif meta.get("has_tsconfig"):
-                specs.append(GateSpec("ts:typecheck", _exec_tsc(pm), path))
-            else:
-                skips.append(
-                    Check("ts:typecheck", SKIP, "no typecheck script / tsconfig.json")
-                )
-
-            tt = ov("ts", "test")
-            if tt:
-                specs.append(GateSpec("ts:test", _shell(tt), path))
-            elif "test" in scripts:
-                specs.append(GateSpec("ts:test", _run_script(pm, "test"), path))
-            else:
-                skips.append(Check("ts:test", SKIP, "no test script"))
-
-    # -- Go ----------------------------------------------------------------- #
-    if "go" in stacks and "go" not in skip_stacks:
-        for key, default in (
-            ("build", "go build ./..."),
-            ("vet", "go vet ./..."),
-            ("test", "go test -race ./..."),
-        ):
-            cmd = ov("go", key) or default
-            specs.append(GateSpec(f"go:{key}", _shell(cmd), path))
-
-    # -- Python ------------------------------------------------------------- #
-    if "python" in stacks and "python" not in skip_stacks:
-        meta = stacks["python"]
-        lint = ov("python", "lint")
-        if lint:
-            specs.append(GateSpec("python:lint", _shell(lint), path))
-        elif meta.get("has_ruff"):
-            specs.append(GateSpec("python:lint", ["ruff", "check", "."], path))
-        else:
-            skips.append(Check("python:lint", SKIP, "no ruff config"))
-
-        test = ov("python", "test")
-        if test:
-            specs.append(GateSpec("python:test", _shell(test), path))
-        elif meta.get("has_pytest"):
-            specs.append(GateSpec("python:test", ["python", "-m", "pytest", "-q"], path))
-        else:
-            skips.append(Check("python:test", SKIP, "no pytest config detected"))
-
-    # -- Nix ---------------------------------------------------------------- #
-    if "nix" in stacks and "nix" not in skip_stacks:
-        chk = ov("nix", "check")
-        if chk:
-            # user opted into the fuller (slow) gate, e.g. `nix flake check`.
-            specs.append(GateSpec("nix:check", _shell(chk), path))
-        else:
-            # default: the CHEAP authoritative parse — fast, side-effect-free.
-            # `nix flake check` is the fuller gate; enable it via config.
-            specs.append(
-                GateSpec(
-                    "nix:parse",
-                    ["nix-instantiate", "--parse", str(path / "flake.nix")],
-                    path,
-                )
-            )
-
-    return specs, skips
+def _first_tok(cmd: str) -> str:
+    parts = cmd.split()
+    return parts[0] if parts else ""
 
 
 def _shell(cmd: str) -> list:
@@ -535,8 +513,7 @@ def _shell(cmd: str) -> list:
 def _run_script(pm: str, script: str) -> list:
     if pm == "npm":
         return ["npm", "run", script]
-    # pnpm / yarn / bun: `<pm> run <script>` is universally valid.
-    return [pm, "run", script]
+    return [pm, "run", script]  # pnpm / yarn / bun: `<pm> run <script>`
 
 
 def _exec_tsc(pm: str) -> list:
@@ -549,11 +526,228 @@ def _exec_tsc(pm: str) -> list:
     return ["npx", "--no-install", "tsc", "--noEmit"]
 
 
+def _ts_unit_specs(unit: Path, label: str, pm: str, scripts: dict, has_tsconfig: bool) -> list:
+    """Resolvable authoritative gates for ONE package dir (root or workspace member)."""
+    suffix = f"[{label}]" if label else ""
+    specs: list = []
+    if "typecheck" in scripts:
+        specs.append(GateSpec(f"ts:typecheck{suffix}", _run_script(pm, "typecheck"), unit, tool=pm))
+    elif has_tsconfig:
+        cmd = _exec_tsc(pm)
+        specs.append(GateSpec(f"ts:typecheck{suffix}", cmd, unit, tool=cmd[0]))
+    if "test" in scripts:
+        specs.append(GateSpec(f"ts:test{suffix}", _run_script(pm, "test"), unit, tool=pm))
+    return specs
+
+
+def _read_pkg_scripts(unit: Path) -> dict:
+    try:
+        data = json.loads((unit / "package.json").read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return data.get("scripts", {}) or {}
+
+
+def _resolve_workspace_dirs(path: Path, globs: list) -> list:
+    dirs: list = []
+    seen: set = set()
+    for g in globs:
+        g = g.strip().strip("'\"")
+        if not g or g.startswith("!"):
+            continue
+        try:
+            matches = path.glob(g)
+        except (ValueError, OSError):
+            continue
+        for p in matches:
+            if not (p.is_dir() and (p / "package.json").is_file()):
+                continue
+            if "node_modules" in p.parts:
+                continue
+            rp = p.resolve()
+            if rp not in seen:
+                seen.add(rp)
+                dirs.append(p)
+    return sorted(dirs)
+
+
+def _plan_ts(path: Path, meta: dict, config: dict) -> list:
+    ov = config.get("ts") or {}
+    tc_ov, tt_ov = ov.get("typecheck"), ov.get("test")
+    if tc_ov or tt_ov:  # explicit config is authoritative — don't second-guess
+        specs = []
+        if tc_ov:
+            specs.append(GateSpec("ts:typecheck", _shell(tc_ov), path, tool=_first_tok(tc_ov)))
+        if tt_ov:
+            specs.append(GateSpec("ts:test", _shell(tt_ov), path, tool=_first_tok(tt_ov)))
+        return specs
+
+    pm = meta.get("package_manager", "npm")
+    root_specs = _ts_unit_specs(path, "", pm, meta.get("scripts", {}), meta.get("has_tsconfig"))
+    if root_specs:
+        return root_specs
+
+    # No root-level gate — fan out across workspace members if this is a monorepo
+    # root, so a workspaces repo with no root typecheck/test script is not a
+    # silent green.
+    if meta.get("is_workspace_root"):
+        specs = []
+        for member in _resolve_workspace_dirs(path, meta.get("workspace_globs", [])):
+            m_scripts = _read_pkg_scripts(member)
+            m_tsconfig = (member / "tsconfig.json").is_file()
+            specs.extend(_ts_unit_specs(member, member.name, pm, m_scripts, m_tsconfig))
+        return specs
+    return []
+
+
+def _cgo_available(config: dict) -> bool:
+    ge = config.get("go") or {}
+    if "race" in ge:
+        return bool(ge["race"])
+    if os.environ.get("CGO_ENABLED") == "0":
+        return False
+    return any(shutil.which(c) for c in ("cc", "gcc", "clang"))
+
+
+def _nested_go_modules(path: Path) -> list:
+    mods: list = []
+    root = os.path.abspath(path)
+    for dirpath, dirnames, filenames in os.walk(path):
+        dirnames[:] = [
+            d for d in dirnames
+            if d not in (".git", "node_modules", "vendor", "testdata") and not d.startswith(".")
+        ]
+        if os.path.abspath(dirpath) == root:
+            continue
+        if "go.mod" in filenames:
+            mods.append(Path(dirpath))
+            dirnames[:] = []  # a module's own `./...` covers its subdirs
+    return sorted(mods)
+
+
+def _plan_python(path: Path, meta: dict, config: dict) -> list:
+    ov = config.get("python") or {}
+    specs: list = []
+    lint = ov.get("lint")
+    if lint:
+        specs.append(GateSpec("python:lint", _shell(lint), path, tool=_first_tok(lint)))
+    elif meta.get("has_ruff"):
+        specs.append(GateSpec("python:lint", ["ruff", "check", "."], path, tool="ruff"))
+    test = ov.get("test")
+    if test:
+        specs.append(GateSpec("python:test", _shell(test), path, tool=_first_tok(test)))
+    elif meta.get("has_pytest"):
+        specs.append(GateSpec("python:test", ["python", "-m", "pytest", "-q"], path, tool="python"))
+    return specs
+
+
+def build_gate_plan(path: Path, stacks: dict, config: dict, node_ok: bool) -> tuple:
+    """Return (specs, aux_checks).
+
+    `specs` are the authoritative commands to run. `aux_checks` carries SKIP
+    notes AND — critically — an INCOMPLETE check for any DETECTED stack whose
+    gate could not be resolved/run, so such a stack never counts as green.
+    Pure: computes WHAT to run without running anything.
+    """
+    skip_stacks = set(config.get("skip", []) or [])
+    specs: list = []
+    aux: list = []
+
+    def ov(stack: str, key: str) -> Optional[str]:
+        return (config.get(stack) or {}).get(key)
+
+    # -- TypeScript / JS ---------------------------------------------------- #
+    if "ts" in stacks and "ts" not in skip_stacks:
+        meta = stacks["ts"]
+        if not node_ok:
+            aux.append(
+                Check(
+                    "ts",
+                    INCOMPLETE,
+                    "TS gate could NOT run — dependencies not installed (see env:node_modules)",
+                    detail="install deps in this worktree, then re-run; UNVERIFIED, not a pass",
+                )
+            )
+        else:
+            ts_specs = _plan_ts(path, meta, config)
+            if ts_specs:
+                specs.extend(ts_specs)
+            else:
+                aux.append(
+                    Check(
+                        "ts",
+                        INCOMPLETE,
+                        "detected package.json but NO runnable authoritative gate found",
+                        detail=(
+                            "no typecheck/test script, no tsconfig.json"
+                            + (", no workspace member with one" if meta.get("is_workspace_root") else "")
+                            + " — add a gate or \"skip\":[\"ts\"] in .verify-agent.json"
+                        ),
+                    )
+                )
+
+    # -- Go ----------------------------------------------------------------- #
+    if "go" in stacks and "go" not in skip_stacks:
+        race = _cgo_available(config)
+        if not race:
+            aux.append(
+                Check("go:race", SKIP, "cgo unavailable → running `go test` WITHOUT -race")
+            )
+        modules = [path] + _nested_go_modules(path)
+        for mod in modules:
+            label = "" if mod == path else f"[{os.path.relpath(mod, path)}]"
+            build_cmd = ov("go", "build") or "go build ./..."
+            vet_cmd = ov("go", "vet") or "go vet ./..."
+            test_cmd = ov("go", "test") or ("go test -race ./..." if race else "go test ./...")
+            specs.append(GateSpec(f"go:build{label}", _shell(build_cmd), mod, tool="go"))
+            specs.append(GateSpec(f"go:vet{label}", _shell(vet_cmd), mod, tool="go"))
+            specs.append(GateSpec(f"go:test{label}", _shell(test_cmd), mod, tool="go"))
+
+    # -- Python ------------------------------------------------------------- #
+    if "python" in stacks and "python" not in skip_stacks:
+        py_specs = _plan_python(path, stacks["python"], config)
+        if py_specs:
+            specs.extend(py_specs)
+        else:
+            aux.append(
+                Check(
+                    "python",
+                    INCOMPLETE,
+                    "detected python project but NO runnable gate (no ruff config, no pytest config)",
+                    detail="add ruff/pytest, set python.lint/test, or skip 'python' in .verify-agent.json",
+                )
+            )
+
+    # -- Nix ---------------------------------------------------------------- #
+    if "nix" in stacks and "nix" not in skip_stacks:
+        chk = ov("nix", "check")
+        if chk:
+            specs.append(GateSpec("nix:check", _shell(chk), path, tool=_first_tok(chk)))
+        else:
+            # default: the CHEAP authoritative parse. `nix flake check` is the
+            # fuller gate — enable via config.
+            specs.append(
+                GateSpec(
+                    "nix:parse",
+                    ["nix-instantiate", "--parse", str(path / "flake.nix")],
+                    path,
+                    tool="nix-instantiate",
+                )
+            )
+
+    return specs, aux
+
+
 # --------------------------------------------------------------------------- #
 # gate execution
 # --------------------------------------------------------------------------- #
 
 _MAX_OUTPUT_LINES = 40
+
+_MISSING_TOOL_HINT = (
+    "toolchain missing where the gate ran — this stack is UNVERIFIED, not a "
+    "pass; run the gate where the toolchain is available (or install it)"
+)
 
 
 def _truncate(text: str, max_lines: int = _MAX_OUTPUT_LINES) -> str:
@@ -564,33 +758,34 @@ def _truncate(text: str, max_lines: int = _MAX_OUTPUT_LINES) -> str:
     if len(lines) <= max_lines:
         return text
     hidden = len(lines) - max_lines
-    tail = lines[-max_lines:]
-    return f"... [{hidden} earlier line(s) truncated] ...\n" + "\n".join(tail)
+    return f"... [{hidden} earlier line(s) truncated] ...\n" + "\n".join(lines[-max_lines:])
 
 
 def run_gate(spec: GateSpec, timeout: int = 600) -> Check:
+    tool = spec.tool or (spec.cmd[0] if spec.cmd else "")
+    # A DETECTED stack whose toolchain is absent did NOT get verified → INCOMPLETE
+    # (never a WARN-to-green). Pre-check so a `bash -c` wrapper can't hide it.
+    if tool and shutil.which(tool) is None:
+        return Check(spec.name, INCOMPLETE, f"tool not found: {tool} — gate did not run", detail=_MISSING_TOOL_HINT)
     try:
         res = subprocess.run(
-            spec.cmd,
-            cwd=str(spec.cwd),
-            capture_output=True,
-            text=True,
-            timeout=timeout,
+            spec.cmd, cwd=str(spec.cwd), capture_output=True, text=True, timeout=timeout
         )
     except FileNotFoundError:
-        tool = spec.cmd[0]
-        return Check(
-            spec.name,
-            WARN,
-            f"tool not found: {tool} — toolchain missing, gate not run",
-        )
+        return Check(spec.name, INCOMPLETE, f"tool not found: {tool} — gate did not run", detail=_MISSING_TOOL_HINT)
     except subprocess.TimeoutExpired:
-        return Check(
-            spec.name, FAIL, f"TIMEOUT after {timeout}s: {' '.join(spec.cmd)}"
-        )
+        return Check(spec.name, FAIL, f"TIMEOUT after {timeout}s: {' '.join(spec.cmd)}")
     combined = (res.stdout or "") + (res.stderr or "")
     if res.returncode == 0:
         return Check(spec.name, PASS, f"$ {' '.join(spec.cmd)}")
+    if res.returncode == 127:  # command-not-found inside a shell wrapper
+        return Check(
+            spec.name,
+            INCOMPLETE,
+            f"exit 127 (command not found): $ {' '.join(spec.cmd)}",
+            detail=_MISSING_TOOL_HINT,
+            output=_truncate(combined),
+        )
     return Check(
         spec.name,
         FAIL,
@@ -618,7 +813,8 @@ def verify(
     result.stacks = sorted(stacks.keys())
     config = load_config(target)
 
-    # 1. env footgun (stale node_modules) — attributed to ENV, not code.
+    # 1. env footgun (stale node_modules) — attributed to ENV; makes the TS gate
+    #    INCOMPLETE (it could not run), handled in build_gate_plan via node_ok.
     node_ok = True
     if "ts" in stacks:
         nm_check = check_node_modules(target, stacks["ts"])
@@ -629,9 +825,9 @@ def verify(
     # 2. git completeness.
     result.checks.extend(check_git(git_state(target), target, use_gh=use_gh))
 
-    # 3. authoritative per-stack gates.
-    specs, skips = build_gate_plan(target, stacks, config, node_ok)
-    result.checks.extend(skips)
+    # 3. authoritative per-stack gates (+ INCOMPLETE aux for unrun detected stacks).
+    specs, aux = build_gate_plan(target, stacks, config, node_ok)
+    result.checks.extend(aux)
     for spec in specs:
         result.checks.append(gate_runner(spec, timeout))
 
@@ -642,34 +838,40 @@ def verify(
 # rendering
 # --------------------------------------------------------------------------- #
 
-_ICON = {PASS: "PASS", FAIL: "FAIL", WARN: "WARN", SKIP: "skip"}
+_ICON = {PASS: "PASS", FAIL: "FAIL", INCOMPLETE: "INCP", WARN: "WARN", SKIP: "skip"}
 
 
 def render_text(result: Result) -> str:
-    lines = []
-    lines.append(f"verify-agent-work: {result.target}")
-    lines.append(
-        f"stacks: {', '.join(result.stacks) if result.stacks else '(none detected)'}"
-    )
-    lines.append("")
+    lines = [
+        f"verify-agent-work: {result.target}",
+        f"stacks: {', '.join(result.stacks) if result.stacks else '(none detected)'}",
+        "",
+    ]
     for c in result.checks:
-        lines.append(f"  [{_ICON.get(c.status, c.status):4}] {c.name:20} {c.summary}")
+        lines.append(f"  [{_ICON.get(c.status, c.status):4}] {c.name:22} {c.summary}")
         if c.detail:
             lines.append(f"         {c.detail}")
-        if c.output:
-            for oln in c.output.splitlines():
-                lines.append(f"         | {oln}")
+        for oln in c.output.splitlines():
+            lines.append(f"         | {oln}")
     lines.append("")
     n_fail = sum(1 for c in result.checks if c.status == FAIL)
+    n_incp = sum(1 for c in result.checks if c.status == INCOMPLETE)
     n_warn = sum(1 for c in result.checks if c.status == WARN)
-    if result.verdict == PASS:
-        verdict = f"VERDICT: PASS ({n_warn} warning(s))"
+    v = result.verdict
+    if v == PASS:
+        lines.append(f"VERDICT: PASS ({n_warn} warning(s))")
+    elif v == INCOMPLETE:
+        lines.append(
+            f"VERDICT: INCOMPLETE — {n_incp} detected stack(s) could NOT be verified "
+            "(non-zero exit). This is NOT a pass; do not trust an agent 'done' claim."
+        )
     else:
         reason = f"{n_fail} hard failure(s)"
+        if n_incp:
+            reason += f" + {n_incp} unverified stack(s)"
         if result.strict and n_warn:
             reason += f" + {n_warn} warning(s) [strict]"
-        verdict = f"VERDICT: FAIL — {reason}. Do NOT trust an agent 'done' claim over this."
-    lines.append(verdict)
+        lines.append(f"VERDICT: FAIL — {reason}. Do NOT trust an agent 'done' claim over this.")
     return "\n".join(lines)
 
 
@@ -685,7 +887,7 @@ def main(argv: Optional[list] = None) -> int:
     )
     p.add_argument("target", nargs="?", default=".", help="repo/worktree path (default: cwd)")
     p.add_argument("--json", action="store_true", help="emit structured JSON")
-    p.add_argument("--strict", action="store_true", help="promote WARN to hard fail")
+    p.add_argument("--strict", action="store_true", help="also promote WARN to hard fail")
     p.add_argument("--no-gh", action="store_true", help="skip the gh open-PR lookup")
     p.add_argument("--timeout", type=int, default=600, help="per-gate timeout (s)")
     args = p.parse_args(argv)
@@ -698,12 +900,7 @@ def main(argv: Optional[list] = None) -> int:
         print(f"verify-agent-work: target is not a directory: {target}", file=sys.stderr)
         return 2
 
-    result = verify(
-        target,
-        use_gh=not args.no_gh,
-        strict=args.strict,
-        timeout=args.timeout,
-    )
+    result = verify(target, use_gh=not args.no_gh, strict=args.strict, timeout=args.timeout)
 
     if args.json:
         print(json.dumps(result.to_dict(), indent=2))


### PR DESCRIPTION
> **Update — adversarial-audit round (commit `aeb8d5f`).** The audit passed with no deploy-blockers but found the gate had its OWN false-green windows: it returned `verdict: PASS / exit 0` in cases where a **detected** stack was never actually verified. Fixed on this branch — see **"Audit round"** below. New verdict/exit semantics: a detected-but-unrun stack is now `INCOMPLETE` (non-zero exit), never a silent green; a repo with **no** stack present stays a legitimate `PASS`.

## Why

Zach works entirely through dispatched subagents/Tasks. Across 8+ recent sessions the **same** failure recurred: a subagent claimed "build green / committed / done" but

- **a proxy command hid a real error** — a green `vite build` hid live `tsc` type errors (a bundler build does NOT typecheck),
- **the agent "committed but stopped before finishing"** — dirty tree / unpushed commits contradicting the "done" claim, or
- **a stale worktree `node_modules` symlink** produced a flood of false "cannot find module" LSP errors mistaken for real code errors.

Claude then re-ran the authoritative gate **by hand every single time**. One real money-path 500 regression shipped because a report-only red test wasn't surfaced at the merge decision (self-caught 4 PRs later). This turns that per-agent manual re-verification ritual into ONE deterministic command whose output Claude reads **instead of** trusting the agent's prose.

## How this differs from what exists

- **`/audit-pr`** — adversarial **LLM** review of a diff (risks/regressions/second-order effects). Costs a model call; judgement-based.
- **`verify` skill** — **e2e behaviour** verification (drive the actual flow, observe runtime).
- **THIS (`/verify-agent`)** — the cheap **mechanical structural** gate: deterministic, no LLM, no browser. Re-runs the authoritative CI checks + git-completeness + the stale-deps footgun. It's the always-run floor the other two build on, not a replacement for either.

## What it checks

`scripts/verify-agent-work [TARGET] [--json] [--strict] [--no-gh] [--timeout N]` — default target is cwd/the handed-back worktree. For each stack **actually present** (never hard-fails a repo that legitimately lacks one):

- **TS/JS** (`package.json`): the repo's `typecheck` script or `tsc --noEmit` — **never `build`** — **and** the `test` script. Detects pnpm/npm/yarn/bun.
- **Go** (`go.mod`): `go build ./...` + `go vet ./...` + `go test -race ./...`.
- **Python** (`pyproject`/`requirements`): `ruff check` + `pytest` when configured.
- **Nix** (`flake.nix`): `nix-instantiate --parse` by default (fast, side-effect-free); `nix flake check` if opted in via config.
- **Git completeness**: uncommitted/untracked, unpushed vs upstream, open PR (best-effort `gh`) — the "committed but stopped" tell.
- **Stale-worktree footgun**: a broken/missing `node_modules` is reported as an **ENV** issue and the TS gates are **SKIPPED**, so a false "cannot find module" flood is attributed correctly rather than read as real code errors.

Output: PASS/FAIL per check with the **actual** error output surfaced (tail-truncated), a one-line verdict, and a **non-zero exit on any hard failure** (usable in CI/a hook later). `--json` emits a structured result. Gate failures (typecheck/test/build/vet/lint) are hard FAILs; git-completeness / stale-deps are WARN by default (advisory) and promoted to hard fail under `--strict`. Read-only except running the target's own build/test — no writes, no commits, no installs. The command set is overridable per stack via a repo-local `.verify-agent.json` (override or `skip` a stack).

Surfaced via **`/verify-agent`** (`claude/commands/verify-agent.md`) which instructs Claude to READ the gate verdict instead of trusting an agent's summary.

## Tests

`scripts/tests/test_verify_agent_work.py` — 46 tests, hermetic (temp dirs + fixture git repos, no network/cluster; gate execution mocked via an injected runner so no toolchain is required). Covers: stack detection (TS / Go / Python / Nix / mixed / none), package-manager detection, git state (clean/dirty/unpushed via temp repos incl. a bare-remote ahead-count), stale-`node_modules` (missing / broken symlink / present / not-required), gate-plan shape + config override + skip, JSON output shape, and exit codes. `scripts/tests/` is already in `run-tests.sh` HERMETIC_DIRS, so this rides the existing `nix flake check` / pre-push gate — no runner change.

```
58 passed in 0.58s        # this suite (was 46; +12 for the audit-round contract)
365 passed in 1.99s       # full scripts/tests dir (regression-clean)
```

Also exercised end-to-end against real targets: valid `flake.nix` → `nix:parse` PASS; deliberately broken flake → `nix:parse` FAIL with the syntax error surfaced and **exit 1**; dirty/no-upstream worktree → the expected git-completeness WARNs.

## Audit round — false-green fixes (commit `aeb8d5f`)

The adversarial audit found the gate returned `PASS/exit 0` while NOT actually verifying a detected stack. Core invariant now enforced: **a detected stack whose authoritative gate did not run is never green** — a new `INCOMPLETE` state (always a hard non-pass / non-zero exit, strict or not); a repo with **no** stack present stays a legitimate `PASS/0`.

| verdict | exit | meaning |
|---|---|---|
| `PASS` | 0 | every detected stack's gate ran and passed (WARNs allowed unless `--strict`); or no stack present |
| `FAIL` | 1 | a gate ran and failed (typecheck/test/build/vet/lint red), or `--strict` + a WARN |
| `INCOMPLETE` | 1 | a detected stack's gate could NOT run — missing toolchain, no resolvable gate, or deps not installed. **Not a pass** |

- **#1 missing toolchain** (confirmed live: `pnpm` absent → previously `WARN`/PASS): a detected stack whose tool is absent on PATH is now `INCOMPLETE` (`shutil.which` pre-check + `FileNotFoundError` + exit-127 detection). Common, since `/verify-agent` only guarantees `python3`, not the target toolchain.
- **#2 monorepo/workspaces** (confirmed live: root `package.json` with `workspaces` and no root script → previously PASS): detect workspaces (`workspaces`, `pnpm-workspace.yaml`, lerna) and fan the TS gate out across member packages; a detected TS/JS stack with **no** resolvable gate (no typecheck/test script, no `tsconfig`, no runnable member) is `INCOMPLETE`. Same "no runnable gate ⇒ not green" applied to Python; nested `go.mod` modules are each built (`go build ./...` doesn't cross module boundaries).
- **#3 stale `node_modules`**: broken/missing deps for a detected TS stack is now `INCOMPLETE` (typecheck genuinely didn't run) — the ENV `WARN` still explains why a "cannot find module" flood is environmental.
- **#4 cgo/`-race`**: fall back to `go test` without `-race` when cgo / a C compiler is unavailable (avoids a spurious FAIL under `CGO_ENABLED=0`) and report which variant ran.
- **#5 untrusted-repo caveat**: documented in BOTH the script docstring and the command doc — the gate runs the target's own build/test and honours `.verify-agent.json` = arbitrary code execution; don't run it against a repo you don't trust (CLAUDE.md treats agent worktrees / fuzzyclaw as UNTRUSTED).
- **#6 git timeout**: the `git` subprocesses now have a bounded timeout like the `gh` call.

Verified live end-to-end after the fix: missing-`pnpm` TS repo → `INCOMPLETE`/exit 1; monorepo-no-root-script → `INCOMPLETE`/exit 1; broken-`node_modules`+TS → `INCOMPLETE`/exit 1; no-stack repo → `PASS`/exit 0.

## Deploy note

`claude/commands/verify-agent.md` is a **new** command file — it's `git add`ed (flakes only see tracked files). A `home-manager switch` / `scripts/ship.sh` is needed to symlink it into `~/.claude/commands/`. Not done here — left to Zach.

## Follow-ups (out of scope by design, not implemented here)

- **gopls / LSP workspace-for-worktrees fix** — the other half of the false-LSP theme (a git worktree's LSP resolving against the wrong workspace root). Separate change.
- No LLM layer, no hook auto-trigger, no e2e/browser verification — those are deliberately out of scope (that's `/audit-pr` and the `verify` skill).
- The gate could later be wired as a `Stop`/`SubagentStop` hook to run automatically — intentionally left manual for now.

## Honesty / caveats

- The gate proves the **authoritative checks pass and the tree is complete**; it does **not** prove the feature behaves correctly (that's the `verify` skill) — the command text says so explicitly.
- The `git:pr` lookup is best-effort `SKIP` (never a false FAIL) when `gh` is absent/unauthed. A missing **stack** toolchain (`go`/`pnpm`/`ruff`/`nix`) is deliberately NOT a soft pass — it's `INCOMPLETE`/non-zero (post-audit), because the stack was detected but not verified; run the gate where the toolchain exists (or `skip` the stack in `.verify-agent.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

