### PR TITLE
docs(rules): require ≥2 measurements before a dimension-dependent claim

### DIFF
--- a/claude/PRINCIPLES.md
+++ b/claude/PRINCIPLES.md
@@ -3,6 +3,6 @@
 **Core Directive**: Evidence > assumptions · Code > documentation · Efficiency > verbosity
 
 - **Task-First**: Understand → Plan → Execute → Validate.
-- **Evidence-Based**: every claim verifiable by testing, metrics, or docs — not speculation.
+- **Evidence-Based**: every claim verifiable by testing, metrics, or docs — not speculation; and stated at the scope you actually measured, not beyond it.
 - **KISS / YAGNI / DRY**: build the simplest thing that works, only for current requirements; eliminate duplication.
 - **Reversibility-aware**: classify a change as reversible / costly / irreversible, and preserve a rollback path under uncertainty.

--- a/claude/RULES.md
+++ b/claude/RULES.md
@@ -9,9 +9,12 @@ Priority legend: **🔴 CRITICAL** (security/data/prod — never compromise) · 
 - **Deployed ≠ verified**: State them separately. "Deployed 0.3.6; not yet verified against the click path" is honest. "Shipped and verified" when you only confirmed the rollout is not.
 - **For UI/interaction bugs, reproduce the user's actual click path** (Playwright) before claiming fixed — don't infer from the code.
 - **When you can't verify, say so plainly** and hand the check to the user with exact steps.
+- **One measurement is not a general claim**: when the behavior depends on a dimension — depth, host, revision, cwd, timing, size, permissions — measure at ≥2 points (a boundary *and* a middle) before asserting it; behavior can differ, and even invert, between them. **Name the points you measured** so the claim carries its own scope. Applies double inside a code comment or test assertion — those outlive the session and get trusted on sight.
 
 ✅ "Deployed. Reproduced the FAB click via Playwright — modal opens. Verified."
 ❌ "FAB fixed and verified on-cluster." (rollout succeeded; click still does nothing)
+✅ "Tested at repo root (errors), depth 1 (stages whole tree), depth 2 (scoped) — the guard must block depth 1."
+❌ "Verified by execution that `git add ..` doesn't stage the tree." (only the repo root was tested)
 
 ## Memory Is a Hypothesis, Not Ground Truth 🔴
 **Triggers**: acting on a remembered fact — MEMORY.md, CLAUDE.md notes, prior diagnosis


### PR DESCRIPTION
## Why

Three times in a single session (2026-07-30), a claim was verified at **one point in a parameter space and generalised to the whole space**. Each produced a confident, execution-attributed statement that was wrong; two were written into source (a code comment and a test assertion) where a future reader would reasonably trust them. All three were caught by adversarial audit, not the author.

- `git add ..` tested at the repo **root** only — it errors there, so it was declared "not a blind-stage" and removed from a security guard's blocklist with the comment "verified by execution". From depth 1 it stages the **entire tree** (`git -C <repo>/sub add ..`, no `cd` needed). A test was also written asserting the allow was correct, so a later fix would have read as a regression.
- The same claim re-fixed by testing **depth 1** only — asserted "from a SUBDIRECTORY it stages the entire tree". Measured at three depths: root errors, depth 1 stages the tree, depth 2 is scoped. Wrong again, the same way, one round later.
- home-manager `force = true` checked on **one host** — the link appeared on the laptop; on workbench two consecutive switches returned rc=0, printed "Creating home file links", and silently left the file unmanaged. A one-host check would have shipped a silent no-op of exactly the drift the change existed to end.

The varying dimension differed each time (filesystem depth, host, revision) but the error was identical: **one sample, stated as general.**

## What changed

One bullet + one ✅/❌ pair in `## Verification Honesty 🔴` — it belongs there because it is about *what you are entitled to claim*, not about git. `PRINCIPLES.md`'s Evidence-Based line gains a matching clause: evidence makes a claim verifiable, but says nothing about its scope.

**+3 lines to `RULES.md`**, which is loaded into context every session on both hosts. No new subsection, no table, incidents not restated in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)