### PR TITLE
fix(repo-cos): drop conditional Go/Python skips from skipped_test signal

### DIFF
--- a/scripts/repo-cos/prescan.py
+++ b/scripts/repo-cos/prescan.py
@@ -40,6 +40,10 @@ _MARKER_QUOTE_CHARS = frozenset("'\"`")
 # candidate the LLM can drop, not a correctness bug).
 SKIP_PATTERNS: tuple[tuple[str, re.Pattern], ...] = (
     ("pytest.skip", re.compile(r"@pytest\.mark\.(skip|skipif|xfail)")),
+    # `pytest.skip(...)` is overloaded like the JS `.skip(` below: a bare body call is a
+    # disabled test → flag; but the `if <cond>: pytest.skip("dep missing")` form is a
+    # runtime guard that RUNS in CI (dep present) → `_is_conditional_py_skip` post-filters
+    # it out in `scan_skipped_tests` (a module-level `allow_module_level=True` skip stays).
     ("pytest.skip-call", re.compile(r"pytest\.skip\(")),
     # NB: `(it|describe|test).skip(` is overloaded. The *block-modifier* form
     # (`it.skip('name', fn)`, `describe.skip('suite', ...)`) is a genuinely DISABLED
@@ -51,6 +55,9 @@ SKIP_PATTERNS: tuple[tuple[str, re.Pattern], ...] = (
     # the conditional one in `scan_skipped_tests` (see it for the first-arg heuristic).
     ("js.skip", re.compile(r"\b(it|describe|test)\.skip\(")),
     ("js.xfail", re.compile(r"\.(only)\(")),  # .only leaves the rest un-run — same smell
+    # `t.Skip(`/`t.Skipf(`/`t.SkipNow(`: a top-of-func skip is disabled → flag; but the
+    # `if <cond> { t.Skip(…) }` form (e.g. clawgate `if dsn == "" { t.Skip(…) }`) is a
+    # graceful-degradation guard that RUNS in CI → `_is_conditional_go_skip` post-filters.
     ("go.skip", re.compile(r"\bt\.Skip(f|Now)?\(")),
     ("rust.ignore", re.compile(r"#\[ignore")),
     ("unittest.skip", re.compile(r"@unittest\.skip")),
@@ -279,6 +286,109 @@ def _is_conditional_js_skip(line: str) -> bool:
     return True       # first arg is a condition expression → conditional runtime guard
 
 
+# ---- Go / Python: conditional graceful-degradation guard vs disabled test -----
+#
+# Same conditional-vs-disabled distinction as `_is_conditional_js_skip`, generalized
+# to the two languages that flag `t.Skip(...)` / `pytest.skip(...)` unconditionally.
+# The false positive we must kill: a skip nested inside an `if <cond>:` runtime guard
+# that skips ONLY when an optional dependency is absent (so the test RUNS in CI where
+# the dep is present) — that's correct code, not a "re-enable me" fix.
+#
+# Real recurring cases that motivated this:
+#   • Go — clawgate `internal/agents/pgstore_test.go`:
+#         if dsn == "" {
+#             t.Skip("set CLAWGATE_TEST_DATABASE_URL to run the Postgres-backed test")
+#         }
+#     Runs in CI (DB present); skips locally when the DSN is unset. Flagged every week.
+#   • Python — devrc optional-dep guards:
+#         if not node:
+#             pytest.skip("node not on PATH")
+#         if ET._yaml is None:
+#             pytest.skip("PyYAML not available")
+#
+# Both use the enclosing-block opener, not the skip's own first arg (unlike JS), so
+# these helpers take the full `lines` list + the skip's 0-based index for context.
+#
+# CONSERVATIVE / recall-biased rule (both helpers): only an `if`/`elif`/`else`/`else if`
+# opener is treated as "conditional" (→ DROP). If the nearest shallower enclosing line is
+# anything else (`for`/`with`/`try`/`func`/`def`/`describe`/…) we do NOT treat it as
+# conditional → KEEP/flag. A rare `if > with > skip` nesting therefore stays flagged —
+# that's the safe direction: a flagged real conditional guard is the false positive we
+# want gone, but a KEPT genuinely-disabled test is only a candidate the LLM can drop.
+
+
+def _enclosing_opener(lines: list[str], idx: int) -> str | None:
+    """Return the nearest preceding non-blank line whose indentation is STRICTLY LESS
+    than line `idx`'s — i.e. the immediately-enclosing block opener. `idx` is 0-based.
+    Returns None if no shallower line precedes it (skip is at column 0 / file top)."""
+    def _indent(s: str) -> int:
+        return len(s) - len(s.lstrip())
+
+    target = _indent(lines[idx])
+    for j in range(idx - 1, -1, -1):
+        prev = lines[j]
+        if not prev.strip():
+            continue  # skip blank lines
+        if _indent(prev) < target:
+            return prev
+    return None
+
+
+# Go: an `if …{` / `} else if …{` / `} else {` opener (brace-and-indent based, no parse).
+_GO_IF_OPENER_RE = re.compile(r"^\s*(if\b|}\s*else\b)")
+
+# Python: an `if …:` / `elif …:` / `else:` opener (indent based, no parse).
+_PY_IF_OPENER_RE = re.compile(r"^\s*(if|elif)\b.*:\s*$|^\s*else\s*:\s*$")
+
+
+def _is_conditional_go_skip(lines: list[str], idx: int) -> bool:
+    """True when a Go `t.Skip(`/`t.Skipf(`/`t.SkipNow(` at line `idx` (0-based) is the
+    *conditional* graceful-degradation form — nested inside an `if <cond> { … }` guard —
+    rather than an unconditional top-of-function disabled test.
+
+    Two shapes, only one is a real "re-enable me" candidate:
+      • conditional guard — the skip's immediately-enclosing opener is `if …{` or
+        `} else if …{` (or a `} else {` in an if-chain): `if dsn == "" { t.Skip(…) }`
+        (the real clawgate `pgstore_test.go` case). The test RUNS when the condition is
+        false (the DB/dep is present in CI) → NOT disabled → must NEVER be flagged → DROP.
+      • unconditional disabled test — the enclosing opener is the `func …{` itself, so a
+        bare top-of-func `t.Skip("not implemented yet")` with no `if` between it and the
+        function signature. Genuinely disabled → a CI-verifiable candidate → KEEP/flag.
+
+    Heuristic: find the nearest preceding line shallower than the skip (its enclosing
+    block opener); return True iff that opener is an `if`/`} else if`/`} else` line."""
+    opener = _enclosing_opener(lines, idx)
+    if opener is None:
+        return False  # skip at top-level indentation — treat as unconditional → KEEP
+    return bool(_GO_IF_OPENER_RE.match(opener))
+
+
+def _is_conditional_py_skip(lines: list[str], idx: int) -> bool:
+    """True when a Python `pytest.skip(`/`self.skipTest(` at line `idx` (0-based) is the
+    *conditional* form — nested under an `if <cond>:` / `elif …:` / `else:` runtime guard
+    — rather than an unconditional disabled test.
+
+    Two shapes, only one is a real candidate:
+      • conditional guard — the enclosing opener is `if …:` / `elif …:` / `else:`:
+        `if not node:\n    pytest.skip("node not on PATH")` (the real devrc optional-dep
+        case), `if ET._yaml is None:\n    pytest.skip("PyYAML not available")`. The test
+        RUNS when the dep is present (in CI) → NOT disabled → must NEVER be flagged → DROP.
+      • unconditional disabled test — the enclosing opener is the `def …:` itself, so a
+        bare `pytest.skip("wip")` directly in the function body → genuinely disabled →
+        KEEP/flag.
+
+    Exception: a MODULE-LEVEL skip — `pytest.skip("…", allow_module_level=True)` — is an
+    intentional whole-module skip = a real signal, so KEEP it regardless of any enclosing
+    `if` (a module-level skip is idiomatically written under an `if <cond>:` import guard,
+    but it's still a deliberate "this module is off" marker worth surfacing)."""
+    if "allow_module_level" in lines[idx]:
+        return False  # intentional whole-module skip → a real signal → KEEP
+    opener = _enclosing_opener(lines, idx)
+    if opener is None:
+        return False  # skip at module top-level — treat as unconditional → KEEP
+    return bool(_PY_IF_OPENER_RE.match(opener))
+
+
 def scan_skipped_tests(root: Path, repo: str, cap: int) -> list[Candidate]:
     """Line-scan for skip/xfail/ignore markers across languages. A skipped test is a
     concrete, CI-verifiable fix — bias the LLM toward these."""
@@ -296,9 +406,16 @@ def scan_skipped_tests(root: Path, repo: str, cap: int) -> list[Candidate]:
                 continue
             for label, pat in SKIP_PATTERNS:
                 if pat.search(line):
-                    # A conditional `test.skip(<cond>, …)` is a runtime guard that runs
-                    # in CI, not a disabled test — never a candidate. See the helper.
+                    # Structure-aware post-filters: a conditional guard runs in CI, so
+                    # it's never a disabled-test candidate. `i` is 1-based → idx = i-1.
+                    # • JS: a conditional `test.skip(<cond>, …)` (first-arg heuristic).
                     if label == "js.skip" and _is_conditional_js_skip(line):
+                        continue
+                    # • Go: an `if <cond> { t.Skip(…) }` graceful-degradation guard.
+                    if label == "go.skip" and _is_conditional_go_skip(lines, i - 1):
+                        continue
+                    # • Python: an `if <cond>: pytest.skip(…)` optional-dep guard.
+                    if label == "pytest.skip-call" and _is_conditional_py_skip(lines, i - 1):
                         continue
                     res.append(Candidate(
                         repo, "skipped_test", _rel(root, p), i,

--- a/scripts/repo-cos/tests/test_prescan.py
+++ b/scripts/repo-cos/tests/test_prescan.py
@@ -449,6 +449,190 @@ def test_skipped_go_detected(tmp_path):
     assert any(c.line == 2 and "go.skip" in c.text for c in cands)
 
 
+# ---- skipped Go/Python: conditional graceful-degradation guard vs disabled ----
+# Generalizes #107's JS conditional-vs-disabled distinction to Go (`if <cond> { t.Skip }`)
+# and Python (`if <cond>: pytest.skip`). Motivated by recurring false positives: the
+# clawgate `pgstore_test.go` `if dsn == "" { t.Skip(…) }` DB guard and devrc optional-dep
+# guards (`if not node: pytest.skip("node not on PATH")`) — both RUN in CI, not disabled.
+
+def test_conditional_go_skip_not_flagged(tmp_path):
+    # The real clawgate case + t.Skipf / t.SkipNow siblings inside an `if` → NOT flagged.
+    _write(tmp_path, "pg_test.go",
+           "func TestPG(t *testing.T) {\n"
+           "\tdsn := os.Getenv(\"DB\")\n"
+           "\tif dsn == \"\" {\n"
+           "\t\tt.Skip(\"set DB to run\")\n"
+           "\t}\n"
+           "}\n"
+           "func TestPGf(t *testing.T) {\n"
+           "\tif dsn == \"\" {\n"
+           "\t\tt.Skipf(\"set %s\", \"DB\")\n"
+           "\t}\n"
+           "}\n"
+           "func TestPGNow(t *testing.T) {\n"
+           "\tif dsn == \"\" {\n"
+           "\t\tt.SkipNow()\n"
+           "\t}\n"
+           "}\n")
+    cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=10)
+    assert cands == []
+
+
+def test_conditional_go_skip_else_if_not_flagged(tmp_path):
+    # A skip in an `else if` / `else` chain is still a conditional guard → NOT flagged.
+    _write(tmp_path, "chain_test.go",
+           "func TestChain(t *testing.T) {\n"
+           "\tif a {\n"
+           "\t\tdoThing()\n"
+           "\t} else if b {\n"
+           "\t\tt.Skip(\"b path unsupported\")\n"
+           "\t} else {\n"
+           "\t\tt.Skip(\"default path unsupported\")\n"
+           "\t}\n"
+           "}\n")
+    cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=10)
+    assert cands == []
+
+
+def test_unconditional_go_skip_still_flagged(tmp_path):
+    # A bare top-of-func t.Skip (enclosing opener is the `func`, not an `if`) → flagged.
+    _write(tmp_path, "wip_test.go",
+           "func TestWip(t *testing.T) {\n"
+           "\tt.Skip(\"not implemented yet\")\n"
+           "}\n")
+    cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=10)
+    assert [c.line for c in cands] == [2]
+    assert "go.skip" in cands[0].text
+
+
+def test_go_skip_under_non_if_block_still_flagged(tmp_path):
+    # Conservative rule: a `for`/`with`-style enclosing block is NOT treated as
+    # conditional, so a skip nested under it stays flagged (recall-biased, safe direction).
+    _write(tmp_path, "loop_test.go",
+           "func TestLoop(t *testing.T) {\n"
+           "\tfor _, c := range cases {\n"
+           "\t\tt.Skip(\"todo per-case\")\n"
+           "\t}\n"
+           "}\n")
+    cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=10)
+    assert [c.line for c in cands] == [3]
+
+
+def test_conditional_go_skip_helper():
+    lines = [
+        "func TestPG(t *testing.T) {\n",   # 0
+        "\tif dsn == \"\" {\n",             # 1
+        "\t\tt.Skip(\"set DB\")\n",        # 2  → conditional
+        "\t}\n",                            # 3
+        "\tt.Skip(\"unconditional\")\n",  # 4  → enclosing opener is func → NOT conditional
+        "}\n",                              # 5
+    ]
+    assert prescan._is_conditional_go_skip(lines, 2) is True
+    assert prescan._is_conditional_go_skip(lines, 4) is False
+
+
+def test_conditional_py_skip_not_flagged(tmp_path):
+    # The real devrc optional-dep cases → NOT flagged.
+    _write(tmp_path, "test_dep.py",
+           "def test_node():\n"
+           "    if not node:\n"
+           "        pytest.skip(\"node not on PATH\")\n"
+           "\n"
+           "def test_yaml():\n"
+           "    if ET._yaml is None:\n"
+           "        pytest.skip(\"PyYAML not available\")\n")
+    cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=10)
+    assert cands == []
+
+
+def test_unconditional_py_skip_still_flagged(tmp_path):
+    # A bare pytest.skip in the function body (enclosing opener is the `def`) → flagged.
+    _write(tmp_path, "test_wip.py",
+           "def test_y():\n"
+           "    pytest.skip(\"wip\")\n")
+    cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=10)
+    assert [c.line for c in cands] == [2]
+    assert "pytest.skip" in cands[0].text
+
+
+def test_module_level_py_skip_still_flagged(tmp_path):
+    # `allow_module_level=True` is an intentional whole-module skip = a real signal →
+    # KEEP even though it sits under an `if <cond>:` import guard.
+    _write(tmp_path, "test_mod.py",
+           "import pytest\n"
+           "if sys.version_info < (3, 12):\n"
+           "    pytest.skip(\"needs 3.12\", allow_module_level=True)\n")
+    cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=10)
+    assert any(c.line == 3 and "pytest.skip" in c.text for c in cands)
+
+
+def test_py_mark_skip_decorator_still_flagged(tmp_path):
+    # The `@pytest.mark.skip` decorator form is unconditional → still flagged (matched by
+    # the `pytest.skip` pattern, untouched by the conditional post-filter).
+    _write(tmp_path, "test_dec.py",
+           "@pytest.mark.skip(reason='flaky')\n"
+           "def test_a():\n"
+           "    pass\n")
+    cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=10)
+    assert [c.line for c in cands] == [1]
+    assert "pytest.skip" in cands[0].text
+
+
+def test_py_skip_under_non_if_block_still_flagged(tmp_path):
+    # Conservative rule (Python): a `with`/`for` enclosing block is not conditional, so a
+    # skip nested under it stays flagged.
+    _write(tmp_path, "test_with.py",
+           "def test_w():\n"
+           "    with ctx():\n"
+           "        pytest.skip(\"todo inside ctx\")\n")
+    cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=10)
+    assert [c.line for c in cands] == [3]
+
+
+def test_conditional_py_skip_helper():
+    lines = [
+        "def test_x():\n",                        # 0
+        "    if not node:\n",                      # 1
+        "        pytest.skip(\"no node\")\n",     # 2  → conditional
+        "    pytest.skip(\"bare\")\n",            # 3  → enclosing opener is def → NOT cond.
+        "pytest.skip(\"m\", allow_module_level=True)\n",  # 4 → module-level → NOT cond.
+    ]
+    assert prescan._is_conditional_py_skip(lines, 2) is True
+    assert prescan._is_conditional_py_skip(lines, 3) is False
+    assert prescan._is_conditional_py_skip(lines, 4) is False
+
+
+def test_conditional_go_py_dropped_alongside_js(tmp_path):
+    # Regression guard: #107's JS path still works next to the new Go/Python filters —
+    # in a mixed tree, each language drops its conditional guard but keeps its disabled test.
+    _write(tmp_path, "mix.spec.ts",
+           "test.skip(!dockerAvailable(), 'guard');\n"
+           "it.skip('disabled thing', () => {});\n")
+    _write(tmp_path, "mix_test.go",
+           "func TestA(t *testing.T) {\n"
+           "\tif dsn == \"\" {\n"
+           "\t\tt.Skip(\"guard\")\n"
+           "\t}\n"
+           "}\n"
+           "func TestB(t *testing.T) {\n"
+           "\tt.Skip(\"disabled\")\n"
+           "}\n")
+    _write(tmp_path, "test_mix.py",
+           "def test_a():\n"
+           "    if not dep:\n"
+           "        pytest.skip(\"guard\")\n"
+           "def test_b():\n"
+           "    pytest.skip(\"disabled\")\n")
+    cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=20)
+    flagged = {(c.file, c.line) for c in cands}
+    assert ("mix.spec.ts", 2) in flagged      # JS disabled kept
+    assert ("mix.spec.ts", 1) not in flagged  # JS guard dropped
+    assert ("mix_test.go", 7) in flagged      # Go disabled kept
+    assert ("mix_test.go", 3) not in flagged  # Go guard dropped
+    assert ("test_mix.py", 5) in flagged      # Py disabled kept
+    assert ("test_mix.py", 3) not in flagged  # Py guard dropped
+
+
 def test_skipped_rust_ignore_detected(tmp_path):
     _write(tmp_path, "lib.rs", "#[ignore]\n#[test]\nfn t() {}\n")
     cands = prescan.scan_skipped_tests(tmp_path, "repo", cap=10)


