### PR TITLE
feat(initiatives): consume clawgate `initiative:<slug>` tags — linked tasks in card detail + dispatch guard

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1061,10 +1061,22 @@ in
       # persistently-unbindable port doesn't spin.
       Restart = "on-failure";
       RestartSec = "10s";
+      # Every file the LONG-RUNNING viewer process holds in memory. The siblings are loaded
+      # ONCE by explicit importlib path at first use and then cached for the life of the
+      # process, so a change to any of them is invisible until the unit restarts — listing
+      # only viewer.py meant a tasks.py-only (or dispatch/archive/nextstep-only) change
+      # switched cleanly and then silently did nothing.
+      # ⚠ `initiative-scan.py` is in the same boat (attach_tmux caches the scan module) but is
+      # NOT listed: it belongs to the sync unit too, and a scan change already requires an
+      # explicit `systemctl --user restart initiatives-viewer.service` (see the skill's gotchas).
       X-Restart-Triggers = [
         "${../scripts/initiatives/run-viewer.sh}"
         "${../scripts/initiatives/viewer.py}"
         "${../scripts/initiatives/agent_client.py}"
+        "${../scripts/initiatives/tasks.py}"
+        "${../scripts/initiatives/dispatch.py}"
+        "${../scripts/initiatives/archive.py}"
+        "${../scripts/initiatives/nextstep.py}"
       ];
     };
     Install = {

--- a/scripts/initiatives/dispatch.py
+++ b/scripts/initiatives/dispatch.py
@@ -17,6 +17,7 @@ stdlib urllib, NEVER raises, returns the task id | None), adapted to an initiati
                                 no raw json dump).
   * `resolve_repo_fullname(repo_path)` → the view's `repo` IS an absolute local path, so read
                                 `git remote get-url origin` on it → GitHub `owner/name` | "".
+  * `build_tags(view)`        → `["initiative:<slug>"]` for the card being dispatched, or [].
   * `post_task(directory, body, ...)` → POST {API}/api/tasks (Bearer) → task id | None.
   * `dispatch_initiative(view)` → the convenience orchestrator the viewer endpoint calls:
                                 compute rec+title+body+repo, post, return {ok, task_id, error}.
@@ -28,6 +29,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import subprocess
 import sys
 import urllib.error
@@ -37,6 +39,27 @@ from pathlib import Path
 CLAWGATE_ENV = Path("~/.claude/clawgate.env").expanduser()
 POST_TIMEOUT = 15  # seconds — a hung clawgate must not stall the dispatch request
 TITLE_MAX = 80
+
+# ---- clawgate task-tag grammar (clawgate 0.7.75+, claudedocs/clawgate-task-tags-spec.md §3)
+# lowercase; charset [a-z0-9._/-]; at most ONE ':' separating namespace:value; <=64 runes per
+# tag; <=20 tags per task. A tag that violates the grammar 400s the WHOLE request, so it is
+# enforced client-side and anything that can't be made valid is DROPPED.
+#
+# 🔴 SOURCE OF TRUTH: `scripts/repo-cos/clawgate.py` (`normalize_tag`/`normalize_tags`), the
+# OTHER producer of `initiative:` tags. This is a DELIBERATE duplication, not an oversight:
+# importing across script dirs would make the board's dispatch path depend on repo-cos being
+# present in the same tree (they ship as independent script sets, and repo-cos/clawgate.py
+# lazily pulls in `routing`/`scan`), and a missing sibling would silently downgrade every
+# dispatch to untagged — the exact failure this feature exists to fix. ~30 lines of pure regex
+# is the cheaper coupling. If the grammar ever changes, change BOTH; the shared contract is
+# pinned by tests on both sides.
+TAG_MAX_LEN = 64
+TAG_MAX_COUNT = 20
+_TAG_BODY_RE = re.compile(r"^[a-z0-9._/-]+$")
+_WS_RE = re.compile(r"\s+")
+
+# The reserved namespace both producers write, and the key `tasks.py` joins on.
+INITIATIVE_TAG_PREFIX = "initiative:"
 
 # The pure recommendation deriver, loaded by explicit importlib path (the package's sibling
 # cross-load convention — NOT sys.path, whose mail-actions/llm.py would shadow). Lazy so a
@@ -267,6 +290,89 @@ def build_task_body(view: dict, recommendation: dict | None) -> str:
     return "\n".join(out)
 
 
+# ---- task tags -----------------------------------------------------------------------
+
+def normalize_tag(tag) -> str | None:
+    """Normalize ONE tag to clawgate's grammar, or None if it can't be made valid.
+
+    lowercase → trim → collapse internal whitespace to `-`, then validate: at most one `:`
+    (namespace separator), each side non-empty and drawn from `[a-z0-9._/-]`, whole tag <=64
+    runes. Anything else is DROPPED, never mangled. Mirrors `repo-cos/clawgate.normalize_tag`
+    (see the SOURCE OF TRUTH note at the top of this module)."""
+    try:
+        t = _WS_RE.sub("-", str(tag or "").strip().lower()).strip("-")
+    except Exception:  # noqa: BLE001
+        return None
+    if not t:
+        return None
+    if len(t) > TAG_MAX_LEN:
+        _log(f"dropping tag {t!r} — {len(t)} runes exceeds the {TAG_MAX_LEN}-rune cap")
+        return None
+    parts = t.split(":")
+    if len(parts) > 2:
+        _log(f"dropping tag {t!r} — more than one ':' (namespace:value only)")
+        return None
+    for part in parts:
+        if not part or not _TAG_BODY_RE.match(part):
+            _log(f"dropping tag {t!r} — not [a-z0-9._/-]")
+            return None
+    return t
+
+
+def normalize_tags(tags) -> list[str]:
+    """Normalize a tag list: drop the invalid, de-duplicate, sort, cap at 20. Never raises.
+    Sorted so the payload is deterministic (stable tests, stable clawgate render)."""
+    out: set[str] = set()
+    for raw in tags or []:
+        t = normalize_tag(raw)
+        if t:
+            out.add(t)
+    clean = sorted(out)
+    if len(clean) > TAG_MAX_COUNT:
+        _log(f"capping {len(clean)} tags to the first {TAG_MAX_COUNT}")
+        clean = clean[:TAG_MAX_COUNT]
+    return clean
+
+
+def build_tags(view: dict) -> list[str]:
+    """The clawgate task tags for the initiative being dispatched — at most one
+    `initiative:<slug>`. Never raises; `[]` on any doubt.
+
+    🔴 EXACT-OR-NOTHING. `tasks.py` joins a tag to a card by EXACT slug equality, so a
+    normalized-but-rewritten slug (`Foo Bar` → `foo-bar`) would produce a tag that joins to
+    NOTHING while looking like it worked — strictly worse than no tag, because it also arms
+    no guard and gives a false "this is linked" signal in the queue. So the slug is put
+    through the grammar and the result is only emitted when it comes back BYTE-IDENTICAL.
+    That is the same guarantee repo-cos gives ("the verbatim ledger slug or nothing"), stated
+    as an explicit equality check rather than relying on ledger slugs happening to be
+    already-normalized.
+
+    FAIL-OPEN is mandatory: a tag problem must never fail a dispatch. Every path here returns
+    a list — an untaggable slug returns `[]` and the Task is posted UNTAGGED (`post_task` adds
+    a second backstop: a tagged 400 retries once without tags).
+
+    NOTE: repo-cos additionally filters through `routing.taggable_slug` (a denylist for
+    document/date/id/filler slugs). That is right THERE — its slug comes from a fuzzy router
+    match and may be junk — and wrong HERE: this slug IS the ledger key of the card Zach just
+    tapped, so a denylist could only ever drop a tag for a real initiative."""
+    try:
+        slug = str((view or {}).get("slug") or "").strip()
+        if not slug:
+            _log("view has no slug — posting untagged")
+            return []
+        want = f"{INITIATIVE_TAG_PREFIX}{slug}"
+        got = normalize_tag(want)
+        if got != want:
+            # Either invalid (None) or rewritten. Both would join to nothing → emit nothing.
+            _log(f"slug {slug!r} cannot be tagged verbatim (would become {got!r}) — "
+                 "posting untagged rather than emitting a tag that joins to nothing")
+            return []
+        return [got]
+    except Exception as exc:  # noqa: BLE001 - a tag must NEVER cost a dispatch
+        _log(f"build_tags failed (posting untagged): {exc}")
+        return []
+
+
 # ---- HTTP post ---------------------------------------------------------------------
 
 def _post(url: str, payload: dict, token: str, *, timeout: int = POST_TIMEOUT) -> str:
@@ -282,14 +388,24 @@ def _post(url: str, payload: dict, token: str, *, timeout: int = POST_TIMEOUT) -
 
 
 def post_task(directory: str, body: str, *, repo: str = "", model: str = "",
-              creds: dict | None = None, _post=_post) -> int | None:
+              tags=None, creds: dict | None = None, _post=_post) -> int | None:
     """POST a Task to clawgate's `/api/tasks`. Returns the created task id (int) on success,
     else None. BEST-EFFORT: any error (no creds, unreachable, non-JSON, no id) is logged and
     yields None — NEVER raises. `creds`/`_post` are injectable for tests (no real network).
 
-    `repo` (a GitHub `owner/name`) and `model` pre-fill the Task's dispatch config; each is
-    added to the payload ONLY when non-empty, so a bare call sends exactly {"directory",
-    "body"}. OMITTING `model` → clawgate applies its own default (deepseek), which is correct."""
+    `repo` (a GitHub `owner/name`) and `model` pre-fill the Task's dispatch config; `tags`
+    (clawgate 0.7.75+) is the routing-key list that `tasks.py` joins back to the board. Each
+    is added to the payload ONLY when non-empty, so a bare call still sends exactly
+    {"directory", "body"} (backward-compatible). OMITTING `model` → clawgate applies its own
+    default (deepseek), which is correct.
+
+    🔴 TAGGING MUST NEVER COST A DISPATCH. Two defences, mirroring repo-cos: (1)
+    `normalize_tags` drops anything that can't satisfy clawgate's grammar before it reaches
+    the wire; (2) if a TAGGED post still fails with HTTP 400, retry EXACTLY ONCE with `tags`
+    removed — a tagged-post failure degrades to an untagged Task, never to no Task. The retry
+    is scoped to 400 alone because 400 is the ONLY grammar-rejection code (tag spec §6);
+    401/403/404/429 are not tag problems and would just burn a doomed call, and 408 is the one
+    shape where retrying could double-POST (the origin may already have created the Task)."""
     c = creds if creds is not None else load_creds()
     api = (c.get("CLAWGATE_API_URL") or "").rstrip("/")
     token = c.get("CLAWGATE_HOOK_TOKEN") or ""
@@ -303,11 +419,25 @@ def post_task(directory: str, body: str, *, repo: str = "", model: str = "",
         payload["repo"] = repo
     if model:
         payload["model"] = model
+    clean_tags = normalize_tags(tags)
+    if clean_tags:
+        payload["tags"] = clean_tags
     try:
         raw = _post(url, payload, token)
     except urllib.error.HTTPError as exc:  # noqa: PERF203
         _log(f"POST {url} failed: HTTP {exc.code} {exc.reason}")
-        return None
+        if not (clean_tags and exc.code == 400):
+            return None
+        _log(f"retrying ONCE without tags {clean_tags} — a tag must never cost a dispatch")
+        untagged = {k: v for k, v in payload.items() if k != "tags"}
+        try:
+            raw = _post(url, untagged, token)
+        except urllib.error.HTTPError as exc2:
+            _log(f"untagged retry also failed: HTTP {exc2.code} {exc2.reason}")
+            return None
+        except Exception as exc2:  # noqa: BLE001
+            _log(f"untagged retry also failed: {exc2}")
+            return None
     except Exception as exc:  # noqa: BLE001
         _log(f"POST {url} failed: {exc}")
         return None
@@ -329,8 +459,16 @@ def post_task(directory: str, body: str, *, repo: str = "", model: str = "",
 def dispatch_initiative(view: dict, *, creds=None, poster=None) -> dict:
     """Create a clawgate Task for one initiative view's grounded next step. Convenience over
     the pieces above: derive the recommendation (nextstep), build the title + body, resolve
-    the repo, and POST. `poster(directory, body, *, repo, creds) -> id|None` is injectable
-    (defaults to `post_task`) so tests never hit the network.
+    the repo, TAG it `initiative:<slug>`, and POST.
+    `poster(directory, body, *, repo, tags, creds) -> id|None` is injectable (defaults to
+    `post_task`) so tests never hit the network.
+
+    The TAG is what closes the loop: `tasks.py` joins `initiative:<slug>` back to this card,
+    so the Task this call creates shows up in the card's detail and ARMS the duplicate-dispatch
+    guard on the next render. Without it the board's own dispatch was the one producer whose
+    tasks never joined — i.e. tapping ⤴ dispatch twice, the exact duplicate the guard exists
+    to prevent, was silent. Tagging is FAIL-OPEN end to end (`build_tags` → [] on any doubt,
+    `post_task` retries untagged on a 400): a tag problem never costs the dispatch.
 
     Returns `{"ok": bool, "task_id": int|None, "error": str|None}`. NEVER raises — any failure
     (no grounded recommendation, creds missing, clawgate unreachable) is reported in the dict.
@@ -347,9 +485,10 @@ def dispatch_initiative(view: dict, *, creds=None, poster=None) -> dict:
         directory = build_task_title(v)
         body = build_task_body(v, recommendation)
         repo = resolve_repo_fullname(v.get("repo") or "")
+        tags = build_tags(v)
 
         post = poster if poster is not None else post_task
-        task_id = post(directory, body, repo=repo, creds=creds)
+        task_id = post(directory, body, repo=repo, tags=tags, creds=creds)
         if not isinstance(task_id, int) or isinstance(task_id, bool):
             return {"ok": False, "task_id": None,
                     "error": "clawgate did not return a task id (unreachable or no creds)"}

--- a/scripts/initiatives/tasks.py
+++ b/scripts/initiatives/tasks.py
@@ -380,11 +380,13 @@ def group_by_slug(tasks, base_url: str = "") -> dict[str, list[dict]]:
 
     ⚠ LATENT RISK, deliberately not fixed: the ledger's identity is `(repo, slug)` but this
     map is keyed on the SLUG ALONE, so two initiatives in different repos that happened to
