### PR TITLE
fix(browser-agent): pre-flight tab-readiness retry to survive post-reload owned_tab_gone

### DIFF
--- a/scripts/browser-bridge/browser-agent
+++ b/scripts/browser-bridge/browser-agent
@@ -8,7 +8,11 @@
 #                          [--steps N] [--timeout S] [--dry-run]
 #
 # What it does (see README "opencode browser-agent"):
-#   1. `open`s a NEW tab on instance K (its OWN tab) and captures the tabId.
+#   1. `open`s a NEW tab on instance K (its OWN tab), captures the tabId, and
+#      PROBES it (cheap `eval '1'`, no model tokens) to confirm the tab is
+#      live/owned before proceeding — re-opening (bounded retry) if a post-reload
+#      transient left the tab gone (owned_tab_gone), so the model never gets a
+#      doomed tabId.
 #   2. Runs `opencode run --format json -m <deepseek> --agent browser-agent --auto`
 #      in a scratch --dir. The agent def DENIES every built-in tool (bash, edit,
 #      read, webfetch, …) and ALLOWS only ONE custom, TYPED tool: `browser`
@@ -36,7 +40,8 @@
 # Test seams (env overrides): BROWSER_AGENT_OPENCODE (opencode binary),
 # BROWSER_AGENT_BROWSER_BIN (real browser CLI for open/close), BROWSER_AGENT_MODEL,
 # BROWSER_AGENT_TEMPLATE (agent md template), BROWSER_AGENT_TOOL_DIR (dir holding
-# browser.js + browser_tool_impl.mjs), BROWSER_AGENT_KEEP_SCRATCH=1.
+# browser.js + browser_tool_impl.mjs), BROWSER_AGENT_KEEP_SCRATCH=1,
+# BROWSER_AGENT_READY_ATTEMPTS / BROWSER_AGENT_READY_BACKOFF (open→readiness retry).
 set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -184,16 +189,70 @@ if missing:
 sys.exit(0)
 ' || die "tool-set gate FAILED: opencode did not resolve browser-agent to a browser-ONLY tool set — the host-tool denial did not take on this opencode version/config. Refusing to run the model unconfined (see README 'runtime tool-set gate' / 'opencode version requirement')"
 
-# --- open the agent's own tab ------------------------------------------------ #
+# --- open the agent's own tab (with a pre-flight readiness retry) ------------ #
 # Opened AFTER the gate so a gate-fail leaks no tab.
-open_resp="$("$BROWSER_BIN" "${bflags[@]}" open about:blank 2>/dev/null)" \
-  || die "failed to open a tab (is the browser-bridge extension connected? try: browser health)"
-TAB="$(printf '%s' "$open_resp" | python3 -c 'import json,sys
+#
+# Post-reload transient: right after the extension is reloaded, the service
+# worker's tab-tracking isn't settled yet, so the tab we just `open`ed can
+# VANISH before the model's first op — opencode then returns status:"blocked"
+# with op_failed:owned_tab_gone and the run wastes tokens. So before spending
+# ANY model token, VERIFY the freshly-opened tab is actually live/owned with a
+# CHEAP, metadata-only probe (`eval '1'` → returns 1, NO page content). If the
+# probe reports the tab is gone, close the stale tab (best-effort) and re-open —
+# bounded retry with a short backoff to let the SW settle. Only a probe-passing
+# owned tab is ever handed to opencode.
+READY_ATTEMPTS="${BROWSER_AGENT_READY_ATTEMPTS:-3}"   # test seam
+READY_BACKOFF="${BROWSER_AGENT_READY_BACKOFF:-0.4}"   # test seam (seconds)
+
+_open_tab() {  # open a fresh owned tab; set global TAB; die on a hard open failure
+  local open_resp
+  open_resp="$("$BROWSER_BIN" "${bflags[@]}" open about:blank 2>/dev/null)" \
+    || die "failed to open a tab (is the browser-bridge extension connected? try: browser health)"
+  TAB="$(printf '%s' "$open_resp" | python3 -c 'import json,sys
 try:
     print(json.load(sys.stdin)["result"]["data"]["tabId"])
 except Exception:
     pass')"
-case "$TAB" in (*[!0-9]*|"") die "could not determine the opened tabId from: $open_resp";; esac
+  case "$TAB" in (*[!0-9]*|"") die "could not determine the opened tabId from: $open_resp";; esac
+}
+
+# _probe_tab — model-free readiness check of the CURRENT owned tab ($TAB). Runs a
+# harmless `eval '1'` (returns 1; NO page content). Returns:
+#   0 → tab is live/usable (probe passed)
+#   1 → tab is GONE (owned_tab_gone / "no tab with id") — re-open and retry
+#   2 → some OTHER error (hard failure — surfaced via PROBE_OUT)
+# The probe's stdout+stderr are captured into PROBE_OUT and NEVER reach the
+# wrapper's own stdout, so an op-error dump can't pollute the final JSON result.
+PROBE_OUT=""
+_probe_tab() {
+  PROBE_OUT="$("$BROWSER_BIN" "${bflags[@]}" --tab "$TAB" eval '1' 2>&1)"
+  local rc=$?
+  [ "$rc" = "0" ] && return 0
+  case "$PROBE_OUT" in
+    *owned_tab_gone*|*"no tab with id"*|*"No tab with id"*) return 1 ;;
+    *) return 2 ;;
+  esac
+}
+
+_open_tab
+_attempt=1
+while : ; do
+  _probe_tab; _prc=$?
+  [ "$_prc" = "0" ] && break                    # tab is ready — proceed
+  if [ "$_prc" = "2" ]; then                     # a non-tab-gone probe error is hard
+    die "readiness probe failed unexpectedly on tab $TAB: ${PROBE_OUT}"
+  fi
+  # _prc == 1: the freshly-opened tab is already gone (post-reload transient).
+  if [ "$_attempt" -ge "$READY_ATTEMPTS" ]; then
+    die "browser tab not ready after ${READY_ATTEMPTS} attempts — is the extension loaded/connected? try again"
+  fi
+  # Close the stale (gone) tab best-effort, then re-open a fresh one after a
+  # short backoff so the service worker's tab-tracking can settle.
+  "$BROWSER_BIN" "${bflags[@]}" --tab "$TAB" close >/dev/null 2>&1 || true
+  _attempt=$((_attempt + 1))
+  sleep "$READY_BACKOFF" 2>/dev/null || true
+  _open_tab
+done
 
 TRANSCRIPT1="$SCRATCH/opencode-transcript.jsonl"
 TRANSCRIPT2="$SCRATCH/opencode-transcript.retry.jsonl"

