### PR TITLE
feat(adoption-scan): generic via="source" matcher + browser-bridge item

### DIFF
--- a/scripts/session-analysis/adoption-scan.py
+++ b/scripts/session-analysis/adoption-scan.py
@@ -86,6 +86,9 @@ class TelemetryUnavailable(Exception):
 #                    slash-command prefix(es).
 #   via="cwd"     -> match `source=claude` sessions whose cwd names the item
 #                    (best-effort/heuristic — used for the autonomous drafter).
+#   via="source"  -> GENERIC: match an arbitrary `(source, kind)` pair (e.g.
+#                    browser-bridge/cmd), counting by outcome. Any future emit-
+#                    instrumented subsystem is added with a registry line, no code.
 # `impact_outcomes` are the outcomes that evidence a REAL catch (value signal),
 # with `impact_label` explaining what a hit means. opt_in items are the ones
 # whose adoption is fragile (a human has to choose to invoke them).
@@ -139,6 +142,14 @@ REGISTRY = [
         "label": "task-spec-drafter — autonomous weekly ticket drafter (cwd, heuristic)",
         "via": "cwd", "match": DRAFTER_CWD_MATCH, "opt_in": False,
         "outcomes": [], "impact_outcomes": [], "impact_label": "",
+    },
+    {
+        "id": "browser-bridge",
+        "label": "browser — drive live Brave",
+        "via": "source", "source": "browser-bridge", "kind": "cmd",
+        "opt_in": False,  # emitted automatically per browser command, not opt-in
+        "outcomes": ["ok", "error", "ambiguous"],
+        "impact_outcomes": [], "impact_label": "",
     },
 ]
 
@@ -283,6 +294,40 @@ def aggregate_cwd(rows: list[dict], now: float, win: float) -> dict:
             "trend": _trend(recent, prior)}
 
 
