### PR TITLE
feat(initiatives): Phase A card legibility — bring the conversation onto the card

### DIFF
--- a/scripts/initiatives/sync.py
+++ b/scripts/initiatives/sync.py
@@ -94,14 +94,23 @@ CREATE TABLE IF NOT EXISTS initiatives.initiative_snapshot (
     telem_last           timestamptz,
     current_doc          text,
     open_investigations  jsonb,
-    docs                 jsonb
+    docs                 jsonb,
+    recent_messages      jsonb,
+    recent_commits       jsonb
 );
 
 -- Additive migration for pre-existing installs: CREATE TABLE IF NOT EXISTS won't add
--- a column to a table that already exists, so bring `summary` (nullable, deterministic
--- goal/what-this-is line) in explicitly. Idempotent — a no-op once the column exists.
+-- a column to a table that already exists, so bring the nullable, deterministic display
+-- columns in explicitly. Idempotent — a no-op once each column exists.
+--   summary          — the parsed goal/what-this-is line (v2).
+--   recent_messages  — the user's own recent prompts [{text, ts}] newest-first (v3).
+--   recent_commits   — recent commit subjects [str] newest-first (v3).
 ALTER TABLE initiatives.initiative_snapshot
     ADD COLUMN IF NOT EXISTS summary text;
+ALTER TABLE initiatives.initiative_snapshot
+    ADD COLUMN IF NOT EXISTS recent_messages jsonb;
+ALTER TABLE initiatives.initiative_snapshot
+    ADD COLUMN IF NOT EXISTS recent_commits jsonb;
 
 -- Support the `current` view's DISTINCT ON (repo, slug) … JOIN snapshots …
 -- ORDER BY repo, slug, captured_at DESC, plus the FK join / retention scans.
@@ -123,10 +132,14 @@ CREATE INDEX IF NOT EXISTS snapshots_captured_at_idx
 # includes initiatives that have aged out of the scan's N-day window (until the
 # 90-day retention prunes them): the ROUTER wants to match a signal against
 # recently-dormant work, so ghosts are a feature there.
-# v2: the base table gained a `summary` column. A view's `SELECT i.*` is expanded to
-# an explicit column list AT CREATE TIME (Postgres freezes it), so the new column does
-# NOT appear until the view is recreated — bump the marker to force that on deploy.
-VIEW_VERSION = "v2"
+# A view's `SELECT i.*` is expanded to an explicit column list AT CREATE TIME (Postgres
+# freezes it), so a base-table column added later does NOT appear until the view is
+# recreated — bump the marker to force a guarded DROP+CREATE on deploy.
+#   v2: the base table gained `summary`.
+#   v3: the base table gained `recent_messages` + `recent_commits`. Appending them
+#       reorders `SELECT i.*, s.captured_at` (captured_at shifts right), which CREATE OR
+#       REPLACE VIEW rejects ("cannot change name of view column") — hence DROP+CREATE.
+VIEW_VERSION = "v3"
 VIEW_COMMENT = f"initiatives-sync view {VIEW_VERSION}"
 VIEW_DDL = """
 CREATE VIEW initiatives.current AS
@@ -142,8 +155,9 @@ SELECT DISTINCT ON (i.repo, i.slug)
 # (an initiative that dropped out of the scan's window simply isn't in the newest
 # snapshot, so it disappears here even though `current` still carries it). Carries
 # `captured_at` so the viewer can render an "updated Xm ago" freshness footer.
-# v2: recreate to expose the new `summary` column (see VIEW_VERSION note above).
-LATEST_VIEW_VERSION = "v2"
+# v3: recreate to expose `summary` (v2) + `recent_messages`/`recent_commits` (v3) — see
+# the VIEW_VERSION note above for why this is DROP+CREATE, not CREATE OR REPLACE.
+LATEST_VIEW_VERSION = "v3"
 LATEST_VIEW_COMMENT = f"initiatives-sync view latest {LATEST_VIEW_VERSION}"
 LATEST_VIEW_DDL = """
 CREATE VIEW initiatives.latest AS
@@ -166,10 +180,11 @@ ROW_COLUMNS = [
     "host", "repo", "slug", "title", "summary", "doc_date", "momentum", "last_touch",
     "next_step", "commits", "commits_unknown", "merged_prs", "open_prs",
     "session_count", "telem_events", "telem_last", "current_doc",
-    "open_investigations", "docs",
+    "open_investigations", "docs", "recent_messages", "recent_commits",
 ]
 # Columns stored as JSONB (wrapped in psycopg2.extras.Json at write time).
-JSONB_COLUMNS = {"open_prs", "open_investigations", "docs"}
+JSONB_COLUMNS = {"open_prs", "open_investigations", "docs",
+                 "recent_messages", "recent_commits"}
 
 
 # --------------------------------------------------------------------------- #
@@ -238,6 +253,11 @@ def _initiative_to_row(ini: dict, host: str) -> dict:
         "current_doc": ini.get("current_doc"),
         "open_investigations": ini.get("open_investigations") or [],
         "docs": ini.get("docs") or [],
+        # Deterministic card-legibility signals (Phase A): the user's own recent prompts
+        # ([{text, ts}] newest-first) + recent commit subjects ([str] newest-first). Kept
+        # as-is (raw) so a later Phase B LLM recap can reuse them.
+        "recent_messages": ini.get("recent_messages") or [],
+        "recent_commits": ini.get("recent_commits") or [],
     }
 
 

--- a/scripts/initiatives/tests/test_sync.py
+++ b/scripts/initiatives/tests/test_sync.py
@@ -45,6 +45,12 @@ def _fixture_initiative(**over):
         "telem_last": _TELEM_EPOCH,
         "last_touch": _TOUCH_EPOCH,
         "momentum": "active",
+        "recent_messages": [
+            {"text": "add the recent_commits column and bump the view", "ts": _TOUCH_EPOCH},
+            {"text": "eyeball the dry-run before writing", "ts": _TELEM_EPOCH},
+        ],
+        "recent_commits": ["feat: enrich cards with recent messages",
+                           "fix: dedupe pooled turns"],
     }
     ini.update(over)
     return ini
@@ -186,6 +192,32 @@ def test_summary_is_in_row_columns_after_title():
     # title for readability, and ensure it IS one of the written columns.
     assert "summary" in sync.ROW_COLUMNS
     assert sync.ROW_COLUMNS.index("summary") == sync.ROW_COLUMNS.index("title") + 1
+
+
+def test_recent_messages_and_commits_pass_through():
+    _meta, rows = sync.report_to_rows(_fixture_report(), host="workbench")
+    r = rows[0]
+    assert r["recent_messages"] == [
+        {"text": "add the recent_commits column and bump the view", "ts": _TOUCH_EPOCH},
+        {"text": "eyeball the dry-run before writing", "ts": _TELEM_EPOCH},
+    ]
+    assert r["recent_commits"] == ["feat: enrich cards with recent messages",
+                                   "fix: dedupe pooled turns"]
+
+
+def test_recent_fields_default_to_empty_list_when_absent():
+    ini = _fixture_initiative()
+    ini.pop("recent_messages", None)
+    ini.pop("recent_commits", None)
+    _meta, rows = sync.report_to_rows(_fixture_report(by_repo={"/r": [ini]}), host="workbench")
+    assert rows[0]["recent_messages"] == []
+    assert rows[0]["recent_commits"] == []
+
+
+def test_recent_columns_are_written_and_jsonb():
+    assert "recent_messages" in sync.ROW_COLUMNS
+    assert "recent_commits" in sync.ROW_COLUMNS
+    assert {"recent_messages", "recent_commits"} <= sync.JSONB_COLUMNS
 
 
 def test_commits_unknown_true_passes_through():
@@ -352,11 +384,47 @@ def test_ensure_schema_adds_summary_column_additively():
     assert "ADD COLUMN IF NOT EXISTS summary text" in joined  # additive migration
 
 
-def test_view_versions_bumped_so_summary_column_is_exposed():
+def test_view_versions_bumped_so_new_columns_are_exposed():
     # A view's SELECT i.* is frozen at create time; bumping the marker forces a recreate
