### PR TITLE
chore(browser-skill): refresh activate docs + provision skill via nix

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -403,6 +403,20 @@ in
     recursive = true;
     force = true;
   };
+  # `browser` skill — the DELIBERATE EXCEPTION to the store-symlink pattern above.
+  # Its source of truth is the browser-bridge subsystem in THIS repo
+  # (scripts/browser-bridge/{SKILL.md,browser}), NOT devrc/claude/skills/. So rather
+  # than copy those into the store we point ~/.claude/skills/browser/ at the live,
+  # MUTABLE repo checkout via mkOutOfStoreSymlink — the skill then always tracks the
+  # working tree (editable in place; a SKILL.md/CLI edit shows up with no switch).
+  # Ships to both hosts declaratively, replacing the previously HAND-MADE symlinks.
+  # Additive to ship.sh's skills rsync (no-delete; identical symlinks on both hosts
+  # are a no-op). One-time on each host: `rm ~/.claude/skills/browser/{SKILL.md,browser}`
+  # if the old manual symlinks exist, else the first switch reports "would be clobbered".
+  home.file.".claude/skills/browser/SKILL.md".source =
+    config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/scripts/browser-bridge/SKILL.md";
+  home.file.".claude/skills/browser/browser".source =
+    config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/scripts/browser-bridge/browser";
   # Claude Code hooks managed here (the script only — the settings.json
   # registration is per-host/unmanaged, like bash-guard.py). audit-pr-nudge fires
   # PostToolUse on `gh pr create` and injects context so Claude reflexively offers

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -112,7 +112,7 @@ Prefix any op with `--instance <key>` to target a specific connected profile
 | `browser [--instance K] [--tab T] [--frame F] click <selector>` | click the element's center — **TRUSTED** CDP on the top frame; **SYNTHETIC** (`chrome.scripting`) inside a cross-origin `--frame` |
 | `browser [--instance K] [--tab T] [--frame F] type <text> [--selector S]` | text input — **TRUSTED** CDP top frame; **SYNTHETIC** in-frame (focus `--selector` first if given) |
 | `browser [--instance K] [--tab T] [--frame F] key <Enter\|Tab\|Escape\|Backspace\|Delete\|Arrow*\|Home\|End\|Page*> [--selector S]` | dispatch one bounded key — **TRUSTED** CDP top frame; **SYNTHETIC** in-frame |
-| `browser [--instance K] [--tab T] activate [--wait MS \| --no-wait]` | **FOREGROUND** the owned/active tab so a foreground-throttled SPA finishes loading, then can be driven. **⚠ STEALS FOCUS — the ONE intrusive op** (it changes what the user sees; every other op is non-intrusive). Waits (bounded, default ~3s, cap ~8s) for `status:"complete"` + a paint settle unless `--no-wait`; `--wait MS` overrides. Returns `{tabId,windowId,url,title,active,status}`. **i3 caveat:** sets the tab active within its window and requests window focus, but on a tiling WM Chrome may NOT raise the window across workspaces (best-effort). |
+| `browser [--instance K] [--tab T] activate [--wait MS \| --no-wait]` | **FOREGROUND** the owned/active tab so a foreground-throttled SPA finishes loading, then can be read/driven. **⚠ STEALS FOCUS — the ONE intrusive op** (it changes what the user sees; every other op is non-intrusive). Foregrounds via **host-side `i3-msg`** (Chrome-side `tabs.update`/`windows.update` is a no-op on i3), so it works ONLY on a graphical i3 host; returns an extra **`i3:"applied"\|"skipped"\|"failed"`** field alongside `{tabId,windowId,url,title,active,status}`. Waits (bounded, default ~3s, cap ~8s) for `status:"complete"` + a paint settle unless `--no-wait`; `--wait MS` overrides. See "Driving a throttled SPA" below. |
 | `browser [--instance K] agent "<goal>" [flags]` | run the **autonomous opencode browser-agent** in its OWN isolated tab against `<goal>`; returns a compact `{answer,evidence,steps_used,status}` (see below) |
 | `browser --print-session-id`               | print the derived per-session id (debug) and exit |
 
@@ -235,6 +235,42 @@ Two traps that produce a confidently-wrong result:
 - *(Future option, NOT implemented: a `chrome.debugger` + CDP
   `Page.captureScreenshot` path could capture an off-screen tab, but it needs the
   `debugger` permission and shows a debug banner — deliberately out of scope.)*
