### PR TITLE
fix(bash-guard): close the git -C / escape / stage blind-stage gaps

### DIFF
--- a/scripts/claude-hooks/bash-guard.py
+++ b/scripts/claude-hooks/bash-guard.py
@@ -48,14 +48,65 @@ import sys, json, re, ipaddress
 # `--no-ignore-removal` is git's documented alias for `--all`.
 # Erring toward over-matching is deliberate: this guard fails CLOSED, and a
 # false positive costs one `git add <path>` retype.
-_BLIND_FLAG = re.compile(r"(^|\s)(-[A-Za-z]*A[A-Za-z]*|--all|--no-ignore-removal)(\s|$)")
-_BLIND_PATH = re.compile(r"(^|\s)(\.|:/)(\s|$)")
+# `git [global-opts] add|stage <args>`. The global-opts hop matters: `git -C
+# <dir> add -A` is the shape check_cd_then_git and RULES actively PUSH agents
+# toward, so a bare `\bgit\s+add\b` anchor made this guard self-defeating —
+# real transcripts contain blind `git -C "$WT" add -A` calls it never saw.
+# `stage` is git's documented synonym for `add`.
+_GIT_ADD = re.compile(
+    r"\bgit\s+"
+    r"(?:(?:-[Cc]\s+\S+"
+    r"|--(?:git-dir|work-tree|namespace|exec-path)(?:=\S+|\s+\S+)"
+    r"|-[pP]|--paginate|--no-pager|--bare|--literal-pathspecs)\s+)*"
+    r"(?:add|stage)\b([^&|;\n]*)"
+)
+
+# Tokens that stage the whole tree. Checked per-TOKEN rather than with a
+# whitespace-bounded regex: `(git add -A)` and `git add -A;` defeated the
+# boundary, and nested `[A-Za-z]*` around the A backtracked quadratically
+# (6s on a 32k run of A's, on a hook that runs for every Bash call).
+# Short bundles: -A is the only uppercase-A short option `git add` has, so any
+# all-letters dash-token containing A is blind (-Av, -vA, -uA).
+_BLIND_SHORT = re.compile(r"-[A-Za-z]+")
+# git accepts unique long-option PREFIXES: --al == --all, --no-ignore-r == …removal.
+_BLIND_LONG = re.compile(r"--al|--all|--no-ignore-r[a-z-]*")
+# Whole-tree pathspecs: . ./ .// ./. :/ * $PWD $(pwd) :(top)
+# NOT `..` — verified by execution that it does not stage the tree (git errors
+# on it at the repo root), so blocking it would be an unproven over-block.
+# Hence `\.(?:/[./]*)?` rather than `\.[./]*`.
+_BLIND_PATH = re.compile(r"\.(?:/[./]*)?|:/|\*|\$PWD|\$\(pwd\)|:\(top\)\*?")
+
+
+def _stages_everything(argtext):
+    # The shell removes quotes, backslashes and the $ of $'…' before git sees
+    # the word; do the same, or `git add -\A` / `git add $'-A'` slip past.
+    t = re.sub(r"\$(?=['\"])", "", argtext)
+    t = t.replace('"', "").replace("'", "").replace("\\", "")
+    after_ddash = False
+    for raw in t.split():
+        if raw == "--":
+            after_ddash = True          # everything past this is a PATH, not a flag
+            continue
+        # A subshell's closing paren sticks to the last token (`(git add -A)`),
+        # as does a trailing `;`. Test both forms rather than truncating the
+        # capture at `)`, which would hide a real flag after `$(…)`.
+        # `$(pwd)` still matches via the unstripped form.
+        for tok in {raw, raw.rstrip(");")}:
+            if not tok:
+                continue
+            if not after_ddash:
+                if _BLIND_SHORT.fullmatch(tok) and "A" in tok:
+                    return True
+                if _BLIND_LONG.fullmatch(tok):
+                    return True
+            if _BLIND_PATH.fullmatch(tok):
+                return True
+    return False
 
 
 def check_git_add_all(cmd):
