### PR TITLE
fix(task-spec-drafter): harden headless runtime — stop burning calls on blocked/misformed reads

### DIFF
--- a/scripts/task-spec-drafter/drafter-prompt.md
+++ b/scripts/task-spec-drafter/drafter-prompt.md
@@ -17,7 +17,7 @@ NEVER draft a confident task you could not verify the intent of.
   - `clickup get/comments`
   - `git -C <abspath>` with `log`, `show`, `diff`, `grep`, `branch --contains`,
     `rev-parse`, `rev-list`, `merge-base` (incl. `--is-ancestor`), `for-each-ref`,
-    `symbolic-ref --short`, `ls-files`, `cat-file`, `ls-remote` — use these to
+    `symbolic-ref --short`, `ls-files`, `cat-file` — use these to
     answer "is commit/PR X merged / on trunk?" (e.g. `merge-base --is-ancestor
     <sha> origin/main` or `branch --contains <sha>`). Write forms like `git
     branch <name>`, `git branch -d/-D`, `git symbolic-ref HEAD <ref>` are NOT

--- a/scripts/task-spec-drafter/drafter-prompt.md
+++ b/scripts/task-spec-drafter/drafter-prompt.md
@@ -13,10 +13,52 @@ NEVER draft a confident task you could not verify the intent of.
 - **READ-ONLY. Make NO writes anywhere.** Do not post ClickUp comments, do not
   edit/merge/push any repo, do not mutate the cluster. No `clickup ... comment`,
   no `gh pr ...` mutations, no `kubectl apply/delete/edit/scale`, no `git commit`.
-  You may only READ: `clickup get/comments`, `git log`, `gh pr list/view --search`,
-  `kubectl get/logs/describe/top` (read verbs only). No `gh api` and no `curl` —
-  they are not on the allowlist and will not run.
+  You may only READ. The allowed read verbs are:
+  - `clickup get/comments`
+  - `git -C <abspath>` with `log`, `show`, `diff`, `grep`, `branch --contains`,
+    `rev-parse`, `rev-list`, `merge-base` (incl. `--is-ancestor`), `for-each-ref`,
+    `symbolic-ref --short`, `ls-files`, `cat-file`, `ls-remote` — use these to
+    answer "is commit/PR X merged / on trunk?" (e.g. `merge-base --is-ancestor
+    <sha> origin/main` or `branch --contains <sha>`). Write forms like `git
+    branch <name>`, `git branch -d/-D`, `git symbolic-ref HEAD <ref>` are NOT
+    allowed and will not run.
+  - `gh pr list/view/checks/search`
+  - `kubectl get/logs/describe/top`
+  No `gh api` and no `curl` — they are NOT on the allowlist and will not run
+  (a prompt-injected ticket must never be able to reach a POST). Verify PR/merge
+  reality with `gh pr ...` + the git plumbing verbs above instead.
 - **Do not dispatch anything.** You only produce the record below.
