### PR TITLE
fix(browser-agent): probe tab readiness without injecting — the second blocker that made `browser agent` unrunnable

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -922,8 +922,22 @@ browser agent "<goal>" [--instance K] [--allow-domains …] [--deny-domains …]
 
 **Flow (the wrapper, `browser-agent`):**
 
-1. `open`s a NEW background tab on instance K and captures its `tabId` (the
-   agent's OWN tab — reuses the #175 `open`+`--tab` isolation).
+1. `open`s a NEW background tab on instance K **at `about:blank`** and captures
+   its `tabId` (the agent's OWN tab — reuses the #175 `open`+`--tab` isolation),
+   then **PROBES** it before spending a model token: a **non-injecting `browser
+   tabs` listing** (pure `chrome.tabs` metadata — no `chrome.scripting`, no page
+   content) that must contain the new `tabId`. Absent → the post-reload transient
+   → close + re-open, bounded by `BROWSER_AGENT_READY_ATTEMPTS`/`_BACKOFF`. Any
+   other probe error is a hard refusal.
+
+   ⚠ **The probe must never inject.** It used to run `eval '1'`, which made
+   `browser agent` **impossible to run**: `chrome.scripting` cannot inject into
+   `about:blank` (no host permission covers it), so every single run died with
+   `Cannot access contents of url "about:blank". Extension manifest must request
+   permission to access this host.` before the model was ever invoked. The tab
+   deliberately starts neutral — navigating it somewhere on startup would leak a
+   request the caller never asked for and could trip `--allow-domains` — so
+   readiness has to be answerable without page-content access. `tabs` is.
 2. Runs `opencode run --format json -m openrouter/deepseek/deepseek-v4-flash
    --agent browser-agent --auto` in a scratch `--dir`, under a **wall-clock
    `--timeout` enforced with a PROCESS-GROUP kill** (`setsid` + `kill -<pgid>`, so

--- a/scripts/browser-bridge/browser-agent
+++ b/scripts/browser-bridge/browser-agent
@@ -8,11 +8,12 @@
 #                          [--steps N] [--timeout S] [--dry-run]
 #
 # What it does (see README "opencode browser-agent"):
-#   1. `open`s a NEW tab on instance K (its OWN tab), captures the tabId, and
-#      PROBES it (cheap `eval '1'`, no model tokens) to confirm the tab is
-#      live/owned before proceeding — re-opening (bounded retry) if a post-reload
-#      transient left the tab gone (owned_tab_gone), so the model never gets a
-#      doomed tabId.
+#   1. `open`s a NEW tab on instance K (its OWN tab) at about:blank, captures the
+#      tabId, and PROBES it (a NON-INJECTING `browser tabs` listing, no model
+#      tokens) to confirm the tab is live/owned before proceeding — re-opening
+#      (bounded retry) if a post-reload transient left the tab gone, so the model
+#      never gets a doomed tabId. The probe must NOT inject into the page: the
+#      tab starts at about:blank, which no host permission covers.
 #   2. Runs `opencode run --format json -m <deepseek> --agent browser-agent --auto`
 #      in a scratch --dir. The agent def DENIES every built-in tool (bash, edit,
 #      read, webfetch, …) and ALLOWS only ONE custom, TYPED tool: `browser`
@@ -222,10 +223,11 @@ esac
 # VANISH before the model's first op — opencode then returns status:"blocked"
 # with op_failed:owned_tab_gone and the run wastes tokens. So before spending
 # ANY model token, VERIFY the freshly-opened tab is actually live/owned with a
-# CHEAP, metadata-only probe (`eval '1'` → returns 1, NO page content). If the
-# probe reports the tab is gone, close the stale tab (best-effort) and re-open —
-# bounded retry with a short backoff to let the SW settle. Only a probe-passing
-# owned tab is ever handed to opencode.
+# CHEAP, metadata-only, NON-INJECTING probe (`browser tabs` → chrome.tabs
+# metadata only, NO page content, NO chrome.scripting). If the probe reports the
+# tab is gone, close the stale tab (best-effort) and re-open — bounded retry with
+# a short backoff to let the SW settle. Only a probe-passing owned tab is ever
+# handed to opencode.
 READY_ATTEMPTS="${BROWSER_AGENT_READY_ATTEMPTS:-3}"   # test seam
 READY_BACKOFF="${BROWSER_AGENT_READY_BACKOFF:-0.4}"   # test seam (seconds)
 
@@ -241,21 +243,94 @@ except Exception:
   case "$TAB" in (*[!0-9]*|"") die "could not determine the opened tabId from: $open_resp";; esac
 }
 
-# _probe_tab — model-free readiness check of the CURRENT owned tab ($TAB). Runs a
-# harmless `eval '1'` (returns 1; NO page content). Returns:
-#   0 → tab is live/usable (probe passed)
-#   1 → tab is GONE (owned_tab_gone / "no tab with id") — re-open and retry
+# _probe_tab — model-free readiness check of the CURRENT owned tab ($TAB). Lists
+# the browser's tabs (`browser tabs` → pure chrome.tabs metadata: id/url/title/
+# active/windowId; NO chrome.scripting injection, NO page content) and asserts
+# $TAB is present.
+#
+# ⚠ WHY NOT `eval '1'` (what this used to do): that made `browser agent`
+# IMPOSSIBLE to run — an unconditional, 100%-of-the-time hard failure before the
+# model was ever invoked. The agent's tab is deliberately opened at about:blank
+# (a neutral start; navigating it somewhere on startup would leak a request the
+# caller never asked for and could trip --allow-domains), and chrome.scripting
+# CANNOT inject into about:blank — it is not covered by the manifest's <all_urls>
+# host permission. So every probe came back with Chrome's
+#   Cannot access contents of url "about:blank". Extension manifest must request
+#   permission to access this host.
+# which is not owned_tab_gone → rc=2 → `die`. Readiness only ever needed to
+# answer "does this tab exist and can the bridge see it" — the probe's own
+# comment said as much ("NO page content"). `tabs` answers exactly that, for ANY
+# url scheme, without needing page-content access at all.
+#
+# Returns:
+#   0 → tab is live/usable (present in the tab list)
+#   1 → tab is GONE (absent from the list, or the bridge said owned_tab_gone)
 #   2 → some OTHER error (hard failure — surfaced via PROBE_OUT)
 # The probe's stdout+stderr are captured into PROBE_OUT and NEVER reach the
-# wrapper's own stdout, so an op-error dump can't pollute the final JSON result.
+# wrapper's own stdout, so neither an op-error dump nor a tab listing can pollute
+# the final JSON result.
 PROBE_OUT=""
 _probe_tab() {
-  PROBE_OUT="$("$BROWSER_BIN" "${bflags[@]}" --tab "$TAB" eval '1' 2>&1)"
+  PROBE_OUT="$("$BROWSER_BIN" "${bflags[@]}" tabs 2>&1)"
   local rc=$?
-  [ "$rc" = "0" ] && return 0
-  case "$PROBE_OUT" in
-    *owned_tab_gone*|*"no tab with id"*|*"No tab with id"*) return 1 ;;
-    *) return 2 ;;
+  if [ "$rc" != "0" ]; then
+    # A non-zero `tabs` is a bridge/transport failure (no extension, rate limit,
+    # ambiguous instance…) — hard. The owned_tab_gone shapes are kept for
+    # robustness in case a future/older extension answers `tabs` per-tab.
+    case "$PROBE_OUT" in
+      *owned_tab_gone*|*"no tab with id"*|*"No tab with id"*) return 1 ;;
+      *) return 2 ;;
+    esac
+  fi
+  # rc=0 → parse the listing and look for $TAB. Reads stdin (never argv) so a
+  # large listing can't blow the arg limit.
+  local prc
+  printf '%s' "$PROBE_OUT" | python3 -c '
+import json, sys
+# Locate the tabs array inside the CLI envelope ({"ok":…,"result":{…,"data":
+# {"tabs":[…]}}}), tolerating any stderr noise around the JSON document.
+# exit 0 = tab present, 1 = tab absent (gone), 3 = no parseable tab list.
+want = sys.argv[1]
+raw = sys.stdin.read()
+dec = json.JSONDecoder()
+obj = None
+i = raw.find("{")
+while i != -1:
+    try:
+        obj = dec.raw_decode(raw[i:])[0]
+        break
+    except ValueError:
+        i = raw.find("{", i + 1)
+def find_tabs(o):
+    if isinstance(o, dict):
+        t = o.get("tabs")
+        if isinstance(t, list):
+            return t
+        for v in o.values():
+            r = find_tabs(v)
+            if r is not None:
+                return r
+    elif isinstance(o, list):
+        for v in o:
+            r = find_tabs(v)
+            if r is not None:
+                return r
+    return None
+tabs = find_tabs(obj) if obj is not None else None
+if tabs is None:
+    sys.exit(3)
+sys.exit(0 if any(str(t.get("id")) == want
+                  for t in tabs if isinstance(t, dict)) else 1)
+' "$TAB"
+  prc=$?
+  case "$prc" in
+    0) return 0 ;;
+    1) return 1 ;;
+    # Unparseable: replace PROBE_OUT with a SHORT diagnostic — the raw value can
+    # be the operator's whole tab list (every url + title), which must not land
+    # in a stderr error dump.
+    *) PROBE_OUT="could not find a tab list in the \`browser tabs\` response (first 200 bytes: $(printf '%.200s' "$PROBE_OUT"))"
+       return 2 ;;
   esac
 }
 

