### PR TITLE
feat(initiatives-viewer): add a "By recency" view mode (3-way toggle)

### DIFF
--- a/scripts/initiatives/tests/test_viewer.py
+++ b/scripts/initiatives/tests/test_viewer.py
@@ -1043,3 +1043,159 @@ def test_provider_passes_unmatched_through_to_model():
     assert model["live_unmatched"] == [
         {"id": "Vapor-9", "title": "a live uncovered thread",
          "repo": "/home/zach/workspace/devrc", "repo_name": "devrc"}]
+
+
+# --------------------------------------------------------------------------- #
+# "By recency" view — the 3rd toggle mode. Bucketing is CLIENT-SIDE JS (the buckets are in
+# the viewer's BROWSER-LOCAL timezone, only known client-side), factored into the DOM-free
+# `viewer._RECENCY_JS` snippet so these tests exercise the REAL code via node — not a Python
+# replica. The Python side (build_model/model_to_json) is UNCHANGED; `last_touch` already
+# ships to the client as an ISO string, so no server-side render-model change was needed.
+# --------------------------------------------------------------------------- #
+import os as _os                # noqa: E402
+import shutil as _shutil        # noqa: E402
+import subprocess as _subprocess  # noqa: E402
+
+
+def _epoch_ms(y, mo, d, h=0, mi=0, s=0):
+    """A UTC wall-clock -> epoch milliseconds (an absolute instant, tz-independent)."""
+    return int(datetime(y, mo, d, h, mi, s, tzinfo=timezone.utc).timestamp() * 1000)
+
+
+def _iso(y, mo, d, h=0, mi=0, s=0):
+    """A UTC wall-clock -> the ISO-8601 string the JSON island carries for `last_touch`."""
+    return datetime(y, mo, d, h, mi, s, tzinfo=timezone.utc).isoformat()
+
+
+def _node_recency(body, tz="UTC"):
+    """Eval `viewer._RECENCY_JS` + `body` (which console.logs a JSON value) under node with a
+    fixed TZ; return the parsed stdout. Skips if node isn't on PATH — the bucketing is JS, so
+    node is the only way to exercise the ACTUAL page code rather than re-implementing it."""
+    node = _shutil.which("node")
+    if not node:
+        import pytest
+        pytest.skip("node not on PATH — recency-bucketing JS untested this run")
+    src = viewer._RECENCY_JS + "\n" + body
+    out = _subprocess.run([node, "-e", src], capture_output=True, text=True,
+                          env=dict(_os.environ, TZ=tz), timeout=30)
+    assert out.returncode == 0, out.stderr
+    return json.loads(out.stdout)
+
+
+def _bucket_of(ts_ms, now_ms, tz="UTC"):
+    body = "console.log(JSON.stringify(recencyBucketKey(%s, %d)));" % (
+        "null" if ts_ms is None else str(ts_ms), now_ms)
+    return _node_recency(body, tz=tz)
+
+
+def test_recency_bucket_boundaries_utc():
+    # now = 2026-07-22T12:00:00Z; all cutoffs are LOCAL midnights (UTC here). Assert every
+    # boundary lands on the right side: just-before/after midnight, yesterday edge, week edge.
+    now = _epoch_ms(2026, 7, 22, 12)
+    assert _bucket_of(_epoch_ms(2026, 7, 22, 0, 0, 0), now) == "today"       # midnight today
+    assert _bucket_of(now, now) == "today"                                   # noon today
+    assert _bucket_of(_epoch_ms(2026, 7, 21, 23, 59, 59), now) == "yesterday"  # 1s before midnight
+    assert _bucket_of(_epoch_ms(2026, 7, 21, 12), now) == "yesterday"        # yesterday noon
+    assert _bucket_of(_epoch_ms(2026, 7, 21, 0, 0, 0), now) == "yesterday"   # yesterday midnight
+    assert _bucket_of(_epoch_ms(2026, 7, 20, 23, 59, 59), now) == "week"     # 1s before yest edge
+    assert _bucket_of(_epoch_ms(2026, 7, 18, 12), now) == "week"             # mid this week
+    assert _bucket_of(_epoch_ms(2026, 7, 15, 0, 0, 0), now) == "week"        # 7-days-ago midnight
+    assert _bucket_of(_epoch_ms(2026, 7, 14, 23, 59, 59), now) == "older"    # 1s before week edge
+    assert _bucket_of(_epoch_ms(2026, 7, 1, 12), now) == "older"             # well older
+    assert _bucket_of(None, now) == "unknown"                                # missing last_touch
+
+
+def test_recency_bucket_is_browser_local_tz():
+    # The SAME absolute instant buckets differently by the viewer's local tz — proving the
+    # cutoffs are LOCAL midnights, not UTC. now = 2026-07-22T03:00Z (= 2026-07-21 23:00 EDT);
+    # ts = 2026-07-21T05:00Z (= 2026-07-21 01:00 EDT). UTC -> yesterday; New York -> today.
+    now = _epoch_ms(2026, 7, 22, 3)
+    ts = _epoch_ms(2026, 7, 21, 5)
+    assert _bucket_of(ts, now, tz="UTC") == "yesterday"
+    assert _bucket_of(ts, now, tz="America/New_York") == "today"
+
+
+def test_recency_bucket_is_dst_safe():
+    # Local-calendar arithmetic (new Date(y,mo,d-n)) not fixed-24h subtraction, so a midnight
+    # cutoff can't drift across a DST transition. now = 2026-11-02 12:00 EST (day after the
+    # Nov-1 fall-back, a 25h day); ts = 2026-11-01 00:30 EST is genuinely YESTERDAY — a naive
+    # todayStart-24h boundary would land at Nov-1 01:00 and misfile it as "week".
+    body = ("var now = new Date(2026,10,2,12,0,0).getTime();"
+            "var ts  = new Date(2026,10,1,0,30,0).getTime();"
+            "console.log(JSON.stringify(recencyBucketKey(ts, now)));")
+    assert _node_recency(body, tz="America/New_York") == "yesterday"
+
+
+def test_recency_bucketize_omits_empty_and_preserves_input_order():
+    # bucketize a search-filtered, already-DESC flat list: assert (1) buckets come out in
+    # today->yesterday->week->older->unknown order, (2) an empty bucket (no yesterday item)
+    # is OMITTED, (3) within-bucket order preserves the DESC input (the caller feeds data.flat,
+    # which build_model already sorts last_touch-DESC), (4) a null last_touch -> unknown, last.
+    now = _epoch_ms(2026, 7, 22, 12)
+    views = [
+        {"slug": "a1", "last_touch": _iso(2026, 7, 22, 10)},   # today   (newer)
+        {"slug": "a2", "last_touch": _iso(2026, 7, 22, 2)},    # today   (older)
+        {"slug": "w1", "last_touch": _iso(2026, 7, 18, 12)},   # week
+        {"slug": "o1", "last_touch": _iso(2026, 7, 1, 12)},    # older
+        {"slug": "u1", "last_touch": None},                    # unknown (null)
+    ]
+    body = ("var NOW=%d; var VIEWS=%s;"
+            "console.log(JSON.stringify(bucketizeRecency(VIEWS, NOW).map(function(g){"
+            "return {key:g.key, slugs:g.items.map(function(v){return v.slug;})};})));"
+            ) % (now, json.dumps(views))
+    got = _node_recency(body)
+    assert [g["key"] for g in got] == ["today", "week", "older", "unknown"]  # yesterday omitted
+    assert got[0]["slugs"] == ["a1", "a2"]  # within-bucket DESC input order preserved
+    assert got[1]["slugs"] == ["w1"]
+    assert got[2]["slugs"] == ["o1"]
+    assert got[3]["slugs"] == ["u1"]        # unknown bucket last
+
+
+def test_recency_bucketize_parses_space_separated_last_touch():
+    # last_touch ships as json default=str → a SPACE-separated "YYYY-MM-DD HH:MM:SS...+00:00"
+    # (NOT ISO 'T'). bucketize must normalize it so it buckets correctly in EVERY engine (not
+    # just V8) — a naive new Date(space-string) returns NaN in Firefox → everything 'unknown'.
+    now = _epoch_ms(2026, 7, 22, 12)
+    views = [{"slug": "s", "last_touch": "2026-07-22 10:00:00.123456+00:00"}]  # today, space-sep
+    body = ("console.log(JSON.stringify(bucketizeRecency(%s, %d).map(function(g){"
+            "return g.key;})));") % (json.dumps(views), now)
+    assert _node_recency(body) == ["today"]
+
+
+def test_recency_bucketize_all_empty_returns_no_buckets():
+    # No initiatives -> no bucket sections at all (the render then shows the "No initiatives"
+    # empty state, same as flat/grouped).
+    now = _epoch_ms(2026, 7, 22, 12)
+    body = "console.log(JSON.stringify(bucketizeRecency([], %d)));" % now
+    assert _node_recency(body) == []
+
+
+# --- the 3-way toggle: default + persistence (client-side markers) ---------- #
+def test_render_html_has_three_way_toggle():
+    # The toggle grew a third button; flat + grouped keep their ids/labels unchanged.
+    html = viewer.render_html(viewer.build_model([_row(slug="s")], now=NOW))
+    assert 'id="view-flat"' in html
+    assert 'id="view-grouped"' in html
+    assert 'id="view-recency"' in html
+    # Bucket labels are embedded (RECENCY_BUCKETS in the inlined snippet).
+    assert "Earlier this week" in html and "Yesterday" in html and "Older" in html
+
+
+def test_js_recency_toggle_default_and_persistence():
+    js = viewer._JS
+    # default flat: an unknown/legacy stored value falls back via the VALID_VIEWS allowlist.
+    assert "VALID_VIEWS" in js and "VALID_VIEWS[storedView] ? storedView : 'flat'" in js
+    # the recency choice is persisted under the SAME key as flat/grouped.
+    assert "localStorage.setItem(VIEW_KEY, 'recency')" in js
+    # the snippet was inlined (placeholder substituted), so the page can call it.
+    assert "__RECENCY_JS__" not in js
+    assert "bucketizeRecency" in js and "recencyBucketKey" in js
+
+
+def test_js_recency_render_branch_present():
+    # render() has a dedicated recency branch that buckets the filtered flat stream and
+    # renders one section per non-empty bucket (label + count header, .repo styling).
+    assert "state.view === 'recency'" in viewer._JS
+    assert "bucketizeRecency(rviews, Date.now())" in viewer._JS
+    # the repo label shows in recency too (repo isn't the section header there).
+    assert "state.view !== 'grouped'" in viewer._JS