+- **COMMAND-SHAPE CONTRACT (obey EXACTLY or the call is REJECTED and wasted).**
+  The non-interactive shell that runs your Bash tool calls rejects the shapes
+  models reach for by default. Every Bash call MUST be a SINGLE read verb over an
+  ABSOLUTE path:
+  - Use ONLY `git -C <ABSOLUTE-PATH> <verb> …`. The absolute repo path is injected
+    below (`CIVITAI_REPO`) — paste it in literally.
+  - NEVER `cd` anywhere. NEVER `cd repo && git …`.
+  - NEVER a shell variable (`$CIVITAI`, `$CIVITAI_REPO`, `$REPO`, `$HOME`, …). It
+    does NOT expand in this shell and the call is rejected ("Contains
+    simple_expansion"). Write the literal path.
+  - NEVER chain: no `&&`, no `;`, no `|` pipes, no `$(…)` / backticks. ONE verb
+    per Bash call ("multiple operations" is rejected). Run separate calls instead.
+
+  | ❌ REJECTED (do NOT emit) | ✅ DO THIS INSTEAD |
+  |---|---|
+  | `cd civitai && git log --oneline -20` | `git -C /home/zach/workspace/civit/civitai log --oneline -20` |
+  | `git -C $CIVITAI log --grep foo` | `git -C /home/zach/workspace/civit/civitai log --grep foo` |
+  | `git -C /…/civitai branch --contains abc123 && gh pr view 42` | two calls: `git -C /…/civitai branch --contains abc123` then `gh pr view 42` |
+  | `git -C /…/civitai log \| grep fix` | `git -C /…/civitai log --grep fix` |
+
+- **ANTI-CONFABULATION GATE (mandatory).** You MUST run at least ONE successful
+  read (a `clickup get/comments`, a `git …`, a `gh …`, or a `kubectl …` call that
+  actually returned output) BEFORE you assert any factual verdict — e.g. "no
+  commits/PRs found", "already merged", "still firing", "nothing found",
+  "already done". Reasoning from the title alone, or emitting such a claim having
+  run ZERO tools, is a FORBIDDEN fabricated verification. If every read you
+  attempted failed or was blocked (you could not reach ANY source), you MUST
+  classify `NEEDS-DECISION` with `confidence: "low"` and state plainly in
+  `verification` that no source was reachable (e.g. "unverified — all reads
+  failed/blocked"). NEVER assert a negative finding ("no PR", "nothing firing")
+  that you did not actually observe from a tool's output.
 - **SAFETY RULE (the meili-cron lesson):** if you cannot verify *why* something
   is or isn't being done — i.e. you can't confirm whether the work is wanted,
   already underway, or deliberately suppressed — classify **NEEDS-DECISION** and
@@ -34,11 +76,18 @@ other tickets may be referenced for CORRELATE but are not yours to classify here
 - **ClickUp** via the `clickup` skill CLI (read-only here):
   `node /home/zach/.claude/skills/clickup/query.mjs get <id>` (full body, status,
   dates, assignees, links) and `... comments <id> --threads` (ALL comments).
-- **civitai code/PR reality:** repo at `/home/zach/workspace/civit/civitai`.
+- **civitai code/PR reality:** repo at `/home/zach/workspace/civit/civitai` (paste
+  this ABSOLUTE path literally into `-C`; do NOT use `$CIVITAI_REPO`).
   `git -C /home/zach/workspace/civit/civitai log --oneline -n 40 --since=...`,
-  `git -C ... log --all --grep '<keyword>'`,
+  `git -C /home/zach/workspace/civit/civitai log --all --grep '<keyword>'`,
   `gh -R civitai/civitai pr list --search '<keyword>' --state all --limit 20`,
-  `gh -R civitai/civitai pr view <n>`.
+  `gh -R civitai/civitai pr view <n>`, `gh -R civitai/civitai pr checks <n>`.
+  **"Is commit/PR X merged / on trunk?"** — answer deterministically with the
+  git plumbing verbs (single verb per call, absolute `-C`):
+  `git -C /home/zach/workspace/civit/civitai merge-base --is-ancestor <sha> origin/main`
+  (exit 0 ⇒ merged), or
+  `git -C /home/zach/workspace/civit/civitai branch --contains <sha>`, or
+  `git -C /home/zach/workspace/civit/civitai rev-list --count <sha>..origin/main`.
 - **Live cluster state:** `KUBECONFIG=/home/zach/workspace/civit/datapacket-talos/prod-kubeconfig`
   then `kubectl get pods/cronjobs/...`, `kubectl logs ...`, `kubectl describe ...`,
   `kubectl top ...` (read-only). Use to answer "is this component running or

--- a/scripts/task-spec-drafter/drafter.sh
+++ b/scripts/task-spec-drafter/drafter.sh
@@ -154,16 +154,29 @@ export REPO_COS_PROD_KUBECONFIG="${REPO_COS_PROD_KUBECONFIG:-$HOME/workspace/hom
 #       both WRITES. Those write forms do not start with `branch --contains`, so
 #       they can never match this entry.
 #   * `git -C * rev-parse* / rev-list* / merge-base* / for-each-ref* / ls-files*
-#       / cat-file* / ls-remote*` — pure readers (resolve refs → SHA, list commit
+#       / cat-file*` — pure readers (resolve refs → SHA, list commit
 #       ranges/counts, `merge-base --is-ancestor` for the merged check, enumerate
-#       refs, list tracked files, inspect objects, query a remote's refs). None
-#       has a write mode.
+#       refs, list tracked files, inspect objects). None has a write mode NOR an
+#       arbitrary-command flag.
 #   * `git -C * symbolic-ref --short*` — NARROWED: bare `symbolic-ref HEAD <ref>`
 #       (2-arg) REPOINTS HEAD (a write); `--short <ref>` only reads the target,
 #       so pin the read form.
 #   * `gh pr checks*` — read-only CI check-run status for a PR (no mutation).
+#
+# ⛔ `git -C * ls-remote*` was REMOVED (security audit, 2026-07): it is an RCE, not
+#    a read. `git ls-remote --upload-pack=<cmd>` (or `-o <cmd>`) EXECUTES <cmd>
+#    LOCALLY before the transport resolves (proven live: `git -C /tmp ls-remote
+#    --upload-pack="sh -c 'id>/tmp/pwned'" /x` ran the shell). The trailing-`*`
+#    glob permits that suffix with NO $VAR/&&/;/|/$()/redirect, so it slips past
+#    every harness filter AND the bash-guard AND matches the allowlist glob — and
+#    the pass auto-executes (no --permission-mode plan) over UNTRUSTED client
+#    ticket text. This is the exact flag-injection class that keeps `gh api` out:
+#    a prefix glob CANNOT forbid `--upload-pack`/`-o`/`--exec`, so `ls-remote*`
+#    cannot be safely allowlisted — DROP it, don't narrow it. Its only use ("is X
+#    merged / on trunk?") is already covered by merge-base --is-ancestor /
+#    branch --contains / rev-list. Do NOT re-add it (test guards this).
 # Override DRAFTER_ALLOWED_TOOLS via env ONLY with read-only verbs.
-DRAFTER_ALLOWED_TOOLS="${DRAFTER_ALLOWED_TOOLS:-Read,Glob,Grep,WebFetch,Bash(node *query.mjs get*),Bash(node *query.mjs comments*),Bash(node *query.mjs search*),Bash(git -C * log*),Bash(git -C * show*),Bash(git -C * diff*),Bash(git -C * grep*),Bash(git -C * branch --contains*),Bash(git -C * rev-parse*),Bash(git -C * rev-list*),Bash(git -C * merge-base*),Bash(git -C * for-each-ref*),Bash(git -C * symbolic-ref --short*),Bash(git -C * ls-files*),Bash(git -C * cat-file*),Bash(git -C * ls-remote*),Bash(git log*),Bash(gh pr list*),Bash(gh pr view*),Bash(gh pr checks*),Bash(gh search*),Bash(kubectl get*),Bash(kubectl logs*),Bash(kubectl describe*),Bash(kubectl top*),Bash(grep*),Bash(rg*),Bash(jq*),Bash(cat*),Bash(echo*),Bash(date*)}"
+DRAFTER_ALLOWED_TOOLS="${DRAFTER_ALLOWED_TOOLS:-Read,Glob,Grep,WebFetch,Bash(node *query.mjs get*),Bash(node *query.mjs comments*),Bash(node *query.mjs search*),Bash(git -C * log*),Bash(git -C * show*),Bash(git -C * diff*),Bash(git -C * grep*),Bash(git -C * branch --contains*),Bash(git -C * rev-parse*),Bash(git -C * rev-list*),Bash(git -C * merge-base*),Bash(git -C * for-each-ref*),Bash(git -C * symbolic-ref --short*),Bash(git -C * ls-files*),Bash(git -C * cat-file*),Bash(git log*),Bash(gh pr list*),Bash(gh pr view*),Bash(gh pr checks*),Bash(gh search*),Bash(kubectl get*),Bash(kubectl logs*),Bash(kubectl describe*),Bash(kubectl top*),Bash(grep*),Bash(rg*),Bash(jq*),Bash(cat*),Bash(echo*),Bash(date*)}"
 
 mkdir -p "$DRAFTER_OUT_DIR" 2>/dev/null || true
 # The delta-state file may live outside OUT_DIR (e.g. ~/.local/state/...); make

--- a/scripts/task-spec-drafter/drafter.sh
+++ b/scripts/task-spec-drafter/drafter.sh
@@ -130,7 +130,11 @@ export REPO_COS_PROD_KUBECONFIG="${REPO_COS_PROD_KUBECONFIG:-$HOME/workspace/hom
 # EXECUTE unprompted. A prompt-injected ticket must not be able to reach a WRITE.
 # Therefore every entry is a read-only verb only, and specifically NOT:
 #   * `Bash(gh api*)`  — dropped: allows `gh api -X POST/PATCH/DELETE` (mutations).
-#                        PR/commit reality is verified via gh pr list/view/search.
+#                        Kept OUT even though the model reaches for it: a prefix
+#                        glob cannot forbid `-X POST` while allowing the GET
+#                        default, so the whole verb is an injection→mutation path.
+#                        Merge/PR reality is verified via `gh pr
+#                        list/view/checks/search` + the git plumbing verbs below.
 #   * `Bash(curl -s*)` — dropped: allows `curl -X POST -d …` to any URL (mutation +
 #                        exfil). Live-state verification degrades to kubectl
 #                        get/logs/top (pod/cronjob running-vs-suspended), which
@@ -138,8 +142,28 @@ export REPO_COS_PROD_KUBECONFIG="${REPO_COS_PROD_KUBECONFIG:-$HOME/workspace/hom
 #                        off?" axis; ad-hoc Prometheus/Alertmanager HTTP reads go.
 #   * `Bash(env*)`     — dropped: the pass inherits drafter.sh's env, which sources
 #                        ~/.claude/clawgate.env (CLAWGATE_HOOK_TOKEN); no dumping it.
+#
+# READ-ONLY MERGE/REF PLUMBING (added 2026-07): the pass kept burning headless
+# calls on "is commit X merged / on trunk?" because the answer verbs were not
+# allowlisted → "requires approval" → dead in headless. Added below, each
+# justified as strictly read-only (no object/ref mutation possible in the
+# allowed shape):
+#   * `git -C * branch --contains*` — lists branches containing a commit. NARROWED
+#       to `branch --contains` ON PURPOSE: a bare `branch*` glob would also match
+#       `git branch <name>` (creates) and `git branch -d/-D <name>` (deletes) —
+#       both WRITES. Those write forms do not start with `branch --contains`, so
+#       they can never match this entry.
+#   * `git -C * rev-parse* / rev-list* / merge-base* / for-each-ref* / ls-files*
+#       / cat-file* / ls-remote*` — pure readers (resolve refs → SHA, list commit
+#       ranges/counts, `merge-base --is-ancestor` for the merged check, enumerate
+#       refs, list tracked files, inspect objects, query a remote's refs). None
+#       has a write mode.
+#   * `git -C * symbolic-ref --short*` — NARROWED: bare `symbolic-ref HEAD <ref>`
+#       (2-arg) REPOINTS HEAD (a write); `--short <ref>` only reads the target,
+#       so pin the read form.
+#   * `gh pr checks*` — read-only CI check-run status for a PR (no mutation).
 # Override DRAFTER_ALLOWED_TOOLS via env ONLY with read-only verbs.
-DRAFTER_ALLOWED_TOOLS="${DRAFTER_ALLOWED_TOOLS:-Read,Glob,Grep,WebFetch,Bash(node *query.mjs get*),Bash(node *query.mjs comments*),Bash(node *query.mjs search*),Bash(git -C * log*),Bash(git -C * show*),Bash(git -C * diff*),Bash(git -C * grep*),Bash(git log*),Bash(gh pr list*),Bash(gh pr view*),Bash(gh search*),Bash(kubectl get*),Bash(kubectl logs*),Bash(kubectl describe*),Bash(kubectl top*),Bash(grep*),Bash(rg*),Bash(jq*),Bash(cat*),Bash(echo*),Bash(date*)}"
+DRAFTER_ALLOWED_TOOLS="${DRAFTER_ALLOWED_TOOLS:-Read,Glob,Grep,WebFetch,Bash(node *query.mjs get*),Bash(node *query.mjs comments*),Bash(node *query.mjs search*),Bash(git -C * log*),Bash(git -C * show*),Bash(git -C * diff*),Bash(git -C * grep*),Bash(git -C * branch --contains*),Bash(git -C * rev-parse*),Bash(git -C * rev-list*),Bash(git -C * merge-base*),Bash(git -C * for-each-ref*),Bash(git -C * symbolic-ref --short*),Bash(git -C * ls-files*),Bash(git -C * cat-file*),Bash(git -C * ls-remote*),Bash(git log*),Bash(gh pr list*),Bash(gh pr view*),Bash(gh pr checks*),Bash(gh search*),Bash(kubectl get*),Bash(kubectl logs*),Bash(kubectl describe*),Bash(kubectl top*),Bash(grep*),Bash(rg*),Bash(jq*),Bash(cat*),Bash(echo*),Bash(date*)}"
 
 mkdir -p "$DRAFTER_OUT_DIR" 2>/dev/null || true
 # The delta-state file may live outside OUT_DIR (e.g. ~/.local/state/...); make

--- a/scripts/task-spec-drafter/tests/test_shadow_wiring.py
+++ b/scripts/task-spec-drafter/tests/test_shadow_wiring.py
@@ -111,10 +111,32 @@ def test_allowlist_adds_merge_status_readonly_verbs():
         "Bash(git -C * symbolic-ref --short*)",
         "Bash(git -C * ls-files*)",
         "Bash(git -C * cat-file*)",
-        "Bash(git -C * ls-remote*)",
         "Bash(gh pr checks*)",
     ):
         assert verb in al, f"missing read-only merge/ref verb {verb}"
+
+
+def test_allowlist_has_no_arbitrary_command_flag_verbs():
+    """RCE guard (security audit, 2026-07). `git ls-remote --upload-pack=<cmd>`
+    (also `-o <cmd>`) EXECUTES <cmd> locally before the transport resolves; the
+    trailing-`*` glob permits that suffix with no $VAR/&&/;/|/redirect, so it
+    slips past the harness filters AND matches the glob AND auto-executes (no
+    plan mode) over untrusted client ticket text. A prefix glob CANNOT forbid the
+    exec flags, so the whole verb is unsafe to allowlist — same class that keeps
+    `gh api` out. Block re-adding any git subcommand that accepts a
+    remote-helper / exec flag (`--upload-pack`/`--receive-pack`/`--exec`/`-o`)."""
+    al = _allowlist(_read(_DRAFTER))
+    # The specific verb the audit proved, plus its exec-flag siblings — none of
+    # these git subcommands may appear as an allowlist entry.
+    for verb in ("ls-remote", "fetch", "clone", "pull", "push", "daemon",
+                 "archive", "remote", "submodule"):
+        assert f"git -C * {verb}" not in al, (
+            f"git {verb}* accepts an arbitrary-command flag "
+            f"(--upload-pack/--receive-pack/--exec) — a prefix glob can't forbid it; RCE"
+        )
+    # And no raw exec-flag token should ever be baked into an allowlist entry.
+    for flag in ("--upload-pack", "--receive-pack", "--exec"):
+        assert flag not in al, f"exec flag {flag} must never appear in the allowlist"
 
 
 # --- prompt: command-shape contract (headless calls kept getting rejected) ----

--- a/scripts/task-spec-drafter/tests/test_shadow_wiring.py
+++ b/scripts/task-spec-drafter/tests/test_shadow_wiring.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 _HERE = Path(__file__).resolve().parent
 _DRAFTER = _HERE.parent / "drafter.sh"
+_PROMPT = _HERE.parent / "drafter-prompt.md"
 _ENV_EXAMPLE = _HERE.parent / "task-spec-drafter.env.example"
 _HOME_NIX = _HERE.parents[2] / "nix" / "home.nix"
 
@@ -68,6 +69,21 @@ def test_allowlist_has_no_write_capable_verbs():
     assert "gh api" not in al, "gh api* allows `gh api -X POST/PATCH/DELETE`"
     assert "curl" not in al, "curl -s* allows `curl -X POST -d …`"
     assert "Bash(env" not in al, "env* dumps the inherited CLAWGATE_HOOK_TOKEN"
+    # The merge/ref-status verbs added for the headless-runtime fix must be
+    # NARROWED to their read-only shape — the broad globs would also match the
+    # write forms of the same command, so those broad globs must be ABSENT:
+    assert "Bash(git -C * branch*)" not in al, (
+        "broad `git -C * branch*` glob matches `git branch <name>`/`-d/-D` (writes); "
+        "only the read-only `branch --contains*` form is allowed"
+    )
+    assert "Bash(git -C * symbolic-ref*)" not in al, (
+        "broad `git -C * symbolic-ref*` glob matches 2-arg `symbolic-ref HEAD <ref>` "
+        "(repoints HEAD, a write); only `symbolic-ref --short*` is allowed"
+    )
+    # sanity: no obviously-mutating git verbs anywhere in the allowlist.
+    for bad in ("push", "commit", "git -C * apply", "git -C * reset",
+                "git -C * checkout", "git -C * tag", "git -C * update-ref"):
+        assert bad not in al, f"write-capable verb leaked into allowlist: {bad}"
 
 
 def test_allowlist_keeps_readonly_verification_verbs():
@@ -78,6 +94,76 @@ def test_allowlist_keeps_readonly_verification_verbs():
         "Bash(kubectl get*)", "Bash(node *query.mjs get*)",
     ):
         assert verb in al, f"missing read-only verification verb {verb}"
