### PR TITLE
feat(browser-bridge): make `activate` actually foreground on i3 via host-side i3-msg

### DIFF
--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -41,8 +41,11 @@
 #                               loading, then can be driven. ⚠ STEALS FOCUS — the
 #                               ONE intrusive op; it changes what you see. Waits
 #                               (bounded, default ~3s, cap ~8s) for load unless
-#                               --no-wait; --wait MS overrides. i3 caveat: may not
-#                               raise the window across workspaces (best-effort).
+#                               --no-wait; --wait MS overrides. On i3 the SERVER
+#                               also runs `i3-msg` host-side to actually raise the
+#                               Brave window + switch workspace (Chrome-side focus
+#                               alone is a no-op under i3); the result's `i3` field
+#                               reports applied/skipped/failed (skipped off i3).
 #   browser html              — outerHTML of the owned/active tab (+ url, title)
 #   browser text [selector]   — visible innerText of the owned/active tab (cheap
 #                               read; optional CSS selector; --max-bytes N caps
@@ -331,9 +334,10 @@ case "$sub" in
     # Foreground the owned/explicit/active tab (STEALS FOCUS — the one intrusive
     # op) so a foreground-throttled SPA loads and can then be driven. Optional
     # bounded wait-for-load: default a modest wait (server-clamped, cap ~8s);
