### PR TITLE
feat(telemetry): adoption + impact tracking for the gametape tools

### DIFF
--- a/claude/commands/adoption-scan.md
+++ b/claude/commands/adoption-scan.md
@@ -1,0 +1,22 @@
+---
+name: adoption-scan
+description: "Show which shipped 'gametape' productivity tools are actually USED and YIELDING results vs sitting idle/DEAD — deterministic adoption + impact report over activity.events (tool-invocation events + opt-in slash commands + the drafter friction trend). Use for 'is anyone using X', 'which tools are dead', 'did the tool catch anything', or auditing whether a shipped tool stuck."
+argument-hint: "[--days N] [--insight-days N] [--dead-days N] [--host H] [--json] — optional; defaults to --days 14 --insight-days 30"
+allowed-tools: Bash
+---
+
+# /adoption-scan — are the shipped tools USED + YIELDING?
+
+Runs the read-only `adoption-scan.py` report. It answers the measured failure mode ("opt-in commands didn't stick → pivoted to autonomous loops") deterministically off `activity.events`:
+
+- **ADOPTION** — invocations per tracked tool in the window, outcome breakdown, this-half vs prior-half trend, and a loud **DEAD** flag at 0 uses (opt-in tools are the ones most at risk of silently dying).
+- **IMPACT** — the outcome MIX that evidences a real catch: verify-agent `fail|incomplete` (false-greens), obs-read `matched-nothing` (silent-zeros), ticket-status `already-done` (non-tasks dissolved).
+- **DRAFTER FRICTION TREND** — `permission_block` + `wrong_approach` over two windows (DIRECTIONAL — window confounds).
+
+Reader-only; degrades to a clean notice when telemetry is unconfigured. Needs the `CLICKHOUSE_*` reader creds (see the `activity` skill). Args: `$ARGUMENTS` (passed through; default `--days 14`).
+
+```bash
+python3 ~/workspace/devrc/scripts/session-analysis/adoption-scan.py $ARGUMENTS
+```
+
+Honesty: an invocation COUNT proves USE, not VALUE — only the outcome mix gestures at value, and the friction trend is directional. Present the DEAD opt-in tools first (retire or auto-trigger candidates), then the impact mix, then the friction direction.

--- a/scripts/collector/invocation.py
+++ b/scripts/collector/invocation.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""invocation — best-effort adoption/impact telemetry for the "gametape" tools.
+
+We ship productivity tools but some die unused (a measured past failure: opt-in
+commands didn't stick). This helper lets a tool emit ONE deterministic
+`source=tool kind=invocation` event per run so `adoption-scan.py` can tell which
+shipped tools are actually USED and what OUTCOMES they yield — vs sitting idle.
+
+CONTRACT (two hard promises)
+----------------------------
+  * BEST-EFFORT: emitting must NEVER change the calling tool's exit code, output,
+    or behaviour, and must never block it. Every failure path (spool module
+    absent, spool unwritable, a malformed dim, telemetry off) is swallowed — a
+    tool with the collector absent behaves EXACTLY as before. `emit_invocation`
+    never raises; call sites still wrap it as defence-in-depth.
+
+  * PRIVACY: only the tool name, a low-cardinality `outcome` enum, and the small
+    caller-supplied `dims` leave the process. NEVER raw --query text, ticket
+    search terms, ticket bodies, file contents, or secrets. Callers pass ONLY
+    safe low-cardinality dims (preset/cluster/verdict NAMES, version strings,
+    booleans, detected-stack lists). This module additionally hard-caps the
+    number and length of dims as defence-in-depth, but it is NOT a scrubber —
+    the call site is the privacy boundary.
+
+Reuses the pipeline's `spool_emit` (the same v1 spool line the collector daemon
+already ships) — no new schema, no subprocess fork, stdlib only. If the daemon
+is not running the line simply accumulates locally and is never shipped, which
+is the graceful telemetry-off no-op.
+
+Event shape (payload is a JSON string):
+    source=tool  kind=invocation  text=<tool>  duration_ms=<int?>  exit_code=<int?>
+    payload = {"tool": <tool>, "outcome": <enum>, ...flattened safe dims...}
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# spool_emit is the single source of truth for the v1 line format; it lives in
+# the sibling keylog/ dir (shared by the keylogger + browser receiver + i3).
+_KEYLOG = Path(__file__).resolve().parent / "keylog"
+if str(_KEYLOG) not in sys.path:
+    sys.path.insert(0, str(_KEYLOG))
+
+SOURCE = "tool"
+KIND = "invocation"
+
+# Defence-in-depth caps. Safe dims are short NAMES/versions/booleans; anything
+# larger is almost certainly a mistake (a leaked query/body), so we bound it.
+_MAX_DIMS = 12
+_MAX_KEY_LEN = 64
+_MAX_VALUE_LEN = 120
+_MAX_LIST_ITEMS = 12
+
+
+def sanitize_dims(dims) -> dict:
+    """Coerce caller dims to a small, JSON-safe, bounded dict. Pure.
+
+    Bools/ints/floats pass through; strings are truncated; short lists become
+    lists of truncated strings; everything else is stringified+truncated. This
+    caps cardinality/size but is NOT a content scrubber — the call site must only
+    pass safe values in the first place (see the module PRIVACY note).
+    """
+    out: dict = {}
+    if not isinstance(dims, dict):
+        return out
+    for k, v in list(dims.items())[:_MAX_DIMS]:
+        key = str(k)[:_MAX_KEY_LEN]
+        if isinstance(v, bool) or v is None:
+            out[key] = v
+        elif isinstance(v, (int, float)):
+            out[key] = v
+        elif isinstance(v, (list, tuple)):
+            out[key] = [str(x)[:_MAX_VALUE_LEN] for x in list(v)[:_MAX_LIST_ITEMS]]
+        else:
+            out[key] = str(v)[:_MAX_VALUE_LEN]
+    return out
+
+
+def build_fields(tool, outcome, dims=None, duration_ms=None, exit_code=None) -> dict:
+    """Build the spool field dict for one invocation event. Pure/testable.
+
+    `outcome` and the flattened `dims` live in the JSON `payload`; the tool name
+    is ALSO put in `text` so the report can group by tool without parsing JSON.
+    """
+    payload = {"tool": str(tool), "outcome": str(outcome)}
+    payload.update(sanitize_dims(dims))
+    fields: dict = {
+        "source": SOURCE,
+        "kind": KIND,
+        "text": str(tool),
+        "payload": json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
+    }
+    if duration_ms is not None:
+        try:
+            fields["duration_ms"] = int(duration_ms)
+        except (ValueError, TypeError):
+            pass
+    if exit_code is not None:
+        try:
+            fields["exit_code"] = int(exit_code)
+        except (ValueError, TypeError):
+            pass
+    return fields
+
+
+def emit_invocation(tool, outcome, dims=None, duration_ms=None, exit_code=None,
+                    spool_dir=None) -> str:
+    """Emit ONE invocation event, best-effort. Returns the written line, or "" on
+    ANY failure. NEVER raises — telemetry must not break its caller."""
+    try:
+        import spool_emit as SE  # imported lazily so an absent module is a no-op
+        fields = build_fields(tool, outcome, dims=dims,
+                              duration_ms=duration_ms, exit_code=exit_code)
+        return SE.emit(fields, spool_dir=spool_dir)
+    except Exception:  # noqa: BLE001 — best-effort telemetry never raises
+        return ""

--- a/scripts/collector/invocation.py
+++ b/scripts/collector/invocation.py
@@ -83,13 +83,17 @@ def build_fields(tool, outcome, dims=None, duration_ms=None, exit_code=None) -> 
 
     `outcome` and the flattened `dims` live in the JSON `payload`; the tool name
     is ALSO put in `text` so the report can group by tool without parsing JSON.
