### PR TITLE
feat(repo-cos): fetch + scan at origin/<default-branch>, not the drifted local checkout

### DIFF
--- a/scripts/repo-cos/prescan.py
+++ b/scripts/repo-cos/prescan.py
@@ -24,6 +24,7 @@ import os
 import re
 import shutil
 import subprocess
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -117,6 +118,11 @@ class RepoScan:
     path: str
     candidates: list[Candidate] = field(default_factory=list)
     error: str | None = None
+    # Which filesystem state the content signals were scanned against. Set by
+    # `scan_repo_fresh` to one of `fresh-ref (origin/<branch>)` or
+    # `working-tree fallback (<reason>)` so the caller can log it (see scan.py). The
+    # bare `scan_repo` path leaves the default (it scans exactly the dir handed to it).
+    mode: str = "working-tree"
 
 
 # ---- filesystem walk ----------------------------------------------------------
@@ -389,37 +395,207 @@ def scan_stale_locks(root: Path, repo: str, cap: int, now: float | None = None,
     return res[:cap]
 
 
+# ---- fetch-before-scan: materialize the up-to-date committed ref -------------
+#
+# WHY: the scanners walk a filesystem tree. If that tree is a LOCAL checkout that has
+# drifted behind its remote (homelab-talos was once found 181 commits behind
+# origin/trunk), the digest (a) re-proposes already-merged work and (b) cites stale
+# line numbers — which destroys trust. So before scanning we `git fetch` and scan the
+# tree AT `origin/<default-branch>` (the up-to-date committed state) via a temporary,
+# DETACHED, LINKED worktree. This NEVER mutates the real repo's working tree — no
+# pull/checkout/reset/merge; `worktree add/remove` only touch git's admin area and a
+# throwaway temp dir. Any failure (offline, no remote, no origin/HEAD, add fails) falls
+# back to scanning the working tree exactly as before, so the weekly digest can't crash.
+
+_GIT_FETCH_TIMEOUT = 120  # seconds — best-effort; a slow/hung remote falls back
+_GIT_CMD_TIMEOUT = 30     # seconds — for the cheap plumbing (symbolic-ref, rev-parse)
+_GIT_WORKTREE_TIMEOUT = 60
+
+
+def _git(root: Path, args: list[str], timeout: int = _GIT_CMD_TIMEOUT) -> str | None:
+    """Run `git -C <root> <args>`; return stdout on success (rc 0), else None. Never
+    raises — a missing git binary / timeout / non-zero exit all collapse to None so the
+    caller treats them uniformly as "can't do the fresh-ref path → fall back"."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(root), *args],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def _is_git_repo(root: Path) -> bool:
+    """True iff `root` is inside a git working tree. Uses `rev-parse` so it's correct for
+    both a normal clone (`.git` dir) and an already-linked worktree (`.git` file); a
+    plain (non-git) fixture dir returns False → working-tree fallback (keeps the 214
+    existing tests, which scan non-git dirs, on the direct path)."""
+    return _git(root, ["rev-parse", "--is-inside-work-tree"]) is not None
+
+
+def _default_branch(root: Path) -> str | None:
+    """Resolve the remote's default branch name (e.g. `trunk`, `main`) for `root`.
+
+    Primary: `origin/HEAD` symbolic-ref → strip the `refs/remotes/origin/` prefix.
+    Fallback: the current branch's upstream (`@{upstream}` → `origin/main` → `main`).
+    Returns None when neither resolves (→ working-tree fallback)."""
+    out = _git(root, ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"])
+    if out and out.strip():
+        prefix = "refs/remotes/origin/"
+        ref = out.strip()
+        if ref.startswith(prefix):
+            branch = ref[len(prefix):]
+            if branch:
+                return branch
+    # Fallback: upstream of the currently checked-out branch, e.g. `origin/main`.
+    up = _git(root, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"])
+    if up and up.strip() and "/" in up.strip():
+        # `origin/main` → `main` (we always fetch + materialize `origin/<branch>` below).
+        branch = up.strip().split("/", 1)[1]
+        if branch:
+            return branch
+    return None
+
+
+def resolve_scan_root(repo_path: str | Path, *, fetch: bool = True):
+    """Produce a clean filesystem path to scan for `repo_path`, plus a mode label and a
+    cleanup callback. Returns `(scan_path: Path, mode: str, cleanup: callable)`.
+
+    fresh-ref path (default): fetch origin, then `git worktree add --detach <tmp>
+    origin/<default-branch>` into a system-temp dir (OUTSIDE any scanned repo so another
+    repo's walk can't pick it up) and hand back that tmp path. `cleanup()` removes the
+    worktree (`worktree remove --force` + best-effort `prune` + rmtree).
+
+    working-tree fallback: on `--no-fetch`, a non-git dir, no origin/HEAD, a failed
+    fetch, or a failed `worktree add`, return the ORIGINAL path with a no-op cleanup —
+    identical to the pre-existing behavior. `cleanup()` is ALWAYS safe to call (idempotent).
+    """
+    root = Path(repo_path).expanduser()
+
+    def _noop() -> None:
+        return None
+
+    if not fetch:
+        return root, "working-tree fallback (--no-fetch)", _noop
+    if not _is_git_repo(root):
+        return root, "working-tree fallback (not a git repo)", _noop
+    branch = _default_branch(root)
+    if not branch:
+        return root, "working-tree fallback (no origin/HEAD)", _noop
+    # Best-effort fetch — uses whatever git creds are configured (ssh/https). A failure
+    # (offline / auth / no remote) is non-fatal: fall back to the working tree.
+    fetched = _git(root, ["fetch", "--quiet", "origin"], timeout=_GIT_FETCH_TIMEOUT)
+    if fetched is None:
+        return root, "working-tree fallback (fetch failed)", _noop
+
+    # Materialize the fetched ref in a throwaway detached worktree. mkdtemp gives an
+    # empty dir; modern git happily `worktree add`s into an existing empty directory.
+    tmp = tempfile.mkdtemp(prefix="repo-cos-wt-")
+
+    def _cleanup() -> None:
+        # Remove the linked worktree WITHOUT touching the real working tree, then prune
+        # git's admin bookkeeping and delete the temp dir. Every step is best-effort so
+        # cleanup can never raise out of the `finally` that calls it.
+        _git(root, ["worktree", "remove", "--force", tmp], timeout=_GIT_WORKTREE_TIMEOUT)
+        _git(root, ["worktree", "prune"])
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    added = _git(
+        root, ["worktree", "add", "--quiet", "--detach", tmp, f"origin/{branch}"],
+        timeout=_GIT_WORKTREE_TIMEOUT,
+    )
+    if added is None:
+        _cleanup()  # nothing added, but scrub the temp dir + any partial admin state
+        return root, "working-tree fallback (worktree add failed)", _noop
+    return Path(tmp), f"fresh-ref (origin/{branch})", _cleanup
+
+
 # ---- per-repo orchestration ---------------------------------------------------
 
-def scan_repo(path: str, caps: dict[str, int] | None = None) -> RepoScan:
-    """Run every signal against one repo, each capped. Missing repo → RepoScan.error."""
+def scan_repo(path: str, caps: dict[str, int] | None = None, *,
+              repo_name: str | None = None,
+              lock_root: str | Path | None = None) -> RepoScan:
+    """Run every signal against one repo, each capped. Missing repo → RepoScan.error.
+
+    `path` is the tree the CONTENT signals (marker/skipped_test/churn/large_file) scan.
+    Two overrides support the fetch-before-scan wrapper (see `scan_repo_fresh`) without
+    changing the default direct-scan behavior:
+      • `repo_name` pins the display/evidence repo name. CRITICAL: when `path` is a temp
+        worktree, the real basename MUST be threaded through here — otherwise every
+        evidence `ref` (and `exclusions.json` matching, keyed on `repo/file:line`) would
+        carry the temp dir's name. Defaults to `path`'s basename (unchanged behavior).
+      • `lock_root` is where `stale_lock` scans. It stays the ORIGINAL working tree even
+        when content scans run against a fresh worktree: a freshly-checked-out worktree
+        stamps EVERY file's mtime to "now", so lockfiles would look freshly-touched and
+        the mtime-based stale_lock signal would silently no-op. Defaults to `path`.
+    """
     caps = caps or CAP_PER_SIGNAL
     root = Path(path).expanduser()
-    repo = root.name
+    repo = repo_name or root.name
     rs = RepoScan(repo=repo, path=str(root))
     if not root.exists() or not root.is_dir():
         rs.error = "not a directory"
         return rs
+    # stale_lock reads real mtimes → scan the original working tree, not a fresh worktree.
+    lock_path = Path(lock_root).expanduser() if lock_root is not None else root
     try:
         rs.candidates += scan_markers(root, repo, caps.get("marker", 8))
         rs.candidates += scan_skipped_tests(root, repo, caps.get("skipped_test", 8))
         rs.candidates += scan_churn(root, repo, caps.get("churn", 6))
         rs.candidates += scan_large_files(root, repo, caps.get("large_file", 5))
-        rs.candidates += scan_stale_locks(root, repo, caps.get("stale_lock", 3))
+        rs.candidates += scan_stale_locks(lock_path, repo, caps.get("stale_lock", 3))
     except Exception as exc:  # noqa: BLE001 — one bad repo shouldn't kill the scan
         rs.error = f"{type(exc).__name__}: {exc}"
     return rs
 
 
+def scan_repo_fresh(repo_path: str, caps: dict[str, int] | None = None, *,
+                    fetch: bool = True) -> RepoScan:
+    """Fetch-aware wrapper around `scan_repo`: resolve `repo_path` to a clean tree at the
+    up-to-date committed ref (fresh-ref mode), scan it with the REAL repo name preserved,
+    and always clean up the temp worktree. Falls back to the working tree on any failure.
+
+    Mirrors `scan_repo`'s per-repo isolation: a bad repo yields a RepoScan.error rather
+    than aborting the whole run. The reported `path` + `repo` are always the ORIGINAL
+    repo's, never the temp worktree's; `mode` records which tree was scanned."""
+    real_root = Path(repo_path).expanduser()
+    repo_name = real_root.name
+    if not real_root.exists() or not real_root.is_dir():
+        return RepoScan(repo=repo_name, path=str(real_root), error="not a directory")
+    try:
+        scan_path, mode, cleanup = resolve_scan_root(real_root, fetch=fetch)
+    except Exception as exc:  # noqa: BLE001 — resolver hiccup → treat as fallback, don't die
+        rs = scan_repo(str(real_root), caps, repo_name=repo_name)
+        rs.mode = f"working-tree fallback (resolve error: {type(exc).__name__})"
+        return rs
+    try:
+        # Content signals scan `scan_path` (fresh ref or working tree); stale_lock reads
+        # the ORIGINAL tree's mtimes; the evidence repo name stays the real basename.
+        rs = scan_repo(str(scan_path), caps, repo_name=repo_name, lock_root=real_root)
+        rs.path = str(real_root)  # report the real repo, not the temp worktree path
+        rs.mode = mode
+    finally:
+        cleanup()
+    return rs
+
+
 def scan_all(repos: list[str], limit_candidates: int,
-             caps: dict[str, int] | None = None) -> tuple[list[Candidate], list[RepoScan]]:
+             caps: dict[str, int] | None = None, *,
+             fetch: bool = True) -> tuple[list[Candidate], list[RepoScan]]:
     """Scan every repo, then apply a GLOBAL cap (`limit_candidates`) across all of them
     using round-robin interleaving so no single repo monopolizes the LLM budget.
+
+    `fetch=True` (default) scans each repo at its fetched `origin/<default-branch>` via a
+    temp worktree (see `scan_repo_fresh`); `fetch=False` (wired to `--no-fetch`) forces
+    the working-tree scan for every repo (offline/testing/speed).
 
     Returns (capped_candidates, per_repo_scans). The per-repo scans retain their full
     (pre-global-cap) candidate lists for reporting/--candidates-only.
     """
-    scans = [scan_repo(r, caps) for r in repos]
+    scans = [scan_repo_fresh(r, caps, fetch=fetch) for r in repos]
     capped = _interleave_cap([s.candidates for s in scans], limit_candidates)
     return capped, scans
 

--- a/scripts/repo-cos/scan.py
+++ b/scripts/repo-cos/scan.py
@@ -174,7 +174,17 @@ def cmd_scan(args) -> int:
               file=sys.stderr)
         return 2
 
-    candidates, scans = prescan.scan_all(repos, args.limit_candidates)
+    # Fetch each repo + scan at origin/<default-branch> by default so the digest reflects
+    # the up-to-date COMMITTED state, not a drifted local checkout (which re-proposes
+    # already-merged work + cites stale line numbers). --no-fetch forces the working-tree
+    # scan (offline/testing/speed). This NEVER mutates any working tree — see prescan.
+    candidates, scans = prescan.scan_all(
+        repos, args.limit_candidates, fetch=not args.no_fetch)
+
+    # Surface which tree each repo was scanned against — `fresh-ref (origin/<branch>)`
+    # vs `working-tree fallback (<reason>)` — so a silent drift-to-fallback is visible.
+    for s in scans:
+        print(f"  scan: {s.repo}: {s.mode}", file=sys.stderr)
 
     # ---- SUPPRESSED-RECOMMENDATION FILTER (drop suppressed proposals BEFORE the LLM) ----
     # A recommendation Zach replied "skip" (→ excl_state["dismissed"]) OR "approve" (→
@@ -411,6 +421,9 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--no-feedback", action="store_true",
                    help="skip pulling last week's emailed reply into synthesis AND the "
                         "deterministic exclusion parse (stateless run; for clean/testing)")
+    p.add_argument("--no-fetch", action="store_true",
+                   help="scan the working tree as-is instead of git-fetching + scanning "
+                        "at origin/<default-branch> (offline/testing/speed; default: fetch)")
     p.add_argument("--show-exclusions", action="store_true",
                    help="print the current deterministic repo-exclusion state and exit")
     p.add_argument("--repos", default=None,

--- a/scripts/repo-cos/tests/test_dismiss.py
+++ b/scripts/repo-cos/tests/test_dismiss.py
@@ -405,8 +405,8 @@ def test_scan_dismiss_filters_candidate_but_keeps_repo(tmp_path, monkeypatch):
     seen = {}
     orig = scan.prescan.scan_all
 
-    def spy_scan_all(repos, limit, caps=None):
-        return orig(repos, limit, caps)
+    def spy_scan_all(repos, limit, caps=None, *, fetch=True):
+        return orig(repos, limit, caps, fetch=fetch)
     monkeypatch.setattr(scan.prescan, "scan_all", spy_scan_all)
 
     def fake_synth(cands, *, top, model, feedback=None):

--- a/scripts/repo-cos/tests/test_exclusions.py
+++ b/scripts/repo-cos/tests/test_exclusions.py
@@ -369,9 +369,9 @@ def test_scan_reply_excludes_repo_from_synthesis(tmp_path, monkeypatch):
     seen = {}
     orig_scan_all = scan.prescan.scan_all
 
-    def spy_scan_all(repos, limit, caps=None):
+    def spy_scan_all(repos, limit, caps=None, *, fetch=True):
         seen["repos"] = list(repos)
-        return orig_scan_all(repos, limit, caps)
+        return orig_scan_all(repos, limit, caps, fetch=fetch)
 
     monkeypatch.setattr(scan.prescan, "scan_all", spy_scan_all)
     monkeypatch.setattr(llm, "synthesize",
@@ -434,9 +434,9 @@ def test_scan_no_feedback_skips_exclusion_parse(tmp_path, monkeypatch):
     seen = {}
     orig_scan_all = scan.prescan.scan_all
 
-    def spy_scan_all(repos, limit, caps=None):
+    def spy_scan_all(repos, limit, caps=None, *, fetch=True):
         seen["repos"] = list(repos)
-        return orig_scan_all(repos, limit, caps)
+        return orig_scan_all(repos, limit, caps, fetch=fetch)
     monkeypatch.setattr(scan.prescan, "scan_all", spy_scan_all)
     monkeypatch.setattr(llm, "synthesize",
                         lambda cands, *, top, model, feedback=None:

--- a/scripts/repo-cos/tests/test_prescan.py
+++ b/scripts/repo-cos/tests/test_prescan.py
@@ -4,7 +4,9 @@ per-repo capping, churn/large/lockfile signals, and global interleave cap.
 All fixtures are built on a real temp directory tree (tmp_path) so the file-walk,
 line-numbering, and ordering are exercised end-to-end without any network or git remote.
 """
+import os
 import shutil
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -20,6 +22,237 @@ def _write(root: Path, rel: str, content: str) -> Path:
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(content)
     return p
+
+
+# ---- git fixtures for fetch-before-scan --------------------------------------
+# Hermetic: a bare "remote" + a clone whose working tree DRIFTS behind origin. No
+# network. `origin/HEAD` is set explicitly so `_default_branch` resolves via symbolic-ref.
+
+_HAS_GIT = shutil.which("git") is not None
+requires_git = pytest.mark.skipif(not _HAS_GIT, reason="git not on PATH")
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True,
+                   capture_output=True, text=True)
+
+
+def _init_clone(tmp_path: Path, *, branch: str = "main") -> tuple[Path, Path]:
+    """Create a bare remote + a clone with one pushed commit on `branch`. origin/HEAD is
+    pointed at `branch`. Returns (clone_path, bare_path)."""
+    bare = tmp_path / "remote.git"
+    clone = tmp_path / "clone"
+    subprocess.run(["git", "init", "--quiet", "--bare", str(bare)], check=True,
+                   capture_output=True, text=True)
+    subprocess.run(["git", "clone", "--quiet", str(bare), str(clone)], check=True,
+                   capture_output=True, text=True)
+    _git(clone, "config", "user.email", "t@t")
+    _git(clone, "config", "user.name", "t")
+    _write(clone, "seed.py", "x = 1  # seed\n")
+    _git(clone, "add", "seed.py")
+    _git(clone, "commit", "--quiet", "-m", "seed")
+    _git(clone, "push", "--quiet", "origin", f"HEAD:{branch}")
+    # make `branch` the local + tracked branch and point origin/HEAD at it
+    _git(clone, "branch", "-M", branch)
+    _git(clone, "branch", f"--set-upstream-to=origin/{branch}", branch)
+    _git(clone, "remote", "set-head", "origin", branch)
+    return clone, bare
+
+
+def _push_drift(tmp_path: Path, bare: Path, rel: str, content: str, *,
+                branch: str = "main") -> None:
+    """Commit a NEW file to `origin/<branch>` that the `clone` working tree lacks — via a
+    throwaway second clone — so the primary clone is genuinely 'behind'."""
+    other = tmp_path / "pusher"
+    # Fresh clone per call so the pusher path is a throwaway; recreate it each time.
+    shutil.rmtree(other, ignore_errors=True)
+    subprocess.run(["git", "clone", "--quiet", str(bare), str(other)], check=True,
+                   capture_output=True, text=True)
+    _git(other, "config", "user.email", "t@t")
+    _git(other, "config", "user.name", "t")
+    # The bare's symbolic HEAD may not point at `branch`, so base the new commit on the
+    # existing `origin/<branch>` tip explicitly — otherwise we'd commit an unrelated root
+    # commit and the push would be a non-fast-forward.
+    _git(other, "checkout", "-B", branch, f"origin/{branch}")
+    _write(other, rel, content)
+    _git(other, "add", rel)
+    _git(other, "commit", "--quiet", "-m", "drift commit")
+    _git(other, "push", "--quiet", "origin", f"HEAD:{branch}")
+
+
+# ---- fetch-before-scan: fresh-ref materialization ----------------------------
+
+@requires_git
+def test_default_branch_resolves_via_origin_head(tmp_path):
+    clone, _ = _init_clone(tmp_path, branch="trunk")
+    assert prescan._default_branch(clone) == "trunk"
+
+
+@requires_git
+def test_resolve_scan_root_fresh_ref_sees_committed_drift(tmp_path):
+    # The working tree does NOT have drift.py, but origin/main does. Fresh-ref mode must
+    # scan the fetched ref, so the marker in drift.py appears.
+    clone, bare = _init_clone(tmp_path)
+    _push_drift(tmp_path, bare, "drift.py", "# TODO drifted marker\n")
+    assert not (clone / "drift.py").exists()  # working tree is genuinely behind
+
+    scan_path, mode, cleanup = prescan.resolve_scan_root(clone, fetch=True)
+    try:
+        assert mode == "fresh-ref (origin/main)"
+        assert Path(scan_path) != clone           # a temp worktree, not the real repo
+        assert (Path(scan_path) / "drift.py").exists()
+    finally:
+        cleanup()
+    # cleanup removed the temp worktree and left no bookkeeping behind
+    assert not Path(scan_path).exists()
+    wt = subprocess.run(["git", "-C", str(clone), "worktree", "list"],
+                        capture_output=True, text=True).stdout
+    assert str(scan_path) not in wt
+
+
+@requires_git
+def test_scan_repo_fresh_uses_real_repo_name_not_tempdir(tmp_path):
+    # #1 correctness requirement: evidence refs carry the REAL repo basename even though
+    # the scanned tree is a temp worktree with a random name.
+    clone, bare = _init_clone(tmp_path)
+    _push_drift(tmp_path, bare, "drift.py", "# TODO drifted marker\n")
+
+    rs = prescan.scan_repo_fresh(str(clone), fetch=True)
+    assert rs.error is None
+    assert rs.mode == "fresh-ref (origin/main)"
+    assert rs.repo == clone.name          # NOT the temp dir name
+    markers = [c for c in rs.candidates if c.kind == "marker"]
+    assert any(c.file == "drift.py" for c in markers)   # saw the committed-but-undrifted content
+    for c in rs.candidates:
+        assert c.repo == clone.name
+        assert c.ref.startswith(f"{clone.name}/")       # every ref uses the real name
+        assert "repo-cos-wt-" not in c.ref              # never the temp worktree path
+
+
+@requires_git
+def test_scan_repo_fresh_leaves_working_tree_untouched(tmp_path):
+    clone, bare = _init_clone(tmp_path)
+    _push_drift(tmp_path, bare, "drift.py", "# TODO drifted marker\n")
+    head_before = subprocess.run(["git", "-C", str(clone), "rev-parse", "HEAD"],
+                                 capture_output=True, text=True).stdout.strip()
+    branch_before = subprocess.run(
+        ["git", "-C", str(clone), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True).stdout.strip()
+
+    prescan.scan_repo_fresh(str(clone), fetch=True)
+
+    # working tree still behind (drift never checked out), HEAD + branch unchanged,
+    # and no leftover linked worktrees.
+    assert not (clone / "drift.py").exists()
+    head_after = subprocess.run(["git", "-C", str(clone), "rev-parse", "HEAD"],
+                                capture_output=True, text=True).stdout.strip()
+    assert head_after == head_before
+    branch_after = subprocess.run(
+        ["git", "-C", str(clone), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True).stdout.strip()
+    assert branch_after == branch_before
+    wt = subprocess.run(["git", "-C", str(clone), "worktree", "list"],
+                        capture_output=True, text=True).stdout
+    assert wt.count("\n") == 1  # only the main worktree remains
+
+
+@requires_git
+def test_no_fetch_scans_working_tree_not_ref(tmp_path):
+    # --no-fetch must skip fetch/worktree entirely → scan the working tree, so the
+    # origin-only drift is NOT seen.
+    clone, bare = _init_clone(tmp_path)
+    _push_drift(tmp_path, bare, "drift.py", "# TODO drifted marker\n")
+    _write(clone, "local.py", "# TODO local marker\n")  # only in the working tree
+
+    scan_path, mode, cleanup = prescan.resolve_scan_root(clone, fetch=False)
+    try:
+        assert mode == "working-tree fallback (--no-fetch)"
+        assert Path(scan_path) == clone
+    finally:
+        cleanup()
+
+    rs = prescan.scan_repo_fresh(str(clone), fetch=False)
+    files = {c.file for c in rs.candidates if c.kind == "marker"}
+    assert "local.py" in files       # working-tree content seen
+    assert "drift.py" not in files   # origin-only content NOT seen
+
+
+@requires_git
+def test_churn_works_against_fresh_ref_worktree(tmp_path):
+    # scan_churn shells out to `git log` — a linked worktree is a real git dir, so churn
+    # must still return the committed history (regression guard).
+    clone, bare = _init_clone(tmp_path)
+    # Push several commits touching the same file so it clears the >=3 hotspot threshold.
+    for i in range(4):
+        _push_drift(tmp_path, bare, "hot.py", f"# rev {i}\n")
+    scan_path, mode, cleanup = prescan.resolve_scan_root(clone, fetch=True)
+    try:
+        assert mode == "fresh-ref (origin/main)"
+        churn = prescan.scan_churn(Path(scan_path), clone.name, cap=10)
+        assert any(c.file == "hot.py" for c in churn)
+    finally:
+        cleanup()
+
+
+@requires_git
+def test_stale_lock_fires_against_working_tree_mtime_in_fresh_mode(tmp_path):
+    # REGRESSION GUARD: a fresh worktree stamps ALL files mtime=now, which would hide
+    # stale lockfiles. scan_repo_fresh must scan stale_lock against the ORIGINAL working
+    # tree (real mtimes), so a genuinely-old committed lockfile still fires.
+    clone, bare = _init_clone(tmp_path)
+    lock = _write(clone, "poetry.lock", "old\n")
+    _git(clone, "add", "poetry.lock")
+    _git(clone, "commit", "--quiet", "-m", "add lock")
+    _git(clone, "push", "--quiet", "origin", "HEAD:main")
+    old = time.time() - 400 * 86400
+    os.utime(lock, (old, old))  # make the WORKING-TREE copy genuinely old
+
+    rs = prescan.scan_repo_fresh(str(clone), fetch=True)
+    assert rs.mode == "fresh-ref (origin/main)"
+    stale = [c for c in rs.candidates if c.kind == "stale_lock"]
+    assert any(c.file == "poetry.lock" for c in stale), \
+        "stale_lock regressed to fresh-worktree mtime (should read the working tree)"
+
+
+# ---- fetch-before-scan: fallbacks --------------------------------------------
+
+def test_resolve_scan_root_non_git_dir_falls_back(tmp_path):
+    # A plain (non-git) directory → working-tree fallback, no crash. Keeps the 214
+    # existing non-git-fixture tests on the direct path.
+    _write(tmp_path, "a.py", "# TODO x\n")
+    scan_path, mode, cleanup = prescan.resolve_scan_root(tmp_path, fetch=True)
+    try:
+        assert Path(scan_path) == tmp_path
+        assert mode == "working-tree fallback (not a git repo)"
+    finally:
+        cleanup()
+
+
+def test_scan_repo_fresh_non_git_dir_scans_working_tree(tmp_path):
+    _write(tmp_path, "a.py", "# TODO real marker\n")
+    rs = prescan.scan_repo_fresh(str(tmp_path), fetch=True)
+    assert rs.error is None
+    assert rs.mode.startswith("working-tree fallback")
+    assert rs.repo == tmp_path.name
+    assert any(c.file == "a.py" for c in rs.candidates)
+
+
+def test_scan_repo_fresh_missing_dir_sets_error():
+    rs = prescan.scan_repo_fresh("/nonexistent/path/xyz")
+    assert rs.error is not None
+    assert rs.candidates == []
+
+
+def test_scan_all_fetch_false_scans_working_tree(tmp_path):
+    # non-git fixture dirs with fetch=False behave exactly like the legacy scan_all.
+    r1 = tmp_path / "r1"
+    r2 = tmp_path / "r2"
+    for r in (r1, r2):
+        _write(r, "a.py", "".join(f"# TODO {i}\n" for i in range(20)))
+    capped, scans = prescan.scan_all([str(r1), str(r2)], limit_candidates=5, fetch=False)
+    assert len(capped) == 5
+    assert len(scans) == 2
+    assert all(s.mode.startswith("working-tree fallback") for s in scans)
 
 
 # ---- markers ------------------------------------------------------------------

--- a/scripts/repo-cos/tests/test_scan_cli.py
+++ b/scripts/repo-cos/tests/test_scan_cli.py
@@ -225,3 +225,32 @@ def test_scan_feedback_fetch_failure_proceeds(tmp_path, monkeypatch):
 def test_no_feedback_flag_default_false():
     args = scan.build_parser().parse_args([])
     assert args.no_feedback is False
+
+
+def test_no_fetch_flag_default_false():
+    args = scan.build_parser().parse_args([])
+    assert args.no_fetch is False
+
+
+def test_no_fetch_flag_threads_into_scan_all(tmp_path, monkeypatch):
+    # --no-fetch must reach prescan.scan_all as fetch=False (working-tree scan).
+    _write(tmp_path, "a.py", "# TODO fix the thing\n")
+    seen = {}
+    real_scan_all = scan.prescan.scan_all
+
+    def spy(repos, limit, caps=None, *, fetch=True):
+        seen["fetch"] = fetch
+        return real_scan_all(repos, limit, caps, fetch=fetch)
+
+    monkeypatch.setattr(scan.prescan, "scan_all", spy)
+    args = scan.build_parser().parse_args(
+        ["--no-llm", "--no-fetch", "--repos", str(tmp_path)])
+    rc = scan.cmd_scan(args)
+    assert rc == 0
+    assert seen["fetch"] is False
+
+    # and the default (no flag) threads fetch=True
+    seen.clear()
+    args = scan.build_parser().parse_args(["--no-llm", "--repos", str(tmp_path)])
+    scan.cmd_scan(args)
+    assert seen["fetch"] is True


### PR DESCRIPTION
## Problem

repo-cos's Stage-1 pre-scan (`prescan.py`) walked each repo's **working-tree filesystem** directly (`os.walk`). But local workbench checkouts drift behind their remotes — `~/workspace/homelab-talos` was found **181 commits behind `origin/trunk`**, missing a merged CI fix. Consequences: the weekly digest (a) **re-proposed already-merged work** and (b) **cited stale line numbers**. That destroys trust in the digest.

## Approach

Before scanning, per repo, resolve a **clean filesystem tree at the up-to-date committed ref** and hand *that* to the existing scanners:

1. **Default branch** via `git symbolic-ref refs/remotes/origin/HEAD` → strip `refs/remotes/origin/` (e.g. `trunk`, `main`); fallback to the current branch's upstream.
2. **`git fetch --quiet origin`** (best-effort, 120s; uses existing ssh/https creds).
3. **Materialize the ref in a temporary DETACHED, LINKED worktree**: `git worktree add --detach <tmp> origin/<branch>` into a `tempfile.mkdtemp()` dir **outside any scanned repo**, scan it, and **always remove it in a `finally`** (`worktree remove --force` + best-effort `prune` + `rmtree`).

### Never mutates the working tree
No `pull`/`checkout`/`reset`/`merge` on the repo. `worktree add/remove` only touch git's admin area and a throwaway temp dir — local uncommitted work is untouched. Verified on the real `homelab-talos`: branch/HEAD/status unchanged, no leftover worktrees.

### Real repo name preserved (the #1 correctness requirement)
The scanners derive `Candidate.repo` from the scanned root's basename. Scanning a temp dir would make the repo name the temp dir's random name — breaking every evidence `ref` **and** `exclusions.json` matching (keyed on `repo/file:line`). `scan_repo` gains a `repo_name` override so the **real basename** is threaded through. A test asserts refs carry the real name (never `repo-cos-wt-…`) when scanning a fresh-ref worktree.

### stale_lock keeps real mtimes
A freshly-checked-out worktree stamps **all** files with mtime=now, so the mtime-based `stale_lock` signal would silently return nothing. `scan_repo` gains a `lock_root` override so `stale_lock` scans the **original working tree** even while the other signals run against the fresh ref. (marker/skipped_test/large_file/churn are pure content/git-log scans → fresh ref; churn works because a linked worktree is a real git dir.)

### Robust fallback (the weekly digest must never crash)
`--no-fetch`, a non-git dir, no `origin/HEAD`, a failed fetch, or a failed `worktree add` all fall back to the **working-tree scan** (current behavior). A single bad repo can't abort the run. Each repo logs `fresh-ref (origin/<branch>)` vs `working-tree fallback (<reason>)` to stderr.

### `--no-fetch`
New flag threaded through `scan.py` forces the working-tree scan (offline/testing/speed). Default = fetch-on.

## Implementation

Orchestration **wrapper**, not a rewrite of `scan_repo`'s internals: new `resolve_scan_root(repo_path, fetch=)` → `(scan_path, mode, cleanup)` and `scan_repo_fresh(repo_path, caps, fetch=)`; `scan_all` wires them. The direct `scan_repo(path)` path is preserved for tests + fallback.

## Tests

245 pass (13 new). New coverage: default-branch resolution, fresh-ref sees committed drift the working tree lacks, **real-repo-name preservation**, working-tree-untouched + no-leftover-worktree, `--no-fetch` scans the working tree (drift not seen), churn against a fresh-ref worktree, **stale_lock still fires against a genuinely-old lockfile under fresh-ref mode**, and non-git/missing-dir fallbacks. Three pre-existing `scan_all` mock spies updated for the new `fetch=` kwarg.

## Smoke run

`scan.py --no-llm --repos ~/workspace/homelab-talos` logged `scan: homelab-talos: fresh-ref (origin/trunk)`, scanned the up-to-date ref, and left the working tree + branch + worktree list unchanged with no leftover temp worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)