### PR TITLE
feat(initiatives-viewer): show ALL live claude sessions, not just tagged initiatives

### DIFF
--- a/scripts/initiatives/tests/test_viewer.py
+++ b/scripts/initiatives/tests/test_viewer.py
@@ -292,23 +292,40 @@ def test_provider_returns_error_tuple_on_loader_failure():
 
 def test_attach_tmux_is_best_effort_on_scan_failure(monkeypatch):
     # The live tmux overlay is a nicety: if importing/using the scan blows up, attach_tmux
-    # must swallow it, return False, and leave the rows untouched (no crash, overlay absent).
+    # must swallow it, return [] (no unmatched), and leave the rows untouched (overlay absent).
     def boom():
         raise RuntimeError("scan import failed")
 
     monkeypatch.setattr(viewer, "_scan", boom)
     rows = [_row(slug="ok")]
-    assert viewer.attach_tmux(rows) is False
+    assert viewer.attach_tmux(rows) == []
     assert "tmux_sessions" not in rows[0]  # untouched
 
 
 def test_attach_tmux_absent_when_no_tmux_server(monkeypatch):
-    # No panes = no tmux server on this host → overlay absent (False), not an error.
+    # No panes = no tmux server on this host → overlay absent ([] unmatched), not an error.
     class _FakeScan:
         collect_tmux_panes = staticmethod(lambda: [])
 
     monkeypatch.setattr(viewer, "_scan", lambda: _FakeScan)
-    assert viewer.attach_tmux([_row(slug="ok")]) is False
+    assert viewer.attach_tmux([_row(slug="ok")]) == []
+
+
+def test_attach_tmux_returns_unmatched_from_scan(monkeypatch):
+    # attach_tmux passes through the unmatched list `match_tmux_to_initiatives` returns
+    # (the live claude panes that mapped to no initiative) — verbatim, no reimplementation.
+    unmatched = [{"id": "Pool-6", "title": "some uncovered work", "repo": "/r"}]
+
+    class _FakeScan:
+        collect_tmux_panes = staticmethod(lambda: [{"session": "x"}])
+        discover_repos = staticmethod(lambda: ["/r"])
+        worktree_canonical_map = staticmethod(lambda repos: {})
+        load_scratch_codenames = staticmethod(lambda: {})
+        match_tmux_to_initiatives = staticmethod(
+            lambda inis, panes, repos, wt, cn: unmatched)
+
+    monkeypatch.setattr(viewer, "_scan", lambda: _FakeScan)
+    assert viewer.attach_tmux([_row(slug="ok")]) == unmatched
 
 
 # --- flat view + enriched view fields (Feedback 1 + 3) ---------------------- #
@@ -880,3 +897,149 @@ def test_render_html_face_shows_substantive_not_boilerplate():
     assert "wire the comfy cloud scaffold" in html           # substantive prompt in payload
     assert '"face_message"' in html                            # the face field is embedded
     assert "v.face_message" in html                            # the card reads it for the face
