### PR TITLE
feat(repo-cos): tag proposals with their related initiative (surface-only)

### DIFF
--- a/scripts/repo-cos/digest.py
+++ b/scripts/repo-cos/digest.py
@@ -45,13 +45,18 @@ def render(proposals: list, *, today: date | None = None,
            candidate_count: int | None = None,
            approx_tokens: int | None = None,
            excluded_repos: list | None = None,
-           dismissed_count: int | None = None) -> str:
+           dismissed_count: int | None = None,
+           related: list | None = None) -> str:
     """Render proposals (llm.Proposal objects) into a compact skimmable digest.
 
     Empty proposal list is handled explicitly (honest 'nothing surfaced' message rather
     than a blank email). `excluded_repos` (deterministically dropped from the scan) is
     surfaced as a footer so Zach sees the state and can reply "resume <repo>" to undo it.
-    `dismissed_count` (per-recommendation dismissals) is surfaced as a terse footer line."""
+    `dismissed_count` (per-recommendation dismissals) is surfaced as a terse footer line.
+    `related` (optional, index-aligned to `proposals`) is a SURFACE-ONLY initiative slug
+    per proposal (or None) from the router — rendered as a `↳ relates to: <slug>`
+    breadcrumb under the title, omitted where there's no confident match. Purely
+    informational: it drives no action and a missing/short list just means no tags."""
     d = today or date.today()
     excl_footer = _excluded_footer(excluded_repos)
     dism_footer = _dismissed_footer(dismissed_count)
@@ -82,6 +87,9 @@ def render(proposals: list, *, today: date | None = None,
         ci = "✅ CI-verifiable" if p.ci_verifiable else "○ needs judgement"
         eff = EFFORT_LABEL.get(p.effort, p.effort)
         lines.append(f"{i}. {p.title}  [{p.repo}]")
+        rel = related[i - 1] if related is not None and i - 1 < len(related) else None
+        if rel:
+            lines.append(f"   ↳ relates to: {rel}")
         lines.append(f"   why:      {p.why}")
         lines.append(f"   effort:   {eff}   {ci}")
         if p.approach:

--- a/scripts/repo-cos/routing.py
+++ b/scripts/repo-cos/routing.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""SURFACE-ONLY initiative tagging for repo-cos proposals.
+
+Given the proposals llm.synthesize produced, tag each with the EXISTING initiative
+it relates to (if any) so the digest can show a `↳ relates to: <slug>` breadcrumb.
+It is strictly DISPLAY — no dispatch, no writes, no effect on the exclusions /
+approve / clawgate-task flow. A proposal that doesn't confidently match any
+initiative simply carries no tag.
+
+Consumes the Phase-2 router (`scripts/initiatives/route.py`, a READ-ONLY view over
+the Phase-1 `initiatives.current` store). The store lives in the homelab `mailbox`
+Postgres and is read via `route.load_current()` — a kubectl port-forward — so we
+call it EXACTLY ONCE per repo-cos run and rank every proposal against that one
+in-memory snapshot (never per-proposal).
+
+BEST-EFFORT + SAFE (the load-bearing contract): every entry point that touches the
+store or the router is wrapped so ANY failure — store unreachable, no kubeconfig,
+import error, malformed rows — is logged to stderr and yields NO tags. The digest
+must still render and send byte-for-byte as it did before this feature existed.
+
+Tagging rule (see the router's confidence model): a proposal is tagged with
+`ranked[0]["slug"]` ONLY when `ranked[0]["confident"]` is true — the single top
+row, not every confident row. Shared multi-token prefixes can make several sibling
+initiatives "confident" at once, so surfacing more than the top one would be noise;
+a low-confidence best row is dropped entirely rather than shown as a weak guess.
+
+`route.py` is loaded by EXPLICIT importlib path (NOT via sys.path) for the same
+reason feedback.py loads `mail-actions/_db.py` that way: the mail-actions dir ships
+its own `llm.py` that would SHADOW repo-cos's `llm.py` if that dir hit sys.path and
+break synthesis. route.py imports only stdlib at module load (its own scan/db
+imports are lazy), so a standalone load is safe.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# The Phase-2 router (scripts/initiatives/route.py). Sibling package dir, loaded by
+# explicit path — do NOT add scripts/initiatives OR scripts/mail-actions to sys.path.
+ROUTE_PATH = Path(__file__).resolve().parents[1] / "initiatives" / "route.py"
+
+_route_mod = None
+
+
+def _log(msg: str) -> None:
+    print(f"  routing: {msg}", file=sys.stderr)
+
+
+def _route():
+    """Load initiatives/route.py by explicit importlib path and cache it.
+
+    Lazy + cached so importing `routing` costs nothing and the router (which itself
+    lazily pulls in the scan's tokenizers on first match) is only paid for when we
+    actually tag. Raises ImportError if the file can't be loaded — callers wrap it."""
+    global _route_mod
+    if _route_mod is None:
+        spec = importlib.util.spec_from_file_location("repo_cos_route", ROUTE_PATH)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"cannot load {ROUTE_PATH}")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        _route_mod = mod
+    return _route_mod
+
+
+def signal_text(proposal) -> str:
+    """The human-readable text repo-cos has for a proposal, for the router to match on.
+
+    Duck-typed on the fields llm.Proposal exposes (title / why / approach) — the
+    title plus its rationale/approach is the richest description we have. Missing
+    fields are tolerated (a bare dict or a partial object still works)."""
+    parts = []
+    for attr in ("title", "why", "approach"):
+        val = getattr(proposal, attr, None)
+        if val is None and isinstance(proposal, dict):
+            val = proposal.get(attr)
+        if val:
+            parts.append(str(val))
+    return "  ".join(parts).strip()
+
+
+def _proposal_repo(proposal):
+    """The proposal's repo scope for the router (None when absent → match all repos)."""
+    repo = getattr(proposal, "repo", None)
+    if repo is None and isinstance(proposal, dict):
+        repo = proposal.get("repo")
+    repo = (str(repo).strip() if repo else "")
+    return repo or None
+
+
+def tag_proposals(proposals, initiatives) -> list:
+    """PURE: return a related-initiative slug (or None) per proposal, index-aligned.
+
+    No I/O — `initiatives` is an already-loaded snapshot of `initiatives.current`.
+    For each proposal we rank the existing initiatives against its signal text
+    (scoped to the proposal's repo) and take the TOP row's slug iff it's confident,
+    else None. An empty `initiatives` list → all None (nothing to relate to)."""
+    route = _route()
+    related: list = []
+    for p in proposals:
+        text = signal_text(p)
+        slug = None
+        if text and initiatives:
+            ranked = route.rank_matches(text, initiatives,
+                                        repo=_proposal_repo(p), limit=1)
+            if ranked and ranked[0].get("confident"):
+                slug = ranked[0].get("slug")
+        related.append(slug)
+    return related
+
+
+def related_for(proposals) -> list:
+    """BEST-EFFORT: load `initiatives.current` ONCE, tag every proposal, never raise.
+
+    The single entry point repo-cos calls. Any failure — router import error, store
+    unreachable, no kubeconfig, bad rows — is logged and degrades to NO tags (a list
+    of None the same length as `proposals`) so the digest is unaffected. Returns an
+    index-aligned list[str | None]."""
+    n = len(proposals)
+    if not n:
+        return []
+    try:
+        route = _route()
+        initiatives = route.load_current()
+    except Exception as exc:  # noqa: BLE001 - best-effort: never break the digest
+        _log(f"could not load initiatives (proceeding without tags): {exc}")
+        return [None] * n
+    try:
+        related = tag_proposals(proposals, initiatives)
+    except Exception as exc:  # noqa: BLE001 - best-effort: never break the digest
+        _log(f"tagging failed (proceeding without tags): {exc}")
+        return [None] * n
+    tagged = sum(1 for s in related if s)
+    _log(f"tagged {tagged}/{n} proposal(s) with a related initiative "
+         f"(from {len(initiatives)} in the store)")
+    return related

