### PR TITLE
feat(initiatives): flat viewer + realtime refresh + legible enriched cards

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -782,12 +782,14 @@ in
     };
   };
 
-  # Timer: fire the sync ~hourly. The scan is EXPENSIVE (git-log across all repos +
-  # transcript parse + ClickHouse + `gh pr list` open+merged per repo + a kubectl
-  # port-forward) and its inputs change on an hours scale, so hourly is the right
-  # cadence. OnUnitActiveSec re-arms after each run so a slow sync never overlaps
-  # itself; OnStartupSec gives one prompt run after login. (No Persistent — it only
-  # applies to OnCalendar timers, not monotonic ones.)
+  # Timer: fire the sync ~every 15min so the store is "realtime enough" (the live tmux
+  # overlay is already render-time live; this keeps momentum/PRs/next-step fresh). The
+  # scan is EXPENSIVE (git-log across all repos + transcript parse + ClickHouse +
+  # `gh pr list` open+merged per repo + a kubectl port-forward), but 4×/hr keeps `gh`
+  # well under the 5000/hr rate limit. OnUnitActiveSec re-arms after each run so a slow
+  # sync never overlaps itself; OnStartupSec gives one prompt run after login. (No
+  # Persistent — it only applies to OnCalendar timers, not monotonic ones.) The ↻ button
+  # in the viewer forces an out-of-band sync on demand (single-flighted + debounced).
   #
   # DOUBLE-GATED: serverMode (workbench-only, LAN access) AND enableInitiativesSync
   # (the OFF-by-default master switch in the let-block above). With the switch false
