### PR TITLE
harden(repo-cos): guard_tags shape checks + property-based corpus assertions

### DIFF
--- a/scripts/repo-cos/README.md
+++ b/scripts/repo-cos/README.md
@@ -169,13 +169,21 @@ it only collects the full proposal; the **only new network** is the clawgate POS
   logged with its rule) and `clawgate.normalize_tags` (clawgate's grammar: lowercase,
   `[a-z0-9._/-]`, ≤1 `:`, ≤64 runes, ≤20 tags; anything invalid is **dropped, not mangled**).
   Measured over `tests/fixtures/initiatives_current_slugs.txt` — a **hand-refreshed snapshot**
-  of `initiatives.current`, last taken 2026-07-30 at **142 slugs**: 10 denylist drops → 132 pass
-  the denylist → 3 more lost to the 64-rune cap → **129 taggable** (and 129 actually emitted by
-  `build_tags`, pinned on the positive side too). Those numbers are pinned by `test_routing.py`
-  **against the snapshot, not the live store**: the default suite is deliberately hermetic (see
-  `tests/conftest.py`), so no ordinary test can tell you the fixture has gone stale — it drifted
-  twice within two days of a refresh (139 → 140 → 142), green each time. So there is now an
-  **opt-in live drift check**, skipped by default:
+  of `initiatives.current`, last taken 2026-07-30 at **144 slugs**: 10 denylist drops → 134 pass
+  the denylist → 3 more lost to the 64-rune cap → **131 taggable** (and 131 actually emitted by
+  `build_tags`). **Those figures are context, not assertions.** `test_routing.py` used to pin
+  them and they rotted on three consecutive days (139 → 140 → 142 → 144) as the scan minted new
+  slugs — every refresh pure churn, none a behaviour change. The corpus tests now assert
+  **properties** that hold at any vocabulary size: `emitted == taggable` (set equality — the
+  mute-button guard), every emitted tag equals its slug byte-for-byte, the denylist drops
+  something and every drop names a reason from a **pinned reason set**, and the fixture is
+  well-formed. Refreshing the snapshot therefore needs **no counts re-stated anywhere** — paste
+  the new `select` output under the header and stop.
+
+  These still read the snapshot, not the live store: the default suite is deliberately hermetic
+  (see `tests/conftest.py`), so no ordinary test can tell you the fixture has gone stale — with
+  counts gone that is now a coverage gap (new slug shapes unexercised), never a red suite. The
+  **opt-in live drift check** is what reports actual drift, skipped by default:
 
   ```sh
   # reads initiatives.current and diffs it against the fixture, naming the slugs that moved
@@ -184,7 +192,9 @@ it only collects the full proposal; the **only new network** is the clawgate POS
   REPO_COS_LIVE_DRIFT_CHECK=1 REPO_COS_KUBECONFIG=/path/to/kubeconfig python -m pytest ...
   ```
 
-  When it fails, refresh with the command in the fixture header, then re-state these counts.
+  `REPO_COS_LIVE_DRIFT_CHECK=0` (or `false`/`no`/`off`, case-insensitive) means **off** — it
+  used to opt you *in*, since any non-empty value enabled the check. When the check fails,
+  refresh with the command in the fixture header; that is the whole procedure.
 - **🔴 An emitted tag always equals its ledger slug, byte-for-byte** (byte-equal to the
   **stripped** slug — `routing.taggable_slug` and `build_tags` both `.strip()`, so a stored
   slug with surrounding whitespace emits `initiative:<stripped>`; nothing else may alter it).
@@ -299,7 +309,11 @@ suites drive the real `cmd_scan`, so `tests/conftest.py` carries an **autouse fi
 stubs `load_current` to an empty store** for every test; `test_routing.py` re-patches it
 in-test where it wants a fixture store. Measured: 11 real store-read attempts without the
 fixture, 0 with it. `tests/fixtures/initiatives_current_slugs.txt` is a checked-in
-**snapshot** of the real slug vocabulary (never a live read in a default run) used to pin the
+**snapshot** of the real slug vocabulary (never a live read in a default run) used to assert the
 denylist's corpus-wide properties; refresh it with the psql command in its header. The ONE test
 that reads the live store — `test_fixture_matches_the_live_initiatives_store`, the drift check —
-is **skipped unless `REPO_COS_LIVE_DRIFT_CHECK=1`** is set, so the default run stays network-free.
+is **skipped unless `REPO_COS_LIVE_DRIFT_CHECK` is set to something other than `0`/`false`/`no`/
+`off`**, so the default run stays network-free. The suite's only `--email` test additionally
+blocks `smtplib.SMTP`, `smtplib.SMTP_SSL` and `email_send`'s `subprocess.Popen` (the relay path's
+production-cluster `kubectl port-forward`) beneath its `send_digest` stub, so no failure of that
+stub can reach the network or prod.