+
+## Driving a throttled/backgrounded SPA (the `activate` pattern)
+
+A heavy SPA opened in a **backgrounded** tab is throttled by Chrome —
+`document.visibilityState:"hidden"`, so its timers/RAF are starved and it often
+**never finishes rendering**. You then can't read or drive it: `text`/`frames`
+come back empty or half-built, and in-frame `click`/`type` hit elements that don't
+exist yet. Verified case: `model-benchmarking.civit.ai` (an OOPIF inside a
+`civitai.com` tab) stayed blank while backgrounded.
+
+`activate` fixes this by **foregrounding the tab** so it un-throttles
+(`visibilityState:"visible"`) and the app paints. On i3 the foregrounding is done
+**host-side via `i3-msg`** (Chrome's own `tabs.update`/`windows.update` is a no-op
+under a tiling WM), and the result carries `i3:"applied"|"skipped"|"failed"` so you
+can confirm it actually raised the window.
+
+**Verified pattern to read & drive a cross-origin app:**
+
+```bash
+BB=~/workspace/devrc/scripts/browser-bridge/browser
+$BB --instance work open https://civitai.com/apps/run/model-benchmarking  # backgrounded
+$BB --instance work activate            # → visibilityState:"visible", app renders
+$BB --instance work frames              # now the OOPIF is listed
+$BB --instance work --frame model-benchmarking text    # read inside it
+$BB --instance work --frame model-benchmarking click 'button:has-text("Grid")'  # drive it
+```
+
+**Caveats (document honestly):**
+- **`activate` STEALS FOCUS** — it's the one intentionally-intrusive op; it changes
+  what the user sees. Restore their focus afterward if it matters
+  (`i3-msg '[id="<prev-winid>"] focus'`).
+- **i3-gated:** it only works on a graphical i3 host (it shells out to `i3-msg`); on
+  a headless/non-i3 host expect `i3:"skipped"` (or `"failed"`) and no foregrounding.
+- **In-frame `click`/`type` are SYNTHETIC** (`isTrusted:false`, the `chrome.scripting`
+  OOPIF path) — but were verified to actually drive the real app (the Grid tab got
+  selected). Top-frame input remains TRUSTED CDP.
 
 ## `browser agent "<goal>"` — autonomous read/navigate in an isolated tab
 


### PR DESCRIPTION
Two changes so the `browser` Claude Code skill is current AND provisioned reproducibly from the repo on both hosts.

## 1. SKILL.md — refresh the `activate` docs (#196/#197, live-verified)
The `activate` section was last written for #195 (old Chrome-side behavior, a stale "i3 may not raise" caveat). Updated to reality:
- `activate` foregrounds the tab **host-side via `i3-msg`** (Chrome-side `tabs.update`/`windows.update` is a no-op on i3) and returns an `i3:"applied"|"skipped"|"failed"` field.
- New **"Driving a throttled/backgrounded SPA"** section documenting WHY it exists: a backgrounded heavy SPA (e.g. `model-benchmarking.civit.ai` inside civitai) is throttled (`visibilityState:"hidden"`) and never renders, so you can't read/drive it. The verified pattern is `open` (backgrounded) → `activate` (→ `visible`, app paints) → `frames`/`--frame text`/`--frame click` to read & drive the cross-origin app.
- Honest caveats: `activate` STEALS FOCUS (the one intentionally-intrusive op); it's i3-gated (graphical i3 host only); in-frame `click`/`type` are SYNTHETIC (`isTrusted:false`) but were verified to drive the real app (Grid tab selected). The rest of SKILL.md (frames/click/type/key/text/`eval --frame`/screenshot, from #190/#192/#194) was already current and is unchanged.

## 2. nix/home.nix — provision the skill from the repo (reproducible on both hosts)
Added declarative provisioning of the skill's two symlinks via home-manager's out-of-store helper:

```nix
home.file.".claude/skills/browser/SKILL.md".source =
  config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/scripts/browser-bridge/SKILL.md";
home.file.".claude/skills/browser/browser".source =
  config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/scripts/browser-bridge/browser";
```

`mkOutOfStoreSymlink` points at the **mutable** repo checkout (outside the nix store), so `home-manager switch` on any host recreates `~/.claude/skills/browser/{SKILL.md,browser}` pointing at the editable repo files — the skill always tracks the working tree (edit SKILL.md/CLI, no switch needed to see it).

**Why this is the right exception:** per repo convention `~/.claude/skills/` is normally per-host and synced by `ship.sh`, and the other skills are read-only store symlinks from `devrc/claude/skills/`. But the `browser` skill's source of truth is the **browser-bridge subsystem in this repo** (`scripts/browser-bridge/`), not `devrc/claude/skills/` — so the correct "ship via repo" mechanism is an out-of-store symlink into that subsystem, keeping it editable in place. This is additive to `ship.sh`'s skills rsync (no-delete; identical symlinks on both hosts are a no-op). It replaces the previously **hand-made, non-reproducible** symlinks.

## ⚠ One-time operator step (per host, before the first switch)
The pre-existing MANUAL symlinks at `~/.claude/skills/browser/` will block home-manager from taking them over ("would be clobbered" — `home.file.force` does not clobber unmanaged files). On **each host**, once:

```sh
rm ~/.claude/skills/browser/{SKILL.md,browser}
home-manager switch --flake ~/workspace/devrc --impure   # or scripts/ship.sh
ls -l ~/.claude/skills/browser/                          # nix-managed symlinks
browser health                                           # still works
```

I did NOT run this / did NOT run `home-manager switch` / did NOT touch `~/.claude`.

## Verification
- `nix-instantiate --parse nix/home.nix` → PARSE_OK
- `bash -n scripts/browser-bridge/browser` → BASH_OK (untouched, sanity)
- SKILL.md re-reads coherently.
- NOT applied: home-manager switch was not run (staged for the operator per the step above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
