### PR TITLE
feat(initiatives): Phase 1 — sync initiative-scan into mailbox Postgres

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -724,6 +724,68 @@ in
     };
   };
 
+  # Initiatives consolidation (PHASE 1) — periodic sync of the on-demand
+  # initiative-scan into the homelab `mailbox` Postgres (initiatives schema), so
+  # later apps (a live viewer + a router) query a durable, live store instead of
+  # re-running the expensive scan. The wrapper (scripts/initiatives/run-sync.sh)
+  # shells out to initiative-scan.py --json and writes one append-only snapshot via
+  # a kubectl port-forward — SAME cluster-access shape as mail-actions-archive.
+  #
+  # WORKBENCH-ONLY (gated on serverMode), identical rationale to the archiver: the
+  # homelab kubeconfig points at 192.168.50.94:6443 (direct LAN, no proxy), which
+  # only this host has; the laptop is nebula-only and its run would just fail noisily.
+  #
+  # ⚠ OPEN FOLLOW-UP: CLICKHOUSE_* creds are deliberately NOT injected here yet, so
+  # the timer currently runs the scan TELEMETRY-OFF (still writes a useful handoff+
+  # git+session snapshot; momentum/ev degrade). Provisioning those creds into the
+  # unit env is a separate task — see the PR. Do NOT enable/deploy this before Zach
+  # has eyeballed `sync.py --dry-run` output.
+  #
+  # Minimal user-unit env, so PATH is explicit: nix (nix-shell) + git + gh (the
+  # scan's branch/PR reads) + kubectl (the port-forward) + coreutils/sed/grep, and
+  # NIX_PATH so `nix-shell -p` resolves <nixpkgs>. The wrapper's nix-shell adds
+  # psycopg2 (the DB write) + requests (the scan's ClickHouse read).
+  systemd.user.services.initiatives-sync = lib.mkIf serverMode {
+    Unit = {
+      Description = "Initiatives sync — initiative-scan → homelab mailbox Postgres (initiatives schema)";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+      OnFailure = [ "notify-failure@%n.service" ];
+    };
+    Service = {
+      Type = "oneshot";
+      # Hard ceiling so a half-hung kubectl / scan can't wedge the timer; the
+      # cgroup is killed and the timer re-arms on the next OnUnitActiveSec.
+      TimeoutStartSec = 300;
+      Environment = [
+        "PATH=${lib.makeBinPath [ pkgs.nix pkgs.git pkgs.gh pkgs.kubectl pkgs.bash pkgs.coreutils pkgs.gnused pkgs.gnugrep ]}"
+        "NIX_PATH=nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos"
+        "KUBECONFIG=%h/workspace/homelab-talos/homelab-kubeconfig"
+        "HOME=%h"
+      ];
+      ExecStart = "${pkgs.bash}/bin/bash %h/workspace/devrc/scripts/initiatives/run-sync.sh";
+      # Re-run the unit when the wrapper changes (cf. X-Restart-Triggers above).
+      X-Restart-Triggers = [ "${../scripts/initiatives/run-sync.sh}" ];
+    };
+  };
+
+  # Timer: fire the sync ~every 15 min. OnUnitActiveSec re-arms after each run so a
+  # slow sync never overlaps itself; OnStartupSec gives one prompt run after login.
+  # (No Persistent — it only applies to OnCalendar timers, not monotonic ones.)
+  # Workbench-only, same as its service (serverMode).
+  systemd.user.timers.initiatives-sync = lib.mkIf serverMode {
+    Unit = {
+      Description = "Periodic timer for the initiatives → Postgres sync";
+    };
+    Timer = {
+      OnStartupSec = "2min";
+      OnUnitActiveSec = "15min";
+    };
+    Install = {
+      WantedBy = [ "timers.target" ];
+    };
+  };
+
   # Repo chief-of-staff — WEEKLY: deterministic scan of Zach's repos for improvement
   # signals (TODO/FIXME, skipped tests, `latest` tags, churn, large files) → cheap LLM
   # synthesis (OpenRouter) → ranked proposal digest EMAILED. The "agents bring me ideas"

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -10,6 +10,12 @@ let
   # there (same trap the i3 bar hit — see graphical.nix). serverMode now gates ONLY
   # server-side task enablement; graphical services key off `graphical` below.
   serverMode = builtins.pathExists "${home}/.server-mode";
+  # Initiatives-sync (Phase 1) master switch — OFF by default so a routine deploy
+  # (ship.sh / home-manager switch) can NEVER silently enable the still-unvalidated
+  # prod-write timer. The service definition is left in place regardless (so it can be
+  # started by hand); only the TIMER is wired into timers.target when this is true.
+  # FLIP TO true after the first SUPERVISED live write validates the DDL/insert path.
+  enableInitiativesSync = false;
   # Graphical host = runs X/i3 (both current NixOS hosts do; only a genuinely headless
   # box would not). Approximated as isNixOS, mirroring graphical.nix — deliberately NOT
   # !serverMode, which is true on the graphical workbench.
@@ -761,6 +767,10 @@ in
         "PATH=${lib.makeBinPath [ pkgs.nix pkgs.git pkgs.gh pkgs.kubectl pkgs.bash pkgs.coreutils pkgs.gnused pkgs.gnugrep ]}"
         "NIX_PATH=nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos"
         "KUBECONFIG=%h/workspace/homelab-talos/homelab-kubeconfig"
+        # Explicit host tag — user units do NOT source .zshenv, so resolve_host()
+        # would otherwise only land on "workbench" by falling through
+        # gethostname()=="nixos". Explicit here so a future laptop copy can't mis-tag.
+        "ACTIVITY_HOST=workbench"
         "HOME=%h"
       ];
       ExecStart = "${pkgs.bash}/bin/bash %h/workspace/devrc/scripts/initiatives/run-sync.sh";
@@ -769,17 +779,24 @@ in
     };
   };
 
