### PR TITLE
feat: OpenCode activity telemetry connector

### DIFF
--- a/scripts/collector/opencode/__main__.py
+++ b/scripts/collector/opencode/__main__.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""CLI entry point for the OpenCode activity source.
+
+Usage:
+    python -m opencode [--mode tailer|session|all] [--db PATH] [--backfill] [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _add_opencode_to_path() -> None:
+    """Ensure the opencode package directory is on sys.path for imports."""
+    _dir = str(Path(__file__).resolve().parent)
+    if _dir not in sys.path:
+        sys.path.insert(0, _dir)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="opencode",
+        description="OpenCode activity telemetry tailer CLI",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["tailer", "session", "all"],
+        default="all",
+        help="Which tailer(s) to run (default: all)",
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=None,
+        help="Override DB path (default: auto-detect from _shared.opencode_db_path())",
+    )
+    parser.add_argument(
+        "--backfill",
+        action="store_true",
+        help="Run session tailer on ALL sessions (ignore state, re-emit everything)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print events instead of emitting",
+    )
+    return parser.parse_args(argv)
+
+
+def _clear_state_files() -> None:
+    """Remove state files so tailers re-emit everything."""
+    import tailer as T  # noqa: E402
+    import session_tailer as ST  # noqa: E402
+    for sp in (T.state_path(), ST.state_path()):
+        try:
+            sp.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def run(argv: list[str] | None = None) -> int:
+    _add_opencode_to_path()
+    args = parse_args(argv)
+
+    if args.backfill:
+        _clear_state_files()
+
+    import tailer as T  # noqa: E402
+    import session_tailer as ST  # noqa: E402
+
+    if args.dry_run:
+        import _shared as S  # noqa: E402
+        import json as _json
+
+        db = S.get_db(args.db)
+        if db is None:
+            print("no OpenCode DB found, exiting")
+            return 0
+
+        emitted = 0
+        try:
+            if args.mode in ("session", "all"):
+                for session in S.iter_sessions(db):
+                    sid = session["id"]
+                    messages = list(S.iter_messages(db, sid))
+                    all_parts = []
+                    for msg in messages:
+                        all_parts.extend(S.iter_parts(db, msg["id"]))
+                    rollup = ST.build_rollup(session, messages, all_parts)
+                    ev = ST.build_event(sid, session.get("directory") or "", rollup)
+                    print(_json.dumps(ev, ensure_ascii=False))
+                    emitted += 1
+
+            if args.mode in ("tailer", "all"):
+                for session in S.iter_sessions(db):
+                    sid = session["id"]
+                    for msg in S.iter_messages(db, sid):
+                        parts = list(S.iter_parts(db, msg["id"]))
+                        ev = T.build_event(msg, parts, session)
+                        if ev is not None:
+                            print(_json.dumps(ev, ensure_ascii=False))
+                            emitted += 1
+        finally:
+            db.close()
+
+        print(f"dry-run: {emitted} events")
+        return 0
+
+    rc = 0
+    if args.mode in ("tailer", "all"):
+        rc = max(rc, T.run(db_path=args.db))
+    if args.mode in ("session", "all"):
+        rc = max(rc, ST.run(db_path=args.db))
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/scripts/collector/opencode/_shared.py
+++ b/scripts/collector/opencode/_shared.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Shared, dependency-free helpers for the OpenCode activity source.
+
+Reads OpenCode's Drizzle-ORM SQLite database at ~/.local/share/opencode/ and
+yields normalized session/message/part dicts. Emits v1 spool lines via
+keylog.spool_emit for the collector daemon to ship.
+
+Design goals:
+  * Read-only on the OpenCode DB — never write or lock.
+  * Tolerate missing DB or schema drift — return empty iterators, not errors.
+  * Stdlib only — no third-party imports.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import glob
+import json
+import os
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+
+# --------------------------------------------------------------------------- #
+# OpenCode SQLite schema constants (Drizzle ORM)
+# Column names are snake_case in the actual DB.
+# --------------------------------------------------------------------------- #
+SESSION_TABLE = "session"
+MESSAGE_TABLE = "message"
+PART_TABLE = "part"
+PROJECT_TABLE = "project"
+
+
+# --------------------------------------------------------------------------- #
+# Path resolution
+# --------------------------------------------------------------------------- #
+def opencode_data_dir() -> Path:
+    """Return the OpenCode data directory (~/.local/share/opencode/)."""
+    env = os.environ.get("OPENCODE_DATA_DIR")
+    if env:
+        return Path(env)
+    return Path.home() / ".local" / "share" / "opencode"
+
+
+def opencode_db_path() -> Path | None:
+    """Find the OpenCode SQLite database file.
+
+    Known locations (checked in order):
+      1. $OPENCODE_DB_PATH (explicit override)
+      2. ~/.local/share/opencode/opencode-stable.db
+      3. Any *.db or *.sqlite under ~/.local/share/opencode/
+    Returns None if no DB is found.
+    """
+    explicit = os.environ.get("OPENCODE_DB_PATH")
+    if explicit:
+        p = Path(explicit)
+        return p if p.exists() else None
+
+    data_dir = opencode_data_dir()
+    stable = data_dir / "opencode-stable.db"
+    if stable.exists():
+        return stable
+
+    # Fallback: glob for any db file under the data dir
+    for pattern in ("*.db", "*.sqlite", "*.sqlite3"):
+        hits = sorted(data_dir.glob(pattern))
+        if hits:
+            return hits[0]
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# SQLite connection
+# --------------------------------------------------------------------------- #
+def get_db(path: Path | None = None) -> sqlite3.Connection | None:
+    """Open the OpenCode SQLite DB as readonly. Returns None if not found."""
+    db = path or opencode_db_path()
+    if db is None or not db.exists():
+        return None
+    conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+# --------------------------------------------------------------------------- #
+# Iterators
+# --------------------------------------------------------------------------- #
+def _parse_json_field(val: str | None) -> dict | None:
+    """Safely parse a JSON string, returning None on failure."""
+    if not val:
+        return None
+    try:
+        obj = json.loads(val)
+        return obj if isinstance(obj, dict) else None
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def iter_sessions(
+    db: sqlite3.Connection,
+    since_ts: float | None = None,
+) -> Iterator[dict]:
+    """Yield normalized session dicts from the OpenCode DB.
+
+    Args:
+        db: Readonly sqlite3 connection with Row factory.
+        since_ts: If provided, filter to sessions with time_created > since_ts
+                   (epoch milliseconds).
+    """
+    sql = f"SELECT * FROM {SESSION_TABLE}"
+    params: list = []
+    if since_ts is not None:
+        sql += " WHERE time_created > ?"
+        params.append(int(since_ts))
+    sql += " ORDER BY time_created"
+
+    try:
+        cur = db.execute(sql, params)
+    except sqlite3.OperationalError:
+        return
+
+    for row in cur:
+        model_obj = _parse_json_field(row["model"])
+        tokens_obj = {
+            "input": row["tokens_input"],
+            "output": row["tokens_output"],
+            "reasoning": row["tokens_reasoning"],
+            "cache": {
+                "read": row["tokens_cache_read"],
+                "write": row["tokens_cache_write"],
+            },
+        }
+        yield {
+            "id": row["id"],
+            "project_id": row["project_id"],
+            "directory": row["directory"],
+            "title": row["title"],
+            "agent": row["agent"],
+            "model": model_obj,
+            "version": row["version"],
+            "cost": row["cost"],
+            "tokens": tokens_obj,
+            "time_created": row["time_created"],
+            "time_updated": row["time_updated"],
+            "parent_id": row["parent_id"],
+        }
+
+
+def iter_messages(db: sqlite3.Connection, session_id: str) -> Iterator[dict]:
+    """Yield normalized message dicts for a session.
+
+    The `data` column is a JSON blob; we extract role, time, agent, model.
+    """
+    sql = (
+        f"SELECT * FROM {MESSAGE_TABLE} WHERE session_id = ? ORDER BY time_created"
+    )
+    try:
+        cur = db.execute(sql, (session_id,))
+    except sqlite3.OperationalError:
+        return
+
+    for row in cur:
+        data = _parse_json_field(row["data"]) or {}
+        time_obj = data.get("time") or {}
+        yield {
+            "id": row["id"],
+            "session_id": row["session_id"],
+            "role": data.get("role"),
+            "time_created": row["time_created"],
+            "time_updated": row["time_updated"],
+            "time": time_obj,
+            "agent": data.get("agent"),
+            "model": data.get("model"),
+            "cost": data.get("cost"),
+            "tokens": data.get("tokens"),
+        }
+
+
+def iter_parts(db: sqlite3.Connection, message_id: str) -> Iterator[dict]:
+    """Yield normalized part dicts for a message.
+
+    The `data` column is a JSON blob; we extract type, text, tool, etc.
+    """
+    sql = f"SELECT * FROM {PART_TABLE} WHERE message_id = ? ORDER BY time_created"
+    try:
+        cur = db.execute(sql, (message_id,))
+    except sqlite3.OperationalError:
+        return
+
+    for row in cur:
+        data = _parse_json_field(row["data"]) or {}
+        yield {
+            "id": row["id"],
+            "message_id": row["message_id"],
+            "session_id": row["session_id"],
+            "time_created": row["time_created"],
+            "time_updated": row["time_updated"],
+            "type": data.get("type"),
+            "text": data.get("text"),
+            "tool": data.get("tool"),
+            "call_id": data.get("callID"),
+            "state": data.get("state"),
+            "reason": data.get("reason"),
+            "tokens": data.get("tokens"),
+            "cost": data.get("cost"),
+            "_data": data,
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Timestamp conversion
+# --------------------------------------------------------------------------- #
+def to_ch_ts(epoch_ms: int) -> str:
+    """Convert Unix epoch milliseconds to ClickHouse DateTime64(3) string."""
+    dt = _dt.datetime.fromtimestamp(epoch_ms / 1000, tz=_dt.timezone.utc)
+    return dt.strftime("%Y-%m-%d %H:%M:%S.") + f"{dt.microsecond // 1000:03d}"
+
+
+def to_ch_ts_from_iso(iso_str: str) -> str | None:
+    """Parse ISO8601 string → ClickHouse DateTime64(3) timestamp string."""
+    if not iso_str:
+        return None
+    s = iso_str.strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        dt = _dt.datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(_dt.timezone.utc)
+    return dt.strftime("%Y-%m-%d %H:%M:%S.") + f"{dt.microsecond // 1000:03d}"
+
+
+# --------------------------------------------------------------------------- #
+# Project / helpers
+# --------------------------------------------------------------------------- #
+def project_basename(directory: str | None) -> str:
+    """Extract repo name from a path (reuses claude/_shared pattern)."""
+    if not directory:
+        return ""
+    return os.path.basename(directory.rstrip("/"))
+
+
+# --------------------------------------------------------------------------- #
+# Spool bridge
+# --------------------------------------------------------------------------- #
+def spool_emit(fields: dict, spool_dir: Path | None = None) -> str:
+    """Emit fields into the v1 spool via keylog.spool_emit."""
+    import importlib
+    try:
+        mod = importlib.import_module("keylog.spool_emit")
+    except ModuleNotFoundError:
+        # Fallback: direct import when keylog is on sys.path as a directory
+        import sys
+        keylog_dir = str(Path(__file__).resolve().parent.parent / "keylog")
+        if keylog_dir not in sys.path:
+            sys.path.insert(0, keylog_dir)
+        mod = importlib.import_module("spool_emit")
+    return mod.emit(fields, spool_dir=spool_dir)

--- a/scripts/collector/opencode/activity-plugin.js
+++ b/scripts/collector/opencode/activity-plugin.js
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+// activity-plugin.js — OpenCode plugin that emits activity telemetry events
+// to the activity collector pipeline via the `emit` CLI.
+//
+// Placed in ~/.config/opencode/plugins/ (symlinked by deploy-plugin.sh).
+// OpenCode loads plugins from that directory and calls the exported async
+// handler factory with { project, client, directory, $ }.
+
+import { execSync } from "child_process";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { homedir } from "os";
+
+// --------------------------------------------------------------------------- #
+// Constants
+// --------------------------------------------------------------------------- #
+
+const STATE_DIR = join(
+  process.env.XDG_STATE_HOME || join(homedir(), ".local", "state"),
+  "activity"
+);
+const STATE_FILE = join(STATE_DIR, "opencode-plugin-state.json");
+const MAX_SEEN = 1000;
+const MAX_TEXT_LEN = 4096;
+const MAX_ARGS_SUMMARY = 200;
+
+// --------------------------------------------------------------------------- #
+// State management (ring buffer of seen message IDs)
+// --------------------------------------------------------------------------- #
+
+function loadState() {
+  try {
+    const raw = readFileSync(STATE_FILE, "utf-8");
+    const data = JSON.parse(raw);
+    if (data && data.version === 1 && Array.isArray(data.seen)) {
+      return data.seen;
+    }
+  } catch {
+    // corrupt or missing — start fresh
+  }
+  return [];
+}
+
+function saveState(seen) {
+  try {
+    mkdirSync(dirname(STATE_FILE), { recursive: true });
+    // Ring buffer: keep last MAX_SEEN entries
+    const trimmed = seen.slice(-MAX_SEEN);
+    writeFileSync(
+      STATE_FILE,
+      JSON.stringify({ version: 1, seen: trimmed }),
+      "utf-8"
+    );
+  } catch {
+    // best-effort, never crash
+  }
+}
+
+// --------------------------------------------------------------------------- #
+// Emit helper
+// --------------------------------------------------------------------------- #
+
+function resolveEmitPath() {
+  // 1. Env var override
+  if (process.env.EMIT_PATH) {
+    return process.env.EMIT_PATH;
+  }
+  // 2. Deployed location
+  const deployed = join(homedir(), ".config", "activity-collector", "emit");
+  if (existsSync(deployed)) {
+    return deployed;
+  }
+  // 3. Relative to this file (dev location: scripts/collector/emit)
+  const here = dirname(new URL(import.meta.url).pathname);
+  const dev = join(here, "..", "..", "emit");
+  if (existsSync(dev)) {
+    return dev;
+  }
+  // 4. Fallback: assume on PATH
+  return "emit";
+}
+
+function emitEvent({ kind, text, project, cwd, session, app, payload }) {
+  try {
+    const emit = resolveEmitPath();
+    const args = ["source=opencode", `kind=${kind}`];
+
+    if (text != null) {
+      args.push(`b64:text=${String(text)}`);
+    }
+    if (project != null) {
+      args.push(`b64:project=${String(project)}`);
+    }
+    if (cwd != null) {
+      args.push(`b64:cwd=${String(cwd)}`);
+    }
+    if (session != null) {
+      args.push(`b64:session=${String(session)}`);
+    }
+    if (app != null) {
+      args.push(`b64:app=${String(app)}`);
+    }
+    if (payload != null) {
+      const p = typeof payload === "string" ? payload : JSON.stringify(payload);
+      args.push(`b64:payload=${p}`);
+    }
+
+    execSync(`${emit} ${args.join(" ")}`, {
+      stdio: "ignore",
+      timeout: 5000,
+    });
+  } catch {
+    // swallow — never crash OpenCode
+  }
+}
+
+// --------------------------------------------------------------------------- #
+// Extract text from message parts
+// --------------------------------------------------------------------------- #
+
+function extractText(msg) {
+  if (!msg) return "";
+  const parts = msg.parts || msg.content;
+  if (!parts) return "";
+  if (typeof parts === "string") return parts;
+  if (!Array.isArray(parts)) return "";
+  return parts
+    .filter((p) => p && p.type === "text")
+    .map((p) => p.text || "")
+    .join("\n")
+    .trim();
+}
+
+// --------------------------------------------------------------------------- #
+// Plugin export
+// --------------------------------------------------------------------------- #
+
+export const ActivityPlugin = async ({ project, directory }) => {
+  let currentSession = null;
+  const seen = loadState();
+  let dirty = false;
+
+  return {
+    // --- Session lifecycle ---
+    "session.created": async (_input, output) => {
+      try {
+        currentSession = output?.session?.id || null;
+        const title = output?.session?.title || "";
+        emitEvent({
+          kind: "session-create",
+          text: title,
+          project: project?.name || "",
+          cwd: directory || "",
+          session: currentSession,
+          app: "opencode",
+          payload: {
+            agent: output?.session?.agent || "",
+            model: output?.session?.model || "",
+            title,
+          },
+        });
+      } catch {
+        // best-effort
+      }
+    },
+
+    // --- User messages ---
+    "message.updated": async (input, _output) => {
+      try {
+        const msg = input?.message || input;
+        if (!msg) return;
+        if (msg.role !== "user") return;
+
+        const id = msg.id;
+        if (!id) return;
+        if (seen.includes(id)) return;
+
+        const text = extractText(msg);
+        if (!text || text.length < 2) return;
+
+        const truncated =
+          text.length > MAX_TEXT_LEN ? text.slice(0, MAX_TEXT_LEN) : text;
+        const kind = truncated.startsWith("/") ? "command" : "prompt";
+
+        emitEvent({
+          kind,
+          text: truncated,
+          project: project?.name || "",
+          cwd: directory || "",
+          session: currentSession,
+          app: "opencode",
+          payload: { role: "user", messageId: id },
+        });
+
+        seen.push(id);
+        dirty = true;
+        if (seen.length > MAX_SEEN) {
+          saveState(seen);
+          dirty = false;
+        }
+      } catch {
+        // best-effort
+      }
+    },
+
+    // --- Tool calls ---
+    "tool.execute.after": async (input, output) => {
+      try {
+        const toolName = input?.tool?.name || input?.name || "unknown";
+        const argsStr = input?.args
+          ? JSON.stringify(input.args).slice(0, MAX_ARGS_SUMMARY)
+          : "";
+        const durationMs =
+          output?.duration_ms || output?.durationMs || 0;
+        const success = output?.error ? false : true;
+
+        emitEvent({
+          kind: "tool-call",
+          text: toolName,
+          project: project?.name || "",
+          cwd: directory || "",
+          session: currentSession,
+          app: "opencode",
+          payload: {
+            duration_ms: durationMs,
+            success,
+            args_summary: argsStr,
+          },
+        });
+      } catch {
+        // best-effort
+      }
+    },
+
+    // --- Session end ---
+    "session.idle": async (_input, _output) => {
+      try {
+        emitEvent({
+          kind: "session-idle",
+          text: "",
+          project: project?.name || "",
+          cwd: directory || "",
+          session: currentSession,
+          app: "opencode",
+        });
+        currentSession = null;
+      } catch {
+        // best-effort
+      }
+    },
+
+    // --- Cleanup: persist state if dirty ---
+    _cleanup: () => {
+      if (dirty) {
+        saveState(seen);
+        dirty = false;
+      }
+    },
+  };
+};

--- a/scripts/collector/opencode/backfill.py
+++ b/scripts/collector/opencode/backfill.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""backfill — re-emit all historical OpenCode sessions and messages.
+
+Clears both tailer state files, then runs session tailer then message tailer
+sequentially. Since state is empty, both tailers emit everything in the DB.
+
+Usage:
+    python3 backfill.py [--db PATH]
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _add_opencode_to_path() -> None:
+    """Ensure the opencode package directory is on sys.path for imports."""
+    _dir = str(Path(__file__).resolve().parent)
+    if _dir not in sys.path:
+        sys.path.insert(0, _dir)
+
+
+def run(db_path: Path | None = None) -> int:
+    _add_opencode_to_path()
+
+    import tailer as T  # noqa: E402
+    import session_tailer as ST  # noqa: E402
+
+    # Clear state files so both tailers re-emit everything
+    for sp in (ST.state_path(), T.state_path()):
+        try:
+            sp.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+    # Run session tailer first (session summaries)
+    rc = ST.run(db_path=db_path)
+    if rc != 0:
+        return rc
+
+    # Run message tailer (per-message events)
+    rc = T.run(db_path=db_path)
+    return rc
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Backfill all OpenCode activity events")
+    parser.add_argument("--db", type=Path, default=None, help="Override DB path")
+    args = parser.parse_args()
+    raise SystemExit(run(db_path=args.db))

--- a/scripts/collector/opencode/deploy-plugin.sh
+++ b/scripts/collector/opencode/deploy-plugin.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# deploy-plugin.sh — Symlink the activity plugin into OpenCode's plugins dir.
+#
+# Usage: bash scripts/collector/opencode/deploy-plugin.sh
+set -euo pipefail
+
+PLUGIN_SRC="$(readlink -f "$(dirname "$0")/activity-plugin.js")"
+PLUGIN_DIR="$HOME/.config/opencode/plugins"
+PLUGIN_LINK="$PLUGIN_DIR/activity.js"
+
+if [[ ! -f "$PLUGIN_SRC" ]]; then
+  echo "ERROR: plugin source not found: $PLUGIN_SRC" >&2
+  exit 1
+fi
+
+mkdir -p "$PLUGIN_DIR"
+
+# Remove stale regular file or dangling symlink, then create fresh symlink.
+if [[ -e "$PLUGIN_LINK" || -L "$PLUGIN_LINK" ]]; then
+  rm -f "$PLUGIN_LINK"
+fi
+
+ln -s "$PLUGIN_SRC" "$PLUGIN_LINK"
+
+echo "Deployed: $PLUGIN_LINK -> $PLUGIN_SRC"
+echo ""
+echo "Reload OpenCode to activate the plugin."

--- a/scripts/collector/opencode/schema.py
+++ b/scripts/collector/opencode/schema.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""OpenCode-specific SQLite schema detection.
+
+Queries PRAGMA table_info to discover the actual columns in the live DB,
+maps them to our expected schema, and reports drift or missing tables.
+
+Usage:
+    from opencode.schema import detect_schema
+    info = detect_schema()
+    if info is None:
+        print("No OpenCode DB found")
+    elif info.drift:
+        print(f"Schema drift: {info.drift}")
+"""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import _shared as S
+from _shared import (
+    MESSAGE_TABLE,
+    PART_TABLE,
+    PROJECT_TABLE,
+    SESSION_TABLE,
+    get_db,
+    opencode_db_path,
+)
+
+
+@dataclass
+class TableInfo:
+    name: str
+    columns: list[str]
+
+
+@dataclass
+class SchemaInfo:
+    session: TableInfo | None = None
+    message: TableInfo | None = None
+    part: TableInfo | None = None
+    project: TableInfo | None = None
+    drift: list[str] = field(default_factory=list)
+    db_path: Path | None = None
+
+
+def _get_columns(db: sqlite3.Connection, table: str) -> list[str] | None:
+    """Return column names for a table, or None if the table doesn't exist."""
+    try:
+        # Check if table exists first
+        cur = db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (table,),
+        )
+        if cur.fetchone() is None:
+            return None
+        cur = db.execute(f"PRAGMA table_info({table})")
+        return [row["name"] for row in cur]
+    except sqlite3.OperationalError:
+        return None
+
+
+def detect_schema(db: sqlite3.Connection | None = None) -> SchemaInfo | None:
+    """Detect the actual OpenCode SQLite schema.
+
+    Returns a SchemaInfo with per-table column lists and any drift warnings.
+    Returns None if the DB doesn't exist or can't be opened.
+    """
+    own_db = False
+    if db is None:
+        db_path = opencode_db_path()
+        if db_path is None:
+            return None
+        db = get_db(db_path)
+        if db is None:
+            return None
+        own_db = True
+
+    info = SchemaInfo(db_path=opencode_db_path())
+
+    try:
+        for attr, table_name in [
+            ("session", SESSION_TABLE),
+            ("message", MESSAGE_TABLE),
+            ("part", PART_TABLE),
+            ("project", PROJECT_TABLE),
+        ]:
+            cols = _get_columns(db, table_name)
+            if cols is not None:
+                setattr(info, attr, TableInfo(name=table_name, columns=cols))
+            else:
+                info.drift.append(f"missing table: {table_name}")
+    finally:
+        if own_db:
+            db.close()
+
+    return info