+
+
+def test_allowlist_adds_merge_status_readonly_verbs():
+    """The headless-runtime fix: the drafter kept burning calls on "is X merged /
+    on trunk?" because the answer verbs weren't allowlisted → "requires approval".
+    These read-only merge/ref verbs (each in its narrowest safe shape) must now be
+    present so the check runs non-interactively."""
+    al = _allowlist(_read(_DRAFTER))
+    for verb in (
+        "Bash(git -C * branch --contains*)",
+        "Bash(git -C * rev-parse*)",
+        "Bash(git -C * rev-list*)",
+        "Bash(git -C * merge-base*)",
+        "Bash(git -C * for-each-ref*)",
+        "Bash(git -C * symbolic-ref --short*)",
+        "Bash(git -C * ls-files*)",
+        "Bash(git -C * cat-file*)",
+        "Bash(git -C * ls-remote*)",
+        "Bash(gh pr checks*)",
+    ):
+        assert verb in al, f"missing read-only merge/ref verb {verb}"
+
+
+# --- prompt: command-shape contract (headless calls kept getting rejected) ----
+
+def _norm(s: str) -> str:
+    """Collapse all runs of whitespace to single spaces so phrase assertions are
+    robust to markdown line-wrapping."""
+    return " ".join(s.split())
+
+
+def test_prompt_has_command_shape_contract():
+    """The harness rejects the shapes the model defaults to ($VAR expansion,
+    cd, compound &&/pipes). The prompt must carry a loud contract forbidding them
+    and mandating a single `git -C <abspath>` verb per call."""
+    p = _norm(_read(_PROMPT))
+    assert "COMMAND-SHAPE CONTRACT" in p
+    # forbids cd
+    assert "NEVER `cd`" in p or "NEVER `cd repo" in p
+    # forbids shell-variable expansion (with the concrete $CIVITAI example)
+    assert "$CIVITAI" in p
+    assert "simple_expansion" in p, "should name the exact rejection the harness emits"
+    # forbids compound / pipes, mandates ONE verb per call
+    assert "&&" in p and "pipes" in p
+    assert "ONE verb per Bash call" in p or "ONE read verb per" in p
+    # mandates the git -C <abspath> single-verb shape
+    assert "git -C <ABSOLUTE-PATH>" in p
+    # a concrete REJECTED→DO-THIS table exists
+    assert "REJECTED" in p and "INSTEAD" in p
+
+
+def test_prompt_has_anticonfab_gate():
+    """One drafter run emitted a "nothing found" verdict having run ZERO tools —
+    a fabricated verification. The prompt must hard-require ≥1 successful read
+    before any factual verdict, and route the no-read case to a low-confidence
+    NEEDS-DECISION instead of asserting a negative finding."""
+    p = _norm(_read(_PROMPT))
+    assert "ANTI-CONFABULATION GATE" in p
+    assert "at least ONE successful read" in p or "at least one successful read" in p.lower()
+    # the honest no-read path is NEEDS-DECISION + low confidence, not a false negative
+    assert "NEEDS-DECISION" in p
+    assert 'confidence: "low"' in p or "confidence: low" in p
+    assert "no source was reachable" in p or "all reads failed" in p
+
+
+def test_prompt_still_forbids_gh_api_and_curl():
+    """The expanded read verbs must not have quietly re-permitted the mutation
+    paths the design excludes."""
+    p = _norm(_read(_PROMPT))
+    assert "No `gh api` and no `curl`" in p
 
 
 # --- deterministic safety gate ------------------------------------------------