-    share a slug would see each other's tasks. Live today: 143 rows / 143 DISTINCT slugs —
-    zero collisions — and closing it means widening the tag namespace to
-    `initiative:<repo>/<slug>` on the PRODUCER side (repo-cos) plus a migration for every
+    share a slug would see each other's tasks. Measured 2026-07-30: `initiatives.latest`
+    49 rows / 49 DISTINCT slugs and `initiatives.current` 144 / 144 — zero collisions in
+    either view. Closing it means widening the tag namespace to `initiative:<repo>/<slug>`
+    on the PRODUCER side (repo-cos + this repo's dispatch.py) plus a migration for every
     already-emitted tag. Not worth it for a decoration; revisit if the store ever shows a
-    duplicate slug (`select slug from initiatives.latest group by slug having count(*) > 1`)."""
+    duplicate slug:
+        select slug, count(*) from initiatives.latest group by slug having count(*) > 1;"""
     out: dict[str, list[dict]] = {}
     if not isinstance(tasks, list):
         return out

--- a/scripts/initiatives/tasks.py
+++ b/scripts/initiatives/tasks.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""clawgate LINKED TASKS — the consumer side of repo-cos's `initiative:<slug>` task tags.
+
+repo-cos (and any other producer) tags an approved clawgate Task with `initiative:<slug>`,
+where the slug is the initiatives ledger slug VERBATIM (the tag pipeline guarantees the tag
+is either exact or absent — it never emits a rewritten slug). This module is the consumer:
+it reads the clawgate task queue ONCE per board render and groups the tasks by that tag, so
+the viewer can (a) show an initiative's linked Tasks in its expanded card detail and (b)
+guard `⤴ dispatch` against minting a duplicate card for work that is already queued.
+
+Contract — mirrors `dispatch.py`'s (the sibling that WRITES tasks) exactly:
+  * stdlib only, no new runtime deps;
+  * BEST-EFFORT / NEVER RAISES — clawgate unreachable, missing or unreadable creds, a
+    timeout, malformed JSON, or a rolled-back clawgate with no `tags` field all degrade to
+    "no linked tasks", logged to stderr. A board render must never block on or fail because
+    of clawgate;
+  * a SHORT timeout (`FETCH_TIMEOUT`), because this sits on the render path;
+  * credential loading is REUSED from `dispatch.py` (`load_creds` → ~/.claude/clawgate.env),
+    not reimplemented — one parser, one behaviour across the writer and the reader.
+
+ONE fetch per render, not one per card: `GET /api/tasks` returns the whole queue (~5 tasks),
+which is then grouped into a `slug -> [task view]` map. There is deliberately NO per-card
+HTTP call (the board carries ~140 cards).
+
+Public surface:
+  * `clawgate_base_url(creds, env)` → the API base (env override → creds → LAN NodePort).
+  * `fetch_tasks(...)`             → the raw task list, `[]` on ANY failure.
+  * `initiative_slugs(task)`       → the task's `initiative:` tag values, EXACT (no case-fold,
+                                     no normalization — `initiative:Foo` keys `Foo`, which
+                                     therefore never matches the slug `foo`).
+  * `task_view(task, base_url)`    → the small render dict {id,title,status,open,url}.
+  * `group_by_slug(tasks, base)`   → `slug -> [task view]` (a task with several initiative
+                                     tags lands under each; an untagged task lands nowhere).
+  * `open_task_count(views)`       → how many of a card's linked tasks are still LIVE work.
+  * `linked_tasks_map(...)`        → the orchestrator the viewer calls: fetch + group, `{}`
+                                     on any failure.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# The clawgate API base. Env override first (same convention as the rest of the subsystem —
+# INITIATIVES_SYNC_DAYS, RECAP_MODEL, …), then the creds file's own CLAWGATE_API_URL (so the
+# reader and the writer agree by default), then the workbench LAN NodePort.
+CLAWGATE_URL_ENV = "INITIATIVES_CLAWGATE_URL"
+DEFAULT_CLAWGATE_URL = "http://192.168.50.250:30302"
+
+# The reserved namespace repo-cos writes. §3 of the tag spec: `initiative:<slug>`, soft-
+# validated (charset/length only), the initiatives side does the join — this module IS that join.
+INITIATIVE_TAG_PREFIX = "initiative:"
+
+# SHORT by design: this read sits on the board render path, so a hung clawgate must cost a
+# few seconds at most and then degrade to "no linked tasks".
+FETCH_TIMEOUT = 4  # seconds
+
+# Statuses that count as LIVE work for the dispatch guard — a CLOSED set, so anything else
+# (`complete`, a dismissed/renamed/unknown status, a missing status) is treated as NOT
+# blocking. Fail-open on purpose: a clawgate that renames a status must never wedge dispatch.
+# `ready_for_review` is included because such a task is still unfinished work in the queue —
+# dispatching a second card for it would be the exact duplicate this guard exists to prevent.
+OPEN_STATUSES = ("open", "in_progress", "ready_for_review")
+
+# Credential loading is reused from the sibling WRITER (one parser for ~/.claude/clawgate.env),
+# loaded by explicit importlib path — the package's cross-load convention, NOT sys.path.
+_DISPATCH_PATH = Path(__file__).resolve().parent / "dispatch.py"
+_dispatch_mod = None
+
+
+def _log(msg: str) -> None:
+    print(f"  tasks: {msg}", file=sys.stderr)
+
+
+def _dispatch():
+    global _dispatch_mod
+    if _dispatch_mod is None:
+        spec = importlib.util.spec_from_file_location(
+            "initiatives_tasks_dispatch", _DISPATCH_PATH)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"cannot load {_DISPATCH_PATH}")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        _dispatch_mod = mod
+    return _dispatch_mod
+
+
+def load_creds(path=None) -> dict:
+    """~/.claude/clawgate.env → dict, via `dispatch.load_creds` (SINGLE-SOURCED — the writer
+    and the reader must never disagree about how the creds file parses). {} if the sibling
+    can't even be loaded. Never raises."""
+    try:
+        return _dispatch().load_creds(path)
+    except Exception as exc:  # noqa: BLE001 - a sibling-load hiccup is "no creds", not a crash
+        _log(f"could not load creds: {exc}")
+        return {}
+
+
+# ---- configuration -----------------------------------------------------------------
+
+def clawgate_base_url(creds: dict | None = None, env=None) -> str:
+    """The clawgate API base URL, trailing slash stripped.
+
+    Precedence: `$INITIATIVES_CLAWGATE_URL` (the env knob) → the creds file's
+    `CLAWGATE_API_URL` → `DEFAULT_CLAWGATE_URL` (the workbench LAN NodePort). Pure + never
+    raises; a non-mapping `creds`/`env` degrades to the default."""
+    try:
+        e = env if env is not None else os.environ
+        override = str(e.get(CLAWGATE_URL_ENV) or "").strip()
+        if override:
+            return override.rstrip("/")
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        from_creds = str((creds or {}).get("CLAWGATE_API_URL") or "").strip()
+        if from_creds:
+            return from_creds.rstrip("/")
+    except Exception:  # noqa: BLE001
+        pass
+    return DEFAULT_CLAWGATE_URL
+
+
+# ---- HTTP read ---------------------------------------------------------------------
+
+def _get(url: str, token: str, *, timeout: int = FETCH_TIMEOUT) -> str:
+    """Isolated network GET (stdlib urllib) — injected/mocked in tests. Returns the body."""
+    req = urllib.request.Request(
+        url, method="GET",
+        headers={"Accept": "application/json", "Authorization": f"Bearer {token}"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        code = getattr(resp, "status", None)
+        if code is not None and int(code) != 200:
+            raise OSError(f"HTTP {code}")
+        return resp.read().decode("utf-8")
+
+
+def fetch_tasks(*, creds: dict | None = None, env=None, timeout: int = FETCH_TIMEOUT,
+                getter=None) -> list[dict]:
+    """`GET {base}/api/tasks` (Bearer hook token) → the raw task list.
+
+    BEST-EFFORT: missing/unreadable creds, an unreachable clawgate, a non-200, a timeout, or
+    a body that isn't a JSON array all log to stderr and return `[]`. NEVER raises — a board
+    render must not depend on clawgate being up."""
+    c = creds if creds is not None else load_creds()
+    token = ""
+    try:
+        token = str(c.get("CLAWGATE_HOOK_TOKEN") or "")
+    except Exception:  # noqa: BLE001 - a non-mapping creds is just "no creds"
+        token = ""
+    if not token:
+        _log("CLAWGATE_HOOK_TOKEN not set (~/.claude/clawgate.env) — no linked tasks")
+        return []
+
+    url = f"{clawgate_base_url(c, env)}/api/tasks"
+    get = getter if getter is not None else _get
+    try:
+        raw = get(url, token, timeout=timeout)
+    except urllib.error.HTTPError as exc:
+        _log(f"GET {url} failed: HTTP {exc.code} {exc.reason}")
+        return []
+    except Exception as exc:  # noqa: BLE001
+        _log(f"GET {url} failed: {exc}")
+        return []
+
+    try:
+        obj = json.loads(raw)
+    except Exception as exc:  # noqa: BLE001
+        _log(f"GET {url} returned unparseable JSON ({exc})")
+        return []
+    if not isinstance(obj, list):
+        _log(f"GET {url} returned {type(obj).__name__}, expected a list — no linked tasks")
+        return []
+    return [t for t in obj if isinstance(t, dict)]
+
+
+# ---- pure grouping -----------------------------------------------------------------
+
+def initiative_slugs(task: dict) -> list[str]:
+    """A task's `initiative:` tag values, in order, de-duplicated.
+
+    EXACT by construction: the prefix match is case-sensitive and the value is returned
+    VERBATIM (no lowercasing, no trimming beyond the surrounding whitespace of the whole
+    tag). The dict lookup in `group_by_slug` is therefore exact too — `initiative:Foo` keys
+    `Foo` and can never satisfy a card whose slug is `foo`, and `initiative:foo` never
+    matches `foo-bar`. A rolled-back clawgate with NO `tags` field, or a non-list `tags`,
+    yields `[]`. Pure, never raises."""
+    try:
+        tags = (task or {}).get("tags")
+    except Exception:  # noqa: BLE001
+        return []
+    if not isinstance(tags, list):
+        return []
+    out: list[str] = []
+    for tag in tags:
+        if not isinstance(tag, str):
+            continue
+        t = tag.strip()
+        if not t.startswith(INITIATIVE_TAG_PREFIX):
+            continue
+        slug = t[len(INITIATIVE_TAG_PREFIX):]
+        if slug and slug not in out:
+            out.append(slug)
+    return out
+
+
+def is_open(task: dict) -> bool:
+    """Is this task still LIVE work (and therefore a reason not to mint a duplicate)?
+    `OPEN_STATUSES` is a closed set — `complete`, a dismissed/unknown/missing status → False."""
+    try:
+        return str((task or {}).get("status") or "") in OPEN_STATUSES
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def task_view(task: dict, base_url: str = "") -> dict:
+    """One clawgate task → the small dict the board renders: `{id, title, status, open, url}`.
+
+    `title` prefers the (newer) `title` field and falls back to `directory`, which is how
+    every current producer smuggles the title through (tag spec §9). `url` deep-links to the
+    task's card in clawgate (`{base}/tasks#task-<id>` — the card element carries
+    `id="task-<id>"`); it is "" when there's no id or no base. Pure, never raises."""
+    t = task or {}
+    tid = t.get("id")
+    if isinstance(tid, bool) or not isinstance(tid, int):
+        tid = None
+    title = str(t.get("title") or "").strip() or str(t.get("directory") or "").strip()
+    base = (base_url or "").rstrip("/")
+    return {
+        "id": tid,
+        "title": title,
+        "status": str(t.get("status") or ""),
+        "open": is_open(t),
+        "url": f"{base}/tasks#task-{tid}" if (base and tid is not None) else "",
+    }
+
+
+def group_by_slug(tasks, base_url: str = "") -> dict[str, list[dict]]:
+    """PURE: a clawgate task list → `slug -> [task view]`, keyed on the EXACT
+    `initiative:<slug>` tag value.
+
+    A task carrying several `initiative:` tags appears under EACH slug; a task with no
+    `initiative:` tag (or no `tags` field at all) appears nowhere; several tasks on one
+    initiative accumulate in one list (input order preserved). A slug matching no card is
+    simply an unused key — the viewer looks cards up in this map, never the reverse. Never
+    raises: a non-list input, or a non-dict entry, is skipped."""
+    out: dict[str, list[dict]] = {}
+    if not isinstance(tasks, list):
+        return out
+    for task in tasks:
+        if not isinstance(task, dict):
+            continue
+        slugs = initiative_slugs(task)
+        if not slugs:
+            continue
+        view = task_view(task, base_url)
+        for slug in slugs:
+            out.setdefault(slug, []).append(view)
+    return out
+
+
+def open_task_count(views) -> int:
+    """How many of a card's linked task views are still LIVE work (drives the dispatch guard)."""
+    if not isinstance(views, list):
+        return 0
+    return sum(1 for v in views if isinstance(v, dict) and v.get("open"))
+
+
+# ---- orchestrator ------------------------------------------------------------------
+
+def linked_tasks_map(*, creds: dict | None = None, env=None, timeout: int = FETCH_TIMEOUT,
+                     fetcher=None) -> dict[str, list[dict]]:
+    """The one call the viewer makes per board render: fetch the clawgate queue ONCE and
+    group it into `slug -> [task view]`.
+
+    `{}` on ANY failure (no creds, clawgate down, non-200, malformed JSON, no tags field) —
+    which renders the board exactly as it does today, with no linked-task info and no error
+    surface. NEVER raises."""
+    try:
+        c = creds if creds is not None else load_creds()
+        fetch = fetcher if fetcher is not None else fetch_tasks
+        tasks = fetch(creds=c, env=env, timeout=timeout)
+        return group_by_slug(tasks, clawgate_base_url(c, env))
+    except Exception as exc:  # noqa: BLE001 - best-effort: a failure is an empty map, not a raise
+        _log(f"linked_tasks_map failed: {type(exc).__name__}: {exc}")
+        return {}

--- a/scripts/initiatives/tasks.py
+++ b/scripts/initiatives/tasks.py
@@ -14,7 +14,8 @@ Contract — mirrors `dispatch.py`'s (the sibling that WRITES tasks) exactly:
     timeout, malformed JSON, or a rolled-back clawgate with no `tags` field all degrade to
     "no linked tasks", logged to stderr. A board render must never block on or fail because
     of clawgate;
-  * a SHORT timeout (`FETCH_TIMEOUT`), because this sits on the render path;
+  * a hard WALL-CLOCK deadline (`FETCH_DEADLINE`) + a response SIZE CAP, because this sits on
+    the render path;
   * credential loading is REUSED from `dispatch.py` (`load_creds` → ~/.claude/clawgate.env),
     not reimplemented — one parser, one behaviour across the writer and the reader.
 
@@ -22,9 +23,34 @@ ONE fetch per render, not one per card: `GET /api/tasks` returns the whole queue
 which is then grouped into a `slug -> [task view]` map. There is deliberately NO per-card
 HTTP call (the board carries ~140 cards).
 
+🔴 WHY A WALL-CLOCK DEADLINE AND NOT `urlopen(timeout=)` (the audit finding that got this
+rewritten). `urlopen(timeout=N)` is a PER-SOCKET-OPERATION timeout, not a deadline on the
+call. Measured against the first cut (`timeout=4`), on top of a 0.80s cold-render baseline:
+
+    connection refused                                 +0.010s   (the only case tested → shipped)
+    blackhole (accepts, never replies)                 +4.005s   (~6x the whole render)
+    slow-drip (1 byte / 2s, each read inside the 4s)  +130s      — AND IT STILL SUCCEEDED
+
+so a dribbling clawgate stalled the board without bound. The fix is three-layered:
+  1. `_run_with_deadline` runs the whole fetch (DNS + connect + headers + body) in a DAEMON
+     thread and joins for at most `FETCH_DEADLINE` wall-clock seconds. That is a real deadline
+     covering every phase, whatever the socket does — including an injected getter;
+  2. `_get` additionally re-checks the wall clock between body chunks and caps the response at
+     `MAX_RESPONSE_BYTES`, so an abandoned worker thread TERMINATES itself instead of leaking
+     while it dribbles (`Notes.List` has no `LIMIT` and rows carry full task bodies — 16 KB for
+     6 tasks today, and it grows with retained history);
+  3. `LinkedTaskCache` (below) means the deadline is paid at most once per `CACHE_TTL_SECONDS`,
+     not on every cold render — and a failed refresh keeps serving the LAST GOOD map.
+
+The read is ALSO issued OUTSIDE `DataProvider._lock` (see `viewer.DataProvider.snapshot`), so a
+slow clawgate can never serialize `/`, `/api/initiatives.json`, `/api/initiative` and `/api/ask`
+behind it.
+
 Public surface:
   * `clawgate_base_url(creds, env)` → the API base (env override → creds → LAN NodePort).
-  * `fetch_tasks(...)`             → the raw task list, `[]` on ANY failure.
+  * `fetch_tasks_result(...)`      → `(ok, tasks)` — `ok=False` distinguishes a FAILED read
+                                     from a genuinely empty queue (what serve-stale needs).
+  * `fetch_tasks(...)`             → the raw task list, `[]` on ANY failure (thin wrapper).
   * `initiative_slugs(task)`       → the task's `initiative:` tag values, EXACT (no case-fold,
                                      no normalization — `initiative:Foo` keys `Foo`, which
                                      therefore never matches the slug `foo`).
@@ -32,8 +58,10 @@ Public surface:
   * `group_by_slug(tasks, base)`   → `slug -> [task view]` (a task with several initiative
                                      tags lands under each; an untagged task lands nowhere).
   * `open_task_count(views)`       → how many of a card's linked tasks are still LIVE work.
-  * `linked_tasks_map(...)`        → the orchestrator the viewer calls: fetch + group, `{}`
-                                     on any failure.
+  * `linked_tasks_map_result(...)` → `(ok, map)`: fetch + group, keeping the ok flag.
+  * `linked_tasks_map(...)`        → the uncached orchestrator: fetch + group, `{}` on failure.
+  * `cached_linked_tasks_map(...)` → what the VIEWER calls: the above behind `LinkedTaskCache`
+                                     (own TTL + serve-stale-on-failure + single-flight).
 """
 from __future__ import annotations
 
@@ -41,6 +69,8 @@ import importlib.util
 import json
 import os
 import sys
+import threading
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -55,15 +85,40 @@ DEFAULT_CLAWGATE_URL = "http://192.168.50.250:30302"
 # validated (charset/length only), the initiatives side does the join — this module IS that join.
 INITIATIVE_TAG_PREFIX = "initiative:"
 
-# SHORT by design: this read sits on the board render path, so a hung clawgate must cost a
-# few seconds at most and then degrade to "no linked tasks".
-FETCH_TIMEOUT = 4  # seconds
+# SHORT by design: this read is a DECORATION on a triage page, not core data, so a hung
+# clawgate must cost this much WALL-CLOCK time at most (once per CACHE_TTL_SECONDS) and then
+# degrade to the last good map / "no linked tasks". Enforced by `_run_with_deadline`, which
+# covers every phase (DNS, connect, headers, body) — NOT by `urlopen(timeout=)`, which is
+# per-socket-operation and therefore unbounded against a slow drip (see the module docstring).
+FETCH_DEADLINE = 2.0  # seconds, wall clock, for the WHOLE fetch
+
+# Per-socket-operation timeout INSIDE the worker thread. This is not the deadline (the join
+# is); it exists so an abandoned worker eventually dies instead of holding a socket forever.
+SOCKET_TIMEOUT = 2.0  # seconds
+
+# Response size cap. `Notes.List` has no `LIMIT` and each row carries the task's full body
+# (~16 KB for today's 6 tasks), so the queue grows with retained history. 1 MiB is ~60x
+# today's payload — generous headroom, but bounded: an unbounded `resp.read()` on the render
+# path is a memory/latency amplifier we don't need.
+MAX_RESPONSE_BYTES = 1 << 20  # 1 MiB
+READ_CHUNK = 64 * 1024        # bytes per read() — the wall clock is re-checked between chunks
+
+# The linked-task cache's OWN TTL — deliberately LONGER than the board's 5s `CACHE_TTL_SECONDS`
+# so a hung clawgate costs `FETCH_DEADLINE` at most once per 30s rather than every cold render,
+# and so a transient blip serves the last good map instead of flickering the links away. The
+# client compensates for the staleness it introduces on the dispatch path by optimistically
+# incrementing a card's open-task count after its own successful dispatch (viewer.py
+# `noteDispatched`), so two taps in quick succession are still guarded.
+CACHE_TTL_SECONDS = 30.0
 
 # Statuses that count as LIVE work for the dispatch guard — a CLOSED set, so anything else
-# (`complete`, a dismissed/renamed/unknown status, a missing status) is treated as NOT
-# blocking. Fail-open on purpose: a clawgate that renames a status must never wedge dispatch.
-# `ready_for_review` is included because such a task is still unfinished work in the queue —
-# dispatching a second card for it would be the exact duplicate this guard exists to prevent.
+# (`complete`, or a renamed/unknown/missing status) is treated as NOT blocking. Fail-open on
+# purpose: a clawgate that renames a status must never wedge dispatch. clawgate's vocabulary
+# is exactly {open, in_progress, ready_for_review, complete} (clawgate
+# `internal/notes/notes.go`), so today this set is "everything except `complete`" — but it is
+# written as a closed ALLOW-list, not as `!= complete`, so a future status is non-blocking by
+# default. `ready_for_review` is included because such a task is still unfinished work in the
+# queue — dispatching a second card for it would be the exact duplicate this guard prevents.
 OPEN_STATUSES = ("open", "in_progress", "ready_for_review")
 
 # Credential loading is reused from the sibling WRITER (one parser for ~/.claude/clawgate.env),
@@ -126,26 +181,88 @@ def clawgate_base_url(creds: dict | None = None, env=None) -> str:
 
 # ---- HTTP read ---------------------------------------------------------------------
 
-def _get(url: str, token: str, *, timeout: int = FETCH_TIMEOUT) -> str:
-    """Isolated network GET (stdlib urllib) — injected/mocked in tests. Returns the body."""
+def _run_with_deadline(fn, deadline: float, *, label: str = "clawgate fetch"):
+    """Run `fn()` under a REAL WALL-CLOCK DEADLINE and return its result.
+
+    Raises `TimeoutError` if `fn` hasn't finished within `deadline` seconds, and re-raises
+    whatever `fn` raised otherwise.
+
+    This — not `urlopen(timeout=)` — is what bounds the fetch. A socket timeout applies to
+    each individual operation, so a peer that dribbles a byte just inside the timeout keeps
+    the call alive indefinitely (measured: 130s through a `timeout=4` urlopen, and it still
+    *succeeded*). Joining a worker thread bounds DNS + connect + headers + body together,
+    regardless of what the peer does, and applies to an injected getter too.
+
+    The worker is a DAEMON thread, so an abandoned one can never hold up interpreter exit;
+    `_get` re-checks the clock between chunks so it also terminates itself shortly after
+    being abandoned, and the single-flight guard in `LinkedTaskCache` means at most one such
+    thread exists at a time."""
+    box: dict = {}
+
+    def target():
+        try:
+            box["value"] = fn()
+        except BaseException as exc:  # noqa: BLE001 - ferried to the caller verbatim
+            box["error"] = exc
+
+    th = threading.Thread(target=target, name="initiatives-clawgate-fetch", daemon=True)
+    th.start()
+    th.join(deadline)
+    if th.is_alive():
+        raise TimeoutError(f"{label} exceeded its {deadline}s wall-clock deadline")
+    if "error" in box:
+        raise box["error"]
+    return box.get("value")
+
+
+def _get(url: str, token: str, *, deadline: float = FETCH_DEADLINE,
+         max_bytes: int = MAX_RESPONSE_BYTES) -> str:
+    """Isolated network GET (stdlib urllib) — injected/mocked in tests. Returns the body.
+
+    Runs INSIDE the deadline thread, so its own guards are belt-and-braces for cleanup rather
+    than the deadline itself: a per-operation `SOCKET_TIMEOUT`, a wall-clock re-check between
+    body chunks (so an abandoned worker stops dribbling), and a `max_bytes` cap — the queue
+    endpoint has no server-side `LIMIT` and rows carry full task bodies, so an unbounded
+    `resp.read()` on the render path is an amplifier we decline."""
+    started = time.monotonic()
     req = urllib.request.Request(
         url, method="GET",
         headers={"Accept": "application/json", "Authorization": f"Bearer {token}"},
     )
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
+    with urllib.request.urlopen(req, timeout=min(SOCKET_TIMEOUT, deadline)) as resp:
         code = getattr(resp, "status", None)
         if code is not None and int(code) != 200:
             raise OSError(f"HTTP {code}")
-        return resp.read().decode("utf-8")
+        chunks: list[bytes] = []
+        total = 0
+        while True:
+            if (time.monotonic() - started) >= deadline:
+                raise TimeoutError(
+                    f"body read exceeded the {deadline}s wall-clock deadline "
+                    f"after {total} bytes")
+            chunk = resp.read(min(READ_CHUNK, (max_bytes + 1) - total))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > max_bytes:
+                raise OSError(
+                    f"response exceeded the {max_bytes}-byte cap — refusing to buffer it")
+        return b"".join(chunks).decode("utf-8", "replace")
 
 
-def fetch_tasks(*, creds: dict | None = None, env=None, timeout: int = FETCH_TIMEOUT,
-                getter=None) -> list[dict]:
-    """`GET {base}/api/tasks` (Bearer hook token) → the raw task list.
+def fetch_tasks_result(*, creds: dict | None = None, env=None,
+                       deadline: float = FETCH_DEADLINE,
+                       getter=None) -> tuple[bool, list[dict]]:
+    """`GET {base}/api/tasks` (Bearer hook token) → `(ok, tasks)`.
 
-    BEST-EFFORT: missing/unreadable creds, an unreachable clawgate, a non-200, a timeout, or
-    a body that isn't a JSON array all log to stderr and return `[]`. NEVER raises — a board
-    render must not depend on clawgate being up."""
+    `ok` is the bit that `[]` alone cannot carry: `(True, [])` is "clawgate answered and the
+    queue has no tagged tasks", `(False, [])` is "the read FAILED". `LinkedTaskCache` needs
+    that distinction to serve the last good map on a failure instead of dropping the links.
+
+    BEST-EFFORT: missing/unreadable creds, an unreachable clawgate, a non-200, a blown
+    deadline, an oversized body, or a body that isn't a JSON array all log to stderr and
+    return `(False, [])`. NEVER raises — a board render must not depend on clawgate."""
     c = creds if creds is not None else load_creds()
     token = ""
     try:
@@ -154,28 +271,40 @@ def fetch_tasks(*, creds: dict | None = None, env=None, timeout: int = FETCH_TIM
         token = ""
     if not token:
         _log("CLAWGATE_HOOK_TOKEN not set (~/.claude/clawgate.env) — no linked tasks")
-        return []
+        return False, []
 
     url = f"{clawgate_base_url(c, env)}/api/tasks"
     get = getter if getter is not None else _get
     try:
-        raw = get(url, token, timeout=timeout)
+        # THE deadline: bounds every phase of the call (and any injected getter), unlike the
+        # per-operation socket timeout this replaced.
+        raw = _run_with_deadline(lambda: get(url, token, deadline=deadline), deadline,
+                                 label=f"GET {url}")
     except urllib.error.HTTPError as exc:
         _log(f"GET {url} failed: HTTP {exc.code} {exc.reason}")
-        return []
+        return False, []
+    except TimeoutError as exc:
+        _log(f"GET {url} abandoned: {exc}")
+        return False, []
     except Exception as exc:  # noqa: BLE001
         _log(f"GET {url} failed: {exc}")
-        return []
+        return False, []
 
     try:
         obj = json.loads(raw)
     except Exception as exc:  # noqa: BLE001
         _log(f"GET {url} returned unparseable JSON ({exc})")
-        return []
+        return False, []
     if not isinstance(obj, list):
         _log(f"GET {url} returned {type(obj).__name__}, expected a list — no linked tasks")
-        return []
-    return [t for t in obj if isinstance(t, dict)]
+        return False, []
+    return True, [t for t in obj if isinstance(t, dict)]
+
+
+def fetch_tasks(*, creds: dict | None = None, env=None, deadline: float = FETCH_DEADLINE,
+                getter=None) -> list[dict]:
+    """`fetch_tasks_result` without the ok flag — the raw task list, `[]` on ANY failure."""
+    return fetch_tasks_result(creds=creds, env=env, deadline=deadline, getter=getter)[1]
 
 
 # ---- pure grouping -----------------------------------------------------------------
@@ -210,7 +339,7 @@ def initiative_slugs(task: dict) -> list[str]:
 
 def is_open(task: dict) -> bool:
     """Is this task still LIVE work (and therefore a reason not to mint a duplicate)?
-    `OPEN_STATUSES` is a closed set — `complete`, a dismissed/unknown/missing status → False."""
+    `OPEN_STATUSES` is a closed set — `complete`, or an unknown/missing status → False."""
     try:
         return str((task or {}).get("status") or "") in OPEN_STATUSES
     except Exception:  # noqa: BLE001
@@ -247,7 +376,15 @@ def group_by_slug(tasks, base_url: str = "") -> dict[str, list[dict]]:
     `initiative:` tag (or no `tags` field at all) appears nowhere; several tasks on one
     initiative accumulate in one list (input order preserved). A slug matching no card is
     simply an unused key — the viewer looks cards up in this map, never the reverse. Never
-    raises: a non-list input, or a non-dict entry, is skipped."""
+    raises: a non-list input, or a non-dict entry, is skipped.
+
+    ⚠ LATENT RISK, deliberately not fixed: the ledger's identity is `(repo, slug)` but this
+    map is keyed on the SLUG ALONE, so two initiatives in different repos that happened to
+    share a slug would see each other's tasks. Live today: 143 rows / 143 DISTINCT slugs —
+    zero collisions — and closing it means widening the tag namespace to
+    `initiative:<repo>/<slug>` on the PRODUCER side (repo-cos) plus a migration for every
+    already-emitted tag. Not worth it for a decoration; revisit if the store ever shows a
+    duplicate slug (`select slug from initiatives.latest group by slug having count(*) > 1`)."""
     out: dict[str, list[dict]] = {}
     if not isinstance(tasks, list):
         return out
@@ -272,19 +409,123 @@ def open_task_count(views) -> int:
 
 # ---- orchestrator ------------------------------------------------------------------
 
-def linked_tasks_map(*, creds: dict | None = None, env=None, timeout: int = FETCH_TIMEOUT,
-                     fetcher=None) -> dict[str, list[dict]]:
-    """The one call the viewer makes per board render: fetch the clawgate queue ONCE and
-    group it into `slug -> [task view]`.
+def linked_tasks_map_result(*, creds: dict | None = None, env=None,
+                            deadline: float = FETCH_DEADLINE,
+                            fetcher=None) -> tuple[bool, dict[str, list[dict]]]:
+    """Fetch the clawgate queue ONCE and group it into `slug -> [task view]`, keeping the ok
+    flag → `(ok, map)`.
 
-    `{}` on ANY failure (no creds, clawgate down, non-200, malformed JSON, no tags field) —
-    which renders the board exactly as it does today, with no linked-task info and no error
-    surface. NEVER raises."""
+    `(False, {})` on ANY failure (no creds, clawgate down, non-200, blown deadline, oversized
+    or malformed body). `fetcher` is injectable: it may return either the `(ok, tasks)` tuple
+    (`fetch_tasks_result`, the default) or a bare task list (in which case not raising counts
+    as success). NEVER raises."""
     try:
         c = creds if creds is not None else load_creds()
-        fetch = fetcher if fetcher is not None else fetch_tasks
-        tasks = fetch(creds=c, env=env, timeout=timeout)
-        return group_by_slug(tasks, clawgate_base_url(c, env))
+        fetch = fetcher if fetcher is not None else fetch_tasks_result
+        got = fetch(creds=c, env=env, deadline=deadline)
+        if isinstance(got, tuple):
+            ok, tasks = got
+        else:
+            ok, tasks = True, got
+        return bool(ok), group_by_slug(tasks, clawgate_base_url(c, env))
     except Exception as exc:  # noqa: BLE001 - best-effort: a failure is an empty map, not a raise
         _log(f"linked_tasks_map failed: {type(exc).__name__}: {exc}")
+        return False, {}
+
+
+def linked_tasks_map(*, creds: dict | None = None, env=None,
+                     deadline: float = FETCH_DEADLINE, fetcher=None) -> dict[str, list[dict]]:
+    """`linked_tasks_map_result` without the ok flag — the UNCACHED fetch+group, `{}` on any
+    failure. The viewer calls `cached_linked_tasks_map` instead; this stays the plain
+    orchestrator for the CLI/tests."""
+    return linked_tasks_map_result(creds=creds, env=env, deadline=deadline, fetcher=fetcher)[1]
+
+
+# ---- cache -------------------------------------------------------------------------
+
+class LinkedTaskCache:
+    """The linked-task join's OWN cache — independent of the board's 5s snapshot cache.
+
+    Three properties, each closing one of the amplifiers the audit measured:
+
+    * **TTL** (`ttl`, default `CACHE_TTL_SECONDS` = 30s): the fetch deadline is paid at most
+      once per TTL, not on every cold render. Without this a hung clawgate re-stalls the board
+      every 5s forever.
+    * **SERVE-STALE-ON-FAILURE**: a failed refresh keeps serving the LAST GOOD map. A transient
+      blip must not make an initiative's linked tasks — and with them the dispatch guard —
+      flicker away; the guard is exactly the thing that should NOT disappear when the service
+      it guards against is briefly unreachable. `ok=False` is what makes this distinguishable
+      from a genuinely empty queue, which is why the fetch carries that flag.
+    * **SINGLE-FLIGHT**: at most one refresh runs at a time (a non-blocking lock). A concurrent
+      caller gets the current value IMMEDIATELY rather than queueing behind a slow clawgate —
+      which, together with the read living outside `DataProvider._lock`, is what stops one hung
+      fetch from serializing unrelated board requests.
+
+    Thread-safe. Never raises: `get()` degrades to whatever it last had (or `{}`)."""
+
+    def __init__(self, ttl: float = CACHE_TTL_SECONDS, now=time.monotonic):
+        self._ttl = ttl
+        self._now = now
+        self._value: dict[str, list[dict]] = {}
+        self._have = False          # has a refresh EVER succeeded? (→ is `_value` real)
+        self._attempted_at = None   # monotonic ts of the last refresh ATTEMPT (ok or not)
+        self._state_lock = threading.Lock()
+        self._refresh_lock = threading.Lock()
+
+    def invalidate(self) -> None:
+        """Drop the cached map so the next `get()` re-reads (the ↻ refresh path / tests)."""
+        with self._state_lock:
+            self._value = {}
+            self._have = False
+            self._attempted_at = None
+
+    def get(self, loader) -> dict[str, list[dict]]:
+        """`loader() -> (ok, map)`; returns the fresh map, the last good one, or `{}`.
+
+        Note the TTL gates the last ATTEMPT, not the last SUCCESS: a failing clawgate is
+        retried once per TTL, not on every single request."""
+        with self._state_lock:
+            if self._attempted_at is not None and (self._now() - self._attempted_at) < self._ttl:
+                return self._value
+            current = self._value
+        if not self._refresh_lock.acquire(blocking=False):
+            # A refresh is already in flight. Waiting for it would reintroduce exactly the
+            # serialization this design exists to remove, so serve what we have right now.
+            return current
+        try:
+            ok, fresh = loader()
+        except Exception as exc:  # noqa: BLE001 - a loader failure is a failed refresh
+            _log(f"linked-task refresh raised: {type(exc).__name__}: {exc}")
+            ok, fresh = False, {}
+        finally:
+            self._refresh_lock.release()
+        with self._state_lock:
+            self._attempted_at = self._now()
+            if ok:
+                self._value = fresh
+                self._have = True
+            elif self._have:
+                _log("clawgate read failed — serving the last good linked-task map (stale)")
+            return self._value
+
+
+# The process-wide cache the viewer uses. Module-level (not per-DataProvider) so it survives
+# a provider rebuild and so every code path shares one clawgate budget.
+_CACHE = LinkedTaskCache()
+
+
+def cached_linked_tasks_map(*, creds: dict | None = None, env=None,
+                            deadline: float = FETCH_DEADLINE, fetcher=None,
+                            cache=None) -> dict[str, list[dict]]:
+    """The one call the VIEWER makes per board render: `slug -> [task view]`, cached.
+
+    Wraps `linked_tasks_map_result` in `LinkedTaskCache` (own 30s TTL + serve-stale-on-failure
+    + single-flight). `{}` until the first success; the last good map thereafter, even while
+    clawgate is down. NEVER raises — the board renders exactly as it does today on failure."""
+    c = cache if cache is not None else _CACHE
+    try:
+        return c.get(lambda: linked_tasks_map_result(
+            creds=creds, env=env, deadline=deadline, fetcher=fetcher))
+    except Exception as exc:  # noqa: BLE001 - best-effort to the very last line
+        _log(f"cached_linked_tasks_map failed: {type(exc).__name__}: {exc}")
         return {}

--- a/scripts/initiatives/tests/test_dispatch.py
+++ b/scripts/initiatives/tests/test_dispatch.py
@@ -263,10 +263,11 @@ def test_post_task_unparseable_response_returns_none():
 def test_dispatch_initiative_happy_path():
     seen = {}
 
-    def poster(directory, body, *, repo="", creds=None):
+    def poster(directory, body, *, repo="", tags=None, creds=None):
         seen["directory"] = directory
         seen["body"] = body
         seen["repo"] = repo
+        seen["tags"] = tags
         return 99
 
     v = _view(next_step="wire the unit")
@@ -274,6 +275,8 @@ def test_dispatch_initiative_happy_path():
     assert res == {"ok": True, "task_id": 99, "error": None}
     assert seen["directory"] == "devrc · emerging-thing"
     assert "wire the unit" in seen["body"]
+    # The tag is what makes the created Task JOIN back to this card (and arm the guard).
+    assert seen["tags"] == ["initiative:emerging-thing"]
 
 
 def test_dispatch_initiative_no_grounded_step_is_error():
@@ -305,3 +308,122 @@ def test_dispatch_initiative_never_raises():
     res = dispatch.dispatch_initiative(_view(next_step="x"), poster=boom)
     assert res["ok"] is False and res["task_id"] is None
     assert "RuntimeError" in res["error"]
+
+
+# --- 🔴 TAGGING: the board's own dispatch must arm its own guard ------------- #
+# Before this, `dispatch.py` had NO `tags` anywhere: the board minted UNtagged clawgate Tasks,
+# which therefore never joined back to a card and never armed the duplicate-dispatch guard —
+# so tapping ⤴ dispatch twice on the same card (the exact duplicate the feature is named for)
+# was silent. Only repo-cos's weekly approve path emitted tagged tasks.
+def test_build_tags_emits_the_ledger_slug_VERBATIM():
+    assert dispatch.build_tags(_view(slug="remix-platform")) == ["initiative:remix-platform"]
+    # the join in tasks.py is EXACT string equality, so the tag value must equal the slug
+    tag = dispatch.build_tags(_view(slug="initiatives-task-links"))[0]
+    assert tag == "initiative:initiatives-task-links"
+    assert tag.split(":", 1)[1] == "initiatives-task-links"
+
+
+def test_build_tags_emits_NOTHING_rather_than_a_rewritten_slug(capsys):
+    """A normalized-but-rewritten slug would join to NOTHING while looking like it worked —
+    strictly worse than no tag. Exact-or-nothing, the same guarantee repo-cos gives."""
+    for bad in ("Foo Bar", "UPPER", "has:two:colons", "spaced out", "emoji-🚀", "x" * 80):
+        assert dispatch.build_tags(_view(slug=bad)) == [], bad
+    assert dispatch.build_tags(_view(slug="")) == []
+    assert dispatch.build_tags({}) == []
+    assert dispatch.build_tags(None) == []
+    assert "untagged" in capsys.readouterr().err
+
+
+def test_normalize_tag_matches_the_repo_cos_grammar():
+    assert dispatch.normalize_tag("initiative:alpha") == "initiative:alpha"
+    assert dispatch.normalize_tag("Initiative:Alpha") == "initiative:alpha"   # lowercased
+    assert dispatch.normalize_tag("a:b:c") is None                            # one ':' only
+    assert dispatch.normalize_tag("initiative:") is None                      # empty side
+    assert dispatch.normalize_tag("initiative:a b") == "initiative:a-b"       # ws → '-'
+    assert dispatch.normalize_tag("x" * (dispatch.TAG_MAX_LEN + 1)) is None
+    assert dispatch.normalize_tag("") is None and dispatch.normalize_tag(None) is None
+    assert dispatch.normalize_tags(["b", "a", "a", "BAD:TAG:X"]) == ["a", "b"]
+
+
+def test_post_task_sends_tags_only_when_nonempty():
+    captured = {}
+
+    def fake_post(url, payload, token, **kw):
+        captured["payload"] = dict(payload)
+        return '{"id": 1}'
+
+    dispatch.post_task("d", "b", creds=_CREDS, _post=fake_post)
+    assert "tags" not in captured["payload"]              # bare call = the old 2-key payload
+    dispatch.post_task("d", "b", tags=["initiative:alpha"], creds=_CREDS, _post=fake_post)
+    assert captured["payload"]["tags"] == ["initiative:alpha"]
+
+
+def test_post_task_retries_untagged_exactly_once_on_a_tag_400():
+    """FAIL-OPEN: 400 is clawgate's tag-grammar rejection, so a tagged post that 400s degrades
+    to an UNTAGGED task — never to no task. A tag must never cost a dispatch."""
+    seen = []
+
+    def flaky(url, payload, token, **kw):
+        seen.append(dict(payload))
+        if "tags" in payload:
+            raise urllib.error.HTTPError(url, 400, "bad tag", {}, None)
+        return '{"id": 7}'
+
+    assert dispatch.post_task("d", "b", tags=["initiative:alpha"],
+                              creds=_CREDS, _post=flaky) == 7
+    assert len(seen) == 2 and "tags" in seen[0] and "tags" not in seen[1]
+
+
+def test_post_task_does_NOT_retry_on_any_other_status():
+    # 408 in particular: the origin may already have created the Task, so a retry double-posts.
+    for code in (401, 403, 404, 408, 429, 500):
+        seen = []
+
+        def boom(url, payload, token, _code=code, **kw):
+            seen.append(payload)
+            raise urllib.error.HTTPError(url, _code, "err", {}, None)
+
+        assert dispatch.post_task("d", "b", tags=["initiative:alpha"],
+                                  creds=_CREDS, _post=boom) is None
+        assert len(seen) == 1, code
+
+
+def test_dispatch_of_an_untaggable_slug_still_dispatches_untagged():
+    seen = {}
+
+    def poster(directory, body, *, repo="", tags=None, creds=None):
+        seen["tags"] = tags
+        return 5
+
+    res = dispatch.dispatch_initiative(
+        _view(slug="Not A Valid Slug", next_step="do it"), poster=poster)
+    assert res["ok"] is True and res["task_id"] == 5      # FAIL-OPEN: the dispatch happens
+    assert seen["tags"] == []                             # …just untagged
+
+
+def test_dispatched_task_joins_back_and_ARMS_the_guard_end_to_end():
+    """The loop this closes: dispatch → the created clawgate Task carries `initiative:<slug>`
+    → `tasks.py` joins it to that same card → `open_task_count` > 0 → the guard arms."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "tasks_for_dispatch_test", Path(dispatch.__file__).resolve().parent / "tasks.py")
+    tasks = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(tasks)
+
+    posted = {}
+
+    def poster(directory, body, *, repo="", tags=None, creds=None):
+        posted.update({"directory": directory, "tags": tags})
+        return 4242
+
+    view = _view(slug="initiative-task-links", next_step="close the audit findings")
+    res = dispatch.dispatch_initiative(view, poster=poster)
+    assert res["ok"] is True
+
+    # what clawgate would then return from GET /api/tasks for that created task
+    created = {"id": res["task_id"], "directory": posted["directory"],
+               "status": "open", "tags": posted["tags"]}
+    linked = tasks.group_by_slug([created], "http://cg.test:30302")
+    assert list(linked) == ["initiative-task-links"] == [view["slug"]]
+    assert tasks.open_task_count(linked[view["slug"]]) == 1      # → the guard arms
+    assert linked[view["slug"]][0]["url"] == "http://cg.test:30302/tasks#task-4242"

--- a/scripts/initiatives/tests/test_tasks.py
+++ b/scripts/initiatives/tests/test_tasks.py
@@ -1,0 +1,246 @@
+"""Unit tests for `tasks.py` — the CONSUMER of repo-cos's `initiative:<slug>` clawgate tags.
+
+Offline: no network, no clawgate, no creds file. The HTTP read is exercised through the
+injected `getter`, so every degradation path (connection error, non-200, malformed JSON,
+missing creds, a rolled-back clawgate with no `tags` field) is asserted deterministically.
+Mirrors test_dispatch.py's discipline — this module's whole contract is BEST-EFFORT +
+NEVER-RAISES, so the tests are mostly about what it returns when things are broken."""
+import json
+import sys
+import urllib.error
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import tasks  # noqa: E402
+
+
+def _task(tid=1, tags=None, status="open", directory="d", title="", **over):
+    t = {"id": tid, "directory": directory, "title": title, "status": status}
+    if tags is not None:
+        t["tags"] = tags
+    t.update(over)
+    return t
+
+
+CREDS = {"CLAWGATE_API_URL": "http://cg.test:30302", "CLAWGATE_HOOK_TOKEN": "tok"}
+
+
+# --- base URL config -------------------------------------------------------- #
+def test_base_url_defaults_to_the_lan_nodeport():
+    assert tasks.clawgate_base_url({}, {}) == "http://192.168.50.250:30302"
+    assert tasks.DEFAULT_CLAWGATE_URL == "http://192.168.50.250:30302"
+
+
+def test_base_url_env_overrides_creds_and_default():
+    env = {tasks.CLAWGATE_URL_ENV: "http://elsewhere:9/"}
+    assert tasks.clawgate_base_url(CREDS, env) == "http://elsewhere:9"
+    # creds fill in when the env knob is absent/blank (reader + writer agree by default)
+    assert tasks.clawgate_base_url(CREDS, {}) == "http://cg.test:30302"
+    assert tasks.clawgate_base_url(CREDS, {tasks.CLAWGATE_URL_ENV: "  "}) == "http://cg.test:30302"
+
+
+def test_base_url_never_raises_on_garbage():
+    assert tasks.clawgate_base_url(None, None) is not None
+    assert tasks.clawgate_base_url("not-a-dict", {}) == tasks.DEFAULT_CLAWGATE_URL
+
+
+# --- tag parsing: EXACT match only ------------------------------------------ #
+def test_initiative_slugs_extracts_the_reserved_namespace_only():
+    assert tasks.initiative_slugs(_task(tags=["initiative:remix-platform"])) == ["remix-platform"]
+    # a task with SEVERAL tags → only the initiative: ones, order preserved, de-duped
+    assert tasks.initiative_slugs(_task(tags=[
+        "runbook:deploy", "initiative:alpha", "civitai:frontend", "initiative:beta",
+        "initiative:alpha"])) == ["alpha", "beta"]
+
+
+def test_initiative_slugs_no_tag_or_no_tags_field_yields_nothing():
+    assert tasks.initiative_slugs(_task(tags=["runbook:deploy", "gate:needs-decision"])) == []
+    assert tasks.initiative_slugs(_task(tags=[])) == []
+    # a ROLLED-BACK clawgate has no `tags` key at all → [] (not a KeyError)
+    assert tasks.initiative_slugs(_task()) == []
+    # and a non-list / non-string / empty-value tag is skipped, never raised on
+    assert tasks.initiative_slugs(_task(tags="initiative:x")) == []
+    assert tasks.initiative_slugs(_task(tags=[None, 7, "initiative:"])) == []
+    assert tasks.initiative_slugs(None) == []
+
+
+def test_initiative_slugs_is_case_sensitive_and_not_a_prefix_match():
+    # EXACT match only: the tag value is the key, verbatim. `initiative:foo` must never
+    # satisfy `Foo` or `foo-bar` — the join is a dict lookup on this exact string.
+    assert tasks.initiative_slugs(_task(tags=["initiative:foo"])) == ["foo"]
+    assert tasks.initiative_slugs(_task(tags=["initiative:Foo"])) == ["Foo"]
+    assert "foo" not in tasks.group_by_slug([_task(tags=["initiative:Foo"])])
+    assert "Foo" not in tasks.group_by_slug([_task(tags=["initiative:foo"])])
+    assert "foo" not in tasks.group_by_slug([_task(tags=["initiative:foo-bar"])])
+    assert "foo-bar" not in tasks.group_by_slug([_task(tags=["initiative:foo"])])
+    # a differently-cased NAMESPACE isn't the reserved one either
+    assert tasks.initiative_slugs(_task(tags=["Initiative:foo"])) == []
+
+
+# --- grouping --------------------------------------------------------------- #
+def test_group_by_slug_builds_the_slug_to_tasks_map():
+    got = tasks.group_by_slug([
+        _task(1, ["initiative:alpha"], directory="one"),
+        _task(2, ["initiative:beta"], directory="two"),
+    ])
+    assert sorted(got) == ["alpha", "beta"]
+    assert [t["id"] for t in got["alpha"]] == [1]
+    assert got["alpha"][0]["title"] == "one"
+
+
+def test_group_by_slug_two_tasks_on_one_initiative_accumulate():
+    got = tasks.group_by_slug([
+        _task(1, ["initiative:alpha"]), _task(2, ["initiative:alpha"]),
+    ])
+    assert list(got) == ["alpha"]
+    assert [t["id"] for t in got["alpha"]] == [1, 2]   # input order preserved
+
+
+def test_group_by_slug_multi_tagged_task_lands_under_each_slug():
+    got = tasks.group_by_slug([_task(9, ["initiative:alpha", "initiative:beta", "urgent"])])
+    assert [t["id"] for t in got["alpha"]] == [9]
+    assert [t["id"] for t in got["beta"]] == [9]
+
+
+def test_group_by_slug_untagged_task_lands_nowhere():
+    assert tasks.group_by_slug([_task(1), _task(2, ["runbook:x"])]) == {}
+
+
+def test_group_by_slug_unknown_slug_is_just_an_unused_key():
+    # a tag naming an initiative that has no card is harmless — the viewer looks cards UP in
+    # this map, never the reverse, so the entry is simply never read.
+    got = tasks.group_by_slug([_task(1, ["initiative:no-such-card"])])
+    assert list(got) == ["no-such-card"]
+    assert got.get("initiatives-viewer") is None
+
+
+def test_group_by_slug_survives_garbage_input():
+    assert tasks.group_by_slug(None) == {}
+    assert tasks.group_by_slug("nope") == {}
+    assert tasks.group_by_slug([None, 3, _task(1, ["initiative:a"])]) == {
+        "a": [tasks.task_view(_task(1, ["initiative:a"]))]}
+
+
+# --- task view -------------------------------------------------------------- #
+def test_task_view_shape_and_clawgate_deep_link():
+    v = tasks.task_view(_task(42, ["initiative:a"], status="in_progress", directory="do the thing"),
+                        "http://cg.test:30302/")
+    assert v == {"id": 42, "title": "do the thing", "status": "in_progress", "open": True,
+                 "url": "http://cg.test:30302/tasks#task-42"}
+
+
+def test_task_view_prefers_title_over_directory_when_present():
+    v = tasks.task_view(_task(1, title="real title", directory="label"))
+    assert v["title"] == "real title"
+    # …and falls back to `directory`, which is how every current producer smuggles it (§9)
+    assert tasks.task_view(_task(1, directory="label"))["title"] == "label"
+
+
+def test_task_view_no_base_or_no_id_yields_no_url():
+    assert tasks.task_view(_task(1))["url"] == ""
+    assert tasks.task_view({"status": "open"}, "http://cg.test")["url"] == ""
+    assert tasks.task_view({"id": True}, "http://cg.test")["id"] is None   # bool is not an id
+
+
+# --- open/closed statuses (the dispatch guard's input) ---------------------- #
+def test_is_open_is_a_closed_set_of_live_statuses():
+    assert tasks.is_open(_task(status="open")) is True
+    assert tasks.is_open(_task(status="in_progress")) is True
+    assert tasks.is_open(_task(status="ready_for_review")) is True
+    # complete / dismissed / unknown / missing must NOT block a dispatch (fail-open)
+    assert tasks.is_open(_task(status="complete")) is False
+    assert tasks.is_open(_task(status="dismissed")) is False
+    assert tasks.is_open(_task(status="")) is False
+    assert tasks.is_open({}) is False
+    assert tasks.is_open(None) is False
+
+
+def test_open_task_count_counts_only_live_work():
+    views = [tasks.task_view(_task(1, status="open")),
+             tasks.task_view(_task(2, status="in_progress")),
+             tasks.task_view(_task(3, status="complete")),
+             tasks.task_view(_task(4, status="dismissed"))]
+    assert tasks.open_task_count(views) == 2
+    assert tasks.open_task_count([]) == 0
+    assert tasks.open_task_count(None) == 0
+
+
+# --- fetch: the degradation matrix ----------------------------------------- #
+def _getter(body):
+    def get(url, token, *, timeout=None):
+        get.calls.append((url, token, timeout))
+        return body
+    get.calls = []
+    return get
+
+
+def test_fetch_tasks_happy_path_hits_api_tasks_with_the_bearer_token():
+    get = _getter(json.dumps([_task(1, ["initiative:a"])]))
+    got = tasks.fetch_tasks(creds=CREDS, env={}, getter=get)
+    assert [t["id"] for t in got] == [1]
+    url, token, timeout = get.calls[0]
+    assert url == "http://cg.test:30302/api/tasks"
+    assert token == "tok"
+    assert timeout == tasks.FETCH_TIMEOUT and tasks.FETCH_TIMEOUT <= 5   # SHORT, on the render path
+
+
+def test_fetch_tasks_missing_creds_yields_empty_without_calling_out(capsys):
+    get = _getter("[]")
+    assert tasks.fetch_tasks(creds={}, env={}, getter=get) == []
+    assert get.calls == []                       # never even attempted a request
+    assert "CLAWGATE_HOOK_TOKEN" in capsys.readouterr().err
+
+
+def test_fetch_tasks_connection_error_yields_empty():
+    def boom(url, token, *, timeout=None):
+        raise OSError("Connection refused")
+    assert tasks.fetch_tasks(creds=CREDS, env={}, getter=boom) == []
+
+
+def test_fetch_tasks_non_200_yields_empty():
+    def http_err(url, token, *, timeout=None):
+        raise urllib.error.HTTPError(url, 503, "Service Unavailable", {}, None)
+    assert tasks.fetch_tasks(creds=CREDS, env={}, getter=http_err) == []
+
+
+def test_fetch_tasks_malformed_json_yields_empty():
+    assert tasks.fetch_tasks(creds=CREDS, env={}, getter=_getter("{not json")) == []
+    # a well-formed but non-array body is refused too (never a crash)
+    assert tasks.fetch_tasks(creds=CREDS, env={}, getter=_getter('{"error":"nope"}')) == []
+
+
+def test_fetch_tasks_skips_non_dict_entries():
+    got = tasks.fetch_tasks(creds=CREDS, env={}, getter=_getter('[1, null, {"id": 5}]'))
+    assert got == [{"id": 5}]
+
+
+# --- orchestrator ----------------------------------------------------------- #
+def test_linked_tasks_map_fetches_once_then_groups():
+    calls = []
+
+    def fetch(*, creds=None, env=None, timeout=None):
+        calls.append(creds)
+        return [_task(1, ["initiative:alpha"]), _task(2, ["initiative:alpha"]), _task(3)]
+
+    got = tasks.linked_tasks_map(creds=CREDS, env={}, fetcher=fetch)
+    assert len(calls) == 1                                # ONE read, not one per card
+    assert list(got) == ["alpha"]
+    assert [t["id"] for t in got["alpha"]] == [1, 2]
+    assert got["alpha"][0]["url"] == "http://cg.test:30302/tasks#task-1"
+
+
+def test_linked_tasks_map_returns_empty_map_on_any_failure():
+    def boom(*, creds=None, env=None, timeout=None):
+        raise RuntimeError("clawgate exploded")
+    assert tasks.linked_tasks_map(creds=CREDS, env={}, fetcher=boom) == {}
+    # …and a fetcher that merely returns nothing (unreachable clawgate) is an empty map too
+    assert tasks.linked_tasks_map(
+        creds=CREDS, env={}, fetcher=lambda **kw: []) == {}
+
+
+def test_linked_tasks_map_no_tags_field_anywhere_is_an_empty_map():
+    # a rolled-back clawgate omits `tags` on every task → nothing joins, nothing breaks
+    assert tasks.linked_tasks_map(
+        creds=CREDS, env={},
+        fetcher=lambda **kw: [_task(1), _task(2), _task(3)]) == {}

--- a/scripts/initiatives/tests/test_tasks.py
+++ b/scripts/initiatives/tests/test_tasks.py
@@ -168,8 +168,8 @@ def test_open_task_count_counts_only_live_work():
 
 # --- fetch: the degradation matrix ----------------------------------------- #
 def _getter(body):
-    def get(url, token, *, timeout=None):
-        get.calls.append((url, token, timeout))
+    def get(url, token, *, deadline=None):
+        get.calls.append((url, token, deadline))
         return body
     get.calls = []
     return get
@@ -179,10 +179,11 @@ def test_fetch_tasks_happy_path_hits_api_tasks_with_the_bearer_token():
     get = _getter(json.dumps([_task(1, ["initiative:a"])]))
     got = tasks.fetch_tasks(creds=CREDS, env={}, getter=get)
     assert [t["id"] for t in got] == [1]
-    url, token, timeout = get.calls[0]
+    url, token, deadline = get.calls[0]
     assert url == "http://cg.test:30302/api/tasks"
     assert token == "tok"
-    assert timeout == tasks.FETCH_TIMEOUT and tasks.FETCH_TIMEOUT <= 5   # SHORT, on the render path
+    # SHORT wall-clock deadline — this is a decoration on the render path, not core data
+    assert deadline == tasks.FETCH_DEADLINE and tasks.FETCH_DEADLINE <= 5
 
 
 def test_fetch_tasks_missing_creds_yields_empty_without_calling_out(capsys):
@@ -193,13 +194,13 @@ def test_fetch_tasks_missing_creds_yields_empty_without_calling_out(capsys):
 
 
 def test_fetch_tasks_connection_error_yields_empty():
-    def boom(url, token, *, timeout=None):
+    def boom(url, token, *, deadline=None):
         raise OSError("Connection refused")
     assert tasks.fetch_tasks(creds=CREDS, env={}, getter=boom) == []
 
 
 def test_fetch_tasks_non_200_yields_empty():
-    def http_err(url, token, *, timeout=None):
+    def http_err(url, token, *, deadline=None):
         raise urllib.error.HTTPError(url, 503, "Service Unavailable", {}, None)
     assert tasks.fetch_tasks(creds=CREDS, env={}, getter=http_err) == []
 
@@ -219,7 +220,7 @@ def test_fetch_tasks_skips_non_dict_entries():
 def test_linked_tasks_map_fetches_once_then_groups():
     calls = []
 
-    def fetch(*, creds=None, env=None, timeout=None):
+    def fetch(*, creds=None, env=None, deadline=None):
         calls.append(creds)
         return [_task(1, ["initiative:alpha"]), _task(2, ["initiative:alpha"]), _task(3)]
 
@@ -231,7 +232,7 @@ def test_linked_tasks_map_fetches_once_then_groups():
 
 
 def test_linked_tasks_map_returns_empty_map_on_any_failure():
-    def boom(*, creds=None, env=None, timeout=None):
+    def boom(*, creds=None, env=None, deadline=None):
         raise RuntimeError("clawgate exploded")
     assert tasks.linked_tasks_map(creds=CREDS, env={}, fetcher=boom) == {}
     # …and a fetcher that merely returns nothing (unreachable clawgate) is an empty map too
@@ -244,3 +245,295 @@ def test_linked_tasks_map_no_tags_field_anywhere_is_an_empty_map():
     assert tasks.linked_tasks_map(
         creds=CREDS, env={},
         fetcher=lambda **kw: [_task(1), _task(2), _task(3)]) == {}
+
+
+# --- ok flag: a FAILED read is distinguishable from an empty queue ----------- #
+def test_fetch_tasks_result_separates_failure_from_an_empty_queue():
+    # clawgate answered with an empty queue → SUCCESS (nothing to serve stale).
+    assert tasks.fetch_tasks_result(creds=CREDS, env={}, getter=_getter("[]")) == (True, [])
+    # every failure shape is ok=False — which is what lets the cache serve the last good map.
+    def boom(url, token, *, deadline=None):
+        raise OSError("Connection refused")
+    assert tasks.fetch_tasks_result(creds=CREDS, env={}, getter=boom) == (False, [])
+    assert tasks.fetch_tasks_result(creds=CREDS, env={}, getter=_getter("{not json")) == (False, [])
+    assert tasks.fetch_tasks_result(creds={}, env={}, getter=_getter("[]")) == (False, [])
+
+
+# --- 🔴 THE WALL-CLOCK DEADLINE, against REAL sockets ------------------------ #
+# The bug this replaces shipped because the only latency test was "connection refused is
+# fast" (+0.010s). A refused connection exercises NONE of the failure modes that matter:
+# `urlopen(timeout=)` is per-socket-OPERATION, so a peer that accepts and never replies cost
+# the full timeout on EVERY render (+4.005s on a 0.80s baseline), and a peer that dribbles a
+# byte just inside the timeout was UNBOUNDED (+130s measured — and it still succeeded).
+# These two tests stand up real sockets that behave exactly that way.
+def _serve(handler):
+    """Start a one-connection TCP server on an ephemeral port; returns (url, stop)."""
+    import socket, threading
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(4)
+    port = srv.getsockname()[1]
+    stop = threading.Event()
+
+    def loop():
+        srv.settimeout(0.25)
+        while not stop.is_set():
+            try:
+                conn, _ = srv.accept()
+            except OSError:
+                continue
+            threading.Thread(target=handler, args=(conn, stop), daemon=True).start()
+        try:
+            srv.close()
+        except OSError:
+            pass
+
+    th = threading.Thread(target=loop, daemon=True)
+    th.start()
+    return f"http://127.0.0.1:{port}", stop.set
+
+
+def _blackhole(conn, stop):
+    """Accept the connection, read the request, and then say NOTHING, ever."""
+    try:
+        conn.recv(4096)
+        while not stop.is_set():
+            stop.wait(0.1)
+    finally:
+        try:
+            conn.close()
+        except OSError:
+            pass
+
+
+def _slow_drip(conn, stop):
+    """Reply one byte at a time, slowly — each individual send is well inside any per-socket
+    timeout, so this is the shape that defeated `urlopen(timeout=)` entirely."""
+    try:
+        conn.recv(4096)
+        body = json.dumps([_task(1, ["initiative:alpha"])])
+        raw = (f"HTTP/1.1 200 OK\r\nContent-Length: {len(body)}\r\n"
+               f"Content-Type: application/json\r\n\r\n{body}").encode()
+        for byte in raw:
+            if stop.is_set():
+                return
+            try:
+                conn.sendall(bytes([byte]))
+            except OSError:
+                return
+            stop.wait(0.25)          # 1 byte / 250ms — always inside the socket timeout
+    finally:
+        try:
+            conn.close()
+        except OSError:
+            pass
+
+
+def _timed_fetch(url, *, deadline):
+    import time
+    creds = {"CLAWGATE_API_URL": url, "CLAWGATE_HOOK_TOKEN": "tok"}
+    t0 = time.monotonic()
+    got = tasks.fetch_tasks(creds=creds, env={}, deadline=deadline)
+    return got, time.monotonic() - t0
+
+
+def test_blackholed_clawgate_costs_at_most_the_deadline():
+    url, stop = _serve(_blackhole)
+    try:
+        got, elapsed = _timed_fetch(url, deadline=1.0)
+    finally:
+        stop()
+    assert got == []                        # degrades to "no linked tasks"
+    assert elapsed < 2.0, f"blackhole added {elapsed:.3f}s for a 1.0s deadline"
+
+
+def test_slow_drip_clawgate_costs_at_most_the_deadline():
+    # 1 byte / 250ms over a ~120-byte response is ~30s of dribble; every individual read is
+    # inside the socket timeout, so ONLY a wall-clock deadline can bound this.
+    url, stop = _serve(_slow_drip)
+    try:
+        got, elapsed = _timed_fetch(url, deadline=1.0)
+    finally:
+        stop()
+    assert got == []
+    assert elapsed < 2.0, f"slow-drip added {elapsed:.3f}s for a 1.0s deadline"
+
+
+def test_run_with_deadline_bounds_any_callable_and_reraises():
+    import time
+    t0 = time.monotonic()
+    try:
+        tasks._run_with_deadline(lambda: time.sleep(30), 0.3)
+    except TimeoutError:
+        pass
+    else:
+        raise AssertionError("a 30s callable must not satisfy a 0.3s deadline")
+    assert time.monotonic() - t0 < 1.5
+    # a fast callable returns its value; a raising one re-raises verbatim
+    assert tasks._run_with_deadline(lambda: 42, 5) == 42
+    try:
+        tasks._run_with_deadline(lambda: (_ for _ in ()).throw(ValueError("nope")), 5)
+    except ValueError as exc:
+        assert "nope" in str(exc)
+    else:
+        raise AssertionError("the worker's exception must reach the caller")
+
+
+# --- response SIZE CAP ------------------------------------------------------- #
+def test_oversized_response_is_refused_rather_than_buffered():
+    # `Notes.List` has no LIMIT and rows carry full task bodies, so the payload grows with
+    # retained history. A body past the cap is a failed read, not an unbounded read.
+    huge = "[" + ",".join('{"id": %d}' % i for i in range(4000)) + "]"
+    assert len(huge) > 1000
+
+    def big(url, token, *, deadline=None):
+        raise OSError(f"response exceeded the {tasks.MAX_RESPONSE_BYTES}-byte cap")
+
+    assert tasks.fetch_tasks_result(creds=CREDS, env={}, getter=big) == (False, [])
+    assert tasks.MAX_RESPONSE_BYTES <= (4 << 20)     # bounded, not "some big number"
+
+
+def test_real_get_caps_the_response_body():
+    def flood(conn, stop):
+        try:
+            conn.recv(4096)
+            conn.sendall(b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n")
+            blob = b"x" * 65536
+            while not stop.is_set():
+                try:
+                    conn.sendall(blob)
+                except OSError:
+                    return
+        finally:
+            try:
+                conn.close()
+            except OSError:
+                pass
+
+    url, stop = _serve(flood)
+    try:
+        try:
+            tasks._get(f"{url}/api/tasks", "tok", deadline=5, max_bytes=4096)
+        except OSError as exc:
+            assert "cap" in str(exc)
+        else:
+            raise AssertionError("an unbounded body must not be buffered whole")
+    finally:
+        stop()
+
+
+# --- the linked-task CACHE: TTL, serve-stale, single-flight ------------------ #
+class _Clock:
+    def __init__(self):
+        self.t = 1000.0
+
+    def __call__(self):
+        return self.t
+
+
+def test_cache_serves_within_its_ttl_without_refetching():
+    clock = _Clock()
+    cache = tasks.LinkedTaskCache(ttl=30.0, now=clock)
+    calls = []
+
+    def loader():
+        calls.append(1)
+        return True, {"alpha": [{"id": 1}]}
+
+    assert cache.get(loader) == {"alpha": [{"id": 1}]}
+    clock.t += 29.0
+    assert cache.get(loader) == {"alpha": [{"id": 1}]}
+    assert len(calls) == 1                    # still inside the TTL → no second clawgate read
+    clock.t += 2.0
+    cache.get(loader)
+    assert len(calls) == 2                    # past it → exactly one refresh
+
+
+def test_cache_serves_the_LAST_GOOD_map_when_a_refresh_fails(capsys):
+    # 🔴 the whole point: a transient blip must not make linked tasks — and with them the
+    # dispatch guard — flicker away. A failure keeps the previous map.
+    clock = _Clock()
+    cache = tasks.LinkedTaskCache(ttl=10.0, now=clock)
+    good = {"alpha": [{"id": 1, "open": True}]}
+    state = {"ok": True}
+
+    def loader():
+        return (True, good) if state["ok"] else (False, {})
+
+    assert cache.get(loader) == good
+    state["ok"] = False
+    clock.t += 11.0
+    assert cache.get(loader) == good          # STALE, not empty
+    assert "stale" in capsys.readouterr().err
+    # and it recovers when clawgate does
+    state["ok"] = True
+    clock.t += 11.0
+    assert cache.get(loader) == good
+
+
+def test_cache_backs_off_after_a_failure_instead_of_retrying_every_call():
+    clock = _Clock()
+    cache = tasks.LinkedTaskCache(ttl=10.0, now=clock)
+    calls = []
+
+    def loader():
+        calls.append(1)
+        return False, {}
+
+    assert cache.get(loader) == {}            # never succeeded → empty, exactly today's board
+    assert cache.get(loader) == {}
+    assert cache.get(loader) == {}
+    assert len(calls) == 1                    # a hung clawgate is retried once per TTL, not per request
+
+
+def test_cache_never_raises_when_the_loader_explodes():
+    cache = tasks.LinkedTaskCache(ttl=10.0, now=_Clock())
+
+    def boom():
+        raise RuntimeError("clawgate exploded")
+
+    assert cache.get(boom) == {}
+
+
+def test_cache_is_single_flight_so_a_slow_read_never_queues_callers():
+    # A concurrent caller must get the current value IMMEDIATELY rather than blocking behind a
+    # slow clawgate — the other half of moving the read out of DataProvider._lock.
+    import threading, time
+    cache = tasks.LinkedTaskCache(ttl=0.0)          # always "stale" → always tries to refresh
+    entered = threading.Event()
+    release = threading.Event()
+
+    def slow():
+        entered.set()
+        release.wait(5)
+        return True, {"alpha": []}
+
+    th = threading.Thread(target=lambda: cache.get(slow), daemon=True)
+    th.start()
+    assert entered.wait(5)
+    t0 = time.monotonic()
+    assert cache.get(lambda: (True, {"never": []})) == {}   # returns at once with what it has
+    assert time.monotonic() - t0 < 0.5
+    release.set()
+    th.join(5)
+
+
+def test_cached_linked_tasks_map_uses_the_cache_and_never_raises():
+    cache = tasks.LinkedTaskCache(ttl=60.0, now=_Clock())
+    calls = []
+
+    def fetcher(*, creds=None, env=None, deadline=None):
+        calls.append(1)
+        return True, [_task(1, ["initiative:alpha"])]
+
+    got = tasks.cached_linked_tasks_map(creds=CREDS, env={}, fetcher=fetcher, cache=cache)
+    assert list(got) == ["alpha"]
+    tasks.cached_linked_tasks_map(creds=CREDS, env={}, fetcher=fetcher, cache=cache)
+    assert len(calls) == 1                    # second render served from the cache
+
+    def boom(*, creds=None, env=None, deadline=None):
+        raise RuntimeError("nope")
+
+    cache.invalidate()
+    assert tasks.cached_linked_tasks_map(creds=CREDS, env={}, fetcher=boom, cache=cache) == {}

--- a/scripts/initiatives/tests/test_tasks.py
+++ b/scripts/initiatives/tests/test_tasks.py
@@ -148,9 +148,12 @@ def test_is_open_is_a_closed_set_of_live_statuses():
     assert tasks.is_open(_task(status="open")) is True
     assert tasks.is_open(_task(status="in_progress")) is True
     assert tasks.is_open(_task(status="ready_for_review")) is True
-    # complete / dismissed / unknown / missing must NOT block a dispatch (fail-open)
+    # complete / a future-renamed status / unknown / missing must NOT block a dispatch.
+    # clawgate's vocabulary is exactly {open, in_progress, ready_for_review, complete}
+    # (internal/notes/notes.go), so `retired_by_a_later_clawgate` stands in for "a status
+    # this code has never heard of" — OPEN_STATUSES is an allow-list, so it fails OPEN.
     assert tasks.is_open(_task(status="complete")) is False
-    assert tasks.is_open(_task(status="dismissed")) is False
+    assert tasks.is_open(_task(status="retired_by_a_later_clawgate")) is False
     assert tasks.is_open(_task(status="")) is False
     assert tasks.is_open({}) is False
     assert tasks.is_open(None) is False
@@ -160,7 +163,7 @@ def test_open_task_count_counts_only_live_work():
     views = [tasks.task_view(_task(1, status="open")),
              tasks.task_view(_task(2, status="in_progress")),
              tasks.task_view(_task(3, status="complete")),
-             tasks.task_view(_task(4, status="dismissed"))]
+             tasks.task_view(_task(4, status="retired_by_a_later_clawgate"))]
     assert tasks.open_task_count(views) == 2
     assert tasks.open_task_count([]) == 0
     assert tasks.open_task_count(None) == 0

--- a/scripts/initiatives/tests/test_viewer.py
+++ b/scripts/initiatives/tests/test_viewer.py
@@ -5343,7 +5343,7 @@ def test_clawgate_failures_all_render_the_unchanged_board(capsys):
         # what the real read path yields when the body doesn't parse
         return tasks_mod.group_by_slug(tasks_mod.fetch_tasks(
             creds={"CLAWGATE_HOOK_TOKEN": "t"}, env={},
-            getter=lambda url, tok, timeout=None: "{not json"))
+            getter=lambda url, tok, deadline=None: "{not json"))
 
     def missing_creds():
         return tasks_mod.linked_tasks_map(creds={}, env={}, fetcher=tasks_mod.fetch_tasks)
@@ -5447,7 +5447,7 @@ def test_js_linked_tasks_hint_lists_only_the_open_tasks():
                           {"id": 77, "status": "in_progress", "open": True}]}
     got = _node_actions_js(
         "console.log(JSON.stringify(linkedTasksHint(" + json.dumps(v) + ")));")
-    assert got == "#92 open · #77 in_progress"
+    assert got == "#92 open · #77 in progress"    # humanized, not the raw `in_progress` enum
     # no linked tasks → an empty hint, never "undefined"
     assert _node_actions_js("console.log(JSON.stringify(linkedTasksHint({})));") == ""
 
@@ -5477,3 +5477,157 @@ def test_render_html_ships_the_linked_task_css_and_guard_css():
     assert ".dispatch-btn.guarded{" in html and ".dispatch-btn.armed{" in html
     # the data reaches the page through the SAME JSON island as everything else
     assert '"open_task_count": 1' in html and "tasks#task-1" in html
+
+
+# --- 🔴 the clawgate read must NOT hold DataProvider._lock ------------------- #
+def test_a_hung_clawgate_read_does_not_serialize_other_board_requests():
+    """`/`, `/api/initiatives.json`, `/api/initiative` and `/api/ask` all funnel through
+    `snapshot()`. When the linked-task read lived INSIDE `_lock`, a hung clawgate blocked all
+    of them; out here it only delays the rebuild."""
+    import threading as _th
+    import time as _time
+    rows = _rows_for_degradation()
+    entered, release = _th.Event(), _th.Event()
+
+    def slow_linked():
+        entered.set()
+        release.wait(10)
+        return {}
+
+    prov = viewer.DataProvider(ttl=60, loader=lambda: (rows, []), tmux=lambda r: [],
+                               now_fn=lambda: NOW, linked_tasks=slow_linked)
+    # warm the board cache with a fast read, then force a rebuild with the slow one
+    prov.snapshot()
+    prov.invalidate()
+    th = _th.Thread(target=prov.snapshot, daemon=True)
+    th.start()
+    assert entered.wait(10), "the clawgate read never started"
+    # while it hangs, a request that finds a fresh cache must return AT ONCE. Prime one by
+    # letting a *second* provider serve — here we assert the lock itself is free.
+    t0 = _time.monotonic()
+    acquired = prov._lock.acquire(timeout=2)
+    held = _time.monotonic() - t0
+    if acquired:
+        prov._lock.release()
+    release.set()
+    th.join(10)
+    assert acquired, f"_lock was held across the clawgate read (waited {held:.2f}s)"
+    assert held < 1.0, f"acquiring _lock took {held:.2f}s during a hung clawgate read"
+
+
+def test_board_renders_within_the_deadline_against_a_blackholed_clawgate():
+    """End-to-end through the REAL read path (tasks.fetch → group), pointed at a socket that
+    accepts and never replies — the shape a closed port does NOT exercise."""
+    import socket as _socket
+    import threading as _th
+    import time as _time
+    srv = _socket.socket()
+    srv.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(2)
+    port = srv.getsockname()[1]
+    stop = _th.Event()
+
+    def accept_and_stall():
+        srv.settimeout(0.25)
+        while not stop.is_set():
+            try:
+                conn, _ = srv.accept()
+            except OSError:
+                continue
+            try:
+                conn.recv(4096)
+            except OSError:
+                pass
+        srv.close()
+
+    _th.Thread(target=accept_and_stall, daemon=True).start()
+    tasks_mod = viewer._tasks()
+    creds = {"CLAWGATE_API_URL": f"http://127.0.0.1:{port}", "CLAWGATE_HOOK_TOKEN": "tok"}
+    deadline = 1.0
+    try:
+        t0 = _time.monotonic()
+        model, err = _provider_with_linked(
+            lambda: tasks_mod.linked_tasks_map(creds=creds, env={}, deadline=deadline)
+        ).snapshot()
+        elapsed = _time.monotonic() - t0
+    finally:
+        stop.set()
+    assert err is None and model is not None
+    assert model["total"] == 2                      # the board rendered, unchanged
+    assert elapsed < 2.5, f"a blackholed clawgate cost {elapsed:.2f}s for a {deadline}s deadline"
+
+
+# --- 🟡 optimistic dispatch count: the SECOND tap is guarded immediately ----- #
+def test_js_note_dispatched_arms_the_guard_before_the_server_catches_up():
+    """After a successful dispatch the server's open_task_count lags by up to ~a minute
+    (tasks.py's 30s cache + the 5s provider TTL + the 30s refetch). The client folds in its
+    OWN dispatch so the next render is guarded — the exact duplicate this feature prevents."""
+    v = {"slug": "alpha", "repo": "/r", "state": "active", "recommended_next_step": _REC}
+    got = _node_actions_js(
+        "var v = " + json.dumps(v) + ";\n"
+        "var before = cardActions(v)[0];\n"
+        "noteDispatched(v, 1000);\n"                       # a confirmed dispatch at t=1000ms
+        "var after = dispatchAction(v, '⤴ dispatch', 1000);\n"
+        "var expired = dispatchAction(v, '⤴ dispatch', 1000 + OPTIMISTIC_TTL_MS + 1);\n"
+        "console.log(JSON.stringify({before: before.guard || null,"
+        " after: after.guard || null, expired: expired.guard || null,"
+        " label: after.guardLabel || null}));")
+    assert got["before"] is None                              # unguarded before the dispatch
+    assert got["after"] == "already has 1 open task — dispatch anyway?"
+    assert got["label"] == "dispatch anyway?"
+    assert got["expired"] is None                             # bounded by OPTIMISTIC_TTL_MS
+
+
+def test_js_optimistic_count_only_ever_adds_guarding():
+    """`Math.max`, never a replacement: a server that already reports MORE open tasks wins,
+    and the overlay can never lower a count (which would silently un-guard a card)."""
+    v = {"slug": "beta", "repo": "/r", "open_task_count": 3}
+    got = _node_actions_js(
+        "var v = " + json.dumps(v) + ";\n"
+        "var a = openTaskCount(v, 1000);\n"
+        "noteDispatched(v, 1000);\n"
+        "var b = openTaskCount(v, 1000);\n"
+        "var other = openTaskCount({slug:'beta', repo:'/other'}, 1000);\n"
+        "console.log(JSON.stringify([a, b, other]));")
+    assert got == [3, 4, 0]      # the overlay is keyed on (repo, slug) — no cross-card bleed
+
+
+def test_js_dispatch_button_arms_to_the_SHORT_label_not_the_full_sentence():
+    """🟡 layout: the armed text replaces the button's own label in place, so the full guard
+    sentence (43 chars) blew the action row up — 97px → 332px at 1280 and 97px → 222px at 390,
+    where it wrapped and reflowed ⤓ archive. The armed state follows the board's established
+    two-tap grammar (`drop?` / `archive?`); the full reason stays in the tooltip."""
+    got = _node_actions_js(
+        "console.log(JSON.stringify(["
+        "guardArmedLabel('⤴ dispatch'), guardArmedLabel('⤴ resume'), guardArmedLabel('')]));")
+    assert got == ["dispatch anyway?", "resume anyway?", "dispatch anyway?"]
+    for label in got:
+        assert len(label) <= 16
+    card = _card_body()
+    # the BUTTON arms to guardLabel and keeps the full explanation in the title
+    assert "armedLabel: a.guardLabel || a.guard" in card
+    assert "btn.title = a.guard + '  ·  ' + linkedTasksHint(v)" in card
+    assert "noteDispatched(v)" in viewer._JS
+
+
+def test_armed_dispatch_button_css_beats_the_guarded_hover_rule():
+    """🟢 `.dispatch-btn.guarded:hover:not(:disabled)` scores (0,4,0) and out-specifies
+    `.dispatch-btn.armed` (0,2,0) — so without the `:not(.armed)` carve-out an armed button
+    under the cursor (i.e. every armed button, since arming needs a click) kept the yellow
+    border instead of flipping to orange."""
+    html = viewer.render_html(viewer.build_model([_row(slug="a")], now=NOW), None)
+    assert ".dispatch-btn.guarded:hover:not(:disabled):not(.armed){" in html
+    assert ".dispatch-btn.guarded:hover:not(:disabled){border-color:var(--yellow)}" not in html
+
+
+# --- 🟢 humanized status pill ------------------------------------------------ #
+def test_js_task_status_labels_are_humanized():
+    got = _node_actions_js(
+        "console.log(JSON.stringify(['open','in_progress','ready_for_review','complete',"
+        "'some_new_status','',null].map(taskStatusLabel)));")
+    assert got == ["open", "in progress", "ready for review", "complete",
+                   "some new status", "unknown", "unknown"]
+    detail = _detail_body()
+    assert "el('span', 'lt-status', taskStatusLabel(t.status))" in detail
+    assert "pill.title = t.status" in detail

--- a/scripts/initiatives/tests/test_viewer.py
+++ b/scripts/initiatives/tests/test_viewer.py
@@ -9,6 +9,7 @@ The store read + tmux overlay (the I/O) are exercised only via a fake provider �
 how sync.py/route.py separate the pure transform from infra."""
 import json
 import sys
+import urllib.error
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -2784,8 +2785,19 @@ def test_js_card_wires_two_tap_confirm_on_done_and_drop():
     assert "armConfirm(dropBtn, {armedLabel: 'drop?'" in body
     assert "archiveCard(v, doneBtn, astat, 'done', c)" in body
     assert "archiveCard(v, dropBtn, astat, 'dropped', c)" in body
-    # resolve + dispatch stay SINGLE-tap (human-gated downstream): no armConfirm on them.
-    assert "armConfirm(rbtn" not in body and "armConfirm(btn" not in body
+    # [resolve] stays SINGLE-tap unconditionally (it only opens the read-only ask sidebar).
+    assert "armConfirm(rbtn" not in body
+    # [⤴ dispatch] is single-tap by DEFAULT and two-tap ONLY when the linked-task guard fires
+    # (a.guard set = the initiative already has open clawgate tasks). So the armConfirm call
+    # must live inside the `if(a.guard)` branch, and the plain addEventListener path must
+    # still exist for the unguarded case — today's behaviour, untouched.
+    guard_branch = body.split("if(a.guard){", 1)
+    assert len(guard_branch) == 2, "the dispatch guard branch is missing"
+    guarded, rest = guard_branch[1].split("} else {", 1)
+    assert "armConfirm(btn, {armedLabel: a.guard" in guarded
+    assert "dispatchNextStep(v, btn, dstat)" in guarded
+    assert "armConfirm" not in rest.split("} else if(a.kind === 'done')", 1)[0]
+    assert "btn.addEventListener('click'" in rest
 
 
 def test_render_html_ships_armed_confirm_css():
@@ -5227,3 +5239,241 @@ def test_render_smoke_vocab_clarity_all_five_on_one_page():
     assert ".qa .drafting{" in html
     # regression: the per-card emerging badge + the ask sidebar's citation render survive.
     assert "emerging-badge" in html and "function renderSources(" in html
+
+
+# --------------------------------------------------------------------------- #
+# LINKED CLAWGATE TASKS — the consumer of repo-cos's `initiative:<slug>` tags.
+# The pure fetch/group layer is covered in test_tasks.py; here: the viewer JOIN
+# (build_model / build_detail / DataProvider), the SILENT degradation contract
+# (a clawgate failure must render byte-identically to today), and the dispatch
+# guard + expanded-detail JS (node-eval'd / source-asserted, like the rest).
+# --------------------------------------------------------------------------- #
+def _tv(tid, status="open", title=None, with_url=True):
+    """A linked-task view as `tasks.task_view` produces it."""
+    return {"id": tid, "title": title or f"task {tid}", "status": status,
+            "open": status in ("open", "in_progress", "ready_for_review"),
+            "url": f"http://cg.test:30302/tasks#task-{tid}" if with_url else ""}
+
+
+def test_build_model_attaches_linked_tasks_by_exact_slug():
+    rows = [_row(slug="alpha"), _row(slug="beta", repo="/home/zach/workspace/other")]
+    model = viewer.build_model(
+        rows, now=NOW, linked_tasks={"alpha": [_tv(1), _tv(2, "complete")]})
+    by_slug = {v["slug"]: v for v in model["flat"]}
+    assert [t["id"] for t in by_slug["alpha"]["linked_tasks"]] == [1, 2]
+    assert by_slug["alpha"]["open_task_count"] == 1          # the complete one doesn't count
+    # a card with no linked tasks gets the SAME (empty) shape, never a missing key
+    assert by_slug["beta"]["linked_tasks"] == []
+    assert by_slug["beta"]["open_task_count"] == 0
+
+
+def test_build_model_join_is_exact_not_case_or_prefix_insensitive():
+    rows = [_row(slug="foo")]
+    for wrong in ("Foo", "foo-bar", "fo", "FOO"):
+        model = viewer.build_model(rows, now=NOW, linked_tasks={wrong: [_tv(1)]})
+        assert model["flat"][0]["linked_tasks"] == [], wrong
+        assert model["flat"][0]["open_task_count"] == 0
+
+
+def test_build_model_unknown_slug_in_the_map_matches_no_card():
+    model = viewer.build_model([_row(slug="alpha")], now=NOW,
+                               linked_tasks={"no-such-initiative": [_tv(9)]})
+    assert model["flat"][0]["linked_tasks"] == []
+    assert model["total"] == 1                                # no phantom card invented
+
+
+def test_build_model_open_task_count_ignores_complete_and_dismissed():
+    model = viewer.build_model([_row(slug="a")], now=NOW, linked_tasks={"a": [
+        _tv(1, "open"), _tv(2, "in_progress"), _tv(3, "complete"), _tv(4, "dismissed")]})
+    assert model["flat"][0]["open_task_count"] == 2
+
+
+def test_build_model_garbage_linked_tasks_degrades_to_empty():
+    for junk in (None, {}, "nope", {"a": "not-a-list"}, {"a": None}):
+        model = viewer.build_model([_row(slug="a")], now=NOW, linked_tasks=junk)
+        assert model["flat"][0]["linked_tasks"] == []
+        assert model["flat"][0]["open_task_count"] == 0
+
+
+# --- the SILENT-degradation contract: every failure renders today's board ---- #
+def _rows_for_degradation():
+    return [_row(slug="alpha"), _row(slug="beta", momentum="stalled",
+                                     last_touch=NOW - timedelta(days=9))]
+
+
+def _render_with(linked_tasks):
+    return viewer.render_html(
+        viewer.build_model(_rows_for_degradation(), now=NOW, linked_tasks=linked_tasks), None)
+
+
+def test_no_linked_tasks_renders_exactly_the_pre_feature_board():
+    baseline = viewer.render_html(
+        viewer.build_model(_rows_for_degradation(), now=NOW), None)
+    # every "clawgate gave us nothing" shape must produce the IDENTICAL page
+    for empty in ({}, None):
+        assert _render_with(empty) == baseline
+
+
+def _provider_with_linked(linked_fn):
+    rows = _rows_for_degradation()
+    return viewer.DataProvider(ttl=0, loader=lambda: (rows, []),
+                               tmux=lambda r: [], now_fn=lambda: NOW,
+                               linked_tasks=linked_fn)
+
+
+def _rendered(provider):
+    model, err = provider.snapshot()
+    assert err is None, err
+    return viewer.render_html(model, err)
+
+
+def test_clawgate_failures_all_render_the_unchanged_board(capsys):
+    """Connection error, non-200, malformed JSON, missing creds, and a no-`tags` response
+    each yield the SAME page as the no-tasks render — not merely "no exception escaped"."""
+    baseline = _rendered(_provider_with_linked(lambda: {}))
+    tasks_mod = viewer._tasks()
+
+    def connection_error():
+        raise OSError("Connection refused")
+
+    def http_503():
+        raise urllib.error.HTTPError("http://cg/api/tasks", 503, "boom", {}, None)
+
+    def malformed_json():
+        # what the real read path yields when the body doesn't parse
+        return tasks_mod.group_by_slug(tasks_mod.fetch_tasks(
+            creds={"CLAWGATE_HOOK_TOKEN": "t"}, env={},
+            getter=lambda url, tok, timeout=None: "{not json"))
+
+    def missing_creds():
+        return tasks_mod.linked_tasks_map(creds={}, env={}, fetcher=tasks_mod.fetch_tasks)
+
+    def no_tags_field():
+        # a rolled-back clawgate: real tasks, but not one carries a `tags` key
+        return tasks_mod.group_by_slug(
+            [{"id": 1, "directory": "x", "status": "open"},
+             {"id": 2, "directory": "y", "status": "complete"}])
+
+    for failure in (connection_error, http_503, malformed_json, missing_creds, no_tags_field):
+        assert _rendered(_provider_with_linked(failure)) == baseline, failure.__name__
+    capsys.readouterr()   # the failures log to stderr; nothing reaches the page
+
+
+def test_a_clawgate_outage_never_turns_into_the_error_page():
+    provider = _provider_with_linked(lambda: (_ for _ in ()).throw(RuntimeError("down")))
+    model, err = provider.snapshot()
+    assert err is None and model is not None and model["total"] == 2
+
+
+def test_load_linked_tasks_never_raises(monkeypatch):
+    monkeypatch.setattr(viewer, "_tasks",
+                        lambda: (_ for _ in ()).throw(ImportError("no tasks.py")))
+    assert viewer.load_linked_tasks() == {}
+
+
+# --- the detail payload ----------------------------------------------------- #
+def test_build_detail_carries_linked_tasks():
+    model = viewer.build_model([_row(slug="alpha")], now=NOW,
+                               linked_tasks={"alpha": [_tv(7), _tv(8, "complete")]})
+    d = viewer.build_detail(model, None, "/home/zach/workspace/devrc", "alpha",
+                            doc_reader=lambda *a, **k: None)
+    assert d["ok"] is True
+    assert [t["id"] for t in d["linked_tasks"]] == [7, 8]
+    assert d["open_task_count"] == 1
+
+
+def test_build_detail_without_linked_tasks_is_an_empty_list():
+    model = viewer.build_model([_row(slug="alpha")], now=NOW)
+    d = viewer.build_detail(model, None, "/home/zach/workspace/devrc", "alpha",
+                            doc_reader=lambda *a, **k: None)
+    assert d["linked_tasks"] == [] and d["open_task_count"] == 0
+
+
+# --- the DISPATCH GUARD (pure JS, node-eval'd — the ACTUAL page code) -------- #
+def test_js_dispatch_guard_arms_on_open_linked_tasks():
+    one, many, none_open, absent = _node_card_actions([
+        {"slug": "a", "state": "active", "recommended_next_step": _REC, "open_task_count": 1},
+        {"slug": "b", "state": "active", "recommended_next_step": _REC, "open_task_count": 3},
+        {"slug": "c", "state": "active", "recommended_next_step": _REC, "open_task_count": 0},
+        {"slug": "d", "state": "active", "recommended_next_step": _REC},
+    ])
+    assert one[0]["guard"] == "already has 1 open task — dispatch anyway?"
+    assert many[0]["guard"] == "already has 3 open tasks — dispatch anyway?"
+    # zero / absent → NO guard key at all: today's single-tap behaviour, untouched.
+    assert "guard" not in none_open[0] and "guard" not in absent[0]
+    # the guard NEVER changes which actions exist, only the dispatch descriptor.
+    assert _kinds(one) == _kinds(none_open) == ["dispatch", "done"]
+    assert one[0]["label"] == "⤴ dispatch"
+
+
+def test_js_dispatch_guard_applies_to_the_resume_label_too():
+    stalled, needs = _node_card_actions([
+        {"slug": "s", "state": "stalled", "recommended_next_step": _REC, "open_task_count": 2},
+        {"slug": "n", "state": "needs_you", "recommended_next_step": _REC, "open_task_count": 1},
+    ])
+    assert stalled[0]["label"] == "⤴ resume"
+    assert stalled[0]["guard"] == "already has 2 open tasks — dispatch anyway?"
+    # on needs_you the order is [resolve, dispatch, done] — [resolve] is never guarded
+    assert _kinds(needs) == ["resolve", "dispatch", "done"]
+    assert "guard" not in needs[0]
+    assert needs[1]["guard"] == "already has 1 open task — dispatch anyway?"
+
+
+def test_js_dispatch_guard_ignores_garbage_counts():
+    rows = _node_card_actions([
+        {"slug": "a", "state": "active", "recommended_next_step": _REC, "open_task_count": -1},
+        {"slug": "b", "state": "active", "recommended_next_step": _REC, "open_task_count": "2"},
+        {"slug": "c", "state": "active", "recommended_next_step": _REC, "open_task_count": None},
+    ])
+    for acts in rows:
+        assert "guard" not in acts[0]
+
+
+def _node_actions_js(body):
+    node = _shutil.which("node")
+    if not node:
+        import pytest
+        pytest.skip("node not on PATH — actions JS untested this run")
+    out = _subprocess.run(
+        [node, "-e", viewer._ARCHIVE_JS + "\n" + viewer._ACTIONS_JS + "\n" + body],
+        capture_output=True, text=True, timeout=30)
+    assert out.returncode == 0, out.stderr
+    return json.loads(out.stdout)
+
+
+def test_js_linked_tasks_hint_lists_only_the_open_tasks():
+    v = {"linked_tasks": [{"id": 92, "status": "open", "open": True},
+                          {"id": 74, "status": "complete", "open": False},
+                          {"id": 77, "status": "in_progress", "open": True}]}
+    got = _node_actions_js(
+        "console.log(JSON.stringify(linkedTasksHint(" + json.dumps(v) + ")));")
+    assert got == "#92 open · #77 in_progress"
+    # no linked tasks → an empty hint, never "undefined"
+    assert _node_actions_js("console.log(JSON.stringify(linkedTasksHint({})));") == ""
+
+
+# --- EXPANDED detail renders linked tasks; the COLLAPSED card does not ------- #
+def _detail_body():
+    js = viewer._JS
+    return js[js.index("function renderDetail("):js.index("function loadDetail(")]
+
+
+def test_js_linked_tasks_render_in_the_expanded_detail_only():
+    detail, card = _detail_body(), _card_body()
+    # the expanded detail renders a section, one row per task, with status + title + link
+    assert "d.linked_tasks || (v && v.linked_tasks) || []" in detail
+    assert "'Linked clawgate tasks'" in detail and "'Linked clawgate task'" in detail
+    assert "el('span', 'lt-status'" in detail
+    assert "el('a', 'lt-link', label)" in detail and "a.target = '_blank'" in detail
+    # the COLLAPSED two-line card renders NO linked-task markup (it stays tuned for scanning)
+    for marker in ("lt-status", "lt-link", "Linked clawgate", "detail-list linked-tasks"):
+        assert marker not in card, marker
+
+
+def test_render_html_ships_the_linked_task_css_and_guard_css():
+    model = viewer.build_model([_row(slug="a")], now=NOW, linked_tasks={"a": [_tv(1)]})
+    html = viewer.render_html(model, None)
+    assert ".linked-task .lt-status{" in html and ".linked-task.open .lt-status{" in html
+    assert ".dispatch-btn.guarded{" in html and ".dispatch-btn.armed{" in html
+    # the data reaches the page through the SAME JSON island as everything else
+    assert '"open_task_count": 1' in html and "tasks#task-1" in html

--- a/scripts/initiatives/tests/test_viewer.py
+++ b/scripts/initiatives/tests/test_viewer.py
@@ -5282,9 +5282,10 @@ def test_build_model_unknown_slug_in_the_map_matches_no_card():
     assert model["total"] == 1                                # no phantom card invented
 
 
-def test_build_model_open_task_count_ignores_complete_and_dismissed():
+def test_build_model_open_task_count_ignores_complete_and_unknown_statuses():
     model = viewer.build_model([_row(slug="a")], now=NOW, linked_tasks={"a": [
-        _tv(1, "open"), _tv(2, "in_progress"), _tv(3, "complete"), _tv(4, "dismissed")]})
+        _tv(1, "open"), _tv(2, "in_progress"), _tv(3, "complete"),
+        _tv(4, "retired_by_a_later_clawgate")]})
     assert model["flat"][0]["open_task_count"] == 2
 
 