--- a/scripts/repo-cos/clawgate.py
+++ b/scripts/repo-cos/clawgate.py
@@ -265,7 +265,9 @@ def guard_tags(raw) -> list[str]:
     """🔴 THE STRUCTURAL JOIN GUARD, applied PER TAG.
 
     A consumer of an `initiative:` tag joins on `tag == "initiative:" + slug` byte-for-byte
-    (see `scripts/initiatives/tasks.py` — it does no case-folding and no normalization), so
+    (see `scripts/initiatives/tasks.py` — FORTHCOMING, it lands with the still-open PR #202
+    and is on no merged branch yet; the join semantics cited here are that PR's, and it does
+    no case-folding and no normalization), so
     the ONLY acceptable outcome for a tag is the exact string we asked for. `normalize_tag`
     performs THREE mutations — lowercase, whitespace→`-`, and a `-` strip — and the `routing`
     denylist only polices the first (`not-lowercase`). A slug like `foo bar`, `x  y` or
@@ -285,14 +287,37 @@ def guard_tags(raw) -> list[str]:
     A drop is the correct degradation — a missing tag is cheap, a tag that joins to nothing
     is a lie (and the untagged Task is still posted either way). Every drop logs exactly ONE
     accurate reason: the grammar's, when the grammar rejected it outright; the join
-    violation's, when the grammar would have silently rewritten it."""
+    violation's, when the grammar would have silently rewritten it.
+
+    🔴 SHAPE IS CHECKED BEFORE ITERATION, and elements must already BE strings. Both halves
+    are load-bearing for a PUBLIC entry point (the `runbook:` seam above points future
+    implementers straight at it):
+
+      * a non-list `raw` is rejected outright rather than iterated. `guard_tags(5)` would
+        otherwise raise `TypeError` out of the loop header — outside the per-item `try` —
+        breaking the "never costs an approval" contract; and the *iterable* non-lists are
+        worse than a raise, because they are consumed ELEMENT-WISE and succeed:
+        `guard_tags("initiative:remix")` → `['a','e','i','m','n','r','t','v','x']`,
+        `guard_tags(b"x")` → `['120']`, `guard_tags({"a": 1})` → `['a']`. A caller passing
+        a bare tag STRING instead of a one-element list is the most plausible future
+        mistake here, and emitting nine single-letter tags is the worst possible answer to
+        it. Only `list`/`tuple` is accepted; everything else yields `[]`.
+      * a non-string ELEMENT is dropped rather than `str()`d. `str(item)` is itself a
+        mutation, and it is the one mutation this guard compares AFTER instead of against —
+        so `[123]` used to launder itself past the equality check and emit `'123'` (the
+        pre-per-tag whole-list guard dropped it, because `normalize_tags([123]) != [123]`).
+        The type name alone is logged: an arbitrary object's `__repr__` can itself raise."""
+    if not isinstance(raw, (list, tuple)):
+        if raw is not None:                    # None = "no tags", the normal empty case
+            _log(f"dropping all tags: expected a list of tag strings, got "
+                 f"{type(raw).__name__} (a bare tag string must be passed as [tag])")
+        return []
     kept: list[str] = []
-    for item in raw or []:
-        try:
-            tag = str(item)
-        except Exception as exc:  # noqa: BLE001 - a tag must NEVER cost an approval
-            _log(f"dropping an unstringifiable tag: {exc}")
+    for item in raw:
+        if not isinstance(item, str):
+            _log(f"dropping a non-string tag of type {type(item).__name__}")
             continue
+        tag = item
         norm, reason = _normalize_tag(tag)
         if norm is not None and norm == tag:
             kept.append(tag)

--- a/scripts/repo-cos/tests/fixtures/initiatives_current_slugs.txt
+++ b/scripts/repo-cos/tests/fixtures/initiatives_current_slugs.txt
@@ -1,28 +1,38 @@
 # SNAPSHOT of `select slug from initiatives.current order by 1;` — the REAL, MINED
 # initiative vocabulary the `initiative:<slug>` tag is drawn from.
 #
-# Taken 2026-07-30 (142 slugs). Regenerate with:
+# Taken 2026-07-30 (144 slugs). Regenerate with:
 #   kubectl --kubeconfig ~/workspace/homelab-talos/homelab-kubeconfig -n mailbox \
 #     exec mailbox-postgres-0 -- sh -c 'psql -U ${POSTGRES_USER:-mail} \
 #     -d ${POSTGRES_DB:-mail} -tAc "select slug from initiatives.current order by 1;"'
 #
-# ⚠ This is a SNAPSHOT, refreshed BY HAND — and it has now gone stale TWICE within two
-# days of being refreshed (139 → 140 → 142), each time with the whole suite green. The
-# default run is hermetic (see tests/conftest.py) so no ordinary test can tell you this
-# file is behind. What CAN: the OPT-IN drift check
+# ⚠ This is a SNAPSHOT, refreshed BY HAND, and the store moves most days (139 → 140 → 142
+# → 144 over three days). The default run is hermetic (see tests/conftest.py) so no
+# ordinary test can tell you this file is behind.
+#
+# ⚠ REFRESHING THIS FILE NO LONGER REQUIRES RE-STATING ANY COUNTS. The corpus tests in
+# test_routing.py assert PROPERTIES (emitted == taggable, every emitted tag equals its
+# slug, every drop names a known reason), not totals — precisely because the totals rotted
+# three days running. Drop the new `select` output in below the header and you are done; a
+# stale fixture is a coverage gap (new slug shapes unexercised), never a red suite.
+#
+# What DOES report drift, opt-in:
 #
 #   REPO_COS_LIVE_DRIFT_CHECK=1 python -m pytest scripts/repo-cos/tests/test_routing.py -q
 #
 # (test_routing.py::test_fixture_matches_the_live_initiatives_store — SKIPPED unless that
