### PR TITLE
fix(dl-router): gate setup-brave-profile.sh on the user-data-dir, not the binary name

### DIFF
--- a/scripts/dl-router/README.md
+++ b/scripts/dl-router/README.md
@@ -289,8 +289,16 @@ never renamed.
    ```
    This sets `download.default_directory` and `savefile.default_directory` to
    the library root and turns off `prompt_for_download`, after backing up
-   `Preferences`. It refuses to run while Brave is running, because Brave
-   rewrites `Preferences` on exit and would revert the change.
+   `Preferences`. It refuses to run while a browser is **using that
+   user-data-dir**, because Brave rewrites `Preferences` on exit and would
+   revert the change — and it says which pid to quit. It checks for an open fd
+   under the directory, a browser main process whose `--user-data-dir` resolves
+   there (or that has none, i.e. the default one), and a `SingletonLock` whose
+   pid is still alive. An instance on a *different* `--user-data-dir` (headless
+   automation on a throwaway profile) and a stale lock left by a crash do not
+   count. `--list` and `--dry-run` write nothing and are not gated at all.
+   If it cannot read a process table it still refuses;
+   `DL_ROUTER_ASSUME_BROWSER_CLOSED=1` overrides *that* case only.
 4. **Load the extension.** `brave://extensions` → Developer mode → Load
    unpacked → this directory's `extension/`.
 5. **Enable it for that profile.** Open the extension's Options page, paste the

--- a/scripts/dl-router/SKILL.md
+++ b/scripts/dl-router/SKILL.md
@@ -106,7 +106,12 @@ carries the new rules. Selector subset: tag, `.class`, `#id`, `[attr]`,
 **"Downloads still show a Save-As dialog."** The profile's
 `download.default_directory` is not the library root, or `prompt_for_download`
 is still on. Re-run `setup-brave-profile.sh` with Brave **fully closed** (it
-refuses otherwise, because Brave rewrites `Preferences` on exit).
+refuses otherwise, because Brave rewrites `Preferences` on exit). "Closed"
+means *this* profile: the guard asks whether any live process is using this
+`--user-data-dir` (open fd / main-process cmdline / a live `SingletonLock`), so
+headless automation on a throwaway `/tmp` profile does not block it, and a
+stale lock from a crash does not either. It names the pid to quit. `--list` and
+`--dry-run` write nothing and are never gated.
 
 ## Backfill — the one dangerous path
 

--- a/scripts/dl-router/setup-brave-profile.sh
+++ b/scripts/dl-router/setup-brave-profile.sh
@@ -13,17 +13,20 @@
 #     download.prompt_for_download = false
 #
 # Safety:
-#   * refuses to run while Brave is running (Brave rewrites Preferences on exit
-#     and would clobber the edit);
+#   * refuses to run while a browser is USING THIS user-data-dir (it rewrites
+#     Preferences on exit and would clobber the edit). An instance on some
+#     OTHER --user-data-dir -- headless automation on a throwaway profile, say
+#     -- shares the binary but not this file, and does not count;
 #   * backs up Preferences with a timestamp before touching it;
 #   * lists the profile display names first, so the right directory is chosen;
-#   * --dry-run prints the resulting diff without writing.
+#   * --list and --dry-run write nothing, so they are not gated at all.
 #
 # Nothing here is committed with a real path: the library root comes from
 # ~/.config/dl-router/config.toml (or --root).
 set -euo pipefail
 
-BRAVE_DIR="${BRAVE_DIR:-$HOME/.config/BraveSoftware/Brave-Browser}"
+DEFAULT_BRAVE_DIR="$HOME/.config/BraveSoftware/Brave-Browser"
+BRAVE_DIR="${BRAVE_DIR:-$DEFAULT_BRAVE_DIR}"
 CONFIG="${DL_ROUTER_CONFIG:-$HOME/.config/dl-router/config.toml}"
 PROFILE=""
 ROOT=""
