### PR TITLE
feat(observability): OnFailure toasts + agent-ops local-health view

### DIFF
--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -471,6 +471,9 @@ lib.mkIf isNixOS {
       Description = "Poll clawgate/mail/alerts/civitai/media/airvpn → ~/.cache/bar-status for the i3 bar";
       After = [ "network-online.target" ];
       Wants = [ "network-online.target" ];
+      # Toast on failure (the notify-failure@ template lives in home.nix, installed
+      # on every host). This is the workbench, so the toast actually fires here.
+      OnFailure = [ "notify-failure@%n.service" ];
     };
     Service = {
       Type = "oneshot";

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -286,6 +286,15 @@ in
     executable = true;
   };
 
+  # systemd-unit failure handler: the ExecStart of the notify-failure@ template
+  # unit below. Emits a sticky desktop toast pointing at the failed unit's
+  # journal (headless-safe: logs + exits 0 when no X/dunst). Symlinked from the
+  # repo so both hosts stay in sync (like cpu-monitor.sh above).
+  home.file.".config/notify-failure/notify-failure.sh" = {
+    source = ../scripts/notify-failure.sh;
+    executable = true;
+  };
+
   # Activity-telemetry collector: hot-path emit helper + daemon. Symlinked from
   # the repo so both hosts stay in sync. Config (CLICKHOUSE_URL/credentials) lives
   # in ~/.config/activity-collector/env — created below, NOT in the nix store.
@@ -367,6 +376,36 @@ in
     source = ../scripts/claude-hooks/shell-env-nudge.py;
   };
 