--- a/scripts/browser-bridge/tests/test_browser_agent.py
+++ b/scripts/browser-bridge/tests/test_browser_agent.py
@@ -56,6 +56,10 @@ def _fake_browser(path: Path) -> Path:
     - `--print-session-id`           → prints a stable fake id.
     - `[--instance K] open [url]`     → prints {result:{data:{tabId:FRB_TABID}}}
       (or exits 1 if FRB_OPEN_FAIL=1).
+    - `[--instance K] --tab N eval …` → the wrapper's readiness PROBE. Succeeds by
+      default; if FRB_PROBE_FAIL_TIMES>0 the FIRST that-many probe calls instead
+      mimic a tab-gone op error (stderr `owned_tab_gone`, exit 1) — the counter is
+      persisted in FRB_PROBE_COUNT so retries advance it.
     - `[--instance K] --tab N <op> …` → prints a canned success envelope.
     Every invocation is appended (one JSON line) to $FRB_LOG for assertions.
     """
@@ -86,6 +90,24 @@ if op == "open":
     tabid = int(os.environ.get("FRB_TABID", "4242"))
     print(json.dumps({"ok": True, "result": {"id": "x", "ok": True,
           "data": {"tabId": tabid, "url": "about:blank"}}}))
+    sys.exit(0)
+if op == "eval":
+    # The wrapper's cheap readiness probe. Optionally fail the first N calls with
+    # a tab-gone op error (as the real `browser` CLI surfaces owned_tab_gone: a
+    # message on stderr + non-zero exit) to exercise the open->probe->reopen loop.
+    fail_times = int(os.environ.get("FRB_PROBE_FAIL_TIMES", "0"))
+    cf = os.environ.get("FRB_PROBE_COUNT")
+    cur = 0
+    if cf and os.path.exists(cf):
+        try: cur = int(open(cf).read().strip() or "0")
+        except ValueError: cur = 0
+    if cf:
+        open(cf, "w").write(str(cur + 1))
+    if cur < fail_times:
+        sys.stderr.write("browser: op 'eval' failed in the browser: owned_tab_gone\\n")
+        sys.exit(1)
+    print(json.dumps({"ok": True, "result": {"id": "x", "ok": True,
+          "data": {"value": 1}}}))
     sys.exit(0)
 print(json.dumps({"ok": True, "result": {"id": "x", "ok": True,
       "data": {"url": "https://x.test", "title": "X", "text": "page text"}}}))
@@ -196,18 +218,23 @@ def rig(tmp_path):
     frb_log = tmp_path / "frb.log"
     oc_log = tmp_path / "oc.log"
     oc_env = tmp_path / "oc_env.log"
+    probe_count = tmp_path / "probe.count"
     scratch_root = tmp_path / "scratch"; scratch_root.mkdir()
 
     def run(args, mode="ok", extra_env=None, timeout=60, open_fail=False,
-            tabid=TAB_ID):
+            tabid=TAB_ID, probe_fail=0):
         env = dict(os.environ)
         env.update(
             BROWSER_AGENT_OPENCODE=str(focode),
             BROWSER_AGENT_BROWSER_BIN=str(fbrowser),
             FAKE_OC_MODE=mode, FAKE_OC_LOG=str(oc_log), FAKE_OC_ENV=str(oc_env),
             FRB_LOG=str(frb_log), FRB_TABID=str(tabid),
+            FRB_PROBE_FAIL_TIMES=str(probe_fail), FRB_PROBE_COUNT=str(probe_count),
             TMPDIR=str(scratch_root),
             BROWSER_AGENT_KEEP_SCRATCH="1",
+            # Keep the open->readiness-retry backoff near-zero so the retry tests
+            # don't sleep (the real default is ~0.4s to let the SW settle).
+            BROWSER_AGENT_READY_BACKOFF="0.01",
             PATH=f"{bind}:{env.get('PATH','')}",
         )
         if open_fail:
@@ -438,6 +465,77 @@ def test_open_failure_clean_error(rig):
     assert "failed to open a tab" in r.stderr.lower()
     # A failed open leaves nothing to close (only the open attempt was logged).
     assert [c for c in _browser_calls(rig.frb_log) if c["op"] == "close"] == []
+
+
+# --------------------------------------------------------------------------- #
+# Pre-flight tab-readiness retry: after opening its own tab, the wrapper PROBES
+# it (cheap `eval '1'`, no model tokens) to confirm the tab is live/owned before
+# invoking opencode. Right after an extension reload the service worker's tab
+# tracking isn't settled, so the just-opened tab can vanish (owned_tab_gone); the
+# wrapper must re-open (bounded retry) so the model never gets a doomed tabId.
+# --------------------------------------------------------------------------- #
+def test_readiness_probe_passes_first_try_single_open(rig):
+    """Happy path: the probe passes on the first attempt → EXACTLY one open, one
+    probe, no needless extra opens, then opencode is invoked."""
+    r = rig.run(["read the page"], mode="ok")           # probe_fail defaults 0
+    assert r.returncode == 0, r.stderr
+    calls = _browser_calls(rig.frb_log)
+    opens = [c for c in calls if c["op"] == "open"]
+    probes = [c for c in calls if c["op"] == "eval"]
+    assert len(opens) == 1, f"expected exactly one open, got {len(opens)}"
+    assert len(probes) == 1, f"expected exactly one readiness probe, got {len(probes)}"
+    assert probes[0]["tab"] == str(TAB_ID), "the probe must target the opened tab"
+    assert len(_oc_calls(rig.oc_log)) == 1, "opencode must be invoked once the probe passes"
+
+
+def test_readiness_reopens_on_transient_tab_gone(rig):
+    """First probe reports owned_tab_gone (post-reload transient), the retry's
+    probe passes → the wrapper re-opens, the probe passes, and opencode IS
+    invoked and the run proceeds to a normal result."""
+    r = rig.run(["read the page"], mode="ok", probe_fail=1)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert json.loads(r.stdout.strip()) == SCHEMA_OK
+    calls = _browser_calls(rig.frb_log)
+    opens = [c for c in calls if c["op"] == "open"]
+    probes = [c for c in calls if c["op"] == "eval"]
+    assert len(opens) == 2, f"expected a re-open after the transient, got {len(opens)} opens"
+    assert len(probes) == 2, f"expected two probes (fail then pass), got {len(probes)}"
+    # The stale (gone) tab is closed best-effort before re-opening.
+    closes = [c for c in calls if c["op"] == "close"]
+    assert len(closes) >= 1, "the stale tab must be closed best-effort before re-opening"
+    assert len(_oc_calls(rig.oc_log)) == 1, "opencode must run once the tab is ready"
+
+
+def test_readiness_all_attempts_fail_no_token_spend(rig):
+    """Every probe reports tab-gone → the wrapper dies NON-ZERO with a clear
+    message, NEVER invokes opencode (no token spend), and leaves NO tab open
+    (cleanup closed the last owned tab)."""
+    r = rig.run(["read the page"], mode="ok", probe_fail=99)
+    assert r.returncode != 0, r.stdout + r.stderr
+    assert "not ready after" in r.stderr.lower()
+    # The clear error must NOT be a raw op-error dump on stdout, and no JSON result
+    # (a doomed run must not print a fake schema).
+    assert "owned_tab_gone" not in r.stdout, "the probe's op-error must not leak to stdout"
+    assert r.stdout.strip() == "", "a readiness failure must not print a schema result"
+    assert _oc_calls(rig.oc_log) == [], "opencode must NEVER run when the tab never gets ready"
+    calls = _browser_calls(rig.frb_log)
+    assert len([c for c in calls if c["op"] == "open"]) == 3, "should try open 3 times (bounded)"
+    # No orphan: every opened tab was closed (2 stale closes in-loop + 1 on cleanup).
+    opens = [c for c in calls if c["op"] == "open"]
+    closes = [c for c in calls if c["op"] == "close"]
+    assert len(closes) >= len(opens), "every opened tab must be closed (no orphan)"
+
+
+def test_readiness_failure_still_closes_tab_no_orphan(rig):
+    """A readiness-failure exit path must still run cleanup — the last owned tab
+    is closed, so nothing is orphaned, and the error is human-readable."""
+    r = rig.run(["read the page"], mode="ok", probe_fail=99)
+    assert r.returncode != 0
+    calls = _browser_calls(rig.frb_log)
+    # The last-owned tab (TAB_ID) must appear in a close call (cleanup trap).
+    assert any(c["op"] == "close" and c["tab"] == str(TAB_ID) for c in calls), \
+        "cleanup must close the last owned tab on a readiness-failure exit"
+    assert "extension loaded/connected" in r.stderr.lower(), "the error must be actionable"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## The bug (observed live on the workbench)

Right after **reloading the browser-bridge extension**, the FIRST `browser agent "…"` run failed: the wrapper `open`ed a tab (got a tabId), handed it to opencode, and the model's first `nav` returned `op_failed:owned_tab_gone` → the run came back `status:"blocked"` (and a net −1 tab churned). A retry worked. Root cause: right after a reload the service worker's tab-tracking isn't settled yet, so the tab the wrapper just opened can vanish before the model's first op. The wrapper was handing opencode a tabId that wasn't yet stable/registered.

## The fix — pre-flight readiness retry (before any model spend)

After the wrapper opens its own tab, and **before invoking `opencode run`**, it now verifies the tab is actually live/owned:

1. **Cheap, metadata-only probe** of the just-opened tab — `browser --tab <id> eval '1'` (returns `1`, no page content, no model tokens).
2. On a **tab-gone signal** (`owned_tab_gone` / "no tab with id"), close the stale tab best-effort and **re-`open`** a fresh one. Bounded to **3 open+probe attempts** with a short backoff (~0.4s, env-tunable via `BROWSER_AGENT_READY_BACKOFF`/`_READY_ATTEMPTS`) so the SW can settle.
3. Only a **probe-passing** owned tab is handed to opencode. If all attempts fail → `die` non-zero with an actionable message (`browser tab not ready after N attempts — is the extension loaded/connected? try again`) and **opencode is NEVER invoked** (no doomed-run token spend).
4. A non-tab-gone probe error is treated as a hard failure (distinct from tab-gone).

**Cleanup / no-orphan guarantee:** the existing `cleanup` trap still closes the last owned tab on **every** exit path, including a readiness-failure exit — no leaked/orphaned tab and no net tab churn. The probe's own op-error output is captured into a variable and never pollutes the wrapper's final JSON on stdout.

**Scope:** only the initial open→readiness path. Mid-run tab loss inside the opencode conversation still yields a clean `blocked` (out of scope). The typed `browser` tool, the agent def, and the fail-closed tool-set / security gate (#175/#178/#180/#181–#183) are untouched.

## Tests

Extended the fake-`browser` shim with a configurable tab-gone probe (`FRB_PROBE_FAIL_TIMES`), plus new cases:
- **transient-then-recover**: first probe returns `owned_tab_gone`, retry passes → asserts re-open, probe passes, opencode IS invoked, run proceeds.
- **all-fail**: every probe returns tab-gone → asserts `die` non-zero, opencode NEVER invoked (no token spend), no orphan tab (cleanup closed the last owned tab), and no op-error dump on stdout.
- **happy path**: probe passes first try → exactly one open, one probe, then opencode (no needless extra opens).

`bash -n` clean on both scripts. Full suites green: **142 python (was 138), 82 node**.

## Honest verification

Unit-tested deterministically with the fake shim only. The real post-reload transient needs live Brave and was **not** reproduced here. **Manual check:** reload the browser-bridge extension, then run the FIRST `browser agent "…"` — it should now succeed (no `owned_tab_gone` block) because the wrapper re-opens until the tab is ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