@@ -36,17 +39,25 @@ usage: setup-brave-profile.sh [--list] [--profile <dir>] [--root <path>] [--dry-
   --list            show each profile directory and its display name, then exit
   --profile <dir>   profile DIRECTORY name ("Default", "Profile 2", ...)
   --root <path>     library root (default: library_root from config.toml)
-  --dry-run         show what would change; write nothing
+  --dry-run         show what would change; write nothing (writes nothing by
+                    construction, so it is not gated on the browser: a live
+                    instance is reported as a warning instead of a refusal)
 
 Environment:
-  BRAVE_DIR                          browser profile directory
+  BRAVE_DIR                          browser user-data-dir holding the profile
   DL_ROUTER_CONFIG                   config.toml to read library_root from
   DL_ROUTER_ASSUME_BROWSER_CLOSED=1  proceed even when this script cannot
-                                     determine whether the browser is running
-                                     (pgrep missing or erroring). Only use it
-                                     with the browser genuinely closed: it
-                                     rewrites Preferences on exit and would
-                                     silently revert the change.
+                                     determine whether anything is using this
+                                     user-data-dir (no readable process table).
+                                     It does NOT override a browser that WAS
+                                     positively detected -- quit that one
+                                     instead. Only use it with the browser
+                                     genuinely closed: it rewrites Preferences
+                                     on exit and would silently revert the
+                                     change.
+  DL_ROUTER_PROC_DIR                 procfs mount point (default /proc); the
+                                     "is anything using this profile?" check
+                                     reads it.
 
 Run --list first, pick the profile whose display name is the one you download
 with, then re-run with --profile.
@@ -153,67 +164,242 @@ if [ ! -f "$PREFS" ]; then
   exit 2
 fi
 
-# --- refuse while the browser is running ----------------------------------- #
-# Match the real binary names, not a bare pattern: `pgrep -f brave` would also
-# match this script's own command line.
+# --- refuse while something is using THIS user-data-dir --------------------- #
+# THE BUG THIS GUARD USED TO HAVE: it asked `pgrep -x brave`, i.e. "does a
+# process with that BINARY NAME exist", and called that "the browser is
+# running". On a host that also drives headless Brave for automation
+# (Playwright/chromedp, each on its own `--user-data-dir=/tmp/...`) that is a
+# false positive essentially always: the real browser is closed, nothing holds
+# this profile, and the one-time setup step is simply unrunnable. The
+# documented escape hatch did not help either -- it only covered "pgrep could
+# not answer", and here pgrep answered, loudly and wrongly.
 #
-# THE BUG THIS GUARD USED TO HAVE: `pgrep ... >/dev/null 2>&1` was treated as
-# "not running" for ANY non-zero exit. pgrep exits 1 for "no match" and the
-# SHELL exits 127 when the binary is absent from PATH -- and 2>/dev/null hid
-# the "command not found" message. On a host without procps the guard silently
-# passed and the script patched Preferences under a live browser, which then
-# rewrote them on exit and reverted the change: exactly the failure the guard
-# exists to prevent, and a confusing one because nothing appears to be wrong.
+# What actually matters is not the binary name but the FILE: is any live
+# process using the user-data-dir that contains the profile we are about to
+# patch? Three signals, most reliable first (see the embedded checker):
+#   1. a process holding an open fd under the user-data-dir -- kernel truth,
+#      no parsing, and it catches non-Brave holders too;
+#   2. a browser MAIN process (no --type=, i.e. not a renderer/zygote child)
+#      whose --user-data-dir resolves here -- or that has no --user-data-dir at
+#      all, which means it is on the default one;
+#   3. SingletonLock, a "<host>-<pid>" symlink -- but only when that pid is
+#      still alive. A stale lock from a crash or an unclean exit must not block
+#      the script forever.
 #
-# So: distinguish 1 (checked, not running) from anything else (could not
-# check), and fail closed on "could not check".
-browser_running() {
-  local rc saw_answer=0 name
-  for name in brave brave-browser Brave-Browser brave-bin; do
-    # `|| rc=$?` keeps a non-zero exit non-fatal under `set -e` without
-    # toggling the option (an inner `set -e` would re-arm it for the caller).
-    rc=0
-    pgrep -x "$name" >/dev/null 2>&1 || rc=$?
-    case "$rc" in
-      0) return 0 ;;     # running
-      1) saw_answer=1 ;; # definitely not running under this name
-      *) ;;              # 127 / 126 / anything else: the tool did not answer
-    esac
-  done
-  if [ "$saw_answer" -eq 1 ]; then
-    return 1
-  fi
-  return 2               # never got a usable answer from pgrep at all
-}
+# Fail closed is preserved: if the checker cannot get a usable process table it
+# refuses, and only DL_ROUTER_ASSUME_BROWSER_CLOSED=1 overrides THAT. It does
+# not override a positively identified instance -- there is nothing to guess
+# about, and the message names the pid to quit.
+GUARD_RC=0
+GUARD_MSG="$(
+  python3 - "$BRAVE_DIR" "$PROFILE" "$DEFAULT_BRAVE_DIR" <<'PY' 2>&1
+import os
+import re
+import sys
 
