### PR TITLE
feat(initiatives-sync): provision ClickHouse reader creds + enable the hourly timer

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -10,12 +10,14 @@ let
   # there (same trap the i3 bar hit — see graphical.nix). serverMode now gates ONLY
   # server-side task enablement; graphical services key off `graphical` below.
   serverMode = builtins.pathExists "${home}/.server-mode";
-  # Initiatives-sync (Phase 1) master switch — OFF by default so a routine deploy
-  # (ship.sh / home-manager switch) can NEVER silently enable the still-unvalidated
-  # prod-write timer. The service definition is left in place regardless (so it can be
-  # started by hand); only the TIMER is wired into timers.target when this is true.
-  # FLIP TO true after the first SUPERVISED live write validates the DDL/insert path.
-  enableInitiativesSync = false;
+  # Initiatives-sync (Phase 1) master switch — gates only whether the TIMER is wired
+  # into timers.target; the service definition is always emitted (so it can be started
+  # by hand). Kept OFF through the initial supervised validation so a routine deploy
+  # (ship.sh / home-manager switch) could never silently enable an unvalidated
+  # prod-write timer. ENABLED now: the first supervised live write validated the
+  # DDL/insert path (snapshot #1 wrote 23 rows to prod, telemetry-on, and the DSN role
+  # is confirmed to have CREATE SCHEMA). The timer runs hourly (see the timer below).
+  enableInitiativesSync = true;
   # Graphical host = runs X/i3 (both current NixOS hosts do; only a genuinely headless
   # box would not). Approximated as isNixOS, mirroring graphical.nix — deliberately NOT
   # !serverMode, which is true on the graphical workbench.
@@ -741,16 +743,17 @@ in
   # homelab kubeconfig points at 192.168.50.94:6443 (direct LAN, no proxy), which
   # only this host has; the laptop is nebula-only and its run would just fail noisily.
   #
-  # ⚠ OPEN FOLLOW-UP: CLICKHOUSE_* creds are deliberately NOT injected here yet, so
-  # the timer currently runs the scan TELEMETRY-OFF (still writes a useful handoff+
-  # git+session snapshot; momentum/ev degrade). Provisioning those creds into the
-  # unit env is a separate task — see the PR. Do NOT enable/deploy this before Zach
-  # has eyeballed `sync.py --dry-run` output.
+  # CLICKHOUSE_* creds are provisioned by the wrapper at RUN TIME via a sops decrypt
+  # (NO plaintext secret at rest — same recipe as the /initiatives slash command), so
+  # the scan runs TELEMETRY-ON. The decrypt is fully best-effort and degrades to
+  # telemetry-off if the age key / homelab repo / sops / decrypt is unavailable, so it
+  # can never fail the sync. `sops` is put on the unit PATH below for exactly this.
   #
   # Minimal user-unit env, so PATH is explicit: nix (nix-shell) + git + gh (the
