### PR TITLE
fix(browser-bridge): reach cross-origin OOPIF iframes via webNavigation + scripting

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -132,17 +132,20 @@ always-detach) is in the **CDP ops** section below.
 | `screenshot` | **CDP `Page.captureScreenshot`** (png) — works on a BACKGROUND/occluded tab + each profile's own tab; a foreground tab uses the cheap `captureVisibleTab` fast path. `fullpage` grabs the whole document | `{url,dataUrl,via}` |
 | `open`       | `chrome.tabs.create({url,active:false})`                 | `{tabId,url}` |
 | `close`      | `chrome.tabs.remove(tabId)`                               | `{closed:tabId}` |
-| `frames`     | **CDP `Page.getFrameTree`** — the tab's frames incl. cross-origin iframes | `{url,title,frames:[{frameId,url,name,parentId}]}` |
-| `click`      | **CDP** `getBoundingClientRect` → `Input.dispatchMouseEvent` press+release (trusted) at the element center; `selector` required, `frame` optional | `{url,clicked,x,y,frame}` |
-| `type`       | **CDP `Input.insertText`** (trusted); `text` required, `selector`/`frame` optional (focus first) | `{url,typed,frame}` |
-| `key`        | **CDP `Input.dispatchKeyEvent`** (keyDown+keyUp) for one bounded key; `key` required | `{url,key,frame}` |
+| `frames`     | **`chrome.webNavigation.getAllFrames`** — the tab's frames INCLUDING cross-origin OUT-OF-PROCESS iframes (OOPIFs) | `{url,title,frames:[{frameId,url,parentFrameId}]}` |
+| `click`      | top frame: **CDP** `getBoundingClientRect` → `Input.dispatchMouseEvent` (trusted); `--frame`: **SYNTHETIC** click via `chrome.scripting`; `selector` required, `frame` optional | `{url,clicked,x,y,frame,trusted}` |
+| `type`       | top frame: **CDP `Input.insertText`** (trusted); `--frame`: **SYNTHETIC** input via `chrome.scripting`; `text` required, `selector`/`frame` optional | `{url,typed,frame,trusted}` |
+| `key`        | top frame: **CDP `Input.dispatchKeyEvent`** (trusted); `--frame`: **SYNTHETIC** key via `chrome.scripting`; one bounded key; `key` required | `{url,key,frame,trusted}` |
 
 `open`/`close` are dispatched to the extension; `release` (drop ownership, don't
 close the tab) is handled server-side and never reaches the extension.
-`frames`/`click`/`type`/`key` + a `--frame` on `getHtml`/`text`/`eval` are the
-**CDP (chrome.debugger) ops** (see the CDP section below). `--frame <frameId|
-url-substring>` routes a read/click INTO that (possibly cross-origin) frame via a
-CDP isolated-world `Runtime.evaluate`. The tab-scoped ops
+`frames` enumerates via **`chrome.webNavigation`** and a `--frame` on
+`getHtml`/`text`/`eval`/`click`/`type`/`key` injects via **`chrome.scripting`** INTO
+the resolved frame — this reaches CROSS-ORIGIN out-of-process iframes (OOPIFs) that
+CDP `Page.getFrameTree` could NOT enumerate. `--frame <numeric-frameId|url-substring>`
+selects the frame (the identifier is the numeric webNavigation `frameId`). `screenshot`
+and TOP-frame trusted input still use **CDP (chrome.debugger)** (see the CDP section
+below). The tab-scoped ops
 (`getHtml`/`text`/`eval`/`nav`/`screenshot`/`close`/`frames`/`click`/`type`/`key`)
 run against
 the calling session's owned tab when it has one (see Session isolation), else the
@@ -161,14 +164,25 @@ structured error: `503 extension_not_connected`, `504 timeout`,
 `403 bad_host`, `429 rate_limited|queue_full` (the per-instance concurrency
 backstop — see below; body carries a `retry_after` hint).
 
-## CDP ops (chrome.debugger): any-frame reads, trusted input, background screenshots
+## Frame ops (webNavigation + scripting) & CDP ops (debugger)
 
-`frames`/`click`/`type`/`key`, `--frame` reads, and `screenshot` use the Chrome
-DevTools Protocol via the extension's `debugger` permission. They fix three real
-agent failures: (1) `captureVisibleTab` could only grab the foreground tab (can't
-screenshot a background tab or two profiles); (2) `text`/`html`/`eval` saw only the
-top frame (the target app is a cross-origin iframe); (3) there was no trusted-input
-primitive to drive an app.
+**Cross-origin frames (OOPIFs) — `frames` + `--frame`.** `frames` enumerates via
+`chrome.webNavigation.getAllFrames` and `--frame` reads/input inject via
+`chrome.scripting.executeScript({target:{frameIds:[id]}})`. This fixes the
+cross-origin-iframe gap: under Chrome site isolation a cross-origin iframe is an
+OUT-OF-PROCESS iframe (OOPIF) in its own renderer, which CDP `Page.getFrameTree` from
+the top tab target does NOT enumerate — so `frames` never listed it and `--frame` could
+never target it. `getAllFrames` sees OOPIFs and `scripting` injects into them (given
+`<all_urls>`), with NO debugger banner. The frame identifier is the **numeric**
+webNavigation `frameId`. In-frame input is **SYNTHETIC** (`isTrusted:false`) — the
+reachable OOPIF path (a trusted CDP `Input.*` event from the top target can't easily
+reach an OOPIF), and enough to drive most apps.
+
+**CDP ops (`chrome.debugger`) — `screenshot` + TOP-frame trusted input.** These use the
+Chrome DevTools Protocol via the `debugger` permission. They fix two real agent
+failures: (1) `captureVisibleTab` could only grab the foreground tab (can't screenshot
+a background tab or two profiles); (2) there was no trusted-input primitive to drive an
+app's top frame.
 
 **Design — per-op attach → run → always-detach.** The extension attaches
 `chrome.debugger` for the single op, runs a FIXED set of CDP methods, and detaches
@@ -380,9 +394,10 @@ first-class self-telemetry in ClickHouse `activity.events`:
 - **METADATA-ONLY (privacy):** it emits **only** the op name, instance key,
   outcome, latency, and the active tab's **bare domain** — **never** the eval
   source, page HTML, screenshot bytes/data-URLs, a full URL with path/query, or
-  any page content. For the CDP ops this specifically means **no frame URLs**
-  (only the bare top-level domain), **no typed text** (`type`), and no click
-  selector — the domain is derived only from the result's top-level `url`.
+  any page content. For the frame/input ops this specifically means **no frame URLs**
+  (the `frames` result lists them to the caller, but telemetry keeps only the bare
+  top-level domain), **no typed text** (`type`), and no click selector — the domain is
+  derived only from the result's top-level `url`.
 - **Best-effort / fire-and-forget:** emitting runs **after** the HTTP response is
   sent and can never delay or break a command — a missing collector, unwritable
   spool, or any exception is swallowed and the command still succeeds. No new

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -104,42 +104,54 @@ Prefix any op with `--instance <key>` to target a specific connected profile
 | `browser [--instance K] release`           | drop ownership WITHOUT closing the tab |
 | `browser [--instance K] [--tab T] html`              | `outerHTML` of the owned tab (else the active tab) |
 | `browser [--instance K] [--tab T] text [selector] [--max-bytes N]` | **cheap read** — visible `innerText` of the owned/active tab (optional CSS `selector`), whitespace-normalized + byte-capped (default 32768; `0`=uncapped; a truncation note is appended). ~98% smaller than `html` — prefer it |
