### PR TITLE
feat(task-spec-drafter): wire into home-manager on the workbench (SHADOW)

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -822,8 +822,13 @@ in
     Service = {
       Type = "oneshot";
       # Each ticket runs a headless claude pass with real tool calls; daily cadence
-      # tolerates an occasional long run. DRAFTER_MAX_TICKETS caps the first run.
-      TimeoutStartSec = 3600;
+      # tolerates an occasional long run. Bound: the FIRST (empty-state) run is the
+      # worst case — it processes at most DRAFTER_MAX_TICKETS (default 25) and
+      # baselines the rest, so 25 × DRAFTER_TIMEOUT(240s) = 6000s. 7200s clears that
+      # with headroom (steady-state delta runs are a handful of tickets). If you
+      # raise the cap or per-ticket timeout, raise this to match so a run never gets
+      # SIGTERM'd mid-loop (which would strand the digest + fire a failure toast).
+      TimeoutStartSec = 7200;
       Nice = 10;
       Environment = [
         # claude + gh live in the HM profile (not devrc's flake) -> profile bins

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -772,4 +772,87 @@ in
       WantedBy = [ "timers.target" ];
     };
   };
+
+  # Seed the task-spec-drafter env file with safe defaults (DRAFTER_MODE=shadow)
+  # if it does not exist yet. It holds no secrets today, but is chmod 600 and kept
+  # OUT of the nix store so DRAFTER_MODE flips (shadow -> on) are a one-line edit +
+  # switch, no code change — mirrors the activity-collector env seeding above.
+  home.activation.taskSpecDrafterEnv = lib.hm.dag.entryAfter ["writeBoundary"] ''
+    envFile="$HOME/.claude/task-spec-drafter.env"
+    if [ ! -e "$envFile" ]; then
+      mkdir -p "$HOME/.claude"
+      cp ${../scripts/task-spec-drafter/task-spec-drafter.env.example} "$envFile"
+      chmod 600 "$envFile"
+      echo "task-spec-drafter: seeded $envFile from the example (DRAFTER_MODE=shadow)"
+    fi
+  '';
+
+  # Deep-context task-spec drafter — DAILY, SHADOW-first (scripts/task-spec-drafter/).
+  # A verifier/triage layer over the ClickUp "To Schedule" queue: per-ticket it runs
+  # a headless `claude -p` deep-context pass (ENRICH -> VERIFY vs live git/PRs/metrics
+  # -> CLASSIFY -> DRAFT only genuine TASKs; a deterministic safety gate force-escalates
+  # security/money/destructive tickets to NEEDS-DECISION). It emits a triage queue and
+  # EMAILS the day's digest (the review surface) reusing repo-cos's DKIM-signed relay.
+  #
+  # SHADOW by default (DRAFTER_MODE in ~/.claude/task-spec-drafter.env, seeded above):
+  # it writes the queue + emails the digest + LOGS "would POST to clawgate" and
+  # dispatches NOTHING / POSTs NOTHING to clawgate / mutates no repo/cluster until the
+  # env flag flips to `on`. Delta-scoping keeps each daily run cheap (only new/changed
+  # tickets); the first run baselines the backlog (see the README).
+  #
+  # WORKBENCH-ONLY (serverMode), same rationale as repo-cos / mail-actions-archive: the
+  # civitai checkout + prod kubeconfig + clickup skill CLI + the `claude` CLI (ambient
+  # auth) all live here, and this host has direct LAN access to the cluster APIs the
+  # verify step + email relay reach.
+  #
+  # Minimal user-unit env, so PATH is explicit. The pipeline needs profile-installed
+  # CLIs that are NOT in devrc's flake — `claude` (headless reasoning) and `gh` (PR
+  # checks) come from the home-manager profile — so %h/.nix-profile/bin + the system
+  # profile are on PATH ahead of the pinned deterministic tools (node for the clickup
+  # CLI, git, kubectl, jq, curl, python3, coreutils). KUBECONFIG for the per-ticket
+  # claude pass is set by drafter.sh itself (it exports the prod kubeconfig per call);
+  # REPO_COS_PROD_KUBECONFIG here is the relay kubeconfig for the digest email.
+  systemd.user.services.task-spec-drafter = lib.mkIf serverMode {
+    Unit = {
+      Description = "Deep-context task-spec drafter (ClickUp triage, daily, shadow-first)";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+      OnFailure = [ "notify-failure@%n.service" ];
+    };
+    Service = {
+      Type = "oneshot";
+      # Each ticket runs a headless claude pass with real tool calls; daily cadence
+      # tolerates an occasional long run. DRAFTER_MAX_TICKETS caps the first run.
+      TimeoutStartSec = 3600;
+      Nice = 10;
+      Environment = [
+        # claude + gh live in the HM profile (not devrc's flake) -> profile bins
+        # first, then the system profile (curl), then the pinned deterministic tools.
+        "PATH=%h/.nix-profile/bin:/run/current-system/sw/bin:${lib.makeBinPath [ pkgs.nodejs_26 pkgs.git pkgs.kubectl pkgs.jq pkgs.curl pkgs.python312 pkgs.bash pkgs.coreutils pkgs.gnugrep pkgs.gnused pkgs.gawk ]}"
+        "HOME=%h"
+        # Relay kubeconfig for the digest email (reuses repo-cos's postfix relay).
+        "REPO_COS_PROD_KUBECONFIG=%h/workspace/homelab-talos/production-kubeconfig"
+      ];
+      ExecStart = "${pkgs.bash}/bin/bash %h/workspace/devrc/scripts/task-spec-drafter/drafter.sh";
+      # Re-run with fresh code after a script-only edit (cf. X-Restart-Triggers above).
+      X-Restart-Triggers = [ "${../scripts/task-spec-drafter/drafter.sh}" ];
+    };
+  };
+
+  # Timer: fire the drafter daily at 08:00 local. Persistent=true catches up a
+  # single missed run (host asleep at 08:00) on the next wake. Shadow-by-default,
+  # so enabling it changes nothing externally until DRAFTER_MODE=on.
+  systemd.user.timers.task-spec-drafter = lib.mkIf serverMode {
+    Unit = {
+      Description = "Daily timer for the deep-context task-spec drafter";
+    };
+    Timer = {
+      OnCalendar = "*-*-* 08:00:00";
+      Persistent = true;
+      RandomizedDelaySec = 300;
+    };
+    Install = {
+      WantedBy = [ "timers.target" ];
+    };
+  };
 }

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -57,6 +57,7 @@ HERMETIC_DIRS=(
   scripts/session-analysis/session_insight/tests
   scripts/mail-actions/tests
   scripts/repo-cos/tests
+  scripts/task-spec-drafter/tests
 )
 
 # --- DEV-HOST-ONLY set ---------------------------------------------------------

