### PR TITLE
feat(browser-bridge): local command channel to drive the live Brave session

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -347,6 +347,14 @@ in
     source = ../scripts/collector/browser-ext;
     recursive = true;
   };
+  # browser-bridge server (SIBLING to the activity receiver above — a *command*
+  # channel that lets a Claude skill drive the live Brave tab, NOT telemetry).
+  # Deployed as a single-file symlink into ~/.config/browser-bridge/ so the
+  # runtime-created, writable ~/.config/browser-bridge/token can live alongside
+  # the read-only nix-store server.py (symlinking the whole dir would collide
+  # with that token file). server.py is stdlib-only + standalone (no sibling
+  # imports), so unlike the receiver it has NO don't-.resolve() import quirk.
+  home.file.".config/browser-bridge/server.py".source = ../scripts/browser-bridge/server.py;
   # i3 focus collector. Reuses keylog's spool_emit (the v1 line format), so
   # keylog/ must be present alongside it (it always is — shipped above).
   home.file.".config/activity-collector/i3" = {
@@ -658,6 +666,40 @@ in
       # Tracks browser-ext AND keylog, because the receiver reuses keylog's
       # spool_emit (single source of truth for the v1 line format).
       X-Restart-Triggers = [ "${../scripts/collector/browser-ext}" "${../scripts/collector/keylog}" ];
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
+
+  # browser-bridge — loopback rendezvous server that lets a Claude Code skill
+  # drive the user's LIVE Brave tab (getHtml/eval/tabs/nav/screenshot) via the
+  # browser-bridge MV3 extension. SIBLING to browser-activity-receiver above;
+  # modelled on it exactly (loopback env, python312, X-Restart-Triggers so a
+  # `home-manager switch` restarts on a script change, WantedBy default.target).
+  # Bound to 127.0.0.1 only + bearer-token auth (token auto-created 0600 at
+  # ~/.config/browser-bridge/token on first start). Staged + enabled but inert
+  # until the unpacked extension is loaded in Brave (see the `browser` skill).
+  systemd.user.services.browser-bridge = {
+    Unit = {
+      Description = "Browser bridge (loopback command channel → live Brave tab)";
+      After = [ "network.target" ];
+    };
+    Service = {
+      Type = "simple";
+      Environment = [
+        "PATH=${lib.makeBinPath [ pkgs.python312 pkgs.coreutils ]}"
+        # Bind loopback only; never reachable off-host.
+        "BROWSER_BRIDGE_HOST=127.0.0.1"
+        # Distinct from the activity receiver's 8787.
+        "BROWSER_BRIDGE_PORT=8788"
+      ];
+      ExecStart = "${pkgs.python312}/bin/python3 %h/.config/browser-bridge/server.py";
+      Restart = "always";
+      RestartSec = 10;
+      # Restart on a script-only change (cf. the receiver above). server.py is
+      # standalone, so only its own path needs tracking.
+      X-Restart-Triggers = [ "${../scripts/browser-bridge/server.py}" ];
     };
     Install = {
       WantedBy = [ "default.target" ];

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -1,0 +1,126 @@
+# browser-bridge
+
+A local, token-authenticated command channel that lets a Claude Code skill drive
+the user's **real, logged-in Brave** browser. This is authorized personal
+automation on the user's own workbench.
+
+It is a **sibling** to the activity-collector's `scripts/collector/browser-ext/`
+(a one-way telemetry sink). browser-bridge is a *command* channel and does not
+touch the collector or its extension.
+
+## Architecture
+
+```
+  Claude skill  ──HTTP POST /cmd──▶  server.py (loopback rendezvous)
+   (scripts/browser-bridge/browser)        │
+                                     GET /poll (long-poll) ▲   ▼ dispatch
+                                            │
+                                MV3 extension service_worker.js
+                                  (runs in the LIVE Brave session)
+                                            │
+                          chrome.scripting / chrome.tabs / captureVisibleTab
+                                            │
+                                  POST /result  ──────────▶ back to the skill
+```
+
+Three actors, one loopback meeting point:
+
+1. **`server.py`** — a stdlib `http.server` bound to `127.0.0.1:8788`. Holds a
+   command queue and correlates each `POST /cmd` (skill) with the matching
+   `POST /result` (extension) by an id.
+2. **`extension/`** — a standalone MV3 extension. Its service worker long-polls
+   `GET /poll`, executes the op against the active tab, and posts the result.
+3. **`browser`** — the bash skill entrypoint Claude calls (`html`, `eval`,
+   `tabs`, `nav`, `screenshot`, `health`).
+
+### Transport: HTTP long-poll (not WebSocket)
+
+An MV3 service worker can't bind a socket, so the local server is the rendezvous.
+We use an **HTTP long-poll command queue**:
+
+- The extension issues `GET /poll`, which blocks until a command is queued (or
+  ~25s → `204`, then it immediately re-polls). A pending fetch keeps the MV3
+  worker alive, so **the long-poll itself is the keepalive** — no RFC6455 ping.
+- `POST /cmd` enqueues a command and blocks (bounded) for the reply.
+
+Long-poll was chosen over a hand-rolled stdlib WebSocket because the whole
+rendezvous stays pure `http.server` + `threading` and is **fully unit-testable
+with stdlib alone** against an in-process fake extension — no new pip deps
+(matching the receiver's stdlib-only footprint; the nix unit pins python312).
+
+## Security model
+
+The socket is loopback-only, but a malicious web page could still try to reach
+it (DNS-rebinding). Two independent gates defeat that:
+
+- **Bearer token** on *every* endpoint — the skill and the extension's long-poll
+  alike. The secret is auto-created `0600` at `~/.config/browser-bridge/token`
+  (`secrets.token_urlsafe`) on first start. Missing/wrong → `401`. A rebinding
+  page cannot read the token file, so it cannot forge a request.
+- **Host-header allowlist** — only `127.0.0.1` / `localhost` / `::1` accepted;
+  anything else → `403`. A rebind victim page carries a foreign `Host`.
+
+The extension holds `<all_urls>` host permissions + `scripting` (maximal — it
+must run in whatever tab is active). This can be scoped down later; noted in
+`extension/README.md`.
+
+## Ops
+
+| op | maps to | returns |
+|----|---------|---------|
+| `getHtml`    | `chrome.scripting` → `document.documentElement.outerHTML` | `{url,title,html}` |
+| `eval`       | `chrome.scripting.executeScript` (MAIN world) of `js`     | `{url,value}` |
+| `tabs`       | `chrome.tabs.query({})`                                   | `{tabs:[...]}` |
+| `nav`        | `chrome.tabs.update(active,{url})`                        | `{tabId,url}` |
+| `screenshot` | `chrome.tabs.captureVisibleTab` (png)                     | `{url,dataUrl}` |
+
+Server envelope: `POST /cmd` → `200 {"ok":true,"result":{id,ok,data}}`, or a
+structured error: `503 extension_not_connected`, `504 timeout`,
+`400 unknown_op|missing_field:<f>`, `401 unauthorized`, `403 bad_host`.
+
+## Running the tests
+
+```bash
+# Python (server.py) — headless, no Brave, no network beyond loopback:
+nix-shell -p python312Packages.pytest --run "pytest scripts/browser-bridge/tests"
+
+# Extension protocol logic (pure, no chrome.* runtime):
+nix-shell -p nodejs --run "node --test scripts/browser-bridge/tests/protocol.test.mjs"
+```
+
+The Python suite (`tests/test_server.py`) also runs as part of
+`scripts/run-tests.sh` (it's in the hermetic set). It covers: token gen + `0600`
+perms, `401`/`403` gates, `/health` connection state, a `/cmd` round-trip against
+an in-process fake extension, `503`/`504` no-extension/timeout paths, unknown-op
++ bad-JSON errors, and request↔reply id correlation (incl. out-of-order replies).
+The chrome.* glue in `service_worker.js` genuinely needs a real browser and is
+covered by the manual checklist in `extension/README.md`.
+
+## Deploy (nix)
+
+`nix/home.nix` deploys `server.py` to `~/.config/browser-bridge/server.py` and
+runs it as the `browser-bridge` systemd **user** service (loopback, port 8788,
+`X-Restart-Triggers` so `home-manager switch` restarts it on a code change). The
+runtime token file lives alongside it in the same real dir.
+
+```bash
+home-manager switch --flake ~/workspace/devrc --impure
+systemctl --user status browser-bridge
+```
+
+## End-to-end manual verification (the one step that needs real Brave)
+
+1. `home-manager switch …` — starts the `browser-bridge` service on 127.0.0.1:8788.
+2. Load the extension: Brave → `brave://extensions` → enable **Developer mode** →
+   **Load unpacked** → select `scripts/browser-bridge/extension/`.
+3. Open the extension's **options** (⋯ → Options / "Extension options"), paste the
+   token from `~/.config/browser-bridge/token`, port `8788`, **Save**.
+4. `scripts/browser-bridge/browser health` → `{"ok":true,"extension_connected":true}`.
+5. Focus a tab where you are **logged in** (e.g. Gmail), then
+   `scripts/browser-bridge/browser html | grep -i <your-name-or-account-marker>` —
+   seeing logged-in-only markup **proves it's the live authenticated session**,
+   not a fresh fetch.
+
+⚠ After editing anything in `extension/`, click the **reload** ↻ on the
+extension card in `brave://extensions` — Brave does not hot-reload unpacked
+extensions.

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: browser
+description: Drive the user's LIVE, logged-in Brave browser from Claude Code — read the active tab's HTML, run JS in it, list/navigate tabs, and screenshot the visible tab — via the local token-authenticated browser-bridge (loopback rendezvous server + MV3 extension). Use when the user asks you to look at / read / scrape / interact with a page THEY have open, act on an authenticated site they're logged into, check what's on their screen in Brave, navigate their browser, or grab a screenshot of their current tab. NOT for headless fetching of public URLs (use WebFetch) — this is specifically their real, authenticated session.
+---
+
+# browser — drive the live Brave session
+
+`browser-bridge` lets you operate the user's **real, logged-in Brave** browser.
+Commands go: the `browser` CLI → a loopback rendezvous server (`127.0.0.1:8788`,
+bearer-token auth) → a standalone MV3 extension in the live Brave session →
+executed against the **active tab** → result back to you.
+
+This is authorized personal automation on the user's own workbench. It is a
+**sibling** to the activity-collector browser extension (telemetry) — different
+subsystem, do not conflate.
+
+Full architecture, security model, and deploy: `scripts/browser-bridge/README.md`.
+
+## Entrypoint
+
+`scripts/browser-bridge/browser <subcommand>` (JSON on stdout, pretty-printed if
+`jq` is present):
+
+| command | does |
+|---------|------|
+| `browser health`            | is the extension connected? `{"ok":true,"extension_connected":bool}` |
+| `browser html`              | active tab `outerHTML` (+ url, title) |
+| `browser eval '<js>'`       | run JS in the active tab, return its value |
+| `browser tabs`              | list open tabs |
+| `browser nav <url>`         | navigate the active tab to `<url>` |
+| `browser screenshot [path]` | captureVisibleTab; prints the data URL, or writes a `.png` to `path` |
+
+Result payloads land under `.result.data` in the JSON (the envelope is
+`{"ok":true,"result":{"id","ok","data":{...}}}`).
+
+## Security contract (why it's safe)
+
+- **Loopback only** (`127.0.0.1:8788`) — never bound to an external interface.
+- **Bearer token** on every request — auto-created `0600` at
+  `~/.config/browser-bridge/token` on first server start. The `browser` CLI
+  reads it; a web page can't. Defeats DNS-rebinding.
+- **Host-header allowlist** — only `127.0.0.1`/`localhost`/`::1`.
+
+## Before you rely on it
+
+1. `browser health` — if `extension_connected:false` or it errors, the extension
+   isn't loaded/paired. Tell the user to load + pair it (see below); you cannot
+   do this for them (it's a manual Brave step).
+2. **Verify it's the LIVE authenticated session**: after `browser html`, confirm
+   the returned markup contains **logged-in-only** content (their name, account
+   menu, inbox contents). If it looks like a logged-out/anonymous page, the wrong
+   tab is active or they're not logged in — say so rather than proceeding.
+
+## Error shapes (from `/cmd`)
+
+- `503 extension_not_connected` → extension not loaded/paired, or Brave closed.
+- `504 timeout` → extension picked it up but didn't answer (tab unresponsive).
+- `400 unknown_op` / `missing_field:url|js` → bad command.
+- `401 unauthorized` → token mismatch (re-paste in the extension options).
+
+## Gotcha: reload the unpacked extension after any change
+
+Brave does **not** hot-reload unpacked extensions. If `extension/` was edited,
+the user must click **reload** ↻ on the card in `brave://extensions`, or the old
+service-worker code keeps running. The `browser-bridge` **server** does restart
+automatically on a `home-manager switch` (X-Restart-Triggers).
+
+## One-time setup (hand these steps to the user)
+
+1. `home-manager switch --flake ~/workspace/devrc --impure` (starts the service).
+2. Brave → `brave://extensions` → Developer mode → **Load unpacked** →
+   `scripts/browser-bridge/extension/`.
+3. Extension **Options** → paste the token from `~/.config/browser-bridge/token`,
+   port `8788`, **Save**.
+4. `browser health` → `extension_connected:true`.

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# browser — Claude-facing entrypoint for the browser-bridge command channel.
+#
+# Talks to the loopback rendezvous server (scripts/browser-bridge/server.py) over
+# HTTP with the bearer token from ~/.config/browser-bridge/token, which forwards
+# the command to the browser-bridge MV3 extension running in the user's live,
+# logged-in Brave session.
+#
+# Subcommands:
+#   browser health            — is an extension connected?
+#   browser html              — outerHTML of the active tab (+ url, title)
+#   browser eval '<js>'       — run JS in the active tab, return its value
+#   browser tabs              — list open tabs
+#   browser nav <url>         — navigate the active tab to <url>
+#   browser screenshot [path] — captureVisibleTab; prints data URL, or writes a
+#                               .png to <path> if given
+#
+# Output is JSON on stdout (pretty-printed if `jq` is present). Exit non-zero on
+# transport/HTTP error so a caller can branch.
+set -uo pipefail
+
+HOST="${BROWSER_BRIDGE_HOST:-127.0.0.1}"
+PORT="${BROWSER_BRIDGE_PORT:-8788}"
+TOKEN_FILE="${BROWSER_BRIDGE_TOKEN_FILE:-$HOME/.config/browser-bridge/token}"
+BASE="http://${HOST}:${PORT}"
+
+die() { echo "browser: $*" >&2; exit 1; }
+
+[ -r "$TOKEN_FILE" ] || die "token file not found/readable: $TOKEN_FILE (is the browser-bridge service running?)"
+TOKEN="$(tr -d '[:space:]' < "$TOKEN_FILE")"
+[ -n "$TOKEN" ] || die "token file is empty: $TOKEN_FILE"
+
+command -v curl >/dev/null 2>&1 || die "curl not found on PATH"
+
+pretty() {
+  if command -v jq >/dev/null 2>&1; then jq .; else cat; fi
+}
+
+# _curl METHOD PATH [JSON_BODY] — emits `<body>\n<http_code>` to stdout. The
+# caller splits it (globals can't cross the command-substitution subshell).
+_curl() {
+  local method="$1" path="$2" body="${3:-}"
+  local args=(-sS -m 60 -X "$method"
+    -H "Authorization: Bearer ${TOKEN}"
+    -H "Host: 127.0.0.1"
+    -w '\n%{http_code}')
+  if [ -n "$body" ]; then
+    args+=(-H "Content-Type: application/json" --data "$body")
+  fi
+  curl "${args[@]}" "${BASE}${path}" || die "curl failed talking to ${BASE}${path}"
+}
+
+# cmd_op OP [EXTRA_JSON_FIELDS] — POST /cmd, print result JSON, exit on error.
+cmd_op() {
+  local op="$1" extra="${2:-}"
+  local body="{\"op\":\"${op}\"${extra:+,${extra}}}"
+  local raw HTTP_CODE resp
+  raw="$(_curl POST /cmd "$body")"
+  HTTP_CODE="${raw##*$'\n'}"; resp="${raw%$'\n'*}"
+  case "$HTTP_CODE" in
+    200) printf '%s' "$resp" ;;
+    503) echo "$resp" >&2; die "no extension connected — load the browser-bridge extension in Brave (see SKILL.md)" ;;
+    504) echo "$resp" >&2; die "timeout waiting for the extension to answer (is Brave focused / responsive?)" ;;
+    401) die "unauthorized — token mismatch (re-paste the token in the extension options)" ;;
+    *)   echo "$resp" >&2; die "HTTP $HTTP_CODE from /cmd" ;;
+  esac
+}
+
+# JSON-escape a string via python (available everywhere here; avoids jq dep).
+json_str() { python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$1"; }
+
+sub="${1:-}"; shift || true
+case "$sub" in
+  health)
+    raw="$(_curl GET /health)"
+    HTTP_CODE="${raw##*$'\n'}"; resp="${raw%$'\n'*}"
+    [ "$HTTP_CODE" = "200" ] || { echo "$resp" >&2; die "HTTP $HTTP_CODE from /health"; }
+    printf '%s\n' "$resp" | pretty
+    ;;
+  html)
+    cmd_op getHtml | pretty
+    ;;
+  eval)
+    [ $# -ge 1 ] || die "usage: browser eval '<js>'"
+    js="$(json_str "$1")"
+    cmd_op eval "\"js\":${js}" | pretty
+    ;;
+  tabs)
+    cmd_op tabs | pretty
+    ;;
+  nav)
+    [ $# -ge 1 ] || die "usage: browser nav <url>"
+    url="$(json_str "$1")"
+    cmd_op nav "\"url\":${url}" | pretty
+    ;;
+  screenshot)
+    resp="$(cmd_op screenshot)"
+    if [ $# -ge 1 ]; then
+      # Extract the base64 payload of the data URL and write a .png.
+      out="$1"
+      printf '%s' "$resp" | python3 -c '
+import json,sys,base64,re
+d=json.load(sys.stdin)
+url=d["result"]["data"]["dataUrl"]
+b64=re.sub(r"^data:image/[^;]+;base64,","",url)
+open(sys.argv[1],"wb").write(base64.b64decode(b64))
+print(sys.argv[1])
+' "$out"
+    else
+      printf '%s\n' "$resp" | pretty
+    fi
+    ;;
+  ""|-h|--help|help)
+    grep -E '^#( |$)' "$0" | sed -E 's/^# ?//'
+    ;;
+  *)
+    die "unknown subcommand: $sub (try: health html eval tabs nav screenshot)"
+    ;;
+esac

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -47,23 +47,55 @@ _curl() {
   if [ -n "$body" ]; then
     args+=(-H "Content-Type: application/json" --data "$body")
   fi
-  curl "${args[@]}" "${BASE}${path}" || die "curl failed talking to ${BASE}${path}"
+  # NOTE: a failure here would only `die` the command-substitution subshell, so
+  # every caller wraps `$(_curl …)` in `|| die` to actually propagate the exit.
+  curl "${args[@]}" "${BASE}${path}"
 }
 