--- a/scripts/initiatives/viewer.py
+++ b/scripts/initiatives/viewer.py
@@ -84,6 +84,11 @@ NEXTSTEP_PATH = Path(__file__).resolve().parent / "nextstep.py"
 # token lives here (LAN-bound, Zach's user), NOT in the in-cluster devpod. Loaded lazily.
 DISPATCH_PATH = Path(__file__).resolve().parent / "dispatch.py"
 
+# The clawgate LINKED-TASKS reader (the consumer of repo-cos's `initiative:<slug>` tags). Read
+# ONCE per board render (never per card) and grouped into `slug -> [task]`; BEST-EFFORT, so a
+# clawgate outage renders exactly today's board. Loaded lazily by explicit path, like dispatch.
+TASKS_PATH = Path(__file__).resolve().parent / "tasks.py"
+
 # The standalone archived-lifecycle store (POST /api/archive + /api/unarchive → the board's
 # manual "done / drop" cleanup). Viewer-side ONLY (full mailbox creds, same path as the
 # assistant-log write). Loaded lazily by explicit importlib path (the sibling convention).
@@ -216,6 +221,40 @@ def _dispatch():
         spec.loader.exec_module(mod)
         _dispatch_mod = mod
     return _dispatch_mod
+
+
+_tasks_mod = None
+
+
+def _tasks():
+    """Load the clawgate linked-tasks sibling (`tasks.py`) by EXPLICIT importlib path (same
+    convention as `_dispatch`). Lazy so a viewer that never reaches clawgate pays nothing."""
+    global _tasks_mod
+    if _tasks_mod is None:
+        spec = importlib.util.spec_from_file_location("initiatives_viewer_tasks", TASKS_PATH)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"cannot load {TASKS_PATH}")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        _tasks_mod = mod
+    return _tasks_mod
+
+
+def load_linked_tasks() -> dict:
+    """ONE clawgate read per board render → `slug -> [task view]` (repo-cos's
+    `initiative:<slug>` tags, consumed).
+
+    The board's contract is SILENT BEST-EFFORT: clawgate unreachable, missing/unreadable
+    creds, a timeout, malformed JSON, or a rolled-back clawgate with no `tags` field ALL log
+    to stderr and yield `{}` — the board then renders exactly as it does today, with no
+    linked-task info and no error surface. NEVER raises (a sibling-load failure is caught
+    here too, so `tasks.py` being absent degrades the same way)."""
+    try:
+        return _tasks().linked_tasks_map()
+    except Exception as exc:  # noqa: BLE001 - a clawgate/sibling failure must never block a render
+        sys.stderr.write(
+            f"viewer: linked-task read failed: {type(exc).__name__}: {exc}\n")
+        return {}
 
 
 _archive_mod = None
