### PR TITLE
fix(playwright): launch nixpkgs Chromium on NixOS instead of the broken bundle

### DIFF
--- a/claudedocs/playwright-nixos.md
+++ b/claudedocs/playwright-nixos.md
@@ -11,6 +11,20 @@ DB-baseline *proxies* for verification.
 (`playwright-driver.browsers`) via `PLAYWRIGHT_BROWSERS_PATH`, and skip Playwright's
 host-requirements probe + its (broken) auto-download.
 
+## One pinned source of truth
+
+Both paths resolve the browser bundle from **this repo's flake** (the
+`flake.lock`-pinned, `allowUnfree` nixpkgs), never the ambient `nixpkgs#…`
+registry (which tracks the moving unstable channel and would silently drift):
+
+- `flake.nix` exposes `packages.<system>.playwright-driver = pkgs.playwright-driver`.
+- `scripts/playwright-nixos` builds `<repo>#playwright-driver.browsers` (+ reads
+  `.version`) — self-locating via `readlink -f "$0"` so it uses the flake it ships in.
+- `nix/sessionVariables.nix` exports the same `pkgs.playwright-driver.browsers`.
+
+So the wrapper, interactive shells, and the MCP all get the **identical** Chromium
+build; a channel bump can't split them.
+
 ## The version-match gotcha
 
 Playwright pins **one exact Chromium build per release**. The npm `playwright` /
@@ -21,6 +35,11 @@ doesn't contain and refuses to launch.
 - Get the version to pin to: `scripts/playwright-nixos --version` (currently **1.61.1**).
 - Pin npm to it: `npm install playwright@$(scripts/playwright-nixos --version)`.
 - The wrapper WARNS if it detects a mismatched local `node_modules` install.
+- It also WARNS on **MCP build skew**: it compares the Chromium build the Playwright
+  MCP already fetched (`~/.cache/ms-playwright/chromium-<N>`) against the build the
+  pinned bundle provides; a mismatch means the MCP (Recipe 2) would fail to launch even
+  though the wrapper works — bump the flake's `playwright-driver` (or the MCP's
+  `playwright-core`) so the two build numbers agree.
 
 ## Recipe 1 — the wrapper (switch-free; for agents / CI / one-offs)
 
@@ -71,6 +90,14 @@ per-command wrapper. Non-interactive `zsh -c` still won't see it → use Recipe 
   OAuth / run-page checks can now run in-session instead of DB-baseline proxies.
 - Drive them via **Recipe 1** inside a session, or the **Playwright MCP** after a
   switch (Recipe 2).
+
+## Known limitation
+
+Because the browser bundle is now a `home.sessionVariables` value + a flake package,
+**every `home-manager switch` realises the ~hundreds-of-MB nixpkgs browser bundle** as
+a build-time dependency (first switch per host; then cached). On a network-constrained
+host (e.g. the laptop on a slow link) that first switch can be slow or fail to fetch —
+it's a one-time cost per host, but worth knowing.
 
 ## Verified
 

