### PR TITLE
fix(bash-guard): block quoted and bundled blind-stage forms

### DIFF
--- a/scripts/claude-hooks/bash-guard.py
+++ b/scripts/claude-hooks/bash-guard.py
@@ -38,10 +38,24 @@ security guard with a rotating cast of bypasses.
 import sys, json, re, ipaddress
 
 
+# Blind-stage forms. Quotes are STRIPPED from the argument text before matching,
+# because the shell removes them too: `git add "-A"`, `git add '-A'` and
+# `git add "."` all stage everything, but were invisible to a match that
+# required whitespace around the flag (each verified to stage every file).
+# `-[A-Za-z]*A[A-Za-z]*` catches BUNDLED short flags (`-Av`, `-vA`, `-uA`) --
+# `-A` is the only uppercase-A short option `git add` has, so this cannot
+# collide with -n/-v/-f/-i/-p/-e/-u/-N.
+# `--no-ignore-removal` is git's documented alias for `--all`.
+# Erring toward over-matching is deliberate: this guard fails CLOSED, and a
+# false positive costs one `git add <path>` retype.
+_BLIND_FLAG = re.compile(r"(^|\s)(-[A-Za-z]*A[A-Za-z]*|--all|--no-ignore-removal)(\s|$)")
+_BLIND_PATH = re.compile(r"(^|\s)(\.|:/)(\s|$)")
+
+
 def check_git_add_all(cmd):
     for m in re.finditer(r"\bgit\s+add\b([^&|;\n]*)", cmd):
-        args = m.group(1)
-        if re.search(r"(^|\s)(-A|--all)(\s|$)", args) or re.search(r"(^|\s)\.(\s|$)", args):
+        args = m.group(1).replace('"', "").replace("'", "")
+        if _BLIND_FLAG.search(args) or _BLIND_PATH.search(args):
             return ("`git add -A` / `git add --all` / `git add .` is blocked by your RULES "
                     "(never blind-stage — it sweeps up unrelated working-tree changes and has "
                     "caused near-miss leaks). Stage specific paths instead: `git add <path> ...`. "

--- a/scripts/claude-hooks/tests/test_bash_guard.py
+++ b/scripts/claude-hooks/tests/test_bash_guard.py
@@ -67,6 +67,26 @@ CASES = [
     ("real add -A after a commit",    f'git commit -m "ok" && {ADDA}', True),
     ("explicit path staging",         "git a" + "dd clusters/foo.yaml", False),
 
+    # --- blind-stage forms that evaded the whitespace-bounded match ----
+    # Each was verified to stage every file in a throwaway repo (round-4 audit).
+    ("blind: double-quoted -A",       'git a' + 'dd "-A"', True),
+    ("blind: single-quoted -A",       "git a" + "dd '-A'", True),
+    ("blind: quoted --all",           "git a" + "dd '--all'", True),
+    ("blind: bundled -Av",            "git a" + "dd -Av", True),
+    ("blind: bundled -vA",            "git a" + "dd -vA", True),
+    ("blind: quoted dot",             'git a' + 'dd "."', True),
+    ("blind: single-quoted dot",      "git a" + "dd '.'", True),
+    ("blind: --no-ignore-removal",    "git a" + "dd --no-ignore-removal", True),
+    ("blind: root pathspec :/",       "git a" + "dd :/", True),
+    # ...without over-blocking ordinary staging
+    ("ok: -p patch mode",             "git a" + "dd -p", False),
+    ("ok: -u with a path",            "git a" + "dd -u src/", False),
+    ("ok: -N intent-to-add",          "git a" + "dd -N newfile.txt", False),
+    ("ok: relative path ./src",       "git a" + "dd ./src/main.go", False),
+    ("ok: quoted path with spaces",   'git a' + 'dd "my file.txt"', False),
+    ("ok: path containing a dot",     "git a" + "dd foo.yaml", False),
+    ("ok: file named A",              "git a" + "dd A", False),
+
     # --- was-a-bypass under _strip_message_text: MUST STAY BLOCKED ------
     # round 1: same-tag heredoc / substitution / stale offsets / escaped quote
     ("was-bypass: 2nd heredoc same tag",


### PR DESCRIPTION
Closes the pre-existing gap the round-4 audit of #217 found. It predates that PR and was out of scope for a revert.

## The gap

`check_git_add_all` required the flag to be surrounded by whitespace, so the shell's own quote removal walked straight past it. **Nine forms were allowed.** Each was *executed* in a throwaway repo and confirmed to stage every file, including brand-new untracked ones:

| form | staged | guard on `main` |
|---|---|---|
| `git add "-A"` | all 4 | **allow** |
| `git add '-A'` | all 4 | **allow** |
| `git add '--all'` | all 4 | **allow** |
| `git add -Av` | all 4 | **allow** |
| `git add -vA` | all 4 | **allow** |
| `git add "."` | all 4 | **allow** |
| `git add '.'` | all 4 | **allow** |
| `git add --no-ignore-removal` | all 4 | **allow** |
| `git add :/` | all 4 | **allow** |

This is the rule the hook exists to enforce — "never blind-stage; it sweeps up unrelated WIP and secrets, and has caused near-miss leaks."

## The fix

- **Strip quotes before matching**, because the shell does too.
- **Match bundled short flags** via `-[A-Za-z]*A[A-Za-z]*`. `-A` is the only uppercase-A short option `git add` has, so this cannot collide with `-n`/`-v`/`-f`/`-i`/`-p`/`-e`/`-u`/`-N`.
- Add `--no-ignore-removal`, git's documented alias for `--all`.
- Add the `:/` root pathspec.

Erring toward over-matching is deliberate: this guard **fails closed**, and a false positive costs one `git add <path>` retype, whereas a miss is the leak the rule exists to prevent.

## Verification

- All 9 forms: `allow` → `block` against `main` (`f6c4a7b`).
- 7 ordinary forms stay allowed on both revisions: `-p`, `-u src/`, `-N newfile.txt`, `./src/main.go`, `"my file.txt"`, `foo.yaml`, and a file literally named `A`.
- Suite 42/42, wired into `scripts/run-tests.sh`.

Known and accepted: `git add -- -A` (staging a file literally named `-A`) is blocked. Fails closed; vanishingly rare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