-    # --wait MS overrides; --no-wait skips (waitMs:0). i3 caveat: may not raise
-    # the window across workspaces (best-effort). NOTE: an extension code change —
-    # requires an extension reload to take effect (no permission re-prompt).
+    # --wait MS overrides; --no-wait skips (waitMs:0). On i3, the SERVER then runs
+    # `i3-msg` host-side to actually raise the Brave window + switch workspace
+    # (Chrome-side focus alone is a no-op under i3); the result's `i3` field is
+    # applied/skipped/failed. Off a graphical/i3 host it is skipped (best-effort).
     wait=""
     while [ $# -gt 0 ]; do
       case "$1" in

--- a/scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
+++ b/scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
@@ -291,8 +291,10 @@ export function summarizeResult(op, envelope) {
   }
   if (op === "activate") {
     // Compact confirmation the tab foregrounded (metadata only — no page content).
+    // `i3` reports host-side i3 window focusing: applied | skipped | failed.
     return JSON.stringify({ ok: true, tabId: data.tabId ?? null,
       active: data.active ?? null, status: data.status ?? null,
+      i3: data.i3 ?? null,
       url: data.url ?? null, title: data.title ?? null });
   }
   return JSON.stringify(data);

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -84,7 +84,10 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import secrets
+import shutil
+import subprocess
 import sys
 import threading
 import time
@@ -186,6 +189,18 @@ OWNER_TTL_S = float(os.environ.get("BROWSER_BRIDGE_OWNER_TTL", "900"))
 RATE_PER_SEC = float(os.environ.get("BROWSER_BRIDGE_RATE_PER_SEC", "5"))
 BURST = float(os.environ.get("BROWSER_BRIDGE_BURST", "20"))
 MAX_QUEUE = int(os.environ.get("BROWSER_BRIDGE_MAX_QUEUE", "32"))
+
+# Host-side i3 foregrounding for the `activate` op (see i3_foreground below).
+# The Chrome-side activate (chrome.tabs.update{active}+windows.update{focused})
+# is a NO-OP for actual VISIBILITY under a tiling WM: a backgrounded tab stays
+# `document.visibilityState:"hidden"`, so a foreground-throttled SPA never
+# renders. Focusing the matching Brave X11 window via `i3-msg` is what actually
+# raises it + switches workspace, un-throttling the tab. Bounded by this timeout;
+# any failure is non-fatal (the Chrome-side activate result still returns).
+I3_MSG_TIMEOUT = float(os.environ.get("BROWSER_BRIDGE_I3_TIMEOUT", "1.5"))
+# Cap on the UNTRUSTED (page-controlled) tab-title fragment used in the i3
+# criteria — bounds a pathological title before it is re.escape'd.
+I3_TITLE_MAX = 80
 
 # Synthetic routing key for a legacy extension that polls without a handshake
 # (no X-Bridge-Instance-Id). All such polls collapse onto one unnamed instance.
@@ -947,6 +962,121 @@ def _coerce_tab(tab):
 
 
 # --------------------------------------------------------------------------- #
+# Host-side i3 foregrounding for `activate` (untrusted-title-safe, best-effort)
+# --------------------------------------------------------------------------- #
+# The `activate` op sets the tab active Chrome-side, which makes the tab's Brave
+# X11 window TITLE become the tab's title. The SERVER (same host as the browser)
+# then focuses THAT Brave window via `i3-msg` so i3 actually raises it + switches
+# workspace — the step that turns activation from a no-op into real visibility.
+#
+# SECURITY — the title is UNTRUSTED (page-controlled; a hostile page the agent
+# visited can set `document.title` to ANYTHING). The bound MUST be: the worst
+# outcome is "focuses the wrong Brave window or no window", NEVER command
+# execution and NEVER focusing a non-Brave window. That is enforced by:
+#   * subprocess with an ARGV LIST + shell=False (no shell → no `;`/`|`/`$()`/
+#     redirection surface at all). NEVER os.system / shell=True.
+#   * The i3 criteria `title=` value is a REGEX delimited by double-quotes inside
+#     the criteria. re.escape() neutralises regex metacharacters but does NOT
+#     escape the `"`/`[`/`]`/`\` that STRUCTURE an i3 criteria — a `"` could close
+#     the quoted value early and let trailing text be read as an i3 command
+#     (e.g. `exec`). So we STRIP those structural chars (and control chars) BEFORE
+#     re.escape. After that the value cannot break out of `title="..."`.
+#   * A `class="Brave-browser"` constraint so a matched window is always Brave.
+#   * A length cap + a bounded timeout; failure/timeout is swallowed (non-fatal).
+# i3-only chars that i3 uses to delimit a criteria/value. Stripped from the
+# UNTRUSTED title BEFORE re.escape so the value cannot escape its `title="..."`
+# quoting (re.escape does not touch `"`). Removing them at worst makes the title
+# match a different window or none — never a breakout.
+_I3_STRUCTURAL = str.maketrans("", "", '"[]\\')
+
+
+def _sanitize_i3_title(title) -> str:
+    """Reduce an UNTRUSTED tab title to a safe i3 criteria fragment.
+
+    Strips control chars / newlines AND the i3-criteria structural chars
+    (``"[]\\``), then caps length. The remaining text is re.escape'd by the
+    caller so regex metacharacters match literally. Returns "" when nothing
+    usable remains (the caller then SKIPS — there is nothing to focus)."""
+    if not isinstance(title, str):
+        return ""
+    # Drop C0 control chars (incl. \n/\r/\t) and DEL.
+    cleaned = "".join(ch for ch in title if ch >= " " and ch != "\x7f")
+    cleaned = cleaned.translate(_I3_STRUCTURAL)
+    return cleaned.strip()[:I3_TITLE_MAX]
+
+
+def i3_focus_argv(title):
+    """Build the argv LIST for `i3-msg` to focus the Brave window whose title
+    matches `title`, or None when there is no usable title (→ skip).
+
+    shell=False BY CONSTRUCTION (a list, never a shell string). The criteria is
+    `[class="Brave-browser" title="<re.escape'd fragment>"] focus`, so the worst
+    case is "focuses the wrong Brave window or none" — never a non-Brave window,
+    never code execution. See the module block above for the threat model."""
+    safe = _sanitize_i3_title(title)
+    if not safe:
+        return None
+    criteria = '[class="Brave-browser" title="%s"] focus' % re.escape(safe)
+    return ["i3-msg", criteria]
+
+
+def i3_available() -> bool:
+    """True when host-side i3 foregrounding is meaningful: a graphical session
+    (DISPLAY set) AND `i3-msg` on PATH. A headless / non-i3 host → False → the
+    `activate` op SKIPS the i3 step gracefully (no error)."""
+    if not os.environ.get("DISPLAY"):
+        return False
+    return shutil.which("i3-msg") is not None
+
+
+def i3_foreground(title, *, timeout: float = I3_MSG_TIMEOUT) -> str:
+    """Best-effort host-side i3 foregrounding of the Brave window matching the
+    (UNTRUSTED) `title`. Returns a small metadata state for the caller:
+
+      * "skipped" — no graphical/i3 session (i3-msg absent or no DISPLAY), or no
+        usable title. NOT an error — the Chrome-side activate still returns.
+      * "applied" — i3-msg ran and exited 0.
+      * "failed"  — i3-msg errored, timed out, or exited nonzero (non-fatal).
+
+    The title is sanitized + re.escape'd (see i3_focus_argv) and the call is
+    shell=False + timeout-bounded, so a hostile title can at worst focus the
+    wrong Brave window / none — never execute a command."""
+    if not i3_available():
+        return "skipped"
+    argv = i3_focus_argv(title)
+    if argv is None:
+        return "skipped"
+    try:
+        proc = subprocess.run(argv, shell=False, capture_output=True,
+                              timeout=timeout)
+    except Exception:  # noqa: BLE001 — best-effort; any failure is non-fatal.
+        log("activate_i3_failed", reason="exception")
+        return "failed"
+    if getattr(proc, "returncode", 1) == 0:
+        return "applied"
+    log("activate_i3_failed", reason="nonzero", rc=getattr(proc, "returncode", None))
+    return "failed"
+
+
+def _result_title(result) -> str:
+    """The tab title from an `activate` result envelope ({id,ok,data:{title}}),
+    or "" if absent. This is the UNTRUSTED, page-controlled string."""
+    if isinstance(result, dict):
+        data = result.get("data")
+        if isinstance(data, dict) and isinstance(data.get("title"), str):
+            return data["title"]
+    return ""
+
+
+def _annotate_i3(result, state: str) -> None:
+    """Record the i3-foregrounding outcome as a small metadata field on the
+    activate result's data ({...,"i3":"applied"|"skipped"|"failed"}) so the
+    caller knows whether the window was actually raised. Never emits the title."""
+    if isinstance(result, dict) and isinstance(result.get("data"), dict):
+        result["data"]["i3"] = state
+
+
+# --------------------------------------------------------------------------- #
 # Command validation
 # --------------------------------------------------------------------------- #
 def validate_command(body):
@@ -1195,6 +1325,17 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
             else:
                 domain = _domain_from_result(result)
                 log("cmd_ok", op=op)
+                if op == "activate":
+                    # Chrome-side activate only set the tab active WITHIN its
+                    # window (a no-op for real visibility under i3 — the tab stays
+                    # document.hidden). Focus the matching Brave X11 WINDOW via
+                    # i3-msg so i3 raises it + switches workspace → the throttled
+                    # SPA un-throttles and renders. Best-effort + bounded; the
+                    # title is UNTRUSTED (page-controlled) and handled shell=False
+                    # + re.escape'd inside i3_foreground. Skipped gracefully off i3.
+                    state = i3_foreground(_result_title(result))
+                    _annotate_i3(result, state)
+                    log("activate_i3", state=state)
                 self._send(200, {"ok": True, "result": result})
             # Off the critical path: the HTTP response is already sent. Metadata-
             # only + best-effort — cannot delay or break the command (the key is

--- a/scripts/browser-bridge/tests/browser_tool.test.mjs
+++ b/scripts/browser-bridge/tests/browser_tool.test.mjs
@@ -315,9 +315,18 @@ test("buildRequest: activate forces the env tab; bounded waitMs only; NO raw pas
 test("summarizeResult: activate returns compact metadata-only confirmation", () => {
   const s = JSON.parse(summarizeResult("activate", { data: {
     tabId: 9, windowId: 2, url: "https://x.test/", title: "X",
-    active: true, status: "complete" } }));
+    active: true, status: "complete", i3: "applied" } }));
   assert.deepEqual(s, { ok: true, tabId: 9, active: true, status: "complete",
-    url: "https://x.test/", title: "X" });
+    i3: "applied", url: "https://x.test/", title: "X" });
+});
+
+test("summarizeResult: activate i3 field defaults to null when the server omits it", () => {
+  // Off an i3 host the server may not annotate `i3`; the summary reports null,
+  // never throws.
+  const s = JSON.parse(summarizeResult("activate", { data: {
+    tabId: 9, url: "https://x.test/", title: "X", active: true,
+    status: "complete" } }));
+  assert.equal(s.i3, null);
 });
 
 test("runBrowserOp: activate reaches the bridge with the forced tab", async () => {

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -12,6 +12,7 @@ import base64
 import hashlib
 import json
 import os
+import re
 import shutil
 import stat
 import struct
@@ -31,6 +32,11 @@ import server as S  # noqa: E402
 
 TOKEN = "test-token-abc123"
 EXT_DIR = Path(__file__).resolve().parent.parent / "extension"
+
+# Capture the REAL i3_available at import (the _disable_i3 autouse fixture stubs
+# the module attribute to False for hermeticity; this reference lets the
+# gating-logic test still exercise the genuine implementation).
+_REAL_I3_AVAILABLE = S.i3_available
 
 # The in-repo activity spool emitter (single source of truth for the v1 line
 # format). scripts/browser-bridge/tests/ -> parent.parent.parent == scripts/.
@@ -87,6 +93,16 @@ def _isolate_activity_spool(tmp_path, monkeypatch):
     monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(tmp_path / "activity-spool"))
     monkeypatch.setattr(S, "_spool_emit_mod", None)
     monkeypatch.setattr(S, "_spool_emit_tried", False)
+
+
+@pytest.fixture(autouse=True)
+def _disable_i3(monkeypatch):
+    """HERMETIC by default: neutralise host-side i3 foregrounding so no test
+    accidentally fires a real `i3-msg` (the suite runs on Zach's graphical
+    workbench where DISPLAY is set + i3-msg is on PATH). Tests that exercise the
+    i3 path re-enable it explicitly (monkeypatch S.i3_available → True + a fake
+    subprocess.run). With it False, `activate` reports i3:"skipped"."""
+    monkeypatch.setattr(S, "i3_available", lambda: False)
 
 
 @pytest.fixture
@@ -1529,6 +1545,224 @@ def test_activate_telemetry_is_metadata_only(telemetry):
         assert p["domain"] == "model-benchmarking.civit.ai"
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --- `activate` host-side i3 foregrounding (untrusted-title-safe) ---------- #
+class _FakeProc:
+    def __init__(self, returncode=0):
+        self.returncode = returncode
+        self.stdout = b""
+        self.stderr = b""
+
+
+def _enable_i3(monkeypatch, returncode=0, raise_exc=None):
+    """Turn the i3 path ON and stub subprocess.run to capture the argv (never a
+    real i3-msg). Returns the list the fake appends (argv, kwargs) to per call."""
+    calls = []
+    monkeypatch.setattr(S, "i3_available", lambda: True)
+
+    def _fake_run(argv, **kw):
+        calls.append((argv, kw))
+        if raise_exc is not None:
+            raise raise_exc
+        return _FakeProc(returncode)
+
+    monkeypatch.setattr(S.subprocess, "run", _fake_run)
+    return calls
+
+
+def test_i3_focus_argv_hostile_title_is_safe():
+    """KEY SECURITY TEST: a hostile, page-controlled title (i3-criteria breakout
+    attempt, regex metachars, quotes, `;`, newlines, `$()`, backticks, very long)
+    can NEVER break out of the `title="..."` value into an i3 command. The argv is
+    a 2-element LIST (→ shell=False), constrained to class="Brave-browser", and
+    the criteria has EXACTLY the 4 structural `"`, one `[`, one `]` — a hostile
+    `"`/`]` would add more. Worst case is "wrong Brave window or none"."""
+    hostile = (
+        'evil"] exec xterm [title="pwn'      # try to close value → i3 `exec`
+        + '; rm -rf ~ | cat `id` $(whoami)'  # shell metachars (irrelevant, no shell)
+        + '\n\r\tmore .*+?[]{}^$\\ '          # control chars + regex metachars
+        + "A" * 500                             # length bomb
+    )
+    argv = S.i3_focus_argv(hostile)
+    assert isinstance(argv, list) and len(argv) == 2
+    assert argv[0] == "i3-msg"
+    crit = argv[1]
+    # Structural integrity: exactly one criteria bracket pair + the 2 quoted
+    # attribute values (class + title) → 4 double-quotes, and NO breakout.
+    assert crit.startswith('[class="Brave-browser" title="')
+    assert crit.endswith('"] focus')
+    assert crit.count('"') == 4, crit
+    assert crit.count("[") == 1 and crit.count("]") == 1, crit
+    assert "\n" not in crit and "\r" not in crit and "\t" not in crit
+    # `exec` cannot be a standalone i3 command — it only survives as inert text
+    # INSIDE the quoted title value (still between title=" and "]).
+    title_frag = crit[len('[class="Brave-browser" title="'):-len('"] focus')]
+    assert '"' not in title_frag and "]" not in title_frag and "[" not in title_frag
+    # Length is capped (the 500-char bomb cannot bloat the criteria unbounded).
+    assert len(title_frag) <= len(re.escape("A" * S.I3_TITLE_MAX)) + 40
+
+
+def test_i3_focus_argv_escapes_regex_metacharacters():
+    """A plain title with regex metacharacters is re.escape'd so it matches
+    literally (never alters i3's regex matching)."""
+    argv = S.i3_focus_argv("Model Benchmarking")
+    assert argv == ["i3-msg",
+                    '[class="Brave-browser" title="%s"] focus'
+                    % re.escape("Model Benchmarking")]
+
+
+def test_i3_focus_argv_empty_title_returns_none():
+    """No usable title (empty / only structural+control chars) → None → skip."""
+    assert S.i3_focus_argv("") is None
+    assert S.i3_focus_argv(None) is None
+    assert S.i3_focus_argv('"[]\\\n\t ') is None
+
+
+def test_activate_invokes_i3_msg_on_success(monkeypatch):
+    """On a successful activate the server runs i3-msg with the ARGV LIST
+    (shell=False), a class="Brave-browser" + re.escape'd-title criteria, and
+    `focus`; the result reports i3:"applied"."""
+    calls = _enable_i3(monkeypatch, returncode=0)
+    srv, _ = _serve()
+    ext = FakeExtension(srv, executor=lambda c: {
+        "tabId": 5, "windowId": 1, "active": True, "status": "complete",
+        "url": "https://model-benchmarking.civit.ai/run",
+        "title": "Model Benchmarking"})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _req(srv, "POST", "/cmd", {"op": "activate"})
+        assert st == 200
+        assert body["result"]["data"]["i3"] == "applied"
+        assert len(calls) == 1
+        argv, kw = calls[0]
+        assert argv[0] == "i3-msg"
+        assert argv[1] == ('[class="Brave-browser" title="%s"] focus'
+                           % re.escape("Model Benchmarking"))
+        assert kw.get("shell", False) is False  # NEVER a shell string
+        assert kw.get("timeout")  # bounded
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_activate_i3_skipped_when_unavailable(monkeypatch):
+    """i3-msg unavailable (headless/non-i3) → SKIPPED gracefully; the activate
+    still returns the Chrome-side result and NO subprocess is spawned."""
+    # _disable_i3 (autouse) already forces i3_available False; also make any
+    # subprocess.run a hard failure so a regression that skips the gate is caught.
+    def _boom(*a, **k):
+        raise AssertionError("i3-msg must NOT run when i3 is unavailable")
+    monkeypatch.setattr(S.subprocess, "run", _boom)
+    srv, _ = _serve()
+    ext = FakeExtension(srv, executor=lambda c: {
+        "tabId": 5, "active": True, "status": "complete",
+        "url": "https://x.test", "title": "Anything"})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _req(srv, "POST", "/cmd", {"op": "activate"})
+        assert st == 200
+        assert body["result"]["data"]["i3"] == "skipped"
+        assert body["result"]["data"]["tabId"] == 5  # Chrome-side result intact
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_activate_i3_skipped_when_no_title(monkeypatch):
+    """i3 available but the tab has no usable title → SKIPPED (no criteria to
+    match); no subprocess is spawned."""
+    calls = _enable_i3(monkeypatch, returncode=0)
+    srv, _ = _serve()
+    ext = FakeExtension(srv, executor=lambda c: {
+        "tabId": 5, "active": True, "status": "complete", "url": "https://x.test"})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _req(srv, "POST", "/cmd", {"op": "activate"})
+        assert st == 200
+        assert body["result"]["data"]["i3"] == "skipped"
+        assert calls == []
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_activate_i3_failed_on_nonzero(monkeypatch):
+    """i3-msg exits nonzero → non-fatal FAILED; the Chrome-side result still
+    returns."""
+    _enable_i3(monkeypatch, returncode=1)
+    srv, _ = _serve()
+    ext = FakeExtension(srv, executor=lambda c: {
+        "tabId": 5, "active": True, "status": "complete",
+        "url": "https://x.test", "title": "Some Tab"})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _req(srv, "POST", "/cmd", {"op": "activate"})
+        assert st == 200
+        assert body["result"]["data"]["i3"] == "failed"
+        assert body["result"]["data"]["tabId"] == 5
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_activate_i3_failed_on_timeout(monkeypatch):
+    """i3-msg timing out → non-fatal FAILED (the call is timeout-bounded)."""
+    _enable_i3(monkeypatch,
+               raise_exc=subprocess.TimeoutExpired(cmd="i3-msg", timeout=1.5))
+    srv, _ = _serve()
+    ext = FakeExtension(srv, executor=lambda c: {
+        "tabId": 5, "active": True, "status": "complete",
+        "url": "https://x.test", "title": "Some Tab"})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _req(srv, "POST", "/cmd", {"op": "activate"})
+        assert st == 200
+        assert body["result"]["data"]["i3"] == "failed"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_activate_i3_telemetry_stays_metadata_only(telemetry, monkeypatch):
+    """Even when i3 focusing is APPLIED, the activate telemetry event carries NO
+    page title — only op / outcome / bare domain (the title can hold page
+    content; the i3 step must not leak it into activity.events)."""
+    spool_dir = telemetry
+    _enable_i3(monkeypatch, returncode=0)
+    srv, _ = _serve()
+    ext = FakeExtension(srv, executor=lambda c: {
+        "tabId": 5, "active": True, "status": "complete",
+        "url": "https://model-benchmarking.civit.ai/run",
+        "title": "SECRET PAGE CONTENT IN TITLE"})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, _ = _req(srv, "POST", "/cmd", {"op": "activate"})
+        assert st == 200
+        e = _wait_events(spool_dir, 1)[0]
+        p = json.loads(e["payload"])
+        assert p["op"] == "activate" and p["outcome"] == "ok"
+        assert p["domain"] == "model-benchmarking.civit.ai"
+        # No title anywhere in the emitted event.
+        assert "SECRET" not in json.dumps(e)
+        assert "title" not in p
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_i3_available_requires_display_and_i3msg(monkeypatch):
+    """i3_available gates on BOTH a graphical session (DISPLAY) and i3-msg on
+    PATH — either missing → False (skip). Exercises the REAL implementation
+    (the autouse fixture stubs the module attribute for hermeticity)."""
+    monkeypatch.setattr(S.shutil, "which",
+                        lambda n: "/run/current-system/sw/bin/i3-msg")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    assert _REAL_I3_AVAILABLE() is False          # no DISPLAY → False
+    monkeypatch.setenv("DISPLAY", ":0")
+    assert _REAL_I3_AVAILABLE() is True           # DISPLAY + i3-msg → True
+    monkeypatch.setattr(S.shutil, "which", lambda n: None)
+    assert _REAL_I3_AVAILABLE() is False          # i3-msg absent → False
 
 
 # --- THE BUG: two sessions interleave without clobbering ------------------- #


### PR DESCRIPTION
## Why: Chrome-side focus is a no-op on i3 (LIVE-verified)

The `activate` op (#195) does Chrome-side `chrome.tabs.update({active:true})` +
`chrome.windows.update({focused:true})`. Live-tested on i3 this session: it is a
**no-op for actual visibility** — the tab stayed `document.visibilityState:"hidden"`,
so a foreground-throttled SPA (`model-benchmarking.civit.ai`) never rendered. Then
host-side `i3-msg '[title="Model Benchmarking"] focus'` returned `{"success":true}`
and the tab flipped to `visibility:"visible"` → the app un-throttled and rendered →
a synthetic `click --frame` then drove it. So: **Chrome-side focus doesn't move i3;
host-side `i3-msg` focus by the tab's window TITLE does.**

## The fix: host-side i3-msg after a successful activate

After the extension's `activate` sets the tab active (making that Brave X11
window's TITLE the tab's title), the **server** (`server.py`, same host as the
browser) focuses the matching Brave window via `i3-msg` so i3 raises it + switches
workspace. The Chrome-side activate + optional wait-for-load (#195) are unchanged
— we do BOTH (Chrome-side makes the window title right; i3-side raises the window).

## Untrusted-title security model

The tab title is **page-controlled and UNTRUSTED** (a hostile page the agent
visited can set `document.title` to anything). The bound is: worst case is
"focuses the wrong Brave window or none" — **never command execution, never a
non-Brave window**:

- `subprocess.run` with an **ARGV LIST + `shell=False`** — no `os.system`, no
  `shell=True`; there is no shell metachar surface at all.
- The i3 criteria `title=` value is a **regex delimited by double-quotes**.
  `re.escape` neutralises regex metacharacters but does **not** escape the
  `"`/`[`/`]`/`\` that *structure* an i3 criteria (a `"` could close the value
  early and let trailing text be read as an i3 `exec` command). So the title is
  **stripped of those structural chars (and control chars) BEFORE `re.escape`**,
  then length-capped (80 chars).
- A **`class="Brave-browser"`** constraint so a match is always a Brave window.
- A **bounded timeout**; any failure/timeout is swallowed (non-fatal).

The key security test drives a hostile title (`evil"] exec xterm [title="pwn; rm
-rf ~ | $(whoami)` + newlines + regex metachars + a 500-char bomb) and asserts the
built argv has exactly the 4 structural `"`, one `[`, one `]`, no breakout, capped.

## i3-gating / portability

i3-msg is attempted only when meaningful — **DISPLAY set AND i3-msg on PATH**. On a
headless/non-i3 host it **skips gracefully** (no error); the op still returns the
Chrome-side result. The activate result reports `i3: "applied" | "skipped" |
"failed"` so the caller knows.

## Manual live check (needs a graphical i3 host)

`browser --instance work open <heavy-SPA>` (backgrounded, stuck loading) →
`browser --tab <id> activate` → the Brave window RAISES on i3 and the tab becomes
`visibility:"visible"` → the SPA renders → `frames`/`click --frame` drive it.
The `i3-msg [title=…] focus` step was verified by hand this session. The i3-msg
server logic is unit-tested (mocked subprocess); the actual foregrounding needs a
live i3 session — **not** a headless host.

## Reload needed?

**No.** This is a server-only change (`server.py` + CLI/tool metadata). The bridge
service restarts on `home-manager switch` via X-Restart-Triggers; the extension is
untouched, so no extension reload is required.

## Test results

- Python: **171 passed** (was 161; +10 — argv-escaping/hostile-title, applied/
  skipped/failed states, no-title skip, i3-availability gating, metadata-only
  telemetry with i3 applied).
- Node: **159 passed** (was 158; +1 — activate summary carries `i3`).
- `node --check`, `bash -n browser`, `jq` manifest all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