+
+
+# --- live_unmatched: the "everything else running" catch-all ----------------- #
+def _um(id_, title="some work", repo="/home/zach/workspace/devrc"):
+    """One `match_tmux_to_initiatives` unmatched pane (id/title/repo)."""
+    return {"id": id_, "title": title, "repo": repo}
+
+
+def test_build_live_unmatched_shape_dedup_and_sort():
+    um = [
+        _um("main:8-4", "civ work", repo="/home/zach/workspace/civitai"),
+        _um("Pool-6", "devrc work A"),
+        _um("Pool-6", "devrc work A"),          # exact dup (id+title) → dropped
+        _um("main:8-2", "devrc work B"),
+    ]
+    out = viewer.build_live_unmatched(um)
+    # de-duped
+    assert len(out) == 3
+    # view shape
+    assert out[0].keys() >= {"id", "title", "repo", "repo_name"}
+    # sorted by repo_name then the scan's natural session key: civitai first, then within
+    # devrc capitalized codenames sort ahead of the lowercase `main:` sessions (mirrors the
+    # scan's `_tmux_session_sort_key`, so the CLI + viewer order sessions identically).
+    assert [(v["repo_name"], v["id"]) for v in out] == [
+        ("civitai", "main:8-4"),
+        ("devrc", "Pool-6"),
+        ("devrc", "main:8-2"),
+    ]
+
+
+def test_build_live_unmatched_natural_numeric_order():
+    # window numbers sort by VALUE, not lexically (8-2 before 8-10; Pool2 before Pool10);
+    # capitalized codenames (Pool…) sort ahead of lowercase `main:` — the scan's ordering.
+    um = [_um("main:8-10"), _um("main:8-2"), _um("Pool10"), _um("Pool2")]
+    ids = [v["id"] for v in viewer.build_live_unmatched(um)]
+    assert ids == ["Pool2", "Pool10", "main:8-2", "main:8-10"]
+
+
+def test_build_live_unmatched_none_repo_becomes_unknown():
+    out = viewer.build_live_unmatched([_um("x-1", "orphan", repo=None)])
+    assert out[0]["repo"] == ""
+    assert out[0]["repo_name"] == "(unknown repo)"
+
+
+def test_build_live_unmatched_coerces_non_list_and_junk():
+    # a fake tmux hook returning a bool (or None) → [] (no section); non-dict entries dropped.
+    assert viewer.build_live_unmatched(True) == []
+    assert viewer.build_live_unmatched(None) == []
+    assert viewer.build_live_unmatched(["junk", 3, _um("ok-1")]) == [
+        {"id": "ok-1", "title": "some work", "repo": "/home/zach/workspace/devrc",
+         "repo_name": "devrc"}]
+
+
+def test_build_model_carries_live_unmatched():
+    model = viewer.build_model([_row(slug="s")], now=NOW,
+                               unmatched=[_um("Pool-6", "uncovered thread")])
+    assert model["live_unmatched"] == [
+        {"id": "Pool-6", "title": "uncovered thread",
+         "repo": "/home/zach/workspace/devrc", "repo_name": "devrc"}]
+
+
+def test_build_model_live_unmatched_defaults_empty():
+    # no unmatched arg (and a non-list) → empty list, never missing/raising.
+    assert viewer.build_model([_row(slug="s")], now=NOW)["live_unmatched"] == []
+    assert viewer.build_model([_row(slug="s")], now=NOW,
+                              unmatched=True)["live_unmatched"] == []
+
+
+def test_model_to_json_includes_live_unmatched_ok_and_error():
+    model = viewer.build_model([_row(slug="a")], now=NOW, unmatched=[_um("Vapor-1", "t")])
+    j = viewer.model_to_json(model, None)
+    assert j["live_unmatched"] == [
+        {"id": "Vapor-1", "title": "t", "repo": "/home/zach/workspace/devrc",
+         "repo_name": "devrc"}]
+    # error branch always carries an empty list so the JS never sees undefined.
+    assert viewer.model_to_json(None, "store down")["live_unmatched"] == []
+
+
+def test_render_html_renders_live_unmatched_section_and_escapes():
+    model = viewer.build_model([_row(slug="s")], now=NOW, unmatched=[
+        _um("Pool-6", "<script>alert('u')</script>", repo="/home/zach/workspace/civitai")])
+    html = viewer.render_html(model)
+    # the section + its data ride the JSON island + JS (rendered client-side)
+    assert "Live sessions — not tied to an initiative" in html
+    assert "renderUnmatched" in html
+    assert '"live_unmatched"' in html
+    assert "Pool-6" in html                              # session id in the payload
+    assert "<script>alert('u')</script>" not in html     # untrusted title never raw
+    assert "u003cscript" in html                         # neutralized in the island
+
+
+def test_render_html_no_section_when_live_unmatched_empty():
+    # empty list → the JSON island carries [] and the JS early-returns (no section rows).
+    model = viewer.build_model([_row(slug="s")], now=NOW, unmatched=[])
+    j = viewer.model_to_json(model, None)
+    assert j["live_unmatched"] == []
+    html = viewer.render_html(model)
+    assert '"live_unmatched": []' in html or '"live_unmatched":[]' in html
+    # the renderer guards on length (no rows → no <section>)
+    assert "if(!rows.length) return;" in viewer._JS
+
+
+# --- multi-pane cosmetic: show ALL matched live tasks, not just the first ----- #
+def test_view_live_tasks_lists_all_matched_panes():
+    # An initiative matched by MORE than one live pane must surface EVERY task, while
+    # live_task (first) stays for the detail endpoint / back-compat.
+    rows = [_row(slug="next-session")]
+    rows[0]["tmux_tasks"] = ["Continue dp-prod performance…", "Pick up dp-prod 500 arc…"]
+    v = viewer.build_model(rows, now=NOW)["flat"][0]
+    assert v["live_task"] == "Continue dp-prod performance…"
+    assert v["live_tasks"] == ["Continue dp-prod performance…", "Pick up dp-prod 500 arc…"]
+
+
+def test_view_live_tasks_defaults_empty():
+    v = viewer.build_model([_row(slug="s")], now=NOW)["flat"][0]
+    assert v["live_tasks"] == []
+
+
+def test_js_card_renders_all_live_tasks():
+    # the card iterates the full live_tasks list (one line per session), not a single line.
+    assert "v.live_tasks" in viewer._JS
+    assert "ltasks.forEach" in viewer._JS
+
+
+def test_build_detail_carries_live_tasks():
+    rows = [_row(slug="s")]
+    rows[0]["tmux_tasks"] = ["task one", "task two"]
+    model = viewer.build_model(rows, now=NOW)
+    d = viewer.build_detail(model, None, "/home/zach/workspace/devrc", "s",
+                            doc_reader=lambda repo, doc: None)
+    assert d["live_tasks"] == ["task one", "task two"]
+
+
+def test_provider_passes_unmatched_through_to_model():
+    # the DataProvider must thread attach_tmux's unmatched return into build_model so the
+    # section is populated from the live tmux read (not silently dropped, as it was before).
+    def tmux(rows):
+        return [_um("Vapor-9", "a live uncovered thread")]
+
+    prov = viewer.DataProvider(ttl=60, loader=lambda: [_row(slug="s")], tmux=tmux,
+                               now_fn=lambda: NOW)
+    model, error = prov.snapshot()
+    assert error is None
+    assert model["live_unmatched"] == [
+        {"id": "Vapor-9", "title": "a live uncovered thread",
+         "repo": "/home/zach/workspace/devrc", "repo_name": "devrc"}]

