### PR TITLE
feat(browser-bridge): typed file-upload + hidden-tab self-announce + stale-extension detection (task #92)

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -143,19 +143,20 @@ always-detach) is in the **CDP ops** section below.
 
 | op | maps to | returns |
 |----|---------|---------|
-| `getHtml`    | `chrome.scripting` → `document.documentElement.outerHTML` | `{url,title,html}` |
-| `text`       | `chrome.scripting` → `(selector?document.querySelector(selector):document.body).innerText`, normalized + byte-capped (`selector`/`maxBytes` optional) | `{url,title,text,truncated}` |
-| `eval`       | top frame: `chrome.scripting.executeScript` (MAIN world) of `js`; **`--frame`: CDP `Runtime.evaluate`** in the frame's context (same-process isolated world OR OOPIF flat session) — chrome.scripting can't eval a STRING | `{url,value,frame?}` |
+| `getHtml`    | `chrome.scripting` → `document.documentElement.outerHTML` | `{url,title,html,visibilityState,hidden?,note?}` |
+| `text`       | `chrome.scripting` → `(selector?document.querySelector(selector):document.body).innerText`, normalized + byte-capped (`selector`/`maxBytes` optional) | `{url,title,text,truncated,visibilityState,hidden?,note?}` |
+| `eval`       | top frame: `chrome.scripting.executeScript` (MAIN world) of `js`; **`--frame`: CDP `Runtime.evaluate`** in the frame's context (same-process isolated world OR OOPIF flat session) — chrome.scripting can't eval a STRING | `{url,value,frame?,visibilityState,hidden?,note?}` |
 | `tabs`       | `chrome.tabs.query({})`                                   | `{tabs:[...],ownedTabId}` |
 | `nav`        | `chrome.tabs.update(tab,{url})`                           | `{tabId,url}` |
 | `screenshot` | **CDP `Page.captureScreenshot`** (png) — works on a BACKGROUND/occluded tab + each profile's own tab; a foreground tab uses the cheap `captureVisibleTab` fast path. `fullpage` grabs the whole document | `{url,dataUrl,via}` |
-| `open`       | `chrome.tabs.create({url,active:false})`                 | `{tabId,url}` |
+| `open`       | `chrome.tabs.create({url,active:false})` — **background/HIDDEN** (`visibilityState:"hidden"` → Chromium throttles it → a heavy SPA won't render → reads return a shell; `browser activate` un-throttles). Reads self-announce this via `hidden`/`note` | `{tabId,url}` |
 | `close`      | `chrome.tabs.remove(tabId)`                               | `{closed:tabId}` |
 | `frames`     | **`chrome.webNavigation.getAllFrames`** — the tab's frames INCLUDING cross-origin OUT-OF-PROCESS iframes (OOPIFs) | `{url,title,frames:[{frameId,url,parentFrameId}]}` |
 | `click`      | top frame: **CDP** `getBoundingClientRect` → `Input.dispatchMouseEvent` (trusted); `--frame`: **SYNTHETIC** click via `chrome.scripting`; `selector` required, `frame` optional | `{url,clicked,x,y,frame,trusted}` |
 | `type`       | top frame: **CDP `Input.insertText`** (trusted); `--frame`: **SYNTHETIC** input via `chrome.scripting`; `text` required, `selector`/`frame` optional | `{url,typed,frame,trusted}` |
 | `key`        | top frame: **CDP `Input.dispatchKeyEvent`** (trusted); `--frame`: **SYNTHETIC** key via `chrome.scripting`; one bounded key; `key` required | `{url,key,frame,trusted}` |
 | `activate`   | **FOREGROUND the tab** — `chrome.tabs.update(tab,{active:true})` + `chrome.windows.update(windowId,{focused:true})`, then an OPTIONAL bounded wait-for-`status:"complete"` + paint settle (`waitMs`, clamped ≤8s; a discarded/never-completing tab returns promptly — no wedge). Loads a foreground-throttled SPA so it can be driven. **⚠ STEALS FOCUS** (the one intrusive op); **i3:** requests window focus but may not raise across workspaces (best-effort). No new permission | `{tabId,windowId,url,title,active,status}` |
+| `upload`     | **CDP `DOM.setFileInputFiles`** — resolve the `<input type=file>` at `selector` to a RemoteObject, VERIFY it is a file input, then hand Chrome the ABSOLUTE `path` (Chrome reads the file itself — **no bytes cross the bridge**); `--frame` routes into a same-process iframe OR a cross-origin OOPIF. Own-tab, #189-bounded, NO raw-CDP passthrough. **Data-exfil-capable → the server AUDIT-LOGS every upload** (op + target domain + path). `selector`+`path` required | `{ok,selector,frame,url,files:[basename]}` |
 
 `open`/`close` are dispatched to the extension; `release` (drop ownership, don't
 close the tab) is handled server-side and never reaches the extension.
@@ -274,6 +275,16 @@ only the thin `chrome.debugger` side-effect glue.
 `text`/`html`/`eval` or a foreground `screenshot` takes the lighter non-CDP path
 (no banner). **The manifest gained the `debugger` permission → the extension needs
 a manual reload** (and Brave may re-prompt for the permission).
+
+**⚠ Reloading (↻) the extension is UNRELIABLE — a full Brave restart is the
+reliable fix.** The extension's long-poll (`GET /poll`) keeps the OLD service
+worker permanently alive, so clicking ↻ in `brave://extensions` frequently does
+NOT swap in the new build. Symptom of a stale extension: a NEW op (e.g. `upload`
+on a pre-0.2.0 build) returns a server-side op-level **`unknown_op`** — the server
+knew the op and dispatched it, but the old service worker didn't. The **CLI maps
+that to a clear reload/restart message + non-zero exit**, and **`browser health`
+shows the loaded `extension_version` vs `extension_version_current`** so you can
+confirm. If a reload doesn't take, **fully quit and reopen Brave**.
 
 ## Concurrency backstop (per-instance rate limit + queue cap)
 
@@ -404,7 +415,11 @@ per-session (multi-step **workflow**) isolation did not.
   The multi-instance `--instance` targeting, ambiguity/supersede semantics, and
   telemetry are unchanged.
 
-`GET /health` → `{"ok":true,"extension_connected":bool,"count":N,"instances":[{key,label,instanceId,activeTab},…]}`.
+`GET /health` → `{"ok":true,"extension_connected":bool,"count":N,"extension_version_current":"<repo manifest>","instances":[{key,label,instanceId,activeTab,extension_version},…]}`.
+Each instance carries its **loaded `extension_version`** (from the `X-Bridge-Ext-Version`
+poll header; `null` until a build that reports it), and the bridge carries
+**`extension_version_current`** (the manifest version the server reads from the
+repo) — eyeball loaded-vs-current to spot a **stale** extension (see the stale note below).
 `GET /instances` → `{"ok":true,"count":N,"instances":[…]}`.
 
 ## Telemetry (activity pipeline)

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -36,7 +36,19 @@ until the user reloads it. Don't debug the server; **tell the user to click relo
 ↻ on the card in `brave://extensions`**. Meanwhile work without `open`: run
 `browser tabs`, pick an existing tab, and pass `--tab <id>` on every op (or just
 read the active tab for a one-shot). Same reasoning for any op that answers
-`unknown_op`.
+`unknown_op` (e.g. `upload` on a pre-0.2.0 extension).
+
+The CLI now **detects this for you**: any op the CLI dispatches that returns a
+server-side `unknown_op` is mapped to a clear message + non-zero exit telling you
+the loaded extension is OLDER than the CLI and to reload/restart. **`browser
+health` also shows the build** — each instance's loaded `extension_version` vs the
+bridge's `extension_version_current` (repo manifest); a mismatch = stale.
+
+**⚠ Reload ↻ is UNRELIABLE — a full Brave restart is the reliable fix.** The
+extension's long-poll keeps the OLD service worker permanently alive, so clicking
+↻ in `brave://extensions` often does NOT swap in the new build. If a reload
+doesn't take (the op still returns `unknown_op`, or `health` still shows the old
+`extension_version`), tell the user to **fully quit and reopen Brave**.
 
 ## `eval` gotchas — a `null` result does NOT mean the bridge is down
 
@@ -97,10 +109,10 @@ Prefix any op with `--instance <key>` to target a specific connected profile
 
 | command | does |
 |---------|------|
-| `browser health`            | connected instances + count: `{"ok":true,"extension_connected":bool,"count":N,"instances":[…]}` |
+| `browser health`            | connected instances + count: `{"ok":true,"extension_connected":bool,"count":N,"extension_version_current":"<repo manifest>","instances":[{…,"extension_version":"<loaded>"}]}`. Each instance now shows its **loaded `extension_version`** and the bridge shows **`extension_version_current`** (the repo manifest) — eyeball loaded-vs-current to spot a STALE extension |
 | `browser whoami`            | **read-only identity + diagnostics** (global; no `--instance`/`--tab`). Reports **which HOST** (`host.label` = `laptop`/`workbench`/`unknown`, resolved `ACTIVITY_HOST` env → the activity-collector env file → LAN-IP detect, with `host.source` naming the method + `host.ips`), the connected **instances** (`key`/`label`/`instanceId` + active-tab **DOMAIN** only + reported `extension_version`), and **bridge** diagnostics (`endpoint`/`port`/`server_version`{version+git-HEAD}/`connected` count/`rate_limit` + `extension_version_current` = the manifest version the SERVER reads from the repo). Use it FIRST to confirm you're on the right host/profile (both hosts are hostname `nixos`). ⚠ There is deliberately **no hard "stale" flag** — the manifest version isn't bumped per-change, so compare `extension_version` (loaded) vs `extension_version_current` (repo) by eye. `extension_version` shows `null` until an extension build that reports it has reloaded; the rest of whoami needs NO extension change/reload. |
 | `browser instances`         | list connected instances as JSON (routing key, label, instanceId, active-tab url/title) |
-| `browser [--instance K] open [url]`        | open a NEW tab THIS session owns (default `about:blank`, created in the background); records ownership; returns its `tabId`. Use for multi-step work. |
+| `browser [--instance K] open [url]`        | open a NEW tab THIS session owns (default `about:blank`, created in the **background/HIDDEN** — `active:false`); records ownership; returns its `tabId`. Use for multi-step work. ⚠ A background tab is `document.visibilityState:"hidden"` → **Chromium throttles it, so a heavy SPA never renders** and a subsequent `text`/`html`/`eval` returns a **shell-only DOM** (indistinguishable from a broken site). The reads now **self-announce** this (`data.hidden:true` + a one-line warning on stderr); the escape hatch is **`browser activate`** (foreground it so it un-throttles). |
 | `browser [--instance K] close`             | close this session's owned tab and drop ownership |
 | `browser [--instance K] release`           | drop ownership WITHOUT closing the tab |
 | `browser [--instance K] [--tab T] html`              | `outerHTML` of the owned tab (else the active tab) |
@@ -113,6 +125,7 @@ Prefix any op with `--instance <key>` to target a specific connected profile
 | `browser [--instance K] [--tab T] [--frame F] click <selector>` | click the element's center — **TRUSTED** CDP on the top frame; **SYNTHETIC** (`chrome.scripting`) inside a cross-origin `--frame` |
 | `browser [--instance K] [--tab T] [--frame F] type <text> [--selector S]` | text input — **TRUSTED** CDP top frame; **SYNTHETIC** in-frame (focus `--selector` first if given) |
 | `browser [--instance K] [--tab T] [--frame F] key <Enter\|Tab\|Escape\|Backspace\|Delete\|Arrow*\|Home\|End\|Page*> [--selector S]` | dispatch one bounded key — **TRUSTED** CDP top frame; **SYNTHETIC** in-frame |