--- a/claudedocs/playwright-nixos.md
+++ b/claudedocs/playwright-nixos.md
@@ -1,0 +1,82 @@
+# Driving Playwright on NixOS
+
+**Problem (gametape #6):** Playwright's bundled Chromium (`~/.cache/ms-playwright/chromium-*/…/chrome`)
+is a generic-linux dynamically-linked ELF. NixOS has no global `/lib` `ld-linux`,
+so `stub-ld` refuses it — the browser dies at spawn with `exitCode=127` (and, with
+an FHS/patchelf half-fix in play, the classic `GLIBC_ABI_GNU2_TLS not found`). Result:
+every headless-Chromium e2e / OAuth-tester / run-page click-path was undrivable, forcing
+DB-baseline *proxies* for verification.
+
+**Fix:** use the browsers nixpkgs already patched for NixOS
+(`playwright-driver.browsers`) via `PLAYWRIGHT_BROWSERS_PATH`, and skip Playwright's
+host-requirements probe + its (broken) auto-download.
+
+## The version-match gotcha
+
+Playwright pins **one exact Chromium build per release**. The npm `playwright` /
+`@playwright/test` / `playwright-core` version in a project **must equal** the nixpkgs
+`playwright-driver` version, or Playwright looks for a build number the nix bundle
+doesn't contain and refuses to launch.
+
+- Get the version to pin to: `scripts/playwright-nixos --version` (currently **1.61.1**).
+- Pin npm to it: `npm install playwright@$(scripts/playwright-nixos --version)`.
+- The wrapper WARNS if it detects a mismatched local `node_modules` install.
+
+## Recipe 1 — the wrapper (switch-free; for agents / CI / one-offs)
+
+`scripts/playwright-nixos` resolves the nix browser bundle on demand (cached after the
+first realise) and exports the right env, needing **no `home-manager switch`**:
+
+```sh
+# run a script / test with Chromium wired up:
+scripts/playwright-nixos node e2e.mjs
+scripts/playwright-nixos npx playwright test
+
+# or export into the current shell:
+eval "$(scripts/playwright-nixos --env)"
+
+# introspection:
+scripts/playwright-nixos --version   # nixpkgs driver version to pin npm to
+scripts/playwright-nixos --env       # the three export lines
+```
+
+This is the path the **Bash tool** must use: it runs *non-interactive* `zsh -c`, which
+sources `.zshenv` only — NOT the `profile.d` file that carries `home.sessionVariables`
+(Recipe 2). So inside a Claude session, always go through the wrapper.
+
+The three env vars it sets:
+
+| var | value |
+| --- | --- |
+| `PLAYWRIGHT_BROWSERS_PATH` | `…-playwright-browsers` (nix store) |
+| `PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS` | `true` |
+| `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` | `1` (so `npm install` won't re-fetch the broken bundle) |
+
+## Recipe 2 — global (interactive shells + the Playwright MCP)
+
+`nix/sessionVariables.nix` now exports `PLAYWRIGHT_BROWSERS_PATH` +
+`PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS` from `pkgs.playwright-driver.browsers`
+(the arg was already plumbed into the file but silently dropped — it's now used).
+After a `home-manager switch` / `ship.sh`, **interactive** shells and any process they
+launch — including the **Playwright MCP** (`mcp__playwright__browser_*`, whose cached
+Chromium build 1228 already matches driver 1.61.1) — launch Chromium natively with no
+per-command wrapper. Non-interactive `zsh -c` still won't see it → use Recipe 1 there.
+
+## How this composes with verification
+
+- **`/verify-agent`** is the *mechanical* gate — build / typecheck / test / vet /
+  git-completeness only. It does **not** drive a browser. Unchanged.
+- **The `verify` skill's e2e layer** (and `/ux-audit`, the `ux-audit-loops`
+  naida/vetr harnesses) is what this unblocks: real headless-Chromium click-path /
+  OAuth / run-page checks can now run in-session instead of DB-baseline proxies.
+- Drive them via **Recipe 1** inside a session, or the **Playwright MCP** after a
+  switch (Recipe 2).
+
+## Verified
+
+`scripts/playwright-nixos node launch.mjs` on the workbench: headless Chromium
+launched (`browserVersion=149.0.7827.55`), rendered `page.setContent(...)`
+(title + `#x` text read back), screenshotted, and `goto('https://example.com')`
+returned **200 / "Example Domain"**. The same script against the default
+`~/.cache/ms-playwright` bundle fails with `exitCode=127`. Version-mismatch warning
+fires when local npm playwright ≠ driver version.

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,16 @@
       };
     in
     {
+      # Pinned Playwright driver + browsers, built from THIS flake's locked
+      # (allowUnfree) nixpkgs — the single source of truth shared by both
+      # Playwright paths so they can never diverge on a channel bump:
+      #   • scripts/playwright-nixos resolves `<repo>#playwright-driver.browsers`
+      #     (+ `.version`) — NOT the ambient `nixpkgs#…` registry, which tracks
+      #     the moving unstable channel.
+      #   • nix/sessionVariables.nix (Recipe 2 / the Playwright MCP) exports the
+      #     same `pkgs.playwright-driver.browsers`.
+      packages.${system}.playwright-driver = pkgs.playwright-driver;
+
       homeConfigurations."zach" = home-manager.lib.homeManagerConfiguration {
         inherit pkgs;
         extraSpecialArgs = { isNixOS = true; };

--- a/nix/sessionVariables.nix
+++ b/nix/sessionVariables.nix
@@ -1,4 +1,4 @@
-{ elixirLspPath, homePath, playwrightBrowsersPath, ... }:
+{ pkgs, elixirLspPath, homePath, playwrightBrowsersPath ? null, ... }:
 
 let
   fzfDefaultCommand = "fd --type file --follow --hidden --exclude .git --exclude node_modules --exclude www --exclude public -E vendor";
@@ -15,17 +15,19 @@ in
 
   ELIXIR_LSP_PATH = "${elixirLspPath}/share/vscode/extensions/JakeBecker.elixir-ls/elixir-ls-release/language_server.sh";
   K9S_FEATURE_GATE_NODE_SHELL = "true";
-
-  # Playwright on NixOS: point it at the nixpkgs-patched browser bundle instead of
-  # its own download (a generic-linux ELF that stub-ld refuses → exitCode=127 /
-  # "GLIBC_ABI_GNU2_TLS not found"), and skip the host-requirements probe. This
-  # makes interactive shells + the Playwright MCP launch Chromium natively.
-  # NB: the npm `playwright` version in a project MUST match this bundle's
-  # `playwright-driver` version or Chromium's build number won't align — see
-  # scripts/playwright-nixos (`--version` prints the version to pin to).
-  # (home.sessionVariables land in profile.d, sourced by INTERACTIVE shells, not
-  # the non-interactive `zsh -c` the Bash tool uses — so scripts/playwright-nixos
-  # stays the switch-free path for agent/CI use.)
+}
+# Playwright on NixOS: point it at the nixpkgs-patched browser bundle instead of
+# its own download (a generic-linux ELF that stub-ld refuses → exitCode=127 /
+# "GLIBC_ABI_GNU2_TLS not found"), and skip the host-requirements probe. This
+# makes interactive shells + the Playwright MCP launch Chromium natively.
+# NB: the npm `playwright` version in a project MUST match this bundle's
+# `playwright-driver` version or Chromium's build number won't align — see
+# scripts/playwright-nixos (`--version` prints the version to pin to).
+# (home.sessionVariables land in profile.d, sourced by INTERACTIVE shells, not
+# the non-interactive `zsh -c` the Bash tool uses — so scripts/playwright-nixos
+# stays the switch-free path for agent/CI use.)
+# Guarded so a host/refactor that doesn't pass the path can't hard-break the switch.
+// pkgs.lib.optionalAttrs (playwrightBrowsersPath != null) {
   PLAYWRIGHT_BROWSERS_PATH = "${playwrightBrowsersPath}";
   PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";
 }

--- a/nix/sessionVariables.nix
+++ b/nix/sessionVariables.nix
@@ -1,4 +1,4 @@
-{ elixirLspPath, homePath, ... }:
+{ elixirLspPath, homePath, playwrightBrowsersPath, ... }:
 
 let
   fzfDefaultCommand = "fd --type file --follow --hidden --exclude .git --exclude node_modules --exclude www --exclude public -E vendor";
@@ -15,4 +15,17 @@ in
 
   ELIXIR_LSP_PATH = "${elixirLspPath}/share/vscode/extensions/JakeBecker.elixir-ls/elixir-ls-release/language_server.sh";
   K9S_FEATURE_GATE_NODE_SHELL = "true";
+
+  # Playwright on NixOS: point it at the nixpkgs-patched browser bundle instead of
+  # its own download (a generic-linux ELF that stub-ld refuses → exitCode=127 /
+  # "GLIBC_ABI_GNU2_TLS not found"), and skip the host-requirements probe. This
+  # makes interactive shells + the Playwright MCP launch Chromium natively.
+  # NB: the npm `playwright` version in a project MUST match this bundle's
+  # `playwright-driver` version or Chromium's build number won't align — see
+  # scripts/playwright-nixos (`--version` prints the version to pin to).
+  # (home.sessionVariables land in profile.d, sourced by INTERACTIVE shells, not
+  # the non-interactive `zsh -c` the Bash tool uses — so scripts/playwright-nixos
+  # stays the switch-free path for agent/CI use.)
+  PLAYWRIGHT_BROWSERS_PATH = "${playwrightBrowsersPath}";
+  PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";
 }

