### PR TITLE
feat(initiatives): Phase 3 — live web viewer over the store

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -806,6 +806,62 @@ in
     };
   };
 
+  # Initiatives consolidation (PHASE 3) — the LIVE WEB VIEWER over the Phase-1 store.
+  # A long-running stdlib-http.server (scripts/initiatives/viewer.py, launched by
+  # run-viewer.sh) that renders the current initiatives from `initiatives.latest`
+  # (ghost-free: newest snapshot only) grouped by repo, with momentum badges,
+  # next-step, open PRs, and a LIVE tmux overlay read from THIS host at render time.
+  # It is the durable, browser-viewable counterpart to the ephemeral agent-ops TUI.
+  #
+  # WORKBENCH-ONLY (gated on serverMode), same rationale as the sync: the homelab
+  # kubeconfig is direct-LAN only here, AND the viewer must run on the host whose
+  # tmux server it reads (the live overlay). It binds a workbench-LAN address
+  # (192.168.50.94:8899) — internal work data, deliberately NOT wired into the public
+  # homelab gateway. Public exposure would be a later, explicit choice.
+  #
+  # UNLIKE the sync it needs NO ClickHouse/sops creds (it only READS the already-synced
+  # store — no telemetry query), so it's enabled directly under serverMode with no
+  # off-by-default master switch: it's read-only and low-risk. Crash-loop safety is in
+  # the CODE, not the unit — every store read is per-request and a DB outage renders an
+  # error page while the process keeps serving, so Restart=on-failure only ever fires on
+  # a genuine process crash (e.g. the port already bound), backed off by RestartSec.
+  #
+  # Minimal user-unit env, so PATH is explicit: nix (nix-shell) + kubectl (the
+  # port-forward) + git (the scan's repo/worktree discovery for the overlay) + tmux (the
+  # live pane read) + bash/coreutils, and NIX_PATH so `nix-shell -p` resolves <nixpkgs>.
+  # The wrapper's nix-shell adds psycopg2 (the DB read) + requests (the scan import).
+  systemd.user.services.initiatives-viewer = lib.mkIf serverMode {
+    Unit = {
+      Description = "Initiatives live web viewer — initiatives.latest + live tmux overlay";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+      OnFailure = [ "notify-failure@%n.service" ];
+    };
+    Service = {
+      Type = "simple";
+      Environment = [
+        "PATH=${lib.makeBinPath [ pkgs.nix pkgs.kubectl pkgs.git pkgs.tmux pkgs.bash pkgs.coreutils pkgs.gnused pkgs.gnugrep ]}"
+        "NIX_PATH=nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos"
+        "KUBECONFIG=%h/workspace/homelab-talos/homelab-kubeconfig"
+        "INITIATIVES_VIEWER_HOST=192.168.50.94"
+        "INITIATIVES_VIEWER_PORT=8899"
+        "HOME=%h"
+      ];
+      ExecStart = "${pkgs.bash}/bin/bash %h/workspace/devrc/scripts/initiatives/run-viewer.sh";
+      # Only ever restarts on a real crash (see the crash-loop note above); back off so a
+      # persistently-unbindable port doesn't spin.
+      Restart = "on-failure";
+      RestartSec = "10s";
+      X-Restart-Triggers = [
+        "${../scripts/initiatives/run-viewer.sh}"
+        "${../scripts/initiatives/viewer.py}"
+      ];
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
+
   # Repo chief-of-staff — WEEKLY: deterministic scan of Zach's repos for improvement
   # signals (TODO/FIXME, skipped tests, `latest` tags, churn, large files) → cheap LLM
   # synthesis (OpenRouter) → ranked proposal digest EMAILED. The "agents bring me ideas"

--- a/scripts/initiatives/run-viewer.sh
+++ b/scripts/initiatives/run-viewer.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Long-running launcher for the initiatives live web viewer (Phase 3).
+#
+# Serves scripts/initiatives/viewer.py: an auto-refreshing HTML page over the
+# homelab `mailbox` Postgres `initiatives.latest` view (read via a kubectl
+# port-forward), plus a LIVE tmux overlay read from THIS host at render time.
+# Binds a workbench-LAN address by default; NOT wired into the public gateway.
+#
+# Unlike run-sync.sh this needs NO ClickHouse/sops creds — the viewer only READS
+# the already-synced store; it does not re-run the scan's telemetry query. The scan
+# module is imported ONLY for its tmux machinery (best-effort; absent if no server).
+#
+# Requirements on PATH/env (provided by the systemd unit or the login shell):
+#   KUBECONFIG  — homelab kubeconfig (the DB is only reachable via port-forward)
+#   kubectl     — the port-forward
+#   git         — the scan's repo/worktree discovery for the tmux overlay
+#   tmux        — the live pane read (overlay degrades to absent if missing)
+# The nix-shell below adds psycopg2 (the DB read) + requests (the scan import).
+#
+# Run by hand or via systemd:  systemctl --user start initiatives-viewer.service
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# KUBECONFIG defaults to the homelab admin config; the unit also sets it, but keep a
+# default so the wrapper works when invoked from an interactive shell.
+export KUBECONFIG="${KUBECONFIG:-${HOME}/workspace/homelab-talos/homelab-kubeconfig}"
+
+# Bind address/port — workbench-LAN by default; override to 127.0.0.1 for local-only.
+HOST="${INITIATIVES_VIEWER_HOST:-192.168.50.94}"
+PORT="${INITIATIVES_VIEWER_PORT:-8899}"
+
+exec nix-shell -p 'python3.withPackages(p:[p.psycopg2 p.requests])' \
+  --run "python ${SCRIPT_DIR}/viewer.py --host ${HOST} --port ${PORT}"

--- a/scripts/initiatives/sync.py
+++ b/scripts/initiatives/sync.py
@@ -106,10 +106,15 @@ CREATE INDEX IF NOT EXISTS snapshots_captured_at_idx
     ON initiatives.snapshots (captured_at);
 """
 
-# The `current` view is guarded separately (see ensure_schema): re-running
+# The views are guarded separately (see ensure_schema / _ensure_view): re-running
 # CREATE OR REPLACE VIEW takes an ACCESS EXCLUSIVE lock every time, so we only
-# (re)create it when it's absent or its version marker differs. Bump VIEW_VERSION
-# whenever VIEW_DDL changes so a deploy recreates it.
+# (re)create a view when it's absent or its version marker differs. Bump the
+# matching *_VERSION whenever its DDL changes so a deploy recreates it.
+#
+# `current` — newest row per (repo, slug) across ALL history. This deliberately
+# includes initiatives that have aged out of the scan's N-day window (until the
+# 90-day retention prunes them): the ROUTER wants to match a signal against
+# recently-dormant work, so ghosts are a feature there.
 VIEW_VERSION = "v1"
 VIEW_COMMENT = f"initiatives-sync view {VIEW_VERSION}"
 VIEW_DDL = """
@@ -119,6 +124,21 @@ SELECT DISTINCT ON (i.repo, i.slug)
   FROM initiatives.initiative_snapshot i
   JOIN initiatives.snapshots s ON s.id = i.snapshot_id
  ORDER BY i.repo, i.slug, s.captured_at DESC;
+"""
+
+# `latest` — rows from the MOST RECENT snapshot only. This is the correct view for
+# a live VIEWER: it shows exactly what the last scan saw, with NO aged-out ghosts
+# (an initiative that dropped out of the scan's window simply isn't in the newest
+# snapshot, so it disappears here even though `current` still carries it). Carries
+# `captured_at` so the viewer can render an "updated Xm ago" freshness footer.
+LATEST_VIEW_VERSION = "v1"
+LATEST_VIEW_COMMENT = f"initiatives-sync view latest {LATEST_VIEW_VERSION}"
+LATEST_VIEW_DDL = """
+CREATE OR REPLACE VIEW initiatives.latest AS
+SELECT i.*, s.captured_at
+  FROM initiatives.initiative_snapshot i
+  JOIN initiatives.snapshots s ON s.id = i.snapshot_id
+ WHERE i.snapshot_id = (SELECT max(id) FROM initiatives.snapshots);
 """
 
 # Arbitrary constant key for the schema advisory lock (pg_advisory_xact_lock), so a
@@ -276,30 +296,40 @@ def _import_maildb():
     return mod.MailDB
 
 
+def _ensure_view(cur, view: str, ddl: str, comment: str) -> None:
+    """(Re)create a guarded view ONLY when it's missing or its version marker differs.
+
+    CREATE OR REPLACE VIEW takes an ACCESS EXCLUSIVE lock every run, so we gate it on
+    a version-marker `COMMENT ON VIEW`: steady state (view present, marker matches)
+    does nothing. `view` is a trusted module constant (never user input) so
+    interpolating it into the introspection SQL is safe. Bump the view's *_VERSION to
+    force a recreate after a hand-edit to its DDL."""
+    cur.execute(f"SELECT to_regclass('{view}')")
+    exists = cur.fetchone()[0] is not None
+    need_view = True
+    if exists:
+        cur.execute(f"SELECT obj_description('{view}'::regclass, 'pg_class')")
+        row = cur.fetchone()
+        need_view = (row[0] if row else None) != comment
+    if need_view:
+        cur.execute(ddl)
+        cur.execute(f"COMMENT ON VIEW {view} IS %s", (comment,))
+
+
 def ensure_schema(conn) -> None:
-    """Create the schema/tables/indexes/view idempotently (self-migrating, additive-only).
+    """Create the schema/tables/indexes/views idempotently (self-migrating, additive-only).
 
     Wrapped in a transaction-scoped advisory lock so a manual run racing the timer
-    can't collide on the not-fully-race-safe CREATE … IF NOT EXISTS. The `current`
-    view is only (re)created when absent or its version marker differs — steady state
-    skips re-taking ACCESS EXCLUSIVE on it every run."""
+    can't collide on the not-fully-race-safe CREATE … IF NOT EXISTS. Each view
+    (`current` for the router, `latest` for the viewer) is only (re)created when
+    absent or its version marker differs — steady state skips re-taking ACCESS
+    EXCLUSIVE on either every run."""
     with conn.cursor() as cur:
         # Serialize concurrent schema setup (released at COMMIT below).
         cur.execute("SELECT pg_advisory_xact_lock(%s)", (SCHEMA_LOCK_KEY,))
         cur.execute(TABLES_DDL)
-
-        # View guard: (re)create only when missing or the version marker differs.
-        cur.execute("SELECT to_regclass('initiatives.current')")
-        exists = cur.fetchone()[0] is not None
-        need_view = True
-        if exists:
-            cur.execute(
-                "SELECT obj_description('initiatives.current'::regclass, 'pg_class')")
-            row = cur.fetchone()
-            need_view = (row[0] if row else None) != VIEW_COMMENT
-        if need_view:
-            cur.execute(VIEW_DDL)
-            cur.execute("COMMENT ON VIEW initiatives.current IS %s", (VIEW_COMMENT,))
+        _ensure_view(cur, "initiatives.current", VIEW_DDL, VIEW_COMMENT)
+        _ensure_view(cur, "initiatives.latest", LATEST_VIEW_DDL, LATEST_VIEW_COMMENT)
     conn.commit()
 
 

--- a/scripts/initiatives/tests/test_sync.py
+++ b/scripts/initiatives/tests/test_sync.py
@@ -267,6 +267,10 @@ class _FakeCursor:
         self._result = None
         if "to_regclass('initiatives.current')" in norm:
             self._result = (self._conn.view_regclass,)
+        elif "to_regclass('initiatives.latest')" in norm:
+            self._result = (self._conn.latest_regclass,)
+        elif "obj_description" in norm and "initiatives.latest" in norm:
+            self._result = (self._conn.latest_comment,)
         elif "obj_description" in norm:
             self._result = (self._conn.view_comment,)
         elif "RETURNING id" in norm:
@@ -280,11 +284,14 @@ class _FakeCursor:
 
 class _FakeConn:
     def __init__(self, *, view_regclass=None, view_comment=None,
+                 latest_regclass=None, latest_comment=None,
                  next_snapshot_id=1, delete_rowcount=0):
         self.executed = []
         self.commits = 0
         self.view_regclass = view_regclass
         self.view_comment = view_comment
+        self.latest_regclass = latest_regclass
+        self.latest_comment = latest_comment
         self.next_snapshot_id = next_snapshot_id
         self.delete_rowcount = delete_rowcount
 
@@ -347,6 +354,45 @@ def test_ensure_schema_recreates_view_when_version_differs():
     sync.ensure_schema(conn)
     joined = " ".join(_sqls(conn))
     assert "CREATE OR REPLACE VIEW initiatives.current" in joined
+
+
+# --- the `latest` view (viewer's ghost-free source) ------------------------- #
+def test_ensure_schema_creates_latest_view_when_absent():
+    conn = _FakeConn(latest_regclass=None)
+    sync.ensure_schema(conn)
+    joined = " ".join(_sqls(conn))
+    assert "CREATE OR REPLACE VIEW initiatives.latest" in joined
+    assert "COMMENT ON VIEW initiatives.latest" in joined
+    # rows from the most recent snapshot only (the ghost-free semantic)
+    assert "WHERE i.snapshot_id = (SELECT max(id) FROM initiatives.snapshots)" in joined
+
+
+def test_ensure_schema_skips_latest_view_when_present_and_version_matches():
+    conn = _FakeConn(latest_regclass="initiatives.latest",
+                     latest_comment=sync.LATEST_VIEW_COMMENT)
+    sync.ensure_schema(conn)
+    joined = " ".join(_sqls(conn))
+    assert "CREATE OR REPLACE VIEW initiatives.latest" not in joined
+
+
+def test_ensure_schema_recreates_latest_view_when_version_differs():
+    conn = _FakeConn(latest_regclass="initiatives.latest",
+                     latest_comment="initiatives-sync view latest v0")
+    sync.ensure_schema(conn)
+    joined = " ".join(_sqls(conn))
+    assert "CREATE OR REPLACE VIEW initiatives.latest" in joined
+
+
+def test_ensure_schema_manages_both_views_independently():
+    # current present+matching (skip), latest absent (create) — the two guards don't
+    # interfere with one another.
+    conn = _FakeConn(view_regclass="initiatives.current", view_comment=sync.VIEW_COMMENT,
+                     latest_regclass=None)
+    sync.ensure_schema(conn)
+    joined = " ".join(_sqls(conn))
+    assert "CREATE OR REPLACE VIEW initiatives.current" not in joined
+    assert "CREATE OR REPLACE VIEW initiatives.latest" in joined
+    assert conn.commits == 1  # still one commit for the whole schema pass
 
 
 def test_prune_old_snapshots_issues_cascade_delete_and_returns_count():

--- a/scripts/initiatives/tests/test_viewer.py
+++ b/scripts/initiatives/tests/test_viewer.py
@@ -1,0 +1,291 @@
+"""Unit tests for the PURE render + HTTP-routing layers of viewer.py.
+
+Offline: no live DB, no live tmux, no sockets. We feed `build_model` fixture store
+rows and assert on the grouped/sorted render model (grouping by repo, momentum
+ordering, rel-age formatting, the "updated Xm ago" from captured_at), assert the HTML
+render given a fixture model (slug / momentum badge / tmux tag / footer), and smoke-test
+`route_request` with a fake provider (/healthz ok; / and /api return 200 + markers).
+The store read + tmux overlay (the I/O) are exercised only via a fake provider — mirroring
+how sync.py/route.py separate the pure transform from infra."""
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import viewer  # noqa: E402
+
+NOW = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _row(**over):
+    """A representative `initiatives.latest` row (the shape the viewer consumes)."""
+    r = {
+        "slug": "initiatives-viewer",
+        "repo": "/home/zach/workspace/devrc",
+        "title": "Initiatives consolidation Phase 3",
+        "momentum": "active",
+        "last_touch": NOW - timedelta(minutes=30),
+        "next_step": "wire the systemd unit",
+        "commits": 7,
+        "commits_unknown": False,
+        "merged_prs": 2,
+        "open_prs": [{"number": 138, "title": "feat: viewer"}],
+        "session_count": 3,
+        "telem_events": 42,
+        "current_doc": "/home/zach/workspace/devrc/claudedocs/handoff-x.md",
+        "open_investigations": ["does the tmux overlay hold under refresh churn?"],
+        "captured_at": NOW - timedelta(minutes=6),
+    }
+    r.update(over)
+    return r
+
+
+# --- rel_age ---------------------------------------------------------------- #
+def test_rel_age_buckets():
+    assert viewer.rel_age(NOW - timedelta(seconds=10), NOW) == "now"
+    assert viewer.rel_age(NOW - timedelta(minutes=5), NOW) == "5m"
+    assert viewer.rel_age(NOW - timedelta(hours=3), NOW) == "3h"
+    assert viewer.rel_age(NOW - timedelta(days=2), NOW) == "2d"
+    assert viewer.rel_age(NOW - timedelta(days=21), NOW) == "3w"
+
+
+def test_rel_age_none_is_dash():
+    assert viewer.rel_age(None, NOW) == "—"
+    assert viewer.rel_age("not-a-datetime", NOW) == "—"
+
+
+def test_rel_age_future_clamps_to_now():
+    # clock skew: a captured_at slightly ahead of `now` must not go negative
+    assert viewer.rel_age(NOW + timedelta(seconds=30), NOW) == "now"
+
+
+def test_rel_age_coerces_naive_datetime_to_utc():
+    naive = (NOW - timedelta(hours=2)).replace(tzinfo=None)
+    assert viewer.rel_age(naive, NOW) == "2h"
+
+
+# --- momentum_badge --------------------------------------------------------- #
+def test_momentum_badge_known_and_unknown():
+    assert viewer.momentum_badge("active") == ("●", "active")
+    assert viewer.momentum_badge("slowing") == ("◐", "slowing")
+    assert viewer.momentum_badge("stalled") == ("○", "stalled")
+    assert viewer.momentum_badge(None) == ("·", "unknown")
+    assert viewer.momentum_badge("bogus") == ("·", "unknown")
+
+
+# --- build_model: grouping + ordering + freshness --------------------------- #
+def test_build_model_groups_by_repo():
+    rows = [
+        _row(slug="a", repo="/home/zach/workspace/devrc"),
+        _row(slug="b", repo="/home/zach/workspace/devrc"),
+        _row(slug="c", repo="/home/zach/workspace/homelab"),
+    ]
+    model = viewer.build_model(rows, now=NOW)
+    assert model["total"] == 3
+    assert model["repo_count"] == 2
+    names = {g["name"]: [i["slug"] for i in g["initiatives"]] for g in model["repos"]}
+    assert names == {"devrc": ["a", "b"], "homelab": ["c"]}
+
+
+def test_build_model_orders_initiatives_by_momentum_then_recency():
+    rows = [
+        _row(slug="stalled-old", momentum="stalled", last_touch=NOW - timedelta(days=10)),
+        _row(slug="active-older", momentum="active", last_touch=NOW - timedelta(hours=5)),
+        _row(slug="active-newer", momentum="active", last_touch=NOW - timedelta(minutes=5)),
+        _row(slug="slowing-mid", momentum="slowing", last_touch=NOW - timedelta(days=3)),
+    ]
+    model = viewer.build_model(rows, now=NOW)
+    order = [i["slug"] for i in model["repos"][0]["initiatives"]]
+    # active (newest first), then slowing, then stalled
+    assert order == ["active-newer", "active-older", "slowing-mid", "stalled-old"]
+
+
+def test_build_model_orders_repos_by_best_momentum():
+    rows = [
+        _row(slug="q", repo="/ws/quietrepo", momentum="stalled",
+             last_touch=NOW - timedelta(days=9)),
+        _row(slug="h", repo="/ws/hotrepo", momentum="active",
+             last_touch=NOW - timedelta(minutes=2)),
+    ]
+    model = viewer.build_model(rows, now=NOW)
+    assert [g["name"] for g in model["repos"]] == ["hotrepo", "quietrepo"]
+
+
+def test_build_model_captured_age_from_newest_captured_at():
+    rows = [
+        _row(slug="a", captured_at=NOW - timedelta(minutes=6)),
+        _row(slug="b", captured_at=NOW - timedelta(minutes=6)),
+    ]
+    model = viewer.build_model(rows, now=NOW)
+    assert model["captured_at"] == NOW - timedelta(minutes=6)
+    assert model["captured_age"] == "6m"
+
+
+def test_build_model_empty_rows_is_wellformed():
+    model = viewer.build_model([], now=NOW)
+    assert model["total"] == 0
+    assert model["repos"] == []
+    assert model["captured_at"] is None
+    assert model["captured_age"] is None
+
+
+def test_build_model_carries_tmux_sessions_into_view():
+    rows = [_row(slug="a")]
+    rows[0]["tmux_sessions"] = {"Vapor-2", "main:8-1"}
+    model = viewer.build_model(rows, now=NOW)
+    v = model["repos"][0]["initiatives"][0]
+    assert v["tmux_sessions"] == ["Vapor-2", "main:8-1"]  # sorted
+
+
+def test_build_model_none_repo_becomes_unknown_group():
+    model = viewer.build_model([_row(slug="a", repo=None)], now=NOW)
+    assert model["repos"][0]["name"] == "(unknown repo)"
+
+
+# --- HTML render ------------------------------------------------------------ #
+def test_render_html_contains_slug_badge_tmux_and_footer():
+    rows = [_row(slug="initiatives-viewer")]
+    rows[0]["tmux_sessions"] = {"Vapor-2"}
+    model = viewer.build_model(rows, now=NOW)
+    html = viewer.render_html(model)
+    assert "initiatives-viewer" in html            # a slug
+    assert "●" in html and "active" in html         # a momentum badge glyph + label
+    assert "[tmux:Vapor-2]" in html                 # a tmux tag
+    assert "wire the systemd unit" in html          # the next-step
+    assert "#138" in html                           # the open PR
+    assert "hourly sync" in html                    # the footer
+    assert "2026-07-22 11:54 UTC" in html           # captured_at in the footer
+    assert 'http-equiv="refresh"' in html           # auto-refresh wired
+    assert html.startswith("<!doctype html>")
+
+
+def test_render_html_escapes_untrusted_text():
+    model = viewer.build_model([_row(title="<script>alert(1)</script>")], now=NOW)
+    html = viewer.render_html(model)
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_render_html_error_page_when_store_unreachable():
+    html = viewer.render_html(None, error="OperationalError: connection refused")
+    assert "store unreachable" in html
+    assert "connection refused" in html
+    assert html.startswith("<!doctype html>")
+
+
+def test_render_html_empty_model_shows_empty_message():
+    model = viewer.build_model([], now=NOW)
+    html = viewer.render_html(model)
+    assert "No initiatives" in html
+
+
+# --- JSON payload ----------------------------------------------------------- #
+def test_model_to_json_ok_and_error():
+    model = viewer.build_model([_row(slug="a")], now=NOW)
+    ok = viewer.model_to_json(model, None)
+    assert ok["ok"] is True and ok["total"] == 1 and ok["repo_count"] == 1
+    err = viewer.model_to_json(None, "boom")
+    assert err["ok"] is False and err["error"] == "boom" and err["repos"] == []
+
+
+# --- HTTP routing (fake provider — no server, no DB) ------------------------ #
+class _FakeProvider:
+    def __init__(self, model=None, error=None):
+        self._model = model
+        self._error = error
+        self.calls = 0
+
+    def snapshot(self):
+        self.calls += 1
+        return self._model, self._error
+
+
+def test_route_healthz_is_ok_and_store_independent():
+    prov = _FakeProvider(error="db down")  # even with the store down, healthz is ok
+    status, ctype, body = viewer.route_request("/healthz", prov)
+    assert status == 200
+    assert body == b"ok\n"
+    assert prov.calls == 0  # healthz must NOT touch the store
+
+
+def test_route_root_returns_html_200():
+    model = viewer.build_model([_row(slug="routed-slug")], now=NOW)
+    status, ctype, body = viewer.route_request("/", _FakeProvider(model=model))
+    assert status == 200
+    assert "text/html" in ctype
+    assert b"routed-slug" in body
+
+
+def test_route_root_renders_error_page_on_store_failure():
+    status, ctype, body = viewer.route_request("/", _FakeProvider(error="OperationalError"))
+    assert status == 200  # still a valid page, degrades gracefully
+    assert b"store unreachable" in body
+
+
+def test_route_api_json_200_and_parseable():
+    model = viewer.build_model([_row(slug="api-slug")], now=NOW)
+    status, ctype, body = viewer.route_request("/api/initiatives.json",
+                                               _FakeProvider(model=model))
+    assert status == 200
+    assert "application/json" in ctype
+    payload = json.loads(body)
+    assert payload["ok"] is True
+    assert payload["repos"][0]["initiatives"][0]["slug"] == "api-slug"
+
+
+def test_route_unknown_path_404():
+    status, _ctype, body = viewer.route_request("/nope", _FakeProvider())
+    assert status == 404
+    assert b"not found" in body
+
+
+# --- DataProvider (caching + graceful error, fake loader/tmux) -------------- #
+def test_provider_caches_within_ttl():
+    calls = {"n": 0}
+
+    def loader():
+        calls["n"] += 1
+        return [_row(slug="cached")]
+
+    prov = viewer.DataProvider(ttl=60, loader=loader, tmux=lambda rows: True,
+                               now_fn=lambda: NOW)
+    m1, e1 = prov.snapshot()
+    m2, e2 = prov.snapshot()
+    assert e1 is None and e2 is None
+    assert calls["n"] == 1  # second call served from cache
+    assert m1 is m2
+
+
+def test_provider_returns_error_tuple_on_loader_failure():
+    def boom():
+        raise RuntimeError("port-forward exited early")
+
+    prov = viewer.DataProvider(ttl=60, loader=boom, tmux=lambda rows: True,
+                               now_fn=lambda: NOW)
+    model, error = prov.snapshot()
+    assert model is None
+    assert "port-forward exited early" in error
+    assert error.startswith("RuntimeError")
+
+
+def test_attach_tmux_is_best_effort_on_scan_failure(monkeypatch):
+    # The live tmux overlay is a nicety: if importing/using the scan blows up, attach_tmux
+    # must swallow it, return False, and leave the rows untouched (no crash, overlay absent).
+    def boom():
+        raise RuntimeError("scan import failed")
+
+    monkeypatch.setattr(viewer, "_scan", boom)
+    rows = [_row(slug="ok")]
+    assert viewer.attach_tmux(rows) is False
+    assert "tmux_sessions" not in rows[0]  # untouched
+
+
+def test_attach_tmux_absent_when_no_tmux_server(monkeypatch):
+    # No panes = no tmux server on this host → overlay absent (False), not an error.
+    class _FakeScan:
+        collect_tmux_panes = staticmethod(lambda: [])
+
+    monkeypatch.setattr(viewer, "_scan", lambda: _FakeScan)
+    assert viewer.attach_tmux([_row(slug="ok")]) is False

--- a/scripts/initiatives/viewer.py
+++ b/scripts/initiatives/viewer.py
@@ -1,0 +1,614 @@
+#!/usr/bin/env python3
+"""Live web viewer over the Phase-1 initiatives store.
+
+PHASE 3 of the "initiatives consolidation" feature. A self-contained, auto-refreshing
+web page (stdlib `http.server`, NO web framework) that renders the CURRENT initiatives
+from the homelab `mailbox` Postgres — grouped by repo, with momentum badges, next-step,
+open PRs, and a LIVE tmux overlay (which tmux session is on each initiative right now).
+It is the durable, browser-viewable counterpart to the ephemeral agent-ops TUI.
+
+Data (two layers, both best-effort per request):
+  1. The STORE — `initiatives.latest` (rows from the most recent snapshot only, so NO
+     aged-out "ghosts" — unlike `initiatives.current`, which the router wants). Read via
+     `mail-actions/_db.py`'s kubectl port-forward. Falls back to an inline
+     `WHERE snapshot_id=(SELECT max(id) …)` query if the `latest` view doesn't exist yet
+     (i.e. before the next sync recreates the schema).
+  2. The LIVE tmux overlay — attached at RENDER TIME from THIS host's tmux server, reusing
+     the scan's machinery (`collect_tmux_panes` / `match_tmux_to_initiatives` / …) rather
+     than reimplementing it. Deliberately NOT stored in Postgres (the durable-vs-live split
+     the agent-ops dashboard uses). Absent if there's no tmux server (best-effort).
+
+Layering mirrors sync.py / route.py: the pure render transform (`build_model` /
+`render_html`) is separated from all I/O (the DB read, the tmux read, the HTTP server),
+so it is unit-testable with fixtures — no live DB, no live tmux, no sockets.
+
+Serving:
+  Routes: `/` (HTML), `/healthz` (200/ok — process liveness, NOT the DB), and
+  `/api/initiatives.json` (the JSON the page is built from). Binds LAN/localhost only by
+  default; NOT wired into the public homelab gateway — this is internal work data. A short
+  in-process cache (a few seconds) avoids hammering the port-forward on rapid refreshes.
+  A DB outage renders a clear error page and keeps serving (never crash-loops).
+
+Requires (for the live read; the pure render path needs none of these):
+    KUBECONFIG  — homelab kubeconfig (the DB is only reachable via kubectl port-forward)
+    kubectl     — on PATH
+    psycopg2    — python dep
+On NixOS run under:
+    nix-shell -p "python3.withPackages(p:[p.psycopg2 p.requests])" \
+      --run "python scripts/initiatives/viewer.py --host 127.0.0.1 --port 8899"
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import importlib.util
+import json
+import os
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlparse
+
+# The scan we borrow the tmux machinery from (hyphenated filename → importlib, not import).
+SCAN_PATH = Path(__file__).resolve().parents[1] / "session-analysis" / "initiative-scan.py"
+# chquery lives here; the scan adds it to sys.path on import, mirror that so the scan's
+# top-level `import chquery` resolves regardless of cwd.
+VALIDATION_DIR = Path(__file__).resolve().parents[1] / "validation"
+
+# The shared mailbox-Postgres helper (kubectl port-forward + psycopg2 + DSN-from-secret).
+MAILDB_PATH = Path(__file__).resolve().parents[1] / "mail-actions" / "_db.py"
+
+# The rich display columns the viewer reads (present on both `initiatives.latest` and the
+# base `initiative_snapshot` table, so the inline fallback selects the SAME set + captured_at).
+DISPLAY_COLUMNS = [
+    "slug", "repo", "title", "momentum", "last_touch", "next_step", "commits",
+    "commits_unknown", "merged_prs", "open_prs", "session_count", "telem_events",
+    "current_doc", "open_investigations",
+]
+
+# Momentum ordering + badges — SAME ranks/glyphs the scan uses (active→stalled→unknown).
+MOMENTUM_RANK = {"active": 0, "slowing": 1, "stalled": 2, "unknown": 3}
+MOMENTUM_BADGE = {
+    "active": ("●", "active"),    # ●
+    "slowing": ("◐", "slowing"),  # ◐
+    "stalled": ("○", "stalled"),  # ○
+    "unknown": ("·", "unknown"),  # ·
+}
+
+# Auto-refresh cadence for the page (seconds) — matches the "sync is hourly, but tmux is
+# live" story: a 30s refresh keeps the tmux overlay near-live without hammering the DB (the
+# provider cache absorbs the store reads).
+REFRESH_SECONDS = 30
+DEFAULT_HOST = "192.168.50.94"  # workbench-LAN bind; override with --host 127.0.0.1 for local
+DEFAULT_PORT = 8899
+CACHE_TTL_SECONDS = 5.0
+
+
+# --------------------------------------------------------------------------- #
+# Lazy imports of the two borrowed modules (single-sourced; not reimplemented).
+# --------------------------------------------------------------------------- #
+_scan_mod = None
+
+
+def _scan():
+    """Load initiative-scan.py by explicit path and cache it (for the tmux machinery).
+
+    Lazy + side-effect-light: the scan's top-level `import chquery` only runs the first
+    time the tmux overlay is attached. `chquery` needs `requests` + the
+    `scripts/validation` dir on sys.path; we add the latter idempotently, mirroring
+    route.py."""
+    global _scan_mod
+    if _scan_mod is None:
+        vdir = str(VALIDATION_DIR)
+        if vdir not in sys.path:
+            sys.path.insert(0, vdir)
+        spec = importlib.util.spec_from_file_location("initiative_scan_for_viewer", SCAN_PATH)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"cannot load {SCAN_PATH}")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        _scan_mod = mod
+    return _scan_mod
+
+
+def _import_maildb():
+    """Load MailDB from scripts/mail-actions/_db.py by EXPLICIT importlib path.
+
+    Do NOT put mail-actions/ on sys.path — its `llm.py` shadows other modules and breaks
+    callers (documented in the repo CLAUDE.md; sync.py/route.py/repo-cos hit the same
+    trap). `_db.py` imports only stdlib+psycopg2, so a standalone load is safe."""
+    spec = importlib.util.spec_from_file_location("initiatives_viewer_maildb", MAILDB_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {MAILDB_PATH}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.MailDB
+
+
+# --------------------------------------------------------------------------- #
+# I/O — read the store, then attach the live tmux overlay.
+# --------------------------------------------------------------------------- #
+def load_latest() -> list[dict]:
+    """Read the current initiatives from `initiatives.latest` → list of row dicts.
+
+    Prefers the `latest` view (newest snapshot only, no ghosts). If that view doesn't
+    exist yet (before the next sync recreates the schema), transparently falls back to
+    an inline `WHERE snapshot_id=(SELECT max(id) …)` query over the base table — the
+    same rows the view would return. Raises on an unreachable store; the provider turns
+    that into a graceful error page rather than crashing the server."""
+    import psycopg2
+    import psycopg2.extras
+
+    cols = ", ".join(DISPLAY_COLUMNS)
+    MailDB = _import_maildb()
+    with MailDB() as db:
+        with db.conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            try:
+                cur.execute(f"SELECT {cols}, captured_at FROM initiatives.latest")
+                return [dict(r) for r in cur.fetchall()]
+            except psycopg2.Error:
+                # View absent (or otherwise unqueryable): the transaction is now aborted,
+                # so roll back before the fallback query on the same connection.
+                db.conn.rollback()
+            icols = ", ".join(f"i.{c}" for c in DISPLAY_COLUMNS)
+            cur.execute(
+                f"SELECT {icols}, s.captured_at "
+                "FROM initiatives.initiative_snapshot i "
+                "JOIN initiatives.snapshots s ON s.id = i.snapshot_id "
+                "WHERE i.snapshot_id = (SELECT max(id) FROM initiatives.snapshots)"
+            )
+            return [dict(r) for r in cur.fetchall()]
+
+
+def attach_tmux(initiatives: list[dict]) -> bool:
+    """Attach live tmux sessions to each initiative (mutates `tmux_sessions`). Returns
+    True if the overlay was applied, False if absent (no tmux server / any failure).
+
+    Reuses the scan's machinery verbatim: `collect_tmux_panes` reads THIS host's panes,
+    `match_tmux_to_initiatives` links each pane's title to an initiative in its repo. The
+    viewer must run ON the host whose tmux we want to see (that's where its systemd unit
+    lives). Fully best-effort — no tmux server, no scan import, any error → overlay simply
+    absent, never fatal."""
+    try:
+        scan = _scan()
+        panes = scan.collect_tmux_panes()
+        if not panes:
+            return False  # no tmux server on this host → overlay absent (not an error)
+        repos = scan.discover_repos()
+        wt_map = scan.worktree_canonical_map(repos)
+        codenames = scan.load_scratch_codenames()
+        scan.match_tmux_to_initiatives(initiatives, panes, repos, wt_map, codenames)
+        return True
+    except Exception:  # noqa: BLE001 - the overlay is a nicety, never a hard dependency
+        return False
+
+
+# --------------------------------------------------------------------------- #
+# Pure render transform (rows -> model -> HTML). No I/O — unit-tested with fixtures.
+# --------------------------------------------------------------------------- #
+def _as_utc(dt) -> datetime | None:
+    """Coerce a value to a tz-aware UTC datetime (psycopg2 returns tz-aware; a naive
+    datetime is assumed UTC). None / non-datetime -> None."""
+    if not isinstance(dt, datetime):
+        return None
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def rel_age(dt, now: datetime) -> str:
+    """A compact 'time since' string: 'now', '5m', '3h', '2d', '4w'. None -> '—'.
+
+    Clamps a slightly-future timestamp (clock skew between the DB and this host) to
+    'now' rather than emitting a negative age."""
+    d = _as_utc(dt)
+    if d is None:
+        return "—"  # —
+    secs = (now - d).total_seconds()
+    if secs < 60:
+        return "now"
+    mins = secs / 60
+    if mins < 60:
+        return f"{int(mins)}m"
+    hours = mins / 60
+    if hours < 24:
+        return f"{int(hours)}h"
+    days = hours / 24
+    if days < 7:
+        return f"{int(days)}d"
+    return f"{int(days / 7)}w"
+
+
+def momentum_badge(momentum: str | None) -> tuple[str, str]:
+    """(glyph, label) for a momentum value; falls back to the 'unknown' badge."""
+    return MOMENTUM_BADGE.get(momentum or "unknown", MOMENTUM_BADGE["unknown"])
+
+
+def _short_repo(repo: str | None) -> str:
+    return os.path.basename(str(repo).rstrip("/")) if repo else "(unknown repo)"
+
+
+def _initiative_view(ini: dict, now: datetime) -> dict:
+    """One store row (+ any attached tmux_sessions) -> a flat, template-ready view dict."""
+    momentum = ini.get("momentum") or "unknown"
+    glyph, label = momentum_badge(momentum)
+    open_prs = ini.get("open_prs") or []
+    tmux = sorted(ini.get("tmux_sessions") or [])
+    return {
+        "slug": ini.get("slug") or "(no slug)",
+        "title": ini.get("title") or "",
+        "momentum": momentum,
+        "momentum_rank": MOMENTUM_RANK.get(momentum, 9),
+        "badge_glyph": glyph,
+        "badge_label": label,
+        "last_touch": _as_utc(ini.get("last_touch")),
+        "age": rel_age(ini.get("last_touch"), now),
+        "next_step": (ini.get("next_step") or "").strip(),
+        "commits": ini.get("commits") or 0,
+        "commits_unknown": bool(ini.get("commits_unknown")),
+        "merged_prs": ini.get("merged_prs") or 0,
+        "open_prs": [
+            {"number": p.get("number"), "title": p.get("title", "")}
+            for p in open_prs if isinstance(p, dict)
+        ],
+        "session_count": ini.get("session_count") or 0,
+        "telem_events": ini.get("telem_events") or 0,
+        "current_doc": ini.get("current_doc") or "",
+        "open_investigations": [
+            str(x) for x in (ini.get("open_investigations") or [])
+        ],
+        "tmux_sessions": tmux,
+    }
+
+
+def build_model(rows: list[dict], now: datetime | None = None) -> dict:
+    """PURE: store rows (+ any attached tmux) -> a grouped, sorted render model.
+
+    Groups initiatives by repo; within a repo sorts by momentum (active→stalled→unknown)
+    then recency (newest last_touch first); orders repos by their most-active initiative
+    then by name, so the busiest repos surface first. `captured_at` (the snapshot's
+    freshness, carried on every row) drives the 'updated Xm ago' footer. An empty row
+    list yields an empty (but well-formed) model — never raises."""
+    now = now or datetime.now(timezone.utc)
+
+    # The snapshot freshness = the newest captured_at across the rows (they should all
+    # share one snapshot, but max() is robust to a mixed read).
+    captured_ats = [_as_utc(r.get("captured_at")) for r in rows]
+    captured_at = max((c for c in captured_ats if c is not None), default=None)
+
+    by_repo: dict[str | None, list[dict]] = {}
+    for r in rows:
+        by_repo.setdefault(r.get("repo"), []).append(_initiative_view(r, now))
+
+    repos: list[dict] = []
+    for repo_path, inis in by_repo.items():
+        inis.sort(key=lambda v: (
+            v["momentum_rank"],
+            -(v["last_touch"].timestamp() if v["last_touch"] else 0.0),
+            v["slug"],
+        ))
+        repos.append({
+            "repo": repo_path,
+            "name": _short_repo(repo_path),
+            "best_rank": min(v["momentum_rank"] for v in inis),
+            "initiatives": inis,
+        })
+    repos.sort(key=lambda g: (g["best_rank"], g["name"]))
+
+    return {
+        "generated_at": now,
+        "captured_at": captured_at,
+        "captured_age": rel_age(captured_at, now) if captured_at else None,
+        "total": len(rows),
+        "repo_count": len(repos),
+        "repos": repos,
+    }
+
+
+def model_to_json(model: dict | None, error: str | None) -> dict:
+    """The `/api/initiatives.json` payload (datetimes isoformatted via json default=str)."""
+    if error is not None or model is None:
+        return {"ok": False, "error": error or "no data", "repos": []}
+    return {
+        "ok": True,
+        "generated_at": model["generated_at"],
+        "captured_at": model["captured_at"],
+        "captured_age": model["captured_age"],
+        "total": model["total"],
+        "repo_count": model["repo_count"],
+        "repos": model["repos"],
+    }
+
+
+# --------------------------------------------------------------------------- #
+# HTML rendering — self-contained, inline CSS, gruvbox-ish, no external assets.
+# --------------------------------------------------------------------------- #
+_CSS = """
+:root{
+  --bg:#282828; --bg1:#3c3836; --bg2:#504945; --fg:#ebdbb2; --fg2:#d5c4a1;
+  --gray:#928374; --red:#fb4934; --green:#b8bb26; --yellow:#fabd2f;
+  --blue:#83a598; --aqua:#8ec07c; --orange:#fe8019;
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--fg);
+  font-family:"JetBrainsMono Nerd Font","JetBrains Mono",ui-monospace,Menlo,Consolas,monospace;
+  font-size:14px;line-height:1.5;padding:1.2rem}
+a{color:var(--blue);text-decoration:none}
+a:hover{text-decoration:underline}
+header{display:flex;flex-wrap:wrap;align-items:baseline;gap:.6rem;
+  border-bottom:1px solid var(--bg2);padding-bottom:.6rem;margin-bottom:1rem}
+header h1{font-size:1.15rem;margin:0;color:var(--yellow)}
+header .meta{color:var(--gray);font-size:.85rem}
+.repo{margin:0 0 1.4rem}
+.repo > h2{font-size:.95rem;margin:0 0 .5rem;color:var(--aqua);
+  border-bottom:1px dotted var(--bg2);padding-bottom:.25rem}
+.repo > h2 .count{color:var(--gray);font-weight:normal;font-size:.8rem;margin-left:.4rem}
+.ini{background:var(--bg1);border-left:3px solid var(--gray);border-radius:4px;
+  padding:.55rem .7rem;margin:0 0 .5rem}
+.ini.active{border-left-color:var(--green)}
+.ini.slowing{border-left-color:var(--yellow)}
+.ini.stalled{border-left-color:var(--gray)}
+.ini .row1{display:flex;flex-wrap:wrap;align-items:baseline;gap:.5rem}
+.badge{font-weight:bold}
+.badge.active{color:var(--green)}
+.badge.slowing{color:var(--yellow)}
+.badge.stalled{color:var(--gray)}
+.badge.unknown{color:var(--gray)}
+.slug{font-weight:bold;color:var(--fg)}
+.title{color:var(--fg2)}
+.age{color:var(--gray);font-size:.82rem;margin-left:auto}
+.tags{margin-top:.3rem;display:flex;flex-wrap:wrap;gap:.35rem;align-items:center}
+.tag{font-size:.78rem;padding:.05rem .4rem;border-radius:3px;background:var(--bg2);color:var(--fg2)}
+.tag.tmux{background:#665c54;color:var(--green)}
+.tag.pr{background:var(--bg2);color:var(--blue)}
+.tag.stat{background:transparent;color:var(--gray);padding-left:0}
+.next{margin-top:.3rem;color:var(--fg2);font-size:.86rem}
+.next b{color:var(--orange);font-weight:normal}
+.invs{margin:.25rem 0 0;padding-left:1.1rem;color:var(--gray);font-size:.8rem}
+.empty{color:var(--gray);padding:2rem 0}
+.err{background:#442222;border:1px solid var(--red);color:var(--fg);
+  padding:1rem;border-radius:4px}
+.err b{color:var(--red)}
+footer{margin-top:1.5rem;padding-top:.6rem;border-top:1px solid var(--bg2);
+  color:var(--gray);font-size:.8rem}
+""".strip()
+
+
+def _e(s) -> str:
+    """HTML-escape any value (str/None/number) for safe interpolation."""
+    return html.escape("" if s is None else str(s))
+
+
+def _render_initiative(v: dict) -> str:
+    m = v["momentum"]
+    parts = [f'<div class="ini {_e(m)}">']
+    # Row 1: badge · slug · title · age
+    parts.append('<div class="row1">')
+    parts.append(f'<span class="badge {_e(m)}">{_e(v["badge_glyph"])} {_e(v["badge_label"])}</span>')
+    parts.append(f'<span class="slug">{_e(v["slug"])}</span>')
+    if v["title"]:
+        parts.append(f'<span class="title">{_e(v["title"])}</span>')
+    parts.append(f'<span class="age">updated {_e(v["age"])} ago</span>')
+    parts.append('</div>')
+
+    # Tags: tmux sessions, open PRs, and a couple of stat chips.
+    tags: list[str] = []
+    for sess in v["tmux_sessions"]:
+        tags.append(f'<span class="tag tmux">[tmux:{_e(sess)}]</span>')
+    for pr in v["open_prs"]:
+        num = pr["number"]
+        label = f'#{num}' if num is not None else 'PR'
+        title = f' {_e(pr["title"])}' if pr["title"] else ''
+        tags.append(f'<span class="tag pr" title="{_e(pr["title"])}">{_e(label)}{title}</span>')
+    commits = "?" if v["commits_unknown"] else v["commits"]
+    stat = f'{commits} commits · {v["merged_prs"]} merged · {v["session_count"]} sess · {v["telem_events"]} ev'
+    tags.append(f'<span class="tag stat">{_e(stat)}</span>')
+    parts.append(f'<div class="tags">{"".join(tags)}</div>')
+
+    # Next step.
+    if v["next_step"]:
+        parts.append(f'<div class="next"><b>next</b> &rsaquo; {_e(v["next_step"])}</div>')
+
+    # Open investigations (first few).
+    if v["open_investigations"]:
+        lis = "".join(f"<li>{_e(x)}</li>" for x in v["open_investigations"][:3])
+        parts.append(f'<ul class="invs">{lis}</ul>')
+
+    parts.append('</div>')
+    return "".join(parts)
+
+
+def render_html(model: dict | None, error: str | None = None,
+                refresh: int = REFRESH_SECONDS) -> str:
+    """PURE: a render model (or an error) -> a complete, self-contained HTML page.
+
+    Auto-refreshes via <meta http-equiv=refresh>; all CSS inline; no external assets. A
+    None model / non-None error renders a clear inline error box (the store was
+    unreachable) while STILL serving a valid page, so a DB blip degrades gracefully."""
+    head = (
+        '<!doctype html><html lang="en"><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width,initial-scale=1">'
+        f'<meta http-equiv="refresh" content="{int(refresh)}">'
+        '<title>initiatives</title>'
+        f'<style>{_CSS}</style></head><body>'
+    )
+    body: list[str] = []
+
+    if error is not None or model is None:
+        body.append('<header><h1>initiatives</h1>'
+                    '<span class="meta">live viewer</span></header>')
+        body.append(
+            '<div class="err"><b>store unreachable</b> — could not read the '
+            'initiatives store this refresh. Retrying automatically.'
+            f'<br><small>{_e(error or "no data")}</small></div>')
+        body.append('<footer>the page auto-refreshes; the store is populated by the '
+                    'hourly initiatives-sync timer.</footer>')
+        return head + "".join(body) + "</body></html>"
+
+    total, repo_count = model["total"], model["repo_count"]
+    body.append(
+        '<header><h1>initiatives</h1>'
+        f'<span class="meta">{total} in flight across {repo_count} repos</span>'
+        '</header>')
+
+    if not model["repos"]:
+        body.append('<div class="empty">No initiatives in the latest snapshot. '
+                    '(The store may be empty, or every initiative aged out of the '
+                    'scan window.)</div>')
+    for group in model["repos"]:
+        body.append('<section class="repo">')
+        body.append(f'<h2>{_e(group["name"])}'
+                    f'<span class="count">{len(group["initiatives"])}</span></h2>')
+        for v in group["initiatives"]:
+            body.append(_render_initiative(v))
+        body.append('</section>')
+
+    # Footer: freshness from the snapshot's captured_at + the sync cadence.
+    if model["captured_at"] is not None:
+        cap = model["captured_at"].strftime("%Y-%m-%d %H:%M UTC")
+        fresh = f'updated {_e(model["captured_age"])} ago · snapshot {_e(cap)} · hourly sync'
+    else:
+        fresh = 'no snapshot captured_at · hourly sync'
+    gen = model["generated_at"].strftime("%H:%M:%S UTC")
+    body.append(f'<footer>{fresh} · tmux overlay is live · '
+                f'page rendered {_e(gen)}, auto-refresh {int(refresh)}s</footer>')
+
+    return head + "".join(body) + "</body></html>"
+
+
+# --------------------------------------------------------------------------- #
+# Data provider — reads the store + tmux with a short TTL cache; thread-safe.
+# --------------------------------------------------------------------------- #
+class DataProvider:
+    """Fetches (store rows + live tmux) and builds a render model, cached for `ttl`
+    seconds so rapid page refreshes don't each open a fresh kubectl port-forward.
+
+    `snapshot()` returns `(model, error)`: on success `(model, None)`, on any read
+    failure `(None, "<message>")` — the server renders the error inline and keeps
+    serving (no crash-loop). Thread-safe: the ThreadingHTTPServer serves requests
+    concurrently, so the cache is guarded by a lock and only ONE refresh runs at a time.
+    """
+
+    def __init__(self, ttl: float = CACHE_TTL_SECONDS,
+                 loader=load_latest, tmux=attach_tmux,
+                 now_fn=lambda: datetime.now(timezone.utc)):
+        self._ttl = ttl
+        self._loader = loader
+        self._tmux = tmux
+        self._now = now_fn
+        self._lock = threading.Lock()
+        self._cached: tuple[dict | None, str | None] | None = None
+        self._fetched_at = 0.0
+
+    def snapshot(self) -> tuple[dict | None, str | None]:
+        with self._lock:
+            if self._cached is not None and (time.monotonic() - self._fetched_at) < self._ttl:
+                return self._cached
+            try:
+                rows = self._loader()
+                self._tmux(rows)  # best-effort; mutates rows in place
+                result: tuple[dict | None, str | None] = (build_model(rows, self._now()), None)
+            except Exception as exc:  # noqa: BLE001 - any read failure → graceful error page
+                result = (None, f"{type(exc).__name__}: {exc}")
+            self._cached = result
+            self._fetched_at = time.monotonic()
+            return result
+
+
+# --------------------------------------------------------------------------- #
+# HTTP layer — a thin BaseHTTPRequestHandler over a pure `route_request`.
+# --------------------------------------------------------------------------- #
+def route_request(path: str, provider) -> tuple[int, str, bytes]:
+    """PURE-ish request router: (path, provider) -> (status, content_type, body bytes).
+
+    Separated from the socket handler so it's unit-testable with a fake provider (no
+    server, no DB). `/healthz` is deliberately independent of the store — it reports
+    PROCESS liveness (200/ok) so a DB outage doesn't take the unit 'unhealthy' and
+    trigger a needless restart; the store's health surfaces on the page itself."""
+    if path == "/healthz":
+        return 200, "text/plain; charset=utf-8", b"ok\n"
+    if path in ("/", ""):
+        model, error = provider.snapshot()
+        return 200, "text/html; charset=utf-8", render_html(model, error).encode("utf-8")
+    if path == "/api/initiatives.json":
+        model, error = provider.snapshot()
+        payload = json.dumps(model_to_json(model, error), default=str,
+                             ensure_ascii=False, indent=2)
+        return 200, "application/json; charset=utf-8", payload.encode("utf-8")
+    return 404, "text/plain; charset=utf-8", b"not found\n"
+
+
+def make_handler(provider):
+    """Build a BaseHTTPRequestHandler subclass bound to `provider`."""
+
+    class Handler(BaseHTTPRequestHandler):
+        server_version = "initiatives-viewer/1.0"
+
+        def _serve(self, write_body: bool) -> None:
+            path = urlparse(self.path).path
+            try:
+                status, ctype, body = route_request(path, provider)
+            except Exception as exc:  # noqa: BLE001 - never let a handler error kill the thread
+                status, ctype = 500, "text/plain; charset=utf-8"
+                body = f"internal error: {type(exc).__name__}: {exc}\n".encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            if write_body:
+                self.wfile.write(body)
+
+        def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract
+            self._serve(write_body=True)
+
+        def do_HEAD(self) -> None:  # noqa: N802
+            self._serve(write_body=False)
+
+        def log_message(self, fmt, *args) -> None:  # quiet: one compact line to stderr
+            sys.stderr.write("viewer: %s - %s\n" % (self.address_string(), fmt % args))
+
+    return Handler
+
+
+def serve(host: str, port: int, provider: DataProvider | None = None) -> None:
+    """Start the blocking HTTP server on host:port with a threaded handler."""
+    provider = provider or DataProvider()
+    httpd = ThreadingHTTPServer((host, port), make_handler(provider))
+    httpd.daemon_threads = True
+    sys.stderr.write(f"viewer: serving on http://{host}:{port}/ "
+                     f"(/, /healthz, /api/initiatives.json)\n")
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        httpd.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Live web viewer over the initiatives store (initiatives.latest + "
+                    "a live tmux overlay). Binds LAN/localhost only.")
+    p.add_argument("--host", default=os.environ.get("INITIATIVES_VIEWER_HOST", DEFAULT_HOST),
+                   help=f"bind address (default {DEFAULT_HOST}; use 127.0.0.1 for local-only)")
+    p.add_argument("--port", type=int,
+                   default=int(os.environ.get("INITIATIVES_VIEWER_PORT", DEFAULT_PORT)),
+                   help=f"bind port (default {DEFAULT_PORT})")
+    p.add_argument("--ttl", type=float, default=CACHE_TTL_SECONDS,
+                   help=f"in-process data cache TTL seconds (default {CACHE_TTL_SECONDS})")
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    a = parse_args(argv)
+    serve(a.host, a.port, DataProvider(ttl=a.ttl))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Phase 3 — live web viewer

The durable, browser-viewable counterpart to the ephemeral agent-ops TUI. A self-contained, auto-refreshing web page (stdlib `http.server`, no framework) that renders the current initiatives from the Phase-1 Postgres store — grouped by repo, with momentum badges, next-step, open PRs, and a **live tmux overlay** (which session is on each initiative right now).

Builds on Phase 1 (sync, PR #135/#136) and Phase 2 (router, PR #137). Handoff: `claudedocs/handoff-initiatives-consolidation-2026-07-22.md`.

### Ghost-free store view (`initiatives.latest`)
`initiatives.current` is newest-per-`(repo,slug)` across ALL history → includes aged-out "ghosts" (wrong for a viewer). This PR adds an **`initiatives.latest`** view (rows from `max(snapshot_id)` only) to `sync.py`'s idempotent DDL, guarded by the same version-marker `COMMENT ON VIEW` mechanism as `current` — refactored into a shared `_ensure_view` helper. Additive; created on the next sync.

The viewer reads `latest` and **falls back inline** to `WHERE snapshot_id=(SELECT max(id) FROM snapshots)` if the view doesn't exist yet (before the next sync recreates the schema). `current` is untouched — the router wants recently-dormant matches.

### Live tmux overlay (render-time, host-local)
Reuses the scan's machinery verbatim (`collect_tmux_panes` / `discover_repos` / `worktree_canonical_map` / `load_scratch_codenames` / `match_tmux_to_initiatives`) via importlib — never reimplemented. Best-effort: absent if no tmux server. Kept OUT of Postgres (the durable-vs-live split).

### Serving
- `scripts/initiatives/viewer.py` + `run-viewer.sh` wrapper.
- Routes: `/` (HTML), `/healthz` (200/ok — process liveness, store-independent), `/api/initiatives.json`.
- Binds **workbench-LAN only** (`192.168.50.94:8899`); NOT wired into the public homelab gateway — internal work data. Public exposure is a deliberate later choice.
- Short in-process cache (5s) so rapid refreshes don't churn the port-forward.
- A DB outage renders a clear error page and **keeps serving** (no crash-loop). Crash-loop safety is in the code (per-request reads), not the unit.
- Workbench-only `systemd --user` service in `nix/home.nix` (serverMode-gated, `Restart=on-failure`, `RestartSec=10s`). Enabled directly under serverMode (read-only, low-risk) — no off-by-default master switch.

### Aesthetic
Clean, gruvbox, JetBrainsMono, inline CSS, no external assets. Group by repo (busiest repo first); momentum badges ●active ◐slowing ○stalled; `[tmux:<session>]` tags, open-PR chips, next-step, and an "updated Xm ago · hourly sync" footer from the snapshot's `captured_at`. `<meta http-equiv=refresh content=30>`.

### Tests
32 new viewer tests + 5 new sync tests for the `latest` view guard. Pure render model / HTML render / JSON payload / `route_request` smoke (fake provider) / `DataProvider` caching + graceful error / `attach_tmux` best-effort. **Full hermetic suite green** (313 tests + hook). Also smoke-tested the real socket path in-process (healthz/200, /, /api, 404).

### NOT deployed / not verified live
Per Phase-1 convention, the human deploys + verifies. No `home-manager switch`, no service start here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)