### PR TITLE
fix(initiatives): single-best-credit recent-message attribution + substantive card face

### DIFF
--- a/scripts/initiatives/tests/test_viewer.py
+++ b/scripts/initiatives/tests/test_viewer.py
@@ -689,3 +689,69 @@ def test_model_to_json_flat_includes_recent_fields():
     v = j["flat"][0]
     assert v["recent_messages"] == [{"text": "m", "ts": 1.0}]
     assert v["recent_commits"] == ["c"]
+
+
+# --- Card-FACE substantive-prompt selection (Problem 2) --------------------- #
+def test_is_trivial_prompt_flags_boilerplate_and_short():
+    for triv in ["dispatch", "Proceed.", "yes", "go", " submitted ", "OK", "merged",
+                 "continue", "done", "y", ""]:
+        assert viewer._is_trivial_prompt(triv), triv
+    for real in ["relabel the node as web", "fix bad-eyes then launch round 3",
+                 "wire the comfy cloud scaffold"]:
+        assert not viewer._is_trivial_prompt(real), real
+
+
+def test_pick_face_message_skips_boilerplate_for_first_substantive():
+    # newest-first list whose newest entries are boilerplate → face is the first real one.
+    msgs = [
+        {"text": "dispatch", "ts": 500.0},
+        {"text": "proceed", "ts": 400.0},
+        {"text": "relabel the node as web", "ts": 300.0},
+        {"text": "older substantive prompt here", "ts": 200.0},
+    ]
+    assert viewer.pick_face_message(msgs) == {"text": "relabel the node as web", "ts": 300.0}
+
+
+def test_pick_face_message_falls_back_when_all_trivial():
+    msgs = [{"text": "dispatch", "ts": 500.0}, {"text": "yes", "ts": 400.0}]
+    # every message trivial → fall back to the most-recent (never blank).
+    assert viewer.pick_face_message(msgs) == {"text": "dispatch", "ts": 500.0}
+
+
+def test_pick_face_message_empty_is_none():
+    assert viewer.pick_face_message([]) is None
+    assert viewer.pick_face_message(None) is None
+
+
+def test_view_face_message_is_substantive_but_full_list_intact():
+    # The card FACE skips the boilerplate; the stored recent_messages list stays COMPLETE
+    # (unfiltered) for the expand + Phase B.
+    rows = [_row(slug="s", recent_messages=[
+        {"text": "dispatch", "ts": 500.0},
+        {"text": "submitted", "ts": 450.0},
+        {"text": "close the review arc for app-blocks", "ts": 300.0},
+    ])]
+    v = viewer.build_model(rows, now=NOW)["flat"][0]
+    assert v["face_message"] == {"text": "close the review arc for app-blocks", "ts": 300.0}
+    # full list preserved verbatim (all three, boilerplate included), newest-first.
+    assert [m["text"] for m in v["recent_messages"]] == [
+        "dispatch", "submitted", "close the review arc for app-blocks"]
+
+
+def test_view_face_message_none_when_no_messages():
+    v = viewer.build_model([_row(slug="s")], now=NOW)["flat"][0]
+    assert v["face_message"] is None
+
+
+def test_render_html_face_shows_substantive_not_boilerplate():
+    # The card FACE line (you › …) must render the substantive prompt, while the boilerplate
+    # still rides along in the JSON island (for the expand). We assert the JS reads
+    # face_message for the face, and the substantive text is present in the payload.
+    rows = [_row(slug="s", recent_messages=[
+        {"text": "dispatch", "ts": 500.0},
+        {"text": "wire the comfy cloud scaffold", "ts": 300.0},
+    ])]
+    html = viewer.render_html(viewer.build_model(rows, now=NOW))
+    assert "wire the comfy cloud scaffold" in html           # substantive prompt in payload
+    assert '"face_message"' in html                            # the face field is embedded
+    assert "v.face_message" in html                            # the card reads it for the face

--- a/scripts/initiatives/viewer.py
+++ b/scripts/initiatives/viewer.py
@@ -55,6 +55,7 @@ import html
 import importlib.util
 import json
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -270,6 +271,50 @@ def _norm_docs(docs) -> list[dict]:
     return out
 
 