--- a/scripts/task-spec-drafter/README.md
+++ b/scripts/task-spec-drafter/README.md
@@ -207,17 +207,41 @@ until `DRAFTER_MODE=on`. Delta-scoping keeps the daily run cheap (a handful of
 tickets), and the first scheduled run baselines the backlog (see
 [First-run behavior](#first-run-behavior-important)).
 
-### NixOS note (why imperative, not home-manager — yet)
+### NixOS note (home-manager, SHADOW soak)
 
-This is NixOS, but the timer is installed **imperatively** (`systemctl --user
-enable`, which symlinks the unit) **on purpose**: this is an experimental shadow
-tool and the imperative path is reversible and zero-commitment. **Do not bake it
-into `nix/home-manager` yet** — it isn't proven. The productionization step, once
-shadow proves out, is `systemd.user.services`/`systemd.user.timers` in the
-home-manager config (declarative, with `services.<…>` units pointing at this same
-`drafter.sh`), plus moving `~/.claude/task-spec-drafter.env` into a managed file.
-That's the "graduate to declarative" task, deferred until the adjudication ratio
-justifies it.
+The timer is now wired **declaratively in home-manager** (`nix/home.nix`,
+`systemd.user.services.task-spec-drafter` + its timer), **workbench-only**
+(`lib.mkIf serverMode`, the same host gate as `repo-cos` / `mail-actions-archive`),
+**daily at 08:00**, with `OnFailure=notify-failure@%n.service` (a broken run
+toasts) and PATH exposing the `claude`/`gh` profile CLIs + `node`/`git`/`kubectl`/
+`jq`/`curl`/`python3`. The env file is **seeded once** by a `home.activation` hook
+(`~/.claude/task-spec-drafter.env`, chmod 600, never clobbered) so `DRAFTER_MODE`
+lives outside the nix store — flipping **shadow → on** is a one-line edit + a
+`home-manager switch`, no code change. The imperative `systemctl --user enable`
+path in `systemd/*.{service,timer}` is kept as a documented fallback but the HM
+unit is authoritative on the workbench.
+
+It runs in **SHADOW**: enabling the timer changes nothing externally — it writes
+the queue, **emails the daily digest** (below), and only *logs* "would POST to
+clawgate". It dispatches nothing and POSTs nothing to clawgate until the env flag
+flips to `on`. Graduation past shadow still waits on the adjudication ratio.
+
+### Daily email digest (the SHADOW review surface)
+
+Each run that processes ≥1 ticket **emails Zach the day's triage** — the human
+summary (classification counts + per-ticket classification + one-line why + the
+drafted spec for genuine `TASK`s + the suppressed `FYI`/`STALE-close`/
+`ALREADY-DONE` one-liners). Subject: `task-drafter SHADOW digest — N
+would-dispatch, M need-decision`. This is the whole point of the soak: adjudicate
+the queue from the inbox while clawgate/dispatch stay silent.
+
+The send **reuses repo-cos's DKIM-signed postfix relay** (`send_digest.py` loads
+`repo-cos/email_send.py` by explicit importlib path — no new mailer), so it needs
+`REPO_COS_PROD_KUBECONFIG` + `kubectl` (a production-cluster port-forward). It is
+**best-effort**: a relay hiccup logs + continues, never wedging the run. Knobs:
+`DRAFTER_EMAIL=on|off`, `DRAFTER_EMAIL_TO`, and `DRAFTER_EMAIL_DRYRUN=1` (render
+the email to `$DRAFTER_OUT_DIR/digest-email-<ts>.txt` and send **nothing** — used
+for proof runs).
 
 ### Disable / kill-switch
 

--- a/scripts/task-spec-drafter/drafter-prompt.md
+++ b/scripts/task-spec-drafter/drafter-prompt.md
@@ -14,7 +14,8 @@ NEVER draft a confident task you could not verify the intent of.
   edit/merge/push any repo, do not mutate the cluster. No `clickup ... comment`,
   no `gh pr ...` mutations, no `kubectl apply/delete/edit/scale`, no `git commit`.
   You may only READ: `clickup get/comments`, `git log`, `gh pr list/view --search`,
-  `kubectl get/logs` (read verbs) + Prometheus/Alertmanager reads.
+  `kubectl get/logs/describe/top` (read verbs only). No `gh api` and no `curl` —
+  they are not on the allowlist and will not run.
 - **Do not dispatch anything.** You only produce the record below.
 - **SAFETY RULE (the meili-cron lesson):** if you cannot verify *why* something
   is or isn't being done — i.e. you can't confirm whether the work is wanted,
@@ -38,10 +39,11 @@ other tickets may be referenced for CORRELATE but are not yours to classify here
   `git -C ... log --all --grep '<keyword>'`,
   `gh -R civitai/civitai pr list --search '<keyword>' --state all --limit 20`,
   `gh -R civitai/civitai pr view <n>`.
-- **Live metrics/alerts:** `KUBECONFIG=/home/zach/workspace/civit/datapacket-talos/prod-kubeconfig`
-  then `kubectl get pods/cronjobs/...`, `kubectl logs ...`, and query
-  Alertmanager/Prometheus if reachable. Use to answer "is this still firing?",
-  "is this component running or suspended?".
+- **Live cluster state:** `KUBECONFIG=/home/zach/workspace/civit/datapacket-talos/prod-kubeconfig`
+  then `kubectl get pods/cronjobs/...`, `kubectl logs ...`, `kubectl describe ...`,
+  `kubectl top ...` (read-only). Use to answer "is this component running or
+  suspended?", "is the workload healthy / erroring?". (No HTTP `curl` to
+  Prometheus/Alertmanager — not on the allowlist; rely on kubectl for live state.)
 
 Use these tools liberally — the WHOLE point is to cross-check the ticket against
 live reality before classifying. A title-only read is the FAILURE mode (it would

--- a/scripts/task-spec-drafter/drafter.sh
+++ b/scripts/task-spec-drafter/drafter.sh
@@ -122,11 +122,24 @@ DRAFTER_EMAIL_DRYRUN="${DRAFTER_EMAIL_DRYRUN:-0}"
 # Relay kubeconfig for the email path (production cluster; same one repo-cos uses).
 export REPO_COS_PROD_KUBECONFIG="${REPO_COS_PROD_KUBECONFIG:-$HOME/workspace/homelab-talos/production-kubeconfig}"
 
-# Tight READ-ONLY allowlist for the headless pipeline pass. Only verbs that read
-# state appear here — no apply/edit/delete/scale/commit/push/comment. This is the
-# enforcement complement to the prompt's HARD CONSTRAINTS. Override via env if a
-# verification source needs a verb not listed.
-DRAFTER_ALLOWED_TOOLS="${DRAFTER_ALLOWED_TOOLS:-Read,Glob,Grep,WebFetch,Bash(node *query.mjs get*),Bash(node *query.mjs comments*),Bash(node *query.mjs search*),Bash(git -C * log*),Bash(git -C * show*),Bash(git -C * diff*),Bash(git -C * grep*),Bash(git log*),Bash(gh pr list*),Bash(gh pr view*),Bash(gh search*),Bash(gh api*),Bash(kubectl get*),Bash(kubectl logs*),Bash(kubectl describe*),Bash(kubectl top*),Bash(curl -s*),Bash(grep*),Bash(rg*),Bash(jq*),Bash(cat*),Bash(echo*),Bash(date*),Bash(env*)}"
+# Tight READ-ONLY allowlist for the headless pipeline pass. Only verbs that READ
+# state appear here — no apply/edit/delete/scale/commit/push/comment.
+#
+# SECURITY: the per-ticket pass reasons over UNTRUSTED civitai *client* ticket text
+# (title + body + comments) with NO --permission-mode plan, so allowlisted tools
+# EXECUTE unprompted. A prompt-injected ticket must not be able to reach a WRITE.
+# Therefore every entry is a read-only verb only, and specifically NOT:
+#   * `Bash(gh api*)`  — dropped: allows `gh api -X POST/PATCH/DELETE` (mutations).
+#                        PR/commit reality is verified via gh pr list/view/search.
+#   * `Bash(curl -s*)` — dropped: allows `curl -X POST -d …` to any URL (mutation +
+#                        exfil). Live-state verification degrades to kubectl
+#                        get/logs/top (pod/cronjob running-vs-suspended), which
+#                        covers the primary "is it still firing / intentionally
+#                        off?" axis; ad-hoc Prometheus/Alertmanager HTTP reads go.
+#   * `Bash(env*)`     — dropped: the pass inherits drafter.sh's env, which sources
+#                        ~/.claude/clawgate.env (CLAWGATE_HOOK_TOKEN); no dumping it.
+# Override DRAFTER_ALLOWED_TOOLS via env ONLY with read-only verbs.
+DRAFTER_ALLOWED_TOOLS="${DRAFTER_ALLOWED_TOOLS:-Read,Glob,Grep,WebFetch,Bash(node *query.mjs get*),Bash(node *query.mjs comments*),Bash(node *query.mjs search*),Bash(git -C * log*),Bash(git -C * show*),Bash(git -C * diff*),Bash(git -C * grep*),Bash(git log*),Bash(gh pr list*),Bash(gh pr view*),Bash(gh search*),Bash(kubectl get*),Bash(kubectl logs*),Bash(kubectl describe*),Bash(kubectl top*),Bash(grep*),Bash(rg*),Bash(jq*),Bash(cat*),Bash(echo*),Bash(date*)}"
 
 mkdir -p "$DRAFTER_OUT_DIR" 2>/dev/null || true
 # The delta-state file may live outside OUT_DIR (e.g. ~/.local/state/...); make

--- a/scripts/task-spec-drafter/drafter.sh
+++ b/scripts/task-spec-drafter/drafter.sh
@@ -64,11 +64,27 @@
 #   CLICKUP_VIEW_ID       triage view (def 6-901111220963-1 = "To Schedule")
 #   CLAWGATE_API_URL / CLAWGATE_HOOK_TOKEN — reused from ~/.claude/clawgate.env
 #
+#   DRAFTER_EMAIL         on|off — email the day's digest (the review surface, def on)
+#   DRAFTER_EMAIL_TO      digest recipient (def owner)
+#   DRAFTER_EMAIL_DRYRUN  1 -> render the digest email to a file, send NOTHING (proofs)
+#   REPO_COS_PROD_KUBECONFIG — relay kubeconfig for the digest send (reuses repo-cos)
+#
+# === REVIEW SURFACE: daily email digest ====================================
+# On every run that processes ≥1 ticket, the human summary (counts + per-ticket
+# classification + one-line why + drafted spec for TASKs) is EMAILED (reusing
+# repo-cos's DKIM-signed postfix relay). In SHADOW this is the whole point: the
+# triage lands in Zach's inbox to adjudicate, while clawgate/dispatch stay silent.
+#
 set -uo pipefail
 
 # --- locate self + companions ----------------------------------------------
-SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Unset CDPATH + silence cd: with CDPATH set in the caller's env, a relative
+# `cd` prints the resolved dir to stdout, which the command substitution would
+# capture as a spurious extra line and corrupt SELF_DIR. (The systemd unit env
+# has no CDPATH, but be robust for hand-runs too.)
+SELF_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 PROMPT_FILE="$SELF_DIR/drafter-prompt.md"
+SEND_HELPER="$SELF_DIR/send_digest.py"
 CLICKUP_CLI="${CLICKUP_CLI:-$HOME/.claude/skills/clickup/query.mjs}"
 CLICKUP_ACCOUNTS="${CLICKUP_ACCOUNTS:-$HOME/.claude/skills/clickup/accounts.json}"
 
@@ -93,6 +109,19 @@ HOST="${CLAUDE_HOST:-$(hostname 2>/dev/null || echo unknown)}"
 CIVITAI_REPO="${CIVITAI_REPO:-/home/zach/workspace/civit/civitai}"
 PROD_KUBECONFIG="${PROD_KUBECONFIG:-/home/zach/workspace/civit/datapacket-talos/prod-kubeconfig}"
 
+# --- daily email digest (the SHADOW review surface) ------------------------
+# Fires in BOTH shadow and on: the day's triage is emailed so Zach adjudicates
+# from his inbox. Reuses repo-cos's DKIM-signed postfix relay (send_digest.py ->
+# repo-cos/email_send.py), so the relay needs REPO_COS_PROD_KUBECONFIG + kubectl.
+#   DRAFTER_EMAIL         on|off — send the digest email at all      (def on)
+#   DRAFTER_EMAIL_TO      recipient                                   (def owner)
+#   DRAFTER_EMAIL_DRYRUN  1 -> render the email to a file, send NOTHING (proof runs)
+DRAFTER_EMAIL="${DRAFTER_EMAIL:-on}"
+DRAFTER_EMAIL_TO="${DRAFTER_EMAIL_TO:-zachlowden1@gmail.com}"
+DRAFTER_EMAIL_DRYRUN="${DRAFTER_EMAIL_DRYRUN:-0}"
+# Relay kubeconfig for the email path (production cluster; same one repo-cos uses).
+export REPO_COS_PROD_KUBECONFIG="${REPO_COS_PROD_KUBECONFIG:-$HOME/workspace/homelab-talos/production-kubeconfig}"
+
 # Tight READ-ONLY allowlist for the headless pipeline pass. Only verbs that read
 # state appear here — no apply/edit/delete/scale/commit/push/comment. This is the
 # enforcement complement to the prompt's HARD CONSTRAINTS. Override via env if a
@@ -100,6 +129,9 @@ PROD_KUBECONFIG="${PROD_KUBECONFIG:-/home/zach/workspace/civit/datapacket-talos/
 DRAFTER_ALLOWED_TOOLS="${DRAFTER_ALLOWED_TOOLS:-Read,Glob,Grep,WebFetch,Bash(node *query.mjs get*),Bash(node *query.mjs comments*),Bash(node *query.mjs search*),Bash(git -C * log*),Bash(git -C * show*),Bash(git -C * diff*),Bash(git -C * grep*),Bash(git log*),Bash(gh pr list*),Bash(gh pr view*),Bash(gh search*),Bash(gh api*),Bash(kubectl get*),Bash(kubectl logs*),Bash(kubectl describe*),Bash(kubectl top*),Bash(curl -s*),Bash(grep*),Bash(rg*),Bash(jq*),Bash(cat*),Bash(echo*),Bash(date*),Bash(env*)}"
 
 mkdir -p "$DRAFTER_OUT_DIR" 2>/dev/null || true
+# The delta-state file may live outside OUT_DIR (e.g. ~/.local/state/...); make
+# sure its parent exists so update_state's atomic .tmp+mv never fails.
+mkdir -p "$(dirname "$DRAFTER_STATE_FILE")" 2>/dev/null || true
 log() { printf '[%s] %s\n' "$(date '+%F %T')" "$*" | tee -a "$DRAFTER_LOG_FILE" >&2; }
 
 # === DETERMINISTIC SAFETY-ESCALATION GATE ==================================
@@ -426,6 +458,39 @@ N_TASK="$(jq -r 'select(.classification=="TASK")|.ticket_id' "$QUEUE_JSONL" | gr
 N_DEC="$(jq -r 'select(.classification=="NEEDS-DECISION" or (.safety_flag|length>0))|.ticket_id' "$QUEUE_JSONL" | grep -c . || true)"
 N_VER="$(jq -r 'select(.classification=="VERIFY")|.ticket_id' "$QUEUE_JSONL" | grep -c . || true)"
 SUMMARY_LINE="$N_TASK genuine TASK, $N_DEC needs-decision, $N_VER verify (of $PROCESSED inbound)"
+
+# --- daily digest email (the SHADOW review surface) ------------------------
+# Emails the human summary (QUEUE_SUMMARY: counts + per-ticket classification +
+# one-line why + drafted spec for TASKs + suppressed one-liners) so Zach reviews
+# the day's triage in his inbox. Fires in BOTH shadow and on — it is the review
+# surface regardless of mode; it NEVER dispatches or mutates anything. Best-effort:
+# a send failure logs + continues (never wedges / fails the run). Reuses repo-cos's
+# relay via send_digest.py; DRAFTER_EMAIL_DRYRUN=1 renders to a file, sends nothing.
+if { [ "$DRAFTER_EMAIL" = "on" ] || [ "$DRAFTER_EMAIL" = "1" ]; } \
+   && command -v python3 >/dev/null 2>&1 && [ -f "$SEND_HELPER" ]; then
+  MODE_TAG="$([ "$DRAFTER_MODE" = "shadow" ] && echo SHADOW || echo LIVE)"
+  EMAIL_SUBJECT="task-drafter $MODE_TAG digest — $N_TASK would-dispatch, $N_DEC need-decision"
+  if [ "$DRAFTER_EMAIL_DRYRUN" = "1" ]; then
+    DIGEST_RENDER="$DRAFTER_OUT_DIR/digest-email-$RUN_TS.txt"
+    if python3 "$SEND_HELPER" --subject "$EMAIL_SUBJECT" --body-file "$QUEUE_SUMMARY" \
+         --to "$DRAFTER_EMAIL_TO" --dry-run --out "$DIGEST_RENDER" >>"$DRAFTER_LOG_FILE" 2>&1; then
+      log "digest email DRY-RUN rendered -> $DIGEST_RENDER (nothing sent): $EMAIL_SUBJECT"
+    else
+      log "digest email dry-run render FAILED (best-effort; see log)"
+    fi
+  else
+    if python3 "$SEND_HELPER" --subject "$EMAIL_SUBJECT" --body-file "$QUEUE_SUMMARY" \
+         --to "$DRAFTER_EMAIL_TO" >>"$DRAFTER_LOG_FILE" 2>&1; then
+      log "digest emailed to $DRAFTER_EMAIL_TO: $EMAIL_SUBJECT"
+    else
+      log "digest email FAILED (best-effort; queue still written): $EMAIL_SUBJECT"
+    fi
+  fi
+elif [ "$DRAFTER_EMAIL" = "on" ] || [ "$DRAFTER_EMAIL" = "1" ]; then
+  log "digest email skipped: python3 or send helper unavailable (queue still written)"
+else
+  log "digest email disabled (DRAFTER_EMAIL=$DRAFTER_EMAIL)"
+fi
 
 # Build a compact context array: one line per action-worthy item.
 CONTEXT_JSON="$(jq -sc '

--- a/scripts/task-spec-drafter/send_digest.py
+++ b/scripts/task-spec-drafter/send_digest.py
@@ -6,12 +6,16 @@ the day's triage (would-dispatch TASKs + the NEEDS-DECISION / STALE / ALREADY-DO
 classifications) so he can adjudicate from his inbox without the tool touching
 anything.
 