-# cmd_op OP [EXTRA_JSON_FIELDS] — POST /cmd, print result JSON, exit on error.
+# op_error RESP — for a 200 /cmd response, print the extension's op-level error
+# string when the wrapped envelope reports ok:false, else print nothing. Exits 2
+# (with no stdout) if the response cannot be parsed as JSON.
+op_error() {
+  printf '%s' "$1" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(2)
+r = d.get("result") if isinstance(d, dict) else None
+if isinstance(r, dict) and r.get("ok") is False:
+    sys.stdout.write(str(r.get("error") or "unknown error"))
+'
+}
+
+# cmd_op OP [EXTRA_JSON_FIELDS] — POST /cmd, print the result JSON on a genuine
+# success; exit non-zero with a readable message on a transport, HTTP, OR
+# op-level (result.ok:false) error.
 cmd_op() {
   local op="$1" extra="${2:-}"
   local body="{\"op\":\"${op}\"${extra:+,${extra}}}"
   local raw HTTP_CODE resp
-  raw="$(_curl POST /cmd "$body")"
+  raw="$(_curl POST /cmd "$body")" || die "curl failed talking to ${BASE}/cmd"
   HTTP_CODE="${raw##*$'\n'}"; resp="${raw%$'\n'*}"
   case "$HTTP_CODE" in
-    200) printf '%s' "$resp" ;;
+    200) : ;;  # HTTP ok — still must inspect the inner op result below.
     503) echo "$resp" >&2; die "no extension connected — load the browser-bridge extension in Brave (see SKILL.md)" ;;
     504) echo "$resp" >&2; die "timeout waiting for the extension to answer (is Brave focused / responsive?)" ;;
     401) die "unauthorized — token mismatch (re-paste the token in the extension options)" ;;
     *)   echo "$resp" >&2; die "HTTP $HTTP_CODE from /cmd" ;;
   esac
