### PR TITLE
espanso(:acq): expand into a dispatch-feedback ritual

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -88,7 +88,7 @@ in
           # (:whn removed 2026-07-06 — 0 fires over the audit window, superseded by
           #  /handoff + :eos which ends "…then write the handoff to proceed in next session")
           { trigger = ":eos"; replace = "reflect on work done this session and identify skills that may need updating, then dispatch subagent to update those skills and any relevant docs, then write the handoff to proceed in next session"; label = "End-of-session ritual: review → update skills/docs → handoff"; search_terms = ["end" "session" "wrap" "handoff" "skills" "review" "update" "docs" "ritual"]; }
-          { trigger = ":acq"; replace = "ask me clarifying questions and recommend anything you think would be useful to include"; label = "Ask clarifying questions + suggest additions"; search_terms = ["ask" "clarify" "clarifying" "questions" "elicit" "scope" "include"]; }
+          { trigger = ":acq"; replace = "dispatch subagent to process feedback\n ask me clarifying questions and recommend anything you think would be useful to include before dispatching"; label = "Ask clarifying questions + suggest additions"; search_terms = ["ask" "clarify" "clarifying" "questions" "elicit" "scope" "include"]; }
           { trigger = ":kickoff"; replace = "give me the kickoff message to copy paste to next session"; label = "Kickoff message for next session"; search_terms = ["kickoff" "kick off" "next session" "copy paste" "handoff" "message"]; }
           # Removed 2026-07-25 via /espanso-audit — all keylog-evidence-backed:
           #  ZERO-FIRE set — 0 keylog fires + short-form hand-typing; steering already in


### PR DESCRIPTION
Zach's edit to `:acq`. New expansion:

> dispatch subagent to process feedback\n ask me clarifying questions and recommend anything you think would be useful to include before dispatching

Encodes the clarify-then-dispatch workflow as one whole-message ritual instead of the bare clarify prompt.

Fits the *sticks* profile from the keylog typing-toil analysis (`claudedocs/espanso-typing-toil-2026-07-25.md`): long, whole-message, search-invoked — the opposite of the short mid-sentence prefixes (`:ds`/`:rns`) dropped in #166.

- Miner `SNIPPETS` unchanged (the `:acq` detection substring is still present in the new expansion).
- `nix-instantiate --parse nix/home.nix` ✅
- Note: the expansion contains a literal `\n` → the pasted text is two lines (clipboard paste, so it inserts a newline, does not submit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)