-if ! command -v pgrep >/dev/null 2>&1; then
-  echo "pgrep is not available, so this script cannot tell whether the browser" >&2
-  echo "is running. Refusing: patching Preferences under a live browser is" >&2
-  echo "silently reverted on exit. Install procps (or quit the browser and" >&2
-  echo "re-run with DL_ROUTER_ASSUME_BROWSER_CLOSED=1)." >&2
-  [ "${DL_ROUTER_ASSUME_BROWSER_CLOSED:-0}" = "1" ] || exit 3
+BUSY, UNKNOWN = 3, 4
+udd_arg, profile, default_arg = sys.argv[1], sys.argv[2], sys.argv[3]
+proc_root = os.environ.get("DL_ROUTER_PROC_DIR") or "/proc"
+
+
+def norm(path):
+    try:
+        return os.path.realpath(path)
+    except OSError:
+        return os.path.abspath(path)
+
+
+udd = norm(udd_arg)
+inside = udd.rstrip("/") + "/"
+udd_is_default = udd == norm(default_arg)
+
+# Packaging calls it brave, brave-browser, brave-bin, .brave-wrapped (Nix), ...
+# The name is only ever used to decide whether a process is ELIGIBLE for the
+# cmdline check -- never on its own to conclude that this profile is in use.
+BRAVE_NAME = re.compile(r"^\.?brave", re.IGNORECASE)
+
+
+def read_text(pid, name):
+    try:
+        with open(os.path.join(proc_root, pid, name), "rb") as fh:
+            return fh.read().decode("utf-8", "replace")
+    except OSError:
+        return None
+
+
+def link(pid, name):
+    try:
+        return os.readlink(os.path.join(proc_root, pid, name))
+    except OSError:
+        return ""
+
+
+def first_token(cmdline):
+    # Chromium REWRITES its own argv to set the process title, which collapses
+    # the NUL separators into spaces -- on a live browser every process reads
+    # back as one space-joined blob, not a NUL-separated vector. Handle both.
+    return re.split(r"[\0 ]", cmdline, maxsplit=1)[0]
+
+
+def names_of(pid, cmdline):
+    out = [read_text(pid, "comm") or "", os.path.basename(link(pid, "exe"))]
+    if cmdline:
+        out.append(os.path.basename(first_token(cmdline)))
+    return [n.strip() for n in out if n.strip()]
+
+
+def flag_value(cmdline, flag):
+    m = re.search(r"(?:^|[\0 ])" + re.escape(flag) + r"[= ]", cmdline)
+    if not m:
+        return None
+    # The value ends at the next NUL (a real argv) or at the next " --flag" (an
+    # argv the process rewrote into one blob).
+    return re.split(r"\0| --", cmdline[m.end():], maxsplit=1)[0].strip()
+
+
+def has_flag(cmdline, flag):
+    return re.search(r"(?:^|[\0 ])" + re.escape(flag) + r"[= ]", cmdline) is not None
+
+
+def fd_under_udd(pid):
+    fd_dir = os.path.join(proc_root, pid, "fd")
+    try:
+        entries = os.listdir(fd_dir)
+    except OSError:
+        return None
+    for fd in entries:
+        try:
+            target = os.readlink(os.path.join(fd_dir, fd))
+        except OSError:
+            continue
+        target = target.split(" (deleted)")[0]
+        if target == udd or target.startswith(inside):
+            return target
+    return None
+
+
+def live_pids():
+    try:
+        found = sorted((e for e in os.listdir(proc_root) if e.isdigit()), key=int)
+    except OSError:
+        return None
+    # A real process table always has pid 1. An empty (or simply wrong)
+    # directory is not evidence that nothing is running.
+    return found or None
+
+
+def lock_pid():
+    try:
+        target = os.readlink(os.path.join(udd, "SingletonLock"))
+    except OSError:
+        return None
+    m = re.search(r"-(\d+)$", target)
+    return m.group(1) if m else None
+
+
+def describe(pid, cmdline):
+    names = names_of(pid, cmdline)
+    return "pid %s (%s)" % (pid, names[0] if names else "unknown")
+
+
+def verdict():
+    """('clear'|'busy'|'unknown', detail)."""
+    pids = live_pids()
+    held_by = lock_pid()
+
+    if pids is None:
+        # No process table. The lock is the only signal left, and it can only
+        # prove BUSY, never free.
+        if held_by is not None:
+            try:
+                os.kill(int(held_by), 0)
+                alive = True
+            except ProcessLookupError:
+                alive = False
+            except (OSError, ValueError):
+                alive = True   # cannot signal it, so cannot rule it out
+            if alive:
+                return "busy", ("pid %s" % held_by,
+                                "holds this profile's SingletonLock")
+        return "unknown", ("no readable process table at %s -- cannot tell "
+                           "whether anything is using this profile" % proc_root)
+
+    for pid in pids:
+        cmdline = read_text(pid, "cmdline")
+        if cmdline is None:
+            continue           # gone, or not ours to inspect
+        open_file = fd_under_udd(pid)
+        if open_file:
+            return "busy", (describe(pid, cmdline),
+                            "has %s open" % open_file)
+        if not any(BRAVE_NAME.match(n) for n in names_of(pid, cmdline)):
+            continue
+        if has_flag(cmdline, "--type"):
+            continue           # a renderer/zygote/gpu child, not an instance
+        value = flag_value(cmdline, "--user-data-dir")
+        if value is not None:
+            if not os.path.isabs(value):
+                cwd = link(pid, "cwd")
+                value = os.path.join(cwd, value) if cwd else value
+            if norm(value) == udd:
+                return "busy", (describe(pid, cmdline),
+                                "was started with --user-data-dir=%s" % udd)
+        elif udd_is_default:
+            return "busy", (describe(pid, cmdline),
+                            "has no --user-data-dir, so it is on the default "
+                            "one, which is this one")
+
+    if held_by is not None and held_by in pids and read_text(held_by, "cmdline") is None:
+        # Alive, holds the lock, and opaque to us (another user, or hidepid).
+        # Every other case of a live lock holder was decided above.
+        return "busy", ("pid %s" % held_by,
+                        "holds this profile's SingletonLock and cannot be "
+                        "inspected from here")
+
+    return "clear", None
+
+
+status, detail = verdict()
+if status == "clear":
+    raise SystemExit(0)
+if status == "busy":
+    who, why = detail
+    sys.stderr.write(
+        "A browser is using the profile directory this script would patch:\n"
+        "  blocked by:      %s\n"
+        "                   %s\n"
+        "  profile:         %s\n"
+        "  user-data-dir:   %s\n"
+        "Quit THAT instance completely and re-run -- it rewrites Preferences\n"
+        "on exit, which would silently revert this change. Instances on a\n"
+        "different --user-data-dir (headless automation, throwaway profiles)\n"
+        "are ignored by this check and are safe to leave running.\n"
+        % (who, why, profile, udd))
+    raise SystemExit(BUSY)
+sys.stderr.write("Could not determine whether a browser is using this profile "
+                 "directory:\n  %s\n" % detail)
+raise SystemExit(UNKNOWN)
+PY
+)" || GUARD_RC=$?
+
+if [ -n "$GUARD_MSG" ]; then
+  printf '%s\n' "$GUARD_MSG" >&2
 fi
-
-BROWSER_RC=0
-browser_running || BROWSER_RC=$?
-case "$BROWSER_RC" in
-  0)
-    echo "The browser is running. Quit it completely (it rewrites Preferences" >&2
-    echo "on exit, which would silently revert this change), then re-run." >&2
+if [ "$GUARD_RC" -ne 0 ] && [ "$DRY_RUN" -eq 1 ]; then
+  echo "(--dry-run writes nothing, so that is a warning, not a refusal.)" >&2
+elif [ "$GUARD_RC" -eq 3 ]; then
+  exit 3
+elif [ "$GUARD_RC" -ne 0 ]; then
+  # 4 = the check ran and could not answer. Anything else = the check itself
+  # broke (no python3, a traceback, ...). Both are "no answer", and no answer
+  # fails closed -- that is what DL_ROUTER_ASSUME_BROWSER_CLOSED=1 is for.
+  if [ "${DL_ROUTER_ASSUME_BROWSER_CLOSED:-0}" != "1" ]; then
+    echo "Refusing rather than guessing: patching Preferences under a live" >&2
+    echo "browser is silently reverted on exit. Quit the browser and re-run" >&2
+    echo "with DL_ROUTER_ASSUME_BROWSER_CLOSED=1 to override." >&2
     exit 3