+    Every field (tool/outcome/text AND the dims) is length-capped so the
+    defence-in-depth bound covers the whole event, not just the dims.
     """
-    payload = {"tool": str(tool), "outcome": str(outcome)}
+    tool_s = str(tool)[:_MAX_VALUE_LEN]
+    outcome_s = str(outcome)[:_MAX_VALUE_LEN]
+    payload = {"tool": tool_s, "outcome": outcome_s}
     payload.update(sanitize_dims(dims))
     fields: dict = {
         "source": SOURCE,
         "kind": KIND,
-        "text": str(tool),
+        "text": tool_s,
         "payload": json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
     }
     if duration_ms is not None:

--- a/scripts/collector/tests/test_invocation.py
+++ b/scripts/collector/tests/test_invocation.py
@@ -60,6 +60,18 @@ def test_sanitize_preserves_bools_and_numbers():
     assert out["git_dirty"] is True and out["n"] == 3 and out["none"] is None
 
 
+def test_build_fields_caps_tool_outcome_and_text():
+    # Defence-in-depth must cover EVERY field, not only dims: an oversized tool /
+    # outcome (a would-be leak vector) is truncated in payload AND the text column.
+    huge_tool = "t" * 500
+    huge_outcome = "o" * 500
+    f = INV.build_fields(huge_tool, huge_outcome, dims={"cluster": "x"})
+    assert len(f["text"]) <= INV._MAX_VALUE_LEN
+    p = json.loads(f["payload"])
+    assert len(p["tool"]) <= INV._MAX_VALUE_LEN
+    assert len(p["outcome"]) <= INV._MAX_VALUE_LEN
+
+
 # --------------------------------------------------------------------------- #
 # emit_invocation -> temp spool -> daemon round-trip
 # --------------------------------------------------------------------------- #

--- a/scripts/collector/tests/test_invocation.py
+++ b/scripts/collector/tests/test_invocation.py
@@ -1,0 +1,101 @@
+"""Unit tests for scripts/collector/invocation.py — the adoption-telemetry helper.
+
+Fully HERMETIC: writes to a temp spool (no daemon, no ClickHouse) and round-trips
+the line through the REAL collector.parse_line, so the emitted event is asserted
+exactly as the daemon would ship it. Covers the BEST-EFFORT contract (never
+raises, even when spool_emit blows up) and the PRIVACY/size caps.
+
+Run: pytest scripts/collector/tests/test_invocation.py
+"""
+import json
+import sys
+from pathlib import Path
+
+# invocation + collector are siblings (not a package).
+_COLL = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_COLL))
+sys.path.insert(0, str(_COLL / "keylog"))
+import invocation as INV  # noqa: E402
+import collector as C  # noqa: E402
+
+
+def _read_event(spool_dir: Path) -> dict:
+    """Parse the single line the helper wrote, via the real daemon parser."""
+    line = (spool_dir / "current.log").read_text().strip().splitlines()[-1]
+    ev = C.parse_line(line)
+    assert ev is not None, f"daemon could not parse emitted line: {line!r}"
+    return ev
+
+
+# --------------------------------------------------------------------------- #
+# build_fields / sanitize (pure)
+# --------------------------------------------------------------------------- #
+def test_build_fields_shape():
+    f = INV.build_fields("obs-read", "matched-nothing",
+                         dims={"cluster": "dpprod", "preset": "dp-5xx-rate"},
+                         duration_ms=12, exit_code=0)
+    assert f["source"] == "tool" and f["kind"] == "invocation"
+    assert f["text"] == "obs-read"
+    assert f["duration_ms"] == 12 and f["exit_code"] == 0
+    p = json.loads(f["payload"])
+    assert p["tool"] == "obs-read" and p["outcome"] == "matched-nothing"
+    assert p["cluster"] == "dpprod" and p["preset"] == "dp-5xx-rate"
+
+
+def test_sanitize_caps_count_and_length():
+    big = {f"k{i}": "x" for i in range(50)}
+    big["huge"] = "y" * 500
+    big["list"] = ["a" * 500] * 50
+    out = INV.sanitize_dims(big)
+    assert len(out) <= INV._MAX_DIMS
+    if "huge" in out:
+        assert len(out["huge"]) <= INV._MAX_VALUE_LEN
+    if "list" in out:
+        assert len(out["list"]) <= INV._MAX_LIST_ITEMS
+        assert all(len(x) <= INV._MAX_VALUE_LEN for x in out["list"])
+
+
+def test_sanitize_preserves_bools_and_numbers():
+    out = INV.sanitize_dims({"git_dirty": True, "n": 3, "none": None})
+    assert out["git_dirty"] is True and out["n"] == 3 and out["none"] is None
+
+
+# --------------------------------------------------------------------------- #
+# emit_invocation -> temp spool -> daemon round-trip
+# --------------------------------------------------------------------------- #
+def test_emit_roundtrips_through_daemon(tmp_path):
+    line = INV.emit_invocation("verify-agent-work", "fail",
+                               dims={"stacks": ["ts", "go"], "git_dirty": True},
+                               exit_code=1, spool_dir=tmp_path)
+    assert line
+    ev = _read_event(tmp_path)
+    assert ev["source"] == "tool" and ev["kind"] == "invocation"
+    assert ev["text"] == "verify-agent-work" and ev["exit_code"] == 1
+    p = json.loads(ev["payload"])
+    assert p["tool"] == "verify-agent-work" and p["outcome"] == "fail"
+    assert p["stacks"] == ["ts", "go"] and p["git_dirty"] is True
+
+
+# --------------------------------------------------------------------------- #
+# best-effort: NEVER raises, even when the spool layer fails
+# --------------------------------------------------------------------------- #
+def test_emit_swallows_spool_failure(monkeypatch):
+    import spool_emit as SE
+
+    def boom(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(SE, "emit", boom)
+    # Must not raise; returns "" on failure.
+    assert INV.emit_invocation("obs-read", "ok", dims={"cluster": "homelab"}) == ""
+
+
+def test_emit_swallows_bad_dims(tmp_path):
+    # A dim value that can't be str()'d cleanly still must not raise.
+    class Weird:
+        def __str__(self):
+            raise ValueError("nope")
+
+    # emit_invocation must swallow this entirely.
+    assert INV.emit_invocation("x", "ok", dims={"bad": Weird()},
+                               spool_dir=tmp_path) == "" or True

--- a/scripts/obs-read
+++ b/scripts/obs-read
@@ -811,6 +811,45 @@ def query_backend(kubeconfig: str, backend: str, query: str, kind: str,
 
 
 # --------------------------------------------------------------------------- #
+# adoption telemetry (best-effort; NEVER changes exit code or output)
+# --------------------------------------------------------------------------- #
+def invocation_outcome(matched_nothing: bool, absence_ok: bool) -> str:
+    """Map a query result to the adoption outcome enum. Pure.
+
+    A matched-nothing result is the silent-zero trap this tool exists to catch —
+    it is reported as `matched-nothing` so adoption-scan can count silent-zeros
+    caught. But for an expected-absence preset (e.g. "no alerts firing") an empty
+    result is the HEALTHY state, so it counts as `ok`, not a caught silent-zero.
+    """
+    if matched_nothing and not absence_ok:
+        return "matched-nothing"
+    return "ok"
+
+
+def _emit_adoption(outcome: str, cluster, backend, preset,
+                   duration_ms=None) -> None:
+    """Best-effort adoption event. dims carry ONLY the cluster/backend/preset
+    NAMES — NEVER the --query text or any label values. Fully swallowed."""
+    try:
+        sys.path.insert(0, os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), "collector"))
+        import invocation  # noqa: PLC0415
+        invocation.emit_invocation(
+            "obs-read", outcome,
+            dims={
+                "cluster": cluster or "",
+                "backend": backend or "",
+                # preset NAME only (from our fixed library) or the literal
+                # "adhoc" sentinel — the raw --query text is NEVER emitted.
+                "preset": preset if preset else "adhoc",
+            },
+            duration_ms=duration_ms,
+        )
+    except Exception:  # noqa: BLE001 — defence-in-depth around the helper
+        pass
+
+
+# --------------------------------------------------------------------------- #
 # CLI
 # --------------------------------------------------------------------------- #
 def _list_presets() -> str:
@@ -882,12 +921,17 @@ def main(argv=None, *, pf_factory=PortForward, http_get=_http_get,
         print("obs-read: note — preset %r is usually run against %r, you chose "
               "%r." % (p.name, p.cluster_hint, args.cluster), file=sys.stderr)
 
+    import time
+    _t0 = time.monotonic()
+    _dur = lambda: int((time.monotonic() - _t0) * 1000)  # noqa: E731
+
     try:
         payload = query_backend(kubeconfig, backend, query, kind, since_s,
                                  pf_factory=pf_factory, http_get=http_get,
                                  http_timeout=args.timeout)
     except Exception as e:  # noqa: BLE001 — surface transport failures cleanly
         print("obs-read: query transport failed: %s" % e, file=sys.stderr)
+        _emit_adoption("error", args.cluster, backend, args.preset, _dur())
         return 1
 
     try:
@@ -895,9 +939,12 @@ def main(argv=None, *, pf_factory=PortForward, http_get=_http_get,
     except ValueError as e:
         print("obs-read: could not parse %s response: %s" % (backend, e),
               file=sys.stderr)
+        _emit_adoption("error", args.cluster, backend, args.preset, _dur())
         return 1
 
     absence_ok = bool(p and p.absence_ok)
+    _emit_adoption(invocation_outcome(qr.matched_nothing, absence_ok),
+                   args.cluster, backend, args.preset, _dur())
     stdout, stderr = render(qr, args.json, query, args.cluster, backend,
                             absence_ok=absence_ok)
     if stderr:

--- a/scripts/playwright-nixos
+++ b/scripts/playwright-nixos
@@ -47,7 +47,28 @@ FLAKEREF="${REPO}#playwright-driver"
 BROWSERS="$(nix build --no-link --print-out-paths "${FLAKEREF}.browsers" 2>/dev/null | head -n1 || true)"
 DRIVER_VER="$(nix eval --raw "${FLAKEREF}.version" 2>/dev/null || echo unknown)"
 
+# --- adoption telemetry (best-effort; NEVER changes exit code or output) -------
+# Emit ONE invocation event via the sibling `emit` binary. Bounded by a timeout
+# and `|| true`, and skipped entirely if `emit` is absent — telemetry must never
+# affect whether/how the wrapped command runs. dims carry ONLY the driver
+# version + a mode flag; no query/URL/secret ever leaves here.
+_emit_invocation() {
+  local outcome="$1" mode="$2"
+  local emit_bin="${REPO}/scripts/collector/emit"
+  [[ -x "$emit_bin" ]] || return 0
+  local to=""
+  command -v timeout >/dev/null 2>&1 && to="timeout 5"
+  # shellcheck disable=SC2086
+  $to "$emit_bin" source=tool kind=invocation \
+      b64:text=playwright-nixos \
+      b64:tool=playwright-nixos \
+      "b64:outcome=$outcome" \
+      "b64:driver=$DRIVER_VER" \
+      "b64:mode=$mode" >/dev/null 2>&1 || true
+}
+
 if [[ -z "$BROWSERS" || ! -d "$BROWSERS" ]]; then
+  _emit_invocation error resolve-error
   echo "playwright-nixos: could not resolve ${FLAKEREF}.browsers from $REPO" >&2
   echo "  try: nix build \"${FLAKEREF}.browsers\"" >&2
   exit 1
@@ -117,4 +138,8 @@ esac
 
 warn_version_mismatch
 warn_mcp_build_skew
+# Emit BEFORE exec — exec replaces this process, so "ok" here means the wrapper
+# resolved the NixOS browser bundle and is about to launch the command (we can't
+# observe the child's own exit code from a replaced process).
+_emit_invocation ok exec
 exec "$@"

--- a/scripts/session-analysis/README.md
+++ b/scripts/session-analysis/README.md
@@ -11,7 +11,22 @@ gracefully when telemetry is unconfigured/unreachable.
 | `activity-scan.py` | "where workflow time goes + what to automate" (repeated commands, bottlenecks, attention). |
 | `initiative-scan.py` | cross-repo initiative + progress ledger (handoff docs + git + telemetry). `/initiatives`. |
 | `insights.py` | telemetry-native Claude Code insights report (successor to the built-in `/insights`). |
+| `adoption-scan.py` | which shipped "gametape" tools are actually USED + YIELDING vs DEAD (adoption + outcome-mix + drafter friction trend). `/adoption-scan`. |
 | `session_insight/` | **Layer B** qualitative-facet extractor (this dir). |
+
+## Tool adoption telemetry (`source=tool`, `kind=invocation`)
+
+The instrumented tools each emit ONE best-effort `source=tool kind=invocation`
+event per run via `collector/invocation.py` (`emit_invocation`) — tool name in
+`text`, `{tool, outcome, ...safe dims}` in `payload`, plus `duration_ms` /
+`exit_code`. `adoption-scan.py` reads these (+ the `/verify-agent` `/obs-read`
+message-stream commands + the drafter's cwd sessions + `session-insight` friction)
+into an adoption/impact report. **Privacy:** only the tool name, a low-cardinality
+`outcome` enum, and safe NAMES (preset/cluster/verdict/version) are emitted —
+NEVER raw queries, ticket terms, bodies, or secrets. **Best-effort:** the emit
+never changes a tool's exit code/output; an absent collector is a clean no-op.
+Instrumented today: `verify-agent-work`, `obs-read`, `ticket-status`,
+`playwright-nixos`. Add a row to `adoption-scan.py`'s `REGISTRY` when you ship more.
 
 ## Claude-session telemetry layers (`source=claude`)
 

--- a/scripts/session-analysis/adoption-scan.py
+++ b/scripts/session-analysis/adoption-scan.py
@@ -205,8 +205,18 @@ def _trend(recent: int, prior: int) -> str:
 # --------------------------------------------------------------------------- #
 # Per-item aggregation (pure — the whole decision surface is unit-tested)
 # --------------------------------------------------------------------------- #
-def aggregate_tool(rows: list[dict], tool: str, now: float, half_s: float) -> dict:
-    """Aggregate `source=tool kind=invocation` rows for ONE tool name."""
+def command_matches(text: str, prefixes: list[str]) -> bool:
+    """True iff a slash-command line IS one of `prefixes` (bare or with args).
+    Tight on purpose: `/obs-read-foo` must NOT count as `/obs-read`. Pure."""
+    t = (text or "").strip()
+    return any(t == pre or t.startswith(pre + " ") for pre in prefixes)
+
+
+def aggregate_tool(rows: list[dict], tool: str, now: float, win: float) -> dict:
+    """Aggregate `source=tool kind=invocation` rows for ONE tool name, counting
+    ONLY events within the adoption window `win` (rows from a wider dead-window
+    fetch are excluded from counts/trend). Trend halves are win/2."""
+    half_s = win / 2.0
     total = 0
     outcomes: Counter = Counter()
     recent = prior = 0
@@ -215,10 +225,13 @@ def aggregate_tool(rows: list[dict], tool: str, now: float, half_s: float) -> di
         name = r.get("tool") or r.get("text") or p.get("tool")
         if name != tool:
             continue
+        e = ch_ts_to_epoch(r.get("ts"))
+        if e is None or (now - e) > win:
+            continue  # outside the --days window (may be in the wider fetch)
         total += 1
         outcome = p.get("outcome") or "unknown"
         outcomes[outcome] += 1
-        b = _half(ch_ts_to_epoch(r.get("ts")), now, half_s)
+        b = _half(e, now, half_s)
         if b == "recent":
             recent += 1
         elif b == "prior":
@@ -228,17 +241,20 @@ def aggregate_tool(rows: list[dict], tool: str, now: float, half_s: float) -> di
 
 
 def aggregate_command(rows: list[dict], prefixes: list[str], now: float,
-                      half_s: float) -> dict:
-    """Aggregate message-stream `command` rows whose text matches a slash prefix."""
+                      win: float) -> dict:
+    """Aggregate message-stream `command` rows whose text IS one of the slash
+    prefixes, within the adoption window `win`."""
+    half_s = win / 2.0
     total = 0
     recent = prior = 0
     for r in rows:
-        text = (r.get("text") or "").strip()
-        if not any(text == pre or text.startswith(pre + " ") or
-                   text.startswith(pre) for pre in prefixes):
+        if not command_matches(r.get("text"), prefixes):
+            continue
+        e = ch_ts_to_epoch(r.get("ts"))
+        if e is None or (now - e) > win:
             continue
         total += 1
-        b = _half(ch_ts_to_epoch(r.get("ts")), now, half_s)
+        b = _half(e, now, half_s)
         if b == "recent":
             recent += 1
         elif b == "prior":
@@ -247,13 +263,18 @@ def aggregate_command(rows: list[dict], prefixes: list[str], now: float,
             "trend": _trend(recent, prior)}
 
 
-def aggregate_cwd(rows: list[dict], now: float, half_s: float) -> dict:
-    """Aggregate the (already cwd-filtered) session rows for a cwd-detected item.
-    Each row is one session that touched the item's cwd."""
-    total = len(rows)
+def aggregate_cwd(rows: list[dict], now: float, win: float) -> dict:
+    """Aggregate the (already cwd-filtered) session rows for a cwd-detected item,
+    within the adoption window `win`. Each row is one session touching the cwd."""
+    half_s = win / 2.0
+    total = 0
     recent = prior = 0
     for r in rows:
-        b = _half(ch_ts_to_epoch(r.get("ts")), now, half_s)
+        e = ch_ts_to_epoch(r.get("ts"))
+        if e is None or (now - e) > win:
+            continue
+        total += 1
+        b = _half(e, now, half_s)
         if b == "recent":
             recent += 1
         elif b == "prior":
