### PR TITLE
docs(browser): rescue three measured gotchas (mid-session extension drop, throttled-tab confirmation, data-testid stripped in prod)

### DIFF
--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -84,13 +84,19 @@ Discord, …) — there, `text`/`html` are the only reads that work.
 
 ## When things look broken — triage
 
-1. **A read is empty / half-built / `data.hidden:true`** → the tab is throttled.
+1. **A call that WORKED now fails, errors, or returns nothing** → re-run `browser
+   health` BEFORE debugging the page or the CLI. The extension can drop
+   mid-session (`extension_connected:false`) with no user action and no error
+   (measured twice in one session, 2026-07-31). ⚠ The ↻ fix must be done **in the
+   profile you are driving** — `brave://extensions` is per-profile, and `health`'s
+   connected count can be coming from a DIFFERENT instance. → `reference/errors.md`
+2. **A read is empty / half-built / `data.hidden:true`** → the tab is throttled.
    `browser wake`, then re-read. → `reference/spa-wake.md`
-2. **`null` from `js`/`eval`** → multi-statement body first, then page CSP. Fall
+3. **`null` from `js`/`eval`** → multi-statement body first, then page CSP. Fall
    back to `text`/`html` before concluding the bridge is down.
-3. **`unknown_op` on an op the CLI knows** → stale extension; full Brave restart.
-4. **Any other unrecognised error string** → look it up in `reference/errors.md`.
-5. **Never diagnose a site OUTAGE from a browser read.** "Is this broken for real
+4. **`unknown_op` on an op the CLI knows** → stale extension; full Brave restart.
+5. **Any other unrecognised error string** → look it up in `reference/errors.md`.
+6. **Never diagnose a site OUTAGE from a browser read.** "Is this broken for real
    users?" is answered by server-side evidence (RUM, metrics, pod health, an
    anonymous `curl`). A hidden-tab read once produced a confident, false, site-wide
    outage report. → `reference/spa-wake.md`
@@ -131,7 +137,7 @@ exact path — only `SKILL.md` and the `browser` CLI are symlinked into
 | `reference/errors.md` | any op returned an error string you don't recognise; `unknown_op`; a reload ↻ didn't take |
 | `reference/frames-cdp.md` | `frame_not_found` / `ambiguous_frame` / `oopif_*_cap` / `cdp_attach_refused`; a `--frame` read returned the TOP page; you need to read or drive inside a cross-origin iframe; the debugger banner |
 | `reference/tabs-instances.md` | `ambiguous_instance` / `unknown_instance` / `superseded` / `no_owned_tab` / `owned_tab_gone`; two drivers fighting over one tab; multi-profile or multi-subagent workflows |
-| `reference/css-hit-test.md` | an element is present but invisible/unclickable/painted under something; a `z-index` change "does nothing" |
+| `reference/css-hit-test.md` | an element is present but invisible/unclickable/painted under something; a `z-index` change "does nothing"; a `data-testid` selector matches NOTHING on a prod page |
 | `reference/agent.md` | running `browser agent` — flags, guardrails, prereqs; it returned `blocked`; `op_not_allowed` / `nav_scheme_denied` |
 | `reference/security-ops.md` | 🔴 **you are MODIFYING browser-bridge** (the live-verify-on-real-Brave gate is mandatory); the user asks whether/what it records; first-time setup or a second profile |
 | `reference/x-fallback.md` | CDP `screenshot` is unsatisfactory and you must capture the raw X window (`DISPLAY`/`XAUTHORITY`, xdotool/maim) |

--- a/scripts/browser-bridge/reference/css-hit-test.md
+++ b/scripts/browser-bridge/reference/css-hit-test.md
@@ -2,10 +2,35 @@
 
 **Load this when:** an element is in the DOM but invisible, unclickable, or painted
 UNDER something else · a popover/dropdown/tooltip renders behind neighbouring content ·