--- a/scripts/browser-bridge/tests/test_browser_agent.py
+++ b/scripts/browser-bridge/tests/test_browser_agent.py
@@ -55,22 +55,39 @@ def _write_exec(path: Path, content: str):
     return path
 
 
-def _fake_browser(path: Path) -> Path:
-    """A stand-in for the real `browser` CLI (used ONLY for open/close/print-session-id
-    by the wrapper — the agent's own reads go through the custom tool, not this).
+# A distinctive string that appears ONLY in the fake `browser tabs` listing — used
+# to prove the probe's output never reaches the wrapper's own stdout. (In the real
+# world that listing is the operator's entire tab list: every url + title.)
+PROBE_MARKER = "PROBE-ONLY-TAB-TITLE-9f3ac1"
 
-    - `--print-session-id`           → prints a stable fake id.
+
+def _fake_browser(path: Path) -> Path:
+    """A stand-in for the real `browser` CLI (used ONLY for open/close/tabs/
+    print-session-id by the wrapper — the agent's own reads go through the custom
+    tool, not this).
+
+    - `--print-session-id`            → prints a stable fake id.
     - `[--instance K] open [url]`     → prints {result:{data:{tabId:FRB_TABID}}}
-      (or exits 1 if FRB_OPEN_FAIL=1).
-    - `[--instance K] --tab N eval …` → the wrapper's readiness PROBE. Succeeds by
-      default; if FRB_PROBE_FAIL_TIMES>0 the FIRST that-many probe calls instead
-      mimic a tab-gone op error (stderr `owned_tab_gone`, exit 1) — the counter is
-      persisted in FRB_PROBE_COUNT so retries advance it.
+      (or exits 1 if FRB_OPEN_FAIL=1). The tab is opened at **about:blank**, as
+      the real wrapper does.
+    - `[--instance K] tabs`           → the wrapper's readiness PROBE: a
+      chrome.tabs-style listing (id/url/title/active/windowId), always including a
+      decoy tab titled PROBE_MARKER. Modes:
+        * FRB_PROBE_FAIL_TIMES>0 — the FIRST that-many probes OMIT the owned tab
+          from the listing (the tab-gone shape → wrapper must re-open); the
+          counter is persisted in FRB_PROBE_COUNT so retries advance it.
+        * FRB_PROBE_HARD_FAIL=1  — a bridge/transport error (stderr + exit 1).
+        * FRB_PROBE_UNPARSEABLE=1 — exits 0 with output that carries no tab list.
+    - `[--instance K] --tab N eval …` → mimics REAL Chrome on an about:blank tab:
+      chrome.scripting cannot inject there (no host permission covers about:blank),
+      so it FAILS. This is the regression pin — a wrapper that probes with `eval`
+      can never start.
     - `[--instance K] --tab N <op> …` → prints a canned success envelope.
     Every invocation is appended (one JSON line) to $FRB_LOG for assertions.
     """
     return _write_exec(path, '''#!/usr/bin/env python3
 import json, os, sys
+MARKER = "PROBE-ONLY-TAB-TITLE-9f3ac1"
 argv = sys.argv[1:]
 if argv and argv[0] == "--print-session-id":
     print("claude:fake-session"); sys.exit(0)
@@ -90,17 +107,18 @@ if log:
     with open(log, "a") as f:
         f.write(json.dumps({"op": op, "tab": tab, "instance": inst,
                             "rest": rest}) + "\\n")
+tabid = int(os.environ.get("FRB_TABID", "4242"))
 if op == "open":
     if os.environ.get("FRB_OPEN_FAIL") == "1":
         sys.stderr.write("fake open failed\\n"); sys.exit(1)
-    tabid = int(os.environ.get("FRB_TABID", "4242"))
     print(json.dumps({"ok": True, "result": {"id": "x", "ok": True,
           "data": {"tabId": tabid, "url": "about:blank"}}}))
     sys.exit(0)
-if op == "eval":
-    # The wrapper's cheap readiness probe. Optionally fail the first N calls with
-    # a tab-gone op error (as the real `browser` CLI surfaces owned_tab_gone: a
-    # message on stderr + non-zero exit) to exercise the open->probe->reopen loop.
+if op == "tabs":
+    # The wrapper's NON-INJECTING readiness probe.
+    if os.environ.get("FRB_PROBE_HARD_FAIL") == "1":
+        sys.stderr.write("browser: no extension connected " + MARKER + "\\n")
+        sys.exit(1)
     fail_times = int(os.environ.get("FRB_PROBE_FAIL_TIMES", "0"))
     cf = os.environ.get("FRB_PROBE_COUNT")
     cur = 0
@@ -109,12 +127,26 @@ if op == "eval":
         except ValueError: cur = 0
     if cf:
         open(cf, "w").write(str(cur + 1))
-    if cur < fail_times:
-        sys.stderr.write("browser: op 'eval' failed in the browser: owned_tab_gone\\n")
-        sys.exit(1)
+    if os.environ.get("FRB_PROBE_UNPARSEABLE") == "1":
+        print("<not json, no tab list> " + MARKER); sys.exit(0)
+    # A decoy tab is ALWAYS present; the owned tab is omitted while "gone".
+    tabs = [{"id": 11, "url": "https://decoy.test/", "title": MARKER,
+             "active": True, "windowId": 1}]
+    if cur >= fail_times:
+        tabs.append({"id": tabid, "url": "about:blank", "title": "",
+                     "active": False, "windowId": 1})
     print(json.dumps({"ok": True, "result": {"id": "x", "ok": True,
-          "data": {"value": 1}}}))
+          "data": {"tabs": tabs}}}))
     sys.exit(0)
+if op == "eval":
+    # REAL Chrome behaviour on the agent's about:blank tab: chrome.scripting has
+    # no host permission for about:blank, so injection is refused. Any wrapper
+    # that uses `eval` as its readiness probe dies here, before the model runs.
+    sys.stderr.write(
+        "browser: op 'eval' failed in the browser: Cannot access contents of url "
+        "\\"about:blank\\". Extension manifest must request permission to access "
+        "this host.\\n")
+    sys.exit(1)
 print(json.dumps({"ok": True, "result": {"id": "x", "ok": True,
       "data": {"url": "https://x.test", "title": "X", "text": "page text"}}}))
 sys.exit(0)
@@ -588,10 +620,10 @@ def test_open_failure_clean_error(rig):
 
 # --------------------------------------------------------------------------- #
 # Pre-flight tab-readiness retry: after opening its own tab, the wrapper PROBES
-# it (cheap `eval '1'`, no model tokens) to confirm the tab is live/owned before
-# invoking opencode. Right after an extension reload the service worker's tab
-# tracking isn't settled, so the just-opened tab can vanish (owned_tab_gone); the
-# wrapper must re-open (bounded retry) so the model never gets a doomed tabId.
+# it (a NON-INJECTING `browser tabs` listing, no model tokens) to confirm the tab
+# is live/owned before invoking opencode. Right after an extension reload the
+# service worker's tab tracking isn't settled, so the just-opened tab can vanish;
+# the wrapper must re-open (bounded retry) so the model never gets a doomed tabId.
 # --------------------------------------------------------------------------- #
 def test_readiness_probe_passes_first_try_single_open(rig):
     """Happy path: the probe passes on the first attempt → EXACTLY one open, one