-    ;;
-  1) : ;;   # confirmed closed
-  *)
-    if [ "${DL_ROUTER_ASSUME_BROWSER_CLOSED:-0}" != "1" ]; then
-      echo "Could not determine whether the browser is running (pgrep gave no" >&2
-      echo "usable answer). Refusing rather than guessing -- patching" >&2
-      echo "Preferences under a live browser is silently reverted on exit." >&2
-      echo "Quit it and re-run with DL_ROUTER_ASSUME_BROWSER_CLOSED=1 to" >&2
-      echo "override." >&2
-      exit 3
-    fi
-    ;;
-esac
+  fi
+fi
 
 # --- back up + patch -------------------------------------------------------- #
 STAMP="$(date +%Y%m%d-%H%M%S)"

--- a/scripts/dl-router/tests/test_setup_script.py
+++ b/scripts/dl-router/tests/test_setup_script.py
@@ -1,12 +1,21 @@
 """setup-brave-profile.sh -- the one-time browser profile change.
 
 It edits the browser's `Preferences`, and the browser REWRITES that file on
-exit. So the "is it running?" guard is the whole safety story: if it passes
-while the browser is live, the change is silently reverted later and the user
-is left with a router that never sees a download, and no error anywhere.
+exit. So the guard is the whole safety story: if it passes while a browser is
+live on this profile, the change is silently reverted later and the user is
+left with a router that never sees a download, and no error anywhere.
 
-Every test here runs the real script with a fabricated PATH, so `pgrep` is
-whatever the test says it is. Nothing touches a real browser profile.
+The guard's question is NOT "does a process called brave exist" -- on a machine
+that also drives headless Brave for automation (each instance on its own
+`--user-data-dir=/tmp/...`) that answer is yes essentially always, and gating on
+it makes the setup step unrunnable while the real browser is closed. The
+question is "is any live process using THIS user-data-dir".
+
+So the tests fabricate a process table (`DL_ROUTER_PROC_DIR`) and a
+`SingletonLock`, and assert on which of those actually count. A fake `pgrep` is
+still installed to pin the regression: the answer to "is a brave binary
+running" must no longer decide anything on its own. Nothing here touches a real
+browser profile.
 """
 from __future__ import annotations
 
@@ -24,11 +33,11 @@ SCRIPT = Path(__file__).resolve().parent.parent / "setup-brave-profile.sh"
 EXIT_USAGE = 2
 EXIT_REFUSED = 3
 
+# A realistic Chromium argv0.
+BRAVE_EXE = "/nix/store/deadbeef-brave-1.0/opt/brave.com/brave/brave"
 
-@pytest.fixture
-def fake_env(tmp_path):
-    """A browser profile dir, a library root, and a PATH we control."""
-    brave = tmp_path / "Brave-Browser"
+
+def _build_env(tmp_path, brave: Path) -> dict:
     profile = brave / "Profile 2"
     profile.mkdir(parents=True)
     (profile / "Preferences").write_text(json.dumps({
@@ -39,21 +48,48 @@ def fake_env(tmp_path):
         "profile": {"info_cache": {"Profile 2": {"name": "Media"}}},
     }), encoding="utf-8")
     library = tmp_path / "library"
-    library.mkdir()
+    library.mkdir(exist_ok=True)
 
     bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
+    bin_dir.mkdir(exist_ok=True)
     # A real python3 is needed by the script's embedded heredocs.
     (bin_dir / "python3").symlink_to(sys.executable)
-    # Everything the script shells out to -- but deliberately NOT pgrep, so a
-    # test can make it genuinely absent from PATH.
     for tool in ("bash", "env", "date", "cp", "cat", "dirname", "pwd", "mktemp",
                  "rm", "ls"):
         found = _which(tool)
         if found:
             (bin_dir / tool).symlink_to(found)
+
+    proc = tmp_path / "proc"
+    proc.mkdir(exist_ok=True)
+    # A process table is never empty; give it an init so "empty" stays
+    # available as a distinct, suspicious case.
+    add_process(proc, 1, cmdline="/sbin/init", comm="systemd")
+
     return {"brave": brave, "profile": profile, "library": library,
-            "bin": bin_dir, "tmp": tmp_path}
+            "bin": bin_dir, "proc": proc, "tmp": tmp_path,
+            "env_base": {"BRAVE_DIR": str(brave)}}
+
+
+@pytest.fixture
+def fake_env(tmp_path):
+    """A browser user-data-dir, a library root, a PATH and a process table."""
+    return _build_env(tmp_path, tmp_path / "Brave-Browser")
+
+
+@pytest.fixture
+def default_udd_env(tmp_path):
+    """The same, but the profile lives in the DEFAULT user-data-dir.
+
+    Needed because "a browser with no --user-data-dir at all" is on the default
+    one -- which only blocks when the default is the directory being patched.
+    """
+    home = tmp_path / "home"
+    env = _build_env(
+        tmp_path, home / ".config" / "BraveSoftware" / "Brave-Browser")
+    # BRAVE_DIR empty => the script falls back to its $HOME-derived default.
+    env["env_base"] = {"HOME": str(home), "BRAVE_DIR": ""}
+    return env
 
 
 def _which(name):