+| `browser [--instance K] [--tab T] [--frame F] upload <selector> <path>` | populate the `<input type=file>` at `<selector>` with the LOCAL file `<path>` via **CDP `DOM.setFileInputFiles`** — Chrome reads the file BY PATH itself (same host), so **no bytes cross the bridge**. The CLI validates the path (readable regular file) + resolves it to ABSOLUTE **before** dispatch; `--frame` routes into a cross-origin OOPIF. **Bounded TYPED op, own-tab, NO raw-CDP passthrough** — but it IS **data-exfil-capable** (any readable file's CONTENTS could be posted to the site), so **every upload is AUDIT-LOGGED** (op + target domain + path). Result carries the basename only |
 | `browser [--instance K] [--tab T] activate [--wait MS \| --no-wait]` | **FOREGROUND** the owned/active tab so a foreground-throttled SPA finishes loading, then can be read/driven. **⚠ STEALS FOCUS — the ONE intrusive op** (it changes what the user sees; every other op is non-intrusive). Foregrounds via **host-side `i3-msg`** (Chrome-side `tabs.update`/`windows.update` is a no-op on i3), so it works ONLY on a graphical i3 host; returns an extra **`i3:"applied"\|"skipped"\|"failed"`** field alongside `{tabId,windowId,url,title,active,status}`. Waits (bounded, default ~3s, cap ~8s) for `status:"complete"` + a paint settle unless `--no-wait`; `--wait MS` overrides. See "Driving a throttled SPA" below. |
 | `browser [--instance K] agent "<goal>" [flags]` | run the **autonomous opencode browser-agent** in its OWN isolated tab against `<goal>`; returns a compact `{answer,evidence,steps_used,status}` (see below) |
 | `browser --print-session-id`               | print the derived per-session id (debug) and exit |

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -81,6 +81,11 @@
 #   browser [--frame <f>] key <Enter|Tab|Escape|...> [--selector <sel>]
 #                             — dispatch one bounded key (TRUSTED CDP top frame;
 #                               SYNTHETIC in-frame)
+#   browser [--frame <f>] upload <selector> <path>
+#                             — populate the <input type=file> at <selector> with the
+#                               LOCAL file <path> (CDP DOM.setFileInputFiles; Chrome
+#                               reads it by path, no bytes cross the bridge). Path is
+#                               validated + made absolute; every upload is AUDIT-LOGGED
 #   browser agent "<goal>"    — run the autonomous opencode browser-agent in its
 #                               OWN isolated tab against <goal> (see browser-agent)
 #   browser --print-session-id — print the derived per-session id and exit
@@ -230,6 +235,27 @@ if isinstance(r, dict) and r.get("ok") is False:
 '
 }
 
+# _hidden_warn RESP — for a successful read response, if the extension flagged the
+# tab as HIDDEN (background → throttled → an SPA may not have rendered → the read
+# is a shell-only DOM), print its note to STDERR. A WARNING only: exit stays 0 and
+# the JSON on stdout is untouched, so a caller/agent is warned without breaking the
+# machine-readable result. A no-op for any op whose result carries no `hidden` flag.
+_hidden_warn() {
+  printf '%s' "$1" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+r = d.get("result") if isinstance(d, dict) else None
+data = r.get("data") if isinstance(r, dict) else None
+if isinstance(data, dict) and data.get("hidden") is True:
+    note = data.get("note") or ("tab is hidden (background) — content may not have "
+                                "rendered; run \x27browser activate\x27")
+    sys.stderr.write("browser: " + str(note) + "\n")
+'
+}
+
 # cmd_op OP [EXTRA_JSON_FIELDS] — POST /cmd, print the result JSON on a genuine
 # success; exit non-zero with a readable message on a transport, HTTP, OR
 # op-level (result.ok:false) error. Honours the global --instance (INSTANCE) by
@@ -300,8 +326,19 @@ cmd_op() {
     echo "$resp" >&2; die "could not parse the server response from /cmd"
   fi
   if [ -n "$oe" ]; then
+    # A server-side `unknown_op` for an op the CLI KNOWS (every op cmd_op dispatches
+    # is a real op — a user typo is caught by the subcommand dispatch BEFORE here, and
+    # the SERVER 400s an op IT doesn't know) means the EXTENSION returned unknown_op:
+    # i.e. the loaded MV3 service worker is OLDER than this CLI. Map it to clear
+    # reload/restart guidance (the long-poll keeps the old SW alive, so ↻ is unreliable).
+    if [ "$oe" = "unknown_op" ]; then
+      die "op '$op' returned unknown_op — your loaded browser-bridge extension is OLDER than this CLI. Reload it in brave://extensions. If the reload doesn't take, FULLY RESTART Brave (the extension's long-poll keeps the old service worker alive, so ↻ is unreliable)."
+    fi
     die "op '$op' failed in the browser: $oe"
   fi
+  # Gap 2: a read on a hidden/background tab self-announces (data.hidden) — warn on
+  # STDERR (exit stays 0) so the JSON result on stdout is unbroken.
+  _hidden_warn "$resp"
   printf '%s' "$resp"
 }
 
@@ -494,6 +531,23 @@ print(sys.argv[1])
     if [ -n "$ksel" ]; then extra="${extra},\"selector\":$(json_str "$ksel")"; fi
     cmd_op key "$extra" | pretty
     ;;
+  upload)
+    # browser [--frame <f>] upload <css-selector> <path>
+    # Populate the <input type=file> matched by <css-selector> with the LOCAL file
+    # at <path>. Chrome reads the file BY PATH itself (same host) — no bytes cross
+    # the bridge. VALIDATE the path (readable regular file) BEFORE dispatch, resolve
+    # it to an ABSOLUTE path, then send it as a typed op. The server AUDIT-LOGS every
+    # upload (op + target domain + path). --frame routes into a cross-origin OOPIF.
+    [ $# -ge 2 ] || die "usage: browser [--frame <f>] upload <css-selector> <path>"
+    usel="$1"; upath="$2"; shift 2
+    [ $# -eq 0 ] || die "browser upload takes exactly <selector> <path> (got extra: $1)"
+    [ -e "$upath" ] || die "upload: no such file: $upath"
+    [ -f "$upath" ] || die "upload: not a regular file: $upath"
+    [ -r "$upath" ] || die "upload: file not readable: $upath"
+    uabs="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$upath")" \
+      || die "upload: could not resolve an absolute path for: $upath"
+    cmd_op upload "\"selector\":$(json_str "$usel"),\"path\":$(json_str "$uabs")" | pretty
+    ;;
   agent)
     # Hand off to the sibling browser-agent wrapper (autonomous opencode agent in
     # its own isolated tab). Forward a leading --instance (if the caller put it
@@ -510,6 +564,6 @@ print(sys.argv[1])
     grep -E '^#( |$)' "$0" | sed -E 's/^# ?//'
     ;;
   *)
-    die "unknown subcommand: $sub (try: health whoami instances open close release activate html text eval tabs nav screenshot frames click type key agent)"
+    die "unknown subcommand: $sub (try: health whoami instances open close release activate html text eval tabs nav screenshot frames click type key upload agent)"
     ;;
 esac

--- a/scripts/browser-bridge/extension/manifest.json
+++ b/scripts/browser-bridge/extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Browser Bridge (command channel)",
-  "version": "0.1.0",
-  "description": "Lets a local Claude Code skill drive the active Brave tab (getHtml/eval/tabs/nav/screenshot/frames/click/type/key/activate) via a loopback, token-authenticated rendezvous server. Local-only, authorized personal automation.",
+  "version": "0.2.0",
+  "description": "Lets a local Claude Code skill drive the active Brave tab (getHtml/eval/tabs/nav/screenshot/frames/click/type/key/activate/upload) via a loopback, token-authenticated rendezvous server. Local-only, authorized personal automation.",
   "permissions": ["scripting", "tabs", "activeTab", "storage", "alarms", "debugger", "webNavigation"],
   "host_permissions": ["http://127.0.0.1:8788/*", "<all_urls>"],
   "icons": {

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -18,9 +18,16 @@
 // Chrome throttles while backgrounded) actually loads and can then be driven. It
 // is the ONE op that deliberately STEALS the user's focus; every other op is
 // non-intrusive. Tab-scoped (it targets a specific tab); no new permission.
+// `upload` populates an <input type=file> via CDP DOM.setFileInputFiles — Chrome
+// reads the file BY PATH itself (same host as the browser), so NO file bytes
+// cross the bridge. It is a bounded TYPED CDP op exactly like click/type/key:
+// selector + path args, own-tab-scoped, #189-bounded, scheme-checked; there is
+// NO raw-CDP passthrough. It IS a data-exfil-capable action (an explicit
+// operator decision to let the autonomous agent read ANY path) — so the server
+// AUDIT-LOGS every upload (op + target domain + path).
 export const ALLOWED_OPS = [
   "getHtml", "text", "eval", "tabs", "nav", "screenshot", "open", "close",
-  "frames", "click", "type", "key", "activate",
+  "frames", "click", "type", "key", "activate", "upload",
 ];
 
 // Per-op required fields (mirrors server.py REQUIRED_FIELDS). The server already
@@ -31,6 +38,7 @@ export const REQUIRED_FIELDS = {
   click: ["selector"],
   type: ["text"],
   key: ["key"],
+  upload: ["selector", "path"],   // the file-input selector + the ABSOLUTE local path
 };
 
 // Validate an inbound command dict. Returns { ok:true } or { ok:false, error }.
@@ -300,6 +308,63 @@ export async function waitForTabLoad(getTab, opts = {}) {
     tab = await getTab();
   }
   return { tab, waited: true };
+}
+
+// --- hidden-tab self-announcing reads (prevent the "false outage") ---------- //
+// A tab opened via `open` is BACKGROUND, so document.visibilityState==="hidden"
+// and Chromium THROTTLES it — a heavy SPA never renders, and text/html/eval/frames
+// return an empty shell that is indistinguishable from a broken site. So every
+// read op reports the tab's visibilityState in its result, and when the tab is
+// hidden it self-announces (data.hidden=true + a note pointing at `activate`) so
+// an operator/agent is not fooled into declaring a false outage. Pure — the SW
+// supplies the tab's document.visibilityState (which reflects the tab; an OOPIF's
+// document follows the tab, so a --frame read reports it the same way).
+export const HIDDEN_TAB_NOTE =
+  "tab is hidden — background tabs are throttled, so SPA content may not have " +
+  "rendered; run 'browser activate' or expect a shell-only DOM.";
+
+// Merge the tab's visibilityState into a read result's `data`. A truthy
+// visibilityState is recorded; when it is exactly "hidden", the result ALSO
+// carries data.hidden=true + data.note so the read self-announces. A null/absent
+// visibilityState (the probe failed / a mock omitted it) adds nothing — the read
+// still returns its content. Returns the same object (mutated) for convenience.
+export function annotateVisibility(data, visibilityState) {
+  if (data && typeof data === "object" && visibilityState) {
+    data.visibilityState = visibilityState;
+    if (visibilityState === "hidden") {
+      data.hidden = true;
+      data.note = HIDDEN_TAB_NOTE;
+    }
+  }
+  return data;
+}
+
+// --- upload op: populate an <input type=file> via CDP DOM.setFileInputFiles --- //
+// The element is resolved to a CDP RemoteObject (objectId) via Runtime.evaluate,
+// verified to be a real file input, then handed to DOM.setFileInputFiles with the
+// ABSOLUTE path — Chrome reads the file itself, so no bytes cross the bridge. All
+// of the pure string/probe pieces live here so the SW stays thin + unit-tested.
+
+// Expression that resolves the file-input element to a RemoteObject (returnByValue
+// MUST be false so CDP hands back the node's objectId, not a serialized clone).
+export function fileInputSelectorExpression(selector) {
+  return `document.querySelector(${JSON.stringify(String(selector))})`;
+}
+
+// Function declaration for Runtime.callFunctionOn(objectId,...): true iff the
+// resolved node is genuinely an <input type=file> (else `not_a_file_input`). Kept
+// as a STRING (callFunctionOn takes a function-declaration string) and self-
+// contained (references only `this`).
+export const FILE_INPUT_CHECK_FN =
+  "function(){return this.tagName==='INPUT'&&this.type==='file';}";
+
+// The basename of an absolute path (POSIX). The RESULT returns ONLY the basename
+// (the full path stays server/CLI-side + in the audit log) — a trailing slash is
+// ignored; "" when nothing usable remains. Pure.
+export function basenameOf(path) {
+  const s = String(path == null ? "" : path).replace(/\/+$/, "");
+  const i = s.lastIndexOf("/");
+  return i >= 0 ? s.slice(i + 1) : s;
 }
 
 // --- CDP (chrome.debugger) ops: any-frame reads + trusted input ------------- //

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -37,6 +37,12 @@ import {
   // context (chrome.scripting can only run a serialized FUNC — the #190 null bug).
   frameEvalExpressions, isCdpSyntaxError, matchCdpFrameId, pickOopifSessionId,
   evalValueOrThrow,
+  // hidden-tab self-announce (Gap 2): reads report the tab's visibilityState so a
+  // throttled background read can't masquerade as a real outage.
+  annotateVisibility,
+  // upload op (Gap 1): resolve a file input + hand its ABSOLUTE path to CDP
+  // DOM.setFileInputFiles (Chrome reads the file itself — no bytes cross the bridge).
+  fileInputSelectorExpression, FILE_INPUT_CHECK_FN, basenameOf,
 } from "./protocol.js";
 
 const DEFAULT_PORT = 8788;