--- a/scripts/initiatives/viewer.py
+++ b/scripts/initiatives/viewer.py
@@ -233,27 +233,29 @@ def attach_recaps(conn, rows: list[dict]) -> bool:
     return True
 
 
-def attach_tmux(initiatives: list[dict]) -> bool:
-    """Attach live tmux sessions to each initiative (mutates `tmux_sessions`). Returns
-    True if the overlay was applied, False if absent (no tmux server / any failure).
+def attach_tmux(initiatives: list[dict]) -> list[dict]:
+    """Attach live tmux sessions to each initiative (mutates `tmux_sessions`/`tmux_tasks`)
+    and RETURN the list of live claude panes that matched NO initiative (each
+    `{"id", "title", "repo"}`) — the "everything else running" catch-all the board must
+    surface honestly. Returns `[]` if the overlay is absent (no tmux server / any failure).
 
     Reuses the scan's machinery verbatim: `collect_tmux_panes` reads THIS host's panes,
-    `match_tmux_to_initiatives` links each pane's title to an initiative in its repo. The
-    viewer must run ON the host whose tmux we want to see (that's where its systemd unit
-    lives). Fully best-effort — no tmux server, no scan import, any error → overlay simply
-    absent, never fatal."""
+    `match_tmux_to_initiatives` links each pane's title to an initiative in its repo AND
+    returns the unmatched claude panes (live work the ledger doesn't cover — a new thread
+    or a handoff not yet written). The viewer must run ON the host whose tmux we want to
+    see (that's where its systemd unit lives). Fully best-effort — no tmux server, no scan
+    import, any error → overlay absent + empty unmatched, never fatal."""
     try:
         scan = _scan()
         panes = scan.collect_tmux_panes()
         if not panes:
