### PR TITLE
fix(airvpn): police all physical NICs + fail-closed killswitch + active-pill display

### DIFF
--- a/scripts/airvpn-updown
+++ b/scripts/airvpn-updown
@@ -71,17 +71,41 @@ KS_TABLE="airvpn_ks"
 
 log() { logger -t airvpn-updown "$*" 2>/dev/null || echo "airvpn-updown: $*" >&2; }
 
+# Blanket FAIL-CLOSED ruleset — installed only if the main killswitch nft load
+# fails, so an nft error can never leave the uplink UNFILTERED (fail-open). Minimal
+# on purpose (no dynamic PHYS_SET / fwmark / EP substitution that could be what
+# broke the main load): allow internal ifaces + nebula (skuid) + LAN + lighthouse,
+# drop the rest. Keeps the operator reachable while still stopping an internet leak.
+arm_failclosed() {
+    nft add table inet "$KS_TABLE" 2>/dev/null || true
+    nft flush table inet "$KS_TABLE" 2>/dev/null || true
+    nft -f - <<FB || log "FALLBACK nft load ALSO FAILED — uplink is NOT filtered!"
+table inet ${KS_TABLE} {
+    chain out {
+        type filter hook output priority 0; policy accept;
+        oifname { "lo", "${IFACE}", "nebula.mesh", "cni0", "flannel.1", "docker0" } accept
+        meta skuid "${NEBULA_USER}" accept
+        ip daddr ${LAN_SUBNET} accept
+        ip daddr ${NEBULA_LIGHTHOUSE} accept
+        drop
+    }
+}
+FB
+}
+
 # Original default gateway + physical iface (the default route NOT via the tunnel).
 # Used for the split-tunnel bypass ROUTES (they need one specific gateway).
 orig_gw()   { ip -o route show default 2>/dev/null | grep -v "dev ${IFACE}" | awk '{print $3}' | head -1; }
 orig_if()   { ip -o route show default 2>/dev/null | grep -v "dev ${IFACE}" | awk '{print $5}' | head -1; }
 