+# Card-FACE prompt filtering (Phase A precision, Problem 2). The stored
+# `recent_messages` list is kept COMPLETE (the card expand shows it verbatim, and Phase B
+# will consume it) — only the SINGLE line shown on the card FACE is filtered to the
+# most-recent SUBSTANTIVE prompt, skipping low-signal boilerplate like `dispatch` /
+# `proceed` / `yes` that says nothing about what an initiative IS.
+FACE_MIN_CHARS = 15
+# Exact-match (post-normalization) trivial prompts: agent-pipeline ritual words / bare
+# acks that carry no topic. An explicit set so tuning FACE_MIN_CHARS can never let one of
+# these through.
+TRIVIAL_PROMPTS = frozenset({
+    "dispatch", "proceed", "submitted", "yes", "y", "go", "ok", "okay",
+    "continue", "merged", "done", "next", "sure", "approved", "lgtm",
+})
+
+
+def _is_trivial_prompt(text: str) -> bool:
+    """A low-signal card-FACE prompt: an exact known boilerplate ack (`dispatch`/`proceed`/
+    `yes`…) or too short to describe the work (< FACE_MIN_CHARS). Punctuation-insensitive +
+    case-folded, so `Proceed.` and `dispatch!` both count. PURE — used ONLY for FACE
+    selection; the stored `recent_messages` list is never filtered by it."""
+    norm = re.sub(r"[^a-z0-9]+", "", (text or "").lower())
+    if not norm:
+        return True
+    if norm in TRIVIAL_PROMPTS:
+        return True
+    return len((text or "").strip()) < FACE_MIN_CHARS
+
+
+def pick_face_message(recent_messages: list[dict]) -> dict | None:
+    """The single message to show on a card's FACE: the most-recent SUBSTANTIVE prompt.
+
+    `recent_messages` is newest-first (as stored). Returns the first non-trivial one
+    (`_is_trivial_prompt`); if EVERY message is trivial, falls back to the most-recent one
+    (never blank when there's any message). None only for an empty list. The full list is
+    left intact for the expand — this only picks the face line."""
+    msgs = [m for m in (recent_messages or []) if isinstance(m, dict)]
+    if not msgs:
+        return None
+    for m in msgs:
+        if not _is_trivial_prompt(str(m.get("text") or "")):
+            return m
+    return msgs[0]
+
+
 def _initiative_view(ini: dict, now: datetime) -> dict:
     """One store row (+ any attached tmux_sessions) -> a flat, template-ready view dict."""
     momentum = ini.get("momentum") or "unknown"
@@ -280,6 +325,12 @@ def _initiative_view(ini: dict, now: datetime) -> dict:
     # not stored). First title if a session is open, else "".
     tmux_tasks = [str(t) for t in (ini.get("tmux_tasks") or []) if str(t).strip()]
     repo = ini.get("repo")
+    # The COMPLETE recent-prompt list (newest-first, as stored) — the expand renders it
+    # verbatim. The card FACE shows only `face_message` (the most-recent substantive one).
+    recent_messages = [
+        {"text": str(m.get("text") or ""), "ts": m.get("ts")}
+        for m in (ini.get("recent_messages") or []) if isinstance(m, dict)
+    ]
     return {
         "slug": ini.get("slug") or "(no slug)",
         "repo": repo or "",
@@ -311,10 +362,11 @@ def _initiative_view(ini: dict, now: datetime) -> dict:
         # Phase A card-legibility signals. `recent_messages` = the user's own recent
         # prompts (newest-first, from the store); `recent_commits` = recent commit
         # subjects; `live_task` = the open tmux session's task (render-time overlay).
-        "recent_messages": [
-            {"text": str(m.get("text") or ""), "ts": m.get("ts")}
-            for m in (ini.get("recent_messages") or []) if isinstance(m, dict)
-        ],
+        "recent_messages": recent_messages,
+        # The single most-recent SUBSTANTIVE prompt for the card FACE (boilerplate like
+        # `dispatch`/`proceed` skipped; falls back to the newest when all are trivial).
+        # `recent_messages` above stays complete for the expand.
+        "face_message": pick_face_message(recent_messages),
         "recent_commits": [str(x) for x in (ini.get("recent_commits") or [])],
         "live_task": tmux_tasks[0] if tmux_tasks else "",
     }