-            return False  # no tmux server on this host → overlay absent (not an error)
+            return []  # no tmux server on this host → overlay absent (not an error)
         repos = scan.discover_repos()
         wt_map = scan.worktree_canonical_map(repos)
         codenames = scan.load_scratch_codenames()
-        scan.match_tmux_to_initiatives(initiatives, panes, repos, wt_map, codenames)
-        return True
+        return scan.match_tmux_to_initiatives(initiatives, panes, repos, wt_map, codenames)
     except Exception:  # noqa: BLE001 - the overlay is a nicety, never a hard dependency
-        return False
+        return []
 
 
 # --------------------------------------------------------------------------- #
@@ -411,7 +413,12 @@ def _initiative_view(ini: dict, now: datetime) -> dict:
         # `recent_messages` above stays complete for the expand.
         "face_message": pick_face_message(recent_messages),
         "recent_commits": [str(x) for x in (ini.get("recent_commits") or [])],
+        # `live_task` = the first matched pane's task (kept for the detail endpoint +
+        # back-compat); `live_tasks` = ALL matched panes' tasks so an initiative hosting
+        # MORE than one live session shows every session's task (one line each), not just
+        # the first. Both derive from the same de-duped `tmux_tasks` overlay.
         "live_task": tmux_tasks[0] if tmux_tasks else "",
+        "live_tasks": tmux_tasks,
     }
 
 
@@ -422,14 +429,74 @@ def _flat_sort_key(v: dict):
     return (-ts, v["momentum_rank"], v["slug"])
 
 
