### PR TITLE
feat(browser-bridge): per-session tab isolation + FIFO (fix concurrent-session clobber)

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -127,7 +127,9 @@ Server envelope: `POST /cmd` → `200 {"ok":true,"result":{id,ok,data}}`, or a
 structured error: `503 extension_not_connected`, `504 timeout`,
 `409 ambiguous_instance` (>1 connected, no `target`), `409 no_owned_tab`
 (`close` with nothing owned), `409 superseded`, `404 unknown_instance`,
-`400 unknown_op|missing_field:<f>`, `401 unauthorized`, `403 bad_host`.
+`400 unknown_op|missing_field:<f>`, `400 bad_tab` (a non-numeric/non-scalar
+`tab` from a raw caller — the CLI already validates `--tab`), `401 unauthorized`,
+`403 bad_host`.
 
 ## Session isolation (concurrent-session tab clobbering)
 
@@ -148,14 +150,36 @@ per-session (multi-step **workflow**) isolation did not.
   PPID (the Claude Code process, stable across a session's calls). It is used for
   **routing only** and is **never** trusted for auth — bearer + Host still gate
   every request. If two sessions ever resolve the same id they share a tab
-  (documented degradation — no worse than before; a subagent inherits its
-  parent's `CLAUDE_CODE_SESSION_ID`, so it shares the parent's tab).
+  (documented degradation — no worse than before).
+- **⚠ Sibling subagents share identity (known limitation).** Per-session
+  isolation covers concurrent **top-level** sessions, NOT sibling subagents of
+  one parent. Empirically (dumped from inside two parallel subagents) a subagent
+  inherits the **parent's** `CLAUDE_CODE_SESSION_ID` *and* runs in the same
+  `$TMUX_PANE`, and the harness injects **no** subagent-unique, stable env var
+  (no agentId/taskId/tool-use id is visible to the subagent's own shell), so two
+  sibling subagents derive the SAME session id and would own the same tab. The
+  robust fix is **explicit tab handles**: each such driver runs `browser open`
+  (which returns a real `tabId`) and then threads its OWN `--tab <id>` on every
+  subsequent op. An explicit `--tab` **overrides** owned-tab routing entirely, so
+  two indistinguishable drivers never collide. See SKILL.md → Concurrent drivers.
 - **Ownership.** `browser open [url]` creates a tab (background, `active:false`,
   so parallel sessions don't fight over the foreground) and the server records
   `(instance_key, session_id) -> tabId`. That session's tab-scoped ops then route
   to its tab; a session with **no** owned tab falls back to the active tab (the
   one-shot read path). `--tab <id>` overrides explicitly. `browser close` closes
   the tab + drops ownership; `browser release` drops ownership only.
+- **Idempotent `open` (no orphaned tab).** A second `open` from a session that
+  already owns a **live** tab returns that SAME tab (the server passes the owned
+  tabId as `reuseTabId`; the extension reuses it) instead of creating a second
+  real tab — so a double `open` never orphans/leaks the first tab. If the owned
+  tab is **gone**, `open` transparently creates a fresh one.
+- **Self-heal on a vanished owned tab.** If the user manually closes an owned
+  background tab, the next tab-scoped op dispatches the stale tabId and the
+  extension returns `owned_tab_gone` (ok:false). The server then **drops** that
+  session's ownership so the NEXT command self-heals to the active-tab fallback
+  (instead of staying wedged to the dead tab until the TTL reclaims it). `browser
+  close` clears the mapping **unconditionally** — even when the tab was already
+  gone — and the extension treats an already-gone close as success (idempotent).
 - **FIFO on remaining contention.** With isolation most sessions use different
   tabs and don't contend. When two commands DO target the same tab (both active,
   or one `--tab`s another's owned tab) they are serialized **FIFO in arrival
@@ -257,10 +281,17 @@ per-tab FIFO serialization (same-tab commands serialize in arrival order,
 different tabs don't block, a queued command still honours `cmd_timeout`), TTL
 reclaim (injected clock — released, not closed), the `no_owned_tab` error, the
 session id being routing-only (bearer/Host still enforced), and backward-compat
-(single session, no open → unchanged active-tab dispatch). Current totals: **72
-Python** (`test_server.py`) + **22 node** (`protocol.test.mjs`). The chrome.* glue
-in `service_worker.js` genuinely needs a real browser and is covered by the
-manual checklist in `extension/README.md`.
+(single session, no open → unchanged active-tab dispatch). It also covers the
+**self-heal + idempotency hardening**: an `owned_tab_gone` op dropping the stale
+ownership (self-heal to active-tab) while an unrelated `--tab` gone tab does NOT
+evict a healthy mapping, `close` clearing ownership even when the tab was already
+gone, an idempotent double `open` returning the reused tab (no orphan) vs opening
+fresh when the owned tab is gone, a malformed `tab` (list/dict/bool) returning a
+clean `400 bad_tab` instead of a 500 (+ the `_coerce_tab`/`_is_tab_gone` helper
+units), and an explicit `--tab` overriding owned-tab routing (the subagent
+escape hatch). Current totals: **82 Python** (`test_server.py`) + **22 node**
+(`protocol.test.mjs`). The chrome.* glue in `service_worker.js` genuinely needs a
+real browser and is covered by the manual checklist in `extension/README.md`.
 
 ## Deploy (nix)
 

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -111,15 +111,71 @@ must run in whatever tab is active). This can be scoped down later; noted in
 |----|---------|---------|
 | `getHtml`    | `chrome.scripting` → `document.documentElement.outerHTML` | `{url,title,html}` |
 | `eval`       | `chrome.scripting.executeScript` (MAIN world) of `js`     | `{url,value}` |
-| `tabs`       | `chrome.tabs.query({})`                                   | `{tabs:[...]}` |
-| `nav`        | `chrome.tabs.update(active,{url})`                        | `{tabId,url}` |
+| `tabs`       | `chrome.tabs.query({})`                                   | `{tabs:[...],ownedTabId}` |
+| `nav`        | `chrome.tabs.update(tab,{url})`                           | `{tabId,url}` |
 | `screenshot` | `chrome.tabs.captureVisibleTab` (png)                     | `{url,dataUrl}` |
+| `open`       | `chrome.tabs.create({url,active:false})`                 | `{tabId,url}` |
+| `close`      | `chrome.tabs.remove(tabId)`                               | `{closed:tabId}` |
+
+`open`/`close` are dispatched to the extension; `release` (drop ownership, don't
+close the tab) is handled server-side and never reaches the extension. The
+tab-scoped ops (`getHtml`/`eval`/`nav`/`screenshot`/`close`) run against the
+calling session's owned tab when it has one (see Session isolation), else the
+active tab.
 
 Server envelope: `POST /cmd` → `200 {"ok":true,"result":{id,ok,data}}`, or a
 structured error: `503 extension_not_connected`, `504 timeout`,
-`409 ambiguous_instance` (>1 connected, no `target`), `409 superseded`,
-`404 unknown_instance`, `400 unknown_op|missing_field:<f>`, `401 unauthorized`,
-`403 bad_host`.
+`409 ambiguous_instance` (>1 connected, no `target`), `409 no_owned_tab`
+(`close` with nothing owned), `409 superseded`, `404 unknown_instance`,
+`400 unknown_op|missing_field:<f>`, `401 unauthorized`, `403 bad_host`.
+
+## Session isolation (concurrent-session tab clobbering)
+
+The transport is correct (each `/cmd` gets a unique cid, a FIFO outbox, and a
+cid-correlated reply — no cross-delivery). The old clobber was **semantic**:
+every op targeted "the active tab of the last-focused window", so two Claude
+sessions driving one instance interleaved on **one shared tab** (A `nav X` then
+`getHtml`; B `nav Y` in between; A reads Y). Command-level serialization existed;
+per-session (multi-step **workflow**) isolation did not.
+
+**Fix — a per-session owned tab:**
+
+- **Per-session id.** The `browser` skill sends a stable `X-Session-Id` on every
+  `/cmd`, derived (in order) from `CLAUDE_CODE_SESSION_ID` (Claude Code's own
+  session UUID — identical across every Bash-tool call in a session, verified on
+  the 2.1.x CLI) → `CLAUDE_SESSION_ID` (defensive alternate) → `$TMUX_PANE` (each
+  session runs in its own tmux pane) → a random token cached under the shell's
+  PPID (the Claude Code process, stable across a session's calls). It is used for
+  **routing only** and is **never** trusted for auth — bearer + Host still gate
+  every request. If two sessions ever resolve the same id they share a tab
+  (documented degradation — no worse than before; a subagent inherits its
+  parent's `CLAUDE_CODE_SESSION_ID`, so it shares the parent's tab).
+- **Ownership.** `browser open [url]` creates a tab (background, `active:false`,
+  so parallel sessions don't fight over the foreground) and the server records
+  `(instance_key, session_id) -> tabId`. That session's tab-scoped ops then route
+  to its tab; a session with **no** owned tab falls back to the active tab (the
+  one-shot read path). `--tab <id>` overrides explicitly. `browser close` closes
+  the tab + drops ownership; `browser release` drops ownership only.
+- **FIFO on remaining contention.** With isolation most sessions use different
+  tabs and don't contend. When two commands DO target the same tab (both active,
+  or one `--tab`s another's owned tab) they are serialized **FIFO in arrival
+  order** — competing commands **queue** (blocking) rather than fail-fast,
+  bounded by `cmd_timeout` so a queued command can't block forever. Commands to
+  **different** tabs never block each other.
+- **Lifecycle (reversible — flag for veto).** Ownership has an idle TTL
+  (`BROWSER_BRIDGE_OWNER_TTL`, default 900 s). On expiry the mapping is
+  **released** so a dead session doesn't leak ownership, but the real Brave tab
+  is deliberately **NOT closed** (never yank a visible tab out from under the
+  user) — only an explicit `browser close` closes it.
+- **Screenshot caveat (honest).** `captureVisibleTab` only ever captures the
+  **visible** tab of a window. Screenshotting a session's **background** owned
+  tab therefore briefly activates it → captures → restores the previously-active
+  tab (a short visible flicker in that window), so we never silently capture the
+  wrong tab. A screenshot of an owned tab that is already visible is unaffected.
+- **Backward-compat.** A single session with no `open` (and even no
+  `X-Session-Id`) behaves exactly as before: active-tab ops, no `tabId` injected.
+  The multi-instance `--instance` targeting, ambiguity/supersede semantics, and
+  telemetry are unchanged.
 
 `GET /health` → `{"ok":true,"extension_connected":bool,"count":N,"instances":[{key,label,instanceId,activeTab},…]}`.
 `GET /instances` → `{"ok":true,"count":N,"instances":[…]}`.
@@ -191,10 +247,20 @@ error, unknown-target, label-vs-auto-id key resolution, supersede-on-duplicate
 the displaced poll returning the distinct `409 superseded` signal instead of the
 idle `204`, and the supersede being logged exactly once per displacement — the
 no-churn/livelock-fix contract), legacy no-handshake back-compat, and an icon
-sanity check (each declared PNG
-exists and its IHDR size matches). The chrome.* glue in `service_worker.js`
-genuinely needs a real browser and is covered by the manual checklist in
-`extension/README.md`.
+sanity check (each declared PNG exists and its IHDR size matches). It also covers
+**session isolation**: `open` recording `(instance,session)->tabId`, two sessions
+getting distinct ownership, ops routing to the owning session's tabId (and the
+interleaved-two-sessions clobber test), the active-tab fallback + `--tab`
+override, `close`/`release` (drop ownership; `close` dispatches a remove-shaped
+command, `release` never touches the extension), `tabs` ownedTabId annotation,
+per-tab FIFO serialization (same-tab commands serialize in arrival order,
+different tabs don't block, a queued command still honours `cmd_timeout`), TTL
+reclaim (injected clock — released, not closed), the `no_owned_tab` error, the
+session id being routing-only (bearer/Host still enforced), and backward-compat
+(single session, no open → unchanged active-tab dispatch). Current totals: **72
+Python** (`test_server.py`) + **22 node** (`protocol.test.mjs`). The chrome.* glue
+in `service_worker.js` genuinely needs a real browser and is covered by the
+manual checklist in `extension/README.md`.
 
 ## Deploy (nix)
 

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -21,21 +21,51 @@ Full architecture, security model, and deploy: `scripts/browser-bridge/README.md
 `scripts/browser-bridge/browser <subcommand>` (JSON on stdout, pretty-printed if
 `jq` is present):
 
-Prefix any op with `--instance <key>` to target a specific connected profile:
-`browser --instance work html`.
+Prefix any op with `--instance <key>` to target a specific connected profile
+(`browser --instance work html`) and/or `--tab <id>` to target an explicit tab.
 
 | command | does |
 |---------|------|
 | `browser health`            | connected instances + count: `{"ok":true,"extension_connected":bool,"count":N,"instances":[…]}` |
 | `browser instances`         | list connected instances as JSON (routing key, label, instanceId, active-tab url/title) |
-| `browser [--instance K] html`              | active tab `outerHTML` (+ url, title) |
-| `browser [--instance K] eval '<js>'`       | run JS in the active tab, return its value |
-| `browser [--instance K] tabs`              | list open tabs |
-| `browser [--instance K] nav <url>`         | navigate the active tab to `<url>` |
-| `browser [--instance K] screenshot [path]` | captureVisibleTab; prints the data URL, or writes a `.png` to `path` |
+| `browser [--instance K] open [url]`        | open a NEW tab THIS session owns (default `about:blank`, created in the background); records ownership; returns its `tabId`. Use for multi-step work. |
+| `browser [--instance K] close`             | close this session's owned tab and drop ownership |
+| `browser [--instance K] release`           | drop ownership WITHOUT closing the tab |
+| `browser [--instance K] [--tab T] html`              | `outerHTML` of the owned tab (else the active tab) |
+| `browser [--instance K] [--tab T] eval '<js>'`       | run JS in the owned/active tab, return its value |
+| `browser [--instance K] tabs`              | list open tabs (`.data.ownedTabId` flags this session's owned tab) |
+| `browser [--instance K] [--tab T] nav <url>`         | navigate the owned/active tab to `<url>` |
+| `browser [--instance K] [--tab T] screenshot [path]` | captureVisibleTab; prints the data URL, or writes a `.png` to `path` |
+| `browser --print-session-id`               | print the derived per-session id (debug) and exit |
 
 Result payloads land under `.result.data` in the JSON (the envelope is
 `{"ok":true,"result":{"id","ok","data":{...}}}`).
+
+## Per-session tab isolation (use `open` for multi-step work)
+
+Two Claude sessions driving one browser used to interleave on the ONE shared
+active tab (session A `nav`s, session B `nav`s in between, A reads B's page).
+Now each session can own its own tab:
+
+- **Multi-step workflow → `browser open <url>` first.** The server records this
+  session's owned tab (keyed by a stable per-session id sent automatically on
+  every request) and routes your subsequent `html`/`eval`/`nav`/`screenshot`/
+  `close` to it — a parallel session doing the same on its own tab can't clobber
+  you. Finish with `browser close` (closes the tab) or `browser release` (keeps
+  the tab, drops ownership).
+- **One-shot read → just `browser html` (no `open`).** With no owned tab, ops
+  fall back to the active tab — the historical "read the tab the user has open"
+  behaviour, which is a single read and inherently safe.
+- **`--tab <id>`** targets a specific tab explicitly (overrides owned/active).
+- **Session id source:** `CLAUDE_CODE_SESSION_ID` → `$TMUX_PANE` → a
+  per-process-tree token (see README). It is routing-only, never trusted for
+  auth. If two sessions ever resolve the same id they share a tab (degrades to
+  the old behaviour — no worse).
+- **Contention → FIFO, not failure.** If two sessions DO target the same tab
+  (both active, or one `--tab`s another's tab), the commands queue in arrival
+  order (bounded by `cmd_timeout`) rather than fail.
+- **Lifecycle:** idle ownership is reclaimed after a TTL, which RELEASES it but
+  does NOT close the real Brave tab (only `browser close` closes it).
 
 ## Multiple instances (per host)
 
@@ -91,6 +121,7 @@ know browser usage is being counted. Details: `README.md` → Telemetry.
 - `503 extension_not_connected` → extension not loaded/paired, or Brave closed.
 - `504 timeout` → extension picked it up but didn't answer (tab unresponsive).
 - `409 ambiguous_instance` → >1 instance connected and no `--instance` — pick one.
+- `409 no_owned_tab` → `close` with nothing to close — run `browser open` first (or `--tab`).
 - `409 superseded` → the instance was replaced by a newer connection; retry.
 - `404 unknown_instance` → the `--instance` key matches no connected instance.
 - `400 unknown_op` / `missing_field:url|js` → bad command.

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -57,10 +57,28 @@ Now each session can own its own tab:
   fall back to the active tab — the historical "read the tab the user has open"
   behaviour, which is a single read and inherently safe.
 - **`--tab <id>`** targets a specific tab explicitly (overrides owned/active).
+- **Double `open` is safe (idempotent).** Calling `browser open` again in a
+  session that already owns a **live** tab returns that SAME tabId (it does not
+  leak a second tab). If the owned tab was closed, `open` makes a fresh one.
+- **Self-heal.** If the user manually closes your owned tab, the next op fails
+  with `owned_tab_gone` and the bridge drops your ownership — your NEXT command
+  automatically falls back to the active tab. `browser close` always clears the
+  mapping, even if the tab was already gone.
 - **Session id source:** `CLAUDE_CODE_SESSION_ID` → `$TMUX_PANE` → a
   per-process-tree token (see README). It is routing-only, never trusted for
-  auth. If two sessions ever resolve the same id they share a tab (degrades to
+  auth. If two drivers ever resolve the same id they share a tab (degrades to
   the old behaviour — no worse).
+- **⚠ Concurrent drivers that may share a session id (subagents): pass explicit
+  `--tab`.** Sibling subagents of ONE parent share identity — a subagent inherits
+  the parent's `CLAUDE_CODE_SESSION_ID` and the same `$TMUX_PANE`, and there is NO
+  subagent-unique env var — so two parallel subagents derive the SAME session id
+  and would own the SAME tab (re-introducing the clobber). Per-session isolation
+  only separates concurrent **top-level** sessions. When you spawn concurrent
+  drivers that each drive the browser, have EACH one `browser open` (capture the
+  returned `tabId`) and then pass its OWN `--tab <id>` on **every** subsequent op
+  (`browser --tab <id> nav …`, `--tab <id> html`, …). An explicit `--tab`
+  overrides owned-tab routing entirely, so indistinguishable drivers never
+  collide. (Each `close`s its own `--tab <id>` at the end.)
 - **Contention → FIFO, not failure.** If two sessions DO target the same tab
   (both active, or one `--tab`s another's tab), the commands queue in arrival
   order (bounded by `cmd_timeout`) rather than fail.
@@ -125,6 +143,10 @@ know browser usage is being counted. Details: `README.md` → Telemetry.
 - `409 superseded` → the instance was replaced by a newer connection; retry.
 - `404 unknown_instance` → the `--instance` key matches no connected instance.
 - `400 unknown_op` / `missing_field:url|js` → bad command.
+- `400 bad_tab` → a non-numeric `tab` (only reachable via a raw API POST; the CLI
+  already validates `--tab`).
+- `owned_tab_gone` (op-level, in `.result`) → your owned tab was closed; ownership
+  is auto-dropped, so just re-issue (it falls back to the active tab / re-`open`).
 - `401 unauthorized` → token mismatch (re-paste in the extension options).
 
 ## Gotcha: reload the unpacked extension after any change

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -71,9 +71,17 @@ die() { echo "browser: $*" >&2; exit 1; }
 #   4. a random token cached under the controlling process tree (keyed by the
 #      shell's PPID = the Claude Code process managing the Bash tool, stable
 #      across a session's calls), persisted so repeated calls read the same id.
-# DEGRADATION: if two sessions ever resolve the SAME id (e.g. both fall through
-# to the same PPID token, or a subagent inherits its parent's
-# CLAUDE_CODE_SESSION_ID), they SHARE a tab — no worse than the pre-fix behaviour.
+# DEGRADATION: if two drivers ever resolve the SAME id they SHARE a tab — no
+# worse than the pre-fix behaviour. This is NOT hypothetical for one case:
+# **sibling subagents of one parent share identity.** Empirically (dumped from
+# inside two parallel subagents) a subagent inherits the PARENT's
+# CLAUDE_CODE_SESSION_ID *and* runs in the same $TMUX_PANE, and the harness
+# injects NO subagent-unique, stable env var (no agentId/taskId/tool-use id is
+# visible to the subagent's own shell). So per-session isolation covers concurrent
+# TOP-LEVEL sessions, NOT sibling subagents of one parent. ESCAPE HATCH: two
+# drivers that may share a session id should each `open` and then pass the
+# returned `--tab <id>` explicitly on every subsequent op — an explicit --tab
+# overrides owned-tab routing entirely, so they never collide. See SKILL.md.
 derive_session_id() {
   if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then printf 'claude:%s' "$CLAUDE_CODE_SESSION_ID"; return; fi
   if [ -n "${CLAUDE_SESSION_ID:-}" ];      then printf 'claude:%s' "$CLAUDE_SESSION_ID"; return; fi

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -10,21 +10,38 @@
 # of connected instances keyed by a routing key (the profile's label, else its
 # stable auto-id). Use --instance to target one explicitly:
 #
-#   browser [--instance <key>] <subcommand>
+#   browser [--instance <key>] [--tab <id>] <subcommand>
 #
 # With exactly ONE instance connected, --instance is optional (back-compat). With
 # more than one and no --instance, a command ERRORS (it never guesses) and lists
 # the connected instances — pick one with --instance <key>.
 #
+# Per-session tab isolation (fixes concurrent-session clobbering):
+#   Two Claude sessions driving one browser used to interleave on ONE shared
+#   active tab. Now each session can `open` its OWN tab; the server records the
+#   ownership under a stable per-session id (X-Session-Id header, derived from
+#   CLAUDE_CODE_SESSION_ID → $TMUX_PANE → a per-process-tree token — see
+#   derive_session_id below) and routes that session's html/eval/nav/screenshot/
+#   close to ITS tab. A session that never `open`ed falls back to the active tab
+#   (the one-shot read path — inherently safe). `--tab <id>` overrides the target
+#   tab explicitly. Ownership has an idle TTL; on expiry it is RELEASED but the
+#   real Brave tab is NOT closed (only `browser close` closes it).
+#
 # Subcommands:
 #   browser health            — connected instances + count (per-instance)
 #   browser instances         — list connected instances as JSON (key/label/url)
-#   browser html              — outerHTML of the active tab (+ url, title)
-#   browser eval '<js>'       — run JS in the active tab, return its value
-#   browser tabs              — list open tabs
-#   browser nav <url>         — navigate the active tab to <url>
+#   browser open [url]        — open a NEW tab this session owns (default about:blank);
+#                               subsequent ops route to it. Prints its tabId.
+#   browser close             — close this session's owned tab + drop ownership
+#   browser release           — drop ownership WITHOUT closing the tab
+#   browser html              — outerHTML of the owned/active tab (+ url, title)
+#   browser eval '<js>'       — run JS in the owned/active tab, return its value
+#   browser tabs              — list open tabs (flags this session's owned tab)
+#   browser nav <url>         — navigate the owned/active tab to <url>
 #   browser screenshot [path] — captureVisibleTab; prints data URL, or writes a
-#                               .png to <path> if given
+#                               .png to <path> if given (a background owned tab is
+#                               briefly foregrounded to capture, then restored)
+#   browser --print-session-id — print the derived per-session id and exit
 #
 # Output is JSON on stdout (pretty-printed if `jq` is present). Exit non-zero on
 # transport/HTTP error so a caller can branch.
@@ -35,17 +52,57 @@ PORT="${BROWSER_BRIDGE_PORT:-8788}"
 TOKEN_FILE="${BROWSER_BRIDGE_TOKEN_FILE:-$HOME/.config/browser-bridge/token}"
 BASE="http://${HOST}:${PORT}"
 INSTANCE=""   # routing key set via --instance <key> (empty → single-instance)
+TAB=""        # explicit tab id set via --tab <id> (overrides owned/active routing)
 
 die() { echo "browser: $*" >&2; exit 1; }
 
-# Parse a leading --instance <key> / --instance=<key> (before the subcommand).
+# derive_session_id — a STABLE identifier for THIS Claude session, identical
+# across the many `browser` invocations one session makes (each is a fresh
+# `bash` process, so it must come from the environment / process tree, not shell
+# state). Sent as X-Session-Id on every /cmd so the server can route this session
+# to its OWN owned tab. Namespaced by source so ids from different sources can't
+# collide. Fallback chain (most→least reliable), documented in README/SKILL:
+#   1. CLAUDE_CODE_SESSION_ID — Claude Code's own session UUID (present since the
+#      2.1.x CLI; verified stable across every Bash-tool call in a session). Best.
+#   2. CLAUDE_SESSION_ID — defensive alternate spelling, in case a CLI build
+#      renames the var.
+#   3. $TMUX_PANE — the user runs each session in its own tmux pane, so the pane
+#      id is a good per-session proxy when no Claude var is exported.
+#   4. a random token cached under the controlling process tree (keyed by the
+#      shell's PPID = the Claude Code process managing the Bash tool, stable
+#      across a session's calls), persisted so repeated calls read the same id.
+# DEGRADATION: if two sessions ever resolve the SAME id (e.g. both fall through
+# to the same PPID token, or a subagent inherits its parent's
+# CLAUDE_CODE_SESSION_ID), they SHARE a tab — no worse than the pre-fix behaviour.
+derive_session_id() {
+  if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then printf 'claude:%s' "$CLAUDE_CODE_SESSION_ID"; return; fi
+  if [ -n "${CLAUDE_SESSION_ID:-}" ];      then printf 'claude:%s' "$CLAUDE_SESSION_ID"; return; fi
+  if [ -n "${TMUX_PANE:-}" ];              then printf 'tmux:%s' "$TMUX_PANE"; return; fi
+  local dir="${XDG_RUNTIME_DIR:-/tmp}/browser-bridge"
+  local f="${dir}/session-${PPID}"
+  if [ -r "$f" ]; then cat "$f"; return; fi
+  local rnd; rnd="$(head -c8 /dev/urandom 2>/dev/null | od -An -tx1 | tr -d ' \n')"
+  [ -n "$rnd" ] || rnd="$$"
+  local tok="ppid:${PPID}:${rnd}"
+  mkdir -p "$dir" 2>/dev/null || true
+  ( umask 077; printf '%s' "$tok" > "$f" ) 2>/dev/null || true
+  printf '%s' "$tok"
+}
+
+# Parse leading global flags (--instance / --tab / --print-session-id) before the
+# subcommand. --print-session-id short-circuits (no server/token needed).
 while [ $# -gt 0 ]; do
   case "$1" in
     --instance) shift; [ $# -ge 1 ] || die "usage: browser --instance <key> <subcommand>"; INSTANCE="$1"; shift ;;
     --instance=*) INSTANCE="${1#--instance=}"; shift ;;
+    --tab) shift; [ $# -ge 1 ] || die "usage: browser --tab <id> <subcommand>"; TAB="$1"; shift ;;
+    --tab=*) TAB="${1#--tab=}"; shift ;;
+    --print-session-id) derive_session_id; echo; exit 0 ;;
     *) break ;;
   esac
 done
+
+SESSION_ID="$(derive_session_id)"
 
 [ -r "$TOKEN_FILE" ] || die "token file not found/readable: $TOKEN_FILE (is the browser-bridge service running?)"
 TOKEN="$(tr -d '[:space:]' < "$TOKEN_FILE")"
@@ -81,9 +138,12 @@ for i in (insts or []):
 # caller splits it (globals can't cross the command-substitution subshell).
 _curl() {
   local method="$1" path="$2" body="${3:-}"
+  # X-Session-Id routes this session to its owned tab. It is ROUTING-ONLY — the
+  # server never trusts it for auth (bearer + Host still gate every request).
   local args=(-sS -m 60 -X "$method"
     -H "Authorization: Bearer ${TOKEN}"
     -H "Host: 127.0.0.1"
+    -H "X-Session-Id: ${SESSION_ID}"
     -w '\n%{http_code}')
   if [ -n "$body" ]; then
     args+=(-H "Content-Type: application/json" --data "$body")
@@ -117,7 +177,13 @@ cmd_op() {
   local op="$1" extra="${2:-}"
   local tgt=""
   if [ -n "$INSTANCE" ]; then tgt=",\"target\":$(json_str "$INSTANCE")"; fi
-  local body="{\"op\":\"${op}\"${extra:+,${extra}}${tgt}}"
+  # --tab injects an explicit numeric tab override (validated as an integer).
+  local tabf=""
+  if [ -n "$TAB" ]; then
+    case "$TAB" in (*[!0-9]*|"") die "--tab must be a numeric tab id (got: $TAB)";; esac
+    tabf=",\"tab\":${TAB}"
+  fi
+  local body="{\"op\":\"${op}\"${extra:+,${extra}}${tgt}${tabf}}"
   local raw HTTP_CODE resp
   raw="$(_curl POST /cmd "$body")" || die "curl failed talking to ${BASE}/cmd"
   HTTP_CODE="${raw##*$'\n'}"; resp="${raw%$'\n'*}"
@@ -127,11 +193,14 @@ cmd_op() {
     504) echo "$resp" >&2; die "timeout waiting for the extension to answer (is Brave focused / responsive?)" ;;
     401) die "unauthorized — token mismatch (re-paste the token in the extension options)" ;;
     409)
-      # ambiguous_instance (>1 connected, no --instance) or superseded.
+      # ambiguous_instance (>1 connected, no --instance), no_owned_tab, or superseded.
       if printf '%s' "$resp" | grep -q '"ambiguous_instance"'; then
         echo "browser: multiple instances connected — specify one with --instance <key>:" >&2
         printf '%s' "$resp" | render_instances
         exit 1
+      fi
+      if printf '%s' "$resp" | grep -q '"no_owned_tab"'; then
+        die "this session owns no tab to close — run 'browser open [url]' first (or pass --tab <id>)"
       fi
       echo "$resp" >&2
       die "instance superseded by a newer connection with the same key — retry"
@@ -178,6 +247,21 @@ case "$sub" in
     # Emit the instances array as JSON on stdout.
     printf '%s' "$resp" | python3 -c 'import json,sys; print(json.dumps(json.load(sys.stdin).get("instances", []), indent=2))'
     ;;
+  open)
+    # Optional url; default about:blank. Records this session's owned tab.
+    if [ $# -ge 1 ]; then
+      url="$(json_str "$1")"
+      cmd_op open "\"url\":${url}" | pretty
+    else
+      cmd_op open | pretty
+    fi
+    ;;
+  close)
+    cmd_op close | pretty
+    ;;
+  release)
+    cmd_op release | pretty
+    ;;
   html)
     cmd_op getHtml | pretty
     ;;
@@ -221,6 +305,6 @@ print(sys.argv[1])
     grep -E '^#( |$)' "$0" | sed -E 's/^# ?//'
     ;;
   *)
-    die "unknown subcommand: $sub (try: health instances html eval tabs nav screenshot)"
+    die "unknown subcommand: $sub (try: health instances open close release html eval tabs nav screenshot)"
     ;;
 esac

--- a/scripts/browser-bridge/extension/README.md
+++ b/scripts/browser-bridge/extension/README.md
@@ -31,8 +31,16 @@ back this:
   returns the real `tabId`. It creates the tab in the **background** (`active:
   false`) so parallel sessions each opening a tab don't fight over the
   foreground; the server records it as that session's owned tab.
+  **Idempotent re-open:** when the server passes `reuseTabId` (the session already
+  owns a tab), the SW `chrome.tabs.get(reuseTabId)`s it and returns that SAME tab
+  (`{tabId, url, reused:true}`) when it's still live — so a double `open` does NOT
+  create a second tab that would be orphaned/leaked. If the reuse tab is gone,
+  the SW falls through and creates a fresh one.
 - **`close`** → `chrome.tabs.remove(tabId)` (the server injects the owned tabId;
-  the SW errors `missing_tabId` if it's absent).
+  the SW errors `missing_tabId` if it's absent). **Idempotent:** if the tab was
+  already closed out-of-band, `chrome.tabs.remove` rejects and the SW returns
+  `{closed:tabId, alreadyGone:true}` (a success) so the server cleanly drops the
+  stale ownership rather than surfacing a spurious error.
 
 **Screenshot of a background owned tab:** `chrome.tabs.captureVisibleTab` only
 captures the **visible** tab of a window. If the target tab isn't active the SW
@@ -41,8 +49,9 @@ short visible flicker, but it never silently screenshots the wrong tab. A target
 tab that is already visible is captured directly with no flicker.
 
 If an owned tab was closed out-of-band, `chrome.tabs.get` throws and the op
-returns an `owned_tab_gone` error envelope (the server's TTL will later reclaim
-the stale ownership).
+returns an `owned_tab_gone` error envelope. On that signal the **server drops the
+session's ownership immediately** (self-heal → the next op falls back to the
+active tab), rather than waiting for the TTL to reclaim it.
 
 ## Multiple instances (label)
 
@@ -128,6 +137,17 @@ The chrome.* glue needs a real browser — verify by hand after loading:
 - [ ] `browser open https://example.com` opens a NEW background tab and returns
       its `tabId`; a following `browser html` reads THAT tab (not the previously
       active one); `browser close` closes it.
+- [ ] **Idempotent open (no orphan):** `browser open` twice in one session →
+      the second returns the SAME `tabId` (`reused:true`), and `brave://` shows
+      only ONE new tab (not two). `browser close` then closes that single tab.
+- [ ] **Self-heal:** `browser open` a tab, then close it MANUALLY in Brave. The
+      next `browser html` returns an `owned_tab_gone` error; the one AFTER that
+      succeeds against the active tab (ownership was auto-dropped). `browser open`
+      again creates a fresh owned tab.
+- [ ] **Subagent escape hatch:** two concurrent drivers that share a session id
+      (e.g. sibling subagents) each `browser open`, capture the `tabId`, and run
+      every op with `browser --tab <id> …`. Confirm each reads/navigates only its
+      OWN tab — the explicit `--tab` overrides the shared owned-tab routing.
 - [ ] `browser screenshot` of a background owned tab briefly flickers it to the
       foreground, captures it, and restores the tab that was active before.
 - [ ] **Two-session isolation (the fix):** open two Claude sessions (each in its

--- a/scripts/browser-bridge/extension/README.md
+++ b/scripts/browser-bridge/extension/README.md
@@ -16,6 +16,34 @@ or merge them.
 | `icons/icon.svg`    | gruvbox bridge/link glyph — the SVG source |
 | `icons/icon-{16,32,48,128}.png` | rasterised icons wired into the manifest (regenerate with `rsvg-convert`, see `../README.md`) |
 
+## Per-session tab targeting (open/close + injected tabId)
+
+The op executors run against a **target tab**, not always the active one. When
+the server injects a `tabId` (the calling Claude session owns a tab, or passed
+`--tab`), `getHtml`/`eval`/`nav`/`screenshot`/`close` run against **that** tab
+(`chrome.tabs.get(tabId)` → `chrome.scripting.executeScript({target:{tabId}})` /
+`chrome.tabs.update(tabId,…)` / `chrome.tabs.remove(tabId)`). With no injected
+`tabId` they fall back to the active tab (`chrome.tabs.query({active:true,
+lastFocusedWindow:true})`) — the historical single-session behaviour. Two new ops
+back this:
+
+- **`open`** → `chrome.tabs.create({url: url||"about:blank", active:false})` and
+  returns the real `tabId`. It creates the tab in the **background** (`active:
+  false`) so parallel sessions each opening a tab don't fight over the
+  foreground; the server records it as that session's owned tab.
+- **`close`** → `chrome.tabs.remove(tabId)` (the server injects the owned tabId;
+  the SW errors `missing_tabId` if it's absent).
+
+**Screenshot of a background owned tab:** `chrome.tabs.captureVisibleTab` only
+captures the **visible** tab of a window. If the target tab isn't active the SW
+briefly activates it, captures, then **restores** the previously-active tab — a
+short visible flicker, but it never silently screenshots the wrong tab. A target
+tab that is already visible is captured directly with no flicker.
+
+If an owned tab was closed out-of-band, `chrome.tabs.get` throws and the op
+returns an `owned_tab_gone` error envelope (the server's TTL will later reclaim
+the stale ownership).
+
 ## Multiple instances (label)
 
 Each profile that loads this extension is one **instance**. On first run the SW
@@ -97,4 +125,14 @@ The chrome.* glue needs a real browser — verify by hand after loading:
       worker console) and go quiet (~30 s between attempts), NOT spin — journald
       for `browser-bridge` should show at most an occasional `supersede`, not a
       flood. Fix one label → both settle and `browser instances` lists two again.
+- [ ] `browser open https://example.com` opens a NEW background tab and returns
+      its `tabId`; a following `browser html` reads THAT tab (not the previously
+      active one); `browser close` closes it.
+- [ ] `browser screenshot` of a background owned tab briefly flickers it to the
+      foreground, captures it, and restores the tab that was active before.
+- [ ] **Two-session isolation (the fix):** open two Claude sessions (each in its
+      own tmux pane). In each, `browser open` a DIFFERENT url, then interleave
+      `browser nav …` / `browser html` between the sessions. Confirm neither
+      clobbers the other — each `html` returns its OWN tab's page, never the other
+      session's. (`browser --print-session-id` in each shows the distinct ids.)
 - [ ] The toolbar shows the bridge/link icon (manifest `action.default_icon`).

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -4,7 +4,11 @@
 // asserted by protocol.test.mjs and documented in ../../README.md).
 
 // The command ops the bridge understands. MUST equal server.py ALLOWED_OPS.
-export const ALLOWED_OPS = ["getHtml", "eval", "tabs", "nav", "screenshot"];
+// `open` (create a per-session tab) and `close` (remove it) back the per-session
+// tab-isolation model; the server injects the target `tabId` on tab-scoped ops.
+export const ALLOWED_OPS = [
+  "getHtml", "eval", "tabs", "nav", "screenshot", "open", "close",
+];
 
 // Per-op required fields (mirrors server.py REQUIRED_FIELDS). The server already
 // validates these, but the SW re-checks so a hand-crafted command can't wedge it.

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -58,18 +58,34 @@ function authHeaders(token) {
   return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
 }
 
-// --- active-tab helpers ---------------------------------------------------- //
+// --- tab-targeting helpers ------------------------------------------------- //
 async function activeTab() {
   const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
   if (!tab) throw new Error("no_active_tab");
   return tab;
 }
 
+// The tab an op runs against. When the server injected a `tabId` (the caller
+// owns a tab, or passed --tab), use THAT tab — this is the per-session isolation
+// that stops two Claude sessions from clobbering one shared active tab. With no
+// tabId (a one-shot read by a session that never `open`ed), fall back to the
+// active tab — exactly the historical behaviour.
+async function targetTab(cmd) {
+  if (cmd && cmd.tabId != null) {
+    try {
+      return await chrome.tabs.get(cmd.tabId);
+    } catch (e) {
+      throw new Error("owned_tab_gone");   // the tab was closed out-of-band
+    }
+  }
+  return activeTab();
+}
+
 // --- op executors ---------------------------------------------------------- //
 // Each returns the op-specific `data` object; throws on failure (→ errorEnvelope).
 const OPS = {
-  async getHtml() {
-    const tab = await activeTab();
+  async getHtml(cmd) {
+    const tab = await targetTab(cmd);
     const [inj] = await chrome.scripting.executeScript({
       target: { tabId: tab.id },
       func: () => document.documentElement.outerHTML,
@@ -78,7 +94,7 @@ const OPS = {
   },
 
   async eval(cmd) {
-    const tab = await activeTab();
+    const tab = await targetTab(cmd);
     // chrome.scripting runs in an ISOLATED world; `js` is evaluated and its
     // completion value returned. Wrapped so a bare expression or a statement
     // block both work. Result must be JSON-serialisable (structured clone).
@@ -121,17 +137,55 @@ const OPS = {
   },
 
   async nav(cmd) {
-    const tab = await activeTab();
+    const tab = await targetTab(cmd);
     await chrome.tabs.update(tab.id, { url: cmd.url });
     return { tabId: tab.id, url: cmd.url };
   },
 
-  async screenshot() {
-    const tab = await activeTab();
-    const dataUrl = await chrome.tabs.captureVisibleTab(tab.windowId, {
-      format: "png",
+  async screenshot(cmd) {
+    const tab = await targetTab(cmd);
+    // captureVisibleTab only ever captures the VISIBLE tab of its window. If the
+    // caller's owned tab is in the background, capturing it requires briefly
+    // bringing it to the foreground. We do exactly that — activate → capture →
+    // restore the previously-active tab — so we never SILENTLY screenshot the
+    // wrong tab. This causes a brief visible flicker in that window (documented).
+    if (tab.active) {
+      const dataUrl = await chrome.tabs.captureVisibleTab(tab.windowId, { format: "png" });
+      return { url: tab.url, dataUrl };
+    }
+    let prevActiveId = null;
+    try {
+      const [prev] = await chrome.tabs.query({ active: true, windowId: tab.windowId });
+      prevActiveId = prev ? prev.id : null;
+      await chrome.tabs.update(tab.id, { active: true });
+      const dataUrl = await chrome.tabs.captureVisibleTab(tab.windowId, { format: "png" });
+      return { url: tab.url, dataUrl };
+    } finally {
+      // Restore focus to the tab that was active before, so a background
+      // screenshot doesn't permanently steal the user's foreground tab.
+      if (prevActiveId != null && prevActiveId !== tab.id) {
+        try { await chrome.tabs.update(prevActiveId, { active: true }); } catch (e) { /* ignore */ }
+      }
+    }
+  },
+
+  // Create a NEW tab for the calling session to own. active:false so parallel
+  // sessions don't fight over the foreground when each opens its own tab. The
+  // server records this real tabId as the session's owned tab.
+  async open(cmd) {
+    const tab = await chrome.tabs.create({
+      url: (cmd && cmd.url) ? cmd.url : "about:blank",
+      active: false,
     });
-    return { url: tab.url, dataUrl };
+    return { tabId: tab.id, url: tab.url || (cmd && cmd.url) || "about:blank" };
+  },
+
+  // Close the session's owned tab (the server injects its tabId). The server
+  // drops the ownership mapping on success.
+  async close(cmd) {
+    if (!cmd || cmd.tabId == null) throw new Error("missing_tabId");
+    await chrome.tabs.remove(cmd.tabId);
+    return { closed: cmd.tabId };
   },
 };
 

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -172,7 +172,20 @@ const OPS = {
   // Create a NEW tab for the calling session to own. active:false so parallel
   // sessions don't fight over the foreground when each opens its own tab. The
   // server records this real tabId as the session's owned tab.
+  //
+  // Idempotent re-open: when the server passes `reuseTabId` (the session already
+  // owns a tab), reuse THAT tab if it is still live instead of creating a second
+  // one — otherwise a double `open` would orphan the first real tab (no ownership
+  // → never closed → leaked). If the reuse tab is gone, fall through and open a
+  // fresh one (open-after-owned-tab-gone).
   async open(cmd) {
+    if (cmd && cmd.reuseTabId != null) {
+      try {
+        const existing = await chrome.tabs.get(cmd.reuseTabId);
+        return { tabId: existing.id, url: existing.url || "about:blank",
+                 reused: true };
+      } catch (e) { /* owned tab gone → open a fresh one below */ }
+    }
     const tab = await chrome.tabs.create({
       url: (cmd && cmd.url) ? cmd.url : "about:blank",
       active: false,
@@ -181,11 +194,18 @@ const OPS = {
   },
 
   // Close the session's owned tab (the server injects its tabId). The server
-  // drops the ownership mapping on success.
+  // drops the ownership mapping on success. Idempotent: if the tab was already
+  // closed out-of-band, `chrome.tabs.remove` rejects — treat that as success
+  // (the desired end-state, tab absent, already holds) so the session's stale
+  // ownership is cleanly dropped instead of surfacing a spurious error.
   async close(cmd) {
     if (!cmd || cmd.tabId == null) throw new Error("missing_tabId");
-    await chrome.tabs.remove(cmd.tabId);
-    return { closed: cmd.tabId };
+    try {
+      await chrome.tabs.remove(cmd.tabId);
+      return { closed: cmd.tabId };
+    } catch (e) {
+      return { closed: cmd.tabId, alreadyGone: true };
+    }
   },
 };
 

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -589,6 +589,15 @@ class Registry:
             inst = self._resolve_target_locked(target)
             tab_id, tab_key = self._effective_tab_locked(inst, op, session_id,
                                                          tab)
+            # Idempotent `open`: if this session already owns a tab on the target
+            # instance, hand the extension that tabId as `reuseTabId`. The SW
+            # returns the SAME tab when it is still live (no second real tab → no
+            # orphaned/leaked tab) and only creates a fresh one when the old tab
+            # is gone (owned_tab_gone) — so a double `open` never orphans a tab.
+            reuse_tab_id = None
+            if op == "open" and session_id is not None and tab is None:
+                reuse_tab_id = self._owned_tab_locked(inst.key, session_id,
+                                                      touch=False)
             deadline = self._clock() + timeout
             ticket = object()
             if tab_key is not None:
@@ -609,6 +618,8 @@ class Registry:
                 cmd["id"] = cid
                 if tab_id is not None:
                     cmd["tabId"] = tab_id
+                if reuse_tab_id is not None:
+                    cmd["reuseTabId"] = reuse_tab_id
                 inst.outbox.append(cmd)
                 inst.waiters.add(cid)
                 self._cond.notify_all()  # wake this instance's waiting poller
@@ -643,22 +654,47 @@ class Registry:
 
     def _record_ownership_locked(self, inst, op, session_id, tab_id,
                                  result) -> None:
-        """After a successful op, update the session's ownership: `open` records
-        the newly-created tabId; `close` drops the mapping (the tab is gone)."""
+        """After an op, reconcile the session's ownership mapping.
+
+        `open` records the (re)used tabId; `close` drops the mapping; a
+        tab-scoped op whose OWNED tab turns out to be gone drops the stale
+        mapping so the session self-heals to the active-tab fallback.
+        """
         if session_id is None or not isinstance(result, dict):
             return
-        if result.get("ok") is False:
-            return  # op threw in the page → don't record/drop on a failure
+        okey = (inst.key, session_id)
+        failed = result.get("ok") is False
+        # `close` drops ownership UNCONDITIONALLY: the session asked to end its
+        # tab, so the desired end-state is "no mapping" whether the remove
+        # succeeded OR the tab was already gone (idempotent). Otherwise a tab the
+        # user closed out-of-band would wedge the session to a dead id until the
+        # TTL reclaimed it, and `close` could never clear it (remove → ok:false).
+        if op == "close":
+            if self._owners.pop(okey, None) is not None:
+                log("owner_close", key=inst.key, session=session_id,
+                    tab=tab_id, ok=(not failed))
+            return
+        if failed:
+            # Self-heal: a tab-scoped op that failed because ITS owned tab is
+            # gone → drop the stale mapping so the NEXT command falls back to the
+            # active tab instead of re-dispatching to the dead tabId for up to
+            # OWNER_TTL. Only evict when the dispatched tab IS the session's owned
+            # tab — an explicit --tab to some other gone tab must not evict a
+            # healthy owned mapping.
+            if _is_tab_gone(result.get("error")):
+                o = self._owners.get(okey)
+                if o is not None and o["tab_id"] == tab_id:
+                    del self._owners[okey]
+                    log("owner_tab_gone", key=inst.key, session=session_id,
+                        tab=tab_id)
+            return  # op threw in the page → nothing else to record
         if op == "open":
             data = result.get("data")
             tid = data.get("tabId") if isinstance(data, dict) else None
             if isinstance(tid, int):
-                self._owners[(inst.key, session_id)] = {
+                self._owners[okey] = {
                     "tab_id": tid, "last_seen": self._clock()}
                 log("owner_open", key=inst.key, session=session_id, tab=tid)
-        elif op == "close":
-            self._owners.pop((inst.key, session_id), None)
-            log("owner_close", key=inst.key, session=session_id, tab=tab_id)
         elif op == "tabs":
             # Annotate the listing with which tab (if any) THIS session owns, so
             # `browser tabs` can flag it. Metadata only (a tabId, never content).
@@ -711,6 +747,41 @@ class Registry:
     def connected(self) -> bool:
         with self._cond:
             return bool(self._live_instances_locked())
+
+
+# --------------------------------------------------------------------------- #
+# Small scalar guards (module-level so they're directly unit-testable)
+# --------------------------------------------------------------------------- #
+def _is_tab_gone(err) -> bool:
+    """True if an op-level error string signals the target tab no longer exists.
+
+    The extension raises a clean `owned_tab_gone` (its `chrome.tabs.get` on the
+    injected tabId failed); we also match chrome's raw "No tab with id" message
+    defensively so an older/edge extension build still triggers the self-heal.
+    """
+    if not isinstance(err, str):
+        return False
+    e = err.lower()
+    return "owned_tab_gone" in e or "no tab with id" in e
+
+
+def _coerce_tab(tab):
+    """Coerce a raw `tab` request field to a non-negative int tab id.
+
+    Returns (tab_id, None) on success or (None, "bad_tab") on an invalid value.
+    A raw token-holder could POST `{"op":"getHtml","tab":[1,2]}`; an unhashable
+    `tab` would blow up the per-tab turnstile key with an uncaught TypeError → a
+    500. This is the server-side safety net (the `browser` CLI already validates
+    `--tab` is numeric) so a malformed `tab` yields a clean 400 instead. `bool`
+    is rejected explicitly (it is an `int` subclass but never a real tab id).
+    """
+    if isinstance(tab, bool):
+        return None, "bad_tab"
+    if isinstance(tab, int):
+        return (tab, None) if tab >= 0 else (None, "bad_tab")
+    if isinstance(tab, str) and tab.isdigit():
+        return int(tab), None
+    return None, "bad_tab"
 
 
 # --------------------------------------------------------------------------- #
@@ -888,6 +959,15 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
             # gated this request in _guard).
             target = body.pop("target", None)
             tab = body.pop("tab", None)
+            if tab is not None:
+                # Guard a malformed `tab` from a raw token-holder (the CLI already
+                # validates --tab is numeric): a non-scalar would make an
+                # unhashable turnstile key → an uncaught TypeError → 500. Coerce
+                # to an int here; an invalid value is a clean 400, not a 500.
+                tab, terr = _coerce_tab(tab)
+                if terr:
+                    self._send(400, {"ok": False, "error": terr})
+                    return
             session_id = self.headers.get(HDR_SESSION_ID) or None
             outcome, exit_code, domain = "ok", 0, ""
             # `release` is server-side: drop the session's ownership without ever

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -86,11 +86,25 @@ from pathlib import Path
 from urllib.parse import unquote, urlsplit
 
 # --- protocol contract (shared with extension/protocol.js — keep in sync) ---- #
-# The op set the bridge accepts. Both sides validate against this exact set; the
-# JS side mirrors it in extension/protocol.js (asserted by the extension test).
-ALLOWED_OPS = ("getHtml", "eval", "tabs", "nav", "screenshot")
+# The op set the bridge accepts and DISPATCHES to the extension. Both sides
+# validate against this exact set; the JS side mirrors it in
+# extension/protocol.js (asserted by the extension test). `open`/`close` were
+# added for per-session tab isolation (see the Session isolation block below).
+ALLOWED_OPS = ("getHtml", "eval", "tabs", "nav", "screenshot", "open", "close")
 
-# Per-op required fields (skill-supplied). Absent → 400 bad_request.
+# Ops handled ENTIRELY server-side (never dispatched to the extension). `release`
+# relinquishes a session's owned-tab mapping without touching the real Brave tab.
+# Not part of the shared JS contract (the extension never sees these).
+SERVER_OPS = ("release",)
+
+# Ops that act on ONE specific tab and therefore participate in per-tab FIFO
+# serialization (see Registry.submit). `open` (creates a tab), `tabs` (lists all)
+# and `release` (server-side) do NOT contend for a single tab.
+TAB_SCOPED_OPS = frozenset({"getHtml", "eval", "nav", "screenshot", "close"})
+
+# Per-op required fields (skill-supplied). Absent → 400 bad_request. NOTE: `close`
+# takes NO skill-supplied field — the server injects the caller's owned tabId (or
+# a --tab override); it errors with `no_owned_tab` if the session owns nothing.
 REQUIRED_FIELDS = {
     "eval": ("js",),
     "nav": ("url",),
@@ -101,6 +115,36 @@ MAX_RESULT_BODY = 32 * 1024 * 1024  # a screenshot data URL can be a few MB.
 
 # A connection is considered "present" if a long-poll landed within this window.
 CONNECT_STALE_S = 40.0
+
+# Session isolation (fixes concurrent-session tab clobbering)
+# ----------------------------------------------------------
+# Every op historically targeted "the active tab of the last-focused window", so
+# two Claude sessions driving one browser instance interleaved on ONE shared tab
+# (A does `nav X` then `getHtml`; B does `nav Y` in between; A reads Y). The
+# transport was already correct (cid-correlated, no cross-delivery) — the clobber
+# was SEMANTIC: no per-session (multi-step workflow) tab isolation.
+#
+# Fix: a session may `open` its OWN tab; the server records
+# `(instance_key, session_id) -> owned_tab_id` and routes that session's
+# tab-scoped ops (html/eval/nav/screenshot/close) to ITS tab. A session with no
+# owned tab falls back to the active tab (the one-shot "read the tab I have open"
+# path — a single read, inherently safe). `--tab <id>` overrides explicitly.
+#
+# The session_id is supplied by the `browser` skill on EVERY /cmd via the
+# X-Session-Id header (derived from CLAUDE_CODE_SESSION_ID, else $TMUX_PANE, else
+# a per-process-tree token — see the skill). It is used for ROUTING ONLY and is
+# NEVER trusted for auth (bearer + Host still gate every request). If two sessions
+# somehow present the SAME id they would share a tab (documented degradation).
+#
+# Ownership has an idle TTL: a session that stops calling has its mapping
+# reclaimed (released) so dead sessions don't leak ownership forever. Reclaim
+# RELEASES ownership but deliberately does NOT close the real Brave tab (never
+# yank a visible tab out from under the user); explicit `browser close` closes it.
+HDR_SESSION_ID = "X-Session-Id"
+
+# Idle seconds after which a session's tab ownership is reclaimed (released, NOT
+# closed). Refreshed on every op the session routes through its owned tab.
+OWNER_TTL_S = float(os.environ.get("BROWSER_BRIDGE_OWNER_TTL", "900"))
 
 # Synthetic routing key for a legacy extension that polls without a handshake
 # (no X-Bridge-Instance-Id). All such polls collapse onto one unnamed instance.
@@ -316,6 +360,11 @@ class BridgeSuperseded(Exception):
         self.key = key
 
 
+class NoOwnedTab(Exception):
+    """A `close` was issued by a session that owns no tab on the target instance
+    (and gave no explicit --tab). Nothing to close → a clear error, not a guess."""
+
+
 class Instance:
     """One connected extension: its own command queue + reply correlation.
 
@@ -352,10 +401,19 @@ class Registry:
     single `_cond` — blocking here is safe and cheap.
     """
 
-    def __init__(self, clock=time.monotonic):
+    def __init__(self, clock=time.monotonic, owner_ttl=OWNER_TTL_S):
         self._cond = threading.Condition()
         self._instances: dict[str, Instance] = {}   # routing key -> Instance
         self._clock = clock
+        # Per-session tab ownership: (instance_key, session_id) -> {tab_id, last_seen}.
+        # Guarded by _cond like everything else. An idle TTL reclaims dead sessions.
+        self._owners: dict[tuple, dict] = {}
+        self._owner_ttl = owner_ttl
+        # Per-tab FIFO turnstiles: tab_key -> deque of arrival-ordered tickets.
+        # A command holding a tab_key's HEAD ticket is the one allowed to be
+        # in-flight; the rest block (in arrival order) until it completes. Only
+        # commands that target the SAME tab contend; different tabs never block.
+        self._tab_queues: dict[tuple, deque] = {}
 
     # --- registration ------------------------------------------------------ #
     def _register_locked(self, instance_id: str, label: str,
@@ -394,6 +452,71 @@ class Registry:
         self._cond.notify_all()
         log("supersede", key=inst.key, instance_id=inst.instance_id,
             reason=reason)
+
+    # --- per-session tab ownership ---------------------------------------- #
+    def _reap_owners_locked(self) -> None:
+        """Reclaim (release, do NOT close) ownership for sessions idle past the
+        TTL. Called on every ownership touch so dead sessions never leak."""
+        now = self._clock()
+        dead = [k for k, o in self._owners.items()
+                if now - o["last_seen"] > self._owner_ttl]
+        for k in dead:
+            del self._owners[k]
+            log("owner_reclaim", key=k[0], session=k[1])
+
+    def _owned_tab_locked(self, inst_key: str, session_id, *, touch: bool):
+        """Return the tab_id this (instance, session) owns, or None. If `touch`,
+        refresh its idle timer (any op that routes through the tab keeps it
+        alive). Reaps expired owners first so a just-expired mapping reads None."""
+        self._reap_owners_locked()
+        if session_id is None:
+            return None
+        o = self._owners.get((inst_key, session_id))
+        if o is None:
+            return None
+        if touch:
+            o["last_seen"] = self._clock()
+        return o["tab_id"]
+
+    def _effective_tab_locked(self, inst, op, session_id, tab):
+        """Resolve (tab_id, tab_key) for a command.
+
+        tab_id is what gets injected into the dispatched command (None → the
+        extension uses the active tab). tab_key is the per-tab FIFO turnstile key
+        (None → the op does not contend for a single tab). Raises NoOwnedTab for a
+        `close` that has neither an explicit --tab nor an owned tab.
+        """
+        owned = self._owned_tab_locked(inst.key, session_id, touch=True)
+        if op not in TAB_SCOPED_OPS:
+            # open (creates a tab) / tabs (lists all): never injected, never gated.
+            return None, None
+        resolved = tab if tab is not None else owned
+        if op == "close" and resolved is None:
+            raise NoOwnedTab()
+        # Active-tab ops with no concrete tab still share ONE physical tab per
+        # instance, so they serialize under a synthetic "active" key.
+        tab_key = (inst.key, resolved if resolved is not None else "active")
+        return resolved, tab_key
+
+    def release_session(self, session_id) -> int:
+        """Drop ALL tab ownership held by `session_id` (across every instance)
+        WITHOUT closing any real tab. Returns how many mappings were released."""
+        if session_id is None:
+            return 0
+        with self._cond:
+            keys = [k for k in self._owners if k[1] == session_id]
+            for k in keys:
+                del self._owners[k]
+            if keys:
+                log("owner_release", session=session_id, count=len(keys))
+            return len(keys)
+
+    def owners_snapshot(self):
+        """Test/introspection helper: {(key,session): tab_id} of live owners
+        (expired ones reaped first)."""
+        with self._cond:
+            self._reap_owners_locked()
+            return {k: o["tab_id"] for k, o in self._owners.items()}
 
     # --- extension side ---------------------------------------------------- #
     def poll(self, instance_id: str, label: str, wait_timeout: float,
@@ -443,36 +566,106 @@ class Registry:
             return False
 
     # --- skill side -------------------------------------------------------- #
-    def submit(self, command: dict, timeout: float, target: str = None) -> dict:
+    def submit(self, command: dict, timeout: float, target: str = None,
+               session_id=None, tab=None) -> dict:
         """Enqueue `command` (a dict without id) to the resolved target instance
         and block for its reply.
 
+        Session isolation: if the calling `session_id` OWNS a tab on the target
+        instance (or `tab` is an explicit override), tab-scoped ops route to that
+        tabId; otherwise they fall back to the active tab. Tab-scoped commands
+        that target the SAME tab are serialized FIFO in arrival order (`open`
+        creates a tab and `tabs` lists all — neither contends). `open`/`close`
+        also record/drop the session's ownership on success.
+
         Raises NoExtension / AmbiguousInstance / UnknownInstance if the target
-        cannot be resolved, BridgeSuperseded if the servicing instance is
-        dropped mid-flight, or BridgeTimeout on no reply within `timeout`.
+        cannot be resolved, NoOwnedTab for a `close` with nothing to close,
+        BridgeSuperseded if the servicing instance is dropped mid-flight, or
+        BridgeTimeout on no reply within `timeout` (the upper bound that keeps a
+        FIFO-queued command from blocking forever).
         """
+        op = command.get("op")
         with self._cond:
             inst = self._resolve_target_locked(target)
-            cid = secrets.token_hex(8)
-            cmd = dict(command)
-            cmd["id"] = cid
-            inst.outbox.append(cmd)
-            inst.waiters.add(cid)
-            self._cond.notify_all()  # wake this instance's waiting poller
+            tab_id, tab_key = self._effective_tab_locked(inst, op, session_id,
+                                                         tab)
             deadline = self._clock() + timeout
-            while cid not in inst.results:
-                if inst.superseded:
-                    inst.waiters.discard(cid)
-                    raise BridgeSuperseded(inst.key)
-                remaining = deadline - self._clock()
-                if remaining <= 0:
-                    inst.waiters.discard(cid)
-                    inst.outbox = deque(c for c in inst.outbox
-                                        if c.get("id") != cid)
-                    raise BridgeTimeout()
-                self._cond.wait(remaining)
-            inst.waiters.discard(cid)
-            return inst.results.pop(cid)
+            ticket = object()
+            if tab_key is not None:
+                self._tab_queues.setdefault(tab_key, deque()).append(ticket)
+            try:
+                # (1) Wait for this tab's FIFO turn (no-op when tab_key is None).
+                if tab_key is not None:
+                    while self._tab_queues[tab_key][0] is not ticket:
+                        if inst.superseded:
+                            raise BridgeSuperseded(inst.key)
+                        remaining = deadline - self._clock()
+                        if remaining <= 0:
+                            raise BridgeTimeout()
+                        self._cond.wait(remaining)
+                # (2) Our turn: enqueue the command (with the resolved tabId).
+                cid = secrets.token_hex(8)
+                cmd = dict(command)
+                cmd["id"] = cid
+                if tab_id is not None:
+                    cmd["tabId"] = tab_id
+                inst.outbox.append(cmd)
+                inst.waiters.add(cid)
+                self._cond.notify_all()  # wake this instance's waiting poller
+                while cid not in inst.results:
+                    if inst.superseded:
+                        inst.waiters.discard(cid)
+                        raise BridgeSuperseded(inst.key)
+                    remaining = deadline - self._clock()
+                    if remaining <= 0:
+                        inst.waiters.discard(cid)
+                        inst.outbox = deque(c for c in inst.outbox
+                                            if c.get("id") != cid)
+                        raise BridgeTimeout()
+                    self._cond.wait(remaining)
+                inst.waiters.discard(cid)
+                result = inst.results.pop(cid)
+                self._record_ownership_locked(inst, op, session_id, tab_id,
+                                              result)
+                return result
+            finally:
+                # (3) Leave the turnstile and wake the next in line.
+                if tab_key is not None:
+                    q = self._tab_queues.get(tab_key)
+                    if q is not None:
+                        try:
+                            q.remove(ticket)
+                        except ValueError:
+                            pass
+                        if not q:
+                            del self._tab_queues[tab_key]
+                    self._cond.notify_all()
+
+    def _record_ownership_locked(self, inst, op, session_id, tab_id,
+                                 result) -> None:
+        """After a successful op, update the session's ownership: `open` records
+        the newly-created tabId; `close` drops the mapping (the tab is gone)."""
+        if session_id is None or not isinstance(result, dict):
+            return
+        if result.get("ok") is False:
+            return  # op threw in the page → don't record/drop on a failure
+        if op == "open":
+            data = result.get("data")
+            tid = data.get("tabId") if isinstance(data, dict) else None
+            if isinstance(tid, int):
+                self._owners[(inst.key, session_id)] = {
+                    "tab_id": tid, "last_seen": self._clock()}
+                log("owner_open", key=inst.key, session=session_id, tab=tid)
+        elif op == "close":
+            self._owners.pop((inst.key, session_id), None)
+            log("owner_close", key=inst.key, session=session_id, tab=tab_id)
+        elif op == "tabs":
+            # Annotate the listing with which tab (if any) THIS session owns, so
+            # `browser tabs` can flag it. Metadata only (a tabId, never content).
+            data = result.get("data")
+            if isinstance(data, dict):
+                data["ownedTabId"] = self._owned_tab_locked(
+                    inst.key, session_id, touch=False)
 
     # --- resolution / introspection --------------------------------------- #
     def _live_instances_locked(self):
@@ -528,7 +721,7 @@ def validate_command(body):
     if not isinstance(body, dict):
         return None, "body_not_object"
     op = body.get("op")
-    if op not in ALLOWED_OPS:
+    if op not in ALLOWED_OPS and op not in SERVER_OPS:
         return None, "unknown_op"
     for field in REQUIRED_FIELDS.get(op, ()):
         if not body.get(field):
@@ -688,13 +881,34 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                                  "op": body.get("op") if isinstance(body, dict)
                                  else None})
                 return
-            # `target` is a skill-side routing hint, NOT part of the command the
-            # extension executes — strip it before enqueue.
+            # `target`/`tab` are skill-side routing hints, NOT part of the command
+            # the extension executes — strip them before enqueue. `session_id`
+            # (X-Session-Id header) routes to the caller's owned tab; it is used
+            # for ROUTING ONLY and is NEVER trusted for auth (bearer + Host already
+            # gated this request in _guard).
             target = body.pop("target", None)
+            tab = body.pop("tab", None)
+            session_id = self.headers.get(HDR_SESSION_ID) or None
             outcome, exit_code, domain = "ok", 0, ""
+            # `release` is server-side: drop the session's ownership without ever
+            # touching the real Brave tab or the extension.
+            if op == "release":
+                n = registry.release_session(session_id)
+                self._send(200, {"ok": True, "result": {
+                    "id": None, "ok": True, "data": {"released": n}}})
+                emit_cmd_event(
+                    op=op, key=(target or ""), outcome="ok",
+                    duration_ms=int((time.monotonic() - t0) * 1000),
+                    domain="", exit_code=0)
+                return
             try:
                 result = registry.submit(body, timeout=cmd_timeout,
-                                         target=target)
+                                         target=target, session_id=session_id,
+                                         tab=tab)
+            except NoOwnedTab:
+                outcome, exit_code = "no_owned_tab", 1
+                log("cmd_no_owned_tab", op=op)
+                self._send(409, {"ok": False, "error": "no_owned_tab"})
             except NoExtension:
                 outcome, exit_code = "no_extension", 1
                 log("cmd_no_extension", op=op)

--- a/scripts/browser-bridge/tests/protocol.test.mjs
+++ b/scripts/browser-bridge/tests/protocol.test.mjs
@@ -18,11 +18,32 @@ import {
 } from "../extension/protocol.js";
 
 test("op set mirrors the server contract", () => {
-  // If this changes, server.py ALLOWED_OPS must change in lockstep.
+  // If this changes, server.py ALLOWED_OPS must change in lockstep. `open`/`close`
+  // back the per-session tab-isolation model (`release` is server-side only, so
+  // it is deliberately NOT in the shared op set).
   assert.deepEqual(
     [...ALLOWED_OPS].sort(),
-    ["eval", "getHtml", "nav", "screenshot", "tabs"],
+    ["close", "eval", "getHtml", "nav", "open", "screenshot", "tabs"],
   );
+});
+
+test("validateCommand accepts the tab-isolation ops (open/close)", () => {
+  // open takes an OPTIONAL url; close takes no skill-supplied field (the server
+  // injects the owned tabId) — so a bare op validates for both.
+  assert.deepEqual(validateCommand({ op: "open" }), { ok: true });
+  assert.deepEqual(validateCommand({ op: "open", url: "https://x.test" }), { ok: true });
+  assert.deepEqual(validateCommand({ op: "close" }), { ok: true });
+  // A server-injected tabId on a tab-scoped op is accepted (never rejected).
+  assert.deepEqual(validateCommand({ op: "getHtml", tabId: 42 }), { ok: true });
+  assert.deepEqual(validateCommand({ op: "nav", url: "https://x", tabId: 7 }), { ok: true });
+});
+
+test("open/close result envelopes carry their tab payloads", () => {
+  // The wire shapes the SW returns for the new ops.
+  assert.deepEqual(resultEnvelope("cid", { tabId: 101, url: "about:blank" }),
+    { id: "cid", ok: true, data: { tabId: 101, url: "about:blank" } });
+  assert.deepEqual(resultEnvelope("cid", { closed: 101 }),
+    { id: "cid", ok: true, data: { closed: 101 } });
 });
 
 test("validateCommand accepts a bare op", () => {

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -127,8 +127,8 @@ def _req(srv, method, path, body=None, token=TOKEN, host="127.0.0.1",
         return e.code, (json.loads(raw) if raw else None)
 
 
-def _serve(cmd_timeout=5.0, poll_timeout=5.0):
-    registry = S.Registry()
+def _serve(cmd_timeout=5.0, poll_timeout=5.0, registry=None):
+    registry = registry if registry is not None else S.Registry()
     handler = S.make_handler(registry, TOKEN, cmd_timeout, poll_timeout)
     srv = S.ThreadingHTTPServer(("127.0.0.1", 0), handler)
     srv.daemon_threads = True
@@ -151,6 +151,7 @@ class FakeExtension(threading.Thread):
         self.swallow = swallow  # pick up a command but never answer (→ timeout)
         self.active_url = active_url
         self.active_title = active_title
+        self.dispatched = []    # every command this fake picked up (for assertions)
         self._stopev = threading.Event()
 
     def _poll_headers(self):
@@ -174,6 +175,7 @@ class FakeExtension(threading.Thread):
                 continue
             if status == 204 or cmd is None:
                 continue
+            self.dispatched.append(cmd)
             if self.swallow:
                 continue
             envelope = {"id": cmd["id"], "ok": True,
@@ -865,7 +867,12 @@ def test_registry_supersede_inflight_resolves_error_no_leak():
 
 def test_registry_id_correlation_out_of_order():
     """Two concurrent submits to the SAME instance get their OWN replies even
-    when the extension answers them in reverse order."""
+    when the extension answers them in reverse order.
+
+    They target DIFFERENT tabs so both are concurrently in-flight — commands to
+    the SAME tab now serialize FIFO (per-tab isolation), so only distinct tabs
+    can be simultaneously outstanding. The transport's cid correlation is what's
+    under test here and is unchanged."""
     reg = S.Registry()
     poll_done = threading.Event()
     picked = []
@@ -881,7 +888,9 @@ def test_registry_id_correlation_out_of_order():
     results = {}
 
     def submit(tag):
-        results[tag] = reg.submit({"op": "eval", "tag": tag}, timeout=3.0)
+        # Distinct tabs (1 for A, 2 for B) → independent tab-FIFO turnstiles.
+        results[tag] = reg.submit({"op": "eval", "tag": tag}, timeout=3.0,
+                                  tab=(1 if tag == "A" else 2))
 
     s1 = threading.Thread(target=submit, args=("A",), daemon=True)
     s2 = threading.Thread(target=submit, args=("B",), daemon=True)
@@ -916,12 +925,18 @@ def test_registry_deliver_unknown_id_false():
 
 def test_validate_command_contract():
     # The op set is the shared contract with extension/protocol.js.
-    assert set(S.ALLOWED_OPS) == {"getHtml", "eval", "tabs", "nav", "screenshot"}
+    assert set(S.ALLOWED_OPS) == {"getHtml", "eval", "tabs", "nav", "screenshot",
+                                  "open", "close"}
     assert S.validate_command({"op": "tabs"}) == ("tabs", None)
     assert S.validate_command({"op": "eval", "js": "1"})[0] == "eval"
     assert S.validate_command({"op": "eval"})[1] == "missing_field:js"
     assert S.validate_command({"op": "bogus"})[1] == "unknown_op"
     assert S.validate_command("nope")[1] == "body_not_object"
+    # open/close (dispatched) and release (server-side) are all accepted ops.
+    assert S.validate_command({"op": "open"}) == ("open", None)
+    assert S.validate_command({"op": "close"}) == ("close", None)
+    assert S.validate_command({"op": "release"}) == ("release", None)
+    assert "release" in S.SERVER_OPS and "release" not in S.ALLOWED_OPS
 
 
 # --------------------------------------------------------------------------- #
@@ -1215,3 +1230,401 @@ def test_load_spool_emit_missing_path_returns_none(monkeypatch, tmp_path):
     monkeypatch.setattr(S, "_spool_emit_mod", None)
     monkeypatch.setattr(S, "_spool_emit_tried", False)
     assert S._load_spool_emit() is None
+
+
+# --------------------------------------------------------------------------- #
+# Per-session tab isolation (the concurrent-session clobber fix)
+#
+# The clobber was SEMANTIC: every op targeted the ONE shared active tab, so two
+# sessions' multi-step workflows interleaved on it. Fix: a session `open`s its own
+# tab; the server records `(instance_key, session_id) -> tabId` and routes that
+# session's tab-scoped ops to ITS tab. These are all headless — an in-process
+# FakeExtension that ECHOES the dispatched tabId models "which tab did the op hit".
+# --------------------------------------------------------------------------- #
+def _wait_until(pred, timeout=3.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if pred():
+            return True
+        time.sleep(0.005)
+    return pred()
+
+
+def _tab_echo_exec(open_ids):
+    """Executor: `open` returns the next id from `open_ids`; every other op echoes
+    back the tabId the SERVER injected (None → active-tab fallback) + the op."""
+    it = iter(open_ids)
+
+    def _exec(cmd):
+        if cmd["op"] == "open":
+            return {"tabId": next(it), "url": cmd.get("url")}
+        if cmd["op"] == "close":
+            return {"closed": cmd.get("tabId")}
+        return {"tabId": cmd.get("tabId"), "op": cmd["op"]}
+    return _exec
+
+
+def _cmd(srv, body, session=None):
+    hdrs = {S.HDR_SESSION_ID: session} if session is not None else None
+    return _req(srv, "POST", "/cmd", body, headers=hdrs)
+
+
+# --- ownership: open records (instance,session)->tabId --------------------- #
+def test_open_records_ownership_and_returns_tabid():
+    srv, reg = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_echo_exec([101]))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _cmd(srv, {"op": "open", "url": "https://a.test"}, session="A")
+        assert st == 200
+        assert body["result"]["data"]["tabId"] == 101
+        assert reg.owners_snapshot() == {("only", "A"): 101}
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_two_sessions_get_distinct_ownership():
+    srv, reg = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_echo_exec([101, 202]))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _cmd(srv, {"op": "open"}, session="A")[1]["result"]["data"]["tabId"] == 101
+        assert _cmd(srv, {"op": "open"}, session="B")[1]["result"]["data"]["tabId"] == 202
+        assert reg.owners_snapshot() == {("only", "A"): 101, ("only", "B"): 202}
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --- routing: a session's ops carry ITS owned tabId ------------------------ #
+def test_owned_session_ops_route_to_its_tab():
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_echo_exec([101]))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        _cmd(srv, {"op": "open"}, session="A")
+        for op in ("getHtml", "eval", "nav"):
+            b = {"op": op}
+            if op == "eval":
+                b["js"] = "1"
+            if op == "nav":
+                b["url"] = "https://x.test"
+            st, body = _cmd(srv, b, session="A")
+            assert st == 200, (op, body)
+            assert body["result"]["data"]["tabId"] == 101, \
+                f"{op} must route to A's owned tab 101"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_no_owned_tab_falls_back_to_active():
+    """A session that never `open`ed → no tabId injected (extension uses the
+    active tab). This preserves the one-shot 'read the tab I have open' path."""
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=lambda c: {"hasTab": ("tabId" in c), "op": c["op"]})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _cmd(srv, {"op": "getHtml"}, session="Z")   # session, but no open
+        assert st == 200
+        assert body["result"]["data"]["hasTab"] is False
+        # And the dispatched command genuinely carried no tabId.
+        assert all("tabId" not in c for c in ext.dispatched)
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_explicit_tab_override():
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_echo_exec([]))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        # No open at all, but --tab 77 forces the target.
+        st, body = _req(srv, "POST", "/cmd", {"op": "getHtml", "tab": 77},
+                        headers={S.HDR_SESSION_ID: "A"})
+        assert st == 200
+        assert body["result"]["data"]["tabId"] == 77
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --- THE BUG: two sessions interleave without clobbering ------------------- #
+def test_two_sessions_interleaved_never_clobber():
+    """Session A and B each own a tab; interleaved nav+read ops each dispatch
+    against their OWN tabId — the clobber (A reads B's page) cannot happen."""
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_echo_exec([101, 202]))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        _cmd(srv, {"op": "open", "url": "https://a.test"}, session="A")
+        _cmd(srv, {"op": "open", "url": "https://b.test"}, session="B")
+        # Interleave: A nav, B nav, A read, B read.
+        assert _cmd(srv, {"op": "nav", "url": "https://a2.test"}, session="A")[1]["result"]["data"]["tabId"] == 101
+        assert _cmd(srv, {"op": "nav", "url": "https://b2.test"}, session="B")[1]["result"]["data"]["tabId"] == 202
+        assert _cmd(srv, {"op": "getHtml"}, session="A")[1]["result"]["data"]["tabId"] == 101
+        assert _cmd(srv, {"op": "getHtml"}, session="B")[1]["result"]["data"]["tabId"] == 202
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --- close / release ------------------------------------------------------- #
+def test_close_drops_ownership_and_dispatches_remove():
+    srv, reg = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_echo_exec([101]))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        _cmd(srv, {"op": "open"}, session="A")
+        assert reg.owners_snapshot() == {("only", "A"): 101}
+        st, body = _cmd(srv, {"op": "close"}, session="A")
+        assert st == 200
+        assert body["result"]["data"]["closed"] == 101
+        assert reg.owners_snapshot() == {}
+        # A close-shaped command (op=close, tabId=owned) was dispatched.
+        close_cmds = [c for c in ext.dispatched if c["op"] == "close"]
+        assert len(close_cmds) == 1 and close_cmds[0]["tabId"] == 101
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_close_without_owned_tab_409_no_owned_tab():
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only")
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _cmd(srv, {"op": "close"}, session="A")   # never opened
+        assert st == 409
+        assert body["error"] == "no_owned_tab"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_release_drops_ownership_without_dispatch():
+    srv, reg = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_echo_exec([101]))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        _cmd(srv, {"op": "open"}, session="A")
+        assert reg.owners_snapshot() == {("only", "A"): 101}
+        st, body = _cmd(srv, {"op": "release"}, session="A")
+        assert st == 200
+        assert body["result"]["data"]["released"] == 1
+        assert reg.owners_snapshot() == {}
+        # release is server-side: the extension NEVER saw a release/close command.
+        assert all(c["op"] not in ("release", "close") for c in ext.dispatched)
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_tabs_annotates_owned_tab_id():
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_echo_exec([101]))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        _cmd(srv, {"op": "open"}, session="A")
+        st, body = _cmd(srv, {"op": "tabs"}, session="A")
+        assert st == 200
+        assert body["result"]["data"]["ownedTabId"] == 101
+        # A different session owns nothing here → None.
+        st, body = _cmd(srv, {"op": "tabs"}, session="B")
+        assert body["result"]["data"]["ownedTabId"] is None
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --- backward compatibility ------------------------------------------------ #
+def test_backward_compat_no_session_no_open_unchanged():
+    """A SINGLE session with NO session header and NO open behaves EXACTLY as
+    before: active-tab dispatch, no tabId injected."""
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=lambda c: {"hasTab": ("tabId" in c)})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _req(srv, "POST", "/cmd", {"op": "getHtml"})   # no X-Session-Id
+        assert st == 200
+        assert body["result"]["data"]["hasTab"] is False
+        assert all("tabId" not in c for c in ext.dispatched)
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --- security: the session id is routing-only, never trusted for auth ------ #
+def test_cmd_with_session_still_enforces_auth_and_host():
+    srv, _ = _serve()
+    try:
+        # Wrong bearer + a session header → still 401 (session never grants auth).
+        st, body = _req(srv, "POST", "/cmd", {"op": "getHtml"}, token="nope",
+                        headers={S.HDR_SESSION_ID: "A"})
+        assert st == 401 and body["error"] == "unauthorized"
+        # Bad Host + a session header → still 403.
+        st, body = _req(srv, "POST", "/cmd", {"op": "getHtml"},
+                        host="evil.example.com",
+                        headers={S.HDR_SESSION_ID: "A"})
+        assert st == 403 and body["error"] == "bad_host"
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+# --- per-tab FIFO serialization (Registry-level, deterministic) ------------ #
+def _register_live(reg, iid="solo", key="one"):
+    """Register a live instance via one idle poll (leaves last_poll recent so it
+    counts live within CONNECT_STALE_S) and return its Instance."""
+    reg.poll(iid, key, 0.01)
+    with reg._cond:
+        return reg._instances[key]
+
+
+def test_same_tab_commands_serialize_fifo():
+    """Two commands targeting the SAME tab are granted in arrival order: the
+    second does not even enqueue until the first completes."""
+    reg = S.Registry()
+    inst = _register_live(reg)
+
+    r1 = {}
+
+    def sub1():
+        r1["v"] = reg.submit({"op": "getHtml"}, 5.0, session_id="s1", tab=5)
+
+    threading.Thread(target=sub1, daemon=True).start()
+    assert _wait_until(lambda: len(inst.waiters) == 1), "cmd1 never enqueued"
+    cid1 = next(iter(inst.waiters))
+
+    # A second command to the SAME tab (5) must be FIFO-gated (not enqueued yet).
+    threading.Thread(
+        target=lambda: reg.submit({"op": "getHtml"}, 5.0, session_id="s2", tab=5),
+        daemon=True).start()
+    time.sleep(0.15)
+    assert inst.waiters == {cid1}, "second same-tab command must NOT enqueue while cmd1 is in-flight"
+
+    # Complete cmd1 → its turn is released → cmd2 enqueues.
+    reg.deliver_result(cid1, {"id": cid1, "ok": True, "data": {}},
+                       instance_id="solo")
+    assert _wait_until(lambda: inst.waiters and next(iter(inst.waiters)) != cid1), \
+        "cmd2 must enqueue once cmd1 completed"
+    cid2 = next(iter(inst.waiters))
+    reg.deliver_result(cid2, {"id": cid2, "ok": True, "data": {}},
+                       instance_id="solo")
+
+
+def test_different_tab_commands_do_not_block():
+    """A command to a DIFFERENT tab enqueues immediately, even while another tab's
+    command is in flight (no false serialization across tabs)."""
+    reg = S.Registry()
+    inst = _register_live(reg)
+
+    def sub1():
+        reg.submit({"op": "getHtml"}, 5.0, session_id="s1", tab=5)
+
+    threading.Thread(target=sub1, daemon=True).start()
+    assert _wait_until(lambda: len(inst.waiters) == 1)
+    cid1 = next(iter(inst.waiters))
+
+    # Different tab (6) — must enqueue right away (→ 2 waiters), not wait for cid1.
+    threading.Thread(
+        target=lambda: reg.submit({"op": "getHtml"}, 5.0, session_id="s2", tab=6),
+        daemon=True).start()
+    assert _wait_until(lambda: len(inst.waiters) == 2), \
+        "a different-tab command must not be blocked by cmd1"
+    for cid in list(inst.waiters):
+        reg.deliver_result(cid, {"id": cid, "ok": True, "data": {}},
+                           instance_id="solo")
+
+
+def test_fifo_queued_command_respects_cmd_timeout():
+    """A command queued behind an in-flight one on the same tab still times out
+    at cmd_timeout (a queued command can never block forever)."""
+    reg = S.Registry()
+    inst = _register_live(reg)
+
+    def sub1():
+        # Never delivered → holds the tab turn until ITS own timeout.
+        try:
+            reg.submit({"op": "getHtml"}, 5.0, session_id="s1", tab=5)
+        except S.BridgeTimeout:
+            pass
+
+    threading.Thread(target=sub1, daemon=True).start()
+    assert _wait_until(lambda: len(inst.waiters) == 1)
+
+    r2 = {}
+
+    def sub2():
+        try:
+            reg.submit({"op": "getHtml"}, 0.3, session_id="s2", tab=5)
+        except Exception as e:  # noqa: BLE001
+            r2["err"] = type(e).__name__
+
+    t2 = threading.Thread(target=sub2, daemon=True)
+    t2.start()
+    t2.join(3)
+    assert r2.get("err") == "BridgeTimeout", \
+        "a FIFO-queued command must still honour cmd_timeout"
+
+
+# --- TTL reclaim: released, NOT closed ------------------------------------- #
+def test_owner_ttl_reclaims_without_closing(monkeypatch):
+    """Ownership idle past the TTL is RELEASED (mapping dropped) using an injected
+    clock — never a real Date.now(). Reclaim must NOT dispatch a close."""
+    clock = [1000.0]
+    reg = S.Registry(clock=lambda: clock[0], owner_ttl=10.0)
+    with reg._cond:
+        reg._owners[("k", "s")] = {"tab_id": 42, "last_seen": clock[0]}
+    assert reg.owners_snapshot() == {("k", "s"): 42}
+
+    events = []
+    monkeypatch.setattr(S, "log", lambda ev, **kw: events.append(ev))
+    clock[0] += 11.0                      # advance past the idle TTL
+    assert reg.owners_snapshot() == {}    # reclaimed on the next touch
+    assert "owner_reclaim" in events
+
+
+def test_owner_ttl_reclaim_falls_back_to_active_not_close():
+    """After a session's ownership expires, its next op routes with NO injected
+    tabId (active-tab fallback) and NO close is ever dispatched — the real tab is
+    left open. Registry-level with an injected clock (no real Date.now())."""
+    clock = [1000.0]
+    reg = S.Registry(clock=lambda: clock[0], owner_ttl=10.0)
+
+    dispatched = []
+    stop = threading.Event()
+
+    def poller():
+        while not stop.is_set():
+            cmd = reg.poll("solo", "one", 0.05)
+            if cmd is not None and cmd is not S.SUPERSEDED:
+                dispatched.append(cmd)
+                reg.deliver_result(cmd["id"], {"id": cmd["id"], "ok": True,
+                                               "data": {}}, instance_id="solo")
+
+    threading.Thread(target=poller, daemon=True).start()
+    try:
+        assert _wait_until(lambda: len(reg.snapshot()) == 1)
+        # Model an owned tab, then let it go idle past the TTL.
+        with reg._cond:
+            reg._owners[("one", "S")] = {"tab_id": 55, "last_seen": clock[0]}
+        clock[0] += 11.0                  # past owner TTL (10), within stale (40)
+        reg.submit({"op": "getHtml"}, 3.0, session_id="S")   # no tab arg
+        assert reg.owners_snapshot() == {}                    # ownership reclaimed
+        assert dispatched, "the op was never dispatched"
+        assert all("tabId" not in c for c in dispatched)      # active-tab fallback
+        assert all(c["op"] != "close" for c in dispatched)    # tab NOT closed
+    finally:
+        stop.set()

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -178,8 +178,18 @@ class FakeExtension(threading.Thread):
             self.dispatched.append(cmd)
             if self.swallow:
                 continue
-            envelope = {"id": cmd["id"], "ok": True,
-                        "data": self.executor(cmd), "instanceId": self.instance_id}
+            data = self.executor(cmd)
+            # An executor may model an op-level FAILURE (the op threw in the page
+            # / the target tab is gone) by returning {"__error__": "<msg>"} — the
+            # fake then emits the extension's ok:false error envelope instead of a
+            # success envelope. A plain dict stays a success `data` payload.
+            if isinstance(data, dict) and "__error__" in data:
+                envelope = {"id": cmd["id"], "ok": False,
+                            "error": data["__error__"],
+                            "instanceId": self.instance_id}
+            else:
+                envelope = {"id": cmd["id"], "ok": True, "data": data,
+                            "instanceId": self.instance_id}
             try:
                 _req(self.srv, "POST", "/result", envelope)
             except Exception:
@@ -1628,3 +1638,266 @@ def test_owner_ttl_reclaim_falls_back_to_active_not_close():
         assert all(c["op"] != "close" for c in dispatched)    # tab NOT closed
     finally:
         stop.set()
+
+
+# --------------------------------------------------------------------------- #
+# Fix 1 — self-heal when an owned tab is gone
+#
+# When the user manually closes an owned BACKGROUND tab, the next tab-scoped op
+# dispatches the stale tabId → the extension returns `owned_tab_gone` (ok:false).
+# The session must DROP its ownership so the next command self-heals to the
+# active-tab fallback (instead of staying wedged to the dead tab for OWNER_TTL),
+# and `close` must clear the mapping even when the remove reports the tab gone.
+# --------------------------------------------------------------------------- #
+def _tab_gone_exec(open_ids, gone):
+    """Executor: `open` hands out the next id; a tab-scoped op whose injected
+    tabId is in the mutable `gone` set returns an `owned_tab_gone` error envelope;
+    otherwise it echoes the injected tabId (None → active-tab fallback)."""
+    it = iter(open_ids)
+
+    def _exec(cmd):
+        if cmd["op"] == "open":
+            return {"tabId": next(it), "url": cmd.get("url")}
+        tid = cmd.get("tabId")
+        if tid is not None and tid in gone:
+            return {"__error__": "owned_tab_gone"}
+        if cmd["op"] == "close":
+            return {"closed": tid}
+        return {"tabId": tid, "op": cmd["op"]}
+    return _exec
+
+
+def test_is_tab_gone_helper():
+    assert S._is_tab_gone("owned_tab_gone") is True
+    assert S._is_tab_gone("No tab with id: 42.") is True   # chrome's raw message
+    assert S._is_tab_gone("something_else") is False
+    assert S._is_tab_gone(None) is False
+    assert S._is_tab_gone(123) is False
+
+
+def test_owned_tab_gone_drops_ownership_and_self_heals():
+    """A tab-scoped op that fails with `owned_tab_gone` for the session's OWNED
+    tab drops the mapping; the NEXT op falls back to the active tab (no tabId)."""
+    srv, reg = _serve()
+    gone = set()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_gone_exec([101], gone))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        _cmd(srv, {"op": "open"}, session="A")
+        assert reg.owners_snapshot() == {("only", "A"): 101}
+        # The user closes tab 101 out-of-band.
+        gone.add(101)
+        st, body = _cmd(srv, {"op": "getHtml"}, session="A")
+        assert st == 200                          # HTTP ok; op-level failure
+        assert body["result"]["ok"] is False
+        assert body["result"]["error"] == "owned_tab_gone"
+        assert reg.owners_snapshot() == {}        # ownership self-healed (dropped)
+        # Next op now falls back to the active tab (no tabId injected).
+        st, body = _cmd(srv, {"op": "getHtml"}, session="A")
+        assert st == 200 and body["result"]["ok"] is True
+        assert body["result"]["data"]["tabId"] is None
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_close_drops_ownership_even_when_tab_already_gone():
+    """`close` clears the mapping UNCONDITIONALLY — even when the extension
+    reports the tab already gone (remove → ok:false). Without this, a tab the
+    user closed out-of-band could never be cleared and wedged the session."""
+    srv, reg = _serve()
+    gone = set()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_gone_exec([101], gone))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        _cmd(srv, {"op": "open"}, session="A")
+        assert reg.owners_snapshot() == {("only", "A"): 101}
+        gone.add(101)                              # closed out-of-band
+        st, body = _cmd(srv, {"op": "close"}, session="A")
+        assert st == 200
+        assert body["result"]["ok"] is False       # remove reported it gone
+        assert reg.owners_snapshot() == {}          # mapping cleared regardless
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_explicit_tab_gone_does_not_evict_owned_mapping():
+    """An explicit --tab to a DIFFERENT (gone) tab must NOT evict the session's
+    healthy owned mapping — only the session's OWN owned tab going gone self-heals."""
+    srv, reg = _serve()
+    gone = {999}
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_gone_exec([101], gone))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        _cmd(srv, {"op": "open"}, session="A")      # owns 101
+        # Target an unrelated, already-gone tab 999 via --tab.
+        st, body = _req(srv, "POST", "/cmd", {"op": "getHtml", "tab": 999},
+                        headers={S.HDR_SESSION_ID: "A"})
+        assert st == 200 and body["result"]["ok"] is False
+        assert body["result"]["error"] == "owned_tab_gone"
+        # The session's own tab (101) is untouched.
+        assert reg.owners_snapshot() == {("only", "A"): 101}
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# Fix 2 — a double `open` must not orphan a real tab
+#
+# A second `open` from a session used to overwrite its ownership with a brand-new
+# tabId, orphaning the FIRST real tab (no ownership → never closed → leaked). The
+# server now passes the owned tabId as `reuseTabId`; the extension returns the
+# SAME tab when it is still live (idempotent), and only opens fresh when gone.
+# --------------------------------------------------------------------------- #
+def _open_reuse_exec(new_ids, live):
+    """Model the SW `open` reuse logic: honour `reuseTabId` when that tab is still
+    in the mutable `live` set (idempotent), else create the next new id. `close`
+    removes from `live`; other ops echo their injected tabId."""
+    it = iter(new_ids)
+
+    def _exec(cmd):
+        if cmd["op"] == "open":
+            reuse = cmd.get("reuseTabId")
+            if reuse is not None and reuse in live:
+                return {"tabId": reuse, "url": cmd.get("url"), "reused": True}
+            tid = next(it)
+            live.add(tid)
+            return {"tabId": tid, "url": cmd.get("url")}
+        if cmd["op"] == "close":
+            live.discard(cmd.get("tabId"))
+            return {"closed": cmd.get("tabId")}
+        return {"tabId": cmd.get("tabId"), "op": cmd["op"]}
+    return _exec
+
+
+def test_double_open_is_idempotent_no_orphan():
+    """A second `open` returns the EXISTING owned tab (reused) — no second real
+    tab is created, so the first tab is never orphaned/leaked."""
+    srv, reg = _serve()
+    live = set()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_open_reuse_exec([101, 202], live))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _cmd(srv, {"op": "open"}, session="A")
+        assert body["result"]["data"]["tabId"] == 101
+        assert live == {101}
+        # Second open by the SAME session → the server injects reuseTabId=101 and
+        # the extension returns the SAME live tab (no new 202 tab created).
+        st, body = _cmd(srv, {"op": "open"}, session="A")
+        assert st == 200
+        assert body["result"]["data"]["tabId"] == 101
+        assert body["result"]["data"].get("reused") is True
+        assert live == {101}, "a second real tab was created → orphaned/leaked"
+        assert reg.owners_snapshot() == {("only", "A"): 101}
+        # The server injected the reuse hint on the second open.
+        opens = [c for c in ext.dispatched if c["op"] == "open"]
+        assert opens[1].get("reuseTabId") == 101
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_open_after_owned_tab_gone_opens_fresh():
+    """If the previously-owned tab is GONE, `open` creates a fresh tab and the
+    ownership updates to it (the stale mapping is replaced, not reused)."""
+    srv, reg = _serve()
+    live = set()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_open_reuse_exec([101, 202], live))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        _cmd(srv, {"op": "open"}, session="A")       # owns 101
+        live.discard(101)                            # user closed it out-of-band
+        st, body = _cmd(srv, {"op": "open"}, session="A")
+        assert st == 200
+        assert body["result"]["data"]["tabId"] == 202    # fresh tab
+        assert body["result"]["data"].get("reused") is None
+        assert reg.owners_snapshot() == {("only", "A"): 202}
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# Fix 3 — a malformed `tab` from a raw API caller is a clean 400, never a 500
+# --------------------------------------------------------------------------- #
+def test_coerce_tab_helper():
+    assert S._coerce_tab(5) == (5, None)
+    assert S._coerce_tab(0) == (0, None)
+    assert S._coerce_tab("77") == (77, None)
+    assert S._coerce_tab([1, 2]) == (None, "bad_tab")
+    assert S._coerce_tab({"x": 1}) == (None, "bad_tab")
+    assert S._coerce_tab(True) == (None, "bad_tab")      # bool is not a tab id
+    assert S._coerce_tab(1.5) == (None, "bad_tab")
+    assert S._coerce_tab(-3) == (None, "bad_tab")
+    assert S._coerce_tab("x") == (None, "bad_tab")
+
+
+def test_malformed_tab_returns_400_bad_tab_not_500():
+    """A raw token-holder POSTing an unhashable `tab` (list/dict) gets a clean
+    400 bad_tab — never an uncaught TypeError → 500."""
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only")
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        for bad in ([1, 2], {"x": 1}, True, 1.5, "nope"):
+            st, body = _req(srv, "POST", "/cmd", {"op": "getHtml", "tab": bad})
+            assert st == 400, f"tab={bad!r} → {st}"
+            assert body["error"] == "bad_tab"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_numeric_string_tab_is_coerced_and_routes():
+    """A valid numeric-string `tab` is coerced to an int and routes normally."""
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=lambda c: {"tabId": c.get("tabId")})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _req(srv, "POST", "/cmd", {"op": "getHtml", "tab": "5"},
+                        headers={S.HDR_SESSION_ID: "A"})
+        assert st == 200
+        assert body["result"]["data"]["tabId"] == 5
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# Fix 4 — explicit --tab overrides owned-tab routing (the subagent escape hatch)
+#
+# Sibling subagents of one parent share a session id (CLAUDE_CODE_SESSION_ID +
+# $TMUX_PANE are inherited, and no subagent-unique env var exists), so they would
+# own the SAME tab. The robust isolation is explicit tab handles: each driver
+# `open`s and then threads its OWN --tab on every op. This asserts --tab fully
+# overrides the session-ownership mapping so two same-session drivers never collide.
+# --------------------------------------------------------------------------- #
+def test_explicit_tab_overrides_owned_mapping():
+    srv, reg = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_echo_exec([101]))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        _cmd(srv, {"op": "open"}, session="A")          # session A owns tab 101
+        # An explicit --tab 999 must target 999, NOT the owned 101.
+        st, body = _req(srv, "POST", "/cmd", {"op": "getHtml", "tab": 999},
+                        headers={S.HDR_SESSION_ID: "A"})
+        assert st == 200
+        assert body["result"]["data"]["tabId"] == 999, \
+            "--tab must override the session's owned-tab routing"
+        # The override does not disturb the owned mapping.
+        assert reg.owners_snapshot() == {("only", "A"): 101}
+        # And with no --tab the same session still routes to its owned tab.
+        st, body = _cmd(srv, {"op": "getHtml"}, session="A")
+        assert body["result"]["data"]["tabId"] == 101
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()


### PR DESCRIPTION
## The bug (root cause)

Two Claude sessions driving one Brave instance clobbered each other. The
transport is **correct** — each `submit()` gets a unique cid, a FIFO outbox, and
a cid-correlated reply, with no cross-delivery. The clobber was **semantic**:
every op targeted "the active tab of the last-focused window"
(`chrome.tabs.query({active:true,lastFocusedWindow:true})`), so two sessions'
multi-step workflows interleaved on **one shared tab** — session A does `nav X`
then `getHtml`, session B does `nav Y` in between, A reads Y. Command-level
serialization existed; per-session (multi-step **workflow**) tab isolation did
not.

## Design

**1. Per-session identity.** The `browser` skill (one bash process per command)
needs a stable id identical across a session's many invocations. Verified
empirically in the Bash-tool env: `CLAUDE_CODE_SESSION_ID` is present (the
session UUID, matches the transcript/scratch path) and **stable across
invocations**, as are `$TMUX_PANE` and the shell `PPID`. Fallback chain
(most → least reliable), sent as `X-Session-Id` on every `/cmd`:

1. `CLAUDE_CODE_SESSION_ID` — Claude Code's own session UUID (2.1.x CLI).
2. `CLAUDE_SESSION_ID` — defensive alternate spelling.
3. `$TMUX_PANE` — each session runs in its own tmux pane (a good proxy).
4. a random token cached under the controlling shell's `PPID` (the Claude Code
   process managing the Bash tool — stable across a session's calls), persisted
   so repeated calls read the same id.

Routing-only; **never** trusted for auth. Degradation: if two sessions resolve
the same id they share a tab (no worse than today) — e.g. a **subagent** inherits
its parent's `CLAUDE_CODE_SESSION_ID` and so shares the parent's tab.

**2. Per-session owned tab.** `browser open [url]` → the extension
`chrome.tabs.create({url, active:false})` (background, so parallel sessions don't
fight the foreground) and returns the real `tabId`; the server records
`(instance_key, session_id) -> tabId` under `Registry._cond`. Tab-scoped ops
(`html`/`eval`/`nav`/`screenshot`/`close`) route to the caller's owned tab; **no
owned tab → active-tab fallback** (the safe one-shot read). `--tab <id>`
overrides. `browser close` closes the tab + drops ownership; `browser release`
drops ownership without closing. `browser tabs` annotates `ownedTabId`.

**3. FIFO on remaining contention.** When two commands DO target the same tab
(both active, or one `--tab`s another's tab) they serialize **FIFO in arrival
order** via a per-tab turnstile in the Registry — competing commands **queue**
(blocking), not fail-fast, bounded by `cmd_timeout`. Different tabs never block.

**4. Lifecycle (reversible — please veto if unwanted).** Ownership has an idle
TTL (`BROWSER_BRIDGE_OWNER_TTL`, default 900 s). On expiry the mapping is
**released** so a dead session doesn't leak ownership, but the real Brave tab is
**NOT closed** — never yank a visible tab out from under the user; only explicit
`browser close` closes it.

**Screenshot caveat (handled honestly).** `captureVisibleTab` only captures the
**visible** tab of a window. Screenshotting a **background** owned tab briefly
activates it → captures → **restores** the previously-active tab (a short visible
flicker), so it never silently captures the wrong tab.

## Security invariants preserved

Loopback bind, bearer token on **every** endpoint (incl. `/poll` & `/result`),
Host-header allowlist, constant-time compare, no CORS — all unchanged. The new
`X-Session-Id` is routing-only and is checked **after** the auth/Host gate (tests
assert `/cmd` with a session header + wrong token → 401, + bad Host → 403). The
#169 multi-instance `--instance` targeting / ambiguity / supersede semantics and
the #173 metadata-only telemetry are untouched (no page content, no session id
added to the emitted payload — the telemetry `key` stays the instance target).

## Tests (headless — no Brave / network / ClickHouse)

**72 Python** (`test_server.py`) + **22 node** (`protocol.test.mjs`), up from
~55 / ~20. New coverage: session-id derivation fallback chain (via
`browser --print-session-id`), `open` recording `(instance,session)->tabId`, two
sessions getting distinct ownership, ops routing to the owning session's tabId,
**the interleaved two-session clobber** (each read dispatched against its own
tab), active-tab fallback + `--tab` override, `close`/`release` (drop ownership;
`close` dispatches a `chrome.tabs.remove`-shaped command, `release` never touches
the extension), `tabs` ownedTabId annotation, **per-tab FIFO** (same-tab
serialize in arrival order, different tabs don't block, a queued command still
honours `cmd_timeout`), **TTL reclaim** (injected fake clock — released, not
closed), `no_owned_tab`, the session id being routing-only (bearer/Host still
enforced), and backward-compat (single session, no open → unchanged active-tab
dispatch). Also an end-to-end CLI smoke against a live server + in-process fake
extension exercising the real bash wiring (13/13 pass).

```
72 passed (pytest)      22 pass 0 fail (node --test)      bash -n OK
```

## Manual two-session live check (needs real Brave)

MV3 `chrome.*` glue can't be driven headlessly. To verify live: open two Claude
sessions (each in its own tmux pane); in each run `browser open <different-url>`,
then interleave `browser nav …` / `browser html` between them. Confirm neither
clobbers the other — each `html` returns **its own** tab's page, never the other
session's. `browser --print-session-id` in each shows the distinct ids. Also
check `browser screenshot` of a background owned tab flickers it foreground,
captures, and restores the prior tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
