### PR TITLE
docs(browser): lead the quick-start with whoami (orient-first)

### DIFF
--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -14,10 +14,17 @@ skill dir is symlinked). Don't hunt for it under `~/.claude/skills/...`.
 
 ```bash
 BB=~/workspace/devrc/scripts/browser-bridge/browser   # ← the executable
+$BB whoami                          # ORIENT FIRST — which HOST (laptop/workbench; both are hostname 'nixos'),
+                                    #   which profiles/instances are connected, loaded-vs-repo extension version.
+                                    #   Run this BEFORE grabbing the browser so you know which machine/profile you're driving.
 $BB health                          # is an extension connected?
 $BB --instance <key> open <url>     # open a NEW tab this session owns
 $BB --instance <key> --tab <id> html   # act on a specific tab
 ```
+
+**Orientation rule:** on a fresh browser task, run `whoami` first (both hosts are
+hostname `nixos`, and this session's loopback bridge could be either machine with
+multiple profiles) — confirm the host + pick the right `--instance` before acting.
 
 ## ⚠ The LOADED extension may be older than this doc
 


### PR DESCRIPTION
Promotes `browser whoami` to the first step of the skill's Quick start so an agent orients (which host/profile — both hosts are hostname `nixos`) before grabbing the browser. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)