### PR DESCRIPTION
## What

Generalizes #107's conditional-vs-disabled distinction (which only handled JS `test.skip(<cond>, …)`) to **Go** and **Python** in `prescan.py`'s `scan_skipped_tests`. Those two languages were still flagging *conditional graceful-degradation guards* unconditionally, producing recurring false positives in the weekly digest.

A skip nested inside an `if <cond>` guard **runs in CI** when the optional dependency is present and skips only when it's absent — that's correct code, not a "re-enable me" candidate.

## How

Two structure-aware post-filters mirror `_is_conditional_js_skip`, but use the skip's *enclosing block opener* (not its first arg), so they take `(lines, idx)`:

- **`_is_conditional_go_skip`** — DROPs `go.skip` matches whose immediately-enclosing opener is `if …{` / `} else if …{` / `} else {`.
  - Recurring FP: clawgate `internal/agents/pgstore_test.go` — `if dsn == "" { t.Skip(…) }` (all 6 `t.Skip` lines, flagged every week).
- **`_is_conditional_py_skip`** — DROPs `pytest.skip-call` matches whose enclosing opener is `if …:` / `elif …:` / `else:`.
  - Recurring FPs: devrc `if not node: pytest.skip("node not on PATH")` and `if ET._yaml is None: pytest.skip("PyYAML not available")`.

Both share `_enclosing_opener` (nearest preceding line of strictly-shallower indentation).

**Still flagged (regression guards):** bare top-of-func `t.Skip("not impl")`; bare body `pytest.skip("wip")`; `@pytest.mark.skip` decorator; module-level `pytest.skip(…, allow_module_level=True)` (an intentional whole-module skip = a real signal). JS path and non-skip patterns (`.only`/`#[ignore]`/`xfail`) untouched.

## Deliberate tradeoff

Recall-biased: only `if`/`elif`/`else`/`else if` openers count as conditional. Any other enclosing block (`for`/`with`/`try`/`func`/`def`) keeps the flag, so a rare `if > with > skip` nesting stays flagged — the safe direction. The accepted cost: a *genuinely-missing* conditional-skip CI gap will no longer be surfaced (accepted per maintainer's call — a flagged correct guard is the false positive we care about).

## Verification

- `python -m pytest scripts/repo-cos/tests -q` → **257 passed** (245 existing + 12 new).
- Real-world check against the actual recurring FP: scanning a copy of clawgate `pgstore_test.go` yields **0 `go.skip` candidates**, and all 6 `t.Skip` lines classify as conditional via `_is_conditional_go_skip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)