-def build_model(rows: list[dict], now: datetime | None = None) -> dict:
+def _session_natural_key(sess_id: str) -> tuple:
+    """Order `<session>-<window>` ids naturally: '1','8-1','8-3','Pool2','Pool10'.
+
+    Mirrors the scan's `_tmux_session_sort_key` (peel a trailing `-<window>`, then split
+    the session into a non-digit prefix + numeric suffix so a numeric tail sorts by VALUE
+    and the window index tiebreaks). Kept LOCAL so `build_model` stays pure — no scan
+    import in the render transform (it is unit-tested with no scan / requests / psycopg2)."""
+    name = sess_id or ""
+    win = -1
+    session = name
+    mw = re.match(r"^(.*)-(\d+)$", name)
+    if mw:
+        session, win = mw.group(1), int(mw.group(2))
+    m = re.match(r"^(.*?)(\d*)$", session)
+    prefix = m.group(1) if m else session
+    num = int(m.group(2)) if (m and m.group(2)) else -1
+    return (prefix, num, win, name)
+
+
+def _unmatched_view(u: dict) -> dict:
+    """One unmatched live claude pane (`{"id","title","repo"}` from
+    `match_tmux_to_initiatives`) -> a flat, template-ready view dict. `repo` is the full
+    path (as the scan returns it, possibly None); `repo_name` is the short label used for
+    the grouped section header (matches the initiative cards' repo label)."""
+    repo = u.get("repo")
+    return {
+        "id": str(u.get("id") or "?"),
+        "title": (str(u.get("title") or "")).strip(),
+        "repo": repo or "",
+        "repo_name": _short_repo(repo),
+    }
+
+
+def build_live_unmatched(unmatched) -> list[dict]:
+    """PURE: the `match_tmux_to_initiatives` unmatched list -> the render model's
+    `live_unmatched`: de-duped (by id+title, like the CLI section) view dicts, sorted by
+    repo then natural session id so the page can group them by repo. A non-list input
+    (e.g. a fake tmux hook returning a bool, or None) yields `[]` — the section then
+    simply doesn't render."""
+    if not isinstance(unmatched, list):
+        return []
+    seen: set = set()
+    out: list[dict] = []
+    for u in unmatched:
+        if not isinstance(u, dict):
+            continue
+        v = _unmatched_view(u)
+        dedupe_key = (v["id"], v["title"])
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        out.append(v)
+    out.sort(key=lambda v: (v["repo_name"].lower(), _session_natural_key(v["id"])))
+    return out
+
+
+def build_model(rows: list[dict], now: datetime | None = None,
+                unmatched=None) -> dict:
     """PURE: store rows (+ any attached tmux) -> BOTH a grouped and a flat render model.
 
     `repos` groups initiatives by repo (within a repo: momentum then recency; repos
     ordered by their most-active initiative then name). `flat` is one stream of ALL
     initiatives ordered most-recently-active first (the default view; each card carries
-    a repo label). `captured_at` (the snapshot's freshness) drives the footer. An empty
-    row list yields an empty (but well-formed) model — never raises."""
+    a repo label). `live_unmatched` is the "everything else running" catch-all: live
+    claude panes that matched NO initiative (from `attach_tmux`), so the board shows ALL
+    running threads (the tagged initiatives + the uncovered sessions), not just the tagged
+    few. `captured_at` (the snapshot's freshness) drives the footer. An empty row list
+    yields an empty (but well-formed) model — never raises."""
     now = now or datetime.now(timezone.utc)
 
     # The snapshot freshness = the newest captured_at across the rows (they should all
@@ -459,6 +526,7 @@ def build_model(rows: list[dict], now: datetime | None = None) -> dict:
     repos.sort(key=lambda g: (g["best_rank"], g["name"]))
 
     flat = sorted(views, key=_flat_sort_key)
+    live_unmatched = build_live_unmatched(unmatched)
 
     return {
         "generated_at": now,
@@ -468,13 +536,15 @@ def build_model(rows: list[dict], now: datetime | None = None) -> dict:
         "repo_count": len(repos),
         "repos": repos,
         "flat": flat,
+        "live_unmatched": live_unmatched,
     }
 
 
 def model_to_json(model: dict | None, error: str | None) -> dict:
     """The `/api/initiatives.json` payload (datetimes isoformatted via json default=str)."""
     if error is not None or model is None:
-        return {"ok": False, "error": error or "no data", "repos": [], "flat": []}
+        return {"ok": False, "error": error or "no data", "repos": [], "flat": [],
+                "live_unmatched": []}
     return {
         "ok": True,
         "generated_at": model["generated_at"],
@@ -484,6 +554,7 @@ def model_to_json(model: dict | None, error: str | None) -> dict:
         "repo_count": model["repo_count"],
         "repos": model["repos"],
         "flat": model["flat"],
+        "live_unmatched": model.get("live_unmatched", []),
     }
 
 
@@ -608,6 +679,7 @@ def build_detail(model: dict | None, error: str | None, repo: str, slug: str,
         "recent_messages": view.get("recent_messages") or [],
         "recent_commits": view.get("recent_commits") or [],
         "live_task": view.get("live_task") or "",
+        "live_tasks": view.get("live_tasks") or [],
         "live": False,
     }
 
@@ -711,6 +783,24 @@ header .meta{color:var(--gray);font-size:.85rem}
 .detail-doc{color:var(--gray);font-size:.78rem;margin-top:.35rem;word-break:break-all}
 .detail-err{color:var(--red);font-size:.82rem}
 .empty{color:var(--gray);padding:2rem 0}
+/* "Live sessions — not tied to an initiative": the everything-else-running catch-all.
+   Visually SECONDARY to the initiatives (dimmer, denser) but scannable at 30+ rows. */
+.unmatched{margin:1.6rem 0 0;border-top:1px solid var(--bg2);padding-top:.8rem}
+.unmatched > h2{font-size:.9rem;margin:0;color:var(--fg2);cursor:pointer;
+  display:flex;align-items:baseline;gap:.4rem;user-select:none}
+.unmatched > h2:hover{color:var(--fg)}
+.unmatched > h2 .chev{color:var(--gray);font-size:.75rem;width:.8rem}
+.unmatched > h2 .count{color:var(--gray);font-weight:normal;font-size:.8rem}
+.unmatched > h2 .hint{color:var(--gray);font-weight:normal;font-size:.75rem;margin-left:.2rem}
+.unmatched-body{margin-top:.6rem}
+.u-repo{margin:0 0 .5rem}
+.u-repo > h3{font-size:.8rem;margin:0 0 .2rem;color:var(--aqua);font-weight:normal}
+.u-repo > h3 .count{color:var(--gray);margin-left:.35rem}
+.u-row{display:flex;align-items:baseline;gap:.5rem;padding:.05rem 0 .05rem .6rem;
+  font-size:.82rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.u-id{color:var(--green);flex:0 0 auto}
+.u-title{color:var(--fg2);overflow:hidden;text-overflow:ellipsis}
+.u-title.untitled{color:var(--gray);font-style:italic}
 .err{background:#442222;border:1px solid var(--red);color:var(--fg);
   padding:1rem;border-radius:4px}
 .err b{color:var(--red)}
@@ -729,11 +819,15 @@ _JS = r"""
   var el0 = document.getElementById('idata');
   var data;
   try { data = JSON.parse(el0.textContent); }
-  catch(e){ data = {ok:false, error:'bad payload', repos:[], flat:[]}; }
+  catch(e){ data = {ok:false, error:'bad payload', repos:[], flat:[], live_unmatched:[]}; }
 
   var VIEW_KEY = 'initiatives-view';
+  var UNMATCHED_KEY = 'initiatives-unmatched-collapsed';
   var state = { view: (localStorage.getItem(VIEW_KEY) === 'grouped') ? 'grouped' : 'flat',
                 q: '' };
+  // The catch-all "live sessions" section is collapsible; remember the user's choice.
+  // Default EXPANDED (the whole point is to see every running thread) — set to '1' to collapse.
+  var unmatchedCollapsed = localStorage.getItem(UNMATCHED_KEY) === '1';
   var expanded = {};     // key -> true
   var detailCache = {};  // key -> detail payload
 
@@ -773,9 +867,11 @@ _JS = r"""
       return;
     }
     if(d.summary) det.appendChild(el('div', 'detail-summary', d.summary));
-    if(d.live_task){
-      det.appendChild(el('div', 'detail-h', 'Live session'));
-      det.appendChild(el('div', 'detail-summary', d.live_task));
+    var dtasks = (d.live_tasks && d.live_tasks.length) ? d.live_tasks
+                 : (d.live_task ? [d.live_task] : []);
+    if(dtasks.length){
+      det.appendChild(el('div', 'detail-h', dtasks.length > 1 ? 'Live sessions' : 'Live session'));
+      dtasks.forEach(function(t){ det.appendChild(el('div', 'detail-summary', t)); });
     }
     var rmsgs = d.recent_messages || (v && v.recent_messages) || [];
     if(rmsgs.length){
@@ -873,13 +969,17 @@ _JS = r"""
       c.appendChild(m);
     }
 
