### PR TITLE
feat(drafter): severity-order the digest + skip the gate for non-dispatching classes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,12 @@
             # git: verify-agent-work tests drive real temp git repos in-sandbox.
             # util-linux: the browser-agent wrapper uses `setsid` for its
             # process-group timeout kill (test_browser_agent.py exercises it).
-            nativeBuildInputs = [ pyEnv pkgs.bash pkgs.ripgrep pkgs.git pkgs.util-linux ];
+            # jq + gnugrep: task-spec-drafter's behavioral tests
+            # (test_severity_and_gate_skip.py) source drafter.sh and exercise the
+            # real safety_gate/severity_tag/build_summary via bash+jq+grep; without
+            # these on PATH the suite pytest-skips and the gate goes green without
+            # ever running the invariant (e.g. "TASK-with-risk STILL escalates").
+            nativeBuildInputs = [ pyEnv pkgs.bash pkgs.ripgrep pkgs.git pkgs.util-linux pkgs.jq pkgs.gnugrep ];
           }
           ''
             cp -r ${./.} src

--- a/scripts/task-spec-drafter/drafter.sh
+++ b/scripts/task-spec-drafter/drafter.sh
@@ -664,6 +664,35 @@ GATE_RE_SECURITY='\b(cert|certs|tls|ssl|mtls|mta-?sts|secret|secrets|token|token
 GATE_RE_MONEY='\b(buzz|currency|payment|payments|refund|refunds|withdraw|withdrawal|payout|payouts|billing|invoice|stripe|paypal|subscription|chargeback|wallet|merch)\b'
 GATE_RE_DESTRUCTIVE='\b(delete|deletes|deletion|drop|truncate|migration|migrations|rollback|restore|prod|production|scale ?down|scale-down|evict|eviction|wipe|purge|destroy|terraform destroy|drop table|force ?push)\b'
 