@@ -262,9 +283,11 @@ def aggregate_cwd(rows: list[dict], now: float, half_s: float) -> dict:
             "trend": _trend(recent, prior)}
 
 
-def aggregate_friction(insight_rows: list[dict], now: float, half_s: float) -> dict:
-    """Sum the tracked friction categories over two windows (recent vs prior half).
-    DIRECTIONAL only — confounded by different tickets/models across the windows."""
+def aggregate_friction(insight_rows: list[dict], now: float, iwin: float) -> dict:
+    """Sum the tracked friction categories over two windows (recent vs prior half
+    of the insight window `iwin`). DIRECTIONAL only — confounded by different
+    tickets/models across the windows."""
+    half_s = iwin / 2.0
     recent = {k: 0 for k in FRICTION_TRACKED}
     prior = {k: 0 for k in FRICTION_TRACKED}
     sess_recent = sess_prior = 0
@@ -350,20 +373,22 @@ def gather(client, days: int, insight_days: int, dead_days: int,
     now = time.time() if now is None else now
     win = window_seconds(days)
     iwin = window_seconds(insight_days)
-    half = win / 2.0
-    ihalf = iwin / 2.0
     dead_s = window_seconds(dead_days)
+    # The fetch must span BOTH windows so a dead_days LARGER than days is honest
+    # (otherwise a bigger --dead-days is silently clamped to the fetch). Counts
+    # stay scoped to `win` inside the aggregators; DEAD uses the full dead window.
+    fetch_win = max(win, dead_s)
 
     try:
-        tool_rows = client.rows(q_tool_invocations(win, host))
-        cmd_rows = client.rows(q_commands(win, host))
+        tool_rows = client.rows(q_tool_invocations(fetch_win, host))
+        cmd_rows = client.rows(q_commands(fetch_win, host))
         insight_rows = client.rows(q_insights(iwin, host))
         # cwd-detected items each get their own filtered query.
         cwd_rows: dict = {}
         for item in REGISTRY:
             if item["via"] == "cwd":
                 cwd_rows[item["id"]] = client.rows(
-                    q_cwd_sessions(win, item["match"], host))
+                    q_cwd_sessions(fetch_win, item["match"], host))
     except Exception as e:  # noqa: BLE001 — telemetry optional; degrade cleanly
         raise TelemetryUnavailable(str(e)) from e
 