@@ -106,6 +112,23 @@ async function targetTab(cmd) {
     }
   }
   return activeTab();
+}
+
+// Read the tab's `document.visibilityState` (top frame) so a read op can self-
+// announce a hidden/background tab (Gap 2). visibilityState reflects the TAB, and
+// an OOPIF's document follows the tab, so the top-frame read is correct for
+// --frame reads too. Best-effort: any failure (discarded tab, no host permission)
+// returns null and the read simply omits the field — it NEVER fails the read.
+async function tabVisibilityState(tabId) {
+  try {
+    const [inj] = await chrome.scripting.executeScript({
+      target: { tabId },
+      func: () => document.visibilityState,
+    });
+    return inj ? inj.result : null;
+  } catch (e) {
+    return null;
+  }
 }
 
 // --- CDP (chrome.debugger) glue -------------------------------------------- //
@@ -270,6 +293,68 @@ async function cdpFrameEval(tabId, tabUrl, frame, src) {
   });
 }
 
+// Populate the file input matched by `selector` with the ABSOLUTE local `absPath`
+// via CDP DOM.setFileInputFiles (Gap 1). Chrome reads the file itself by path (same
+// host) — so NO file bytes cross the bridge. Attaches ONLY to the owned/target tab
+// (withCdp → #187 own-tab scope + #189 bounded timeouts + discarded-tab fail-fast,
+// ALWAYS detach). `frame` (optional) routes into a SAME-PROCESS iframe (isolated
+// world) OR a cross-origin OOPIF (flat auto-attached session) — the SAME resolution
+// `eval --frame` uses. The element is resolved to a RemoteObject and VERIFIED to be
+// a real <input type=file> before anything is set. NO raw-CDP passthrough — a fixed
+// typed sequence of CDP calls. Returns [basename] (the full path never returns).
+async function cdpSetFileInput(tabId, tabUrl, frame, selector, absPath) {
+  return withCdp(tabId, tabUrl, async (send) => {
+    // Resolve the execution target for the element lookup: (sessionId, contextId).
+    // No frame → the tab's top session/default context (both undefined).
+    let sessionId;
+    let contextId;
+    if (frame) {
+      // SAME-PROCESS frame → in the top session's frame tree → isolated-world context.
+      const { frameTree } = await send("Page.getFrameTree");
+      const cdpFrameId = matchCdpFrameId(frameTree, frame.url);
+      if (cdpFrameId) {
+        const iso = await send("Page.createIsolatedWorld",
+          { frameId: cdpFrameId, worldName: "browser-bridge-upload", grantUniveralAccess: false });
+        contextId = iso.executionContextId;
+      } else {
+        // CROSS-ORIGIN OOPIF → NOT in the top frame tree → auto-attach flat, match
+        // the target session by url, evaluate in THAT session (as `eval --frame`).
+        const attached = [];
+        const onEvt = (_source, method, params) => {
+          if (method === "Target.attachedToTarget" && params && params.targetInfo) {
+            attached.push({ sessionId: params.sessionId, url: params.targetInfo.url });
+          }
+        };
+        chrome.debugger.onEvent.addListener(onEvt);
+        try {
+          await send("Target.setAutoAttach",
+            { autoAttach: true, flatten: true, waitForDebuggerOnStart: false });
+          sessionId = pickOopifSessionId(attached, frame.url);
+          if (!sessionId) throw new Error(`frame_not_found:${frame.url || frame.frameId}`);
+        } finally {
+          chrome.debugger.onEvent.removeListener(onEvt);
+        }
+      }
+    }
+    // 1. Resolve the element to a CDP RemoteObject (returnByValue:false → objectId).
+    const evalParams = { expression: fileInputSelectorExpression(selector), returnByValue: false };
+    if (contextId != null) evalParams.contextId = contextId;
+    const res = await send("Runtime.evaluate", evalParams, sessionId);
+    if (res && res.exceptionDetails) throw new Error(`element_not_found:${selector}`);
+    const objectId = res && res.result && res.result.objectId;
+    if (!objectId) throw new Error(`element_not_found:${selector}`);
+    // 2. VERIFY it is genuinely an <input type=file> before setting anything.
+    const check = await send("Runtime.callFunctionOn",
+      { objectId, functionDeclaration: FILE_INPUT_CHECK_FN, returnByValue: true }, sessionId);
+    if (!(check && check.result && check.result.value === true)) {
+      throw new Error(`not_a_file_input:${selector}`);
+    }
+    // 3. Hand the ABSOLUTE path to Chrome — it reads the file itself (no bytes here).
+    await send("DOM.setFileInputFiles", { objectId, files: [absPath] }, sessionId);
+    return [basenameOf(absPath)];
+  });
+}
+
 // --- op executors ---------------------------------------------------------- //
 // Each returns the op-specific `data` object; throws on failure (→ errorEnvelope).
 const OPS = {
@@ -279,17 +364,20 @@ const OPS = {
     // chrome.scripting (reaches an out-of-process iframe; no debugger banner).
     if (cmd && cmd.frame) {
       const frame = await resolveFrame(tab.id, cmd.frame);
+      const vis = await tabVisibilityState(tab.id);   // BEFORE the read → read stays last
       const html = await execInFrame(tab.id, frame.frameId, frameReadHtmlFn, []);
       // Report the FRAME's own url (not the top tab url) so the caller can confirm it
       // read the intended frame (#190 reported the top url for a frame read).
-      return { url: frame.url || tab.url, title: tab.title, html, frame: cmd.frame };
+      return annotateVisibility(
+        { url: frame.url || tab.url, title: tab.title, html, frame: cmd.frame }, vis);
     }
     // No frame → the lighter chrome.scripting top-frame read (no debugger banner).
+    const vis = await tabVisibilityState(tab.id);
     const [inj] = await chrome.scripting.executeScript({
       target: { tabId: tab.id },
       func: () => document.documentElement.outerHTML,
     });
-    return { url: tab.url, title: tab.title, html: inj.result };
+    return annotateVisibility({ url: tab.url, title: tab.title, html: inj.result }, vis);
   },
 
   // Cheap read: the tab's VISIBLE innerText (optionally scoped to a CSS
@@ -306,11 +394,14 @@ const OPS = {
     // chrome.scripting (reaches an out-of-process iframe; no debugger banner).
     if (cmd && cmd.frame) {
       const frame = await resolveFrame(tab.id, cmd.frame);
+      const vis = await tabVisibilityState(tab.id);   // BEFORE the read → read stays last
       const raw = await execInFrame(tab.id, frame.frameId, frameReadTextFn, [sel]);
       const { text, truncated } = normalizeText(raw, cap);
       // Report the FRAME's own url (see getHtml) so the caller confirms the right frame.
-      return { url: frame.url || tab.url, title: tab.title, text, truncated, frame: cmd.frame };
+      return annotateVisibility(
+        { url: frame.url || tab.url, title: tab.title, text, truncated, frame: cmd.frame }, vis);
     }
+    const vis = await tabVisibilityState(tab.id);
     const [inj] = await chrome.scripting.executeScript({
       target: { tabId: tab.id },
       args: [sel],
@@ -320,7 +411,7 @@ const OPS = {
       },
     });
     const { text, truncated } = normalizeText(inj.result, cap);
-    return { url: tab.url, title: tab.title, text, truncated };
+    return annotateVisibility({ url: tab.url, title: tab.title, text, truncated }, vis);
   },
 
   async eval(cmd) {
@@ -333,9 +424,14 @@ const OPS = {
     // OR OOPIF flat session) and NEVER silent-nulls (frame_not_found / frame_eval_failed).
     if (cmd && cmd.frame) {
       const frame = await resolveFrame(tab.id, cmd.frame);
+      // visibilityState is read on the TOP frame (it reflects the tab; the OOPIF's
+      // document follows the tab) via chrome.scripting — the EVAL itself still runs
+      // via CDP (the #190 fix), so this probe does not regress the eval mechanism.
+      const vis = await tabVisibilityState(tab.id);
       const value = await cdpFrameEval(tab.id, tab.url, frame, cmd.js);
-      return { url: frame.url || tab.url, value, frame: cmd.frame };
+      return annotateVisibility({ url: frame.url || tab.url, value, frame: cmd.frame }, vis);
     }
+    const vis = await tabVisibilityState(tab.id);
     // chrome.scripting runs the top-frame eval in the page's MAIN world (world:
     // "MAIN" below) — so `js` sees the page's own globals — and its completion value
     // is returned. Wrapped so a bare expression or a statement block both work.
@@ -365,7 +461,7 @@ const OPS = {
         return fn();
       },
     });
-    return { url: tab.url, value: inj.result };
+    return annotateVisibility({ url: tab.url, value: inj.result }, vis);
   },
 
   async tabs() {
@@ -425,7 +521,28 @@ const OPS = {
   async frames(cmd) {
     const tab = await targetTab(cmd);
     const frames = await framesForTab(tab.id);
-    return { url: tab.url, title: tab.title, frames };
+    const vis = await tabVisibilityState(tab.id);
+    return annotateVisibility({ url: tab.url, title: tab.title, frames }, vis);
+  },
+
+  // Populate an <input type=file> matched by `selector` with the ABSOLUTE local
+  // `path` via CDP DOM.setFileInputFiles (Gap 1). Chrome reads the file itself by
+  // path (same host) — NO file bytes cross the bridge. Own-tab-scoped + #189-bounded
+  // (cdpSetFileInput → withCdp). `--frame` routes into a same-process iframe OR a
+  // cross-origin OOPIF exactly like `eval --frame`. Verifies the element is a real
+  // file input (`not_a_file_input`) / exists (`element_not_found`). The RESULT
+  // carries only the BASENAME(s) — the full path stays server/CLI-side + audit log.
+  async upload(cmd) {
+    const tab = await targetTab(cmd);
+    const selector = String(cmd.selector);
+    const absPath = String(cmd.path);
+    if (cmd && cmd.frame) {
+      const frame = await resolveFrame(tab.id, cmd.frame);
+      const files = await cdpSetFileInput(tab.id, tab.url, frame, selector, absPath);
+      return { ok: true, selector, frame: cmd.frame, url: frame.url || tab.url, files };
+    }
+    const files = await cdpSetFileInput(tab.id, tab.url, null, selector, absPath);
+    return { ok: true, selector, frame: null, url: tab.url, files };
   },
 
   // Click `selector`. TWO paths, by design:

--- a/scripts/browser-bridge/opencode/browser-agent.md
+++ b/scripts/browser-bridge/opencode/browser-agent.md
@@ -28,6 +28,7 @@ fetch). Your tab is FIXED: you cannot choose or change which tab you act on.
 | `browser(op="click", selector="…")` (opt. `frame`) | **trusted** click at the element's center |
 | `browser(op="type", text="…")` (opt. `selector`, `frame`) | **trusted** text input (focus `selector` first if given) |
 | `browser(op="key", key="Enter")` (opt. `selector`, `frame`) | dispatch one **trusted** key (Enter/Tab/Escape/Arrow*/…) |
+| `browser(op="upload", selector="…", path="…")` (opt. `frame`) | populate an `<input type=file>` with a LOCAL file at `path` (Chrome reads it by path — no bytes cross the bridge). ⚠ ANY path is allowed by design; **every upload is audit-logged** (op + target domain + path). Use only the file the task told you to upload |
 | `browser(op="activate")` (opt. `waitMs`) | **FOREGROUND your tab** so a foreground-throttled SPA finishes loading — use when a heavy JS app is stuck on "Loading…" because your tab is backgrounded |
 | `browser(op="whoami")`                 | read-only identity + diagnostics: which HOST (laptop/workbench), the connected browser instance(s), and bridge/extension versions — call it to CONFIRM which host/profile you're on before acting (metadata only, no page content) |
 

--- a/scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
+++ b/scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
@@ -58,12 +58,22 @@ export const OP_TO_SERVER = Object.freeze({
   type: "type",
   key: "key",
   activate: "activate",
+  upload: "upload",
   whoami: "whoami",
 });
 
+// `upload` populates an <input type=file> with a file at a caller-chosen PATH via
+// CDP DOM.setFileInputFiles. EXFIL TRADEOFF (explicit operator decision): the agent
+// may supply ANY path — there is NO path allowlist here. Chrome reads the file by
+// path itself (same host), so no bytes route through the agent, but the CONTENTS of
+// any readable file could be posted to the target site. This is accepted; it is made
+// safe-to-audit rather than blocked: the SERVER audit-logs EVERY upload (op + target
+// domain + path). Still a bounded TYPED op — only selector/path/frame reach the wire
+// (buildRequest whitelists them); no raw-CDP/method/params passthrough. Own-tab-scoped
+// (the tab is forced by env), like every other op.
 export const ALLOWED_OPS_DEFAULT = Object.freeze([
   "text", "html", "eval", "nav", "screenshot",
-  "frames", "click", "type", "key", "activate", "whoami",
+  "frames", "click", "type", "key", "activate", "upload", "whoami",
 ]);
 
 export const TEXT_MAX_BYTES_DEFAULT = 32768;
@@ -261,6 +271,16 @@ export function buildRequest(args, env, token) {
       }
       body.waitMs = n;
     }