--- a/scripts/playwright-nixos
+++ b/scripts/playwright-nixos
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# playwright-nixos — drive Playwright with the NIXPKGS-provided Chromium so it
+# actually launches on this NixOS host.
+#
+# WHY: Playwright's own download (~/.cache/ms-playwright/chromium-*/…/chrome) is
+# a generic-linux dynamically-linked ELF. NixOS has no global /lib ld-linux, so
+# stub-ld refuses it — the browser dies at spawn with exitCode=127 (and, when an
+# FHS/patchelf half-fix is in play, the classic `GLIBC_ABI_GNU2_TLS not found`).
+# Net effect: every headless-Chromium e2e / OAuth / click-path check is undrivable.
+#
+# FIX: use the browsers that nixpkgs already patched for NixOS
+# (playwright-driver.browsers), pointed to via PLAYWRIGHT_BROWSERS_PATH, and skip
+# Playwright's host-requirements probe + its (broken) auto-download.
+#
+# VERSION-MATCH GOTCHA (important): Playwright pins one exact Chromium *build*
+# per release. The nixpkgs `playwright-driver` version MUST match the npm
+# `playwright` (or `@playwright/test` / `playwright-core`) version in your project,
+# or Playwright looks for a build number the nix bundle doesn't contain and refuses
+# to launch. This wrapper prints the nixpkgs driver version so you can pin npm to it,
+# and WARNS if it detects a mismatched local install.
+#
+# USAGE:
+#   playwright-nixos <cmd> [args...]   run <cmd> with the browser env exported
+#                                        e.g. playwright-nixos node e2e.mjs
+#                                             playwright-nixos npx playwright test
+#   playwright-nixos --env             print `export …` lines (eval it, or feed an
+#                                        MCP server / skill the same vars)
+#   playwright-nixos --version         print the nixpkgs driver version to pin npm to
+#   playwright-nixos                   (no args) print the resolved env + guidance
+#
+# Needs no home-manager switch — it resolves the browser bundle from nixpkgs on
+# demand (nix caches it after the first realise).
+set -euo pipefail
+
+FLAKE="nixpkgs"
+
+# Resolve (and realise, cached) the NixOS-patched browser bundle + driver version.
+BROWSERS="$(nix build --no-link --print-out-paths "${FLAKE}#playwright-driver.browsers" 2>/dev/null | head -n1 || true)"
+DRIVER_VER="$(nix eval --raw "${FLAKE}#playwright-driver.version" 2>/dev/null || echo unknown)"
+
+if [[ -z "$BROWSERS" || ! -d "$BROWSERS" ]]; then
+  echo "playwright-nixos: could not resolve ${FLAKE}#playwright-driver.browsers" >&2
+  echo "  try: nix build ${FLAKE}#playwright-driver.browsers" >&2
+  exit 1
+fi
+
+export PLAYWRIGHT_BROWSERS_PATH="$BROWSERS"
+export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
+export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
+# Best-effort version-match warning against a local npm install, if present.
+warn_version_mismatch() {
+  local pkg_json v
+  for pkg_json in \
+      "$PWD/node_modules/playwright-core/package.json" \
+      "$PWD/node_modules/playwright/package.json" \
+      "$PWD/node_modules/@playwright/test/package.json"; do
+    if [[ -f "$pkg_json" ]]; then
+      v="$(node -e "process.stdout.write(require('$pkg_json').version)" 2>/dev/null || true)"
+      if [[ -n "$v" && "$v" != "$DRIVER_VER" && "$DRIVER_VER" != "unknown" ]]; then
+        echo "playwright-nixos: WARNING — npm playwright $v != nixpkgs driver $DRIVER_VER" >&2
+        echo "  Chromium build numbers won't align; browser may refuse to launch." >&2
+        echo "  Pin npm to the driver:  npm install playwright@$DRIVER_VER" >&2
+      fi
+      return 0
+    fi
+  done
+}
+
+print_env() {
+  echo "export PLAYWRIGHT_BROWSERS_PATH=$PLAYWRIGHT_BROWSERS_PATH"
+  echo "export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=$PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS"
+  echo "export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=$PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD"
+}
+
+case "${1:-}" in
+  --version) echo "$DRIVER_VER"; exit 0 ;;
+  --env)     print_env; exit 0 ;;
+  "")
+    echo "# playwright-nixos — nixpkgs Chromium for Playwright on NixOS"
+    echo "# nixpkgs driver version (pin npm playwright to this): $DRIVER_VER"
+    echo "#"
+    print_env
+    echo "#"
+    echo "# run a script:   playwright-nixos node e2e.mjs"
+    echo "# run PW test:    playwright-nixos npx playwright test"
+    echo "# export in shell: eval \"\$(playwright-nixos --env)\""
+    exit 0
+    ;;
+esac
+
+warn_version_mismatch
+exec "$@"

