### PR TITLE
feat(browser-bridge): per-instance backpressure (rate limit + queue cap) + discoverable entrypoint

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -158,7 +158,10 @@ extension is the bottleneck, so throttling instance A never affects instance B):
 - **Token-bucket rate limit** on accepted `/cmd` dispatches: `BROWSER_BRIDGE_RATE_PER_SEC`
   sustained (default **5/sec**), `BROWSER_BRIDGE_BURST` burst (default **20**). A
   dispatch that would exceed the bucket is **rejected** (never silently queued).
-  `RATE_PER_SEC=0` disables it (power-user unlimited).
+  `RATE_PER_SEC=0` disables it (power-user unlimited). When rate-limiting is
+  active (`RATE_PER_SEC>0`), `BURST` is **clamped to ≥1** — a sub-1 burst can
+  never hold a whole token, so it would silently rate_limit *every* `/cmd`
+  forever; use `RATE_PER_SEC=0`, not a 0 burst, to disable throttling.
 - **Queue-depth cap** `BROWSER_BRIDGE_MAX_QUEUE` (default **32**): if an instance's
   pending (admitted-but-unfinished) command count is at the cap, new `/cmd` are
   rejected until it drains — this bounds the latency tail. `MAX_QUEUE=0` disables it.

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -8,6 +8,19 @@ It is a **sibling** to the activity-collector's `scripts/collector/browser-ext/`
 (a one-way telemetry sink). browser-bridge is a *command* channel and does not
 touch the collector or its extension.
 
