### PR TITLE
feat(home): set Brave as the default browser

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -206,6 +206,21 @@ in
     "${home}/.npm-packages/bin"
   ];
 
+  # Default browser: Brave (Chromium-based). Declaratively own the web
+  # scheme/mime handlers so both hosts agree; matches the $mod+b i3 launcher
+  # and the activity-collector's BROWSER_APP=brave labelling.
+  xdg.mimeApps = {
+    enable = true;
+    defaultApplications = {
+      "text/html" = "brave-browser.desktop";
+      "application/xhtml+xml" = "brave-browser.desktop";
+      "x-scheme-handler/http" = "brave-browser.desktop";
+      "x-scheme-handler/https" = "brave-browser.desktop";
+      "x-scheme-handler/about" = "brave-browser.desktop";
+      "x-scheme-handler/unknown" = "brave-browser.desktop";
+    };
+  };
+
   # Symlink tmux scripts
   home.file.".config/tmux/idle-update.sh" = {
     source = ../scripts/tmux-idle-update.sh;


### PR DESCRIPTION
## What

Adds an `xdg.mimeApps` block to `nix/home.nix` that declaratively sets `brave-browser.desktop` as the handler for the web scheme/mime types (`http`, `https`, `text/html`, `application/xhtml+xml`, `about`, `unknown`).

## Why

The default browser was resolving to a stale `firefox.desktop` handler — and Firefox isn't even installed, so link-opening was broken. Brave was already the `$mod+b` i3 launcher and the activity collector's `BROWSER_APP=brave`; this makes the default handler agree.

## Verification

Applied via `home-manager switch --flake . --impure` on the workbench (had to move two pre-existing unmanaged `mimeapps.list` files aside so HM could own them). After switch:

```
$ xdg-settings get default-web-browser
brave-browser.desktop
$ xdg-mime query default x-scheme-handler/https
brave-browser.desktop
$ xdg-mime query default text/html
brave-browser.desktop
```

(was `firefox.desktop` for all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)