### PR TITLE
feat(espanso): SSH-connect snippets for workbench + laptop (nebula + LAN)

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -66,6 +66,12 @@ in
           { trigger = ":kuc"; replace = "${workspace}/kubeclaw "; label = "kubeclaw path"; search_terms = ["kubeclaw"]; }
           { trigger = ":nixos"; replace = "/etc/nixos/configuration.nix"; label = "nixos config"; search_terms = ["nixos" "configuration"]; }
 
+          # SSH connect
+          { trigger = ":sshwn"; replace = "ssh zach@10.42.0.30"; label = "SSH workbench (nebula)"; search_terms = ["ssh" "workbench" "wb" "nebula" "mesh" "remote"]; }
+          { trigger = ":sshwl"; replace = "ssh zach@192.168.50.250"; label = "SSH workbench (LAN)"; search_terms = ["ssh" "workbench" "wb" "lan" "local"]; }
+          { trigger = ":sshln"; replace = "ssh zach@10.42.0.100"; label = "SSH laptop (nebula)"; search_terms = ["ssh" "laptop" "framework" "nebula" "mesh" "remote"]; }
+          { trigger = ":sshll"; replace = "ssh zach@192.168.50.155"; label = "SSH laptop (LAN)"; search_terms = ["ssh" "laptop" "framework" "lan" "local"]; }
+
           # hot singles
           { trigger = "dashbaord"; replace = "dashboard"; }
           { trigger = "reocmmend"; replace = "recommend"; }

--- a/scripts/collector/keylog/tests/test_espanso_triggers.py
+++ b/scripts/collector/keylog/tests/test_espanso_triggers.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import espanso_triggers as ET  # noqa: E402
+import espanso_detect as ED  # noqa: E402
 
 # A base.yml shaped exactly like home-manager renders it: `replace:` appears
 # BEFORE `trigger:`, and some matches omit label / search_terms.
@@ -106,3 +107,87 @@ def test_path_based_load_roundtrip(tmp_path):
     assert ts.triggers == [":date"]
     assert ts.meta[":date"]["search_terms"] == ["today"]
     assert ts.search_shortcut == (True, 0x20)
+
+
+# --------------------------------------------------------------------------- #
+# SSH-connect snippets (:sshwn/:sshwl/:sshln/:sshll) — shaped exactly like
+# home-manager renders them (`replace:` before `trigger:`), covering parse,
+# direct-fire detection, and the by-design 2-way search ambiguity.
+# --------------------------------------------------------------------------- #
+SSH_BASE = {
+    "matches": [
+        {
+            "label": "SSH workbench (nebula)",
+            "replace": "ssh zach@10.42.0.30",
+            "search_terms": ["ssh", "workbench", "wb", "nebula", "mesh", "remote"],
+            "trigger": ":sshwn",
+        },
+        {
+            "label": "SSH workbench (LAN)",
+            "replace": "ssh zach@192.168.50.250",
+            "search_terms": ["ssh", "workbench", "wb", "lan", "local"],
+            "trigger": ":sshwl",
+        },
+        {
+            "label": "SSH laptop (nebula)",
+            "replace": "ssh zach@10.42.0.100",
+            "search_terms": ["ssh", "laptop", "framework", "nebula", "mesh", "remote"],
+            "trigger": ":sshln",
+        },
+        {
+            "label": "SSH laptop (LAN)",
+            "replace": "ssh zach@192.168.50.155",
+            "search_terms": ["ssh", "laptop", "framework", "lan", "local"],
+            "trigger": ":sshll",
+        },
+    ]
+}
+
+_SSH_EXPECTED = {
+    ":sshwn": ("ssh zach@10.42.0.30", "SSH workbench (nebula)",
+               ["ssh", "workbench", "wb", "nebula", "mesh", "remote"]),
+    ":sshwl": ("ssh zach@192.168.50.250", "SSH workbench (LAN)",
+               ["ssh", "workbench", "wb", "lan", "local"]),
+    ":sshln": ("ssh zach@10.42.0.100", "SSH laptop (nebula)",
+               ["ssh", "laptop", "framework", "nebula", "mesh", "remote"]),
+    ":sshll": ("ssh zach@192.168.50.155", "SSH laptop (LAN)",
+               ["ssh", "laptop", "framework", "lan", "local"]),
+}
+
+
+def test_ssh_snippets_parse_replace_label_search_terms():
+    ts = ET.load_triggers(SSH_BASE, DEFAULT)
+    assert set(ts.triggers) == set(_SSH_EXPECTED)
+    for trig, (replace, label, terms) in _SSH_EXPECTED.items():
+        assert ts.meta[trig]["replace"] == replace
+        assert ts.meta[trig]["label"] == label
+        assert ts.meta[trig]["search_terms"] == terms
+
+
+def test_ssh_snippets_direct_fire():
+    ts = ET.load_triggers(SSH_BASE, DEFAULT)
+    for trig in _SSH_EXPECTED:
+        det = ED.EspansoDetector(ts)
+        events = []
+        for ch in trig:
+            events.extend(
+                det.feed_char(ch, app="term", session="s1", now=0.0)
+            )
+        assert len(events) == 1, f"{trig} should fire exactly one event"
+        ev = events[0]
+        assert isinstance(ev, ED.EspansoEvent)
+        assert ev.trigger == trig
+        assert ev.method == "direct"
+        assert ev.inferred is False
+
+
+def test_ssh_search_attribution_is_ambiguous_by_design():
+    # Both a nebula and a LAN snippet share "laptop"/"workbench"/"wb", so a
+    # search on any of those terms matches TWO snippets. `_attribute` returns
+    # None for >1 match — this is the INTENDED behaviour (the user is shown a
+    # 2-item espanso picker to choose nebula vs LAN), NOT a bug.
+    ts = ET.load_triggers(SSH_BASE, DEFAULT)
+    det = ED.EspansoDetector(ts)
+    assert det._attribute("laptop") is None      # :sshln + :sshll
+    assert det._attribute("workbench") is None   # :sshwn + :sshwl
+    assert det._attribute("wb") is None           # :sshwn + :sshwl

