### PR TITLE
fix(browser-bridge): space screenshot retries to respect Chrome's ~2/sec captureVisibleTab quota

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -261,8 +261,11 @@ per-session (multi-step **workflow**) isolation did not.
   tab that is already visible is unaffected. **Background-tab settle + retry:** a
   just-activated background tab hasn't painted its first frame, so a bare capture
   returns `"image readback failed"`; the SW waits for `status:"complete"` + a
-  short paint settle, then **retries** the capture on that transient error (a few
-  bounded tries with a short back-off) before giving up. This hardens the
+  paint settle (~350ms) so the FIRST capture usually wins, then **retries** on a
+  transient error. Retries **respect Chrome's ~2/sec `captureVisibleTab` quota**
+  (spaced ≥~600ms; a `MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND` hit waits a ~1s
+  window) — a faster retry would re-trip the quota instead of recovering (needs
+  an extension **reload** to take effect). This hardens the
   `browser agent` path, which screenshots in its OWN background tab. The classify
   + retry + settle + activate→capture→restore logic is pure and unit-tested in
   `extension/protocol.js` (`isTransientCaptureError` / `captureWithRetry` /

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -65,7 +65,7 @@ Prefix any op with `--instance <key>` to target a specific connected profile
 | `browser [--instance K] [--tab T] eval '<js>'`       | run JS in the owned/active tab, return its value |
 | `browser [--instance K] tabs`              | list open tabs (`.data.ownedTabId` flags this session's owned tab) |
 | `browser [--instance K] [--tab T] nav <url>`         | navigate the owned/active tab to `<url>` |
-| `browser [--instance K] [--tab T] screenshot [path]` | captureVisibleTab; prints the data URL, or writes a `.png` to `path`. A BACKGROUND owned tab is briefly activated, **settled until painted, then captured with a bounded retry** on the transient `image readback failed` (needs an extension **reload** to take effect) |
+| `browser [--instance K] [--tab T] screenshot [path]` | captureVisibleTab; prints the data URL, or writes a `.png` to `path`. A BACKGROUND owned tab is briefly activated, **settled until painted (~350ms), then captured with a bounded retry** on a transient `image readback failed` — retries are **spaced ≥~600ms to respect Chrome's ~2/sec `captureVisibleTab` quota** (`MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND`; a faster retry re-trips it) (needs an extension **reload** to take effect) |
 | `browser [--instance K] agent "<goal>" [flags]` | run the **autonomous opencode browser-agent** in its OWN isolated tab against `<goal>`; returns a compact `{answer,evidence,steps_used,status}` (see below) |
 | `browser --print-session-id`               | print the derived per-session id (debug) and exit |
 

--- a/scripts/browser-bridge/extension/README.md
+++ b/scripts/browser-bridge/extension/README.md
@@ -52,10 +52,15 @@ captured directly with no flicker.
 *Background-tab settle + retry (robustness):* a JUST-activated background tab
 hasn't painted its first frame yet, so a bare `captureVisibleTab` returns
 `"image readback failed"`. The SW therefore (1) waits for the tab to reach
-`status:"complete"` **plus a short paint settle** before capturing, and (2)
-**retries** the capture on the transient readback error (bounded — a few tries
-with a short linear back-off) before giving up. This matters because `browser
-agent` screenshots run in the agent's OWN background tab. The classifier
+`status:"complete"` **plus a paint settle (~350ms)** so the FIRST capture
+usually succeeds, and (2) **retries** the capture on a transient error (bounded —
+a few tries). **Retries respect Chrome's ~2/sec `captureVisibleTab` quota:** the
+API is throttled to ~2 calls/sec (~500ms), so retries are **spaced ≥~600ms**
+apart (a quota hit — `MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND` — waits a full
+~1s window) — a faster retry would just re-trip the quota instead of recovering.
+This matters because `browser agent` screenshots run in the agent's OWN
+background tab. **Reload the extension** after changing this to take effect. The
+classifier
 (`isTransientCaptureError`), the retry (`captureWithRetry`), the settle
 (`waitForCaptureReady`) and the activate→capture→restore orchestration
 (`screenshotWithRestore`, restore on success AND failure) are pure + unit-tested
@@ -163,10 +168,12 @@ The chrome.* glue needs a real browser — verify by hand after loading:
       OWN tab — the explicit `--tab` overrides the shared owned-tab routing.
 - [ ] `browser screenshot` of a background owned tab briefly flickers it to the
       foreground, captures it, and restores the tab that was active before. It
-      **succeeds even on the first shot of a fresh background tab** (the settle +
-      retry defeats the old `image readback failed`): `browser --instance <key>
-      open <url>` → `browser --instance <key> --tab <id> screenshot /tmp/x.png`
-      writes a real PNG (was flaky before this fix).
+      **succeeds even on the first shot of a fresh background tab** with **NO
+      `MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND` quota error** (the paint settle +
+      the ≥~600ms-spaced retry defeat both the old `image readback failed` and the
+      quota trip): `browser --instance <key> open <url>` → `browser --instance
+      <key> --tab <id> screenshot /tmp/x.png` writes a real PNG (was flaky before
+      this fix — reload the extension first so the new spacing is live).
 - [ ] **Two-session isolation (the fix):** open two Claude sessions (each in its
       own tmux pane). In each, `browser open` a DIFFERENT url, then interleave
       `browser nav …` / `browser html` between the sessions. Confirm neither

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -119,48 +119,87 @@ export function nextBackoffMs(attempt, baseMs = 1000, capMs = 30000) {
 }
 
 // --- screenshot capture: settle + retry (background-tab robustness) --------- //
-// captureVisibleTab of a JUST-activated background tab often fails with
-// "Failed to capture tab: image readback failed": the tab has been made active
-// but Chrome hasn't painted its first frame yet, so the GPU read-back has no
-// pixels. It is TRANSIENT — a short settle + a retry almost always succeeds.
-// The decision logic (classify + retry loop + the activate→settle→capture→restore
-// orchestration) is pure and injectable here; service_worker.js supplies the real
-// chrome.* side effects. Keep the SW's screenshot op in sync with this.
+// captureVisibleTab of a JUST-activated background tab can fail two ways, both
+// TRANSIENT:
+//   1. "Failed to capture tab: image readback failed" — the tab was made active
+//      but Chrome hasn't painted its first frame yet, so the GPU read-back has
+//      no pixels.
+//   2. "This request exceeds the MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND quota."
+//      — Chrome throttles captureVisibleTab to ~2 calls/sec (≈500ms spacing). A
+//      retry fired too soon after the first attempt trips this.
+// CRITICAL SPACING INVARIANT: retries must be spaced ≥ the quota window, else the
+// retry meant to recover a readback error just trips the quota error instead
+// (the original PR #181 bug: a 150ms backoff fired a 2nd capture inside the same
+// 1s quota window). So the retry backoff is ≥~600ms and a quota hit waits a full
+// ~1s window before the next attempt.
+// The decision logic (classify + spaced retry loop + the
+// activate→settle→capture→restore orchestration) is pure and injectable here;
+// service_worker.js supplies the real chrome.* side effects. Keep the SW's
+// screenshot op in sync with this.
 
 export const CAPTURE_MAX_ATTEMPTS = 3;      // total capture tries before giving up
-export const CAPTURE_RETRY_BASE_MS = 150;   // linear backoff: 150ms, 300ms, …
-export const CAPTURE_SETTLE_MS = 150;       // paint settle after 'complete'
+// Linear backoff base. MUST be ≥ Chrome's captureVisibleTab quota window
+// (~2/sec ≈ 500ms) with margin, so two capture attempts never land inside one
+// quota window: attempt-1 retry waits base·1 (700ms), attempt-2 waits base·2.
+export const CAPTURE_RETRY_BASE_MS = 700;
+// After a quota error specifically, wait AT LEAST a full quota window (~1s) so
+// the next attempt is safely outside it (belt-and-braces over the base spacing).
+export const CAPTURE_QUOTA_WAIT_MS = 1000;
+// Paint settle after 'complete'. Chrome fires "complete" slightly BEFORE the
+// first paint, so this settle (≈350ms) lets the FIRST capture usually succeed —
+// avoiding a retry (hence any quota risk) in the common case.
+export const CAPTURE_SETTLE_MS = 350;
 export const CAPTURE_READY_TIMEOUT_MS = 2000; // cap on the status poll
 export const CAPTURE_READY_POLL_MS = 100;   // status re-poll cadence
 
-// Transient (retry-worthy) capture failures — the GPU/paint race, NOT a
-// permanent permission/URL error (retrying THOSE just burns the cmd_timeout).
-// Matched case-insensitively against the error message. Kept deliberately narrow.
+// Transient (retry-worthy) capture failures — the GPU/paint race and the
+// per-second capture quota, NOT a permanent permission/URL error (retrying THOSE
+// just burns the cmd_timeout). Matched case-insensitively against the error
+// message. Kept deliberately narrow.
 const TRANSIENT_CAPTURE_PATTERNS = [
-  "image readback failed",   // the observed background-tab race
+  "image readback failed",   // the observed background-tab paint race
   "readback",                // any GPU read-back failure phrasing
+  "max_capture_visible_tab_calls_per_second", // the ~2/sec capture quota
 ];
+
+// The per-second capture quota substring (matched case-insensitively). A quota
+// hit needs a longer wait (a full quota window) than a plain readback retry.
+const CAPTURE_QUOTA_PATTERN = "max_capture_visible_tab_calls_per_second";
+
+function errText(err) {
+  const msg = (err && err.message != null) ? err.message : err;
+  return String(msg == null ? "" : msg).toLowerCase();
+}
 
 // True when `err`'s message looks like a transient capture failure worth a retry.
 // Accepts an Error, a string, or anything stringifiable; unknown/empty → false
 // (fail closed: an unclassifiable error is treated as permanent, not retried).
 export function isTransientCaptureError(err) {
-  const msg = (err && err.message != null) ? err.message : err;
-  const s = String(msg == null ? "" : msg).toLowerCase();
+  const s = errText(err);
   if (!s) return false;
   return TRANSIENT_CAPTURE_PATTERNS.some((p) => s.includes(p));
+}
+
+// True when `err` is specifically the per-second captureVisibleTab quota error.
+export function isCaptureQuotaError(err) {
+  const s = errText(err);
+  return !!s && s.includes(CAPTURE_QUOTA_PATTERN);
 }
 
 const defaultSleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // Call `capture()` (→ Promise<dataUrl>) with a bounded retry on a TRANSIENT
 // failure. A non-transient error propagates IMMEDIATELY (no wasted retries); a
-// transient error backs off (linear: base, 2·base, …) and retries up to
-// `maxAttempts` total, then the last error propagates. `sleep` is injectable for
-// tests. Returns whatever `capture()` resolves to on the first success.
+// transient error backs off and retries up to `maxAttempts` total, then the last
+// error propagates. The backoff SPACES attempts ≥ Chrome's captureVisibleTab
+// quota window (linear base·attempt, base ≥~600ms) so a retry never re-trips the
+// per-second quota; a quota error waits at least a full window (`quotaWaitMs`).
+// `sleep` is injectable for tests. Returns whatever `capture()` resolves to on
+// the first success.
 export async function captureWithRetry(capture, opts = {}) {
   const maxAttempts = opts.maxAttempts || CAPTURE_MAX_ATTEMPTS;
   const baseMs = opts.baseMs == null ? CAPTURE_RETRY_BASE_MS : opts.baseMs;
+  const quotaWaitMs = opts.quotaWaitMs == null ? CAPTURE_QUOTA_WAIT_MS : opts.quotaWaitMs;
   const sleep = opts.sleep || defaultSleep;
   let lastErr;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -170,7 +209,11 @@ export async function captureWithRetry(capture, opts = {}) {
       lastErr = e;
       // Permanent error, or out of attempts → give up now.
       if (!isTransientCaptureError(e) || attempt === maxAttempts) throw e;
-      await sleep(baseMs * attempt);
+      // Space the next attempt ≥ the quota window. Linear base·attempt is already
+      // ≥ a window; a quota hit waits at least a full window on top of that.
+      let delay = baseMs * attempt;
+      if (isCaptureQuotaError(e)) delay = Math.max(delay, quotaWaitMs);
+      await sleep(delay);
     }
   }
   throw lastErr; // unreachable (loop always returns or throws) — belt & braces

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -177,10 +177,14 @@ const OPS = {
     // A JUST-activated background tab hasn't painted its first frame yet, so a
     // bare captureVisibleTab returns "image readback failed". So for the
     // background path we (1) wait for the tab to reach `status:"complete"` + a
-    // short paint settle, and (2) retry the capture on the transient readback
-    // error. Both the settle and the retry, plus the activate→capture→restore
-    // orchestration (restore on success AND failure), are pure + unit-tested in
-    // protocol.js — keep this in sync with them.
+    // paint settle (so the FIRST capture usually succeeds — no retry needed), and
+    // (2) retry the capture on a transient error. CRITICAL: Chrome throttles
+    // captureVisibleTab to ~2/sec (MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND), so
+    // the retry backoff spaces attempts ≥~600ms (a quota hit waits a full ~1s
+    // window) — a faster retry would re-trip the quota. Both the settle and the
+    // spaced retry, plus the activate→capture→restore orchestration (restore on
+    // success AND failure), are pure + unit-tested in protocol.js — keep this in
+    // sync with them.
     const capture = () =>
       chrome.tabs.captureVisibleTab(tab.windowId, { format: "png" });
     const dataUrl = await screenshotWithRestore({

--- a/scripts/browser-bridge/tests/protocol.test.mjs
+++ b/scripts/browser-bridge/tests/protocol.test.mjs
@@ -16,8 +16,9 @@ import {
   POLL_UNAUTHORIZED, SUPERSEDE_BACKOFF_MS,
   capHeaderValue, MAX_HEADER_VALUE_CHARS,
   normalizeText, TEXT_MAX_BYTES_DEFAULT,
-  isTransientCaptureError, captureWithRetry, waitForCaptureReady,
-  screenshotWithRestore, CAPTURE_MAX_ATTEMPTS,
+  isTransientCaptureError, isCaptureQuotaError, captureWithRetry,
+  waitForCaptureReady, screenshotWithRestore, CAPTURE_MAX_ATTEMPTS,
+  CAPTURE_RETRY_BASE_MS, CAPTURE_QUOTA_WAIT_MS, CAPTURE_SETTLE_MS,
 } from "../extension/protocol.js";
 
 test("op set mirrors the server contract", () => {
@@ -286,6 +287,31 @@ test("isTransientCaptureError classifies the readback race as retry-worthy", () 
   assert.equal(isTransientCaptureError("IMAGE READBACK FAILED"), true);
 });
 
+test("isTransientCaptureError classifies the per-second capture quota as retry-worthy", () => {
+  // The observed live failure (PR #181 regression): a too-fast retry trips the
+  // ~2/sec captureVisibleTab quota. It is TRANSIENT — waiting out the window
+  // recovers it, so it must be retried (with the spaced backoff below).
+  assert.equal(isTransientCaptureError(new Error(
+    "This request exceeds the MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND quota.")), true);
+  assert.equal(isTransientCaptureError(
+    "This request exceeds the MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND quota."), true);
+  // Case-insensitive (Chrome could vary the surrounding prose).
+  assert.equal(isTransientCaptureError(
+    "exceeds the max_capture_visible_tab_calls_per_second quota"), true);
+});
+
+test("isCaptureQuotaError isolates the quota error from other transient errors", () => {
+  // Only the quota error is a quota error — a plain readback race is NOT (it
+  // takes the shorter backoff, not the full quota-window wait).
+  assert.equal(isCaptureQuotaError(new Error(
+    "This request exceeds the MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND quota.")), true);
+  assert.equal(isCaptureQuotaError("IMAGE readback FAILED as MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND"), true);
+  assert.equal(isCaptureQuotaError("image readback failed"), false);
+  assert.equal(isCaptureQuotaError("Cannot access contents of the page"), false);
+  assert.equal(isCaptureQuotaError(""), false);
+  assert.equal(isCaptureQuotaError(null), false);
+});
+
 test("isTransientCaptureError treats permanent/unknown errors as NON-transient (fail closed)", () => {
   // A permission/URL error must NOT be retried (it would just burn cmd_timeout).
   assert.equal(isTransientCaptureError(new Error(
@@ -295,6 +321,18 @@ test("isTransientCaptureError treats permanent/unknown errors as NON-transient (
   assert.equal(isTransientCaptureError(""), false);
   assert.equal(isTransientCaptureError(null), false);
   assert.equal(isTransientCaptureError(undefined), false);
+});
+
+test("capture spacing constants respect Chrome's ~2/sec captureVisibleTab quota", () => {
+  // The core regression guard as a constant invariant: the FIRST retry (base·1)
+  // and the quota-window wait must BOTH be ≥~600ms — faster than that re-trips
+  // MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND (the ~2/sec ≈ 500ms window).
+  assert.ok(CAPTURE_RETRY_BASE_MS >= 600, `first-retry gap ${CAPTURE_RETRY_BASE_MS}ms must be ≥600ms`);
+  assert.ok(CAPTURE_QUOTA_WAIT_MS >= 600, `quota wait ${CAPTURE_QUOTA_WAIT_MS}ms must be ≥600ms`);
+  // And the whole retry budget stays well under the server cmd_timeout (20s):
+  // worst case = base·1 + base·2 (+ settle) with 3 attempts.
+  const worst = CAPTURE_RETRY_BASE_MS * 1 + CAPTURE_RETRY_BASE_MS * 2;
+  assert.ok(worst < 20000, `retry budget ${worst}ms must stay under the 20s cmd_timeout`);
 });
 
 test("captureWithRetry: a transient failure then success resolves (retries, then wins)", async () => {
@@ -308,7 +346,46 @@ test("captureWithRetry: a transient failure then success resolves (retries, then
   const out = await captureWithRetry(capture, { sleep: (ms) => { sleeps.push(ms); } });
   assert.equal(out, "data:png;ok");
   assert.equal(calls, 2, "one retry after the transient failure");
-  assert.deepEqual(sleeps, [150], "one linear backoff before the retry");
+  assert.deepEqual(sleeps, [CAPTURE_RETRY_BASE_MS], "one spaced backoff before the retry");
+  // The regression guard: the retry is spaced ≥ the quota window, so a 2nd
+  // capture never fires inside the ~2/sec captureVisibleTab quota window.
+  assert.ok(sleeps[0] >= 600, `retry gap ${sleeps[0]}ms must be ≥600ms (quota window)`);
+});
+
+test("captureWithRetry: every retry gap is ≥ the quota window (core spacing regression)", async () => {
+  // Persistent readback race → drains the whole attempt budget. Assert EACH gap
+  // between capture attempts is ≥~600ms — proving no two captures can land in
+  // one ~2/sec quota window (the PR #181 bug fired a 2nd capture 150ms later).
+  const sleeps = [];
+  const capture = async () => { throw new Error("image readback failed"); };
+  await assert.rejects(
+    () => captureWithRetry(capture, { sleep: (ms) => { sleeps.push(ms); } }),
+    /image readback failed/);
+  // maxAttempts=3 → two inter-attempt gaps.
+  assert.equal(sleeps.length, CAPTURE_MAX_ATTEMPTS - 1);
+  for (const gap of sleeps) {
+    assert.ok(gap >= 600, `every capture-attempt gap (${gap}ms) must be ≥600ms`);
+  }
+  // Linear spacing: base·1 then base·2.
+  assert.deepEqual(sleeps, [CAPTURE_RETRY_BASE_MS, CAPTURE_RETRY_BASE_MS * 2]);
+});
+
+test("captureWithRetry: a quota error waits a FULL quota window, then the retry succeeds", async () => {
+  // The exact live failure: attempt 1 trips the ~2/sec quota; the retry must
+  // wait out the window (≥~1s) so it doesn't immediately re-trip it, then win.
+  let calls = 0;
+  const sleeps = [];
+  const capture = async () => {
+    calls++;
+    if (calls < 2) throw new Error(
+      "This request exceeds the MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND quota.");
+    return "data:png;ok";
+  };
+  const out = await captureWithRetry(capture, { sleep: (ms) => { sleeps.push(ms); } });
+  assert.equal(out, "data:png;ok");
+  assert.equal(calls, 2, "one retry after the quota error");
+  assert.deepEqual(sleeps, [CAPTURE_QUOTA_WAIT_MS], "waited a full quota window before retrying");
+  assert.ok(sleeps[0] >= 1000, `quota wait ${sleeps[0]}ms must be ≥~1s window`);
 });
 
 test("captureWithRetry: a persistent transient error fails after exactly N attempts", async () => {
@@ -343,6 +420,17 @@ test("waitForCaptureReady polls until 'complete', then applies the paint settle"
   // Two poll waits (while loading) + one final settle wait.
   assert.deepEqual(sleeps, [100, 100, 150]);
   assert.equal(i, 3, "stopped polling as soon as it read 'complete'");
+});
+
+test("waitForCaptureReady applies a real paint settle by DEFAULT (first-capture success → no retry)", async () => {
+  // The paint settle exists so the FIRST capture usually succeeds — dodging a
+  // retry (hence any quota risk). Lock the default settle at a meaningful ≥250ms
+  // (Chrome fires 'complete' before first paint) and prove it is actually waited.
+  assert.ok(CAPTURE_SETTLE_MS >= 250, `default paint settle ${CAPTURE_SETTLE_MS}ms must be ≥250ms`);
+  const sleeps = [];
+  await waitForCaptureReady(async () => "complete",
+    { sleep: (ms) => { sleeps.push(ms); }, now: () => 0 });
+  assert.deepEqual(sleeps, [CAPTURE_SETTLE_MS], "already-complete tab still waits the default settle");
 });
 
 test("waitForCaptureReady stops at the timeout even if never 'complete' (no hang)", async () => {


### PR DESCRIPTION
## The bug (reproduced LIVE against real Brave)

PR #181 added settle+retry for screenshotting a background owned tab, with a **150/300ms linear backoff**. Live result: a SINGLE `browser screenshot` of a background owned tab failed with:

```
This request exceeds the MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND quota.
```

**Root cause:** Chrome throttles `chrome.tabs.captureVisibleTab` to **~2 calls/sec** (~500ms spacing). When the first capture of a freshly-activated background tab returns `image readback failed`, the retry fired ~150ms later — a SECOND `captureVisibleTab` **inside the same 1s quota window** → trips a NEW quota error. The retry meant to recover the readback race instead created a quota failure, so even a single lone invocation failed.

## Fix (all in the pure, unit-tested `protocol.js` decision logic)

1. **Spacing ≥ the quota window.** `CAPTURE_RETRY_BASE_MS` 150 → **700** (linear `base·attempt` ⇒ 700ms, 1400ms), so no two capture attempts land inside one ~500ms window. Still 3 bounded attempts; worst-case retry budget 2100ms + settle, well under the 20s server `cmd_timeout`.
2. **Classify the quota error as transient.** `MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND` (matched case-insensitively) is now retry-worthy, and a quota hit waits a **full ~1s window** (`CAPTURE_QUOTA_WAIT_MS`, via new `isCaptureQuotaError`) before the next attempt so it can't re-trip. `image readback failed` stays transient too.
3. **Reduce the need to retry.** Paint settle after `status:"complete"` 150 → **350ms** (Chrome fires `complete` before first paint), so the FIRST capture usually succeeds and no retry — hence no quota risk — is needed in the common case.
4. **Invariants preserved (#175/#178/#173/#180 untouched):** activate→capture→restore restores the previously-active tab on success AND failure; an already-visible tab short-circuits to a single capture with no activate.

## Tests

+6 node tests: `isTransientCaptureError`/`isCaptureQuotaError` classify the quota error (and existing readback / permanent errors); **every retry gap ≥600ms** (the core spacing regression); a quota error waits the full window then attempt 2 succeeds; default paint settle ≥250ms is applied.

```
74 node tests pass (was 68)
138 python tests pass
node --check protocol.js && node --check service_worker.js  → OK
bash -n scripts/browser-bridge/browser  → OK
```

## Docs

`README.md` / `SKILL.md` / `extension/README.md` now note background-tab screenshot retries respect Chrome's ~2/sec `captureVisibleTab` quota (≥~600ms spacing, ~1s on a quota hit) and that it **needs an extension reload** to take effect.

## Honest verification

The capture behavior needs real Brave — the classification + spacing decision is unit-tested deterministically. This fix is **VERIFIED against the reproduced live failure only after the operator** reloads the extension and runs:

```
browser --instance work open <url>
browser --instance work --tab <id> screenshot /tmp/x.png
```

on a background owned tab and confirms it writes a PNG with **no quota error**. Until that manual reload+check: deployed logic, not yet live-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)