+  } else if (op === "upload") {
+    // Populate a file input. TYPED scalars only: selector + path (+ optional frame).
+    // ANY path is allowed for the agent (the explicit exfil tradeoff above); the
+    // server audit-logs every upload. Only these fields reach the wire — a smuggled
+    // cdp/method/params is dropped (the whitelist build below).
+    if (!args || !args.selector) throw new BrowserToolRefusal("upload_missing_selector");
+    if (!args.path) throw new BrowserToolRefusal("upload_missing_path");
+    body.selector = String(args.selector);
+    body.path = String(args.path);
+    _addFrame(body, args);
   }
   // frames / screenshot: no extra typed fields (the tab is forced by env).
 
@@ -311,6 +331,13 @@ export function summarizeResult(op, envelope) {
   }
   if (op === "key") {
     return JSON.stringify({ ok: true, key: data.key ?? null });
+  }
+  if (op === "upload") {
+    // Metadata-only confirmation: the selector + the BASENAME(s) set (never the
+    // full path — that stays server/CLI-side + in the audit log) + the frame.
+    return JSON.stringify({ ok: true, selector: data.selector ?? null,
+      files: Array.isArray(data.files) ? data.files : [],
+      frame: data.frame ?? null });
   }
   if (op === "activate") {
     // Compact confirmation the tab foregrounded (metadata only — no page content).
@@ -379,7 +406,8 @@ export async function runBrowserOp(args, opts = {}) {
   // forced tab (a bad op/tab is refused even in dry-run).
   const MUTATING = op === "nav" || op === "eval" ||
                    op === "click" || op === "type" || op === "key" ||
-                   op === "activate";   // activate steals focus → never in a dry-run
+                   op === "activate" ||  // activate steals focus → never in a dry-run
+                   op === "upload";      // upload populates a file input → never in a dry-run
   if (dry && MUTATING) {
     const allowed = allowedOpsFromEnv(env);
     if (!allowed.includes(op)) throw new BrowserToolRefusal(`op_not_allowed:${op}`);

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -114,8 +114,17 @@ from urllib.parse import unquote, urlsplit
 # tab-scoped and dispatched like the other tab-scoped ops (its optional `waitMs`
 # is a passthrough field, not a routing hint). It is the ONE op that STEALS the
 # user's foreground focus (documented as intended, best-effort under i3).
+# `upload` is a TYPED CDP op (DOM.setFileInputFiles): it populates an
+# <input type=file> with a local file whose ABSOLUTE path Chrome reads ITSELF
+# (same host) — so NO file bytes cross the bridge. It dispatches + tab-scopes
+# exactly like the other CDP ops (own-tab, #189-bounded, scheme-checked); the
+# server stays op-agnostic about the CDP mechanics and only forwards the typed
+# selector/path/frame. It IS a data-exfil-capable action (an EXPLICIT operator
+# decision to allow the autonomous agent any path) → the server AUDIT-LOGS every
+# upload (op + target domain + the file path — local metadata, never file CONTENT).
 ALLOWED_OPS = ("getHtml", "text", "eval", "tabs", "nav", "screenshot",
-               "open", "close", "frames", "click", "type", "key", "activate")
+               "open", "close", "frames", "click", "type", "key", "activate",
+               "upload")
 
 # Ops handled ENTIRELY server-side (never dispatched to the extension). `release`
 # relinquishes a session's owned-tab mapping without touching the real Brave tab.
@@ -127,7 +136,7 @@ SERVER_OPS = ("release",)
 # and `release` (server-side) do NOT contend for a single tab.
 TAB_SCOPED_OPS = frozenset({"getHtml", "text", "eval", "nav", "screenshot",
                             "close", "frames", "click", "type", "key",
-                            "activate"})
+                            "activate", "upload"})
 
 # Per-op required fields (skill-supplied). Absent → 400 bad_request. NOTE: `close`
 # takes NO skill-supplied field — the server injects the caller's owned tabId (or
@@ -138,6 +147,7 @@ REQUIRED_FIELDS = {
     "click": ("selector",),   # CDP trusted click needs the element selector
     "type": ("text",),        # CDP trusted type needs the text to insert
     "key": ("key",),          # CDP key event needs the key name
+    "upload": ("selector", "path"),  # file-input selector + the ABSOLUTE local path
 }
 
 MAX_CMD_BODY = 256 * 1024      # a command is tiny (op + a url / a js snippet).
@@ -1092,8 +1102,13 @@ class Registry:
 
     @staticmethod
     def _describe(inst: Instance) -> dict:
+        # extension_version (best-effort, from the /poll X-Bridge-Ext-Version
+        # header; None until a build that reports it polls) is surfaced in /health
+        # + /instances too so `browser health` shows which extension BUILD is loaded
+        # — the signal that distinguishes a stale extension from a missing op.
         return {"key": inst.key, "label": inst.label,
-                "instanceId": inst.instance_id, "activeTab": inst.active_tab}
+                "instanceId": inst.instance_id, "activeTab": inst.active_tab,
+                "extension_version": inst.extension_version}
 
     def snapshot(self):
         """A list of currently-live instances (key/label/instanceId/activeTab)."""
@@ -1473,9 +1488,15 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
             path = urlsplit(self.path).path
             if path == "/health":
                 insts = registry.snapshot()
+                # extension_version_current = the manifest version the SERVER reads
+                # from the repo (best-effort, absolute path like whoami). Compare it
+                # by eye against each instance's reported extension_version to spot a
+                # stale loaded extension (NOT a hard "stale" flag — the manifest
+                # version is not bumped per-change).
                 self._send(200, {"ok": True,
                                  "extension_connected": bool(insts),
                                  "count": len(insts),
+                                 "extension_version_current": manifest_version(),
                                  "instances": insts})
                 return
             if path == "/instances":
@@ -1551,6 +1572,11 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                     self._send(400, {"ok": False, "error": terr})
                     return
             session_id = self.headers.get(HDR_SESSION_ID) or None
+            # The upload file PATH is captured for the AUDIT log/event (see the
+            # ALLOWED_OPS note). It is local metadata (never file content); logging
+            # it is acceptable and required for traceability of this exfil-capable
+            # action. `body` still carries it (target/tab are popped, path is not).
+            upload_path = body.get("path") if op == "upload" else None
             outcome, exit_code, domain = "ok", 0, ""
             # `release` is server-side: drop the session's ownership without ever
             # touching the real Brave tab or the extension.
@@ -1578,11 +1604,17 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                 log("throttled", op=op, key=e.key, reason=e.reason, sess=sess)
                 self._send(429, {"ok": False, "error": e.reason,
                                  "retry_after": round(e.retry_after, 3)})
+                extra = {"reason": e.reason, "sess": sess}
+                if op == "upload":
+                    # AUDIT even a throttled upload attempt (it never reached the
+                    # browser, so no file was read — but the attempt is traceable).
+                    extra["path"] = upload_path
+                    log("upload", outcome="throttled", domain="",
+                        path=upload_path, key=(target or ""))
                 emit_cmd_event(
                     op=op, key=(target or ""), outcome="throttled",
                     duration_ms=int((time.monotonic() - t0) * 1000),
-                    domain="", exit_code=1,
-                    extra={"reason": e.reason, "sess": sess})
+                    domain="", exit_code=1, extra=extra)
                 return
             except NoOwnedTab:
                 outcome, exit_code = "no_owned_tab", 1
@@ -1631,9 +1663,16 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
             # only + best-effort — cannot delay or break the command (the key is
             # the skill's routing target, empty for the implicit single-instance
             # case). See emit_cmd_event / the PRIVACY + BEST-EFFORT contracts.
+            # `upload` additionally carries the file PATH (audit metadata) + a
+            # dedicated structured log line — this op is exfil-capable so EVERY
+            # outcome is traceable (the path is local metadata, never file content).
+            upload_extra = {"path": upload_path} if op == "upload" else None
+            if op == "upload":
+                log("upload", outcome=outcome, domain=domain, path=upload_path,
+                    key=(target or ""))
             emit_cmd_event(op=op, key=(target or ""), outcome=outcome,
                            duration_ms=int((time.monotonic() - t0) * 1000),
-                           domain=domain, exit_code=exit_code)
+                           domain=domain, exit_code=exit_code, extra=upload_extra)
 
         def _handle_result(self):
             body, err = self._read_body(MAX_RESULT_BODY)