--- a/scripts/initiatives/viewer.py
+++ b/scripts/initiatives/viewer.py
@@ -810,12 +810,75 @@ footer .live{color:var(--green)}
 """.strip()
 
 
-# The whole page's client-side behaviour: parse the embedded JSON, render flat|grouped,
-# filter by search, expand a card (live detail fetch), refresh (POST /refresh), and
-# auto-refresh the data in place. Vanilla JS, no framework, no external assets. Untrusted
-# text is written via textContent (never innerHTML) so it can't inject markup.
+# PURE, DOM-FREE recency-bucketing logic — kept in its OWN snippet so the node test can
+# `eval` it standalone (SINGLE source of truth: `_JS` embeds this verbatim via the
+# __RECENCY_JS__ placeholder). Buckets an initiative's `last_touch` epoch into a recency
+# key relative to a supplied "now", both in MILLISECONDS, in the BROWSER's LOCAL timezone.
+#
+# Boundaries (newest→oldest; all cutoffs are LOCAL midnights, so a card flips buckets the
+# instant local midnight passes — matching the "updated Xm ago" the card already shows):
+#   today      ts >= local-midnight-today
+#   yesterday  local-midnight-yesterday   <= ts < local-midnight-today
+#   week       local-midnight-7-days-ago  <= ts < local-midnight-yesterday   ("earlier this week")
+#   older      ts <  local-midnight-7-days-ago                               (> ~7 local days)
+#   unknown    ts is null / NaN                                              (guard; shouldn't happen)
+# Using `new Date(y, mo, d - n)` (LOCAL-calendar arithmetic) rather than subtracting fixed
+# 24h spans makes the cutoffs DST-safe — a midnight boundary can't drift an hour across a
+# spring-forward/fall-back transition. `bucketizeRecency` groups a PRE-FILTERED, ALREADY
+# last_touch-DESC-sorted view list into ordered, NON-EMPTY buckets, preserving input order
+# within each bucket (so within-bucket order stays newest-first) — the one unit the render
+# path and the node test both exercise.
+_RECENCY_JS = r"""
+var RECENCY_BUCKETS = [
+  {key:'today',     label:'Today'},
+  {key:'yesterday', label:'Yesterday'},
+  {key:'week',      label:'Earlier this week'},
+  {key:'older',     label:'Older'},
+  {key:'unknown',   label:'Unknown'}
+];
+function recencyBucketKey(tsMs, nowMs){
+  if(tsMs == null || isNaN(tsMs)) return 'unknown';
+  var now = new Date(nowMs);
+  var y = now.getFullYear(), mo = now.getMonth(), d = now.getDate();
+  if(tsMs >= new Date(y, mo, d).getTime())     return 'today';
+  if(tsMs >= new Date(y, mo, d - 1).getTime()) return 'yesterday';
+  if(tsMs >= new Date(y, mo, d - 7).getTime()) return 'week';
+  return 'older';
+}
+function parseLastTouch(raw){
+  // `last_touch` is serialized server-side via json default=str → a SPACE-separated
+  // "YYYY-MM-DD HH:MM:SS.ffffff+00:00" (NOT ISO-8601 'T'). V8 parses that leniently but the
+  // ECMAScript date parse of a non-standard string is engine-defined (Firefox returns NaN),
+  // so normalize the space→'T' to a valid ISO string before Date() — robust in every engine.
+  if(!raw) return null;
+  var t = new Date(String(raw).replace(' ', 'T')).getTime();
+  return isNaN(t) ? null : t;
+}
+function bucketizeRecency(views, nowMs){
+  var groups = {};
+  views.forEach(function(v){
+    var ts = parseLastTouch(v.last_touch);
+    var b = recencyBucketKey(ts, nowMs);
+    (groups[b] = groups[b] || []).push(v);
+  });
+  var out = [];
+  RECENCY_BUCKETS.forEach(function(bk){
+    var items = groups[bk.key];
+    if(items && items.length) out.push({key:bk.key, label:bk.label, items:items});
+  });
+  return out;
+}
+""".strip()
+
+
+# The whole page's client-side behaviour: parse the embedded JSON, render
+# flat|grouped|recency, filter by search, expand a card (live detail fetch), refresh (POST
+# /refresh), and auto-refresh the data in place. Vanilla JS, no framework, no external
+# assets. Untrusted text is written via textContent (never innerHTML) so it can't inject
+# markup. The __RECENCY_JS__ placeholder is substituted at module load with _RECENCY_JS.
 _JS = r"""
 (function(){
+  __RECENCY_JS__
   var el0 = document.getElementById('idata');
   var data;
   try { data = JSON.parse(el0.textContent); }
@@ -823,8 +886,11 @@ _JS = r"""
 
   var VIEW_KEY = 'initiatives-view';
   var UNMATCHED_KEY = 'initiatives-unmatched-collapsed';
-  var state = { view: (localStorage.getItem(VIEW_KEY) === 'grouped') ? 'grouped' : 'flat',
-                q: '' };
+  // 3-way view toggle: 'flat' (default) | 'grouped' (by repo) | 'recency' (by last_touch
+  // bucket, LOCAL tz). Persisted in localStorage; an unknown/legacy value falls back to flat.
+  var VALID_VIEWS = {flat:1, grouped:1, recency:1};
+  var storedView = localStorage.getItem(VIEW_KEY);
+  var state = { view: VALID_VIEWS[storedView] ? storedView : 'flat', q: '' };
   // The catch-all "live sessions" section is collapsible; remember the user's choice.
   // Default EXPANDED (the whole point is to see every running thread) — set to '1' to collapse.
   var unmatchedCollapsed = localStorage.getItem(UNMATCHED_KEY) === '1';
@@ -836,6 +902,7 @@ _JS = r"""
   var footer = document.getElementById('foot');
   var btnFlat = document.getElementById('view-flat');
   var btnGrouped = document.getElementById('view-grouped');
+  var btnRecency = document.getElementById('view-recency');
   var btnRefresh = document.getElementById('refresh');
   var refreshMsg = document.getElementById('refresh-msg');
   var countEl = document.getElementById('count');
@@ -947,7 +1014,9 @@ _JS = r"""
                         v.badge_glyph + ' ' + v.badge_label));
     row1.appendChild(el('span', 'slug', v.slug));
     if(v.title) row1.appendChild(el('span', 'title', v.title));
-    if(state.view === 'flat' && v.repo_name)
+    // Show the repo label whenever repo isn't the section header — i.e. flat AND recency
+    // (both mix repos in one stream); grouped uses the repo as its section heading instead.
+    if(state.view !== 'grouped' && v.repo_name)
       row1.appendChild(el('span', 'repo-label', v.repo_name));
     row1.appendChild(el('span', 'age', 'updated ' + v.age + ' ago'));
     c.appendChild(row1);
@@ -1080,6 +1149,7 @@ _JS = r"""
   function updateChrome(){
     btnFlat.classList.toggle('active', state.view === 'flat');
     btnGrouped.classList.toggle('active', state.view === 'grouped');
+    if(btnRecency) btnRecency.classList.toggle('active', state.view === 'recency');
     if(countEl){
       var txt = (data.total || 0) + ' in flight across ' + (data.repo_count || 0) + ' repos';
       var nu = (data.live_unmatched || []).length;
@@ -1110,6 +1180,20 @@ _JS = r"""
         if(matchQ(v, q)){ wrap.appendChild(card(v)); shown++; }
       });
       app.appendChild(wrap);
+    } else if(state.view === 'recency'){
+      // Group the (search-filtered) flat stream into LOCAL-tz recency buckets. `data.flat`
+      // is already last_touch-DESC, and bucketizeRecency preserves that order within each
+      // bucket, so cards stay newest-first per bucket. Empty buckets are omitted. Headers
+      // read like the repo-group headers (label + count) — same `.repo`/`.count` styling.
+      var rviews = (data.flat || []).filter(function(v){ return matchQ(v, q); });
+      bucketizeRecency(rviews, Date.now()).forEach(function(g){
+        var sec = el('section', 'repo');
+        var h = el('h2', null, g.label);
+        h.appendChild(el('span', 'count', String(g.items.length)));
+        sec.appendChild(h);
+        g.items.forEach(function(v){ sec.appendChild(card(v)); shown++; });
+        app.appendChild(sec);
+      });
     } else {
       (data.repos || []).forEach(function(g){
         var vis = (g.initiatives || []).filter(function(v){ return matchQ(v, q); });
@@ -1164,6 +1248,9 @@ _JS = r"""
   btnGrouped.addEventListener('click', function(){
     state.view = 'grouped'; localStorage.setItem(VIEW_KEY, 'grouped'); render();
   });
+  if(btnRecency) btnRecency.addEventListener('click', function(){
+    state.view = 'recency'; localStorage.setItem(VIEW_KEY, 'recency'); render();
+  });
   searchInput.addEventListener('input', function(){ state.q = searchInput.value; render(); });
   btnRefresh.addEventListener('click', doRefresh);
 
@@ -1173,6 +1260,10 @@ _JS = r"""
   render();
 })();
 """.strip()
+
+# Inline the pure recency-bucketing snippet into the page JS (single source of truth: the
+# node test evals _RECENCY_JS directly, the page runs this substituted copy).
+_JS = _JS.replace("__RECENCY_JS__", _RECENCY_JS)
 
 
 def _e(s) -> str:
@@ -1225,6 +1316,7 @@ def render_html(model: dict | None, error: str | None = None,
         '<div class="toggle" role="group" aria-label="view">'
         '<button id="view-flat" class="tbtn" type="button">flat</button>'
         '<button id="view-grouped" class="tbtn" type="button">grouped</button>'
+        '<button id="view-recency" class="tbtn" type="button">recency</button>'
         '</div>'
         '<input id="search" class="search" type="search" placeholder="filter…" '
         'autocomplete="off" spellcheck="false" aria-label="filter initiatives">'


### PR DESCRIPTION
## What

Adds a third view mode — **recency** — to the initiatives web viewer (`scripts/initiatives/viewer.py`, live at http://192.168.50.250:8899), alongside the existing **flat** and **grouped** modes. Recency groups initiatives into `last_touch` buckets in the viewer's **local timezone**:

- **Today** (since local midnight) · **Yesterday** · **Earlier this week** (back to 7 local days ago) · **Older** (>7 days) · **Unknown** (missing `last_touch`, guard, rendered last).
- Newest bucket first; cards `last_touch`-DESC within each bucket; **empty buckets omitted**.
- Bucket headers reuse the repo-group header styling (label + count).

## Architecture — bucketing is client-side JS (in the browser-local tz)

The user's local timezone is only known client-side, so bucketing runs in the browser. The server render-model is **unchanged** — `last_touch` already ships to the client. The DOM-free boundary logic is factored into a `_RECENCY_JS` snippet (`recencyBucketKey` / `bucketizeRecency`), inlined into the page JS via a placeholder and **exercised directly by node in the tests** (the real code, not a Python replica).

Correctness details:
- Cutoffs are **local midnights** via local-calendar arithmetic (`new Date(y, mo, d - n)`), so they are **DST-safe** (a fixed-24h subtraction would drift an hour across a transition — regression-tested against the Nov fall-back).
- `last_touch` is normalized `space -> 'T'` before `new Date()` so it parses in **every engine**. This is the first client-side consumer of `last_touch`; the `json default=str` form is space-separated (`"2026-07-24 06:00:02...+00:00"`), which V8 parses leniently but Firefox returns `NaN` for.

## Toggle + everything else keeps working

- 3-way toggle persists under the existing `VIEW_KEY` in `localStorage`; unknown/legacy values fall back to `flat`. **Flat and grouped behave exactly as before.**
- Search/filter, recap/summary line, PR titles, live-tmux tags, click-to-expand, refresh, and the "Live sessions — not tied to an initiative" section all keep working in recency mode. Repo labels also show on recency cards (repo isn't the section header there).

## Tests

Extends the hermetic viewer tests (`test_viewer.py`), all node-driven for the JS boundary logic:
- boundary cases: just-before/after local midnight, yesterday / week / older edges, null -> unknown;
- **local-tz sensitivity** (same instant → `yesterday` in UTC, `today` in America/New_York);
- **DST fall-back** safety;
- **space-separated `last_touch`** parses correctly;
- `bucketize` omits empty buckets + preserves within-bucket DESC input order + unknown-last;
- 3-way toggle default/persistence + render markers + third button present.

`scripts/run-tests.sh` green (initiatives suite: 101 tests). Node-based tests `skip` gracefully if `node` is off PATH.

## Verification

Rendered the recency view end-to-end through the **real `_JS`** (the bundled Playwright chromium is broken on NixOS) via a minimal DOM shim over a fixture provider. Sample render (host tz CDT):

```
### Today
  - initiatives-recency   (updated 8m ago)
### Yesterday
  - clawgate-chat-polish   (updated 3h ago)     # correct: 22:00 local previous day
### Earlier this week
  - mail-sent-poller   (updated 1d ago)
  - spend-analytics   (updated 3d ago)
### Older
  - nebula-443   (updated 2w ago)
### Unknown
  - ghost-no-touch   (updated — ago)
```

## Residual risk

- **Server-vs-browser tz:** bucketing uses the *browser's* local tz (correct by design). If the page is opened from a machine in a different tz than the workbench, buckets reflect the viewer's tz — this is the intended "user's local timezone" semantics, not a bug.
- **Midnight boundary is live:** a card flips Today→Yesterday the instant local midnight passes; the next auto-refresh/re-render re-buckets. Boundaries are unit-tested to the second.
- Not deployed — the human deploys + eyeballs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