@@ -656,7 +708,9 @@ _JS = r"""
 
   function matchQ(v, q){
     if(!q) return true;
-    var msg = (v.recent_messages && v.recent_messages[0] && v.recent_messages[0].text) || '';
+    // Search the FULL recent-message list (not just the face line) so a card is findable
+    // by any of its prompts, even the ones filtered off the face.
+    var msg = (v.recent_messages || []).map(function(m){ return (m && m.text) || ''; }).join(' ');
     var hay = ((v.slug||'') + ' ' + (v.title||'') + ' ' + (v.summary||'') + ' ' +
                (v.repo_name||'') + ' ' + (v.momentum||'') + ' ' + msg + ' ' +
                (v.live_task||'')).toLowerCase();
@@ -762,13 +816,15 @@ _JS = r"""
 
     if(v.summary) c.appendChild(el('div', 'summary', v.summary));
 
-    // The user's own most-recent prompt — the highest-signal "what is this" line
-    // (summary + latest message read well together). textContent-only, never innerHTML.
-    var msgs = v.recent_messages || [];
-    if(msgs.length && msgs[0] && msgs[0].text){
+    // The user's own most-recent SUBSTANTIVE prompt — the highest-signal "what is this"
+    // line (summary + latest message read well together). `face_message` skips low-signal
+    // boilerplate (dispatch/proceed/yes); the expand still shows the full recent_messages
+    // list. textContent-only, never innerHTML.
+    var face = v.face_message;
+    if(face && face.text){
       var m = el('div', 'msg');
       m.appendChild(el('span', 'lbl', 'you ›'));
-      m.appendChild(document.createTextNode(' ' + msgs[0].text));
+      m.appendChild(document.createTextNode(' ' + face.text));
       c.appendChild(m);
     }
 

--- a/scripts/session-analysis/initiative-scan.py
+++ b/scripts/session-analysis/initiative-scan.py
@@ -467,6 +467,16 @@ def branch_matches_slug(branch: str, slug: str) -> bool:
     return set(slug_toks).issubset(btoks)
 
 
+def _specificity_key(ini: dict) -> tuple:
+    """Ranking key for "most-specific initiative": most slug tokens, then longest raw
+    slug, then lexical. This is the EXACT tie-break `best_matching_initiative` awards
+    branch/PR/telemetry credit by; factored out so message single-crediting
+    (attribute_recent_messages) ranks siblings identically instead of inventing a
+    second rule."""
+    slug = ini.get("slug", "")
+    return (len(slug_tokens(slug)), len(slug), slug)
+
+
 def best_matching_initiative(branch: str, initiatives: list[dict]) -> dict | None:
     """Pick the single most-specific initiative whose slug matches `branch`.
 
@@ -474,19 +484,14 @@ def best_matching_initiative(branch: str, initiatives: list[dict]) -> dict | Non
     return the one with the MOST slug tokens (longest / most-specific), so a
     branch like `app-blocks-followups` is credited to the `app-blocks-followups`
     initiative, NOT also to the broader `app-blocks` sibling. Ties (equal token
-    count) are broken by the longer raw slug, then lexically, for determinism.
-    None if nothing matches.
+    count) are broken by the longer raw slug, then lexically, for determinism
+    (`_specificity_key`). None if nothing matches.
     """
     candidates = [ini for ini in initiatives
                   if branch_matches_slug(branch, ini.get("slug", ""))]
     if not candidates:
         return None
-    return max(
-        candidates,
-        key=lambda ini: (len(slug_tokens(ini.get("slug", ""))),
-                         len(ini.get("slug", "")),
-                         ini.get("slug", "")),
-    )
+    return max(candidates, key=_specificity_key)
 
 
 def classify_momentum(last_ts: float | None, now: float | None = None) -> str:
@@ -1138,16 +1143,23 @@ def attribute_recent_messages(initiatives: list[dict], records: list[dict],
     """Mutate each initiative with `recent_messages` = [{text, ts}], newest-first, top-N.
 
     Bring the conversation onto the card: surface the user's OWN recent prompts. A
-    session's recent user turns are credited to an initiative when EITHER:
+    session is a candidate for an initiative when EITHER:
       • genesis  — its genesis text names a handoff of the initiative (the SAME rule as
-        attribute_sessions; a genesis naming two handoffs credits both), OR
+        attribute_sessions), OR
       • branch+cwd — its gitBranch is the initiative's most-specific match
         (best_matching_initiative) AND its cwd resolves to the initiative's repo
         (resolve_cwd_repo) — catching feature-branch sessions the genesis missed.
     Both predicates are the SAME ones the scan already uses for session/telemetry
-    attribution (no new scheme). Turns are pooled across the initiative's attributed
-    sessions, sorted by timestamp DESC (a None ts sorts last), de-duplicated, truncated,
-    and the top-N kept."""
+    attribution (no new scheme).
+
+    SINGLE-BEST-CREDIT: unlike session_count (attribute_sessions), a session's MESSAGES
+    are credited to exactly ONE initiative — its MOST-SPECIFIC candidate (`_specificity_key`,
+    the same ranking `best_matching_initiative` uses for branch/PR/telemetry credit). This
+    is what stops a session whose genesis names `handoff-app-blocks-comfy-cloud-scaffold.md`
+    from ALSO crediting the generic `app-blocks` sibling (whose `handoff-app-blocks` name is
+    a prefix substring) — the prompt would otherwise show on every prefix-sharing sibling.
+    Turns for the winning initiative are pooled across its attributed sessions, sorted by
+    timestamp DESC (a None ts sorts last), de-duplicated, truncated, and the top-N kept."""
     wt_map = wt_map or {}
     inis_by_repo: dict[str, list[dict]] = {}
     names_by_id: dict[int, set[str]] = {}
@@ -1164,20 +1176,25 @@ def attribute_recent_messages(initiatives: list[dict], records: list[dict],
         turns = r.get("turns") or []
         if not turns:
             continue
-        credited: set[int] = set()
+        candidates: list[dict] = []
         genesis = (r.get("genesis") or "").lower()
         if genesis:
             for ini in initiatives:
                 if any(nm in genesis for nm in names_by_id[id(ini)]):
-                    credited.add(id(ini))
+                    candidates.append(ini)
         branch = (r.get("branch") or "").strip()
         repo = resolve_cwd_repo(r.get("cwd"), repos, wt_map)
         if branch and repo is not None:
             best = best_matching_initiative(branch, inis_by_repo.get(repo, []))
             if best is not None:
-                credited.add(id(best))
-        for iid in credited:
-            acc[iid].extend(turns)
+                candidates.append(best)  # a repeat of a genesis candidate is harmless to max
+        if not candidates:
+            continue
+        # Single-best-credit: the session's messages go to its MOST-SPECIFIC candidate
+        # only (same ranking as best_matching_initiative), so sibling slugs sharing a
+        # prefix don't each surface the same prompt.
+        winner = max(candidates, key=_specificity_key)
+        acc[id(winner)].extend(turns)
 
     for ini in initiatives:
         # Newest-first; a None ts sorts after any real ts (present-flag as primary key).

--- a/scripts/session-analysis/tests/test_initiative_scan.py
+++ b/scripts/session-analysis/tests/test_initiative_scan.py
@@ -1382,6 +1382,108 @@ def test_attribute_recent_messages_dedupes_identical_boilerplate():
     assert inis[0]["recent_messages"] == [{"text": boiler, "ts": 200.0}]
 
 
+def test_attribute_recent_messages_sibling_genesis_credits_only_most_specific():
+    # THE core precision fix. A session whose genesis names the SPECIFIC child handoff
+    # must credit its message to ONLY that child — NOT the generic `app-blocks` sibling
+    # (whose `handoff-app-blocks` name is a prefix SUBSTRING of the child's filename).
+    repo = "/r"
+    generic = {"slug": "app-blocks", "repo": repo,
+               "docs": [{"path": "/r/claudedocs/handoff-app-blocks.md", "date": None}]}
+    child = {"slug": "app-blocks-comfy-cloud-scaffold", "repo": repo,
+             "docs": [{"path": "/r/claudedocs/handoff-app-blocks-comfy-cloud-scaffold.md",
+                       "date": None}]}
+    inis = [generic, child]
+    records = [{"genesis": "resume handoff-app-blocks-comfy-cloud-scaffold.md",
+                "mtime": 1.0, "cwd": None, "branch": None,
+                "turns": [{"text": "wire the comfy cloud scaffold", "ts": 500.0}]}]
+    isc.attribute_recent_messages(inis, records, [repo])
+    assert generic["recent_messages"] == []                       # NOT duplicated onto generic
+    assert [m["text"] for m in child["recent_messages"]] == ["wire the comfy cloud scaffold"]
+
+
+def test_attribute_recent_messages_three_prefix_siblings_single_credit():
+    # generic + TWO specific children all prefix-share `app-blocks`; a child-named genesis
+    # lands on exactly ONE (the named child), never the generic OR the other sibling.
+    repo = "/r"
+    generic = {"slug": "app-blocks", "repo": repo,
+               "docs": [{"path": "/r/claudedocs/handoff-app-blocks.md", "date": None}]}
+    scaffold = {"slug": "app-blocks-comfy-cloud-scaffold", "repo": repo,
+                "docs": [{"path":
+                          "/r/claudedocs/handoff-app-blocks-comfy-cloud-scaffold.md",
+                          "date": None}]}
+    review = {"slug": "app-blocks-agentic-review-arc", "repo": repo,
+              "docs": [{"path": "/r/claudedocs/handoff-app-blocks-agentic-review-arc.md",
+                        "date": None}]}
+    inis = [generic, scaffold, review]
+    records = [{"genesis": "continue handoff-app-blocks-agentic-review-arc.md",
+                "mtime": 1.0, "cwd": None, "branch": None,
+                "turns": [{"text": "close the review arc", "ts": 500.0}]}]
+    isc.attribute_recent_messages(inis, records, [repo])
+    assert generic["recent_messages"] == []
+    assert scaffold["recent_messages"] == []
+    assert [m["text"] for m in review["recent_messages"]] == ["close the review arc"]
+
+
+def test_attribute_recent_messages_generic_genesis_credits_generic_not_child():
+    # A genesis naming ONLY the generic handoff credits the generic. The child does NOT
+    # match (its longer `handoff-app-blocks-comfy-cloud-scaffold` name is not a substring of
+    # the short generic genesis), so the single-best rule has just one candidate — no
+    # accidental diversion to a child the session never referenced.
+    repo = "/r"
+    generic = {"slug": "app-blocks", "repo": repo,
+               "docs": [{"path": "/r/claudedocs/handoff-app-blocks.md", "date": None}]}
+    child = {"slug": "app-blocks-comfy-cloud-scaffold", "repo": repo,
+             "docs": [{"path": "/r/claudedocs/handoff-app-blocks-comfy-cloud-scaffold.md",
+                       "date": None}]}
+    inis = [generic, child]
+    records = [{"genesis": "resume handoff-app-blocks.md", "mtime": 1.0,
+                "cwd": None, "branch": None,
+                "turns": [{"text": "generic app-blocks work", "ts": 500.0}]}]
+    isc.attribute_recent_messages(inis, records, [repo])
+    assert [m["text"] for m in generic["recent_messages"]] == ["generic app-blocks work"]
+    assert child["recent_messages"] == []
+
+
+def test_attribute_recent_messages_tiebreak_longer_slug_wins():
+    # Two candidates with the SAME slug-token count: the tie-break (longer raw slug, then
+    # lexical — `_specificity_key`, mirroring best_matching_initiative) decides the winner.
+    repo = "/r"
+    # both have 2 meaningful tokens ({red, panda} vs {red, pandas}) — different raw lengths.
+    a = {"slug": "red-panda", "repo": repo,
+         "docs": [{"path": "/r/claudedocs/handoff-red-panda.md", "date": None}]}
+    b = {"slug": "red-pandas", "repo": repo,
+         "docs": [{"path": "/r/claudedocs/handoff-red-pandas.md", "date": None}]}
+    inis = [a, b]
+    # Genesis names BOTH handoffs -> both are candidates; longer raw slug ("red-pandas") wins.
+    records = [{"genesis": "handoff-red-panda.md and handoff-red-pandas.md", "mtime": 1.0,
+                "cwd": None, "branch": None,
+                "turns": [{"text": "which panda", "ts": 500.0}]}]
+    isc.attribute_recent_messages(inis, records, [repo])
+    assert a["recent_messages"] == []
+    assert [m["text"] for m in b["recent_messages"]] == ["which panda"]
+    # Confirm the tie-break agrees with _specificity_key directly.
+    assert isc._specificity_key(b) > isc._specificity_key(a)
+
+
+def test_attribute_recent_messages_single_credit_does_not_change_session_counts():
+    # SCOPE GUARD: the message single-credit fix must NOT touch attribute_sessions —
+    # `session_count` (the displayed `sess:` count) still MULTI-credits prefix siblings.
+    repo = "/r"
+    generic = {"slug": "app-blocks", "repo": repo,
+               "docs": [{"path": "/r/claudedocs/handoff-app-blocks.md", "date": None}]}
+    child = {"slug": "app-blocks-comfy-cloud-scaffold", "repo": repo,
+             "docs": [{"path": "/r/claudedocs/handoff-app-blocks-comfy-cloud-scaffold.md",
+                       "date": None}]}
+    inis = [generic, child]
+    genesis = [{"text": "resume handoff-app-blocks-comfy-cloud-scaffold.md", "mtime": 10.0}]
+    isc.attribute_sessions(inis, genesis)
+    # BOTH still counted (unchanged multi-credit) — the child filename contains the generic
+    # `handoff-app-blocks` substring, so the generic's session_count is 1, not diverted.
+    assert generic["session_count"] == 1
+    assert child["session_count"] == 1
+    assert generic["last_session"] == 10.0 and child["last_session"] == 10.0
+
+
 # --------------------------------------------------------------------------- #
 # Recent commit subjects
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Two precision fixes to the Phase A initiatives card enrichment (PR #143), scan-logic + viewer-render only — **no schema change, no migration, no new columns**. Deployable straight after review.

## Problem 1 (core) — sibling slugs duplicated the same prompt
Message attribution reused the scan's session→initiative matching, whose **genesis path multi-credits**: it tests `"handoff-<slug>" in genesis_text` (substring), so a session whose genesis names `handoff-app-blocks-comfy-cloud-scaffold.md` ALSO matched the generic `app-blocks` (its `handoff-app-blocks` name is a prefix substring). One prompt showed on `app-blocks` AND every prefix-sharing sibling.

**Fix — single-best-credit for MESSAGES:** a session now contributes its `recent_messages` to exactly **one** initiative — its **most-specific** match — reusing `best_matching_initiative`'s ranking (factored into a shared `_specificity_key`: most slug tokens → longest raw slug → lexical). `attribute_recent_messages` collects all candidates (genesis + branch/cwd), then `max(candidates, key=_specificity_key)` wins.

Measured on `civit/datapacket-talos` (415 in-window sessions): **before**, 29 crediting sessions multi-credited (one session hit 3 initiatives, e.g. `app-blocks` + `app-blocks-review-sandbox` + `app-blocks-ux`); **after**, all 70 crediting sessions credit exactly one. The exact bug case from the handoff — `● Resume — App Blocks: Comfy Cloud scaffold + dev-tunnel fix` landing on both the generic and the specific child — is gone.

**Scope:** MESSAGE attribution only. `session_count`/`last_session` (the displayed `sess:` count, `attribute_sessions`) is deliberately **untouched** and still multi-credits prefix siblings — asserted by a guard test. `sess:` counts are unchanged.

## Problem 2 — card face showed low-signal prompts
The card FACE rendered the newest prompt even when boilerplate (`dispatch`/`proceed`/`//exit`/`yes`).

**Fix (viewer-side):** `pick_face_message` selects the most-recent **substantive** prompt for the face — skips a small stopword set + <15-char prompts — falling back to the newest when all are trivial (never blank). The stored `recent_messages` list stays **complete**: the expand shows every prompt verbatim; only the face line is filtered. Live examples: `app-blocks` face `//exit` → `3259 already released. give me the kickoff message…`; `app-blocks-agentic-review-arc` face `yes, dispatch` → `dispatch to process feedback: on /apps/submit…`.

## Tests
Extends the hermetic suites (fixtures, no live infra): sibling single-credit (generic + specific children → most-specific only), three-prefix-siblings, generic-genesis-credits-generic, tie-break via `_specificity_key`, a `sess:`-unchanged scope guard, and the face selection (skips boilerplate / falls back when all trivial / full list intact). `scripts/run-tests.sh` green (full hermetic set).

## Residual / honesty
- Verified fixture-only AND exercised on real handoffs+transcripts (the before/after above ran the real modules, no git/gh/telemetry).
- The face filter is length + a small stopword set (deterministic). A *re-injected long agent-pipeline preamble* is substantive-length, so it can still be the face for a session that had nothing else — Phase A's dedup collapses it within an initiative but it can appear across unrelated initiatives (each from its own session). That's honest attribution, not the Problem-1 bug; Phase B (LLM recap) is the intended cure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)