-    # so the new `summary` column surfaces on initiatives.latest / .current.
-    assert sync.VIEW_VERSION == "v2"
-    assert sync.LATEST_VIEW_VERSION == "v2"
+    # so base-table columns added later (summary=v2; recent_messages/recent_commits=v3)
+    # surface on initiatives.latest / .current. v3 is the card-legibility bump.
+    assert sync.VIEW_VERSION == "v3"
+    assert sync.LATEST_VIEW_VERSION == "v3"
+    assert sync.VIEW_COMMENT == "initiatives-sync view v3"
+    assert sync.LATEST_VIEW_COMMENT == "initiatives-sync view latest v3"
+
+
+def test_ensure_schema_adds_recent_columns_additively():
+    # Fresh installs get the columns in CREATE TABLE; pre-existing tables get them via
+    # idempotent ADD COLUMN IF NOT EXISTS (the exact v2→v3 additive migration).
+    conn = _FakeConn()
+    sync.ensure_schema(conn)
+    joined = " ".join(_sqls(conn))  # whitespace-normalized by the fake cursor
+    assert "recent_messages jsonb" in joined  # in CREATE TABLE
+    assert "recent_commits jsonb" in joined
+    assert "ADD COLUMN IF NOT EXISTS recent_messages jsonb" in joined
+    assert "ADD COLUMN IF NOT EXISTS recent_commits jsonb" in joined
+
+
+def test_ensure_schema_v2_to_v3_recreates_both_views_drop_before_create():
+    # The migration trap: appending recent_messages/recent_commits reorders the views'
+    # `SELECT i.*, s.captured_at` columns, which CREATE OR REPLACE VIEW rejects. Simulate
+    # a live v2 store (both views present, marked v2) and assert the v3 marker mismatch
+    # fires DROP-before-CREATE on BOTH views (never the shape-locked CREATE OR REPLACE).
+    conn = _FakeConn(view_regclass="initiatives.current",
+                     view_comment="initiatives-sync view v2",
+                     latest_regclass="initiatives.latest",
+                     latest_comment="initiatives-sync view latest v2")
+    sync.ensure_schema(conn)
+    sqls = _sqls(conn)
+    assert "CREATE OR REPLACE VIEW" not in " ".join(sqls)
+    for view in ("initiatives.current", "initiatives.latest"):
+        drop_i = next(i for i, s in enumerate(sqls)
+                      if f"DROP VIEW IF EXISTS {view}" in s)
+        create_i = next(i for i, s in enumerate(sqls)
+                        if f"CREATE VIEW {view}" in s)
+        assert drop_i < create_i, f"{view}: DROP must precede CREATE"
+    assert conn.commits == 1
 
 
 def test_ensure_schema_fk_cascades():
@@ -468,9 +536,10 @@ def test_write_snapshot_inserts_snapshot_then_rows_with_jsonb():
     row_sql, row_params = conn.executed[1]
     assert "INSERT INTO initiatives.initiative_snapshot" in row_sql
     assert row_params[0] == 7  # snapshot_id prepended
-    # open_prs / open_investigations / docs are wrapped in psycopg2 Json
+    # open_prs / open_investigations / docs / recent_messages / recent_commits are each
+    # wrapped in psycopg2 Json (5 JSONB columns after the v3 card-legibility add).
     jsonb_count = sum(1 for p in row_params if isinstance(p, Json))
-    assert jsonb_count == 3
+    assert jsonb_count == 5
     assert conn.commits == 1
     # the summary column is in the INSERT list, and its value lands at the matching index
     assert "summary" in row_sql

--- a/scripts/initiatives/tests/test_viewer.py
+++ b/scripts/initiatives/tests/test_viewer.py
@@ -611,3 +611,81 @@ def test_provider_invalidate_forces_reload():
     prov.invalidate()
     prov.snapshot()
     assert calls["n"] == 2          # re-read after invalidate
+
+
+# --- Phase A card-legibility fields: recent messages / commits / live task -- #
+def test_view_carries_recent_messages_commits_and_live_task():
+    rows = [_row(slug="s",
+                 recent_messages=[{"text": "enrich the cards with my prompts", "ts": 300.0},
+                                  {"text": "older prompt", "ts": 100.0}],
+                 recent_commits=["feat: enrich cards", "fix: dedupe turns"])]
+    rows[0]["tmux_tasks"] = ["Bring the conversation onto the card"]
+    v = viewer.build_model(rows, now=NOW)["flat"][0]
+    assert v["recent_messages"] == [
+        {"text": "enrich the cards with my prompts", "ts": 300.0},
+        {"text": "older prompt", "ts": 100.0}]
+    assert v["recent_commits"] == ["feat: enrich cards", "fix: dedupe turns"]
+    assert v["live_task"] == "Bring the conversation onto the card"
+
+
+def test_view_defaults_recent_fields_when_absent():
+    v = viewer.build_model([_row(slug="s")], now=NOW)["flat"][0]
+    assert v["recent_messages"] == []
+    assert v["recent_commits"] == []
+    assert v["live_task"] == ""
+
+
+def test_view_live_task_is_first_tmux_task():
+    rows = [_row(slug="s")]
+    rows[0]["tmux_tasks"] = ["primary task", "secondary task"]
+    v = viewer.build_model(rows, now=NOW)["flat"][0]
+    assert v["live_task"] == "primary task"
+
+
+def test_view_recent_messages_coerces_and_drops_non_dicts():
+    rows = [_row(slug="s",
+                 recent_messages=[{"text": 123, "ts": None}, "junk", {"nope": 1}])]
+    v = viewer.build_model(rows, now=NOW)["flat"][0]
+    # non-dicts dropped; text str-coerced; a dict without text -> ""
+    assert v["recent_messages"] == [{"text": "123", "ts": None}, {"text": "", "ts": None}]
+
+
+def test_render_html_embeds_recent_message_and_commit():
+    rows = [_row(slug="s",
+                 recent_messages=[{"text": "the most recent prompt line", "ts": 1.0}],
+                 recent_commits=["feat: a recent commit subject"])]
+    html = viewer.render_html(viewer.build_model(rows, now=NOW))
+    assert "the most recent prompt line" in html       # latest message in the JSON island
+    assert "feat: a recent commit subject" in html      # commit subject in the payload
+    assert "you \\u203a" in html or "you ›" in html      # card-face renders the you › line
+
+
+def test_render_html_neutralizes_untrusted_prompt_text():
+    # a prompt containing markup must be neutralized in the JSON island (never raw).
+    rows = [_row(slug="s",
+                 recent_messages=[{"text": "<img src=x onerror=alert(1)>", "ts": 1.0}])]
+    html = viewer.render_html(viewer.build_model(rows, now=NOW))
+    assert "<img src=x onerror=alert(1)>" not in html   # never raw markup
+    assert "u003cimg" in html                            # neutralized as <
+
+
+def test_build_detail_carries_recent_fields_and_live_task():
+    rows = [_row(slug="s",
+                 recent_messages=[{"text": "detail prompt", "ts": 5.0}],
+                 recent_commits=["chore: bump"])]
+    rows[0]["tmux_tasks"] = ["open live task"]
+    model = viewer.build_model(rows, now=NOW)
+    d = viewer.build_detail(model, None, "/home/zach/workspace/devrc", "s",
+                            doc_reader=lambda repo, doc: None)  # no live overlay
+    assert d["recent_messages"] == [{"text": "detail prompt", "ts": 5.0}]
+    assert d["recent_commits"] == ["chore: bump"]
+    assert d["live_task"] == "open live task"
+
+
+def test_model_to_json_flat_includes_recent_fields():
+    rows = [_row(slug="a",
+                 recent_messages=[{"text": "m", "ts": 1.0}], recent_commits=["c"])]
+    j = viewer.model_to_json(viewer.build_model(rows, now=NOW), None)
+    v = j["flat"][0]
+    assert v["recent_messages"] == [{"text": "m", "ts": 1.0}]
+    assert v["recent_commits"] == ["c"]

--- a/scripts/initiatives/viewer.py
+++ b/scripts/initiatives/viewer.py
@@ -85,7 +85,7 @@ RUN_SYNC_PATH = Path(__file__).resolve().parent / "run-sync.sh"
 DISPLAY_COLUMNS = [
     "slug", "repo", "title", "summary", "momentum", "last_touch", "next_step", "commits",
     "commits_unknown", "merged_prs", "open_prs", "session_count", "telem_events",
-    "current_doc", "open_investigations", "docs",
+    "current_doc", "open_investigations", "docs", "recent_messages", "recent_commits",
 ]
 
 # Momentum ordering + badges — SAME ranks/glyphs the scan uses (active→stalled→unknown).