--- a/scripts/session-analysis/espanso-usage.py
+++ b/scripts/session-analysis/espanso-usage.py
@@ -140,6 +140,12 @@ SNIPPETS = {
     ":csc":   ("path", ["civitai-spine-controller"], [], False),
     ":cpk":   ("path", ["datapacket-talos/prod-kubeconfig"], [], False),
     ":subk":  ("path", ["submodel-dc-03-a-kubeconfig"], [], False),
+    # ssh connect — pasted into a terminal, never appears in a transcript
+    # (not text-detectable; keylog is the only fire signal, same as :aep)
+    ":sshwn": ("ssh", None, [], False),
+    ":sshwl": ("ssh", None, [], False),
+    ":sshln": ("ssh", None, [], False),
+    ":sshll": ("ssh", None, [], False),
     # workflow prompts (current expansions)
     ":eos":     ("prompt", ["identify skills that may need updating"], [], False),
     ":acq":     ("prompt", ["recommend anything you think would be useful to include"], [], False),


### PR DESCRIPTION
## What

Adds four espanso SSH-connect snippets to the home-manager espanso config so `ssh`-ing to either host over either network is a two-key expansion instead of recalling IPs.

| trigger | replace | label |
|---|---|---|
| `:sshwn` | `ssh zach@10.42.0.30` | SSH workbench (nebula) |
| `:sshwl` | `ssh zach@192.168.50.250` | SSH workbench (LAN) |
| `:sshln` | `ssh zach@10.42.0.100` | SSH laptop (nebula) |
| `:sshll` | `ssh zach@192.168.50.155` | SSH laptop (LAN) |

Each `replace` is the bare command (no trailing space/newline). Placed under a new `# SSH connect` section next to the existing path snippets.

## Notes
- `espanso-usage.py`: the four triggers are registered as **not text-detectable** (`subs=None`, kind `ssh`) — an ssh command pasted into a terminal never lands in a Claude transcript, so the keylog `EspansoDetector` is the only fire signal (same treatment as `:aep`). The keylog detector auto-parses the live rendered config on each switch, so no detector code change was needed.
- The nebula/LAN pairs deliberately share host search terms (`laptop`/`workbench`/`wb`), so a Ctrl+Space search on those yields the intended **2-item picker** (nebula vs LAN) rather than a unique attribution.

## Test coverage
Extended `scripts/collector/keylog/tests/test_espanso_triggers.py`:
1. Parse: `load_triggers` returns the four triggers with correct `replace`, `label`, `search_terms`.
2. Direct fire: feeding each trigger's chars through `EspansoDetector.feed_char` fires exactly one `EspansoEvent` (`method=direct`, `inferred=False`) with the right trigger.
3. By-design ambiguity: `_attribute("laptop")`, `_attribute("workbench")`, `_attribute("wb")` each return `None` (two snippets match → picker), asserted as intended behavior, not a bug.

Full suite: **61 passed**. Rendered `~/.config/espanso/match/base.yml` confirmed to contain all four triggers with exact replace strings after `home-manager switch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)