@@ -64,22 +100,48 @@ def _which(name):
     return None
 
 
+def add_process(proc_dir: Path, pid, *, cmdline=None, comm="", fds=()):
+    """Fabricate one /proc/<pid> entry.
+
+    `cmdline` is written VERBATIM. A live Chromium rewrites its own argv to set
+    the process title, which collapses the NUL separators into spaces -- on a
+    real machine every brave process reads back as ONE space-joined blob, not a
+    NUL-separated vector -- so tests use that shape. `cmdline=None` leaves the
+    file out entirely: a process that is alive but opaque to us.
+    """
+    d = proc_dir / str(pid)
+    (d / "fd").mkdir(parents=True)
+    if cmdline is not None:
+        (d / "cmdline").write_text(cmdline, encoding="utf-8")
+    if comm:
+        (d / "comm").write_text(comm + "\n", encoding="utf-8")
+    for slot, target in enumerate(fds, start=3):
+        (d / "fd" / str(slot)).symlink_to(target)
+    return d
+
+
+def singleton_lock(fake_env, pid, host="somehost"):
+    (Path(fake_env["brave"]) / "SingletonLock").symlink_to(f"{host}-{pid}")
+
+
 def write_pgrep(bin_dir: Path, *, exit_code: int):
+    """Install a `pgrep` with a fixed answer.
+
+    exit 0 = "a process with that binary name exists". That used to be the
+    whole guard; it must not decide anything now.
+    """
     (bin_dir / "pgrep").write_text(
         f"#!/usr/bin/env bash\nexit {exit_code}\n", encoding="utf-8")
     os.chmod(bin_dir / "pgrep", 0o755)
 
 
-def run(fake_env, *args, env_extra=None, with_pgrep=True):
+def run(fake_env, *args, env_extra=None):
     env = dict(os.environ)
     env["PATH"] = f"{fake_env['bin']}{os.pathsep}{env['PATH']}"
-    env["BRAVE_DIR"] = str(fake_env["brave"])
     env["DL_ROUTER_CONFIG"] = str(fake_env["tmp"] / "no-such-config.toml")
+    env["DL_ROUTER_PROC_DIR"] = str(fake_env["proc"])
+    env.update(fake_env["env_base"])
     env.update(env_extra or {})
-    if not with_pgrep:
-        # Only our bin dir, so pgrep genuinely is not on PATH. Keep a real
-        # coreutils dir for the script's own helpers.
-        env["PATH"] = str(fake_env["bin"])
     return subprocess.run([str(SCRIPT), *args], capture_output=True, text=True,
                           env=env, timeout=60)
 
@@ -88,67 +150,243 @@ def prefs(fake_env) -> dict:
     return json.loads((fake_env["profile"] / "Preferences").read_text())
 
 
-# --- the guard ------------------------------------------------------------- #
-def test_it_refuses_while_the_browser_is_running(fake_env):
-    write_pgrep(fake_env["bin"], exit_code=0)
-    out = run(fake_env, "--profile", "Profile 2",
-              "--root", str(fake_env["library"]))
-    assert out.returncode == EXIT_REFUSED
-    assert "running" in out.stderr.lower()
+def apply(fake_env, **kw):
+    return run(fake_env, "--profile", "Profile 2",
+               "--root", str(fake_env["library"]), **kw)
+
+
+def assert_untouched(fake_env):
     assert prefs(fake_env)["download"]["default_directory"] == "/old/path"
+    assert not list(fake_env["profile"].glob("Preferences.dl-router-backup-*"))
 
 
-def test_it_proceeds_when_the_browser_is_confirmed_closed(fake_env):
-    write_pgrep(fake_env["bin"], exit_code=1)
-    out = run(fake_env, "--profile", "Profile 2",
-              "--root", str(fake_env["library"]))
-    assert out.returncode == 0, out.stderr
+def assert_applied(fake_env):
     assert prefs(fake_env)["download"]["default_directory"] \
         == str(fake_env["library"])