### PR DESCRIPTION
## 🔴 Security fix (audit round) — dropped `ls-remote` (RCE)

A security audit of the first push **found and PROVED an RCE** in the allowlist change and it has been fixed in the same branch (commit `1fe19ff`).

**The hole:** `Bash(git -C * ls-remote*)` is remote-code-execution, not a read. `git ls-remote --upload-pack=<cmd>` (or short `-o <cmd>`) **executes `<cmd>` locally** before the transport even resolves — proven live:
```
git -C /tmp ls-remote --upload-pack="sh -c 'id > /tmp/pwned'" /x   # ran the shell
```
The trailing-`*` glob permits that suffix with **no** `$VAR`/`&&`/`;`/`|`/`$()`/redirect, so it slips past every harness filter **and** the bash-guard **and** matches the allowlist glob — and the pass runs `claude -p --allowedTools` with **no `--permission-mode plan`**, so it **auto-executes** over untrusted civitai *client* ticket text. Attacker-filed ClickUp ticket → haiku emits the command → arbitrary code execution as Zach's uid (clawgate token, prod kubeconfigs, SSH keys, mail creds, egress to exfil). This is the exact flag-injection class that (correctly) keeps `gh api` out.

**The fix:** a prefix glob **cannot** forbid `--upload-pack`/`-o`/`--exec`, so `ls-remote*` cannot be safely narrowed — it was **removed**, not narrowed. Its only purpose ("is X merged / on trunk?") is already fully covered by the `merge-base --is-ancestor` / `branch --contains` / `rev-list` verbs.

