### PR TITLE
fix(browser-bridge): eval --frame actually evaluates via CDP Runtime.evaluate (incl. OOPIF)

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -126,7 +126,7 @@ always-detach) is in the **CDP ops** section below.
 |----|---------|---------|
 | `getHtml`    | `chrome.scripting` → `document.documentElement.outerHTML` | `{url,title,html}` |
 | `text`       | `chrome.scripting` → `(selector?document.querySelector(selector):document.body).innerText`, normalized + byte-capped (`selector`/`maxBytes` optional) | `{url,title,text,truncated}` |
-| `eval`       | `chrome.scripting.executeScript` (MAIN world) of `js`     | `{url,value}` |
+| `eval`       | top frame: `chrome.scripting.executeScript` (MAIN world) of `js`; **`--frame`: CDP `Runtime.evaluate`** in the frame's context (same-process isolated world OR OOPIF flat session) — chrome.scripting can't eval a STRING | `{url,value,frame?}` |
 | `tabs`       | `chrome.tabs.query({})`                                   | `{tabs:[...],ownedTabId}` |
 | `nav`        | `chrome.tabs.update(tab,{url})`                           | `{tabId,url}` |
 | `screenshot` | **CDP `Page.captureScreenshot`** (png) — works on a BACKGROUND/occluded tab + each profile's own tab; a foreground tab uses the cheap `captureVisibleTab` fast path. `fullpage` grabs the whole document | `{url,dataUrl,via}` |
@@ -139,13 +139,20 @@ always-detach) is in the **CDP ops** section below.
 
 `open`/`close` are dispatched to the extension; `release` (drop ownership, don't
 close the tab) is handled server-side and never reaches the extension.
-`frames` enumerates via **`chrome.webNavigation`** and a `--frame` on
-`getHtml`/`text`/`eval`/`click`/`type`/`key` injects via **`chrome.scripting`** INTO
+`frames` enumerates via **`chrome.webNavigation`** and a `--frame` on the fixed-func
+ops `getHtml`/`text`/`click`/`type`/`key` injects via **`chrome.scripting`** INTO
 the resolved frame — this reaches CROSS-ORIGIN out-of-process iframes (OOPIFs) that
-CDP `Page.getFrameTree` could NOT enumerate. `--frame <numeric-frameId|url-substring>`
-selects the frame (the identifier is the numeric webNavigation `frameId`). `screenshot`
-and TOP-frame trusted input still use **CDP (chrome.debugger)** (see the CDP section
-below). The tab-scoped ops
+CDP `Page.getFrameTree` could NOT enumerate. **`eval --frame` is the exception: it
+runs via CDP `Runtime.evaluate`, NOT `chrome.scripting`** — `chrome.scripting` runs a
+serialized FUNC, so it can't evaluate an arbitrary JS STRING in the frame (it returned
+`value:null`-as-success), whereas `Runtime.evaluate` runs the string in the frame's
+execution context (same-process isolated world, or the OOPIF's own flat session via
+`Target.setAutoAttach`) and surfaces exceptions as a clear `frame_eval_failed` error —
+never a silent null. `--frame <numeric-frameId|url-substring>`
+selects the frame (the identifier is the numeric webNavigation `frameId`). `screenshot`,
+`eval --frame`, and TOP-frame trusted input use **CDP (chrome.debugger)** (see the CDP
+section below). A `--frame` op reports the FRAME's own `url` (so a caller can confirm it
+read the intended frame, not the top document). The tab-scoped ops
 (`getHtml`/`text`/`eval`/`nav`/`screenshot`/`close`/`frames`/`click`/`type`/`key`)
 run against
 the calling session's owned tab when it has one (see Session isolation), else the
@@ -177,6 +184,22 @@ never target it. `getAllFrames` sees OOPIFs and `scripting` injects into them (g
 webNavigation `frameId`. In-frame input is **SYNTHETIC** (`isTrusted:false`) — the
 reachable OOPIF path (a trusted CDP `Input.*` event from the top target can't easily
 reach an OOPIF), and enough to drive most apps.
+
+**`eval --frame` runs via CDP `Runtime.evaluate` (not `chrome.scripting`).** The
+fixed-func frame ops above work because `chrome.scripting.executeScript` runs a
+serialized FUNCTION. But `eval` is an arbitrary JS STRING, and routing a string through
+a `func` that `new Function(src)`s it inside the frame's isolated world hits the
+extension CSP / returns `value:null`-as-success — it never truly evaluates (the bug).
+So `eval --frame` attaches `chrome.debugger` to the OWNED tab and resolves the target
+frame's execution context by URL (the numeric webNavigation `frameId` does not map 1:1
+to a CDP frame/target): a **same-process** frame is found in the top session's
+`Page.getFrameTree` → `Page.createIsolatedWorld` → `Runtime.evaluate({contextId})`; a
+**cross-origin OOPIF** is not in that tree → `Target.setAutoAttach({flatten:true})`
+auto-attaches its target (matched by URL) → `Runtime.evaluate` in that flat session.
+Everything is bounded by the per-op CDP timeouts (a bad frame fails fast, never wedges),
+and the never-silent-null contract holds: a genuine `null`/`undefined` is returned as a
+value, but a failure to execute is a clear `frame_not_found` / `frame_eval_failed:<reason>`
+error. Own-tab-only + typed-op invariants are unchanged (no raw-CDP passthrough).
 
 **CDP ops (`chrome.debugger`) — `screenshot` + TOP-frame trusted input.** These use the
 Chrome DevTools Protocol via the `debugger` permission. They fix two real agent
