### PR TITLE
fix(repo-cos): make the initiative tag==slug invariant structural + cover the scan→last_emailed join

### DIFF
--- a/scripts/repo-cos/README.md
+++ b/scripts/repo-cos/README.md
@@ -168,13 +168,21 @@ it only collects the full proposal; the **only new network** is the clawgate POS
   `HANDOFF-comfyui-session`, `2026-07-21`, `868j34n9y-…`, `actionable-next-steps` — each drop
   logged with its rule) and `clawgate.normalize_tags` (clawgate's grammar: lowercase,
   `[a-z0-9._/-]`, ≤1 `:`, ≤64 runes, ≤20 tags; anything invalid is **dropped, not mangled**).
-  Live measurement (2026-07-30, 139 slugs in `initiatives.current`): 10 denylist drops + 3
-  lost to the 64-rune cap → **126 taggable**.
-- **🔴 An emitted tag always equals its ledger slug, byte-for-byte.** `normalize_tag`
-  lowercases, so a slug carrying any uppercase letter would be emitted as a tag that no longer
-  matches the ledger and the initiatives-side join would silently miss. Rather than mangle,
-  the denylist drops it (`not-lowercase`). A missing tag is cheap; a tag that joins to nothing
-  is a lie.
+  Measured over `tests/fixtures/initiatives_current_slugs.txt` — a **hand-refreshed snapshot**
+  of `initiatives.current`, last taken 2026-07-30 at **140 slugs**: 10 denylist drops + 3 lost
+  to the 64-rune cap → **127 taggable**. Those numbers are pinned by `test_routing.py`, but
+  **against the snapshot, not the live store**: the suite is deliberately hermetic (see
+  `tests/conftest.py`), so no test can tell you the fixture has gone stale — it already drifted
+  once (139 → 140) with everything green. Re-run the command in the fixture header to refresh
+  it, then re-state these counts.
+- **🔴 An emitted tag always equals its ledger slug, byte-for-byte.** This is enforced
+  **structurally** in `clawgate.build_tags`: the normalized tag is compared against the exact
+  `initiative:<slug>` we asked for and **dropped on any difference**. The denylist alone is not
+  sufficient — it polices only `normalize_tag`'s lowercasing (`not-lowercase`), while the same
+  function also collapses whitespace to `-` and strips leading/trailing `-`, so a slug like
+  `foo bar` or `trailing-dash-` would clear the denylist and be emitted **rewritten**, joining
+  to nothing. No live slug has that shape today, which is precisely why the guarantee must not
+  rest on a snapshot of the store. A missing tag is cheap; a tag that joins to nothing is a lie.
 - **🔴 Tagging must never cost an approval.** Because suppression is POST-success-gated, a
   tag-induced `400` would silently lose the approval for a week. Backstop: **HTTP `400` on a
   tagged POST retries EXACTLY ONCE with the `tags` key removed** (both the failure and the

--- a/scripts/repo-cos/clawgate.py
+++ b/scripts/repo-cos/clawgate.py
@@ -259,6 +259,11 @@ def build_tags(proposal) -> list[str]:
     field simply yields no tag. It is then filtered by `routing.taggable_slug` (drops
     document/date/id/filler slugs) and normalized to the tag grammar.
 
+    🔴 The emitted tag ALWAYS equals `initiative:<ledger-slug>` byte-for-byte, enforced
+    STRUCTURALLY: the normalized result is compared to the exact tag we asked for and
+    dropped on ANY difference (see the guard below). The denylist alone is not enough —
+    it polices only one of `normalize_tag`'s mutations.
+
     ── SEAM: a future `runbook:<name>` tag ────────────────────────────────────────────
     Deliberately NOT emitted today. `runbook:` is HARD-validated by clawgate
     (`runbooks.GetRunbookByName`) so an unknown name 400s the POST — and there is
@@ -281,7 +286,26 @@ def build_tags(proposal) -> list[str]:
         if not keep:
             return []
         raw = [f"initiative:{keep}"]
-        return normalize_tags(raw)
+        tags = normalize_tags(raw)
+        # 🔴 STRUCTURAL JOIN GUARD. The initiatives-side join matches on `tag == slug`
+        # byte-for-byte, so the ONLY acceptable outcome is the exact tag we asked for.
+        # `normalize_tag` performs THREE mutations — lowercase, whitespace→`-`, and a
+        # `-` strip — and the `routing` denylist only polices the first (`not-lowercase`).
+        # A slug like `foo bar`, `x  y` or `trailing-dash-` would therefore survive the
+        # denylist and be emitted REWRITTEN (`initiative:foo-bar`), joining to nothing.
+        # No live slug has that shape today, so pinning it with another denylist rule
+        # would only re-encode a SNAPSHOT of the store. Comparing the normalizer's
+        # OUTPUT to its input instead makes the invariant hold structurally: any future
+        # slug, and any fourth mutation added to `normalize_tag`, is caught here. A drop
+        # is the correct degradation — a missing tag is cheap, a tag that joins to
+        # nothing is a lie (and the untagged Task is still posted either way).
+        want = [f"initiative:{keep}"]
+        if tags != want:
+            _log(f"dropping initiative tag for slug {keep!r} — the tag grammar would "
+                 f"emit {tags!r}, not {want!r}; an emitted tag must equal its ledger "
+                 f"slug byte-for-byte or the initiatives-side join misses")
+            return []
+        return tags
     except Exception as exc:  # noqa: BLE001 - a tag must NEVER cost an approval
         _log(f"build_tags failed (posting untagged): {exc}")
         return []
@@ -327,7 +351,19 @@ def post_task(directory: str, body: str, *, repo: str = "", model: str = "",
     a second doomed call, and 408 — a proxy request-timeout raised AFTER the origin may
     already have created the Task — is the one shape where retrying could double-POST two
     Task cards. Connection errors and 5xx are likewise not retried: one hung weekly run
-    must not turn into a retry loop."""
+    must not turn into a retry loop.
+
+    ⚠ KNOWN DIVERGENCE — `400` is a CROSS-REPO WIRE CONTRACT WITH NO TEST ON EITHER SIDE.
+    "an invalid tag ⇒ HTTP 400" lives in clawgate's task-tags spec §6, in clawgate's Go
+    handler, and here. Nothing on either side asserts it, and clawgate ships from a
+    different repo on its own cadence. If clawgate ever moves tag rejection to 422
+    (unprocessable) or 409, this backstop stops firing and repo-cos SILENTLY degrades
+    from *losing the tag* to *losing the approval* — the proposal is not suppressed, so
+    it just re-nags a week later and the only trace is one `POST … failed: HTTP 422`
+    line in the weekly run log. So: the literal `400` below is LOAD-BEARING, not
+    incidental. Widening the retry set is not free either (see the 408 double-POST
+    hazard above) — the fix if clawgate changes is to update this code to match the new
+    code, not to retry everything."""
     c = creds if creds is not None else load_creds()
     api = (c.get("CLAWGATE_API_URL") or "").rstrip("/")
     token = c.get("CLAWGATE_HOOK_TOKEN") or ""

--- a/scripts/repo-cos/exclusions.py
+++ b/scripts/repo-cos/exclusions.py
@@ -296,6 +296,19 @@ def attach_related(proposal_dicts: list[dict], related) -> list[dict]:
     differs from `proposal_dicts` is therefore treated as a BUG: log loudly and attach
     NOTHING (no tag beats a wrong tag). Never raises — the best-effort contract holds.
 
+    ⚠ KNOWN DIVERGENCE from `digest.render` on that same misalignment. `render` stamps
+    the breadcrumb positionally too, but tolerates a SHORT list (`related[i-1] if i-1 <
+    len(related) else None`) — it prefix-stamps whatever it has. So in the hypothetical
+    misaligned case the two paths disagree: the EMAIL would show `↳ relates to: <slug>`
+    on the first N proposals while `last_emailed.json` (and therefore the clawgate task
+    tag) carries NO `initiative` at all. That asymmetry is DELIBERATE and in the safe
+    direction — the breadcrumb is display-only and re-read by a human, whereas the
+    stamped field is a durable routing key a later run acts on unattended, so the
+    durable path fails closed and the display path degrades gracefully. Worth knowing
+    when debugging: an email breadcrumb with no corresponding tag is a legitimate
+    symptom of a misalignment bug, not a tagging bug. Fix the caller, not either
+    stamper. (Today's single caller threads one list to both, so it cannot happen.)
+
     Mutates + returns the dicts."""
     try:
         if related and len(related) != len(proposal_dicts):

--- a/scripts/repo-cos/tests/fixtures/initiatives_current_slugs.txt
+++ b/scripts/repo-cos/tests/fixtures/initiatives_current_slugs.txt
@@ -1,10 +1,17 @@
 # SNAPSHOT of `select slug from initiatives.current order by 1;` — the REAL, MINED
 # initiative vocabulary the `initiative:<slug>` tag is drawn from.
 #
-# Taken 2026-07-30 (139 slugs). Regenerate with:
+# Taken 2026-07-30 (140 slugs). Regenerate with:
 #   kubectl --kubeconfig ~/workspace/homelab-talos/homelab-kubeconfig -n mailbox \
 #     exec mailbox-postgres-0 -- sh -c 'psql -U ${POSTGRES_USER:-mail} \
 #     -d ${POSTGRES_DB:-mail} -tAc "select slug from initiatives.current order by 1;"'
+#
+# ⚠ This is a SNAPSHOT, refreshed BY HAND. Nothing in the suite reads the live store
+# (see tests/conftest.py — the whole run is deliberately hermetic), so no test can tell
+# you this file has gone stale; only re-running the command above can. Expect drift: the
+# store is mined continuously and grew by one slug between the feature landing and its
+# first follow-up. When you refresh it, re-state the counts in test_routing.py's corpus
+# tests and in README.md rather than letting them silently disagree with reality.
 #
 # Used by test_routing.py to pin the corpus-wide properties of the taggable-slug
 # denylist (notably: an emitted tag ALWAYS equals its ledger slug byte-for-byte).
@@ -93,6 +100,7 @@ delete-dispatch-flow-web
 delete-pod-stuck
 deleted-investigate-item-restore
 dependencies-improvements-repository-security
+deploy-comfyui-video-generation
 deref-quarantine-handoff
 deref-quarantine-sweeps-wet-autopilot
 detailer-hands-lora-output-portrait-walk-with

--- a/scripts/repo-cos/tests/test_approve.py
+++ b/scripts/repo-cos/tests/test_approve.py
@@ -734,6 +734,78 @@ def test_build_tags_never_raises_on_routing_failure(monkeypatch):
     assert clawgate.build_tags({"initiative": "clawgate-agent-loop-close"}) == []
 
 
+# ---- 7c. the STRUCTURAL join invariant ----------------------------------------------
+# `normalize_tag` performs THREE mutations — lowercase, whitespace→`-`, `.strip("-")` —
+# and the routing denylist polices only the first (`not-lowercase`). These slugs clear the
+# denylist but WOULD be rewritten by the grammar layer, which is exactly the shape that
+# breaks the `tag == slug` join. build_tags must drop them, not emit the rewrite.
+_SLUGS_THE_GRAMMAR_WOULD_REWRITE = (
+    "foo bar",          # whitespace → '-'  (→ initiative:foo-bar)
+    "x  y",             # collapsed run of whitespace
+    "trailing-dash-",   # .strip('-')        (→ initiative:trailing-dash)
+    "-leading-dash",    # .strip('-') on the other end
+    "tab\tseparated",   # _WS_RE covers all whitespace, not just ' '
+    " padded-slug ",    # NB: build_tags strips first, so this one is NOT a rewrite
+)
+
+# Slugs that must still tag, verbatim — the guard has to be a scalpel, not a mute button.
+_SLUGS_THAT_MUST_STILL_TAG = (
+    "clawgate-agent-loop-close",
+    "deploy-comfyui-video-generation",
+    "security-audit-v0.1.64",
+    "remix/composer",
+    "dp_prod.latency",
+)
+
+
+def test_build_tags_emitted_tag_always_equals_its_slug_exactly():
+    """🔴 THE INVARIANT, as a PROPERTY over every shape above: build_tags returns either
+    NOTHING or exactly `[f"initiative:{slug}"]`. It may never return a third thing (a
+    rewritten tag), because the initiatives-side join matches on the slug byte-for-byte
+    and a rewritten tag joins to nothing while looking perfectly healthy."""
+    for slug in _SLUGS_THE_GRAMMAR_WOULD_REWRITE + _SLUGS_THAT_MUST_STILL_TAG:
+        tags = clawgate.build_tags({"initiative": slug})
+        assert tags in ([], [f"initiative:{slug.strip()}"]), (slug, tags)
+
+
+def test_build_tags_drops_every_slug_the_grammar_would_rewrite():
+    """The property asserted STRUCTURALLY rather than by enumerating known shapes: derive
+    the 'would be rewritten' set from `normalize_tag` ITSELF, then require build_tags to
+    emit nothing for each. If someone adds a FOURTH mutation to normalize_tag, the new
+    shape lands in `mutating` automatically and this test covers it without being edited —
+    which is the whole point of guarding in build_tags instead of adding a denylist rule
+    per mutation."""
+    import routing
+    mutating = []
+    for slug in _SLUGS_THE_GRAMMAR_WOULD_REWRITE:
+        keep = routing.taggable_slug(slug)
+        if keep is None:
+            continue  # already handled upstream by the denylist — not this guard's job
+        if clawgate.normalize_tag(f"initiative:{keep}") != f"initiative:{keep}":
+            mutating.append(slug)
+    # guard against a VACUOUS pass: if none of the shapes reach the grammar layer intact,
+    # this test proves nothing and the corpus above needs new shapes.
+    assert mutating, "no sample slug survives the denylist AND gets rewritten — vacuous"
+    for slug in mutating:
+        assert clawgate.build_tags({"initiative": slug}) == [], slug
+
+
+def test_build_tags_logs_why_it_dropped_a_rewritten_tag(capsys):
+    # A silent drop would be indistinguishable from "no initiative resolved" in the weekly
+    # run log, so the guard must say which slug it refused and what the grammar wanted.
+    assert clawgate.build_tags({"initiative": "foo bar"}) == []
+    err = capsys.readouterr().err
+    assert "foo bar" in err
+    assert "initiative:foo-bar" in err
+
+
+def test_build_tags_guard_never_raises_and_never_costs_the_post():
+    # The load-bearing contract: the guard may only ever DROP a tag. It must not raise
+    # (post_task would never be reached) — a dropped tag is fine, a failed POST is not.
+    for slug in _SLUGS_THE_GRAMMAR_WOULD_REWRITE:
+        assert isinstance(clawgate.build_tags({"initiative": slug}), list)
+
+
 # ---- 7c. post_task payload + back-compat --------------------------------------------
 
 def test_post_task_includes_tags_when_passed():

--- a/scripts/repo-cos/tests/test_routing.py
+++ b/scripts/repo-cos/tests/test_routing.py
@@ -316,29 +316,47 @@ def test_an_all_lowercase_slug_is_kept_verbatim():
 
 # --------------------------------------------------------------------------- #
 # CORPUS PROPERTIES — asserted over a SNAPSHOT of the real `initiatives.current`
-# vocabulary (tests/fixtures/initiatives_current_slugs.txt, 139 slugs, 2026-07-30).
+# vocabulary (tests/fixtures/initiatives_current_slugs.txt, 140 slugs, 2026-07-30).
 # Hermetic: the file is a checked-in snapshot, never a live read.
+#
+# ⚠ WHAT THESE CAN AND CANNOT CATCH. Every number below is pinned against the FIXTURE,
+# not against the live store, so they detect an unreviewed EDIT to the fixture or a
+# behaviour change in the denylist — never that the live vocabulary has moved on. It
+# already has once (139 → 140 between the feature landing and this follow-up) with the
+# suite fully green. Refreshing the fixture is a manual step; the command is in its
+# header. That trade is deliberate: a live read here would make the whole suite depend
+# on cross-cluster reachability, which tests/conftest.py exists specifically to prevent.
 # --------------------------------------------------------------------------- #
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 
 
-def _live_slug_corpus() -> list[str]:
+def _slug_corpus() -> list[str]:
+    """The checked-in SNAPSHOT of `initiatives.current` — not a live read (see above)."""
     lines = FIXTURES.joinpath("initiatives_current_slugs.txt").read_text().splitlines()
     return [ln.strip() for ln in lines if ln.strip() and not ln.startswith("#")]
 
 
-def test_corpus_snapshot_is_the_expected_size():
-    # Guards the numbers the properties below are stated in. If the store grew, refresh the
-    # fixture (command in its header) and re-state the counts — don't silently drift.
-    assert len(_live_slug_corpus()) == 139
+def test_corpus_fixture_self_check_not_a_live_drift_detector():
+    """SELF-CHECK on the checked-in fixture — deliberately NOT a live-store drift detector.
+
+    All this proves is that the fixture still holds the number of slugs the properties
+    below are stated in, i.e. it fails only if someone edits the file without re-stating
+    the counts. It CANNOT fail because `initiatives.current` grew, since nothing here
+    reads the store. Do not read a green suite as "the snapshot is current" — refresh it
+    with the command in the fixture header (and re-state these counts + README.md)."""
+    assert len(_slug_corpus()) == 140
 
 
 def test_every_emitted_tag_equals_its_ledger_slug_exactly(capsys):
-    """🔴 THE JOIN INVARIANT. For every slug in the real vocabulary, the tag we would emit
-    is either absent or EXACTLY `initiative:<slug>` — never a lowercased/mangled variant.
-    This is what the not-lowercase rule buys: no tag can point at a slug that isn't there."""
+    """🔴 THE JOIN INVARIANT, over the whole real vocabulary and through the REAL emission
+    path (`clawgate.build_tags`, not just the grammar layer): every slug yields either NO
+    tag or EXACTLY `initiative:<slug>` — never a lowercased/whitespace-collapsed/mangled
+    variant. Enforced structurally in build_tags; the denylist's not-lowercase rule only
+    keeps that from throwing away tags we could have kept."""
     import clawgate  # noqa: PLC0415 - local: keeps the routing-only tests import-light
-    for slug in _live_slug_corpus():
+    for slug in _slug_corpus():
+        # the emission path, end to end: a slug on a proposal → the tag list posted.
+        assert clawgate.build_tags({"initiative": slug}) in ([], [f"initiative:{slug}"]), slug
         keep = routing.taggable_slug(slug)
         if keep is None:
             continue
@@ -350,25 +368,28 @@ def test_every_emitted_tag_equals_its_ledger_slug_exactly(capsys):
 
 
 def test_corpus_denylist_drop_counts_are_pinned(capsys):
-    """The live measurement this rule change was justified by: 139 slugs → 10 denylist
-    drops (4 all-caps + 2 mixed-case + 1 bare date + 1 opaque id + 2 generic) → 129 pass
-    the denylist → 3 more lost to the 64-rune tag cap → 126 actually taggable."""
+    """The measurement this rule change was justified by, restated against the CURRENT
+    fixture (2026-07-30, 140 slugs): 10 denylist drops (4 all-caps + 2 mixed-case + 1 bare
+    date + 1 opaque id + 2 generic) → 130 pass the denylist → 3 more lost to the 64-rune
+    tag cap → 127 actually taggable. These are fixture numbers, not live ones — see the
+    section header. (The one slug added since the feature landed,
+    `deploy-comfyui-video-generation`, is taggable, so only the totals moved.)"""
     import clawgate  # noqa: PLC0415
     from collections import Counter
-    corpus = _live_slug_corpus()
+    corpus = _slug_corpus()
     reasons = Counter(r for r in (routing.slug_drop_reason(s) for s in corpus) if r)
     assert reasons == {"not-lowercase": 6, "no-letters": 1, "opaque-id": 1, "generic": 2}
     kept = [s for s in corpus if routing.slug_drop_reason(s) is None]
-    assert len(kept) == 129
+    assert len(kept) == 130
     taggable = [s for s in kept if clawgate.normalize_tags([f"initiative:{s}"])]
-    assert len(taggable) == 126
+    assert len(taggable) == 127
     capsys.readouterr()
 
 
 def test_the_two_mixed_case_corpus_slugs_are_now_dropped(capsys):
     # The exact slugs this rule change added to the drop set — pinned by name so a
     # regression is legible, not just a count that moved.
-    corpus = _live_slug_corpus()
+    corpus = _slug_corpus()
     for slug in ("HANDOFF-comfyui-session", "SECURITY-AUDIT-v0.1.64"):
         assert slug in corpus, f"{slug} left the store — refresh the fixture"
         assert routing.slug_drop_reason(slug) == "not-lowercase"

--- a/scripts/repo-cos/tests/test_scan_cli.py
+++ b/scripts/repo-cos/tests/test_scan_cli.py
@@ -254,3 +254,89 @@ def test_no_fetch_flag_threads_into_scan_all(tmp_path, monkeypatch):
     args = scan.build_parser().parse_args(["--no-llm", "--repos", str(tmp_path)])
     scan.cmd_scan(args)
     assert seen["fetch"] is True
+
+
+# ---- INITIATIVE THREADING: router → cmd_scan → last_emailed.json -------------------
+# 🔴 THE FEATURE'S CENTRAL WIRING, and until now the one part with NO coverage. Both
+# HALVES were tested in isolation — test_routing proves `related_for` resolves slugs, and
+# test_approve proves the approve path tags from a HAND-WRITTEN `last_emailed.json` — but
+# nothing exercised the JOIN between them: that cmd_scan actually carries the resolved
+# slugs from the router into the file the approve path later reads. Mutation testing on
+# the merged code confirmed the gap: BOTH `related = routing.related_for(...)` → `[None]*n`
+# (scan.py:244) and `related=related` → `related=None` at the write_last_emailed call
+# (scan.py:381) left the entire 303-test suite green. If the threading silently broke,
+# every Task would post untagged and neither the tests nor production would say a word.
+#
+# This test drives the REAL cmd_scan end to end with only the two true externalities
+# stubbed (the LLM, and the SMTP send), and asserts the slug lands in the durable file.
+# It is written to FAIL under either mutation above — verify that before trusting it.
+#
+# `--email` is required because it is the ONLY path that writes last_emailed.json; the
+# send itself is stubbed, so no real digest is ever sent.
+
+def test_cmd_scan_threads_resolved_initiative_slugs_into_last_emailed(tmp_path, monkeypatch):
+    import json
+
+    import clawgate
+    import exclusions
+    import feedback as feedback_mod
+    import llm
+    import routing
+
+    dev = tmp_path / "devrc"
+    dev.mkdir()
+    (dev / "a.py").write_text("# TODO fix the thing\n")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "k")
+    monkeypatch.setattr(scan, "PERSIST_DIR", tmp_path / "state")
+    monkeypatch.setattr(exclusions, "LAST_EMAILED_FILE", tmp_path / "last_emailed.json")
+    monkeypatch.setattr(exclusions, "EXCLUSIONS_FILE", tmp_path / "exclusions.json")
+    monkeypatch.setattr(feedback_mod, "fetch_last_feedback", lambda: None)
+
+    # RE-PATCH the suite-wide hermeticity stub (conftest.py pins load_current to an EMPTY
+    # store). A later setattr on the same function-scoped monkeypatch wins, and both are
+    # undone in reverse at teardown — so this stays hermetic: still no live store read.
+    route = routing._route()
+    monkeypatch.setattr(route, "load_current", lambda: [
+        {"slug": "clawgate-agent-loop", "repo": str(dev),
+         "title": "Clawgate agent loop close"},
+        {"slug": "tekton-pipeline", "repo": str(dev), "title": "Tekton pipeline migration"},
+    ])
+
+    # Two proposals: the first matches an initiative confidently, the second matches
+    # nothing — so a bug that stamps a CONSTANT slug on everything also fails here.
+    matching = _RealishProp("harden the clawgate agent loop")
+    unrelated = _RealishProp("zzz unrelated proposal about nothing")
+    for p in (matching, unrelated):
+        p.repo, p.why, p.approach = "devrc", "", ""
+    monkeypatch.setattr(llm, "synthesize", lambda cands, *, top, model, feedback=None:
+                        llm.Synthesis(proposals=[matching, unrelated],
+                                      approx_prompt_tokens=1))
+
+    # STUB THE SEND. --email is the only branch that writes last_emailed.json; the real
+    # send_digest would deliver an actual digest to Zach's inbox.
+    import email_send
+    sent = {}
+
+    def fake_send(*, subject, body, **kw):
+        sent["subject"], sent["body"] = subject, body
+        return "repo-cos@inbox.zacx.dev"
+
+    monkeypatch.setattr(email_send, "send_digest", fake_send)
+
+    args = scan.build_parser().parse_args(["--email", "--repos", str(dev)])
+    assert scan.cmd_scan(args) == 0
+    assert sent, "the digest send was never reached — nothing wrote last_emailed.json"
+
+    # 1) the resolved slug is DURABLE: it reached the file the approve path reads.
+    payload = json.loads((tmp_path / "last_emailed.json").read_text())
+    props = payload["proposals"]
+    assert len(props) == 2
+    assert props[0]["initiative"] == "clawgate-agent-loop", props[0]
+    # 2) index-aligned, not blanket-stamped: the unmatched proposal carries no slug.
+    assert "initiative" not in props[1], props[1]
+    # 3) the whole point of persisting it — the approve path can now build the tag.
+    assert clawgate.build_tags(props[0]) == ["initiative:clawgate-agent-loop"]
+    assert clawgate.build_tags(props[1]) == []
+    # 4) and the emailed digest showed the SAME slug as a breadcrumb (the tag must equal
+    #    what Zach saw when he approved).
+    assert "↳ relates to: clawgate-agent-loop" in sent["body"]


### PR DESCRIPTION
Closes the two post-merge follow-ups from the adversarial audit of #198, plus two honesty fixes. **Gate: 308 passed / 0 failed** (baseline 303). No runtime behaviour change except Fix 1, which can only ever *drop* a tag.

## Fix 1 — the `tag == slug` invariant is now STRUCTURAL, not snapshot-pinned

The feature's contract is that an emitted tag equals its ledger slug **exactly**, so a future initiatives-side join can match on it. That was enforced by a denylist rule (`not-lowercase`) — but `normalize_tag` performs **three** mutations and the denylist policed only one. Reproducible on merged `main`:

```
'foo bar'         → drop=None → ['initiative:foo-bar']        invariant BROKEN
'trailing-dash-'  → drop=None → ['initiative:trailing-dash']  invariant BROKEN
'x  y'            → drop=None → ['initiative:x-y']            invariant BROKEN
```

`_WS_RE.sub("-", …)` and `.strip("-")` were unguarded. No live slug has that shape today — which is exactly the problem: the guarantee rested on a **snapshot of the store**, not on structure.

`clawgate.build_tags` (`clawgate.py:289-306`) now emits only when `normalize_tags` returns exactly `[f"initiative:{keep}"]`, and drops + logs otherwise. That holds for any future slug and for any *fourth* mutation someone adds to `normalize_tag` — the deterministic fix, rather than another denylist rule chasing each mutation.

The load-bearing property is preserved: the guard can only **drop**. It never raises, so it can never cost an approval (a dropped tag is fine, a failed POST is not).

Tests (`test_approve.py:738-810`): the three shapes yield **no tag** (not a rewritten one); clean slugs still tag verbatim; the drop is logged. `test_build_tags_drops_every_slug_the_grammar_would_rewrite` derives the "would be rewritten" set **from `normalize_tag` itself** rather than enumerating shapes, and asserts non-vacuousness — so a fourth mutation is covered without editing the test. The corpus test now also runs the real `build_tags` path over all 140 live slugs.

## Fix 2 — the feature's central wiring was UNTESTED (the important one)

Mutation testing proved both of these left **all 303 tests passing** on merged `main`:

| mutation | site |
|---|---|
| `related=related` → `related=None` | `scan.py:381` (the `write_last_emailed` call) |
| `related = routing.related_for(...)` → `[None] * n` | `scan.py:244` |

Both halves were covered — `test_routing` proves the router resolves slugs, `test_approve` proves the approve path tags from a hand-written `last_emailed.json` — but **nothing exercised the join**. If the threading broke, every Task would post untagged and neither the tests nor production would say a word.

`test_scan_cli.py:257-343` drives the **real `cmd_scan`** end to end with only the two true externalities stubbed (the LLM, and the SMTP send), and asserts the resolved slug lands in `last_emailed.json`. It re-patches `route.load_current` over conftest's autouse empty-store stub (a later `setattr` on the same function-scoped `monkeypatch` wins), so the run stays hermetic — still no live store read.

It asserts four things: the slug is durable in the file; it is **index-aligned** (a second, unmatched proposal carries none — so a blanket-stamp bug also fails); it rebuilds into the tag via `build_tags`; and the emailed digest showed the **same** slug as a breadcrumb.

**🔴 Mutation-verified.** Each mutation was applied, the suite re-run, and reverted:

| mutation | result |
|---|---|
| `related=None` at `scan.py:381` | **1 failed, 307 passed** — only the new test |
| `[None] * n` at `scan.py:244` | **1 failed, 307 passed** — only the new test |

`scan.py` is byte-identical to `main` on this branch (`git diff --stat -- scan.py` is empty). `--email` is required because it is the only path that writes `last_emailed.json`; the send is stubbed, so no real digest was ever sent.

## Fix 3 — the corpus fixture had already drifted

Refreshed from the live store: **139 → 140 slugs** (new: `deploy-comfyui-video-generation`). Drop reasons are unchanged (`not-lowercase: 6, no-letters: 1, opaque-id: 1, generic: 2`); kept **129 → 130**, taggable **126 → 127**.

The honesty problem: `test_corpus_snapshot_is_the_expected_size` asserted the fixture's *own* length, so it could only fail if someone edited the fixture — it **could not detect that the live store had moved**, and indeed didn't. Renamed to `test_corpus_fixture_self_check_not_a_live_drift_detector` and documented as the self-check it is, with the same caveat in the fixture header, the section header, and the README.

I did **not** make it a genuine live drift detector: that would require a cross-cluster read, which `tests/conftest.py` exists specifically to prevent (it stubs `route.load_current` suite-wide precisely so the run doesn't depend on cluster reachability). Trading suite hermeticity for drift detection seemed the wrong call — so the fixture stays a hand-refreshed snapshot and every place that quotes its numbers now says so plainly. Flagging in case you'd rather have an opt-in (env-gated, skipped-by-default) live check instead.

`README.md:171-186` — the "Live measurement (2026-07-30, 139 slugs)" framing overstated what the test pins; restated with the refreshed numbers and what they're measured against.

## Fix 4 — two known divergences documented (docstrings, no behaviour change)

- **`exclusions.attach_related`** (`exclusions.py:299-312`): on a length mismatch it stamps nothing, but `digest.render` still positionally prefix-stamps a short list — so a hypothetical misalignment shows `↳ relates to: <slug>` in the email while `last_emailed.json` carries no tag. That's the safe direction (display-only degrades gracefully; the durable routing key fails closed), but the two paths disagree, and an email breadcrumb with no corresponding tag is a legitimate symptom of a *caller* bug.
- **`clawgate.post_task` retry** (`clawgate.py:355-366`): the "invalid tag ⇒ HTTP 400" coupling is a **cross-repo wire contract with no test on either side**. If clawgate ever moves tag rejection to 422/409, repo-cos degrades from *losing the tag* to *losing the approval*, silently, for a week — the only trace being one line in the weekly run log. Noted at the retry site so the next reader knows `400` is load-bearing, not incidental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