@@ -276,6 +276,9 @@ def _initiative_view(ini: dict, now: datetime) -> dict:
     glyph, label = momentum_badge(momentum)
     open_prs = ini.get("open_prs") or []
     tmux = sorted(ini.get("tmux_sessions") or [])
+    # The matched live pane's task summary (render-time tmux overlay, viewer-side only —
+    # not stored). First title if a session is open, else "".
+    tmux_tasks = [str(t) for t in (ini.get("tmux_tasks") or []) if str(t).strip()]
     repo = ini.get("repo")
     return {
         "slug": ini.get("slug") or "(no slug)",
@@ -305,6 +308,15 @@ def _initiative_view(ini: dict, now: datetime) -> dict:
         ],
         "docs": _norm_docs(ini.get("docs")),
         "tmux_sessions": tmux,
+        # Phase A card-legibility signals. `recent_messages` = the user's own recent
+        # prompts (newest-first, from the store); `recent_commits` = recent commit
+        # subjects; `live_task` = the open tmux session's task (render-time overlay).
+        "recent_messages": [
+            {"text": str(m.get("text") or ""), "ts": m.get("ts")}
+            for m in (ini.get("recent_messages") or []) if isinstance(m, dict)
+        ],
+        "recent_commits": [str(x) for x in (ini.get("recent_commits") or [])],
+        "live_task": tmux_tasks[0] if tmux_tasks else "",
     }
 
 
@@ -496,6 +508,11 @@ def build_detail(model: dict | None, error: str | None, repo: str, slug: str,
         "docs": view.get("docs") or [],
         "next_steps": [view["next_step"]] if view.get("next_step") else [],
         "open_investigations": view["open_investigations"],
+        # Phase A signals flow through the detail endpoint too (stored on the view — the
+        # live handoff read below never overrides them).
+        "recent_messages": view.get("recent_messages") or [],
+        "recent_commits": view.get("recent_commits") or [],
+        "live_task": view.get("live_task") or "",
         "live": False,
     }
 
@@ -575,6 +592,15 @@ header .meta{color:var(--gray);font-size:.85rem}
   padding:.02rem .4rem}
 .age{color:var(--gray);font-size:.82rem;margin-left:auto}
 .summary{margin-top:.3rem;color:var(--fg);font-size:.86rem}