-REUSES repo-cos's `email_send.py` (the DKIM-signed postfix-relay send path,
-`From: repo-cos@mail.zacx.dev`) — it does NOT build a new mailer. `email_send.py`
-is loaded by EXPLICIT importlib path, NOT by putting `scripts/repo-cos/` on
-sys.path: repo-cos ships an `llm.py` (and mail-actions a shadowing `_db.py`) that
-we must never pull in — email_send.py is standalone stdlib, so an isolated
-module load is both sufficient and safe (mirrors feedback.py's importlib gotcha).
+REUSES repo-cos's `email_send.py` (the DKIM-signed postfix-relay send path) — it
+does NOT build a new mailer — but sends under the drafter's OWN identity
+(`From: task-drafter@mail.zacx.dev`, `Reply-To: zachlowden1@gmail.com`) so a reply
+lands in Zach's inbox, NOT repo-cos's Postgres feedback parser (which acts on
+approve/pause keywords). `email_send.py` is loaded by EXPLICIT importlib path, NOT
+by putting `scripts/repo-cos/` on sys.path: repo-cos ships an `llm.py` (and
+mail-actions a shadowing `_db.py`) that we must never pull in — email_send.py is
+standalone stdlib, so an isolated module load is both sufficient and safe (mirrors
+feedback.py's importlib gotcha). The identity is set via email_send's own
+REPO_COS_FROM / REPO_COS_REPLY_TO env hooks (process-local — repo-cos unaffected).
 
 Usage:
   send_digest.py --subject SUBJ --body-file FILE [--to ADDR] [--dry-run] [--out FILE]
@@ -30,6 +34,27 @@ from pathlib import Path
 
 DEFAULT_TO = "zachlowden1@gmail.com"
 
+# DISTINCT mail identity — the drafter digest must NOT reuse repo-cos's From/
+# Reply-To. repo-cos sends `From: repo-cos@mail.zacx.dev` / `Reply-To:
+# repo-cos@inbox.zacx.dev`, and a reply to THAT address routes into repo-cos's
+# Postgres feedback inbox where feedback.py/exclusions.py act on approve/pause
+# keywords (and can POST a clawgate Task). Zach WILL reply to these soak digests,
+# so the drafter uses its own sender and points replies back at his OWN inbox.
+# email_send.py reads these from REPO_COS_FROM / REPO_COS_REPLY_TO (its
+# `_from_addr()` / `_reply_to()` env hooks) — so we set them in THIS process's
+# env before calling send_digest, WITHOUT modifying email_send.py (read-only
+# reuse; repo-cos's own runs, a different process, keep their defaults).
+DRAFTER_FROM = "task-drafter <task-drafter@mail.zacx.dev>"
+DRAFTER_REPLY_TO = "zachlowden1@gmail.com"
+
+
+def _from_addr() -> str:
+    return os.environ.get("DRAFTER_EMAIL_FROM", DRAFTER_FROM)
+
+
+def _reply_to() -> str:
+    return os.environ.get("DRAFTER_EMAIL_REPLY_TO", DRAFTER_REPLY_TO)
+
 
 def _load_email_send():
     """Load repo-cos/email_send.py in isolation (explicit path, no sys.path edits)."""
@@ -38,8 +63,9 @@ def _load_email_send():
     if not mod_path.exists():
         raise FileNotFoundError(f"repo-cos email_send.py not found at {mod_path}")
     spec = importlib.util.spec_from_file_location("drafter_email_send", mod_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot build import spec for {mod_path}")
     mod = importlib.util.module_from_spec(spec)
-    assert spec and spec.loader
     spec.loader.exec_module(mod)
     return mod
 
@@ -59,9 +85,14 @@ def main(argv: list[str] | None = None) -> int:
     args = ap.parse_args(argv)
 
     body = Path(args.body_file).read_text(encoding="utf-8", errors="replace")
+    from_addr = _from_addr()
+    reply_to = _reply_to()
 
     if args.dry_run:
-        rendered = f"To: {args.to}\nSubject: {args.subject}\n\n{body}"
+        rendered = (
+            f"From: {from_addr}\nReply-To: {reply_to}\n"
+            f"To: {args.to}\nSubject: {args.subject}\n\n{body}"
+        )
         if args.out:
             Path(args.out).write_text(rendered, encoding="utf-8")
             print(f"[dry-run] digest email rendered to {args.out} (nothing sent)")
@@ -71,10 +102,14 @@ def main(argv: list[str] | None = None) -> int:
 
     # Real send — best-effort: never raise into the caller (the drafter treats a
     # send failure as a logged, non-fatal degrade; the queue is still written).
+    # Point email_send at the DRAFTER's identity (not repo-cos's) via its env
+    # hooks — process-local, so repo-cos's own sends are unaffected.
+    os.environ["REPO_COS_FROM"] = from_addr
+    os.environ["REPO_COS_REPLY_TO"] = reply_to
     try:
         email_send = _load_email_send()
         to = email_send.send_digest(subject=args.subject, body=body, to_addr=args.to)
-        print(f"digest sent to {to}")
+        print(f"digest sent to {to} (From: {from_addr}, Reply-To: {reply_to})")
         return 0
     except Exception as exc:  # noqa: BLE001 — deliberate best-effort boundary
         print(f"digest send FAILED: {exc}", file=sys.stderr)

--- a/scripts/task-spec-drafter/send_digest.py
+++ b/scripts/task-spec-drafter/send_digest.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Send the task-spec-drafter daily triage digest by email.
+
+The digest is the SHADOW soak's review surface: each scheduled run emails Zach
+the day's triage (would-dispatch TASKs + the NEEDS-DECISION / STALE / ALREADY-DONE
+classifications) so he can adjudicate from his inbox without the tool touching
+anything.
+
+REUSES repo-cos's `email_send.py` (the DKIM-signed postfix-relay send path,
+`From: repo-cos@mail.zacx.dev`) — it does NOT build a new mailer. `email_send.py`
+is loaded by EXPLICIT importlib path, NOT by putting `scripts/repo-cos/` on
+sys.path: repo-cos ships an `llm.py` (and mail-actions a shadowing `_db.py`) that
+we must never pull in — email_send.py is standalone stdlib, so an isolated
+module load is both sufficient and safe (mirrors feedback.py's importlib gotcha).
+
+Usage:
+  send_digest.py --subject SUBJ --body-file FILE [--to ADDR] [--dry-run] [--out FILE]
+
+DRY-RUN (--dry-run or DRAFTER_EMAIL_DRYRUN=1): render `To/Subject/body` to --out
+(or stdout) and send NOTHING — used by the shadow proof run so a dry-run costs
+no external side effect. The first REAL scheduled run does the actual send.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+DEFAULT_TO = "zachlowden1@gmail.com"
+
+
+def _load_email_send():
+    """Load repo-cos/email_send.py in isolation (explicit path, no sys.path edits)."""
+    here = Path(__file__).resolve().parent
+    mod_path = here.parent / "repo-cos" / "email_send.py"
+    if not mod_path.exists():
+        raise FileNotFoundError(f"repo-cos email_send.py not found at {mod_path}")
+    spec = importlib.util.spec_from_file_location("drafter_email_send", mod_path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--subject", required=True)
+    ap.add_argument("--body-file", required=True)
+    ap.add_argument("--to", default=os.environ.get("DRAFTER_EMAIL_TO", DEFAULT_TO))
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=os.environ.get("DRAFTER_EMAIL_DRYRUN", "0") == "1",
+        help="render the email, send nothing",
+    )
+    ap.add_argument("--out", default="", help="dry-run: write rendered email here (else stdout)")
+    args = ap.parse_args(argv)
+
+    body = Path(args.body_file).read_text(encoding="utf-8", errors="replace")
+
+    if args.dry_run:
+        rendered = f"To: {args.to}\nSubject: {args.subject}\n\n{body}"
+        if args.out:
+            Path(args.out).write_text(rendered, encoding="utf-8")
+            print(f"[dry-run] digest email rendered to {args.out} (nothing sent)")
+        else:
+            sys.stdout.write(rendered)
+        return 0
+
+    # Real send — best-effort: never raise into the caller (the drafter treats a
+    # send failure as a logged, non-fatal degrade; the queue is still written).
+    try:
+        email_send = _load_email_send()
+        to = email_send.send_digest(subject=args.subject, body=body, to_addr=args.to)
+        print(f"digest sent to {to}")
+        return 0
+    except Exception as exc:  # noqa: BLE001 — deliberate best-effort boundary
+        print(f"digest send FAILED: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/task-spec-drafter/systemd/task-spec-drafter.service
+++ b/scripts/task-spec-drafter/systemd/task-spec-drafter.service
@@ -23,6 +23,9 @@ Type=oneshot
 # Adjust the path if devrc lives elsewhere on this host.
 ExecStart=/home/zach/workspace/devrc/scripts/task-spec-drafter/drafter.sh
 # Long because each ticket runs a headless claude pass; the timer is daily so an
-# occasional long run is fine. Tune down via DRAFTER_MAX_TICKETS for cheap runs.
-TimeoutStartSec=3600
+# occasional long run is fine. Worst case = first (empty-state) run: at most
+# DRAFTER_MAX_TICKETS(25) × DRAFTER_TIMEOUT(240s) = 6000s, so 7200s clears it with
+# headroom. Raise this if you raise the cap/per-ticket timeout. Matches the
+# home-manager unit (nix/home.nix), which is authoritative on the workbench.
+TimeoutStartSec=7200
 Nice=10

--- a/scripts/task-spec-drafter/systemd/task-spec-drafter.timer
+++ b/scripts/task-spec-drafter/systemd/task-spec-drafter.timer
@@ -1,11 +1,12 @@
-# Daily run, ~09:15 local, a bit before standup-triage's 10:30 slot so the queue
-# is fresh when you glance at it. Persistent=true catches up if the machine was
-# off at the scheduled time (it's a daily cadence; nothing auto-dispatches).
+# Daily run at 08:00 local (matches the home-manager unit in nix/home.nix, which
+# is the authoritative install path on the workbench; this imperative unit is the
+# reversible fallback documented in the README). Persistent=true catches up if the
+# machine was off at the scheduled time (daily cadence; nothing auto-dispatches).
 [Unit]
 Description=Daily timer for the deep-context task-spec drafter
 
 [Timer]
-OnCalendar=*-*-* 09:15:00
+OnCalendar=*-*-* 08:00:00
 Persistent=true
 RandomizedDelaySec=300
 Unit=task-spec-drafter.service

--- a/scripts/task-spec-drafter/task-spec-drafter.env.example
+++ b/scripts/task-spec-drafter/task-spec-drafter.env.example
@@ -26,7 +26,9 @@ DRAFTER_MAX_TICKETS=25
 # Delta-scoping state file: {ticket_id: date_updated}. A run processes a ticket
 # only if it's new (absent) or changed (live date_updated newer than stored);
 # unchanged tickets are skipped. Corrupt/missing -> treated as empty (no crash).
-# DRAFTER_STATE_FILE=~/.claude/task-spec-drafter/processed.json
+# Kept under ~/.local/state (persistent, survives OUT_DIR cleanup); drafter.sh
+# creates the parent dir so steady-state runs only touch new/changed tickets.
+DRAFTER_STATE_FILE=~/.local/state/task-spec-drafter/processed.json
 
 # Seconds budget per ticket's headless `claude -p` deep-context call.
 DRAFTER_TIMEOUT=240
@@ -34,8 +36,19 @@ DRAFTER_TIMEOUT=240
 # Where shadow queues + the run log are written.
 DRAFTER_OUT_DIR=~/.claude/task-spec-drafter
 
-# ClickUp triage view to read (default = the "To Schedule" standup queue).
+# ClickUp triage view to read (default = the "To Schedule" standup queue). This
+# is the list-view over the clickup skill's defaultListId 901111220963.
 CLICKUP_VIEW_ID=6-901111220963-1
+
+# --- daily digest email (the SHADOW review surface) ------------------------
+# Every run that processes >=1 ticket emails the day's triage summary so it can be
+# reviewed from the inbox. Reuses repo-cos's DKIM-signed postfix relay (no new
+# mailer). Set DRAFTER_EMAIL=off to disable. The relay is reached via a
+# kubectl port-forward to the production cluster; override the kubeconfig if it
+# moved (default ~/workspace/homelab-talos/production-kubeconfig).
+DRAFTER_EMAIL=on
+DRAFTER_EMAIL_TO=zachlowden1@gmail.com
+# REPO_COS_PROD_KUBECONFIG=~/workspace/homelab-talos/production-kubeconfig
 
 # Verification sources (override only if your checkouts move).
 # CIVITAI_REPO=/home/zach/workspace/civit/civitai

--- a/scripts/task-spec-drafter/tests/test_send_digest.py
+++ b/scripts/task-spec-drafter/tests/test_send_digest.py
@@ -48,6 +48,38 @@ def test_dry_run_renders_to_file_and_sends_nothing(tmp_path):
     assert "do the thing" in rendered  # the body is carried verbatim
 
 
+def test_dry_run_uses_distinct_drafter_identity(tmp_path):
+    """The digest must NOT reuse repo-cos's From/Reply-To (a reply to those routes
+    into repo-cos's feedback parser). It sends as task-drafter@ and points replies
+    at Zach's own inbox."""
+    body = tmp_path / "d.md"
+    body.write_text("x\n", encoding="utf-8")
+    out = tmp_path / "r.txt"
+    r = _run(["--subject", "s", "--body-file", str(body), "--dry-run", "--out", str(out)])
+    assert r.returncode == 0, r.stderr
+    rendered = out.read_text(encoding="utf-8")
+    assert "From: task-drafter <task-drafter@mail.zacx.dev>" in rendered
+    assert "Reply-To: zachlowden1@gmail.com" in rendered
+    # explicitly NOT repo-cos's identity
+    assert "repo-cos@mail.zacx.dev" not in rendered
+    assert "repo-cos@inbox.zacx.dev" not in rendered
+
+
+def test_identity_env_overrides(tmp_path):
+    body = tmp_path / "d.md"
+    body.write_text("x\n", encoding="utf-8")
+    out = tmp_path / "r.txt"
+    r = _run(
+        ["--subject", "s", "--body-file", str(body), "--dry-run", "--out", str(out)],
+        env_extra={"DRAFTER_EMAIL_FROM": "custom <c@x.dev>",
+                   "DRAFTER_EMAIL_REPLY_TO": "reply@x.dev"},
+    )
+    assert r.returncode == 0, r.stderr
+    rendered = out.read_text(encoding="utf-8")
+    assert "From: custom <c@x.dev>" in rendered
+    assert "Reply-To: reply@x.dev" in rendered
+
+
 def test_dry_run_via_env_flag_to_stdout(tmp_path):
     body = tmp_path / "digest.md"
     body.write_text("BODYMARKER\n", encoding="utf-8")

--- a/scripts/task-spec-drafter/tests/test_send_digest.py
+++ b/scripts/task-spec-drafter/tests/test_send_digest.py
@@ -1,0 +1,75 @@
+"""Tests for send_digest.py — the task-spec-drafter digest email helper.
+
+Hermetic: the dry-run path touches no network; the real-send path is exercised
+only as far as the relay's local `PROD_KUBECONFIG.exists()` guard (a missing
+kubeconfig raises before any port-forward / SMTP), which proves BOTH that the
+default send mode is the repo-cos relay AND that a send failure degrades to a
+logged non-zero exit rather than raising into the drafter.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HELPER = _HERE.parent / "send_digest.py"
+
+
+def _run(args, env_extra=None):
+    env = dict(os.environ)
+    env.pop("DRAFTER_EMAIL_DRYRUN", None)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(_HELPER), *args],
+        capture_output=True, text=True, env=env, timeout=60,
+    )
+
+
+def test_helper_exists_and_is_executable():
+    assert _HELPER.exists()
+    assert os.access(_HELPER, os.X_OK)
+
+
+def test_dry_run_renders_to_file_and_sends_nothing(tmp_path):
+    body = tmp_path / "digest.md"
+    body.write_text("# triage\n[TASK] abc — do the thing\n", encoding="utf-8")
+    out = tmp_path / "rendered.txt"
+    r = _run([
+        "--subject", "task-drafter SHADOW digest — 1 would-dispatch, 2 need-decision",
+        "--body-file", str(body),
+        "--to", "someone@example.com",
+        "--dry-run", "--out", str(out),
+    ])
+    assert r.returncode == 0, r.stderr
+    rendered = out.read_text(encoding="utf-8")
+    assert "To: someone@example.com" in rendered
+    assert "Subject: task-drafter SHADOW digest" in rendered
+    assert "do the thing" in rendered  # the body is carried verbatim
+
+
+def test_dry_run_via_env_flag_to_stdout(tmp_path):
+    body = tmp_path / "digest.md"
+    body.write_text("BODYMARKER\n", encoding="utf-8")
+    r = _run(
+        ["--subject", "s", "--body-file", str(body)],
+        env_extra={"DRAFTER_EMAIL_DRYRUN": "1"},
+    )
+    assert r.returncode == 0, r.stderr
+    assert "BODYMARKER" in r.stdout
+
+
+def test_real_send_missing_kubeconfig_is_best_effort(tmp_path):
+    """Default mode is the repo-cos relay; a missing prod kubeconfig fails the
+    relay's local existence guard BEFORE any network, and send_digest catches it
+    -> exit 1 + a logged 'FAILED', never an unhandled exception."""
+    body = tmp_path / "digest.md"
+    body.write_text("x\n", encoding="utf-8")
+    r = _run(
+        ["--subject", "s", "--body-file", str(body), "--to", "z@example.com"],
+        env_extra={"REPO_COS_PROD_KUBECONFIG": str(tmp_path / "nope-kubeconfig")},
+    )
+    assert r.returncode == 1
+    assert "FAILED" in r.stderr
+    # no traceback leaked
+    assert "Traceback" not in r.stderr

--- a/scripts/task-spec-drafter/tests/test_shadow_wiring.py
+++ b/scripts/task-spec-drafter/tests/test_shadow_wiring.py
@@ -52,6 +52,34 @@ def test_shadow_branch_exits_before_send():
     assert 'exit 0' in seg.split('# on: actually notify clawgate', 1)[0]
 
 
+# --- read-only allowlist (no write-capable verbs reachable under injection) ----
+
+def _allowlist(src: str) -> str:
+    """Extract the DRAFTER_ALLOWED_TOOLS default value."""
+    line = next(l for l in src.splitlines() if l.startswith("DRAFTER_ALLOWED_TOOLS="))
+    return line
+
+
+def test_allowlist_has_no_write_capable_verbs():
+    """The headless pass reasons over untrusted client ticket text with no plan
+    mode, so a write-capable allowlist entry is an injection→mutation path. These
+    must NOT be present."""
+    al = _allowlist(_read(_DRAFTER))
+    assert "gh api" not in al, "gh api* allows `gh api -X POST/PATCH/DELETE`"
+    assert "curl" not in al, "curl -s* allows `curl -X POST -d …`"
+    assert "Bash(env" not in al, "env* dumps the inherited CLAWGATE_HOOK_TOKEN"
+
+
+def test_allowlist_keeps_readonly_verification_verbs():
+    al = _allowlist(_read(_DRAFTER))
+    for verb in (
+        "Bash(git -C * log*)", "Bash(git -C * show*)",
+        "Bash(gh pr list*)", "Bash(gh pr view*)",
+        "Bash(kubectl get*)", "Bash(node *query.mjs get*)",
+    ):
+        assert verb in al, f"missing read-only verification verb {verb}"
+
+
 # --- deterministic safety gate ------------------------------------------------
 
 def test_safety_gate_forces_needs_decision():
@@ -101,6 +129,16 @@ def test_hm_unit_has_onfailure_and_execstart():
     assert 'OnFailure = [ "notify-failure@%n.service" ]' in block
     assert "scripts/task-spec-drafter/drafter.sh" in block
     assert "REPO_COS_PROD_KUBECONFIG" in block
+
+
+def test_hm_unit_timeout_covers_first_run():
+    """TimeoutStartSec must clear the worst-case first run
+    (DRAFTER_MAX_TICKETS 25 × DRAFTER_TIMEOUT 240s = 6000s) so it isn't SIGTERM'd
+    mid-loop."""
+    nix = _read(_HOME_NIX)
+    block = nix.split("systemd.user.services.task-spec-drafter", 1)[1].split(
+        "systemd.user.timers.task-spec-drafter", 1)[0]
+    assert "TimeoutStartSec = 7200" in block
 
 
 def test_hm_seeds_shadow_env():

--- a/scripts/task-spec-drafter/tests/test_shadow_wiring.py
+++ b/scripts/task-spec-drafter/tests/test_shadow_wiring.py
@@ -1,0 +1,110 @@
+"""Static contract tests for the SHADOW safety invariant + the home-manager wiring.
+
+These encode the non-negotiables in code so a future edit can't silently break
+them:
+  * SHADOW is the default and NOTHING is POSTed to clawgate / dispatched in it —
+    proven structurally: the only clawgate `/api/send` POST lives strictly AFTER
+    the shadow branch's `exit 0`, so a shadow run can never reach it.
+  * the deterministic safety gate force-escalates risk tickets to NEEDS-DECISION.
+  * the drafter is wired into home-manager: workbench-only (serverMode-gated),
+    daily 08:00, OnFailure toast, and the env is seeded shadow-by-default.
+
+Pure text assertions over the committed sources — hermetic, no execution.
+"""
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_DRAFTER = _HERE.parent / "drafter.sh"
+_ENV_EXAMPLE = _HERE.parent / "task-spec-drafter.env.example"
+_HOME_NIX = _HERE.parents[2] / "nix" / "home.nix"
+
+
+def _read(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+# --- drafter.sh: SHADOW is the default + nothing dispatches in shadow ----------
+
+def test_drafter_defaults_to_shadow():
+    assert 'DRAFTER_MODE="${DRAFTER_MODE:-shadow}"' in _read(_DRAFTER)
+
+
+def test_drafter_defaults_model_haiku():
+    assert 'DRAFTER_MODEL="${DRAFTER_MODEL:-haiku}"' in _read(_DRAFTER)
+
+
+def test_no_clawgate_post_reachable_in_shadow():
+    """The clawgate POST must sit AFTER the shadow branch's `exit 0`, so a shadow
+    run structurally cannot reach it."""
+    src = _read(_DRAFTER)
+    shadow_exit = src.index('run $RUN_TS done (shadow, nothing sent)')
+    post_idx = src.index('/api/send')
+    assert shadow_exit < post_idx, "clawgate POST appears before the shadow exit — shadow could dispatch!"
+    # and the POST is guarded by mode=on, not shadow
+    assert 'on: actually notify clawgate' in src
+
+
+def test_shadow_branch_exits_before_send():
+    src = _read(_DRAFTER)
+    assert 'if [ "$DRAFTER_MODE" = "shadow" ]; then' in src
+    # the shadow block ends in exit 0
+    seg = src.split('if [ "$DRAFTER_MODE" = "shadow" ]; then', 1)[1]
+    assert 'exit 0' in seg.split('# on: actually notify clawgate', 1)[0]
+
+
+# --- deterministic safety gate ------------------------------------------------
+
+def test_safety_gate_forces_needs_decision():
+    src = _read(_DRAFTER)
+    assert 'safety_gate()' in src
+    assert '.classification = "NEEDS-DECISION"' in src
+    for cat in ("GATE_RE_SECURITY", "GATE_RE_MONEY", "GATE_RE_DESTRUCTIVE"):
+        assert cat in src
+
+
+# --- daily email digest (the review surface) ----------------------------------
+
+def test_digest_email_step_present_and_default_on():
+    src = _read(_DRAFTER)
+    assert 'DRAFTER_EMAIL="${DRAFTER_EMAIL:-on}"' in src
+    assert "send_digest.py" in src or "$SEND_HELPER" in src
+    assert "task-drafter $MODE_TAG digest" in src
+
+
+def test_env_example_is_shadow_and_haiku():
+    env = _read(_ENV_EXAMPLE)
+    assert "DRAFTER_MODE=shadow" in env
+    assert "DRAFTER_MODEL=haiku" in env
+    assert "CLICKUP_VIEW_ID=6-901111220963-1" in env
+
+
+# --- home-manager wiring ------------------------------------------------------
+
+def test_hm_unit_is_servermode_gated():
+    nix = _read(_HOME_NIX)
+    assert "systemd.user.services.task-spec-drafter = lib.mkIf serverMode" in nix
+    assert "systemd.user.timers.task-spec-drafter = lib.mkIf serverMode" in nix
+
+
+def test_hm_timer_is_daily_0800():
+    nix = _read(_HOME_NIX)
+    # the drafter timer block carries the 08:00 calendar
+    block = nix.split("systemd.user.timers.task-spec-drafter", 1)[1]
+    assert 'OnCalendar = "*-*-* 08:00:00"' in block
+    assert "Persistent = true" in block
+
+
+def test_hm_unit_has_onfailure_and_execstart():
+    nix = _read(_HOME_NIX)
+    block = nix.split("systemd.user.services.task-spec-drafter", 1)[1].split(
+        "systemd.user.timers.task-spec-drafter", 1)[0]
+    assert 'OnFailure = [ "notify-failure@%n.service" ]' in block
+    assert "scripts/task-spec-drafter/drafter.sh" in block
+    assert "REPO_COS_PROD_KUBECONFIG" in block
+
+
+def test_hm_seeds_shadow_env():
+    nix = _read(_HOME_NIX)
+    assert "home.activation.taskSpecDrafterEnv" in nix
+    assert "task-spec-drafter.env" in nix
+    assert "chmod 600" in nix


### PR DESCRIPTION
Graduate the deep-context ClickUp triage drafter from the imperative `systemctl --user` install to a **declarative home-manager unit**, **workbench-only** (serverMode-gated), **daily at 08:00**, running in **SHADOW** by default. Adds a **daily email digest** as the shadow review surface.

## What's wired
- **`systemd.user.{service,timer}.task-spec-drafter`** (`nix/home.nix`), mirroring the repo-cos pattern:
  - `lib.mkIf serverMode` (workbench only, like repo-cos / mail-actions-archive)
  - `OnFailure = notify-failure@%n.service` (#127 template — a broken run toasts)
  - Timer `OnCalendar = *-*-* 08:00:00`, `Persistent = true`, `RandomizedDelaySec = 300`
  - Explicit PATH: `%h/.nix-profile/bin` + system profile first (so the profile-installed `claude` + `gh` resolve), then pinned `node`/`git`/`kubectl`/`jq`/`curl`/`python3`/coreutils; `X-Restart-Triggers` on `drafter.sh`
- **Env seeded once** via `home.activation.taskSpecDrafterEnv` (chmod 600, no-clobber) — so `DRAFTER_MODE` lives outside the nix store and **shadow→on is a one-line edit + switch**, no code change.
- **State file** moved to a stable `~/.local/state/task-spec-drafter/processed.json`; `drafter.sh` now `mkdir`s the state parent so an out-of-OUT_DIR state file never breaks the atomic write.

## The key addition — daily email digest (SHADOW review surface)
Every run that processes ≥1 ticket **emails the day's triage** (per-ticket classification + one-line why + drafted spec for TASKs + suppressed one-liners), **reusing repo-cos's DKIM-signed postfix relay** — `send_digest.py` loads `repo-cos/email_send.py` by explicit importlib path (no new mailer; no `llm.py`/`_db.py` sys.path shadowing). Subject: `task-drafter SHADOW digest — N would-dispatch, M need-decision`. `DRAFTER_EMAIL_DRYRUN=1` renders the email to a file and sends nothing (used for proofs).

## Safety (SHADOW is paramount)
In shadow the pipeline **dispatches NOTHING and POSTs NOTHING to clawgate** — the clawgate `/api/send` POST lives strictly *after* the shadow branch's `exit 0` (asserted in a test). The digest email is the only outbound, and it is the explicitly-sanctioned review surface. Also hardened `SELF_DIR` against `CDPATH`-echo corruption.

## Resolved ClickUp view
`6-901111220963-1` (the "To Schedule" list-view over the clickup skill's `defaultListId` 901111220963). The clickup `accounts.json` stores only the API token, so the view is the fixed constant the standup-triage CronJob + drafter already use.

## Validation
- `nix-instantiate --parse` + `home-manager build` (`nix build .#homeConfigurations.zach.activationPackage --impure`) **build green**; both generated units verified (ExecStart→`drafter.sh`, `OnCalendar=*-*-* 08:00:00`, `OnFailure=notify-failure@%n.service`, serverMode-gated, correct Environment/PATH).
- Full hermetic suite (`scripts/run-tests.sh --set hermetic`) **PASS**, including the new `scripts/task-spec-drafter/tests`.
- **SHADOW dry-run over the live ClickUp queue** (cap 2, `DRAFTER_EMAIL_DRYRUN=1`): processed 2 tickets end-to-end with real deep-context verification (inspected civitai `image.service.ts` HEAD, cited line 3358 + `image.schema.ts` line 349), classified 1 TASK + 1 NEEDS-DECISION, rendered the digest, and **sent/dispatched/POSTed nothing** (`rc=0`, `done (shadow, nothing sent)`). An earlier wider pass also exercised the deterministic safety gate firing (`TASK ⛔ GATE FIRED [security/secrets,money] → NEEDS-DECISION`).

## Verification boundary (remaining live checks, after merge + `ship.sh`/switch)
A build + dry-run proves the pipeline + wiring; it does **not** prove the 08:00 timer fires or that the email arrives on-cluster. After deploy on the workbench:
1. `systemctl --user start task-spec-drafter.service` → confirm a digest email arrives in the inbox and `journalctl --user -u task-spec-drafter.service` shows `done (shadow, nothing sent)`.
2. Confirm clawgate shows **zero** new tasks/cards from the run.
3. `systemctl --user list-timers task-spec-drafter.timer` → confirm the 08:00 next-fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)