### PR TITLE
fix(airvpn): killswitch polices only the physical uplink (fixes k3s outage)

### DIFF
--- a/nix/system/airvpn-host.nix
+++ b/nix/system/airvpn-host.nix
@@ -28,11 +28,14 @@
 # rebuild / reboot leaves the host on its DIRECT route until Zach connects.
 #
 # KILLSWITCH + SPLIT-TUNNEL live in the conf's PostUp/PreDown (→ scripts/airvpn-updown),
-# so they are armed ONLY while the tunnel is up and replicate the old Mullvad
-# bypasses exactly: VPN endpoint via the original gateway, 192.168.50.1 (LAN
-# router/DNS), LAN 192.168.50.0/24 direct, and the nebula Hetzner lighthouse
-# 5.161.118.55 (mail/mesh survives). Fail-closed: while up, non-tunnel egress that
-# isn't an explicit bypass is dropped.
+# armed ONLY while the tunnel is up. Split-tunnel bypass ROUTES: VPN endpoint via the
+# original gateway, the LAN router/DNS + LAN 192.168.50.0/24 direct, and the nebula
+# lighthouse. The KILLSWITCH is fail-closed but POLICES ONLY THE PHYSICAL UPLINK
+# (`oifname != <phys> drop-by-default`): loopback, the tunnel, the nebula overlay
+# (nebula.mesh) and the k3s CNI (cni0/flannel.1 → pods/services) egress non-physical
+# ifaces and are always allowed — this host runs k3s + is reached over nebula, so an
+# enumerate-every-internal-net allow-list was fragile (it dropped the overlay, then
+# the cluster). Uplink-only policing is leak-equivalent and needs no rule per new net.
 #
 # ---- PostUp/PreDown to append to /etc/wireguard/airvpn.conf [Interface] -------
 #   PostUp   = /etc/nixos/i3blocks-scripts/airvpn-updown up %i

--- a/scripts/airvpn-sudo
+++ b/scripts/airvpn-sudo
@@ -62,6 +62,12 @@ case "$cmd" in
     down)
         # Best-effort: down even if partially up; never fail the menu on a no-op.
         wg-quick down "$WG_IFACE" || true
+        # If the iface was already gone, wg-quick errors BEFORE running the conf's
+        # PostDown, so the killswitch table can be ORPHANED — still dropping uplink
+        # traffic with no tunnel. Tear it down explicitly (idempotent; a no-op when
+        # PostDown already ran). Table name kept in lock-step with airvpn-updown.
+        nft delete table inet airvpn_ks 2>/dev/null || true
+        rm -f /run/airvpn-gateway /run/airvpn-iface 2>/dev/null || true
         ;;
     status)
         # Read-only. Empty output if the interface isn't up.

--- a/scripts/airvpn-updown
+++ b/scripts/airvpn-updown
@@ -12,24 +12,26 @@
 #     PostUp   = /etc/nixos/i3blocks-scripts/airvpn-updown up %i
 #     PreDown  = /etc/nixos/i3blocks-scripts/airvpn-updown down %i
 #
-# It REPLICATES the old (commented) Mullvad host wg-quick split-tunnel bypasses:
-#   * bypass the VPN ENDPOINT itself via the original gateway (wg-quick's fwmark
-#     already exempts wg's own encrypted packets; this /32 is belt-and-suspenders
-#     + is what a `switch` refreshes),
-#   * bypass 192.168.50.1 (LAN router / DNS upstream),
-#   * keep the LAN 192.168.50.0/24 direct (it already is — connected route),
-#   * keep the NEBULA OVERLAY alive so the operator is not locked out: this host is
-#     reached over nebula (overlay 10.42.0.0/24 on nebula.mesh, e.g. 10.42.0.30) AND
-#     the homelab/mail automation rides the same overlay. The killswitch therefore
-#     exempts BOTH layers — the decrypted side (oifname nebula.mesh + daddr
-#     10.42.0.0/24) AND nebula's own ENCRYPTED transport (udp sport 4242, covering
-#     punchy direct peers as well as the lighthouse) — NOT just the lighthouse /32.
-#     (Exempting only the lighthouse preserves nebula DISCOVERY but drops the overlay
-#     DATA plane → a Connect over the nebula path would sever the operator's session
-#     with no in-band Disconnect. Fixed 2026-07-18 after the PR #118 audit.)
-# The KILLSWITCH is fail-closed: while up, any output that would leave the box
-# NOT through the tunnel (and isn't one of the explicit bypasses / LAN) is dropped,
-# so a tunnel drop can't silently leak traffic onto the direct link.
+# SPLIT-TUNNEL BYPASS ROUTES (main-table /32s that beat the tunnel default):
+#   * the VPN ENDPOINT via the original gateway (so the handshake isn't routed into
+#     the tunnel; also what a `switch` refreshes),
+#   * 192.168.50.1 (LAN router / DNS upstream) + the LAN 192.168.50.0/24 direct,
+#   * the nebula Hetzner lighthouse (discovery/relay).
+#
+# KILLSWITCH (fail-closed) — POLICES ONLY THE PHYSICAL UPLINK. The chain's first
+# rule is `oifname != <phys> accept`, so everything leaving via a NON-physical
+# interface is ALWAYS allowed: loopback, the airvpn tunnel, the nebula overlay
+# (nebula.mesh), and the k3s CNI (cni0 / flannel.1 → the pod & service CIDRs). Only
+# traffic egressing the physical uplink is filtered, and there only wg's own
+# encrypted packets (fwmark), the LAN, the nebula transport (udp sport 4242) +
+# lighthouse, and the endpoint/gateway are allowed — everything else is DROPPED.
+#   Why this shape: the ONLY path by which host traffic can leak un-tunnelled is the
+#   physical uplink, so that is the only thing worth policing. Enumerating internal
+#   networks to ALLOW them (the old model) was both unnecessary and fragile — it
+#   dropped the nebula overlay (PR #118 audit, 2026-07-18) and then the k3s cluster
+#   (apiserver→pod replies dropped → CoreDNS/Traefik/Flux CrashLooped, 2026-07-21).
+#   Policing the uplink is leak-equivalent AND immune to any future internal network
+#   (a new CNI, overlay, bridge, …) with no new rule.
 #
 # wg-quick uses fwmark routing (Table=auto): the main table keeps the physical
 # default route, unmarked traffic is sent to the wg table via `ip rule`, and
