### PR TITLE
docs(browser): split SKILL.md into a lean core + 8 symptom-triggered reference files (~14.0K → ~2.8K tokens per browser task)

### DIFF
--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -3,755 +3,135 @@ name: browser
 description: Drive the user's LIVE, logged-in Brave browser from Claude Code — read the active tab's HTML, run JS in it, list/navigate tabs, and screenshot the visible tab — via the local token-authenticated browser-bridge (loopback rendezvous server + MV3 extension). Use when the user asks you to look at / read / scrape / interact with a page THEY have open, act on an authenticated site they're logged into, check what's on their screen in Brave, navigate their browser, or grab a screenshot of their current tab. NOT for headless fetching of public URLs (use WebFetch) — this is specifically their real, authenticated session.
 ---
 
-```
-~/workspace/devrc/scripts/browser-bridge/browser <subcommand>
-```
-
-**Run it by that exact path** (also `~/.claude/skills/browser/browser` if the
-skill dir is symlinked). Don't hunt for it under `~/.claude/skills/...`.
-
-## Quick start / binary path
+## Quick start — orient FIRST
 
 ```bash
-BB=~/workspace/devrc/scripts/browser-bridge/browser   # ← the executable
-$BB whoami                          # ORIENT FIRST — which HOST (laptop/workbench; both are hostname 'nixos'),
-                                    #   which profiles/instances are connected, loaded-vs-repo extension version.
-                                    #   Run this BEFORE grabbing the browser so you know which machine/profile you're driving.
-$BB health                          # is an extension connected?
-$BB --instance <key> open <url>     # open a NEW tab this session owns
-$BB --instance <key> --tab <id> html   # act on a specific tab
+BB=~/workspace/devrc/scripts/browser-bridge/browser   # ← run it by this exact path
+$BB whoami                          # ORIENT FIRST: which HOST + which profiles are connected
+$BB health                          # is an extension connected? loaded vs repo extension_version
+$BB --instance <key> open <url>     # open a NEW tab THIS session owns → returns tabId
+$BB --instance <key> --tab <id> text   # cheap read of a specific tab
 ```
 
-**Orientation rule:** on a fresh browser task, run `whoami` first (both hosts are
-hostname `nixos`, and this session's loopback bridge could be either machine with
-multiple profiles) — confirm the host + pick the right `--instance` before acting.
+🔴 **Run `whoami` first on every fresh browser task.** Both hosts are hostname
+`nixos`, and this session's loopback bridge could be either machine with several
+Brave profiles — confirm the host and pick the right `--instance` before acting.
 
-## ⚠ The LOADED extension may be older than this doc
+Full architecture / security model: `scripts/browser-bridge/README.md`.
 
-The CLI is always current; the **extension build running in Brave is not**. Brave
-does not hot-reload unpacked extensions, so the live service worker can be far
-behind. Symptom, seen for real:
+## Ops
 
-```
-$ browser --instance work open https://example.com
-op 'open' failed in the browser: unknown_op
-```
+Global flags, usable before any op: `--instance <key>` (which profile),
+`--tab <id>` (explicit tab), `--frame <numericId|urlSubstring>` (inside an iframe).
+Result payloads land under `.result.data`.
 
-**`open` answering `unknown_op` means the loaded extension predates owned-tab
-support** — the whole "per-session tab isolation" section below is unavailable
-until the user reloads it. Don't debug the server; **tell the user to click reload
-↻ on the card in `brave://extensions`**. Meanwhile work without `open`: run
-`browser tabs`, pick an existing tab, and pass `--tab <id>` on every op (or just
-read the active tab for a one-shot). Same reasoning for any op that answers
-`unknown_op` (e.g. `upload` on a pre-0.2.0 extension).
+| command | does |
+|---|---|
+| `whoami` | **read-only identity** (global; no `--instance`/`--tab`) — host label (`laptop`/`workbench`), connected instances (active-tab **domain** only), bridge diagnostics + `extension_version_current` |
+| `health` | connected instances + count; compare each instance's loaded `extension_version` against `extension_version_current` (repo manifest) by eye — mismatch = STALE |
+| `instances` | list connected instances as JSON (key, label, instanceId, active-tab url/title) |
+| `open [url]` | open a NEW tab this session owns (default `about:blank`, **created in the BACKGROUND/hidden**), returns `tabId`. Idempotent. Use for multi-step work |
+| `close` / `release` | close this session's owned tab / drop ownership without closing it |
+| `tabs` | list open tabs (`.data.ownedTabId` flags yours) |
+| `nav <url>` | navigate the owned/active tab |
+| `text [selector] [--max-bytes N]` | **cheap read** — visible `innerText` (optional CSS selector), whitespace-normalized, byte-capped (default 32768; `0`=uncapped; truncation appends a note + sets `truncated`). ~98% smaller than `html` — **prefer it** |
+| `html [--max-bytes N]` | `outerHTML`, same byte cap. One uncapped `html` on a heavy SPA is ~100K tokens — the cap is ON by default |
+| `js '<expr>'` (alias: `eval`) | run JS in the tab, return its value. Same op on the wire either way. **Prefer `js` in a worktree-isolated agent** — Claude Code's isolation guard refuses any command containing the literal token `eval` (it matches the WORD, not the behaviour: this ships JS over loopback to Brave and touches no filesystem) |
+| `screenshot [path] [--fullpage] [--data-url]` | CDP capture — **works on a BACKGROUND/occluded tab**. **Always writes a `.png`** (to `path`, else a mode-0600 temp auto-pruned after 24h) and prints `{ok,path,bytes,url,via}`; the base64 is **NEVER** printed (it cost 133K–890K tokens/call) — **`Read` the `.png`**. `--data-url` is the escape hatch |
+| `frames` | list the tab's frames (`frameId`/`url`/`parentFrameId`) **including cross-origin OOPIFs** — pick a numeric `frameId` for `--frame` |
+| `click <selector>` | click the element's center — **TRUSTED** CDP on the top frame, **SYNTHETIC** inside `--frame` |
+| `type <text> [--selector S]` | text input — TRUSTED CDP top frame, SYNTHETIC in-frame |
+| `key <Enter\|Tab\|Escape\|Backspace\|Delete\|Arrow*\|Home\|End\|Page*> [--selector S]` | one bounded keypress, same trust rules |
+| `upload <selector> <path>` | populate an `<input type=file>` via CDP `DOM.setFileInputFiles` — Chrome reads the file by path, **no bytes cross the bridge**. AUDIT-LOGGED, **operator-only** (the agent gets `op_not_allowed:upload`) |
+| `wake [--wait MS]` | **UN-THROTTLE a hidden/background tab with NO focus movement** — the fix for an empty or `hidden` read. ~1.5s settle, cap **6s**. **Wake once per PAGE, not per read**: the un-throttled state ends at detach, but the DOM the page rendered PERSISTS for a following cheap read |
+| `text\|html\|js --wake[=MS]` | run THAT ONE read inside the woken CDP session — only when the read must observe live un-throttled state. `text`/`html --wake` read from an ISOLATED world; `js --wake` is MAIN world by definition. `--wake` + `--frame` is refused (`wake_with_frame_unsupported`) |
+| `activate` | **⚠⚠ STEALS THE OPERATOR'S SCREEN — the ONE intrusive op, a LAST RESORT.** It is **NOT** the fix for a hidden/unrendered tab — that is `wake`. Use it only for something needing the REAL foreground (a browser permission prompt, a native file picker, seeing it with your own eyes), at most **once per TAB, never per read**. i3-gated; unreachable by the autonomous agent |
+| `agent "<goal>"` | run the autonomous opencode browser-agent in its OWN isolated tab; returns compact `{answer,evidence,steps_used,status}` instead of page HTML → `reference/agent.md` |
+| `--print-session-id` | print the derived per-session id (debug) |
 
-The CLI now **detects this for you**: any op the CLI dispatches that returns a
-server-side `unknown_op` is mapped to a clear message + non-zero exit telling you
-the loaded extension is OLDER than the CLI and to reload/restart. **`browser
-health` also shows the build** — each instance's loaded `extension_version` vs the
-bridge's `extension_version_current` (repo manifest); a mismatch = stale.
+## 🔴 Four traps that return a WRONG answer SILENTLY
 
-**⚠ Reload ↻ is UNRELIABLE — a full Brave restart is the reliable fix.** The
-extension's long-poll keeps the OLD service worker permanently alive, so clicking
-↻ in `brave://extensions` often does NOT swap in the new build. If a reload
-doesn't take (the op still returns `unknown_op`, or `health` still shows the old
-`extension_version`), tell the user to **fully quit and reopen Brave**.
+These stay here because you only learn you needed them *after* being misled.
 
-**Nuance (measured 2026-07-30): a ↻ reload DID take** — swapping in a new build after an
-earlier full restart in the same Brave session. So ↻ is worth trying **first**, but only
-when you have a **deterministic tell** for whether it took. Don't reason about it; test
-it. Pick something the new build emits that the old one cannot, e.g. the nested-OOPIF
-`cascade[…]` trace: old build → a bare `frame_not_found:<url>`, new build → the same
-error **plus** the trace. That turns "did the reload take?" from an unfalsifiable guess
-into one command. With no such tell, skip ↻ and do the full restart.
+1. **`js`/`eval` evaluates ONE EXPRESSION, not a script.** A multi-statement body
+   (`window.scrollBy(0,1400); "ok"`) returns **`null` with no error** — it looks
+   like a broken bridge and isn't. Wrap it: `(function(){ …; return x })()`.
+2. **Strict page CSP silently blocks the injected script — notably GitHub.** Even
+   `document.title` comes back `null`, no error. **Use `text`/`html` there — they
+   work**, because they don't inject script. (`chrome://`/`brave://` URLs also give
+   `null` + `Cannot access a chrome:// URL`.)
+3. **A background/hidden tab is THROTTLED → a shell-only DOM**, indistinguishable
+   from a genuinely broken site. `open` creates tabs hidden, so this is the common
+   case. Check `data.hidden` / `document.visibilityState`, then **`wake`** — never
+   `activate`, and spoofing `visibilityState` does not recover the page.
+   → `reference/spa-wake.md`
+4. **A stale loaded extension answers `unknown_op`** for an op the CLI knows, and
+   **reload ↻ in `brave://extensions` is UNRELIABLE** (the long-poll keeps the old
+   service worker alive) — a **full quit-and-reopen of Brave** is the reliable fix.
+   → `reference/errors.md`
 
-## `eval` gotchas — a `null` result does NOT mean the bridge is down
-
-- **`eval` evaluates ONE EXPRESSION, not a script.** A multi-statement body
-  (`window.scrollBy(0,1400); "ok"`) returns **`null` with no error** — it looks
-  like a broken bridge and isn't. Wrap it: `(function(){ window.scrollBy(0,1400);
-  return "ok" })()`, or use the comma operator.
-- **`eval` can't run on `chrome://` / `brave://` URLs** — expect `Cannot access a
-  chrome:// URL` (and a `null` result).
-- **Strict page CSP silently blocks the injected script — notably GitHub.** On a
-  GitHub page even `document.title` comes back `null`, no error. **Use `html` /
-  `text` there — they work**, because they don't inject script.
-
-So on a `null`: first suspect a multi-statement body, then page CSP; fall back to
-`text`/`html` before concluding the bridge is down.
-
-### Cookies and authenticated requests
-
-**There is no cookie op** — the extension has no `cookies` permission, on purpose
-(README → *Security model*). So `eval` + `document.cookie` is the only route, and
-it is structurally blind to **HttpOnly** cookies — which is exactly what a session
-/ auth cookie always is. On a CSP-strict origin you also just get `null`, which
-reads like a dead bridge.
-
-**Don't extract the cookie — make the request from inside the page.** An in-page
-`fetch(url, {credentials:"include"})` attaches the cookies (HttpOnly included)
-automatically and hands back only the data: no new permission, and no credential
-value ever enters the transcript. `eval` takes ONE EXPRESSION, so use an async
-IIFE — the promise IS awaited (top frame `chrome.scripting`, `--frame` CDP
-`awaitPromise:true`), you get the resolved value, not a pending Promise:
+**Cookies / authenticated requests.** There is no cookie op (no `cookies`
+permission, on purpose), and `document.cookie` is structurally blind to **HttpOnly**
+— which a session cookie always is. Don't extract the cookie; **make the request
+from inside the page**, so no credential ever enters the transcript:
 
 ```bash
 browser js '(async function(){ const r = await fetch("/api/thing", {credentials:"include"}); return JSON.stringify({status:r.status, body:(await r.text()).slice(0,500)}) })()'
 ```
 
