### PR TITLE
fix(drafter): opt the unattended pass out of the clawgate approval hook

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1191,6 +1191,14 @@ in
         "HOME=%h"
         # Relay kubeconfig for the digest email (reuses repo-cos's postfix relay).
         "REPO_COS_PROD_KUBECONFIG=%h/workspace/homelab-talos/production-kubeconfig"
+        # The global PermissionRequest hook (clawgate) has no matcher, so it also fires
+        # for THIS unattended pass — where a permission prompt is unanswerable by
+        # construction: nobody is awake at 08:00 to tap approve, and the run is headless.
+        # Left on, the hook polls to CLAWGATE_HOOK_DEADLINE (170s) against a 240s
+        # DRAFTER_TIMEOUT, so a single blocked call burns most of one ticket's budget
+        # AND pushes a pointless notification. The hook supports a per-session opt-out;
+        # take it. (Interactive sessions are untouched — this is unit-scoped.)
+        "CLAWGATE_REMOTE_APPROVAL=off"
       ];
       ExecStart = "${pkgs.bash}/bin/bash %h/workspace/devrc/scripts/task-spec-drafter/drafter.sh";
       # Re-run with fresh code after a script-only edit (cf. X-Restart-Triggers above).


### PR DESCRIPTION
The global `PermissionRequest` hook (clawgate) has `matcher: None`, so it also fires for the task-spec-drafter's **headless 08:00 pass** — where a permission prompt is unanswerable by construction (non-interactive; nobody awake to approve).

Left on, it polls to `CLAWGATE_HOOK_DEADLINE` (170s) against `DRAFTER_TIMEOUT=240`, so a single blocked call burns most of one ticket's budget **and** pushes a notification that cannot be acted on.

**Fix:** the hook already documents a per-session opt-out (`CLAWGATE_REMOTE_APPROVAL=off`). Set it in the unit's `Environment`. No change to the hook or to `~/.claude/settings.json`.

**Verified**
- `~/.claude/clawgate.env` is sourced with `set -a` *before* the activation gate, so it could have clobbered this — it mentions the variable only in a comment and never assigns it. Unit env wins.
- The gate's `case` accepts `off`, so the hook `defer`s (exits 0) immediately.
- `nix-instantiate --parse` clean.
- Scope is the unit only; interactive sessions keep remote approval.

**Honest framing:** this is now mostly preventative. After #177/#179/#185 the drafter's blocked rate is 0.6% (1/154 on the 2026-07-30 run, and that one was a piped command hitting the shape contract), so there is little left for the hook to fire on. It removes a 170s tail-risk rather than a live problem.