+  # Reusable failure-notification TEMPLATE unit. The important user units below
+  # (+ bar-status-poll in graphical.nix) carry OnFailure=notify-failure@%n.service,
+  # so when one enters the `failed` state systemd instantiates this with the failed
+  # unit's name (%i) and the handler fires a desktop toast pointing at its journal.
+  # This is the observability backstop: Zach reasons THROUGH these agents, so a
+  # silently-dead timer/collector is the worst failure mode — make it loud.
+  #
+  # Installed on EVERY host (a template is inert until instanced); the toast itself
+  # is gated on the graphical host by only exporting NOTIFY_FAILURE_GRAPHICAL=1
+  # there (mirrors how dunst/espanso key off `graphical`). On a headless host the
+  # handler logs to the journal and exits 0 — it never errors (an erroring
+  # OnFailure handler is itself an invisible failure). Minimal user-unit env, so
+  # PATH is explicit: bash + coreutils (tr/id/head) + procps (pgrep) + gnugrep +
+  # libnotify (notify-send), exactly the cpu-monitor toast toolchain.
+  systemd.user.services."notify-failure@" = {
+    Unit = {
+      Description = "Desktop toast when the user unit %i fails";
+    };
+    Service = {
+      Type = "oneshot";
+      Environment = [
+        "PATH=${lib.makeBinPath [ pkgs.bash pkgs.coreutils pkgs.procps pkgs.gnugrep pkgs.libnotify ]}"
+      ] ++ lib.optional graphical "NOTIFY_FAILURE_GRAPHICAL=1";
+      ExecStart = "${pkgs.bash}/bin/bash %h/.config/notify-failure/notify-failure.sh %i";
+      # Re-run with fresh handler code after a script-only edit (cf. the
+      # X-Restart-Triggers rationale on the collector units below).
+      X-Restart-Triggers = [ "${../scripts/notify-failure.sh}" ];
+    };
+  };
+
   systemd.user.services.cpu-monitor = {
     Unit = {
       Description = "Desktop alert on sustained high CPU load";
@@ -405,6 +444,7 @@ in
       Description = "Personal activity-telemetry collector → ClickHouse";
       # No graphical-session dep: this must run in headless/server mode too.
       After = [ "network.target" ];
+      OnFailure = [ "notify-failure@%n.service" ];
     };
     Service = {
       Type = "simple";
@@ -444,6 +484,7 @@ in
   systemd.user.services.claude-activity-source = {
     Unit = {
       Description = "Tail Claude Code transcripts → activity spool (prompts + session summaries)";
+      OnFailure = [ "notify-failure@%n.service" ];
     };
     Service = {
       Type = "oneshot";
@@ -491,6 +532,7 @@ in
       # Requires a live X session (RECORD + active-window context).
       After = [ "graphical-session.target" ];
       PartOf = [ "graphical-session.target" ];
+      OnFailure = [ "notify-failure@%n.service" ];
     };
     Service = {
       Type = "simple";
@@ -524,6 +566,7 @@ in
       # Requires a live i3 (IPC socket); tracks the graphical session.
       After = [ "graphical-session.target" ];
       PartOf = [ "graphical-session.target" ];
+      OnFailure = [ "notify-failure@%n.service" ];
     };
     Service = {
       Type = "simple";
@@ -639,6 +682,7 @@ in
       Description = "Mail-actions invoice archiver → minio-archive (deterministic, daily)";
       After = [ "network-online.target" ];
       Wants = [ "network-online.target" ];
+      OnFailure = [ "notify-failure@%n.service" ];
     };
     Service = {
       Type = "oneshot";
@@ -702,6 +746,7 @@ in
       Description = "Repo chief-of-staff — weekly repo-scan → LLM proposals → email digest";
       After = [ "network-online.target" ];
       Wants = [ "network-online.target" ];
+      OnFailure = [ "notify-failure@%n.service" ];
     };
     Service = {
       Type = "oneshot";

--- a/scripts/agent-ops
+++ b/scripts/agent-ops
@@ -94,9 +94,39 @@ PRS_CACHE = os.path.join(CACHE_DIR, "open-prs.json")
 PRS_LOCK = os.path.join(CACHE_DIR, "prs-refresh.lock")
 PRS_TTL = 120
 PRS_GH_TIMEOUT = 12      # per-repo `gh pr list` bound (background path, fail-safe)
+# Local-health telemetry-freshness (single cheap ClickHouse aggregate) — same
+# TTL-cache + detached-background-refresh mechanism as the PR sweep, so the CH
+# round-trip never runs on the (fast, every-few-seconds) popup render path.
+TELEM_CACHE = os.path.join(CACHE_DIR, "telemetry-freshness.json")
+TELEM_LOCK = os.path.join(CACHE_DIR, "telem-refresh.lock")
+TELEM_TTL = 60           # seconds — freshness moves slowly; a stale-ish read is fine
+TELEM_QUERY_TIMEOUT = 3.0  # short bound: a glanceable dashboard must never hang
+# Expected telemetry sources (the `source` column values in activity.events). A
+# source present here but ABSENT from the query result is shown as "—" (possibly
+# dead / just idle). Extra sources returned by the query are appended dimly.
+TELEM_SOURCES = ("zsh", "tmux", "keys", "i3", "browser", "claude")
+# Key timer-backed services whose last-run health is surfaced in Local health.
+# Rendered by their short label; workbench-only ones (repo-cos/mail-actions) show
+# "absent" on the laptop where the unit is not installed (LoadState=not-found).
+LOCAL_HEALTH_UNITS = (
+    ("repo-cos.service", "repo-cos"),
+    ("mail-actions-archive.service", "mail-archive"),
+    ("bar-status-poll.service", "bar-poll"),
+    ("claude-activity-source.service", "claude-src"),
+    ("activity-collector.service", "collector"),
+)
+# The collector's own env file is the SAME endpoint/creds the telemetry writer
+# uses on this host — reuse it (NOT a hardcoded endpoint). chquery (the shared
+# CH client) is loaded by explicit path, fail-safe (CHQUERY_PATH set below, once
+# DEVRC_DIR is defined).
+ACTIVITY_ENV = os.path.join(HOME, ".config", "activity-collector", "env")
 DEVRC_DIR = os.environ.get("DEVRC_DIR") or os.path.join(HOME, "workspace", "devrc")
 ISCAN_SCRIPT = os.path.join(DEVRC_DIR, "scripts", "session-analysis", "initiative-scan.py")
 CLAWGATE_ENV = os.path.join(HOME, ".claude", "clawgate.env")
+# Shared ClickHouse client (validation/chquery.py) — loaded by explicit path for
+# the Local-health telemetry-freshness query. Reuses the collector's env for the
+# endpoint/creds; never hardcodes a new one.
+CHQUERY_PATH = os.path.join(DEVRC_DIR, "scripts", "validation", "chquery.py")
 
 # Scratchpad codename table — THE single source of truth for session<->codename
 # (scripts/tmux-scratch-slots.sh). Mirror how the bash/py consumers resolve it:
@@ -254,6 +284,113 @@ def fetch_repo_open_prs(repo_dir, timeout=PRS_GH_TIMEOUT):
         return data if isinstance(data, list) else None
     except Exception:
         return None
+
+
+def fetch_failed_user_units(timeout=3):
+    """Raw `systemctl --user --failed` (plain, no legend) output, or None on ANY
+    failure (systemctl missing, no user manager, timeout). Fail-safe."""
+    try:
+        out = subprocess.run(
+            ["systemctl", "--user", "--failed", "--plain", "--no-legend",
+             "--no-pager"],
+            capture_output=True, text=True, timeout=timeout)
+        if out.returncode != 0:
+            return None
+        return out.stdout
+    except Exception:
+        return None
+
+
+def fetch_unit_show(unit, timeout=3):
+    """Raw `systemctl --user show <unit>` for the health-relevant properties, or
+    None on ANY failure. The keys are parsed by parse_systemctl_show."""
+    try:
+        out = subprocess.run(
+            ["systemctl", "--user", "show", unit,
+             "-p", "LoadState", "-p", "ActiveState", "-p", "SubState",
+             "-p", "Result", "-p", "ExecMainExitTimestampMonotonic",
+             "-p", "ExecMainStartTimestampMonotonic"],
+            capture_output=True, text=True, timeout=timeout)
+        if out.returncode != 0:
+            return None
+        return out.stdout
+    except Exception:
+        return None
+
+
+def read_uptime():
+    """Seconds since boot (/proc/uptime), or None. Used to turn a unit's
+    ExecMainExitTimestampMonotonic (µs since boot) into a tz-free wall age."""
+    try:
+        with open("/proc/uptime", "r") as fh:
+            return float(fh.read().split()[0])
+    except Exception:
+        return None
+
+
+def _load_chquery():
+    """Import scripts/validation/chquery.py by explicit path (no sys.path games,
+    mirroring how bar-status-poll loads _db.py). Returns the module.
+
+    The module MUST be registered in sys.modules under its spec name before
+    exec_module: chquery uses @dataclass, and dataclass resolution looks the
+    defining module up in sys.modules (a dynamic import that skips this raises
+    'NoneType has no __dict__')."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("_ao_chquery", CHQUERY_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def read_env_file(path):
+    """Parse a KEY=VALUE env file (# comments, blank lines) → dict. {} on failure.
+    Same shape the collector/systemd EnvironmentFile uses."""
+    env = {}
+    try:
+        with open(path, "r") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                k, v = line.split("=", 1)
+                env[k.strip()] = v.strip()
+    except Exception:
+        return {}
+    return env
+
+
+def query_telemetry_freshness(timeout=TELEM_QUERY_TIMEOUT):
+    """Single cheap CH aggregate: seconds since the last row per `source`.
+
+    dateDiff is computed SERVER-side (max(ts) vs now(), both server-UTC) so the
+    result is tz- and local-clock-independent; a 2-day WHERE bounds the scan.
+    Reuses chquery + the collector's env file (the SAME endpoint/creds the
+    telemetry writer uses on this host — never a hardcoded one). Returns
+    {source: age_secs}; RAISES on any failure (unconfigured / unreachable) —
+    the caller (refresh_telemetry_cache) turns that into an error marker."""
+    Q = _load_chquery()
+    env = dict(os.environ)
+    for k, v in read_env_file(ACTIVITY_ENV).items():
+        env.setdefault(k, v)      # explicit env wins; the file fills the gaps
+    conn = Q.CHConn.from_env(env)  # raises if CLICKHOUSE_URL is absent
+    conn.timeout = float(timeout)
+    client = Q.CHClient(conn)
+    sql = (
+        "SELECT source, dateDiff('second', max(ts), now()) AS age_secs "
+        "FROM %s WHERE ts > now() - INTERVAL 2 DAY "
+        "GROUP BY source ORDER BY source" % conn.fq_table)
+    rows = client.rows(sql)
+    out = {}
+    for r in rows:
+        s = r.get("source")
+        if s:
+            try:
+                out[str(s)] = int(r.get("age_secs") or 0)
+            except (TypeError, ValueError):
+                continue
+    return out
 
 
 # ===========================================================================
@@ -527,6 +664,89 @@ def _session_label(session: str, codenames: dict | None) -> str:
     return (codenames or {}).get(session, session)
 
 
+# --- Local health (failed units + timer last-runs + telemetry freshness) ----
+_UNIT_SUFFIXES = (".service", ".timer", ".socket", ".mount", ".path", ".scope",
+                  ".slice", ".target", ".device", ".automount", ".swap")
+
+
+def parse_failed_units(raw) -> list:
+    """First column of `systemctl --user --failed --plain` → [unit, …]. []-safe.
+
+    Each non-blank line's leading token is the unit id (UNIT LOAD ACTIVE SUB …);
+    only tokens ending in a known unit suffix are kept, so a stray header/legend
+    line never leaks in. None/'' → []."""
+    if not raw:
+        return []
+    units = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        tok = line.split()[0]
+        if tok.endswith(_UNIT_SUFFIXES):
+            units.append(tok)
+    return units
+
+
+def parse_systemctl_show(raw) -> dict:
+    """`systemctl show` KEY=VALUE block → dict. {} on None/empty. Never raises."""
+    d = {}
+    if not raw:
+        return d
+    for line in raw.splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            d[k.strip()] = v.strip()
+    return d
+
+
+def _mono_age(show, key, uptime):
+    """Wall age (s) of a monotonic-usec timestamp field vs `uptime`. None if the
+    field is 0/absent or uptime is unknown. tz-free."""
+    try:
+        m = int((show or {}).get(key))
+    except (TypeError, ValueError):
+        return None
+    if m > 0 and uptime is not None:
+        return max(0.0, float(uptime) - m / 1e6)
+    return None
+
+
+def unit_health_row(unit, label, show, uptime=None) -> dict:
+    """Pure: a parsed `systemctl show` dict → a Local-health row.
+
+    Returns {unit, label, present, ok, running, age_secs, result, active}. A unit
+    not installed on this host (LoadState in {not-found, masked} / empty show) is
+    present=False → rendered "absent" (e.g. workbench-only units on the laptop).
+    `ok` is tri-state: True (Result=success), False (ActiveState=failed or a
+    non-success Result), None (unknown). `running` marks a live daemon
+    (ActiveState=active + SubState=running); for those age_secs is the START age
+    (how long it's been up), otherwise it is the last-run COMPLETION age (from the
+    exit timestamp) — None if it has never completed."""
+    present = bool(show)
+    load = (show or {}).get("LoadState")
+    if not present or load in ("not-found", "masked"):
+        return {"unit": unit, "label": label, "present": False, "ok": None,
+                "running": False, "age_secs": None, "result": None, "active": None}
+    result = show.get("Result") or ""
+    active = show.get("ActiveState") or ""
+    sub = show.get("SubState") or ""
+    running = active in ("active", "activating") and sub == "running"
+    if running:
+        age = _mono_age(show, "ExecMainStartTimestampMonotonic", uptime)
+    else:
+        age = _mono_age(show, "ExecMainExitTimestampMonotonic", uptime)
+    if active == "failed" or (result and result != "success"):
+        ok = False
+    elif result == "success" or running:
+        ok = True
+    else:
+        ok = None
+    return {"unit": unit, "label": label, "present": True, "ok": ok,
+            "running": running, "age_secs": age, "result": result,
+            "active": active}
+
+
 # ---------------------------------------------------------------------------
 # Formatting helpers
 # ---------------------------------------------------------------------------
@@ -680,6 +900,96 @@ def render_health(alerts, civitai) -> list:
     return lines
 
 
+# Telemetry freshness colour bands (seconds): a source that has emitted recently
+# is GREEN; a longer gap is YELLOW; a stale/absent one is DIM. NOTE these are
+# intentionally generous — keys/i3/browser only emit while you're active, so a
+# quiet source is not necessarily broken; this view flags "is the layer alive",
+# not "are you at the keyboard". A totally dead collector shows every source DIM.
+_TELEM_FRESH = 1800      # < 30m  → green
+_TELEM_STALE = 10800     # < 3h   → yellow, else dim
+
+
+def render_local_health(failed_units, unit_rows, freshness, now=None) -> list:
+    """Local health: failed user units + key timer last-runs + per-source
+    telemetry freshness. Read-only + fail-safe — every input degrades gracefully
+    (systemctl n/a, a unit absent, telemetry unreachable) to a calm line."""
+    lines = [_header("Local health", AQUA)]
+
+    # 1. Failed user units (None = systemctl unavailable; [] = all healthy).
+    if failed_units is None:
+        lines.append("   %s  %s" % (paint("%-12s" % "units", BLUE),
+                                    paint("— systemctl n/a", DIMMER)))
+    elif not isinstance(failed_units, (list, tuple)) or not failed_units:
+        lines.append("   %s  %s" % (paint("%-12s" % "units", BLUE),
+                                    paint("✓ all user units healthy", GREEN)))
+    else:
+        lines.append("   %s  %s" % (
+            paint("%-12s" % "units", BLUE),
+            paint("✗ %d failed: %s" % (
+                len(failed_units),
+                _truncate(", ".join(str(u) for u in failed_units), 44)),
+                RED, bold=True)))
+
+    # 2. Key timer-backed services — last-run result + age.
+    rows = unit_rows if isinstance(unit_rows, (list, tuple)) else []
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        label = r.get("label") or r.get("unit") or "?"
+        if not r.get("present"):
+            lines.append("   %s  %s" % (
+                paint("%-12s" % _truncate(label, 12), BLUE),
+                paint("— absent", DIMMER)))
+            continue
+        if r.get("ok") is True:
+            mark, mcol, bold = ("running" if r.get("running") else "ok"), GREEN, False
+        elif r.get("ok") is False:
+            mark, mcol, bold = (r.get("result") or "failed"), RED, True
+        else:
+            mark, mcol, bold = (r.get("active") or "?"), YELLOW, False
+        if r.get("age_secs") is None:
+            age = paint("never run", DIMMER)
+        elif r.get("running"):
+            age = paint("up " + rel_age(r["age_secs"]), DIMMER)
+        else:
+            age = paint(rel_age(r["age_secs"]) + " ago", DIMMER)
+        lines.append("   %s  %s  %s" % (
+            paint("%-12s" % _truncate(label, 12), BLUE),
+            paint("%-11s" % _truncate(mark, 11), mcol, bold=bold),
+            age))
+
+    # 3. Per-source telemetry freshness (from the TTL-cached CH aggregate).
+    lines.append(_render_telemetry_line(freshness))
+    return lines
+
+
+def _render_telemetry_line(freshness) -> str:
+    """One 'telemetry  zsh 1m  tmux 1m  keys 3m  …' line, or an 'unreachable'/
+    'off' fallback. `freshness` is the cached payload {sources:{src:age}} | {error}
+    | None."""
+    label = paint("%-12s" % "telemetry", BLUE)
+    if not isinstance(freshness, dict) or freshness.get("error") \
+            or "sources" not in freshness:
+        return "   %s  %s" % (label, paint("unreachable", YELLOW))
+    sources = freshness.get("sources") or {}
+    if not sources:
+        return "   %s  %s" % (label, paint("no rows (telemetry off?)", YELLOW))
+    parts = []
+    for s in TELEM_SOURCES:
+        if s in sources:
+            age = sources[s]
+            col = (GREEN if age < _TELEM_FRESH
+                   else (YELLOW if age < _TELEM_STALE else DIM))
+            parts.append(paint("%s %s" % (s, rel_age(age)), col))
+        else:
+            parts.append(paint("%s —" % s, DIM))
+    # Any unexpected extra sources returned by the query, appended dimly.
+    for s in sorted(sources):
+        if s not in TELEM_SOURCES:
+            parts.append(paint("%s %s" % (s, rel_age(sources[s])), DIM))
+    return "   %s  %s" % (label, "  ".join(parts))
+
+
 def render_done(initiatives, freshness="", limit=6) -> list:
     lines = [_header("Recently done", GREEN, freshness)]
     merged = [i for i in initiatives if (i.get("merged_prs") or 0) > 0]
@@ -814,6 +1124,69 @@ def maybe_refresh_prs(now=None):
             pass
 
 
+def refresh_telemetry_cache(now=None):
+    """Worker (run via `agent-ops --refresh-telemetry`): run the single CH
+    freshness aggregate and atomically write ~/.cache/agent-ops/
+    telemetry-freshness.json as {generated, sources:{src:age}} or
+    {generated, error}. Never raises; always drops the refresh lock."""
+    now = now or time.time()
+    try:
+        os.makedirs(CACHE_DIR, exist_ok=True)
+    except Exception:
+        return
+    payload = {"generated": now}
+    try:
+        payload["sources"] = query_telemetry_freshness()
+    except Exception as e:  # unconfigured / unreachable → error marker
+        payload["error"] = str(e)[:200]
+    try:
+        tmp = TELEM_CACHE + ".tmp"
+        with open(tmp, "w") as fh:
+            json.dump(payload, fh)
+        os.replace(tmp, TELEM_CACHE)
+    except Exception:
+        pass
+    finally:
+        try:
+            os.remove(TELEM_LOCK)
+        except Exception:
+            pass
+
+
+def maybe_refresh_telemetry(now=None):
+    """Kick a detached `agent-ops --refresh-telemetry` if the freshness cache is
+    stale and no refresh is already running. Never blocks; the CH round-trip only
+    ever happens in the detached worker, never on the popup render path."""
+    now = now or time.time()
+    try:
+        os.makedirs(CACHE_DIR, exist_ok=True)
+    except Exception:
+        return
+    cache_age = file_age_secs(TELEM_CACHE, now)
+    if cache_age is not None and cache_age < TELEM_TTL:
+        return
+    lock_age = file_age_secs(TELEM_LOCK, now)
+    if lock_age is not None and lock_age < ISCAN_LOCK_TTL:
+        return
+    if not os.path.exists(CHQUERY_PATH):
+        return  # no client available → leave the cache empty (renders unreachable)
+    try:
+        open(TELEM_LOCK, "w").close()
+    except Exception:
+        return
+    try:
+        subprocess.Popen(
+            [sys.executable, os.path.abspath(__file__), "--refresh-telemetry"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            start_new_session=True)
+    except Exception:
+        try:
+            os.remove(TELEM_LOCK)
+        except Exception:
+            pass
+
+
 # ===========================================================================
 # Frame assembly + interactive loop
 # ===========================================================================
@@ -840,11 +1213,25 @@ def build_body_lines(width: int) -> list:
 
     maybe_refresh_initiatives()
     maybe_refresh_prs()
+    maybe_refresh_telemetry()
     scan = read_json(ISCAN_CACHE)
     initiatives = flatten_initiatives(scan)
     fresh = initiatives_freshness()
     pr_rows = flatten_open_prs(read_json(PRS_CACHE))
     prs_fresh = initiatives_freshness(cache=PRS_CACHE, lock=PRS_LOCK)
+
+    # Local health: failed user units + key timer last-runs are cheap/local, so
+    # they run inline; the telemetry-freshness CH query is served from its TTL
+    # cache (refreshed in the background above), never inline.
+    failed_raw = fetch_failed_user_units()
+    failed_units = None if failed_raw is None else parse_failed_units(failed_raw)
+    uptime = read_uptime()
+    unit_rows = [
+        unit_health_row(unit, label, parse_systemctl_show(fetch_unit_show(unit)),
+                        uptime)
+        for unit, label in LOCAL_HEALTH_UNITS
+    ]
+    telemetry = read_json(TELEM_CACHE)
 
     blocks = [
         render_blocked(clawgate, mail, titles),
@@ -852,6 +1239,7 @@ def build_body_lines(width: int) -> list:
         render_prs(pr_rows, prs_fresh),
         render_momentum(initiatives, fresh),
         render_health(alerts, civitai),
+        render_local_health(failed_units, unit_rows, telemetry),
         render_done(initiatives, fresh),
     ]
     lines = []
@@ -1000,6 +1388,11 @@ def main(argv=None):
     if "--refresh-prs" in argv:
         # Internal: the detached background open-PR sweep (spawned by maybe_refresh_prs).
         refresh_prs_cache()
+        return 0
+    if "--refresh-telemetry" in argv:
+        # Internal: the detached telemetry-freshness CH query (spawned by
+        # maybe_refresh_telemetry).
+        refresh_telemetry_cache()
         return 0
     if "--once" in argv:
         # Non-interactive single frame — handy for capture-pane / debugging.

--- a/scripts/notify-failure.sh
+++ b/scripts/notify-failure.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# notify-failure.sh <failed-unit-name>
+#
+# Fired by the `notify-failure@.service` systemd-user TEMPLATE unit, which is
+# instanced by OnFailure=notify-failure@%n.service on the important user units
+# (see nix/home.nix + nix/graphical.nix). When a wired unit enters the `failed`
+# state, systemd starts notify-failure@<unit>.service, whose ExecStart runs this
+# with the failed unit name (%i) as $1.
+#
+# Zach reasons THROUGH the agent-facing automation layer, so a silently-dead
+# timer/collector is the worst failure mode — this makes it LOUD: a sticky
+# (urgency=critical) desktop toast pointing at the unit's journal.
+#
+# ROBUST WHEN HEADLESS: on a host with no X/dunst session (or when the graphical
+# gate is off) it logs a line to the journal and exits 0 — it must NEVER error
+# (an erroring OnFailure handler is itself an invisible failure). Mirrors the
+# DISPLAY/DBUS-borrow trick scripts/cpu-monitor.sh uses so the toast reaches the
+# desktop from this (systemd) context. Deterministic notification mechanism
+# reused from cpu-monitor (notify-send), NOT a new one.
+set -uo pipefail
+
+unit="${1:-unknown.unit}"
+
+log() { printf '[notify-failure] %s\n' "$*" >&2; }
+
+# Gate: only toast on a graphical host. home-manager sets
+# NOTIFY_FAILURE_GRAPHICAL=1 in the template unit's Environment ONLY on graphical
+# hosts (mirrors how dunst/espanso key off `graphical` in home.nix). The unit is
+# installed everywhere; on a headless host this just no-ops the toast.
+if [ "${NOTIFY_FAILURE_GRAPHICAL:-0}" != "1" ]; then
+  log "unit '$unit' FAILED (headless — no toast). Inspect: journalctl --user -u $unit -e"
+  exit 0
+fi
+
+# notify-send needs a display + session bus. Under a systemd user unit we usually
+# have neither, so borrow them from a running i3 process (same approach as
+# cpu-monitor.sh). Returns 0 only once a session bus is reachable.
+ensure_desktop_env() {
+  [ -n "${DISPLAY:-}" ] && [ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ] && return 0
+  local pid
+  pid=$(pgrep -u "$(id -u)" -x i3 | head -1) || true
+  [ -z "$pid" ] && pid=$(pgrep -u "$(id -u)" -x i3bar | head -1) || true
+  [ -z "$pid" ] && return 1
+  local env_file="/proc/$pid/environ"
+  [ -r "$env_file" ] || return 1
+  local d b x
+  d=$(tr '\0' '\n' < "$env_file" | grep -m1 '^DISPLAY=' || true)
+  b=$(tr '\0' '\n' < "$env_file" | grep -m1 '^DBUS_SESSION_BUS_ADDRESS=' || true)
+  x=$(tr '\0' '\n' < "$env_file" | grep -m1 '^XAUTHORITY=' || true)
+  [ -n "$d" ] && export "${d?}"
+  [ -n "$b" ] && export "${b?}"
+  [ -n "$x" ] && export "${x?}"
+  [ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ]
+}
+
+if ensure_desktop_env; then
+  # urgency=critical -> sticky in the dunstrc (timeout 0) so a failure is not
+  # missed. -a sets the app name; the body carries the exact journal command.
+  notify-send -u critical -a notify-failure -i dialog-error \
+    "⚠ ${unit} failed" \
+    "A user unit entered the failed state.
+journalctl --user -u ${unit} -e" \
+    || log "notify-send failed for '$unit' (see: journalctl --user -u $unit)"
+else
+  # No reachable desktop session — fall back to the journal so nothing is lost.
+  log "unit '$unit' FAILED (no desktop session). Inspect: journalctl --user -u $unit -e"
+fi
+exit 0

--- a/scripts/tests/test_agent_ops.py
+++ b/scripts/tests/test_agent_ops.py
@@ -528,9 +528,150 @@ def test_build_frame_failsafe(monkeypatch):
     monkeypatch.setattr(ao, "own_pid_chain", lambda: set())
     monkeypatch.setattr(ao, "maybe_refresh_initiatives", lambda *a, **k: None)
     monkeypatch.setattr(ao, "maybe_refresh_prs", lambda *a, **k: None)
+    monkeypatch.setattr(ao, "maybe_refresh_telemetry", lambda *a, **k: None)
     monkeypatch.setattr(ao, "enrich_clawgate_titles", lambda *a, **k: [])
+    # Local-health fetches must not touch systemctl / the network in the sandbox.
+    monkeypatch.setattr(ao, "fetch_failed_user_units", lambda *a, **k: None)
+    monkeypatch.setattr(ao, "fetch_unit_show", lambda *a, **k: None)
+    monkeypatch.setattr(ao, "read_uptime", lambda *a, **k: None)
     frame = ao.build_frame(100)
     body = plain(frame)
     for section in ("BLOCKED ON ME", "ACTIVE AGENT RUNS", "IN FLIGHT",
-                    "MOMENTUM", "HEALTH", "RECENTLY DONE"):
+                    "MOMENTUM", "HEALTH", "LOCAL HEALTH", "RECENTLY DONE"):
         assert section in body
+
+
+# ---------------------------------------------------------------------------
+# Local health — parse_failed_units / parse_systemctl_show / unit_health_row
+# ---------------------------------------------------------------------------
+def test_parse_failed_units_extracts_unit_column():
+    raw = (
+        "keylog.service       loaded failed failed X11 keystroke collector\n"
+        "repo-cos.timer       loaded failed failed Weekly timer\n"
+        "\n"
+    )
+    assert ao.parse_failed_units(raw) == ["keylog.service", "repo-cos.timer"]
+
+
+def test_parse_failed_units_failsafe():
+    assert ao.parse_failed_units(None) == []
+    assert ao.parse_failed_units("") == []
+    # a stray non-unit line (e.g. a legend) is ignored
+    assert ao.parse_failed_units("0 loaded units listed.") == []
+
+
+def test_parse_systemctl_show_keyvalues():
+    raw = "LoadState=loaded\nActiveState=failed\nResult=exit-code\n"
+    d = ao.parse_systemctl_show(raw)
+    assert d["LoadState"] == "loaded"
+    assert d["ActiveState"] == "failed"
+    assert d["Result"] == "exit-code"
+    assert ao.parse_systemctl_show(None) == {}
+
+
+def test_unit_health_row_oneshot_success():
+    show = {"LoadState": "loaded", "ActiveState": "inactive", "SubState": "dead",
+            "Result": "success", "ExecMainExitTimestampMonotonic": "1000000"}
+    r = ao.unit_health_row("repo-cos.service", "repo-cos", show, uptime=3601)
+    assert r["present"] and r["ok"] is True and r["running"] is False
+    # 3601s uptime - 1_000_000us(=1s) exit → ~3600s (1h) ago
+    assert 3590 <= r["age_secs"] <= 3601
+
+
+def test_unit_health_row_running_daemon_uses_start_age():
+    show = {"LoadState": "loaded", "ActiveState": "active", "SubState": "running",
+            "Result": "success", "ExecMainStartTimestampMonotonic": "1000000",
+            "ExecMainExitTimestampMonotonic": "0"}
+    r = ao.unit_health_row("activity-collector.service", "collector", show,
+                           uptime=7201)
+    assert r["running"] is True and r["ok"] is True
+    assert 7190 <= r["age_secs"] <= 7201   # up ~2h (start age, not exit)
+
+
+def test_unit_health_row_failed():
+    show = {"LoadState": "loaded", "ActiveState": "failed", "SubState": "failed",
+            "Result": "exit-code", "ExecMainExitTimestampMonotonic": "1000000"}
+    r = ao.unit_health_row("keylog.service", "keylog", show, uptime=100)
+    assert r["ok"] is False and r["result"] == "exit-code"
+
+
+def test_unit_health_row_absent_when_not_found():
+    r = ao.unit_health_row("mail-actions-archive.service", "mail-archive",
+                           {"LoadState": "not-found"}, uptime=100)
+    assert r["present"] is False and r["ok"] is None and r["age_secs"] is None
+    # an empty show (systemctl failed) is also absent
+    assert ao.unit_health_row("x.service", "x", {}, uptime=100)["present"] is False
+
+
+def test_unit_health_row_never_run_unknown():
+    # loaded but never started (oneshot before first fire): no exit ts, inactive.
+    show = {"LoadState": "loaded", "ActiveState": "inactive", "SubState": "dead",
+            "Result": "success", "ExecMainExitTimestampMonotonic": "0"}
+    r = ao.unit_health_row("mail-actions-archive.service", "mail-archive", show,
+                           uptime=None)
+    assert r["present"] is True and r["age_secs"] is None
+
+
+# ---------------------------------------------------------------------------
+# Local health — render_local_health / _render_telemetry_line
+# ---------------------------------------------------------------------------
+def _row(label, **kw):
+    base = {"unit": label + ".service", "label": label, "present": True,
+            "ok": True, "running": False, "age_secs": 60, "result": "success",
+            "active": "inactive"}
+    base.update(kw)
+    return base
+
+
+def test_render_local_health_all_healthy():
+    fresh = {"sources": {"zsh": 30, "tmux": 45, "keys": 5, "i3": 12,
+                         "browser": 300, "claude": 90}, "generated": 0}
+    out = plain(ao.render_local_health([], [_row("repo-cos")], fresh))
+    text = "\n".join(out)
+    assert "LOCAL HEALTH" in text
+    assert "all user units healthy" in text
+    assert "repo-cos" in text and "ok" in text
+    # every expected source appears in the telemetry line
+    for src in ("zsh", "tmux", "keys", "i3", "browser", "claude"):
+        assert src in text
+
+
+def test_render_local_health_failed_and_absent():
+    out = plain(ao.render_local_health(
+        ["keylog.service"],
+        [_row("bad", ok=False, result="exit-code"),
+         _row("gone", present=False, ok=None, age_secs=None)],
+        None))
+    text = "\n".join(out)
+    assert "1 failed: keylog.service" in text
+    assert "exit-code" in text
+    assert "absent" in text
+    # None cache → telemetry unreachable
+    assert "unreachable" in text
+
+
+def test_render_local_health_systemctl_na():
+    out = plain(ao.render_local_health(None, [], {"error": "x", "generated": 0}))
+    text = "\n".join(out)
+    assert "systemctl n/a" in text
+    assert "unreachable" in text
+
+
+def test_render_telemetry_line_missing_source_shown_dim():
+    # keys/browser absent from the result → shown as "keys —"/"browser —"
+    line = plain(ao._render_telemetry_line(
+        {"sources": {"zsh": 10, "tmux": 20, "i3": 5, "claude": 8},
+         "generated": 0}))
+    assert "keys —" in line and "browser —" in line
+    assert "zsh" in line and "tmux" in line
+
+
+def test_render_telemetry_line_no_rows():
+    line = plain(ao._render_telemetry_line({"sources": {}, "generated": 0}))
+    assert "telemetry off" in line or "no rows" in line
+
+
+def test_render_local_health_never_raises_on_junk():
+    # totally malformed inputs must degrade, never raise
+    ao.render_local_health("junk", "junk", "junk")
+    ao.render_local_health(None, None, None)

--- a/scripts/tests/test_notify_failure.py
+++ b/scripts/tests/test_notify_failure.py
@@ -1,0 +1,96 @@
+"""Tests for scripts/notify-failure.sh — the systemd OnFailure toast handler.
+
+Hermetic: drives the bash script as a subprocess with an injected fake
+`notify-send` on PATH and (for the graphical case) DISPLAY/DBUS pre-set so the
+handler's desktop-env probe short-circuits without needing a real i3/X session.
+
+Two contracts under test:
+  * headless (NOTIFY_FAILURE_GRAPHICAL unset/0): exits 0, fires NO toast, logs a
+    journal hint to stderr — never errors (an erroring OnFailure handler is
+    itself an invisible failure).
+  * graphical (NOTIFY_FAILURE_GRAPHICAL=1 + a reachable session bus): calls
+    notify-send with the failed unit name in the summary.
+"""
+import os
+import subprocess
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_HANDLER = os.path.join(_HERE, "..", "notify-failure.sh")
+
+
+def _make_fake_notify_send(dir_path):
+    """Write a stub `notify-send` that records argv to <dir>/notify-send.args."""
+    out = os.path.join(dir_path, "notify-send.args")
+    stub = os.path.join(dir_path, "notify-send")
+    # $@ / %s\n are literal bash; only `out` is interpolated (via concatenation
+    # so no Python %-formatting touches the bash body).
+    body = "#!/usr/bin/env bash\nprintf '%s\\n' \"$@\" > '" + out + "'\n"
+    with open(stub, "w") as fh:
+        fh.write(body)
+    os.chmod(stub, 0o755)
+    return out
+
+
+def _run(env_extra, unit="repo-cos.service"):
+    env = dict(os.environ)
+    env.update(env_extra)
+    return subprocess.run(
+        ["bash", _HANDLER, unit],
+        capture_output=True, text=True, env=env, timeout=15)
+
+
+def test_headless_no_toast_exits_zero(tmp_path):
+    """No graphical gate → exit 0, journal hint on stderr, notify-send never run."""
+    argfile = _make_fake_notify_send(str(tmp_path))
+    r = _run({
+        "PATH": "%s:%s" % (tmp_path, os.environ.get("PATH", "")),
+        "NOTIFY_FAILURE_GRAPHICAL": "0",
+        # ensure the desktop probe can't accidentally find a bus
+        "DISPLAY": "", "DBUS_SESSION_BUS_ADDRESS": "",
+    })
+    assert r.returncode == 0
+    assert "repo-cos.service" in r.stderr
+    assert "journalctl --user -u repo-cos.service" in r.stderr
+    assert not os.path.exists(argfile)  # NO toast fired
+
+
+def test_graphical_gate_unset_is_headless(tmp_path):
+    """Missing NOTIFY_FAILURE_GRAPHICAL behaves like headless (default 0)."""
+    argfile = _make_fake_notify_send(str(tmp_path))
+    env = {"PATH": "%s:%s" % (tmp_path, os.environ.get("PATH", "")),
+           "DISPLAY": "", "DBUS_SESSION_BUS_ADDRESS": ""}
+    env.pop("NOTIFY_FAILURE_GRAPHICAL", None)
+    r = _run(env)
+    assert r.returncode == 0
+    assert not os.path.exists(argfile)
+
+
+def test_graphical_fires_toast_with_unit_name(tmp_path):
+    """Graphical + a reachable session bus → notify-send called with the unit."""
+    argfile = _make_fake_notify_send(str(tmp_path))
+    r = _run({
+        "PATH": "%s:%s" % (tmp_path, os.environ.get("PATH", "")),
+        "NOTIFY_FAILURE_GRAPHICAL": "1",
+        # Pre-set both so ensure_desktop_env short-circuits (no i3/pgrep needed).
+        "DISPLAY": ":0",
+        "DBUS_SESSION_BUS_ADDRESS": "unix:path=/run/user/1000/bus",
+    }, unit="mail-actions-archive.service")
+    assert r.returncode == 0
+    assert os.path.exists(argfile), "notify-send should have been invoked"
+    with open(argfile) as fh:
+        args = fh.read()
+    assert "mail-actions-archive.service" in args
+    assert "critical" in args  # urgency=critical (sticky)
+
+
+def test_default_unit_when_no_arg(tmp_path):
+    """No arg → 'unknown.unit', still exits 0 (never errors)."""
+    _make_fake_notify_send(str(tmp_path))
+    env = dict(os.environ)
+    env.update({"PATH": "%s:%s" % (tmp_path, os.environ.get("PATH", "")),
+                "NOTIFY_FAILURE_GRAPHICAL": "0",
+                "DISPLAY": "", "DBUS_SESSION_BUS_ADDRESS": ""})
+    r = subprocess.run(["bash", _HANDLER], capture_output=True, text=True,
+                       env=env, timeout=15)
+    assert r.returncode == 0
+    assert "unknown.unit" in r.stderr


### PR DESCRIPTION
Make the agent-facing automation layer **observable**. Zach reasons *through* this automation, so silent failure / stale data is the worst failure mode. Two related changes, one PR.

## Part 1 — systemd `OnFailure=` failure notifications (gap #2)
Before this PR `grep OnFailure nix/*.nix` returned nothing — the user timers/services failed silently.

- **New `notify-failure@.service` user TEMPLATE unit** (`nix/home.nix`), instanced by `OnFailure=notify-failure@%n.service` so the handler learns the failed unit's name via `%i`. Installed on **every** host; the toast is gated on the graphical host by only exporting `NOTIFY_FAILURE_GRAPHICAL=1` there (mirrors the `dunst`/`espanso` `graphical` gate).
- **`scripts/notify-failure.sh`** — emits a sticky (`urgency=critical`) desktop toast `⚠ <unit> failed` pointing at `journalctl --user -u <unit>`, **reusing cpu-monitor's `notify-send` + DISPLAY/DBUS-borrow-from-i3 pattern** (not a new mechanism). Headless-safe: no reachable session bus → logs to the journal and **exits 0**, never errors.
- **`OnFailure=` wired onto the important units**: `activity-collector`, `claude-activity-source`, `keylog`, `i3-source`, `mail-actions-archive`, `repo-cos` (home.nix) + `bar-status-poll` (graphical.nix).

## Part 2 — agent-ops "Local health" (gap #3)
`scripts/agent-ops` previously showed only homelab/civitai Grafana alerts. New **Local health** block so an agent/Zach can see at a glance whether the layer feeding their decisions is alive:

- **(a) unit health** — `systemctl --user --failed` + last-run result/age of the key timers (repo-cos, mail-actions-archive, bar-status-poll, claude-activity-source, activity-collector). Running daemons show `running · up Nh`; oneshots show `ok · Nh ago`; workbench-only units show `absent` on the laptop.
- **(b) telemetry freshness** — `last activity.events row N ago` per `source`, from a **single cheap CH aggregate** (`dateDiff('second', max(ts), now()) GROUP BY source`, 2-day scan, short timeout). Endpoint/creds are **reused from the collector's own env file + the shared `validation/chquery` client — NOT hardcoded**. Served from a 60s TTL cache with a detached background refresh (same pattern as the PR/initiative caches), so the CH round-trip never runs on the popup render path.
- Fully fail-safe: `systemctl` n/a, an absent unit, or unreachable CH each degrade to a calm line (`telemetry: unreachable`), never a crash.

## Validation
- `nix-instantiate --parse` clean on both touched nix files.
- **Build-validated without activating**: `nix build .#homeConfigurations.zach.activationPackage --impure` → **exit 0**. Inspected the generated units: `notify-failure@.service` present (with `NOTIFY_FAILURE_GRAPHICAL=1` + libnotify on PATH), and all 7 target units carry `OnFailure=notify-failure@%n.service`.
- **Tests green**: `scripts/run-tests.sh --set hermetic` → RESULT: PASS. New `test_notify_failure.py` (handler-as-subprocess: headless no-toast/exit-0 + graphical fires-toast-with-unit-name) and extended `test_agent_ops.py` (parse_failed_units / parse_systemctl_show / unit_health_row / render_local_health / telemetry-line + fail-safe).
- **Real toast smoke** (handler → live dunst, borrowing DISPLAY/DBUS from i3): `⚠ smoke-test.service failed` landed in `dunstctl history` — the notify-send → dunst path works end-to-end on the actual desktop.

### Verification boundary (remaining LIVE steps — require `home-manager switch`, do after merge)
1. **Toast on a real OnFailure fire**: after switch, `systemctl --user start notify-failure@test.service` → expect a `⚠ test failed` toast. (Or force a real unit to fail and confirm its OnFailure toast.)
2. **agent-ops render on-cluster**: open the dashboard (`$mod+i` / tmux `prefix+A` / ▦ bar button) and confirm the **Local health** block renders with live unit states + populated telemetry-freshness line.

The build proves it evaluates/builds and the handler's toast path works; it does **not** prove systemd fires OnFailure on a live unit failure or that the dashboard renders on-cluster — those are the two steps above.

### Design choices flagged
- **Telemetry freshness colour bands are deliberately generous** (green <30m, yellow <3h, else dim). keys/i3/browser only emit while you're active, so a quiet source isn't necessarily broken — this view flags "is the layer alive", not "are you at the keyboard". A totally dead collector shows every source dim.
- **`NOTIFY_FAILURE_GRAPHICAL` is set on both real hosts** (both are NixOS+graphical, `graphical = isNixOS`); the runtime i3/DBUS probe is the actual headless backstop. If you ever run a truly headless host, the env is absent there and the handler no-ops.
- **Freshness reuses the collector's writer env** (`~/.config/activity-collector/env`, the endpoint the writer uses on this host) rather than the `activity_reader`/SOPS creds, since agent-ops runs without those exported — same cluster, no new secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)