### PR TITLE
feat(browser-bridge): per-command activity telemetry (metadata-only, best-effort)

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -124,6 +124,38 @@ structured error: `503 extension_not_connected`, `504 timeout`,
 `GET /health` → `{"ok":true,"extension_connected":bool,"count":N,"instances":[{key,label,instanceId,activeTab},…]}`.
 `GET /instances` → `{"ok":true,"count":N,"instances":[…]}`.
 
+## Telemetry (activity pipeline)
+
+Each **handled command** (`getHtml`/`eval`/`tabs`/`nav`/`screenshot`, incl. its
+error/ambiguous outcomes) emits **one** event into the personal
+activity-telemetry pipeline, so browser-skill usage is first-class self-telemetry
+in ClickHouse `activity.events`:
+
+- **`source="browser-bridge"`, `kind="cmd"`** — a *distinct* source from the
+  collector's `browser` (nav/scroll) source; the two are kept separate.
+- **Fields:** `text` = the active-tab bare **domain** (or the op when no domain),
+  `duration_ms` = server-side latency, `exit_code` = 0/1, and a tiny `payload`
+  JSON `{op, key, outcome[, domain]}` (`key` = the `--instance` routing target,
+  empty for the implicit single-instance case; `outcome` ∈
+  `ok|no_extension|ambiguous|unknown_instance|superseded|timeout`).
+- **METADATA-ONLY (privacy):** it emits **only** the op name, instance key,
+  outcome, latency, and the active tab's **bare domain** — **never** the eval
+  source, page HTML, screenshot bytes/data-URLs, a full URL with path/query, or
+  any page content.
+- **Best-effort / fire-and-forget:** emitting runs **after** the HTTP response is
+  sent and can never delay or break a command — a missing collector, unwritable
+  spool, or any exception is swallowed and the command still succeeds. No new
+  deps: it reuses the collector's `scripts/collector/keylog/spool_emit.py`
+  (single source of truth for the v1 line format), located by its stable
+  absolute repo path (`~/workspace/devrc/…`) because `server.py` is deployed as a
+  flat `/nix/store` symlink so `__file__` can't find the sibling collector tree.
+- `health`/`instances`/`poll`/`result` are noise and deliberately do **not** emit.
+
+Feeds the `activity.events` table (and, once its registry learns the source,
+`adoption-scan`). The live end-to-end check (needs the running collector + real
+Brave): run any `browser` command, then confirm a `source='browser-bridge'` row
+landed in `activity.events`.
+
 ## Icon
 
 A gruvbox-tinted **bridge / chain-link** glyph (blue loopback node linked to the

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -65,6 +65,17 @@ else a stable auto-id; labels must be unique per host).
   reads it; a web page can't. Defeats DNS-rebinding.
 - **Host-header allowlist** — only `127.0.0.1`/`localhost`/`::1`.
 
+## Telemetry (metadata-only)
+
+Every handled command emits one **best-effort** activity event
+(`source=browser-bridge`, `kind=cmd`) into the personal telemetry pipeline
+(`activity.events`), so browser-skill usage is queryable / visible to
+`adoption-scan`. It records **only** metadata — op, instance key, outcome,
+latency, and the active tab's **bare domain** — **never** the eval source, page
+HTML, screenshot bytes, full URLs, or any page content. It runs off the critical
+path and can never delay or break a command. Nothing you need to do; noted so you
+know browser usage is being counted. Details: `README.md` → Telemetry.
+
 ## Before you rely on it
 
 1. `browser health` — if `extension_connected:false` or it errors, the extension

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -133,6 +133,116 @@ def log(event: str, **fields) -> None:
 
 
 # --------------------------------------------------------------------------- #