-a `z-index` change "does nothing" · a click lands on the wrong element · you are about
+a `z-index` change "does nothing" · a click lands on the wrong element · a
+`data-testid` selector matches NOTHING on a production page · you are about
 to reason about paint order from CSS source instead of measuring it.
 
 Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`.
+
+## 🔴 `data-testid` is STRIPPED in production builds — it silently finds NOTHING
+
+Before you conclude "the element isn't there", check what you selected ON. At least
+the civitai app strips it: `next.config.mjs` sets
+`compiler.reactRemoveProperties` under `NODE_ENV=production`, which deletes
+`data-testid` from the shipped DOM. **This is a common Next/SWC production
+setting generally**, so assume it of any prod Next app.
+
+The failure is silent and reads as a product bug: the selector matches zero nodes,
+`click`/`text` report nothing found, and the element is right there on screen.
+
+Select **structurally** instead:
+
+- semantic **roles / visible text** (`button`, heading text, `aria-label`);
+- **DOM shape** (parent/child/nth relationships that the build can't erase);
+- a **computed style** — e.g. `getComputedStyle(el).aspectRatio` to pick out cards
+  of a known ratio.
+
+⚠ Only `data-testid` is targeted. **Non-`testid` data attributes are NOT stripped**,
+so a purpose-built one survives into prod and makes a reliable selector — civitai
+added `data-listing-cover-placeholder` for exactly this. If you own the app and
+need a stable hook for browser-driving, add a non-`testid` data attribute rather
+than fighting the strip.
 
 The bridge is the only way to see PAINT ORDER. Markup-level tests and `html` reads
 can't: an element can be present, correct, and completely covered. The sequence

--- a/scripts/browser-bridge/reference/errors.md
+++ b/scripts/browser-bridge/reference/errors.md
@@ -3,7 +3,9 @@
 **Load this when:** any op returned an error string you don't recognise — look it up
 below · an op the CLI knows answers `unknown_op` · you clicked reload ↻ in
 `brave://extensions` and the old behaviour persists · `health` still shows the old
-`extension_version` after a reload.
+`extension_version` after a reload · a bridge that was WORKING suddenly returns
+nothing / `extension_not_connected` with no user action · you reloaded ↻ and the
+instance you're driving is still dead.
 
 Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`. This file is the catch-all: no error string
 should strand you.
@@ -50,6 +52,29 @@ should strand you.
   browser-agent's op or scheme gate, `~/workspace/devrc/scripts/browser-bridge/reference/agent.md`.
 - `Cannot access a chrome:// URL` (with a `null` result) → `eval`/`js` can't run on
   `chrome://` / `brave://` pages. Not a bridge fault.
+
+## ⚠ The extension can DROP mid-session — and ↻ is PER-PROFILE
+
+Distinct from a stale build: this is a bridge that was **working in this very
+session** and stops. Measured twice in one session (2026-07-31) — a healthy bridge
+went `extension_connected:false` with **no user action, no error on the Claude
+side**, and no signal other than ops that suddenly returned nothing. MV3 service
+workers are evictable and the long-poll can lose its peer; treat a drop as normal
+wear, not as evidence of a bug in the page, the CLI or the server.
+
+🔴 **Actionable rule: re-run `browser health` the moment a call unexpectedly fails
+or returns nothing — BEFORE you start debugging the page or the CLI.** It is one
+cheap command and it collapses the whole "is the page broken?" branch.
+
+The fix is the same manual step as a stale build (the user clicks ↻ on the card in
+`brave://extensions`) — but you have to notice it first, and:
+
+⚠ **↻ must be done in the PROFILE you are driving.** `brave://extensions` is
+per-profile, so reloading it in profile A leaves profile B still disconnected —
+while `health` keeps reporting a connected count **from A**, which reads as "the
+extension is fine". Name the profile when you ask the user to reload, and confirm
+recovery with `browser --instance <key> health`, not a bare `health`.
+→ multi-instance semantics: `~/workspace/devrc/scripts/browser-bridge/reference/tabs-instances.md`
 
 ## The LOADED extension may be older than the CLI
 