@@ -371,22 +396,20 @@ def gather(client, days: int, insight_days: int, dead_days: int,
     for item in REGISTRY:
         via = item["via"]
         if via == "tool":
-            agg = aggregate_tool(tool_rows, item["tool"], now, half)
+            agg = aggregate_tool(tool_rows, item["tool"], now, win)
         elif via == "command":
-            agg = aggregate_command(cmd_rows, item["prefixes"], now, half)
+            agg = aggregate_command(cmd_rows, item["prefixes"], now, win)
         elif via == "cwd":
-            agg = aggregate_cwd(cwd_rows.get(item["id"], []), now, half)
+            agg = aggregate_cwd(cwd_rows.get(item["id"], []), now, win)
         else:
             agg = {"total": 0, "outcomes": {}, "recent": 0, "prior": 0,
                    "trend": "flat"}
 
-        # DEAD = zero uses within the dead-days window. When dead_days == days
-        # the whole window is the dead window (total==0); otherwise re-bucket.
-        if dead_s >= win:
-            dead = agg["total"] == 0
-        else:
-            dead = _count_within(_item_ts(item, tool_rows, cmd_rows, cwd_rows),
-                                 now, dead_s) == 0
+        # DEAD = zero uses within the dead-days window, computed over the FULL
+        # fetched set (which spans dead_s), so it is correct whether dead_days is
+        # smaller, equal to, or larger than days.
+        dead = _count_within(_item_ts(item, tool_rows, cmd_rows, cwd_rows),
+                             now, dead_s) == 0
 
         impact = {o: agg["outcomes"].get(o, 0) for o in item.get("impact_outcomes", [])}
         items.append({
@@ -397,7 +420,7 @@ def gather(client, days: int, insight_days: int, dead_days: int,
             "impact": impact, "impact_label": item.get("impact_label", ""),
         })
 
-    friction = aggregate_friction(insight_rows, now, ihalf)
+    friction = aggregate_friction(insight_rows, now, iwin)
 
     return {
         "days": days, "insight_days": insight_days, "dead_days": dead_days,
@@ -422,7 +445,7 @@ def _item_ts(item, tool_rows, cmd_rows, cwd_rows) -> list:
     if item["via"] == "command":
         pres = item["prefixes"]
         return [r.get("ts") for r in cmd_rows
-                if any((r.get("text") or "").strip().startswith(pre) for pre in pres)]
+                if command_matches(r.get("text"), pres)]
     if item["via"] == "cwd":
         return [r.get("ts") for r in cwd_rows.get(item["id"], [])]
     return []

--- a/scripts/session-analysis/adoption-scan.py
+++ b/scripts/session-analysis/adoption-scan.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+"""adoption-scan — which shipped "gametape" tools are actually USED and YIELDING.
+
+We ship productivity tools but some die unused — a measured past failure ("opt-in
+commands didn't stick → pivoted to autonomous loops"). This is the deterministic
+tracker that tells USE from idle and, where we can, USE from VALUE, straight off
+the activity telemetry (`activity.events`):
+
+  * a REGISTRY of tracked improvements, each mapping to how its use is detected.
+  * ADOPTION per item: invocations in the window, broken down by outcome, a
+    this-half vs prior-half trend, and a loud DEAD flag at 0 uses (the opt-in
+    tools are the ones most at risk of silently dying).
+  * IMPACT (yielding, not just firing): the outcome MIX that proves the tool
+    caught something real — verify-agent `fail|incomplete` (false-greens caught),
+    obs-read `matched-nothing` (silent-zeros caught), ticket-status `already-done`
+    (non-tasks dissolved) — plus a compact, explicitly-DIRECTIONAL drafter
+    friction trend (permission_block + wrong_approach over two windows).
+
+Data sources (all already emitted; nothing new stored except the tool-invocation
+events this project added):
+  * `source=tool  kind=invocation`  — the emit-instrumented tools (verify-agent-
+    work, obs-read, ticket-status, playwright-nixos). tool name in `text`,
+    `outcome`/dims in the JSON `payload`.
+  * `source=claude kind=command`    — the opt-in slash commands from the message
+    stream (`/verify-agent`, `/obs-read`).
+  * `source=claude kind=session-insight` — Layer-B qualitative facets, for the
+    friction trend (dedup argMax per session, per the read contract).
+
+Credentials (read-only reader, from env — NEVER hardcoded; same block as
+activity-scan.py / initiative-scan.py):
+  export CLICKHOUSE_URL=http://192.168.50.94:30123
+  export CLICKHOUSE_USER=activity_reader
+  export CLICKHOUSE_PASSWORD=<reader-password>   # from SOPS
+Degrades gracefully: if telemetry is unconfigured/unreachable it prints a clear
+message and exits 0 (mirrors insights.py) — never crashes.
+
+HONESTY (baked into the output):
+  * an invocation COUNT proves USE, not VALUE. Only the outcome MIX gestures at
+    value, and even then imperfectly.
+  * the friction trend is DIRECTIONAL — different tickets/models/週 confound it;
+    read the direction, not the absolute delta.
+
+Usage:
+  adoption-scan.py [--days N] [--insight-days N] [--json] [--host H] [--dead-days N]
+  --days         adoption window in days (default 14).
+  --insight-days friction-trend window in days (default 30 — facets accrue slower).
+  --dead-days    a tool with 0 uses within this many days is flagged DEAD
+                 (default = --days).
+  --json         machine-readable output.
+  --host         restrict to one ACTIVITY_HOST label.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+# Reuse the shared ClickHouse client + creds-from-env (no new deps).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "validation"))
+import chquery as Q  # noqa: E402
+
+DAY = 86400
+DEFAULT_DAYS = 14
+# Qualitative facets (Layer B) accrue slower than raw invocations, so the
+# friction trend uses a wider default window than the adoption sections.
+DEFAULT_INSIGHT_DAYS = 30
+DRAFTER_CWD_MATCH = "task-spec-drafter"
+# The friction categories the #157/#159 fixes were meant to move (baseline was
+# permission_block=57). Kept tiny + explicit so the trend stays legible.
+FRICTION_TRACKED = ["permission_block", "wrong_approach"]
+
+
+class TelemetryUnavailable(Exception):
+    """Telemetry is not configured / not reachable — degrade, don't crash."""
+
+
+# --------------------------------------------------------------------------- #
+# Registry of tracked improvements
+# --------------------------------------------------------------------------- #
+# Each row says HOW to detect an item's use. Add a row when we ship more:
+#   via="tool"    -> match `source=tool kind=invocation` rows by tool name.
+#   via="command" -> match `source=claude kind=command` message-stream text by
+#                    slash-command prefix(es).
+#   via="cwd"     -> match `source=claude` sessions whose cwd names the item
+#                    (best-effort/heuristic — used for the autonomous drafter).
+# `impact_outcomes` are the outcomes that evidence a REAL catch (value signal),
+# with `impact_label` explaining what a hit means. opt_in items are the ones
+# whose adoption is fragile (a human has to choose to invoke them).
+REGISTRY = [
+    {
+        "id": "verify-agent-work",
+        "label": "verify-agent-work — post-agent verification gate",
+        "via": "tool", "tool": "verify-agent-work", "opt_in": True,
+        "outcomes": ["pass", "fail", "incomplete"],
+        "impact_outcomes": ["fail", "incomplete"],
+        "impact_label": "false-greens caught (agent 'done' contradicted)",
+    },
+    {
+        "id": "obs-read",
+        "label": "obs-read — cluster-aware observability query",
+        "via": "tool", "tool": "obs-read", "opt_in": True,
+        "outcomes": ["ok", "matched-nothing", "error"],
+        "impact_outcomes": ["matched-nothing"],
+        "impact_label": "silent-zeros caught (wrong label/service, not a real 0)",
+    },
+    {
+        "id": "ticket-status",
+        "label": "ticket-status — drafter prior-art / merge-status probe",
+        "via": "tool", "tool": "ticket-status", "opt_in": False,
+        "outcomes": ["already-done", "partial", "not-found", "error"],
+        "impact_outcomes": ["already-done"],
+        "impact_label": "non-tasks dissolved (already merged to trunk)",
+    },
+    {
+        "id": "playwright-nixos",
+        "label": "playwright-nixos — NixOS Chromium wrapper for Playwright",
+        "via": "tool", "tool": "playwright-nixos", "opt_in": False,
+        "outcomes": ["ok", "error"],
+        "impact_outcomes": [],
+        "impact_label": "",
+    },
+    {
+        "id": "cmd:verify-agent",
+        "label": "/verify-agent (slash command typed)",
+        "via": "command", "prefixes": ["/verify-agent"], "opt_in": True,
+        "outcomes": [], "impact_outcomes": [], "impact_label": "",
+    },
+    {
+        "id": "cmd:obs-read",
+        "label": "/obs-read (slash command typed)",
+        "via": "command", "prefixes": ["/obs-read"], "opt_in": True,
+        "outcomes": [], "impact_outcomes": [], "impact_label": "",
+    },
+    {
+        "id": "task-spec-drafter",
+        "label": "task-spec-drafter — autonomous weekly ticket drafter (cwd, heuristic)",
+        "via": "cwd", "match": DRAFTER_CWD_MATCH, "opt_in": False,
+        "outcomes": [], "impact_outcomes": [], "impact_label": "",
+    },
+]
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+def window_seconds(days: int) -> int:
+    if days <= 0:
+        raise ValueError("days must be positive")
+    return days * DAY
+
+
+def ch_ts_to_epoch(s) -> float | None:
+    """Parse a ClickHouse/emit 'YYYY-MM-DD HH:MM:SS[.fff]' UTC string to epoch.
+    The stored `ts` is a tz-less DateTime64 holding the UTC instant."""
+    if s is None:
+        return None
+    txt = str(s).strip()
+    for fmt in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"):
+        try:
+            return _dt.datetime.strptime(txt, fmt).replace(
+                tzinfo=_dt.timezone.utc).timestamp()
+        except ValueError:
+            continue
+    return None
+
+
+def parse_payload(p) -> dict:
+    if isinstance(p, dict):
+        return p
+    if isinstance(p, str) and p:
+        try:
+            d = json.loads(p)
+            return d if isinstance(d, dict) else {}
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _half(ts_epoch, now: float, half_s: float) -> str | None:
+    """Bucket a row into 'recent' (age <= half) or 'prior' (half < age <= 2*half).
+    Returns None if the ts is unparseable or falls outside the window."""
+    if ts_epoch is None:
+        return None
+    age = now - ts_epoch
+    if age < 0:
+        return "recent"  # clock skew: a just-emitted row -> treat as recent
+    if age <= half_s:
+        return "recent"
+    if age <= 2 * half_s:
+        return "prior"
+    return None
+
+
+def _trend(recent: int, prior: int) -> str:
+    if recent > prior:
+        return "up"
+    if recent < prior:
+        return "down"
+    return "flat"
+
+
+# --------------------------------------------------------------------------- #
+# Per-item aggregation (pure — the whole decision surface is unit-tested)
+# --------------------------------------------------------------------------- #
+def aggregate_tool(rows: list[dict], tool: str, now: float, half_s: float) -> dict:
+    """Aggregate `source=tool kind=invocation` rows for ONE tool name."""
+    total = 0
+    outcomes: Counter = Counter()
+    recent = prior = 0
+    for r in rows:
+        p = parse_payload(r.get("payload"))
+        name = r.get("tool") or r.get("text") or p.get("tool")
+        if name != tool:
+            continue
+        total += 1
+        outcome = p.get("outcome") or "unknown"
+        outcomes[outcome] += 1
+        b = _half(ch_ts_to_epoch(r.get("ts")), now, half_s)
+        if b == "recent":
+            recent += 1
+        elif b == "prior":
+            prior += 1
+    return {"total": total, "outcomes": dict(outcomes),
+            "recent": recent, "prior": prior, "trend": _trend(recent, prior)}
+
+
+def aggregate_command(rows: list[dict], prefixes: list[str], now: float,
+                      half_s: float) -> dict:
+    """Aggregate message-stream `command` rows whose text matches a slash prefix."""
+    total = 0
+    recent = prior = 0
+    for r in rows:
+        text = (r.get("text") or "").strip()
+        if not any(text == pre or text.startswith(pre + " ") or
+                   text.startswith(pre) for pre in prefixes):
+            continue
+        total += 1
+        b = _half(ch_ts_to_epoch(r.get("ts")), now, half_s)
+        if b == "recent":
+            recent += 1
+        elif b == "prior":
+            prior += 1
+    return {"total": total, "outcomes": {}, "recent": recent, "prior": prior,
+            "trend": _trend(recent, prior)}
+
+
+def aggregate_cwd(rows: list[dict], now: float, half_s: float) -> dict:
+    """Aggregate the (already cwd-filtered) session rows for a cwd-detected item.
+    Each row is one session that touched the item's cwd."""
+    total = len(rows)
+    recent = prior = 0
+    for r in rows:
+        b = _half(ch_ts_to_epoch(r.get("ts")), now, half_s)
+        if b == "recent":
+            recent += 1
+        elif b == "prior":
+            prior += 1
+    return {"total": total, "outcomes": {}, "recent": recent, "prior": prior,
+            "trend": _trend(recent, prior)}
+
+
+def aggregate_friction(insight_rows: list[dict], now: float, half_s: float) -> dict:
+    """Sum the tracked friction categories over two windows (recent vs prior half).
+    DIRECTIONAL only — confounded by different tickets/models across the windows."""
+    recent = {k: 0 for k in FRICTION_TRACKED}
+    prior = {k: 0 for k in FRICTION_TRACKED}
+    sess_recent = sess_prior = 0
+    unreadable = 0
+    for r in insight_rows:
+        p = parse_payload(r.get("payload"))
+        if not p or p.get("unreadable"):
+            unreadable += 1
+            continue
+        b = _half(ch_ts_to_epoch(r.get("ts")), now, half_s)
+        if b is None:
+            continue
+        bucket = recent if b == "recent" else prior
+        if b == "recent":
+            sess_recent += 1
+        else:
+            sess_prior += 1
+        fc = p.get("friction_counts") or {}
+        if isinstance(fc, dict):
+            for k in FRICTION_TRACKED:
+                v = fc.get(k)
+                if isinstance(v, (int, float)) and not isinstance(v, bool):
+                    bucket[k] += int(v)
+    deltas = {k: recent[k] - prior[k] for k in FRICTION_TRACKED}
+    return {
+        "recent": recent, "prior": prior, "deltas": deltas,
+        "sessions_recent": sess_recent, "sessions_prior": sess_prior,
+        "unreadable": unreadable,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Queries
+# --------------------------------------------------------------------------- #
+def _host_filter(host: str | None) -> str:
+    return f" AND host={Q.sql_quote(host)}" if host else ""
+
+
+def q_tool_invocations(win: int, host: str | None = None) -> str:
+    return (
+        "SELECT text AS tool, toString(payload) AS payload, "
+        "exit_code, duration_ms, ts, host "
+        "FROM activity.events "
+        f"WHERE source='tool' AND kind='invocation' AND ts>now()-{win}"
+        f"{_host_filter(host)}"
+    )
+
+
+def q_commands(win: int, host: str | None = None) -> str:
+    return (
+        "SELECT text AS text, ts, host FROM activity.events "
+        f"WHERE source='claude' AND kind='command' AND ts>now()-{win}"
+        f"{_host_filter(host)}"
+    )
+
+
+def q_cwd_sessions(win: int, match: str, host: str | None = None) -> str:
+    lit = Q.sql_quote(match.lower())
+    return (
+        "SELECT session AS session, max(ts) AS ts FROM activity.events "
+        f"WHERE source='claude' AND ts>now()-{win} "
+        f"AND position(lower(cwd), {lit}) > 0{_host_filter(host)} "
+        "GROUP BY session"
+    )
+
+
+def q_insights(win: int, host: str | None = None) -> str:
+    return (
+        "SELECT session, argMax(toString(payload), ingested_at) AS payload, "
+        "max(ts) AS ts FROM activity.events "
+        f"WHERE source='claude' AND kind='session-insight' AND ts>now()-{win}"
+        f"{_host_filter(host)} GROUP BY session"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+def gather(client, days: int, insight_days: int, dead_days: int,
+           host: str | None = None, now: float | None = None) -> dict:
+    """Fetch + aggregate. Raises TelemetryUnavailable if the store is unreachable."""
+    import time
+    now = time.time() if now is None else now
+    win = window_seconds(days)
+    iwin = window_seconds(insight_days)
+    half = win / 2.0
+    ihalf = iwin / 2.0
+    dead_s = window_seconds(dead_days)
+
+    try:
+        tool_rows = client.rows(q_tool_invocations(win, host))
+        cmd_rows = client.rows(q_commands(win, host))
+        insight_rows = client.rows(q_insights(iwin, host))
+        # cwd-detected items each get their own filtered query.
+        cwd_rows: dict = {}
+        for item in REGISTRY:
+            if item["via"] == "cwd":
+                cwd_rows[item["id"]] = client.rows(
+                    q_cwd_sessions(win, item["match"], host))
+    except Exception as e:  # noqa: BLE001 — telemetry optional; degrade cleanly
+        raise TelemetryUnavailable(str(e)) from e
+
+    items = []
+    for item in REGISTRY:
+        via = item["via"]
+        if via == "tool":
+            agg = aggregate_tool(tool_rows, item["tool"], now, half)
+        elif via == "command":
+            agg = aggregate_command(cmd_rows, item["prefixes"], now, half)
+        elif via == "cwd":
+            agg = aggregate_cwd(cwd_rows.get(item["id"], []), now, half)
+        else:
+            agg = {"total": 0, "outcomes": {}, "recent": 0, "prior": 0,
+                   "trend": "flat"}
+
+        # DEAD = zero uses within the dead-days window. When dead_days == days
+        # the whole window is the dead window (total==0); otherwise re-bucket.
+        if dead_s >= win:
+            dead = agg["total"] == 0
+        else:
+            dead = _count_within(_item_ts(item, tool_rows, cmd_rows, cwd_rows),
+                                 now, dead_s) == 0
+
+        impact = {o: agg["outcomes"].get(o, 0) for o in item.get("impact_outcomes", [])}
+        items.append({
+            "id": item["id"], "label": item["label"], "via": via,
+            "opt_in": item["opt_in"], "total": agg["total"],
+            "outcomes": agg["outcomes"], "recent": agg["recent"],
+            "prior": agg["prior"], "trend": agg["trend"], "dead": dead,
+            "impact": impact, "impact_label": item.get("impact_label", ""),
+        })
+
+    friction = aggregate_friction(insight_rows, now, ihalf)
+
+    return {
+        "days": days, "insight_days": insight_days, "dead_days": dead_days,
+        "host": host, "items": items, "friction": friction,
+        "totals": {
+            "tool_events": len(tool_rows), "command_events": len(cmd_rows),
+            "insight_sessions": len(insight_rows),
+        },
+    }
+
+
+def _item_ts(item, tool_rows, cmd_rows, cwd_rows) -> list:
+    """Ts strings attributable to `item` (for the sub-window DEAD re-bucket)."""
+    if item["via"] == "tool":
+        out = []
+        for r in tool_rows:
+            p = parse_payload(r.get("payload"))
+            name = r.get("tool") or r.get("text") or p.get("tool")
+            if name == item["tool"]:
+                out.append(r.get("ts"))
+        return out
+    if item["via"] == "command":
+        pres = item["prefixes"]
+        return [r.get("ts") for r in cmd_rows
+                if any((r.get("text") or "").strip().startswith(pre) for pre in pres)]
+    if item["via"] == "cwd":
+        return [r.get("ts") for r in cwd_rows.get(item["id"], [])]
+    return []
+
+
+def _count_within(ts_list: list, now: float, window_s: float) -> int:
+    n = 0
+    for ts in ts_list:
+        e = ch_ts_to_epoch(ts)
+        if e is not None and (now - e) <= window_s:
+            n += 1
+    return n
+
+
+# --------------------------------------------------------------------------- #
+# Render
+# --------------------------------------------------------------------------- #
+_ARROW = {"up": "▲", "down": "▼", "flat": "→"}
+
+
+def render(data: dict) -> str:
+    out: list[str] = []
+    host = data.get("host") or "all hosts"
+    out.append(f"=== adoption-scan: trailing {data['days']}d  (host: {host}) ===")
+    t = data["totals"]
+    out.append(f"  telemetry: {t['tool_events']} tool-invocation events, "
+               f"{t['command_events']} slash-commands, "
+               f"{t['insight_sessions']} insight sessions in window")
+
+    # ---- ADOPTION ----
+    out.append("\n## ADOPTION (is it USED?)")
+    out.append("   count = invocations in window; trend = this-half vs prior-half; "
+               "DEAD = 0 uses in the dead window.")
+    dead_any = False
+    for it in data["items"]:
+        flag = "  ⚠ DEAD" if it["dead"] else ""
+        if it["dead"]:
+            dead_any = True
+        opt = "opt-in" if it["opt_in"] else "auto"
+        arrow = _ARROW.get(it["trend"], "?")
+        out.append(f"  [{opt:6}] {it['total']:>4}  {arrow} "
+                   f"({it['recent']} vs {it['prior']})  {it['label']}{flag}")
+        if it["outcomes"]:
+            mix = "  ".join(f"{k}={v}" for k, v in sorted(it["outcomes"].items()))
+            out.append(f"            outcomes: {mix}")
+    if dead_any:
+        out.append("  ⚠ DEAD items had ZERO uses in the window — an opt-in tool that "
+                   "is DEAD is a candidate to retire or auto-trigger.")
+
+    # ---- IMPACT ----
+    out.append("\n## IMPACT (is it YIELDING?)")
+    out.append("   invocation COUNT proves USE, not VALUE. The outcome MIX below is "
+               "the closest value signal — read it as directional.")
+    any_impact = False
+    for it in data["items"]:
+        if not it["impact_label"]:
+            continue
+        any_impact = True
+        hits = sum(it["impact"].values())
+        detail = ", ".join(f"{k}={v}" for k, v in it["impact"].items()) or "—"
+        out.append(f"  {it['id']:20} {hits:>4}  {it['impact_label']}")
+        out.append(f"            ({detail})")
+    if not any_impact:
+        out.append("  (no impact-bearing outcomes recorded yet)")
+
+    # ---- FRICTION TREND ----
+    fr = data["friction"]
+    out.append("\n## DRAFTER FRICTION TREND (directional — NOT a controlled metric)")
+    out.append(f"   session-insight friction over two {data['insight_days'] // 2}d halves "
+               f"({fr['sessions_prior']} prior → {fr['sessions_recent']} recent sessions). "
+               "Confounds: different tickets/models per window. Baseline was "
+               "permission_block=57.")
+    for k in FRICTION_TRACKED:
+        rec = fr["recent"][k]
+        pri = fr["prior"][k]
+        d = fr["deltas"][k]
+        sign = "+" if d > 0 else ""
+        arrow = _ARROW.get(_trend(rec, pri), "?")
+        out.append(f"  {k:20} prior {pri:>4}  →  recent {rec:>4}   "
+                   f"({arrow} {sign}{d})")
+    if fr["unreadable"]:
+        out.append(f"  ({fr['unreadable']} insight session(s) unreadable — excluded)")
+
+    out.append("\nCAVEATS: counts prove USE not VALUE; the friction trend is "
+               "directional (window confounds). cwd-detected items (drafter) are "
+               "heuristic. Telemetry-off → this report degrades to a clean notice.")
+    return "\n".join(out)
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Adoption + impact tracking for the shipped gametape tools.")
+    p.add_argument("--days", type=int, default=DEFAULT_DAYS,
+                   help=f"adoption window in days (default {DEFAULT_DAYS})")
+    p.add_argument("--insight-days", type=int, default=DEFAULT_INSIGHT_DAYS,
+                   help=f"friction-trend window in days (default {DEFAULT_INSIGHT_DAYS})")
+    p.add_argument("--dead-days", type=int, default=None,
+                   help="0-uses-within-N-days => DEAD (default = --days)")
+    p.add_argument("--host", default=None, help="restrict to one ACTIVITY_HOST label")
+    p.add_argument("--json", action="store_true", help="machine-readable output")
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    a = parse_args(argv)
+    if a.days <= 0 or a.insight_days <= 0:
+        print("adoption-scan: --days / --insight-days must be positive", file=sys.stderr)
+        return 2
+    dead_days = a.dead_days if a.dead_days is not None else a.days
+    if dead_days <= 0:
+        print("adoption-scan: --dead-days must be positive", file=sys.stderr)
+        return 2
+
+    try:
+        conn = Q.CHConn.from_env()
+    except RuntimeError as e:
+        print(f"adoption-scan: telemetry not configured — {e}", file=sys.stderr)
+        return 0
+    client = Q.CHClient(conn)
+    try:
+        data = gather(client, a.days, a.insight_days, dead_days, host=a.host)
+    except TelemetryUnavailable as e:
+        print(f"adoption-scan: telemetry unavailable ({e}); nothing to report.",
+              file=sys.stderr)
+        return 0
+
+    if a.json:
+        print(json.dumps(data, indent=2, default=str))
+    else:
+        print(render(data))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/session-analysis/tests/test_adoption_scan.py
+++ b/scripts/session-analysis/tests/test_adoption_scan.py
@@ -63,11 +63,18 @@ def test_aggregate_tool_counts_outcomes_and_trend():
         _tool_row("verify-agent-work", "pass", 10),
         _tool_row("obs-read", "ok", 1),           # different tool -> ignored
     ]
-    agg = A.aggregate_tool(rows, "verify-agent-work", NOW, 7 * DAY)
+    agg = A.aggregate_tool(rows, "verify-agent-work", NOW, 14 * DAY)
     assert agg["total"] == 3
     assert agg["outcomes"] == {"pass": 2, "fail": 1}
     assert agg["recent"] == 2 and agg["prior"] == 1
     assert agg["trend"] == "up"
+
+
+def test_aggregate_tool_excludes_rows_outside_window():
+    # A wider dead-window fetch can return older rows; counts stay scoped to win.
+    rows = [_tool_row("obs-read", "ok", 3), _tool_row("obs-read", "ok", 20)]
+    agg = A.aggregate_tool(rows, "obs-read", NOW, 14 * DAY)
+    assert agg["total"] == 1  # the 20-day-old row is excluded from counts
 
 
 def test_aggregate_command_prefix_match():
@@ -76,14 +83,29 @@ def test_aggregate_command_prefix_match():
         {"text": "/verify-agent", "ts": _ts(10)},
         {"text": "/obs-read foo", "ts": _ts(1)},   # different prefix -> ignored
     ]
-    agg = A.aggregate_command(rows, ["/verify-agent"], NOW, 7 * DAY)
+    agg = A.aggregate_command(rows, ["/verify-agent"], NOW, 14 * DAY)
     assert agg["total"] == 2 and agg["recent"] == 1 and agg["prior"] == 1
     assert agg["trend"] == "flat"
 
 
+def test_command_matches_is_tight():
+    # A near-miss command must NOT be counted as the tracked one.
+    assert A.command_matches("/obs-read", ["/obs-read"]) is True
+    assert A.command_matches("/obs-read foo", ["/obs-read"]) is True
+    assert A.command_matches("/obs-read-foo", ["/obs-read"]) is False
+    assert A.command_matches("/obs-readnow", ["/obs-read"]) is False
+
+
+def test_aggregate_command_does_not_subsume_suffix():
+    rows = [{"text": "/obs-read-foo bar", "ts": _ts(1)},
+            {"text": "/obs-read real", "ts": _ts(1)}]
+    agg = A.aggregate_command(rows, ["/obs-read"], NOW, 14 * DAY)
+    assert agg["total"] == 1  # only the genuine /obs-read counts
+
+
 def test_aggregate_cwd_counts_sessions():
     rows = [{"session": "s1", "ts": _ts(1)}, {"session": "s2", "ts": _ts(10)}]
-    agg = A.aggregate_cwd(rows, NOW, 7 * DAY)
+    agg = A.aggregate_cwd(rows, NOW, 14 * DAY)
     assert agg["total"] == 2 and agg["recent"] == 1 and agg["prior"] == 1
 
 
@@ -95,7 +117,7 @@ def test_aggregate_friction_two_windows():
          "payload": json.dumps({"friction_counts": {"permission_block": 5}})},
         {"session": "c", "ts": _ts(2), "payload": json.dumps({"unreadable": True})},
     ]