Allowlist diff (this round):
```
-Bash(git -C * ls-remote*),
```

New guard test `test_allowlist_has_no_arbitrary_command_flag_verbs` blocks re-adding **any** git subcommand that accepts a remote-helper/exec flag (`ls-remote`/`fetch`/`clone`/`pull`/`push`/`daemon`/`archive`/`remote`/`submodule`) and any raw `--upload-pack`/`--receive-pack`/`--exec` token. Negative control confirmed it fires on a re-added `ls-remote`.

```
19 passed   # scripts/task-spec-drafter/tests/test_shadow_wiring.py (was 18; +1 guard, -0 net after removing the ls-remote present-assertion)
RESULT: PASS  # full hermetic set (scripts/run-tests.sh --set hermetic) — all 13 dirs + hook script
bash -n scripts/task-spec-drafter/drafter.sh  → OK
```

### Noted follow-up (🟡, NOT in this PR — keep the blocker fix tight)
The audit also flagged (non-blocking) that `git -C * cat-file*` and the pre-existing `log*`/`show*` allow `-C <any path>` reads of **other** repos. Once `ls-remote` is gone there is **no allowlisted egress channel**, so this is incremental/low-risk. The broader hardening — scope every `git -C` entry to the civitai repo path — is left as a **follow-up**, deliberately not implemented here.

