### PR TITLE
fix(mail-actions): send clawgate task title in `directory`; add in-cluster direct-DB mode

### DIFF
--- a/scripts/mail-actions/_db.py
+++ b/scripts/mail-actions/_db.py
@@ -1,11 +1,24 @@
 #!/usr/bin/env python3
 """DB access for the mail-actions extractor.
 
-The mailbox Postgres lives in the homelab cluster and is only reachable in-cluster
-(ClusterIP `mailbox-postgres:5432`). We bridge to it by starting a `kubectl
-port-forward` on an ephemeral local port, connecting with psycopg2 over 127.0.0.1,
-and tearing the forward down on exit. Reads AND writes go through this so email
-bodies are passed as bound parameters — never shell-escaped into `psql -c`.
+The mailbox Postgres lives in the homelab cluster. Two connection modes:
+
+  * **Port-forward (default, OFF-cluster).** The workbench tools (sync/viewer/recap/
+    mail-actions) run outside the cluster, where the DB is only reachable in-cluster
+    (ClusterIP `mailbox-postgres:5432`). We bridge to it by starting a `kubectl
+    port-forward` on an ephemeral local port, connecting with psycopg2 over 127.0.0.1,
+    and tearing the forward down on exit. This is the default when no direct-mode env
+    var is set — existing consumers keep working unchanged.
+
+  * **Direct (IN-cluster).** A long-lived in-cluster consumer (e.g. the initiatives
+    agent pod) reaches `mailbox-postgres.mailbox.svc.cluster.local:5432` directly and
+    must NOT spawn a `kubectl port-forward` per query. Opt in by setting `MAILBOX_PG_HOST`
+    (the service host) — optionally with `MAILBOX_PG_PORT` (default 5432) — or the
+    explicit `MAILBOX_PG_DIRECT=1` flag (which then uses the DSN's own host). No kubectl,
+    no subprocess. See `_direct_target()` for the exact env contract.
+
+Reads AND writes go through this so email bodies are passed as bound parameters —
+never shell-escaped into `psql -c`.
 
 Usage:
     with MailDB() as db:
@@ -13,9 +26,13 @@ Usage:
         db.mark_processed(mail_id, label="fyi")
 
 Requires in PATH/env:
-    KUBECONFIG  — homelab kubeconfig
-    kubectl     — on PATH
+    KUBECONFIG  — homelab kubeconfig (port-forward mode only; unused in direct mode)
+    kubectl     — on PATH        (port-forward mode only; unused in direct mode)
     psycopg2    — python dep (psycopg2-binary is fine); see README for nix-shell.
+
+Credentials (user/password/dbname) come from an explicit `MAILBOX_PG_DSN` env / `dsn=`
+arg when provided, else the k8s secret `mailbox-postgres-auth` (port-forward mode).
+Direct-mode consumers typically pass the full DSN via `MAILBOX_PG_DSN`.
 """
 from __future__ import annotations
 
@@ -67,20 +84,56 @@ def _read_dsn_from_secret() -> str:
     return base64.b64decode(out).decode().strip()
 
 
-def _rewrite_dsn_host(dsn: str, host: str, port: int) -> dict:
-    """Parse a postgres:// DSN and return psycopg2 connect kwargs pointing at host:port."""
+def _dsn_connect_kwargs(dsn: str, *, host: str | None = None,
+                        port: int | None = None) -> dict:
+    """Parse a postgres:// DSN → psycopg2 connect kwargs.
+
+    `host`/`port` OVERRIDE the DSN's own host/port when provided (the port-forward path
+    passes host="127.0.0.1", port=<local>; direct mode may pass an in-cluster service
+    host). When an override is None the DSN's own value is kept — so a fully-specified
+    direct DSN connects as written. Falls back to port 5432 if neither the override nor
+    the DSN specify one. Credential/dbname parsing is shared by both modes."""
     u = urlparse(dsn)
     if u.scheme not in ("postgres", "postgresql"):
         raise ValueError(f"unexpected DSN scheme: {u.scheme!r}")
     dbname = (u.path or "/").lstrip("/") or "mailbox"
     return {
-        "host": host,
-        "port": port,
+        "host": host if host is not None else u.hostname,
+        "port": port if port is not None else (u.port or 5432),
         "user": u.username,
         "password": u.password,
         "dbname": dbname,
         "connect_timeout": 10,
     }