@@ -41,16 +43,13 @@ set -uo pipefail
 action="${1:-}"
 IFACE="${2:-airvpn}"
 
-# The split-tunnel bypass destinations (mirror the old Mullvad conf).
+# The split-tunnel bypass destinations (mirror the old Mullvad conf). Everything
+# INTERNAL (nebula overlay, k3s pod/service CIDRs, CNI bridges) needs no entry here:
+# it egresses a non-physical iface and the killswitch only polices the uplink.
 LAN_ROUTER="192.168.50.1"          # LAN router / DNS upstream
 NEBULA_LIGHTHOUSE="5.161.118.55"   # Hetzner nebula lighthouse (discovery/relay)
 LAN_SUBNET="192.168.50.0/24"       # LAN kept direct
-# Nebula OVERLAY exemptions — without these a Connect over nebula locks the operator
-# out (this host is reached at 10.42.0.30 on nebula.mesh; homelab/mail automation
-# rides the overlay too). Exempt the decrypted tun + subnet AND the encrypted UDP.
-NEBULA_IFACE="nebula.mesh"         # decrypted overlay tun (return traffic to peers)
-NEBULA_SUBNET="10.42.0.0/24"       # nebula overlay subnet (SSH/agent + homelab access)
-NEBULA_PORT="4242"                 # nebula encrypted transport (punchy direct + lighthouse)
+NEBULA_PORT="4242"                 # nebula ENCRYPTED transport out the uplink (punchy + lighthouse)
 
 GW_FILE="/run/airvpn-gateway"
 IFACE_FILE="/run/airvpn-iface"
