### PR TITLE
fix(initiatives): time last_session from last user turn, not transcript mtime

### DIFF
--- a/scripts/session-analysis/initiative-scan.py
+++ b/scripts/session-analysis/initiative-scan.py
@@ -1041,13 +1041,20 @@ def _truncate(s: str, n: int) -> str:
 
 
 def _read_session_turns(path: str, n: int) -> dict | None:
-    """Parse ONE transcript into {genesis, turns, cwd, branch}, or None if it has no
-    genuine user turn.
+    """Parse ONE transcript into {genesis, turns, last_user_ts, cwd, branch}, or None if
+    it has no genuine user turn.
 
     - genesis: the FIRST genuine user turn text (the SAME rule _first_user_turn used —
       skips harness/system-reminder/command/interrupt/caveat noise via _clean_turn).
     - turns: [{text, ts}] for the LAST `n` genuine user turns (oldest→newest), each
       cleaned; `ts` is the turn's UTC epoch (from its ISO `timestamp`), or None.
+    - last_user_ts: the MAX UTC epoch across ALL genuine user turns (independent of the
+      `n`-turn window) — the "last real interaction" time. This is the momentum-safe
+      touch signal: unlike the transcript's filesystem mtime it is NOT bumped when
+      Claude Code rewrites the .jsonl in place for metadata maintenance (title/mode/
+      permission), which otherwise makes an idle session read as freshly touched. None
+      only when NO genuine turn carried a parseable `timestamp` (rare/edge). Mirrors the
+      `doc_touch_epoch` rule that avoids mtime for the same class of bulk-rewrite reason.
     - cwd / branch: from the MOST-RECENT turn that carries them (each user turn records
       `cwd` + `gitBranch`) — used by the branch/cwd attribution fallback.
     Reads the file ONCE (transcript reads are the costly part of the scan)."""
@@ -1058,6 +1065,7 @@ def _read_session_turns(path: str, n: int) -> dict | None:
         return None
     genesis: str | None = None
     turns: list[dict] = []
+    last_user_ts: float | None = None
     cwd: str | None = None
     branch: str | None = None
     for line in lines:
@@ -1083,7 +1091,10 @@ def _read_session_turns(path: str, n: int) -> dict | None:
             continue
         if genesis is None:
             genesis = txt
-        turns.append({"text": txt, "ts": _iso_to_epoch(obj.get("timestamp"))})
+        ts = _iso_to_epoch(obj.get("timestamp"))
+        turns.append({"text": txt, "ts": ts})
+        if ts is not None:
+            last_user_ts = ts if last_user_ts is None else max(last_user_ts, ts)
         c = obj.get("cwd")
         if c:
             cwd = c
@@ -1093,7 +1104,7 @@ def _read_session_turns(path: str, n: int) -> dict | None:
     if genesis is None:
         return None
     return {"genesis": genesis, "turns": turns[-n:] if n > 0 else [],
-            "cwd": cwd, "branch": branch}
+            "last_user_ts": last_user_ts, "cwd": cwd, "branch": branch}
 
 
 def _first_user_turn(path: str) -> str | None:
@@ -1128,11 +1139,15 @@ def collect_session_records(projects_root: str, since_days: int,
 
 
 def session_genesis_refs(projects_root: str, since_days: int) -> list[dict]:
-    """[{text, mtime}] over each in-window session's genesis (first genuine user turn).
+    """[{text, mtime, last_user_ts}] over each in-window session's genesis (first genuine
+    user turn).
 
     A thin adapter over collect_session_records so the transcript walk is single-sourced
-    (attribute_sessions still consumes exactly this shape)."""
-    return [{"text": r["genesis"], "mtime": r["mtime"]}
+    (attribute_sessions still consumes exactly this shape). `last_user_ts` (the last
+    genuine user-turn epoch) is carried alongside `mtime` so attribute_sessions can time
+    `last_session` from real interaction, not the mtime that in-place .jsonl rewrites bump."""
+    return [{"text": r["genesis"], "mtime": r["mtime"],
+             "last_user_ts": r.get("last_user_ts")}
             for r in collect_session_records(projects_root, since_days, n=1)]
 
 
@@ -1227,6 +1242,15 @@ def attribute_sessions(initiatives: list[dict], genesis: list[dict]) -> None:
     A session belongs to an initiative when its genesis text mentions
     `handoff-<slug>` (slug or any dated variant filename of the cluster). Counted
     per initiative independently — a genesis naming two handoffs counts for both.
+
+    `last_session` is timed from each session's LAST genuine user-turn epoch
+    (`last_user_ts`), NOT its transcript filesystem mtime: Claude Code rewrites the
+    .jsonl in place for metadata maintenance (title/mode/permission) with zero new work,
+    bumping mtime and making an idle session masquerade as freshly touched → false
+    `active` momentum. This mirrors `doc_touch_epoch`, which avoids mtime for the same
+    bulk-rewrite reason. FALLBACK: a session with no parseable user-turn ts (rare — a
+    genuine turn whose `timestamp` was absent/unparseable) contributes its `mtime`, the
+    only remaining signal; `session_count` is unaffected either way.
     """
     for ini in initiatives:
         names = {os.path.basename(d["path"]).lower() for d in ini["docs"]}
@@ -1237,7 +1261,10 @@ def attribute_sessions(initiatives: list[dict], genesis: list[dict]) -> None:
             low = g["text"].lower()
             if any(n in low for n in names):
                 count += 1
-                last = newest_touch(last, g["mtime"])
+                touch = g.get("last_user_ts")
+                if touch is None:
+                    touch = g.get("mtime")
+                last = newest_touch(last, touch)
         ini["session_count"] = count
         ini["last_session"] = last
 
@@ -1642,7 +1669,8 @@ def build_report(days: int, repos: list[str] | None = None,
     # ONE transcript walk feeds both session-count attribution AND recent-message
     # surfacing (transcripts are the costly read; genesis is derived from the records).
     records = collect_session_records(projects_root, days)
-    genesis = [{"text": r["genesis"], "mtime": r["mtime"]} for r in records]
+    genesis = [{"text": r["genesis"], "mtime": r["mtime"],
+                "last_user_ts": r.get("last_user_ts")} for r in records]
     attribute_sessions(initiatives, genesis)
 
     # Resolve cwds living in linked worktrees back to their canonical repo so worktree

--- a/scripts/session-analysis/tests/test_initiative_scan.py
+++ b/scripts/session-analysis/tests/test_initiative_scan.py
@@ -1206,6 +1206,36 @@ def test_build_report_keeps_stale_handoff_with_live_session(tmp_path, monkeypatc
     assert inis[0]["tmux_sessions"] == ["main:8-1"]
 
 
+def test_build_report_last_session_from_user_turn_not_mtime(tmp_path, monkeypatch):
+    # HOT-PATH GUARD for the false-active bug: build_report inlines the genesis dict from
+    # collect_session_records; it MUST carry last_user_ts so last_session times from the
+    # last genuine user turn, not the transcript's fs-mtime (which Claude Code bumps on an
+    # in-place metadata rewrite with zero new work). Pre-fix, mtime (~30m ago) read active;
+    # post-fix, the 20-day-old last user turn reads stalled. The exact clawgate-chat-polish
+    # case, exercised through the real build_report path (not just attribute_sessions).
+    import calendar
+    now = float(calendar.timegm((2026, 7, 25, 0, 0, 0, 0, 0, 0)))
+    repo = tmp_path / "r"
+    (repo / "claudedocs").mkdir(parents=True)
+    (repo / "claudedocs" / "handoff-widget-2026-07-01.md").write_text(
+        "# Handoff: widget\n## Next steps\n1. go\n")   # dated 07-01 -> doc freshness stalled too
+    _stub_no_external_io(monkeypatch)
+    old_turn = now - 20 * isc.DAY                       # ~2026-07-05, a genuine old interaction
+    rec = {"genesis": "resume handoff-widget-2026-07-01.md",
+           "mtime": now - 1800,                         # in-place-rewrite bump: ~30m ago
+           "last_user_ts": old_turn,
+           "cwd": str(repo), "branch": "main",
+           "turns": [{"text": "resume handoff-widget-2026-07-01.md", "ts": old_turn}]}
+    monkeypatch.setattr(isc, "collect_session_records", lambda root, d, n=5: [rec])
+
+    report = isc.build_report(30, repos=[str(repo)], client=None, now=now)
+    ini = report["by_repo"][str(repo)][0]
+    assert ini["slug"] == "widget"
+    assert ini["session_count"] == 1                    # attribution unchanged
+    assert ini["last_session"] == old_turn              # NOT rec["mtime"]
+    assert ini["momentum"] == "stalled"                 # would be "active" off the mtime
+
+
 # --------------------------------------------------------------------------- #
 # Recent user-message extraction + attribution (Phase A card legibility)
 # --------------------------------------------------------------------------- #
@@ -1311,6 +1341,116 @@ def test_session_genesis_refs_derives_from_records(tmp_path):
     assert len(refs) == 1
     assert refs[0]["text"] == "genesis line"     # genesis, not the last turn
     assert "mtime" in refs[0]
+
+
+# --------------------------------------------------------------------------- #
+# last_user_ts — momentum from the last genuine user turn, NOT transcript mtime.
+# (Claude Code rewrites .jsonl in place for metadata → mtime bumps with zero new
+#  work → an idle session reads as freshly touched → false `active`. Mirrors the
+#  doc_touch_epoch mtime-avoidance fix.)
+# --------------------------------------------------------------------------- #
+def test_read_session_turns_carries_last_user_ts(tmp_path):
+    # last_user_ts = MAX epoch across ALL genuine user turns, independent of the
+    # n-turn window and of the (noise) turns that get skipped.
+    p = tmp_path / "s.jsonl"
+    _write_transcript(p, [
+        _jsonl_user("<system-reminder>noise</system-reminder>", "2026-07-05T09:59:00Z"),
+        _jsonl_user("read handoff-foo.md and start", "2026-07-05T10:00:00Z"),
+        _jsonl_user("do the next thing", "2026-07-05T10:05:00Z"),
+    ])
+    rec = isc._read_session_turns(str(p), 1)   # tiny window; last_user_ts must ignore it
+    assert rec["last_user_ts"] == isc._iso_to_epoch("2026-07-05T10:05:00Z")
+    assert len(rec["turns"]) == 1              # window kept only the last turn
+
+
+def test_read_session_turns_last_user_ts_none_without_timestamp(tmp_path):
+    # A genuine turn whose `timestamp` is absent -> last_user_ts None (fallback path),
+    # but the record is still returned (genesis present).
+    line = _json.dumps({"type": "user",
+                        "message": {"role": "user", "content": "a real turn, no ts"}})
+    p = tmp_path / "s.jsonl"
+    _write_transcript(p, [line])
+    rec = isc._read_session_turns(str(p), 5)
+    assert rec is not None and rec["genesis"] == "a real turn, no ts"
+    assert rec["last_user_ts"] is None
+
+
+def test_session_genesis_refs_carries_last_user_ts_below_mtime(tmp_path):
+    # The clawgate reproduction at the walk level: the file's mtime is "now" (just
+    # written) but its last genuine user turn is 18 days old -> last_user_ts is the
+    # OLD epoch, far below mtime.
+    p = tmp_path / "proj" / "a.jsonl"
+    p.parent.mkdir(parents=True)
+    _write_transcript(p, [
+        _jsonl_user("resume handoff-clawgate-chat-polish-2026-07-05.md", "2026-07-05T10:00:00Z"),
+        _jsonl_user("last real turn that day", "2026-07-05T11:00:00Z"),
+    ])
+    refs = isc.session_genesis_refs(str(tmp_path), 3650)
+    assert len(refs) == 1
+    assert refs[0]["last_user_ts"] == isc._iso_to_epoch("2026-07-05T11:00:00Z")
+    # file was just created -> its mtime is "now", strictly newer than the 2026-07-05 turn.
+    assert refs[0]["mtime"] > refs[0]["last_user_ts"]
+
+
+def test_attribute_sessions_times_last_session_from_user_turn_not_mtime():
+    # The exact clawgate-chat-polish bug: mtime bumped to ~53m ago by an in-place
+    # rewrite, but the last genuine user turn was 18d ago. last_session must be the
+    # OLD user-turn epoch (-> stalled), NOT the recent mtime (-> false active).
+    now = isc._iso_to_epoch("2026-07-23T10:00:00Z")
+    old_turn = isc._iso_to_epoch("2026-07-05T10:00:00Z")   # 18 days before `now`
+    recent_mtime = now - 53 * 60                            # in-place-rewrite bump
+    inis = [{"slug": "clawgate-chat-polish", "docs": [
+        {"path": "/r/claudedocs/handoff-clawgate-chat-polish-2026-07-05.md",
+         "date": "2026-07-05"}]}]
+    genesis = [{"text": "resume handoff-clawgate-chat-polish-2026-07-05.md",
+                "mtime": recent_mtime, "last_user_ts": old_turn}]
+    isc.attribute_sessions(inis, genesis)
+    assert inis[0]["session_count"] == 1
+    assert inis[0]["last_session"] == old_turn              # NOT recent_mtime
+    assert isc.classify_momentum(inis[0]["last_session"], now) == "stalled"
+
+
+def test_attribute_sessions_recent_user_turn_stays_active():
+    # A genuinely-recent session (last user turn ~1h ago) still classifies active.
+    now = isc._iso_to_epoch("2026-07-23T10:00:00Z")
+    recent_turn = now - 3600
+    inis = [{"slug": "live-work", "docs": [
+        {"path": "/r/claudedocs/handoff-live-work-2026-07-23.md", "date": "2026-07-23"}]}]
+    genesis = [{"text": "read handoff-live-work-2026-07-23.md",
+                "mtime": now, "last_user_ts": recent_turn}]
+    isc.attribute_sessions(inis, genesis)
+    assert inis[0]["last_session"] == recent_turn
+    assert isc.classify_momentum(inis[0]["last_session"], now) == "active"
+
+
+def test_attribute_sessions_falls_back_to_mtime_without_user_ts():
+    # No parseable user-turn ts (last_user_ts absent/None) -> fall back to mtime,
+    # the only remaining signal (session still counts).
+    inis = [{"slug": "edge", "docs": [
+        {"path": "/r/claudedocs/handoff-edge.md", "date": None}]}]
+    # one session carries a real user-turn ts, one only a mtime (no last_user_ts key)
+    genesis = [
+        {"text": "resume handoff-edge.md", "mtime": 5000.0, "last_user_ts": None},
+        {"text": "resume handoff-edge.md again", "mtime": 9000.0},   # key absent -> .get None
+    ]
+    isc.attribute_sessions(inis, genesis)
+    assert inis[0]["session_count"] == 2
+    assert inis[0]["last_session"] == 9000.0    # newest mtime wins via fallback
+
+
+def test_attribute_sessions_session_count_independent_of_ts_source():
+    # SCOPE GUARD: switching last_session's timestamp source does NOT change session_count
+    # — a mix of ts-bearing and ts-less matching sessions all still count.
+    inis = [{"slug": "cnt", "docs": [
+        {"path": "/r/claudedocs/handoff-cnt.md", "date": None}]}]
+    genesis = [
+        {"text": "resume handoff-cnt.md", "mtime": 1.0, "last_user_ts": 100.0},
+        {"text": "resume handoff-cnt.md", "mtime": 2.0, "last_user_ts": None},
+        {"text": "resume handoff-cnt.md", "mtime": 3.0},           # no key
+        {"text": "unrelated", "mtime": 4.0, "last_user_ts": 400.0},
+    ]
+    isc.attribute_sessions(inis, genesis)
+    assert inis[0]["session_count"] == 3        # three matched, one unrelated
 
 
 def test_attribute_recent_messages_genesis_pool_desc_truncate():


### PR DESCRIPTION
## The bug
`scripts/session-analysis/initiative-scan.py` computed each initiative's `last_session` (→ momentum: <2d active / 2–7d slowing / ≥7d stalled) from the session transcript's **filesystem mtime**. Claude Code rewrites session `.jsonl` files **in place** for metadata maintenance (title/mode/permission) with **zero new work**, bumping mtime — so an idle 18-day-old session read as "touched ~53m ago" and its initiative showed a false **active**. Same mtime-bulk-rewrite class already fixed for handoff docs by `doc_touch_epoch`.

3 initiatives were currently false-active: `clawgate-chat-polish`, `sysredis-buffer-and-soft-dependency`, `dp-500-sweep-automate-obs`.

## The fix (Option A — deterministic/structural)
Carry each session's **last genuine USER-turn epoch** (max over all real user turns, reusing the existing `_read_session_turns` parse + `_clean_turn` noise filter — harness/system-reminder/interrupt/caveat turns excluded, same as genesis) and time `last_session` from it instead of mtime.

Threaded through:
- `_read_session_turns` (initiative-scan.py) now returns `last_user_ts` = max UTC epoch across all genuine user turns (independent of the recent-turns window).
- Carried by `collect_session_records` → **both** the `build_report` hot-path inline genesis dict **and** the `session_genesis_refs` adapter (the hot path had inlined its own `{text, mtime}` dict, bypassing the adapter — that was the real bug site).
- `attribute_sessions` consumes `last_user_ts`, falling back to `mtime` only when a matched session has **no parseable** user-turn timestamp (rare/edge). `session_count` semantics unchanged.

No schema/store change — `last_touch`/`momentum` are recomputed on the next sync.

## Verification (real data, telemetry-off scan)
| initiative | before | after |
|---|---|---|
| clawgate-chat-polish | active (last_session 2026-07-23 23:21 = mtime) | **stalled** (2026-07-05 17:47, 18d) |
| sysredis-buffer-and-soft-dependency | active (2026-07-23) | **stalled** (2026-07-06) |
| dp-500-sweep-automate-obs | active (2026-07-23) | **stalled** (2026-07-14) |

All three keep `session_count == 1`. The clawgate transcript directly shows the bug: file mtime today vs last genuine user turn 2026-07-05 (18.2-day delta).

Note: run against the *live* board the clawgate initiative may read active again **legitimately** if a genuine user turn references its handoff during this work — the fix times from real interaction, which is correct.

## Tests
8 added to `scripts/session-analysis/tests/test_initiative_scan.py`: `_read_session_turns` carries `last_user_ts` (+ None fallback), `session_genesis_refs` carries it below mtime, `attribute_sessions` times from user-turn not mtime / stays active on a recent turn / mtime fallback / session_count invariance, and a **build_report hot-path guard** (the exact clawgate case end-to-end). `scripts/run-tests.sh` green (full hermetic set).

## Residual risk
- A matched session whose genuine user turns **all** lack a parseable `timestamp` falls back to mtime (the buggy signal) — but such sessions are extraordinarily rare (Claude Code always writes turn timestamps); the false-active case specifically involves sessions that *do* carry old valid timestamps, which this fixes.
- Timezone: epochs are derived via the existing `_iso_to_epoch` (ISO tz-aware `timestamp` → epoch), consistent with how the codebase already parses turn ts; no local/UTC mixing introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)