-  # Timer: fire the sync ~every 15 min. OnUnitActiveSec re-arms after each run so a
-  # slow sync never overlaps itself; OnStartupSec gives one prompt run after login.
-  # (No Persistent — it only applies to OnCalendar timers, not monotonic ones.)
-  # Workbench-only, same as its service (serverMode).
-  systemd.user.timers.initiatives-sync = lib.mkIf serverMode {
+  # Timer: fire the sync ~hourly. The scan is EXPENSIVE (git-log across all repos +
+  # transcript parse + ClickHouse + `gh pr list` open+merged per repo + a kubectl
+  # port-forward) and its inputs change on an hours scale, so hourly is the right
+  # cadence. OnUnitActiveSec re-arms after each run so a slow sync never overlaps
+  # itself; OnStartupSec gives one prompt run after login. (No Persistent — it only
+  # applies to OnCalendar timers, not monotonic ones.)
+  #
+  # DOUBLE-GATED: serverMode (workbench-only, LAN access) AND enableInitiativesSync
+  # (the OFF-by-default master switch in the let-block above). With the switch false
+  # the timer unit is not emitted at all, so NO deploy can wire it into timers.target
+  # until the first supervised live write validates the write path.
+  systemd.user.timers.initiatives-sync = lib.mkIf (serverMode && enableInitiativesSync) {
     Unit = {
       Description = "Periodic timer for the initiatives → Postgres sync";
     };
     Timer = {
       OnStartupSec = "2min";
-      OnUnitActiveSec = "15min";
+      OnUnitActiveSec = "1h";
     };
     Install = {
       WantedBy = [ "timers.target" ];

--- a/scripts/initiatives/run-sync.sh
+++ b/scripts/initiatives/run-sync.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Deterministic initiative-scan → Postgres sync pass for the systemd user timer.
+#
+# Runs scripts/initiatives/sync.py, which shells out to initiative-scan.py --json
+# and writes one append-only snapshot into the homelab `mailbox` Postgres
+# (initiatives schema) via a kubectl port-forward. KUBECONFIG + kubectl + network
+# are the cluster requirements; git/gh are on PATH for the scan's git/PR reads.
+#
+# CLICKHOUSE_* are NOT set here — see the PR: cred provisioning for the timer's
+# environment is an OPEN follow-up. Unset -> the scan runs telemetry-off (still
+# writes a useful handoff+git+session snapshot; momentum/ev degrade).
+#
+# Run by hand or via systemd:  systemctl --user start initiatives-sync.service
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# KUBECONFIG defaults to the homelab admin config; the unit also sets it, but keep
+# a default so the wrapper works when invoked from an interactive shell.
+export KUBECONFIG="${KUBECONFIG:-${HOME}/workspace/homelab-talos/homelab-kubeconfig}"
+
+# Trailing window (default 4, matching the ledger); overridable via env for tuning.
+DAYS="${INITIATIVES_SYNC_DAYS:-4}"
+
+# nix-shell pulls the sync path's deps: psycopg2 (_db.py write) + requests (the
+# scan's ClickHouse read). kubectl/git/gh are provided on PATH by the unit (systemd)
+# or the login shell (interactive) and inherited into the nix-shell.
+exec nix-shell -p 'python3.withPackages(p:[p.psycopg2 p.requests])' \
+  --run "python ${SCRIPT_DIR}/sync.py --days ${DAYS}"

--- a/scripts/initiatives/sync.py
+++ b/scripts/initiatives/sync.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Sync the on-demand initiative-scan into the homelab `mailbox` Postgres.
+
+PHASE 1 of the "initiatives consolidation" feature: turn the expensive, on-demand
+`initiative-scan.py` report into a durable, live store that later apps (a viewer +
+a router) can query cheaply. This script ONLY does the sync — no viewer, no router.
+
+Pipeline (per run):
+  1. Shell out to `scripts/session-analysis/initiative-scan.py --days N --json`
+     (WITHOUT --tmux — the ephemeral tmux overlay is deliberately excluded) and parse
+     stdout. We treat that report as the CONTRACT: we never re-derive its logic and we
+     never import its internals. The scan degrades gracefully with no ClickHouse creds
+     (telemetry_available=false) — so does this sync.
+  2. Ensure the `initiatives` schema/tables/view exist (idempotent, self-migrating DDL).
+     The tables live in their OWN schema inside the `mailbox` database so a future
+     router can natively JOIN them against `mail_actions`.
+  3. Insert one `initiatives.snapshots` row + one `initiatives.initiative_snapshot`
+     row per initiative (append-only snapshots; `initiatives.current` is the live view).
+
+The transform (report dict -> insert-row dicts) is a PURE function (`report_to_rows`),
+separate from all I/O (the subprocess scan + the DB write), so it is unit-testable
+without a live scan or a live DB — mirroring how initiative-scan.py separates pure
+logic from I/O.
+
+Requires (for a REAL write, not --dry-run):
+    KUBECONFIG  — homelab kubeconfig (the DB is only reachable via kubectl port-forward)
+    kubectl     — on PATH
+    psycopg2    — python dep
+On NixOS run under:
+    nix-shell -p "python3.withPackages(p:[p.psycopg2 p.requests])" \
+      --run "python scripts/initiatives/sync.py --dry-run"
+
+CLICKHOUSE_* creds are read from the environment by the scan; unset -> telemetry-off
+(still useful — handoff+git+session data — but momentum/ev degrade).
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import socket
+import subprocess
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+# The scan we shell out to (the data-source contract). Absolute so systemd/nix-shell
+# invocations (any cwd) resolve it; the scan manages its OWN sys.path internally.
+SCAN_PATH = Path(__file__).resolve().parents[1] / "session-analysis" / "initiative-scan.py"
+
+# The shared mailbox-Postgres helper (kubectl port-forward + psycopg2 + DSN-from-secret).
+MAILDB_PATH = Path(__file__).resolve().parents[1] / "mail-actions" / "_db.py"
+
+# --------------------------------------------------------------------------- #
+# Schema — self-migrating, additive-only DDL (idempotent on every run)
+# --------------------------------------------------------------------------- #
+# One namespaced schema in the `mailbox` DB so a future router can JOIN against
+# `mail_actions`. `snapshots` = one row per sync run; `initiative_snapshot` = one
+# row per initiative per run (append-only). `current` = DISTINCT ON latest per
+# (repo, slug), which tolerates a partially-failed snapshot (older rows survive).
+SCHEMA_DDL = """
+CREATE SCHEMA IF NOT EXISTS initiatives;
+
+CREATE TABLE IF NOT EXISTS initiatives.snapshots (
+    id                   serial PRIMARY KEY,
+    captured_at          timestamptz DEFAULT now(),
+    host                 text,
+    days_window          int,
+    telemetry_available  boolean
+);
+
+CREATE TABLE IF NOT EXISTS initiatives.initiative_snapshot (
+    id                   serial PRIMARY KEY,
+    snapshot_id          int REFERENCES initiatives.snapshots(id),
+    host                 text,
+    repo                 text,
+    slug                 text,
+    title                text,
+    doc_date             date,
+    momentum             text,
+    last_touch           timestamptz,
+    next_step            text,
+    commits              int,
+    commits_unknown      boolean,
+    merged_prs           int,
+    open_prs             jsonb,
+    session_count        int,
+    telem_events         int,
+    telem_last           timestamptz,
+    current_doc          text,
+    open_investigations  jsonb,
+    docs                 jsonb
+);
+
+CREATE OR REPLACE VIEW initiatives.current AS
+SELECT DISTINCT ON (i.repo, i.slug)
+       i.*, s.captured_at
+  FROM initiatives.initiative_snapshot i
+  JOIN initiatives.snapshots s ON s.id = i.snapshot_id
+ ORDER BY i.repo, i.slug, s.captured_at DESC;
+"""
+
+# Column order for the per-initiative insert (snapshot_id is prepended at write time).
+ROW_COLUMNS = [
+    "host", "repo", "slug", "title", "doc_date", "momentum", "last_touch",
+    "next_step", "commits", "commits_unknown", "merged_prs", "open_prs",
+    "session_count", "telem_events", "telem_last", "current_doc",
+    "open_investigations", "docs",
+]
+# Columns stored as JSONB (wrapped in psycopg2.extras.Json at write time).
+JSONB_COLUMNS = {"open_prs", "open_investigations", "docs"}
+
+
+# --------------------------------------------------------------------------- #
+# Pure transform (report dict -> insert rows). No I/O — unit-tested directly.
+# --------------------------------------------------------------------------- #
+def _epoch_to_dt(v) -> datetime | None:
+    """UNIX epoch seconds (float|int|str) -> UTC-aware datetime; None -> None.
+
+    `--json` runs with default=str, so an epoch usually arrives as a JSON number,
+    but we accept a stringified number too, and return None for null / unparseable.
+    Storing UTC keeps the column unambiguous (the scan's epochs are wall-clock UTC)."""
+    if v is None:
+        return None
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return None
+    return datetime.fromtimestamp(f, tz=timezone.utc)
+
+
+def _to_date(v) -> date | None:
+    """A handoff's authored date string (e.g. '2026-07-13') -> date; None/blank -> None.
+
+    Tolerant: takes the leading YYYY-MM-DD and returns None on anything unparseable so
+    a malformed `date` can never crash the sync."""
+    if not v:
+        return None
+    try:
+        return date.fromisoformat(str(v).strip()[:10])
+    except ValueError:
+        return None
+
+
+def _to_int(v, default: int = 0) -> int:
+    if v is None:
+        return default
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _initiative_to_row(ini: dict, host: str) -> dict:
+    """One scan `initiative` dict -> one `initiative_snapshot` insert-row dict.
+
+    Epoch floats -> UTC timestamptz; the authored `date` -> a real date; the list/dict
+    fields stay Python objects (wrapped as JSONB only at DB-write time, so the pure
+    transform is inspectable / assertable without psycopg2)."""
+    return {
+        "host": host,
+        "repo": ini.get("repo"),
+        "slug": ini.get("slug"),
+        "title": ini.get("title"),
+        "doc_date": _to_date(ini.get("date")),
+        "momentum": ini.get("momentum"),
+        "last_touch": _epoch_to_dt(ini.get("last_touch")),
+        "next_step": ini.get("next_step"),
+        "commits": _to_int(ini.get("commits")),
+        "commits_unknown": bool(ini.get("commits_unknown")),
+        "merged_prs": _to_int(ini.get("merged_prs")),
+        "open_prs": ini.get("open_prs") or [],
+        "session_count": _to_int(ini.get("session_count")),
+        "telem_events": _to_int(ini.get("telem_events")),
+        "telem_last": _epoch_to_dt(ini.get("telem_last")),
+        "current_doc": ini.get("current_doc"),
+        "open_investigations": ini.get("open_investigations") or [],
+        "docs": ini.get("docs") or [],
+    }
+
+
+def report_to_rows(report: dict, host: str) -> tuple[dict, list[dict]]:
+    """PURE: a scan `--json` report dict -> (snapshot-meta, [initiative-row, ...]).
+
+    Flattens `by_repo` (every repo's initiatives) into one host-tagged row list. The
+    ephemeral tmux overlay and the report-level catchall are intentionally NOT stored
+    (Phase 1 is the durable per-initiative payload only). An empty / telemetry-off
+    report yields an empty row list and telemetry_available=False — never raises."""
+    meta = {
+        "host": host,
+        "days_window": report.get("days"),
+        "telemetry_available": bool(report.get("telemetry_available")),
+    }
+    rows: list[dict] = []
+    for _repo, inis in (report.get("by_repo") or {}).items():
+        for ini in inis or []:
+            rows.append(_initiative_to_row(ini, host))
+    return meta, rows
+
+
+def resolve_host() -> str:
+    """Host tag for the rows. ACTIVITY_HOST wins (BOTH devrc hosts are hostname
+    `nixos`, so the raw hostname can't disambiguate); else a meaningful gethostname();
+    else default to 'workbench' (Phase 1 runs workbench-only)."""
+    env = os.environ.get("ACTIVITY_HOST", "").strip()
+    if env:
+        return env
+    hn = socket.gethostname().strip()
+    if hn and hn != "nixos":
+        return hn
+    return "workbench"
+
+
+# --------------------------------------------------------------------------- #
+# I/O — the scan subprocess, the DB import, schema DDL, and the write
+# --------------------------------------------------------------------------- #
+def run_scan(days: int, scan_path: Path = SCAN_PATH, env: dict | None = None) -> dict:
+    """Shell out to initiative-scan.py --days N --json (NO --tmux) and parse stdout.
+
+    Runs with the SAME interpreter (sys.executable) so the nix-shell python that has
+    `requests` is used for the scan's ClickHouse read. Inherits the environment
+    (CLICKHOUSE_* etc.); the scan degrades to telemetry-off if they're unset."""
+    cmd = [sys.executable, str(scan_path), "--days", str(days), "--json"]
+    out = subprocess.check_output(cmd, text=True, env=env or os.environ.copy())
+    return json.loads(out)
+
+
+def _import_maildb():
+    """Load MailDB from scripts/mail-actions/_db.py by EXPLICIT importlib path.
+
+    Do NOT put mail-actions/ on sys.path — its `llm.py` shadows other modules and
+    breaks callers (documented in the repo CLAUDE.md; repo-cos/feedback.py hits the
+    same trap). `_db.py` imports only stdlib+psycopg2, so a standalone load is safe."""
+    spec = importlib.util.spec_from_file_location("initiatives_maildb", MAILDB_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {MAILDB_PATH}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.MailDB
+
+
+def ensure_schema(conn) -> None:
+    """Create the schema/tables/view idempotently (self-migrating, additive-only)."""
+    with conn.cursor() as cur:
+        cur.execute(SCHEMA_DDL)
+    conn.commit()
+
+
+def write_snapshot(conn, meta: dict, rows: list[dict]) -> int:
+    """Insert one snapshots row + one initiative_snapshot row per initiative.
+
+    JSONB columns are wrapped in psycopg2.extras.Json; datetimes/dates adapt natively.
+    Returns the new snapshot id. Commits once at the end (all-or-nothing per run)."""
+    from psycopg2.extras import Json  # local import so the pure path needs no psycopg2
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO initiatives.snapshots (host, days_window, telemetry_available) "
+            "VALUES (%s, %s, %s) RETURNING id",
+            (meta["host"], meta["days_window"], meta["telemetry_available"]),
+        )
+        snapshot_id = cur.fetchone()[0]
+
+        cols = ["snapshot_id"] + ROW_COLUMNS
+        placeholders = ", ".join(["%s"] * len(cols))
+        sql = (
+            f"INSERT INTO initiatives.initiative_snapshot ({', '.join(cols)}) "
+            f"VALUES ({placeholders})"
+        )
+        for r in rows:
+            vals = [snapshot_id]
+            for c in ROW_COLUMNS:
+                v = r[c]
+                vals.append(Json(v) if c in JSONB_COLUMNS else v)
+            cur.execute(sql, vals)
+    conn.commit()
+    return snapshot_id
+
+
+# --------------------------------------------------------------------------- #
+# Dry-run rendering
+# --------------------------------------------------------------------------- #
+def _short_repo(repo: str | None) -> str:
+    return os.path.basename(str(repo).rstrip("/")) if repo else "?"
+
+
+def _jsonable(row: dict) -> dict:
+    """A row with datetimes/dates isoformatted, for readable dry-run JSON."""
+    out = {}
+    for k, v in row.items():
+        if isinstance(v, (datetime, date)):
+            out[k] = v.isoformat()
+        else:
+            out[k] = v
+    return out
+
+
+def _iso_short(dt: datetime | None) -> str:
+    return dt.strftime("%Y-%m-%d %H:%M") if isinstance(dt, datetime) else "-"
+
+
+def render_dry_run(meta: dict, rows: list[dict]) -> str:
+    """Human-readable, COMPLETE preview of exactly what a real run would insert:
+    the snapshot meta, a scannable table, the row count, and the full per-row JSON."""
+    out: list[str] = []
+    out.append("=== initiatives sync DRY-RUN (no DB write) ===")
+    out.append(
+        f"snapshot: host={meta['host']}  days_window={meta['days_window']}  "
+        f"telemetry_available={meta['telemetry_available']}  "
+        f"captured_at≈{datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M')}Z"
+    )
+    out.append("target:   initiatives.snapshots + initiatives.initiative_snapshot "
+               "(mailbox DB)")
+    if not meta["telemetry_available"]:
+        out.append("NOTE: telemetry OFF (CLICKHOUSE_* unset/unreachable) — momentum/ev "
+                   "degrade to handoff+git+session signal only.")
+    out.append(f"rows to insert: {len(rows)}")
+    out.append("")
+
+    # Scannable summary table.
+    hdr = (f"{'#':>2}  {'repo':<16} {'slug':<34} {'momentum':<8} "
+           f"{'last_touch':<16} {'cmt':>4} {'mPR':>3} {'oPR':>3} {'sess':>4} {'ev':>5}")
+    out.append(hdr)
+    out.append("-" * len(hdr))
+    for i, r in enumerate(rows, 1):
+        out.append(
+            f"{i:>2}  {_short_repo(r['repo']):<16.16} {str(r['slug'] or ''):<34.34} "
+            f"{str(r['momentum'] or ''):<8.8} {_iso_short(r['last_touch']):<16} "
+            f"{r['commits']:>4} {r['merged_prs']:>3} {len(r['open_prs'] or []):>3} "
+            f"{r['session_count']:>4} {r['telem_events']:>5}"
+        )
+    out.append("")
+
+    # Full, complete rows (nothing hidden) so the shape can be eyeballed.
+    out.append("--- full rows (exactly what would be inserted, one per initiative) ---")
+    for i, r in enumerate(rows, 1):
+        out.append(f"[{i}] {_short_repo(r['repo'])} / {r['slug']}")
+        out.append(json.dumps(_jsonable(r), indent=2, ensure_ascii=False))
+    return "\n".join(out)
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Sync initiative-scan --json into the mailbox Postgres "
+                    "(initiatives schema).")
+    p.add_argument("--days", type=int, default=4,
+                   help="trailing window passed to initiative-scan (default 4, "
+                        "matching the ledger default)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="do everything EXCEPT the DB write; print the rows that "
+                        "WOULD be inserted (table + count + full JSON)")
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    a = parse_args(argv)
+    if a.days <= 0:
+        print("error: --days must be positive", file=sys.stderr)
+        return 2
+
+    host = resolve_host()
+    try:
+        report = run_scan(a.days)
+    except subprocess.CalledProcessError as exc:
+        print(f"error: initiative-scan failed (exit {exc.returncode})", file=sys.stderr)
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"error: could not parse initiative-scan --json output: {exc}",
+              file=sys.stderr)
+        return 1
+
+    meta, rows = report_to_rows(report, host)
+
+    if a.dry_run:
+        print(render_dry_run(meta, rows))
+        return 0
+
+    MailDB = _import_maildb()
+    with MailDB() as db:
+        ensure_schema(db.conn)
+        snapshot_id = write_snapshot(db.conn, meta, rows)
+
+    tel = "on" if meta["telemetry_available"] else "OFF (handoff+git only)"
+    print(f"initiatives-sync: wrote snapshot #{snapshot_id} — {len(rows)} initiative "
+          f"rows (host={host}, days={a.days}, telemetry {tel})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/initiatives/sync.py
+++ b/scripts/initiatives/sync.py
@@ -59,7 +59,10 @@ MAILDB_PATH = Path(__file__).resolve().parents[1] / "mail-actions" / "_db.py"
 # `mail_actions`. `snapshots` = one row per sync run; `initiative_snapshot` = one
 # row per initiative per run (append-only). `current` = DISTINCT ON latest per
 # (repo, slug), which tolerates a partially-failed snapshot (older rows survive).
-SCHEMA_DDL = """
+#
+# The child FK is ON DELETE CASCADE so the 90-day retention prune (delete old
+# `snapshots`) removes the child `initiative_snapshot` rows with them.
+TABLES_DDL = """
 CREATE SCHEMA IF NOT EXISTS initiatives;
 
 CREATE TABLE IF NOT EXISTS initiatives.snapshots (
@@ -72,7 +75,7 @@ CREATE TABLE IF NOT EXISTS initiatives.snapshots (
 
 CREATE TABLE IF NOT EXISTS initiatives.initiative_snapshot (
     id                   serial PRIMARY KEY,
-    snapshot_id          int REFERENCES initiatives.snapshots(id),
+    snapshot_id          int REFERENCES initiatives.snapshots(id) ON DELETE CASCADE,
     host                 text,
     repo                 text,
     slug                 text,
@@ -93,6 +96,23 @@ CREATE TABLE IF NOT EXISTS initiatives.initiative_snapshot (
     docs                 jsonb
 );
 
+-- Support the `current` view's DISTINCT ON (repo, slug) … JOIN snapshots …
+-- ORDER BY repo, slug, captured_at DESC, plus the FK join / retention scans.
+CREATE INDEX IF NOT EXISTS initiative_snapshot_repo_slug_snap_idx
+    ON initiatives.initiative_snapshot (repo, slug, snapshot_id);
+CREATE INDEX IF NOT EXISTS initiative_snapshot_snapshot_id_idx
+    ON initiatives.initiative_snapshot (snapshot_id);
+CREATE INDEX IF NOT EXISTS snapshots_captured_at_idx
+    ON initiatives.snapshots (captured_at);
+"""
+
+# The `current` view is guarded separately (see ensure_schema): re-running
+# CREATE OR REPLACE VIEW takes an ACCESS EXCLUSIVE lock every time, so we only
+# (re)create it when it's absent or its version marker differs. Bump VIEW_VERSION
+# whenever VIEW_DDL changes so a deploy recreates it.
+VIEW_VERSION = "v1"
+VIEW_COMMENT = f"initiatives-sync view {VIEW_VERSION}"
+VIEW_DDL = """
 CREATE OR REPLACE VIEW initiatives.current AS
 SELECT DISTINCT ON (i.repo, i.slug)
        i.*, s.captured_at
@@ -100,6 +120,14 @@ SELECT DISTINCT ON (i.repo, i.slug)
   JOIN initiatives.snapshots s ON s.id = i.snapshot_id
  ORDER BY i.repo, i.slug, s.captured_at DESC;
 """
+
+# Arbitrary constant key for the schema advisory lock (pg_advisory_xact_lock), so a
+# manual run can't race the timer on the not-fully-race-safe CREATE … IF NOT EXISTS.
+SCHEMA_LOCK_KEY = 0x1417_1717
+
+# Append-only retention: prune snapshots (and, via ON DELETE CASCADE, their child
+# rows) older than this on every write, so the shared prod DB doesn't grow unbounded.
+RETENTION_DAYS = 90
 
 # Column order for the per-initiative insert (snapshot_id is prepended at write time).
 ROW_COLUMNS = [
@@ -215,14 +243,22 @@ def resolve_host() -> str:
 # --------------------------------------------------------------------------- #
 # I/O — the scan subprocess, the DB import, schema DDL, and the write
 # --------------------------------------------------------------------------- #
-def run_scan(days: int, scan_path: Path = SCAN_PATH, env: dict | None = None) -> dict:
+# Ceiling on the (expensive) scan so a manual invocation with a hung gh/kubectl can't
+# hang forever — systemd's TimeoutStartSec only covers the timer path.
+SCAN_TIMEOUT_SEC = 240
+
+
+def run_scan(days: int, scan_path: Path = SCAN_PATH, env: dict | None = None,
+             timeout: int = SCAN_TIMEOUT_SEC) -> dict:
     """Shell out to initiative-scan.py --days N --json (NO --tmux) and parse stdout.
 
     Runs with the SAME interpreter (sys.executable) so the nix-shell python that has
     `requests` is used for the scan's ClickHouse read. Inherits the environment
-    (CLICKHOUSE_* etc.); the scan degrades to telemetry-off if they're unset."""
+    (CLICKHOUSE_* etc.); the scan degrades to telemetry-off if they're unset. Bounded
+    by `timeout` seconds so a hung gh/kubectl child can't wedge a manual run."""
     cmd = [sys.executable, str(scan_path), "--days", str(days), "--json"]
-    out = subprocess.check_output(cmd, text=True, env=env or os.environ.copy())
+    out = subprocess.check_output(cmd, text=True, env=env or os.environ.copy(),
+                                  timeout=timeout)
     return json.loads(out)
 
 
@@ -241,10 +277,44 @@ def _import_maildb():
 
 
 def ensure_schema(conn) -> None:
-    """Create the schema/tables/view idempotently (self-migrating, additive-only)."""
+    """Create the schema/tables/indexes/view idempotently (self-migrating, additive-only).
+
+    Wrapped in a transaction-scoped advisory lock so a manual run racing the timer
+    can't collide on the not-fully-race-safe CREATE … IF NOT EXISTS. The `current`
+    view is only (re)created when absent or its version marker differs — steady state
+    skips re-taking ACCESS EXCLUSIVE on it every run."""
     with conn.cursor() as cur:
-        cur.execute(SCHEMA_DDL)
+        # Serialize concurrent schema setup (released at COMMIT below).
+        cur.execute("SELECT pg_advisory_xact_lock(%s)", (SCHEMA_LOCK_KEY,))
+        cur.execute(TABLES_DDL)
+
+        # View guard: (re)create only when missing or the version marker differs.
+        cur.execute("SELECT to_regclass('initiatives.current')")
+        exists = cur.fetchone()[0] is not None
+        need_view = True
+        if exists:
+            cur.execute(
+                "SELECT obj_description('initiatives.current'::regclass, 'pg_class')")
+            row = cur.fetchone()
+            need_view = (row[0] if row else None) != VIEW_COMMENT
+        if need_view:
+            cur.execute(VIEW_DDL)
+            cur.execute("COMMENT ON VIEW initiatives.current IS %s", (VIEW_COMMENT,))
     conn.commit()
+
+
+def prune_old_snapshots(conn, retain_days: int = RETENTION_DAYS) -> int:
+    """Delete snapshots older than `retain_days` (child rows cascade). Returns the
+    number of snapshots removed. Keeps the append-only store bounded on shared prod."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM initiatives.snapshots "
+            "WHERE captured_at < now() - make_interval(days => %s)",
+            (retain_days,),
+        )
+        n = cur.rowcount
+    conn.commit()
+    return n
 
 
 def write_snapshot(conn, meta: dict, rows: list[dict]) -> int:
@@ -365,6 +435,10 @@ def main(argv=None) -> int:
     host = resolve_host()
     try:
         report = run_scan(a.days)
+    except subprocess.TimeoutExpired:
+        print(f"error: initiative-scan timed out after {SCAN_TIMEOUT_SEC}s",
+              file=sys.stderr)
+        return 1
     except subprocess.CalledProcessError as exc:
         print(f"error: initiative-scan failed (exit {exc.returncode})", file=sys.stderr)
         return 1
@@ -383,10 +457,12 @@ def main(argv=None) -> int:
     with MailDB() as db:
         ensure_schema(db.conn)
         snapshot_id = write_snapshot(db.conn, meta, rows)
+        pruned = prune_old_snapshots(db.conn)
 
     tel = "on" if meta["telemetry_available"] else "OFF (handoff+git only)"
+    pruned_note = f", pruned {pruned} snapshot(s) >{RETENTION_DAYS}d" if pruned else ""
     print(f"initiatives-sync: wrote snapshot #{snapshot_id} — {len(rows)} initiative "
-          f"rows (host={host}, days={a.days}, telemetry {tel})")
+          f"rows (host={host}, days={a.days}, telemetry {tel}){pruned_note}")
     return 0
 
 

--- a/scripts/initiatives/tests/test_sync.py
+++ b/scripts/initiatives/tests/test_sync.py
@@ -15,7 +15,7 @@ import sync  # noqa: E402
 
 
 # A representative scan `--json` initiative (the shape sync.py consumes). Epochs are
-# UNIX seconds; 2026-07-13 12:00:00Z == 1768305600.0.
+# UNIX seconds; 2026-07-13 12:00:00Z == 1783944000.0.
 _TOUCH_EPOCH = 1783944000.0  # 2026-07-13 12:00:00 UTC
 _TELEM_EPOCH = 1783857600.0  # 2026-07-12 12:00:00 UTC
 
@@ -241,3 +241,140 @@ def test_render_dry_run_flags_telemetry_off():
     text = sync.render_dry_run(meta, rows)
     assert "telemetry OFF" in text
     assert "rows to insert: 0" in text
+
+
+# --------------------------------------------------------------------------- #
+# I/O SQL tests via a fake psycopg2 connection (no port-forward, no Postgres).
+# Assert on the emitted SQL: the advisory lock, index DDL, the view guard, the
+# retention DELETE, and the snapshot/JSONB insert shape.
+# --------------------------------------------------------------------------- #
+class _FakeCursor:
+    def __init__(self, conn):
+        self._conn = conn
+        self.rowcount = 0
+        self._result = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, sql, params=None):
+        norm = " ".join(sql.split())
+        self._conn.executed.append((norm, params))
+        self.rowcount = 0
+        self._result = None
+        if "to_regclass('initiatives.current')" in norm:
+            self._result = (self._conn.view_regclass,)
+        elif "obj_description" in norm:
+            self._result = (self._conn.view_comment,)
+        elif "RETURNING id" in norm:
+            self._result = (self._conn.next_snapshot_id,)
+        elif norm.startswith("DELETE FROM initiatives.snapshots"):
+            self.rowcount = self._conn.delete_rowcount
+
+    def fetchone(self):
+        return self._result
+
+
+class _FakeConn:
+    def __init__(self, *, view_regclass=None, view_comment=None,
+                 next_snapshot_id=1, delete_rowcount=0):
+        self.executed = []
+        self.commits = 0
+        self.view_regclass = view_regclass
+        self.view_comment = view_comment
+        self.next_snapshot_id = next_snapshot_id
+        self.delete_rowcount = delete_rowcount
+
+    def cursor(self, cursor_factory=None):
+        return _FakeCursor(self)
+
+    def commit(self):
+        self.commits += 1
+
+
+def _sqls(conn):
+    return [s for s, _ in conn.executed]
+
+
+def test_ensure_schema_takes_advisory_lock_first():
+    conn = _FakeConn()
+    sync.ensure_schema(conn)
+    first_sql, first_params = conn.executed[0]
+    assert "pg_advisory_xact_lock" in first_sql
+    assert first_params == (sync.SCHEMA_LOCK_KEY,)
+    assert conn.commits == 1
+
+
+def test_ensure_schema_creates_indexes():
+    conn = _FakeConn()
+    sync.ensure_schema(conn)
+    joined = " ".join(_sqls(conn))
+    assert "initiative_snapshot_repo_slug_snap_idx" in joined
+    assert "(repo, slug, snapshot_id)" in joined
+    assert "initiative_snapshot_snapshot_id_idx" in joined
+    assert "snapshots_captured_at_idx" in joined
+
+
+def test_ensure_schema_fk_cascades():
+    conn = _FakeConn()
+    sync.ensure_schema(conn)
+    joined = " ".join(_sqls(conn))
+    assert "REFERENCES initiatives.snapshots(id) ON DELETE CASCADE" in joined
+
+
+def test_ensure_schema_creates_view_when_absent():
+    conn = _FakeConn(view_regclass=None)
+    sync.ensure_schema(conn)
+    joined = " ".join(_sqls(conn))
+    assert "CREATE OR REPLACE VIEW initiatives.current" in joined
+    assert "COMMENT ON VIEW initiatives.current" in joined
+
+
+def test_ensure_schema_skips_view_when_present_and_version_matches():
+    conn = _FakeConn(view_regclass="initiatives.current",
+                     view_comment=sync.VIEW_COMMENT)
+    sync.ensure_schema(conn)
+    joined = " ".join(_sqls(conn))
+    assert "CREATE OR REPLACE VIEW initiatives.current" not in joined
+
+
+def test_ensure_schema_recreates_view_when_version_differs():
+    conn = _FakeConn(view_regclass="initiatives.current",
+                     view_comment="initiatives-sync view v0")
+    sync.ensure_schema(conn)
+    joined = " ".join(_sqls(conn))
+    assert "CREATE OR REPLACE VIEW initiatives.current" in joined
+
+
+def test_prune_old_snapshots_issues_cascade_delete_and_returns_count():
+    conn = _FakeConn(delete_rowcount=3)
+    n = sync.prune_old_snapshots(conn, retain_days=90)
+    assert n == 3
+    sql, params = conn.executed[-1]
+    assert sql.startswith("DELETE FROM initiatives.snapshots")
+    assert "captured_at < now() - make_interval(days => %s)" in sql
+    assert params == (90,)
+    assert conn.commits == 1
+
+
+def test_write_snapshot_inserts_snapshot_then_rows_with_jsonb():
+    from psycopg2.extras import Json
+    conn = _FakeConn(next_snapshot_id=7)
+    meta, rows = sync.report_to_rows(_fixture_report(), host="workbench")
+    snap_id = sync.write_snapshot(conn, meta, rows)
+    assert snap_id == 7
+    # first insert = the snapshots row (RETURNING id), with meta values
+    snap_sql, snap_params = conn.executed[0]
+    assert "INSERT INTO initiatives.snapshots" in snap_sql
+    assert snap_params == ("workbench", 4, True)
+    # then one initiative_snapshot insert carrying snapshot_id + JSONB-wrapped fields
+    row_sql, row_params = conn.executed[1]
+    assert "INSERT INTO initiatives.initiative_snapshot" in row_sql
+    assert row_params[0] == 7  # snapshot_id prepended
+    # open_prs / open_investigations / docs are wrapped in psycopg2 Json
+    jsonb_count = sum(1 for p in row_params if isinstance(p, Json))
+    assert jsonb_count == 3
+    assert conn.commits == 1

--- a/scripts/initiatives/tests/test_sync.py
+++ b/scripts/initiatives/tests/test_sync.py
@@ -1,0 +1,243 @@
+"""Unit tests for the PURE transform in scripts/initiatives/sync.py.
+
+Offline: no live scan, no live DB. We feed `report_to_rows` a fixture `--json`
+report dict and assert on the emitted insert-row dicts — epoch→timestamptz (UTC)
+conversion, null handling (last_touch / telem_last / date), the JSONB payloads
+(open_prs / open_investigations / docs), host tagging, momentum passthrough, and
+an empty / telemetry-off report."""
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import sync  # noqa: E402
+
+
+# A representative scan `--json` initiative (the shape sync.py consumes). Epochs are
+# UNIX seconds; 2026-07-13 12:00:00Z == 1768305600.0.
+_TOUCH_EPOCH = 1783944000.0  # 2026-07-13 12:00:00 UTC
+_TELEM_EPOCH = 1783857600.0  # 2026-07-12 12:00:00 UTC
+
+
+def _fixture_initiative(**over):
+    ini = {
+        "repo": "/home/zach/workspace/devrc",
+        "slug": "initiatives-consolidation",
+        "title": "Initiatives consolidation Phase 1",
+        "date": "2026-07-13",
+        "doc_mtime": 1768300000.0,
+        "next_step": "eyeball the dry-run output",
+        "open_investigations": ["does the router want a JOIN view?"],
+        "current_doc": "/home/zach/workspace/devrc/claudedocs/handoff-x.md",
+        "docs": [{"path": "/home/zach/workspace/devrc/claudedocs/handoff-x.md",
+                  "date": "2026-07-13"}],
+        "matching_branches": ["feat/initiatives"],
+        "commits": 7,
+        "commits_unknown": False,
+        "last_commit": _TOUCH_EPOCH,
+        "open_prs": [{"number": 135, "title": "feat: initiatives sync"}],
+        "merged_prs": 2,
+        "session_count": 3,
+        "last_session": _TOUCH_EPOCH,
+        "telem_events": 42,
+        "telem_last": _TELEM_EPOCH,
+        "last_touch": _TOUCH_EPOCH,
+        "momentum": "active",
+    }
+    ini.update(over)
+    return ini
+
+
+def _fixture_report(**over):
+    rep = {
+        "days": 4,
+        "telemetry_available": True,
+        "tmux_enabled": False,
+        "tmux_unmatched": [],
+        "repos": ["/home/zach/workspace/devrc"],
+        "by_repo": {"/home/zach/workspace/devrc": [_fixture_initiative()]},
+        "catchall": {},
+    }
+    rep.update(over)
+    return rep
+
+
+# --- meta + host tagging ---------------------------------------------------- #
+def test_meta_carries_days_and_telemetry():
+    meta, _rows = sync.report_to_rows(_fixture_report(), host="workbench")
+    assert meta == {"host": "workbench", "days_window": 4, "telemetry_available": True}
+
+
+def test_host_tag_applied_to_every_row():
+    _meta, rows = sync.report_to_rows(_fixture_report(), host="laptop")
+    assert rows and all(r["host"] == "laptop" for r in rows)
+
+
+def test_resolve_host_prefers_activity_host(monkeypatch):
+    monkeypatch.setenv("ACTIVITY_HOST", "workbench")
+    assert sync.resolve_host() == "workbench"
+
+
+def test_resolve_host_defaults_to_workbench_when_hostname_is_nixos(monkeypatch):
+    monkeypatch.delenv("ACTIVITY_HOST", raising=False)
+    monkeypatch.setattr(sync.socket, "gethostname", lambda: "nixos")
+    assert sync.resolve_host() == "workbench"
+
+
+def test_resolve_host_uses_meaningful_hostname(monkeypatch):
+    monkeypatch.delenv("ACTIVITY_HOST", raising=False)
+    monkeypatch.setattr(sync.socket, "gethostname", lambda: "some-box")
+    assert sync.resolve_host() == "some-box"
+
+
+# --- epoch -> timestamptz (UTC) --------------------------------------------- #
+def test_epoch_fields_convert_to_utc_datetimes():
+    _meta, rows = sync.report_to_rows(_fixture_report(), host="workbench")
+    r = rows[0]
+    assert r["last_touch"] == datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc)
+    assert r["telem_last"] == datetime(2026, 7, 12, 12, 0, tzinfo=timezone.utc)
+    assert r["last_touch"].tzinfo is timezone.utc
+
+
+def test_epoch_accepts_stringified_number():
+    # --json runs with default=str; be robust to an epoch that arrives as a str.
+    assert sync._epoch_to_dt("1783944000.0") == \
+        datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc)
+
+
+def test_epoch_none_and_unparseable_become_none():
+    assert sync._epoch_to_dt(None) is None
+    assert sync._epoch_to_dt("not-a-number") is None
+
+
+# --- null handling ---------------------------------------------------------- #
+def test_null_last_touch_and_telem_last_become_none():
+    ini = _fixture_initiative(last_touch=None, telem_last=None)
+    rep = _fixture_report(by_repo={"/r": [ini]})
+    _meta, rows = sync.report_to_rows(rep, host="workbench")
+    assert rows[0]["last_touch"] is None
+    assert rows[0]["telem_last"] is None
+
+
+def test_null_doc_date_becomes_none():
+    ini = _fixture_initiative(date=None)
+    rep = _fixture_report(by_repo={"/r": [ini]})
+    _meta, rows = sync.report_to_rows(rep, host="workbench")
+    assert rows[0]["doc_date"] is None
+
+
+def test_doc_date_parses_to_date_object():
+    _meta, rows = sync.report_to_rows(_fixture_report(), host="workbench")
+    assert rows[0]["doc_date"] == date(2026, 7, 13)
+
+
+def test_malformed_doc_date_becomes_none():
+    ini = _fixture_initiative(date="not-a-date")
+    rep = _fixture_report(by_repo={"/r": [ini]})
+    _meta, rows = sync.report_to_rows(rep, host="workbench")
+    assert rows[0]["doc_date"] is None
+
+
+# --- JSONB payloads + scalar passthrough ------------------------------------ #
+def test_jsonb_fields_preserved_as_python_objects():
+    _meta, rows = sync.report_to_rows(_fixture_report(), host="workbench")
+    r = rows[0]
+    assert r["open_prs"] == [{"number": 135, "title": "feat: initiatives sync"}]
+    assert r["open_investigations"] == ["does the router want a JOIN view?"]
+    assert r["docs"] == [{"path": "/home/zach/workspace/devrc/claudedocs/handoff-x.md",
+                          "date": "2026-07-13"}]
+
+
+def test_missing_jsonb_fields_default_to_empty_list():
+    ini = _fixture_initiative()
+    for k in ("open_prs", "open_investigations", "docs"):
+        ini.pop(k, None)
+    rep = _fixture_report(by_repo={"/r": [ini]})
+    _meta, rows = sync.report_to_rows(rep, host="workbench")
+    r = rows[0]
+    assert r["open_prs"] == [] and r["open_investigations"] == [] and r["docs"] == []
+
+
+def test_momentum_and_scalars_pass_through():
+    _meta, rows = sync.report_to_rows(_fixture_report(), host="workbench")
+    r = rows[0]
+    assert r["momentum"] == "active"
+    assert r["slug"] == "initiatives-consolidation"
+    assert r["title"] == "Initiatives consolidation Phase 1"
+    assert r["next_step"] == "eyeball the dry-run output"
+    assert r["commits"] == 7 and r["merged_prs"] == 2
+    assert r["session_count"] == 3 and r["telem_events"] == 42
+    assert r["commits_unknown"] is False
+
+
+def test_commits_unknown_true_passes_through():
+    ini = _fixture_initiative(commits_unknown=True, commits=0)
+    rep = _fixture_report(by_repo={"/r": [ini]})
+    _meta, rows = sync.report_to_rows(rep, host="workbench")
+    assert rows[0]["commits_unknown"] is True
+
+
+def test_missing_int_fields_default_to_zero():
+    ini = _fixture_initiative()
+    for k in ("commits", "merged_prs", "session_count", "telem_events"):
+        ini.pop(k, None)
+    rep = _fixture_report(by_repo={"/r": [ini]})
+    _meta, rows = sync.report_to_rows(rep, host="workbench")
+    r = rows[0]
+    assert r["commits"] == 0 and r["merged_prs"] == 0
+    assert r["session_count"] == 0 and r["telem_events"] == 0
+
+
+# --- multi-repo flattening -------------------------------------------------- #
+def test_flattens_all_repos_into_one_row_list():
+    rep = _fixture_report(by_repo={
+        "/home/zach/workspace/devrc": [_fixture_initiative(slug="a"),
+                                       _fixture_initiative(slug="b")],
+        "/home/zach/workspace/homelab": [_fixture_initiative(
+            repo="/home/zach/workspace/homelab", slug="c")],
+    })
+    _meta, rows = sync.report_to_rows(rep, host="workbench")
+    assert len(rows) == 3
+    assert {r["slug"] for r in rows} == {"a", "b", "c"}
+
+
+# --- empty / telemetry-off report ------------------------------------------- #
+def test_empty_report_yields_no_rows():
+    rep = _fixture_report(by_repo={}, telemetry_available=False)
+    meta, rows = sync.report_to_rows(rep, host="workbench")
+    assert rows == []
+    assert meta["telemetry_available"] is False
+
+
+def test_telemetry_off_report_still_produces_rows():
+    rep = _fixture_report(telemetry_available=False)
+    meta, rows = sync.report_to_rows(rep, host="workbench")
+    assert meta["telemetry_available"] is False
+    assert len(rows) == 1
+
+
+def test_missing_by_repo_key_is_tolerated():
+    meta, rows = sync.report_to_rows({"days": 4, "telemetry_available": True},
+                                     host="workbench")
+    assert rows == []
+    assert meta == {"host": "workbench", "days_window": 4, "telemetry_available": True}
+
+
+# --- dry-run rendering (smoke: complete + non-crashing) --------------------- #
+def test_render_dry_run_includes_count_table_and_full_json():
+    meta, rows = sync.report_to_rows(_fixture_report(), host="workbench")
+    text = sync.render_dry_run(meta, rows)
+    assert "rows to insert: 1" in text
+    assert "initiatives-consolidation" in text
+    assert "full rows" in text
+    # the isoformatted timestamp survives into the full JSON dump
+    assert "2026-07-13T12:00:00+00:00" in text
+
+
+def test_render_dry_run_flags_telemetry_off():
+    meta, rows = sync.report_to_rows(_fixture_report(telemetry_available=False,
+                                                     by_repo={}), host="workbench")
+    text = sync.render_dry_run(meta, rows)
+    assert "telemetry OFF" in text
+    assert "rows to insert: 0" in text

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -56,6 +56,7 @@ HERMETIC_DIRS=(
   scripts/session-analysis/tests
   scripts/session-analysis/session_insight/tests
   scripts/mail-actions/tests
+  scripts/initiatives/tests
   scripts/repo-cos/tests
   scripts/task-spec-drafter/tests
 )


### PR DESCRIPTION
## What & why

**Phase 1** of the "initiatives consolidation" feature: sync the on-demand
`initiative-scan.py` report into the homelab `mailbox` Postgres on a timer, so
later apps (a live **viewer** + a **router**) can query a durable, live
initiative store instead of re-running the expensive scan. **This PR is the sync
ONLY** — no viewer, no router.

## How it works

- **Data source is the contract.** `sync.py` shells out to
  `initiative-scan.py --days N --json` (WITHOUT `--tmux` — the ephemeral tmux
  overlay is excluded) and parses stdout. It never imports the scan's internals
  or re-derives anything; the scan degrades gracefully with no ClickHouse creds
  and so does the sync.
- **Pure transform, testable without infra.** `report_to_rows(report, host)` is a
  pure function (epoch floats → UTC `timestamptz`, authored `date` str → `date`,
  JSONB for `open_prs`/`open_investigations`/`docs`, host tagging, momentum
  passthrough). All I/O (the subprocess scan + the DB write) is separate.
- **DB reuse.** Reuses `scripts/mail-actions/_db.py`'s port-forward + psycopg2 +
  DSN-from-secret plumbing, loaded by **explicit importlib path** (NOT `sys.path`
  — avoids the `llm.py` shadow trap flagged in CLAUDE.md; mirrors
  `repo-cos/feedback.py`).
- **Own schema, self-migrating.** Tables live in a new `initiatives` schema inside
  the `mailbox` DB (so a future router can natively JOIN against `mail_actions`).
  DDL is `CREATE ... IF NOT EXISTS` / `CREATE OR REPLACE VIEW` on every run —
  additive-only, no manual prod DDL step.
- **Append-only snapshots.** `initiatives.snapshots` (one row per run) +
  `initiatives.initiative_snapshot` (one row per initiative per run) +
  `initiatives.current` (DISTINCT ON latest per `(repo, slug)`, tolerates a
  partially-failed snapshot).

## Timer (wired, NOT enabled/deployed)

Workbench-only (`serverMode`, same LAN-access rationale as `mail-actions-archive`)
`systemd --user` service + ~15min timer in `nix/home.nix`. **Not switched/deployed
here** — Zach eyeballs `--dry-run` output first.

## Verification (done honestly)

- **Unit tests:** 23 tests over the pure transform (epoch/null/jsonb/host/
  momentum/empty + telemetry-off) — pass. Registered in the hermetic set.
- **Live end-to-end `--dry-run` WITH telemetry creds:** ran against the real scan
  → 23 rows, `telemetry_available=True`. Verified telemetry epochs convert to UTC
  `timestamptz` (`telem_last`/`last_touch`), git `commits`/`merged_prs` populate,
  `doc_date` parses, `docs` JSONB, null `next_step`. Sample row (task-spec-drafter):
  `commits=2, merged_prs=1, telem_events=10, telem_last=2026-07-21T20:34:49...+00:00`.
- **NOT verified:** an actual DB write to prod (deliberately — `--dry-run` only,
  per the task). `nix flake check`/`home-manager switch` not run (nix file parses
  via `nix-instantiate --parse`).

## OPEN follow-ups (deferred, by design)

1. **CLICKHOUSE_\* cred provisioning for the timer env** — not injected yet, so the
   timer would run **telemetry-off** (still writes a useful handoff+git+session
   snapshot; momentum/ev degrade). Separate task.
2. **Dual-host merge** — Phase 1 is workbench-only; a laptop/second-host snapshot
   merge is Phase 2+.
3. **Enable/deploy the timer + first real write** — pending Zach's `--dry-run`
   eyeball.

## Schema DDL (for the eyeball)

```sql
CREATE SCHEMA IF NOT EXISTS initiatives;

CREATE TABLE IF NOT EXISTS initiatives.snapshots (
    id                   serial PRIMARY KEY,
    captured_at          timestamptz DEFAULT now(),
    host                 text,
    days_window          int,
    telemetry_available  boolean
);

CREATE TABLE IF NOT EXISTS initiatives.initiative_snapshot (
    id                   serial PRIMARY KEY,
    snapshot_id          int REFERENCES initiatives.snapshots(id),
    host                 text,
    repo                 text,
    slug                 text,
    title                text,
    doc_date             date,
    momentum             text,
    last_touch           timestamptz,
    next_step            text,
    commits              int,
    commits_unknown      boolean,
    merged_prs           int,
    open_prs             jsonb,
    session_count        int,
    telem_events         int,
    telem_last           timestamptz,
    current_doc          text,
    open_investigations  jsonb,
    docs                 jsonb
);

CREATE OR REPLACE VIEW initiatives.current AS
SELECT DISTINCT ON (i.repo, i.slug)
       i.*, s.captured_at
  FROM initiatives.initiative_snapshot i
  JOIN initiatives.snapshots s ON s.id = i.snapshot_id
 ORDER BY i.repo, i.slug, s.captured_at DESC;
```

## Questions for Zach before Phase 2

- **`id serial PRIMARY KEY` on `initiative_snapshot`** — added beyond the spec (a
  stable per-row PK for the future router / potential FKs). OK, or drop it?
- **`catchall` not stored** — the report-level trunk `catchall` is intentionally
  omitted (doesn't fit the per-initiative row cleanly; KISS). Want it in Phase 2
  (its own small table), or leave it report-only?
- **`_db.py` reuse** — imported by importlib path today. If Phase 2 grows more
  shared DB helpers, worth promoting the port-forward/DSN plumbing into a small
  shared module instead of importing `mail-actions/_db.py` sideways?

🤖 Generated with [Claude Code](https://claude.com/claude-code)