### PR TITLE
docs(browser-bridge): rescue the false-outage post-mortem — remedy updated `activate` → `wake`

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -578,9 +578,57 @@ the real foreground (a permission prompt, a native picker, verifying with your o
 eyes). It just stops being the default advice, and it is now **operator-only**
 (absent from the agent's op set entirely).
 
-**⚠ NOT LIVE-VERIFIED against the operator's real Brave.** The CDP semantics above
-are measured against real Brave, but the extension/server/CLI wiring has only been
-unit-tested. See *Live verification* below for the exact sequence.
+**✅ LIVE-VERIFIED against the operator's real Brave** using the sequence in *Live
+verification* below: `WAKE-RIG-SHELL` → `WAKE-RIG-RENDERED`, `visibilityState`
+`"visible"` during the wake and back to `"hidden"` after detach, and
+`xdotool getactivewindow` **unchanged** before/after — the page rendered and the
+operator's focus never moved.
+
+### Real false-outage report — a hidden tab that looked like a production outage
+
+This is the cost of the failure mode `wake` exists to prevent, and the reason the
+`visibilityState` rule in SKILL.md is 🔴. It happened.
+
+An agent read `civitai.com/apps` in a BACKGROUND tab it owned and saw 0 content
+cards, 3 spinners, and 0 tRPC calls — for a logged-in user with every feature flag
+on. It declared the production store broken, then escalated to **"site-wide"** when
+a second page looked the same.
+
+Every corroborating check it ran shared the identical flaw:
+
+- **A second profile on a different account reproduced it exactly** — also a
+  background tab. Two independent-looking confirmations, one shared cause.
+- **`?cb=<ts>` cache-busting didn't help** — the tab was still hidden, so the fresh
+  load was throttled the same way.
+- **A `next.router.push` soft-nav inside the hidden tab threw a plausible
+  `TypeError` plus a minified React error** — errors **the probe itself caused**.
+  Real-user telemetry showed **zero** occurrences of them in the preceding 2 hours.
+
+Nothing inside the browser could settle it, because every reading came from the same
+poisoned vantage point. It was settled only by **leaving the browser**: RUM showed
+~24k content-paint samples in 30 minutes, pods were healthy, and an anonymous `curl`
+returned 200. The site was fine the entire time.
+
+**The remedy, updated.** The original write-up of this incident concluded that
+`activate` was the only fix, because at the time it was — foregrounding the tab was
+the only way to un-throttle it. **That is no longer true.** `browser wake` (#225)
+un-throttles the tab via CDP focus emulation **without moving the operator's focus**,
+so the diagnostic step no longer costs the operator their screen. `activate` remains
+only for things that genuinely need the real foreground (a permission prompt, a
+native picker, seeing it with your own eyes), and is unreachable by the autonomous
+agent. See *The two shapes* above for `wake` vs `--wake`.
+
+**The three rules this bought** (carried in SKILL.md, in the `wake` section):
+
+1. Check `document.visibilityState` FIRST. If `"hidden"`, a "nothing rendered / no
+   requests fired" reading is MEANINGLESS.
+2. Spoofing `visibilityState` afterwards does NOT recover the page — the throttling
+   is browser-enforced and the app's fetch decisions are already made. `wake` is the
+   fix.
+3. **"Is this page broken for REAL users?" is not a browser question.** Answer it
+   from server-side / real-user evidence — RUM, metrics, pod health, an anonymous
+   `curl`. Use the browser probe to EXPLAIN a failure telemetry already shows, never
+   to DISCOVER one.
 
 ### Live verification (operator-run)
 
@@ -622,8 +670,9 @@ Optional third check — the read world (`wake-shadow.html` installs a main-worl
 
 ```bash
 browser open http://127.0.0.1:8901/wake-shadow.html
-browser html --wake     # MUST contain WAKE-SHADOW-REAL, MUST NOT contain POISON
-browser text --wake     # MUST be WAKE-SHADOW-REAL,      MUST NOT contain POISON
+browser html --wake     # MUST be the FULL document containing WAKE-SHADOW-REAL —
+                        # NOT the short `<html>WAKE-SHADOW-POISON-MAIN-WORLD</html>`
+browser text --wake     # MUST be exactly WAKE-SHADOW-REAL
 browser js 'document.documentElement.outerHTML' --wake   # WILL show the POISON — expected
 browser close
 ```

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -358,6 +358,24 @@ drive it: `text`/`frames` come back empty or half-built, and in-frame
 `model-benchmarking.civit.ai` (an OOPIF inside a `civitai.com` tab) stayed blank
 while backgrounded.
 
+🔴 **Before you believe any "nothing rendered / no requests fired" reading:**
+
+- **Check `document.visibilityState` FIRST**
+  (`browser --tab <id> eval 'document.visibilityState'`). If `"hidden"`, that
+  reading is MEANINGLESS — a shell-only DOM is indistinguishable from a genuinely
+  broken frontend. (Reads self-announce it: `data.hidden:true` + a stderr warning.)
+- **Spoofing it afterwards does NOT recover the page.**
+  `Object.defineProperty(document,'visibilityState',…)` changes nothing: the
+  throttling is browser-enforced and the app's fetch decisions are already made.
+  **`wake` is the fix** — not a spoof, and not `activate`.
+- 🔴 **"Is this page broken for REAL users?" is not a browser question.** Answer it
+  from server-side/real-user evidence — RUM, metrics, pod health, an anonymous
+  `curl`. Use the browser probe to EXPLAIN a failure telemetry already shows, never
+  to DISCOVER one. An agent once escalated a hidden-tab read to a site-wide
+  production outage that was not happening; every "corroborating" check shared the
+  identical flaw, and one of the errors it cited was caused by the probe itself.
+  Post-mortem: README.md § *Real false-outage report*.
+
 **`wake` is the fix, and it does NOT take the operator's screen.** It attaches CDP
 to your own tab, enables focus emulation (measured: `visibilityState` → `visible`,
 rAF 0/s → 62/s), holds it for a bounded settle (cap 6s) so the page paints, then explicitly

--- a/scripts/browser-bridge/tests/fixtures/oopif-rig/README.md
+++ b/scripts/browser-bridge/tests/fixtures/oopif-rig/README.md
@@ -272,11 +272,17 @@ main-world read could be served attacker-authored content that is not in the DOM
 
 ```bash
 browser open http://127.0.0.1:8901/wake-shadow.html
-browser html --wake     # MUST contain WAKE-SHADOW-REAL, MUST NOT contain POISON
-browser text --wake     # MUST be WAKE-SHADOW-REAL,      MUST NOT contain POISON
+browser html --wake     # MUST be the FULL document containing WAKE-SHADOW-REAL —
+                        # NOT the short `<html>WAKE-SHADOW-POISON-MAIN-WORLD</html>`
+browser text --wake     # MUST be exactly WAKE-SHADOW-REAL
 browser js 'document.documentElement.outerHTML' --wake   # WILL show the POISON — expected
 browser close
 ```
+
+⚠ "must not contain POISON" is the WRONG check for `html --wake`: the fixture's own
+source contains that word (in its comment and its script), so a **correct**
+isolated-world read of the full document legitimately includes it. The discriminator
+is that the read returns the whole document rather than the short shadowed string.
 
 The last line is not a failure: `eval` means "run my JS with the page's own globals",
 and plain `eval` is already `world:"MAIN"`, so `--wake` adds no exposure there.

--- a/scripts/browser-bridge/tests/fixtures/oopif-rig/wake-shadow.html
+++ b/scripts/browser-bridge/tests/fixtures/oopif-rig/wake-shadow.html
@@ -14,8 +14,16 @@
   un-throttle is CDP), so these overrides must NOT be observed:
 
     browser open http://127.0.0.1:8901/wake-shadow.html
-    browser html --wake     # MUST contain WAKE-SHADOW-REAL, MUST NOT contain POISON
-    browser text --wake     # MUST be WAKE-SHADOW-REAL,      MUST NOT contain POISON
+    browser html --wake     # MUST be the FULL document (this whole file, kilobytes)
+                            # containing WAKE-SHADOW-REAL -- NOT the short string
+                            # `<html>WAKE-SHADOW-POISON-MAIN-WORLD</html>`.
+                            # NOTE: "must not contain POISON" is the WRONG check --
+                            # this file's own source contains that word (here and in
+                            # the script below), so a CORRECT isolated-world read of
+                            # the full document legitimately includes it. LENGTH +
+                            # WAKE-SHADOW-REAL is the discriminator, not the word.
+    browser text --wake     # MUST be exactly WAKE-SHADOW-REAL (body innerText; the
+                            # main-world innerText shadow must NOT be observed)
 
   `js`/`eval --wake` DOES run in the main world — same as plain `js`/`eval`, which is
   what `eval` means — so this is the expected contrast, not a bug:


### PR DESCRIPTION
## What this rescues

A detailed write-up of a **real incident** was written into `scripts/browser-bridge/SKILL.md` on the workbench by another session and never committed. A `git stash pop` during a deploy conflicted with newly-merged content, and it survived only in a stash entry plus a rescue copy — **it was not in `main` at all** (`grep -c "Real false-outage report"` on main's SKILL.md returned 0). This lands it, reconciled against what actually shipped in #225.

## What it teaches

An agent read `civitai.com/apps` in an owned **background** tab, saw 0 content cards / 3 spinners / 0 tRPC calls for a logged-in user with every flag on, declared the production store broken — then escalated to **"site-wide"** when a second page looked the same.

Every corroborating check shared the *identical* flaw, which is what makes this worth writing down:

- a second profile on a different account reproduced it exactly — **also a background tab** (two independent-looking confirmations, one shared cause);
- `?cb=<ts>` cache-busting didn't help — still hidden, so the fresh load was throttled the same way;
- a `next.router.push` soft-nav inside the hidden tab threw a plausible `TypeError` plus a minified React error **that the probe itself caused** (zero occurrences in 2h of real-user telemetry).

Nothing inside the browser could settle it, because every reading came from the same poisoned vantage point. It was settled only by **leaving the browser**: RUM showed ~24k content-paint samples in 30 minutes, pods healthy, anonymous `curl` 200. The site was fine the whole time.

The three rules it bought:

1. Check `document.visibilityState` **FIRST**. If `"hidden"`, any "nothing rendered / no requests fired" reading is MEANINGLESS.
2. Spoofing `visibilityState` afterwards does **not** recover the page — throttling is browser-enforced and the app's fetch decisions are already made.
3. **"Is this page broken for REAL users?" is not a browser question.** Answer it from server-side / real-user evidence (RUM, metrics, pod health, anonymous `curl`). Use the browser probe to **EXPLAIN** a failure telemetry already shows, never to **DISCOVER** one.

## How the remedy was updated: `activate` → `wake`

The original write-up concluded **"`activate` is the only fix"** and "`activate` fixes this by foregrounding the tab". At the time that was true. **It is not any more.** #225 shipped `browser wake`, which un-throttles a hidden tab via CDP focus emulation **without stealing the operator's screen**.

The claims were corrected rather than dropped — the guidance now points at `wake`:

| was | now |
|---|---|
| "`activate` is the only fix" | **`wake` is the fix** — not a spoof, and not `activate` |
| "`activate` fixes this by foregrounding the tab" | `wake` un-throttles via CDP focus emulation, no focus movement; `activate` is the **last resort** for things that genuinely need the real foreground (permission prompt, native picker, seeing it with your own eyes) and is **unreachable by the autonomous agent** |
| README `wake`: "⚠ **NOT LIVE-VERIFIED** against the operator's real Brave" | ✅ **live-verified** — `WAKE-RIG-SHELL` → `WAKE-RIG-RENDERED`, `visibilityState` `"visible"` during the wake then back to `"hidden"`, `xdotool getactivewindow` **unchanged** before/after |

## Placement: rules in SKILL.md, narrative in README.md

SKILL.md is ~55KB and loads on **every** browser task, and a lean-core-plus-references restructure is planned — so the addition is kept tight:

- **SKILL.md** (+18 lines, in the existing `wake` section): the three rules only, as a 🔴 block, ending in a one-line pointer to the post-mortem.
- **README.md**: the full incident narrative as `### Real false-outage report — a hidden tab that looked like a production outage`, inside the `wake` section next to "The measured problem".

No guidance already in main's `wake` section is duplicated — the narrative cross-references *The two shapes* for `wake` vs `--wake` instead of restating it.

## Also fixed: an impossible verification check

`tests/fixtures/oopif-rig/wake-shadow.html` claimed `browser html --wake` "MUST contain WAKE-SHADOW-REAL, **MUST NOT contain POISON**". The second half is **impossible and misleading**: the fixture's own source contains `POISON` 8 times (in that very comment and in the script), so a *correct* isolated-world read of the full document legitimately includes it — the check would fail a working bridge.

The real discriminator, verified live: `html --wake` returns the **FULL document** (containing `WAKE-SHADOW-REAL`) rather than the short shadowed string `<html>WAKE-SHADOW-POISON-MAIN-WORLD</html>`. Rewritten in all **three** places the wrong check was copied to (the fixture comment, `README.md`, and `tests/fixtures/oopif-rig/README.md`), with a note saying why the word-absence check is wrong so it doesn't get reintroduced. The `text --wake` half is genuinely correct and was kept, tightened to "MUST be exactly WAKE-SHADOW-REAL".

## Scope / risk

Docs + that one fixture **comment** only — **no code**. Confirmed no test asserts on the fixture comment (`grep -rn wake-shadow` over `*.mjs`/`*.py`/`*.js` returns nothing), so this cannot affect CI. Reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