---


## Why

A 4-day session **gametape** found the task-spec-drafter's #1 friction is its own **read-only verification calls getting denied or mis-shaped** inside the headless `claude -p` pass: across ~63 drafter runs, **57 `permission_block`** + **89 `wrong_approach`** events — almost entirely the drafter's own read verbs. This is the bounded **runtime** fix (allowlist + prompt hardening), not the larger `repo-query` wrapper.

## What changed (3 root causes → 3 fixes)

### 1. Expanded `DRAFTER_ALLOWED_TOOLS` with the missing read-only merge/ref verbs
"Is commit X merged / on trunk?" had **no allowlisted answer verb** → `requires approval` → dead in headless. Added (each justified inline as strictly read-only):

| Verb (allowlist entry) | Read-only justification |
|---|---|
| `git -C * branch --contains*` | Lists branches containing a commit. **Narrowed** to `--contains` — a bare `branch*` glob would also match `git branch <name>` (create) and `git branch -d/-D` (delete), which are **writes**. |
| `git -C * rev-parse*` | Resolves refs→SHA / current branch. No write mode. |
| `git -C * rev-list*` | Lists commit ranges/counts. No write mode. |
| `git -C * merge-base*` | Common ancestor; `merge-base --is-ancestor` **is** the merged check. No write mode. |
| `git -C * for-each-ref*` | Enumerates refs. No write mode. |
| `git -C * symbolic-ref --short*` | **Narrowed** — bare `symbolic-ref HEAD <ref>` (2-arg) repoints HEAD (a write); `--short <ref>` only reads. |
| `git -C * ls-files*` | Lists tracked files. No write mode. |
| `git -C * cat-file*` | Inspects objects (`-p/-t/-e/--batch`). No write mode. |
| `git -C * ls-remote*` | Queries a remote's refs. No write mode. |
| `gh pr checks*` | Read-only CI check-run status for a PR. |