@@ -707,8 +730,11 @@ The **`browser agent`** slice, all headless (NO live model, NO Brave, NO bridge)
   ONE `--continue` retry then `blocked`, no-retry on a hard error.
 
 Current totals: **157 Python** (`test_server.py` 115 + `test_browser_agent_parse.py`
-14 + `test_browser_agent.py` 28) + **121 node** (`protocol.test.mjs` 59 +
-`browser_tool.test.mjs` 33 + `cdp_protocol.test.mjs` 29) — the `protocol.test.mjs` cases cover the screenshot
+14 + `test_browser_agent.py` 28) + **157 node** (`protocol.test.mjs` 59 +
+`browser_tool.test.mjs` 33 + `cdp_protocol.test.mjs` 32 + `frame_oopif.test.mjs` 15 +
+`frame_eval_cdp.test.mjs` 9 + `service_worker.test.mjs` 9) — `frame_eval_cdp.test.mjs`
+covers the `eval --frame` CDP `Runtime.evaluate` fix (same-process + OOPIF context
+resolution, never-silent-null, #189 timeout no-wedge); the `protocol.test.mjs` cases cover the screenshot
 settle+retry decision logic (`isTransientCaptureError` / `captureWithRetry` /
 `waitForCaptureReady` / `screenshotWithRestore`) **and the exhausted-retry error
 mapping** (`isOcclusionCaptureError` / `mapCaptureFailure`): a persistent readback

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -104,7 +104,7 @@ Prefix any op with `--instance <key>` to target a specific connected profile
 | `browser [--instance K] release`           | drop ownership WITHOUT closing the tab |
 | `browser [--instance K] [--tab T] html`              | `outerHTML` of the owned tab (else the active tab) |
 | `browser [--instance K] [--tab T] text [selector] [--max-bytes N]` | **cheap read** — visible `innerText` of the owned/active tab (optional CSS `selector`), whitespace-normalized + byte-capped (default 32768; `0`=uncapped; a truncation note is appended). ~98% smaller than `html` — prefer it |
-| `browser [--instance K] [--tab T] [--frame F] eval '<js>'` | run JS in the owned/active tab, return its value (`--frame` runs it INSIDE a cross-origin OOPIF via `chrome.scripting`, isolated world) |
+| `browser [--instance K] [--tab T] [--frame F] eval '<js>'` | run JS in the owned/active tab, return its value. **`--frame` runs the JS INSIDE the target frame (incl. a cross-origin OOPIF) via CDP `Runtime.evaluate`** (not `chrome.scripting`, which can only run a func — the old path returned `value:null`); a frame that can't be resolved / an exception → a clear `frame_not_found` / `frame_eval_failed:<reason>` error, never a silent null; reports the frame's own `url` |
 | `browser [--instance K] tabs`              | list open tabs (`.data.ownedTabId` flags this session's owned tab) |
 | `browser [--instance K] [--tab T] nav <url>`         | navigate the owned/active tab to `<url>` |
 | `browser [--instance K] [--tab T] screenshot [path] [--fullpage]` | screenshot via **CDP `Page.captureScreenshot`** — **works on a BACKGROUND/occluded tab** and on each profile's own tab (a foreground tab uses the cheap captureVisibleTab fast path). `--fullpage` grabs the whole scrollable document. Prints the data URL, or writes a `.png` to `path` |
@@ -116,12 +116,18 @@ Prefix any op with `--instance <key>` to target a specific connected profile
 | `browser --print-session-id`               | print the derived per-session id (debug) and exit |
 
 `--frame <F>` (a **numeric** `frameId` from `frames`, or a URL substring) routes a
-`text`/`html`/`eval`/`click`/`type`/`key` INTO that frame via `chrome.scripting` —
-which reaches CROSS-ORIGIN out-of-process iframes (OOPIFs). A frame-scoped `eval`/read
+`text`/`html`/`click`/`type`/`key` INTO that frame via `chrome.scripting` — which
+reaches CROSS-ORIGIN out-of-process iframes (OOPIFs). A frame-scoped fixed-func read
 runs in an **isolated world** (DOM-capable; it does not see that frame's page globals).
+**`eval --frame` is the exception: it runs the JS string via CDP `Runtime.evaluate`**
+(`chrome.scripting` can only run a serialized func, so the old path evaluated nothing and
+returned `value:null`) — same-process frames in an isolated world, a cross-origin OOPIF
+in its own flat session; a resolve/exec failure is a clear `frame_not_found` /
+`frame_eval_failed` error, never a silent null.
 In-frame `click`/`type`/`key` dispatch **SYNTHETIC** events (`isTrusted:false`, the
 reachable OOPIF path — drives most apps); the result carries `trusted:false` for
-`--frame` input and `trusted:true` for top-frame CDP input.
+`--frame` input and `trusted:true` for top-frame CDP input. A `--frame` op reports the
+FRAME's own `url` (so you can confirm you read the intended frame, not the top).
 
 Result payloads land under `.result.data` in the JSON (the envelope is
 `{"ok":true,"result":{"id","ok","data":{...}}}`).
@@ -142,8 +148,10 @@ limitations:
    `civitai.com`) because `chrome.webNavigation.getAllFrames` enumerates OOPIFs that
    CDP `Page.getFrameTree` could not; then `browser --tab T --frame <numericId-or-url>
    text` reads inside it and `--frame … click/type/key` drives an in-app control (via
-   `chrome.scripting` injection). Plain `text`/`html`/`eval` still see only the top
-   frame.
+   `chrome.scripting` injection), while `--frame … eval '<js>'` runs a JS string inside
+   it via CDP `Runtime.evaluate` (e.g. `--frame <oopif> eval 'location.href'` returns the
+   OOPIF's own url, not null). Plain `text`/`html`/`eval` (no `--frame`) still see only
+   the top frame.
 3. **Drive an app's TOP frame with trusted input** — top-frame `click`/`type`/`key`
    dispatch real `isTrusted` events via CDP. (In a cross-origin `--frame`, input is
    SYNTHETIC — see above.)

--- a/scripts/browser-bridge/extension/README.md
+++ b/scripts/browser-bridge/extension/README.md
@@ -155,12 +155,23 @@ target it. `getAllFrames` enumerates OOPIFs; `scripting` injects into them (give
 (`isTrusted:false`) — the reachable OOPIF path, and enough to drive most apps; TOP-frame
 input stays CDP-**trusted**.
 
-### `debugger` — screenshots + TOP-frame trusted input
+**Exception — `eval --frame` uses CDP, not `scripting`.** `chrome.scripting` runs a
+serialized FUNCTION; the fixed-func frame ops (`text`/`html`/`click`/`type`/`key`) work
+that way, but `eval` is an arbitrary JS STRING, and `new Function(src)`-ing it inside
+the frame's isolated world hits the extension CSP / returns `value:null`-as-success — it
+never truly evaluates. So `eval --frame` runs via CDP `Runtime.evaluate` in the frame's
+execution context (same-process → `Page.createIsolatedWorld`; cross-origin OOPIF →
+`Target.setAutoAttach({flatten:true})` flat session, matched by URL), returning the real
+value and surfacing exceptions as `frame_eval_failed` — never a silent null. See the
+`debugger` section below.
+
+### `debugger` — screenshots + `eval --frame` + TOP-frame trusted input
 
 `chrome.debugger` is the biggest-blast-radius permission, so the CDP layer is
-tightly bounded (all decision logic is pure + unit-tested in `protocol.js`). It is now
-used ONLY for `screenshot` (works on a background/occluded tab) and TOP-frame trusted
-`click`/`type`/`key` (no `--frame`):
+tightly bounded (all decision logic is pure + unit-tested in `protocol.js`). It is used
+for `screenshot` (works on a background/occluded tab), **`eval --frame`** (run a JS
+string in a specific same-process or cross-origin OOPIF frame — see the exception
+above), and TOP-frame trusted `click`/`type`/`key` (no `--frame`):
 
 - **Own-tab attach ONLY.** A CDP op attaches `chrome.debugger` ONLY to the
   server-injected owned/`--tab` tab, and **refuses to attach to a privileged
@@ -173,9 +184,11 @@ used ONLY for `screenshot` (works on a background/occluded tab) and TOP-frame tr
 - **Typed commands only.** The SW maps each bounded op to a FIXED set of CDP methods;
   there is NO generic "run this CDP method" endpoint reachable by a caller/model.
 - **Banner tradeoff:** Brave shows "an extension is debugging this browser" while a
-  CDP op runs. Attach is per-op to keep that window tiny; `text`/`html`/`eval`
-  (top-frame AND `--frame`), `frames`, `--frame` input, and foreground-`screenshot`
-  all take the non-CDP path (no banner).
+  CDP op runs. Attach is per-op to keep that window tiny; `text`/`html` (top-frame AND
+  `--frame`), top-frame `eval`, `frames`, `--frame` input, and foreground-`screenshot`
+  all take the non-CDP path (no banner). `eval --frame` DOES attach (it needs
+  `Runtime.evaluate` to reach the frame), so it briefly shows the banner — bounded by
+  the per-op CDP timeouts and always-detach, like the other CDP ops.
 
 ## Stable extension ID (optional)
 
@@ -245,6 +258,15 @@ The chrome.* glue needs a real browser — verify by hand after loading:
       cross-origin `model-benchmarking.civit.ai` frame (the whole point — CDP
       getFrameTree missed it); `browser --tab <id> --frame <numericId-or-url> text`
       returns THAT frame's innerText (plain `text` shows only the top frame).
+- [ ] **`eval --frame` actually evaluates INSIDE the frame (the #190 fix):** on the same
+      OOPIF page, `browser --tab <id> frames` → note the cross-origin frame's numeric id.
+      `browser --tab <id> --frame <oopif-id> eval 'location.href'` returns
+      `https://model-benchmarking.civit.ai/...` (PROOF eval ran inside the OOPIF) — NOT
+      `value:null`. `--frame 0 eval 'location.href'` returns the TOP url. A bad frame
+      (`--frame nope eval '1'`) returns a clear `frame_not_found` error, and a throwing
+      expression (`--frame <id> eval 'x.y.z'`) returns `frame_eval_failed:<reason>` —
+      neither is a silent null. No instance wedge afterward (`browser health` still OK).
+      (A brief debugger banner flashes for `eval --frame` — it's a CDP op now.)
 - [ ] **Drive an in-app control INSIDE the cross-origin iframe:** `browser --tab <id>
       --frame <f> click "<selector>"` reaches a control inside the OOPIF; `--frame <f>
       type`/`--frame <f> key Enter` fill + submit. Input is SYNTHETIC in-frame

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -458,7 +458,10 @@ export function promiseWithTimeout(promise, ms, label, timers = {}) {
 //   run(send):Promise<result>, timeouts?:{attachMs,commandMs,budgetMs}, timers? }.
 // `send` is OPTIONAL: when present, `run` is handed a timeout-WRAPPED send so each
 // CDP command is individually bounded; when absent, `run` receives undefined
-// (back-compat with call sites that don't issue commands).
+// (back-compat with call sites that don't issue commands). The wrapped send takes an
+// OPTIONAL 3rd arg `sessionId` — forwarded to the raw send so a command can target a
+// flat auto-attached sub-session (an OOPIF target) while STILL being bounded by the
+// per-command timeout; call sites that don't use flat sessions simply omit it.
 export async function withCdpSession(deps) {
   assertCdpAttachable(deps.url);        // BEFORE attach — refuse privileged/other tab
   const timers = deps.timers || {};
@@ -484,7 +487,8 @@ export async function withCdpSession(deps) {
   try {
     const rawSend = deps.send;
     const send = rawSend
-      ? (method, params) => promiseWithTimeout(rawSend(method, params), commandMs, method, timers)
+      ? (method, params, sessionId) =>
+          promiseWithTimeout(rawSend(method, params, sessionId), commandMs, method, timers)
       : undefined;
     return await promiseWithTimeout(
       Promise.resolve(deps.run(send)), budgetMs, "op", timers);
@@ -613,6 +617,77 @@ export function cdpExceptionText(exceptionDetails) {
   return String(ex.description || exceptionDetails.text || "eval_failed");
 }
 
+// --- CDP `eval --frame`: run an arbitrary JS STRING in a target frame ---------- //
+// WHY the CDP path (not chrome.scripting) for `eval --frame`: chrome.scripting.
+// executeScript runs a SERIALIZED FUNCTION, not an arbitrary JS string. The fixed-func
+// frame ops (text/html/click/type/key) work that way, but `eval` is an arbitrary user
+// STRING — routing it through a `func` that `new Function(src)`s inside the frame's
+// ISOLATED world hits the extension CSP / returns a null-as-success, so it never truly
+// evaluates (the #190 regression). The reliable way to run a JS STRING in a SPECIFIC
+// frame — including a cross-origin OOPIF (a separate renderer/target under site
+// isolation) — is CDP `Runtime.evaluate` in that frame's execution context.
+//
+// The numeric webNavigation frameId does NOT map 1:1 to a CDP frame id/target, so we
+// locate the target frame by URL (resolveWebNavFrame gives the frame's url). Two paths:
+//   * SAME-PROCESS frame → it appears in the top session's Page.getFrameTree; grab its
+//     CDP frameId (matchCdpFrameId), Page.createIsolatedWorld → an executionContextId,
+//     Runtime.evaluate({contextId}).
+//   * CROSS-ORIGIN OOPIF → it is NOT in the top session's frame tree (getFrameTree from
+//     the top target omits OOPIFs — the same reason #190 moved enumeration to
+//     webNavigation). Target.setAutoAttach({autoAttach,flatten}) auto-attaches to the
+//     OOPIF's target, surfacing a flat sessionId (pickOopifSessionId matches it by url);
+//     Runtime.evaluate is then issued in THAT session's default context.
+// The SW glue (service_worker.js) supplies the chrome.debugger side effects; ALL of it
+// is time-bounded by withCdpSession (#189) so a bad frame fails fast, never wedges.
+
+// Match a target frame URL against a CDP Page.getFrameTree result, returning the CDP
+// (string) frameId of the SAME-PROCESS frame whose url equals `targetUrl`, else null
+// (→ the frame is an OOPIF in a separate target, take the auto-attach path). Exact url
+// equality (getFrameTree urls mirror webNavigation urls for same-process frames); the
+// main frame (frameId 0 / the top url) matches its root node. Pure.
+export function matchCdpFrameId(frameTree, targetUrl) {
+  const want = String(targetUrl == null ? "" : targetUrl);
+  if (!want) return null;
+  for (const f of flattenFrameTree(frameTree)) {
+    if (f.url === want) return f.frameId;
+  }
+  return null;
+}
+
+// Pick the flat sessionId of the auto-attached OOPIF target whose url matches
+// `targetUrl`. `attached` is the list of {sessionId,url} the SW collected from
+// Target.attachedToTarget events after Target.setAutoAttach. Exact url match first,
+// then a suffix/prefix-tolerant fallback (an OOPIF target url can carry a trailing
+// slash the frame url lacks, or vice-versa). Returns null when none matches (→
+// frame_not_found). Pure.
+export function pickOopifSessionId(attached, targetUrl) {
+  const want = String(targetUrl == null ? "" : targetUrl);
+  if (!want) return null;
+  for (const a of attached || []) if (a && a.url === want) return a.sessionId;
+  // Tolerant fallback: ignore a single trailing slash difference.
+  const norm = (u) => String(u || "").replace(/\/+$/, "");
+  const w = norm(want);
+  for (const a of attached || []) if (a && norm(a.url) === w) return a.sessionId;
+  return null;
+}
+
+// Interpret a CDP Runtime.evaluate result under the NEVER-SILENT-NULL contract:
+//   * an exceptionDetails (a thrown error / CSP violation) → THROW
+//     `frame_eval_failed:<reason>` — a failure to execute must be a CLEAR op error,
+//     never a value:null masquerading as success (the exact #190 bug).
+//   * otherwise return the result's value verbatim — a genuine null/undefined result
+//     IS a legitimate value and is returned AS such (distinct from a failure). When
+//     returnByValue was set, `result.value` is the structured value; a bare handle
+//     (no value key) → undefined.
+// Pure — the SW passes the raw Runtime.evaluate reply.
+export function evalValueOrThrow(cdpResult) {
+  const r = cdpResult || {};
+  if (r.exceptionDetails) {
+    throw new Error(`frame_eval_failed:${cdpExceptionText(r.exceptionDetails)}`);
+  }
+  return r.result ? r.result.value : undefined;
+}
+
 // Frame-scoped read/probe expression builders (run in the frame's isolated world
 // via CDP Runtime.evaluate). Pure string builders so the SW stays thin + testable.
 export function frameHtmlExpression() {
@@ -678,26 +753,38 @@ export function normalizeWebNavFrames(frames) {
 }
 
 // Resolve a caller `--frame <sel>` against a normalized getAllFrames list, returning
-// the NUMERIC frameId to inject into. `sel` may be an exact numeric frameId (e.g. "0"
-// or 5 — the webNavigation id) OR a URL substring (case-insensitive). An exact
-// frameId match WINS over a substring; among substring matches the FIRST (list order)
-// wins deterministically. Throws `frame_not_found:<sel>` when nothing matches and
-// `frame_not_specified` for an empty sel (a caller bug — the SW only calls this when
-// a frame IS targeted). Tab-scoped by construction: `frames` comes from ONE tab's
-// getAllFrames, so a resolved frameId can only ever reference a frame of THAT tab —
-// a frameId belonging to another tab is simply absent → frame_not_found. Pure.
-export function resolveWebNavFrameId(frames, sel) {
+// the matched FRAME OBJECT ({frameId,url,parentFrameId}). `sel` may be an exact
+// numeric frameId (e.g. "0" or 5 — the webNavigation id) OR a URL substring
+// (case-insensitive). An exact frameId match WINS over a substring; among substring
+// matches the FIRST (list order) wins deterministically. Throws `frame_not_found:<sel>`
+// when nothing matches and `frame_not_specified` for an empty sel (a caller bug — the
+// SW only calls this when a frame IS targeted). Tab-scoped by construction: `frames`
+// comes from ONE tab's getAllFrames, so a resolved frame can only ever reference a
+// frame of THAT tab — a frameId belonging to another tab is simply absent →
+// frame_not_found. Returning the OBJECT (not just the id) lets the SW both inject by
+// frameId AND report the FRAME'S OWN url in the op result (so a caller can confirm it
+// read the intended frame, not the top document), and — for `eval --frame` — map the
+// numeric webNavigation frameId to the frame's URL so the CDP path can locate its
+// execution context (see cdp_protocol: matchCdpFrameId / pickOopifSessionId). Pure.
+export function resolveWebNavFrame(frames, sel) {
   const s = String(sel == null ? "" : sel).trim();
   if (!s) throw new Error("frame_not_specified");
   if (/^\d+$/.test(s)) {
     const n = Number(s);
-    for (const f of frames || []) if (f.frameId === n) return n;
+    for (const f of frames || []) if (f.frameId === n) return f;
   }
   const low = s.toLowerCase();
   for (const f of frames || []) {
-    if ((f.url || "").toLowerCase().includes(low)) return f.frameId;
+    if ((f.url || "").toLowerCase().includes(low)) return f;
   }
   throw new Error(`frame_not_found:${s}`);
+}
+
+// Back-compat convenience: resolve `--frame <sel>` to just the NUMERIC frameId (the
+// fixed-func frame ops inject by id). Delegates to resolveWebNavFrame so the two can
+// never diverge. Pure.
+export function resolveWebNavFrameId(frames, sel) {
+  return resolveWebNavFrame(frames, sel).frameId;
 }
 
 // --- injected page functions (run INSIDE the resolved frame via executeScript) --- //

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -28,9 +28,13 @@ import {
   clickPoint, cdpExceptionText, elementRectExpression, focusExpression, fullPageClip,
   // OOPIF-capable frame enumeration/injection (chrome.webNavigation + chrome.scripting):
   // reaches cross-origin out-of-process iframes where CDP getFrameTree could not.
-  normalizeWebNavFrames, resolveWebNavFrameId,
-  frameReadHtmlFn, frameReadTextFn, frameEvalFn,
+  normalizeWebNavFrames, resolveWebNavFrame,
+  frameReadHtmlFn, frameReadTextFn,
   frameClickFn, frameTypeFn, frameKeyFn,
+  // CDP `eval --frame`: run an arbitrary JS STRING in the target frame's execution
+  // context (chrome.scripting can only run a serialized FUNC — the #190 null bug).
+  frameEvalExpressions, isCdpSyntaxError, matchCdpFrameId, pickOopifSessionId,
+  evalValueOrThrow,
 } from "./protocol.js";
 
 const DEFAULT_PORT = 8788;
@@ -108,10 +112,17 @@ function sendCdp(target, method, params) {
 // Attach chrome.debugger to `tabId`, run `run(send)`, and ALWAYS detach. `url` is
 // the target tab's URL, validated BEFORE attach by withCdpSession (a privileged /
 // other-surface tab is refused, never attached — the STRICT attach-scope invariant).
+// The `send` handed to `run` takes an optional 3rd arg `sessionId` so a command can
+// target a flat auto-attached sub-session (an OOPIF target) — still bounded by the
+// #189 per-command timeout. `globalThis.BROWSER_BRIDGE_CDP_TIMEOUTS` is a TEST-ONLY
+// hook to shrink the (8s) budgets so a no-wedge test settles in ms; undefined in
+// production → the real CDP_* budgets.
 async function withCdp(tabId, url, run) {
   const target = { tabId };
   return withCdpSession({
     url,
+    timeouts: (typeof globalThis !== "undefined" && globalThis.BROWSER_BRIDGE_CDP_TIMEOUTS)
+      || undefined,
     attach: async () => {
       // Fail fast on a discarded/unloaded tab (no live renderer → attach would
       // hang forever). withCdpSession's per-call timeouts are the backstop for any
@@ -128,8 +139,11 @@ async function withCdp(tabId, url, run) {
       await chrome.debugger.detach(target);
     },
     // Raw send — withCdpSession wraps it in the per-command timeout before handing
-    // it to `run`, so a single hung CDP command can't wedge the SW.
-    send: (method, params) => sendCdp(target, method, params),
+    // it to `run`, so a single hung CDP command can't wedge the SW. A non-null
+    // `sessionId` targets a flat auto-attached OOPIF sub-session (Debuggee
+    // {tabId, sessionId}); omitted → the tab's top session.
+    send: (method, params, sessionId) =>
+      sendCdp(sessionId != null ? { ...target, sessionId } : target, method, params),
     run: (send) => run(send),
   });
 }
@@ -153,11 +167,14 @@ async function framesForTab(tabId) {
   return normalizeWebNavFrames(raw || []);
 }
 
-// Resolve a caller `--frame <sel>` to a NUMERIC webNavigation frameId within `tabId`.
-// Throws frame_not_found / frame_not_specified. Confined to this tab by construction.
-async function resolveFrameId(tabId, frameSel) {
+// Resolve a caller `--frame <sel>` to the FRAME OBJECT ({frameId,url,parentFrameId})
+// within `tabId`. Throws frame_not_found / frame_not_specified. Confined to this tab by
+// construction (framesForTab is tab-scoped). Callers use `.frameId` to inject and
+// `.url` both to report the frame's own url AND (for eval) to locate the frame's CDP
+// execution context by URL.
+async function resolveFrame(tabId, frameSel) {
   const frames = await framesForTab(tabId);
-  return resolveWebNavFrameId(frames, frameSel);
+  return resolveWebNavFrame(frames, frameSel);
 }
 
 // Inject `func(...args)` INTO one resolved frame (by numeric frameId) of `tabId` via
@@ -175,6 +192,70 @@ async function execInFrame(tabId, frameId, func, args) {
   return inj ? inj.result : undefined;
 }
 
+// Evaluate an arbitrary JS STRING inside one resolved frame of `tabId` via CDP
+// Runtime.evaluate — the RELIABLE path for `eval --frame` (chrome.scripting can only
+// run a serialized FUNC, so it can't evaluate a user string: the #190 null-as-success
+// bug). Works for a SAME-PROCESS frame AND a cross-origin OOPIF (a separate target):
+//   1. attach chrome.debugger to the OWNED tab (withCdp → #187 own-tab-only scope +
+//      #189 bounded timeouts + discarded-tab fail-fast);
+//   2. SAME-PROCESS: the frame is in the top session's Page.getFrameTree → its CDP
+//      frameId → Page.createIsolatedWorld → an executionContextId → Runtime.evaluate;
+//   3. OOPIF: NOT in the top frame tree → Target.setAutoAttach({autoAttach,flatten})
+//      auto-attaches the OOPIF's target (flat sessionId, matched by url) → Runtime.
+//      evaluate in that session's default context.
+// NEVER SILENT-NULL: a genuine null/undefined result is returned AS a value, but a
+// FAILURE to execute (frame not resolvable / exceptionDetails) is a CLEAR op error
+// (frame_not_found / frame_eval_failed:<reason>) via evalValueOrThrow. `frame` is the
+// resolved {frameId,url} object; matching is by `frame.url` (the numeric webNavigation
+// frameId does not map 1:1 to a CDP frame/target).
+async function cdpFrameEval(tabId, tabUrl, frame, src) {
+  const { expression, fallback } = frameEvalExpressions(src);
+  return withCdp(tabId, tabUrl, async (send) => {
+    // Try `expression` (expression form); on a CDP SyntaxError retry `fallback` (the
+    // statement form). One evaluate per form → a side effect never double-runs.
+    const evaluate = async (sessionId, contextId) => {
+      const params = { expression, returnByValue: true, awaitPromise: true };
+      if (contextId != null) params.contextId = contextId;
+      let res = await send("Runtime.evaluate", params, sessionId);
+      if (res && res.exceptionDetails && isCdpSyntaxError(res.exceptionDetails)) {
+        const p2 = { expression: fallback, returnByValue: true, awaitPromise: true };
+        if (contextId != null) p2.contextId = contextId;
+        res = await send("Runtime.evaluate", p2, sessionId);
+      }
+      return evalValueOrThrow(res);   // throws frame_eval_failed:<reason> on exception
+    };
+
+    // (2) SAME-PROCESS frame — locate it in the top session's frame tree by url.
+    const { frameTree } = await send("Page.getFrameTree");
+    const cdpFrameId = matchCdpFrameId(frameTree, frame.url);
+    if (cdpFrameId) {
+      const iso = await send("Page.createIsolatedWorld",
+        { frameId: cdpFrameId, worldName: "browser-bridge-eval", grantUniveralAccess: false });
+      return evaluate(undefined, iso.executionContextId);
+    }
+
+    // (3) CROSS-ORIGIN OOPIF — auto-attach flat, match the target session by url,
+    // evaluate in THAT session. Collect Target.attachedToTarget events for the duration
+    // of this op only (listener removed in finally), then match by frame url.
+    const attached = [];
+    const onEvt = (_source, method, params) => {
+      if (method === "Target.attachedToTarget" && params && params.targetInfo) {
+        attached.push({ sessionId: params.sessionId, url: params.targetInfo.url });
+      }
+    };
+    chrome.debugger.onEvent.addListener(onEvt);
+    try {
+      await send("Target.setAutoAttach",
+        { autoAttach: true, flatten: true, waitForDebuggerOnStart: false });
+      const sessionId = pickOopifSessionId(attached, frame.url);
+      if (!sessionId) throw new Error(`frame_not_found:${frame.url || frame.frameId}`);
+      return await evaluate(sessionId, undefined);
+    } finally {
+      chrome.debugger.onEvent.removeListener(onEvt);
+    }
+  });
+}
+
 // --- op executors ---------------------------------------------------------- //
 // Each returns the op-specific `data` object; throws on failure (→ errorEnvelope).
 const OPS = {
@@ -183,9 +264,11 @@ const OPS = {
     // --frame → read the outerHTML INSIDE the chosen (cross-origin OOPIF) frame via
     // chrome.scripting (reaches an out-of-process iframe; no debugger banner).
     if (cmd && cmd.frame) {
-      const frameId = await resolveFrameId(tab.id, cmd.frame);
-      const html = await execInFrame(tab.id, frameId, frameReadHtmlFn, []);
-      return { url: tab.url, title: tab.title, html, frame: cmd.frame };
+      const frame = await resolveFrame(tab.id, cmd.frame);
+      const html = await execInFrame(tab.id, frame.frameId, frameReadHtmlFn, []);
+      // Report the FRAME's own url (not the top tab url) so the caller can confirm it
+      // read the intended frame (#190 reported the top url for a frame read).
+      return { url: frame.url || tab.url, title: tab.title, html, frame: cmd.frame };
     }
     // No frame → the lighter chrome.scripting top-frame read (no debugger banner).
     const [inj] = await chrome.scripting.executeScript({
@@ -208,10 +291,11 @@ const OPS = {
     // --frame → read innerText INSIDE the chosen (cross-origin OOPIF) frame via
     // chrome.scripting (reaches an out-of-process iframe; no debugger banner).
     if (cmd && cmd.frame) {
-      const frameId = await resolveFrameId(tab.id, cmd.frame);
-      const raw = await execInFrame(tab.id, frameId, frameReadTextFn, [sel]);
+      const frame = await resolveFrame(tab.id, cmd.frame);
+      const raw = await execInFrame(tab.id, frame.frameId, frameReadTextFn, [sel]);
       const { text, truncated } = normalizeText(raw, cap);
-      return { url: tab.url, title: tab.title, text, truncated, frame: cmd.frame };
+      // Report the FRAME's own url (see getHtml) so the caller confirms the right frame.
+      return { url: frame.url || tab.url, title: tab.title, text, truncated, frame: cmd.frame };
     }
     const [inj] = await chrome.scripting.executeScript({
       target: { tabId: tab.id },
@@ -227,13 +311,16 @@ const OPS = {
 
   async eval(cmd) {
     const tab = await targetTab(cmd);
-    // --frame → evaluate INSIDE the chosen (cross-origin OOPIF) frame via
-    // chrome.scripting. Runs in the frame's ISOLATED world (DOM-capable; no access to
-    // that frame's page globals — documented, matches the prior CDP semantics).
+    // --frame → evaluate the arbitrary JS STRING INSIDE the chosen frame (incl. a
+    // cross-origin OOPIF) via CDP Runtime.evaluate. chrome.scripting can only run a
+    // serialized FUNC (not a string), so the #190 chrome.scripting path executed
+    // nothing meaningful and returned value:null-as-success — the bug this fixes.
+    // cdpFrameEval resolves the frame's execution context (same-process isolated world
+    // OR OOPIF flat session) and NEVER silent-nulls (frame_not_found / frame_eval_failed).
     if (cmd && cmd.frame) {
-      const frameId = await resolveFrameId(tab.id, cmd.frame);
-      const value = await execInFrame(tab.id, frameId, frameEvalFn, [cmd.js]);
-      return { url: tab.url, value, frame: cmd.frame };
+      const frame = await resolveFrame(tab.id, cmd.frame);
+      const value = await cdpFrameEval(tab.id, tab.url, frame, cmd.js);
+      return { url: frame.url || tab.url, value, frame: cmd.frame };
     }
     // chrome.scripting runs in an ISOLATED world; `js` is evaluated and its
     // completion value returned. Wrapped so a bare expression or a statement
@@ -338,10 +425,10 @@ const OPS = {
     const tab = await targetTab(cmd);
     const selector = String(cmd.selector);
     if (cmd.frame) {
-      const frameId = await resolveFrameId(tab.id, cmd.frame);
-      const res = await execInFrame(tab.id, frameId, frameClickFn, [selector]);
+      const frame = await resolveFrame(tab.id, cmd.frame);
+      const res = await execInFrame(tab.id, frame.frameId, frameClickFn, [selector]);
       if (!res || res.ok === false) throw new Error(`element_not_found:${selector}`);
-      return { url: tab.url, clicked: selector, x: res.x, y: res.y,
+      return { url: frame.url || tab.url, clicked: selector, x: res.x, y: res.y,
                frame: cmd.frame, trusted: false };
     }
     const point = await withCdp(tab.id, tab.url, async (send) => {
@@ -367,11 +454,11 @@ const OPS = {
     const tab = await targetTab(cmd);
     const text = String(cmd.text);
     if (cmd.frame) {
-      const frameId = await resolveFrameId(tab.id, cmd.frame);
-      const res = await execInFrame(tab.id, frameId, frameTypeFn,
+      const frame = await resolveFrame(tab.id, cmd.frame);
+      const res = await execInFrame(tab.id, frame.frameId, frameTypeFn,
         [cmd.selector || "", text]);
       if (!res || res.ok === false) throw new Error(`element_not_found:${cmd.selector}`);
-      return { url: tab.url, typed: text.length, frame: cmd.frame, trusted: false };
+      return { url: frame.url || tab.url, typed: text.length, frame: cmd.frame, trusted: false };
     }
     await withCdp(tab.id, tab.url, async (send) => {
       if (cmd.selector) {
@@ -393,10 +480,10 @@ const OPS = {
     const tab = await targetTab(cmd);
     const p = keyEventParams(cmd.key);   // throws unknown_key (no injection/attach on refusal)
     if (cmd.frame) {
-      const frameId = await resolveFrameId(tab.id, cmd.frame);
-      const res = await execInFrame(tab.id, frameId, frameKeyFn, [cmd.selector || "", p]);
+      const frame = await resolveFrame(tab.id, cmd.frame);
+      const res = await execInFrame(tab.id, frame.frameId, frameKeyFn, [cmd.selector || "", p]);
       if (!res || res.ok === false) throw new Error(`element_not_found:${cmd.selector}`);
-      return { url: tab.url, key: p.key, frame: cmd.frame, trusted: false };
+      return { url: frame.url || tab.url, key: p.key, frame: cmd.frame, trusted: false };
     }
     await withCdp(tab.id, tab.url, async (send) => {
       if (cmd.selector) {

--- a/scripts/browser-bridge/tests/cdp_protocol.test.mjs
+++ b/scripts/browser-bridge/tests/cdp_protocol.test.mjs
@@ -16,6 +16,7 @@ import {
   elementRectExpression, focusExpression, fullPageClip,
   promiseWithTimeout, assertTabCdpReady, TAB_DISCARDED_MESSAGE,
   CDP_ATTACH_TIMEOUT_MS, CDP_COMMAND_TIMEOUT_MS, CDP_OP_BUDGET_MS,
+  matchCdpFrameId, pickOopifSessionId, evalValueOrThrow,
 } from "../extension/protocol.js";
 
 // A promise that NEVER settles — models a hung chrome.debugger call (the wedge).
@@ -342,4 +343,60 @@ test("withCdpSession still enforces security: a privileged url is REFUSED before
     detach: async () => {}, send: async () => ({}), run: (s) => s("Page.enable"),
   }), /cdp_attach_refused/);
   assert.equal(attached, false, "the timeout wiring must not weaken the attach-scope invariant");
+});
+
+// --- CDP `eval --frame` frame-context resolution (the #190 null fix) --------- //
+// The decision layer for running an arbitrary JS STRING in a target frame via CDP
+// Runtime.evaluate: locate a SAME-PROCESS frame in the top session's frame tree by url,
+// or an OOPIF flat session by url, and interpret the evaluate reply under the
+// never-silent-null contract. All pure — the SW supplies the chrome.debugger effects.
+
+test("matchCdpFrameId: finds a SAME-PROCESS frame's CDP id by url; an OOPIF (absent) → null", () => {
+  const tree = {
+    frame: { id: "MAIN", url: "https://civitai.com/apps/run/model-benchmarking", name: "" },
+    childFrames: [
+      { frame: { id: "SAME1", url: "https://civitai.com/embed/widget", name: "w" } },
+    ],
+  };
+  // top frame (frameId 0 maps to the top url) → the main CDP frame id.
+  assert.equal(matchCdpFrameId(tree, "https://civitai.com/apps/run/model-benchmarking"), "MAIN");
+  // a same-process child by exact url.
+  assert.equal(matchCdpFrameId(tree, "https://civitai.com/embed/widget"), "SAME1");
+  // the cross-origin OOPIF is NOT in the top session's frame tree → null (take the
+  // auto-attach path). This is the whole reason getFrameTree can't reach it.
+  assert.equal(matchCdpFrameId(tree, "https://model-benchmarking.civit.ai/"), null);
+  assert.equal(matchCdpFrameId(tree, ""), null);
+  assert.equal(matchCdpFrameId(null, "https://x/"), null);
+});
+
+test("pickOopifSessionId: matches the auto-attached OOPIF target session by url (trailing-slash tolerant)", () => {
+  const attached = [
+    { sessionId: "S_ad", url: "https://ads.example/pixel" },
+    { sessionId: "S_bench", url: "https://model-benchmarking.civit.ai/" },
+  ];
+  assert.equal(pickOopifSessionId(attached, "https://model-benchmarking.civit.ai/"), "S_bench");
+  // frame url without the trailing slash still matches the target url that has one.
+  assert.equal(pickOopifSessionId(attached, "https://model-benchmarking.civit.ai"), "S_bench");
+  assert.equal(pickOopifSessionId(attached, "https://ads.example/pixel"), "S_ad");
+  assert.equal(pickOopifSessionId(attached, "https://not-attached/"), null);
+  assert.equal(pickOopifSessionId([], "https://x/"), null);
+  assert.equal(pickOopifSessionId(null, "https://x/"), null);
+});
+
+test("evalValueOrThrow: NEVER-SILENT-NULL — exception → frame_eval_failed; real null/undefined pass AS values", () => {
+  // A real value passes through.
+  assert.equal(evalValueOrThrow({ result: { value: 1234 } }), 1234);
+  assert.equal(evalValueOrThrow({ result: { value: "https://model-benchmarking.civit.ai/" } }),
+    "https://model-benchmarking.civit.ai/");
+  // A GENUINE null/undefined result is a legitimate value (distinct from a failure).
+  assert.equal(evalValueOrThrow({ result: { value: null } }), null);
+  assert.equal(evalValueOrThrow({ result: { value: undefined } }), undefined);
+  assert.equal(evalValueOrThrow({}), undefined);                 // bare handle → undefined
+  // An exceptionDetails is a FAILURE TO EXECUTE → a clear op error, NOT value:null.
+  assert.throws(() => evalValueOrThrow({
+    result: { type: "object" },
+    exceptionDetails: { exception: { description: "TypeError: x is not a function" } },
+  }), /frame_eval_failed:TypeError: x is not a function/);
+  assert.throws(() => evalValueOrThrow({ exceptionDetails: { text: "Uncaught" } }),
+    /frame_eval_failed:Uncaught/);
 });

--- a/scripts/browser-bridge/tests/frame_eval_cdp.test.mjs
+++ b/scripts/browser-bridge/tests/frame_eval_cdp.test.mjs
@@ -1,0 +1,227 @@
+// Glue tests for `eval --frame` against a MOCKED chrome — proving the #190 fix is wired
+// correctly WITHOUT a real Brave. The bug: `eval --frame` was routed through
+// chrome.scripting.executeScript, which runs a serialized FUNC, not an arbitrary JS
+// STRING → it evaluated nothing meaningful and returned value:null-as-success. The fix
+// routes `eval --frame` through CDP Runtime.evaluate in the target frame's execution
+// context (same-process isolated world OR cross-origin OOPIF flat session).
+//
+// These assert, against a mock chrome.debugger/webNavigation:
+//   * the CDP path is TAKEN (chrome.debugger.attach), NOT chrome.scripting;
+//   * SAME-PROCESS frame: Page.getFrameTree → Page.createIsolatedWorld →
+//     Runtime.evaluate(contextId) returns the eval VALUE (NOT null — the regression);
+//   * cross-origin OOPIF: Target.setAutoAttach flat → the target session matched by url
+//     → Runtime.evaluate(sessionId) returns the value (OOPIF context resolution path);
+//   * NEVER-SILENT-NULL: an exceptionDetails → frame_eval_failed; an unresolvable OOPIF
+//     → frame_not_found (never value:null);
+//   * a SyntaxError on the expression form retries the statement form (once);
+//   * #189 timeouts still bound the CDP eval path: a hung Runtime.evaluate settles with
+//     cdp_timeout and STILL detaches — no SW wedge;
+//   * security/telemetry: own-tab attach, typed op only, no eval source echoed.
+//
+// SW auto-start is suppressed (BROWSER_BRIDGE_NO_AUTOSTART) so importing does no I/O.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const TAB_ID = 5;
+const TOP_URL = "https://civitai.com/apps/run/model-benchmarking";
+const OOPIF_URL = "https://model-benchmarking.civit.ai/";
+
+// A same-process frame tree from the TOP session's Page.getFrameTree: the top frame +
+// a same-process child. The cross-origin OOPIF is DELIBERATELY ABSENT (getFrameTree
+// from the top target omits OOPIFs — the reason the auto-attach path exists).
+const FRAME_TREE = {
+  frame: { id: "CDP_MAIN", url: TOP_URL, name: "" },
+  childFrames: [{ frame: { id: "CDP_SAME", url: "https://civitai.com/embed/w", name: "w" } }],
+};
+
+const state = {
+  frames: [
+    { frameId: 0, parentFrameId: -1, url: TOP_URL },
+    { frameId: 7, parentFrameId: 0, url: OOPIF_URL },
+  ],
+  tab: { id: TAB_ID, url: TOP_URL, title: "Bench", active: false, status: "complete", windowId: 1 },
+  // The reply(ies) the mock returns for Runtime.evaluate, in order (falls back to the
+  // single `evalReply` when the queue is empty).
+  evalReplies: [],
+  evalReply: { result: { value: null } },
+  // Auto-attach targets the mock announces when Target.setAutoAttach is called.
+  autoAttachTargets: [{ sessionId: "SID_OOPIF", url: OOPIF_URL }],
+  hangEvaluate: false,   // make Runtime.evaluate never resolve (timeout test)
+  calls: { cdp: [], executeScript: [], attach: [], detach: [], getAllFrames: [] },
+};
+function reset() {
+  state.calls = { cdp: [], executeScript: [], attach: [], detach: [], getAllFrames: [] };
+  state.evalReplies = [];
+  state.evalReply = { result: { value: null } };
+  state.autoAttachTargets = [{ sessionId: "SID_OOPIF", url: OOPIF_URL }];
+  state.hangEvaluate = false;
+  delete globalThis.BROWSER_BRIDGE_CDP_TIMEOUTS;
+}
+
+const evtListeners = new Set();
+
+globalThis.BROWSER_BRIDGE_NO_AUTOSTART = true;
+globalThis.chrome = {
+  webNavigation: {
+    async getAllFrames({ tabId }) { state.calls.getAllFrames.push(tabId); return state.frames; },
+  },
+  scripting: {
+    async executeScript(params) { state.calls.executeScript.push(params); return [{ result: null }]; },
+  },
+  tabs: {
+    async get(id) { return { ...state.tab, id }; },
+    async query() { return [state.tab]; },
+    async update() {},
+  },
+  debugger: {
+    async attach(target) { state.calls.attach.push(target); },
+    async detach(target) { state.calls.detach.push(target); },
+    async sendCommand(target, method, params) {
+      state.calls.cdp.push({ method, sessionId: target.sessionId, params });
+      if (method === "Page.getFrameTree") return { frameTree: FRAME_TREE };
+      if (method === "Page.createIsolatedWorld") return { executionContextId: 99 };
+      if (method === "Target.setAutoAttach") {
+        // Announce the auto-attached OOPIF target(s) to every onEvent listener, exactly
+        // as Chrome fires Target.attachedToTarget for existing OOPIFs on setAutoAttach.
+        for (const t of state.autoAttachTargets) {
+          for (const fn of evtListeners) {
+            fn(target, "Target.attachedToTarget",
+              { sessionId: t.sessionId, targetInfo: { url: t.url, type: "iframe", targetId: "T_" + t.sessionId } });
+          }
+        }
+        return {};
+      }
+      if (method === "Runtime.evaluate") {
+        if (state.hangEvaluate) return new Promise(() => {});   // never settles → timeout
+        return state.evalReplies.length ? state.evalReplies.shift() : state.evalReply;
+      }
+      return {};
+    },
+    onDetach: { addListener() {} },
+    onEvent: {
+      addListener(fn) { evtListeners.add(fn); },
+      removeListener(fn) { evtListeners.delete(fn); },
+    },
+  },
+  storage: { local: { async get() { return {}; }, async set() {} } },
+  runtime: { onInstalled: { addListener() {} }, onStartup: { addListener() {} } },
+  alarms: { create() {}, onAlarm: { addListener() {} } },
+};
+
+const { OPS } = await import("../extension/service_worker.js");
+
+const cdpMethods = () => state.calls.cdp.map((c) => c.method);
+const lastEval = () => [...state.calls.cdp].reverse().find((c) => c.method === "Runtime.evaluate");
+
+// --------------------------------------------------------------------------- //
+test("eval --frame 0 (SAME-PROCESS/top): CDP Runtime.evaluate returns the VALUE, not null", async () => {
+  reset();
+  state.evalReply = { result: { value: TOP_URL } };   // e.g. location.href in the top frame
+  const out = await OPS.eval({ tabId: TAB_ID, frame: "0", js: "location.href" });
+  // The CDP path was taken — attach happened, chrome.scripting did NOT.
+  assert.equal(state.calls.attach.length, 1, "eval --frame must attach chrome.debugger (CDP path)");
+  assert.equal(state.calls.executeScript.length, 0, "eval --frame must NOT use chrome.scripting");
+  // Same-process → frame tree lookup + isolated world + evaluate(contextId).
+  assert.ok(cdpMethods().includes("Page.getFrameTree"));
+  assert.ok(cdpMethods().includes("Page.createIsolatedWorld"));
+  assert.equal(lastEval().params.contextId, 99, "evaluated in the frame's isolated-world context");
+  assert.equal(lastEval().params.returnByValue, true);
+  assert.ok(String(lastEval().params.expression).includes("location.href"));
+  // THE REGRESSION: the value is the eval result, NOT null.
+  assert.equal(out.value, TOP_URL);
+  assert.equal(out.frame, "0");
+  assert.equal(out.url, TOP_URL, "reports the frame's own url");
+  assert.equal(state.calls.detach.length, 1, "always detaches");
+});
+
+test("eval --frame <oopif>: OOPIF target resolved via setAutoAttach flat session → Runtime.evaluate returns the value", async () => {
+  reset();
+  state.evalReply = { result: { value: OOPIF_URL } };   // location.href INSIDE the OOPIF
+  const out = await OPS.eval({ tabId: TAB_ID, frame: "model-benchmarking.civit.ai", js: "location.href" });
+  assert.equal(state.calls.executeScript.length, 0, "still not chrome.scripting");
+  // OOPIF path: NOT in the frame tree → auto-attach → evaluate in the matched SESSION.
+  assert.ok(cdpMethods().includes("Target.setAutoAttach"), "auto-attaches to reach the OOPIF target");
+  assert.equal(lastEval().sessionId, "SID_OOPIF", "evaluate is issued in the OOPIF's flat session");
+  assert.equal(lastEval().params.contextId, undefined, "OOPIF eval uses the session default context");
+  // PROOF eval ran inside the OOPIF (its own url), not null.
+  assert.equal(out.value, OOPIF_URL);
+  assert.equal(out.url, OOPIF_URL);
+  assert.equal(state.calls.detach.length, 1);
+});
+
+test("eval --frame numeric OOPIF id also resolves the OOPIF session (numeric id → url → CDP target)", async () => {
+  reset();
+  state.evalReply = { result: { value: 1234 } };
+  const out = await OPS.eval({ tabId: TAB_ID, frame: "7", js: "6*206 + 2" });
+  assert.equal(lastEval().sessionId, "SID_OOPIF");
+  assert.equal(out.value, 1234, "not null — the numeric frameId mapped to the OOPIF's url→session");
+});
+
+test("NEVER-SILENT-NULL: a Runtime.evaluate exceptionDetails → frame_eval_failed (not value:null)", async () => {
+  reset();
+  state.evalReply = { result: { type: "object" },
+    exceptionDetails: { exception: { description: "TypeError: foo is not a function" } } };
+  await assert.rejects(() => OPS.eval({ tabId: TAB_ID, frame: "0", js: "foo()" }),
+    /frame_eval_failed:TypeError: foo is not a function/);
+  assert.equal(state.calls.detach.length, 1, "detaches even when the eval threw");
+});
+
+test("NEVER-SILENT-NULL: an unresolvable OOPIF frame → frame_not_found (not value:null)", async () => {
+  reset();
+  // getAllFrames still HAS frame 7 (resolveFrame succeeds), but auto-attach announces a
+  // DIFFERENT target → no session matches its url → frame_not_found, never a silent null.
+  state.autoAttachTargets = [{ sessionId: "SID_OTHER", url: "https://unrelated.example/" }];
+  await assert.rejects(() => OPS.eval({ tabId: TAB_ID, frame: "7", js: "location.href" }),
+    /frame_not_found:https:\/\/model-benchmarking\.civit\.ai\//);
+  // Runtime.evaluate was NEVER issued (we failed to resolve the context first).
+  assert.equal(cdpMethods().includes("Runtime.evaluate"), false);
+  assert.equal(state.calls.detach.length, 1, "still detaches on the frame_not_found path");
+});
+
+test("a genuine null result is returned AS a value (distinct from a failure to execute)", async () => {
+  reset();
+  state.evalReply = { result: { value: null } };
+  const out = await OPS.eval({ tabId: TAB_ID, frame: "0", js: "window.__nothing" });
+  assert.equal(out.value, null, "a real null eval result is a legitimate value, not an error");
+});
+
+test("SyntaxError on the expression form retries the statement form ONCE", async () => {
+  reset();
+  // First evaluate (expression form) → CDP SyntaxError; second (statement fallback) → value.
+  state.evalReplies = [
+    { exceptionDetails: { exception: { className: "SyntaxError" }, text: "Uncaught SyntaxError" } },
+    { result: { value: 7 } },
+  ];
+  const out = await OPS.eval({ tabId: TAB_ID, frame: "0", js: "var x = 7; x" });
+  assert.equal(out.value, 7);
+  const evals = state.calls.cdp.filter((c) => c.method === "Runtime.evaluate");
+  assert.equal(evals.length, 2, "exactly two evaluate calls: expression then statement fallback");
+});
+
+test("#189: a HUNG Runtime.evaluate settles with cdp_timeout and STILL detaches — no SW wedge", async () => {
+  reset();
+  // Shrink the CDP budgets (test-only hook) so this settles in ms, not the 8s default.
+  globalThis.BROWSER_BRIDGE_CDP_TIMEOUTS = { attachMs: 60, commandMs: 20, budgetMs: 200 };
+  state.hangEvaluate = true;
+  const started = Date.now();
+  await assert.rejects(() => OPS.eval({ tabId: TAB_ID, frame: "0", js: "while(1){}" }),
+    /cdp_timeout/);
+  assert.ok(Date.now() - started < 4000, "must settle by the tiny budget, not the 20s server timeout");
+  assert.equal(state.calls.detach.length, 1, "a hung eval must still best-effort detach (no leaked session)");
+});
+
+test("SECURITY: eval --frame attaches ONLY to the op's own tab; typed op — no raw CDP passthrough", async () => {
+  reset();
+  state.evalReply = { result: { value: 1 } };
+  await OPS.eval({ tabId: TAB_ID, frame: "0", js: "1" });
+  // Every attach/detach targeted THIS tab (own-tab-only, #187).
+  assert.ok(state.calls.attach.every((t) => t.tabId === TAB_ID));
+  assert.ok(state.calls.detach.every((t) => t.tabId === TAB_ID || t.tabId === undefined));
+  // Frame enumeration was scoped to this tab too.
+  assert.ok(state.calls.getAllFrames.every((t) => t === TAB_ID));
+  // The only CDP methods used are the FIXED typed set — no arbitrary CDP surface.
+  const allowed = new Set(["Page.getFrameTree", "Page.createIsolatedWorld",
+                           "Target.setAutoAttach", "Runtime.evaluate"]);
+  for (const m of cdpMethods()) assert.ok(allowed.has(m), `unexpected CDP method: ${m}`);
+});

--- a/scripts/browser-bridge/tests/frame_oopif.test.mjs
+++ b/scripts/browser-bridge/tests/frame_oopif.test.mjs
@@ -15,7 +15,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
-  normalizeWebNavFrames, resolveWebNavFrameId,
+  normalizeWebNavFrames, resolveWebNavFrameId, resolveWebNavFrame,
   frameReadHtmlFn, frameReadTextFn, frameEvalFn,
   frameClickFn, frameTypeFn, frameKeyFn, keyEventParams,
 } from "../extension/protocol.js";
@@ -72,6 +72,23 @@ test("resolveWebNavFrameId: exact numeric frameId wins; url substring; case-inse
   assert.equal(resolveWebNavFrameId(frames, "MODEL-BENCHMARKING.CIVIT.AI"), 7);
   // first (list-order) substring match wins deterministically.
   assert.equal(resolveWebNavFrameId(frames, "https://"), 0);
+});
+
+test("resolveWebNavFrame: returns the FRAME OBJECT (id+url+parent) so the SW can report/locate the frame", () => {
+  const frames = normalizeWebNavFrames(GET_ALL_FRAMES);
+  // exact numeric id → the whole object (url is what the SW reports + matches in CDP).
+  assert.deepEqual(resolveWebNavFrame(frames, "7"),
+    { frameId: 7, url: "https://model-benchmarking.civit.ai/", parentFrameId: 0 });
+  // url substring → the same object.
+  assert.deepEqual(resolveWebNavFrame(frames, "model-benchmarking.civit.ai"),
+    { frameId: 7, url: "https://model-benchmarking.civit.ai/", parentFrameId: 0 });
+  // the top frame.
+  assert.equal(resolveWebNavFrame(frames, "0").frameId, 0);
+  // resolveWebNavFrameId delegates → same numeric id, never diverges.
+  assert.equal(resolveWebNavFrameId(frames, "model-benchmarking.civit.ai"),
+    resolveWebNavFrame(frames, "model-benchmarking.civit.ai").frameId);
+  assert.throws(() => resolveWebNavFrame(frames, "nope"), /frame_not_found:nope/);
+  assert.throws(() => resolveWebNavFrame(frames, ""), /frame_not_specified/);
 });
 
 test("resolveWebNavFrameId: unknown → frame_not_found; empty → frame_not_specified", () => {

--- a/scripts/browser-bridge/tests/service_worker.test.mjs
+++ b/scripts/browser-bridge/tests/service_worker.test.mjs
@@ -59,6 +59,7 @@ globalThis.chrome = {
       return {};
     },
     onDetach: { addListener() {} },
+    onEvent: { addListener() {}, removeListener() {} },
   },
   storage: { local: { async get() { return {}; }, async set() {} } },
   runtime: { onInstalled: { addListener() {} }, onStartup: { addListener() {} } },
@@ -94,23 +95,23 @@ test("--frame text: resolves the numeric frameId + injects via executeScript int
   assert.equal(typeof call.func, "function");
   assert.equal(out.text, "INNER OOPIF TEXT");
   assert.equal(out.frame, "model-benchmarking.civit.ai");
+  assert.equal(out.url, OOPIF_URL,
+    "a frame read reports the FRAME's own url (proves it targeted the OOPIF, not the top)");
   assert.deepEqual(state.calls.debugger, [], "a frame read must NOT use the debugger");
 });
 
-test("--frame html/eval: inject into the resolved OOPIF frame via executeScript", async () => {
+test("--frame html: inject into the resolved OOPIF frame via executeScript; reports the FRAME url", async () => {
   resetCalls();
   state.execResult = "<html>oopif</html>";
   const h = await OPS.getHtml({ tabId: TAB_ID, frame: "7" });   // numeric frame id
   assert.deepEqual(lastExec().target, { tabId: TAB_ID, frameIds: [7] });
   assert.equal(h.html, "<html>oopif</html>");
-
-  resetCalls();
-  state.execResult = 1234;
-  const e = await OPS.eval({ tabId: TAB_ID, frame: "model-benchmarking.civit.ai", js: "6*206 + 2" });
-  assert.deepEqual(lastExec().target, { tabId: TAB_ID, frameIds: [7] });
-  assert.equal(e.value, 1234);
-  assert.deepEqual(lastExec().args, ["6*206 + 2"]);
+  assert.equal(h.url, OOPIF_URL, "a frame read reports the FRAME's own url, not the top url");
+  assert.deepEqual(state.calls.debugger, [], "a fixed-func frame read must NOT use the debugger");
 });
+// NOTE: `eval --frame` no longer uses executeScript (chrome.scripting can only run a
+// serialized FUNC, never an arbitrary JS STRING → the #190 value:null bug). It now runs
+// via CDP Runtime.evaluate — see tests/frame_eval_cdp.test.mjs.
 
 test("--frame click/type/key: injected into the OOPIF frame; report trusted:false", async () => {
   resetCalls();
@@ -118,7 +119,7 @@ test("--frame click/type/key: injected into the OOPIF frame; report trusted:fals
   const c = await OPS.click({ tabId: TAB_ID, frame: "model-benchmarking.civit.ai", selector: "#run" });
   assert.deepEqual(lastExec().target, { tabId: TAB_ID, frameIds: [7] });
   assert.deepEqual(lastExec().args, ["#run"]);
-  assert.deepEqual(c, { url: state.tab.url, clicked: "#run", x: 60, y: 40,
+  assert.deepEqual(c, { url: OOPIF_URL, clicked: "#run", x: 60, y: 40,
                         frame: "model-benchmarking.civit.ai", trusted: false });
 
   resetCalls();


### PR DESCRIPTION
## The bug (confirmed live)

`browser --tab <id> --frame 0 eval 'location.href'` returned
`{"ok":true,"data":{"value":null,"frame":"0"}}` — **null**, even for the TOP
frame where `location.href` is obviously non-null, and the same for a
cross-origin OOPIF frame. A `null`-as-success masquerading as a real result.

## Root cause: chrome.scripting can't eval a STRING

#190 routed frame-scoped ops through `chrome.scripting.executeScript`, which
runs a **serialized FUNC**, not an arbitrary JS **string**. The fixed-func ops
(`text`/`html`/`click`/`type`/`key`) work that way, but `eval` is an arbitrary
user JS string — running it via a `func` that `new Function(src)`s it inside
the frame's isolated world hits the extension CSP / returns `value:null`, so
the eval-in-frame path executed nothing meaningful. (Top-frame `eval` WITHOUT
`--frame` still worked — it uses `chrome.scripting` MAIN world directly, not
the frame path.)

## Fix: `eval --frame` → CDP `Runtime.evaluate` in the frame's context

The reliable way to run a JS **string** in a specific frame — including a
cross-origin OOPIF (a separate renderer/target under site isolation) — is CDP
`Runtime.evaluate` in that frame's execution context. The numeric
webNavigation frameId does **not** map 1:1 to a CDP frame/target, so the frame
is located **by URL** (from `resolveWebNavFrame`, which now returns the frame
object incl. its url):

- **Same-process frame** → found in the top session's `Page.getFrameTree` →
  `Page.createIsolatedWorld` → `Runtime.evaluate({contextId})`.
- **Cross-origin OOPIF** → NOT in that tree (getFrameTree from the top target
  omits OOPIFs — the same reason #190 moved enumeration to webNavigation) →
  `Target.setAutoAttach({flatten:true})` auto-attaches its target, surfacing a
  flat `sessionId` matched by URL → `Runtime.evaluate` in that session.

The expression/statement duality is preserved (`frameEvalExpressions`): try the
expression form, retry the statement form once on a CDP `SyntaxError` — a side
effect never double-runs.

## Never silent-null

- A genuine `null`/`undefined` result is returned **as a value** (legitimate).
- A **failure to execute** is a clear op error, never `value:null`:
  - `frame_not_found:<url|id>` when the frame can't be resolved;
  - `frame_eval_failed:<reason>` from a `Runtime.evaluate` `exceptionDetails`.

## Invariants preserved

- **#187** own-tab-only CDP attach (attaches only to the server-injected owned
  tab; privileged surfaces refused before attach).
- **#189** per-op CDP timeouts (attach/command/budget) bound the whole eval path
  — a bad frame or hung `Runtime.evaluate` fails fast and **always detaches**,
  never wedges the service worker. Sub-session sends are routed through the same
  bounded `send` wrapper.
- **#175/#178/#180** typed-op surface / no raw-CDP passthrough — the agent still
  sends only typed scalars (`op`/`frame`/`js`); CDP routing is internal to the SW.
- **#190** OOPIF frame *enumeration* via webNavigation (`frames`) unchanged; the
  fixed-func frame ops stay on `chrome.scripting`.

While here: a `--frame` op now reports the **frame's own url** (not the top tab
url) so a caller can confirm it read the intended frame (the reported ambiguity
in the task).

## Tests

- New `tests/frame_eval_cdp.test.mjs` drives `OPS.eval --frame` end-to-end
  against a mocked `chrome.debugger`/`webNavigation`: same-process (frame tree +
  isolated world) and OOPIF (setAutoAttach flat session) both return the eval
  **value** (not null — the exact regression); `exceptionDetails` →
  `frame_eval_failed`; unresolvable OOPIF → `frame_not_found`; syntax-form
  fallback; and the **#189 hung-`Runtime.evaluate` → bounded `cdp_timeout`,
  still detaches** (no wedge); plus own-tab-only + typed-CDP-method-set security.
- Pure helpers unit-tested in `cdp_protocol.test.mjs`
  (`matchCdpFrameId`/`pickOopifSessionId`/`evalValueOrThrow`) and
  `frame_oopif.test.mjs` (`resolveWebNavFrame`).
- Fixed-func `--frame` ops + `frames` unchanged and still green.

**Totals: 157 Python / 157 node, all passing** (node was 144 pre-change; the
2 stale executeScript-based eval assertions were rewritten for the CDP path,
+13 net new). `node --check` + `bash -n browser` clean.

## Honest verification

Unit tests exercise the wiring/decision layer; the chrome.* CDP glue needs a
real Brave. **Manual live check** (unverified in CI — the extension MUST be
reloaded first): on a loaded `civitai.com/apps/run/model-benchmarking`,
`browser --tab <id> frames` → note the `model-benchmarking.civit.ai` OOPIF id;
`browser --tab <id> --frame <oopif-id> eval 'location.href'` returns
`https://model-benchmarking.civit.ai/...` (PROOF eval ran inside the OOPIF, not
null); `--frame 0 eval 'location.href'` → the top url; a bad frame → clear
`frame_not_found`; a throwing expr → `frame_eval_failed`; `browser health` OK
afterward (no instance wedge).

## ⚠ Mandatory after merge/pull

**Reload the unpacked extension** in `brave://extensions` — Brave does not
hot-reload unpacked extensions, so the running service worker keeps the old
(broken) `eval --frame` until reloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)