+  # A 200 wraps the extension's envelope: {"ok":true,"result":<envelope>}. When
+  # the op THREW in the page the envelope is {…,"ok":false,"error":…}; surface
+  # that as a non-zero exit instead of printing a "successful" error JSON.
+  local oe rc
+  oe="$(op_error "$resp")"; rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "$resp" >&2; die "could not parse the server response from /cmd"
+  fi
+  if [ -n "$oe" ]; then
+    die "op '$op' failed in the browser: $oe"
+  fi
+  printf '%s' "$resp"
 }
 
 # JSON-escape a string via python (available everywhere here; avoids jq dep).
@@ -72,7 +104,7 @@ json_str() { python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$1"; 
 sub="${1:-}"; shift || true
 case "$sub" in
   health)
-    raw="$(_curl GET /health)"
+    raw="$(_curl GET /health)" || die "curl failed talking to ${BASE}/health"
     HTTP_CODE="${raw##*$'\n'}"; resp="${raw%$'\n'*}"
     [ "$HTTP_CODE" = "200" ] || { echo "$resp" >&2; die "HTTP $HTTP_CODE from /health"; }
     printf '%s\n' "$resp" | pretty
@@ -94,14 +126,20 @@ case "$sub" in
     cmd_op nav "\"url\":${url}" | pretty
     ;;
   screenshot)
-    resp="$(cmd_op screenshot)"
+    # cmd_op runs in a command substitution, so its `die`/exit can't propagate
+    # on its own — `|| exit 1` forwards an op/transport error to the caller.
+    resp="$(cmd_op screenshot)" || exit 1
     if [ $# -ge 1 ]; then
       # Extract the base64 payload of the data URL and write a .png.
       out="$1"
       printf '%s' "$resp" | python3 -c '
 import json,sys,base64,re
 d=json.load(sys.stdin)
-url=d["result"]["data"]["dataUrl"]
+try:
+    url=d["result"]["data"]["dataUrl"]
+except (KeyError, TypeError):
+    sys.stderr.write("browser: screenshot response missing image data\n")
+    sys.exit(1)
 b64=re.sub(r"^data:image/[^;]+;base64,","",url)
 open(sys.argv[1],"wb").write(base64.b64decode(b64))
 print(sys.argv[1])

--- a/scripts/browser-bridge/extension/README.md
+++ b/scripts/browser-bridge/extension/README.md
@@ -1,0 +1,64 @@
+# browser-bridge extension (MV3)
+
+A standalone Manifest V3 extension that connects the user's live Brave session to
+the local `browser-bridge` server so a Claude Code skill can drive the active
+tab. This is a **sibling** to the activity collector's extension — do not confuse
+or merge them.
+
+## Files
+
+| file | role |
+|------|------|
+| `manifest.json`     | MV3 manifest (permissions, background SW, options page) |
+| `service_worker.js` | long-poll loop + chrome.* op executors (needs real Brave) |
+| `protocol.js`       | pure op-set / validation / envelope / backoff logic (unit-tested) |
+| `options.html/js`   | one-time setup: paste the bearer token + port into `chrome.storage.local` |
+
+## Load it (and reload after every change)
+
+1. Brave → `brave://extensions`
+2. Toggle **Developer mode** (top-right).
+3. **Load unpacked** → select this `extension/` directory.
+4. Click the extension's **Options** (⋯ menu → Options), paste the token from
+   `~/.config/browser-bridge/token`, set port `8788`, **Save**.
+
+⚠ **Brave does not hot-reload unpacked extensions.** After editing any file here,
+click the **reload** ↻ button on the extension's card in `brave://extensions`,
+or the service worker keeps running the old code.
+
+## Permissions (maximal — can be scoped later)
+
+`scripting`, `tabs`, `activeTab`, `alarms`, `storage`, and
+`host_permissions: ["<all_urls>"]`. `<all_urls>` + `scripting` is what lets the
+worker run in whatever tab is active. If you only ever drive a known set of
+sites, scope `host_permissions` to those origins and reload.
+
+## Stable extension ID (optional)
+
+Unpacked extensions get a per-path random ID. To pin a stable ID (e.g. so an
+allowlist elsewhere can reference it), generate a keypair and add its public key
+as a top-level `"key"` in `manifest.json`:
+
+```bash
+# generate a private key + derive the manifest "key" (base64 SPKI):
+openssl genrsa 2048 | openssl pkcs8 -topk8 -nocrypt -out key.pem
+openssl rsa -in key.pem -pubout -outform DER | base64 -w0   # → paste as manifest "key"
+```
+
+Left out of the committed manifest (MVP) — the bridge does not depend on the ID.
+
+## Manual test checklist (what the unit tests can't cover)
+
+The pure logic in `protocol.js` is unit-tested (`../tests/protocol.test.mjs`).
+The chrome.* glue needs a real browser — verify by hand after loading:
+
+- [ ] With the server running + token pasted, `browser health` reports
+      `extension_connected:true` within ~1 min (or after a reload).
+- [ ] `browser html` on a logged-in tab returns markup containing logged-in-only
+      content (proves the live authenticated session).
+- [ ] `browser eval 'document.title'` returns the active tab's title.
+- [ ] `browser tabs` lists your open tabs.
+- [ ] `browser nav https://example.com` navigates the active tab.
+- [ ] `browser screenshot /tmp/shot.png` writes a real PNG of the visible tab.
+- [ ] Stop the server → `browser health` fails / `extension_connected:false`
+      after the stale window; restart → it reconnects on the next poll.

--- a/scripts/browser-bridge/extension/manifest.json
+++ b/scripts/browser-bridge/extension/manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifest_version": 3,
+  "name": "Browser Bridge (command channel)",
+  "version": "0.1.0",
+  "description": "Lets a local Claude Code skill drive the active Brave tab (getHtml/eval/tabs/nav/screenshot) via a loopback, token-authenticated rendezvous server. Local-only, authorized personal automation.",
+  "permissions": ["scripting", "tabs", "activeTab", "storage", "alarms"],
+  "host_permissions": ["http://127.0.0.1:8788/*", "<all_urls>"],
+  "background": {
+    "service_worker": "service_worker.js",
+    "type": "module"
+  },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  }
+}