--- a/scripts/playwright-nixos
+++ b/scripts/playwright-nixos
@@ -32,15 +32,24 @@
 # demand (nix caches it after the first realise).
 set -euo pipefail
 
-FLAKE="nixpkgs"
+# SINGLE SOURCE OF TRUTH: resolve the browser bundle from THIS repo's flake
+# (the flake.lock-pinned nixpkgs), NOT the ambient `nixpkgs#…` registry — the
+# registry tracks the moving unstable channel, so it would silently drift out of
+# sync with the HM export (nix/sessionVariables.nix), which uses the pinned
+# `pkgs.playwright-driver.browsers`. Both paths must resolve to ONE build.
+# The `playwright-driver` flake output (flake.nix) exposes both `.browsers` and
+# `.version` from that locked, allowUnfree pkgs.
+SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
+REPO="$(cd "$(dirname "$SCRIPT_PATH")/.." && pwd)"    # <repo>/scripts/.. = repo root
+FLAKEREF="${REPO}#playwright-driver"
 
 # Resolve (and realise, cached) the NixOS-patched browser bundle + driver version.
-BROWSERS="$(nix build --no-link --print-out-paths "${FLAKE}#playwright-driver.browsers" 2>/dev/null | head -n1 || true)"
-DRIVER_VER="$(nix eval --raw "${FLAKE}#playwright-driver.version" 2>/dev/null || echo unknown)"
+BROWSERS="$(nix build --no-link --print-out-paths "${FLAKEREF}.browsers" 2>/dev/null | head -n1 || true)"
+DRIVER_VER="$(nix eval --raw "${FLAKEREF}.version" 2>/dev/null || echo unknown)"
 
 if [[ -z "$BROWSERS" || ! -d "$BROWSERS" ]]; then