+def aggregate_source(rows: list[dict], now: float, win: float,
+                     outcome_field: str = "outcome") -> dict:
+    """Aggregate generic emit-instrumented `source=<X> kind=<Y>` rows (already
+    filtered to one (source,kind) pair by the query), counting ONLY events within
+    the adoption window `win`. Mirrors `aggregate_tool`'s shape: a window count,
+    an outcome breakdown, and a recent-vs-prior trend (halves are win/2).
+
+    Outcome comes from `payload.<outcome_field>`; if that field is absent it falls
+    back to the row's `exit_code` (0 -> "ok", anything else -> "error"). This is
+    the reusable matcher — any future emit-instrumented subsystem is added with a
+    REGISTRY line (via="source", source=..., kind=...), no new code."""
+    half_s = win / 2.0
+    total = 0
+    outcomes: Counter = Counter()
+    recent = prior = 0
+    for r in rows:
+        e = ch_ts_to_epoch(r.get("ts"))
+        if e is None or (now - e) > win:
+            continue  # outside the --days window (may be in the wider fetch)
+        total += 1
+        p = parse_payload(r.get("payload"))
+        outcome = p.get(outcome_field)
+        if not outcome:
+            outcome = "ok" if r.get("exit_code") in (0, "0") else "error"
+        outcomes[outcome] += 1
+        b = _half(e, now, half_s)
+        if b == "recent":
+            recent += 1
+        elif b == "prior":
+            prior += 1
+    return {"total": total, "outcomes": dict(outcomes),
+            "recent": recent, "prior": prior, "trend": _trend(recent, prior)}
+
+
 def aggregate_friction(insight_rows: list[dict], now: float, iwin: float) -> dict:
     """Sum the tracked friction categories over two windows (recent vs prior half
     of the insight window `iwin`). DIRECTIONAL only — confounded by different
@@ -357,6 +402,19 @@ def q_cwd_sessions(win: int, match: str, host: str | None = None) -> str:
     )
 
 
+def q_source(win: int, source: str, kind: str, host: str | None = None) -> str:
+    """Rows for a generic emit-instrumented `(source, kind)` pair in the window.
+    Same column set / `_host_filter` pattern as q_tool_invocations — the outcome
+    lives inside `payload` (parsed by aggregate_source), exit_code is the fallback."""
+    return (
+        "SELECT text AS text, toString(payload) AS payload, "
+        "exit_code, duration_ms, ts, host "
+        "FROM activity.events "
+        f"WHERE source={Q.sql_quote(source)} AND kind={Q.sql_quote(kind)} "
+        f"AND ts>now()-{win}{_host_filter(host)}"
+    )
+
+
 def q_insights(win: int, host: str | None = None) -> str:
     # `max(ts) AS last_ts` not `AS ts` — see q_cwd_sessions: an aggregate aliased
     # to the raw column name `ts` shadows it in WHERE → ILLEGAL_AGGREGATION.
@@ -404,6 +462,15 @@ def gather(client, days: int, insight_days: int, dead_days: int,
             if item["via"] == "cwd":
                 cwd_rows[item["id"]] = _norm_last_ts(client.rows(
                     q_cwd_sessions(fetch_win, item["match"], host)))
+        # via="source" items: one query per DISTINCT (source, kind) pair, keyed by
+        # that pair so multiple registry items sharing a pair reuse the fetch.
+        source_rows: dict = {}
+        for item in REGISTRY:
+            if item["via"] == "source":
+                pair = (item["source"], item["kind"])
+                if pair not in source_rows:
+                    source_rows[pair] = client.rows(
+                        q_source(fetch_win, item["source"], item["kind"], host))
     except Exception as e:  # noqa: BLE001 — telemetry optional; degrade cleanly
         raise TelemetryUnavailable(str(e)) from e
 
@@ -416,6 +483,10 @@ def gather(client, days: int, insight_days: int, dead_days: int,
             agg = aggregate_command(cmd_rows, item["prefixes"], now, win)
         elif via == "cwd":
             agg = aggregate_cwd(cwd_rows.get(item["id"], []), now, win)
+        elif via == "source":
+            agg = aggregate_source(
+                source_rows.get((item["source"], item["kind"]), []), now, win,
+                item.get("outcome_field", "outcome"))
         else:
             agg = {"total": 0, "outcomes": {}, "recent": 0, "prior": 0,
                    "trend": "flat"}
@@ -423,8 +494,9 @@ def gather(client, days: int, insight_days: int, dead_days: int,
         # DEAD = zero uses within the dead-days window, computed over the FULL
         # fetched set (which spans dead_s), so it is correct whether dead_days is
         # smaller, equal to, or larger than days.
-        dead = _count_within(_item_ts(item, tool_rows, cmd_rows, cwd_rows),
-                             now, dead_s) == 0
+        dead = _count_within(
+            _item_ts(item, tool_rows, cmd_rows, cwd_rows, source_rows),
+            now, dead_s) == 0
 
         impact = {o: agg["outcomes"].get(o, 0) for o in item.get("impact_outcomes", [])}
         items.append({
@@ -447,7 +519,7 @@ def gather(client, days: int, insight_days: int, dead_days: int,
     }
 
 
-def _item_ts(item, tool_rows, cmd_rows, cwd_rows) -> list:
+def _item_ts(item, tool_rows, cmd_rows, cwd_rows, source_rows=None) -> list:
     """Ts strings attributable to `item` (for the sub-window DEAD re-bucket)."""
     if item["via"] == "tool":
         out = []
@@ -463,6 +535,9 @@ def _item_ts(item, tool_rows, cmd_rows, cwd_rows) -> list:
                 if command_matches(r.get("text"), pres)]
     if item["via"] == "cwd":
         return [r.get("ts") for r in cwd_rows.get(item["id"], [])]
+    if item["via"] == "source":
+        rows = (source_rows or {}).get((item["source"], item["kind"]), [])
+        return [r.get("ts") for r in rows]
     return []
 
 

--- a/scripts/session-analysis/tests/test_adoption_scan.py
+++ b/scripts/session-analysis/tests/test_adoption_scan.py
@@ -37,6 +37,20 @@ def _tool_row(tool, outcome, age_days):
             "payload": json.dumps({"tool": tool, "outcome": outcome})}
 
 
+def _bb_row(outcome, age_days, *, op="eval", domain="example.com",
+            exit_code=0, include_outcome=True):
+    """A `source=browser-bridge kind=cmd` row as the code sees it on read.
+    `include_outcome=False` drops the payload outcome to exercise the exit_code
+    fallback path in aggregate_source."""
+    payload = {"op": op, "key": "default"}
+    if include_outcome:
+        payload["outcome"] = outcome
+    if domain:
+        payload["domain"] = domain
+    return {"text": domain or op, "exit_code": exit_code, "duration_ms": 12,
+            "ts": _ts(age_days), "payload": json.dumps(payload)}
+
+
 # --------------------------------------------------------------------------- #
 # pure helpers
 # --------------------------------------------------------------------------- #
@@ -109,6 +123,64 @@ def test_aggregate_cwd_counts_sessions():
     assert agg["total"] == 2 and agg["recent"] == 1 and agg["prior"] == 1
 
 
+# --------------------------------------------------------------------------- #
+# aggregate_source (generic (source,kind) matcher — browser-bridge)
+# --------------------------------------------------------------------------- #
+def test_aggregate_source_counts_outcomes_and_trend():
+    rows = [
+        _bb_row("ok", 1),
+        _bb_row("error", 1, exit_code=1),
+        _bb_row("ambiguous", 1, exit_code=1),
+        _bb_row("ok", 10),  # prior half
+    ]
+    agg = A.aggregate_source(rows, NOW, 14 * DAY)
+    assert agg["total"] == 4
+    assert agg["outcomes"] == {"ok": 2, "error": 1, "ambiguous": 1}
+    assert agg["recent"] == 3 and agg["prior"] == 1
+    assert agg["trend"] == "up"
+
+
+def test_aggregate_source_excludes_rows_outside_window():
+    rows = [_bb_row("ok", 3), _bb_row("ok", 20)]
+    agg = A.aggregate_source(rows, NOW, 14 * DAY)
+    assert agg["total"] == 1  # 20-day-old row excluded from counts
+
+
+def test_aggregate_source_exit_code_fallback_when_outcome_absent():
+    # payload without an `outcome` field -> derive from exit_code (0=ok,else=error)
+    rows = [
+        _bb_row("", 1, include_outcome=False, exit_code=0),
+        _bb_row("", 1, include_outcome=False, exit_code=1),
+        _bb_row("", 1, include_outcome=False, exit_code="0"),  # str form
+    ]
+    agg = A.aggregate_source(rows, NOW, 14 * DAY)
+    assert agg["outcomes"] == {"ok": 2, "error": 1}
+
+
+def test_aggregate_source_custom_outcome_field():
+    rows = [{"text": "x", "exit_code": 0, "duration_ms": 1, "ts": _ts(1),
+             "payload": json.dumps({"status": "weird"})}]
+    agg = A.aggregate_source(rows, NOW, 14 * DAY, outcome_field="status")
+    assert agg["outcomes"] == {"weird": 1}
+
+
+def test_aggregate_source_empty_is_flat_and_zero():
+    agg = A.aggregate_source([], NOW, 14 * DAY)
+    assert agg["total"] == 0 and agg["trend"] == "flat"
+    assert agg["outcomes"] == {}
+
+
+def test_q_source_builds_expected_sql():
+    sql = A.q_source(1209600, "browser-bridge", "cmd", host="workbench")
+    assert "source='browser-bridge'" in sql
+    assert "kind='cmd'" in sql
+    assert "FROM activity.events" in sql
+    assert "ts>now()-1209600" in sql
+    assert "AND host='workbench'" in sql
+    # no host -> no host filter
+    assert "host=" not in A.q_source(3600, "browser-bridge", "cmd")
+
+
 def test_aggregate_friction_two_windows():
     rows = [
         {"session": "a", "ts": _ts(1),
@@ -130,9 +202,11 @@ def test_aggregate_friction_two_windows():
 # gather() end-to-end via a fake client
 # --------------------------------------------------------------------------- #
 class FakeClient:
-    def __init__(self, tool_rows, cmd_rows, insight_rows, cwd_rows):
+    def __init__(self, tool_rows, cmd_rows, insight_rows, cwd_rows,
+                 source_rows=None):
         self._tool, self._cmd, self._ins, self._cwd = (
             tool_rows, cmd_rows, insight_rows, cwd_rows)
+        self._source = source_rows or []
 
     def rows(self, sql):
         if "kind='invocation'" in sql:
@@ -141,6 +215,10 @@ class FakeClient:
             return self._ins
         if "position(lower(cwd)" in sql:
             return self._cwd
+        if "source='browser-bridge'" in sql:
+            return self._source
+        if "kind='command'" in sql:
+            return self._cmd
         return self._cmd
 
 
@@ -160,7 +238,12 @@ def _sample_client():
          "payload": json.dumps({"friction_counts": {"permission_block": 5}})},
     ]
     cwd_rows = [{"session": "d1", "ts": _ts(1)}]
-    return FakeClient(tool_rows, cmd_rows, insight_rows, cwd_rows)
+    source_rows = [
+        _bb_row("ok", 1),
+        _bb_row("error", 1, exit_code=1),
+        _bb_row("ok", 10),
+    ]
+    return FakeClient(tool_rows, cmd_rows, insight_rows, cwd_rows, source_rows)
 
 
 def _by_id(data):
@@ -178,6 +261,39 @@ def test_gather_per_item_counts_and_outcomes():
     assert vaw["impact"] == {"fail": 1, "incomplete": 0}
     assert items["cmd:verify-agent"]["total"] == 1
     assert items["task-spec-drafter"]["total"] == 1
+
+
+def test_gather_browser_bridge_flows_through():
+    """The generic via="source" browser-bridge item lands in the result dict with
+    the right id/label/via/opt_in and outcome-broken-down counts."""
+    data = A.gather(_sample_client(), days=14, insight_days=30, dead_days=14, now=NOW)
+    bb = _by_id(data)["browser-bridge"]
+    assert bb["via"] == "source"
+    assert bb["label"] == "browser — drive live Brave"
+    assert bb["opt_in"] is False
+    assert bb["total"] == 3  # 2 ok (1d + 10d) + 1 error (1d)
+    assert bb["outcomes"] == {"ok": 2, "error": 1}
+    assert bb["recent"] == 2 and bb["prior"] == 1
+    assert bb["trend"] == "up"
+    assert bb["dead"] is False
+
+
+def test_gather_browser_bridge_dead_when_no_rows():
+    """Zero browser-bridge rows -> the item reports DEAD like any other."""
+    client = FakeClient([_tool_row("obs-read", "ok", 1)], [], [], [], source_rows=[])
+    bb = _by_id(A.gather(client, days=14, insight_days=30, dead_days=14, now=NOW))[
+        "browser-bridge"]
+    assert bb["total"] == 0
+    assert bb["dead"] is True
+
+
+def test_gather_browser_bridge_dead_subwindow():
+    """Only use 10d ago -> alive over 14d, DEAD under a 3d dead window."""
+    client = FakeClient([], [], [], [], source_rows=[_bb_row("ok", 10)])
+    alive = _by_id(A.gather(client, days=14, insight_days=30, dead_days=14, now=NOW))
+    assert alive["browser-bridge"]["dead"] is False
+    dead = _by_id(A.gather(client, days=14, insight_days=30, dead_days=3, now=NOW))
+    assert dead["browser-bridge"]["dead"] is True
 
 
 def test_gather_dead_flag_fires_at_zero_and_not_when_used():
@@ -243,6 +359,8 @@ def test_render_has_sections():
     assert "## DRAFTER FRICTION TREND" in text
     assert "DEAD" in text
     assert "CAVEATS" in text
+    # the generic via="source" browser-bridge item renders in the ADOPTION table
+    assert "browser — drive live Brave" in text
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

`adoption-scan.py` reports which shipped gametape tools are actually USED over `activity.events`. #173 shipped per-command browser-bridge telemetry (`source=browser-bridge kind=cmd`), but adoption-scan had no matcher for it, so the usage never surfaced.

This adds a **generic, reusable `via="source"` matcher** (not a browser-bridge one-off): it keys on an arbitrary `(source, kind)` pair and aggregates by count + outcome, so any future emit-instrumented subsystem is added with a single REGISTRY line — no new code.

## The generic `via="source"` matcher

- **`aggregate_source(rows, now, win, outcome_field="outcome")`** — mirrors `aggregate_tool`'s shape: window count, outcome breakdown, recent-vs-prior trend (halves `win/2`), and DEAD detection consistent with the other matchers. Outcome comes from `payload.<outcome_field>`, falling back to `exit_code` (0 → `ok`, else → `error`) when the field is absent. Reuses `parse_payload`/`_half`/`_trend`/`ch_ts_to_epoch` (no duplication).
- **`q_source(win, source, kind, host)`** — same column set / `_host_filter` pattern as the other `q_*` builders.
- **`gather()`** — fetches source-rows once per distinct `(source, kind)` pair (batched, like `tool_rows`) and branches `via == "source"` → `aggregate_source`, emitting the same per-item result dict shape so `render()` / `--json` need zero special-casing.
- **`_item_ts()`** — a `via == "source"` branch feeds the DEAD sub-window re-bucket.

## The browser-bridge REGISTRY entry

```
id="browser-bridge", label="browser — drive live Brave",
via="source", source="browser-bridge", kind="cmd", opt_in=False
```

`opt_in=False` because it's emitted automatically per browser command, not opt-in. It renders in the ADOPTION table with its ok/error/ambiguous outcome mix and participates in the DEAD/idle logic and `--json` output like every other item.

The existing tool/command/cwd matchers and the browser-bridge emit are untouched.

## Tests

Extends `tests/test_adoption_scan.py` (stdlib `unittest`/pytest style, synthetic rows via `FakeClient` — no ClickHouse/network):

- `aggregate_source`: in-window counts, ok/error/ambiguous breakdown from `payload.outcome`, **exit_code fallback** when `outcome` is missing, custom `outcome_field`, empty→flat/zero, out-of-window exclusion.
- `q_source`: SQL string-assert for `(source, kind, host)` and the no-host case.
- `gather()`-level flow-through: the browser-bridge item lands in the result dict with the right id/label/via/opt_in + outcome-broken-down counts + trend; DEAD at zero rows; DEAD under a 3-day sub-window; render() shows the `browser — drive live Brave` line.

```
30 passed  (tests/test_adoption_scan.py)
261 passed (scripts/session-analysis/tests/)
```
`scripts/session-analysis/tests` is already in `run-tests.sh` HERMETIC_DIRS, so this rides the flake check + pre-push hook.

## Manual live check (post-merge)

Cannot be verified headlessly against live ClickHouse — unit-tested with synthetic rows only. After merge, run the adoption-scan (via the `adoption-scan` skill, with the reader creds from SOPS in env) and confirm the **`browser — drive live Brave`** line appears with real invocation counts (there are already `source=browser-bridge` rows in `activity.events` from today):

```
scripts/session-analysis/adoption-scan.py --days 14
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)