-# env var is set; needs the homelab kubeconfig, override its path with REPO_COS_KUBECONFIG).
-# It reads the live store, diffs it against this file, and NAMES the slugs that moved.
-# After refreshing, re-state the counts in test_routing.py's corpus tests and in README.md.
+# env var is set to something other than 0/false/no/off; needs the homelab kubeconfig,
+# override its path with REPO_COS_KUBECONFIG). It reads the live store, diffs it against
+# this file, and NAMES the slugs that moved.
 #
-# Used by test_routing.py to pin the corpus-wide properties of the taggable-slug
-# denylist (notably: an emitted tag ALWAYS equals its ledger slug byte-for-byte).
-# `#` comments and blank lines are ignored by the loader.
 2026-07-21
 868j34n9y-868kf6w7r-complete-mark
+APP-DISCOVERY-DESIGN
+COMFYUI-INTEGRATION-DESIGN
+HANDOFF
+HANDOFF-comfyui-session
+SECURITY-AUDIT-v0.1.64
+SESSION-HANDOFF
 actionable-next-steps
 activity-days-from-last
 after-few-hours-progress
@@ -37,6 +47,7 @@ app-blocks
 app-blocks-agentic-review-arc
 app-blocks-and-cluster
 app-blocks-arc-complete
+app-blocks-batch-d-platform-scope
 app-blocks-buzz-payout-scope
 app-blocks-comfy-cloud-scaffold-and-devtunnel
 app-blocks-design-system-and-submit
@@ -51,8 +62,8 @@ app-blocks-playable-collections-run-page-arc
 app-blocks-review-flow-and-sandbox
 app-blocks-review-ux-and-redos
 app-blocks-review-ux-media-reachability
-app-blocks-scopes-arc
 app-blocks-scope-system-audit
+app-blocks-scopes-arc
 app-blocks-shared-storage-functional
 app-blocks-spend-before-approval-dogfood-blind-kickoff
 app-blocks-ux
@@ -60,7 +71,6 @@ app-blocks-viewer-bridge-sdk-published
 app-blocks-w13-vitrine-published
 app-blocks-w2-apps-as-repos-v0-handoff
 app-blocks-w6-ui-blind-dogfood-kickoff
-APP-DISCOVERY-DESIGN
 app-engine-event-new-service-set
 app-mod-review-flow-review-pass
 app-panorama-customcomfy-bridge
@@ -87,21 +97,20 @@ civitai-design-system-rollout
 civitai-dispatch-prs
 civitai-dp-prod-cohort-bluegreen-release-proposal
 clawgate-chat-polish
-clips-composer-land-remix
 cli-public-api-arc
+clips-composer-land-remix
 cluster-cnpg-docs-production-verify
 code-open
 comfy-create-graceful-kill-relaunching-restart-script-with
 comfyui-docs-latest-setup-with
-COMFYUI-INTEGRATION-DESIGN
 comment-information-label-preview-with
 component-file
 custom-generators
 data-initiatives-retrieval-skill-understand
 decisions-human-tiering
-deleted-investigate-item-restore
 delete-dispatch-flow-web
 delete-pod-stuck
+deleted-investigate-item-restore
 dependencies-improvements-repository-security
 deploy-comfyui-video-generation
 deref-quarantine-handoff
@@ -126,8 +135,6 @@ espanso-floating-improve-integration-with
 espanso-typing-toil
 feed-live-remix-verify
 funnel-submit-link-deploy-runbook
-HANDOFF
-HANDOFF-comfyui-session
 harness-tuning
 health-system-tiering-verify
 increase-investigate-rate-request-sudden
@@ -151,10 +158,9 @@ remix-platform
 remix-session
 remix-templates
 repo-cos-precision-iteration
+scope-civitai-cli-listing-media
 scope-resume-state-digest
 second-set-with
-SECURITY-AUDIT-v0.1.64
-SESSION-HANDOFF
 session-prompt-civitai-app-starters-blocks
 session-serializer-perf
 spec-insights-telemetry-pr2

--- a/scripts/repo-cos/tests/test_approve.py
+++ b/scripts/repo-cos/tests/test_approve.py
@@ -15,6 +15,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import clawgate  # noqa: E402
 import exclusions  # noqa: E402
@@ -855,6 +857,57 @@ def test_guard_tags_keeps_a_second_namespace_and_drops_only_the_offender():
     assert clawgate.guard_tags(["initiative:foo bar"]) == []
     assert clawgate.guard_tags([]) == []
     assert clawgate.guard_tags(None) == []
