### PR TITLE
fix(adoption-scan): stop aliasing max(ts) AS ts (ClickHouse ILLEGAL_AGGREGATION)

### DIFF
--- a/scripts/session-analysis/adoption-scan.py
+++ b/scripts/session-analysis/adoption-scan.py
@@ -346,8 +346,11 @@ def q_commands(win: int, host: str | None = None) -> str:
 
 def q_cwd_sessions(win: int, match: str, host: str | None = None) -> str:
     lit = Q.sql_quote(match.lower())
+    # Alias the aggregate to `last_ts`, NOT `ts`: aliasing max(ts) AS ts shadows
+    # the raw `ts` column, so the WHERE `ts>now()` binds to the aggregate →
+    # ClickHouse ILLEGAL_AGGREGATION. gather() normalises `last_ts`→`ts` on read.
     return (
-        "SELECT session AS session, max(ts) AS ts FROM activity.events "
+        "SELECT session AS session, max(ts) AS last_ts FROM activity.events "
         f"WHERE source='claude' AND ts>now()-{win} "
         f"AND position(lower(cwd), {lit}) > 0{_host_filter(host)} "
         "GROUP BY session"
@@ -355,12 +358,24 @@ def q_cwd_sessions(win: int, match: str, host: str | None = None) -> str:
 
 
 def q_insights(win: int, host: str | None = None) -> str:
+    # `max(ts) AS last_ts` not `AS ts` — see q_cwd_sessions: an aggregate aliased
+    # to the raw column name `ts` shadows it in WHERE → ILLEGAL_AGGREGATION.
     return (
         "SELECT session, argMax(toString(payload), ingested_at) AS payload, "
-        "max(ts) AS ts FROM activity.events "
+        "max(ts) AS last_ts FROM activity.events "
         f"WHERE source='claude' AND kind='session-insight' AND ts>now()-{win}"
         f"{_host_filter(host)} GROUP BY session"
     )
+
+
+def _norm_last_ts(rows: list[dict]) -> list[dict]:
+    """Map the `last_ts` aggregate alias back to `ts` so the shared aggregators
+    (which read `r.get("ts")`) work unchanged. The alias is `last_ts` in SQL only
+    to avoid shadowing the raw `ts` column in the WHERE clause."""
+    for r in rows:
+        if "last_ts" in r:
+            r["ts"] = r["last_ts"]
+    return rows
 
 
 # --------------------------------------------------------------------------- #
@@ -382,13 +397,13 @@ def gather(client, days: int, insight_days: int, dead_days: int,
     try:
         tool_rows = client.rows(q_tool_invocations(fetch_win, host))
         cmd_rows = client.rows(q_commands(fetch_win, host))
-        insight_rows = client.rows(q_insights(iwin, host))
+        insight_rows = _norm_last_ts(client.rows(q_insights(iwin, host)))
         # cwd-detected items each get their own filtered query.
         cwd_rows: dict = {}
         for item in REGISTRY:
             if item["via"] == "cwd":
-                cwd_rows[item["id"]] = client.rows(
-                    q_cwd_sessions(fetch_win, item["match"], host))
+                cwd_rows[item["id"]] = _norm_last_ts(client.rows(
+                    q_cwd_sessions(fetch_win, item["match"], host)))
     except Exception as e:  # noqa: BLE001 — telemetry optional; degrade cleanly
         raise TelemetryUnavailable(str(e)) from e
 

--- a/scripts/session-analysis/tests/test_adoption_scan.py
+++ b/scripts/session-analysis/tests/test_adoption_scan.py
@@ -275,3 +275,18 @@ def test_main_unavailable_exits_zero(monkeypatch, capsys):
 
 def test_main_bad_days_exits_two(capsys):
     assert A.main(["--days", "0"]) == 2
+
+
+def test_aggregating_queries_do_not_shadow_ts_column():
+    """Regression: aliasing an aggregate as `max(ts) AS ts` shadows the raw `ts`
+    column, so the WHERE `ts>now()` binds to the aggregate → ClickHouse
+    ILLEGAL_AGGREGATION (a live 500 hermetic mocks can't catch). The two GROUP BY
+    queries must alias to `last_ts`, and only those two carry that alias."""
+    for sql in (A.q_insights(3600), A.q_cwd_sessions(3600, "task-spec-drafter")):
+        assert "max(ts) AS ts " not in sql and "max(ts) AS ts\n" not in sql
+        assert "max(ts) AS last_ts" in sql
+        # the WHERE still filters on the raw column, unshadowed
+        assert "ts>now()-" in sql
+    # a normalised row exposes `ts` for the shared aggregators
+    assert A._norm_last_ts([{"session": "s", "last_ts": "2026-01-01 00:00:00"}])[0]["ts"] \
+        == "2026-01-01 00:00:00"


### PR DESCRIPTION
The two GROUP BY queries aliased `max(ts) AS ts`, shadowing the raw `ts` column so the WHERE `ts>now()` bound to the aggregate → ClickHouse 500 (ILLEGAL_AGGREGATION), swallowed by graceful-degrade as "telemetry unavailable". Hermetic tests mock the CH layer so they missed it.

**Fix:** alias to `last_ts`; `gather()` normalises back to `ts`. Static regression guard added.

**Verified end-to-end against live ClickHouse** — full report renders (3/3 clean); the two failing queries confirmed fixed directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)