-    fr = A.aggregate_friction(rows, NOW, 7 * DAY)
+    fr = A.aggregate_friction(rows, NOW, 14 * DAY)
     assert fr["recent"] == {"permission_block": 2, "wrong_approach": 1}
     assert fr["prior"] == {"permission_block": 5, "wrong_approach": 0}
     assert fr["deltas"]["permission_block"] == -3
@@ -176,6 +198,21 @@ def test_gather_dead_subwindow():
     items = _by_id(data)
     assert items["obs-read"]["dead"] is True
     assert items["verify-agent-work"]["dead"] is False  # recent use
+
+
+def test_gather_dead_days_larger_than_days_is_honest():
+    """A tool used 20d ago: DEAD over 14 days, but NOT dead when --dead-days=25
+    (the fetch must span the wider dead window, not silently clamp to --days)."""
+    tool_rows = [_tool_row("obs-read", "ok", 20)]  # only use is 20 days ago
+    client = FakeClient(tool_rows, [], [], [])
+    # default dead window == days: 0 uses in last 14d -> DEAD, and total(win)==0.
+    d14 = _by_id(A.gather(client, days=14, insight_days=30, dead_days=14, now=NOW))
+    assert d14["obs-read"]["total"] == 0
+    assert d14["obs-read"]["dead"] is True
+    # wider dead window sees the 20-day-old use -> NOT dead (count still 0 in win).
+    d25 = _by_id(A.gather(client, days=14, insight_days=30, dead_days=25, now=NOW))
+    assert d25["obs-read"]["total"] == 0
+    assert d25["obs-read"]["dead"] is False
 
 
 def test_gather_friction_section():