--- a/scripts/browser-bridge/extension/options.html
+++ b/scripts/browser-bridge/extension/options.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Browser Bridge — setup</title>
+  <style>
+    body { font: 14px system-ui, sans-serif; max-width: 32rem; margin: 2rem auto; padding: 0 1rem; }
+    label { display: block; margin: 1rem 0 0.25rem; font-weight: 600; }
+    input { width: 100%; padding: 0.5rem; box-sizing: border-box; font-family: monospace; }
+    button { margin-top: 1rem; padding: 0.5rem 1rem; }
+    #status { margin-top: 1rem; color: green; }
+    code { background: #eee; padding: 0 0.25rem; }
+  </style>
+</head>
+<body>
+  <h1>Browser Bridge setup</h1>
+  <p>Paste the bearer token from
+    <code>~/.config/browser-bridge/token</code> and the port the
+    <code>browser-bridge</code> service listens on (default 8788).</p>
+  <label for="port">Port</label>
+  <input id="port" type="text" placeholder="8788" />
+  <label for="token">Token</label>
+  <input id="token" type="text" placeholder="paste token here" />
+  <button id="save">Save</button>
+  <div id="status"></div>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/scripts/browser-bridge/extension/options.js
+++ b/scripts/browser-bridge/extension/options.js
@@ -1,0 +1,17 @@
+// options.js — persist the loopback port + bearer token into chrome.storage.local
+// (read by service_worker.js). No network here; purely local config.
+async function load() {
+  const { port, token } = await chrome.storage.local.get(["port", "token"]);
+  document.getElementById("port").value = port || 8788;
+  document.getElementById("token").value = token || "";
+}
+
+document.getElementById("save").addEventListener("click", async () => {
+  const port = parseInt(document.getElementById("port").value, 10) || 8788;
+  const token = document.getElementById("token").value.trim();
+  await chrome.storage.local.set({ port, token });
+  document.getElementById("status").textContent =
+    "Saved. The bridge will connect within ~1 minute (or reload the extension).";
+});
+
+load();

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -34,6 +34,36 @@ export function errorEnvelope(id, error) {
   return { id, ok: false, error: String(error) };
 }
 
+// Compile a user `eval` snippet into a single callable, choosing between the
+// expression form (`return (src)`) and the statement form (`src`) WITHOUT ever
+// executing a side effect twice.
+//
+// The distinction that matters: a *construction* SyntaxError means the
+// expression-wrapped body could not be PARSED (e.g. `src` is a statement like
+// `const x = 1;`), so we legitimately fall back to the statement form. A
+// *runtime* throw only happens later, when the returned function is CALLED — it
+// must propagate as the op error and must NOT trigger a second execution of an
+// already-run side effect. By deciding the form at PARSE time and returning one
+// function, the caller invokes it exactly once.
+//
+// `FunctionCtor` is injectable for unit testing; production passes the real
+// `Function`. NOTE: service_worker.js's injected `eval` executor mirrors this
+// logic inline (an injected function can't import this module) — keep in sync.
+export function compileEval(src, FunctionCtor = Function) {
+  try {
+    // Parses the expression-wrapped form. A SyntaxError here is a *parse*
+    // failure — never a side effect (the body is not executed by construction).
+    return FunctionCtor(`return (${src})`);
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      // Expression form is unparseable → compile the statement form instead.
+      // (If THAT is also a SyntaxError it propagates — genuinely invalid JS.)
+      return FunctionCtor(src);
+    }
+    throw e;
+  }
+}
+
 // Reconnect / re-poll backoff after a transport error, capped. Attempt 0 → base.
 // Deterministic (no jitter) so it is unit-testable; the SW adds a small random
 // jitter at call time.

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -1,0 +1,43 @@
+// protocol.js — the pure, browser-independent half of the browser-bridge
+// extension. Everything here is testable with `node --test` (no chrome.* APIs),
+// and the op set MIRRORS server.py's ALLOWED_OPS (the shared JSON contract —
+// asserted by protocol.test.mjs and documented in ../../README.md).
+
+// The command ops the bridge understands. MUST equal server.py ALLOWED_OPS.
+export const ALLOWED_OPS = ["getHtml", "eval", "tabs", "nav", "screenshot"];
+
+// Per-op required fields (mirrors server.py REQUIRED_FIELDS). The server already
+// validates these, but the SW re-checks so a hand-crafted command can't wedge it.
+export const REQUIRED_FIELDS = {
+  eval: ["js"],
+  nav: ["url"],
+};
+
+// Validate an inbound command dict. Returns { ok:true } or { ok:false, error }.
+export function validateCommand(cmd) {
+  if (!cmd || typeof cmd !== "object") return { ok: false, error: "body_not_object" };
+  if (!ALLOWED_OPS.includes(cmd.op)) return { ok: false, error: "unknown_op" };
+  for (const f of REQUIRED_FIELDS[cmd.op] || []) {
+    if (!cmd[f]) return { ok: false, error: `missing_field:${f}` };
+  }
+  return { ok: true };
+}
+
+// A successful result envelope for command `id`. `data` is the op-specific
+// payload the server hands back to the skill under result.data.
+export function resultEnvelope(id, data) {
+  return { id, ok: true, data };
+}
+
+// A failure envelope for command `id` (op threw / unsupported in this browser).
+export function errorEnvelope(id, error) {
+  return { id, ok: false, error: String(error) };
+}
+
+// Reconnect / re-poll backoff after a transport error, capped. Attempt 0 → base.
+// Deterministic (no jitter) so it is unit-testable; the SW adds a small random
+// jitter at call time.
+export function nextBackoffMs(attempt, baseMs = 1000, capMs = 30000) {
+  const n = Math.max(0, attempt | 0);
+  return Math.min(capMs, baseMs * Math.pow(2, n));
+}

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -65,13 +65,24 @@ const OPS = {
       world: "MAIN",
       args: [cmd.js],
       func: (src) => {
-        // eslint-disable-next-line no-new-func
-        const v = new Function(`return (${src})`);
-        try { return v(); } catch (_e) {
-          // Fall back to statement execution (no return value).
+        // Decide expression-vs-statement form by whether the expression-wrapped
+        // body PARSES — WITHOUT executing it — then call the chosen fn exactly
+        // once. A construction SyntaxError → fall back to the statement form; a
+        // runtime throw from calling the fn must propagate (never re-run a side
+        // effect). Mirrors protocol.js compileEval — keep the two in sync.
+        let fn;
+        try {
           // eslint-disable-next-line no-new-func
-          return new Function(src)();
+          fn = new Function(`return (${src})`);
+        } catch (e) {
+          if (e instanceof SyntaxError) {
+            // eslint-disable-next-line no-new-func
+            fn = new Function(src);   // statement form (no return value)
+          } else {
+            throw e;
+          }
         }
+        return fn();
       },
     });
     return { url: tab.url, value: inj.result };

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -1,0 +1,176 @@
+// service_worker.js — MV3 background worker for the browser-bridge command
+// channel. SIBLING to the activity collector's SW; this one is a *command*
+// executor, not a telemetry emitter.
+//
+// It long-polls the loopback rendezvous server (GET /poll), executes each
+// command against the ACTIVE Brave tab via chrome.* APIs, and POSTs the result
+// back (POST /result). A pending /poll fetch keeps the MV3 worker alive, so the
+// long-poll IS the keepalive — a chrome.alarms tick (every ~1 min) is a
+// belt-and-suspenders restart in case the worker was suspended between polls.
+//
+// The pure protocol logic (op set, validation, envelopes, backoff) lives in
+// protocol.js and is unit-tested with `node --test`; this file is only the thin
+// chrome.* glue that genuinely needs a real browser.
+//
+// Config: the port + bearer token are read from chrome.storage.local
+// ("port","token"), set once from the extension's options-free setup (see
+// README — you paste the token from ~/.config/browser-bridge/token). Defaults
+// to port 8788.
+
+import { ALLOWED_OPS, validateCommand, resultEnvelope, errorEnvelope, nextBackoffMs }
+  from "./protocol.js";
+
+const DEFAULT_PORT = 8788;
+let running = false;
+
+async function config() {
+  const { port, token } = await chrome.storage.local.get(["port", "token"]);
+  return { port: port || DEFAULT_PORT, token: token || "" };
+}
+
+function base(port) {
+  return `http://127.0.0.1:${port}`;
+}
+
+function authHeaders(token) {
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+// --- active-tab helpers ---------------------------------------------------- //
+async function activeTab() {
+  const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+  if (!tab) throw new Error("no_active_tab");
+  return tab;
+}
+
+// --- op executors ---------------------------------------------------------- //
+// Each returns the op-specific `data` object; throws on failure (→ errorEnvelope).
+const OPS = {
+  async getHtml() {
+    const tab = await activeTab();
+    const [inj] = await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: () => document.documentElement.outerHTML,
+    });
+    return { url: tab.url, title: tab.title, html: inj.result };
+  },
+
+  async eval(cmd) {
+    const tab = await activeTab();
+    // chrome.scripting runs in an ISOLATED world; `js` is evaluated and its
+    // completion value returned. Wrapped so a bare expression or a statement
+    // block both work. Result must be JSON-serialisable (structured clone).
+    const [inj] = await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      world: "MAIN",
+      args: [cmd.js],
+      func: (src) => {
+        // eslint-disable-next-line no-new-func
+        const v = new Function(`return (${src})`);
+        try { return v(); } catch (_e) {
+          // Fall back to statement execution (no return value).
+          // eslint-disable-next-line no-new-func
+          return new Function(src)();
+        }
+      },
+    });
+    return { url: tab.url, value: inj.result };
+  },
+
+  async tabs() {
+    const tabs = await chrome.tabs.query({});
+    return {
+      tabs: tabs.map((t) => ({
+        id: t.id, url: t.url, title: t.title,
+        active: t.active, windowId: t.windowId,
+      })),
+    };
+  },
+
+  async nav(cmd) {
+    const tab = await activeTab();
+    await chrome.tabs.update(tab.id, { url: cmd.url });
+    return { tabId: tab.id, url: cmd.url };
+  },
+
+  async screenshot() {
+    const tab = await activeTab();
+    const dataUrl = await chrome.tabs.captureVisibleTab(tab.windowId, {
+      format: "png",
+    });
+    return { url: tab.url, dataUrl };
+  },
+};
+
+async function execute(cmd) {
+  const v = validateCommand(cmd);
+  if (!v.ok) return errorEnvelope(cmd.id, v.error);
+  try {
+    const data = await OPS[cmd.op](cmd);
+    return resultEnvelope(cmd.id, data);
+  } catch (e) {
+    return errorEnvelope(cmd.id, e && e.message ? e.message : e);
+  }
+}
+
+// --- long-poll loop -------------------------------------------------------- //
+async function pollOnce({ port, token }) {
+  const res = await fetch(`${base(port)}/poll`, { headers: authHeaders(token) });
+  if (res.status === 204) return null;          // idle timeout → re-poll
+  if (res.status === 401) throw new Error("unauthorized");
+  if (!res.ok) throw new Error(`poll_${res.status}`);
+  return res.json();
+}
+
+async function postResult(cfg, envelope) {
+  await fetch(`${base(cfg.port)}/result`, {
+    method: "POST",
+    headers: authHeaders(cfg.token),
+    body: JSON.stringify(envelope),
+  });
+}
+
+async function loop() {
+  if (running) return;
+  running = true;
+  let attempt = 0;
+  try {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const cfg = await config();
+      if (!cfg.token) { await sleep(5000); continue; }
+      try {
+        const cmd = await pollOnce(cfg);
+        attempt = 0;                             // healthy round-trip
+        if (cmd) {
+          const envelope = await execute(cmd);
+          await postResult(cfg, envelope);
+        }
+      } catch (e) {
+        // Transport error (server down, unauthorized, network) → backoff.
+        const wait = nextBackoffMs(attempt++) + Math.floor(Math.random() * 250);
+        await sleep(wait);
+      }
+    }
+  } finally {
+    running = false;
+  }
+}
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// --- MV3 keepalive: restart the loop on install / startup / alarm ---------- //
+chrome.runtime.onInstalled.addListener(() => loop());
+chrome.runtime.onStartup.addListener(() => loop());
+chrome.alarms.create("bridge-keepalive", { periodInMinutes: 1 });
+chrome.alarms.onAlarm.addListener((a) => {
+  if (a.name === "bridge-keepalive") loop();
+});
+
+// Kick immediately when the worker is first evaluated.
+loop();
+
+// Exported for reuse / potential future tests (no-op in the browser).
+export { execute, OPS, ALLOWED_OPS };

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""browser-bridge server — loopback rendezvous between a Claude skill and the
+live Brave browser.
+
+This is a SIBLING to the activity-collector's `browser-ext/receiver.py`, NOT a
+modification of it. Where the receiver is a one-way telemetry sink (extension
+--POST--> server --> spool), this adds a *command* channel that lets Claude Code
+drive the user's real, logged-in Brave tab:
+
+    Claude skill --HTTP `POST /cmd`--> THIS server --long-poll--> extension
+        --> executes in the active Brave tab --> `POST /result` --> back to skill
+
+Transport choice (documented, deliberate): an MV3 service worker cannot bind a
+socket, so the local server is the meeting point. We use an **HTTP long-poll
+command queue** rather than a WebSocket:
+
+  * The extension SW issues `GET /poll`, which blocks until a command is queued
+    (or ~25s, then 204 → immediate re-poll). A pending fetch keeps the MV3
+    worker alive, so this IS the keepalive — no RFC6455 ping needed.
+  * The skill's `POST /cmd` enqueues a command, waits (bounded) for the matching
+    `POST /result`, and returns it.
+
+Long-poll (vs a hand-rolled stdlib WebSocket) was chosen because the whole
+rendezvous is then pure `http.server` + `threading` and is FULLY unit-testable
+with stdlib alone against an in-process fake extension — no new pip deps, mirror-
+ing the receiver's stdlib-only footprint (the nix unit pins python312).
+
+Security contract (defeats DNS-rebinding / local malware reaching the socket):
+  * Binds 127.0.0.1 only (env `BROWSER_BRIDGE_HOST`, default 127.0.0.1).
+  * Bearer-token auth on EVERY endpoint — skill requests and the extension's
+    long-poll alike. The secret lives in `~/.config/browser-bridge/token`,
+    created 0600 with `secrets.token_urlsafe` on first run. 401 otherwise.
+  * Host-header allowlist: only 127.0.0.1 / localhost / ::1 accepted (403
+    otherwise) — a DNS-rebind victim page hits us with a foreign Host header.
+
+Config (env):
+    BROWSER_BRIDGE_HOST          bind host (default 127.0.0.1 — keep loopback)
+    BROWSER_BRIDGE_PORT          bind port (default 8788 — must NOT be 8787)
+    BROWSER_BRIDGE_TOKEN_FILE    token path (default ~/.config/browser-bridge/token)
+    BROWSER_BRIDGE_CMD_TIMEOUT   seconds a /cmd waits for a result (default 20)
+    BROWSER_BRIDGE_POLL_TIMEOUT  seconds a /poll blocks before 204 (default 25)
+"""
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import sys
+import threading
+import time
+from collections import deque
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+# --- protocol contract (shared with extension/protocol.js — keep in sync) ---- #
+# The op set the bridge accepts. Both sides validate against this exact set; the
+# JS side mirrors it in extension/protocol.js (asserted by the extension test).
+ALLOWED_OPS = ("getHtml", "eval", "tabs", "nav", "screenshot")
+
+# Per-op required fields (skill-supplied). Absent → 400 bad_request.
+REQUIRED_FIELDS = {
+    "eval": ("js",),
+    "nav": ("url",),
+}
+
+MAX_CMD_BODY = 256 * 1024      # a command is tiny (op + a url / a js snippet).
+MAX_RESULT_BODY = 32 * 1024 * 1024  # a screenshot data URL can be a few MB.
+
+# A connection is considered "present" if a long-poll landed within this window.
+CONNECT_STALE_S = 40.0
+
+_ALLOWED_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "[::1]"})
+
+
+# --------------------------------------------------------------------------- #
+# Structured logging (JSON lines to stderr, like the receiver's journal usage)
+# --------------------------------------------------------------------------- #
+def log(event: str, **fields) -> None:
+    rec = {"ts": round(time.time(), 3), "event": event, **fields}
+    print(json.dumps(rec, ensure_ascii=False, separators=(",", ":")),
+          file=sys.stderr, flush=True)
+
+
+# --------------------------------------------------------------------------- #
+# Token
+# --------------------------------------------------------------------------- #
+def default_token_file() -> Path:
+    override = os.environ.get("BROWSER_BRIDGE_TOKEN_FILE")
+    if override:
+        return Path(override)
+    return Path.home() / ".config" / "browser-bridge" / "token"
+
+
+def load_or_create_token(path: Path) -> str:
+    """Return the bearer secret, creating it 0600 on first run.
+
+    The file holds a single `secrets.token_urlsafe(32)` line. Directory is
+    created 0700. An existing file is read verbatim (stripped) so restarts keep
+    the same token and the loaded extension does not need re-pairing.
+    """
+    path = Path(path)
+    if path.exists():
+        tok = path.read_text(encoding="utf-8").strip()
+        if tok:
+            return tok
+        # Empty/corrupt → regenerate below.
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    tok = secrets.token_urlsafe(32)
+    # Create with 0600 from the start (avoid a readable window between create and
+    # chmod): open with restrictive mode via os.open.
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, (tok + "\n").encode("utf-8"))
+    finally:
+        os.close(fd)
+    # Belt-and-suspenders in case the file pre-existed with looser perms.
+    os.chmod(path, 0o600)
+    return tok
+
+
+# --------------------------------------------------------------------------- #
+# Bridge — transport-agnostic rendezvous core (thread-safe, fully unit-testable)
+# --------------------------------------------------------------------------- #
+class BridgeTimeout(Exception):
+    """A submitted command was not answered within its deadline."""
+
+
+class NoExtension(Exception):
+    """No extension is currently connected to pick up the command."""
+
+
+class Bridge:
+    """Correlates skill commands with extension replies via ids.
+
+    `submit()` (skill side) enqueues a command and blocks for its reply.
+    `next_command()` (extension long-poll) dequeues the next pending command.
+    `deliver_result()` (extension) completes the matching `submit()`.
+
+    All state is guarded by a single Condition; ThreadingHTTPServer serves each
+    request in its own thread, so blocking here is safe and cheap.
+    """
+
+    def __init__(self, clock=time.monotonic):
+        self._cond = threading.Condition()
+        self._outbox: deque[dict] = deque()   # commands awaiting pickup
+        self._results: dict[str, dict] = {}    # id -> result payload
+        self._waiters: set[str] = set()        # ids with a live submit() waiting
+        self._active_polls = 0
+        self._last_poll = 0.0
+        self._clock = clock
+
+    # --- skill side -------------------------------------------------------- #
+    def submit(self, command: dict, timeout: float) -> dict:
+        """Enqueue `command` (a dict without id), block for its reply.
+
+        Raises NoExtension if nothing is connected to service it, or
+        BridgeTimeout if no reply arrives within `timeout` seconds.
+        """
+        with self._cond:
+            if not self._connected_locked():
+                raise NoExtension()
+            cid = secrets.token_hex(8)
+            cmd = dict(command)
+            cmd["id"] = cid
+            self._outbox.append(cmd)
+            self._waiters.add(cid)
+            self._cond.notify_all()  # wake a waiting poller
+            deadline = self._clock() + timeout
+            while cid not in self._results:
+                remaining = deadline - self._clock()
+                if remaining <= 0:
+                    self._waiters.discard(cid)
+                    self._drop_from_outbox_locked(cid)
+                    raise BridgeTimeout()
+                self._cond.wait(remaining)
+            self._waiters.discard(cid)
+            return self._results.pop(cid)
+
+    def _drop_from_outbox_locked(self, cid: str) -> None:
+        # Remove a still-unpicked command on timeout so a late poller never
+        # dispatches an already-abandoned request.
+        self._outbox = deque(c for c in self._outbox if c.get("id") != cid)
+
+    # --- extension side ---------------------------------------------------- #
+    def next_command(self, wait_timeout: float):
+        """Long-poll: block up to `wait_timeout` for the next command.
+
+        Returns the command dict (with its id) or None on timeout. Marks the
+        extension as connected for the duration + a stale window afterwards.
+        """
+        with self._cond:
+            self._active_polls += 1
+            self._last_poll = self._clock()
+            try:
+                deadline = self._clock() + wait_timeout
+                while not self._outbox:
+                    remaining = deadline - self._clock()
+                    if remaining <= 0:
+                        return None
+                    self._cond.wait(remaining)
+                return self._outbox.popleft()
+            finally:
+                self._active_polls -= 1
+                self._last_poll = self._clock()
+
+    def deliver_result(self, cid: str, payload: dict) -> bool:
+        """Record a reply for `cid`. Returns False if no submit() awaits it
+        (unknown/expired id) so the extension can log-and-drop."""
+        with self._cond:
+            if cid not in self._waiters:
+                return False
+            self._results[cid] = payload
+            self._cond.notify_all()
+            return True
+
+    # --- health ------------------------------------------------------------ #
+    def _connected_locked(self) -> bool:
+        if self._active_polls > 0:
+            return True
+        return (self._clock() - self._last_poll) < CONNECT_STALE_S
+
+    @property
+    def connected(self) -> bool:
+        with self._cond:
+            return self._connected_locked()
+
+
+# --------------------------------------------------------------------------- #
+# Command validation
+# --------------------------------------------------------------------------- #
+def validate_command(body):
+    """Return (op, None) if valid, else (None, error_string)."""
+    if not isinstance(body, dict):
+        return None, "body_not_object"
+    op = body.get("op")
+    if op not in ALLOWED_OPS:
+        return None, "unknown_op"
+    for field in REQUIRED_FIELDS.get(op, ()):
+        if not body.get(field):
+            return None, f"missing_field:{field}"
+    return op, None
+
+
+# --------------------------------------------------------------------------- #
+# HTTP handler
+# --------------------------------------------------------------------------- #
+def make_handler(bridge: Bridge, token: str, cmd_timeout: float,
+                 poll_timeout: float):
+    class Handler(BaseHTTPRequestHandler):
+        server_version = "browser-bridge/1"
+
+        # Suppress the default per-request stderr spam; we log structurally.
+        def log_message(self, *a):  # noqa: A003
+            pass
+
+        # --- helpers ------------------------------------------------------- #
+        def _send(self, code: int, obj=None, raw: bytes = None):
+            if raw is None:
+                raw = (json.dumps(obj, ensure_ascii=False,
+                                  separators=(",", ":")).encode("utf-8")
+                       if obj is not None else b"")
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            if raw and self.command != "HEAD":
+                self.wfile.write(raw)
+
+        def _host_ok(self) -> bool:
+            host = self.headers.get("Host", "")
+            # Strip the port (host:port or [::1]:port).
+            if host.startswith("["):
+                hostname = host.split("]")[0] + "]"
+            else:
+                hostname = host.split(":")[0]
+            return hostname in _ALLOWED_HOSTS
+
+        def _auth_ok(self) -> bool:
+            hdr = self.headers.get("Authorization", "")
+            prefix = "Bearer "
+            if not hdr.startswith(prefix):
+                return False
+            presented = hdr[len(prefix):].strip()
+            return secrets.compare_digest(presented, token)
+
+        def _guard(self) -> bool:
+            """Host + auth gate shared by every endpoint. Returns True to
+            proceed; has already sent the rejection response on False."""
+            if not self._host_ok():
+                log("reject", reason="bad_host", host=self.headers.get("Host"),
+                    path=self.path)
+                self._send(403, {"ok": False, "error": "bad_host"})
+                return False
+            if not self._auth_ok():
+                log("reject", reason="unauthorized", path=self.path)
+                self._send(401, {"ok": False, "error": "unauthorized"})
+                return False
+            return True
+
+        def _read_body(self, cap: int):
+            try:
+                length = int(self.headers.get("Content-Length") or 0)
+            except ValueError:
+                return None, "bad_length"
+            if length <= 0 or length > cap:
+                return None, "bad_length"
+            raw = self.rfile.read(length)
+            try:
+                obj = json.loads(raw.decode("utf-8"))
+            except (ValueError, UnicodeDecodeError):
+                return None, "bad_json"
+            return obj, None
+
+        # --- routes -------------------------------------------------------- #
+        def do_GET(self):
+            if not self._guard():
+                return
+            if self.path == "/health":
+                self._send(200, {"ok": True,
+                                 "extension_connected": bridge.connected})
+                return
+            if self.path == "/poll":
+                cmd = bridge.next_command(poll_timeout)
+                if cmd is None:
+                    self._send(204)
+                else:
+                    log("dispatch", id=cmd.get("id"), op=cmd.get("op"))
+                    self._send(200, cmd)
+                return
+            self._send(404, {"ok": False, "error": "not_found"})
+
+        def do_POST(self):
+            if not self._guard():
+                return
+            if self.path == "/cmd":
+                self._handle_cmd()
+            elif self.path == "/result":
+                self._handle_result()
+            else:
+                self._send(404, {"ok": False, "error": "not_found"})
+
+        def _handle_cmd(self):
+            body, err = self._read_body(MAX_CMD_BODY)
+            if err:
+                self._send(400, {"ok": False, "error": err})
+                return
+            op, verr = validate_command(body)
+            if verr:
+                self._send(400, {"ok": False, "error": verr,
+                                 "op": body.get("op") if isinstance(body, dict)
+                                 else None})
+                return
+            try:
+                result = bridge.submit(body, timeout=cmd_timeout)
+            except NoExtension:
+                log("cmd_no_extension", op=op)
+                self._send(503, {"ok": False, "error": "extension_not_connected"})
+                return
+            except BridgeTimeout:
+                log("cmd_timeout", op=op)
+                self._send(504, {"ok": False, "error": "timeout"})
+                return
+            log("cmd_ok", op=op)
+            self._send(200, {"ok": True, "result": result})
+
+        def _handle_result(self):
+            body, err = self._read_body(MAX_RESULT_BODY)
+            if err:
+                self._send(400, {"ok": False, "error": err})
+                return
+            if not isinstance(body, dict) or "id" not in body:
+                self._send(400, {"ok": False, "error": "missing_id"})
+                return
+            cid = body["id"]
+            delivered = bridge.deliver_result(cid, body)
+            if not delivered:
+                log("result_unknown_id", id=cid)
+                self._send(200, {"ok": False, "error": "unknown_id"})
+                return
+            self._send(200, {"ok": True})
+
+    return Handler
+
+
+# --------------------------------------------------------------------------- #
+# Entrypoint
+# --------------------------------------------------------------------------- #
+def build_server(host: str, port: int, bridge: Bridge, token: str,
+                 cmd_timeout: float, poll_timeout: float) -> ThreadingHTTPServer:
+    handler = make_handler(bridge, token, cmd_timeout, poll_timeout)
+    server = ThreadingHTTPServer((host, port), handler)
+    server.daemon_threads = True  # let shutdown not hang on a blocked long-poll
+    return server
+
+
+def main(argv=None) -> int:
+    host = os.environ.get("BROWSER_BRIDGE_HOST", "127.0.0.1")
+    port = int(os.environ.get("BROWSER_BRIDGE_PORT", "8788"))
+    cmd_timeout = float(os.environ.get("BROWSER_BRIDGE_CMD_TIMEOUT", "20"))
+    poll_timeout = float(os.environ.get("BROWSER_BRIDGE_POLL_TIMEOUT", "25"))
+    token_file = default_token_file()
+    token = load_or_create_token(token_file)
+
+    bridge = Bridge()
+    server = build_server(host, port, bridge, token, cmd_timeout, poll_timeout)
+    log("listening", host=host, port=port, token_file=str(token_file),
+        cmd_timeout=cmd_timeout, poll_timeout=poll_timeout)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/browser-bridge/tests/protocol.test.mjs
+++ b/scripts/browser-bridge/tests/protocol.test.mjs
@@ -1,0 +1,61 @@
+// Tests for the pure extension protocol logic (no chrome.* runtime needed).
+//
+// Covers: the op-set contract (MUST mirror server.py ALLOWED_OPS), command
+// validation, result/error envelope shapes, and the reconnect backoff curve.
+// The chrome.* glue in service_worker.js genuinely needs a real browser and is
+// covered by the manual checklist in ../extension/README.md.
+//
+// Run: nix-shell -p nodejs --run "node --test scripts/browser-bridge/tests/protocol.test.mjs"
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  ALLOWED_OPS, REQUIRED_FIELDS, validateCommand, resultEnvelope, errorEnvelope,
+  nextBackoffMs,
+} from "../extension/protocol.js";
+
+test("op set mirrors the server contract", () => {
+  // If this changes, server.py ALLOWED_OPS must change in lockstep.
+  assert.deepEqual(
+    [...ALLOWED_OPS].sort(),
+    ["eval", "getHtml", "nav", "screenshot", "tabs"],
+  );
+});
+
+test("validateCommand accepts a bare op", () => {
+  assert.deepEqual(validateCommand({ op: "tabs" }), { ok: true });
+  assert.deepEqual(validateCommand({ op: "getHtml" }), { ok: true });
+});
+
+test("validateCommand enforces required fields", () => {
+  assert.equal(validateCommand({ op: "eval" }).error, "missing_field:js");
+  assert.equal(validateCommand({ op: "nav" }).error, "missing_field:url");
+  assert.deepEqual(validateCommand({ op: "eval", js: "1+1" }), { ok: true });
+  assert.deepEqual(validateCommand({ op: "nav", url: "https://x" }), { ok: true });
+});
+
+test("validateCommand rejects unknown op / non-object", () => {
+  assert.equal(validateCommand({ op: "rm_rf" }).error, "unknown_op");
+  assert.equal(validateCommand(null).error, "body_not_object");
+  assert.equal(validateCommand("nope").error, "body_not_object");
+});
+
+test("REQUIRED_FIELDS matches the ops that need args", () => {
+  assert.deepEqual(REQUIRED_FIELDS.eval, ["js"]);
+  assert.deepEqual(REQUIRED_FIELDS.nav, ["url"]);
+});
+
+test("result / error envelopes carry the id", () => {
+  assert.deepEqual(resultEnvelope("abc", { html: "x" }),
+    { id: "abc", ok: true, data: { html: "x" } });
+  const e = errorEnvelope("abc", new Error("boom"));
+  assert.equal(e.id, "abc");
+  assert.equal(e.ok, false);
+  assert.match(e.error, /boom/);
+});
+
+test("backoff is exponential and capped", () => {
+  assert.equal(nextBackoffMs(0), 1000);
+  assert.equal(nextBackoffMs(1), 2000);
+  assert.equal(nextBackoffMs(3), 8000);
+  assert.equal(nextBackoffMs(99), 30000); // capped
+});

--- a/scripts/browser-bridge/tests/protocol.test.mjs
+++ b/scripts/browser-bridge/tests/protocol.test.mjs
@@ -10,7 +10,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   ALLOWED_OPS, REQUIRED_FIELDS, validateCommand, resultEnvelope, errorEnvelope,
-  nextBackoffMs,
+  nextBackoffMs, compileEval,
 } from "../extension/protocol.js";
 
 test("op set mirrors the server contract", () => {
@@ -58,4 +58,56 @@ test("backoff is exponential and capped", () => {
   assert.equal(nextBackoffMs(1), 2000);
   assert.equal(nextBackoffMs(3), 8000);
   assert.equal(nextBackoffMs(99), 30000); // capped
+});
+
+// --- compileEval: the expression/statement decision must never double-run a
+// side effect (regression for the old try/catch-then-fallback executor) ------ //
+test("compileEval evaluates a bare expression and returns its value", () => {
+  assert.equal(compileEval("2 * 21")(), 42);
+  assert.equal(compileEval("[1,2,3].length")(), 3);
+});
+
+test("compileEval falls back to the statement form when the expression can't parse", () => {
+  // `return (const x = 41; …)` is a *construction* SyntaxError → statement form.
+  globalThis.__ce_r = 0;
+  const fn = compileEval("const x = 41; globalThis.__ce_r = x + 1;");
+  fn();
+  assert.equal(globalThis.__ce_r, 42);
+  delete globalThis.__ce_r;
+});
+
+test("compileEval runs an expression's side effect EXACTLY ONCE even when it throws at runtime", () => {
+  // Expression parses fine, so no fallback — the runtime throw must propagate
+  // and the side effect must fire only once (the bug this fix closes).
+  globalThis.__ce_hits = 0;
+  const src = "(globalThis.__ce_hits++, (function () { throw new Error('boom'); })())";
+  const fn = compileEval(src);          // construction only — no side effect yet
+  assert.equal(globalThis.__ce_hits, 0, "construction must not execute the body");
+  assert.throws(() => fn(), /boom/);     // one call → one throw
+  assert.equal(globalThis.__ce_hits, 1, "side effect must run exactly once");
+  delete globalThis.__ce_hits;
+});
+
+test("compileEval routes a construction SyntaxError to the statement form (injectable ctor)", () => {
+  const calls = [];
+  const fakeCtor = (body) => {
+    calls.push(body);
+    if (body.startsWith("return (")) {
+      throw new SyntaxError("cannot wrap a statement as an expression");
+    }
+    return () => "stmt";
+  };
+  const fn = compileEval("var x = 1;", fakeCtor);
+  assert.equal(fn(), "stmt");
+  assert.deepEqual(calls, ["return (var x = 1;)", "var x = 1;"]);
+});
+
+test("compileEval propagates a non-SyntaxError construction failure without falling back", () => {
+  const calls = [];
+  const fakeCtor = (body) => {
+    calls.push(body);
+    throw new RangeError("nope");   // not a SyntaxError → must NOT fall back
+  };
+  assert.throws(() => compileEval("whatever", fakeCtor), RangeError);
+  assert.deepEqual(calls, ["return (whatever)"], "must not try the statement form");
 });

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -172,6 +172,77 @@ def test_host_with_port_allowed():
 
 
 # --------------------------------------------------------------------------- #
+# Command-delivery channel auth: /poll (extension long-poll) and /result must
+# enforce the SAME host + bearer gate as /health and /cmd. These are the two
+# endpoints that actually move commands, so they get direct coverage rather
+# than being tested only transitively. The guard runs before any polling/body
+# work, so a rejected request returns immediately (no poll_timeout wait).
+# --------------------------------------------------------------------------- #
+def test_poll_missing_token_401():
+    srv, _ = _serve()
+    try:
+        status, body = _req(srv, "GET", "/poll", token=None)
+        assert status == 401
+        assert body["error"] == "unauthorized"
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_poll_wrong_token_401():
+    srv, _ = _serve()
+    try:
+        status, body = _req(srv, "GET", "/poll", token="nope")
+        assert status == 401
+        assert body["error"] == "unauthorized"
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_poll_bad_host_403():
+    srv, _ = _serve()
+    try:
+        status, body = _req(srv, "GET", "/poll", host="evil.example.com")
+        assert status == 403
+        assert body["error"] == "bad_host"
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_result_missing_token_401():
+    srv, _ = _serve()
+    try:
+        status, body = _req(srv, "POST", "/result",
+                            {"id": "x", "ok": True, "data": {}}, token=None)
+        assert status == 401
+        assert body["error"] == "unauthorized"
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_result_wrong_token_401():
+    srv, _ = _serve()
+    try:
+        status, body = _req(srv, "POST", "/result",
+                            {"id": "x", "ok": True, "data": {}}, token="nope")
+        assert status == 401
+        assert body["error"] == "unauthorized"
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_result_bad_host_403():
+    srv, _ = _serve()
+    try:
+        status, body = _req(srv, "POST", "/result",
+                            {"id": "x", "ok": True, "data": {}},
+                            host="evil.example.com")
+        assert status == 403
+        assert body["error"] == "bad_host"
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
 # /health connection state
 # --------------------------------------------------------------------------- #
 def test_health_no_extension():

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -1,0 +1,377 @@
+"""Tests for the browser-bridge rendezvous server.
+
+Fully HEADLESS: no Brave, no network beyond loopback. The extension is
+simulated in-process by a `FakeExtension` thread that long-polls `/poll`,
+"executes" the op (echo), and POSTs to `/result` — exercising the real HTTP
+round-trip and the request↔reply id correlation.
+
+Run: nix-shell -p python312Packages.pytest --run "pytest scripts/browser-bridge/tests"
+"""
+import json
+import os
+import stat
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import server as S  # noqa: E402
+
+TOKEN = "test-token-abc123"
+
+
+# --------------------------------------------------------------------------- #
+# HTTP helpers
+# --------------------------------------------------------------------------- #
+def _req(srv, method, path, body=None, token=TOKEN, host="127.0.0.1"):
+    port = srv.server_address[1]
+    headers = {}
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    if host is not None:
+        headers["Host"] = host
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}", data=data, headers=headers,
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            raw = r.read()
+            return r.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        return e.code, (json.loads(raw) if raw else None)
+
+
+def _serve(cmd_timeout=5.0, poll_timeout=5.0):
+    bridge = S.Bridge()
+    handler = S.make_handler(bridge, TOKEN, cmd_timeout, poll_timeout)
+    srv = S.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    srv.daemon_threads = True
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    return srv, bridge
+
+
+class FakeExtension(threading.Thread):
+    """Simulated extension: long-polls /poll, echoes the op back via /result."""
+
+    def __init__(self, srv, executor=None, swallow=False):
+        super().__init__(daemon=True)
+        self.srv = srv
+        self.executor = executor or (lambda cmd: {"echo": cmd.get("op")})
+        self.swallow = swallow  # pick up a command but never answer (→ timeout)
+        self._stop = threading.Event()
+
+    def run(self):
+        while not self._stop.is_set():
+            try:
+                status, cmd = _req(self.srv, "GET", "/poll")
+            except Exception:
+                if self._stop.is_set():
+                    return
+                continue
+            if status == 204 or cmd is None:
+                continue
+            if self.swallow:
+                continue
+            envelope = {"id": cmd["id"], "ok": True, "data": self.executor(cmd)}
+            try:
+                _req(self.srv, "POST", "/result", envelope)
+            except Exception:
+                pass
+
+    def stop(self):
+        self._stop.set()
+
+
+def _wait_connected(srv, want=True, timeout=3.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        status, body = _req(srv, "GET", "/health")
+        if status == 200 and body["extension_connected"] == want:
+            return True
+        time.sleep(0.02)
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Token generation + perms
+# --------------------------------------------------------------------------- #
+def test_token_created_with_0600(tmp_path):
+    p = tmp_path / "sub" / "token"
+    tok = S.load_or_create_token(p)
+    assert tok and len(tok) >= 32
+    mode = stat.S_IMODE(os.stat(p).st_mode)
+    assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+
+
+def test_token_stable_across_calls(tmp_path):
+    p = tmp_path / "token"
+    a = S.load_or_create_token(p)
+    b = S.load_or_create_token(p)
+    assert a == b
+
+
+def test_empty_token_file_regenerated(tmp_path):
+    p = tmp_path / "token"
+    p.write_text("   \n")
+    tok = S.load_or_create_token(p)
+    assert tok.strip()
+    assert stat.S_IMODE(os.stat(p).st_mode) == 0o600
+
+
+# --------------------------------------------------------------------------- #
+# Auth + host allowlist
+# --------------------------------------------------------------------------- #
+def test_missing_token_401():
+    srv, _ = _serve()
+    try:
+        status, body = _req(srv, "GET", "/health", token=None)
+        assert status == 401
+        assert body["error"] == "unauthorized"
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_wrong_token_401():
+    srv, _ = _serve()
+    try:
+        status, body = _req(srv, "GET", "/health", token="nope")
+        assert status == 401
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_bad_host_403():
+    srv, _ = _serve()
+    try:
+        status, body = _req(srv, "GET", "/health", host="evil.example.com")
+        assert status == 403
+        assert body["error"] == "bad_host"
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_host_with_port_allowed():
+    srv, _ = _serve()
+    try:
+        status, _ = _req(srv, "GET", "/health", host="localhost:8788")
+        assert status == 200
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# /health connection state
+# --------------------------------------------------------------------------- #
+def test_health_no_extension():
+    srv, _ = _serve()
+    try:
+        status, body = _req(srv, "GET", "/health")
+        assert status == 200
+        assert body == {"ok": True, "extension_connected": False}
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_health_reflects_connected_extension():
+    srv, _ = _serve(poll_timeout=5.0)
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True), "extension never showed connected"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# /cmd round-trip
+# --------------------------------------------------------------------------- #
+def test_cmd_roundtrip_getHtml():
+    srv, _ = _serve()
+
+    def executor(cmd):
+        return {"html": "<html><body>hi</body></html>", "url": "https://x.test"}
+
+    ext = FakeExtension(srv, executor=executor)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        status, body = _req(srv, "POST", "/cmd", {"op": "getHtml"})
+        assert status == 200
+        assert body["ok"] is True
+        assert body["result"]["data"]["html"] == "<html><body>hi</body></html>"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_cmd_nav_requires_url():
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        status, body = _req(srv, "POST", "/cmd", {"op": "nav"})
+        assert status == 400
+        assert body["error"] == "missing_field:url"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_cmd_unknown_op_400():
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        status, body = _req(srv, "POST", "/cmd", {"op": "rm_rf"})
+        assert status == 400
+        assert body["error"] == "unknown_op"
+        assert body["op"] == "rm_rf"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_cmd_no_extension_503():
+    srv, _ = _serve()
+    try:
+        status, body = _req(srv, "POST", "/cmd", {"op": "getHtml"})
+        assert status == 503
+        assert body["error"] == "extension_not_connected"
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_cmd_timeout_504():
+    # Extension connects + picks up the command but never answers → 504.
+    srv, _ = _serve(cmd_timeout=0.5, poll_timeout=5.0)
+    ext = FakeExtension(srv, swallow=True)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        status, body = _req(srv, "POST", "/cmd", {"op": "getHtml"})
+        assert status == 504
+        assert body["error"] == "timeout"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_bad_json_body_400():
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        port = srv.server_address[1]
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/cmd", data=b"not-json{{",
+            headers={"Authorization": f"Bearer {TOKEN}", "Host": "127.0.0.1",
+                     "Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            urllib.request.urlopen(req, timeout=5)
+            assert False, "expected 400"
+        except urllib.error.HTTPError as e:
+            assert e.code == 400
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_result_unknown_id_reported():
+    srv, _ = _serve()
+    try:
+        status, body = _req(srv, "POST", "/result",
+                            {"id": "deadbeef", "ok": True, "data": {}})
+        assert status == 200
+        assert body["ok"] is False
+        assert body["error"] == "unknown_id"
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_unknown_path_404():
+    srv, _ = _serve()
+    try:
+        status, _ = _req(srv, "GET", "/nope")
+        assert status == 404
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# Bridge core: id correlation + concurrency (no HTTP)
+# --------------------------------------------------------------------------- #
+def test_bridge_id_correlation_out_of_order():
+    """Two concurrent submits get their OWN replies even when a mock extension
+    answers them in reverse order."""
+    bridge = S.Bridge()
+    # Prime "connected".
+    poll_done = threading.Event()
+
+    def poller():
+        # Simulate a connected extension that stays connected long enough.
+        while not poll_done.is_set():
+            cmd = bridge.next_command(0.2)
+            if cmd is not None:
+                picked.append(cmd)
+
+    picked = []
+    t = threading.Thread(target=poller, daemon=True)
+    t.start()
+
+    results = {}
+
+    def submit(tag):
+        results[tag] = bridge.submit({"op": "eval", "tag": tag}, timeout=3.0)
+
+    s1 = threading.Thread(target=submit, args=("A",), daemon=True)
+    s2 = threading.Thread(target=submit, args=("B",), daemon=True)
+    s1.start(); s2.start()
+
+    # Wait until both commands are picked up.
+    deadline = time.time() + 3
+    while len(picked) < 2 and time.time() < deadline:
+        time.sleep(0.01)
+    assert len(picked) == 2
+
+    # Answer in REVERSE order.
+    for cmd in reversed(picked):
+        bridge.deliver_result(cmd["id"], {"id": cmd["id"], "ok": True,
+                                          "data": {"tag": cmd["tag"]}})
+
+    s1.join(3); s2.join(3)
+    poll_done.set()
+    assert results["A"]["data"]["tag"] == "A"
+    assert results["B"]["data"]["tag"] == "B"
+
+
+def test_bridge_submit_no_extension_raises():
+    bridge = S.Bridge()
+    with pytest.raises(S.NoExtension):
+        bridge.submit({"op": "getHtml"}, timeout=0.2)
+
+
+def test_bridge_deliver_unknown_id_false():
+    bridge = S.Bridge()
+    assert bridge.deliver_result("nope", {"x": 1}) is False
+
+
+def test_validate_command_contract():
+    # The op set is the shared contract with extension/protocol.js.
+    assert set(S.ALLOWED_OPS) == {"getHtml", "eval", "tabs", "nav", "screenshot"}
+    assert S.validate_command({"op": "tabs"}) == ("tabs", None)
+    assert S.validate_command({"op": "eval", "js": "1"})[0] == "eval"
+    assert S.validate_command({"op": "eval"})[1] == "missing_field:js"
+    assert S.validate_command({"op": "bogus"})[1] == "unknown_op"
+    assert S.validate_command("nope")[1] == "body_not_object"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -52,6 +52,7 @@ HERMETIC_DIRS=(
   scripts/collector/claude/tests
   scripts/collector/i3/tests
   scripts/collector/browser-ext/tests
+  scripts/browser-bridge/tests
   scripts/validation/tests
   scripts/session-analysis/tests
   scripts/session-analysis/session_insight/tests


### PR DESCRIPTION
## What

A new **`scripts/browser-bridge/`** subsystem: a token-authenticated, loopback command channel that lets a Claude Code **`browser`** skill drive the user's **real, logged-in Brave** tab. Ops: `getHtml`, `eval`, `tabs`, `nav`, `screenshot`, `health`.

It is a **sibling** to the activity-collector's `scripts/collector/browser-ext/` (a one-way telemetry sink) — that extension and its receiver are **untouched**.

## Architecture

```
Claude skill (scripts/browser-bridge/browser)
   ──HTTP POST /cmd──▶ server.py (loopback rendezvous, 127.0.0.1:8788)
         GET /poll (long-poll) ◀──▶ MV3 extension service_worker.js (live Brave)
                                        chrome.scripting / tabs / captureVisibleTab
   ◀──────────────── POST /result ─────────────────────────────────────
```

**Transport = HTTP long-poll command queue** (not a WebSocket). An MV3 service worker can't bind a socket, so the local server is the rendezvous. The extension long-polls `GET /poll` (blocks until a command is queued or ~25s → 204 → re-poll); a pending fetch keeps the MV3 worker alive, so **the long-poll itself is the keepalive** — no RFC6455 ping. Chosen over a hand-rolled stdlib WebSocket because the rendezvous then stays pure `http.server` + `threading` and is **fully unit-testable with stdlib alone** against an in-process fake extension — **no new pip deps** (matches the receiver's stdlib-only footprint; the nix unit pins python312).

## Security model

- **Loopback-only** bind (`127.0.0.1`, env-overridable), port `8788` (distinct from the receiver's `8787`).
- **Bearer token on every endpoint** — skill requests *and* the extension long-poll. Secret auto-created `0600` at `~/.config/browser-bridge/token` (`secrets.token_urlsafe`) on first start; `401` otherwise. A DNS-rebinding page can't read the token file, so it can't forge a request.
- **Host-header allowlist** — only `127.0.0.1`/`localhost`/`::1` (`403` otherwise).
- Extension holds `<all_urls>` + `scripting` (maximal — noted as scope-down-able in `extension/README.md`).

## Files

- `server.py` — rendezvous server (Bridge core + HTTP handler).
- `extension/` — standalone MV3 extension: `manifest.json`, `service_worker.js` (long-poll + chrome.* executors), `protocol.js` (pure op-set/validation/envelope/backoff), `options.html`/`options.js` (paste token), `README.md`.
- `browser` — bash skill entrypoint; `SKILL.md` — Claude-facing skill doc.
- `README.md` — architecture, security, test + verify steps.
- `nix/home.nix` — `browser-bridge` systemd **user** service modelled exactly on `browser-activity-receiver` (loopback env, python312, `X-Restart-Triggers` on `server.py`, `WantedBy=default.target`) + a single-file `home.file` symlink (so the writable runtime token can coexist with the read-only nix-store script).
- `scripts/run-tests.sh` — registered the new test dir in the hermetic set.

## Test results

Python (`pytest scripts/browser-bridge/tests`): **21 passed** — token gen + `0600` perms, `401` missing/wrong token, `403` bad Host (and host:port allowed), `/health` connection state, `/cmd` round-trip vs an in-process fake extension, `503 extension_not_connected`, `504 timeout`, `400 unknown_op`/`missing_field`/bad-JSON, `unknown_id` result, and request↔reply id correlation incl. out-of-order replies.

Node (`node --test scripts/browser-bridge/tests/protocol.test.mjs`): **7 passed** — op-set contract mirrors `server.py`, validation, envelopes, capped exponential backoff.

The `browser` CLI was also smoke-tested end-to-end against an in-process fake extension (health/eval/tabs/nav/screenshot-to-PNG + a `401` path). `nix-instantiate --parse nix/home.nix` passes.

**Not** verified against a live browser — MV3 can't be driven headlessly. The chrome.* glue in `service_worker.js` is covered by a manual checklist in `extension/README.md`.

## Manual live-browser verification (the one step that needs real Brave)

1. `home-manager switch --flake ~/workspace/devrc --impure` (starts the `browser-bridge` service).
2. Brave → `brave://extensions` → Developer mode → **Load unpacked** → `scripts/browser-bridge/extension/`.
3. Extension **Options** → paste the token from `~/.config/browser-bridge/token`, port `8788`, **Save**.
4. `scripts/browser-bridge/browser health` → `{"ok":true,"extension_connected":true}`.
5. Focus a **logged-in** tab (e.g. Gmail) → `scripts/browser-bridge/browser html | grep -i <account-marker>` — logged-in-only markup proves it's the live authenticated session.

⚠ After editing anything in `extension/`, click **reload** ↻ on the card in `brave://extensions` (Brave doesn't hot-reload unpacked extensions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)