### PR TITLE
fix(browser-bridge): clear "tab not visible on-screen" error for occluded-tab screenshots

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -127,7 +127,7 @@ must run in whatever tab is active). This can be scoped down later; noted in
 | `eval`       | `chrome.scripting.executeScript` (MAIN world) of `js`     | `{url,value}` |
 | `tabs`       | `chrome.tabs.query({})`                                   | `{tabs:[...],ownedTabId}` |
 | `nav`        | `chrome.tabs.update(tab,{url})`                           | `{tabId,url}` |
-| `screenshot` | `chrome.tabs.captureVisibleTab` (png)                     | `{url,dataUrl}` |
+| `screenshot` | `chrome.tabs.captureVisibleTab` (png) — **visible/foreground tab only** (a background/occluded tab fails with a clear "not visible on-screen" error; see the screenshot caveat) | `{url,dataUrl}` |
 | `open`       | `chrome.tabs.create({url,active:false})`                 | `{tabId,url}` |
 | `close`      | `chrome.tabs.remove(tabId)`                               | `{closed:tabId}` |
 
@@ -253,25 +253,50 @@ per-session (multi-step **workflow**) isolation did not.
   **released** so a dead session doesn't leak ownership, but the real Brave tab
   is deliberately **NOT closed** (never yank a visible tab out from under the
   user) — only an explicit `browser close` closes it.
