### PR TITLE
feat(initiatives): read-only Q&A assistant + sidebar chat

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -864,6 +864,15 @@ in
         "ACTIVITY_HOST=workbench"
         "INITIATIVES_VIEWER_HOST=192.168.50.250"
         "INITIATIVES_VIEWER_PORT=8899"
+        # Local model for the read-only Q&A sidebar (POST /api/ask): the SAME homelab vLLM
+        # the recap generator uses (ns promptver, svc/vllm-recap:8000, served model "recap").
+        # The assistant opens/tears down a kubectl port-forward per ask; a model outage
+        # degrades to the deterministic answer, so this is best-effort.
+        "INITIATIVES_RECAP_ENABLED=1"
+        "RECAP_NAMESPACE=promptver"
+        "RECAP_SERVICE=svc/vllm-recap"
+        "RECAP_SERVICE_PORT=8000"
+        "RECAP_MODEL=recap"
         "HOME=%h"
       ];
       ExecStart = "${pkgs.bash}/bin/bash %h/workspace/devrc/scripts/initiatives/run-viewer.sh";

--- a/scripts/initiatives/assistant.py
+++ b/scripts/initiatives/assistant.py
@@ -1,0 +1,876 @@
+#!/usr/bin/env python3
+"""Read-only "initiatives assistant" — natural-language Q&A + routing over the store.
+
+PHASE 1 of the "initiatives agent" (the deliberately RE-SCOPED phase from the red-team
+eval `claudedocs/initiatives-agent-proposal-eval-2026-07-24.md`). It is a plain Python
+assistant over the EXISTING initiatives store + `route()` + the local model. There is
+NO containerized runtime, NO clawgate/openclaw, NO MCP, NO dispatch, and — the load-
+bearing property — NO path that MUTATES state, dispatches work, writes a handoff, or
+reaches outside the initiatives store. Every tool below is strictly READ-ONLY.
+
+Why read-only matters (respect this boundary): the eval's core finding is that a
+write/dispatch agent's safety gate would be *voluntary* (prompt-injection-defeatable).
+Phase 1 sidesteps ALL of that: the worst case of a prompt-injected handoff/status the
+model reads is a weird ANSWER, never an action. Do not add a mutating tool here.
+
+Shape (robust on a small local model — Qwen2.5-7B via the homelab `vllm-recap` endpoint):
+  we do NOT ask the 7B to plan multi-step tool use. Instead the flow is mostly
+  DETERMINISTIC and the model is used only for the two things it is good at:
+    (a) fuzzy question -> intent/args mapping (ONLY when the deterministic classifier
+        is unsure), and
+    (b) phrasing a natural, grounded answer over the tool's REAL output.
+  The deterministic tool output is the GROUND TRUTH. `sources` (which initiatives the
+  answer draws from) is computed deterministically from that output — never from the
+  model — so answers stay auditable and anti-confabulation holds even if the model
+  hallucinates. If the model or the store is unreachable we DEGRADE GRACEFULLY: the
+  deterministic tool result is rendered plainly (or a clear error) — we never crash.
+
+Layering (mirrors route.py / viewer.py): the PURE logic (intent parsing, the tool
+queries, the plain renderer, the fact projection) is separated from all I/O (the store
+read, the model call) so it is unit-testable with fixtures — no live DB, no live model.
+
+Reuse (do not reimplement):
+  - the store read + the normalized initiative "view" dicts: `viewer.load_latest` +
+    `viewer.attach_tmux` + `viewer.build_model` (its `flat` list is exactly the shape
+    the tools want). Imported lazily to avoid a viewer<->assistant import cycle.
+  - routing / name-matching: `route.rank_matches` (the scan's single-sourced token
+    matcher) powers both `route_signal` and the fuzzy "which initiative is X" lookup.
+  - the handoff read: `viewer.read_doc_detail_live` (the size-capped, traversal-guarded
+    reader) — never a raw open().
+  - the model client: `recap.VllmClient` + `recap.recap_config` (the OpenAI-compatible
+    call over the kubectl port-forward, same endpoint the recap generator uses).
+
+CLI:
+    assistant.py "what's blocked on me?"
+    assistant.py --json "status of clawgate"
+On NixOS (for the live read/model) run under:
+    nix-shell -p "python3.withPackages(p:[p.psycopg2 p.requests])" \
+      --run 'python scripts/initiatives/assistant.py "what am I working on?"'
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Sibling modules in this same directory. route/viewer/recap are imported LAZILY (inside
+# the functions that need them) so that (a) the viewer<->assistant pair has no import
+# cycle, and (b) merely importing `assistant` (e.g. for a unit test of the pure core)
+# costs nothing and needs no psycopg2/requests.
+_ROUTE_PATH = Path(__file__).resolve().parent / "route.py"
+_RECAP_PATH = Path(__file__).resolve().parent / "recap.py"
+_VIEWER_PATH = Path(__file__).resolve().parent / "viewer.py"
+
+_route_mod = None
+_recap_mod = None
+_viewer_mod = None
+
+
+def _load_sibling(path: Path, mod_name: str):
+    """Load a sibling module by explicit importlib path and return it.
+
+    Used for viewer/recap/route so a `python assistant.py` run (sys.path[0] = this dir)
+    AND a test that only inserts this dir both resolve them, without depending on package
+    layout — and without importing them at module load (keeping the pure-core import
+    side-effect free)."""
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _route():
+    global _route_mod
+    if _route_mod is None:
+        _route_mod = _load_sibling(_ROUTE_PATH, "initiatives_assistant_route")
+    return _route_mod
+
+
+def _recap():
+    global _recap_mod
+    if _recap_mod is None:
+        _recap_mod = _load_sibling(_RECAP_PATH, "initiatives_assistant_recap")
+    return _recap_mod
+
+
+def _viewer():
+    global _viewer_mod
+    if _viewer_mod is None:
+        _viewer_mod = _load_sibling(_VIEWER_PATH, "initiatives_assistant_viewer")
+    return _viewer_mod
+
+
+# --------------------------------------------------------------------------- #
+# Intents — the fixed, enumerated question shapes the assistant understands.
+# --------------------------------------------------------------------------- #
+INTENTS = (
+    "blocked_on_me",   # what's waiting on me / awaiting my input / my call
+    "active",          # what's active / in flight / what am I working on
+    "slowing",         # what's slowing / losing momentum
+    "stalled",         # what's stalled / stuck / gone quiet
+    "most_recent",     # what did I touch last / most recently active
+    "live_sessions",   # what's running right now (live tmux)
+    "status_of",       # status of / where did I leave <named initiative>   (-> target)
+    "by_repo",         # what's in <repo> / group by repo                    (-> target?)
+    "route",           # which initiative does <X> belong to / triage <X>    (-> target)
+    "handoff",         # read the handoff / more detail on <named initiative> (-> target)
+    "overview",        # catch-all: what are my initiatives
+)
+
+# Text markers that mean "this initiative is waiting on the human" — scanned across an
+# initiative's action-oriented fields (status + next_step, per the spec) plus summary/
+# identity for recall. Kept as a tunable module constant (unit-tested), NOT a prose
+# instruction to the model.
+BLOCKED_MARKERS = (
+    "awaiting", "blocked on", "blocked", "your call", "your input", "your decision",
+    "your review", "your sign-off", "your signoff", "your go-ahead", "your go ahead",
+    "waiting on you", "waiting for you", "waiting on zach", "waiting for zach",
+    "needs you", "needs zach", "need zach", "need you to", "pending your",
+    "up to zach", "for zach to", "hand to the user", "hand it to the user",
+    "human deploys", "human verif", "you deploy", "eyeball",
+)
+
+# How many initiatives (max) to hand the model as grounding facts, and per-field trims —
+# keep the 7B's context small + on-topic.
+_MODEL_FACT_CAP = 14
+_FACT_TEXT_TRIM = 220
+_QUESTION_MAX = 2000  # cap an incoming question (CLI + /api/ask) — abuse/context guard
+
+# Model call sizing (the recap client defaults to a tiny 160-token cap tuned for a 1-line
+# recap; a chat answer wants a little more room, classification almost none).
+_SYNTH_MAX_TOKENS = 320
+_SYNTH_TEMPERATURE = 0.2
+_CLASSIFY_MAX_TOKENS = 64
+_CLASSIFY_TEMPERATURE = 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Small pure helpers.
+# --------------------------------------------------------------------------- #
+def _short(repo) -> str:
+    return os.path.basename(str(repo).rstrip("/")) if repo else ""
+
+
+def _trim(text, n: int) -> str:
+    s = (text or "").strip()
+    return s if len(s) <= n else s[: n - 1].rstrip() + "…"
+
+
+def _clean_target(text: str) -> str:
+    """Normalize an extracted initiative name / signal: strip trailing punctuation,
+    quotes, and filler words a natural question wraps the name in."""
+    t = (text or "").strip().strip("?.!,:;\"'` ").strip()
+    t = re.sub(r"^(the|my|our)\s+", "", t, flags=re.I)
+    t = re.sub(r"\s+(initiative|project|work|thread|effort)$", "", t, flags=re.I)
+    t = re.sub(r"\s+(going|doing|coming along|at|now|these days)$", "", t, flags=re.I)
+    return t.strip()
+
+
+# --------------------------------------------------------------------------- #
+# Intent classification — DETERMINISTIC first (pure, unit-tested). The model only
+# refines an `overview` fallback (see `ask`), never overrides a confident parse.
+# --------------------------------------------------------------------------- #
+# (pattern, intent, capture-group-is-target) — evaluated in order, most specific first.
+# A capturing group, when present, yields the target/signal for that intent.
+_PATTERNS: list[tuple[re.Pattern, str, bool]] = [
+    # -- routing / triage (needs a signal) --
+    (re.compile(r"which initiative(?:\s+does)?\s+(.+?)\s+(?:belong|relate|go|fit)", re.I), "route", True),
+    (re.compile(r"where does\s+(.+?)\s+(?:belong|go|fit)", re.I), "route", True),
+    (re.compile(r"\b(?:route|triage)\b\s+(?:this\s+)?(.+)", re.I), "route", True),
+    (re.compile(r"what initiative is\s+(.+?)\s+(?:part of|related to)", re.I), "route", True),
+    # -- handoff / deep detail on a named initiative --
+    (re.compile(r"(?:read|open|show)\s+(?:me\s+)?the handoff\s+(?:doc\s+)?(?:for|on|of)\s+(.+)", re.I), "handoff", True),
+    (re.compile(r"handoff\s+(?:doc\s+)?(?:for|on|of)\s+(.+)", re.I), "handoff", True),
+    (re.compile(r"(?:full\s+)?details?\s+(?:on|for|about)\s+(.+)", re.I), "handoff", True),
+    (re.compile(r"tell me (?:more|everything)\s+about\s+(.+)", re.I), "handoff", True),
+    # -- blocked on me (the headline ask) --
+    (re.compile(r"blocked on (?:me|you|zach)", re.I), "blocked_on_me", False),
+    (re.compile(r"waiting (?:on|for) (?:me|you|zach)", re.I), "blocked_on_me", False),
+    (re.compile(r"(?:needs?|require[sd]?)\s+(?:my|your)\s+(?:input|call|decision|review|sign)", re.I), "blocked_on_me", False),
+    (re.compile(r"what(?:'s| is)?\s+(?:blocking|blocked|waiting)(?:\s+on\s+me)?\b", re.I), "blocked_on_me", False),
+    (re.compile(r"what needs (?:me|my)\b", re.I), "blocked_on_me", False),
+    (re.compile(r"\b(?:my|your)\s+(?:call|input|decision|sign-?off|go-?ahead)\b", re.I), "blocked_on_me", False),
+    (re.compile(r"awaiting\s+(?:me|my|zach)", re.I), "blocked_on_me", False),
+    # -- momentum buckets --
+    (re.compile(r"\b(?:stalled|stuck|abandoned|gone quiet|dropped|dormant)\b", re.I), "stalled", False),
+    (re.compile(r"\b(?:slowing|losing momentum|cooling|slowed down)\b", re.I), "slowing", False),
+    # -- live sessions right now --
+    (re.compile(r"\blive session", re.I), "live_sessions", False),
+    (re.compile(r"running (?:right )?now", re.I), "live_sessions", False),
+    (re.compile(r"what(?:'s| is)?\s+running\b", re.I), "live_sessions", False),
+    (re.compile(r"\bin tmux\b|tmux session", re.I), "live_sessions", False),
+    (re.compile(r"what (?:am i|are we) running", re.I), "live_sessions", False),
+    # -- most recently active --
+    (re.compile(r"most recent(?:ly)?(?:\s+active)?", re.I), "most_recent", False),
+    (re.compile(r"last (?:touched|worked on|active)", re.I), "most_recent", False),
+    (re.compile(r"what did i (?:last|just)\b", re.I), "most_recent", False),
+    (re.compile(r"\blatest\b", re.I), "most_recent", False),
+    # -- status of a NAMED initiative (capture the name) --
+    (re.compile(r"status(?:\s+of|\s+on)\s+(.+)", re.I), "status_of", True),
+    (re.compile(r"state of\s+(.+)", re.I), "status_of", True),
+    (re.compile(r"where did i leave\s+(?:off\s+(?:on|with)\s+)?(.+)", re.I), "status_of", True),
+    (re.compile(r"what(?:'s| is)?\s+(?:happening|going on|up)\s+(?:with|on|for)\s+(.+)", re.I), "status_of", True),
+    (re.compile(r"update on\s+(.+)", re.I), "status_of", True),
+    (re.compile(r"how(?:'s| is| are)\s+(.+?)\s+(?:going|doing|coming along|progressing)", re.I), "status_of", True),
+    # -- by repo (optional target repo) --
+    (re.compile(r"group(?:ed)? by repo|by repo\b", re.I), "by_repo", False),
+    (re.compile(r"(?:initiatives?|work|what(?:'s| is)?)\s+in (?:the\s+)?(.+?)\s+repo", re.I), "by_repo", True),
+    (re.compile(r"what(?:'s| is)?\s+in (?:the\s+)?([a-z0-9._-]+)\s*\??$", re.I), "by_repo", True),
+    # -- active / in flight / what am I working on --
+    (re.compile(r"what am i working on", re.I), "active", False),
+    (re.compile(r"in[- ]flight|in flight", re.I), "active", False),
+    (re.compile(r"\b(?:active|in progress)\b", re.I), "active", False),
+    (re.compile(r"what(?:'s| is)?\s+(?:going on|current|cooking)\b", re.I), "active", False),
+    # -- overview / list all --
+    (re.compile(r"what are (?:all )?my initiatives|list (?:my )?initiatives|overview|everything", re.I), "overview", False),
+]
+
+
+def classify_intent(question: str) -> dict:
+    """PURE: question -> {"intent", "target"}.
+
+    Deterministic keyword/regex matching, most-specific first. `target` is the extracted
+    initiative name (status_of/handoff/by_repo) or free signal (route), cleaned; "" when
+    the intent takes no argument or none was found. Returns intent="overview" (the safe
+    catch-all) when nothing matches — the caller may then ask the model to refine (best-
+    effort) before falling back to a broad summary."""
+    q = (question or "").strip()
+    if not q:
+        return {"intent": "overview", "target": ""}
+    for pat, intent, is_target in _PATTERNS:
+        m = pat.search(q)
+        if not m:
+            continue
+        target = ""
+        if is_target and m.groups():
+            target = _clean_target(m.group(1))
+        return {"intent": intent, "target": target}
+    return {"intent": "overview", "target": ""}
+
+
+# --------------------------------------------------------------------------- #
+# READ-ONLY tools — PURE functions over the normalized initiative "view" list
+# (viewer.build_model's `flat`). Each returns a structured result whose facts are the
+# ground truth for both the model synthesis and the deterministic `sources`/renderer.
+# --------------------------------------------------------------------------- #
+def _blocking_hits(view: dict) -> list[str]:
+    """The BLOCKED_MARKERS that appear in an initiative's action fields (status +
+    next_step, per spec) plus its summary/identity (recall). Empty => not blocked."""
+    hay = " ".join([
+        str(view.get("status") or ""), str(view.get("next_step") or ""),
+        str(view.get("summary") or ""), str(view.get("identity") or ""),
+    ]).lower()
+    return [mk for mk in BLOCKED_MARKERS if mk in hay]
+
+
+def tool_blocked_on_me(views: list[dict]) -> dict:
+    """Initiatives whose status/next_step (etc.) say they are waiting on the human."""
+    hits = []
+    for v in views:
+        marks = _blocking_hits(v)
+        if marks:
+            hits.append({"view": v, "markers": marks})
+    hits.sort(key=lambda h: _recency_key(h["view"]))
+    return {"kind": "blocked_on_me", "initiatives": [h["view"] for h in hits],
+            "markers": {h["view"].get("slug"): h["markers"] for h in hits}}
+
+
+def tool_by_momentum(views: list[dict], momentum: str) -> dict:
+    inis = [v for v in views if (v.get("momentum") or "unknown") == momentum]
+    inis.sort(key=_recency_key)
+    return {"kind": momentum, "initiatives": inis}
+
+
+def tool_most_recent(views: list[dict], n: int = 1) -> dict:
+    ordered = sorted(views, key=_recency_key)
+    return {"kind": "most_recent", "initiatives": ordered[: max(1, n)]}
+
+
+def tool_live_sessions(views: list[dict], unmatched: list[dict] | None) -> dict:
+    """Initiatives with a live tmux session right now, plus the untracked live panes."""
+    tied = [v for v in views if v.get("live_tasks") or v.get("tmux_sessions")]
+    tied.sort(key=_recency_key)
+    return {"kind": "live_sessions", "initiatives": tied,
+            "untracked": list(unmatched or [])}
+
+
+def tool_by_repo(views: list[dict], target: str = "") -> dict:
+    """Group initiatives by repo; if `target` names a repo, scope to it."""
+    want = _short(target).lower() if target else ""
+    groups: dict[str, list[dict]] = {}
+    for v in views:
+        name = v.get("repo_name") or _short(v.get("repo")) or "(unknown)"
+        if want and want not in name.lower():
+            continue
+        groups.setdefault(name, []).append(v)
+    for inis in groups.values():
+        inis.sort(key=_recency_key)
+    flat = [v for inis in groups.values() for v in inis]
+    return {"kind": "by_repo", "target": target,
+            "groups": {k: groups[k] for k in sorted(groups)}, "initiatives": flat}
+
+
+def tool_status_of(views: list[dict], target: str) -> dict:
+    """Fuzzy-find the named initiative(s) via the SAME token matcher the router uses
+    (route.rank_matches over the view dicts, which already carry slug/repo/title), then
+    return the FULL views for the top matches — single-sourced name resolution."""
+    target = (target or "").strip()
+    if not target or not views:
+        return {"kind": "status_of", "target": target, "initiatives": [], "ranked": []}
+    ranked = _route().rank_matches(target, views, limit=5)
+    by_key = {(v.get("repo"), v.get("slug")): v for v in views}
+    matched: list[dict] = []
+    for r in ranked:
+        v = by_key.get((r.get("repo"), r.get("slug")))
+        if v is not None:
+            matched.append(v)
+    # If the matcher found nothing (no shared token), fall back to a plain substring scan
+    # so a partial name a human types ("clawgate") still resolves even below the token bar.
+    if not matched:
+        tl = target.lower()
+        matched = [v for v in views
+                   if tl in str(v.get("slug") or "").lower()
+                   or tl in str(v.get("title") or "").lower()]
+        matched.sort(key=_recency_key)
+    return {"kind": "status_of", "target": target,
+            "initiatives": matched[:5], "ranked": ranked}
+
+
+def tool_route(views: list[dict], signal: str) -> dict:
+    """Delegate to route.rank_matches: which existing initiative(s) does this signal
+    belong to? Returns the ranking + the verdict (confident match vs likely new work)."""
+    route = _route()
+    ranked = route.rank_matches(signal or "", views, limit=5)
+    return {"kind": "route", "signal": signal, "ranked": ranked,
+            "verdict": route.classify(ranked)}
+
+
+def tool_overview(views: list[dict]) -> dict:
+    buckets: dict[str, list[dict]] = {"active": [], "slowing": [], "stalled": [],
+                                      "unknown": []}
+    for v in views:
+        buckets.setdefault(v.get("momentum") or "unknown", buckets["unknown"]).append(v)
+    for inis in buckets.values():
+        inis.sort(key=_recency_key)
+    return {"kind": "overview", "initiatives": sorted(views, key=_recency_key),
+            "buckets": buckets, "total": len(views)}
+
+
+def tool_read_handoff(views: list[dict], target: str, reader=None) -> dict:
+    """Resolve the named initiative (via tool_status_of), then read its handoff doc off
+    disk through viewer's size-capped, traversal-guarded reader. `reader` is injectable
+    (repo, current_doc) -> detail|None for tests. Read-only; None on any guard failure."""
+    resolved = tool_status_of(views, target)
+    inis = resolved["initiatives"]
+    if not inis:
+        return {"kind": "handoff", "target": target, "initiative": None, "detail": None}
+    v = inis[0]
+    if reader is None:
+        reader = _viewer().read_doc_detail_live
+    detail = None
+    try:
+        detail = reader(v.get("repo"), v.get("current_doc"))
+    except Exception:  # noqa: BLE001 - a read hiccup degrades to the stored fields
+        detail = None
+    return {"kind": "handoff", "target": target, "initiative": v, "detail": detail}
+
+
+def _recency_key(v: dict):
+    """Sort key: most-recently-active first (last_touch DESC, None last)."""
+    lt = v.get("last_touch")
+    ts = None
+    if hasattr(lt, "timestamp"):
+        try:
+            ts = lt.timestamp()
+        except Exception:  # noqa: BLE001
+            ts = None
+    return (-(ts if ts is not None else float("-inf")), v.get("slug") or "")
+
+
+def run_tool(intent: str, info: dict, views: list[dict],
+             unmatched: list[dict] | None) -> dict:
+    """Dispatch a classified intent to its READ-ONLY tool. The returned dict's facts are
+    the ground truth for both `sources_of` and the model synthesis."""
+    target = info.get("target") or ""
+    if intent == "blocked_on_me":
+        return tool_blocked_on_me(views)
+    if intent in ("active", "slowing", "stalled"):
+        return tool_by_momentum(views, intent)
+    if intent == "most_recent":
+        return tool_most_recent(views, n=3)
+    if intent == "live_sessions":
+        return tool_live_sessions(views, unmatched)
+    if intent == "by_repo":
+        return tool_by_repo(views, target)
+    if intent == "status_of":
+        return tool_status_of(views, target)
+    if intent == "route":
+        return tool_route(views, target)
+    if intent == "handoff":
+        return tool_read_handoff(views, target)
+    return tool_overview(views)
+
+
+# --------------------------------------------------------------------------- #
+# Sources — DETERMINISTIC citation of which initiatives an answer draws from. Computed
+# from the tool result, NEVER from the model (the anti-confabulation anchor).
+# --------------------------------------------------------------------------- #
+def sources_of(result: dict) -> list[dict]:
+    """The initiatives the tool result references -> [{slug, repo}] (de-duped, order
+    preserved). For `route` these are the ranked candidates; for `handoff` the one
+    resolved initiative; otherwise the returned initiative list."""
+    out: list[dict] = []
+    seen: set = set()
+
+    def _add(slug, repo):
+        key = (repo, slug)
+        if slug and key not in seen:
+            seen.add(key)
+            out.append({"slug": slug, "repo": _short(repo)})
+
+    kind = result.get("kind")
+    if kind == "route":
+        for r in result.get("ranked", []):
+            _add(r.get("slug"), r.get("repo"))
+    elif kind == "handoff":
+        v = result.get("initiative")
+        if v:
+            _add(v.get("slug"), v.get("repo"))
+    else:
+        for v in result.get("initiatives", []):
+            _add(v.get("slug"), v.get("repo"))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Model grounding — a COMPACT, on-topic facts projection handed to the 7B (kept small).
+# --------------------------------------------------------------------------- #
+def _fact(v: dict, blocking: list[str] | None = None) -> dict:
+    f = {
+        "slug": v.get("slug"),
+        "repo": v.get("repo_name") or _short(v.get("repo")),
+        "momentum": v.get("momentum") or "unknown",
+        "updated": v.get("age") or "?",
+        "next_step": _trim(v.get("next_step"), _FACT_TEXT_TRIM),
+        "status": _trim(v.get("status") or v.get("summary") or v.get("identity"),
+                        _FACT_TEXT_TRIM),
+        "live": bool(v.get("live_tasks") or v.get("tmux_sessions")),
+    }
+    if blocking:
+        f["waiting_on_you_because"] = ", ".join(blocking)
+    return {k: val for k, val in f.items() if val not in ("", None, False)}
+
+
+def build_facts(result: dict) -> dict:
+    """The ground-truth JSON handed to the model — small, on-topic, and derived ONLY from
+    the deterministic tool result (so the model has nothing to confabulate from)."""
+    kind = result.get("kind")
+    markers = result.get("markers") or {}
+    if kind == "route":
+        ranked = result.get("ranked", [])
+        return {
+            "kind": kind,
+            "signal": result.get("signal"),
+            "verdict": result.get("verdict"),
+            "candidates": [
+                {"slug": r.get("slug"), "repo": _short(r.get("repo")),
+                 "score": r.get("score"), "confident": r.get("confident")}
+                for r in ranked[:_MODEL_FACT_CAP]
+            ],
+        }
+    if kind == "handoff":
+        v = result.get("initiative")
+        detail = result.get("detail") or {}
+        if not v:
+            return {"kind": kind, "target": result.get("target"), "found": False}
+        return {
+            "kind": kind, "found": True, "initiative": _fact(v),
+            "summary": _trim(detail.get("summary") or v.get("summary"), 400),
+            "next_steps": [_trim(s, 200) for s in (detail.get("next_steps") or [])][:6],
+            "open_investigations":
+                [_trim(s, 200) for s in (detail.get("open_investigations") or [])][:6],
+        }
+    if kind == "live_sessions":
+        return {
+            "kind": kind,
+            "live_initiatives": [_fact(v) for v in result.get("initiatives", [])[:_MODEL_FACT_CAP]],
+            "untracked_session_count": len(result.get("untracked", [])),
+        }
+    # filter / momentum / status_of / most_recent / overview / by_repo
+    inis = result.get("initiatives", [])
+    facts = {
+        "kind": kind,
+        "count": len(inis),
+        "initiatives": [_fact(v, markers.get(v.get("slug"))) for v in inis[:_MODEL_FACT_CAP]],
+    }
+    if result.get("target"):
+        facts["asked_about"] = result["target"]
+    return facts
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic answer renderer — the graceful-degradation path (model down/unset) AND
+# the fallback when synthesis fails. Pure; unit-tested.
+# --------------------------------------------------------------------------- #
+def _one_line(v: dict) -> str:
+    bits = [str(v.get("slug") or "?")]
+    repo = v.get("repo_name") or _short(v.get("repo"))
+    if repo:
+        bits.append(f"({repo})")
+    mom = v.get("momentum")
+    if mom and mom != "unknown":
+        bits.append(f"· {mom}")
+    if v.get("age"):
+        bits.append(f"· updated {v['age']} ago")
+    line = " ".join(bits)
+    tail = _trim(v.get("next_step") or v.get("status") or v.get("summary"), 160)
+    return f"{line} — {tail}" if tail else line
+
+
+def render_plain(intent: str, info: dict, result: dict) -> str:
+    """PURE: a readable text answer from the tool result WITHOUT the model."""
+    kind = result.get("kind")
+    inis = result.get("initiatives", [])
+
+    if kind == "blocked_on_me":
+        if not inis:
+            return "Nothing looks blocked on you right now."
+        lines = [f"{len(inis)} initiative(s) look blocked on you:"]
+        lines += [f"  • {_one_line(v)}" for v in inis]
+        return "\n".join(lines)
+
+    if kind in ("active", "slowing", "stalled"):
+        if not inis:
+            return f"No {kind} initiatives right now."
+        lines = [f"{len(inis)} {kind} initiative(s):"]
+        lines += [f"  • {_one_line(v)}" for v in inis]
+        return "\n".join(lines)
+
+    if kind == "most_recent":
+        if not inis:
+            return "No initiatives found."
+        top = inis[0]
+        head = f"Most recently active: {_one_line(top)}"
+        if len(inis) > 1:
+            head += "\nAlso recent:\n" + "\n".join(f"  • {_one_line(v)}" for v in inis[1:])
+        return head
+
+    if kind == "live_sessions":
+        untracked = result.get("untracked", [])
+        if not inis and not untracked:
+            return "No live sessions running right now."
+        lines = []
+        if inis:
+            lines.append(f"{len(inis)} initiative(s) have a live session:")
+            for v in inis:
+                task = (v.get("live_tasks") or [v.get("live_task")] or [""])[0] or ""
+                lines.append(f"  • {v.get('slug')} — {_trim(task, 140)}" if task
+                             else f"  • {v.get('slug')}")
+        if untracked:
+            lines.append(f"{len(untracked)} live session(s) not tied to an initiative.")
+        return "\n".join(lines)
+
+    if kind == "by_repo":
+        groups = result.get("groups") or {}
+        if not groups:
+            tgt = result.get("target")
+            return (f"No initiatives in a repo matching '{tgt}'." if tgt
+                    else "No initiatives found.")
+        lines = []
+        for repo, items in groups.items():
+            lines.append(f"{repo} ({len(items)}):")
+            lines += [f"  • {_one_line(v)}" for v in items]
+        return "\n".join(lines)
+
+    if kind == "status_of":
+        if not inis:
+            return f"Couldn't find an initiative matching '{result.get('target')}'."
+        top = inis[0]
+        out = [_one_line(top)]
+        if top.get("status"):
+            out.append(f"  current › {_trim(top.get('status'), 200)}")
+        if top.get("next_step"):
+            out.append(f"  next › {_trim(top.get('next_step'), 200)}")
+        if len(inis) > 1:
+            out.append("Other possible matches: "
+                       + ", ".join(v.get("slug") for v in inis[1:]))
+        return "\n".join(out)
+
+    if kind == "route":
+        ranked = result.get("ranked", [])
+        head = f"'{result.get('signal')}' → {result.get('verdict')}"
+        if not ranked:
+            return head + "\n  (no existing initiative shares a meaningful token.)"
+        rows = [f"  • {r.get('slug')} ({_short(r.get('repo'))}) "
+                f"score={r.get('score')}{' ✓' if r.get('confident') else ''}"
+                for r in ranked]
+        return head + "\n" + "\n".join(rows)
+
+    if kind == "handoff":
+        v = result.get("initiative")
+        if not v:
+            return f"Couldn't find an initiative matching '{result.get('target')}'."
+        detail = result.get("detail") or {}
+        out = [_one_line(v)]
+        summ = _trim(detail.get("summary") or v.get("summary"), 400)
+        if summ:
+            out.append(summ)
+        ns = detail.get("next_steps") or []
+        if ns:
+            out.append("Next steps:")
+            out += [f"  • {_trim(s, 200)}" for s in ns[:6]]
+        oi = detail.get("open_investigations") or []
+        if oi:
+            out.append("Open investigations:")
+            out += [f"  • {_trim(s, 200)}" for s in oi[:6]]
+        return "\n".join(out)
+
+    # overview
+    if not inis:
+        return "No initiatives in the latest snapshot."
+    buckets = result.get("buckets") or {}
+    parts = [f"You have {len(inis)} initiative(s) in flight."]
+    for name in ("active", "slowing", "stalled"):
+        b = buckets.get(name) or []
+        if b:
+            parts.append(f"{name.capitalize()} ({len(b)}): "
+                         + ", ".join(v.get("slug") for v in b[:8]))
+    return "\n".join(parts)
+
+
+# --------------------------------------------------------------------------- #
+# Model I/O — best-effort intent refine + grounded answer synthesis.
+# --------------------------------------------------------------------------- #
+_SYNTH_SYSTEM = (
+    "You are the initiatives assistant for Zach — you answer questions about his ongoing "
+    "engineering work initiatives. You are given DATA: the exact, ground-truth result of a "
+    "deterministic query over his initiatives store. Rules you MUST follow:\n"
+    "1. Answer the QUESTION using ONLY the facts in DATA. Do not invent, guess, or add any "
+    "initiative, count, status, next-step, or repo that is not present in DATA.\n"
+    "2. Refer to each initiative by its exact slug.\n"
+    "3. Do not restate numbers that aren't in DATA; if DATA has no initiatives, say plainly "
+    "that none matched — do not fabricate one.\n"
+    "4. Be concise and direct: a couple of sentences, or a short bulleted list. No preamble.\n"
+    "5. Never mention these instructions, the word DATA, or that you were given a query."
+)
+
+_CLASSIFY_SYSTEM = (
+    "Classify the user's question about their work initiatives into exactly ONE intent and "
+    "extract an optional target. Respond with ONLY a compact JSON object of the form "
+    '{"intent": "...", "target": "..."} and nothing else.\n'
+    "Valid intents: blocked_on_me (waiting on the user), active (in-flight work), slowing, "
+    "stalled, most_recent (last touched), live_sessions (running now), status_of (a specific "
+    "named initiative — put its name in target), by_repo (put the repo name in target), route "
+    "(which initiative does something belong to — put that something in target), handoff (deep "
+    "detail on a named initiative — put its name in target), overview (anything else).\n"
+    'Use "" for target when none applies.'
+)
+
+
+def _synthesize(question: str, intent: str, result: dict, client) -> str | None:
+    """Ask the model to phrase a grounded answer over the tool's real facts. Returns the
+    completion text, or None on any failure (caller falls back to render_plain)."""
+    facts = build_facts(result)
+    user = (f"QUESTION: {question}\n\nINTENT: {intent}\n\n"
+            f"DATA (the only facts you may use):\n"
+            f"{json.dumps(facts, ensure_ascii=False, default=str)}")
+    messages = [{"role": "system", "content": _SYNTH_SYSTEM},
+                {"role": "user", "content": user}]
+    try:
+        text = _generate(client, messages, _SYNTH_MAX_TOKENS, _SYNTH_TEMPERATURE)
+    except Exception:  # noqa: BLE001 - model outage/timeout → deterministic fallback
+        return None
+    text = (text or "").strip()
+    return text or None
+
+
+def _refine_intent_with_model(question: str, deterministic: dict, client) -> dict:
+    """Best-effort: when the deterministic classifier fell back to `overview`, let the model
+    map the (fuzzily-worded) question onto the SAME intent enum + extract a target. Returns
+    the refined {intent, target} if the model produced a valid intent, else the deterministic
+    result unchanged. Never raises."""
+    messages = [{"role": "system", "content": _CLASSIFY_SYSTEM},
+                {"role": "user", "content": (question or "")[:_QUESTION_MAX]}]
+    try:
+        raw = _generate(client, messages, _CLASSIFY_MAX_TOKENS, _CLASSIFY_TEMPERATURE)
+    except Exception:  # noqa: BLE001
+        return deterministic
+    parsed = _parse_intent_json(raw)
+    if parsed and parsed.get("intent") in INTENTS:
+        return {"intent": parsed["intent"], "target": _clean_target(parsed.get("target") or "")}
+    return deterministic
+
+
+def _parse_intent_json(raw: str | None) -> dict | None:
+    """Pull the first {...} JSON object out of a model reply, defensively."""
+    if not raw:
+        return None
+    m = re.search(r"\{.*\}", raw, re.S)
+    if not m:
+        return None
+    try:
+        obj = json.loads(m.group(0))
+    except (ValueError, TypeError):
+        return None
+    return obj if isinstance(obj, dict) else None
+
+
+def _generate(client, messages, max_tokens: int, temperature: float) -> str:
+    """Call the client's generate, passing max_tokens/temperature when it accepts them
+    (the recap VllmClient does) and degrading to the bare call for a minimal fake."""
+    try:
+        return client.generate(messages, max_tokens=max_tokens, temperature=temperature)
+    except TypeError:
+        return client.generate(messages)
+
+
+# --------------------------------------------------------------------------- #
+# I/O — load the initiative views from the store (reusing the viewer's readers).
+# --------------------------------------------------------------------------- #
+def load_initiatives() -> tuple[list[dict], list[dict]]:
+    """Read the current initiatives from the store + attach the live tmux overlay, and
+    return `(views, untracked_live_sessions)` — the SAME normalized `flat` views the
+    viewer renders (so the tools operate on one shape). Read-only. Raises on an unreachable
+    store (ask() turns that into a graceful error result)."""
+    viewer = _viewer()
+    rows = viewer.load_latest()
+    unmatched = viewer.attach_tmux(rows)  # best-effort; mutates rows, returns unmatched panes
+    model = viewer.build_model(rows, unmatched=unmatched)
+    return model.get("flat", []), model.get("live_unmatched", [])
+
+
+def _default_client(env=None):
+    """Build a recap VllmClient for the configured endpoint, or None if the model isn't
+    configured (then the assistant answers deterministically). Does NOT open the port-
+    forward yet — the caller enters it as a context manager."""
+    recap = _recap()
+    cfg = recap.recap_config(env or os.environ)
+    model = (cfg.get("model") or "").strip()
+    if not model or model == recap.RECAP_MODEL:  # unset or the placeholder default
+        return None
+    if not (cfg.get("base_url") or (cfg.get("namespace") and cfg.get("service"))):
+        return None
+    return recap.VllmClient(cfg)
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration — the one callable. Best-effort throughout; never raises.
+# --------------------------------------------------------------------------- #
+def _error_result(question: str, message: str) -> dict:
+    return {"ok": False, "question": question, "intent": "error",
+            "answer": message, "sources": []}
+
+
+def _run(question: str, views: list[dict], unmatched: list[dict] | None,
+         client) -> dict:
+    """PURE-ish core (client is the only impurity, and may be None): classify -> tool ->
+    (model synth | deterministic render). Sources are computed from the tool result."""
+    info = classify_intent(question)
+    if info["intent"] == "overview" and client is not None:
+        info = _refine_intent_with_model(question, info, client)
+    intent = info["intent"]
+    result = run_tool(intent, info, views, unmatched)
+    sources = sources_of(result)
+    answer = None
+    if client is not None:
+        answer = _synthesize(question, intent, result, client)
+    if not answer:
+        answer = render_plain(intent, info, result)
+    return {"ok": True, "question": question, "intent": intent,
+            "answer": answer, "sources": sources}
+
+
+def ask(question: str, *, views: list[dict] | None = None,
+        unmatched: list[dict] | None = None, loader=None,
+        client=None, client_factory=None, env=None) -> dict:
+    """Answer a natural-language question about the initiatives. READ-ONLY.
+
+    Returns {ok, question, intent, answer, sources}. `sources` is [{slug, repo}] — the
+    initiatives the answer is grounded in (deterministic, from the tool result).
+
+    Injection points (all optional; production uses none):
+      views/unmatched — pre-loaded initiative views (the viewer passes its cached model's
+                        `flat`/`live_unmatched` to avoid a second DB read). If omitted,
+                        loaded via `loader` (default: `load_initiatives`).
+      client          — an already-open model client (tests). Used directly, no lifecycle.
+      client_factory  — callable() -> a context-manager client (production opens/closes the
+                        vLLM port-forward around the whole ask). Default: env-configured.
+      env             — env dict for the model config (default os.environ).
+
+    Degradation: an unreachable store -> a clear error result; an unreachable/unset model
+    -> the deterministic renderer over the real tool output. Never raises."""
+    question = (question or "").strip()[:_QUESTION_MAX]
+    if not question:
+        return _error_result(question, "Ask a question about your initiatives.")
+
+    if views is None:
+        loader = loader or load_initiatives
+        try:
+            views, unmatched = loader()
+        except Exception as exc:  # noqa: BLE001 - store unreachable → graceful error
+            return _error_result(
+                question, f"Couldn't read the initiatives store ({type(exc).__name__}). "
+                          "The assistant is read-only and needs the store to answer.")
+    views = views or []
+
+    # Direct client (tests) — no lifecycle to manage.
+    if client is not None:
+        return _run(question, views, unmatched, client)
+
+    # Production: open the model client (port-forward) for the whole ask, best-effort. Any
+    # failure to build/enter it -> answer deterministically (client=None).
+    factory = client_factory if client_factory is not None else (lambda: _default_client(env))
+    try:
+        cm = factory()
+    except Exception:  # noqa: BLE001
+        cm = None
+    if cm is None:
+        return _run(question, views, unmatched, None)
+    try:
+        with cm as c:
+            return _run(question, views, unmatched, c)
+    except Exception:  # noqa: BLE001 - port-forward/model failure → deterministic
+        return _run(question, views, unmatched, None)
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _render_cli(res: dict) -> str:
+    out = [res.get("answer") or ""]
+    srcs = res.get("sources") or []
+    if srcs:
+        out.append("")
+        out.append("sources: " + ", ".join(
+            f"{s['slug']}" + (f" ({s['repo']})" if s.get("repo") else "") for s in srcs))
+    return "\n".join(out)
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Read-only initiatives assistant: ask a natural-language question "
+                    "about your initiatives (Q&A + routing). Suggests, never acts.")
+    p.add_argument("question", help="the question, e.g. \"what's blocked on me?\"")
+    p.add_argument("--json", action="store_true",
+                   help="emit the machine-readable {answer, sources, intent} JSON")
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    a = parse_args(argv)
+    res = ask(a.question)
+    if a.json:
+        print(json.dumps(res, indent=2, ensure_ascii=False, default=str))
+    else:
+        print(_render_cli(res))
+    return 0 if res.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/initiatives/recap.py
+++ b/scripts/initiatives/recap.py
@@ -546,15 +546,21 @@ class VllmClient:
             time.sleep(0.25)
         raise TimeoutError(f"vLLM port-forward to {host}:{port} not ready in time")
 
-    def generate(self, messages: list[dict]) -> str:
-        """POST an OpenAI chat-completions request; return choices[0].message.content."""
+    def generate(self, messages: list[dict], *, max_tokens: int | None = None,
+                 temperature: float | None = None) -> str:
+        """POST an OpenAI chat-completions request; return choices[0].message.content.
+
+        `max_tokens`/`temperature` are keyword-only overrides (default to the recap
+        module constants tuned for a 1-line recap) — the assistant passes a larger
+        `max_tokens` for a chat answer and 0 temperature for JSON classification. Existing
+        callers (sync_recaps) pass neither and get the unchanged recap behaviour."""
         if not self._url:
             raise RuntimeError("VllmClient used outside its context manager")
         body = json.dumps({
             "model": self._cfg["model"],
             "messages": messages,
-            "temperature": RECAP_TEMPERATURE,
-            "max_tokens": RECAP_MAX_TOKENS,
+            "temperature": RECAP_TEMPERATURE if temperature is None else temperature,
+            "max_tokens": RECAP_MAX_TOKENS if max_tokens is None else max_tokens,
             "stream": False,
         }).encode("utf-8")
         req = urllib.request.Request(

--- a/scripts/initiatives/tests/test_assistant.py
+++ b/scripts/initiatives/tests/test_assistant.py
@@ -1,0 +1,401 @@
+"""Unit tests for the READ-ONLY initiatives assistant (scripts/initiatives/assistant.py).
+
+Hermetic: no live DB, no live model. The pure core (intent classification, the tool
+queries, the plain renderer, the fact projection, sources) is exercised with fixture
+initiative "views"; the assistant loop is exercised with an injected FAKE model client and
+injected views, so nothing here opens a port-forward or hits ClickHouse/Postgres/vLLM.
+
+`assistant` lazily loads its `route` sibling (the scan's token matcher) via importlib for
+the status_of/route tools — the same import test_route.py relies on, available in the
+hermetic pytest sandbox. No viewer/recap module is loaded (handoff read + model are
+injected).
+"""
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import assistant  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fixture initiative "views" — the shape viewer.build_model's `flat` produces.
+# --------------------------------------------------------------------------- #
+NOW = datetime(2026, 7, 24, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _view(slug, title, repo, *, momentum="active", status="", next_step="",
+          summary="", identity="", age="1h", minutes_ago=60,
+          live_tasks=None, tmux_sessions=None, current_doc=""):
+    return {
+        "slug": slug, "title": title, "repo": repo, "repo_name": repo.rsplit("/", 1)[-1],
+        "momentum": momentum, "status": status, "next_step": next_step,
+        "summary": summary, "identity": identity, "age": age,
+        "last_touch": NOW - timedelta(minutes=minutes_ago),
+        "open_prs": [], "live_tasks": live_tasks or [], "live_task": (live_tasks or [""])[0],
+        "tmux_sessions": tmux_sessions or [], "current_doc": current_doc,
+    }
+
+
+CLAWGATE = _view("clawgate-agent-loop", "Clawgate agent loop close", "/repo/devrc",
+                 status="awaiting Zach's go-ahead on the phase-7 cutover",
+                 next_step="cut over phase 7", age="20m", minutes_ago=20)
+SYSREDIS = _view("sysredis-buffer", "Redis sentinel failover hardening", "/repo/homelab",
+                 momentum="stalled", next_step="resume the sentinel failover soak",
+                 age="9d", minutes_ago=60 * 24 * 9)
+REMIX = _view("remix-session", "Remix session platform", "/repo/remix",
+              momentum="slowing", status="exploring age-gating and moderation",
+              age="2d", minutes_ago=60 * 48)
+TAXES = _view("taxes-archiver", "Tax invoice archiver", "/repo/devrc",
+              next_step="your call on the invoice archive format", age="3h",
+              minutes_ago=180)
+COMFY = _view("2026-07-21", "ComfyUI realism pipeline", "/repo/civitai",
+              live_tasks=["running preference round 3"], tmux_sessions=["8-1"],
+              age="45m", minutes_ago=45)
+
+VIEWS = [CLAWGATE, SYSREDIS, REMIX, TAXES, COMFY]
+UNMATCHED = [{"id": "Pool2", "title": "dp-500 sweep", "repo": "/repo/datapacket",
+              "repo_name": "datapacket"}]
+
+
+def _slugs(items):
+    return [i["slug"] for i in items]
+
+
+# --------------------------------------------------------------------------- #
+# Intent classification (pure, deterministic)
+# --------------------------------------------------------------------------- #
+def test_classify_blocked_on_me_variants():
+    for q in ["what's blocked on me?", "what is waiting on me right now",
+              "anything need my input?", "what needs my call"]:
+        assert assistant.classify_intent(q)["intent"] == "blocked_on_me", q
+
+
+def test_classify_momentum_buckets():
+    assert assistant.classify_intent("what's stalled?")["intent"] == "stalled"
+    assert assistant.classify_intent("anything slowing down")["intent"] == "slowing"
+    assert assistant.classify_intent("what am I working on")["intent"] == "active"
+
+
+def test_classify_status_of_extracts_target():
+    info = assistant.classify_intent("what's the status of clawgate")
+    assert info["intent"] == "status_of"
+    assert info["target"] == "clawgate"
+
+
+def test_classify_where_did_i_leave_extracts_target():
+    info = assistant.classify_intent("where did I leave off with sysredis buffer")
+    assert info["intent"] == "status_of"
+    assert "sysredis" in info["target"]
+
+
+def test_classify_route_extracts_signal():
+    info = assistant.classify_intent("which initiative does the redis failover work belong to")
+    assert info["intent"] == "route"
+    assert "redis" in info["target"]
+
+
+def test_classify_handoff_extracts_target():
+    info = assistant.classify_intent("read the handoff for clawgate")
+    assert info["intent"] == "handoff"
+    assert info["target"] == "clawgate"
+
+
+def test_classify_live_sessions_and_most_recent():
+    assert assistant.classify_intent("what's running right now")["intent"] == "live_sessions"
+    assert assistant.classify_intent("what did I touch most recently")["intent"] == "most_recent"
+
+
+def test_classify_unknown_falls_back_to_overview():
+    assert assistant.classify_intent("hello there friend")["intent"] == "overview"
+    assert assistant.classify_intent("")["intent"] == "overview"
+
+
+# --------------------------------------------------------------------------- #
+# Tools (pure, over fixture views)
+# --------------------------------------------------------------------------- #
+def test_tool_blocked_on_me_filters_on_markers():
+    res = assistant.tool_blocked_on_me(VIEWS)
+    # clawgate ("awaiting …") + taxes ("your call …") are blocked; the rest are not.
+    assert set(_slugs(res["initiatives"])) == {"clawgate-agent-loop", "taxes-archiver"}
+    assert "awaiting" in res["markers"]["clawgate-agent-loop"]
+    assert "your call" in res["markers"]["taxes-archiver"]
+
+
+def test_tool_blocked_on_me_empty_when_nothing_waiting():
+    calm = [_view("calm-a", "Calm A", "/repo/x", status="all merged and shipped"),
+            _view("calm-b", "Calm B", "/repo/x", next_step="keep soaking")]
+    assert assistant.tool_blocked_on_me(calm)["initiatives"] == []
+
+
+def test_tool_by_momentum():
+    assert _slugs(assistant.tool_by_momentum(VIEWS, "stalled")["initiatives"]) == \
+        ["sysredis-buffer"]
+    assert _slugs(assistant.tool_by_momentum(VIEWS, "slowing")["initiatives"]) == \
+        ["remix-session"]
+    active = _slugs(assistant.tool_by_momentum(VIEWS, "active")["initiatives"])
+    assert set(active) == {"clawgate-agent-loop", "taxes-archiver", "2026-07-21"}
+
+
+def test_tool_most_recent_orders_by_last_touch():
+    res = assistant.tool_most_recent(VIEWS, n=3)
+    # clawgate (20m) is newest, then comfyui (45m), then taxes (3h).
+    assert _slugs(res["initiatives"]) == ["clawgate-agent-loop", "2026-07-21", "taxes-archiver"]
+
+
+def test_tool_status_of_resolves_named_initiative_via_matcher():
+    res = assistant.tool_status_of(VIEWS, "clawgate")
+    assert res["initiatives"][0]["slug"] == "clawgate-agent-loop"
+
+
+def test_tool_status_of_substring_fallback_below_token_bar():
+    # "taxes" isn't a slug/title token of taxes-archiver's title ("Tax invoice archiver"),
+    # so the token matcher may miss — the substring fallback still resolves it by slug.
+    res = assistant.tool_status_of(VIEWS, "taxes")
+    assert any(v["slug"] == "taxes-archiver" for v in res["initiatives"])
+
+
+def test_tool_status_of_unknown_returns_empty():
+    assert assistant.tool_status_of(VIEWS, "nonexistent-xyz")["initiatives"] == []
+
+
+def test_tool_route_delegates_to_route_module():
+    res = assistant.tool_route(VIEWS, "harden the redis sentinel failover soak")
+    assert res["ranked"][0]["slug"] == "sysredis-buffer"
+    assert res["ranked"][0]["confident"] is True
+    assert "sysredis-buffer" in res["verdict"]
+
+
+def test_tool_route_matches_route_rank_matches_exactly():
+    # route_signal must be a faithful delegate — same ranking route.rank_matches gives.
+    route = assistant._route()
+    signal = "harden the redis sentinel failover soak"
+    assert assistant.tool_route(VIEWS, signal)["ranked"] == \
+        route.rank_matches(signal, VIEWS, limit=5)
+
+
+def test_tool_live_sessions_lists_tied_plus_untracked():
+    res = assistant.tool_live_sessions(VIEWS, UNMATCHED)
+    assert _slugs(res["initiatives"]) == ["2026-07-21"]
+    assert len(res["untracked"]) == 1
+
+
+def test_tool_by_repo_groups_and_scopes():
+    grouped = assistant.tool_by_repo(VIEWS)
+    assert set(grouped["groups"]) == {"devrc", "homelab", "remix", "civitai"}
+    scoped = assistant.tool_by_repo(VIEWS, "devrc")
+    assert set(_slugs(scoped["initiatives"])) == {"clawgate-agent-loop", "taxes-archiver"}
+
+
+def test_tool_read_handoff_uses_injected_reader_and_resolves_name():
+    captured = {}
+
+    def reader(repo, current_doc):
+        captured["repo"] = repo
+        return {"summary": "the durable goal", "next_steps": ["do X", "do Y"],
+                "open_investigations": []}
+
+    res = assistant.tool_read_handoff(VIEWS, "clawgate", reader=reader)
+    assert res["initiative"]["slug"] == "clawgate-agent-loop"
+    assert res["detail"]["summary"] == "the durable goal"
+    assert captured["repo"] == "/repo/devrc"
+
+
+def test_tool_read_handoff_unknown_initiative():
+    res = assistant.tool_read_handoff(VIEWS, "nope-xyz", reader=lambda r, d: None)
+    assert res["initiative"] is None
+
+
+# --------------------------------------------------------------------------- #
+# Sources (deterministic citation — the anti-confabulation anchor)
+# --------------------------------------------------------------------------- #
+def test_sources_from_filter_result():
+    res = assistant.tool_blocked_on_me(VIEWS)
+    srcs = assistant.sources_of(res)
+    assert {s["slug"] for s in srcs} == {"clawgate-agent-loop", "taxes-archiver"}
+    assert {s["repo"] for s in srcs} == {"devrc"}
+
+
+def test_sources_from_route_result():
+    res = assistant.tool_route(VIEWS, "redis sentinel failover")
+    assert any(s["slug"] == "sysredis-buffer" for s in assistant.sources_of(res))
+
+
+def test_sources_from_handoff_result():
+    res = assistant.tool_read_handoff(VIEWS, "clawgate", reader=lambda r, d: {})
+    srcs = assistant.sources_of(res)
+    assert _slugs(srcs) == ["clawgate-agent-loop"]
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic renderer (graceful-degradation path)
+# --------------------------------------------------------------------------- #
+def test_render_plain_blocked_lists_initiatives():
+    out = assistant.render_plain("blocked_on_me", {},
+                                 assistant.tool_blocked_on_me(VIEWS))
+    assert "clawgate-agent-loop" in out and "taxes-archiver" in out
+
+
+def test_render_plain_blocked_empty():
+    out = assistant.render_plain("blocked_on_me", {},
+                                 assistant.tool_blocked_on_me([]))
+    assert "Nothing" in out
+
+
+def test_render_plain_status_of_not_found():
+    out = assistant.render_plain("status_of", {"target": "ghost"},
+                                 assistant.tool_status_of(VIEWS, "ghost"))
+    assert "Couldn't find" in out and "ghost" in out
+
+
+def test_render_plain_route_shows_verdict():
+    out = assistant.render_plain("route", {},
+                                 assistant.tool_route(VIEWS, "redis sentinel failover"))
+    assert "sysredis-buffer" in out
+
+
+# --------------------------------------------------------------------------- #
+# build_facts — compact + only tool-derived (nothing to confabulate from)
+# --------------------------------------------------------------------------- #
+def test_build_facts_caps_and_projects():
+    facts = assistant.build_facts(assistant.tool_overview(VIEWS))
+    assert facts["count"] == len(VIEWS)
+    slugs = {f["slug"] for f in facts["initiatives"]}
+    assert slugs == {v["slug"] for v in VIEWS}
+
+
+def test_build_facts_blocked_carries_reason():
+    facts = assistant.build_facts(assistant.tool_blocked_on_me(VIEWS))
+    claw = next(f for f in facts["initiatives"] if f["slug"] == "clawgate-agent-loop")
+    assert "awaiting" in claw["waiting_on_you_because"]
+
+
+# --------------------------------------------------------------------------- #
+# The assistant loop with a FAKE model client (intent -> tool -> grounded answer)
+# --------------------------------------------------------------------------- #
+class _FakeClient:
+    """Routes generate() by the system prompt: the classify call (JSON) vs the synthesis
+    call (a phrased answer). Records the DATA it was given so a test can assert grounding."""
+
+    def __init__(self, *, synth="here is a grounded answer", classify_json=None):
+        self._synth = synth
+        self._classify_json = classify_json
+        self.synth_calls = 0
+        self.classify_calls = 0
+        self.last_data = None
+
+    def generate(self, messages, *, max_tokens=None, temperature=None):
+        sys_prompt = messages[0]["content"]
+        if sys_prompt.startswith("Classify"):
+            self.classify_calls += 1
+            return self._classify_json or '{"intent": "overview", "target": ""}'
+        self.synth_calls += 1
+        # capture the DATA json handed to the model
+        user = messages[1]["content"]
+        self.last_data = user
+        return self._synth
+
+
+def test_ask_intent_to_tool_to_model_answer():
+    client = _FakeClient(synth="clawgate-agent-loop and taxes-archiver await you.")
+    res = assistant.ask("what's blocked on me?", views=VIEWS, unmatched=UNMATCHED,
+                        client=client)
+    assert res["ok"] is True
+    assert res["intent"] == "blocked_on_me"
+    assert res["answer"] == "clawgate-agent-loop and taxes-archiver await you."
+    assert {s["slug"] for s in res["sources"]} == {"clawgate-agent-loop", "taxes-archiver"}
+    assert client.synth_calls == 1
+    # a confidently-classified question must NOT invoke the model classifier
+    assert client.classify_calls == 0
+
+
+def test_ask_anticonfab_sources_come_from_tool_not_model():
+    # The model FABRICATES an initiative in its prose; sources must still be ONLY the real
+    # tool output (the auditability anchor). The invented slug never enters sources.
+    client = _FakeClient(synth="You should look at ghost-initiative, it is on fire!")
+    res = assistant.ask("what's stalled?", views=VIEWS, client=client)
+    src_slugs = {s["slug"] for s in res["sources"]}
+    assert "ghost-initiative" not in src_slugs
+    assert src_slugs == {"sysredis-buffer"}   # the only real stalled initiative
+
+
+def test_ask_model_refines_overview_fallback():
+    # A fuzzily-worded question deterministic can't parse -> overview; the model maps it to
+    # blocked_on_me and the RIGHT tool runs.
+    client = _FakeClient(synth="two things await you",
+                         classify_json='{"intent": "blocked_on_me", "target": ""}')
+    res = assistant.ask("hey any hot potatoes on my plate", views=VIEWS, client=client)
+    assert res["intent"] == "blocked_on_me"
+    assert client.classify_calls == 1
+    assert {s["slug"] for s in res["sources"]} == {"clawgate-agent-loop", "taxes-archiver"}
+
+
+def test_ask_data_handed_to_model_is_grounded():
+    client = _FakeClient()
+    assistant.ask("what's stalled?", views=VIEWS, client=client)
+    data = json.loads(client.last_data.split("DATA (the only facts you may use):\n", 1)[1])
+    # the model only ever sees the real stalled initiative — nothing else to confabulate.
+    assert [f["slug"] for f in data["initiatives"]] == ["sysredis-buffer"]
+
+
+# --------------------------------------------------------------------------- #
+# Best-effort degradation
+# --------------------------------------------------------------------------- #
+def test_ask_no_model_uses_deterministic_render():
+    res = assistant.ask("what's blocked on me?", views=VIEWS, client=None,
+                        client_factory=lambda: None)
+    assert res["ok"] is True
+    assert res["intent"] == "blocked_on_me"
+    # deterministic renderer output (no model) still names the real initiatives
+    assert "clawgate-agent-loop" in res["answer"]
+    assert {s["slug"] for s in res["sources"]} == {"clawgate-agent-loop", "taxes-archiver"}
+
+
+def test_ask_model_error_degrades_to_deterministic():
+    class Boom:
+        def generate(self, *a, **k):
+            raise RuntimeError("vllm timeout")
+
+    res = assistant.ask("what's stalled?", views=VIEWS, client=Boom())
+    assert res["ok"] is True
+    assert "sysredis-buffer" in res["answer"]  # deterministic fallback ran
+
+
+def test_ask_store_unreachable_is_graceful_error():
+    def boom_loader():
+        raise ConnectionError("port-forward failed")
+
+    res = assistant.ask("what's active?", loader=boom_loader)
+    assert res["ok"] is False
+    assert res["intent"] == "error"
+    assert res["sources"] == []
+    assert "read-only" in res["answer"]
+
+
+def test_ask_empty_question_is_handled():
+    res = assistant.ask("   ", views=VIEWS)
+    assert res["ok"] is False
+    assert res["sources"] == []
+
+
+def test_ask_client_factory_failure_degrades():
+    def bad_factory():
+        raise RuntimeError("cannot open port-forward")
+
+    res = assistant.ask("what's stalled?", views=VIEWS, client_factory=bad_factory)
+    assert res["ok"] is True
+    assert "sysredis-buffer" in res["answer"]
+
+
+# --------------------------------------------------------------------------- #
+# Model-config gating (no live call)
+# --------------------------------------------------------------------------- #
+def test_default_client_none_when_model_unconfigured():
+    assert assistant._default_client({}) is None  # no RECAP_MODEL -> no client
+
+
+def test_default_client_none_on_placeholder_model():
+    recap = assistant._recap()
+    assert assistant._default_client({"RECAP_MODEL": recap.RECAP_MODEL}) is None

--- a/scripts/initiatives/tests/test_viewer.py
+++ b/scripts/initiatives/tests/test_viewer.py
@@ -1261,3 +1261,126 @@ def test_js_recency_render_branch_present():
     assert "bucketizeRecency(rviews, Date.now())" in viewer._JS
     # the repo label shows in recency too (repo isn't the section header there).
     assert "state.view !== 'grouped'" in viewer._JS
+
+
+# --------------------------------------------------------------------------- #
+# Read-only Q&A sidebar — POST /api/ask + the chat pane render (Phase 1 assistant)
+# --------------------------------------------------------------------------- #
+def test_parse_ask_question_variants():
+    assert viewer._parse_ask_question(b'{"question": "what is blocked?"}') == "what is blocked?"
+    assert viewer._parse_ask_question(b'{"question": "  padded  "}') == "padded"
+    assert viewer._parse_ask_question(b'{"nope": 1}') == ""       # missing key
+    assert viewer._parse_ask_question(b'not json') == ""          # unparseable
+    assert viewer._parse_ask_question(b'{"question": 5}') == ""   # non-string
+    assert viewer._parse_ask_question(b"") == ""                  # empty body
+    assert viewer._parse_ask_question(None) == ""
+
+
+def test_route_ask_calls_asker_and_returns_answer():
+    seen = {}
+
+    def asker(q):
+        seen["q"] = q
+        return {"ok": True, "intent": "blocked_on_me",
+                "answer": "clawgate-agent-loop awaits you.",
+                "sources": [{"slug": "clawgate-agent-loop", "repo": "devrc"}]}
+
+    status, ctype, body = viewer.route_request(
+        "/api/ask", _FakeProvider(), method="POST",
+        body=b'{"question": "what is blocked on me?"}', asker=asker)
+    assert status == 200
+    assert "application/json" in ctype
+    payload = json.loads(body)
+    assert payload["ok"] is True
+    assert payload["answer"] == "clawgate-agent-loop awaits you."
+    assert payload["sources"][0]["slug"] == "clawgate-agent-loop"
+    assert payload["intent"] == "blocked_on_me"
+    assert seen["q"] == "what is blocked on me?"
+
+
+def test_route_ask_missing_question_400():
+    status, _ctype, body = viewer.route_request(
+        "/api/ask", _FakeProvider(), method="POST", body=b'{}', asker=lambda q: {})
+    assert status == 400
+    assert json.loads(body)["ok"] is False
+
+
+def test_route_ask_no_asker_503():
+    status, _ctype, body = viewer.route_request(
+        "/api/ask", _FakeProvider(), method="POST",
+        body=b'{"question": "x"}', asker=None)
+    assert status == 503
+    assert json.loads(body)["ok"] is False
+
+
+def test_route_ask_asker_error_is_caught_200():
+    def boom(q):
+        raise RuntimeError("assistant exploded")
+
+    status, _ctype, body = viewer.route_request(
+        "/api/ask", _FakeProvider(), method="POST",
+        body=b'{"question": "x"}', asker=boom)
+    assert status == 200                       # never 500s the request
+    payload = json.loads(body)
+    assert payload["ok"] is False
+    assert payload["sources"] == []
+
+
+def test_route_ask_is_get_safe_404():
+    # /api/ask is POST-only; a GET falls through to the 404 (no read side effect).
+    status, _ctype, _body = viewer.route_request("/api/ask", _FakeProvider(), method="GET")
+    assert status == 404
+
+
+def test_default_ask_errors_when_store_unreachable():
+    # default_ask must degrade (not raise) when the provider snapshot has no model.
+    res = viewer.default_ask("what's blocked?", _FakeProvider(error="db down"))
+    assert res["ok"] is False
+    assert res["sources"] == []
+
+
+def test_default_ask_passes_provider_views_to_assistant(monkeypatch):
+    # default_ask reuses the provider's CACHED snapshot (no second DB read) and hands the
+    # flat views + live_unmatched straight to assistant.ask.
+    model = viewer.build_model([_row(slug="a-slug")], now=NOW)
+    captured = {}
+
+    class _StubAssistant:
+        def ask(self, question, *, views=None, unmatched=None):
+            captured["question"] = question
+            captured["views"] = views
+            captured["unmatched"] = unmatched
+            return {"ok": True, "answer": "ok", "sources": [], "intent": "overview"}
+
+    monkeypatch.setattr(viewer, "_assistant", lambda: _StubAssistant())
+    res = viewer.default_ask("what's up", _FakeProvider(model=model))
+    assert res["answer"] == "ok"
+    assert captured["question"] == "what's up"
+    assert [v["slug"] for v in captured["views"]] == ["a-slug"]
+
+
+def test_render_html_includes_chat_pane_and_ask_wiring():
+    model = viewer.build_model([_row(slug="s")], now=NOW)
+    html = viewer.render_html(model, None)
+    # the toggle button + the sidebar element + the input/form are present
+    assert 'id="ask-toggle"' in html
+    assert 'id="chat"' in html and 'class="chat"' in html
+    assert 'id="chat-input"' in html and 'id="chat-form"' in html
+    # the client posts to the read-only endpoint and renders sources
+    assert "/api/ask" in viewer._JS
+    assert "renderSources" in viewer._JS
+    # the input is disabled while a request is in flight (debounce/lockout)
+    assert "chatInput.disabled = true" in viewer._JS
+    assert "askInFlight" in viewer._JS
+
+
+def test_render_html_chat_answer_uses_textContent_not_innerhtml():
+    # untrusted answer/source text must be written via textContent (XSS discipline).
+    assert "aEl.textContent = j.answer" in viewer._JS
+
+
+def test_chat_pane_absent_from_error_page():
+    # the graceful error page has no JS/model island — and no chat pane wiring.
+    html = viewer.render_html(None, "OperationalError")
+    assert 'id="chat"' not in html
+    assert "store unreachable" in html

--- a/scripts/initiatives/viewer.py
+++ b/scripts/initiatives/viewer.py
@@ -161,6 +161,47 @@ def _import_maildb():
     return mod.MailDB
 
 
+# The sibling read-only Q&A assistant (POST /api/ask). Loaded by EXPLICIT importlib path
+# (not a top-level `import assistant`) so the viewer<->assistant pair has no import cycle
+# and merely importing the viewer stays cheap. assistant itself lazily loads the viewer
+# only for its handoff reader, so the answer path here (which passes pre-loaded views) does
+# not re-enter this module.
+ASSISTANT_PATH = Path(__file__).resolve().parent / "assistant.py"
+_assistant_mod = None
+
+# Cap the POST body the server will read for /api/ask (a question is a short string; this
+# guards against a client streaming an unbounded body).
+MAX_ASK_BODY_BYTES = 64 * 1024
+
+
+def _assistant():
+    global _assistant_mod
+    if _assistant_mod is None:
+        spec = importlib.util.spec_from_file_location(
+            "initiatives_viewer_assistant", ASSISTANT_PATH)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"cannot load {ASSISTANT_PATH}")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        _assistant_mod = mod
+    return _assistant_mod
+
+
+def default_ask(question: str, provider) -> dict:
+    """Answer a question with the READ-ONLY assistant, reusing the provider's CACHED
+    snapshot (its `flat` views + `live_unmatched`) so no second DB port-forward is opened,
+    plus the env-configured local model (`vllm-recap`). Best-effort: a store-read error
+    surfaces as the assistant's graceful error result; a model outage degrades to the
+    deterministic answer. There is NO write/dispatch path here — the assistant only reads."""
+    model, error = provider.snapshot()
+    if model is None:
+        return {"ok": False, "intent": "error", "sources": [],
+                "answer": f"Couldn't read the initiatives store ({error or 'no data'})."}
+    return _assistant().ask(
+        question, views=model.get("flat", []),
+        unmatched=model.get("live_unmatched", []))
+
+
 # --------------------------------------------------------------------------- #
 # I/O — read the store, then attach the live tmux overlay.
 # --------------------------------------------------------------------------- #
@@ -856,6 +897,45 @@ header .meta{color:var(--gray);font-size:.85rem}
 footer{margin-top:1.5rem;padding-top:.6rem;border-top:1px solid var(--bg2);
   color:var(--gray);font-size:.8rem}
 footer .live{color:var(--green)}
+/* The read-only Q&A sidebar (💬 ask). A fixed right-hand panel, hidden until toggled;
+   gruvbox to match the cards. Untrusted answer text is textContent-only in the JS. */
+.abtn{background:var(--bg1);color:var(--yellow);border:1px solid var(--bg2);border-radius:4px;
+  padding:.3rem .7rem;cursor:pointer;font:inherit;font-size:.82rem}
+.abtn:hover{background:var(--bg2)}
+.abtn.active{background:var(--yellow);color:var(--bg)}
+.chat{position:fixed;top:0;right:0;bottom:0;width:min(30rem,92vw);z-index:20;
+  background:var(--bg);border-left:1px solid var(--bg2);box-shadow:-8px 0 24px #0006;
+  display:flex;flex-direction:column;padding:.8rem}
+.chat[hidden]{display:none}
+.chat-head{display:flex;align-items:center;gap:.5rem;border-bottom:1px solid var(--bg2);
+  padding-bottom:.5rem;margin-bottom:.5rem}
+.chat-title{color:var(--yellow);font-weight:bold;font-size:.9rem}
+.chat-x{margin-left:auto;background:var(--bg1);color:var(--fg2);border:1px solid var(--bg2);
+  border-radius:4px;padding:.15rem .5rem;cursor:pointer;font:inherit;font-size:.8rem}
+.chat-x:hover{background:var(--bg2);color:var(--red)}
+.chat-log{flex:1;overflow-y:auto;display:flex;flex-direction:column;gap:.7rem;padding:.2rem 0}
+.chat-empty{color:var(--gray);font-size:.82rem;padding:.6rem .2rem}
+.qa{display:flex;flex-direction:column;gap:.25rem}
+.qa .q{color:var(--aqua);font-size:.84rem;white-space:pre-wrap;word-break:break-word}
+.qa .q .who{color:var(--gray);margin-right:.3rem}
+.qa .a{color:var(--fg);font-size:.86rem;white-space:pre-wrap;word-break:break-word;
+  background:var(--bg1);border-left:3px solid var(--green);border-radius:4px;padding:.4rem .55rem}
+.qa .a.pending{color:var(--gray);border-left-color:var(--gray);font-style:italic}
+.qa .a.err{border-left-color:var(--red)}
+.qa .srcs{display:flex;flex-wrap:wrap;gap:.3rem;margin-top:.1rem}
+.qa .src{font-size:.74rem;padding:.03rem .4rem;border-radius:3px;background:var(--bg2);
+  color:var(--blue)}
+.qa .srcs .lbl{color:var(--gray);font-size:.74rem}
+.chat-form{display:flex;gap:.4rem;margin-top:.5rem}
+.chat-input{flex:1;background:var(--bg1);color:var(--fg);border:1px solid var(--bg2);
+  border-radius:4px;padding:.4rem .55rem;font:inherit;font-size:.84rem}
+.chat-input:focus{outline:1px solid var(--yellow)}
+.chat-input:disabled{opacity:.6}
+.chat-send{background:var(--bg1);color:var(--green);border:1px solid var(--bg2);
+  border-radius:4px;padding:.4rem .8rem;cursor:pointer;font:inherit;font-size:.84rem}
+.chat-send:hover:not(:disabled){background:var(--bg2)}
+.chat-send:disabled{opacity:.55;cursor:progress}
+.chat-hint{color:var(--gray);font-size:.72rem;margin-top:.4rem;text-align:center}
 """.strip()
 
 
@@ -1333,6 +1413,114 @@ _JS = r"""
   searchInput.addEventListener('input', function(){ state.q = searchInput.value; render(); });
   btnRefresh.addEventListener('click', doRefresh);
 
+  // ---- Read-only Q&A sidebar (💬 ask) -------------------------------------------------
+  // Single-turn: POST the question to /api/ask, render the grounded answer + the sources
+  // (which initiatives it drew from). All untrusted server text via textContent (el()).
+  var askToggle = document.getElementById('ask-toggle');
+  var chat = document.getElementById('chat');
+  var chatClose = document.getElementById('chat-close');
+  var chatLog = document.getElementById('chat-log');
+  var chatForm = document.getElementById('chat-form');
+  var chatInput = document.getElementById('chat-input');
+  var chatSend = document.getElementById('chat-send');
+  var askInFlight = false;
+
+  function chatEmptyHint(){
+    if(chatLog.children.length === 0){
+      chatLog.appendChild(el('div', 'chat-empty',
+        'Ask about your initiatives — e.g. “what’s blocked on me?”, “status of clawgate”, ' +
+        '“what’s stalled?”, or “which initiative does <thing> belong to?”. Read-only.'));
+    }
+  }
+  function clearEmptyHint(){
+    var h = chatLog.querySelector('.chat-empty');
+    if(h) chatLog.removeChild(h);
+  }
+  function openChat(){
+    chat.hidden = false;
+    askToggle.classList.add('active');
+    chatEmptyHint();
+    chatInput.focus();
+  }
+  function closeChat(){
+    chat.hidden = true;
+    askToggle.classList.remove('active');
+  }
+  if(askToggle) askToggle.addEventListener('click', function(){
+    if(chat.hidden) openChat(); else closeChat();
+  });
+  if(chatClose) chatClose.addEventListener('click', closeChat);
+  document.addEventListener('keydown', function(ev){
+    if(ev.key === 'Escape' && !chat.hidden) closeChat();
+  });
+
+  function renderSources(container, sources){
+    if(!sources || !sources.length) return;
+    var wrap = el('div', 'srcs');
+    wrap.appendChild(el('span', 'lbl', 'sources:'));
+    sources.forEach(function(s){
+      var label = (s && s.slug) ? s.slug : '?';
+      if(s && s.repo) label += ' · ' + s.repo;
+      wrap.appendChild(el('span', 'src', label));
+    });
+    container.appendChild(wrap);
+  }
+
+  function submitQuestion(q){
+    if(askInFlight || !q) return;
+    askInFlight = true;
+    clearEmptyHint();
+    chatInput.value = '';
+    chatInput.disabled = true;
+    chatSend.disabled = true;
+
+    var block = el('div', 'qa');
+    var qEl = el('div', 'q');
+    qEl.appendChild(el('span', 'who', 'you ›'));
+    qEl.appendChild(document.createTextNode(' ' + q));
+    block.appendChild(qEl);
+    var aEl = el('div', 'a pending', 'thinking…');
+    block.appendChild(aEl);
+    chatLog.appendChild(block);
+    chatLog.scrollTop = chatLog.scrollHeight;
+
+    fetch('/api/ask', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({question: q})
+    })
+      .then(function(r){ return r.json().then(function(j){ return {code: r.status, j: j}; }); })
+      .then(function(res){
+        var j = res.j || {};
+        aEl.classList.remove('pending');
+        if(j.answer){
+          aEl.textContent = j.answer;
+        } else {
+          aEl.classList.add('err');
+          aEl.textContent = j.error ? ('error: ' + j.error) : 'no answer';
+        }
+        if(j.ok === false && j.answer) aEl.classList.add('err');
+        renderSources(block, j.sources);
+      })
+      .catch(function(){
+        aEl.classList.remove('pending');
+        aEl.classList.add('err');
+        aEl.textContent = 'request failed — is the viewer still up?';
+      })
+      .then(function(){
+        askInFlight = false;
+        chatInput.disabled = false;
+        chatSend.disabled = false;
+        chatInput.focus();
+        chatLog.scrollTop = chatLog.scrollHeight;
+      });
+  }
+
+  if(chatForm) chatForm.addEventListener('submit', function(ev){
+    ev.preventDefault();
+    submitQuestion((chatInput.value || '').trim());
+  });
+
   setInterval(function(){ refetch().catch(function(){}); }, __REFRESH_MS__);
 
   searchInput.value = state.q;
@@ -1402,13 +1590,34 @@ def render_html(model: dict | None, error: str | None = None,
         '<button id="refresh" class="rbtn" type="button" '
         'title="run a fresh sync now">↻ refresh</button>'
         '<span id="refresh-msg" class="rmsg"></span>'
+        '<button id="ask-toggle" class="abtn" type="button" '
+        'title="ask a read-only question about your initiatives">💬 ask</button>'
         '</div>'
         '</header>'
+    )
+    # The read-only Q&A sidebar (collapsible; hidden until toggled). A transcript of
+    # single-turn Q&A + an input. Untrusted answer/source text is written via textContent
+    # in the JS (never innerHTML), same discipline as the cards.
+    chat = (
+        '<aside id="chat" class="chat" hidden aria-label="initiatives assistant">'
+        '<div class="chat-head">'
+        '<span class="chat-title">ask · read-only</span>'
+        '<button id="chat-close" class="chat-x" type="button" title="close">✕</button>'
+        '</div>'
+        '<div id="chat-log" class="chat-log"></div>'
+        '<form id="chat-form" class="chat-form">'
+        '<input id="chat-input" class="chat-input" type="text" autocomplete="off" '
+        'spellcheck="false" placeholder="what\'s blocked on me?" '
+        'aria-label="ask the initiatives assistant">'
+        '<button id="chat-send" class="chat-send" type="submit">send</button>'
+        '</form>'
+        '<div class="chat-hint">read-only · answers cite the initiatives they use</div>'
+        '</aside>'
     )
     js = _JS.replace("__REFRESH_MS__", str(int(refresh) * 1000))
     return (
         head + header +
-        '<main id="app"></main>'
+        '<main id="app"></main>' + chat +
         '<footer id="foot"></footer>'
         '<script id="idata" type="application/json">' + payload + '</script>'
         '<script>' + js + '</script>'
@@ -1558,16 +1767,44 @@ class DataProvider:
 # HTTP layer — a thin BaseHTTPRequestHandler over a pure `route_request`.
 # --------------------------------------------------------------------------- #
 def route_request(path: str, provider, method: str = "GET", query: dict | None = None,
-                  refresh_controller=None) -> tuple[int, str, bytes]:
-    """PURE-ish request router: (path, provider, method, query, refresh) -> (status,
-    content_type, body bytes). Separated from the socket handler so it's unit-testable
-    with a fake provider / controller (no server, no DB, no subprocess).
+                  refresh_controller=None, body: bytes | None = None,
+                  asker=None) -> tuple[int, str, bytes]:
+    """PURE-ish request router: (path, provider, method, query, refresh, body, asker) ->
+    (status, content_type, body bytes). Separated from the socket handler so it's unit-
+    testable with a fake provider / controller / asker (no server, no DB, no subprocess).
 
     `/healthz` is deliberately store-independent (PROCESS liveness). `POST /refresh` runs
     a single-flighted+debounced sync then invalidates the provider cache on success.
-    `/api/initiative` returns one initiative's live detail."""
+    `/api/initiative` returns one initiative's live detail. `POST /api/ask` runs the
+    READ-ONLY Q&A assistant (`asker(question)`) — it never mutates or dispatches."""
     if path == "/healthz":
         return 200, "text/plain; charset=utf-8", b"ok\n"
+
+    if method == "POST" and path == "/api/ask":
+        # READ-ONLY natural-language Q&A over the store. Same LAN trust model as the rest of
+        # the viewer (no new auth) — but there is NO write path: the assistant only reads the
+        # initiatives store + calls the local model to phrase an answer. Deliberately
+        # unauthenticated, LAN-bound (Zach's call), abuse bounded by the input cap + the
+        # assistant's own read-only nature.
+        question = _parse_ask_question(body)
+        if not question:
+            return (400, "application/json; charset=utf-8",
+                    json.dumps({"ok": False, "error": "missing 'question'"}).encode("utf-8"))
+        if asker is None:
+            return (503, "application/json; charset=utf-8",
+                    json.dumps({"ok": False, "error": "assistant unavailable"}).encode("utf-8"))
+        try:
+            result = asker(question)
+        except Exception as exc:  # noqa: BLE001 - never let an ask error kill the request
+            sys.stderr.write(f"viewer: /api/ask failed: {type(exc).__name__}: {exc}\n")
+            result = {"ok": False, "answer": "the assistant hit an error answering that.",
+                      "sources": [], "intent": "error"}
+        payload = {"ok": bool(result.get("ok", True)),
+                   "answer": result.get("answer", ""),
+                   "sources": result.get("sources", []),
+                   "intent": result.get("intent")}
+        return (200, "application/json; charset=utf-8",
+                json.dumps(payload, ensure_ascii=False, default=str).encode("utf-8"))
 
     if method == "POST" and path == "/refresh":
         # Deliberately UNAUTHENTICATED: the viewer binds LAN/localhost only (not the public
@@ -1619,38 +1856,60 @@ def _first_qs(query: dict, name: str) -> str:
     return v if isinstance(v, str) else ""
 
 
-def make_handler(provider, refresh_controller=None):
-    """Build a BaseHTTPRequestHandler subclass bound to `provider` + `refresh_controller`."""
+def _parse_ask_question(body: bytes | None) -> str:
+    """Extract the `question` string from a JSON POST body. "" on any parse failure /
+    non-string / empty — the route turns that into a 400. Pure + defensive."""
+    if not body:
+        return ""
+    try:
+        obj = json.loads(body.decode("utf-8", errors="replace"))
+    except (ValueError, AttributeError):
+        return ""
+    if not isinstance(obj, dict):
+        return ""
+    q = obj.get("question")
+    return q.strip() if isinstance(q, str) else ""
+
+
+def make_handler(provider, refresh_controller=None, asker=None):
+    """Build a BaseHTTPRequestHandler subclass bound to `provider` + `refresh_controller`
+    + `asker` (the READ-ONLY Q&A callable for POST /api/ask; defaults to `default_ask`
+    over this provider). `asker` is injectable so the route is testable without a model."""
+    if asker is None:
+        asker = lambda q: default_ask(q, provider)  # noqa: E731
 
     class Handler(BaseHTTPRequestHandler):
         server_version = "initiatives-viewer/2.0"
 
-        def _serve(self, write_body: bool, method: str) -> None:
+        def _serve(self, write_body: bool, method: str, body: bytes | None = None) -> None:
             parsed = urlparse(self.path)
             query = parse_qs(parsed.query)
             try:
-                status, ctype, body = route_request(
+                status, ctype, resp = route_request(
                     parsed.path, provider, method=method, query=query,
-                    refresh_controller=refresh_controller)
+                    refresh_controller=refresh_controller, body=body, asker=asker)
             except Exception as exc:  # noqa: BLE001 - never let a handler error kill the thread
                 status, ctype = 500, "text/plain; charset=utf-8"
-                body = f"internal error: {type(exc).__name__}: {exc}\n".encode("utf-8")
+                resp = f"internal error: {type(exc).__name__}: {exc}\n".encode("utf-8")
             self.send_response(status)
             self.send_header("Content-Type", ctype)
-            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Content-Length", str(len(resp)))
             self.send_header("Cache-Control", "no-store")
             self.end_headers()
             if write_body:
-                self.wfile.write(body)
+                self.wfile.write(resp)
 
-        def _drain_body(self) -> None:
-            """Consume any request body so the connection stays usable (POST /refresh)."""
+        def _read_body(self) -> bytes:
+            """Read the request body (capped at MAX_ASK_BODY_BYTES) so it can be parsed
+            (POST /api/ask) AND the connection stays usable. An over-cap body is truncated
+            — the JSON parse then simply fails and the route 400s."""
             try:
                 n = int(self.headers.get("Content-Length", 0) or 0)
             except ValueError:
                 n = 0
-            if n > 0:
-                self.rfile.read(n)
+            if n <= 0:
+                return b""
+            return self.rfile.read(min(n, MAX_ASK_BODY_BYTES))
 
         def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract
             self._serve(write_body=True, method="GET")
@@ -1659,8 +1918,8 @@ def make_handler(provider, refresh_controller=None):
             self._serve(write_body=False, method="GET")
 
         def do_POST(self) -> None:  # noqa: N802
-            self._drain_body()
-            self._serve(write_body=True, method="POST")
+            body = self._read_body()
+            self._serve(write_body=True, method="POST", body=body)
 
         def log_message(self, fmt, *args) -> None:  # quiet: one compact line to stderr
             sys.stderr.write("viewer: %s - %s\n" % (self.address_string(), fmt % args))


### PR DESCRIPTION
**Phase 1 of the initiatives agent — the deliberately RE-SCOPED phase** from the red-team eval (`claudedocs/initiatives-agent-proposal-eval-2026-07-24.md`). A **strictly READ-ONLY** "initiatives assistant" (Q&A + routing) with a sidebar chat in the viewer.

**NOT built (respecting the eval's boundary):** no containerized runtime/devpod, no clawgate/openclaw, no MCP, no mutation/dispatch, no cross-cluster creds. A plain Python assistant over the EXISTING store + `route()` + the local model.

## Why read-only
The eval's core finding: a write/dispatch agent's safety gate would be *voluntary* (prompt-injection-defeatable) and needs a structural fix + scoped DB creds first. Phase 1 sidesteps all of it: **the worst case of a prompt-injected handoff the model reads is a weird ANSWER, not an action.** There is no tool that mutates state, dispatches work, writes a handoff, or reaches outside the initiatives store. Confirmed blast radius below.

## `scripts/initiatives/assistant.py`
`ask(question) -> {answer, sources}` (+ CLI `assistant.py "what's blocked on me?"`).

- **Deterministic-first shape** (robust on the 7B Qwen2.5 `vllm-recap` endpoint — no multi-step tool-planning asked of the small model): a pure regex classifier picks 1 of 11 intents + extracts a target → the matching **read-only** tool runs over the store's normalized views → the model is used only for (a) refining an `overview` fallback and (b) phrasing a grounded answer. **Tool output is the ground truth.**
- **Tools:** `blocked_on_me` (status/next_step marker scan), `active`/`slowing`/`stalled`, `most_recent`, `live_sessions`, `by_repo`, `status_of` + `route` (both delegate to `route.rank_matches` — single-sourced matcher), `read_handoff` (reuses the viewer's size-capped, traversal-guarded reader).
- **Anti-confabulation:** `sources` is computed **deterministically from the tool result, never from the model** — auditable even if the model hallucinates; the model only ever sees a compact facts projection of the real tool output.
- **Best-effort:** store down → graceful error; model down/unset → deterministic render over the real tool output; never crashes.
- **Reuse:** `recap.VllmClient`/`recap_config` (model), `route.rank_matches` (matching), `viewer.load_latest`/`build_model`/`read_doc_detail_live` (store + guarded read) — via importlib (no `mail-actions/` on `sys.path`).

## `scripts/initiatives/viewer.py`
- **`POST /api/ask`** runs `assistant.ask` server-side over the provider's **cached snapshot** (no second DB port-forward), returns `{answer, sources}`. Read-only, 400 on missing question, asker errors caught (never 500s).
- **Collapsible gruvbox sidebar chat** (💬 ask): single-turn transcript, input debounced/disabled in-flight, sources shown per answer, untrusted text via `textContent`.

## Other
- `recap.py`: `VllmClient.generate` gains keyword-only `max_tokens`/`temperature` overrides (defaulted to the recap constants — **zero change for existing callers**).
- `nix/home.nix`: the viewer unit gets the `vllm-recap` model env (best-effort).

## Tests
**41 new (assistant) + 12 new (viewer)**; full `scripts/run-tests.sh` hermetic set green. Covers the tools, intent classification, the loop with a mocked model (intent→tool→grounded answer; anti-confab — no invented initiatives in sources), best-effort degradation (store/model down), and the `/api/ask` endpoint + chat-pane render (string-presence).

## Live verification (not just tests)
CLI + a running viewer against the **real store + `vllm-recap`**:
- `what's blocked on me?` → grounded answer citing `spend-analytics`, `task-spec-drafter` (both genuinely awaiting Zach).
- `what's stalled?`, `what am I working on?`, `what's running right now?` → grounded, sources match the tool output exactly.
- `POST /api/ask` over HTTP → `{ok, answer, sources, intent}`; bad body → 400; healthz ok; chat pane present in served HTML.

## Residual risk
- **No write/dispatch path** — every tool only SELECTs the store / reads a guarded handoff / calls the model to phrase text. A prompt-injected handoff or status can only skew an ANSWER, never trigger an action. `/api/ask` is LAN-bound + unauthenticated by the same trust model as the rest of the viewer (Zach's call), input-capped, with no side effect.
- `route()`'s word-equality matcher misses morphological variants (`polish`≠`polishing`) — inherited; a triage/status ask on prose may under-recall (falls back to a substring scan for `status_of`).
- Answer quality rides on the 7B; low-context initiatives get thinner phrasing (degrades to honest, not wrong).

**The human deploys + eyeballs the sidebar chat** (not merged/deployed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)