-# ALL physical NICs (hardware devices), one name per line — the COMPLETE leak
-# surface for the killswitch. `/sys/class/net/<if>/device` exists only for real
-# hardware (PCI/USB) NICs; virtual ifaces (lo, wg/airvpn, nebula.mesh tun, cni0
-# bridge, flannel.1 vxlan, docker0, veth*) have no such symlink and are never
-# policed. Derived from hardware presence (not the default route) so it covers
-# multi-homed hosts and a NIC that gets routed after PostUp.
+# ALL physical NICs (hardware devices), one name per line. `/sys/class/net/<if>/
+# device` exists only for real hardware (PCI/USB) NICs; virtual ifaces (lo, wg/
+# airvpn, nebula.mesh tun, cni0 bridge, flannel.1 vxlan, docker0, veth*) have no
+# such symlink. Derived from hardware presence (not the default route) so it covers
+# multi-homed hosts and a NIC that gets routed after PostUp. NOTE: the policed set
+# (below) UNIONS this with the live default-route egress iface — because a
+# bridge/bond/VLAN uplink (br0, bond0, eth1.100) carries internet but has NO device
+# symlink, so hardware-presence ALONE would trust (leak) it (#128 audit 🟡).
 phys_ifaces() {
     local d n
     for d in /sys/class/net/*/device; do
@@ -99,7 +123,14 @@ endpoint_ip() {
 case "$action" in
     up)
         GW="$(orig_gw)"; PHYS="$(orig_if)"
-        mapfile -t PHYS_SET < <(phys_ifaces)
+        # Policed set = ALL hardware NICs UNION the live default-route egress iface(s)
+        # (excluding the tunnel). The union closes the bridge/bond/VLAN blind spot: those
+        # carry internet but have no /sys device, so hardware-presence alone would leak
+        # them; adding the actual egress iface polices whatever the default route uses.
+        mapfile -t PHYS_SET < <(
+            { phys_ifaces
+              ip -o route show default 2>/dev/null | grep -v "dev ${IFACE}" | awk '{print $5}'
+            } | sort -u)
 
         # --- split-tunnel bypass routes (need ONE gateway; skip + warn if absent,
         #     but STILL arm the killswitch below so we never fail OPEN) -------------
@@ -133,7 +164,7 @@ case "$action" in
         fi
         nft add table inet "$KS_TABLE" 2>/dev/null || true
         nft flush table inet "$KS_TABLE" 2>/dev/null || true
-        nft -f - <<NFT || log "killswitch nft load failed (traffic NOT fail-closed)"
+        nft -f - <<NFT || { log "killswitch nft load FAILED — installing blanket fail-closed fallback"; arm_failclosed; }
 table inet ${KS_TABLE} {
     chain out {
         type filter hook output priority 0; policy accept;
@@ -159,7 +190,6 @@ NFT
         ;;
     down)
         nft delete table inet "$KS_TABLE" 2>/dev/null || true
-        GW="$(cat "$GW_FILE" 2>/dev/null || true)"
         for dst in "$NEBULA_LIGHTHOUSE" "$LAN_ROUTER"; do
             ip route del "$dst" 2>/dev/null || true
         done

--- a/scripts/airvpn-updown
+++ b/scripts/airvpn-updown
@@ -18,11 +18,18 @@
 #   * 192.168.50.1 (LAN router / DNS upstream) + the LAN 192.168.50.0/24 direct,
 #   * the nebula Hetzner lighthouse (discovery/relay).
 #
-# KILLSWITCH (fail-closed) — POLICES ONLY THE PHYSICAL UPLINK. The chain's first
-# rule is `oifname != <phys> accept`, so everything leaving via a NON-physical
-# interface is ALWAYS allowed: loopback, the airvpn tunnel, the nebula overlay
-# (nebula.mesh), and the k3s CNI (cni0 / flannel.1 → the pod & service CIDRs). Only
-# traffic egressing the physical uplink is filtered, and there only wg's own
+# KILLSWITCH (fail-closed) — POLICES ALL PHYSICAL NICs. The chain's first rule is
+# `oifname != { <all physical NICs> } accept`, so everything leaving via a
+# NON-physical interface is ALWAYS allowed: loopback, the airvpn tunnel, the nebula
+# overlay (nebula.mesh), and the k3s CNI (cni0 / flannel.1 → the pod & service
+# CIDRs). The physical set is derived from /sys/class/net/*/device (hardware
+# presence), NOT the default route — so it covers a MULTI-HOMED host (eth + wifi +
+# usb; this workbench has 3 NICs) AND a NIC that gains a default route AFTER PostUp,
+# both of which a single-`$PHYS` guard would leak (#126 audit 🟡). If NO physical NIC
+# is found (near-impossible with a live tunnel), it FAILS CLOSED (allow internal
+# ifaces only, drop the rest) rather than the old fail-OPEN `exit 0` that left the
+# tunnel up with no killswitch. Only traffic egressing a physical NIC is filtered,
+# and there only wg's own
 # encrypted packets (fwmark), the LAN, nebula's own transport (matched by SOCKET
 # OWNER — `meta skuid nebula-mesh` — NOT a port, because nebula runs listen.port:0
 # and binds a RANDOM source port; a `udp sport 4242` rule matched nothing and let
@@ -65,8 +72,24 @@ KS_TABLE="airvpn_ks"
 log() { logger -t airvpn-updown "$*" 2>/dev/null || echo "airvpn-updown: $*" >&2; }
 
 # Original default gateway + physical iface (the default route NOT via the tunnel).
+# Used for the split-tunnel bypass ROUTES (they need one specific gateway).
 orig_gw()   { ip -o route show default 2>/dev/null | grep -v "dev ${IFACE}" | awk '{print $3}' | head -1; }
 orig_if()   { ip -o route show default 2>/dev/null | grep -v "dev ${IFACE}" | awk '{print $5}' | head -1; }
+
+# ALL physical NICs (hardware devices), one name per line — the COMPLETE leak
+# surface for the killswitch. `/sys/class/net/<if>/device` exists only for real
+# hardware (PCI/USB) NICs; virtual ifaces (lo, wg/airvpn, nebula.mesh tun, cni0
+# bridge, flannel.1 vxlan, docker0, veth*) have no such symlink and are never
+# policed. Derived from hardware presence (not the default route) so it covers
+# multi-homed hosts and a NIC that gets routed after PostUp.
+phys_ifaces() {
+    local d n
+    for d in /sys/class/net/*/device; do
+        [[ -e "$d" ]] || continue
+        n="${d%/device}"
+        basename "$n"
+    done
+}
 
 # The connected peer endpoint IP (for the endpoint bypass /32).
 endpoint_ip() {
@@ -76,50 +99,63 @@ endpoint_ip() {
 case "$action" in
     up)
         GW="$(orig_gw)"; PHYS="$(orig_if)"
-        if [[ -z "$GW" || -z "$PHYS" ]]; then
-            log "could not determine original gateway/iface — aborting bypass setup"
-            exit 0   # never fail the tunnel bring-up
+        mapfile -t PHYS_SET < <(phys_ifaces)
+
+        # --- split-tunnel bypass routes (need ONE gateway; skip + warn if absent,
+        #     but STILL arm the killswitch below so we never fail OPEN) -------------
+        if [[ -n "$GW" && -n "$PHYS" ]]; then
+            echo "$GW"   > "$GW_FILE"
+            echo "$PHYS" > "$IFACE_FILE"
+            EP="$(endpoint_ip)"
+            [[ -n "$EP" ]] && ip route replace "$EP" via "$GW" dev "$PHYS" 2>/dev/null || true
+            ip route replace "$LAN_ROUTER"        via "$GW" dev "$PHYS" 2>/dev/null || true
+            ip route replace "$NEBULA_LIGHTHOUSE" via "$GW" dev "$PHYS" 2>/dev/null || true
+            # LAN /24 stays direct via the connected route; assert it explicitly too.
+            ip route replace "$LAN_SUBNET" dev "$PHYS" scope link 2>/dev/null || true
+        else
+            EP=""
+            log "WARNING: no default gateway/iface — split-tunnel bypass routes NOT set; arming killswitch anyway (fail-closed)"
         fi
-        echo "$GW"   > "$GW_FILE"
-        echo "$PHYS" > "$IFACE_FILE"
 
-        EP="$(endpoint_ip)"
-        # --- split-tunnel bypass routes (MAIN table /32s beat the tunnel default) --
-        [[ -n "$EP" ]] && ip route replace "$EP" via "$GW" dev "$PHYS" 2>/dev/null || true
-        ip route replace "$LAN_ROUTER"       via "$GW" dev "$PHYS" 2>/dev/null || true
-        ip route replace "$NEBULA_LIGHTHOUSE" via "$GW" dev "$PHYS" 2>/dev/null || true
-        # LAN /24 stays direct via the connected route; assert it explicitly too.
-        ip route replace "$LAN_SUBNET" dev "$PHYS" scope link 2>/dev/null || true
-
-        # --- fail-closed killswitch (nftables) -----------------------------------
+        # --- fail-closed killswitch (nftables) — polices ALL physical NICs --------
         FWMARK="$(wg show "$IFACE" fwmark 2>/dev/null)"   # e.g. 0xca6c
+        # Build rule 1 (the uplink guard). NORMAL: accept everything NOT egressing a
+        # physical NIC (durable + covers every physical uplink). DEGRADED (no physical
+        # NIC found — near-impossible with a live tunnel): FAIL CLOSED, allow only the
+        # known-internal ifaces and drop the rest, rather than leave the killswitch
+        # open. `oifname` matches by NAME, so listing an absent iface is harmless.
+        if [[ ${#PHYS_SET[@]} -gt 0 ]]; then
+            _set="$(printf '"%s", ' "${PHYS_SET[@]}")"
+            UPLINK_GUARD="oifname != { ${_set%, } } accept"
+        else
+            log "ERROR: no physical uplink NIC found — arming FAIL-CLOSED killswitch (internal ifaces only)"
+            UPLINK_GUARD='oifname { "lo", "'"${IFACE}"'", "nebula.mesh", "cni0", "flannel.1", "docker0" } accept'
+        fi
         nft add table inet "$KS_TABLE" 2>/dev/null || true
         nft flush table inet "$KS_TABLE" 2>/dev/null || true
         nft -f - <<NFT || log "killswitch nft load failed (traffic NOT fail-closed)"
 table inet ${KS_TABLE} {
     chain out {
         type filter hook output priority 0; policy accept;
-        # Police ONLY the physical uplink. Loopback, the tunnel, the nebula overlay
-        # (nebula.mesh) and the k3s CNI (cni0/flannel.1 → pods/services) all egress a
-        # NON-physical iface and are always allowed — durable: new internal nets need
-        # no rule. See the header for why this is leak-equivalent to a default-drop.
-        oifname != "${PHYS}" accept
-        # On the uplink, allow only the legitimate un-tunnelled flows; drop the rest.
+        # Rule 1: allow all NON-physical egress (loopback, tunnel, nebula.mesh, CNI,
+        # docker, veth). Durable — new internal nets need no rule. See the header.
+        ${UPLINK_GUARD}
+        # On a physical NIC, allow only the legitimate un-tunnelled flows; drop rest.
         $( [[ -n "$FWMARK" && "$FWMARK" != "off" ]] && echo "meta mark ${FWMARK} accept" )
         ip daddr ${LAN_SUBNET} accept
         meta skuid "${NEBULA_USER}" accept
         ip daddr ${NEBULA_LIGHTHOUSE} accept
         $( [[ -n "$EP" ]] && echo "ip daddr ${EP} accept" )
-        ip daddr ${GW} accept
+        $( [[ -n "$GW" ]] && echo "ip daddr ${GW} accept" )
         # link-local + multicast housekeeping stay allowed
         ip6 daddr fe80::/10 accept
         ip daddr 224.0.0.0/4 accept
-        # anything else egressing the uplink un-tunnelled -> DROP (fail-closed)
+        # anything else egressing a physical NIC un-tunnelled -> DROP (fail-closed)
         drop
     }
 }
 NFT
-        log "up: killswitch armed (fwmark=${FWMARK:-none}), bypasses gw=$GW ep=${EP:-?}"
+        log "up: killswitch armed (fwmark=${FWMARK:-none}) policing [${PHYS_SET[*]:-FAIL-CLOSED}], gw=${GW:-none} ep=${EP:-?}"
         ;;
     down)
         nft delete table inet "$KS_TABLE" 2>/dev/null || true

--- a/scripts/i3status-airvpn
+++ b/scripts/i3status-airvpn
@@ -61,13 +61,20 @@ def load(path):
 
 
 def _cc(payload) -> str:
-    """Short country label for the pill: country_code upper, else first-2 of name."""
+    """Short country label for the pill: the connected SERVER's country_code (else
+    its name), falling back to the observed EXIT country when the server's is unknown
+    (a hostname endpoint like `ca3.vpn.airdns.org` doesn't map to a manifest server,
+    so `country_code` is null while ipinfo still gives us `exit_country`). Without the
+    fallback the active pill renders a useless `??`."""
     cc = payload.get("country_code")
     if isinstance(cc, str) and cc.strip():
         return cc.strip().upper()[:3]
     name = payload.get("country")
     if isinstance(name, str) and name.strip():
         return name.strip()[:2].upper()
+    exit_cc = payload.get("exit_country")
+    if isinstance(exit_cc, str) and exit_cc.strip():
+        return exit_cc.strip().upper()[:3]
     return "??"
 
 

--- a/scripts/tests/test_airvpn_menu.py
+++ b/scripts/tests/test_airvpn_menu.py
@@ -304,6 +304,15 @@ def test_render_up_unknown_marks_but_stays_neutral():
     assert r["state"] == "Idle" and r["text"] == "CA?"
 
 
+def test_render_up_falls_back_to_exit_country_when_server_unknown():
+    # Active tunnel to a HOSTNAME endpoint (e.g. ca3.vpn.airdns.org): the poller
+    # can't map it to a manifest server so country_code/country are null, but ipinfo
+    # still gives exit_country. Must show the exit CC, not a useless '??' -> '???'.
+    r = blk.render({"up": True, "country_code": None, "country": None,
+                    "exit_country": "ca", "verdict": "unknown"})
+    assert r["state"] == "Idle" and r["text"] == "CA?"
+
+
 def test_render_leak_is_critical():
     r = blk.render({"up": True, "country_code": "ca", "verdict": "leak"})
     assert r["state"] == "Critical" and r["text"] == "LEAK"


### PR DESCRIPTION
Closes the two 🟡s from the #126 audit, plus a display bug found while verifying the live tunnel.

## 🟡 → fixed: killswitch (`scripts/airvpn-updown`)
**Second-uplink leak.** `oifname != "$PHYS" accept` accepted egress on any *other* physical NIC. This workbench actually has **three** (`eth1` + `wlp15s0` + `enp18s0u2u2c2`), and the laptop is multi-homed — so this was a live latent leak, not hypothetical. Now polices **all physical NICs**, derived from `/sys/class/net/*/device` (hardware presence, not the default route) → `oifname != { <all phys> } accept`. Also covers a NIC that gains a default route *after* PostUp.

**Fail-open abort.** Empty `GW`/`PHYS` did `exit 0` *before* loading nft → tunnel up with **no killswitch** (silent leak). Now the killswitch **always arms**; only the bypass *routes* are skipped (loud warning) when there's no gateway. If **no** physical NIC is found (near-impossible with a live tunnel), it **fails closed** (allow internal ifaces only, drop the rest).

## Bonus: active-pill display bug (`scripts/i3status-airvpn`)
While verifying the live tunnel the active pill rendered **`???`** — a hostname endpoint (`ca3.vpn.airdns.org`) doesn't map to a manifest server, so the server `country_code` is null. `_cc()` now falls back to the observed ipinfo `exit_country` → shows **`CA?`**. Confirmed live (screenshot). +1 render test.

**Display now:** inactive → icon-only dim · active → `⟨icon⟩ CA?` (or `CA` when verified) · leak → `LEAK` red · fwd-port down → `CA!` yellow · stale → icon-only soft-yellow.

## Verification
- `bash -n`; `phys_ifaces()` returns the 3 real NICs live; nft chain rendered offline for **3-NIC / single-NIC / empty(fail-closed)**; **42** pytest pass.
- Display fix deployed via `home-manager switch` and **confirmed on the live bar** (`CA?`).
- ⚠️ The **killswitch change is NOT live** — it needs re-install to `/etc/nixos/i3blocks-scripts/` + a reconnect. That reconnect must be **off-LAN nebula, `kubectl` watching, orphan-safe `down` staged** (a LAN test can't reach the direct-punch lockout mode). I can't run that.

Follows #118 / #122 / #126. Bar skill updated (per-host) with the new display + killswitch model + live Phase-2 status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)