+    assert clawgate.guard_tags(("initiative:remix-composer",)) == ["initiative:remix-composer"]
+
+
+# ---- 7c-ter. guard_tags is a PUBLIC entry point — non-list input may not raise or emit --
+
+class _ExplodingRepr:
+    def __repr__(self):
+        raise RuntimeError("repr blew up")
+
+
+@pytest.mark.parametrize("bad", [
+    "initiative:remix",          # 🔴 a BARE TAG STRING — the most plausible caller mistake.
+    "",                          # iterable, and str/bytes/dict all get consumed ELEMENT-WISE:
+    b"initiative:x",             # "initiative:remix" used to yield ['a','e','i','m','n', …]
+    bytearray(b"ab"),            # and b"..." the ordinals as strings.
+    {"initiative": "remix"},     # a dict iterates its KEYS → ['initiative']
+    {"initiative:remix"},        # a set is not a documented input either
+    5,                           # non-iterables raised TypeError out of the LOOP HEADER,
+    3.5,                         # which the per-item try/except never covered …
+    object(),
+    _ExplodingRepr(),            # … and must not be repr()'d while being reported, either
+])
+def test_guard_tags_rejects_non_list_input_without_raising_or_emitting(bad, capsys):
+    """`guard_tags` is documented, public, and pointed at by the `runbook:` seam. On a
+    non-list it must do what its contract says (return a list, never raise, never invent a
+    tag) — the two things it existed to guarantee were both violated for these shapes."""
+    assert clawgate.guard_tags(bad) == []
+    capsys.readouterr()
+
+
+def test_guard_tags_logs_what_it_refused_on_non_list_input(capsys):
+    # A silent [] is indistinguishable from "no tags resolved"; name the shape.
+    assert clawgate.guard_tags("initiative:remix") == []
+    err = capsys.readouterr().err
+    assert "str" in err and "expected a list" in err
+    # …but the normal "no tags" case (None) is not an error and must stay quiet.
+    assert clawgate.guard_tags(None) == []
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.parametrize("bad", [123, None, b"x", 1.5, ["nested"], object(), _ExplodingRepr()])
+def test_guard_tags_drops_non_string_elements_and_keeps_valid_siblings(bad, capsys):
+    """`str(item)` is itself a MUTATION, and the one this guard compares AFTER rather than
+    against — so `[123]` laundered itself past the equality check and emitted `'123'` (the
+    pre-per-tag whole-list guard dropped it: `normalize_tags([123]) != [123]`). Per-tag, a
+    non-string element must drop like any other offender, without costing its siblings."""
+    assert clawgate.guard_tags([bad]) == []
+    assert clawgate.guard_tags([bad, "runbook:perf-deep-dive"]) == ["runbook:perf-deep-dive"]
+    assert clawgate.guard_tags(["runbook:perf-deep-dive", bad]) == ["runbook:perf-deep-dive"]
+    err = capsys.readouterr().err
+    assert "non-string tag" in err, err
 
 
 def test_guard_tags_drop_logs_one_accurate_reason_not_two(capsys):

--- a/scripts/repo-cos/tests/test_routing.py
+++ b/scripts/repo-cos/tests/test_routing.py
@@ -320,26 +320,45 @@ def test_an_all_lowercase_slug_is_kept_verbatim():
 
 # --------------------------------------------------------------------------- #
 # CORPUS PROPERTIES — asserted over a SNAPSHOT of the real `initiatives.current`
-# vocabulary (tests/fixtures/initiatives_current_slugs.txt, 142 slugs, 2026-07-30).
+# vocabulary (tests/fixtures/initiatives_current_slugs.txt, 144 slugs, 2026-07-30).
 # Hermetic: the file is a checked-in snapshot, never a live read.
 #
-# ⚠ WHAT THESE CAN AND CANNOT CATCH. Every number below is pinned against the FIXTURE,
-# not against the live store, so they detect an unreviewed EDIT to the fixture or a
-# behaviour change in the denylist — never that the live vocabulary has moved on. It has
-# now done so TWICE within two days (139 → 140 → 142), each time with the suite fully
-# green, which is why "refresh it by hand and remember" is no longer the whole answer:
-# `test_fixture_matches_the_live_initiatives_store` (below) does the comparison for you,
-# SKIPPED by default and opt-in via `REPO_COS_LIVE_DRIFT_CHECK=1`. Keeping it opt-in is
-# deliberate: an unconditional live read would make the whole suite depend on
-# cross-cluster reachability, which tests/conftest.py exists specifically to prevent.
+# 🔴 THESE ARE PROPERTY ASSERTIONS, NOT COUNT ASSERTIONS — deliberately. They used to pin
+# absolute totals (`len(corpus) == 142`, `len(taggable) == 129`, a per-reason Counter), and
+# those numbers rotted on THREE consecutive days (139 → 140 → 142 → 144) as the scan minted
+# new slugs. Every one of those refreshes was pure churn: not one of them was a behaviour
+# change, and re-stating a number in three places is exactly the ritual that trains people
+# to update it without reading it. So the assertions below state what must be TRUE of the
+# vocabulary (emitted == taggable, every emitted tag equals its slug byte-for-byte, drops
+# are non-zero and every drop carries a known reason) and hold at any corpus size.
+#
+# ⚠ WHAT THESE CAN AND CANNOT CATCH. They read the FIXTURE, not the live store, so they
+# detect a behaviour change in the denylist/guard — never that the live vocabulary has
+# moved on. That is what `test_fixture_matches_the_live_initiatives_store` (below) is for:
+# it names the slugs that moved, SKIPPED by default and opt-in via
+# `REPO_COS_LIVE_DRIFT_CHECK=1`. Keeping it opt-in is deliberate: an unconditional live
+# read would make the whole suite depend on cross-cluster reachability, which
+# tests/conftest.py exists specifically to prevent. With counts gone, a stale fixture is
+# now only a coverage gap (new shapes unexercised), never a red suite.
 # --------------------------------------------------------------------------- #
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 
 # Opt-in env var for the live-store drift check below (also documented in the fixture