-| `browser [--instance K] [--tab T] [--frame F] eval '<js>'` | run JS in the owned/active tab, return its value (`--frame` runs it inside a cross-origin frame — CDP, isolated world) |
+| `browser [--instance K] [--tab T] [--frame F] eval '<js>'` | run JS in the owned/active tab, return its value (`--frame` runs it INSIDE a cross-origin OOPIF via `chrome.scripting`, isolated world) |
 | `browser [--instance K] tabs`              | list open tabs (`.data.ownedTabId` flags this session's owned tab) |
 | `browser [--instance K] [--tab T] nav <url>`         | navigate the owned/active tab to `<url>` |
 | `browser [--instance K] [--tab T] screenshot [path] [--fullpage]` | screenshot via **CDP `Page.captureScreenshot`** — **works on a BACKGROUND/occluded tab** and on each profile's own tab (a foreground tab uses the cheap captureVisibleTab fast path). `--fullpage` grabs the whole scrollable document. Prints the data URL, or writes a `.png` to `path` |
-| `browser [--instance K] [--tab T] frames`  | list the tab's frames (`frameId`/`url`/`name`), **including cross-origin iframes** — pick one for `--frame` |
-| `browser [--instance K] [--tab T] [--frame F] click <selector>` | **TRUSTED** CDP click at the element's center |
-| `browser [--instance K] [--tab T] [--frame F] type <text> [--selector S]` | **TRUSTED** CDP text input (focus `--selector` first if given) |
-| `browser [--instance K] [--tab T] [--frame F] key <Enter\|Tab\|Escape\|Backspace\|Delete\|Arrow*\|Home\|End\|Page*> [--selector S]` | dispatch one **TRUSTED** key to the focused element |
+| `browser [--instance K] [--tab T] frames`  | list the tab's frames (`frameId`/`url`/`parentFrameId`) via `chrome.webNavigation`, **INCLUDING cross-origin OUT-OF-PROCESS iframes (OOPIFs)** — pick a numeric `frameId` (or url-substring) for `--frame` |
+| `browser [--instance K] [--tab T] [--frame F] click <selector>` | click the element's center — **TRUSTED** CDP on the top frame; **SYNTHETIC** (`chrome.scripting`) inside a cross-origin `--frame` |
+| `browser [--instance K] [--tab T] [--frame F] type <text> [--selector S]` | text input — **TRUSTED** CDP top frame; **SYNTHETIC** in-frame (focus `--selector` first if given) |
+| `browser [--instance K] [--tab T] [--frame F] key <Enter\|Tab\|Escape\|Backspace\|Delete\|Arrow*\|Home\|End\|Page*> [--selector S]` | dispatch one bounded key — **TRUSTED** CDP top frame; **SYNTHETIC** in-frame |
 | `browser [--instance K] agent "<goal>" [flags]` | run the **autonomous opencode browser-agent** in its OWN isolated tab against `<goal>`; returns a compact `{answer,evidence,steps_used,status}` (see below) |
 | `browser --print-session-id`               | print the derived per-session id (debug) and exit |
 
-`--frame <F>` (a `frameId` from `frames`, or a URL substring) routes a
-`text`/`html`/`eval`/`click`/`type`/`key` INTO that (possibly cross-origin) frame.
-A frame-scoped `eval`/read runs in an **isolated world** (DOM-capable; it does not
-see that frame's page globals).
+`--frame <F>` (a **numeric** `frameId` from `frames`, or a URL substring) routes a
+`text`/`html`/`eval`/`click`/`type`/`key` INTO that frame via `chrome.scripting` —
+which reaches CROSS-ORIGIN out-of-process iframes (OOPIFs). A frame-scoped `eval`/read
+runs in an **isolated world** (DOM-capable; it does not see that frame's page globals).
+In-frame `click`/`type`/`key` dispatch **SYNTHETIC** events (`isTrusted:false`, the
+reachable OOPIF path — drives most apps); the result carries `trusted:false` for
+`--frame` input and `trusted:true` for top-frame CDP input.
 
 Result payloads land under `.result.data` in the JSON (the envelope is
 `{"ok":true,"result":{"id","ok","data":{...}}}`).
 
-## CDP ops (chrome.debugger): any-frame reads + trusted input + background screenshots
+## Frame ops (webNavigation + scripting) & CDP ops (debugger)
 
-`frames`/`click`/`type`/`key`, `--frame` reads, and `screenshot` use the Chrome
-DevTools Protocol via the `debugger` permission. They fix three real limitations:
+`frames` + `--frame` reach cross-origin OUT-OF-PROCESS iframes (OOPIFs) via
+`chrome.webNavigation` + `chrome.scripting`; `screenshot` + TOP-frame trusted input use
+the Chrome DevTools Protocol (`debugger` permission). Together they fix three real
+limitations:
 
 1. **Screenshot a BACKGROUND / occluded tab** (and each profile's own tab) — CDP
    `Page.captureScreenshot` does not need the tab to be the on-screen foreground
    tab, so the old i3 "not visible on-screen" limitation is gone for the normal
    path. (`--fullpage` grabs the whole scrollable document.)
-2. **Read INTO a cross-origin iframe** — `browser --tab T frames` lists the frames
-   (e.g. `model-benchmarking.civit.ai` inside `civitai.com`); then
-   `browser --tab T --frame <id-or-url> text` reads inside it. Plain `text`/`html`/
-   `eval` still see only the top frame.
-3. **Drive an app with trusted input** — `click`/`type`/`key` dispatch real
-   `isTrusted` events (reach an in-app tab, fill a field, submit a generation).
+2. **Read/drive INTO a CROSS-ORIGIN iframe (the OOPIF fix)** — `browser --tab T frames`
+   now LISTS the cross-origin frame (e.g. `model-benchmarking.civit.ai` inside
+   `civitai.com`) because `chrome.webNavigation.getAllFrames` enumerates OOPIFs that
+   CDP `Page.getFrameTree` could not; then `browser --tab T --frame <numericId-or-url>
+   text` reads inside it and `--frame … click/type/key` drives an in-app control (via
+   `chrome.scripting` injection). Plain `text`/`html`/`eval` still see only the top
+   frame.
+3. **Drive an app's TOP frame with trusted input** — top-frame `click`/`type`/`key`
+   dispatch real `isTrusted` events via CDP. (In a cross-origin `--frame`, input is
+   SYNTHETIC — see above.)
 
 **Security model (built in — this is the point):**
+- **Frame enumeration + injection are STRICTLY own-tab-scoped.** `getAllFrames` and
+  `executeScript` are tab-scoped, so a model-supplied `--frame` can only ever resolve
+  to / inject into a frame of the session's owned/`--tab` tab — never another tab.
 - **CDP attach is STRICTLY own-tab-scoped.** The server routes a CDP op only to the
   session's owned/`--tab` tab; the extension attaches `chrome.debugger` ONLY to that
   tab and **refuses to attach to a privileged surface** (`chrome://`, extension,

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -47,22 +47,30 @@
 #                               occluded tab and on each profile's own tab; a
 #                               foreground tab uses the cheap captureVisibleTab fast
 #                               path. --fullpage grabs the whole scrollable document.
-#   browser frames            — list the tab's frames (frameId/url/name), incl.
-#                               cross-origin iframes (CDP) — pick one for --frame
+#   browser frames            — list the tab's frames (frameId/url/parentFrameId),
+#                               INCLUDING cross-origin OUT-OF-PROCESS iframes (via
+#                               chrome.webNavigation) — pick a numeric frameId (or
+#                               url-substring) for --frame
 #   browser [--frame <f>] click <selector>
-#                             — TRUSTED CDP click at the element's center
+#                             — click the element's center (TRUSTED CDP on the top
+#                               frame; SYNTHETIC in a cross-origin --frame)
 #   browser [--frame <f>] type <text> [--selector <sel>]
-#                             — TRUSTED CDP text input (focus --selector first if given)
+#                             — text input (TRUSTED CDP top frame; SYNTHETIC in-frame);
+#                               focus --selector first if given
 #   browser [--frame <f>] key <Enter|Tab|Escape|...> [--selector <sel>]
-#                             — dispatch one TRUSTED key to the focused element
+#                             — dispatch one bounded key (TRUSTED CDP top frame;
+#                               SYNTHETIC in-frame)
 #   browser agent "<goal>"    — run the autonomous opencode browser-agent in its
 #                               OWN isolated tab against <goal> (see browser-agent)
 #   browser --print-session-id — print the derived per-session id and exit
 #
 # Global flags (before the subcommand): --instance <key>, --tab <id>,
 #   --frame <frameId|url-substring> (route a read/click INTO a cross-origin frame).
-# The CDP ops (screenshot/frames/click/type/key + --frame reads) use chrome.debugger
-# and attach ONLY to the owned/target tab (a privileged chrome://—etc. tab is refused).
+# Frame enumeration + --frame reads/input use chrome.webNavigation + chrome.scripting,
+# which reach CROSS-ORIGIN out-of-process iframes (OOPIFs) that CDP getFrameTree could
+# NOT see. `screenshot` still uses chrome.debugger (CDP), attaching ONLY to the owned/
+# target tab (a privileged chrome://—etc. tab is refused). In-frame input is SYNTHETIC
+# (isTrusted:false); top-frame input stays TRUSTED (CDP Input.*).
 #
 # Output is JSON on stdout (pretty-printed if `jq` is present). Exit non-zero on
 # transport/HTTP error so a caller can branch.
@@ -215,7 +223,8 @@ cmd_op() {
     case "$TAB" in (*[!0-9]*|"") die "--tab must be a numeric tab id (got: $TAB)";; esac
     tabf=",\"tab\":${TAB}"
   fi
-  # --frame routes a read/click INTO a specific (cross-origin) frame via CDP. The
+  # --frame routes a read/click INTO a specific (cross-origin OOPIF) frame; the
+  # extension resolves it via chrome.webNavigation + injects via chrome.scripting. The
   # server forwards it verbatim to the extension; ops that ignore it are unaffected.
   local framef=""
   if [ -n "$FRAME" ]; then framef=",\"frame\":$(json_str "$FRAME")"; fi
@@ -380,20 +389,22 @@ print(sys.argv[1])
     fi
     ;;
   frames)
-    # List the owned/active tab's frames (frameId/url/name) so you can pick one for
-    # --frame. Cross-origin iframes are included (via CDP Page.getFrameTree).
+    # List the owned/active tab's frames (frameId/url/parentFrameId) so you can pick
+    # one for --frame. Cross-origin OUT-OF-PROCESS iframes ARE included (via
+    # chrome.webNavigation.getAllFrames — CDP Page.getFrameTree missed them).
     cmd_op frames | pretty
     ;;
   click)
-    # browser [--frame <f>] click <selector> — TRUSTED CDP click at the element's
-    # center (frame-aware via the global --frame).
+    # browser [--frame <f>] click <selector> — click the element's center. Top frame:
+    # TRUSTED CDP. Cross-origin --frame: SYNTHETIC click injected via chrome.scripting.
     [ $# -ge 1 ] || die "usage: browser [--frame <f>] click <css-selector>"
     sel="$(json_str "$1")"
     cmd_op click "\"selector\":${sel}" | pretty
     ;;
   type)
-    # browser [--frame <f>] type <text> [--selector <sel>] — TRUSTED CDP text input
-    # into the focused element (or --selector first).
+    # browser [--frame <f>] type <text> [--selector <sel>] — text input into the
+    # focused element (or --selector first). Top frame: TRUSTED CDP. Cross-origin
+    # --frame: SYNTHETIC input (set value + input/change) via chrome.scripting.
     txt=""; tsel=""
     while [ $# -gt 0 ]; do
       case "$1" in

--- a/scripts/browser-bridge/extension/README.md
+++ b/scripts/browser-bridge/extension/README.md
@@ -127,23 +127,40 @@ SW and can only be checked in a real browser — see the checklist below.)
 click the **reload** ↻ button on the extension's card in `brave://extensions`,
 or the service worker keeps running the old code.
 
-> **MANDATORY reload after the CDP change:** the manifest now requests the
-> `debugger` permission (for the CDP ops — screenshot/frames/click/type/key +
-> `--frame` reads). A permission change is NOT hot-applied — reload the unpacked
-> extension in `brave://extensions`, and Brave may prompt you to **re-confirm the
-> new `debugger` permission**. Until you do, the CDP ops fail.
+> **MANDATORY reload after a permission change:** the manifest requests the
+> `debugger` permission (screenshot + TOP-frame trusted input) AND the
+> `webNavigation` permission (OOPIF-capable `frames` enumeration). A permission
+> change is NOT hot-applied — reload the unpacked extension in `brave://extensions`,
+> and Brave may prompt you to **re-confirm the new permissions**. Until you do, the
+> affected ops fail.
 
 ## Permissions (maximal — can be scoped later)
 
-`scripting`, `tabs`, `activeTab`, `alarms`, `storage`, `debugger`, and
-`host_permissions: ["<all_urls>"]`. `<all_urls>` + `scripting` is what lets the
-worker run in whatever tab is active. If you only ever drive a known set of
+`scripting`, `tabs`, `activeTab`, `alarms`, `storage`, `debugger`,
+`webNavigation`, and `host_permissions: ["<all_urls>"]`. `<all_urls>` + `scripting`
+is what lets the worker run in whatever tab is active — and, crucially, inject INTO a
+cross-origin out-of-process iframe (OOPIF). If you only ever drive a known set of
 sites, scope `host_permissions` to those origins and reload.
 
-### `debugger` — the CDP ops (screenshot/frames/click/type/key + `--frame`)
+### `webNavigation` + `scripting` — OOPIF-capable frames + `--frame` reads/input
+
+`frames` enumerates via **`chrome.webNavigation.getAllFrames`** and `--frame`
+reads/input inject via **`chrome.scripting.executeScript({target:{frameIds:[id]}})`**.
+This is the fix for the cross-origin-iframe gap: CDP `Page.getFrameTree` from the top
+tab target only sees SAME-PROCESS frames, so a cross-origin OOPIF (its own renderer
+under site isolation) was invisible — `frames` couldn't list it and `--frame` couldn't
+target it. `getAllFrames` enumerates OOPIFs; `scripting` injects into them (given
+`<all_urls>`), NO debugger banner. The frame identifier is the **numeric webNavigation
+`frameId`** (or a URL substring). In-frame input events are **SYNTHETIC**
+(`isTrusted:false`) — the reachable OOPIF path, and enough to drive most apps; TOP-frame
+input stays CDP-**trusted**.
+
+### `debugger` — screenshots + TOP-frame trusted input
 
 `chrome.debugger` is the biggest-blast-radius permission, so the CDP layer is
-tightly bounded (all decision logic is pure + unit-tested in `protocol.js`):
+tightly bounded (all decision logic is pure + unit-tested in `protocol.js`). It is now
+used ONLY for `screenshot` (works on a background/occluded tab) and TOP-frame trusted
+`click`/`type`/`key` (no `--frame`):
 
 - **Own-tab attach ONLY.** A CDP op attaches `chrome.debugger` ONLY to the
   server-injected owned/`--tab` tab, and **refuses to attach to a privileged
@@ -156,8 +173,9 @@ tightly bounded (all decision logic is pure + unit-tested in `protocol.js`):
 - **Typed commands only.** The SW maps each bounded op to a FIXED set of CDP methods;
   there is NO generic "run this CDP method" endpoint reachable by a caller/model.
 - **Banner tradeoff:** Brave shows "an extension is debugging this browser" while a
-  CDP op runs. Attach is per-op to keep that window tiny; simple top-frame
-  `text`/`html`/`eval`/foreground-`screenshot` take the non-CDP path (no banner).
+  CDP op runs. Attach is per-op to keep that window tiny; `text`/`html`/`eval`
+  (top-frame AND `--frame`), `frames`, `--frame` input, and foreground-`screenshot`
+  all take the non-CDP path (no banner).
 
 ## Stable extension ID (optional)
 
@@ -221,13 +239,17 @@ The chrome.* glue needs a real browser — verify by hand after loading:
 - [ ] **Two profiles each screenshot independently:** two Brave profiles (distinct
       labels), each `open` + `screenshot --tab <id>` its own tab → each writes its
       OWN tab's PNG even though only one profile is foreground.
-- [ ] **Read INTO a cross-origin iframe:** open a page with a cross-origin iframe
-      (e.g. `civitai.com` embedding `model-benchmarking.civit.ai`). `browser --tab
-      <id> frames` lists the iframe; `browser --tab <id> --frame <frameId-or-url>
-      text` returns the iframe's innerText (plain `text` shows only the top frame).
-- [ ] **Trusted click drives an in-app control:** `browser --tab <id> [--frame <f>]
-      click "<selector>"` reaches an in-app tab/button; `type`/`key Enter` fill +
-      submit. Confirm the app reacts as to a human click.
+- [ ] **Read INTO a CROSS-ORIGIN (OOPIF) iframe:** open a page embedding a
+      cross-origin iframe (e.g. `civitai.com/apps/run/model-benchmarking` embedding
+      `model-benchmarking.civit.ai`). `browser --tab <id> frames` MUST now LIST the
+      cross-origin `model-benchmarking.civit.ai` frame (the whole point — CDP
+      getFrameTree missed it); `browser --tab <id> --frame <numericId-or-url> text`
+      returns THAT frame's innerText (plain `text` shows only the top frame).
+- [ ] **Drive an in-app control INSIDE the cross-origin iframe:** `browser --tab <id>
+      --frame <f> click "<selector>"` reaches a control inside the OOPIF; `--frame <f>
+      type`/`--frame <f> key Enter` fill + submit. Input is SYNTHETIC in-frame
+      (isTrusted:false) — confirm the app reacts. Top-frame (no `--frame`) input stays
+      CDP-trusted.
 - [ ] **CDP attach is refused on a privileged tab:** point `--tab` at a
       `chrome://`/extension page and run a CDP op → it fails with
       `cdp_attach_refused:<scheme>` and NEVER attaches the debugger.

--- a/scripts/browser-bridge/extension/manifest.json
+++ b/scripts/browser-bridge/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "Browser Bridge (command channel)",
   "version": "0.1.0",
   "description": "Lets a local Claude Code skill drive the active Brave tab (getHtml/eval/tabs/nav/screenshot/frames/click/type/key) via a loopback, token-authenticated rendezvous server. Local-only, authorized personal automation.",
-  "permissions": ["scripting", "tabs", "activeTab", "storage", "alarms", "debugger"],
+  "permissions": ["scripting", "tabs", "activeTab", "storage", "alarms", "debugger", "webNavigation"],
   "host_permissions": ["http://127.0.0.1:8788/*", "<all_urls>"],
   "icons": {
     "16": "icons/icon-16.png",

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -639,6 +639,167 @@ export function focusExpression(selector) {
          `el.focus();return true;})(${sel})`;
 }
 
+// --- OOPIF-capable frame ops: chrome.webNavigation + chrome.scripting --------- //
+// WHY this replaced the CDP `Page.getFrameTree` frame path (the OOPIF bug):
+// `Page.getFrameTree` from the TOP tab target only enumerates SAME-PROCESS frames.
+// Under Chrome's site isolation a CROSS-ORIGIN iframe is an OUT-OF-PROCESS iframe
+// (OOPIF) living in a SEPARATE renderer/target, so getFrameTree from the top tab
+// silently OMITS it — `frames` could never list it and `--frame` could never
+// target it (the whole point of a cross-origin embed like model-benchmarking.civit.ai).
+//
+// The fix uses the two chrome.* APIs that ARE OOPIF-aware:
+//   * chrome.webNavigation.getAllFrames({tabId}) enumerates EVERY frame in the tab
+//     — same-process AND cross-origin OOPIFs — as {frameId:<number>, parentFrameId,
+//     url}. This is the enumeration `frames` returns and `--frame` resolves against.
+//   * chrome.scripting.executeScript({target:{tabId, frameIds:[id]}}) injects INTO a
+//     specific frame — including a cross-origin OOPIF, given the extension's
+//     <all_urls> host permission — so a frame read/click/type/key reaches the OOPIF
+//     where CDP could not, and WITHOUT the chrome.debugger banner.
+//
+// The frame IDENTIFIER is therefore the NUMERIC webNavigation frameId (NOT the old
+// CDP string frame id). Enumeration + resolution are pure + unit-tested here; the SW
+// is the thin chrome.webNavigation/chrome.scripting glue.
+
+// Map a chrome.webNavigation.getAllFrames() result to the compact, METADATA-ONLY
+// list the `frames` op returns: [{frameId:<number>, url, parentFrameId:<number>}].
+// The top frame is frameId 0 / parentFrameId -1. Entries without a numeric frameId
+// are dropped defensively. NEVER includes frame CONTENT — id/url/parent only. Pure.
+export function normalizeWebNavFrames(frames) {
+  const out = [];
+  for (const f of frames || []) {
+    if (!f || typeof f.frameId !== "number") continue;
+    out.push({
+      frameId: f.frameId,
+      url: f.url || "",
+      parentFrameId: (typeof f.parentFrameId === "number") ? f.parentFrameId : -1,
+    });
+  }
+  return out;
+}
+
+// Resolve a caller `--frame <sel>` against a normalized getAllFrames list, returning
+// the NUMERIC frameId to inject into. `sel` may be an exact numeric frameId (e.g. "0"
+// or 5 — the webNavigation id) OR a URL substring (case-insensitive). An exact
+// frameId match WINS over a substring; among substring matches the FIRST (list order)
+// wins deterministically. Throws `frame_not_found:<sel>` when nothing matches and
+// `frame_not_specified` for an empty sel (a caller bug — the SW only calls this when
+// a frame IS targeted). Tab-scoped by construction: `frames` comes from ONE tab's
+// getAllFrames, so a resolved frameId can only ever reference a frame of THAT tab —
+// a frameId belonging to another tab is simply absent → frame_not_found. Pure.
+export function resolveWebNavFrameId(frames, sel) {
+  const s = String(sel == null ? "" : sel).trim();
+  if (!s) throw new Error("frame_not_specified");
+  if (/^\d+$/.test(s)) {
+    const n = Number(s);
+    for (const f of frames || []) if (f.frameId === n) return n;
+  }
+  const low = s.toLowerCase();
+  for (const f of frames || []) {
+    if ((f.url || "").toLowerCase().includes(low)) return f.frameId;
+  }
+  throw new Error(`frame_not_found:${s}`);
+}
+
+// --- injected page functions (run INSIDE the resolved frame via executeScript) --- //
+// These are handed to chrome.scripting.executeScript as `func` (with `args`), so
+// Chrome serializes each via Function.prototype.toString and runs it in the target
+// frame — INCLUDING a cross-origin OOPIF. HARD REQUIREMENT: each must be SELF-
+// CONTAINED — reference ONLY its own parameters and page globals (document / window /
+// MouseEvent / KeyboardEvent / Event). It must close over NOTHING from this module
+// (a closed-over reference is undefined once serialized into the page). They return
+// STRUCTURED-CLONEABLE values (executeScript deep-clones the result across the
+// process boundary). Exported so their behaviour is unit-tested directly.
+//
+// TRUST NOTE (documented, honest): events these dispatch are SYNTHETIC
+// (`isTrusted === false`), NOT the CDP `Input.*` trusted events. A trusted event
+// from the top tab target cannot easily reach an OOPIF, so synthetic-in-frame is the
+// REACHABLE path for cross-origin-frame input — and it drives the vast majority of
+// web apps (which listen for ordinary click/input/keydown). The top-frame (no
+// `--frame`) input path keeps using CDP trusted events (see service_worker.js).
+
+// outerHTML of the frame's document. Self-contained.
+export function frameReadHtmlFn() {
+  return document.documentElement.outerHTML;
+}
+
+// Visible innerText of `selector` (or the whole body when empty). Self-contained;
+// the SW normalizes + byte-caps the returned raw text via normalizeText.
+export function frameReadTextFn(selector) {
+  var el = selector ? document.querySelector(selector) : document.body;
+  return el ? el.innerText : "";
+}
+
+// Evaluate `src` in the frame's (isolated-world) context and return its completion
+// value. Mirrors compileEval's expression-vs-statement duality WITHOUT double-running
+// a side effect: build the chosen form ONCE at parse time, then call it once. A
+// runtime throw propagates (executeScript rejects → the op errors). Self-contained.
+export function frameEvalFn(src) {
+  var fn;
+  try {
+    fn = new Function("return (" + src + ")");
+  } catch (e) {
+    if (e instanceof SyntaxError) fn = new Function(src);
+    else throw e;
+  }
+  return fn();
+}
+
+// Synthetic click on `selector`: scroll into view, then dispatch a realistic
+// mousedown→mouseup→click sequence AND call el.click() (covers apps that listen for
+// either). Returns {ok:true,x,y} (frame-local center) or {ok:false,error} when the
+// selector matches nothing. Self-contained.
+export function frameClickFn(selector) {
+  var el = document.querySelector(selector);
+  if (!el) return { ok: false, error: "element_not_found" };
+  el.scrollIntoView({ block: "center", inline: "center" });
+  var r = el.getBoundingClientRect();
+  var x = Math.round(r.left + r.width / 2);
+  var y = Math.round(r.top + r.height / 2);
+  var opts = { bubbles: true, cancelable: true, view: window,
+               clientX: x, clientY: y, button: 0 };
+  el.dispatchEvent(new MouseEvent("mousedown", opts));
+  el.dispatchEvent(new MouseEvent("mouseup", opts));
+  el.dispatchEvent(new MouseEvent("click", opts));
+  if (typeof el.click === "function") el.click();
+  return { ok: true, x: x, y: y };
+}
+
+// Synthetic type into `selector` (or the frame's activeElement when empty): focus,
+// set .value (or textContent for a contenteditable), then dispatch input+change so a
+// framework's listeners see the update. Returns {ok:true,typed:<len>} or
+// {ok:false,error} when a given selector matches nothing. NEVER returns the text.
+// Self-contained.
+export function frameTypeFn(selector, text) {
+  var el = selector ? document.querySelector(selector) : document.activeElement;
+  if (selector && !el) return { ok: false, error: "element_not_found" };
+  if (!el) el = document.body;
+  if (typeof el.focus === "function") el.focus();
+  if (el && "value" in el) el.value = text;
+  else if (el && el.isContentEditable) el.textContent = text;
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+  el.dispatchEvent(new Event("change", { bubbles: true }));
+  return { ok: true, typed: text.length };
+}
+
+// Synthetic key dispatch to `selector` (or the frame's activeElement): keydown→
+// (keypress if the key is printable)→keyup with the pre-resolved `keyParams`
+// (from keyEventParams, so the bounded-key gate + unknown_key refusal happen in the
+// SW BEFORE injection). Returns {ok:true,key} or {ok:false,error} when a given
+// selector matches nothing. Self-contained.
+export function frameKeyFn(selector, keyParams) {
+  var el = selector ? document.querySelector(selector) : document.activeElement;
+  if (selector && !el) return { ok: false, error: "element_not_found" };
+  var target = el || document.body;
+  if (el && typeof el.focus === "function") el.focus();
+  var init = { bubbles: true, cancelable: true, key: keyParams.key,
+               code: keyParams.code, keyCode: keyParams.keyCode,
+               which: keyParams.keyCode };
+  target.dispatchEvent(new KeyboardEvent("keydown", init));
+  if (keyParams.text) target.dispatchEvent(new KeyboardEvent("keypress", init));
+  target.dispatchEvent(new KeyboardEvent("keyup", init));
+  return { ok: true, key: keyParams.key };
+}
+
 // The full-page screenshot clip from a CDP Page.getLayoutMetrics result. Uses the
 // css content size (the full scrollable document) so `--fullpage` captures beyond
 // the viewport. Pure; returns a clip suitable for Page.captureScreenshot.

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -22,12 +22,15 @@ import {
   pollHeaders, resultWithInstance, normalizeText, TEXT_MAX_BYTES_DEFAULT,
   classifyPollStatus, POLL_COMMAND, POLL_IDLE, POLL_SUPERSEDED,
   POLL_UNAUTHORIZED, SUPERSEDE_BACKOFF_MS, captureWithRetry,
-  // CDP (chrome.debugger) helpers — the pure, unit-tested decision layer.
-  CDP_VERSION, withCdpSession, assertTabCdpReady,
-  flattenFrameTree, resolveFrame, keyEventParams,
-  clickPoint, boxModelOrigin, frameEvalExpressions, isCdpSyntaxError,
-  cdpExceptionText, frameHtmlExpression, frameTextExpression,
-  elementRectExpression, focusExpression, fullPageClip,
+  // CDP (chrome.debugger) helpers — still used for screenshots + TOP-frame trusted
+  // input (the pure, unit-tested decision layer).
+  CDP_VERSION, withCdpSession, assertTabCdpReady, keyEventParams,
+  clickPoint, cdpExceptionText, elementRectExpression, focusExpression, fullPageClip,
+  // OOPIF-capable frame enumeration/injection (chrome.webNavigation + chrome.scripting):
+  // reaches cross-origin out-of-process iframes where CDP getFrameTree could not.
+  normalizeWebNavFrames, resolveWebNavFrameId,
+  frameReadHtmlFn, frameReadTextFn, frameEvalFn,
+  frameClickFn, frameTypeFn, frameKeyFn,
 } from "./protocol.js";
 
 const DEFAULT_PORT = 8788;
@@ -141,42 +144,35 @@ async function cdpEval(send, contextId, expression) {
   return res.result ? res.result.value : undefined;
 }
 
-// Frame-scoped `eval`: try the expression form, fall back to the statement form on a
-// SyntaxError (mirrors compileEval), running in the frame's isolated world.
-async function cdpFrameEval(send, contextId, js) {
-  const { expression, fallback } = frameEvalExpressions(js);
-  let res = await send("Runtime.evaluate",
-    { expression, contextId, returnByValue: true, awaitPromise: true });
-  if (res.exceptionDetails && isCdpSyntaxError(res.exceptionDetails)) {
-    res = await send("Runtime.evaluate",
-      { expression: fallback, contextId, returnByValue: true, awaitPromise: true });
-  }
-  if (res.exceptionDetails) throw new Error(cdpExceptionText(res.exceptionDetails));
-  return res.result ? res.result.value : undefined;
+// --- OOPIF-capable frame glue (chrome.webNavigation + chrome.scripting) ------- //
+// Enumerate ALL of `tabId`'s frames — same-process AND cross-origin OOPIFs — as the
+// compact metadata list the `frames` op returns. getAllFrames is tab-scoped, so the
+// list can only ever describe frames of THIS tab (the security scope for `--frame`).
+async function framesForTab(tabId) {
+  const raw = await chrome.webNavigation.getAllFrames({ tabId });
+  return normalizeWebNavFrames(raw || []);
 }
 
-// Resolve a `--frame <sel>` into an isolated-world execution context so a read/click
-// runs INSIDE that (possibly cross-origin) frame. Returns { executionContextId,
-// frameId, isMain, ownerOffset } — ownerOffset is the frame's on-page origin (for a
-// sub-frame, from DOM.getBoxModel on its owner element; {0,0} for the main frame).
-async function resolveFrameContext(send, frameSel) {
-  await send("Page.enable");
-  const { frameTree } = await send("Page.getFrameTree");
-  const frames = flattenFrameTree(frameTree);
-  const frame = resolveFrame(frames, frameSel);           // throws frame_not_found
-  const isMain = frames.length > 0 && frames[0].frameId === frame.frameId;
-  const { executionContextId } = await send("Page.createIsolatedWorld",
-    { frameId: frame.frameId, worldName: "browser_bridge" });
-  let ownerOffset = { x: 0, y: 0 };
-  if (!isMain) {
-    // A sub-frame's element coords are frame-local; offset them by the iframe
-    // element's on-page box so Input.dispatchMouseEvent lands in the right place.
-    await send("DOM.enable");
-    const { backendNodeId } = await send("DOM.getFrameOwner", { frameId: frame.frameId });
-    const { model } = await send("DOM.getBoxModel", { backendNodeId });
-    ownerOffset = boxModelOrigin(model);
-  }
-  return { executionContextId, frameId: frame.frameId, isMain, ownerOffset };
+// Resolve a caller `--frame <sel>` to a NUMERIC webNavigation frameId within `tabId`.
+// Throws frame_not_found / frame_not_specified. Confined to this tab by construction.
+async function resolveFrameId(tabId, frameSel) {
+  const frames = await framesForTab(tabId);
+  return resolveWebNavFrameId(frames, frameSel);
+}
+
+// Inject `func(...args)` INTO one resolved frame (by numeric frameId) of `tabId` via
+// chrome.scripting — the OOPIF-reaching path (works on a cross-origin frame given the
+// extension's <all_urls> host permission), no chrome.debugger/banner. Returns the
+// injected function's (structured-cloned) result. A frameId is confined to `tabId`;
+// executeScript cannot escape the target tab's frames.
+async function execInFrame(tabId, frameId, func, args) {
+  const results = await chrome.scripting.executeScript({
+    target: { tabId, frameIds: [frameId] },
+    func,
+    args: args || [],
+  });
+  const inj = Array.isArray(results) ? results[0] : undefined;
+  return inj ? inj.result : undefined;
 }
 
 // --- op executors ---------------------------------------------------------- //
@@ -184,12 +180,11 @@ async function resolveFrameContext(send, frameSel) {
 const OPS = {
   async getHtml(cmd) {
     const tab = await targetTab(cmd);
-    // --frame → read the outerHTML INSIDE the chosen (cross-origin) frame via CDP.
+    // --frame → read the outerHTML INSIDE the chosen (cross-origin OOPIF) frame via
+    // chrome.scripting (reaches an out-of-process iframe; no debugger banner).
     if (cmd && cmd.frame) {
-      const html = await withCdp(tab.id, tab.url, async (send) => {
-        const { executionContextId } = await resolveFrameContext(send, cmd.frame);
-        return cdpEval(send, executionContextId, frameHtmlExpression());
-      });
+      const frameId = await resolveFrameId(tab.id, cmd.frame);
+      const html = await execInFrame(tab.id, frameId, frameReadHtmlFn, []);
       return { url: tab.url, title: tab.title, html, frame: cmd.frame };
     }
     // No frame → the lighter chrome.scripting top-frame read (no debugger banner).
@@ -210,12 +205,11 @@ const OPS = {
     const sel = (cmd && typeof cmd.selector === "string") ? cmd.selector : "";
     const cap = (cmd && cmd.maxBytes != null)
       ? cmd.maxBytes : TEXT_MAX_BYTES_DEFAULT;
-    // --frame → read innerText INSIDE the chosen (cross-origin) frame via CDP.
+    // --frame → read innerText INSIDE the chosen (cross-origin OOPIF) frame via
+    // chrome.scripting (reaches an out-of-process iframe; no debugger banner).
     if (cmd && cmd.frame) {
-      const raw = await withCdp(tab.id, tab.url, async (send) => {
-        const { executionContextId } = await resolveFrameContext(send, cmd.frame);
-        return cdpEval(send, executionContextId, frameTextExpression(sel));
-      });
+      const frameId = await resolveFrameId(tab.id, cmd.frame);
+      const raw = await execInFrame(tab.id, frameId, frameReadTextFn, [sel]);
       const { text, truncated } = normalizeText(raw, cap);
       return { url: tab.url, title: tab.title, text, truncated, frame: cmd.frame };
     }
@@ -233,13 +227,12 @@ const OPS = {
 
   async eval(cmd) {
     const tab = await targetTab(cmd);
-    // --frame → evaluate INSIDE the chosen (cross-origin) frame's isolated world
-    // via CDP (DOM-capable; no access to that frame's page globals — documented).
+    // --frame → evaluate INSIDE the chosen (cross-origin OOPIF) frame via
+    // chrome.scripting. Runs in the frame's ISOLATED world (DOM-capable; no access to
+    // that frame's page globals — documented, matches the prior CDP semantics).
     if (cmd && cmd.frame) {
-      const value = await withCdp(tab.id, tab.url, async (send) => {
-        const { executionContextId } = await resolveFrameContext(send, cmd.frame);
-        return cdpFrameEval(send, executionContextId, cmd.js);
-      });
+      const frameId = await resolveFrameId(tab.id, cmd.frame);
+      const value = await execInFrame(tab.id, frameId, frameEvalFn, [cmd.js]);
       return { url: tab.url, value, frame: cmd.frame };
     }
     // chrome.scripting runs in an ISOLATED world; `js` is evaluated and its
@@ -322,37 +315,39 @@ const OPS = {
     return { url: tab.url, dataUrl, via: "cdp" };
   },
 
-  // List the target tab's frames (frameId/url/name/parentId) via CDP
-  // Page.getFrameTree — so a caller can discover a cross-origin iframe and then
-  // read/click INTO it with `--frame <frameId|url-substring>`. Metadata only.
+  // List the target tab's frames ({frameId,url,parentFrameId}) via
+  // chrome.webNavigation.getAllFrames — which, UNLIKE CDP Page.getFrameTree,
+  // enumerates OUT-OF-PROCESS (cross-origin) iframes too. So a caller can discover a
+  // cross-origin OOPIF and read/click INTO it with `--frame <frameId|url-substring>`.
+  // Metadata only (numeric frameId + url + parent) — never frame content. No debugger.
   async frames(cmd) {
     const tab = await targetTab(cmd);
-    const frames = await withCdp(tab.id, tab.url, async (send) => {
-      await send("Page.enable");
-      const { frameTree } = await send("Page.getFrameTree");
-      return flattenFrameTree(frameTree);
-    });
+    const frames = await framesForTab(tab.id);
     return { url: tab.url, title: tab.title, frames };
   },
 
-  // TRUSTED click on `selector` (optionally inside `--frame`). Resolves the element
-  // box via getBoundingClientRect (in the frame's isolated world), offsets by the
-  // frame's on-page origin for a sub-frame, then dispatches a real press+release
-  // via CDP Input.dispatchMouseEvent — an isTrusted click the page can't tell from
-  // a human's. `selector` is validated present by server/SW REQUIRED_FIELDS.
+  // Click `selector`. TWO paths, by design:
+  //   * `--frame` (cross-origin OOPIF): inject a SYNTHETIC click into the resolved
+  //     frame via chrome.scripting (the only path that reaches an OOPIF). The
+  //     dispatched events are `isTrusted:false` — honestly reported as trusted:false —
+  //     but drive the vast majority of apps (which listen for ordinary click/input).
+  //   * TOP frame (no `--frame`): the CDP Input.dispatchMouseEvent path — a real
+  //     `isTrusted` press+release the page can't tell from a human's (unchanged).
+  // `selector` is validated present by server/SW REQUIRED_FIELDS.
   async click(cmd) {
     const tab = await targetTab(cmd);
     const selector = String(cmd.selector);
+    if (cmd.frame) {
+      const frameId = await resolveFrameId(tab.id, cmd.frame);
+      const res = await execInFrame(tab.id, frameId, frameClickFn, [selector]);
+      if (!res || res.ok === false) throw new Error(`element_not_found:${selector}`);
+      return { url: tab.url, clicked: selector, x: res.x, y: res.y,
+               frame: cmd.frame, trusted: false };
+    }
     const point = await withCdp(tab.id, tab.url, async (send) => {
-      let ctxId, offset = { x: 0, y: 0 };
-      if (cmd.frame) {
-        const fc = await resolveFrameContext(send, cmd.frame);
-        ctxId = fc.executionContextId;
-        offset = fc.ownerOffset;
-      }
-      const rect = await cdpEval(send, ctxId, elementRectExpression(selector));
+      const rect = await cdpEval(send, undefined, elementRectExpression(selector));
       if (!rect) throw new Error(`element_not_found:${selector}`);
-      const p = clickPoint(rect, offset);
+      const p = clickPoint(rect, { x: 0, y: 0 });
       const mouse = (type) => send("Input.dispatchMouseEvent",
         { type, x: p.x, y: p.y, button: "left", buttons: 1, clickCount: 1 });
       await mouse("mousePressed");
@@ -360,38 +355,52 @@ const OPS = {
       return p;
     });
     return { url: tab.url, clicked: selector, x: point.x, y: point.y,
-             frame: cmd.frame || null };
+             frame: null, trusted: true };
   },
 
-  // Type `text` into the focused element (optionally focus `--selector` first,
-  // optionally inside `--frame`) via CDP Input.insertText — a trusted input event.
-  // Returns only the LENGTH typed, never echoes the text back (privacy + telemetry).
+  // Type `text` (optionally focus `--selector` first). `--frame` → SYNTHETIC input
+  // (focus + set value + input/change) injected into the cross-origin OOPIF via
+  // chrome.scripting (trusted:false — the reachable OOPIF path). TOP frame → CDP
+  // Input.insertText, a trusted input event (unchanged). Returns only the LENGTH
+  // typed, never echoes the text back (privacy + telemetry).
   async type(cmd) {
     const tab = await targetTab(cmd);
     const text = String(cmd.text);
+    if (cmd.frame) {
+      const frameId = await resolveFrameId(tab.id, cmd.frame);
+      const res = await execInFrame(tab.id, frameId, frameTypeFn,
+        [cmd.selector || "", text]);
+      if (!res || res.ok === false) throw new Error(`element_not_found:${cmd.selector}`);
+      return { url: tab.url, typed: text.length, frame: cmd.frame, trusted: false };
+    }
     await withCdp(tab.id, tab.url, async (send) => {
-      let ctxId;
-      if (cmd.frame) ctxId = (await resolveFrameContext(send, cmd.frame)).executionContextId;
       if (cmd.selector) {
-        const ok = await cdpEval(send, ctxId, focusExpression(cmd.selector));
+        const ok = await cdpEval(send, undefined, focusExpression(cmd.selector));
         if (!ok) throw new Error(`element_not_found:${cmd.selector}`);
       }
       await send("Input.insertText", { text });
     });
-    return { url: tab.url, typed: text.length, frame: cmd.frame || null };
+    return { url: tab.url, typed: text.length, frame: null, trusted: true };
   },
 
-  // Dispatch a single bounded key (Enter/Tab/Escape/arrows/…) to the focused element
-  // (optionally focus `--selector` first, optionally inside `--frame`) via CDP
-  // Input.dispatchKeyEvent (keyDown+keyUp). An unknown key is refused BEFORE attach.
+  // Dispatch one bounded key (Enter/Tab/Escape/arrows/…). The key name is resolved +
+  // validated by keyEventParams FIRST — an unknown key is refused BEFORE any injection
+  // or attach (the bounded-key surface is preserved on both paths). `--frame` →
+  // SYNTHETIC keydown/keyup injected into the cross-origin OOPIF via chrome.scripting
+  // (trusted:false — the reachable OOPIF path). TOP frame → CDP Input.dispatchKeyEvent,
+  // a trusted key event (unchanged).
   async key(cmd) {
     const tab = await targetTab(cmd);
-    const p = keyEventParams(cmd.key);   // throws unknown_key (no attach on refusal)
+    const p = keyEventParams(cmd.key);   // throws unknown_key (no injection/attach on refusal)
+    if (cmd.frame) {
+      const frameId = await resolveFrameId(tab.id, cmd.frame);
+      const res = await execInFrame(tab.id, frameId, frameKeyFn, [cmd.selector || "", p]);
+      if (!res || res.ok === false) throw new Error(`element_not_found:${cmd.selector}`);
+      return { url: tab.url, key: p.key, frame: cmd.frame, trusted: false };
+    }
     await withCdp(tab.id, tab.url, async (send) => {
-      let ctxId;
-      if (cmd.frame) ctxId = (await resolveFrameContext(send, cmd.frame)).executionContextId;
       if (cmd.selector) {
-        const ok = await cdpEval(send, ctxId, focusExpression(cmd.selector));
+        const ok = await cdpEval(send, undefined, focusExpression(cmd.selector));
         if (!ok) throw new Error(`element_not_found:${cmd.selector}`);
       }
       const base = { key: p.key, code: p.code,
@@ -400,7 +409,7 @@ const OPS = {
         { type: p.text ? "keyDown" : "rawKeyDown", ...base, ...(p.text ? { text: p.text } : {}) });
       await send("Input.dispatchKeyEvent", { type: "keyUp", ...base });
     });
-    return { url: tab.url, key: p.key, frame: cmd.frame || null };
+    return { url: tab.url, key: p.key, frame: null, trusted: true };
   },
 
   // Create a NEW tab for the calling session to own. active:false so parallel
@@ -557,26 +566,35 @@ function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-// --- MV3 keepalive: restart the loop on install / startup / alarm ---------- //
-chrome.runtime.onInstalled.addListener(() => loop());
-chrome.runtime.onStartup.addListener(() => loop());
-chrome.alarms.create("bridge-keepalive", { periodInMinutes: 1 });
-chrome.alarms.onAlarm.addListener((a) => {
-  if (a.name === "bridge-keepalive") loop();
-});
-
-// If Chrome detaches our debugger out-of-band (tab crash/close, DevTools opened, or
-// the user hitting the "an extension is debugging this browser" banner's Cancel),
-// drop the tracked attach so we never think we still hold it. withCdp already
-// always-detaches per op; this is the belt-and-braces for an external detach.
-if (chrome.debugger && chrome.debugger.onDetach) {
-  chrome.debugger.onDetach.addListener((source) => {
-    if (source && source.tabId != null) cdpAttached.delete(source.tabId);
+// --- MV3 keepalive + background wiring -------------------------------------- //
+// All the real-browser side effects (event listeners, the keepalive alarm, and the
+// immediate loop kick) are grouped here so a unit test can import this module for its
+// pure OPS glue WITHOUT starting the poll loop or requiring chrome.runtime/alarms:
+// set `globalThis.BROWSER_BRIDGE_NO_AUTOSTART = true` before importing.
+function startBackground() {
+  chrome.runtime.onInstalled.addListener(() => loop());
+  chrome.runtime.onStartup.addListener(() => loop());
+  chrome.alarms.create("bridge-keepalive", { periodInMinutes: 1 });
+  chrome.alarms.onAlarm.addListener((a) => {
+    if (a.name === "bridge-keepalive") loop();
   });
+  // If Chrome detaches our debugger out-of-band (tab crash/close, DevTools opened, or
+  // the user hitting the "an extension is debugging this browser" banner's Cancel),
+  // drop the tracked attach so we never think we still hold it. withCdp already
+  // always-detaches per op; this is the belt-and-braces for an external detach.
+  if (chrome.debugger && chrome.debugger.onDetach) {
+    chrome.debugger.onDetach.addListener((source) => {
+      if (source && source.tabId != null) cdpAttached.delete(source.tabId);
+    });
+  }
+  // Kick immediately when the worker is first evaluated.
+  loop();
 }
 
-// Kick immediately when the worker is first evaluated.
-loop();
+if (!(typeof globalThis !== "undefined" && globalThis.BROWSER_BRIDGE_NO_AUTOSTART)) {
+  startBackground();
+}
 
-// Exported for reuse / potential future tests (no-op in the browser).
+// Exported for reuse / unit tests (the frame glue is exercised against a mocked
+// chrome in tests/service_worker.test.mjs).
 export { execute, OPS, ALLOWED_OPS };

--- a/scripts/browser-bridge/tests/frame_oopif.test.mjs
+++ b/scripts/browser-bridge/tests/frame_oopif.test.mjs
@@ -1,0 +1,209 @@
+// Tests for the OOPIF-capable frame layer in extension/protocol.js — the fix for
+// the cross-origin (out-of-process) iframe gap. Two pure, browser-independent parts:
+//
+//  1. Enumeration/resolution over a chrome.webNavigation.getAllFrames() result
+//     (numeric frameIds, INCLUDING cross-origin OOPIFs — the exact frames CDP
+//     Page.getFrameTree omitted).
+//  2. The SELF-CONTAINED page functions injected via chrome.scripting.executeScript
+//     into the resolved frame. They reference only their args + page globals, so we
+//     exercise them directly against a tiny hand-rolled DOM (no jsdom dep).
+//
+// The chrome.* side effects (getAllFrames / executeScript) are covered by
+// tests/service_worker.test.mjs against a mocked chrome; the real cross-origin
+// injection is verified manually (see the PR body / SKILL.md live-check).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  normalizeWebNavFrames, resolveWebNavFrameId,
+  frameReadHtmlFn, frameReadTextFn, frameEvalFn,
+  frameClickFn, frameTypeFn, frameKeyFn, keyEventParams,
+} from "../extension/protocol.js";
+
+// A getAllFrames() result for civitai.com/apps/run/model-benchmarking: the top frame
+// PLUS a CROSS-ORIGIN child (model-benchmarking.civit.ai) that runs OUT-OF-PROCESS —
+// the frame the old CDP getFrameTree could NOT see.
+const GET_ALL_FRAMES = [
+  { frameId: 0, parentFrameId: -1, url: "https://civitai.com/apps/run/model-benchmarking", documentId: "d0" },
+  { frameId: 7, parentFrameId: 0, url: "https://model-benchmarking.civit.ai/", documentId: "d7" },
+  { frameId: 12, parentFrameId: 7, url: "https://ads.example/pixel", documentId: "d12" },
+];
+
+// --- enumeration ----------------------------------------------------------- //
+test("normalizeWebNavFrames maps getAllFrames → {frameId,url,parentFrameId} incl. the OOPIF", () => {
+  const out = normalizeWebNavFrames(GET_ALL_FRAMES);
+  assert.deepEqual(out, [
+    { frameId: 0, url: "https://civitai.com/apps/run/model-benchmarking", parentFrameId: -1 },
+    { frameId: 7, url: "https://model-benchmarking.civit.ai/", parentFrameId: 0 },
+    { frameId: 12, url: "https://ads.example/pixel", parentFrameId: 7 },
+  ]);
+  // THE REGRESSION: the cross-origin child frame IS present (getFrameTree missed it).
+  assert.ok(out.some((f) => f.url.includes("model-benchmarking.civit.ai")),
+    "the cross-origin OOPIF must appear in the enumeration");
+});
+
+test("normalizeWebNavFrames is metadata-only + drops junk entries", () => {
+  const out = normalizeWebNavFrames([
+    { frameId: 0, url: "https://a/", parentFrameId: -1, documentId: "x", errorOccurred: false },
+    { url: "https://no-id/" },          // no numeric frameId → dropped
+    null,                                // junk → dropped
+    { frameId: 3 },                      // missing url/parent → defaulted
+  ]);
+  assert.deepEqual(out, [
+    { frameId: 0, url: "https://a/", parentFrameId: -1 },
+    { frameId: 3, url: "", parentFrameId: -1 },
+  ]);
+  // Never any content/document fields — id/url/parent only.
+  for (const f of out) {
+    assert.deepEqual(Object.keys(f).sort(), ["frameId", "parentFrameId", "url"]);
+  }
+  assert.deepEqual(normalizeWebNavFrames(null), []);
+});
+
+// --- resolution ------------------------------------------------------------ //
+test("resolveWebNavFrameId: exact numeric frameId wins; url substring; case-insensitive", () => {
+  const frames = normalizeWebNavFrames(GET_ALL_FRAMES);
+  // numeric frameId (string or number), incl. the top frame 0.
+  assert.equal(resolveWebNavFrameId(frames, 7), 7);
+  assert.equal(resolveWebNavFrameId(frames, "7"), 7);
+  assert.equal(resolveWebNavFrameId(frames, "0"), 0);
+  // url substring → the numeric id of the matching frame.
+  assert.equal(resolveWebNavFrameId(frames, "model-benchmarking.civit.ai"), 7);
+  assert.equal(resolveWebNavFrameId(frames, "MODEL-BENCHMARKING.CIVIT.AI"), 7);
+  // first (list-order) substring match wins deterministically.
+  assert.equal(resolveWebNavFrameId(frames, "https://"), 0);
+});
+
+test("resolveWebNavFrameId: unknown → frame_not_found; empty → frame_not_specified", () => {
+  const frames = normalizeWebNavFrames(GET_ALL_FRAMES);
+  assert.throws(() => resolveWebNavFrameId(frames, "nope"), /frame_not_found:nope/);
+  assert.throws(() => resolveWebNavFrameId(frames, "999"), /frame_not_found:999/);
+  assert.throws(() => resolveWebNavFrameId(frames, ""), /frame_not_specified/);
+  assert.throws(() => resolveWebNavFrameId(frames, null), /frame_not_specified/);
+  // Tab-scoped by construction: a frameId that only exists in ANOTHER tab's list is
+  // simply absent here → frame_not_found (can't reach another tab's frame).
+  assert.throws(() => resolveWebNavFrameId([], "7"), /frame_not_found:7/);
+});
+
+// --- injected page functions (self-contained; run inside the frame) --------- //
+// A tiny DOM/event shim so the injected functions run under node exactly as they
+// would in the page — proving the synthetic dispatch logic without a browser.
+class FakeEvt { constructor(type, opts = {}) { this.type = type; Object.assign(this, opts); } }
+
+function installDom() {
+  globalThis.MouseEvent = class extends FakeEvt {};
+  globalThis.KeyboardEvent = class extends FakeEvt {};
+  globalThis.Event = class extends FakeEvt {};
+  globalThis.window = {};
+}
+installDom();
+
+function fakeEl(over = {}) {
+  const el = {
+    events: [], focusCalls: 0, clickCalls: 0, scrolled: false,
+    value: "", isContentEditable: false,
+    focus() { this.focusCalls++; },
+    click() { this.clickCalls++; },
+    scrollIntoView() { this.scrolled = true; },
+    getBoundingClientRect() { return { left: 10, top: 20, width: 100, height: 40 }; },
+    dispatchEvent(e) { this.events.push(e); return true; },
+    ...over,
+  };
+  return el;
+}
+
+function fakeDoc({ map = {}, active = null, body = null } = {}) {
+  globalThis.document = {
+    documentElement: { outerHTML: "<html><body>frame</body></html>" },
+    body: body || { innerText: "BODY TEXT", events: [], dispatchEvent() {} },
+    activeElement: active,
+    querySelector(sel) { return map[sel] || null; },
+  };
+  return globalThis.document;
+}
+
+test("frameReadHtmlFn returns the frame document's outerHTML", () => {
+  fakeDoc();
+  assert.equal(frameReadHtmlFn(), "<html><body>frame</body></html>");
+});
+
+test("frameReadTextFn reads a selector's innerText, else the body's", () => {
+  fakeDoc({ map: { "#main": { innerText: "HELLO OOPIF" } } });
+  assert.equal(frameReadTextFn("#main"), "HELLO OOPIF");
+  assert.equal(frameReadTextFn(""), "BODY TEXT");
+  assert.equal(frameReadTextFn("#missing"), "");   // selector matches nothing
+});
+
+test("frameEvalFn evaluates an expression (once), falls back to statements, propagates throws", () => {
+  fakeDoc();
+  assert.equal(frameEvalFn("2 * 21"), 42);
+  assert.equal(frameEvalFn("[1,2,3].length"), 3);
+  // statement form (unparseable as an expression) runs without a return value.
+  assert.equal(frameEvalFn("var x = 1;"), undefined);
+  // a runtime throw propagates (executeScript would reject → the op errors).
+  assert.throws(() => frameEvalFn("(function(){ throw new Error('boom'); })()"), /boom/);
+});
+
+test("frameClickFn: scrolls, dispatches mousedown→mouseup→click AND el.click(); returns center", () => {
+  const el = fakeEl();
+  fakeDoc({ map: { "#go": el } });
+  const res = frameClickFn("#go");
+  assert.deepEqual(res, { ok: true, x: 60, y: 40 });  // center of 100x40 @ (10,20)
+  assert.equal(el.scrolled, true);
+  assert.deepEqual(el.events.map((e) => e.type), ["mousedown", "mouseup", "click"]);
+  assert.equal(el.clickCalls, 1, "also calls el.click() for click-only listeners");
+  assert.equal(el.events[0].clientX, 60);
+  assert.equal(el.events[0].clientY, 40);
+});
+
+test("frameClickFn: a missing selector → {ok:false,error:element_not_found} (no throw)", () => {
+  fakeDoc({ map: {} });
+  assert.deepEqual(frameClickFn("#nope"), { ok: false, error: "element_not_found" });
+});
+
+test("frameTypeFn: focuses, sets .value, dispatches input+change; returns only the LENGTH", () => {
+  const el = fakeEl();
+  fakeDoc({ map: { "#in": el } });
+  const res = frameTypeFn("#in", "hello");
+  assert.deepEqual(res, { ok: true, typed: 5 });
+  assert.equal(el.value, "hello");
+  assert.equal(el.focusCalls, 1);
+  assert.deepEqual(el.events.map((e) => e.type), ["input", "change"]);
+  assert.ok(!("text" in res), "the typed text must never be returned");
+});
+
+test("frameTypeFn: empty selector types into the frame's activeElement", () => {
+  const el = fakeEl();
+  fakeDoc({ active: el });
+  const res = frameTypeFn("", "abc");
+  assert.deepEqual(res, { ok: true, typed: 3 });
+  assert.equal(el.value, "abc");
+});
+
+test("frameTypeFn: a given selector matching nothing → element_not_found", () => {
+  fakeDoc({ map: {} });
+  assert.deepEqual(frameTypeFn("#nope", "x"), { ok: false, error: "element_not_found" });
+});
+
+test("frameKeyFn: dispatches keydown→keypress→keyup for a printable key with the mapped params", () => {
+  const el = fakeEl();
+  fakeDoc({ map: { "#f": el } });
+  const res = frameKeyFn("#f", keyEventParams("Enter"));
+  assert.deepEqual(res, { ok: true, key: "Enter" });
+  assert.equal(el.focusCalls, 1);
+  // Enter carries text ("\r") → keypress is included between down and up.
+  assert.deepEqual(el.events.map((e) => e.type), ["keydown", "keypress", "keyup"]);
+  assert.equal(el.events[0].key, "Enter");
+  assert.equal(el.events[0].keyCode, 13);
+});
+
+test("frameKeyFn: a non-printable key (Tab) omits keypress; missing selector → element_not_found", () => {
+  const el = fakeEl();
+  fakeDoc({ map: { "#f": el } });
+  const res = frameKeyFn("#f", keyEventParams("Tab"));
+  assert.deepEqual(res, { ok: true, key: "Tab" });
+  assert.deepEqual(el.events.map((e) => e.type), ["keydown", "keyup"]);  // no keypress
+  fakeDoc({ map: {} });
+  assert.deepEqual(frameKeyFn("#nope", keyEventParams("Enter")),
+    { ok: false, error: "element_not_found" });
+});

--- a/scripts/browser-bridge/tests/service_worker.test.mjs
+++ b/scripts/browser-bridge/tests/service_worker.test.mjs
@@ -1,0 +1,191 @@
+// Glue tests for service_worker.js OPS against a MOCKED chrome — proving the OOPIF
+// fix is wired correctly WITHOUT a real Brave:
+//   * `frames` calls chrome.webNavigation.getAllFrames({tabId}) and returns the list
+//     INCLUDING the cross-origin OOPIF child (the exact regression);
+//   * `--frame` reads/inputs resolve a NUMERIC frameId and inject via
+//     chrome.scripting.executeScript({target:{tabId, frameIds:[id]}}) — never CDP;
+//   * an unknown/absent frame → a clear error, before any injection;
+//   * SECURITY: frame resolution is confined to the op's OWN tab (getAllFrames is
+//     tab-scoped) and an unknown `key` is refused before touching the tab;
+//   * `screenshot` STILL uses the chrome.debugger (CDP) path — not regressed.
+//
+// The SW auto-start (poll loop + listeners) is suppressed via BROWSER_BRIDGE_NO_AUTOSTART
+// so importing it here does not start networking.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// --- a single mutable chrome mock the SW closes over -------------------------- //
+const TAB_ID = 5;
+const OOPIF_URL = "https://model-benchmarking.civit.ai/";
+const state = {
+  frames: [
+    { frameId: 0, parentFrameId: -1, url: "https://civitai.com/apps/run/model-benchmarking" },
+    { frameId: 7, parentFrameId: 0, url: OOPIF_URL },
+  ],
+  execResult: { ok: true },
+  tab: { id: TAB_ID, url: "https://civitai.com/apps/run/model-benchmarking",
+         title: "Model Benchmarking", active: false, status: "complete", windowId: 1 },
+  calls: { getAllFrames: [], executeScript: [], debugger: [], tabsGet: [] },
+};
+function resetCalls() {
+  state.calls = { getAllFrames: [], executeScript: [], debugger: [], tabsGet: [] };
+  state.execResult = { ok: true };
+}
+
+globalThis.BROWSER_BRIDGE_NO_AUTOSTART = true;
+globalThis.chrome = {
+  webNavigation: {
+    async getAllFrames({ tabId }) { state.calls.getAllFrames.push(tabId); return state.frames; },
+  },
+  scripting: {
+    async executeScript(params) {
+      state.calls.executeScript.push(params);
+      return [{ result: state.execResult, frameId: (params.target.frameIds || [0])[0] }];
+    },
+  },
+  tabs: {
+    async get(id) { state.calls.tabsGet.push(id); return { ...state.tab, id }; },
+    async query() { return [state.tab]; },
+    async captureVisibleTab() { return "data:image/png;base64,AAAA"; },
+    async update() {},
+  },
+  debugger: {
+    async attach() { state.calls.debugger.push("attach"); },
+    async detach() { state.calls.debugger.push("detach"); },
+    async sendCommand(_t, method) {
+      state.calls.debugger.push(method);
+      if (method === "Page.captureScreenshot") return { data: "QkJCQg==" };
+      return {};
+    },
+    onDetach: { addListener() {} },
+  },
+  storage: { local: { async get() { return {}; }, async set() {} } },
+  runtime: { onInstalled: { addListener() {} }, onStartup: { addListener() {} } },
+  alarms: { create() {}, onAlarm: { addListener() {} } },
+};
+
+const { OPS } = await import("../extension/service_worker.js");
+
+function lastExec() { return state.calls.executeScript[state.calls.executeScript.length - 1]; }
+
+// --------------------------------------------------------------------------- //
+test("frames op: enumerates via webNavigation.getAllFrames — the OOPIF child IS present", async () => {
+  resetCalls();
+  const out = await OPS.frames({ tabId: TAB_ID });
+  // getAllFrames was called for THIS tab.
+  assert.deepEqual(state.calls.getAllFrames, [TAB_ID]);
+  // No CDP/debugger was used to enumerate frames anymore.
+  assert.deepEqual(state.calls.debugger, []);
+  // THE REGRESSION: the cross-origin OOPIF appears in the returned list.
+  assert.ok(out.frames.some((f) => f.url === OOPIF_URL),
+    "the cross-origin frame must be enumerated (getFrameTree missed it)");
+  assert.deepEqual(out.frames.find((f) => f.url === OOPIF_URL),
+    { frameId: 7, url: OOPIF_URL, parentFrameId: 0 });
+});
+
+test("--frame text: resolves the numeric frameId + injects via executeScript into that frame", async () => {
+  resetCalls();
+  state.execResult = "INNER OOPIF TEXT";
+  const out = await OPS.text({ tabId: TAB_ID, frame: "model-benchmarking.civit.ai" });
+  const call = lastExec();
+  assert.deepEqual(call.target, { tabId: TAB_ID, frameIds: [7] },
+    "the resolved OOPIF frameId is the executeScript target");
+  assert.equal(typeof call.func, "function");
+  assert.equal(out.text, "INNER OOPIF TEXT");
+  assert.equal(out.frame, "model-benchmarking.civit.ai");
+  assert.deepEqual(state.calls.debugger, [], "a frame read must NOT use the debugger");
+});
+
+test("--frame html/eval: inject into the resolved OOPIF frame via executeScript", async () => {
+  resetCalls();
+  state.execResult = "<html>oopif</html>";
+  const h = await OPS.getHtml({ tabId: TAB_ID, frame: "7" });   // numeric frame id
+  assert.deepEqual(lastExec().target, { tabId: TAB_ID, frameIds: [7] });
+  assert.equal(h.html, "<html>oopif</html>");
+
+  resetCalls();
+  state.execResult = 1234;
+  const e = await OPS.eval({ tabId: TAB_ID, frame: "model-benchmarking.civit.ai", js: "6*206 + 2" });
+  assert.deepEqual(lastExec().target, { tabId: TAB_ID, frameIds: [7] });
+  assert.equal(e.value, 1234);
+  assert.deepEqual(lastExec().args, ["6*206 + 2"]);
+});
+
+test("--frame click/type/key: injected into the OOPIF frame; report trusted:false", async () => {
+  resetCalls();
+  state.execResult = { ok: true, x: 60, y: 40 };
+  const c = await OPS.click({ tabId: TAB_ID, frame: "model-benchmarking.civit.ai", selector: "#run" });
+  assert.deepEqual(lastExec().target, { tabId: TAB_ID, frameIds: [7] });
+  assert.deepEqual(lastExec().args, ["#run"]);
+  assert.deepEqual(c, { url: state.tab.url, clicked: "#run", x: 60, y: 40,
+                        frame: "model-benchmarking.civit.ai", trusted: false });
+
+  resetCalls();
+  state.execResult = { ok: true, typed: 5 };
+  const t = await OPS.type({ tabId: TAB_ID, frame: "model-benchmarking.civit.ai", text: "hello", selector: "#q" });
+  assert.deepEqual(lastExec().target, { tabId: TAB_ID, frameIds: [7] });
+  assert.deepEqual(lastExec().args, ["#q", "hello"]);
+  assert.equal(t.typed, 5);
+  assert.equal(t.trusted, false);
+  assert.ok(!("text" in t), "type must never echo the text");
+
+  resetCalls();
+  state.execResult = { ok: true, key: "Enter" };
+  const k = await OPS.key({ tabId: TAB_ID, frame: "model-benchmarking.civit.ai", key: "Enter" });
+  assert.deepEqual(lastExec().target, { tabId: TAB_ID, frameIds: [7] });
+  // The bounded key params (resolved in the SW) are passed to the injected fn.
+  assert.equal(lastExec().args[0], "");            // no --selector
+  assert.equal(lastExec().args[1].key, "Enter");
+  assert.equal(lastExec().args[1].keyCode, 13);
+  assert.equal(k.trusted, false);
+  assert.deepEqual(state.calls.debugger, [], "in-frame input must NOT use the debugger");
+});
+
+test("--frame input: an element_not_found in the frame surfaces a clear op error", async () => {
+  resetCalls();
+  state.execResult = { ok: false, error: "element_not_found" };
+  await assert.rejects(() => OPS.click({ tabId: TAB_ID, frame: "7", selector: "#missing" }),
+    /element_not_found:#missing/);
+  await assert.rejects(() => OPS.type({ tabId: TAB_ID, frame: "7", text: "x", selector: "#missing" }),
+    /element_not_found:#missing/);
+});
+
+test("--frame unknown: frame_not_found is raised BEFORE any injection", async () => {
+  resetCalls();
+  await assert.rejects(() => OPS.text({ tabId: TAB_ID, frame: "does-not-exist" }),
+    /frame_not_found:does-not-exist/);
+  assert.equal(state.calls.executeScript.length, 0, "no injection for an unresolved frame");
+});
+
+test("SECURITY: frame resolution is confined to the op's OWN tab (getAllFrames is tab-scoped)", async () => {
+  resetCalls();
+  // Even though the model supplies frame "7", it is resolved ONLY against getAllFrames
+  // for the op's tab (TAB_ID) — never another tab. Assert every getAllFrames call used
+  // THIS tab id, and the executeScript target tabId is THIS tab.
+  state.execResult = "x";
+  await OPS.text({ tabId: TAB_ID, frame: "7" });
+  assert.ok(state.calls.getAllFrames.every((t) => t === TAB_ID),
+    "frame enumeration must be scoped to the op's own tab");
+  assert.equal(lastExec().target.tabId, TAB_ID,
+    "executeScript must target the op's own tab — a frameId can't escape it");
+});
+
+test("SECURITY: an unknown key is refused before ANY frame enumeration or injection", async () => {
+  resetCalls();
+  await assert.rejects(() => OPS.key({ tabId: TAB_ID, frame: "7", key: "F13" }), /unknown_key:F13/);
+  assert.equal(state.calls.getAllFrames.length, 0, "no frame lookup for a refused key");
+  assert.equal(state.calls.executeScript.length, 0, "no injection for a refused key");
+});
+
+test("screenshot STILL uses the chrome.debugger (CDP) path — not regressed to scripting", async () => {
+  resetCalls();
+  const out = await OPS.screenshot({ tabId: TAB_ID });   // tab.active:false → CDP path
+  assert.ok(state.calls.debugger.includes("attach"));
+  assert.ok(state.calls.debugger.includes("Page.captureScreenshot"));
+  assert.ok(state.calls.debugger.includes("detach"), "always detaches");
+  assert.equal(state.calls.executeScript.length, 0, "screenshot must not use executeScript");
+  assert.equal(state.calls.getAllFrames.length, 0, "screenshot must not enumerate frames");
+  assert.equal(out.via, "cdp");
+  assert.match(out.dataUrl, /^data:image\/png;base64,/);
+});


### PR DESCRIPTION
## The OOPIF gap (confirmed live)

The `frames` op and `--frame` targeting (just-merged CDP work) were built on CDP
`Page.getFrameTree`. From the top tab target that only enumerates **same-process**
frames. Under Chrome **site isolation** a cross-origin iframe is an **out-of-process
iframe (OOPIF)** running in a separate renderer/target, so `getFrameTree` from the top
tab **silently omits it**.

Confirmed on `https://civitai.com/apps/run/model-benchmarking`: a top-frame `eval` of
`document.querySelectorAll("iframe")` shows the cross-origin
`https://model-benchmarking.civit.ai/` iframe exists, but `browser --tab <id> frames`
returned **only** the top `civitai.com` frame → `--frame` could never target the app
iframe, defeating the whole cross-origin-read/drive use case.

## The fix — chrome.webNavigation + chrome.scripting (reach OOPIFs, no debugger)

- **`frames`** → `chrome.webNavigation.getAllFrames({tabId})`, which enumerates **all**
  frames including cross-origin OOPIFs. Returns `{frameId (number), url, parentFrameId}`.
  The frame identifier is now the **numeric** webNavigation `frameId` (or a
  url-substring); resolution accepts either.
- **`--frame` reads** (`getHtml`/`text`/`eval`) → `chrome.scripting.executeScript(
  {target:{tabId, frameIds:[id]}, func, args})` INTO the resolved frame. `chrome.scripting`
  injects into a cross-origin OOPIF given the extension's `<all_urls>` host permission —
  this is the key that reaches `model-benchmarking.civit.ai` where `getFrameTree` could
  not. No debugger/CDP → **no banner** for frame reads.
- **`--frame` input** (`click`/`type`/`key`) → injected in-frame dispatch via
  `chrome.scripting` (click: `el.click()` + mousedown/mouseup/click sequence; type:
  focus + set value + input/change; key: keydown/(keypress)/keyup with the bounded key
  params). These are **SYNTHETIC** events (`isTrusted:false`). This is documented
  honestly: a trusted CDP `Input.*` event from the top target can't easily reach an
  OOPIF, so synthetic-in-frame is the reachable path — and it drives the vast majority
  of apps. **TOP-frame** (no `--frame`) input **keeps the CDP trusted path**; the result
  carries `trusted:true|false` so the caller knows which was used.
- **`webNavigation` permission added** to the manifest (low-risk; needed for
  `getAllFrames`). `debugger` kept for screenshots + top-frame trusted input.
  ⚠ **A permission change is NOT hot-applied → the unpacked extension MUST be reloaded**
  in `brave://extensions` (Brave will re-prompt for the new permission).

## Security invariants preserved (#187/#189 + #168/#173/#175/#178/#180)

- **Own-tab-only.** `getAllFrames` and `executeScript` are **tab-scoped**, so a
  model-supplied `--frame` can only ever resolve to / inject into a frame of the
  session's owned/`--tab` tab — never another tab (unit-tested). The agent's env-forced
  tab is unchanged.
- **No raw-CDP passthrough.** The autonomous agent's typed tool still exposes only the
  bounded ops with typed scalars (`frames`/`eval`/`html`/`text`/`click`/`type`/`key` +
  `frameId`/`selector`/`text`/`key`) — no `cdp`/`method`/`params`. Injected page
  functions are a fixed whitelist, not caller-supplied.
- **Bounded keys.** An unknown `key` is refused **before** any frame enumeration or
  injection (unit-tested).
- **Telemetry metadata-only.** Still emits only op/outcome/bare-top-domain — never frame
  URLs, eval source/result, typed text, or screenshot bytes.
- **Screenshots + #189 no-wedge unchanged.** `screenshot` still uses CDP
  `Page.captureScreenshot`; the bounded CDP timeouts + discarded-tab fast-fail are
  untouched (verified: existing cdp_protocol tests green; a new test asserts screenshot
  still takes the debugger path).

## Tests

- **`tests/frame_oopif.test.mjs` (new)** — pure layer: `normalizeWebNavFrames`
  (asserts the cross-origin OOPIF child IS present — the exact regression),
  `resolveWebNavFrameId` (numeric id / url-substring / not_found / tab-scoping), and the
  self-contained injected page functions (`frameReadText/Html/Eval`,
  `frameClick/Type/Key`) exercised against a tiny hand-rolled DOM (no new deps).
- **`tests/service_worker.test.mjs` (new)** — OPS glue against a **mocked**
  `chrome.webNavigation`/`chrome.scripting`/`chrome.debugger`: `frames` calls
  `getAllFrames({tabId})` and returns the OOPIF child; `--frame` reads/input resolve a
  numeric frameId and inject with `target.frameIds:[id]`; a url-substring resolves; an
  unknown frame → `frame_not_found` (before any injection); own-tab scoping; an unknown
  key refused pre-enumeration; `screenshot` still uses the CDP path.

Suite totals: **144 node** (was 121, +23) · **157 python** (unchanged — the server is
op-agnostic and forwards `frame` verbatim, so no server change was needed). `node --check`
JS, `bash -n` browser, `jq` manifest all pass.

## Honest verification

Unit tests cover the decision + wiring headlessly. The real chrome.* injection needs a
live Brave — **not yet verified end-to-end**. Manual live-check steps (after reloading
the extension for the new permission): on a fully-loaded
`civitai.com/apps/run/model-benchmarking`:
1. `browser --tab <id> frames` **now lists** the `model-benchmarking.civit.ai`
   cross-origin frame.
2. `browser --tab <id> --frame <numericId-or-url> text` reads inside it.
3. `browser --tab <id> --frame <id> click "<selector>"` drives an in-app control.
4. `browser --tab <id> screenshot /tmp/x.png` still writes a PNG; no instance wedge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