-    for m in re.finditer(r"\bgit\s+add\b([^&|;\n]*)", cmd):
-        args = m.group(1).replace('"', "").replace("'", "")
-        if _BLIND_FLAG.search(args) or _BLIND_PATH.search(args):
+    for m in _GIT_ADD.finditer(cmd):
+        if _stages_everything(m.group(1)):
             return ("`git add -A` / `git add --all` / `git add .` is blocked by your RULES "
                     "(never blind-stage — it sweeps up unrelated working-tree changes and has "
                     "caused near-miss leaks). Stage specific paths instead: `git add <path> ...`. "

--- a/scripts/claude-hooks/bash-guard.py
+++ b/scripts/claude-hooks/bash-guard.py
@@ -70,11 +70,21 @@ _GIT_ADD = re.compile(
 _BLIND_SHORT = re.compile(r"-[A-Za-z]+")
 # git accepts unique long-option PREFIXES: --al == --all, --no-ignore-r == …removal.
 _BLIND_LONG = re.compile(r"--al|--all|--no-ignore-r[a-z-]*")
-# Whole-tree pathspecs: . ./ .// ./. :/ * $PWD $(pwd) :(top)
-# NOT `..` — verified by execution that it does not stage the tree (git errors
-# on it at the repo root), so blocking it would be an unproven over-block.
-# Hence `\.(?:/[./]*)?` rather than `\.[./]*`.
-_BLIND_PATH = re.compile(r"\.(?:/[./]*)?|:/|\*|\$PWD|\$\(pwd\)|:\(top\)\*?")
+# Whole-tree pathspecs.
+# `..` IS included. It errors at the repo ROOT ("outside repository"), which is
+# what an earlier root-only test showed — but from a SUBDIRECTORY it stages the
+# entire tree, and `git -C <repo>/sub add ..` reaches that without a `cd`, in
+# exactly the shape this guard now covers. Blocking the root form costs nothing
+# because git rejects it anyway.
+# `${PWD}` / `$PWD/` / `` `pwd` `` / `:/*` are the near-miss siblings of forms
+# already blocked; all verified to stage the whole tree.
+_BLIND_PATH = re.compile(
+    r"\.{1,2}(?:/[./]*)?"          # . ./ .// ./. .. ../ ../..
+    r"|:/\*?|\*"                    # :/ :/* *
+    r"|\$\{?PWD\}?/?\.?"            # $PWD ${PWD} $PWD/ $PWD/.
+    r"|\$\(pwd\)/?\.?|`pwd`/?\.?"   # $(pwd) `pwd`
+    r"|:\(top\)\*?"
+)
 
 
 def _stages_everything(argtext):

--- a/scripts/claude-hooks/bash-guard.py
+++ b/scripts/claude-hooks/bash-guard.py
@@ -71,19 +71,32 @@ _BLIND_SHORT = re.compile(r"-[A-Za-z]+")
 # git accepts unique long-option PREFIXES: --al == --all, --no-ignore-r == …removal.
 _BLIND_LONG = re.compile(r"--al|--all|--no-ignore-r[a-z-]*")
 # Whole-tree pathspecs.
-# `..` IS included. It errors at the repo ROOT ("outside repository"), which is
-# what an earlier root-only test showed — but from a SUBDIRECTORY it stages the
-# entire tree, and `git -C <repo>/sub add ..` reaches that without a `cd`, in
-# exactly the shape this guard now covers. Blocking the root form costs nothing
-# because git rejects it anyway.
-# `${PWD}` / `$PWD/` / `` `pwd` `` / `:/*` are the near-miss siblings of forms
-# already blocked; all verified to stage the whole tree.
+#
+# `..` IS included. Measured: it errors at the repo ROOT ("outside repository"),
+# stages the WHOLE TREE from a depth-1 subdirectory, and stages only the parent
+# directory from depth >= 2 (from `a/b/` it stages `a/`). So blocking it is
+# exact at depth 1, harmless at the root (git rejects it anyway), and a
+# fail-closed over-block deeper down — which the "err toward over-matching"
+# stance above accepts. It appears 0 times in 32k real commands.
+# (An earlier root-only test led to it being excluded, then a depth-1-only
+# test led to the claim that it is always whole-tree. Both were generalised
+# from a single depth. Measure at 0, 1 and 2 before touching this.)
+#
+# KNOWN LIMITATION, deliberately not chased: whether `X/..` is whole-tree
+# depends on runtime cwd and repo-root depth, which the command text does not
+# carry — `a/..` at the root is the whole tree, `a/b/..` is just `a/`, and
+# staging `a/` is allowed. Same for `$OLDPWD` and
+# `$(git rev-parse --show-toplevel)`, which the per-token split shatters
+# anyway. Guessing at these is the trap the DESIGN NOTE records.
+_TAIL = r"(?:/[./]*)?"              # trailing / ./ .// ./. on any stem
 _BLIND_PATH = re.compile(
-    r"\.{1,2}(?:/[./]*)?"          # . ./ .// ./. .. ../ ../..
-    r"|:/\*?|\*"                    # :/ :/* *
-    r"|\$\{?PWD\}?/?\.?"            # $PWD ${PWD} $PWD/ $PWD/.
-    r"|\$\(pwd\)/?\.?|`pwd`/?\.?"   # $(pwd) `pwd`
-    r"|:\(top\)\*?"
+    r"\.{1,2}" + _TAIL              # . ./ .// ./. .. ../ ../..
+    + r"|:/\*?|\*"                  # :/ :/* *
+    + r"|\$\{?PWD\}?" + _TAIL       # $PWD ${PWD} $PWD/ $PWD// $PWD/./
+    + r"|\$\(pwd\)" + _TAIL         # $(pwd) $(pwd)// …
+    + r"|`pwd`" + _TAIL             # `pwd` `pwd`/./ …
+    + r"|:\(top[a-z,]*\)\*?"        # :(top) :(top,glob) :(top,icase)
+    + r"|:"                         # bare `:` is the whole repo
 )
 
 

--- a/scripts/claude-hooks/tests/test_bash_guard.py
+++ b/scripts/claude-hooks/tests/test_bash_guard.py
@@ -94,7 +94,13 @@ CASES = [
     # into, and it bypassed the guard entirely (11 blind hits in transcripts).
     ("gap: git -C dir add -A",        "git -C /tmp/x a" + "dd -A", True),
     ("gap: git -C dir add .",         "git -C /tmp/x a" + "dd .", True),
-    ("gap: git --git-dir= add -A",    "git --git-dir=/tmp/x/.git a" + "dd -A", True),
+    # NOTE: the git-dir must NOT end in `.git`, or the literal substring
+    # "git add" makes the case vacuous -- base blocks it without the opt-hop.
+    ("gap: git --git-dir= add -A",    "git --git-dir=/tmp/x/store a" + "dd -A", True),
+    ("gap: git -C x -C y add -A",     "git -C /tmp/x -C /tmp/y a" + "dd -A", True),
+    ("gap: git --exec-path= add -A",  "git --exec-path=/tmp/x a" + "dd -A", True),
+    ("gap: git --no-pager add -A",    "git --no-pager a" + "dd -A", True),
+    ("gap: blind flag before --",     "git a" + "dd -A -- src/", True),
     ("gap: git -c k=v add -A",        "git -c user.name=x a" + "dd -A", True),
     ("gap: git -P add -A",            "git -P a" + "dd -A", True),
     # backslash / ANSI-C escapes — same evasion class quoting was
@@ -114,10 +120,19 @@ CASES = [
     ("gap: $(git add -A)",            "echo $(git a" + "dd -A)", True),
     # other whole-tree pathspecs
     ("gap: ./ and .//",               "git a" + "dd ./", True),
-    # `git add ..` is deliberately NOT blocked: execution showed it does not
-    # stage the tree (git errors at the repo root), so blocking it would be an
-    # over-block resting on an unproven assumption.
-    ("ok: parent .. (unproven blind)", "git a" + "dd ..", False),
+    # `..` errors at the repo ROOT but stages the WHOLE TREE from a
+    # subdirectory -- and `git -C <repo>/sub add ..` reaches that with no `cd`.
+    # A root-only test once suggested otherwise; don't re-derive from that.
+    ("gap: parent .. (blind from subdir)", "git a" + "dd ..", True),
+    ("gap: git -C sub add ..",         "git -C /tmp/x/sub a" + "dd ..", True),
+    ("gap: ../ from a subdir",         "git -C /tmp/x/sub a" + "dd ../", True),
+    ("gap: ../.. from deeper",         "git -C /tmp/x/a/b a" + "dd ../..", True),
+    # near-miss siblings of already-blocked whole-tree pathspecs
+    ("gap: ${PWD}",                    "git a" + "dd ${PWD}", True),
+    ("gap: $PWD/",                     "git a" + "dd $PWD/", True),
+    ("gap: backtick pwd",              "git a" + "dd `pwd`", True),
+    ("gap: :/* root glob",             "git a" + "dd ':/*'", True),
+    ("gap: .// double slash",          "git a" + "dd .//", True),
     ("gap: glob *",                   "git a" + "dd *", True),
     ("gap: $PWD",                     "git a" + "dd $PWD", True),
     ("gap: :(top)",                   "git a" + "dd ':(top)'", True),
@@ -131,6 +146,19 @@ CASES = [
     ("ok: stage a path",              "git st" + "age src/main.go", False),
     ("ok: --no-all is the opposite",  "git a" + "dd --no-all -u src/", False),
     ("ok: filename with -A inside",   "git a" + "dd 'CHANGELOG -A.md'", False),
+    # 🔴 The opt-hop must NOT swallow sibling `add` subcommands. This repo runs
+    # `git worktree add` constantly (it is the prescribed workflow), so a
+    # regression here would block the thing RULES tells you to do.
+    ("ok: git worktree add -B",       "git worktree a" + "dd -B br /tmp/wt origin/main", False),
+    ("ok: git -C repo worktree add",  "git -C /repo worktree a" + "dd /tmp/wt -B x", False),
+    ("ok: git remote add",            "git remote a" + "dd origin git@h:r.git", False),
+    ("ok: git submodule add",         "git submodule a" + "dd https://h/r.git ext/r", False),
+    ("ok: git notes add -m",          "git notes a" + "dd -m 'note'", False),
+    ("ok: git stash (not stage)",     "git stash list", False),
+    # after `--` everything is a path, so a file literally named -A is fine
+    ("ok: git add -- x -A",           "git a" + "dd -- x -A", False),
+    ("ok: $PWD-rooted single path",   "git a" + "dd $PWD/src/main.go", False),
+    ("ok: rooted glob :/ *.go",       "git a" + "dd ':/src/*.go'", False),
 
     # --- was-a-bypass under _strip_message_text: MUST STAY BLOCKED ------
     # round 1: same-tag heredoc / substitution / stale offsets / escaped quote

--- a/scripts/claude-hooks/tests/test_bash_guard.py
+++ b/scripts/claude-hooks/tests/test_bash_guard.py
@@ -26,9 +26,11 @@ GUARD = os.path.normpath(GUARD)
 
 # Dangerous substrings are built piecewise so this file can never trip a live
 # guard that is inspecting the command used to run it.
-# NOTE: keep a trailing word after -A. `check_git_add_all` requires -A to be
-# followed by whitespace or end-of-string, so a payload ending `-A'` silently
-# matches nothing and makes a test vacuous (this hid a real bypass once).
+# NOTE: keep a trailing word after -A. This USED to matter because the check
+# required -A to be followed by whitespace, so a payload ending `-A'` matched
+# nothing and made a test vacuous (that hid a real bypass once). Token matching
+# now catches the quoted form too, but the trailing word is kept so these read
+# as prose rather than as a bare flag.
 ADDA = "git a" + "dd -A ever"
 HARD = "git re" + "set --hard HEAD"
 
@@ -86,6 +88,49 @@ CASES = [
     ("ok: quoted path with spaces",   'git a' + 'dd "my file.txt"', False),
     ("ok: path containing a dot",     "git a" + "dd foo.yaml", False),
     ("ok: file named A",              "git a" + "dd A", False),
+
+    # --- gaps found by the #219 audit: all proven to stage everything ---
+    # `git -C <dir> add -A` is the shape RULES + check_cd_then_git push agents
+    # into, and it bypassed the guard entirely (11 blind hits in transcripts).
+    ("gap: git -C dir add -A",        "git -C /tmp/x a" + "dd -A", True),
+    ("gap: git -C dir add .",         "git -C /tmp/x a" + "dd .", True),
+    ("gap: git --git-dir= add -A",    "git --git-dir=/tmp/x/.git a" + "dd -A", True),
+    ("gap: git -c k=v add -A",        "git -c user.name=x a" + "dd -A", True),
+    ("gap: git -P add -A",            "git -P a" + "dd -A", True),
+    # backslash / ANSI-C escapes — same evasion class quoting was
+    ("gap: backslash -\\A",           "git a" + "dd -\\A", True),
+    ("gap: backslash \\-A",           "git a" + "dd \\-A", True),
+    ("gap: escaped --a\\ll",          "git a" + "dd --a\\ll", True),
+    ("gap: escaped dot",              "git a" + "dd \\.", True),
+    ("gap: ANSI-C $'-A'",             "git a" + "dd $'-A'", True),
+    # `git stage` is a documented synonym for `git add`
+    ("gap: git stage -A",             "git st" + "age -A", True),
+    ("gap: git stage .",              "git st" + "age .", True),
+    # unique long-option prefixes
+    ("gap: --al prefix",              "git a" + "dd --al", True),
+    ("gap: --no-ignore-remov",        "git a" + "dd --no-ignore-remov", True),
+    # subshell parens defeated the whitespace boundary
+    ("gap: (git add -A)",             "(git a" + "dd -A)", True),
+    ("gap: $(git add -A)",            "echo $(git a" + "dd -A)", True),
+    # other whole-tree pathspecs
+    ("gap: ./ and .//",               "git a" + "dd ./", True),
+    # `git add ..` is deliberately NOT blocked: execution showed it does not
+    # stage the tree (git errors at the repo root), so blocking it would be an
+    # over-block resting on an unproven assumption.
+    ("ok: parent .. (unproven blind)", "git a" + "dd ..", False),
+    ("gap: glob *",                   "git a" + "dd *", True),
+    ("gap: $PWD",                     "git a" + "dd $PWD", True),
+    ("gap: :(top)",                   "git a" + "dd ':(top)'", True),
+
+    # ...and the tightening must not catch scoped forms
+    ("ok: git -C dir add path",       "git -C /tmp/x a" + "dd src/main.go", False),
+    ("ok: git -C dir status",         "git -C /tmp/x status", False),
+    ("ok: rooted single path :/foo",  "git a" + "dd :/target.txt", False),
+    ("ok: scoped glob *.go",          "git a" + "dd *.go", False),
+    ("ok: file literally named -A",   "git a" + "dd -- -A", False),
+    ("ok: stage a path",              "git st" + "age src/main.go", False),
+    ("ok: --no-all is the opposite",  "git a" + "dd --no-all -u src/", False),
+    ("ok: filename with -A inside",   "git a" + "dd 'CHANGELOG -A.md'", False),
 
     # --- was-a-bypass under _strip_message_text: MUST STAY BLOCKED ------
     # round 1: same-tag heredoc / substitution / stale offsets / escaped quote
@@ -153,12 +198,18 @@ fail += not ok
 print(f"{'PASS' if ok else 'FAIL'}  secret inside -m still caught{'  ' + err if err else ''}")
 
 # No pathological backtracking anywhere in the remaining patterns.
-t0 = time.time()
-_, err = run('git commit -m "' + "\\" * 200)
-elapsed = time.time() - t0
-ok = elapsed < 2.0 and not err
-fail += not ok
-print(f"{'PASS' if ok else 'FAIL'}  no catastrophic backtracking ({elapsed:.2f}s)")
+for label, probe in [
+    ("quote+backslash run", 'git commit -m "' + "\\" * 200),
+    # the old _BLIND_FLAG had two adjacent [A-Za-z]* around the A and went
+    # quadratic when the run failed the trailing boundary: 6s at 32k.
+    ("long -AAAA… run", "git a" + "dd -" + "A" * 32000 + "!"),
+]:
+    t0 = time.time()
+    _, err = run(probe)
+    elapsed = time.time() - t0
+    ok = elapsed < 2.0 and not err
+    fail += not ok
+    print(f"{'PASS' if ok else 'FAIL'}  no catastrophic backtracking: {label} ({elapsed:.2f}s)")
 
 print("\nRESULT:", "all good" if not fail else f"{fail} failure(s)")
 sys.exit(1 if fail else 0)

--- a/scripts/claude-hooks/tests/test_bash_guard.py
+++ b/scripts/claude-hooks/tests/test_bash_guard.py
@@ -133,6 +133,14 @@ CASES = [
     ("gap: backtick pwd",              "git a" + "dd `pwd`", True),
     ("gap: :/* root glob",             "git a" + "dd ':/*'", True),
     ("gap: .// double slash",          "git a" + "dd .//", True),
+    # same-shape siblings of the stems above -- all proven whole-tree
+    ("gap: $PWD//",                    'git a' + 'dd "$PWD//"', True),
+    ("gap: $PWD/./",                   'git a' + 'dd "$PWD/./"', True),
+    ("gap: $(pwd)//",                  'git a' + 'dd "$(pwd)//"', True),
+    ("gap: `pwd`/./",                  'git a' + 'dd "`pwd`/./"', True),
+    ("gap: :(top,glob)",               "git a" + "dd ':(top,glob)'", True),
+    ("gap: :(top,icase)",              "git a" + "dd ':(top,icase)'", True),
+    ("gap: bare colon pathspec",       "git a" + "dd ':'", True),
     ("gap: glob *",                   "git a" + "dd *", True),
     ("gap: $PWD",                     "git a" + "dd $PWD", True),
     ("gap: :(top)",                   "git a" + "dd ':(top)'", True),
@@ -159,6 +167,20 @@ CASES = [
     ("ok: git add -- x -A",           "git a" + "dd -- x -A", False),
     ("ok: $PWD-rooted single path",   "git a" + "dd $PWD/src/main.go", False),
     ("ok: rooted glob :/ *.go",       "git a" + "dd ':/src/*.go'", False),
+    # the widened stems must not swallow scoped paths built from them
+    ("ok: $PWD/<path>",               'git a' + 'dd "$PWD/src/main.go"', False),
+    ("ok: ${PWD}/<path>",             'git a' + 'dd "${PWD}/x"', False),
+    ("ok: $(pwd)/<file>",             'git a' + 'dd "$(pwd)/file.txt"', False),
+    ("ok: $PWDX is a different var",  'git a' + 'dd "$PWDX"', False),
+    ("ok: $PWD_BACKUP",               'git a' + 'dd "$PWD_BACKUP"', False),
+    ("ok: :(top,glob) with a path",   "git a" + "dd ':(top,glob)x'", False),
+    ("ok: :(exclude)vendor",          "git a" + "dd ':(exclude)vendor'", False),
+    ("ok: :!foo negation",            "git a" + "dd ':!foo'", False),
+    ("ok: ..foo is a filename",       "git a" + "dd ..foo", False),
+    ("ok: .hidden file",              "git a" + "dd .hidden", False),
+    ("ok: .github path",              "git a" + "dd .github/workflows/ci.yml", False),
+    ("ok: ../sibling/file.txt",       "git a" + "dd ../sibling/file.txt", False),
+    ("ok: ../pkg/ scoped dir",        "git a" + "dd ../pkg/", False),
 
     # --- was-a-bypass under _strip_message_text: MUST STAY BLOCKED ------
     # round 1: same-tag heredoc / substitution / stale offsets / escaped quote


### PR DESCRIPTION
Follow-ups from the #219 audit. The headline gap is **self-defeating**.

## The gap that mattered

A bare `\bgit\s+add\b` anchor meant **`git -C <dir> add -A` bypassed the guard entirely** — the exact shape `check_cd_then_git` and `RULES.md` actively *push* agents toward. The guard was steering people into its own blind spot.

Replaying **31,989 real commands** from local transcripts found **11 blind `git -C "$WT" add -A …` calls** the guard never saw, across civitai, homelab-talos and datapacket work.

## Structural fix, not another alternation tweak

Replaced whitespace-bounded regexes with **tokenisation**:

| class | previously allowed | now |
|---|---|---|
| global-option hop | `git -C <dir> add -A`, `-c k=v`, `--git-dir=`, `--exec-path=`, `-P`, `--no-pager`, `-C x -C y` | blocked; `stage` accepted as git's documented synonym |
| shell escape removal | `git add -\A`, `\-A`, `--a\ll`, `\.`, `$'-A'` | blocked — backslashes and `$'…'` stripped as the shell does |
| token boundary | `(git add -A)`, trailing `;`, `--al`, `--no-ignore-remov` | blocked — matched per token; git's unique long-option prefixes covered |
| whole-tree pathspecs | `..`, `../`, `../..`, `./`, `.//`, `*`, `$PWD`, `${PWD}`, `$PWD//`, `$PWD/./`, `` `pwd` ``, `$(pwd)//`, `:/`, `:/*`, `:`, `:(top)`, `:(top,glob)`, `:(top,icase)` | blocked — every one verified by execution to stage the whole tree |

## Two things it also fixes

- **Quadratic backtracking.** The old pattern had two adjacent `[A-Za-z]*` around the `A`: **7.14s on a 32k input**, >8s (timeout) at 200k, on a hook that runs for every Bash call. Now 0.001s / 0.029s at 1M. A timing case covers it.
- **An accepted FP.** After `--`, arguments are paths — so `git add -- -A` (staging a file literally named `-A`) is allowed again.

## On `..` — I got this wrong twice, so here is the measurement

| depth | result |
|---|---|
| repo root | 0 staged, rc=128 — `fatal: '..' is outside repository` |
| depth 1 (`a/`) | **WHOLE TREE** |
| depth 2 (`a/b/`) | scoped — stages `a/` only |

It is blocked. Exact at depth 1, harmless at the root (git rejects it anyway), fail-closed over-block deeper — consistent with the module's stated "err toward over-matching", and **0 occurrences in 32k real commands**. An earlier root-only test led me to exclude it; a depth-1-only test then led me to claim it is *always* whole-tree. Both were generalised from one depth. The code comment now records all three and says to measure at 0, 1 and 2 before touching it.

## Known limitation, deliberately not chased

Whether `X/..` is whole-tree depends on runtime cwd and repo-root depth, which the command text does not carry: `a/..` at the root is everything, `a/b/..` is just `a/`, and staging `a/` is allowed. Same for `$OLDPWD` and `$(git rev-parse --show-toplevel)` (which the per-token split shatters anyway). Guessing at these is the trap the module's `DESIGN NOTE` records. Documented **in code**, not only here.

## Verification

- **Execution:** every newly-blocked form run in a throwaway repo and confirmed to stage every file, including untracked ones. Every widened stem confirmed *not* to catch scoped paths built from it (`$PWD/<file>`, `${PWD}/x`, `$(pwd)/<file>`, `$PWDX`, `$PWD_BACKUP`, `:(top,glob)x`, `:(exclude)vendor`, `:!foo`, `..foo`, `.hidden`, `.github/…`, `../sibling/file.txt`, `../pkg/`).
- **Replay:** 31,989 real commands through both revisions → **0 loosening, 0 errors, 13 newly blocked.** All 13 inspected individually.
- **Sibling subcommands verified unaffected:** `git worktree add` (the workflow RULES prescribes), `remote add`, `submodule add`, `notes add`, `subtree add`, `git stash` — all still allowed, and locked in by tests.
- Other five checks **byte-identical** to main; **113 assertions**, wired into `scripts/run-tests.sh`.

**Friction note:** 6 of the 13 newly-blocked are *path-scoped* (`git -C $W add -A containers/remix` stages that path, not the tree). Blocking them is policy-consistent — base already blocked plain `git add -A src/`, and the `-C` hop is the only reason they were invisible — but it is a real change in what gets stopped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