+# Activity telemetry (best-effort, fire-and-forget, METADATA-ONLY)
+# --------------------------------------------------------------------------- #
+# Each handled command emits ONE event into the personal activity pipeline
+# (source="browser-bridge", kind="cmd") so browser-skill usage is first-class
+# self-telemetry — queryable in ClickHouse activity.events. This is a DISTINCT
+# source from the collector's `browser` (nav/scroll) source; keep them separate.
+#
+# PRIVACY CONTRACT (do not weaken): we emit ONLY metadata — the op name, the
+# instance routing key, the outcome, the server-side latency, and (best-effort)
+# the active tab's BARE DOMAIN. We NEVER emit the eval source, page HTML,
+# screenshot bytes/data-URLs, a full URL with path/query, or any page content.
+# The payload stays tiny.
+#
+# BEST-EFFORT CONTRACT (do not weaken): emitting must never affect command
+# handling. The emitter is discovered lazily by absolute path and every failure
+# mode (missing module, unwritable spool, any exception) is swallowed — the
+# browser command still succeeds. It runs OFF the critical path (after the HTTP
+# response is sent) and only does a local spool append (no network, no fork), so
+# it can neither delay nor break a request.
+
+# The activity spool emitter (scripts/collector/keylog/spool_emit.py) is the
+# single source of truth for the v1 spool line format, so we DON'T hand-roll it.
+# server.py is deployed as a FLAT single-file /nix/store symlink by home-manager,
+# so Path(__file__) does NOT sit next to the collector tree (and .resolve() would
+# only make that worse — cf. the receiver's documented no-.resolve() gotcha). We
+# therefore locate the emitter by its stable ABSOLUTE repo path (identical on
+# both hosts) and degrade gracefully if it is absent (collector not checked out →
+# telemetry simply off). BROWSER_BRIDGE_SPOOL_EMIT overrides the path (tests).
+_SPOOL_EMIT_PATH = Path(
+    os.environ.get("BROWSER_BRIDGE_SPOOL_EMIT")
+    or (Path.home() / "workspace" / "devrc" / "scripts" / "collector"
+        / "keylog" / "spool_emit.py")
+)
+_spool_emit_mod = None
+_spool_emit_tried = False
+
+
+def _load_spool_emit():
+    """Import the activity spool emitter by absolute path, once. Returns the
+    module or None (best-effort — a missing/broken emitter just disables
+    telemetry, never raises)."""
+    global _spool_emit_mod, _spool_emit_tried
+    if _spool_emit_tried:
+        return _spool_emit_mod
+    _spool_emit_tried = True
+    try:
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "browser_bridge_spool_emit", str(_SPOOL_EMIT_PATH))
+        if spec is None or spec.loader is None:
+            return None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        _spool_emit_mod = mod
+    except Exception:  # noqa: BLE001 — telemetry is strictly best-effort.
+        _spool_emit_mod = None
+    return _spool_emit_mod
+
+
+def _domain_from_result(result) -> str:
+    """BARE hostname from a command result envelope, for telemetry only.
+
+    Reads ONLY a `url`-named field (never HTML/screenshot bytes) and returns its
+    hostname component — NO scheme, NO path, NO query, NO port. A data: URL (a
+    screenshot) has no hostname → "". Any problem → "".
+    """
+    try:
+        url = None
+        if isinstance(result, dict):
+            data = result.get("data")
+            if isinstance(data, dict) and isinstance(data.get("url"), str):
+                url = data["url"]
+            elif isinstance(result.get("url"), str):
+                url = result["url"]
+        if not url:
+            return ""
+        return urlsplit(url).hostname or ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def emit_cmd_event(op: str, key: str, outcome: str, duration_ms: int,
+                   domain: str = "", exit_code: int = 0) -> None:
+    """Append ONE metadata-only activity event for a handled command.
+
+    Best-effort + fire-and-forget: any failure is swallowed so telemetry can
+    never break command handling. See the PRIVACY / BEST-EFFORT contracts above.
+    """
+    try:
+        se = _load_spool_emit()
+        if se is None:
+            return
+        # METADATA ONLY — op/key/outcome/(bare)domain. Never page content.
+        payload = {"op": op, "key": key, "outcome": outcome}
+        if domain:
+            payload["domain"] = domain
+        se.emit({
+            "source": "browser-bridge",
+            "kind": "cmd",
+            "text": domain or op,
+            "duration_ms": int(duration_ms),
+            "exit_code": int(exit_code),
+            "payload": json.dumps(payload, ensure_ascii=False,
+                                  separators=(",", ":")),
+        })
+    except Exception:  # noqa: BLE001 — strictly best-effort.
+        pass
+
+
+# --------------------------------------------------------------------------- #
 # Token
 # --------------------------------------------------------------------------- #
 def default_token_file() -> Path:
@@ -564,12 +674,16 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                 self._send(404, {"ok": False, "error": "not_found"})
 
         def _handle_cmd(self):
+            t0 = time.monotonic()
             body, err = self._read_body(MAX_CMD_BODY)
             if err:
+                # Malformed request — never reached an instance; not a real op
+                # dispatch, so no telemetry (as with health/instances/poll).
                 self._send(400, {"ok": False, "error": err})
                 return
             op, verr = validate_command(body)
             if verr:
+                # Invalid/unknown op — not one of the five real ops → no event.
                 self._send(400, {"ok": False, "error": verr,
                                  "op": body.get("op") if isinstance(body, dict)
                                  else None})
@@ -577,35 +691,45 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
             # `target` is a skill-side routing hint, NOT part of the command the
             # extension executes — strip it before enqueue.
             target = body.pop("target", None)
+            outcome, exit_code, domain = "ok", 0, ""
             try:
                 result = registry.submit(body, timeout=cmd_timeout,
                                          target=target)
             except NoExtension:
+                outcome, exit_code = "no_extension", 1
                 log("cmd_no_extension", op=op)
                 self._send(503, {"ok": False,
                                  "error": "extension_not_connected"})
-                return
             except AmbiguousInstance as e:
+                outcome, exit_code = "ambiguous", 1
                 log("cmd_ambiguous", op=op, count=len(e.instances))
                 self._send(409, {"ok": False, "error": "ambiguous_instance",
                                  "instances": e.instances})
-                return
             except UnknownInstance as e:
+                outcome, exit_code = "unknown_instance", 1
                 log("cmd_unknown_instance", op=op, target=e.target)
                 self._send(404, {"ok": False, "error": "unknown_instance",
                                  "target": e.target, "instances": e.instances})
-                return
             except BridgeSuperseded as e:
+                outcome, exit_code = "superseded", 1
                 log("cmd_superseded", op=op, key=e.key)
                 self._send(409, {"ok": False, "error": "superseded",
                                  "key": e.key})
-                return
             except BridgeTimeout:
+                outcome, exit_code = "timeout", 1
                 log("cmd_timeout", op=op)
                 self._send(504, {"ok": False, "error": "timeout"})
