### PR TITLE
test(flake-check): restore the hermetic nix-check gate to green (sandbox-portable stub shebangs)

### DIFF
--- a/scripts/browser-bridge/tests/test_browser_agent.py
+++ b/scripts/browser-bridge/tests/test_browser_agent.py
@@ -22,6 +22,7 @@ import os
 import shutil
 import stat
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -44,6 +45,11 @@ SCHEMA_OK = {"answer": "The top 3 stories are A, B, C.",
 # Fixture builders — write tiny executable stand-ins into a tmp bin dir.
 # --------------------------------------------------------------------------- #
 def _write_exec(path: Path, content: str):
+    # The fake stdlib-only python stubs carry a `#!/usr/bin/env python3` shebang,
+    # but the nix build sandbox has no /usr/bin/env — point them at the running
+    # interpreter so they exec both in the sandbox AND on the dev host.
+    content = content.replace(
+        "#!/usr/bin/env python3\n", f"#!{sys.executable}\n", 1)
     path.write_text(content)
     path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
     return path

--- a/scripts/claude-hooks/tests/test_claude_notify.py
+++ b/scripts/claude-hooks/tests/test_claude_notify.py
@@ -42,7 +42,9 @@ def make_env(tmp):
     for name in ("dunstify", "notify-send", "curl"):
         p = os.path.join(bindir, name)
         with open(p, "w") as f:
-            f.write('#!/usr/bin/env bash\n'
+            # /bin/sh (not /usr/bin/env bash) so the stub also execs in the nix
+            # build sandbox, which has no /usr/bin/env; the body is POSIX-sh.
+            f.write('#!/bin/sh\n'
                     'echo "%s $*" >> "%s"\nexit 0\n' % (name, stub_log))
         os.chmod(p, 0o755)
 

--- a/scripts/task-spec-drafter/tests/test_allowlist_covers_prompt_shapes.py
+++ b/scripts/task-spec-drafter/tests/test_allowlist_covers_prompt_shapes.py
@@ -1606,7 +1606,9 @@ def _run_wrapper(argv: list[str], kubeconfig: str = "/tmp/kubectl-ro-test.conf")
 
     with tempfile.TemporaryDirectory() as stub:
         Path(stub, "kubectl").write_text(
-            '#!/usr/bin/env bash\necho "KUBECTL-REACHED: $*"\n', encoding="utf-8"
+            # /bin/sh (not /usr/bin/env bash) so this stub also execs in the nix
+            # build sandbox, which has no /usr/bin/env; the body is POSIX-sh.
+            '#!/bin/sh\necho "KUBECTL-REACHED: $*"\n', encoding="utf-8"
         )
         os.chmod(Path(stub, "kubectl"), 0o755)
         p = subprocess.run(

--- a/scripts/tests/test_playwright_nixos.py
+++ b/scripts/tests/test_playwright_nixos.py
@@ -30,7 +30,9 @@ def _stub_nix(dirpath: Path):
     """A fake `nix`: `build` echoes $FAKE_BROWSERS, `eval` prints a version."""
     p = dirpath / "nix"
     p.write_text(
-        "#!/usr/bin/env bash\n"
+        # /bin/sh (not `#!/usr/bin/env bash`) so the stub also execs in the nix
+        # build sandbox, which has no /usr/bin/env; body is POSIX-sh compatible.
+        "#!/bin/sh\n"
         'case "$1" in\n'
         '  build) [ -n "${FAKE_BROWSERS:-}" ] && echo "$FAKE_BROWSERS" ;;\n'
         '  eval)  echo "1.2.3" ;;\n'


### PR DESCRIPTION
## Problem

`nix build .#checks.x86_64-linux.pytests --impure` (the `nix flake check` test gate) was **RED in the pure nix sandbox**, so the gate enforced nothing — a real regression could hide behind the pre-existing red. `scripts/run-tests.sh --set hermetic` on the dev host stayed green (full PATH), which is why it went unnoticed.

## Root cause (one bug, shared by all four failing suites)

Each failing suite generates a tiny executable **stub** at test time whose shebang is `#!/usr/bin/env <interp>`. The nix build sandbox has **no `/usr/bin/env`** (the exact reason the flake already `patchShebangs src/scripts`), so every such stub failed to exec:

| Suite | Stub | Sandbox symptom |
|---|---|---|
| `scripts/tests/test_playwright_nixos.py` | fake `nix` | `DRIVER=unknown` / resolve-error (3 failed) |
| `scripts/browser-bridge/tests/test_browser_agent.py` | fake `opencode`/`browser` | tool-set gate "failed to run" / JSONDecodeError (~18 failed) |
| `scripts/task-spec-drafter/tests/test_allowlist_covers_prompt_shapes.py` | stub `kubectl` | `rc=126` (bad interpreter) on the pass-through reads (3 failed) |
| `scripts/claude-hooks/tests/test_claude_notify.py` | stub `dunstify`/`notify-send`/`curl` | no toast fired (8 failed) |

**No genuine external dependency was missing** — every failing test is designed-hermetic and CAN run. (Verified the sandbox root is read-only, so a centralized `/usr/bin/env` shim isn't possible; `/bin/sh` and `bash`/`python3` on PATH are available.)

## Fix

Point the stub shebangs at an interpreter guaranteed present in **both** the sandbox and the dev host — purely shebang edits, no assertion/logic touched:

- POSIX-sh stubs → `#!/bin/sh` (nix always provides `/bin/sh`; the bodies are already POSIX)
- python stubs → `sys.executable` (centralized in `_write_exec`)

This keeps every test **fully enforced** (runs for real in both places) rather than skipping anything. No `skipif`/`xfail`/skip/delete added; drafter allow/deny/dispatch untouched.

## Proof

**Sandbox GREEN** — `nix build .#checks.x86_64-linux.pytests --impure` → exit 0. All 14 pytest suites PASS + 3 hook scripts PASS. Previously-red suites now: `scripts/tests` 469 passed, `browser-bridge` 147 passed, `task-spec-drafter` 141 passed, claude-notify script all passed. Skips are all pre-existing (10 browser-bridge, 115 initiatives, 1 session_insight) — this PR adds zero skips.

**Dev host still runs them for real** — `run-tests.sh --set hermetic` → `RESULT: PASS`, and the previously-red nodes **execute (not skip)** with real tools present: 3 playwright, 6 `kubectl_ro`, 5 browser-bridge all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)