### PR TITLE
fix(ship): detect host by IP, not hostname; safe skills-sync direction

### DIFF
--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -1,16 +1,28 @@
 #!/usr/bin/env bash
-# ship — converge both hosts (workbench + laptop) to origin/main and verify.
+# ship — converge BOTH NixOS hosts (workbench + laptop) to origin/main + verify.
 #
 # Agent-callable deterministic deploy primitive. Replaces the manual,
 # error-prone per-host ritual (stash -> pull --ff-only -> home-manager
 # switch -> stash pop -> verify) with one idempotent command, so a config
 # change lands identically on both machines in a single tool call.
 #
+# Host identity: BOTH machines have hostname `nixos`, so we CANNOT tell them
+# apart by hostname. Instead we detect the physical host from its local IPv4
+# addresses (see detect_role) and derive the REMOTE (the other host) from that.
+# This is direction-agnostic: run it from EITHER host and it converges local +
+# the other one. Historically it hardcoded "local == workbench" and an SSH
+# target that was actually the laptop's own address — so running it on the
+# laptop mislabelled the laptop as workbench and SSH'd to itself while the real
+# workbench was never converged. Detection fixes that.
+#
 # Scope: home-manager (user-level) — the bulk of this repo's changes.
 # It does NOT run `sudo nixos-rebuild` (needs an interactive password);
 # system/i3 changes are surfaced as a remaining manual step, not attempted.
 # It ALSO rsyncs the per-host Claude skills (~/.claude/skills/, not in git/nix)
-# from the workbench to the laptop so the skill set does not drift between hosts.
+# from the WORKBENCH to the laptop so the skill set does not drift. The workbench
+# is the source of truth: the rsync ONLY runs when the LOCAL host is the
+# workbench (workbench -> laptop). Run from the laptop it is SKIPPED, never
+# pushing laptop skills back onto the workbench (which would clobber the source).
 #
 # Verifier (cheap + automatic): each host ends ON the `main` BRANCH at
 # HEAD == origin/main AND `home-manager switch` exits 0. It is not enough for
@@ -22,31 +34,100 @@
 # is skipped — never auto-rebased.
 #
 # Usage:
-#   scripts/ship.sh              # converge local (workbench) + laptop
-#   scripts/ship.sh --no-laptop  # local only
-#   scripts/ship.sh --no-local   # laptop only
+#   scripts/ship.sh              # converge local host + the other (remote) host
+#   scripts/ship.sh --no-remote  # local host only  (alias: --no-laptop)
+#   scripts/ship.sh --no-local   # remote host only
 #   scripts/ship.sh --no-switch  # land on main + verify git state, SKIP home-manager (test/dry-run)
+#   scripts/ship.sh --detect-role # print detected local role (workbench|laptop|unknown) and exit
 #
 # Env overrides:
-#   LAPTOP_SSH    laptop ssh target (default zach@10.42.0.100)
+#   SHIP_ROLE     force the local role (workbench|laptop) when detection fails/differs
+#   REMOTE_SSH    ssh target for the OTHER host (default derived from role)
+#   LAPTOP_SSH    back-compat: ssh target used ONLY when the remote host is the laptop
 #   SHIP_REPO     repo path the CONVERGE routine operates on (default $HOME/workspace/devrc)
 #   SHIP_NO_SWITCH=1  same as --no-switch: run full git-landing logic, skip home-manager switch
 set -uo pipefail
 