-                return
-            log("cmd_ok", op=op)
-            self._send(200, {"ok": True, "result": result})
+            else:
+                domain = _domain_from_result(result)
+                log("cmd_ok", op=op)
+                self._send(200, {"ok": True, "result": result})
+            # Off the critical path: the HTTP response is already sent. Metadata-
+            # only + best-effort — cannot delay or break the command (the key is
+            # the skill's routing target, empty for the implicit single-instance
+            # case). See emit_cmd_event / the PRIVACY + BEST-EFFORT contracts.
+            emit_cmd_event(op=op, key=(target or ""), outcome=outcome,
+                           duration_ms=int((time.monotonic() - t0) * 1000),
+                           domain=domain, exit_code=exit_code)
 
         def _handle_result(self):
             body, err = self._read_body(MAX_RESULT_BODY)

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -8,6 +8,7 @@ request↔reply id correlation, AND the multi-instance registry/routing.
 
 Run: nix-shell -p python312Packages.pytest --run "pytest scripts/browser-bridge/tests"
 """
+import base64
 import json
 import os
 import stat
@@ -27,6 +28,73 @@ import server as S  # noqa: E402
 
 TOKEN = "test-token-abc123"
 EXT_DIR = Path(__file__).resolve().parent.parent / "extension"
+
+# The in-repo activity spool emitter (single source of truth for the v1 line
+# format). scripts/browser-bridge/tests/ -> parent.parent.parent == scripts/.
+SPOOL_EMIT_PY = (Path(__file__).resolve().parent.parent.parent
+                 / "collector" / "keylog" / "spool_emit.py")
+
+
+# --------------------------------------------------------------------------- #
+# Telemetry (browser-bridge -> activity spool) test scaffolding
+# --------------------------------------------------------------------------- #
+def _parse_spool_line(line: str) -> dict:
+    """Decode ONE v1 spool line into a field dict (base64 keys decoded)."""
+    parts = line.rstrip("\n").split("\t")
+    assert parts and parts[0] == "v1", f"not a v1 line: {line!r}"
+    out = {}
+    for kv in parts[1:]:
+        key, _, val = kv.partition("=")
+        if key.startswith("b64:"):
+            out[key[4:]] = base64.b64decode(val).decode("utf-8")
+        else:
+            out[key] = val
+    return out
+
+
+def _log_file(spool_dir) -> Path:
+    return Path(spool_dir) / "current.log"
+
+
+def _read_events(spool_dir) -> list:
+    f = _log_file(spool_dir)
+    if not f.exists():
+        return []
+    return [_parse_spool_line(ln) for ln in f.read_text().splitlines()
+            if ln.strip()]
+
+
+def _wait_events(spool_dir, n=1, timeout=3.0) -> list:
+    """Poll the spool for >=n events (the emit runs off the critical path, after
+    the HTTP response, so it lands slightly after /cmd returns)."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        evs = _read_events(spool_dir)
+        if len(evs) >= n:
+            return evs
+        time.sleep(0.02)
+    return _read_events(spool_dir)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_activity_spool(tmp_path, monkeypatch):
+    """Protect the REAL activity spool: EVERY test's telemetry writes go to a
+    per-test temp dir, and the lazy emitter cache is reset so each test loads it
+    fresh under the current env."""
+    monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(tmp_path / "activity-spool"))
+    monkeypatch.setattr(S, "_spool_emit_mod", None)
+    monkeypatch.setattr(S, "_spool_emit_tried", False)
+
+
+@pytest.fixture
+def telemetry(tmp_path, monkeypatch):
+    """Pin the bridge telemetry emitter at the in-repo spool_emit (hermetic — no
+    dependency on the host's ~/workspace checkout) and return the temp spool dir
+    that `_isolate_activity_spool` pointed ACTIVITY_SPOOL_DIR at."""
+    monkeypatch.setattr(S, "_SPOOL_EMIT_PATH", SPOOL_EMIT_PY)
+    monkeypatch.setattr(S, "_spool_emit_mod", None)
+    monkeypatch.setattr(S, "_spool_emit_tried", False)
+    return tmp_path / "activity-spool"
 
 
 # --------------------------------------------------------------------------- #
@@ -890,3 +958,260 @@ def test_manifest_icons_exist_and_match_declared_size():
 def test_svg_source_present():
     assert (EXT_DIR / "icons" / "icon.svg").exists(), \
         "the SVG icon source must be committed alongside the PNGs"
