### PR TITLE
docs(browser-bridge): cookie limits + the in-page credentialed-fetch pattern

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -139,6 +139,57 @@ permission. This can be scoped down later; noted in `extension/README.md`. The C
 layer's own bounded security model (own-tab-only attach, no raw-CDP passthrough,
 always-detach) is in the **CDP ops** section below.
 
+### No cookie op — deliberate (decided 2026-07-30)
+
+There is **no `cookies` op** in the CLI, `server.py` or the extension, and the
+manifest deliberately does **not** request the `cookies` permission (verified:
+`permissions` is `["scripting","tabs","activeTab","storage","alarms","debugger",
+"webNavigation"]`). A cookie-read op is credential exfiltration by definition —
+it hands a live session token to a caller. Adding one would mean, at minimum:
+hard-denying it to the autonomous browser-agent the way `upload` is (see
+*opencode browser-agent*), audit-logging every read, and accepting that session
+tokens land in Claude transcripts, which persist on disk. The value it buys does
+not justify that, because the sanctioned alternative below covers the real use
+case without any of it. **Recorded so it isn't re-litigated.**
+
+Consequences to know:
+
+- `document.cookie` via `eval` is the ONLY cookie surface, and it cannot see
+  **HttpOnly** cookies — i.e. essentially every session/auth cookie. The cookie
+  that matters is exactly the invisible one.
+- On a CSP-strict origin the injected script doesn't run at all, so a cookie read
+  there returns `null` with no error, indistinguishable from a broken bridge.
+
+**Sanctioned pattern: don't extract the cookie — make the request from inside the
+page.** An in-page `fetch(url, {credentials:"include"})` run through `eval`
+attaches the cookies (HttpOnly included) automatically and returns only the
+response data. It needs no new permission and keeps credential *values* out of
+Claude's context and off disk. `eval` takes one expression, so use an async IIFE;
+the promise is awaited (`chrome.scripting` on the top frame, CDP
+`awaitPromise:true` for `--frame`), so you get the resolved value:
+
+```bash
+browser js '(async function(){ const r = await fetch("/api/thing", {credentials:"include"}); return JSON.stringify({status:r.status, body:(await r.text()).slice(0,500)}) })()'
+```
+
+Verified live 2026-07-30 against real Brave (laptop, both profiles):
+
+- Same origin (`openrouter.ai`), same path, status only: `credentials:"include"`
+  → **404**, `credentials:"omit"` → **401**. The differing status proves the
+  HttpOnly session cookie WAS attached by the in-page fetch, with no cookie value
+  ever crossing into the transcript.
+- `(async function(){ return "resolved:"+(1+1) })()` → `"resolved:2"`, confirming
+  the async-IIFE shape yields a resolved value, not a pending Promise.
+- CSP contrast: on a `github.com` tab `browser js 'location.host'` → `null` (no
+  error) while `text`/`html` work; the identical eval on `openrouter.ai` →
+  `"openrouter.ai"`.
+
+**Limitation, stated plainly:** the in-page fetch pattern does NOT work on
+CSP-strict origins (GitHub, Discord, …) — no injected script runs there, so an
+authenticated API call through the page is unavailable and `text`/`html` are the
+only reads. (The recipe is verified mechanically and credential-wise as above; it
+has not been exercised against a third-party authenticated API beyond that.)
+
 ## Ops
 
 | op | maps to | returns |

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -72,6 +72,29 @@ doesn't take (the op still returns `unknown_op`, or `health` still shows the old
 So on a `null`: first suspect a multi-statement body, then page CSP; fall back to
 `text`/`html` before concluding the bridge is down.
 
+### Cookies and authenticated requests
+
+**There is no cookie op** — the extension has no `cookies` permission, on purpose
+(README → *Security model*). So `eval` + `document.cookie` is the only route, and
+it is structurally blind to **HttpOnly** cookies — which is exactly what a session
+/ auth cookie always is. On a CSP-strict origin you also just get `null`, which
+reads like a dead bridge.
+
+**Don't extract the cookie — make the request from inside the page.** An in-page
+`fetch(url, {credentials:"include"})` attaches the cookies (HttpOnly included)
+automatically and hands back only the data: no new permission, and no credential
+value ever enters the transcript. `eval` takes ONE EXPRESSION, so use an async
+IIFE — the promise IS awaited (top frame `chrome.scripting`, `--frame` CDP
+`awaitPromise:true`), you get the resolved value, not a pending Promise:
+
+```bash
+browser js '(async function(){ const r = await fetch("/api/thing", {credentials:"include"}); return JSON.stringify({status:r.status, body:(await r.text()).slice(0,500)}) })()'
+```
+
+⚠ **This does NOT work on CSP-strict origins** (GitHub, Discord, …) — the injected
+script never runs there at all, so an authenticated API call *through the page* is
+simply unavailable; `text`/`html` are the only reads that work.
+
 ## The user is USING this browser
 
 It's their live session, not a scratch VM. Don't `nav` a tab that may hold unsaved