-LAPTOP_SSH="${LAPTOP_SSH:-zach@10.42.0.100}"
+# --- Canonical per-host identity (both hosts share hostname `nixos`) -----------
+# Primary signal: the stable LAN address (192.168.50.x) — reliable across boots.
+# Secondary signal: the 10.42.x address (less stable) — fallback only.
+WORKBENCH_IP_PRIMARY="192.168.50.250"
+WORKBENCH_IP_SECONDARY="10.42.0.30"
+LAPTOP_IP_PRIMARY="192.168.50.155"
+LAPTOP_IP_SECONDARY="10.42.0.100"
+WORKBENCH_SSH_DEFAULT="zach@192.168.50.250"
+LAPTOP_SSH_DEFAULT="zach@192.168.50.155"
+
+# detect_role <space-or-comma-separated ipv4 list> -> workbench|laptop|unknown
+# Pure + testable: takes an IP list as input (no live-machine calls), so it can
+# be unit-tested with injected addresses. Precedence is deterministic:
+#   1. primary LAN addresses (192.168.50.x) are matched before secondary ones;
+#   2. within a pass, WORKBENCH is matched before LAPTOP — so an (unexpected)
+#      list carrying BOTH hosts' primary addresses resolves to "workbench".
+detect_role() {
+  local ips="${1:-}"
+  ips="${ips//,/ }"
+  local ip
+  for ip in $ips; do [ "$ip" = "$WORKBENCH_IP_PRIMARY" ] && { echo workbench; return 0; }; done
+  for ip in $ips; do [ "$ip" = "$LAPTOP_IP_PRIMARY" ]    && { echo laptop;    return 0; }; done
+  for ip in $ips; do [ "$ip" = "$WORKBENCH_IP_SECONDARY" ] && { echo workbench; return 0; }; done
+  for ip in $ips; do [ "$ip" = "$LAPTOP_IP_SECONDARY" ]    && { echo laptop;    return 0; }; done
+  echo unknown
+  return 0
+}
+
+# local_ipv4s — global-scope IPv4 addresses of THIS machine, one per line
+# (scope global drops 127.0.0.1). Used as detect_role's input at runtime.
+local_ipv4s() {
+  ip -4 -o addr show scope global 2>/dev/null | awk '{print $4}' | cut -d/ -f1
+}
+
+# Hidden mode: print the role detected from an injected IP list (for tests) or,
+# with no list, from this machine's own addresses. Prints role, exits 0.
+if [ "${1:-}" = "--detect-role" ]; then
+  # With an explicit (even empty) IP-list arg, detect from it (testable);
+  # with no second arg, detect from THIS machine's own addresses.
+  if [ "$#" -ge 2 ]; then detect_role "$2"; else detect_role "$(local_ipv4s | tr '\n' ' ')"; fi
+  exit 0
+fi
+
 SHIP_REPO="${SHIP_REPO:-$HOME/workspace/devrc}"
 SHIP_NO_SWITCH="${SHIP_NO_SWITCH:-0}"
 DO_LOCAL=1
-DO_LAPTOP=1
+DO_REMOTE=1
 for a in "$@"; do
   case "$a" in
-    --no-laptop) DO_LAPTOP=0 ;;
-    --no-local)  DO_LOCAL=0 ;;
+    --no-remote|--no-laptop) DO_REMOTE=0 ;;   # skip the OTHER (remote) host
+    --no-local)  DO_LOCAL=0 ;;                # skip THIS (local) host
     --no-switch) SHIP_NO_SWITCH=1 ;;
-    -h|--help)   sed -n '2,33p' "$0"; exit 0 ;;
+    --detect-role) : ;;                        # handled above
+    -h|--help)   sed -n '2,48p' "$0"; exit 0 ;;
     *) echo "unknown arg: $a" >&2; exit 2 ;;
   esac
 done