+## Quick start / binary path
+
+The executable lives at
+`~/workspace/devrc/scripts/browser-bridge/browser` (also
+`~/.claude/skills/browser/browser` if the skill dir is symlinked):
+
+```bash
+BB=~/workspace/devrc/scripts/browser-bridge/browser
+$BB health                              # connected instances + count
+$BB --instance <key> open <url>         # open a NEW tab this session owns → tabId
+$BB --instance <key> --tab <id> html    # act on a specific tab
+```
+
 ## Architecture
 
 ```
@@ -129,7 +142,48 @@ structured error: `503 extension_not_connected`, `504 timeout`,
 (`close` with nothing owned), `409 superseded`, `404 unknown_instance`,
 `400 unknown_op|missing_field:<f>`, `400 bad_tab` (a non-numeric/non-scalar
 `tab` from a raw caller — the CLI already validates `--tab`), `401 unauthorized`,
-`403 bad_host`.
+`403 bad_host`, `429 rate_limited|queue_full` (the per-instance concurrency
+backstop — see below; body carries a `retry_after` hint).
+
+## Concurrency backstop (per-instance rate limit + queue cap)
+
+The extension is a **single serial connection**, and the transport used to accept
+`/cmd` dispatches with **no backpressure**. An audit found a 44,061-event storm —
+**43,991 `eval`s in one hour (~13/sec sustained)** from an unisolated fleet/loop —
+that saturated one instance's queue and ballooned latency from ~10 ms to ~5.5 s.
+
+To bound that damage the server enforces two **per-instance** limits (the
+extension is the bottleneck, so throttling instance A never affects instance B):
+
+- **Token-bucket rate limit** on accepted `/cmd` dispatches: `BROWSER_BRIDGE_RATE_PER_SEC`
+  sustained (default **5/sec**), `BROWSER_BRIDGE_BURST` burst (default **20**). A
+  dispatch that would exceed the bucket is **rejected** (never silently queued).
+  `RATE_PER_SEC=0` disables it (power-user unlimited).
+- **Queue-depth cap** `BROWSER_BRIDGE_MAX_QUEUE` (default **32**): if an instance's
+  pending (admitted-but-unfinished) command count is at the cap, new `/cmd` are
+  rejected until it drains — this bounds the latency tail. `MAX_QUEUE=0` disables it.
+
+A rejected dispatch returns **HTTP 429** `{"ok":false,"error":"rate_limited"|"queue_full","retry_after":<s>}`
+(caller-visible backpressure). The `browser` CLI prints a back-off message and
+exits non-zero, so a runaway loop gets a hard, detectable signal. **The defaults
+do not hurt legitimate use:** an interactive/agent workflow is a handful of ops
+per burst (well under burst 20 and depth 32); only a sustained high-rate flood is
+throttled.
+
+The admission check runs **under the existing lock**, is lock-free of any blocking
+wait, and rejects **before** the command joins the per-tab FIFO turnstile — so it
+can neither deadlock nor wedge the turnstile (a rejection returns immediately,
+leaving no orphaned waiter). The audited concurrency core (single `Condition`, no
+lock held across a blocking wait, turnstile self-releases in `finally`) is
+unchanged.
+
+**Observability (so the next storm is attributable):** a throttle both `log()`s a
+distinct `{"event":"throttled","key":…,"reason":…,"sess":…}` line AND emits a
+telemetry event (`outcome="throttled"`, `payload.reason`) into `activity.events`.
+`payload.sess` is a **coarse, non-reversible** fingerprint (first 8 hex of
+sha256 of the `X-Session-Id`) — enough to attribute a flood to a session without
+storing the raw id, kept metadata-only (no page content). This is the ONLY event
+that carries the session hash.
 
 ## Session isolation (concurrent-session tab clobbering)
 
@@ -289,7 +343,16 @@ gone, an idempotent double `open` returning the reused tab (no orphan) vs openin
 fresh when the owned tab is gone, a malformed `tab` (list/dict/bool) returning a
 clean `400 bad_tab` instead of a 500 (+ the `_coerce_tab`/`_is_tab_gone` helper
 units), and an explicit `--tab` overriding owned-tab routing (the subagent
-escape hatch). Current totals: **82 Python** (`test_server.py`) + **22 node**
+escape hatch). It also covers the **per-instance concurrency backstop**: the
+token-bucket admission (burst passes then `rate_limited`, refill-over-fake-time
+resume, cap-at-burst), the queue-depth cap (`queue_full` at `MAX_QUEUE`, drain
+resumes), strict per-instance isolation (throttling A never throttles B), the
+disable path (rate=0/max_queue=0 → unlimited), a rejected submit leaving NO
+turnstile/waiter residue (no deadlock), the HTTP `429 rate_limited` + throttle
+telemetry event (metadata-only, a COARSE non-reversible session hash — never the
+raw id), the HTTP `429 queue_full`, that the production defaults never throttle a
+normal small burst, and the `browser` CLI backing off (non-zero exit) on a 429.
+Current totals: **92 Python** (`test_server.py`) + **22 node**
 (`protocol.test.mjs`). The chrome.* glue in `service_worker.js` genuinely needs a
 real browser and is covered by the manual checklist in `extension/README.md`.
 

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -172,8 +172,9 @@ know browser usage is being counted. Details: `README.md` → Telemetry.
   retry** (the body carries a `retry_after` seconds hint). A normal handful of ops
   is never throttled; this only fires on a sustained flood. Knobs (env, on the
   server): `BROWSER_BRIDGE_RATE_PER_SEC` (default 5, sustained/sec; 0 = unlimited),
-  `BROWSER_BRIDGE_BURST` (default 20), `BROWSER_BRIDGE_MAX_QUEUE` (default 32, 0 =
-  unlimited).
+  `BROWSER_BRIDGE_BURST` (default 20; clamped to ≥1 when rate>0 — a <1 burst
+  would rate_limit every /cmd forever), `BROWSER_BRIDGE_MAX_QUEUE` (default 32,
+  0 = unlimited).
 - `409 ambiguous_instance` → >1 instance connected and no `--instance` — pick one.
 - `409 no_owned_tab` → `close` with nothing to close — run `browser open` first (or `--tab`).
 - `409 superseded` → the instance was replaced by a newer connection; retry.

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -3,6 +3,35 @@ name: browser
 description: Drive the user's LIVE, logged-in Brave browser from Claude Code — read the active tab's HTML, run JS in it, list/navigate tabs, and screenshot the visible tab — via the local token-authenticated browser-bridge (loopback rendezvous server + MV3 extension). Use when the user asks you to look at / read / scrape / interact with a page THEY have open, act on an authenticated site they're logged into, check what's on their screen in Brave, navigate their browser, or grab a screenshot of their current tab. NOT for headless fetching of public URLs (use WebFetch) — this is specifically their real, authenticated session.
 ---
 
+```
+~/workspace/devrc/scripts/browser-bridge/browser <subcommand>
+```
+
+**Run it by that exact path** (also `~/.claude/skills/browser/browser` if the
+skill dir is symlinked). Don't hunt for it under `~/.claude/skills/...`.
+
+## Quick start / binary path
+
+```bash
+BB=~/workspace/devrc/scripts/browser-bridge/browser   # ← the executable
+$BB health                          # is an extension connected?
+$BB --instance <key> open <url>     # open a NEW tab this session owns
+$BB --instance <key> --tab <id> html   # act on a specific tab
+```
+
+## Concurrency / don't do this
+
+- **Concurrent drivers (esp. sibling subagents) → each `open` and thread its own
+  `--tab <id>`.** Sibling subagents of one parent SHARE a session id (they
+  inherit `CLAUDE_CODE_SESSION_ID` + `$TMUX_PANE`), so without explicit `--tab`
+  they fight over the SAME active tab. Have each driver `browser open` (capture
+  the returned `tabId`) and pass `--tab <id>` on every subsequent op.
+- **Do NOT run a bare high-rate `eval` loop** (no `--instance`/`open`). It shares
+  the one active tab AND saturates the single serial extension connection; the
+  server now **rate-limits** it and returns **HTTP 429** (`rate_limited` /
+  `queue_full`) — the `browser` CLI prints a back-off message and exits non-zero.
+  Batch what you need into fewer `eval`s, or space them out.
+
 # browser — drive the live Brave session
 
 `browser-bridge` lets you operate the user's **real, logged-in Brave** browser.
@@ -138,6 +167,13 @@ know browser usage is being counted. Details: `README.md` → Telemetry.
 
 - `503 extension_not_connected` → extension not loaded/paired, or Brave closed.
 - `504 timeout` → extension picked it up but didn't answer (tab unresponsive).
+- `429 rate_limited` / `429 queue_full` → the per-instance concurrency backstop is
+  shedding load — you're dispatching too fast / too many at once. **Back off and
+  retry** (the body carries a `retry_after` seconds hint). A normal handful of ops
+  is never throttled; this only fires on a sustained flood. Knobs (env, on the
+  server): `BROWSER_BRIDGE_RATE_PER_SEC` (default 5, sustained/sec; 0 = unlimited),
+  `BROWSER_BRIDGE_BURST` (default 20), `BROWSER_BRIDGE_MAX_QUEUE` (default 32, 0 =
+  unlimited).
 - `409 ambiguous_instance` → >1 instance connected and no `--instance` — pick one.
 - `409 no_owned_tab` → `close` with nothing to close — run `browser open` first (or `--tab`).
 - `409 superseded` → the instance was replaced by a newer connection; retry.

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -200,6 +200,16 @@ cmd_op() {
     503) echo "$resp" >&2; die "no extension connected — load the browser-bridge extension in Brave (see SKILL.md)" ;;
     504) echo "$resp" >&2; die "timeout waiting for the extension to answer (is Brave focused / responsive?)" ;;
     401) die "unauthorized — token mismatch (re-paste the token in the extension options)" ;;
+    429)
+      # rate_limited / queue_full — the per-instance concurrency backstop is
+      # shedding load (see SKILL.md → Concurrency). Exit non-zero so a runaway
+      # loop gets a hard, detectable back-off signal (that IS the point).
+      echo "$resp" >&2
+      if printf '%s' "$resp" | grep -q '"queue_full"'; then
+        die "queue full — too many concurrent browser ops on this instance; back off and retry"
+      fi
+      die "rate-limited — browser ops issued too fast; back off and retry (a bare high-rate eval loop is throttled — see SKILL.md Concurrency)"
+      ;;
     409)
       # ambiguous_instance (>1 connected, no --instance), no_owned_tab, or superseded.
       if printf '%s' "$resp" | grep -q '"ambiguous_instance"'; then

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -71,9 +71,15 @@ Config (env):
     BROWSER_BRIDGE_TOKEN_FILE    token path (default ~/.config/browser-bridge/token)
     BROWSER_BRIDGE_CMD_TIMEOUT   seconds a /cmd waits for a result (default 20)
     BROWSER_BRIDGE_POLL_TIMEOUT  seconds a /poll blocks before 204 (default 25)
+    BROWSER_BRIDGE_RATE_PER_SEC  per-instance sustained /cmd dispatch rate
+                                 (token-bucket refill, default 5; 0 → unlimited)
+    BROWSER_BRIDGE_BURST         per-instance token-bucket burst size (default 20)
+    BROWSER_BRIDGE_MAX_QUEUE     per-instance pending-command cap (default 32;
+                                 0 → unlimited). Over-cap /cmd → HTTP 429.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import secrets
@@ -145,6 +151,20 @@ HDR_SESSION_ID = "X-Session-Id"
 # Idle seconds after which a session's tab ownership is reclaimed (released, NOT
 # closed). Refreshed on every op the session routes through its owned tab.
 OWNER_TTL_S = float(os.environ.get("BROWSER_BRIDGE_OWNER_TTL", "900"))
+
+# Concurrency backstop (bounds the damage a runaway caller can do to the SINGLE
+# serial extension connection — the audited 44K-eval storm saturated one queue
+# with no backpressure). Enforced PER-INSTANCE (the extension is the bottleneck):
+#   * a token-bucket RATE limit on accepted /cmd dispatches, and
+#   * a MAX_QUEUE cap on an instance's pending (admitted-but-unfinished) commands.
+# Defaults are GENEROUS: a handful of ops per burst is NEVER throttled; only a
+# sustained high-rate flood (e.g. the observed ~13/sec) is. Escape hatches for
+# power users: RATE_PER_SEC=0 disables the rate limit, MAX_QUEUE=0 disables the
+# depth cap. An over-limit dispatch is REJECTED with HTTP 429 (caller-visible
+# backpressure) — never silently queued forever.
+RATE_PER_SEC = float(os.environ.get("BROWSER_BRIDGE_RATE_PER_SEC", "5"))
+BURST = float(os.environ.get("BROWSER_BRIDGE_BURST", "20"))
+MAX_QUEUE = int(os.environ.get("BROWSER_BRIDGE_MAX_QUEUE", "32"))
 
 # Synthetic routing key for a legacy extension that polls without a handshake
 # (no X-Bridge-Instance-Id). All such polls collapse onto one unnamed instance.
@@ -258,12 +278,26 @@ def _domain_from_result(result) -> str:
         return ""
 
 
+def _session_hash(session_id) -> str:
+    """A COARSE, non-reversible fingerprint of a session id: first 8 hex of its
+    sha256. Used ONLY in the throttle telemetry event so a flood is attributable
+    to a session in activity.events WITHOUT ever storing the raw routing id
+    (which is itself never page content, but is still an opaque handle we keep
+    out of telemetry). Empty id → "" (nothing to attribute)."""
+    if not session_id:
+        return ""
+    return hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:8]
+
+
 def emit_cmd_event(op: str, key: str, outcome: str, duration_ms: int,
-                   domain: str = "", exit_code: int = 0) -> None:
+                   domain: str = "", exit_code: int = 0, extra: dict = None) -> None:
     """Append ONE metadata-only activity event for a handled command.
 
     Best-effort + fire-and-forget: any failure is swallowed so telemetry can
     never break command handling. See the PRIVACY / BEST-EFFORT contracts above.
+    `extra` merges additional METADATA-ONLY keys into the payload (used by the
+    throttle path for {reason, sess} — a fixed reason string + a coarse session
+    hash, never page content).
     """
     try:
         se = _load_spool_emit()
@@ -273,6 +307,8 @@ def emit_cmd_event(op: str, key: str, outcome: str, duration_ms: int,
         payload = {"op": op, "key": key, "outcome": outcome}
         if domain:
             payload["domain"] = domain
+        if extra:
+            payload.update(extra)
         se.emit({
             "source": "browser-bridge",
             "kind": "cmd",
@@ -365,6 +401,21 @@ class NoOwnedTab(Exception):
     (and gave no explicit --tab). Nothing to close → a clear error, not a guess."""
 
 
+class RateLimited(Exception):
+    """A /cmd dispatch was rejected by the per-instance concurrency backstop —
+    either the token bucket is empty (`reason="rate_limited"`) or the instance's
+    pending-command depth is at the cap (`reason="queue_full"`). Maps to HTTP 429
+    with a `retry_after` hint. Raised (and returned) IMMEDIATELY — it never joins
+    the turnstile or blocks, so a runaway caller gets fast, deterministic
+    backpressure and can never wedge the FIFO turnstile."""
+
+    def __init__(self, reason, retry_after, key):
+        super().__init__(reason)
+        self.reason = reason
+        self.retry_after = retry_after
+        self.key = key
+
+
 class Instance:
     """One connected extension: its own command queue + reply correlation.
 
@@ -373,9 +424,10 @@ class Instance:
     """
 
     __slots__ = ("key", "instance_id", "label", "outbox", "results", "waiters",
-                 "active_polls", "last_poll", "active_tab", "superseded")
+                 "active_polls", "last_poll", "active_tab", "superseded",
+                 "pending", "rl_tokens", "rl_last")
 
-    def __init__(self, key, instance_id, label, now):
+    def __init__(self, key, instance_id, label, now, burst=0.0):
         self.key = key
         self.instance_id = instance_id
         self.label = label
@@ -386,6 +438,14 @@ class Instance:
         self.last_poll = now
         self.active_tab = None                # {url,title} best-effort from /poll
         self.superseded = False
+        # Concurrency backstop (per-instance, guarded by the Registry's _cond):
+        #   pending   = admitted /cmd dispatches not yet completed (depth cap).
+        #   rl_tokens = token-bucket balance; starts FULL so the whole burst is
+        #               available immediately, refilled at rate_per_sec up to
+        #               `burst`. rl_last = last refill clock reading.
+        self.pending = 0
+        self.rl_tokens = float(burst)
+        self.rl_last = now
 
 
 class Registry:
@@ -401,10 +461,16 @@ class Registry:
     single `_cond` — blocking here is safe and cheap.
     """
 
-    def __init__(self, clock=time.monotonic, owner_ttl=OWNER_TTL_S):
+    def __init__(self, clock=time.monotonic, owner_ttl=OWNER_TTL_S,
+                 rate_per_sec=RATE_PER_SEC, burst=BURST, max_queue=MAX_QUEUE):
         self._cond = threading.Condition()
         self._instances: dict[str, Instance] = {}   # routing key -> Instance
         self._clock = clock
+        # Per-instance concurrency backstop knobs (see the RATE_PER_SEC block).
+        # rate_per_sec<=0 → rate limit off; max_queue<=0 → depth cap off.
+        self._rate_per_sec = float(rate_per_sec)
+        self._burst = float(burst)
+        self._max_queue = int(max_queue)
         # Per-session tab ownership: (instance_key, session_id) -> {tab_id, last_seen}.
         # Guarded by _cond like everything else. An idle TTL reclaims dead sessions.
         self._owners: dict[tuple, dict] = {}
@@ -434,7 +500,8 @@ class Registry:
             self._supersede_locked(inst, "superseded")
             inst = None
         if inst is None:
-            inst = Instance(key, instance_id, label, self._clock())
+            inst = Instance(key, instance_id, label, self._clock(),
+                            burst=self._burst)
             self._instances[key] = inst
         else:
             inst.label = label
@@ -565,6 +632,41 @@ class Registry:
                     return True
             return False
 
+    # --- concurrency backstop (per-instance rate limit + queue-depth cap) --- #
+    def _admit_locked(self, inst: Instance):
+        """Decide whether `inst` may accept ANOTHER /cmd dispatch RIGHT NOW.
+
+        Runs UNDER `_cond` (caller holds it) and is lock-free of any blocking
+        wait — it either admits (bumps `inst.pending`, spends one token) or
+        rejects immediately. Returns None to admit, or `(reason, retry_after)`
+        to reject (`reason` ∈ {"queue_full","rate_limited"}). Order: the cheap,
+        side-effect-free depth cap first (bounds the latency tail), THEN the
+        token bucket (which mutates the balance) — so a queue-full rejection
+        never wastes a token. Both knobs independently disable at <= 0.
+
+        STRICTLY PER-INSTANCE: every Instance owns its own `pending`/`rl_tokens`,
+        so throttling instance A can never throttle instance B.
+        """
+        # Queue-depth cap: bound pending (admitted-but-unfinished) commands so a
+        # flood can't grow the latency tail unboundedly (the audited 10ms→5.5s).
+        if self._max_queue > 0 and inst.pending >= self._max_queue:
+            return ("queue_full", 1.0)
+        # Token bucket: refill by elapsed*rate (capped at burst), spend one.
+        if self._rate_per_sec > 0:
+            now = self._clock()
+            elapsed = now - inst.rl_last
+            if elapsed > 0:
+                inst.rl_tokens = min(self._burst,
+                                     inst.rl_tokens + elapsed * self._rate_per_sec)
+                inst.rl_last = now
+            if inst.rl_tokens < 1.0:
+                # Time until the next whole token is available — a Retry-After hint.
+                retry = (1.0 - inst.rl_tokens) / self._rate_per_sec
+                return ("rate_limited", retry)
+            inst.rl_tokens -= 1.0
+        inst.pending += 1
+        return None
+
     # --- skill side -------------------------------------------------------- #
     def submit(self, command: dict, timeout: float, target: str = None,
                session_id=None, tab=None) -> dict:
@@ -589,6 +691,16 @@ class Registry:
             inst = self._resolve_target_locked(target)
             tab_id, tab_key = self._effective_tab_locked(inst, op, session_id,
                                                          tab)
+            # Concurrency backstop: admit (or 429) BEFORE joining the turnstile,
+            # so a rejected command never enqueues, never waits, and can't wedge
+            # the FIFO. Placed AFTER target/tab resolution so their own errors
+            # (no_extension / ambiguous / no_owned_tab) win — those never reached
+            # the extension, so they don't spend a token or a queue slot. Admit
+            # bumps inst.pending; the finally below releases it on every exit.
+            verdict = self._admit_locked(inst)
+            if verdict is not None:
+                reason, retry_after = verdict
+                raise RateLimited(reason, retry_after, inst.key)
             # Idempotent `open`: if this session already owns a tab on the target
             # instance, hand the extension that tabId as `reuseTabId`. The SW
             # returns the SAME tab when it is still live (no second real tab → no
@@ -640,6 +752,10 @@ class Registry:
                                               result)
                 return result
             finally:
+                # Release the admitted queue slot (balances _admit_locked's
+                # pending bump) on EVERY exit — normal return, timeout, or
+                # supersede — so the depth cap can never leak a phantom slot.
+                inst.pending -= 1
                 # (3) Leave the turnstile and wake the next in line.
                 if tab_key is not None:
                     q = self._tab_queues.get(tab_key)
@@ -985,6 +1101,23 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                 result = registry.submit(body, timeout=cmd_timeout,
                                          target=target, session_id=session_id,
                                          tab=tab)
+            except RateLimited as e:
+                # Per-instance concurrency backstop tripped. Distinct structured
+                # log + a telemetry event carrying a COARSE session hash so the
+                # NEXT storm is attributable in activity.events without storing
+                # the raw session id (the audit couldn't attribute the 44K flood).
+                # Returns immediately (no turnstile impact) — caller-visible 429
+                # backpressure with a Retry-After-style hint in the body.
+                sess = _session_hash(session_id)
+                log("throttled", op=op, key=e.key, reason=e.reason, sess=sess)
+                self._send(429, {"ok": False, "error": e.reason,
+                                 "retry_after": round(e.retry_after, 3)})
+                emit_cmd_event(
+                    op=op, key=(target or ""), outcome="throttled",
+                    duration_ms=int((time.monotonic() - t0) * 1000),
+                    domain="", exit_code=1,
+                    extra={"reason": e.reason, "sess": sess})
+                return
             except NoOwnedTab:
                 outcome, exit_code = "no_owned_tab", 1
                 log("cmd_no_owned_tab", op=op)

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -73,7 +73,9 @@ Config (env):
     BROWSER_BRIDGE_POLL_TIMEOUT  seconds a /poll blocks before 204 (default 25)
     BROWSER_BRIDGE_RATE_PER_SEC  per-instance sustained /cmd dispatch rate
                                  (token-bucket refill, default 5; 0 → unlimited)
-    BROWSER_BRIDGE_BURST         per-instance token-bucket burst size (default 20)
+    BROWSER_BRIDGE_BURST         per-instance token-bucket burst size (default 20;
+                                 clamped to >=1 when RATE_PER_SEC>0, else a <1
+                                 burst would rate_limit EVERY /cmd forever)
     BROWSER_BRIDGE_MAX_QUEUE     per-instance pending-command cap (default 32;
                                  0 → unlimited). Over-cap /cmd → HTTP 429.
 """
@@ -470,6 +472,16 @@ class Registry:
         # rate_per_sec<=0 → rate limit off; max_queue<=0 → depth cap off.
         self._rate_per_sec = float(rate_per_sec)
         self._burst = float(burst)
+        # A sub-1 burst while the rate limit is ACTIVE (rate>0) can never hold a
+        # whole token, so `rl_tokens < 1.0` is ALWAYS true → EVERY /cmd returns
+        # rate_limited forever (a silent total lockout). Clamp it to a sane floor
+        # of 1: a burst<1 with rate>0 is a misconfiguration, NOT a disable path
+        # (RATE_PER_SEC=0 is the intended "unlimited" escape hatch, honoured
+        # regardless of burst). Log once so the operator sees the correction.
+        if self._rate_per_sec > 0 and self._burst < 1:
+            log("browser_bridge_burst_clamped", requested=self._burst,
+                clamped=1.0, rate_per_sec=self._rate_per_sec)
+            self._burst = 1.0
         self._max_queue = int(max_queue)
         # Per-session tab ownership: (instance_key, session_id) -> {tab_id, last_seen}.
         # Guarded by _cond like everything else. An idle TTL reclaims dead sessions.
@@ -637,8 +649,11 @@ class Registry:
         """Decide whether `inst` may accept ANOTHER /cmd dispatch RIGHT NOW.
 
         Runs UNDER `_cond` (caller holds it) and is lock-free of any blocking
-        wait — it either admits (bumps `inst.pending`, spends one token) or
-        rejects immediately. Returns None to admit, or `(reason, retry_after)`
+        wait — it either admits (spends one token) or rejects immediately. On
+        admit the CALLER bumps `inst.pending` as the first line of its try (so
+        the increment is structurally paired with the releasing finally — see
+        `submit`); this method only spends the token and checks the depth cap.
+        Returns None to admit, or `(reason, retry_after)`
         to reject (`reason` ∈ {"queue_full","rate_limited"}). Order: the cheap,
         side-effect-free depth cap first (bounds the latency tail), THEN the
         token bucket (which mutates the balance) — so a queue-full rejection
@@ -664,7 +679,8 @@ class Registry:
                 retry = (1.0 - inst.rl_tokens) / self._rate_per_sec
                 return ("rate_limited", retry)
             inst.rl_tokens -= 1.0
-        inst.pending += 1
+        # Admit. The queue slot (inst.pending) is claimed by the caller inside
+        # its try, so the increment can never outlive its releasing finally.
         return None
 
     # --- skill side -------------------------------------------------------- #
@@ -695,8 +711,9 @@ class Registry:
             # so a rejected command never enqueues, never waits, and can't wedge
             # the FIFO. Placed AFTER target/tab resolution so their own errors
             # (no_extension / ambiguous / no_owned_tab) win — those never reached
-            # the extension, so they don't spend a token or a queue slot. Admit
-            # bumps inst.pending; the finally below releases it on every exit.
+            # the extension, so they don't spend a token or a queue slot. On
+            # admit the queue slot (inst.pending) is claimed inside the try
+            # below, structurally paired with the finally that releases it.
             verdict = self._admit_locked(inst)
             if verdict is not None:
                 reason, retry_after = verdict
@@ -715,6 +732,16 @@ class Registry:
             if tab_key is not None:
                 self._tab_queues.setdefault(tab_key, deque()).append(ticket)
             try:
+                # Claim the admitted queue slot NOW — the FIRST statement inside
+                # the try whose finally releases it (`inst.pending -= 1`). Pairing
+                # the increment with its decrement in one try/finally makes the
+                # balance structurally leak-proof: ANY raise below (BridgeTimeout,
+                # BridgeSuperseded, a resolution error, or future code) still
+                # unwinds through the finally, so a phantom `pending` slot can
+                # never be stranded (which would eventually wedge the depth cap
+                # into a permanent queue_full). Still under `_cond` and before any
+                # wait, so the depth cap observes the bump atomically.
+                inst.pending += 1
                 # (1) Wait for this tab's FIFO turn (no-op when tab_key is None).
                 if tab_key is not None:
                     while self._tab_queues[tab_key][0] is not ticket:

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -1938,6 +1938,7 @@ def test_admit_token_bucket_burst_then_rate_limited():
     with reg._cond:
         for i in range(3):
             assert reg._admit_locked(inst) is None, f"burst slot {i} must admit"
+            inst.pending += 1              # caller (submit) claims the slot
         verdict = reg._admit_locked(inst)
     assert verdict is not None
     reason, retry_after = verdict
@@ -1972,8 +1973,11 @@ def test_admit_queue_depth_cap():
     reg = S.Registry(rate_per_sec=0, max_queue=2)
     inst = _mk_instance(reg, burst=0)
     with reg._cond:
+        # The caller (submit) bumps pending on each admit; the depth cap reads it.
         assert reg._admit_locked(inst) is None    # pending 1
+        inst.pending += 1
         assert reg._admit_locked(inst) is None    # pending 2
+        inst.pending += 1
         verdict = reg._admit_locked(inst)         # 2 >= cap 2 → queue_full
         assert verdict is not None and verdict[0] == "queue_full"
         assert inst.pending == 2                  # a rejection does NOT bump pending
@@ -1990,8 +1994,10 @@ def test_admit_is_strictly_per_instance():
     b = _mk_instance(reg, key="b", burst=1)
     with reg._cond:
         assert reg._admit_locked(a) is None                       # a: token+slot
+        a.pending += 1                                            # caller claims slot
         assert reg._admit_locked(a)[0] in ("rate_limited", "queue_full")
         assert reg._admit_locked(b) is None                       # b unaffected
+        b.pending += 1
         assert a.pending == 1 and b.pending == 1
 
 
@@ -2002,6 +2008,7 @@ def test_admit_disabled_never_throttles():
     with reg._cond:
         for _ in range(1000):
             assert reg._admit_locked(inst) is None
+            inst.pending += 1                     # caller (submit) claims the slot
     assert inst.pending == 1000
 
 
@@ -2034,6 +2041,47 @@ def test_rate_limited_submit_leaves_no_turnstile_residue():
             assert inst.pending == 0          # admitted slot released
     finally:
         stop.set()
+
+
+# --- Fix 1: BURST<1 with rate>0 must NOT silently brick the instance -------- #
+def test_burst_below_one_with_rate_does_not_lock_out():
+    """A sub-1 burst while RATE_PER_SEC>0 used to permanently brick the instance:
+    rl_tokens started at 0 and the refill cap was min(0,…)=0, so `rl_tokens<1.0`
+    was ALWAYS true → EVERY /cmd returned rate_limited forever (silent lockout).
+    The burst is now clamped to a floor of 1 so a normal command is admitted."""
+    for bad_burst in (0, 0.5):
+        reg = S.Registry(rate_per_sec=5.0, burst=bad_burst)
+        assert reg._burst == 1.0                  # clamped up to the sane floor
+        inst = _register_live(reg)                # created with the clamped burst
+        with reg._cond:
+            # First admit must PASS (full bucket of 1) — not rate_limited forever.
+            assert reg._admit_locked(inst) is None
+    # RATE_PER_SEC=0 (unlimited) is the real disable path — honoured regardless
+    # of burst, so a 0 burst there is left untouched (no spurious clamp/log).
+    reg0 = S.Registry(rate_per_sec=0, burst=0)
+    assert reg0._burst == 0.0
+
+
+# --- Fix 2: a post-admission raise must not leak the pending slot ----------- #
+def test_pending_slot_released_on_post_admission_raise(monkeypatch):
+    """The pending increment lives INSIDE the try whose finally releases it, so
+    a raise AFTER admission but BEFORE the turnstile completes cannot strand a
+    `pending` slot (which would eventually wedge the depth cap into a permanent
+    queue_full). Force such a raise mid-submit (token_hex blows up) and assert
+    the balance returns to 0 and no turnstile ticket leaks."""
+    reg = S.Registry(rate_per_sec=0, max_queue=1000)   # admit always succeeds
+    inst = _register_live(reg)
+
+    def _boom(*a, **k):
+        raise RuntimeError("forced post-admission failure")
+    # token_hex is called inside submit's try, AFTER pending is bumped.
+    monkeypatch.setattr(S.secrets, "token_hex", _boom)
+
+    with pytest.raises(RuntimeError):
+        reg.submit({"op": "getHtml"}, 3.0)   # admitted, then raises past the bump
+    with reg._cond:
+        assert inst.pending == 0             # released by the finally, no leak
+        assert reg._tab_queues == {}         # no leaked turnstile ticket either
 
 
 # --- HTTP: burst over the bucket → 429 rate_limited + throttle telemetry --- #

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -9,10 +9,13 @@ request↔reply id correlation, AND the multi-instance registry/routing.
 Run: nix-shell -p python312Packages.pytest --run "pytest scripts/browser-bridge/tests"
 """
 import base64
+import hashlib
 import json
 import os
+import shutil
 import stat
 import struct
+import subprocess
 import sys
 import threading
 import time
@@ -1901,3 +1904,262 @@ def test_explicit_tab_overrides_owned_mapping():
         assert body["result"]["data"]["tabId"] == 101
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# Fix 5 — per-instance concurrency backstop (rate limit + queue-depth cap)
+#
+# Motivation: an audit found a 44,061-event storm (43,991 evals in one hour,
+# ~13/sec sustained) that saturated the SINGLE serial extension connection with
+# NO backpressure (latency 10ms→5.5s). The server now enforces, PER-INSTANCE, a
+# token-bucket rate limit + a pending-command depth cap; an over-limit /cmd is
+# rejected with HTTP 429 (caller-visible backpressure). The admission decision
+# (`_admit_locked`) is unit-tested directly with an INJECTED clock (scripts forbid
+# real-time nondeterminism), plus HTTP round-trips prove the 429 + telemetry.
+# --------------------------------------------------------------------------- #
+def _mk_instance(reg, key="k", burst=0.0, now=0.0):
+    """A bare Instance for direct _admit_locked unit tests (no HTTP/registry)."""
+    return S.Instance(key, key, "", now, burst=burst)
+
+
+def _instance_pending(reg):
+    with reg._cond:
+        return sum(i.pending for i in reg._instances.values())
+
+
+# --- token bucket: burst passes, then rate_limited (frozen clock) ---------- #
+def test_admit_token_bucket_burst_then_rate_limited():
+    """Within `burst`, admits pass; the next over the empty bucket → rate_limited.
+    Frozen clock ⇒ no refill ⇒ deterministic."""
+    clock = [100.0]
+    reg = S.Registry(clock=lambda: clock[0], rate_per_sec=5.0, burst=3,
+                     max_queue=1000)
+    inst = _mk_instance(reg, burst=3, now=clock[0])
+    with reg._cond:
+        for i in range(3):
+            assert reg._admit_locked(inst) is None, f"burst slot {i} must admit"
+        verdict = reg._admit_locked(inst)
+    assert verdict is not None
+    reason, retry_after = verdict
+    assert reason == "rate_limited"
+    assert retry_after > 0                 # a positive Retry-After-style hint
+    assert inst.pending == 3               # ONLY the 3 admitted bumped pending
+
+
+# --- token bucket refills over (fake) time → dispatches resume ------------- #
+def test_admit_token_bucket_refills_over_time():
+    clock = [100.0]
+    reg = S.Registry(clock=lambda: clock[0], rate_per_sec=5.0, burst=2,
+                     max_queue=1000)
+    inst = _mk_instance(reg, burst=2, now=clock[0])
+    with reg._cond:
+        assert reg._admit_locked(inst) is None
+        assert reg._admit_locked(inst) is None
+        assert reg._admit_locked(inst)[0] == "rate_limited"   # bucket empty
+        clock[0] += 0.2                                       # +1 token @5/sec
+        assert reg._admit_locked(inst) is None                # resumed
+        assert reg._admit_locked(inst)[0] == "rate_limited"   # empty again
+        clock[0] += 100.0                                     # long idle
+        # Refill is CAPPED at `burst` (2) — no unbounded accrual.
+        assert reg._admit_locked(inst) is None
+        assert reg._admit_locked(inst) is None
+        assert reg._admit_locked(inst)[0] == "rate_limited"
+
+
+# --- queue-depth cap: fill to MAX_QUEUE → queue_full; drain resumes -------- #
+def test_admit_queue_depth_cap():
+    """Rate limit disabled so ONLY the depth cap is exercised."""
+    reg = S.Registry(rate_per_sec=0, max_queue=2)
+    inst = _mk_instance(reg, burst=0)
+    with reg._cond:
+        assert reg._admit_locked(inst) is None    # pending 1
+        assert reg._admit_locked(inst) is None    # pending 2
+        verdict = reg._admit_locked(inst)         # 2 >= cap 2 → queue_full
+        assert verdict is not None and verdict[0] == "queue_full"
+        assert inst.pending == 2                  # a rejection does NOT bump pending
+        inst.pending -= 1                         # a command completes (drains)
+        assert reg._admit_locked(inst) is None    # slot freed → resumes
+
+
+# --- strict per-instance isolation ----------------------------------------- #
+def test_admit_is_strictly_per_instance():
+    """Throttling instance A must NOT throttle instance B — independent buckets
+    AND independent pending."""
+    reg = S.Registry(rate_per_sec=5.0, burst=1, max_queue=1)
+    a = _mk_instance(reg, key="a", burst=1)
+    b = _mk_instance(reg, key="b", burst=1)
+    with reg._cond:
+        assert reg._admit_locked(a) is None                       # a: token+slot
+        assert reg._admit_locked(a)[0] in ("rate_limited", "queue_full")
+        assert reg._admit_locked(b) is None                       # b unaffected
+        assert a.pending == 1 and b.pending == 1
+
+
+# --- disable path (rate=0 AND max_queue=0) never throttles ----------------- #
+def test_admit_disabled_never_throttles():
+    reg = S.Registry(rate_per_sec=0, max_queue=0)
+    inst = _mk_instance(reg, burst=0)
+    with reg._cond:
+        for _ in range(1000):
+            assert reg._admit_locked(inst) is None
+    assert inst.pending == 1000
+
+
+# --- a rejected submit leaves NO turnstile/waiter residue (no deadlock) ---- #
+def test_rate_limited_submit_leaves_no_turnstile_residue():
+    """A rejected submit raises RateLimited IMMEDIATELY and leaves no residue —
+    no tab-queue ticket, no waiter, pending balanced — so it can neither wedge
+    the FIFO turnstile nor leak a queue slot."""
+    reg = S.Registry(rate_per_sec=0.001, burst=1, max_queue=1000)  # ~no refill
+    inst = _register_live(reg)
+    stop = threading.Event()
+
+    def deliverer():
+        while not stop.is_set():
+            cmd = reg.poll("solo", "one", 0.05)
+            if cmd is not None and cmd is not S.SUPERSEDED:
+                reg.deliver_result(cmd["id"], {"id": cmd["id"], "ok": True,
+                                               "data": {}}, instance_id="solo")
+
+    threading.Thread(target=deliverer, daemon=True).start()
+    try:
+        reg.submit({"op": "getHtml"}, 3.0, session_id="s1", tab=5)  # spends token
+        with pytest.raises(S.RateLimited) as ei:
+            reg.submit({"op": "getHtml"}, 3.0, session_id="s2", tab=5)
+        assert ei.value.reason == "rate_limited"
+        assert ei.value.key == "one"
+        with reg._cond:
+            assert inst.waiters == set()      # no leaked waiter
+            assert reg._tab_queues == {}      # no leaked turnstile ticket
+            assert inst.pending == 0          # admitted slot released
+    finally:
+        stop.set()
+
+
+# --- HTTP: burst over the bucket → 429 rate_limited + throttle telemetry --- #
+def test_cmd_rate_limited_returns_429_and_emits_throttle(telemetry):
+    """Over-burst /cmd → HTTP 429 rate_limited (with a retry_after hint), a
+    DISTINCT throttle telemetry event that is metadata-only and carries a COARSE
+    session hash (never the raw id), and the server stays responsive (no wedge)."""
+    spool_dir = telemetry
+    reg = S.Registry(rate_per_sec=0.001, burst=2, max_queue=1000)  # ~no refill
+    srv, _ = _serve(registry=reg)
+    ext = FakeExtension(srv, executor=lambda c: {"url": "https://x.test"})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _req(srv, "POST", "/cmd", {"op": "getHtml"})[0] == 200   # burst 1
+        assert _req(srv, "POST", "/cmd", {"op": "getHtml"})[0] == 200   # burst 2
+        st, body = _cmd(srv, {"op": "getHtml"}, session="floodsession")  # over
+        assert st == 429
+        assert body["error"] == "rate_limited"
+        assert body["retry_after"] > 0
+        # 3 events: 2 ok + 1 throttled.
+        evs = _wait_events(spool_dir, 3)
+        throttled = [e for e in evs
+                     if json.loads(e["payload"]).get("outcome") == "throttled"]
+        assert len(throttled) == 1, f"expected one throttle event, got {evs}"
+        p = json.loads(throttled[0]["payload"])
+        assert p["op"] == "getHtml"
+        assert p["reason"] == "rate_limited"
+        # Attribution is a COARSE, non-reversible hash of X-Session-Id — NOT raw.
+        assert p["sess"] == hashlib.sha256(b"floodsession").hexdigest()[:8]
+        raw = _log_file(spool_dir).read_text()
+        assert "floodsession" not in raw          # raw session id NEVER stored
+        # No deadlock: the server still answers after shedding load.
+        assert _req(srv, "GET", "/health")[0] == 200
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --- HTTP: pending at MAX_QUEUE → next /cmd is 429 queue_full (immediate) --- #
+def test_cmd_queue_full_returns_429():
+    """Two stuck (un-answered) in-flight commands fill an instance's pending to
+    MAX_QUEUE; the next /cmd is rejected FAST with 429 queue_full (it does not
+    block behind the queue). Rate disabled so ONLY the cap fires."""
+    reg = S.Registry(rate_per_sec=0, max_queue=2)
+    srv, _ = _serve(cmd_timeout=5.0, poll_timeout=5.0, registry=reg)
+    ext = FakeExtension(srv, swallow=True)     # picks up but never answers
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        for t in (1, 2):     # different tabs → both admitted + pending
+            threading.Thread(
+                target=lambda tt=t: _req(srv, "POST", "/cmd",
+                                         {"op": "getHtml", "tab": tt}),
+                daemon=True).start()
+        assert _wait_until(lambda: _instance_pending(reg) >= 2), \
+            "two in-flight commands never filled the queue"
+        t0 = time.time()
+        st, body = _req(srv, "POST", "/cmd", {"op": "getHtml", "tab": 3})
+        assert st == 429 and body["error"] == "queue_full"
+        assert time.time() - t0 < 2.0, "queue_full must reject immediately"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --- default knobs never throttle a legitimate small burst ----------------- #
+def test_default_knobs_do_not_throttle_normal_use():
+    """With PRODUCTION defaults, a normal workflow (open + a handful of ops) is
+    NEVER throttled — the storm-only guarantee for legit use."""
+    reg = S.Registry()   # default rate=5/s, burst=20, max_queue=32
+    srv, _ = _serve(registry=reg)
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_echo_exec([101]))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _cmd(srv, {"op": "open"}, session="A")[0] == 200
+        for _ in range(10):            # 10 rapid ops, well under burst 20
+            st, _b = _cmd(srv, {"op": "getHtml"}, session="A")
+            assert st == 200, "a normal small burst must never be throttled"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# Skill side: a 429 from /cmd makes the `browser` CLI print a back-off message
+# and exit non-zero (the runaway-loop backpressure signal). Runs the REAL bash
+# entrypoint against an in-process fake server that always answers /cmd with 429.
+# Skipped where curl is unavailable (the CLI shells out to curl).
+# --------------------------------------------------------------------------- #
+BROWSER_BIN = Path(__file__).resolve().parent.parent / "browser"
+
+
+@pytest.mark.skipif(shutil.which("curl") is None, reason="curl not on PATH")
+def test_browser_cli_backs_off_on_429(tmp_path):
+    class _H(S.BaseHTTPRequestHandler):
+        def log_message(self, *a):  # noqa: A003
+            pass
+
+        def do_POST(self):
+            ln = int(self.headers.get("Content-Length") or 0)
+            if ln:
+                self.rfile.read(ln)
+            payload = json.dumps({"ok": False, "error": "rate_limited",
+                                  "retry_after": 1.5}).encode("utf-8")
+            self.send_response(429)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+    srv = S.ThreadingHTTPServer(("127.0.0.1", 0), _H)
+    srv.daemon_threads = True
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    tokf = tmp_path / "token"
+    tokf.write_text("smoke-token\n")
+    env = dict(os.environ)
+    env.update(BROWSER_BRIDGE_HOST="127.0.0.1",
+               BROWSER_BRIDGE_PORT=str(port),
+               BROWSER_BRIDGE_TOKEN_FILE=str(tokf))
+    try:
+        r = subprocess.run([str(BROWSER_BIN), "eval", "1+1"], env=env,
+                           capture_output=True, text=True, timeout=30)
+        assert r.returncode != 0, "a 429 must make the CLI exit non-zero"
+        low = r.stderr.lower()
+        assert "rate-limited" in low or "back off" in low, \
+            f"expected a back-off message on stderr, got: {r.stderr!r}"
+    finally:
+        srv.shutdown(); srv.server_close()


### PR DESCRIPTION
## Motivation

An audit of the browser-bridge found two problems:

1. **A 44,061-event storm** — **43,991 `eval`s in one hour (~13/sec sustained)** from an unisolated fleet/loop — saturated the **single serial extension connection** with **no backpressure**. Latency ballooned from ~10 ms to ~5.5 s. The audit also couldn't *attribute* the storm to a session.
2. **Agents burned 3–4 commands hunting for the `browser` executable** because it isn't discoverable from the skill dir (they tried `~/.claude/skills/browser/scripts/...`).

## Fix 1 — server-side concurrency backstop (per-instance)

The extension is the bottleneck, so both limits are enforced **per-instance** (throttling instance A never affects B):

- **Token-bucket rate limit** on accepted `/cmd` dispatches — `BROWSER_BRIDGE_RATE_PER_SEC` sustained (**default 5/sec**), `BROWSER_BRIDGE_BURST` burst (**default 20**). A dispatch over the bucket is **rejected**, never silently queued. `RATE_PER_SEC=0` → unlimited (power-user escape hatch).
- **Queue-depth cap** `BROWSER_BRIDGE_MAX_QUEUE` (**default 32**) on an instance's *pending* (admitted-but-unfinished) command count — bounds the latency tail (prevents the 5.5 s). `MAX_QUEUE=0` → unlimited.
- **Why the defaults don't hurt legit use:** interactive/agent work is a handful of ops per burst — well under burst 20 and depth 32. Only a *sustained* high-rate flood is throttled. (Unit-tested: 10 rapid ops under the production defaults are never throttled.)
- On rejection → **HTTP 429** `{"ok":false,"error":"rate_limited"|"queue_full","retry_after":<s>}` (caller-visible backpressure). The **`browser` CLI** prints a clear back-off message and **exits non-zero**, so a runaway loop gets a hard, detectable signal — the whole point of backpressure.

### Safety / no regression
- Admission (`_admit_locked`) runs **under the existing `_cond` lock**, is lock-free of any blocking wait, and rejects **before** the command joins the per-tab FIFO turnstile — so it can neither deadlock nor wedge the turnstile. A rejection returns immediately, leaves **no orphaned waiter / no turnstile ticket**, and `pending` is released in `finally` on every exit path (return / timeout / supersede). The audited concurrency core (single `Condition`, no lock held across a blocking wait, turnstile self-release) is **unchanged**.
- All security invariants preserved: loopback bind, bearer on **every** endpoint (incl. `/poll` & `/result`), Host allowlist, no CORS, constant-time compare. The #169 multi-instance/supersede model, #173 metadata-only telemetry, and #175 session-isolation + FIFO turnstile are intact.

### Observability (so the next storm is attributable)
A throttle both `log()`s a distinct `{"event":"throttled","key":…,"reason":…,"sess":…}` line **and** emits a telemetry event (`outcome="throttled"`, `payload.reason`) into `activity.events`. `payload.sess` is a **coarse, non-reversible** fingerprint (first 8 hex of sha256 of `X-Session-Id`) — enough to attribute a flood to a session **without storing the raw id**, kept metadata-only (no page content). This is the **only** event that carries the session hash.

## Fix 2 — discoverability
- **SKILL.md's very first content line** (right after frontmatter) is the exact runnable path: `~/workspace/devrc/scripts/browser-bridge/browser <subcommand>` (noting the `~/.claude/skills/browser/browser` symlink alias).
- A **Quick start / binary path** section near the top of both SKILL.md and README.md with copy-paste examples (`health`, `--instance … open`, `--tab`).
- A prominent **Concurrency / don't do this** section: concurrent drivers (esp. sibling subagents that share a session id) should each `open` and thread their own `--tab <id>`; a bare high-rate `eval` loop with no `--instance`/`open` shares the active tab **and is now rate-limited**.

## Env knobs
| var | default | effect |
|-----|---------|--------|
| `BROWSER_BRIDGE_RATE_PER_SEC` | `5` | sustained accepted /cmd per sec (token refill); `0` = unlimited |
| `BROWSER_BRIDGE_BURST` | `20` | token-bucket burst size |
| `BROWSER_BRIDGE_MAX_QUEUE` | `32` | per-instance pending-command cap; `0` = unlimited |

Documented in the `server.py` config docstring, SKILL.md, and README.md. The systemd unit was **not** modified — defaults live in `server.py` and are env-overridable, so the existing `X-Restart-Triggers` restart on the code change is sufficient.

## Tests
`nix-shell -p python312Packages.pytest --run "python -m pytest scripts/browser-bridge/tests"` → **92 passed** (was 82; +10). `node --test .../protocol.test.mjs` → **22 passed** (unchanged). `bash -n browser` → OK.

New coverage (headless, injected clock — no Brave/network/ClickHouse):
- token-bucket burst then `rate_limited`; refill over fake time; refill capped at burst
- queue-depth cap → `queue_full` at `MAX_QUEUE`; draining resumes
- **strict per-instance isolation** (throttling A does not throttle B)
- disable path (rate=0 & max_queue=0) never throttles
- a rejected submit leaves **no turnstile/waiter residue** (no deadlock), `pending` balanced
- HTTP **429 `rate_limited`** + distinct throttle telemetry event — asserts metadata-only and that the payload carries the **hashed** session, never the raw id
- HTTP **429 `queue_full`** rejected immediately (does not block behind the queue)
- production defaults never throttle a normal small burst
- the **`browser` CLI** backs off (non-zero exit, back-off message) on a 429 — runs the real bash entrypoint against an in-process fake 429 server

## Manual live check (needs the real extension in Brave — not automatable here)
Rate-limit/cap/backpressure is fully unit-tested with a fake clock (done above). The one thing that needs real Brave:
1. `home-manager switch …`; load + pair the extension; `browser health` → `extension_connected:true`.
2. Hammer `browser eval` in a tight loop (e.g. `for i in $(seq 1 100); do browser eval '1' >/dev/null 2>&1 || echo throttled; done`) → confirm it starts returning **429 / back-off** (non-zero exit) after the burst, rather than unbounded queueing, and that server logs show `{"event":"throttled",...}`.
3. Confirm a **normal** handful-of-ops workflow (`open` → a few `eval`/`html`) is **never** throttled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
