### PR TITLE
fix(repo-cos): close 4 audit findings on the initiative-tag join guard

### DIFF
--- a/scripts/repo-cos/README.md
+++ b/scripts/repo-cos/README.md
@@ -169,20 +169,36 @@ it only collects the full proposal; the **only new network** is the clawgate POS
   logged with its rule) and `clawgate.normalize_tags` (clawgate's grammar: lowercase,
   `[a-z0-9._/-]`, ≤1 `:`, ≤64 runes, ≤20 tags; anything invalid is **dropped, not mangled**).
   Measured over `tests/fixtures/initiatives_current_slugs.txt` — a **hand-refreshed snapshot**
-  of `initiatives.current`, last taken 2026-07-30 at **140 slugs**: 10 denylist drops + 3 lost
-  to the 64-rune cap → **127 taggable**. Those numbers are pinned by `test_routing.py`, but
-  **against the snapshot, not the live store**: the suite is deliberately hermetic (see
-  `tests/conftest.py`), so no test can tell you the fixture has gone stale — it already drifted
-  once (139 → 140) with everything green. Re-run the command in the fixture header to refresh
-  it, then re-state these counts.
-- **🔴 An emitted tag always equals its ledger slug, byte-for-byte.** This is enforced
-  **structurally** in `clawgate.build_tags`: the normalized tag is compared against the exact
-  `initiative:<slug>` we asked for and **dropped on any difference**. The denylist alone is not
-  sufficient — it polices only `normalize_tag`'s lowercasing (`not-lowercase`), while the same
-  function also collapses whitespace to `-` and strips leading/trailing `-`, so a slug like
-  `foo bar` or `trailing-dash-` would clear the denylist and be emitted **rewritten**, joining
-  to nothing. No live slug has that shape today, which is precisely why the guarantee must not
-  rest on a snapshot of the store. A missing tag is cheap; a tag that joins to nothing is a lie.
+  of `initiatives.current`, last taken 2026-07-30 at **142 slugs**: 10 denylist drops → 132 pass
+  the denylist → 3 more lost to the 64-rune cap → **129 taggable** (and 129 actually emitted by
+  `build_tags`, pinned on the positive side too). Those numbers are pinned by `test_routing.py`
+  **against the snapshot, not the live store**: the default suite is deliberately hermetic (see
+  `tests/conftest.py`), so no ordinary test can tell you the fixture has gone stale — it drifted
+  twice within two days of a refresh (139 → 140 → 142), green each time. So there is now an
+  **opt-in live drift check**, skipped by default:
+
+  ```sh
+  # reads initiatives.current and diffs it against the fixture, naming the slugs that moved
+  REPO_COS_LIVE_DRIFT_CHECK=1 python -m pytest scripts/repo-cos/tests/test_routing.py -q
+  # kubeconfig defaults to ~/workspace/homelab-talos/homelab-kubeconfig; override:
+  REPO_COS_LIVE_DRIFT_CHECK=1 REPO_COS_KUBECONFIG=/path/to/kubeconfig python -m pytest ...
+  ```
+
+  When it fails, refresh with the command in the fixture header, then re-state these counts.
+- **🔴 An emitted tag always equals its ledger slug, byte-for-byte** (byte-equal to the
+  **stripped** slug — `routing.taggable_slug` and `build_tags` both `.strip()`, so a stored
+  slug with surrounding whitespace emits `initiative:<stripped>`; nothing else may alter it).
+  This is enforced **structurally** by `clawgate.guard_tags`: each normalized tag is compared
+  against the exact tag we asked for and **dropped on any difference**. The denylist alone is
+  not sufficient — it polices only `normalize_tag`'s lowercasing (`not-lowercase`), while the
+  same function also collapses whitespace to `-` and strips leading/trailing `-`, so a slug
+  like `foo bar` or `trailing-dash-` would clear the denylist and be emitted **rewritten**,
+  joining to nothing. No live slug has that shape today, which is precisely why the guarantee
+  must not rest on a snapshot of the store. A missing tag is cheap; a tag that joins to nothing
+  is a lie. The guard is **per tag**: one bad tag costs only itself, so a second namespace
+  (see the `runbook:` seam) can be added without silently deleting the `initiative:` tag on
+  every Task. Each drop logs **exactly one** accurate reason (the grammar's, or the join
+  violation's — never both).
 - **🔴 Tagging must never cost an approval.** Because suppression is POST-success-gated, a
   tag-induced `400` would silently lose the approval for a week. Backstop: **HTTP `400` on a
   tagged POST retries EXACTLY ONCE with the `tags` key removed** (both the failure and the
@@ -193,7 +209,9 @@ it only collects the full proposal; the **only new network** is the clawgate POS
   call with no tags sends the byte-identical pre-tags payload.
 - **No `runbook:` tags.** `runbook:` is hard-validated by clawgate (unknown name → `400`),
   there is no machine endpoint to list valid names, and exactly one runbook exists. A marked
-  seam in `clawgate.build_tags` documents where one would slot in.
+  seam in `clawgate.build_tags` documents where one would slot in — and since the join guard
+  is per-tag, following it literally now emits both tags instead of dropping both
+  (`test_guard_tags_keeps_a_second_namespace_and_drops_only_the_offender`).
 
 ## Usage
 
@@ -281,5 +299,7 @@ suites drive the real `cmd_scan`, so `tests/conftest.py` carries an **autouse fi
 stubs `load_current` to an empty store** for every test; `test_routing.py` re-patches it
 in-test where it wants a fixture store. Measured: 11 real store-read attempts without the
 fixture, 0 with it. `tests/fixtures/initiatives_current_slugs.txt` is a checked-in
-**snapshot** of the real slug vocabulary (never a live read) used to pin the denylist's
-corpus-wide properties; refresh it with the psql command in its header.
+**snapshot** of the real slug vocabulary (never a live read in a default run) used to pin the
+denylist's corpus-wide properties; refresh it with the psql command in its header. The ONE test
+that reads the live store — `test_fixture_matches_the_live_initiatives_store`, the drift check —
+is **skipped unless `REPO_COS_LIVE_DRIFT_CHECK=1`** is set, so the default run stays network-free.

--- a/scripts/repo-cos/clawgate.py
+++ b/scripts/repo-cos/clawgate.py
@@ -204,6 +204,30 @@ def build_task_body(proposal: dict) -> str:
 
 # ---- task tags -----------------------------------------------------------------------
 
+def _normalize_tag(tag) -> tuple[str | None, str | None]:
+    """PURE core of `normalize_tag`: `(normalized_tag, drop_reason)`. Does NOT log.
+
+    Split out so a caller can decide WHICH reason to report. The join guard below needs
+    that: a tag can fail for a grammar reason (too long, bad charset) OR merely be
+    rewritten, and logging both — as the previous shape did for every >64-rune slug —
+    mis-attributes the drop. Exactly one of the two elements is ever non-None."""
+    try:
+        t = _WS_RE.sub("-", str(tag or "").strip().lower()).strip("-")
+    except Exception:  # noqa: BLE001
+        return None, "unstringifiable"
+    if not t:
+        return None, "empty"
+    if len(t) > TAG_MAX_LEN:
+        return None, f"{len(t)} runes exceeds the {TAG_MAX_LEN}-rune cap"
+    parts = t.split(":")
+    if len(parts) > 2:
+        return None, "more than one ':' (namespace:value only)"
+    for part in parts:
+        if not part or not _TAG_BODY_RE.match(part):
+            return None, "not [a-z0-9._/-]"
+    return t, None
+
+
 def normalize_tag(tag) -> str | None:
     """Normalize ONE tag to clawgate's grammar, or None if it can't be made valid.
 
@@ -212,23 +236,12 @@ def normalize_tag(tag) -> str | None:
     tag <=64 runes. Anything else is DROPPED, never mangled: silently rewriting
     `remix:clip_editor` into some other tag would produce a routing key that points at
     the wrong thing, which is exactly the failure a tag is supposed to prevent."""
-    try:
-        t = _WS_RE.sub("-", str(tag or "").strip().lower()).strip("-")
-    except Exception:  # noqa: BLE001
-        return None
-    if not t:
-        return None
-    if len(t) > TAG_MAX_LEN:
-        _log(f"dropping tag {t!r} — {len(t)} runes exceeds the {TAG_MAX_LEN}-rune cap")
-        return None
-    parts = t.split(":")
-    if len(parts) > 2:
-        _log(f"dropping tag {t!r} — more than one ':' (namespace:value only)")
-        return None
-    for part in parts:
-        if not part or not _TAG_BODY_RE.match(part):
-            _log(f"dropping tag {t!r} — not [a-z0-9._/-]")
-            return None
+    t, reason = _normalize_tag(tag)
+    if t is None and reason not in (None, "empty", "unstringifiable"):
+        # log the NORMALIZED form when we have one (matches the pre-split behaviour);
+        # a normalization that itself blew up has nothing meaningful to show.
+        shown = _WS_RE.sub("-", str(tag or "").strip().lower()).strip("-")
+        _log(f"dropping tag {shown!r} — {reason}")
     return t
 
 
@@ -248,6 +261,50 @@ def normalize_tags(tags) -> list[str]:
     return clean
 
 
+def guard_tags(raw) -> list[str]:
+    """🔴 THE STRUCTURAL JOIN GUARD, applied PER TAG.
+
+    A consumer of an `initiative:` tag joins on `tag == "initiative:" + slug` byte-for-byte
+    (see `scripts/initiatives/tasks.py` — it does no case-folding and no normalization), so
+    the ONLY acceptable outcome for a tag is the exact string we asked for. `normalize_tag`
+    performs THREE mutations — lowercase, whitespace→`-`, and a `-` strip — and the `routing`
+    denylist only polices the first (`not-lowercase`). A slug like `foo bar`, `x  y` or
+    `trailing-dash-` would therefore survive the denylist and be emitted REWRITTEN
+    (`initiative:foo-bar`), joining to nothing while looking perfectly healthy. No live slug
+    has that shape today, so pinning it with another denylist rule would only re-encode a
+    SNAPSHOT of the store. Comparing the normalizer's OUTPUT to its INPUT instead makes the
+    invariant hold structurally: any future slug, and any fourth mutation added to
+    `normalize_tag`, is caught here.
+
+    Each tag is judged INDEPENDENTLY and only the offender is dropped. That is deliberate:
+    an all-or-nothing guard (compare the whole normalized LIST to the whole wanted list)
+    would make one bad tag silently delete every OTHER namespace's tag on the same Task —
+    which turned the `runbook:` seam below into a trap (`raw = [initiative, runbook]` would
+    have dropped BOTH tags on every Task). Per-tag, adding a second namespace is safe.
+
+    A drop is the correct degradation — a missing tag is cheap, a tag that joins to nothing
+    is a lie (and the untagged Task is still posted either way). Every drop logs exactly ONE
+    accurate reason: the grammar's, when the grammar rejected it outright; the join
+    violation's, when the grammar would have silently rewritten it."""
+    kept: list[str] = []
+    for item in raw or []:
+        try:
+            tag = str(item)
+        except Exception as exc:  # noqa: BLE001 - a tag must NEVER cost an approval
+            _log(f"dropping an unstringifiable tag: {exc}")
+            continue
+        norm, reason = _normalize_tag(tag)
+        if norm is not None and norm == tag:
+            kept.append(tag)
+        elif reason is not None:
+            _log(f"dropping tag {tag!r} — {reason}")
+        else:
+            _log(f"dropping tag {tag!r} — the tag grammar would emit {norm!r}, not "
+                 f"{tag!r}; an emitted tag must equal its (stripped) ledger slug "
+                 f"byte-for-byte or the consuming join misses")
+    return normalize_tags(kept)
+
+
 def build_tags(proposal) -> list[str]:
     """The clawgate task tags for an APPROVED proposal. Never raises; [] on any doubt.
 
@@ -260,9 +317,17 @@ def build_tags(proposal) -> list[str]:
     document/date/id/filler slugs) and normalized to the tag grammar.
 
     🔴 The emitted tag ALWAYS equals `initiative:<ledger-slug>` byte-for-byte, enforced
-    STRUCTURALLY: the normalized result is compared to the exact tag we asked for and
-    dropped on ANY difference (see the guard below). The denylist alone is not enough —
-    it polices only one of `normalize_tag`'s mutations.
+    STRUCTURALLY by `guard_tags`: each normalized tag is compared to the exact tag we
+    asked for and dropped on ANY difference. The denylist alone is not enough — it
+    polices only one of `normalize_tag`'s mutations.
+
+    ⚠ ONE DELIBERATE NORMALIZATION, stated precisely: the slug is `.strip()`ped before
+    the tag is built (here, and again in `routing.taggable_slug`), so a stored slug with
+    surrounding whitespace — `"  padded-slug  "` — emits `initiative:padded-slug`, which
+    is byte-equal to the STRIPPED slug, not to the raw stored bytes. Everything the
+    guard promises is relative to that stripped form. In practice the store has no such
+    slug (a leading/trailing space would be a scan bug), and a consumer joining on a slug
+    it read from the same store would have to preserve that whitespace to miss.
 
     ── SEAM: a future `runbook:<name>` tag ────────────────────────────────────────────
     Deliberately NOT emitted today. `runbook:` is HARD-validated by clawgate
@@ -271,8 +336,12 @@ def build_tags(proposal) -> list[str]:
     non-converging) with no machine endpoint to list/validate names against. When
     clawgate grows a `GET /api/runbooks` (or the runbook set becomes worth routing to),
     slot it in HERE: resolve the name, verify it against that endpoint, and append
-    `f"runbook:{name}"` to `raw` below. Do NOT emit an unverified runbook name — the
-    fail-open retry in post_task would silently strip the whole tag list.
+    `f"runbook:{name}"` to `raw` below. That is SAFE as written — `guard_tags` judges
+    each tag independently, so a bad `runbook:` name costs only its own tag and the
+    `initiative:` tag still ships (it was NOT safe before the guard was made per-tag: an
+    all-or-nothing comparison dropped BOTH tags on every Task). Do NOT emit an unverified
+    runbook name — the fail-open retry in post_task would still strip the whole tag list
+    if clawgate 400s the request.
     ───────────────────────────────────────────────────────────────────────────────────
     """
     try:
@@ -285,27 +354,10 @@ def build_tags(proposal) -> list[str]:
         keep = routing.taggable_slug(slug)
         if not keep:
             return []
+        # ONE tag today; `guard_tags` enforces `emitted == asked-for` per tag, so a
+        # second namespace can be appended here without endangering this one (see SEAM).
         raw = [f"initiative:{keep}"]
-        tags = normalize_tags(raw)
-        # 🔴 STRUCTURAL JOIN GUARD. The initiatives-side join matches on `tag == slug`
-        # byte-for-byte, so the ONLY acceptable outcome is the exact tag we asked for.
-        # `normalize_tag` performs THREE mutations — lowercase, whitespace→`-`, and a
-        # `-` strip — and the `routing` denylist only polices the first (`not-lowercase`).
-        # A slug like `foo bar`, `x  y` or `trailing-dash-` would therefore survive the
-        # denylist and be emitted REWRITTEN (`initiative:foo-bar`), joining to nothing.
-        # No live slug has that shape today, so pinning it with another denylist rule
-        # would only re-encode a SNAPSHOT of the store. Comparing the normalizer's
-        # OUTPUT to its input instead makes the invariant hold structurally: any future
-        # slug, and any fourth mutation added to `normalize_tag`, is caught here. A drop
-        # is the correct degradation — a missing tag is cheap, a tag that joins to
-        # nothing is a lie (and the untagged Task is still posted either way).
-        want = [f"initiative:{keep}"]
-        if tags != want:
-            _log(f"dropping initiative tag for slug {keep!r} — the tag grammar would "
-                 f"emit {tags!r}, not {want!r}; an emitted tag must equal its ledger "
-                 f"slug byte-for-byte or the initiatives-side join misses")
-            return []
-        return tags
+        return guard_tags(raw)
     except Exception as exc:  # noqa: BLE001 - a tag must NEVER cost an approval
         _log(f"build_tags failed (posting untagged): {exc}")
         return []

--- a/scripts/repo-cos/routing.py
+++ b/scripts/repo-cos/routing.py
@@ -162,6 +162,11 @@ def related_for(proposals) -> list:
 # of `initiative:<slug>`. `clawgate.normalize_tag` lowercases, so anything not already
 # all-lowercase is dropped (`not-lowercase`) rather than mangled — that keeps the emitted
 # tag byte-equal to the ledger slug, which is what the initiatives-side join relies on.
+# ONE deliberate exception, stated precisely: `taggable_slug` `.strip()`s, so a stored slug
+# with surrounding whitespace is emitted as its STRIPPED form. "Byte-equal" everywhere in
+# this module and in clawgate.build_tags means byte-equal to the STRIPPED ledger slug.
+# (`clawgate.guard_tags` then enforces that nothing else — case, inner whitespace, a `-`
+# strip — rewrites the tag; a rewritten tag is dropped, never emitted.)
 
 # A ClickUp/opaque task id: starts with a digit, >=8 alphanumerics, no separators.
 # Matches 868j34n9y / 868kf6w7r / 868f9pd14; does NOT match 0313, 504, or v0.1.73.

--- a/scripts/repo-cos/tests/fixtures/initiatives_current_slugs.txt
+++ b/scripts/repo-cos/tests/fixtures/initiatives_current_slugs.txt
@@ -1,29 +1,28 @@
 # SNAPSHOT of `select slug from initiatives.current order by 1;` — the REAL, MINED
 # initiative vocabulary the `initiative:<slug>` tag is drawn from.
 #
-# Taken 2026-07-30 (140 slugs). Regenerate with:
+# Taken 2026-07-30 (142 slugs). Regenerate with:
 #   kubectl --kubeconfig ~/workspace/homelab-talos/homelab-kubeconfig -n mailbox \
 #     exec mailbox-postgres-0 -- sh -c 'psql -U ${POSTGRES_USER:-mail} \
 #     -d ${POSTGRES_DB:-mail} -tAc "select slug from initiatives.current order by 1;"'
 #
-# ⚠ This is a SNAPSHOT, refreshed BY HAND. Nothing in the suite reads the live store
-# (see tests/conftest.py — the whole run is deliberately hermetic), so no test can tell
-# you this file has gone stale; only re-running the command above can. Expect drift: the
-# store is mined continuously and grew by one slug between the feature landing and its
-# first follow-up. When you refresh it, re-state the counts in test_routing.py's corpus
-# tests and in README.md rather than letting them silently disagree with reality.
+# ⚠ This is a SNAPSHOT, refreshed BY HAND — and it has now gone stale TWICE within two
+# days of being refreshed (139 → 140 → 142), each time with the whole suite green. The
+# default run is hermetic (see tests/conftest.py) so no ordinary test can tell you this
+# file is behind. What CAN: the OPT-IN drift check
+#
+#   REPO_COS_LIVE_DRIFT_CHECK=1 python -m pytest scripts/repo-cos/tests/test_routing.py -q
+#
+# (test_routing.py::test_fixture_matches_the_live_initiatives_store — SKIPPED unless that
+# env var is set; needs the homelab kubeconfig, override its path with REPO_COS_KUBECONFIG).
+# It reads the live store, diffs it against this file, and NAMES the slugs that moved.
+# After refreshing, re-state the counts in test_routing.py's corpus tests and in README.md.
 #
 # Used by test_routing.py to pin the corpus-wide properties of the taggable-slug
 # denylist (notably: an emitted tag ALWAYS equals its ledger slug byte-for-byte).
 # `#` comments and blank lines are ignored by the loader.
 2026-07-21
 868j34n9y-868kf6w7r-complete-mark
-APP-DISCOVERY-DESIGN
-COMFYUI-INTEGRATION-DESIGN
-HANDOFF
-HANDOFF-comfyui-session
-SECURITY-AUDIT-v0.1.64
-SESSION-HANDOFF
 actionable-next-steps
 activity-days-from-last
 after-few-hours-progress
@@ -44,6 +43,7 @@ app-blocks-design-system-and-submit
 app-blocks-external-ga-connect-flow-preflip-gate
 app-blocks-external-ga-phase1
 app-blocks-marketplace-and-listing-media
+app-blocks-message-passing-inventory
 app-blocks-p3a-external-listing-submission-scope
 app-blocks-p3b-delist-claim-scope
 app-blocks-playable-collections
@@ -51,8 +51,8 @@ app-blocks-playable-collections-run-page-arc
 app-blocks-review-flow-and-sandbox
 app-blocks-review-ux-and-redos
 app-blocks-review-ux-media-reachability
-app-blocks-scope-system-audit
 app-blocks-scopes-arc
+app-blocks-scope-system-audit
 app-blocks-shared-storage-functional
 app-blocks-spend-before-approval-dogfood-blind-kickoff
 app-blocks-ux
@@ -60,6 +60,7 @@ app-blocks-viewer-bridge-sdk-published
 app-blocks-w13-vitrine-published
 app-blocks-w2-apps-as-repos-v0-handoff
 app-blocks-w6-ui-blind-dogfood-kickoff
+APP-DISCOVERY-DESIGN
 app-engine-event-new-service-set
 app-mod-review-flow-review-pass
 app-panorama-customcomfy-bridge
@@ -84,21 +85,23 @@ civitai-cli-arc-v0.1.79
 civitai-cli-browse-download-arc
 civitai-design-system-rollout
 civitai-dispatch-prs
+civitai-dp-prod-cohort-bluegreen-release-proposal
 clawgate-chat-polish
-cli-public-api-arc
 clips-composer-land-remix
+cli-public-api-arc
 cluster-cnpg-docs-production-verify
 code-open
 comfy-create-graceful-kill-relaunching-restart-script-with
 comfyui-docs-latest-setup-with
+COMFYUI-INTEGRATION-DESIGN
 comment-information-label-preview-with
 component-file
 custom-generators
 data-initiatives-retrieval-skill-understand
 decisions-human-tiering
+deleted-investigate-item-restore
 delete-dispatch-flow-web
 delete-pod-stuck
-deleted-investigate-item-restore
 dependencies-improvements-repository-security
 deploy-comfyui-video-generation
 deref-quarantine-handoff
@@ -123,6 +126,8 @@ espanso-floating-improve-integration-with
 espanso-typing-toil
 feed-live-remix-verify
 funnel-submit-link-deploy-runbook
+HANDOFF
+HANDOFF-comfyui-session
 harness-tuning
 health-system-tiering-verify
 increase-investigate-rate-request-sudden
@@ -148,6 +153,8 @@ remix-templates
 repo-cos-precision-iteration
 scope-resume-state-digest
 second-set-with
+SECURITY-AUDIT-v0.1.64
+SESSION-HANDOFF
 session-prompt-civitai-app-starters-blocks
 session-serializer-perf
 spec-insights-telemetry-pr2

--- a/scripts/repo-cos/tests/test_approve.py
+++ b/scripts/repo-cos/tests/test_approve.py
@@ -743,7 +743,10 @@ _SLUGS_THE_GRAMMAR_WOULD_REWRITE = (
     "foo bar",          # whitespace → '-'  (→ initiative:foo-bar)
     "x  y",             # collapsed run of whitespace
     "trailing-dash-",   # .strip('-')        (→ initiative:trailing-dash)
-    "-leading-dash",    # .strip('-') on the other end
+    "-leading-dash",    # NOT a rewrite: .strip('-') runs on the WHOLE tag, whose first
+                        # char is the 'i' of `initiative:`, so this one EMITS VERBATIM
+                        # as `initiative:-leading-dash`. Kept in the table as the
+                        # asymmetry's negative control (the trailing twin IS rewritten).
     "tab\tseparated",   # _WS_RE covers all whitespace, not just ' '
     " padded-slug ",    # NB: build_tags strips first, so this one is NOT a rewrite
 )
@@ -762,10 +765,22 @@ def test_build_tags_emitted_tag_always_equals_its_slug_exactly():
     """🔴 THE INVARIANT, as a PROPERTY over every shape above: build_tags returns either
     NOTHING or exactly `[f"initiative:{slug}"]`. It may never return a third thing (a
     rewritten tag), because the initiatives-side join matches on the slug byte-for-byte
-    and a rewritten tag joins to nothing while looking perfectly healthy."""
+    and a rewritten tag joins to nothing while looking perfectly healthy.
+
+    NB the `.strip()`: `build_tags` (and `routing.taggable_slug`) strip the slug before
+    building the tag, so the promise is byte-equality with the STRIPPED slug — which is
+    why `" padded-slug "` is in the table above yet legitimately emits
+    `initiative:padded-slug`. That is the ONE normalization the guard permits."""
     for slug in _SLUGS_THE_GRAMMAR_WOULD_REWRITE + _SLUGS_THAT_MUST_STILL_TAG:
         tags = clawgate.build_tags({"initiative": slug})
         assert tags in ([], [f"initiative:{slug.strip()}"]), (slug, tags)
+    # 🔴 THE POSITIVE HALF — without it the assertion above is satisfiable by a guard that
+    # emits NOTHING, EVER. (Verified: mutating build_tags to `return []` for any slug
+    # containing '/' or '_' left the whole suite green before this loop existed. A guard
+    # that silently over-drops is undetectable in production — a dropped tag is silent BY
+    # DESIGN — so the scalpel-not-mute-button property has to be pinned in the tests.)
+    for slug in _SLUGS_THAT_MUST_STILL_TAG:
+        assert clawgate.build_tags({"initiative": slug}) == [f"initiative:{slug}"], slug
 
 
 def test_build_tags_drops_every_slug_the_grammar_would_rewrite():
@@ -800,13 +815,75 @@ def test_build_tags_logs_why_it_dropped_a_rewritten_tag(capsys):
 
 
 def test_build_tags_guard_never_raises_and_never_costs_the_post():
-    # The load-bearing contract: the guard may only ever DROP a tag. It must not raise
-    # (post_task would never be reached) — a dropped tag is fine, a failed POST is not.
-    for slug in _SLUGS_THE_GRAMMAR_WOULD_REWRITE:
-        assert isinstance(clawgate.build_tags({"initiative": slug}), list)
+    """The load-bearing contract: the guard may only ever DROP a tag — never raise, and
+    never make the POST fail. The name used to overclaim (it asserted `isinstance(..., list)`
+    and never went near `post_task`), so the post half is now actually exercised: every
+    guarded shape is carried through the REAL post_task and must still produce a Task id."""
+    posted = []
+
+    def fake_post(url, payload, token, timeout=15):
+        posted.append(dict(payload))
+        return json.dumps({"id": 42})
+
+    for slug in _SLUGS_THE_GRAMMAR_WOULD_REWRITE + _SLUGS_THAT_MUST_STILL_TAG:
+        tags = clawgate.build_tags({"initiative": slug})
+        assert isinstance(tags, list)
+        tid = clawgate.post_task("d", "b", tags=tags, creds=_CREDS, _post=fake_post)
+        assert tid == 42, slug            # the approval is never lost to a tag
+        for tag in posted[-1].get("tags", []):
+            _assert_valid_tag(tag)        # nothing that would 400 ever reaches the wire
 
 
-# ---- 7c. post_task payload + back-compat --------------------------------------------
+# ---- 7c-bis. the guard is PER TAG (the `runbook:` seam is not a trap) ----------------
+
+def test_guard_tags_keeps_a_second_namespace_and_drops_only_the_offender():
+    """Following the `runbook:` seam literally — appending `f"runbook:{name}"` to `raw` —
+    must emit BOTH tags. Under the original all-or-nothing guard (whole normalized list
+    vs whole wanted list) a two-namespace `raw` compared unequal and dropped EVERY tag on
+    EVERY Task, silently. Per-tag, one bad tag costs only itself."""
+    both = clawgate.guard_tags(["initiative:remix-composer", "runbook:perf-deep-dive"])
+    assert both == ["initiative:remix-composer", "runbook:perf-deep-dive"]  # sorted
+    for tag in both:
+        _assert_valid_tag(tag)
+    # a rewritable tag alongside a good one: only the offender is dropped …
+    assert clawgate.guard_tags(["initiative:foo bar", "runbook:perf-deep-dive"]) == [
+        "runbook:perf-deep-dive"]
+    # … in either order, and for a grammar rejection (over-long) too.
+    assert clawgate.guard_tags(["runbook:perf-deep-dive", "initiative:" + "x" * 60]) == [
+        "runbook:perf-deep-dive"]
+    # and the single-tag behaviour build_tags relies on is unchanged.
+    assert clawgate.guard_tags(["initiative:foo bar"]) == []
+    assert clawgate.guard_tags([]) == []
+    assert clawgate.guard_tags(None) == []
+
+
+def test_guard_tags_drop_logs_one_accurate_reason_not_two(capsys):
+    """A >64-rune tag used to log BOTH the cap message and the join-violation message,
+    mis-attributing a length drop to the join guard. 3 live slugs hit this every weekly
+    run, and that log line is the only trace the drop leaves."""
+    assert clawgate.guard_tags(["initiative:" + "x" * 60]) == []
+    err = capsys.readouterr().err
+    assert "runes exceeds" in err
+    assert "must equal its" not in err, err        # NOT the join-violation message
+    assert err.count("dropping tag") == 1, err
+    # the rewrite case logs the join violation, and only that.
+    assert clawgate.guard_tags(["initiative:foo bar"]) == []
+    err = capsys.readouterr().err
+    assert "initiative:foo-bar" in err
+    assert "runes exceeds" not in err
+    assert err.count("dropping tag") == 1, err
+
+
+def test_build_tags_over_long_slug_logs_only_the_cap_reason(capsys):
+    # Same honesty fix, through the REAL emission path (a real store slug, 59 chars).
+    assert clawgate.build_tags(
+        {"initiative": "alert-civitai-disk-investigate-prioritize-remediation-space"}) == []
+    err = capsys.readouterr().err
+    assert "runes exceeds" in err
+    assert "must equal its" not in err, err
+
+
+# ---- 7d. post_task payload + back-compat --------------------------------------------
 
 def test_post_task_includes_tags_when_passed():
     seen = {}
@@ -832,7 +909,7 @@ def test_post_task_omits_tags_key_entirely_when_empty():
     assert seen["payload"] == {"directory": "d", "body": "b"}   # invalid tag → key absent
 
 
-# ---- 7d. FAIL-OPEN: a tag must never cost an approval --------------------------------
+# ---- 7e. FAIL-OPEN: a tag must never cost an approval --------------------------------
 
 def _http_error(code):
     import urllib.error
@@ -935,7 +1012,7 @@ def test_post_task_retry_that_also_fails_returns_none():
     assert len(calls) == 2   # tagged + one untagged retry, then give up
 
 
-# ---- 7e. PERSISTENCE: last_emailed.json round-trips the slug -------------------------
+# ---- 7f. PERSISTENCE: last_emailed.json round-trips the slug -------------------------
 
 def test_write_last_emailed_persists_the_initiative_slug(tmp_path):
     path = tmp_path / "last_emailed.json"
@@ -970,7 +1047,7 @@ def test_write_last_emailed_skips_attaching_on_a_MISALIGNED_related_list(tmp_pat
     assert "1 slug(s) for 2 proposal(s)" in err
 
 
-# ---- 7e-bis. attach_related: the positional-misalignment guard, directly -------------
+# ---- 7f-bis. attach_related: the positional-misalignment guard, directly -------------
 
 def test_attach_related_stamps_when_lengths_match():
     props = [{"title": "a"}, {"title": "b"}]
@@ -1024,7 +1101,7 @@ def test_approve_payload_on_an_OLD_last_emailed_file_yields_no_tag():
     assert clawgate.build_tags(approvals[0]) == []
 
 
-# ---- 7f. approve path end-to-end: tagged vs untagged ---------------------------------
+# ---- 7g. approve path end-to-end: tagged vs untagged ---------------------------------
 
 def _fake_clawgate(captured, *, tid=4242):
     import types

--- a/scripts/repo-cos/tests/test_routing.py
+++ b/scripts/repo-cos/tests/test_routing.py
@@ -10,9 +10,13 @@ never touch Postgres; a store/tagging failure is asserted to be swallowed.
 matcher reuses the scan's tokenizers — the same import path proven hermetic by
 `scripts/initiatives/tests/test_route.py` and `test_initiative_scan.py`.
 """
+import os
+import subprocess
 import sys
 from datetime import date
 from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -316,18 +320,26 @@ def test_an_all_lowercase_slug_is_kept_verbatim():
 
 # --------------------------------------------------------------------------- #
 # CORPUS PROPERTIES — asserted over a SNAPSHOT of the real `initiatives.current`
-# vocabulary (tests/fixtures/initiatives_current_slugs.txt, 140 slugs, 2026-07-30).
+# vocabulary (tests/fixtures/initiatives_current_slugs.txt, 142 slugs, 2026-07-30).
 # Hermetic: the file is a checked-in snapshot, never a live read.
 #
 # ⚠ WHAT THESE CAN AND CANNOT CATCH. Every number below is pinned against the FIXTURE,
 # not against the live store, so they detect an unreviewed EDIT to the fixture or a
-# behaviour change in the denylist — never that the live vocabulary has moved on. It
-# already has once (139 → 140 between the feature landing and this follow-up) with the
-# suite fully green. Refreshing the fixture is a manual step; the command is in its
-# header. That trade is deliberate: a live read here would make the whole suite depend
-# on cross-cluster reachability, which tests/conftest.py exists specifically to prevent.
+# behaviour change in the denylist — never that the live vocabulary has moved on. It has
+# now done so TWICE within two days (139 → 140 → 142), each time with the suite fully
+# green, which is why "refresh it by hand and remember" is no longer the whole answer:
+# `test_fixture_matches_the_live_initiatives_store` (below) does the comparison for you,
+# SKIPPED by default and opt-in via `REPO_COS_LIVE_DRIFT_CHECK=1`. Keeping it opt-in is
+# deliberate: an unconditional live read would make the whole suite depend on
+# cross-cluster reachability, which tests/conftest.py exists specifically to prevent.
 # --------------------------------------------------------------------------- #
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+# Opt-in env var for the live-store drift check below (also documented in the fixture
+# header and in README.md). Anything truthy-looking enables it; unset = SKIPPED.
+LIVE_DRIFT_ENV = "REPO_COS_LIVE_DRIFT_CHECK"
+KUBECONFIG_ENV = "REPO_COS_KUBECONFIG"
+DEFAULT_KUBECONFIG = Path.home() / "workspace" / "homelab-talos" / "homelab-kubeconfig"
 
 
 def _slug_corpus() -> list[str]:
@@ -342,9 +354,10 @@ def test_corpus_fixture_self_check_not_a_live_drift_detector():
     All this proves is that the fixture still holds the number of slugs the properties
     below are stated in, i.e. it fails only if someone edits the file without re-stating
     the counts. It CANNOT fail because `initiatives.current` grew, since nothing here
-    reads the store. Do not read a green suite as "the snapshot is current" — refresh it
-    with the command in the fixture header (and re-state these counts + README.md)."""
-    assert len(_slug_corpus()) == 140
+    reads the store. Do not read a green suite as "the snapshot is current" — run the
+    opt-in drift check below (`REPO_COS_LIVE_DRIFT_CHECK=1`), or refresh with the command
+    in the fixture header (and re-state these counts + README.md)."""
+    assert len(_slug_corpus()) == 142
 
 
 def test_every_emitted_tag_equals_its_ledger_slug_exactly(capsys):
@@ -369,21 +382,87 @@ def test_every_emitted_tag_equals_its_ledger_slug_exactly(capsys):
 
 def test_corpus_denylist_drop_counts_are_pinned(capsys):
     """The measurement this rule change was justified by, restated against the CURRENT
-    fixture (2026-07-30, 140 slugs): 10 denylist drops (4 all-caps + 2 mixed-case + 1 bare
-    date + 1 opaque id + 2 generic) → 130 pass the denylist → 3 more lost to the 64-rune
-    tag cap → 127 actually taggable. These are fixture numbers, not live ones — see the
-    section header. (The one slug added since the feature landed,
-    `deploy-comfyui-video-generation`, is taggable, so only the totals moved.)"""
+    fixture (2026-07-30, 142 slugs): 10 denylist drops (4 all-caps + 2 mixed-case + 1 bare
+    date + 1 opaque id + 2 generic) → 132 pass the denylist → 3 more lost to the 64-rune
+    tag cap → 129 actually taggable. These are fixture numbers, not live ones — see the
+    section header. (The three slugs added since the feature landed —
+    `deploy-comfyui-video-generation`, `app-blocks-message-passing-inventory`,
+    `civitai-dp-prod-cohort-bluegreen-release-proposal` — are all taggable, so only the
+    totals moved.)"""
     import clawgate  # noqa: PLC0415
     from collections import Counter
     corpus = _slug_corpus()
     reasons = Counter(r for r in (routing.slug_drop_reason(s) for s in corpus) if r)
     assert reasons == {"not-lowercase": 6, "no-letters": 1, "opaque-id": 1, "generic": 2}
     kept = [s for s in corpus if routing.slug_drop_reason(s) is None]
-    assert len(kept) == 130
+    assert len(kept) == 132
     taggable = [s for s in kept if clawgate.normalize_tags([f"initiative:{s}"])]
-    assert len(taggable) == 127
+    assert len(taggable) == 129
+    # 🔴 THE POSITIVE SIDE, pinned through the REAL emission path. Everything above counts
+    # the LAYERS; this counts what `build_tags` actually emits. Without it the corpus
+    # suite is satisfied by a guard that emits nothing at all — a mutation making
+    # build_tags return [] for any slug containing '/' or '_' passed the whole 308-test
+    # suite. A guard that silently over-drops is exactly the failure this feature cannot
+    # detect in production, because a dropped tag is silent BY DESIGN.
+    emitted = [s for s in corpus if clawgate.build_tags({"initiative": s})]
+    assert len(emitted) == 129
+    assert emitted == taggable          # and it is the SAME set, not merely the same size
     capsys.readouterr()
+
+
+# --------------------------------------------------------------------------- #
+# OPT-IN LIVE DRIFT CHECK — the one test that reads the real store. SKIPPED by default.
+# --------------------------------------------------------------------------- #
+
+def _live_slugs() -> list[str]:
+    """Read `initiatives.current` from the homelab mailbox Postgres (the same command the
+    fixture header documents). ONLY ever called from the opt-in test below."""
+    kubeconfig = os.environ.get(KUBECONFIG_ENV) or str(DEFAULT_KUBECONFIG)
+    proc = subprocess.run(
+        ["kubectl", "--kubeconfig", kubeconfig, "-n", "mailbox",
+         "exec", "mailbox-postgres-0", "--", "sh", "-c",
+         'psql -U ${POSTGRES_USER:-mail} -d ${POSTGRES_DB:-mail} '
+         '-tAc "select slug from initiatives.current order by 1;"'],
+        capture_output=True, text=True, timeout=120,
+    )
+    if proc.returncode != 0:
+        pytest.fail(f"live store read failed (rc={proc.returncode}); set {KUBECONFIG_ENV} "
+                    f"if the kubeconfig is not at {DEFAULT_KUBECONFIG}\n{proc.stderr[-800:]}")
+    return [ln.strip() for ln in proc.stdout.splitlines() if ln.strip()]
+
+
+@pytest.mark.skipif(
+    not os.environ.get(LIVE_DRIFT_ENV),
+    reason=f"live-store drift check is opt-in: set {LIVE_DRIFT_ENV}=1 (needs the homelab "
+           f"kubeconfig; override its path with {KUBECONFIG_ENV})",
+)
+def test_fixture_matches_the_live_initiatives_store():
+    """🔴 THE ONE TEST THAT READS THE LIVE STORE — opt-in, never part of a default run.
+
+    Every other corpus property is pinned against the checked-in snapshot, so none of
+    them can fail because `initiatives.current` moved on. It moved twice within two days
+    of being refreshed (139 → 140 → 142) with the suite green both times, so relying on
+    a manual refresh step that nothing enforces has now failed twice on the record.
+
+    Enable it (a `kubectl exec` into the homelab mailbox Postgres, ~1s):
+
+        REPO_COS_LIVE_DRIFT_CHECK=1 python -m pytest scripts/repo-cos/tests/test_routing.py -q
+
+    Left OPT-IN on purpose: tests/conftest.py exists precisely to keep the default run
+    hermetic (no cross-cluster reachability, no network round-trip per test), and this
+    check must not weaken that. Nothing here touches `route.load_current`, so the
+    conftest stub is neither needed nor disturbed. When it fails, refresh the fixture
+    with the command in its header and re-state the counts above + in README.md."""
+    live = set(_live_slugs())
+    assert live, "the live store returned no slugs — that is a store problem, not drift"
+    fixture = set(_slug_corpus())
+    added = sorted(live - fixture)
+    removed = sorted(fixture - live)
+    assert not added and not removed, (
+        f"fixture is STALE vs the live store ({len(fixture)} fixture / {len(live)} live)\n"
+        f"  added in the store, missing from the fixture: {added}\n"
+        f"  in the fixture, gone from the store: {removed}\n"
+        "  refresh: see the command in tests/fixtures/initiatives_current_slugs.txt")
 
 
 def test_the_two_mixed_case_corpus_slugs_are_now_dropped(capsys):

--- a/scripts/repo-cos/tests/test_scan_cli.py
+++ b/scripts/repo-cos/tests/test_scan_cli.py
@@ -323,6 +323,20 @@ def test_cmd_scan_threads_resolved_initiative_slugs_into_last_emailed(tmp_path, 
 
     monkeypatch.setattr(email_send, "send_digest", fake_send)
 
+    # BELT AND BRACES. This is the suite's ONLY --email test, and the stub above patches
+    # `send_digest` WHOLESALE — if a refactor changes how scan.py reaches it (a
+    # `from email_send import send_digest` at module scope, say), the patch silently
+    # no-ops and a REAL digest goes out before the assertions below fail. So block the
+    # two send seams as well, and — because `send_digest`'s `_relay`/`_sender` defaults
+    # are bound at DEF time and would keep pointing at the originals — the smtplib
+    # constructor underneath both of them, which is what actually opens the socket.
+    def _no_network(*a, **kw):
+        raise AssertionError("a REAL send was attempted — the send stub did not hold")
+
+    monkeypatch.setattr(email_send, "_relay_send", _no_network)
+    monkeypatch.setattr(email_send, "_smtp_send", _no_network)
+    monkeypatch.setattr(email_send.smtplib, "SMTP", _no_network)
+
     args = scan.build_parser().parse_args(["--email", "--repos", str(dev)])
     assert scan.cmd_scan(args) == 0
     assert sent, "the digest send was never reached — nothing wrote last_emailed.json"


### PR DESCRIPTION
Adversarial-audit follow-up to #201 (`a14aaea`). Four findings closed. **Do not merge without review** — one behaviour change (the guard is now per-tag).

## Fix 1 — the guard's tests permitted a mute button 🔴
`_SLUGS_THAT_MUST_STILL_TAG` is documented as "the guard has to be a scalpel, not a mute button", but the only assertion over it was `assert tags in ([], [f"initiative:{slug.strip()}"])` — which **permits `[]`**. Nothing pinned the positive side, so mutating `build_tags` to `return []` for any slug containing `/` or `_` left **all 308 tests green**. A guard that silently over-drops is precisely the failure this feature cannot detect in production, since a dropped tag is silent by design.

Pinned in both places:
- `tests/test_approve.py` — an equality loop over `_SLUGS_THAT_MUST_STILL_TAG`.
- `tests/test_routing.py::test_corpus_denylist_drop_counts_are_pinned` — `emitted = [s for s in corpus if clawgate.build_tags(...)]`, `len(emitted) == 129` **and** `emitted == taggable` (same set, not just the same size), through the real emission path.

**Mutation-verified**: with the `/`-and-`_` mute mutation applied → `2 failed, 309 passed` — exactly `test_build_tags_emitted_tag_always_equals_its_slug_exactly` and `test_corpus_denylist_drop_counts_are_pinned`. Reverted → green.

## Fix 2 — the `runbook:` seam gave guard-breaking instructions → **option (a)**
Following the seam literally produced `tags = ['initiative:…', 'runbook:…']`, which `!= want = ['initiative:…']`, so the all-or-nothing guard fired and dropped **both** tags silently on **every** Task.

Chose **(a)**, the per-tag guard, as the task preferred: it removes the trap rather than documenting it, and it does **not** weaken the current guarantee — for a single-element `raw`, "each tag must survive normalization unchanged" is exactly equivalent to the old whole-list comparison (`normalize_tags` sorting/dedup is a no-op on one element). New `clawgate.guard_tags` drops any tag where `normalize_tag(t) != t` and keeps the rest; `build_tags` delegates to it. The seam docstring now states the two-namespace case is safe *because* the guard is per-tag.

New test: `test_guard_tags_keeps_a_second_namespace_and_drops_only_the_offender` — both tags emitted for a 2-namespace `raw`; a rewritable or over-long tag drops only itself, in either order; single-tag behaviour unchanged.

## Fix 3 — corpus refreshed, drift made self-detecting
Live store re-read: **142** slugs. The fixture was missing `app-blocks-message-passing-inventory` and `civitai-dp-prod-cohort-bluegreen-release-proposal` (both taggable). Counts re-stated in the fixture header, both corpus tests and `README.md`:

| | old (stale) | now |
|---|---|---|
| corpus | 140 | **142** |
| denylist drops | 10 | 10 (unchanged: 6 not-lowercase, 1 no-letters, 1 opaque-id, 2 generic) |
| pass denylist | 130 | **132** |
| taggable / emitted | 127 | **129 / 129** |

Twice-stale-in-two-days is enough evidence against a manual step nothing enforces, so `test_fixture_matches_the_live_initiatives_store` reads the live store and diffs it against the fixture, **naming** the slugs that moved. **Skipped by default**, opt-in:

```sh
REPO_COS_LIVE_DRIFT_CHECK=1 python -m pytest scripts/repo-cos/tests/test_routing.py -q
```

`REPO_COS_KUBECONFIG` overrides the kubeconfig path. Documented in the fixture header, the test docstring, and README (both the tag section and the Hermeticity paragraph). It never touches `route.load_current`, so `tests/conftest.py`'s hermeticity fixture is neither needed nor disturbed.

Verified three ways: passes against live; **fails with a named diff** when a fake slug is added to the fixture; `pytest.fail`s with actionable text on an unreadable kubeconfig.

## Fix 4 — honesty corrections (no behaviour change)
- **`.strip()` hole**: restated as byte-equality with the **stripped** ledger slug, with the reasoning, in `build_tags`, `routing.py`'s invariant note, README, and the invariant test's docstring (which is why `" padded-slug "` legitimately emits `initiative:padded-slug`).
- **Double-log**: `normalize_tag` split into a pure `_normalize_tag() -> (tag, reason)` core plus a logging wrapper, so the guard emits exactly **one** accurate reason. The 3 live slugs that hit the 64-rune cap every weekly run now log the cap message only, not a mis-attributed join violation. Pinned by two new tests.
- **Overclaiming name**: `test_build_tags_guard_never_raises_and_never_costs_the_post` now drives the real `post_task` (with a fake transport) and asserts a Task id comes back for every guarded shape, plus that nothing reaching the wire violates the tag grammar.
- Duplicate `# ---- 7c.` headers renumbered (`7c-bis`/`7d`/`7e`/`7f`/`7f-bis`/`7g`); the wrong `-leading-dash` annotation corrected — it emits **verbatim**, because `.strip('-')` runs on the whole tag whose first char is the `i` of `initiative:` (verified empirically).

## Fix 5 — hardened the one `--email` test
It stubbed `email_send.send_digest` wholesale; an import-style refactor would silently no-op the patch and **send a real digest**. Now also blocks `_relay_send`/`_smtp_send` **and** `email_send.smtplib.SMTP` — the last one matters because `send_digest`'s `_relay`/`_sender` defaults bind at **def time**, so patching the module attributes alone would not stop today's code path. The smtplib patch is the one that actually prevents a socket.

## Gate
```
nix-shell -p 'python3.withPackages(p:[p.pytest p.requests p.psycopg2])' \
  --run 'python -m pytest scripts/repo-cos/tests -q'
→ 311 passed, 1 skipped   (baseline: 308 passed, 0 skipped)
```
The 1 skip is the opt-in drift check. **Default run is network-free**: re-run with `socket.socket.connect`, `socket.create_connection` and any `kubectl`/`psql`/`curl`/`ssh` subprocess made fatal → still 311 passed / 1 skipped. The same harness *does* trip the drift check when `REPO_COS_LIVE_DRIFT_CHECK=1` is set, so it is a real check rather than a vacuous one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