+
+
+# --------------------------------------------------------------------------- #
+# Activity telemetry: every handled command emits ONE metadata-only,
+# best-effort event into the activity spool (source=browser-bridge, kind=cmd).
+# All headless — writes to a temp spool dir, never ClickHouse/network/Brave.
+# --------------------------------------------------------------------------- #
+def test_domain_from_result_bare_host_only():
+    """Only a bare hostname is ever derived — never a path/query/port, and a
+    screenshot data: URL yields nothing."""
+    d = S._domain_from_result
+    assert d({"data": {"url": "https://mail.google.com/mail/u/0?tok=SECRET"}}) \
+        == "mail.google.com"
+    assert d({"url": "https://x.test:8443/p?q=1"}) == "x.test"
+    assert d({"data": {"url": "data:image/png;base64,AAAABBBB"}}) == ""
+    assert d({"data": {"dataUrl": "data:image/png;base64,AAAA"}}) == ""
+    assert d({"data": {"tabs": []}}) == ""
+    assert d({}) == ""
+    assert d(None) == ""
+    assert d("not-a-dict") == ""
+
+
+def test_cmd_ok_emits_one_metadata_event(telemetry):
+    spool_dir = telemetry
+    srv, _ = _serve()
+    ext = FakeExtension(
+        srv, executor=lambda c: {"url": "https://mail.google.com/mail/u/0?t=rm",
+                                 "html": "<html>hi</html>"})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _req(srv, "POST", "/cmd", {"op": "getHtml"})
+        assert st == 200
+        evs = _wait_events(spool_dir, 1)
+        assert len(evs) == 1, f"expected exactly one event, got {evs}"
+        e = evs[0]
+        assert e["source"] == "browser-bridge"
+        assert e["kind"] == "cmd"
+        assert e["exit_code"] == "0"
+        assert int(e["duration_ms"]) >= 0        # latency present
+        assert e["text"] == "mail.google.com"    # text = bare domain
+        p = json.loads(e["payload"])
+        assert p == {"op": "getHtml", "key": "", "outcome": "ok",
+                     "domain": "mail.google.com"}
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_cmd_ok_no_url_uses_op_as_text_and_omits_domain(telemetry):
+    """A result with no url (e.g. tabs) → text falls back to the op, and the
+    payload carries no domain key."""
+    spool_dir = telemetry
+    srv, _ = _serve()
+    ext = FakeExtension(srv, executor=lambda c: {"tabs": [{"id": 1}]})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, _ = _req(srv, "POST", "/cmd", {"op": "tabs"})
+        assert st == 200
+        e = _wait_events(spool_dir, 1)[0]
+        assert e["text"] == "tabs"
+        p = json.loads(e["payload"])
+        assert p["op"] == "tabs" and p["outcome"] == "ok"
+        assert "domain" not in p
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_cmd_emits_routing_key_from_target(telemetry):
+    """The instance routing key (the skill's --instance target) is recorded."""
+    spool_dir = telemetry
+    srv, _ = _serve(poll_timeout=5.0)
+    a = FakeExtension(srv, instance_id="a", label="alpha",
+                      executor=lambda c: {"who": "a"})
+    b = FakeExtension(srv, instance_id="b", label="beta",
+                      executor=lambda c: {"who": "b"})
+    a.start(); b.start()
+    try:
+        assert _wait_instances(srv, 2) is not None
+        st, _ = _req(srv, "POST", "/cmd", {"op": "tabs", "target": "alpha"})
+        assert st == 200
+        e = _wait_events(spool_dir, 1)[0]
+        p = json.loads(e["payload"])
+        assert p["key"] == "alpha"
+        assert p["outcome"] == "ok"
+    finally:
+        a.stop(); b.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_cmd_no_extension_emits_error_outcome(telemetry):
+    """An error dispatch (no extension) still emits, with a nonzero exit_code and
+    the error outcome — no domain (no result)."""
+    spool_dir = telemetry
+    srv, _ = _serve()
+    try:
+        st, _ = _req(srv, "POST", "/cmd", {"op": "tabs"})
+        assert st == 503
+        e = _wait_events(spool_dir, 1)[0]
+        assert e["exit_code"] == "1"
+        p = json.loads(e["payload"])
+        assert p["op"] == "tabs"
+        assert p["outcome"] == "no_extension"
+        assert "domain" not in p
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_cmd_ambiguous_emits_ambiguous_outcome(telemetry):
+    """An ambiguous dispatch (>1 instance, no target) emits outcome=ambiguous."""
+    spool_dir = telemetry
+    srv, _ = _serve(poll_timeout=5.0)
+    a = FakeExtension(srv, instance_id="a", label="alpha")
+    b = FakeExtension(srv, instance_id="b", label="beta")
+    a.start(); b.start()
+    try:
+        assert _wait_instances(srv, 2) is not None
+        st, _ = _req(srv, "POST", "/cmd", {"op": "tabs"})
+        assert st == 409
+        e = _wait_events(spool_dir, 1)[0]
+        assert e["exit_code"] == "1"
+        p = json.loads(e["payload"])
+        assert p["outcome"] == "ambiguous"
+        assert p["op"] == "tabs"
+    finally:
+        a.stop(); b.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_cmd_timeout_emits_timeout_outcome(telemetry):
+    spool_dir = telemetry
+    srv, _ = _serve(cmd_timeout=0.5, poll_timeout=5.0)
+    ext = FakeExtension(srv, swallow=True)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, _ = _req(srv, "POST", "/cmd", {"op": "getHtml"})
+        assert st == 504
+        e = _wait_events(spool_dir, 1)[0]
+        assert e["exit_code"] == "1"
+        assert json.loads(e["payload"])["outcome"] == "timeout"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_emitted_event_is_metadata_only_no_page_content(telemetry):
+    """PRIVACY: even when the command carries an eval source marker AND the
+    result carries HTML, an eval return value, a screenshot data-URL, and a full
+    URL with a secret query, NONE of that appears in the emitted event — only
+    op/key/outcome/duration + the BARE domain."""
+    spool_dir = telemetry
+    srv, _ = _serve()
+    marker_js = "SECRET_EVAL_MARKER_deadbeef()"
+    secret_data_url = "data:image/png;base64,SCREENSHOTSECRETBYTESxyz=="
+    secret_html = "<html>SECRET_HTML_BODY_TOKEN</html>"
+    secret_query = "SUPERSECRETQUERY"
+
+    def executor(cmd):
+        # The extension echoes a rich result incl. sensitive fields + a full URL
+        # with a query string. The command itself carried the eval marker.
+        return {"url": f"https://mail.google.com/mail/u/0?token={secret_query}",
+                "value": "EVAL_RETURN_SECRET", "html": secret_html,
+                "dataUrl": secret_data_url}
+
+    ext = FakeExtension(srv, executor=executor)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _req(srv, "POST", "/cmd", {"op": "eval", "js": marker_js})
+        assert st == 200
+        # Sanity: the sensitive material genuinely WAS in the round-trip.
+        assert body["result"]["data"]["value"] == "EVAL_RETURN_SECRET"
+        evs = _wait_events(spool_dir, 1)
+        assert len(evs) == 1
+        e = evs[0]
+        # The fully-decoded event (every field incl. the b64 payload) leaks none.
+        decoded_blob = "\t".join(f"{k}={v}" for k, v in e.items())
+        # The RAW spool bytes too — defeats any base64-hidden copy.
+        raw = _log_file(spool_dir).read_text()
+        for secret in (marker_js, "SECRET_EVAL_MARKER", "EVAL_RETURN_SECRET",
+                       secret_html, "SECRET_HTML_BODY_TOKEN", secret_data_url,
+                       "SCREENSHOTSECRETBYTES", secret_query, "token="):
+            assert secret not in decoded_blob, f"leaked in event: {secret}"
+            assert secret not in raw, f"leaked in raw spool: {secret}"
+        # What IS recorded: op + the bare domain, nothing else sensitive.
+        p = json.loads(e["payload"])
+        assert p["op"] == "eval"
+        assert p["outcome"] == "ok"
+        assert p["domain"] == "mail.google.com"   # host only — no path/query
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_cmd_succeeds_when_emitter_raises(monkeypatch):
+    """BEST-EFFORT: if the emitter itself raises, the command STILL returns its
+    normal successful result — no 500, no exception into the handler."""
+    class Boom:
+        def emit(self, *a, **k):
+            raise RuntimeError("spool exploded")
+
+    monkeypatch.setattr(S, "_load_spool_emit", lambda: Boom())
+    srv, _ = _serve()
+    ext = FakeExtension(srv, executor=lambda c: {"url": "https://x.test"})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _req(srv, "POST", "/cmd", {"op": "getHtml"})
+        assert st == 200
+        assert body["ok"] is True
+        assert body["result"]["data"]["url"] == "https://x.test"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_cmd_succeeds_when_spool_unwritable(telemetry, monkeypatch, tmp_path):
+    """BEST-EFFORT: an unwritable spool path never breaks a command."""
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("x")  # a regular file where a dir is expected
+    monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(blocker / "spool"))
+    srv, _ = _serve()
+    ext = FakeExtension(srv, executor=lambda c: {"url": "https://x.test"})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _req(srv, "POST", "/cmd", {"op": "getHtml"})
+        assert st == 200
+        assert body["ok"] is True
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_health_and_instances_do_not_emit(telemetry):
+    """health / instances (and the extension's /poll) are noise — no events."""
+    spool_dir = telemetry
+    srv, _ = _serve(poll_timeout=5.0)
+    ext = FakeExtension(srv, instance_id="a", label="alpha")
+    ext.start()
+    try:
+        assert _wait_instances(srv, 1) is not None   # exercises /poll repeatedly
+        _req(srv, "GET", "/health")
+        _req(srv, "GET", "/instances")
+        time.sleep(0.2)  # give any erroneous emit a chance to land
+        assert _read_events(spool_dir) == []
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_emit_cmd_event_noop_when_emitter_missing(monkeypatch):
+    """emit_cmd_event is a silent no-op (never raises) when the emitter can't be
+    loaded — the collector not being checked out just disables telemetry."""
+    monkeypatch.setattr(S, "_load_spool_emit", lambda: None)
+    S.emit_cmd_event(op="tabs", key="", outcome="ok", duration_ms=1)
+
+
+def test_load_spool_emit_missing_path_returns_none(monkeypatch, tmp_path):
+    monkeypatch.setattr(S, "_SPOOL_EMIT_PATH", tmp_path / "nope.py")
+    monkeypatch.setattr(S, "_spool_emit_mod", None)
+    monkeypatch.setattr(S, "_spool_emit_tried", False)
+    assert S._load_spool_emit() is None