### PR DESCRIPTION
Docs only — no CLI, `server.py` or extension changes. A real session tried to read a cookie value through the bridge and failed; both failure modes reproduced live against real Brave. Neither is a bug — they're undocumented **structural** limits, and the missing docs cost that session real time.

## Failure mode 1 — strict page CSP silently kills `eval`

Verified live (laptop, `work` profile, a `github.com` PR tab):

```
browser --instance work js 'location.host'   →  value: null      (no error)
browser --instance personal js 'location.host' (openrouter.ai) →  "openrouter.ai"
```

`text`/`html` on the same GitHub tab work fine. SKILL.md already warned that CSP blocks eval and named GitHub, but never connected it to **cookie reads** — and a `null` from a cookie read looks exactly like a broken bridge.

## Failure mode 2 — `document.cookie` can't see HttpOnly cookies

Verified by inspection: `extension/manifest.json` requests
`["scripting","tabs","activeTab","storage","alarms","debugger","webNavigation"]` — **no `cookies` permission** — and there is **no cookie op** anywhere in the `browser` CLI, `server.py`, or `extension/`. So `eval` + `document.cookie` is the only route, and it is structurally blind to HttpOnly cookies. Session/auth cookies are essentially always HttpOnly, so the cookie that matters is exactly the invisible one.

## The sanctioned pattern (main deliverable)

**Don't extract the cookie — make the request from inside the page.**

```bash
browser js '(async function(){ const r = await fetch("/api/thing", {credentials:"include"}); return JSON.stringify({status:r.status, body:(await r.text()).slice(0,500)}) })()'
```

Needs no new permission, and credential *values* never enter Claude's context or hit disk (transcripts persist).

**Verified live, not assumed:**

- `(async function(){ return "resolved:"+(1+1) })()` → `"resolved:2"` — the async-IIFE shape returns a **resolved value, not a pending Promise**. Mechanism: the top-frame path is `chrome.scripting.executeScript` (MAIN world), which awaits a returned promise; `--frame` goes through CDP `Runtime.evaluate` with `awaitPromise:true` (`cdpFrameEval` in `extension/service_worker.js`).
- Same origin (`openrouter.ai`), same path, **status only**: `credentials:"include"` → **404**, `credentials:"omit"` → **401**. The differing status proves the HttpOnly session cookie WAS attached by the in-page fetch — with no cookie value crossing into the transcript.
- Not yet exercised against a third-party authenticated API beyond that; the mechanism and the credential attachment are what's verified.

**Limitation stated plainly in both docs:** the pattern does NOT work on CSP-strict origins (GitHub, Discord, …) — the injected script never runs there at all, so an authenticated API call *through the page* is unavailable; `text`/`html` are the only reads.

## Explicit decision: NOT adding a `cookies` op

Recorded in README so it isn't re-litigated. A cookie-read op is credential exfiltration by definition. Shipping one would require, at minimum: hard-denying it to the autonomous browser-agent the way `upload` is, audit-logging every read, and accepting that session tokens land in persisted transcripts. The in-page fetch pattern covers the real use case without any of that.

## Where each piece landed

- `scripts/browser-bridge/SKILL.md` — **+23 lines**, a tight "Cookies and authenticated requests" subsection appended to the existing "`eval` gotchas — a `null` result does NOT mean the bridge is down" section (SKILL.md loads on every browser task).
- `scripts/browser-bridge/README.md` — **+51 lines**, a fuller "No cookie op — deliberate" subsection under **Security model**: the decision + reasoning, the consequences, the recipe, the live evidence, the caveat.

## Notes

- Deliberately scoped to stay out of the frame/OOPIF sections and op-table rows that `feat/nested-oopif-eval` (#212) is editing — should merge conflict-free.
- No tests changed. Two existing test lines *mention* cookies (`tests/browser_tool.test.mjs:156` `javascript:alert(document.cookie)`, `:401` a `file://` exfil case) but they assert URL-scheme/path guards, not cookie behaviour — left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