**`gh api` was deliberately NOT added**, despite the gametape listing it: a prefix glob **cannot** forbid `-X POST/PATCH/DELETE` while allowing the GET default, so it stays an injection→mutation path (the pass reasons over untrusted *client* ticket text with no plan mode). Merge/PR reality is fully answerable via the git plumbing verbs above + `gh pr list/view/checks/search`. This keeps `test_allowlist_has_no_write_capable_verbs` passing — the CRITICAL invariant in the brief overrides the softer "add gh api" mention. **Flagging for your call.**

### 2. Command-SHAPE contract in `drafter-prompt.md`
The harness rejects the shapes the model defaults to. Added a loud contract + a concrete REJECTED→DO-THIS table mandating: **ONE `git -C <ABSOLUTE-PATH> <verb>` read per Bash call**; **NEVER** `cd`; **NEVER** a shell var like `$CIVITAI` (does not expand → `Contains simple_expansion`); **NEVER** compound `&&`/`;`/pipes.

> Honest flag: this half is **prose/prompt**, not deterministic. The deterministic endgame is a `repo-query`/`ticket-status` wrapper that fixes the shape at the source — **out of scope here**, noted as the follow-up.

### 3. Anti-confabulation gate
One run emitted a verdict (`no commits/PRs/alerts found`) having run **ZERO** tools — a fabricated verification. Added a hard prompt constraint: the pipeline **MUST run ≥1 successful read** (git/gh/clickup/kubectl) before emitting ANY factual verdict; if no source was reachable, it must emit **low-confidence `NEEDS-DECISION`** and say so in `verification`, never assert a negative finding it didn't observe.