-⚠ **This does NOT work on CSP-strict origins** (GitHub, Discord, …) — the injected
-script never runs there at all, so an authenticated API call *through the page* is
-simply unavailable; `text`/`html` are the only reads that work.
-
-## The user is USING this browser
-
-It's their live session, not a scratch VM. Don't `nav` a tab that may hold unsaved
-work (a half-typed comment, a form, a logged-in console) — prefer a
-`chrome://newtab`/obviously disposable tab, or `open` your own when the extension
-supports it. If you focus a window to capture it, **restore their focus
-afterwards** (`i3-msg '[id="<prev-winid>"] focus'`).
-
-## Concurrency / don't do this
-
-- **Concurrent drivers (esp. sibling subagents) → each `open` and thread its own
-  `--tab <id>`.** Sibling subagents of one parent SHARE a session id (they
-  inherit `CLAUDE_CODE_SESSION_ID` + `$TMUX_PANE`), so without explicit `--tab`
-  they fight over the SAME active tab. Have each driver `browser open` (capture
-  the returned `tabId`) and pass `--tab <id>` on every subsequent op.
-- **Do NOT run a bare high-rate `eval` loop** (no `--instance`/`open`). It shares
-  the one active tab AND saturates the single serial extension connection; the
-  server now **rate-limits** it and returns **HTTP 429** (`rate_limited` /
-  `queue_full`) — the `browser` CLI prints a back-off message and exits non-zero.
-  Batch what you need into fewer `eval`s, or space them out.
-
-# browser — drive the live Brave session
-
-`browser-bridge` lets you operate the user's **real, logged-in Brave** browser.
-Commands go: the `browser` CLI → a loopback rendezvous server (`127.0.0.1:8788`,
-bearer-token auth) → a standalone MV3 extension in the live Brave session →
-executed against the **active tab** → result back to you.
-
-This is authorized personal automation on the user's own workbench. It is a
-**sibling** to the activity-collector browser extension (telemetry) — different
-subsystem, do not conflate.
-
-Full architecture, security model, and deploy: `scripts/browser-bridge/README.md`.
-
-## Entrypoint
-
-`scripts/browser-bridge/browser <subcommand>` (JSON on stdout, pretty-printed if
-`jq` is present):
-
-Prefix any op with `--instance <key>` to target a specific connected profile
-(`browser --instance work html`) and/or `--tab <id>` to target an explicit tab.
-
-| command | does |
-|---------|------|
-| `browser health`            | connected instances + count: `{"ok":true,"extension_connected":bool,"count":N,"extension_version_current":"<repo manifest>","instances":[{…,"extension_version":"<loaded>"}]}`. Each instance now shows its **loaded `extension_version`** and the bridge shows **`extension_version_current`** (the repo manifest) — eyeball loaded-vs-current to spot a STALE extension |
-| `browser whoami`            | **read-only identity + diagnostics** (global; no `--instance`/`--tab`). Reports **which HOST** (`host.label` = `laptop`/`workbench`/`unknown`, resolved `ACTIVITY_HOST` env → the activity-collector env file → LAN-IP detect, with `host.source` naming the method + `host.ips`), the connected **instances** (`key`/`label`/`instanceId` + active-tab **DOMAIN** only + reported `extension_version`), and **bridge** diagnostics (`endpoint`/`port`/`server_version`{version+git-HEAD}/`connected` count/`rate_limit` + `extension_version_current` = the manifest version the SERVER reads from the repo). Use it FIRST to confirm you're on the right host/profile (both hosts are hostname `nixos`). ⚠ There is deliberately **no hard "stale" flag** — the manifest version isn't bumped per-change, so compare `extension_version` (loaded) vs `extension_version_current` (repo) by eye. `extension_version` shows `null` until an extension build that reports it has reloaded; the rest of whoami needs NO extension change/reload. |
-| `browser instances`         | list connected instances as JSON (routing key, label, instanceId, active-tab url/title) |
-| `browser [--instance K] open [url]`        | open a NEW tab THIS session owns (default `about:blank`, created in the **background/HIDDEN** — `active:false`); records ownership; returns its `tabId`. Use for multi-step work. ⚠ A background tab is `document.visibilityState:"hidden"` → **Chromium throttles it, so a heavy SPA never renders** and a subsequent `text`/`html`/`eval` returns a **shell-only DOM** (indistinguishable from a broken site). The reads now **self-announce** this (`data.hidden:true` + a one-line warning on stderr); the escape hatch is **`browser wake`** — it un-throttles the tab via CDP focus emulation and **does NOT move the operator's focus**. (`browser activate` also un-throttles, but it STEALS THE OPERATOR'S SCREEN — last resort only.) |
-| `browser [--instance K] close`             | close this session's owned tab and drop ownership |
-| `browser [--instance K] release`           | drop ownership WITHOUT closing the tab |
-| `browser [--instance K] [--tab T] html [--max-bytes N]` | `outerHTML` of the owned tab (else the active tab), byte-capped exactly like `text` (default 32768; `0`=uncapped; truncation appends `…[truncated N bytes]` and sets `truncated`). One uncapped `html` on a heavy SPA is ~100K tokens — the cap is ON by default. Prefer `text` anyway |
-| `browser [--instance K] [--tab T] text [selector] [--max-bytes N]` | **cheap read** — visible `innerText` of the owned/active tab (optional CSS `selector`), whitespace-normalized + byte-capped (default 32768; `0`=uncapped; a truncation note is appended). ~98% smaller than `html` — prefer it |
-| `browser [--instance K] [--tab T] [--frame F] js '<js>'` | **ALIAS of `eval`** — identical semantics and flags (`--frame` included, so everything the `eval` row says about nested OOPIFs applies verbatim), and the op sent ON THE WIRE is `eval` either way. **Prefer `js` when you are a worktree-isolated agent:** Claude Code's isolation guard pattern-matches the literal token `eval` in a command string and REFUSES to run it ("runs a string through eval, which can't be verified to stay inside the worktree"). The guard reacts to the WORD, not the behaviour — this op ships JS over loopback to Brave and runs it in the PAGE; it touches no filesystem and cannot escape the worktree. `eval` remains valid everywhere else and is NOT deprecated |
-| `browser [--instance K] [--tab T] [--frame F] eval '<js>'` (alias: `js`) | run JS in the owned/active tab, return its value. **`--frame` runs the JS INSIDE the target frame (incl. a cross-origin OOPIF) via CDP `Runtime.evaluate`** (not `chrome.scripting`, which can only run a func — the old path returned `value:null`); a frame that can't be resolved / an exception → a clear `frame_not_found` / `frame_eval_failed:<reason>` error, never a silent null; reports the frame's own `url`. **NESTED (grandchild+) OOPIFs are reached** via a bounded recursive auto-attach cascade — capped at depth 5 / 50 targets (`oopif_depth_cap` / `oopif_target_cap`), duplicate-URL frames fail `ambiguous_frame`; every failure carries a bounded `cascade[…]` diagnostic |
-| `browser [--instance K] tabs`              | list open tabs (`.data.ownedTabId` flags this session's owned tab) |
-| `browser [--instance K] [--tab T] nav <url>`         | navigate the owned/active tab to `<url>` |
-| `browser [--instance K] [--tab T] screenshot [path] [--fullpage] [--data-url]` | screenshot via **CDP `Page.captureScreenshot`** — **works on a BACKGROUND/occluded tab** and on each profile's own tab (a foreground tab uses the cheap captureVisibleTab fast path). `--fullpage` grabs the whole scrollable document. **Always writes a `.png`**: to `path` if given (prints the path), else to a **mode-0600** temp file (honours `TMPDIR`) and prints compact JSON `{ok,path,bytes,url,via}`. **The base64 data URL is NEVER printed** — it cost 133K–890K tokens per call and you can't see an image from a data URL anyway; **`Read` the `.png`**. A screenshot is a pixel-perfect image of an **authenticated** view, so temp captures are owner-only and **auto-pruned after 24h** (prefix-scoped, best-effort) — copy one to `path` if you need to keep it. The payload is validated (strict base64 + PNG signature) before any write, so a failed capture errors instead of leaving a 0-byte `.png`. `--data-url` is the escape hatch that restores the old raw-data-URL output (mutually exclusive with `path`) |
-| `browser [--instance K] [--tab T] frames`  | list the tab's frames (`frameId`/`url`/`parentFrameId`) via `chrome.webNavigation`, **INCLUDING cross-origin OUT-OF-PROCESS iframes (OOPIFs)** — pick a numeric `frameId` (or url-substring) for `--frame` |
-| `browser [--instance K] [--tab T] [--frame F] click <selector>` | click the element's center — **TRUSTED** CDP on the top frame; **SYNTHETIC** (`chrome.scripting`) inside a cross-origin `--frame` |
-| `browser [--instance K] [--tab T] [--frame F] type <text> [--selector S]` | text input — **TRUSTED** CDP top frame; **SYNTHETIC** in-frame (focus `--selector` first if given) |
-| `browser [--instance K] [--tab T] [--frame F] key <Enter\|Tab\|Escape\|Backspace\|Delete\|Arrow*\|Home\|End\|Page*> [--selector S]` | dispatch one bounded key — **TRUSTED** CDP top frame; **SYNTHETIC** in-frame |
-| `browser [--instance K] [--tab T] [--frame F] upload <selector> <path>` | populate the `<input type=file>` at `<selector>` with the LOCAL file `<path>` via **CDP `DOM.setFileInputFiles`** — Chrome reads the file BY PATH itself (same host), so **no bytes cross the bridge**. The CLI validates the path (readable regular file) + resolves it to ABSOLUTE **before** dispatch; `--frame` routes into a cross-origin OOPIF (incl. a NESTED one — same bounded cascade + caps as `eval --frame`). **Bounded TYPED op, own-tab, NO raw-CDP passthrough** — but it IS **data-exfil-capable** (any readable file's CONTENTS could be posted to the site), so **every upload is AUDIT-LOGGED** (op + target domain + path) and it is **OPERATOR-ONLY: `upload` is NOT in the autonomous browser-agent's default op set** (the model gets `op_not_allowed:upload`; re-enable only via an explicit `BROWSER_AGENT_ALLOWED_OPS` opt-in). Result carries the basename only |
-| `browser [--instance K] [--tab T] wake [--wait MS \| --no-wait]` | **UN-THROTTLE the owned/active tab WITHOUT touching focus** — the fix for a `hidden`/empty read. A background tab gets NO animation frames and ~1 Hz timers, so a heavy SPA never paints; `wake` attaches CDP to that tab only, turns on `Emulation.setFocusEmulationEnabled` (+ a best-effort `Page.setWebLifecycleState` thaw), holds it ~1.5s (cap **6s**, `--wait MS` — derived so the settle plus one worst-case CDP command still fits the op budget) so the page renders, then **explicitly disables focus emulation** and detaches (the revert is never left to detach). Returns `{woke,visibilityState,readyState,applied,settleMs,…}`; `woke` is probed from an ISOLATED world, so a page cannot fake it. **Nothing in this path moves the operator's screen** (no `i3-msg`, no tab/window focus change). ⚠ The un-throttled STATE ends at detach (measured) — what persists is the **DOM the page rendered**, which is what a following cheap read wants. If a read must OBSERVE live un-throttled state, use `--wake` on that read instead. |
-| `browser … text\|html\|js [--wake[=MS]]` | run THAT ONE read inside a woken CDP session (same un-throttle, applied in the same session as the read). Opt-in on purpose: the default read path stays on `chrome.scripting` with **no debugger banner**, and routing every read through CDP would flash "an extension is debugging this browser" on every read. `--wake` + `--frame` is refused (`wake_with_frame_unsupported`) — `wake` first, then the frame read. |
-| `browser [--instance K] [--tab T] activate [--wait MS \| --no-wait]` | **FOREGROUND** the owned/active tab. **⚠⚠ STEALS THE OPERATOR'S SCREEN — the ONE intrusive op**, and a **LAST RESORT**. It is **NOT** the remedy for a throttled/hidden tab — that is `wake` (above), which achieves the same rendering without touching focus. Use `activate` only when something genuinely needs the REAL foreground: a browser permission prompt, a native file picker, or seeing the page with your own eyes. **Needed at most ONCE PER TAB — never per read** (telemetry caught a session calling it 1–5×/minute, grabbing the operator's screen on nearly every interaction). Foregrounds via **host-side `i3-msg`** (Chrome-side `tabs.update`/`windows.update` is a no-op on i3), so it works ONLY on a graphical i3 host; returns **`i3:"applied"\|"skipped"\|"failed"`** alongside `{tabId,windowId,url,title,active,status}`. Waits (bounded, default ~3s, cap ~8s) for `status:"complete"` + a paint settle unless `--no-wait`. **Operator-only — absent from the autonomous agent's op set.** |
-| `browser [--instance K] agent "<goal>" [flags]` | run the **autonomous opencode browser-agent** in its OWN isolated tab against `<goal>`; returns a compact `{answer,evidence,steps_used,status}` (see below) |
-| `browser --print-session-id`               | print the derived per-session id (debug) and exit |
-
-`--frame <F>` (a **numeric** `frameId` from `frames`, or a URL substring) routes a
-`text`/`html`/`click`/`type`/`key` INTO that frame via `chrome.scripting` — which
-reaches CROSS-ORIGIN out-of-process iframes (OOPIFs). A frame-scoped fixed-func read
-runs in an **isolated world** (DOM-capable; it does not see that frame's page globals).
-**`eval --frame` is the exception: it runs the JS string via CDP `Runtime.evaluate`**
-(`chrome.scripting` can only run a serialized func, so the old path evaluated nothing and
-returned `value:null`) — same-process frames in an isolated world, a cross-origin OOPIF
-in its own flat session; a resolve/exec failure is a clear `frame_not_found` /
-`frame_eval_failed` error, never a silent null.
-In-frame `click`/`type`/`key` dispatch **SYNTHETIC** events (`isTrusted:false`, the
-reachable OOPIF path — drives most apps); the result carries `trusted:false` for
-`--frame` input and `trusted:true` for top-frame CDP input. A `--frame` op reports the
-FRAME's own `url` (so you can confirm you read the intended frame, not the top).
-
-**Picking `--frame` reliably (avoid the wrong frame):** prefer a **numeric `frameId`**
-from `frames` — it always wins and is never ambiguous. A URL substring is resolved
-**HOST-first** (matched against each frame's hostname before its path), so
-`--frame model-benchmarking` targets the OOPIF `model-benchmarking.civit.ai` rather than
-the top page's `civitai.com/apps/run/model-benchmarking` PATH. If a substring still
-matches **multiple** frames the op fails with `ambiguous_frame:<n> [<id>:<url>, …]`
-listing the candidates — re-issue with the numeric `frameId` (it does NOT silently pick
-the first match). So: **use the numeric id, or a host substring** — not a bare path token.
-**⚠ The numeric-id escape hatch does NOT apply to `eval`/`upload --frame` on a
-cross-origin OOPIF** — see the duplicate-URL limitation below.
-
-**Nested OOPIFs (OOPIF-in-OOPIF) — supported, with hard caps.** `Target.setAutoAttach`
-is not recursive (it attaches only a session's DIRECT child targets), which is why
-`eval --frame` on a **grandchild** cross-origin iframe used to return `frame_not_found`.
-It now **re-arms auto-attach on each attached child session**, walking the cascade DOWN
-the frame tree until the wanted frame's target appears — so a grandchild (and deeper)
-cross-origin frame IS reachable by `eval --frame` and by the OOPIF branch of
-`upload --frame`. Because a hostile page can nest/spawn frames without limit, the descent
-is **hard-bounded** and every bound fails LOUD (never a silent truncation, never a hang):
-
-| failure | error | meaning |
-|---------|-------|---------|
-| frame never attaches within the bounded wait (5 s **hard** ceiling, checked every iteration; 600 ms quiet-window settle, restarted on each new `setAutoAttach`) | `frame_not_found:<url> cascade[…]` | the frame isn't there — **plus a bounded diagnostic**, see below |
-| nesting deeper than **5** levels below the tab | `oopif_depth_cap:5` | we deliberately stopped descending |
-| more than **50** attached targets for one op | `oopif_target_cap:50` | frame-spamming page; work is bounded |
-| two attached frames share the target URL | `ambiguous_frame:<n> [<sessionId>:<url>, …]` | **no escape hatch — see below**; it never silently picks one |
-
-Both caps are named constants in `extension/protocol.js` (`OOPIF_MAX_DEPTH`,
-`OOPIF_MAX_TARGETS`, `OOPIF_SETTLE_MS`, `OOPIF_WAIT_MS`) and the whole cascade stays well
-under the per-op CDP budget. `text`/`html`/`click`/`type`/`key --frame` reach a nested
-frame as they always did (they use `chrome.scripting`, not CDP).
-
-**Every discovered target is filtered before it can ever be an eval target** — the
-recursion removed the old implicit "one level below a validated tab" boundary, so the
-boundary is now explicit: **own tab** (`chrome.debugger.onEvent` is global; a foreign
-`source.tabId` is dropped — and a caller that omits the tab fails CLOSED), **`iframe`
-targets only** (so a page's `new Worker(location.href)` can neither deny service by
-forcing `ambiguous_frame` nor capture your JS in a worker global), and **http/https
-only** (the same scheme gate the top tab passes, so a `chrome-extension://` child — any
-extension's web-accessible resource — can never become an eval target one level down).
-
-**⚠ Duplicate-URL OOPIFs are UNREACHABLE by `eval`/`upload --frame`, and the numeric
-`frameId` does NOT help.** The CDP path matches the frame purely by URL (a numeric
-webNavigation frameId has no 1:1 CDP target mapping), so two identical
-`<iframe src="https://embed.example/widget">` — a duplicated ad/widget slot, which is
-common — both match and the op fails `ambiguous_frame` with no way to pick one. That is a
-deliberate refusal, not a silent wrong-frame, but it IS a dead end: use
-`text`/`html`/`click`/`type`/`key --frame` (which resolve by numeric frameId and are
-unaffected), or change the page selector. A parent-chain tiebreak is a filed follow-up.
-
-**Every OOPIF failure carries a bounded `cascade[…]` diagnostic** naming the loop exit
-(`match`/`settle`/`deadline`/`depth-cap`/`target-cap`), which sessions were auto-attached,
-and — for up to 20 observed targets — the target `type`, whether `source.tabId` was
-present/matched, whether the parent session was known, the computed depth, and why each
-was dropped (`drop:type`/`drop:scheme`/`drop:foreign-tab`/`drop:unowned`/`drop:dup`).
-It is **caller-facing text only** — telemetry stays metadata-only. Read it before
-theorising about a `frame_not_found`.
-
-**✅ LIVE-VERIFIED against real Brave** (`tests/fixtures/oopif-rig/`, both checks). A
-grandchild OOPIF evaluates correctly, and on the 7-level deep rig depth 3 and depth 5
-resolve while depth 6 is refused with `oopif_depth_cap:5` and a full trace showing four
-chained sub-session auto-attaches. **`OOPIF_MAX_DEPTH = 5` is a real, measured guarantee**
-— not a contingent one.
-
-**📌 Discovered Chrome behaviour (cost a full verify round — remember it):
-Chrome does NOT populate `source.tabId` on SUB-session `Target.attachedToTarget` events.**
-They carry `sessionId` only. An own-tab check that requires `tabId` therefore silently
-eats every level-2+ event and the whole cascade goes **inert** — it returns
-`frame_not_found` and *never* a depth cap, because no nested session is ever recorded.
-Ownership is consequently proven by **session parentage**: an event whose
-`source.sessionId` is a session this cascade itself attached is ours. `tabId` stays
-authoritative when present; an event proving neither is dropped. If you ever add a
-listener-side own-tab gate to a flat-mode CDP cascade, this is the trap.
-
-Result payloads land under `.result.data` in the JSON (the envelope is
-`{"ok":true,"result":{"id","ok","data":{...}}}`).
-
-## Frame ops (webNavigation + scripting) & CDP ops (debugger)
-
-`frames` + `--frame` reach cross-origin OUT-OF-PROCESS iframes (OOPIFs) via
-`chrome.webNavigation` + `chrome.scripting`; `screenshot` + TOP-frame trusted input use
-the Chrome DevTools Protocol (`debugger` permission). Together they fix three real
-limitations:
-
-1. **Screenshot a BACKGROUND / occluded tab** (and each profile's own tab) — CDP
-   `Page.captureScreenshot` does not need the tab to be the on-screen foreground
-   tab, so the old i3 "not visible on-screen" limitation is gone for the normal
-   path. (`--fullpage` grabs the whole scrollable document.)
-2. **Read/drive INTO a CROSS-ORIGIN iframe (the OOPIF fix)** — `browser --tab T frames`
-   now LISTS the cross-origin frame (e.g. `model-benchmarking.civit.ai` inside
-   `civitai.com`) because `chrome.webNavigation.getAllFrames` enumerates OOPIFs that
-   CDP `Page.getFrameTree` could not; then `browser --tab T --frame <numericId-or-url>
-   text` reads inside it and `--frame … click/type/key` drives an in-app control (via
-   `chrome.scripting` injection), while `--frame … eval '<js>'` runs a JS string inside
-   it via CDP `Runtime.evaluate` (e.g. `--frame <oopif> eval 'location.href'` returns the
-   OOPIF's own url, not null). Plain `text`/`html`/`eval` (no `--frame`) still see only
-   the top frame.
-3. **Drive an app's TOP frame with trusted input** — top-frame `click`/`type`/`key`
-   dispatch real `isTrusted` events via CDP. (In a cross-origin `--frame`, input is
-   SYNTHETIC — see above.)
-
-**Security model (built in — this is the point):**
-- **Frame enumeration + injection are STRICTLY own-tab-scoped.** `getAllFrames` and
-  `executeScript` are tab-scoped, so a model-supplied `--frame` can only ever resolve
-  to / inject into a frame of the session's owned/`--tab` tab — never another tab.
-- **CDP attach is STRICTLY own-tab-scoped.** The server routes a CDP op only to the
-  session's owned/`--tab` tab; the extension attaches `chrome.debugger` ONLY to that
-  tab and **refuses to attach to a privileged surface** (`chrome://`, extension,
-  `devtools:`, `file:`) — the attach is validated *before* it happens. The
-  autonomous agent's tab is FORCED, so it can never attach to another tab/profile.
-- **NO raw-CDP passthrough.** The agent's typed tool exposes ONLY the bounded ops
-  with typed scalars — there is no `cdp`/`method`/`params` field, so the model can
-  never send an arbitrary CDP command (no `Page.navigate file://`, no `Browser.*`,
-  no exfil `Runtime.evaluate`). Arbitrary CDP would reintroduce an RCE-class hole.
-- **Always detach.** Every CDP op is attach→run→**detach** (a `finally`, so a thrown
-  op still detaches) — no leaked attachment / stuck banner. An out-of-band detach is
-  handled too.
-- **Metadata-only telemetry** still holds: op/domain only — never frame URLs, typed
-  text, eval source, or screenshot bytes.
-
-**Tradeoff — the debug banner:** while a CDP op runs, Brave shows an "an extension
-is debugging this browser" banner. Attach is per-op (attach → run → detach) to keep
-that window tiny; a simple top-frame `text`/`html`/`eval`/foreground-`screenshot`
-takes the lighter non-CDP path and shows no banner.
-
-> **After updating the extension you MUST reload it** (the manifest gained the
-> `debugger` permission) — see the reload section below; Brave may prompt to
-> re-confirm the new permission.
-
-### The X-server fallback (still available for a genuinely un-composited window)
-
-If a window is on another i3 workspace and even CDP capture is unsatisfactory, you
-can still bypass the extension and capture the X window directly:
-
-```sh
-# 1. The Bash tool has NO X env by default — without this xdotool silently
-#    "sees" zero windows and every search returns nothing.
-export DISPLAY=:0 XAUTHORITY=/home/zach/.Xauthority
-
-# 2. Find the window by PAGE TITLE, not by class — several Brave windows exist
-#    and class-matching gives you an arbitrary one.
-nix-shell -p xdotool --run 'xdotool search --name "<page title fragment>"'
-
-# 3. Make it VISIBLE — focusing its workspace is not enough.
-i3-msg '[id="<winid>"] focus'
-
-# 4. Capture (settle first; the compositor needs a beat after the raise).
-nix-shell -p xdotool maim --run 'xdotool sleep 2; maim -i <winid> out.png'
-nix-shell -p imagemagick --run 'magick out.png -crop WxH+X+Y +repage cropped.png'
-```
-
-Two traps that produce a confidently-wrong result:
-
-- **A window on the focused workspace can still be *behind* another window** — the
-  capture then comes back blank/dark while `maim` exits 0. **Verify by LOOKING at
-  the image**, never by trusting the exit code.
-- **`maim -i <winid>` captures whatever tab is active in that window**, which may
-  not be the tab you just `nav`ed. After navigating, re-find the window **by the
-  new page title** so you're capturing the tab you think you are.
-- *(Future option, NOT implemented: a `chrome.debugger` + CDP
-  `Page.captureScreenshot` path could capture an off-screen tab, but it needs the
-  `debugger` permission and shows a debug banner — deliberately out of scope.)*
-
-## Driving a throttled/backgrounded SPA (the `wake` pattern)
-
-A heavy SPA opened in a **backgrounded** tab is throttled by Chrome —
-`document.visibilityState:"hidden"`, so it gets **no animation frames at all** and
-~1 Hz timers, and it often **never finishes rendering**. You then can't read or
-drive it: `text`/`frames` come back empty or half-built, and in-frame
-`click`/`type` hit elements that don't exist yet. Verified case:
-`model-benchmarking.civit.ai` (an OOPIF inside a `civitai.com` tab) stayed blank
-while backgrounded.
-
-🔴 **Before you believe any "nothing rendered / no requests fired" reading:**
-
-- **Check `document.visibilityState` FIRST**
-  (`browser --tab <id> eval 'document.visibilityState'`). If `"hidden"`, that
-  reading is MEANINGLESS — a shell-only DOM is indistinguishable from a genuinely
-  broken frontend. (Reads self-announce it: `data.hidden:true` + a stderr warning.)
-- **Spoofing it afterwards does NOT recover the page.**
-  `Object.defineProperty(document,'visibilityState',…)` changes nothing: the
-  throttling is browser-enforced and the app's fetch decisions are already made.
-  **`wake` is the fix** — not a spoof, and not `activate`.
-- 🔴 **"Is this page broken for REAL users?" is not a browser question.** Answer it
-  from server-side/real-user evidence — RUM, metrics, pod health, an anonymous
-  `curl`. Use the browser probe to EXPLAIN a failure telemetry already shows, never
-  to DISCOVER one. An agent once escalated a hidden-tab read to a site-wide
-  production outage that was not happening; every "corroborating" check shared the
-  identical flaw, and one of the errors it cited was caused by the probe itself.
-  Post-mortem: README.md § *Real false-outage report*.
-
-**`wake` is the fix, and it does NOT take the operator's screen.** It attaches CDP
-to your own tab, enables focus emulation (measured: `visibilityState` → `visible`,
-rAF 0/s → 62/s), holds it for a bounded settle (cap 6s) so the page paints, then explicitly
-disables focus emulation and detaches.
-No `i3-msg`, no tab/window focus change.
-
-```bash
-BB=~/workspace/devrc/scripts/browser-bridge/browser
-$BB --instance work open https://civitai.com/apps/run/model-benchmarking  # backgrounded
-$BB --instance work wake                # → woke:true, the app renders
-$BB --instance work frames              # now the OOPIF is listed
-$BB --instance work --frame model-benchmarking text    # read inside it
-$BB --instance work --frame model-benchmarking click 'button:has-text("Grid")'  # drive it
-```
-
-**Wake once per page, not per read.** The un-throttled *state* ends when the CDP
-session detaches (measured), but the **DOM the page rendered during the wake
-window persists** — so a following ordinary `text`/`html` sees the rendered page
-on the cheap, banner-free path. Re-wake after a navigation or when the app needs
-to do more rendering work.
-
-**When the read itself must observe live un-throttled state** — you are measuring
-rAF, or the app hydrates lazily and re-empties while hidden — put the un-throttle
-and the read in ONE session:
-
-```bash
-$BB --instance work text --wake         # un-throttle + read, same CDP session
-$BB --instance work html --wake=3000    # longer settle
-$BB --instance work js '…' --wake
-```
-
-`--wake` is deliberately opt-in: an ordinary `text`/`html`/`eval` takes the light
-`chrome.scripting` path with **no debugger banner**, and routing every read
-through CDP would flash "an extension is debugging this browser" on every single
-read. `--wake` cannot be combined with `--frame` (refused with
-`wake_with_frame_unsupported`) — run `browser wake`, then the frame read.
-
-**When you actually need `activate` (rare).** `activate` is still the honest
-answer when something needs the REAL foreground: a browser permission prompt, a
-native file picker, or verifying with your own eyes. **It STEALS the operator's
-screen** — telemetry caught a session calling it 1–5 times per minute, grabbing
-the screen on nearly every interaction. If you must, call it **once per tab**,
-never per read, and restore focus afterward
-(`i3-msg '[id="<prev-winid>"] focus'`). It is i3-gated (`i3:"skipped"` off a
-graphical i3 host) and is **not available to the autonomous browser-agent at all**.
-
-**Caveat:** in-frame `click`/`type` are SYNTHETIC (`isTrusted:false`, the
-`chrome.scripting` OOPIF path) — but were verified to actually drive the real app
-(the Grid tab got selected). Top-frame input remains TRUSTED CDP.
-
-## Diagnosing a CSS / layout bug (hit-test, don't theorise)
-
-The bridge is the only way to see PAINT ORDER. Markup-level tests and `html` reads
-can't: an element can be present, correct, and completely covered. The sequence
-that found a real one (civitai-manager v0.1.82 — an open popover painted under the
-next card, after ~30 UI changes had passed every server-side test):
-
-**1. `open` → `wake` → `screenshot` — and LOOK at the image.** The un-throttle is
-not optional; a backgrounded tab is throttled and may never finish painting, so
-you'd screenshot a half-built page. Use `wake` (non-intrusive), NOT `activate` —
-`screenshot` already works on a background tab via CDP, so nothing here needs the
-real foreground. Exit 0 is not a rendered page. `screenshot` prints a `.png` PATH
-(not a data URL) — `Read` that file; that is the LOOK step.
-
-**2. Hit-test the suspect element.** Take its `getBoundingClientRect()` and call
-`document.elementFromPoint(x, y)` at several points inside it, reporting for each
-whether the hit node is `contains()`-inside the element you expected. This NAMES
-the covering element instead of guessing — in the real case it returned the *next*
-card's NSFW-reveal `<button>`, which reading the popover's own CSS would never
-have suggested.
-
-```bash
-$BB --instance work eval '(function(){
-  const el = document.querySelector(".cm-updated-pop");
-  const r  = el.getBoundingClientRect();
-  const pts = [[r.left+8, r.top+8], [r.left+r.width/2, r.top+r.height/2], [r.right-8, r.bottom-8]];
-  return JSON.stringify(pts.map(([x,y]) => {
-    const hit = document.elementFromPoint(x, y);
-    return {x, y, hit: hit && hit.className, insidePop: !!hit && el.contains(hit)};
-  }));
-})()'
-```
-
-Any `insidePop:false` is the bug, and `hit` is the culprit.
-
-**3. Walk the ancestors for the first stacking-context creator.** The offender is
-almost never the element you're staring at. Check each ancestor's computed
-`transform`, `filter`, `opacity` (<1), `isolation`, `will-change`, `contain`, and
-`position`+non-`auto` `z-index` — the first one that creates a context traps every
-`z-index` below it.
-
-```bash
-$BB --instance work eval '(function(){
-  const out=[]; let n=document.querySelector(".cm-updated-pop");
-  while (n && n !== document.documentElement) {
-    const s = getComputedStyle(n);
-    out.push({cls:n.className, pos:s.position, z:s.zIndex, tf:s.transform,
-              flt:s.filter, op:s.opacity, iso:s.isolation, wc:s.willChange});
-    n = n.parentElement;
-  }
-  return JSON.stringify(out);
-})()'
-```
-
-**4. Inject a probe `<style>`, re-hit-test, THEN write code.** Proving the fix in
-the live page before touching the repo turns a guess into a measurement.
-
-```bash
-$BB --instance work eval '(function(){
-  const s=document.createElement("style"); s.id="probe";
-  s.textContent=".cm-lift:has(.cm-updated:hover){z-index:25}";
-  document.head.appendChild(s); return "probed";
-})()'
-# ...re-run the step-2 hit-test; every point should now report insidePop:true...
-$BB --instance work eval '(function(){ const s=document.getElementById("probe"); if(s) s.remove(); return "clean" })()'
-```
-
-⚠ **A probe that clears the problem can still be wrong in the OTHER direction.**
-The first value tried in the real case cleared the overlap fine — and would have
-painted the card over the sticky nav. Only checking the UPPER bound caught it. So
-hit-test both: the thing that was covered, *and* the chrome your fix now
-out-ranks. **Always remove the probe** — it's the user's live page.
-
-⚠ Reiterating, because it bites hardest here: **`eval` takes ONE EXPRESSION.** All
-four steps above are multi-statement, so every one of them must be wrapped in
-`(function(){ … })()` — otherwise you get `null` with no error and spend the next
-ten minutes debugging a bridge that is working fine.
-
-## `browser agent "<goal>"` — autonomous read/navigate in an isolated tab
-
-Offload an open-ended "go read X and tell me Y" browsing task to a **cheap
-autonomous agent** (opencode + DeepSeek `deepseek-v4-flash` via OpenRouter) so it
-never burns YOUR context on transient page HTML — only a compact structured
-result comes back.
-
-```bash
-browser agent "go to news.ycombinator.com and report the top 3 story titles" \
-  [--instance K] [--allow-domains a.com,b.com] [--deny-domains x.com] \
-  [--steps N] [--timeout S] [--dry-run]
-```
-
-- **Output (stdout):** one compact JSON object — never raw HTML:
-  `{"answer":"…","evidence":["…"],"steps_used":N,"status":"ok|partial|blocked"}`.
-  Exit 0 for `ok`/`partial`, non-zero for `blocked`/errors.
-- **Own isolated tab + NO shell (structural safety).** The wrapper `open`s a NEW
-  background tab and gives the agent exactly ONE capability: a TYPED custom tool
-  `browser` (opencode/tools/browser.js). The agent def **denies bash and every
-  other built-in tool**, so the model has no shell at all — it calls the tool with
-  structured args (`op` + optional `selector`/`url`/`js`), never a command string.
-  The tab, instance, and `--deny/--allow-domains` are **forced on the tool via env
-  the wrapper sets** — the model cannot choose the tab or reach a denied domain.
-  The tab is closed on EVERY exit path (success, timeout, error).
-  - **WHY typed, not bash (the PR #180 RCE fix):** the earlier design gave the
-    agent opencode's bash tool scoped to `browser --tab <id> *`. A shell OUTPUT
-    REDIRECT (`browser --tab N eval '…' >> ~/.zshenv`) is not a separate command
-    node, so it rode the allowed `browser` command through opencode's wildcard
-    glob and the shell performed the redirect → a hostile page could induce the
-    model to write to a sourced dotfile → host RCE. The typed tool removes the
-    shell entirely, so there is no `>`/`;`/`|`/`$()` surface to abuse.
-- **Runtime fail-closed tool-set gate (makes an un-upgraded opencode SAFE):**
-  before opening a tab or spending a model token, the wrapper runs `opencode debug
-  agent browser-agent` (a read-only, **model-free** config dump) and refuses to run
-  (`die`, model never invoked) unless the resolved `tools` map is browser-ONLY —
-  `browser:true` AND every host tool (`bash`/`read`/`edit`/`write`/`webfetch`)
-  present AND `false`. Any uncertainty (unparseable output, `browser` absent, a
-  host tool `true`, or a host tool absent) fails closed. This is the one place the
-  fail-closed property is *verified at runtime* rather than trusted — on any
-  opencode where the host-tool denial didn't take, `browser agent` refuses instead
-  of running the model unconfined. The gate runs BEFORE the tab is opened, so a
-  gate failure leaks no tab. **Both hosts run opencode 1.18.4 and both resolve
-  browser-only** — there is no version-skew caveat.
-  - ⚠ **If you check the gate by hand, redirect to a FILE**
-    (`opencode debug agent browser-agent > /tmp/gate.json`), never a pipe or
-    `$(...)`: opencode doesn't reliably flush stdout before exiting into a pipe, so
-    a capture can be TRUNCATED and the gate then (correctly) fails closed with
-    `unparseable debug-agent tool set: Unterminated string…` — which looks like a
-    version problem and is not. The wrapper itself now captures to
-    `$SCRATCH/gate.json` for exactly this reason.
-- **The agent's `whoami` is narrowed.** It sees its OWN profile + the host label +
-  versions — never the operator's other profiles, never any `activeTabDomain`,
-  never the git HEAD. (Otherwise a prompt-injected page could have the model report
-  that your `banking` profile is on chase.com, then `nav` that to an attacker.) The
-  `browser whoami` CLI you run by hand is unchanged and still shows everything.
-- **No `upload` and no `activate` for the agent.** The autonomous model's op set
-  is 11 ops (`text`/`html`/`eval`/`nav`/`screenshot`/`frames`/`click`/`type`/
-  `key`/`wake`/`whoami`). `upload` is operator-only — you can still `browser
-  upload` by hand; the model gets `op_not_allowed:upload`, and it is re-enabled
-  only by an explicit `BROWSER_AGENT_ALLOWED_OPS` opt-in. **`activate` is stricter
-  still: it is not reachable by the model at ALL**, not even via that opt-in,
-  because it takes the operator's screen. The agent gets `wake` instead — the
-  un-throttling it actually needed, with no focus theft.
-- **Guardrails:** a step budget (`--steps`, default 12), a wall-clock `--timeout`
-  (default 120s) enforced with a **process-group kill** (`setsid` + kill the whole
-  group, so no opencode child survives), `--deny-domains`/`--allow-domains`
-  enforced INSIDE the tool (a denied `nav` is refused before it reaches the
-  bridge), a **non-http(s) nav scheme hard-denial** (a `nav` to `file:`/`data:`/
-  `about:`/`javascript:`/`chrome:`/… is refused as `nav_scheme_denied:<scheme>`
-  before any fetch — those have no host and would otherwise bypass
-  `--allow-domains`), and `--dry-run` (intercepts `nav`/`eval` — logs, doesn't
-  execute). The full opencode JSON transcript + a metadata-only tool audit are kept
-  in a scratch dir. **Domain deny is best-effort** (see note below).
-- **⚠ Privacy:** the pages the agent reads are sent to **OpenRouter/DeepSeek**.
-  Do NOT point it at high-secret authenticated pages casually.
-- **⚠ Domain deny is a mitigation, not a guarantee.** The tool refuses a `nav` to
-  a denied host, but it cannot see a page's own client-side redirect (meta-refresh
-  / `location=` after an allowed nav) — the bridge navigates the tab and the tool
-  only sees the op it issued. Treat `--deny-domains` as best-effort defence in
-  depth; the real isolation is the own-tab lock. (Follow-up: server-side
-  enforcement against the tab's resolved post-nav URL would make it binding.)
-- **Prereqs:** `opencode` on PATH with the OpenRouter key already in its auth
-  store (`~/.local/share/opencode/auth.json`), the extension connected, and BOTH
-  the agent def AND the custom tool symlinked into opencode's config (see README →
-  Deploy). If any is missing you get a clean error and no orphaned tab.
-
-## Per-session tab isolation (use `open` for multi-step work)
-
-Two Claude sessions driving one browser used to interleave on the ONE shared
-active tab (session A `nav`s, session B `nav`s in between, A reads B's page).
-Now each session can own its own tab:
-
-- **Multi-step workflow → `browser open <url>` first.** The server records this
-  session's owned tab (keyed by a stable per-session id sent automatically on
-  every request) and routes your subsequent `html`/`eval`/`nav`/`screenshot`/
-  `close` to it — a parallel session doing the same on its own tab can't clobber
-  you. Finish with `browser close` (closes the tab) or `browser release` (keeps
-  the tab, drops ownership).
-- **One-shot read → just `browser html` (no `open`).** With no owned tab, ops
-  fall back to the active tab — the historical "read the tab the user has open"
-  behaviour, which is a single read and inherently safe.
-- **`--tab <id>`** targets a specific tab explicitly (overrides owned/active).
-- **Double `open` is safe (idempotent).** Calling `browser open` again in a
-  session that already owns a **live** tab returns that SAME tabId (it does not
-  leak a second tab). If the owned tab was closed, `open` makes a fresh one.
-- **Self-heal.** If the user manually closes your owned tab, the next op fails
-  with `owned_tab_gone` and the bridge drops your ownership — your NEXT command
-  automatically falls back to the active tab. `browser close` always clears the
-  mapping, even if the tab was already gone.
-- **Session id source:** `CLAUDE_CODE_SESSION_ID` → `$TMUX_PANE` → a
-  per-process-tree token (see README). It is routing-only, never trusted for
-  auth. If two drivers ever resolve the same id they share a tab (degrades to
-  the old behaviour — no worse).
-- **⚠ Concurrent drivers that may share a session id (subagents): pass explicit
-  `--tab`.** Sibling subagents of ONE parent share identity — a subagent inherits
-  the parent's `CLAUDE_CODE_SESSION_ID` and the same `$TMUX_PANE`, and there is NO
-  subagent-unique env var — so two parallel subagents derive the SAME session id
-  and would own the SAME tab (re-introducing the clobber). Per-session isolation
-  only separates concurrent **top-level** sessions. When you spawn concurrent
-  drivers that each drive the browser, have EACH one `browser open` (capture the
-  returned `tabId`) and then pass its OWN `--tab <id>` on **every** subsequent op
-  (`browser --tab <id> nav …`, `--tab <id> html`, …). An explicit `--tab`
-  overrides owned-tab routing entirely, so indistinguishable drivers never
-  collide. (Each `close`s its own `--tab <id>` at the end.)
-- **Contention → FIFO, not failure.** If two sessions DO target the same tab
-  (both active, or one `--tab`s another's tab), the commands queue in arrival
-  order (bounded by `cmd_timeout`) rather than fail.
-- **Lifecycle:** idle ownership is reclaimed after a TTL, which RELEASES it but
-  does NOT close the real Brave tab (only `browser close` closes it).
-
-## Multiple instances (per host)
-
-Several Brave profiles can each run the extension and be driven independently —
-each has its own command queue (routing key = the profile's **label** if set,
-else a stable auto-id; labels must be unique per host).
-
-- **One instance connected** → no `--instance` needed (back-compat).
-- **More than one and no `--instance`** → the command **ERRORS** and lists the
-  connected instances. Do NOT retry blindly — run `browser instances`, pick the
-  right key, and re-issue with `--instance <key>`. (The bridge never guesses.)
-- **`browser --instance <key> <op>`** targets one (key = label or auto-id); an
-  unknown key errors.
-- **Newest supersedes:** a fresh connection for an already-held key drops the old
-  one; an in-flight command on the dropped connection returns a `superseded`
-  error — just retry. The displaced connection's own `/poll` gets a distinct
-  `409 superseded` (not the idle `204`) and the extension **backs off ~30s** (and
-  shows a "superseded — set a unique label" state) instead of re-registering
-  instantly, so two profiles sharing a label can't mutual-supersede in a tight
-  loop. If you see `superseded` steadily, two profiles share a label → fix it.
-
-## Security contract (why it's safe)
-
-- **Loopback only** (`127.0.0.1:8788`) — never bound to an external interface.
-- **Bearer token** on every request — auto-created `0600` at
-  `~/.config/browser-bridge/token` on first server start. The `browser` CLI
-  reads it; a web page can't. Defeats DNS-rebinding.
-- **Host-header allowlist** — only `127.0.0.1`/`localhost`/`::1`.
-
-## Telemetry (metadata-only)
-
-Every handled command emits one **best-effort** activity event
-(`source=browser-bridge`, `kind=cmd`) into the personal telemetry pipeline
-(`activity.events`), so browser-skill usage is queryable / visible to
-`adoption-scan`. It records **only** metadata — op, instance key, outcome,
-latency, and the active tab's **bare domain** — **never** the eval source, page
-HTML, screenshot bytes, full URLs, or any page content. It runs off the critical
-path and can never delay or break a command. Nothing you need to do; noted so you
-know browser usage is being counted. Details: `README.md` → Telemetry.
+The promise IS awaited. ⚠ This does **not** work on CSP-strict origins (GitHub,
+Discord, …) — there, `text`/`html` are the only reads that work.
+
+## When things look broken — triage
+
+1. **A read is empty / half-built / `data.hidden:true`** → the tab is throttled.
+   `browser wake`, then re-read. → `reference/spa-wake.md`
+2. **`null` from `js`/`eval`** → multi-statement body first, then page CSP. Fall
+   back to `text`/`html` before concluding the bridge is down.
+3. **`unknown_op` on an op the CLI knows** → stale extension; full Brave restart.
+4. **Any other unrecognised error string** → look it up in `reference/errors.md`.
+5. **Never diagnose a site OUTAGE from a browser read.** "Is this broken for real
+   users?" is answered by server-side evidence (RUM, metrics, pod health, an
+   anonymous `curl`). A hidden-tab read once produced a confident, false, site-wide
+   outage report. → `reference/spa-wake.md`
+
+## This is the user's LIVE session
+
+It's their real browser, not a scratch VM. Don't `nav` a tab that may hold unsaved
+work (a half-typed comment, a form, a logged-in console) — `open` your own tab, or
+use an obviously disposable one. If anything moved their focus, **restore it**
+(`i3-msg '[id="<prev-winid>"] focus'`).
+
+**Concurrent drivers (esp. sibling subagents) → each `open` and thread its own
+`--tab <id>`.** Sibling subagents of one parent SHARE a session id (they inherit
+`CLAUDE_CODE_SESSION_ID` + `$TMUX_PANE`), so without an explicit `--tab` they fight
+over the SAME tab. Do **not** run a bare high-rate `eval` loop — it saturates the
+single serial extension connection and gets `429 rate_limited`.
+→ `reference/tabs-instances.md`
 
 ## Before you rely on it
 
 1. `browser health` — if `extension_connected:false` or it errors, the extension
-   isn't loaded/paired. Tell the user to load + pair it (see below); you cannot
-   do this for them (it's a manual Brave step).
-2. **Verify it's the LIVE authenticated session**: after `browser html`, confirm
-   the returned markup contains **logged-in-only** content (their name, account
-   menu, inbox contents). If it looks like a logged-out/anonymous page, the wrong
-   tab is active or they're not logged in — say so rather than proceeding.
+   isn't loaded/paired. Tell the user to load + pair it (`reference/security-ops.md`);
+   you cannot do this for them (it's a manual Brave step).
+2. **Verify it's the LIVE authenticated session**: after a read, confirm the content
+   contains **logged-in-only** material (their name, account menu, inbox). If it
+   looks logged-out/anonymous, the wrong tab is active or they aren't logged in —
+   say so rather than proceeding.
 
-## Error shapes (from `/cmd`)
+## Reference files — load ONE only when its trigger fires
 
-- `503 extension_not_connected` → extension not loaded/paired, or Brave closed.
-- `504 timeout` → extension picked it up but didn't answer (tab unresponsive).
-- `429 rate_limited` / `429 queue_full` → the per-instance concurrency backstop is
-  shedding load — you're dispatching too fast / too many at once. **Back off and
-  retry** (the body carries a `retry_after` seconds hint). A normal handful of ops
-  is never throttled; this only fires on a sustained flood. Knobs (env, on the
-  server): `BROWSER_BRIDGE_RATE_PER_SEC` (default 5, sustained/sec; 0 = unlimited),
-  `BROWSER_BRIDGE_BURST` (default 20; clamped to ≥1 when rate>0 — a <1 burst
-  would rate_limit every /cmd forever), `BROWSER_BRIDGE_MAX_QUEUE` (default 32,
-  0 = unlimited).
-- `409 ambiguous_instance` → >1 instance connected and no `--instance` — pick one.
-- `409 no_owned_tab` → `close` with nothing to close — run `browser open` first (or `--tab`).
-- `409 superseded` → the instance was replaced by a newer connection; retry.
-- `404 unknown_instance` → the `--instance` key matches no connected instance.
-- `400 unknown_op` / `missing_field:url|js` → bad command.
-- `op '<op>' failed in the browser: unknown_op` (op-level — the CLI knows the op
-  but the **extension** doesn't) → the loaded extension is an older build. Ask the
-  user to reload it in `brave://extensions`; use `tabs` + `--tab <id>` meanwhile.
-- `Failed to capture tab: image readback failed` (a `captureVisibleTab` readback
-  race on the fast path) → the SW now falls through to the **CDP `Page.captureScreenshot`**
-  primary path, which captures a background/occluded tab directly, so this should no
-  longer surface as an op error on current builds. If it does, reload the extension.
-- `400 bad_tab` → a non-numeric `tab` (only reachable via a raw API POST; the CLI
-  already validates `--tab`).
-- `owned_tab_gone` (op-level, in `.result`) → your owned tab was closed; ownership
-  is auto-dropped, so just re-issue (it falls back to the active tab / re-`open`).
-- `cdp_attach_refused:<scheme>` (op-level, in `.result`) → a CDP op (screenshot /
-  top-frame input / `eval --frame`) was aimed at a privileged tab (`chrome://`,
-  `file:`, extension, devtools, …); the bridge refuses to attach `chrome.debugger`
-  there. Point the op at a real `http/https` tab.
-- `401 unauthorized` → token mismatch (re-paste in the extension options).
+**Read them at `~/workspace/devrc/scripts/browser-bridge/reference/<file>`.** (That
+exact path — only `SKILL.md` and the `browser` CLI are symlinked into
+`~/.claude/skills/browser/`; `reference/` is not.)
 
-## Gotcha: reload the unpacked extension after any change
-
-Brave does **not** hot-reload unpacked extensions. If `extension/` was edited,
-the old service-worker code keeps running until it's swapped in — **and clicking
-reload ↻ on the card in `brave://extensions` is UNRELIABLE** (the extension's
-long-poll keeps the OLD service worker permanently alive), so the reliable fix is
-a **full quit-and-reopen of Brave** (see the top of this doc). Symptom of a stale
-build: an op the CLI knows returns `unknown_op`, or `health` still shows the old
-`extension_version`. The `browser-bridge` **server** (not the extension) DOES
-restart automatically on a `home-manager switch` (X-Restart-Triggers).
-
-## Changing the bridge: live-verify against real Brave is the ONLY gate
-
-If you MODIFY browser-bridge (server / extension / CLI), a green test suite and a
-clean security audit are **prerequisites, NOT verification** — CI cannot drive a
-real Brave, so it never exercises the actual MV3 / CDP / i3 behaviour. Across the
-build-out, driving each change against the live browser caught ~11 defects that
-passing tests and audits BOTH missed (Chrome-side focus being inert on i3;
-`chrome.scripting` unable to eval a string → CDP `Runtime.evaluate`;
-`captureVisibleTab` needing foreground → CDP `Page.captureScreenshot`; OOPIFs
-needing `Target.setAutoAttach`; the reload-vs-restart trap). So the mandatory loop
-for any browser change is **build → audit → fix → merge → ship → live-verify on
-real Brave** — reproduce the exact path and LOOK at the actual result (exit 0 is
-not verification). Operate changes via a feature branch + `/audit-pr`-style review
-given it's a live-cookie surface.
-
-## One-time setup (hand these steps to the user)
-
-1. `home-manager switch --flake ~/workspace/devrc --impure` (starts the service).
-2. Brave → `brave://extensions` → Developer mode → **Load unpacked** →
-   `scripts/browser-bridge/extension/`.
-3. Extension **Options** → paste the token from `~/.config/browser-bridge/token`,
-   port `8788`, optionally set a unique **label** (required only if a second
-   profile also connects), **Save**.
-4. `browser health` → `extension_connected:true`.
-
-For a second profile, repeat in that profile and give it a **different** label,
-then target with `browser --instance <label> <op>`.
+| file | load it when… |
+|---|---|
+| `reference/spa-wake.md` | a read came back empty/half-built, `data.hidden:true`, an SPA is stuck "Loading…", or you're about to call a site broken |
+| `reference/errors.md` | any op returned an error string you don't recognise; `unknown_op`; a reload ↻ didn't take |
+| `reference/frames-cdp.md` | `frame_not_found` / `ambiguous_frame` / `oopif_*_cap` / `cdp_attach_refused`; a `--frame` read returned the TOP page; you need to read or drive inside a cross-origin iframe; the debugger banner |
+| `reference/tabs-instances.md` | `ambiguous_instance` / `unknown_instance` / `superseded` / `no_owned_tab` / `owned_tab_gone`; two drivers fighting over one tab; multi-profile or multi-subagent workflows |
+| `reference/css-hit-test.md` | an element is present but invisible/unclickable/painted under something; a `z-index` change "does nothing" |
+| `reference/agent.md` | running `browser agent` — flags, guardrails, prereqs; it returned `blocked`; `op_not_allowed` / `nav_scheme_denied` |
+| `reference/security-ops.md` | 🔴 **you are MODIFYING browser-bridge** (the live-verify-on-real-Brave gate is mandatory); the user asks whether/what it records; first-time setup or a second profile |
+| `reference/x-fallback.md` | CDP `screenshot` is unsatisfactory and you must capture the raw X window (`DISPLAY`/`XAUTHORITY`, xdotool/maim) |

--- a/scripts/browser-bridge/reference/agent.md
+++ b/scripts/browser-bridge/reference/agent.md
@@ -1,0 +1,93 @@
+# `browser agent "<goal>"` — autonomous read/navigate in an isolated tab
+
+**Load this when:** you are about to run `browser agent` and need its flags,
+guardrails or prereqs · the agent returned `status:"blocked"` or a non-zero exit ·
+you got `op_not_allowed:<op>` or `nav_scheme_denied:<scheme>` · the wrapper died with
+`unparseable debug-agent tool set: …` · you need the RCE-fix / typed-tool rationale ·
+you need to know what the agent can and cannot reach.
+
+Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`.
+
+Offload an open-ended "go read X and tell me Y" browsing task to a **cheap
+autonomous agent** (opencode + DeepSeek `deepseek-v4-flash` via OpenRouter) so it
+never burns YOUR context on transient page HTML — only a compact structured
+result comes back.
+
+```bash
+browser agent "go to news.ycombinator.com and report the top 3 story titles" \
+  [--instance K] [--allow-domains a.com,b.com] [--deny-domains x.com] \
+  [--steps N] [--timeout S] [--dry-run]
+```
+
+- **Output (stdout):** one compact JSON object — never raw HTML:
+  `{"answer":"…","evidence":["…"],"steps_used":N,"status":"ok|partial|blocked"}`.
+  Exit 0 for `ok`/`partial`, non-zero for `blocked`/errors.
+- **Own isolated tab + NO shell (structural safety).** The wrapper `open`s a NEW
+  background tab and gives the agent exactly ONE capability: a TYPED custom tool
+  `browser` (opencode/tools/browser.js). The agent def **denies bash and every
+  other built-in tool**, so the model has no shell at all — it calls the tool with
+  structured args (`op` + optional `selector`/`url`/`js`), never a command string.
+  The tab, instance, and `--deny/--allow-domains` are **forced on the tool via env
+  the wrapper sets** — the model cannot choose the tab or reach a denied domain.
+  The tab is closed on EVERY exit path (success, timeout, error).
+  - **WHY typed, not bash (the PR #180 RCE fix):** the earlier design gave the
+    agent opencode's bash tool scoped to `browser --tab <id> *`. A shell OUTPUT
+    REDIRECT (`browser --tab N eval '…' >> ~/.zshenv`) is not a separate command
+    node, so it rode the allowed `browser` command through opencode's wildcard
+    glob and the shell performed the redirect → a hostile page could induce the
+    model to write to a sourced dotfile → host RCE. The typed tool removes the
+    shell entirely, so there is no `>`/`;`/`|`/`$()` surface to abuse.
+- **Runtime fail-closed tool-set gate (makes an un-upgraded opencode SAFE):**
+  before opening a tab or spending a model token, the wrapper runs `opencode debug
+  agent browser-agent` (a read-only, **model-free** config dump) and refuses to run
+  (`die`, model never invoked) unless the resolved `tools` map is browser-ONLY —
+  `browser:true` AND every host tool (`bash`/`read`/`edit`/`write`/`webfetch`)
+  present AND `false`. Any uncertainty (unparseable output, `browser` absent, a
+  host tool `true`, or a host tool absent) fails closed. This is the one place the
+  fail-closed property is *verified at runtime* rather than trusted — on any
+  opencode where the host-tool denial didn't take, `browser agent` refuses instead
+  of running the model unconfined. The gate runs BEFORE the tab is opened, so a
+  gate failure leaks no tab. **Both hosts run opencode 1.18.4 and both resolve
+  browser-only** — there is no version-skew caveat.
+  - ⚠ **If you check the gate by hand, redirect to a FILE**
+    (`opencode debug agent browser-agent > /tmp/gate.json`), never a pipe or
+    `$(...)`: opencode doesn't reliably flush stdout before exiting into a pipe, so
+    a capture can be TRUNCATED and the gate then (correctly) fails closed with
+    `unparseable debug-agent tool set: Unterminated string…` — which looks like a
+    version problem and is not. The wrapper itself now captures to
+    `$SCRATCH/gate.json` for exactly this reason.
+- **The agent's `whoami` is narrowed.** It sees its OWN profile + the host label +
+  versions — never the operator's other profiles, never any `activeTabDomain`,
+  never the git HEAD. (Otherwise a prompt-injected page could have the model report
+  that your `banking` profile is on chase.com, then `nav` that to an attacker.) The
+  `browser whoami` CLI you run by hand is unchanged and still shows everything.
+- **No `upload` and no `activate` for the agent.** The autonomous model's op set
+  is **11 ops** (`text`/`html`/`eval`/`nav`/`screenshot`/`frames`/`click`/`type`/
+  `key`/`wake`/`whoami`). `upload` is operator-only — you can still `browser
+  upload` by hand; the model gets `op_not_allowed:upload`, and it is re-enabled
+  only by an explicit `BROWSER_AGENT_ALLOWED_OPS` opt-in. **`activate` is stricter
+  still: it is not reachable by the model at ALL**, not even via that opt-in,
+  because it takes the operator's screen. The agent gets `wake` instead — the
+  un-throttling it actually needed, with no focus theft.
+- **Guardrails:** a step budget (`--steps`, default 12), a wall-clock `--timeout`
+  (default 120s) enforced with a **process-group kill** (`setsid` + kill the whole
+  group, so no opencode child survives), `--deny-domains`/`--allow-domains`
+  enforced INSIDE the tool (a denied `nav` is refused before it reaches the
+  bridge), a **non-http(s) nav scheme hard-denial** (a `nav` to `file:`/`data:`/
+  `about:`/`javascript:`/`chrome:`/… is refused as `nav_scheme_denied:<scheme>`
+  before any fetch — those have no host and would otherwise bypass
+  `--allow-domains`), and `--dry-run` (intercepts `nav`/`eval` — logs, doesn't
+  execute). The full opencode JSON transcript + a metadata-only tool audit are kept
+  in a scratch dir. **Domain deny is best-effort** (see note below).
+- **⚠ Privacy:** the pages the agent reads are sent to **OpenRouter/DeepSeek**.
+  Do NOT point it at high-secret authenticated pages casually.
+- **⚠ Domain deny is a mitigation, not a guarantee.** The tool refuses a `nav` to
+  a denied host, but it cannot see a page's own client-side redirect (meta-refresh
+  / `location=` after an allowed nav) — the bridge navigates the tab and the tool
+  only sees the op it issued. Treat `--deny-domains` as best-effort defence in
+  depth; the real isolation is the own-tab lock. (Follow-up: server-side
+  enforcement against the tab's resolved post-nav URL would make it binding.)
+- **Prereqs:** `opencode` on PATH with the OpenRouter key already in its auth
+  store (`~/.local/share/opencode/auth.json`), the extension connected, and BOTH
+  the agent def AND the custom tool symlinked into opencode's config (see README →
+  Deploy). If any is missing you get a clean error and no orphaned tab.

--- a/scripts/browser-bridge/reference/css-hit-test.md
+++ b/scripts/browser-bridge/reference/css-hit-test.md
@@ -1,0 +1,84 @@
+# Diagnosing a CSS / layout bug (hit-test, don't theorise)
+
+**Load this when:** an element is in the DOM but invisible, unclickable, or painted
+UNDER something else · a popover/dropdown/tooltip renders behind neighbouring content ·
+a `z-index` change "does nothing" · a click lands on the wrong element · you are about
+to reason about paint order from CSS source instead of measuring it.
+
+Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`.
+
+The bridge is the only way to see PAINT ORDER. Markup-level tests and `html` reads
+can't: an element can be present, correct, and completely covered. The sequence
+that found a real one (civitai-manager v0.1.82 — an open popover painted under the
+next card, after ~30 UI changes had passed every server-side test):
+
+**1. `open` → `wake` → `screenshot` — and LOOK at the image.** The un-throttle is
+not optional; a backgrounded tab is throttled and may never finish painting, so
+you'd screenshot a half-built page. Use `wake` (non-intrusive), NOT `activate` —
+`screenshot` already works on a background tab via CDP, so nothing here needs the
+real foreground. Exit 0 is not a rendered page. `screenshot` prints a `.png` PATH
+(not a data URL) — `Read` that file; that is the LOOK step.
+
+**2. Hit-test the suspect element.** Take its `getBoundingClientRect()` and call
+`document.elementFromPoint(x, y)` at several points inside it, reporting for each
+whether the hit node is `contains()`-inside the element you expected. This NAMES
+the covering element instead of guessing — in the real case it returned the *next*
+card's NSFW-reveal `<button>`, which reading the popover's own CSS would never
+have suggested.
+
+```bash
+$BB --instance work js '(function(){
+  const el = document.querySelector(".cm-updated-pop");
+  const r  = el.getBoundingClientRect();
+  const pts = [[r.left+8, r.top+8], [r.left+r.width/2, r.top+r.height/2], [r.right-8, r.bottom-8]];
+  return JSON.stringify(pts.map(([x,y]) => {
+    const hit = document.elementFromPoint(x, y);
+    return {x, y, hit: hit && hit.className, insidePop: !!hit && el.contains(hit)};
+  }));
+})()'
+```
+
+Any `insidePop:false` is the bug, and `hit` is the culprit.
+
+**3. Walk the ancestors for the first stacking-context creator.** The offender is
+almost never the element you're staring at. Check each ancestor's computed
+`transform`, `filter`, `opacity` (<1), `isolation`, `will-change`, `contain`, and
+`position`+non-`auto` `z-index` — the first one that creates a context traps every
+`z-index` below it.
+
+```bash
+$BB --instance work js '(function(){
+  const out=[]; let n=document.querySelector(".cm-updated-pop");
+  while (n && n !== document.documentElement) {
+    const s = getComputedStyle(n);
+    out.push({cls:n.className, pos:s.position, z:s.zIndex, tf:s.transform,
+              flt:s.filter, op:s.opacity, iso:s.isolation, wc:s.willChange});
+    n = n.parentElement;
+  }
+  return JSON.stringify(out);
+})()'
+```
+
+**4. Inject a probe `<style>`, re-hit-test, THEN write code.** Proving the fix in
+the live page before touching the repo turns a guess into a measurement.
+
+```bash
+$BB --instance work js '(function(){
+  const s=document.createElement("style"); s.id="probe";
+  s.textContent=".cm-lift:has(.cm-updated:hover){z-index:25}";
+  document.head.appendChild(s); return "probed";
+})()'
+# ...re-run the step-2 hit-test; every point should now report insidePop:true...
+$BB --instance work js '(function(){ const s=document.getElementById("probe"); if(s) s.remove(); return "clean" })()'
+```
+
+⚠ **A probe that clears the problem can still be wrong in the OTHER direction.**
+The first value tried in the real case cleared the overlap fine — and would have
+painted the card over the sticky nav. Only checking the UPPER bound caught it. So
+hit-test both: the thing that was covered, *and* the chrome your fix now
+out-ranks. **Always remove the probe** — it's the user's live page.
+
+⚠ Reiterating, because it bites hardest here: **`eval`/`js` takes ONE EXPRESSION.**
+All four steps above are multi-statement, so every one of them must be wrapped in
+`(function(){ … })()` — otherwise you get `null` with no error and spend the next
+ten minutes debugging a bridge that is working fine.

--- a/scripts/browser-bridge/reference/errors.md
+++ b/scripts/browser-bridge/reference/errors.md
@@ -1,0 +1,95 @@
+# Error catalogue + the stale-extension playbook
+
+**Load this when:** any op returned an error string you don't recognise — look it up
+below · an op the CLI knows answers `unknown_op` · you clicked reload ↻ in
+`brave://extensions` and the old behaviour persists · `health` still shows the old
+`extension_version` after a reload.
+
+Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`. This file is the catch-all: no error string
+should strand you.
+
+## Error shapes (from `/cmd`)
+
+- `503 extension_not_connected` → extension not loaded/paired, or Brave closed.
+- `504 timeout` → extension picked it up but didn't answer (tab unresponsive).
+- `429 rate_limited` / `429 queue_full` → the per-instance concurrency backstop is
+  shedding load — you're dispatching too fast / too many at once. **Back off and
+  retry** (the body carries a `retry_after` seconds hint). A normal handful of ops
+  is never throttled; this only fires on a sustained flood. Knobs (env, on the
+  server): `BROWSER_BRIDGE_RATE_PER_SEC` (default 5, sustained/sec; 0 = unlimited),
+  `BROWSER_BRIDGE_BURST` (default 20; clamped to ≥1 when rate>0 — a <1 burst
+  would rate_limit every /cmd forever), `BROWSER_BRIDGE_MAX_QUEUE` (default 32,
+  0 = unlimited).
+- `409 ambiguous_instance` → >1 instance connected and no `--instance` — pick one.
+- `409 no_owned_tab` → `close` with nothing to close — run `browser open` first (or `--tab`).
+- `409 superseded` → the instance was replaced by a newer connection; retry.
+- `404 unknown_instance` → the `--instance` key matches no connected instance.
+- `400 unknown_op` / `missing_field:url|js` → bad command.
+- `op '<op>' failed in the browser: unknown_op` (op-level — the CLI knows the op
+  but the **extension** doesn't) → the loaded extension is an older build. See the
+  stale-extension playbook below; use `tabs` + `--tab <id>` meanwhile.
+- `Failed to capture tab: image readback failed` (a `captureVisibleTab` readback
+  race on the fast path) → the SW now falls through to the **CDP `Page.captureScreenshot`**
+  primary path, which captures a background/occluded tab directly, so this should no
+  longer surface as an op error on current builds. If it does, reload the extension.
+- `400 bad_tab` → a non-numeric `tab` (only reachable via a raw API POST; the CLI
+  already validates `--tab`).
+- `owned_tab_gone` (op-level, in `.result`) → your owned tab was closed; ownership
+  is auto-dropped, so just re-issue (it falls back to the active tab / re-`open`).
+- `cdp_attach_refused:<scheme>` (op-level, in `.result`) → a CDP op (screenshot /
+  top-frame input / `eval --frame`) was aimed at a privileged tab (`chrome://`,
+  `file:`, extension, devtools, …); the bridge refuses to attach `chrome.debugger`
+  there. Point the op at a real `http/https` tab.
+- `401 unauthorized` → token mismatch (re-paste in the extension options).
+- `wake_with_frame_unsupported` → `--wake` was combined with `--frame`. Run
+  `browser wake`, then the frame read (`~/workspace/devrc/scripts/browser-bridge/reference/spa-wake.md`).
+- `frame_not_found:<url> cascade[…]` / `frame_eval_failed:<reason>` /
+  `ambiguous_frame:<n>` / `oopif_depth_cap:5` / `oopif_target_cap:50` →
+  `~/workspace/devrc/scripts/browser-bridge/reference/frames-cdp.md`.
+- `op_not_allowed:<op>` / `nav_scheme_denied:<scheme>` → the autonomous
+  browser-agent's op or scheme gate, `~/workspace/devrc/scripts/browser-bridge/reference/agent.md`.
+- `Cannot access a chrome:// URL` (with a `null` result) → `eval`/`js` can't run on
+  `chrome://` / `brave://` pages. Not a bridge fault.
+
+## The LOADED extension may be older than the CLI
+
+The CLI is always current; the **extension build running in Brave is not**. Brave
+does not hot-reload unpacked extensions, so the live service worker can be far
+behind. Symptom, seen for real:
+
+```
+$ browser --instance work open https://example.com
+op 'open' failed in the browser: unknown_op
+```
+
+**`open` answering `unknown_op` means the loaded extension predates owned-tab
+support** — per-session tab isolation is unavailable until the user reloads it.
+Don't debug the server. Meanwhile work without `open`: run `browser tabs`, pick an
+existing tab, and pass `--tab <id>` on every op (or just read the active tab for a
+one-shot). Same reasoning for any op that answers `unknown_op` (e.g. `upload` on a
+pre-0.2.0 extension).
+
+The CLI **detects this for you**: any op the CLI dispatches that returns a
+server-side `unknown_op` is mapped to a clear message + non-zero exit telling you
+the loaded extension is OLDER than the CLI and to reload/restart. **`browser
+health` also shows the build** — each instance's loaded `extension_version` vs the
+bridge's `extension_version_current` (repo manifest); a mismatch = stale.
+
+**⚠ Reload ↻ is UNRELIABLE — a full Brave restart is the reliable fix.** The
+extension's long-poll keeps the OLD service worker permanently alive, so clicking
+↻ in `brave://extensions` often does NOT swap in the new build. If a reload
+doesn't take (the op still returns `unknown_op`, or `health` still shows the old
+`extension_version`), tell the user to **fully quit and reopen Brave**.
+
+**Nuance (measured 2026-07-30): a ↻ reload DID take** — swapping in a new build after an
+earlier full restart in the same Brave session. So ↻ is worth trying **first**, but only
+when you have a **deterministic tell** for whether it took. Don't reason about it; test
+it. Pick something the new build emits that the old one cannot, e.g. the nested-OOPIF
+`cascade[…]` trace: old build → a bare `frame_not_found:<url>`, new build → the same
+error **plus** the trace. That turns "did the reload take?" from an unfalsifiable guess
+into one command. With no such tell, skip ↻ and do the full restart.
+
+Symptom of a stale build: an op the CLI knows returns `unknown_op`, or `health` still
+shows the old `extension_version`. The `browser-bridge` **server** (not the extension)
+DOES restart automatically on a `home-manager switch` (X-Restart-Triggers) — only the
+extension needs the manual step.

--- a/scripts/browser-bridge/reference/frames-cdp.md
+++ b/scripts/browser-bridge/reference/frames-cdp.md
@@ -1,0 +1,163 @@
+# Frames, cross-origin OOPIFs, and CDP
+
+**Load this when:** a `--frame` op returned `frame_not_found:<url>`,
+`ambiguous_frame:<n>`, `frame_eval_failed:<reason>`, `oopif_depth_cap:5`,
+`oopif_target_cap:50`, or `cdp_attach_refused:<scheme>` · a `--frame` read came back
+as the TOP page instead of the iframe you meant · `eval --frame` returned
+`value:null` · you need to read or drive something inside a cross-origin iframe ·
+you need to know why in-frame `click`/`type` is `isTrusted:false` · Brave is showing
+"an extension is debugging this browser" and you want to know why.
+
+Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`.
+
+## What reaches what
+
+`frames` + `--frame` reach cross-origin OUT-OF-PROCESS iframes (OOPIFs) via
+`chrome.webNavigation` + `chrome.scripting`; `screenshot` + TOP-frame trusted input use
+the Chrome DevTools Protocol (`debugger` permission). Together they fix three real
+limitations:
+
+1. **Screenshot a BACKGROUND / occluded tab** (and each profile's own tab) — CDP
+   `Page.captureScreenshot` does not need the tab to be the on-screen foreground
+   tab, so the old i3 "not visible on-screen" limitation is gone for the normal
+   path. (`--fullpage` grabs the whole scrollable document.)
+2. **Read/drive INTO a CROSS-ORIGIN iframe (the OOPIF fix)** — `browser --tab T frames`
+   LISTS the cross-origin frame (e.g. `model-benchmarking.civit.ai` inside
+   `civitai.com`) because `chrome.webNavigation.getAllFrames` enumerates OOPIFs that
+   CDP `Page.getFrameTree` could not; then `browser --tab T --frame <numericId-or-url>
+   text` reads inside it and `--frame … click/type/key` drives an in-app control (via
+   `chrome.scripting` injection), while `--frame … eval '<js>'` runs a JS string inside
+   it via CDP `Runtime.evaluate` (e.g. `--frame <oopif> eval 'location.href'` returns the
+   OOPIF's own url, not null). Plain `text`/`html`/`eval` (no `--frame`) still see only
+   the top frame.
+3. **Drive an app's TOP frame with trusted input** — top-frame `click`/`type`/`key`
+   dispatch real `isTrusted` events via CDP. (In a cross-origin `--frame`, input is
+   SYNTHETIC — see below.)
+
+## How `--frame` routes
+
+`--frame <F>` (a **numeric** `frameId` from `frames`, or a URL substring) routes a
+`text`/`html`/`click`/`type`/`key` INTO that frame via `chrome.scripting` — which
+reaches CROSS-ORIGIN out-of-process iframes (OOPIFs). A frame-scoped fixed-func read
+runs in an **isolated world** (DOM-capable; it does not see that frame's page globals).
+**`eval --frame` is the exception: it runs the JS string via CDP `Runtime.evaluate`**
+(`chrome.scripting` can only run a serialized func, so the old path evaluated nothing and
+returned `value:null`) — same-process frames in an isolated world, a cross-origin OOPIF
+in its own flat session; a resolve/exec failure is a clear `frame_not_found` /
+`frame_eval_failed` error, never a silent null.
+In-frame `click`/`type`/`key` dispatch **SYNTHETIC** events (`isTrusted:false`, the
+reachable OOPIF path — drives most apps); the result carries `trusted:false` for
+`--frame` input and `trusted:true` for top-frame CDP input. A `--frame` op reports the
+FRAME's own `url` (so you can confirm you read the intended frame, not the top).
+
+**Picking `--frame` reliably (avoid the wrong frame):** prefer a **numeric `frameId`**
+from `frames` — it always wins and is never ambiguous. A URL substring is resolved
+**HOST-first** (matched against each frame's hostname before its path), so
+`--frame model-benchmarking` targets the OOPIF `model-benchmarking.civit.ai` rather than
+the top page's `civitai.com/apps/run/model-benchmarking` PATH. If a substring still
+matches **multiple** frames the op fails with `ambiguous_frame:<n> [<id>:<url>, …]`
+listing the candidates — re-issue with the numeric `frameId` (it does NOT silently pick
+the first match). So: **use the numeric id, or a host substring** — not a bare path token.
+**⚠ The numeric-id escape hatch does NOT apply to `eval`/`upload --frame` on a
+cross-origin OOPIF** — see the duplicate-URL limitation below.
+
+## Nested OOPIFs (OOPIF-in-OOPIF) — supported, with hard caps
+
+`Target.setAutoAttach` is not recursive (it attaches only a session's DIRECT child
+targets), which is why `eval --frame` on a **grandchild** cross-origin iframe used to
+return `frame_not_found`. It now **re-arms auto-attach on each attached child session**,
+walking the cascade DOWN the frame tree until the wanted frame's target appears — so a
+grandchild (and deeper) cross-origin frame IS reachable by `eval --frame` and by the
+OOPIF branch of `upload --frame`. Because a hostile page can nest/spawn frames without
+limit, the descent is **hard-bounded** and every bound fails LOUD (never a silent
+truncation, never a hang):
+
+| failure | error | meaning |
+|---------|-------|---------|
+| frame never attaches within the bounded wait (5 s **hard** ceiling, checked every iteration; 600 ms quiet-window settle, restarted on each new `setAutoAttach`) | `frame_not_found:<url> cascade[…]` | the frame isn't there — **plus a bounded diagnostic**, see below |
+| nesting deeper than **5** levels below the tab | `oopif_depth_cap:5` | we deliberately stopped descending |
+| more than **50** attached targets for one op | `oopif_target_cap:50` | frame-spamming page; work is bounded |
+| two attached frames share the target URL | `ambiguous_frame:<n> [<sessionId>:<url>, …]` | **no escape hatch — see below**; it never silently picks one |
+
+Both caps are named constants in `extension/protocol.js` (`OOPIF_MAX_DEPTH`,
+`OOPIF_MAX_TARGETS`, `OOPIF_SETTLE_MS`, `OOPIF_WAIT_MS`) and the whole cascade stays well
+under the per-op CDP budget. `text`/`html`/`click`/`type`/`key --frame` reach a nested
+frame as they always did (they use `chrome.scripting`, not CDP).
+
+**Every discovered target is filtered before it can ever be an eval target** — the
+recursion removed the old implicit "one level below a validated tab" boundary, so the
+boundary is now explicit: **own tab** (`chrome.debugger.onEvent` is global; a foreign
+`source.tabId` is dropped — and a caller that omits the tab fails CLOSED), **`iframe`
+targets only** (so a page's `new Worker(location.href)` can neither deny service by
+forcing `ambiguous_frame` nor capture your JS in a worker global), and **http/https
+only** (the same scheme gate the top tab passes, so a `chrome-extension://` child — any
+extension's web-accessible resource — can never become an eval target one level down).
+
+**⚠ Duplicate-URL OOPIFs are UNREACHABLE by `eval`/`upload --frame`, and the numeric
+`frameId` does NOT help.** The CDP path matches the frame purely by URL (a numeric
+webNavigation frameId has no 1:1 CDP target mapping), so two identical
+`<iframe src="https://embed.example/widget">` — a duplicated ad/widget slot, which is
+common — both match and the op fails `ambiguous_frame` with no way to pick one. That is a
+deliberate refusal, not a silent wrong-frame, but it IS a dead end: use
+`text`/`html`/`click`/`type`/`key --frame` (which resolve by numeric frameId and are
+unaffected), or change the page selector. A parent-chain tiebreak is a filed follow-up.
+
+**Every OOPIF failure carries a bounded `cascade[…]` diagnostic** naming the loop exit
+(`match`/`settle`/`deadline`/`depth-cap`/`target-cap`), which sessions were auto-attached,
+and — for up to 20 observed targets — the target `type`, whether `source.tabId` was
+present/matched, whether the parent session was known, the computed depth, and why each
+was dropped (`drop:type`/`drop:scheme`/`drop:foreign-tab`/`drop:unowned`/`drop:dup`).
+It is **caller-facing text only** — telemetry stays metadata-only. Read it before
+theorising about a `frame_not_found`.
+
+**✅ LIVE-VERIFIED against real Brave** (`tests/fixtures/oopif-rig/`, both checks). A
+grandchild OOPIF evaluates correctly, and on the 7-level deep rig depth 3 and depth 5
+resolve while depth 6 is refused with `oopif_depth_cap:5` and a full trace showing four
+chained sub-session auto-attaches. **`OOPIF_MAX_DEPTH = 5` is a real, measured guarantee**
+— not a contingent one.
+
+**📌 Discovered Chrome behaviour (cost a full verify round — remember it):
+Chrome does NOT populate `source.tabId` on SUB-session `Target.attachedToTarget` events.**
+They carry `sessionId` only. An own-tab check that requires `tabId` therefore silently
+eats every level-2+ event and the whole cascade goes **inert** — it returns
+`frame_not_found` and *never* a depth cap, because no nested session is ever recorded.
+Ownership is consequently proven by **session parentage**: an event whose
+`source.sessionId` is a session this cascade itself attached is ours. `tabId` stays
+authoritative when present; an event proving neither is dropped. If you ever add a
+listener-side own-tab gate to a flat-mode CDP cascade, this is the trap.
+
+The `cascade[…]` trace is also a useful **deterministic tell for whether an extension
+reload took**: an old build answers a nested-OOPIF miss with a bare
+`frame_not_found:<url>`, a new build answers with the same error **plus** the trace.
+
+## CDP security model (built in — this is the point)
+
+- **Frame enumeration + injection are STRICTLY own-tab-scoped.** `getAllFrames` and
+  `executeScript` are tab-scoped, so a model-supplied `--frame` can only ever resolve
+  to / inject into a frame of the session's owned/`--tab` tab — never another tab.
+- **CDP attach is STRICTLY own-tab-scoped.** The server routes a CDP op only to the
+  session's owned/`--tab` tab; the extension attaches `chrome.debugger` ONLY to that
+  tab and **refuses to attach to a privileged surface** (`chrome://`, extension,
+  `devtools:`, `file:`) — the attach is validated *before* it happens. The
+  autonomous agent's tab is FORCED, so it can never attach to another tab/profile.
+- **NO raw-CDP passthrough.** The agent's typed tool exposes ONLY the bounded ops
+  with typed scalars — there is no `cdp`/`method`/`params` field, so the model can
+  never send an arbitrary CDP command (no `Page.navigate file://`, no `Browser.*`,
+  no exfil `Runtime.evaluate`). Arbitrary CDP would reintroduce an RCE-class hole.
+- **Always detach.** Every CDP op is attach→run→**detach** (a `finally`, so a thrown
+  op still detaches) — no leaked attachment / stuck banner. An out-of-band detach is
+  handled too.
+- **Metadata-only telemetry** still holds: op/domain only — never frame URLs, typed
+  text, eval source, or screenshot bytes.
+
+**Tradeoff — the debug banner:** while a CDP op runs, Brave shows an "an extension
+is debugging this browser" banner. Attach is per-op (attach → run → detach) to keep
+that window tiny; a simple top-frame `text`/`html`/`eval`/foreground-`screenshot`
+takes the lighter non-CDP path and shows no banner.
+
+> **After updating the extension you MUST reload it** (the manifest gained the
+> `debugger` permission) — see `~/workspace/devrc/scripts/browser-bridge/reference/errors.md`; Brave may prompt to
+> re-confirm the new permission.
+
+Result payloads land under `.result.data` in the JSON (the envelope is
+`{"ok":true,"result":{"id","ok","data":{...}}}`).

--- a/scripts/browser-bridge/reference/security-ops.md
+++ b/scripts/browser-bridge/reference/security-ops.md
@@ -1,0 +1,86 @@
+# Security contract, telemetry, first-time setup, and the change gate
+
+**Load this when:** you are about to MODIFY browser-bridge (server / extension / CLI)
+— the live-verify gate below is MANDATORY · the user asks whether/why this is safe, or
+what it records · `browser health` says `extension_connected:false` and the extension
+has never been paired on this profile · you are setting up a second Brave profile.
+
+Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`.
+Full architecture + security model: `~/workspace/devrc/scripts/browser-bridge/README.md`.
+
+## What this is
+
+`browser-bridge` lets you operate the user's **real, logged-in Brave** browser.
+Commands go: the `browser` CLI → a loopback rendezvous server (`127.0.0.1:8788`,
+bearer-token auth) → a standalone MV3 extension in the live Brave session →
+executed against the **active tab** → result back to you.
+
+This is authorized personal automation on the user's own workbench. It is a
+**sibling** to the activity-collector browser extension (telemetry) — different
+subsystem, do not conflate.
+
+## Security contract (why it's safe)
+
+- **Loopback only** (`127.0.0.1:8788`) — never bound to an external interface.
+- **Bearer token** on every request — auto-created `0600` at
+  `~/.config/browser-bridge/token` on first server start. The `browser` CLI
+  reads it; a web page can't. Defeats DNS-rebinding.
+- **Host-header allowlist** — only `127.0.0.1`/`localhost`/`::1`.
+- **No `cookies` permission, on purpose** (README → *Security model*) — which is why
+  there is no cookie op; see the core's authenticated-request pattern.
+- **CDP is own-tab-scoped, typed, and always detached** — details in
+  `~/workspace/devrc/scripts/browser-bridge/reference/frames-cdp.md` § *CDP security model*.
+- **`upload` is data-exfil-capable** (any readable file's CONTENTS could be posted to
+  the site), so **every upload is AUDIT-LOGGED** (op + target domain + path) and it is
+  **OPERATOR-ONLY** — not in the autonomous agent's default op set (`op_not_allowed:upload`;
+  re-enable only via an explicit `BROWSER_AGENT_ALLOWED_OPS` opt-in). The result carries
+  the basename only. Chrome reads the file BY PATH itself (same host), so **no bytes
+  cross the bridge**; the CLI validates the path (readable regular file) and resolves it
+  to ABSOLUTE **before** dispatch.
+- **`screenshot` writes owner-only files** — a screenshot is a pixel-perfect image of an
+  **authenticated** view, so temp captures are mode-0600 and **auto-pruned after 24h**
+  (prefix-scoped, best-effort). Copy one to an explicit `path` if you need to keep it.
+  The payload is validated (strict base64 + PNG signature) before any write, so a failed
+  capture errors instead of leaving a 0-byte `.png`.
+
+## Telemetry (metadata-only)
+
+Every handled command emits one **best-effort** activity event
+(`source=browser-bridge`, `kind=cmd`) into the personal telemetry pipeline
+(`activity.events`), so browser-skill usage is queryable / visible to
+`adoption-scan`. It records **only** metadata — op, instance key, outcome,
+latency, and the active tab's **bare domain** — **never** the eval source, page
+HTML, screenshot bytes, full URLs, or any page content. It runs off the critical
+path and can never delay or break a command. Nothing you need to do; noted so you
+know browser usage is being counted. Details: `README.md` → Telemetry.
+
+## 🔴 Changing the bridge: live-verify against real Brave is the ONLY gate
+
+If you MODIFY browser-bridge (server / extension / CLI), a green test suite and a
+clean security audit are **prerequisites, NOT verification** — CI cannot drive a
+real Brave, so it never exercises the actual MV3 / CDP / i3 behaviour. Across the
+build-out, driving each change against the live browser caught ~11 defects that
+passing tests and audits BOTH missed (Chrome-side focus being inert on i3;
+`chrome.scripting` unable to eval a string → CDP `Runtime.evaluate`;
+`captureVisibleTab` needing foreground → CDP `Page.captureScreenshot`; OOPIFs
+needing `Target.setAutoAttach`; the reload-vs-restart trap). So the mandatory loop
+for any browser change is **build → audit → fix → merge → ship → live-verify on
+real Brave** — reproduce the exact path and LOOK at the actual result (exit 0 is
+not verification). Operate changes via a feature branch + `/audit-pr`-style review
+given it's a live-cookie surface.
+
+## One-time setup (hand these steps to the user)
+
+1. `home-manager switch --flake ~/workspace/devrc --impure` (starts the service).
+2. Brave → `brave://extensions` → Developer mode → **Load unpacked** →
+   `scripts/browser-bridge/extension/`.
+3. Extension **Options** → paste the token from `~/.config/browser-bridge/token`,
+   port `8788`, optionally set a unique **label** (required only if a second
+   profile also connects), **Save**.
+4. `browser health` → `extension_connected:true`.
+
+For a second profile, repeat in that profile and give it a **different** label,
+then target with `browser --instance <label> <op>`.
+
+> After updating the extension you MUST reload it — and reload ↻ is unreliable;
+> see `~/workspace/devrc/scripts/browser-bridge/reference/errors.md`. Brave may prompt to re-confirm the `debugger` permission.

--- a/scripts/browser-bridge/reference/spa-wake.md
+++ b/scripts/browser-bridge/reference/spa-wake.md
@@ -1,0 +1,103 @@
+# Throttled / backgrounded tabs — the `wake` pattern
+
+**Load this when:** a `text`/`html` read came back empty, half-built or shell-only ·
+a read reported `data.hidden:true` or printed a hidden-tab warning on stderr · an SPA
+looks stuck "Loading…" · `frames` lists no OOPIF you know is there · in-frame
+`click`/`type` hits elements that "don't exist yet" · you are about to conclude a site
+is BROKEN from a browser read · before driving any heavy JS app in an `open`ed tab.
+
+Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`.
+
+## The trap
+
+A heavy SPA opened in a **backgrounded** tab is throttled by Chrome —
+`document.visibilityState:"hidden"`, so it gets **no animation frames at all** and
+~1 Hz timers, and it often **never finishes rendering**. You then can't read or
+drive it: `text`/`frames` come back empty or half-built, and in-frame
+`click`/`type` hit elements that don't exist yet. Verified case:
+`model-benchmarking.civit.ai` (an OOPIF inside a `civitai.com` tab) stayed blank
+while backgrounded.
+
+`browser open` creates its tab in the **background** (`active:false`) on purpose, so
+every `open`ed heavy app starts throttled.
+
+🔴 **Before you believe any "nothing rendered / no requests fired" reading:**
+
+- **Check `document.visibilityState` FIRST**
+  (`browser --tab <id> js 'document.visibilityState'`). If `"hidden"`, that
+  reading is MEANINGLESS — a shell-only DOM is indistinguishable from a genuinely
+  broken frontend. (Reads self-announce it: `data.hidden:true` + a stderr warning.)
+- **Spoofing it afterwards does NOT recover the page.**
+  `Object.defineProperty(document,'visibilityState',…)` changes nothing: the
+  throttling is browser-enforced and the app's fetch decisions are already made.
+  **`wake` is the fix** — not a spoof, and not `activate`.
+- 🔴 **"Is this page broken for REAL users?" is not a browser question.** Answer it
+  from server-side/real-user evidence — RUM, metrics, pod health, an anonymous
+  `curl`. Use the browser probe to EXPLAIN a failure telemetry already shows, never
+  to DISCOVER one. An agent once escalated a hidden-tab read to a site-wide
+  production outage that was not happening; every "corroborating" check shared the
+  identical flaw, and one of the errors it cited was caused by the probe itself.
+  **Post-mortem: `~/workspace/devrc/scripts/browser-bridge/README.md` § *Real false-outage report*.**
+
+## `wake` — the fix, and it does NOT take the operator's screen
+
+It attaches CDP to that tab ONLY, turns on `Emulation.setFocusEmulationEnabled`
+(+ a best-effort `Page.setWebLifecycleState` thaw) (measured:
+`visibilityState` → `visible`, rAF 0/s → 62/s), holds it for a bounded settle
+(~1.5s default, cap **6s** via `--wait MS`) so the page paints, then explicitly
+disables focus emulation and detaches (the revert is never left to detach). Returns
+`{woke,visibilityState,readyState,applied,settleMs,…}`; `woke` is probed from an
+ISOLATED world, so a page cannot fake it. **Nothing in this path moves the operator's
+screen** — no `i3-msg`, no tab/window focus change.
+
+```bash
+BB=~/workspace/devrc/scripts/browser-bridge/browser
+$BB --instance work open https://civitai.com/apps/run/model-benchmarking  # backgrounded
+$BB --instance work wake                # → woke:true, the app renders
+$BB --instance work frames              # now the OOPIF is listed
+$BB --instance work --frame model-benchmarking text    # read inside it
+$BB --instance work --frame model-benchmarking click 'button:has-text("Grid")'  # drive it
+```
+
+**Wake once per PAGE, not per read.** The un-throttled *state* ends when the CDP
+session detaches (measured), but the **DOM the page rendered during the wake
+window persists** — so a following ordinary `text`/`html` sees the rendered page
+on the cheap, banner-free path. Re-wake after a navigation or when the app needs
+to do more rendering work.
+
+## `--wake` — when the read itself must observe live un-throttled state
+
+Use it when you are measuring rAF, or the app hydrates lazily and re-empties while
+hidden: put the un-throttle and the read in ONE CDP session.
+
+```bash
+$BB --instance work text --wake         # un-throttle + read, same CDP session
+$BB --instance work html --wake=3000    # longer settle
+$BB --instance work js '…' --wake
+```
+
+`--wake` is deliberately opt-in: an ordinary `text`/`html`/`eval` takes the light
+`chrome.scripting` path with **no debugger banner**, and routing every read
+through CDP would flash "an extension is debugging this browser" on every single
+read. `--wake` cannot be combined with `--frame` (refused with
+`wake_with_frame_unsupported`) — run `browser wake`, then the frame read.
+
+**World nuance:** `text`/`html --wake` read from an **ISOLATED world** (DOM-capable,
+no page globals); `js`/`eval --wake` is **MAIN world** by definition — that is what
+`eval` means.
+
+## When you actually need `activate` (rare)
+
+`activate` is still the honest answer when something needs the REAL foreground: a
+browser permission prompt, a native file picker, or verifying with your own eyes.
+**It STEALS the operator's screen** — telemetry caught a session calling it 1–5 times
+per minute, grabbing the screen on nearly every interaction. If you must, call it
+**once per TAB, never per read**, and restore focus afterward
+(`i3-msg '[id="<prev-winid>"] focus'`). It foregrounds via host-side `i3-msg`
+(Chrome-side `tabs.update`/`windows.update` is a no-op on i3), so it is i3-gated
+(`i3:"skipped"` off a graphical i3 host) and is **not available to the autonomous
+browser-agent at all**.
+
+**Caveat:** in-frame `click`/`type` are SYNTHETIC (`isTrusted:false`, the
+`chrome.scripting` OOPIF path) — but were verified to actually drive the real app
+(the Grid tab got selected). Top-frame input remains TRUSTED CDP.

--- a/scripts/browser-bridge/reference/tabs-instances.md
+++ b/scripts/browser-bridge/reference/tabs-instances.md
@@ -1,0 +1,82 @@
+# Per-session tab ownership & multiple Brave instances
+
+**Load this when:** you got `409 ambiguous_instance`, `404 unknown_instance`,
+`409 superseded`, `409 no_owned_tab`, or `owned_tab_gone` · two drivers appear to be
+fighting over one tab / you read a page another session navigated · you are designing a
+multi-session, multi-subagent or multi-profile workflow · you want to know whether
+`open` leaks tabs, or what `close` vs `release` do.
+
+Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`.
+
+## Per-session tab isolation (use `open` for multi-step work)
+
+Two Claude sessions driving one browser used to interleave on the ONE shared
+active tab (session A `nav`s, session B `nav`s in between, A reads B's page).
+Now each session can own its own tab:
+
+- **Multi-step workflow → `browser open <url>` first.** The server records this
+  session's owned tab (keyed by a stable per-session id sent automatically on
+  every request) and routes your subsequent `html`/`eval`/`nav`/`screenshot`/
+  `close` to it — a parallel session doing the same on its own tab can't clobber
+  you. Finish with `browser close` (closes the tab) or `browser release` (keeps
+  the tab, drops ownership).
+- **One-shot read → just `browser html` (no `open`).** With no owned tab, ops
+  fall back to the active tab — the historical "read the tab the user has open"
+  behaviour, which is a single read and inherently safe.
+- **`--tab <id>`** targets a specific tab explicitly (overrides owned/active).
+- **Double `open` is safe (idempotent).** Calling `browser open` again in a
+  session that already owns a **live** tab returns that SAME tabId (it does not
+  leak a second tab). If the owned tab was closed, `open` makes a fresh one.
+- **Self-heal.** If the user manually closes your owned tab, the next op fails
+  with `owned_tab_gone` and the bridge drops your ownership — your NEXT command
+  automatically falls back to the active tab. `browser close` always clears the
+  mapping, even if the tab was already gone.
+- **Session id source:** `CLAUDE_CODE_SESSION_ID` → `$TMUX_PANE` → a
+  per-process-tree token (see README). It is routing-only, never trusted for
+  auth. If two drivers ever resolve the same id they share a tab (degrades to
+  the old behaviour — no worse). `browser --print-session-id` prints the derived id.
+- **⚠ Concurrent drivers that may share a session id (subagents): pass explicit
+  `--tab`.** Sibling subagents of ONE parent share identity — a subagent inherits
+  the parent's `CLAUDE_CODE_SESSION_ID` and the same `$TMUX_PANE`, and there is NO
+  subagent-unique env var — so two parallel subagents derive the SAME session id
+  and would own the SAME tab (re-introducing the clobber). Per-session isolation
+  only separates concurrent **top-level** sessions. When you spawn concurrent
+  drivers that each drive the browser, have EACH one `browser open` (capture the
+  returned `tabId`) and then pass its OWN `--tab <id>` on **every** subsequent op
+  (`browser --tab <id> nav …`, `--tab <id> html`, …). An explicit `--tab`
+  overrides owned-tab routing entirely, so indistinguishable drivers never
+  collide. (Each `close`s its own `--tab <id>` at the end.)
+- **Contention → FIFO, not failure.** If two sessions DO target the same tab
+  (both active, or one `--tab`s another's tab), the commands queue in arrival
+  order (bounded by `cmd_timeout`) rather than fail.
+- **Lifecycle:** idle ownership is reclaimed after a TTL, which RELEASES it but
+  does NOT close the real Brave tab (only `browser close` closes it).
+
+## Don't do this: a bare high-rate `eval` loop
+
+Do **NOT** run a bare high-rate `eval` loop (no `--instance`/`open`). It shares
+the one active tab AND saturates the single serial extension connection; the
+server **rate-limits** it and returns **HTTP 429** (`rate_limited` /
+`queue_full`) — the `browser` CLI prints a back-off message and exits non-zero.
+Batch what you need into fewer `eval`s, or space them out. Knobs are in
+`~/workspace/devrc/scripts/browser-bridge/reference/errors.md`.
+
+## Multiple instances (per host)
+
+Several Brave profiles can each run the extension and be driven independently —
+each has its own command queue (routing key = the profile's **label** if set,
+else a stable auto-id; labels must be unique per host).
+
+- **One instance connected** → no `--instance` needed (back-compat).
+- **More than one and no `--instance`** → the command **ERRORS** and lists the
+  connected instances. Do NOT retry blindly — run `browser instances`, pick the
+  right key, and re-issue with `--instance <key>`. (The bridge never guesses.)
+- **`browser --instance <key> <op>`** targets one (key = label or auto-id); an
+  unknown key errors.
+- **Newest supersedes:** a fresh connection for an already-held key drops the old
+  one; an in-flight command on the dropped connection returns a `superseded`
+  error — just retry. The displaced connection's own `/poll` gets a distinct
+  `409 superseded` (not the idle `204`) and the extension **backs off ~30s** (and
+  shows a "superseded — set a unique label" state) instead of re-registering
+  instantly, so two profiles sharing a label can't mutual-supersede in a tight
+  loop. If you see `superseded` steadily, two profiles share a label → fix it.

--- a/scripts/browser-bridge/reference/x-fallback.md
+++ b/scripts/browser-bridge/reference/x-fallback.md
@@ -1,0 +1,46 @@
+# The X-server fallback (xdotool / maim)
+
+**Load this when:** `browser screenshot` is unsatisfactory for a genuinely
+un-composited window and you must capture the raw X window instead · `xdotool search`
+returns nothing · a capture came back blank/dark while the command exited 0 · a
+capture shows a DIFFERENT tab than the one you navigated.
+
+Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`. Try CDP `screenshot` first — it works on a
+BACKGROUND/occluded tab and needs none of this.
+
+If a window is on another i3 workspace and even CDP capture is unsatisfactory, you
+can still bypass the extension and capture the X window directly:
+
+```sh
+# 1. The Bash tool has NO X env by default — without this xdotool silently
+#    "sees" zero windows and every search returns nothing.
+export DISPLAY=:0 XAUTHORITY=/home/zach/.Xauthority
+
+# 2. Find the window by PAGE TITLE, not by class — several Brave windows exist
+#    and class-matching gives you an arbitrary one.
+nix-shell -p xdotool --run 'xdotool search --name "<page title fragment>"'
+
+# 3. Make it VISIBLE — focusing its workspace is not enough.
+i3-msg '[id="<winid>"] focus'
+
+# 4. Capture (settle first; the compositor needs a beat after the raise).
+nix-shell -p xdotool maim --run 'xdotool sleep 2; maim -i <winid> out.png'
+nix-shell -p imagemagick --run 'magick out.png -crop WxH+X+Y +repage cropped.png'
+```
+
+⚠ Step 3 focuses a window — that TAKES THE OPERATOR'S SCREEN, same cost as
+`browser activate`. Restore their focus afterwards
+(`i3-msg '[id="<prev-winid>"] focus'`).
+
+Two traps that produce a confidently-wrong result:
+
+- **A window on the focused workspace can still be *behind* another window** — the
+  capture then comes back blank/dark while `maim` exits 0. **Verify by LOOKING at
+  the image**, never by trusting the exit code.
+- **`maim -i <winid>` captures whatever tab is active in that window**, which may
+  not be the tab you just `nav`ed. After navigating, re-find the window **by the
+  new page title** so you're capturing the tab you think you are.
+- *(Historical note: the "future option" of a `chrome.debugger` + CDP
+  `Page.captureScreenshot` path for off-screen tabs is now IMPLEMENTED and is the
+  primary `screenshot` path — this X fallback is no longer the way to capture a
+  background tab.)*


### PR DESCRIPTION
Splits `scripts/browser-bridge/SKILL.md` — loaded into context on **every** browser task — into a lean operational core plus eight on-demand reference files. Docs only.

## Before / after

| artifact | bytes | ≈ tokens (bytes/4) | loaded |
|---|---:|---:|---|
| `SKILL.md` **before** | 56,031 | ~14,008 | every browser task |
| `SKILL.md` **after** | 11,322 | ~2,831 | every browser task |

Core is under the design's 12,000 B / ~3,000-token ceiling. It is above the design's 8,400 B *draft* figure because that draft was measured against a 41,177 B snapshot; the file has since grown 36% (wake/`--wake`, `activate`-as-last-resort, the nested-OOPIF cascade + `cascade[…]` diagnostics, `js` alias, screenshot-to-file, `html --max-bytes`, the cookie/HttpOnly pattern). Nothing was dropped to hit a number.

### Reference files

| file | bytes | ≈ tokens |
|---|---:|---:|
| `reference/frames-cdp.md` | 11,115 | ~2,779 |
| `reference/agent.md` | 6,605 | ~1,651 |
| `reference/errors.md` | 6,085 | ~1,521 |
| `reference/spa-wake.md` | 5,788 | ~1,447 |
| `reference/tabs-instances.md` | 5,270 | ~1,318 |
| `reference/security-ops.md` | 5,241 | ~1,310 |
| `reference/css-hit-test.md` | 4,212 | ~1,053 |
| `reference/x-fallback.md` | 2,303 | ~576 |
| **total** | **46,619** | **~11,655** |

## Estimated saving per browser task — arithmetic

```
Baseline SKILL.md        56,031 B  → 56,031/4 = 14,008 tokens
New core                 11,322 B  → 11,322/4 =  2,831 tokens
Gross saving             44,709 B  →            11,177 tokens

Mean reference size = 46,619/8 = 5,827 B ≈ 1,457 tokens
Assumption (stated, not measured): 30% of tasks load exactly ONE reference.
Expected reference cost = 0.30 × 1,457 = 437 tokens

NET saving per browser task = 11,177 − 437 = ~10,740 tokens
```

Sensitivity:

```
100% of tasks load ONE reference:    11,177 − 1,457  = 9,720 tokens saved
100% of tasks load TWO references:   11,177 − 2,914  = 8,263 tokens saved
100% of tasks load FOUR references:  11,177 − 5,828  = 5,349 tokens saved
every task loaded ALL EIGHT:         11,177 − 11,655 =  −478 tokens (net LOSS)
```

Honest note: unlike the design doc's figures (computed against the smaller baseline), the absolute worst case here is **marginally negative**. It requires every browser task to load all eight references, which the symptom-phrased triggers are specifically designed to prevent — most tasks should load zero. `bytes/4` is a rule of thumb, not a measurement; read all figures as ±15%.

## Coverage map — every old section → its new home

| old section (line span in `origin/main`) | destination |
|---|---|
| frontmatter (1–4) | core, **unchanged** |
| Quick start / binary path (13–27) | core § *Quick start — orient FIRST* |
| ⚠ The LOADED extension may be older than this doc (29–66) | `reference/errors.md` § *The LOADED extension may be older than the CLI* (incl. the 2026-07-30 "↻ DID take" nuance + the deterministic-tell method); **1-line summary as core trap #4** |
| `eval` gotchas — a `null` result… (68–81) | core trap #1 (one expression) + trap #2 (page CSP / GitHub, `chrome://`) |
| Cookies and authenticated requests (83–104) | core § *Cookies / authenticated requests* (HttpOnly blindness, in-page `fetch(…,{credentials:"include"})`, the CSP-strict caveat) |
| The user is USING this browser (106–112) | core § *This is the user's LIVE session* |
| Concurrency / don't do this (114–125) | core (sibling-subagent `--tab` rule) + `reference/tabs-instances.md` § *Don't do this: a bare high-rate `eval` loop* |
| `# browser — drive the live Brave session` preamble (127–138) | `reference/security-ops.md` § *What this is* |
| Entrypoint op table (140–172) | core § *Ops* (every op retained, condensed to one line; the long-form detail for `screenshot`/`upload`/`wake`/`activate`/`eval --frame` moved to the matching reference) |
| `--frame` routing + picking prose (174–197) | `reference/frames-cdp.md` §§ *How `--frame` routes*, *Picking `--frame` reliably* |
| Nested OOPIFs + cap table + target filtering (199–228) | `reference/frames-cdp.md` § *Nested OOPIFs — supported, with hard caps* |
| Duplicate-URL OOPIF dead end (229–236) | `reference/frames-cdp.md` (same section) |
| `cascade[…]` diagnostic (238–244) | `reference/frames-cdp.md` (same section) + reused in `errors.md` as the reload tell |
| ✅ LIVE-VERIFIED oopif-rig note (246–250) | `reference/frames-cdp.md` |
| 📌 Chrome does NOT populate `source.tabId` on sub-sessions (252–260) | `reference/frames-cdp.md` |
| `.result.data` envelope note (262–263) | `reference/frames-cdp.md` (end) + core § *Ops* preamble |
| Frame ops & CDP ops — the three fixes (265–287) | `reference/frames-cdp.md` § *What reaches what* |
| Security model (built in) bullets (289–306) | `reference/frames-cdp.md` § *CDP security model* |
| Debug-banner tradeoff + reload blockquote (308–315) | `reference/frames-cdp.md` |
| The X-server fallback (317–349) | `reference/x-fallback.md` |
| Driving a throttled/backgrounded SPA — the `wake` pattern (351–427) | `reference/spa-wake.md` (the trap, the 🔴 visibilityState rule, the no-spoof rule, the false-outage rule + README pointer, `wake`, `--wake`, wake-once-per-page, `activate`-as-last-resort, the synthetic-input caveat); **condensed as core trap #3 + triage items 1 and 5** |
| Diagnosing a CSS / layout bug (429–505) | `reference/css-hit-test.md` (all four steps, both ⚠ warnings) |
| `browser agent "<goal>"` (507–591) | `reference/agent.md` — **relocated verbatim, no policy change** |
| Per-session tab isolation (593–635) | `reference/tabs-instances.md` |
| Multiple instances (per host) (637–655) | `reference/tabs-instances.md` |
| Security contract (657–663) | `reference/security-ops.md` |
| Telemetry (metadata-only) (665–674) | `reference/security-ops.md` |
| Before you rely on it (676–684) | core § *Before you rely on it* |
| Error shapes (686–718) | `reference/errors.md` (all 14 shapes verbatim, plus 5 newly catalogued: `wake_with_frame_unsupported`, the OOPIF family, `op_not_allowed`/`nav_scheme_denied`, `Cannot access a chrome:// URL`) |
| Gotcha: reload the unpacked extension (720–729) | `reference/errors.md` |
| Changing the bridge: live-verify is the ONLY gate (731–744) | `reference/security-ops.md` (🔴 retained) |
| One-time setup (746–757) | `reference/security-ops.md` |

### Verification of coverage

A mechanical check grepped **75 distinctive strings** lifted from the old file — every error code (`ambiguous_frame`, `cdp_attach_refused`, `owned_tab_gone`, `bad_tab`, `queue_full`, …), every env knob (`BROWSER_BRIDGE_RATE_PER_SEC`, `BROWSER_BRIDGE_BURST`, `BROWSER_BRIDGE_MAX_QUEUE`, `BROWSER_AGENT_ALLOWED_OPS`), every CDP method named (`Emulation.setFocusEmulationEnabled`, `Page.setWebLifecycleState`, `Page.captureScreenshot`, `DOM.setFileInputFiles`, `Target.setAutoAttach`, `Runtime.evaluate`), the named constants (`OOPIF_MAX_DEPTH`, `OOPIF_SETTLE_MS`, `protocol.js`, `tests/fixtures/oopif-rig`), the verified-case identifiers (`model-benchmarking`, `civitai-manager v0.1.82`), and the incident pointers (`Real false-outage report`, `PR #180`, `drop:foreign-tab`, `133K`) — against the new core + all eight references. **Result: 0 missing.** The check script was temporary and is not committed.

## Reflects everything merged in the last day

Verified against the current file, not the design doc's snapshot:

- `wake` / `--wake` on `text`/`html`/`eval` — no focus movement, 6 s settle cap, **wake once per page not per read** (the rendered DOM persists after detach); `text`/`html --wake` read from an ISOLATED world, `js`/`eval --wake` is MAIN world by definition.
- `activate` is the **last resort**, steals the operator's screen via `i3-msg`, unreachable by the autonomous agent. The old "run `browser activate`" hidden-tab advice is **gone from every file** — grepped; the only surviving mentions are the prohibition, the `wake`-not-`activate` redirect, and the narrow "needs the real foreground" case.
- `js` is a CLI alias for `eval` (wire op stays `eval`); the worktree-isolation-guard rationale is in the core op table.
- `screenshot` writes a mode-0600 `.png`, auto-pruned after 24 h, no base64 to stdout, `--data-url` escape hatch.
- `html --max-bytes` cap.
- Cookies: HttpOnly invisible to `document.cookie`; CSP-strict origins return `null`; sanctioned in-page `fetch(…, {credentials:'include'})` pattern.
- Agent op set is **11 ops**; `upload` operator-only (opt-in via `BROWSER_AGENT_ALLOWED_OPS`), `activate` operator-only with **no** opt-in.

## The `browser agent` default flip is deliberately NOT in this PR

The design doc (Part B) proposes making `browser agent` the default for open-ended reads, including a new core `## FIRST DECISION: agent or direct?` section. **That is not implemented here, and no wording steering sessions toward the agent was added.** Two current blockers:

1. A readiness-probe bug means `browser agent` **cannot start at all** (fix in flight on `fix/browser-agent-readiness-probe`).
2. deepseek-flash's capability on this task has **never been measured**.

The existing agent guidance is relocated as-is into `reference/agent.md`. The default flip is a separate PR once the agent demonstrably runs.

## Judged questionable, left in place (flagged, not deleted)

One item only: the old X-fallback closed with *"(Future option, NOT implemented: a `chrome.debugger` + CDP `Page.captureScreenshot` path could capture an off-screen tab … deliberately out of scope.)"* — that path **is** now implemented and is the primary `screenshot` path, so the parenthetical contradicted the rest of the doc. It was **not deleted**: it is kept in `reference/x-fallback.md` re-labelled as a historical note stating the feature now exists. This is the only place I changed a claim rather than relocating it verbatim. Reviewer's call if you'd prefer the original wording restored.

I also **added** one warning that was implied but never stated: X-fallback step 3 (`i3-msg … focus`) takes the operator's screen exactly like `activate`, so restore focus afterwards.

## Notes for the reviewer

- `SKILL.md` stays at its exact path — the `~/.claude/skills/browser/SKILL.md` symlink chain is untouched.
- `nix/home.nix` symlinks only `SKILL.md` and the `browser` CLI into `~/.claude/skills/browser/`, **not** `reference/`. The core therefore addresses references by repo-absolute path (`~/workspace/devrc/scripts/browser-bridge/reference/<file>`) and says so explicitly. Adding a `reference/` symlink to `home.nix` would let them be addressed relatively, but that is a Nix change and out of scope for a docs-only PR.
- No changes to `browser`, `browser-agent`, `server.py`, `extension/`, `opencode/`, or `tests/` — a concurrent branch owns `browser-agent` + `tests/test_browser_agent.py`.
- Not live-verified against real Brave, because nothing executable changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