+# === DETERMINISTIC SEVERITY / URGENCY DETECTOR =============================
+# ORTHOGONAL to the safety gate above: it does NOT change classification and it
+# never blocks/relabels anything — it only stamps an auditable `severity` field
+# (URGENT | normal) so the digest can FLOAT an active prod incident to the top
+# instead of burying it mid-list next to a vague backlog ticket.
+#
+# Mirrors safety_gate()'s structure: a word-boundary, case-insensitive scan of
+# the ticket TEXT (title + body + comments — the model-independent signal, so an
+# incident is surfaced regardless of what the model concluded). A match on any
+# active-incident / high-urgency signal → severity=URGENT, else normal.
+#
+# TUNE the regex here. TRADEOFF (deliberate, documented): the set is kept
+# reasonably specific (word-anchored; `\b500s?\b` won't fire on "2500"), but
+# over-surfacing is the CHEAP failure (one extra glance at a non-incident) while
+# under-surfacing a real "image scanning DOWN" incident is the EXPENSIVE miss —
+# so when in doubt this leans toward tagging URGENT.
+SEV_RE_INCIDENT='\b(down|outage|broken|not working|stopped working|0 (images|jobs|results)|nothing (is )?processing|stuck|wedged?|crashloop|500s?|error rate|failing|regression|data loss|losing (money|buzz|revenue)|p0|p1|sev-?[012]|urgent|asap|critical|blocked prod|prod(uction)? (is )?(down|broken))\b'
+
+# severity_tag <ticket_text_file>  -> prints "URGENT" or "normal"
+# Deterministic, model-independent (scans ONLY the raw ticket text).
+severity_tag() {
+  local txt_file="$1"
+  if grep -Eiq "$SEV_RE_INCIDENT" "$txt_file" 2>/dev/null; then
+    printf 'URGENT'
+  else
+    printf 'normal'
+  fi
+}
+
 # safety_gate <ticket_text_file> <model_json>  -> prints possibly-rewritten json
 # Returns the json on stdout. Sets nothing else.
 safety_gate() {
@@ -675,6 +704,11 @@ safety_gate() {
   local scan
   scan="$(printf '%s\n%s' "$(cat "$txt_file" 2>/dev/null)" "$model_text")"
 
+  # ORTHOGONAL severity tag (URGENT | normal) — stamped on EVERY record below,
+  # never alters classification. Scans only the raw ticket text (model-independent).
+  local sev
+  sev="$(severity_tag "$txt_file")"
+
   local cats=""
   printf '%s' "$scan" | grep -Eiq "$GATE_RE_SECURITY"     && cats="${cats}security/secrets, "
   printf '%s' "$scan" | grep -Eiq "$GATE_RE_MONEY"        && cats="${cats}money, "
@@ -683,15 +717,46 @@ safety_gate() {
 
   if [ -z "$cats" ]; then
     # no risk match: pass through, just mark gate_fired=false for audit
-    printf '%s' "$json" | jq -c '. + {gate_fired:false}'
+    printf '%s' "$json" | jq -c --arg sev "$sev" '. + {gate_fired:false, severity:$sev}'
     return 0
   fi
 
-  # RISK match: force escalation, overriding the model. Preserve the model's
-  # original classification for audit (gate_override_from), blank the spec
-  # (it is no longer a dispatchable TASK), and stamp/extend the safety_flag.
+  # === CHANGE 2: SKIP the gate override for NON-DISPATCHING classifications ===
+  # The gate's job is to BLOCK a risky auto-dispatch. It does that by forcing
+  # NEEDS-DECISION + blanking the spec. But some classifications produce NO
+  # dispatchable spec at all — ALREADY-DONE / STALE-close / STALE / VERIFY / FYI
+  # / DUPLICATE. Relabeling one of those to NEEDS-DECISION with a scary
+  # safety_flag (e.g. a "close this, it's merged" ALREADY-DONE that merely
+  # mentions "prod") is pure DIGEST NOISE: it changes only the label, never an
+  # action.
+  #
+  # SAFETY REASONING (why this is safe): these classes never dispatch, so
+  # skipping the gate for them changes only the DIGEST LABEL, never an action —
+  # and an attacker cannot gain anything by evading the gate INTO a
+  # non-dispatching class, because no action is taken for that class either. The
+  # gate's dispatch-blocking value is UNCHANGED for TASK (and any class that
+  # yields a dispatchable spec), where it still fires fully below.
+  local cls
+  cls="$(printf '%s' "$json" | jq -r '.classification // ""')"
+  case "$cls" in
+    ALREADY-DONE|STALE-close|STALE|VERIFY|FYI|DUPLICATE)
+      # Keep the model's original classification + recommendation; do NOT relabel
+      # and do NOT attach a safety_flag. Record what the gate WOULD have matched
+      # for auditability (gate_fired stays false — no override happened).
+      printf '%s' "$json" | jq -c --arg sev "$sev" --arg cats "$cats" \
+        '. + {gate_fired:false, severity:$sev, gate_exempt_class:true, gate_would_have_categories:($cats|split(", "))}'
+      return 0
+      ;;
+  esac
+
+  # RISK match on a DISPATCHABLE classification (TASK / NEEDS-DECISION / ERROR):
+  # force escalation, overriding the model. Preserve the model's original
+  # classification for audit (gate_override_from), blank the spec (it is no
+  # longer a dispatchable TASK), and stamp/extend the safety_flag.
   printf '%s' "$json" | jq -c \
-    --arg cats "$cats" '
+    --arg cats "$cats" --arg sev "$sev" '
+      .severity = $sev
+      |
       . as $orig
       | .gate_fired = true
       | .gate_categories = ($cats | split(", "))
@@ -706,6 +771,71 @@ safety_gate() {
         )
     '
 }
+
+# === HUMAN SUMMARY / DIGEST BODY (severity-ordered) ========================
+# build_summary <queue_jsonl>  -> writes the markdown digest body to stdout.
+# Split into a function so the digest rendering (severity ordering + the urgent
+# callout — CHANGE 1) is testable OFFLINE against a synthetic queue, without the
+# live ClickUp/claude pipeline. Reads run-scoped globals for the meta line
+# (RUN_TS / TOTAL / PROCESSED / SKIPPED / BASELINED / GATE_HITS / DRAFTER_MODEL /
+# DRAFTER_MODE / CLICKUP_VIEW_ID) exactly as the inline block did.
+build_summary() {
+  local queue="$1"
+
+  # The action-worthy set severity ordering operates on (kept in sync with the
+  # section select below). An URGENT tag only floats an item that is ALSO
+  # action-worthy — an already-resolved incident (e.g. an ALREADY-DONE that
+  # merely mentions "down") is not an open incident, so it never reaches the
+  # callout or the reordering.
+  local aw='.classification=="TASK" or .classification=="NEEDS-DECISION" or .classification=="VERIFY" or .classification=="DUPLICATE" or (.safety_flag|length>0)'
+  local urgent_callout n_urgent
+  urgent_callout="$(jq -sr "
+    map(select((.severity==\"URGENT\") and ($aw)))
+    | if length==0 then empty
+      else \"🔥 \(length) URGENT — active incident\(if length>1 then \"s\" else \"\" end): \"
+           + (map(\"\(.ticket_id) \(.title)\") | join(\"; \"))
+      end" "$queue" 2>/dev/null)"
+  n_urgent="$(jq -sr "map(select((.severity==\"URGENT\") and ($aw))) | length" "$queue" 2>/dev/null)"
+  [ -n "$n_urgent" ] || n_urgent=0
+
+  echo "# Task-spec drafter — shadow queue $RUN_TS"
+  echo
+  # CHANGE 1: float the active-incident callout to the VERY TOP of the digest.
+  [ -n "$urgent_callout" ] && { echo "$urgent_callout"; echo; }
+  echo "Source: ClickUp triage view \`$CLICKUP_VIEW_ID\` · queue $TOTAL · processed $PROCESSED new/changed · skipped $SKIPPED unchanged · baselined $BASELINED · model=$DRAFTER_MODEL · mode=$DRAFTER_MODE · deterministic-gate escalations: $GATE_HITS · urgent: $n_urgent"
+  echo
+  echo "## Classification counts"
+  echo
+  jq -r '.classification' "$queue" | sort | uniq -c | sort -rn | sed 's/^/    /'
+  echo
+  echo "## Action-worthy (TASK / NEEDS-DECISION / VERIFY / DUPLICATE / safety-flagged)"
+  echo
+  # CHANGE 1: severity ordering — URGENT items FIRST (with a 🔥 URGENT marker),
+  # then the rest in file order. Slurp so the two groups can be concatenated
+  # deterministically (no reliance on jq sort stability); severity is orthogonal
+  # to classification, so the classification framing is unchanged within a group.
+  jq -sr "map(select($aw))
+         | (map(select(.severity==\"URGENT\")) + map(select(.severity!=\"URGENT\")))
+         | .[]
+         | \"### \" + (if .severity==\"URGENT\" then \"🔥 URGENT · \" else \"\" end) + \"[\(.classification)] \(.ticket_id) — \(.title)\n- confidence: \(.confidence)  age: \(.age_days // \"?\")d  status: \(.status // \"?\")\n- verified: \(.verification)\n\" +
+           (if (.correlations|length>0) then \"- correlations: \(.correlations|join(\"; \"))\n\" else \"\" end) +
+           (if (.classification==\"TASK\") then \"- SPEC goal: \(.spec.goal)\n- SPEC done(verifier): \(.spec.done)\n- SPEC owner: \(.spec.owner)  autonomy: \(.spec.autonomy)\n\" else \"- recommendation: \(.recommendation)\n\" end) +
+           (if (.safety_flag|length>0) then \"- ⚠ SAFETY: \(.safety_flag)\n\" else \"\" end)" \
+     "$queue"
+  echo
+  echo "## Suppressed (FYI / STALE-close / ALREADY-DONE, one-liners)"
+  echo
+  jq -r 'select(.classification=="FYI" or .classification=="STALE-close" or .classification=="ALREADY-DONE")
+         | "- [\(.classification)] \(.ticket_id) \(.title) — \(.recommendation // .verification)"' \
+     "$queue"
+}
+
+# TEST HOOK: let the hermetic suite source ONLY the pure functions
+# (severity_tag / safety_gate + the GATE_RE_* / SEV_RE_* regexes) in isolation,
+# without running the pipeline (no ClickUp fetch, no `claude -p`, no clawgate
+# POST). Sourcing with DRAFTER_LIB_ONLY=1 returns here. This is inert on the real
+# run path — DRAFTER_LIB_ONLY is unset by the systemd unit and every hand-run.
+if [ "${DRAFTER_LIB_ONLY:-0}" = "1" ]; then return 0 2>/dev/null || exit 0; fi
 
 RUN_TS="$(date '+%Y%m%dT%H%M%S')"
 QUEUE_JSONL="$DRAFTER_OUT_DIR/queue-$RUN_TS.jsonl"
@@ -965,31 +1095,8 @@ if [ "$PROCESSED" -eq 0 ]; then
   exit 0
 fi
 
-# --- build the human summary (counts by class + the genuine/decision items) -
-{
-  echo "# Task-spec drafter — shadow queue $RUN_TS"
-  echo
-  echo "Source: ClickUp triage view \`$CLICKUP_VIEW_ID\` · queue $TOTAL · processed $PROCESSED new/changed · skipped $SKIPPED unchanged · baselined $BASELINED · model=$DRAFTER_MODEL · mode=$DRAFTER_MODE · deterministic-gate escalations: $GATE_HITS"
-  echo
-  echo "## Classification counts"
-  echo
-  jq -r '.classification' "$QUEUE_JSONL" | sort | uniq -c | sort -rn | sed 's/^/    /'
-  echo
-  echo "## Action-worthy (TASK / NEEDS-DECISION / VERIFY / DUPLICATE / safety-flagged)"
-  echo
-  jq -r 'select(.classification=="TASK" or .classification=="NEEDS-DECISION" or .classification=="VERIFY" or .classification=="DUPLICATE" or (.safety_flag|length>0))
-         | "### [\(.classification)] \(.ticket_id) — \(.title)\n- confidence: \(.confidence)  age: \(.age_days // "?")d  status: \(.status // "?")\n- verified: \(.verification)\n" +
-           (if (.correlations|length>0) then "- correlations: \(.correlations|join("; "))\n" else "" end) +
-           (if (.classification=="TASK") then "- SPEC goal: \(.spec.goal)\n- SPEC done(verifier): \(.spec.done)\n- SPEC owner: \(.spec.owner)  autonomy: \(.spec.autonomy)\n" else "- recommendation: \(.recommendation)\n" end) +
-           (if (.safety_flag|length>0) then "- ⚠ SAFETY: \(.safety_flag)\n" else "" end)' \
-     "$QUEUE_JSONL"
-  echo
-  echo "## Suppressed (FYI / STALE-close / ALREADY-DONE, one-liners)"
-  echo
-  jq -r 'select(.classification=="FYI" or .classification=="STALE-close" or .classification=="ALREADY-DONE")
-         | "- [\(.classification)] \(.ticket_id) \(.title) — \(.recommendation // .verification)"' \
-     "$QUEUE_JSONL"
-} > "$QUEUE_SUMMARY"
+# --- build the human summary (severity-ordered; CHANGE 1) ------------------
+build_summary "$QUEUE_JSONL" > "$QUEUE_SUMMARY"
 
 log "summary written: $QUEUE_SUMMARY"
 ln -sf "$(basename "$QUEUE_JSONL")"  "$DRAFTER_OUT_DIR/latest.jsonl"

--- a/scripts/task-spec-drafter/tests/test_severity_and_gate_skip.py
+++ b/scripts/task-spec-drafter/tests/test_severity_and_gate_skip.py
@@ -1,0 +1,311 @@
+"""Behavioral tests for the two digest-content changes (2026-07-29):
+
+CHANGE 1 — deterministic SEVERITY/URGENCY detector + digest ordering:
+  (c) incident-language tickets are tagged URGENT and the digest floats them to
+      the top with a 🔥 marker + a top-of-digest callout;
+  (d) a normal ticket stays non-urgent.
+
+CHANGE 2 — SKIP the safety-gate override for NON-DISPATCHING classifications:
+  (a) an ALREADY-DONE / VERIFY ticket carrying risk keywords is NOT relabeled to
+      NEEDS-DECISION and carries NO safety flag;
+  (b) a TASK carrying risk keywords STILL gets gate-escalated (unchanged).
+
+These EXERCISE the real bash functions (severity_tag / safety_gate /
+build_summary) by sourcing drafter.sh with DRAFTER_LIB_ONLY=1 (a test hook that
+returns before the live ClickUp/claude pipeline runs). Pure-text structural
+assertions live alongside these in test_shadow_wiring.py.
+
+Skips cleanly when bash/jq are unavailable (e.g. a minimal nix sandbox) so the
+hermetic flake check never goes red on tooling; on the dev host (where
+run-tests.sh runs) bash+jq are present and the tests execute for real.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+_DRAFTER = _HERE.parent / "drafter.sh"
+
+_BASH = shutil.which("bash")
+_JQ = shutil.which("jq")
+_GREP = shutil.which("grep")
+
+pytestmark = pytest.mark.skipif(
+    not (_BASH and _JQ and _GREP),
+    reason="behavioral tests need bash + jq + grep on PATH",
+)
+
+
+def _run_lib(snippet: str, tmp_path: Path) -> str:
+    """Source drafter.sh (lib-only) then run `snippet`; return stdout."""
+    out_dir = tmp_path / "out"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    script = textwrap.dedent(
+        f"""
+        set -uo pipefail
+        export DRAFTER_LIB_ONLY=1
+        export DRAFTER_OUT_DIR={out_dir!s}
+        export DRAFTER_LOG_FILE={out_dir!s}/log
+        source {_DRAFTER!s}
+        {snippet}
+        """
+    )
+    res = subprocess.run(
+        [_BASH, "-c", script],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+    assert res.returncode == 0, f"lib snippet failed rc={res.returncode}\nstderr:\n{res.stderr}"
+    return res.stdout
+
+
+def _write(p: Path, text: str) -> Path:
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def _gate(tmp_path: Path, ticket_text: str, record: dict) -> dict:
+    """Run safety_gate over (ticket_text, record) and return the JSON result."""
+    txt = _write(tmp_path / "ticket.txt", ticket_text)
+    rec = _write(tmp_path / "rec.json", json.dumps(record))
+    out = _run_lib(f'safety_gate "{txt}" "$(cat "{rec}")"', tmp_path)
+    return json.loads(out.strip().splitlines()[-1])
+
+
+# --- CHANGE 2: gate skip for non-dispatching classes --------------------------
+
+def test_a_already_done_with_risk_keywords_not_relabeled(tmp_path):
+    """(a) ALREADY-DONE carrying prod/migration risk keywords must keep its class
+    and carry NO safety flag — a close-recommendation never dispatches, so gating
+    it is pure noise."""
+    rec = {
+        "ticket_id": "ccc333",
+        "title": "Prod migration for user table",
+        "classification": "ALREADY-DONE",
+        "confidence": "high",
+        "verification": "merged in PR 2811, deployed",
+        "recommendation": "close it — already shipped",
+        "correlations": [],
+        "spec": {"goal": "", "done": "", "owner": "", "autonomy": ""},
+        "safety_flag": "",
+    }
+    out = _gate(tmp_path, "Close this — the prod migration is already merged and deployed", rec)
+    assert out["classification"] == "ALREADY-DONE", "must NOT be relabeled to NEEDS-DECISION"
+    assert out["gate_fired"] is False
+    assert out["safety_flag"] == "", "no safety flag on a non-dispatching class"
+    assert out["recommendation"] == "close it — already shipped", "model recommendation preserved"
+    # audit trail: record that the gate WOULD have matched, for transparency
+    assert out.get("gate_exempt_class") is True
+    assert "destructive/prod-mutation" in out.get("gate_would_have_categories", [])
+
+
+def test_a_verify_with_money_keywords_not_relabeled(tmp_path):
+    """(a, sibling) VERIFY carrying money-category keywords is likewise exempt."""
+    rec = {
+        "ticket_id": "vvv444",
+        "title": "Refund path sanity check",
+        "classification": "VERIFY",
+        "confidence": "medium",
+        "verification": "looks shipped",
+        "recommendation": "manual confirm the refund flow",
+        "correlations": [],
+        "spec": {"goal": "", "done": "", "owner": "", "autonomy": ""},
+        "safety_flag": "",
+    }
+    out = _gate(tmp_path, "Confirm the payment refund path works", rec)
+    assert out["classification"] == "VERIFY"
+    assert out["gate_fired"] is False
+    assert out["safety_flag"] == ""
+
+
+def test_all_nondispatching_classes_are_exempt(tmp_path):
+    """Every non-dispatching class token the code exempts stays put under a risk
+    match (ALREADY-DONE / STALE-close / STALE / VERIFY / FYI / DUPLICATE)."""
+    for cls in ("ALREADY-DONE", "STALE-close", "STALE", "VERIFY", "FYI", "DUPLICATE"):
+        rec = {
+            "ticket_id": "x",
+            "title": "prod delete migration",
+            "classification": cls,
+            "confidence": "high",
+            "verification": "v",
+            "recommendation": "r",
+            "correlations": [],
+            "spec": {"goal": "", "done": "", "owner": "", "autonomy": ""},
+            "safety_flag": "",
+        }
+        out = _gate(tmp_path, "delete the prod table via migration", rec)
+        assert out["classification"] == cls, f"{cls} must not be relabeled"
+        assert out["gate_fired"] is False, f"{cls} must not fire the gate"
+        assert out["safety_flag"] == "", f"{cls} must carry no safety flag"
+
+
+# --- CHANGE 2 (unchanged half): TASK still escalates --------------------------
+
+def test_b_task_with_risk_keywords_still_escalates(tmp_path):
+    """(b) A TASK (dispatchable) carrying risk keywords MUST still be force-
+    escalated to NEEDS-DECISION with a safety flag + needs-Zach — the gate's core
+    dispatch-blocking job is unchanged."""
+    rec = {
+        "ticket_id": "t1",
+        "title": "Rebuild search index in production",
+        "classification": "TASK",
+        "confidence": "high",
+        "verification": "checked",
+        "recommendation": "do it",
+        "correlations": [],
+        "spec": {"goal": "rebuild", "done": "green", "owner": "zach", "autonomy": "auto"},
+        "safety_flag": "",
+    }
+    out = _gate(tmp_path, "Delete the prod meilisearch index and rebuild", rec)
+    assert out["classification"] == "NEEDS-DECISION", "TASK with risk must escalate"
+    assert out["gate_fired"] is True
+    assert len(out["safety_flag"]) > 0
+    assert out["spec"]["autonomy"] == "needs-Zach"
+    assert out["gate_override_from"] == "TASK"
+    assert out["spec"]["goal"] == "", "dispatchable spec blanked"
+
+
+def test_task_without_risk_keywords_passes_through(tmp_path):
+    """A clean TASK is untouched (gate_fired=false, spec intact)."""
+    rec = {
+        "ticket_id": "t2",
+        "title": "Improve onboarding copy",
+        "classification": "TASK",
+        "confidence": "medium",
+        "verification": "no prior art",
+        "recommendation": "",
+        "correlations": [],
+        "spec": {"goal": "tidy copy", "done": "reviewed", "owner": "zach", "autonomy": "auto"},
+        "safety_flag": "",
+    }
+    out = _gate(tmp_path, "Please tidy up the onboarding copy on the about page", rec)
+    assert out["classification"] == "TASK"
+    assert out["gate_fired"] is False
+    assert out["spec"]["goal"] == "tidy copy"
+
+
+# --- CHANGE 1: severity detector ----------------------------------------------
+
+def _severity(tmp_path: Path, ticket_text: str) -> str:
+    txt = _write(tmp_path / "ticket.txt", ticket_text)
+    return _run_lib(f'severity_tag "{txt}"', tmp_path).strip()
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Image scanning DOWN since restart, 0 images reaching Scanned",
+        "Upload pipeline is stuck, nothing processing for 2 hours",
+        "prod is broken — 500s on every request",
+        "P1: error rate spiking, data loss suspected",
+        "URGENT please fix ASAP the scanner crashloop",
+    ],
+)
+def test_c_incident_language_is_urgent(tmp_path, text):
+    """(c) incident/high-urgency language → URGENT."""
+    assert _severity(tmp_path, text) == "URGENT"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Improve onboarding copy on the about page when you get a chance",
+        "Add a tooltip to the settings gear icon",
+        "Consider renaming the 'models' tab to 'checkpoints' someday",
+    ],
+)
+def test_d_normal_language_stays_normal(tmp_path, text):
+    """(d) a vague/backlog ticket stays non-urgent."""
+    assert _severity(tmp_path, text) == "normal"
+
+
+def test_severity_is_word_anchored_no_false_positive_on_2500(tmp_path):
+    """`\\b500s?\\b` must not fire on '2500' (documented false-positive guard)."""
+    assert _severity(tmp_path, "Bump the batch size to 2500 items per page") == "normal"
+
+
+# --- CHANGE 1: digest ordering + callout (via build_summary) ------------------
+
+def _build_summary(tmp_path: Path, records: list[dict]) -> str:
+    q = tmp_path / "queue.jsonl"
+    q.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+    snippet = (
+        'RUN_TS=T CLICKUP_VIEW_ID=v TOTAL=9 PROCESSED=3 SKIPPED=6 BASELINED=0 '
+        'GATE_HITS=0 DRAFTER_MODEL=haiku DRAFTER_MODE=shadow; '
+        f'build_summary "{q}"'
+    )
+    return _run_lib(snippet, tmp_path)
+
+
+def test_c_digest_floats_urgent_first_with_marker_and_callout(tmp_path):
+    """(c) URGENT action-worthy items sort FIRST, wear a 🔥 URGENT marker, and a
+    top-of-digest callout names the incident."""
+    records = [
+        # normal TASK appears FIRST in the file — must be pushed BELOW the incident
+        {"ticket_id": "aaa111", "title": "Improve onboarding copy",
+         "classification": "TASK", "confidence": "medium", "age_days": 40, "status": "open",
+         "verification": "no prior art", "recommendation": "", "correlations": [],
+         "spec": {"goal": "copy", "done": "reviewed", "owner": "zach", "autonomy": "auto"},
+         "safety_flag": "", "gate_fired": False, "severity": "normal"},
+        # the active incident — mid-file, must float to the top
+        {"ticket_id": "868kfwm3j",
+         "title": "Image scanning DOWN since restart, 0 images reaching Scanned",
+         "classification": "NEEDS-DECISION", "confidence": "medium", "age_days": 0, "status": "open",
+         "verification": "scanner pod crashlooping in prod",
+         "recommendation": "needs Zach — active incident", "correlations": [],
+         "spec": {"goal": "", "done": "", "owner": "", "autonomy": "needs-Zach"},
+         "safety_flag": "", "gate_fired": False, "severity": "URGENT"},
+    ]
+    out = _build_summary(tmp_path, records)
+
+    # top-of-digest callout, before the "Source:" meta line
+    assert "🔥 1 URGENT — active incident: 868kfwm3j Image scanning DOWN" in out
+    assert out.index("🔥 1 URGENT") < out.index("Source: ClickUp"), "callout must be at the very top"
+    assert "· urgent: 1" in out
+
+    # ordering: the urgent heading appears before the normal TASK heading
+    urgent_hd = out.index("### 🔥 URGENT · [NEEDS-DECISION] 868kfwm3j")
+    normal_hd = out.index("### [TASK] aaa111")
+    assert urgent_hd < normal_hd, "URGENT item must render before the normal item"
+    # the normal item carries NO 🔥 marker on its heading
+    assert "🔥 URGENT · [TASK] aaa111" not in out
+
+
+def test_d_no_callout_when_nothing_urgent(tmp_path):
+    """No urgent items → no 🔥 callout, urgent count 0, normal ordering intact."""
+    records = [
+        {"ticket_id": "aaa111", "title": "Improve onboarding copy",
+         "classification": "TASK", "confidence": "medium", "age_days": 40, "status": "open",
+         "verification": "no prior art", "recommendation": "", "correlations": [],
+         "spec": {"goal": "copy", "done": "reviewed", "owner": "zach", "autonomy": "auto"},
+         "safety_flag": "", "gate_fired": False, "severity": "normal"},
+    ]
+    out = _build_summary(tmp_path, records)
+    assert "🔥" not in out
+    assert "· urgent: 0" in out
+    assert "### [TASK] aaa111" in out
+
+
+def test_c_already_done_urgent_words_not_in_callout(tmp_path):
+    """An ALREADY-DONE that merely mentions incident words is NOT an open
+    incident, so it never reaches the callout or the action-worthy reordering —
+    it stays in Suppressed."""
+    records = [
+        {"ticket_id": "ddd555", "title": "Scanner was DOWN last week",
+         "classification": "ALREADY-DONE", "confidence": "high", "age_days": 7, "status": "closed",
+         "verification": "fixed + deployed in PR 900", "recommendation": "close — resolved",
+         "correlations": [], "spec": {"goal": "", "done": "", "owner": "", "autonomy": ""},
+         "safety_flag": "", "gate_fired": False, "severity": "URGENT"},
+    ]
+    out = _build_summary(tmp_path, records)
+    assert "🔥" not in out, "a resolved incident must not raise the callout"
+    assert "· urgent: 0" in out
+    assert "## Suppressed" in out
+    assert "[ALREADY-DONE] ddd555" in out

--- a/scripts/task-spec-drafter/tests/test_shadow_wiring.py
+++ b/scripts/task-spec-drafter/tests/test_shadow_wiring.py
@@ -230,6 +230,65 @@ def test_safety_gate_forces_needs_decision():
         assert cat in src
 
 
+# --- CHANGE 2: gate SKIPS non-dispatching classes (structural) ----------------
+
+def test_gate_exempts_nondispatching_classes():
+    """The gate override must be SKIPPED for classes that yield no dispatchable
+    spec — relabeling them is pure digest noise (they never dispatch)."""
+    src = _read(_DRAFTER)
+    # a single case arm names every exempt class token exactly as the prompt emits
+    assert "ALREADY-DONE|STALE-close|STALE|VERIFY|FYI|DUPLICATE)" in src
+    # the exempt arm records the audit trail and returns WITHOUT relabeling
+    assert "gate_exempt_class:true" in src
+    assert "gate_would_have_categories" in src
+    # the safety reasoning is preserved in a code comment
+    assert "changes only the DIGEST LABEL, never an action" in src
+
+
+# --- CHANGE 1: deterministic severity detector + digest ordering (structural) --
+
+def test_severity_detector_present_and_tuned_next_to_gate():
+    src = _read(_DRAFTER)
+    assert "SEV_RE_INCIDENT=" in src
+    assert "severity_tag()" in src
+    # a representative slice of the tunable incident regex
+    for token in ("down", "outage", "crashloop", "error rate", "p0", "p1", "asap"):
+        assert token in src.split("SEV_RE_INCIDENT=", 1)[1].split("\n", 1)[0]
+
+
+def test_severity_is_stamped_on_every_gated_record():
+    """safety_gate must stamp `severity` on all three outputs (pass-through,
+    exempt, and escalated) so every queue record is auditable + orderable."""
+    src = _read(_DRAFTER)
+    gate = src.split("safety_gate() {", 1)[1].split("\nbuild_summary()", 1)[0] \
+        if "build_summary()" in src else src.split("safety_gate() {", 1)[1]
+    # severity computed once, added to json in every branch
+    assert 'sev="$(severity_tag "$txt_file")"' in gate
+    assert gate.count("severity:$sev") >= 2  # pass-through + exempt branches
+    assert ".severity = $sev" in gate         # escalation branch
+
+
+def test_digest_orders_urgent_first_with_marker_and_callout():
+    src = _read(_DRAFTER)
+    body = src.split("build_summary()", 1)[1]
+    # urgent-first ordering: two groups concatenated (urgent ++ non-urgent)
+    assert 'map(select(.severity==\\"URGENT\\")) + map(select(.severity!=\\"URGENT\\"))' in body
+    # 🔥 URGENT heading marker + the top-of-digest callout
+    assert "🔥 URGENT ·" in body
+    assert "active incident" in body
+    assert "urgent: $n_urgent" in body
+
+
+def test_lib_only_hook_returns_before_pipeline():
+    """The DRAFTER_LIB_ONLY test hook must sit AFTER the function defs but BEFORE
+    the live pipeline (the ClickUp fetch), so sourcing runs no live work."""
+    src = _read(_DRAFTER)
+    hook = src.index('DRAFTER_LIB_ONLY:-0')
+    assert hook < src.index("fetch_queue()"), "lib-only hook must precede the pipeline"
+    assert src.index("safety_gate()") < hook, "functions must be defined before the hook"
+    assert src.index("build_summary()") < hook
+
+
 # --- daily email digest (the review surface) ----------------------------------
 
 def test_digest_email_step_present_and_default_on():


### PR DESCRIPTION
Two bounded, deterministic improvements to the **task-spec-drafter digest content**. The tool runs daily unattended in **SHADOW** mode over untrusted civitai client tickets.

## Invariants preserved
- **`DRAFTER_MODE` behavior unchanged** — stays SHADOW; the tool dispatches nothing in either mode, and **no ticket that previously reached actual dispatch is affected** (`N_TASK` and the dispatch path are untouched).
  - Precise note on CHANGE 2 in `on` mode: because an exempt-class ticket (ALREADY-DONE/STALE-close/STALE/VERIFY/FYI/DUPLICATE) that trips a risk keyword is no longer force-relabeled to NEEDS-DECISION, it drops out of the clawgate **notification card content** and the `N_DEC` count. That is **notification-only** and is exactly the intended noise reduction — these are non-dispatching classes, so nothing that would dispatch changes; the `on`-mode POST still fires, only its listed items/counts shrink. In SHADOW (the live default) nothing POSTs at all, unchanged.
- **Allowlist (`DRAFTER_ALLOWED_TOOLS`) and deny layer (`DRAFTER_DENY_*`) untouched** — verified the diff touches neither.
- **Fully deterministic** (regex/code), no new LLM call, no trust in model self-assessment — consistent with `safety_gate()`.

## CHANGE 1 — severity ordering
An active prod incident used to be buried mid-list. Added:
- `SEV_RE_INCIDENT` (word-boundary, case-insensitive incident-signal regex, tuned at the top next to the gate regexes) + `severity_tag()`.
- `safety_gate()` now stamps an **orthogonal** `severity` field (`URGENT`|`normal`) on **every** record — auditable, never alters classification.
- The digest (refactored into `build_summary()`, so it is testable offline) floats `URGENT` action-worthy items to the top with a `🔥 URGENT ·` heading marker and emits a top-of-digest callout `🔥 N URGENT — active incident: <id> <title>`.
- Word-anchored so `500` in `2500` does not fire; over- vs under-surfacing tradeoff documented in-code.

## CHANGE 2 — skip the gate for non-dispatching classes
The gate force-relabels risk-keyword tickets to `NEEDS-DECISION` + attaches a safety flag. For classes that produce **no dispatchable spec** — `ALREADY-DONE` / `STALE-close` / `STALE` / `VERIFY` / `FYI` / `DUPLICATE` — that was pure digest noise. The gate now **skips the override** for those (keeps the model's class + recommendation, no safety flag; records `gate_would_have_categories` for audit). It **still fires fully for `TASK`** — its dispatch-blocking job is unchanged.

**Safety reasoning (in-code):** these classes never dispatch, so skipping only changes the DIGEST LABEL (and, in `on` mode, the notification-card content — see the invariant note above), never an action — and an attacker cannot gain by evading the gate INTO a non-dispatching class.

## Validation
- `home-manager build --flake .#zach --impure` — green.
- `scripts/run-tests.sh --set hermetic` (dev host, full PATH) — green (incl. `scripts/task-spec-drafter/tests`).
- **Flake-check gate now RUNS the behavioral tests** (not silently skipped): `flake.nix`'s `checks.pytests` `nativeBuildInputs` gains `pkgs.jq pkgs.gnugrep` so the sandbox has the `bash+jq+grep` the behavioral suite needs. Proven in-sandbox: `nix build .#checks.x86_64-linux.pytests` takes `scripts/task-spec-drafter/tests` from `3 failed, 121 passed, **17 skipped**` → `3 failed, **138 passed, 0 skipped**` — the 17 formerly-skipped are exactly `test_severity_and_gate_skip.py`, now executing and passing. (The 3 pre-existing `kubectl-ro` failures are **byte-identical in both builds** — unrelated sandbox-tooling gaps on `main`, not introduced here; likewise the browser-bridge suite.)
- New behavioral tests exercise the **real bash functions** (source via a `DRAFTER_LIB_ONLY` test hook): (a) ALREADY-DONE/VERIFY with risk keywords not relabeled + no flag, (b) TASK with risk keywords still escalates, (c) incident language → URGENT + digest orders urgent-first with callout, (d) normal ticket stays non-urgent. Plus structural guards in `test_shadow_wiring.py`.
- SHADOW dry-run over a synthetic post-gate queue through the real `send_digest.py --dry-run` (nothing sent) — the incident floats to the top with the 🔥 callout + marker, and the risk-keyword ALREADY-DONE lands in Suppressed with no safety flag.

> Note: the full live pipeline (`claude -p` per ticket over untrusted tickets + live ClickUp) was **not** run from the worktree; the digest-content behavior is proven deterministically against a synthetic queue driving the real render/email code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)