### PR TITLE
fix(browser-bridge): bound every CDP call so a hung debugger op can't wedge the SW

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -609,7 +609,11 @@ nix-shell -p nodejs --run "node --test scripts/browser-bridge/tests/*.test.mjs"
 The CDP (chrome.debugger) ops are covered deterministically without a real browser:
 `tests/cdp_protocol.test.mjs` unit-tests the pure decision layer (attach-scope
 refuse-before-attach, always-detach on success/error/detach-failure, frame
-enumeration/resolution, key/coordinate math, injection-safe expression builders);
+enumeration/resolution, key/coordinate math, injection-safe expression builders,
+and the **SW-side CDP timeouts**: a hung attach/command/detach settles with a
+`cdp_timeout:<phase>` error within a bounded budget — never wedging the poll loop
+— a discarded/unloaded tab fails fast with `tab_discarded`, and the no-wedge
+guarantee that the next op is still processed after a hung one);
 `tests/browser_tool.test.mjs` proves the typed tool forces the own-tab, forwards
 only whitelisted typed fields, and **drops any smuggled `cdp`/`method`/`params`
 field** (the RCE-class regression guard); `tests/test_server.py` proves the new ops
@@ -687,9 +691,9 @@ The **`browser agent`** slice, all headless (NO live model, NO Brave, NO bridge)
   inherited-group straggler → asserted reaped, no orphan); schema parse + EXACTLY
   ONE `--continue` retry then `blocked`, no-retry on a hard error.
 
-Current totals: **138 Python** (`test_server.py` 100 + `test_browser_agent_parse.py`
-14 + `test_browser_agent.py` 24) + **82 node** (`protocol.test.mjs` 58 +
-`browser_tool.test.mjs` 24) — the `protocol.test.mjs` cases cover the screenshot
+Current totals: **157 Python** (`test_server.py` 115 + `test_browser_agent_parse.py`
+14 + `test_browser_agent.py` 28) + **121 node** (`protocol.test.mjs` 59 +
+`browser_tool.test.mjs` 33 + `cdp_protocol.test.mjs` 29) — the `protocol.test.mjs` cases cover the screenshot
 settle+retry decision logic (`isTransientCaptureError` / `captureWithRetry` /
 `waitForCaptureReady` / `screenshotWithRestore`) **and the exhausted-retry error
 mapping** (`isOcclusionCaptureError` / `mapCaptureFailure`): a persistent readback

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -383,24 +383,113 @@ export function assertCdpAttachable(url) {
   }
 }
 
