### PR TITLE
feat(initiatives): Phase 2 router — rank a free-text signal to existing initiatives

### DIFF
--- a/scripts/initiatives/route.py
+++ b/scripts/initiatives/route.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Route an incoming free-text signal to the best-matching EXISTING initiative(s).
+
+PHASE 2 of the "initiatives consolidation" feature. A READ-ONLY consumer of the
+Phase-1 store (`initiatives.current` in the homelab `mailbox` Postgres). Given a
+signal — a new task title, a repo-cos proposal, a mail subject/thread snippet —
+it returns the existing initiatives ranked with an interpretable score, and
+classifies the top one as a confident match vs "likely new work".
+
+It SUGGESTS, never acts: no dispatch, no writes, no confidence *gate* that
+force-picks. The caller (repo-cos / mail-actions / a human) decides what to do
+with the ranking.
+
+Design (reuse, don't reimplement):
+  The scan (`scripts/session-analysis/initiative-scan.py`) already contains the
+  exact token matcher used to attach a live tmux pane title to an initiative
+  (`text_tokens`, `slug_tokens`, `best_title_match`). A router signal is just a
+  pane-title-like free string, so we reuse those SAME scoring components — but
+  where `best_title_match` returns only the single best (or None), the router
+  returns ALL candidates ranked, each with its score + which tokens matched, and
+  classifies confident-vs-new-work using the SAME qualification bar
+  `best_title_match` uses (the document-frequency uniqueness gate).
+
+  We import the scan by explicit importlib path (its filename is hyphenated and
+  so not importable) rather than copying its ~6 token/match functions, so the
+  matcher stays single-sourced: the router can never drift from the scan's
+  behaviour. Importing the scan runs its top-level `import chquery` (needs
+  `requests` + `scripts/validation` on sys.path) — harmless (its `main()` is
+  `__main__`-guarded), and lazy here so merely importing `route` costs nothing.
+
+Scoring (interpretable, not a magic scalar):
+  For each initiative we expose the two components `best_title_match` scores on:
+    slug_overlap  — # signal tokens that hit the initiative's SLUG tokens
+                    (the fingerprint: clawgate, sysredis, tekton, …)
+    title_overlap — # signal tokens that hit TITLE-only tokens (title minus slug)
+  A candidate is `confident` iff it clears the SAME bar as `best_title_match`:
+    slug_overlap >= 2   OR
+    exactly one slug hit AND that token is UNIQUE (document-frequency == 1)
+                        to this initiative among the eligible set  OR
+    title_overlap >= 2
+  The df-uniqueness gate is what stops a single token SHARED across siblings
+  (e.g. `blocks` in both `app-blocks` and `app-blocks-followups`) from firing a
+  confident match on either, while still letting a single DISTINCTIVE token
+  (`followups`, `tekton`) match. `score = slug_overlap + 0.25*title_overlap` is
+  the headline number for display; the actual RANK order uses the full
+  deterministic tuple `(confident, slug_overlap, title_overlap, slug-length,
+  slug)` — identical to `best_title_match`'s tie-breaks — so the top confident
+  row equals what `best_title_match` would have picked.
+
+Requires (only for the live read / CLI, NOT for the pure `rank_matches`):
+    KUBECONFIG  — homelab kubeconfig (the DB is only reachable via port-forward)
+    kubectl     — on PATH
+    psycopg2    — python dep
+On NixOS run under:
+    nix-shell -p "python3.withPackages(p:[p.psycopg2 p.requests])" \
+      --run 'python scripts/initiatives/route.py "your signal text"'
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+# The scan we borrow the matcher from (hyphenated filename → importlib, not import).
+SCAN_PATH = Path(__file__).resolve().parents[1] / "session-analysis" / "initiative-scan.py"
+# chquery lives here; the scan adds it to sys.path on import, we mirror that so the
+# top-level `import chquery` resolves regardless of cwd.
+VALIDATION_DIR = Path(__file__).resolve().parents[1] / "validation"
+
+# The shared mailbox-Postgres helper (kubectl port-forward + psycopg2 + DSN-from-secret).
+MAILDB_PATH = Path(__file__).resolve().parents[1] / "mail-actions" / "_db.py"
+
+# Interpretable headline score: a slug hit is worth more than a title hit. The RANK
+# tie-breaks use the full component tuple (see module docstring), not this scalar.
+SLUG_WEIGHT = 1.0
+TITLE_WEIGHT = 0.25
+
+
+# --------------------------------------------------------------------------- #
+# Lazy import of the scan's matcher (single-sourced; not reimplemented).
+# --------------------------------------------------------------------------- #
+_scan_mod = None
+
+
+def _scan():
+    """Load initiative-scan.py by explicit path and cache it.
+
+    Lazy so importing `route` (e.g. by a repo-cos/mail-actions caller) stays cheap
+    and side-effect-light — the scan's top-level `import chquery as Q` only runs
+    the first time a match is actually computed. `chquery` needs `requests` and the
+    `scripts/validation` dir on sys.path; we add the latter here (idempotently)."""
+    global _scan_mod
+    if _scan_mod is None:
+        vdir = str(VALIDATION_DIR)
+        if vdir not in sys.path:
+            sys.path.insert(0, vdir)
+        spec = importlib.util.spec_from_file_location("initiative_scan_for_route", SCAN_PATH)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"cannot load {SCAN_PATH}")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        _scan_mod = mod
+    return _scan_mod
+
+
+# --------------------------------------------------------------------------- #
+# Pure core — no infra. Unit-tested directly with fixture initiative sets.
+# --------------------------------------------------------------------------- #
+def _repo_matches(cand_repo: str | None, want: str | None) -> bool:
+    """Does an initiative's `repo` path match a caller-supplied `--repo` scope?
+
+    Accepts a full path (`/home/zach/workspace/devrc`), a worktree/subdir under the
+    repo (the repo is that path's ancestor), or a bare basename (`devrc`) — mirroring
+    how `best_title_match` is scoped by cwd→repo, but tolerant of the shorthands a
+    human/caller will actually pass. Empty `want` matches everything (no scope)."""
+    if not want:
+        return True
+    if not cand_repo:
+        return False
+    c = str(cand_repo).rstrip("/")
+    w = str(want).rstrip("/")
+    cr, wr = os.path.realpath(c), os.path.realpath(w)
+    if cr == wr or wr.startswith(cr + "/"):  # exact, or want is a subdir/worktree of the repo
+        return True
+    return os.path.basename(c) == os.path.basename(w)
+
+
+def rank_matches(signal_text: str, initiatives: list[dict],
+                 repo: str | None = None, limit: int | None = 5) -> list[dict]:
+    """PURE: rank existing initiatives against a free-text signal, best-first.
+
+    Reuses the scan's `text_tokens` / `slug_tokens` and `best_title_match`'s scoring
+    components (slug_overlap, title_overlap, the df-uniqueness confidence gate), but
+    returns ALL candidates with any token overlap ranked — not just the single best.
+
+    Args:
+      signal_text: the incoming free text (task title / proposal / mail subject).
+      initiatives: rows from `initiatives.current` — each needs at least `slug`,
+                   `repo`, `title` (extra keys ignored).
+      repo:        optional path/basename to scope candidates to one repo.
+      limit:       cap the returned list (None = no cap).
+
+    Returns a list of dicts sorted best-first, each:
+      {slug, repo, title, score, slug_overlap, title_overlap, matched_tokens, confident}
+    where `confident` uses the SAME bar as `best_title_match`. An empty return (no
+    candidate had any overlap) is the caller's "likely new work" signal — see
+    `classify`."""
+    scan = _scan()
+    text_tokens = scan.text_tokens
+    slug_tokens = scan.slug_tokens
+
+    signal_toks = set(text_tokens(signal_text or ""))
+
+    candidates = initiatives
+    if repo:
+        candidates = [i for i in initiatives if _repo_matches(i.get("repo"), repo)]
+
+    # Document frequency of each token across the ELIGIBLE set (post repo-scope), so a
+    # single slug hit can require that token to be UNIQUE (df == 1) — byte-identical to
+    # best_title_match's uniqueness gate. Scoping df to the eligible set matches the
+    # scan, which builds df per-repo (its candidates are already repo-filtered).
+    df: dict[str, int] = {}
+    for ini in candidates:
+        toks = set(slug_tokens(ini.get("slug", "") or "")) \
+            | set(text_tokens(ini.get("title") or ""))
+        for t in toks:
+            df[t] = df.get(t, 0) + 1
+
+    results: list[dict] = []
+    for ini in candidates:
+        slug_t = set(slug_tokens(ini.get("slug", "") or ""))
+        title_t = set(text_tokens(ini.get("title") or ""))
+        slug_hits = signal_toks & slug_t
+        title_hits = signal_toks & (title_t - slug_t)
+        slug_overlap = len(slug_hits)
+        title_overlap = len(title_hits)
+        if slug_overlap == 0 and title_overlap == 0:
+            continue  # no overlap at all — not a candidate
+
+        unique_single = slug_overlap == 1 and df.get(next(iter(slug_hits)), 1) == 1
+        confident = slug_overlap >= 2 or unique_single or title_overlap >= 2
+        score = round(slug_overlap * SLUG_WEIGHT + title_overlap * TITLE_WEIGHT, 3)
+        results.append({
+            "slug": ini.get("slug"),
+            "repo": ini.get("repo"),
+            "title": ini.get("title"),
+            "score": score,
+            "slug_overlap": slug_overlap,
+            "title_overlap": title_overlap,
+            "matched_tokens": sorted(slug_hits | title_hits),
+            "confident": confident,
+        })
+
+    # Rank: confident first, then the same tie-breaks best_title_match uses
+    # (slug_overlap, title_overlap, slug length, slug lexical) — so the top confident
+    # row is exactly what best_title_match would have returned for this signal.
+    results.sort(
+        key=lambda r: (r["confident"], r["slug_overlap"], r["title_overlap"],
+                       len(r["slug"] or ""), r["slug"] or ""),
+        reverse=True,
+    )
+    if limit is not None and limit >= 0:
+        results = results[:limit]
+    return results
+
+
+def classify(ranked: list[dict]) -> str:
+    """Top-level verdict for a ranked list: confident match vs likely-new-work.
+
+    A weak/absent match surfaces as new work rather than being force-fit to the
+    nearest initiative (the router suggests, it does not gate)."""
+    if ranked and ranked[0].get("confident"):
+        return f"confident match: {ranked[0]['slug']}"
+    return "no confident match — likely new work"
+
+
+# --------------------------------------------------------------------------- #
+# I/O layer — read initiatives.current, then call the pure core.
+# --------------------------------------------------------------------------- #
+def _import_maildb():
+    """Load MailDB from scripts/mail-actions/_db.py by EXPLICIT importlib path.
+
+    Do NOT put mail-actions/ on sys.path — its `llm.py` shadows other modules and
+    breaks callers (documented in the repo CLAUDE.md; sync.py/repo-cos hit the same
+    trap). `_db.py` imports only stdlib+psycopg2, so a standalone load is safe."""
+    spec = importlib.util.spec_from_file_location("initiatives_route_maildb", MAILDB_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {MAILDB_PATH}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.MailDB
+
+
+def load_current() -> list[dict]:
+    """Read `initiatives.current` → list of initiative dicts (slug/repo/title + a few
+    context fields). Reads the Phase-1 store live; does NOT re-run the scan (the whole
+    point of Phase 1 was to make this cheap). Raises on an unreachable store — the CLI
+    turns that into a clear error rather than silently falling back."""
+    import psycopg2.extras  # local so importing route needs no psycopg2
+
+    MailDB = _import_maildb()
+    with MailDB() as db:
+        with db.conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                "SELECT slug, repo, title, momentum, last_touch, current_doc "
+                "FROM initiatives.current"
+            )
+            return [dict(r) for r in cur.fetchall()]
+
+
+# --------------------------------------------------------------------------- #
+# Callable API — importable by repo-cos / mail-actions.
+# --------------------------------------------------------------------------- #
+def route(signal_text: str, repo: str | None = None, limit: int | None = 5) -> list[dict]:
+    """Route a signal against the LIVE `initiatives.current` and return the ranking.
+
+    The one call a caller (repo-cos with a proposal, mail-actions with a subject)
+    makes:  `route("Harden the clawgate approval hook")`  →  ranked list (see
+    `rank_matches` for the dict shape) + use `classify(...)` for the verdict.
+    Reads the store; the pure `rank_matches` is what you'd unit-test."""
+    initiatives = load_current()
+    return rank_matches(signal_text, initiatives, repo=repo, limit=limit)
+
+
+# --------------------------------------------------------------------------- #
+# CLI rendering
+# --------------------------------------------------------------------------- #
+def _short_repo(repo: str | None) -> str:
+    return os.path.basename(str(repo).rstrip("/")) if repo else "?"
+
+
+def render(ranked: list[dict], signal: str, repo: str | None) -> str:
+    """Human-readable ranked output: the verdict, then a scannable table."""
+    out: list[str] = []
+    scope = f"  [repo={_short_repo(repo)}]" if repo else ""
+    out.append(f'signal: "{signal}"{scope}')
+    out.append(f"verdict: {classify(ranked)}")
+    if not ranked:
+        out.append("  (no existing initiative shares a meaningful token — likely new work)")
+        return "\n".join(out)
+    out.append("")
+    hdr = (f"{'#':>2} {'ok':<2} {'score':>5} {'sl':>2} {'ti':>2}  "
+           f"{'repo':<12} {'slug':<34} matched")
+    out.append(hdr)
+    out.append("-" * len(hdr))
+    for i, r in enumerate(ranked, 1):
+        mark = "✓" if r["confident"] else "·"
+        out.append(
+            f"{i:>2} {mark:<2} {r['score']:>5} {r['slug_overlap']:>2} "
+            f"{r['title_overlap']:>2}  {_short_repo(r['repo']):<12.12} "
+            f"{str(r['slug'] or ''):<34.34} {', '.join(r['matched_tokens'])}"
+        )
+    return "\n".join(out)
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Route a free-text signal to the best-matching existing "
+                    "initiative(s) in initiatives.current (suggests, never acts).")
+    p.add_argument("signal", help="the incoming free text (task title / proposal / "
+                                  "mail subject) to route")
+    p.add_argument("--repo", default=None,
+                   help="scope candidates to one repo (full path, worktree subdir, "
+                        "or bare basename like 'devrc')")
+    p.add_argument("--limit", type=int, default=5,
+                   help="max ranked matches to return (default 5)")
+    p.add_argument("--json", action="store_true",
+                   help="emit machine-readable JSON instead of the table")
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    a = parse_args(argv)
+    try:
+        initiatives = load_current()
+    except Exception as exc:  # noqa: BLE001 - surface any store-read failure cleanly
+        print(f"error: could not read initiatives.current: {exc}", file=sys.stderr)
+        print("  the router reads the Phase-1 store — it does NOT re-run the scan. "
+              "Needs KUBECONFIG=$KC_HOMELAB + kubectl + psycopg2.", file=sys.stderr)
+        return 1
+
+    ranked = rank_matches(a.signal, initiatives, repo=a.repo, limit=a.limit)
+
+    if a.json:
+        payload = {
+            "signal": a.signal,
+            "repo": a.repo,
+            "confident": bool(ranked and ranked[0]["confident"]),
+            "classification": classify(ranked),
+            "matches": ranked,
+        }
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+    else:
+        print(render(ranked, a.signal, a.repo))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/initiatives/tests/test_route.py
+++ b/scripts/initiatives/tests/test_route.py
@@ -1,0 +1,201 @@
+"""Unit tests for the PURE core of scripts/initiatives/route.py.
+
+Offline: no live DB, no live scan run. We feed `rank_matches` fixture initiative
+sets + free-text signals and assert on the ranking, the exposed score components,
+the confident-vs-likely-new-work classification, repo scoping, and limit.
+
+`rank_matches` reuses the scan's tokenizers (`text_tokens` / `slug_tokens`) by
+importing `initiative-scan.py` via importlib — that import runs the scan's
+top-level `import chquery` (needs `requests` + `scripts/validation` on sys.path),
+which is available in the hermetic pytest sandbox exactly as it is for
+`test_initiative_scan.py`. No ClickHouse/git/gh is touched by the pure matcher.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import route  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fixture initiatives — minimal (slug/repo/title is all the matcher reads).
+# --------------------------------------------------------------------------- #
+def _ini(slug, title, repo="/repo/devrc"):
+    return {"slug": slug, "repo": repo, "title": title}
+
+
+CLAWGATE = _ini("clawgate-agent-loop", "Clawgate agent loop close")
+TEKTON = _ini("tekton-pipeline", "Tekton pipeline migration")
+SYSREDIS = _ini("sysredis", "Redis sentinel failover hardening")
+AGENT_OPS = _ini("agent-ops-dashboard", "Agent ops dashboard")
+
+# Sibling pair sharing a common prefix (the classic app-blocks ⊂ app-blocks-followups).
+APP_BLOCKS = _ini("app-blocks", "App blocks")
+APP_BLOCKS_FU = _ini("app-blocks-followups", "App blocks followups")
+
+
+def _slugs(ranked):
+    return [r["slug"] for r in ranked]
+
+
+def _by_slug(ranked, slug):
+    return next(r for r in ranked if r["slug"] == slug)
+
+
+# --------------------------------------------------------------------------- #
+# Exact / strong slug hit
+# --------------------------------------------------------------------------- #
+def test_exact_slug_hit_is_confident_and_top():
+    inis = [CLAWGATE, TEKTON, SYSREDIS]
+    ranked = route.rank_matches("harden the clawgate agent loop soak testing", inis)
+    assert ranked[0]["slug"] == "clawgate-agent-loop"
+    assert ranked[0]["confident"] is True
+    assert ranked[0]["slug_overlap"] == 3
+    assert route.classify(ranked) == "confident match: clawgate-agent-loop"
+
+
+def test_matched_tokens_are_the_actual_overlaps():
+    ranked = route.rank_matches("clawgate agent loop", [CLAWGATE])
+    assert ranked[0]["matched_tokens"] == ["agent", "clawgate", "loop"]
+
+
+# --------------------------------------------------------------------------- #
+# Unique-single-token match (df == 1 gate)
+# --------------------------------------------------------------------------- #
+def test_unique_single_slug_token_is_confident():
+    inis = [CLAWGATE, TEKTON, SYSREDIS]
+    ranked = route.rank_matches("some tekton thing", inis)
+    top = ranked[0]
+    assert top["slug"] == "tekton-pipeline"
+    assert top["slug_overlap"] == 1
+    assert top["confident"] is True  # unique token → qualifies on a single hit
+
+
+def test_single_shared_token_is_not_confident():
+    # 'agent' is shared by clawgate-agent-loop AND agent-ops-dashboard (df==2), so a
+    # lone 'agent' hit must NOT fire a confident match on either.
+    inis = [CLAWGATE, AGENT_OPS]
+    ranked = route.rank_matches("agent onboarding", inis)
+    assert ranked, "both share the token 'agent' → should still be listed"
+    assert all(r["confident"] is False for r in ranked)
+    assert route.classify(ranked) == "no confident match — likely new work"
+
+
+# --------------------------------------------------------------------------- #
+# Title-only match
+# --------------------------------------------------------------------------- #
+def test_title_only_two_token_match_is_confident():
+    # Signal shares no SLUG token with sysredis, but two TITLE tokens → confident.
+    ranked = route.rank_matches("sentinel failover runbook", [SYSREDIS, TEKTON])
+    top = ranked[0]
+    assert top["slug"] == "sysredis"
+    assert top["slug_overlap"] == 0
+    assert top["title_overlap"] == 2
+    assert top["confident"] is True
+
+
+# --------------------------------------------------------------------------- #
+# No match → likely new work
+# --------------------------------------------------------------------------- #
+def test_no_overlap_returns_empty_and_new_work():
+    inis = [CLAWGATE, TEKTON, SYSREDIS]
+    ranked = route.rank_matches("quarterly tax invoice paperwork", inis)
+    assert ranked == []
+    assert route.classify(ranked) == "no confident match — likely new work"
+
+
+def test_weak_single_shared_token_classifies_as_new_work():
+    ranked = route.rank_matches("agent onboarding", [CLAWGATE, AGENT_OPS])
+    assert route.classify(ranked) == "no confident match — likely new work"
+
+
+# --------------------------------------------------------------------------- #
+# Sibling disambiguation
+# --------------------------------------------------------------------------- #
+def test_siblings_do_not_both_fire_on_one_shared_token():
+    inis = [APP_BLOCKS, APP_BLOCKS_FU]
+    ranked = route.rank_matches("blocks redesign work", inis)
+    # both share 'blocks' so both are listed, but the df gate keeps BOTH non-confident.
+    assert set(_slugs(ranked)) == {"app-blocks", "app-blocks-followups"}
+    assert all(r["confident"] is False for r in ranked)
+
+
+def test_unique_sibling_token_fires_only_the_specific_initiative():
+    inis = [APP_BLOCKS, APP_BLOCKS_FU]
+    ranked = route.rank_matches("followups cleanup", inis)
+    assert _slugs(ranked) == ["app-blocks-followups"]  # app-blocks has zero overlap
+    assert ranked[0]["confident"] is True
+
+
+def test_full_sibling_name_prefers_the_more_specific_slug():
+    inis = [APP_BLOCKS, APP_BLOCKS_FU]
+    ranked = route.rank_matches("app-blocks-followups triage", inis)
+    assert ranked[0]["slug"] == "app-blocks-followups"  # 3 slug hits beats 2
+    assert ranked[0]["slug_overlap"] == 3
+    assert _by_slug(ranked, "app-blocks")["slug_overlap"] == 2
+
+
+# --------------------------------------------------------------------------- #
+# Ranking order
+# --------------------------------------------------------------------------- #
+def test_confident_ranks_above_weak_non_confident():
+    inis = [CLAWGATE, AGENT_OPS]
+    ranked = route.rank_matches("clawgate agent loop", inis)
+    assert _slugs(ranked) == ["clawgate-agent-loop", "agent-ops-dashboard"]
+    assert ranked[0]["confident"] is True
+    assert ranked[1]["confident"] is False
+    assert ranked[0]["score"] > ranked[1]["score"]
+
+
+# --------------------------------------------------------------------------- #
+# Repo scoping
+# --------------------------------------------------------------------------- #
+_WIDGET_A = _ini("widget-sync", "Widget sync", repo="/repo/devrc")
+_WIDGET_B = _ini("widget-sync-mirror", "Widget sync mirror", repo="/repo/other")
+
+
+def test_repo_scope_by_full_path():
+    inis = [_WIDGET_A, _WIDGET_B]
+    ranked = route.rank_matches("widget sync", inis, repo="/repo/devrc")
+    assert _slugs(ranked) == ["widget-sync"]
+
+
+def test_repo_scope_by_basename():
+    inis = [_WIDGET_A, _WIDGET_B]
+    ranked = route.rank_matches("widget sync", inis, repo="other")
+    assert _slugs(ranked) == ["widget-sync-mirror"]
+
+
+def test_no_repo_scope_considers_all_repos():
+    inis = [_WIDGET_A, _WIDGET_B]
+    ranked = route.rank_matches("widget sync", inis)
+    assert set(_slugs(ranked)) == {"widget-sync", "widget-sync-mirror"}
+
+
+def test_repo_scope_narrows_df_uniqueness():
+    # Both repos have a 'widget' initiative → across the full set 'widget' is df==2 and
+    # a lone 'widget' hit is not unique; scoped to one repo it becomes unique (df==1).
+    inis = [_WIDGET_A, _WIDGET_B]
+    scoped = route.rank_matches("widget", inis, repo="/repo/devrc")
+    assert scoped and scoped[0]["confident"] is True  # unique within the scoped set
+
+
+# --------------------------------------------------------------------------- #
+# Limit + empty store
+# --------------------------------------------------------------------------- #
+def test_limit_caps_the_result_list():
+    inis = [APP_BLOCKS, APP_BLOCKS_FU, _ini("app-blocks-legacy", "App blocks legacy")]
+    ranked = route.rank_matches("app blocks", inis, limit=2)
+    assert len(ranked) == 2
+
+
+def test_empty_store_returns_empty_and_new_work():
+    ranked = route.rank_matches("anything at all", [])
+    assert ranked == []
+    assert route.classify(ranked) == "no confident match — likely new work"
+
+
+def test_empty_signal_matches_nothing():
+    ranked = route.rank_matches("", [CLAWGATE, TEKTON])
+    assert ranked == []


### PR DESCRIPTION
## What

**Phase 2** of the initiatives-consolidation feature: the **router**. A READ-ONLY consumer of the Phase-1 `initiatives.current` Postgres view (PR #135/#136). Given an incoming free-text signal — a new task title, a repo-cos proposal, a mail subject/thread snippet — it ranks the existing initiatives with an interpretable score and classifies the top one as a **confident match** vs **"likely new work"**. It **suggests, never acts**: no dispatch, no writes, no confidence *gate* that force-picks.

## Reuses the scan's matcher (single-sourced, not reimplemented)

`route.py` imports `session-analysis/initiative-scan.py` by **importlib path** (its filename is hyphenated → not importable) and borrows `text_tokens` / `slug_tokens` + `best_title_match`'s exact scoring components:

- `slug_overlap` — # signal tokens hitting the initiative's SLUG tokens (the fingerprint)
- `title_overlap` — # signal tokens hitting TITLE-only tokens
- the **document-frequency uniqueness gate** for the confident flag

Where `best_title_match` returns only the single best (or None), the router returns **all candidates ranked** with numeric scores + which tokens matched, using the **same qualification bar** for `confident`. Ranking uses the full deterministic tuple `(confident, slug_overlap, title_overlap, slug-length, slug)` — identical to `best_title_match`'s tie-breaks — so the top confident row equals what `best_title_match` would have picked. The scan import is **lazy** so importing `route` (from a repo-cos / mail-actions caller) stays side-effect-light.

## Shape (mirrors `sync.py`'s pure-core-vs-I/O split)

- `rank_matches(signal, initiatives, repo=, limit=)` — **PURE**, unit-tested, no infra.
- `load_current()` — reads `initiatives.current` via `mail-actions/_db.py` (importlib path, **not** `sys.path` — its `llm.py` shadows).
- `route(signal, repo=, limit=)` — callable API for repo-cos / mail-actions.
- CLI: `route.py "<signal>" [--repo PATH] [--limit N] [--json]`; graceful error when the store is unreachable (does **not** fall back to re-running the scan).

## Confident-vs-new-work threshold

Same bar as `best_title_match`: a candidate is `confident` iff `slug_overlap >= 2` **OR** exactly one slug hit on a token **unique** (df == 1) to that initiative among the eligible set **OR** `title_overlap >= 2`. `classify(ranked)` → `"confident match: <slug>"` when the top row is confident, else `"no confident match — likely new work"`.

## Tests

18 unit tests in `scripts/initiatives/tests/test_route.py` covering: exact slug hit, unique-single-token, title-only, no-match → likely-new-work, sibling disambiguation (`app-blocks` vs `app-blocks-followups` — the df gate), repo scoping (path + basename), df-narrowing under scope, limit, ranking order, empty store, empty signal. `scripts/initiatives/tests` is already in `run-tests.sh` HERMETIC_DIRS; `test_route` co-exists with `test_sync` under the per-dir `sys.path`. Full hermetic suite green.

## Live demo (read-only, against the real `initiatives.current`)

```
$ route.py "polish the clawgate agent chat transcript rendering"
verdict: confident match: clawgate-chat-polish
 1 ✓  3.5  3  2  devrc  clawgate-chat-polish  agent, chat, clawgate, polish, transcript

$ route.py "renew the home insurance policy and pay the water bill"
verdict: no confident match — likely new work
```

## Caller integration (one-liner)

```python
# repo-cos / mail-actions
import route  # scripts/initiatives/route.py (importlib in practice, hyphen-free filename)
matches = route.route(proposal_or_subject, repo=repo_path)  # ranked, best-first
verdict = route.classify(matches)  # "confident match: <slug>" | "likely new work"
```

## Not in scope / for later

Suggests only — no autonomous dispatch (Zach's pick). When a signal contains a shared multi-token prefix (e.g. "app blocks"), all siblings clear the 2-token bar and show as confident alternates under the best-guess top row — intended "suggest, don't gate" behavior, not a false-positive gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)