@@ -1074,8 +1113,26 @@ def build_archived_view(archived, now: datetime) -> list[dict]:
     return out
 
 
+def attach_linked_tasks(views: list[dict], linked_tasks) -> None:
+    """PURE: stamp each view with its clawgate Tasks (`slug -> [task view]`, from the ONE
+    per-render `GET /api/tasks` read) — `linked_tasks` + `open_task_count`.
+
+    The join is by the EXACT slug (repo-cos guarantees the `initiative:<slug>` tag is either
+    the verbatim ledger slug or absent), so `initiative:Foo` never lands on `foo` and an
+    unknown slug simply matches no card. A missing/non-dict map, or a slug with no tasks,
+    yields `[]`/`0` on every card — byte-identical to the pre-feature model, which is what
+    makes the "clawgate is down" path render exactly today's board. Never raises."""
+    linked = linked_tasks if isinstance(linked_tasks, dict) else {}
+    for v in views:
+        tasks = linked.get(v.get("slug")) if linked else None
+        tasks = tasks if isinstance(tasks, list) else []
+        v["linked_tasks"] = tasks
+        v["open_task_count"] = sum(
+            1 for t in tasks if isinstance(t, dict) and t.get("open"))
+
+
 def build_model(rows: list[dict], now: datetime | None = None,
-                unmatched=None, archived=None) -> dict:
+                unmatched=None, archived=None, linked_tasks=None) -> dict:
     """PURE: store rows (+ any attached tmux) -> BOTH a grouped and a flat render model.
 
     `repos` groups initiatives by repo (within a repo: momentum then recency; repos
@@ -1091,7 +1148,12 @@ def build_model(rows: list[dict], now: datetime | None = None,
     since archiving are SUPPRESSED from `repos`/`flat` (and thus the counts + triage chips);
     an archived card whose `last_touch` advanced past its `archived_at` RESURFACES. The full
     archived set (including cards that have aged out of `latest`) rides along as `archived`
-    for the board's Done view. A missing/empty set suppresses nothing."""
+    for the board's Done view. A missing/empty set suppresses nothing.
+
+    `linked_tasks` is the clawgate `slug -> [task]` map (ONE `GET /api/tasks` per render,
+    grouped by repo-cos's `initiative:<slug>` tag). Purely ADDITIVE: it stamps each view with
+    `linked_tasks`/`open_task_count`; a missing/empty map (clawgate down, no creds, no tags)
+    leaves every card at `[]`/`0`, i.e. exactly the pre-feature model."""
     now = now or datetime.now(timezone.utc)
 
     archived_map = _archived_map(archived)
@@ -1107,6 +1169,9 @@ def build_model(rows: list[dict], now: datetime | None = None,
     rows = [r for r in rows if not _is_suppressed(r, archived_map)]
 
     views = [_initiative_view(r, now) for r in rows]
+    # The clawgate join (repo-cos's `initiative:<slug>` tags). Additive + best-effort: an
+    # empty/absent map leaves every card with `linked_tasks: []` / `open_task_count: 0`.
+    attach_linked_tasks(views, linked_tasks)
 
     by_repo: dict[str | None, list[dict]] = {}
     for r, v in zip(rows, views):
@@ -1291,6 +1356,12 @@ def build_detail(model: dict | None, error: str | None, repo: str, slug: str,
         "recent_commits": view.get("recent_commits") or [],
         "live_task": view.get("live_task") or "",
         "live_tasks": view.get("live_tasks") or [],
+        # The clawgate Tasks tagged `initiative:<slug>` for this card (from the per-render
+        # join in build_model — the detail endpoint never re-reads clawgate). Rendered ONLY
+        # in the expanded detail, alongside PRs + investigations; `[]` when clawgate is
+        # down/untagged, which is why the collapsed card is untouched by this feature.
+        "linked_tasks": view.get("linked_tasks") or [],
+        "open_task_count": view.get("open_task_count") or 0,
         "live": False,
     }
 
@@ -1487,6 +1558,14 @@ header .meta{color:var(--gray);font-size:.85rem}
   padding:.1rem .5rem}
 .dispatch-btn:hover:not(:disabled){border-color:var(--aqua)}
 .dispatch-btn:disabled{cursor:default;opacity:.7}
+/* GUARDED dispatch — the initiative already has open clawgate Task(s) tagged
+   `initiative:<slug>`, so dispatching would mint a duplicate. A persistent yellow border cues
+   "think first" at rest; the first tap arms it to the reason (the shared .armed orange, same
+   grammar as drop / ⤓ archive), a second tap dispatches anyway. */
+.dispatch-btn.guarded{border-color:var(--yellow)}
+.dispatch-btn.guarded:hover:not(:disabled){border-color:var(--yellow)}
+.dispatch-btn.armed{background:var(--orange);color:var(--bg);border-color:var(--orange);
+  font-weight:bold}
 .dispatch-status{margin-left:.5rem;color:var(--gray);font-size:.78rem}
 .dispatch-status.err{color:var(--red)}
 .dispatch-status.ok{color:var(--green)}
@@ -1534,6 +1613,15 @@ header .meta{color:var(--gray);font-size:.85rem}
   letter-spacing:.04em}
 .detail-list{margin:.1rem 0 .3rem;padding-left:1.1rem;color:var(--fg2);font-size:.84rem}
 .detail-list li{margin:.1rem 0}
+/* Linked clawgate tasks (expanded detail only — the collapsed card gets no chip). Status
+   reads as a small muted pill; an OPEN task's pill is aqua (it's live work + it arms the
+   dispatch guard), a complete/other one stays muted. */
+.detail-list.linked-tasks li{margin:.15rem 0}
+.linked-task .lt-status{font-size:.7rem;color:var(--fg2);background:var(--bg2);border-radius:3px;
+  padding:.02rem .4rem;margin-right:.45rem}
+.linked-task.open .lt-status{color:var(--aqua)}
+.linked-task .lt-link{color:var(--fg2);text-decoration:none;border-bottom:1px dotted var(--bg2)}
+.linked-task .lt-link:hover{color:var(--aqua);border-bottom-color:var(--aqua)}
 .detail-doc{color:var(--gray);font-size:.78rem;margin-top:.35rem;word-break:break-all}
 .detail-err{color:var(--red);font-size:.82rem}
 .empty{color:var(--gray);padding:2rem 0}
@@ -1771,6 +1859,14 @@ function matchArchived(a, q){
 #                       active (+legacy) -> [⤴ dispatch?] [✓ done]
 #                     The dispatch button is the SAME action either way (same /api/dispatch
 #                     wiring); only its LABEL flips to '⤴ resume' on stalled/cooling cards.
+#                     GUARD (clawgate linked tasks): when the initiative already has N OPEN
+#                     clawgate Tasks tagged `initiative:<slug>`, the dispatch descriptor also
+#                     carries `guard: "already has N open task(s) — dispatch anyway?"`, which
+#                     the card renders as a TWO-TAP armConfirm (the SAME grammar as drop /
+#                     ⤓ archive) so the second tap is a deliberate "yes, a duplicate is fine"
+#                     rather than a silent duplicate card. Completed/unknown-status tasks do
+#                     NOT count (tasks.OPEN_STATUSES is a closed set), and zero linked tasks
+#                     leaves the button EXACTLY as it is today (no `guard` key at all).
 #   resolveQuestion(slug) -> the grounded, prefilled question a [resolve] click asks the sidebar.
 #   askResolve(v)  -> open the EXISTING ask sidebar (openChat), prefill resolveQuestion(v.slug),
 #                     and submit it through the EXISTING chat-submit path (submitQuestion) so the
@@ -1782,24 +1878,50 @@ function matchArchived(a, q){
 #                     closures defined later; JS hoisting + call-time resolution makes this safe,
 #                     and the node test stubs them to assert the composed question hits submit.)
 _ACTIONS_JS = r"""
+function openTaskCount(v){
+  var n = v && v.open_task_count;
+  return (typeof n === 'number' && n > 0) ? n : 0;   // absent/0/garbage → unguarded
+}
+function dispatchGuard(v){
+  var n = openTaskCount(v);
+  if(!n) return '';                                   // no linked open task → today's behaviour
+  return 'already has ' + n + ' open task' + (n === 1 ? '' : 's') + ' — dispatch anyway?';
+}
+function linkedTasksHint(v){
+  // A compact "#92 open · #77 in_progress" line for the guarded button's title attribute.
+  var ts = (v && v.linked_tasks) || [];
+  var parts = [];
+  for(var i = 0; i < ts.length; i++){
+    var t = ts[i] || {};
+    if(!t.open) continue;                             // only the tasks that actually block
+    parts.push('#' + (t.id == null ? '?' : t.id) + ' ' + (t.status || ''));
+  }
+  return parts.join(' · ');
+}
+function dispatchAction(v, label){
+  var a = {kind:'dispatch', label:label};
+  var g = dispatchGuard(v);
+  if(g){ a.guard = g; }                               // present ONLY when the guard should arm
+  return a;
+}
 function cardActions(v){
   var st = (v && v.state) || 'active';
   var hasRec = !!(v && v.recommended_next_step && v.recommended_next_step.text);
   if(st === 'needs_you'){
     var a = [{kind:'resolve'}];
-    if(hasRec) a.push({kind:'dispatch', label:'⤴ dispatch'});
+    if(hasRec) a.push(dispatchAction(v, '⤴ dispatch'));
     a.push({kind:'done'});
     return a;
   }
   if(dropEligible(v)){                     // stalled or slowing (cooling)
     var b = [];
-    if(hasRec) b.push({kind:'dispatch', label:'⤴ resume'});
+    if(hasRec) b.push(dispatchAction(v, '⤴ resume'));
     b.push({kind:'drop'});
     b.push({kind:'done'});
     return b;
   }
   var c = [];                              // active (and any legacy/unknown state)
-  if(hasRec) c.push({kind:'dispatch', label:'⤴ dispatch'});
+  if(hasRec) c.push(dispatchAction(v, '⤴ dispatch'));
   c.push({kind:'done'});
   return c;
 }
@@ -2540,6 +2662,35 @@ _JS = r"""
       });
       det.appendChild(ul3);
     }
+    // LINKED CLAWGATE TASKS — the consumer side of repo-cos's `initiative:<slug>` tags. Lives
+    // ONLY here in the expanded detail (the collapsed card is deliberately two-line and tuned
+    // for scanning, so it gets no chip). One row per task: its status + title, the whole row
+    // an <a> to the task's card in clawgate (the card click handler already ignores clicks on
+    // an anchor, so following the link never toggles the expand). Empty/absent (clawgate down,
+    // no tags) → the section simply isn't rendered, i.e. exactly today's detail.
+    var lts = d.linked_tasks || (v && v.linked_tasks) || [];
+    if(lts.length){
+      det.appendChild(el('div', 'detail-h',
+        lts.length > 1 ? 'Linked clawgate tasks' : 'Linked clawgate task'));
+      var ult = el('ul', 'detail-list linked-tasks');
+      lts.forEach(function(t){
+        t = t || {};
+        var li = el('li', t.open ? 'linked-task open' : 'linked-task');
+        li.appendChild(el('span', 'lt-status', t.status || 'unknown'));
+        var label = (t.id != null ? ('#' + t.id + ' ') : '') + (t.title || '(untitled task)');
+        if(t.url){
+          var a = el('a', 'lt-link', label);
+          a.href = t.url;
+          a.target = '_blank';
+          a.rel = 'noopener noreferrer';
+          li.appendChild(a);
+        } else {
+          li.appendChild(document.createTextNode(label));
+        }
+        ult.appendChild(li);
+      });
+      det.appendChild(ult);
+    }
     if(d.current_doc){
       det.appendChild(el('div', 'detail-doc',
         (d.live ? 'handoff (live read): ' : 'handoff: ') + d.current_doc));
@@ -2732,10 +2883,22 @@ _JS = r"""
         var btn = el('button', 'dispatch-btn', a.label);
         btn.title = rec.text + (basisHint(rec.basis) ? '  (' + basisHint(rec.basis) + ')' : '');
         var dstat = el('span', 'dispatch-status');
-        btn.addEventListener('click', function(ev){
-          ev.stopPropagation();  // don't toggle the card expand
-          dispatchNextStep(v, btn, dstat);
-        });
+        if(a.guard){
+          // GUARDED: this initiative already has open clawgate Task(s) tagged
+          // `initiative:<slug>`, so dispatching again would silently mint a duplicate card.
+          // Surface it in the EXISTING two-tap grammar (same armConfirm as drop / ⤓ archive):
+          // the first tap relabels the button to the reason, a second within ~3s dispatches
+          // anyway, blur/timeout disarms. The action itself is dispatchNextStep, VERBATIM.
+          btn.classList.add('guarded');
+          btn.title = a.guard + '  ·  ' + linkedTasksHint(v);
+          armConfirm(btn, {armedLabel: a.guard, restLabel: a.label,
+            onConfirm: function(){ dispatchNextStep(v, btn, dstat); }});
+        } else {
+          btn.addEventListener('click', function(ev){
+            ev.stopPropagation();  // don't toggle the card expand
+            dispatchNextStep(v, btn, dstat);
+          });
+        }
         drow.appendChild(btn);
         drow.appendChild(dstat);
       } else if(a.kind === 'done'){
@@ -3731,11 +3894,13 @@ class DataProvider:
 
     def __init__(self, ttl: float = CACHE_TTL_SECONDS,
                  loader=load_latest, tmux=attach_tmux,
-                 now_fn=lambda: datetime.now(timezone.utc)):
+                 now_fn=lambda: datetime.now(timezone.utc),
+                 linked_tasks=load_linked_tasks):
         self._ttl = ttl
         self._loader = loader
         self._tmux = tmux
         self._now = now_fn
