### PR TITLE
fix(ci): repair the nix flake-check pytest gate (git in sandbox + notify shebang)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,8 @@
         pkgs.runCommandLocal "devrc-pytests"
           {
             # ripgrep: one repo-cos prescan test skipif's without it on PATH.
-            nativeBuildInputs = [ pyEnv pkgs.bash pkgs.ripgrep ];
+            # git: verify-agent-work tests drive real temp git repos in-sandbox.
+            nativeBuildInputs = [ pyEnv pkgs.bash pkgs.ripgrep pkgs.git ];
           }
           ''
             cp -r ${./.} src

--- a/scripts/tests/test_notify_failure.py
+++ b/scripts/tests/test_notify_failure.py
@@ -12,6 +12,7 @@ Two contracts under test:
     notify-send with the failed unit name in the summary.
 """
 import os
+import shutil
 import subprocess
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
@@ -24,7 +25,10 @@ def _make_fake_notify_send(dir_path):
     stub = os.path.join(dir_path, "notify-send")
     # $@ / %s\n are literal bash; only `out` is interpolated (via concatenation
     # so no Python %-formatting touches the bash body).
-    body = "#!/usr/bin/env bash\nprintf '%s\\n' \"$@\" > '" + out + "'\n"
+    # Resolve bash to an absolute path: the nix flake-check sandbox has no
+    # /usr/bin/env, so a `#!/usr/bin/env bash` stub would fail to exec there.
+    _bash = shutil.which("bash") or "/bin/bash"
+    body = "#!" + _bash + "\nprintf '%s\\n' \"$@\" > '" + out + "'\n"
     with open(stub, "w") as fh:
         fh.write(body)
     os.chmod(stub, 0o755)


### PR DESCRIPTION
## Problem
The hermetic `nix flake check` pytest derivation (`.#checks.x86_64-linux.pytests`, the gate from #115) has been **red on main since #127** — but nothing surfaced it because there's no GitHub CI running it, and the blocking *pre-push hook* runs the suite in a dev-host nix-shell where the missing tools exist. Only the stricter sandbox fails.

Two independent causes:
1. **`git` absent from the sandbox** — `verify-agent-work`'s tests (merged in #120) drive real temp git repos, but `checks.pytests` `nativeBuildInputs` had only python/bash/ripgrep → `git init` failed (rc 255). They're the first hermetic suite to shell out to real git.
2. **notify-send stub shebang** (pre-existing, from #127) — `test_notify_failure.py`'s fake `notify-send` used `#!/usr/bin/env bash`, which can't resolve in the sandbox (no `/usr/bin/env`), so the stub never ran and the graphical-toast assertion failed.

## Fix
- Add `pkgs.git` to the check's `nativeBuildInputs`. The tests set per-repo `user.email`/`user.name`, so they remain fully hermetic (no global identity, no network).
- Resolve the fake `notify-send` shebang to an absolute `bash` via `shutil.which`.

## Verification
`nix build .#checks.x86_64-linux.pytests` now builds **green** (`RESULT: PASS`, all hermetic dirs), where it previously failed on `scripts/tests`. Sandbox-parity runs: `test_notify_failure.py` 4 passed, `test_verify_agent_work.py` 58 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)