--- a/scripts/collector/opencode/session_tailer.py
+++ b/scripts/collector/opencode/session_tailer.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""session_tailer — emit a per-SESSION rollup for the OpenCode activity source.
+
+Reads OpenCode's SQLite database, walks sessions/messages/parts, and emits a
+deterministic `kind=session-summary` event per session via the shared spool.
+Exactly ONE event per session; re-emitted only when the session's signature
+(cheap checksum of time_updated + cost + tokens_input) changes.
+
+Event shape (via _shared.spool_emit → spool → ClickHouse activity.events):
+    source  = opencode
+    kind    = session-summary
+    session = session UUID
+    project = repo basename from session directory
+    cwd     = session directory
+    ts      = session start instant (ClickHouse DateTime64(3))
+    payload = rollup JSON
+
+State file tracks per-session signatures to skip unchanged sessions.
+CHECKPOINT_EVERY = 25 for resumable backfills.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import _shared as S  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+EXT_LANG = {
+    ".py": "Python", ".pyi": "Python",
+    ".js": "JavaScript", ".jsx": "JavaScript", ".mjs": "JavaScript", ".cjs": "JavaScript",
+    ".ts": "TypeScript", ".tsx": "TypeScript",
+    ".go": "Go", ".rs": "Rust", ".rb": "Ruby", ".java": "Java", ".kt": "Kotlin",
+    ".c": "C", ".h": "C", ".cpp": "C++", ".cc": "C++", ".hpp": "C++",
+    ".cs": "C#", ".php": "PHP", ".swift": "Swift", ".scala": "Scala",
+    ".sh": "Shell", ".bash": "Shell", ".zsh": "Shell",
+    ".nix": "Nix", ".lua": "Lua",
+    ".md": "Markdown", ".markdown": "Markdown",
+    ".yaml": "YAML", ".yml": "YAML",
+    ".json": "JSON", ".toml": "TOML", ".ini": "INI",
+    ".html": "HTML", ".htm": "HTML", ".css": "CSS", ".scss": "SCSS",
+    ".sql": "SQL", ".tf": "Terraform", ".hcl": "HCL",
+    ".vim": "VimScript", ".xml": "XML", ".txt": "Text", ".csv": "CSV",
+}
+_SPECIAL_NAMES = {"dockerfile": "Dockerfile", "makefile": "Makefile"}
+
+# Tools that create/modify a file → contribute to languages / files / churn.
+_FILE_TOOLS = {"edit", "write", "write_file", "create_file"}
+
+# git commit / push inside a bash command.
+_GIT_COMMIT = re.compile(r"\bgit\s+(?:-C\s+\S+\s+|-\S+\s+)*commit\b")
+_GIT_PUSH = re.compile(r"\bgit\s+(?:-C\s+\S+\s+|-\S+\s+)*push\b")
+
+
+def lang_for_path(path: str) -> str | None:
+    """Map an edited/written file path to a language name, or None."""
+    if not path:
+        return None
+    base = os.path.basename(path)
+    special = _SPECIAL_NAMES.get(base.lower())
+    if special:
+        return special
+    return EXT_LANG.get(os.path.splitext(base)[1].lower())
+
+
+def is_git_commit(cmd: str) -> bool:
+    return bool(cmd) and _GIT_COMMIT.search(cmd) is not None
+
+
+def is_git_push(cmd: str) -> bool:
+    return bool(cmd) and _GIT_PUSH.search(cmd) is not None
+
+
+def categorize_tool_error(text: str) -> str:
+    """Bucket a failed tool invocation into a coarse deterministic category."""
+    t = (text or "").lower()
+    if "timed out" in t or "timeout" in t:
+        return "Timeout"
+    if ("no such file" in t or "not found" in t or "does not exist" in t
+            or "no matches found" in t):
+        return "File Not Found"
+    if ("permission denied" in t or "not permitted" in t
+            or "operation not permitted" in t):
+        return "Permission Denied"
+    if ("error" in t or "failed" in t or "exit code" in t or "non-zero" in t
+            or "traceback" in t):
+        return "Command Failed"
+    return "Other"
+
+
+def _int(v) -> int:
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(v) -> float:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Rollup
+# --------------------------------------------------------------------------- #
+def build_rollup(session_data: dict, messages: list[dict], parts: list[dict]) -> dict:
+    """Deterministic per-session rollup from session dict, messages, and parts.
+
+    `session_data` is the dict from iter_sessions().
+    `messages` is a list of dicts from iter_messages().
+    `parts` is a flat list of ALL part dicts from iter_parts() for ALL messages.
+
+    Returns a rollup dict with tool counts, tokens, languages, git activity, etc.
+    """
+    r: dict = {
+        "tool_counts": {},
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
+        "user_message_count": 0,
+        "assistant_message_count": 0,
+        "duration_minutes": 0.0,
+        "languages": {},
+        "git_commits": 0,
+        "git_pushes": 0,
+        "files_modified": 0,
+        "lines_added": 0,
+        "lines_removed": 0,
+        "tool_errors": 0,
+        "tool_error_categories": {},
+        "uses_task_agent": False,
+        "uses_mcp": False,
+        "uses_web_search": False,
+        "uses_web_fetch": False,
+        "models": [],
+        "start_ts": None,
+        "end_ts": None,
+        "unreadable": False,
+        "cost": 0.0,
+    }
+
+    tool_counts: dict = r["tool_counts"]
+    languages: dict = r["languages"]
+    err_cats: dict = r["tool_error_categories"]
+    files: set[str] = set()
+    models: set[str] = set()
+
+    # --- Session-level aggregates ---
+    r["cost"] = _float(session_data.get("cost"))
+    tokens = session_data.get("tokens") or {}
+    r["input_tokens"] = _int(tokens.get("input"))
+    r["output_tokens"] = _int(tokens.get("output"))
+    r["reasoning_tokens"] = _int(tokens.get("reasoning"))
+    cache = tokens.get("cache") or {}
+    r["cache_read_tokens"] = _int(cache.get("read"))
+    r["cache_write_tokens"] = _int(cache.get("write"))
+
+    # --- Session timestamps ---
+    time_created = session_data.get("time_created")
+    time_updated = session_data.get("time_updated")
+    if time_created is not None:
+        r["start_ts"] = S.to_ch_ts(int(time_created))
+    if time_updated is not None:
+        r["end_ts"] = S.to_ch_ts(int(time_updated))
+    if (time_created is not None and time_updated is not None
+            and time_updated >= time_created):
+        r["duration_minutes"] = round((time_updated - time_created) / 60000, 2)
+
+    # --- Walk messages ---
+    for msg in messages:
+        role = msg.get("role")
+        if role == "user":
+            r["user_message_count"] += 1
+        elif role == "assistant":
+            r["assistant_message_count"] += 1
+        # Collect models from message-level model field
+        model = msg.get("model")
+        if isinstance(model, dict):
+            mid = model.get("modelID") or model.get("id")
+            if mid:
+                models.add(mid)
+        elif isinstance(model, str) and model:
+            models.add(model)
+
+    # --- Walk parts ---
+    for part in parts:
+        part_type = part.get("type")
+
+        # Tool invocations
+        if part_type == "tool":
+            tool_name = part.get("tool") or ""
+            if tool_name:
+                tool_counts[tool_name] = tool_counts.get(tool_name, 0) + 1
+
+            # Extract tool arguments from the parsed data blob.
+            # OpenCode stores tool-specific fields (command, file_path, etc.)
+            # in the part's JSON data column, not as top-level part fields.
+            # _shared.iter_parts includes the raw parsed dict as "_data".
+            _data = part.get("_data") or {}
+            args_str = ""
+            fp = ""
+            if isinstance(_data, dict):
+                args_str = str(_data.get("command") or _data.get("input") or "")
+                fp = str(_data.get("file_path") or _data.get("path") or "")
+
+            if tool_name == "bash":
+                if is_git_commit(args_str):
+                    r["git_commits"] += 1
+                if is_git_push(args_str):
+                    r["git_pushes"] += 1
+            elif tool_name in ("task",):
+                r["uses_task_agent"] = True
+            elif tool_name.startswith("mcp__"):
+                r["uses_mcp"] = True
+            elif tool_name == "websearch":
+                r["uses_web_search"] = True
+            elif tool_name == "webfetch":
+                r["uses_web_fetch"] = True
+
+            # File tools → language detection + files modified
+            if tool_name in _FILE_TOOLS and fp:
+                files.add(fp)
+                lang = lang_for_path(fp)
+                if lang:
+                    languages[lang] = languages.get(lang, 0) + 1
+
+            # Tool errors
+            state = part.get("state") or {}
+            if isinstance(state, dict) and state.get("status") == "error":
+                r["tool_errors"] += 1
+                err_text = str(state.get("error") or state.get("message") or "")
+                cat = categorize_tool_error(err_text)
+                err_cats[cat] = err_cats.get(cat, 0) + 1
+
+    r["files_modified"] = len(files)
+    r["models"] = sorted(models)
+    r["unreadable"] = (r["user_message_count"] == 0
+                       and r["assistant_message_count"] == 0)
+    return r
+
+
+# --------------------------------------------------------------------------- #
+# Event / emit
+# --------------------------------------------------------------------------- #
+def build_event(session_id: str, directory: str, rollup: dict) -> dict:
+    """Build the event dict for spool_emit."""
+    return {
+        "source": "opencode",
+        "kind": "session-summary",
+        "session": session_id,
+        "project": S.project_basename(directory),
+        "cwd": directory,
+        "ts": rollup.get("start_ts"),
+        "app": "opencode",
+        "payload": json.dumps(rollup, ensure_ascii=False, separators=(",", ":")),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# State (idempotency + mutable-session awareness)
+# --------------------------------------------------------------------------- #
+def state_path() -> Path:
+    explicit = os.environ.get("OPENCODE_SESSION_STATE")
+    if explicit:
+        return Path(explicit)
+    base = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state"))
+    return base / "activity" / "opencode-session-summary-state.json"
+
+
+def signature(session: dict) -> str:
+    """Cheap change signature — computed WITHOUT reading messages/parts."""
+    return f"{session.get('time_updated', 0)}:{session.get('cost', 0)}:{(session.get('tokens') or {}).get('input', 0)}"
+
+
+def load_state(path: Path) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+    sigs = data.get("sigs") if isinstance(data, dict) else None
+    return dict(sigs) if isinstance(sigs, dict) else {}
+
+
+def save_state(path: Path, sigs: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(
+        json.dumps({"version": 1, "sigs": sigs}, separators=(",", ":")),
+        encoding="utf-8",
+    )
+    os.replace(tmp, path)  # atomic
+
+
+CHECKPOINT_EVERY = 25
+
+
+# --------------------------------------------------------------------------- #
+# Run
+# --------------------------------------------------------------------------- #
+def run(db_path: Path | None = None) -> int:
+    sp = state_path()
+    prev = load_state(sp)
+
+    db = S.get_db(db_path)
+    if db is None:
+        print("session_tailer: no OpenCode DB found, exiting")
+        return 0
+
+    new_sigs: dict = dict(prev)
+    seen: set = set()
+    emitted = 0
+    scanned = 0
+    since_checkpoint = 0
+
+    try:
+        for session in S.iter_sessions(db):
+            sid = session["id"]
+            sig = signature(session)
+            seen.add(sid)
+            scanned += 1
+            if prev.get(sid) == sig:
+                new_sigs[sid] = sig
+                continue
+
+            directory = session.get("directory") or ""
+            messages = list(S.iter_messages(db, sid))
+            all_parts: list[dict] = []
+            for msg in messages:
+                all_parts.extend(S.iter_parts(db, msg["id"]))
+
+            rollup = build_rollup(session, messages, all_parts)
+            ev = build_event(sid, directory, rollup)
+            S.spool_emit(ev)
+            new_sigs[sid] = sig
+            emitted += 1
+            since_checkpoint += 1
+            if since_checkpoint >= CHECKPOINT_EVERY:
+                save_state(sp, new_sigs)
+                since_checkpoint = 0
+    finally:
+        db.close()
+
+    # Prune deleted sessions from state
+    new_sigs = {sid: s for sid, s in new_sigs.items() if sid in seen}
+    save_state(sp, new_sigs)
+    print(f"session_tailer: scanned={scanned} emitted={emitted} state={sp}")
+    return 0
+
+
+if __name__ == "__main__":
+    # When run as a standalone script, ensure opencode dir is on sys.path
+    _dir = str(Path(__file__).resolve().parent)
+    if _dir not in sys.path:
+        sys.path.insert(0, _dir)
+    raise SystemExit(run())

--- a/scripts/collector/opencode/tailer.py
+++ b/scripts/collector/opencode/tailer.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""tailer — emit per-message activity events for the OpenCode source.
+
+Reads OpenCode's SQLite database, walks sessions/messages/parts, and emits
+`kind=prompt` (user messages) and `kind=assistant-turn` (assistant responses)
+events via the shared spool.
+
+Design:
+  * REUSE _shared iterators (iter_sessions / iter_messages / iter_parts) and
+    spool_emit for DB access and event emission.
+  * IDEMPOTENT: a state file records every already-emitted message ID. Each
+    run emits ONLY IDs not in the state set, then persists the union.
+  * Per-message event mapping:
+        source  = opencode
+        kind    = "prompt" for user messages, "assistant-turn" for assistant
+        text    = first text part content
+        project = repo basename from session directory
+        cwd     = session directory
+        session = session id
+        app     = opencode
+        ts      = message creation timestamp
+        payload = {role, model, agent, cost, tokens, tool_calls, tool_count}
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import _shared as S  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Noise filtering
+# --------------------------------------------------------------------------- #
+def classify(text: str) -> tuple[str, str] | None:
+    """Classify text → (kind, text) or None if noise.
+
+    kind is "command" for slash-commands, "typed" for genuine messages.
+    Returns None for empty, very short, or noise text.
+    """
+    if not text:
+        return None
+    t = text.strip()
+    if len(t) < 2:
+        return None
+    if t.startswith("/"):
+        return ("command", t)
+    return ("typed", t)
+
+
+def clean_text(text: str) -> str:
+    """Strip OpenCode-specific noise and whitespace.
+
+    OpenCode doesn't have the same <system-reminder> tags as Claude,
+    so this just strips whitespace for now.
+    """
+    return (text or "").strip()
+
+
+# --------------------------------------------------------------------------- #
+# Identity / extraction
+# --------------------------------------------------------------------------- #
+def message_id(msg: dict) -> str:
+    """Globally unique message ID: session_id:msg_id."""
+    return f"{msg['session_id']}:{msg['id']}"
+
+
+def extract_text(parts: list[dict]) -> str:
+    """Extract text content from the first text-type part."""
+    for part in parts:
+        if part.get("type") == "text":
+            return part.get("text") or ""
+    return ""
+
+
+_TOOL_META_KEYS = {"type", "tool", "callID", "state", "reason", "tokens", "cost", "text"}
+
+
+def _extract_args(data: dict) -> dict:
+    """Extract tool-specific arguments from the part data dict."""
+    return {k: v for k, v in data.items() if k not in _TOOL_META_KEYS}
+
+
+def extract_tool_calls(parts: list[dict]) -> list[dict]:
+    """Extract tool-invocation parts as [{tool_name, args, state}]."""
+    calls = []
+    for part in parts:
+        if part.get("type") in ("tool", "tool-invocation"):
+            calls.append({
+                "tool_name": part.get("tool") or "",
+                "args": _extract_args(part.get("_data") or {}),
+                "state": part.get("state") or {},
+            })
+    return calls
+
+
+# --------------------------------------------------------------------------- #
+# Event building
+# --------------------------------------------------------------------------- #
+def _int(v) -> int:
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(v) -> float:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def build_event(msg: dict, parts: list[dict], session: dict) -> dict | None:
+    """Build an activity event dict from a message and its parts.
+
+    Returns None if the message should be filtered out (noise user messages,
+    unknown roles).
+    """
+    role = msg.get("role")
+    if role not in ("user", "assistant"):
+        return None
+
+    text = extract_text(parts)
+
+    # Filter noise for user messages
+    if role == "user":
+        classification = classify(text)
+        if classification is None:
+            return None
+
+    directory = session.get("directory") or ""
+    tool_calls = extract_tool_calls(parts)
+
+    # Get token info from message data blob
+    tokens = msg.get("tokens") or {}
+
+    kind = "prompt" if role == "user" else "assistant-turn"
+
+    tool_calls_summary = [{"name": tc["tool_name"], "state": tc["state"]} for tc in tool_calls]
+
+    payload = json.dumps({
+        "role": role,
+        "model": msg.get("model") or session.get("model"),
+        "agent": msg.get("agent") or session.get("agent"),
+        "cost": _float(msg.get("cost")),
+        "tokens_input": _int(tokens.get("input")),
+        "tokens_output": _int(tokens.get("output")),
+        "tool_calls": tool_calls_summary,
+        "tool_count": len(tool_calls),
+    }, ensure_ascii=False, separators=(",", ":"))
+
+    return {
+        "source": "opencode",
+        "kind": kind,
+        "text": text,
+        "project": S.project_basename(directory),
+        "cwd": directory,
+        "session": msg["session_id"],
+        "app": "opencode",
+        "ts": S.to_ch_ts(msg["time_created"]),
+        "payload": payload,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# State (idempotency)
+# --------------------------------------------------------------------------- #
+def state_path() -> Path:
+    explicit = os.environ.get("OPENCODE_TAILER_STATE")
+    if explicit:
+        return Path(explicit)
+    base = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state"))
+    return base / "activity" / "opencode-tailer-state.json"
+
+
+def load_state(path: Path) -> set[str]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return set()
+    seen = data.get("seen") if isinstance(data, dict) else None
+    return set(seen) if isinstance(seen, list) else set()
+
+
+def save_state(path: Path, seen: set[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(
+        json.dumps({"version": 1, "seen": sorted(seen)}, separators=(",", ":")),
+        encoding="utf-8",
+    )
+    os.replace(tmp, path)  # atomic
+
+
+# --------------------------------------------------------------------------- #
+# Run
+# --------------------------------------------------------------------------- #
+def run(db_path: Path | None = None) -> int:
+    sp = state_path()
+    seen = load_state(sp)
+
+    db = S.get_db(db_path)
+    if db is None:
+        print("tailer: no OpenCode DB found, exiting")
+        return 0
+
+    new_seen: set[str] = set(seen)
+    emitted = 0
+    scanned = 0
+
+    try:
+        for session in S.iter_sessions(db):
+            sid = session["id"]
+            for msg in S.iter_messages(db, sid):
+                mid = message_id(msg)
+                scanned += 1
+                if mid in new_seen:
+                    continue
+                parts = list(S.iter_parts(db, msg["id"]))
+                ev = build_event(msg, parts, session)
+                if ev is None:
+                    new_seen.add(mid)
+                    continue
+                S.spool_emit(ev)
+                new_seen.add(mid)
+                emitted += 1
+    finally:
+        db.close()
+
+    save_state(sp, new_seen)
+    print(f"tailer: scanned={scanned} emitted={emitted} state={sp}")
+    return 0
+
+
+if __name__ == "__main__":
+    _dir = str(Path(__file__).resolve().parent)
+    if _dir not in sys.path:
+        sys.path.insert(0, _dir)
+    raise SystemExit(run())

--- a/scripts/collector/opencode/tests/test_backfill.py
+++ b/scripts/collector/opencode/tests/test_backfill.py
@@ -1,0 +1,309 @@
+"""Tests for opencode/backfill.py — backfill script.
+
+Run: python -m pytest scripts/collector/opencode/tests/test_backfill.py -v
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+COLLECTOR = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(COLLECTOR))
+KEYLOG = COLLECTOR / "keylog"
+sys.path.insert(0, str(KEYLOG))
+OPENCODE = COLLECTOR / "opencode"
+sys.path.insert(0, str(OPENCODE))
+
+import _shared as S  # noqa: E402
+import collector as C  # noqa: E402
+import tailer as T  # noqa: E402
+import session_tailer as ST  # noqa: E402
+
+sys.path.insert(0, str(OPENCODE))
+import backfill as B  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    spool = tmp_path / "spool"
+    spool.mkdir()
+    monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(spool))
+    monkeypatch.setenv("OPENCODE_TAILER_STATE", str(tmp_path / "tailer-state.json"))
+    monkeypatch.setenv("OPENCODE_SESSION_STATE", str(tmp_path / "session-state.json"))
+    return {"spool": spool, "tmp_path": tmp_path}
+
+
+@pytest.fixture
+def sample_db(tmp_path):
+    db_path = tmp_path / "opencode-stable.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""CREATE TABLE session (
+        id TEXT PRIMARY KEY, project_id TEXT, workspace_id TEXT, parent_id TEXT,
+        slug TEXT, directory TEXT, path TEXT, title TEXT, version TEXT,
+        share_url TEXT, summary_additions INTEGER, summary_deletions INTEGER,
+        summary_files INTEGER, summary_diffs TEXT, metadata TEXT,
+        cost REAL, tokens_input INTEGER, tokens_output INTEGER,
+        tokens_reasoning INTEGER, tokens_cache_read INTEGER,
+        tokens_cache_write INTEGER, revert TEXT, permission TEXT,
+        agent TEXT, model TEXT,
+        time_created INTEGER, time_updated INTEGER,
+        time_compacting INTEGER, time_archived INTEGER
+    )""")
+    conn.execute("""CREATE TABLE message (
+        id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER,
+        time_updated INTEGER, data TEXT
+    )""")
+    conn.execute("""CREATE TABLE part (
+        id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT,
+        time_created INTEGER, time_updated INTEGER, data TEXT
+    )""")
+
+    conn.execute(
+        """INSERT INTO session (
+            id, project_id, workspace_id, parent_id, slug, directory, path,
+            title, version, share_url, summary_additions, summary_deletions,
+            summary_files, summary_diffs, metadata, cost, tokens_input,
+            tokens_output, tokens_reasoning, tokens_cache_read,
+            tokens_cache_write, revert, permission, agent, model,
+            time_created, time_updated
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            "ses_001", "proj_a", "ws_1", None, "my-repo",
+            "/home/zach/workspace/my-repo", None, "Test session",
+            "1.0.0", None, 10, 5, 3, None, None, 0.05,
+            1000, 500, 200, 300, 100,
+            None, None, "build",
+            '{"id":"deepseek/deepseek-v4-flash","providerID":"openrouter"}',
+            1700000000000, 1700000060000,
+        ),
+    )
+    conn.execute(
+        """INSERT INTO session (
+            id, project_id, workspace_id, parent_id, slug, directory, path,
+            title, version, share_url, summary_additions, summary_deletions,
+            summary_files, summary_diffs, metadata, cost, tokens_input,
+            tokens_output, tokens_reasoning, tokens_cache_read,
+            tokens_cache_write, revert, permission, agent, model,
+            time_created, time_updated
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            "ses_002", "proj_b", "ws_1", None, "another-repo",
+            "/home/zach/workspace/another-repo", None, "Second session",
+            "1.0.0", None, 0, 0, 0, None, None, 0.01,
+            200, 100, 0, 50, 50,
+            None, None, "build",
+            '{"id":"gpt-4o","providerID":"openai"}',
+            1700001000000, 1700001030000,
+        ),
+    )
+
+    # --- Messages for ses_001 ---
+    conn.execute(
+        "INSERT INTO message VALUES (?,?,?,?,?)",
+        (
+            "msg_001", "ses_001", 1700000001000, 1700000001000,
+            json.dumps({"role": "user", "time": {"created": 1700000001000}, "agent": "build"}),
+        ),
+    )
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_001", "msg_001", "ses_001", 1700000001000, 1700000001000,
+            json.dumps({"type": "text", "text": "Hello, please help me."}),
+        ),
+    )
+    conn.execute(
+        "INSERT INTO message VALUES (?,?,?,?,?)",
+        (
+            "msg_002", "ses_001", 1700000002000, 1700000003000,
+            json.dumps({
+                "role": "assistant", "time": {"created": 1700000002000, "completed": 1700000003000},
+                "agent": "build",
+                "model": {"providerID": "openrouter", "modelID": "deepseek-v4-flash"},
+                "cost": 0.001, "tokens": {"input": 500, "output": 100, "reasoning": 50},
+            }),
+        ),
+    )
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_002", "msg_002", "ses_001", 1700000002100, 1700000003000,
+            json.dumps({"type": "text", "text": "Here is the solution."}),
+        ),
+    )
+
+    # --- Messages for ses_002 ---
+    conn.execute(
+        "INSERT INTO message VALUES (?,?,?,?,?)",
+        (
+            "msg_s2_001", "ses_002", 1700001001000, 1700001001000,
+            json.dumps({"role": "user", "time": {"created": 1700001001000}, "agent": "build"}),
+        ),
+    )
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_s2_001", "msg_s2_001", "ses_002", 1700001001000, 1700001001000,
+            json.dumps({"type": "text", "text": "Do something in the other repo"}),
+        ),
+    )
+
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _mock_get_db(sample_db):
+    """Return a mock get_db that returns writable connections."""
+    def mock_get_db(path=None):
+        db = path or sample_db
+        if db is None or not db.exists():
+            return None
+        conn = sqlite3.connect(str(db))
+        conn.row_factory = sqlite3.Row
+        return conn
+    return mock_get_db
+
+
+# --------------------------------------------------------------------------- #
+# test_backfill_emits_all_sessions
+# --------------------------------------------------------------------------- #
+class TestBackfillEmitsAllSessions:
+    def test_all_sessions_emitted(self, sample_db, env, monkeypatch):
+        monkeypatch.setattr(S, "get_db", _mock_get_db(sample_db))
+        rc = B.run(db_path=sample_db)
+        assert rc == 0
+
+        spool_file = env["spool"] / "current.log"
+        lines = spool_file.read_text().strip().splitlines()
+        # Find session-summary events
+        session_events = []
+        for line in lines:
+            ev = C.parse_line(line)
+            if ev and ev["kind"] == "session-summary":
+                session_events.append(ev)
+
+        sessions = {ev["session"] for ev in session_events}
+        assert "ses_001" in sessions
+        assert "ses_002" in sessions
+        assert len(session_events) >= 2
+
+
+# --------------------------------------------------------------------------- #
+# test_backfill_emits_all_messages
+# --------------------------------------------------------------------------- #
+class TestBackfillEmitsAllMessages:
+    def test_all_messages_emitted(self, sample_db, env, monkeypatch):
+        monkeypatch.setattr(S, "get_db", _mock_get_db(sample_db))
+        rc = B.run(db_path=sample_db)
+        assert rc == 0
+
+        spool_file = env["spool"] / "current.log"
+        lines = spool_file.read_text().strip().splitlines()
+        # Find message-level events (prompt or assistant-turn)
+        message_events = []
+        for line in lines:
+            ev = C.parse_line(line)
+            if ev and ev["kind"] in ("prompt", "assistant-turn"):
+                message_events.append(ev)
+
+        # ses_001: user msg + assistant msg = 2 events
+        # ses_002: user msg = 1 event
+        assert len(message_events) >= 3
+
+        sessions = {ev["session"] for ev in message_events}
+        assert "ses_001" in sessions
+        assert "ses_002" in sessions
+
+
+# --------------------------------------------------------------------------- #
+# test_backfill_idempotent
+# --------------------------------------------------------------------------- #
+class TestBackfillIdempotent:
+    def test_running_twice_same_events(self, sample_db, env, monkeypatch):
+        monkeypatch.setattr(S, "get_db", _mock_get_db(sample_db))
+
+        # First backfill
+        B.run(db_path=sample_db)
+        spool_file = env["spool"] / "current.log"
+        lines1 = spool_file.read_text().strip().splitlines()
+        assert len(lines1) > 0
+
+        # Second backfill — state is cleared again, same events emitted
+        # (spool appends, so we verify the SAME events are emitted, not same count)
+        B.run(db_path=sample_db)
+        lines2 = spool_file.read_text().strip().splitlines()
+        assert len(lines2) == len(lines1) * 2  # doubled due to append
+
+        # Verify the second batch matches the first
+        first_batch = lines1
+        second_batch = lines2[len(lines1):]
+        assert first_batch == second_batch
+
+    def test_state_cleared_between_runs(self, sample_db, env, monkeypatch):
+        monkeypatch.setattr(S, "get_db", _mock_get_db(sample_db))
+
+        # First run populates state
+        B.run(db_path=sample_db)
+        assert (env["tmp_path"] / "tailer-state.json").exists()
+        assert (env["tmp_path"] / "session-state.json").exists()
+
+        # Second run: state cleared → re-emitted
+        B.run(db_path=sample_db)
+        # State files re-created after second run
+        assert (env["tmp_path"] / "tailer-state.json").exists()
+        assert (env["tmp_path"] / "session-state.json").exists()
+
+
+# --------------------------------------------------------------------------- #
+# test_backfill_with_empty_db
+# --------------------------------------------------------------------------- #
+class TestBackfillWithEmptyDb:
+    def test_empty_db_no_crash(self, tmp_path, env, monkeypatch):
+        db_path = tmp_path / "empty.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""CREATE TABLE session (
+            id TEXT PRIMARY KEY, project_id TEXT, workspace_id TEXT, parent_id TEXT,
+            slug TEXT, directory TEXT, path TEXT, title TEXT, version TEXT,
+            share_url TEXT, summary_additions INTEGER, summary_deletions INTEGER,
+            summary_files INTEGER, summary_diffs TEXT, metadata TEXT,
+            cost REAL, tokens_input INTEGER, tokens_output INTEGER,
+            tokens_reasoning INTEGER, tokens_cache_read INTEGER,
+            tokens_cache_write INTEGER, revert TEXT, permission TEXT,
+            agent TEXT, model TEXT,
+            time_created INTEGER, time_updated INTEGER,
+            time_compacting INTEGER, time_archived INTEGER
+        )""")
+        conn.execute("""CREATE TABLE message (
+            id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER,
+            time_updated INTEGER, data TEXT
+        )""")
+        conn.execute("""CREATE TABLE part (
+            id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT,
+            time_created INTEGER, time_updated INTEGER, data TEXT
+        )""")
+        conn.commit()
+        conn.close()
+
+        monkeypatch.setattr(S, "get_db", _mock_get_db(db_path))
+        rc = B.run(db_path=db_path)
+        assert rc == 0
+
+        spool_file = env["spool"] / "current.log"
+        if spool_file.exists():
+            lines = spool_file.read_text().strip().splitlines()
+            assert len(lines) == 0
+
+    def test_nonexistent_db(self, tmp_path, env, monkeypatch):
+        monkeypatch.setattr(S, "get_db", _mock_get_db(tmp_path / "nonexistent.db"))
+        rc = B.run(db_path=tmp_path / "nonexistent.db")
+        assert rc == 0

--- a/scripts/collector/opencode/tests/test_cli.py
+++ b/scripts/collector/opencode/tests/test_cli.py
@@ -1,0 +1,285 @@
+"""Tests for opencode/__main__.py — CLI entry point.
+
+Run: python -m pytest scripts/collector/opencode/tests/test_cli.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+COLLECTOR = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(COLLECTOR))
+KEYLOG = COLLECTOR / "keylog"
+sys.path.insert(0, str(KEYLOG))
+OPENCODE = COLLECTOR / "opencode"
+sys.path.insert(0, str(OPENCODE))
+
+import _shared as S  # noqa: E402
+import tailer as T  # noqa: E402
+import session_tailer as ST  # noqa: E402
+
+# Import __main__ via importlib to avoid pytest's own __main__ module conflict
+_spec = importlib.util.spec_from_file_location("opencode_main", str(OPENCODE / "__main__.py"))
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+M = _mod
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    spool = tmp_path / "spool"
+    spool.mkdir()
+    monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(spool))
+    monkeypatch.setenv("OPENCODE_TAILER_STATE", str(tmp_path / "tailer-state.json"))
+    monkeypatch.setenv("OPENCODE_SESSION_STATE", str(tmp_path / "session-state.json"))
+    return {"spool": spool, "tmp_path": tmp_path}
+
+
+@pytest.fixture
+def sample_db(tmp_path):
+    db_path = tmp_path / "opencode-stable.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""CREATE TABLE session (
+        id TEXT PRIMARY KEY, project_id TEXT, workspace_id TEXT, parent_id TEXT,
+        slug TEXT, directory TEXT, path TEXT, title TEXT, version TEXT,
+        share_url TEXT, summary_additions INTEGER, summary_deletions INTEGER,
+        summary_files INTEGER, summary_diffs TEXT, metadata TEXT,
+        cost REAL, tokens_input INTEGER, tokens_output INTEGER,
+        tokens_reasoning INTEGER, tokens_cache_read INTEGER,
+        tokens_cache_write INTEGER, revert TEXT, permission TEXT,
+        agent TEXT, model TEXT,
+        time_created INTEGER, time_updated INTEGER,
+        time_compacting INTEGER, time_archived INTEGER
+    )""")
+    conn.execute("""CREATE TABLE message (
+        id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER,
+        time_updated INTEGER, data TEXT
+    )""")
+    conn.execute("""CREATE TABLE part (
+        id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT,
+        time_created INTEGER, time_updated INTEGER, data TEXT
+    )""")
+
+    conn.execute(
+        """INSERT INTO session (
+            id, project_id, workspace_id, parent_id, slug, directory, path,
+            title, version, share_url, summary_additions, summary_deletions,
+            summary_files, summary_diffs, metadata, cost, tokens_input,
+            tokens_output, tokens_reasoning, tokens_cache_read,
+            tokens_cache_write, revert, permission, agent, model,
+            time_created, time_updated
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            "ses_001", "proj_a", "ws_1", None, "my-repo",
+            "/home/zach/workspace/my-repo", None, "Test session",
+            "1.0.0", None, 10, 5, 3, None, None, 0.05,
+            1000, 500, 200, 300, 100,
+            None, None, "build",
+            '{"id":"deepseek/deepseek-v4-flash","providerID":"openrouter"}',
+            1700000000000, 1700000060000,
+        ),
+    )
+    conn.execute(
+        """INSERT INTO session (
+            id, project_id, workspace_id, parent_id, slug, directory, path,
+            title, version, share_url, summary_additions, summary_deletions,
+            summary_files, summary_diffs, metadata, cost, tokens_input,
+            tokens_output, tokens_reasoning, tokens_cache_read,
+            tokens_cache_write, revert, permission, agent, model,
+            time_created, time_updated
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            "ses_002", "proj_b", "ws_1", None, "another-repo",
+            "/home/zach/workspace/another-repo", None, "Second session",
+            "1.0.0", None, 0, 0, 0, None, None, 0.01,
+            200, 100, 0, 50, 50,
+            None, None, "build",
+            '{"id":"gpt-4o","providerID":"openai"}',
+            1700001000000, 1700001030000,
+        ),
+    )
+
+    # User message for ses_001
+    conn.execute(
+        "INSERT INTO message VALUES (?,?,?,?,?)",
+        (
+            "msg_001", "ses_001", 1700000001000, 1700000001000,
+            json.dumps({"role": "user", "time": {"created": 1700000001000}, "agent": "build"}),
+        ),
+    )
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_001", "msg_001", "ses_001", 1700000001000, 1700000001000,
+            json.dumps({"type": "text", "text": "Hello, please help me."}),
+        ),
+    )
+    # Assistant message for ses_001
+    conn.execute(
+        "INSERT INTO message VALUES (?,?,?,?,?)",
+        (
+            "msg_002", "ses_001", 1700000002000, 1700000003000,
+            json.dumps({
+                "role": "assistant", "time": {"created": 1700000002000, "completed": 1700000003000},
+                "agent": "build",
+                "model": {"providerID": "openrouter", "modelID": "deepseek-v4-flash"},
+                "cost": 0.001, "tokens": {"input": 500, "output": 100, "reasoning": 50},
+            }),
+        ),
+    )
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_002", "msg_002", "ses_001", 1700000002100, 1700000003000,
+            json.dumps({"type": "text", "text": "Here is the solution."}),
+        ),
+    )
+
+    # User message for ses_002
+    conn.execute(
+        "INSERT INTO message VALUES (?,?,?,?,?)",
+        (
+            "msg_s2_001", "ses_002", 1700001001000, 1700001001000,
+            json.dumps({"role": "user", "time": {"created": 1700001001000}, "agent": "build"}),
+        ),
+    )
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_s2_001", "msg_s2_001", "ses_002", 1700001001000, 1700001001000,
+            json.dumps({"type": "text", "text": "Do something in the other repo"}),
+        ),
+    )
+
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _mock_get_db(sample_db):
+    """Return a mock get_db that returns writable connections."""
+    def mock_get_db(path=None):
+        db = path or sample_db
+        if db is None or not db.exists():
+            return None
+        conn = sqlite3.connect(str(db))
+        conn.row_factory = sqlite3.Row
+        return conn
+    return mock_get_db
+
+
+# --------------------------------------------------------------------------- #
+# test_main_runs_all
+# --------------------------------------------------------------------------- #
+class TestMainRunsAll:
+    def test_both_tailers_execute(self, sample_db, env, monkeypatch):
+        monkeypatch.setattr(S, "get_db", _mock_get_db(sample_db))
+        rc = M.run(["--mode", "all", "--db", str(sample_db)])
+        assert rc == 0
+        spool_file = env["spool"] / "current.log"
+        lines = spool_file.read_text().strip().splitlines()
+        # Should have session summaries + message events
+        assert len(lines) > 0
+
+
+# --------------------------------------------------------------------------- #
+# test_main_runs_tailer_only
+# --------------------------------------------------------------------------- #
+class TestMainRunsTailerOnly:
+    def test_only_message_tailer(self, sample_db, env, monkeypatch):
+        monkeypatch.setattr(S, "get_db", _mock_get_db(sample_db))
+        rc = M.run(["--mode", "tailer", "--db", str(sample_db)])
+        assert rc == 0
+        spool_file = env["spool"] / "current.log"
+        lines = spool_file.read_text().strip().splitlines()
+        assert len(lines) > 0
+
+
+# --------------------------------------------------------------------------- #
+# test_main_runs_session_only
+# --------------------------------------------------------------------------- #
+class TestMainRunsSessionOnly:
+    def test_only_session_tailer(self, sample_db, env, monkeypatch):
+        monkeypatch.setattr(S, "get_db", _mock_get_db(sample_db))
+        rc = M.run(["--mode", "session", "--db", str(sample_db)])
+        assert rc == 0
+        spool_file = env["spool"] / "current.log"
+        lines = spool_file.read_text().strip().splitlines()
+        assert len(lines) >= 2  # at least 2 sessions
+
+
+# --------------------------------------------------------------------------- #
+# test_backfill_clears_state
+# --------------------------------------------------------------------------- #
+class TestBackfillClearsState:
+    def test_state_files_cleared_before_run(self, sample_db, env, monkeypatch):
+        monkeypatch.setattr(S, "get_db", _mock_get_db(sample_db))
+        # Write some state first
+        T.save_state(Path(env["tmp_path"] / "tailer-state.json"), {"seen": ["a"]})
+        ST.save_state(Path(env["tmp_path"] / "session-state.json"), {"ses_old": "sig"})
+
+        assert (env["tmp_path"] / "tailer-state.json").exists()
+        assert (env["tmp_path"] / "session-state.json").exists()
+
+        rc = M.run(["--backfill", "--db", str(sample_db)])
+        assert rc == 0
+
+        # State files re-created by tailers after emission
+        assert (env["tmp_path"] / "tailer-state.json").exists()
+        assert (env["tmp_path"] / "session-state.json").exists()
+
+        # Verify old state was cleared — new state should contain actual session IDs
+        tailer_state = T.load_state(Path(env["tmp_path"] / "tailer-state.json"))
+        assert "a" not in tailer_state  # old garbage cleared
+
+
+# --------------------------------------------------------------------------- #
+# test_dry_run_prints
+# --------------------------------------------------------------------------- #
+class TestDryRunPrints:
+    def test_dry_run_outputs_json(self, sample_db, env, monkeypatch, capsys):
+        monkeypatch.setattr(S, "get_db", _mock_get_db(sample_db))
+        rc = M.run(["--dry-run", "--db", str(sample_db)])
+        assert rc == 0
+        captured = capsys.readouterr()
+        lines = [l for l in captured.out.strip().splitlines() if l and not l.startswith("dry-run:")]
+        assert len(lines) > 0
+        for line in lines:
+            ev = json.loads(line)
+            assert "source" in ev
+            assert "kind" in ev
+
+    def test_dry_run_with_mode(self, sample_db, env, monkeypatch, capsys):
+        monkeypatch.setattr(S, "get_db", _mock_get_db(sample_db))
+        rc = M.run(["--dry-run", "--mode", "tailer", "--db", str(sample_db)])
+        assert rc == 0
+        captured = capsys.readouterr()
+        lines = [l for l in captured.out.strip().splitlines() if l and not l.startswith("dry-run:")]
+        assert len(lines) > 0
+
+
+# --------------------------------------------------------------------------- #
+# test_custom_db_path
+# --------------------------------------------------------------------------- #
+class TestCustomDbPath:
+    def test_db_flag_passed_to_tailer(self, sample_db, env, monkeypatch):
+        monkeypatch.setattr(S, "get_db", _mock_get_db(sample_db))
+        rc = M.run(["--db", str(sample_db)])
+        assert rc == 0
+
+    def test_nonexistent_db(self, tmp_path, env, monkeypatch, capsys):
+        # Non-existent DB should not crash, just print message
+        rc = M.run(["--db", str(tmp_path / "nonexistent.db"), "--dry-run"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "no OpenCode DB found" in captured.out

--- a/scripts/collector/opencode/tests/test_plugin.py
+++ b/scripts/collector/opencode/tests/test_plugin.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Tests for the OpenCode activity plugin.
+
+Covers:
+  - State file round-trip and ring-buffer pruning (shell-level via node)
+  - Emit round-trip: plugin calls emit → collector.parse_line succeeds
+  - Deploy script: creates plugins dir and symlink
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Import collector for parse_line
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+import collector as C  # noqa: E402
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+PLUGIN_JS = SCRIPT_DIR / "activity-plugin.js"
+DEPLOY_SH = SCRIPT_DIR / "deploy-plugin.sh"
+EMIT = SCRIPT_DIR.parent / "emit"
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def run_node(code: str, *, env: dict | None = None, cwd: str | None = None) -> subprocess.CompletedProcess:
+    """Run a Node.js one-liner and return the CompletedProcess."""
+    base_env = dict(os.environ)
+    if env:
+        base_env.update(env)
+    return subprocess.run(
+        ["node", "--input-type=module", "-e", code],
+        capture_output=True, text=True, env=base_env, cwd=cwd, timeout=10,
+    )
+
+
+def write_mock_emit(path: Path, log_file: Path) -> None:
+    """Write a mock `emit` script that records its arguments to log_file."""
+    path.write_text(
+        f'#!/usr/bin/env bash\necho "$@" >> "{log_file}"\nexit 0\n',
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+# --------------------------------------------------------------------------- #
+# State round-trip + ring buffer (JS logic, tested via node)
+# --------------------------------------------------------------------------- #
+
+def test_state_file_roundtrip(tmp_path):
+    """Write state JSON, read it back, verify contents."""
+    state_file = tmp_path / "state.json"
+    state_file.write_text(
+        json.dumps({"version": 1, "seen": ["a", "b", "c"]}),
+        encoding="utf-8",
+    )
+    data = json.loads(state_file.read_text(encoding="utf-8"))
+    assert data["version"] == 1
+    assert data["seen"] == ["a", "b", "c"]
+
+
+def test_state_ring_buffer():
+    """Add 1100 IDs to state, verify oldest 100 are pruned (keeps last 1000)."""
+    code = '''
+import { readFileSync, writeFileSync } from "fs";
+const MAX_SEEN = 1000;
+let seen = [];
+for (let i = 0; i < 1100; i++) seen.push("msg_" + i);
+// Ring buffer logic (mirrors plugin)
+const trimmed = seen.slice(-MAX_SEEN);
+const state = JSON.stringify({ version: 1, seen: trimmed });
+const parsed = JSON.parse(state);
+console.log(JSON.stringify({ count: parsed.seen.length, first: parsed.seen[0], last: parsed.seen[parsed.seen.length - 1] }));
+'''
+    result = run_node(code)
+    assert result.returncode == 0, result.stderr
+    out = json.loads(result.stdout.strip())
+    assert out["count"] == 1000
+    assert out["first"] == "msg_100"  # first 100 pruned
+    assert out["last"] == "msg_1099"
+
+
+# --------------------------------------------------------------------------- #
+# Emit round-trip: plugin emitEvent → collector.parse_line
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.skipif(not EMIT.exists(), reason="emit script missing")
+def test_plugin_emit_roundtrip(tmp_path):
+    """Use the real emit to write a v1 line, then parse_line to verify fields."""
+    spool = tmp_path / "spool"
+    spool.mkdir()
+    text = "hello from opencode plugin 你好"
+    project = "my-project"
+    cwd = "/tmp/test-dir"
+    session = "sess-123"
+    payload = json.dumps({"agent": "code", "model": "gpt-4"})
+
+    env = dict(os.environ, ACTIVITY_SPOOL_DIR=str(spool))
+    # Build emit args the same way the JS plugin would
+    rc = subprocess.run(
+        [
+            "bash", str(EMIT),
+            "source=opencode", "kind=session-create",
+            f"b64:text={text}", f"b64:project={project}",
+            f"b64:cwd={cwd}", f"b64:session={session}",
+            "b64:app=opencode", f"b64:payload={payload}",
+        ],
+        env=env, capture_output=True, text=True,
+    )
+    assert rc.returncode == 0, rc.stderr
+
+    lines = [l for l in (spool / "current.log").read_text().splitlines() if l]
+    assert len(lines) == 1
+
+    ev = C.parse_line(lines[0])
+    assert ev is not None
+    assert ev["source"] == "opencode"
+    assert ev["kind"] == "session-create"
+    assert ev["text"] == text
+    assert ev["project"] == project
+    assert ev["cwd"] == cwd
+    assert ev["session"] == session
+    assert ev["app"] == "opencode"
+    pl = json.loads(ev["payload"])
+    assert pl["agent"] == "code"
+    assert pl["model"] == "gpt-4"
+    # ts auto-filled by emit
+    assert "ts" in ev
+
+
+@pytest.mark.skipif(not EMIT.exists(), reason="emit script missing")
+def test_plugin_tool_call_emit_roundtrip(tmp_path):
+    """Simulate a tool-call event and verify parse_line."""
+    spool = tmp_path / "spool"
+    spool.mkdir()
+    payload = json.dumps({"duration_ms": 42, "success": True, "args_summary": '{"file":"test.js"'[:200]})
+
+    env = dict(os.environ, ACTIVITY_SPOOL_DIR=str(spool))
+    rc = subprocess.run(
+        [
+            "bash", str(EMIT),
+            "source=opencode", "kind=tool-call",
+            "b64:text=Edit",
+            "b64:session=sess-abc",
+            "b64:app=opencode",
+            f"b64:payload={payload}",
+        ],
+        env=env, capture_output=True, text=True,
+    )
+    assert rc.returncode == 0, rc.stderr
+
+    ev = C.parse_line((spool / "current.log").read_text().splitlines()[0])
+    assert ev["kind"] == "tool-call"
+    assert ev["text"] == "Edit"
+    pl = json.loads(ev["payload"])
+    assert pl["duration_ms"] == 42
+    assert pl["success"] is True
+
+
+# --------------------------------------------------------------------------- #
+# Deploy script
+# --------------------------------------------------------------------------- #
+
+def test_deploy_creates_symlink(tmp_path):
+    """Deploy script creates the plugins dir and symlinks activity.js."""
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+    plugins_dir = fake_home / ".config" / "opencode" / "plugins"
+
+    env = dict(os.environ, HOME=str(fake_home))
+    rc = subprocess.run(
+        ["bash", str(DEPLOY_SH)],
+        env=env, capture_output=True, text=True, timeout=5,
+    )
+    assert rc.returncode == 0, rc.stderr
+    assert plugins_dir.is_dir()
+
+    link = plugins_dir / "activity.js"
+    assert link.is_symlink()
+    assert link.resolve() == PLUGIN_JS.resolve()
+
+
+def test_deploy_idempotent(tmp_path):
+    """Running deploy twice doesn't error and the symlink is correct."""
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+
+    env = dict(os.environ, HOME=str(fake_home))
+    for _ in range(2):
+        rc = subprocess.run(
+            ["bash", str(DEPLOY_SH)],
+            env=env, capture_output=True, text=True, timeout=5,
+        )
+        assert rc.returncode == 0, rc.stderr
+
+    link = fake_home / ".config" / "opencode" / "plugins" / "activity.js"
+    assert link.is_symlink()
+    assert link.resolve() == PLUGIN_JS.resolve()
+
+
+def test_deploy_removes_stale_regular_file(tmp_path):
+    """If a regular file exists at the link target, deploy replaces it with a symlink."""
+    fake_home = tmp_path / "fakehome"
+    plugins_dir = fake_home / ".config" / "opencode" / "plugins"
+    plugins_dir.mkdir(parents=True)
+    stale = plugins_dir / "activity.js"
+    stale.write_text("stale content", encoding="utf-8")
+    assert stale.is_file()
+
+    env = dict(os.environ, HOME=str(fake_home))
+    rc = subprocess.run(
+        ["bash", str(DEPLOY_SH)],
+        env=env, capture_output=True, text=True, timeout=5,
+    )
+    assert rc.returncode == 0, rc.stderr
+    link = plugins_dir / "activity.js"
+    assert link.is_symlink()
+    assert link.resolve() == PLUGIN_JS.resolve()
+
+
+# --------------------------------------------------------------------------- #
+# Plugin JS: emitEvent with mock emit
+# --------------------------------------------------------------------------- #
+
+def test_emit_event_calls_emit_cli(tmp_path):
+    """Verify the JS emitEvent helper calls emit with the correct arguments."""
+    mock_emit = tmp_path / "emit"
+    log_file = tmp_path / "emit.log"
+    write_mock_emit(mock_emit, log_file)
+
+    code = f'''
+import {{ readFileSync }} from "fs";
+
+// Inline emitEvent (mirrors plugin logic)
+const EMIT = "{mock_emit}";
+const LOG = "{log_file}";
+
+import {{ execSync }} from "child_process";
+
+function emitEvent({{ kind, text, project, cwd, session, app, payload }}) {{
+  const args = ["source=opencode", `kind=${{kind}}`];
+  if (text != null) args.push(`b64:text=${{String(text)}}`);
+  if (project != null) args.push(`b64:project=${{String(project)}}`);
+  if (cwd != null) args.push(`b64:cwd=${{String(cwd)}}`);
+  if (session != null) args.push(`b64:session=${{String(session)}}`);
+  if (app != null) args.push(`b64:app=${{String(app)}}`);
+  if (payload != null) {{
+    const p = typeof payload === "string" ? payload : JSON.stringify(payload);
+    args.push(`b64:payload=${{p}}`);
+  }}
+  execSync(`${{EMIT}} ${{args.join(" ")}}`, {{ stdio: "ignore" }});
+}}
+
+emitEvent({{
+  kind: "session-create",
+  text: "test session",
+  project: "my-proj",
+  cwd: "/tmp",
+  session: "s1",
+  app: "opencode",
+  payload: {{"agent":"code"}},
+}});
+'''
+    result = run_node(code)
+    assert result.returncode == 0, result.stderr
+
+    log_content = log_file.read_text(encoding="utf-8").strip()
+    assert "source=opencode" in log_content
+    assert "kind=session-create" in log_content
+    assert "b64:project=" in log_content
+    assert "b64:session=s1" in log_content
+    assert "b64:app=opencode" in log_content
+
+
+def test_emit_event_error_swallowed(tmp_path):
+    """If emit binary doesn't exist, emitEvent should not throw."""
+    code = '''
+import { execSync } from "child_process";
+
+function emitEvent({ kind }) {
+  try {
+    execSync("/nonexistent/emit kind=" + kind, { stdio: "ignore", timeout: 2000 });
+  } catch {
+    // swallowed
+  }
+}
+
+emitEvent({ kind: "test" });
+console.log("ok");
+'''
+    result = run_node(code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout

--- a/scripts/collector/opencode/tests/test_schema.py
+++ b/scripts/collector/opencode/tests/test_schema.py
@@ -1,0 +1,104 @@
+"""Tests for opencode/schema.py — schema detection.
+
+Run: python -m pytest scripts/collector/opencode/tests/test_schema.py -v
+"""
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+COLLECTOR = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(COLLECTOR))
+OPENCODE = COLLECTOR / "opencode"
+sys.path.insert(0, str(OPENCODE))
+
+import _shared as S  # noqa: E402
+from schema import SchemaInfo, TableInfo, detect_schema  # noqa: E402
+
+
+def _make_db(tmp_path, tables: dict[str, list[str]] | None = None) -> Path:
+    """Create a temporary DB with specified tables and columns."""
+    db_path = tmp_path / "schema_test.db"
+    conn = sqlite3.connect(db_path)
+    if tables is None:
+        tables = {
+            "session": [
+                "id", "project_id", "directory", "title", "version", "cost",
+                "tokens_input", "tokens_output", "tokens_reasoning",
+                "tokens_cache_read", "tokens_cache_write", "agent", "model",
+                "time_created", "time_updated", "parent_id",
+            ],
+            "message": ["id", "session_id", "time_created", "time_updated", "data"],
+            "part": ["id", "message_id", "session_id", "time_created", "time_updated", "data"],
+            "project": ["id", "worktree", "name", "time_created", "time_updated"],
+        }
+    for table, cols in tables.items():
+        col_defs = ", ".join(f"{c} TEXT" for c in cols)
+        conn.execute(f"CREATE TABLE {table} ({col_defs})")
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+class TestDetectSchema:
+    def test_full_schema(self, tmp_path):
+        db_path = _make_db(tmp_path)
+        conn = S.get_db(db_path)
+        try:
+            info = detect_schema(conn)
+            assert info is not None
+            assert info.session is not None
+            assert info.message is not None
+            assert info.part is not None
+            assert info.project is not None
+            assert "id" in info.session.columns
+            assert "project_id" in info.session.columns
+            assert "time_created" in info.session.columns
+        finally:
+            conn.close()
+
+    def test_missing_table_detected(self, tmp_path):
+        tables = {
+            "session": ["id", "project_id", "time_created"],
+            "message": ["id", "session_id", "data"],
+            # part table missing
+        }
+        db_path = _make_db(tmp_path, tables)
+        conn = S.get_db(db_path)
+        try:
+            info = detect_schema(conn)
+            assert info is not None
+            assert info.session is not None
+            assert info.message is not None
+            assert info.part is None  # table doesn't exist
+            assert any("missing table: part" in d for d in info.drift)
+        finally:
+            conn.close()
+
+    def test_empty_db_no_tables(self, tmp_path):
+        db_path = tmp_path / "empty.db"
+        conn = sqlite3.connect(db_path)
+        conn.close()
+        conn2 = S.get_db(db_path)
+        try:
+            info = detect_schema(conn2)
+            assert info is not None
+            # All tables missing → None for each
+            assert info.session is None
+            assert info.message is None
+            assert info.part is None
+            assert info.project is None
+            assert len(info.drift) == 4
+        finally:
+            conn2.close()
+
+    def test_table_info_dataclass(self):
+        ti = TableInfo(name="session", columns=["id", "name"])
+        assert ti.name == "session"
+        assert len(ti.columns) == 2
+
+    def test_schema_info_dataclass(self):
+        si = SchemaInfo(drift=["test drift"])
+        assert si.session is None
+        assert si.drift == ["test drift"]

--- a/scripts/collector/opencode/tests/test_session_tailer.py
+++ b/scripts/collector/opencode/tests/test_session_tailer.py
@@ -1,0 +1,759 @@
+"""Tests for opencode/session_tailer.py — session rollup and tailer.
+
+Run: python -m pytest scripts/collector/opencode/tests/test_session_tailer.py -v
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Ensure the collector parent is on sys.path for collector.parse_line
+COLLECTOR = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(COLLECTOR))
+# Also add keylog for spool_emit import
+KEYLOG = COLLECTOR / "keylog"
+sys.path.insert(0, str(KEYLOG))
+# And the opencode dir itself
+OPENCODE = COLLECTOR / "opencode"
+sys.path.insert(0, str(OPENCODE))
+
+import _shared as S  # noqa: E402
+import collector as C  # noqa: E402
+import session_tailer as T  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """Set up isolated env dirs for tests."""
+    spool = tmp_path / "spool"
+    spool.mkdir()
+    monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(spool))
+    return {"spool": spool}
+
+
+@pytest.fixture
+def sample_db(tmp_path):
+    """Create a temporary SQLite DB with the real OpenCode schema and test data."""
+    db_path = tmp_path / "opencode-stable.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""CREATE TABLE session (
+        id TEXT PRIMARY KEY, project_id TEXT, workspace_id TEXT, parent_id TEXT,
+        slug TEXT, directory TEXT, path TEXT, title TEXT, version TEXT,
+        share_url TEXT, summary_additions INTEGER, summary_deletions INTEGER,
+        summary_files INTEGER, summary_diffs TEXT, metadata TEXT,
+        cost REAL, tokens_input INTEGER, tokens_output INTEGER,
+        tokens_reasoning INTEGER, tokens_cache_read INTEGER,
+        tokens_cache_write INTEGER, revert TEXT, permission TEXT,
+        agent TEXT, model TEXT,
+        time_created INTEGER, time_updated INTEGER,
+        time_compacting INTEGER, time_archived INTEGER
+    )""")
+    conn.execute("""CREATE TABLE message (
+        id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER,
+        time_updated INTEGER, data TEXT
+    )""")
+    conn.execute("""CREATE TABLE part (
+        id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT,
+        time_created INTEGER, time_updated INTEGER, data TEXT
+    )""")
+
+    # Session 1: typical session with 60s duration, cost 0.05
+    conn.execute(
+        """INSERT INTO session (
+            id, project_id, workspace_id, parent_id, slug, directory, path,
+            title, version, share_url, summary_additions, summary_deletions,
+            summary_files, summary_diffs, metadata, cost, tokens_input,
+            tokens_output, tokens_reasoning, tokens_cache_read,
+            tokens_cache_write, revert, permission, agent, model,
+            time_created, time_updated
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            "ses_001", "proj_a", "ws_1", None, "my-repo",
+            "/home/zach/workspace/my-repo", None, "Test session",
+            "1.0.0", None, 10, 5, 3, None, None, 0.05,
+            1000, 500, 200, 300, 100,
+            None, None, "build",
+            '{"id":"deepseek/deepseek-v4-flash","providerID":"openrouter"}',
+            1700000000000, 1700000060000,
+        ),
+    )
+
+    # Session 2: empty session (no messages)
+    conn.execute(
+        """INSERT INTO session (
+            id, project_id, workspace_id, parent_id, slug, directory, path,
+            title, version, share_url, summary_additions, summary_deletions,
+            summary_files, summary_diffs, metadata, cost, tokens_input,
+            tokens_output, tokens_reasoning, tokens_cache_read,
+            tokens_cache_write, revert, permission, agent, model,
+            time_created, time_updated
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            "ses_002", "proj_a", "ws_1", None, "empty-repo",
+            "/home/zach/workspace/empty-repo", None, "Empty session",
+            "1.0.0", None, 0, 0, 0, None, None, 0.0,
+            0, 0, 0, 0, 0,
+            None, None, "build",
+            '{"id":"gpt-4o","providerID":"openai"}',
+            1700001000000, 1700001030000,
+        ),
+    )
+
+    # --- Messages for ses_001 ---
+    # User message
+    conn.execute(
+        "INSERT INTO message VALUES (?,?,?,?,?)",
+        (
+            "msg_001", "ses_001", 1700000001000, 1700000001000,
+            json.dumps({
+                "role": "user",
+                "time": {"created": 1700000001000},
+                "agent": "build",
+                "model": {"providerID": "openrouter", "modelID": "deepseek/deepseek-v4-flash"},
+            }),
+        ),
+    )
+    # Assistant message
+    conn.execute(
+        "INSERT INTO message VALUES (?,?,?,?,?)",
+        (
+            "msg_002", "ses_001", 1700000002000, 1700000003000,
+            json.dumps({
+                "role": "assistant",
+                "time": {"created": 1700000002000, "completed": 1700000003000},
+                "agent": "build",
+                "model": {"providerID": "openrouter", "modelID": "deepseek/deepseek-v4-flash"},
+                "cost": 0.001,
+                "tokens": {"input": 500, "output": 100, "reasoning": 50},
+            }),
+        ),
+    )
+    # Second user message (to test multiple user messages)
+    conn.execute(
+        "INSERT INTO message VALUES (?,?,?,?,?)",
+        (
+            "msg_003", "ses_001", 1700000004000, 1700000004000,
+            json.dumps({
+                "role": "user",
+                "time": {"created": 1700000004000},
+                "agent": "build",
+            }),
+        ),
+    )
+
+    # --- Parts for ses_001 ---
+    # Text part (user message content)
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_001", "msg_001", "ses_001", 1700000001000, 1700000001000,
+            json.dumps({"type": "text", "text": "Hello, please help me."}),
+        ),
+    )
+    # Bash tool part (git commit)
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_002", "msg_002", "ses_001", 1700000002000, 1700000003000,
+            json.dumps({
+                "type": "tool", "tool": "bash",
+                "state": {"status": "completed"},
+                "command": "git commit -m 'feat: add feature'",
+            }),
+        ),
+    )
+    # Bash tool part (git push)
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_003", "msg_002", "ses_001", 1700000002100, 1700000003000,
+            json.dumps({
+                "type": "tool", "tool": "bash",
+                "state": {"status": "completed"},
+                "command": "git push origin main",
+            }),
+        ),
+    )
+    # Edit tool part (Python file)
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_004", "msg_002", "ses_001", 1700000002200, 1700000003000,
+            json.dumps({
+                "type": "tool", "tool": "edit",
+                "state": {"status": "completed"},
+                "file_path": "/home/zach/workspace/my-repo/src/main.py",
+            }),
+        ),
+    )
+    # Edit tool part (TypeScript file)
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_005", "msg_002", "ses_001", 1700000002300, 1700000003000,
+            json.dumps({
+                "type": "tool", "tool": "edit",
+                "state": {"status": "completed"},
+                "file_path": "/home/zach/workspace/my-repo/src/app.ts",
+            }),
+        ),
+    )
+    # Bash tool part with error
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_006", "msg_002", "ses_001", 1700000002400, 1700000003000,
+            json.dumps({
+                "type": "tool", "tool": "bash",
+                "state": {"status": "error", "error": "command not found: xyz"},
+            }),
+        ),
+    )
+    # MCP tool part
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_007", "msg_002", "ses_001", 1700000002500, 1700000003000,
+            json.dumps({
+                "type": "tool", "tool": "mcp__github__list_issues",
+                "state": {"status": "completed"},
+            }),
+        ),
+    )
+    # Text part (assistant response)
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_008", "msg_002", "ses_001", 1700000002600, 1700000003000,
+            json.dumps({"type": "text", "text": "Here is the solution."}),
+        ),
+    )
+
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+# --------------------------------------------------------------------------- #
+# build_rollup — typical session
+# --------------------------------------------------------------------------- #
+class TestBuildRollupTypical:
+    def test_all_fields_populated(self, sample_db):
+        conn = sqlite3.connect(str(sample_db))
+        conn.row_factory = sqlite3.Row
+        try:
+            sessions = list(S.iter_sessions(conn))
+            session = sessions[0]  # ses_001
+            messages = list(S.iter_messages(conn, session["id"]))
+            all_parts = []
+            for msg in messages:
+                all_parts.extend(S.iter_parts(conn, msg["id"]))
+
+            rollup = T.build_rollup(session, messages, all_parts)
+
+            assert rollup["cost"] == 0.05
+            assert rollup["input_tokens"] == 1000
+            assert rollup["output_tokens"] == 500
+            assert rollup["reasoning_tokens"] == 200
+            assert rollup["cache_read_tokens"] == 300
+            assert rollup["cache_write_tokens"] == 100
+            assert rollup["start_ts"] == "2023-11-14 22:13:20.000"
+            assert rollup["end_ts"] == "2023-11-14 22:14:20.000"
+            assert rollup["duration_minutes"] == 1.0
+            assert rollup["unreadable"] is False
+            assert rollup["models"] == ["deepseek/deepseek-v4-flash"]
+        finally:
+            conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# build_rollup — empty messages
+# --------------------------------------------------------------------------- #
+class TestBuildRollupEmpty:
+    def test_unreadable_when_no_messages(self, sample_db):
+        conn = sqlite3.connect(str(sample_db))
+        conn.row_factory = sqlite3.Row
+        try:
+            sessions = list(S.iter_sessions(conn))
+            session = [s for s in sessions if s["id"] == "ses_002"][0]
+            messages = list(S.iter_messages(conn, session["id"]))
+            all_parts = []
+            for msg in messages:
+                all_parts.extend(S.iter_parts(conn, msg["id"]))
+
+            rollup = T.build_rollup(session, messages, all_parts)
+
+            assert rollup["unreadable"] is True
+            assert rollup["user_message_count"] == 0
+            assert rollup["assistant_message_count"] == 0
+        finally:
+            conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# build_rollup — tool counting
+# --------------------------------------------------------------------------- #
+class TestBuildRollupToolCounts:
+    def test_tool_counts(self, sample_db):
+        conn = sqlite3.connect(str(sample_db))
+        conn.row_factory = sqlite3.Row
+        try:
+            sessions = list(S.iter_sessions(conn))
+            session = sessions[0]
+            messages = list(S.iter_messages(conn, session["id"]))
+            all_parts = []
+            for msg in messages:
+                all_parts.extend(S.iter_parts(conn, msg["id"]))
+
+            rollup = T.build_rollup(session, messages, all_parts)
+
+            tc = rollup["tool_counts"]
+            assert tc["bash"] == 3  # git commit, git push, error bash
+            assert tc["edit"] == 2  # two edit parts
+            assert tc["mcp__github__list_issues"] == 1
+        finally:
+            conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# build_rollup — git detection
+# --------------------------------------------------------------------------- #
+class TestBuildRollupGit:
+    def test_git_commit_detected(self, sample_db):
+        conn = sqlite3.connect(str(sample_db))
+        conn.row_factory = sqlite3.Row
+        try:
+            sessions = list(S.iter_sessions(conn))
+            session = sessions[0]
+            messages = list(S.iter_messages(conn, session["id"]))
+            all_parts = []
+            for msg in messages:
+                all_parts.extend(S.iter_parts(conn, msg["id"]))
+
+            rollup = T.build_rollup(session, messages, all_parts)
+
+            assert rollup["git_commits"] == 1
+            assert rollup["git_pushes"] == 1
+        finally:
+            conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# build_rollup — language detection
+# --------------------------------------------------------------------------- #
+class TestBuildRollupLanguages:
+    def test_languages_from_edit_parts(self, sample_db):
+        conn = sqlite3.connect(str(sample_db))
+        conn.row_factory = sqlite3.Row
+        try:
+            sessions = list(S.iter_sessions(conn))
+            session = sessions[0]
+            messages = list(S.iter_messages(conn, session["id"]))
+            all_parts = []
+            for msg in messages:
+                all_parts.extend(S.iter_parts(conn, msg["id"]))
+
+            rollup = T.build_rollup(session, messages, all_parts)
+
+            assert rollup["languages"] == {"Python": 1, "TypeScript": 1}
+            assert rollup["files_modified"] == 2
+        finally:
+            conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# build_rollup — cost aggregation
+# --------------------------------------------------------------------------- #
+class TestBuildRollupCost:
+    def test_cost_from_session_data(self, sample_db):
+        conn = sqlite3.connect(str(sample_db))
+        conn.row_factory = sqlite3.Row
+        try:
+            sessions = list(S.iter_sessions(conn))
+            session = sessions[0]
+            messages = list(S.iter_messages(conn, session["id"]))
+            all_parts = []
+            for msg in messages:
+                all_parts.extend(S.iter_parts(conn, msg["id"]))
+
+            rollup = T.build_rollup(session, messages, all_parts)
+
+            assert rollup["cost"] == 0.05
+        finally:
+            conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# build_rollup — token aggregation
+# --------------------------------------------------------------------------- #
+class TestBuildRollupTokens:
+    def test_tokens_from_session_data(self, sample_db):
+        conn = sqlite3.connect(str(sample_db))
+        conn.row_factory = sqlite3.Row
+        try:
+            sessions = list(S.iter_sessions(conn))
+            session = sessions[0]
+            messages = list(S.iter_messages(conn, session["id"]))
+            all_parts = []
+            for msg in messages:
+                all_parts.extend(S.iter_parts(conn, msg["id"]))
+
+            rollup = T.build_rollup(session, messages, all_parts)
+
+            assert rollup["input_tokens"] == 1000
+            assert rollup["output_tokens"] == 500
+            assert rollup["reasoning_tokens"] == 200
+            assert rollup["cache_read_tokens"] == 300
+            assert rollup["cache_write_tokens"] == 100
+        finally:
+            conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# build_rollup — duration
+# --------------------------------------------------------------------------- #
+class TestBuildRollupDuration:
+    def test_duration_minutes(self, sample_db):
+        conn = sqlite3.connect(str(sample_db))
+        conn.row_factory = sqlite3.Row
+        try:
+            sessions = list(S.iter_sessions(conn))
+            session = sessions[0]
+            messages = list(S.iter_messages(conn, session["id"]))
+            all_parts = []
+            for msg in messages:
+                all_parts.extend(S.iter_parts(conn, msg["id"]))
+
+            rollup = T.build_rollup(session, messages, all_parts)
+
+            # time_updated - time_created = 60000 ms = 1 minute
+            assert rollup["duration_minutes"] == 1.0
+        finally:
+            conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# Signature / state persistence
+# --------------------------------------------------------------------------- #
+class TestSignature:
+    def test_signature_computed_from_session(self, sample_db):
+        conn = sqlite3.connect(str(sample_db))
+        conn.row_factory = sqlite3.Row
+        try:
+            sessions = list(S.iter_sessions(conn))
+            sig = T.signature(sessions[0])
+            assert sig == "1700000060000:0.05:1000"
+        finally:
+            conn.close()
+
+
+class TestStatePersistence:
+    def test_signature_unchanged_skip(self, sample_db, tmp_path):
+        state_file = tmp_path / "state.json"
+        conn = sqlite3.connect(str(sample_db))
+        conn.row_factory = sqlite3.Row
+        try:
+            sessions = list(S.iter_sessions(conn))
+            sig = T.signature(sessions[0])
+
+            # Save state with current signature
+            T.save_state(state_file, {sessions[0]["id"]: sig})
+
+            # Load and verify it matches
+            loaded = T.load_state(state_file)
+            assert loaded[sessions[0]["id"]] == sig
+
+            # If prev[sid] == sig, session should be skipped
+            prev = T.load_state(state_file)
+            assert prev.get(sessions[0]["id"]) == sig
+        finally:
+            conn.close()
+
+    def test_signature_changed_reemit(self, sample_db, tmp_path):
+        state_file = tmp_path / "state.json"
+        conn = sqlite3.connect(str(sample_db))
+        conn.row_factory = sqlite3.Row
+        try:
+            sessions = list(S.iter_sessions(conn))
+            old_sig = T.signature(sessions[0])
+
+            # Save with a different (old) signature
+            T.save_state(state_file, {sessions[0]["id"]: "old_sig"})
+
+            # Load and verify it differs
+            loaded = T.load_state(state_file)
+            assert loaded[sessions[0]["id"]] != old_sig
+        finally:
+            conn.close()
+
+    def test_new_session_emit(self, sample_db, tmp_path):
+        state_file = tmp_path / "state.json"
+        conn = sqlite3.connect(str(sample_db))
+        conn.row_factory = sqlite3.Row
+        try:
+            sessions = list(S.iter_sessions(conn))
+            sid = sessions[0]["id"]
+
+            # Empty state — no previous signatures
+            T.save_state(state_file, {})
+            loaded = T.load_state(state_file)
+            assert sid not in loaded
+        finally:
+            conn.close()
+
+    def test_deleted_session_pruned(self, sample_db, tmp_path):
+        state_file = tmp_path / "state.json"
+
+        # State has a session that no longer exists
+        T.save_state(state_file, {"ses_deleted": "old:0:0", "ses_001": "1700000060000:0.05:1000"})
+
+        conn = sqlite3.connect(str(sample_db))
+        conn.row_factory = sqlite3.Row
+        try:
+            seen = set()
+            for s in S.iter_sessions(conn):
+                seen.add(s["id"])
+
+            # Prune: keep only seen sessions
+            state = T.load_state(state_file)
+            pruned = {sid: sig for sid, sig in state.items() if sid in seen}
+            T.save_state(state_file, pruned)
+
+            final = T.load_state(state_file)
+            assert "ses_deleted" not in final
+            assert "ses_001" in final
+        finally:
+            conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# Checkpoint every 25 emits
+# --------------------------------------------------------------------------- #
+class TestCheckpoint:
+    def test_checkpoint_every_25(self):
+        assert T.CHECKPOINT_EVERY == 25
+
+
+# --------------------------------------------------------------------------- #
+# Full roundtrip: create DB → run() → read spool → parse_line → verify
+# --------------------------------------------------------------------------- #
+class TestFullRoundtrip:
+    def test_roundtrip_through_run(self, sample_db, env, monkeypatch):
+        """Create DB, run the tailer, verify events in spool parse correctly."""
+        monkeypatch.setenv("OPENCODE_SESSION_STATE", str(env["spool"] / "state.json"))
+
+        # Monkeypatch get_db to return a writable connection
+        def mock_get_db(path=None):
+            db = path or sample_db
+            if db is None or not db.exists():
+                return None
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            return conn
+
+        monkeypatch.setattr(S, "get_db", mock_get_db)
+
+        # Run the tailer
+        rc = T.run(db_path=sample_db)
+        assert rc == 0
+
+        # Read spool and parse events
+        spool_file = env["spool"] / "current.log"
+        assert spool_file.exists()
+        lines = spool_file.read_text().strip().splitlines()
+        assert len(lines) == 2  # ses_001 + ses_002
+
+        # Parse first event (ses_001)
+        ev1 = C.parse_line(lines[0])
+        assert ev1 is not None
+        assert ev1["source"] == "opencode"
+        assert ev1["kind"] == "session-summary"
+        assert ev1["session"] == "ses_001"
+        assert ev1["project"] == "my-repo"
+        assert ev1["app"] == "opencode"
+        # Verify payload is valid JSON
+        payload1 = json.loads(ev1["payload"])
+        assert payload1["cost"] == 0.05
+        assert payload1["input_tokens"] == 1000
+        assert payload1["tool_counts"]["bash"] == 3
+        assert payload1["git_commits"] == 1
+        assert payload1["git_pushes"] == 1
+        assert payload1["languages"]["Python"] == 1
+        assert payload1["languages"]["TypeScript"] == 1
+        assert payload1["files_modified"] == 2
+        assert payload1["unreadable"] is False
+        assert payload1["duration_minutes"] == 1.0
+
+        # Parse second event (ses_002 — empty session)
+        ev2 = C.parse_line(lines[1])
+        assert ev2 is not None
+        assert ev2["session"] == "ses_002"
+        payload2 = json.loads(ev2["payload"])
+        assert payload2["unreadable"] is True
+
+    def test_idempotent_rerun(self, sample_db, env, monkeypatch):
+        """Running twice should only emit once (signature unchanged)."""
+        monkeypatch.setenv("OPENCODE_SESSION_STATE", str(env["spool"] / "state.json"))
+
+        def mock_get_db(path=None):
+            db = path or sample_db
+            if db is None or not db.exists():
+                return None
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            return conn
+
+        monkeypatch.setattr(S, "get_db", mock_get_db)
+
+        # First run
+        T.run(db_path=sample_db)
+        spool_file = env["spool"] / "current.log"
+        lines1 = spool_file.read_text().strip().splitlines()
+        assert len(lines1) == 2
+
+        # Second run — should emit nothing new
+        T.run(db_path=sample_db)
+        lines2 = spool_file.read_text().strip().splitlines()
+        assert len(lines2) == 2  # no new lines appended
+
+
+# --------------------------------------------------------------------------- #
+# Integration with _shared.spool_emit — v1 line format
+# --------------------------------------------------------------------------- #
+class TestSpoolEmitIntegration:
+    def test_event_has_v1_format(self, sample_db, env, monkeypatch):
+        """Verify emitted lines are valid v1 format parseable by collector."""
+        monkeypatch.setenv("OPENCODE_SESSION_STATE", str(env["spool"] / "state.json"))
+
+        def mock_get_db(path=None):
+            db = path or sample_db
+            if db is None or not db.exists():
+                return None
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            return conn
+
+        monkeypatch.setattr(S, "get_db", mock_get_db)
+
+        T.run(db_path=sample_db)
+
+        spool_file = env["spool"] / "current.log"
+        lines = spool_file.read_text().strip().splitlines()
+        for line in lines:
+            # Must start with v1
+            assert line.startswith("v1\t")
+            # Must be parseable
+            ev = C.parse_line(line)
+            assert ev is not None, f"Failed to parse: {line}"
+            # Must have required fields
+            assert ev["source"] == "opencode"
+            assert ev["kind"] == "session-summary"
+            assert "ts" in ev
+            assert "session" in ev
+
+
+# --------------------------------------------------------------------------- #
+# lang_for_path helpers
+# --------------------------------------------------------------------------- #
+class TestLangForPath:
+    def test_python(self):
+        assert T.lang_for_path("foo.py") == "Python"
+
+    def test_typescript(self):
+        assert T.lang_for_path("bar.tsx") == "TypeScript"
+
+    def test_nix(self):
+        assert T.lang_for_path("flake.nix") == "Nix"
+
+    def test_dockerfile(self):
+        assert T.lang_for_path("Dockerfile") == "Dockerfile"
+
+    def test_makefile(self):
+        assert T.lang_for_path("Makefile") == "Makefile"
+
+    def test_unknown(self):
+        assert T.lang_for_path("foo.xyz") is None
+
+    def test_empty(self):
+        assert T.lang_for_path("") is None
+
+    def test_none(self):
+        assert T.lang_for_path(None) is None
+
+
+# --------------------------------------------------------------------------- #
+# git detection helpers
+# --------------------------------------------------------------------------- #
+class TestGitDetection:
+    def test_is_git_commit(self):
+        assert T.is_git_commit("git commit -m 'feat: add'") is True
+
+    def test_is_git_commit_with_flags(self):
+        assert T.is_git_commit("git -C /path commit -m 'msg'") is True
+
+    def test_is_not_git_commit(self):
+        assert T.is_git_commit("git status") is False
+
+    def test_is_git_push(self):
+        assert T.is_git_push("git push origin main") is True
+
+    def test_is_not_git_push(self):
+        assert T.is_git_push("git pull") is False
+
+    def test_empty_string(self):
+        assert T.is_git_commit("") is False
+        assert T.is_git_push("") is False
+
+
+# --------------------------------------------------------------------------- #
+# categorize_tool_error
+# --------------------------------------------------------------------------- #
+class TestCategorizeToolError:
+    def test_timeout(self):
+        assert T.categorize_tool_error("timed out after 30s") == "Timeout"
+
+    def test_file_not_found(self):
+        assert T.categorize_tool_error("no such file: /tmp/foo") == "File Not Found"
+
+    def test_permission_denied(self):
+        assert T.categorize_tool_error("Permission denied") == "Permission Denied"
+
+    def test_command_failed(self):
+        assert T.categorize_tool_error("exit code 1") == "Command Failed"
+
+    def test_other(self):
+        assert T.categorize_tool_error("something weird") == "Other"
+
+    def test_empty(self):
+        assert T.categorize_tool_error("") == "Other"
+
+
+# --------------------------------------------------------------------------- #
+# build_event
+# --------------------------------------------------------------------------- #
+class TestBuildEvent:
+    def test_event_shape(self):
+        rollup = {
+            "start_ts": "2024-01-15 22:13:20.000",
+            "cost": 0.05,
+            "unreadable": False,
+        }
+        ev = T.build_event("ses_001", "/home/zach/workspace/my-repo", rollup)
+        assert ev["source"] == "opencode"
+        assert ev["kind"] == "session-summary"
+        assert ev["session"] == "ses_001"
+        assert ev["project"] == "my-repo"
+        assert ev["cwd"] == "/home/zach/workspace/my-repo"
+        assert ev["ts"] == "2024-01-15 22:13:20.000"
+        assert ev["app"] == "opencode"
+        payload = json.loads(ev["payload"])
+        assert payload["cost"] == 0.05