+
+
+# --- the guard: what BLOCKS ------------------------------------------------ #
+def test_a_live_instance_on_this_user_data_dir_blocks(fake_env):
+    write_pgrep(fake_env["bin"], exit_code=1)   # name-matching would say "no"
+    add_process(fake_env["proc"], 901, comm="brave",
+                cmdline=f"{BRAVE_EXE} --user-data-dir={fake_env['brave']} "
+                        "--no-first-run")
+    out = apply(fake_env)
+    assert out.returncode == EXIT_REFUSED, out.stdout + out.stderr
+    assert_untouched(fake_env)
+
+
+def test_the_refusal_says_which_instance_and_which_profile(fake_env):
+    """"The browser is running" was actively misleading: the browser the user
+    cared about was closed. The message has to identify the blocker."""
+    write_pgrep(fake_env["bin"], exit_code=1)
+    add_process(fake_env["proc"], 901, comm="brave",
+                cmdline=f"{BRAVE_EXE} --user-data-dir={fake_env['brave']}")
+    err = apply(fake_env).stderr
+    assert "pid 901" in err
+    assert "Profile 2" in err
+    assert str(fake_env["brave"]) in err
+
+
+def test_an_instance_with_no_user_data_dir_blocks_the_default_one(
+        default_udd_env):
+    """No --user-data-dir means the default one -- the case the binary-name
+    check happened to cover and a naive cmdline check would miss."""
+    write_pgrep(default_udd_env["bin"], exit_code=1)
+    add_process(default_udd_env["proc"], 902, comm="brave",
+                cmdline=f"{BRAVE_EXE} --no-first-run --restore-last-session")
+    out = apply(default_udd_env)
+    assert out.returncode == EXIT_REFUSED, out.stdout + out.stderr
+    assert "pid 902" in out.stderr
+    assert_untouched(default_udd_env)
+
+
+def test_any_process_holding_a_file_open_in_this_profile_blocks(fake_env):
+    """The kernel-truth signal: it needs no cmdline parsing and catches
+    holders that are not named brave at all."""
+    write_pgrep(fake_env["bin"], exit_code=1)
+    add_process(fake_env["proc"], 903, comm="chrome_crashpad",
+                cmdline="/opt/chrome_crashpad_handler --monitor-self",
+                fds=[fake_env["profile"] / "Preferences"])
+    out = apply(fake_env)
+    assert out.returncode == EXIT_REFUSED, out.stdout + out.stderr
+    assert "pid 903" in out.stderr
+    assert_untouched(fake_env)
+
+
+def test_a_live_lock_holder_we_cannot_inspect_blocks(fake_env):
+    """SingletonLock -> "<host>-<pid>" where the pid is alive but opaque (root,
+    or hidepid). Nothing to guess about: fail closed."""
+    write_pgrep(fake_env["bin"], exit_code=1)
+    add_process(fake_env["proc"], 4242, cmdline=None)
+    singleton_lock(fake_env, 4242)
+    out = apply(fake_env)
+    assert out.returncode == EXIT_REFUSED, out.stdout + out.stderr
+    assert "4242" in out.stderr
+    assert_untouched(fake_env)
+
+
+# --- the guard: what MUST NOT block ---------------------------------------- #
+def test_a_headless_instance_on_another_user_data_dir_does_not_block(fake_env):
+    """THE finding. Agents run Playwright/chromedp against the SAME brave
+    binary on throwaway `--user-data-dir=/tmp/...` profiles. `pgrep -x brave`
+    matches them, so the guard refused with the real browser fully closed and
+    nothing holding this profile -- and the documented escape hatch did not
+    apply, because pgrep had answered."""
+    write_pgrep(fake_env["bin"], exit_code=0)
+    other = fake_env["tmp"] / "chromedp-runner1253386066"
+    other.mkdir()
+    add_process(fake_env["proc"], 975904, comm="brave",
+                cmdline=f"{BRAVE_EXE} --headless --user-data-dir={other} "
+                        "--no-first-run")
+    add_process(fake_env["proc"], 975949, comm="brave",
+                cmdline=f"{BRAVE_EXE} --type=zygote --no-sandbox --headless "
+                        f"--user-data-dir={other}")
+    out = apply(fake_env)
+    assert out.returncode == 0, out.stdout + out.stderr
+    assert_applied(fake_env)
+
+
+def test_a_child_of_another_instance_does_not_block_the_default(
+        default_udd_env):
+    """Renderer/zygote/gpu children do not carry --user-data-dir, so "no
+    --user-data-dir means the default one" must only apply to a MAIN process
+    (no --type=). Otherwise every headless instance drags ~10 children that
+    each look like a default-profile browser."""
+    write_pgrep(default_udd_env["bin"], exit_code=0)
+    add_process(default_udd_env["proc"], 976034, comm="brave",
+                cmdline=f"{BRAVE_EXE} --type=gpu-process --no-sandbox "
+                        "--headless --ozone-platform=headless")
+    add_process(default_udd_env["proc"], 976036, comm="brave",
+                cmdline=f"{BRAVE_EXE} --type=utility "
+                        "--utility-sub-type=network.mojom.NetworkService")
+    out = apply(default_udd_env)
+    assert out.returncode == 0, out.stdout + out.stderr
+    assert_applied(default_udd_env)
+
+
+def test_a_stale_singleton_lock_does_not_block(fake_env):
+    """A crash or an unclean exit leaves SingletonLock pointing at a dead pid.
+    Treating the lock as authoritative would make the script permanently
+    unrunnable with no way out."""
+    write_pgrep(fake_env["bin"], exit_code=0)
+    singleton_lock(fake_env, 4242)          # not in the process table at all
+    out = apply(fake_env)
+    assert out.returncode == 0, out.stdout + out.stderr
+    assert_applied(fake_env)
+
+
+def test_a_lock_pid_recycled_by_another_program_does_not_block(fake_env):
+    """The lock is only authoritative when its pid is alive AND is a browser.
+    Pids get reused."""
+    write_pgrep(fake_env["bin"], exit_code=0)
+    add_process(fake_env["proc"], 4242, comm="vim",
+                cmdline="/usr/bin/vim\0notes.txt\0")
+    singleton_lock(fake_env, 4242)
+    out = apply(fake_env)
+    assert out.returncode == 0, out.stdout + out.stderr
+    assert_applied(fake_env)
+
+
+def test_it_proceeds_when_nothing_is_using_this_profile(fake_env):
+    write_pgrep(fake_env["bin"], exit_code=1)
+    out = apply(fake_env)
+    assert out.returncode == 0, out.stderr
+    assert_applied(fake_env)
     assert prefs(fake_env)["download"]["prompt_for_download"] is False
     assert prefs(fake_env)["savefile"]["default_directory"] \
         == str(fake_env["library"])
 
 
-def test_a_missing_pgrep_is_NOT_read_as_not_running(fake_env):
-    """THE finding. `pgrep ... >/dev/null 2>&1` returning 127 (binary absent
-    from PATH) was indistinguishable from 1 (no match), and 2>/dev/null hid the
-    "command not found". The guard passed and the script patched Preferences
-    under a live browser -- which then reverted it on exit, silently."""
-    out = run(fake_env, "--profile", "Profile 2",
-              "--root", str(fake_env["library"]), with_pgrep=False)
+# --- the guard: fail closed ------------------------------------------------ #
+def test_no_readable_process_table_is_NOT_read_as_nothing_running(fake_env):
+    """The original bug in this guard, in its new form: "the check could not
+    run" must never collapse into "nothing is running"."""
+    write_pgrep(fake_env["bin"], exit_code=1)
+    out = apply(fake_env,
+                env_extra={"DL_ROUTER_PROC_DIR": str(fake_env["tmp"] / "gone")})
     assert out.returncode == EXIT_REFUSED, out.stdout + out.stderr
