### PR TITLE
feat(mail-actions): tag action items with their related initiative (surface-only)

### DIFF
--- a/scripts/mail-actions/README.md
+++ b/scripts/mail-actions/README.md
@@ -196,6 +196,25 @@ operator backfills them, e.g.:
 -- (done by the operator during verification; new rows get it automatically)
 ```
 
+`ensure_schema` also adds `related_initiative text` via
+`ALTER TABLE mail_actions ADD COLUMN IF NOT EXISTS related_initiative text`
+(idempotent, additive, nullable — see "Initiative routing (surface-only)" below).
+
+### Initiative routing (surface-only)
+
+Each newly-extracted action is tagged, best-effort, with the **existing initiative
+it relates to** (if any). The run loads the Phase-1 store's `initiatives.current`
+view ONCE (`MailDB.fetch_current_initiatives()`, reusing the open connection — no
+second port-forward) and, for each action, ranks the mail **subject** against it via
+the shared router `scripts/initiatives/route.py` (loaded by explicit importlib path —
+NOT on `sys.path`, to avoid the `llm.py` shadow trap). The top match is taken **only
+when `ranked[0]["confident"]`**; the slug lands in `related_initiative` and surfaces
+as `relates to: <slug>` in `extract.py list` and on the clawgate card. Strictly
+display-only: it never dispatches or acts. The whole path is wrapped so **any router
+or store failure logs a warning and the action is queued untagged** — extraction
+behaves exactly as before. When the `initiatives` schema/view is absent (Phase-1 sync
+not deployed on the host), the store read returns `[]` and every action is untagged.
+
 ## Invoice archiver (`archive-invoices`)
 
 A **separate, deterministic** loop (no LLM) that mines the inbox for **PDF invoice

--- a/scripts/mail-actions/_db.py
+++ b/scripts/mail-actions/_db.py
@@ -158,6 +158,7 @@ class MailDB:
                     reason      text,
                     status      text DEFAULT 'open',
                     thread_key  text,
+                    related_initiative text,
                     created_at  timestamptz DEFAULT now()
                 )
                 """
@@ -168,6 +169,15 @@ class MailDB:
             cur.execute(
                 "ALTER TABLE mail_actions "
                 "ADD COLUMN IF NOT EXISTS thread_key text"
+            )
+            # Idempotent migration for the surface-only initiative router tag
+            # (Phase-2 wiring). Additive + nullable: legacy rows, and any action with
+            # no confident routed initiative, keep this NULL. Nothing keys off it — it
+            # is pure display metadata (the queue's "relates to: <slug>" line), so a
+            # router/DB failure never affects extraction or the existing columns.
+            cur.execute(
+                "ALTER TABLE mail_actions "
+                "ADD COLUMN IF NOT EXISTS related_initiative text"
             )
         self._c.commit()
 
@@ -247,10 +257,29 @@ class MailDB:
         with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             cur.execute(
                 "SELECT id, mail_id, from_addr, subject, received_at, who, ask, "
-                "deadline, amount, confidence, status, created_at "
+                "deadline, amount, confidence, status, related_initiative, created_at "
                 "FROM mail_actions WHERE status = 'open' ORDER BY created_at DESC"
             )
             return cur.fetchall()
+
+    def fetch_current_initiatives(self):
+        """Best-effort read of `initiatives.current` (Phase-1 store) → list of
+        {slug, repo, title} for the surface-only mail→initiative router.
+
+        Reuses THIS already-open mailbox connection instead of `route.load_current()`
+        opening a SECOND kubectl port-forward to the same DB. Strictly best-effort:
+        if the `initiatives` schema/view is absent (the sync isn't deployed on this
+        host), returns [] via a `to_regclass` guard — routing is display-only and must
+        never break extraction. Any harder failure propagates to the caller's
+        try/except, which also degrades to no-tag."""
+        with self._c.cursor() as cur:
+            cur.execute("SELECT to_regclass('initiatives.current')")
+            reg = cur.fetchone()
+            if reg is None or reg[0] is None:
+                return []
+        with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute("SELECT slug, repo, title FROM initiatives.current")
+            return [dict(r) for r in cur.fetchall()]
 
     # -- writes ------------------------------------------------------------
     def mark_processed(self, mail_id: int, label: str) -> None:
@@ -294,16 +323,19 @@ class MailDB:
         working; cmd_run always supplies it now."""
         params = dict(row)
         params.setdefault("thread_key", None)
+        params.setdefault("related_initiative", None)
         with self._c.cursor() as cur:
             cur.execute(
                 """
                 INSERT INTO mail_actions
                     (mail_id, message_id, from_addr, subject, received_at,
-                     who, ask, deadline, amount, confidence, reason, thread_key)
+                     who, ask, deadline, amount, confidence, reason, thread_key,
+                     related_initiative)
                 VALUES
                     (%(mail_id)s, %(message_id)s, %(from_addr)s, %(subject)s,
                      %(received_at)s, %(who)s, %(ask)s, %(deadline)s, %(amount)s,
-                     %(confidence)s, %(reason)s, %(thread_key)s)
+                     %(confidence)s, %(reason)s, %(thread_key)s,
+                     %(related_initiative)s)
                 ON CONFLICT (mail_id) DO NOTHING
                 """,
                 params,

--- a/scripts/mail-actions/extract.py
+++ b/scripts/mail-actions/extract.py
@@ -39,6 +39,7 @@ Env: OPENROUTER_API_KEY (Stage 2), KUBECONFIG (DB), CLAWGATE_HOOK_TOKEN (optiona
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import sys
@@ -55,9 +56,59 @@ DEFAULT_LIMIT = 150
 EST_USD_PER_1K_TOKENS = 0.0002
 EST_TOKENS_PER_MAIL = 1500  # system+subject+truncated body+output, order of magnitude
 
+# The initiatives router (Phase 2). Loaded by EXPLICIT importlib path — NOT by
+# adding scripts/initiatives/ to sys.path: mail-actions' own `llm.py` shadows other
+# modules, so putting sibling dirs on the path is a known trap (see repo CLAUDE.md /
+# repo-cos). route.py imports only stdlib at module scope, so a standalone load is
+# safe; its scan matcher is imported lazily inside rank_matches.
+ROUTE_PATH = Path(__file__).resolve().parents[1] / "initiatives" / "route.py"
+_route_mod = None
+
 
 def _est_cost(n: int) -> float:
     return n * EST_TOKENS_PER_MAIL / 1000.0 * EST_USD_PER_1K_TOKENS
+
+
+def _route():
+    """Load scripts/initiatives/route.py by explicit path and cache it.
+
+    Lazy so merely importing `extract` costs nothing; the module only materialises
+    the first time a run actually routes. Raises on a genuinely broken load — the
+    caller wraps this in try/except so a failure degrades to no tag, never a crash."""
+    global _route_mod
+    if _route_mod is None:
+        spec = importlib.util.spec_from_file_location("mail_actions_route", ROUTE_PATH)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"cannot load {ROUTE_PATH}")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        _route_mod = mod
+    return _route_mod
+
+
+def related_initiative_slug(subject, initiatives, repo=None):
+    """Surface-only: the slug of the initiative this mail action relates to, or None.
+
+    PURE-ish + strictly best-effort. Ranks the mail `subject` against the once-loaded
+    `initiatives.current` set via the shared router and returns `ranked[0]['slug']`
+    ONLY when that top row is `confident` — the router's own qualification bar. A
+    non-confident top row, an empty store, an empty subject, or ANY exception in the
+    routing path all yield None so the action is queued untagged and extraction
+    proceeds exactly as before. This never acts — it only labels.
+
+    `initiatives` is the list from `MailDB.fetch_current_initiatives()`; pass it in
+    (loaded ONCE per run) rather than reading the store per action."""
+    if not subject or not initiatives:
+        return None
+    try:
+        route = _route()
+        ranked = route.rank_matches(subject, initiatives, repo=repo, limit=1)
+        if ranked and ranked[0].get("confident"):
+            return ranked[0].get("slug")
+    except Exception as exc:  # noqa: BLE001 — routing is display-only, never fatal
+        print(f"  ! initiative routing failed (subject={subject!r}): {exc}",
+              file=sys.stderr)
+    return None
 
 
 def _partition(rows):
@@ -216,6 +267,16 @@ def cmd_run(args) -> int:
                   "Use --dry-run for the filter-only pass.", file=sys.stderr)
             return 2
 
+        # Surface-only initiative routing (Phase 2): load the current-initiatives set
+        # ONCE per run (reusing the open connection — no 2nd port-forward), then tag
+        # each new action with its confident match in memory. Best-effort: any failure
+        # here leaves `initiatives` empty and every action goes out untagged.
+        try:
+            initiatives = db.fetch_current_initiatives()
+        except Exception as exc:  # noqa: BLE001 — routing is display-only, never fatal
+            print(f"  ! initiative store read failed: {exc}", file=sys.stderr)
+            initiatives = []
+
         actions = 0
         fyis = 0
         invoices = 0
@@ -223,6 +284,7 @@ def cmd_run(args) -> int:
         sent = 0
         errors = 0
         emitted = 0
+        routed = 0
         seen_threads: set[str] = set()
         # Survivors arrive most-recent-first (fetch_unprocessed ORDER BY received_at
         # DESC), so the FIRST survivor seen for a thread is the latest message — the
@@ -269,6 +331,11 @@ def cmd_run(args) -> int:
                 continue
 
             if ex.action_required:
+                # Surface-only: which existing initiative (if any) this thread relates
+                # to. Best-effort, in memory against the once-loaded set; None → no tag.
+                related = related_initiative_slug(r.get("subject"), initiatives)
+                if related:
+                    routed += 1
                 # Feature 1: a NEWER message's action retires the older OPEN action for
                 # this thread (cross-run, persisted). Guarded by received_at so an older
                 # message can't supersede a newer open action.
@@ -283,12 +350,13 @@ def cmd_run(args) -> int:
                     "subject": r.get("subject"),
                     "received_at": r.get("received_at"),
                     "thread_key": tkey or None,
+                    "related_initiative": related,
                     **ex.as_row(),
                 })
                 db.mark_processed(r["id"], "action-required")
                 actions += 1
                 if inserted and args.emit_clawgate:
-                    emitted += _emit_clawgate(r, ex)
+                    emitted += _emit_clawgate(r, ex, related)
             else:
                 db.mark_processed(r["id"], "fyi")
                 fyis += 1
@@ -306,6 +374,7 @@ def cmd_run(args) -> int:
             "superseded": superseded,
             "sent": sent,
             "closed": closed,
+            "routed": routed,
             "extract_errors": errors,
             "clawgate_emitted": emitted,
             "est_llm_cost_usd": round(_est_cost(len(survivors)), 4),
@@ -317,12 +386,16 @@ def cmd_run(args) -> int:
         return 0
 
 
-def _emit_clawgate(r, ex) -> int:
+def _emit_clawgate(r, ex, related=None) -> int:
     try:
         from clawgate import emit_task
+        source_ref = f"mail#{r['id']} {r.get('from_addr')}"
+        if related:
+            # Surface-only: show the related initiative on the clawgate card too.
+            source_ref += f" · relates to: {related}"
         ok = emit_task(
             who=ex.who, ask=ex.ask, deadline=ex.deadline, amount=ex.amount,
-            source_ref=f"mail#{r['id']} {r.get('from_addr')}",
+            source_ref=source_ref,
         )
         return 1 if ok else 0
     except Exception as exc:  # noqa: BLE001
@@ -496,6 +569,8 @@ def cmd_list(args) -> int:
             meta.append(f"deadline={r['deadline']}")
         if r.get("amount"):
             meta.append(f"amount={r['amount']}")
+        if r.get("related_initiative"):
+            meta.append(f"relates to: {r['related_initiative']}")
         meta.append(f"from={r['from_addr']}")
         meta.append(f"mail#{r['mail_id']}")
         print(f"        {'  '.join(meta)}")
@@ -525,6 +600,8 @@ def _print_run(s) -> None:
     print(f"  superseded:       {s.get('superseded', 0)}")
     print(f"  sent (owner):     {s.get('sent', 0)}")
     print(f"  closed (owner):   {s.get('closed', 0)}")
+    if s.get("routed"):
+        print(f"  routed (init.):   {s['routed']}")
     if s["extract_errors"]:
         print(f"  extract errors:   {s['extract_errors']}")
     if s.get("clawgate_emitted"):

--- a/scripts/mail-actions/tests/test_db_schema.py
+++ b/scripts/mail-actions/tests/test_db_schema.py
@@ -28,7 +28,13 @@ class FakeCursor:
         self._conn.executed.append((" ".join(sql.split()), params))
         # let a test preload a rowcount/result for the next fetch
         self.rowcount = self._conn.next_rowcount
-        self._result = self._conn.next_result
+        # A multi-query method (e.g. fetch_current_initiatives issues a to_regclass
+        # guard THEN a SELECT) can preload a per-execute result queue; otherwise every
+        # execute sees the single `next_result`.
+        if self._conn.result_queue:
+            self._result = self._conn.result_queue.pop(0)
+        else:
+            self._result = self._conn.next_result
 
     def fetchall(self):
         return self._result
@@ -43,6 +49,7 @@ class FakeConn:
         self.commits = 0
         self.next_rowcount = 0
         self.next_result = []
+        self.result_queue = []
 
     def cursor(self, cursor_factory=None):
         return FakeCursor(self)
@@ -71,6 +78,10 @@ def test_ensure_schema_issues_add_column_migration():
     # ... AND the idempotent migration for the pre-existing live table is issued.
     assert any("ALTER TABLE mail_actions ADD COLUMN IF NOT EXISTS thread_key text" in s
                for s in sqls)
+    # ... AND the additive surface-only initiative-router column migration.
+    assert any(
+        "ALTER TABLE mail_actions ADD COLUMN IF NOT EXISTS related_initiative text" in s
+        for s in sqls)
     assert conn.commits == 1
 
 
@@ -89,7 +100,23 @@ def test_insert_action_includes_thread_key_column_and_param():
     assert params["thread_key"] == "tk1"
 
 
-def test_insert_action_defaults_thread_key_null_when_absent():
+def test_insert_action_includes_related_initiative_column_and_param():
+    db, conn = _db_with_conn()
+    conn.next_rowcount = 1
+    ok = db.insert_action({
+        "mail_id": 3, "message_id": "<m>", "from_addr": "a@b.com", "subject": "s",
+        "received_at": 100, "who": "w", "ask": "a", "deadline": None, "amount": None,
+        "confidence": 0.9, "reason": "r", "thread_key": "tk1",
+        "related_initiative": "clawgate-chat-polish",
+    })
+    assert ok is True
+    sql, params = conn.executed[-1]
+    assert "related_initiative" in sql
+    assert "%(related_initiative)s" in sql
+    assert params["related_initiative"] == "clawgate-chat-polish"
+
+
+def test_insert_action_defaults_thread_key_and_related_null_when_absent():
     db, conn = _db_with_conn()
     conn.next_rowcount = 1
     db.insert_action({
@@ -99,6 +126,28 @@ def test_insert_action_defaults_thread_key_null_when_absent():
     })
     _sql, params = conn.executed[-1]
     assert params["thread_key"] is None
+    assert params["related_initiative"] is None
+
+
+def test_fetch_current_initiatives_absent_view_returns_empty():
+    db, conn = _db_with_conn()
+    # to_regclass('initiatives.current') → NULL when the Phase-1 sync isn't deployed.
+    conn.next_result = [(None,)]
+    assert db.fetch_current_initiatives() == []
+    sql, _ = conn.executed[-1]
+    assert "to_regclass('initiatives.current')" in sql
+
+
+def test_fetch_current_initiatives_reads_view_when_present():
+    db, conn = _db_with_conn()
+    # Execute #1 (to_regclass) → a non-NULL regclass tuple; execute #2 (SELECT) → rows.
+    row = {"slug": "clawgate-chat-polish", "repo": "/r/devrc",
+           "title": "Clawgate chat polish"}
+    conn.result_queue = [[("initiatives.current",)], [row]]
+    rows = db.fetch_current_initiatives()
+    assert rows == [row]
+    sql, _ = conn.executed[-1]
+    assert "SELECT slug, repo, title FROM initiatives.current" in sql
 
 
 def test_supersede_open_actions_sql_has_timestamp_guard():

--- a/scripts/mail-actions/tests/test_routing_tag.py
+++ b/scripts/mail-actions/tests/test_routing_tag.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Unit tests for the PURE surface-only tagging helper `related_initiative_slug`.
+
+Offline: no live DB, no port-forward. The helper loads the shared router
+(`scripts/initiatives/route.py`) by explicit importlib path and ranks a mail
+subject against a fixture `initiatives.current` set, returning the top slug ONLY
+when confident. Loading route runs the scan's lazy `import chquery` (needs
+`requests` + `scripts/validation` on sys.path) exactly as the initiatives
+`test_route.py` does in the same hermetic sandbox.
+
+Contract under test (the tagging rule the task specifies):
+  - confident top match           → that initiative's slug
+  - non-confident / no overlap    → None
+  - empty store / empty subject    → None
+  - ANY exception in the router    → None (swallowed; caller keeps going)
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import extract  # noqa: E402
+
+
+# Fixture initiatives — the router only reads slug/repo/title.
+INITIATIVES = [
+    {"slug": "clawgate-chat-polish", "repo": "/repo/devrc",
+     "title": "Clawgate chat polish"},
+    {"slug": "activity-telemetry", "repo": "/repo/devrc",
+     "title": "Activity telemetry pipeline"},
+    {"slug": "mail-actions-routing", "repo": "/repo/devrc",
+     "title": "Mail actions routing"},
+]
+
+
+def test_confident_match_returns_slug():
+    slug = extract.related_initiative_slug(
+        "Re: clawgate chat polish feedback", INITIATIVES)
+    assert slug == "clawgate-chat-polish"
+
+
+def test_single_distinctive_slug_token_is_confident():
+    # One slug hit, but 'telemetry' is unique to that initiative → confident.
+    slug = extract.related_initiative_slug(
+        "question about telemetry retention", INITIATIVES)
+    assert slug == "activity-telemetry"
+
+
+def test_non_confident_subject_returns_none():
+    # No slug/title token overlaps any initiative → no match.
+    slug = extract.related_initiative_slug(
+        "Your parcel has shipped", INITIATIVES)
+    assert slug is None
+
+
+def test_empty_store_returns_none():
+    assert extract.related_initiative_slug("clawgate chat polish", []) is None
+
+
+def test_empty_subject_returns_none():
+    assert extract.related_initiative_slug("", INITIATIVES) is None
+    assert extract.related_initiative_slug(None, INITIATIVES) is None
+
+
+def test_router_exception_is_swallowed(monkeypatch, capsys):
+    def _boom():
+        raise RuntimeError("scan matcher exploded")
+
+    monkeypatch.setattr(extract, "_route", _boom)
+    slug = extract.related_initiative_slug("clawgate chat polish", INITIATIVES)
+    assert slug is None
+    # Failure reported to stderr, never raised.
+    assert "initiative routing failed" in capsys.readouterr().err
+
+
+def test_rank_matches_exception_is_swallowed(monkeypatch):
+    # Even if rank_matches itself blows up mid-call, the helper returns None.
+    class _BadRoute:
+        @staticmethod
+        def rank_matches(*a, **k):
+            raise ValueError("bad rank")
+
+    monkeypatch.setattr(extract, "_route", lambda: _BadRoute)
+    assert extract.related_initiative_slug("clawgate chat polish", INITIATIVES) is None

--- a/scripts/mail-actions/tests/test_run_routing.py
+++ b/scripts/mail-actions/tests/test_run_routing.py
@@ -39,7 +39,7 @@ def _raw_with_pdf(from_addr, subject, filename):
 class FakeMailDB:
     """Mirrors _db.MailDB's run surface, in memory; rows may carry a `raw` value."""
 
-    def __init__(self, rows):
+    def __init__(self, rows, initiatives=None):
         self._mail = {}
         for r in rows:
             r = dict(r)
@@ -49,6 +49,11 @@ class FakeMailDB:
             self._mail[r["id"]] = r
         self.actions = {}
         self.commits = 0
+        # Surface-only initiative router: the once-per-run current-initiatives set.
+        self._initiatives = list(initiatives or [])
+
+    def fetch_current_initiatives(self):
+        return list(self._initiatives)
 
     def __enter__(self):
         return self
@@ -285,3 +290,119 @@ def test_summary_reports_invoice_and_superseded_counters(monkeypatch, capsys):
     assert summary["superseded"] == 1
     assert summary["action_required"] == 1   # the thread's newest (T1)
     assert summary["survivors"] == 3
+
+
+# --------------------------------------------------------------------------- #
+# Surface-only initiative routing (Phase 2) — cmd_run integration.
+# --------------------------------------------------------------------------- #
+# The current-initiatives fixture set (only slug/repo/title are read by the router).
+_INITIATIVES = [
+    {"slug": "clawgate-chat-polish", "repo": "/repo/devrc",
+     "title": "Clawgate chat polish"},
+    {"slug": "activity-telemetry", "repo": "/repo/devrc",
+     "title": "Activity telemetry pipeline"},
+]
+
+
+def test_confident_match_tags_action_and_counts_routed(monkeypatch, capsys):
+    # Subject shares clawgate/chat/polish with the slug → a confident router match.
+    rows = [
+        {"id": 30, "message_id": "<cg@x>", "from_addr": "sender@example.com",
+         "subject": "Re: clawgate chat polish feedback", "received_at": 100,
+         "category": "personal", "headers": {}, "text_body": "thoughts?"},
+    ]
+    db = FakeMailDB(rows, initiatives=_INITIATIVES)
+    _run(monkeypatch, db, CountingLLM(action_required=True))
+
+    # The inserted action carries the routed slug (surface-only tag).
+    assert db.actions[30]["related_initiative"] == "clawgate-chat-polish"
+
+
+def test_confident_match_reports_routed_in_summary(monkeypatch, capsys):
+    rows = [
+        {"id": 31, "message_id": "<cg2@x>", "from_addr": "sender@example.com",
+         "subject": "clawgate chat polish", "received_at": 100,
+         "category": "personal", "headers": {}, "text_body": "x"},
+    ]
+    db = FakeMailDB(rows, initiatives=_INITIATIVES)
+    import json as _json
+    import _db
+    monkeypatch.setattr(_db, "MailDB", lambda *a, **k: db)
+    monkeypatch.setattr(llm, "extract", CountingLLM(action_required=True))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    args = types.SimpleNamespace(dry_run=False, limit=150, model=None,
+                                 emit_clawgate=False, json=True)
+    extract.cmd_run(args)
+    summary = _json.loads(capsys.readouterr().out)
+    assert summary["routed"] == 1
+    assert summary["action_required"] == 1
+
+
+def test_non_confident_subject_leaves_action_untagged(monkeypatch, capsys):
+    # No meaningful token overlap with any initiative → no tag, routed stays 0.
+    rows = [
+        {"id": 32, "message_id": "<nc@x>", "from_addr": "sender@example.com",
+         "subject": "Your parcel has shipped", "received_at": 100,
+         "category": "personal", "headers": {}, "text_body": "tracking"},
+    ]
+    db = FakeMailDB(rows, initiatives=_INITIATIVES)
+    _run(monkeypatch, db, CountingLLM(action_required=True))
+    assert db.actions[32]["related_initiative"] is None
+
+
+def test_empty_initiative_store_leaves_action_untagged(monkeypatch, capsys):
+    # Phase-1 sync not deployed → fetch_current_initiatives() returns [] → no tag,
+    # and the extraction proceeds exactly as before.
+    rows = [
+        {"id": 33, "message_id": "<es@x>", "from_addr": "sender@example.com",
+         "subject": "clawgate chat polish", "received_at": 100,
+         "category": "personal", "headers": {}, "text_body": "x"},
+    ]
+    db = FakeMailDB(rows, initiatives=[])
+    _run(monkeypatch, db, CountingLLM(action_required=True))
+    assert db.actions[33]["related_initiative"] is None
+    assert db._mail[33]["labels"] == ["action-required"]
+
+
+def test_router_exception_is_swallowed_extraction_continues(monkeypatch, capsys):
+    # A hard failure inside the router (e.g. the scan matcher blowing up) must NEVER
+    # break extraction — the action is still inserted, untagged.
+    rows = [
+        {"id": 34, "message_id": "<ex@x>", "from_addr": "sender@example.com",
+         "subject": "clawgate chat polish", "received_at": 100,
+         "category": "personal", "headers": {}, "text_body": "x"},
+    ]
+    db = FakeMailDB(rows, initiatives=_INITIATIVES)
+
+    def _boom():
+        raise RuntimeError("router import exploded")
+
+    monkeypatch.setattr(extract, "_route", _boom)
+    _run(monkeypatch, db, CountingLLM(action_required=True))
+
+    # Extraction completed: action inserted + labelled, just with NO tag.
+    assert set(db.actions) == {34}
+    assert db.actions[34]["related_initiative"] is None
+    assert db._mail[34]["labels"] == ["action-required"]
+    # The failure was reported to stderr, not raised.
+    assert "initiative routing failed" in capsys.readouterr().err
+
+
+def test_store_read_failure_is_swallowed(monkeypatch, capsys):
+    # fetch_current_initiatives() itself raising must degrade to no-tag, not crash.
+    rows = [
+        {"id": 35, "message_id": "<sr@x>", "from_addr": "sender@example.com",
+         "subject": "clawgate chat polish", "received_at": 100,
+         "category": "personal", "headers": {}, "text_body": "x"},
+    ]
+    db = FakeMailDB(rows, initiatives=_INITIATIVES)
+
+    def _boom():
+        raise RuntimeError("store read exploded")
+
+    monkeypatch.setattr(db, "fetch_current_initiatives", _boom)
+    _run(monkeypatch, db, CountingLLM(action_required=True))
+
+    assert db.actions[35]["related_initiative"] is None
+    assert db._mail[35]["labels"] == ["action-required"]
+    assert "initiative store read failed" in capsys.readouterr().err


### PR DESCRIPTION
Wires the Phase-2 initiatives **router** (`scripts/initiatives/route.py`, shipped in #137) into **mail-actions**. When the extractor pulls an action-required item off a thread, it tags it with the existing **initiative it relates to** (if any), so the queue shows e.g. `relates to: clawgate-chat-polish`. **Surface-only — it displays a relation, it takes NO action.**

### ⚠️ Live-table change — please review before merge
`ensure_schema` now issues an **additive, nullable** migration on the live `mail_actions` table:
```sql
ALTER TABLE mail_actions ADD COLUMN IF NOT EXISTS related_initiative text
```
Same idempotent pattern as the existing `thread_key` column. No existing column or behavior is altered; legacy rows and any action with no confident match stay `NULL`. Nothing keys off it — it is pure display metadata.

### Where it hooks in
- **Load once per run** — `MailDB.fetch_current_initiatives()` (new, `_db.py`) reads `initiatives.current` reusing the **already-open** mailbox connection (no 2nd port-forward). Returns `[]` via a `to_regclass` guard when the Phase-1 sync isn't deployed on the host.
- **Per action** — `related_initiative_slug(subject, initiatives)` (`extract.py`) ranks the mail **subject** and takes `ranked[0]` **only when `confident`**. `route.py` is loaded by **explicit importlib path** (NOT on `sys.path` — avoids the `llm.py` shadow trap).
- **Surfaces** as `relates to: <slug>` in `extract.py list`, on the clawgate card `source_ref`, a persisted `related_initiative` column, and a `routed` counter in the run summary.

### Best-effort wrapping (the queue is unchanged on any failure)
The store read and every per-action routing call are wrapped in `try/except`: a router/DB/import failure logs a warning to stderr and the action is queued **untagged**. Extraction/queue behave exactly as before.

### Tests (+16, full hermetic `run-tests.sh` passes)
- `test_routing_tag.py` (new) — pure `related_initiative_slug`: confident match, single-distinctive-token, non-confident → None, empty store → None, empty subject → None, swallowed exceptions (`_route` + `rank_matches` raising).
- `test_run_routing.py` — cmd_run integration: tag applied + `routed` counter; non-confident / empty store untagged; **router exception** and **store-read exception** both swallowed with the action still inserted + labelled.
- `test_db_schema.py` — the additive `related_initiative` column migration, insert column/param + NULL default, `fetch_current_initiatives` absent-view (`[]`) and present-view SQL.

### Residual risk
- Untested against the **live** DB — verified via the offline hermetic suite only (mocked connection; no port-forward). The additive column write on the real table has not been exercised.
- Router matching is word-equality (no stemming), inherited from the scan — `polish` ≠ `polishing`; expect misses on morphological variants of the subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)