-  echo "playwright-nixos: could not resolve ${FLAKE}#playwright-driver.browsers" >&2
-  echo "  try: nix build ${FLAKE}#playwright-driver.browsers" >&2
+  echo "playwright-nixos: could not resolve ${FLAKEREF}.browsers from $REPO" >&2
+  echo "  try: nix build \"${FLAKEREF}.browsers\"" >&2
   exit 1
 fi
 
@@ -67,6 +76,23 @@ warn_version_mismatch() {
   done
 }
 
+# Deterministic MCP-alignment check (addresses the Recipe 2 blind spot): the
+# Playwright MCP ships its OWN playwright-core and, when it honours
+# PLAYWRIGHT_BROWSERS_PATH, looks up ITS pinned Chromium *build number* inside the
+# nix bundle. Compare the build the MCP already downloaded (~/.cache/ms-playwright
+# /chromium-<N>) against the build the pinned bundle provides; a mismatch means the
+# MCP would fail to launch after a switch even though this wrapper works.
+warn_mcp_build_skew() {
+  local nix_build mcp_build
+  nix_build="$(basename "$(echo "$BROWSERS"/chromium-* 2>/dev/null | tr ' ' '\n' | grep -m1 -E '/chromium-[0-9]+$')" 2>/dev/null || true)"
+  mcp_build="$(basename "$(echo "$HOME"/.cache/ms-playwright/chromium-* 2>/dev/null | tr ' ' '\n' | grep -m1 -E '/chromium-[0-9]+$')" 2>/dev/null || true)"
+  if [[ -n "$nix_build" && -n "$mcp_build" && "$nix_build" != "$mcp_build" ]]; then
+    echo "playwright-nixos: WARNING — Playwright MCP expects $mcp_build but the pinned bundle provides $nix_build" >&2
+    echo "  The MCP (Recipe 2) may fail to launch; bump the flake's playwright-driver to match the MCP," >&2
+    echo "  or the MCP's playwright-core to a version whose build == the pinned one." >&2
+  fi
+}
+
 print_env() {
   echo "export PLAYWRIGHT_BROWSERS_PATH=$PLAYWRIGHT_BROWSERS_PATH"
   echo "export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=$PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS"
@@ -90,4 +116,5 @@ case "${1:-}" in
 esac
 
 warn_version_mismatch
+warn_mcp_build_skew
 exec "$@"


### PR DESCRIPTION
## Problem (gametape #6)

Playwright's bundled Chromium (`~/.cache/ms-playwright/chromium-*/…/chrome`) is a
generic-linux dynamically-linked ELF. NixOS has no global `/lib` `ld-linux`, so
`stub-ld` refuses it — the browser dies at spawn with `exitCode=127` (and, with an
FHS/patchelf half-fix in play, the classic `GLIBC_ABI_GNU2_TLS not found`). Result:
every headless-Chromium e2e / OAuth-tester / run-page click-path was undrivable
in-session, forcing DB-baseline **proxies** for verification.

## Root cause

Confirmed live: running the bundled binary gives NixOS's stub-ld refusal, and `ldd`
shows the bundle's `libglib`/`libnss`/etc. as `not found`. The idiomatic NixOS fix is
to use the **nixpkgs-provided** browsers, which are already patched for NixOS, instead
of Playwright's download.

## Fix

- **`scripts/playwright-nixos`** — switch-free wrapper. Resolves
  `nixpkgs#playwright-driver.browsers` on demand (nix-cached) and runs any command with
  `PLAYWRIGHT_BROWSERS_PATH` + `PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true` +
  `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` exported. `--env` / `--version` / no-arg
  introspection. **This is the path for the Bash tool** (non-interactive `zsh -c`,
  which sources only `.zshenv`, not the `profile.d` file that carries
  `home.sessionVariables`).
- **`nix/sessionVariables.nix`** — the `playwrightBrowsersPath` arg was already plumbed
  in from `home.nix:27` but silently dropped by `...` (dead plumbing — the intended
  global fix was started but never completed). Now actually exports
  `PLAYWRIGHT_BROWSERS_PATH` + `PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS`, so
  **interactive shells + the Playwright MCP** launch Chromium natively after a switch
  (the MCP's cached Chromium build 1228 already matches driver 1.61.1).
- **`claudedocs/playwright-nixos.md`** — recipe, MCP wiring, verification.

## Version-match gotcha (handled)

Playwright pins one exact Chromium build per release, so the npm `playwright` version
**must equal** the nixpkgs `playwright-driver` version (currently **1.61.1**) or the
browser won't launch. `playwright-nixos --version` prints the version to pin to, and the
wrapper WARNS on a mismatched local `node_modules` install.

## Composition with verification

- `/verify-agent` stays the *mechanical* build/typecheck/test/vet gate — it does not
  drive a browser and is unchanged.
- This unblocks the **`verify` skill's e2e layer** (+ `/ux-audit`, the `ux-audit-loops`
  naida/vetr harnesses): real headless-Chromium click-path / OAuth checks now run
  in-session instead of DB-baseline proxies.

## Verified (real browser launch, workbench)

```
$ scripts/playwright-nixos node launch.mjs
LAUNCH_OK title=NixOS PW OK h1=hello from nixos chromium browserVersion=149.0.7827.55
$ scripts/playwright-nixos node nav.mjs
NAV status=200 title=Example Domain
```

- Headless Chromium launched, rendered `page.setContent(...)`, read back title + `#x`
  text, took a screenshot, and navigated to a real public URL (200).
- The **same** script against the default `~/.cache/ms-playwright` bundle fails with
  `exitCode=127` (the reproduced symptom) — so the fix, not the environment, is what
  makes it work.
- Version-mismatch warning fires when npm playwright ≠ driver version.
- HM change verified switch-free via `nix eval` of the module's output (emits the same
  store path that launched); **no host-wide `home-manager switch` was run**.

