### PR TITLE
fix(initiatives): recap describes the WORK not the handoff doc + bust cache on prompt/model change

### DIFF
--- a/scripts/initiatives/recap.py
+++ b/scripts/initiatives/recap.py
@@ -128,14 +128,30 @@ ANTI_CONFABULATION_CONTRACT = (
 
 RECAP_INSTRUCTIONS = (
     "You summarize one software initiative for a status board. Produce a plain-language "
-    "recap of ONE to TWO sentences: what the initiative is and where it currently "
-    "stands. Requirements: present tense; terse and concrete; describe the substance "
-    "directly — do NOT open with meta like \"This initiative…\" / \"The goal is…\"; no "
-    "preamble, no bullet points, no markdown, no quotes around the output. Return ONLY "
-    "the recap text."
+    "recap of ONE to TWO sentences: what the initiative is (the actual work / system) "
+    "and where it currently stands. "
+    "Describe the WORK ITSELF, never the paperwork about it. You MUST NEVER mention or "
+    "describe a handoff doc, a resume/canonical doc, a markdown or notes file, any "
+    "filename, the word \"supersedes\", or the existence of documentation — the recap is "
+    "about the feature / system and its status, NOT about any document that tracks it. "
+    "If the only context is doc-meta (e.g. one file superseding another, a \"resume "
+    "doc\"), write from whatever substantive work IS present, or a single honest clause "
+    "about the work — never \"this is a doc that…\" or a reference to the document. "
+    "Requirements: present tense; terse and concrete; describe the substance directly — "
+    "do NOT open with meta like \"This initiative…\" / \"The goal is…\"; no preamble, no "
+    "bullet points, no markdown, no quotes around the output. Return ONLY the recap text."
 )
 
 SYSTEM_PROMPT = RECAP_INSTRUCTIONS + "\n\n" + ANTI_CONFABULATION_CONTRACT
+
+# A short, deterministic fingerprint of the prompt text (system message). Folding it into
+# `input_hash` means any edit to SYSTEM_PROMPT (tightening the instructions, or the
+# anti-confabulation contract) changes EVERY initiative's hash → the whole recap cache is
+# busted and the next sync regenerates all recaps under the new prompt. This is automatic:
+# no manual version bump to remember (a stale RECAP_PROMPT_VERSION constant is the classic
+# way to serve recaps from an old prompt forever). Only a prefix is used — full 256-bit
+# collision resistance is irrelevant for a cache key.
+_PROMPT_FINGERPRINT = hashlib.sha256(SYSTEM_PROMPT.encode("utf-8")).hexdigest()[:16]
 
 
 def recap_context(ini: dict) -> dict:
@@ -174,15 +190,25 @@ def _pr_text(p) -> str:
     return str(p or "").strip()
 
 
-def input_hash(ctx: dict) -> str:
-    """PURE + STABLE: a sha256 over the context fields that define "what / where it
-    stands". Order-INDEPENDENT for the set-like fields (open_investigations / open_prs
-    are sorted) and for dict-key order (sort_keys), so a mere reordering never triggers a
-    regenerate; a genuine content change (a new/edited message, commit, next-step,
-    summary, momentum, investigation, or PR) DOES. `recent_messages`/`recent_commits`
-    keep their newest-first order — a reorder there implies added/removed content, which
-    is exactly a change we want to re-recap."""
+def input_hash(ctx: dict, model: str = "") -> str:
+    """PURE + STABLE: a sha256 over everything that determines the generated recap — the
+    context fields that define "what / where it stands", PLUS the prompt fingerprint and
+    the served `model`. Order-INDEPENDENT for the set-like fields (open_investigations /
+    open_prs are sorted) and for dict-key order (sort_keys), so a mere reordering never
+    triggers a regenerate; a genuine content change (a new/edited message, commit,
+    next-step, summary, momentum, investigation, or PR) DOES. `recent_messages`/
+    `recent_commits` keep their newest-first order — a reorder there implies added/removed
+    content, which is exactly a change we want to re-recap.
+
+    Folding the prompt fingerprint and model in means a PROMPT edit (see
+    `_PROMPT_FINGERPRINT`) or a MODEL swap also busts the cache, so the next sync
+    regenerates every recap under the new prompt/model instead of serving stale output
+    from the old one. Everything else stays deterministic (the same sorted-fields /
+    sort_keys properties), so an unchanged prompt + model + context yields a stable hash
+    (a cache hit)."""
     canonical = {
+        "prompt": _PROMPT_FINGERPRINT,
+        "model": (model or "").strip(),
         "momentum": ctx.get("momentum", ""),
         "summary": ctx.get("summary", ""),
         "next_step": ctx.get("next_step", ""),
@@ -377,7 +403,7 @@ def sync_recaps(conn, rows: list[dict], *, client, model: str) -> dict:
                 stats["skipped"] += 1
                 continue
             ctx = recap_context(r)
-            ihash = input_hash(ctx)
+            ihash = input_hash(ctx, model=model)
             prev = cached.get((repo, slug))
             if prev and prev.get("input_hash") == ihash and prev.get("recap"):
                 stats["cached"] += 1  # unchanged → reuse the cached recap, no model call

--- a/scripts/initiatives/tests/test_recap.py
+++ b/scripts/initiatives/tests/test_recap.py
@@ -81,6 +81,47 @@ def test_input_hash_ignores_message_timestamps_only_text_matters():
 
 
 # --------------------------------------------------------------------------- #
+# input_hash — the cache key also folds in the PROMPT and the served MODEL, so a
+# prompt edit or a model swap busts the cache and forces a regenerate on next sync.
+# --------------------------------------------------------------------------- #
+def test_prompt_fingerprint_derives_deterministically_from_system_prompt():
+    # The fingerprint is a stable sha256 prefix of SYSTEM_PROMPT — so ANY edit to the
+    # prompt text changes the fingerprint (and therefore every input_hash).
+    import hashlib
+    expected = hashlib.sha256(recap.SYSTEM_PROMPT.encode("utf-8")).hexdigest()[:16]
+    assert recap._PROMPT_FINGERPRINT == expected
+
+
+def test_input_hash_changes_when_the_prompt_changes(monkeypatch):
+    # (a) A change to SYSTEM_PROMPT (surfaced via its fingerprint) changes input_hash for
+    # the SAME context → the next sync sees a hash mismatch and regenerates.
+    ctx = recap.recap_context(_fixture_ini())
+    before = recap.input_hash(ctx)
+    monkeypatch.setattr(recap, "_PROMPT_FINGERPRINT", "0000tightenedfp")
+    after = recap.input_hash(ctx)
+    assert before != after
+
+
+def test_input_hash_is_stable_when_prompt_and_model_unchanged():
+    # (b) Unchanged prompt + model + context → identical hash (a cache hit, no regen).
+    a = recap.input_hash(recap.recap_context(_fixture_ini()), model="qwen")
+    b = recap.input_hash(recap.recap_context(_fixture_ini()), model="qwen")
+    assert a == b
+
+
+def test_input_hash_changes_when_the_model_changes():
+    # A model swap must also bust the cache → regenerate under the new served model.
+    ctx = recap.recap_context(_fixture_ini())
+    assert recap.input_hash(ctx, model="qwen-7b") != recap.input_hash(ctx, model="qwen-14b")
+
+
+def test_input_hash_default_model_is_empty_string():
+    # No model given == model="" (stable default; the two calls agree).
+    ctx = recap.recap_context(_fixture_ini())
+    assert recap.input_hash(ctx) == recap.input_hash(ctx, model="")
+
+
+# --------------------------------------------------------------------------- #
 # recap_context — extraction / normalization
 # --------------------------------------------------------------------------- #
 def test_recap_context_extracts_message_text_and_formats_prs():
@@ -121,6 +162,18 @@ def test_build_messages_carries_anti_confabulation_contract():
     assert "ONE to TWO sentences" in sys_text
     assert "present tense" in sys_text
     assert "do NOT open with meta" in sys_text
+
+
+def test_prompt_forbids_describing_the_handoff_doc_not_the_work():
+    # (c) The tightened prompt must instruct the model to describe the WORK, never the
+    # handoff/doc/markdown file — the fix for recaps like "Supersedes handoff-….md".
+    sys_text = recap.build_messages(recap.recap_context(_fixture_ini()))[0]["content"]
+    low = sys_text.lower()
+    assert "never" in low
+    assert "handoff" in low
+    assert "supersedes" in low          # the specific meta phrasing to suppress
+    assert "documentation" in low
+    assert "the work itself" in low     # positive framing: describe the work
 
 
 def test_build_messages_user_content_includes_only_provided_context():
@@ -233,7 +286,7 @@ def test_upsert_recap_uses_on_conflict_do_update():
 # --------------------------------------------------------------------------- #
 def test_sync_recaps_cache_hit_skips_the_model_and_upsert():
     ini = _fixture_ini()
-    ihash = recap.input_hash(recap.recap_context(ini))
+    ihash = recap.input_hash(recap.recap_context(ini), model="m")
     conn = _FakeConn(recaps_rows=[(ini["repo"], ini["slug"], "cached recap", ihash)])
     client = _FakeClient()
     stats = recap.sync_recaps(conn, [ini], client=client, model="m")
@@ -259,7 +312,8 @@ def test_sync_recaps_regenerates_when_hash_differs():
                      if "INSERT INTO initiatives.recaps" in s)
     assert params[0] == ini["repo"] and params[1] == ini["slug"]
     assert params[2] == "fresh recap text"
-    assert params[3] == recap.input_hash(recap.recap_context(ini))
+    # the stored hash folds in the served model (the same model sync_recaps ran with)
+    assert params[3] == recap.input_hash(recap.recap_context(ini), model="m")
     assert params[4] == "m"
 
 


### PR DESCRIPTION
## What

Two fixes to the initiatives LLM-recap generator (`scripts/initiatives/recap.py`).

### 1. Recap describes the WORK, never the handoff doc
Live recaps sometimes described the handoff *document* instead of the actual work — e.g. `"Supersedes claudedocs/handoff-2026-07-20-remix-session.md and is active"`, `"Canonical resume doc for the civitai Go CLI continues, superseding previous documentation"`.

`RECAP_INSTRUCTIONS` now adds an explicit rule: the recap describes the initiative's actual work/system and its status, and **NEVER** mentions or describes a handoff/resume/canonical doc, a markdown/notes file, a filename, `"supersedes"`, or the existence of documentation. When the only context is doc-meta, the model writes from whatever substantive work IS present, or a single honest clause about the work. All existing style constraints (present tense, 1–2 sentences, terse, no `"This initiative…"`/`"The goal is…"` openers, no markdown/bullets/quotes) are kept.

### 2. A prompt change now actually regenerates cached recaps (cache-key bug)
`input_hash` hashed only the initiative **context**, not the prompt — so changing `SYSTEM_PROMPT` (like fix #1) did **not** invalidate cached recaps, and the next sync would keep serving stale recaps generated by the OLD prompt.

Fix: fold a deterministic prompt fingerprint (`_PROMPT_FINGERPRINT = sha256(SYSTEM_PROMPT)[:16]`) **and** the served `model` into `input_hash`. A prompt edit or a model swap now busts the whole cache → the next sync regenerates every recap under the new prompt/model. No manual version bump to remember (hashing the prompt itself is self-updating). The hash stays deterministic otherwise — same sorted-fields / `sort_keys` properties, so unchanged prompt + model + context is a stable cache hit.

No schema/migration change — the `recaps` table is unchanged.

## Tests
`scripts/initiatives/tests/test_recap.py` extended: prompt-fingerprint derives deterministically from `SYSTEM_PROMPT`; a prompt change and a model swap each change `input_hash` for the same context (→ regenerate); unchanged prompt+model+context is stable (→ cache hit); the prompt string forbids describing the handoff/doc. Two existing sync tests updated to fold `model` into the expected hash.

`scripts/run-tests.sh` (hermetic set) is green — recap suite: 33 passed.

## Deploy note
Human merges, deploys, and triggers a sync. With the cache-key fix, all 24 cached recaps regenerate under the tightened prompt on the next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)