-- **Screenshot caveat (honest).** `captureVisibleTab` only ever captures the
-  **visible** tab of a window. Screenshotting a session's **background** owned
-  tab therefore briefly activates it → **settles until painted** → captures (with
-  retry) → restores the previously-active tab (a short visible flicker in that
-  window), so we never silently capture the wrong tab. A screenshot of an owned
-  tab that is already visible is unaffected. **Background-tab settle + retry:** a
-  just-activated background tab hasn't painted its first frame, so a bare capture
-  returns `"image readback failed"`; the SW waits for `status:"complete"` + a
-  paint settle (~350ms) so the FIRST capture usually wins, then **retries** on a
-  transient error. Retries **respect Chrome's ~2/sec `captureVisibleTab` quota**
-  (spaced ≥~600ms; a `MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND` hit waits a ~1s
-  window) — a faster retry would re-trip the quota instead of recovering (needs
-  an extension **reload** to take effect). This hardens the
-  `browser agent` path, which screenshots in its OWN background tab. The classify
-  + retry + settle + activate→capture→restore logic is pure and unit-tested in
-  `extension/protocol.js` (`isTransientCaptureError` / `captureWithRetry` /
-  `waitForCaptureReady` / `screenshotWithRestore`); the capture itself needs real
-  Brave, so it stays on the manual checklist. Like any `extension/` change, it
-  only takes effect after a manual extension **reload** in `brave://extensions`.
+- **Screenshot is a VISIBLE-tab op (fundamental limitation, honest).**
+  `captureVisibleTab` captures the **on-screen composited pixels of a window's
+  foreground tab** — it fundamentally **cannot** capture a tab that isn't visible
+  on-screen. Screenshotting the **actual foreground tab** works fine. For a
+  session's **background/owned** tab the bridge makes a **best-effort** attempt —
+  briefly activate → **settle until painted** → capture (with retry) → restore the
+  previously-active tab (a short flicker) — so it never silently captures the wrong
+  tab. **But on the user's i3 tiling WM this commonly fails:** activating a tab does
+  NOT guarantee its Brave *window* is raised/composited (Chrome can't force i3 to
+  raise a window), so an owned/agent tab's window is often off-screen, the tab never
+  composites, and the capture keeps returning `"image readback failed"` no matter
+  how many times we retry. This is a **permanent condition for that tab, not the
+  transient paint race** the retry recovers.
+  - **Settle + retry (transient recovery):** a just-activated tab that IS visible
+    but momentarily unpainted returns `"image readback failed"` on the first try;
+    the SW waits for `status:"complete"` + a paint settle (~350ms) so the FIRST
+    capture usually wins, then **retries** on a transient error. Retries **respect
+    Chrome's ~2/sec `captureVisibleTab` quota** (spaced ≥~600ms; a
+    `MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND` hit waits a ~1s window) — a faster
+    retry would re-trip the quota instead of recovering.
+  - **Exhausted-retry → clear, actionable error (not the opaque chrome string).**
+    When the quota-spaced retries are **exhausted** on a persistent readback error
+    (the occluded-window case above), the op maps it to a caller-actionable message
+    — `screenshot unavailable: the target tab is not visible on-screen (background
+    or occluded window). captureVisibleTab can only capture the foreground tab;
+    bring the tab to the foreground, or use 'text'/'html'/'eval' which work on
+    background tabs.` — instead of `image readback failed`. It is returned as the op
+    error (non-zero exit via the normal envelope). This is distinct from the
+    transient case: a readback a retry could still recover is NOT reported as
+    "unavailable" (the mapping runs only post-exhaustion), and the **quota error
+    keeps its own message** (it is a throttle, not an occlusion).
+  - **Use `text` / `html` / `eval` for a background tab** — they read the tab
+    directly regardless of whether it is on-screen, so an agent/owned tab (e.g. the
+    `browser agent`'s OWN background tab) should read, not screenshot.
+  - *Future opt-in (NOT implemented):* a `chrome.debugger` + CDP
+    `Page.captureScreenshot` path COULD capture an off-screen tab, but it needs the
+    `debugger` permission and shows a debug banner — deliberately out of scope.
+  - The classify + retry + settle + activate→capture→restore logic **and the
+    exhausted-retry error mapping** are pure and unit-tested in
+    `extension/protocol.js` (`isTransientCaptureError` / `captureWithRetry` /
+    `waitForCaptureReady` / `screenshotWithRestore` / `isOcclusionCaptureError` /
+    `mapCaptureFailure`); the capture itself needs real Brave, so it stays on the
+    manual checklist. Like any `extension/` change, it only takes effect after a
+    manual extension **reload** in `brave://extensions`.
 - **Backward-compat.** A single session with no `open` (and even no
   `X-Session-Id`) behaves exactly as before: active-tab ops, no `tabId` injected.
   The multi-instance `--instance` targeting, ambiguity/supersede semantics, and
@@ -589,10 +614,14 @@ The **`browser agent`** slice, all headless (NO live model, NO Brave, NO bridge)
   ONE `--continue` retry then `blocked`, no-retry on a hard error.
 
 Current totals: **138 Python** (`test_server.py` 100 + `test_browser_agent_parse.py`
-14 + `test_browser_agent.py` 24) + **68 node** (`protocol.test.mjs` 47 +
-`browser_tool.test.mjs` 21) — the 18 added `protocol.test.mjs` cases cover the
-screenshot settle+retry decision logic (`isTransientCaptureError` /
-`captureWithRetry` / `waitForCaptureReady` / `screenshotWithRestore`). The live browser-driving loop (real DeepSeek + real
+14 + `test_browser_agent.py` 24) + **82 node** (`protocol.test.mjs` 58 +
+`browser_tool.test.mjs` 24) — the `protocol.test.mjs` cases cover the screenshot
+settle+retry decision logic (`isTransientCaptureError` / `captureWithRetry` /
+`waitForCaptureReady` / `screenshotWithRestore`) **and the exhausted-retry error
+mapping** (`isOcclusionCaptureError` / `mapCaptureFailure`): a persistent readback
+(retries exhausted) → the actionable "not visible on-screen" message, a transient
+readback that a spaced retry recovers still succeeds (no premature "unavailable"),
+and the #182 quota error keeps its own message. The live browser-driving loop (real DeepSeek + real
 Brave) canNOT run in CI; the chrome.* glue in `service_worker.js` and the
 end-to-end agent run are covered by the manual checklists (`extension/README.md` +
 "opencode browser-agent" above). The two `opencode debug agent` checks under

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -65,12 +65,38 @@ Prefix any op with `--instance <key>` to target a specific connected profile
 | `browser [--instance K] [--tab T] eval '<js>'`       | run JS in the owned/active tab, return its value |
 | `browser [--instance K] tabs`              | list open tabs (`.data.ownedTabId` flags this session's owned tab) |
 | `browser [--instance K] [--tab T] nav <url>`         | navigate the owned/active tab to `<url>` |
-| `browser [--instance K] [--tab T] screenshot [path]` | captureVisibleTab; prints the data URL, or writes a `.png` to `path`. A BACKGROUND owned tab is briefly activated, **settled until painted (~350ms), then captured with a bounded retry** on a transient `image readback failed` — retries are **spaced ≥~600ms to respect Chrome's ~2/sec `captureVisibleTab` quota** (`MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND`; a faster retry re-trips it) (needs an extension **reload** to take effect) |
+| `browser [--instance K] [--tab T] screenshot [path]` | **VISIBLE-tab op only** — captureVisibleTab; prints the data URL, or writes a `.png` to `path`. A background/owned tab is briefly activated + settled + captured with a bounded quota-spaced retry (best-effort), but **on i3 it commonly fails** — see the note below. Use `text`/`html`/`eval` for a background tab |
 | `browser [--instance K] agent "<goal>" [flags]` | run the **autonomous opencode browser-agent** in its OWN isolated tab against `<goal>`; returns a compact `{answer,evidence,steps_used,status}` (see below) |
 | `browser --print-session-id`               | print the derived per-session id (debug) and exit |
 
 Result payloads land under `.result.data` in the JSON (the envelope is
 `{"ok":true,"result":{"id","ok","data":{...}}}`).
+
+### ⚠ `screenshot` is a VISIBLE-tab op (background tabs are NOT supported on i3)
+
+`chrome.captureVisibleTab` captures the **on-screen composited pixels of the
+window's foreground tab** — it fundamentally cannot capture a tab that isn't
+visible on-screen. The bridge makes a best-effort attempt to foreground a
+background/owned tab before capturing, but on the user's **i3 tiling WM** an
+owned/agent tab's Brave window is often not raised (Chrome can't force i3 to raise
+it), so the tab never composites and the capture fails. After the quota-spaced
+retries are exhausted you get a **clear, actionable error** (non-zero exit), not
+the opaque `image readback failed`:
+
+```
+op 'screenshot' failed in the browser: screenshot unavailable: the target tab is
+not visible on-screen (background or occluded window). captureVisibleTab can only
+capture the foreground tab; bring the tab to the foreground, or use
+'text'/'html'/'eval' which work on background tabs.
+```
+
+- **Screenshots of the ACTUAL foreground tab work fine** (the tab the user is
+  looking at). Occluded/background tabs cannot be captured this way.
+- **For a background/owned tab, use `text` / `html` / `eval`** — they read the tab
+  directly regardless of whether it is on-screen. Don't loop retrying screenshots.
+- *(Future option, NOT implemented: a `chrome.debugger` + CDP
+  `Page.captureScreenshot` path could capture an off-screen tab, but it needs the
+  `debugger` permission and shows a debug banner — deliberately out of scope.)*
 
 ## `browser agent "<goal>"` — autonomous read/navigate in an isolated tab
 