+// The actionable error when the target tab has no live renderer to attach to.
+export const TAB_DISCARDED_MESSAGE =
+  "tab_discarded: the target tab was unloaded by Chrome (memory saver) and has no " +
+  "live renderer to attach to — reload the tab or bring it to the foreground, then retry.";
+
+// Fail FAST (before any chrome.debugger.attach) when the target tab has no live
+// renderer. A DISCARDED / unloaded tab (Chrome's memory saver evicts background
+// tabs) has no renderer process, so chrome.debugger.attach / Page.getFrameTree
+// would NEVER resolve — the observed root cause of the SW wedge. Detecting it here
+// turns an unbounded hang into an immediate, clear, actionable error (and the
+// per-call timeouts in withCdpSession are the backstop for any OTHER hang cause).
+// `owned_tab_gone` when the tab is missing entirely. Pure — the SW passes the
+// chrome.tabs.get(tabId) result; unit-tested without a real browser.
+export function assertTabCdpReady(tab) {
+  if (!tab) throw new Error("owned_tab_gone");
+  if (tab.discarded || tab.status === "unloaded") throw new Error(TAB_DISCARDED_MESSAGE);
+}
+
+// --- SW-side CDP timeouts: never let a hung chrome.debugger call wedge the SW - //
+// A chrome.debugger.attach / sendCommand / detach that NEVER resolves (the
+// classic case: the tab was DISCARDED by Chrome's memory saver, so it has no live
+// renderer and Page.* never answers) would leave the SW's command handler blocked
+// on an unresolved await FOREVER — the /poll loop never resumes and the whole
+// instance silently drops (the bug this module fixes). So EVERY chrome.debugger
+// call is raced against a bounded timeout: on timeout the op SETTLES (rejects)
+// and control returns to the poll loop; the hung underlying promise is abandoned.
+//
+// Deadlines are chosen WELL UNDER the server's cmd_timeout (default 20s) so the
+// SW returns a clear error BEFORE the server gives up AND before the next /poll is
+// starved: attach ≤ ATTACH, each command ≤ COMMAND, whole op ≤ BUDGET (a cumulative
+// backstop). All injectable via `deps.timeouts`/`deps.timers` for deterministic
+// unit tests (no real clock needed).
+export const CDP_ATTACH_TIMEOUT_MS = 8000;
+export const CDP_COMMAND_TIMEOUT_MS = 8000;
+export const CDP_OP_BUDGET_MS = 15000;
+
+// Race `promise` against a `ms` deadline. On timeout, REJECT with
+// `cdp_timeout:<label>` (the phase — attach / a CDP method / op / detach) so the
+// caller sees WHICH call hung; the underlying promise is left pending (abandoned)
+// but the returned promise SETTLES, so the awaiter is never blocked past `ms`. A
+// promise that settles on its own (resolve OR reject) wins the race and its
+// value/error passes through unchanged, and the timer is cleared so nothing lingers.
+// `ms <= 0` disables the bound (returns the promise as-is). Timers injectable.
+export function promiseWithTimeout(promise, ms, label, timers = {}) {
+  const p = Promise.resolve(promise);
+  if (!(ms > 0)) return p;
+  const setT = timers.setTimeout || setTimeout;
+  const clearT = timers.clearTimeout || clearTimeout;
+  let handle;
+  const timeout = new Promise((_, reject) => {
+    handle = setT(() => reject(new Error(`cdp_timeout:${label}`)), ms);
+  });
+  return Promise.race([p, timeout]).finally(() => clearT(handle));
+}
+
 // Orchestrate a CDP op with a per-op attach→run→ALWAYS-detach lifecycle, every
 // chrome.debugger side effect INJECTED so the invariants are unit-testable without
 // a real browser:
 //   * the target URL is validated BEFORE attach — a privileged/other tab is refused
 //     and `attach` is NEVER called (invariant #1);