-    assert "pgrep" in out.stderr
-    assert prefs(fake_env)["download"]["default_directory"] == "/old/path", \
-        "Preferences must be untouched when the guard could not run"
-
-
-def test_a_pgrep_that_errors_out_is_also_refused(fake_env):
-    """127 is not the only way to get no answer -- a broken or permission-denied
-    pgrep must fail closed too."""
-    write_pgrep(fake_env["bin"], exit_code=126)
-    out = run(fake_env, "--profile", "Profile 2",
-              "--root", str(fake_env["library"]))
-    assert out.returncode == EXIT_REFUSED
     assert "could not determine" in out.stderr.lower()
-    assert prefs(fake_env)["download"]["default_directory"] == "/old/path"
+    assert_untouched(fake_env)
 
 
-def test_the_override_is_explicit_and_opt_in(fake_env):
-    write_pgrep(fake_env["bin"], exit_code=126)
-    out = run(fake_env, "--profile", "Profile 2",
-              "--root", str(fake_env["library"]),
-              env_extra={"DL_ROUTER_ASSUME_BROWSER_CLOSED": "1"})
+def test_an_empty_directory_is_not_a_process_table(fake_env):
+    """A real one always has pid 1. An empty (or simply wrong) directory is not
+    evidence that nothing is running."""
+    write_pgrep(fake_env["bin"], exit_code=1)
+    empty = fake_env["tmp"] / "empty-proc"
+    empty.mkdir()
+    out = apply(fake_env, env_extra={"DL_ROUTER_PROC_DIR": str(empty)})
+    assert out.returncode == EXIT_REFUSED, out.stdout + out.stderr
+    assert "could not determine" in out.stderr.lower()
+    assert_untouched(fake_env)
+
+
+def test_the_override_covers_the_undetectable_case(fake_env):
+    write_pgrep(fake_env["bin"], exit_code=1)
+    out = apply(fake_env, env_extra={
+        "DL_ROUTER_PROC_DIR": str(fake_env["tmp"] / "gone"),
+        "DL_ROUTER_ASSUME_BROWSER_CLOSED": "1"})
     assert out.returncode == 0, out.stderr
-    assert prefs(fake_env)["download"]["default_directory"] \
-        == str(fake_env["library"])
+    assert "could not determine" in out.stderr.lower(), \
+        "say what was overridden, do not proceed silently"
+    assert_applied(fake_env)
+
+
+def test_the_override_does_NOT_cover_a_detected_instance(fake_env):
+    """It means "I cannot tell, and I promise it is closed" -- not "ignore the
+    browser you just found". There is nothing to promise about a live pid."""
+    write_pgrep(fake_env["bin"], exit_code=1)
+    add_process(fake_env["proc"], 901, comm="brave",
+                cmdline=f"{BRAVE_EXE} --user-data-dir={fake_env['brave']}")
+    out = apply(fake_env,
+                env_extra={"DL_ROUTER_ASSUME_BROWSER_CLOSED": "1"})
+    assert out.returncode == EXIT_REFUSED, out.stdout + out.stderr
+    assert_untouched(fake_env)
 
 
 def test_the_refusal_exit_code_is_stable(fake_env):
     """Other tooling keys off it; 3 means "refused", not "failed"."""
+    write_pgrep(fake_env["bin"], exit_code=1)
+    add_process(fake_env["proc"], 901, comm="brave",
+                cmdline=f"{BRAVE_EXE} --user-data-dir={fake_env['brave']}")
+    assert apply(fake_env).returncode == 3
+
+
+# --- the guard: against a real /proc --------------------------------------- #
+@pytest.mark.skipif(not Path("/proc/self/fd").is_dir(), reason="needs procfs")
+def test_a_real_process_holding_the_profile_open_blocks(fake_env):
+    """The fabricated process tables above are only as good as their fidelity
+    to procfs. Prove the reader works against the real thing."""
+    write_pgrep(fake_env["bin"], exit_code=1)
+    child = subprocess.Popen(
+        [sys.executable, "-c",
+         "import sys, time\n"
+         "fh = open(sys.argv[1])\n"
+         "sys.stdout.write('ok'); sys.stdout.flush()\n"
+         "time.sleep(120)\n",
+         str(fake_env["profile"] / "Preferences")],
+        stdout=subprocess.PIPE)
+    try:
+        assert child.stdout.read(2) == b"ok", "child never opened the file"
+        out = apply(fake_env, env_extra={"DL_ROUTER_PROC_DIR": "/proc"})
+        assert out.returncode == EXIT_REFUSED, out.stdout + out.stderr
+        assert f"pid {child.pid}" in out.stderr
+        assert_untouched(fake_env)
+    finally:
+        child.kill()
+        child.wait()
+        child.stdout.close()
+
+
+@pytest.mark.skipif(not Path("/proc/self/fd").is_dir(), reason="needs procfs")
+def test_a_real_process_table_with_no_holder_does_not_block(fake_env):
+    """The other half: whatever else this machine is running -- headless
+    browsers included -- nothing is using THIS directory, so it applies."""
     write_pgrep(fake_env["bin"], exit_code=0)
