### PR TITLE
feat(dl-router): identity signals (Discord channel / forum thread), directory kinds, and a learning rule that only learns the discriminating signal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,10 +19,13 @@ __pycache__/
 
 # dl-router local state. None of this may ever be committed: config.toml holds
 # the library root and the qBittorrent credentials, `token` is the sidecar
-# bearer token, the SQLite store holds the alias table and the route log, and a
-# manifest names real files. A stray `cp config.example.toml config.toml` inside
-# the repo must not be stageable.
+# bearer token, the SQLite store holds the alias table and the route log, a
+# manifest names real files, and dirs.toml is a list of the operator's real
+# subject directories -- `dl-route dirs classify --out` will write it wherever
+# it is pointed. A stray `cp config.example.toml config.toml` inside the repo
+# must not be stageable, and neither must a draft written next to the code.
 /scripts/dl-router/config.toml
+/scripts/dl-router/dirs.toml
 /scripts/dl-router/token
 /scripts/dl-router/manifests/
 /scripts/dl-router/*.sqlite3

--- a/scripts/dl-router/README.md
+++ b/scripts/dl-router/README.md
@@ -54,7 +54,8 @@ existing directories are never renamed.
 | `server.py` | loopback HTTP sidecar (127.0.0.1:8791, bearer auth) |
 | `matcher.py` | deterministic scoring — no LLM, no network, no I/O |
 | `safety.py` | the one place a page-derived string becomes a path component |
-| `store.py` | SQLite: aliases, labelled examples, route log, host prior |
+| `store.py` | SQLite: aliases (+ provenance), examples, route log, host prior, picker-assigned kinds |
+| `dirkinds.py` | performer/category classification + the draft generator |
 | `dirindex.py` | mtime+TTL-cached scan of the library root |
 | `qbt.py` | qBittorrent WebUI client + runtime-derived path mapping |
 | `fetcher.py` | yt-dlp jobs for HLS/DASH sources |
@@ -78,12 +79,75 @@ Normalisation key: NFKD → strip diacritics → casefold → drop non-alphanume
 
 | Rule | Score |
 |---|---|
+| identity-signal alias hit (Discord channel, forum thread) | 1.00 |
 | exact alias hit, site-scoped | 1.00 |
 | exact alias hit, global | 0.90 |
 | normalised page tag/subject == directory key | 0.85 |
 | token-sequence containment, scaled by coverage | 0.60–0.80 |
 | filename token match | ≤ 0.50 |
 | host prior (last directory used on this site) | +0.05, display only |
+
+### Identity signals — the deterministic half
+
+Page scraping has a hard floor: a single-page app gives a content script
+nothing to read. The first evening of real traffic hit it — most downloads came
+from a chat CDN whose captured context was completely empty (`tags: []`,
+`title: ''`, `pageUrl: ''`), and scored 0.00.
+
+But the URL is structured. `identity_signals()` derives site-scoped alias keys
+from it and nothing else:
+
+| Signal | Key | Scope |
+|---|---|---|
+| Discord attachment (`cdn.discordapp.com`, `media.discordapp.net`) | `discord:<channel id>` | `discord.com` |
+| forum thread slug in the path | `thread:<slug>` | that forum's host |
+
+The first download from a channel or thread has no signal, opens the picker,
+and confirming it writes the key. Every later download from the same channel
+matches at **1.00 with nothing scraped from any page** — so a UI change on the
+source site cannot break routing that already works.
+
+The **same function** produces the keys the matcher looks up and the keys the
+learner writes, so "what we match on" and "what we learn" cannot drift apart.
+The URL table is a shared fixture asserted against *both* `matcher.py` and
+`extension/route_core.js`.
+
+**Subject ordering** follows from the same evidence: the URL thread slug leads,
+then the page title with the site's own branding removed, and the tag list
+trails both. On the one forum download that *did* capture context, the tag list
+was the forum's section names and other posters' usernames while the subject
+sat in the slug and the title.
+
+### Cross-host referrer carry
+
+A download from a paired file host has no context of its own — the page is a
+download button. The forum thread that sent the user there does have one, and it
+is carried **only when the link is provable**: a captured click whose `href` is
+this page, or the tab this one was opened from (`openerTabId`). There is
+deliberately no time window and no "the last thread I saw"; both are wrong
+exactly when several tabs are open, which is how anyone browses a forum. An
+unprovable link goes to the picker.
+
+### Directory kinds
+
+The library is not purely subject-keyed. `~/.config/dl-router/dirs.toml` (never
+committed) classifies each directory:
+
+```toml
+performer = ["Ada Lovelace"]     # a person or group
+category  = ["Field Recordings"] # unattributed material, filed by topic
+```
+
+* **Only a `performer` directory may auto-file.** A `category` always opens the
+  picker whatever it scores — a tag legitimately identifies the category, but a
+  tag is a weak claim about any *one* file.
+* **An unclassified directory never auto-files either.** Absence of a
+  classification is not permission.
+* `dl-route dirs classify` drafts the file from the live index with a
+  best-guess split and the reason on every line, so the review action is
+  "move this line", not "type every directory name".
+* Creating a directory through the picker **asks which kind it is** — otherwise
+  the new directory would silently interrupt every future download into it.
 
 Guards:
 
@@ -113,6 +177,47 @@ overwrites** — `conflictAction: "uniquify"` handles real collisions.
 Route provenance lives in SQLite only. There are deliberately **no
 `.dlmeta.json` sidecar files**: extra files inside the media directories would
 pollute them and risk confusing qBittorrent and media scanners.
+
+---
+
+## Learning — only the discriminating signal
+
+A correction is the only place the router gains knowledge, so it is also the
+only place it can gain *wrong* knowledge. The first version wrote an alias for
+the first three subject phrases of the context plus one at global scope; on a
+forum page that meant a section name and two other posters' usernames, one of
+them global. Four rows had to be deleted by hand, and nothing surfaced them.
+
+What `/learn` writes now depends on what the directory **is**:
+
+| Directory kind | Learns |
+|---|---|
+| `performer` | identity signals (Discord channel, thread slug) and a subject name found in the page title. **Never a tag.** |
+| `category` | the above, plus tag → directory aliases — site-scoped, capped, and only from an explicit confirmation |
+| unclassified | identity signals only |
+
+**No alias is ever learned at global scope.** A global alias applies on every
+site at once: the widest blast radius the store has, and the least evidence
+supports it. `dl-route alias set --site '*'` still exists for a deliberate one.
+
+Every candidate key is screened first, by rules that describe the *failure
+class* rather than the four strings that caused it — and every rule is measured
+from data the router already holds, because a vocabulary of "bad words" would
+be both unmaintainable and un-committable to a public repo:
+
+* shorter than 4 characters;
+* seen on **two or more different directories** in the labelled examples — the
+  signature of site chrome (a section name, an uploader's username), which
+  appears on everything, while a subject tag appears on one directory's pages;
+* part of the **site's own name**;
+* every word of it already appears in two or more library directories, which is
+  what a taxonomy reads like and a person's name does not;
+* a single token containing digits (a handle, not a name).
+
+`dl-route alias review` shows what has been learned with the evidence, the
+provenance and the hit count behind each row, riskiest first, flagging the
+global and suspicious ones. Refusals are reported back in `/learn`'s response
+rather than silently dropped.
 
 ---
 
@@ -278,7 +383,12 @@ never renamed.
 ## Setup
 
 1. **Configure.** `cp config.example.toml ~/.config/dl-router/config.toml` and
-   set `library_root`.
+   set `library_root`. Then classify the directories, or nothing will ever
+   auto-file:
+   ```
+   dl-route dirs classify --out ~/.config/dl-router/dirs.toml
+   $EDITOR ~/.config/dl-router/dirs.toml     # move the wrong lines
+   ```
 2. **Start the sidecar.** `home-manager switch` installs the
    `dl-router` systemd user service. Check with `dl-route status`.
 3. **Point the browser profile at the library.** With Brave **fully closed**:
@@ -315,16 +425,24 @@ never renamed.
 ## CLI
 
 ```
-dl-route status                      sidecar + index health
-dl-route dirs                        list routing targets
+dl-route status                      sidecar + index health + kind counts
+dl-route dirs                        list routing targets + their kinds
+dl-route dirs classify [--out P]     DRAFT the directory-kind file
 dl-route match --filename F --tag T  dry-run the matcher on a context
 dl-route log -n 20                   recent routing decisions
 dl-route alias list|set|rm           inspect/edit the alias table
+dl-route alias review [--json]       what was LEARNED, with evidence + hits
 dl-route backfill plan [--seed-aliases]  read-only (tree AND alias DB)
 dl-route backfill apply --manifest P.tsv [--dry-run]
 dl-route fetch URL --dir NAME        queue a yt-dlp job
 dl-route token                       print the bearer token
 ```
+
+`alias list` prints `*` for a global alias, and `alias rm --site '*'` accepts
+it — what is displayed is what is accepted. (`--site ''` still works.) `alias
+set` refuses a key that trips the suspicious-key screen unless you pass
+`--force`, and structured keys round-trip verbatim:
+`dl-route alias rm 'discord:<channel id>' --site discord.com`.
 
 ---
 
@@ -373,7 +491,10 @@ delegating to either standard library.
 
 ## Privacy
 
-Nothing about the library is committed. `library_root`, per-site rules,
-aliases, the route log, qBittorrent credentials and the bearer token all live
-under `~/.config/dl-router/` and `~/.local/share/dl-router/`. The sidecar's
-journal lines are metadata only. All fixtures in `tests/` are synthetic.
+Nothing about the library is committed. `library_root`, the directory-kind
+classification (`dirs.toml` — a list of the operator's private directory
+names), per-site rules, aliases, the route log, qBittorrent credentials and the
+bearer token all live under `~/.config/dl-router/` and
+`~/.local/share/dl-router/`. The sidecar's journal lines are metadata only. All
+fixtures in `tests/` are synthetic, including the URL table — no real channel
+id, host or forum appears anywhere in this repo.

--- a/scripts/dl-router/README.md
+++ b/scripts/dl-router/README.md
@@ -102,8 +102,9 @@ from it and nothing else:
 | Discord attachment (`cdn.discordapp.com`, `media.discordapp.net`) | `discord:<channel id>` | `discord.com` |
 | forum thread slug, **anchored** to a thread route | `thread:<slug>` | that forum's host |
 
-A slug is the path segment immediately after `/threads/`, `/topic/`, `/t/`,
-`showthread.php` or similar — and **nowhere else**. That is positional on
+A slug is the path segment immediately after an **unambiguous** thread route
+(`/threads/`, `/thread/`, `showthread.php`, `viewtopic.php`) — and nowhere else.
+`/topic/`, `/topics/` and `/t/` are deliberately not anchors; see below. That is positional on
 purpose. The first version took "the deepest segment with ≥2 words", and when a
 thread's own slug was a single word the *section* one level up won instead
 (`/forums/general-discussion/threads/aster.99/` → `general discussion`), so one
@@ -254,14 +255,24 @@ be both unmaintainable and un-committable to a public repo:
   (`poster1988`). Narrowed from "a single token containing any digit", which
   refused legitimate stage names.
 
-Refusals are **surfaced**, not silently dropped: they come back in `/learn`'s
-response and the sidecar logs a metadata-only count and reason-code line. An
-over-strict screen that nobody can see is the same failure as an over-loose one.
+A refusal is a **durable fact, not an event**. It is recorded in the store
+against its `(key, site, directory)` and listed permanently by
+`dl-route alias review` — which shows both halves: what was learned (evidence,
+provenance, hit count, riskiest first, global and suspicious rows flagged) and
+what was *refused* ("these will NEVER auto-file", with the reason and how many
+times it has recurred). An over-strict screen that nobody can see is the same
+failure as an over-loose one, so both are inspectable in one command.
 
-`dl-route alias review` shows what has been learned with the evidence, the
-provenance and the hit count behind each row, riskiest first, flagging the
-global and suspicious ones. Refusals are reported back in `/learn`'s response
-rather than silently dropped.
+The extension notifies **once per fact**, the first time a refusal is recorded.
+That shape was arrived at the hard way: three successive attempts filtered the
+*event* harder — the notification was first silent, then fired on every routine
+catch-all filing, then fired forever for a permanently-refused identity — and
+each fix carried the next defect, because the event is the wrong unit. What is
+worth saying is "this source will never be learned", which is true once. A
+suppression map in the extension cannot hold that either: MV3 tears the service
+worker down after ~30 s idle, so the map would empty and the notifications
+would resume. The store is the only durable place, and the notification is
+demoted to a one-time pointer at `alias review`.
 
 ---
 

--- a/scripts/dl-router/README.md
+++ b/scripts/dl-router/README.md
@@ -100,7 +100,21 @@ from it and nothing else:
 | Signal | Key | Scope |
 |---|---|---|
 | Discord attachment (`cdn.discordapp.com`, `media.discordapp.net`) | `discord:<channel id>` | `discord.com` |
-| forum thread slug in the path | `thread:<slug>` | that forum's host |
+| forum thread slug, **anchored** to a thread route | `thread:<slug>` | that forum's host |
+
+A slug is the path segment immediately after `/threads/`, `/topic/`, `/t/`,
+`showthread.php` or similar — and **nowhere else**. That is positional on
+purpose. The first version took "the deepest segment with ≥2 words", and when a
+thread's own slug was a single word the *section* one level up won instead
+(`/forums/general-discussion/threads/aster.99/` → `general discussion`), so one
+correction taught the router that an entire forum section meant one directory,
+at 1.00, with auto-file. A superlative over candidates ("deepest that
+qualifies", "longest that survives") picks the wrong thing exactly when the
+subject is short, and short subjects are the common case.
+
+Identity keys are **near-verbatim**: stopwords are kept, because
+`aster-vale-new-set` and `aster-vale-set` folding to one key silently repointed
+a live alias.
 
 The first download from a channel or thread has no signal, opens the picker,
 and confirming it writes the key. Every later download from the same channel
@@ -113,8 +127,10 @@ The URL table is a shared fixture asserted against *both* `matcher.py` and
 `extension/route_core.js`.
 
 **Subject ordering** follows from the same evidence: the URL thread slug leads,
-then the page title with the site's own branding removed, and the tag list
-trails both. On the one forum download that *did* capture context, the tag list
+then the page title with the site's own branding removed (**the first**
+surviving segment, not the longest — "longest wins" returned the *site* name
+whenever the subject was one word and the site's display name did not resemble
+its hostname), and the tag list trails both. On the one forum download that *did* capture context, the tag list
 was the forum's section names and other posters' usernames while the subject
 sat in the slug and the title.
 
@@ -122,11 +138,18 @@ sat in the slug and the title.
 
 A download from a paired file host has no context of its own — the page is a
 download button. The forum thread that sent the user there does have one, and it
-is carried **only when the link is provable**: a captured click whose `href` is
-this page, or the tab this one was opened from (`openerTabId`). There is
-deliberately no time window and no "the last thread I saw"; both are wrong
-exactly when several tabs are open, which is how anyone browses a forum. An
-unprovable link goes to the picker.
+is carried **only when the link is provable**, and there is exactly one proof:
+a captured click on another page whose `href`/`mediaSrc` is this page. When the
+opener tab is known, the donor must additionally be in it — `openerTabId` can
+only *narrow* the proof, never supply one.
+
+An opener-tab-only branch existed briefly and was **deleted, not tightened**.
+It took the newest capture from the opener tab with nothing binding it to the
+navigation that opened the tab, which is "the last thread I saw in that tab"
+wearing the word "provable" — and it went wrong on the ordinary pattern of
+opening a file host in a new tab and carrying on browsing. There is no time
+window either: a window is a guess about how fast someone browses. An
+unprovable link goes to the picker, which is the point.
 
 ### Directory kinds
 
@@ -143,9 +166,12 @@ category  = ["Field Recordings"] # unattributed material, filed by topic
   tag is a weak claim about any *one* file.
 * **An unclassified directory never auto-files either.** Absence of a
   classification is not permission.
-* `dl-route dirs classify` drafts the file from the live index with a
-  best-guess split and the reason on every line, so the review action is
-  "move this line", not "type every directory name".
+* `dl-route dirs classify` drafts the file from the live index with the reason
+  on every line, so the review action is "move this line", not "type every
+  directory name". **Everything starts in `category`** — nothing available to a
+  generator distinguishes a person's name from a topic, and `category` is the
+  side that asks, so a skimmed review leaves directories that ask too often
+  rather than directories that auto-file into the wrong place.
 * Creating a directory through the picker **asks which kind it is** — otherwise
   the new directory would silently interrupt every future download into it.
 
@@ -196,12 +222,24 @@ What `/learn` writes now depends on what the directory **is**:
 | `category` | the above, plus tag → directory aliases — site-scoped, capped, and only from an explicit confirmation |
 | unclassified | identity signals only |
 
-**No alias is ever learned at global scope.** A global alias applies on every
-site at once: the widest blast radius the store has, and the least evidence
-supports it. `dl-route alias set --site '*'` still exists for a deliberate one.
+**The correction path never learns a global alias.** A global alias applies on
+every site at once: the widest blast radius the store has, and the least
+evidence supports it. Two deliberate, explicitly-invoked exceptions remain, and
+both show up flagged in `alias review`: `dl-route alias set --site '*' --force`,
+and `backfill plan --seed-aliases` (which has no site to scope to — the seeds
+come from directory and torrent names, not from a page).
 
-Every candidate key is screened first, by rules that describe the *failure
-class* rather than the four strings that caused it — and every rule is measured
+**The catch-all learns nothing at all.** Sending a download there is "not any
+of these" — the absence of a subject rather than evidence of one.
+
+Every candidate key is screened first — **including the identity signals**. A
+badly derived identity is still an identity as far as the store is concerned,
+and it lands at 1.00 *with* auto-file rather than at 0.85 without, so the worst
+row the router can write must not be the one row nothing checks. Structured
+keys skip only the two rules that describe a word rather than a source
+(minimum length, handle shape).
+
+The rules describe the *failure class* rather than the four strings that caused it — and every rule is measured
 from data the router already holds, because a vocabulary of "bad words" would
 be both unmaintainable and un-committable to a public repo:
 
@@ -212,7 +250,13 @@ be both unmaintainable and un-committable to a public repo:
 * part of the **site's own name**;
 * every word of it already appears in two or more library directories, which is
   what a taxonomy reads like and a person's name does not;
-* a single token containing digits (a handle, not a name).
+* it reads as a handle — a word with a number stuck on the end
+  (`poster1988`). Narrowed from "a single token containing any digit", which
+  refused legitimate stage names.
+
+Refusals are **surfaced**, not silently dropped: they come back in `/learn`'s
+response and the sidecar logs a metadata-only count and reason-code line. An
+over-strict screen that nobody can see is the same failure as an over-loose one.
 
 `dl-route alias review` shows what has been learned with the evidence, the
 provenance and the hit count behind each row, riskiest first, flagging the

--- a/scripts/dl-router/SKILL.md
+++ b/scripts/dl-router/SKILL.md
@@ -87,7 +87,10 @@ dl-route alias review          # evidence, provenance and hit count per row
 ```
 
 **"It learned something wrong."** `dl-route alias review` flags global and
-suspicious rows and prints the exact removal command. A performer directory
+suspicious rows, lists every **refused** candidate with its reason and how many
+times it has recurred, and prints the exact removal command. A refused
+candidate never auto-files — if one is a real subject,
+`dl-route alias set '<phrase>' '<Dir>' --site <host> --force`. A performer directory
 never learns a tag, and nothing is ever learned at global scope, so a bad row
 now means either a manual `alias set --force` or a category confirmation.
 ```bash

--- a/scripts/dl-router/SKILL.md
+++ b/scripts/dl-router/SKILL.md
@@ -236,6 +236,15 @@ Editing the sidecar requires a `home-manager switch` (it runs from the nix
 store). `SKILL.md` and `dl-route` are out-of-store symlinks and track the
 working tree immediately.
 
+**Deploying a matching change is TWO steps, not one.** The extension carries
+its own copy of the matcher (`route_core.js`) for the cached fallback, so a
+`home-manager switch` alone leaves the OLD service worker running with the old
+rules — including, after the directory-kinds change, a `localDecide` with no
+kind gate, which will keep auto-filing from cache into a directory you have
+just reclassified as a category. Finish the deploy with a **full Brave
+restart** (not the reload button — the long-poll keeps the old worker alive,
+same gotcha as browser-bridge), then re-check `dl-route status`.
+
 ## Gotchas
 
 * Port **8791** — 8790 is already taken on the workbench.

--- a/scripts/dl-router/SKILL.md
+++ b/scripts/dl-router/SKILL.md
@@ -28,16 +28,20 @@ configured — the sidecar answers `/healthz` but every routing endpoint returns
 |---|---|
 | code | `scripts/dl-router/` (this repo) |
 | config | `~/.config/dl-router/config.toml` (**never committed**) |
+| directory kinds | `~/.config/dl-router/dirs.toml` (**never committed**) |
 | bearer token | `~/.config/dl-router/token` (0600, auto-created) |
 | aliases, route log | `~/.local/share/dl-router/dl-router.sqlite3` |
 | backfill manifests | `~/.local/share/dl-router/manifests/` |
 | service | `systemd --user` unit `dl-router` (from `nix/home.nix`) |
 | extension | `scripts/dl-router/extension/`, loaded unpacked per profile |
 
-**Never print the library root, directory names, filenames or the route log
-into a commit message, a PR, a doc, or any file in this repo.** The repo is
-public; the library is private. Synthetic names only (`Jane Doe`, `acme-studio`,
-`example-site.test`).
+**Never print the library root, directory names, filenames, the route log,
+alias keys, real channel ids, forum names or host names into a commit message,
+a PR, a doc, or any file in this repo.** The repo is public; the library is
+private. Synthetic names only (`Jane Doe`, `acme-studio`, `example-site.test`,
+`someforum.test`, and made-up snowflakes). This includes the output of
+`dl-route dirs classify` and `dl-route alias review` — both are lists of the
+operator's private taxonomy.
 
 ## Common tasks
 
@@ -55,11 +59,41 @@ dl-route alias set "<page tag>" "<Directory>" --site example-site.test
 Site-scoped aliases score 1.00 and beat everything else. Re-check with
 `dl-route match --tag "<page tag>" --site example-site.test`.
 
-**"It keeps asking instead of auto-filing."** The score is under
-`auto_threshold` (0.75) or two candidates are within `tie_margin`.
-`dl-route match …` shows the candidate list. Prefer adding an alias over
-lowering the threshold — the threshold is what keeps a wrong guess out of a
-subject directory.
+**"It keeps asking instead of auto-filing."** Check the reason string first —
+there are now four distinct causes and only one of them is the score:
+
+1. **`unclassified directory '<X>'`** — `~/.config/dl-router/dirs.toml` does not
+   list it. An unclassified directory NEVER auto-files. This is the most likely
+   cause on a host that has not run the classifier; `dl-route status` prints
+   `unclassified=N` for exactly this reason.
+   ```bash
+   dl-route dirs classify --out ~/.config/dl-router/dirs.toml   # then edit it
+   ```
+   The file is picked up live — no restart.
+2. **`category directory — always confirm`** — by design. A category is
+   confirmed every time, whatever it scores. Do not "fix" this by reclassifying
+   a genuine category as a performer.
+3. **`tie: …`** — two candidates within `tie_margin`.
+4. the score is under `auto_threshold` (0.75). `dl-route match …` shows the
+   candidate list. Prefer adding an alias over lowering the threshold — the
+   threshold is what keeps a wrong guess out of a subject directory.
+
+**"Everything from this chat channel / forum thread opens the picker."** That
+is the FIRST download from it, by design. Confirm it once and the identity
+alias is written; later downloads match at 1.00 with nothing scraped. Check
+what was learned:
+```bash
+dl-route alias review          # evidence, provenance and hit count per row
+```
+
+**"It learned something wrong."** `dl-route alias review` flags global and
+suspicious rows and prints the exact removal command. A performer directory
+never learns a tag, and nothing is ever learned at global scope, so a bad row
+now means either a manual `alias set --force` or a category confirmation.
+```bash
+dl-route alias rm '<key>' --site '*'          # `*` == global, as listed
+dl-route alias rm 'discord:<channel id>' --site discord.com
+```
 
 **"The undo / `change` button says it could not move the file."**
 `/relocate` refuses anything it cannot prove this router created — the library
@@ -176,7 +210,23 @@ Invariants the tests exist to protect — do not weaken them:
   the sidecar plus an idempotent `finish()` is what makes this true.
 * **Every page-derived string is validated before it becomes a path.**
   `safety.py` and `extension/sanitize.js` must agree; the same hostile-input
-  table is asserted against both.
+  table (`tests/fixtures/name_cases.json`) is asserted against both. After
+  touching either, re-run the differential fuzzer — it must print
+  `0 divergence(s)`:
+  ```bash
+  nix-shell -p nodejs python312 --run "python3 scripts/dl-router/tests/difffuzz.py"
+  ```
+* **Identity signals must agree across the two languages too.**
+  `matcher.py` and `extension/route_core.js` both derive a Discord channel id
+  and a forum thread slug from a URL, and the extension's copy runs exactly
+  when the sidecar is unreachable — so a divergence is invisible until it
+  misfiles. `tests/fixtures/url_cases.json` is the one table both suites
+  assert. Add a row there before adding a URL shape to either implementation.
+* **Only a `performer` directory may auto-file**, in the cached fallback as
+  well as in the sidecar. Weakening the gate on one side only re-creates a
+  divergence that shows up solely when the sidecar is down.
+* **Nothing is ever learned at global scope**, and a performer directory never
+  learns a tag. That is the fix for the mislearning incident, not a preference.
 * **yt-dlp is invoked as an argv list with a validated http(s) URL and a `--`
   terminator** — never a shell string. The URL comes from a web page.
 * **The sidecar refuses any non-loopback bind**, with no override.

--- a/scripts/dl-router/backfill.py
+++ b/scripts/dl-router/backfill.py
@@ -209,7 +209,7 @@ def seed_aliases(store, dir_names, torrents=None, path_map=None,
 def plan(root, *, store, dir_names, matcher: Matcher | None = None,
          torrents=None, path_map=None, threshold: float = 0.75,
          clock=time.time, do_seed: bool = True, persist_seeds: bool = False,
-         files_for=None) -> Plan:
+         files_for=None, dir_kinds=None) -> Plan:
     """Build a manifest for the loose root files.
 
     READ-ONLY by default: it writes nothing into the tree AND nothing into the
@@ -236,7 +236,15 @@ def plan(root, *, store, dir_names, matcher: Matcher | None = None,
         for key, target in seeds.items():
             aliases.setdefault((key, ""), target)
     if matcher is None:
-        matcher = Matcher(dir_names, aliases, threshold=threshold)
+        # `dir_kinds` matters here for the same reason it does live: the
+        # `result.auto` branch below is the one place a FILENAME-only signal
+        # can move a file, and only a `performer` directory may auto-file. An
+        # unclassified target therefore SKIPs -- which is this tool's safe
+        # answer and the one it defaults to everywhere else. Passing it in
+        # rather than leaving it empty keeps the plan honest about what the
+        # live router would do with the same row.
+        matcher = Matcher(dir_names, aliases, threshold=threshold,
+                          dir_kinds=dir_kinds)
     else:
         matcher.aliases = aliases
 

--- a/scripts/dl-router/backfill.py
+++ b/scripts/dl-router/backfill.py
@@ -202,7 +202,8 @@ def seed_aliases(store, dir_names, torrents=None, path_map=None,
     """PERSIST the seeds from `alias_seeds`. Returns how many were written."""
     seeds = alias_seeds(store, dir_names, torrents, path_map, root)
     for key, target in seeds.items():
-        store.upsert_alias(key, target, "")
+        store.upsert_alias(key, target, "", source="backfill-seed",
+                           evidence=key)
     return len(seeds)
 
 
@@ -225,7 +226,8 @@ def plan(root, *, store, dir_names, matcher: Matcher | None = None,
         seeds = alias_seeds(store, dir_names, torrents, path_map, root)
         if persist_seeds:
             for key, target in seeds.items():
-                store.upsert_alias(key, target, "")
+                store.upsert_alias(key, target, "", source="backfill-seed",
+                                   evidence=key)
             notes.append(f"seeded {len(seeds)} alias(es)")
         elif seeds:
             notes.append(f"{len(seeds)} alias(es) would be seeded "

--- a/scripts/dl-router/config.example.toml
+++ b/scripts/dl-router/config.example.toml
@@ -16,6 +16,16 @@ port = 8791
 
 # Auto-file at or above this score; below it the picker opens. Two candidates
 # within `tie_margin` of each other also go to the picker.
+#
+# The score is NOT the only gate. Only a directory classified `performer` in
+# ~/.config/dl-router/dirs.toml may auto-file at all: a `category` directory
+# always confirms, and an UNCLASSIFIED one does too. Generate a draft to
+# review with:
+#
+#     dl-route dirs classify --out ~/.config/dl-router/dirs.toml
+#
+# Until that file exists nothing auto-files, which is the safe end of the
+# range, not a misconfiguration.
 auto_threshold = 0.75
 tie_margin = 0.05
 

--- a/scripts/dl-router/config.py
+++ b/scripts/dl-router/config.py
@@ -4,6 +4,8 @@ Everything host-specific lives OUTSIDE the repo:
 
     ~/.config/dl-router/config.toml   settings (library root, qBittorrent creds,
                                       per-site capture rules)
+    ~/.config/dl-router/dirs.toml     directory kinds (performer/category) —
+                                      see dirkinds.py
     ~/.config/dl-router/token         bearer token, 0600, auto-created
     ~/.local/share/dl-router/         SQLite store + backfill manifests
 
@@ -14,6 +16,7 @@ endpoints until it is configured.
 Env overrides (all optional, mainly for tests + the systemd unit):
 
     DL_ROUTER_CONFIG        path to config.toml
+    DL_ROUTER_DIRS_FILE     path to dirs.toml (directory kinds)
     DL_ROUTER_STATE_DIR     state dir (SQLite, manifests)
     DL_ROUTER_TOKEN_FILE    bearer-token path
     DL_ROUTER_LIBRARY_ROOT  library root (overrides config.toml)

--- a/scripts/dl-router/config.py
+++ b/scripts/dl-router/config.py
@@ -122,14 +122,29 @@ def _deep_merge(base: dict, over: dict) -> dict:
 class Config:
     """Loaded configuration. Attribute access for the hot fields."""
 
-    __slots__ = ("data", "path", "state_dir", "token_file")
+    __slots__ = ("data", "path", "state_dir", "token_file", "_dirs_file")
 
     def __init__(self, data: dict, *, path: Path | None = None,
-                 state_dir: Path | None = None, token_file: Path | None = None):
+                 state_dir: Path | None = None, token_file: Path | None = None,
+                 dirs_file: Path | None = None):
         self.data = data
         self.path = path
         self.state_dir = Path(state_dir) if state_dir else default_state_dir()
         self.token_file = Path(token_file) if token_file else default_token_file()
+        self._dirs_file = Path(dirs_file) if dirs_file else None
+
+    @property
+    def dirs_file(self) -> Path:
+        """The directory-kind classification (see dirkinds.py).
+
+        Host-specific and never committed, so it lives beside config.toml
+        rather than in the repo. Imported lazily to keep this loader free of a
+        dependency on the matcher.
+        """
+        if self._dirs_file is not None:
+            return self._dirs_file
+        from dirkinds import default_dirs_file
+        return default_dirs_file()
 
     # --- hot fields ------------------------------------------------------- #
     @property
@@ -243,9 +258,12 @@ def load(path: Path | None = None, *, env=None) -> Config:
         else default_state_dir()
     token_file = Path(env["DL_ROUTER_TOKEN_FILE"]) if env.get("DL_ROUTER_TOKEN_FILE") \
         else default_token_file()
+    dirs_file = Path(env["DL_ROUTER_DIRS_FILE"]) \
+        if env.get("DL_ROUTER_DIRS_FILE") else None
 
     _validate(data)
-    return Config(data, path=path, state_dir=state_dir, token_file=token_file)
+    return Config(data, path=path, state_dir=state_dir, token_file=token_file,
+                  dirs_file=dirs_file)
 
 
 def _validate(data: dict) -> None:
@@ -311,8 +329,10 @@ def load_degraded(path: Path | None = None, *, env=None):
             if env.get("DL_ROUTER_STATE_DIR") else default_state_dir()
         token_file = Path(env["DL_ROUTER_TOKEN_FILE"]) \
             if env.get("DL_ROUTER_TOKEN_FILE") else default_token_file()
+        dirs_file = Path(env["DL_ROUTER_DIRS_FILE"]) \
+            if env.get("DL_ROUTER_DIRS_FILE") else None
         return Config(data, path=resolved, state_dir=state_dir,
-                      token_file=token_file), str(exc)
+                      token_file=token_file, dirs_file=dirs_file), str(exc)
 
 
 def load_or_create_token(path: Path | None = None) -> str:

--- a/scripts/dl-router/dirkinds.py
+++ b/scripts/dl-router/dirkinds.py
@@ -51,6 +51,14 @@ from matcher import (
 
 DIRS_FILE_ENV = "DL_ROUTER_DIRS_FILE"
 
+# The generator's third list. It is DELIBERATELY not a kind: `DirKinds` ignores
+# it, so everything parked there is unclassified and therefore asks. It exists
+# so the draft can pre-sort the directories it IS sure about (a single word,
+# digits, a shared vocabulary) without silently authorising the ones it is not.
+# Folding the ambiguous ones into `category` instead was safe, but it threw away
+# the whole labour saving for a library that is mostly people.
+ASK_LIST = "ask"
+
 # A word appearing in this many directory names is a taxonomy word, not a
 # subject. Same threshold, same reasoning as matcher.CHROME_DIR_SPREAD.
 SHARED_TOKEN_DIRS = 2
@@ -117,6 +125,11 @@ class DirKinds:
                             error=f"cannot read {path}: {exc}")
         errors = []
         seen: dict = {}
+        for key in raw:
+            if key not in (KIND_PERFORMER, KIND_CATEGORY, ASK_LIST):
+                errors.append(f"unknown list {key!r} — expected "
+                              f"{KIND_PERFORMER}, {KIND_CATEGORY} or "
+                              f"{ASK_LIST}")
         for kind in (KIND_PERFORMER, KIND_CATEGORY):
             value = raw.get(kind, [])
             if not isinstance(value, list):
@@ -205,8 +218,7 @@ def guess_kind(name: str, freq: dict):
         return KIND_CATEGORY, f"{len(toks)} words — long for a name"
     if all(freq.get(t, 0) >= SHARED_TOKEN_DIRS for t in toks):
         return KIND_CATEGORY, "every word is shared with other directories"
-    return KIND_CATEGORY, (f"{len(toks)} words — could be a name; MOVE IT UP "
-                           "if it is a person")
+    return ASK_LIST, f"{len(toks)} words — could be either; you decide"
 
 
 _TOML_ESCAPES = {
@@ -234,13 +246,14 @@ HEADER = """\
 # Save as ~/.config/dl-router/dirs.toml (or $DL_ROUTER_DIRS_FILE).  This file is
 # NEVER committed: it describes a private library.
 #
-# The only review action is to move a line between the two lists.  The comment
-# after each line is why the generator put it there.
+# The only review action is to move a line between the lists.  The comment after
+# each line is why the generator put it there.
 #
-# EVERYTHING STARTS IN `category`, ON PURPOSE.  Nothing here can tell a person's
-# name from a topic, and `category` is the side that ASKS -- so a skimmed review
-# leaves you with directories that ask too often, never with directories that
-# auto-file into the wrong place.  Move the ones that name a person up.
+# THE GENERATOR ONLY SORTS WHAT IT CAN PROVE -- a single word, digits, a
+# vocabulary shared with other directories.  Nothing available to it
+# distinguishes "Ada Lovelace" from "Field Recordings" (two capitalised words
+# either way), so those go to `ask` rather than being guessed onto the
+# auto-filing side.
 #
 #   performer  filed by subject identity.  MAY auto-file.  Learns only identity
 #              signals — a Discord channel id, a forum thread slug, a subject
@@ -249,8 +262,12 @@ HEADER = """\
 #              Learns tag -> directory aliases, site-scoped only, and only from
 #              an explicit confirmation.
 #
-# A directory in NEITHER list is unclassified: it never auto-files and never
-# learns a tag.  That is the safe end of the range, not a bug.
+#   ask        NOT A KIND -- this list is IGNORED, so everything in it is
+#              unclassified and therefore asks.  EMPTY IT as you review: move
+#              each line into `performer` or `category`.
+#
+# A directory in NONE of the lists is unclassified too: it never auto-files and
+# never learns a tag.  That is the safe end of the range, not a bug.
 """
 
 
@@ -262,7 +279,7 @@ def draft(dir_names, *, known=None) -> str:
     """
     names = sorted({str(n) for n in (dir_names or ()) if str(n).strip()})
     freq = _token_document_frequency(names)
-    buckets = {KIND_PERFORMER: [], KIND_CATEGORY: []}
+    buckets = {KIND_PERFORMER: [], KIND_CATEGORY: [], ASK_LIST: []}
     for name in names:
         settled = known.kind(name) if known is not None else KIND_UNKNOWN
         if settled in KINDS:
@@ -272,12 +289,11 @@ def draft(dir_names, *, known=None) -> str:
         buckets[kind].append((name, why))
 
     lines = [HEADER]
-    for kind in (KIND_PERFORMER, KIND_CATEGORY):
+    for kind in (KIND_PERFORMER, KIND_CATEGORY, ASK_LIST):
         rows = buckets[kind]
         lines.append(f"\n{kind} = [")
         if not rows:
-            lines.append("  # (none — move directories here from the other "
-                         "list)")
+            lines.append("  # (none — move directories here from another list)")
         width = max((len(toml_string(n)) for n, _ in rows), default=0)
         for name, why in rows:
             literal = toml_string(name) + ","

--- a/scripts/dl-router/dirkinds.py
+++ b/scripts/dl-router/dirkinds.py
@@ -1,0 +1,258 @@
+"""Directory KINDS — is this directory keyed by subject, or by category?
+
+The library is not purely subject-keyed. Some directories name a person or
+group ("performer"); others collect unattributed material by topic
+("category"). The two need opposite rules, and conflating them is what produced
+the mislearning that motivated this module:
+
+    performer   identity signals only. A Discord channel id, a forum thread
+                slug, a subject name in the page title. NEVER a tag: a tag list
+                on a forum page is section names and other posters' usernames,
+                and learning those aliased unrelated content into a subject's
+                directory at full confidence.
+    category    a tag IS the legitimate signal, so tag -> directory aliases are
+                allowed — site-scoped only, never global, and only from an
+                explicit confirmation.
+    unknown     never auto-files, and never learns a tag. Absence of a
+                classification is not permission.
+
+WHERE IT LIVES. The classification is a fact about the operator's private
+library, so it is never committed: `~/.config/dl-router/dirs.toml`, in the same
+directory as the rest of the host-specific config. The format is two arrays
+because the review action is "move this line to the other list":
+
+    performer = [
+      "Ada Lovelace",
+    ]
+    category = [
+      "Field Recordings",
+    ]
+
+`dl-route dirs classify` drafts that file from the live index with a best-guess
+split and a reason on every line, so the operator corrects rather than types.
+
+A SECOND, MACHINE-WRITTEN SOURCE exists: when a directory is created through
+the picker the extension asks which kind it is, and that answer goes into the
+SQLite store (`dir_kinds`), not into this file — appending to a human-edited
+TOML would either destroy their comments or need a round-tripping writer.
+`DirKinds.load` overlays the two with the human file winning, which is the
+right precedence: the file is the thing they reviewed.
+"""
+from __future__ import annotations
+
+import os
+import tomllib
+from pathlib import Path
+
+from matcher import (
+    KIND_CATEGORY, KIND_PERFORMER, KIND_UNKNOWN, KINDS, content_tokens,
+    norm_key,
+)
+
+DIRS_FILE_ENV = "DL_ROUTER_DIRS_FILE"
+
+# A word appearing in this many directory names is a taxonomy word, not a
+# subject. Same threshold, same reasoning as matcher.CHROME_DIR_SPREAD.
+SHARED_TOKEN_DIRS = 2
+# A subject directory is a person's name: two or three words in practice.
+NAME_MIN_TOKENS = 2
+NAME_MAX_TOKENS = 3
+
+
+def default_dirs_file(env=None) -> Path:
+    env = os.environ if env is None else env
+    if env.get(DIRS_FILE_ENV):
+        return Path(env[DIRS_FILE_ENV])
+    return Path.home() / ".config" / "dl-router" / "dirs.toml"
+
+
+class DirKinds:
+    """Resolved directory classification. Read-only, cheap to rebuild."""
+
+    __slots__ = ("_by_key", "path", "present", "error")
+
+    def __init__(self, mapping=None, *, path=None, present: bool = False,
+                 error: str | None = None):
+        self._by_key: dict = {}
+        for name, kind in dict(mapping or {}).items():
+            key = norm_key(name)
+            if key and kind in KINDS:
+                self._by_key[key] = kind
+        self.path = Path(path) if path else None
+        self.present = bool(present)
+        self.error = error
+
+    # --- loading ----------------------------------------------------------- #
+    @staticmethod
+    def load(path=None, *, overlay=None, env=None) -> "DirKinds":
+        """Load the human file, overlaid on the machine-assigned kinds.
+
+        A missing file is normal (every directory is then UNKNOWN, so nothing
+        auto-files and nothing learns a tag — the safe end of the range). A
+        MALFORMED file degrades the same way rather than raising: this is
+        loaded on the /match path, and the sidecar failing a match is worse
+        than every match asking.
+        """
+        path = Path(path) if path is not None else default_dirs_file(env)
+        merged: dict = {}
+        for name, kind in dict(overlay or {}).items():
+            if kind in KINDS:
+                merged[name] = kind
+        if not path.exists():
+            return DirKinds(merged, path=path, present=False)
+        try:
+            with open(path, "rb") as fh:
+                raw = tomllib.load(fh)
+        except (OSError, tomllib.TOMLDecodeError) as exc:
+            return DirKinds(merged, path=path, present=True,
+                            error=f"cannot read {path}: {exc}")
+        errors = []
+        seen: dict = {}
+        for kind in (KIND_PERFORMER, KIND_CATEGORY):
+            value = raw.get(kind, [])
+            if not isinstance(value, list):
+                errors.append(f"{kind} must be a list of directory names")
+                continue
+            for item in value:
+                if not isinstance(item, str) or not item.strip():
+                    errors.append(f"{kind}: entries must be non-empty strings")
+                    continue
+                key = norm_key(item)
+                if not key:
+                    continue
+                if key in seen and seen[key] != kind:
+                    # Listed as BOTH. Ambiguous, so it resolves to unknown —
+                    # which asks — rather than to whichever list was read last.
+                    errors.append(f"{item!r} is in both lists — treated as "
+                                  "unclassified")
+                    merged.pop(item, None)
+                    seen[key] = None
+                    continue
+                seen[key] = kind
+                merged[item] = kind
+        for key, kind in seen.items():
+            if kind is None:
+                # Drop every spelling of an ambiguous directory.
+                for name in [n for n in merged if norm_key(n) == key]:
+                    merged.pop(name, None)
+        return DirKinds(merged, path=path, present=True,
+                        error="; ".join(errors) if errors else None)
+
+    # --- lookups ----------------------------------------------------------- #
+    def kind(self, name) -> str:
+        return self._by_key.get(norm_key(name), KIND_UNKNOWN)
+
+    def as_map(self) -> dict:
+        """`{norm_key: kind}` — the shape `Matcher(dir_kinds=...)` wants."""
+        return dict(self._by_key)
+
+    def counts(self, names) -> dict:
+        out = {KIND_PERFORMER: 0, KIND_CATEGORY: 0, KIND_UNKNOWN: 0}
+        for name in names or ():
+            out[self.kind(name)] += 1
+        return out
+
+    def unclassified(self, names) -> list:
+        return [n for n in (names or ()) if self.kind(n) == KIND_UNKNOWN]
+
+
+# --- the draft generator --------------------------------------------------- #
+def _token_document_frequency(names) -> dict:
+    freq: dict = {}
+    for name in names:
+        for tok in set(content_tokens(name)):
+            freq[tok] = freq.get(tok, 0) + 1
+    return freq
+
+
+def guess_kind(name: str, freq: dict):
+    """Best-guess kind for one directory, with the reason to print beside it.
+
+    Deliberately crude and deliberately EXPLAINED. It exists to save typing,
+    not to be right: every line carries why it landed where it did, so the
+    review is "does that reason hold?" rather than "what even is this?".
+    """
+    toks = content_tokens(name)
+    if not toks:
+        return KIND_CATEGORY, "no word-like content"
+    if any(any(ch.isdigit() for ch in t) for t in toks):
+        return KIND_CATEGORY, "contains digits"
+    if len(toks) < NAME_MIN_TOKENS:
+        return KIND_CATEGORY, "a single word"
+    if len(toks) > NAME_MAX_TOKENS:
+        return KIND_CATEGORY, f"{len(toks)} words — long for a name"
+    if all(freq.get(t, 0) >= SHARED_TOKEN_DIRS for t in toks):
+        return KIND_CATEGORY, "every word is shared with other directories"
+    return KIND_PERFORMER, f"{len(toks)} name-like words"
+
+
+_TOML_ESCAPES = {
+    "\\": "\\\\", '"': '\\"', "\b": "\\b", "\f": "\\f", "\n": "\\n",
+    "\r": "\\r", "\t": "\\t",
+}
+
+
+def toml_string(value: str) -> str:
+    """A TOML basic string. Escapes everything TOML requires escaped."""
+    out = []
+    for ch in str(value):
+        if ch in _TOML_ESCAPES:
+            out.append(_TOML_ESCAPES[ch])
+        elif ord(ch) < 0x20 or ord(ch) == 0x7F:
+            out.append("\\u%04X" % ord(ch))
+        else:
+            out.append(ch)
+    return '"' + "".join(out) + '"'
+
+
+HEADER = """\
+# dl-router — directory kinds.  DRAFT: review before use.
+#
+# Save as ~/.config/dl-router/dirs.toml (or $DL_ROUTER_DIRS_FILE).  This file is
+# NEVER committed: it describes a private library.
+#
+# The only review action is to move a line between the two lists.  The comment
+# after each line is why the generator put it there.
+#
+#   performer  filed by subject identity.  MAY auto-file.  Learns only identity
+#              signals — a Discord channel id, a forum thread slug, a subject
+#              name in the page title.  Never a tag.
+#   category   filed by topic.  ALWAYS opens the picker, whatever it scores.
+#              Learns tag -> directory aliases, site-scoped only, and only from
+#              an explicit confirmation.
+#
+# A directory in NEITHER list is unclassified: it never auto-files and never
+# learns a tag.  That is the safe end of the range, not a bug.
+"""
+
+
+def draft(dir_names, *, known=None) -> str:
+    """The draft TOML for `dir_names`, best-guess split, reason per line.
+
+    `known` (an existing DirKinds) is honoured over the guess, so re-running
+    the generator after a partial review does not undo it.
+    """
+    names = sorted({str(n) for n in (dir_names or ()) if str(n).strip()})
+    freq = _token_document_frequency(names)
+    buckets = {KIND_PERFORMER: [], KIND_CATEGORY: []}
+    for name in names:
+        settled = known.kind(name) if known is not None else KIND_UNKNOWN
+        if settled in KINDS:
+            buckets[settled].append((name, "already classified"))
+            continue
+        kind, why = guess_kind(name, freq)
+        buckets[kind].append((name, why))
+
+    lines = [HEADER]
+    for kind in (KIND_PERFORMER, KIND_CATEGORY):
+        rows = buckets[kind]
+        lines.append(f"\n{kind} = [")
+        if not rows:
+            lines.append("  # (none — move directories here from the other "
+                         "list)")
+        width = max((len(toml_string(n)) for n, _ in rows), default=0)
+        for name, why in rows:
+            literal = toml_string(name) + ","
+            lines.append(f"  {literal.ljust(width + 1)}  # {why}")
+        lines.append("]")
+    return "\n".join(lines) + "\n"

--- a/scripts/dl-router/dirkinds.py
+++ b/scripts/dl-router/dirkinds.py
@@ -150,8 +150,8 @@ class DirKinds:
                 if key in seen and seen[key] != kind:
                     # Listed as BOTH. Ambiguous, so it resolves to unknown —
                     # which asks — rather than to whichever list was read last.
-                    errors.append(f"{item!r} is in both lists — treated as "
-                                  "unclassified")
+                    errors.append(f"{item!r} appears in more than one list "
+                                  "— treated as unclassified")
                     merged.pop(item, None)
                     seen[key] = None
                     continue

--- a/scripts/dl-router/dirkinds.py
+++ b/scripts/dl-router/dirkinds.py
@@ -130,7 +130,12 @@ class DirKinds:
                 errors.append(f"unknown list {key!r} — expected "
                               f"{KIND_PERFORMER}, {KIND_CATEGORY} or "
                               f"{ASK_LIST}")
-        for kind in (KIND_PERFORMER, KIND_CATEGORY):
+        # ALL THREE lists, `ask` included. A name left in `performer` while a
+        # copy was moved to `ask` used to resolve to `performer` with no error
+        # -- so a half-finished review kept auto-filing the very directory the
+        # operator had just parked as undecided. Ambiguity resolves to unknown,
+        # which is this module's rule everywhere else.
+        for kind in (KIND_PERFORMER, KIND_CATEGORY, ASK_LIST):
             value = raw.get(kind, [])
             if not isinstance(value, list):
                 errors.append(f"{kind} must be a list of directory names")

--- a/scripts/dl-router/dirkinds.py
+++ b/scripts/dl-router/dirkinds.py
@@ -92,6 +92,14 @@ class DirKinds:
         MALFORMED file degrades the same way rather than raising: this is
         loaded on the /match path, and the sidecar failing a match is worse
         than every match asking.
+
+        A malformed file FAILS CLOSED COMPLETELY — the picker overlay is
+        dropped too. It used to seed `merged` from the overlay before parsing,
+        so picker-assigned `performer` kinds survived a broken file and kept
+        auto-filing while the operator believed their edit had disabled it. The
+        overlay is machine state and syntactically fine, but the file is the
+        authority over it, and "I cannot read the authority" is not a state in
+        which to keep auto-filing.
         """
         path = Path(path) if path is not None else default_dirs_file(env)
         merged: dict = {}
@@ -104,7 +112,8 @@ class DirKinds:
             with open(path, "rb") as fh:
                 raw = tomllib.load(fh)
         except (OSError, tomllib.TOMLDecodeError) as exc:
-            return DirKinds(merged, path=path, present=True,
+            # Everything, including the overlay -- see the docstring.
+            return DirKinds({}, path=path, present=True,
                             error=f"cannot read {path}: {exc}")
         errors = []
         seen: dict = {}
@@ -168,9 +177,22 @@ def _token_document_frequency(names) -> dict:
 def guess_kind(name: str, freq: dict):
     """Best-guess kind for one directory, with the reason to print beside it.
 
-    Deliberately crude and deliberately EXPLAINED. It exists to save typing,
-    not to be right: every line carries why it landed where it did, so the
-    review is "does that reason hold?" rather than "what even is this?".
+    IT GUESSES THE ASKING SIDE. Without a vocabulary of names — which could
+    never be committed to a public repo and would need endless maintenance —
+    nothing distinguishes "Ada Lovelace" from "Field Recordings": two
+    capitalised words either way. The first draft resolved that ambiguity
+    towards `performer`, which is the AUTO-FILING side, so a skimmed review
+    turned category directories into auto-filers. Its own docstring example,
+    "Field Recordings", drafted as a performer.
+
+    So the ambiguous case now lands in `category`, and the two failure modes
+    are no longer symmetric: skim this draft and the worst outcome is that a
+    performer directory keeps asking (mildly annoying, one line to move) rather
+    than a category directory silently auto-filing (wrong files, discovered
+    later, and the alias is learned too).
+
+    Every line still carries its reason, so the review is "does that hold?"
+    rather than "what even is this?".
     """
     toks = content_tokens(name)
     if not toks:
@@ -183,7 +205,8 @@ def guess_kind(name: str, freq: dict):
         return KIND_CATEGORY, f"{len(toks)} words — long for a name"
     if all(freq.get(t, 0) >= SHARED_TOKEN_DIRS for t in toks):
         return KIND_CATEGORY, "every word is shared with other directories"
-    return KIND_PERFORMER, f"{len(toks)} name-like words"
+    return KIND_CATEGORY, (f"{len(toks)} words — could be a name; MOVE IT UP "
+                           "if it is a person")
 
 
 _TOML_ESCAPES = {
@@ -213,6 +236,11 @@ HEADER = """\
 #
 # The only review action is to move a line between the two lists.  The comment
 # after each line is why the generator put it there.
+#
+# EVERYTHING STARTS IN `category`, ON PURPOSE.  Nothing here can tell a person's
+# name from a topic, and `category` is the side that ASKS -- so a skimmed review
+# leaves you with directories that ask too often, never with directories that
+# auto-file into the wrong place.  Move the ones that name a person up.
 #
 #   performer  filed by subject identity.  MAY auto-file.  Learns only identity
 #              signals — a Discord channel id, a forum thread slug, a subject

--- a/scripts/dl-router/dl-route
+++ b/scripts/dl-router/dl-route
@@ -2,10 +2,12 @@
 """dl-route — CLI for the media download router.
 
     dl-route status                     sidecar + index health
-    dl-route dirs                       list the routing targets
+    dl-route dirs                       list the routing targets + their kinds
+    dl-route dirs classify [--out P]    DRAFT the directory-kind file
     dl-route match --filename F [...]   dry-run the matcher on a context
     dl-route log [-n 20]                recent routing decisions
     dl-route alias list|set|rm          inspect/edit the alias table
+    dl-route alias review [--json]      what has been LEARNED, with evidence
     dl-route backfill plan [--seed-aliases]
     dl-route backfill apply --manifest PATH.tsv [--dry-run]
     dl-route fetch URL --dir NAME       queue a yt-dlp job via the sidecar
@@ -30,10 +32,39 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import backfill as backfill_mod  # noqa: E402
 import config as config_mod  # noqa: E402
+import dirkinds as dirkinds_mod  # noqa: E402
 import qbt as qbt_mod  # noqa: E402
 from dirindex import DirIndex  # noqa: E402
-from matcher import MatchContext, Matcher  # noqa: E402
+from matcher import (  # noqa: E402
+    KIND_UNKNOWN, MatchContext, Matcher, alias_key, suspicious_alias_key,
+)
 from store import Store  # noqa: E402
+
+# What `alias list` prints for a site-less (global) alias, and what `alias rm`
+# must therefore ACCEPT for one.
+#
+# It printed `*` and refused it: the site is stored as `''`, so `--site '*'`
+# looked for a literal-asterisk site and removed nothing, with a cheerful
+# "alias removed" either way. The most dangerous alias in the table -- a global
+# one, which applies on every site at once -- was the one that could not be
+# removed the obvious way.
+GLOBAL_SITE_DISPLAY = "*"
+
+
+def _site_arg(value) -> str:
+    """Normalise a `--site` argument to the stored representation.
+
+    `*` (what `alias list` prints) and `''` both mean GLOBAL. Hostnames fold to
+    lower case, because that is how the sidecar stores every site it derives.
+    """
+    text = str(value or "").strip()
+    if text in ("", GLOBAL_SITE_DISPLAY):
+        return ""
+    return text.lower()
+
+
+def _site_display(site: str) -> str:
+    return site or GLOBAL_SITE_DISPLAY
 
 
 def _cfg() -> config_mod.Config:
@@ -66,6 +97,12 @@ def _local_bits(cfg):
     return root, index, store
 
 
+def _kinds(cfg, store):
+    """The resolved directory classification (human file + picker answers)."""
+    return dirkinds_mod.DirKinds.load(cfg.dirs_file,
+                                      overlay=store.dir_kind_map())
+
+
 # --- commands ------------------------------------------------------------- #
 def cmd_status(args) -> int:
     cfg = _cfg()
@@ -76,10 +113,24 @@ def cmd_status(args) -> int:
     print(f"library    {root or '(unset — configure library_root)'}")
     if root is not None:
         index = DirIndex(root, other_dir=cfg.other_dir)
-        print(f"dirs       {len(index.names())}")
+        names = index.names()
+        print(f"dirs       {len(names)}")
         errs = index.errors()
         if errs:
             print(f"index errs {errs}")
+        kinds = _kinds(cfg, Store(cfg.db_path))
+        counts = kinds.counts(names)
+        print(f"dir kinds  {cfg.dirs_file}"
+              f"{'' if kinds.present else ' (absent)'}")
+        print(f"           performer={counts['performer']} "
+              f"category={counts['category']} "
+              f"unclassified={counts[KIND_UNKNOWN]}")
+        if kinds.error:
+            print(f"           ERROR {kinds.error}")
+        if counts[KIND_UNKNOWN]:
+            # The single most likely cause of "why does it ask every time?".
+            print("           unclassified directories never auto-file — "
+                  "run: dl-route dirs classify")
     try:
         health = _api(cfg, "GET", "/healthz", timeout=3.0)
         print(f"sidecar    up · {json.dumps(health)}")
@@ -90,9 +141,37 @@ def cmd_status(args) -> int:
 
 def cmd_dirs(args) -> int:
     cfg = _cfg()
-    root, index, _ = _local_bits(cfg)
+    root, index, store = _local_bits(cfg)
+    kinds = _kinds(cfg, store)
     for entry in index.entries():
-        print(f"{entry.name}\t{entry.key}")
+        print(f"{entry.name}\t{entry.key}\t{kinds.kind(entry.name)}")
+    return 0
+
+
+def cmd_dirs_classify(args) -> int:
+    """DRAFT the directory-kind file from the live index.
+
+    Writes nothing anywhere near the library, and prints to stdout by default:
+    the point is that the operator reviews a best-guess split and moves the
+    wrong lines, rather than typing every directory name by hand. The draft is
+    NEVER committed — it is a list of their private directories.
+    """
+    cfg = _cfg()
+    root, index, store = _local_bits(cfg)
+    text = dirkinds_mod.draft(index.names(), known=_kinds(cfg, store))
+    if not args.out:
+        sys.stdout.write(text)
+        print(f"\n# review, then save as {cfg.dirs_file}", file=sys.stderr)
+        return 0
+    out = Path(args.out)
+    if out.exists() and not args.force:
+        raise SystemExit(f"{out} exists — review it, or pass --force to "
+                         f"overwrite (already-classified entries are kept)")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(text, encoding="utf-8")
+    print(f"draft written: {out}", file=sys.stderr)
+    print("review it (move lines between the two lists), then it takes effect "
+          "on the next match", file=sys.stderr)
     return 0
 
 
@@ -101,12 +180,13 @@ def cmd_match(args) -> int:
     root, index, store = _local_bits(cfg)
     matcher = Matcher(index.entries(), store.alias_map(),
                       threshold=cfg.auto_threshold, tie_margin=cfg.tie_margin,
-                      other_dir=cfg.other_dir)
+                      other_dir=cfg.other_dir,
+                      dir_kinds=_kinds(cfg, store).as_map())
     ctx = MatchContext(
         filename=args.filename or "", url=args.url or "",
         referrer=args.referrer or "", site=args.site or "",
         title=args.title or "", tags=tuple(args.tag or ()),
-        link_text=args.link_text or "")
+        link_text=args.link_text or "", page_url=args.page_url or "")
     result = matcher.match(ctx, host_prior=store.host_prior(ctx.site))
     print(json.dumps(result.as_dict(), indent=2, ensure_ascii=False))
     return 0
@@ -121,20 +201,117 @@ def cmd_log(args) -> int:
     return 0
 
 
+def _alias_warning(cfg, store, phrase, key, site):
+    """Why this alias looks like a mistake, or None."""
+    root = cfg.library_root
+    names = DirIndex(root, other_dir=cfg.other_dir).names() if root else []
+    spread = store.phrase_dir_spread().get(key, 0)
+    why = suspicious_alias_key(phrase, key=key, dir_names=names, site=site,
+                               spread=spread)
+    if why:
+        return why
+    if not site:
+        return ("global scope — it applies on EVERY site, which is the widest "
+                "blast radius the alias table has")
+    return None
+
+
 def cmd_alias(args) -> int:
     cfg = _cfg()
     store = Store(cfg.db_path)
     if args.alias_cmd == "list":
         for (key, site), target in sorted(store.alias_map().items()):
-            print(f"{key}\t{site or '*'}\t{target}")
+            # `_site_display` and `_site_arg` are inverses, so what is printed
+            # here is exactly what `alias rm --site` accepts.
+            print(f"{key}\t{_site_display(site)}\t{target}")
+    elif args.alias_cmd == "review":
+        return cmd_alias_review(args, cfg, store)
     elif args.alias_cmd == "set":
-        from matcher import norm_key
-        store.upsert_alias(norm_key(args.phrase), args.dir, args.site or "")
-        print(f"alias set: {args.phrase!r} -> {args.dir}")
+        site = _site_arg(args.site)
+        key = alias_key(args.phrase)
+        if not key:
+            raise SystemExit(f"{args.phrase!r} does not produce an alias key")
+        warning = _alias_warning(cfg, store, args.phrase, key, site)
+        if warning and not args.force:
+            raise SystemExit(
+                f"refusing to write {key!r} -> {args.dir}: {warning}\n"
+                f"  pass --force if you mean it")
+        if warning:
+            print(f"warning: {warning}", file=sys.stderr)
+        store.upsert_alias(key, args.dir, site, source="manual",
+                           evidence=str(args.phrase))
+        print(f"alias set: {key!r} @ {_site_display(site)} -> {args.dir}")
     elif args.alias_cmd == "rm":
-        from matcher import norm_key
-        store.delete_alias(norm_key(args.phrase), args.site or "")
-        print(f"alias removed: {args.phrase!r}")
+        site = _site_arg(args.site)
+        key = alias_key(args.phrase)
+        if store.alias(key, site) is None:
+            # Silence here is how an un-removable alias stayed un-removed: the
+            # old command printed "alias removed" whether or not a row existed.
+            print(f"no alias {key!r} at site {_site_display(site)}",
+                  file=sys.stderr)
+            return 1
+        store.delete_alias(key, site)
+        print(f"alias removed: {key!r} @ {_site_display(site)}")
+    return 0
+
+
+def cmd_alias_review(args, cfg=None, store=None) -> int:
+    """Everything that has been LEARNED, with the evidence behind it.
+
+    This command exists because four wrong aliases -- a forum section name and
+    two other posters' usernames, one of them global -- sat in the table with
+    nothing to surface them. `alias list` printed three columns of keys; it
+    could not answer "what made you believe this?" or "has it ever fired?".
+    """
+    cfg = cfg or _cfg()
+    store = store or Store(cfg.db_path)
+    rows = store.alias_rows()
+    root = cfg.library_root
+    names = DirIndex(root, other_dir=cfg.other_dir).names() if root else []
+    spread = store.phrase_dir_spread()
+    for row in rows:
+        row["suspect"] = suspicious_alias_key(
+            row["evidence"] or row["key"], key=row["key"], dir_names=names,
+            site=row["site"], spread=spread.get(row["key"], 0))
+        row["global"] = not row["site"]
+    # Riskiest first: global scope, then flagged, then most-used.
+    rows.sort(key=lambda r: (not r["global"], r["suspect"] is None,
+                             -int(r["hits"]), r["key"]))
+
+    if getattr(args, "json", False):
+        print(json.dumps(rows, indent=2, ensure_ascii=False))
+        return 0
+
+    if not rows:
+        print("no aliases learned yet")
+        return 0
+    widths = {
+        "key": max(3, *(len(r["key"]) for r in rows)),
+        "site": max(4, *(len(_site_display(r["site"])) for r in rows)),
+        "dir": max(3, *(len(r["dir"]) for r in rows)),
+        "source": max(6, *(len(r["source"] or "?") for r in rows)),
+    }
+    flagged = sum(1 for r in rows if r["suspect"] or r["global"])
+    print(f"{len(rows)} alias(es), {flagged} worth a look  "
+          f"(! = suspicious or global)")
+    print(f"  {'KEY'.ljust(widths['key'])}  {'SITE'.ljust(widths['site'])}  "
+          f"{'DIR'.ljust(widths['dir'])}  HITS  "
+          f"{'SOURCE'.ljust(widths['source'])}  EVIDENCE")
+    for row in rows:
+        flag = "!" if (row["suspect"] or row["global"]) else " "
+        print(f"{flag} {row['key'].ljust(widths['key'])}  "
+              f"{_site_display(row['site']).ljust(widths['site'])}  "
+              f"{row['dir'].ljust(widths['dir'])}  "
+              f"{str(row['hits']).rjust(4)}  "
+              f"{(row['source'] or '?').ljust(widths['source'])}  "
+              f"{row['evidence'] or ''}")
+        if row["suspect"]:
+            print(f"    ^ {row['suspect']}")
+        elif row["global"]:
+            print("    ^ global scope — applies on every site")
+    if flagged:
+        print(f"\nremove one with: dl-route alias rm '<key>' --site "
+              f"'{GLOBAL_SITE_DISPLAY}'   (or --site <hostname>)")
     return 0
 
 
@@ -271,13 +448,27 @@ def build_parser() -> argparse.ArgumentParser:
     sub = p.add_subparsers(dest="cmd", required=True)
 
     sub.add_parser("status", help="sidecar + index health").set_defaults(fn=cmd_status)
-    sub.add_parser("dirs", help="list routing targets").set_defaults(fn=cmd_dirs)
     sub.add_parser("token", help="print the bearer token").set_defaults(fn=cmd_token)
+
+    d = sub.add_parser("dirs", help="list routing targets + their kinds")
+    d.set_defaults(fn=cmd_dirs)
+    # `required=False`: a bare `dl-route dirs` still lists.
+    dsub = d.add_subparsers(dest="dirs_cmd", required=False)
+    dc = dsub.add_parser(
+        "classify",
+        help="DRAFT the directory-kind file (performer vs category)")
+    dc.add_argument("--out", default="",
+                    help="write the draft here instead of stdout")
+    dc.add_argument("--force", action="store_true",
+                    help="overwrite an existing --out file")
+    dc.set_defaults(fn=cmd_dirs_classify)
 
     m = sub.add_parser("match", help="dry-run the matcher")
     m.add_argument("--filename", default="")
     m.add_argument("--url", default="")
     m.add_argument("--referrer", default="")
+    m.add_argument("--page-url", default="",
+                   help="the page the download was clicked on (thread slug)")
     m.add_argument("--site", default="")
     m.add_argument("--title", default="")
     m.add_argument("--link-text", default="")
@@ -290,14 +481,22 @@ def build_parser() -> argparse.ArgumentParser:
 
     al = sub.add_parser("alias", help="inspect/edit aliases")
     alsub = al.add_subparsers(dest="alias_cmd", required=True)
-    alsub.add_parser("list")
+    alsub.add_parser("list", help="key / site / dir, one per line")
+    arev = alsub.add_parser(
+        "review", help="what has been LEARNED, with evidence and hit counts")
+    arev.add_argument("--json", action="store_true")
     aset = alsub.add_parser("set")
     aset.add_argument("phrase")
     aset.add_argument("dir")
-    aset.add_argument("--site", default="")
+    # `*` and `''` both mean global, so what `alias list` PRINTS is accepted.
+    aset.add_argument("--site", default="",
+                      help=f"hostname, or '{GLOBAL_SITE_DISPLAY}'/'' for global")
+    aset.add_argument("--force", action="store_true",
+                      help="write it even though it looks like a mistake")
     arm = alsub.add_parser("rm")
     arm.add_argument("phrase")
-    arm.add_argument("--site", default="")
+    arm.add_argument("--site", default="",
+                     help=f"hostname, or '{GLOBAL_SITE_DISPLAY}'/'' for global")
     al.set_defaults(fn=cmd_alias)
 
     bf = sub.add_parser("backfill", help="plan/apply the loose-file backfill")

--- a/scripts/dl-router/dl-route
+++ b/scripts/dl-router/dl-route
@@ -36,7 +36,8 @@ import dirkinds as dirkinds_mod  # noqa: E402
 import qbt as qbt_mod  # noqa: E402
 from dirindex import DirIndex  # noqa: E402
 from matcher import (  # noqa: E402
-    KIND_UNKNOWN, MatchContext, Matcher, alias_key, suspicious_alias_key,
+    KIND_UNKNOWN, MatchContext, Matcher, alias_key, norm_key,
+    suspicious_alias_key,
 )
 from store import Store  # noqa: E402
 
@@ -223,7 +224,12 @@ def _alias_warning(cfg, store, phrase, key, site):
     """Why this alias looks like a mistake, or None."""
     root = cfg.library_root
     names = DirIndex(root, other_dir=cfg.other_dir).names() if root else []
-    spread = store.phrase_dir_spread().get(key, 0)
+    # `norm_key(phrase)`, the same key the SERVER screens on. Keying this on
+    # the stored alias key instead meant the two never agreed for a structured
+    # row -- so `alias review`, the tool whose whole job is to surface exactly
+    # those rows, could not reproduce the server's verdict on them.
+    spread = store.phrase_dir_spread(
+        other_dir=cfg.other_dir).get(norm_key(phrase), 0)
     why = suspicious_alias_key(phrase, key=key, dir_names=names, site=site,
                                spread=spread)
     if why:
@@ -286,11 +292,12 @@ def cmd_alias_review(args, cfg=None, store=None) -> int:
     rows = store.alias_rows()
     root = cfg.library_root
     names = DirIndex(root, other_dir=cfg.other_dir).names() if root else []
-    spread = store.phrase_dir_spread()
+    spread = store.phrase_dir_spread(other_dir=cfg.other_dir)
     for row in rows:
+        evidence = row["evidence"] or row["key"]
         row["suspect"] = suspicious_alias_key(
-            row["evidence"] or row["key"], key=row["key"], dir_names=names,
-            site=row["site"], spread=spread.get(row["key"], 0))
+            evidence, key=row["key"], dir_names=names,
+            site=row["site"], spread=spread.get(norm_key(evidence), 0))
         row["global"] = not row["site"]
     # Riskiest first: global scope, then flagged, then most-used.
     rows.sort(key=lambda r: (not r["global"], r["suspect"] is None,

--- a/scripts/dl-router/dl-route
+++ b/scripts/dl-router/dl-route
@@ -118,7 +118,11 @@ def cmd_status(args) -> int:
         errs = index.errors()
         if errs:
             print(f"index errs {errs}")
-        kinds = _kinds(cfg, Store(cfg.db_path))
+        # Read-only: do NOT construct a Store when there is no database yet
+        # (it would create the state directory as a side effect of `status`).
+        store = Store(cfg.db_path) if cfg.db_path.exists() else None
+        kinds = (_kinds(cfg, store) if store is not None
+                 else dirkinds_mod.DirKinds.load(cfg.dirs_file))
         counts = kinds.counts(names)
         print(f"dir kinds  {cfg.dirs_file}"
               f"{'' if kinds.present else ' (absent)'}")
@@ -158,7 +162,8 @@ def cmd_dirs_classify(args) -> int:
     """
     cfg = _cfg()
     root, index, store = _local_bits(cfg)
-    text = dirkinds_mod.draft(index.names(), known=_kinds(cfg, store))
+    known = _kinds(cfg, store)
+    text = dirkinds_mod.draft(index.names(), known=known)
     if not args.out:
         sys.stdout.write(text)
         print(f"\n# review, then save as {cfg.dirs_file}", file=sys.stderr)
@@ -167,6 +172,19 @@ def cmd_dirs_classify(args) -> int:
     if out.exists() and not args.force:
         raise SystemExit(f"{out} exists — review it, or pass --force to "
                          f"overwrite (already-classified entries are kept)")
+    # --force is safe ONLY because an existing classification is carried into
+    # the draft. When the current file cannot be PARSED there is nothing to
+    # carry, so --force would silently reset every decision in it -- the one
+    # destructive act available from a command whose whole job is to be
+    # read-only. Refuse, and say what to do instead.
+    if out.exists() and args.force:
+        existing = dirkinds_mod.DirKinds.load(out)
+        if existing.error:
+            raise SystemExit(
+                f"refusing to overwrite {out}: it exists but cannot be parsed "
+                f"({existing.error}), so none of its classifications can be "
+                f"carried into the draft and --force would discard them all.\n"
+                f"  fix the syntax, or move the file aside first")
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(text, encoding="utf-8")
     print(f"draft written: {out}", file=sys.stderr)

--- a/scripts/dl-router/dl-route
+++ b/scripts/dl-router/dl-route
@@ -371,7 +371,8 @@ def cmd_backfill_plan(args) -> int:
                                  torrents=torrents, path_map=path_map,
                                  threshold=cfg.auto_threshold,
                                  persist_seeds=args.seed_aliases,
-                                 files_for=files_for)
+                                 files_for=files_for,
+                                 dir_kinds=_kinds(cfg, store).as_map())
     paths = backfill_mod.write_manifest(plan_obj, cfg.state_dir / "manifests")
     print(plan_obj.to_tsv())
     print(f"counts: {plan_obj.counts()}", file=sys.stderr)

--- a/scripts/dl-router/dl-route
+++ b/scripts/dl-router/dl-route
@@ -303,13 +303,20 @@ def cmd_alias_review(args, cfg=None, store=None) -> int:
     rows.sort(key=lambda r: (not r["global"], r["suspect"] is None,
                              -int(r["hits"]), r["key"]))
 
+    refused = store.screened_rows()
+
     if getattr(args, "json", False):
-        print(json.dumps(rows, indent=2, ensure_ascii=False))
+        print(json.dumps({"aliases": rows, "refused": refused}, indent=2,
+                         ensure_ascii=False)
+              if refused else json.dumps(rows, indent=2, ensure_ascii=False))
         return 0
 
     if not rows:
+        # NOT an early return: "nothing was learned" is the most interesting
+        # moment to see WHAT WAS REFUSED, and printing only this line hid the
+        # refusals in exactly that case.
         print("no aliases learned yet")
-        return 0
+        return _print_refused(refused)
     widths = {
         "key": max(3, *(len(r["key"]) for r in rows)),
         "site": max(4, *(len(_site_display(r["site"])) for r in rows)),
@@ -337,6 +344,29 @@ def cmd_alias_review(args, cfg=None, store=None) -> int:
     if flagged:
         print(f"\nremove one with: dl-route alias rm '<key>' --site "
               f"'{GLOBAL_SITE_DISPLAY}'   (or --site <hostname>)")
+
+    return _print_refused(refused)
+
+
+def _print_refused(refused) -> int:
+    """REFUSALS ARE THE OTHER HALF OF "what has been learned".
+
+    A screened candidate writes no alias row, so before this it existed nowhere
+    the operator could look: the only surface was a notification that fires
+    once. This is the permanent one, and it is what makes the over-strict half
+    of the screen as visible as the over-loose half.
+    """
+    if not refused:
+        return 0
+    print(f"\n{len(refused)} refused candidate(s) — these will NEVER "
+          f"auto-file:")
+    for row in refused:
+        print(f"  {row['key']}  @ {_site_display(row['site'])}"
+              f"  -> {row['dir']}  ({row['source'] or '?'}, seen "
+              f"{row['hits']}x)")
+        print(f"    ^ {row['why']}")
+    print("\nif one of these is a real subject: dl-route alias set "
+          "'<phrase>' '<Directory>' --site <hostname> --force")
     return 0
 
 

--- a/scripts/dl-router/extension/picker.js
+++ b/scripts/dl-router/extension/picker.js
@@ -16,6 +16,21 @@ import { contentTokens, normKey } from "./route_core.js";
 
 export const ENTRY_NEW = "new";
 export const ENTRY_DIR = "dir";
+export const ENTRY_KIND = "kind";
+
+// The two directory kinds, and the one-line explanation of each. Creating a
+// directory without saying which it is leaves it UNCLASSIFIED, and an
+// unclassified directory never auto-files -- so it would silently interrupt
+// every future download into it. Hence a second keypress, not an assumption.
+export const KIND_CHOICES = [
+  { name: "performer", label: "performer - a person or group (may auto-file)" },
+  { name: "category", label: "category - a topic (always asks first)" },
+];
+
+export function kindEntries() {
+  return KIND_CHOICES.map((k) => ({ kind: ENTRY_KIND, name: k.name,
+    label: k.label }));
+}
 
 // How hard mount() tries to get the directory list before giving up. A cold
 // service worker needs one storage read; these bounds cover a slow wake without
@@ -97,6 +112,9 @@ export function initialState({ dirs = [], suggestNew = "", downloadId = null,
     error: "",
     status: "",
     pendingEnter: false,
+    // The name of a directory the user asked to CREATE, while we ask which
+    // kind it is. Non-null means the list on screen is the kind prompt.
+    pendingNew: null,
     query: "", index: 0, done: null,
   };
   state.entries = filterEntries(dirs, "", suggestNew);
@@ -138,6 +156,37 @@ export function reduce(state, event) {
   }
   if (state.done) return state;
   const next = { ...state };
+  // --- the kind prompt --------------------------------------------------- //
+  // A modal sub-step, handled BEFORE the normal branches so a stray `input`
+  // (the text box keeps focus) cannot rebuild the list out from under it.
+  if (state.pendingNew) {
+    if (event.type !== "key") return state;
+    if (event.key === "ArrowDown") {
+      next.index = Math.min(state.index + 1, state.entries.length - 1);
+      return next;
+    }
+    if (event.key === "ArrowUp") {
+      next.index = Math.max(state.index - 1, 0);
+      return next;
+    }
+    if (event.key === "Escape") {
+      // Back to the directory list, NOT out of the picker. Escaping a
+      // sub-question should undo the sub-question.
+      next.pendingNew = null;
+      next.entries = filterEntries(state.dirs, state.query, state.suggestNew);
+      next.index = 0;
+      return next;
+    }
+    if (event.key === "Enter") {
+      const choice = state.entries[state.index];
+      if (!choice) return state;
+      next.pendingNew = null;
+      next.done = { action: "choose", dir: state.pendingNew,
+        createdNew: true, kind: choice.name };
+      return next;
+    }
+    return state;
+  }
   if (event.type === "input") {
     // Typing is a new attempt: the previous refusal is no longer what the
     // screen is about. It used to persist through the retype AND through the
@@ -204,10 +253,17 @@ export function reduce(state, event) {
       const entry = state.entries[state.index];
       if (!entry) return state;
       next.error = "";
+      if (entry.kind === ENTRY_NEW) {
+        // One more question before anything is created.
+        next.pendingNew = entry.name;
+        next.entries = kindEntries();
+        next.index = 0;
+        return next;
+      }
       next.done = {
         action: "choose",
         dir: entry.name,
-        createdNew: entry.kind === ENTRY_NEW,
+        createdNew: false,
       };
       return next;
     }
@@ -255,7 +311,9 @@ export function mount(doc, chromeApi, { closeWindow } = {}) {
     // render() erased it -- and any event during an in-flight choose triggers
     // one, so an Escape mid-choose left a BLANK meta line on a picker that is
     // (correctly) unresponsive until the choose settles.
-    meta.textContent = state.status || state.error || state.reason;
+    meta.textContent = state.pendingNew
+      ? `New directory "${state.pendingNew}" - which kind? (Esc to go back)`
+      : (state.status || state.error || state.reason);
     if (state.dup) dup.textContent = state.dup;
   };
   renderMeta();
@@ -291,12 +349,17 @@ export function mount(doc, chromeApi, { closeWindow } = {}) {
       apply({ type: "choosing", dir: done.dir });
       let resp;
       try {
-        resp = await chromeApi.runtime.sendMessage({
+        const message = {
           type: "dlr:choose",
           downloadId,
           dir: done.dir,
           createdNew: done.createdNew,
-        });
+        };
+        // Only on creation, and only ever set by the kind prompt -- so
+        // selecting an existing directory sends exactly the message it always
+        // did, with no `kind: undefined` riding along.
+        if (done.kind) message.kind = done.kind;
+        resp = await chromeApi.runtime.sendMessage(message);
       } catch (err) {
         // `err.message`, not String(err): String() prepends "Error: ", the
         // exact shape just removed from the sidecar path.

--- a/scripts/dl-router/extension/route_core.js
+++ b/scripts/dl-router/extension/route_core.js
@@ -93,9 +93,20 @@ const SNOWFLAKE = /^[0-9]{5,25}$/;
 // the deepest segment that qualifies" rule handed a forum SECTION name a 1.00
 // identity alias whenever the thread's own slug was a single word.
 const THREAD_ANCHORS = new Set([
-  "threads", "thread", "topic", "topics", "t",
-  "showthread.php", "viewtopic.php", "showthread", "viewtopic",
+  "threads", "thread", "showthread.php", "viewtopic.php",
+  "showthread", "viewtopic",
 ]);
+
+// AMBIGUOUS routes: Discourse and IPB use these for a thread, but plenty of
+// sites use the same words for an INDEX (`/topics/general-discussion`,
+// `/t/photography`). A real thread always carries a numeric id beside the
+// slug; an index route never does. See matcher._ID_ANCHORS.
+const ID_ANCHORS = new Set(["topic", "topics", "t"]);
+
+function carriesThreadId(segments, i) {
+  if (LEADING_ID.test(segments[i]) || TRAILING_ID.test(segments[i])) return true;
+  return i + 1 < segments.length && /^\d+$/.test(segments[i + 1]);
+}
 const TRAILING_ID = /[.\-_]\d{2,}$/;
 const LEADING_ID = /^\d{2,}[.\-_]/;
 // Title separators. Escaped rather than literal: every source file here is
@@ -173,7 +184,10 @@ export function threadSlug(url) {
   let best = [];
   const segments = pathSegments(url);
   for (let i = 1; i < segments.length; i += 1) {
-    if (!THREAD_ANCHORS.has(segments[i - 1].toLowerCase())) continue;
+    const anchor = segments[i - 1].toLowerCase();
+    if (ID_ANCHORS.has(anchor)) {
+      if (!carriesThreadId(segments, i)) continue;
+    } else if (!THREAD_ANCHORS.has(anchor)) continue;
     const toks = allTokens(
       segments[i].replace(LEADING_ID, "").replace(TRAILING_ID, ""));
     // The thread route already proves this is a thread, so a ONE-word slug is
@@ -203,20 +217,32 @@ export function isSiteBranding(phrase, site) {
 }
 
 /**
- * The subject half of a page title, with the site's branding dropped.
- * THE FIRST surviving segment, not the longest -- see matcher.title_subject.
- * "Longest wins" returned the SITE name whenever the subject was one word and
- * the site's display name did not resemble its hostname.
+ * The subject segment of a page title, CORROBORATED against the URL slug.
+ *
+ * Neither position nor size can do this job and both were tried: "longest"
+ * returned the SITE name for a one-word subject, and "first" then broke every
+ * template that does not put the subject first (`'Some Forum - View topic -
+ * <subject>'`, `'Section | <subject> | Some Forum'`). phpBB puts the subject
+ * last, XenForo puts it first, and both are common.
+ *
+ * So it asks the anchored slug, which is independent and positionally proven,
+ * and takes the segment sharing the most tokens with it. WITH NO SLUG THERE IS
+ * NO ANSWER -- "" rather than a guess. See matcher.title_subject.
  */
-export function titleSubject(title, site) {
+export function titleSubject(title, site, slug) {
   if (typeof title !== "string" || !title.trim()) return "";
+  const slugTokens = new Set(contentTokens(slug));
+  if (!slugTokens.size) return "";
+  let best = ""; let bestOverlap = 0;
   for (const raw of title.split(TITLE_SPLIT)) {
     const part = (raw || "").trim();
-    if (!part || !contentTokens(part).length) continue;
-    if (isSiteBranding(part, site)) continue;
-    return part;
+    const toks = contentTokens(part);
+    if (!toks.length || isSiteBranding(part, site)) continue;
+    const overlap = [...new Set(toks)].filter((t) => slugTokens.has(t)).length;
+    // Strictly greater, so the FIRST segment wins a tie.
+    if (overlap > bestOverlap) { best = part; bestOverlap = overlap; }
   }
-  return "";
+  return bestOverlap ? best : "";
 }
 
 /** Thread-subject phrases from a context's URLs, strongest first. */
@@ -291,9 +317,12 @@ export function subjectPhrases(ctx) {
     seen.add(key);
     out.push(v);
   };
-  for (const slug of threadSlugs(ctx)) add(slug);
-  add(titleSubject(ctx?.referrerTitle, hostOf(ctx?.referrerUrl)));
-  add(titleSubject(ctx?.pageTitle, ctx?.site));
+  const slugs = threadSlugs(ctx);
+  for (const slug of slugs) add(slug);
+  const ownSlug = threadSlug(ctx?.pageUrl) || slugs[0] || "";
+  add(titleSubject(ctx?.referrerTitle, hostOf(ctx?.referrerUrl),
+    threadSlug(ctx?.referrerUrl)));
+  add(titleSubject(ctx?.pageTitle, ctx?.site, ownSlug));
   for (const tag of ctx?.tags || []) add(tag);
   const og = ctx?.og || {};
   for (const k of ["video:actor", "video:tag", "og:video:actor",

--- a/scripts/dl-router/extension/route_core.js
+++ b/scripts/dl-router/extension/route_core.js
@@ -49,12 +49,17 @@ export function normKey(text) {
     .replace(/[^\p{L}\p{N}]+/gu, "");
 }
 
-/** Ordered alphanumeric tokens, minus stopwords. */
-export function contentTokens(text) {
+/** Ordered alphanumeric tokens, VERBATIM (stopwords kept). */
+export function allTokens(text) {
   if (typeof text !== "string") return [];
   return text.normalize("NFKD").replace(/\p{M}/gu, "").toLowerCase()
     .split(/[^\p{L}\p{N}]+/u)
-    .filter((t) => t && !STOPWORDS.has(t));
+    .filter(Boolean);
+}
+
+/** Ordered alphanumeric tokens, minus stopwords. */
+export function contentTokens(text) {
+  return allTokens(text).filter((t) => !STOPWORDS.has(t));
 }
 
 export function passesFuzzyGuard(tokens) {
@@ -75,7 +80,6 @@ export function passesFuzzyGuard(tokens) {
 export const DISCORD_SITE = "discord.com";
 export const KEY_PREFIX_DISCORD = "discord:";
 export const KEY_PREFIX_THREAD = "thread:";
-export const MIN_SLUG_TOKENS = 2;
 
 const DISCORD_CDN_HOSTS = new Set(["cdn.discordapp.com", "media.discordapp.net"]);
 const DISCORD_ATTACHMENT_SEGMENTS = new Set([
@@ -83,13 +87,14 @@ const DISCORD_ATTACHMENT_SEGMENTS = new Set([
 ]);
 const SNOWFLAKE = /^[0-9]{5,25}$/;
 
-// Structural route/verb segments, not a vocabulary of subject words.
-const PATH_CHROME = new Set([
-  "threads", "thread", "topic", "topics", "forum", "forums", "board",
-  "boards", "index.php", "showthread.php", "viewtopic.php", "viewforum.php",
-  "t", "f", "p", "post", "posts", "page", "pages", "attachment",
-  "attachments", "download", "downloads", "view", "watch", "media", "album",
-  "gallery", "comments", "s", "goto", "print",
+// The path segments that INTRODUCE a thread. A slug is the segment
+// immediately after one of these, and nowhere else. See matcher.py's
+// _THREAD_ANCHORS for the full reasoning: the previous "skip the chrome, take
+// the deepest segment that qualifies" rule handed a forum SECTION name a 1.00
+// identity alias whenever the thread's own slug was a single word.
+const THREAD_ANCHORS = new Set([
+  "threads", "thread", "topic", "topics", "t",
+  "showthread.php", "viewtopic.php", "showthread", "viewtopic",
 ]);
 const TRAILING_ID = /[.\-_]\d{2,}$/;
 const LEADING_ID = /^\d{2,}[.\-_]/;
@@ -98,17 +103,31 @@ const LEADING_ID = /^\d{2,}[.\-_]/;
 const TITLE_SPLIT
   = /\s*[|\u2013\u2014\u00b7\u2022\u00bb\u00ab]\s*|\s+[-\u2010]\s+|\s*::\s*/;
 
+/**
+ * Hostname of an http(s) URL, normalised. "" for anything else.
+ *
+ * The scheme filter and the bracket strip are the contract, not the parser's
+ * defaults: these hosts become the SCOPE of an alias, `file:`/`data:`/`blob:`
+ * have no meaningful one, and `new URL` brackets an IPv6 literal where
+ * Python's `urlsplit` does not. Mirrors matcher.host_of; pinned by
+ * fixtures/url_cases.json.
+ */
 export function hostOf(url) {
   if (typeof url !== "string" || !url) return "";
+  let parsed;
   try {
-    return new URL(url).hostname.toLowerCase();
+    parsed = new URL(url);
   } catch {
     return "";
   }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return "";
+  const host = parsed.hostname.toLowerCase();
+  return host.startsWith("[") && host.endsWith("]")
+    ? host.slice(1, -1) : host;
 }
 
 function pathSegments(url) {
-  if (typeof url !== "string" || !url) return [];
+  if (!hostOf(url)) return [];
   try {
     return new URL(url).pathname.split("/").filter(Boolean);
   } catch {
@@ -129,29 +148,41 @@ export function discordAliasKey(channelId) {
   return KEY_PREFIX_DISCORD + String(channelId);
 }
 
+/**
+ * The stored key for a thread slug. NEAR-VERBATIM: `allTokens`, not
+ * `contentTokens`. Stopword stripping belongs to fuzzy matching, never to an
+ * identity -- it collided distinct threads (`aster-vale-new-set` and
+ * `aster-vale-set` both folded to `thread:aster-vale-set`) and upsert_alias
+ * re-points on conflict, so the collision was silent.
+ */
 export function threadAliasKey(slug) {
-  const toks = contentTokens(slug);
+  const toks = allTokens(slug);
   return toks.length ? KEY_PREFIX_THREAD + toks.join("-") : "";
 }
 
 /**
- * The forum thread subject carried by a URL path, as a phrase.
- * `/forums/some-section/threads/subject-name.12345/page-2` -> "subject name"
+ * The forum thread subject carried by a URL path, as a phrase. ANCHORED: the
+ * slug is the segment immediately following a thread route, and nowhere else.
  *
- * TWO tokens minimum, not the usual fuzzy guard: a file host's path is
- * `/d/AbCdEf`, one opaque token, and minting that as a thread identity would
- * invent a subject for a page that has no thread.
+ *   /forums/some-section/threads/subject-name.12345/page-2 -> "subject name"
+ *   /forums/some-section/                                  -> ""
+ *   /members/some-poster.4321/                             -> ""
+ *   /uploads/dsc-0123.jpg                                  -> ""
  */
 export function threadSlug(url) {
   let best = [];
-  for (const segment of pathSegments(url)) {
-    if (PATH_CHROME.has(segment.toLowerCase())) continue;
-    const toks = contentTokens(
-      segment.replace(LEADING_ID, "").replace(TRAILING_ID, ""));
-    if (toks.length < MIN_SLUG_TOKENS) continue;
-    if (toks.length <= 2 && PATH_CHROME.has(toks[0])) continue;   // `page-2`
-    if (toks.every((t) => /^\d+$/.test(t))) continue;
-    best = toks;                                  // deepest qualifying wins
+  const segments = pathSegments(url);
+  for (let i = 1; i < segments.length; i += 1) {
+    if (!THREAD_ANCHORS.has(segments[i - 1].toLowerCase())) continue;
+    const toks = allTokens(
+      segments[i].replace(LEADING_ID, "").replace(TRAILING_ID, ""));
+    // The thread route already proves this is a thread, so a ONE-word slug is
+    // legitimate here; the old >=2-token guard existed only to stop an opaque
+    // file-host id being minted as a subject, and no anchor introduces one.
+    const meaningful = toks.filter(
+      (t) => !STOPWORDS.has(t) && !/^\d+$/.test(t));
+    if (!meaningful.length || !passesFuzzyGuard(meaningful)) continue;
+    best = toks;
   }
   return best.join(" ");
 }
@@ -171,19 +202,21 @@ export function isSiteBranding(phrase, site) {
   return key.length >= MIN_SINGLE_TOKEN_LEN && normKey(site).includes(key);
 }
 
-/** The subject half of a page title, with the site's branding dropped. */
+/**
+ * The subject half of a page title, with the site's branding dropped.
+ * THE FIRST surviving segment, not the longest -- see matcher.title_subject.
+ * "Longest wins" returned the SITE name whenever the subject was one word and
+ * the site's display name did not resemble its hostname.
+ */
 export function titleSubject(title, site) {
   if (typeof title !== "string" || !title.trim()) return "";
-  const kept = [];
   for (const raw of title.split(TITLE_SPLIT)) {
     const part = (raw || "").trim();
-    const toks = contentTokens(part);
-    if (!toks.length || isSiteBranding(part, site)) continue;
-    kept.push({ n: toks.length, part });
+    if (!part || !contentTokens(part).length) continue;
+    if (isSiteBranding(part, site)) continue;
+    return part;
   }
-  if (!kept.length) return "";
-  kept.sort((a, b) => b.n - a.n);
-  return kept[0].part;
+  return "";
 }
 
 /** Thread-subject phrases from a context's URLs, strongest first. */
@@ -370,16 +403,29 @@ export function kindOf(snapshot, name) {
  *
  * A download from a paired file host has no context of its own: the page is a
  * download button and nothing else. The thread that sent the user there does
- * have one -- but only if we can prove the two are connected. Two proofs, and
- * deliberately no third:
+ * have one -- but only if we can PROVE the two are connected.
  *
- *   1. a captured click on another page whose `href` IS this page (or is the
- *      download's referrer);
- *   2. the tab this one was OPENED FROM (`openerTabId`).
+ * There is exactly ONE proof, and it is a link the user was observed
+ * following: a captured click on another page whose `href`/`mediaSrc` is this
+ * page (or is the download's referrer).
  *
- * There is NO time window and no "the last thread I saw", because both are
- * guesses that get it wrong exactly when the user has several tabs open --
- * which is how anyone browses a forum. An unprovable link goes to the picker.
+ * THE OPENER-TAB BRANCH WAS DELETED, not tightened. It took the newest usable
+ * capture whose `tabId` matched `openerTabId`, with nothing binding that
+ * capture to the navigation that opened the tab and no time bound at all --
+ * so it was "the last thread I saw in that tab" wearing the word "provable".
+ * It went wrong on the ordinary forum pattern: open a file host in a new tab,
+ * keep browsing the opener tab, and by the time the download fires the newest
+ * capture from that tab is a DIFFERENT thread. The href proof cannot always
+ * cover for it (a `?ref=` parameter or any URL normalisation breaks the
+ * equality), and the wrong answer was not merely used for one match -- it was
+ * LEARNED, as a 1.00 identity alias.
+ *
+ * `openerTabId` is still recorded, and now only ever NARROWS the href proof:
+ * when we know which tab this page was opened from, the donor must be in it.
+ * That can only reject a candidate, never invent one.
+ *
+ * No time window either: a window is a guess about how fast someone browses.
+ * An unprovable link goes to the picker, which is the whole point.
  *
  * Returns `{ pageUrl, pageTitle }` or null.
  */
@@ -390,24 +436,23 @@ export function carryReferrer(item, capture, captures) {
   if (capture && Array.isArray(capture.tags) && capture.tags.length) return null;
 
   const here = new Set([capture?.pageUrl, item?.referrer].filter(Boolean));
+  if (!here.size) return null;
   const openerTabId = capture?.openerTabId;
   const list = (captures || []).slice().sort((a, b) => (b.ts || 0) - (a.ts || 0));
 
-  const usable = (c) => c && c.pageUrl && !here.has(c.pageUrl)
-    && (threadSlug(c.pageUrl) || c.pageTitle);
-
   for (const c of list) {
-    if (!usable(c)) continue;
-    if ((c.href && here.has(c.href)) || (c.mediaSrc && here.has(c.mediaSrc))) {
-      return { pageUrl: c.pageUrl, pageTitle: c.pageTitle || "" };
+    if (!c || !c.pageUrl || here.has(c.pageUrl)) continue;
+    if (!threadSlug(c.pageUrl) && !c.pageTitle) continue;
+    // The proof itself: this donor page linked to the page we are on.
+    if (!((c.href && here.has(c.href)) || (c.mediaSrc && here.has(c.mediaSrc)))) {
+      continue;
     }
-  }
-  if (openerTabId !== undefined && openerTabId !== null) {
-    for (const c of list) {
-      if (usable(c) && c.tabId === openerTabId) {
-        return { pageUrl: c.pageUrl, pageTitle: c.pageTitle || "" };
-      }
+    // ...and, when we know it, the donor must be the tab we came from.
+    if (openerTabId !== undefined && openerTabId !== null
+        && c.tabId !== openerTabId) {
+      continue;
     }
+    return { pageUrl: c.pageUrl, pageTitle: c.pageTitle || "" };
   }
   return null;
 }

--- a/scripts/dl-router/extension/route_core.js
+++ b/scripts/dl-router/extension/route_core.js
@@ -97,16 +97,11 @@ const THREAD_ANCHORS = new Set([
   "showthread", "viewtopic",
 ]);
 
-// AMBIGUOUS routes: Discourse and IPB use these for a thread, but plenty of
-// sites use the same words for an INDEX (`/topics/general-discussion`,
-// `/t/photography`). A real thread always carries a numeric id beside the
-// slug; an index route never does. See matcher._ID_ANCHORS.
-const ID_ANCHORS = new Set(["topic", "topics", "t"]);
-
-function carriesThreadId(segments, i) {
-  if (LEADING_ID.test(segments[i]) || TRAILING_ID.test(segments[i])) return true;
-  return i + 1 < segments.length && /^\d+$/.test(segments[i + 1]);
-}
+// `t`, `topic` and `topics` are DELIBERATELY ABSENT -- see matcher.py. Gating
+// them on an adjacent numeric id does not work: a PAGINATED index
+// (`/topics/general-discussion/2`) is structurally identical to a Discourse
+// thread, so no adjacency rule can separate them. No slug is fine; a wrong
+// slug is not.
 const TRAILING_ID = /[.\-_]\d{2,}$/;
 const LEADING_ID = /^\d{2,}[.\-_]/;
 // Title separators. Escaped rather than literal: every source file here is
@@ -184,10 +179,7 @@ export function threadSlug(url) {
   let best = [];
   const segments = pathSegments(url);
   for (let i = 1; i < segments.length; i += 1) {
-    const anchor = segments[i - 1].toLowerCase();
-    if (ID_ANCHORS.has(anchor)) {
-      if (!carriesThreadId(segments, i)) continue;
-    } else if (!THREAD_ANCHORS.has(anchor)) continue;
+    if (!THREAD_ANCHORS.has(segments[i - 1].toLowerCase())) continue;
     const toks = allTokens(
       segments[i].replace(LEADING_ID, "").replace(TRAILING_ID, ""));
     // The thread route already proves this is a thread, so a ONE-word slug is
@@ -238,7 +230,12 @@ export function titleSubject(title, site, slug) {
     const part = (raw || "").trim();
     const toks = contentTokens(part);
     if (!toks.length || isSiteBranding(part, site)) continue;
-    const overlap = [...new Set(toks)].filter((t) => slugTokens.has(t)).length;
+    const unique = new Set(toks);
+    const overlap = [...unique].filter((t) => slugTokens.has(t)).length;
+    // ONE shared token is a coincidence, not corroboration, and the whole
+    // segment is emitted verbatim -- see matcher.title_subject.
+    if (overlap < 1 || (overlap < 2 && unique.size > 1)) continue;
+    if (overlap * 2 < unique.size) continue;
     // Strictly greater, so the FIRST segment wins a tie.
     if (overlap > bestOverlap) { best = part; bestOverlap = overlap; }
   }

--- a/scripts/dl-router/extension/route_core.js
+++ b/scripts/dl-router/extension/route_core.js
@@ -62,6 +62,169 @@ export function passesFuzzyGuard(tokens) {
   return tokens.length === 1 && tokens[0].length >= MIN_SINGLE_TOKEN_LEN;
 }
 
+// --- identity signals ------------------------------------------------------ //
+// Mirrors matcher.py's half of the same name. The shared fixture table
+// tests/fixtures/url_cases.json is asserted against BOTH, so these cannot
+// drift the way two hand-copied lists did.
+//
+// WHY THIS EXISTS. On the first evening of real traffic six of nine downloads
+// came from a Discord CDN, where the page is a SPA and the captured context was
+// completely empty -- no tags, no title, not even a page URL. There is nothing
+// to scrape. But the attachment URL carries the channel id, so the routing key
+// is structural and survives any Discord UI change.
+export const DISCORD_SITE = "discord.com";
+export const KEY_PREFIX_DISCORD = "discord:";
+export const KEY_PREFIX_THREAD = "thread:";
+export const MIN_SLUG_TOKENS = 2;
+
+const DISCORD_CDN_HOSTS = new Set(["cdn.discordapp.com", "media.discordapp.net"]);
+const DISCORD_ATTACHMENT_SEGMENTS = new Set([
+  "attachments", "ephemeral-attachments",
+]);
+const SNOWFLAKE = /^[0-9]{5,25}$/;
+
+// Structural route/verb segments, not a vocabulary of subject words.
+const PATH_CHROME = new Set([
+  "threads", "thread", "topic", "topics", "forum", "forums", "board",
+  "boards", "index.php", "showthread.php", "viewtopic.php", "viewforum.php",
+  "t", "f", "p", "post", "posts", "page", "pages", "attachment",
+  "attachments", "download", "downloads", "view", "watch", "media", "album",
+  "gallery", "comments", "s", "goto", "print",
+]);
+const TRAILING_ID = /[.\-_]\d{2,}$/;
+const LEADING_ID = /^\d{2,}[.\-_]/;
+// Title separators. Escaped rather than literal: every source file here is
+// plain ASCII on purpose (see tests/source_hygiene.test.mjs).
+const TITLE_SPLIT
+  = /\s*[|\u2013\u2014\u00b7\u2022\u00bb\u00ab]\s*|\s+[-\u2010]\s+|\s*::\s*/;
+
+export function hostOf(url) {
+  if (typeof url !== "string" || !url) return "";
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+function pathSegments(url) {
+  if (typeof url !== "string" || !url) return [];
+  try {
+    return new URL(url).pathname.split("/").filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/** The channel id from a Discord attachment URL, else "". */
+export function discordChannelId(url) {
+  if (!DISCORD_CDN_HOSTS.has(hostOf(url))) return "";
+  const segments = pathSegments(url);
+  if (segments.length < 3) return "";
+  if (!DISCORD_ATTACHMENT_SEGMENTS.has(segments[0].toLowerCase())) return "";
+  return SNOWFLAKE.test(segments[1]) ? segments[1] : "";
+}
+
+export function discordAliasKey(channelId) {
+  return KEY_PREFIX_DISCORD + String(channelId);
+}
+
+export function threadAliasKey(slug) {
+  const toks = contentTokens(slug);
+  return toks.length ? KEY_PREFIX_THREAD + toks.join("-") : "";
+}
+
+/**
+ * The forum thread subject carried by a URL path, as a phrase.
+ * `/forums/some-section/threads/subject-name.12345/page-2` -> "subject name"
+ *
+ * TWO tokens minimum, not the usual fuzzy guard: a file host's path is
+ * `/d/AbCdEf`, one opaque token, and minting that as a thread identity would
+ * invent a subject for a page that has no thread.
+ */
+export function threadSlug(url) {
+  let best = [];
+  for (const segment of pathSegments(url)) {
+    if (PATH_CHROME.has(segment.toLowerCase())) continue;
+    const toks = contentTokens(
+      segment.replace(LEADING_ID, "").replace(TRAILING_ID, ""));
+    if (toks.length < MIN_SLUG_TOKENS) continue;
+    if (toks.length <= 2 && PATH_CHROME.has(toks[0])) continue;   // `page-2`
+    if (toks.every((t) => /^\d+$/.test(t))) continue;
+    best = toks;                                  // deepest qualifying wins
+  }
+  return best.join(" ");
+}
+
+function hostTokens(site) {
+  return new Set(contentTokens(site).filter((t) => t.length > 1));
+}
+
+/** True when `phrase` is the SITE's own name rather than a subject. */
+export function isSiteBranding(phrase, site) {
+  if (!site) return false;
+  const toks = contentTokens(phrase);
+  if (!toks.length) return false;
+  const hostToks = hostTokens(site);
+  if (hostToks.size && toks.every((t) => hostToks.has(t))) return true;
+  const key = normKey(phrase);
+  return key.length >= MIN_SINGLE_TOKEN_LEN && normKey(site).includes(key);
+}
+
+/** The subject half of a page title, with the site's branding dropped. */
+export function titleSubject(title, site) {
+  if (typeof title !== "string" || !title.trim()) return "";
+  const kept = [];
+  for (const raw of title.split(TITLE_SPLIT)) {
+    const part = (raw || "").trim();
+    const toks = contentTokens(part);
+    if (!toks.length || isSiteBranding(part, site)) continue;
+    kept.push({ n: toks.length, part });
+  }
+  if (!kept.length) return "";
+  kept.sort((a, b) => b.n - a.n);
+  return kept[0].part;
+}
+
+/** Thread-subject phrases from a context's URLs, strongest first. */
+export function threadSlugs(ctx) {
+  const out = [];
+  const seen = new Set();
+  for (const url of [ctx?.pageUrl, ctx?.url, ctx?.finalUrl, ctx?.referrer,
+    ctx?.referrerUrl]) {
+    const slug = threadSlug(url);
+    const key = normKey(slug);
+    if (slug && !seen.has(key)) { seen.add(key); out.push(slug); }
+  }
+  return out;
+}
+
+/**
+ * Every identity signal derivable from a context's URLs, strongest first.
+ * Returns [{ key, site, kind }]. Deliberately URL-only: page DOM content is
+ * not an identity, and treating it as one is what the mislearning was made of.
+ */
+export function identitySignals(ctx) {
+  const out = [];
+  const seen = new Set();
+  const add = (key, site, kind) => {
+    const id = `${key}@${site}`;
+    if (!key || seen.has(id)) return;
+    seen.add(id);
+    out.push({ key, site, kind });
+  };
+  for (const url of [ctx?.url, ctx?.finalUrl, ctx?.referrer]) {
+    const channel = discordChannelId(url);
+    if (channel) add(discordAliasKey(channel), DISCORD_SITE, "discord-channel");
+  }
+  for (const url of [ctx?.pageUrl, ctx?.url, ctx?.finalUrl, ctx?.referrer,
+    ctx?.referrerUrl]) {
+    const key = threadAliasKey(threadSlug(url));
+    if (key) add(key, hostOf(url), "thread-slug");
+  }
+  return out;
+}
+
 function containsSequence(haystack, needle) {
   if (!needle.length || needle.length > haystack.length) return false;
   for (let i = 0; i <= haystack.length - needle.length; i += 1) {
@@ -74,7 +237,15 @@ function containsSequence(haystack, needle) {
   return false;
 }
 
-/** Subject strings from a captured context, strongest signal first. */
+/**
+ * Subject strings from a captured context, strongest signal first.
+ *
+ * ORDER CHANGED after the first evening of real traffic, and matches
+ * matcher.py's. It used to be tags-first; on the one forum download where
+ * context WAS captured, the tag list was the forum's own section names and
+ * other posters' usernames while the subject sat in the URL thread slug and in
+ * the page title. The slug leads, the de-branded title follows, tags trail.
+ */
 export function subjectPhrases(ctx) {
   const out = [];
   const seen = new Set();
@@ -87,6 +258,9 @@ export function subjectPhrases(ctx) {
     seen.add(key);
     out.push(v);
   };
+  for (const slug of threadSlugs(ctx)) add(slug);
+  add(titleSubject(ctx?.referrerTitle, hostOf(ctx?.referrerUrl)));
+  add(titleSubject(ctx?.pageTitle, ctx?.site));
   for (const tag of ctx?.tags || []) add(tag);
   const og = ctx?.og || {};
   for (const k of ["video:actor", "video:tag", "og:video:actor",
@@ -94,6 +268,7 @@ export function subjectPhrases(ctx) {
   add(ctx?.linkText);
   add(ctx?.alt);
   add(ctx?.pageTitle);
+  add(ctx?.referrerTitle);
   return out;
 }
 
@@ -127,6 +302,13 @@ export function localDecide(ctx, snapshot) {
     if (!cur || score > cur.confidence) best.set(dir, { dir, confidence: score, reason });
   };
 
+  // Identity signals first -- the Discord path. A Discord attachment carries
+  // no page context at all, so this is the ONLY rule that can score it.
+  for (const sig of identitySignals(ctx)) {
+    const hit = aliasSite.get(`${sig.key}\u0000${sig.site}`);
+    if (hit) bump(hit, SCORE_ALIAS_SITE, `alias(${sig.kind}) '${sig.key}'`);
+  }
+
   for (const phrase of phrases) {
     const key = normKey(phrase);
     if (!key) continue;
@@ -156,7 +338,78 @@ export function localDecide(ctx, snapshot) {
   const ranked = [...best.values()].sort(
     (a, b) => (b.confidence - a.confidence) || a.dir.localeCompare(b.dir));
   const top = ranked[0];
-  return { ...top, auto: top.confidence >= threshold, source: "cache" };
+  // THE SAME AUTO-FILE GATE THE SIDECAR APPLIES. Only a `performer` directory
+  // may auto-file; a category always confirms and an unclassified one does
+  // too. Without this the cached fallback would auto-file into a directory the
+  // sidecar itself would have asked about -- and the fallback runs precisely
+  // when the sidecar is slow or down, so the divergence would be invisible.
+  const kind = kindOf(snapshot, top.dir);
+  const auto = top.confidence >= threshold && kind === KIND_PERFORMER;
+  const reason = auto ? top.reason
+    : `${kind === KIND_CATEGORY ? "category" : "unclassified"} directory - ${top.reason}`;
+  return { ...top, reason, auto, source: "cache" };
+}
+
+export const KIND_PERFORMER = "performer";
+export const KIND_CATEGORY = "category";
+export const KIND_UNKNOWN = "unknown";
+
+/** The kind the /dirs snapshot recorded for a directory. */
+export function kindOf(snapshot, name) {
+  for (const d of snapshot?.dirs || []) {
+    if (d && d.name === name) {
+      return d.kind === KIND_PERFORMER || d.kind === KIND_CATEGORY
+        ? d.kind : KIND_UNKNOWN;
+    }
+  }
+  return KIND_UNKNOWN;
+}
+
+/**
+ * The forum thread that linked to this file host, when the link is PROVABLE.
+ *
+ * A download from a paired file host has no context of its own: the page is a
+ * download button and nothing else. The thread that sent the user there does
+ * have one -- but only if we can prove the two are connected. Two proofs, and
+ * deliberately no third:
+ *
+ *   1. a captured click on another page whose `href` IS this page (or is the
+ *      download's referrer);
+ *   2. the tab this one was OPENED FROM (`openerTabId`).
+ *
+ * There is NO time window and no "the last thread I saw", because both are
+ * guesses that get it wrong exactly when the user has several tabs open --
+ * which is how anyone browses a forum. An unprovable link goes to the picker.
+ *
+ * Returns `{ pageUrl, pageTitle }` or null.
+ */
+export function carryReferrer(item, capture, captures) {
+  // Only for a page with NOTHING of its own. A page that produced tags is
+  // describing its own content, and importing a thread subject over the top of
+  // that would be the tag-list mistake in a new costume.
+  if (capture && Array.isArray(capture.tags) && capture.tags.length) return null;
+
+  const here = new Set([capture?.pageUrl, item?.referrer].filter(Boolean));
+  const openerTabId = capture?.openerTabId;
+  const list = (captures || []).slice().sort((a, b) => (b.ts || 0) - (a.ts || 0));
+
+  const usable = (c) => c && c.pageUrl && !here.has(c.pageUrl)
+    && (threadSlug(c.pageUrl) || c.pageTitle);
+
+  for (const c of list) {
+    if (!usable(c)) continue;
+    if ((c.href && here.has(c.href)) || (c.mediaSrc && here.has(c.mediaSrc))) {
+      return { pageUrl: c.pageUrl, pageTitle: c.pageTitle || "" };
+    }
+  }
+  if (openerTabId !== undefined && openerTabId !== null) {
+    for (const c of list) {
+      if (usable(c) && c.tabId === openerTabId) {
+        return { pageUrl: c.pageUrl, pageTitle: c.pageTitle || "" };
+      }
+    }
+  }
+  return null;
 }
 
 /**
@@ -197,8 +450,9 @@ export function correlateCapture(item, captures, opts = {}) {
 }
 
 /** The JSON body POSTed to the sidecar's /match. */
-export function buildMatchPayload(item, capture) {
+export function buildMatchPayload(item, capture, carried) {
   const c = capture || {};
+  const ref = carried || {};
   return {
     // The browser's DownloadItem id. The sidecar records it against the
     // routing decision, and that record is the ONLY thing that later lets
@@ -219,7 +473,34 @@ export function buildMatchPayload(item, capture) {
       og: c.og || {},
       linkText: c.linkText || "",
       alt: c.alt || "",
+      // A PROVEN cross-host referrer only (see carryReferrer). The sidecar
+      // treats these as identity evidence, so an unprovable guess here would
+      // be learned as one.
+      referrerUrl: ref.pageUrl || "",
+      referrerTitle: ref.pageTitle || "",
     },
+  };
+}
+
+/** The context shape localDecide expects, from a /match payload. */
+export function localContext(payload) {
+  const page = payload?.page || {};
+  return {
+    tags: page.tags,
+    og: page.og,
+    linkText: page.linkText,
+    alt: page.alt,
+    pageTitle: page.title,
+    pageUrl: page.url,
+    site: page.site,
+    // The URLs are what carry a Discord channel or a thread slug -- without
+    // them the cached fallback cannot score the very downloads the sidecar
+    // now can.
+    url: payload?.url,
+    finalUrl: payload?.finalUrl,
+    referrer: payload?.referrer,
+    referrerUrl: page.referrerUrl,
+    referrerTitle: page.referrerTitle,
   };
 }
 

--- a/scripts/dl-router/extension/route_core.js
+++ b/scripts/dl-router/extension/route_core.js
@@ -134,11 +134,22 @@ export function hostOf(url) {
 
 function pathSegments(url) {
   if (!hostOf(url)) return [];
+  let raw;
   try {
-    return new URL(url).pathname.split("/").filter(Boolean);
+    raw = new URL(url).pathname.split("/").filter(Boolean);
   } catch {
     return [];
   }
+  // PERCENT-DECODED: `pathname` is the encoded form here while Python's
+  // `urlsplit().path` is the raw one, so a non-latin slug produced `%D0%BF...`
+  // tokens on this side and real words on the other. See matcher.py.
+  return raw.map((seg) => {
+    try {
+      return decodeURIComponent(seg);
+    } catch {
+      return seg;
+    }
+  });
 }
 
 /** The channel id from a Discord attachment URL, else "". */
@@ -185,8 +196,10 @@ export function threadSlug(url) {
     // The thread route already proves this is a thread, so a ONE-word slug is
     // legitimate here; the old >=2-token guard existed only to stop an opaque
     // file-host id being minted as a subject, and no anchor introduces one.
+    // `\p{Nd}`, not `\d`: a bare id is not a subject in any script, and
+    // Python's `isdigit()` covers every Unicode decimal. See matcher.py.
     const meaningful = toks.filter(
-      (t) => !STOPWORDS.has(t) && !/^\d+$/.test(t));
+      (t) => !STOPWORDS.has(t) && !/^\p{Nd}+$/u.test(t));
     if (!meaningful.length || !passesFuzzyGuard(meaningful)) continue;
     best = toks;
   }

--- a/scripts/dl-router/extension/service_worker.js
+++ b/scripts/dl-router/extension/service_worker.js
@@ -18,8 +18,8 @@
 // suppress listener registration and networking.
 
 import {
-  buildMatchPayload, correlateCapture, formatDup, handleDetermining,
-  localDecide,
+  buildMatchPayload, carryReferrer, correlateCapture, formatDup,
+  handleDetermining, localContext, localDecide,
 } from "./route_core.js";
 import { isHttpUrl, relPathFromAbsolute, sanitizeDirName } from "./sanitize.js";
 import { DEFAULT_PORT, manifestPort as readManifestPort } from "./port.js";
@@ -217,6 +217,10 @@ export function recordCapture(payload, sender) {
       ? payload.tags.filter((t) => typeof t === "string").slice(0, 64) : [],
     og: payload.og && typeof payload.og === "object" ? payload.og : {},
     tabId: sender?.tab?.id,
+    // The tab this one was opened from. It is the ONLY provable link between a
+    // forum thread and the file host it sent the user to, and it comes free on
+    // the sender -- the content script has no way to know it.
+    openerTabId: sender?.tab?.openerTabId,
     ts: Date.now(),
   };
   state.captures.push(capture);
@@ -275,20 +279,14 @@ function routeDownload(item, suggest) {
     windowMs: (state.snapshot?.captureWindowS ?? 15) * 1000,
     activeTabId: state.activeTabId,
   });
-  const payload = buildMatchPayload(item, capture);
+  const payload = buildMatchPayload(
+    item, capture, carryReferrer(item, capture, state.captures));
 
   return handleDetermining(item, suggest, {
     knownDirs: knownDirs(),
     otherDir: otherDir(),
     timeoutMs: state.snapshot?.matchTimeoutMs ?? 400,
-    localDecision: () => localDecide({
-      tags: payload.page.tags,
-      og: payload.page.og,
-      linkText: payload.page.linkText,
-      alt: payload.page.alt,
-      pageTitle: payload.page.title,
-      site: payload.page.site,
-    }, state.snapshot),
+    localDecision: () => localDecide(localContext(payload), state.snapshot),
     requestMatch: () => api("POST", "/match", payload,
       { timeoutMs: state.snapshot?.matchTimeoutMs ?? 400 }),
     onDecision: (info) => {
@@ -425,7 +423,8 @@ export async function openPicker(info) {
  * relocated (a same-filesystem rename, instant); otherwise the target is
  * remembered and applied when onChanged reports completion.
  */
-export async function applyChoice(downloadId, chosenDir, { createdNew } = {}) {
+export async function applyChoice(downloadId, chosenDir,
+  { createdNew, kind } = {}) {
   // A cold-woken worker has no config and no snapshot yet, so knownDirs() is
   // empty and EVERY pick would be thrown away as "unsafe". The picker is a
   // separate popup window the user can leave open past the ~30s idle teardown,
@@ -434,7 +433,12 @@ export async function applyChoice(downloadId, chosenDir, { createdNew } = {}) {
   const entry = state.pending.get(downloadId);
   const known = new Set([...knownDirs(), otherDir()]);
   if (createdNew) {
-    await api("POST", "/mkdir", { name: chosenDir }, { timeoutMs: 5000 });
+    // `kind` is what the picker asked for. Creating a directory WITHOUT one
+    // leaves it unclassified, and an unclassified directory never auto-files
+    // -- so the new directory would silently interrupt every future download
+    // into it. That is why the picker asks rather than assuming.
+    await api("POST", "/mkdir", { name: chosenDir, kind: kind || undefined },
+      { timeoutMs: 5000 });
     await refreshSnapshot();
   }
   const safe = sanitizeDirName(chosenDir, createdNew ? null : known);
@@ -503,6 +507,12 @@ async function learn(entry, chosenDir, createdNew) {
     chosenDir,
     autoDir: entry.dir,
     createdNew: Boolean(createdNew),
+    // EXPLICIT CONFIRMATION. Every call here follows the user choosing a
+    // directory in the picker (or confirming the one the router chose), and
+    // the sidecar will not learn a tag -> directory alias without it. Stated
+    // as a flag rather than inferred from the endpoint so the rule is legible
+    // on both sides, and so a future automatic caller fails closed.
+    confirmed: true,
   }, { timeoutMs: 5000 }).catch(() => {});
 }
 
@@ -618,17 +628,15 @@ export async function startFetch(url, info, tab) {
     { now: Date.now(),
       windowMs: (state.snapshot?.captureWindowS ?? 15) * 1000,
       activeTabId: tab?.id ?? state.activeTabId }).capture;
-  const payload = buildMatchPayload({ url, filename: "" }, capture);
+  const item = { url, filename: "", referrer: info?.pageUrl || "" };
+  const payload = buildMatchPayload(
+    item, capture, carryReferrer(item, capture, state.captures));
 
   let decision = null;
   try {
     decision = await api("POST", "/match", payload, { timeoutMs: 4000 });
   } catch {
-    decision = localDecide({
-      tags: payload.page.tags, og: payload.page.og,
-      linkText: payload.page.linkText, alt: payload.page.alt,
-      pageTitle: payload.page.title, site: payload.page.site,
-    }, state.snapshot);
+    decision = localDecide(localContext(payload), state.snapshot);
   }
 
   const known = new Set([...knownDirs(), otherDir()]);
@@ -665,7 +673,7 @@ export async function submitFetch(key, dir, { createdNew } = {}) {
     if (job && createdNew !== undefined) {
       await api("POST", "/learn", {
         context: job.payload, chosenDir: dir, autoDir: null,
-        createdNew: Boolean(createdNew),
+        createdNew: Boolean(createdNew), confirmed: true,
       }, { timeoutMs: 5000 }).catch(() => {});
     }
     return { ok: true, dir, jobId: out?.jobId };
@@ -722,7 +730,7 @@ export function onMessage(msg, sender, sendResponse) {
   if (msg.type === "dlr:choose") {
     ready()
       .then(() => applyChoice(msg.downloadId, msg.dir,
-        { createdNew: msg.createdNew }))
+        { createdNew: msg.createdNew, kind: msg.kind }))
       .then((r) => sendResponse(r))
       .catch((e) => sendResponse({ ok: false, error: errorMessage(e) }));
     return true;   // async response

--- a/scripts/dl-router/extension/service_worker.js
+++ b/scripts/dl-router/extension/service_worker.js
@@ -522,8 +522,8 @@ async function learn(entry, chosenDir, createdNew) {
 const IDENTITY_SOURCES = new Set(["discord-channel", "thread-slug"]);
 
 /**
- * Tell the user when a correction taught the router something LESS than it
- * looked like it did.
+ * Tell the user ONCE when a correction taught the router something less than
+ * it looked like it did.
  *
  * The sidecar screens every candidate alias and returns what it refused, and
  * nothing consumed that -- which is how an over-strict screen stayed invisible
@@ -540,11 +540,25 @@ const IDENTITY_SOURCES = new Set(["discord-channel", "thread-slug"]);
  * The catch-all is excluded outright: `/learn` returns a `skipped` entry for it
  * BY DESIGN ("the absence of a subject, not one"), and filing to the catch-all
  * is routine -- notifying there would train the operator to dismiss the very
- * notification the rest of this exists for.
+ * notification the rest of this exists for. The `"catch-all"` source string is
+ * a CROSS-LANGUAGE CONTRACT with server.App.learn and is pinned on both sides.
+ *
+ * Everything here is once-per-fact, never once-per-download. `dl-route alias
+ * review` is the permanent surface; this is only the pointer at it.
  */
 export function reportNothingLearned(out) {
   if (!out || !Array.isArray(out.skipped)) return false;
-  const real = out.skipped.filter((s) => s && s.source !== "catch-all");
+  // `first` is the sidecar telling us it has not refused this exact
+  // (key, site, dir) before. WITHOUT IT the identity rule below notifies on
+  // EVERY correction, because a permanent refusal (site branding, shared
+  // vocabulary, a spread that only ever grows) recurs on every one -- and a
+  // screened identity writes no row, so nothing else ever changes either.
+  //
+  // The flag lives in the SIDECAR, not in a suppression map here: MV3 tears
+  // this worker down after ~30s idle, so a map would empty and the
+  // notifications would resume. See Store.record_screened.
+  const real = out.skipped.filter(
+    (s) => s && s.source !== "catch-all" && s.first !== false);
   if (!real.length) return false;
   const identity = real.find((s) => IDENTITY_SOURCES.has(s.source));
   const wroteSomething = Array.isArray(out.written) && out.written.length > 0;

--- a/scripts/dl-router/extension/service_worker.js
+++ b/scripts/dl-router/extension/service_worker.js
@@ -518,23 +518,46 @@ async function learn(entry, chosenDir, createdNew) {
   reportNothingLearned(out);
 }
 
+/** Sources that carry a full-confidence identity (see matcher.identity_signals). */
+const IDENTITY_SOURCES = new Set(["discord-channel", "thread-slug"]);
+
 /**
- * Tell the user when a correction taught the router NOTHING.
+ * Tell the user when a correction taught the router something LESS than it
+ * looked like it did.
  *
  * The sidecar screens every candidate alias and returns what it refused, and
- * nothing consumed that -- so an over-strict screen was invisible outside the
- * sidecar journal, which is how it stayed silent. This deliberately fires only
- * when the correction produced no alias AT ALL: a category page whose junk
- * tags were screened while a good one was learned is working as designed and
- * must not nag.
+ * nothing consumed that -- which is how an over-strict screen stayed invisible
+ * outside the sidecar journal. Two rules, and both matter:
+ *
+ *   * A SCREENED IDENTITY always notifies, even when something else was
+ *     written. A screened identity writes no row, so the re-point bypass never
+ *     engages for it either -- that channel or thread will never auto-file, and
+ *     reporting "learned" because an unrelated tag landed hides it forever.
+ *   * Otherwise, notify only when NOTHING was written. A category page whose
+ *     junk tags were screened while a good one was learned is working as
+ *     designed and must not nag.
+ *
+ * The catch-all is excluded outright: `/learn` returns a `skipped` entry for it
+ * BY DESIGN ("the absence of a subject, not one"), and filing to the catch-all
+ * is routine -- notifying there would train the operator to dismiss the very
+ * notification the rest of this exists for.
  */
 export function reportNothingLearned(out) {
-  if (!out || !Array.isArray(out.skipped) || !out.skipped.length) return false;
-  if (Array.isArray(out.written) && out.written.length) return false;
-  const why = out.skipped.find((s) => s && s.why);
+  if (!out || !Array.isArray(out.skipped)) return false;
+  const real = out.skipped.filter((s) => s && s.source !== "catch-all");
+  if (!real.length) return false;
+  const identity = real.find((s) => IDENTITY_SOURCES.has(s.source));
+  const wroteSomething = Array.isArray(out.written) && out.written.length > 0;
+  if (!identity && wroteSomething) return false;
+  // Report the IDENTITY refusal when there is one: it is the consequential
+  // one, and `find(s => s.why)` would have reported whichever came first.
+  const chosen = identity || real.find((s) => s.why) || real[0];
   void reportFailure(
-    `Filed into ${out.dir}, but learned nothing from it`,
-    why ? String(why.why) : "every candidate was screened out");
+    identity
+      ? `Filed into ${out.dir}, but it will not learn this source`
+      : `Filed into ${out.dir}, but learned nothing from it`,
+    (chosen && chosen.why) ? String(chosen.why)
+      : "every candidate was screened out");
   return true;
 }
 

--- a/scripts/dl-router/extension/service_worker.js
+++ b/scripts/dl-router/extension/service_worker.js
@@ -217,9 +217,10 @@ export function recordCapture(payload, sender) {
       ? payload.tags.filter((t) => typeof t === "string").slice(0, 64) : [],
     og: payload.og && typeof payload.og === "object" ? payload.og : {},
     tabId: sender?.tab?.id,
-    // The tab this one was opened from. It is the ONLY provable link between a
-    // forum thread and the file host it sent the user to, and it comes free on
-    // the sender -- the content script has no way to know it.
+    // The tab this one was opened from. It NARROWS the referrer carry's href
+    // proof (see carryReferrer) -- it is not itself a proof, and the branch
+    // that treated it as one was deleted. It comes free on the sender; the
+    // content script has no way to know it.
     openerTabId: sender?.tab?.openerTabId,
     ts: Date.now(),
   };
@@ -502,7 +503,7 @@ async function relocate(rel, toDir, downloadId) {
 
 async function learn(entry, chosenDir, createdNew) {
   if (!entry) return;
-  await api("POST", "/learn", {
+  const out = await api("POST", "/learn", {
     context: entry.payload,
     chosenDir,
     autoDir: entry.dir,
@@ -513,7 +514,28 @@ async function learn(entry, chosenDir, createdNew) {
     // as a flag rather than inferred from the endpoint so the rule is legible
     // on both sides, and so a future automatic caller fails closed.
     confirmed: true,
-  }, { timeoutMs: 5000 }).catch(() => {});
+  }, { timeoutMs: 5000 }).catch(() => null);
+  reportNothingLearned(out);
+}
+
+/**
+ * Tell the user when a correction taught the router NOTHING.
+ *
+ * The sidecar screens every candidate alias and returns what it refused, and
+ * nothing consumed that -- so an over-strict screen was invisible outside the
+ * sidecar journal, which is how it stayed silent. This deliberately fires only
+ * when the correction produced no alias AT ALL: a category page whose junk
+ * tags were screened while a good one was learned is working as designed and
+ * must not nag.
+ */
+export function reportNothingLearned(out) {
+  if (!out || !Array.isArray(out.skipped) || !out.skipped.length) return false;
+  if (Array.isArray(out.written) && out.written.length) return false;
+  const why = out.skipped.find((s) => s && s.why);
+  void reportFailure(
+    `Filed into ${out.dir}, but learned nothing from it`,
+    why ? String(why.why) : "every candidate was screened out");
+  return true;
 }
 
 export async function onDownloadChanged(delta) {

--- a/scripts/dl-router/matcher.py
+++ b/scripts/dl-router/matcher.py
@@ -14,12 +14,13 @@ string, which is why existing directories are never renamed (decision D7):
 
 Scoring (highest rule wins per directory):
 
-    exact alias hit, site-scoped                            1.00
-    exact alias hit, global                                 0.90
-    normalised page tag/subject == dir key                  0.85
-    token-sequence containment, scaled by coverage     0.60-0.80
-    filename token match                                   <=0.50
-    host prior (last dir used on this host)          +0.05 ranking only
+    identity-signal alias hit (Discord channel, forum thread)   1.00
+    exact alias hit, site-scoped                                1.00
+    exact alias hit, global                                     0.90
+    normalised page tag/subject == dir key                      0.85
+    token-sequence containment, scaled by coverage         0.60-0.80
+    filename token match                                       <=0.50
+    host prior (last dir used on this host)              +0.05 ranking only
 
 Guards
     * A fuzzy hit (containment or filename) needs >=2 tokens, or a single token
@@ -33,11 +34,28 @@ Guards
       identical `base` -- and such a pair is inside the tie margin by
       definition, so the picker opens anyway.
     * Top two within `tie_margin` -> no auto-file, show the picker.
+    * DIRECTORY KIND gates auto-filing. Only a `performer` directory may
+      auto-file. A `category` directory always opens the picker regardless of
+      score, and an UNCLASSIFIED directory does too -- unknown is "ask", never
+      "probably fine". See dirkinds.py.
+
+IDENTITY SIGNALS (the deterministic half)
+
+The evening this module met real traffic, eight of nine downloads scored 0.00
+"no signal in page context or filename": six came from a Discord CDN, where the
+page is a SPA and the captured context was completely empty. Page scraping
+cannot fix that. But the Discord attachment URL carries its channel id, and a
+forum attachment URL carries its thread slug -- structured, in the URL, immune
+to any UI change. `identity_signals()` turns those into `(key, site)` alias
+pairs, and it is the SAME function the matcher looks up and the learner writes,
+so the two can never drift apart.
 """
 from __future__ import annotations
 
+import re
 import unicodedata
 from dataclasses import dataclass, field
+from urllib.parse import urlsplit
 
 # Score constants — named so tests assert against the spec table, not magic
 # numbers scattered through the scorer.
@@ -51,6 +69,14 @@ HOST_PRIOR_BONUS = 0.05
 
 MIN_FUZZY_TOKENS = 2
 MIN_SINGLE_TOKEN_LEN = 4
+
+# Directory kinds. The library is NOT purely subject-keyed: unattributed
+# material is filed by category, and the two need opposite learning rules and
+# opposite auto-file rules. See dirkinds.py for where the classification lives.
+KIND_PERFORMER = "performer"
+KIND_CATEGORY = "category"
+KIND_UNKNOWN = "unknown"
+KINDS = frozenset({KIND_PERFORMER, KIND_CATEGORY})
 
 # Tokens that carry no subject information and would otherwise create
 # accidental containment hits. Deliberately tiny and generic (no site- or
@@ -68,6 +94,248 @@ _FILENAME_NOISE = frozenset({
     "1080p", "720p", "480p", "2160p", "4k", "hevc", "h264", "h265", "x264",
     "x265", "aac", "avc", "60fps", "30fps",
 })
+
+# --- identity signals ------------------------------------------------------ #
+# Structured alias keys. They are stored VERBATIM (not folded through
+# `norm_key`) so that `dl-route alias list` prints exactly what `alias rm`
+# accepts, and so a channel id can never be confused with a subject phrase.
+KEY_PREFIX_DISCORD = "discord:"
+KEY_PREFIX_THREAD = "thread:"
+KEY_PREFIXES = (KEY_PREFIX_DISCORD, KEY_PREFIX_THREAD)
+
+# The site an identity signal is scoped to. Discord attachments are served from
+# a CDN host that is NOT the site the user was on, and the SPA gives us no page
+# context at all, so the scope is pinned to this constant rather than derived.
+DISCORD_SITE = "discord.com"
+_DISCORD_CDN_HOSTS = frozenset({"cdn.discordapp.com", "media.discordapp.net"})
+# Both hosts serve `/attachments/<channel>/<message>/<file>`; ephemeral (slash
+# command) uploads use the same shape under a different first segment.
+_DISCORD_ATTACHMENT_SEGMENTS = frozenset({"attachments", "ephemeral-attachments"})
+# A snowflake is 17-19 digits today. Bounded loosely, but bounded: an unbounded
+# "any digits" rule would turn a stray numeric path segment into an alias key.
+_SNOWFLAKE = re.compile(r"^[0-9]{5,25}$")
+
+# URL path segments that are forum CHROME rather than a thread subject. This is
+# a structural list (route/verb segments), not a vocabulary of subject words --
+# no library-specific or site-specific term belongs here.
+_PATH_CHROME = frozenset({
+    "threads", "thread", "topic", "topics", "forum", "forums", "board",
+    "boards", "index.php", "showthread.php", "viewtopic.php", "viewforum.php",
+    "t", "f", "p", "post", "posts", "page", "pages", "attachment",
+    "attachments", "download", "downloads", "view", "watch", "media", "album",
+    "gallery", "comments", "s", "goto", "print",
+})
+
+# `slug.123456` (xenforo) and `123456-slug` (vbulletin) both carry a numeric id
+# beside the slug. Stripping it is what makes the two shapes fold to one key.
+_TRAILING_ID = re.compile(r"[.\-_]\d{2,}$")
+_LEADING_ID = re.compile(r"^\d{2,}[.\-_]")
+
+# Title separators. A page title is routinely "<subject> | <site>"; the site
+# half is chrome and is dropped by comparing against the host's own tokens.
+_TITLE_SPLIT = re.compile(r"\s*[|–—·•»«]\s*|\s+[-‐]\s+|\s*::\s*")
+
+# A learned alias key shorter than this is refused: two or three characters
+# match far too much page prose to be a subject.
+MIN_ALIAS_KEY_LEN = 4
+# A thread slug is hyphenated WORDS. One token is an opaque id (`/d/AbCdEf`).
+MIN_SLUG_TOKENS = 2
+# A phrase seen on this many DISTINCT directories is site chrome (a forum
+# section, an uploader's username), not a subject. Data-driven: it is measured
+# from the labelled examples, not read off a word list.
+CHROME_DIR_SPREAD = 2
+
+
+def host_of(url) -> str:
+    """Hostname of `url`, lowercased. `''` when it has none."""
+    if not isinstance(url, str) or not url:
+        return ""
+    try:
+        return (urlsplit(url).hostname or "").lower()
+    except ValueError:
+        return ""
+
+
+def url_path_segments(url) -> tuple:
+    """Non-empty path segments of `url`."""
+    if not isinstance(url, str) or not url:
+        return ()
+    try:
+        path = urlsplit(url).path
+    except ValueError:
+        return ()
+    return tuple(seg for seg in path.split("/") if seg)
+
+
+def discord_channel_id(url) -> str:
+    """The channel id from a Discord attachment URL, else `''`.
+
+    `https://cdn.discordapp.com/attachments/<channel>/<message>/<file>`
+
+    This is the whole point of the Discord path: the id is IN THE URL, so no
+    DOM scraping is involved and a Discord UI change cannot break it.
+    """
+    if host_of(url) not in _DISCORD_CDN_HOSTS:
+        return ""
+    segments = url_path_segments(url)
+    if len(segments) < 3 or segments[0].lower() not in _DISCORD_ATTACHMENT_SEGMENTS:
+        return ""
+    channel = segments[1]
+    return channel if _SNOWFLAKE.match(channel) else ""
+
+
+def discord_alias_key(channel_id: str) -> str:
+    return KEY_PREFIX_DISCORD + str(channel_id)
+
+
+def _slug_tokens(segment: str) -> tuple:
+    """Content tokens of one path segment, with any adjacent numeric id gone."""
+    seg = str(segment or "")
+    seg = _LEADING_ID.sub("", seg)
+    seg = _TRAILING_ID.sub("", seg)
+    return content_tokens(seg)
+
+
+def thread_slug(url) -> str:
+    """The forum thread subject carried by a URL path, as a phrase.
+
+    `/forums/some-section/threads/subject-name.12345/page-2`  ->  "subject name"
+
+    Preferred over the tag list (decision: the tag list on a forum is chrome and
+    other posters' usernames) and over the page title (which carries site
+    branding). Returns `''` when no segment qualifies.
+    """
+    best = ()
+    for segment in url_path_segments(url):
+        lowered = segment.lower()
+        if lowered in _PATH_CHROME:
+            continue
+        toks = _slug_tokens(segment)
+        # TWO tokens minimum, not the usual fuzzy guard. A file host's path is
+        # `/d/AbCdEf` -- one opaque 6-character token, which the fuzzy guard
+        # happily accepts and which would then be minted as a thread identity
+        # for a page that has no thread. A slug is hyphenated words; an id is
+        # not. The cost is missing a genuinely one-word thread title, which
+        # falls through to the picker exactly as it does today.
+        if len(toks) < MIN_SLUG_TOKENS:
+            continue
+        # `page-2`, `post-14` -- a chrome verb plus its number is not a subject.
+        if len(toks) <= 2 and toks[0] in _PATH_CHROME:
+            continue
+        if all(t.isdigit() for t in toks):
+            continue
+        # DEEPEST wins: `/forums/<section>/threads/<subject>` puts the section
+        # before the subject, and the subject is the one that identifies it.
+        best = toks
+    return " ".join(best)
+
+
+def thread_alias_key(slug: str) -> str:
+    toks = content_tokens(slug)
+    return (KEY_PREFIX_THREAD + "-".join(toks)) if toks else ""
+
+
+def _host_tokens(site: str) -> frozenset:
+    """Tokens of a hostname, minus the parts every hostname has."""
+    return frozenset(t for t in tokens(site)
+                     if t not in STOPWORDS and len(t) > 1)
+
+
+def is_site_branding(phrase, site: str) -> bool:
+    """True when `phrase` is the SITE's own name rather than a subject.
+
+    Two checks, because a hostname concatenates what a title spaces out:
+    `"Some Forum"` on `someforum.test` shares no TOKEN with the host, but its
+    normalisation key `someforum` is right there inside `someforumtest`.
+
+    Known and accepted cost: a subject whose name is a substring of the host
+    they publish on (`Jane Doe` on `janedoe.test`) reads as branding here. It
+    loses one weak title-derived alias; the identity signals, which are the
+    ones that actually carry that site, are unaffected.
+    """
+    if not site:
+        return False
+    toks = content_tokens(phrase)
+    if not toks:
+        return False
+    host_toks = _host_tokens(site)
+    if host_toks and all(t in host_toks for t in toks):
+        return True
+    key = norm_key(phrase)
+    return len(key) >= MIN_ALIAS_KEY_LEN and key in norm_key(site)
+
+
+def title_subject(title, site: str = "") -> str:
+    """The subject half of a page title, with the site's branding dropped.
+
+    `"Subject Name | Some Forum"` on `someforum.test` -> `"Subject Name"`.
+
+    Deterministic and data-driven: a segment is chrome when every one of its
+    tokens is also a token of the HOST, so no list of site names is needed.
+    """
+    if not isinstance(title, str) or not title.strip():
+        return ""
+    parts = [p.strip() for p in _TITLE_SPLIT.split(title) if p and p.strip()]
+    kept = []
+    for part in parts:
+        toks = content_tokens(part)
+        if not toks or is_site_branding(part, site):
+            continue
+        kept.append((len(toks), part))
+    if not kept:
+        return ""
+    # The longest surviving segment: a title is "<subject> | <site>" far more
+    # often than the reverse, but ordering is not reliable across sites while
+    # "the site name is short" is.
+    kept.sort(key=lambda pair: -pair[0])
+    return kept[0][1]
+
+
+@dataclass(frozen=True)
+class IdentitySignal:
+    """A structured, site-scoped alias key derived from the URL.
+
+    ONE function produces these and BOTH the matcher and the learner consume
+    it, which is what stops "what we match on" and "what we learn" drifting.
+    """
+    key: str
+    site: str
+    kind: str        # provenance, surfaced by `dl-route alias review`
+    evidence: str
+
+
+def identity_signals(ctx) -> list:
+    """Every identity signal derivable from a context's URLs, strongest first.
+
+    Deliberately URL-only. Page DOM content is not an identity: it is what the
+    mislearning incident was made of.
+    """
+    out: list = []
+    seen = set()
+
+    def add(key, site, kind, evidence):
+        if not key or (key, site) in seen:
+            return
+        seen.add((key, site))
+        out.append(IdentitySignal(key=key, site=site, kind=kind,
+                                  evidence=evidence))
+
+    for url in (ctx.url, ctx.final_url, ctx.referrer):
+        channel = discord_channel_id(url)
+        if channel:
+            add(discord_alias_key(channel), DISCORD_SITE, "discord-channel",
+                f"channel {channel}")
+
+    # Order matters: the page the download was clicked ON first, then the
+    # download's own URL, then a PROVEN cross-host referrer (see the extension's
+    # carryReferrer -- never a time window, never "the last thread I saw").
+    for url in (ctx.page_url, ctx.url, ctx.final_url, ctx.referrer,
+                ctx.referrer_url):
+        slug = thread_slug(url)
+        key = thread_alias_key(slug)
+        if key:
+            add(key, host_of(url), "thread-slug", slug)
+    return out
 
 
 def strip_diacritics(text: str) -> str:
@@ -158,6 +426,13 @@ class MatchContext:
     link_text: str = ""
     alt: str = ""
     og: dict = field(default_factory=dict)
+    page_url: str = ""      # URL of the page the download was clicked on
+    # A PROVEN cross-host referrer: the forum thread that linked to this file
+    # host. Only ever populated when the extension could prove the link (an
+    # opener-tab chain or a captured click whose href is this page) -- never
+    # from a time window or "the last thread seen".
+    referrer_url: str = ""
+    referrer_title: str = ""
 
     @staticmethod
     def from_payload(payload: dict) -> "MatchContext":
@@ -168,17 +443,30 @@ class MatchContext:
         tags = tuple(str(t) for t in raw_tags
                      if isinstance(t, str) and t.strip())[:64] \
             if isinstance(raw_tags, list) else ()
+        page_url = str(page.get("url") or "")
+        url = str(payload.get("url") or "")
+        final_url = str(payload.get("finalUrl") or "")
+        referrer = str(payload.get("referrer") or "")
         site = str(page.get("site") or "").strip().lower()
         if not site:
-            site = _host_of(str(page.get("url") or payload.get("referrer") or ""))
+            site = host_of(page_url or referrer)
+        if not site and any(discord_channel_id(u)
+                            for u in (url, final_url, referrer)):
+            # Discord is a SPA: the captured page context is EMPTY (no title,
+            # no tags, no page URL), so there is nothing to derive a site from.
+            # The attachment URL still proves which site this is, and pinning it
+            # keeps everything learned here SITE-SCOPED instead of falling into
+            # the global-alias branch -- which is how a username became a
+            # library-wide alias the first evening this ran.
+            site = DISCORD_SITE
         try:
             size = int(payload.get("size") or 0)
         except (TypeError, ValueError):
             size = 0
         return MatchContext(
-            url=str(payload.get("url") or ""),
-            final_url=str(payload.get("finalUrl") or ""),
-            referrer=str(payload.get("referrer") or ""),
+            url=url,
+            final_url=final_url,
+            referrer=referrer,
             filename=str(payload.get("filename") or ""),
             mime=str(payload.get("mime") or ""),
             size=size,
@@ -189,13 +477,33 @@ class MatchContext:
             alt=str(page.get("alt") or ""),
             og={str(k): str(v) for k, v in og.items()
                 if isinstance(v, (str, int, float))},
+            page_url=page_url,
+            referrer_url=str(page.get("referrerUrl") or ""),
+            referrer_title=str(page.get("referrerTitle") or ""),
         )
+
+    def thread_slugs(self) -> list:
+        """Thread-subject phrases from the URLs, deepest-first per URL."""
+        out, seen = [], set()
+        for url in (self.page_url, self.url, self.final_url, self.referrer,
+                    self.referrer_url):
+            slug = thread_slug(url)
+            key = norm_key(slug)
+            if slug and key not in seen:
+                seen.add(key)
+                out.append(slug)
+        return out
 
     def subject_phrases(self) -> list:
         """Ordered candidate subject strings, strongest signal first.
 
-        Tags are the designed signal; og/link/alt/title are the fallbacks that
-        make the matcher work on sites with no tag markup at all.
+        ORDER CHANGED after the first evening of real traffic. It used to be
+        tags-first; on the one forum download where context WAS captured, the
+        tag list was the forum's own section names and other posters'
+        usernames, while the subject sat in the URL's thread slug and in the
+        page title. The URL slug is the cleanest carrier of a subject there is
+        -- it cannot be polluted by other users' content -- so it leads, the
+        de-branded title follows, and the tag list is demoted behind both.
         """
         out: list = []
         seen = set()
@@ -212,6 +520,10 @@ class MatchContext:
             seen.add(key)
             out.append(value)
 
+        for slug in self.thread_slugs():
+            add(slug)
+        add(title_subject(self.referrer_title, host_of(self.referrer_url)))
+        add(title_subject(self.title, self.site))
         for tag in self.tags:
             add(tag)
         for og_key in ("video:actor", "video:tag", "og:video:actor",
@@ -221,15 +533,12 @@ class MatchContext:
         add(self.link_text)
         add(self.alt)
         add(self.title)
+        add(self.referrer_title)
         return out
 
 
-def _host_of(url: str) -> str:
-    from urllib.parse import urlsplit
-    try:
-        return (urlsplit(url).hostname or "").lower()
-    except ValueError:
-        return ""
+# Back-compat alias for the private name this module used to expose.
+_host_of = host_of
 
 
 def filename_stem(filename: str) -> str:
@@ -290,12 +599,16 @@ class MatchResult:
 class Matcher:
     """Scores a `MatchContext` against the directory index + alias table.
 
-    `aliases` maps `(norm_key, site)` -> directory name, with `site=""` for a
+    `aliases` maps `(key, site)` -> directory name, with `site=""` for a
     global alias. Injected, so the scorer stays pure and unit-testable.
+
+    `dir_kinds` maps a directory name to `performer` / `category`. Anything
+    absent is UNKNOWN, and only a `performer` directory may ever auto-file.
     """
 
     def __init__(self, dirs, aliases=None, *, threshold: float = 0.75,
-                 tie_margin: float = 0.05, other_dir: str = "other"):
+                 tie_margin: float = 0.05, other_dir: str = "other",
+                 dir_kinds=None):
         self.dirs = [d if isinstance(d, DirEntry) else DirEntry.of(str(d))
                      for d in (dirs or [])]
         self.by_name = {d.name: d for d in self.dirs}
@@ -308,8 +621,33 @@ class Matcher:
         self.threshold = float(threshold)
         self.tie_margin = float(tie_margin)
         self.other_dir = other_dir
+        # Keyed by norm_key so a dirs.toml written in a different naming
+        # convention than the directory on disk still classifies it -- the same
+        # convention-folding that stops directories ever needing a rename.
+        self.dir_kinds = {norm_key(k): str(v)
+                          for k, v in dict(dir_kinds or {}).items()
+                          if norm_key(k) and v in KINDS}
+
+    def kind_of(self, dir_name: str) -> str:
+        return self.dir_kinds.get(norm_key(dir_name), KIND_UNKNOWN)
 
     # --- individual rules -------------------------------------------------- #
+    def _identity_hits(self, ctx) -> list:
+        """Structured URL identities -> full-confidence alias hits.
+
+        This is the Discord path. The first download from a channel has no
+        signal at all and opens the picker; confirming it writes
+        `discord:<channel id>` scoped to Discord, and every later download from
+        that channel lands here at 1.00 with nothing scraped from any page.
+        """
+        out = []
+        for sig in identity_signals(ctx):
+            target = self.aliases.get((sig.key, sig.site))
+            if target and target in self.by_name:
+                out.append(Candidate(target, SCORE_ALIAS_SITE, SCORE_ALIAS_SITE,
+                                     f"alias({sig.kind}) '{sig.key}'"))
+        return out
+
     def _alias_hits(self, phrases, site: str) -> list:
         out = []
         for phrase in phrases:
@@ -389,6 +727,7 @@ class Matcher:
               dup: dict | None = None) -> MatchResult:
         phrases = ctx.subject_phrases()
         hits: list = []
+        hits += self._identity_hits(ctx)
         hits += self._alias_hits(phrases, ctx.site)
         hits += self._tag_exact(phrases)
         hits += self._containment(phrases)
@@ -444,6 +783,26 @@ class Matcher:
                 auto = False
                 reason = (f"tie: '{top.dir}' {top.base:.2f} vs "
                           f"'{runner.dir}' {runner.base:.2f} — {top.reason}")
+        # DIRECTORY KIND. Applied LAST and unconditionally, so no score, alias
+        # or prior can route around it.
+        #
+        #   * category  -- a tag legitimately identifies the directory, but a
+        #     tag is a weak claim about any ONE file, so a category always gets
+        #     confirmed. (Known consequence: a confirmed Discord channel alias
+        #     pointing at a category directory keeps asking forever. That is
+        #     the rule as specified; see the PR body for the exception.)
+        #   * unknown   -- absence of a classification is not permission. An
+        #     unclassified directory is one `dl-route dirs classify` away from
+        #     being usable, and until then it asks.
+        if auto:
+            kind = self.kind_of(top.dir)
+            if kind == KIND_CATEGORY:
+                auto = False
+                reason = f"category directory — always confirm — {reason}"
+            elif kind != KIND_PERFORMER:
+                auto = False
+                reason = (f"unclassified directory '{top.dir}' — set its kind "
+                          f"(dl-route dirs classify) — {reason}")
         # `confidence` is the pre-bonus score: it is what the threshold was
         # tested against, so reporting the bonused number would be a lie.
         return MatchResult(dir=top.dir, confidence=top.base, reason=reason,
@@ -468,6 +827,69 @@ class Matcher:
             if is_safe_dir_name(proposal) and proposal not in self.by_name:
                 return proposal
         return None
+
+
+def is_structured_key(key) -> bool:
+    """True for `discord:`/`thread:` keys — an identity, not a word."""
+    return isinstance(key, str) and key.startswith(KEY_PREFIXES)
+
+
+def alias_key(phrase) -> str:
+    """The stored key for a phrase, as typed at the CLI or learned.
+
+    Structured keys keep their prefix and are canonicalised inside it, so
+    `dl-route alias rm 'discord:123'` removes exactly the row
+    `dl-route alias list` printed. Everything else folds through `norm_key`.
+    """
+    raw = str(phrase or "").strip()
+    lowered = raw.lower()
+    if lowered.startswith(KEY_PREFIX_DISCORD):
+        rest = raw[len(KEY_PREFIX_DISCORD):].strip()
+        return discord_alias_key(rest) if _SNOWFLAKE.match(rest) else ""
+    if lowered.startswith(KEY_PREFIX_THREAD):
+        return thread_alias_key(raw[len(KEY_PREFIX_THREAD):])
+    return norm_key(raw)
+
+
+def suspicious_alias_key(phrase, *, key: str = "", dir_names=(), site: str = "",
+                         spread: int = 0):
+    """Why `phrase` must not become an alias, or None if it is fine.
+
+    This is the generalisation of the four rows that had to be deleted by hand
+    after the first evening: a forum section name, two other posters' usernames
+    and one of them at GLOBAL scope. Catching those four specific strings would
+    have been a word list; these rules catch the FAILURE CLASS, and every one of
+    them is measured from data the router already has rather than from a
+    vocabulary that would need maintaining (and could never be committed to a
+    public repo anyway).
+    """
+    key = key or alias_key(phrase)
+    if not key:
+        return "empty key"
+    if is_structured_key(key):
+        return None          # a channel id / thread slug is an identity
+    if len(key) < MIN_ALIAS_KEY_LEN:
+        return (f"key {key!r} is shorter than {MIN_ALIAS_KEY_LEN} characters — "
+                "it would match unrelated page prose")
+    if spread >= CHROME_DIR_SPREAD:
+        return (f"seen on {spread} different directories — that is site chrome "
+                "(a section name, an uploader's username), not a subject")
+    ptoks = content_tokens(phrase)
+    if is_site_branding(phrase, site):
+        return f"it is part of the site name ({site})"
+    if ptoks:
+        shared = 0
+        for tok in ptoks:
+            hits = sum(1 for name in dir_names if tok in content_tokens(name))
+            if hits >= CHROME_DIR_SPREAD:
+                shared += 1
+        if shared == len(ptoks):
+            return ("every word of it already appears in "
+                    f"{CHROME_DIR_SPREAD}+ library directories — it reads as a "
+                    "category word, not a subject")
+    if len(ptoks) == 1 and any(ch.isdigit() for ch in ptoks[0]):
+        return "a single word with digits in it reads as a handle, not a name"
+    return None
 
 
 def find_duplicate(index, target_dir: str, filename: str, size: int = 0):

--- a/scripts/dl-router/matcher.py
+++ b/scripts/dl-router/matcher.py
@@ -55,7 +55,7 @@ from __future__ import annotations
 import re
 import unicodedata
 from dataclasses import dataclass, field
-from urllib.parse import urlsplit
+from urllib.parse import unquote, urlsplit
 
 # Score constants — named so tests assert against the spec table, not magic
 # numbers scattered through the scorer.
@@ -157,9 +157,14 @@ _THREAD_ANCHORS = frozenset({
 # The ambiguity was the problem, not the gate around it. This design already
 # says no slug is fine and a wrong slug is not, so the ambiguous routes are
 # simply not anchors: an id-less Discourse or IPB thread degrades to the
-# picker. If one of those platforms ever matters here, the honest way to add it
-# is a per-site rule in local config where the operator ASSERTS the shape --
-# not a global guess about everyone's URLs.
+# picker, and a Discord channel or an unambiguous forum route still carries it.
+#
+# There is deliberately NO promise of a workaround here. `site_rules` in
+# config.toml are CSS selectors for DOM capture and cannot express a URL shape,
+# and for a performer directory a tag is never learned -- so nothing that
+# exists today can restore a Discourse identity alias. Supporting one would
+# take a new per-host anchor list in config (`[thread_anchors."<host>"]`) that
+# the operator asserts; that is a feature, not a setting, and it is not built.
 
 # `slug.123456` (xenforo) and `123456-slug` (vbulletin) both carry a numeric id
 # beside the slug. Stripping it is what makes the two shapes fold to one key.
@@ -199,7 +204,6 @@ def _ascii_host(host: str) -> str:
         # `new URL` percent-DECODES the host before punycoding it; `urlsplit`
         # hands back the raw escapes. Without this the two produce
         # `xn--e1afmkfd.test` and `%d0%bf....test` for the same URL.
-        from urllib.parse import unquote
         try:
             decoded = unquote(host, errors="strict")
         except (UnicodeDecodeError, ValueError):
@@ -250,7 +254,20 @@ def url_path_segments(url) -> tuple:
         path = urlsplit(url).path
     except ValueError:
         return ()
-    return tuple(seg for seg in path.split("/") if seg)
+    # PERCENT-DECODED, because `new URL().pathname` hands JS the encoded form
+    # while `urlsplit().path` hands Python the raw one -- so an unescaped
+    # non-ASCII slug produced `%D0%BF...` tokens on one side and real words on
+    # the other. Decoding in both is what makes a non-latin thread slug work
+    # at all, rather than merely agreeing on junk.
+    out = []
+    for seg in path.split("/"):
+        if not seg:
+            continue
+        try:
+            out.append(unquote(seg, errors="strict"))
+        except (UnicodeDecodeError, ValueError):
+            out.append(seg)
+    return tuple(out)
 
 
 def discord_channel_id(url) -> str:
@@ -323,12 +340,15 @@ def thread_slug(url) -> str:
         # is legitimate here in a way it never was under the old rule -- the
         # >=2-token guard existed only to stop an opaque file-host id
         # (`/d/AbCdEf`) being minted as a subject, and no anchor introduces one.
-        # `isascii()` as well as `isdigit()`: Python's `isdigit` accepts
-        # non-ASCII digits and JS's `/^\d+$/` does not, and these two
-        # implementations have to agree.
+        # A bare id is not a subject IN ANY SCRIPT. The previous spelling
+        # (`isascii() and isdigit()`) was sold as a parity fix but WIDENED the
+        # rule: `/threads/\u0660\u0661\u0662` minted its Arabic-Indic id as a
+        # slug, contradicting the fixture contract that `/threads/481920/`
+        # yields nothing. `isdigit()` covers every Unicode decimal, and JS's
+        # mirror uses `\p{Nd}` so the two agree -- rejecting, which is the safe
+        # direction.
         meaningful = tuple(t for t in toks
-                           if t not in STOPWORDS
-                           and not (t.isascii() and t.isdigit()))
+                           if t not in STOPWORDS and not t.isdigit())
         if not meaningful or not passes_fuzzy_guard(meaningful):
             continue
         best = toks

--- a/scripts/dl-router/matcher.py
+++ b/scripts/dl-router/matcher.py
@@ -115,15 +115,32 @@ _DISCORD_ATTACHMENT_SEGMENTS = frozenset({"attachments", "ephemeral-attachments"
 # "any digits" rule would turn a stray numeric path segment into an alias key.
 _SNOWFLAKE = re.compile(r"^[0-9]{5,25}$")
 
-# URL path segments that are forum CHROME rather than a thread subject. This is
-# a structural list (route/verb segments), not a vocabulary of subject words --
-# no library-specific or site-specific term belongs here.
-_PATH_CHROME = frozenset({
-    "threads", "thread", "topic", "topics", "forum", "forums", "board",
-    "boards", "index.php", "showthread.php", "viewtopic.php", "viewforum.php",
-    "t", "f", "p", "post", "posts", "page", "pages", "attachment",
-    "attachments", "download", "downloads", "view", "watch", "media", "album",
-    "gallery", "comments", "s", "goto", "print",
+# The path segments that INTRODUCE a thread. A slug is the segment immediately
+# after one of these, and nowhere else.
+#
+# THIS USED TO BE A "SKIP THE CHROME, TAKE THE DEEPEST SEGMENT THAT QUALIFIES"
+# RULE, AND THAT RULE WAS WRONG IN THE ONE CASE THAT MATTERS. When a thread's
+# own slug is a single word, it failed the >=2-token test and the SECTION name
+# one level up won instead:
+#
+#     /forums/general-discussion/threads/aster.99/  ->  "general discussion"
+#     /forums/general-discussion.12/                ->  "general discussion"
+#     /members/some-poster.4321/                    ->  "some poster"
+#
+# Those became `thread:` identity keys, which score 1.00 and auto-file -- so
+# one correction taught the router that an entire forum SECTION, or another
+# member's profile, meant one subject directory. That is precisely the
+# mislearning this whole change exists to remove, relocated from the tag list
+# into the URL path and made worse, because an identity key outranks everything
+# else.
+#
+# Anchoring is a POSITIONAL rule, not a superlative over candidates: a
+# superlative ("deepest that qualifies", "longest that survives") picks the
+# wrong thing exactly when the subject is short, and short subjects are common.
+# A segment that no forum route introduced is not a thread, full stop.
+_THREAD_ANCHORS = frozenset({
+    "threads", "thread", "topic", "topics", "t",
+    "showthread.php", "viewtopic.php", "showthread", "viewtopic",
 })
 
 # `slug.123456` (xenforo) and `123456-slug` (vbulletin) both carry a numeric id
@@ -135,44 +152,83 @@ _LEADING_ID = re.compile(r"^\d{2,}[.\-_]")
 # half is chrome and is dropped by comparing against the host's own tokens.
 _TITLE_SPLIT = re.compile(r"\s*[|–—·•»«]\s*|\s+[-‐]\s+|\s*::\s*")
 
-# A learned alias key shorter than this is refused: two or three characters
-# match far too much page prose to be a subject.
-MIN_ALIAS_KEY_LEN = 4
-# A thread slug is hyphenated WORDS. One token is an opaque id (`/d/AbCdEf`).
-MIN_SLUG_TOKENS = 2
+# A learned alias key shorter than this is refused: two characters match far
+# too much page prose to be a subject. Three is deliberate rather than four:
+# an initialised stage name folds to three (`M.I.A.` -> `mia`), and refusing a
+# real subject is not free just because the refusal is quiet.
+MIN_ALIAS_KEY_LEN = 3
 # A phrase seen on this many DISTINCT directories is site chrome (a forum
 # section, an uploader's username), not a subject. Data-driven: it is measured
 # from the labelled examples, not read off a word list.
 CHROME_DIR_SPREAD = 2
 
 
+def _ascii_host(host: str) -> str:
+    """A hostname in the one form BOTH implementations produce.
+
+    JS's `new URL().hostname` punycodes an internationalised host and wraps an
+    IPv6 literal in brackets; Python's `urlsplit().hostname` does neither and
+    strips the brackets. Both are right for their own spec, which is exactly
+    why neither can be the contract -- so the rule is written out here and
+    mirrored in route_core.js, the same treatment `is_http_url` already gets in
+    safety.py. An un-encodable host is refused rather than guessed at.
+    """
+    host = (host or "").lower()
+    if not host:
+        return ""
+    if "%" in host:
+        # `new URL` percent-DECODES the host before punycoding it; `urlsplit`
+        # hands back the raw escapes. Without this the two produce
+        # `xn--e1afmkfd.test` and `%d0%bf....test` for the same URL.
+        from urllib.parse import unquote
+        try:
+            decoded = unquote(host, errors="strict")
+        except (UnicodeDecodeError, ValueError):
+            return ""
+        if any(ch in decoded for ch in "/\\?#@[]:"):
+            return ""       # an escape that smuggles authority syntax
+        host = decoded
+    if all(ord(ch) < 128 for ch in host):
+        return host
+    try:
+        return host.encode("idna").decode("ascii")
+    except (UnicodeError, ValueError):
+        return ""
+
+
 def host_of(url) -> str:
-    """Hostname of `url`, lowercased. `''` when it has none."""
+    """Hostname of an http(s) URL, normalised. `''` for anything else.
+
+    The scheme filter matters: these hosts become the SCOPE of an alias, and
+    `file:`, `data:` and `blob:` URLs have no meaningful one. `urlsplit`
+    cheerfully parses all three; `new URL` parses them too but reports a
+    different hostname, so without an explicit gate the two implementations
+    disagreed on 9 of 30 hostile inputs.
+    """
     if not isinstance(url, str) or not url:
         return ""
     try:
-        return (urlsplit(url).hostname or "").lower()
+        split = urlsplit(url)
+        if split.scheme.lower() not in ("http", "https"):
+            return ""
+        return _ascii_host(split.hostname or "")
     except ValueError:
         return ""
 
 
 def url_path_segments(url) -> tuple:
-    """Non-empty path segments of an ABSOLUTE URL. `()` for anything else.
+    """Non-empty path segments of an absolute http(s) URL. `()` otherwise.
 
-    The hostname requirement is not cosmetic: `urlsplit` happily parses
+    Gated on `host_of` for two reasons. `urlsplit` happily parses
     `"not a url"` as a relative path and hands back `["not a url"]`, which the
-    slug extractor then reads as a two-word thread subject. JS's `new URL`
-    throws on the same input, so without this the two implementations disagree
-    -- and the extension's copy runs exactly when the sidecar is unreachable,
-    where the disagreement is invisible. Pinned by fixtures/url_cases.json.
+    slug extractor then read as a two-word thread subject, while JS's
+    `new URL` throws. And `data:`/`file:`/`blob:` URLs have paths but no site
+    to scope an alias to. Pinned by fixtures/url_cases.json.
     """
-    if not isinstance(url, str) or not url:
+    if not host_of(url):
         return ()
     try:
-        split = urlsplit(url)
-        if not split.hostname:
-            return ()
-        path = split.path
+        path = urlsplit(url).path
     except ValueError:
         return ()
     return tuple(seg for seg in path.split("/") if seg)
@@ -200,49 +256,65 @@ def discord_alias_key(channel_id: str) -> str:
 
 
 def _slug_tokens(segment: str) -> tuple:
-    """Content tokens of one path segment, with any adjacent numeric id gone."""
+    """VERBATIM tokens of one path segment, with any adjacent numeric id gone.
+
+    `tokens`, not `content_tokens`. Stopword stripping belongs to fuzzy
+    matching, never to an identity: it made distinct threads collide, and
+    `upsert_alias` re-points on conflict, so the collision was silent --
+
+        /threads/aster-vale-new-set.222/  ->  thread:aster-vale-set
+        /threads/aster-vale-set.223/      ->  thread:aster-vale-set
+
+    ...and the second correction quietly repointed a key the first thread hits
+    at 1.00. `new` is a stopword here; so are `part`, `scene`, `full`, `hd`,
+    `clip`, `video`, `source`, `original` and `final`, which is a lot of real
+    thread titles.
+    """
     seg = str(segment or "")
     seg = _LEADING_ID.sub("", seg)
     seg = _TRAILING_ID.sub("", seg)
-    return content_tokens(seg)
+    return tokens(seg)
 
 
 def thread_slug(url) -> str:
     """The forum thread subject carried by a URL path, as a phrase.
 
-    `/forums/some-section/threads/subject-name.12345/page-2`  ->  "subject name"
+    ANCHORED: the slug is the segment immediately following a thread route
+    (`/threads/`, `/topic/`, `/t/`, `showthread.php`, ...) and nowhere else.
 
-    Preferred over the tag list (decision: the tag list on a forum is chrome and
-    other posters' usernames) and over the page title (which carries site
-    branding). Returns `''` when no segment qualifies.
+        /forums/some-section/threads/subject-name.12345/page-2 -> "subject name"
+        /forums/some-section/                                  -> ""
+        /members/some-poster.4321/                             -> ""
+        /uploads/dsc-0123.jpg                                  -> ""
+
+    See `_THREAD_ANCHORS` for why this is positional rather than a superlative
+    over candidate segments. The last anchored segment wins when a URL somehow
+    contains two, which is deterministic without being a "best of" rule.
+
+    Preferred over the tag list (on a forum that is section names and other
+    posters' usernames) and over the page title (site branding).
     """
     best = ()
-    for segment in url_path_segments(url):
-        lowered = segment.lower()
-        if lowered in _PATH_CHROME:
+    segments = url_path_segments(url)
+    for i in range(1, len(segments)):
+        if segments[i - 1].lower() not in _THREAD_ANCHORS:
             continue
-        toks = _slug_tokens(segment)
-        # TWO tokens minimum, not the usual fuzzy guard. A file host's path is
-        # `/d/AbCdEf` -- one opaque 6-character token, which the fuzzy guard
-        # happily accepts and which would then be minted as a thread identity
-        # for a page that has no thread. A slug is hyphenated words; an id is
-        # not. The cost is missing a genuinely one-word thread title, which
-        # falls through to the picker exactly as it does today.
-        if len(toks) < MIN_SLUG_TOKENS:
+        toks = _slug_tokens(segments[i])
+        # The thread route already proves this is a thread, so a ONE-word slug
+        # is legitimate here in a way it never was under the old rule -- the
+        # >=2-token guard existed only to stop an opaque file-host id
+        # (`/d/AbCdEf`) being minted as a subject, and no anchor introduces one.
+        meaningful = tuple(t for t in toks
+                           if t not in STOPWORDS and not t.isdigit())
+        if not meaningful or not passes_fuzzy_guard(meaningful):
             continue
-        # `page-2`, `post-14` -- a chrome verb plus its number is not a subject.
-        if len(toks) <= 2 and toks[0] in _PATH_CHROME:
-            continue
-        if all(t.isdigit() for t in toks):
-            continue
-        # DEEPEST wins: `/forums/<section>/threads/<subject>` puts the section
-        # before the subject, and the subject is the one that identifies it.
         best = toks
     return " ".join(best)
 
 
 def thread_alias_key(slug: str) -> str:
-    toks = content_tokens(slug)
+    """The stored key for a thread slug. Near-verbatim — see `_slug_tokens`."""
+    toks = tokens(slug)
     return (KEY_PREFIX_THREAD + "-".join(toks)) if toks else ""
 
 
@@ -281,25 +353,37 @@ def title_subject(title, site: str = "") -> str:
 
     `"Subject Name | Some Forum"` on `someforum.test` -> `"Subject Name"`.
 
-    Deterministic and data-driven: a segment is chrome when every one of its
-    tokens is also a token of the HOST, so no list of site names is needed.
+    THE FIRST surviving segment, not the longest.
+
+    "Longest wins" was a superlative over candidates, and like the old slug
+    rule it picked the wrong thing exactly when the subject was short. The
+    branding test can only recognise a site whose display name resembles its
+    hostname, so on a forum where those differ it fires for neither segment --
+    and then the longer one wins, which is the SITE name whenever the subject
+    is a single word:
+
+        title_subject('Aster | Some Forum', 'forum.test')  ->  'Some Forum'
+
+    That is a 1.00 site-scoped alias for the site's own name: every page on
+    that forum with a short subject then auto-files into one directory.
+
+    Position is the reliable signal. `"<subject> | <site>"` is the dominant
+    convention by a wide margin, and the reverse order is still handled
+    whenever the branding test CAN see it, because that segment is dropped
+    before position is consulted. When neither is knowable, taking the first
+    segment is at worst a weak alias for one page's real title -- the failure
+    mode is a useless alias, not a wrong one.
     """
     if not isinstance(title, str) or not title.strip():
         return ""
-    parts = [p.strip() for p in _TITLE_SPLIT.split(title) if p and p.strip()]
-    kept = []
-    for part in parts:
-        toks = content_tokens(part)
-        if not toks or is_site_branding(part, site):
+    for part in _TITLE_SPLIT.split(title):
+        part = (part or "").strip()
+        if not part or not content_tokens(part):
             continue
-        kept.append((len(toks), part))
-    if not kept:
-        return ""
-    # The longest surviving segment: a title is "<subject> | <site>" far more
-    # often than the reverse, but ordering is not reliable across sites while
-    # "the site name is short" is.
-    kept.sort(key=lambda pair: -pair[0])
-    return kept[0][1]
+        if is_site_branding(part, site):
+            continue
+        return part
+    return ""
 
 
 @dataclass(frozen=True)
@@ -873,13 +957,27 @@ def suspicious_alias_key(phrase, *, key: str = "", dir_names=(), site: str = "",
     them is measured from data the router already has rather than from a
     vocabulary that would need maintaining (and could never be committed to a
     public repo anyway).
+
+    STRUCTURED KEYS ARE SCREENED TOO. They used to return None immediately, on
+    the reasoning that a channel id is an identity rather than a word. The
+    reasoning held; the exemption did not, because a BADLY DERIVED identity is
+    still an identity as far as the store is concerned, and it lands at 1.00
+    with auto-file rather than at 0.85 without. A section name mis-read as a
+    thread slug was the worst row the router could possibly write, and it was
+    the one row nothing checked.
+
+    What structured keys are exempt from is only the two rules that describe a
+    WORD rather than a source: minimum length (a channel id is digits; a
+    one-word thread slug is legitimately short) and the handle shape (a channel
+    id is nothing but digits). Chrome spread, site branding and shared library
+    vocabulary all still apply, and all three are exactly what catches a
+    section name.
     """
     key = key or alias_key(phrase)
     if not key:
         return "empty key"
-    if is_structured_key(key):
-        return None          # a channel id / thread slug is an identity
-    if len(key) < MIN_ALIAS_KEY_LEN:
+    structured = is_structured_key(key)
+    if not structured and len(key) < MIN_ALIAS_KEY_LEN:
         return (f"key {key!r} is shorter than {MIN_ALIAS_KEY_LEN} characters — "
                 "it would match unrelated page prose")
     if spread >= CHROME_DIR_SPREAD:
@@ -898,9 +996,24 @@ def suspicious_alias_key(phrase, *, key: str = "", dir_names=(), site: str = "",
             return ("every word of it already appears in "
                     f"{CHROME_DIR_SPREAD}+ library directories — it reads as a "
                     "category word, not a subject")
-    if len(ptoks) == 1 and any(ch.isdigit() for ch in ptoks[0]):
-        return "a single word with digits in it reads as a handle, not a name"
+    if not structured and _looks_like_a_handle(ptoks):
+        return "it reads as a handle (a word with a number stuck on the end)"
     return None
+
+
+def _looks_like_a_handle(ptoks) -> bool:
+    """`poster1988`, `uploader42` — a word with a number stuck on the end.
+
+    NARROWED from "a single token containing any digit", which refused
+    legitimate single-word stage names that merely contain a numeral. The
+    remaining false positive is a name that genuinely ends in digits; it is
+    reported rather than silently dropped, and `--force` still writes it.
+    """
+    if len(ptoks) != 1:
+        return False
+    tok = ptoks[0]
+    return (len(tok) >= 6 and tok[-1].isdigit() and tok[-2].isdigit()
+            and not tok[0].isdigit())
 
 
 def find_duplicate(index, target_dir: str, filename: str, size: int = 0):

--- a/scripts/dl-router/matcher.py
+++ b/scripts/dl-router/matcher.py
@@ -138,10 +138,24 @@ _SNOWFLAKE = re.compile(r"^[0-9]{5,25}$")
 # superlative ("deepest that qualifies", "longest that survives") picks the
 # wrong thing exactly when the subject is short, and short subjects are common.
 # A segment that no forum route introduced is not a thread, full stop.
+# UNAMBIGUOUS thread routes: nothing else lives behind these.
 _THREAD_ANCHORS = frozenset({
-    "threads", "thread", "topic", "topics", "t",
-    "showthread.php", "viewtopic.php", "showthread", "viewtopic",
+    "threads", "thread", "showthread.php", "viewtopic.php",
+    "showthread", "viewtopic",
 })
+
+# AMBIGUOUS routes. Discourse (`/t/<slug>/<id>`) and IPB (`/topic/<id>-<slug>/`)
+# use these for a thread, but plenty of sites use the same words for an INDEX:
+#
+#     /topics/general-discussion   ->  a section listing, not a thread
+#     /t/photography               ->  a tag page, not a thread
+#
+# Treating them as unambiguous asserted something untrue and re-opened the
+# section-name hole one level down. A real thread on these platforms always
+# carries a numeric id beside the slug; an index route never does, so the id is
+# the discriminator -- and requiring it is fail-closed, because a thread shape
+# nobody anticipated degrades to "no slug" (the picker), never to a wrong slug.
+_ID_ANCHORS = frozenset({"topic", "topics", "t"})
 
 # `slug.123456` (xenforo) and `123456-slug` (vbulletin) both carry a numeric id
 # beside the slug. Stripping it is what makes the two shapes fold to one key.
@@ -152,11 +166,12 @@ _LEADING_ID = re.compile(r"^\d{2,}[.\-_]")
 # half is chrome and is dropped by comparing against the host's own tokens.
 _TITLE_SPLIT = re.compile(r"\s*[|–—·•»«]\s*|\s+[-‐]\s+|\s*::\s*")
 
-# A learned alias key shorter than this is refused: two characters match far
-# too much page prose to be a subject. Three is deliberate rather than four:
-# an initialised stage name folds to three (`M.I.A.` -> `mia`), and refusing a
-# real subject is not free just because the refusal is quiet.
-MIN_ALIAS_KEY_LEN = 3
+# A learned alias key shorter than this is refused: three characters match far
+# too much page prose to be a subject. An INITIALISED name is exempt
+# (`M.I.A.` -> `mia`) -- the punctuation is what distinguishes it from a bare
+# three-letter word, and lowering the floor for everything instead let `gif`,
+# `mp4`, `www` and `com` through.
+MIN_ALIAS_KEY_LEN = 4
 # A phrase seen on this many DISTINCT directories is site chrome (a forum
 # section, an uploader's username), not a subject. Data-driven: it is measured
 # from the labelled examples, not read off a word list.
@@ -276,6 +291,19 @@ def _slug_tokens(segment: str) -> tuple:
     return tokens(seg)
 
 
+def _carries_thread_id(segments, i: int) -> bool:
+    """True when the slug at `segments[i]` has a numeric thread id beside it.
+
+    Either inside the segment (`/topic/12345-slug/`, `/topic/slug.12345/`) or as
+    the next one (`/t/slug/12345`). This is what separates a Discourse/IPB
+    thread from a same-named index route.
+    """
+    segment = segments[i]
+    if _LEADING_ID.match(segment) or _TRAILING_ID.search(segment):
+        return True
+    return i + 1 < len(segments) and segments[i + 1].isdigit()
+
+
 def thread_slug(url) -> str:
     """The forum thread subject carried by a URL path, as a phrase.
 
@@ -297,7 +325,11 @@ def thread_slug(url) -> str:
     best = ()
     segments = url_path_segments(url)
     for i in range(1, len(segments)):
-        if segments[i - 1].lower() not in _THREAD_ANCHORS:
+        anchor = segments[i - 1].lower()
+        if anchor in _ID_ANCHORS:
+            if not _carries_thread_id(segments, i):
+                continue
+        elif anchor not in _THREAD_ANCHORS:
             continue
         toks = _slug_tokens(segments[i])
         # The thread route already proves this is a thread, so a ONE-word slug
@@ -348,42 +380,57 @@ def is_site_branding(phrase, site: str) -> bool:
     return len(key) >= MIN_ALIAS_KEY_LEN and key in norm_key(site)
 
 
-def title_subject(title, site: str = "") -> str:
-    """The subject half of a page title, with the site's branding dropped.
+def title_subject(title, site: str = "", slug: str = "") -> str:
+    """The subject segment of a page title, CORROBORATED against the URL slug.
 
-    `"Subject Name | Some Forum"` on `someforum.test` -> `"Subject Name"`.
+    `"Subject Name | Some Forum"` with slug `"subject name"` -> `"Subject Name"`.
 
-    THE FIRST surviving segment, not the longest.
+    NEITHER POSITION NOR SIZE CAN DO THIS JOB, and both were tried:
 
-    "Longest wins" was a superlative over candidates, and like the old slug
-    rule it picked the wrong thing exactly when the subject was short. The
-    branding test can only recognise a site whose display name resembles its
-    hostname, so on a forum where those differ it fires for neither segment --
-    and then the longer one wins, which is the SITE name whenever the subject
-    is a single word:
+      * "longest surviving segment" returned the SITE name whenever the subject
+        was one word and the site's display name did not resemble its hostname
+        (`'Aster | Some Forum'` on `forum.test` -> `'Some Forum'`);
+      * "first surviving segment" then broke every template that does not put
+        the subject first, which is a large share of real forums --
 
-        title_subject('Aster | Some Forum', 'forum.test')  ->  'Some Forum'
+            'Some Forum - View topic - Aster Vale Deluxe Photo Set' -> 'View topic'
+            'Section | Aster Vale Deluxe Photo Set | Some Forum'    -> 'Section'
+            'Page 2 | Aster Vale Deluxe Photo Set | Some Forum'     -> 'Page 2'
 
-    That is a 1.00 site-scoped alias for the site's own name: every page on
-    that forum with a short subject then auto-files into one directory.
+        ...and `'View topic'` is a phpBB constant, so it became a site-wide
+        1.00 alias. phpBB puts the subject last, XenForo puts it first, and
+        both are common: there is no ordering rule, and a third superlative
+        would just relocate the failure again.
 
-    Position is the reliable signal. `"<subject> | <site>"` is the dominant
-    convention by a wide margin, and the reverse order is still handled
-    whenever the branding test CAN see it, because that segment is dropped
-    before position is consulted. When neither is knowable, taking the first
-    segment is at worst a weak alias for one page's real title -- the failure
-    mode is a useless alias, not a wrong one.
+    So this stops guessing and asks something that already knows. The anchored
+    URL slug is an independent, positionally-proven statement of what the
+    thread is about; the title segment that shares the most tokens with it is
+    the subject, and every other segment is chrome by construction.
+
+    WITH NO SLUG THERE IS NO ANSWER, and `''` is returned rather than a guess.
+    A title subject can therefore only ever be learned when something
+    independent has already confirmed the subject -- fail-closed, and it
+    deletes the guessing problem instead of re-tuning it. Pages with no thread
+    slug still match on their raw title through the ordinary containment rule;
+    what they no longer do is mint an alias.
     """
     if not isinstance(title, str) or not title.strip():
         return ""
+    slug_tokens = set(content_tokens(slug))
+    if not slug_tokens:
+        return ""
+    best, best_overlap = "", 0
     for part in _TITLE_SPLIT.split(title):
         part = (part or "").strip()
-        if not part or not content_tokens(part):
+        toks = content_tokens(part)
+        if not toks or is_site_branding(part, site):
             continue
-        if is_site_branding(part, site):
-            continue
-        return part
-    return ""
+        overlap = sum(1 for t in set(toks) if t in slug_tokens)
+        # Strictly greater, so the FIRST segment wins a tie -- deterministic,
+        # and only ever consulted between segments that corroborate equally.
+        if overlap > best_overlap:
+            best, best_overlap = part, overlap
+    return best if best_overlap else ""
 
 
 @dataclass(frozen=True)
@@ -615,10 +662,16 @@ class MatchContext:
             seen.add(key)
             out.append(value)
 
-        for slug in self.thread_slugs():
+        slugs = self.thread_slugs()
+        for slug in slugs:
             add(slug)
-        add(title_subject(self.referrer_title, host_of(self.referrer_url)))
-        add(title_subject(self.title, self.site))
+        # The de-branded title is CORROBORATED against the slug (see
+        # title_subject): with no slug it contributes nothing here, and the raw
+        # title below still carries the page through ordinary containment.
+        own_slug = thread_slug(self.page_url) or (slugs[0] if slugs else "")
+        add(title_subject(self.referrer_title, host_of(self.referrer_url),
+                          thread_slug(self.referrer_url)))
+        add(title_subject(self.title, self.site, own_slug))
         for tag in self.tags:
             add(tag)
         for og_key in ("video:actor", "video:tag", "og:video:actor",
@@ -977,13 +1030,21 @@ def suspicious_alias_key(phrase, *, key: str = "", dir_names=(), site: str = "",
     if not key:
         return "empty key"
     structured = is_structured_key(key)
-    if not structured and len(key) < MIN_ALIAS_KEY_LEN:
+    ptoks = content_tokens(phrase)
+    if not structured and not ptoks:
+        # Nothing but stopwords and format noise -- `gif`, `mp4`, `www`, `com`.
+        # This has to come FIRST: with no content tokens the shared-vocabulary
+        # and handle rules below both silently pass, so a short stopword slipped
+        # through the whole screen once the length floor was lowered.
+        return (f"{phrase!r} is nothing but stopwords or format noise, "
+                "so it says nothing about a subject")
+    if not structured and len(key) < MIN_ALIAS_KEY_LEN \
+            and not _looks_initialised(phrase):
         return (f"key {key!r} is shorter than {MIN_ALIAS_KEY_LEN} characters — "
                 "it would match unrelated page prose")
     if spread >= CHROME_DIR_SPREAD:
         return (f"seen on {spread} different directories — that is site chrome "
                 "(a section name, an uploader's username), not a subject")
-    ptoks = content_tokens(phrase)
     if is_site_branding(phrase, site):
         return f"it is part of the site name ({site})"
     if ptoks:
@@ -1001,19 +1062,28 @@ def suspicious_alias_key(phrase, *, key: str = "", dir_names=(), site: str = "",
     return None
 
 
-def _looks_like_a_handle(ptoks) -> bool:
-    """`poster1988`, `uploader42` — a word with a number stuck on the end.
+# A word with a number stuck on the end: `poster1988`, `uploader7`, `user2`.
+# One trailing digit is the COMMON username shape, so requiring two (an earlier
+# narrowing) let most real handles straight through.
+_HANDLE = re.compile(r"^[^\W\d_]+[0-9]{1,4}$")
+# Letters separated by punctuation: `M.I.A.`, `K. D.` -- an initialised stage
+# name, not a three-letter word. This is what lets the length floor stay at 4
+# without refusing a real subject.
+_INITIALISED = re.compile(r"^(?:[^\W\d_][.\u00b7\s]+){2,}[^\W\d_]?[.]?$")
 
-    NARROWED from "a single token containing any digit", which refused
-    legitimate single-word stage names that merely contain a numeral. The
-    remaining false positive is a name that genuinely ends in digits; it is
-    reported rather than silently dropped, and `--force` still writes it.
+
+def _looks_initialised(phrase) -> bool:
+    return bool(_INITIALISED.match(str(phrase or "").strip()))
+
+
+def _looks_like_a_handle(ptoks) -> bool:
+    """`poster1988`, `uploader7`, `user2` — a word with a number on the end.
+
+    A name that genuinely ends in digits is a false positive; it is REPORTED
+    rather than silently dropped, and `--force` still writes it. A numeral
+    inside a word (`m1a`) is not matched.
     """
-    if len(ptoks) != 1:
-        return False
-    tok = ptoks[0]
-    return (len(tok) >= 6 and tok[-1].isdigit() and tok[-2].isdigit()
-            and not tok[0].isdigit())
+    return len(ptoks) == 1 and bool(_HANDLE.match(ptoks[0]))
 
 
 def find_duplicate(index, target_dir: str, filename: str, size: int = 0):

--- a/scripts/dl-router/matcher.py
+++ b/scripts/dl-router/matcher.py
@@ -157,11 +157,22 @@ def host_of(url) -> str:
 
 
 def url_path_segments(url) -> tuple:
-    """Non-empty path segments of `url`."""
+    """Non-empty path segments of an ABSOLUTE URL. `()` for anything else.
+
+    The hostname requirement is not cosmetic: `urlsplit` happily parses
+    `"not a url"` as a relative path and hands back `["not a url"]`, which the
+    slug extractor then reads as a two-word thread subject. JS's `new URL`
+    throws on the same input, so without this the two implementations disagree
+    -- and the extension's copy runs exactly when the sidecar is unreachable,
+    where the disagreement is invisible. Pinned by fixtures/url_cases.json.
+    """
     if not isinstance(url, str) or not url:
         return ()
     try:
-        path = urlsplit(url).path
+        split = urlsplit(url)
+        if not split.hostname:
+            return ()
+        path = split.path
     except ValueError:
         return ()
     return tuple(seg for seg in path.split("/") if seg)

--- a/scripts/dl-router/matcher.py
+++ b/scripts/dl-router/matcher.py
@@ -144,18 +144,22 @@ _THREAD_ANCHORS = frozenset({
     "showthread", "viewtopic",
 })
 
-# AMBIGUOUS routes. Discourse (`/t/<slug>/<id>`) and IPB (`/topic/<id>-<slug>/`)
-# use these for a thread, but plenty of sites use the same words for an INDEX:
+# `t`, `topic` and `topics` are DELIBERATELY ABSENT.
 #
-#     /topics/general-discussion   ->  a section listing, not a thread
-#     /t/photography               ->  a tag page, not a thread
+# Discourse (`/t/<slug>/<id>`) and IPB (`/topic/<id>-<slug>/`) use them for a
+# thread, and plenty of other sites use the same words for an index. Two rounds
+# went into gating them: first on the presence of a numeric id beside the slug,
+# which is false for a PAGINATED index (`/topics/general-discussion/2`,
+# `/t/photography/3`) -- and a paginated index is structurally identical to a
+# Discourse thread, so no adjacency rule can separate them. `/t/best-of-2024`
+# is worse still: the year admits the route AND is stripped as an id.
 #
-# Treating them as unambiguous asserted something untrue and re-opened the
-# section-name hole one level down. A real thread on these platforms always
-# carries a numeric id beside the slug; an index route never does, so the id is
-# the discriminator -- and requiring it is fail-closed, because a thread shape
-# nobody anticipated degrades to "no slug" (the picker), never to a wrong slug.
-_ID_ANCHORS = frozenset({"topic", "topics", "t"})
+# The ambiguity was the problem, not the gate around it. This design already
+# says no slug is fine and a wrong slug is not, so the ambiguous routes are
+# simply not anchors: an id-less Discourse or IPB thread degrades to the
+# picker. If one of those platforms ever matters here, the honest way to add it
+# is a per-site rule in local config where the operator ASSERTS the shape --
+# not a global guess about everyone's URLs.
 
 # `slug.123456` (xenforo) and `123456-slug` (vbulletin) both carry a numeric id
 # beside the slug. Stripping it is what makes the two shapes fold to one key.
@@ -291,19 +295,6 @@ def _slug_tokens(segment: str) -> tuple:
     return tokens(seg)
 
 
-def _carries_thread_id(segments, i: int) -> bool:
-    """True when the slug at `segments[i]` has a numeric thread id beside it.
-
-    Either inside the segment (`/topic/12345-slug/`, `/topic/slug.12345/`) or as
-    the next one (`/t/slug/12345`). This is what separates a Discourse/IPB
-    thread from a same-named index route.
-    """
-    segment = segments[i]
-    if _LEADING_ID.match(segment) or _TRAILING_ID.search(segment):
-        return True
-    return i + 1 < len(segments) and segments[i + 1].isdigit()
-
-
 def thread_slug(url) -> str:
     """The forum thread subject carried by a URL path, as a phrase.
 
@@ -325,19 +316,19 @@ def thread_slug(url) -> str:
     best = ()
     segments = url_path_segments(url)
     for i in range(1, len(segments)):
-        anchor = segments[i - 1].lower()
-        if anchor in _ID_ANCHORS:
-            if not _carries_thread_id(segments, i):
-                continue
-        elif anchor not in _THREAD_ANCHORS:
+        if segments[i - 1].lower() not in _THREAD_ANCHORS:
             continue
         toks = _slug_tokens(segments[i])
         # The thread route already proves this is a thread, so a ONE-word slug
         # is legitimate here in a way it never was under the old rule -- the
         # >=2-token guard existed only to stop an opaque file-host id
         # (`/d/AbCdEf`) being minted as a subject, and no anchor introduces one.
+        # `isascii()` as well as `isdigit()`: Python's `isdigit` accepts
+        # non-ASCII digits and JS's `/^\d+$/` does not, and these two
+        # implementations have to agree.
         meaningful = tuple(t for t in toks
-                           if t not in STOPWORDS and not t.isdigit())
+                           if t not in STOPWORDS
+                           and not (t.isascii() and t.isdigit()))
         if not meaningful or not passes_fuzzy_guard(meaningful):
             continue
         best = toks
@@ -425,9 +416,19 @@ def title_subject(title, site: str = "", slug: str = "") -> str:
         toks = content_tokens(part)
         if not toks or is_site_branding(part, site):
             continue
-        overlap = sum(1 for t in set(toks) if t in slug_tokens)
-        # Strictly greater, so the FIRST segment wins a tie -- deterministic,
-        # and only ever consulted between segments that corroborate equally.
+        unique = set(toks)
+        overlap = sum(1 for t in unique if t in slug_tokens)
+        # ONE shared token is a coincidence, not corroboration, and the whole
+        # segment gets emitted verbatim -- so `"Section: Photography"` was
+        # minted off the single word `photography`, and `"Page 12"` off a `12`
+        # that happened to appear in the slug. Require either a segment that is
+        # ENTIRELY one corroborated word, or two shared words; and in both
+        # cases require the shared words to be at least half of the segment, so
+        # a long sentence cannot ride in on two incidental hits.
+        if overlap < 1 or (overlap < 2 and len(unique) > 1):
+            continue
+        if overlap * 2 < len(unique):
+            continue
         if overlap > best_overlap:
             best, best_overlap = part, overlap
     return best if best_overlap else ""
@@ -665,6 +666,11 @@ class MatchContext:
         slugs = self.thread_slugs()
         for slug in slugs:
             add(slug)
+        # `slugs[0]` may come from the PROVEN cross-host referrer rather than
+        # this page -- deliberate, and safe for the same reason the carry is:
+        # nothing reaches `referrer_url` unless the extension proved the link.
+        # It is what lets a file-host page corroborate its title against the
+        # forum thread that sent the user there.
         # The de-branded title is CORROBORATED against the slug (see
         # title_subject): with no slug it contributes nothing here, and the raw
         # title below still carries the page through ordinary containment.
@@ -1066,14 +1072,25 @@ def suspicious_alias_key(phrase, *, key: str = "", dir_names=(), site: str = "",
 # One trailing digit is the COMMON username shape, so requiring two (an earlier
 # narrowing) let most real handles straight through.
 _HANDLE = re.compile(r"^[^\W\d_]+[0-9]{1,4}$")
-# Letters separated by punctuation: `M.I.A.`, `K. D.` -- an initialised stage
-# name, not a three-letter word. This is what lets the length floor stay at 4
-# without refusing a real subject.
-_INITIALISED = re.compile(r"^(?:[^\W\d_][.\u00b7\s]+){2,}[^\W\d_]?[.]?$")
+# Single letters separated by DOTS: `M.I.A.` -- an initialised stage name, not
+# a three-letter word. This is what lets the length floor stay at 4 without
+# refusing a real subject.
+#
+# Dots only, and never below three letters. Allowing spaces as a separator and
+# putting no floor under it re-opened everything the floor was for: `w.w.w.`
+# folds to `www` (defeating the stopword rule two hunks above), and `e.g.`,
+# `i.e.`, `p.s.` and `O. K.` all fold to TWO-character keys -- under the floor
+# this very change restored.
+_INITIALISED = re.compile(r"^(?:[^\W\d_]\.){2,}$")
+MIN_INITIALISED_KEY_LEN = 3
 
 
 def _looks_initialised(phrase) -> bool:
-    return bool(_INITIALISED.match(str(phrase or "").strip()))
+    phrase = str(phrase or "").strip()
+    if not _INITIALISED.match(phrase):
+        return False
+    key = norm_key(phrase)
+    return len(key) >= MIN_INITIALISED_KEY_LEN and key not in STOPWORDS
 
 
 def _looks_like_a_handle(ptoks) -> bool:

--- a/scripts/dl-router/server.py
+++ b/scripts/dl-router/server.py
@@ -48,7 +48,8 @@ from dirindex import DirIndex, FileIndex  # noqa: E402
 from dirkinds import DirKinds  # noqa: E402
 from fetcher import Fetcher  # noqa: E402
 from matcher import (  # noqa: E402
-    KIND_CATEGORY, KIND_UNKNOWN, KINDS, MatchContext, Matcher, content_tokens,
+    KIND_CATEGORY, KIND_PERFORMER, KIND_UNKNOWN, KINDS, MatchContext, Matcher,
+    content_tokens,
     find_duplicate, host_of, identity_signals, norm_key, passes_fuzzy_guard,
     suspicious_alias_key, title_subject,
 )
@@ -185,7 +186,10 @@ class App:
             names = self.dirs.names()
             out["dirs"] = len(names)
             out["aliases"] = self.store.alias_count()
-            out["etag"] = self.dirs.etag()
+            # The snapshot hash, NOT DirIndex's names-only etag: two different
+            # values under one name, in the subsystem whose last bug was an
+            # etag that did not cover what it labelled.
+            out["etag"] = self.dirs_snapshot()["etag"]
             # Unclassified directories never auto-file, so this count is the
             # single most useful number for "why is it asking every time?".
             kinds = self.dir_kinds()
@@ -297,35 +301,70 @@ class App:
                                     evidence=str(evidence)[:200])
             written.append({"key": key, "site": site, "source": source})
 
-        def screen(phrase, key, source, spread):
+        spread_map = self.store.phrase_dir_spread()
+
+        def screen(phrase, key, source, site):
             why = suspicious_alias_key(phrase, key=key, dir_names=dir_names,
-                                       site=ctx.site, spread=spread)
+                                       site=site,
+                                       spread=spread_map.get(norm_key(phrase), 0))
             if why:
                 skipped.append({"key": key, "source": source, "why": why})
             return why is None
 
-        # 1. Identity signals — every kind, always. Site-scoped by construction.
-        for sig in identity_signals(ctx):
-            write(sig.key, sig.site, sig.kind, sig.evidence)
+        # THE CATCH-ALL LEARNS NOTHING.
+        #
+        # Sending a download to the catch-all is the user saying "not any of
+        # these", which is the absence of a subject, not evidence of one. It
+        # cannot auto-file (the directory is unclassified), but a 1.00 identity
+        # alias pointing at it would make the catch-all the permanent top
+        # candidate in the picker for that channel or thread -- turning one
+        # shrug into a standing recommendation.
+        if chosen == self.cfg.other_dir:
+            self.store.add_example(payload.get("context") or {}, chosen,
+                                   payload.get("autoDir"),
+                                   bool(payload.get("createdNew")))
+            return {"ok": True, "aliases": 0, "written": [],
+                    "skipped": [{"key": "", "source": "catch-all",
+                                 "why": "the catch-all directory is the "
+                                        "absence of a subject, not one"}],
+                    "dir": chosen, "kind": kind}
 
-        spread_map = self.store.phrase_dir_spread()
+        # 1. Identity signals — every kind, always. Site-scoped by construction,
+        #    and SCREENED: a badly derived identity is still an identity as far
+        #    as the store is concerned, and it lands at 1.00 with auto-file
+        #    rather than at 0.85 without. This is the one row that most needed
+        #    checking and was the only one exempt from the check.
+        for sig in identity_signals(ctx):
+            if screen(sig.evidence, sig.key, sig.kind, sig.site):
+                write(sig.key, sig.site, sig.kind, sig.evidence)
 
         if kind == KIND_CATEGORY:
             # 2. Tags — the legitimate signal for a category, and ONLY there.
             if confirmed and ctx.site:
-                for tag in ctx.tags[:MAX_LEARNED_TAGS]:
+                learned = 0
+                for tag in ctx.tags:
+                    if learned >= MAX_LEARNED_TAGS:
+                        break
                     key = norm_key(tag)
                     if not key:
                         continue
-                    if screen(tag, key, "tag", spread_map.get(key, 0)):
+                    # SCREEN FIRST, THEN CAP. Capping the input list meant a
+                    # page whose first three tags were junk consumed the whole
+                    # budget and a legitimate fourth was never even considered.
+                    if screen(tag, key, "tag", ctx.site):
                         write(key, ctx.site, "tag", tag)
+                        learned += 1
             elif ctx.tags:
                 skipped.append({
                     "key": "", "source": "tag",
                     "why": "a tag is learned only from an explicit "
                            "confirmation on a site-scoped context"})
-        else:
-            # 3. The subject inside the page title — performer / unclassified.
+        elif kind == KIND_PERFORMER:
+            # 3. The subject inside the page title. PERFORMER ONLY -- an
+            #    unclassified directory learns identity signals and nothing
+            #    else, which is what the docs have always said. Learning weak
+            #    title aliases for it meant a pile of dormant rows that would
+            #    all activate at once the moment it was classified.
             for title, site in ((ctx.title, ctx.site),
                                 (ctx.referrer_title, host_of(ctx.referrer_url))):
                 subject = title_subject(title, site)
@@ -335,9 +374,16 @@ class App:
                 if not passes_fuzzy_guard(toks) or len(toks) > MAX_TITLE_SUBJECT_TOKENS:
                     continue
                 key = norm_key(subject)
-                if key and screen(subject, key, "title-subject",
-                                  spread_map.get(key, 0)):
+                if key and screen(subject, key, "title-subject", site):
                     write(key, site, "title-subject", subject)
+
+        if skipped:
+            # AN OVER-STRICT SCREEN MUST NOT BE SILENT. The response carries the
+            # detail; this line is what makes it visible without one. Reason
+            # CODES only -- the keys themselves are the operator's private
+            # library, and this journal is world-readable (see log()).
+            log("learn_screened", n=len(skipped),
+                sources="|".join(sorted({s["source"] for s in skipped})))
 
         if ctx.site:
             self.store.set_host_prior(ctx.site, chosen)

--- a/scripts/dl-router/server.py
+++ b/scripts/dl-router/server.py
@@ -51,7 +51,7 @@ from matcher import (  # noqa: E402
     KIND_CATEGORY, KIND_PERFORMER, KIND_UNKNOWN, KINDS, MatchContext, Matcher,
     content_tokens,
     find_duplicate, host_of, identity_signals, norm_key, passes_fuzzy_guard,
-    suspicious_alias_key, title_subject,
+    suspicious_alias_key, thread_slug, title_subject,
 )
 from safety import (  # noqa: E402
     UnsafeName, is_safe_dir_name, names_match, safe_rel_path,
@@ -301,9 +301,24 @@ class App:
                                     evidence=str(evidence)[:200])
             written.append({"key": key, "site": site, "source": source})
 
-        spread_map = self.store.phrase_dir_spread()
+        spread_map = self.store.phrase_dir_spread(
+            other_dir=self.cfg.other_dir)
 
         def screen(phrase, key, source, site):
+            # AN EXPLICIT CORRECTION ALWAYS WINS.
+            #
+            # If a row already exists for this (key, site), the operator is
+            # RE-POINTING something the router previously learned, and the
+            # screen must not stand in the way. It did: the chrome-spread
+            # measure counts the operator's OWN routing history, so correcting
+            # the same thread to a second directory looked exactly like a
+            # phrase "seen on 2 different directories" -- the fix was refused,
+            # the original wrong alias survived, and the next download from
+            # that thread still auto-filed into the wrong directory at 1.00. A
+            # router that overrules the operator on the second correction is
+            # worse than one that never learned anything.
+            if self.store.alias(key, site) is not None:
+                return True
             why = suspicious_alias_key(phrase, key=key, dir_names=dir_names,
                                        site=site,
                                        spread=spread_map.get(norm_key(phrase), 0))
@@ -365,9 +380,13 @@ class App:
             #    else, which is what the docs have always said. Learning weak
             #    title aliases for it meant a pile of dormant rows that would
             #    all activate at once the moment it was classified.
-            for title, site in ((ctx.title, ctx.site),
-                                (ctx.referrer_title, host_of(ctx.referrer_url))):
-                subject = title_subject(title, site)
+            slugs = ctx.thread_slugs()
+            own_slug = thread_slug(ctx.page_url) or (slugs[0] if slugs else "")
+            for title, site, slug in (
+                    (ctx.title, ctx.site, own_slug),
+                    (ctx.referrer_title, host_of(ctx.referrer_url),
+                     thread_slug(ctx.referrer_url))):
+                subject = title_subject(title, site, slug)
                 if not subject or not site:
                     continue
                 toks = content_tokens(subject)

--- a/scripts/dl-router/server.py
+++ b/scripts/dl-router/server.py
@@ -44,8 +44,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import config as config_mod  # noqa: E402
 from dirindex import DirIndex, FileIndex  # noqa: E402
+from dirkinds import DirKinds  # noqa: E402
 from fetcher import Fetcher  # noqa: E402
-from matcher import MatchContext, Matcher, find_duplicate, norm_key  # noqa: E402
+from matcher import (  # noqa: E402
+    KIND_CATEGORY, KIND_UNKNOWN, KINDS, MatchContext, Matcher, content_tokens,
+    find_duplicate, host_of, identity_signals, norm_key, passes_fuzzy_guard,
+    suspicious_alias_key, title_subject,
+)
 from safety import (  # noqa: E402
     UnsafeName, is_safe_dir_name, names_match, safe_rel_path,
 )
@@ -59,6 +64,14 @@ MAX_BODY = 256 * 1024
 # clock skew — both come from the same machine). A torrent payload predates its
 # would-be routing decision by hours or days, so a few seconds costs nothing.
 MTIME_SLACK_S = 5.0
+
+# How many tags a single confirmation may turn into aliases, for a CATEGORY
+# directory. A tag list can hold 64 entries; the user confirmed one directory,
+# not sixty-four synonyms for it, and the first few are the most specific (site
+# rules and JSON-LD are pushed to the front of the list by the capture script).
+MAX_LEARNED_TAGS = 3
+# A title-derived subject longer than this is a sentence, not a name.
+MAX_TITLE_SUBJECT_TOKENS = 5
 
 _LOOPBACK = frozenset({"127.0.0.1", "::1", "localhost"})
 _ALLOWED_HOST_HEADERS = frozenset({"127.0.0.1", "localhost", "::1", "[::1]"})
@@ -116,16 +129,47 @@ class App:
         else:
             self.fetcher = None
 
+        self._kinds_file: DirKinds | None = None
+        self._kinds_stamp = None
+
     # --- helpers ----------------------------------------------------------- #
     @property
     def configured(self) -> bool:
         return self.root is not None and self.dirs is not None
 
+    def dir_kinds(self) -> DirKinds:
+        """The resolved directory classification.
+
+        The human TOML is re-parsed only when its mtime/size changes -- this is
+        on the /match path and /match has a 400 ms budget before the extension
+        gives up and uses its cached decision. The picker-assigned kinds come
+        from SQLite and are read every time, because /mkdir writes one and the
+        very next call must see it.
+        """
+        path = Path(self.cfg.dirs_file)
+        try:
+            st = path.stat()
+            stamp = (st.st_mtime_ns, st.st_size)
+        except OSError:
+            stamp = None
+        if self._kinds_file is None or stamp != self._kinds_stamp:
+            self._kinds_file = DirKinds.load(path)
+            self._kinds_stamp = stamp
+        overlay = self.store.dir_kind_map()
+        if not overlay:
+            return self._kinds_file
+        merged = dict(overlay)
+        # The human file wins: it is the one the operator reviewed.
+        merged.update(self._kinds_file.as_map())
+        return DirKinds(merged, path=path, present=self._kinds_file.present,
+                        error=self._kinds_file.error)
+
     def matcher(self) -> Matcher:
         return Matcher(self.dirs.entries(), self.store.alias_map(),
                        threshold=self.cfg.auto_threshold,
                        tie_margin=self.cfg.tie_margin,
-                       other_dir=self.cfg.other_dir)
+                       other_dir=self.cfg.other_dir,
+                       dir_kinds=self.dir_kinds().as_map())
 
     # --- endpoint logic (HTTP-free, so tests can call it directly) --------- #
     def healthz(self) -> dict:
@@ -137,13 +181,29 @@ class App:
             out["configError"] = self.config_error
         if self.configured:
             out["root_present"] = self.root.is_dir()
-            out["dirs"] = len(self.dirs.entries())
+            names = self.dirs.names()
+            out["dirs"] = len(names)
             out["aliases"] = self.store.alias_count()
             out["etag"] = self.dirs.etag()
+            # Unclassified directories never auto-file, so this count is the
+            # single most useful number for "why is it asking every time?".
+            kinds = self.dir_kinds()
+            out["dirKinds"] = kinds.counts(names)
+            out["dirsFile"] = {"path": str(kinds.path or ""),
+                               "present": kinds.present}
+            if kinds.error:
+                out["dirsFile"]["error"] = kinds.error
         return out
 
     def dirs_snapshot(self) -> dict:
         snap = self.dirs.snapshot()
+        # The kind travels WITH each directory: the extension's cached
+        # fallback matcher has to apply the same auto-file gate as the sidecar,
+        # or a sidecar timeout would auto-file into a category directory that
+        # the sidecar itself would have asked about.
+        kinds = self.dir_kinds()
+        for entry in snap.get("dirs", ()):
+            entry["kind"] = kinds.kind(entry.get("name", ""))
         # The extension needs the root to prove a completed download actually
         # landed inside the library before it asks /relocate to move it (see
         # relPathFromAbsolute). Loopback + bearer token only, and it never
@@ -178,50 +238,121 @@ class App:
         return result.as_dict(ttl_ms=int(self.cfg.get("dir_cache_ttl_s", 5.0) * 1000))
 
     def learn(self, payload: dict) -> dict:
+        """Persist a correction — ONLY the discriminating signal.
+
+        WHAT THIS REPLACED, and why. The first version wrote an alias for the
+        first three SUBJECT PHRASES of the context, plus one at GLOBAL scope.
+        On the first forum download that produced four aliases, of which three
+        were wrong: a forum section name, and two other posters' usernames --
+        one of them global, so it would have auto-filed anything carrying that
+        username into a stranger's directory at alias confidence. They were
+        deleted by hand; nothing in the system had surfaced them.
+
+        The rule is now keyed on WHAT the directory is:
+
+          * identity signals (Discord channel id, forum thread slug) are
+            learned for ANY kind. They are structural, come from the URL, and
+            cannot be contaminated by another user's content.
+          * a subject name in the page TITLE is learned for a performer (or a
+            not-yet-classified) directory. Never for a category.
+          * a TAG is learned only for a CATEGORY directory, where a tag is the
+            legitimate signal -- and then only from an explicit confirmation,
+            capped, site-scoped, and screened by `suspicious_alias_key`.
+
+        NO ALIAS IS EVER LEARNED AT GLOBAL SCOPE. A global alias applies to
+        every site at once, which is the largest blast radius the store has and
+        the least evidence supports it. `dl-route alias set --site '*'` still
+        exists for a deliberate one.
+        """
         chosen = payload.get("chosenDir")
         if not is_safe_dir_name(chosen):
             raise UnsafeName("chosenDir is not a valid directory name")
         if not self.dirs.has(chosen):
             raise UnsafeName(f"unknown directory: {chosen!r}")
         ctx = MatchContext.from_payload(payload.get("context") or {})
-        phrases = ctx.subject_phrases()
-        keys = [norm_key(p) for p in phrases[:3]]
-        keys = [k for k in keys if k]
-        written = 0
-        for key in keys:
-            if ctx.site:
-                self.store.upsert_alias(key, chosen, ctx.site)
-                written += 1
-            elif self.store.alias(key, "") is None:
-                # No site context (a direct-link download): a global alias is
-                # the only thing we can learn.
-                self.store.upsert_alias(key, chosen, "")
-                written += 1
-        # A global alias is seeded only when absent, so a site-specific
-        # correction never silently re-points every other site.
-        for key in keys[:1]:
-            if self.store.alias(key, "") is None:
-                self.store.upsert_alias(key, chosen, "")
-                written += 1
+        kind = self.dir_kinds().kind(chosen)
+        confirmed = bool(payload.get("confirmed"))
+        dir_names = sorted(self.dirs.name_set())
+        written: list = []
+        skipped: list = []
+
+        def write(key, site, source, evidence):
+            self.store.upsert_alias(key, chosen, site, source=source,
+                                    evidence=str(evidence)[:200])
+            written.append({"key": key, "site": site, "source": source})
+
+        def screen(phrase, key, source, spread):
+            why = suspicious_alias_key(phrase, key=key, dir_names=dir_names,
+                                       site=ctx.site, spread=spread)
+            if why:
+                skipped.append({"key": key, "source": source, "why": why})
+            return why is None
+
+        # 1. Identity signals — every kind, always. Site-scoped by construction.
+        for sig in identity_signals(ctx):
+            write(sig.key, sig.site, sig.kind, sig.evidence)
+
+        spread_map = self.store.phrase_dir_spread()
+
+        if kind == KIND_CATEGORY:
+            # 2. Tags — the legitimate signal for a category, and ONLY there.
+            if confirmed and ctx.site:
+                for tag in ctx.tags[:MAX_LEARNED_TAGS]:
+                    key = norm_key(tag)
+                    if not key:
+                        continue
+                    if screen(tag, key, "tag", spread_map.get(key, 0)):
+                        write(key, ctx.site, "tag", tag)
+            elif ctx.tags:
+                skipped.append({
+                    "key": "", "source": "tag",
+                    "why": "a tag is learned only from an explicit "
+                           "confirmation on a site-scoped context"})
+        else:
+            # 3. The subject inside the page title — performer / unclassified.
+            for title, site in ((ctx.title, ctx.site),
+                                (ctx.referrer_title, host_of(ctx.referrer_url))):
+                subject = title_subject(title, site)
+                if not subject or not site:
+                    continue
+                toks = content_tokens(subject)
+                if not passes_fuzzy_guard(toks) or len(toks) > MAX_TITLE_SUBJECT_TOKENS:
+                    continue
+                key = norm_key(subject)
+                if key and screen(subject, key, "title-subject",
+                                  spread_map.get(key, 0)):
+                    write(key, site, "title-subject", subject)
+
         if ctx.site:
             self.store.set_host_prior(ctx.site, chosen)
         self.store.add_example(payload.get("context") or {}, chosen,
                                payload.get("autoDir"),
                                bool(payload.get("createdNew")))
-        return {"ok": True, "aliases": written, "dir": chosen}
+        return {"ok": True, "aliases": len(written), "written": written,
+                "skipped": skipped, "dir": chosen, "kind": kind}
 
     def mkdir(self, payload: dict) -> dict:
         name = payload.get("name")
         if not is_safe_dir_name(name):
             raise UnsafeName(f"invalid directory name: {name!r}")
+        # The picker asks which kind a NEW directory is, because an
+        # unclassified one never auto-files -- creating one without an answer
+        # would quietly produce a directory that always interrupts.
+        kind = payload.get("kind")
+        if kind is not None and kind not in KINDS:
+            raise UnsafeName(f"invalid directory kind: {kind!r} "
+                             f"(expected one of {sorted(KINDS)})")
         target = self.root / name
         # Belt and braces: the name is already one safe component, but resolve
         # it too so a symlinked collision cannot land outside the root.
         resolved = safe_rel_path(name, root=self.root)
         existed = target.is_dir()
         os.makedirs(resolved, exist_ok=True)
+        if kind in KINDS:
+            self.store.set_dir_kind(name, kind, source="picker")
         self.dirs.refresh(force=True)
         return {"ok": True, "dir": name, "created": not existed,
+                "kind": self.dir_kinds().kind(name),
                 "etag": self.dirs.etag()}
 
     def _prove_owned(self, rel_path: str, src, download_id: str) -> None:

--- a/scripts/dl-router/server.py
+++ b/scripts/dl-router/server.py
@@ -323,7 +323,14 @@ class App:
                                        site=site,
                                        spread=spread_map.get(norm_key(phrase), 0))
             if why:
-                skipped.append({"key": key, "source": source, "why": why})
+                # `first` is what stops the extension notifying on every
+                # correction for a PERMANENTLY refused candidate -- see
+                # Store.record_screened. The refusal is durable state, not an
+                # event, and `dl-route alias review` shows it permanently.
+                first = self.store.record_screened(key, site, chosen, source,
+                                                   why)
+                skipped.append({"key": key, "source": source, "why": why,
+                                "first": first})
             return why is None
 
         # THE CATCH-ALL LEARNS NOTHING.
@@ -339,7 +346,13 @@ class App:
                                    payload.get("autoDir"),
                                    bool(payload.get("createdNew")))
             return {"ok": True, "aliases": 0, "written": [],
+                    # SOURCE STRING IS A CROSS-LANGUAGE CONTRACT: the
+                    # extension's reportNothingLearned filters on this literal
+                    # so a routine catch-all filing never notifies. Pinned on
+                    # both sides (test_the_catch_all_learns_nothing,
+                    # service_worker.test.mjs).
                     "skipped": [{"key": "", "source": "catch-all",
+                                 "first": False,
                                  "why": "the catch-all directory is the "
                                         "absence of a subject, not one"}],
                     "dir": chosen, "kind": kind}
@@ -371,7 +384,7 @@ class App:
                         learned += 1
             elif ctx.tags:
                 skipped.append({
-                    "key": "", "source": "tag",
+                    "key": "", "source": "tag", "first": False,
                     "why": "a tag is learned only from an explicit "
                            "confirmation on a site-scoped context"})
         elif kind == KIND_PERFORMER:

--- a/scripts/dl-router/server.py
+++ b/scripts/dl-router/server.py
@@ -31,6 +31,7 @@ Env: DL_ROUTER_HOST, DL_ROUTER_PORT, DL_ROUTER_CONFIG, DL_ROUTER_STATE_DIR,
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import secrets
@@ -218,6 +219,21 @@ class App:
         snap["matchTimeoutMs"] = int(self.cfg.get("match_timeout_ms", 400))
         snap["captureWindowS"] = int(self.cfg.get("capture_window_s", 15))
         snap["toastMs"] = int(self.cfg.get("toast_ms", 8000))
+        # THE ETAG COVERS THE WHOLE SNAPSHOT, not just the directory names.
+        #
+        # DirIndex's etag hashes the names it scanned, which is all it can
+        # know about. But the extension caches this ENTIRE payload and revalidates
+        # with `If-None-Match`, so anything else in here that changes without a
+        # directory being added or removed -- an alias learned, a kind edited
+        # into dirs.toml -- produced a 304 and a permanently stale cache. The
+        # kinds made that load-bearing: the cached fallback would keep
+        # auto-filing into a directory the operator had just reclassified as a
+        # category, and only when the sidecar was unreachable, which is exactly
+        # when nobody is watching.
+        snap["etag"] = hashlib.sha256(
+            json.dumps(snap, sort_keys=True, ensure_ascii=False,
+                       separators=(",", ":")).encode("utf-8")
+        ).hexdigest()[:16]
         return snap
 
     def match(self, payload: dict) -> dict:

--- a/scripts/dl-router/store.py
+++ b/scripts/dl-router/store.py
@@ -17,7 +17,7 @@ import threading
 import time
 from pathlib import Path
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 MIGRATIONS = {
     1: [
@@ -105,6 +105,36 @@ MIGRATIONS = {
               source TEXT NOT NULL DEFAULT '',
               ts     REAL NOT NULL
            )""",
+    ],
+    # v4 -- REFUSALS ARE A DURABLE FACT, not an event.
+    #
+    # Three rounds of defects landed on one mechanism: the notification that
+    # tells the operator the screen refused something. It was silent, then it
+    # fired on every catch-all filing, then it fired forever for a permanently
+    # refused identity. Each fix filtered the EVENT harder, and each carried
+    # the next defect, because the event is the wrong unit: what is worth
+    # saying is "this source will never be learned", which is a fact about a
+    # (key, site, dir) -- true once, not once per download.
+    #
+    # A suppression map in the extension cannot hold it either: MV3 tears the
+    # service worker down after ~30s idle, so the map empties and the
+    # notifications resume. The store is the only durable place, and recording
+    # the refusal here also gives `dl-route alias review` something permanent
+    # to show -- which is where a durable fact belongs, with the notification
+    # demoted to a one-time pointer at it.
+    4: [
+        """CREATE TABLE IF NOT EXISTS screened (
+              key      TEXT NOT NULL,
+              site     TEXT NOT NULL DEFAULT '',
+              dir      TEXT NOT NULL,
+              source   TEXT NOT NULL DEFAULT '',
+              why      TEXT NOT NULL DEFAULT '',
+              hits     INTEGER NOT NULL DEFAULT 1,
+              first_ts REAL NOT NULL,
+              last_ts  REAL NOT NULL,
+              PRIMARY KEY (key, site, dir)
+           )""",
+        "CREATE INDEX IF NOT EXISTS screened_dir ON screened(dir)",
     ],
 }
 
@@ -319,6 +349,48 @@ class Store:
                 if key:
                     spread.setdefault(key, set()).add(chosen)
         return {key: len(dirs) for key, dirs in spread.items()}
+
+    # --- screened (refused) candidates -------------------------------------- #
+    def record_screened(self, key: str, site: str, dir_name: str,
+                        source: str = "", why: str = "") -> bool:
+        """Remember that this candidate was refused. True iff it is NEW.
+
+        The return value is what makes the notification a one-time pointer
+        rather than a per-download alarm: a phrase refused for a permanent
+        reason (site branding, shared vocabulary, a spread that only ever
+        grows) is refused on EVERY correction, and reporting it every time
+        trains the operator to dismiss it.
+        """
+        now = self._clock()
+        cur = self.conn.execute(
+            """INSERT INTO screened (key, site, dir, source, why, hits,
+                                     first_ts, last_ts)
+               VALUES (?, ?, ?, ?, ?, 1, ?, ?)
+               ON CONFLICT(key, site, dir) DO UPDATE SET
+                 hits = screened.hits + 1,
+                 why = excluded.why,
+                 last_ts = excluded.last_ts""",
+            (key, site or "", dir_name, str(source or ""), str(why or ""),
+             now, now))
+        # `rowcount` is 1 for both branches, so ask the row itself.
+        row = self.conn.execute(
+            "SELECT hits FROM screened WHERE key=? AND site=? AND dir=?",
+            (key, site or "", dir_name)).fetchone()
+        self.conn.commit()
+        del cur
+        return bool(row) and int(row["hits"]) == 1
+
+    def screened_rows(self, limit: int = 200) -> list:
+        rows = self.conn.execute(
+            "SELECT * FROM screened ORDER BY last_ts DESC LIMIT ?",
+            (int(limit),)).fetchall()
+        return [dict(r) for r in rows]
+
+    def clear_screened(self, key: str, site: str = "") -> int:
+        cur = self.conn.execute("DELETE FROM screened WHERE key=? AND site=?",
+                                (key, site or ""))
+        self.conn.commit()
+        return int(cur.rowcount)
 
     # --- directory kinds ---------------------------------------------------- #
     def set_dir_kind(self, name: str, kind: str, source: str = "") -> None:

--- a/scripts/dl-router/store.py
+++ b/scripts/dl-router/store.py
@@ -17,7 +17,7 @@ import threading
 import time
 from pathlib import Path
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 MIGRATIONS = {
     1: [
@@ -82,6 +82,28 @@ MIGRATIONS = {
               download_id TEXT NOT NULL DEFAULT '',
               dir         TEXT NOT NULL,
               ts          REAL NOT NULL
+           )""",
+    ],
+    # v3 -- alias PROVENANCE, and picker-assigned directory kinds.
+    #
+    # Four bad aliases had to be deleted by hand after the first evening of
+    # real use: a forum section name, two other posters' usernames, one of them
+    # at GLOBAL scope. Nothing surfaced them, because an alias row recorded only
+    # `(key, site) -> dir`; there was no way to ask "what made you believe
+    # this?". `source` and `evidence` are what `dl-route alias review` reads.
+    #
+    # `dir_kinds` is the machine-written half of the classification: the picker
+    # asks which kind a NEW directory is, and the answer lands here rather than
+    # being appended to the human-edited dirs.toml.
+    3: [
+        ("ADD_COLUMN_IF_MISSING", "aliases", "source", "TEXT NOT NULL DEFAULT ''"),
+        ("ADD_COLUMN_IF_MISSING", "aliases", "evidence",
+         "TEXT NOT NULL DEFAULT ''"),
+        """CREATE TABLE IF NOT EXISTS dir_kinds (
+              name   TEXT PRIMARY KEY,
+              kind   TEXT NOT NULL,
+              source TEXT NOT NULL DEFAULT '',
+              ts     REAL NOT NULL
            )""",
     ],
 }
@@ -168,22 +190,39 @@ class Store:
         return int(self.conn.execute("PRAGMA user_version").fetchone()[0])
 
     # --- aliases ----------------------------------------------------------- #
-    def upsert_alias(self, key: str, dir_name: str, site: str = "") -> None:
+    def upsert_alias(self, key: str, dir_name: str, site: str = "", *,
+                     source: str = "", evidence: str = "") -> None:
         """Insert or re-point an alias, bumping its hit count.
 
         A correction re-points an existing alias rather than accumulating a
         second row: the user's latest choice is authoritative.
+
+        `source`/`evidence` are the provenance `dl-route alias review` prints.
+        They are refreshed on every write, because a re-pointed alias was
+        re-derived from whatever the LATEST correction saw.
         """
         now = self._clock()
         self.conn.execute(
-            """INSERT INTO aliases (key, site, dir, hits, created_at, updated_at)
-               VALUES (?, ?, ?, 1, ?, ?)
+            """INSERT INTO aliases (key, site, dir, hits, created_at,
+                                    updated_at, source, evidence)
+               VALUES (?, ?, ?, 1, ?, ?, ?, ?)
                ON CONFLICT(key, site) DO UPDATE SET
                  dir = excluded.dir,
                  hits = aliases.hits + 1,
-                 updated_at = excluded.updated_at""",
-            (key, site or "", dir_name, now, now))
+                 updated_at = excluded.updated_at,
+                 source = excluded.source,
+                 evidence = excluded.evidence""",
+            (key, site or "", dir_name, now, now, str(source or ""),
+             str(evidence or "")))
         self.conn.commit()
+
+    def alias_rows(self) -> list:
+        """Every alias with its provenance, most recently written first."""
+        rows = self.conn.execute(
+            """SELECT key, site, dir, hits, created_at, updated_at, source,
+                      evidence
+               FROM aliases ORDER BY updated_at DESC, key ASC""").fetchall()
+        return [dict(r) for r in rows]
 
     def alias(self, key: str, site: str = ""):
         row = self.conn.execute(
@@ -222,6 +261,51 @@ class Store:
             "SELECT * FROM examples ORDER BY id DESC LIMIT ?",
             (int(limit),)).fetchall()
         return [dict(r) for r in rows]
+
+    def phrase_dir_spread(self, limit: int = 500) -> dict:
+        """`{phrase key: how many DISTINCT directories it has been seen on}`.
+
+        The data-driven half of the site-chrome exclusion. A subject tag
+        appears on the pages of ONE directory's content; a forum section name
+        or an uploader's username appears on everything, so it accumulates
+        spread. Measured from the labelled examples the router already stores,
+        so no vocabulary has to be maintained (and none could be committed —
+        the words are the operator's private library).
+        """
+        from matcher import norm_key  # local: keeps store.py import-light
+
+        spread: dict = {}
+        for row in self.examples(limit):
+            chosen = row.get("chosen_dir") or ""
+            try:
+                ctx = json.loads(row.get("context") or "{}")
+            except ValueError:
+                continue
+            page = ctx.get("page") if isinstance(ctx, dict) else None
+            tags = page.get("tags") if isinstance(page, dict) else None
+            if not isinstance(tags, list):
+                continue
+            for tag in tags:
+                key = norm_key(tag) if isinstance(tag, str) else ""
+                if key:
+                    spread.setdefault(key, set()).add(chosen)
+        return {key: len(dirs) for key, dirs in spread.items()}
+
+    # --- directory kinds ---------------------------------------------------- #
+    def set_dir_kind(self, name: str, kind: str, source: str = "") -> None:
+        self.conn.execute(
+            """INSERT INTO dir_kinds (name, kind, source, ts)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT(name) DO UPDATE SET
+                 kind = excluded.kind,
+                 source = excluded.source,
+                 ts = excluded.ts""",
+            (str(name), str(kind), str(source or ""), self._clock()))
+        self.conn.commit()
+
+    def dir_kind_map(self) -> dict:
+        rows = self.conn.execute("SELECT name, kind FROM dir_kinds").fetchall()
+        return {r["name"]: r["kind"] for r in rows}
 
     # --- route log --------------------------------------------------------- #
     def log_route(self, *, url="", site="", filename="", dir_name="",

--- a/scripts/dl-router/store.py
+++ b/scripts/dl-router/store.py
@@ -272,7 +272,8 @@ class Store:
         so no vocabulary has to be maintained (and none could be committed —
         the words are the operator's private library).
         """
-        from matcher import norm_key  # local: keeps store.py import-light
+        # Local imports keep store.py import-light.
+        from matcher import norm_key, title_subject
 
         spread: dict = {}
         for row in self.examples(limit):
@@ -282,11 +283,23 @@ class Store:
             except ValueError:
                 continue
             page = ctx.get("page") if isinstance(ctx, dict) else None
-            tags = page.get("tags") if isinstance(page, dict) else None
-            if not isinstance(tags, list):
+            if not isinstance(page, dict):
                 continue
-            for tag in tags:
-                key = norm_key(tag) if isinstance(tag, str) else ""
+            phrases = [t for t in (page.get("tags") or [])
+                       if isinstance(t, str)] \
+                if isinstance(page.get("tags"), list) else []
+            # THE TITLE SUBJECT COUNTS TOO. The branding test can only
+            # recognise a site whose display name resembles its hostname, so on
+            # a forum where they differ the site's own name survives as a
+            # "subject". Counting it here is what eventually catches it: a real
+            # subject belongs to one directory, a site name turns up on every
+            # one of them.
+            subject = title_subject(page.get("title") or "",
+                                    str(page.get("site") or ""))
+            if subject:
+                phrases.append(subject)
+            for phrase in phrases:
+                key = norm_key(phrase)
                 if key:
                     spread.setdefault(key, set()).add(chosen)
         return {key: len(dirs) for key, dirs in spread.items()}

--- a/scripts/dl-router/store.py
+++ b/scripts/dl-router/store.py
@@ -262,7 +262,8 @@ class Store:
             (int(limit),)).fetchall()
         return [dict(r) for r in rows]
 
-    def phrase_dir_spread(self, limit: int = 500) -> dict:
+    def phrase_dir_spread(self, limit: int = 500, *,
+                          other_dir: str = "") -> dict:
         """`{phrase key: how many DISTINCT directories it has been seen on}`.
 
         The data-driven half of the site-chrome exclusion. A subject tag
@@ -271,13 +272,22 @@ class Store:
         spread. Measured from the labelled examples the router already stores,
         so no vocabulary has to be maintained (and none could be committed —
         the words are the operator's private library).
+
+        `other_dir` (the catch-all) is EXCLUDED. Sending a download there is
+        the operator saying "not any of these" — the absence of a subject, not
+        evidence of one, which is exactly why `learn` refuses to write an alias
+        for it. Counting it here contradicted that: one shrug plus one real
+        correction made every phrase on the page look like chrome, and the
+        operator's next correction was refused as "site chrome".
         """
         # Local imports keep store.py import-light.
-        from matcher import norm_key, title_subject
+        from matcher import norm_key, thread_slug, title_subject
 
         spread: dict = {}
         for row in self.examples(limit):
             chosen = row.get("chosen_dir") or ""
+            if other_dir and chosen == other_dir:
+                continue
             try:
                 ctx = json.loads(row.get("context") or "{}")
             except ValueError:
@@ -295,7 +305,8 @@ class Store:
             # subject belongs to one directory, a site name turns up on every
             # one of them.
             subject = title_subject(page.get("title") or "",
-                                    str(page.get("site") or ""))
+                                    str(page.get("site") or ""),
+                                    thread_slug(page.get("url") or ""))
             if subject:
                 phrases.append(subject)
             for phrase in phrases:

--- a/scripts/dl-router/store.py
+++ b/scripts/dl-router/store.py
@@ -304,6 +304,11 @@ class Store:
             # "subject". Counting it here is what eventually catches it: a real
             # subject belongs to one directory, a site name turns up on every
             # one of them.
+            # Corroborated, so a page with no thread slug contributes no
+            # title phrase here at all. That does weaken this measure on
+            # slug-less sites -- accepted: an UNCORROBORATED title phrase is
+            # exactly the thing that turned out to be junk, and counting junk
+            # towards a chrome measure makes the measure worse, not better.
             subject = title_subject(page.get("title") or "",
                                     str(page.get("site") or ""),
                                     thread_slug(page.get("url") or ""))

--- a/scripts/dl-router/tests/conftest.py
+++ b/scripts/dl-router/tests/conftest.py
@@ -45,6 +45,18 @@ def load_name_cases() -> dict:
     raw = json.loads((FIXTURES / "name_cases.json").read_text(encoding="utf-8"))
     return {k: _expand(v) for k, v in raw.items() if not k.startswith("_")}
 
+
+def load_url_cases() -> dict:
+    """THE shared identity-signal table (tests/fixtures/url_cases.json).
+
+    `tests/fixtures.mjs` loads the SAME file, so matcher.py and
+    extension/route_core.js are asserted against one table. The extension's
+    cached fallback runs exactly when the sidecar is unreachable, so a
+    divergence between the two would be invisible until it misfiled something.
+    """
+    raw = json.loads((FIXTURES / "url_cases.json").read_text(encoding="utf-8"))
+    return {k: v for k, v in raw.items() if not k.startswith("_")}
+
 # The three naming conventions that coexist in a real library. The matcher must
 # fold all of them to one key, which is why existing dirs are never renamed.
 SAMPLE_DIRS = [

--- a/scripts/dl-router/tests/conftest.py
+++ b/scripts/dl-router/tests/conftest.py
@@ -104,7 +104,25 @@ def file_index(library, clock):
 
 
 @pytest.fixture
-def cfg(tmp_path, library):
+def dirs_file(tmp_path):
+    """Directory kinds for the sample library — every directory `performer`.
+
+    Only a `performer` directory may auto-file (a `category` always asks, and
+    an unclassified one does too), so without a classification EVERY auto-file
+    assertion in the suite would be asserting the kind gate rather than the
+    rule it names. The gate has its own tests, and the category/unclassified
+    cases write their own file.
+    """
+    path = tmp_path / "dirs.toml"
+    body = ["performer = ["]
+    body += [f'  "{name}",' for name in SAMPLE_DIRS]
+    body += ["]", "category = []", ""]
+    path.write_text("\n".join(body), encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def cfg(tmp_path, library, dirs_file):
     """A Config pointing entirely at temp paths."""
     data = config_mod._deep_merge(config_mod.DEFAULTS, {
         "library_root": str(library),
@@ -113,4 +131,5 @@ def cfg(tmp_path, library):
     })
     return config_mod.Config(data, path=tmp_path / "config.toml",
                              state_dir=tmp_path / "state",
-                             token_file=tmp_path / "token")
+                             token_file=tmp_path / "token",
+                             dirs_file=dirs_file)

--- a/scripts/dl-router/tests/fixtures.mjs
+++ b/scripts/dl-router/tests/fixtures.mjs
@@ -20,6 +20,24 @@ function expand(value) {
   return value;
 }
 
+/**
+ * THE shared identity-signal table (fixtures/url_cases.json).
+ *
+ * tests/conftest.py loads the same file, so matcher.py and route_core.js are
+ * asserted against ONE table. The cached fallback runs exactly when the sidecar
+ * is unreachable, so a divergence between the two is invisible until it
+ * misfiles something.
+ */
+export function loadUrlCases() {
+  const raw = JSON.parse(
+    readFileSync(join(HERE, "fixtures", "url_cases.json"), "utf8"));
+  const out = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (!key.startsWith("_")) out[key] = value;
+  }
+  return out;
+}
+
 export function loadNameCases() {
   const raw = JSON.parse(
     readFileSync(join(HERE, "fixtures", "name_cases.json"), "utf8"));

--- a/scripts/dl-router/tests/fixtures/url_cases.json
+++ b/scripts/dl-router/tests/fixtures/url_cases.json
@@ -75,7 +75,7 @@
     },
     {
       "url": "https://board.test/t/aster-vale/1234",
-      "slug": "aster vale"
+      "slug": ""
     },
     {
       "url": "https://forum.test/threads/481920/",
@@ -147,15 +147,27 @@
     },
     {
       "url": "https://forum.test/topic/12345-aster-vale/",
-      "slug": "aster vale"
+      "slug": ""
     },
     {
       "url": "https://forum.test/t/aster-vale/1234",
-      "slug": "aster vale"
+      "slug": ""
     },
     {
       "url": "https://forum.test/topic/aster-vale.9912/",
-      "slug": "aster vale"
+      "slug": ""
+    },
+    {
+      "url": "https://forum.test/topics/general-discussion/2",
+      "slug": ""
+    },
+    {
+      "url": "https://forum.test/t/photography/3",
+      "slug": ""
+    },
+    {
+      "url": "https://forum.test/t/best-of-2024",
+      "slug": ""
     }
   ],
   "_host_why": [

--- a/scripts/dl-router/tests/fixtures/url_cases.json
+++ b/scripts/dl-router/tests/fixtures/url_cases.json
@@ -1,0 +1,53 @@
+{
+  "_why": [
+    "ONE table, TWO implementations. matcher.py and extension/route_core.js each",
+    "derive identity signals from a URL, and the extension's cached fallback runs",
+    "exactly when the sidecar is unreachable -- so a divergence between them is",
+    "invisible until it misfiles something. The hostile-name table",
+    "(name_cases.json) exists for the same reason: two hand-copied lists agreed",
+    "with each other and both passed while the implementations disagreed on 991",
+    "inputs neither list contained.",
+    "",
+    "Every id, host and name here is SYNTHETIC."
+  ],
+  "discord": [
+    {"url": "https://cdn.discordapp.com/attachments/119283746551234567/998877665544332211/clip.mp4",
+     "channel": "119283746551234567"},
+    {"url": "https://media.discordapp.net/attachments/119283746551234567/998877665544332211/still.png",
+     "channel": "119283746551234567"},
+    {"url": "https://cdn.discordapp.com/attachments/119283746551234567/998877665544332211/clip.mp4?ex=abc&is=def",
+     "channel": "119283746551234567"},
+    {"url": "https://cdn.discordapp.com/ephemeral-attachments/220000000000000001/1/x.mp4",
+     "channel": "220000000000000001"},
+    {"url": "https://cdn.discordapp.com/avatars/119283746551234567/abc.png",
+     "channel": ""},
+    {"url": "https://cdn.discordapp.com/attachments/not-a-snowflake/1/clip.mp4",
+     "channel": ""},
+    {"url": "https://cdn.discordapp.com/attachments/119283746551234567",
+     "channel": ""},
+    {"url": "https://example-site.test/attachments/119283746551234567/1/clip.mp4",
+     "channel": ""},
+    {"url": "https://evil.test/cdn.discordapp.com/attachments/119283746551234567/1/x.mp4",
+     "channel": ""},
+    {"url": "not a url", "channel": ""},
+    {"url": "", "channel": ""}
+  ],
+  "slug": [
+    {"url": "https://forum.test/threads/aster-vale-collection.481920/",
+     "slug": "aster vale collection"},
+    {"url": "https://forum.test/threads/aster-vale-collection.481920/page-3",
+     "slug": "aster vale collection"},
+    {"url": "https://forum.test/showthread.php/481920-aster-vale-collection",
+     "slug": "aster vale collection"},
+    {"url": "https://forum.test/forums/general-discussion/threads/aster-vale.99/",
+     "slug": "aster vale"},
+    {"url": "https://board.test/t/aster-vale/1234", "slug": "aster vale"},
+    {"url": "https://forum.test/threads/481920/", "slug": ""},
+    {"url": "https://forum.test/threads/", "slug": ""},
+    {"url": "https://forum.test/", "slug": ""},
+    {"url": "https://filehost.test/d/AbCdEf", "slug": ""},
+    {"url": "https://filehost.test/f/9f2a1c92b", "slug": ""},
+    {"url": "not a url", "slug": ""},
+    {"url": "", "slug": ""}
+  ]
+}

--- a/scripts/dl-router/tests/fixtures/url_cases.json
+++ b/scripts/dl-router/tests/fixtures/url_cases.json
@@ -168,6 +168,18 @@
     {
       "url": "https://forum.test/t/best-of-2024",
       "slug": ""
+    },
+    {
+      "url": "https://forum.test/threads/%D9%A0%D9%A1%D9%A2%D9%A0%D9%A1%D9%A2",
+      "slug": ""
+    },
+    {
+      "url": "https://forum.test/threads/%D9%A0%D9%A1%D9%A2-%D9%A0%D9%A1%D9%A2/",
+      "slug": ""
+    },
+    {
+      "url": "https://forum.test/threads/%D0%B0%D1%81%D1%82%D0%B5%D1%80-%D0%B2%D0%B5%D0%B9%D0%BB.99/",
+      "slug": "астер веил"
     }
   ],
   "_host_why": [

--- a/scripts/dl-router/tests/fixtures/url_cases.json
+++ b/scripts/dl-router/tests/fixtures/url_cases.json
@@ -11,43 +11,217 @@
     "Every id, host and name here is SYNTHETIC."
   ],
   "discord": [
-    {"url": "https://cdn.discordapp.com/attachments/119283746551234567/998877665544332211/clip.mp4",
-     "channel": "119283746551234567"},
-    {"url": "https://media.discordapp.net/attachments/119283746551234567/998877665544332211/still.png",
-     "channel": "119283746551234567"},
-    {"url": "https://cdn.discordapp.com/attachments/119283746551234567/998877665544332211/clip.mp4?ex=abc&is=def",
-     "channel": "119283746551234567"},
-    {"url": "https://cdn.discordapp.com/ephemeral-attachments/220000000000000001/1/x.mp4",
-     "channel": "220000000000000001"},
-    {"url": "https://cdn.discordapp.com/avatars/119283746551234567/abc.png",
-     "channel": ""},
-    {"url": "https://cdn.discordapp.com/attachments/not-a-snowflake/1/clip.mp4",
-     "channel": ""},
-    {"url": "https://cdn.discordapp.com/attachments/119283746551234567",
-     "channel": ""},
-    {"url": "https://example-site.test/attachments/119283746551234567/1/clip.mp4",
-     "channel": ""},
-    {"url": "https://evil.test/cdn.discordapp.com/attachments/119283746551234567/1/x.mp4",
-     "channel": ""},
-    {"url": "not a url", "channel": ""},
-    {"url": "", "channel": ""}
+    {
+      "url": "https://cdn.discordapp.com/attachments/119283746551234567/998877665544332211/clip.mp4",
+      "channel": "119283746551234567"
+    },
+    {
+      "url": "https://media.discordapp.net/attachments/119283746551234567/998877665544332211/still.png",
+      "channel": "119283746551234567"
+    },
+    {
+      "url": "https://cdn.discordapp.com/attachments/119283746551234567/998877665544332211/clip.mp4?ex=abc&is=def",
+      "channel": "119283746551234567"
+    },
+    {
+      "url": "https://cdn.discordapp.com/ephemeral-attachments/220000000000000001/1/x.mp4",
+      "channel": "220000000000000001"
+    },
+    {
+      "url": "https://cdn.discordapp.com/avatars/119283746551234567/abc.png",
+      "channel": ""
+    },
+    {
+      "url": "https://cdn.discordapp.com/attachments/not-a-snowflake/1/clip.mp4",
+      "channel": ""
+    },
+    {
+      "url": "https://cdn.discordapp.com/attachments/119283746551234567",
+      "channel": ""
+    },
+    {
+      "url": "https://example-site.test/attachments/119283746551234567/1/clip.mp4",
+      "channel": ""
+    },
+    {
+      "url": "https://evil.test/cdn.discordapp.com/attachments/119283746551234567/1/x.mp4",
+      "channel": ""
+    },
+    {
+      "url": "not a url",
+      "channel": ""
+    },
+    {
+      "url": "",
+      "channel": ""
+    }
   ],
   "slug": [
-    {"url": "https://forum.test/threads/aster-vale-collection.481920/",
-     "slug": "aster vale collection"},
-    {"url": "https://forum.test/threads/aster-vale-collection.481920/page-3",
-     "slug": "aster vale collection"},
-    {"url": "https://forum.test/showthread.php/481920-aster-vale-collection",
-     "slug": "aster vale collection"},
-    {"url": "https://forum.test/forums/general-discussion/threads/aster-vale.99/",
-     "slug": "aster vale"},
-    {"url": "https://board.test/t/aster-vale/1234", "slug": "aster vale"},
-    {"url": "https://forum.test/threads/481920/", "slug": ""},
-    {"url": "https://forum.test/threads/", "slug": ""},
-    {"url": "https://forum.test/", "slug": ""},
-    {"url": "https://filehost.test/d/AbCdEf", "slug": ""},
-    {"url": "https://filehost.test/f/9f2a1c92b", "slug": ""},
-    {"url": "not a url", "slug": ""},
-    {"url": "", "slug": ""}
+    {
+      "url": "https://forum.test/threads/aster-vale-collection.481920/",
+      "slug": "aster vale collection"
+    },
+    {
+      "url": "https://forum.test/threads/aster-vale-collection.481920/page-3",
+      "slug": "aster vale collection"
+    },
+    {
+      "url": "https://forum.test/showthread.php/481920-aster-vale-collection",
+      "slug": "aster vale collection"
+    },
+    {
+      "url": "https://forum.test/forums/general-discussion/threads/aster-vale.99/",
+      "slug": "aster vale"
+    },
+    {
+      "url": "https://board.test/t/aster-vale/1234",
+      "slug": "aster vale"
+    },
+    {
+      "url": "https://forum.test/threads/481920/",
+      "slug": ""
+    },
+    {
+      "url": "https://forum.test/threads/",
+      "slug": ""
+    },
+    {
+      "url": "https://forum.test/",
+      "slug": ""
+    },
+    {
+      "url": "https://filehost.test/d/AbCdEf",
+      "slug": ""
+    },
+    {
+      "url": "https://filehost.test/f/9f2a1c92b",
+      "slug": ""
+    },
+    {
+      "url": "not a url",
+      "slug": ""
+    },
+    {
+      "url": "",
+      "slug": ""
+    },
+    {
+      "url": "https://forum.test/forums/general-discussion/threads/aster.99/",
+      "slug": "aster"
+    },
+    {
+      "url": "https://forum.test/forums/general-discussion.12/",
+      "slug": ""
+    },
+    {
+      "url": "https://forum.test/members/some-poster.4321/",
+      "slug": ""
+    },
+    {
+      "url": "https://cdn.test/uploads/dsc-0123.jpg",
+      "slug": ""
+    },
+    {
+      "url": "https://cdn.test/i/img-20240101.mp4",
+      "slug": ""
+    },
+    {
+      "url": "https://forum.test/threads/aster-vale-new-set.222/",
+      "slug": "aster vale new set"
+    },
+    {
+      "url": "https://forum.test/topic/aster-vale/",
+      "slug": "aster vale"
+    },
+    {
+      "url": "https://forum.test/viewtopic.php/aster-vale",
+      "slug": "aster vale"
+    }
+  ],
+  "_host_why": [
+    "hostOf feeds the SCOPE of an alias, so the two implementations have to agree",
+    "on what a host is. They did not: `urlsplit` and `new URL` disagreed on 9 of",
+    "30 hostile inputs (scheme handling, IPv6 brackets, IDN punycoding,",
+    "percent-encoded authorities). The rule is written out in both rather than",
+    "delegated to either standard library -- the same treatment is_http_url",
+    "already gets in safety.py / sanitize.js."
+  ],
+  "host": [
+    {
+      "url": "https://forum.test/x",
+      "host": "forum.test"
+    },
+    {
+      "url": "HTTP://Forum.TEST/x",
+      "host": "forum.test"
+    },
+    {
+      "url": "http://forum.test:8080/x",
+      "host": "forum.test"
+    },
+    {
+      "url": "https://user:pw@forum.test/x",
+      "host": "forum.test"
+    },
+    {
+      "url": "file:///etc/passwd",
+      "host": ""
+    },
+    {
+      "url": "data:text/html,x",
+      "host": ""
+    },
+    {
+      "url": "blob:https://a.test/x",
+      "host": ""
+    },
+    {
+      "url": "javascript:alert(1)",
+      "host": ""
+    },
+    {
+      "url": "ftp://forum.test/x",
+      "host": ""
+    },
+    {
+      "url": "//forum.test/x",
+      "host": ""
+    },
+    {
+      "url": "https:///",
+      "host": ""
+    },
+    {
+      "url": "https://",
+      "host": ""
+    },
+    {
+      "url": "not a url",
+      "host": ""
+    },
+    {
+      "url": "",
+      "host": ""
+    },
+    {
+      "url": "http://[::1]/x",
+      "host": "::1"
+    },
+    {
+      "url": "http://[2001:db8::1]:80/x",
+      "host": "2001:db8::1"
+    },
+    {
+      "url": "http://127.0.0.1/x",
+      "host": "127.0.0.1"
+    },
+    {
+      "url": "http://%D0%BF%D1%80%D0%B8%D0%BC%D0%B5%D1%80.test/",
+      "host": "xn--e1afmkfd.test"
+    },
+    {
+      "url": "http://xn--e1afmkfd.test/",
+      "host": "xn--e1afmkfd.test"
+    }
   ]
 }

--- a/scripts/dl-router/tests/fixtures/url_cases.json
+++ b/scripts/dl-router/tests/fixtures/url_cases.json
@@ -131,10 +131,30 @@
     },
     {
       "url": "https://forum.test/topic/aster-vale/",
-      "slug": "aster vale"
+      "slug": ""
     },
     {
       "url": "https://forum.test/viewtopic.php/aster-vale",
+      "slug": "aster vale"
+    },
+    {
+      "url": "https://forum.test/topics/general-discussion",
+      "slug": ""
+    },
+    {
+      "url": "https://forum.test/t/photography",
+      "slug": ""
+    },
+    {
+      "url": "https://forum.test/topic/12345-aster-vale/",
+      "slug": "aster vale"
+    },
+    {
+      "url": "https://forum.test/t/aster-vale/1234",
+      "slug": "aster vale"
+    },
+    {
+      "url": "https://forum.test/topic/aster-vale.9912/",
       "slug": "aster vale"
     }
   ],

--- a/scripts/dl-router/tests/identity.test.mjs
+++ b/scripts/dl-router/tests/identity.test.mjs
@@ -1,0 +1,195 @@
+// Identity signals in the extension, and the auto-file gate in the cached
+// fallback. Both must agree with the sidecar: the fallback runs exactly when
+// the sidecar is unreachable, so any divergence is invisible until it misfiles.
+//
+// The URL table is shared with tests/test_signals.py -- see fixtures/url_cases.json.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  KIND_CATEGORY, KIND_PERFORMER, SCORE_ALIAS_SITE, buildMatchPayload,
+  carryReferrer, discordAliasKey, discordChannelId, identitySignals, kindOf,
+  localContext, localDecide, subjectPhrases, threadAliasKey, threadSlug,
+  titleSubject,
+} from "../extension/route_core.js";
+import { loadUrlCases } from "./fixtures.mjs";
+
+const URL_CASES = loadUrlCases();
+const CHANNEL = "119283746551234567";
+const CDN
+  = `https://cdn.discordapp.com/attachments/${CHANNEL}/998877665544332211/clip.mp4`;
+const THREAD = "https://someforum.test/threads/aster-vale.481920/";
+
+const DIRS = [
+  { name: "Jane Doe", key: "janedoe", tokens: ["jane", "doe"],
+    kind: KIND_PERFORMER },
+  { name: "Field Notes", key: "fieldnotes", tokens: ["field", "notes"],
+    kind: KIND_CATEGORY },
+  { name: "Aster Vale", key: "astervale", tokens: ["aster", "vale"] },
+  { name: "other", key: "other", tokens: [] },
+];
+
+function snapshot(aliases = []) {
+  return { dirs: DIRS, aliases, threshold: 0.75, otherDir: "other" };
+}
+
+// --- the shared table ------------------------------------------------------- //
+test("Discord channel ids match the shared table byte for byte", () => {
+  for (const c of URL_CASES.discord) {
+    assert.equal(discordChannelId(c.url), c.channel, c.url);
+  }
+});
+
+test("thread slugs match the shared table byte for byte", () => {
+  for (const c of URL_CASES.slug) {
+    assert.equal(threadSlug(c.url), c.slug, c.url);
+  }
+});
+
+// --- Discord ---------------------------------------------------------------- //
+test("a Discord attachment yields a site-scoped channel identity", () => {
+  // Six of nine real downloads looked like this: `tags: []`, `title: ''`,
+  // `pageUrl: ''`. The channel id in the URL is the only signal there is.
+  const sigs = identitySignals({ url: CDN });
+  assert.deepEqual(sigs, [{ key: discordAliasKey(CHANNEL),
+    site: "discord.com", kind: "discord-channel" }]);
+});
+
+test("a confirmed channel scores at full confidence from the CACHE", () => {
+  const snap = snapshot([
+    { key: discordAliasKey(CHANNEL), site: "discord.com", dir: "Jane Doe" },
+  ]);
+  const out = localDecide({ url: CDN }, snap);
+  assert.equal(out.dir, "Jane Doe");
+  assert.equal(out.confidence, SCORE_ALIAS_SITE);
+  assert.equal(out.auto, true);
+  assert.match(out.reason, /discord-channel/);
+});
+
+test("an unconfirmed channel scores nothing", () => {
+  assert.equal(localDecide({ url: CDN }, snapshot()), null);
+});
+
+test("the match payload carries the URLs the identity is derived from", () => {
+  // Without them the sidecar cannot see the channel either.
+  const payload = buildMatchPayload({ id: 3, url: CDN, filename: "clip.mp4" },
+    null);
+  assert.equal(payload.url, CDN);
+  assert.equal(discordChannelId(localContext(payload).url), CHANNEL);
+});
+
+// --- the auto-file gate ----------------------------------------------------- //
+test("only a performer directory auto-files from the cache", () => {
+  const snap = snapshot([
+    { key: "fieldnotes", site: "site.test", dir: "Field Notes" },
+  ]);
+  const out = localDecide({ tags: ["Field Notes"], site: "site.test" }, snap);
+  assert.equal(out.dir, "Field Notes");
+  assert.equal(out.confidence, SCORE_ALIAS_SITE);
+  assert.equal(out.auto, false, "a category always confirms");
+  assert.match(out.reason, /category/);
+});
+
+test("an unclassified directory never auto-files from the cache", () => {
+  const snap = snapshot([
+    { key: "astervale", site: "site.test", dir: "Aster Vale" },
+  ]);
+  const out = localDecide({ tags: ["Aster Vale"], site: "site.test" }, snap);
+  assert.equal(out.auto, false);
+  assert.match(out.reason, /unclassified/);
+});
+
+test("kindOf reads only the two real kinds", () => {
+  assert.equal(kindOf(snapshot(), "Jane Doe"), KIND_PERFORMER);
+  assert.equal(kindOf(snapshot(), "Aster Vale"), "unknown");
+  assert.equal(kindOf(snapshot(), "nope"), "unknown");
+  assert.equal(kindOf({ dirs: [{ name: "x", kind: "performer!" }] }, "x"),
+    "unknown");
+});
+
+// --- forum threads ---------------------------------------------------------- //
+test("the slug leads the subject phrases, ahead of the tag list", () => {
+  const phrases = subjectPhrases({
+    pageUrl: THREAD,
+    site: "someforum.test",
+    pageTitle: "Aster Vale | Some Forum",
+    tags: ["General Discussion", "poster_1988"],
+  });
+  assert.equal(phrases[0], "aster vale");
+  assert.ok(phrases.indexOf("General Discussion") > 0);
+});
+
+test("the de-branded title beats the raw one", () => {
+  assert.equal(titleSubject("Aster Vale | Some Forum", "someforum.test"),
+    "Aster Vale");
+});
+
+// --- the cross-host referrer carry ------------------------------------------ //
+const forumCapture = {
+  pageUrl: THREAD, pageTitle: "Aster Vale | Some Forum", tabId: 1,
+  href: "https://filehost.test/f/AbCdEf", tags: [],
+};
+const hostCapture = {
+  pageUrl: "https://filehost.test/f/AbCdEf", pageTitle: "Download - Filehost",
+  tabId: 2, openerTabId: 1, tags: [],
+};
+
+test("a captured click whose href IS this page proves the link", () => {
+  const carried = carryReferrer({ url: "https://filehost.test/d/AbCdEf" },
+    hostCapture, [forumCapture, hostCapture]);
+  assert.equal(carried.pageUrl, THREAD);
+});
+
+test("an opener-tab chain proves the link too", () => {
+  const donor = { ...forumCapture, href: "" };
+  const carried = carryReferrer({ url: "https://filehost.test/d/AbCdEf" },
+    hostCapture, [donor, hostCapture]);
+  assert.equal(carried.pageUrl, THREAD);
+});
+
+test("an unprovable thread is NOT carried, however recent", () => {
+  // No time window and no "last thread seen": both get it wrong exactly when
+  // several tabs are open, which is how anyone browses a forum.
+  const unrelated = { ...forumCapture, href: "", tabId: 9, ts: Date.now() };
+  const orphan = { ...hostCapture, openerTabId: undefined };
+  assert.equal(carryReferrer({ url: "https://filehost.test/d/AbCdEf" },
+    orphan, [unrelated, orphan]), null);
+});
+
+test("a page with its own tags never imports someone else's subject", () => {
+  const rich = { ...hostCapture, tags: ["Jane Doe"] };
+  assert.equal(carryReferrer({ url: "https://filehost.test/d/AbCdEf" },
+    rich, [forumCapture, rich]), null);
+});
+
+test("the carried thread becomes an identity signal, scoped to the FORUM", () => {
+  const carried = carryReferrer({ url: "https://filehost.test/d/AbCdEf" },
+    hostCapture, [forumCapture, hostCapture]);
+  const payload = buildMatchPayload(
+    { id: 1, url: "https://filehost.test/d/AbCdEf" }, hostCapture, carried);
+  assert.equal(payload.page.referrerUrl, THREAD);
+  const sigs = identitySignals(localContext(payload));
+  assert.deepEqual(sigs, [{ key: threadAliasKey("aster vale"),
+    site: "someforum.test", kind: "thread-slug" }]);
+});
+
+test("a carried thread matches its directory from the cache", () => {
+  const snap = snapshot([
+    { key: threadAliasKey("aster vale"), site: "someforum.test",
+      dir: "Jane Doe" },
+  ]);
+  const carried = carryReferrer({ url: "https://filehost.test/d/AbCdEf" },
+    hostCapture, [forumCapture, hostCapture]);
+  const payload = buildMatchPayload(
+    { id: 1, url: "https://filehost.test/d/AbCdEf" }, hostCapture, carried);
+  const out = localDecide(localContext(payload), snap);
+  assert.equal(out.dir, "Jane Doe");
+  assert.equal(out.auto, true);
+});
+
+test("no carry means the payload says so, rather than guessing", () => {
+  const payload = buildMatchPayload({ id: 1, url: "https://filehost.test/d/x" },
+    hostCapture, null);
+  assert.equal(payload.page.referrerUrl, "");
+  assert.equal(payload.page.referrerTitle, "");
+});

--- a/scripts/dl-router/tests/identity.test.mjs
+++ b/scripts/dl-router/tests/identity.test.mjs
@@ -150,15 +150,27 @@ test("with no slug there is no title subject at all", () => {
     "");
 });
 
-test("an index route is not a thread without a numeric id", () => {
-  // `/topics/...` and `/t/...` are thread routes on Discourse and IPB and
-  // INDEX routes elsewhere. A thread always carries an id beside the slug.
-  assert.equal(threadSlug("https://forum.test/topics/general-discussion"), "");
-  assert.equal(threadSlug("https://forum.test/t/photography"), "");
-  assert.equal(threadSlug("https://forum.test/t/aster-vale/1234"),
+test("the ambiguous routes are not anchors at all", () => {
+  // Gating `t`/`topic`/`topics` on an adjacent numeric id does not work: a
+  // PAGINATED index is structurally identical to a Discourse thread.
+  for (const url of [
+    "https://forum.test/topics/general-discussion",
+    "https://forum.test/topics/general-discussion/2",
+    "https://forum.test/t/photography",
+    "https://forum.test/t/photography/3",
+    "https://forum.test/t/best-of-2024",
+    "https://forum.test/t/aster-vale/1234",
+    "https://forum.test/topic/12345-aster-vale/",
+  ]) assert.equal(threadSlug(url), "", url);
+  // ...while the unambiguous routes still work.
+  assert.equal(threadSlug("https://forum.test/threads/aster-vale.99/"),
     "aster vale");
-  assert.equal(threadSlug("https://forum.test/topic/12345-aster-vale/"),
-    "aster vale");
+});
+
+test("one shared token is a coincidence, not corroboration", () => {
+  assert.equal(titleSubject("Section: Photography | Some Forum", "forum.test",
+    "photography meetup"), "");
+  assert.equal(titleSubject("Page 12 | X", "forum.test", "top-12-sets"), "");
 });
 
 // --- the cross-host referrer carry ------------------------------------------ //

--- a/scripts/dl-router/tests/identity.test.mjs
+++ b/scripts/dl-router/tests/identity.test.mjs
@@ -130,9 +130,35 @@ test("the slug leads the subject phrases, ahead of the tag list", () => {
   assert.ok(phrases.indexOf("General Discussion") > 0);
 });
 
-test("the de-branded title beats the raw one", () => {
-  assert.equal(titleSubject("Aster Vale | Some Forum", "someforum.test"),
-    "Aster Vale");
+test("the title subject is corroborated against the slug, not guessed", () => {
+  // phpBB puts the subject LAST, XenForo puts it FIRST, and both are common:
+  // neither position nor size can pick it. See matcher.title_subject.
+  const SUBJECT = "Aster Vale Deluxe Photo Set";
+  const SLUG = "aster vale deluxe photo set";
+  for (const title of [
+    `${SUBJECT} | Some Forum`,
+    `Some Forum - View topic - ${SUBJECT}`,
+    `Section | ${SUBJECT} | Some Forum`,
+    `Page 2 | ${SUBJECT} | Some Forum`,
+  ]) {
+    assert.equal(titleSubject(title, "forum.test", SLUG), SUBJECT, title);
+  }
+});
+
+test("with no slug there is no title subject at all", () => {
+  assert.equal(titleSubject("Aster Vale | Some Forum", "someforum.test", ""),
+    "");
+});
+
+test("an index route is not a thread without a numeric id", () => {
+  // `/topics/...` and `/t/...` are thread routes on Discourse and IPB and
+  // INDEX routes elsewhere. A thread always carries an id beside the slug.
+  assert.equal(threadSlug("https://forum.test/topics/general-discussion"), "");
+  assert.equal(threadSlug("https://forum.test/t/photography"), "");
+  assert.equal(threadSlug("https://forum.test/t/aster-vale/1234"),
+    "aster vale");
+  assert.equal(threadSlug("https://forum.test/topic/12345-aster-vale/"),
+    "aster vale");
 });
 
 // --- the cross-host referrer carry ------------------------------------------ //

--- a/scripts/dl-router/tests/identity.test.mjs
+++ b/scripts/dl-router/tests/identity.test.mjs
@@ -8,7 +8,8 @@ import assert from "node:assert/strict";
 
 import {
   KIND_CATEGORY, KIND_PERFORMER, SCORE_ALIAS_SITE, buildMatchPayload,
-  carryReferrer, discordAliasKey, discordChannelId, identitySignals, kindOf,
+  carryReferrer, discordAliasKey, discordChannelId, hostOf, identitySignals,
+  kindOf,
   localContext, localDecide, subjectPhrases, threadAliasKey, threadSlug,
   titleSubject,
 } from "../extension/route_core.js";
@@ -43,6 +44,16 @@ test("Discord channel ids match the shared table byte for byte", () => {
 test("thread slugs match the shared table byte for byte", () => {
   for (const c of URL_CASES.slug) {
     assert.equal(threadSlug(c.url), c.slug, c.url);
+  }
+});
+
+test("hostnames match the shared table byte for byte", () => {
+  // The host is the SCOPE of an alias. `new URL` and Python's `urlsplit`
+  // disagreed on 9 of 30 hostile inputs (scheme handling, IPv6 brackets, IDN
+  // punycoding, percent-encoded authorities), so the rule is written out in
+  // both rather than delegated to either standard library.
+  for (const c of URL_CASES.host) {
+    assert.equal(hostOf(c.url), c.host, c.url);
   }
 });
 
@@ -140,11 +151,45 @@ test("a captured click whose href IS this page proves the link", () => {
   assert.equal(carried.pageUrl, THREAD);
 });
 
-test("an opener-tab chain proves the link too", () => {
-  const donor = { ...forumCapture, href: "" };
+// BLOCKER 3. The opener-tab branch took the newest usable capture whose tabId
+// matched `openerTabId`, with nothing binding that capture to the navigation
+// that opened the tab and no time bound -- "the last thread I saw in that tab"
+// wearing the word "provable". The wrong answer was not just used for one
+// match; it was LEARNED, as a 1.00 identity alias.
+test("an opener tab alone is NOT a proof — the branch is gone", () => {
+  const donor = { ...forumCapture, href: "" };   // never linked here
+  assert.equal(carryReferrer({ url: "https://filehost.test/d/AbCdEf" },
+    hostCapture, [donor, hostCapture]), null);
+});
+
+test("the ordinary forum pattern no longer carries the WRONG thread", () => {
+  // Open the file host in a new tab, keep browsing the opener tab. By the time
+  // the download fires, the newest capture from that tab is a different
+  // thread -- and the href proof cannot cover for it, because a `?ref=`
+  // parameter on the published href breaks the equality.
+  const linked = { ...forumCapture, href: "https://filehost.test/f/AbCdEf?ref=1" };
+  const laterThread = {
+    pageUrl: "https://someforum.test/threads/someone-else.99/",
+    pageTitle: "Someone Else", tabId: 1, href: "", tags: [], ts: Date.now(),
+  };
+  assert.equal(carryReferrer({ url: "https://filehost.test/d/AbCdEf" },
+    hostCapture, [linked, laterThread, hostCapture]), null);
+});
+
+test("openerTabId can only NARROW the href proof, never invent one", () => {
+  // Same proven link, but the donor is not the tab we came from.
+  const donor = { ...forumCapture, tabId: 77 };
+  assert.equal(carryReferrer({ url: "https://filehost.test/d/AbCdEf" },
+    hostCapture, [donor, hostCapture]), null);
+  // ...and with the tab agreeing, the carry stands.
   const carried = carryReferrer({ url: "https://filehost.test/d/AbCdEf" },
-    hostCapture, [donor, hostCapture]);
+    hostCapture, [forumCapture, hostCapture]);
   assert.equal(carried.pageUrl, THREAD);
+});
+
+test("a download with no page of its own at all carries nothing", () => {
+  assert.equal(carryReferrer({ url: "https://filehost.test/d/AbCdEf" },
+    null, [forumCapture]), null);
 });
 
 test("an unprovable thread is NOT carried, however recent", () => {

--- a/scripts/dl-router/tests/picker.test.mjs
+++ b/scripts/dl-router/tests/picker.test.mjs
@@ -132,18 +132,48 @@ test("Enter chooses the highlighted existing directory", () => {
     { action: "choose", dir: "john-smith", createdNew: false });
 });
 
-test("Enter on the top entry creates a new directory", () => {
+test("Enter on the top entry creates a new directory, after asking its kind", () => {
+  // Creating a directory without saying which KIND it is leaves it
+  // unclassified, and an unclassified directory never auto-files -- so it
+  // would silently interrupt every future download into it. Hence the second
+  // keypress.
   let state = initialState({ dirs: DIRS, suggestNew: "Aster Vale" });
   state = drive(state, [key("Enter")]);
-  assert.deepEqual(state.done,
-    { action: "choose", dir: "Aster Vale", createdNew: true });
+  assert.equal(state.done, null, "nothing is created before the kind is known");
+  assert.equal(state.pendingNew, "Aster Vale");
+  assert.deepEqual(state.entries.map((e) => e.name), ["performer", "category"]);
+  state = drive(state, [key("Enter")]);
+  assert.deepEqual(state.done, { action: "choose", dir: "Aster Vale",
+    createdNew: true, kind: "performer" });
+});
+
+test("the kind prompt can pick category", () => {
+  let state = initialState({ dirs: DIRS, suggestNew: "Aster Vale" });
+  state = drive(state, [key("Enter"), key("ArrowDown"), key("Enter")]);
+  assert.equal(state.done.kind, "category");
+});
+
+test("Escape in the kind prompt goes back to the list, not out of the picker", () => {
+  let state = initialState({ dirs: DIRS, suggestNew: "Aster Vale" });
+  state = drive(state, [key("Enter"), key("Escape")]);
+  assert.equal(state.done, null, "escaping a sub-question undoes the question");
+  assert.equal(state.pendingNew, null);
+  assert.equal(state.entries[0].name, "Aster Vale");
+});
+
+test("typing while the kind prompt is up cannot rebuild the list under it", () => {
+  let state = initialState({ dirs: DIRS, suggestNew: "Aster Vale" });
+  state = drive(state, [key("Enter"), input("jane")]);
+  assert.equal(state.pendingNew, "Aster Vale");
+  assert.deepEqual(state.entries.map((e) => e.name), ["performer", "category"]);
 });
 
 test("typing then Enter creates the typed directory", () => {
   let state = initialState({ dirs: DIRS });
-  state = drive(state, [input("aster nightingale"), key("Enter")]);
-  assert.deepEqual(state.done,
-    { action: "choose", dir: "Aster Nightingale", createdNew: true });
+  state = drive(state, [input("aster nightingale"), key("Enter"),
+    key("Enter")]);
+  assert.deepEqual(state.done, { action: "choose", dir: "Aster Nightingale",
+    createdNew: true, kind: "performer" });
 });
 
 test("typing resets the highlight to the top", () => {
@@ -221,8 +251,9 @@ test("a deferred Enter still creates when nothing really matches", () => {
   let state = initialState({ dirs: [], loading: true });
   state = drive(state, [input("aster nightingale"), key("Enter")]);
   state = reduce(state, { type: "dirs", dirs: DIRS });
-  assert.deepEqual(state.done,
-    { action: "choose", dir: "Aster Nightingale", createdNew: true });
+  state = drive(state, [key("Enter")]);          // the kind prompt
+  assert.deepEqual(state.done, { action: "choose", dir: "Aster Nightingale",
+    createdNew: true, kind: "performer" });
 });
 
 test("Escape works immediately even while loading", () => {
@@ -368,9 +399,10 @@ test("mount: an empty snapshot still offers the new-directory entry", () => {
     search: "?id=7&suggestNew=Aster+Vale" });
   assert.match(doc.getElementById("list").textContent, /new dir "Aster Vale"/);
   doc.fire("keydown", { key: "Enter" });
+  doc.fire("keydown", { key: "Enter" });        // performer
   const choose = sent.find((m) => m.type === "dlr:choose");
   assert.deepEqual(choose, { type: "dlr:choose", downloadId: 7,
-    dir: "Aster Vale", createdNew: true });
+    dir: "Aster Vale", createdNew: true, kind: "performer" });
 });
 
 
@@ -411,9 +443,9 @@ test("a GENUINELY empty library does clear loading", () => {
   state = reduce(state, { type: "dirs", dirs: [] });
   assert.equal(state.loading, false);
   assert.equal(state.failed, false);
-  state = drive(state, [key("Enter")]);
-  assert.deepEqual(state.done,
-    { action: "choose", dir: "Aster Vale", createdNew: true });
+  state = drive(state, [key("Enter"), key("Enter")]);
+  assert.deepEqual(state.done, { action: "choose", dir: "Aster Vale",
+    createdNew: true, kind: "performer" });
 });
 
 test("mount retries a failed snapshot rather than giving up on the first no", async () => {
@@ -553,7 +585,8 @@ test("Escape still works after a refusal", async () => {
   const { doc, sent, closed } = mountPicker({
     chooseResult: { ok: false, error: "refused" },
   });
-  doc.fire("keydown", { key: "Enter" });
+  doc.fire("keydown", { key: "Enter" });        // the new-directory entry
+  doc.fire("keydown", { key: "Enter" });        // its kind
   await tick();
   doc.fire("keydown", { key: "Escape" });
   await tick();
@@ -564,6 +597,7 @@ test("Escape still works after a refusal", async () => {
 test("an accepted choice still closes the window", async () => {
   const { doc, closed } = mountPicker({ chooseResult: { ok: true, dir: "x" } });
   doc.fire("keydown", { key: "Enter" });
+  doc.fire("keydown", { key: "Enter" });        // its kind
   await tick();
   assert.equal(closed(), 1);
 });

--- a/scripts/dl-router/tests/route_core.test.mjs
+++ b/scripts/dl-router/tests/route_core.test.mjs
@@ -16,10 +16,17 @@ import {
   subjectPhrases,
 } from "../extension/route_core.js";
 
+// `kind` travels with every directory in the /dirs snapshot. Only a
+// `performer` directory may auto-file, in the cached fallback exactly as in
+// the sidecar -- so the fixtures classify, or every auto-file assertion below
+// would silently be asserting the kind gate instead of the rule it names.
 const DIRS = [
-  { name: "Jane Doe", key: "janedoe", tokens: ["jane", "doe"] },
-  { name: "john-smith", key: "johnsmith", tokens: ["john", "smith"] },
-  { name: "Mary_Major", key: "marymajor", tokens: ["mary", "major"] },
+  { name: "Jane Doe", key: "janedoe", tokens: ["jane", "doe"],
+    kind: "performer" },
+  { name: "john-smith", key: "johnsmith", tokens: ["john", "smith"],
+    kind: "performer" },
+  { name: "Mary_Major", key: "marymajor", tokens: ["mary", "major"],
+    kind: "performer" },
   { name: "other", key: "other", tokens: [] },
 ];
 
@@ -185,7 +192,8 @@ test("cached decision: containment is scored between the bounds", () => {
 test("cached decision: a short directory name does not match prose", () => {
   const snap = {
     ...SNAPSHOT,
-    dirs: [{ name: "Cat", key: "cat", tokens: ["cat"] }, DIRS[3]],
+    dirs: [{ name: "Cat", key: "cat", tokens: ["cat"],
+      kind: "performer" }, DIRS[3]],
   };
   assert.equal(localDecide({ pageTitle: "the cat sat on a mat" }, snap), null);
 });

--- a/scripts/dl-router/tests/service_worker.test.mjs
+++ b/scripts/dl-router/tests/service_worker.test.mjs
@@ -1203,3 +1203,74 @@ test("a correction is marked as an explicit confirmation", async () => {
   const learn = posted.find((p) => p.url.endsWith("/learn"));
   assert.equal(learn.body.confirmed, true);
 });
+
+// --- reportNothingLearned: the notification that makes the screen visible --- //
+// It had no test at all, and it is the only consumer of `skipped` -- so the
+// mechanism the screen's visibility depends on was itself unpinned.
+test("filing to the catch-all does NOT notify", () => {
+  // /learn returns a `skipped` entry for the catch-all BY DESIGN ("the absence
+  // of a subject, not one"), and filing there is routine. Notifying would
+  // train the operator to dismiss the exact notification this exists for.
+  reset();
+  const fired = SW.reportNothingLearned({
+    dir: "other", written: [],
+    skipped: [{ key: "", source: "catch-all", why: "the catch-all is..." }],
+  });
+  assert.equal(fired, false);
+  assert.equal(calls.notifications.length, 0);
+});
+
+test("a screened IDENTITY notifies even when something else was written", () => {
+  // A screened identity writes no row, so the re-point bypass never engages
+  // for it either: that thread will never auto-file, forever. Reporting
+  // success because an unrelated tag landed hides it permanently.
+  reset();
+  const fired = SW.reportNothingLearned({
+    dir: "Jane Doe",
+    written: [{ key: "fieldrecordings", site: "s.test", source: "tag" }],
+    skipped: [{ key: "thread:x", source: "thread-slug", why: "seen on 2..." }],
+  });
+  assert.equal(fired, true);
+  assert.match(calls.notifications[0].title, /will not learn this source/);
+  assert.match(calls.notifications[0].message, /seen on 2/);
+});
+
+test("a screened tag with something else written stays quiet", () => {
+  reset();
+  assert.equal(SW.reportNothingLearned({
+    dir: "acme-studio",
+    written: [{ key: "fieldrecordings", site: "s.test", source: "tag" }],
+    skipped: [{ key: "jd", source: "tag", why: "too short" }],
+  }), false);
+  assert.equal(calls.notifications.length, 0);
+});
+
+test("a correction that learned nothing at all notifies", () => {
+  reset();
+  assert.equal(SW.reportNothingLearned({
+    dir: "acme-studio", written: [],
+    skipped: [{ key: "jd", source: "tag", why: "too short" }],
+  }), true);
+  assert.match(calls.notifications[0].title, /learned nothing/);
+});
+
+test("nothing skipped, nothing said", () => {
+  reset();
+  assert.equal(SW.reportNothingLearned({ dir: "Jane Doe",
+    written: [{ key: "k", site: "s", source: "thread-slug" }], skipped: [] }),
+  false);
+  assert.equal(SW.reportNothingLearned(null), false);
+  assert.equal(calls.notifications.length, 0);
+});
+
+test("the identity refusal is the one reported, not merely the first", () => {
+  reset();
+  SW.reportNothingLearned({
+    dir: "Jane Doe", written: [],
+    skipped: [
+      { key: "jd", source: "tag", why: "FIRST but unimportant" },
+      { key: "thread:x", source: "thread-slug", why: "THE consequential one" },
+    ],
+  });
+  assert.match(calls.notifications[0].message, /consequential/);
+});

--- a/scripts/dl-router/tests/service_worker.test.mjs
+++ b/scripts/dl-router/tests/service_worker.test.mjs
@@ -96,8 +96,12 @@ const SNAPSHOT = {
   captureWindowS: 15,
   toastMs: 8000,
   dirs: [
-    { name: "Jane Doe", key: "janedoe", tokens: ["jane", "doe"] },
-    { name: "john-smith", key: "johnsmith", tokens: ["john", "smith"] },
+    // `kind` gates auto-filing in the cached fallback the same way it does in
+    // the sidecar; unclassified never auto-files.
+    { name: "Jane Doe", key: "janedoe", tokens: ["jane", "doe"],
+      kind: "performer" },
+    { name: "john-smith", key: "johnsmith", tokens: ["john", "smith"],
+      kind: "performer" },
   ],
   aliases: [],
   siteRules: { "example-site.test": { tags: [".tag a"] } },
@@ -382,7 +386,7 @@ test("applyChoice creates a new directory first when asked", async () => {
       return { ok: true, status: 200,
         json: async () => ({ ...SNAPSHOT, etag: "new",
           dirs: [...SNAPSHOT.dirs, { name: "Aster Vale", key: "astervale",
-            tokens: ["aster", "vale"] }] }) };
+            tokens: ["aster", "vale"], kind: "performer" }] }) };
     }
     return { ok: true, status: 200, json: async () => ({ ok: true }) };
   };
@@ -1095,4 +1099,107 @@ test("a non-string detail does not become [object Object]", async () => {
     assert.match(String(err.message), /sidecar 400/);
     return true;
   });
+});
+
+// --- identity signals, kinds and the referrer carry, through the real glue --- //
+test("recordCapture remembers the opener tab", () => {
+  // The ONLY provable link between a forum thread and the file host it sent
+  // the user to. The content script cannot know it; the sender does.
+  reset();
+  SW.recordCapture({ pageUrl: "https://filehost.test/f/AbCdEf" },
+    { tab: { id: 12, openerTabId: 4 } });
+  const c = SW.state.captures.at(-1);
+  assert.equal(c.tabId, 12);
+  assert.equal(c.openerTabId, 4);
+});
+
+test("a Discord download posts its URL, so the sidecar can read the channel", async () => {
+  // Six of nine real downloads had NO page context at all -- correlation finds
+  // nothing, and the URL is the entire signal.
+  reset();
+  const url = "https://cdn.discordapp.com/attachments/119283746551234567"
+    + "/998877665544332211/clip.mp4";
+  let posted = null;
+  fetchHandler = async (u, opts) => {
+    if (u.endsWith("/match")) posted = JSON.parse(opts.body);
+    return { ok: true, status: 200,
+      json: async () => ({ dir: "other", auto: false, confidence: 0 }) };
+  };
+  SW.onDeterminingFilename({ id: 40, url, filename: "clip.mp4" }, spy());
+  await settle(5);
+  assert.equal(posted.url, url);
+});
+
+test("a proven referrer travels to the sidecar; an unprovable one does not", async () => {
+  reset();
+  const thread = "https://someforum.test/threads/aster-vale.481920/";
+  const hostPage = "https://filehost.test/f/AbCdEf";
+  SW.recordCapture({ pageUrl: thread, pageTitle: "Aster Vale | Some Forum",
+    href: hostPage, tags: [] }, { tab: { id: 4 } });
+  SW.recordCapture({ pageUrl: hostPage, pageTitle: "Download", tags: [] },
+    { tab: { id: 5, openerTabId: 4 } });
+
+  let posted = null;
+  const capturePost = () => {
+    fetchHandler = async (u, opts) => {
+      if (u.endsWith("/match")) posted = JSON.parse(opts.body);
+      return { ok: true, status: 200,
+        json: async () => ({ dir: "other", auto: false, confidence: 0 }) };
+    };
+  };
+  capturePost();
+  SW.onDeterminingFilename(
+    { id: 41, url: "https://filehost.test/d/AbCdEf", referrer: hostPage,
+      filename: "f.mp4" }, spy());
+  await settle(5);
+  assert.equal(posted.page.referrerUrl, thread);
+
+  // Now the same download with the chain broken: no href, no opener.
+  reset();                       // ...which also restores the default handler
+  SW.recordCapture({ pageUrl: thread, pageTitle: "Aster Vale", tags: [] },
+    { tab: { id: 4 } });
+  SW.recordCapture({ pageUrl: hostPage, tags: [] }, { tab: { id: 5 } });
+  posted = null;
+  capturePost();
+  SW.onDeterminingFilename(
+    { id: 42, url: "https://filehost.test/d/AbCdEf", referrer: hostPage,
+      filename: "f.mp4" }, spy());
+  await settle(5);
+  assert.equal(posted.page.referrerUrl, "",
+    "an unprovable thread is never carried");
+});
+
+test("creating a directory sends the kind the picker asked for", async () => {
+  reset();
+  const posted = [];
+  fetchHandler = async (url, opts) => {
+    posted.push({ url, body: opts.body ? JSON.parse(opts.body) : null });
+    if (url.endsWith("/dirs")) {
+      return { ok: true, status: 200, json: async () => SNAPSHOT };
+    }
+    return { ok: true, status: 200, json: async () => ({ ok: true }) };
+  };
+  await SW.applyChoice(50, "Aster Vale",
+    { createdNew: true, kind: "performer" });
+  const mkdir = posted.find((p) => p.url.endsWith("/mkdir"));
+  assert.deepEqual(mkdir.body, { name: "Aster Vale", kind: "performer" });
+});
+
+test("a correction is marked as an explicit confirmation", async () => {
+  // The sidecar refuses to learn a tag -> directory alias without it, and the
+  // flag is stated rather than inferred so a future automatic caller fails
+  // closed.
+  reset();
+  SW.state.pending.set(60, { dir: "other", filename: "f.mp4",
+    payload: { page: {} }, ts: Date.now() });
+  searchResult = [{ id: 60, state: "complete",
+    filename: `${LIB_ROOT}/Jane Doe/f.mp4` }];
+  const posted = [];
+  fetchHandler = async (url, opts) => {
+    posted.push({ url, body: opts.body ? JSON.parse(opts.body) : null });
+    return { ok: true, status: 200, json: async () => ({ ok: true }) };
+  };
+  await SW.applyChoice(60, "Jane Doe", {});
+  const learn = posted.find((p) => p.url.endsWith("/learn"));
+  assert.equal(learn.body.confirmed, true);
 });

--- a/scripts/dl-router/tests/service_worker.test.mjs
+++ b/scripts/dl-router/tests/service_worker.test.mjs
@@ -1274,3 +1274,36 @@ test("the identity refusal is the one reported, not merely the first", () => {
   });
   assert.match(calls.notifications[0].message, /consequential/);
 });
+
+test("a PERMANENTLY refused identity notifies once, not once per download", () => {
+  // The screen refuses a permanent reason (site branding, shared vocabulary, a
+  // spread that only ever grows) on EVERY correction, and a screened identity
+  // writes no row so nothing else changes either. Without the sidecar's
+  // `first` flag this fired forever -- the same "train them to dismiss it"
+  // failure as the catch-all bug, narrower in trigger but unbounded.
+  reset();
+  const learned = {
+    dir: "acme-studio",
+    written: [{ key: "fieldrecordings", site: "s.test", source: "tag" }],
+    skipped: [{ key: "thread:x", source: "thread-slug",
+      why: "it is part of the site name", first: true }],
+  };
+  assert.equal(SW.reportNothingLearned(learned), true);
+  assert.equal(calls.notifications.length, 1);
+
+  // ...every subsequent correction for the same key says `first: false`.
+  const again = { ...learned,
+    skipped: [{ ...learned.skipped[0], first: false }] };
+  assert.equal(SW.reportNothingLearned(again), false);
+  assert.equal(SW.reportNothingLearned(again), false);
+  assert.equal(calls.notifications.length, 1, "one fact, one notification");
+});
+
+test("a refusal with no `first` field at all still notifies", () => {
+  // Forward compatibility with an older sidecar: absent is not `false`.
+  reset();
+  assert.equal(SW.reportNothingLearned({
+    dir: "Jane Doe", written: [],
+    skipped: [{ key: "jd", source: "tag", why: "too short" }],
+  }), true);
+});

--- a/scripts/dl-router/tests/test_cli.py
+++ b/scripts/dl-router/tests/test_cli.py
@@ -489,3 +489,47 @@ def test_status_names_the_unclassified_directories_as_the_reason_it_asks(
     out = capsys.readouterr().out
     assert "unclassified=6" in out
     assert "dl-route dirs classify" in out
+
+
+def test_dirs_classify_force_refuses_to_discard_an_unparseable_file(cli_env,
+                                                                    tmp_path):
+    """--force is safe only because an existing classification is carried into
+    the draft. When the file cannot be PARSED there is nothing to carry, so
+    --force would silently reset every decision in it — the one destructive act
+    available from a command whose whole job is to be read-only."""
+    out = tmp_path / "broken.toml"
+    out.write_text("performer = [ oops", encoding="utf-8")
+    with pytest.raises(SystemExit, match="cannot be parsed"):
+        call(["dirs", "classify", "--out", str(out), "--force"])
+    assert out.read_text(encoding="utf-8") == "performer = [ oops"
+
+
+def test_dirs_classify_force_does_overwrite_a_readable_file(cli_env, tmp_path):
+    out = tmp_path / "ok.toml"
+    out.write_text('performer = ["Jane Doe"]\ncategory = []\n', encoding="utf-8")
+    assert call(["dirs", "classify", "--out", str(out), "--force"]) == 0
+    import tomllib
+    # ...and the existing decision survived the regeneration.
+    assert "Jane Doe" in tomllib.loads(out.read_text(encoding="utf-8"))["performer"]
+
+
+def test_status_does_not_create_the_state_dir(cli_env, capsys):
+    """A read-only command must not have a side effect on disk."""
+    state = Path(cli_env["state"])
+    assert not state.exists()
+    assert call(["status"]) == 0
+    assert not state.exists(), "status created the state directory"
+
+
+def test_alias_review_shows_backfill_seeds_as_the_global_rows_they_are(cli_env,
+                                                                      capsys):
+    """`backfill plan --seed-aliases` is the ONE place a global alias is
+    written. It is explicit and user-invoked, but it must be visible as such."""
+    store = Store(cli._cfg().db_path)
+    store.upsert_alias("janedoe", "Jane Doe", "", source="backfill-seed",
+                       evidence="janedoe")
+    store.close()
+    assert call(["alias", "review"]) == 0
+    out = capsys.readouterr().out
+    assert "backfill-seed" in out
+    assert "! janedoe" in out

--- a/scripts/dl-router/tests/test_cli.py
+++ b/scripts/dl-router/tests/test_cli.py
@@ -569,3 +569,24 @@ def test_alias_review_does_not_flag_a_structured_row_with_no_spread(cli_env,
     store.close()
     assert call(["alias", "review", "--json"]) == 0
     assert json.loads(capsys.readouterr().out)[0]["suspect"] is None
+
+
+def test_alias_review_lists_refused_candidates_as_the_permanent_surface(
+        cli_env, capsys):
+    """A screened candidate writes no alias row, so the only thing that ever
+    mentioned it was a notification that fires once. This is where the fact
+    lives permanently — and it is what makes the over-strict half of the screen
+    as visible as the over-loose half."""
+    store = Store(cli._cfg().db_path)
+    for _ in range(2):
+        store.record_screened("thread:general-discussion", "example-site.test",
+                              "Jane Doe", "thread-slug",
+                              "seen on 2 different directories")
+    store.close()
+    assert call(["alias", "review"]) == 0
+    out = capsys.readouterr().out
+    assert "refused candidate" in out
+    assert "thread:general-discussion" in out
+    assert "seen on 2 different directories" in out
+    assert "seen 2x" in out
+    assert "will NEVER auto-file" in out

--- a/scripts/dl-router/tests/test_cli.py
+++ b/scripts/dl-router/tests/test_cli.py
@@ -40,7 +40,7 @@ cli = _load_cli()
 
 
 @pytest.fixture
-def cli_env(tmp_path, library, monkeypatch):
+def cli_env(tmp_path, library, dirs_file, monkeypatch):
     """Point the CLI's config loader entirely at temp paths."""
     cfg_path = tmp_path / "config.toml"
     cfg_path.write_text(f'library_root = "{library}"\nport = 8799\n',
@@ -49,7 +49,9 @@ def cli_env(tmp_path, library, monkeypatch):
     monkeypatch.setenv("DL_ROUTER_CONFIG", str(cfg_path))
     monkeypatch.setenv("DL_ROUTER_STATE_DIR", str(state))
     monkeypatch.setenv("DL_ROUTER_TOKEN_FILE", str(tmp_path / "token"))
-    return {"config": cfg_path, "state": state, "library": library}
+    monkeypatch.setenv("DL_ROUTER_DIRS_FILE", str(dirs_file))
+    return {"config": cfg_path, "state": state, "library": library,
+            "dirs_file": dirs_file}
 
 
 def call(argv):
@@ -110,11 +112,14 @@ def test_status_reports_an_unset_library_root(tmp_path, monkeypatch, capsys):
     assert "unset" in capsys.readouterr().out
 
 
-def test_dirs_lists_the_routing_targets(cli_env, capsys):
+def test_dirs_lists_the_routing_targets_with_their_kinds(cli_env, capsys):
     assert call(["dirs"]) == 0
     lines = capsys.readouterr().out.splitlines()
-    assert "Jane Doe\tjanedoe" in lines
-    assert "john-smith\tjohnsmith" in lines
+    # name / normalisation key / kind -- the kind is the third column because
+    # an unclassified directory never auto-files, so "which are unclassified?"
+    # has to be answerable from the listing.
+    assert "Jane Doe\tjanedoe\tperformer" in lines
+    assert "john-smith\tjohnsmith\tperformer" in lines
 
 
 def test_token_prints_a_stable_token_and_creates_it_0600(cli_env, capsys):
@@ -145,21 +150,21 @@ def test_match_on_an_opaque_filename_lands_on_the_catch_all(cli_env, capsys):
 
 
 def test_alias_set_list_and_rm_round_trip(cli_env, capsys):
-    assert call(["alias", "set", "JD", "Jane Doe",
+    assert call(["alias", "set", "JDoe", "Jane Doe",
                  "--site", "example-site.test"]) == 0
     capsys.readouterr()
     assert call(["alias", "list"]) == 0
     listed = capsys.readouterr().out
-    assert "jd\texample-site.test\tJane Doe" in listed
+    assert "jdoe\texample-site.test\tJane Doe" in listed
 
     # ...and the matcher now uses it.
-    assert call(["match", "--tag", "JD", "--site", "example-site.test"]) == 0
+    assert call(["match", "--tag", "JDoe", "--site", "example-site.test"]) == 0
     assert json.loads(capsys.readouterr().out)["confidence"] == 1.0
 
-    assert call(["alias", "rm", "JD", "--site", "example-site.test"]) == 0
+    assert call(["alias", "rm", "JDoe", "--site", "example-site.test"]) == 0
     capsys.readouterr()
     call(["alias", "list"])
-    assert "jd\t" not in capsys.readouterr().out
+    assert "jdoe\t" not in capsys.readouterr().out
 
 
 def test_log_prints_recent_routes(cli_env, capsys):
@@ -352,3 +357,135 @@ def test_fetch_refuses_a_non_http_url(live_sidecar):
 def test_an_unreachable_sidecar_gives_an_actionable_message(cli_env):
     with pytest.raises(SystemExit, match="systemctl --user status dl-router"):
         call(["fetch", "https://example-site.test/v/1", "--dir", "other"])
+
+
+# --- the alias round-trip bug ---------------------------------------------- #
+def test_a_global_alias_can_be_removed_with_the_star_that_list_prints(cli_env,
+                                                                      capsys):
+    """`alias list` printed `*` for a global alias and `alias rm --site '*'`
+    could not remove it: the site is stored as `''`, so it looked for a
+    literal-asterisk site, removed nothing, and printed "alias removed" anyway.
+    The most dangerous alias in the table was the one that could not be removed
+    the obvious way."""
+    store = Store(cli._cfg().db_path)
+    store.upsert_alias("astervale", "Jane Doe", "", source="manual")
+    store.close()
+
+    assert call(["alias", "list"]) == 0
+    assert "astervale\t*\tJane Doe" in capsys.readouterr().out
+
+    assert call(["alias", "rm", "Aster Vale", "--site", "*"]) == 0
+    capsys.readouterr()
+    call(["alias", "list"])
+    assert "astervale" not in capsys.readouterr().out
+
+
+def test_an_empty_site_still_means_global(cli_env, capsys):
+    store = Store(cli._cfg().db_path)
+    store.upsert_alias("astervale", "Jane Doe", "")
+    store.close()
+    assert call(["alias", "rm", "Aster Vale", "--site", ""]) == 0
+
+
+def test_removing_an_alias_that_is_not_there_says_so(cli_env, capsys):
+    """It used to print "alias removed" whether or not a row existed, which is
+    how the un-removable global alias stayed un-removed."""
+    assert call(["alias", "rm", "Aster Vale", "--site", "*"]) == 1
+    assert "no alias" in capsys.readouterr().err
+
+
+def test_alias_set_refuses_a_key_that_looks_like_a_mistake(cli_env):
+    with pytest.raises(SystemExit, match="shorter than"):
+        call(["alias", "set", "JD", "Jane Doe", "--site", "example-site.test"])
+
+
+def test_alias_set_force_writes_it_anyway(cli_env, capsys):
+    assert call(["alias", "set", "JD", "Jane Doe", "--site",
+                 "example-site.test", "--force"]) == 0
+    assert "warning" in capsys.readouterr().err
+
+
+def test_a_structured_alias_key_round_trips_through_set_list_and_rm(cli_env,
+                                                                    capsys):
+    channel = "119283746551234567"
+    assert call(["alias", "set", f"discord:{channel}", "Jane Doe",
+                 "--site", "discord.com"]) == 0
+    capsys.readouterr()
+    call(["alias", "list"])
+    assert f"discord:{channel}\tdiscord.com\tJane Doe" in capsys.readouterr().out
+    assert call(["alias", "rm", f"discord:{channel}",
+                 "--site", "discord.com"]) == 0
+
+
+# --- alias review ----------------------------------------------------------- #
+def test_alias_review_shows_evidence_and_hits_and_flags_the_global_one(cli_env,
+                                                                       capsys):
+    """Nothing surfaced the four bad rows; that is why this command exists."""
+    store = Store(cli._cfg().db_path)
+    store.upsert_alias("astervale", "Jane Doe", "example-site.test",
+                       source="title-subject", evidence="Aster Vale")
+    store.upsert_alias("poster1988", "Jane Doe", "",
+                       source="tag", evidence="poster_1988")
+    store.close()
+    assert call(["alias", "review"]) == 0
+    out = capsys.readouterr().out
+    assert "title-subject" in out and "Aster Vale" in out
+    # The global one is flagged, and it is listed FIRST (riskiest first).
+    assert out.index("poster1988") < out.index("astervale")
+    assert "! poster1988" in out
+    assert "handle" in out or "global scope" in out
+    assert "dl-route alias rm" in out
+
+
+def test_alias_review_json_is_machine_readable(cli_env, capsys):
+    store = Store(cli._cfg().db_path)
+    store.upsert_alias("astervale", "Jane Doe", "example-site.test",
+                       source="title-subject", evidence="Aster Vale")
+    store.close()
+    assert call(["alias", "review", "--json"]) == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert rows[0]["key"] == "astervale"
+    assert rows[0]["source"] == "title-subject"
+    assert rows[0]["hits"] == 1
+    assert rows[0]["suspect"] is None
+
+
+def test_alias_review_on_an_empty_table_is_not_an_error(cli_env, capsys):
+    assert call(["alias", "review"]) == 0
+    assert "no aliases" in capsys.readouterr().out
+
+
+# --- the directory-kind draft ---------------------------------------------- #
+def test_dirs_classify_drafts_a_reviewable_file(cli_env, capsys, tmp_path):
+    out = tmp_path / "draft.toml"
+    assert call(["dirs", "classify", "--out", str(out)]) == 0
+    import tomllib
+    parsed = tomllib.loads(out.read_text(encoding="utf-8"))
+    assert set(parsed) == {"performer", "category"}
+    assert "Jane Doe" in parsed["performer"]
+    # ...and it explains itself rather than emitting a bare list.
+    assert "review" in out.read_text(encoding="utf-8").lower()
+
+
+def test_dirs_classify_prints_to_stdout_by_default(cli_env, capsys):
+    assert call(["dirs", "classify"]) == 0
+    assert "performer = [" in capsys.readouterr().out
+
+
+def test_dirs_classify_refuses_to_clobber_a_reviewed_file(cli_env, tmp_path):
+    out = tmp_path / "draft.toml"
+    out.write_text("performer = []\ncategory = []\n", encoding="utf-8")
+    with pytest.raises(SystemExit, match="--force"):
+        call(["dirs", "classify", "--out", str(out)])
+
+
+def test_status_names_the_unclassified_directories_as_the_reason_it_asks(
+        cli_env, capsys, tmp_path):
+    """`dirs       26` with everything asking and no explanation is the shape
+    of the evening this batch came from."""
+    (tmp_path / "dirs.toml").write_text('performer = []\ncategory = []\n',
+                                        encoding="utf-8")
+    assert call(["status"]) == 0
+    out = capsys.readouterr().out
+    assert "unclassified=6" in out
+    assert "dl-route dirs classify" in out

--- a/scripts/dl-router/tests/test_cli.py
+++ b/scripts/dl-router/tests/test_cli.py
@@ -461,7 +461,8 @@ def test_dirs_classify_drafts_a_reviewable_file(cli_env, capsys, tmp_path):
     assert call(["dirs", "classify", "--out", str(out)]) == 0
     import tomllib
     parsed = tomllib.loads(out.read_text(encoding="utf-8"))
-    assert set(parsed) == {"performer", "category"}
+    assert set(parsed) == {"performer", "category", "ask"}
+    # An already-reviewed classification survives regeneration...
     assert "Jane Doe" in parsed["performer"]
     # ...and it explains itself rather than emitting a bare list.
     assert "review" in out.read_text(encoding="utf-8").lower()

--- a/scripts/dl-router/tests/test_cli.py
+++ b/scripts/dl-router/tests/test_cli.py
@@ -534,3 +534,38 @@ def test_alias_review_shows_backfill_seeds_as_the_global_rows_they_are(cli_env,
     out = capsys.readouterr().out
     assert "backfill-seed" in out
     assert "! janedoe" in out
+
+
+def test_alias_review_reproduces_the_servers_verdict_on_a_structured_row(
+        cli_env, capsys):
+    """PINS THE SPREAD-KEY FIX.
+
+    The server screens on `norm_key(evidence)`; `alias review` used to look up
+    `row["key"]`. For a structured row those never agree — `thread:aster-vale`
+    is not `astervale` — so the tool whose entire job is to surface exactly
+    those rows could not reproduce the server's verdict on them. Reverting the
+    key leaves this failing.
+    """
+    store = Store(cli._cfg().db_path)
+    store.upsert_alias("thread:aster-vale", "Jane Doe", "example-site.test",
+                       source="thread-slug", evidence="aster vale")
+    for chosen in ("Jane Doe", "john-smith"):
+        store.add_example({"page": {"tags": ["Aster Vale"],
+                                    "site": "example-site.test"}}, chosen)
+    store.close()
+    assert call(["alias", "review", "--json"]) == 0
+    row = json.loads(capsys.readouterr().out)[0]
+    assert row["key"] == "thread:aster-vale"
+    assert row["suspect"] and "different directories" in row["suspect"]
+
+
+def test_alias_review_does_not_flag_a_structured_row_with_no_spread(cli_env,
+                                                                    capsys):
+    """The other half: the lookup has to be able to come back clean too, or the
+    test above would pass with any always-suspect key."""
+    store = Store(cli._cfg().db_path)
+    store.upsert_alias("thread:aster-vale", "Jane Doe", "example-site.test",
+                       source="thread-slug", evidence="aster vale")
+    store.close()
+    assert call(["alias", "review", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out)[0]["suspect"] is None

--- a/scripts/dl-router/tests/test_dirkinds.py
+++ b/scripts/dl-router/tests/test_dirkinds.py
@@ -108,18 +108,34 @@ def test_the_draft_is_valid_toml_and_covers_every_directory():
     assert listed == {norm_key(n) for n in DRAFT_DIRS}
 
 
-def test_the_draft_splits_names_from_categories():
+def test_the_draft_guesses_the_ASKING_side_for_everything_ambiguous():
+    """The draft must never silently authorise auto-filing.
+
+    Nothing available to a generator distinguishes "Ada Lovelace" from "Field
+    Recordings" -- two capitalised words either way -- so resolving that
+    ambiguity towards `performer` meant a skimmed review turned category
+    directories into auto-filers. (The module's own docstring example, "Field
+    Recordings", drafted as a performer.) Ambiguous now lands in `category`,
+    which ASKS: skim it and the worst case is a directory that asks too often.
+    """
     parsed = tomllib.loads(dk.draft(DRAFT_DIRS))
-    assert "Jane Doe" in parsed["performer"]
-    assert "john-smith" in parsed["performer"]
-    # single word, digits, too many words, and the shared-vocabulary rule:
-    # every word of "Live Sets" / "Archive Sets" / "Live Archive" also appears
-    # in another directory, which is what a taxonomy looks like and what a
-    # person's name does not.
-    for name in ("Compilations", "Season 2024",
-                 "A Very Long Directory Name Indeed", "Live Sets",
-                 "Archive Sets", "Live Archive"):
-        assert name in parsed["category"], name
+    assert parsed["performer"] == []
+    assert set(parsed["category"]) == set(DRAFT_DIRS)
+
+
+def test_an_ambiguous_line_says_it_may_need_moving_up():
+    text = dk.draft(["Jane Doe"])
+    line = next(l for l in text.splitlines() if "Jane Doe" in l)
+    assert "MOVE IT UP" in line
+
+
+def test_the_draft_still_explains_the_unambiguous_ones(): 
+    text = dk.draft(DRAFT_DIRS)
+    reasons = {l.split("#", 1)[1].strip() for l in text.splitlines()
+               if l.strip().startswith('"')}
+    assert "a single word" in reasons
+    assert "contains digits" in reasons
+    assert "every word is shared with other directories" in reasons
 
 
 def test_every_draft_line_carries_the_reason_it_landed_there():
@@ -190,3 +206,16 @@ def test_the_gate_cannot_be_routed_around_by_the_host_prior():
         MatchContext(tags=("Jane Doe",), site="site.test"),
         host_prior="Jane Doe")
     assert res.auto is False
+
+
+def test_a_malformed_file_drops_the_picker_overlay_too(tmp_path):
+    """FAIL CLOSED, completely. `merged` used to be seeded from the SQLite
+    picker overlay BEFORE parsing, so picker-assigned `performer` kinds
+    survived a broken dirs.toml and kept auto-filing while the operator
+    believed their edit had disabled it. The overlay is machine state and
+    syntactically fine, but the file is the authority over it, and "I cannot
+    read the authority" is not a state in which to keep auto-filing."""
+    path = write(tmp_path, "this is not = valid toml [[[")
+    kinds = dk.DirKinds.load(path, overlay={"Jane Doe": KIND_PERFORMER})
+    assert kinds.kind("Jane Doe") == KIND_UNKNOWN
+    assert kinds.error

--- a/scripts/dl-router/tests/test_dirkinds.py
+++ b/scripts/dl-router/tests/test_dirkinds.py
@@ -7,6 +7,7 @@ auto-file rules. Fixtures are synthetic throughout.
 """
 from __future__ import annotations
 
+import pathlib
 import sys
 import tomllib
 from pathlib import Path
@@ -101,32 +102,58 @@ DRAFT_DIRS = ["Jane Doe", "john-smith", "Field Notes", "Compilations",
               "A Very Long Directory Name Indeed"]
 
 
+def all_listed(parsed):
+    return parsed["performer"] + parsed["category"] + parsed[dk.ASK_LIST]
+
+
 def test_the_draft_is_valid_toml_and_covers_every_directory():
-    text = dk.draft(DRAFT_DIRS)
-    parsed = tomllib.loads(text)
-    listed = {norm_key(n) for n in parsed["performer"] + parsed["category"]}
-    assert listed == {norm_key(n) for n in DRAFT_DIRS}
+    parsed = tomllib.loads(dk.draft(DRAFT_DIRS))
+    assert {norm_key(n) for n in all_listed(parsed)} \
+        == {norm_key(n) for n in DRAFT_DIRS}
 
 
-def test_the_draft_guesses_the_ASKING_side_for_everything_ambiguous():
+def test_the_draft_never_guesses_onto_the_auto_filing_side():
     """The draft must never silently authorise auto-filing.
 
     Nothing available to a generator distinguishes "Ada Lovelace" from "Field
     Recordings" -- two capitalised words either way -- so resolving that
     ambiguity towards `performer` meant a skimmed review turned category
     directories into auto-filers. (The module's own docstring example, "Field
-    Recordings", drafted as a performer.) Ambiguous now lands in `category`,
-    which ASKS: skim it and the worst case is a directory that asks too often.
+    Recordings", drafted as a performer.)
     """
     parsed = tomllib.loads(dk.draft(DRAFT_DIRS))
     assert parsed["performer"] == []
-    assert set(parsed["category"]) == set(DRAFT_DIRS)
 
 
-def test_an_ambiguous_line_says_it_may_need_moving_up():
-    text = dk.draft(["Jane Doe"])
-    line = next(l for l in text.splitlines() if "Jane Doe" in l)
-    assert "MOVE IT UP" in line
+def test_the_ambiguous_ones_go_to_a_list_that_is_NOT_a_kind():
+    """`ask` is ignored by the loader, so everything in it is unclassified and
+    therefore asks. Folding them into `category` instead was safe, but it threw
+    away the labour saving for a library that is mostly people."""
+    parsed = tomllib.loads(dk.draft(DRAFT_DIRS))
+    assert "Jane Doe" in parsed[dk.ASK_LIST]
+    assert "john-smith" in parsed[dk.ASK_LIST]
+    # ...and it is not a kind at all.
+    assert dk.ASK_LIST not in dk.KINDS
+
+
+def test_the_ask_list_really_does_read_as_unclassified(tmp_path):
+    path = write(tmp_path, 'performer = []\ncategory = []\nask = ["Jane Doe"]\n')
+    kinds = dk.DirKinds.load(path)
+    assert kinds.kind("Jane Doe") == KIND_UNKNOWN
+    assert not kinds.error
+
+
+def test_an_unknown_list_name_is_reported(tmp_path):
+    path = write(tmp_path, 'performer = []\ncategory = []\nperfomer = []\n')
+    assert "unknown list" in (dk.DirKinds.load(path).error or "")
+
+
+def test_the_draft_still_sorts_what_it_can_prove():
+    parsed = tomllib.loads(dk.draft(DRAFT_DIRS))
+    for name in ("Compilations", "Season 2024",
+                 "A Very Long Directory Name Indeed", "Live Sets",
+                 "Archive Sets", "Live Archive"):
+        assert name in parsed["category"], name
 
 
 def test_the_draft_still_explains_the_unambiguous_ones(): 
@@ -156,13 +183,12 @@ def test_the_draft_preserves_an_existing_classification(tmp_path):
 
 def test_a_directory_name_with_toml_metacharacters_survives_the_round_trip():
     tricky = ['He said "hi"', "back\\slash", "tab\there"]
-    parsed = tomllib.loads(dk.draft(tricky))
-    assert set(parsed["performer"] + parsed["category"]) == set(tricky)
+    assert set(all_listed(tomllib.loads(dk.draft(tricky)))) == set(tricky)
 
 
 def test_an_empty_library_still_produces_a_usable_file():
-    parsed = tomllib.loads(dk.draft([]))
-    assert parsed == {"performer": [], "category": []}
+    assert tomllib.loads(dk.draft([])) == {"performer": [], "category": [],
+                                           dk.ASK_LIST: []}
 
 
 # --- the auto-file gate ----------------------------------------------------- #

--- a/scripts/dl-router/tests/test_dirkinds.py
+++ b/scripts/dl-router/tests/test_dirkinds.py
@@ -1,0 +1,192 @@
+"""Directory kinds: the classification file, the draft generator, and the
+auto-file gate it drives.
+
+The library is not purely subject-keyed — some directories collect unattributed
+material by category — and the two need opposite learning rules and opposite
+auto-file rules. Fixtures are synthetic throughout.
+"""
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import dirkinds as dk  # noqa: E402
+from matcher import (  # noqa: E402
+    KIND_CATEGORY, KIND_PERFORMER, KIND_UNKNOWN, MatchContext, Matcher,
+    norm_key,
+)
+
+
+def write(tmp_path, body: str) -> Path:
+    path = tmp_path / "dirs.toml"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# --- loading ---------------------------------------------------------------- #
+def test_a_missing_file_leaves_everything_unclassified(tmp_path):
+    kinds = dk.DirKinds.load(tmp_path / "nope.toml")
+    assert kinds.present is False
+    assert kinds.kind("Jane Doe") == KIND_UNKNOWN
+    assert kinds.error is None
+
+
+def test_the_two_lists_classify(tmp_path):
+    path = write(tmp_path, 'performer = ["Jane Doe"]\ncategory = ["Field Notes"]\n')
+    kinds = dk.DirKinds.load(path)
+    assert kinds.kind("Jane Doe") == KIND_PERFORMER
+    assert kinds.kind("Field Notes") == KIND_CATEGORY
+    assert kinds.kind("Someone Else") == KIND_UNKNOWN
+
+
+@pytest.mark.parametrize("spelling", ["jane-doe", "JANE_DOE", "  Jane Doe  "])
+def test_classification_folds_the_naming_conventions(tmp_path, spelling):
+    """The same convention folding that means existing directories are never
+    renamed: a dirs.toml written in a different case still classifies."""
+    path = write(tmp_path, f'performer = ["{spelling}"]\ncategory = []\n')
+    assert dk.DirKinds.load(path).kind("Jane Doe") == KIND_PERFORMER
+
+
+def test_a_directory_in_both_lists_is_ambiguous_and_therefore_unknown(tmp_path):
+    """Unknown ASKS. Resolving to whichever list happened to be read last would
+    silently pick a rule for a directory the operator was unsure about."""
+    path = write(tmp_path,
+                 'performer = ["Jane Doe"]\ncategory = ["jane-doe"]\n')
+    kinds = dk.DirKinds.load(path)
+    assert kinds.kind("Jane Doe") == KIND_UNKNOWN
+    assert kinds.error and "both lists" in kinds.error
+
+
+def test_a_malformed_file_degrades_instead_of_raising(tmp_path):
+    """This is loaded on the /match path, which has a 400 ms budget before the
+    extension gives up. A parse error there must not take matching down."""
+    path = write(tmp_path, "this is not = valid toml [[[")
+    kinds = dk.DirKinds.load(path)
+    assert kinds.error and kinds.kind("Jane Doe") == KIND_UNKNOWN
+
+
+def test_a_wrongly_typed_list_is_reported_not_obeyed(tmp_path):
+    path = write(tmp_path, 'performer = "Jane Doe"\ncategory = []\n')
+    kinds = dk.DirKinds.load(path)
+    assert kinds.kind("Jane Doe") == KIND_UNKNOWN
+    assert kinds.error
+
+
+def test_the_human_file_wins_over_the_picker_overlay(tmp_path):
+    """The file is the thing the operator reviewed."""
+    path = write(tmp_path, 'performer = ["Jane Doe"]\ncategory = []\n')
+    kinds = dk.DirKinds.load(path, overlay={"Jane Doe": KIND_CATEGORY,
+                                            "Field Notes": KIND_CATEGORY})
+    assert kinds.kind("Jane Doe") == KIND_PERFORMER
+    assert kinds.kind("Field Notes") == KIND_CATEGORY
+
+
+def test_counts_and_unclassified(tmp_path):
+    path = write(tmp_path, 'performer = ["Jane Doe"]\ncategory = ["Field Notes"]\n')
+    kinds = dk.DirKinds.load(path)
+    names = ["Jane Doe", "Field Notes", "Nobody Knows"]
+    assert kinds.counts(names) == {KIND_PERFORMER: 1, KIND_CATEGORY: 1,
+                                   KIND_UNKNOWN: 1}
+    assert kinds.unclassified(names) == ["Nobody Knows"]
+
+
+# --- the draft generator ---------------------------------------------------- #
+DRAFT_DIRS = ["Jane Doe", "john-smith", "Field Notes", "Compilations",
+              "Live Sets", "Archive Sets", "Live Archive", "Season 2024",
+              "A Very Long Directory Name Indeed"]
+
+
+def test_the_draft_is_valid_toml_and_covers_every_directory():
+    text = dk.draft(DRAFT_DIRS)
+    parsed = tomllib.loads(text)
+    listed = {norm_key(n) for n in parsed["performer"] + parsed["category"]}
+    assert listed == {norm_key(n) for n in DRAFT_DIRS}
+
+
+def test_the_draft_splits_names_from_categories():
+    parsed = tomllib.loads(dk.draft(DRAFT_DIRS))
+    assert "Jane Doe" in parsed["performer"]
+    assert "john-smith" in parsed["performer"]
+    # single word, digits, too many words, and the shared-vocabulary rule:
+    # every word of "Live Sets" / "Archive Sets" / "Live Archive" also appears
+    # in another directory, which is what a taxonomy looks like and what a
+    # person's name does not.
+    for name in ("Compilations", "Season 2024",
+                 "A Very Long Directory Name Indeed", "Live Sets",
+                 "Archive Sets", "Live Archive"):
+        assert name in parsed["category"], name
+
+
+def test_every_draft_line_carries_the_reason_it_landed_there():
+    """The review action is "does that reason hold?", not "what even is this?"."""
+    text = dk.draft(DRAFT_DIRS)
+    for line in text.splitlines():
+        if line.strip().startswith('"'):
+            assert "#" in line, line
+
+
+def test_the_draft_preserves_an_existing_classification(tmp_path):
+    """Re-running the generator after a partial review must not undo it."""
+    path = write(tmp_path, 'performer = ["Compilations"]\ncategory = []\n')
+    parsed = tomllib.loads(
+        dk.draft(DRAFT_DIRS, known=dk.DirKinds.load(path)))
+    assert "Compilations" in parsed["performer"]
+
+
+def test_a_directory_name_with_toml_metacharacters_survives_the_round_trip():
+    tricky = ['He said "hi"', "back\\slash", "tab\there"]
+    parsed = tomllib.loads(dk.draft(tricky))
+    assert set(parsed["performer"] + parsed["category"]) == set(tricky)
+
+
+def test_an_empty_library_still_produces_a_usable_file():
+    parsed = tomllib.loads(dk.draft([]))
+    assert parsed == {"performer": [], "category": []}
+
+
+# --- the auto-file gate ----------------------------------------------------- #
+def alias_matcher(kinds):
+    return Matcher(["Jane Doe", "Field Notes", "other"],
+                   {("janedoe", "site.test"): "Jane Doe",
+                    ("fieldnotes", "site.test"): "Field Notes"},
+                   dir_kinds=kinds)
+
+
+def test_a_performer_directory_auto_files():
+    res = alias_matcher({"Jane Doe": KIND_PERFORMER}).match(
+        MatchContext(tags=("Jane Doe",), site="site.test"))
+    assert res.dir == "Jane Doe" and res.auto is True
+
+
+def test_a_category_directory_always_asks_however_high_it_scores():
+    """A tag legitimately identifies a category directory, but a tag is a weak
+    claim about any ONE file — so it is confirmed every time."""
+    res = alias_matcher({"Field Notes": KIND_CATEGORY}).match(
+        MatchContext(tags=("Field Notes",), site="site.test"))
+    assert res.dir == "Field Notes"
+    assert res.confidence == pytest.approx(1.0)
+    assert res.auto is False
+    assert "category" in res.reason
+
+
+def test_an_unclassified_directory_never_auto_files():
+    """Absence of a classification is not permission."""
+    res = alias_matcher({}).match(
+        MatchContext(tags=("Jane Doe",), site="site.test"))
+    assert res.dir == "Jane Doe"
+    assert res.auto is False
+    assert "unclassified" in res.reason
+    # ...and it says what to do about it.
+    assert "classify" in res.reason
+
+
+def test_the_gate_cannot_be_routed_around_by_the_host_prior():
+    res = alias_matcher({}).match(
+        MatchContext(tags=("Jane Doe",), site="site.test"),
+        host_prior="Jane Doe")
+    assert res.auto is False

--- a/scripts/dl-router/tests/test_dirkinds.py
+++ b/scripts/dl-router/tests/test_dirkinds.py
@@ -60,7 +60,7 @@ def test_a_directory_in_both_lists_is_ambiguous_and_therefore_unknown(tmp_path):
                  'performer = ["Jane Doe"]\ncategory = ["jane-doe"]\n')
     kinds = dk.DirKinds.load(path)
     assert kinds.kind("Jane Doe") == KIND_UNKNOWN
-    assert kinds.error and "both lists" in kinds.error
+    assert kinds.error and "more than one list" in kinds.error
 
 
 def test_a_malformed_file_degrades_instead_of_raising(tmp_path):
@@ -263,5 +263,16 @@ def test_a_name_in_both_ask_and_performer_is_ambiguous(tmp_path):
 def test_a_clean_ask_entry_is_not_an_error(tmp_path):
     path = write(tmp_path, 'performer = []\ncategory = []\nask = ["Jane Doe"]\n')
     kinds = dk.DirKinds.load(path)
+    assert kinds.kind("Jane Doe") == KIND_UNKNOWN
+    assert not kinds.error
+
+
+def test_an_ask_entry_overrides_a_picker_assigned_kind(tmp_path):
+    """The reviewed file is the authority over the machine overlay, and `ask`
+    is a decision too: parking a directory there has to be able to UNDO a kind
+    the picker assigned, or a reclassification could never take an auto-filing
+    directory back out of service."""
+    path = write(tmp_path, 'performer = []\ncategory = []\nask = ["Jane Doe"]\n')
+    kinds = dk.DirKinds.load(path, overlay={"Jane Doe": KIND_PERFORMER})
     assert kinds.kind("Jane Doe") == KIND_UNKNOWN
     assert not kinds.error

--- a/scripts/dl-router/tests/test_dirkinds.py
+++ b/scripts/dl-router/tests/test_dirkinds.py
@@ -245,3 +245,23 @@ def test_a_malformed_file_drops_the_picker_overlay_too(tmp_path):
     kinds = dk.DirKinds.load(path, overlay={"Jane Doe": KIND_PERFORMER})
     assert kinds.kind("Jane Doe") == KIND_UNKNOWN
     assert kinds.error
+
+
+def test_a_name_in_both_ask_and_performer_is_ambiguous(tmp_path):
+    """A half-finished review — the line copied to `ask` but the original left
+    in `performer` — used to resolve to `performer` with no error, so the very
+    directory the operator had just parked as undecided carried on auto-filing.
+    Ambiguity resolves to unknown, which is this module's rule everywhere else.
+    """
+    path = write(tmp_path,
+                 'performer = ["Jane Doe"]\ncategory = []\nask = ["Jane Doe"]\n')
+    kinds = dk.DirKinds.load(path)
+    assert kinds.kind("Jane Doe") == KIND_UNKNOWN
+    assert kinds.error
+
+
+def test_a_clean_ask_entry_is_not_an_error(tmp_path):
+    path = write(tmp_path, 'performer = []\ncategory = []\nask = ["Jane Doe"]\n')
+    kinds = dk.DirKinds.load(path)
+    assert kinds.kind("Jane Doe") == KIND_UNKNOWN
+    assert not kinds.error

--- a/scripts/dl-router/tests/test_learning.py
+++ b/scripts/dl-router/tests/test_learning.py
@@ -23,8 +23,8 @@ import server as S  # noqa: E402
 from conftest import SAMPLE_DIRS  # noqa: E402
 from fetcher import Fetcher  # noqa: E402
 from matcher import (  # noqa: E402
-    DISCORD_SITE, KIND_CATEGORY, KIND_PERFORMER, MatchContext, discord_alias_key,
-    thread_alias_key,
+    CHROME_DIR_SPREAD, DISCORD_SITE, KIND_CATEGORY, KIND_PERFORMER,
+    MIN_ALIAS_KEY_LEN, MatchContext, discord_alias_key, thread_alias_key,
 )
 
 CHANNEL = "119283746551234567"
@@ -459,3 +459,68 @@ def test_an_initialised_name_is_exempt_from_the_length_floor_but_a_word_is_not()
     from matcher import suspicious_alias_key
     assert suspicious_alias_key("M.I.A.", dir_names=["Jane Doe"]) is None
     assert suspicious_alias_key("set", dir_names=["Jane Doe"])
+
+
+# --- pins on the PERMISSIVE changes ------------------------------------------ #
+# Across this PR the defects have been in WIDENED behaviour while every pin sat
+# on TIGHTENED behaviour, so the riskiest lines were revertible with a green
+# suite. Each test below fails when its permissive change is deleted.
+def test_a_re_point_wins_even_once_the_phrase_reads_as_chrome(kinded_app):
+    """PINS THE SCREEN BYPASS at server.learn's `screen()`.
+
+    Deleting the bypass leaves this failing. The earlier
+    `test_a_second_correction_overrules_the_first` does NOT cover it: with the
+    catch-all excluded from spread, its fixture only reaches spread 1, so the
+    screen passes anyway and the bypass is never load-bearing. It becomes
+    load-bearing on the THIRD correction, which is what this builds directly.
+    """
+    key = thread_alias_key("aster vale collection")
+    # The operator's own history has now put this phrase on two directories,
+    # which is exactly what the chrome measure looks for.
+    for chosen in ("Mary_Major", "acme-studio"):
+        kinded_app.store.add_example(
+            {"page": {"tags": ["Aster Vale Collection"],
+                      "site": "someforum.test"}}, chosen)
+    spread = kinded_app.store.phrase_dir_spread(other_dir="other")
+    assert spread.get("astervalecollection", 0) >= CHROME_DIR_SPREAD, \
+        "fixture must actually trip the screen, or this pins nothing"
+    # ...and the router already learned this key once.
+    kinded_app.store.upsert_alias(key, "Jane Doe", "someforum.test",
+                                  source="thread-slug",
+                                  evidence="aster vale collection")
+
+    out = kinded_app.learn({"context": forum_context([]),
+                            "chosenDir": "john-smith", "confirmed": True})
+    assert key in {w["key"] for w in out["written"]}, out["skipped"]
+    assert kinded_app.store.alias(key, "someforum.test") == "john-smith"
+
+
+def test_the_same_phrase_is_still_refused_when_there_is_nothing_to_re_point(
+        kinded_app):
+    """The other half of the pin: identical fixture, no existing row, refused.
+    Without this the test above would also pass if the screen were removed."""
+    for chosen in ("Mary_Major", "acme-studio"):
+        kinded_app.store.add_example(
+            {"page": {"tags": ["Aster Vale Collection"],
+                      "site": "someforum.test"}}, chosen)
+    out = kinded_app.learn({"context": forum_context([]),
+                            "chosenDir": "john-smith", "confirmed": True})
+    assert thread_alias_key("aster vale collection") not in \
+        {w["key"] for w in out["written"]}
+
+
+@pytest.mark.parametrize("junk", ["Download Video", "Free HD Clip",
+                                  "the and of"])
+def test_a_stopword_phrase_is_refused_even_well_over_the_length_floor(junk):
+    """PINS THE STOPWORD-FIRST RULE.
+
+    The earlier parametrized cases (`gif`, `mp4`, `www`, `com`) are all under
+    the 4-character floor, so the floor catches them and deleting the stopword
+    rule changes nothing. These fold to long keys — `downloadvideo` is thirteen
+    characters — and are caught ONLY by the stopword rule. That rule also has
+    to run FIRST: with no content tokens, the shared-vocabulary and handle
+    rules below it both pass silently.
+    """
+    from matcher import norm_key, suspicious_alias_key
+    assert len(norm_key(junk)) > MIN_ALIAS_KEY_LEN
+    assert suspicious_alias_key(junk, dir_names=["Jane Doe"])

--- a/scripts/dl-router/tests/test_learning.py
+++ b/scripts/dl-router/tests/test_learning.py
@@ -1,0 +1,279 @@
+"""The learning rule: only the DISCRIMINATING signal, and never globally.
+
+The regression this file exists for. On the first forum download, `/learn`
+wrote an alias for every captured subject phrase — which on that page meant a
+forum section name and two other posters' usernames — plus one at GLOBAL scope,
+so anything carrying that username on ANY site would have auto-filed into a
+stranger's directory at alias confidence. Four rows had to be deleted by hand,
+and nothing in the system had surfaced them.
+
+`App.learn` is HTTP-free by design, so these drive it directly.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import config as config_mod  # noqa: E402
+import server as S  # noqa: E402
+from conftest import SAMPLE_DIRS  # noqa: E402
+from fetcher import Fetcher  # noqa: E402
+from matcher import (  # noqa: E402
+    DISCORD_SITE, KIND_CATEGORY, KIND_PERFORMER, MatchContext, discord_alias_key,
+    thread_alias_key,
+)
+
+CHANNEL = "119283746551234567"
+CDN = f"https://cdn.discordapp.com/attachments/{CHANNEL}/998877665544332211/clip.mp4"
+THREAD = "https://someforum.test/threads/aster-vale-collection.481920/"
+
+# "Jane Doe" is a person; "acme-studio" collects unattributed material.
+KINDS_TOML = """\
+performer = ["Jane Doe", "john-smith", "Mary_Major", "Aster Vale"]
+category = ["acme-studio"]
+"""
+
+
+class Spawner:
+    def __call__(self, argv, cwd=None):
+        class P:
+            def poll(self_inner):
+                return None
+
+            def terminate(self_inner):
+                pass
+        return P()
+
+
+@pytest.fixture
+def kinded_app(tmp_path, library, store, dir_index, file_index, clock):
+    path = tmp_path / "dirs.toml"
+    path.write_text(KINDS_TOML, encoding="utf-8")
+    data = config_mod._deep_merge(config_mod.DEFAULTS, {
+        "library_root": str(library), "host": "127.0.0.1", "port": 0})
+    cfg = config_mod.Config(data, path=tmp_path / "config.toml",
+                            state_dir=tmp_path / "state",
+                            token_file=tmp_path / "token", dirs_file=path)
+    return S.App(cfg, store=store, dir_index=dir_index, file_index=file_index,
+                 fetcher=Fetcher(library, runner=Spawner(), clock=clock),
+                 clock=clock)
+
+
+def forum_context(tags):
+    """The shape that produced the four bad rows: a forum page whose tag list is
+    section names and other posters' usernames."""
+    return {
+        "url": "https://someforum.test/attachments/opaque-9f2.mp4",
+        "filename": "opaque-9f2.mp4",
+        "page": {"url": THREAD, "site": "someforum.test",
+                 "title": "Aster Vale Collection | Some Forum", "tags": tags},
+    }
+
+
+# --- the regression --------------------------------------------------------- #
+def test_a_tag_never_becomes_an_alias_for_a_performer_directory(kinded_app):
+    chrome = ["General Discussion", "poster_1988", "uploader42"]
+    out = kinded_app.learn({"context": forum_context(chrome),
+                            "chosenDir": "Aster Vale", "confirmed": True})
+    written = {w["key"] for w in out["written"]}
+    for tag in chrome:
+        from matcher import norm_key
+        assert norm_key(tag) not in written, tag
+    assert kinded_app.store.alias("generaldiscussion", "someforum.test") is None
+    assert kinded_app.store.alias("poster1988", "") is None
+
+
+def test_learning_never_writes_a_global_alias(kinded_app):
+    """A global alias applies on every site at once — the widest blast radius
+    the store has, and the least evidence supports it. `dl-route alias set
+    --site '*'` still exists for a deliberate one."""
+    for chosen, ctx in (("Aster Vale", forum_context(["Aster Vale"])),
+                        ("acme-studio", forum_context(["Acme Studio"])),
+                        ("Jane Doe", {"url": CDN, "page": {}})):
+        kinded_app.learn({"context": ctx, "chosenDir": chosen,
+                          "confirmed": True})
+    assert all(site for (_key, site) in kinded_app.store.alias_map())
+
+
+def test_a_performer_learns_the_thread_slug_and_the_title_subject(kinded_app):
+    out = kinded_app.learn({"context": forum_context(["General Discussion"]),
+                            "chosenDir": "Aster Vale", "confirmed": True})
+    written = {(w["key"], w["site"]) for w in out["written"]}
+    assert (thread_alias_key("aster vale collection"), "someforum.test") in written
+    # The de-branded title, NOT the raw "... | Some Forum".
+    assert ("astervalecollection", "someforum.test") in written
+
+
+def test_a_discord_download_learns_its_channel_and_nothing_else(kinded_app):
+    """Six of nine real downloads looked exactly like this: no page context at
+    all. The channel id is the only thing there is, and it is enough."""
+    out = kinded_app.learn({
+        "context": {"url": CDN, "filename": "clip.mp4",
+                    "page": {"tags": [], "title": "", "url": ""}},
+        "chosenDir": "Jane Doe", "confirmed": True})
+    assert [(w["key"], w["site"]) for w in out["written"]] == [
+        (discord_alias_key(CHANNEL), DISCORD_SITE)]
+
+
+def test_the_learned_channel_then_auto_files_the_next_download(kinded_app):
+    kinded_app.learn({"context": {"url": CDN, "page": {}},
+                      "chosenDir": "Jane Doe", "confirmed": True})
+    res = kinded_app.match({"url": CDN.replace("clip.mp4", "another.mp4"),
+                            "filename": "another.mp4", "page": {}})
+    assert res["dir"] == "Jane Doe"
+    assert res["auto"] is True
+
+
+# --- the category rule ------------------------------------------------------ #
+def test_a_category_directory_does_learn_a_tag_but_only_site_scoped(kinded_app):
+    out = kinded_app.learn({"context": forum_context(["Field Recordings"]),
+                            "chosenDir": "acme-studio", "confirmed": True})
+    assert ("fieldrecordings", "someforum.test") in {
+        (w["key"], w["site"]) for w in out["written"]}
+    assert kinded_app.store.alias("fieldrecordings", "") is None
+
+
+def test_a_category_tag_is_not_learned_without_an_explicit_confirmation(
+        kinded_app):
+    out = kinded_app.learn({"context": forum_context(["Field Recordings"]),
+                            "chosenDir": "acme-studio"})
+    assert not [w for w in out["written"] if w["source"] == "tag"]
+    assert out["skipped"]
+
+
+def test_a_category_confirmation_is_capped(kinded_app):
+    """A tag list can hold 64 entries. The user confirmed one directory, not
+    sixty-four synonyms for it."""
+    many = [f"Tag Number {n}" for n in range(20)]
+    out = kinded_app.learn({"context": forum_context(many),
+                            "chosenDir": "acme-studio", "confirmed": True})
+    assert len([w for w in out["written"] if w["source"] == "tag"]) \
+        <= S.MAX_LEARNED_TAGS
+
+
+def test_a_suspicious_tag_is_refused_and_reported(kinded_app):
+    """The screen catches the failure CLASS, not four specific strings."""
+    out = kinded_app.learn({"context": forum_context(["Some Forum", "JD"]),
+                            "chosenDir": "acme-studio", "confirmed": True})
+    assert not [w for w in out["written"] if w["source"] == "tag"]
+    reasons = " ".join(s["why"] for s in out["skipped"])
+    assert "site name" in reasons and "shorter than" in reasons
+
+
+def test_a_tag_seen_on_many_directories_stops_being_learnable(kinded_app):
+    """Data-driven, from the labelled examples the router already stores: a
+    subject tag appears on ONE directory's pages; a section name appears on
+    everything, so it accumulates spread."""
+    for chosen in ("Jane Doe", "john-smith"):
+        kinded_app.learn({"context": forum_context(["Common Section"]),
+                          "chosenDir": chosen, "confirmed": True})
+    out = kinded_app.learn({"context": forum_context(["Common Section"]),
+                            "chosenDir": "acme-studio", "confirmed": True})
+    assert kinded_app.store.alias("commonsection", "someforum.test") is None
+    assert any("different directories" in s["why"] for s in out["skipped"])
+
+
+# --- provenance + kinds ----------------------------------------------------- #
+def test_every_learned_alias_records_what_produced_it(kinded_app):
+    kinded_app.learn({"context": {"url": CDN, "page": {}},
+                      "chosenDir": "Jane Doe", "confirmed": True})
+    row = kinded_app.store.alias_rows()[0]
+    assert row["source"] == "discord-channel"
+    assert CHANNEL in row["evidence"]
+    assert row["hits"] == 1
+
+
+def test_mkdir_records_the_kind_the_picker_asked_for(kinded_app):
+    out = kinded_app.mkdir({"name": "Aster Nightingale",
+                            "kind": KIND_PERFORMER})
+    assert out["kind"] == KIND_PERFORMER
+    assert kinded_app.dir_kinds().kind("Aster Nightingale") == KIND_PERFORMER
+
+
+def test_mkdir_without_a_kind_leaves_the_directory_unclassified(kinded_app):
+    """...and an unclassified directory never auto-files, which is why the
+    picker asks."""
+    out = kinded_app.mkdir({"name": "Aster Nightingale"})
+    assert out["kind"] == "unknown"
+
+
+def test_mkdir_refuses_an_invented_kind(kinded_app):
+    from safety import UnsafeName
+    with pytest.raises(UnsafeName):
+        kinded_app.mkdir({"name": "Aster Nightingale", "kind": "performer!"})
+
+
+def test_the_snapshot_carries_each_directory_kind(kinded_app):
+    """The extension's cached fallback matcher applies the same gate, or a
+    sidecar timeout would auto-file into a category the sidecar would have
+    asked about."""
+    snap = kinded_app.dirs_snapshot()
+    kinds = {d["name"]: d["kind"] for d in snap["dirs"]}
+    assert kinds["Jane Doe"] == KIND_PERFORMER
+    assert kinds["acme-studio"] == KIND_CATEGORY
+    assert kinds["other"] == "unknown"
+    assert set(kinds) == set(SAMPLE_DIRS)
+
+
+def test_healthz_reports_how_many_directories_are_unclassified(kinded_app):
+    out = kinded_app.healthz()
+    assert out["dirKinds"]["unknown"] >= 1
+    assert out["dirsFile"]["present"] is True
+
+
+def test_a_category_match_asks_even_from_a_confirmed_identity_alias(kinded_app):
+    """KNOWN CONSEQUENCE, recorded on purpose: a confirmed Discord channel
+    pointing at a CATEGORY directory keeps asking forever. That is the rule as
+    specified — a category is always confirmed — and it is flagged in the PR
+    body rather than quietly excepted here."""
+    kinded_app.learn({"context": {"url": CDN, "page": {}},
+                      "chosenDir": "acme-studio", "confirmed": True})
+    res = kinded_app.match({"url": CDN, "filename": "clip.mp4", "page": {}})
+    assert res["dir"] == "acme-studio"
+    assert res["confidence"] == pytest.approx(1.0)
+    assert res["auto"] is False
+
+
+def test_the_context_still_lands_in_the_example_log(kinded_app):
+    kinded_app.learn({"context": forum_context(["Anything"]),
+                      "chosenDir": "Jane Doe", "autoDir": "other"})
+    example = kinded_app.store.examples()[0]
+    assert example["chosen_dir"] == "Jane Doe"
+    assert example["auto_dir"] == "other"
+
+
+def test_learn_still_refuses_an_unknown_directory(kinded_app):
+    from safety import UnsafeName
+    with pytest.raises(UnsafeName):
+        kinded_app.learn({"context": forum_context([]),
+                          "chosenDir": "Not A Real Dir"})
+
+
+def test_the_host_prior_is_still_recorded(kinded_app):
+    kinded_app.learn({"context": forum_context([]), "chosenDir": "Jane Doe"})
+    assert kinded_app.store.host_prior("someforum.test") == "Jane Doe"
+
+
+def test_a_context_with_nothing_provable_learns_nothing(kinded_app):
+    """A direct-link download with no page, no thread and no channel. It used
+    to produce a GLOBAL alias off the filename-derived phrase."""
+    out = kinded_app.learn({
+        "context": {"url": "https://filehost.test/d/AbCdEf",
+                    "filename": "opaque.mp4", "page": {}},
+        "chosenDir": "Jane Doe", "confirmed": True})
+    assert out["written"] == []
+    assert kinded_app.store.alias_count() == 0
+
+
+def test_the_kind_gate_reads_a_live_edit_of_the_dirs_file(kinded_app):
+    """The classification is a plain file the operator edits; a stale cache
+    would mean an edit does not take effect until the sidecar restarts."""
+    ctx = MatchContext(tags=("Jane Doe",), site="someforum.test")
+    assert kinded_app.matcher().match(ctx).auto is True
+    Path(kinded_app.cfg.dirs_file).write_text(
+        'performer = []\ncategory = ["Jane Doe"]\n', encoding="utf-8")
+    assert kinded_app.matcher().match(ctx).auto is False

--- a/scripts/dl-router/tests/test_learning.py
+++ b/scripts/dl-router/tests/test_learning.py
@@ -277,3 +277,56 @@ def test_the_kind_gate_reads_a_live_edit_of_the_dirs_file(kinded_app):
     Path(kinded_app.cfg.dirs_file).write_text(
         'performer = []\ncategory = ["Jane Doe"]\n', encoding="utf-8")
     assert kinded_app.matcher().match(ctx).auto is False
+
+
+# --- cache invalidation ------------------------------------------------------ #
+def test_editing_the_kinds_file_changes_the_dirs_etag(kinded_app):
+    """The extension caches the WHOLE /dirs payload and revalidates with
+    `If-None-Match`. DirIndex's etag only hashes directory NAMES, so a kind
+    edited into dirs.toml used to produce a 304 and a permanently stale cache
+    -- and the stale copy would keep auto-filing into a directory just
+    reclassified as a category, only while the sidecar was unreachable, which
+    is exactly when nobody is watching.
+    """
+    before = kinded_app.dirs_snapshot()["etag"]
+    Path(kinded_app.cfg.dirs_file).write_text(
+        'performer = []\ncategory = ["Jane Doe"]\n', encoding="utf-8")
+    after = kinded_app.dirs_snapshot()["etag"]
+    assert before != after
+
+
+def test_learning_an_alias_changes_the_dirs_etag(kinded_app):
+    before = kinded_app.dirs_snapshot()["etag"]
+    kinded_app.learn({"context": {"url": CDN, "page": {}},
+                      "chosenDir": "Jane Doe", "confirmed": True})
+    assert kinded_app.dirs_snapshot()["etag"] != before
+
+
+def test_the_backfill_plan_applies_the_same_kind_gate(library, store):
+    """SKIP is the backfill's safe answer, and an unclassified target is not a
+    licence to rename a file inside a live seeding target.
+
+    The `result.auto` branch in backfill.plan is the ONE place a filename-only
+    signal can move a file (it needs a lowered threshold to be reachable at
+    all, since the filename rule is capped at 0.50). The kind gate applies
+    there exactly as it does live.
+    """
+    import backfill as backfill_mod
+    from qbt import PathMap
+
+    (library / "jane_doe.mp4").write_bytes(b"x")
+    # A reachable qBittorrent with NO torrents is positive proof that the file
+    # is not a payload, which is what lets a row be `fs` at all.
+    common = dict(store=store, dir_names=["Jane Doe", "other"],
+                  torrents=[], path_map=PathMap("/downloads", str(library)),
+                  threshold=0.1, do_seed=False)
+    unclassified = backfill_mod.plan(library, dir_kinds={}, **common)
+    classified = backfill_mod.plan(library,
+                                   dir_kinds={"Jane Doe": KIND_PERFORMER},
+                                   **common)
+
+    def row(plan):
+        return next(r for r in plan.rows if r.relpath == "jane_doe.mp4")
+
+    assert row(classified).action != backfill_mod.ACTION_SKIP
+    assert row(unclassified).action == backfill_mod.ACTION_SKIP

--- a/scripts/dl-router/tests/test_learning.py
+++ b/scripts/dl-router/tests/test_learning.py
@@ -357,22 +357,23 @@ def test_an_unclassified_directory_learns_identity_only(kinded_app):
     assert {w["source"] for w in out["written"]} == {"thread-slug"}
 
 
-def test_a_screened_identity_signal_is_refused_not_written(kinded_app):
+def test_a_screened_identity_signal_is_refused_on_a_FIRST_write(kinded_app):
     """Identity signals used to bypass the screen entirely — the one row that
-    most needed checking was the only one exempt."""
-    for chosen in ("Jane Doe", "john-smith"):
-        kinded_app.learn({"context": forum_context([]), "chosenDir": chosen,
-                          "confirmed": True})
-    # The slug phrase has now been seen against two different directories.
-    kinded_app.store.add_example(
-        {"page": {"tags": ["aster vale collection"], "site": "someforum.test"}},
-        "Mary_Major")
-    kinded_app.store.add_example(
-        {"page": {"tags": ["aster vale collection"], "site": "someforum.test"}},
-        "john-smith")
+    most needed checking was the only one exempt.
+
+    The screen applies on a first write only: once a row exists, a further
+    correction is the operator RE-POINTING it, and an explicit correction
+    always wins (see test_a_second_correction_overrules_the_first).
+    """
+    for chosen in ("Mary_Major", "john-smith"):
+        kinded_app.store.add_example(
+            {"page": {"tags": ["aster vale collection"],
+                      "site": "someforum.test"}}, chosen)
     out = kinded_app.learn({"context": forum_context([]),
                             "chosenDir": "Aster Vale", "confirmed": True})
     assert any(s["source"] == "thread-slug" for s in out["skipped"])
+    assert kinded_app.store.alias(thread_alias_key("aster vale collection"),
+                                  "someforum.test") is None
 
 
 def test_junk_tags_do_not_consume_the_category_budget(kinded_app):
@@ -391,16 +392,70 @@ def test_refusals_are_reported_in_the_response(kinded_app):
     assert out["skipped"] and out["skipped"][0]["why"]
 
 
-def test_an_initialised_stage_name_is_no_longer_refused(kinded_app):
-    """`M.I.A.` folds to a three-character key. Refusing a real subject is not
-    free just because the refusal is quiet."""
-    from matcher import suspicious_alias_key
-    assert suspicious_alias_key("M.I.A.", dir_names=["Jane Doe"],
-                                site="someforum.test") is None
+def test_a_second_correction_overrules_the_first(kinded_app):
+    """AN EXPLICIT CORRECTION ALWAYS WINS.
+
+    The chrome-spread measure counts the operator's OWN routing history, so
+    correcting the same thread to a second directory looked exactly like a
+    phrase "seen on 2 different directories": the fix was REFUSED, the original
+    wrong alias survived, and the next download from that thread still
+    auto-filed into the wrong place at 1.00. A router that overrules the
+    operator on the second correction is worse than one that never learned.
+    """
+    key = thread_alias_key("aster vale collection")
+    kinded_app.learn({"context": forum_context([]), "chosenDir": "other",
+                      "confirmed": True})                       # a shrug
+    kinded_app.learn({"context": forum_context([]), "chosenDir": "Jane Doe",
+                      "confirmed": True})                       # wrong
+    assert kinded_app.store.alias(key, "someforum.test") == "Jane Doe"
+
+    out = kinded_app.learn({"context": forum_context([]),
+                            "chosenDir": "john-smith", "confirmed": True})
+    assert key in {w["key"] for w in out["written"]}, out["skipped"]
+    assert kinded_app.store.alias(key, "someforum.test") == "john-smith"
+
+    res = kinded_app.match({"url": THREAD, "filename": "x.mp4",
+                            "page": {"url": THREAD, "site": "someforum.test"}})
+    assert res["dir"] == "john-smith"
 
 
-def test_a_stage_name_containing_a_numeral_is_no_longer_refused():
+def test_the_catch_all_does_not_count_towards_chrome_spread(kinded_app):
+    """It is "not any of these" — the absence of a subject, not evidence of
+    one, which is exactly why learn() refuses to write an alias for it.
+    Counting it here contradicted that."""
+    kinded_app.store.add_example(
+        {"page": {"tags": ["Field Recordings"], "site": "someforum.test"}},
+        "other")
+    kinded_app.store.add_example(
+        {"page": {"tags": ["Field Recordings"], "site": "someforum.test"}},
+        "Jane Doe")
+    spread = kinded_app.store.phrase_dir_spread(other_dir="other")
+    assert spread.get("fieldrecordings", 0) == 1
+
+
+def test_a_numeral_INSIDE_a_word_is_not_a_handle():
     from matcher import suspicious_alias_key
-    assert suspicious_alias_key("m1a", dir_names=["Jane Doe"]) is None
-    # ...while a word with a number stuck on the end still reads as a handle.
-    assert suspicious_alias_key("poster1988", dir_names=["Jane Doe"])
+    assert suspicious_alias_key("mi5a", dir_names=["Jane Doe"]) is None
+
+
+@pytest.mark.parametrize("handle", ["poster1988", "poster1", "uploader7",
+                                    "user2", "x1988"])
+def test_a_word_with_a_number_on_the_end_still_reads_as_a_handle(handle):
+    """ONE trailing digit is the common username shape. An earlier narrowing
+    required two, which let most real handles straight through."""
+    from matcher import suspicious_alias_key
+    assert suspicious_alias_key(handle, dir_names=["Jane Doe"])
+
+
+@pytest.mark.parametrize("junk", ["gif", "mp4", "www", "com"])
+def test_a_stopword_or_format_word_can_never_become_an_alias(junk):
+    """These have no content tokens at all, so the shared-vocabulary and handle
+    rules below both passed them silently once the length floor was lowered."""
+    from matcher import suspicious_alias_key
+    assert suspicious_alias_key(junk, dir_names=["Jane Doe"])
+
+
+def test_an_initialised_name_is_exempt_from_the_length_floor_but_a_word_is_not():
+    from matcher import suspicious_alias_key
+    assert suspicious_alias_key("M.I.A.", dir_names=["Jane Doe"]) is None
+    assert suspicious_alias_key("set", dir_names=["Jane Doe"])

--- a/scripts/dl-router/tests/test_learning.py
+++ b/scripts/dl-router/tests/test_learning.py
@@ -330,3 +330,77 @@ def test_the_backfill_plan_applies_the_same_kind_gate(library, store):
 
     assert row(classified).action != backfill_mod.ACTION_SKIP
     assert row(unclassified).action == backfill_mod.ACTION_SKIP
+
+
+# --- audit follow-ups -------------------------------------------------------- #
+def test_the_catch_all_learns_nothing(kinded_app):
+    """Sending a download to the catch-all is "not any of these" — the absence
+    of a subject, not evidence of one. A 1.00 identity alias pointing at it
+    cannot auto-file (it is unclassified), but it would make the catch-all the
+    permanent top candidate in the picker for that channel."""
+    out = kinded_app.learn({"context": {"url": CDN, "page": {}},
+                            "chosenDir": "other", "confirmed": True})
+    assert out["written"] == []
+    assert kinded_app.store.alias_count() == 0
+    assert kinded_app.store.host_prior(DISCORD_SITE) is None
+    # ...but the correction is still recorded as an example.
+    assert kinded_app.store.examples()[0]["chosen_dir"] == "other"
+
+
+def test_an_unclassified_directory_learns_identity_only(kinded_app):
+    """The docs always said so; the code learned title subjects for it too,
+    leaving dormant rows that would all activate at once on classification."""
+    (Path(kinded_app.root) / "Unlisted Dir").mkdir()
+    kinded_app.dirs.refresh(force=True)
+    out = kinded_app.learn({"context": forum_context([]),
+                            "chosenDir": "Unlisted Dir", "confirmed": True})
+    assert {w["source"] for w in out["written"]} == {"thread-slug"}
+
+
+def test_a_screened_identity_signal_is_refused_not_written(kinded_app):
+    """Identity signals used to bypass the screen entirely — the one row that
+    most needed checking was the only one exempt."""
+    for chosen in ("Jane Doe", "john-smith"):
+        kinded_app.learn({"context": forum_context([]), "chosenDir": chosen,
+                          "confirmed": True})
+    # The slug phrase has now been seen against two different directories.
+    kinded_app.store.add_example(
+        {"page": {"tags": ["aster vale collection"], "site": "someforum.test"}},
+        "Mary_Major")
+    kinded_app.store.add_example(
+        {"page": {"tags": ["aster vale collection"], "site": "someforum.test"}},
+        "john-smith")
+    out = kinded_app.learn({"context": forum_context([]),
+                            "chosenDir": "Aster Vale", "confirmed": True})
+    assert any(s["source"] == "thread-slug" for s in out["skipped"])
+
+
+def test_junk_tags_do_not_consume_the_category_budget(kinded_app):
+    """Screen FIRST, then cap. Capping the input list meant a page whose first
+    three tags were junk spent the whole budget and a legitimate fourth was
+    never considered."""
+    tags = ["JD", "Some Forum", "poster1988", "Field Recordings"]
+    out = kinded_app.learn({"context": forum_context(tags),
+                            "chosenDir": "acme-studio", "confirmed": True})
+    assert "fieldrecordings" in {w["key"] for w in out["written"]}
+
+
+def test_refusals_are_reported_in_the_response(kinded_app):
+    out = kinded_app.learn({"context": forum_context(["JD"]),
+                            "chosenDir": "acme-studio", "confirmed": True})
+    assert out["skipped"] and out["skipped"][0]["why"]
+
+
+def test_an_initialised_stage_name_is_no_longer_refused(kinded_app):
+    """`M.I.A.` folds to a three-character key. Refusing a real subject is not
+    free just because the refusal is quiet."""
+    from matcher import suspicious_alias_key
+    assert suspicious_alias_key("M.I.A.", dir_names=["Jane Doe"],
+                                site="someforum.test") is None
+
+
+def test_a_stage_name_containing_a_numeral_is_no_longer_refused():
+    from matcher import suspicious_alias_key
+    assert suspicious_alias_key("m1a", dir_names=["Jane Doe"]) is None
+    # ...while a word with a number stuck on the end still reads as a handle.
+    assert suspicious_alias_key("poster1988", dir_names=["Jane Doe"])

--- a/scripts/dl-router/tests/test_learning.py
+++ b/scripts/dl-router/tests/test_learning.py
@@ -345,6 +345,13 @@ def test_the_catch_all_learns_nothing(kinded_app):
     assert kinded_app.store.host_prior(DISCORD_SITE) is None
     # ...but the correction is still recorded as an example.
     assert kinded_app.store.examples()[0]["chosen_dir"] == "other"
+    # THE SOURCE STRING IS A CROSS-LANGUAGE CONTRACT. The extension's
+    # reportNothingLearned filters on this exact literal so that a routine
+    # catch-all filing never notifies (service_worker.js, IDENTITY_SOURCES
+    # block). It was pinned only on the JS side, so renaming it here left all
+    # of pytest green while silently re-opening the notification-spam bug.
+    assert [s["source"] for s in out["skipped"]] == ["catch-all"]
+    assert out["skipped"][0]["first"] is False
 
 
 def test_an_unclassified_directory_learns_identity_only(kinded_app):
@@ -524,3 +531,62 @@ def test_a_stopword_phrase_is_refused_even_well_over_the_length_floor(junk):
     from matcher import norm_key, suspicious_alias_key
     assert len(norm_key(junk)) > MIN_ALIAS_KEY_LEN
     assert suspicious_alias_key(junk, dir_names=["Jane Doe"])
+
+
+# --- refusals are a durable fact, not an event ------------------------------- #
+def test_a_repeated_refusal_is_reported_as_first_only_once(kinded_app):
+    """PINS THE `first` FLAG, which is what makes the refusal notification
+    once-per-fact instead of once-per-download.
+
+    A permanent refusal (site branding, shared vocabulary, a spread that only
+    ever grows) recurs on EVERY correction, and a screened identity writes no
+    row so nothing else changes either. The flag cannot live in the extension:
+    MV3 tears the service worker down after ~30 s idle, so a suppression map
+    there would empty and the notifications would resume.
+    """
+    for chosen in ("Mary_Major", "acme-studio"):
+        kinded_app.store.add_example(
+            {"page": {"tags": ["Aster Vale Collection"],
+                      "site": "someforum.test"}}, chosen)
+
+    def slug_refusal(out):
+        return next(s for s in out["skipped"] if s["source"] == "thread-slug")
+
+    first = kinded_app.learn({"context": forum_context([]),
+                              "chosenDir": "Aster Vale", "confirmed": True})
+    assert slug_refusal(first)["first"] is True
+    for _ in range(3):
+        again = kinded_app.learn({"context": forum_context([]),
+                                  "chosenDir": "Aster Vale", "confirmed": True})
+        assert slug_refusal(again)["first"] is False
+
+
+def test_the_same_refusal_for_a_DIFFERENT_directory_is_a_new_fact(kinded_app):
+    for chosen in ("Mary_Major", "acme-studio"):
+        kinded_app.store.add_example(
+            {"page": {"tags": ["Aster Vale Collection"],
+                      "site": "someforum.test"}}, chosen)
+    kinded_app.learn({"context": forum_context([]), "chosenDir": "Aster Vale",
+                      "confirmed": True})
+    out = kinded_app.learn({"context": forum_context([]),
+                            "chosenDir": "Jane Doe", "confirmed": True})
+    assert next(s for s in out["skipped"]
+                if s["source"] == "thread-slug")["first"] is True
+
+
+def test_a_refusal_is_recorded_where_the_operator_can_find_it(kinded_app):
+    """A screened candidate writes no alias row, so before this it existed
+    nowhere inspectable and a one-shot notification was the only surface."""
+    for chosen in ("Mary_Major", "acme-studio"):
+        kinded_app.store.add_example(
+            {"page": {"tags": ["Aster Vale Collection"],
+                      "site": "someforum.test"}}, chosen)
+    kinded_app.learn({"context": forum_context([]), "chosenDir": "Aster Vale",
+                      "confirmed": True})
+    kinded_app.learn({"context": forum_context([]), "chosenDir": "Aster Vale",
+                      "confirmed": True})
+    row = next(r for r in kinded_app.store.screened_rows()
+               if r["source"] == "thread-slug")
+    assert row["dir"] == "Aster Vale"
+    assert row["hits"] == 2
+    assert row["why"]

--- a/scripts/dl-router/tests/test_matcher.py
+++ b/scripts/dl-router/tests/test_matcher.py
@@ -14,15 +14,26 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from conftest import SAMPLE_DIRS  # noqa: E402
 from matcher import (  # noqa: E402
-    HOST_PRIOR_BONUS, SCORE_ALIAS_GLOBAL, SCORE_ALIAS_SITE, SCORE_CONTAIN_MAX,
-    SCORE_CONTAIN_MIN, SCORE_FILENAME_MAX, SCORE_TAG_EXACT, DirEntry,
-    MatchContext, Matcher, content_tokens, find_duplicate, norm_key,
-    passes_fuzzy_guard, title_case, tokens,
+    HOST_PRIOR_BONUS, KIND_CATEGORY, KIND_PERFORMER, SCORE_ALIAS_GLOBAL,
+    SCORE_ALIAS_SITE, SCORE_CONTAIN_MAX, SCORE_CONTAIN_MIN, SCORE_FILENAME_MAX,
+    SCORE_TAG_EXACT, DirEntry, MatchContext, Matcher, content_tokens,
+    find_duplicate, norm_key, passes_fuzzy_guard, title_case, tokens,
 )
 
 
 def make(dirs=None, aliases=None, **kw) -> Matcher:
-    return Matcher(dirs if dirs is not None else SAMPLE_DIRS, aliases or {}, **kw)
+    """A matcher over the sample dirs, all classified `performer`.
+
+    Classifying them by default keeps every SCORING test about scoring. Only a
+    performer directory may auto-file (a category always asks, and so does an
+    unclassified one), so without this every `auto is True` assertion below
+    would be asserting the kind gate instead of the rule it names. The gate has
+    its own tests further down.
+    """
+    dirs = dirs if dirs is not None else SAMPLE_DIRS
+    kw.setdefault("dir_kinds",
+                  {getattr(d, "name", d): KIND_PERFORMER for d in dirs})
+    return Matcher(dirs, aliases or {}, **kw)
 
 
 # --- normalisation --------------------------------------------------------- #

--- a/scripts/dl-router/tests/test_rework.py
+++ b/scripts/dl-router/tests/test_rework.py
@@ -23,7 +23,7 @@ import server as S  # noqa: E402
 from conftest import SAMPLE_DIRS  # noqa: E402
 from dirindex import DirIndex, FileIndex  # noqa: E402
 from qbt import PathMap  # noqa: E402
-from store import Store  # noqa: E402
+from store import SCHEMA_VERSION, Store  # noqa: E402
 
 
 class FakeQbt:
@@ -268,7 +268,7 @@ def test_migration_2_is_re_runnable_after_a_crash(tmp_path):
     conn.close()
 
     store = Store(db)                     # must not raise
-    assert store.version() == 2
+    assert store.version() == SCHEMA_VERSION
     store.log_route(dir_name="other", download_id="7")
     assert store.route_for_download("7")["dir"] == "other"
     store.close()
@@ -277,11 +277,11 @@ def test_migration_2_is_re_runnable_after_a_crash(tmp_path):
 def test_migration_is_idempotent_when_run_twice(tmp_path):
     db = tmp_path / "dl-router.sqlite3"
     a = Store(db)
-    assert a.migrate() == 2
-    assert a.migrate() == 2
+    assert a.migrate() == SCHEMA_VERSION
+    assert a.migrate() == SCHEMA_VERSION
     a.close()
     b = Store(db)
-    assert b.version() == 2
+    assert b.version() == SCHEMA_VERSION
     b.close()
 
 

--- a/scripts/dl-router/tests/test_server.py
+++ b/scripts/dl-router/tests/test_server.py
@@ -199,15 +199,28 @@ def test_match_uses_the_host_prior_from_the_store(live, store):
     assert "+host-prior" in body["candidates"][0]["reason"]
 
 
-def test_learn_writes_an_alias_and_an_example(live, store):
+def test_learn_records_the_example_and_prior_but_no_tag_alias_for_a_performer(
+        live, store):
+    """The mislearning fix, at the endpoint.
+
+    This used to assert the OPPOSITE: that a page tag became a site alias for
+    whichever directory was chosen. On real traffic that turned a forum section
+    name and two other posters' usernames into aliases for a subject directory
+    (one of them global), because a tag list is not evidence about a PERSON.
+    The example and the host prior are still recorded -- they are the parts
+    that were never the problem.
+    """
     status, body, _ = call(live, "POST", "/learn", {
         "context": {"page": {"url": "https://example-site.test/v",
                              "tags": ["Aster Nightingale"]}},
         "chosenDir": "Jane Doe",
         "autoDir": "other",
+        "confirmed": True,
     })
     assert status == 200 and body["ok"] is True
-    assert store.alias("asternightingale", "example-site.test") == "Jane Doe"
+    assert store.alias("asternightingale", "example-site.test") is None
+    assert store.alias("asternightingale", "") is None
+    assert body["aliases"] == 0
     assert store.host_prior("example-site.test") == "Jane Doe"
     assert store.examples()[0]["chosen_dir"] == "Jane Doe"
 

--- a/scripts/dl-router/tests/test_signals.py
+++ b/scripts/dl-router/tests/test_signals.py
@@ -180,19 +180,56 @@ def test_a_forum_thread_matches_its_directory_by_slug_alone():
 
 
 # --- page titles ------------------------------------------------------------ #
-@pytest.mark.parametrize("title,site,expected", [
-    ("Aster Vale Collection | Some Forum", "someforum.test",
-     "Aster Vale Collection"),
-    ("Some Forum - Aster Vale Collection", "someforum.test",
-     "Aster Vale Collection"),
-    ("Aster Vale", "", "Aster Vale"),
-    ("", "someforum.test", ""),
+# Real `<title>` templates. phpBB puts the subject LAST, XenForo puts it FIRST,
+# and both are common -- which is why neither position nor size can pick it.
+SLUG = "aster vale deluxe photo set"
+SUBJECT = "Aster Vale Deluxe Photo Set"
+
+
+@pytest.mark.parametrize("title", [
+    f"{SUBJECT} | Some Forum",                       # XenForo
+    f"Some Forum - View topic - {SUBJECT}",          # phpBB
+    f"Section | {SUBJECT} | Some Forum",
+    f"Page 2 | {SUBJECT} | Some Forum",
+    f"Some Forum \u00bb {SUBJECT}",
 ])
-def test_title_subject_drops_the_site_branding(title, site, expected):
-    """Data-driven: a title segment is chrome when every word of it is also a
-    word of the HOST. No list of site names has to be maintained (and none
-    could be committed -- they are the operator's private browsing)."""
-    assert title_subject(title, site) == expected
+def test_the_title_subject_is_corroborated_against_the_slug(title):
+    """`title_subject` asks the anchored URL slug instead of guessing.
+
+    Both guesses were tried and both failed on real templates. "Longest
+    surviving segment" returned the SITE name whenever the subject was one
+    word; "first surviving segment" then returned `'View topic'` (a phpBB
+    constant, so a site-wide 1.00 alias), `'Section'` and `'Page 2'`. There is
+    no ordering rule to find, and a third superlative would just relocate the
+    failure -- so this corroborates against a signal that is already proven.
+    """
+    assert title_subject(title, "forum.test", SLUG) == SUBJECT
+
+
+def test_with_no_slug_there_is_no_title_subject_at_all():
+    """FAIL CLOSED. A title subject can only ever be learned when something
+    independent has already confirmed what the subject is. Pages with no thread
+    slug still MATCH on their raw title through ordinary containment; what they
+    no longer do is mint an alias."""
+    assert title_subject(f"{SUBJECT} | Some Forum", "forum.test", "") == ""
+    assert title_subject("Anything At All", "forum.test") == ""
+
+
+def test_a_title_that_corroborates_nothing_yields_nothing():
+    assert title_subject("Completely Unrelated | Some Forum", "forum.test",
+                         SLUG) == ""
+
+
+@pytest.mark.parametrize("title,site,slug,expected", [
+    ("Aster Vale Collection | Some Forum", "someforum.test",
+     "aster vale collection", "Aster Vale Collection"),
+    ("Some Forum - Aster Vale Collection", "someforum.test",
+     "aster vale collection", "Aster Vale Collection"),
+    ("", "someforum.test", "aster vale", ""),
+])
+def test_title_subject_still_drops_the_site_branding(title, site, slug,
+                                                     expected):
+    assert title_subject(title, site, slug) == expected
 
 
 # --- cross-host referrer carry ---------------------------------------------- #
@@ -389,19 +426,17 @@ def test_a_downloads_own_filename_is_not_a_pseudo_thread():
 
 
 def test_the_site_name_does_not_win_a_short_title():
-    """BLOCKER 2. `title_subject` took the LONGEST surviving segment, and the
-    branding test only recognises a site whose display name resembles its
-    hostname -- so on a forum where they differ the site name won whenever the
-    subject was one word, giving every short-titled page on that forum a 1.00
-    site-scoped alias into one directory."""
-    assert title_subject("Aster | Some Forum", "forum.test") == "Aster"
+    """The site's display name must never become the subject, on a forum where
+    the branding test cannot see it (display name unlike the hostname)."""
+    assert title_subject("Aster | Some Forum", "forum.test", "aster") == "Aster"
 
 
-def test_the_branding_test_still_wins_over_position_when_it_can_see_it():
-    """Position is the fallback, not a replacement: a reversed title is still
-    handled wherever the site name IS recognisable."""
-    assert title_subject("Some Forum - Aster Vale Collection",
-                         "someforum.test") == "Aster Vale Collection"
+def test_the_phpBB_constant_never_becomes_an_alias():
+    """`'View topic'` appears in the title of every phpBB thread on a site. As
+    a learned alias it is a site-wide 1.00 auto-file into one directory."""
+    for slug in (SLUG, "aster vale", "photography"):
+        assert title_subject(f"Some Forum - View topic - {SUBJECT}",
+                             "forum.test", slug) != "View topic"
 
 
 def test_identity_keys_are_near_verbatim_so_threads_do_not_collide():

--- a/scripts/dl-router/tests/test_signals.py
+++ b/scripts/dl-router/tests/test_signals.py
@@ -130,13 +130,21 @@ def test_a_channel_alias_does_not_leak_to_another_channel():
     # a section ABOVE the thread -- the deepest qualifying segment wins
     ("https://forum.test/forums/general-discussion/threads/aster-vale.99/",
      "aster vale"),
-    ("https://board.test/t/aster-vale/1234", "aster vale"),
 ])
 def test_thread_slug_extraction(url, expected):
     assert thread_slug(url) == expected
 
 
 @pytest.mark.parametrize("url", [
+    # `t`/`topic`/`topics` are NOT anchors: a paginated index route is
+    # structurally identical to a Discourse thread, so no adjacency rule can
+    # separate them. An id-less Discourse/IPB thread degrades to the picker,
+    # which this design calls acceptable — a wrong slug is not.
+    "https://board.test/t/aster-vale/1234",
+    "https://forum.test/topic/12345-aster-vale/",
+    "https://forum.test/topics/general-discussion/2",
+    "https://forum.test/t/photography/3",
+    "https://forum.test/t/best-of-2024",
     "",
     None,
     "https://forum.test/",
@@ -448,3 +456,31 @@ def test_identity_keys_are_near_verbatim_so_threads_do_not_collide():
     b = thread_alias_key(thread_slug(
         "https://forum.test/threads/aster-vale-set.223/"))
     assert a and b and a != b
+
+
+# --- corroboration needs more than a coincidence ----------------------------- #
+@pytest.mark.parametrize("title,slug", [
+    ("Section: Photography | Some Forum", "photography meetup"),
+    ("Page 12 | Some Forum", "top-12-sets"),
+    ("A Long Sentence Mentioning Aster And Vale In Passing | X", "aster vale"),
+])
+def test_one_shared_token_is_a_coincidence_not_corroboration(title, slug):
+    """The whole segment is emitted VERBATIM, so a single incidental overlap
+    minted `'Section: Photography'` and `'Page 12'` as subjects."""
+    assert title_subject(title, "forum.test", slug) == ""
+
+
+def test_a_single_word_segment_that_matches_outright_still_corroborates():
+    assert title_subject("Aster | Some Forum", "forum.test", "aster") == "Aster"
+
+
+@pytest.mark.parametrize("phrase", ["w.w.w.", "e.g.", "i.e.", "p.s.", "O. K."])
+def test_the_initialism_exemption_has_a_floor_and_a_stopword_check(phrase):
+    """It had neither, so it re-opened everything the length floor was for:
+    `w.w.w.` folds to `www` (defeating the stopword rule), and the rest fold to
+    two-character keys — under the floor this change restored."""
+    assert suspicious_alias_key(phrase, dir_names=["Jane Doe"])
+
+
+def test_a_real_initialised_name_is_still_exempt():
+    assert suspicious_alias_key("M.I.A.", dir_names=["Jane Doe"]) is None

--- a/scripts/dl-router/tests/test_signals.py
+++ b/scripts/dl-router/tests/test_signals.py
@@ -27,7 +27,8 @@ from conftest import load_url_cases  # noqa: E402
 from matcher import (  # noqa: E402
     DISCORD_SITE, KEY_PREFIX_DISCORD, KIND_PERFORMER, SCORE_ALIAS_SITE,
     MatchContext, Matcher, alias_key, discord_alias_key, discord_channel_id,
-    identity_signals, is_structured_key, suspicious_alias_key, thread_alias_key,
+    host_of, identity_signals, is_structured_key, suspicious_alias_key,
+    thread_alias_key,
     thread_slug, title_subject,
 )
 
@@ -265,12 +266,32 @@ def test_a_handle_shaped_token_is_refused():
     assert why and "handle" in why
 
 
-def test_a_structured_key_is_never_suspicious():
-    """A channel id is short, numeric and shared by everything in that channel.
-    It is an IDENTITY, and the screen must not fight the mechanism that makes
-    Discord work at all."""
-    assert suspicious_alias_key(discord_alias_key(CHANNEL),
-                                dir_names=["Jane Doe"], spread=99) is None
+def test_a_structured_key_skips_only_the_WORD_rules():
+    """Structured keys used to be exempt from the screen entirely.
+
+    The reasoning ("a channel id is an identity, not a word") held; the
+    exemption did not. A badly derived identity is still an identity as far as
+    the store is concerned, and it lands at 1.00 WITH auto-file rather than at
+    0.85 without -- so the worst row the router can write was the one row
+    nothing checked. What structured keys skip now is only the two rules that
+    describe a word rather than a source.
+    """
+    channel = discord_alias_key(CHANNEL)
+    # ...the word rules do not fire on it: it is short and it is all digits.
+    assert suspicious_alias_key(channel, dir_names=["Jane Doe"],
+                                site="discord.com") is None
+    # ...but the chrome-spread rule still does.
+    assert suspicious_alias_key(channel, dir_names=["Jane Doe"], spread=99)
+
+
+def test_a_section_name_mistaken_for_a_thread_is_still_screened():
+    """Defence in depth behind the anchoring fix: even if some future URL shape
+    slipped a section name through as a `thread:` key, the spread rule catches
+    it once it has been seen on two directories."""
+    key = thread_alias_key("general discussion")
+    assert suspicious_alias_key("general discussion", key=key,
+                                dir_names=["Jane Doe"], site="forum.test",
+                                spread=2)
 
 
 def test_a_real_subject_name_passes_the_screen():
@@ -296,3 +317,99 @@ def test_discord_ids_match_the_shared_table(case):
                          ids=lambda c: c["url"][:60] or "empty")
 def test_thread_slugs_match_the_shared_table(case):
     assert thread_slug(case["url"]) == case["slug"]
+
+
+@pytest.mark.parametrize("case", URL_CASES["host"],
+                         ids=lambda c: c["url"][:60] or "empty")
+def test_hosts_match_the_shared_table(case):
+    """`urlsplit` and `new URL` disagreed on 9 of 30 hostile inputs — scheme
+    handling, IPv6 brackets, IDN punycoding, percent-encoded authorities. The
+    host is the SCOPE of an alias, so the rule is written out in both rather
+    than delegated to either standard library."""
+    assert host_of(case["url"]) == case["host"]
+
+
+# --- audit blockers: reproduced, then pinned -------------------------------- #
+# Each of these FAILED on the first version of this change. The URLs are the
+# ones the audit ran; the names are synthetic.
+SECTION_URLS = [
+    "https://forum.test/forums/general-discussion/threads/aster.99/",
+    "https://forum.test/forums/general-discussion.12/",
+    "https://forum.test/members/some-poster.4321/",
+]
+
+
+@pytest.mark.parametrize("url", SECTION_URLS)
+def test_a_forum_section_or_member_page_is_never_a_thread_identity(url):
+    """BLOCKER 1. `thread_slug` took "the deepest segment with >=2 content
+    tokens", so when a thread's own slug was ONE word the SECTION name one
+    level up won -- and a section name became a 1.00 auto-filing identity key.
+    That is the mislearning this whole change exists to remove, relocated from
+    the tag list into the URL path and made worse, because an identity outranks
+    every other rule.
+
+    The fix is positional, not a better superlative: a slug is the segment
+    immediately after a thread route, and nowhere else.
+    """
+    assert thread_slug(url) != "general discussion"
+    assert thread_slug(url) != "some poster"
+
+
+def test_the_thread_still_wins_when_its_own_slug_is_one_word():
+    assert thread_slug(SECTION_URLS[0]) == "aster"
+
+
+def test_a_section_page_with_no_thread_yields_no_identity_at_all():
+    for url in SECTION_URLS[1:]:
+        assert thread_slug(url) == ""
+        assert identity_signals(
+            MatchContext.from_payload({"page": {"url": url}})) == []
+
+
+def test_a_section_alias_cannot_be_learned_then_hit_from_another_thread():
+    """The end-to-end shape the audit reproduced: one correction in a section,
+    then a DIFFERENT thread in the same section matching at 1.00."""
+    first = SECTION_URLS[0]
+    other = "https://forum.test/forums/general-discussion/threads/vale.100/"
+    keys = {s.key for s in identity_signals(
+        MatchContext.from_payload({"page": {"url": first}}))}
+    other_keys = {s.key for s in identity_signals(
+        MatchContext.from_payload({"page": {"url": other}}))}
+    assert keys and other_keys
+    assert keys.isdisjoint(other_keys), \
+        "two threads in one section must not share an identity key"
+
+
+def test_a_downloads_own_filename_is_not_a_pseudo_thread():
+    """`/uploads/dsc-0123.jpg` used to mint `thread:dsc-0123`. Camera defaults
+    collide across posters, and every download wrote a junk row."""
+    for url in ("https://cdn.test/uploads/dsc-0123.jpg",
+                "https://cdn.test/i/img-20240101.mp4"):
+        assert thread_slug(url) == ""
+
+
+def test_the_site_name_does_not_win_a_short_title():
+    """BLOCKER 2. `title_subject` took the LONGEST surviving segment, and the
+    branding test only recognises a site whose display name resembles its
+    hostname -- so on a forum where they differ the site name won whenever the
+    subject was one word, giving every short-titled page on that forum a 1.00
+    site-scoped alias into one directory."""
+    assert title_subject("Aster | Some Forum", "forum.test") == "Aster"
+
+
+def test_the_branding_test_still_wins_over_position_when_it_can_see_it():
+    """Position is the fallback, not a replacement: a reversed title is still
+    handled wherever the site name IS recognisable."""
+    assert title_subject("Some Forum - Aster Vale Collection",
+                         "someforum.test") == "Aster Vale Collection"
+
+
+def test_identity_keys_are_near_verbatim_so_threads_do_not_collide():
+    """Stopword stripping belongs to fuzzy matching, never to an identity:
+    `aster-vale-new-set` and `aster-vale-set` both folded to one key, and
+    upsert_alias re-points on conflict, so the collision was silent."""
+    a = thread_alias_key(thread_slug(
+        "https://forum.test/threads/aster-vale-new-set.222/"))
+    b = thread_alias_key(thread_slug(
+        "https://forum.test/threads/aster-vale-set.223/"))
+    assert a and b and a != b

--- a/scripts/dl-router/tests/test_signals.py
+++ b/scripts/dl-router/tests/test_signals.py
@@ -1,0 +1,277 @@
+"""Identity signals — the deterministic half of matching.
+
+Every case here is drawn from the shape of the first evening of real traffic
+(nine downloads, zero auto-files, eight scoring 0.00 "no signal"), reproduced
+with SYNTHETIC ids, hosts and names. Nothing about a real library appears in
+this file.
+
+  * six of nine came from a Discord CDN, where the page is a SPA and the
+    captured context was completely empty -- so the only signal is the channel
+    id inside the attachment URL;
+  * one came from a file host reached by clicking through a forum thread, with
+    no context of its own;
+  * one was a forum attachment where context WAS captured, and the tag list was
+    the forum's own section names plus other posters' usernames while the
+    subject sat in the URL slug and the page title.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from matcher import (  # noqa: E402
+    DISCORD_SITE, KEY_PREFIX_DISCORD, KIND_PERFORMER, SCORE_ALIAS_SITE,
+    MatchContext, Matcher, alias_key, discord_alias_key, discord_channel_id,
+    identity_signals, is_structured_key, suspicious_alias_key, thread_alias_key,
+    thread_slug, title_subject,
+)
+
+CHANNEL = "119283746551234567"
+CDN = f"https://cdn.discordapp.com/attachments/{CHANNEL}/998877665544332211/clip.mp4"
+MEDIA = f"https://media.discordapp.net/attachments/{CHANNEL}/998877665544332211/still.png"
+
+
+# --- Discord ---------------------------------------------------------------- #
+@pytest.mark.parametrize("url", [CDN, MEDIA, CDN + "?ex=abc&is=def&hm=0123"])
+def test_discord_channel_id_is_read_from_the_url(url):
+    """No DOM scraping: the id is IN the URL, so a Discord UI change cannot
+    break it. `media.discordapp.net` serves the same `/attachments/...` shape
+    as `cdn.discordapp.com` and needs the identical treatment."""
+    assert discord_channel_id(url) == CHANNEL
+
+
+def test_discord_ephemeral_attachments_are_the_same_shape():
+    url = (f"https://cdn.discordapp.com/ephemeral-attachments/{CHANNEL}/"
+           "998877665544332211/clip.mp4")
+    assert discord_channel_id(url) == CHANNEL
+
+
+@pytest.mark.parametrize("url", [
+    "",
+    None,
+    "https://example-site.test/attachments/119283746551234567/1/clip.mp4",
+    "https://cdn.discordapp.com/avatars/119283746551234567/abc.png",
+    "https://cdn.discordapp.com/attachments/not-a-snowflake/1/clip.mp4",
+    "https://cdn.discordapp.com/attachments/",
+    "https://evil.test/cdn.discordapp.com/attachments/1/2/x.mp4",
+])
+def test_a_non_discord_attachment_url_yields_nothing(url):
+    assert discord_channel_id(url) == ""
+
+
+def test_a_discord_download_carries_a_site_even_with_no_page_context():
+    """Discord is a SPA: `tags: []`, `title: ''`, `pageUrl: ''`.
+
+    Without a site every alias the learner could write would be GLOBAL, which
+    is the widest blast radius in the store. Pinning the site from the URL keeps
+    everything Discord teaches us site-scoped.
+    """
+    ctx = MatchContext.from_payload({"url": CDN, "filename": "clip.mp4",
+                                     "page": {"tags": [], "title": "",
+                                              "url": ""}})
+    assert ctx.site == DISCORD_SITE
+    sigs = identity_signals(ctx)
+    assert [s.key for s in sigs] == [discord_alias_key(CHANNEL)]
+    assert sigs[0].site == DISCORD_SITE
+    assert sigs[0].kind == "discord-channel"
+
+
+def test_a_confirmed_channel_matches_later_downloads_at_full_confidence():
+    """The whole Discord design: the FIRST download from a channel opens the
+    picker, and every later one is deterministic."""
+    m = Matcher(["Jane Doe", "other"],
+                {(discord_alias_key(CHANNEL), DISCORD_SITE): "Jane Doe"},
+                dir_kinds={"Jane Doe": KIND_PERFORMER})
+    other_file = CDN.replace("clip.mp4", "totally-different-name.mp4")
+    res = m.match(MatchContext.from_payload({"url": other_file,
+                                             "filename": "opaque-8f3a1c92.mp4",
+                                             "page": {}}))
+    assert res.dir == "Jane Doe"
+    assert res.confidence == pytest.approx(SCORE_ALIAS_SITE)
+    assert res.auto is True
+    assert "discord-channel" in res.reason
+
+
+def test_an_unconfirmed_channel_scores_nothing_and_opens_the_picker():
+    m = Matcher(["Jane Doe", "other"], {},
+                dir_kinds={"Jane Doe": KIND_PERFORMER})
+    res = m.match(MatchContext.from_payload({"url": CDN, "page": {}}))
+    assert res.auto is False
+    assert res.dir == "other"
+
+
+def test_a_channel_alias_does_not_leak_to_another_channel():
+    other_channel = "220000000000000001"
+    m = Matcher(["Jane Doe", "other"],
+                {(discord_alias_key(CHANNEL), DISCORD_SITE): "Jane Doe"},
+                dir_kinds={"Jane Doe": KIND_PERFORMER})
+    url = CDN.replace(CHANNEL, other_channel)
+    assert m.match(MatchContext.from_payload({"url": url, "page": {}})).auto \
+        is False
+
+
+# --- forum thread slugs ----------------------------------------------------- #
+@pytest.mark.parametrize("url,expected", [
+    # xenforo: slug.<id>
+    ("https://forum.test/threads/aster-vale-collection.481920/",
+     "aster vale collection"),
+    # ...with a page suffix. `page-2` is a chrome verb plus a number.
+    ("https://forum.test/threads/aster-vale-collection.481920/page-3",
+     "aster vale collection"),
+    # vbulletin: <id>-slug
+    ("https://forum.test/showthread.php/481920-aster-vale-collection",
+     "aster vale collection"),
+    # a section ABOVE the thread -- the deepest qualifying segment wins
+    ("https://forum.test/forums/general-discussion/threads/aster-vale.99/",
+     "aster vale"),
+    ("https://board.test/t/aster-vale/1234", "aster vale"),
+])
+def test_thread_slug_extraction(url, expected):
+    assert thread_slug(url) == expected
+
+
+@pytest.mark.parametrize("url", [
+    "",
+    None,
+    "https://forum.test/",
+    "https://forum.test/threads/",
+    "https://forum.test/threads/481920/",       # id only, no slug
+    "https://forum.test/forums/",
+    "https://host.test/a/b/c",                  # single short tokens
+])
+def test_no_slug_where_there_is_none(url):
+    assert thread_slug(url) == ""
+
+
+def test_the_slug_beats_the_tag_list_as_a_subject_phrase():
+    """The one forum download that DID capture context scored 0.67 on title
+    tokens while its tag list was section names and other posters' usernames.
+    The slug is the cleanest carrier of a subject there is -- it cannot be
+    polluted by anyone else's content -- so it leads."""
+    ctx = MatchContext.from_payload({
+        "url": "https://forum.test/attachments/opaque-9f2.mp4",
+        "page": {
+            "url": "https://forum.test/threads/aster-vale-collection.481920/",
+            "site": "forum.test",
+            "title": "Aster Vale Collection | Some Forum",
+            "tags": ["General Discussion", "poster_1988", "uploader42"],
+        },
+    })
+    phrases = ctx.subject_phrases()
+    assert phrases[0] == "aster vale collection"
+    assert phrases.index("General Discussion") > 0
+
+
+def test_a_forum_thread_matches_its_directory_by_slug_alone():
+    m = Matcher(["Aster Vale", "other"], {},
+                dir_kinds={"Aster Vale": KIND_PERFORMER})
+    res = m.match(MatchContext.from_payload({
+        "url": "https://forum.test/attachments/opaque-9f2.mp4",
+        "page": {"url": "https://forum.test/threads/aster-vale.481920/",
+                 "site": "forum.test", "tags": ["General Discussion"]},
+    }))
+    assert res.dir == "Aster Vale"
+
+
+# --- page titles ------------------------------------------------------------ #
+@pytest.mark.parametrize("title,site,expected", [
+    ("Aster Vale Collection | Some Forum", "someforum.test",
+     "Aster Vale Collection"),
+    ("Some Forum - Aster Vale Collection", "someforum.test",
+     "Aster Vale Collection"),
+    ("Aster Vale", "", "Aster Vale"),
+    ("", "someforum.test", ""),
+])
+def test_title_subject_drops_the_site_branding(title, site, expected):
+    """Data-driven: a title segment is chrome when every word of it is also a
+    word of the HOST. No list of site names has to be maintained (and none
+    could be committed -- they are the operator's private browsing)."""
+    assert title_subject(title, site) == expected
+
+
+# --- cross-host referrer carry ---------------------------------------------- #
+def test_a_proven_referrer_carries_the_thread_subject_across_hosts():
+    """A file host reached by clicking through a forum thread has no context of
+    its own. The forum thread's identity is carried ONLY when the extension
+    proved the link (opener tab, or a captured click whose href is this page)
+    -- there is deliberately no time window and no "last thread seen"."""
+    ctx = MatchContext.from_payload({
+        "url": "https://filehost.test/d/AbCdEf",
+        "page": {"url": "https://filehost.test/f/AbCdEf", "site": "filehost.test",
+                 "tags": [],
+                 "referrerUrl": "https://forum.test/threads/aster-vale.481920/",
+                 "referrerTitle": "Aster Vale | Some Forum"},
+    })
+    keys = {(s.key, s.site) for s in identity_signals(ctx)}
+    assert (thread_alias_key("aster vale"), "forum.test") in keys
+    assert "aster vale" in ctx.subject_phrases()
+
+
+def test_without_a_proven_referrer_the_file_host_has_nothing():
+    ctx = MatchContext.from_payload({
+        "url": "https://filehost.test/d/AbCdEf",
+        "page": {"url": "https://filehost.test/f/AbCdEf", "site": "filehost.test",
+                 "tags": []},
+    })
+    assert identity_signals(ctx) == []
+    assert ctx.subject_phrases() == []
+
+
+# --- alias keys ------------------------------------------------------------- #
+def test_structured_keys_round_trip_through_the_cli_form():
+    """`dl-route alias rm 'discord:<id>'` has to remove the row that
+    `dl-route alias list` printed."""
+    assert alias_key(f"{KEY_PREFIX_DISCORD}{CHANNEL}") == discord_alias_key(CHANNEL)
+    assert alias_key("thread:Aster Vale") == thread_alias_key("aster vale")
+    assert alias_key("thread:aster-vale") == thread_alias_key("aster vale")
+    assert alias_key("Jane Doe") == "janedoe"
+    assert alias_key("discord:not-digits") == ""
+    assert is_structured_key(discord_alias_key(CHANNEL))
+    assert not is_structured_key("janedoe")
+
+
+# --- the suspicious-key screen ---------------------------------------------- #
+def test_a_short_key_is_refused():
+    assert suspicious_alias_key("JD", dir_names=["Jane Doe"])
+
+
+def test_a_phrase_seen_on_many_directories_is_site_chrome():
+    """The generalisation of the forum section name that became an alias. It is
+    measured from the labelled examples, not read off a word list."""
+    why = suspicious_alias_key("General Discussion", dir_names=["Jane Doe"],
+                               site="forum.test", spread=3)
+    assert why and "different directories" in why
+
+
+def test_the_site_name_itself_is_never_a_subject():
+    why = suspicious_alias_key("Some Forum", dir_names=["Jane Doe"],
+                               site="someforum.test")
+    assert why and "site name" in why
+
+
+def test_a_word_shared_by_several_directories_is_a_category_word():
+    dirs = ["Live Sets", "Live Recordings", "Live Archive"]
+    why = suspicious_alias_key("live", dir_names=dirs)
+    assert why
+
+
+def test_a_handle_shaped_token_is_refused():
+    why = suspicious_alias_key("poster1988", dir_names=["Jane Doe"])
+    assert why and "handle" in why
+
+
+def test_a_structured_key_is_never_suspicious():
+    """A channel id is short, numeric and shared by everything in that channel.
+    It is an IDENTITY, and the screen must not fight the mechanism that makes
+    Discord work at all."""
+    assert suspicious_alias_key(discord_alias_key(CHANNEL),
+                                dir_names=["Jane Doe"], spread=99) is None
+
+
+def test_a_real_subject_name_passes_the_screen():
+    assert suspicious_alias_key("Aster Nightingale", dir_names=["Jane Doe"],
+                                site="forum.test", spread=1) is None

--- a/scripts/dl-router/tests/test_signals.py
+++ b/scripts/dl-router/tests/test_signals.py
@@ -23,6 +23,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from conftest import load_url_cases  # noqa: E402
 from matcher import (  # noqa: E402
     DISCORD_SITE, KEY_PREFIX_DISCORD, KIND_PERFORMER, SCORE_ALIAS_SITE,
     MatchContext, Matcher, alias_key, discord_alias_key, discord_channel_id,
@@ -275,3 +276,23 @@ def test_a_structured_key_is_never_suspicious():
 def test_a_real_subject_name_passes_the_screen():
     assert suspicious_alias_key("Aster Nightingale", dir_names=["Jane Doe"],
                                 site="forum.test", spread=1) is None
+
+
+# --- the shared table ------------------------------------------------------- #
+# ONE table, TWO implementations (tests/fixtures/url_cases.json). The
+# extension's cached fallback runs exactly when the sidecar is unreachable, so
+# a divergence between matcher.py and route_core.js is invisible until it
+# misfiles something. `identity.test.mjs` asserts the SAME rows.
+URL_CASES = load_url_cases()
+
+
+@pytest.mark.parametrize("case", URL_CASES["discord"],
+                         ids=lambda c: c["url"][:60] or "empty")
+def test_discord_ids_match_the_shared_table(case):
+    assert discord_channel_id(case["url"]) == case["channel"]
+
+
+@pytest.mark.parametrize("case", URL_CASES["slug"],
+                         ids=lambda c: c["url"][:60] or "empty")
+def test_thread_slugs_match_the_shared_table(case):
+    assert thread_slug(case["url"]) == case["slug"]


### PR DESCRIPTION
Driven by the first evening of real traffic: **nine downloads, zero auto-files**, eight scoring `0.00 — no signal in page context or filename`. Then the correction path made it worse — one confirmation wrote four aliases, three of them wrong (a forum section name, two other posters' usernames), one at **global** scope. Those rows were deleted by hand; nothing in the system had surfaced them.

Page scraping cannot fix that shape. This PR adds the signal that can, and rewrites the rule that learned the wrong thing.

## 1. Identity signals — the deterministic half

The URL is structured even when the page is a black box. `identity_signals()` derives site-scoped alias keys from it and nothing else:

| Signal | Key | Scope |
|---|---|---|
| Discord attachment (`cdn.discordapp.com`, `media.discordapp.net`, incl. `ephemeral-attachments`) | `discord:<channel id>` | `discord.com` |
| forum thread slug in the path | `thread:<slug>` | that forum's host |

First download from a channel/thread has no signal and opens the picker; confirming it writes the key, and every later one matches at **1.00 with nothing scraped from any page**. No DOM scraping, so a UI change on the source site cannot break routing that already works.

`media.discordapp.net` **does** need the same treatment — same `/attachments/<channel>/<message>/<file>` path shape. Both are covered.

A Discord download now derives its *site* from the URL too. That matters: with an empty page context the old code fell into the "no site → global alias" branch, which is precisely how a username became a library-wide alias.

**One function produces the keys the matcher looks up and the keys the learner writes**, so "what we match on" and "what we learn" cannot drift.

## 2. Directory kinds — performer vs category

`~/.config/dl-router/dirs.toml` (never committed), two arrays so the review action is "move this line":

- Only a `performer` directory may **auto-file**.
- A `category` directory **always opens the picker**, whatever it scores.
- An **unclassified** directory never auto-files. Absence of a classification is not permission.

`dl-route dirs classify` drafts it from the live index with a best-guess split and a reason per line. Picker-created directories are asked their kind (arrow keys + Enter, Esc goes back) and the answer lands in SQLite rather than being appended to the human-edited file.

## 3. The learning rule

| Directory kind | Learns |
|---|---|
| `performer` | identity signals + a subject name found in the (de-branded) page title. **Never a tag.** |
| `category` | the above, plus tag → dir aliases: site-scoped, capped at 3, explicit confirmation only |
| unclassified | identity signals only |

**No alias is ever learned at global scope again.** `dl-route alias set --site '*' --force` remains for a deliberate one.

Every candidate key is screened by rules describing the *failure class*, all measured from data the router already holds rather than a word list (which would be unmaintainable and un-committable to a public repo): under 4 chars; seen on ≥2 distinct directories in the labelled examples (the signature of site chrome); part of the site's own name; every word already in ≥2 library directories; a single token containing digits.

## 4. Cross-host referrer carry

Carried **only when provable** — a captured click whose `href` is this page, or the tab this one was opened from (`openerTabId`, taken from the message sender). No time window, no "last thread seen": both are wrong exactly when several tabs are open, which is how anyone browses a forum. Skipped entirely for a page that produced its own tags.

## 5. CLI/UX

- **`alias list`/`rm` round-trip** — `*` is what `list` prints and what `rm --site '*'` now accepts; `--site ''` still works; removing a row that isn't there says so instead of claiming success. Structured keys round-trip verbatim.
- **`dl-route alias review`** — every learned alias with its evidence, provenance and hit count, riskiest first, flagging global and suspicious rows and printing the exact removal command. (Schema v2 → v3 adds `aliases.source`/`evidence` and a `dir_kinds` table.)
- **`alias set` refuses** a suspicious key without `--force`.
- `dl-route status` prints `performer=/category=/unclassified=` and names unclassified directories as the reason it keeps asking.

## Two gaps found while reviewing this against the old caching contract

- **`/dirs` ETag covered only directory names**, while the extension caches the whole payload and revalidates with `If-None-Match`. A kind edited into `dirs.toml` answered 304 → permanently stale cache → the cached fallback would keep auto-filing into a directory just reclassified as a category, and only while the sidecar is unreachable. Now a hash of the served snapshot.
- **`backfill.plan` built its Matcher with no kinds**, so its one filename-only move branch became unreachable by accident. Benign (SKIP is the safe answer) but a plan that can't say what the live router would do is not reviewable. Threaded through and pinned.

## ⚠ Known consequence — flagged, not implemented

**A confirmed Discord channel alias pointing at a `category` directory will keep asking forever.** That is rule 4 as specified, and it may well be most of the traffic: the evidence shows 6/9 downloads from Discord, and unattributed chat drops are exactly what a category directory is for.

The one-line exception I would make if asked: *let a **structured identity** signal (`discord:` / `thread:`) auto-file into a category directory, while a **tag** never can.* The justification is that the two things a category confirmation asserts are different — a tag says "this file is about X", which is a weak claim about any one file, whereas a confirmed channel id says "everything from this channel goes here", which is a claim about the *source* and is exactly as strong on the hundredth file as on the first. Pinned by `test_a_category_match_asks_even_from_a_confirmed_identity_alias`, named so it reads as a decision rather than an oversight. **Your call.**

## Tests

593 → **717 pytest**, 272 → **298 node**, all green. `difffuzz.py` still reports `0 divergence(s)`.

Every behaviour change carries a test that fails before it. Where existing tests encoded the old contract they were updated with the reason written in, not deleted — notably `test_learn_writes_an_alias_and_an_example`, which asserted the *exact* mislearning this PR removes.

`tests/fixtures/url_cases.json` is a **new shared table**, asserted by both `test_signals.py` and `identity.test.mjs` — the same "one table, two implementations" pattern as the hostile-name table, because the extension's copy of this logic runs precisely when the sidecar is unreachable, so a divergence would be invisible until it misfiled something. It immediately earned itself: `urlsplit` parses `"not a url"` as a relative path and yielded a two-word "thread subject" where JS's `new URL` throws.

## Not verified

- **Nothing here has run in a browser.** The extension changes (`openerTabId` on the sender, the picker's kind prompt, the referrer carry through real tab chains) are proven against a mocked `chrome` API only.
- **Only a real download can settle**: whether Discord's CDN URL survives to `item.url` unmodified, whether a real forum's thread-slug shapes are covered, and whether the opener-tab chain actually holds through a target=_blank click-through.
- The live sidecar runs from the nix store and is **untouched** by this branch — it still reports `configured=true`, 26 dirs. Deploying needs `home-manager switch`, and the first thing to run after that is `dl-route dirs classify`: until `dirs.toml` exists **nothing auto-files at all**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