@@ -799,7 +801,7 @@ in
     };
     Timer = {
       OnStartupSec = "2min";
-      OnUnitActiveSec = "1h";
+      OnUnitActiveSec = "15min";
     };
     Install = {
       WantedBy = [ "timers.target" ];
@@ -820,17 +822,23 @@ in
   # kube-apiserver/NodePorts and is not assignable here) — internal work data, deliberately
   # NOT wired into the public homelab gateway. Public exposure would be a later, explicit choice.
   #
-  # UNLIKE the sync it needs NO ClickHouse/sops creds (it only READS the already-synced
-  # store — no telemetry query), so it's enabled directly under serverMode with no
-  # off-by-default master switch: it's read-only and low-risk. Crash-loop safety is in
-  # the CODE, not the unit — every store read is per-request and a DB outage renders an
-  # error page while the process keeps serving, so Restart=on-failure only ever fires on
-  # a genuine process crash (e.g. the port already bound), backed off by RestartSec.
+  # For READS it needs NO ClickHouse/sops creds (it only reads the already-synced store).
+  # BUT the ↻ refresh button shells out to run-sync.sh (POST /refresh → a subprocess),
+  # which re-runs the FULL sync — so the viewer unit's PATH now also carries `sops` (the
+  # run-time ClickHouse reader-cred decrypt → telemetry-on) and `gh` (the scan's PR reads);
+  # KUBECONFIG + NIX_PATH are already set. Without sops/gh a refresh still works but the
+  # produced snapshot degrades to telemetry-off / no-PR (best-effort, never fails).
+  # It's enabled directly under serverMode with no off-by-default master switch: reads are
+  # low-risk and the refresh is single-flighted + debounced (~60s) in the code. Crash-loop
+  # safety is in the CODE, not the unit — every store read is per-request and a DB outage
+  # renders an error page while the process keeps serving, so Restart=on-failure only ever
+  # fires on a genuine process crash (e.g. the port already bound), backed off by RestartSec.
   #
   # Minimal user-unit env, so PATH is explicit: nix (nix-shell) + kubectl (the
-  # port-forward) + git (the scan's repo/worktree discovery for the overlay) + tmux (the
-  # live pane read) + bash/coreutils, and NIX_PATH so `nix-shell -p` resolves <nixpkgs>.
-  # The wrapper's nix-shell adds psycopg2 (the DB read) + requests (the scan import).
+  # port-forward) + git (repo/worktree discovery + the sops-decrypt's git show) + tmux (the
+  # live pane read) + sops + gh (the refresh subprocess's sync) + bash/coreutils/sed/grep,
+  # and NIX_PATH so `nix-shell -p` resolves <nixpkgs>. The wrapper's nix-shell adds
+  # psycopg2 (the DB read) + requests (the scan import).
   systemd.user.services.initiatives-viewer = lib.mkIf serverMode {
     Unit = {
       Description = "Initiatives live web viewer — initiatives.latest + live tmux overlay";
@@ -841,9 +849,10 @@ in
     Service = {
       Type = "simple";
       Environment = [
-        "PATH=${lib.makeBinPath [ pkgs.nix pkgs.kubectl pkgs.git pkgs.tmux pkgs.bash pkgs.coreutils pkgs.gnused pkgs.gnugrep ]}"
+        "PATH=${lib.makeBinPath [ pkgs.nix pkgs.kubectl pkgs.git pkgs.tmux pkgs.sops pkgs.gh pkgs.bash pkgs.coreutils pkgs.gnused pkgs.gnugrep ]}"
         "NIX_PATH=nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos"
         "KUBECONFIG=%h/workspace/homelab-talos/homelab-kubeconfig"
+        "ACTIVITY_HOST=workbench"
         "INITIATIVES_VIEWER_HOST=192.168.50.250"
         "INITIATIVES_VIEWER_PORT=8899"
         "HOME=%h"

--- a/scripts/initiatives/run-viewer.sh
+++ b/scripts/initiatives/run-viewer.sh
@@ -26,8 +26,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # default so the wrapper works when invoked from an interactive shell.
 export KUBECONFIG="${KUBECONFIG:-${HOME}/workspace/homelab-talos/homelab-kubeconfig}"
 
-# Bind address/port — workbench-LAN by default; override to 127.0.0.1 for local-only.
-HOST="${INITIATIVES_VIEWER_HOST:-192.168.50.94}"
+# Bind address/port — the workbench's OWN LAN IP (eth1) by default; override to 127.0.0.1
+# for local-only. NOT 192.168.50.94 — that is a homelab node (kube-apiserver/NodePorts),
+# not assignable here; the systemd unit sets INITIATIVES_VIEWER_HOST=192.168.50.250 too.
+HOST="${INITIATIVES_VIEWER_HOST:-192.168.50.250}"
 PORT="${INITIATIVES_VIEWER_PORT:-8899}"
 
 exec nix-shell -p 'python3.withPackages(p:[p.psycopg2 p.requests])' \

--- a/scripts/initiatives/sync.py
+++ b/scripts/initiatives/sync.py
@@ -113,10 +113,11 @@ CREATE INDEX IF NOT EXISTS snapshots_captured_at_idx
     ON initiatives.snapshots (captured_at);
 """
 
-# The views are guarded separately (see ensure_schema / _ensure_view): re-running
-# CREATE OR REPLACE VIEW takes an ACCESS EXCLUSIVE lock every time, so we only
-# (re)create a view when it's absent or its version marker differs. Bump the
-# matching *_VERSION whenever its DDL changes so a deploy recreates it.
+# The views are guarded separately (see ensure_schema / _ensure_view): a recreate is
+# DROP VIEW IF EXISTS + CREATE VIEW (NOT CREATE OR REPLACE — it can't reorder columns,
+# which the v2 `summary` append does; see _ensure_view) and takes an ACCESS EXCLUSIVE
+# lock, so we only (re)create a view when it's absent or its version marker differs.
+# Bump the matching *_VERSION whenever its DDL changes so a deploy recreates it.
 #
 # `current` — newest row per (repo, slug) across ALL history. This deliberately
 # includes initiatives that have aged out of the scan's N-day window (until the
@@ -128,7 +129,7 @@ CREATE INDEX IF NOT EXISTS snapshots_captured_at_idx
 VIEW_VERSION = "v2"
 VIEW_COMMENT = f"initiatives-sync view {VIEW_VERSION}"
 VIEW_DDL = """
-CREATE OR REPLACE VIEW initiatives.current AS
+CREATE VIEW initiatives.current AS
 SELECT DISTINCT ON (i.repo, i.slug)
        i.*, s.captured_at
   FROM initiatives.initiative_snapshot i
@@ -145,7 +146,7 @@ SELECT DISTINCT ON (i.repo, i.slug)
 LATEST_VIEW_VERSION = "v2"
 LATEST_VIEW_COMMENT = f"initiatives-sync view latest {LATEST_VIEW_VERSION}"
 LATEST_VIEW_DDL = """
-CREATE OR REPLACE VIEW initiatives.latest AS
+CREATE VIEW initiatives.latest AS
 SELECT i.*, s.captured_at
   FROM initiatives.initiative_snapshot i
   JOIN initiatives.snapshots s ON s.id = i.snapshot_id
@@ -311,11 +312,20 @@ def _import_maildb():
 def _ensure_view(cur, view: str, ddl: str, comment: str) -> None:
     """(Re)create a guarded view ONLY when it's missing or its version marker differs.
 
-    CREATE OR REPLACE VIEW takes an ACCESS EXCLUSIVE lock every run, so we gate it on
-    a version-marker `COMMENT ON VIEW`: steady state (view present, marker matches)
-    does nothing. `view` is a trusted module constant (never user input) so
-    interpolating it into the introspection SQL is safe. Bump the view's *_VERSION to
-    force a recreate after a hand-edit to its DDL."""
+    Uses DROP VIEW IF EXISTS + CREATE VIEW, NOT CREATE OR REPLACE VIEW: `CREATE OR
+    REPLACE` cannot reorder or rename an existing view's output columns, and the v2
+    schema appends `summary` to `initiative_snapshot`, so `SELECT i.*, s.captured_at`
+    now places `summary` before `captured_at` — Postgres would reject the replace with
+    `cannot change name of view column "captured_at" to "summary"` and, since the whole
+    ensure_schema runs in one advisory-locked transaction, roll the ENTIRE sync back
+    (freezing an existing v1 store). Dropping first sidesteps the column-shape lock.
+    Safe: nothing depends on `latest`/`current` and they don't depend on each other.
+
+    Still gated on a version-marker `COMMENT ON VIEW` so the DROP+CREATE (ACCESS
+    EXCLUSIVE) only runs when the marker actually changes — steady state (view present,
+    marker matches) does nothing. `view` is a trusted module constant (never user input)
+    so interpolating it into the introspection/DROP SQL is safe. Bump the view's
+    *_VERSION to force a recreate after a hand-edit to its DDL."""
     cur.execute(f"SELECT to_regclass('{view}')")
     exists = cur.fetchone()[0] is not None
     need_view = True
@@ -324,6 +334,7 @@ def _ensure_view(cur, view: str, ddl: str, comment: str) -> None:
         row = cur.fetchone()
         need_view = (row[0] if row else None) != comment
     if need_view:
+        cur.execute(f"DROP VIEW IF EXISTS {view}")
         cur.execute(ddl)
         cur.execute(f"COMMENT ON VIEW {view} IS %s", (comment,))
 

--- a/scripts/initiatives/sync.py
+++ b/scripts/initiatives/sync.py
@@ -80,6 +80,7 @@ CREATE TABLE IF NOT EXISTS initiatives.initiative_snapshot (
     repo                 text,
     slug                 text,
     title                text,
+    summary              text,
     doc_date             date,
     momentum             text,
     last_touch           timestamptz,
@@ -95,6 +96,12 @@ CREATE TABLE IF NOT EXISTS initiatives.initiative_snapshot (
     open_investigations  jsonb,
     docs                 jsonb
 );
+
+-- Additive migration for pre-existing installs: CREATE TABLE IF NOT EXISTS won't add
+-- a column to a table that already exists, so bring `summary` (nullable, deterministic
+-- goal/what-this-is line) in explicitly. Idempotent — a no-op once the column exists.
+ALTER TABLE initiatives.initiative_snapshot
+    ADD COLUMN IF NOT EXISTS summary text;
 
 -- Support the `current` view's DISTINCT ON (repo, slug) … JOIN snapshots …
 -- ORDER BY repo, slug, captured_at DESC, plus the FK join / retention scans.
@@ -115,7 +122,10 @@ CREATE INDEX IF NOT EXISTS snapshots_captured_at_idx
 # includes initiatives that have aged out of the scan's N-day window (until the
 # 90-day retention prunes them): the ROUTER wants to match a signal against
 # recently-dormant work, so ghosts are a feature there.
-VIEW_VERSION = "v1"
+# v2: the base table gained a `summary` column. A view's `SELECT i.*` is expanded to
+# an explicit column list AT CREATE TIME (Postgres freezes it), so the new column does
+# NOT appear until the view is recreated — bump the marker to force that on deploy.
+VIEW_VERSION = "v2"
 VIEW_COMMENT = f"initiatives-sync view {VIEW_VERSION}"
 VIEW_DDL = """
 CREATE OR REPLACE VIEW initiatives.current AS
@@ -131,7 +141,8 @@ SELECT DISTINCT ON (i.repo, i.slug)
 # (an initiative that dropped out of the scan's window simply isn't in the newest
 # snapshot, so it disappears here even though `current` still carries it). Carries
 # `captured_at` so the viewer can render an "updated Xm ago" freshness footer.
-LATEST_VIEW_VERSION = "v1"
+# v2: recreate to expose the new `summary` column (see VIEW_VERSION note above).
+LATEST_VIEW_VERSION = "v2"
 LATEST_VIEW_COMMENT = f"initiatives-sync view latest {LATEST_VIEW_VERSION}"
 LATEST_VIEW_DDL = """
 CREATE OR REPLACE VIEW initiatives.latest AS
@@ -151,7 +162,7 @@ RETENTION_DAYS = 90
 
 # Column order for the per-initiative insert (snapshot_id is prepended at write time).
 ROW_COLUMNS = [
-    "host", "repo", "slug", "title", "doc_date", "momentum", "last_touch",
+    "host", "repo", "slug", "title", "summary", "doc_date", "momentum", "last_touch",
     "next_step", "commits", "commits_unknown", "merged_prs", "open_prs",
     "session_count", "telem_events", "telem_last", "current_doc",
     "open_investigations", "docs",
@@ -211,6 +222,7 @@ def _initiative_to_row(ini: dict, host: str) -> dict:
         "repo": ini.get("repo"),
         "slug": ini.get("slug"),
         "title": ini.get("title"),
+        "summary": ini.get("summary"),
         "doc_date": _to_date(ini.get("date")),
         "momentum": ini.get("momentum"),
         "last_touch": _epoch_to_dt(ini.get("last_touch")),

--- a/scripts/initiatives/tests/test_sync.py
+++ b/scripts/initiatives/tests/test_sync.py
@@ -25,6 +25,7 @@ def _fixture_initiative(**over):
         "repo": "/home/zach/workspace/devrc",
         "slug": "initiatives-consolidation",
         "title": "Initiatives consolidation Phase 1",
+        "summary": "Consolidate the scan output into a durable Postgres store.",
         "date": "2026-07-13",
         "doc_mtime": 1768300000.0,
         "next_step": "eyeball the dry-run output",
@@ -169,6 +170,22 @@ def test_momentum_and_scalars_pass_through():
     assert r["commits"] == 7 and r["merged_prs"] == 2
     assert r["session_count"] == 3 and r["telem_events"] == 42
     assert r["commits_unknown"] is False
+
+
+def test_summary_passes_through_and_defaults_to_none():
+    _meta, rows = sync.report_to_rows(_fixture_report(), host="workbench")
+    assert rows[0]["summary"] == "Consolidate the scan output into a durable Postgres store."
+    ini = _fixture_initiative()
+    ini.pop("summary", None)
+    _m, rows2 = sync.report_to_rows(_fixture_report(by_repo={"/r": [ini]}), host="workbench")
+    assert rows2[0]["summary"] is None  # nullable column — no default fabricated
+
+
+def test_summary_is_in_row_columns_after_title():
+    # Order-independent for the INSERT (explicit column list), but keep it adjacent to
+    # title for readability, and ensure it IS one of the written columns.
+    assert "summary" in sync.ROW_COLUMNS
+    assert sync.ROW_COLUMNS.index("summary") == sync.ROW_COLUMNS.index("title") + 1
 
 
 def test_commits_unknown_true_passes_through():
@@ -325,6 +342,23 @@ def test_ensure_schema_creates_indexes():
     assert "snapshots_captured_at_idx" in joined
 
 
+def test_ensure_schema_adds_summary_column_additively():
+    # Fresh installs get the column in CREATE TABLE; pre-existing tables get it via an
+    # idempotent ADD COLUMN IF NOT EXISTS (CREATE TABLE IF NOT EXISTS won't add a column).
+    conn = _FakeConn()
+    sync.ensure_schema(conn)
+    joined = " ".join(_sqls(conn))
+    assert "summary text" in joined  # in CREATE TABLE
+    assert "ADD COLUMN IF NOT EXISTS summary text" in joined  # additive migration
+
+
+def test_view_versions_bumped_so_summary_column_is_exposed():
+    # A view's SELECT i.* is frozen at create time; bumping the marker forces a recreate
+    # so the new `summary` column surfaces on initiatives.latest / .current.
+    assert sync.VIEW_VERSION == "v2"
+    assert sync.LATEST_VIEW_VERSION == "v2"
+
+
 def test_ensure_schema_fk_cascades():
     conn = _FakeConn()
     sync.ensure_schema(conn)
@@ -424,3 +458,8 @@ def test_write_snapshot_inserts_snapshot_then_rows_with_jsonb():
     jsonb_count = sum(1 for p in row_params if isinstance(p, Json))
     assert jsonb_count == 3
     assert conn.commits == 1
+    # the summary column is in the INSERT list, and its value lands at the matching index
+    assert "summary" in row_sql
+    # row_params = [snapshot_id] + ROW_COLUMNS values, so summary is at its ROW_COLUMNS idx + 1
+    summary_idx = sync.ROW_COLUMNS.index("summary") + 1
+    assert row_params[summary_idx] == "Consolidate the scan output into a durable Postgres store."

--- a/scripts/initiatives/tests/test_sync.py
+++ b/scripts/initiatives/tests/test_sync.py
@@ -370,24 +370,33 @@ def test_ensure_schema_creates_view_when_absent():
     conn = _FakeConn(view_regclass=None)
     sync.ensure_schema(conn)
     joined = " ".join(_sqls(conn))
-    assert "CREATE OR REPLACE VIEW initiatives.current" in joined
+    assert "CREATE VIEW initiatives.current" in joined
     assert "COMMENT ON VIEW initiatives.current" in joined
 
 
 def test_ensure_schema_skips_view_when_present_and_version_matches():
+    # Marker matches -> NEITHER a DROP nor a CREATE (steady state is a no-op).
     conn = _FakeConn(view_regclass="initiatives.current",
                      view_comment=sync.VIEW_COMMENT)
     sync.ensure_schema(conn)
     joined = " ".join(_sqls(conn))
-    assert "CREATE OR REPLACE VIEW initiatives.current" not in joined
+    assert "CREATE VIEW initiatives.current" not in joined
+    assert "DROP VIEW IF EXISTS initiatives.current" not in joined
 
 
 def test_ensure_schema_recreates_view_when_version_differs():
+    # Marker differs -> DROP VIEW IF EXISTS must come BEFORE the CREATE VIEW (CREATE OR
+    # REPLACE can't reorder columns after the v2 `summary` append, so we drop+create).
     conn = _FakeConn(view_regclass="initiatives.current",
                      view_comment="initiatives-sync view v0")
     sync.ensure_schema(conn)
-    joined = " ".join(_sqls(conn))
-    assert "CREATE OR REPLACE VIEW initiatives.current" in joined
+    sqls = _sqls(conn)
+    joined = " ".join(sqls)
+    assert "CREATE OR REPLACE VIEW" not in joined  # never the shape-locked form
+    assert "CREATE VIEW initiatives.current" in joined
+    drop_i = next(i for i, s in enumerate(sqls) if "DROP VIEW IF EXISTS initiatives.current" in s)
+    create_i = next(i for i, s in enumerate(sqls) if "CREATE VIEW initiatives.current" in s)
+    assert drop_i < create_i
 
 
 # --- the `latest` view (viewer's ghost-free source) ------------------------- #
@@ -395,7 +404,7 @@ def test_ensure_schema_creates_latest_view_when_absent():
     conn = _FakeConn(latest_regclass=None)
     sync.ensure_schema(conn)
     joined = " ".join(_sqls(conn))
-    assert "CREATE OR REPLACE VIEW initiatives.latest" in joined
+    assert "CREATE VIEW initiatives.latest" in joined
     assert "COMMENT ON VIEW initiatives.latest" in joined
     # rows from the most recent snapshot only (the ghost-free semantic)
     assert "WHERE i.snapshot_id = (SELECT max(id) FROM initiatives.snapshots)" in joined
@@ -406,15 +415,19 @@ def test_ensure_schema_skips_latest_view_when_present_and_version_matches():
                      latest_comment=sync.LATEST_VIEW_COMMENT)
     sync.ensure_schema(conn)
     joined = " ".join(_sqls(conn))
-    assert "CREATE OR REPLACE VIEW initiatives.latest" not in joined
+    assert "CREATE VIEW initiatives.latest" not in joined
+    assert "DROP VIEW IF EXISTS initiatives.latest" not in joined
 
 
 def test_ensure_schema_recreates_latest_view_when_version_differs():
     conn = _FakeConn(latest_regclass="initiatives.latest",
                      latest_comment="initiatives-sync view latest v0")
     sync.ensure_schema(conn)
-    joined = " ".join(_sqls(conn))
-    assert "CREATE OR REPLACE VIEW initiatives.latest" in joined
+    sqls = _sqls(conn)
+    assert "CREATE OR REPLACE VIEW" not in " ".join(sqls)
+    drop_i = next(i for i, s in enumerate(sqls) if "DROP VIEW IF EXISTS initiatives.latest" in s)
+    create_i = next(i for i, s in enumerate(sqls) if "CREATE VIEW initiatives.latest" in s)
+    assert drop_i < create_i
 
 
 def test_ensure_schema_manages_both_views_independently():
@@ -424,8 +437,9 @@ def test_ensure_schema_manages_both_views_independently():
                      latest_regclass=None)
     sync.ensure_schema(conn)
     joined = " ".join(_sqls(conn))
-    assert "CREATE OR REPLACE VIEW initiatives.current" not in joined
-    assert "CREATE OR REPLACE VIEW initiatives.latest" in joined
+    assert "CREATE VIEW initiatives.current" not in joined
+    assert "DROP VIEW IF EXISTS initiatives.current" not in joined
+    assert "CREATE VIEW initiatives.latest" in joined
     assert conn.commits == 1  # still one commit for the whole schema pass
 
 

--- a/scripts/initiatives/tests/test_viewer.py
+++ b/scripts/initiatives/tests/test_viewer.py
@@ -369,6 +369,34 @@ def test_read_doc_detail_live_reads_a_fixture_handoff(tmp_path):
     assert out["summary"] == "do X." and out["next_steps"] == ["a", "b"]
 
 
+def test_read_doc_detail_live_resolves_repo_allowlist_when_repos_omitted(tmp_path, monkeypatch):
+    # With repos omitted, the reader must resolve the known-repo allowlist (not skip it):
+    # an EMPTY allowlist -> the repo isn't allowed -> None (the guard actually runs).
+    repo = tmp_path / "repo"
+    (repo / "claudedocs").mkdir(parents=True)
+    doc = repo / "claudedocs" / "handoff-x.md"
+    doc.write_text("# X\n\n**Goal:** do X.\n")
+    monkeypatch.setattr(viewer, "_discover_repos_safe", lambda: [])
+    assert viewer.read_doc_detail_live(str(repo), str(doc)) is None
+    # and when discovery includes the repo, the read succeeds
+    monkeypatch.setattr(viewer, "_discover_repos_safe", lambda: [str(repo)])
+    assert viewer.read_doc_detail_live(str(repo), str(doc))["summary"] == "do X."
+
+
+def test_read_doc_detail_live_caps_read_size(tmp_path, monkeypatch):
+    # A pathological file is truncated at MAX_DOC_BYTES so it can't spike memory: content
+    # beyond the cap (here a Next-steps section) is not parsed.
+    repo = tmp_path / "repo"
+    (repo / "claudedocs").mkdir(parents=True)
+    doc = repo / "claudedocs" / "handoff-x.md"
+    doc.write_text("**Goal:** short goal.\n" + ("X" * 5000) +
+                   "\n## Next steps\n1. SHOULD_NOT_APPEAR\n")
+    monkeypatch.setattr(viewer, "MAX_DOC_BYTES", 40)
+    out = viewer.read_doc_detail_live(str(repo), str(doc), repos=[str(repo)])
+    assert out["summary"] == "short goal."
+    assert out["next_steps"] == []  # truncated away before the Next-steps section
+
+
 def test_safe_doc_path_containment_and_traversal(tmp_path):
     repo = tmp_path / "repo"
     (repo / "claudedocs").mkdir(parents=True)

--- a/scripts/initiatives/tests/test_viewer.py
+++ b/scripts/initiatives/tests/test_viewer.py
@@ -447,11 +447,15 @@ def test_refresh_single_flighted_while_running():
     assert rc.refresh()["status"] == "in_progress"
 
 
-def test_refresh_reports_error_on_nonzero_rc():
+def test_refresh_reports_error_on_nonzero_rc_without_leaking_stderr():
     c, now_fn = _clock()
-    rc = viewer.RefreshController(runner=lambda s, t: (1, "boom"), now_fn=now_fn)
+    rc = viewer.RefreshController(runner=lambda s, t: (1, "secret /path/to/key stderr"),
+                                 now_fn=now_fn)
     r = rc.refresh()
     assert r["ok"] is False and r["status"] == "error"
+    # the runner's stderr tail must NOT be returned to the (unauthenticated) client
+    assert "detail" not in r
+    assert "secret" not in json.dumps(r)
 
 
 def test_refresh_swallows_runner_exception():
@@ -461,8 +465,21 @@ def test_refresh_swallows_runner_exception():
         raise RuntimeError("spawn failed")
 
     rc = viewer.RefreshController(runner=runner, now_fn=now_fn)
-    assert rc.refresh()["status"] == "error"
+    r = rc.refresh()
+    assert r["status"] == "error" and "detail" not in r
     # after a failure, _running is reset so a later refresh can proceed
+    assert rc._running is False
+
+
+def test_refresh_timeout_from_runner_is_error_and_resets_running():
+    import subprocess as _sp
+    c, now_fn = _clock()
+
+    def runner(script, timeout):
+        raise _sp.TimeoutExpired(cmd="bash", timeout=timeout)
+
+    rc = viewer.RefreshController(runner=runner, now_fn=now_fn)
+    assert rc.refresh()["status"] == "error"
     assert rc._running is False
 
 

--- a/scripts/initiatives/tests/test_viewer.py
+++ b/scripts/initiatives/tests/test_viewer.py
@@ -25,6 +25,7 @@ def _row(**over):
         "slug": "initiatives-viewer",
         "repo": "/home/zach/workspace/devrc",
         "title": "Initiatives consolidation Phase 3",
+        "summary": "A live web viewer over the initiatives store.",
         "momentum": "active",
         "last_touch": NOW - timedelta(minutes=30),
         "next_step": "wire the systemd unit",
@@ -36,6 +37,8 @@ def _row(**over):
         "telem_events": 42,
         "current_doc": "/home/zach/workspace/devrc/claudedocs/handoff-x.md",
         "open_investigations": ["does the tmux overlay hold under refresh churn?"],
+        "docs": [{"path": "/home/zach/workspace/devrc/claudedocs/handoff-x.md",
+                  "date": "2026-07-22"}],
         "captured_at": NOW - timedelta(minutes=6),
     }
     r.update(over)
@@ -144,28 +147,43 @@ def test_build_model_none_repo_becomes_unknown_group():
     assert model["repos"][0]["name"] == "(unknown repo)"
 
 
-# --- HTML render ------------------------------------------------------------ #
-def test_render_html_contains_slug_badge_tmux_and_footer():
+# --- HTML render (JSON island + inline JS; cards are rendered client-side) --- #
+def test_render_html_embeds_data_and_controls():
     rows = [_row(slug="initiatives-viewer")]
     rows[0]["tmux_sessions"] = {"Vapor-2"}
     model = viewer.build_model(rows, now=NOW)
     html = viewer.render_html(model)
-    assert "initiatives-viewer" in html            # a slug
-    assert "●" in html and "active" in html         # a momentum badge glyph + label
-    assert "[tmux:Vapor-2]" in html                 # a tmux tag
-    assert "wire the systemd unit" in html          # the next-step
-    assert "#138" in html                           # the open PR
-    assert "hourly sync" in html                    # the footer
-    assert "2026-07-22 11:54 UTC" in html           # captured_at in the footer
-    assert 'http-equiv="refresh"' in html           # auto-refresh wired
     assert html.startswith("<!doctype html>")
+    # the data the page builds from is embedded as a JSON island
+    assert 'id="idata"' in html
+    assert "initiatives-viewer" in html            # a slug (in the payload)
+    assert "feat: viewer" in html                  # the OPEN PR TITLE, not a bare number
+    assert "A live web viewer over the initiatives store." in html  # the summary
+    assert "Vapor-2" in html                        # a tmux session in the payload
+    # the flat/grouped toggle + search + refresh chrome
+    assert 'id="view-flat"' in html and 'id="view-grouped"' in html
+    assert 'id="search"' in html and 'id="refresh"' in html
+    # inline JS (no external assets) with the auto-refresh interval interpolated
+    assert "localStorage" in html
+    assert str(viewer.REFRESH_SECONDS * 1000) in html
 
 
-def test_render_html_escapes_untrusted_text():
+def test_render_html_escapes_untrusted_text_in_json_island():
+    # Untrusted text is embedded in a <script type=application/json> island; markup must
+    # be neutralized so it can't break out of the script element (\uXXXX is valid JSON).
     model = viewer.build_model([_row(title="<script>alert(1)</script>")], now=NOW)
     html = viewer.render_html(model)
-    assert "<script>alert(1)</script>" not in html
-    assert "&lt;script&gt;" in html
+    assert "<script>alert(1)</script>" not in html   # never raw
+    assert "u003cscript" in html                      # neutralized as <
+
+
+def test_render_html_footer_split_is_honest_not_hourly():
+    # The confusing "updated 1 hour ago / hourly sync" footer is gone; the JS renders a
+    # live-vs-snapshot split from captured_age.
+    model = viewer.build_model([_row(slug="a")], now=NOW)
+    html = viewer.render_html(model)
+    assert "hourly sync" not in html
+    assert "store synced" in html and "live sessions" in html
 
 
 def test_render_html_error_page_when_store_unreachable():
@@ -175,10 +193,12 @@ def test_render_html_error_page_when_store_unreachable():
     assert html.startswith("<!doctype html>")
 
 
-def test_render_html_empty_model_shows_empty_message():
+def test_render_html_empty_model_embeds_empty_payload():
     model = viewer.build_model([], now=NOW)
     html = viewer.render_html(model)
-    assert "No initiatives" in html
+    # payload reflects an empty snapshot; the JS renders the "No initiatives" message
+    assert '"total": 0' in html or '"total":0' in html
+    assert "No initiatives" in html  # the client-side empty message string
 
 
 # --- JSON payload ----------------------------------------------------------- #
@@ -289,3 +309,260 @@ def test_attach_tmux_absent_when_no_tmux_server(monkeypatch):
 
     monkeypatch.setattr(viewer, "_scan", lambda: _FakeScan)
     assert viewer.attach_tmux([_row(slug="ok")]) is False
+
+
+# --- flat view + enriched view fields (Feedback 1 + 3) ---------------------- #
+def test_build_model_flat_orders_by_last_touch_desc():
+    rows = [
+        _row(slug="old", repo="/ws/a", last_touch=NOW - timedelta(days=3)),
+        _row(slug="newest", repo="/ws/b", last_touch=NOW - timedelta(minutes=2)),
+        _row(slug="mid", repo="/ws/a", last_touch=NOW - timedelta(hours=5)),
+    ]
+    model = viewer.build_model(rows, now=NOW)
+    assert [v["slug"] for v in model["flat"]] == ["newest", "mid", "old"]
+
+
+def test_flat_view_carries_repo_label_summary_and_pr_titles():
+    model = viewer.build_model([_row(slug="s")], now=NOW)
+    v = model["flat"][0]
+    assert v["repo"] == "/home/zach/workspace/devrc"
+    assert v["repo_name"] == "devrc"                      # repo label for the flat card
+    assert v["summary"] == "A live web viewer over the initiatives store."
+    assert v["open_prs"] == [{"number": 138, "title": "feat: viewer"}]  # titles, not bare #
+    assert v["docs"] == [{"path": "/home/zach/workspace/devrc/claudedocs/handoff-x.md",
+                          "date": "2026-07-22"}]
+
+
+def test_flat_none_last_touch_sorts_last():
+    rows = [_row(slug="dated", last_touch=NOW - timedelta(days=1)),
+            _row(slug="undated", last_touch=None)]
+    model = viewer.build_model(rows, now=NOW)
+    assert [v["slug"] for v in model["flat"]] == ["dated", "undated"]
+
+
+def test_model_to_json_includes_flat():
+    model = viewer.build_model([_row(slug="a")], now=NOW)
+    j = viewer.model_to_json(model, None)
+    assert "flat" in j and j["flat"][0]["slug"] == "a"
+    err = viewer.model_to_json(None, "boom")
+    assert err["flat"] == [] and err["repos"] == []
+
+
+# --- detail parse + path-traversal guard (Feedback 3.3) --------------------- #
+def test_parse_doc_detail_extracts_sections():
+    text = ("# Handoff — thing, 2026-07-22\n\n"
+            "**Goal:** build the thing.\n\n"
+            "## Next steps\n1. first step\n2. second step\n\n"
+            "## Open investigations\n### an open bug\n")
+    d = viewer.parse_doc_detail(text)
+    assert d["summary"] == "build the thing."
+    assert d["next_steps"] == ["first step", "second step"]  # FULL list, not just the lead
+    assert d["open_investigations"] == ["an open bug"]
+
+
+def test_read_doc_detail_live_reads_a_fixture_handoff(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "claudedocs").mkdir(parents=True)
+    doc = repo / "claudedocs" / "handoff-x-2026-07-22.md"
+    doc.write_text("# X\n\n**Goal:** do X.\n\n## Next steps\n1. a\n2. b\n")
+    out = viewer.read_doc_detail_live(str(repo), str(doc), repos=[str(repo)])
+    assert out["summary"] == "do X." and out["next_steps"] == ["a", "b"]
+
+
+def test_safe_doc_path_containment_and_traversal(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "claudedocs").mkdir(parents=True)
+    doc = repo / "claudedocs" / "handoff-x.md"
+    doc.write_text("hi")
+    # a real file under <repo>/claudedocs/ from a known repo resolves
+    assert viewer.safe_doc_path(str(repo), str(doc), [str(repo)]) is not None
+    # a traversal out of claudedocs/ is rejected
+    escape = str(repo / "claudedocs" / ".." / ".." / "etc" / "passwd")
+    assert viewer.safe_doc_path(str(repo), escape, [str(repo)]) is None
+    # an unknown repo is rejected
+    assert viewer.safe_doc_path(str(repo), str(doc), ["/some/other/repo"]) is None
+    # a missing file is rejected
+    assert viewer.safe_doc_path(str(repo), str(repo / "claudedocs" / "nope.md"),
+                                [str(repo)]) is None
+
+
+def test_build_detail_overlays_live_over_snapshot():
+    model = viewer.build_model([_row(slug="s")], now=NOW)
+    live = {"summary": "fresh summary", "next_steps": ["live 1", "live 2"],
+            "open_investigations": ["live inv"]}
+    d = viewer.build_detail(model, None, "/home/zach/workspace/devrc", "s",
+                            doc_reader=lambda repo, doc: live)
+    assert d["ok"] is True and d["live"] is True
+    assert d["summary"] == "fresh summary"
+    assert d["next_steps"] == ["live 1", "live 2"]          # FULL live list
+    assert d["open_investigations"] == ["live inv"]
+    assert d["open_prs"] == [{"number": 138, "title": "feat: viewer"}]
+
+
+def test_build_detail_falls_back_to_snapshot_when_live_read_fails():
+    model = viewer.build_model([_row(slug="s")], now=NOW)
+    d = viewer.build_detail(model, None, "/home/zach/workspace/devrc", "s",
+                            doc_reader=lambda repo, doc: None)
+    assert d["live"] is False
+    assert d["next_steps"] == ["wire the systemd unit"]     # snapshot's single next-step
+    assert d["open_investigations"] == ["does the tmux overlay hold under refresh churn?"]
+
+
+def test_build_detail_unknown_initiative_is_not_ok():
+    model = viewer.build_model([_row(slug="s")], now=NOW)
+    assert viewer.build_detail(model, None, "/nope", "nope")["ok"] is False
+    assert viewer.build_detail(None, "db down", "/r", "s")["ok"] is False
+
+
+# --- RefreshController: single-flight + debounce (Feedback 2) --------------- #
+def _clock():
+    c = {"t": 1000.0}
+    return c, (lambda: c["t"])
+
+
+def test_refresh_runs_then_debounces_within_window():
+    c, now_fn = _clock()
+    calls = {"n": 0}
+
+    def runner(script, timeout):
+        calls["n"] += 1
+        return 0, ""
+
+    rc = viewer.RefreshController(runner=runner, now_fn=now_fn, min_interval=60)
+    r1 = rc.refresh()
+    assert r1["status"] == "synced" and calls["n"] == 1
+    c["t"] = 1005.0
+    r2 = rc.refresh()                       # 5s later → debounced, NOT re-run
+    assert r2["status"] == "debounced" and calls["n"] == 1
+    assert "just synced" in r2["message"]
+    c["t"] = 1100.0
+    r3 = rc.refresh()                       # past the window → runs again
+    assert r3["status"] == "synced" and calls["n"] == 2
+
+
+def test_refresh_single_flighted_while_running():
+    c, now_fn = _clock()
+    rc = viewer.RefreshController(runner=lambda s, t: (0, ""), now_fn=now_fn)
+    rc._running = True                      # simulate an in-flight sync
+    assert rc.refresh()["status"] == "in_progress"
+
+
+def test_refresh_reports_error_on_nonzero_rc():
+    c, now_fn = _clock()
+    rc = viewer.RefreshController(runner=lambda s, t: (1, "boom"), now_fn=now_fn)
+    r = rc.refresh()
+    assert r["ok"] is False and r["status"] == "error"
+
+
+def test_refresh_swallows_runner_exception():
+    c, now_fn = _clock()
+
+    def runner(script, timeout):
+        raise RuntimeError("spawn failed")
+
+    rc = viewer.RefreshController(runner=runner, now_fn=now_fn)
+    assert rc.refresh()["status"] == "error"
+    # after a failure, _running is reset so a later refresh can proceed
+    assert rc._running is False
+
+
+# --- routing: POST /refresh + GET /api/initiative -------------------------- #
+class _FakeProviderWithInvalidate:
+    def __init__(self, model=None, error=None):
+        self._model = model
+        self._error = error
+        self.invalidated = 0
+
+    def snapshot(self):
+        return self._model, self._error
+
+    def invalidate(self):
+        self.invalidated += 1
+
+
+class _CountingController:
+    def __init__(self, result):
+        self._result = result
+        self.calls = 0
+
+    def refresh(self):
+        self.calls += 1
+        return self._result
+
+
+def test_route_refresh_synced_invalidates_provider():
+    prov = _FakeProviderWithInvalidate()
+    ctrl = _CountingController({"ok": True, "status": "synced", "message": "sync complete"})
+    status, ctype, body = viewer.route_request("/refresh", prov, method="POST",
+                                               refresh_controller=ctrl)
+    assert status == 200 and "application/json" in ctype
+    assert ctrl.calls == 1 and prov.invalidated == 1
+    assert json.loads(body)["status"] == "synced"
+
+
+def test_route_refresh_debounced_does_not_invalidate():
+    prov = _FakeProviderWithInvalidate()
+    ctrl = _CountingController({"ok": True, "status": "debounced",
+                               "message": "just synced 5s ago"})
+    status, _ctype, body = viewer.route_request("/refresh", prov, method="POST",
+                                                refresh_controller=ctrl)
+    assert status == 200 and prov.invalidated == 0
+
+
+def test_route_refresh_in_progress_is_409():
+    prov = _FakeProviderWithInvalidate()
+    ctrl = _CountingController({"ok": False, "status": "in_progress", "message": "busy"})
+    status, _ctype, _body = viewer.route_request("/refresh", prov, method="POST",
+                                                 refresh_controller=ctrl)
+    assert status == 409
+
+
+def test_route_refresh_without_controller_is_503():
+    prov = _FakeProviderWithInvalidate()
+    status, _ctype, _body = viewer.route_request("/refresh", prov, method="POST",
+                                                 refresh_controller=None)
+    assert status == 503
+
+
+def test_route_get_on_refresh_path_is_404():
+    # /refresh is POST-only; a GET falls through to the 404 (not the refresh handler).
+    prov = _FakeProviderWithInvalidate()
+    status, _c, _b = viewer.route_request("/refresh", prov, method="GET")
+    assert status == 404
+
+
+def test_route_detail_endpoint_returns_initiative():
+    model = viewer.build_model([_row(slug="s")], now=NOW)
+    prov = _FakeProviderWithInvalidate(model=model)
+    status, ctype, body = viewer.route_request(
+        "/api/initiative", prov, method="GET",
+        query={"repo": ["/home/zach/workspace/devrc"], "slug": ["s"]})
+    assert status == 200 and "application/json" in ctype
+    payload = json.loads(body)
+    assert payload["ok"] is True and payload["slug"] == "s"
+
+
+def test_route_detail_unknown_is_404():
+    model = viewer.build_model([_row(slug="s")], now=NOW)
+    prov = _FakeProviderWithInvalidate(model=model)
+    status, _c, body = viewer.route_request("/api/initiative", prov, method="GET",
+                                            query={"repo": ["/x"], "slug": ["y"]})
+    assert status == 404 and json.loads(body)["ok"] is False
+
+
+# --- DataProvider.invalidate ------------------------------------------------ #
+def test_provider_invalidate_forces_reload():
+    calls = {"n": 0}
+
+    def loader():
+        calls["n"] += 1
+        return [_row(slug="x")]
+
+    prov = viewer.DataProvider(ttl=999, loader=loader, tmux=lambda rows: True,
+                               now_fn=lambda: NOW)
+    prov.snapshot()
+    prov.snapshot()
+    assert calls["n"] == 1          # cached
+    prov.invalidate()
+    prov.snapshot()
+    assert calls["n"] == 2          # re-read after invalidate

--- a/scripts/initiatives/viewer.py
+++ b/scripts/initiatives/viewer.py
@@ -1,33 +1,44 @@
 #!/usr/bin/env python3
 """Live web viewer over the Phase-1 initiatives store.
 
-PHASE 3 of the "initiatives consolidation" feature. A self-contained, auto-refreshing
-web page (stdlib `http.server`, NO web framework) that renders the CURRENT initiatives
-from the homelab `mailbox` Postgres — grouped by repo, with momentum badges, next-step,
-open PRs, and a LIVE tmux overlay (which tmux session is on each initiative right now).
+PHASE 3 of the "initiatives consolidation" feature. A self-contained web page (stdlib
+`http.server`, NO web framework, inline vanilla JS/CSS, no external/CDN assets) that
+renders the CURRENT initiatives from the homelab `mailbox` Postgres, with momentum
+badges, a per-initiative goal/summary line, next-step, open PRs (titles, not bare
+numbers), and a LIVE tmux overlay (which tmux session is on each initiative right now).
 It is the durable, browser-viewable counterpart to the ephemeral agent-ops TUI.
+
+Interaction (all client-side over the embedded JSON / `/api/initiatives.json`):
+  - a **flat / grouped** toggle (FLAT is the default, most-recently-active first, with a
+    repo label on each card; grouped-by-repo is one click away). Persisted in localStorage.
+  - a **search box** filtering cards by substring across slug/title/summary/repo/momentum.
+  - **click-to-expand** each card → a detail view fetched from `/api/initiative` that
+    LIVE-reads the handoff doc off disk (full Next-steps list + Open investigations + all
+    open-PR titles + the doc path + docs history), falling back to the stored fields.
+  - a header **↻ refresh** button → `POST /refresh` runs a fresh sync (single-flighted +
+    debounced ~60s), then the page re-fetches and re-renders.
 
 Data (two layers, both best-effort per request):
   1. The STORE — `initiatives.latest` (rows from the most recent snapshot only, so NO
-     aged-out "ghosts" — unlike `initiatives.current`, which the router wants). Read via
-     `mail-actions/_db.py`'s kubectl port-forward. Falls back to an inline
-     `WHERE snapshot_id=(SELECT max(id) …)` query if the `latest` view doesn't exist yet
-     (i.e. before the next sync recreates the schema).
+     aged-out "ghosts"). Read via `mail-actions/_db.py`'s kubectl port-forward. Falls back
+     to an inline `WHERE snapshot_id=(SELECT max(id) …)` query if the `latest` view doesn't
+     exist yet (i.e. before the next sync recreates the schema).
   2. The LIVE tmux overlay — attached at RENDER TIME from THIS host's tmux server, reusing
-     the scan's machinery (`collect_tmux_panes` / `match_tmux_to_initiatives` / …) rather
-     than reimplementing it. Deliberately NOT stored in Postgres (the durable-vs-live split
-     the agent-ops dashboard uses). Absent if there's no tmux server (best-effort).
+     the scan's machinery. Deliberately NOT stored in Postgres. Absent if there's no tmux
+     server (best-effort).
 
 Layering mirrors sync.py / route.py: the pure render transform (`build_model` /
-`render_html`) is separated from all I/O (the DB read, the tmux read, the HTTP server),
-so it is unit-testable with fixtures — no live DB, no live tmux, no sockets.
+`model_to_json` / `render_html`) and the pure detail/summary parse are separated from all
+I/O (the DB read, the tmux read, the refresh subprocess, the HTTP server), so they are
+unit-testable with fixtures — no live DB, no live tmux, no sockets, no subprocess.
 
 Serving:
-  Routes: `/` (HTML), `/healthz` (200/ok — process liveness, NOT the DB), and
-  `/api/initiatives.json` (the JSON the page is built from). Binds LAN/localhost only by
-  default; NOT wired into the public homelab gateway — this is internal work data. A short
-  in-process cache (a few seconds) avoids hammering the port-forward on rapid refreshes.
-  A DB outage renders a clear error page and keeps serving (never crash-loops).
+  Routes: `/` (HTML), `/healthz` (200/ok — process liveness, NOT the DB),
+  `/api/initiatives.json` (the JSON the page is built from), `/api/initiative?repo=&slug=`
+  (one initiative's live detail), and `POST /refresh` (trigger a sync now). Binds
+  LAN/localhost only by default; NOT wired into the public homelab gateway — internal work
+  data. A short in-process cache (a few seconds) avoids hammering the port-forward on rapid
+  refreshes. A DB outage renders a clear error page and keeps serving (never crash-loops).
 
 Requires (for the live read; the pure render path needs none of these):
     KUBECONFIG  — homelab kubeconfig (the DB is only reachable via kubectl port-forward)
@@ -44,15 +55,17 @@ import html
 import importlib.util
 import json
 import os
+import subprocess
 import sys
 import threading
 import time
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
-# The scan we borrow the tmux machinery from (hyphenated filename → importlib, not import).
+# The scan we borrow the tmux machinery + the deterministic doc parsers from (hyphenated
+# filename → importlib, not import).
 SCAN_PATH = Path(__file__).resolve().parents[1] / "session-analysis" / "initiative-scan.py"
 # chquery lives here; the scan adds it to sys.path on import, mirror that so the scan's
 # top-level `import chquery` resolves regardless of cwd.
@@ -61,12 +74,17 @@ VALIDATION_DIR = Path(__file__).resolve().parents[1] / "validation"
 # The shared mailbox-Postgres helper (kubectl port-forward + psycopg2 + DSN-from-secret).
 MAILDB_PATH = Path(__file__).resolve().parents[1] / "mail-actions" / "_db.py"
 
+# The sync wrapper the ↻ refresh button shells out to (it already does the nix-shell +
+# sops cred decrypt + scan + store write). Running it as a subprocess sidesteps the
+# `systemctl --user`-from-a-service dbus/XDG_RUNTIME_DIR complexity.
+RUN_SYNC_PATH = Path(__file__).resolve().parent / "run-sync.sh"
+
 # The rich display columns the viewer reads (present on both `initiatives.latest` and the
 # base `initiative_snapshot` table, so the inline fallback selects the SAME set + captured_at).
 DISPLAY_COLUMNS = [
-    "slug", "repo", "title", "momentum", "last_touch", "next_step", "commits",
+    "slug", "repo", "title", "summary", "momentum", "last_touch", "next_step", "commits",
     "commits_unknown", "merged_prs", "open_prs", "session_count", "telem_events",
-    "current_doc", "open_investigations",
+    "current_doc", "open_investigations", "docs",
 ]
 
 # Momentum ordering + badges — SAME ranks/glyphs the scan uses (active→stalled→unknown).
@@ -78,13 +96,20 @@ MOMENTUM_BADGE = {
     "unknown": ("·", "unknown"),  # ·
 }
 
-# Auto-refresh cadence for the page (seconds) — matches the "sync is hourly, but tmux is
-# live" story: a 30s refresh keeps the tmux overlay near-live without hammering the DB (the
-# provider cache absorbs the store reads).
+# The page's client-side auto-refresh cadence (seconds) — re-fetches the JSON and re-renders
+# in place (keeps the live tmux overlay + freshness current WITHOUT resetting the search box,
+# the flat/grouped toggle, or any expanded cards). The store itself is synced ~15min by the
+# timer; the ↻ button forces one on demand.
 REFRESH_SECONDS = 30
-DEFAULT_HOST = "192.168.50.94"  # workbench-LAN bind; override with --host 127.0.0.1 for local
+DEFAULT_HOST = "192.168.50.250"  # workbench-LAN bind (eth1); use --host 127.0.0.1 for local
 DEFAULT_PORT = 8899
 CACHE_TTL_SECONDS = 5.0
+
+# Refresh (↻) debounce + single-flight: ignore a refresh if a sync ran within this many
+# seconds ("just synced Xs ago" instead of re-running); a hard ceiling so a hung scan can't
+# wedge the request forever (matches the sync unit's TimeoutStartSec).
+REFRESH_MIN_INTERVAL = 60.0
+REFRESH_TIMEOUT = 300
 
 
 # --------------------------------------------------------------------------- #
@@ -94,12 +119,13 @@ _scan_mod = None
 
 
 def _scan():
-    """Load initiative-scan.py by explicit path and cache it (for the tmux machinery).
+    """Load initiative-scan.py by explicit path and cache it (for the tmux machinery +
+    the deterministic handoff parsers `parse_summary`/`parse_all_next_steps`/
+    `parse_open_investigations`/`parse_handoff_title`).
 
     Lazy + side-effect-light: the scan's top-level `import chquery` only runs the first
-    time the tmux overlay is attached. `chquery` needs `requests` + the
-    `scripts/validation` dir on sys.path; we add the latter idempotently, mirroring
-    route.py."""
+    time this is called. `chquery` needs `requests` + the `scripts/validation` dir on
+    sys.path; we add the latter idempotently, mirroring route.py."""
     global _scan_mod
     if _scan_mod is None:
         vdir = str(VALIDATION_DIR)
@@ -187,7 +213,7 @@ def attach_tmux(initiatives: list[dict]) -> bool:
 
 
 # --------------------------------------------------------------------------- #
-# Pure render transform (rows -> model -> HTML). No I/O — unit-tested with fixtures.
+# Pure render transform (rows -> model -> JSON). No I/O — unit-tested with fixtures.
 # --------------------------------------------------------------------------- #
 def _as_utc(dt) -> datetime | None:
     """Coerce a value to a tz-aware UTC datetime (psycopg2 returns tz-aware; a naive
@@ -229,15 +255,29 @@ def _short_repo(repo: str | None) -> str:
     return os.path.basename(str(repo).rstrip("/")) if repo else "(unknown repo)"
 
 
+def _norm_docs(docs) -> list[dict]:
+    """The stored `docs` jsonb -> a stable list of {path, date} dicts (str-coerced)."""
+    out: list[dict] = []
+    for d in docs or []:
+        if isinstance(d, dict):
+            out.append({"path": str(d.get("path") or ""),
+                        "date": (str(d["date"]) if d.get("date") else None)})
+    return out
+
+
 def _initiative_view(ini: dict, now: datetime) -> dict:
     """One store row (+ any attached tmux_sessions) -> a flat, template-ready view dict."""
     momentum = ini.get("momentum") or "unknown"
     glyph, label = momentum_badge(momentum)
     open_prs = ini.get("open_prs") or []
     tmux = sorted(ini.get("tmux_sessions") or [])
+    repo = ini.get("repo")
     return {
         "slug": ini.get("slug") or "(no slug)",
+        "repo": repo or "",
+        "repo_name": _short_repo(repo),
         "title": ini.get("title") or "",
+        "summary": (ini.get("summary") or "").strip(),
         "momentum": momentum,
         "momentum_rank": MOMENTUM_RANK.get(momentum, 9),
         "badge_glyph": glyph,
@@ -258,18 +298,26 @@ def _initiative_view(ini: dict, now: datetime) -> dict:
         "open_investigations": [
             str(x) for x in (ini.get("open_investigations") or [])
         ],
+        "docs": _norm_docs(ini.get("docs")),
         "tmux_sessions": tmux,
     }
 
 
-def build_model(rows: list[dict], now: datetime | None = None) -> dict:
-    """PURE: store rows (+ any attached tmux) -> a grouped, sorted render model.
+def _flat_sort_key(v: dict):
+    """Flat ordering: most-recently-active first (last_touch DESC), a None last_touch
+    sorts last, momentum then slug as stable tiebreaks."""
+    ts = v["last_touch"].timestamp() if v["last_touch"] else float("-inf")
+    return (-ts, v["momentum_rank"], v["slug"])
 
-    Groups initiatives by repo; within a repo sorts by momentum (active→stalled→unknown)
-    then recency (newest last_touch first); orders repos by their most-active initiative
-    then by name, so the busiest repos surface first. `captured_at` (the snapshot's
-    freshness, carried on every row) drives the 'updated Xm ago' footer. An empty row
-    list yields an empty (but well-formed) model — never raises."""
+
+def build_model(rows: list[dict], now: datetime | None = None) -> dict:
+    """PURE: store rows (+ any attached tmux) -> BOTH a grouped and a flat render model.
+
+    `repos` groups initiatives by repo (within a repo: momentum then recency; repos
+    ordered by their most-active initiative then name). `flat` is one stream of ALL
+    initiatives ordered most-recently-active first (the default view; each card carries
+    a repo label). `captured_at` (the snapshot's freshness) drives the footer. An empty
+    row list yields an empty (but well-formed) model — never raises."""
     now = now or datetime.now(timezone.utc)
 
     # The snapshot freshness = the newest captured_at across the rows (they should all
@@ -277,9 +325,11 @@ def build_model(rows: list[dict], now: datetime | None = None) -> dict:
     captured_ats = [_as_utc(r.get("captured_at")) for r in rows]
     captured_at = max((c for c in captured_ats if c is not None), default=None)
 
+    views = [_initiative_view(r, now) for r in rows]
+
     by_repo: dict[str | None, list[dict]] = {}
-    for r in rows:
-        by_repo.setdefault(r.get("repo"), []).append(_initiative_view(r, now))
+    for r, v in zip(rows, views):
+        by_repo.setdefault(r.get("repo"), []).append(v)
 
     repos: list[dict] = []
     for repo_path, inis in by_repo.items():
@@ -296,6 +346,8 @@ def build_model(rows: list[dict], now: datetime | None = None) -> dict:
         })
     repos.sort(key=lambda g: (g["best_rank"], g["name"]))
 
+    flat = sorted(views, key=_flat_sort_key)
+
     return {
         "generated_at": now,
         "captured_at": captured_at,
@@ -303,13 +355,14 @@ def build_model(rows: list[dict], now: datetime | None = None) -> dict:
         "total": len(rows),
         "repo_count": len(repos),
         "repos": repos,
+        "flat": flat,
     }
 
 
 def model_to_json(model: dict | None, error: str | None) -> dict:
     """The `/api/initiatives.json` payload (datetimes isoformatted via json default=str)."""
     if error is not None or model is None:
-        return {"ok": False, "error": error or "no data", "repos": []}
+        return {"ok": False, "error": error or "no data", "repos": [], "flat": []}
     return {
         "ok": True,
         "generated_at": model["generated_at"],
@@ -318,11 +371,141 @@ def model_to_json(model: dict | None, error: str | None) -> dict:
         "total": model["total"],
         "repo_count": model["repo_count"],
         "repos": model["repos"],
+        "flat": model["flat"],
     }
 
 
 # --------------------------------------------------------------------------- #
-# HTML rendering — self-contained, inline CSS, gruvbox-ish, no external assets.
+# Detail — one initiative's live handoff read (with a path-traversal guard) + parse.
+# --------------------------------------------------------------------------- #
+def parse_doc_detail(text: str) -> dict:
+    """PURE: a handoff doc's text -> its key sections (via the scan's deterministic
+    parsers, single-sourced — no reimplementation). Goal/summary, the FULL Next-steps
+    list (not just the lead item), Open investigations, and the title."""
+    scan = _scan()
+    return {
+        "title": scan.parse_handoff_title(text),
+        "summary": scan.parse_summary(text),
+        "next_steps": scan.parse_all_next_steps(text),
+        "open_investigations": scan.parse_open_investigations(text),
+    }
+
+
+def safe_doc_path(repo: str, current_doc: str,
+                  repos: list[str] | None = None) -> Path | None:
+    """Resolve `current_doc` to a real path ONLY if it is safe to read: contained under
+    `<repo>/claudedocs/` (realpath-resolved, so `..`/symlink escapes are rejected), the
+    repo is a known/discovered repo when `repos` is supplied, and the file exists. None
+    otherwise. Both `repo` and `current_doc` come from the STORE (not user query input),
+    but this is defense-in-depth against a traversal via a poisoned stored path."""
+    if not repo or not current_doc:
+        return None
+    try:
+        repo_real = Path(repo).resolve()
+    except Exception:  # noqa: BLE001
+        return None
+    if repos is not None and not any(
+        _safe_resolve(r) == repo_real for r in repos
+    ):
+        return None
+    claudedocs = (repo_real / "claudedocs").resolve()
+    doc = _safe_resolve(current_doc)
+    if doc is None:
+        return None
+    if claudedocs not in doc.parents:  # must live directly/indirectly under claudedocs/
+        return None
+    if not doc.is_file():
+        return None
+    return doc
+
+
+def _safe_resolve(p: str) -> Path | None:
+    try:
+        return Path(p).resolve()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def read_doc_detail_live(repo: str, current_doc: str,
+                         repos: list[str] | None = None) -> dict | None:
+    """I/O: validate the handoff path, read it off disk, and parse its sections. None on a
+    failed guard / missing file / read error (the caller falls back to the stored fields)."""
+    path = safe_doc_path(repo, current_doc, repos)
+    if path is None:
+        return None
+    try:
+        text = path.read_text(errors="replace")
+    except OSError:
+        return None
+    try:
+        return parse_doc_detail(text)
+    except Exception:  # noqa: BLE001 - a scan-import hiccup must not 500 the endpoint
+        return None
+
+
+def _discover_repos_safe() -> list[str] | None:
+    """Best-effort `discover_repos()` for the traversal guard; None if the scan can't load."""
+    try:
+        return _scan().discover_repos()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _find_view(model: dict, repo: str, slug: str) -> dict | None:
+    for v in model.get("flat") or []:
+        if v.get("repo") == repo and v.get("slug") == slug:
+            return v
+    return None
+
+
+def build_detail(model: dict | None, error: str | None, repo: str, slug: str,
+                 doc_reader=read_doc_detail_live) -> dict:
+    """PURE-ish: (model, repo, slug) -> the `/api/initiative` payload. Starts from the
+    STORED fields (first next-step + open_investigations + PRs + docs) and OVERLAYS the
+    live handoff read when it succeeds (full Next-steps list + Open investigations +
+    fresher summary/title). `doc_reader` is injectable so the merge is unit-testable with
+    no disk. Unknown (repo, slug) -> ok:false so the endpoint 404s."""
+    if error is not None or model is None:
+        return {"ok": False, "error": error or "no data"}
+    view = _find_view(model, repo, slug)
+    if view is None:
+        return {"ok": False, "error": f"no initiative for repo={repo!r} slug={slug!r}"}
+
+    detail = {
+        "ok": True,
+        "repo": view["repo"],
+        "repo_name": view["repo_name"],
+        "slug": view["slug"],
+        "title": view["title"],
+        "summary": view.get("summary") or "",
+        "current_doc": view.get("current_doc") or "",
+        "open_prs": view["open_prs"],
+        "docs": view.get("docs") or [],
+        "next_steps": [view["next_step"]] if view.get("next_step") else [],
+        "open_investigations": view["open_investigations"],
+        "live": False,
+    }
+
+    live = None
+    try:
+        live = doc_reader(view["repo"], view.get("current_doc") or "")
+    except Exception:  # noqa: BLE001 - a read failure just means "use the stored fields"
+        live = None
+    if live:
+        detail["live"] = True
+        if live.get("summary"):
+            detail["summary"] = live["summary"]
+        if live.get("title"):
+            detail["title"] = live["title"]
+        if live.get("next_steps"):
+            detail["next_steps"] = live["next_steps"]
+        if live.get("open_investigations"):
+            detail["open_investigations"] = live["open_investigations"]
+    return detail
+
+
+# --------------------------------------------------------------------------- #
+# HTML rendering — self-contained, inline CSS + vanilla JS, gruvbox, no external assets.
 # --------------------------------------------------------------------------- #
 _CSS = """
 :root{
@@ -336,19 +519,37 @@ body{margin:0;background:var(--bg);color:var(--fg);
   font-size:14px;line-height:1.5;padding:1.2rem}
 a{color:var(--blue);text-decoration:none}
 a:hover{text-decoration:underline}
-header{display:flex;flex-wrap:wrap;align-items:baseline;gap:.6rem;
+header{display:flex;flex-wrap:wrap;align-items:center;gap:.6rem;
   border-bottom:1px solid var(--bg2);padding-bottom:.6rem;margin-bottom:1rem}
 header h1{font-size:1.15rem;margin:0;color:var(--yellow)}
 header .meta{color:var(--gray);font-size:.85rem}
+.controls{display:flex;flex-wrap:wrap;align-items:center;gap:.5rem;margin-left:auto}
+.toggle{display:inline-flex;border:1px solid var(--bg2);border-radius:4px;overflow:hidden}
+.tbtn{background:var(--bg1);color:var(--fg2);border:0;padding:.3rem .7rem;cursor:pointer;
+  font:inherit;font-size:.82rem}
+.tbtn:hover{background:var(--bg2)}
+.tbtn.active{background:var(--blue);color:var(--bg)}
+.search{background:var(--bg1);color:var(--fg);border:1px solid var(--bg2);border-radius:4px;
+  padding:.3rem .55rem;font:inherit;font-size:.82rem;min-width:12rem}
+.search:focus{outline:1px solid var(--blue)}
+.rbtn{background:var(--bg1);color:var(--aqua);border:1px solid var(--bg2);border-radius:4px;
+  padding:.3rem .7rem;cursor:pointer;font:inherit;font-size:.82rem}
+.rbtn:hover:not(:disabled){background:var(--bg2)}
+.rbtn:disabled{opacity:.6;cursor:progress}
+.rbtn.spin{animation:pulse 1s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:.5}50%{opacity:1}}
+.rmsg{color:var(--gray);font-size:.78rem}
 .repo{margin:0 0 1.4rem}
 .repo > h2{font-size:.95rem;margin:0 0 .5rem;color:var(--aqua);
   border-bottom:1px dotted var(--bg2);padding-bottom:.25rem}
 .repo > h2 .count{color:var(--gray);font-weight:normal;font-size:.8rem;margin-left:.4rem}
 .ini{background:var(--bg1);border-left:3px solid var(--gray);border-radius:4px;
-  padding:.55rem .7rem;margin:0 0 .5rem}
+  padding:.55rem .7rem;margin:0 0 .5rem;cursor:pointer}
+.ini:hover{background:#40393622}
 .ini.active{border-left-color:var(--green)}
 .ini.slowing{border-left-color:var(--yellow)}
 .ini.stalled{border-left-color:var(--gray)}
+.ini.open{outline:1px solid var(--bg2)}
 .ini .row1{display:flex;flex-wrap:wrap;align-items:baseline;gap:.5rem}
 .badge{font-weight:bold}
 .badge.active{color:var(--green)}
@@ -357,7 +558,10 @@ header .meta{color:var(--gray);font-size:.85rem}
 .badge.unknown{color:var(--gray)}
 .slug{font-weight:bold;color:var(--fg)}
 .title{color:var(--fg2)}
+.repo-label{font-size:.75rem;color:var(--aqua);background:var(--bg2);border-radius:3px;
+  padding:.02rem .4rem}
 .age{color:var(--gray);font-size:.82rem;margin-left:auto}
+.summary{margin-top:.3rem;color:var(--fg);font-size:.86rem}
 .tags{margin-top:.3rem;display:flex;flex-wrap:wrap;gap:.35rem;align-items:center}
 .tag{font-size:.78rem;padding:.05rem .4rem;border-radius:3px;background:var(--bg2);color:var(--fg2)}
 .tag.tmux{background:#665c54;color:var(--green)}
@@ -365,13 +569,262 @@ header .meta{color:var(--gray);font-size:.85rem}
 .tag.stat{background:transparent;color:var(--gray);padding-left:0}
 .next{margin-top:.3rem;color:var(--fg2);font-size:.86rem}
 .next b{color:var(--orange);font-weight:normal}
-.invs{margin:.25rem 0 0;padding-left:1.1rem;color:var(--gray);font-size:.8rem}
+.detail{margin-top:.5rem;padding-top:.5rem;border-top:1px dotted var(--bg2)}
+.detail-summary{color:var(--fg);font-size:.86rem;margin-bottom:.4rem}
+.detail-h{color:var(--orange);font-size:.8rem;margin:.4rem 0 .15rem;text-transform:uppercase;
+  letter-spacing:.04em}
+.detail-list{margin:.1rem 0 .3rem;padding-left:1.1rem;color:var(--fg2);font-size:.84rem}
+.detail-list li{margin:.1rem 0}
+.detail-doc{color:var(--gray);font-size:.78rem;margin-top:.35rem;word-break:break-all}
+.detail-err{color:var(--red);font-size:.82rem}
 .empty{color:var(--gray);padding:2rem 0}
 .err{background:#442222;border:1px solid var(--red);color:var(--fg);
   padding:1rem;border-radius:4px}
 .err b{color:var(--red)}
 footer{margin-top:1.5rem;padding-top:.6rem;border-top:1px solid var(--bg2);
   color:var(--gray);font-size:.8rem}
+footer .live{color:var(--green)}
+""".strip()
+
+
+# The whole page's client-side behaviour: parse the embedded JSON, render flat|grouped,
+# filter by search, expand a card (live detail fetch), refresh (POST /refresh), and
+# auto-refresh the data in place. Vanilla JS, no framework, no external assets. Untrusted
+# text is written via textContent (never innerHTML) so it can't inject markup.
+_JS = r"""
+(function(){
+  var el0 = document.getElementById('idata');
+  var data;
+  try { data = JSON.parse(el0.textContent); }
+  catch(e){ data = {ok:false, error:'bad payload', repos:[], flat:[]}; }
+
+  var VIEW_KEY = 'initiatives-view';
+  var state = { view: (localStorage.getItem(VIEW_KEY) === 'grouped') ? 'grouped' : 'flat',
+                q: '' };
+  var expanded = {};     // key -> true
+  var detailCache = {};  // key -> detail payload
+
+  var app = document.getElementById('app');
+  var searchInput = document.getElementById('search');
+  var footer = document.getElementById('foot');
+  var btnFlat = document.getElementById('view-flat');
+  var btnGrouped = document.getElementById('view-grouped');
+  var btnRefresh = document.getElementById('refresh');
+  var refreshMsg = document.getElementById('refresh-msg');
+  var countEl = document.getElementById('count');
+
+  function key(v){ return (v.repo || '') + '::' + (v.slug || ''); }
+
+  function matchQ(v, q){
+    if(!q) return true;
+    var hay = ((v.slug||'') + ' ' + (v.title||'') + ' ' + (v.summary||'') + ' ' +
+               (v.repo_name||'') + ' ' + (v.momentum||'')).toLowerCase();
+    return hay.indexOf(q) !== -1;
+  }
+
+  function el(tag, cls, txt){
+    var e = document.createElement(tag);
+    if(cls) e.className = cls;
+    if(txt != null) e.textContent = txt;
+    return e;
+  }
+
+  function renderDetail(det, d, v){
+    det.innerHTML = '';
+    if(!d || !d.ok){
+      det.appendChild(el('div', 'detail-err', (d && d.error) || 'detail unavailable'));
+      return;
+    }
+    if(d.summary) det.appendChild(el('div', 'detail-summary', d.summary));
+    var ns = d.next_steps || [];
+    if(ns.length){
+      det.appendChild(el('div', 'detail-h', 'Next steps'));
+      var ul = el('ul', 'detail-list');
+      ns.forEach(function(s){ ul.appendChild(el('li', null, s)); });
+      det.appendChild(ul);
+    }
+    var oi = d.open_investigations || [];
+    if(oi.length){
+      det.appendChild(el('div', 'detail-h', 'Open investigations'));
+      var ul2 = el('ul', 'detail-list');
+      oi.forEach(function(s){ ul2.appendChild(el('li', null, s)); });
+      det.appendChild(ul2);
+    }
+    var prs = d.open_prs || (v && v.open_prs) || [];
+    if(prs.length){
+      det.appendChild(el('div', 'detail-h', 'Open PRs'));
+      var ul3 = el('ul', 'detail-list');
+      prs.forEach(function(p){
+        ul3.appendChild(el('li', null,
+          (p.number != null ? ('#' + p.number + ' ') : '') + (p.title || '')));
+      });
+      det.appendChild(ul3);
+    }
+    if(d.current_doc){
+      det.appendChild(el('div', 'detail-doc',
+        (d.live ? 'handoff (live read): ' : 'handoff: ') + d.current_doc));
+    }
+    var docs = d.docs || [];
+    if(docs.length > 1){
+      det.appendChild(el('div', 'detail-h', 'Docs history'));
+      var ul4 = el('ul', 'detail-list');
+      docs.forEach(function(x){
+        ul4.appendChild(el('li', null, (x.date || '?') + '  ' + (x.path || '')));
+      });
+      det.appendChild(ul4);
+    }
+  }
+
+  function loadDetail(v, det){
+    var k = key(v);
+    if(detailCache[k]){ renderDetail(det, detailCache[k], v); return; }
+    det.textContent = 'loading…';
+    fetch('/api/initiative?repo=' + encodeURIComponent(v.repo) +
+          '&slug=' + encodeURIComponent(v.slug))
+      .then(function(r){ return r.json(); })
+      .then(function(d){ detailCache[k] = d; renderDetail(det, d, v); })
+      .catch(function(){ renderDetail(det, {ok:false, error:'detail unavailable'}, v); });
+  }
+
+  function card(v){
+    var k = key(v);
+    var c = el('div', 'ini ' + (v.momentum || 'unknown'));
+    c.setAttribute('data-key', k);
+
+    var row1 = el('div', 'row1');
+    row1.appendChild(el('span', 'badge ' + (v.momentum || 'unknown'),
+                        v.badge_glyph + ' ' + v.badge_label));
+    row1.appendChild(el('span', 'slug', v.slug));
+    if(v.title) row1.appendChild(el('span', 'title', v.title));
+    if(state.view === 'flat' && v.repo_name)
+      row1.appendChild(el('span', 'repo-label', v.repo_name));
+    row1.appendChild(el('span', 'age', 'updated ' + v.age + ' ago'));
+    c.appendChild(row1);
+
+    if(v.summary) c.appendChild(el('div', 'summary', v.summary));
+
+    var tags = el('div', 'tags');
+    (v.tmux_sessions || []).forEach(function(s){
+      tags.appendChild(el('span', 'tag tmux', '[tmux:' + s + ']'));
+    });
+    (v.open_prs || []).forEach(function(p){
+      var label = (p.number != null ? ('#' + p.number) : 'PR') + (p.title ? (' ' + p.title) : '');
+      var t = el('span', 'tag pr', label);
+      if(p.title) t.title = p.title;
+      tags.appendChild(t);
+    });
+    var commits = v.commits_unknown ? '?' : v.commits;
+    tags.appendChild(el('span', 'tag stat',
+      commits + ' commits · ' + v.merged_prs + ' merged · ' +
+      v.session_count + ' sess · ' + v.telem_events + ' ev'));
+    c.appendChild(tags);
+
+    if(v.next_step){
+      var nx = el('div', 'next');
+      nx.appendChild(el('b', null, 'next'));
+      nx.appendChild(document.createTextNode(' › ' + v.next_step));
+      c.appendChild(nx);
+    }
+
+    var det = el('div', 'detail');
+    det.style.display = 'none';
+    c.appendChild(det);
+
+    c.addEventListener('click', function(ev){
+      if(ev.target.closest('a')) return;
+      if(expanded[k]){ delete expanded[k]; det.style.display = 'none'; c.classList.remove('open'); }
+      else { expanded[k] = true; det.style.display = 'block'; c.classList.add('open'); loadDetail(v, det); }
+    });
+    if(expanded[k]){ det.style.display = 'block'; c.classList.add('open'); loadDetail(v, det); }
+    return c;
+  }
+
+  function updateChrome(){
+    btnFlat.classList.toggle('active', state.view === 'flat');
+    btnGrouped.classList.toggle('active', state.view === 'grouped');
+    if(countEl) countEl.textContent =
+      (data.total || 0) + ' in flight across ' + (data.repo_count || 0) + ' repos';
+    footer.innerHTML = '';
+    footer.appendChild(el('span', 'live', 'live sessions ● realtime'));
+    var age = data.captured_age ? (data.captured_age + ' ago') : 'unknown';
+    footer.appendChild(document.createTextNode(' · store synced ' + age +
+      ' · click a card to expand'));
+  }
+
+  function render(){
+    app.innerHTML = '';
+    if(!data.ok){
+      app.appendChild(el('div', 'err', 'store unreachable: ' + (data.error || '')));
+      updateChrome();
+      return;
+    }
+    var q = state.q.trim().toLowerCase();
+    var shown = 0;
+    if(state.view === 'flat'){
+      var wrap = el('div', 'flat');
+      (data.flat || []).forEach(function(v){
+        if(matchQ(v, q)){ wrap.appendChild(card(v)); shown++; }
+      });
+      app.appendChild(wrap);
+    } else {
+      (data.repos || []).forEach(function(g){
+        var vis = (g.initiatives || []).filter(function(v){ return matchQ(v, q); });
+        if(!vis.length) return;
+        var sec = el('section', 'repo');
+        var h = el('h2', null, g.name);
+        h.appendChild(el('span', 'count', String(vis.length)));
+        sec.appendChild(h);
+        vis.forEach(function(v){ sec.appendChild(card(v)); shown++; });
+        app.appendChild(sec);
+      });
+    }
+    if(shown === 0){
+      app.appendChild(el('div', 'empty',
+        q ? ('No initiatives match "' + state.q + '".')
+          : 'No initiatives in the latest snapshot.'));
+    }
+    updateChrome();
+  }
+
+  function refetch(){
+    return fetch('/api/initiatives.json')
+      .then(function(r){ return r.json(); })
+      .then(function(d){ data = d; detailCache = {}; render(); });
+  }
+
+  function doRefresh(){
+    btnRefresh.disabled = true;
+    btnRefresh.classList.add('spin');
+    refreshMsg.textContent = 'refreshing…';
+    fetch('/refresh', {method: 'POST'})
+      .then(function(r){ return r.json().then(function(j){ return {code: r.status, j: j}; }); })
+      .then(function(res){
+        var j = res.j || {};
+        refreshMsg.textContent = j.message || (res.code < 400 ? 'done' : 'error');
+        return refetch();
+      })
+      .catch(function(){ refreshMsg.textContent = 'refresh failed'; })
+      .then(function(){
+        btnRefresh.disabled = false;
+        btnRefresh.classList.remove('spin');
+        setTimeout(function(){ refreshMsg.textContent = ''; }, 5000);
+      });
+  }
+
+  btnFlat.addEventListener('click', function(){
+    state.view = 'flat'; localStorage.setItem(VIEW_KEY, 'flat'); render();
+  });
+  btnGrouped.addEventListener('click', function(){
+    state.view = 'grouped'; localStorage.setItem(VIEW_KEY, 'grouped'); render();
+  });
+  searchInput.addEventListener('input', function(){ state.q = searchInput.value; render(); });
+  btnRefresh.addEventListener('click', doRefresh);
+
+  setInterval(function(){ refetch().catch(function(){}); }, __REFRESH_MS__);
+
+  searchInput.value = state.q;
+  render();
+})();
 """.strip()
 
 
@@ -380,101 +833,129 @@ def _e(s) -> str:
     return html.escape("" if s is None else str(s))
 
 
-def _render_initiative(v: dict) -> str:
-    m = v["momentum"]
-    parts = [f'<div class="ini {_e(m)}">']
-    # Row 1: badge · slug · title · age
-    parts.append('<div class="row1">')
-    parts.append(f'<span class="badge {_e(m)}">{_e(v["badge_glyph"])} {_e(v["badge_label"])}</span>')
-    parts.append(f'<span class="slug">{_e(v["slug"])}</span>')
-    if v["title"]:
-        parts.append(f'<span class="title">{_e(v["title"])}</span>')
-    parts.append(f'<span class="age">updated {_e(v["age"])} ago</span>')
-    parts.append('</div>')
-
-    # Tags: tmux sessions, open PRs, and a couple of stat chips.
-    tags: list[str] = []
-    for sess in v["tmux_sessions"]:
-        tags.append(f'<span class="tag tmux">[tmux:{_e(sess)}]</span>')
-    for pr in v["open_prs"]:
-        num = pr["number"]
-        label = f'#{num}' if num is not None else 'PR'
-        title = f' {_e(pr["title"])}' if pr["title"] else ''
-        tags.append(f'<span class="tag pr" title="{_e(pr["title"])}">{_e(label)}{title}</span>')
-    commits = "?" if v["commits_unknown"] else v["commits"]
-    stat = f'{commits} commits · {v["merged_prs"]} merged · {v["session_count"]} sess · {v["telem_events"]} ev'
-    tags.append(f'<span class="tag stat">{_e(stat)}</span>')
-    parts.append(f'<div class="tags">{"".join(tags)}</div>')
-
-    # Next step.
-    if v["next_step"]:
-        parts.append(f'<div class="next"><b>next</b> &rsaquo; {_e(v["next_step"])}</div>')
-
-    # Open investigations (first few).
-    if v["open_investigations"]:
-        lis = "".join(f"<li>{_e(x)}</li>" for x in v["open_investigations"][:3])
-        parts.append(f'<ul class="invs">{lis}</ul>')
-
-    parts.append('</div>')
-    return "".join(parts)
+def _embed_json(payload: dict) -> str:
+    """Serialize a payload for a <script type=application/json> island, neutralizing any
+    markup so untrusted text (titles/summaries/PR titles) can't break out of the script
+    element or inject a tag. `\\uXXXX` escapes are valid JSON and JSON.parse restores them."""
+    s = json.dumps(payload, default=str, ensure_ascii=False)
+    return (s.replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
+             .replace(" ", "\\u2028").replace(" ", "\\u2029"))
 
 
 def render_html(model: dict | None, error: str | None = None,
                 refresh: int = REFRESH_SECONDS) -> str:
     """PURE: a render model (or an error) -> a complete, self-contained HTML page.
 
-    Auto-refreshes via <meta http-equiv=refresh>; all CSS inline; no external assets. A
-    None model / non-None error renders a clear inline error box (the store was
-    unreachable) while STILL serving a valid page, so a DB blip degrades gracefully."""
+    The OK page embeds the model as a JSON island + inline JS that renders flat|grouped,
+    filters by search, expands cards (live detail fetch), and refreshes. A None model /
+    non-None error renders a clear server-side error box (no JS needed) while STILL serving
+    a valid page, so a DB blip degrades gracefully."""
     head = (
         '<!doctype html><html lang="en"><head><meta charset="utf-8">'
         '<meta name="viewport" content="width=device-width,initial-scale=1">'
-        f'<meta http-equiv="refresh" content="{int(refresh)}">'
         '<title>initiatives</title>'
         f'<style>{_CSS}</style></head><body>'
     )
-    body: list[str] = []
 
     if error is not None or model is None:
-        body.append('<header><h1>initiatives</h1>'
-                    '<span class="meta">live viewer</span></header>')
-        body.append(
+        body = (
+            '<header><h1>initiatives</h1>'
+            '<span class="meta">live viewer</span></header>'
             '<div class="err"><b>store unreachable</b> — could not read the '
             'initiatives store this refresh. Retrying automatically.'
-            f'<br><small>{_e(error or "no data")}</small></div>')
-        body.append('<footer>the page auto-refreshes; the store is populated by the '
-                    'hourly initiatives-sync timer.</footer>')
-        return head + "".join(body) + "</body></html>"
+            f'<br><small>{_e(error or "no data")}</small></div>'
+            '<footer>the page auto-refreshes; the store is populated by the '
+            'initiatives-sync timer (~15min) or the ↻ refresh button.</footer>'
+        )
+        return head + body + "</body></html>"
 
-    total, repo_count = model["total"], model["repo_count"]
-    body.append(
-        '<header><h1>initiatives</h1>'
-        f'<span class="meta">{total} in flight across {repo_count} repos</span>'
-        '</header>')
+    payload = _embed_json(model_to_json(model, None))
+    header = (
+        '<header>'
+        '<h1>initiatives</h1>'
+        '<span class="meta" id="count"></span>'
+        '<div class="controls">'
+        '<div class="toggle" role="group" aria-label="view">'
+        '<button id="view-flat" class="tbtn" type="button">flat</button>'
+        '<button id="view-grouped" class="tbtn" type="button">grouped</button>'
+        '</div>'
+        '<input id="search" class="search" type="search" placeholder="filter…" '
+        'autocomplete="off" spellcheck="false" aria-label="filter initiatives">'
+        '<button id="refresh" class="rbtn" type="button" '
+        'title="run a fresh sync now">↻ refresh</button>'
+        '<span id="refresh-msg" class="rmsg"></span>'
+        '</div>'
+        '</header>'
+    )
+    js = _JS.replace("__REFRESH_MS__", str(int(refresh) * 1000))
+    return (
+        head + header +
+        '<main id="app"></main>'
+        '<footer id="foot"></footer>'
+        '<script id="idata" type="application/json">' + payload + '</script>'
+        '<script>' + js + '</script>'
+        '</body></html>'
+    )
 
-    if not model["repos"]:
-        body.append('<div class="empty">No initiatives in the latest snapshot. '
-                    '(The store may be empty, or every initiative aged out of the '
-                    'scan window.)</div>')
-    for group in model["repos"]:
-        body.append('<section class="repo">')
-        body.append(f'<h2>{_e(group["name"])}'
-                    f'<span class="count">{len(group["initiatives"])}</span></h2>')
-        for v in group["initiatives"]:
-            body.append(_render_initiative(v))
-        body.append('</section>')
 
-    # Footer: freshness from the snapshot's captured_at + the sync cadence.
-    if model["captured_at"] is not None:
-        cap = model["captured_at"].strftime("%Y-%m-%d %H:%M UTC")
-        fresh = f'updated {_e(model["captured_age"])} ago · snapshot {_e(cap)} · hourly sync'
-    else:
-        fresh = 'no snapshot captured_at · hourly sync'
-    gen = model["generated_at"].strftime("%H:%M:%S UTC")
-    body.append(f'<footer>{fresh} · tmux overlay is live · '
-                f'page rendered {_e(gen)}, auto-refresh {int(refresh)}s</footer>')
+# --------------------------------------------------------------------------- #
+# Refresh controller — single-flight + debounced subprocess sync (the ↻ button).
+# --------------------------------------------------------------------------- #
+def _run_sync_subprocess(script: Path, timeout: int) -> tuple[int, str]:
+    """Run run-sync.sh as a subprocess (it does its own nix-shell + sops + scan + write).
+    Returns (returncode, trailing-stderr). Inherits the viewer unit's env (KUBECONFIG,
+    PATH incl. sops/gh/kubectl)."""
+    proc = subprocess.run(["bash", str(script)], capture_output=True, text=True,
+                          timeout=timeout)
+    err = (proc.stderr or "").strip()
+    return proc.returncode, err[-500:]
 
-    return head + "".join(body) + "</body></html>"
+
+class RefreshController:
+    """Serializes on-demand syncs: only ONE runs at a time (single-flight), and a refresh
+    within `min_interval` seconds of the last one is DEBOUNCED ("just synced Xs ago")
+    instead of re-running, so the button can't hammer git/gh/ClickHouse/Postgres. Runs the
+    sync via a subprocess (`runner`, injectable for tests) so a ~15-30s sync doesn't block
+    other requests (the ThreadingHTTPServer serves it on its own thread)."""
+
+    def __init__(self, script: Path = RUN_SYNC_PATH,
+                 min_interval: float = REFRESH_MIN_INTERVAL,
+                 timeout: int = REFRESH_TIMEOUT,
+                 runner=_run_sync_subprocess,
+                 now_fn=time.monotonic):
+        self._script = script
+        self._min_interval = min_interval
+        self._timeout = timeout
+        self._runner = runner
+        self._now = now_fn
+        self._lock = threading.Lock()
+        self._running = False
+        self._last_at: float | None = None
+
+    def refresh(self) -> dict:
+        with self._lock:
+            if self._running:
+                return {"ok": False, "status": "in_progress",
+                        "message": "a sync is already in progress"}
+            now = self._now()
+            if self._last_at is not None and (now - self._last_at) < self._min_interval:
+                ago = int(now - self._last_at)
+                return {"ok": True, "status": "debounced",
+                        "message": f"just synced {ago}s ago", "age_seconds": ago}
+            self._running = True
+        rc, err = 1, ""
+        try:
+            rc, err = self._runner(self._script, self._timeout)
+        except Exception as exc:  # noqa: BLE001 - timeout/spawn failure → error result
+            rc, err = 1, f"{type(exc).__name__}: {exc}"
+        finally:
+            with self._lock:
+                self._running = False
+                self._last_at = self._now()
+        if rc == 0:
+            return {"ok": True, "status": "synced", "message": "sync complete"}
+        return {"ok": False, "status": "error",
+                "message": f"sync failed (rc={rc})", "detail": err}
 
 
 # --------------------------------------------------------------------------- #
@@ -486,8 +967,8 @@ class DataProvider:
 
     `snapshot()` returns `(model, error)`: on success `(model, None)`, on any read
     failure `(None, "<message>")` — the server renders the error inline and keeps
-    serving (no crash-loop). Thread-safe: the ThreadingHTTPServer serves requests
-    concurrently, so the cache is guarded by a lock and only ONE refresh runs at a time.
+    serving (no crash-loop). `invalidate()` drops the cache so the NEXT snapshot re-reads
+    (used right after a ↻ refresh writes a new store snapshot). Thread-safe.
     """
 
     def __init__(self, ttl: float = CACHE_TTL_SECONDS,
@@ -500,6 +981,11 @@ class DataProvider:
         self._lock = threading.Lock()
         self._cached: tuple[dict | None, str | None] | None = None
         self._fetched_at = 0.0
+
+    def invalidate(self) -> None:
+        with self._lock:
+            self._cached = None
+            self._fetched_at = 0.0
 
     def snapshot(self) -> tuple[dict | None, str | None]:
         with self._lock:
@@ -519,36 +1005,77 @@ class DataProvider:
 # --------------------------------------------------------------------------- #
 # HTTP layer — a thin BaseHTTPRequestHandler over a pure `route_request`.
 # --------------------------------------------------------------------------- #
-def route_request(path: str, provider) -> tuple[int, str, bytes]:
-    """PURE-ish request router: (path, provider) -> (status, content_type, body bytes).
+def route_request(path: str, provider, method: str = "GET", query: dict | None = None,
+                  refresh_controller=None) -> tuple[int, str, bytes]:
+    """PURE-ish request router: (path, provider, method, query, refresh) -> (status,
+    content_type, body bytes). Separated from the socket handler so it's unit-testable
+    with a fake provider / controller (no server, no DB, no subprocess).
 
-    Separated from the socket handler so it's unit-testable with a fake provider (no
-    server, no DB). `/healthz` is deliberately independent of the store — it reports
-    PROCESS liveness (200/ok) so a DB outage doesn't take the unit 'unhealthy' and
-    trigger a needless restart; the store's health surfaces on the page itself."""
+    `/healthz` is deliberately store-independent (PROCESS liveness). `POST /refresh` runs
+    a single-flighted+debounced sync then invalidates the provider cache on success.
+    `/api/initiative` returns one initiative's live detail."""
     if path == "/healthz":
         return 200, "text/plain; charset=utf-8", b"ok\n"
+
+    if method == "POST" and path == "/refresh":
+        if refresh_controller is None:
+            return (503, "application/json; charset=utf-8",
+                    json.dumps({"ok": False, "status": "disabled",
+                                "message": "refresh not available"}).encode("utf-8"))
+        result = refresh_controller.refresh()
+        if result.get("status") == "synced":
+            try:
+                provider.invalidate()
+            except Exception:  # noqa: BLE001 - a missing invalidate() must not 500
+                pass
+        code = {"synced": 200, "debounced": 200, "in_progress": 409,
+                "error": 500, "disabled": 503}.get(result.get("status"), 200)
+        return (code, "application/json; charset=utf-8",
+                json.dumps(result).encode("utf-8"))
+
     if path in ("/", ""):
         model, error = provider.snapshot()
         return 200, "text/html; charset=utf-8", render_html(model, error).encode("utf-8")
+
     if path == "/api/initiatives.json":
         model, error = provider.snapshot()
         payload = json.dumps(model_to_json(model, error), default=str,
                              ensure_ascii=False, indent=2)
         return 200, "application/json; charset=utf-8", payload.encode("utf-8")
+
+    if path == "/api/initiative":
+        q = query or {}
+        repo = _first_qs(q, "repo")
+        slug = _first_qs(q, "slug")
+        model, error = provider.snapshot()
+        detail = build_detail(model, error, repo, slug)
+        code = 200 if detail.get("ok") else 404
+        return (code, "application/json; charset=utf-8",
+                json.dumps(detail, default=str, ensure_ascii=False).encode("utf-8"))
+
     return 404, "text/plain; charset=utf-8", b"not found\n"
 
 
-def make_handler(provider):
-    """Build a BaseHTTPRequestHandler subclass bound to `provider`."""
+def _first_qs(query: dict, name: str) -> str:
+    v = query.get(name)
+    if isinstance(v, list):
+        return v[0] if v else ""
+    return v if isinstance(v, str) else ""
+
+
+def make_handler(provider, refresh_controller=None):
+    """Build a BaseHTTPRequestHandler subclass bound to `provider` + `refresh_controller`."""
 
     class Handler(BaseHTTPRequestHandler):
-        server_version = "initiatives-viewer/1.0"
+        server_version = "initiatives-viewer/2.0"
 
-        def _serve(self, write_body: bool) -> None:
-            path = urlparse(self.path).path
+        def _serve(self, write_body: bool, method: str) -> None:
+            parsed = urlparse(self.path)
+            query = parse_qs(parsed.query)
             try:
-                status, ctype, body = route_request(path, provider)
+                status, ctype, body = route_request(
+                    parsed.path, provider, method=method, query=query,
+                    refresh_controller=refresh_controller)
             except Exception as exc:  # noqa: BLE001 - never let a handler error kill the thread
                 status, ctype = 500, "text/plain; charset=utf-8"
                 body = f"internal error: {type(exc).__name__}: {exc}\n".encode("utf-8")
@@ -560,11 +1087,24 @@ def make_handler(provider):
             if write_body:
                 self.wfile.write(body)
 
+        def _drain_body(self) -> None:
+            """Consume any request body so the connection stays usable (POST /refresh)."""
+            try:
+                n = int(self.headers.get("Content-Length", 0) or 0)
+            except ValueError:
+                n = 0
+            if n > 0:
+                self.rfile.read(n)
+
         def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract
-            self._serve(write_body=True)
+            self._serve(write_body=True, method="GET")
 
         def do_HEAD(self) -> None:  # noqa: N802
-            self._serve(write_body=False)
+            self._serve(write_body=False, method="GET")
+
+        def do_POST(self) -> None:  # noqa: N802
+            self._drain_body()
+            self._serve(write_body=True, method="POST")
 
         def log_message(self, fmt, *args) -> None:  # quiet: one compact line to stderr
             sys.stderr.write("viewer: %s - %s\n" % (self.address_string(), fmt % args))
@@ -572,13 +1112,15 @@ def make_handler(provider):
     return Handler
 
 
-def serve(host: str, port: int, provider: DataProvider | None = None) -> None:
+def serve(host: str, port: int, provider: DataProvider | None = None,
+          refresh_controller: RefreshController | None = None) -> None:
     """Start the blocking HTTP server on host:port with a threaded handler."""
     provider = provider or DataProvider()
-    httpd = ThreadingHTTPServer((host, port), make_handler(provider))
+    refresh_controller = refresh_controller or RefreshController()
+    httpd = ThreadingHTTPServer((host, port), make_handler(provider, refresh_controller))
     httpd.daemon_threads = True
     sys.stderr.write(f"viewer: serving on http://{host}:{port}/ "
-                     f"(/, /healthz, /api/initiatives.json)\n")
+                     f"(/, /healthz, /api/initiatives.json, /api/initiative, POST /refresh)\n")
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:
@@ -606,7 +1148,7 @@ def parse_args(argv=None) -> argparse.Namespace:
 
 def main(argv=None) -> int:
     a = parse_args(argv)
-    serve(a.host, a.port, DataProvider(ttl=a.ttl))
+    serve(a.host, a.port, DataProvider(ttl=a.ttl), RefreshController())
     return 0
 
 

--- a/scripts/initiatives/viewer.py
+++ b/scripts/initiatives/viewer.py
@@ -112,6 +112,10 @@ CACHE_TTL_SECONDS = 5.0
 REFRESH_MIN_INTERVAL = 60.0
 REFRESH_TIMEOUT = 300
 
+# Upper bound on a live handoff read (GET /api/initiative). Handoffs are KBs; this caps
+# a pathological/huge file so the detail read can't spike the viewer's memory.
+MAX_DOC_BYTES = 512 * 1024
+
 
 # --------------------------------------------------------------------------- #
 # Lazy imports of the two borrowed modules (single-sourced; not reimplemented).
@@ -430,12 +434,20 @@ def _safe_resolve(p: str) -> Path | None:
 def read_doc_detail_live(repo: str, current_doc: str,
                          repos: list[str] | None = None) -> dict | None:
     """I/O: validate the handoff path, read it off disk, and parse its sections. None on a
-    failed guard / missing file / read error (the caller falls back to the stored fields)."""
+    failed guard / missing file / read error (the caller falls back to the stored fields).
+
+    When `repos` is not supplied, resolves it from `_discover_repos_safe()` so the
+    known-repo allowlist in `safe_doc_path` ACTUALLY runs (best-effort — if the scan
+    can't load, discovery is None and only realpath-containment guards the read). The
+    read is bounded to `MAX_DOC_BYTES` so a pathological file can't spike memory."""
+    if repos is None:
+        repos = _discover_repos_safe()
     path = safe_doc_path(repo, current_doc, repos)
     if path is None:
         return None
     try:
-        text = path.read_text(errors="replace")
+        with path.open("r", errors="replace") as f:
+            text = f.read(MAX_DOC_BYTES)  # bounded read (handoffs are KBs; cap is generous)
     except OSError:
         return None
     try:

--- a/scripts/initiatives/viewer.py
+++ b/scripts/initiatives/viewer.py
@@ -55,6 +55,7 @@ import html
 import importlib.util
 import json
 import os
+import signal
 import subprocess
 import sys
 import threading
@@ -901,14 +902,42 @@ def render_html(model: dict | None, error: str | None = None,
 # --------------------------------------------------------------------------- #
 # Refresh controller — single-flight + debounced subprocess sync (the ↻ button).
 # --------------------------------------------------------------------------- #
+def _kill_process_group(proc) -> None:
+    """SIGTERM then (if it lingers) SIGKILL the process's WHOLE group; reap it. Best-effort."""
+    try:
+        pgid = os.getpgid(proc.pid)
+    except (ProcessLookupError, OSError):
+        return
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(pgid, sig)
+        except (ProcessLookupError, OSError):
+            return
+        try:
+            proc.wait(timeout=5)
+            return
+        except subprocess.TimeoutExpired:
+            continue
+
+
 def _run_sync_subprocess(script: Path, timeout: int) -> tuple[int, str]:
     """Run run-sync.sh as a subprocess (it does its own nix-shell + sops + scan + write).
     Returns (returncode, trailing-stderr). Inherits the viewer unit's env (KUBECONFIG,
-    PATH incl. sops/gh/kubectl)."""
-    proc = subprocess.run(["bash", str(script)], capture_output=True, text=True,
-                          timeout=timeout)
-    err = (proc.stderr or "").strip()
-    return proc.returncode, err[-500:]
+    PATH incl. sops/gh/kubectl).
+
+    Runs in its OWN session/process group (`start_new_session=True`) so a timeout can kill
+    the ENTIRE tree — subprocess.run's timeout would SIGKILL only the `bash` child, orphaning
+    the `nix-shell → python sync.py → kubectl port-forward` grandchildren (which would then
+    pile up under the next refresh/timer sync). On TimeoutExpired we SIGTERM/SIGKILL the whole
+    group and re-raise (the controller turns it into an error result)."""
+    proc = subprocess.Popen(["bash", str(script)], stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, text=True, start_new_session=True)
+    try:
+        _out, err = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _kill_process_group(proc)
+        raise
+    return proc.returncode, (err or "").strip()[-500:]
 
 
 class RefreshController:
@@ -954,8 +983,11 @@ class RefreshController:
                 self._last_at = self._now()
         if rc == 0:
             return {"ok": True, "status": "synced", "message": "sync complete"}
-        return {"ok": False, "status": "error",
-                "message": f"sync failed (rc={rc})", "detail": err}
+        # Log the stderr tail server-side (journal) — do NOT return it to the
+        # unauthenticated client (avoid leaking internal paths/creds hints).
+        if err:
+            sys.stderr.write(f"viewer: refresh sync failed (rc={rc}): {err}\n")
+        return {"ok": False, "status": "error", "message": f"sync failed (rc={rc})"}
 
 
 # --------------------------------------------------------------------------- #
@@ -1018,6 +1050,10 @@ def route_request(path: str, provider, method: str = "GET", query: dict | None =
         return 200, "text/plain; charset=utf-8", b"ok\n"
 
     if method == "POST" and path == "/refresh":
+        # Deliberately UNAUTHENTICATED: the viewer binds LAN/localhost only (not the public
+        # gateway), so /refresh is LAN-trusted by design (Zach's call). Abuse is bounded by
+        # the controller's single-flight + ~60s debounce + the sync's own idempotency —
+        # NOT by auth/token/localhost-gating (intentionally none).
         if refresh_controller is None:
             return (503, "application/json; charset=utf-8",
                     json.dumps({"ok": False, "status": "disabled",

--- a/scripts/session-analysis/initiative-scan.py
+++ b/scripts/session-analysis/initiative-scan.py
@@ -117,6 +117,22 @@ ANY_H2_RE = re.compile(r"^##\s+")
 LIST_ITEM_RE = re.compile(r"^\s*(?:\d+[.)]|[-*])\s+(.*\S)\s*$")
 H3_RE = re.compile(r"^###\s+(.*\S)\s*$")
 
+# Explicit "what this is" markers for parse_summary. Inline form
+# ("**Goal:** …", "Objective: …", "- **Summary:** …") captures the trailing text;
+# the section-heading form ("## Goal", "## Status") points at the paragraph beneath.
+# Optional list marker + optional bold/italic wrappers around the keyword and value.
+SUMMARY_INLINE_RE = re.compile(
+    r"^\s*(?:[-*+]\s+)?[*_]{0,3}\s*(?:goal|objective|summary|status|tl;?dr)"
+    r"\s*[*_]{0,3}\s*:\s*[*_]{0,3}\s*(.*)$",
+    re.I,
+)
+SUMMARY_HEADING_RE = re.compile(
+    r"^#{1,6}\s+(?:goal|objective|summary|status|tl;?dr)\b", re.I)
+# A markdown horizontal rule / thematic break (---, ***, ___).
+HRULE_RE = re.compile(r"^\s*([-*_])(?:\s*\1){2,}\s*$")
+# Cap on the extracted summary length (chars), so a card stays legible.
+SUMMARY_MAX = 200
+
 
 # --------------------------------------------------------------------------- #
 # Pure logic (unit-tested without live infra)
@@ -210,6 +226,107 @@ def _flatten_md(s: str) -> str:
     s = re.sub(r"`(.+?)`", r"\1", s)
     s = re.sub(r"(?<!\*)\*(?!\*)(.+?)\*", r"\1", s)
     return " ".join(s.split())
+
+
+def parse_all_next_steps(text: str) -> list[str]:
+    """EVERY ranked item under the `## Next steps` section (not just the first).
+
+    Companion to `parse_next_step` (which returns only the lead item) — the live
+    viewer's expanded card wants the full list. Same template rules: collect every
+    list item (`1.` / `-` / `*`) until the next H2, leading marker stripped and inline
+    markdown flattened. Empty list if there's no Next-steps section or no items.
+    """
+    lines = text.splitlines()
+    in_section = False
+    out: list[str] = []
+    for line in lines:
+        if NEXT_STEPS_RE.match(line):
+            in_section = True
+            continue
+        if in_section:
+            if ANY_H2_RE.match(line):
+                break
+            m = LIST_ITEM_RE.match(line)
+            if m:
+                out.append(_flatten_md(m.group(1)))
+    return out
+
+
+def _cap_summary(s: str) -> str | None:
+    """Trim + collapse; cap at SUMMARY_MAX chars on a word boundary (adds '…'). None if blank."""
+    s = s.strip()
+    if not s:
+        return None
+    if len(s) <= SUMMARY_MAX:
+        return s
+    cut = s[:SUMMARY_MAX].rstrip()
+    sp = cut.rfind(" ")
+    if sp >= int(SUMMARY_MAX * 0.6):
+        cut = cut[:sp].rstrip()
+    return cut + "…"
+
+
+def _strip_list_marker(s: str) -> str:
+    m = LIST_ITEM_RE.match(s)
+    return m.group(1) if m else s
+
+
+def _first_prose_paragraph(lines: list[str], start: int) -> str | None:
+    """First prose block at/after `start`: skip blanks/headings/rules (and a leading
+    list block), then join consecutive non-blank prose lines until a blank/heading/rule.
+    A leading list marker on the block's first line is stripped. None if no prose."""
+    i, n = start, len(lines)
+    while i < n:
+        s = lines[i].strip()
+        if s and not s.startswith("#") and not HRULE_RE.match(lines[i]):
+            break
+        i += 1
+    if i >= n:
+        return None
+    buf: list[str] = []
+    while i < n:
+        s = lines[i].strip()
+        if not s or s.startswith("#") or HRULE_RE.match(lines[i]):
+            break
+        buf.append(_strip_list_marker(s) if not buf else s)
+        i += 1
+    return " ".join(buf) if buf else None
+
+
+def parse_summary(text: str) -> str | None:
+    """A deterministic 1-2 line "what this is" for a handoff (NO LLM).
+
+    Preference order:
+      1. An explicit inline marker — `**Goal:** …`, `Objective: …`, `Summary: …`,
+         `Status: …`, `TL;DR: …` (optionally a list item / bold) — takes its trailing
+         text; if the marker line has no trailing text (e.g. `**Goal:**` alone) or is a
+         `## Goal` / `## Status` section heading, takes the first prose paragraph beneath.
+      2. Fallback: the first non-heading, non-blank prose paragraph after the leading
+         `# ` title (or the top of the doc if there's no title).
+    Markdown is flattened, whitespace collapsed, and the result capped at ~200 chars.
+    None only when the doc has no prose at all.
+    """
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        m = SUMMARY_INLINE_RE.match(line)
+        if m:
+            val = m.group(1).strip()
+            if val:
+                return _cap_summary(_flatten_md(val))
+            para = _first_prose_paragraph(lines, i + 1)
+            if para:
+                return _cap_summary(_flatten_md(para))
+        elif SUMMARY_HEADING_RE.match(line):
+            para = _first_prose_paragraph(lines, i + 1)
+            if para:
+                return _cap_summary(_flatten_md(para))
+    start = 0
+    for i, line in enumerate(lines):
+        if line.startswith("# "):
+            start = i + 1
+            break
+    para = _first_prose_paragraph(lines, start)
+    return _cap_summary(_flatten_md(para)) if para else None
 
 
 # Ultra-common tokens that would over-match if used as an initiative fingerprint.
@@ -448,6 +565,7 @@ def cluster_handoffs(docs: list[dict]) -> list[dict]:
             "repo": repo,
             "slug": slug,
             "title": cur["title"],
+            "summary": cur["summary"],
             "date": cur["date"],
             "doc_mtime": cur["mtime"],
             "next_step": cur["next_step"],
@@ -628,6 +746,7 @@ def read_handoff(path: str) -> dict:
         "date": date,
         "mtime": _safe_mtime(path),
         "title": parse_handoff_title(text) or slug,
+        "summary": parse_summary(text),
         "next_step": parse_next_step(text),
         "open_investigations": parse_open_investigations(text),
     }
@@ -1446,6 +1565,8 @@ def render(report: dict, now: float | None = None) -> str:
             out.append(head)
             if ini.get("title") and ini["title"] != ini["slug"]:
                 out.append(f"        “{ini['title']}”")
+            if ini.get("summary"):
+                out.append(f"        » {ini['summary'][:160]}")
             for pr in ini.get("open_prs", []):
                 out.append(f"        OPEN PR #{pr['number']}: {pr['title'][:80]}")
             ns = ini.get("next_step")

--- a/scripts/session-analysis/tests/test_initiative_scan.py
+++ b/scripts/session-analysis/tests/test_initiative_scan.py
@@ -104,6 +104,70 @@ def test_next_step_section_ends_at_next_h2():
     assert isc.parse_next_step(doc) is None
 
 
+def test_all_next_steps_returns_every_item_flattened():
+    steps = isc.parse_all_next_steps(NEXT_DOC)
+    assert steps == ["Ship the extractor on the live mail table — highest leverage.",
+                     "Lower: rotate the OpenRouter key."]
+
+
+def test_all_next_steps_stops_at_next_h2_and_empty_without_section():
+    doc = "## Next steps\n- a\n- b\n\n## Gotchas\n- not counted\n"
+    assert isc.parse_all_next_steps(doc) == ["a", "b"]
+    assert isc.parse_all_next_steps("## Goal\nx\n") == []
+
+
+# --------------------------------------------------------------------------- #
+# Summary / goal extraction (parse_summary)
+# --------------------------------------------------------------------------- #
+def test_summary_inline_bold_goal_marker():
+    doc = ("# Handoff — X, 2026-07-22\n\n"
+           "**Goal:** consolidate the scan output into a durable store.\n\n"
+           "## Status\nsomething else\n")
+    assert isc.parse_summary(doc) == "consolidate the scan output into a durable store."
+
+
+def test_summary_plain_objective_marker_flattens_markdown():
+    assert isc.parse_summary("Objective: build **the** thing `fast`\n") == "build the thing fast"
+
+
+def test_summary_status_heading_takes_paragraph_beneath():
+    doc = "# T\n\n## Status\n\nWe are mid-flight on the migration.\n\n## Next steps\n1. x\n"
+    assert isc.parse_summary(doc) == "We are mid-flight on the migration."
+
+
+def test_summary_empty_marker_falls_to_paragraph_beneath():
+    doc = "# T\n\n**Goal:**\n\nDeferred goal paragraph here.\n"
+    assert isc.parse_summary(doc) == "Deferred goal paragraph here."
+
+
+def test_summary_first_paragraph_fallback_when_no_marker():
+    doc = "# Title only heading\n\nResumed from the earlier handoff and shipped the thing.\n"
+    assert isc.parse_summary(doc) == "Resumed from the earlier handoff and shipped the thing."
+
+
+def test_summary_none_when_no_prose():
+    assert isc.parse_summary("# Only a title\n") is None
+    assert isc.parse_summary("") is None
+
+
+def test_summary_caps_length_with_ellipsis():
+    s = isc.parse_summary("Goal: " + "word " * 80)
+    assert s is not None
+    assert len(s) <= isc.SUMMARY_MAX + 1  # +1 for the trailing ellipsis
+    assert s.endswith("…")
+
+
+def test_summary_carried_through_read_handoff_and_cluster(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "claudedocs").mkdir(parents=True)
+    doc = repo / "claudedocs" / "handoff-thing-2026-07-20.md"
+    doc.write_text("# Thing — 2026-07-20\n\n**Goal:** do the thing well.\n")
+    parsed = isc.read_handoff(str(doc))
+    assert parsed["summary"] == "do the thing well."
+    inis = isc.cluster_handoffs([parsed])
+    assert inis[0]["summary"] == "do the thing well."
+
+
 # --------------------------------------------------------------------------- #
 # Open-investigations section (newer template)
 # --------------------------------------------------------------------------- #
@@ -142,10 +206,11 @@ def test_open_inv_doc_still_parses_next_step():
 # --------------------------------------------------------------------------- #
 # Dated-variant clustering
 # --------------------------------------------------------------------------- #
-def _doc(repo, slug, date, mtime, title="t", next_step="ns", path=None):
+def _doc(repo, slug, date, mtime, title="t", next_step="ns", path=None, summary="s"):
     return {
         "repo": repo, "slug": slug, "date": date, "mtime": mtime,
-        "title": title, "next_step": next_step, "open_investigations": [],
+        "title": title, "summary": summary, "next_step": next_step,
+        "open_investigations": [],
         "path": path or f"{repo}/claudedocs/handoff-{slug}-{date}.md",
     }
 


### PR DESCRIPTION
Enhances the **Phase-3 initiatives web viewer** for three pieces of user feedback. Self-contained throughout (stdlib `http.server`, inline vanilla JS/CSS, no framework/CDN — matches the existing design + artifact-style CSP discipline). Human deploys + live-verifies (see below); this PR is fixture-verified only.

## Feedback 1 — flat default + toggle + search
- `build_model` now emits a `flat` stream (`last_touch` DESC) alongside grouped `repos`; each view carries `repo`/`repo_name`/`summary`. The page renders **client-side** from an embedded JSON island.
- Header **flat|grouped toggle** (flat is default, persisted in `localStorage`); flat cards show a **repo label**.
- Client-side **search** over slug/title/summary/repo/momentum, works in both views. No server round-trip to switch/filter.

## Feedback 2 — "realtime"
- `initiatives-sync` cadence **1h → 15min** (`OnUnitActiveSec`), still well under gh 5000/hr at 4×.
- **`POST /refresh`** runs `run-sync.sh` as a **subprocess** (avoids the `systemctl --user`-from-a-service dbus complexity), **single-flighted + debounced ~60s** ("just synced Xs ago"). The header **↻ button** shows a `refreshing…` state, then re-fetches + re-renders; on success it invalidates the provider cache so the reload sees fresh rows. Failure re-enables the button with a brief error.
- **Honest footer**: `live sessions ● realtime · store synced Xm ago` (no more confusing "hourly").
- Viewer unit PATH gains `sops`+`gh` so a refresh-triggered sync runs telemetry-on with PR reads.

## Feedback 3 — legible cards
- New deterministic **`parse_summary()`** in `initiative-scan.py` (explicit `Goal`/`Objective`/`Summary`/`Status` marker → its text or the paragraph beneath; else the first prose paragraph after the title; markdown-flattened, ~200-char cap) + **`parse_all_next_steps()`**. `summary` flows through `read_handoff`/`cluster_handoffs`/`--json`.
- `sync.py` adds an **additive nullable `summary text` column** (`ADD COLUMN IF NOT EXISTS`) + bumps the `latest`/`current` view versions so `SELECT i.*` re-exposes it (Postgres freezes `*` at create time).
- Cards render the **summary line** and **open-PR titles** (not bare numbers).
- **Click-to-expand**: `GET /api/initiative?repo=&slug=` **live-reads the handoff off disk** (full `## Next steps` list + `## Open investigations` + PR titles + doc path + docs history), **path-traversal-guarded** (realpath containment under `<repo>/claudedocs/`, known repo), falling back to the stored fields on a failed read.

Drive-by: fix the stale `192.168.50.94` bind default (a homelab node) → `192.168.50.250` (workbench eth1) in `viewer.py` + `run-viewer.sh`.

## Tests
+40 hermetic tests (no live infra). `scripts/run-tests.sh` **green**; `nix-instantiate --parse nix/home.nix` clean. Also smoke-tested a live `ThreadingHTTPServer` (real sockets: `GET /`, `/api/initiatives.json`, `/api/initiative`, `POST /refresh` twice → synced then debounced) with a stubbed provider/runner.

⚠️ **Fixture-only** — NOT deployed, and the live store / `/refresh` subprocess / live handoff-read were not exercised against real infra. Deploy + verify steps for the human are in the handoff/PR discussion. Viewer binds **192.168.50.250:8899** (workbench eth1, NOT .94).

🤖 Generated with [Claude Code](https://claude.com/claude-code)