--- a/scripts/browser-bridge/tests/browser_tool.test.mjs
+++ b/scripts/browser-bridge/tests/browser_tool.test.mjs
@@ -282,7 +282,7 @@ test("OP_TO_SERVER maps only the bounded ops (no lifecycle ops, no raw CDP)", ()
   // like the rest; still NO lifecycle ops and NO raw-CDP escape.
   assert.deepEqual(Object.keys(OP_TO_SERVER).sort(),
     ["activate", "click", "eval", "frames", "html", "key", "nav", "screenshot",
-     "text", "type", "whoami"]);
+     "text", "type", "upload", "whoami"]);
   // Lifecycle ops (wrapper owns the tab) AND any raw-CDP escape must be unmappable.
   for (const forbidden of ["open", "close", "tabs", "release",
                            "cdp", "command", "attach", "detach", "sendCommand"]) {
@@ -290,7 +290,7 @@ test("OP_TO_SERVER maps only the bounded ops (no lifecycle ops, no raw CDP)", ()
   }
   assert.deepEqual([...ALLOWED_OPS_DEFAULT].sort(),
     ["activate", "click", "eval", "frames", "html", "key", "nav", "screenshot",
-     "text", "type", "whoami"]);
+     "text", "type", "upload", "whoami"]);
 });
 
 test("buildRequest: activate forces the env tab; bounded waitMs only; NO raw passthrough", () => {
@@ -540,4 +540,86 @@ test("runBrowserOp: whoami surfaces a bridge non-200 (auth/host) as an error", a
     async text() { return JSON.stringify({ ok: false, error: "unauthorized" }); } });
   await assert.rejects(() => run({ op: "whoami" }, baseEnv(), impl),
     /HTTP 401/);
+});
+
+// --------------------------------------------------------------------------- //
+// upload op via the TYPED tool (Gap 1): forced own-tab, required typed fields,
+// ANY path allowed (the explicit exfil tradeoff — audit-logged server-side), and
+// NO raw-CDP passthrough. `upload` populates an <input type=file> with a local
+// file whose path Chrome reads itself (no bytes route through the agent).
+// --------------------------------------------------------------------------- //
+test("buildRequest: upload forces the env tab + requires selector & path; forwards --frame", () => {
+  const b = buildRequest({ op: "upload", selector: "#f", path: "/home/zach/x.png" },
+    baseEnv(), TOK).body;
+  assert.equal(b.op, "upload");
+  assert.equal(b.tab, 4242, "upload is forced to the env tab (own-tab-scoped)");
+  assert.equal(b.selector, "#f");
+  assert.equal(b.path, "/home/zach/x.png");
+  const f = buildRequest({ op: "upload", selector: "#f", path: "/p", frame: "bench" },
+    baseEnv(), TOK).body;
+  assert.equal(f.frame, "bench", "upload forwards --frame (route into a cross-origin OOPIF)");
+});
+
+test("buildRequest: upload requires BOTH selector and path", () => {
+  assert.throws(() => buildRequest({ op: "upload", path: "/p" }, baseEnv(), TOK),
+    /upload_missing_selector/);
+  assert.throws(() => buildRequest({ op: "upload", selector: "#f" }, baseEnv(), TOK),
+    /upload_missing_path/);
+});
+
+test("buildRequest: upload allows ANY path (explicit exfil tradeoff — no path allowlist)", () => {
+  for (const p of ["/etc/passwd", "/home/zach/.ssh/id_ed25519", "/tmp/x"]) {
+    const b = buildRequest({ op: "upload", selector: "#f", path: p }, baseEnv(), TOK).body;
+    assert.equal(b.path, p, "any path is forwarded (accepted tradeoff; the server audit-logs it)");
+  }
+});
+
+test("NO raw-CDP passthrough: upload forwards ONLY op/tab/selector/path/frame", () => {
+  const hostile = { op: "upload", selector: "#f", path: "/p", frame: "x",
+    cdp: "Page.setDownloadBehavior", method: "DOM.setFileInputFiles",
+    params: { files: ["/etc/shadow"] }, objectId: "OBJ", files: ["/evil"],
+    tab: 999, tabId: 999, target: "other-profile" };
+  const b = buildRequest(hostile, baseEnv(), TOK).body;
+  assert.deepEqual(Object.keys(b).sort(), ["frame", "op", "path", "selector", "tab"],
+    "only the typed upload fields reach the wire");
+  assert.equal(b.tab, 4242, "the forced env tab wins over a smuggled tab");
+  for (const leak of ["cdp", "method", "params", "objectId", "files", "target", "tabId"]) {
+    assert.ok(!(leak in b), `${leak} must never be forwarded`);
+  }
+});
+
+test("summarizeResult: upload returns basenames only (never the full path)", () => {
+  const s = JSON.parse(summarizeResult("upload", { data: {
+    selector: "#f", files: ["render.png"], frame: null, url: "https://x.test/" } }));
+  assert.deepEqual(s, { ok: true, selector: "#f", files: ["render.png"], frame: null });
+  assert.ok(!/\/home|\/etc|\/tmp/.test(JSON.stringify(s)),
+    "a full path must never reach the model context");
+});
+
+test("runBrowserOp: upload reaches the bridge with the forced tab + typed fields", async () => {
+  const fx = fetchStub({ upload: { ok: true, selector: "#f", files: ["x.png"],
+    frame: null, url: "https://x.test/" } });
+  const out = JSON.parse(await run(
+    { op: "upload", selector: "#f", path: "/home/zach/x.png" }, baseEnv(), fx));
+  assert.equal(fx.calls.length, 1);
+  assert.equal(fx.calls[0].body.op, "upload");
+  assert.equal(fx.calls[0].body.tab, 4242, "forced env tab");
+  assert.equal(fx.calls[0].body.path, "/home/zach/x.png");
+  assert.equal(out.ok, true);
+  assert.deepEqual(out.files, ["x.png"]);
+});
+
+test("runBrowserOp: upload is MUTATING → dry-run intercepts it (never populates a file input)", async () => {
+  const fx = fetchStub();
+  const out = await run({ op: "upload", selector: "#f", path: "/p" },
+    baseEnv({ BROWSER_AGENT_DRY_RUN: "1" }), fx);
+  assert.match(out, /"dryRun":true/);
+  assert.equal(fx.calls.length, 0, "a dry-run must never touch the bridge");
+});
+
+test("runBrowserOp: upload is refused when NOT in the op allowlist", async () => {
+  const fx = fetchStub();
+  await assert.rejects(run({ op: "upload", selector: "#f", path: "/p" },
+    baseEnv({ BROWSER_AGENT_ALLOWED_OPS: "text,html" }), fx), /op_not_allowed:upload/);
+  assert.equal(fx.calls.length, 0);
 });