@@ -252,6 +278,10 @@ know browser usage is being counted. Details: `README.md` → Telemetry.
   already validates `--tab`).
 - `owned_tab_gone` (op-level, in `.result`) → your owned tab was closed; ownership
   is auto-dropped, so just re-issue (it falls back to the active tab / re-`open`).
+- `screenshot unavailable: … not visible on-screen …` (op-level, in `.result`,
+  after the retries are exhausted) → the target tab is background/occluded and
+  `captureVisibleTab` cannot capture it (see the screenshot note above). Do NOT
+  retry the screenshot — use `text`/`html`/`eval`, or foreground the tab.
 - `401 unauthorized` → token mismatch (re-paste in the extension options).
 
 ## Gotcha: reload the unpacked extension after any change

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -41,9 +41,12 @@
 #   browser eval '<js>'       — run JS in the owned/active tab, return its value
 #   browser tabs              — list open tabs (flags this session's owned tab)
 #   browser nav <url>         — navigate the owned/active tab to <url>
-#   browser screenshot [path] — captureVisibleTab; prints data URL, or writes a
-#                               .png to <path> if given (a background owned tab is
-#                               briefly foregrounded to capture, then restored)
+#   browser screenshot [path] — captureVisibleTab (VISIBLE/foreground tab only);
+#                               prints data URL, or writes a .png to <path>. A
+#                               background/owned tab is foregrounded best-effort;
+#                               on an occluded/non-foreground window it fails with
+#                               a clear "not visible on-screen" error — use
+#                               text/html/eval for a background tab
 #   browser agent "<goal>"    — run the autonomous opencode browser-agent in its
 #                               OWN isolated tab against <goal> (see browser-agent)
 #   browser --print-session-id — print the derived per-session id and exit

--- a/scripts/browser-bridge/extension/README.md
+++ b/scripts/browser-bridge/extension/README.md
@@ -42,26 +42,45 @@ back this:
   `{closed:tabId, alreadyGone:true}` (a success) so the server cleanly drops the
   stale ownership rather than surfacing a spurious error.
 