-# header and in README.md). Anything truthy-looking enables it; unset = SKIPPED.
+# header and in README.md). Unset — or set to an explicitly OFF value (`0`/`false`/`no`/
+# `off`/empty, case-insensitive) — leaves it SKIPPED; anything else enables it.
 LIVE_DRIFT_ENV = "REPO_COS_LIVE_DRIFT_CHECK"
 KUBECONFIG_ENV = "REPO_COS_KUBECONFIG"
 DEFAULT_KUBECONFIG = Path.home() / "workspace" / "homelab-talos" / "homelab-kubeconfig"
+_OFF_VALUES = {"", "0", "false", "no", "off"}
+
+
+def _live_drift_enabled() -> bool:
+    """Is the opt-in live drift check on? `REPO_COS_LIVE_DRIFT_CHECK=0` must mean OFF.
+
+    A bare `not os.environ.get(...)` made every non-empty value opt IN, so `=0` and
+    `=false` — the two ways anyone actually writes "don't" — performed a live
+    cross-cluster read from an otherwise hermetic suite."""
+    return os.environ.get(LIVE_DRIFT_ENV, "").strip().lower() not in _OFF_VALUES
 
 
 def _slug_corpus() -> list[str]:
@@ -348,16 +367,21 @@ def _slug_corpus() -> list[str]:
     return [ln.strip() for ln in lines if ln.strip() and not ln.startswith("#")]
 
 