--- a/scripts/browser-bridge/reference/spa-wake.md
+++ b/scripts/browser-bridge/reference/spa-wake.md
@@ -39,6 +39,20 @@ every `open`ed heavy app starts throttled.
   identical flaw, and one of the errors it cited was caused by the probe itself.
   **Post-mortem: `~/workspace/devrc/scripts/browser-bridge/README.md` § *Real false-outage report*.**
 
+## Confirm throttling before you diagnose anything
+
+Two checks that stop a throttled tab from reading as a broken product:
+
+- **`readyState` alone is NOT sufficient.** A throttled SPA reaches
+  `document.readyState === "complete"` on an empty shell and stays there. Poll
+  `readyState` **and a real content selector** (an actual node the page must render),
+  and allow **materially longer** than a foreground load before concluding anything.
+  Then `wake` and re-read — `wake`, never `activate`.
+- **Cross-check a suspected outage with a separate `curl` for the HTTP status.**
+  A **200 from `curl` plus an empty DOM in a background tab is THROTTLING, not a
+  server fault.** That one command separates the two explanations that otherwise
+  look identical from inside the browser.
+
 ## `wake` — the fix, and it does NOT take the operator's screen
 
 It attaches CDP to that tab ONLY, turns on `Emulation.setFocusEmulationEnabled`

--- a/scripts/browser-bridge/reference/tabs-instances.md
+++ b/scripts/browser-bridge/reference/tabs-instances.md
@@ -73,6 +73,12 @@ else a stable auto-id; labels must be unique per host).
   right key, and re-issue with `--instance <key>`. (The bridge never guesses.)
 - **`browser --instance <key> <op>`** targets one (key = label or auto-id); an
   unknown key errors.
+- **⚠ A bare `health` can mask ONE dead instance.** The extension can drop
+  mid-session per profile, and `brave://extensions` is per-profile — reloading ↻ in
+  profile A leaves B disconnected while `health`'s connected count (from A) still
+  looks healthy. Confirm with `browser --instance <key> health`, and name the
+  profile when asking the user to reload.
+  → `~/workspace/devrc/scripts/browser-bridge/reference/errors.md`
 - **Newest supersedes:** a fresh connection for an already-held key drops the old
   one; an in-flight command on the dropped connection returns a `superseded`
   error — just retry. The displaced connection's own `/poll` gets a distinct


### PR DESCRIPTION
## What this is

Three **measured** browser-bridge gotchas that existed only as an **uncommitted change on one host**. Another session wrote them into `scripts/browser-bridge/SKILL.md` on the workbench (2026-07-31) and never committed; the edit was blocking a fast-forward, the diff was rescued, and the file restored. **They were in `main` nowhere** — this PR is the rescue.

Docs only. No code, tests, `browser`, `server.py`, `extension/`, or `opencode/` touched.

They are **merged into** the post-#233 lean-core + symptom-triggered-reference structure, not re-stacked into the core.

## The three, what each teaches, where it landed

### 1. The extension can DROP mid-session — and ↻ is PER-PROFILE

Measured twice in one session: a working bridge went `extension_connected:false` with **no user action and no error on the Claude side**. The only symptom is ops that suddenly return nothing — which reads as a broken page or a broken CLI, and sends you down the wrong branch. Compounding it: `brave://extensions` is per-profile, so reloading ↻ in profile A leaves profile B disconnected while a bare `health` still reports a connected count *from A*.

- **CORE** — a new triage item **#1** (it changes what you do *first* when something breaks): re-run `browser health` before debugging the page or the CLI, plus the per-profile ↻ caveat. Existing triage items renumbered 2–6.
- **`reference/errors.md`** — depth, as its own section *above* the stale-build playbook. Deliberately separate: a stale build and a mid-session drop present differently (`unknown_op` vs. silence) and have different confirmations.
- **`reference/tabs-instances.md`** — one bullet in the multi-instance list: a bare `health` can mask one dead instance; confirm with `browser --instance <key> health`.