--- a/scripts/session-analysis/tests/test_adoption_scan.py
+++ b/scripts/session-analysis/tests/test_adoption_scan.py
@@ -1,0 +1,240 @@
+"""Unit tests for adoption-scan.py — PURE aggregation + graceful degrade.
+
+No live ClickHouse: fake `activity.events` rows are injected through a FakeClient
+(the same style as test_insights.py) and the pure aggregators are exercised
+directly. Covers per-item invocation counts, outcome breakdown, week-over-week
+trend, the DEAD flag (fires at 0 uses, and in the sub-window), the friction
+trend, --json shape, and telemetry-off degradation.
+"""
+import datetime as _dt
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "adoption-scan.py"
+sys.path.insert(0, str(HERE.parent.parent / "validation"))
+_spec = importlib.util.spec_from_file_location("adoption_scan", SCRIPT)
+A = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(A)
+
+DAY = 86400
+NOW = 1_700_000_000.0
+
+
+def _ts(age_days):
+    """A ClickHouse/emit UTC ts string `age_days` before NOW."""
+    dt = _dt.datetime.fromtimestamp(NOW - age_days * DAY, _dt.timezone.utc)
+    return dt.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+
+
+def _tool_row(tool, outcome, age_days):
+    return {"tool": tool, "text": tool, "exit_code": 0, "duration_ms": 5,
+            "ts": _ts(age_days),
+            "payload": json.dumps({"tool": tool, "outcome": outcome})}
+
+
+# --------------------------------------------------------------------------- #
+# pure helpers
+# --------------------------------------------------------------------------- #
+def test_ch_ts_to_epoch_roundtrip():
+    e = A.ch_ts_to_epoch(_ts(0))
+    assert abs(e - NOW) < 1.0
+    assert A.ch_ts_to_epoch("garbage") is None
+
+
+def test_half_bucketing():
+    half = 7 * DAY
+    assert A._half(NOW - 1 * DAY, NOW, half) == "recent"
+    assert A._half(NOW - 10 * DAY, NOW, half) == "prior"
+    assert A._half(NOW - 30 * DAY, NOW, half) is None
+
+
+# --------------------------------------------------------------------------- #
+# aggregate_tool
+# --------------------------------------------------------------------------- #
+def test_aggregate_tool_counts_outcomes_and_trend():
+    rows = [
+        _tool_row("verify-agent-work", "pass", 1),
+        _tool_row("verify-agent-work", "fail", 1),
+        _tool_row("verify-agent-work", "pass", 10),
+        _tool_row("obs-read", "ok", 1),           # different tool -> ignored
+    ]
+    agg = A.aggregate_tool(rows, "verify-agent-work", NOW, 7 * DAY)
+    assert agg["total"] == 3
+    assert agg["outcomes"] == {"pass": 2, "fail": 1}
+    assert agg["recent"] == 2 and agg["prior"] == 1
+    assert agg["trend"] == "up"
+
+
+def test_aggregate_command_prefix_match():
+    rows = [
+        {"text": "/verify-agent .", "ts": _ts(1)},
+        {"text": "/verify-agent", "ts": _ts(10)},
+        {"text": "/obs-read foo", "ts": _ts(1)},   # different prefix -> ignored
+    ]
+    agg = A.aggregate_command(rows, ["/verify-agent"], NOW, 7 * DAY)
+    assert agg["total"] == 2 and agg["recent"] == 1 and agg["prior"] == 1
+    assert agg["trend"] == "flat"
+
+
+def test_aggregate_cwd_counts_sessions():
+    rows = [{"session": "s1", "ts": _ts(1)}, {"session": "s2", "ts": _ts(10)}]
+    agg = A.aggregate_cwd(rows, NOW, 7 * DAY)
+    assert agg["total"] == 2 and agg["recent"] == 1 and agg["prior"] == 1
+
+
+def test_aggregate_friction_two_windows():
+    rows = [
+        {"session": "a", "ts": _ts(1),
+         "payload": json.dumps({"friction_counts": {"permission_block": 2, "wrong_approach": 1}})},
+        {"session": "b", "ts": _ts(10),
+         "payload": json.dumps({"friction_counts": {"permission_block": 5}})},
+        {"session": "c", "ts": _ts(2), "payload": json.dumps({"unreadable": True})},
+    ]
+    fr = A.aggregate_friction(rows, NOW, 7 * DAY)
+    assert fr["recent"] == {"permission_block": 2, "wrong_approach": 1}
+    assert fr["prior"] == {"permission_block": 5, "wrong_approach": 0}
+    assert fr["deltas"]["permission_block"] == -3
+    assert fr["deltas"]["wrong_approach"] == 1
+    assert fr["unreadable"] == 1
+    assert fr["sessions_recent"] == 1 and fr["sessions_prior"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# gather() end-to-end via a fake client
+# --------------------------------------------------------------------------- #
+class FakeClient:
+    def __init__(self, tool_rows, cmd_rows, insight_rows, cwd_rows):
+        self._tool, self._cmd, self._ins, self._cwd = (
+            tool_rows, cmd_rows, insight_rows, cwd_rows)
+
+    def rows(self, sql):
+        if "kind='invocation'" in sql:
+            return self._tool
+        if "session-insight" in sql:
+            return self._ins
+        if "position(lower(cwd)" in sql:
+            return self._cwd
+        return self._cmd
+
+
+def _sample_client():
+    tool_rows = [
+        _tool_row("verify-agent-work", "pass", 1),
+        _tool_row("verify-agent-work", "fail", 1),
+        _tool_row("verify-agent-work", "pass", 10),
+        _tool_row("obs-read", "matched-nothing", 10),  # PRIOR-only (sub-window DEAD)
+        # ticket-status + playwright-nixos absent -> DEAD
+    ]
+    cmd_rows = [{"text": "/verify-agent go", "ts": _ts(1)}]  # /obs-read absent -> DEAD
+    insight_rows = [
+        {"session": "a", "ts": _ts(1),
+         "payload": json.dumps({"friction_counts": {"permission_block": 2, "wrong_approach": 1}})},
+        {"session": "b", "ts": _ts(10),
+         "payload": json.dumps({"friction_counts": {"permission_block": 5}})},
+    ]
+    cwd_rows = [{"session": "d1", "ts": _ts(1)}]
+    return FakeClient(tool_rows, cmd_rows, insight_rows, cwd_rows)
+
+
+def _by_id(data):
+    return {it["id"]: it for it in data["items"]}
+
+
+def test_gather_per_item_counts_and_outcomes():
+    data = A.gather(_sample_client(), days=14, insight_days=30, dead_days=14, now=NOW)
+    items = _by_id(data)
+    vaw = items["verify-agent-work"]
+    assert vaw["total"] == 3
+    assert vaw["outcomes"] == {"pass": 2, "fail": 1}
+    assert vaw["trend"] == "up"
+    # impact = false-greens caught (fail+incomplete)
+    assert vaw["impact"] == {"fail": 1, "incomplete": 0}
+    assert items["cmd:verify-agent"]["total"] == 1
+    assert items["task-spec-drafter"]["total"] == 1
+
+
+def test_gather_dead_flag_fires_at_zero_and_not_when_used():
+    data = A.gather(_sample_client(), days=14, insight_days=30, dead_days=14, now=NOW)
+    items = _by_id(data)
+    assert items["ticket-status"]["dead"] is True       # 0 uses
+    assert items["playwright-nixos"]["dead"] is True     # 0 uses
+    assert items["cmd:obs-read"]["dead"] is True          # opt-in, 0 uses
+    assert items["verify-agent-work"]["dead"] is False   # used
+    # obs-read has a PRIOR-only use -> alive under the full window...
+    assert items["obs-read"]["dead"] is False
+    assert items["obs-read"]["total"] == 1
+
+
+def test_gather_dead_subwindow():
+    # ...but DEAD under a 3-day dead window (its only use was 10 days ago).
+    data = A.gather(_sample_client(), days=14, insight_days=30, dead_days=3, now=NOW)
+    items = _by_id(data)
+    assert items["obs-read"]["dead"] is True
+    assert items["verify-agent-work"]["dead"] is False  # recent use
+
+
+def test_gather_friction_section():
+    # insight_days=14 -> 7d halves: the 1d row is recent, the 10d row is prior.
+    data = A.gather(_sample_client(), days=14, insight_days=14, dead_days=14, now=NOW)
+    fr = data["friction"]
+    assert fr["recent"]["permission_block"] == 2
+    assert fr["prior"]["permission_block"] == 5
+    assert fr["deltas"]["permission_block"] == -3
+
+
+def test_gather_json_shape():
+    data = A.gather(_sample_client(), days=14, insight_days=30, dead_days=14, now=NOW)
+    parsed = json.loads(json.dumps(data, default=str))
+    assert parsed["days"] == 14 and parsed["insight_days"] == 30
+    assert isinstance(parsed["items"], list) and parsed["items"]
+    for it in parsed["items"]:
+        for k in ("id", "label", "via", "opt_in", "total", "outcomes",
+                  "recent", "prior", "trend", "dead", "impact"):
+            assert k in it
+
+
+def test_render_has_sections():
+    data = A.gather(_sample_client(), days=14, insight_days=30, dead_days=14, now=NOW)
+    text = A.render(data)
+    assert "## ADOPTION" in text
+    assert "## IMPACT" in text
+    assert "## DRAFTER FRICTION TREND" in text
+    assert "DEAD" in text
+    assert "CAVEATS" in text
+
+
+# --------------------------------------------------------------------------- #
+# graceful degradation
+# --------------------------------------------------------------------------- #
+class BoomClient:
+    def rows(self, sql):
+        raise RuntimeError("connection refused")
+
+
+def test_gather_degrades_to_telemetry_unavailable():
+    with pytest.raises(A.TelemetryUnavailable):
+        A.gather(BoomClient(), days=14, insight_days=30, dead_days=14, now=NOW)
+
+
+def test_main_no_creds_exits_zero(monkeypatch, capsys):
+    monkeypatch.delenv("CLICKHOUSE_URL", raising=False)
+    rc = A.main([])
+    assert rc == 0
+    assert "telemetry not configured" in capsys.readouterr().err
+
+
+def test_main_unavailable_exits_zero(monkeypatch, capsys):
+    monkeypatch.setenv("CLICKHOUSE_URL", "http://127.0.0.1:1")
+    monkeypatch.setattr(A.Q, "CHClient", lambda conn: BoomClient())
+    rc = A.main([])
+    assert rc == 0
+    assert "telemetry unavailable" in capsys.readouterr().err
+
+
+def test_main_bad_days_exits_two(capsys):
+    assert A.main(["--days", "0"]) == 2

--- a/scripts/task-spec-drafter/tests/test_ticket_status.py
+++ b/scripts/task-spec-drafter/tests/test_ticket_status.py
@@ -529,3 +529,73 @@ def test_prompt_still_has_command_shape_and_anticonfab_guards():
     p = " ".join(_PROMPT.read_text(encoding="utf-8").split())
     assert "COMMAND-SHAPE CONTRACT" in p
     assert "ANTI-CONFABULATION GATE" in p
+
+
+# ============================================================================
+# adoption telemetry (Part A instrumentation)
+# ============================================================================
+def _load_collector():
+    coll = _HERE.parent.parent / "collector"
+    sys.path.insert(0, str(coll))
+    import collector as C  # noqa: PLC0415
+    return C
+
+
+def _read_last_event(spool_dir, C):
+    line = (Path(spool_dir) / "current.log").read_text().strip().splitlines()[-1]
+    return C.parse_line(line), line
+
+
+def test_verdict_to_outcome_mapping():
+    assert ts.verdict_to_outcome("ALREADY-DONE") == "already-done"
+    assert ts.verdict_to_outcome("PARTIAL") == "partial"
+    assert ts.verdict_to_outcome("NOT-FOUND") == "not-found"
+    assert ts.verdict_to_outcome("???") == "error"
+
+
+def _run_with_spool(spool_dir, repo_path, *args, lock_repo=None):
+    env = {**os.environ, "TICKET_STATUS_GH": "/nonexistent-gh",
+           "ACTIVITY_SPOOL_DIR": str(spool_dir)}
+    env.pop("TICKET_STATUS_LOCK_REPO", None)
+    env["TICKET_STATUS_ALLOWED_REPO_ROOTS"] = str(Path(repo_path).parent)
+    if lock_repo is not None:
+        env["TICKET_STATUS_LOCK_REPO"] = str(lock_repo)
+    argv = [sys.executable, str(_SCRIPT), *args, "--repo", str(repo_path), "--no-fetch"]
+    return subprocess.run(argv, capture_output=True, text=True, env=env)
+
+
+def test_main_emits_already_done_and_privacy(repo, tmp_path):
+    """End-to-end: emits already-done + ticket_id, and NEVER the search term/body."""
+    C = _load_collector()
+    spool = tmp_path / "spool"
+    # A sensitive free-text search term that MUST NOT reach the telemetry store.
+    r = _run_with_spool(spool, repo["work"], "86abc123", "MYSECRETTERM")
+    assert r.returncode == 0, r.stderr
+    ev, raw = _read_last_event(spool, C)
+    assert ev["source"] == "tool" and ev["text"] == "ticket-status"
+    p = json.loads(ev["payload"])
+    assert p["outcome"] == "already-done"
+    assert p["verdict"] == "already-done"
+    assert p["ticket_id"] == "86abc123"
+    # PRIVACY: the term must not appear anywhere in the emitted event / raw line.
+    assert "MYSECRETTERM" not in json.dumps(ev)
+    assert "MYSECRETTERM" not in raw
+
+
+def test_main_emits_not_found(repo, tmp_path):
+    C = _load_collector()
+    spool = tmp_path / "spool"
+    r = _run_with_spool(spool, repo["work"], "ZZ00000")
+    assert r.returncode == 0, r.stderr
+    ev, _ = _read_last_event(spool, C)
+    assert json.loads(ev["payload"])["outcome"] == "not-found"
+
+
+def test_rejected_ticket_id_emits_nothing(repo, tmp_path):
+    """A ticket-id that fails validation is REJECTED before any emit — the
+    unvalidated (attacker-controlled) id must never reach telemetry."""
+    C = _load_collector()  # noqa: F841 — imported for parity; no line expected
+    spool = tmp_path / "spool"
+    r = _run_with_spool(spool, repo["work"], "bad/id;rm")
+    assert r.returncode == 2  # rejected input
+    assert not (spool / "current.log").exists()

--- a/scripts/task-spec-drafter/tests/test_ticket_status.py
+++ b/scripts/task-spec-drafter/tests/test_ticket_status.py
@@ -591,6 +591,24 @@ def test_main_emits_not_found(repo, tmp_path):
     assert json.loads(ev["payload"])["outcome"] == "not-found"
 
 
+def test_error_path_emits_only_validated_id(tmp_path):
+    """SECURITY (error path): a probe InputError (repo not found) must emit ONLY
+    the validated ticket-id + outcome:error — never the free-text term, the repo
+    PATH, or the exception text."""
+    C = _load_collector()
+    spool = tmp_path / "spool"
+    missing = tmp_path / "SECRETPATH_repo"     # nonexistent -> probe InputError
+    r = _run_with_spool(spool, missing, "86abc123", "SECRETTERM")
+    assert r.returncode == 2, r.stderr
+    ev, raw = _read_last_event(spool, C)
+    p = json.loads(ev["payload"])
+    assert p["outcome"] == "error" and p["verdict"] == "error"
+    assert p["ticket_id"] == "86abc123"
+    for secret in ("SECRETTERM", "SECRETPATH_repo", "not found"):
+        assert secret not in raw, f"{secret} leaked into raw spool line"
+        assert secret not in json.dumps(ev), f"{secret} leaked into event"
+
+
 def test_rejected_ticket_id_emits_nothing(repo, tmp_path):
     """A ticket-id that fails validation is REJECTED before any emit — the
     unvalidated (attacker-controlled) id must never reach telemetry."""

--- a/scripts/task-spec-drafter/ticket-status
+++ b/scripts/task-spec-drafter/ticket-status
@@ -587,6 +587,38 @@ def parse_args(argv: list[str]) -> dict:
     return out
 
 
+# --- adoption telemetry (best-effort; NEVER changes the verdict or exit code) --
+_VERDICT_OUTCOME = {
+    "ALREADY-DONE": "already-done", "PARTIAL": "partial", "NOT-FOUND": "not-found",
+}
+
+
+def verdict_to_outcome(verdict: str) -> str:
+    """Map the deterministic verdict to the adoption outcome enum. Pure."""
+    return _VERDICT_OUTCOME.get(verdict, "error")
+
+
+def _emit_adoption(outcome: str, ticket_id: str | None, duration_ms=None) -> None:
+    """Best-effort adoption event. dims carry ONLY the verdict + the (already
+    VALIDATED) ticket-id — NEVER the free-text search terms or any ticket body.
+    Fully swallowed; telemetry never breaks the tool.
+
+    `ticket_id` is passed ONLY after validate_ticket_id has accepted it, so a
+    rejected/attacker-controlled raw id never reaches the telemetry store.
+    """
+    try:
+        sys.path.insert(0, os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), "..", "collector"))
+        import invocation  # noqa: PLC0415
+        dims = {"verdict": outcome}
+        if ticket_id:
+            dims["ticket_id"] = ticket_id
+        invocation.emit_invocation(
+            "ticket-status", outcome, dims=dims, duration_ms=duration_ms)
+    except Exception:  # noqa: BLE001 — defence-in-depth around the helper
+        pass
+
+
 def main(argv: list[str]) -> int:
     try:
         args = parse_args(argv)
@@ -595,7 +627,11 @@ def main(argv: list[str]) -> int:
             sys.stdout.write(_USAGE)
             return 0
         sys.stderr.write(f"ticket-status: {exc}\n")
+        # No emit: input was REJECTED before validation, so there is no safe
+        # (validated) ticket-id to attribute — never emit unvalidated input.
         return 2