## Audit fixes (adversarial review — passed, no deploy-blockers)

- **#1 (🟡, the important one) — single source of truth.** The wrapper resolved
  `nixpkgs#playwright-driver` via the **ambient registry** (moving `nixpkgs-unstable`),
  while the HM export used the **flake.lock-pinned** `pkgs` — same store path today, but
  they'd silently diverge on the next channel bump, splitting the wrapper and the MCP
  onto different Chromium builds. Fixed: `flake.nix` now exposes
  `packages.<system>.playwright-driver` (from the flake's locked, allowUnfree nixpkgs),
  and `scripts/playwright-nixos` builds `<repo>#playwright-driver.browsers` / reads
  `.version` (self-locating via `readlink -f "$0"`) instead of `nixpkgs#…`. **One pinned
  source for both paths.** Verified: `wrapper --env` path == `.#playwright-driver.browsers`
  == `homeConfigurations.zach …PLAYWRIGHT_BROWSERS_PATH` (all `…-playwright-browsers`).
- **#4 (🟡) — null-guard the module.** `nix/sessionVariables.nix` now defaults
  `playwrightBrowsersPath ? null` and emits the `PLAYWRIGHT_*` vars via
  `lib.optionalAttrs (… != null)`, so a host/refactor that omits the path can't hard-break
  the switch. Verified: `null` (and omitted) → no `PLAYWRIGHT_BROWSERS_PATH`, no eval error.
- **#2 (🟡) — MCP-version blind spot.** Added a **deterministic** check: the wrapper
  compares the Chromium build the Playwright MCP already fetched
  (`~/.cache/ms-playwright/chromium-<N>`) against the build the pinned bundle provides,
  and warns on skew (the MCP would fail to launch even though the wrapper works). Verified:
  aligned (both `chromium-1228`) → silent; simulated `chromium-9999` → warns.
- **#3 (🟡) — documented** in `claudedocs/playwright-nixos.md`: every
  `home-manager switch` now realises the ~hundreds-of-MB browser bundle (first build per
  host; could be slow/fail on a constrained laptop link).

### Re-verification after the pin change (real browser, workbench)

```
$ scripts/playwright-nixos --version
1.61.1
$ scripts/playwright-nixos --env
export PLAYWRIGHT_BROWSERS_PATH=/nix/store/bcf8w1529mgspizwjsp3iwvaq26plrgj-playwright-browsers
$ scripts/playwright-nixos node launch.mjs
LAUNCH_OK title=NixOS PW OK h1=hello from nixos chromium browserVersion=149.0.7827.55
NAV status=200 title=Example Domain
# parity:
wrapper                              : /nix/store/bcf8…-playwright-browsers
.#playwright-driver.browsers         : /nix/store/bcf8…-playwright-browsers
homeConfigurations.zach …BROWSERS_PATH: /nix/store/bcf8…-playwright-browsers  → PARITY OK
```

Changing the resolver did **not** alter which browser launches — same build (1228 /
Chrome-for-Testing 149.0.7827.55), same store path, still `goto example.com → 200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