-//   * `detach` ALWAYS runs — on success AND on any error `run` throws (invariant #2)
-//     — so a debugger attachment can never leak (a leak = a stuck banner + an open
-//     surface);
-//   * a `detach` failure (tab already gone / already detached) is swallowed so it
-//     never masks the real result or the real error.
-// `deps`: { url, attach():Promise, run():Promise<result>, detach():Promise }.
+//   * every chrome.debugger call is TIME-BOUNDED (attach ≤ attachMs, each command ≤
+//     commandMs via the wrapped `send` handed to `run`, whole op ≤ budgetMs) so a
+//     hung CDP call can never wedge the SW's poll loop — the op settles with a
+//     `cdp_timeout:<phase>` error instead (the no-wedge guarantee);
+//   * `detach` ALWAYS runs — on success, on any error `run` throws, AND after a
+//     timed-out/failed attach (best-effort) — so a debugger attachment can never
+//     leak (a leak = a stuck banner + an open surface) even when attach hung
+//     (invariant #2);
+//   * a `detach` failure/HANG (tab already gone / already detached / no renderer)
+//     is bounded + swallowed so it never masks the real result/error or re-wedges
+//     the finally.
+// `deps`: { url, attach():Promise, detach():Promise, send?(method,params):Promise,
+//   run(send):Promise<result>, timeouts?:{attachMs,commandMs,budgetMs}, timers? }.
+// `send` is OPTIONAL: when present, `run` is handed a timeout-WRAPPED send so each
+// CDP command is individually bounded; when absent, `run` receives undefined
+// (back-compat with call sites that don't issue commands).
 export async function withCdpSession(deps) {
   assertCdpAttachable(deps.url);        // BEFORE attach — refuse privileged/other tab
-  await deps.attach();
+  const timers = deps.timers || {};
+  const t = deps.timeouts || {};
+  const attachMs = t.attachMs == null ? CDP_ATTACH_TIMEOUT_MS : t.attachMs;
+  const commandMs = t.commandMs == null ? CDP_COMMAND_TIMEOUT_MS : t.commandMs;
+  const budgetMs = t.budgetMs == null ? CDP_OP_BUDGET_MS : t.budgetMs;
+  // Bounded, best-effort detach — used in the finally AND after a failed attach so
+  // a late-completing attach can't leak a session. Its own timeout means a hung
+  // detach can't re-wedge the handler.
+  const safeDetach = async () => {
+    try { await promiseWithTimeout(deps.detach(), commandMs, "detach", timers); }
+    catch (e) { /* already detached / tab gone / detach timed out — best effort */ }
+  };
+  // Attach, time-bounded. On timeout/failure, best-effort detach (the attach may
+  // have half-completed / may complete late) then rethrow so the op fails cleanly.
   try {
-    return await deps.run();
+    await promiseWithTimeout(deps.attach(), attachMs, "attach", timers);
+  } catch (e) {
+    await safeDetach();
+    throw e;
+  }
+  try {
+    const rawSend = deps.send;
+    const send = rawSend
+      ? (method, params) => promiseWithTimeout(rawSend(method, params), commandMs, method, timers)
+      : undefined;
+    return await promiseWithTimeout(
+      Promise.resolve(deps.run(send)), budgetMs, "op", timers);
   } finally {
-    try { await deps.detach(); } catch (e) { /* already detached / tab gone */ }
+    await safeDetach();
   }
 }
 

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -23,7 +23,8 @@ import {
   classifyPollStatus, POLL_COMMAND, POLL_IDLE, POLL_SUPERSEDED,
   POLL_UNAUTHORIZED, SUPERSEDE_BACKOFF_MS, captureWithRetry,
   // CDP (chrome.debugger) helpers — the pure, unit-tested decision layer.
-  CDP_VERSION, withCdpSession, flattenFrameTree, resolveFrame, keyEventParams,
+  CDP_VERSION, withCdpSession, assertTabCdpReady,
+  flattenFrameTree, resolveFrame, keyEventParams,
   clickPoint, boxModelOrigin, frameEvalExpressions, isCdpSyntaxError,
   cdpExceptionText, frameHtmlExpression, frameTextExpression,
   elementRectExpression, focusExpression, fullPageClip,
@@ -109,6 +110,13 @@ async function withCdp(tabId, url, run) {
   return withCdpSession({
     url,
     attach: async () => {
+      // Fail fast on a discarded/unloaded tab (no live renderer → attach would
+      // hang forever). withCdpSession's per-call timeouts are the backstop for any
+      // other hang; this turns the common case into an immediate clear error.
+      let tab;
+      try { tab = await chrome.tabs.get(tabId); }
+      catch (e) { throw new Error("owned_tab_gone"); }
+      assertTabCdpReady(tab);
       await chrome.debugger.attach(target, CDP_VERSION);
       cdpAttached.add(tabId);
     },
@@ -116,7 +124,10 @@ async function withCdp(tabId, url, run) {
       cdpAttached.delete(tabId);
       await chrome.debugger.detach(target);
     },
-    run: () => run((method, params) => sendCdp(target, method, params)),
+    // Raw send — withCdpSession wraps it in the per-command timeout before handing
+    // it to `run`, so a single hung CDP command can't wedge the SW.
+    send: (method, params) => sendCdp(target, method, params),
+    run: (send) => run(send),
   });
 }
 

--- a/scripts/browser-bridge/tests/cdp_protocol.test.mjs
+++ b/scripts/browser-bridge/tests/cdp_protocol.test.mjs
@@ -14,7 +14,15 @@ import {
   keyEventParams, KEY_EVENTS, clickPoint, boxModelOrigin, frameEvalExpressions,
   isCdpSyntaxError, cdpExceptionText, frameHtmlExpression, frameTextExpression,
   elementRectExpression, focusExpression, fullPageClip,
+  promiseWithTimeout, assertTabCdpReady, TAB_DISCARDED_MESSAGE,
+  CDP_ATTACH_TIMEOUT_MS, CDP_COMMAND_TIMEOUT_MS, CDP_OP_BUDGET_MS,
 } from "../extension/protocol.js";
+
+// A promise that NEVER settles — models a hung chrome.debugger call (the wedge).
+const NEVER = () => new Promise(() => {});
+// Tiny, injected budgets so the timeout tests settle in milliseconds and PROVE
+// they bound by the (tiny) budget, NOT the 20s server cmd_timeout.
+const FAST = { attachMs: 20, commandMs: 20, budgetMs: 60 };
 
 test("CDP_VERSION is the stable 1.3 protocol channel", () => {
   assert.equal(CDP_VERSION, "1.3");
@@ -205,4 +213,133 @@ test("fullPageClip uses the css content size for a full-document capture", () =>
   assert.deepEqual(clip, { x: 0, y: 0, width: 1200, height: 5401, scale: 1 });
   assert.equal(fullPageClip({ contentSize: { width: 800, height: 600 } }).width, 800);
   assert.deepEqual(fullPageClip({}), { x: 0, y: 0, width: 0, height: 0, scale: 1 });
+});
+
+// --- SW-side CDP timeouts: a hung chrome.debugger call must NOT wedge the SW --- //
+// Root cause fixed here: a chrome.debugger.attach / sendCommand / detach that never
+// resolves (a discarded background tab has no renderer) left the SW's command
+// handler blocked on an unresolved await forever → the /poll loop never resumed →
+// the instance dropped. Every CDP call is now raced against a bounded timeout so
+// the op SETTLES and control returns to the poll loop.
+
+test("timeout budgets are chosen well under the 20s server cmd_timeout", () => {
+  for (const ms of [CDP_ATTACH_TIMEOUT_MS, CDP_COMMAND_TIMEOUT_MS, CDP_OP_BUDGET_MS]) {
+    assert.ok(ms > 0 && ms < 20000, `budget ${ms} must be >0 and < the 20s server timeout`);
+  }
+});
+
+test("promiseWithTimeout: a hung promise rejects with cdp_timeout:<label> (settles, not hangs)", async () => {
+  await assert.rejects(promiseWithTimeout(NEVER(), 10, "attach"), /^Error: cdp_timeout:attach$/);
+  // A promise that settles on its own wins the race unchanged (value + error).
+  assert.equal(await promiseWithTimeout(Promise.resolve(7), 1000, "x"), 7);
+  await assert.rejects(promiseWithTimeout(Promise.reject(new Error("boom")), 1000, "x"), /boom/);
+  // ms<=0 disables the bound (returns the value as-is, no timer).
+  assert.equal(await promiseWithTimeout(Promise.resolve(3), 0, "x"), 3);
+});
+
+test("withCdpSession: a HUNG attach rejects with cdp_timeout within the attach budget — no hang, best-effort detach", async () => {
+  let ran = false, detached = false;
+  const started = Date.now();
+  await assert.rejects(withCdpSession({
+    url: "https://x.test",
+    timeouts: FAST,
+    attach: NEVER,                              // attach never resolves
+    detach: async () => { detached = true; },
+    send: async () => ({}),
+    run: (send) => { ran = true; return send("Page.enable"); },
+  }), /cdp_timeout:attach/);
+  assert.equal(ran, false, "run must NOT start when attach never resolved");
+  assert.equal(detached, true, "a timed-out attach must still best-effort detach (no leaked session)");
+  assert.ok(Date.now() - started < 5000, "must settle by the tiny budget, not the 20s server timeout");
+});
+
+test("withCdpSession: a HUNG CDP command (e.g. Page.getFrameTree) rejects bounded + always detaches", async () => {
+  let detached = false;
+  await assert.rejects(withCdpSession({
+    url: "https://x.test",
+    timeouts: FAST,
+    attach: async () => {},
+    detach: async () => { detached = true; },
+    send: NEVER,                                // Page.getFrameTree never resolves
+    run: (send) => send("Page.getFrameTree"),
+  }), /cdp_timeout:Page\.getFrameTree/);
+  assert.equal(detached, true, "detach must run so no debugger session leaks after a hung command");
+});
+
+test("NO-WEDGE: a hung CDP op settles so the very NEXT op is processed (the core regression)", async () => {
+  // Op 1 hangs in a command → it must SETTLE (reject) and detach, returning control.
+  let detach1 = false;
+  await assert.rejects(withCdpSession({
+    url: "https://x.test", timeouts: FAST,
+    attach: async () => {}, detach: async () => { detach1 = true; },
+    send: NEVER, run: (send) => send("Page.getFrameTree"),
+  }), /cdp_timeout/);
+  assert.equal(detach1, true);
+  // Op 2, issued immediately after, runs normally — proving op 1 did NOT block the
+  // handler (in production this is the /poll loop continuing to the next command).
+  const out = await withCdpSession({
+    url: "https://x.test", timeouts: FAST,
+    attach: async () => {}, detach: async () => {},
+    send: async (m) => ({ ran: m }), run: (send) => send("Page.enable"),
+  });
+  assert.deepEqual(out, { ran: "Page.enable" }, "the next op must be processed after a hung one");
+});
+
+test("withCdpSession: a HUNG detach cannot re-wedge the finally — the op still settles", async () => {
+  const started = Date.now();
+  const out = await withCdpSession({
+    url: "https://x.test",
+    timeouts: FAST,
+    attach: async () => {},
+    detach: NEVER,                              // detach itself hangs
+    send: async () => "OK",
+    run: (send) => send("Page.captureScreenshot"),
+  });
+  assert.equal(out, "OK", "a hung detach must not block the op's already-computed result");
+  assert.ok(Date.now() - started < 5000, "the bounded detach lets the handler return quickly");
+});
+
+test("withCdpSession: the overall op BUDGET backstops a run that never settles", async () => {
+  await assert.rejects(withCdpSession({
+    url: "https://x.test",
+    timeouts: FAST,
+    attach: async () => {},
+    detach: async () => {},
+    send: async () => ({}),
+    run: NEVER,                                 // run resolves to a never-settling promise
+  }), /cdp_timeout:op/);
+});
+
+test("withCdpSession: per-command timeout wraps the send handed to run", async () => {
+  // The `send` given to run is the WRAPPED one — a slow command trips commandMs.
+  await assert.rejects(withCdpSession({
+    url: "https://x.test",
+    timeouts: { attachMs: 50, commandMs: 15, budgetMs: 500 },
+    attach: async () => {}, detach: async () => {},
+    send: NEVER, run: (send) => send("DOM.getBoxModel"),
+  }), /cdp_timeout:DOM\.getBoxModel/);
+});
+
+// --- discarded / unloaded tab (the probable root cause) --------------------- //
+test("assertTabCdpReady: a discarded/unloaded tab fails FAST (no attach on a dead renderer)", () => {
+  assert.throws(() => assertTabCdpReady({ discarded: true }),
+    new RegExp("tab_discarded"));
+  assert.throws(() => assertTabCdpReady({ status: "unloaded" }), /tab_discarded/);
+  assert.throws(() => assertTabCdpReady(null), /owned_tab_gone/);
+  // A live tab passes (any non-discarded status incl. loading/complete/undefined).
+  assert.doesNotThrow(() => assertTabCdpReady({ discarded: false, status: "complete" }));
+  assert.doesNotThrow(() => assertTabCdpReady({ status: "loading" }));
+  assert.doesNotThrow(() => assertTabCdpReady({}));
+  assert.ok(/reload the tab|foreground/.test(TAB_DISCARDED_MESSAGE),
+    "the message must tell the caller how to recover");
+});
+
+test("withCdpSession still enforces security: a privileged url is REFUSED before attach (unchanged)", async () => {
+  let attached = false;
+  await assert.rejects(withCdpSession({
+    url: "chrome://newtab", timeouts: FAST,
+    attach: async () => { attached = true; },
+    detach: async () => {}, send: async () => ({}), run: (s) => s("Page.enable"),
+  }), /cdp_attach_refused/);
+  assert.equal(attached, false, "the timeout wiring must not weaken the attach-scope invariant");
 });


### PR DESCRIPTION
## The bug (reproduced live)

Running `browser --tab <id> frames` and then `screenshot` on a **background cross-origin tab** (`civitai.com/apps/run/model-benchmarking`) both returned `{"error":"timeout"}` (server-side 20s `cmd_timeout`), and **afterward the `work` instance was DISCONNECTED** (only `personal` remained) — the service worker was wedged and never recovered until a manual extension reload. Journal: `dispatch frames` → `cmd_timeout` → `dispatch screenshot` → `cmd_timeout`, then no more work-instance activity.

**Root cause:** the SW awaited `chrome.debugger.attach` / `sendCommand` with **no SW-side timeout**. When a CDP call hangs — almost certainly because Chrome's **memory saver discarded the background tab** (a discarded tab has no live renderer, so `attach` / `Page.getFrameTree` never resolves) — the SW's command handler blocked forever on an unresolved `await`. The server's `cmd_timeout` fired for the caller, but the SW stayed stuck and never resumed its `/poll` loop, so the whole instance dropped. A hung CDP op should fail that **one op**, never take down the instance.

## The fix (SW-side, in the pure/unit-tested decision layer)

All timeout orchestration lives in `extension/protocol.js`'s `withCdpSession` so it's deterministically testable without a real browser; `service_worker.js` stays thin glue.

- **Per-call timeouts on every `chrome.debugger` call.** `promiseWithTimeout` races each call against a bounded deadline: **attach ≤ 8s**, **each command ≤ 8s** (via a timeout-wrapped `send` handed to `run`), **whole op ≤ 15s budget** — all **well under** the 20s server `cmd_timeout`, so the SW settles and returns a clear `cdp_timeout:<phase>` error *before* the server gives up and *before* the next `/poll` is starved. The handler **always settles**; a hung underlying promise is abandoned but no longer blocks the loop.
- **No leaked debugger session.** A timed-out/failed attach still triggers a best-effort (bounded) `detach`, and the `finally` detach is itself bounded so a **hung detach can't re-wedge** the handler.
- **Discarded-tab handling (the probable root cause).** `assertTabCdpReady` checks `chrome.tabs.get(tabId).discarded`/`status` **before any attach** and **fails fast** with an actionable `tab_discarded: reload the tab or bring it to the foreground` error instead of hanging on a dead renderer. (Chosen fail-fast over auto-reload: a single `chrome.tabs.get` is 100% bounded and doesn't mutate the user's tab; the per-call timeouts are the backstop for any *other* hang cause.)
- **No-wedge guarantee:** after any CDP op fails/times out (including a hung attach), the SW still processes the next command — the instance stays connected.

### Security invariants from #187 preserved exactly
Attach-scope still validated **before** attach (own-tab-only, `http`/`https` only, privileged tabs refused); still **no raw-CDP passthrough** (typed ops only — no `cdp`/`method`/`params` surface); `detach` still **always** runs. The timeout wiring adds no new attach path.

## Tests

`tests/cdp_protocol.test.mjs` (node:test) with **injectable budgets** (no real clock) — settle in milliseconds, proving they bound by the budget, not the 20s server timeout:
- hung `attach` → rejects `cdp_timeout:attach` within budget, detach attempted, `run` never starts;
- hung `sendCommand` (`Page.getFrameTree`) → bounded reject + detach;
- **NO-WEDGE regression:** a hung op settles so the very next op is processed;
- hung `detach` can't re-wedge the finally;
- op-budget backstops a never-settling `run`;
- discarded/unloaded tab → fail-fast `tab_discarded` (no attach on a dead renderer);
- `promiseWithTimeout` unit behaviour; attach-scope refusal unchanged.

**Totals: 121 node (was 111) + 157 python (unchanged — server untouched).** `node --check` on both JS files and `bash -n browser` pass.

## Honest verification / mandatory manual live check

Live `chrome.debugger` needs real Brave, so the timeout/no-wedge/discarded decision logic is unit-tested deterministically. **Manual check (requires an extension RELOAD to pick up the new SW):**
1. Reload the browser-bridge extension.
2. `browser --tab <background/discarded tab id> frames` → returns a clear error (`tab_discarded` or `cdp_timeout:*`) and does **NOT** disconnect the instance.
3. `browser --instance work eval '1'` on the same instance still works → proves **no wedge**.
4. `browser --tab <live, recently-foregrounded cross-origin tab> frames` / `screenshot` → succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)