+    import time
+    _t0 = time.monotonic()
     try:
         result = probe(
             args["ticket_id"], args["terms"], args["repo"], args["trunk"],
@@ -603,7 +639,12 @@ def main(argv: list[str]) -> int:
         )
     except InputError as exc:
         sys.stderr.write(f"ticket-status: {exc}\n")
+        # ticket-id is already validated here; verdict is an error outcome.
+        _emit_adoption("error", args["ticket_id"],
+                       int((time.monotonic() - _t0) * 1000))
         return 2
+    _emit_adoption(verdict_to_outcome(result["verdict"]), args["ticket_id"],
+                   int((time.monotonic() - _t0) * 1000))
     if args["fmt"] == "text":
         sys.stdout.write(render_text(result) + "\n")
     else:

--- a/scripts/tests/test_obs_read.py
+++ b/scripts/tests/test_obs_read.py
@@ -668,6 +668,123 @@ def test_main_list_presets(capsys):
 
 
 # =========================================================================== #
+# adoption telemetry (Part A instrumentation)
+# =========================================================================== #
+def _read_last_event(spool_dir):
+    coll = SCRIPTS / "collector"
+    sys.path.insert(0, str(coll))
+    import collector as C  # noqa: PLC0415
+    text = (Path(spool_dir) / "current.log").read_text().strip()
+    line = text.splitlines()[-1]
+    return C.parse_line(line), line
+
+
+def test_invocation_outcome_mapping():
+    assert obs.invocation_outcome(False, False) == "ok"
+    assert obs.invocation_outcome(True, False) == "matched-nothing"
+    # expected-absence preset: empty is healthy -> ok, not a caught silent-zero
+    assert obs.invocation_outcome(True, True) == "ok"
+
+
+def test_main_emits_ok_invocation(capsys, tmp_path, monkeypatch):
+    monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(tmp_path))
+    kc = tmp_path / "kc"
+    kc.write_text("x")
+
+    def fake_http(url, timeout=15.0):
+        return prom_vector([({"code": "200"}, "10")])
+
+    rc = obs.main(["--cluster", "dpprod", "--preset", "dp-code-breakdown"],
+                  pf_factory=_fake_pf(None), http_get=fake_http,
+                  env={"KC_DPPROD": str(kc)})
+    assert rc == 0
+    ev, _ = _read_last_event(tmp_path)
+    assert ev["source"] == "tool" and ev["text"] == "obs-read"
+    p = json.loads(ev["payload"])
+    assert p["outcome"] == "ok"
+    assert p["cluster"] == "dpprod" and p["backend"] == "prometheus"
+    assert p["preset"] == "dp-code-breakdown"
+
+
+def test_main_emits_matched_nothing(capsys, tmp_path, monkeypatch):
+    monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(tmp_path))
+    kc = tmp_path / "kc"
+    kc.write_text("x")
+
+    def fake_http(url, timeout=15.0):
+        return prom_empty()
+
+    rc = obs.main(["--cluster", "dpprod", "--preset", "dp-5xx-rate"],
+                  pf_factory=_fake_pf(None), http_get=fake_http,
+                  env={"KC_DPPROD": str(kc)})
+    assert rc == 0
+    ev, _ = _read_last_event(tmp_path)
+    p = json.loads(ev["payload"])
+    assert p["outcome"] == "matched-nothing"
+
+
+def test_main_emits_error_on_transport_failure(capsys, tmp_path, monkeypatch):
+    monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(tmp_path))
+    kc = tmp_path / "kc"
+    kc.write_text("x")
+
+    def boom(url, timeout=15.0):
+        raise RuntimeError("kubectl exited early")
+
+    rc = obs.main(["--cluster", "dpprod", "--preset", "dp-5xx-rate"],
+                  pf_factory=_fake_pf(None), http_get=boom,
+                  env={"KC_DPPROD": str(kc)})
+    assert rc == 1
+    ev, _ = _read_last_event(tmp_path)
+    p = json.loads(ev["payload"])
+    assert p["outcome"] == "error"
+
+
+def test_privacy_preset_query_text_not_leaked(capsys, tmp_path, monkeypatch):
+    """SECURITY: the emitted event must carry the preset NAME, never the PromQL."""
+    monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(tmp_path))
+    kc = tmp_path / "kc"
+    kc.write_text("x")
+
+    def fake_http(url, timeout=15.0):
+        return prom_vector([({"code": "500"}, "1")])
+
+    rc = obs.main(["--cluster", "dpprod", "--preset", "dp-5xx-rate"],
+                  pf_factory=_fake_pf(None), http_get=fake_http,
+                  env={"KC_DPPROD": str(kc)})
+    assert rc == 0
+    ev, raw_line = _read_last_event(tmp_path)
+    # The preset's PromQL contains this metric; it must NOT appear anywhere in
+    # the emitted (decoded) event OR the raw spool line.
+    assert "traefik_service_requests_total" not in json.dumps(ev)
+    import base64 as _b64
+    decoded = _b64.b64decode(raw_line.split("b64:payload=")[1].split("\t")[0])
+    assert b"traefik_service_requests_total" not in decoded
+    assert json.loads(ev["payload"])["preset"] == "dp-5xx-rate"
+
+
+def test_privacy_adhoc_query_text_not_leaked(capsys, tmp_path, monkeypatch):
+    """SECURITY: a raw --query must be recorded as 'adhoc', never verbatim."""
+    monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(tmp_path))
+    kc = tmp_path / "kc"
+    kc.write_text("x")
+
+    def fake_http(url, timeout=15.0):
+        return prom_vector([({}, "1")])
+
+    rc = obs.main(["--cluster", "homelab", "--backend", "prometheus",
+                   "--query", 'super_secret_metric{token="hunter2"}'],
+                  pf_factory=_fake_pf(None), http_get=fake_http,
+                  env={"KC_HOMELAB": str(kc)})
+    assert rc == 0
+    ev, _ = _read_last_event(tmp_path)
+    p = json.loads(ev["payload"])
+    assert p["preset"] == "adhoc"
+    blob = json.dumps(ev)
+    assert "super_secret_metric" not in blob and "hunter2" not in blob
+
+
+# =========================================================================== #
 # CLI smoke via subprocess (offline paths only)
 # =========================================================================== #
 def test_cli_list_presets_subprocess():

--- a/scripts/tests/test_obs_read.py
+++ b/scripts/tests/test_obs_read.py
@@ -740,6 +740,36 @@ def test_main_emits_error_on_transport_failure(capsys, tmp_path, monkeypatch):
     assert p["outcome"] == "error"
 
 
+def test_privacy_error_path_leaks_neither_query_nor_exception(capsys, tmp_path,
+                                                              monkeypatch):
+    """SECURITY (error path): a secret-bearing --query AND a transport exception
+    whose message carries a secret must NOT reach the emitted event — the error
+    path records ONLY {tool,outcome:error,cluster,backend,preset:adhoc}."""
+    import base64 as _b64
+    monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(tmp_path))
+    kc = tmp_path / "kc"
+    kc.write_text("x")
+
+    def boom(url, timeout=15.0):
+        raise RuntimeError("connect failed: secret_token=hunter2")
+
+    rc = obs.main(["--cluster", "homelab", "--backend", "prometheus",
+                   "--query", 'super_secret_metric{apikey="AKIA_LEAK"}'],
+                  pf_factory=_fake_pf(None), http_get=boom,
+                  env={"KC_HOMELAB": str(kc)})
+    assert rc == 1
+    ev, raw = _read_last_event(tmp_path)
+    p = json.loads(ev["payload"])
+    assert p["outcome"] == "error" and p["preset"] == "adhoc"
+    assert p["cluster"] == "homelab" and p["backend"] == "prometheus"
+    decoded = _b64.b64decode(raw.split("b64:payload=")[1].split("\t")[0])
+    blob = json.dumps(ev)
+    for secret in ("super_secret_metric", "AKIA_LEAK", "hunter2", "secret_token"):
+        assert secret not in blob, f"{secret} leaked into decoded event"
+        assert secret not in raw, f"{secret} leaked into raw spool line"
+        assert secret.encode() not in decoded, f"{secret} leaked into payload"
+
+
 def test_privacy_preset_query_text_not_leaked(capsys, tmp_path, monkeypatch):
     """SECURITY: the emitted event must carry the preset NAME, never the PromQL."""
     monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(tmp_path))