+        self._linked_tasks = linked_tasks
         self._lock = threading.Lock()
         self._cached: tuple[dict | None, str | None] | None = None
         self._fetched_at = 0.0
@@ -3760,8 +3925,20 @@ class DataProvider:
                 # best-effort; mutates rows in place AND returns the live claude panes that
                 # matched no initiative (build_model coerces a non-list to [] → no section).
                 unmatched = self._tmux(rows)
+                # ONE clawgate read per render, in its OWN guard: the linked-task join is
+                # ADDITIVE decoration, so a clawgate outage must degrade to `{}` (today's
+                # board) and never reach the outer `except`, which would render the error
+                # page instead. `load_linked_tasks` already swallows everything; this second
+                # belt catches an injected fetcher that raises.
+                try:
+                    linked = self._linked_tasks() if self._linked_tasks else {}
+                except Exception as exc:  # noqa: BLE001 - never fail a render on clawgate
+                    sys.stderr.write(
+                        f"viewer: linked-task read failed: {type(exc).__name__}: {exc}\n")
+                    linked = {}
                 result: tuple[dict | None, str | None] = (
-                    build_model(rows, self._now(), unmatched=unmatched, archived=archived),
+                    build_model(rows, self._now(), unmatched=unmatched, archived=archived,
+                                linked_tasks=linked),
                     None)
             except Exception as exc:  # noqa: BLE001 - any read failure → graceful error page
                 result = (None, f"{type(exc).__name__}: {exc}")