--- a/scripts/browser-bridge/tests/frame_eval_cdp.test.mjs
+++ b/scripts/browser-bridge/tests/frame_eval_cdp.test.mjs
@@ -121,7 +121,10 @@ test("eval --frame 0 (SAME-PROCESS/top): CDP Runtime.evaluate returns the VALUE,
   const out = await OPS.eval({ tabId: TAB_ID, frame: "0", js: "location.href" });
   // The CDP path was taken — attach happened, chrome.scripting did NOT.
   assert.equal(state.calls.attach.length, 1, "eval --frame must attach chrome.debugger (CDP path)");
-  assert.equal(state.calls.executeScript.length, 0, "eval --frame must NOT use chrome.scripting");
+  // The EVAL itself runs via CDP (asserted below). The only chrome.scripting call is
+  // the top-frame visibilityState probe (Gap 2) — NEVER a frame injection of the eval.
+  assert.ok(state.calls.executeScript.every((c) => !(c.target && c.target.frameIds)),
+    "eval --frame must use CDP for the eval; the only executeScript is the top-frame visibility probe");
   // Same-process → frame tree lookup + isolated world + evaluate(contextId).
   assert.ok(cdpMethods().includes("Page.getFrameTree"));
   assert.ok(cdpMethods().includes("Page.createIsolatedWorld"));
@@ -139,7 +142,9 @@ test("eval --frame <oopif>: OOPIF target resolved via setAutoAttach flat session
   reset();
   state.evalReply = { result: { value: OOPIF_URL } };   // location.href INSIDE the OOPIF
   const out = await OPS.eval({ tabId: TAB_ID, frame: "model-benchmarking.civit.ai", js: "location.href" });
-  assert.equal(state.calls.executeScript.length, 0, "still not chrome.scripting");
+  // Still CDP for the eval — the only executeScript is the top-frame visibility probe.
+  assert.ok(state.calls.executeScript.every((c) => !(c.target && c.target.frameIds)),
+    "eval --frame still uses CDP; the only executeScript is the top-frame visibility probe");
   // OOPIF path: NOT in the frame tree → auto-attach → evaluate in the matched SESSION.
   assert.ok(cdpMethods().includes("Target.setAutoAttach"), "auto-attaches to reach the OOPIF target");
   assert.equal(lastEval().sessionId, "SID_OOPIF", "evaluate is issued in the OOPIF's flat session");

--- a/scripts/browser-bridge/tests/hidden_tab.test.mjs
+++ b/scripts/browser-bridge/tests/hidden_tab.test.mjs
@@ -1,0 +1,113 @@
+// Glue tests for the hidden-tab SELF-ANNOUNCE (Gap 2) against a MOCKED chrome —
+// proving each read executor reports the tab's visibilityState and, when the tab
+// is HIDDEN (a background tab Chromium throttles → a shell-only DOM), flags
+// data.hidden=true + a note so a read can't masquerade as a real outage.
+//
+// The mock distinguishes the top-frame visibilityState PROBE (its injected func
+// references document.visibilityState) from the actual read, so a read returns its
+// content while the probe returns a controllable visibilityState.
+//
+// SW auto-start is suppressed (BROWSER_BRIDGE_NO_AUTOSTART) so importing does no I/O.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { HIDDEN_TAB_NOTE } from "../extension/protocol.js";
+
+const TAB_ID = 5;
+const TOP_URL = "https://civitai.com/apps/run/model-benchmarking";
+const OOPIF_URL = "https://model-benchmarking.civit.ai/";
+
+const state = {
+  frames: [
+    { frameId: 0, parentFrameId: -1, url: TOP_URL },
+    { frameId: 7, parentFrameId: 0, url: OOPIF_URL },
+  ],
+  tab: { id: TAB_ID, url: TOP_URL, title: "Bench", active: false, status: "complete", windowId: 1 },
+  visibility: "visible",          // what the top-frame visibilityState PROBE returns
+  readResult: "TOP READ",          // what a top-frame read returns
+  frameReadResult: "FRAME READ",   // what a --frame injection returns
+};
+
+globalThis.BROWSER_BRIDGE_NO_AUTOSTART = true;
+globalThis.chrome = {
+  webNavigation: {
+    async getAllFrames() { return state.frames; },
+  },
+  scripting: {
+    async executeScript(params) {
+      const src = params.func ? String(params.func) : "";
+      // The visibilityState probe is the ONLY injected func that reads it.
+      if (src.includes("visibilityState")) return [{ result: state.visibility }];
+      if (params.target && params.target.frameIds) return [{ result: state.frameReadResult }];
+      return [{ result: state.readResult }];
+    },
+  },
+  tabs: {
+    async get(id) { return { ...state.tab, id }; },
+    async query() { return [state.tab]; },
+  },
+  debugger: { onDetach: { addListener() {} }, onEvent: { addListener() {}, removeListener() {} } },
+  storage: { local: { async get() { return {}; }, async set() {} } },
+  runtime: { onInstalled: { addListener() {} }, onStartup: { addListener() {} } },
+  alarms: { create() {}, onAlarm: { addListener() {} } },
+};
+
+const { OPS } = await import("../extension/service_worker.js");
+
+// --------------------------------------------------------------------------- //
+test("visible tab: every read reports visibilityState:'visible' and does NOT flag hidden", async () => {
+  state.visibility = "visible";
+  for (const call of [
+    () => OPS.text({ tabId: TAB_ID }),
+    () => OPS.getHtml({ tabId: TAB_ID }),
+    () => OPS.eval({ tabId: TAB_ID, js: "1" }),
+    () => OPS.frames({ tabId: TAB_ID }),
+  ]) {
+    const out = await call();
+    assert.equal(out.visibilityState, "visible");
+    assert.ok(!("hidden" in out), "a visible tab must NOT set hidden");
+    assert.ok(!("note" in out), "a visible tab must NOT carry the throttle note");
+  }
+});
+
+test("hidden tab: text self-announces (hidden:true + the throttle note)", async () => {
+  state.visibility = "hidden";
+  const out = await OPS.text({ tabId: TAB_ID });
+  assert.equal(out.text, "TOP READ", "the read still returns its (shell) content");
+  assert.equal(out.visibilityState, "hidden");
+  assert.equal(out.hidden, true);
+  assert.equal(out.note, HIDDEN_TAB_NOTE);
+  assert.match(out.note, /background tabs are throttled/);
+  assert.match(out.note, /browser activate/);
+});
+
+test("hidden tab: html / eval / frames each self-announce too", async () => {
+  state.visibility = "hidden";
+  for (const call of [
+    () => OPS.getHtml({ tabId: TAB_ID }),
+    () => OPS.eval({ tabId: TAB_ID, js: "document.title" }),
+    () => OPS.frames({ tabId: TAB_ID }),
+  ]) {
+    const out = await call();
+    assert.equal(out.hidden, true);
+    assert.equal(out.note, HIDDEN_TAB_NOTE);
+    assert.equal(out.visibilityState, "hidden");
+  }
+});
+
+test("hidden tab: a --frame read reports the tab's hidden state the same way", async () => {
+  state.visibility = "hidden";
+  const out = await OPS.text({ tabId: TAB_ID, frame: "model-benchmarking.civit.ai" });
+  assert.equal(out.text, "FRAME READ", "the OOPIF read still returns its content");
+  assert.equal(out.frame, "model-benchmarking.civit.ai");
+  assert.equal(out.hidden, true, "an OOPIF's document follows the tab → hidden reported the same way");
+  assert.equal(out.note, HIDDEN_TAB_NOTE);
+});
+
+test("visibility probe failure is swallowed: the read still returns (no visibility fields)", async () => {
+  state.visibility = null;   // probe returns null (e.g. discarded tab / no permission)
+  const out = await OPS.text({ tabId: TAB_ID });
+  assert.equal(out.text, "TOP READ");
+  assert.ok(!("visibilityState" in out), "a null probe adds nothing — the read never fails");
+  assert.ok(!("hidden" in out));
+});

--- a/scripts/browser-bridge/tests/protocol.test.mjs
+++ b/scripts/browser-bridge/tests/protocol.test.mjs
@@ -37,7 +37,7 @@ test("op set mirrors the server contract", () => {
   assert.deepEqual(
     [...ALLOWED_OPS].sort(),
     ["activate", "click", "close", "eval", "frames", "getHtml", "key", "nav",
-     "open", "screenshot", "tabs", "text", "type"],
+     "open", "screenshot", "tabs", "text", "type", "upload"],
   );
 });
 
@@ -119,6 +119,7 @@ test("REQUIRED_FIELDS matches the ops that need args", () => {
   assert.deepEqual(REQUIRED_FIELDS.click, ["selector"]);
   assert.deepEqual(REQUIRED_FIELDS.type, ["text"]);
   assert.deepEqual(REQUIRED_FIELDS.key, ["key"]);
+  assert.deepEqual(REQUIRED_FIELDS.upload, ["selector", "path"]);
 });
 
 test("result / error envelopes carry the id", () => {

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -960,7 +960,16 @@ def test_validate_command_contract():
     # The op set is the shared contract with extension/protocol.js.
     assert set(S.ALLOWED_OPS) == {"getHtml", "text", "eval", "tabs", "nav",
                                   "screenshot", "open", "close",
-                                  "frames", "click", "type", "key", "activate"}
+                                  "frames", "click", "type", "key", "activate",
+                                  "upload"}
+    # `upload` is a dispatched, tab-scoped CDP op requiring selector + path.
+    assert S.validate_command({"op": "upload", "selector": "#f",
+                               "path": "/tmp/x"}) == ("upload", None)
+    assert S.validate_command({"op": "upload", "path": "/tmp/x"})[1] \
+        == "missing_field:selector"
+    assert S.validate_command({"op": "upload", "selector": "#f"})[1] \
+        == "missing_field:path"
+    assert "upload" in S.TAB_SCOPED_OPS
     # `text` is a dispatched, tab-scoped, cheap-read op with NO required field.
     assert S.validate_command({"op": "text"}) == ("text", None)
     assert "text" in S.TAB_SCOPED_OPS
@@ -3075,7 +3084,7 @@ def test_git_short_head_none_on_missing_dir(tmp_path):
 
 def test_manifest_version_reads_current():
     v = S.manifest_version(path=EXT_DIR / "manifest.json")
-    assert isinstance(v, str) and v == "0.1.0"
+    assert isinstance(v, str) and v == "0.2.0"
 
 
 def test_manifest_version_none_on_missing(tmp_path):
@@ -3260,3 +3269,263 @@ def test_browser_cli_whoami(tmp_path):
         assert out["bridge"]["extension_version_current"] == "0.1.0"
     finally:
         srv.shutdown(); srv.server_close()
+
+
+# =========================================================================== #
+# Gap 1 — `upload` op: audit-logged (op + target domain + the file PATH)
+# =========================================================================== #
+def test_upload_dispatches_and_audit_event_has_op_domain_path(telemetry):
+    """An upload dispatches to the extension (tab-scoped like the other CDP ops)
+    AND emits an AUDIT telemetry event carrying op + target domain + the file
+    PATH (local metadata — never file content). The path is required so this
+    exfil-capable action is traceable."""
+    spool_dir = telemetry
+    srv, _ = _serve()
+    ext = FakeExtension(srv, executor=lambda c: {
+        "ok": True, "selector": c.get("selector"),
+        "url": "https://civitai.com/apps/run/model-benchmarking",
+        "files": ["render.png"]})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _req(srv, "POST", "/cmd", {
+            "op": "upload", "selector": "#file",
+            "path": "/home/zach/pics/render.png"})
+        assert st == 200
+        # The path reached the extension (dispatched op), the basename came back.
+        assert ext.dispatched[-1]["path"] == "/home/zach/pics/render.png"
+        assert body["result"]["data"]["files"] == ["render.png"]
+        e = _wait_events(spool_dir, 1)[0]
+        assert e["exit_code"] == "0"
+        p = json.loads(e["payload"])
+        assert p["op"] == "upload"
+        assert p["outcome"] == "ok"
+        assert p["domain"] == "civitai.com"       # target domain (from the result url)
+        assert p["path"] == "/home/zach/pics/render.png"  # AUDIT: the file path
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_upload_is_tab_scoped_and_required_fields_enforced():
+    """`upload` is a tab-scoped op requiring selector + path (server-side 400)."""
+    assert "upload" in S.TAB_SCOPED_OPS
+    assert "upload" in S.ALLOWED_OPS
+    srv, _ = _serve()
+    try:
+        st, body = _req(srv, "POST", "/cmd", {"op": "upload", "path": "/x"})
+        assert st == 400 and body["error"] == "missing_field:selector"
+        st, body = _req(srv, "POST", "/cmd", {"op": "upload", "selector": "#f"})
+        assert st == 400 and body["error"] == "missing_field:path"
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+# --- CLI: path validation happens BEFORE any dispatch ---------------------- #
+@pytest.mark.skipif(shutil.which("curl") is None, reason="curl not on PATH")
+def test_browser_cli_upload_rejects_missing_and_nonfile_path(tmp_path):
+    """`browser upload` validates the path is a readable regular file and resolves
+    it to an ABSOLUTE path BEFORE any /cmd dispatch — a missing/non-file path is a
+    clear error and NEVER reaches the bridge."""
+    srv_state = _CaptureCmdServer()
+    srv = S.ThreadingHTTPServer(("127.0.0.1", 0), srv_state.handler())
+    srv.daemon_threads = True
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    tokf = tmp_path / "token"; tokf.write_text("smoke-token\n")
+    env = dict(os.environ)
+    env.update(BROWSER_BRIDGE_HOST="127.0.0.1", BROWSER_BRIDGE_PORT=str(port),
+               BROWSER_BRIDGE_TOKEN_FILE=str(tokf))
+
+    def run(*args):
+        return subprocess.run([str(BROWSER_BIN), *args], env=env,
+                              capture_output=True, text=True, timeout=30)
+    try:
+        # Nonexistent path → refused before dispatch.
+        r = run("upload", "#f", str(tmp_path / "nope.png"))
+        assert r.returncode != 0 and "no such file" in r.stderr.lower()
+        # A directory (not a regular file) → refused.
+        r = run("upload", "#f", str(tmp_path))
+        assert r.returncode != 0 and "not a regular file" in r.stderr.lower()
+        assert srv_state.bodies == [], "no upload reached the bridge for a bad path"
+        # A real file → dispatched with an ABSOLUTE path + selector.
+        f = tmp_path / "pic.png"; f.write_bytes(b"\x89PNG")
+        r = run("upload", "#file", str(f))
+        assert r.returncode == 0, r.stderr
+        b = srv_state.bodies[-1]
+        assert b["op"] == "upload"
+        assert b["selector"] == "#file"
+        assert b["path"] == os.path.realpath(str(f))  # resolved to an ABSOLUTE path
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+# =========================================================================== #
+# Gap 2 — hidden-tab self-announce: the CLI prints the note to STDERR (exit 0)
+# =========================================================================== #
+class _CannedCmdServer:
+    """A /cmd server that answers with a caller-supplied result envelope `data`."""
+
+    def __init__(self, data):
+        self.data = data
+
+    def handler(self):
+        outer = self
+
+        class _H(S.BaseHTTPRequestHandler):
+            def log_message(self, *a):  # noqa: A003
+                pass
+
+            def do_POST(self):
+                ln = int(self.headers.get("Content-Length") or 0)
+                if ln:
+                    self.rfile.read(ln)
+                payload = json.dumps({"ok": True, "result": {
+                    "id": "x", "ok": True, "data": outer.data}}).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+        return _H
+
+
+def _run_browser_against(data, args, tmp_path):
+    srv = S.ThreadingHTTPServer(("127.0.0.1", 0), _CannedCmdServer(data).handler())
+    srv.daemon_threads = True
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    tokf = tmp_path / "token"; tokf.write_text("smoke-token\n")
+    env = dict(os.environ)
+    env.update(BROWSER_BRIDGE_HOST="127.0.0.1", BROWSER_BRIDGE_PORT=str(port),
+               BROWSER_BRIDGE_TOKEN_FILE=str(tokf))
+    try:
+        return subprocess.run([str(BROWSER_BIN), *args], env=env,
+                              capture_output=True, text=True, timeout=30)
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+@pytest.mark.skipif(shutil.which("curl") is None, reason="curl not on PATH")
+def test_browser_cli_hidden_tab_note_to_stderr_exit0(tmp_path):
+    """A read whose result flags the tab hidden prints the note to STDERR but
+    exits 0 (a warning, not an error) and leaves the JSON on stdout intact."""
+    note = "tab is hidden — background tabs are throttled; run 'browser activate'"
+    data = {"url": "https://x.test", "title": "X", "html": "<html></html>",
+            "visibilityState": "hidden", "hidden": True, "note": note}
+    r = _run_browser_against(data, ["html"], tmp_path)
+    assert r.returncode == 0, "a hidden-tab warning must NOT fail the command"
+    assert note in r.stderr, f"the note must be on stderr, got: {r.stderr!r}"
+    # The JSON result is still on stdout, unbroken.
+    out = json.loads(r.stdout)
+    assert out["result"]["data"]["hidden"] is True
+
+
+@pytest.mark.skipif(shutil.which("curl") is None, reason="curl not on PATH")
+def test_browser_cli_visible_tab_no_stderr_warning(tmp_path):
+    """A read on a VISIBLE tab prints NO hidden-tab warning to stderr."""
+    data = {"url": "https://x.test", "title": "X", "html": "<html></html>",
+            "visibilityState": "visible"}
+    r = _run_browser_against(data, ["html"], tmp_path)
+    assert r.returncode == 0
+    assert "hidden" not in r.stderr.lower()
+    assert "throttled" not in r.stderr.lower()
+
+
+# =========================================================================== #
+# Gap 3 — stale extension: version in /health + unknown_op → reload/restart map
+# =========================================================================== #
+def test_health_includes_extension_version_and_current():
+    """/health surfaces each instance's reported extension_version AND the bridge-
+    level extension_version_current (the manifest version the server reads)."""
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="a", label="alpha", ext_version="0.1.0")
+    ext.start()
+    try:
+        body = _wait_instances(srv, 1)
+        assert body is not None
+        # /health surfaces exactly what the server reads from the repo manifest.
+        assert body["extension_version_current"] == S.manifest_version()
+        inst = body["instances"][0]
+        assert inst["extension_version"] == "0.1.0"   # what THIS instance reported
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_health_extension_version_null_when_unreported():
+    """An instance whose extension predates version reporting → null (no crash)."""
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="b", label="beta")  # no ext_version
+    ext.start()
+    try:
+        body = _wait_instances(srv, 1)
+        assert body is not None
+        assert body["instances"][0]["extension_version"] is None
+        assert "extension_version_current" in body
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_health_no_extension_still_reports_current_version():
+    srv, _ = _serve()
+    try:
+        st, body = _req(srv, "GET", "/health")
+        assert st == 200
+        assert "extension_version_current" in body
+        assert body["instances"] == []
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+@pytest.mark.skipif(shutil.which("curl") is None, reason="curl not on PATH")
+def test_browser_cli_unknown_op_maps_to_stale_extension_message(tmp_path):
+    """A server-side op-level `unknown_op` for a DISPATCHED op (the extension is
+    older than this CLI) maps to a clear reload/restart-Brave message + non-zero
+    exit (the ↻-is-unreliable insight: the long-poll keeps the old SW alive)."""
+    data_env = {"ok": False, "error": "unknown_op"}   # extension returned unknown_op
+
+    class _H(S.BaseHTTPRequestHandler):
+        def log_message(self, *a):  # noqa: A003
+            pass
+
+        def do_POST(self):
+            ln = int(self.headers.get("Content-Length") or 0)
+            if ln:
+                self.rfile.read(ln)
+            payload = json.dumps({"ok": True, "result": {
+                "id": "x", **data_env}}).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+    srv = S.ThreadingHTTPServer(("127.0.0.1", 0), _H)
+    srv.daemon_threads = True
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    tokf = tmp_path / "token"; tokf.write_text("smoke-token\n")
+    env = dict(os.environ)
+    env.update(BROWSER_BRIDGE_HOST="127.0.0.1", BROWSER_BRIDGE_PORT=str(port),
+               BROWSER_BRIDGE_TOKEN_FILE=str(tokf))
+    try:
+        r = subprocess.run([str(BROWSER_BIN), "upload", "#f", str(tokf)],
+                           env=env, capture_output=True, text=True, timeout=30)
+        assert r.returncode != 0, "a stale-extension unknown_op must exit non-zero"
+        low = r.stderr.lower()
+        assert "unknown_op" in low
+        assert "older than this cli" in low
+        assert "restart brave" in low, f"expected restart-Brave guidance, got: {r.stderr!r}"
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+@pytest.mark.skipif(shutil.which("curl") is None, reason="curl not on PATH")
+def test_browser_cli_normal_op_result_unaffected_by_unknown_op_mapping(tmp_path):
+    """A NORMAL successful op result is unaffected by the unknown_op mapping."""
+    data = {"url": "https://x.test", "title": "X", "html": "<html>ok</html>"}
+    r = _run_browser_against(data, ["html"], tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "older than this cli" not in r.stderr.lower()
+    out = json.loads(r.stdout)
+    assert out["result"]["data"]["html"] == "<html>ok</html>"

--- a/scripts/browser-bridge/tests/upload.test.mjs
+++ b/scripts/browser-bridge/tests/upload.test.mjs
@@ -1,0 +1,212 @@
+// Glue tests for the `upload` op (Gap 1) against a MOCKED chrome.debugger — proving
+// the typed CDP file-upload is wired correctly WITHOUT a real Brave. `upload`
+// resolves the file input to a CDP RemoteObject, VERIFIES it is a real
+// <input type=file>, then hands the ABSOLUTE path to DOM.setFileInputFiles (Chrome
+// reads the file itself — no bytes cross the bridge).
+//
+// These assert, against a mock chrome.debugger/webNavigation:
+//   * TOP frame: Runtime.evaluate(querySelector) → objectId → Runtime.callFunctionOn
+//     (is-file-input) → DOM.setFileInputFiles({objectId, files:[absPath]}) in the
+//     tab's top session;
+//   * cross-origin OOPIF (--frame): the SAME setAutoAttach flat-session path
+//     `eval --frame` uses → setFileInputFiles issued in the matched SESSION;
+//   * not_a_file_input / element_not_found error paths (nothing is set);
+//   * SECURITY: own-tab-only attach (#187), a FIXED typed CDP method set (no raw
+//     passthrough), and the full path never leaks into the result (basename only);
+//   * #189: a hung Runtime.evaluate settles with cdp_timeout and STILL detaches.
+//
+// SW auto-start is suppressed (BROWSER_BRIDGE_NO_AUTOSTART) so importing does no I/O.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const TAB_ID = 5;
+const TOP_URL = "https://civitai.com/apps/run/model-benchmarking";
+const OOPIF_URL = "https://model-benchmarking.civit.ai/";
+const ABS_PATH = "/home/zach/pics/render.png";
+
+const FRAME_TREE = {
+  frame: { id: "CDP_MAIN", url: TOP_URL, name: "" },
+  childFrames: [{ frame: { id: "CDP_SAME", url: "https://civitai.com/embed/w", name: "w" } }],
+};
+
+const state = {
+  frames: [
+    { frameId: 0, parentFrameId: -1, url: TOP_URL },
+    { frameId: 3, parentFrameId: 0, url: "https://civitai.com/embed/w" }, // same-process child
+    { frameId: 7, parentFrameId: 0, url: OOPIF_URL },
+  ],
+  tab: { id: TAB_ID, url: TOP_URL, title: "Bench", active: false, status: "complete", windowId: 1 },
+  // Runtime.evaluate reply for the querySelector → RemoteObject: an objectId means
+  // "found"; no objectId (subtype null) means element_not_found.
+  evalResult: { result: { type: "object", subtype: "node", objectId: "OBJ_FILE" } },
+  isFileInput: true,          // Runtime.callFunctionOn(is-file-input) → this value
+  autoAttachTargets: [{ sessionId: "SID_OOPIF", url: OOPIF_URL }],
+  hangEvaluate: false,
+  calls: { cdp: [], attach: [], detach: [], getAllFrames: [], setFile: [] },
+};
+function reset() {
+  state.calls = { cdp: [], attach: [], detach: [], getAllFrames: [], setFile: [] };
+  state.evalResult = { result: { type: "object", subtype: "node", objectId: "OBJ_FILE" } };
+  state.isFileInput = true;
+  state.autoAttachTargets = [{ sessionId: "SID_OOPIF", url: OOPIF_URL }];
+  state.hangEvaluate = false;
+  delete globalThis.BROWSER_BRIDGE_CDP_TIMEOUTS;
+}
+
+const evtListeners = new Set();
+
+globalThis.BROWSER_BRIDGE_NO_AUTOSTART = true;
+globalThis.chrome = {
+  webNavigation: {
+    async getAllFrames({ tabId }) { state.calls.getAllFrames.push(tabId); return state.frames; },
+  },
+  scripting: {
+    async executeScript() { throw new Error("upload must NOT use chrome.scripting"); },
+  },
+  tabs: {
+    async get(id) { return { ...state.tab, id }; },
+    async query() { return [state.tab]; },
+    async update() {},
+  },
+  debugger: {
+    async attach(target) { state.calls.attach.push(target); },
+    async detach(target) { state.calls.detach.push(target); },
+    async sendCommand(target, method, params) {
+      state.calls.cdp.push({ method, sessionId: target.sessionId, params });
+      if (method === "Page.getFrameTree") return { frameTree: FRAME_TREE };
+      if (method === "Page.createIsolatedWorld") return { executionContextId: 99 };
+      if (method === "Target.setAutoAttach") {
+        for (const t of state.autoAttachTargets) {
+          for (const fn of evtListeners) {
+            fn(target, "Target.attachedToTarget",
+              { sessionId: t.sessionId, targetInfo: { url: t.url, type: "iframe", targetId: "T_" + t.sessionId } });
+          }
+        }
+        return {};
+      }
+      if (method === "Runtime.evaluate") {
+        if (state.hangEvaluate) return new Promise(() => {});   // never settles → timeout
+        return state.evalResult;
+      }
+      if (method === "Runtime.callFunctionOn") return { result: { value: state.isFileInput } };
+      if (method === "DOM.setFileInputFiles") {
+        state.calls.setFile.push({ sessionId: target.sessionId, params });
+        return {};
+      }
+      return {};
+    },
+    onDetach: { addListener() {} },
+    onEvent: {
+      addListener(fn) { evtListeners.add(fn); },
+      removeListener(fn) { evtListeners.delete(fn); },
+    },
+  },
+  storage: { local: { async get() { return {}; }, async set() {} } },
+  runtime: { onInstalled: { addListener() {} }, onStartup: { addListener() {} } },
+  alarms: { create() {}, onAlarm: { addListener() {} } },
+};
+
+const { OPS } = await import("../extension/service_worker.js");
+
+const cdpMethods = () => state.calls.cdp.map((c) => c.method);
+
+// --------------------------------------------------------------------------- //
+test("upload TOP frame: DOM.setFileInputFiles with the ABS path on the resolved objectId", async () => {
+  reset();
+  const out = await OPS.upload({ tabId: TAB_ID, selector: "#file", path: ABS_PATH });
+  assert.equal(state.calls.setFile.length, 1, "exactly one setFileInputFiles");
+  const call = state.calls.setFile[0];
+  assert.equal(call.sessionId, undefined, "top-frame upload uses the tab's top session");
+  assert.deepEqual(call.params, { objectId: "OBJ_FILE", files: [ABS_PATH] },
+    "the ABSOLUTE path is handed to Chrome on the resolved element objectId");
+  // The RESULT carries the BASENAME only — never the full path.
+  assert.deepEqual(out, { ok: true, selector: "#file", frame: null, url: TOP_URL,
+    files: ["render.png"] });
+  assert.ok(!JSON.stringify(out).includes("/home/zach"), "the full path must NOT be in the result");
+  assert.equal(state.calls.attach.length, 1, "attaches once");
+  assert.equal(state.calls.detach.length, 1, "always detaches");
+});
+
+test("upload --frame OOPIF: setFileInputFiles is issued in the auto-attached OOPIF session", async () => {
+  reset();
+  const out = await OPS.upload({ tabId: TAB_ID, frame: "model-benchmarking.civit.ai",
+    selector: "#drop input[type=file]", path: ABS_PATH });
+  assert.ok(cdpMethods().includes("Target.setAutoAttach"), "reaches the OOPIF via auto-attach");
+  assert.equal(state.calls.setFile.length, 1);
+  assert.equal(state.calls.setFile[0].sessionId, "SID_OOPIF",
+    "the file is set INSIDE the cross-origin OOPIF's flat session");
+  assert.deepEqual(state.calls.setFile[0].params.files, [ABS_PATH]);
+  assert.equal(out.frame, "model-benchmarking.civit.ai");
+  assert.equal(out.url, OOPIF_URL, "reports the FRAME's own url (proves it targeted the OOPIF)");
+  assert.deepEqual(out.files, ["render.png"]);
+  assert.equal(state.calls.detach.length, 1);
+});
+
+test("upload --frame SAME-PROCESS: resolves via Page.createIsolatedWorld (contextId)", async () => {
+  reset();
+  // A same-process frame (in the top session's frame tree) → isolated-world context.
+  const out = await OPS.upload({ tabId: TAB_ID, frame: "civitai.com/embed/w",
+    selector: "#f", path: ABS_PATH });
+  assert.ok(cdpMethods().includes("Page.createIsolatedWorld"), "same-process frame uses an isolated world");
+  assert.ok(!cdpMethods().includes("Target.setAutoAttach"), "no OOPIF auto-attach for a same-process frame");
+  // The querySelector eval ran in the isolated-world contextId (99).
+  const ev = state.calls.cdp.find((c) => c.method === "Runtime.evaluate");
+  assert.equal(ev.params.contextId, 99);
+  assert.equal(state.calls.setFile.length, 1);
+  assert.equal(out.url, "https://civitai.com/embed/w");
+});
+
+test("upload not_a_file_input: a non-file element is refused; NOTHING is set", async () => {
+  reset();
+  state.isFileInput = false;   // the resolved element is not an <input type=file>
+  await assert.rejects(() => OPS.upload({ tabId: TAB_ID, selector: "#notfile", path: ABS_PATH }),
+    /not_a_file_input:#notfile/);
+  assert.equal(state.calls.setFile.length, 0, "no file is set for a non-file input");
+  assert.equal(state.calls.detach.length, 1, "still detaches");
+});
+
+test("upload element_not_found: a selector matching nothing is a clear error; NOTHING is set", async () => {
+  reset();
+  state.evalResult = { result: { type: "object", subtype: "null", value: null } };  // no objectId
+  await assert.rejects(() => OPS.upload({ tabId: TAB_ID, selector: "#missing", path: ABS_PATH }),
+    /element_not_found:#missing/);
+  assert.equal(state.calls.setFile.length, 0);
+  assert.equal(state.calls.detach.length, 1);
+});
+
+test("upload --frame unresolvable OOPIF: frame_not_found, NOTHING set (never a silent success)", async () => {
+  reset();
+  // getAllFrames still has frame 7 (resolveFrame ok) but auto-attach announces a
+  // DIFFERENT target → no session matches → frame_not_found before any setFile.
+  state.autoAttachTargets = [{ sessionId: "SID_OTHER", url: "https://unrelated.example/" }];
+  await assert.rejects(() => OPS.upload({ tabId: TAB_ID, frame: "7", selector: "#f", path: ABS_PATH }),
+    /frame_not_found/);
+  assert.equal(state.calls.setFile.length, 0);
+  assert.equal(state.calls.detach.length, 1);
+});
+
+test("SECURITY: upload attaches ONLY to the op's own tab; a FIXED typed CDP method set", async () => {
+  reset();
+  await OPS.upload({ tabId: TAB_ID, frame: "model-benchmarking.civit.ai", selector: "#f", path: ABS_PATH });
+  assert.ok(state.calls.attach.every((t) => t.tabId === TAB_ID), "own-tab-only attach (#187)");
+  assert.ok(state.calls.detach.every((t) => t.tabId === TAB_ID || t.tabId === undefined));
+  assert.ok(state.calls.getAllFrames.every((t) => t === TAB_ID), "frame enum scoped to the op's tab");
+  // Only the fixed typed CDP methods — no arbitrary raw-CDP passthrough surface.
+  const allowed = new Set(["Page.getFrameTree", "Page.createIsolatedWorld",
+    "Target.setAutoAttach", "Runtime.evaluate", "Runtime.callFunctionOn",
+    "DOM.setFileInputFiles"]);
+  for (const m of cdpMethods()) assert.ok(allowed.has(m), `unexpected CDP method: ${m}`);
+});
+
+test("#189: a HUNG Runtime.evaluate settles with cdp_timeout and STILL detaches — no SW wedge", async () => {
+  reset();
+  globalThis.BROWSER_BRIDGE_CDP_TIMEOUTS = { attachMs: 60, commandMs: 20, budgetMs: 200 };
+  state.hangEvaluate = true;
+  const started = Date.now();
+  await assert.rejects(() => OPS.upload({ tabId: TAB_ID, selector: "#f", path: ABS_PATH }),
+    /cdp_timeout/);
+  assert.ok(Date.now() - started < 4000, "settles by the tiny budget, not the 20s server timeout");
+  assert.equal(state.calls.setFile.length, 0);
+  assert.equal(state.calls.detach.length, 1, "a hung upload still best-effort detaches");
+});


### PR DESCRIPTION
Three browser-bridge gaps surfaced by a Civitai App-Store operator session (clawgate task **#92**). All reuse the existing CDP patterns (`withCdpSession`/`withCdp`, own-tab-only attach, #189 bounded timeouts, the `eval --frame` OOPIF `setAutoAttach` path) and preserve every invariant (#168 loopback/bearer/Host/constant-time, #175 own-tab isolation, #178 rate-limit, #180 no-raw-CDP + fail-closed tool-set gate, #187 own-tab-only attach, #189 no-wedge, #190/#192 OOPIF, #200 whoami).

## Gap 1 — `browser upload <selector> <path>`
A bounded **TYPED** CDP op (`DOM.setFileInputFiles`) to populate an `<input type=file>`. Chrome reads the file **by path itself** (same host) — so **no file bytes cross the bridge**. The extension resolves the element to a CDP RemoteObject, **verifies it is a real file input** (`not_a_file_input` / `element_not_found` otherwise), then hands Chrome the ABSOLUTE path — **top frame AND cross-origin OOPIF** (via the same `Target.setAutoAttach` flat-session path `eval --frame` uses; same-process iframes via `Page.createIsolatedWorld`).

**Security model:** typed op only (selector/path/frame) — `buildRequest` whitelists the wire body, so a smuggled `cdp`/`method`/`params`/`objectId`/`files` is dropped; own-tab-scoped (#187); #189-bounded (a hung attach/evaluate → `cdp_timeout`, always detaches); scheme-checked. It **is data-exfil-capable** — an **EXPLICIT operator decision** to let the autonomous agent read **ANY path** (any readable file's contents could be posted to the site). That tradeoff is made **safe-to-audit rather than blocked**: the server **AUDIT-LOGS every upload** — `log("upload", …)` + a telemetry event carrying **op + target domain + the file path** (local metadata, never file content). The result returns the **basename only** (the full path stays server/CLI-side + in the audit log). The CLI validates the path is a readable regular file and resolves it to absolute **before** any dispatch.

## Gap 2 — hidden-tab self-announcing reads (prevent the "false outage")
An `open`ed tab is background → `document.visibilityState==='hidden'` → Chromium throttles it → a heavy SPA never renders → `text`/`html`/`eval`/`frames` return an empty shell indistinguishable from a broken site. Reads now include the tab's **`visibilityState`**, and when hidden add **`data.hidden=true` + a note** pointing at `browser activate`. The CLI prints that note to **STDERR** (exit 0 — a warning, JSON on stdout unbroken). A `--frame` read reports it the same way (an OOPIF's document follows the tab; read from the top frame). The `eval` mechanism is unchanged (still CDP — the only added `chrome.scripting` call is the top-frame visibility probe).

## Gap 3 — stale-extension detection + the ↻-unreliable insight
A stale MV3 service worker answers a NEW op with `unknown_op`, indistinguishable from "op doesn't exist". Now:
- **`/health`** surfaces each instance's loaded **`extension_version`** + the bridge's **`extension_version_current`** (repo manifest) — eyeball loaded-vs-current.
- The **CLI maps** a server-side op-level `unknown_op` for a **dispatched** op (a user typo is caught by the subcommand dispatch first; the server 400s an op it doesn't know) to a clear message + non-zero exit: *"your loaded extension is OLDER than this CLI. Reload it in brave://extensions. If the reload doesn't take, FULLY RESTART Brave — the extension's long-poll keeps the old service worker alive, so ↻ is unreliable."*
- Manifest bumped **0.1.0 → 0.2.0** so the comparison is meaningful.

## Tests
Fully headless (mock `chrome.debugger`/`scripting`/`webNavigation`/`DOM`; no real Brave/network). **186 node + 208 python, all green.**
- **+21 node:** `upload.test.mjs` (setFileInputFiles with abs path on the resolved objectId — top frame + OOPIF + same-process; `not_a_file_input`/`element_not_found`/`frame_not_found`; own-tab-only + fixed CDP method set; #189 hung-eval → `cdp_timeout` + detach; basename-only result), `hidden_tab.test.mjs` (visible → no flag; hidden → `hidden:true`+note across text/html/eval/frames + a `--frame` read; null probe swallowed), and opencode typed-tool upload tests (forced tab, required fields, ANY-path allowed, **no-raw-CDP passthrough**, dry-run intercept, allowlist gate, basename-only summary).
- **+10 python:** upload audit event carries **op+domain+path**; CLI path-validation-before-dispatch (nonexistent/non-file refused, real file → absolute path on the wire); hidden-tab note → stderr (exit 0) + visible → none; `/health` includes `extension_version` (+ current); `unknown_op` → stale-extension message + non-zero exit; a normal op result unaffected.
- Two `frame_eval_cdp` assertions refined (the eval still uses CDP — the only `executeScript` is the top-frame visibility probe) and the op-set / manifest-version contract pins updated for the new op + version. `node --check`, `bash -n browser`, `jq` manifest all pass.

## Manual live checks (NOT yet run — needs an extension reload)
Deterministically unit-tested the wiring/security; the following need a real Brave with the reloaded extension:
1. `open` a page with a file input → `browser upload '<sel>' /path` populates it (top-frame AND inside a cross-origin OOPIF via `--frame`).
2. `text` on a freshly-`open`ed background tab prints the `hidden` warning to stderr; after `activate` it doesn't.
3. With a deliberately-stale extension, a known op prints the reload/restart-Brave guidance; `health` shows `extension_version`.

⚠ **Requires an extension reload — a full Brave restart** — to pick up the new executors (the long-poll keeps the old SW alive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)