### PR TITLE
feat(task-spec-drafter): deterministic ticket-status prior-art/merge probe

### DIFF
--- a/scripts/task-spec-drafter/README.md
+++ b/scripts/task-spec-drafter/README.md
@@ -85,6 +85,7 @@ though Haiku alone did not flag them.**
 |---|---|
 | `scripts/task-spec-drafter/drafter.sh` | Orchestrator — fetches the queue, runs the per-ticket headless pass, writes the shadow queue, routes to clawgate (shadow/on). |
 | `scripts/task-spec-drafter/drafter-prompt.md` | The five-step pipeline prompt (the LLM reasoning core). Read-only HARD CONSTRAINTS up top. |
+| `scripts/task-spec-drafter/ticket-status` | **Deterministic** prior-art / merge-status probe (NO LLM). One allowlisted command the pass runs FIRST instead of hand-rolling ticket→code `git log`/`merge-base`/`gh`: validates the untrusted ticket-id + terms, greps the `CU <id>` commit convention, checks merged-to-trunk, fetches for freshness, and emits `{verdict: ALREADY-DONE\|PARTIAL\|NOT-FOUND, …}` JSON. The safe boundary that lets the allowlist drop hand-rolled git. |
 | `scripts/task-spec-drafter/task-spec-drafter.env.example` | Copy to `~/.claude/task-spec-drafter.env`. Master knob `DRAFTER_MODE`. |
 | `scripts/task-spec-drafter/systemd/*.{service,timer}` | Daily user timer (09:15 local). |
 

--- a/scripts/task-spec-drafter/drafter-prompt.md
+++ b/scripts/task-spec-drafter/drafter-prompt.md
@@ -73,6 +73,22 @@ other tickets may be referenced for CORRELATE but are not yours to classify here
 
 ## Tooling available
 
+- **`ticket-status` — the DETERMINISTIC prior-art / merge-status probe (USE THIS
+  FIRST).** A fixed, allowlisted wrapper that answers "is this ticket already done
+  / where does it live / is it merged to trunk?" deterministically, with NO
+  hand-rolled git. It runs the ticket-id commit-convention search (`CU <id>`), the
+  merged-to-trunk check, branch/PR lookups, and a freshness `git fetch` for you,
+  and emits JSON: `{verdict: ALREADY-DONE|PARTIAL|NOT-FOUND, prior_art:[…],
+  prs:[…], branches:[…], clone_fresh, behind_trunk, evidence:[…]}`. Run it as the
+  FIRST verification step and **prefer its JSON verdict over hand-rolling
+  `git log`/`merge-base`/`gh` yourself**:
+
+      /home/zach/workspace/devrc/scripts/task-spec-drafter/ticket-status <ticket-id>
+
+  (single verb, absolute path, obeys the command-shape contract). Optionally pass a
+  few plain keyword terms after the id. It only READS + fetches the civitai origin;
+  it makes no writes. Fall back to the raw git verbs below only to dig deeper into a
+  commit `ticket-status` surfaced.
 - **ClickUp** via the `clickup` skill CLI (read-only here):
   `node /home/zach/.claude/skills/clickup/query.mjs get <id>` (full body, status,
   dates, assignees, links) and `... comments <id> --threads` (ALL comments).
@@ -104,8 +120,11 @@ have crashed Meilisearch).
    created date + last-activity (compute AGE in days) + assignees + any linked
    tickets/PRs/URLs. Never reason from the title alone.
 2. **VERIFY current state** — cross-check vs reality on the axes that apply:
-   - *Already fixed?* search civitai git log / PRs for the referenced behavior;
-     if a merged PR addresses it, note the PR # + merge date.
+   - *Already fixed?* **Run `ticket-status <ticket-id>` FIRST** and read its
+     `verdict` + `prior_art`/`prs` — that is the deterministic answer to "already
+     done / merged to trunk?" (prefer it over hand-rolled `git log`/`gh`). Only
+     dig into a specific commit with the raw git verbs if you need more than it
+     surfaced; if a merged PR addresses it, note the PR # + merge date.
    - *Still happening?* check live metrics/alerts — is the alert still firing, is
      the bad behavior still observable?
    - *Intentionally off / constrained?* check whether the component is suspended,

--- a/scripts/task-spec-drafter/drafter.sh
+++ b/scripts/task-spec-drafter/drafter.sh
@@ -106,7 +106,9 @@ API_URL="${CLAWGATE_API_URL:-http://192.168.50.250:30302}"
 HOOK_TOKEN="${CLAWGATE_HOOK_TOKEN:-}"
 HOST="${CLAUDE_HOST:-$(hostname 2>/dev/null || echo unknown)}"
 
-CIVITAI_REPO="${CIVITAI_REPO:-/home/zach/workspace/civit/civitai}"
+# Exported so the deterministic `ticket-status` wrapper (invoked by the pass)
+# scopes its git -C to the SAME configured repo as the rest of the pipeline.
+export CIVITAI_REPO="${CIVITAI_REPO:-/home/zach/workspace/civit/civitai}"
 PROD_KUBECONFIG="${PROD_KUBECONFIG:-/home/zach/workspace/civit/datapacket-talos/prod-kubeconfig}"
 
 # --- daily email digest (the SHADOW review surface) ------------------------
@@ -175,8 +177,18 @@ export REPO_COS_PROD_KUBECONFIG="${REPO_COS_PROD_KUBECONFIG:-$HOME/workspace/hom
 #    cannot be safely allowlisted — DROP it, don't narrow it. Its only use ("is X
 #    merged / on trunk?") is already covered by merge-base --is-ancestor /
 #    branch --contains / rev-list. Do NOT re-add it (test guards this).
+#
+# ✅ `ticket-status` (added 2026-07): the DETERMINISTIC prior-art/merge-status
+#    wrapper (this dir's `ticket-status`). It replaces the hand-rolled ticket→code
+#    prior-art + merge search the pass ran on EVERY ticket (44+22 sessions of toil,
+#    and the driver behind the permission-block storm + the RCE-prone ls-remote
+#    allowlist expansion above). The entry pins the wrapper's FIXED absolute path
+#    (`$SELF_DIR/ticket-status*`) — because it is a fixed script, the pass cannot
+#    inject flags into git THROUGH it: the wrapper validates the (untrusted) ticket
+#    id + terms and controls exactly what git runs. This is the safe boundary the
+#    audit called for; prefer it over hand-rolled git in the prompt.
 # Override DRAFTER_ALLOWED_TOOLS via env ONLY with read-only verbs.
-DRAFTER_ALLOWED_TOOLS="${DRAFTER_ALLOWED_TOOLS:-Read,Glob,Grep,WebFetch,Bash(node *query.mjs get*),Bash(node *query.mjs comments*),Bash(node *query.mjs search*),Bash(git -C * log*),Bash(git -C * show*),Bash(git -C * diff*),Bash(git -C * grep*),Bash(git -C * branch --contains*),Bash(git -C * rev-parse*),Bash(git -C * rev-list*),Bash(git -C * merge-base*),Bash(git -C * for-each-ref*),Bash(git -C * symbolic-ref --short*),Bash(git -C * ls-files*),Bash(git -C * cat-file*),Bash(git log*),Bash(gh pr list*),Bash(gh pr view*),Bash(gh pr checks*),Bash(gh search*),Bash(kubectl get*),Bash(kubectl logs*),Bash(kubectl describe*),Bash(kubectl top*),Bash(grep*),Bash(rg*),Bash(jq*),Bash(cat*),Bash(echo*),Bash(date*)}"
+DRAFTER_ALLOWED_TOOLS="${DRAFTER_ALLOWED_TOOLS:-Read,Glob,Grep,WebFetch,Bash($SELF_DIR/ticket-status*),Bash(node *query.mjs get*),Bash(node *query.mjs comments*),Bash(node *query.mjs search*),Bash(git -C * log*),Bash(git -C * show*),Bash(git -C * diff*),Bash(git -C * grep*),Bash(git -C * branch --contains*),Bash(git -C * rev-parse*),Bash(git -C * rev-list*),Bash(git -C * merge-base*),Bash(git -C * for-each-ref*),Bash(git -C * symbolic-ref --short*),Bash(git -C * ls-files*),Bash(git -C * cat-file*),Bash(git log*),Bash(gh pr list*),Bash(gh pr view*),Bash(gh pr checks*),Bash(gh search*),Bash(kubectl get*),Bash(kubectl logs*),Bash(kubectl describe*),Bash(kubectl top*),Bash(grep*),Bash(rg*),Bash(jq*),Bash(cat*),Bash(echo*),Bash(date*)}"
 
 mkdir -p "$DRAFTER_OUT_DIR" 2>/dev/null || true
 # The delta-state file may live outside OUT_DIR (e.g. ~/.local/state/...); make
@@ -394,6 +406,7 @@ title: $TNAME
 current_status: $TSTATUS
 
 Environment for your tools:
+  TICKET_STATUS (run FIRST for prior-art/merge verdict): $SELF_DIR/ticket-status $TID
   CLICKUP_CLI: node $CLICKUP_CLI get $TID   |   node $CLICKUP_CLI comments $TID --threads
   CIVITAI_REPO: $CIVITAI_REPO
   PROD_KUBECONFIG: $PROD_KUBECONFIG

--- a/scripts/task-spec-drafter/drafter.sh
+++ b/scripts/task-spec-drafter/drafter.sh
@@ -109,6 +109,13 @@ HOST="${CLAUDE_HOST:-$(hostname 2>/dev/null || echo unknown)}"
 # Exported so the deterministic `ticket-status` wrapper (invoked by the pass)
 # scopes its git -C to the SAME configured repo as the rest of the pipeline.
 export CIVITAI_REPO="${CIVITAI_REPO:-/home/zach/workspace/civit/civitai}"