-  # scan's branch/PR reads) + kubectl (the port-forward) + coreutils/sed/grep, and
-  # NIX_PATH so `nix-shell -p` resolves <nixpkgs>. The wrapper's nix-shell adds
-  # psycopg2 (the DB write) + requests (the scan's ClickHouse read).
+  # scan's branch/PR reads) + kubectl (the port-forward) + sops (the run-time reader
+  # cred decrypt) + coreutils/sed/grep, and NIX_PATH so `nix-shell -p` resolves
+  # <nixpkgs>. The wrapper's nix-shell adds psycopg2 (the DB write) + requests (the
+  # scan's ClickHouse read).
   systemd.user.services.initiatives-sync = lib.mkIf serverMode {
     Unit = {
       Description = "Initiatives sync — initiative-scan → homelab mailbox Postgres (initiatives schema)";
@@ -764,7 +767,7 @@ in
       # cgroup is killed and the timer re-arms on the next OnUnitActiveSec.
       TimeoutStartSec = 300;
       Environment = [
-        "PATH=${lib.makeBinPath [ pkgs.nix pkgs.git pkgs.gh pkgs.kubectl pkgs.bash pkgs.coreutils pkgs.gnused pkgs.gnugrep ]}"
+        "PATH=${lib.makeBinPath [ pkgs.nix pkgs.git pkgs.gh pkgs.kubectl pkgs.sops pkgs.bash pkgs.coreutils pkgs.gnused pkgs.gnugrep ]}"
         "NIX_PATH=nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos"
         "KUBECONFIG=%h/workspace/homelab-talos/homelab-kubeconfig"
         # Explicit host tag — user units do NOT source .zshenv, so resolve_host()

--- a/scripts/initiatives/run-sync.sh
+++ b/scripts/initiatives/run-sync.sh
@@ -6,9 +6,14 @@
 # (initiatives schema) via a kubectl port-forward. KUBECONFIG + kubectl + network
 # are the cluster requirements; git/gh are on PATH for the scan's git/PR reads.
 #
-# CLICKHOUSE_* are NOT set here — see the PR: cred provisioning for the timer's
-# environment is an OPEN follow-up. Unset -> the scan runs telemetry-off (still
-# writes a useful handoff+git+session snapshot; momentum/ev degrade).
+# CLICKHOUSE_* ARE provisioned here now (runtime sops decrypt, NO plaintext secret at
+# rest) so the scan runs TELEMETRY-ON, exactly like the /initiatives slash command:
+# the activity reader password is decrypted from the homelab-talos secrets at run time
+# and exported. Every decrypt step is GUARDED — a missing age key / absent repo /
+# missing sops / empty decrypt leaves CLICKHOUSE_* unset and the scan degrades to
+# telemetry-off (still writes a useful handoff+git+session snapshot; momentum/ev
+# degrade). The decrypt deliberately never aborts the run and never persists the
+# secrets yaml, so the unit is safe even if copied to the laptop (no age key there).
 #
 # Run by hand or via systemd:  systemctl --user start initiatives-sync.service
 set -euo pipefail
@@ -22,8 +27,66 @@ export KUBECONFIG="${KUBECONFIG:-${HOME}/workspace/homelab-talos/homelab-kubecon
 # Trailing window (default 4, matching the ledger); overridable via env for tuning.
 DAYS="${INITIATIVES_SYNC_DAYS:-4}"
 
+# --- ClickHouse reader creds — runtime sops decrypt (NO plaintext secret at rest) ---
+# Mirrors the /initiatives slash command: decrypt the activity reader password from the
+# homelab-talos secrets AT RUN TIME and export CLICKHOUSE_* so the scan runs telemetry-ON.
+# Fully best-effort: any of {age key missing, repo absent, sops absent, decrypt empty}
+# leaves CLICKHOUSE_* unset → sync.py runs telemetry-off (the scan already handles that).
+# Each step is guarded so a decrypt miss can NEVER abort the sync (even under `set -e`),
+# and the decrypted yaml lives only in a mktemp file that is trap-removed on return.
+provision_clickhouse_creds() {
+  local homelab_repo="${HOMELAB:-${HOME}/workspace/homelab-talos}"
+  local age_key="${SOPS_AGE_KEY_FILE:-${homelab_repo}/.secrets/age.key}"
+
+  if [ ! -r "$age_key" ]; then
+    echo "run-sync: age key not readable ($age_key) — telemetry-off" >&2
+    return 0
+  fi
+  if [ ! -d "${homelab_repo}/.git" ]; then
+    echo "run-sync: homelab-talos repo absent ($homelab_repo) — telemetry-off" >&2
+    return 0
+  fi
+  if ! command -v sops >/dev/null 2>&1; then
+    echo "run-sync: sops not on PATH — telemetry-off" >&2
+    return 0
+  fi
+
+  # Decrypt into a private temp file, trap-cleaned; never persist the secrets yaml.
+  local enc
+  enc="$(mktemp)" || { echo "run-sync: mktemp failed — telemetry-off" >&2; return 0; }
+  # shellcheck disable=SC2064  # expand $enc now (at trap-set time), not at return
+  trap "rm -f '$enc'" RETURN
+
+  if ! git -C "$homelab_repo" show \
+        origin/trunk:clusters/homelab/apps/activity/secrets.enc.yaml >"$enc" 2>/dev/null; then
+    echo "run-sync: could not read encrypted secrets from homelab-talos — telemetry-off" >&2
+    return 0
+  fi
+
+  # --input-type yaml is REQUIRED: the mktemp file has no .yaml extension, so sops
+  # cannot auto-detect the format and would otherwise fail to unmarshal (the
+  # /initiatives slash command sidesteps this by writing to a *.yaml path).
+  local pw
+  pw="$(SOPS_AGE_KEY_FILE="$age_key" sops -d --input-type yaml \
+        --extract '["stringData"]["reader-password"]' "$enc" 2>/dev/null)" || pw=""
+  if [ -z "$pw" ]; then
+    echo "run-sync: reader-password decrypt yielded empty — telemetry-off" >&2
+    return 0
+  fi
+
+  # Workbench LAN reader endpoint (NodePort). Overridable so a laptop copy could point
+  # CLICKHOUSE_URL at its nebula CH endpoint; the password never touches the logs.
+  export CLICKHOUSE_URL="${CLICKHOUSE_URL:-http://192.168.50.94:30123}"
+  export CLICKHOUSE_USER="${CLICKHOUSE_USER:-activity_reader}"
+  export CLICKHOUSE_PASSWORD="$pw"
+  echo "run-sync: ClickHouse reader creds provisioned — telemetry-on" >&2
+}
+
+provision_clickhouse_creds
+
 # nix-shell pulls the sync path's deps: psycopg2 (_db.py write) + requests (the
-# scan's ClickHouse read). kubectl/git/gh are provided on PATH by the unit (systemd)
-# or the login shell (interactive) and inherited into the nix-shell.
+# scan's ClickHouse read). kubectl/git/gh/sops are provided on PATH by the unit
+# (systemd) or the login shell (interactive) and inherited into the nix-shell; the
+# CLICKHOUSE_* exports above are inherited too (nix-shell is not --pure).
 exec nix-shell -p 'python3.withPackages(p:[p.psycopg2 p.requests])' \
   --run "python ${SCRIPT_DIR}/sync.py --days ${DAYS}"


### PR DESCRIPTION
## What

Follow-up to the just-merged initiatives-sync **Phase 1**. Wire the ClickHouse **reader** creds into the `initiatives-sync` systemd user timer's runtime so it writes **telemetry-ON** snapshots, then flip the off-by-default master switch on.

Previously the timer was disabled and `run-sync.sh` left `CLICKHOUSE_*` unset → the scan ran telemetry-off.

## How

**`scripts/initiatives/run-sync.sh`** — new `provision_clickhouse_creds()` that decrypts the activity reader password at **run time** via sops (NO plaintext secret at rest — same recipe as the `/initiatives` slash command), into a `trap`-cleaned `mktemp` file, and exports `CLICKHOUSE_URL/USER/PASSWORD`.
- **Fully best-effort / graceful degradation**: every step is guarded — missing age key, absent `homelab-talos` repo, `sops` not on PATH, or an empty decrypt each leaves `CLICKHOUSE_*` unset and lets `sync.py` run telemetry-off. The decrypt **never aborts the run** (each guard `return 0`s even under `set -e`) and **never persists** the decrypted secrets yaml. Safe if the unit is ever copied to the laptop (no age key there).
- Requires `sops -d --input-type yaml` — the `mktemp` file has no `.yaml` extension so sops can't auto-detect the format (the slash command sidesteps this by writing to a `*.yaml` path). This was caught during isolated verification; without it the decrypt returns empty and silently stays telemetry-off.

**`nix/home.nix`**
- Add `pkgs.sops` to the unit PATH (same `lib.makeBinPath` list that already provides git/gh/kubectl to this unit) so the decrypt has `sops` in the minimal systemd-user env.
- Flip `enableInitiativesSync = true` — the first supervised live write validated the DDL/insert path (snapshot #1 wrote 23 rows to prod, telemetry-on; DSN role confirmed to have CREATE SCHEMA). Cadence stays **hourly**.
- Refresh the stale comments (creds now provisioned; the "open follow-up" note removed).

## Validation (no deploy / no prod write from CI or the author)

- `nix-instantiate --parse nix/home.nix` — OK
- `shellcheck scripts/initiatives/run-sync.sh` — clean (exit 0)
- Decrypt logic exercised **in isolation** under `set -euo pipefail` (read-only, `sync.py` NOT invoked): yields a non-empty 30-char reader password and exports the three vars.

**Not done here (human, post-merge):** `home-manager switch`, `systemctl --user start`, and the live telemetry-on snapshot verification — see PR discussion / the requesting task for the exact deploy+verify commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)