-def test_corpus_fixture_self_check_not_a_live_drift_detector():
+def test_corpus_fixture_is_well_formed_and_not_gutted():
     """SELF-CHECK on the checked-in fixture — deliberately NOT a live-store drift detector.
 
-    All this proves is that the fixture still holds the number of slugs the properties
-    below are stated in, i.e. it fails only if someone edits the file without re-stating
-    the counts. It CANNOT fail because `initiatives.current` grew, since nothing here
-    reads the store. Do not read a green suite as "the snapshot is current" — run the
-    opt-in drift check below (`REPO_COS_LIVE_DRIFT_CHECK=1`), or refresh with the command
-    in the fixture header (and re-state these counts + README.md)."""
-    assert len(_slug_corpus()) == 142
+    It proves the file is still a usable corpus (non-trivial, unique, whitespace-clean), so
+    a truncated/garbled fixture cannot make the properties below pass VACUOUSLY. It states
+    no total: the store gains slugs most days and a pinned length rotted three days running.
+    It CANNOT fail because `initiatives.current` grew, since nothing here reads the store —
+    do not read a green suite as "the snapshot is current". Run the opt-in drift check
+    below (`REPO_COS_LIVE_DRIFT_CHECK=1`), or refresh with the command in the fixture
+    header."""
+    corpus = _slug_corpus()
+    # a floor, not a pin: the vocabulary only grows, so this can never rot upward.
+    assert len(corpus) > 100, f"fixture looks truncated ({len(corpus)} slugs)"
+    assert len(set(corpus)) == len(corpus), "duplicate slugs in the fixture"
+    assert all(s == s.strip() and s for s in corpus), "blank / unstripped fixture line"
 
 
 def test_every_emitted_tag_equals_its_ledger_slug_exactly(capsys):
@@ -380,33 +404,60 @@ def test_every_emitted_tag_equals_its_ledger_slug_exactly(capsys):
     capsys.readouterr()  # swallow the per-drop log lines
 
 
-def test_corpus_denylist_drop_counts_are_pinned(capsys):
-    """The measurement this rule change was justified by, restated against the CURRENT
-    fixture (2026-07-30, 142 slugs): 10 denylist drops (4 all-caps + 2 mixed-case + 1 bare
-    date + 1 opaque id + 2 generic) → 132 pass the denylist → 3 more lost to the 64-rune
-    tag cap → 129 actually taggable. These are fixture numbers, not live ones — see the
-    section header. (The three slugs added since the feature landed —
-    `deploy-comfyui-video-generation`, `app-blocks-message-passing-inventory`,
-    `civitai-dp-prod-cohort-bluegreen-release-proposal` — are all taggable, so only the
-    totals moved.)"""
-    import clawgate  # noqa: PLC0415
-    from collections import Counter
+# The complete set of reasons `routing.slug_drop_reason` may return. A NEW reason string
+# is a behaviour change and must be added here consciously — that, not a per-reason count,
+# is the thing worth pinning (the counts move whenever the scan mints a slug).
+KNOWN_DROP_REASONS = {"no-letters", "not-lowercase", "opaque-id", "generic",
+                      "empty", "too-short"}
+
+
+def test_corpus_denylist_drops_are_real_and_every_drop_names_a_known_reason(capsys):
+    """The denylist's shape over the real vocabulary, as PROPERTIES rather than totals.
+
+    Observationally today (2026-07-30, 144 fixture slugs): 10 denylist drops → 134 pass →
+    3 more lost to the 64-rune tag cap → 131 taggable. Those numbers are recorded here and
+    in README.md as context ONLY; asserting them made the suite go red every time the scan
+    minted a slug (139 → 140 → 142 → 144 in three days), which is churn, not signal. What
+    IS asserted: the denylist bites (a rule set that dropped nothing would be a silent
+    no-op), it does not eat the vocabulary, and every drop carries a reason from the known
+    set — so a new/renamed reason string surfaces as a failure."""
     corpus = _slug_corpus()
-    reasons = Counter(r for r in (routing.slug_drop_reason(s) for s in corpus) if r)
-    assert reasons == {"not-lowercase": 6, "no-letters": 1, "opaque-id": 1, "generic": 2}
+    reasons = [routing.slug_drop_reason(s) for s in corpus]
+    dropped = [r for r in reasons if r]
+    assert dropped, "the denylist dropped NOTHING over the real vocabulary — it is a no-op"
+    assert set(dropped) <= KNOWN_DROP_REASONS, set(dropped) - KNOWN_DROP_REASONS
     kept = [s for s in corpus if routing.slug_drop_reason(s) is None]
-    assert len(kept) == 132
+    # the denylist is a filter, not a wall: the genuine majority must survive it.
+    assert len(kept) > len(corpus) * 0.8, f"denylist ate {len(corpus) - len(kept)} of {len(corpus)}"
+    capsys.readouterr()
+
+
+def test_every_taggable_slug_is_actually_emitted_by_build_tags(capsys):
+    """🔴 THE MUTE-BUTTON GUARD. Everything else here checks the LAYERS; this checks what
+    `build_tags` actually emits, as a SET EQUALITY against what the layers say is taggable.
+
+    Without it the corpus suite is satisfied by a guard that emits nothing at all — a
+    mutation making `build_tags` return `[]` for any slug containing `/` or `_` passed the
+    whole suite before this assertion existed. A guard that silently over-drops is exactly
+    the failure this feature cannot detect in production, because a dropped tag is silent
+    BY DESIGN. Set equality (not a count) is what makes this survive corpus growth: a
+    single wrongly-muted slug fails it at any vocabulary size."""
+    import clawgate  # noqa: PLC0415
+    corpus = _slug_corpus()
+    kept = [s for s in corpus if routing.slug_drop_reason(s) is None]
     taggable = [s for s in kept if clawgate.normalize_tags([f"initiative:{s}"])]
-    assert len(taggable) == 129
-    # 🔴 THE POSITIVE SIDE, pinned through the REAL emission path. Everything above counts
-    # the LAYERS; this counts what `build_tags` actually emits. Without it the corpus
-    # suite is satisfied by a guard that emits nothing at all — a mutation making
-    # build_tags return [] for any slug containing '/' or '_' passed the whole 308-test
-    # suite. A guard that silently over-drops is exactly the failure this feature cannot
-    # detect in production, because a dropped tag is silent BY DESIGN.
     emitted = [s for s in corpus if clawgate.build_tags({"initiative": s})]
-    assert len(emitted) == 129
-    assert emitted == taggable          # and it is the SAME set, not merely the same size
+    assert taggable, "no slug in the corpus is taggable — the guard has muted everything"
+    assert emitted == taggable          # the SAME set, in order — not merely the same size
+    # non-vacuity for the `/`-and-`_` mute mutation specifically: if the corpus ever loses
+    # every slug using the wider tag charset, that mutation would pass unnoticed.
+    plain = set("abcdefghijklmnopqrstuvwxyz0123456789-")
+    assert [s for s in taggable if set(s) - plain], (
+        "no taggable slug exercises the wider tag charset (._/) — the mute mutation would "
+        "pass VACUOUSLY; add such a slug to the fixture")
+    # and the grammar layer keeps the majority it is handed (an over-strict cap would show
+    # up here rather than as a mysteriously shrinking tag rate in production).
+    assert len(taggable) > len(kept) * 0.9, f"only {len(taggable)} of {len(kept)} taggable"
     capsys.readouterr()
 
 
@@ -418,13 +469,23 @@ def _live_slugs() -> list[str]:
     """Read `initiatives.current` from the homelab mailbox Postgres (the same command the
     fixture header documents). ONLY ever called from the opt-in test below."""
     kubeconfig = os.environ.get(KUBECONFIG_ENV) or str(DEFAULT_KUBECONFIG)
-    proc = subprocess.run(
-        ["kubectl", "--kubeconfig", kubeconfig, "-n", "mailbox",
-         "exec", "mailbox-postgres-0", "--", "sh", "-c",
-         'psql -U ${POSTGRES_USER:-mail} -d ${POSTGRES_DB:-mail} '
-         '-tAc "select slug from initiatives.current order by 1;"'],
-        capture_output=True, text=True, timeout=120,
-    )
+    try:
+        proc = subprocess.run(
+            ["kubectl", "--kubeconfig", kubeconfig, "-n", "mailbox",
+             "exec", "mailbox-postgres-0", "--", "sh", "-c",
+             'psql -U ${POSTGRES_USER:-mail} -d ${POSTGRES_DB:-mail} '
+             '-tAc "select slug from initiatives.current order by 1;"'],
+            capture_output=True, text=True, timeout=120,
+        )
+    except FileNotFoundError:
+        # no kubectl on PATH — the rc branch below never runs, so without this the
+        # opt-in check dies on a raw traceback instead of saying what to install.
+        pytest.fail("live store read failed: `kubectl` is not on PATH (the drift check "
+                    "shells out to it); install it or unset " + LIVE_DRIFT_ENV)
+    except subprocess.TimeoutExpired:
+        pytest.fail("live store read timed out after 120s — the homelab cluster is "
+                    f"unreachable from here (kubeconfig {kubeconfig}); unset "
+                    f"{LIVE_DRIFT_ENV} to skip the check")
     if proc.returncode != 0:
         pytest.fail(f"live store read failed (rc={proc.returncode}); set {KUBECONFIG_ENV} "
                     f"if the kubeconfig is not at {DEFAULT_KUBECONFIG}\n{proc.stderr[-800:]}")
@@ -432,7 +493,7 @@ def _live_slugs() -> list[str]:
 
 
 @pytest.mark.skipif(
-    not os.environ.get(LIVE_DRIFT_ENV),
+    not _live_drift_enabled(),
     reason=f"live-store drift check is opt-in: set {LIVE_DRIFT_ENV}=1 (needs the homelab "
            f"kubeconfig; override its path with {KUBECONFIG_ENV})",
 )

--- a/scripts/repo-cos/tests/test_scan_cli.py
+++ b/scripts/repo-cos/tests/test_scan_cli.py
@@ -2,6 +2,7 @@
 
 These exercise the CLI wiring without any network (--no-llm never touches OpenRouter).
 """