-    // A live tmux session's task summary (render-time overlay), when one is open.
-    if(v.live_task){
+    // Live tmux session task summaries (render-time overlay). When an initiative hosts
+    // MORE than one live session, show EVERY session's task (one line each), not just the
+    // first — `live_tasks` is the full de-duped list (`live_task` is only its first item).
+    var ltasks = (v.live_tasks && v.live_tasks.length) ? v.live_tasks
+                 : (v.live_task ? [v.live_task] : []);
+    ltasks.forEach(function(task){
       var lt = el('div', 'live-task');
       lt.appendChild(el('span', 'lbl', 'live ›'));
-      lt.appendChild(document.createTextNode(' ' + v.live_task));
+      lt.appendChild(document.createTextNode(' ' + task));
       c.appendChild(lt);
-    }
+    });
 
     var tags = el('div', 'tags');
     (v.tmux_sessions || []).forEach(function(s){
@@ -925,11 +1025,69 @@ _JS = r"""
     return c;
   }
 
+  function matchUnmatched(u, q){
+    if(!q) return true;
+    var hay = ((u.id||'') + ' ' + (u.title||'') + ' ' + (u.repo_name||'')).toLowerCase();
+    return hay.indexOf(q) !== -1;
+  }
+
+  // The "everything else running" catch-all: live claude sessions that map to NO
+  // initiative. Grouped by repo, collapsible, visually secondary. Rendered BELOW the
+  // initiatives so the board honestly shows ALL running threads. Empty list → no section.
+  function renderUnmatched(q){
+    var rows = (data.live_unmatched || []).filter(function(u){ return matchUnmatched(u, q); });
+    if(!rows.length) return;  // nothing uncovered (or all filtered out) → no section
+
+    var sec = el('section', 'unmatched');
+    var h = el('h2');
+    h.appendChild(el('span', 'chev', unmatchedCollapsed ? '▸' : '▾'));
+    h.appendChild(document.createTextNode('Live sessions — not tied to an initiative'));
+    h.appendChild(el('span', 'count', '(' + rows.length + ')'));
+    h.appendChild(el('span', 'hint', 'open work the ledger doesn’t cover'));
+    sec.appendChild(h);
+
+    var body = el('div', 'unmatched-body');
+    body.style.display = unmatchedCollapsed ? 'none' : 'block';
+    // rows arrive pre-sorted by (repo, session) so same-repo runs are contiguous → group.
+    var curRepo = null, group = null;
+    rows.forEach(function(u){
+      var name = u.repo_name || '(unknown repo)';
+      if(name !== curRepo){
+        curRepo = name;
+        group = el('div', 'u-repo');
+        var rh = el('h3', null, name);
+        group.appendChild(rh);
+        body.appendChild(group);
+      }
+      var row = el('div', 'u-row');
+      row.appendChild(el('span', 'u-id', '[' + (u.id || '?') + ']'));
+      var title = (u.title || '').trim();
+      row.appendChild(el('span', 'u-title' + (title ? '' : ' untitled'),
+                         title || '(untitled)'));
+      group.appendChild(row);
+    });
+    sec.appendChild(body);
+
+    h.addEventListener('click', function(){
+      unmatchedCollapsed = !unmatchedCollapsed;
+      localStorage.setItem(UNMATCHED_KEY, unmatchedCollapsed ? '1' : '0');
+      body.style.display = unmatchedCollapsed ? 'none' : 'block';
+      sec.querySelector('.chev').textContent = unmatchedCollapsed ? '▸' : '▾';
+    });
+    app.appendChild(sec);
+  }
+
   function updateChrome(){
     btnFlat.classList.toggle('active', state.view === 'flat');
     btnGrouped.classList.toggle('active', state.view === 'grouped');
-    if(countEl) countEl.textContent =
-      (data.total || 0) + ' in flight across ' + (data.repo_count || 0) + ' repos';
+    if(countEl){
+      var txt = (data.total || 0) + ' in flight across ' + (data.repo_count || 0) + ' repos';
+      var nu = (data.live_unmatched || []).length;
+      // Surface the uncovered live sessions in the header so the board's honesty is visible
+      // at a glance (tagged initiatives + N untracked live threads).
+      if(nu) txt += ' · ' + nu + ' live session' + (nu === 1 ? '' : 's') + ' untracked';
+      countEl.textContent = txt;
+    }
     footer.innerHTML = '';
     footer.appendChild(el('span', 'live', 'live sessions ● realtime'));
     var age = data.captured_age ? (data.captured_age + ' ago') : 'unknown';
@@ -969,6 +1127,9 @@ _JS = r"""
         q ? ('No initiatives match "' + state.q + '".')
           : 'No initiatives in the latest snapshot.'));
     }