@@ -93,12 +92,14 @@ case "$action" in
 table inet ${KS_TABLE} {
     chain out {
         type filter hook output priority 0; policy accept;
-        oifname "${IFACE}" accept
-        oifname "lo" accept
-        oifname "${NEBULA_IFACE}" accept
+        # Police ONLY the physical uplink. Loopback, the tunnel, the nebula overlay
+        # (nebula.mesh) and the k3s CNI (cni0/flannel.1 → pods/services) all egress a
+        # NON-physical iface and are always allowed — durable: new internal nets need
+        # no rule. See the header for why this is leak-equivalent to a default-drop.
+        oifname != "${PHYS}" accept
+        # On the uplink, allow only the legitimate un-tunnelled flows; drop the rest.
         $( [[ -n "$FWMARK" && "$FWMARK" != "off" ]] && echo "meta mark ${FWMARK} accept" )
         ip daddr ${LAN_SUBNET} accept
-        ip daddr ${NEBULA_SUBNET} accept
         udp sport ${NEBULA_PORT} accept
         ip daddr ${NEBULA_LIGHTHOUSE} accept
         $( [[ -n "$EP" ]] && echo "ip daddr ${EP} accept" )
@@ -106,9 +107,8 @@ table inet ${KS_TABLE} {
         # link-local + multicast housekeeping stay allowed
         ip6 daddr fe80::/10 accept
         ip daddr 224.0.0.0/4 accept
-        # anything else that would egress un-tunnelled -> DROP (fail-closed)
-        meta nfproto ipv4 drop
-        meta nfproto ipv6 drop
+        # anything else egressing the uplink un-tunnelled -> DROP (fail-closed)
+        drop
     }
 }
 NFT

--- a/scripts/airvpn-updown
+++ b/scripts/airvpn-updown
@@ -23,8 +23,11 @@
 # interface is ALWAYS allowed: loopback, the airvpn tunnel, the nebula overlay
 # (nebula.mesh), and the k3s CNI (cni0 / flannel.1 → the pod & service CIDRs). Only
 # traffic egressing the physical uplink is filtered, and there only wg's own
-# encrypted packets (fwmark), the LAN, the nebula transport (udp sport 4242) +
-# lighthouse, and the endpoint/gateway are allowed — everything else is DROPPED.
+# encrypted packets (fwmark), the LAN, nebula's own transport (matched by SOCKET
+# OWNER — `meta skuid nebula-mesh` — NOT a port, because nebula runs listen.port:0
+# and binds a RANDOM source port; a `udp sport 4242` rule matched nothing and let
+# the direct-punched overlay to an off-LAN peer get dropped → lockout, PR #126 audit
+# 2026-07-21), the lighthouse, and the endpoint/gateway are allowed — else DROPPED.
 #   Why this shape: the ONLY path by which host traffic can leak un-tunnelled is the
 #   physical uplink, so that is the only thing worth policing. Enumerating internal
 #   networks to ALLOW them (the old model) was both unnecessary and fragile — it
@@ -49,7 +52,11 @@ IFACE="${2:-airvpn}"
 LAN_ROUTER="192.168.50.1"          # LAN router / DNS upstream
 NEBULA_LIGHTHOUSE="5.161.118.55"   # Hetzner nebula lighthouse (discovery/relay)
 LAN_SUBNET="192.168.50.0/24"       # LAN kept direct
-NEBULA_PORT="4242"                 # nebula ENCRYPTED transport out the uplink (punchy + lighthouse)
+# Nebula binds listen.port:0 → a RANDOM source port, so match its transport by the
+# SOCKET OWNER instead of a port. This covers punchy DIRECT peers (to a remote
+# operator's public IP) + relay + lighthouse regardless of port. `id -un` the nebula
+# service user; fall back to the known default if it can't be resolved.
+NEBULA_USER="$(id -un nebula-mesh 2>/dev/null || echo nebula-mesh)"
 
 GW_FILE="/run/airvpn-gateway"
 IFACE_FILE="/run/airvpn-iface"
@@ -100,7 +107,7 @@ table inet ${KS_TABLE} {
         # On the uplink, allow only the legitimate un-tunnelled flows; drop the rest.
         $( [[ -n "$FWMARK" && "$FWMARK" != "off" ]] && echo "meta mark ${FWMARK} accept" )
         ip daddr ${LAN_SUBNET} accept
-        udp sport ${NEBULA_PORT} accept
+        meta skuid "${NEBULA_USER}" accept
         ip daddr ${NEBULA_LIGHTHOUSE} accept
         $( [[ -n "$EP" ]] && echo "ip daddr ${EP} accept" )
         ip daddr ${GW} accept


### PR DESCRIPTION
## What broke
Enabling the host AirVPN tunnel **CrashLooped the entire k3s cluster** — CoreDNS, Traefik (→ 502s), all 4 Flux controllers, metrics-server, devpods. External `kubectl` worked fine, which made it look API-side.

## Root cause
The fail-closed killswitch's `output` chain (`scripts/airvpn-updown`) had an **allow-list of internal networks**, and the **pod CIDR `10.244.0.0/16` wasn't in it**. Flow: a pod hits the API service `10.245.0.1:443` → kube-proxy DNATs to the host apiserver `192.168.50.250:6443` → the apiserver (host-local process) replies **to the pod IP** → egresses `cni0` → hits the killswitch → not in the allow-list → **dropped**. External kubectl survived because its replies go to `192.168.50.x` (allowed).

Same class of bug as the nebula-overlay drop fixed after the #118 audit: an allow-list that must enumerate every internal network is fragile on a host that runs k3s **and** is reached over nebula.

## Durable fix — flip the model
Police **only the physical uplink**: `oifname != <phys> accept` first, so loopback, the airvpn tunnel, the nebula overlay (nebula.mesh) and the k3s CNI (cni0/flannel.1 → pod & service CIDRs) are always allowed; only uplink egress is filtered (wg fwmark, LAN, nebula transport + lighthouse, endpoint, gateway → allow; else drop). The only un-tunnelled leak path IS the physical uplink, so this is **leak-equivalent** to the old default-drop **and immune to any future internal network** with no new rule.

## Also: orphan-teardown fix (`scripts/airvpn-sudo`)
`down` only ran `wg-quick down`, which errors before PostDown when the iface is already gone → killswitch table left armed with no tunnel. Now tears it down explicitly (idempotent). Latent lockout risk on unclean teardown/reboot (not the k3s trigger — the table came down cleanly here).

## Verification
- `bash -n` both scripts; `nix-instantiate --parse` the module.
- nft chain traced offline: apiserver→pod ✅ accept · nebula overlay ✅ accept · tunnel-up ✅ tunnelled · **leak out uplink ✅ dropped**.
- ⚠️ **NOT re-tested against a live Connect.** Re-test must be **LAN-first** (`192.168.50.x`) with external `kubectl` watching cluster health, and the orphan-safe `down` ready.

Follows #118 + #122. CIDRs from the live node: cluster `10.244.0.0/16`, service `10.245.0.0/16`, CNI `cni0`/`flannel.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)