+.msg{margin-top:.3rem;color:var(--fg);font-size:.86rem;
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.msg .lbl{color:var(--aqua);margin-right:.2rem}
+.live-task{margin-top:.25rem;color:var(--green);font-size:.84rem;
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.live-task .lbl{color:var(--green);font-weight:bold;margin-right:.2rem}
+.commit{margin-top:.25rem;color:var(--gray);font-size:.8rem;
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.commit .lbl{color:var(--blue);margin-right:.2rem}
 .tags{margin-top:.3rem;display:flex;flex-wrap:wrap;gap:.35rem;align-items:center}
 .tag{font-size:.78rem;padding:.05rem .4rem;border-radius:3px;background:var(--bg2);color:var(--fg2)}
 .tag.tmux{background:#665c54;color:var(--green)}
@@ -630,8 +656,10 @@ _JS = r"""
 
   function matchQ(v, q){
     if(!q) return true;
+    var msg = (v.recent_messages && v.recent_messages[0] && v.recent_messages[0].text) || '';
     var hay = ((v.slug||'') + ' ' + (v.title||'') + ' ' + (v.summary||'') + ' ' +
-               (v.repo_name||'') + ' ' + (v.momentum||'')).toLowerCase();
+               (v.repo_name||'') + ' ' + (v.momentum||'') + ' ' + msg + ' ' +
+               (v.live_task||'')).toLowerCase();
     return hay.indexOf(q) !== -1;
   }
 
@@ -649,6 +677,17 @@ _JS = r"""
       return;
     }
     if(d.summary) det.appendChild(el('div', 'detail-summary', d.summary));
+    if(d.live_task){
+      det.appendChild(el('div', 'detail-h', 'Live session'));
+      det.appendChild(el('div', 'detail-summary', d.live_task));
+    }
+    var rmsgs = d.recent_messages || (v && v.recent_messages) || [];
+    if(rmsgs.length){
+      det.appendChild(el('div', 'detail-h', 'Recent messages'));
+      var ulm = el('ul', 'detail-list');
+      rmsgs.forEach(function(m){ ulm.appendChild(el('li', null, (m && m.text) || '')); });
+      det.appendChild(ulm);
+    }
     var ns = d.next_steps || [];
     if(ns.length){
       det.appendChild(el('div', 'detail-h', 'Next steps'));
@@ -662,6 +701,13 @@ _JS = r"""
       var ul2 = el('ul', 'detail-list');
       oi.forEach(function(s){ ul2.appendChild(el('li', null, s)); });
       det.appendChild(ul2);
+    }
+    var rcom = d.recent_commits || (v && v.recent_commits) || [];
+    if(rcom.length){
+      det.appendChild(el('div', 'detail-h', 'Recent commits'));
+      var ulc = el('ul', 'detail-list');
+      rcom.forEach(function(s){ ulc.appendChild(el('li', null, s)); });
+      det.appendChild(ulc);
     }
     var prs = d.open_prs || (v && v.open_prs) || [];
     if(prs.length){
@@ -716,6 +762,24 @@ _JS = r"""
 
     if(v.summary) c.appendChild(el('div', 'summary', v.summary));
 
+    // The user's own most-recent prompt — the highest-signal "what is this" line
+    // (summary + latest message read well together). textContent-only, never innerHTML.
+    var msgs = v.recent_messages || [];
+    if(msgs.length && msgs[0] && msgs[0].text){
+      var m = el('div', 'msg');
+      m.appendChild(el('span', 'lbl', 'you ›'));
+      m.appendChild(document.createTextNode(' ' + msgs[0].text));
+      c.appendChild(m);
+    }
+
+    // A live tmux session's task summary (render-time overlay), when one is open.
+    if(v.live_task){
+      var lt = el('div', 'live-task');
+      lt.appendChild(el('span', 'lbl', 'live ›'));
+      lt.appendChild(document.createTextNode(' ' + v.live_task));
+      c.appendChild(lt);
+    }
+
     var tags = el('div', 'tags');
     (v.tmux_sessions || []).forEach(function(s){
       tags.appendChild(el('span', 'tag tmux', '[tmux:' + s + ']'));
@@ -731,6 +795,15 @@ _JS = r"""
       commits + ' commits · ' + v.merged_prs + ' merged · ' +
       v.session_count + ' sess · ' + v.telem_events + ' ev'));
     c.appendChild(tags);
+
+    // A small hint of the most-recent commit subject, when present.
+    var rc = v.recent_commits || [];
+    if(rc.length && rc[0]){
+      var cm = el('div', 'commit');
+      cm.appendChild(el('span', 'lbl', 'commit ›'));
+      cm.appendChild(document.createTextNode(' ' + rc[0]));
+      c.appendChild(cm);
+    }
 
     if(v.next_step){
       var nx = el('div', 'next');

--- a/scripts/session-analysis/initiative-scan.py
+++ b/scripts/session-analysis/initiative-scan.py
@@ -107,6 +107,15 @@ COMMAND_ARGS = re.compile(r"<command-args>(.*?)</command-args>", re.S)
 HARNESS = ("<task-notification>", "<task-reminder>", "<post-tool-use", "<bash-",
            "<user-prompt-submit", "<local-command-stdout>")
 
+# Recent-user-message + recent-commit surfacing (Phase A card legibility). Zach works
+# entirely via agents, so his own recent prompts are the highest-signal "what is this"
+# for an initiative. These are collected DETERMINISTICALLY (no LLM) — a later Phase B
+# may add an LLM recap on top, so the raw fields are kept cleanly reusable.
+RECENT_TURNS_PER_SESSION = 5        # last-N genuine user turns kept per attributed session
+RECENT_MESSAGES_PER_INITIATIVE = 5  # top-N (newest) messages surfaced per initiative
+RECENT_MESSAGE_MAX_CHARS = 200      # per-message truncation so a card stays legible
+RECENT_COMMITS_PER_INITIATIVE = 5   # most-recent commit subjects surfaced per initiative
+
 # A YYYY-MM-DD date anywhere in a handoff filename stem.
 DATE_RE = re.compile(r"(\d{4}-\d{2}-\d{2})")
 # "## Next steps" with any trailing decoration (the template varies a little).
@@ -896,6 +905,44 @@ def git_commits_in_window(repo: str, branch: str, since_days: int,
     return (len(epochs), float(max(epochs)))
 
 
+def git_recent_commit_subjects(repo: str, branch: str, since_days: int,
+                               default_branch: str | None = None,
+                               limit: int = RECENT_COMMITS_PER_INITIATIVE
+                               ) -> list[tuple[float, str]]:
+    """[(epoch, subject)] for the most-recent commits UNIQUE to `branch` in the window,
+    newest-first, capped at `limit`.
+
+    Mirrors git_commits_in_window's ref resolution + default-branch exclusion EXACTLY
+    (so a feature branch is credited only with ITS OWN subjects, not the whole trunk),
+    just capturing `%s` subjects instead of counting. The default branch (unsegmented
+    catch-all) and an unresolvable ref both yield []. A NUL (`%x00`) field separator so a
+    subject containing whitespace/tabs can't split the parse."""
+    if default_branch and branch.lower() == default_branch.lower():
+        return []
+    target = _resolve_branch_ref(repo, branch)
+    if target is None:
+        return []
+    cmd = ["git", "-C", repo, "log", target, "--no-merges",
+           f"--since={since_days} days ago", "--format=%ct%x00%s"]
+    if default_branch and default_branch.lower() != branch.lower():
+        excludes = []
+        for ref in (default_branch, f"origin/{default_branch}"):
+            if _ref_exists(repo, ref) and ref not in excludes:
+                excludes.append(ref)
+        if excludes:
+            cmd += ["--not", *excludes]
+    out = _run(cmd)
+    res: list[tuple[float, str]] = []
+    for ln in out.splitlines():
+        if "\x00" not in ln:
+            continue
+        cts, subj = ln.split("\x00", 1)
+        cts, subj = cts.strip(), subj.strip()
+        if cts.isdigit() and subj:
+            res.append((float(cts), subj))
+    return res[:limit]
+
+
 def gh_open_prs(repo: str) -> list[dict]:
     """OPEN PRs as [{number, title, headRefName}] — empty on any failure."""
     out = _run([
@@ -969,32 +1016,45 @@ def _clean_turn(raw: str) -> str:
     return t
 
 
-def session_genesis_refs(projects_root: str, since_days: int) -> list[dict]:
-    """For each transcript touched in the window, return its genesis text + mtime.
-
-    [{text, mtime}] over the FIRST genuine user turn per session. Used to attribute
-    a session to an initiative when the genesis names `handoff-<slug>.md`.
-    """
-    cutoff = time.time() - since_days * DAY
-    out = []
-    for path in glob.glob(os.path.join(projects_root, "**", "*.jsonl"), recursive=True):
-        if "/subagents/" in path or "/wf_" in path:
-            continue
-        mt = _safe_mtime(path)
-        if mt < cutoff:
-            continue
-        text = _first_user_turn(path)
-        if text:
-            out.append({"text": text, "mtime": mt})
-    return out
+def _extract_user_text(content) -> str | None:
+    """The text of a user message's `content` (str form, or the first text block of a
+    list form). None when there's no text block. Shared by every transcript reader so
+    genesis + recent-turn extraction agree on what a user turn's text IS."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        for b in content:
+            if isinstance(b, dict) and b.get("type") == "text":
+                return b.get("text", "")
+    return None
 
 
-def _first_user_turn(path: str) -> str | None:
+def _truncate(s: str, n: int) -> str:
+    """Trim/ellipsize a string to at most `n` chars (with a trailing … when cut)."""
+    s = (s or "").strip()
+    return s if len(s) <= n else s[: max(0, n - 1)].rstrip() + "…"
+
+
+def _read_session_turns(path: str, n: int) -> dict | None:
+    """Parse ONE transcript into {genesis, turns, cwd, branch}, or None if it has no
+    genuine user turn.
+
+    - genesis: the FIRST genuine user turn text (the SAME rule _first_user_turn used —
+      skips harness/system-reminder/command/interrupt/caveat noise via _clean_turn).
+    - turns: [{text, ts}] for the LAST `n` genuine user turns (oldest→newest), each
+      cleaned; `ts` is the turn's UTC epoch (from its ISO `timestamp`), or None.
+    - cwd / branch: from the MOST-RECENT turn that carries them (each user turn records
+      `cwd` + `gitBranch`) — used by the branch/cwd attribution fallback.
+    Reads the file ONCE (transcript reads are the costly part of the scan)."""
     try:
         with open(path, errors="replace") as f:
             lines = f.readlines()
     except OSError:
         return None
+    genesis: str | None = None
+    turns: list[dict] = []
+    cwd: str | None = None
+    branch: str | None = None
     for line in lines:
         line = line.strip()
         if not line:
@@ -1008,15 +1068,7 @@ def _first_user_turn(path: str) -> str | None:
         msg = obj.get("message") or {}
         if msg.get("role") != "user":
             continue
-        content = msg.get("content")
-        raw = None
-        if isinstance(content, str):
-            raw = content
-        elif isinstance(content, list):
-            for b in content:
-                if isinstance(b, dict) and b.get("type") == "text":
-                    raw = b.get("text", "")
-                    break
+        raw = _extract_user_text(msg.get("content"))
         if not raw:
             continue
         txt = _clean_turn(raw)
@@ -1024,8 +1076,132 @@ def _first_user_turn(path: str) -> str | None:
             continue
         if txt.startswith("[Request interrupted") or txt.startswith("Caveat: The messages below"):
             continue
-        return txt
-    return None
+        if genesis is None:
+            genesis = txt
+        turns.append({"text": txt, "ts": _iso_to_epoch(obj.get("timestamp"))})
+        c = obj.get("cwd")
+        if c:
+            cwd = c
+        b = obj.get("gitBranch")
+        if b:
+            branch = b
+    if genesis is None:
+        return None
+    return {"genesis": genesis, "turns": turns[-n:] if n > 0 else [],
+            "cwd": cwd, "branch": branch}
+
+
+def _first_user_turn(path: str) -> str | None:
+    """The first genuine user turn of a transcript (back-compat thin wrapper)."""
+    rec = _read_session_turns(path, 1)
+    return rec["genesis"] if rec else None
+
+
+def collect_session_records(projects_root: str, since_days: int,
+                            n: int = RECENT_TURNS_PER_SESSION) -> list[dict]:
+    """Walk every transcript touched in the window ONCE; per session return
+    {genesis, mtime, cwd, branch, turns}.
+
+    The SUPERSET of session_genesis_refs: it additionally carries the last-`n` user
+    turns (recent-message attribution) and the session's cwd/branch (the branch/cwd
+    attribution fallback). One walk feeds BOTH attribute_sessions and
+    attribute_recent_messages so transcripts aren't read twice."""
+    cutoff = time.time() - since_days * DAY
+    out: list[dict] = []
+    for path in glob.glob(os.path.join(projects_root, "**", "*.jsonl"), recursive=True):
+        if "/subagents/" in path or "/wf_" in path:
+            continue
+        mt = _safe_mtime(path)
+        if mt < cutoff:
+            continue
+        rec = _read_session_turns(path, n)
+        if rec is None:
+            continue
+        rec["mtime"] = mt
+        out.append(rec)
+    return out
+
+
+def session_genesis_refs(projects_root: str, since_days: int) -> list[dict]:
+    """[{text, mtime}] over each in-window session's genesis (first genuine user turn).
+
+    A thin adapter over collect_session_records so the transcript walk is single-sourced
+    (attribute_sessions still consumes exactly this shape)."""
+    return [{"text": r["genesis"], "mtime": r["mtime"]}
+            for r in collect_session_records(projects_root, since_days, n=1)]
+
+
+def attribute_recent_messages(initiatives: list[dict], records: list[dict],
+                              repos: list[str], wt_map: dict[str, str] | None = None,
+                              keep: int = RECENT_MESSAGES_PER_INITIATIVE,
+                              max_chars: int = RECENT_MESSAGE_MAX_CHARS) -> None:
+    """Mutate each initiative with `recent_messages` = [{text, ts}], newest-first, top-N.
+
+    Bring the conversation onto the card: surface the user's OWN recent prompts. A
+    session's recent user turns are credited to an initiative when EITHER:
+      • genesis  — its genesis text names a handoff of the initiative (the SAME rule as
+        attribute_sessions; a genesis naming two handoffs credits both), OR
+      • branch+cwd — its gitBranch is the initiative's most-specific match
+        (best_matching_initiative) AND its cwd resolves to the initiative's repo
+        (resolve_cwd_repo) — catching feature-branch sessions the genesis missed.
+    Both predicates are the SAME ones the scan already uses for session/telemetry
+    attribution (no new scheme). Turns are pooled across the initiative's attributed
+    sessions, sorted by timestamp DESC (a None ts sorts last), de-duplicated, truncated,
+    and the top-N kept."""
+    wt_map = wt_map or {}
+    inis_by_repo: dict[str, list[dict]] = {}
+    names_by_id: dict[int, set[str]] = {}
+    acc: dict[int, list[dict]] = {}
+    for ini in initiatives:
+        ini["recent_messages"] = []
+        inis_by_repo.setdefault(ini["repo"], []).append(ini)
+        names = {os.path.basename(d["path"]).lower() for d in ini.get("docs", [])}
+        names.add(f"handoff-{ini.get('slug', '').lower()}")
+        names_by_id[id(ini)] = names
+        acc[id(ini)] = []
+
+    for r in records:
+        turns = r.get("turns") or []
+        if not turns:
+            continue
+        credited: set[int] = set()
+        genesis = (r.get("genesis") or "").lower()
+        if genesis:
+            for ini in initiatives:
+                if any(nm in genesis for nm in names_by_id[id(ini)]):
+                    credited.add(id(ini))
+        branch = (r.get("branch") or "").strip()
+        repo = resolve_cwd_repo(r.get("cwd"), repos, wt_map)
+        if branch and repo is not None:
+            best = best_matching_initiative(branch, inis_by_repo.get(repo, []))
+            if best is not None:
+                credited.add(id(best))
+        for iid in credited:
+            acc[iid].extend(turns)
+
+    for ini in initiatives:
+        # Newest-first; a None ts sorts after any real ts (present-flag as primary key).
+        pooled = sorted(acc[id(ini)],
+                        key=lambda m: (m.get("ts") is not None, m.get("ts") or 0.0),
+                        reverse=True)
+        seen: set = set()
+        msgs: list[dict] = []
+        for m in pooled:
+            text = (m.get("text") or "").strip()
+            if not text:
+                continue
+            # De-dupe on the DISPLAYED (truncated) text so identical card lines collapse
+            # to one — automated agent sessions (e.g. the task-spec drafter) re-inject the
+            # same boilerplate prompt across many sessions; showing it once is enough. The
+            # newest occurrence wins (pooled is already sorted DESC).
+            disp = _truncate(text, max_chars)
+            if disp in seen:
+                continue
+            seen.add(disp)
+            msgs.append({"text": disp, "ts": m.get("ts")})
+            if len(msgs) >= keep:
+                break
+        ini["recent_messages"] = msgs
 
 
 def attribute_sessions(initiatives: list[dict], genesis: list[dict]) -> None:
@@ -1325,6 +1501,7 @@ def match_tmux_to_initiatives(initiatives: list[dict], panes: list[dict],
     """
     for ini in initiatives:
         ini.setdefault("tmux_sessions", set())
+        ini.setdefault("tmux_tasks", [])
     by_repo: dict[str, list[dict]] = {}
     for ini in initiatives:
         by_repo.setdefault(ini["repo"], []).append(ini)
@@ -1337,6 +1514,11 @@ def match_tmux_to_initiatives(initiatives: list[dict], panes: list[dict],
         ini = best_title_match(ptoks, eligible) if ptoks else None
         if ini is not None:
             ini["tmux_sessions"].add(pane_id(pane, codenames))
+            # Surface the matched pane's title (the live session's task summary) so a
+            # viewer can render a `live: <task>` line. De-duped, insertion-ordered.
+            task = (pane.get("title") or "").strip()
+            if task and task not in ini["tmux_tasks"]:
+                ini["tmux_tasks"].append(task)
         elif pane.get("command", "") == "claude":
             unmatched.append({"id": pane_id(pane, codenames),
                               "title": pane.get("title", ""),
@@ -1359,6 +1541,9 @@ def attribute_git(initiatives: list[dict], days: int) -> None:
     default_cache: dict[str, str | None] = {}
     open_pr_cache: dict[str, list[dict]] = {}
     merged_pr_cache: dict[str, list[dict]] = {}
+    # (epoch, subject) pairs per initiative, pooled across its matching branches; the
+    # top-N newest become `recent_commits` after the per-repo pass.
+    commit_subs: dict[int, list[tuple[float, str]]] = {}
 
     # Group initiatives by repo so "best match" is decided within a repo's own slugs.
     by_repo: dict[str, list[dict]] = {}
@@ -1370,6 +1555,7 @@ def attribute_git(initiatives: list[dict], days: int) -> None:
         ini["last_commit"] = None
         ini["open_prs"] = []
         ini["merged_prs"] = 0
+        ini["recent_commits"] = []
 
     for repo, repo_inis in by_repo.items():
         if repo not in branch_cache:
@@ -1386,6 +1572,9 @@ def attribute_git(initiatives: list[dict], days: int) -> None:
             if ini is None:
                 continue
             ini["matching_branches"].append(b)
+            subs = git_recent_commit_subjects(repo, b, days, default_branch)
+            if subs:
+                commit_subs.setdefault(id(ini), []).extend(subs)
             c, lc = git_commits_in_window(repo, b, days, default_branch)
             if c is None:
                 ini["commits_unknown"] = True  # unresolvable ref — don't fake 0
@@ -1410,6 +1599,9 @@ def attribute_git(initiatives: list[dict], days: int) -> None:
         # "commits:?" only when we have NO confident count at all (every matching
         # branch was unresolvable) — a partial count stays a number.
         ini["commits_unknown"] = ini["commits_unknown"] and ini["commits"] == 0
+        # The newest commit subjects across all matching branches (deterministic hint).
+        pooled = sorted(commit_subs.get(id(ini), []), key=lambda t: t[0], reverse=True)
+        ini["recent_commits"] = [s for _ts, s in pooled[:RECENT_COMMITS_PER_INITIATIVE]]
 
 
 # --------------------------------------------------------------------------- #
@@ -1429,14 +1621,22 @@ def build_report(days: int, repos: list[str] | None = None,
     initiatives = load_initiatives(repos)
 
     attribute_git(initiatives, days)
-    genesis = session_genesis_refs(projects_root, days)
+
+    # ONE transcript walk feeds both session-count attribution AND recent-message
+    # surfacing (transcripts are the costly read; genesis is derived from the records).
+    records = collect_session_records(projects_root, days)
+    genesis = [{"text": r["genesis"], "mtime": r["mtime"]} for r in records]
     attribute_sessions(initiatives, genesis)
+
+    # Resolve cwds living in linked worktrees back to their canonical repo so worktree
+    # sessions/telemetry attribute to the parent and `(unknown repo)` shrinks. Computed
+    # unconditionally now: message attribution's branch/cwd fallback needs it too (agents
+    # run in isolated worktrees), and telemetry/tmux reuse the same map below.
+    wt_map = worktree_canonical_map(repos)
+    attribute_recent_messages(initiatives, records, repos, wt_map)
 
     telem_rows = fetch_telemetry(client, days) if client is not None else None
     telemetry_available = telem_rows is not None
-    # Resolve cwds living in linked worktrees back to their canonical repo so
-    # worktree telemetry attributes to the parent and `(unknown repo)` shrinks.
-    wt_map = worktree_canonical_map(repos) if (telem_rows or include_tmux) else {}
     catchall = attribute_telemetry(initiatives, telem_rows, repos, wt_map)
 
     tmux_unmatched: list[dict] = []
@@ -1567,6 +1767,12 @@ def render(report: dict, now: float | None = None) -> str:
                 out.append(f"        “{ini['title']}”")
             if ini.get("summary"):
                 out.append(f"        » {ini['summary'][:160]}")
+            msgs = ini.get("recent_messages") or []
+            if msgs:
+                out.append(f"        you › {msgs[0].get('text', '')[:160]}")
+            rc = ini.get("recent_commits") or []
+            if rc:
+                out.append(f"        commit › {rc[0][:100]}")
             for pr in ini.get("open_prs", []):
                 out.append(f"        OPEN PR #{pr['number']}: {pr['title'][:80]}")
             ns = ini.get("next_step")

--- a/scripts/session-analysis/tests/test_initiative_scan.py
+++ b/scripts/session-analysis/tests/test_initiative_scan.py
@@ -688,7 +688,9 @@ def test_build_report_end_to_end_no_telemetry(tmp_path, monkeypatch):
     monkeypatch.setattr(isc, "gh_open_prs", lambda r: [
         {"number": 42, "title": "mail extractor", "headRefName": "feat/mail-automation"}])
     monkeypatch.setattr(isc, "gh_merged_prs", lambda r, d: [])
-    monkeypatch.setattr(isc, "session_genesis_refs", lambda root, d: [])
+    # build_report now single-walks transcripts via collect_session_records (genesis is
+    # derived from it); stub that so the orchestration test stays hermetic.
+    monkeypatch.setattr(isc, "collect_session_records", lambda root, d, n=5: [])
 
     now = 2_000.0  # last_commit at 1000 -> age 1000s -> active
     report = isc.build_report(2, repos=[str(repo)], client=None, now=now)
@@ -717,7 +719,9 @@ def test_render_emits_trunk_catchall(monkeypatch, tmp_path):
     monkeypatch.setattr(isc, "git_default_branch", lambda r: "main")
     monkeypatch.setattr(isc, "gh_open_prs", lambda r: [])
     monkeypatch.setattr(isc, "gh_merged_prs", lambda r, d: [])
-    monkeypatch.setattr(isc, "session_genesis_refs", lambda root, d: [])
+    # build_report now single-walks transcripts via collect_session_records (genesis is
+    # derived from it); stub that so the orchestration test stays hermetic.
+    monkeypatch.setattr(isc, "collect_session_records", lambda root, d, n=5: [])
 
     class FakeClient:
         def rows(self, sql):
@@ -1039,7 +1043,9 @@ def test_build_report_tmux_annotates_and_lists_unmatched(tmp_path, monkeypatch):
     monkeypatch.setattr(isc, "git_default_branch", lambda r: "main")
     monkeypatch.setattr(isc, "gh_open_prs", lambda r: [])
     monkeypatch.setattr(isc, "gh_merged_prs", lambda r, d: [])
-    monkeypatch.setattr(isc, "session_genesis_refs", lambda root, d: [])
+    # build_report now single-walks transcripts via collect_session_records (genesis is
+    # derived from it); stub that so the orchestration test stays hermetic.
+    monkeypatch.setattr(isc, "collect_session_records", lambda root, d, n=5: [])
     # Isolate the window/unmatched logic from the real codename table (tested apart).
     monkeypatch.setattr(isc, "load_scratch_codenames", lambda *a, **k: {})
 
@@ -1073,7 +1079,9 @@ def test_build_report_tmux_applies_codenames(tmp_path, monkeypatch):
     monkeypatch.setattr(isc, "git_default_branch", lambda r: "main")
     monkeypatch.setattr(isc, "gh_open_prs", lambda r: [])
     monkeypatch.setattr(isc, "gh_merged_prs", lambda r, d: [])
-    monkeypatch.setattr(isc, "session_genesis_refs", lambda root, d: [])
+    # build_report now single-walks transcripts via collect_session_records (genesis is
+    # derived from it); stub that so the orchestration test stays hermetic.
+    monkeypatch.setattr(isc, "collect_session_records", lambda root, d, n=5: [])
     monkeypatch.setattr(isc, "load_scratch_codenames", lambda *a, **k: {"scratch4": "Vapor"})
 
     panes = [{"session": "scratch4", "window": "2", "cwd": str(repo),
@@ -1093,7 +1101,9 @@ def test_build_report_tmux_no_session_marker(tmp_path, monkeypatch):
     monkeypatch.setattr(isc, "git_default_branch", lambda r: "main")
     monkeypatch.setattr(isc, "gh_open_prs", lambda r: [])
     monkeypatch.setattr(isc, "gh_merged_prs", lambda r, d: [])
-    monkeypatch.setattr(isc, "session_genesis_refs", lambda root, d: [])
+    # build_report now single-walks transcripts via collect_session_records (genesis is
+    # derived from it); stub that so the orchestration test stays hermetic.
+    monkeypatch.setattr(isc, "collect_session_records", lambda root, d, n=5: [])
 
     # No panes at all -> initiative shows [no session].
     report = isc.build_report(14, repos=[str(repo)], client=None,
@@ -1113,7 +1123,9 @@ def test_build_report_tmux_suppressed_when_no_server(tmp_path, monkeypatch):
     monkeypatch.setattr(isc, "git_default_branch", lambda r: "main")
     monkeypatch.setattr(isc, "gh_open_prs", lambda r: [])
     monkeypatch.setattr(isc, "gh_merged_prs", lambda r, d: [])
-    monkeypatch.setattr(isc, "session_genesis_refs", lambda root, d: [])
+    # build_report now single-walks transcripts via collect_session_records (genesis is
+    # derived from it); stub that so the orchestration test stays hermetic.
+    monkeypatch.setattr(isc, "collect_session_records", lambda root, d, n=5: [])
     monkeypatch.setattr(isc, "collect_tmux_panes", lambda: [])  # no server
 
     # panes=None -> live read path; collect returns [] -> column disabled.
@@ -1146,7 +1158,9 @@ def _stub_no_external_io(monkeypatch):
     monkeypatch.setattr(isc, "git_default_branch", lambda r: "main")
     monkeypatch.setattr(isc, "gh_open_prs", lambda r: [])
     monkeypatch.setattr(isc, "gh_merged_prs", lambda r, d: [])
-    monkeypatch.setattr(isc, "session_genesis_refs", lambda root, d: [])
+    # build_report now single-walks transcripts via collect_session_records (genesis is
+    # derived from it); stub that so the orchestration test stays hermetic.
+    monkeypatch.setattr(isc, "collect_session_records", lambda root, d, n=5: [])
 
 
 def test_build_report_windows_out_stale_dated_handoff(tmp_path, monkeypatch):
@@ -1190,3 +1204,257 @@ def test_build_report_keeps_stale_handoff_with_live_session(tmp_path, monkeypatc
     assert len(inis) == 1 and inis[0]["slug"] == "oldwork"
     assert inis[0]["momentum"] == "active"        # live session => touched now
     assert inis[0]["tmux_sessions"] == ["main:8-1"]
+
+
+# --------------------------------------------------------------------------- #
+# Recent user-message extraction + attribution (Phase A card legibility)
+# --------------------------------------------------------------------------- #
+import json as _json  # noqa: E402
+
+
+def _jsonl_user(text, ts, cwd="/home/u/workspace/devrc", branch="feat/x"):
+    """One transcript user-turn line (mirrors the real ~/.claude JSONL shape)."""
+    return _json.dumps({
+        "type": "user", "timestamp": ts, "cwd": cwd, "gitBranch": branch,
+        "message": {"role": "user", "content": text},
+    })
+
+
+def _write_transcript(path, entries):
+    path.write_text("\n".join(entries) + "\n")
+
+
+def test_read_session_turns_collects_turns_with_ts_cwd_branch(tmp_path):
+    p = tmp_path / "s.jsonl"
+    _write_transcript(p, [
+        _jsonl_user("<system-reminder>noise</system-reminder>   ", "2026-07-20T10:00:00Z"),
+        _jsonl_user("read handoff-foo.md and start", "2026-07-20T10:01:00Z", branch="feat/foo"),
+        _jsonl_user("do the next thing", "2026-07-20T10:02:00Z", branch="feat/foo"),
+        _jsonl_user("[Request interrupted by user]", "2026-07-20T10:03:00Z"),
+        _jsonl_user("third real turn", "2026-07-20T10:04:00Z", branch="feat/foo-2"),
+    ])
+    rec = isc._read_session_turns(str(p), 5)
+    # genesis = FIRST genuine turn (the system-reminder + interrupt turns are skipped).
+    assert rec["genesis"] == "read handoff-foo.md and start"
+    assert [t["text"] for t in rec["turns"]] == [
+        "read handoff-foo.md and start", "do the next thing", "third real turn"]
+    assert rec["turns"][0]["ts"] is not None  # ISO timestamp parsed to epoch
+    # cwd/branch come from the MOST-RECENT turn that carried them.
+    assert rec["cwd"] == "/home/u/workspace/devrc"
+    assert rec["branch"] == "feat/foo-2"
+
+
+def test_read_session_turns_keeps_only_last_n(tmp_path):
+    p = tmp_path / "s.jsonl"
+    _write_transcript(p, [
+        _jsonl_user(f"turn {i}", f"2026-07-20T10:0{i}:00Z") for i in range(6)])
+    rec = isc._read_session_turns(str(p), 2)
+    assert rec["genesis"] == "turn 0"                 # genesis independent of the window
+    assert [t["text"] for t in rec["turns"]] == ["turn 4", "turn 5"]  # last 2 only
+
+
+def test_read_session_turns_none_without_genuine_turn(tmp_path):
+    p = tmp_path / "s.jsonl"
+    _write_transcript(p, [_jsonl_user("<system-reminder>only noise</system-reminder>",
+                                      "2026-07-20T10:00:00Z")])
+    assert isc._read_session_turns(str(p), 5) is None
+
+
+def test_read_session_turns_extracts_list_content(tmp_path):
+    # content as a list of blocks -> the first text block is the turn text.
+    line = _json.dumps({
+        "type": "user", "timestamp": "2026-07-20T10:00:00Z",
+        "cwd": "/r", "gitBranch": "feat/y",
+        "message": {"role": "user",
+                    "content": [{"type": "text", "text": "block-form message"}]},
+    })
+    p = tmp_path / "s.jsonl"
+    _write_transcript(p, [line])
+    rec = isc._read_session_turns(str(p), 5)
+    assert rec["turns"][0]["text"] == "block-form message"
+
+
+def test_first_user_turn_returns_genesis(tmp_path):
+    p = tmp_path / "s.jsonl"
+    _write_transcript(p, [
+        _jsonl_user("<system-reminder>x</system-reminder>", "2026-07-20T10:00:00Z"),
+        _jsonl_user("the real first message", "2026-07-20T10:01:00Z"),
+        _jsonl_user("second", "2026-07-20T10:02:00Z"),
+    ])
+    assert isc._first_user_turn(str(p)) == "the real first message"
+
+
+def test_collect_session_records_skips_subagents_and_old(tmp_path):
+    root = tmp_path
+    good = root / "proj" / "a.jsonl"
+    good.parent.mkdir(parents=True)
+    _write_transcript(good, [_jsonl_user("hello world", "2026-07-20T10:00:00Z")])
+    sub = root / "subagents" / "b.jsonl"
+    sub.parent.mkdir(parents=True)
+    _write_transcript(sub, [_jsonl_user("sub msg", "2026-07-20T10:00:00Z")])
+    recs = isc.collect_session_records(str(root), 3650)  # wide window -> the good one in
+    genes = [r["genesis"] for r in recs]
+    assert "hello world" in genes
+    assert "sub msg" not in genes          # /subagents/ path excluded
+    # a very tight window excludes even the just-written file (mtime older than cutoff=now)
+    assert isc.collect_session_records(str(root), 0) == []
+
+
+def test_session_genesis_refs_derives_from_records(tmp_path):
+    p = tmp_path / "proj" / "a.jsonl"
+    p.parent.mkdir(parents=True)
+    _write_transcript(p, [
+        _jsonl_user("genesis line", "2026-07-20T10:00:00Z"),
+        _jsonl_user("later line", "2026-07-20T10:01:00Z"),
+    ])
+    refs = isc.session_genesis_refs(str(tmp_path), 3650)
+    assert len(refs) == 1
+    assert refs[0]["text"] == "genesis line"     # genesis, not the last turn
+    assert "mtime" in refs[0]
+
+
+def test_attribute_recent_messages_genesis_pool_desc_truncate():
+    inis = [{"slug": "foo-bar", "repo": "/r",
+             "docs": [{"path": "/r/claudedocs/handoff-foo-bar-2026-07-20.md",
+                       "date": "2026-07-20"}]}]
+    long = "y" * 250
+    records = [
+        {"genesis": "resume handoff-foo-bar-2026-07-20.md", "mtime": 1.0,
+         "cwd": None, "branch": None,
+         "turns": [{"text": "older msg", "ts": 100.0}, {"text": long, "ts": 300.0}]},
+        {"genesis": "continue handoff-foo-bar per slug", "mtime": 2.0,
+         "cwd": None, "branch": None,
+         "turns": [{"text": "newest msg", "ts": 400.0}]},
+        {"genesis": "unrelated session about weather", "mtime": 3.0,
+         "cwd": None, "branch": None,
+         "turns": [{"text": "should not appear", "ts": 999.0}]},
+    ]
+    isc.attribute_recent_messages(inis, records, ["/r"], keep=5)
+    texts = [m["text"] for m in inis[0]["recent_messages"]]
+    assert texts[0] == "newest msg"                 # DESC by ts (400 > 300 > 100)
+    assert texts[1].endswith("…") and len(texts[1]) == 200  # truncated to 200 chars
+    assert texts[2] == "older msg"
+    assert "should not appear" not in texts         # unattributed session excluded
+
+
+def test_attribute_recent_messages_branch_cwd_fallback():
+    # genesis does NOT name the handoff, but branch+cwd match -> still credited.
+    repo = "/home/u/workspace/devrc"
+    inis = [{"slug": "app-blocks", "repo": repo, "docs": []}]
+    records = [{"genesis": "just start working", "mtime": 1.0,
+                "cwd": repo, "branch": "feat/app-blocks",
+                "turns": [{"text": "branch-matched msg", "ts": 500.0}]}]
+    isc.attribute_recent_messages(inis, records, [repo])
+    assert [m["text"] for m in inis[0]["recent_messages"]] == ["branch-matched msg"]
+
+
+def test_attribute_recent_messages_branch_cwd_wrong_repo_no_credit():
+    # right branch token, WRONG cwd/repo -> no cross-repo credit (mirrors telemetry).
+    devrc, civit = "/home/u/workspace/devrc", "/home/u/workspace/civit/dp"
+    inis = [{"slug": "faro-rum-widening", "repo": civit, "docs": []}]
+    records = [{"genesis": "start", "mtime": 1.0, "cwd": devrc,
+                "branch": "feat/faro-rum-widening",
+                "turns": [{"text": "x", "ts": 1.0}]}]
+    isc.attribute_recent_messages(inis, records, [devrc, civit])
+    assert inis[0]["recent_messages"] == []
+
+
+def test_attribute_recent_messages_empty_when_no_records():
+    inis = [{"slug": "x", "repo": "/r", "docs": []}]
+    isc.attribute_recent_messages(inis, [], ["/r"])
+    assert inis[0]["recent_messages"] == []
+
+
+def test_attribute_recent_messages_dedupes_identical_boilerplate():
+    # Automated agent sessions re-inject the SAME prompt across many sessions; identical
+    # displayed lines collapse to ONE (newest ts wins), not N duplicate card rows.
+    repo = "/r"
+    inis = [{"slug": "drafter", "repo": repo,
+             "docs": [{"path": "/r/claudedocs/handoff-drafter.md", "date": None}]}]
+    boiler = "# task-spec drafter pipeline — you are the drafter"
+    records = [
+        {"genesis": "start handoff-drafter", "mtime": 1.0, "cwd": None, "branch": None,
+         "turns": [{"text": boiler, "ts": 100.0}]},
+        {"genesis": "start handoff-drafter", "mtime": 2.0, "cwd": None, "branch": None,
+         "turns": [{"text": boiler, "ts": 200.0}]},
+    ]
+    isc.attribute_recent_messages(inis, records, [repo])
+    assert inis[0]["recent_messages"] == [{"text": boiler, "ts": 200.0}]
+
+
+# --------------------------------------------------------------------------- #
+# Recent commit subjects
+# --------------------------------------------------------------------------- #
+def test_git_recent_commit_subjects_parses_and_excludes_default(monkeypatch):
+    monkeypatch.setattr(isc, "_resolve_branch_ref", lambda r, b: b)
+    monkeypatch.setattr(isc, "_ref_exists", lambda r, ref: ref == "main")
+    seen = {}
+
+    def fake_run(cmd, timeout=20.0):
+        seen["cmd"] = cmd
+        return "1783000200\x00feat: two words\n1783000100\x00fix: one\n"
+
+    monkeypatch.setattr(isc, "_run", fake_run)
+    out = isc.git_recent_commit_subjects("/r", "feat/x", 7, "main", limit=5)
+    assert out == [(1783000200.0, "feat: two words"), (1783000100.0, "fix: one")]
+    assert "--not" in seen["cmd"] and "main" in seen["cmd"]  # default excluded
+    assert any("%ct%x00%s" in c for c in seen["cmd"])        # NUL-separated format
+
+
+def test_git_recent_commit_subjects_caps_at_limit(monkeypatch):
+    monkeypatch.setattr(isc, "_resolve_branch_ref", lambda r, b: b)
+    monkeypatch.setattr(isc, "_ref_exists", lambda r, ref: False)
+    monkeypatch.setattr(isc, "_run",
+                        lambda cmd, timeout=20.0: "".join(
+                            f"{1000 + i}\x00subject {i}\n" for i in range(10)))
+    out = isc.git_recent_commit_subjects("/r", "feat/x", 7, "main", limit=3)
+    assert len(out) == 3
+
+
+def test_git_recent_commit_subjects_default_branch_and_unresolvable_empty(monkeypatch):
+    assert isc.git_recent_commit_subjects("/r", "main", 7, "main") == []  # default branch
+    monkeypatch.setattr(isc, "_resolve_branch_ref", lambda r, b: None)
+    assert isc.git_recent_commit_subjects("/r", "feat/x", 7, "main") == []  # no such ref
+
+
+def test_attribute_git_populates_recent_commits(monkeypatch):
+    repo = "/home/u/workspace/devrc"
+    inis = [{"slug": "mail-automation", "repo": repo}]
+    monkeypatch.setattr(isc, "git_branches", lambda r: ["feat/mail-automation", "main"])
+    monkeypatch.setattr(isc, "git_default_branch", lambda r: "main")
+    monkeypatch.setattr(isc, "git_commits_in_window", lambda r, b, d, db=None: (2, 1000.0))
+    monkeypatch.setattr(isc, "gh_open_prs", lambda r: [])
+    monkeypatch.setattr(isc, "gh_merged_prs", lambda r, d: [])
+    monkeypatch.setattr(
+        isc, "git_recent_commit_subjects",
+        lambda r, b, d, db=None, limit=5:
+            [(300.0, "newer subject"), (100.0, "older subject")]
+            if b == "feat/mail-automation" else [])
+    isc.attribute_git(inis, 7)
+    assert inis[0]["recent_commits"] == ["newer subject", "older subject"]  # newest-first
+
+
+# --------------------------------------------------------------------------- #
+# tmux task titles (the render-time `live: <task>` signal)
+# --------------------------------------------------------------------------- #
+def test_match_tmux_populates_tmux_tasks():
+    civit = "/home/u/workspace/civit/dp"
+    inis = [{"slug": "faro-rum-widening", "title": "Faro RUM widening", "repo": civit}]
+    panes = [{"session": "scratch4", "window": "2", "cwd": civit, "command": "claude",
+              "title": "Wire Faro to main civitai app"}]
+    isc.match_tmux_to_initiatives(inis, panes, [civit], codenames={"scratch4": "Vapor"})
+    assert inis[0]["tmux_tasks"] == ["Wire Faro to main civitai app"]
+    assert inis[0]["tmux_sessions"] == {"Vapor-2"}
+
+
+def test_match_tmux_tasks_dedupe_and_absent_when_unmatched():
+    civit = "/home/u/workspace/civit/dp"
+    inis = [{"slug": "sysredis-buffer", "title": "sysRedis buffer", "repo": civit}]
+    panes = [
+        {"session": "8", "window": "2", "cwd": civit, "command": "claude",
+         "title": "Continue sysredis buffer work"},
+        {"session": "8", "window": "2", "cwd": civit, "command": "claude",
+         "title": "Continue sysredis buffer work"},  # identical title -> de-duped
+    ]
+    isc.match_tmux_to_initiatives(inis, panes, [civit])
+    assert inis[0]["tmux_tasks"] == ["Continue sysredis buffer work"]


### PR DESCRIPTION
## What

**Phase A (deterministic, no LLM)** of an initiatives-viewer card-legibility improvement. Cards currently show a `summary` parsed from the handoff doc — a process artifact. This adds three deterministic signals so each card says what the initiative is actually FOR. A later **Phase B** adds an LLM recap on top, so the new fields are kept cleanly reusable (raw text, stored).

### 1. Recent sent messages (the user's own prompts)
The prompt TEXT lives ONLY in the Claude transcripts (`~/.claude/projects/**/*.jsonl`) — not in ClickHouse (`kind=prompt` stores metadata only). `_read_session_turns` generalizes `_first_user_turn` → the last-N cleaned user turns (+ `ts`/`cwd`/`gitBranch`), reusing `_clean_turn`'s noise-skipping. `collect_session_records` walks transcripts **once** and now feeds BOTH session-count attribution AND message surfacing. `attribute_recent_messages` credits a session's turns via the **same predicates the scan already uses** — genesis names a handoff (`attribute_sessions` rule), OR `gitBranch` best-matches + `cwd` resolves to the repo (`best_matching_initiative` + `resolve_cwd_repo`, catching worktree/feature-branch sessions). Pooled → sorted DESC → de-duped on displayed text (collapses automated-agent boilerplate) → truncated to 200 chars → top-5. `recent_messages: [{text, ts}]`.

### 2. Recent commit subjects
`git_recent_commit_subjects` mirrors `git_commits_in_window`'s ref resolution + default-branch exclusion (a feature branch is credited only with its OWN commits), capturing `%s`. `attribute_git` pools across matching branches, newest-5. `recent_commits: [str]`.

### 3. Live-session task title
`match_tmux_to_initiatives` also records the matched pane's title (`tmux_tasks`) — a viewer-side, render-time signal (no store change) rendered as `live: <task>`.

## Store (sync.py)
Additive `recent_messages`/`recent_commits` `jsonb` columns (`ADD COLUMN IF NOT EXISTS`) + transform + INSERT.

🔴 **Migration:** appending columns to `initiative_snapshot` reorders the `latest`/`current` views' `SELECT i.*, s.captured_at` output, which `CREATE OR REPLACE VIEW` rejects. **Both view markers bumped `v2`→`v3`** so `_ensure_view` fires its guarded **DROP+CREATE**. A `_FakeConn` test asserts DROP-before-CREATE on the v2→v3 marker mismatch for both views. **The human replays the real v2→v3 migration on a throwaway Postgres before deploy.**

## Viewer (viewer.py)
- **Card face:** summary + the most-recent message (`you ›`), a `live ›` task line, a `commit ›` hint.
- **Expand:** full recent-messages list + recent commit subjects, alongside next-steps / open-investigations / handoff link.
- All untrusted prompt text flows through the JSON island + `textContent` (never `innerHTML`). New fields flow through `/api/initiatives.json` and the detail endpoint.

## Verification
- `scripts/run-tests.sh` — full hermetic suite **green**.
- Real scan (`--repo devrc --days 10 --json`) attributed e.g. `clawgate-chat-polish` → *"yes implement and ship, ensure compelte test coverage"* (genesis-attributed) and `initiatives-consolidation` → its `feat/initiatives` commit subjects (branch-attributed).
- Card FACE rendered in a real (headless nixpkgs) Chromium from a fixture model — confirmed the client-side JS emits the summary / `you ›` / `live ›` / `commit ›` / `next ›` lines.

**Honesty:** NOT deployed, migration NOT run (the human does, on a throwaway PG first). The **expand/detail** rendering is verified at unit/logic level (build_detail carries the fields) — not browser-driven, as it needs the live server + DB.

## Residual risk
- **Attribution precision:** genesis + branch/cwd are the scan's existing heuristics (word-equality, no stemming) — a mis-scoped branch or a shared cwd could surface a message on the wrong card. Automated-agent sessions inject boilerplate as their "user turn" (deduped to one line, but still not a human prompt).
- **Transcript read cost:** unchanged walk count (single walk feeds both paths); per-file work grew from first-turn to last-N.
- **Migration:** the v2→v3 view recreate is the freeze risk if the marker bump were missed — covered by the DROP-before-CREATE test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)