+    // The catch-all live-sessions section renders BELOW the initiatives (honestly showing
+    // every running thread, not just the tagged few). Respects the same search filter.
+    renderUnmatched(q);
     updateChrome();
   }
 
@@ -1210,8 +1371,11 @@ class DataProvider:
                 return self._cached
             try:
                 rows = self._loader()
-                self._tmux(rows)  # best-effort; mutates rows in place
-                result: tuple[dict | None, str | None] = (build_model(rows, self._now()), None)
+                # best-effort; mutates rows in place AND returns the live claude panes that
+                # matched no initiative (build_model coerces a non-list to [] → no section).
+                unmatched = self._tmux(rows)
+                result: tuple[dict | None, str | None] = (
+                    build_model(rows, self._now(), unmatched=unmatched), None)
             except Exception as exc:  # noqa: BLE001 - any read failure → graceful error page
                 result = (None, f"{type(exc).__name__}: {exc}")
             self._cached = result


### PR DESCRIPTION
## Problem
The web viewer (`scripts/initiatives/viewer.py`, live at http://192.168.50.250:8899) computes a render-time live-tmux overlay via the scan's `match_tmux_to_initiatives`, which **returns an `unmatched` list** of live claude panes that map to no initiative. The viewer **discarded that list** — so the board showed ~7 live tags while ~44 claude sessions were actually running. The `/initiatives` CLI already renders this section; the viewer now does too.

## Changes
- **Capture the unmatched list.** `attach_tmux` now RETURNS the `unmatched` panes (was `bool`); `DataProvider.snapshot` threads it into `build_model`, which builds `live_unmatched` (de-duped by id+title, sorted by repo then a scan-consistent natural session key — capitalized codenames before `main:`, numeric windows by value). No tmux server / scan-import failure → `[]` → no section (best-effort preserved).
- **API:** top-level `live_unmatched: [{id, title, repo, repo_name}]` in `/api/initiatives.json` (and the error branch carries `[]` so the JS never sees `undefined`).
- **Page:** a collapsible **"Live sessions — not tied to an initiative"** section below the initiatives, grouped by repo, each row `[session-id] task-title`. Visually secondary (dimmer/denser), scannable at 30+ rows, collapse state persisted in localStorage. Header count gains `· N live sessions untracked`. Untrusted text via the JSON island + `textContent`, matching the gruvbox style.
- **Cosmetic fix (item 4):** an initiative matched by MORE than one live pane now shows EVERY session's task (`live_tasks`, one `live ›` line each) on the card + detail expand, not just the first. `live_task` (first) kept for back-compat.

## Tests
Extends the hermetic viewer suite — **92 pass**. New coverage: `build_live_unmatched` shape/dedup/sort/None-repo/non-list-coercion; `build_model` + `model_to_json` carry `live_unmatched` (ok + error); `render_html` renders the section + escapes an untrusted title, empty → no section; `attach_tmux` returns the scan's unmatched list; `DataProvider` threads it through; the multi-pane `live_tasks` cosmetic (card + detail). `scripts/run-tests.sh` green.

No schema/store change — this is render-time tmux only.

## Verification
Author has NOT deployed/live-verified. The human deploys (`home-manager switch` on the workbench) and confirms the board shows ~44 live threads (7 tagged + the rest in the new section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)