### PR TITLE
feat(claude-hooks): migrate turn-finished notifier into devrc (both hosts)

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -389,6 +389,31 @@ in
   home.file.".claude/hooks/shell-env-nudge.py" = {
     source = ../scripts/claude-hooks/shell-env-nudge.py;
   };
+  # claude-notify is the turn-finished notifier: on UserPromptSubmit/Stop/SubagentStop
+  # it fires a desktop toast (or, headless, a clawgate phone push as FALLBACK) when a
+  # turn ran >= threshold (default 60s). Telemetry shows Claude runs mostly on the
+  # headless workbench (98x/14d vs 8x on the laptop) with the long waits there
+  # (306min vs 41min) — exactly where the phone-push fallback earns its keep. Script
+  # delivered here to BOTH hosts; the 3 settings.json events are registered per-host
+  # by register-nudge-hook.py (settings.json is per-host/unmanaged).
+  home.file.".claude/hooks/claude-notify.py" = {
+    source = ../scripts/claude-hooks/claude-notify.py;
+  };
+
+  # This hook previously existed only as a PLAIN local file on the laptop
+  # (~/.claude/hooks/claude-notify.py + test_claude_notify.py). home-manager's
+  # store symlink above would collide with that non-symlink and fail
+  # checkLinkTargets on the first switch. Remove the stale NON-symlink copies
+  # (and the now-managed-elsewhere test) before the link check runs. Guarded on
+  # `! -L` so a legitimately-managed store symlink is never touched — this only
+  # ever removes a hand-placed regular file.
+  home.activation.dropStaleClaudeNotify = lib.hm.dag.entryBefore ["checkLinkTargets"] ''
+    for f in "$HOME/.claude/hooks/claude-notify.py" "$HOME/.claude/hooks/test_claude_notify.py"; do
+      if [ -e "$f" ] && [ ! -L "$f" ]; then
+        $DRY_RUN_CMD rm -f "$f"
+      fi
+    done
+  '';
 
   # Reusable failure-notification TEMPLATE unit. The important user units below
   # (+ bar-status-poll in graphical.nix) carry OnFailure=notify-failure@%n.service,

--- a/scripts/claude-hooks/claude-notify.py
+++ b/scripts/claude-hooks/claude-notify.py
@@ -29,8 +29,11 @@ session. Any internal error is swallowed. Worst case == the hook not existing.
 
 Kill-switch: CLAUDE_NOTIFY=off (or 0/false/no) disables it for a session.
 Config env:
-  CLAUDE_NOTIFY_MIN_SECONDS  threshold in seconds (default 60)
-  CLAUDE_NOTIFY              off/0/false/no -> disabled
+  CLAUDE_NOTIFY_MIN_SECONDS       threshold in seconds (default 60)
+  CLAUDE_NOTIFY_COOLDOWN_SECONDS  min seconds between pings per session
+                                  (default = the threshold) — collapses a burst
+                                  of parallel SubagentStops into one ping.
+  CLAUDE_NOTIFY                   off/0/false/no -> disabled
   CLAWGATE_API_URL           clawgate base URL (else read from clawgate.env)
   CLAWGATE_HOOK_TOKEN        clawgate machine bearer token (else clawgate.env)
 """
@@ -46,7 +49,7 @@ CACHE_DIR = os.path.join(HOME, ".cache", "claude-notify")
 CLAWGATE_ENV = os.path.join(HOME, ".claude", "clawgate.env")
 LOG_FILE = os.path.join(HOME, ".claude", "claude-notify.log")
 DEFAULT_THRESHOLD = 60
-STALE_SECONDS = 24 * 60 * 60  # prune start files older than 1 day
+STALE_SECONDS = 24 * 60 * 60  # prune start/lastnotify files older than 1 day
 
 
 def log(msg):
@@ -68,6 +71,17 @@ def threshold():
         return DEFAULT_THRESHOLD
 
 
+def cooldown():
+    """Min seconds between notifications for one session. Defaults to the
+    threshold. Collapses a burst of parallel SubagentStops (N subagents ->
+    N+1 pings) down to one ping while a genuinely spread-out sequence still
+    pings each time it clears the cooldown."""
+    try:
+        return float(os.environ.get("CLAUDE_NOTIFY_COOLDOWN_SECONDS", threshold()))
+    except Exception:
+        return threshold()
+
+
 def safe_session_id(sid):
     """Sanitize a session id for use as a filename (never traverse)."""
     keep = [c for c in (sid or "") if c.isalnum() or c in "-_"]
@@ -78,12 +92,16 @@ def start_path(sid):
     return os.path.join(CACHE_DIR, safe_session_id(sid) + ".start")
 
 
+def lastnotify_path(sid):
+    return os.path.join(CACHE_DIR, safe_session_id(sid) + ".lastnotify")
+
+
 def prune_stale():
-    """Best-effort: drop start files older than a day (crashed/abandoned turns)."""
+    """Best-effort: drop start/lastnotify files older than a day (crashed/abandoned turns)."""
     try:
         now = time.time()
         for name in os.listdir(CACHE_DIR):
-            if not name.endswith(".start"):
+            if not (name.endswith(".start") or name.endswith(".lastnotify")):
                 continue
             p = os.path.join(CACHE_DIR, name)
             try:
@@ -243,20 +261,54 @@ def handle():
         return
 
     elapsed = time.time() - start
+    lp = lastnotify_path(session)
 
-    # Stop always ends the turn: consume the start file regardless of threshold.
-    # SubagentStop leaves it in place (the parent turn continues).
+    # Read the cooldown marker BEFORE any Stop cleanup, so a Stop that follows a
+    # just-fired SubagentStop can still see the marker and suppress itself.
+    now = time.time()
+    within_cooldown = False
+    try:
+        if os.path.isfile(lp):
+            with open(lp) as f:
+                last = float(f.read().strip())
+            within_cooldown = (now - last) < cooldown()
+    except Exception:  # fail-open: unreadable marker -> treat as not cooling down
+        within_cooldown = False
+
+    # Stop always ends the turn: consume the start file (and its lastnotify
+    # sibling) regardless of threshold/cooldown. SubagentStop leaves them in
+    # place (the parent turn continues).
     if event == "Stop":
-        try:
-            os.remove(sp)
-        except Exception:
-            pass
+        for p in (sp, lp):
+            try:
+                os.remove(p)
+            except Exception:
+                pass
 
     if elapsed < threshold():
         return
 
+    # Per-session notification cooldown: a burst of parallel SubagentStops (N
+    # subagents past the parent threshold would otherwise fire N+1 pings)
+    # collapses to ONE ping; a Stop right after that SubagentStop is likewise
+    # suppressed if within the cooldown. A genuinely spread-out sequence
+    # (>cooldown apart) still pings each time.
+    if within_cooldown:
+        return
+
     do_notify.elapsed_str = fmt_elapsed(elapsed)
     do_notify(event, cwd, session)
+
+    # Record this notification time so the next event within the cooldown is
+    # suppressed. Only meaningful for SubagentStop (the parent turn continues);
+    # on Stop the turn is over and the marker was already removed above, so skip
+    # the write to avoid orphaning a marker with no start file.
+    if event != "Stop":
+        try:
+            with open(lp, "w") as f:
+                f.write(str(now))
+        except Exception:
+            pass
 
 
 def main():

--- a/scripts/claude-hooks/claude-notify.py
+++ b/scripts/claude-hooks/claude-notify.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Turn-finished notifier for Claude Code.
+
+One script, three hook events (dispatched on stdin's `hook_event_name`):
+
+  UserPromptSubmit  -> record turn-start epoch in a per-session file.
+  Stop              -> main agent finished a turn: if it ran >= threshold,
+                       fire a notification, then delete the start file.
+  SubagentStop      -> a dispatched subagent finished: if the (parent) turn has
+                       already run >= threshold, notify. Does NOT delete the
+                       start file (the parent turn is still going; its Stop will).
+
+Purpose: long turns (the measured time sink is `claude` foreground-blocking,
+557m/14d with a tail to ~80min) ping the user instead of being babysat. Short
+turns stay silent (threshold gate; default 60s, env CLAUDE_NOTIFY_MIN_SECONDS).
+
+Delivery, best-effort. The desktop toast is preferred; the clawgate phone push
+is a FALLBACK used only when there is no local desktop (headless workbench /
+away from the laptop) -- firing both would push a redundant phone card while the
+user is sitting at the machine:
+  - Local desktop (DISPLAY set): dunstify / notify-send low-urgency toast.
+  - Else (headless / cross-host): clawgate push (POST /api/notify with the
+    machine hook token from ~/.claude/clawgate.env) -> Web Push to the phone.
+    /api/notify is notify-only (no approve/deny card); added in clawgate 0.7.67.
+
+Contract: this hook is a best-effort SIDE EFFECT only. It ALWAYS exits 0 and
+never emits blocking output — a non-zero/blocking Stop hook would perturb the
+session. Any internal error is swallowed. Worst case == the hook not existing.
+
+Kill-switch: CLAUDE_NOTIFY=off (or 0/false/no) disables it for a session.
+Config env:
+  CLAUDE_NOTIFY_MIN_SECONDS  threshold in seconds (default 60)
+  CLAUDE_NOTIFY              off/0/false/no -> disabled
+  CLAWGATE_API_URL           clawgate base URL (else read from clawgate.env)
+  CLAWGATE_HOOK_TOKEN        clawgate machine bearer token (else clawgate.env)
+"""
+import os
+import sys
+import json
+import time
+import shutil
+import subprocess
+
+HOME = os.path.expanduser("~")
+CACHE_DIR = os.path.join(HOME, ".cache", "claude-notify")
+CLAWGATE_ENV = os.path.join(HOME, ".claude", "clawgate.env")
+LOG_FILE = os.path.join(HOME, ".claude", "claude-notify.log")
+DEFAULT_THRESHOLD = 60
+STALE_SECONDS = 24 * 60 * 60  # prune start files older than 1 day
+
+
+def log(msg):
+    try:
+        with open(LOG_FILE, "a") as f:
+            f.write("[%s] %s\n" % (time.strftime("%Y-%m-%d %H:%M:%S"), msg))
+    except Exception:
+        pass
+
+
+def disabled():
+    return os.environ.get("CLAUDE_NOTIFY", "on").lower() in ("0", "off", "false", "no")
+
+
+def threshold():
+    try:
+        return float(os.environ.get("CLAUDE_NOTIFY_MIN_SECONDS", DEFAULT_THRESHOLD))
+    except Exception:
+        return DEFAULT_THRESHOLD
+
+
+def safe_session_id(sid):
+    """Sanitize a session id for use as a filename (never traverse)."""
+    keep = [c for c in (sid or "") if c.isalnum() or c in "-_"]
+    return "".join(keep)[:128]
+
+
+def start_path(sid):
+    return os.path.join(CACHE_DIR, safe_session_id(sid) + ".start")
+
+
+def prune_stale():
+    """Best-effort: drop start files older than a day (crashed/abandoned turns)."""
+    try:
+        now = time.time()
+        for name in os.listdir(CACHE_DIR):
+            if not name.endswith(".start"):
+                continue
+            p = os.path.join(CACHE_DIR, name)
+            try:
+                if now - os.path.getmtime(p) > STALE_SECONDS:
+                    os.remove(p)
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+
+def fmt_elapsed(sec):
+    sec = int(sec)
+    m, s = divmod(sec, 60)
+    if m:
+        return "%dm %ds" % (m, s)
+    return "%ds" % s
+
+
+def load_clawgate_env():
+    """Read CLAWGATE_API_URL / CLAWGATE_HOOK_TOKEN from env or ~/.claude/clawgate.env."""
+    url = os.environ.get("CLAWGATE_API_URL", "")
+    token = os.environ.get("CLAWGATE_HOOK_TOKEN", "")
+    try:
+        if (not url or not token) and os.path.isfile(CLAWGATE_ENV):
+            with open(CLAWGATE_ENV) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    k, v = line.split("=", 1)
+                    k = k.strip()
+                    v = v.strip().strip('"').strip("'")
+                    if k == "CLAWGATE_API_URL" and not url:
+                        url = v
+                    elif k == "CLAWGATE_HOOK_TOKEN" and not token:
+                        token = v
+    except Exception:
+        pass
+    return url, token
+
+
+def notify_desktop(title, body):
+    """Low-urgency toast via dunstify (preferred) or notify-send. No-op headless."""
+    if not os.environ.get("DISPLAY") and not os.environ.get("WAYLAND_DISPLAY"):
+        return False
+    try:
+        if shutil.which("dunstify"):
+            subprocess.run(
+                ["dunstify", "-u", "low", "-a", "claude", title, body],
+                timeout=5, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+            return True
+        if shutil.which("notify-send"):
+            subprocess.run(
+                ["notify-send", "-u", "low", "-a", "claude", title, body],
+                timeout=5, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def notify_clawgate(title, body, host, project, cwd, session):
+    """Fire-and-forget Web Push via clawgate's notify-only /api/notify endpoint.
+
+    /api/notify (clawgate 0.7.68+) sends a plain Web Push with NO approve/deny
+    card — the right semantics for a "finished" ping (the old /api/send created a
+    self-expiring permission card). Requires the machine hook token; silently
+    no-ops if unavailable or curl is missing. `cwd`/`session` are unused by the
+    endpoint (kept in the signature for a stable call site).
+    """
+    url, token = load_clawgate_env()
+    if not url or not token or not shutil.which("curl"):
+        return False
+    try:
+        payload = json.dumps({
+            "title": title,         # e.g. "✅ Claude finished (4m 12s)"
+            "body": body,           # e.g. "civitai — turn ran 4m 12s"
+            "host": host,
+            "project": project,
+        })
+        r = subprocess.run(
+            ["curl", "-sf", "--max-time", "6", "-X", "POST",
+             url.rstrip("/") + "/api/notify",
+             "-H", "Content-Type: application/json",
+             "-H", "Authorization: Bearer " + token,
+             "-d", payload],
+            timeout=10, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def do_notify(event, cwd, session):
+    project = os.path.basename(cwd) if cwd else ""
+    try:
+        host = os.uname().nodename
+    except Exception:
+        host = os.environ.get("CLAUDE_HOST", "")
+    elapsed = do_notify.elapsed_str
+    label = "subagent finished" if event == "SubagentStop" else "finished"
+    title = "✅ Claude %s (%s)" % (label, elapsed)
+    body = ("%s — turn ran %s" % (project, elapsed)) if project else ("turn ran %s" % elapsed)
+    d = notify_desktop(title, body)
+    # clawgate (phone push) is a FALLBACK: only when there's no local desktop
+    # toast (i.e. the headless workbench / away-from-laptop). Firing both would
+    # push a redundant phone card while the user is sitting at the laptop.
+    c = notify_clawgate(title, body, host, project, cwd, session) if not d else False
+    log("notify event=%s project=%s elapsed=%s desktop=%s clawgate=%s"
+        % (event, project, elapsed, d, c))
+
+
+def handle():
+    if disabled():
+        return
+
+    raw = sys.stdin.read()
+    if not raw:
+        return
+    data = json.loads(raw)
+
+    event = data.get("hook_event_name", "")
+    session = data.get("session_id", "")
+    cwd = data.get("cwd", "") or os.getcwd()
+
+    os.makedirs(CACHE_DIR, exist_ok=True)
+
+    if event == "UserPromptSubmit":
+        # Record turn start.
+        try:
+            with open(start_path(session), "w") as f:
+                f.write(str(time.time()))
+        except Exception:
+            pass
+        prune_stale()
+        return
+
+    if event not in ("Stop", "SubagentStop"):
+        return
+
+    # Loop safety: already in a stop continuation -> never do anything.
+    if data.get("stop_hook_active"):
+        return
+
+    sp = start_path(session)
+    if not os.path.isfile(sp):
+        # No recorded start (edge case: subagent w/o prompt, restart, pruned) -> skip.
+        return
+
+    try:
+        with open(sp) as f:
+            start = float(f.read().strip())
+    except Exception:
+        return
+
+    elapsed = time.time() - start
+
+    # Stop always ends the turn: consume the start file regardless of threshold.
+    # SubagentStop leaves it in place (the parent turn continues).
+    if event == "Stop":
+        try:
+            os.remove(sp)
+        except Exception:
+            pass
+
+    if elapsed < threshold():
+        return
+
+    do_notify.elapsed_str = fmt_elapsed(elapsed)
+    do_notify(event, cwd, session)
+
+
+def main():
+    try:
+        handle()
+    except Exception as e:  # never break a session
+        log("error: %r" % (e,))
+    # ALWAYS exit 0, ALWAYS empty stdout (best-effort side effect only).
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/claude-hooks/register-nudge-hook.py
+++ b/scripts/claude-hooks/register-nudge-hook.py
@@ -1,11 +1,19 @@
 #!/usr/bin/env python3
-"""Idempotently register the PostToolUse nudge hooks in ~/.claude/settings.json.
+"""Idempotently register the devrc-managed Claude Code hooks in ~/.claude/settings.json.
 
 settings.json is per-host and unmanaged (holds permissions/allowlists/secrets), so the
 hook *scripts* are symlinked by home-manager but their *registration* is applied by
-running this once per host. Safe to re-run: it adds only the entries that are missing.
+running this once per host. Safe to re-run: it adds only the entries that are missing
+and NEVER clobbers hooks it doesn't own (clawgate PermissionRequest/Stop, bash-guard,
+tmux hooks, etc. are preserved — this only ever appends).
 
-Run on each host after a home-manager switch that adds a new nudge hook:
+Registers:
+  * PostToolUse(Bash): audit-pr-nudge.py, shell-env-nudge.py
+  * UserPromptSubmit / Stop / SubagentStop: claude-notify.py (the turn-finished
+    notifier — a best-effort side-effect hook, appended alongside any existing
+    Stop/clawgate-stop/tmux hooks).
+
+Run on each host after a home-manager switch that adds a new hook:
     python3 ~/workspace/devrc/scripts/claude-hooks/register-nudge-hook.py
 """
 import json, os, sys
@@ -13,33 +21,54 @@ import json, os, sys
 SETTINGS = os.path.expanduser("~/.claude/settings.json")
 
 # PostToolUse(Bash) nudge hooks to ensure are registered.
-CMDS = [
+POST_BASH_CMDS = [
     "python3 ~/.claude/hooks/audit-pr-nudge.py",
     "python3 ~/.claude/hooks/shell-env-nudge.py",
 ]
+
+# The turn-finished notifier fires on these three events (single script,
+# dispatched on the event name in its stdin payload).
+NOTIFY_CMD = "python3 ~/.claude/hooks/claude-notify.py"
+NOTIFY_EVENTS = ["UserPromptSubmit", "Stop", "SubagentStop"]
 
 with open(SETTINGS) as f:
     data = json.load(f)
 
 hooks = data.setdefault("hooks", {})
-post = hooks.setdefault("PostToolUse", [])
-
-registered = {h.get("command") for entry in post for h in entry.get("hooks", [])}
-
 added = []
-for cmd in CMDS:
-    if cmd in registered:
+
+
+def registered_commands(event_arrays):
+    """All command strings already present across an event's entry list."""
+    return {h.get("command") for entry in event_arrays for h in entry.get("hooks", [])}
+
+
+# --- PostToolUse(Bash) nudge hooks (append-only, matcher=Bash) ---------------
+post = hooks.setdefault("PostToolUse", [])
+post_registered = registered_commands(post)
+for cmd in POST_BASH_CMDS:
+    if cmd in post_registered:
         continue
     post.append({"matcher": "Bash", "hooks": [{"type": "command", "command": cmd}]})
-    added.append(cmd)
+    added.append("PostToolUse(Bash): " + cmd)
+
+# --- claude-notify on the three turn-boundary events (append-only) -----------
+# Preserve every existing entry on each event array (e.g. a clawgate-stop-hook or
+# a tmux Stop hook) — only add claude-notify where it's missing.
+for event in NOTIFY_EVENTS:
+    arr = hooks.setdefault(event, [])
+    if NOTIFY_CMD in registered_commands(arr):
+        continue
+    arr.append({"hooks": [{"type": "command", "command": NOTIFY_CMD}]})
+    added.append("%s: %s" % (event, NOTIFY_CMD))
 
 if not added:
-    print("all nudge hooks already registered — no change")
+    print("all devrc-managed hooks already registered — no change")
     sys.exit(0)
 
 with open(SETTINGS, "w") as f:
     json.dump(data, f, indent=2)
     f.write("\n")
-print("registered PostToolUse(Bash) hooks:")
+print("registered hooks:")
 for c in added:
     print("  +", c)

--- a/scripts/claude-hooks/register-nudge-hook.py
+++ b/scripts/claude-hooks/register-nudge-hook.py
@@ -16,7 +16,7 @@ Registers:
 Run on each host after a home-manager switch that adds a new hook:
     python3 ~/workspace/devrc/scripts/claude-hooks/register-nudge-hook.py
 """
-import json, os, sys
+import json, os, sys, tempfile
 
 SETTINGS = os.path.expanduser("~/.claude/settings.json")
 
@@ -66,9 +66,23 @@ if not added:
     print("all devrc-managed hooks already registered — no change")
     sys.exit(0)
 
-with open(SETTINGS, "w") as f:
-    json.dump(data, f, indent=2)
-    f.write("\n")
+# Atomic write: settings.json gates permissions, so a crash mid-write must never
+# leave it truncated/corrupt. Write a temp file in the same dir, then os.replace
+# (atomic rename on the same filesystem) so readers only ever see the old file
+# or the fully-written new one.
+d = os.path.dirname(SETTINGS) or "."
+fd, tmp = tempfile.mkstemp(dir=d, prefix=".settings.", suffix=".tmp")
+try:
+    with os.fdopen(fd, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+    os.replace(tmp, SETTINGS)
+except Exception:
+    try:
+        os.remove(tmp)
+    except OSError:
+        pass
+    raise
 print("registered hooks:")
 for c in added:
     print("  +", c)

--- a/scripts/claude-hooks/tests/test_claude_notify.py
+++ b/scripts/claude-hooks/tests/test_claude_notify.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Tests for claude-notify.py — the turn-finished notifier hook.
+
+Drives the hook by piping mock Claude Code hook JSON on stdin, with a temp HOME
+(so real ~/.cache and ~/.claude are untouched) and PATH stubs for dunstify /
+notify-send / curl that append their invocation to a stub-log. We assert:
+
+  1. UserPromptSubmit writes a per-session start file.
+  2. Stop with elapsed >= threshold + a desktop present -> desktop toast only
+     (clawgate is a FALLBACK, must NOT fire when the desktop toast worked),
+     start file removed, exit 0.
+  2b. Stop with elapsed >= threshold + NO desktop (headless) -> clawgate push
+     fires (and no desktop toast).
+  3. Stop with elapsed <  threshold -> NO notification, exit 0.
+  4. Stop with stop_hook_active=true -> immediate exit 0, no notification.
+  5. Stop with no start file -> exit 0, no notification, no crash.
+
+Run: python3 test_claude_notify.py
+"""
+import os
+import sys
+import json
+import time
+import tempfile
+import subprocess
+
+# The hook lives one dir up (scripts/claude-hooks/); this test is in tests/.
+# Locate it relative to this file so the suite runs both from the devrc repo and
+# wherever it's colocated. (Mirrors test_shell_env_nudge.py's "../<hook>.py".)
+HOOK = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "claude-notify.py")
+
+
+def make_env(tmp):
+    """A temp HOME with stub dunstify/notify-send/curl on PATH, a fake DISPLAY,
+    and a fake clawgate.env so the clawgate push path is exercised."""
+    home = os.path.join(tmp, "home")
+    bindir = os.path.join(tmp, "bin")
+    os.makedirs(bindir)
+    os.makedirs(os.path.join(home, ".claude"))
+    stub_log = os.path.join(tmp, "stub.log")
+
+    for name in ("dunstify", "notify-send", "curl"):
+        p = os.path.join(bindir, name)
+        with open(p, "w") as f:
+            f.write('#!/usr/bin/env bash\n'
+                    'echo "%s $*" >> "%s"\nexit 0\n' % (name, stub_log))
+        os.chmod(p, 0o755)
+
+    # Fake clawgate config so notify_clawgate() has a url+token to POST to.
+    with open(os.path.join(home, ".claude", "clawgate.env"), "w") as f:
+        f.write("CLAWGATE_API_URL=http://127.0.0.1:1/stub\n")
+        f.write("CLAWGATE_HOOK_TOKEN=stub-token\n")
+
+    env = dict(os.environ)
+    env["HOME"] = home
+    env["PATH"] = bindir + os.pathsep + env.get("PATH", "")
+    env["DISPLAY"] = ":99"
+    env.pop("CLAUDE_NOTIFY", None)
+    env.pop("CLAUDE_NOTIFY_MIN_SECONDS", None)
+    env.pop("CLAWGATE_API_URL", None)
+    env.pop("CLAWGATE_HOOK_TOKEN", None)
+    return home, stub_log, env
+
+
+def run(env, payload, extra=None):
+    e = dict(env)
+    if extra:
+        e.update(extra)
+    p = subprocess.run([sys.executable, HOOK], input=json.dumps(payload),
+                       text=True, capture_output=True, env=e)
+    return p
+
+
+def start_file(home, sid):
+    return os.path.join(home, ".cache", "claude-notify", sid + ".start")
+
+
+def read_stub(stub_log):
+    if not os.path.isfile(stub_log):
+        return ""
+    with open(stub_log) as f:
+        return f.read()
+
+
+failures = []
+
+
+def check(name, cond):
+    print(("PASS" if cond else "FAIL") + " - " + name)
+    if not cond:
+        failures.append(name)
+
+
+# --- Test 1: UserPromptSubmit writes a start file ---------------------------
+with tempfile.TemporaryDirectory() as tmp:
+    home, stub_log, env = make_env(tmp)
+    sid = "sess-1"
+    p = run(env, {"hook_event_name": "UserPromptSubmit", "session_id": sid,
+                  "cwd": "/home/zach/workspace/civit/example"})
+    check("1: UserPromptSubmit exit 0", p.returncode == 0)
+    check("1: start file written", os.path.isfile(start_file(home, sid)))
+    check("1: no notification on prompt submit", read_stub(stub_log) == "")
+
+# --- Test 2: Stop, elapsed >= threshold -> notify, start file removed -------
+with tempfile.TemporaryDirectory() as tmp:
+    home, stub_log, env = make_env(tmp)
+    sid = "sess-2"
+    sf = start_file(home, sid)
+    os.makedirs(os.path.dirname(sf))
+    with open(sf, "w") as f:               # started 120s ago; default threshold 60s
+        f.write(str(time.time() - 120))
+    p = run(env, {"hook_event_name": "Stop", "session_id": sid,
+                  "cwd": "/home/zach/workspace/civit/example", "stop_hook_active": False})
+    log = read_stub(stub_log)
+    check("2: Stop exit 0", p.returncode == 0)
+    check("2: desktop notify fired", "dunstify" in log)
+    check("2: clawgate NOT fired when desktop toast worked (fallback-only)",
+          "curl" not in log)
+    check("2: elapsed rendered as minutes", "2m" in log)
+    check("2: start file removed after Stop", not os.path.isfile(sf))
+
+# --- Test 2b: Stop, no desktop (headless) -> clawgate push is the fallback ---
+with tempfile.TemporaryDirectory() as tmp:
+    home, stub_log, env = make_env(tmp)
+    env.pop("DISPLAY", None)               # headless: no local desktop toast
+    env.pop("WAYLAND_DISPLAY", None)
+    sid = "sess-2b"
+    sf = start_file(home, sid)
+    os.makedirs(os.path.dirname(sf))
+    with open(sf, "w") as f:               # started 120s ago
+        f.write(str(time.time() - 120))
+    p = run(env, {"hook_event_name": "Stop", "session_id": sid,
+                  "cwd": "/home/zach/workspace/civit/example", "stop_hook_active": False})
+    log = read_stub(stub_log)
+    check("2b: Stop exit 0", p.returncode == 0)
+    check("2b: clawgate push fired when headless", "curl" in log and "/api/notify" in log)
+    check("2b: no desktop toast when headless", "dunstify" not in log)
+    check("2b: start file removed after Stop", not os.path.isfile(sf))
+
+# --- Test 3: Stop, elapsed < threshold -> no notification -------------------
+with tempfile.TemporaryDirectory() as tmp:
+    home, stub_log, env = make_env(tmp)
+    sid = "sess-3"
+    sf = start_file(home, sid)
+    os.makedirs(os.path.dirname(sf))
+    with open(sf, "w") as f:               # started 5s ago; below 60s threshold
+        f.write(str(time.time() - 5))
+    p = run(env, {"hook_event_name": "Stop", "session_id": sid,
+                  "cwd": "/tmp/x", "stop_hook_active": False})
+    check("3: Stop exit 0", p.returncode == 0)
+    check("3: no notification below threshold", read_stub(stub_log) == "")
+    check("3: start file still consumed", not os.path.isfile(sf))
+
+# --- Test 4: Stop with stop_hook_active=true -> immediate no-op --------------
+with tempfile.TemporaryDirectory() as tmp:
+    home, stub_log, env = make_env(tmp)
+    sid = "sess-4"
+    sf = start_file(home, sid)
+    os.makedirs(os.path.dirname(sf))
+    with open(sf, "w") as f:
+        f.write(str(time.time() - 300))    # very old; would notify if not gated
+    p = run(env, {"hook_event_name": "Stop", "session_id": sid,
+                  "cwd": "/tmp/x", "stop_hook_active": True})
+    check("4: Stop(active) exit 0", p.returncode == 0)
+    check("4: no notification when stop_hook_active", read_stub(stub_log) == "")
+    check("4: start file untouched when active", os.path.isfile(sf))
+
+# --- Test 5: Stop with no start file -> exit 0, no notify, no crash ----------
+with tempfile.TemporaryDirectory() as tmp:
+    home, stub_log, env = make_env(tmp)
+    p = run(env, {"hook_event_name": "Stop", "session_id": "sess-missing",
+                  "cwd": "/tmp/x", "stop_hook_active": False})
+    check("5: Stop(no start file) exit 0", p.returncode == 0)
+    check("5: no notification without start file", read_stub(stub_log) == "")
+    check("5: no traceback on stderr", "Traceback" not in p.stderr)
+
+# --- Bonus: SubagentStop notifies but leaves start file for parent Stop ------
+with tempfile.TemporaryDirectory() as tmp:
+    home, stub_log, env = make_env(tmp)
+    sid = "sess-6"
+    sf = start_file(home, sid)
+    os.makedirs(os.path.dirname(sf))
+    with open(sf, "w") as f:
+        f.write(str(time.time() - 120))
+    p = run(env, {"hook_event_name": "SubagentStop", "session_id": sid,
+                  "cwd": "/home/zach/workspace/civit/example", "stop_hook_active": False})
+    log = read_stub(stub_log)
+    check("6: SubagentStop exit 0", p.returncode == 0)
+    check("6: SubagentStop notifies", "dunstify" in log and "subagent finished" in log)
+    check("6: SubagentStop keeps start file for parent Stop", os.path.isfile(sf))
+
+print()
+if failures:
+    print("%d FAILURE(S): %s" % (len(failures), ", ".join(failures)))
+    sys.exit(1)
+print("all claude-notify tests passed")

--- a/scripts/claude-hooks/tests/test_claude_notify.py
+++ b/scripts/claude-hooks/tests/test_claude_notify.py
@@ -75,6 +75,14 @@ def start_file(home, sid):
     return os.path.join(home, ".cache", "claude-notify", sid + ".start")
 
 
+def lastnotify_file(home, sid):
+    return os.path.join(home, ".cache", "claude-notify", sid + ".lastnotify")
+
+
+def count(hay, needle):
+    return hay.count(needle)
+
+
 def read_stub(stub_log):
     if not os.path.isfile(stub_log):
         return ""
@@ -188,6 +196,78 @@ with tempfile.TemporaryDirectory() as tmp:
     check("6: SubagentStop exit 0", p.returncode == 0)
     check("6: SubagentStop notifies", "dunstify" in log and "subagent finished" in log)
     check("6: SubagentStop keeps start file for parent Stop", os.path.isfile(sf))
+    check("6: SubagentStop writes lastnotify marker", os.path.isfile(lastnotify_file(home, sid)))
+
+# --- Test 7: burst of SubagentStops collapses to ONE ping (cooldown) ---------
+with tempfile.TemporaryDirectory() as tmp:
+    home, stub_log, env = make_env(tmp)
+    sid = "sess-7"
+    sf = start_file(home, sid)
+    os.makedirs(os.path.dirname(sf))
+    with open(sf, "w") as f:                # parent turn started 120s ago (> threshold)
+        f.write(str(time.time() - 120))
+    # Two SubagentStops in quick succession (default cooldown = threshold = 60s).
+    p1 = run(env, {"hook_event_name": "SubagentStop", "session_id": sid,
+                   "cwd": "/home/zach/workspace/civit/example", "stop_hook_active": False})
+    p2 = run(env, {"hook_event_name": "SubagentStop", "session_id": sid,
+                   "cwd": "/home/zach/workspace/civit/example", "stop_hook_active": False})
+    log = read_stub(stub_log)
+    check("7: both SubagentStops exit 0", p1.returncode == 0 and p2.returncode == 0)
+    check("7: burst collapses to ONE notification (not two)", count(log, "dunstify") == 1)
+    check("7: start file still present after subagents", os.path.isfile(sf))
+
+# --- Test 8: a Stop within the cooldown after a SubagentStop does NOT re-notify
+with tempfile.TemporaryDirectory() as tmp:
+    home, stub_log, env = make_env(tmp)
+    sid = "sess-8"
+    sf = start_file(home, sid)
+    os.makedirs(os.path.dirname(sf))
+    with open(sf, "w") as f:
+        f.write(str(time.time() - 120))
+    p1 = run(env, {"hook_event_name": "SubagentStop", "session_id": sid,
+                   "cwd": "/home/zach/workspace/civit/example", "stop_hook_active": False})
+    p2 = run(env, {"hook_event_name": "Stop", "session_id": sid,
+                   "cwd": "/home/zach/workspace/civit/example", "stop_hook_active": False})
+    log = read_stub(stub_log)
+    check("8: SubagentStop then Stop -> exactly ONE notification", count(log, "dunstify") == 1)
+    check("8: Stop still consumes the start file", not os.path.isfile(sf))
+    check("8: Stop cleans up the lastnotify marker", not os.path.isfile(lastnotify_file(home, sid)))
+
+# --- Test 8b: cooldown is PER-SESSION (session A's marker doesn't gate B) -----
+with tempfile.TemporaryDirectory() as tmp:
+    home, stub_log, env = make_env(tmp)
+    cache = os.path.join(home, ".cache", "claude-notify")
+    os.makedirs(cache)
+    # Session A just notified (recent marker); session B has its own long turn.
+    with open(lastnotify_file(home, "sess-A"), "w") as f:
+        f.write(str(time.time()))
+    sfb = start_file(home, "sess-B")
+    with open(sfb, "w") as f:
+        f.write(str(time.time() - 120))
+    p = run(env, {"hook_event_name": "Stop", "session_id": "sess-B",
+                  "cwd": "/home/zach/workspace/civit/example", "stop_hook_active": False})
+    log = read_stub(stub_log)
+    check("8b: session B notifies despite session A's recent marker (per-session)",
+          count(log, "dunstify") == 1)
+
+# --- Test 9: a Stop AFTER the cooldown has elapsed DOES notify ---------------
+with tempfile.TemporaryDirectory() as tmp:
+    home, stub_log, env = make_env(tmp)
+    sid = "sess-9"
+    cache = os.path.join(home, ".cache", "claude-notify")
+    os.makedirs(cache)
+    sf = start_file(home, sid)
+    with open(sf, "w") as f:
+        f.write(str(time.time() - 200))
+    # Prior notification was 120s ago — older than the 60s cooldown, so re-notify.
+    with open(lastnotify_file(home, sid), "w") as f:
+        f.write(str(time.time() - 120))
+    p = run(env, {"hook_event_name": "Stop", "session_id": sid,
+                  "cwd": "/home/zach/workspace/civit/example", "stop_hook_active": False})
+    log = read_stub(stub_log)
+    check("9: Stop after cooldown elapsed DOES notify", count(log, "dunstify") == 1)
+    check("9: Stop consumes start file + lastnotify", not os.path.isfile(sf)
+          and not os.path.isfile(lastnotify_file(home, sid)))
 
 print()
 if failures:

--- a/scripts/claude-hooks/tests/test_register_nudge_hook.py
+++ b/scripts/claude-hooks/tests/test_register_nudge_hook.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Tests for register-nudge-hook.py — the per-host settings.json registrant.
+
+Runs the script against a temp HOME whose ~/.claude/settings.json already holds
+unrelated hooks (clawgate PermissionRequest/Stop, bash-guard, the PostToolUse
+nudges), and asserts:
+
+  1. It appends claude-notify on the 3 turn-boundary events, append-only.
+  2. It NEVER clobbers pre-existing hooks (the clawgate Stop hook survives).
+  3. It is idempotent (a 2nd run makes no change, no duplicates).
+  4. The final settings.json is valid JSON.
+  5. The write is ATOMIC (uses os.replace) and leaves no .settings.*.tmp litter.
+
+Run: python3 test_register_nudge_hook.py
+"""
+import os, sys, json, tempfile, subprocess
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "..", "register-nudge-hook.py")
+
+NOTIFY = "python3 ~/.claude/hooks/claude-notify.py"
+CLAWGATE_STOP = "/home/zach/.claude/clawgate-stop-hook.sh"
+
+failures = []
+
+
+def check(name, cond):
+    print(("PASS" if cond else "FAIL") + " - " + name)
+    if not cond:
+        failures.append(name)
+
+
+BASE_SETTINGS = {
+    "hooks": {
+        "PermissionRequest": [
+            {"hooks": [{"type": "command", "command": "CLAUDE_HOST=wb /home/zach/.claude/clawgate-hook.sh", "timeout": 180}]}
+        ],
+        "PreToolUse": [
+            {"matcher": "Bash", "hooks": [{"type": "command", "command": "python3 ~/.claude/hooks/bash-guard.py"}]}
+        ],
+        "PostToolUse": [
+            {"matcher": "Bash", "hooks": [{"type": "command", "command": "python3 ~/.claude/hooks/audit-pr-nudge.py"}]},
+            {"matcher": "Bash", "hooks": [{"type": "command", "command": "python3 ~/.claude/hooks/shell-env-nudge.py"}]},
+        ],
+        "Stop": [
+            {"hooks": [{"type": "command", "command": CLAWGATE_STOP}]}
+        ],
+    }
+}
+
+
+def run(env):
+    return subprocess.run([sys.executable, SCRIPT], env=env, capture_output=True, text=True)
+
+
+def cmds(data, event):
+    return [h.get("command") for e in data.get("hooks", {}).get(event, []) for h in e.get("hooks", [])]
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    home = os.path.join(tmp, "home")
+    os.makedirs(os.path.join(home, ".claude"))
+    settings = os.path.join(home, ".claude", "settings.json")
+    with open(settings, "w") as f:
+        json.dump(BASE_SETTINGS, f, indent=2)
+
+    env = dict(os.environ)
+    env["HOME"] = home
+
+    p1 = run(env)
+    check("1: first run exit 0", p1.returncode == 0)
+
+    with open(settings) as f:
+        d = json.load(f)
+    check("1: valid JSON after write", isinstance(d, dict))
+    for ev in ("UserPromptSubmit", "Stop", "SubagentStop"):
+        check("1: claude-notify registered on " + ev, NOTIFY in cmds(d, ev))
+    check("2: pre-existing clawgate Stop hook preserved", CLAWGATE_STOP in cmds(d, "Stop"))
+    check("2: bash-guard preserved", "python3 ~/.claude/hooks/bash-guard.py" in cmds(d, "PreToolUse"))
+    check("2: both PostToolUse nudges preserved",
+          "python3 ~/.claude/hooks/audit-pr-nudge.py" in cmds(d, "PostToolUse")
+          and "python3 ~/.claude/hooks/shell-env-nudge.py" in cmds(d, "PostToolUse"))
+
+    # Idempotency: a second run changes nothing and never duplicates.
+    p2 = run(env)
+    check("3: second run exit 0", p2.returncode == 0)
+    check("3: second run reports no change", "no change" in p2.stdout)
+    with open(settings) as f:
+        d2 = json.load(f)
+    check("3: no duplicate claude-notify on Stop", cmds(d2, "Stop").count(NOTIFY) == 1)
+    check("3: clawgate Stop still single + present", cmds(d2, "Stop").count(CLAWGATE_STOP) == 1)
+
+    # Atomicity: no temp litter left in the dir, and the source uses os.replace.
+    leftovers = [n for n in os.listdir(os.path.dirname(settings)) if n.startswith(".settings.")]
+    check("5: no leftover temp files after atomic write", leftovers == [])
+
+with open(SCRIPT) as f:
+    src = f.read()
+check("5: script uses os.replace for atomic write", "os.replace(" in src)
+
+print()
+if failures:
+    print("%d FAILURE(S): %s" % (len(failures), ", ".join(failures)))
+    sys.exit(1)
+print("all register-nudge-hook tests passed")

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -98,11 +98,15 @@ for d in "${DIRS[@]}"; do
   run_pytest "$d"
 done
 
-# The claude-hooks nudge test is a hand-rolled script (asserts + sys.exit, not
-# pytest-collectable) — run it directly. Hermetic (pure string logic + a
+# The claude-hooks tests are hand-rolled scripts (asserts + sys.exit, not
+# pytest-collectable) — run them directly. Hermetic (pure string logic + a
 # subprocess of the hook itself). Always part of the hermetic set.
-HOOK_TEST="scripts/claude-hooks/tests/test_shell_env_nudge.py"
-if [ -f "$HOOK_TEST" ]; then
+HOOK_TESTS=(
+  "scripts/claude-hooks/tests/test_shell_env_nudge.py"
+  "scripts/claude-hooks/tests/test_claude_notify.py"
+)
+for HOOK_TEST in "${HOOK_TESTS[@]}"; do
+  [ -f "$HOOK_TEST" ] || continue
   echo "=== script $HOOK_TEST ==="
   if python "$HOOK_TEST"; then
     RESULTS+=("PASS  $HOOK_TEST (script)")
@@ -111,7 +115,7 @@ if [ -f "$HOOK_TEST" ]; then
     fail=1
   fi
   echo
-fi
+done
 
 echo "======================== SUMMARY ($SET set) ========================"
 for r in "${RESULTS[@]}"; do echo "  $r"; done

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -104,6 +104,7 @@ done
 HOOK_TESTS=(
   "scripts/claude-hooks/tests/test_shell_env_nudge.py"
   "scripts/claude-hooks/tests/test_claude_notify.py"
+  "scripts/claude-hooks/tests/test_register_nudge_hook.py"
 )
 for HOOK_TEST in "${HOOK_TESTS[@]}"; do
   [ -f "$HOOK_TEST" ] || continue


### PR DESCRIPTION
## What

Migrates the Claude Code **turn-finished notifier** hook (`claude-notify.py`) into devrc so home-manager/`ship.sh` delivers it to **both hosts** (laptop + workbench) and it survives re-provisions. It previously existed only as plain local files on the laptop.

The hook fires on `UserPromptSubmit` / `Stop` / `SubagentStop`: when a turn ran ≥ threshold (default 60s) it pings you — a **desktop toast** when there's a local display, else a **clawgate phone push** (POST to clawgate's notify-only `/api/notify`) as a headless-only FALLBACK (never both). Best-effort side-effect only; always exits 0.

## Why (telemetry)

Claude runs **98×/14d on the headless workbench vs 8× on the laptop**, and the long waits the hook exists for are **306 min on the workbench vs 41 min on the laptop**. The value is on the workbench — where the hook wasn't installed. This fixes that.

## Changes

- `scripts/claude-hooks/claude-notify.py` — the hook, copied verbatim (final version: clawgate is fallback-only, POSTs to `/api/notify`).
- `scripts/claude-hooks/tests/test_claude_notify.py` — its test, relocated under `tests/` and pointed at `../claude-notify.py` (matches `test_shell_env_nudge.py`). Passes 24/24.
- `nix/home.nix` — symlinks `claude-notify.py` into `~/.claude/hooks/` exactly like `audit-pr-nudge.py`/`shell-env-nudge.py`, **plus** a `home.activation.dropStaleClaudeNotify` snippet (ordered `entryBefore ["checkLinkTargets"]`) that removes a **stale NON-symlink** `claude-notify.py`/`test_claude_notify.py` before linking, so the first switch on the laptop doesn't collide with the existing plain files. Guarded on `[ ! -L ]` so a legitimately home-manager-managed store symlink is never removed.
- `scripts/claude-hooks/register-nudge-hook.py` — extended to also **idempotently** register `claude-notify.py` on the three events, **append-only**: it preserves every existing hook on each array (clawgate `PermissionRequest`/`Stop`, `bash-guard`, tmux hooks, etc.) and never duplicates. Verified against a realistic settings.json (clawgate-stop-hook preserved; 2nd run = no-op).
- `scripts/run-tests.sh` — runs `test_claude_notify.py` in the hermetic gate too (so `nix flake check` covers it).

## Verification done here (no switch)

- `test_claude_notify.py` from its new location: **24/24 PASS**.
- `register-nudge-hook.py`: idempotency + hook-preservation asserted against a realistic multi-hook settings.json (clawgate Stop hook preserved, no dupes on re-run).
- `nix eval …#homeConfigurations.zach.activationPackage.drvPath`: **full home config evaluates to a derivation** (no build/activate) — home.nix is valid incl. the new `home.file` entry + activation snippet.

## Post-merge activation (Zach)

1. `scripts/ship.sh` on both hosts (converges to `origin/main` + `home-manager switch`). The `dropStaleClaudeNotify` activation removes the stale laptop plain files, then the store symlink lands.
2. On **each** host, register the settings.json entries (settings.json is per-host/unmanaged):
   ```
   python3 ~/workspace/devrc/scripts/claude-hooks/register-nudge-hook.py
   ```
   Safe/idempotent; append-only. Confirm `~/.claude/hooks/claude-notify.py` is now a store symlink and the three events are present.

## Workbench prerequisite (verify — NOT changed here)

For the phone-push fallback to work on the headless workbench, that host needs `~/.claude/clawgate.env` with a **reachable** `CLAWGATE_API_URL` + the shared `CLAWGATE_HOOK_TOKEN`. The **laptop** has this (confirmed: `CLAWGATE_API_URL=http://10.42.0.10:8109` + token present). I could not ssh to the workbench from the laptop to verify, so **please check on the workbench** (it likely already has one if the clawgate PermissionRequest hook runs there):
```
cat ~/.claude/clawgate.env    # expect CLAWGATE_API_URL (LAN: http://192.168.50.250:30302) + CLAWGATE_HOOK_TOKEN, URL reachable
```
Note the URL is host-specific (laptop uses `10.42.0.10:8109`); the workbench should use whatever clawgate address is reachable from it.

## Flagged / not verifiable without a switch

- Actual delivery on the workbench (desktop-absent → clawgate push) can only be confirmed after `ship.sh` + register + a real ≥60s turn on that host.
- The `dropStaleClaudeNotify` collision handling is verified by logic + guard, not by an actual switch (I did not run `home-manager switch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