+
+
+def _truthy(val: str | None) -> bool:
+    return (val or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _direct_target() -> tuple[str | None, int | None] | None:
+    """Decide whether to connect DIRECTLY (no kubectl port-forward), and to where.
+
+    Returns None → use the default port-forward path (off-cluster workbench tools).
+    Returns (host_override, port_override) → connect directly, where either element may
+    be None to mean "keep the DSN's own value". Direct mode is opted into by env:
+
+      * `MAILBOX_PG_HOST` set → direct; connect to that host (e.g. the in-cluster
+        `mailbox-postgres.mailbox.svc.cluster.local`). `MAILBOX_PG_PORT` overrides the
+        port (default: the DSN's port, else 5432).
+      * `MAILBOX_PG_DIRECT` truthy (1/true/yes/on) → direct using the DSN's OWN host/port
+        (for a consumer that already supplies a fully-direct `MAILBOX_PG_DSN`);
+        `MAILBOX_PG_HOST`/`PORT` still override if also set.
+
+    Neither set → None (port-forward). This is purely additive: existing `MailDB()`
+    callers set no such env, so they keep port-forwarding unchanged."""
+    host = os.environ.get("MAILBOX_PG_HOST") or None
+    direct = _truthy(os.environ.get("MAILBOX_PG_DIRECT"))
+    if not host and not direct:
+        return None
+    port_s = os.environ.get("MAILBOX_PG_PORT")
+    port = int(port_s) if port_s and port_s.strip() else None
+    return host, port
 
 
 class MailDB:
@@ -94,6 +147,18 @@ class MailDB:
 
     # -- lifecycle ---------------------------------------------------------
     def __enter__(self) -> "MailDB":
+        direct = _direct_target()
+        if direct is not None:
+            # In-cluster consumer: connect straight to the service, no port-forward.
+            # Credentials still come from the DSN (explicit env/arg, else the secret).
+            dsn = self._dsn or _read_dsn_from_secret()
+            host_override, port_override = direct
+            kwargs = _dsn_connect_kwargs(dsn, host=host_override, port=port_override)
+            self.conn = psycopg2.connect(**kwargs)
+            self.conn.autocommit = False
+            return self
+
+        # Default (off-cluster): bridge via an ephemeral kubectl port-forward.
         dsn = self._dsn or _read_dsn_from_secret()
         local_port = _free_local_port()
         self._pf = subprocess.Popen(
@@ -105,7 +170,7 @@ class MailDB:
             stderr=subprocess.PIPE,
         )
         self._wait_for_port("127.0.0.1", local_port)
-        kwargs = _rewrite_dsn_host(dsn, "127.0.0.1", local_port)
+        kwargs = _dsn_connect_kwargs(dsn, host="127.0.0.1", port=local_port)
         self.conn = psycopg2.connect(**kwargs)
         self.conn.autocommit = False
         return self

--- a/scripts/mail-actions/clawgate.py
+++ b/scripts/mail-actions/clawgate.py
@@ -3,12 +3,45 @@
 
 Thin + swappable. POSTs a decision-shaped card to the clawgate hook-token endpoint.
 If CLAWGATE_HOOK_TOKEN is unset, `emit_task` is a graceful no-op (returns False).
+
+Contract note (fixed 2026-07-24): clawgate's `POST /api/tasks` handler
+(`homelab-talos/containers/clawgate/internal/api/notes.go` `handleAPITaskCreate`)
+decodes ONLY these JSON fields: `directory, body, model, repo, branch, privileges`.
+There is NO `title` field — a `title` key is silently dropped by Go's JSON decoder.
+The card's DISPLAY title is `directory` (`internal/ui/notes.go` `noteDispatchButton`:
+`label := n.Directory`, falling back to the first body line when empty). This module
+previously sent `{"title", "body"}`, so the title was dropped AND `directory` was
+empty → the card showed only the truncated first body line. We now send the title
+text as `directory` (mirroring `repo-cos/clawgate.py`, which already gets this right).
 """
 from __future__ import annotations
 
 import os
 
 ENDPOINT = "http://192.168.50.250:30302/api/tasks"
+
+# clawgate renders `directory` as the Task card's title; trim to a sane label length.
+TITLE_MAX = 120
+
+
+def build_task_payload(*, who: str, ask: str, deadline: str | None,
+                       amount: str | None, source_ref: str) -> dict:
+    """Build the `POST /api/tasks` JSON body for one action item.
+
+    Pure + side-effect-free so it can be asserted in a unit test. The action's title
+    goes in `directory` (clawgate's card-title field — NOT `title`, which the server
+    ignores); the ask/deadline/amount/source lines go in `body`.
+    """
+    bits = [ask.strip()]
+    if deadline:
+        bits.append(f"Deadline: {deadline}")
+    if amount:
+        bits.append(f"Amount: {amount}")
+    bits.append(f"Source: {source_ref}")
+    return {
+        "directory": f"\U0001F4E8 action-required · {who}"[:TITLE_MAX],
+        "body": "\n".join(b for b in bits if b),
+    }
 
 
 def emit_task(*, who: str, ask: str, deadline: str | None, amount: str | None,
@@ -19,16 +52,9 @@ def emit_task(*, who: str, ask: str, deadline: str | None, amount: str | None,
         return False
     import requests
 
-    bits = [ask.strip()]
-    if deadline:
-        bits.append(f"Deadline: {deadline}")
-    if amount:
-        bits.append(f"Amount: {amount}")
-    bits.append(f"Source: {source_ref}")
-    body = {
-        "title": f"\U0001F4E8 action-required · {who}"[:120],
-        "body": "\n".join(b for b in bits if b),
-    }
+    body = build_task_payload(
+        who=who, ask=ask, deadline=deadline, amount=amount, source_ref=source_ref,
+    )
     resp = requests.post(
         ENDPOINT,
         headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},

--- a/scripts/mail-actions/tests/test_clawgate_task.py
+++ b/scripts/mail-actions/tests/test_clawgate_task.py
@@ -1,0 +1,119 @@
+"""Tests for `clawgate.emit_task` / `build_task_payload`.
+
+Regression guard for the silently-dropped-title bug: clawgate's `POST /api/tasks`
+handler reads `directory` (which it renders as the card title) and IGNORES any
+`title` key. These tests assert the built payload carries the action title in
+`directory` (NOT `title`), and that `emit_task` POSTs exactly that body with the
+bearer token — with the HTTP layer mocked (no live clawgate)."""
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import clawgate  # noqa: E402
+
+
+# -- pure payload builder ------------------------------------------------------
+
+def test_payload_puts_title_in_directory_not_title():
+    body = clawgate.build_task_payload(
+        who="Acme Billing", ask="Pay invoice", deadline=None, amount=None,
+        source_ref="mail#42 billing@acme.com",
+    )
+    # The server renders `directory` as the card title; `title` is dropped.
+    assert "title" not in body
+    assert set(body) == {"directory", "body"}
+    assert body["directory"].endswith("Acme Billing")
+    assert "action-required" in body["directory"]
+
+
+def test_payload_body_includes_ask_deadline_amount_source():
+    body = clawgate.build_task_payload(
+        who="Acme", ask="  Approve the PO  ", deadline="2026-08-01", amount="$1,200",
+        source_ref="mail#7 po@acme.com",
+    )
+    lines = body["body"].splitlines()
+    assert lines[0] == "Approve the PO"  # ask, stripped
+    assert "Deadline: 2026-08-01" in lines
+    assert "Amount: $1,200" in lines
+    assert "Source: mail#7 po@acme.com" in lines
+
+
+def test_payload_omits_absent_deadline_and_amount():
+    body = clawgate.build_task_payload(
+        who="X", ask="do thing", deadline=None, amount=None, source_ref="mail#1 a@b.com",
+    )
+    assert body["body"] == "do thing\nSource: mail#1 a@b.com"
+
+
+def test_directory_title_is_length_capped():
+    body = clawgate.build_task_payload(
+        who="W" * 500, ask="a", deadline=None, amount=None, source_ref="mail#1 a@b.com",
+    )
+    assert len(body["directory"]) <= clawgate.TITLE_MAX
+
+
+# -- emit_task (HTTP mocked) ---------------------------------------------------
+
+class _FakeResponse:
+    def __init__(self):
+        self.raised = False
+
+    def raise_for_status(self):
+        self.raised = True
+
+
+class _FakeRequests:
+    """Minimal stand-in for the `requests` module emit_task imports lazily."""
+
+    def __init__(self):
+        self.calls = []
+        self._resp = _FakeResponse()
+
+    def post(self, url, headers=None, json=None, timeout=None):
+        self.calls.append(
+            {"url": url, "headers": headers, "json": json, "timeout": timeout}
+        )
+        return self._resp
+
+
+def _install_fake_requests(monkeypatch):
+    fake = _FakeRequests()
+    mod = types.ModuleType("requests")
+    mod.post = fake.post
+    monkeypatch.setitem(sys.modules, "requests", mod)
+    return fake
+
+
+def test_emit_task_noop_without_token(monkeypatch):
+    monkeypatch.delenv("CLAWGATE_HOOK_TOKEN", raising=False)
+    fake = _install_fake_requests(monkeypatch)
+    assert clawgate.emit_task(
+        who="X", ask="a", deadline=None, amount=None, source_ref="mail#1 a@b.com",
+    ) is False
+    assert fake.calls == []  # graceful no-op — nothing posted
+
+
+def test_emit_task_posts_directory_payload_with_bearer(monkeypatch):
+    monkeypatch.setenv("CLAWGATE_HOOK_TOKEN", "tok-123")
+    fake = _install_fake_requests(monkeypatch)
+
+    ok = clawgate.emit_task(
+        who="Acme", ask="Pay invoice", deadline="2026-08-01", amount="$5",
+        source_ref="mail#9 x@acme.com",
+    )
+    assert ok is True
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    assert call["url"] == clawgate.ENDPOINT
+    assert call["headers"]["Authorization"] == "Bearer tok-123"
+    # The POSTed body carries the title in `directory`, never `title`.
+    posted = call["json"]
+    assert "title" not in posted
+    assert posted["directory"].endswith("Acme")
+    assert posted == clawgate.build_task_payload(
+        who="Acme", ask="Pay invoice", deadline="2026-08-01", amount="$5",
+        source_ref="mail#9 x@acme.com",
+    )
+    assert fake._resp.raised is True  # raise_for_status() was called

--- a/scripts/mail-actions/tests/test_db_direct_mode.py
+++ b/scripts/mail-actions/tests/test_db_direct_mode.py
@@ -1,0 +1,210 @@
+"""Tests for MailDB's connection-mode selection (direct vs kubectl port-forward).
+
+Offline: psycopg2.connect and subprocess.Popen are mocked, so no real DB, no real
+kubectl. We assert:
+  * env UNSET  → port-forward path: a `kubectl port-forward` subprocess is spawned and
+    the connection targets 127.0.0.1:<local-port> (existing behavior, unchanged).
+  * MAILBOX_PG_HOST set → DIRECT path: NO subprocess spawned; connection targets the
+    override host (and MAILBOX_PG_PORT, when set).
+  * MAILBOX_PG_DIRECT=1 → DIRECT path using the DSN's OWN host/port.
+Plus pure kwargs-parsing tests for `_dsn_connect_kwargs`."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import _db  # noqa: E402
+
+DSN = "postgres://mailer:s3cr3t@mailbox-postgres.mailbox.svc.cluster.local:5432/mailbox"
+
+
+# -- pure DSN → connect-kwargs -------------------------------------------------
+
+def test_dsn_connect_kwargs_keeps_dsn_host_when_no_override():
+    kw = _db._dsn_connect_kwargs(DSN)
+    assert kw["host"] == "mailbox-postgres.mailbox.svc.cluster.local"
+    assert kw["port"] == 5432
+    assert kw["user"] == "mailer"
+    assert kw["password"] == "s3cr3t"
+    assert kw["dbname"] == "mailbox"
+
+
+def test_dsn_connect_kwargs_overrides_host_and_port():
+    kw = _db._dsn_connect_kwargs(DSN, host="127.0.0.1", port=54321)
+    assert kw["host"] == "127.0.0.1"
+    assert kw["port"] == 54321
+    # credentials still come from the DSN
+    assert kw["user"] == "mailer"
+    assert kw["dbname"] == "mailbox"
+
+
+def test_dsn_connect_kwargs_defaults_port_5432_when_absent():
+    kw = _db._dsn_connect_kwargs("postgres://u:p@h/db")
+    assert kw["port"] == 5432
+
+
+def test_dsn_connect_kwargs_rejects_non_postgres_scheme():
+    try:
+        _db._dsn_connect_kwargs("mysql://u:p@h/db")
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError on non-postgres scheme")
+
+
+# -- direct-target env contract ------------------------------------------------
+
+def test_direct_target_none_when_no_env(monkeypatch):
+    for k in ("MAILBOX_PG_HOST", "MAILBOX_PG_PORT", "MAILBOX_PG_DIRECT"):
+        monkeypatch.delenv(k, raising=False)
+    assert _db._direct_target() is None
+
+
+def test_direct_target_host_only(monkeypatch):
+    monkeypatch.delenv("MAILBOX_PG_DIRECT", raising=False)
+    monkeypatch.delenv("MAILBOX_PG_PORT", raising=False)
+    monkeypatch.setenv("MAILBOX_PG_HOST", "svc.internal")
+    assert _db._direct_target() == ("svc.internal", None)
+
+
+def test_direct_target_host_and_port(monkeypatch):
+    monkeypatch.setenv("MAILBOX_PG_HOST", "svc.internal")
+    monkeypatch.setenv("MAILBOX_PG_PORT", "6543")
+    assert _db._direct_target() == ("svc.internal", 6543)
+
+
+def test_direct_target_flag_only_uses_dsn_host(monkeypatch):
+    monkeypatch.delenv("MAILBOX_PG_HOST", raising=False)
+    monkeypatch.delenv("MAILBOX_PG_PORT", raising=False)
+    monkeypatch.setenv("MAILBOX_PG_DIRECT", "1")
+    assert _db._direct_target() == (None, None)
+
+
+def test_direct_target_flag_falsey_is_ignored(monkeypatch):
+    monkeypatch.delenv("MAILBOX_PG_HOST", raising=False)
+    monkeypatch.setenv("MAILBOX_PG_DIRECT", "0")
+    assert _db._direct_target() is None
+
+
+# -- MailDB.__enter__ mode selection (psycopg2 + subprocess mocked) ------------
+
+class _FakeConn:
+    def __init__(self):
+        self.autocommit = None
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def _patch_conn(monkeypatch):
+    """Capture the kwargs psycopg2.connect is called with; return a recorder dict."""
+    rec = {"connect_kwargs": None, "conn": _FakeConn()}
+
+    def fake_connect(**kwargs):
+        rec["connect_kwargs"] = kwargs
+        return rec["conn"]
+
+    monkeypatch.setattr(_db.psycopg2, "connect", fake_connect)
+    return rec
+
+
+def _forbid_popen(monkeypatch):
+    """Fail loudly if the code spawns any subprocess in direct mode."""
+    def boom(*a, **k):  # pragma: no cover - only hit on regression
+        raise AssertionError("subprocess.Popen must NOT be called in direct mode")
+
+    monkeypatch.setattr(_db.subprocess, "Popen", boom)
+
+
+def _clear_direct_env(monkeypatch):
+    for k in ("MAILBOX_PG_HOST", "MAILBOX_PG_PORT", "MAILBOX_PG_DIRECT"):
+        monkeypatch.delenv(k, raising=False)
+
+
+def test_direct_mode_host_override_no_port_forward(monkeypatch):
+    _clear_direct_env(monkeypatch)
+    monkeypatch.setenv("MAILBOX_PG_HOST", "mailbox-postgres.mailbox.svc.cluster.local")
+    rec = _patch_conn(monkeypatch)
+    _forbid_popen(monkeypatch)  # any Popen call fails the test
+
+    with _db.MailDB(dsn=DSN) as db:
+        assert db.conn is rec["conn"]
+        assert db._pf is None  # no port-forward process
+    kw = rec["connect_kwargs"]
+    assert kw["host"] == "mailbox-postgres.mailbox.svc.cluster.local"
+    assert kw["port"] == 5432  # from the DSN (no MAILBOX_PG_PORT override)
+    assert kw["user"] == "mailer"
+
+
+def test_direct_mode_flag_uses_dsn_host(monkeypatch):
+    _clear_direct_env(monkeypatch)
+    monkeypatch.setenv("MAILBOX_PG_DIRECT", "true")
+    rec = _patch_conn(monkeypatch)
+    _forbid_popen(monkeypatch)
+
+    with _db.MailDB(dsn=DSN):
+        pass
+    kw = rec["connect_kwargs"]
+    # DSN's own host is honored (not 127.0.0.1).
+    assert kw["host"] == "mailbox-postgres.mailbox.svc.cluster.local"
+    assert kw["port"] == 5432
+
+
+def test_direct_mode_port_override(monkeypatch):
+    _clear_direct_env(monkeypatch)
+    monkeypatch.setenv("MAILBOX_PG_HOST", "svc.internal")
+    monkeypatch.setenv("MAILBOX_PG_PORT", "6543")
+    rec = _patch_conn(monkeypatch)
+    _forbid_popen(monkeypatch)
+
+    with _db.MailDB(dsn=DSN):
+        pass
+    kw = rec["connect_kwargs"]
+    assert (kw["host"], kw["port"]) == ("svc.internal", 6543)
+
+
+class _FakePopen:
+    """Stand-in for the kubectl port-forward subprocess."""
+
+    def __init__(self, argv, **kwargs):
+        self.argv = argv
+        self.stderr = None
+        self._alive = True
+
+    def poll(self):
+        return None  # still running
+
+    def terminate(self):
+        self._alive = False
+
+    def wait(self, timeout=None):
+        return 0
+
+
+def test_port_forward_default_when_no_env(monkeypatch):
+    _clear_direct_env(monkeypatch)  # nothing set → port-forward path
+    rec = _patch_conn(monkeypatch)
+
+    spawned = {}
+
+    def fake_popen(argv, **kwargs):
+        spawned["argv"] = argv
+        return _FakePopen(argv, **kwargs)
+
+    monkeypatch.setattr(_db.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(_db, "_free_local_port", lambda: 55555)
+    # Skip the real socket readiness wait.
+    monkeypatch.setattr(_db.MailDB, "_wait_for_port", lambda self, host, port: None)
+
+    with _db.MailDB(dsn=DSN) as db:
+        assert db._pf is not None  # a port-forward WAS spawned
+
+    # kubectl port-forward was invoked for the mailbox service on the free local port.
+    argv = spawned["argv"]
+    assert argv[0] == "kubectl"
+    assert "port-forward" in argv
+    assert "55555:5432" in argv
+    # Connection targets the local forwarded port, not the DSN host.
+    kw = rec["connect_kwargs"]
+    assert kw["host"] == "127.0.0.1"
+    assert kw["port"] == 55555


### PR DESCRIPTION
Fixes two gaps surfaced by the initiatives-agent proposal (`claudedocs/initiatives-agent-proposal-2026-07-24.md`). Both live in `scripts/mail-actions/`. Additive, low-blast-radius.

## Gap 1 — clawgate task `title` silently dropped (CLIENT bug — fixed here, no server change)

**Root cause.** clawgate's `POST /api/tasks` handler `handleAPITaskCreate` (`homelab-talos/containers/clawgate/internal/api/notes.go`) decodes only:

```go
Directory, Body, Model, Repo, Branch, Privileges
```

There is **no `title` field**, and the handler's `json.NewDecoder(...).Decode(&body)` does **not** set `DisallowUnknownFields` → an unknown `title` key is silently ignored. The card's display title is `directory` (`internal/ui/notes.go` `noteDispatchButton`: `label := n.Directory`, falling back to the body's first line when empty).

`mail-actions/clawgate.py` was sending `{"title": …, "body": …}` → the title was dropped **and** `directory` was empty, so cards rendered only the truncated first body line. `repo-cos/clawgate.py` already gets this right (it sends its title as `directory`).

**Fix (client-side).** Send the title text as `directory`. Extracted a pure `build_task_payload()` so the body is unit-testable. **No clawgate/server change required.**

## Gap 2 — store reachable only via `kubectl port-forward`

`MailDB` spawned a `kubectl port-forward` per connection — fine for the off-cluster workbench tools, but a long-lived **in-cluster** consumer (the proposed initiatives agent pod) reaches `mailbox-postgres.mailbox.svc.cluster.local:5432` directly and must not port-forward per query.

**Fix (additive, opt-in).** New DIRECT mode:

- `MAILBOX_PG_HOST` set (optionally `MAILBOX_PG_PORT`, default 5432) → connect straight to that host, **no kubectl, no subprocess**.
- `MAILBOX_PG_DIRECT=1` (truthy) → direct using the DSN's own host/port (for a consumer supplying a fully-direct `MAILBOX_PG_DSN`).
- Neither set → **unchanged** kubectl-port-forward path (workbench default).

Credentials (user/password/dbname) still come from `MAILBOX_PG_DSN`/`dsn=` else the k8s secret. Generalized the DSN→connect-kwargs parser (`_dsn_connect_kwargs`) so the secret logic stays reusable across both modes. All existing consumers (`extract`/`sync`/`viewer`/`recap`/`feedback`) call `MailDB()` with no direct-env → unaffected.

## Tests

+19 unit tests, all HTTP/psycopg2/subprocess mocked (offline, hermetic):
- `tests/test_clawgate_task.py` (6): payload carries title in `directory` not `title`; body lines; length cap; `emit_task` no-ops without token; posts the exact body with bearer.
- `tests/test_db_direct_mode.py` (13): `_dsn_connect_kwargs` parsing; `_direct_target` env contract; `__enter__` mode selection (direct → no `Popen`, targets override host; unset → spawns port-forward, targets 127.0.0.1:local).

Green: mail-actions **135**, initiatives **213**, repo-cos **232** (the last two consume `_db.py`).

## Residual risk / notes

- No live `POST /api/tasks` was fired — deliberately, to avoid polluting the prod Tasks queue with a junk card. The fix is validated against the server contract read directly from clawgate's Go source + a unit test; a real card render is a 30-second manual check for the reviewer if desired.
- `directory` doubles as clawgate's dispatch "working directory" label; here it carries human title text (same as repo-cos's shipped Phase-2 usage), which is the accepted convention for producer-created Task cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)