--- a/scripts/repo-cos/scan.py
+++ b/scripts/repo-cos/scan.py
@@ -223,12 +223,27 @@ def cmd_scan(args) -> int:
         print(f"ERROR: synthesis failed: {exc}", file=sys.stderr)
         return 1
 
+    # ---- SURFACE-ONLY initiative routing (best-effort; NEVER breaks the digest) ----
+    # Tag each synthesized proposal with the EXISTING initiative it relates to (if any)
+    # so the digest shows a `↳ relates to: <slug>` breadcrumb. Loads the Phase-1 store
+    # ONCE (a kubectl port-forward) and ranks in memory. Wrapped so a router/store/import
+    # failure logs a warning and proceeds with NO tags — the digest sends exactly as before.
+    related = []
+    try:
+        import routing
+        related = routing.related_for(result.proposals)
+    except Exception as exc:  # noqa: BLE001 - best-effort: never break the digest
+        print(f"  ! initiative routing failed (proceeding without tags): {exc}",
+              file=sys.stderr)
+        related = []
+
     body = digest.render(
         result.proposals,
         candidate_count=len(cand_dicts),
         approx_tokens=result.approx_prompt_tokens,
         excluded_repos=excluded_names,
         dismissed_count=len(dismissed_recs),
+        related=related,
     )
     print(f"  synthesis: model={result.model} candidates={len(cand_dicts)} "
           f"proposals={len(result.proposals)} ~prompt_tokens={result.approx_prompt_tokens} "

--- a/scripts/repo-cos/tests/test_routing.py
+++ b/scripts/repo-cos/tests/test_routing.py
@@ -1,0 +1,191 @@
+"""Tests for the SURFACE-ONLY initiative tagging (scripts/repo-cos/routing.py) and
+its digest rendering.
+
+Offline: no live DB, no live scan. `routing.tag_proposals` is PURE — we feed it
+fixture initiative sets + Proposal objects and assert the tag. The best-effort
+`related_for` is exercised by injecting `route.load_current` (the ONLY I/O) so we
+never touch Postgres; a store/tagging failure is asserted to be swallowed.
+
+`routing` loads the router (`scripts/initiatives/route.py`) by importlib, whose pure
+matcher reuses the scan's tokenizers — the same import path proven hermetic by
+`scripts/initiatives/tests/test_route.py` and `test_initiative_scan.py`.
+"""
+import sys
+from datetime import date
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import digest  # noqa: E402
+import llm  # noqa: E402
+import routing  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+def _prop(title="Fix", *, repo="devrc", why="better CI", approach="do it", ci=True):
+    return llm.Proposal(
+        title=title, repo=repo, evidence=[f"{repo}/a.py:1"], why=why,
+        effort="S", approach=approach, ci_verifiable=ci,
+    )
+
+
+def _ini(slug, title, repo="/home/zach/workspace/devrc"):
+    return {"slug": slug, "repo": repo, "title": title}
+
+
+CLAWGATE = _ini("clawgate-agent-loop", "Clawgate agent loop close")
+TEKTON = _ini("tekton-pipeline", "Tekton pipeline migration")
+AGENT_OPS = _ini("agent-ops-dashboard", "Agent ops dashboard")
+APP_BLOCKS = _ini("app-blocks", "App blocks")
+APP_BLOCKS_FU = _ini("app-blocks-followups", "App blocks followups")
+
+
+# --------------------------------------------------------------------------- #
+# signal_text
+# --------------------------------------------------------------------------- #
+def test_signal_text_combines_title_why_approach():
+    p = _prop(title="Harden hook", why="prevents drift", approach="add a guard")
+    text = routing.signal_text(p)
+    assert "Harden hook" in text
+    assert "prevents drift" in text
+    assert "add a guard" in text
+
+
+def test_signal_text_tolerates_dict_and_missing_fields():
+    assert routing.signal_text({"title": "Just a title"}) == "Just a title"
+    assert routing.signal_text({}) == ""
+
+
+# --------------------------------------------------------------------------- #
+# tag_proposals — PURE
+# --------------------------------------------------------------------------- #
+def test_confident_match_is_tagged():
+    props = [_prop(title="harden the clawgate agent loop soak testing", why="", approach="")]
+    related = routing.tag_proposals(props, [CLAWGATE, TEKTON])
+    assert related == ["clawgate-agent-loop"]
+
+
+def test_non_confident_match_is_not_tagged():
+    # 'agent' alone is shared by clawgate-agent-loop AND agent-ops-dashboard (df==2) →
+    # not a confident match on either → no tag.
+    props = [_prop(title="agent onboarding docs", why="", approach="")]
+    related = routing.tag_proposals(props, [CLAWGATE, AGENT_OPS])
+    assert related == [None]
+
+
+def test_no_overlap_is_not_tagged():
+    props = [_prop(title="quarterly tax invoice paperwork", why="", approach="")]
+    assert routing.tag_proposals(props, [CLAWGATE, TEKTON]) == [None]
+
+
+def test_empty_store_yields_no_tags():
+    props = [_prop(title="harden the clawgate agent loop"), _prop(title="tekton pipeline")]
+    assert routing.tag_proposals(props, []) == [None, None]
+
+
+def test_tags_are_index_aligned_per_proposal():
+    props = [
+        _prop(title="harden the clawgate agent loop", why="", approach=""),
+        _prop(title="quarterly tax invoice paperwork", why="", approach=""),
+        _prop(title="migrate the tekton pipeline", why="", approach=""),
+    ]
+    related = routing.tag_proposals(props, [CLAWGATE, TEKTON])
+    assert related == ["clawgate-agent-loop", None, "tekton-pipeline"]
+
+
+def test_only_the_single_top_row_is_taken_when_siblings_are_confident():
+    # 'app-blocks-followups' hits 3 slug tokens on the FU sibling and 2 on app-blocks —
+    # both can qualify, but tagging takes ONLY the top row (the more specific slug).
+    props = [_prop(title="app-blocks-followups triage", why="", approach="")]
+    related = routing.tag_proposals(props, [APP_BLOCKS, APP_BLOCKS_FU])
+    assert related == ["app-blocks-followups"]
+
+
+def test_repo_scope_limits_the_candidate_initiatives():
+    a = _ini("widget-sync", "Widget sync", repo="/home/zach/workspace/devrc")
+    b = _ini("widget-sync-mirror", "Widget sync mirror", repo="/home/zach/workspace/other")
+    props = [_prop(title="widget sync fixes", repo="other", why="", approach="")]
+    related = routing.tag_proposals(props, [a, b])
+    assert related == ["widget-sync-mirror"]
+
+
+# --------------------------------------------------------------------------- #
+# related_for — BEST-EFFORT wrapper (inject route.load_current; no real DB)
+# --------------------------------------------------------------------------- #
+def test_related_for_tags_from_injected_store(monkeypatch):
+    route = routing._route()
+    monkeypatch.setattr(route, "load_current", lambda: [CLAWGATE, TEKTON])
+    props = [_prop(title="harden the clawgate agent loop", why="", approach="")]
+    assert routing.related_for(props) == ["clawgate-agent-loop"]
+
+
+def test_related_for_empty_store_no_tags(monkeypatch):
+    route = routing._route()
+    monkeypatch.setattr(route, "load_current", lambda: [])
+    props = [_prop(title="harden the clawgate agent loop"), _prop(title="tekton")]
+    assert routing.related_for(props) == [None, None]
+
+
+def test_related_for_empty_proposals_returns_empty():
+    assert routing.related_for([]) == []
+
+
+def test_related_for_swallows_store_failure(monkeypatch):
+    # Store unreachable → load_current raises → NO tags, pipeline continues (never raises).
+    route = routing._route()
+
+    def boom():
+        raise RuntimeError("store down / no kubeconfig")
+
+    monkeypatch.setattr(route, "load_current", boom)
+    props = [_prop("A"), _prop("B")]
+    assert routing.related_for(props) == [None, None]
+
+
+def test_related_for_swallows_tagging_failure(monkeypatch):
+    # Store loads, but the matcher blows up mid-tag → still swallowed → all None.
+    route = routing._route()
+    monkeypatch.setattr(route, "load_current", lambda: [CLAWGATE])
+
+    def boom(*a, **k):
+        raise RuntimeError("matcher exploded")
+
+    monkeypatch.setattr(route, "rank_matches", boom)
+    props = [_prop("A"), _prop("B")]
+    assert routing.related_for(props) == [None, None]
+
+
+def test_related_for_swallows_router_import_failure(monkeypatch):
+    # Router import itself fails → NO tags, no crash.
+    def boom():
+        raise ImportError("cannot load route.py")
+
+    monkeypatch.setattr(routing, "_route", boom)
+    props = [_prop("A")]
+    assert routing.related_for(props) == [None]
+
+
+# --------------------------------------------------------------------------- #
+# digest rendering of the ↳ relates-to breadcrumb
+# --------------------------------------------------------------------------- #
+def test_render_shows_relates_to_only_where_tagged():
+    props = [_prop("A"), _prop("B")]
+    body = digest.render(props, today=date(2026, 7, 1),
+                         related=["clawgate-chat-polish", None])
+    assert "↳ relates to: clawgate-chat-polish" in body
+    assert body.count("relates to:") == 1  # only the tagged proposal shows it
+
+
+def test_render_without_related_has_no_breadcrumb():
+    body = digest.render([_prop("A")], today=date(2026, 7, 1))
+    assert "relates to" not in body
+
+
+def test_render_tolerates_short_related_list():
+    # A related list shorter than proposals must not IndexError — extra proposals untagged.
+    body = digest.render([_prop("A"), _prop("B")], today=date(2026, 7, 1),
+                         related=["only-first"])
+    assert "↳ relates to: only-first" in body
+    assert body.count("relates to:") == 1


### PR DESCRIPTION
## What

Wire the Phase-2 initiatives **router** (`scripts/initiatives/route.py`) into **repo-cos**. When the weekly digest synthesizes its improvement proposals, each proposal that confidently matches an existing initiative now shows a breadcrumb:

```
1. Close the clawgate agent loop soak gap  [devrc]
   ↳ relates to: clawgate-agent-loop-close
   why:      reduces manual babysitting
   ...
```

**Surface-only** — it displays a relation and takes NO action. It does not touch the exclusions / approve / clawgate-task flow.

## How

- **New `scripts/repo-cos/routing.py`**:
  - Loads `initiatives/route.py` by **explicit importlib path** (same reason `feedback.py` loads `mail-actions/_db.py` that way — the mail-actions `llm.py` would shadow repo-cos's `llm.py` if that dir hit `sys.path`).
  - `related_for(proposals)` calls `route.load_current()` **ONCE per run** (a kubectl port-forward), then ranks every proposal in memory.
  - `tag_proposals()` is a **pure**, index-aligned tagger: takes `route.rank_matches()`'s **single top row** iff `confident` (per the router's confidence model; shared multi-token prefixes can make several siblings confident, so only the top one is taken).
  - `signal_text()` = proposal title + why + approach.
- **Best-effort + safe**: `related_for` wraps the store load AND the tagging in try/except — any failure (store unreachable, no kubeconfig, import error, bad rows) is logged to stderr and degrades to NO tags. The digest renders and sends **exactly as before**.
- **`scan.py`** wires it in after synthesis, itself wrapped in try/except.
- **`digest.py`** `render()` grows an optional index-aligned `related` list; renders `↳ relates to: <slug>` under the title, omitted where there's no confident match. Tolerates a short/None list (no IndexError).

## Tests

18 new tests in `scripts/repo-cos/tests/test_routing.py` (dir already registered in `run-tests.sh`):
- Pure tagging: confident match tagged, non-confident → none, no-overlap → none, empty store → none, index-alignment, top-row-only when siblings confident, repo-scope.
- Best-effort: store-load failure, mid-tag failure, and router-import failure all swallowed → all-None (pipeline continues).
- Digest render: breadcrumb only where tagged, absent without `related`, short-list tolerance.

Verification: full `scripts/run-tests.sh` hermetic set **PASS** (232 in repo-cos incl. the 18 new; 281 across repo-cos+initiatives). Also exercised the real end-to-end render with an injected store — the tagged/untagged breadcrumb renders as shown above, and the store-failure path leaves the digest byte-identical (no crash, no breadcrumb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)