-    assert run(fake_env, "--profile", "Profile 2",
-               "--root", str(fake_env["library"])).returncode == 3
+    out = apply(fake_env, env_extra={"DL_ROUTER_PROC_DIR": "/proc"})
+    assert out.returncode == 0, out.stdout + out.stderr
+    assert_applied(fake_env)
 
 
 # --- argument handling ----------------------------------------------------- #
@@ -204,8 +442,22 @@ def test_dry_run_writes_nothing(fake_env):
               "--root", str(fake_env["library"]), "--dry-run")
     assert out.returncode == 0, out.stderr
     assert "dry run" in out.stdout
-    assert prefs(fake_env)["download"]["default_directory"] == "/old/path"
-    assert not list(fake_env["profile"].glob("Preferences.dl-router-backup-*"))
+    assert_untouched(fake_env)
+
+
+def test_dry_run_is_not_gated_on_the_browser(fake_env):
+    """It writes nothing by construction, so refusing only forced the user to
+    go and edit Preferences by hand -- which is what this script exists to make
+    unnecessary. Report the instance, then show the diff anyway."""
+    write_pgrep(fake_env["bin"], exit_code=1)
+    add_process(fake_env["proc"], 901, comm="brave",
+                cmdline=f"{BRAVE_EXE} --user-data-dir={fake_env['brave']}")
+    out = run(fake_env, "--profile", "Profile 2",
+              "--root", str(fake_env["library"]), "--dry-run")
+    assert out.returncode == 0, out.stdout + out.stderr
+    assert "dry run" in out.stdout
+    assert "pid 901" in out.stderr, "still say what would block the real run"
+    assert_untouched(fake_env)
 
 
 def test_a_backup_is_made_before_the_edit(fake_env):
@@ -227,5 +479,7 @@ def test_list_shows_the_profile_and_its_display_name(fake_env):
 
 def test_list_does_not_need_the_browser_to_be_closed(fake_env):
     write_pgrep(fake_env["bin"], exit_code=0)
+    add_process(fake_env["proc"], 901, comm="brave",
+                cmdline=f"{BRAVE_EXE} --user-data-dir={fake_env['brave']}")
     out = run(fake_env, "--list")
     assert out.returncode == 0, "listing is read-only"


### PR DESCRIPTION
fix(dl-router): gate setup-brave-profile.sh on the user-data-dir, not the binary name

The guard asked `pgrep -x brave` -- "does a process with that binary name
exist" -- and called a match "the browser is running". On a host that also
drives headless Brave for automation (Playwright/chromedp, each on its own
`--user-data-dir=/tmp/...`) that is a false positive essentially always: the
real browser fully closed, nothing holding the profile, a stale SingletonLock
pointing at a dead pid, and the one-time setup step still refuses. Measured on
the reporting host: 15 browser main processes, 14 of them headless instances on
throwaway directories.

`DL_ROUTER_ASSUME_BROWSER_CLOSED=1` did not help either -- it only covered
"pgrep could not answer", and here pgrep answered. Net effect: the safe tool is
unrunnable, which pushes the user toward hand-editing Preferences, which is the
exact thing the tool exists to prevent.

Ask the question that matters instead: is any live process using the
user-data-dir that contains the profile being patched?

  1. a process holding an open fd under that directory (kernel truth, no
     parsing, catches non-Brave holders such as the crashpad handler);
  2. a browser MAIN process -- no `--type=`, i.e. not a renderer/zygote/gpu
     child -- whose `--user-data-dir` resolves there, or that carries no
     `--user-data-dir` at all and is therefore on the default one. The
     `--type=` filter matters: children do not inherit the flag, so without it
     every headless instance drags ~10 processes that each look like a
     default-profile browser;
  3. `SingletonLock`, a `<host>-<pid>` symlink, but only while that pid is
     alive and is a browser. A stale lock must not block the script forever.

Chromium rewrites its own argv to set the process title, which collapses the
NUL separators into spaces -- on a live browser every process reads back as one
space-joined blob -- so the cmdline reader handles both shapes.

Fail-closed is preserved: no readable process table (or a checker that breaks
outright) still refuses, and DL_ROUTER_ASSUME_BROWSER_CLOSED=1 still overrides
exactly that case. It deliberately does NOT override a positively identified
instance -- there is nothing to guess about a live pid, and the refusal now
names it and the profile instead of the useless "the browser is running".

Also: `--dry-run` writes nothing by construction, so it is no longer gated --
a detected instance is reported as a warning and the diff is shown anyway.
`--list` was already ungated.

Tests: 29 in the module (was 17). 16 of them fail against the previous script,
including a real-procfs pair that proves the reader matches the kernel rather
than only the fabricated process tables. Full suite 593 pytest / 272 node.


## Verification

- `python3 -m pytest scripts/dl-router/tests -q` → **593 passed** (581 on main; +12 net in `test_setup_script.py`, 17 → 29).
- `node --test 'scripts/dl-router/tests/*.test.mjs'` → **272 pass, 0 fail** (unchanged).
- Same test file run against `origin/main`'s script: **16 failed, 13 passed** — every new/changed guard assertion fails on the old code.
- `shellcheck` clean, `bash -n` clean.
- Read-only probe of the reporting host's real `/proc` with the new reader: 15 browser main processes — 14 headless instances on throwaway directories (correctly ignored), 1 on the default user-data-dir (correctly identified, and it is the pid the live `SingletonLock` points at). The fd signal found 36 holders, all belonging to that one instance and none from the 14 headless ones. Guard runtime ~0.14 s against a real `/proc` with ~170 browser processes.

Not verified: the script was **not** run against the real profile (already configured; explicitly out of scope), so the end-to-end "apply with the real browser quit" path is unexercised. The blocking/ignoring logic was verified against real procfs, and the write path is unchanged from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