+# SECURITY: PIN the wrapper's repo on the drafter path. The pass auto-runs
+# ticket-status over UNTRUSTED ticket text with no --permission-mode plan, so
+# injected content could otherwise ride in a `--repo <planted-checkout>` option —
+# which is RCE (the planted repo's own git config execs on `git fetch`) and
+# cross-repo info-disclosure. With this lock set, the wrapper IGNORES any --repo
+# and uses only $CIVITAI_REPO, so no injected option can steer which repo it reads.
+export TICKET_STATUS_LOCK_REPO="$CIVITAI_REPO"
 PROD_KUBECONFIG="${PROD_KUBECONFIG:-/home/zach/workspace/civit/datapacket-talos/prod-kubeconfig}"
 
 # --- daily email digest (the SHADOW review surface) ------------------------

--- a/scripts/task-spec-drafter/tests/test_ticket_status.py
+++ b/scripts/task-spec-drafter/tests/test_ticket_status.py
@@ -83,6 +83,41 @@ def repo(tmp_path):
             "merged_sha": merged_sha, "unmerged_sha": unmerged_sha}
 
 
+@pytest.fixture()
+def poison_repo(tmp_path):
+    """A real git repo whose OWN config execs a marker on `git fetch` — the exact
+    RCE the audit proved (`remote.origin.uploadpack = 'touch <marker>; ...'` on a
+    local/file remote runs locally). Used to prove the pin/root-allowlist refuse it
+    and that the fetch-config neutralisation defangs it even when pinned."""
+    porigin = tmp_path / "porigin.git"
+    pwork = tmp_path / "poison"
+    marker = tmp_path / "PWNED"
+    subprocess.run(["git", "init", "-q", "--bare", str(porigin)], env=_GIT_ENV, check=True)
+    subprocess.run(["git", "init", "-q", str(pwork)], env=_GIT_ENV, check=True)
+    _git(pwork, "remote", "add", "origin", str(porigin))
+    _git(pwork, "checkout", "-q", "-b", "main")
+    _commit(pwork, "CU 86abc123 planted", "p.txt")
+    _git(pwork, "push", "-q", "origin", "main")
+    # poison the repo's own config: fetch will run this uploadpack command locally
+    _git(pwork, "config", "remote.origin.uploadpack", f"touch {marker}; git-upload-pack")
+    return {"work": pwork, "origin": porigin, "marker": marker}
+
+
+def _bare_fetch_fires(poison) -> bool:
+    """Sanity control: does a plain `git fetch origin` (NO neutralisation) actually
+    trip the poisoned config on this git build? If not, the fixture can't prove the
+    guard, so the dependent test skips."""
+    m = poison["marker"]
+    if m.exists():
+        m.unlink()
+    subprocess.run(["git", "-C", str(poison["work"]), "fetch", "--quiet", "origin"],
+                   env=_GIT_ENV, capture_output=True, text=True)
+    fired = m.exists()
+    if fired:
+        m.unlink()
+    return fired
+
+
 def _fake_gh(tmp_path, payload):
     """A fake `gh` that ignores its args and prints FAKE_GH_OUT. Shebang uses the
     absolute running interpreter so it resolves in the offline nix sandbox."""
@@ -93,11 +128,25 @@ def _fake_gh(tmp_path, payload):
     return p, json.dumps(payload)
 
 
-def _run_cli(repo_path, *args, gh="/nonexistent-gh", gh_out=None, fetch=False):
+def _run_cli(repo_path, *args, gh="/nonexistent-gh", gh_out=None, fetch=False,
+             allowed_roots="__parent__", lock_repo=None, with_repo=True):
     env = {**os.environ, "TICKET_STATUS_GH": str(gh)}
+    env.pop("TICKET_STATUS_LOCK_REPO", None)
+    env.pop("TICKET_STATUS_ALLOWED_REPO_ROOTS", None)
     if gh_out is not None:
         env["FAKE_GH_OUT"] = gh_out
-    argv = [sys.executable, str(_SCRIPT), *args, "--repo", str(repo_path)]
+    # By default, allow the temp repo (outside the built-in civitai root) so the
+    # behavioural tests can point --repo at it. Tests can override the roots or set
+    # a lock to exercise the pin.
+    if allowed_roots == "__parent__":
+        allowed_roots = str(Path(repo_path).parent)
+    if allowed_roots is not None:
+        env["TICKET_STATUS_ALLOWED_REPO_ROOTS"] = str(allowed_roots)
+    if lock_repo is not None:
+        env["TICKET_STATUS_LOCK_REPO"] = str(lock_repo)
+    argv = [sys.executable, str(_SCRIPT), *args]
+    if with_repo:
+        argv += ["--repo", str(repo_path)]
     if not fetch:
         argv.append("--no-fetch")
     return subprocess.run(argv, capture_output=True, text=True, env=env)
@@ -335,22 +384,102 @@ def test_no_shell_true_or_bash_c_in_source():
 
 
 def test_invalid_repo_config_errors_cleanly(tmp_path):
-    r = subprocess.run([sys.executable, str(_SCRIPT), "86abc123",
-                        "--repo", str(tmp_path / "nope"), "--no-fetch"],
-                       capture_output=True, text=True,
-                       env={**os.environ, "TICKET_STATUS_GH": "/nogh"})
+    r = _run_cli(tmp_path / "nope", "86abc123", allowed_roots=str(tmp_path))
     assert r.returncode == 2
     assert "repo not found" in r.stderr
 
 
 def test_non_git_dir_rejected(tmp_path):
     (tmp_path / "plain").mkdir()
-    r = subprocess.run([sys.executable, str(_SCRIPT), "86abc123",
-                        "--repo", str(tmp_path / "plain"), "--no-fetch"],
-                       capture_output=True, text=True,
-                       env={**os.environ, "TICKET_STATUS_GH": "/nogh"})
+    r = _run_cli(tmp_path / "plain", "86abc123", allowed_roots=str(tmp_path))
     assert r.returncode == 2
     assert "not a git work tree" in r.stderr
+
+
+# ============================================================================
+# SECURITY (audit round) — --repo is attacker-reachable on the drafter path
+# ============================================================================
+def test_repo_outside_allowed_roots_is_refused(repo, tmp_path):
+    """A standalone `--repo` pointing outside the allowed roots (another repo, a
+    planted checkout) is REFUSED — closes cross-repo info-disclosure + RCE-via-
+    planted-config, since we never even fetch it."""
+    other = tmp_path / "somewhere-else"
+    r = _run_cli(repo["work"], "86abc123", allowed_roots=str(other))
+    assert r.returncode == 2
+    assert "outside the allowed roots" in r.stderr
+    assert r.stdout == ""
+
+
+def test_repo_within_allowed_roots_still_works(repo):
+    """`--repo` inside an allowed root works for interactive/standalone use."""
+    d = _json_cli(repo["work"], "86abc123")  # default allowed_roots = parent
+    assert d["repo"] == os.path.realpath(str(repo["work"]))
+    assert d["verdict"] == "ALREADY-DONE"
+
+
+def test_lock_env_ignores_repo_option(repo, tmp_path):
+    """LOCK (drafter path): with TICKET_STATUS_LOCK_REPO set, a caller `--repo
+    <anything>` is IGNORED and the locked repo is used — injected options cannot
+    steer which repo is read."""
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    d = _json_cli(elsewhere, "86abc123", lock_repo=repo["work"], allowed_roots=None,
+                  with_repo=True)
+    assert d["repo"] == os.path.realpath(str(repo["work"]))
+    assert any("ignored --repo" in w for w in d["warnings"])
+
+
+def test_lock_env_ignores_poison_repo_no_exec(repo, poison_repo):
+    """RCE finding, LOCK layer: lock to the CLEAN repo, pass `--repo <poison>` — the
+    poison repo is ignored and never fetched, so its config never execs."""
+    if poison_repo["marker"].exists():
+        poison_repo["marker"].unlink()
+    d = _json_cli(poison_repo["work"], "86abc123", lock_repo=repo["work"],
+                  allowed_roots=None, fetch=True)
+    assert d["repo"] == os.path.realpath(str(repo["work"]))
+    assert not poison_repo["marker"].exists(), "poison config executed — RCE not blocked"
+
+
+def test_poison_repo_refused_without_lock_no_exec(repo, poison_repo, tmp_path):
+    """RCE finding, ROOT-ALLOWLIST layer: a `--repo <poison>` outside the allowed
+    roots is refused BEFORE any fetch, so nothing execs."""
+    if poison_repo["marker"].exists():
+        poison_repo["marker"].unlink()
+    # allow only the clean repo dir itself; poison is a sibling, so it's outside.
+    r = _run_cli(poison_repo["work"], "86abc123",
+                 allowed_roots=str(repo["work"]), fetch=True)
+    assert r.returncode == 2
+    assert "outside the allowed roots" in r.stderr
+    assert not poison_repo["marker"].exists()
+
+
+def test_fetch_config_neutralised_even_when_pinned(poison_repo):
+    """Defense-in-depth: even when the poison repo is the PINNED/locked target, the
+    fetch runs with the exec config neutralised, so it must NOT exec the marker.
+    Skips if the fixture's poison doesn't fire under a plain fetch on this git."""
+    if not _bare_fetch_fires(poison_repo):
+        pytest.skip("poisoned uploadpack did not fire under a plain fetch on this git build")
+    # sanity: the control just proved a bare fetch DOES fire; now the wrapper must not
+    assert not poison_repo["marker"].exists()
+    d = _json_cli(poison_repo["work"], "86abc123", lock_repo=poison_repo["work"],
+                  allowed_roots=None, fetch=True)
+    assert not poison_repo["marker"].exists(), \
+        "fetch executed poisoned uploadpack despite neutralisation"
+    # still produced an answer from the (now-fetched) pinned repo
+    assert d["verdict"] in ("ALREADY-DONE", "PARTIAL", "NOT-FOUND")
+
+
+def test_trunk_leading_dash_rejected(repo):
+    r = _run_cli(repo["work"], "86abc123", "--trunk", "-x")
+    assert r.returncode == 2
+    assert "must not start with '-'" in r.stderr
+
+
+def test_fetch_timeout_nonpositive_rejected(repo):
+    for bad in ("-5", "0"):
+        r = _run_cli(repo["work"], "86abc123", "--fetch-timeout", bad)
+        assert r.returncode == 2, f"expected rejection for --fetch-timeout {bad}"
+        assert "positive integer" in r.stderr
 
 
 # ============================================================================