-**Screenshot of a background owned tab:** `chrome.tabs.captureVisibleTab` only
-captures the **visible** tab of a window. If the target tab isn't active the SW
-briefly activates it, **settles** until it has painted, captures, then
-**restores** the previously-active tab — a short visible flicker, but it never
-silently screenshots the wrong tab. A target tab that is already visible is
-captured directly with no flicker.
+**Screenshot is a VISIBLE-tab op (fundamental limitation):**
+`chrome.tabs.captureVisibleTab` captures the **on-screen composited pixels of the
+window's foreground tab** — it fundamentally **cannot** capture a tab that isn't
+visible on-screen. The **actual foreground tab** captures fine. For a target tab
+that isn't active the SW makes a **best-effort** attempt — briefly activate,
+**settle** until painted, capture, then **restore** the previously-active tab (a
+short flicker, never silently the wrong tab). **On i3 this commonly fails,**
+though: activating a tab does NOT guarantee its Brave *window* is raised (Chrome
+can't force i3 to raise a window), so an owned/background tab's window is often
+off-screen, the tab never composites, and the capture keeps returning
+`"image readback failed"` no matter how many times we retry — a **permanent**
+condition for that tab, not the transient paint race the retry recovers.
+**Use `text`/`html`/`eval` for a background tab** (incl. the `browser agent`'s OWN
+background tab); those read the tab regardless of visibility.
 
-*Background-tab settle + retry (robustness):* a JUST-activated background tab
-hasn't painted its first frame yet, so a bare `captureVisibleTab` returns
-`"image readback failed"`. The SW therefore (1) waits for the tab to reach
-`status:"complete"` **plus a paint settle (~350ms)** so the FIRST capture
-usually succeeds, and (2) **retries** the capture on a transient error (bounded —
-a few tries). **Retries respect Chrome's ~2/sec `captureVisibleTab` quota:** the
-API is throttled to ~2 calls/sec (~500ms), so retries are **spaced ≥~600ms**
-apart (a quota hit — `MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND` — waits a full
-~1s window) — a faster retry would just re-trip the quota instead of recovering.
-This matters because `browser agent` screenshots run in the agent's OWN
-background tab. **Reload the extension** after changing this to take effect. The
-classifier
-(`isTransientCaptureError`), the retry (`captureWithRetry`), the settle
+*Background-tab settle + retry (transient recovery):* a JUST-activated tab that IS
+visible but hasn't painted its first frame returns `"image readback failed"`. The
+SW (1) waits for the tab to reach `status:"complete"` **plus a paint settle
+(~350ms)** so the FIRST capture usually succeeds, and (2) **retries** on a
+transient error (bounded — a few tries). **Retries respect Chrome's ~2/sec
+`captureVisibleTab` quota:** the API is throttled to ~2 calls/sec (~500ms), so
+retries are **spaced ≥~600ms** apart (a quota hit —
+`MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND` — waits a full ~1s window) — a faster
+retry would just re-trip the quota instead of recovering.
+
+*Exhausted-retry → clear, actionable error:* when the quota-spaced retries are
+**exhausted** on a persistent readback error (the occluded-window case above), the
+op maps it via `mapCaptureFailure` to a caller-actionable message
+(`screenshot unavailable: the target tab is not visible on-screen … use
+'text'/'html'/'eval' which work on background tabs`) instead of the opaque
+`image readback failed`. The mapping runs **only post-exhaustion** (a readback a
+retry could still recover is never wrongly reported "unavailable"), and the quota
+error keeps its own message. *(Future opt-in, NOT implemented: a `chrome.debugger`
++ CDP `Page.captureScreenshot` path could capture an off-screen tab, but it needs
+the `debugger` permission and shows a debug banner.)*
+
+**Reload the extension** after changing this to take effect. The classifier
+(`isTransientCaptureError` / `isOcclusionCaptureError`), the retry
+(`captureWithRetry`), the error mapping (`mapCaptureFailure`), the settle
 (`waitForCaptureReady`) and the activate→capture→restore orchestration
 (`screenshotWithRestore`, restore on success AND failure) are pure + unit-tested
 in `protocol.js`; `service_worker.js` supplies the chrome.* side effects.
@@ -166,14 +185,19 @@ The chrome.* glue needs a real browser — verify by hand after loading:
       (e.g. sibling subagents) each `browser open`, capture the `tabId`, and run
       every op with `browser --tab <id> …`. Confirm each reads/navigates only its
       OWN tab — the explicit `--tab` overrides the shared owned-tab routing.
-- [ ] `browser screenshot` of a background owned tab briefly flickers it to the
-      foreground, captures it, and restores the tab that was active before. It
-      **succeeds even on the first shot of a fresh background tab** with **NO
-      `MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND` quota error** (the paint settle +
-      the ≥~600ms-spaced retry defeat both the old `image readback failed` and the
-      quota trip): `browser --instance <key> open <url>` → `browser --instance
-      <key> --tab <id> screenshot /tmp/x.png` writes a real PNG (was flaky before
-      this fix — reload the extension first so the new spacing is live).
+- [ ] **Visible-tab screenshot works:** focus a normal tab, `browser screenshot
+      /tmp/vis.png` writes a real PNG of that foreground tab.
+- [ ] **Background/occluded-tab screenshot returns the CLEAR error (i3):**
+      `browser --instance <key> open <url>` → `browser --instance <key> --tab <id>
+      screenshot /tmp/x.png`. On i3 (the owned tab's window isn't raised) this
+      should fail — after the quota-spaced retries — with the **actionable**
+      `screenshot unavailable: … not visible on-screen … use 'text'/'html'/'eval'`
+      message and a **non-zero exit**, NOT the opaque `image readback failed` (and
+      NOT a `MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND` quota dump). Reload the
+      extension first so the new mapping is live. (If the owned tab's window HAPPENS
+      to be composited/visible, it may instead write a PNG — that path still works;
+      the point is the failure is now a clear, actionable message.) Read that tab
+      with `browser --tab <id> text` instead — it works regardless of visibility.
 - [ ] **Two-session isolation (the fix):** open two Claude sessions (each in its
       own tmux pane). In each, `browser open` a DIFFERENT url, then interleave
       `browser nav …` / `browser html` between the sessions. Confirm neither

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -186,6 +186,55 @@ export function isCaptureQuotaError(err) {
   return !!s && s.includes(CAPTURE_QUOTA_PATTERN);
 }
 
+// --- fundamental limitation: captureVisibleTab needs an ON-SCREEN tab -------- //
+// captureVisibleTab captures the on-screen COMPOSITED pixels of a window's
+// visible tab. On the user's i3 tiling WM an owned/agent tab is intentionally
+// NOT foregrounded, and activating it does NOT guarantee its Brave WINDOW is
+// raised/composited (Chrome can't force i3 to raise a window). So the tab may
+// never composite and the GPU read-back keeps returning "image readback failed"
+// no matter how many times we retry — this is a PERMANENT condition for that tab,
+// NOT the paint race the settle+retry recovers. Once the spaced retries are spent
+// (a genuinely transient readback would already have succeeded on a retry), a
+// readback error means the tab is simply not visible on-screen.
+const OCCLUSION_CAPTURE_PATTERNS = ["image readback failed", "readback"];
+
+// The actionable error surfaced to the caller when a screenshot cannot be
+// captured because the target tab is not visible on-screen (background / occluded
+// window). Names the alternative ops that DO work on a background tab so the
+// caller/agent acts instead of blindly retrying a capture that cannot succeed.
+export const SCREENSHOT_NOT_VISIBLE_MESSAGE =
+  "screenshot unavailable: the target tab is not visible on-screen (background " +
+  "or occluded window). captureVisibleTab can only capture the foreground tab; " +
+  "bring the tab to the foreground, or use 'text'/'html'/'eval' which work on " +
+  "background tabs.";
+
+// True when `err` looks like the readback/occlusion failure (a GPU read-back with
+// no pixels) — but NOT the per-second quota error, which is a distinct, genuinely
+// transient throttle that keeps its own message (#182). Matched case-insensitively.
+// Intended to be checked only AFTER the retry budget is exhausted: a transient
+// readback that a spaced retry could recover has already succeeded by then, so a
+// match here means the tab is persistently not compositing → the limitation above.
+export function isOcclusionCaptureError(err) {
+  const s = errText(err);
+  if (!s) return false;
+  if (isCaptureQuotaError(err)) return false; // a quota hit is not an occlusion
+  return OCCLUSION_CAPTURE_PATTERNS.some((p) => s.includes(p));
+}
+
+// Map a POST-RETRY (exhausted-budget) capture failure to the error string the
+// caller sees. A readback/occlusion failure that survived every spaced retry is
+// the fundamental "tab not visible on-screen" limitation → the actionable
+// SCREENSHOT_NOT_VISIBLE_MESSAGE. Everything else (the quota error, a
+// permission/URL error, owned_tab_gone, …) passes through UNCHANGED so its own
+// specific cause is preserved. MUST be applied ONLY after the retries are
+// exhausted — never on an error a retry could still recover (that would wrongly
+// claim "unavailable"). Pure + unit-tested; service_worker.js applies it in the
+// screenshot op's catch, which by construction runs only post-retry.
+export function mapCaptureFailure(err) {
+  if (isOcclusionCaptureError(err)) return SCREENSHOT_NOT_VISIBLE_MESSAGE;
+  return String((err && err.message != null) ? err.message : err);
+}
+
 const defaultSleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // Call `capture()` (→ Promise<dataUrl>) with a bounded retry on a TRANSIENT

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -23,6 +23,7 @@ import {
   classifyPollStatus, POLL_COMMAND, POLL_IDLE, POLL_SUPERSEDED,
   POLL_UNAUTHORIZED, SUPERSEDE_BACKOFF_MS,
   captureWithRetry, waitForCaptureReady, screenshotWithRestore,
+  mapCaptureFailure,
 } from "./protocol.js";
 
 const DEFAULT_PORT = 8788;
@@ -167,42 +168,62 @@ const OPS = {
 
   async screenshot(cmd) {
     const tab = await targetTab(cmd);
-    // captureVisibleTab only ever captures the VISIBLE tab of its window. If the
-    // caller's owned tab is in the background, capturing it requires briefly
-    // bringing it to the foreground. We do exactly that — activate → SETTLE →
-    // capture (with retry) → restore the previously-active tab — so we never
-    // SILENTLY screenshot the wrong tab. This causes a brief visible flicker in
-    // that window (documented).
+    // captureVisibleTab only ever captures the VISIBLE (composited, on-screen) tab
+    // of its window. If the caller's owned tab is in the background we make a
+    // BEST-EFFORT attempt to bring it forward — activate → SETTLE → capture (with
+    // retry) → restore the previously-active tab — so we never SILENTLY screenshot
+    // the wrong tab. This causes a brief visible flicker in that window (documented).
     //
-    // A JUST-activated background tab hasn't painted its first frame yet, so a
-    // bare captureVisibleTab returns "image readback failed". So for the
-    // background path we (1) wait for the tab to reach `status:"complete"` + a
-    // paint settle (so the FIRST capture usually succeeds — no retry needed), and
-    // (2) retry the capture on a transient error. CRITICAL: Chrome throttles
-    // captureVisibleTab to ~2/sec (MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND), so
-    // the retry backoff spaces attempts ≥~600ms (a quota hit waits a full ~1s
-    // window) — a faster retry would re-trip the quota. Both the settle and the
-    // spaced retry, plus the activate→capture→restore orchestration (restore on
-    // success AND failure), are pure + unit-tested in protocol.js — keep this in
-    // sync with them.
+    // FUNDAMENTAL LIMITATION (i3): activating a tab does NOT guarantee its Brave
+    // WINDOW is raised/composited — on the user's i3 tiling WM an owned/agent tab's
+    // window is often not on-screen, and Chrome can't force i3 to raise it. Then the
+    // tab never composites and captureVisibleTab keeps returning "image readback
+    // failed" no matter how we retry. So the settle + spaced retry below recover a
+    // genuinely TRANSIENT paint race (a tab that IS visible but momentarily
+    // unpainted), and when they're EXHAUSTED on a persistent readback error we map
+    // it to a CLEAR "tab not visible on-screen" message (mapCaptureFailure) instead
+    // of the opaque "image readback failed" — the caller should use text/html/eval,
+    // which work on a background tab. (A future opt-in chrome.debugger + CDP
+    // Page.captureScreenshot path COULD capture an off-screen tab, but it needs the
+    // debugger permission + shows a debug banner — deliberately out of scope here.)
+    //
+    // A JUST-activated background tab hasn't painted its first frame yet, so a bare
+    // captureVisibleTab returns "image readback failed". So for the background path
+    // we (1) wait for the tab to reach `status:"complete"` + a paint settle (so the
+    // FIRST capture usually succeeds — no retry needed), and (2) retry the capture on
+    // a transient error. CRITICAL: Chrome throttles captureVisibleTab to ~2/sec
+    // (MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND), so the retry backoff spaces attempts
+    // ≥~600ms (a quota hit waits a full ~1s window) — a faster retry would re-trip the
+    // quota. The settle, the spaced retry, the activate→capture→restore orchestration
+    // (restore on success AND failure), and the exhausted-retry error mapping are all
+    // pure + unit-tested in protocol.js — keep this in sync with them.
     const capture = () =>
       chrome.tabs.captureVisibleTab(tab.windowId, { format: "png" });
-    const dataUrl = await screenshotWithRestore({
-      isActive: !!tab.active,
-      targetId: tab.id,
-      // The visible-tab path is a hot GPU capture too — retry it as well (cheap,
-      // and it hardens against a rare transient readback even when already active).
-      capture: () => captureWithRetry(capture),
-      getPrevActiveId: async () => {
-        const [prev] = await chrome.tabs.query({ active: true, windowId: tab.windowId });
-        return prev ? prev.id : null;
-      },
-      activate: (id) => chrome.tabs.update(id, { active: true }),
-      waitReady: () => waitForCaptureReady(async () => {
-        try { return (await chrome.tabs.get(tab.id)).status; } catch (e) { return null; }
-      }),
-      restore: (id) => chrome.tabs.update(id, { active: true }),
-    });
+    let dataUrl;
+    try {
+      dataUrl = await screenshotWithRestore({
+        isActive: !!tab.active,
+        targetId: tab.id,
+        // The visible-tab path is a hot GPU capture too — retry it as well (cheap,
+        // and it hardens against a rare transient readback even when already active).
+        capture: () => captureWithRetry(capture),
+        getPrevActiveId: async () => {
+          const [prev] = await chrome.tabs.query({ active: true, windowId: tab.windowId });
+          return prev ? prev.id : null;
+        },
+        activate: (id) => chrome.tabs.update(id, { active: true }),
+        waitReady: () => waitForCaptureReady(async () => {
+          try { return (await chrome.tabs.get(tab.id)).status; } catch (e) { return null; }
+        }),
+        restore: (id) => chrome.tabs.update(id, { active: true }),
+      });
+    } catch (e) {
+      // Reached only AFTER captureWithRetry exhausted its spaced retries (a
+      // recoverable transient readback would have resolved above). A persistent
+      // readback/occlusion error → the actionable "not visible on-screen" message;
+      // every other error (quota, permission, owned_tab_gone) passes through.
+      throw new Error(mapCaptureFailure(e));
+    }
     return { url: tab.url, dataUrl };
   },
 

--- a/scripts/browser-bridge/opencode/browser-agent.md
+++ b/scripts/browser-bridge/opencode/browser-agent.md
@@ -23,12 +23,17 @@ fetch). Your tab is FIXED: you cannot choose or change which tab you act on.
 | `browser(op="html")`                   | read raw `outerHTML` — LAST RESORT (100s of KB; it will drown you) |
 | `browser(op="eval", js="…")`           | evaluate a small JS expression in the page and get its value |
 | `browser(op="nav", url="…")`           | navigate your tab to `<url>` |
-| `browser(op="screenshot")`             | capture the visible tab (you get only a note, not the image) |
+| `browser(op="screenshot")`             | capture the visible tab (you get only a note, not the image) — **often unavailable to you** (see below) |
 
 ## Rules
 - **Prefer `op="text"` over `op="html"`.** `text` returns clean innerText (~KB).
   `html` returns hundreds of KB and wastes your budget — only use it (or `eval`)
   if `text` is genuinely insufficient.
+- **Do NOT rely on `op="screenshot"`.** Your tab is a BACKGROUND tab, and
+  `captureVisibleTab` can only capture the on-screen foreground tab — so a
+  screenshot of your tab is usually `unavailable` ("not visible on-screen"). Read
+  the page with `text`/`html`/`eval` instead; don't waste steps retrying a
+  screenshot. (You never see the image anyway — only a note.)
 - **Stay on the allowed domains** given in the task. A `nav` to a denied domain
   is refused by the tool.
 - **Work in as few steps as possible.** You have a hard budget of **__STEPS__**

--- a/scripts/browser-bridge/tests/protocol.test.mjs
+++ b/scripts/browser-bridge/tests/protocol.test.mjs
@@ -19,6 +19,7 @@ import {
   isTransientCaptureError, isCaptureQuotaError, captureWithRetry,
   waitForCaptureReady, screenshotWithRestore, CAPTURE_MAX_ATTEMPTS,
   CAPTURE_RETRY_BASE_MS, CAPTURE_QUOTA_WAIT_MS, CAPTURE_SETTLE_MS,
+  isOcclusionCaptureError, mapCaptureFailure, SCREENSHOT_NOT_VISIBLE_MESSAGE,
 } from "../extension/protocol.js";
 
 test("op set mirrors the server contract", () => {
@@ -511,4 +512,111 @@ test("screenshotWithRestore swallows a restore failure but returns the capture r
   // A failing restore must NOT mask the successful capture.
   const out = await screenshotWithRestore(deps);
   assert.equal(out, "data:png");
+});
+
+// --- exhausted-retry error mapping: the fundamental captureVisibleTab/i3 limit -- //
+// captureVisibleTab needs an ON-SCREEN composited tab. On i3 an owned/background
+// tab's window may never be raised, so a readback error PERSISTS past every spaced
+// retry. Once exhausted, that must surface as a CLEAR, actionable message — not the
+// opaque "image readback failed" — while a genuinely transient readback (recovered
+// by a retry) and the #182 quota error keep their existing behaviour.
+
+test("isOcclusionCaptureError matches a persistent readback failure but NOT the quota error", () => {
+  assert.equal(isOcclusionCaptureError(new Error("Failed to capture tab: image readback failed")), true);
+  assert.equal(isOcclusionCaptureError("image readback failed"), true);
+  assert.equal(isOcclusionCaptureError("GPU readback error"), true);
+  assert.equal(isOcclusionCaptureError("IMAGE READBACK FAILED"), true); // case-insensitive
+  // The per-second quota error is its OWN thing (#182) — never re-mapped to occlusion,
+  // even when a message happens to mention both (quota wins).
+  assert.equal(isOcclusionCaptureError(new Error(
+    "This request exceeds the MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND quota.")), false);
+  assert.equal(isOcclusionCaptureError(
+    "IMAGE readback FAILED as MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND"), false);
+  // Permanent/unknown/empty errors are not occlusion errors either.
+  assert.equal(isOcclusionCaptureError("Cannot access contents of the page"), false);
+  assert.equal(isOcclusionCaptureError("owned_tab_gone"), false);
+  assert.equal(isOcclusionCaptureError(""), false);
+  assert.equal(isOcclusionCaptureError(null), false);
+  assert.equal(isOcclusionCaptureError(undefined), false);
+});
+
+test("SCREENSHOT_NOT_VISIBLE_MESSAGE is actionable and points at the working ops", () => {
+  // The message must be human/agent-actionable: name the cause AND the alternative.
+  assert.match(SCREENSHOT_NOT_VISIBLE_MESSAGE, /not visible on-screen/);
+  assert.match(SCREENSHOT_NOT_VISIBLE_MESSAGE, /background or occluded/);
+  assert.match(SCREENSHOT_NOT_VISIBLE_MESSAGE, /captureVisibleTab can only capture the foreground tab/);
+  assert.match(SCREENSHOT_NOT_VISIBLE_MESSAGE, /'text'\/'html'\/'eval'/);
+  // It is NOT the raw chrome error.
+  assert.doesNotMatch(SCREENSHOT_NOT_VISIBLE_MESSAGE, /image readback failed/i);
+});
+
+test("mapCaptureFailure: a persistent readback → the actionable not-visible message", () => {
+  assert.equal(mapCaptureFailure(new Error("Failed to capture tab: image readback failed")),
+    SCREENSHOT_NOT_VISIBLE_MESSAGE);
+  assert.equal(mapCaptureFailure("image readback failed"), SCREENSHOT_NOT_VISIBLE_MESSAGE);
+});
+
+test("mapCaptureFailure: the quota error passes through UNCHANGED (#182 stays)", () => {
+  const quota = "This request exceeds the MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND quota.";
+  assert.equal(mapCaptureFailure(new Error(quota)), quota);
+  assert.equal(mapCaptureFailure(quota), quota);
+});
+
+test("mapCaptureFailure: permission / owned_tab_gone errors pass through UNCHANGED", () => {
+  assert.equal(mapCaptureFailure(new Error("Cannot access contents of the page")),
+    "Cannot access contents of the page");
+  assert.equal(mapCaptureFailure("owned_tab_gone"), "owned_tab_gone");
+});
+
+// Mirror the SW screenshot op: capture wrapped in captureWithRetry inside
+// screenshotWithRestore, and the exhausted error mapped in the op's catch. This
+// proves the DECISION path end-to-end (no chrome.* needed) — the piece that turns
+// a real occluded-tab capture into the clear message.
+async function screenshotOp(deps, retryOpts = {}) {
+  try {
+    return await screenshotWithRestore({
+      ...deps,
+      capture: () => captureWithRetry(deps.capture, { sleep: noSleep, ...retryOpts }),
+    });
+  } catch (e) {
+    throw new Error(mapCaptureFailure(e));
+  }
+}
+
+test("screenshot op: persistent readback (retries exhausted) → the actionable not-visible error", async () => {
+  let calls = 0;
+  const { deps } = spyDeps({
+    capture: async () => { calls++; throw new Error("Failed to capture tab: image readback failed"); },
+  });
+  await assert.rejects(() => screenshotOp(deps), (e) => {
+    assert.equal(e.message, SCREENSHOT_NOT_VISIBLE_MESSAGE, "maps to the actionable message");
+    assert.doesNotMatch(e.message, /image readback failed/, "not the raw chrome error");
+    return true;
+  });
+  // It only claims "unavailable" AFTER the full retry budget is spent.
+  assert.equal(calls, CAPTURE_MAX_ATTEMPTS, "exhausted every retry before giving up");
+});
+
+test("screenshot op: a transient readback that a retry recovers still SUCCEEDS (no premature 'unavailable')", async () => {
+  let calls = 0;
+  const { deps } = spyDeps({
+    capture: async () => {
+      calls++;
+      if (calls < 2) throw new Error("image readback failed"); // one transient miss
+      return "data:png;ok";
+    },
+  });
+  const out = await screenshotOp(deps);
+  assert.equal(out, "data:png;ok", "the spaced retry wins → real screenshot, not the error");
+  assert.equal(calls, 2, "recovered on the retry");
+});
+
+test("screenshot op: a persistent quota error surfaces the QUOTA message, not the not-visible one", async () => {
+  const quota = "This request exceeds the MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND quota.";
+  const { deps } = spyDeps({ capture: async () => { throw new Error(quota); } });
+  await assert.rejects(() => screenshotOp(deps), (e) => {
+    assert.equal(e.message, quota, "quota error is preserved (#182)");
+    assert.notEqual(e.message, SCREENSHOT_NOT_VISIBLE_MESSAGE);
+    return true;
+  });
 });


### PR DESCRIPTION
## Problem

`browser screenshot` of a **background/owned** tab fails with the opaque
`Failed to capture tab: image readback failed`, even after PR #181/#182 added
settle + retry + quota-spacing. Those PRs fixed the *transient* paint race, but
the real failure for an owned/agent tab is **fundamental, not timing**.

`chrome.tabs.captureVisibleTab` captures the **on-screen composited pixels of a
window's visible tab**. On the user's **i3 tiling WM** an owned/agent tab is
intentionally not foregrounded, and activating it does **not** guarantee its
Brave *window* is raised/composited — Chrome can't force i3 to raise a window.
So the tab never composites and the GPU read-back keeps failing no matter how
many times we retry. Visible-tab (actual foreground tab) screenshots work fine;
occluded/background tabs simply cannot be captured this way.

## Change (small)

- **Actionable error, not `image readback failed`.** New pure helpers in
  `extension/protocol.js` — `isOcclusionCaptureError` + `mapCaptureFailure`.
  After the quota-spaced retries are **exhausted** on a persistent readback
  error, the SW screenshot op's catch maps it to:

  > `screenshot unavailable: the target tab is not visible on-screen (background or occluded window). captureVisibleTab can only capture the foreground tab; bring the tab to the foreground, or use 'text'/'html'/'eval' which work on background tabs.`

  The mapping runs **only post-exhaustion**, so a genuinely transient readback
  that a spaced retry could still recover is **never** wrongly reported
  "unavailable". The **#182 quota error keeps its own message** (a throttle, not
  an occlusion). The existing settle + spaced-retry + activate→capture→restore
  logic is untouched.

- **Skill message.** The `browser` CLI already surfaces op errors as a readable
  stderr line + non-zero exit (`op 'screenshot' failed in the browser: …`); the
  new message flows through cleanly — no raw JSON dump.

- **Docs.** `SKILL.md` / `README.md` / `extension/README.md` / the `browser` CLI
  help now state screenshot is a **VISIBLE-tab op**; background/owned-tab
  screenshots are **not supported on i3** (captureVisibleTab needs on-screen
  compositing) — use `text`/`html`/`eval` for a background tab. Corrected the
  older "#175 briefly-foreground a background tab to capture" language to
  **best-effort; fails on an occluded/non-foreground window with a clear error**.

- **Future option (deliberately out of scope).** A `chrome.debugger` + CDP
  `Page.captureScreenshot` path COULD capture an off-screen tab, but it needs the
  `debugger` permission and shows a debug banner — noted as a FUTURE opt-in only,
  not implemented here. The RCE-safe opencode typed-tool surface is untouched.

- **Agent harness prompt** (`opencode/browser-agent.md`): the cheap model is now
  told to prefer `text`/`html`/`eval` and that `screenshot` is usually unavailable
  for its own (background) tab — so it doesn't waste steps retrying screenshots.

## Tests

`protocol.test.mjs` (node:test, injectable capture fn/clock) gains 8 cases:
persistent readback (retries exhausted) → the actionable "not visible on-screen"
message (not the raw chrome error) after the FULL retry budget; a transient
readback that a spaced retry recovers still **succeeds** (no premature
"unavailable"); the #182 quota path preserved (its own message); plus unit
coverage of `isOcclusionCaptureError` / `mapCaptureFailure` /
`SCREENSHOT_NOT_VISIBLE_MESSAGE`.

- **node:** 82 (`protocol.test.mjs` 58 + `browser_tool.test.mjs` 24) — was 74; +8.
- **python:** 138 (unchanged — no Python touched).
- `node --check` on both JS files, `bash -n` on `browser`: pass.

## Verification (honest)

The capture itself needs a real Brave — the message-mapping/decision logic is
**unit-tested deterministically** (above). Logic-tested + suites green +
committed; **not yet live-verified**. Manual live check (operator, after an
extension **reload** in `brave://extensions`):
`browser --instance work open <url>` → `browser --tab <id> screenshot /tmp/x.png`
should return the CLEAR "not visible on-screen" error (non-zero exit), **not**
`image readback failed`; and a VISIBLE/foreground-tab `screenshot /tmp/vis.png`
still writes a real PNG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)