### 2. Background tabs are throttled — confirm before you diagnose

`reference/spa-wake.md` already carried the throttling itself, the `visibilityState` check, the "don't diagnose an outage from a browser read" rule and `curl` in a list of server-side evidence. **Only the genuinely additive parts were merged** — no restating:

- **`readyState` alone is insufficient** — a throttled SPA reaches `"complete"` on an empty shell and stays there. Poll `readyState` **and a real content selector**, and allow materially longer than a foreground load.
- The **`curl` cross-check as a discriminator**: a **200 from `curl` plus an empty DOM in a background tab is throttling, not a server fault.** That is sharper than "use server-side evidence" — it names the one command that separates two explanations which look identical from inside the browser.

The rescued text said "or have the user foreground the tab"; **rephrased to `wake`**, per the current guidance that `activate` steals the operator's screen.

### 3. `data-testid` is STRIPPED in production builds

The most valuable and least obvious of the three: a **silent-wrong-answer** trap. At least the civitai app strips it — `next.config.mjs`, `compiler.reactRemoveProperties` under `NODE_ENV=production` — and this is a common Next/SWC production setting generally. Selecting by `data-testid` against a prod page **matches zero nodes**, which reads as "the element isn't there".

- **`reference/css-hit-test.md`** — full section. This is a *selector* concern, and that file is already the "the element is there but your read says otherwise" home. Includes the structural alternatives (semantic roles/text, DOM shape, computed style e.g. `getComputedStyle(el).aspectRatio`) and the key nuance: **non-`testid` data attributes are NOT stripped**, so a purpose-built one (civitai's `data-listing-cover-placeholder`) survives into prod.
- **CORE** — pointer only, and the cheapest possible one: a symptom phrase appended to the existing `reference/css-hit-test.md` trigger-table row (`a data-testid selector matches NOTHING on a prod page`), ~90 bytes rather than a new trap entry.

## Core byte delta

| | bytes |
|---|---|
| `SKILL.md` before | 11322 |
| `SKILL.md` after | **11870** |
| delta | **+548** |
| ceiling | 12288 (12KB) |

Every added byte, justified:

- **~460** — the new triage item #1. This is the one that earns core space: it is a high-hit-rate rule that changes the *first* action on any unexpected failure, so deferring it to a reference file means it fires only after you've already gone down the wrong branch.
- **~90** — the `data-testid` symptom on the existing css-hit-test trigger row. A pointer, not prose; no new row, no new section.
- Everything else (the drop mechanics, the per-profile confirmation command, the throttling checks, the whole `data-testid` section) went to reference files, which cost nothing until their trigger fires.

## Deduplicated away as already covered

- **The throttling mechanism itself**, the `visibilityState:"hidden"` check, the "spoofing doesn't recover it" note, and `wake`-not-`activate` — all already in `reference/spa-wake.md` (#233/#226). Not restated.
- **"Never diagnose a site outage from a browser read"** — already core triage + a 🔴 block in `spa-wake.md` with the false-outage post-mortem. The rescued text's version was dropped; only the `curl`-as-discriminator refinement was kept.
- **"The bridge WARNS about this / heed the warning"** — already covered by core trap #3 (`data.hidden` / `document.visibilityState`) and `spa-wake.md`'s "reads self-announce it: `data.hidden:true` + a stderr warning". Dropped.
- **The generic "reload ↻ / stale extension" playbook** — `reference/errors.md` already has it, including the measured 2026-07-30 nuance that ↻ *can* take and needs a deterministic tell. The new section covers only what's different about a mid-session drop and layers the per-profile constraint on top, rather than duplicating the playbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