+
+# --- Resolve local role (detection, override-able) + derive the remote target --
+SHIP_ROLE="${SHIP_ROLE:-}"
+if [ -z "$SHIP_ROLE" ]; then
+  SHIP_ROLE="$(detect_role "$(local_ipv4s | tr '\n' ' ')")"
+fi
+if [ "$SHIP_ROLE" != workbench ] && [ "$SHIP_ROLE" != laptop ]; then
+  echo "ship: could not identify this host (role='$SHIP_ROLE')." >&2
+  echo "  local IPv4s: $(local_ipv4s | tr '\n' ' ')" >&2
+  echo "  expected a workbench ($WORKBENCH_IP_PRIMARY) or laptop ($LAPTOP_IP_PRIMARY) address." >&2
+  echo "  override with SHIP_ROLE=workbench|laptop to force." >&2
+  exit 6
+fi
+
+if [ "$SHIP_ROLE" = workbench ]; then
+  REMOTE_ROLE=laptop
+  # remote is the laptop -> honor the back-compat LAPTOP_SSH override here.
+  REMOTE_SSH="${REMOTE_SSH:-${LAPTOP_SSH:-$LAPTOP_SSH_DEFAULT}}"
+else
+  REMOTE_ROLE=workbench
+  # remote is the workbench -> LAPTOP_SSH must NOT apply (it is the laptop itself).
+  REMOTE_SSH="${REMOTE_SSH:-$WORKBENCH_SSH_DEFAULT}"
+fi
 
 # Self-contained converge routine, run identically on each host (local via
 # bash -c, remote via ssh). Single source of truth for the sequence.
@@ -124,39 +205,46 @@ fi
 rc=0
 
 if [ "$DO_LOCAL" = 1 ]; then
-  echo "=== local (workbench) ==="
+  echo "=== local ($SHIP_ROLE) ==="
   SHIP_REPO="$SHIP_REPO" SHIP_NO_SWITCH="$SHIP_NO_SWITCH" bash -c "$CONVERGE" || rc=$?
   echo
 fi
 
-if [ "$DO_LAPTOP" = 1 ]; then
-  echo "=== laptop ($LAPTOP_SSH) ==="
+if [ "$DO_REMOTE" = 1 ]; then
+  echo "=== remote ($REMOTE_ROLE — $REMOTE_SSH) ==="
   # Pass the switch toggle remotely; SHIP_REPO stays host-default ($HOME/workspace/devrc).
-  if ssh -o ConnectTimeout=10 "$LAPTOP_SSH" "SHIP_NO_SWITCH=$SHIP_NO_SWITCH; $CONVERGE"; then :; else
-    laprc=$?
-    rc=$laprc
-    echo "[laptop] converge exited $laprc"
+  if ssh -o ConnectTimeout=10 "$REMOTE_SSH" "SHIP_NO_SWITCH=$SHIP_NO_SWITCH; $CONVERGE"; then :; else
+    remrc=$?
+    rc=$remrc
+    echo "[$REMOTE_ROLE] converge exited $remrc"
   fi
 
   # Sync per-host Claude skills (~/.claude/skills/ — NOT in git/nix; the workbench
   # is the source of truth where they're edited). Keeps the laptop's skill set from
   # drifting. Additive (NO --delete) so a laptop-only skill is never clobbered.
+  # DIRECTION-SAFE: only ever push workbench -> laptop. So the rsync runs ONLY when
+  # THIS host is the workbench (remote == laptop). Run FROM the laptop we SKIP it —
+  # never pushing the laptop's skills onto the workbench (would clobber the source).
   # Auxiliary + best-effort: a failure warns but never fails the ship. Skipped on a
   # --no-switch dry-run (it is a real file change, like the home-manager switch).
-  if [ "$SHIP_NO_SWITCH" != 1 ] && [ -d "$HOME/.claude/skills" ]; then
-    if rsync -az -e "ssh -o ConnectTimeout=10" "$HOME/.claude/skills/" "$LAPTOP_SSH:.claude/skills/" 2>/dev/null; then
-      echo "[laptop] skills synced (~/.claude/skills/)"
+  if [ "$SHIP_NO_SWITCH" = 1 ]; then
+    : # dry-run: no file changes
+  elif [ "$SHIP_ROLE" != workbench ]; then
+    echo "[$REMOTE_ROLE] skills sync skipped (workbench is source of truth; not pushing laptop -> workbench)"
+  elif [ -d "$HOME/.claude/skills" ]; then
+    if rsync -az -e "ssh -o ConnectTimeout=10" "$HOME/.claude/skills/" "$REMOTE_SSH:.claude/skills/" 2>/dev/null; then
+      echo "[$REMOTE_ROLE] skills synced (~/.claude/skills/)"
     else