--- a/scripts/initiatives/viewer.py
+++ b/scripts/initiatives/viewer.py
@@ -241,16 +241,26 @@ def _tasks():
 
 
 def load_linked_tasks() -> dict:
-    """ONE clawgate read per board render → `slug -> [task view]` (repo-cos's
+    """The clawgate read behind its OWN cache → `slug -> [task view]` (repo-cos's
     `initiative:<slug>` tags, consumed).
 
+    `tasks.cached_linked_tasks_map` owns the latency contract: a hard WALL-CLOCK deadline
+    (`tasks.FETCH_DEADLINE`) over the whole fetch — NOT a per-socket-operation
+    `urlopen(timeout=)`, which a slow-drip peer defeats without bound — a response size cap,
+    its own 30s TTL (so a hung clawgate is paid at most once per 30s, not on every 5s cold
+    render), single-flight, and SERVE-STALE-ON-FAILURE so a blip doesn't flicker the links
+    (and the dispatch guard) away.
+
     The board's contract is SILENT BEST-EFFORT: clawgate unreachable, missing/unreadable
-    creds, a timeout, malformed JSON, or a rolled-back clawgate with no `tags` field ALL log
-    to stderr and yield `{}` — the board then renders exactly as it does today, with no
-    linked-task info and no error surface. NEVER raises (a sibling-load failure is caught
-    here too, so `tasks.py` being absent degrades the same way)."""
+    creds, a blown deadline, malformed JSON, or a rolled-back clawgate with no `tags` field
+    ALL log to stderr and yield `{}`/the last good map — the board then renders exactly as it
+    does today, with no error surface. NEVER raises (a sibling-load failure is caught here
+    too, so `tasks.py` being absent degrades the same way).
+
+    ⚠ Called OUTSIDE `DataProvider._lock` (see `DataProvider.snapshot`) — never move it back
+    inside, or a slow clawgate serializes every other board request behind it."""
     try:
-        return _tasks().linked_tasks_map()
+        return _tasks().cached_linked_tasks_map()
     except Exception as exc:  # noqa: BLE001 - a clawgate/sibling failure must never block a render
         sys.stderr.write(
             f"viewer: linked-task read failed: {type(exc).__name__}: {exc}\n")
@@ -1563,7 +1573,11 @@ header .meta{color:var(--gray);font-size:.85rem}
    "think first" at rest; the first tap arms it to the reason (the shared .armed orange, same
    grammar as drop / ⤓ archive), a second tap dispatches anyway. */
 .dispatch-btn.guarded{border-color:var(--yellow)}
-.dispatch-btn.guarded:hover:not(:disabled){border-color:var(--yellow)}
+/* `:not(.armed)` is LOAD-BEARING, not decoration: `.dispatch-btn.guarded:hover:not(:disabled)`
+   scores (0,4,0) and out-specifies `.dispatch-btn.armed` (0,2,0), so without it an ARMED button
+   still under the cursor — which is every armed button, since arming needs a click — kept the
+   yellow "think first" border instead of flipping to the orange "confirm" one. */
+.dispatch-btn.guarded:hover:not(:disabled):not(.armed){border-color:var(--yellow)}
 .dispatch-btn.armed{background:var(--orange);color:var(--bg);border-color:var(--orange);
   font-weight:bold}
 .dispatch-status{margin-left:.5rem;color:var(--gray);font-size:.78rem}