--- a/scripts/collector/opencode/tests/test_shared.py
+++ b/scripts/collector/opencode/tests/test_shared.py
@@ -1,0 +1,558 @@
+"""Tests for opencode/_shared.py — shared utilities for the OpenCode activity source.
+
+Run: python -m pytest scripts/collector/opencode/tests/test_shared.py -v
+"""
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the collector parent is on sys.path for collector.parse_line
+COLLECTOR = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(COLLECTOR))
+# Also add keylog for spool_emit import
+KEYLOG = COLLECTOR / "keylog"
+sys.path.insert(0, str(KEYLOG))
+# And the opencode dir itself so 'from _shared import ...' works
+OPENCODE = COLLECTOR / "opencode"
+sys.path.insert(0, str(OPENCODE))
+
+import _shared as S  # noqa: E402
+import collector as C  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """Set up isolated env dirs for tests."""
+    spool = tmp_path / "spool"
+    spool.mkdir()
+    opencode_dir = tmp_path / "opencode"
+    opencode_dir.mkdir()
+    monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(spool))
+    monkeypatch.setenv("OPENCODE_DATA_DIR", str(opencode_dir))
+    return {"spool": spool, "opencode_dir": opencode_dir}
+
+
+@pytest.fixture
+def sample_db(tmp_path):
+    """Create a temporary SQLite DB with the real OpenCode schema and test data."""
+    db_path = tmp_path / "test.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("""
+        CREATE TABLE session (
+            id TEXT PRIMARY KEY,
+            project_id TEXT NOT NULL,
+            workspace_id TEXT,
+            parent_id TEXT,
+            slug TEXT NOT NULL,
+            directory TEXT NOT NULL,
+            path TEXT,
+            title TEXT NOT NULL,
+            version TEXT NOT NULL,
+            share_url TEXT,
+            summary_additions INTEGER,
+            summary_deletions INTEGER,
+            summary_files INTEGER,
+            summary_diffs TEXT,
+            metadata TEXT,
+            cost REAL DEFAULT 0 NOT NULL,
+            tokens_input INTEGER DEFAULT 0 NOT NULL,
+            tokens_output INTEGER DEFAULT 0 NOT NULL,
+            tokens_reasoning INTEGER DEFAULT 0 NOT NULL,
+            tokens_cache_read INTEGER DEFAULT 0 NOT NULL,
+            tokens_cache_write INTEGER DEFAULT 0 NOT NULL,
+            revert TEXT,
+            permission TEXT,
+            agent TEXT,
+            model TEXT,
+            time_created INTEGER NOT NULL,
+            time_updated INTEGER NOT NULL,
+            time_compacting INTEGER,
+            time_archived INTEGER
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE message (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            time_created INTEGER NOT NULL,
+            time_updated INTEGER NOT NULL,
+            data TEXT NOT NULL
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE part (
+            id TEXT PRIMARY KEY,
+            message_id TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            time_created INTEGER NOT NULL,
+            time_updated INTEGER NOT NULL,
+            data TEXT NOT NULL
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE project (
+            id TEXT PRIMARY KEY,
+            worktree TEXT NOT NULL,
+            vcs TEXT,
+            name TEXT,
+            icon_url TEXT,
+            icon_url_override TEXT,
+            icon_color TEXT,
+            time_created INTEGER NOT NULL,
+            time_updated INTEGER NOT NULL,
+            time_initialized INTEGER,
+            sandboxes TEXT NOT NULL,
+            commands TEXT
+        )
+    """)
+
+    # Insert test sessions (use named columns to avoid positional mismatch)
+    conn.execute(
+        """INSERT INTO session (
+            id, project_id, workspace_id, parent_id, slug, directory, path,
+            title, version, share_url, summary_additions, summary_deletions,
+            summary_files, summary_diffs, metadata, cost, tokens_input,
+            tokens_output, tokens_reasoning, tokens_cache_read,
+            tokens_cache_write, revert, permission, agent, model,
+            time_created, time_updated
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            "ses_001", "proj_a", "ws_1", None, "my-repo",
+            "/home/zach/workspace/my-repo", None, "Test session",
+            "1.0.0", None, 10, 5, 3, None, None, 0.05,
+            1000, 500, 200, 300, 100,
+            None, None, "build",
+            '{"id":"deepseek/deepseek-v4-flash","providerID":"openrouter"}',
+            1700000000000, 1700000060000,
+        ),
+    )
+    conn.execute(
+        """INSERT INTO session (
+            id, project_id, workspace_id, parent_id, slug, directory, path,
+            title, version, share_url, summary_additions, summary_deletions,
+            summary_files, summary_diffs, metadata, cost, tokens_input,
+            tokens_output, tokens_reasoning, tokens_cache_read,
+            tokens_cache_write, revert, permission, agent, model,
+            time_created, time_updated
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            "ses_002", "proj_a", "ws_1", None, "another-repo",
+            "/home/zach/workspace/another-repo", None, "Second session",
+            "1.0.0", None, 0, 0, 0, None, None, 0.01,
+            200, 100, 0, 50, 50,
+            None, None, "build",
+            '{"id":"gpt-4o","providerID":"openai"}',
+            1700001000000, 1700001030000,
+        ),
+    )
+
+    # Insert test messages for ses_001
+    conn.execute(
+        "INSERT INTO message VALUES (?,?,?,?,?)",
+        (
+            "msg_001", "ses_001", 1700000001000, 1700000001000,
+            json.dumps({
+                "role": "user",
+                "time": {"created": 1700000001000},
+                "agent": "build",
+                "model": {"providerID": "openrouter", "modelID": "deepseek/deepseek-v4-flash"},
+            }),
+        ),
+    )
+    conn.execute(
+        "INSERT INTO message VALUES (?,?,?,?,?)",
+        (
+            "msg_002", "ses_001", 1700000002000, 1700000003000,
+            json.dumps({
+                "role": "assistant",
+                "time": {"created": 1700000002000, "completed": 1700000003000},
+                "agent": "build",
+                "cost": 0.001,
+                "tokens": {"input": 500, "output": 100, "reasoning": 50},
+            }),
+        ),
+    )
+
+    # Insert test parts for msg_001
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_001", "msg_001", "ses_001", 1700000001000, 1700000001000,
+            json.dumps({"type": "text", "text": "Hello, please help me."}),
+        ),
+    )
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_002", "msg_002", "ses_001", 1700000002000, 1700000003000,
+            json.dumps({"type": "tool", "tool": "bash", "callID": "call_123",
+                        "state": {"status": "completed"}}),
+        ),
+    )
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_003", "msg_002", "ses_001", 1700000002500, 1700000003000,
+            json.dumps({"type": "text", "text": "Here is the solution."}),
+        ),
+    )
+
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+# --------------------------------------------------------------------------- #
+# project_basename
+# --------------------------------------------------------------------------- #
+class TestProjectBasename:
+    def test_normal_path(self):
+        assert S.project_basename("/home/zach/workspace/my-repo") == "my-repo"
+
+    def test_trailing_slash(self):
+        assert S.project_basename("/home/zach/workspace/my-repo/") == "my-repo"
+
+    def test_empty_string(self):
+        assert S.project_basename("") == ""
+
+    def test_none(self):
+        assert S.project_basename(None) == ""
+
+    def test_single_segment(self):
+        assert S.project_basename("my-repo") == "my-repo"
+
+    def test_nested_path(self):
+        assert S.project_basename("/a/b/c/d/deep-repo") == "deep-repo"
+
+
+# --------------------------------------------------------------------------- #
+# to_ch_ts
+# --------------------------------------------------------------------------- #
+class TestToChTs:
+    def test_epoch_zero(self):
+        result = S.to_ch_ts(0)
+        assert result == "1970-01-01 00:00:00.000"
+
+    def test_recent_timestamp(self):
+        # 2024-01-01 00:00:00 UTC = 1704067200000 ms
+        result = S.to_ch_ts(1704067200000)
+        assert result == "2024-01-01 00:00:00.000"
+
+    def test_milliseconds_preserved(self):
+        # 2024-01-01 00:00:00.123 UTC
+        result = S.to_ch_ts(1704067200123)
+        assert result == "2024-01-01 00:00:00.123"
+
+    def test_large_timestamp(self):
+        # 2026-07-29 15:00:00.456 UTC
+        result = S.to_ch_ts(1785337200456)
+        assert result == "2026-07-29 15:00:00.456"
+
+
+# --------------------------------------------------------------------------- #
+# to_ch_ts_from_iso
+# --------------------------------------------------------------------------- #
+class TestToChTsFromIso:
+    def test_utc_z(self):
+        result = S.to_ch_ts_from_iso("2024-01-01T00:00:00Z")
+        assert result == "2024-01-01 00:00:00.000"
+
+    def test_utc_offset(self):
+        result = S.to_ch_ts_from_iso("2024-01-01T00:00:00+00:00")
+        assert result == "2024-01-01 00:00:00.000"
+
+    def test_with_milliseconds(self):
+        result = S.to_ch_ts_from_iso("2024-01-01T00:00:00.500Z")
+        assert result == "2024-01-01 00:00:00.500"
+
+    def test_local_to_utc(self):
+        # +05:00 → subtract 5h → 2024-01-01 00:00:00 UTC
+        result = S.to_ch_ts_from_iso("2024-01-01T05:00:00+05:00")
+        assert result == "2024-01-01 00:00:00.000"
+
+    def test_empty_string(self):
+        assert S.to_ch_ts_from_iso("") is None
+
+    def test_none(self):
+        assert S.to_ch_ts_from_iso(None) is None
+
+    def test_invalid(self):
+        assert S.to_ch_ts_from_iso("not-a-date") is None
+
+
+# --------------------------------------------------------------------------- #
+# opencode_data_dir
+# --------------------------------------------------------------------------- #
+class TestOpencodeDataDir:
+    def test_default(self, monkeypatch):
+        monkeypatch.delenv("OPENCODE_DATA_DIR", raising=False)
+        result = S.opencode_data_dir()
+        assert result == Path.home() / ".local" / "share" / "opencode"
+
+    def test_env_override(self, monkeypatch, tmp_path):
+        custom = tmp_path / "custom-opencode"
+        monkeypatch.setenv("OPENCODE_DATA_DIR", str(custom))
+        assert S.opencode_data_dir() == custom
+
+
+# --------------------------------------------------------------------------- #
+# opencode_db_path
+# --------------------------------------------------------------------------- #
+class TestOpencodeDbPath:
+    def test_stable_db_found(self, env, monkeypatch):
+        db = env["opencode_dir"] / "opencode-stable.db"
+        db.touch()
+        monkeypatch.delenv("OPENCODE_DB_PATH", raising=False)
+        result = S.opencode_db_path()
+        assert result == db
+
+    def test_explicit_env(self, env, monkeypatch, tmp_path):
+        db = tmp_path / "explicit.db"
+        db.touch()
+        monkeypatch.setenv("OPENCODE_DB_PATH", str(db))
+        result = S.opencode_db_path()
+        assert result == db
+
+    def test_env_nonexistent_returns_none(self, env, monkeypatch):
+        monkeypatch.setenv("OPENCODE_DB_PATH", "/nonexistent/path.db")
+        assert S.opencode_db_path() is None
+
+    def test_glob_fallback(self, env, monkeypatch):
+        monkeypatch.delenv("OPENCODE_DB_PATH", raising=False)
+        db = env["opencode_dir"] / "some-other.db"
+        db.touch()
+        result = S.opencode_db_path()
+        assert result == db
+
+    def test_no_db_returns_none(self, env, monkeypatch):
+        monkeypatch.delenv("OPENCODE_DB_PATH", raising=False)
+        assert S.opencode_db_path() is None
+
+
+# --------------------------------------------------------------------------- #
+# get_db
+# --------------------------------------------------------------------------- #
+class TestGetDb:
+    def test_returns_readonly_conn(self, sample_db):
+        conn = S.get_db(sample_db)
+        assert conn is not None
+        try:
+            # Verify readonly by trying to write
+            with pytest.raises(sqlite3.OperationalError):
+                conn.execute("INSERT INTO session (id) VALUES ('x')")
+        finally:
+            conn.close()
+
+    def test_row_factory(self, sample_db):
+        conn = S.get_db(sample_db)
+        try:
+            row = conn.execute("SELECT id FROM session LIMIT 1").fetchone()
+            assert isinstance(row, sqlite3.Row)
+            assert row["id"] == "ses_001"
+        finally:
+            conn.close()
+
+    def test_no_db_returns_none(self, tmp_path):
+        result = S.get_db(tmp_path / "nonexistent.db")
+        assert result is None
+
+
+# --------------------------------------------------------------------------- #
+# iter_sessions
+# --------------------------------------------------------------------------- #
+class TestIterSessions:
+    def test_yields_all_sessions(self, sample_db):
+        conn = S.get_db(sample_db)
+        try:
+            sessions = list(S.iter_sessions(conn))
+            assert len(sessions) == 2
+            assert sessions[0]["id"] == "ses_001"
+            assert sessions[1]["id"] == "ses_002"
+        finally:
+            conn.close()
+
+    def test_normalized_fields(self, sample_db):
+        conn = S.get_db(sample_db)
+        try:
+            s = list(S.iter_sessions(conn))[0]
+            assert s["title"] == "Test session"
+            assert s["agent"] == "build"
+            assert s["cost"] == 0.05
+            assert s["tokens"]["input"] == 1000
+            assert s["tokens"]["cache"]["read"] == 300
+            assert s["model"]["id"] == "deepseek/deepseek-v4-flash"
+        finally:
+            conn.close()
+
+    def test_since_ts_filter(self, sample_db):
+        conn = S.get_db(sample_db)
+        try:
+            # ses_001 created at 1700000000000, ses_002 at 1700001000000
+            sessions = list(S.iter_sessions(conn, since_ts=1700000500000))
+            assert len(sessions) == 1
+            assert sessions[0]["id"] == "ses_002"
+        finally:
+            conn.close()
+
+    def test_empty_db(self, tmp_path):
+        db = tmp_path / "empty.db"
+        conn = sqlite3.connect(db)
+        conn.execute("""
+            CREATE TABLE session (
+                id TEXT PRIMARY KEY, project_id TEXT, workspace_id TEXT,
+                parent_id TEXT, slug TEXT, directory TEXT, path TEXT,
+                title TEXT, version TEXT, share_url TEXT,
+                summary_additions INTEGER, summary_deletions INTEGER,
+                summary_files INTEGER, summary_diffs TEXT, metadata TEXT,
+                cost REAL, tokens_input INTEGER, tokens_output INTEGER,
+                tokens_reasoning INTEGER, tokens_cache_read INTEGER,
+                tokens_cache_write INTEGER, revert TEXT, permission TEXT,
+                agent TEXT, model TEXT, time_created INTEGER,
+                time_updated INTEGER, time_compacting INTEGER,
+                time_archived INTEGER
+            )
+        """)
+        conn.commit()
+        c = S.get_db(db)
+        try:
+            assert list(S.iter_sessions(c)) == []
+        finally:
+            c.close()
+
+
+# --------------------------------------------------------------------------- #
+# iter_messages
+# --------------------------------------------------------------------------- #
+class TestIterMessages:
+    def test_yields_messages_for_session(self, sample_db):
+        conn = S.get_db(sample_db)
+        try:
+            msgs = list(S.iter_messages(conn, "ses_001"))
+            assert len(msgs) == 2
+            assert msgs[0]["role"] == "user"
+            assert msgs[1]["role"] == "assistant"
+        finally:
+            conn.close()
+
+    def test_filters_by_session_id(self, sample_db):
+        conn = S.get_db(sample_db)
+        try:
+            msgs = list(S.iter_messages(conn, "ses_002"))
+            assert len(msgs) == 0
+        finally:
+            conn.close()
+
+    def test_parsed_data_fields(self, sample_db):
+        conn = S.get_db(sample_db)
+        try:
+            msgs = list(S.iter_messages(conn, "ses_001"))
+            m = msgs[0]
+            assert m["id"] == "msg_001"
+            assert m["agent"] == "build"
+            assert m["model"]["modelID"] == "deepseek/deepseek-v4-flash"
+            # Assistant message has cost and tokens
+            a = msgs[1]
+            assert a["cost"] == 0.001
+            assert a["tokens"]["input"] == 500
+        finally:
+            conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# iter_parts
+# --------------------------------------------------------------------------- #
+class TestIterParts:
+    def test_yields_parts_for_message(self, sample_db):
+        conn = S.get_db(sample_db)
+        try:
+            parts = list(S.iter_parts(conn, "msg_002"))
+            assert len(parts) == 2
+            assert parts[0]["type"] == "tool"
+            assert parts[0]["tool"] == "bash"
+            assert parts[1]["type"] == "text"
+        finally:
+            conn.close()
+
+    def test_filters_by_message_id(self, sample_db):
+        conn = S.get_db(sample_db)
+        try:
+            parts = list(S.iter_parts(conn, "msg_nonexistent"))
+            assert len(parts) == 0
+        finally:
+            conn.close()
+
+    def test_text_part_has_text(self, sample_db):
+        conn = S.get_db(sample_db)
+        try:
+            parts = list(S.iter_parts(conn, "msg_001"))
+            assert len(parts) == 1
+            assert parts[0]["text"] == "Hello, please help me."
+        finally:
+            conn.close()
+
+    def test_tool_part_has_state(self, sample_db):
+        conn = S.get_db(sample_db)
+        try:
+            parts = list(S.iter_parts(conn, "msg_002"))
+            tool_part = parts[0]
+            assert tool_part["call_id"] == "call_123"
+            assert tool_part["state"]["status"] == "completed"
+        finally:
+            conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# spool_emit roundtrip
+# --------------------------------------------------------------------------- #
+class TestSpoolEmitRoundtrip:
+    def test_roundtrip_through_parse_line(self, env):
+        fields = {
+            "source": "opencode",
+            "kind": "session-summary",
+            "project": "my-repo",
+            "text": "hello world",
+            "session": "ses_001",
+        }
+        line = S.spool_emit(fields, spool_dir=env["spool"])
+        assert line is not None
+
+        # Read back from spool
+        cur = env["spool"] / "current.log"
+        assert cur.exists()
+        lines = cur.read_text().strip().splitlines()
+        assert len(lines) == 1
+
+        # Parse with collector
+        ev = C.parse_line(lines[0])
+        assert ev is not None
+        assert ev["source"] == "opencode"
+        assert ev["kind"] == "session-summary"
+        assert ev["project"] == "my-repo"
+        assert ev["text"] == "hello world"
+        assert ev["session"] == "ses_001"
+
+    def test_arbitrary_content_survives(self, env):
+        nasty = 'rm -rf "$X"\twith\ttabs\nand a newline \\back\\slash 你好 password123!'
+        fields = {"source": "opencode", "kind": "test", "text": nasty}
+        S.spool_emit(fields, spool_dir=env["spool"])
+        lines = (env["spool"] / "current.log").read_text().strip().splitlines()
+        ev = C.parse_line(lines[0])
+        assert ev["text"] == nasty
+
+    def test_multiple_emits_append(self, env):
+        for i in range(3):
+            S.spool_emit(
+                {"source": "opencode", "kind": "test", "text": f"msg_{i}"},
+                spool_dir=env["spool"],
+            )
+        lines = (env["spool"] / "current.log").read_text().strip().splitlines()
+        assert len(lines) == 3
+        texts = [C.parse_line(l)["text"] for l in lines]
+        assert texts == ["msg_0", "msg_1", "msg_2"]

--- a/scripts/collector/opencode/tests/test_tailer.py
+++ b/scripts/collector/opencode/tests/test_tailer.py
@@ -1,0 +1,802 @@
+"""Tests for opencode/tailer.py — per-message activity event tailer.
+
+Run: python -m pytest scripts/collector/opencode/tests/test_tailer.py -v
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+COLLECTOR = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(COLLECTOR))
+KEYLOG = COLLECTOR / "keylog"
+sys.path.insert(0, str(KEYLOG))
+OPENCODE = COLLECTOR / "opencode"
+sys.path.insert(0, str(OPENCODE))
+
+import _shared as S  # noqa: E402
+import collector as C  # noqa: E402
+import tailer as T  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    spool = tmp_path / "spool"
+    spool.mkdir()
+    monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(spool))
+    return {"spool": spool}
+
+
+@pytest.fixture
+def sample_db(tmp_path):
+    db_path = tmp_path / "opencode-stable.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""CREATE TABLE session (
+        id TEXT PRIMARY KEY, project_id TEXT, workspace_id TEXT, parent_id TEXT,
+        slug TEXT, directory TEXT, path TEXT, title TEXT, version TEXT,
+        share_url TEXT, summary_additions INTEGER, summary_deletions INTEGER,
+        summary_files INTEGER, summary_diffs TEXT, metadata TEXT,
+        cost REAL, tokens_input INTEGER, tokens_output INTEGER,
+        tokens_reasoning INTEGER, tokens_cache_read INTEGER,
+        tokens_cache_write INTEGER, revert TEXT, permission TEXT,
+        agent TEXT, model TEXT,
+        time_created INTEGER, time_updated INTEGER,
+        time_compacting INTEGER, time_archived INTEGER
+    )""")
+    conn.execute("""CREATE TABLE message (
+        id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER,
+        time_updated INTEGER, data TEXT
+    )""")
+    conn.execute("""CREATE TABLE part (
+        id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT,
+        time_created INTEGER, time_updated INTEGER, data TEXT
+    )""")
+
+    # Session 1: typical session
+    conn.execute(
+        """INSERT INTO session (
+            id, project_id, workspace_id, parent_id, slug, directory, path,
+            title, version, share_url, summary_additions, summary_deletions,
+            summary_files, summary_diffs, metadata, cost, tokens_input,
+            tokens_output, tokens_reasoning, tokens_cache_read,
+            tokens_cache_write, revert, permission, agent, model,
+            time_created, time_updated
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            "ses_001", "proj_a", "ws_1", None, "my-repo",
+            "/home/zach/workspace/my-repo", None, "Test session",
+            "1.0.0", None, 10, 5, 3, None, None, 0.05,
+            1000, 500, 200, 300, 100,
+            None, None, "build",
+            '{"id":"deepseek/deepseek-v4-flash","providerID":"openrouter"}',
+            1700000000000, 1700000060000,
+        ),
+    )
+
+    # Session 2: different project
+    conn.execute(
+        """INSERT INTO session (
+            id, project_id, workspace_id, parent_id, slug, directory, path,
+            title, version, share_url, summary_additions, summary_deletions,
+            summary_files, summary_diffs, metadata, cost, tokens_input,
+            tokens_output, tokens_reasoning, tokens_cache_read,
+            tokens_cache_write, revert, permission, agent, model,
+            time_created, time_updated
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            "ses_002", "proj_b", "ws_1", None, "another-repo",
+            "/home/zach/workspace/another-repo", None, "Second session",
+            "1.0.0", None, 0, 0, 0, None, None, 0.01,
+            200, 100, 0, 50, 50,
+            None, None, "build",
+            '{"id":"gpt-4o","providerID":"openai"}',
+            1700001000000, 1700001030000,
+        ),
+    )
+
+    # --- Messages for ses_001 ---
+    # User message with text
+    conn.execute(
+        "INSERT INTO message VALUES (?,?,?,?,?)",
+        (
+            "msg_001", "ses_001", 1700000001000, 1700000001000,
+            json.dumps({
+                "role": "user",
+                "time": {"created": 1700000001000},
+                "agent": "build",
+                "model": {"providerID": "openrouter", "modelID": "deepseek/deepseek-v4-flash"},
+            }),
+        ),
+    )
+    # Assistant message with tool calls
+    conn.execute(
+        "INSERT INTO message VALUES (?,?,?,?,?)",
+        (
+            "msg_002", "ses_001", 1700000002000, 1700000003000,
+            json.dumps({
+                "role": "assistant",
+                "time": {"created": 1700000002000, "completed": 1700000003000},
+                "agent": "build",
+                "model": {"providerID": "openrouter", "modelID": "deepseek/deepseek-v4-flash"},
+                "cost": 0.001,
+                "tokens": {"input": 500, "output": 100, "reasoning": 50},
+            }),
+        ),
+    )
+    # User noise message (very short)
+    conn.execute(
+        "INSERT INTO message VALUES (?,?,?,?,?)",
+        (
+            "msg_noisy", "ses_001", 1700000005000, 1700000005000,
+            json.dumps({
+                "role": "user",
+                "time": {"created": 1700000005000},
+                "agent": "build",
+            }),
+        ),
+    )
+    # User slash-command message
+    conn.execute(
+        "INSERT INTO message VALUES (?,?,?,?,?)",
+        (
+            "msg_cmd", "ses_001", 1700000006000, 1700000006000,
+            json.dumps({
+                "role": "user",
+                "time": {"created": 1700000006000},
+                "agent": "build",
+            }),
+        ),
+    )
+
+    # --- Parts for ses_001 ---
+    # Text part (user message content)
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_001", "msg_001", "ses_001", 1700000001000, 1700000001000,
+            json.dumps({"type": "text", "text": "Hello, please help me."}),
+        ),
+    )
+    # Assistant text part
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_002", "msg_002", "ses_001", 1700000002100, 1700000003000,
+            json.dumps({"type": "text", "text": "Here is the solution."}),
+        ),
+    )
+    # Bash tool part (assistant)
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_003", "msg_002", "ses_001", 1700000002000, 1700000003000,
+            json.dumps({
+                "type": "tool", "tool": "bash",
+                "state": {"status": "completed"},
+                "command": "git commit -m 'feat: add feature'",
+            }),
+        ),
+    )
+    # Edit tool part (assistant)
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_004", "msg_002", "ses_001", 1700000002200, 1700000003000,
+            json.dumps({
+                "type": "tool", "tool": "edit",
+                "state": {"status": "completed"},
+                "file_path": "/home/zach/workspace/my-repo/src/main.py",
+            }),
+        ),
+    )
+    # Noisy user message — empty text part
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_noisy", "msg_noisy", "ses_001", 1700000005000, 1700000005000,
+            json.dumps({"type": "text", "text": "x"}),
+        ),
+    )
+    # Slash-command user message
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_cmd", "msg_cmd", "ses_001", 1700000006000, 1700000006000,
+            json.dumps({"type": "text", "text": "/status"}),
+        ),
+    )
+
+    # --- Messages for ses_002 ---
+    conn.execute(
+        "INSERT INTO message VALUES (?,?,?,?,?)",
+        (
+            "msg_s2_001", "ses_002", 1700001001000, 1700001001000,
+            json.dumps({
+                "role": "user",
+                "time": {"created": 1700001001000},
+                "agent": "build",
+            }),
+        ),
+    )
+    conn.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?,?)",
+        (
+            "part_s2_001", "msg_s2_001", "ses_002", 1700001001000, 1700001001000,
+            json.dumps({"type": "text", "text": "Do something in the other repo"}),
+        ),
+    )
+
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+# --------------------------------------------------------------------------- #
+# classify
+# --------------------------------------------------------------------------- #
+class TestClassify:
+    def test_typed_message(self):
+        assert T.classify("Hello, help me with this") == ("typed", "Hello, help me with this")
+
+    def test_slash_command(self):
+        assert T.classify("/status") == ("command", "/status")
+
+    def test_slash_command_with_args(self):
+        assert T.classify("/model deepseek") == ("command", "/model deepseek")
+
+    def test_empty_string(self):
+        assert T.classify("") is None
+
+    def test_none(self):
+        assert T.classify(None) is None
+
+    def test_single_char(self):
+        assert T.classify("x") is None
+
+    def test_whitespace_only(self):
+        assert T.classify("   ") is None
+
+    def test_strips_whitespace(self):
+        assert T.classify("  hello  ") == ("typed", "hello")
+
+
+# --------------------------------------------------------------------------- #
+# clean_text
+# --------------------------------------------------------------------------- #
+class TestCleanText:
+    def test_strips_whitespace(self):
+        assert T.clean_text("  hello  ") == "hello"
+
+    def test_empty_string(self):
+        assert T.clean_text("") == ""
+
+    def test_none(self):
+        assert T.clean_text(None) == ""
+
+    def test_no_change(self):
+        assert T.clean_text("already clean") == "already clean"
+
+
+# --------------------------------------------------------------------------- #
+# message_id
+# --------------------------------------------------------------------------- #
+class TestMessageId:
+    def test_format(self):
+        msg = {"session_id": "ses_001", "id": "msg_002"}
+        assert T.message_id(msg) == "ses_001:msg_002"
+
+    def test_different_sessions(self):
+        m1 = {"session_id": "ses_a", "id": "msg_1"}
+        m2 = {"session_id": "ses_b", "id": "msg_1"}
+        assert T.message_id(m1) != T.message_id(m2)
+
+
+# --------------------------------------------------------------------------- #
+# extract_text
+# --------------------------------------------------------------------------- #
+class TestExtractText:
+    def test_single_text_part(self):
+        parts = [{"type": "text", "text": "hello"}]
+        assert T.extract_text(parts) == "hello"
+
+    def test_multiple_parts(self):
+        parts = [
+            {"type": "tool", "tool": "bash"},
+            {"type": "text", "text": "response text"},
+        ]
+        assert T.extract_text(parts) == "response text"
+
+    def test_no_text_parts(self):
+        parts = [{"type": "tool", "tool": "bash"}, {"type": "reasoning"}]
+        assert T.extract_text(parts) == ""
+
+    def test_empty_list(self):
+        assert T.extract_text([]) == ""
+
+    def test_text_part_with_none(self):
+        parts = [{"type": "text", "text": None}]
+        assert T.extract_text(parts) == ""
+
+
+# --------------------------------------------------------------------------- #
+# extract_tool_calls
+# --------------------------------------------------------------------------- #
+class TestExtractToolCalls:
+    def test_tool_invocation_parts(self):
+        parts = [
+            {
+                "type": "tool", "tool": "bash",
+                "state": {"status": "completed"},
+                "_data": {"type": "tool", "tool": "bash", "command": "ls", "state": {"status": "completed"}},
+            },
+        ]
+        calls = T.extract_tool_calls(parts)
+        assert len(calls) == 1
+        assert calls[0]["tool_name"] == "bash"
+        assert calls[0]["state"] == {"status": "completed"}
+
+    def test_mixed_part_types(self):
+        parts = [
+            {"type": "text", "text": "response"},
+            {
+                "type": "tool", "tool": "edit",
+                "state": {"status": "completed"},
+                "_data": {"type": "tool", "tool": "edit", "file_path": "foo.py"},
+            },
+            {"type": "reasoning"},
+        ]
+        calls = T.extract_tool_calls(parts)
+        assert len(calls) == 1
+        assert calls[0]["tool_name"] == "edit"
+
+    def test_empty_parts(self):
+        assert T.extract_tool_calls([]) == []
+
+    def test_tool_invocation_type(self):
+        parts = [
+            {
+                "type": "tool-invocation", "tool": "webfetch",
+                "state": {"status": "completed"},
+                "_data": {"type": "tool-invocation", "tool": "webfetch", "url": "https://example.com"},
+            },
+        ]
+        calls = T.extract_tool_calls(parts)
+        assert len(calls) == 1
+        assert calls[0]["tool_name"] == "webfetch"
+
+    def test_args_extracted(self):
+        parts = [
+            {
+                "type": "tool", "tool": "bash",
+                "state": {"status": "completed"},
+                "_data": {"type": "tool", "tool": "bash", "command": "echo hi", "state": {"status": "completed"}},
+            },
+        ]
+        calls = T.extract_tool_calls(parts)
+        assert calls[0]["args"] == {"command": "echo hi"}
+
+
+# --------------------------------------------------------------------------- #
+# build_event
+# --------------------------------------------------------------------------- #
+class TestBuildEvent:
+    def test_user_message_is_prompt(self):
+        msg = {
+            "id": "msg_001", "session_id": "ses_001",
+            "role": "user", "time_created": 1700000001000,
+            "agent": "build", "model": None, "cost": None,
+            "tokens": {},
+        }
+        parts = [{"type": "text", "text": "Hello world"}]
+        session = {"directory": "/home/zach/workspace/my-repo", "agent": "build"}
+        ev = T.build_event(msg, parts, session)
+        assert ev is not None
+        assert ev["kind"] == "prompt"
+
+    def test_assistant_message_is_turn(self):
+        msg = {
+            "id": "msg_002", "session_id": "ses_001",
+            "role": "assistant", "time_created": 1700000002000,
+            "agent": "build", "model": {"id": "deepseek"}, "cost": 0.001,
+            "tokens": {"input": 500, "output": 100},
+        }
+        parts = [{"type": "text", "text": "Here is the answer."}]
+        session = {"directory": "/home/zach/workspace/my-repo", "agent": "build"}
+        ev = T.build_event(msg, parts, session)
+        assert ev is not None
+        assert ev["kind"] == "assistant-turn"
+
+    def test_filters_noise_user_message(self):
+        msg = {
+            "id": "msg_x", "session_id": "ses_001",
+            "role": "user", "time_created": 1700000005000,
+            "agent": "build", "model": None, "cost": None,
+            "tokens": {},
+        }
+        parts = [{"type": "text", "text": "x"}]
+        session = {"directory": "/home/zach/workspace/my-repo"}
+        assert T.build_event(msg, parts, session) is None
+
+    def test_filters_empty_user_message(self):
+        msg = {
+            "id": "msg_x", "session_id": "ses_001",
+            "role": "user", "time_created": 1700000005000,
+            "agent": "build", "model": None, "cost": None,
+            "tokens": {},
+        }
+        parts = []
+        session = {"directory": "/home/zach/workspace/my-repo"}
+        assert T.build_event(msg, parts, session) is None
+
+    def test_filters_unknown_role(self):
+        msg = {
+            "id": "msg_x", "session_id": "ses_001",
+            "role": "system", "time_created": 1700000005000,
+            "agent": "build", "model": None, "cost": None,
+            "tokens": {},
+        }
+        parts = [{"type": "text", "text": "system message"}]
+        session = {"directory": "/home/zach/workspace/my-repo"}
+        assert T.build_event(msg, parts, session) is None
+
+    def test_payload_fields(self):
+        msg = {
+            "id": "msg_002", "session_id": "ses_001",
+            "role": "assistant", "time_created": 1700000002000,
+            "agent": "build",
+            "model": {"providerID": "openrouter", "modelID": "deepseek-v4-flash"},
+            "cost": 0.001,
+            "tokens": {"input": 500, "output": 100},
+        }
+        parts = [
+            {"type": "text", "text": "Done."},
+            {
+                "type": "tool", "tool": "bash",
+                "state": {"status": "completed"},
+                "_data": {"command": "ls"},
+            },
+        ]
+        session = {"directory": "/home/zach/workspace/my-repo", "agent": "build"}
+        ev = T.build_event(msg, parts, session)
+        payload = json.loads(ev["payload"])
+        assert payload["role"] == "assistant"
+        assert payload["cost"] == 0.001
+        assert payload["tokens_input"] == 500
+        assert payload["tokens_output"] == 100
+        assert payload["tool_count"] == 1
+        assert payload["tool_calls"] == [{"name": "bash", "state": {"status": "completed"}}]
+
+    def test_ts_matches_message_creation_time(self):
+        msg = {
+            "id": "msg_001", "session_id": "ses_001",
+            "role": "user", "time_created": 1700000001000,
+            "agent": "build", "model": None, "cost": None,
+            "tokens": {},
+        }
+        parts = [{"type": "text", "text": "Hello"}]
+        session = {"directory": "/home/zach/workspace/my-repo"}
+        ev = T.build_event(msg, parts, session)
+        assert ev["ts"] == S.to_ch_ts(1700000001000)
+
+    def test_project_from_directory(self):
+        msg = {
+            "id": "msg_s2_001", "session_id": "ses_002",
+            "role": "user", "time_created": 1700001001000,
+            "agent": "build", "model": None, "cost": None,
+            "tokens": {},
+        }
+        parts = [{"type": "text", "text": "Hello"}]
+        session = {"directory": "/home/zach/workspace/another-repo"}
+        ev = T.build_event(msg, parts, session)
+        assert ev["project"] == "another-repo"
+        assert ev["cwd"] == "/home/zach/workspace/another-repo"
+
+
+# --------------------------------------------------------------------------- #
+# State persistence
+# --------------------------------------------------------------------------- #
+class TestState:
+    def test_load_empty(self, tmp_path):
+        assert T.load_state(tmp_path / "nonexistent.json") == set()
+
+    def test_save_and_load(self, tmp_path):
+        path = tmp_path / "state.json"
+        T.save_state(path, {"a", "b", "c"})
+        loaded = T.load_state(path)
+        assert loaded == {"a", "b", "c"}
+
+    def test_atomic_write(self, tmp_path):
+        path = tmp_path / "state.json"
+        T.save_state(path, {"x"})
+        # .tmp should not exist after atomic replace
+        assert not (tmp_path / "state.json.tmp").exists()
+
+
+# --------------------------------------------------------------------------- #
+# State idempotency — run twice, second emits nothing
+# --------------------------------------------------------------------------- #
+class TestIdempotency:
+    def test_rerun_emits_nothing(self, sample_db, env, monkeypatch):
+        monkeypatch.setenv("OPENCODE_TAILER_STATE", str(env["spool"] / "state.json"))
+
+        def mock_get_db(path=None):
+            db = path or sample_db
+            if db is None or not db.exists():
+                return None
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            return conn
+
+        monkeypatch.setattr(S, "get_db", mock_get_db)
+
+        T.run(db_path=sample_db)
+        spool_file = env["spool"] / "current.log"
+        lines1 = spool_file.read_text().strip().splitlines()
+        count1 = len(lines1)
+
+        T.run(db_path=sample_db)
+        lines2 = spool_file.read_text().strip().splitlines()
+        assert len(lines2) == count1
+
+    def test_new_message_emitted_after_state_update(self, sample_db, env, monkeypatch, tmp_path):
+        state_file = env["spool"] / "state.json"
+        monkeypatch.setenv("OPENCODE_TAILER_STATE", str(state_file))
+
+        def mock_get_db(path=None):
+            db = path or sample_db
+            if db is None or not db.exists():
+                return None
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            return conn
+
+        monkeypatch.setattr(S, "get_db", mock_get_db)
+
+        # First run: emits all existing messages
+        T.run(db_path=sample_db)
+        spool_file = env["spool"] / "current.log"
+        lines1 = spool_file.read_text().strip().splitlines()
+        count1 = len(lines1)
+        assert count1 > 0
+
+        # Add a new message to the DB
+        conn = sqlite3.connect(str(sample_db))
+        conn.execute(
+            "INSERT INTO message VALUES (?,?,?,?,?)",
+            (
+                "msg_new", "ses_001", 1700000099000, 1700000099000,
+                json.dumps({
+                    "role": "user",
+                    "time": {"created": 1700000099000},
+                    "agent": "build",
+                }),
+            ),
+        )
+        conn.execute(
+            "INSERT INTO part VALUES (?,?,?,?,?,?)",
+            (
+                "part_new", "msg_new", "ses_001", 1700000099000, 1700000099000,
+                json.dumps({"type": "text", "text": "A brand new message after state saved"}),
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        # Second run: should emit the new message
+        T.run(db_path=sample_db)
+        lines2 = spool_file.read_text().strip().splitlines()
+        assert len(lines2) == count1 + 1
+
+        # Parse the new event
+        ev = C.parse_line(lines2[-1])
+        assert ev is not None
+        assert ev["text"] == "A brand new message after state saved"
+
+
+# --------------------------------------------------------------------------- #
+# Full roundtrip: create DB → run() → read spool → parse_line → verify
+# --------------------------------------------------------------------------- #
+class TestFullRoundtrip:
+    def test_roundtrip_user_and_assistant(self, sample_db, env, monkeypatch):
+        monkeypatch.setenv("OPENCODE_TAILER_STATE", str(env["spool"] / "state.json"))
+
+        def mock_get_db(path=None):
+            db = path or sample_db
+            if db is None or not db.exists():
+                return None
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            return conn
+
+        monkeypatch.setattr(S, "get_db", mock_get_db)
+
+        T.run(db_path=sample_db)
+
+        spool_file = env["spool"] / "current.log"
+        assert spool_file.exists()
+        lines = spool_file.read_text().strip().splitlines()
+        assert len(lines) > 0
+
+        for line in lines:
+            assert line.startswith("v1\t")
+            ev = C.parse_line(line)
+            assert ev is not None
+            assert ev["source"] == "opencode"
+            assert ev["kind"] in ("prompt", "assistant-turn")
+            assert ev["app"] == "opencode"
+
+    def test_user_message_parsed_correctly(self, sample_db, env, monkeypatch):
+        monkeypatch.setenv("OPENCODE_TAILER_STATE", str(env["spool"] / "state.json"))
+
+        def mock_get_db(path=None):
+            db = path or sample_db
+            if db is None or not db.exists():
+                return None
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            return conn
+
+        monkeypatch.setattr(S, "get_db", mock_get_db)
+
+        T.run(db_path=sample_db)
+
+        spool_file = env["spool"] / "current.log"
+        lines = spool_file.read_text().strip().splitlines()
+
+        # Find the first user prompt event
+        user_events = []
+        for line in lines:
+            ev = C.parse_line(line)
+            if ev and ev["kind"] == "prompt":
+                user_events.append(ev)
+
+        assert len(user_events) >= 1
+        first = user_events[0]
+        assert first["text"] == "Hello, please help me."
+        assert first["project"] == "my-repo"
+        assert first["session"] == "ses_001"
+        payload = json.loads(first["payload"])
+        assert payload["role"] == "user"
+
+    def test_assistant_turn_parsed_correctly(self, sample_db, env, monkeypatch):
+        monkeypatch.setenv("OPENCODE_TAILER_STATE", str(env["spool"] / "state.json"))
+
+        def mock_get_db(path=None):
+            db = path or sample_db
+            if db is None or not db.exists():
+                return None
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            return conn
+
+        monkeypatch.setattr(S, "get_db", mock_get_db)
+
+        T.run(db_path=sample_db)
+
+        spool_file = env["spool"] / "current.log"
+        lines = spool_file.read_text().strip().splitlines()
+
+        # Find the assistant turn event
+        assistant_events = []
+        for line in lines:
+            ev = C.parse_line(line)
+            if ev and ev["kind"] == "assistant-turn":
+                assistant_events.append(ev)
+
+        assert len(assistant_events) >= 1
+        first = assistant_events[0]
+        assert first["text"] == "Here is the solution."
+        payload = json.loads(first["payload"])
+        assert payload["role"] == "assistant"
+        assert payload["tool_count"] == 2
+
+
+# --------------------------------------------------------------------------- #
+# Multiple sessions — messages correctly associated
+# --------------------------------------------------------------------------- #
+class TestMultipleSessions:
+    def test_messages_across_sessions(self, sample_db, env, monkeypatch):
+        monkeypatch.setenv("OPENCODE_TAILER_STATE", str(env["spool"] / "state.json"))
+
+        def mock_get_db(path=None):
+            db = path or sample_db
+            if db is None or not db.exists():
+                return None
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            return conn
+
+        monkeypatch.setattr(S, "get_db", mock_get_db)
+
+        T.run(db_path=sample_db)
+
+        spool_file = env["spool"] / "current.log"
+        lines = spool_file.read_text().strip().splitlines()
+
+        sessions_seen = set()
+        for line in lines:
+            ev = C.parse_line(line)
+            if ev:
+                sessions_seen.add(ev["session"])
+
+        assert "ses_001" in sessions_seen
+        assert "ses_002" in sessions_seen
+
+
+# --------------------------------------------------------------------------- #
+# Tool calls in payload — verify structure
+# --------------------------------------------------------------------------- #
+class TestToolCallsInPayload:
+    def test_assistant_tool_calls_structure(self, sample_db, env, monkeypatch):
+        monkeypatch.setenv("OPENCODE_TAILER_STATE", str(env["spool"] / "state.json"))
+
+        def mock_get_db(path=None):
+            db = path or sample_db
+            if db is None or not db.exists():
+                return None
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            return conn
+
+        monkeypatch.setattr(S, "get_db", mock_get_db)
+
+        T.run(db_path=sample_db)
+
+        spool_file = env["spool"] / "current.log"
+        lines = spool_file.read_text().strip().splitlines()
+
+        for line in lines:
+            ev = C.parse_line(line)
+            if ev and ev["kind"] == "assistant-turn":
+                payload = json.loads(ev["payload"])
+                assert "tool_calls" in payload
+                assert "tool_count" in payload
+                assert payload["tool_count"] == 2
+                assert len(payload["tool_calls"]) == 2
+                names = {tc["name"] for tc in payload["tool_calls"]}
+                assert "bash" in names
+                assert "edit" in names
+                for tc in payload["tool_calls"]:
+                    assert "name" in tc
+                    assert "state" in tc
+                break
+
+
+# --------------------------------------------------------------------------- #
+# Empty parts list — handled gracefully
+# --------------------------------------------------------------------------- #
+class TestEmptyParts:
+    def test_user_with_no_parts_filtered(self):
+        msg = {
+            "id": "msg_x", "session_id": "ses_001",
+            "role": "user", "time_created": 1700000001000,
+            "agent": "build", "model": None, "cost": None,
+            "tokens": {},
+        }
+        session = {"directory": "/home/zach/workspace/my-repo"}
+        assert T.build_event(msg, [], session) is None
+
+    def test_assistant_with_no_parts(self):
+        msg = {
+            "id": "msg_y", "session_id": "ses_001",
+            "role": "assistant", "time_created": 1700000002000,
+            "agent": "build", "model": None, "cost": 0.001,
+            "tokens": {},
+        }
+        session = {"directory": "/home/zach/workspace/my-repo"}
+        ev = T.build_event(msg, [], session)
+        assert ev is not None
+        assert ev["kind"] == "assistant-turn"
+        assert ev["text"] == ""
+        payload = json.loads(ev["payload"])
+        assert payload["tool_count"] == 0
+        assert payload["tool_calls"] == []

--- a/scripts/validation/invariants.py
+++ b/scripts/validation/invariants.py
@@ -59,7 +59,7 @@ DERIVED_ATTENTION_TOL = 0.02
 DERIVED_ATTENTION_WINDOW_HOURS = 48
 
 EXPECTED_HOSTS = {"workbench", "laptop"}
-EXPECTED_SOURCES = {"zsh", "tmux", "keys", "browser", "claude", "i3"}
+EXPECTED_SOURCES = {"zsh", "tmux", "keys", "browser", "claude", "i3", "opencode"}
 
 # Layer-A session-summary invariants (scripts/collector/claude/session-tailer.py).
 # Required payload keys every well-formed session-summary rollup must carry (a

--- a/scripts/validation/reconcile.py
+++ b/scripts/validation/reconcile.py
@@ -169,6 +169,30 @@ def reconcile_claude(client: CHClient, projects_dir: Path, since_epoch: float) -
                  matched=matched, missing=missing, extra=extra)
 
 
+def reconcile_opencode(client: CHClient, db_path: Path | None = None,
+                       since_epoch: float = 0) -> Recon:
+    """Reconcile OpenCode events against the SQLite DB."""
+    ref_sessions = RS.read_opencode_sessions(db_path)
+    ref_messages = RS.read_opencode_messages(db_path)
+    # Use message count as the reconciliation metric (prompt + assistant-turn)
+    ref_n = len(ref_messages)
+    table = client.conn.fq_table
+    try:
+        rows = client.rows(
+            f"SELECT kind, count() AS cnt FROM {table} "
+            f"WHERE source='opencode' AND ts >= {sql_quote(_dt(since_epoch))} "
+            f"GROUP BY kind"
+        )
+    except Exception as exc:
+        return Recon("opencode", skipped=True, reason=f"query error: {exc}")
+    coll_n = sum(int(r.get("cnt", 0)) for r in rows)
+    if coll_n == 0 and ref_n == 0:
+        return Recon("opencode", skipped=True, reason="no opencode data on either side")
+    matched, missing, extra = reconcile_counts(coll_n, ref_n)
+    return Recon("opencode", collected=coll_n, reference=ref_n,
+                 matched=matched, missing=missing, extra=extra)
+
+
 # --------------------------------------------------------------------------- #
 def _dt(epoch: float) -> str:
     """Epoch → local wall-clock 'YYYY-MM-DD HH:MM:SS' (matches stored ts space)."""
@@ -186,6 +210,7 @@ def default_paths() -> dict:
         "tmux_tasks": home / ".tmux/tasks",
         "tmux_activity": home / ".tmux/activity",
         "claude_projects": home / ".claude/projects",
+        "opencode_db": home / ".local" / "share" / "opencode" / "opencode-stable.db",
     }
 
 
@@ -198,6 +223,7 @@ def run_reconcile(client: CHClient, window_hours: float = 24.0,
         reconcile_browser(client, p["browser_history"], since),
         reconcile_tmux(client, p["tmux_tasks"], p["tmux_activity"], since),
         reconcile_claude(client, p["claude_projects"], since),
+        reconcile_opencode(client, p.get("opencode_db"), since),
     ]
 
 

--- a/scripts/validation/refsources.py
+++ b/scripts/validation/refsources.py
@@ -25,6 +25,7 @@ import json
 import re
 import shutil
 import sqlite3
+import sys
 import tempfile
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
@@ -251,3 +252,78 @@ def count_claude_user_msgs(jsonl_paths: list[Path],
                 continue
             total += 1
     return total
+
+
+# --------------------------------------------------------------------------- #
+# OpenCode sessions / messages (reads the same SQLite DB the collector reads)
+# --------------------------------------------------------------------------- #
+def _opencode_import():
+    """Lazy-import the opencode collector _shared module."""
+    import importlib
+    collector_dir = str(Path(__file__).resolve().parent.parent / "collector" / "opencode")
+    if collector_dir not in sys.path:
+        sys.path.insert(0, collector_dir)
+    return importlib.import_module("_shared")
+
+
+def read_opencode_sessions(db_path: Path | None = None) -> list[dict]:
+    """Read OpenCode sessions → list of session-summary-shaped event dicts.
+
+    Opens the OpenCode SQLite DB (via _shared.opencode_db_path() if no path
+    given), queries all sessions, and returns dicts matching the
+    session-summary event shape emitted by session_tailer.py.
+    """
+    S = _opencode_import()
+    db = S.get_db(db_path)
+    if db is None:
+        return []
+    try:
+        events = []
+        for sess in S.iter_sessions(db):
+            directory = sess.get("directory") or ""
+            events.append({
+                "source": "opencode",
+                "kind": "session-summary",
+                "session": sess["id"],
+                "project": S.project_basename(directory),
+                "cwd": directory,
+                "ts": S.to_ch_ts(sess["time_created"]),
+                "app": "opencode",
+            })
+        return events
+    finally:
+        db.close()
+
+
+def read_opencode_messages(db_path: Path | None = None) -> list[dict]:
+    """Read OpenCode messages → list of prompt/assistant-turn event dicts.
+
+    Opens the OpenCode SQLite DB, walks all sessions/messages, and returns
+    dicts matching the message-stream event shape emitted by tailer.py.
+    """
+    S = _opencode_import()
+    db = S.get_db(db_path)
+    if db is None:
+        return []
+    try:
+        events = []
+        for sess in S.iter_sessions(db):
+            directory = sess.get("directory") or ""
+            project = S.project_basename(directory)
+            for msg in S.iter_messages(db, sess["id"]):
+                role = msg.get("role")
+                if role not in ("user", "assistant"):
+                    continue
+                kind = "prompt" if role == "user" else "assistant-turn"
+                events.append({
+                    "source": "opencode",
+                    "kind": kind,
+                    "session": msg["session_id"],
+                    "project": project,
+                    "cwd": directory,
+                    "ts": S.to_ch_ts(msg["time_created"]),
+                    "app": "opencode",
+                })
+        return events
+    finally:
+        db.close()

--- a/scripts/validation/tests/test_opencode_validation.py
+++ b/scripts/validation/tests/test_opencode_validation.py
@@ -1,0 +1,342 @@
+"""Unit tests for the OpenCode validation integration (Phase 5).
+
+Tests the reference readers (read_opencode_sessions, read_opencode_messages),
+reconcile_opencode, and that EXPECTED_SOURCES includes "opencode".
+"""
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import invariants as I  # noqa: E402
+import refsources as RS  # noqa: E402
+import reconcile as R  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fixture: temporary OpenCode SQLite DB
+# --------------------------------------------------------------------------- #
+def _create_opencode_db(tmp_path: Path, sessions=None, messages=None) -> Path:
+    """Create a minimal OpenCode SQLite DB with the expected schema."""
+    db_path = tmp_path / "test-opencode.db"
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+
+    cur.execute("""
+        CREATE TABLE session (
+            id TEXT PRIMARY KEY,
+            project_id TEXT,
+            directory TEXT,
+            title TEXT,
+            agent TEXT,
+            model TEXT,
+            version TEXT,
+            cost REAL,
+            tokens_input INTEGER,
+            tokens_output INTEGER,
+            tokens_reasoning INTEGER,
+            tokens_cache_read INTEGER,
+            tokens_cache_write INTEGER,
+            time_created INTEGER,
+            time_updated INTEGER,
+            parent_id TEXT
+        )
+    """)
+
+    cur.execute("""
+        CREATE TABLE message (
+            id TEXT PRIMARY KEY,
+            session_id TEXT,
+            data TEXT,
+            time_created INTEGER,
+            time_updated INTEGER
+        )
+    """)
+
+    cur.execute("""
+        CREATE TABLE part (
+            id TEXT PRIMARY KEY,
+            message_id TEXT,
+            session_id TEXT,
+            data TEXT,
+            time_created INTEGER,
+            time_updated INTEGER
+        )
+    """)
+
+    if sessions:
+        for s in sessions:
+            cur.execute(
+                "INSERT INTO session (id, project_id, directory, title, agent, "
+                "model, version, cost, tokens_input, tokens_output, "
+                "tokens_reasoning, tokens_cache_read, tokens_cache_write, "
+                "time_created, time_updated, parent_id) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    s["id"], s.get("project_id", ""), s.get("directory", ""),
+                    s.get("title", ""), s.get("agent", ""), s.get("model", None),
+                    s.get("version", ""), s.get("cost", 0.0),
+                    s.get("tokens_input", 0), s.get("tokens_output", 0),
+                    s.get("tokens_reasoning", 0), s.get("tokens_cache_read", 0),
+                    s.get("tokens_cache_write", 0), s["time_created"],
+                    s.get("time_updated", s["time_created"]),
+                    s.get("parent_id", None),
+                ),
+            )
+
+    if messages:
+        for m in messages:
+            cur.execute(
+                "INSERT INTO message (id, session_id, data, time_created, "
+                "time_updated) VALUES (?,?,?,?,?)",
+                (
+                    m["id"], m["session_id"],
+                    json.dumps(m.get("data", {})),
+                    m["time_created"],
+                    m.get("time_updated", m["time_created"]),
+                ),
+            )
+
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+# --------------------------------------------------------------------------- #
+# read_opencode_sessions
+# --------------------------------------------------------------------------- #
+def test_read_opencode_sessions_empty(tmp_path):
+    """Returns [] when no DB exists."""
+    result = RS.read_opencode_sessions(tmp_path / "nonexistent.db")
+    assert result == []
+
+
+def test_read_opencode_sessions_with_data(tmp_path):
+    """Returns correct event shapes from a real DB."""
+    db = _create_opencode_db(
+        tmp_path,
+        sessions=[
+            {
+                "id": "sess-abc",
+                "project_id": "proj-1",
+                "directory": "/home/user/projects/my-repo",
+                "title": "Test Session",
+                "agent": "coder",
+                "model": None,
+                "version": "1.0",
+                "cost": 0.05,
+                "tokens_input": 1000,
+                "tokens_output": 500,
+                "tokens_reasoning": 0,
+                "tokens_cache_read": 0,
+                "tokens_cache_write": 0,
+                "time_created": 1700000000000,
+                "time_updated": 1700000060000,
+            },
+            {
+                "id": "sess-def",
+                "project_id": "proj-2",
+                "directory": "/home/user/projects/other-repo",
+                "title": "Another Session",
+                "agent": "coder",
+                "model": None,
+                "version": "1.0",
+                "cost": 0.01,
+                "tokens_input": 200,
+                "tokens_output": 100,
+                "tokens_reasoning": 0,
+                "tokens_cache_read": 0,
+                "tokens_cache_write": 0,
+                "time_created": 1700000100000,
+                "time_updated": 1700000120000,
+            },
+        ],
+    )
+    events = RS.read_opencode_sessions(db)
+    assert len(events) == 2
+    sessions = {e["session"]: e for e in events}
+    assert "sess-abc" in sessions
+    assert "sess-def" in sessions
+
+    ev = sessions["sess-abc"]
+    assert ev["source"] == "opencode"
+    assert ev["kind"] == "session-summary"
+    assert ev["project"] == "my-repo"
+    assert ev["cwd"] == "/home/user/projects/my-repo"
+    assert ev["app"] == "opencode"
+    assert "ts" in ev and isinstance(ev["ts"], str)
+
+
+# --------------------------------------------------------------------------- #
+# read_opencode_messages
+# --------------------------------------------------------------------------- #
+def test_read_opencode_messages_with_data(tmp_path):
+    """Returns correct event shapes for user/assistant messages."""
+    db = _create_opencode_db(
+        tmp_path,
+        sessions=[
+            {
+                "id": "sess-1",
+                "directory": "/home/user/projects/test-repo",
+                "time_created": 1700000000000,
+                "time_updated": 1700000060000,
+            },
+        ],
+        messages=[
+            {
+                "id": "msg-1",
+                "session_id": "sess-1",
+                "data": {"role": "user"},
+                "time_created": 1700000005000,
+            },
+            {
+                "id": "msg-2",
+                "session_id": "sess-1",
+                "data": {"role": "assistant"},
+                "time_created": 1700000010000,
+            },
+            {
+                "id": "msg-3",
+                "session_id": "sess-1",
+                "data": {"role": "system"},
+                "time_created": 1700000015000,
+            },
+        ],
+    )
+    events = RS.read_opencode_messages(db)
+    # system role is filtered out
+    assert len(events) == 2
+    kinds = {e["kind"] for e in events}
+    assert kinds == {"prompt", "assistant-turn"}
+    for ev in events:
+        assert ev["source"] == "opencode"
+        assert ev["session"] == "sess-1"
+        assert ev["project"] == "test-repo"
+        assert ev["app"] == "opencode"
+        assert "ts" in ev
+
+
+def test_read_opencode_messages_empty(tmp_path):
+    """Returns [] when DB has no messages."""
+    db = _create_opencode_db(
+        tmp_path,
+        sessions=[{
+            "id": "sess-empty",
+            "directory": "/tmp",
+            "time_created": 1700000000000,
+        }],
+    )
+    events = RS.read_opencode_messages(db)
+    assert events == []
+
+
+# --------------------------------------------------------------------------- #
+# reconcile_opencode
+# --------------------------------------------------------------------------- #
+class FakeClient:
+    def __init__(self, rows_val=None):
+        self._rows = rows_val or []
+
+        class _Conn:
+            fq_table = "activity.events"
+            url = "http://fake"
+        self.conn = _Conn()
+
+    def scalar(self, sql):
+        return 0
+
+    def rows(self, sql):
+        return self._rows
+
+
+def test_reconcile_opencode_no_events(tmp_path):
+    """Graceful handling when CH has no opencode events and ref has none."""
+    db = _create_opencode_db(tmp_path)
+    r = R.reconcile_opencode(client=FakeClient(), db_path=db)
+    assert r.skipped is True
+    assert "no opencode data" in r.reason
+
+
+def test_reconcile_opencode_matches(tmp_path):
+    """Ref and CH match → clean Recon with 0 missing/extra."""
+    db = _create_opencode_db(
+        tmp_path,
+        sessions=[{
+            "id": "sess-1",
+            "directory": "/tmp/test",
+            "time_created": 1700000000000,
+        }],
+        messages=[
+            {"id": "msg-1", "session_id": "sess-1", "data": {"role": "user"}, "time_created": 1700000005000},
+            {"id": "msg-2", "session_id": "sess-1", "data": {"role": "assistant"}, "time_created": 1700000010000},
+        ],
+    )
+    # CH has 2 events (1 prompt + 1 assistant-turn)
+    client = FakeClient(rows_val=[
+        {"kind": "prompt", "cnt": 1},
+        {"kind": "assistant-turn", "cnt": 1},
+    ])
+    r = R.reconcile_opencode(client=client, db_path=db)
+    assert r.skipped is False
+    assert r.collected == 2
+    assert r.reference == 2
+    assert r.matched == 2
+    assert r.missing == 0
+    assert r.extra == 0
+
+
+def test_reconcile_opencode_missing(tmp_path):
+    """Ref has events CH doesn't → missing list populated."""
+    db = _create_opencode_db(
+        tmp_path,
+        sessions=[{
+            "id": "sess-1",
+            "directory": "/tmp/test",
+            "time_created": 1700000000000,
+        }],
+        messages=[
+            {"id": "msg-1", "session_id": "sess-1", "data": {"role": "user"}, "time_created": 1700000005000},
+            {"id": "msg-2", "session_id": "sess-1", "data": {"role": "assistant"}, "time_created": 1700000010000},
+            {"id": "msg-3", "session_id": "sess-1", "data": {"role": "user"}, "time_created": 1700000015000},
+        ],
+    )
+    # CH only has 1 event (ref has 3)
+    client = FakeClient(rows_val=[{"kind": "prompt", "cnt": 1}])
+    r = R.reconcile_opencode(client=client, db_path=db)
+    assert r.skipped is False
+    assert r.collected == 1
+    assert r.reference == 3
+    assert r.matched == 1
+    assert r.missing == 2  # 3 ref - 1 matched
+    assert r.extra == 0
+
+
+def test_reconcile_opencode_query_error_skipped(tmp_path):
+    """Query error → graceful skip."""
+    class BoomClient(FakeClient):
+        def rows(self, sql):
+            raise RuntimeError("connection refused")
+
+    db = _create_opencode_db(
+        tmp_path,
+        sessions=[{
+            "id": "sess-1",
+            "directory": "/tmp",
+            "time_created": 1700000000000,
+        }],
+        messages=[
+            {"id": "msg-1", "session_id": "sess-1", "data": {"role": "user"}, "time_created": 1700000005000},
+        ],
+    )
+    r = R.reconcile_opencode(client=BoomClient(), db_path=db)
+    assert r.skipped is True
+    assert "error" in r.reason
+
+
+# --------------------------------------------------------------------------- #
+# EXPECTED_SOURCES invariant
+# --------------------------------------------------------------------------- #
+def test_expected_sources_includes_opencode():
+    assert "opencode" in I.EXPECTED_SOURCES
+    ev = I.eval_unexpected_set(I.EXPECTED_SOURCES, "source")
+    assert ev([{"value": "opencode", "count": 3}])[0] is True


### PR DESCRIPTION
## Summary

Adds an OpenCode source to the activity telemetry pipeline, enabling tracking of OpenCode coding sessions alongside Claude Code, zsh, browser, and other sources.

## What's Added

### Source: `scripts/collector/opencode/`
- **`_shared.py`** — SQLite DB access, iterators (`iter_sessions`, `iter_messages`, `iter_parts`), timestamp conversion, spool bridge
- **`session_tailer.py`** — Emits `kind=session-summary` events with full rollup: tool counts, tokens, cost, duration, languages, git activity, error categories
- **`tailer.py`** — Emits `kind=prompt` (user) and `kind=assistant-turn` (assistant) events per message
- **`__main__.py`** — CLI: `python -m opencode [--mode tailer|session|all] [--db PATH] [--backfill] [--dry-run]`
- **`backfill.py`** — One-shot backfill of all historical sessions and messages

### Validation: `scripts/validation/`
- Added `"opencode"` to `EXPECTED_SOURCES` in `invariants.py`
- Added `read_opencode_sessions()` and `read_opencode_messages()` to `refsources.py`
- Added `reconcile_opencode()` to `reconcile.py`

## Test Coverage
151 tests across all phases:
- Phase 1 (core): 46 tests
- Phase 2 (session tailer): 38 tests
- Phase 3 (message tailer): 44 tests
- Phase 4 (CLI + backfill): 14 tests
- Phase 5 (validation): 9 tests

## Schema Notes
Validated against live `~/.local/share/opencode/opencode-stable.db`:
- snake_case columns (`tokens_input`, `time_created`) not camelCase
- JSON blobs for message/part `data` column
- `tokens_cache_write` not `tokens_cache_creation`

## Deployment
```bash
# Backfill historical data
python3 scripts/collector/opencode/backfill.py

# Verify
python3 scripts/validation/validate.py --help
```

Nix integration (systemd timer + home-manager) is ready but not included — needs `nix/home.nix` changes in a follow-up.