-      echo "[laptop] ⚠ skill sync failed (non-fatal — check rsync on both hosts)"
+      echo "[$REMOTE_ROLE] ⚠ skill sync failed (non-fatal — check rsync on both hosts)"
     fi
   fi
   echo
 fi
 
 if [ "$rc" = 0 ]; then
-  echo "ship: both hosts converged + verified at origin/main."
+  echo "ship: converged + verified at origin/main (local=$SHIP_ROLE remote=$REMOTE_ROLE)."
 else
   echo "ship: incomplete (rc=$rc) — see per-host lines above."
-  echo "  rc8=diverged(needs rebase)  rc7=stash-pop-conflict  rc9=switch-failed"
+  echo "  rc6=host-unidentified  rc8=diverged(needs rebase)  rc7=stash-pop-conflict  rc9=switch-failed"
 fi
 exit "$rc"

--- a/scripts/tests/test_ship_detect_role.py
+++ b/scripts/tests/test_ship_detect_role.py
@@ -1,0 +1,68 @@
+"""Unit tests for ship.sh host-role detection (detect_role).
+
+Both NixOS hosts share hostname `nixos`, so ship.sh must identify the physical
+host from its local IPv4 addresses instead. `detect_role` is exposed as a pure,
+side-effect-free path via the hidden `ship.sh --detect-role "<ip,ip,...>"` mode:
+it consumes an INJECTED IP list (no live-machine / network / SSH calls) and
+prints one of workbench|laptop|unknown. These tests drive exactly that, so they
+are fully hermetic and headless.
+
+Precedence contract (mirrors the comment in ship.sh):
+  1. primary LAN addresses (192.168.50.x) match before secondary (10.42.x);
+  2. within a pass, WORKBENCH matches before LAPTOP — so a list carrying BOTH
+     hosts' primary addresses deterministically resolves to "workbench".
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SHIP = Path(__file__).resolve().parents[1] / "ship.sh"
+
+
+def detect_role(ip_list: str) -> str:
+    """Invoke ship.sh's hidden --detect-role mode with an injected IP list."""
+    out = subprocess.run(
+        ["bash", str(SHIP), "--detect-role", ip_list],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.strip()
+
+
+@pytest.mark.parametrize(
+    "ip_list,expected",
+    [
+        # --- workbench (primary LAN, secondary, mixed with noise) ---
+        ("192.168.50.250", "workbench"),
+        ("192.168.50.250 172.17.0.1 127.0.0.1", "workbench"),
+        ("10.42.0.30", "workbench"),                      # secondary-only fallback
+        ("172.17.0.1,10.42.0.30", "workbench"),           # comma-separated input
+        # --- laptop (primary LAN, secondary, mixed with noise) ---
+        ("192.168.50.155", "laptop"),
+        ("192.168.50.155,10.42.0.100,172.17.0.1", "laptop"),
+        ("10.42.0.100", "laptop"),                        # secondary-only fallback
+        # --- unknown (no canonical address present) ---
+        ("172.17.0.1 127.0.0.1", "unknown"),
+        ("", "unknown"),                                   # empty list
+        ("10.0.0.5", "unknown"),                           # unrelated address
+    ],
+)
+def test_detect_role(ip_list, expected):
+    assert detect_role(ip_list) == expected
+
+
+def test_primary_beats_secondary():
+    """A workbench primary + laptop secondary in one list -> workbench (primary wins)."""
+    assert detect_role("192.168.50.250 10.42.0.100") == "workbench"
+    # symmetric: laptop primary + workbench secondary -> laptop
+    assert detect_role("192.168.50.155 10.42.0.30") == "laptop"
+
+
+def test_ambiguous_both_primaries_resolves_to_workbench():
+    """Both hosts' PRIMARY addresses present (unexpected) -> deterministic workbench."""
+    assert detect_role("192.168.50.155 192.168.50.250") == "workbench"
+    # order of the input list must not change the outcome
+    assert detect_role("192.168.50.250 192.168.50.155") == "workbench"


### PR DESCRIPTION
## The bug (confirmed live)

`scripts/ship.sh` converges both NixOS hosts to `origin/main`. **Both hosts have hostname `nixos`**, so hostname can't distinguish them — yet the script:

- hardcoded `LAPTOP_SSH=zach@10.42.0.100`, which is actually the **laptop's own** address;
- labelled the local host `workbench` unconditionally;
- rsynced `~/.claude/skills/` local → laptop assuming **local == workbench == source of truth**.

Consequence: run **on the laptop**, ship.sh (a) mislabelled the laptop as "workbench" and (b) SSH'd to `10.42.0.100` = **itself** (host-key/askpass failure), while the **real workbench at `192.168.50.250` was never converged**. It only worked from the workbench by coincidence (local really was the workbench there).

## Detection approach

New pure function `detect_role(ip_list) -> workbench|laptop|unknown` matches the machine's local IPv4 addresses against canonical per-host addresses — **not hostname**:

- **Primary signal:** stable LAN `192.168.50.x` (`.250` = workbench, `.155` = laptop).
- **Secondary/fallback:** `10.42.x` (`.30` = workbench, `.100` = laptop) — less stable, matched only if no primary hits.
- **Deterministic precedence:** primary before secondary; within a pass, workbench before laptop (so an ambiguous list carrying both hosts' primaries resolves to `workbench`).

Local role + remote target are **derived from detection**, not assumed:
- remote SSH is the OTHER host's real address (from laptop → `zach@192.168.50.250`; from workbench → `zach@192.168.50.155`).
- `REMOTE_SSH` env override added; `LAPTOP_SSH` kept as back-compat but honored **only when the remote is actually the laptop**.
- `unknown` host → **exit 6, loud message**, overridable via `SHIP_ROLE=workbench|laptop`.
- Flags are host-aware: `--no-local` skips this host; `--no-remote` skips the other host (`--no-laptop` kept as a back-compat alias).

## Rsync direction-safety fix

The workbench is the source of truth for `~/.claude/skills/`. The rsync is now **direction-locked to workbench → laptop**: it runs only when THIS host is the workbench. Run **from the laptop it is SKIPPED** (logged), so the laptop can never push its skills back and clobber the workbench source. Still guarded by `--no-switch` (no file changes on a dry-run).

## Tests

- Hidden `scripts/ship.sh --detect-role "<ip,ip,...>"` mode exposes `detect_role` for hermetic testing (injected IPs, no network/SSH/HM).
- `scripts/tests/test_ship_detect_role.py` (auto-collected under `scripts/tests` in `run-tests.sh`'s hermetic set) — 12 cases: workbench/laptop primary + secondary, noise, comma input, empty/unknown, primary-beats-secondary, and the ambiguous-both-primaries → workbench precedence.

```
$ pytest scripts/tests/test_ship_detect_role.py
12 passed in 0.05s
```

- `bash -n scripts/ship.sh` → OK.
- `shellcheck` → only the two **pre-existing** SC2016 (info) findings inside the intentionally single-quoted `CONVERGE` remote-payload string (unchanged by this PR; single-quoting is deliberate so the payload runs on the remote).
- Existing `scripts/tests/ship-converge.test.sh` landing-logic suite → ALL PASS (no regression).

## Detection-only proof (run on the laptop, zero side effects)

```
$ ship.sh --detect-role
laptop
$ SHIP_NO_SWITCH=1 ship.sh --no-local --no-remote
ship: converged + verified at origin/main (local=laptop remote=workbench).
# remote header (stubbed ssh, no real converge):
=== remote (workbench — zach@192.168.50.250) ===
# forced workbench role (symmetry):
=== remote (laptop — zach@192.168.50.155) ===
# from laptop, skills sync is refused:
[workbench] skills sync skipped (workbench is source of truth; not pushing laptop -> workbench)
```

**Verified:** host identity + remote-target derivation + rsync-direction safety, all without a real home-manager switch or SSH converge. **Not yet verified:** a real end-to-end deploy from the workbench (needs a live run on that host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)