### PR TITLE
fix(browser-bridge): resolve i3-msg by abs path so `activate` foregrounds in-service

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -759,7 +759,15 @@ in
     Service = {
       Type = "simple";
       Environment = [
-        "PATH=${lib.makeBinPath [ pkgs.python312 pkgs.coreutils ]}"
+        # pkgs.i3 puts `i3-msg` on the service PATH: the `activate` op's
+        # host-side i3 foregrounding (#196) resolves i3-msg via PATH, but a
+        # systemd --user service otherwise inherits only python3+coreutils —
+        # NOT /run/current-system/sw/bin where i3-msg lives — so `which i3-msg`
+        # returned None in-service and `activate` silently reported i3:"skipped"
+        # even on the graphical i3 host. Pin the hermetic store path (pkgs.i3)
+        # and keep the system profile as a fallback. server.py ALSO resolves
+        # i3-msg by well-known absolute path (belt-and-suspenders).
+        "PATH=${lib.makeBinPath [ pkgs.python312 pkgs.coreutils pkgs.i3 ]}:/run/current-system/sw/bin"
         # Bind loopback only; never reachable off-host.
         "BROWSER_BRIDGE_HOST=127.0.0.1"
         # Distinct from the activity receiver's 8787.

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -1020,13 +1020,45 @@ def i3_focus_argv(title):
     return ["i3-msg", criteria]
 
 
+# Well-known absolute locations for `i3-msg`, tried IN ORDER when it is not on
+# PATH. The browser-bridge systemd --user service runs with a MINIMAL PATH
+# (python3 + coreutils) that does NOT include /run/current-system/sw/bin, where
+# i3-msg actually lives — so `shutil.which("i3-msg")` returns None IN-SERVICE
+# even on a graphical i3 host, and `activate` silently reported i3:"skipped".
+# Resolving i3-msg by these absolute paths makes the host-side foregrounding
+# work regardless of the (possibly minimal) service PATH — belt-and-suspenders
+# with the nix unit's PATH fix (which puts ${pkgs.i3}/bin on PATH).
+_I3_MSG_FALLBACKS = (
+    "/run/current-system/sw/bin/i3-msg",
+    str(Path.home() / ".nix-profile" / "bin" / "i3-msg"),
+)
+
+
+def _resolve_i3_msg():
+    """Absolute path to an executable `i3-msg`, or None if none is found.
+
+    Prefers `shutil.which` (honours PATH), then falls back to the first
+    well-known absolute location (see _I3_MSG_FALLBACKS) that EXISTS and is
+    EXECUTABLE. The fallback is what makes host-side i3 foregrounding work under
+    the browser-bridge systemd --user service, whose minimal PATH omits
+    /run/current-system/sw/bin."""
+    found = shutil.which("i3-msg")
+    if found:
+        return found
+    for cand in _I3_MSG_FALLBACKS:
+        if os.path.exists(cand) and os.access(cand, os.X_OK):
+            return cand
+    return None
+
+
 def i3_available() -> bool:
     """True when host-side i3 foregrounding is meaningful: a graphical session
-    (DISPLAY set) AND `i3-msg` on PATH. A headless / non-i3 host → False → the
+    (DISPLAY set) AND a resolvable `i3-msg` (on PATH or a well-known absolute
+    fallback — see _resolve_i3_msg). A headless / non-i3 host → False → the
     `activate` op SKIPS the i3 step gracefully (no error)."""
     if not os.environ.get("DISPLAY"):
         return False
-    return shutil.which("i3-msg") is not None
+    return _resolve_i3_msg() is not None
 
 
 def i3_foreground(title, *, timeout: float = I3_MSG_TIMEOUT) -> str:
@@ -1046,6 +1078,14 @@ def i3_foreground(title, *, timeout: float = I3_MSG_TIMEOUT) -> str:
     argv = i3_focus_argv(title)
     if argv is None:
         return "skipped"
+    # Resolve i3-msg to an ABSOLUTE path for argv[0] so the call works even when
+    # i3-msg is not on the (minimal systemd --user) PATH. i3_available() above
+    # already confirmed it resolves; re-check defensively. The criteria (argv[1])
+    # is built + sanitized + re.escape'd by i3_focus_argv — UNCHANGED here.
+    i3_msg = _resolve_i3_msg()
+    if i3_msg is None:
+        return "skipped"
+    argv[0] = i3_msg
     try:
         proc = subprocess.run(argv, shell=False, capture_output=True,
                               timeout=timeout)

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -1560,6 +1560,9 @@ def _enable_i3(monkeypatch, returncode=0, raise_exc=None):
     real i3-msg). Returns the list the fake appends (argv, kwargs) to per call."""
     calls = []
     monkeypatch.setattr(S, "i3_available", lambda: True)
+    # Deterministic resolved i3-msg path (used as argv[0]) regardless of host.
+    monkeypatch.setattr(S, "_resolve_i3_msg",
+                        lambda: _FAKE_I3_MSG)
 
     def _fake_run(argv, **kw):
         calls.append((argv, kw))
@@ -1569,6 +1572,11 @@ def _enable_i3(monkeypatch, returncode=0, raise_exc=None):
 
     monkeypatch.setattr(S.subprocess, "run", _fake_run)
     return calls
+
+
+# The absolute i3-msg path the _enable_i3 helper makes _resolve_i3_msg return, so
+# argv[0] assertions are host-independent (matches _I3_MSG_FALLBACKS[0]).
+_FAKE_I3_MSG = "/run/current-system/sw/bin/i3-msg"
 
 
 def test_i3_focus_argv_hostile_title_is_safe():
@@ -1637,7 +1645,9 @@ def test_activate_invokes_i3_msg_on_success(monkeypatch):
         assert body["result"]["data"]["i3"] == "applied"
         assert len(calls) == 1
         argv, kw = calls[0]
-        assert argv[0] == "i3-msg"
+        # argv[0] is the RESOLVED ABSOLUTE i3-msg path (not the bare name) so the
+        # call works even under the minimal systemd --user service PATH.
+        assert argv[0] == _FAKE_I3_MSG
         assert argv[1] == ('[class="Brave-browser" title="%s"] focus'
                            % re.escape("Model Benchmarking"))
         assert kw.get("shell", False) is False  # NEVER a shell string
@@ -1752,8 +1762,8 @@ def test_activate_i3_telemetry_stays_metadata_only(telemetry, monkeypatch):
 
 
 def test_i3_available_requires_display_and_i3msg(monkeypatch):
-    """i3_available gates on BOTH a graphical session (DISPLAY) and i3-msg on
-    PATH — either missing → False (skip). Exercises the REAL implementation
+    """i3_available gates on BOTH a graphical session (DISPLAY) and a resolvable
+    i3-msg — either missing → False (skip). Exercises the REAL implementation
     (the autouse fixture stubs the module attribute for hermeticity)."""
     monkeypatch.setattr(S.shutil, "which",
                         lambda n: "/run/current-system/sw/bin/i3-msg")
@@ -1761,8 +1771,50 @@ def test_i3_available_requires_display_and_i3msg(monkeypatch):
     assert _REAL_I3_AVAILABLE() is False          # no DISPLAY → False
     monkeypatch.setenv("DISPLAY", ":0")
     assert _REAL_I3_AVAILABLE() is True           # DISPLAY + i3-msg → True
+    # i3-msg NOT on PATH *and* no absolute fallback exists → False. Both the
+    # which() lookup AND the absolute-fallback probe must miss (else the resolver
+    # finds a real /run/current-system/... i3-msg on the graphical test host).
     monkeypatch.setattr(S.shutil, "which", lambda n: None)
+    monkeypatch.setattr(S.os.path, "exists", lambda p: False)
     assert _REAL_I3_AVAILABLE() is False          # i3-msg absent → False
+
+
+def test_resolve_i3_msg_prefers_which(monkeypatch):
+    """_resolve_i3_msg returns the PATH-resolved i3-msg when one is on PATH."""
+    monkeypatch.setattr(S.shutil, "which", lambda n: "/usr/bin/i3-msg")
+    assert S._resolve_i3_msg() == "/usr/bin/i3-msg"
+
+
+def test_resolve_i3_msg_falls_back_to_absolute_path(monkeypatch):
+    """THE FIX: i3-msg is NOT on PATH (the minimal systemd --user service PATH),
+    but a well-known absolute i3-msg EXISTS and is executable → resolve to it."""
+    monkeypatch.setattr(S.shutil, "which", lambda n: None)
+    fallback = S._I3_MSG_FALLBACKS[0]
+    monkeypatch.setattr(S.os.path, "exists", lambda p: p == fallback)
+    monkeypatch.setattr(S.os, "access", lambda p, mode: p == fallback)
+    assert S._resolve_i3_msg() == fallback
+
+
+def test_resolve_i3_msg_none_when_nothing_found(monkeypatch):
+    """Nothing on PATH and no absolute fallback exists → None (→ i3 skipped)."""
+    monkeypatch.setattr(S.shutil, "which", lambda n: None)
+    monkeypatch.setattr(S.os.path, "exists", lambda p: False)
+    assert S._resolve_i3_msg() is None
+
+
+def test_i3_available_uses_absolute_fallback_off_path(monkeypatch):
+    """i3_available is TRUE when DISPLAY is set and i3-msg resolves ONLY via the
+    absolute fallback (which() misses) — the exact in-service condition the bug
+    hit. This is what un-breaks `activate` under the minimal service PATH."""
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setattr(S.shutil, "which", lambda n: None)
+    fallback = S._I3_MSG_FALLBACKS[0]
+    monkeypatch.setattr(S.os.path, "exists", lambda p: p == fallback)
+    monkeypatch.setattr(S.os, "access", lambda p, mode: p == fallback)
+    assert _REAL_I3_AVAILABLE() is True
+    # DISPLAY absent → skipped regardless of a resolvable i3-msg.
+    monkeypatch.delenv("DISPLAY", raising=False)
+    assert _REAL_I3_AVAILABLE() is False
 
 
 # --- THE BUG: two sessions interleave without clobbering ------------------- #


### PR DESCRIPTION
## The bug

`browser activate` (#196) was inert in production: it returned `i3:"skipped"`
even on the graphical i3 laptop, so the tab never came to the foreground — it
stayed `document.hidden` / `visibility:hidden` and the foreground-throttled SPA
stayed stuck loading.

## Root cause — minimal service PATH

The `browser-bridge` systemd `--user` service runs with a MINIMAL PATH
(`/nix/store/…python3/bin:/nix/store/…coreutils/bin` only) that does **not**
include `/run/current-system/sw/bin`, where `i3-msg` lives
(`/run/current-system/sw/bin/i3-msg` → `${pkgs.i3}/bin/i3-msg`). So
`shutil.which("i3-msg")` in `i3_available()` returned `None` in the service
context → the i3 step was skipped. `DISPLAY`/`XAUTHORITY` were already in the
service env and `i3-msg` worked fine when invoked with a full path — it was
purely a PATH-resolution problem in the service context.

## Fix (belt-and-suspenders)

1. **Nix — put i3 on the service PATH.** The `systemd.user.services.browser-bridge`
   unit's `Environment` PATH now includes `${pkgs.i3}/bin` (hermetic store path,
   provides `i3-msg`) plus `/run/current-system/sw/bin` as a fallback.
2. **Code — robust i3-msg resolution.** New `_resolve_i3_msg()` resolves `i3-msg`
   via `shutil.which` OR a small list of well-known absolute fallbacks
   (`/run/current-system/sw/bin/i3-msg`, `~/.nix-profile/bin/i3-msg`) — the first
   that exists and is executable. `i3_available()` uses it; `i3_foreground()` uses
   the resolved **absolute** path as `argv[0]`. None found → `i3:"skipped"`
   (unchanged graceful behavior). DISPLAY gating unchanged.

The #196 title-escaping / security is untouched: `shell=False` argv, strip
`"[]\` structural chars, `re.escape`, `class="Brave-browser"`. The criteria
(`argv[1]`) is still built by `i3_focus_argv`; only `argv[0]` becomes the
resolved path.

## Needs `home-manager switch` (NOT a reload)

This is a server + nix change — **no extension reload needed**. A
`home-manager switch` **is** required to apply the unit PATH change; the unit
definition changed, so `X-Restart-Triggers` restarts the service.

## Tests

- New resolution/availability cases: `which` misses but an absolute fallback
  exists+executable → resolves to it; none exist → skipped; DISPLAY absent →
  skipped regardless.
- `argv[0]` asserts the resolved absolute path with `shell=False`.
- The hostile-title escaping security test passes unchanged.

```
Python: 175 passed
Node:   159 passed
nix-instantiate --parse nix/home.nix: clean
bash -n scripts/browser-bridge/browser: clean
```

## Manual live check (still required)

The PATH/resolution logic is unit-tested; the actual i3 foregrounding needs the
live service + i3. After `home-manager switch` (restarts the service with the new
PATH):

1. `browser --instance work open <heavy-SPA>` (backgrounded)
2. `browser --tab <id> activate` now returns `i3:"applied"` (not `"skipped"`)
   AND the tab becomes `visibility:"visible"` and the SPA renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