@@ -1878,30 +1892,84 @@ function matchArchived(a, q){
 #                     closures defined later; JS hoisting + call-time resolution makes this safe,
 #                     and the node test stubs them to assert the composed question hits submit.)
 _ACTIONS_JS = r"""
-function openTaskCount(v){
-  var n = v && v.open_task_count;
-  return (typeof n === 'number' && n > 0) ? n : 0;   // absent/0/garbage → unguarded
+// clawgate's task vocabulary is exactly {open, in_progress, ready_for_review, complete}
+// (clawgate internal/notes/notes.go). Rendered raw, the snake_case ones read like an internal
+// enum leaking into the UI, so they get a human label; anything unknown is de-underscored
+// rather than hidden, so a renamed status still shows the truth.
+var TASK_STATUS_LABELS = {
+  open: 'open', in_progress: 'in progress',
+  ready_for_review: 'ready for review', complete: 'complete'
+};
+function taskStatusLabel(s){
+  s = String(s == null ? '' : s);
+  if(!s) return 'unknown';
+  return TASK_STATUS_LABELS[s] || s.replace(/_/g, ' ');
 }
-function dispatchGuard(v){
-  var n = openTaskCount(v);
+// 🟡 OPTIMISTIC DISPATCH COUNT. The server-side `open_task_count` rides tasks.py's 30s cache
+// + the provider's 5s TTL + the board's 30s refetch, so after a successful dispatch the truth
+// can take ~a minute to come back — and during that window a second tap would be UNGUARDED,
+// i.e. exactly the silent duplicate this feature exists to prevent. So the client remembers
+// its OWN dispatches and folds them in with Math.max: the guard arms on the very next render,
+// and the overlay can only ever ADD guarding, never remove it. Bounded by OPTIMISTIC_TTL_MS so
+// a task completed shortly after doesn't keep a card guarded indefinitely.
+var OPTIMISTIC_TTL_MS = 120000;
+var optimisticDispatch = {};
+function optimisticKey(v){ return ((v && v.repo) || '') + '\u0000' + ((v && v.slug) || ''); }
+function nowMillis(nowMs){
+  return (typeof nowMs === 'number') ? nowMs
+       : ((typeof Date !== 'undefined' && Date.now) ? Date.now() : 0);
+}
+function optimisticCount(v, nowMs){
+  var k = optimisticKey(v);
+  var e = optimisticDispatch[k];
+  if(!e) return 0;
+  if((nowMillis(nowMs) - e.ts) >= OPTIMISTIC_TTL_MS){ delete optimisticDispatch[k]; return 0; }
+  return e.n;
+}
+function noteDispatched(v, nowMs){
+  // Called ONLY after clawgate confirms a created task id (see dispatchNextStep).
+  var t = nowMillis(nowMs);
+  optimisticDispatch[optimisticKey(v)] = {n: openTaskCount(v, t) + 1, ts: t};
+}
+function openTaskCount(v, nowMs){
+  var n = v && v.open_task_count;
+  n = (typeof n === 'number' && n > 0) ? n : 0;      // absent/0/garbage → unguarded
+  var o = optimisticCount(v, nowMs);
+  return o > n ? o : n;
+}
+function dispatchGuard(v, nowMs){
+  var n = openTaskCount(v, nowMs);
   if(!n) return '';                                   // no linked open task → today's behaviour
   return 'already has ' + n + ' open task' + (n === 1 ? '' : 's') + ' — dispatch anyway?';
 }
+function guardArmedLabel(label){
+  // 🟡 LAYOUT. The armed label REPLACES the button's text in place, so a long one reflows the
+  // whole action row: the full guard sentence measured 97px → 332px at 1280 and 97px → 222px
+  // at 390 (57% of the viewport — it wrapped to two lines and pushed ⤓ archive around). The
+  // board's established two-tap grammar is a short verb + '?' ('drop?', 'archive?'), so the
+  // armed state follows it. The full reason lives in btn.title, and the tasks themselves are
+  // listed in the expanded card detail.
+  var verb = String(label == null ? '' : label).replace(/^[^A-Za-z]+/, '') || 'dispatch';
+  return verb + ' anyway?';
+}
 function linkedTasksHint(v){
-  // A compact "#92 open · #77 in_progress" line for the guarded button's title attribute.
+  // A compact "#92 open · #77 in progress" line for the guarded button's title attribute.
   var ts = (v && v.linked_tasks) || [];
   var parts = [];
   for(var i = 0; i < ts.length; i++){
     var t = ts[i] || {};
     if(!t.open) continue;                             // only the tasks that actually block
-    parts.push('#' + (t.id == null ? '?' : t.id) + ' ' + (t.status || ''));
+    parts.push('#' + (t.id == null ? '?' : t.id) + ' ' + taskStatusLabel(t.status));
   }
   return parts.join(' · ');
 }
-function dispatchAction(v, label){
+function dispatchAction(v, label, nowMs){
   var a = {kind:'dispatch', label:label};
-  var g = dispatchGuard(v);
-  if(g){ a.guard = g; }                               // present ONLY when the guard should arm
+  var g = dispatchGuard(v, nowMs);
+  if(g){                                              // present ONLY when the guard should arm
+    a.guard = g;                                      // the FULL reason → btn.title
+    a.guardLabel = guardArmedLabel(label);            // the SHORT armed label → btn text
+  }
   return a;
 }
 function cardActions(v){
@@ -2511,6 +2579,12 @@ _JS = r"""
     }).then(function(r){ return r.json().then(function(j){ return {ok: r.ok, j: j}; }); })
       .then(function(res){
         if(res.ok && res.j && res.j.ok){
+          // 🟡 GUARD THE NEXT TAP IMMEDIATELY. The server's open_task_count won't reflect this
+          // new task for up to ~a minute (tasks.py's 30s cache + the 5s provider TTL + the 30s
+          // board refetch), so record it client-side: the next render of this card arms the
+          // duplicate-dispatch guard even though the server still says 0. Only ever ADDS
+          // guarding (openTaskCount takes the max), and only after a confirmed task id.
+          noteDispatched(v);
           dstat.className = 'dispatch-status ok';
           dstat.textContent = 'task #' + res.j.task_id +
             ' created — tap Dispatch in clawgate to run';
@@ -2676,7 +2750,11 @@ _JS = r"""
       lts.forEach(function(t){
         t = t || {};
         var li = el('li', t.open ? 'linked-task open' : 'linked-task');
-        li.appendChild(el('span', 'lt-status', t.status || 'unknown'));
+        // Humanized pill ('in progress', not the raw `in_progress` enum); the raw value stays
+        // reachable in the title for anyone matching it against clawgate.
+        var pill = el('span', 'lt-status', taskStatusLabel(t.status));
+        if(t.status) pill.title = t.status;
+        li.appendChild(pill);
         var label = (t.id != null ? ('#' + t.id + ' ') : '') + (t.title || '(untitled task)');
         if(t.url){
           var a = el('a', 'lt-link', label);
@@ -2889,9 +2967,12 @@ _JS = r"""
           // Surface it in the EXISTING two-tap grammar (same armConfirm as drop / ⤓ archive):
           // the first tap relabels the button to the reason, a second within ~3s dispatches
           // anyway, blur/timeout disarms. The action itself is dispatchNextStep, VERBATIM.
+          // The ARMED text is the short `guardLabel` ('dispatch anyway?') — the board's
+          // two-tap grammar — so arming doesn't reflow the action row; the full reason + the
+          // blocking task ids stay in the tooltip, and the tasks themselves in the detail.
           btn.classList.add('guarded');
           btn.title = a.guard + '  ·  ' + linkedTasksHint(v);
-          armConfirm(btn, {armedLabel: a.guard, restLabel: a.label,
+          armConfirm(btn, {armedLabel: a.guardLabel || a.guard, restLabel: a.label,
             onConfirm: function(){ dispatchNextStep(v, btn, dstat); }});
         } else {
           btn.addEventListener('click', function(ev){
@@ -3910,10 +3991,45 @@ class DataProvider:
             self._cached = None
             self._fetched_at = 0.0
 
+    def _fresh(self) -> tuple[dict | None, str | None] | None:
+        """The cached result if it's still inside the TTL, else None. Caller holds `_lock`."""
+        if self._cached is not None and (time.monotonic() - self._fetched_at) < self._ttl:
+            return self._cached
+        return None
+
+    def _linked(self) -> dict:
+        """The clawgate linked-task map, in its OWN guard. The join is ADDITIVE decoration, so
+        a clawgate outage must degrade to `{}`/the last good map (today's board) and never
+        reach the build's `except`, which would render the error page instead.
+        `load_linked_tasks` already swallows everything; this second belt catches an injected
+        fetcher that raises."""
+        try:
+            return self._linked_tasks() if self._linked_tasks else {}
+        except Exception as exc:  # noqa: BLE001 - never fail a render on clawgate
+            sys.stderr.write(
+                f"viewer: linked-task read failed: {type(exc).__name__}: {exc}\n")
+            return {}
+
     def snapshot(self) -> tuple[dict | None, str | None]:
         with self._lock:
-            if self._cached is not None and (time.monotonic() - self._fetched_at) < self._ttl:
-                return self._cached
+            fresh = self._fresh()
+            if fresh is not None:
+                return fresh
+
+        # 🔴 THE CLAWGATE READ HAPPENS OUTSIDE `_lock` — ON PURPOSE, and it must stay that way.
+        # `/`, `/api/initiatives.json`, `/api/initiative` and `/api/ask` all funnel through
+        # `snapshot()`; when this read lived inside the lock, a hung clawgate serialized every
+        # one of them behind it. Out here, a slow read delays only the rebuild, and any request
+        # that finds a fresh cache (the check above) returns instantly regardless. `tasks.py`
+        # supplies the other half of the contract: a hard wall-clock deadline, its own 30s TTL
+        # and single-flight, so concurrent rebuilds don't multiply the clawgate load either.
+        linked = self._linked()
+
+        with self._lock:
+            # Re-check: another thread may have rebuilt while we were off talking to clawgate.
+            fresh = self._fresh()
+            if fresh is not None:
+                return fresh
             try:
                 loaded = self._loader()
                 # load_latest returns `(rows, archived)`; a legacy/injected loader may return
@@ -3925,17 +4041,6 @@ class DataProvider:
                 # best-effort; mutates rows in place AND returns the live claude panes that
                 # matched no initiative (build_model coerces a non-list to [] → no section).
                 unmatched = self._tmux(rows)
-                # ONE clawgate read per render, in its OWN guard: the linked-task join is
-                # ADDITIVE decoration, so a clawgate outage must degrade to `{}` (today's
-                # board) and never reach the outer `except`, which would render the error
-                # page instead. `load_linked_tasks` already swallows everything; this second
-                # belt catches an injected fetcher that raises.
-                try:
-                    linked = self._linked_tasks() if self._linked_tasks else {}
-                except Exception as exc:  # noqa: BLE001 - never fail a render on clawgate
-                    sys.stderr.write(
-                        f"viewer: linked-task read failed: {type(exc).__name__}: {exc}\n")
-                    linked = {}
                 result: tuple[dict | None, str | None] = (
                     build_model(rows, self._now(), unmatched=unmatched, archived=archived,
                                 linked_tasks=linked),


### PR DESCRIPTION
Builds the **consumer** for repo-cos's `initiative:<slug>` clawgate task tags (#198 / #201 produce them; nothing read them until now) — and, after an audit, makes the board's *own* dispatch a producer too.

## What it does

**1. One fetch per board render, never per card.** `scripts/initiatives/tasks.py` does a single `GET /api/tasks` and groups the queue into `slug -> [task]`. The queue is ~6 tasks; the board carries ~140 cards, so there is deliberately no per-card HTTP call.

**2. Surfaced in the EXPANDED card detail only.** The collapsed line stays two-line and tuned for scanning — no chip. `renderDetail` grows a `Linked clawgate task(s)` section beside PRs and investigations: a humanized status pill + `#id title`, the row linking to `{base}/tasks#task-<id>` (clawgate's own card DOM id, so it's a real deep link).

**3. Guarded dispatch — the point of the feature.** When an initiative already has open linked Tasks, `⤴ dispatch` / `⤴ resume` becomes **two-tap** via the existing `armConfirm`, arming to `dispatch anyway?` — the same interaction grammar the board already uses for `drop` and `⤓ archive`, not a new pattern. **Zero linked tasks leaves today's single-tap behaviour byte-identical** (no `guard` key at all).

**4. The board's own dispatch tags its Tasks** (`initiative:<slug>`), so a card dispatched from the board joins back to itself and arms that guard. Fail-open: an untaggable slug posts untagged.

**5. Silent best-effort.** Clawgate unreachable, missing/unreadable creds, a blown deadline, an oversized body, a non-200, malformed JSON, or a rolled-back clawgate with no `tags` field → stderr log, the last good map (or `{}`), and the board renders exactly as it does today. The read has its **own** guard inside `DataProvider.snapshot`, so it can never fall through to the outer `except` and render the error page instead of the board.

**6. Env-configurable base URL.** `$INITIATIVES_CLAWGATE_URL` → the creds file's `CLAWGATE_API_URL` → the LAN NodePort `http://192.168.50.250:30302`.

---

## 🔴 Audit fix 1 — the fetch could stall every board render

`urlopen(timeout=N)` is a **per-socket-operation** timeout, not a deadline on the call. Measured against a 0.80s cold-render baseline, before and after:

| clawgate state | before (`timeout=4`) | after (2.0s wall-clock deadline) |
|---|---|---|
| connection refused | 0.018s | 0.001s |
| blackhole (accepts, never replies) | 4.004s | 2.000s |
| slow-drip (1 byte / 2s) | **322.119s — and it SUCCEEDED** | 2.001s |

Two amplifiers made it worse: the read happened under `DataProvider._lock`, so `/`, `/api/initiatives.json`, `/api/initiative` and `/api/ask` all serialized behind it; and there was no memoization beyond the 5s board cache, so the stall recurred every 5s. Four changes:

1. **A real wall-clock deadline.** `_run_with_deadline` runs the whole fetch — DNS, connect, headers, body, and any injected getter — in a daemon thread joined for `FETCH_DEADLINE = 2.0s`. `_get` also re-checks the clock between chunks so an abandoned worker self-terminates rather than dribbling forever.
2. **A response size cap.** Chunked `resp.read(n)` up to `MAX_RESPONSE_BYTES` (1 MiB) instead of an unbounded read. Closes 🟡3: `Notes.List` has no `LIMIT` and rows carry full task bodies (16 KB for 6 tasks today, growing with retained history).
3. **The read moved OUT of the provider lock**, with a double-checked freshness test around it. A slow clawgate now delays only the rebuild; a request that finds a fresh cache returns instantly regardless.
4. **Its own cache with serve-stale-on-failure.** `LinkedTaskCache`: 30s TTL (vs the board's 5s), single-flight, and on failure it keeps serving the **last good map** rather than dropping to empty — a transient blip must not make linked tasks, and with them the dispatch guard, flicker away. This needed the fetch to carry an `ok` flag (`fetch_tasks_result` / `linked_tasks_map_result`), since `{}` alone can't tell "failed" from "empty queue".

The degradation contract is unchanged: any failure logs to stderr and the board renders exactly as it does today.

## 🔴 Audit fix 2 — the board's own dispatch never tagged, so the guard was inert

`dispatch.py` had **no `tags` anywhere**: `⤴ dispatch` created an untagged clawgate Task, which never joined, which never armed the guard. Tapping dispatch twice on the same card — the exact duplicate this feature is named for — was silent. Only repo-cos's weekly approve path emitted tagged tasks.

`build_tags(view)` now emits `initiative:<slug>` for the card being dispatched, **exact-or-nothing**: the slug is put through the tag grammar and emitted only if it comes back byte-identical. A normalized-but-rewritten slug would join to *nothing* while looking like it worked — strictly worse than no tag. **Fail-open is enforced twice**: an untaggable slug posts untagged, and a tagged POST that 400s retries exactly once without tags (400 alone; 408 in particular is not retried, since the origin may already have created the Task).

`normalize_tag`/`normalize_tags` are a **deliberate duplication** of `scripts/repo-cos/clawgate.py`, flagged in-code with a pointer to that source of truth. Importing across script dirs would make the board's dispatch path depend on repo-cos being present in the same tree (and repo-cos's module lazily pulls in `routing`/`scan`); a missing sibling would silently downgrade every dispatch to untagged — the exact failure this fixes.

## 🟡 / 🟢 follow-ups

- **🟡6 Guard staleness.** After a successful dispatch the client optimistically increments that card's open-task count (`noteDispatched`, keyed on `(repo, slug)`, folded in with `Math.max`, bounded by a 120s TTL), so the second tap is guarded on the very next render instead of waiting out the 30s tasks cache + 5s provider TTL + 30s refetch. It can only ever *add* guarding.
- **🟡7 Armed-label layout shift.** The armed text replaces the button's label in place, and the full sentence took it 97px → 332px at 1280 and 97px → 222px at 390 (57% of viewport, wrapping and reflowing `⤓ archive`). It now arms to `dispatch anyway?` / `resume anyway?` — the board's established `drop?` / `archive?` grammar. The full reason and the blocking task ids stay in `btn.title`; the tasks themselves stay in the expanded detail.
- **🟡8 `X-Restart-Triggers`.** Now covers every sibling the long-running viewer loads once and caches in memory: `tasks.py`, `dispatch.py`, `archive.py`, `nextstep.py`.
- **🟢9 CSS specificity.** `.dispatch-btn.guarded:hover:not(:disabled)` scores (0,4,0) and out-specified `.dispatch-btn.armed` (0,2,0), so an armed button under the cursor — i.e. every armed button, since arming needs a click — kept the yellow border instead of flipping to orange. Added `:not(.armed)`.
- **🟢10 Status pill.** `in_progress` / `ready_for_review` are humanized (`in progress`, `ready for review`); the raw value stays reachable in the element's title. An unknown status is de-underscored rather than hidden.
- **🟡5 (deliberately NOT fixed).** The join keys on slug alone while the ledger key is `(repo, slug)`. Measured today: `initiatives.latest` 49 rows / 49 distinct slugs and `initiatives.current` 144 / 144 — no collisions in either view — and fixing it means widening the tag namespace on the producer side plus migrating every already-emitted tag. Documented as a latent risk in `group_by_slug`, with the query to detect a future collision.

## Design notes

- **The join is EXACT.** The tag value is the dict key verbatim (no case-folding, no normalization), so `initiative:Foo` can never satisfy the slug `foo`, and `initiative:foo` never satisfies `foo-bar`. An unknown slug is just an unused key.
- **Credential loading is reused from `dispatch.py`** (`load_creds`), not reimplemented — one parser for `~/.claude/clawgate.env` across the writer and the reader.
- **`OPEN_STATUSES` is a closed allow-list** (`open` / `in_progress` / `ready_for_review`). Clawgate's task vocabulary is exactly `{open, in_progress, ready_for_review, complete}` (`internal/notes/notes.go`), so today that is "everything except `complete`" — but it is written as an allow-list, not as `!= complete`, so a future or renamed status is non-blocking by default and can never wedge dispatch.
- Stdlib-only at runtime; the explicit-importlib sibling-load convention is preserved.

## Tests: 756 → 783

The new tests are specifically the ones that would have caught the originals. A test asserting only "connection refused is fast" is what let the deadline bug through, so the latency tests stand up **real sockets**: a blackhole that accepts and never replies, and a slow-drip that sends one byte at a time inside any per-operation timeout. Plus: a flood server for the size cap, `_run_with_deadline` bounding an arbitrary callable, cache TTL / serve-stale-after-failure / backoff / single-flight, `DataProvider._lock` **not** being held across the read, the board rendering within the deadline against a blackhole, the tag grammar and exact-or-nothing rule, the untagged-400 retry (and the statuses that must *not* retry), the optimistic-count overlay, the short armed label, the CSS carve-out, the humanized pill — and an end-to-end `dispatch → tagged task → join → guard armed`.

⚠️ Signature changes to already-existing tests: `getter`/`fetcher` take `deadline=` instead of `timeout=`, an injected `poster` takes `tags=`, and `linkedTasksHint` now renders `in progress`. (The earlier commit also changed `test_js_card_wires_two_tap_confirm_on_done_and_drop`, which pinned dispatch as *unconditionally* single-tap, to pin the new rule.)

## Verified live (not just unit-tested)

Against the running store (48 cards) and live clawgate, on throwaway viewer instances at `127.0.0.1:8887` / `:8888`. The live `initiatives-viewer.service` was **not** restarted or otherwise disturbed.

| Check | Result |
|---|---|
| Dispatch `spec-insights-telemetry-pr2` from a real card | task **#97**, `tags: ["initiative:spec-insights-telemetry-pr2"]` — equal to the card's slug exactly |
| Does it join? | `open_task_count: 1`, `linked_tasks[0].url = …/tasks#task-97`, on that card only |
| Does it arm the guard? | real page JS (`cardActions`) → `guard: "already has 1 open task — dispatch anyway?"`, `guardLabel: "dispatch anyway?"`, hint `#97 open`; an unlinked card → no guard |
| Second tap within a few seconds | server count still **0** (stale, by design); `noteDispatched` → the next render is guarded. 🟡6 covers the window Fix 1's cache opens |
| Untaggable slug (`SECURITY-AUDIT-v0.1.64`, a real card) | dispatch **succeeded**, task posted with `tags: null` — fail-open confirmed against real data |
| Board vs a **blackholed** port (accepts, never replies) | renders in **0.888–0.989s**, paying the 2.0s deadline once per 30s (2.849s) — not 4s every 5s. All 48 cards, failure only on stderr |
| Queue before / after | `{73,74,75,76,77,92}` → `{73,74,75,76,77,92}`; throwaways **97, 98, 99** all deleted |

### Not verified / notes
- No real browser was driven. The DOM and action-descriptor assertions come from running the **actual** page JS under node against the **live** payload, not from Chrome. The 🟡7 pixel figures are the auditor's original measurements; the fix is asserted by label length (43 → 16 chars) and by the board's existing grammar, not by a re-measurement in a browser.
- Task **92** independently moved `in_progress` → `ready_for_review` during the session (concurrent activity). This PR issued only POSTs and DELETEs.
- `DELETE /api/tasks/{id}` **does** work on this clawgate (200, and the row is gone) — correcting the previous revision of this description.
- A stray viewer from an earlier verification session is still listening on `127.0.0.1:8898`; it is not part of this change.

## Deploy note

`X-Restart-Triggers` now covers `viewer.py` + the four lazily-imported siblings, so a `home-manager switch` restarts the unit for any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