--- a/scripts/collector/README.md
+++ b/scripts/collector/README.md
@@ -38,6 +38,13 @@ tmux focus hooks   ─┼─► emit (pure shell, hot path) ─► spool/current
   Both tailers share `claude/_shared.py` (ts/project/emit/root/iter helpers) and run
   on the same 5-min `claude-activity-source` timer (both hosts).
   Layer B (`kind=session-insight`, qualitative goal/outcome/friction) is a later PR.
+- **External emitters** (write to the same spool, live outside this dir):
+  `browser-ext/receiver.py` (`source=browser, kind=nav` — page nav/scroll from the
+  collector's MV3 extension) and the **browser-bridge server**
+  (`scripts/browser-bridge/server.py`, `source=browser-bridge, kind=cmd` — one
+  best-effort, metadata-only event per Claude-driven browser command:
+  op/instance-key/outcome/latency + bare domain, **never** page content). Both
+  reuse `keylog/spool_emit.py` for the v1 line format.
 - `tests/` — pytest unit + round-trip coverage (mocks the HTTP endpoint).
 
 ## Spool / emit line contract (v1)


### PR DESCRIPTION
## What

Wires the `browser-bridge` rendezvous server (`scripts/browser-bridge/server.py`) into the personal activity-telemetry pipeline. Each handled browser command now emits **one** event into ClickHouse `activity.events`, making browser-skill usage first-class self-telemetry.

## Telemetry design

- **`source="browser-bridge"`, `kind="cmd"`** — a *distinct* source from the collector's `browser` (nav/scroll) source; the two stay separate.
- Emitted for real dispatches — `getHtml`/`eval`/`tabs`/`nav`/`screenshot` — and their outcomes, **including** errors/ambiguous. `health`/`instances`/`poll`/`result` are noise and deliberately do **not** emit.
- **Column mapping:** `text` = active-tab **bare domain** (falls back to op when no domain), `duration_ms` = server-side latency, `exit_code` = 0/1, `payload` = tiny JSON `{op, key, outcome[, domain]}` (`key` = the `--instance` routing target, empty for the implicit single-instance case; `outcome` ∈ `ok|no_extension|ambiguous|unknown_instance|superseded|timeout`).

## Privacy contract (metadata-only)

Emits **only** op name + instance key + outcome + latency + the active tab's **bare domain**. **Never** the eval source, page HTML, screenshot bytes/data-URLs, a full URL with path/query, or any page content. Enforced in code (`_domain_from_result` returns a hostname only; a data: URL yields `""`) and asserted by a dedicated privacy test.

## Best-effort / fire-and-forget contract

Emitting runs **after** the HTTP response is sent and can never delay or break a command. Every failure mode — missing collector, unwritable spool, any exception — is swallowed via `try/except`. It only does a local spool append (no network, no fork), so there is no blocking path to time out.

## Emit mechanism (and why it survives the symlink-flatten gotcha)

Reuses the collector's `scripts/collector/keylog/spool_emit.py` (single source of truth for the v1 line format) rather than hand-rolling the format. `server.py` is deployed by home-manager as a **flat single-file `/nix/store` symlink**, so `Path(__file__)` does not sit next to the collector tree (and `.resolve()` would make it worse — same gotcha the sibling `receiver.py` documents). It is therefore located by its **stable absolute repo path** (`~/workspace/devrc/scripts/collector/keylog/spool_emit.py`, identical on both hosts), imported lazily via `importlib`, and degrades gracefully to a no-op if absent. `BROWSER_BRIDGE_SPOOL_EMIT` overrides the path (used by tests for hermeticity).

Security invariants unchanged: the emit is off the request/auth path (loopback bind, bearer auth, Host allowlist untouched).

## Tests

`scripts/browser-bridge/tests/test_server.py` +13 tests (headless, temp spool, no ClickHouse/network/Brave):
- ok / no-extension(error) / ambiguous / timeout outcomes each emit exactly one event with the expected shape (op, key, outcome, `duration_ms` present, `exit_code`).
- routing key recorded from `--instance` target.
- **privacy**: an `eval` with a recognizable source marker + a result carrying HTML, an eval return value, a screenshot data-URL, and a full URL with a secret query — none of it appears in the emitted line (decoded fields **and** raw spool bytes); only the bare domain does.
- **best-effort**: emitter raises → command still `200`; spool path unwritable → command still `200`.
- `health`/`instances` do not emit.
- pure-unit coverage for `_domain_from_result`, the missing-emitter no-op, and the missing-path loader.

```
55 passed in 19.12s          # scripts/browser-bridge/tests (python, was ~42)
node --test protocol: pass 20, fail 0
bash -n scripts/browser-bridge/browser: OK
```

Plus a deterministic end-to-end check: `server.emit_cmd_event(...)` through the real `spool_emit` produces a valid, collector-parseable v1 line.

## Honest verification / follow-up

- **Not verified end-to-end** against ClickHouse (needs the running collector + a real Brave command — can't be done headlessly). **Live check after merge + ship:** run any `browser` command, then confirm a `source='browser-bridge'` row appears in `activity.events`.
- **`adoption-scan` follow-up (out of scope here):** `scripts/session-analysis/adoption-scan.py` keys on a REGISTRY with `via="tool"` (`source=tool kind=invocation`), `via="command"`, and `via="cwd"` — it has no matcher for a bare `source=browser-bridge kind=cmd`. Picking this up needs a new `via`/aggregation path, which is non-trivial; flagged as a separate follow-up rather than expanding this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)