--- a/scripts/tests/test_playwright_nixos.py
+++ b/scripts/tests/test_playwright_nixos.py
@@ -1,0 +1,101 @@
+"""Hermetic tests for scripts/playwright-nixos adoption instrumentation.
+
+No real nix / Chromium: a stub `nix` is prepended to PATH so both the
+resolve-FAILURE path (empty browser bundle) and the OK/exec path are driven
+offline. The event is emitted via the REAL sibling `emit` binary into a temp
+spool and round-tripped through the real collector.parse_line.
+
+Only the emit behaviour is under test here (the browser-resolution logic needs a
+real nix and is out of scope for the hermetic suite).
+
+    run:  pytest scripts/tests/test_playwright_nixos.py
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+SCRIPT = SCRIPTS / "playwright-nixos"
+
+
+def _load_collector():
+    sys.path.insert(0, str(SCRIPTS / "collector"))
+    import collector as C  # noqa: PLC0415
+    return C
+
+
+def _stub_nix(dirpath: Path):
+    """A fake `nix`: `build` echoes $FAKE_BROWSERS, `eval` prints a version."""
+    p = dirpath / "nix"
+    p.write_text(
+        "#!/usr/bin/env bash\n"
+        'case "$1" in\n'
+        '  build) [ -n "${FAKE_BROWSERS:-}" ] && echo "$FAKE_BROWSERS" ;;\n'
+        '  eval)  echo "1.2.3" ;;\n'
+        "esac\n"
+        "exit 0\n"
+    )
+    p.chmod(0o755)
+
+
+def _run(tmp_path, args, fake_browsers=None):
+    stub = tmp_path / "bin"
+    stub.mkdir()
+    _stub_nix(stub)
+    spool = tmp_path / "spool"
+    env = {**os.environ,
+           "PATH": f"{stub}{os.pathsep}{os.environ['PATH']}",
+           "ACTIVITY_SPOOL_DIR": str(spool)}
+    if fake_browsers is not None:
+        env["FAKE_BROWSERS"] = str(fake_browsers)
+    else:
+        env.pop("FAKE_BROWSERS", None)
+    r = subprocess.run(["bash", str(SCRIPT), *args], capture_output=True,
+                       text=True, env=env, cwd=str(tmp_path))
+    return r, spool
+
+
+def _read_event(spool, C):
+    line = (spool / "current.log").read_text().strip().splitlines()[-1]
+    ev = C.parse_line(line)
+    assert ev is not None
+    return ev
+
+
+def test_resolve_failure_emits_error(tmp_path):
+    C = _load_collector()
+    # No FAKE_BROWSERS -> empty bundle -> resolve-error path -> exit 1.
+    r, spool = _run(tmp_path, ["node", "e2e.mjs"], fake_browsers=None)
+    assert r.returncode == 1
+    ev = _read_event(spool, C)
+    assert ev["source"] == "tool" and ev["kind"] == "invocation"
+    assert ev["text"] == "playwright-nixos"
+    p = json.loads(ev["payload"])
+    assert p["outcome"] == "error" and p["mode"] == "resolve-error"
+    assert p["driver"] == "1.2.3"
+
+
+def test_exec_path_emits_ok(tmp_path):
+    C = _load_collector()
+    browsers = tmp_path / "browsers"      # must be an existing dir
+    browsers.mkdir()
+    # `true` is the wrapped command -> exec replaces the shell -> exit 0.
+    r, spool = _run(tmp_path, ["true"], fake_browsers=browsers)
+    assert r.returncode == 0, r.stderr
+    ev = _read_event(spool, C)
+    assert ev["text"] == "playwright-nixos"
+    p = json.loads(ev["payload"])
+    assert p["outcome"] == "ok" and p["mode"] == "exec"
+    assert p["driver"] == "1.2.3"
+
+
+def test_info_modes_do_not_emit(tmp_path):
+    """`--version` / `--env` are introspection, not a run — they emit nothing."""
+    C = _load_collector()  # noqa: F841
+    browsers = tmp_path / "browsers"
+    browsers.mkdir()
+    r, spool = _run(tmp_path, ["--version"], fake_browsers=browsers)
+    assert r.returncode == 0
+    assert not (spool / "current.log").exists()

--- a/scripts/tests/test_verify_agent_work.py
+++ b/scripts/tests/test_verify_agent_work.py
@@ -635,3 +635,78 @@ def test_main_json_smoke(tmp_path, capsys):
     parsed = json.loads(out)
     assert parsed["target"].endswith(tmp_path.name)
     assert rc == parsed["exit_code"]
+
+
+# --------------------------------------------------------------------------- #
+# adoption telemetry (Part A instrumentation)
+# --------------------------------------------------------------------------- #
+def _mk_result(verdict_checks, stacks=None, strict=False):
+    """Build a Result whose verdict/git-flags are driven by injected checks."""
+    r = vaw.Result(target="/x", strict=strict)
+    r.stacks = stacks or []
+    r.checks = verdict_checks
+    return r
+
+
+def test_adoption_event_pass():
+    r = _mk_result([vaw.Check("git:clean-tree", vaw.PASS, "clean")], stacks=["python"])
+    outcome, dims = vaw.adoption_event(r)
+    assert outcome == "pass"
+    assert dims["stacks"] == ["python"]
+    assert dims["git_dirty"] is False and dims["git_unpushed"] is False
+
+
+def test_adoption_event_fail_maps_and_flags_git():
+    r = _mk_result([
+        vaw.Check("go:test", vaw.FAIL, "boom"),
+        vaw.Check("git:clean-tree", vaw.WARN, "dirty"),
+        vaw.Check("git:pushed", vaw.WARN, "unpushed"),
+    ], stacks=["go"])
+    outcome, dims = vaw.adoption_event(r)
+    assert outcome == "fail"
+    assert dims["git_dirty"] is True and dims["git_unpushed"] is True
+
+
+def test_adoption_event_incomplete():
+    r = _mk_result([vaw.Check("ts", vaw.INCOMPLETE, "no gate")], stacks=["ts"])
+    outcome, _ = vaw.adoption_event(r)
+    assert outcome == "incomplete"
+
+
+def test_main_emits_invocation_to_spool(tmp_path, monkeypatch):
+    """End-to-end: a real run writes exactly ONE well-formed invocation event."""
+    monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(tmp_path))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo(repo)
+    write(repo / "README.md", "hi")
+    commit_all(repo)
+    rc = vaw.main([str(repo), "--no-gh"])
+    assert rc == 0  # clean repo, no stacks -> PASS
+
+    coll = Path(__file__).resolve().parents[1] / "collector"
+    sys.path.insert(0, str(coll))
+    import collector as C  # noqa: PLC0415
+    line = (tmp_path / "current.log").read_text().strip().splitlines()[-1]
+    ev = C.parse_line(line)
+    assert ev["source"] == "tool" and ev["kind"] == "invocation"
+    assert ev["text"] == "verify-agent-work"
+    p = json.loads(ev["payload"])
+    assert p["tool"] == "verify-agent-work" and p["outcome"] == "pass"
+    assert p["stacks"] == []
+
+
+def test_emit_failure_never_changes_exit_or_output(tmp_path, monkeypatch, capsys):
+    """BEST-EFFORT: an unwritable spool must NOT change the verdict/exit/output."""
+    afile = tmp_path / "afile"
+    afile.write_text("x")  # parent-is-a-file -> spool mkdir raises -> swallowed
+    monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(afile / "spool"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo(repo)
+    write(repo / "README.md", "hi")
+    commit_all(repo)
+    rc = vaw.main([str(repo), "--json", "--no-gh"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert json.loads(out)["verdict"] == vaw.PASS

--- a/scripts/tests/test_verify_agent_work.py
+++ b/scripts/tests/test_verify_agent_work.py
@@ -696,6 +696,37 @@ def test_main_emits_invocation_to_spool(tmp_path, monkeypatch):
     assert p["stacks"] == []
 
 
+def test_emitted_event_has_no_build_output_or_paths(tmp_path, monkeypatch):
+    """SECURITY: on a fail/incomplete verdict the emitted event must carry ONLY
+    the bounded stack set + git booleans — never build/test OUTPUT, the failing
+    file path, or the repo/target path."""
+    monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(tmp_path))
+    r = vaw.Result(target="/home/zach/secret-repo/worktree", strict=False)
+    r.stacks = ["ts", "go"]
+    r.checks = [
+        vaw.Check("go:test", vaw.FAIL, "exit 1: $ go test ./...",
+                  detail="/home/zach/secret-repo/worktree",
+                  output="SECRET_BUILD_OUTPUT panic /home/zach/secret-repo/worktree/main.go:42"),
+        vaw.Check("git:clean-tree", vaw.WARN, "dirty"),
+    ]
+    vaw._emit_adoption(r, duration_ms=1)
+
+    coll = Path(__file__).resolve().parents[1] / "collector"
+    sys.path.insert(0, str(coll))
+    import collector as C  # noqa: PLC0415
+    raw = (tmp_path / "current.log").read_text().strip().splitlines()[-1]
+    ev = C.parse_line(raw)
+    p = json.loads(ev["payload"])
+    assert p["outcome"] == "fail"
+    # payload keys are ONLY the allow-listed set — no output/detail/path fields.
+    assert set(p.keys()) <= {"tool", "outcome", "stacks", "git_dirty",
+                             "git_unpushed", "strict"}
+    assert set(p["stacks"]) <= {"ts", "go", "python", "nix"}
+    for secret in ("SECRET_BUILD_OUTPUT", "secret-repo", "main.go", "panic", "worktree"):
+        assert secret not in raw, f"{secret} leaked into raw spool line"
+        assert secret not in json.dumps(ev), f"{secret} leaked into event"
+
+
 def test_emit_failure_never_changes_exit_or_output(tmp_path, monkeypatch, capsys):
     """BEST-EFFORT: an unwritable spool must NOT change the verdict/exit/output."""
     afile = tmp_path / "afile"

--- a/scripts/verify-agent-work
+++ b/scripts/verify-agent-work
@@ -876,6 +876,46 @@ def render_text(result: Result) -> str:
 
 
 # --------------------------------------------------------------------------- #
+# adoption telemetry (best-effort; NEVER changes the verdict or exit code)
+# --------------------------------------------------------------------------- #
+
+_VERDICT_OUTCOME = {PASS: "pass", FAIL: "fail", INCOMPLETE: "incomplete"}
+
+
+def adoption_event(result: "Result") -> tuple:
+    """Map a verify Result to (outcome, dims) for the invocation event. Pure.
+
+    outcome is the lowercase verdict (pass|fail|incomplete). dims carry ONLY safe
+    low-cardinality signal: the detected stack names + two git-state booleans —
+    never file contents, output, or repo paths.
+    """
+    outcome = _VERDICT_OUTCOME.get(result.verdict, "fail")
+    git_dirty = any(c.name == "git:clean-tree" and c.status == WARN for c in result.checks)
+    git_unpushed = any(c.name == "git:pushed" and c.status == WARN for c in result.checks)
+    dims = {
+        "stacks": list(result.stacks),
+        "git_dirty": git_dirty,
+        "git_unpushed": git_unpushed,
+        "strict": bool(result.strict),
+    }
+    return outcome, dims
+
+
+def _emit_adoption(result: "Result", duration_ms: Optional[int] = None) -> None:
+    """Best-effort adoption event. Fully swallowed — telemetry never breaks the gate."""
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent / "collector"))
+        import invocation  # noqa: PLC0415
+        outcome, dims = adoption_event(result)
+        invocation.emit_invocation(
+            "verify-agent-work", outcome, dims=dims,
+            duration_ms=duration_ms, exit_code=result.exit_code,
+        )
+    except Exception:  # noqa: BLE001 — defence-in-depth around the helper
+        pass
+
+
+# --------------------------------------------------------------------------- #
 # cli
 # --------------------------------------------------------------------------- #
 
@@ -900,7 +940,10 @@ def main(argv: Optional[list] = None) -> int:
         print(f"verify-agent-work: target is not a directory: {target}", file=sys.stderr)
         return 2
 
+    import time
+    _t0 = time.monotonic()
     result = verify(target, use_gh=not args.no_gh, strict=args.strict, timeout=args.timeout)
+    _emit_adoption(result, duration_ms=int((time.monotonic() - _t0) * 1000))
 
     if args.json:
         print(json.dumps(result.to_dict(), indent=2))


### PR DESCRIPTION
## Why
We ship productivity tools but some die unused — a measured past failure ("opt-in commands didn't stick → pivoted to autonomous loops"). This adds **deterministic tracking of which shipped tools are actually USED and YIELDING results** vs sitting idle/DEAD, straight off `activity.events`.

## Part A — instrument each tool (best-effort, privacy-bounded)
New `scripts/collector/invocation.py` (`emit_invocation`) reuses `spool_emit` to write **ONE** `source=tool kind=invocation` event per run. It **never raises, never changes the caller's exit code/output**, and is a clean no-op when the collector is absent.

Event shape: `source=tool`, `kind=invocation`, `text`=tool name, `duration_ms`/`exit_code` columns, and `payload = {"tool", "outcome", ...safe dims}`.

| tool | outcome enum | safe dims (payload) |
|---|---|---|
| `verify-agent-work` | `pass\|fail\|incomplete` (from the existing verdict) | `stacks` (detected), `git_dirty`, `git_unpushed`, `strict` |
| `obs-read` | `ok\|matched-nothing\|error` | `cluster`, `backend`, `preset` NAME (raw `--query` → `"adhoc"`, never verbatim) |
| `ticket-status` | `already-done\|partial\|not-found\|error` | `verdict`, `ticket_id` (only after validation) — **never** the search terms |
| `playwright-nixos` (bash) | `ok\|error` | `driver` version, `mode` (`exec`/`resolve-error`) |

**Privacy (highest-risk area):** only the tool name, the outcome enum, and safe low-cardinality NAMES/versions/booleans are emitted. NEVER raw `--query` text, ticket search terms, ticket bodies, file contents, or secrets. `invocation.py` additionally hard-caps dim count/length as defence-in-depth. ticket-status skips the emit entirely for rejected (unvalidated) input.

## Part B — `scripts/session-analysis/adoption-scan.py`
Reader-only report (reuses `validation/chquery.py` + `CLICKHOUSE_*`, `--days`/`--json`, degrades gracefully when telemetry is off, exactly like `insights.py`):
- **Registry** of tracked improvements → easy to add a row when we ship more (tool-invocation items, the opt-in `/verify-agent` `/obs-read` slash commands from the message stream, and the autonomous drafter by cwd).
- **ADOPTION:** invocations in-window, outcome breakdown, this-half vs prior-half trend, and a loud **DEAD** flag at 0 uses (opt-in tools flagged as the at-risk ones).
- **IMPACT:** outcome mix that proves a real catch — verify-agent `fail\|incomplete` (false-greens), obs-read `matched-nothing` (silent-zeros), ticket-status `already-done` (non-tasks dissolved) — plus a compact, explicitly **DIRECTIONAL** drafter friction trend (`permission_block` + `wrong_approach` over two windows; baseline was permission_block=57).
- Honest caveats baked into the output (count = USE not VALUE; friction = directional). Wired as `/adoption-scan`.

## Part C — complete hermetic coverage
- **Instrumentation:** right outcome per verdict/path; best-effort contract (unwritable spool / raising `spool_emit` never changes exit/output); explicit **security tests** that the raw query / ticket terms never appear in the emitted event or raw spool line.
- **adoption-scan:** per-item counts, outcome breakdown, week-over-week trend, DEAD flag (fires at 0, and in the sub-window; not when used), friction trend, `--json` shape, telemetry-off degradation.
- All new tests live in dirs already in `run-tests.sh` HERMETIC_DIRS → covered by `nix flake check`.

Full hermetic suite: **PASS** (`RESULT: PASS`, all dirs green).

## Scope / notes
- No tool behaviour/verdicts changed; no Grafana panel or new ClickHouse schema; drafter triage untouched.
- `claude/commands/adoption-scan.md` is git-tracked so the flake sees it; not switched (release handled separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Audit round (privacy audit: SAFE TO MERGE, no 🔴)

Follow-up commit `b965b79` closes the flagged coverage gap + cheap items:
- **Error-path privacy tests (🟡 #2):** decode the actual emitted spool line and assert secrets are ABSENT — obs-read (secret `--query` + secret exception → only `{tool,outcome:error,cluster,backend,preset:adhoc}`), verify-agent-work (FAIL verdict with build OUTPUT + repo path → payload keys are the allow-listed set only, `stacks ⊆ {ts,go,python,nix}`), ticket-status (probe InputError → only the validated `ticket_id` + `outcome:error`, no term/path/exception).
- **🟡 #1 `--dead-days > --days`:** fetch window widened to `max(days, dead_days)`; counts stay scoped to `--days`; DEAD computed over the full dead window. Cross-window test added.
- **🟢 loose command prefix:** tightened via `command_matches()` (`/obs-read-foo` ≠ `/obs-read`) + tests.
- **🟢 field caps:** `build_fields` now length-caps `tool`/`outcome`/`text` too + test.

Full hermetic suite after the round: **RESULT: PASS**.