@@ -600,15 +632,14 @@ def test_readiness_probe_passes_first_try_single_open(rig):
     assert r.returncode == 0, r.stderr
     calls = _browser_calls(rig.frb_log)
     opens = [c for c in calls if c["op"] == "open"]
-    probes = [c for c in calls if c["op"] == "eval"]
+    probes = [c for c in calls if c["op"] == "tabs"]
     assert len(opens) == 1, f"expected exactly one open, got {len(opens)}"
     assert len(probes) == 1, f"expected exactly one readiness probe, got {len(probes)}"
-    assert probes[0]["tab"] == str(TAB_ID), "the probe must target the opened tab"
     assert len(_oc_calls(rig.oc_log)) == 1, "opencode must be invoked once the probe passes"
 
 
 def test_readiness_reopens_on_transient_tab_gone(rig):
-    """First probe reports owned_tab_gone (post-reload transient), the retry's
+    """First probe reports the tab is gone (post-reload transient), the retry's
     probe passes → the wrapper re-opens, the probe passes, and opencode IS
     invoked and the run proceeds to a normal result."""
     r = rig.run(["read the page"], mode="ok", probe_fail=1)
@@ -616,7 +647,7 @@ def test_readiness_reopens_on_transient_tab_gone(rig):
     assert json.loads(r.stdout.strip()) == SCHEMA_OK
     calls = _browser_calls(rig.frb_log)
     opens = [c for c in calls if c["op"] == "open"]
-    probes = [c for c in calls if c["op"] == "eval"]
+    probes = [c for c in calls if c["op"] == "tabs"]
     assert len(opens) == 2, f"expected a re-open after the transient, got {len(opens)} opens"
     assert len(probes) == 2, f"expected two probes (fail then pass), got {len(probes)}"
     # The stale (gone) tab is closed best-effort before re-opening.
@@ -655,6 +686,112 @@ def test_readiness_failure_still_closes_tab_no_orphan(rig):
     assert any(c["op"] == "close" and c["tab"] == str(TAB_ID) for c in calls), \
         "cleanup must close the last owned tab on a readiness-failure exit"
     assert "extension loaded/connected" in r.stderr.lower(), "the error must be actionable"
+
+
+# --------------------------------------------------------------------------- #
+# REGRESSION (the second of two independent blockers that kept `browser agent`
+# from EVER running): the readiness probe must not need PAGE-CONTENT access.
+#
+# The agent's tab is deliberately opened at about:blank, and chrome.scripting
+# cannot inject into about:blank — it isn't covered by the manifest's <all_urls>
+# host permission. The old probe ran `eval '1'` there, so EVERY run died with
+#   readiness probe failed unexpectedly on tab N: browser: op 'eval' failed in
+#   the browser: Cannot access contents of url "about:blank". …
+# before a single model token was spent. The fake `browser` above reproduces that
+# Chrome behaviour faithfully, so these tests FAIL on the pre-fix wrapper.
+# --------------------------------------------------------------------------- #
+def test_readiness_probe_passes_on_an_about_blank_tab(rig):
+    """THE regression: the agent's own tab starts at about:blank and the probe
+    must still pass. (Pre-fix this died rc=2 with Chrome's host-permission error.)"""
+    r = rig.run(["report the page title"], mode="ok")
+    assert r.returncode == 0, (
+        "the readiness probe must pass on an about:blank tab — page-content "
+        f"access is not required to check that a tab exists:\n{r.stderr}")
+    assert "Cannot access contents of url" not in r.stderr
+    assert json.loads(r.stdout.strip()) == SCHEMA_OK
+    assert len(_oc_calls(rig.oc_log)) == 1, "the model must actually be reached"
+
+
+def test_readiness_probe_does_not_inject_into_the_page(rig):
+    """Structural pin: the probe must use a NON-INJECTING op. No `eval` (nor any
+    other content-script op) may be issued against the agent's tab by the wrapper
+    — the only pre-model browser calls are `open` and the `tabs` probe."""
+    r = rig.run(["read the page"], mode="ok")
+    assert r.returncode == 0, r.stderr
+    ops = [c["op"] for c in _browser_calls(rig.frb_log)]
+    assert "eval" not in ops, "the readiness probe must not inject into the page"
+    for injecting in ("html", "getHtml", "text", "screenshot", "nav"):
+        assert injecting not in ops, f"the wrapper must not issue `{injecting}` itself"
+    assert ops.count("tabs") == 1, f"expected exactly one `tabs` probe, got {ops}"
+
+
+def test_probe_source_does_not_use_eval():
+    """Static guard: `eval` must not creep back into the probe. The wrapper may
+    still MENTION it in the explanatory comment (that is the bug's postmortem),
+    so only non-comment lines are checked."""
+    src = WRAPPER.read_text()
+    code = [ln for ln in src.splitlines() if not ln.lstrip().startswith("#")]
+    probe_calls = [ln for ln in code if '"$BROWSER_BIN"' in ln and " eval " in ln]
+    assert probe_calls == [], f"the wrapper must not run a `browser eval`: {probe_calls}"
+    assert any('"$BROWSER_BIN"' in ln and " tabs" in ln for ln in code), \
+        "the readiness probe must use the non-injecting `tabs` op"
+
+
+def test_probe_hard_failure_dies_rc2_without_running_the_model(rig):
+    """A genuine (non-tab-gone) probe failure is still HARD: rc=2, the error is
+    surfaced on stderr, the model is never invoked, and no retry loop spins."""
+    r = rig.run(["read the page"], mode="ok",
+                extra_env={"FRB_PROBE_HARD_FAIL": "1"})
+    assert r.returncode == 2, r.stdout + r.stderr
+    assert "readiness probe failed unexpectedly" in r.stderr
+    assert _oc_calls(rig.oc_log) == [], "the model must NEVER run on a hard probe failure"
+    # rc=2 is terminal — exactly one open + one probe, no bounded-retry spin.
+    ops = [c["op"] for c in _browser_calls(rig.frb_log)]
+    assert ops.count("open") == 1, f"a hard probe failure must not retry the open: {ops}"
+    assert ops.count("tabs") == 1, f"a hard probe failure must not re-probe: {ops}"
+    assert r.stdout.strip() == "", "a hard probe failure must not print a schema result"
+
+
+def test_probe_unparseable_listing_is_a_hard_failure(rig):
+    """A 0-exit `tabs` whose output carries no tab list is rc=2 (fail closed) — an
+    unreadable answer must never be treated as 'ready'."""
+    r = rig.run(["read the page"], mode="ok",
+                extra_env={"FRB_PROBE_UNPARSEABLE": "1"})
+    assert r.returncode == 2, r.stdout + r.stderr
+    assert "readiness probe failed unexpectedly" in r.stderr
+    assert _oc_calls(rig.oc_log) == [], "the model must NEVER run on an unreadable probe"
+
+
+def test_probe_output_never_reaches_stdout(rig):
+    """PROBE_OUT captures stdout+stderr and must NEVER reach the wrapper's own
+    stdout — in production the `tabs` listing is the operator's ENTIRE tab list
+    (every url + title), and any of it on stdout would corrupt the JSON result."""
+    # Happy path: the listing (incl. the decoy tab's title) must not leak.
+    r = rig.run(["read the page"], mode="ok")
+    assert r.returncode == 0, r.stderr
+    assert PROBE_MARKER not in r.stdout, "the probe's tab listing leaked to stdout"
+    assert PROBE_MARKER not in r.stderr, "the probe's tab listing leaked to stderr"
+    assert json.loads(r.stdout.strip()) == SCHEMA_OK   # stdout is EXACTLY the schema
+    # Tab-gone retry path: still nothing on stdout.
+    r2 = rig.run(["read the page"], mode="ok", probe_fail=1)
+    assert r2.returncode == 0, r2.stderr
+    assert PROBE_MARKER not in r2.stdout
+    assert json.loads(r2.stdout.strip()) == SCHEMA_OK
+    # Hard-failure path: the error goes to STDERR, stdout stays empty.
+    r3 = rig.run(["read the page"], mode="ok",
+                 extra_env={"FRB_PROBE_HARD_FAIL": "1"})
+    assert r3.returncode == 2
+    assert r3.stdout.strip() == "", "an op-error dump must never reach stdout"
+
+
+def test_unparseable_probe_error_does_not_dump_the_whole_listing(rig):
+    """Privacy: when the listing can't be parsed, the stderr diagnostic is capped
+    — it must not spray the operator's full tab list into the terminal/logs."""
+    r = rig.run(["read the page"], mode="ok",
+                extra_env={"FRB_PROBE_UNPARSEABLE": "1"})
+    assert r.returncode == 2
+    assert "could not find a tab list" in r.stderr
+    assert "first 200 bytes" in r.stderr, "the raw response must be truncated"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## The blocker

`browser agent` **could never start.** Not "was flaky" — a 100%-of-the-time hard failure before a single model token was spent.

`_open_tab` opens the agent's own tab at **`about:blank`**. `_probe_tab` then ran `browser --tab <id> eval '1'` as its readiness check. `chrome.scripting` **cannot inject into `about:blank`** — it is not covered by the manifest's `<all_urls>` host permission — so the probe always returned an op error. That error is not `owned_tab_gone`, so it fell through to the `*)` case → rc=2 → `die`.

### Live reproduction (on the workbench, before this change)

```
$ browser --instance personal agent --dry-run "report the page title"
browser-agent: readiness probe failed unexpectedly on tab 484063997: browser: op 'eval'
failed in the browser: Cannot access contents of url "about:blank". Extension manifest
must request permission to access this host.
```

The gate had already passed and the tab had already been opened — the wrapper died on the probe, one step short of invoking the model.

### Why the feature has never run

This is the **second of two independent blockers**. The first was the `opencode debug agent` tool-set-gate flush race (#216) — a `$(...)` pipe capture returned a truncated JSON prefix, so the gate failed closed and refused before the tab was even opened. That one is fixed and working: the run above got *past* the gate and successfully opened a tab. Fixing the gate simply moved the wall one step later, onto this probe. Together they fully explain why `browser agent` has **never once been invoked** on either host despite being built, RCE-hardened, gated and documented.

## The fix

Probe **without injecting**. The readiness check now uses `browser tabs` — pure `chrome.tabs` metadata (`id`/`url`/`title`/`active`/`windowId`), no `chrome.scripting`, no page content — and asserts the owned `tabId` is present in the listing.

The probe's job was only ever "is this tab live and usable"; its own comment said so (*"harmless `eval '1'` (returns 1; NO page content)"*). `tabs` answers exactly that, for **any** url scheme, without needing page-content access at all — so readiness can never again depend on what the tab happens to be showing.

**What was NOT done:** the tab is *not* opened at some real http(s) URL instead. It must start neutral — navigating it on startup would leak a request the caller never asked for and could trip `--allow-domains`.

### Contract preserved

| probe outcome | rc | behaviour |
|---|---|---|
| tabId present in the listing | 0 | ready → proceed |
| tabId absent (or an `owned_tab_gone`-shaped error) | 1 | close stale tab, re-open, bounded retry |
| any other CLI/transport failure | 2 | hard `die`, no model spend |
| 0-exit but no parseable tab list | 2 | fail closed, hard `die` |

Also unchanged: `PROBE_OUT` still captures stdout+stderr and still never reaches the wrapper's own stdout; `BROWSER_AGENT_READY_ATTEMPTS`/`_BACKOFF`; close-the-owned-tab on every exit path; and the fail-closed tool-set gate still runs **before** the tab is opened and before any model token.

One new privacy guard: in production that listing is the operator's **entire tab list** (every url + title), so the "unparseable listing" diagnostic truncates the raw response to 200 bytes rather than spraying it into stderr/logs.

## Tests

The fake `browser` CLI in `tests/test_browser_agent.py` now models **real Chrome**: `eval` against the agent's `about:blank` tab is REFUSED with Chrome's exact host-permission wording, and `tabs` returns a real chrome.tabs-shaped listing (including a decoy tab whose title is a leak marker). That makes the fixture faithful enough that the pre-fix wrapper genuinely dies in it.

Against the **pre-fix** wrapper (verified by checking out `origin/main`'s `browser-agent` under the new tests): **23 passed, 25 failed**, including the new about:blank regression test — the failure message is the live one, `readiness probe failed unexpectedly on tab 4242`.

New coverage:
- `test_readiness_probe_passes_on_an_about_blank_tab` — the exact regression.
- `test_readiness_probe_does_not_inject_into_the_page` — the wrapper issues no injecting op at all (only `open` + `tabs` pre-model).
- `test_probe_source_does_not_use_eval` — static guard so `eval` can't creep back into the probe.
- `test_probe_hard_failure_dies_rc2_without_running_the_model` — rc=2 stays terminal (no model, no retry spin).
- `test_probe_unparseable_listing_is_a_hard_failure` — fail closed on an unreadable answer.
- `test_probe_output_never_reaches_stdout` — the listing never leaks to stdout on the pass, retry, or hard-fail path.
- `test_unparseable_probe_error_does_not_dump_the_whole_listing` — the diagnostic is capped.

Existing tab-gone retry / no-orphan / no-token-spend tests are retained unchanged apart from the probe op they assert on (`eval` → `tabs`). Nothing was weakened or skipped.

### Counts (measured on this branch, not estimated)

| suite | before (`origin/main`) | after |
|---|---|---|
| node (`node --test scripts/browser-bridge/tests/*.test.mjs`) | 274 passed | 274 passed |
| pytest (`scripts/browser-bridge/tests`) | 252 passed | 259 passed |
| of which `test_browser_agent.py` | 41 passed | 48 passed |

Full hermetic gate (`scripts/run-tests.sh --set hermetic`): all 18 suites PASS.

> Note on the node number: the task brief quoted a 261 baseline; the actual count on `origin/main` (`b3b58f0`) is **274**, unchanged by this PR. The brief also referenced a base of `526e644`; `origin/main` at branch time was `b3b58f0`, which is what this branched from.

## Not verified here

This is unit-level only — **no model was invoked and no OpenRouter credit was spent.** The end-to-end live check still has to be run by hand against real Brave + a real model:

```
browser whoami                                   # confirm host + profile first
browser --instance personal agent --dry-run "report the page title"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