> Enforced in the **prompt**, not `drafter.sh`: the script captures only the model's final JSON text (no tool-call transcript), so there's no cheap deterministic tool-count signal without switching to `--output-format stream-json`. Noted as the deterministic follow-up.

## Tests
Extended `tests/test_shadow_wiring.py`:
- `test_allowlist_adds_merge_status_readonly_verbs` — the 10 new read verbs are present.
- `test_allowlist_has_no_write_capable_verbs` (existing) — reinforced: broad `git -C * branch*` / `git -C * symbolic-ref*` globs asserted **ABSENT** (only the narrowed read shapes allowed); no `push`/`commit`/`apply`/`reset`/`checkout`/`tag`/`update-ref`; `gh api`/`curl`/`env` still out.
- `test_prompt_has_command_shape_contract` + `test_prompt_has_anticonfab_gate` + `test_prompt_still_forbids_gh_api_and_curl`.

```
18 passed   # scripts/task-spec-drafter/tests/test_shadow_wiring.py
465 passed  # full hermetic set (scripts/tests + scripts/task-spec-drafter/tests + …)
bash -n scripts/task-spec-drafter/drafter.sh  → OK
```

## Not done (scope discipline)
No `repo-query`/`ticket-status` wrapper; no triage-logic / ClickUp-query changes; no systemd unit changes.

## Final live confirmation left to Zach
A full drafter pass needs ClickUp creds + costs a model call, so it was **not** run. To confirm end-to-end (shadow, cheap, scratch dir):

```bash
DRAFTER_MODE=shadow DRAFTER_MAX_TICKETS=3 DRAFTER_OUT_DIR=/tmp/drafter \
  /home/zach/workspace/devrc/scripts/task-spec-drafter/drafter.sh
```
Then check `/tmp/drafter/drafter.log` for permission-denied lines on the new verbs and that verdicts cite real reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)