@@ -374,6 +503,13 @@ def test_wrapper_allowlist_entry_is_fixed_path_prefix():
     al = _allowlist_line()
     assert "$SELF_DIR/ticket-status" in al
     assert "Bash($SELF_DIR/ticket-status*)" in al
+
+
+def test_drafter_pins_wrapper_repo_via_lock_env():
+    """The drafter must set TICKET_STATUS_LOCK_REPO so injected `--repo` options in
+    ticket text cannot steer the wrapper's repo (RCE + cross-repo disclosure)."""
+    src = _DRAFTER.read_text(encoding="utf-8")
+    assert 'export TICKET_STATUS_LOCK_REPO="$CIVITAI_REPO"' in src
 
 
 def test_wrapper_addition_did_not_reintroduce_write_or_rce_verbs():

--- a/scripts/task-spec-drafter/tests/test_ticket_status.py
+++ b/scripts/task-spec-drafter/tests/test_ticket_status.py
@@ -1,0 +1,395 @@
+"""Hermetic tests for the deterministic `ticket-status` wrapper.
+
+NO live cluster / ClickUp / network. Prior-art + merge classification is proven
+against REAL temp git repos built in-test (the nix sandbox has `git`); the origin
+remote is a local file path so `git fetch` is offline-safe. gh is faked via the
+`TICKET_STATUS_GH` env override (or pointed at a missing path to prove graceful
+degradation). The security cases prove that untrusted input is rejected or
+neutralised — never executed.
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+_SCRIPT = _HERE.parent / "ticket-status"
+_DRAFTER = _HERE.parent / "drafter.sh"
+_PROMPT = _HERE.parent / "drafter-prompt.md"
+
+
+# --- load the extension-less script as a module -------------------------------
+def _load_mod():
+    # The script has no .py extension, so give importlib an explicit source loader.
+    loader = importlib.machinery.SourceFileLoader("ticket_status", str(_SCRIPT))
+    spec = importlib.util.spec_from_loader("ticket_status", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+ts = _load_mod()
+
+
+# --- git test-repo fixtures ---------------------------------------------------
+_GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+    "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull,
+}
+
+
+def _git(cwd, *args):
+    return subprocess.run(["git", "-C", str(cwd), *args], env=_GIT_ENV,
+                          capture_output=True, text=True, check=True)
+
+
+def _commit(work, msg, fname):
+    (Path(work) / fname).write_text(fname, encoding="utf-8")
+    _git(work, "add", fname)
+    _git(work, "commit", "-q", "-m", msg)
+    return _git(work, "rev-parse", "HEAD").stdout.strip()
+
+
+@pytest.fixture()
+def repo(tmp_path):
+    """A work clone with a local-file 'origin' bare remote (offline fetch-safe).
+
+    main has:  'CU 86abc123 add feature X' (merged), then an unrelated commit.
+    A branch 'feature/CU-99xyz-wip' carries an UNMERGED id commit.
+    """
+    origin = tmp_path / "origin.git"
+    work = tmp_path / "work"
+    subprocess.run(["git", "init", "-q", "--bare", str(origin)], env=_GIT_ENV, check=True)
+    subprocess.run(["git", "init", "-q", str(work)], env=_GIT_ENV, check=True)
+    _git(work, "remote", "add", "origin", str(origin))
+    _git(work, "checkout", "-q", "-b", "main")
+    merged_sha = _commit(work, "CU 86abc123 add feature X", "a.txt")
+    _commit(work, "unrelated cache tweak", "b.txt")
+    _git(work, "push", "-q", "origin", "main")
+    # unmerged id branch
+    _git(work, "checkout", "-q", "-b", "feature/CU-99xyz-wip")
+    unmerged_sha = _commit(work, "CU 99xyz partial work", "c.txt")
+    _git(work, "checkout", "-q", "main")
+    return {"origin": origin, "work": work,
+            "merged_sha": merged_sha, "unmerged_sha": unmerged_sha}
+
+
+def _fake_gh(tmp_path, payload):
+    """A fake `gh` that ignores its args and prints FAKE_GH_OUT. Shebang uses the
+    absolute running interpreter so it resolves in the offline nix sandbox."""
+    p = tmp_path / "gh"
+    p.write_text(f"#!{sys.executable}\nimport os,sys\nsys.stdout.write(os.environ.get('FAKE_GH_OUT',''))\n",
+                 encoding="utf-8")
+    p.chmod(0o755)
+    return p, json.dumps(payload)
+
+
+def _run_cli(repo_path, *args, gh="/nonexistent-gh", gh_out=None, fetch=False):
+    env = {**os.environ, "TICKET_STATUS_GH": str(gh)}
+    if gh_out is not None:
+        env["FAKE_GH_OUT"] = gh_out
+    argv = [sys.executable, str(_SCRIPT), *args, "--repo", str(repo_path)]
+    if not fetch:
+        argv.append("--no-fetch")
+    return subprocess.run(argv, capture_output=True, text=True, env=env)
+
+
+def _json_cli(*a, **k):
+    r = _run_cli(*a, **k)
+    assert r.returncode == 0, f"rc={r.returncode} stderr={r.stderr}"
+    return json.loads(r.stdout)
+
+
+# ============================================================================
+# Prior-art + verdict
+# ============================================================================
+def test_prior_art_hit_by_ticket_id_commit_convention(repo):
+    d = _json_cli(repo["work"], "86abc123")
+    shas = {pa["full_sha"] for pa in d["prior_art"]}
+    assert repo["merged_sha"] in shas
+    hit = next(pa for pa in d["prior_art"] if pa["full_sha"] == repo["merged_sha"])
+    assert hit["match_kind"] == "id"
+    assert hit["subject"] == "CU 86abc123 add feature X"
+
+
+def test_merged_id_commit_yields_already_done(repo):
+    d = _json_cli(repo["work"], "86abc123")
+    assert d["verdict"] == "ALREADY-DONE"
+    assert any(pa["merged_to_trunk"] is True for pa in d["prior_art"])
+
+
+def test_unmerged_id_commit_yields_partial(repo):
+    d = _json_cli(repo["work"], "CU-99xyz")
+    assert d["verdict"] == "PARTIAL"
+    hit = next(pa for pa in d["prior_art"] if pa["full_sha"] == repo["unmerged_sha"])
+    assert hit["merged_to_trunk"] is False
+    # the branch name carrying the id is surfaced too
+    assert any("99xyz" in b for b in d["branches"])
+
+
+def test_not_found_verdict(repo):
+    d = _json_cli(repo["work"], "ZZ00000")
+    assert d["verdict"] == "NOT-FOUND"
+    assert d["prior_art"] == []
+    assert d["branches"] == []
+
+
+def test_core_id_strips_cu_prefix_and_matches_bare(repo):
+    # 'CU-86abc123' must still match the 'CU 86abc123 ...' commit via core-id.
+    d = _json_cli(repo["work"], "CU-86abc123")
+    assert d["verdict"] == "ALREADY-DONE"
+    assert repo["merged_sha"] in {pa["full_sha"] for pa in d["prior_art"]}
+
+
+def test_json_shape_has_required_keys(repo):
+    d = _json_cli(repo["work"], "86abc123")
+    for k in ("ticket_id", "repo", "trunk", "clone_fresh", "behind_trunk",
+              "verdict", "deploy_status", "prior_art", "prs", "branches",
+              "evidence", "warnings", "generated_at"):
+        assert k in d, f"missing key {k}"
+    assert d["ticket_id"] == "86abc123"
+    assert d["verdict"] in ("ALREADY-DONE", "PARTIAL", "NOT-FOUND")
+    pa = d["prior_art"][0]
+    for k in ("commit", "full_sha", "subject", "match_kind", "merged_to_trunk",
+              "branches", "tags", "deploy_status"):
+        assert k in pa
+
+
+def test_verdict_rollup_unit():
+    # merged id commit -> ALREADY-DONE
+    assert ts.compute_verdict([{"match_kind": "id", "merged_to_trunk": True}], [], []) == "ALREADY-DONE"
+    # merged id PR -> ALREADY-DONE
+    assert ts.compute_verdict([], [{"match_kind": "id", "state": "MERGED"}], []) == "ALREADY-DONE"
+    # unmerged id commit -> PARTIAL
+    assert ts.compute_verdict([{"match_kind": "id", "merged_to_trunk": False}], [], []) == "PARTIAL"
+    # merged TERM commit is NOT decisive -> PARTIAL (keyword coincidence guard)
+    assert ts.compute_verdict([{"match_kind": "term", "merged_to_trunk": True}], [], []) == "PARTIAL"
+    # branch-only -> PARTIAL
+    assert ts.compute_verdict([], [], ["feature/x"]) == "PARTIAL"
+    # nothing -> NOT-FOUND
+    assert ts.compute_verdict([], [], []) == "NOT-FOUND"
+
+
+# ============================================================================
+# gh integration (faked; also proves graceful offline degradation)
+# ============================================================================
+def test_gh_merged_id_pr_yields_already_done(repo, tmp_path):
+    gh, out = _fake_gh(tmp_path, [{"number": 42, "title": "fix thing",
+                                   "state": "MERGED", "url": "http://x/42"}])
+    # search a ticket id with NO prior-art commit; the merged id-PR decides it.
+    d = _json_cli(repo["work"], "PR00001", gh=gh, gh_out=out)
+    assert d["verdict"] == "ALREADY-DONE"
+    assert d["prs"] and d["prs"][0]["state"] == "MERGED"
+
+
+def test_gh_open_pr_only_is_partial(repo, tmp_path):
+    gh, out = _fake_gh(tmp_path, [{"number": 7, "title": "wip",
+                                   "state": "OPEN", "url": "http://x/7"}])
+    d = _json_cli(repo["work"], "PR00002", gh=gh, gh_out=out)
+    assert d["verdict"] == "PARTIAL"
+
+
+def test_gh_unavailable_degrades_gracefully(repo):
+    d = _json_cli(repo["work"], "86abc123", gh="/nonexistent-gh")
+    # still answers from git; warns that gh was unavailable
+    assert d["verdict"] == "ALREADY-DONE"
+    assert any("gh unavailable" in w for w in d["warnings"])
+
+
+# ============================================================================
+# Freshness
+# ============================================================================
+def test_no_fetch_reports_not_fresh(repo):
+    d = _json_cli(repo["work"], "86abc123", fetch=False)
+    assert d["clone_fresh"] is False
+    assert any("fetch skipped" in w for w in d["warnings"])
+
+
+def test_fetch_detects_behind_origin(repo):
+    # advance origin/main by pushing a new commit from a SECOND clone, so the
+    # first clone is behind until it fetches.
+    work2 = repo["work"].parent / "work2"
+    subprocess.run(["git", "clone", "-q", str(repo["origin"]), str(work2)],
+                   env=_GIT_ENV, check=True)
+    _git(work2, "checkout", "-q", "main")
+    _commit(work2, "CU 55new later work", "d.txt")
+    _git(work2, "push", "-q", "origin", "main")
+    # now fetch from the first clone -> fresh, and HEAD is behind origin/main
+    d = _json_cli(repo["work"], "86abc123", fetch=True)
+    assert d["clone_fresh"] is True
+    assert d["behind_trunk"] == 1
+
+
+def test_fetch_failure_is_stale_but_still_answers(repo, tmp_path):
+    # point origin at a bogus path so `git fetch origin` fails (offline sim)
+    _git(repo["work"], "remote", "set-url", "origin", str(tmp_path / "does-not-exist.git"))
+    d = _json_cli(repo["work"], "86abc123", fetch=True)
+    assert d["clone_fresh"] is False
+    assert any("STALE" in w for w in d["warnings"])
+    assert d["verdict"] == "ALREADY-DONE"  # local answer still produced
+
+
+# ============================================================================
+# deploy_status (optional signal)
+# ============================================================================
+def test_deploy_status_unknown_by_default(repo):
+    d = _json_cli(repo["work"], "86abc123")
+    assert d["deploy_status"] == "unknown"
+
+
+def test_deploy_status_in_release_tag_when_tagged(repo):
+    _git(repo["work"], "tag", "v1.0.0", repo["merged_sha"])
+    d = _json_cli(repo["work"], "86abc123")
+    hit = next(pa for pa in d["prior_art"] if pa["full_sha"] == repo["merged_sha"])
+    assert "v1.0.0" in hit["tags"]
+    assert d["deploy_status"] == "in-release-tag"
+
+
+# ============================================================================
+# SECURITY — untrusted input is rejected or neutralised, never executed
+# ============================================================================
+@pytest.mark.parametrize("bad", [
+    "foo; rm -rf /",            # shell metachars
+    "--upload-pack=sh",         # flag-injection / RCE flag
+    "../../etc/passwd",         # path traversal
+    "86abc/../x",               # slash
+    "a b",                      # whitespace
+    "id$(id)",                  # command substitution
+    "id`whoami`",               # backticks
+    "id|cat",                   # pipe
+    "",                         # empty
+    "x" * 40,                   # too long
+])
+def test_malicious_ticket_id_rejected(repo, bad):
+    r = _run_cli(repo["work"], bad)
+    assert r.returncode == 2, f"expected rejection for {bad!r}, got rc={r.returncode}"
+    assert r.stdout == ""  # nothing produced
+
+
+def test_upload_pack_term_rejected_even_after_dashdash(repo):
+    """A term is UNTRUSTED; a leading-'-' term (e.g. the RCE `--upload-pack=<cmd>`)
+    must be rejected even when forced past option parsing with `--`."""
+    r = _run_cli(repo["work"], "86abc123", "--", "--upload-pack=sh -c id")
+    assert r.returncode == 2
+    assert "leading '-'" in r.stderr or "must not start with '-'" in r.stderr
+
+
+def test_dash_C_option_is_rejected_as_unknown(repo):
+    """An attacker term shaped like `-C /etc` cannot smuggle a git path: `-C` is
+    not a recognised option and is rejected."""
+    r = _run_cli(repo["work"], "86abc123", "-C", "/etc")
+    assert r.returncode == 2
+    assert "unknown/rejected option" in r.stderr
+
+
+def test_slash_etc_term_is_neutralised_as_literal_grep(repo):
+    """A benign-looking `/etc` term is NOT a flag/path — it is passed as a literal
+    fixed-strings grep term and never reaches git's -C. The run succeeds and -C is
+    only ever the resolved repo."""
+    d = _json_cli(repo["work"], "86abc123", "/etc")
+    assert d["repo"] == os.path.realpath(str(repo["work"]))
+    assert d["verdict"] in ("ALREADY-DONE", "PARTIAL", "NOT-FOUND")
+
+
+def test_git_C_is_scoped_to_resolved_repo_only(monkeypatch):
+    """Structural proof: the git() helper always emits `-C <repo>` and the repo is
+    the resolved config value — an untrusted arg can never become the -C path."""
+    calls = []
+
+    def fake_run(argv, timeout):
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, "true", "")
+
+    monkeypatch.setattr(ts, "_run", fake_run)
+    ts.git("/only/this/repo", "log", "--all")
+    assert calls[-1][:4] == [ts.GIT_BIN, "-C", "/only/this/repo", "log"]
+
+
+def test_no_shell_true_or_bash_c_in_source():
+    """AST-level proof (ignores docstrings/comments): no call passes shell=True,
+    and no os.system/os.popen is used — so untrusted input can never reach a
+    shell interpreter."""
+    import ast
+    tree = ast.parse(_SCRIPT.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if kw.arg == "shell":
+                    assert not (isinstance(kw.value, ast.Constant) and kw.value.value is True), \
+                        "a subprocess call uses shell=True"
+            if isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name):
+                banned = {("os", "system"), ("os", "popen")}
+                assert (node.func.value.id, node.func.attr) not in banned, \
+                    f"banned shell call {node.func.value.id}.{node.func.attr}"
+    # and every subprocess call goes through argv arrays (list first arg)
+    assert "subprocess.run(" in _SCRIPT.read_text(encoding="utf-8")
+
+
+def test_invalid_repo_config_errors_cleanly(tmp_path):
+    r = subprocess.run([sys.executable, str(_SCRIPT), "86abc123",
+                        "--repo", str(tmp_path / "nope"), "--no-fetch"],
+                       capture_output=True, text=True,
+                       env={**os.environ, "TICKET_STATUS_GH": "/nogh"})
+    assert r.returncode == 2
+    assert "repo not found" in r.stderr
+
+
+def test_non_git_dir_rejected(tmp_path):
+    (tmp_path / "plain").mkdir()
+    r = subprocess.run([sys.executable, str(_SCRIPT), "86abc123",
+                        "--repo", str(tmp_path / "plain"), "--no-fetch"],
+                       capture_output=True, text=True,
+                       env={**os.environ, "TICKET_STATUS_GH": "/nogh"})
+    assert r.returncode == 2
+    assert "not a git work tree" in r.stderr
+
+
+# ============================================================================
+# Drafter wiring (static) — allowlist entry + prompt, guards intact
+# ============================================================================
+def _allowlist_line() -> str:
+    src = _DRAFTER.read_text(encoding="utf-8")
+    return next(l for l in src.splitlines() if l.startswith("DRAFTER_ALLOWED_TOOLS="))
+
+
+def test_drafter_allowlists_the_wrapper():
+    al = _allowlist_line()
+    assert "ticket-status" in al, "ticket-status wrapper is not on the drafter allowlist"
+
+
+def test_wrapper_allowlist_entry_is_fixed_path_prefix():
+    """The entry must pin the wrapper's own directory ($SELF_DIR, which expands to
+    the script's absolute dir at runtime) so the drafter can only invoke THIS
+    script (which controls exactly what git runs) — not an arbitrary
+    `ticket-status` on PATH."""
+    al = _allowlist_line()
+    assert "$SELF_DIR/ticket-status" in al
+    assert "Bash($SELF_DIR/ticket-status*)" in al
+
+
+def test_wrapper_addition_did_not_reintroduce_write_or_rce_verbs():
+    """Adding the wrapper must not have loosened the read-only / no-RCE posture."""
+    al = _allowlist_line()
+    for bad in ("gh api", "curl", "ls-remote", "--upload-pack", "--exec",
+                "git -C * push", "git -C * commit", "git -C * fetch"):
+        assert bad not in al, f"forbidden verb/flag present: {bad}"
+
+
+def test_prompt_makes_ticket_status_the_first_prior_art_step():
+    p = " ".join(_PROMPT.read_text(encoding="utf-8").split())
+    assert "ticket-status" in p, "prompt does not mention the ticket-status wrapper"
+
+
+def test_prompt_still_has_command_shape_and_anticonfab_guards():
+    p = " ".join(_PROMPT.read_text(encoding="utf-8").split())
+    assert "COMMAND-SHAPE CONTRACT" in p
+    assert "ANTI-CONFABULATION GATE" in p

--- a/scripts/task-spec-drafter/ticket-status
+++ b/scripts/task-spec-drafter/ticket-status
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""ticket-status — deterministic ClickUp-ticket prior-art + merge-status probe.
+
+WHY THIS EXISTS
+---------------
+The task-spec-drafter's per-ticket headless pass hand-rolls the same
+"is this ticket already done / where does it live / is it merged to trunk?"
+git+gh dance on every single run (44+22 sessions of measured toil). That
+hand-rolling was ALSO the driver behind a permission-block storm and the
+RCE-prone `git ls-remote --upload-pack=<cmd>` allowlist expansion that a security
+audit later ripped back out.
+
+This wrapper is the DETERMINISTIC replacement: ONE allowlisted command the drafter
+calls instead of improvising git. Because it is a fixed script the drafter cannot
+inject flags into git THROUGH it — WE decide exactly what git runs, and every
+argument that originates from attacker-controllable ClickUp text is validated
+before it reaches a subprocess.
+
+SECURITY MODEL (the whole point)
+--------------------------------
+The ticket-id and free-text search terms originate from UNTRUSTED ClickUp content
+(title/body/comments a civitai *client* can edit). This script is the safe
+boundary:
+  * The ticket-id is validated against a tight regex; anything else is REJECTED.
+  * Free-text terms with a leading '-' are REJECTED (can't masquerade as a git
+    flag); terms only ever reach git as the literal value of a `--grep=<term>`
+    token under `--fixed-strings`, never as a standalone argv that git could
+    parse as an option.
+  * Every subprocess is an argv ARRAY — never a shell string, never shell=True,
+    never `bash -c`. No untrusted value can inject `&&`/`;`/`|`/`$()`/redirects.
+  * git is ALWAYS scoped with `-C <resolved-repo>` where the repo comes ONLY from
+    operator config (`--repo` / `$CIVITAI_REPO` / the built-in default) — NEVER
+    from a positional/untrusted arg. There is no code path where a search term or
+    ticket-id becomes the `-C` path (closes the audit's `-C <any path>` note).
+  * The only network egress is `git fetch <origin>` to the repo's own configured
+    remote, bounded by a timeout. gh reads degrade to "unavailable" offline.
+
+OUTPUT
+------
+Default `--json`: {ticket_id, repo, trunk, clone_fresh, behind_trunk, verdict,
+prior_art:[...], prs:[...], branches:[...], deploy_status, evidence:[...],
+warnings:[...]}. `--text` renders a short human summary.
+
+VERDICT (deterministic rollup)
+------------------------------
+  ALREADY-DONE  — a ticket-id-matched commit is merged to trunk (or a
+                  ticket-id-matched PR is MERGED). The ticket-id commit-convention
+                  match is the FIRST-CLASS decisive signal.
+  PARTIAL       — prior art exists (unmerged id commit, a branch, an open PR, or a
+                  keyword-term match) but nothing decisive is merged to trunk.
+  NOT-FOUND     — no prior art of any kind.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+# --- configuration (operator-controlled; NOT from untrusted ticket text) ------
+DEFAULT_REPO = os.environ.get("CIVITAI_REPO", "/home/zach/workspace/civit/civitai")
+DEFAULT_TRUNK = "origin/main"
+GIT_BIN = os.environ.get("TICKET_STATUS_GIT", "git")
+GH_BIN = os.environ.get("TICKET_STATUS_GH", "gh")
+DEFAULT_GIT_TIMEOUT = int(os.environ.get("TICKET_STATUS_GIT_TIMEOUT", "20"))
+DEFAULT_FETCH_TIMEOUT = int(os.environ.get("TICKET_STATUS_FETCH_TIMEOUT", "25"))
+MAX_COMMITS = 50
+
+# --- input validation ---------------------------------------------------------
+# ClickUp task ids are short alphanumerics, optionally with a leading list/custom
+# prefix (`CU-...`, `DEV-123`, `86abc1def`, `901111220963`). This regex is a TIGHT
+# allowlist: an optional `<LETTERS>-` prefix then alphanumerics only. It admits no
+# whitespace, no `/`, no `.`, no `=`, no leading `-`, and no shell metacharacter,
+# so a validated id can never be a git flag, a path, or a shell fragment.
+_TICKET_RE = re.compile(r"^(?:[A-Za-z]{1,10}-)?[A-Za-z0-9]{1,24}$")
+# Free-text terms: printable, bounded, and MUST NOT start with '-' (else it could
+# masquerade as a flag). Everything else is neutralised by fixed-strings grep.
+_TERM_MAX = 64
+
+
+class InputError(Exception):
+    """Raised for rejected untrusted input — surfaced to stderr, non-zero exit."""
+
+
+def validate_ticket_id(raw: str) -> str:
+    if not _TICKET_RE.match(raw or ""):
+        raise InputError(
+            f"invalid ticket id {raw!r}: must match {_TICKET_RE.pattern} "
+            "(ClickUp ids are short alphanumerics, optionally a LETTERS- prefix)"
+        )
+    return raw
+
+
+def validate_term(raw: str) -> str:
+    if not raw:
+        raise InputError("empty search term rejected")
+    if raw.startswith("-"):
+        raise InputError(
+            f"search term {raw!r} rejected: a leading '-' could be parsed by git "
+            "as a flag (e.g. --upload-pack=<cmd>); terms must be plain text"
+        )
+    if len(raw) > _TERM_MAX:
+        raise InputError(f"search term too long ({len(raw)} > {_TERM_MAX})")
+    if any(c in raw for c in "\n\r\x00"):
+        raise InputError("search term contains a control character")
+    return raw
+
+
+def core_id(ticket_id: str) -> str:
+    """Strip a leading `CU-` / `CU ` / `CU` list prefix so we also match the bare
+    numeric id inside the `CU <id>` commit convention."""
+    return re.sub(r"^CU[- ]?", "", ticket_id, flags=re.IGNORECASE) or ticket_id
+
+
+# --- subprocess helpers (argv arrays only; no shell, ever) --------------------
+def _run(argv: list[str], timeout: int) -> subprocess.CompletedProcess:
+    """Run an argv array with NO shell. Never raises on non-zero; on
+    timeout/missing-binary returns a synthetic failed result so callers degrade
+    gracefully instead of crashing."""
+    try:
+        return subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        return subprocess.CompletedProcess(argv, returncode=127, stdout="", stderr=str(exc))
+
+
+def git(repo: str, *args: str, timeout: int = DEFAULT_GIT_TIMEOUT) -> subprocess.CompletedProcess:
+    """git ALWAYS scoped to the resolved config repo via -C. `repo` is never an
+    untrusted value (see resolve_repo)."""
+    return _run([GIT_BIN, "-C", repo, *args], timeout)
+
+
+# --- repo / trunk resolution (operator config only) ---------------------------
+def resolve_repo(repo_arg: str | None) -> str:
+    repo = os.path.realpath(repo_arg or DEFAULT_REPO)
+    if not os.path.isdir(repo):
+        raise InputError(f"repo not found: {repo}")
+    r = git(repo, "rev-parse", "--is-inside-work-tree")
+    if r.returncode != 0 or r.stdout.strip() != "true":
+        raise InputError(f"not a git work tree: {repo}")
+    return repo
+
+
+def resolve_trunk(repo: str, trunk_arg: str) -> tuple[str | None, list[str]]:
+    """Return (trunk_ref_or_None, warnings). Try the requested trunk, then common
+    fallbacks, so `merged_to_trunk` is answerable even on an odd clone."""
+    warnings: list[str] = []
+    candidates = [trunk_arg, "origin/main", "origin/master", "main", "master"]
+    for cand in dict.fromkeys(candidates):  # de-dup, keep order
+        if git(repo, "rev-parse", "--verify", "--quiet", cand).returncode == 0:
+            if cand != trunk_arg:
+                warnings.append(f"trunk {trunk_arg!r} not found; using {cand!r}")
+            return cand, warnings
+    warnings.append(f"no trunk ref resolved (tried {candidates}); merge status unknown")
+    return None, warnings
+
+
+# --- freshness ----------------------------------------------------------------
+def refresh(repo: str, do_fetch: bool, fetch_timeout: int) -> tuple[bool, list[str]]:
+    """Fetch the repo's own origin (bounded) so `git log --all` sees merged work.
+    Returns (clone_fresh, warnings). Only egress point; the remote is the repo's
+    configured origin, never an argument."""
+    warnings: list[str] = []
+    if not do_fetch:
+        warnings.append("fetch skipped (--no-fetch): results reflect the local clone only")
+        return False, warnings
+    r = git(repo, "fetch", "--quiet", "--no-tags", "origin", timeout=fetch_timeout)
+    if r.returncode != 0:
+        warnings.append(
+            "git fetch origin failed (offline / no remote?): results may be STALE "
+            f"— {(r.stderr or '').strip()[:160]}"
+        )
+        return False, warnings
+    return True, warnings
+
+
+def behind_trunk(repo: str, trunk: str | None) -> int | None:
+    """How many commits local HEAD is behind trunk (informational staleness)."""
+    if trunk is None:
+        return None
+    r = git(repo, "rev-list", "--count", f"HEAD..{trunk}")
+    if r.returncode != 0:
+        return None
+    try:
+        return int(r.stdout.strip())
+    except ValueError:
+        return None
+
+
+# --- prior-art search ---------------------------------------------------------
+_US = "\x1f"  # unit separator between hash and subject
+
+
+def _log_grep(repo: str, patterns: list[str]) -> list[tuple[str, str]]:
+    """git log --all --fixed-strings --grep=<p> [--grep=<p>...] (OR semantics).
+    Returns [(sha, subject)]. Patterns are already-validated literals; --grep=<p>
+    is a single argv token under --fixed-strings, so none can act as a flag."""
+    if not patterns:
+        return []
+    argv = [
+        "log", "--all", "--no-color", f"--max-count={MAX_COMMITS}",
+        f"--format=%H{_US}%s", "--fixed-strings",
+    ]
+    for p in patterns:
+        argv.append(f"--grep={p}")
+    r = git(repo, *argv)
+    out: list[tuple[str, str]] = []
+    if r.returncode != 0:
+        return out
+    for line in r.stdout.splitlines():
+        if _US in line:
+            sha, subj = line.split(_US, 1)
+            out.append((sha.strip(), subj))
+    return out
+
+
+def merged_to_trunk(repo: str, sha: str, trunk: str | None) -> bool | None:
+    if trunk is None:
+        return None
+    rc = git(repo, "merge-base", "--is-ancestor", sha, trunk).returncode
+    if rc == 0:
+        return True
+    if rc == 1:
+        return False
+    return None  # error resolving
+
+
+def containing_refs(repo: str, sha: str, kind: str) -> list[str]:
+    """Branches or tags containing <sha>, via for-each-ref/tag (read-only)."""
+    if kind == "branches":
+        r = git(repo, "for-each-ref", "--contains", sha,
+                "--format=%(refname:short)", "refs/heads", "refs/remotes")
+    else:  # tags
+        r = git(repo, "tag", "--contains", sha)
+    if r.returncode != 0:
+        return []
+    return [x.strip() for x in r.stdout.splitlines() if x.strip()]
+
+
+def matching_branches(repo: str, needle: str) -> list[str]:
+    """Local+remote branch names whose short name contains the id (filtered in
+    Python — the id never becomes a git pattern/glob)."""
+    r = git(repo, "for-each-ref", "--format=%(refname:short)", "refs/heads", "refs/remotes")
+    if r.returncode != 0:
+        return []
+    nl = needle.lower()
+    return [b.strip() for b in r.stdout.splitlines() if nl in b.strip().lower()]
+
+
+# --- gh (best-effort; argv array; degrades to unavailable offline) ------------
+def gh_prs(repo: str, query: str, match_kind: str) -> tuple[list[dict], bool]:
+    """gh pr list scoped to the repo (via cwd), searching <query>. Returns
+    (prs, available). `query` is a single argv token; never a shell string."""
+    argv = [
+        GH_BIN, "pr", "list", "--search", query, "--state", "all",
+        "--limit", "20", "--json", "number,title,state,url",
+    ]
+    try:
+        r = subprocess.run(argv, cwd=repo, capture_output=True, text=True,
+                           timeout=DEFAULT_GIT_TIMEOUT, check=False)
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return [], False
+    if r.returncode != 0:
+        return [], False
+    try:
+        data = json.loads(r.stdout or "[]")
+    except json.JSONDecodeError:
+        return [], True
+    prs = []
+    for pr in data:
+        prs.append({
+            "number": pr.get("number"),
+            "title": pr.get("title", ""),
+            "state": pr.get("state", ""),
+            "url": pr.get("url", ""),
+            "match_kind": match_kind,
+        })
+    return prs, True
+
+
+# --- verdict rollup (deterministic) -------------------------------------------
+def compute_verdict(prior_art: list[dict], prs: list[dict], branches: list[str]) -> str:
+    merged_id = any(
+        pa["match_kind"] == "id" and pa["merged_to_trunk"] is True for pa in prior_art
+    )
+    merged_id_pr = any(
+        pr["match_kind"] == "id" and str(pr.get("state", "")).upper() == "MERGED"
+        for pr in prs
+    )
+    if merged_id or merged_id_pr:
+        return "ALREADY-DONE"
+    if prior_art or prs or branches:
+        return "PARTIAL"
+    return "NOT-FOUND"
+
+
+# --- orchestration ------------------------------------------------------------
+def probe(ticket_id: str, terms: list[str], repo_arg: str | None, trunk_arg: str,
+          do_fetch: bool, fetch_timeout: int) -> dict:
+    repo = resolve_repo(repo_arg)
+    clone_fresh, warnings = refresh(repo, do_fetch, fetch_timeout)
+    trunk, tw = resolve_trunk(repo, trunk_arg)
+    warnings += tw
+    behind = behind_trunk(repo, trunk)
+
+    evidence: list[str] = []
+
+    # --- prior-art by ticket-id (first-class, decisive) -----------------------
+    cid = core_id(ticket_id)
+    id_patterns = list(dict.fromkeys([ticket_id, cid]))  # de-dup
+    id_hits = _log_grep(repo, id_patterns)
+    evidence.append(
+        f"git log --all --fixed-strings --grep matched {len(id_hits)} commit(s) "
+        f"by ticket-id ({', '.join(id_patterns)})"
+    )
+    # --- prior-art by keyword terms (supplementary) ---------------------------
+    term_hits = _log_grep(repo, terms) if terms else []
+    if terms:
+        evidence.append(
+            f"git log --all --fixed-strings --grep matched {len(term_hits)} commit(s) "
+            f"by term(s) ({', '.join(terms)})"
+        )
+
+    id_shas = {s for s, _ in id_hits}
+    prior_art: list[dict] = []
+    seen: set[str] = set()
+    any_tagged_merged_id = False
+    for sha, subj in id_hits + term_hits:
+        if sha in seen:
+            continue
+        seen.add(sha)
+        kind = "id" if sha in id_shas else "term"
+        merged = merged_to_trunk(repo, sha, trunk)
+        tags = containing_refs(repo, sha, "tags")
+        entry = {
+            "commit": sha[:12],
+            "full_sha": sha,
+            "subject": subj,
+            "match_kind": kind,
+            "merged_to_trunk": merged,
+            "branches": containing_refs(repo, sha, "branches"),
+            "tags": tags,
+            "deploy_status": ("in-release-tag" if tags else "unknown"),
+        }
+        prior_art.append(entry)
+        if kind == "id" and merged and tags:
+            any_tagged_merged_id = True
+
+    # --- branch names containing the id --------------------------------------
+    branches = matching_branches(repo, cid)
+    if branches:
+        evidence.append(f"{len(branches)} branch name(s) contain the id: {', '.join(branches[:5])}")
+
+    # --- gh PRs (best-effort) -------------------------------------------------
+    prs: list[dict] = []
+    gh_avail = False
+    id_prs, a1 = gh_prs(repo, ticket_id, "id")
+    prs += id_prs
+    gh_avail = gh_avail or a1
+    if terms:
+        term_prs, a2 = gh_prs(repo, " ".join(terms), "term")
+        have = {p["number"] for p in prs}
+        prs += [p for p in term_prs if p["number"] not in have]
+        gh_avail = gh_avail or a2
+    if gh_avail:
+        evidence.append(f"gh pr list --search matched {len(prs)} PR(s)")
+    else:
+        warnings.append("gh unavailable/unauthenticated — PR search skipped (best-effort)")
+
+    verdict = compute_verdict(prior_art, prs, branches)
+    deploy_status = "in-release-tag" if any_tagged_merged_id else "unknown"
+    if deploy_status == "unknown":
+        warnings.append(
+            "deploy_status unknown: release-chain resolution is out of scope; only "
+            "a local containing-tag check is done"
+        )
+
+    return {
+        "ticket_id": ticket_id,
+        "repo": repo,
+        "trunk": trunk,
+        "clone_fresh": clone_fresh,
+        "behind_trunk": behind,
+        "verdict": verdict,
+        "deploy_status": deploy_status,
+        "prior_art": prior_art,
+        "prs": prs,
+        "branches": branches,
+        "evidence": evidence,
+        "warnings": warnings,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+
+# --- rendering ----------------------------------------------------------------
+def render_text(result: dict) -> str:
+    lines = []
+    lines.append(f"ticket {result['ticket_id']}  ->  {result['verdict']}")
+    lines.append(f"  repo: {result['repo']}  trunk: {result['trunk']}  "
+                 f"fresh: {result['clone_fresh']}  behind_trunk: {result['behind_trunk']}")
+    lines.append(f"  deploy_status: {result['deploy_status']}")
+    if result["prior_art"]:
+        lines.append("  prior art:")
+        for pa in result["prior_art"]:
+            m = {True: "merged", False: "UNMERGED", None: "merge-unknown"}[pa["merged_to_trunk"]]
+            lines.append(f"    - {pa['commit']} [{pa['match_kind']}/{m}] {pa['subject']}")
+    if result["prs"]:
+        lines.append("  PRs:")
+        for pr in result["prs"]:
+            lines.append(f"    - #{pr['number']} [{pr['state']}] {pr['title']}")
+    if result["branches"]:
+        lines.append(f"  branches: {', '.join(result['branches'])}")
+    if result["warnings"]:
+        lines.append("  warnings:")
+        for w in result["warnings"]:
+            lines.append(f"    ! {w}")
+    return "\n".join(lines)
+
+
+# --- CLI (hand-rolled so untrusted positionals get controlled validation) -----
+_USAGE = (
+    "usage: ticket-status <ticket-id> [term ...] "
+    "[--json|--text] [--repo PATH] [--trunk REF] [--no-fetch] "
+    "[--fetch-timeout N]\n"
+    "  <ticket-id>  ClickUp id (validated: LETTERS- prefix optional, then alnum)\n"
+    "  term ...     optional plain-text keywords (no leading '-')\n"
+    "  --json       structured output (DEFAULT)\n"
+    "  --text       short human summary\n"
+    "  --repo PATH  git repo to search (default $CIVITAI_REPO)\n"
+    "  --trunk REF  trunk ref for merge check (default origin/main)\n"
+    "  --no-fetch   skip the origin fetch (offline; may be stale)\n"
+    "  --fetch-timeout N  seconds for the origin fetch (default 25)\n"
+)
+
+
+def parse_args(argv: list[str]) -> dict:
+    """Hand-rolled parse: options are recognised only in their exact `--x` form;
+    the FIRST non-option is the ticket id, the rest are terms. `--` forces all
+    following tokens to be treated as positionals (still validated)."""
+    out = {"fmt": "json", "repo": None, "trunk": DEFAULT_TRUNK,
+           "fetch": True, "fetch_timeout": DEFAULT_FETCH_TIMEOUT}
+    positionals: list[str] = []
+    i = 0
+    only_positional = False
+    while i < len(argv):
+        a = argv[i]
+        if only_positional:
+            positionals.append(a)
+            i += 1
+            continue
+        if a == "--":
+            only_positional = True
+        elif a in ("-h", "--help"):
+            raise InputError("__help__")
+        elif a == "--json":
+            out["fmt"] = "json"
+        elif a == "--text":
+            out["fmt"] = "text"
+        elif a == "--no-fetch":
+            out["fetch"] = False
+        elif a == "--repo":
+            i += 1
+            if i >= len(argv):
+                raise InputError("--repo requires a path")
+            out["repo"] = argv[i]
+        elif a == "--trunk":
+            i += 1
+            if i >= len(argv):
+                raise InputError("--trunk requires a ref")
+            out["trunk"] = argv[i]
+        elif a == "--fetch-timeout":
+            i += 1
+            if i >= len(argv):
+                raise InputError("--fetch-timeout requires an integer")
+            try:
+                out["fetch_timeout"] = int(argv[i])
+            except ValueError:
+                raise InputError("--fetch-timeout must be an integer")
+        elif a.startswith("-") and a != "-":
+            # Unknown option OR an untrusted token trying to look like a flag.
+            raise InputError(f"unknown/rejected option {a!r} (terms must not start with '-')")
+        else:
+            positionals.append(a)
+        i += 1
+
+    if not positionals:
+        raise InputError("a ticket id is required\n" + _USAGE)
+    out["ticket_id"] = validate_ticket_id(positionals[0])
+    out["terms"] = [validate_term(t) for t in positionals[1:]]
+    return out
+
+
+def main(argv: list[str]) -> int:
+    try:
+        args = parse_args(argv)
+    except InputError as exc:
+        if str(exc) == "__help__":
+            sys.stdout.write(_USAGE)
+            return 0
+        sys.stderr.write(f"ticket-status: {exc}\n")
+        return 2
+    try:
+        result = probe(
+            args["ticket_id"], args["terms"], args["repo"], args["trunk"],
+            args["fetch"], args["fetch_timeout"],
+        )
+    except InputError as exc:
+        sys.stderr.write(f"ticket-status: {exc}\n")
+        return 2
+    if args["fmt"] == "text":
+        sys.stdout.write(render_text(result) + "\n")
+    else:
+        sys.stdout.write(json.dumps(result, indent=2) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/task-spec-drafter/ticket-status
+++ b/scripts/task-spec-drafter/ticket-status
@@ -28,12 +28,25 @@ boundary:
     parse as an option.
   * Every subprocess is an argv ARRAY — never a shell string, never shell=True,
     never `bash -c`. No untrusted value can inject `&&`/`;`/`|`/`$()`/redirects.
-  * git is ALWAYS scoped with `-C <resolved-repo>` where the repo comes ONLY from
-    operator config (`--repo` / `$CIVITAI_REPO` / the built-in default) — NEVER
-    from a positional/untrusted arg. There is no code path where a search term or
-    ticket-id becomes the `-C` path (closes the audit's `-C <any path>` note).
-  * The only network egress is `git fetch <origin>` to the repo's own configured
-    remote, bounded by a timeout. gh reads degrade to "unavailable" offline.
+  * git is ALWAYS scoped with `-C <resolved-repo>`. Which repo is a SECURITY
+    decision, because the untrusted drafter path auto-runs this wrapper over
+    injected ticket text that can smuggle in a `--repo <path>` OPTION:
+      - LOCK (drafter path, bulletproof): if `TICKET_STATUS_LOCK_REPO` is set,
+        `--repo` is IGNORED entirely and the locked path is used. drafter.sh sets
+        this to `$CIVITAI_REPO`, so injected options cannot steer the repo.
+      - ROOT-ALLOWLIST (standalone path): without the lock, `--repo` must resolve
+        INSIDE an allowlisted root (default: the configured `$CIVITAI_REPO`;
+        extend via `TICKET_STATUS_ALLOWED_REPO_ROOTS`, ':'-separated). Anything
+        outside is REFUSED (rc 2). This closes two proven attacks: (1) RCE — a
+        `--repo` pointed at a PLANTED checkout whose own git config
+        (`remote.origin.uploadpack` / `core.sshCommand`) EXECUTES on the internal
+        `git fetch`; (2) cross-repo info-disclosure — `--repo <another repo>`
+        reading a different client's commit subjects/branches into the LLM context.
+  * The internal `git fetch` additionally runs with the fetch-time exec config
+    NEUTRALISED (`remote.origin.uploadpack` reset, `protocol.ext.allow=never`,
+    `core.fsmonitor=`) as defense-in-depth even for the pinned repo.
+  * The only network egress is that `git fetch <origin>` to the repo's own
+    configured remote, bounded by a timeout. gh reads degrade to "unavailable".
 
 OUTPUT
 ------
@@ -137,15 +150,63 @@ def git(repo: str, *args: str, timeout: int = DEFAULT_GIT_TIMEOUT) -> subprocess
     return _run([GIT_BIN, "-C", repo, *args], timeout)
 
 
-# --- repo / trunk resolution (operator config only) ---------------------------
-def resolve_repo(repo_arg: str | None) -> str:
-    repo = os.path.realpath(repo_arg or DEFAULT_REPO)
+# --- repo / trunk resolution -------------------------------------------------
+# WHICH repo we scope git to is a SECURITY decision: the untrusted drafter path
+# auto-runs this wrapper over injected ticket text that can smuggle a `--repo
+# <path>` option, and a `--repo` pointed at a planted checkout is RCE (its own git
+# config execs on `git fetch`) plus cross-repo info-disclosure. Two layers pin it.
+def _allowed_roots() -> list[str]:
+    """Roots a standalone `--repo` may resolve inside. Always includes the
+    configured default repo; operators/tests extend via
+    TICKET_STATUS_ALLOWED_REPO_ROOTS (':'-separated)."""
+    roots = [DEFAULT_REPO]
+    extra = os.environ.get("TICKET_STATUS_ALLOWED_REPO_ROOTS", "")
+    roots += [r for r in extra.split(os.pathsep) if r]
+    return [os.path.realpath(r) for r in roots]
+
+
+def _within_roots(path: str, roots: list[str]) -> bool:
+    p = os.path.realpath(path)
+    for r in roots:
+        if p == r or p.startswith(r + os.sep):
+            return True
+    return False
+
+
+def _verify_git_worktree(repo: str) -> None:
     if not os.path.isdir(repo):
         raise InputError(f"repo not found: {repo}")
     r = git(repo, "rev-parse", "--is-inside-work-tree")
     if r.returncode != 0 or r.stdout.strip() != "true":
         raise InputError(f"not a git work tree: {repo}")
-    return repo
+
+
+def resolve_repo(repo_arg: str | None) -> tuple[str, list[str]]:
+    """Return (resolved_repo, warnings). Enforces the lock env (drafter path) and
+    the root allowlist (standalone path) — see the module docstring."""
+    warnings: list[str] = []
+    lock = os.environ.get("TICKET_STATUS_LOCK_REPO", "").strip()
+    if lock:
+        # Drafter / locked path: IGNORE any caller --repo entirely.
+        repo = os.path.realpath(lock)
+        if repo_arg is not None and os.path.realpath(repo_arg) != repo:
+            warnings.append(
+                "ignored --repo: repo is locked to the configured path via "
+                "TICKET_STATUS_LOCK_REPO (untrusted callers cannot steer it)"
+            )
+        _verify_git_worktree(repo)
+        return repo, warnings
+    # Standalone path: --repo (or default) must resolve INSIDE an allowed root.
+    repo = os.path.realpath(repo_arg or DEFAULT_REPO)
+    roots = _allowed_roots()
+    if not _within_roots(repo, roots):
+        raise InputError(
+            f"repo {repo!r} is outside the allowed roots {roots}; refused. "
+            "Set TICKET_STATUS_ALLOWED_REPO_ROOTS to permit it, or "
+            "TICKET_STATUS_LOCK_REPO to pin one."
+        )
+    _verify_git_worktree(repo)
+    return repo, warnings
 
 
 def resolve_trunk(repo: str, trunk_arg: str) -> tuple[str | None, list[str]]:
@@ -171,7 +232,25 @@ def refresh(repo: str, do_fetch: bool, fetch_timeout: int) -> tuple[bool, list[s
     if not do_fetch:
         warnings.append("fetch skipped (--no-fetch): results reflect the local clone only")
         return False, warnings
-    r = git(repo, "fetch", "--quiet", "--no-tags", "origin", timeout=fetch_timeout)
+    # Defense-in-depth: neutralise the fetch-time exec config even for the pinned
+    # repo, so a compromised-but-legit repo config can't run code on fetch.
+    #   --upload-pack=git-upload-pack -> the fetch-flag override that actually wins
+    #        over a poisoned `remote.origin.uploadpack` on LOCAL transport (verified:
+    #        `-c remote.origin.uploadpack=` does NOT override it; the fetch flag
+    #        does). This was the PROVEN RCE vector.
+    #   protocol.ext.allow=never -> block ext:: helper execution
+    #   core.fsmonitor=          -> disable the fsmonitor hook
+    # (core.sshCommand is intentionally NOT overridden — an empty value would break
+    #  a legitimate ssh remote; the repo pin/root-allowlist is the real guard for
+    #  the ssh-remote case.)
+    r = git(
+        repo,
+        "-c", "protocol.ext.allow=never",
+        "-c", "core.fsmonitor=",
+        "fetch", "--upload-pack=git-upload-pack",
+        "--quiet", "--no-tags", "origin",
+        timeout=fetch_timeout,
+    )
     if r.returncode != 0:
         warnings.append(
             "git fetch origin failed (offline / no remote?): results may be STALE "
@@ -304,8 +383,10 @@ def compute_verdict(prior_art: list[dict], prs: list[dict], branches: list[str])
 # --- orchestration ------------------------------------------------------------
 def probe(ticket_id: str, terms: list[str], repo_arg: str | None, trunk_arg: str,
           do_fetch: bool, fetch_timeout: int) -> dict:
-    repo = resolve_repo(repo_arg)
-    clone_fresh, warnings = refresh(repo, do_fetch, fetch_timeout)
+    repo, warnings = resolve_repo(repo_arg)
+    fresh, fw = refresh(repo, do_fetch, fetch_timeout)
+    clone_fresh = fresh
+    warnings += fw
     trunk, tw = resolve_trunk(repo, trunk_arg)
     warnings += tw
     behind = behind_trunk(repo, trunk)
@@ -474,15 +555,24 @@ def parse_args(argv: list[str]) -> dict:
             i += 1
             if i >= len(argv):
                 raise InputError("--trunk requires a ref")
+            # The trunk ref is an untrusted-reachable value flowing to git; a
+            # leading '-' could be parsed as a flag, so reject it (mirrors terms).
+            if argv[i].startswith("-"):
+                raise InputError(f"--trunk {argv[i]!r} rejected: a ref must not start with '-'")
             out["trunk"] = argv[i]
         elif a == "--fetch-timeout":
             i += 1
             if i >= len(argv):
                 raise InputError("--fetch-timeout requires an integer")
             try:
-                out["fetch_timeout"] = int(argv[i])
+                ft = int(argv[i])
             except ValueError:
                 raise InputError("--fetch-timeout must be an integer")
+            # int() silently accepts a leading '-'; a non-positive timeout is
+            # meaningless and would bypass the leading-dash intent — reject it.
+            if ft <= 0:
+                raise InputError("--fetch-timeout must be a positive integer")
+            out["fetch_timeout"] = ft
         elif a.startswith("-") and a != "-":
             # Unknown option OR an untrusted token trying to look like a flag.
             raise InputError(f"unknown/rejected option {a!r} (terms must not start with '-')")


### PR DESCRIPTION
## Why

The task-spec-drafter's per-ticket headless pass hand-rolled the same ticket→code **prior-art + merge-status** git/gh search on *every* run — the highest-recurrence finding from the 4-day session gametape (44+22 sessions of toil). It was also the driver behind a permission-block storm and the RCE-prone `git ls-remote --upload-pack=<cmd>` allowlist expansion a later security audit ripped back out (#157).

This ships the deterministic replacement: **ONE allowlisted command** the drafter calls instead of improvising git, so it stops hand-rolling and *we* control exactly what git runs.

## What — `scripts/task-spec-drafter/ticket-status`

`ticket-status <CU-id> [terms…]` answers "is this already done / where does it live / is it merged to trunk?" with **NO LLM**:

- **Prior-art** — `git log --all --fixed-strings --grep` for the `CU <id>` commit-convention (first-class decisive signal) + optional keyword terms; branch-name match; best-effort `gh pr list --search` (degrades to "unavailable" offline).
- **Merge status** — `merge-base --is-ancestor <sha> origin/main` per commit; containing branches/tags.
- **Freshness** — bounded `git fetch origin`; reports `clone_fresh` + `behind_trunk`, degrades to a STALE warning if offline but still answers from the local clone.
- **Verdict rollup (deterministic)** — `ALREADY-DONE` (an id-matched commit/PR merged to trunk) / `PARTIAL` (prior art exists but nothing decisive merged) / `NOT-FOUND`. Keyword-only matches never claim ALREADY-DONE.
- **Output** — structured `--json` (default) + a `--text` human summary. `deploy_status` is `unknown` unless a local containing-release-tag is found (full release-chain resolver is out of scope).

## Security (the whole point — ticket-id/terms are attacker-controllable ClickUp text)

- Tight ticket-id regex `^(?:[A-Za-z]{1,10}-)?[A-Za-z0-9]{1,24}$` — anything else **rejected** (rc 2, nothing produced).
- Free-text terms with a leading `-` **rejected** (can't masquerade as `--upload-pack=`/a git flag), even when forced past option parsing with `--`; terms only ever reach git as the literal value of `--grep=<term>` under `--fixed-strings`.
- **argv arrays only** — no `shell=True`, no `bash -c`, no `os.system`/`os.popen` (AST-asserted).
- `git -C` is scoped to the **operator-config repo only** (`--repo`/`$CIVITAI_REPO`/default) — no code path lets an input become the `-C` path (closes the audit's `-C <any path>` note).
- Only network egress is `git fetch` to the repo's own origin, timeout-bounded.

## Drafter wiring (minimal, safe)

- Exactly ONE allowlist entry: `Bash($SELF_DIR/ticket-status*)` — a fixed script the pass can't inject flags into git through.
- `drafter-prompt.md`: `ticket-status` is now the FIRST prior-art/verify step, preferring its JSON over hand-rolled git; existing **command-shape** + **anti-confab** constraints retained.
- `CIVITAI_REPO` exported so the wrapper scopes to the same repo as the pipeline.
- No-write-verb + no-RCE-flag allowlist guards intact (re-asserted by tests).

## Tests (hermetic — no live cluster/ClickUp/network)

37 new cases over real temp git repos (faked `gh` via env override, local-file `origin` so fetch is offline-safe): prior-art hit via `CU <id>`, merged-vs-unmerged classification, NOT-FOUND, JSON shape + verdict rollup, freshness (no-fetch / behind-detect / fetch-fail-still-answers), deploy-tag signal, and the full security battery (malicious id / `--upload-pack` term / `-C /etc` / non-git repo). `bash -n` clean on the drafter. **Full hermetic `run-tests.sh` suite green.**

A live `claude -p` drafter run (creds + paid) is left to the owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🔴 Security fix (audit round — commit 989fb84)

A security audit of the first commit found **TWO real 🔴 issues**, both from the wrapper honoring an attacker-reachable `--repo` (my id/term sanitization never covered the OPTIONS). The drafter auto-runs the allowlisted `Bash($SELF_DIR/ticket-status*)` (trailing-`*`) over attacker-controlled ticket text with **no `--permission-mode plan`**, so injected content can pass `--repo <path>` to the wrapper.

### Findings (both proven)
1. **RCE** — `--repo <planted-checkout>` → the wrapper's internal `git fetch origin` executes the planted repo's OWN git config (`remote.origin.uploadpack = "touch /tmp/pwned; git-upload-pack"` on a local/file remote, and `core.sshCommand` on an ssh remote — both fired live). `resolve_repo` accepted any path with no root allowlist.
2. **Cross-client info-disclosure (no precondition)** — `--repo <another repo>` (e.g. `homelab-talos`, or another client's checkout) resolves fine and reads that repo's commit subjects / branch names into the LLM context → into a client's drafted spec.

### Fix — pin the repo (defense-in-depth, two layers)
- **LOCK env (primary, bulletproof for the drafter):** `drafter.sh` exports `TICKET_STATUS_LOCK_REPO=$CIVITAI_REPO`. When set, the wrapper **IGNORES any `--repo`** and uses only the locked path — no injected option can steer which repo is read.
- **Root-allowlist (standalone/general path):** without the lock, `--repo` must resolve **inside an allowlisted root** (default: the configured `$CIVITAI_REPO`; extend via `TICKET_STATUS_ALLOWED_REPO_ROOTS`, `:`-separated). Anything outside is refused rc 2 **before any fetch**. `--repo` stays usable for interactive/standalone callers within the roots (tests use it).
- **Fetch hardening (even for the pinned repo):** the internal `git fetch` runs with the exec config neutralised — `--upload-pack=git-upload-pack` (the fetch flag that actually overrides a poisoned local-transport `uploadpack`; note `-c remote.origin.uploadpack=` does **not**), `protocol.ext.allow=never`, `core.fsmonitor=`. `core.sshCommand` is deliberately left unset (an empty value would break a legit ssh remote — the pin/root-allowlist is the guard for the ssh case).

### Also fixed
- 🟡 `--trunk` leading-`-` now rejected (mirrors terms — an untrusted-reachable ref flowing to git).
- 🟡 `--fetch-timeout` non-positive now rejected (`int()` had skipped the leading-`-` guard).

### New tests (this class had ZERO coverage — the gap that let it through)
A genuinely **poisoned repo fixture** (`remote.origin.uploadpack` drops a marker) with a **self-validating control** (asserts a bare `git fetch` DOES fire the marker, else skips) proves: lock ignores `--repo` (no exec), out-of-root `--repo` refused **before** fetch (no exec), pinned poison **defanged** by the neutralised fetch, in-root `--repo` still works, lock pins the resolved repo, `--trunk -x` / `--fetch-timeout -5|0` rejected, and `drafter.sh` sets the lock env. **Full hermetic `run-tests.sh` suite green.**
