### PR TITLE
feat(initiative-scan): date-only-slug fingerprint fallback (matcher recall +1, precision held)

### DIFF
--- a/scripts/initiatives/route.py
+++ b/scripts/initiatives/route.py
@@ -151,6 +151,7 @@ def rank_matches(signal_text: str, initiatives: list[dict],
     scan = _scan()
     text_tokens = scan.text_tokens
     slug_tokens = scan.slug_tokens
+    fingerprint = scan.initiative_fingerprint
 
     signal_toks = set(text_tokens(signal_text or ""))
 
@@ -171,7 +172,10 @@ def rank_matches(signal_text: str, initiatives: list[dict],
 
     results: list[dict] = []
     for ini in candidates:
-        slug_t = set(slug_tokens(ini.get("slug", "") or ""))
+        # Fingerprint = slug tokens, or TITLE tokens for a date-only/degenerate slug
+        # (initiative_fingerprint) — so a bare-date initiative in the store isn't
+        # structurally unroutable. Strictly additive; a real slug is unchanged.
+        slug_t = set(fingerprint(ini))
         title_t = set(text_tokens(ini.get("title") or ""))
         slug_hits = signal_toks & slug_t
         title_hits = signal_toks & (title_t - slug_t)
@@ -194,12 +198,15 @@ def rank_matches(signal_text: str, initiatives: list[dict],
             "confident": confident,
         })
 
-    # Rank: confident first, then the same tie-breaks best_title_match uses
+    # Rank: confident first, then the same tie-breaks best_title_match uses — a
+    # real-SLUG fingerprint outranks a date-only TITLE fallback, then
     # (slug_overlap, title_overlap, slug length, slug lexical) — so the top confident
     # row is exactly what best_title_match would have returned for this signal.
+    def _real_slug(slug: str | None) -> int:
+        return 1 if slug_tokens(slug or "") else 0
     results.sort(
-        key=lambda r: (r["confident"], r["slug_overlap"], r["title_overlap"],
-                       len(r["slug"] or ""), r["slug"] or ""),
+        key=lambda r: (r["confident"], _real_slug(r["slug"]), r["slug_overlap"],
+                       r["title_overlap"], len(r["slug"] or ""), r["slug"] or ""),
         reverse=True,
     )
     if limit is not None and limit >= 0:

--- a/scripts/initiatives/tests/test_route.py
+++ b/scripts/initiatives/tests/test_route.py
@@ -199,3 +199,24 @@ def test_empty_store_returns_empty_and_new_work():
 def test_empty_signal_matches_nothing():
     ranked = route.rank_matches("", [CLAWGATE, TEKTON])
     assert ranked == []
+
+
+# --------------------------------------------------------------------------- #
+# Date-only-slug fingerprint fallback (mirrors the scan's recall Fix #1)
+# --------------------------------------------------------------------------- #
+def test_date_only_slug_routes_via_title_fingerprint():
+    # A bare-date slug has no slug tokens; the router falls back to TITLE tokens so a
+    # signal can still route to it on a unique title token (df==1).
+    date_ini = _ini("2026-07-21", "ComfyUI NSFW realism pipeline")
+    ranked = route.rank_matches("run comfyui preference loop", [date_ini, SYSREDIS])
+    assert ranked and ranked[0]["slug"] == "2026-07-21"
+    assert ranked[0]["confident"] is True
+
+
+def test_real_slug_outranks_date_only_title_fallback():
+    # Precision guard mirrored from best_title_match: a real-SLUG match ranks ABOVE a
+    # date-only TITLE-fallback match for a contested signal.
+    date_ini = _ini("2026-07-21", "ComfyUI pipeline realism")
+    real = _ini("comfyui-pipeline", "comfyui pipeline")
+    ranked = route.rank_matches("comfyui pipeline run", [date_ini, real])
+    assert ranked[0]["slug"] == "comfyui-pipeline"

--- a/scripts/session-analysis/initiative-scan.py
+++ b/scripts/session-analysis/initiative-scan.py
@@ -389,6 +389,29 @@ def text_tokens(s: str) -> list[str]:
     return toks
 
 
+def initiative_fingerprint(ini: dict) -> list[str]:
+    """The token fingerprint used to attach FREE TEXT (a tmux pane title / router
+    signal) to an initiative: its SLUG tokens, or — when the slug is date-only /
+    degenerate and yields NO slug tokens — the handoff TITLE tokens as a fallback.
+
+    Why: a bare-date slug (e.g. `handoff-2026-07-21.md` → slug `2026-07-21`) has ZERO
+    `slug_tokens` (dates are dropped), so it can never match its own live panes on the
+    slug fingerprint — it is structurally invisible to `best_title_match`. Falling back
+    to TITLE tokens gives such an initiative *some* fingerprint.
+
+    Precision: STRICTLY ADDITIVE — it only grants matching ability to initiatives that
+    currently match NOTHING (a non-empty slug is returned unchanged, so every existing
+    match is byte-identical). The caller's df/uniqueness gate still applies to the
+    fallback tokens, so a date-only initiative can only claim a pane on a token NO
+    eligible sibling shares; and `best_title_match` ranks a real-slug fingerprint ABOVE
+    a title fallback, so a fallback can never steal a pane from a real-slug match.
+    """
+    toks = slug_tokens(ini.get("slug", ""))
+    if toks:
+        return toks
+    return text_tokens(ini.get("title") or "")
+
+
 def resolve_cwd_repo(cwd: str | None, repos: list[str],
                      wt_map: dict[str, str] | None = None) -> str | None:
     """Map a working directory to its CANONICAL repo, or None.
@@ -1487,20 +1510,33 @@ def pane_id(pane: dict, codenames: dict[str, str] | None = None) -> str:
 def best_title_match(pane_toks: set[str], initiatives: list[dict]) -> dict | None:
     """Pick the initiative whose slug/title best overlaps a pane title's tokens.
 
-    Scored as (# slug-token overlaps, # extra title-token overlaps). Slug tokens are
-    the initiative fingerprint (clawgate, sysredis, wedge, tekton, bitdex); the pane
-    title is first stripped of generic action verbs (`TITLE_STOP` in `text_tokens`),
-    so a pane can't be linked on "resume"/"review"/"monitor" alone. A candidate
-    qualifies with ≥2 slug-token overlaps, OR ≥1 slug-token overlap on a token UNIQUE
-    to that initiative among the eligible set, OR ≥2 title-token overlaps. The
-    uniqueness gate is what stops a pane linking on ONE token SHARED across siblings
-    (e.g. "grafana" in both grafana-alert-drift and alert-chaos-grafana-sqlite) while
-    still allowing a single distinctive token (faro, tekton) to match. Best by
-    (slug_overlap, title_overlap), then longer slug, then lexically, for determinism.
+    Scored as (# fingerprint overlaps, # extra title-token overlaps). The fingerprint
+    is the initiative's SLUG tokens (clawgate, sysredis, wedge, tekton, bitdex) — or,
+    for a date-only/degenerate slug with NO slug tokens, its TITLE tokens
+    (`initiative_fingerprint`, so a bare-date initiative like `2026-07-21` isn't
+    structurally unmatchable). The pane title is first stripped of generic action verbs
+    (`TITLE_STOP` in `text_tokens`), so a pane can't be linked on "resume"/"review"/
+    "monitor" alone. A candidate qualifies with ≥2 fingerprint overlaps, OR ≥1
+    fingerprint overlap on a token UNIQUE to that initiative among the eligible set, OR
+    ≥2 title-token overlaps. The uniqueness gate is what stops a pane linking on ONE
+    token SHARED across siblings (e.g. "grafana" in both grafana-alert-drift and
+    alert-chaos-grafana-sqlite) while still allowing a single distinctive token (faro,
+    tekton) to match.
+
+    Ranked by (real-slug-fingerprint?, fingerprint_overlap, title_overlap, longer slug,
+    lexical). The leading real-slug flag guarantees a real SLUG match always outranks a
+    date-only TITLE-fallback match, so the fallback can only fill a gap — never steal a
+    pane a real-slug initiative would have won. Among real-slug initiatives the flag is
+    constant, so their ordering is byte-identical to before.
 
     LIMITATION: a genuinely multi-topic pane title is attributed to its single
     strongest match and may miss a co-hosted sibling; bag-of-words can't disambiguate.
-    Heuristic — read it as "which session is likely on this", not a proof.
+    A pane whose ONLY overlap is a token SHARED across a sibling family (df>1) is
+    deliberately left UNMATCHED by the uniqueness gate — attaching it to one sibling by
+    recency was evaluated and REJECTED: on live data it is structurally indistinguishable
+    from a false match on a generic client/domain token (see the handoff), and a wrong
+    tag costs more than a miss. Heuristic — read it as "which session is likely on this",
+    not a proof.
     """
     # Document frequency of each token across the eligible set, so a single-token
     # match can require that token to be UNIQUE (df == 1) to this initiative.
@@ -1511,17 +1547,18 @@ def best_title_match(pane_toks: set[str], initiatives: list[dict]) -> dict | Non
             df[t] = df.get(t, 0) + 1
 
     best: dict | None = None
-    best_key: tuple = (0, 0, 0, "")
+    best_key: tuple = (0, 0, 0, 0, "")
     for ini in initiatives:
-        slug_t = set(slug_tokens(ini.get("slug", "")))
+        fp_t = set(initiative_fingerprint(ini))
         title_t = set(text_tokens(ini.get("title") or ""))
-        slug_hits = pane_toks & slug_t
-        slug_overlap = len(slug_hits)
-        title_overlap = len(pane_toks & (title_t - slug_t))
-        unique_single = slug_overlap == 1 and df.get(next(iter(slug_hits)), 1) == 1
-        if not (slug_overlap >= 2 or unique_single or title_overlap >= 2):
+        fp_hits = pane_toks & fp_t
+        fp_overlap = len(fp_hits)
+        title_overlap = len(pane_toks & (title_t - fp_t))
+        unique_single = fp_overlap == 1 and df.get(next(iter(fp_hits)), 1) == 1
+        if not (fp_overlap >= 2 or unique_single or title_overlap >= 2):
             continue
-        key = (slug_overlap, title_overlap,
+        is_real_slug = 1 if slug_tokens(ini.get("slug", "")) else 0
+        key = (is_real_slug, fp_overlap, title_overlap,
                len(ini.get("slug", "")), ini.get("slug", ""))
         if key > best_key:
             best_key = key

--- a/scripts/session-analysis/tests/test_initiative_scan.py
+++ b/scripts/session-analysis/tests/test_initiative_scan.py
@@ -859,8 +859,114 @@ def test_best_title_match_distinctive_token_beats_generic(monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
+# initiative_fingerprint — slug tokens, or title tokens for a date-only slug
+# --------------------------------------------------------------------------- #
+def test_initiative_fingerprint_uses_slug_tokens_for_a_real_slug():
+    # A normal slug is unchanged — the fingerprint IS its slug tokens (byte-identical
+    # to slug_tokens), so every existing match keeps its exact behaviour.
+    ini = {"slug": "clawgate-agent-loop", "title": "Something else entirely"}
+    assert isc.initiative_fingerprint(ini) == isc.slug_tokens("clawgate-agent-loop")
+    assert isc.initiative_fingerprint(ini) == ["clawgate", "agent", "loop"]
+
+
+def test_initiative_fingerprint_falls_back_to_title_for_date_only_slug():
+    # A bare-date slug yields ZERO slug tokens -> fall back to the TITLE tokens so the
+    # initiative isn't structurally unmatchable (the ComfyUI handoff-2026-07-21 case).
+    ini = {"slug": "2026-07-21",
+           "title": "Session Handoff — ComfyUI NSFW realism pipeline"}
+    assert isc.slug_tokens("2026-07-21") == []  # premise: date-only -> no slug tokens
+    assert isc.initiative_fingerprint(ini) == isc.text_tokens(ini["title"])
+    assert "comfyui" in isc.initiative_fingerprint(ini)
+
+
+# --------------------------------------------------------------------------- #
+# best_title_match — date-only-slug fingerprint fallback (recall Fix #1)
+# --------------------------------------------------------------------------- #
+def test_best_title_match_date_only_slug_links_on_unique_title_token():
+    # The live ComfyUI case: a date-only slug ('2026-07-21') matches its own pane via a
+    # TITLE token ('comfyui') that is UNIQUE among the eligible set (df==1).
+    inis = [
+        {"slug": "2026-07-21",
+         "title": "Session Handoff — ComfyUI NSFW realism pipeline"},
+        {"slug": "sysredis-buffer", "title": "sysRedis buffer soft-dependency"},
+    ]
+    toks = set(isc.text_tokens("Run ComfyUI preference optimization loop end-to-end"))
+    assert isc.best_title_match(toks, inis)["slug"] == "2026-07-21"
+
+
+def test_best_title_match_date_only_slug_ignores_unrelated_pane():
+    # A date-only slug must NOT grab a pane it has no topical overlap with — the
+    # fallback only ADDS matches on real title-token overlap, never blanket-claims.
+    inis = [
+        {"slug": "2026-07-21",
+         "title": "Session Handoff — ComfyUI NSFW realism pipeline"},
+    ]
+    toks = set(isc.text_tokens("Fix hands in walk/portrait output with detailer"))
+    assert isc.best_title_match(toks, inis) is None
+
+
+def test_best_title_match_date_only_slug_shared_title_token_does_not_link():
+    # The df/uniqueness gate STILL guards the title fallback: when the only overlapping
+    # title token is SHARED (df>1), the date-only slug does NOT link on it (precision).
+    inis = [
+        {"slug": "2026-07-21", "title": "ComfyUI pipeline realism"},
+        {"slug": "comfyui-runner", "title": "comfyui runner"},
+    ]
+    toks = set(isc.text_tokens("ComfyUI status"))  # only the SHARED 'comfyui' overlaps
+    assert isc.best_title_match(toks, inis) is None
+
+
+def test_best_title_match_real_slug_outranks_date_only_title_fallback():
+    # PRECISION GUARD: when a real-SLUG initiative and a date-only TITLE-fallback
+    # initiative both match a contested pane, the real slug wins — a fallback fingerprint
+    # can never STEAL a pane a real-slug initiative would have claimed.
+    inis = [
+        {"slug": "2026-07-21", "title": "ComfyUI pipeline realism"},   # date-only
+        {"slug": "comfyui-pipeline", "title": "comfyui pipeline"},     # real slug
+    ]
+    toks = set(isc.text_tokens("comfyui pipeline run"))
+    assert isc.best_title_match(toks, inis)["slug"] == "comfyui-pipeline"
+
+
+def test_best_title_match_sibling_shared_prefix_token_stays_unmatched():
+    # DELIBERATE precision decision (recall Fix #2 DEFERRED): a pane whose ONLY overlap
+    # is a token SHARED across a sibling family (df>1) stays UNMATCHED. Attaching it to
+    # the most-recently-touched sibling by recency was evaluated and rejected — on live
+    # data that rule is structurally indistinguishable from a false match on a generic
+    # client/domain token, and a wrong tag costs more than a miss.
+    inis = [
+        {"slug": "remix-session", "title": "Remix — session handoff"},
+        {"slug": "remix-hardening-session", "title": "Remix — hardening"},
+        {"slug": "remix-platform", "title": "Remix platform"},
+        {"slug": "remix-templates", "title": "Remix render templates"},
+    ]
+    toks = set(isc.text_tokens("Resume remix 0.18 work and verify live feed"))
+    assert isc.best_title_match(toks, inis) is None
+
+
+# --------------------------------------------------------------------------- #
 # match_tmux_to_initiatives — attach live sessions, scoped by repo
 # --------------------------------------------------------------------------- #
+def test_match_tmux_date_only_slug_initiative_attaches_its_pane():
+    # End-to-end: a date-only-slug initiative (ComfyUI handoff-2026-07-21) in its own
+    # repo attaches its live pane via the title-token fingerprint fallback, and a
+    # topically-unrelated pane in the same repo stays unmatched.
+    comfy = "/home/u/workspace/fast/comfyui"
+    inis = [{"slug": "2026-07-21",
+             "title": "Session Handoff — ComfyUI NSFW realism pipeline",
+             "repo": comfy}]
+    panes = [
+        {"session": "scratch6", "window": "4", "cwd": comfy, "command": "claude",
+         "title": "Run ComfyUI preference optimization loop end-to-end"},
+        {"session": "scratch6", "window": "5", "cwd": comfy, "command": "claude",
+         "title": "Fix hands in walk/portrait output with detailer and LoRA"},
+    ]
+    unmatched = isc.match_tmux_to_initiatives(inis, panes, [comfy],
+                                              codenames={"scratch6": "Pool"})
+    assert inis[0]["tmux_sessions"] == {"Pool-4"}
+    assert [u["id"] for u in unmatched] == ["Pool-5"]  # the hands pane has no overlap
+
+
 def test_match_tmux_attaches_session_scoped_by_repo():
     devrc, civit = "/home/u/workspace/devrc", "/home/u/workspace/civit/dp"
     inis = [


### PR DESCRIPTION
## What

Improves recall of the initiative↔tmux/session token matcher **without sacrificing precision** (the shared matcher that also backs `route.py` and session/message attribution).

### Fix #1 — date-only-slug title fingerprint (IMPLEMENTED)
An initiative whose slug is a bare date (`handoff-2026-07-21.md` → slug `2026-07-21`, the ComfyUI pipeline) has **zero** `slug_tokens` (dates are dropped) → it is structurally invisible to `best_title_match` and can never tag its own live panes.

`initiative_fingerprint()` returns slug tokens, or the handoff **TITLE tokens** as a fallback **only** when the slug is date-only/degenerate.

**Why it's precision-safe**
- Strictly additive — a non-empty slug is returned unchanged, so every existing match is byte-identical.
- The df/uniqueness gate still applies to the fallback tokens → a date-only initiative can only claim a pane on a token **no eligible sibling shares**.
- `best_title_match`'s rank key gains a leading **real-slug flag**, so a real SLUG match always outranks a date-only TITLE fallback → a fallback fingerprint can never **steal** a pane a real-slug initiative would have won.

## Live verification (telemetry off, `--tmux`, real tmux)
- ✅ `2026-07-21` now tags `Pool-4` "Run ComfyUI preference optimization loop".
- ✅ Unrelated `Pool-5` "Fix hands in walk/portrait…" stays **unmatched** (no topical overlap → no false claim).
- ✅ All **15** pre-existing tmux tags **unchanged** (diff shows only a cosmetic live-spinner glyph in one pane title between captures).
- ✅ **No new false match.**

## Deferred on precision grounds (honest outcome)
**Fix #2 — sibling-dilution (`remix-session`): DEFERRED.** A recency-based "attach the shared-token pane to the most-recently-touched sibling" rule was **implemented and then reverted** because it produced a live **false match**: "Review Civitai dispatch audit PRs" → `civitai-cli-arc-v0.1.79` on the generic client token `civitai`. That false match is **structurally indistinguishable** from the true `remix` match — same df-prefix family, same single session-active member, same recency margin. The only separator (distinctive *project* token vs generic *client/domain* token) is semantic; rejecting it requires a keyword stoplist (against RULES). A wrong tag violates the precision bar, so `remix-session`'s pane stays unmatched (an accepted miss). Encoded as a regression test.

**Fix #3 — cross-repo mis-filing: DEFERRED.** `civitai-cli-arc-*` handoffs live under `datapacket-talos` but the work runs in `civitai-manager`; bridging that would weaken repo-scoping (a precision guard). Data-modeling issue — the initiative should declare its true work-repo.

## Router / attribution impact
`route.py`'s `rank_matches` reuses the same fingerprint + real-slug tiebreak (single-sourced, so the router can't drift from the scan). Its **confidence gate is deliberately not relaxed** for shared-token siblings (avoids feeding a wrong auto-dispatch). Session/message attribution is untouched.

## Tests
- +8 scan tests, +2 router tests (163 pass in the two suites).
- **Full `scripts/run-tests.sh --set hermetic` → RESULT: PASS.**

Do **not** auto-merge/deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)