+import subprocess
 import sys
 from pathlib import Path
 
@@ -329,13 +330,33 @@ def test_cmd_scan_threads_resolved_initiative_slugs_into_last_emailed(tmp_path, 
     # no-ops and a REAL digest goes out before the assertions below fail. So block the
     # two send seams as well, and — because `send_digest`'s `_relay`/`_sender` defaults
     # are bound at DEF time and would keep pointing at the originals — the smtplib
-    # constructor underneath both of them, which is what actually opens the socket.
+    # constructors underneath both of them, which is what actually opens the socket.
+    #
+    # BOTH constructors: `smtplib.SMTP` is the load-bearing one today (both paths use
+    # STARTTLS), but "switch the relay/Gmail hop to implicit TLS" is a one-line refactor
+    # that would move the socket to `SMTP_SSL` and silently reopen this hole.
+    #
+    # And `_relay_send`'s `subprocess.Popen`, for a narrower reason: it spawns a
+    # `kubectl port-forward` against the PRODUCTION cluster BEFORE it reaches smtplib. If
+    # the outer stubs ever fail to hold, blocking the send is not enough — a unit test
+    # must not touch prod at all. Swapped via a shim bound to email_send's module global
+    # (NOT `setattr(email_send.subprocess, "Popen", …)`, which mutates the ONE shared
+    # `subprocess` module and breaks the scan's own git calls) so only this module's Popen
+    # is blocked and `subprocess.run`/`DEVNULL`/`PIPE` stay real.
     def _no_network(*a, **kw):
         raise AssertionError("a REAL send was attempted — the send stub did not hold")
+
+    class _PopenBlocked:
+        Popen = staticmethod(_no_network)
+
+        def __getattr__(self, name):        # everything else forwards to the real module
+            return getattr(subprocess, name)
 
     monkeypatch.setattr(email_send, "_relay_send", _no_network)
     monkeypatch.setattr(email_send, "_smtp_send", _no_network)
     monkeypatch.setattr(email_send.smtplib, "SMTP", _no_network)
+    monkeypatch.setattr(email_send.smtplib, "SMTP_SSL", _no_network)
+    monkeypatch.setattr(email_send, "subprocess", _PopenBlocked())
 
     args = scan.build_parser().parse_args(["--email", "--repos", str(dev)])
     assert scan.cmd_scan(args) == 0


### PR DESCRIPTION
Small hardening pass on `repo-cos`'s `guard_tags`, plus four nits. **Everything here is latent-only — no live defect.** The point is to remove traps before someone follows the documented `runbook:` seam into them. Deliberately the last round on this code path; the diff stays inside `scripts/repo-cos/`.

## Fix 1 — `guard_tags` broke both of its own invariants on non-list input

PR #204 promoted `guard_tags` to a public, documented API that the `runbook:` seam docstring points future implementers at. On non-list input it violated the two things it exists to guarantee:

1. **It raised.** The `except` wrapped only `str(item)`, not the loop header, so `guard_tags(5)` / `guard_tags(object())` threw `TypeError` — contradicting its own docstring ("the untagged Task is still posted either way") and the module-wide `# a tag must NEVER cost an approval`.
2. **It silently emitted garbage.** `str`/`bytes`/`dict` are iterable and got consumed element-wise:

   | input | old output |
   |---|---|
   | `guard_tags("initiative:remix")` | `['a','e','i','m','n','r','t','v','x']` |
   | `guard_tags(b"initiative:x")` | `['101','105','110',…]` |
   | `guard_tags({"a": 1})` | `['a']` |

   A caller passing a bare tag string instead of `[tag]` is the most plausible future mistake here, and nine single-letter tags is the worst possible answer to it.

Now only `list`/`tuple` is accepted; anything else returns `[]` and logs the shape it refused. `None` stays quiet — it is the normal "no tags" case.

## Fix 2 — the per-tag rewrite loosened the guard for non-string elements

`guard_tags([123])` returned `['123']`. The old whole-list guard dropped it (`normalize_tags([123]) == ['123'] != [123]`). `str(item)` is itself a mutation, and it is the one mutation the guard compares *after* rather than *against* — so a non-string element laundered itself past the equality check. Non-string elements are now dropped like any other offender, without costing valid siblings. Only the type name is logged: an arbitrary object's `__repr__` can itself raise.

## Corpus counts → properties

The fixture went stale for the **third time in three days**: live `initiatives.current` is now **144** (`scope-civitai-cli-listing-media` *and* `app-blocks-batch-d-platform-scope`, the latter having appeared while this change was being written — which is the churn itself). That is exactly what the drift check was added to make unnecessary.

The absolute count assertions (`len(corpus) == 142`, `len(kept) == 132`, `len(taggable) == 129`, a per-reason `Counter`) are replaced by **property assertions** that hold at any vocabulary size:

- `emitted == taggable` — set equality, the mute-button guard (**kept from #204**)
- every emitted tag equals its ledger slug byte-for-byte (**kept from #204**)
- the denylist drops something (a rule set that dropped nothing would be a silent no-op) and does not eat the vocabulary
- every drop names a reason from a **pinned reason set** — a new/renamed reason is a behaviour change and surfaces as a failure
- the fixture is well-formed (non-trivial, unique, whitespace-clean) so nothing above passes vacuously

Refreshing the snapshot now requires **no counts re-stated anywhere** — paste the new `select` output under the header and stop. Today's figures (144 / 134 / 131 / 131) are recorded in the fixture header, the test docstrings and the README as *context, not assertions*.

### 🔴 Mute-mutation result

Re-ran the `/`-and-`_` mute on `build_tags` (`if "/" in keep or "_" in keep: return []`) against the new suite:

```
FAILED test_approve.py::test_build_tags_emitted_tag_always_equals_its_slug_exactly
FAILED test_routing.py::test_every_taggable_slug_is_actually_emitted_by_build_tags
2 failed, 328 passed, 1 skipped
```

**Still caught.** The new test additionally asserts non-vacuity: if the corpus ever loses every slug using the wider tag charset (`_ . /` — today only `svi_loop_recipe`), it fails loudly rather than letting that mutation pass unnoticed.

## Nits

- **`REPO_COS_LIVE_DRIFT_CHECK=0` ENABLED the check.** `not os.environ.get(...)` made every non-empty value opt *in*, so `=0`/`=false` performed a live cross-cluster read from an otherwise hermetic suite (verified by running it). `0`/`false`/`no`/`off`/empty are now off, case-insensitive; inline comment, fixture header and README fixed too.
- **`_live_slugs` handled only `returncode != 0`** — a missing `kubectl` raised a raw `FileNotFoundError` and a hang a `TimeoutExpired`, instead of the actionable `pytest.fail` the rc path gives. Both are now caught with messages naming the fix.
- **`--email` hardening covered `SMTP` but not `SMTP_SSL`.** The PR's core reasoning is right (`email_send.py:238` binds `_relay`/`_sender` at def time, so the `smtplib.SMTP` patch is load-bearing) — but "switch to implicit TLS" is exactly the refactor that silently reopens the hole. Also blocked `smtplib.SMTP_SSL`, and `_relay_send`'s `subprocess.Popen` — in the hypothesised no-op-stub scenario it spawns a `kubectl port-forward` against the **production cluster** before reaching smtplib. Popen is swapped via an `email_send`-local shim; `setattr(email_send.subprocess, "Popen", …)` mutates the one shared `subprocess` module and broke the scan's own git calls (caught in test).
- **Dangling citation:** `clawgate.py`'s reference to `scripts/initiatives/tasks.py` is on neither `main` nor any merged branch — it lands only with the still-open #202. The cited semantics are accurate, so it is marked **forthcoming** rather than removed.

## Gate

```
nix-shell -p 'python3.withPackages(p:[p.pytest p.requests p.psycopg2])' \
  --run 'python -m pytest scripts/repo-cos/tests -q'
```

- baseline **311 passed, 1 skipped** → **330 passed, 1 skipped** (+19)
- **network-free confirmed**: the default suite passes inside an isolated network namespace (`unshare -rn`); the single skip is the opt-in drift check
- opt-in drift check re-run against the refreshed fixture: **1 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
