### PR TITLE
feat(dl-router): picker gets item counts, click-to-select, and an in-page overlay (window fallback)

### DIFF
--- a/scripts/dl-router/README.md
+++ b/scripts/dl-router/README.md
@@ -335,12 +335,48 @@ back to the window:
    would leave an empty overlay and no window — a download with no picker,
    which is the one outcome that is not allowed.
 
+**Gate 2 proves the frame booted. It proves nothing a millisecond later.** An
+overlay is a node in a document the extension does not own, and `openPicker`
+has already returned true — so every way it can vanish has a route back to a
+window, or the download ends up unasked:
+
+* the tab **closes** (`chrome.tabs.onRemoved`) or **navigates**
+  (`chrome.tabs.onUpdated`, keyed on `status === "loading"` so a single-page
+  app's `pushState` does not yank the picker into a window);
+* the **page removes the host node** — `document.body.innerHTML = …`, a DOM
+  sanitiser, a framework re-render, or hostile script. A `MutationObserver` on
+  `body`, armed only while an overlay is live, reports `dlr:overlay-lost`.
+* a **second download into the same tab**. The content script keeps exactly one
+  overlay and evicts the incumbent, so the worker refuses the second overlay
+  outright and gives it a window: two questions, both asked, neither lost.
+
+Re-delivery is idempotent — the record is removed first, so two triggers
+produce one window — and it re-asks the *same* question, from the `info` the
+worker kept.
+
 The overlay is **never dismissed by an outside click or by losing focus**. That
 is exactly why `chrome.action.openPopup()` was rejected: an action popup
 dismisses on blur, silently discarding the pick and leaving the file in the
 catch-all. The iframe cannot close itself, so the picker sends
 `dlr:picker-closed` and the worker tears the overlay down — falling back to
-`sender.tab.id` so a pick made after an MV3 teardown still removes it.
+`sender.tab.id` so a pick made after an MV3 teardown still removes it, and the
+content script sweeps a stray host by id if it was re-injected in between.
+
+The overlay's tab is **raised** (`tabs.update` + `windows.update`) once it is
+up: the popup window it replaces was created `focused: true`, and the toast's
+`change` makes this concrete — the user is looking at the toast's own window
+while the overlay goes to the download's tab.
+
+**A pick from an unrecognised subframe is refused.** `picker.html` has to be
+web-accessible to be framed at all, so any page can embed it, point it at a
+recent download id and clickjack two clicks — one to take the "+ new dir" row,
+one to answer the kind prompt — into a `/mkdir` and a `/relocate`.
+Click-to-select is what made two blind clicks sufficient. Our own overlay is a
+subframe too, so the discriminator is the per-open id: unguessable, issued by
+the worker, and never visible to the page because the shadow root holding the
+frame is **closed**. The popup-window picker is the top frame of its own tab and
+carries no id, which is why the test is on `frameId` rather than on an id being
+present.
 
 **The toast is still a popup window**, unconditionally: it is a passive
 notification with an eight-second life, and it has no pick to lose.

--- a/scripts/dl-router/README.md
+++ b/scripts/dl-router/README.md
@@ -24,7 +24,7 @@ individual library subdirectories by hand.
                                               │
                           auto-filed ─────────┴───────── unsure
                                 │                          │
-                          toast + undo               picker (type/↑↓/Enter)
+                          toast + undo            picker (type/↑↓/Enter/click)
                                 └──────── correction ──────┘
                                               ▼
                                     /learn → alias + example
@@ -56,7 +56,7 @@ existing directories are never renamed.
 | `safety.py` | the one place a page-derived string becomes a path component |
 | `store.py` | SQLite: aliases (+ provenance), examples, route log, host prior, picker-assigned kinds |
 | `dirkinds.py` | performer/category classification + the draft generator |
-| `dirindex.py` | mtime+TTL-cached scan of the library root |
+| `dirindex.py` | mtime+TTL-cached scan of the library root; whole-tree file index for dedupe + per-directory counts |
 | `qbt.py` | qBittorrent WebUI client + runtime-derived path mapping |
 | `fetcher.py` | yt-dlp jobs for HLS/DASH sources |
 | `backfill.py` | `plan` (read-only) / `apply` (reviewed manifest only) |
@@ -305,10 +305,72 @@ filename if the listener is slow):
    `suggest({filename: dir + "/" + name, conflictAction: "uniquify"})` — never
    `overwrite`.
 
-**Toast and picker are popup windows**, not in-page overlays: injection fails
-on the PDF viewer, `chrome://` pages and sandboxed frames, which is exactly
-where a download often starts. `chrome.notifications` is the secondary
-fallback.
+**The picker is an in-page overlay, with the popup window as an automatic
+fallback.** The overlay is an iframe of `picker.html` inside a **closed** shadow
+root, injected by `picker_overlay.js` — a second file on the content-script
+declaration `content_capture.js` already has, so it needs no new permissions.
+Framing an extension page from a web page does need `picker.html` in
+`web_accessible_resources`; its module imports are not exposed.
+
+It is the **same page, running the same reducer**. The overlay does not
+reimplement the picker — that is the point, and a test asserts
+`picker_overlay.js` contains none of the picker's vocabulary. Being a separate
+document also means page CSS cannot reach the picker or vice versa; the shadow
+root is what stops the page styling or discovering the host element.
+
+Delivery is decided per download, with **two gates**, and every failure falls
+back to the window:
+
+1. **the content script answers.** `chrome.tabs.sendMessage` rejects with
+   "receiving end does not exist" where no content script runs — one check
+   covering `brave://`/`chrome://`, the PDF viewer (an ordinary `https` URL
+   whose document is a plugin), the Web Store, `view-source:`, `file://`, a
+   discarded tab, and a page that has not reached `document_idle`. A tab that
+   has *closed* — the self-closing file-host tab — fails one step earlier, at
+   `chrome.tabs.get`.
+2. **the frame reports itself ready.** A content-script-injected iframe is
+   subject to the *page's* CSP, so a strict `frame-src` blocks the load while
+   every DOM call in gate 1 still succeeds. Only an extension context that
+   actually booted can send `dlr:picker-ready`. Without this gate such a site
+   would leave an empty overlay and no window — a download with no picker,
+   which is the one outcome that is not allowed.
+
+The overlay is **never dismissed by an outside click or by losing focus**. That
+is exactly why `chrome.action.openPopup()` was rejected: an action popup
+dismisses on blur, silently discarding the pick and leaving the file in the
+catch-all. The iframe cannot close itself, so the picker sends
+`dlr:picker-closed` and the worker tears the overlay down — falling back to
+`sender.tab.id` so a pick made after an MV3 teardown still removes it.
+
+**The toast is still a popup window**, unconditionally: it is a passive
+notification with an eight-second life, and it has no pick to lose.
+`chrome.notifications` remains the last rung under both.
+
+**The picker is keyboard-first and mouse-capable.** Type to filter, arrows to
+move, Enter to accept, Esc to leave it in the catch-all; a **click** on a row
+accepts that row. Click is implemented in the reducer as "move the highlight
+there, then Enter", so it reuses the Enter branch verbatim — the kind prompt,
+the new-directory sub-question and the refusals all come from one place. A
+click while the list is still loading or is known to be unavailable is
+**dropped, not deferred**: Enter defers because a typed query survives the list
+arriving, but a click's intent is a screen position, and honouring it against a
+different list would choose an arbitrary directory or create one.
+
+Each row shows **how many files that directory already holds**. The tally comes
+from the `/dirs` snapshot, as a by-product of the whole-tree walk `FileIndex`
+already performs for dedupe — never a scan of its own, and `dir_counts()`
+deliberately does not refresh, so `/dirs` can never block on a walk of the
+library. `/match` warms it on every download.
+
+**The counts are deliberately not part of the `/dirs` ETag.** That ETag's job is
+"the routing configuration changed" — the directories, their kinds, the aliases,
+the threshold — because the extension's cached fallback matcher runs off exactly
+that. A count changes on every completed download, and `FileIndex` is TTL-cached
+so the same unchanged library can answer with two different counts a minute
+apart; an ETag that changes when nothing changed is not a validator. The cost of
+that choice is that a `304` carries no body, so the extension asks for the
+snapshot **without `If-None-Match` on the picker path** — the one request whose
+freshness a human is waiting on — and revalidates everywhere else.
 
 **Undo after completion**: choosing a different directory after the download
 completes calls `/relocate` (a same-filesystem rename, instant) and then

--- a/scripts/dl-router/README.md
+++ b/scripts/dl-router/README.md
@@ -367,16 +367,38 @@ up: the popup window it replaces was created `focused: true`, and the toast's
 `change` makes this concrete — the user is looking at the toast's own window
 while the overlay goes to the download's tab.
 
-**A pick from an unrecognised subframe is refused.** `picker.html` has to be
-web-accessible to be framed at all, so any page can embed it, point it at a
-recent download id and clickjack two clicks — one to take the "+ new dir" row,
-one to answer the kind prompt — into a `/mkdir` and a `/relocate`.
-Click-to-select is what made two blind clicks sufficient. Our own overlay is a
-subframe too, so the discriminator is the per-open id: unguessable, issued by
-the worker, and never visible to the page because the shadow root holding the
-frame is **closed**. The popup-window picker is the top frame of its own tab and
-carries no id, which is why the test is on `frameId` rather than on an id being
-present.
+**Two mitigations against a page framing the picker.** `picker.html` has to be
+web-accessible to be framed at all, so a page could otherwise embed it, point it
+at a recent download id, and clickjack two clicks — one to take the "+ new dir"
+row, one to answer the kind prompt — into a `/mkdir` and a `/relocate`.
+Click-to-select is what made two blind clicks sufficient.
+
+1. **`use_dynamic_url: true`** rotates the resource URL per browser session, so
+   an arbitrary page cannot construct the URL to frame in the first place. The
+   framed page's own module graph (`picker.js`, `sanitize.js`, `route_core.js`)
+   is listed alongside it, because under a rotating origin its relative imports
+   resolve against that origin.
+2. **A pick from an unrecognised subframe is refused.** Our own overlay is a
+   subframe too, so the discriminator is the per-open id: unguessable, issued by
+   the worker, and never visible to the page because the shadow root holding the
+   frame is **closed**. The popup-window picker is the top frame of its own tab
+   and carries no id, which is why the test is on `frameId` rather than on an id
+   being present.
+
+The second is the authorisation check; the first removes the ability to load the
+surface at all.
+
+**The overlay registry is persisted in `chrome.storage.session`**, and that is
+not incidental. MV3 tears the worker down after ~30 s idle, and choosing a
+directory is the slowest thing the user does here — so the picker routinely
+outlives the worker that opened it. An in-memory-only registry meant the
+subframe guard saw an empty map on the far side of a teardown and **refused a
+legitimate pick**, discarding the choice precisely when the user had been
+deliberating longest; and the tab watchers found no overlay to rescue when its
+tab closed. `storage.session` has exactly the right lifetime: it survives the
+teardown and dies with the browser, which is also when every overlay dies. Same
+lesson as `Store.record_screened` — a fact that must outlive a teardown does not
+live in service-worker memory.
 
 **The toast is still a popup window**, unconditionally: it is a passive
 notification with an eight-second life, and it has no pick to lose.

--- a/scripts/dl-router/SKILL.md
+++ b/scripts/dl-router/SKILL.md
@@ -155,6 +155,15 @@ closed or navigated, the page removed the node, or a second download needed the
 same tab. That is the safety net, not a bug: the alternative is a download
 nobody was asked about.
 
+**If the overlay NEVER works on any site**, suspect `use_dynamic_url` on the
+`web_accessible_resources` entry: the framed page's ES-module imports have to
+resolve under the rotating origin, which is why `picker.js`, `sanitize.js` and
+`route_core.js` are listed next to `picker.html`. This has never been exercised
+in a browser. It fails safe — the frame never boots, gate 2 fires, and every
+picker becomes a window — so the symptom is "always windowed, never in-page".
+Drop `use_dynamic_url` to test the hypothesis; the per-open id still authorises
+picks either way.
+
 **"Downloads still show a Save-As dialog."** The profile's
 `download.default_directory` is not the library root, or `prompt_for_download`
 is still on. Re-run `setup-brave-profile.sh` with Brave **fully closed** (it

--- a/scripts/dl-router/SKILL.md
+++ b/scripts/dl-router/SKILL.md
@@ -138,7 +138,17 @@ carries the new rules. Selector subset: tag, `.class`, `#id`, `[attr]`,
 2. Options page → *Test connection* — port and token right? Is *Enable routing
    in this profile* ticked? It is **per-profile** and off by default.
 3. **An extension code change needs a FULL Brave restart**, not the reload
-   button — same gotcha as browser-bridge.
+   button — same gotcha as browser-bridge. The manifest version is bumped on
+   every code change specifically so `brave://extensions` can be checked:
+   if it still reads the old number, the restart did not take.
+
+**"The picker opens in a separate window instead of in the page."** That is the
+designed fallback, not a fault. The overlay needs a content script in the tab
+and a frame that boots, so it falls back for `brave://`/`chrome://`, the PDF
+viewer, the Web Store, `view-source:`, `file://`, a tab that already closed
+(the self-closing file-host tab), a page still loading, and any site whose CSP
+blocks a `frame-src`. Check the tab's URL first. A picker that never appears at
+all is a real fault; a windowed one is not.
 
 **"Downloads still show a Save-As dialog."** The profile's
 `download.default_directory` is not the library root, or `prompt_for_download`
@@ -251,6 +261,16 @@ same gotcha as browser-bridge), then re-check `dl-route status`.
 ## Gotchas
 
 * Port **8791** — 8790 is already taken on the workbench.
+* The picker's **per-directory counts are not covered by the `/dirs` ETag**, on
+  purpose: they change on every download and `FileIndex` is TTL-cached, so
+  including them would make the ETag change when the routing configuration had
+  not. `dl-route status`'s `etag` therefore still answers "did the routing
+  config change?". The picker's own snapshot request skips `If-None-Match` so
+  it still sees fresh counts; nothing else does.
+* Counts are **empty until the file index has been walked**. `/dirs` never
+  starts that walk (a whole-tree walk there would blow the extension's 4 s
+  snapshot budget on a large library); `/match` warms it on every download. A
+  picker with no counts means no `/match` has run in this sidecar process yet.
 * `onDeterminingFilename` **cannot escape the download root**: no `..`, no
   absolute paths. That is precisely why the profile's download directory has to
   *be* the library root.

--- a/scripts/dl-router/SKILL.md
+++ b/scripts/dl-router/SKILL.md
@@ -150,6 +150,11 @@ viewer, the Web Store, `view-source:`, `file://`, a tab that already closed
 blocks a `frame-src`. Check the tab's URL first. A picker that never appears at
 all is a real fault; a windowed one is not.
 
+It also **converts back to a window** if the overlay stops existing — the tab
+closed or navigated, the page removed the node, or a second download needed the
+same tab. That is the safety net, not a bug: the alternative is a download
+nobody was asked about.
+
 **"Downloads still show a Save-As dialog."** The profile's
 `download.default_directory` is not the library root, or `prompt_for_download`
 is still on. Re-run `setup-brave-profile.sh` with Brave **fully closed** (it
@@ -267,6 +272,9 @@ same gotcha as browser-bridge), then re-check `dl-route status`.
   not. `dl-route status`'s `etag` therefore still answers "did the routing
   config change?". The picker's own snapshot request skips `If-None-Match` so
   it still sees fresh counts; nothing else does.
+* Counts are **suppressed entirely when the file index hit its `file_index_max`
+  cap** — a partial tally of an unknown fraction of the library rendered next to
+  a directory name would be a wrong number, which is worse than none.
 * Counts are **empty until the file index has been walked**. `/dirs` never
   starts that walk (a whole-tree walk there would blow the extension's 4 s
   snapshot budget on a large library); `/match` warms it on every download. A

--- a/scripts/dl-router/dirindex.py
+++ b/scripts/dl-router/dirindex.py
@@ -186,6 +186,12 @@ class FileIndex:
 
     Bounded by `max_files` so a pathological tree cannot exhaust memory; the
     cap being hit is reported rather than silently truncating the answer.
+
+    It ALSO tallies files per top-level directory as a by-product of the walk
+    it already performs (see `dir_counts`). That tally is deliberately not a
+    second scan: this walk visits every file in the library exactly once, and a
+    third traversal of a media library to count what this one already sees
+    would be pure waste.
     """
 
     def __init__(self, root, *, clock=time.monotonic, ttl: float = 60.0,
@@ -195,6 +201,7 @@ class FileIndex:
         self._ttl = float(ttl)
         self._max = int(max_files)
         self._map: dict = {}
+        self._dir_counts: dict = {}
         self._count = 0
         self._truncated = False
         self._loaded_at = -1.0
@@ -203,18 +210,25 @@ class FileIndex:
 
     def _scan(self):
         out: dict = {}
+        counts: dict = {}
         count = 0
         truncated = False
         # followlinks=False: never walk out of the library through a symlink.
         for dirpath, dirnames, filenames in os.walk(self.root, followlinks=False,
                                                     onerror=lambda _e: None):
             dirnames[:] = [d for d in dirnames if not d.startswith(".")]
+            # The subject directory this whole `dirpath` belongs to, computed
+            # ONCE per directory rather than once per file. Empty for the
+            # library root itself: a loose file sitting in the root is in no
+            # subject directory, and counting it under one would be a lie.
+            rel_dir = os.path.relpath(dirpath, self.root)
+            top = "" if rel_dir == os.curdir else rel_dir.split(os.sep, 1)[0]
             for fname in filenames:
                 if fname.startswith("."):
                     continue
                 if count >= self._max:
                     truncated = True
-                    return out, count, truncated
+                    return out, counts, count, truncated
                 full = os.path.join(dirpath, fname)
                 try:
                     size = os.stat(full).st_size
@@ -225,8 +239,10 @@ class FileIndex:
                 key = norm_key(stem)
                 if key:
                     out.setdefault(key, []).append((rel, size))
+                if top:
+                    counts[top] = counts.get(top, 0) + 1
                 count += 1
-        return out, count, truncated
+        return out, counts, count, truncated
 
     def refresh(self, force: bool = False) -> None:
         """Single-flight, and the scan runs OUTSIDE the lock.
@@ -245,13 +261,14 @@ class FileIndex:
                 return
             self._scanning = True
         try:
-            data, count, truncated = self._scan()
+            data, counts, count, truncated = self._scan()
         except Exception:
             with self._lock:
                 self._scanning = False
             raise
         with self._lock:
             self._map = data
+            self._dir_counts = counts
             self._count = count
             self._truncated = truncated
             self._loaded_at = self._clock()
@@ -261,6 +278,34 @@ class FileIndex:
         self.refresh()
         with self._lock:
             return list(self._map.get(key, ()))
+
+    def dir_counts(self) -> dict:
+        """Files per top-level directory, as of the last completed walk.
+
+        THIS DELIBERATELY DOES NOT REFRESH, and that is the whole reason the
+        counts are affordable.
+
+        Its only caller is `/dirs`, which the extension hits on every picker
+        open and every five-minute alarm. Calling `refresh()` here would put a
+        whole-tree walk of a media library on that path: the first `/dirs`
+        after a restart would block until the walk finished, and the
+        extension's snapshot fetch gives up after 4 s — so a large library
+        would turn a cosmetic counter into a picker that shows "Loading
+        directories..." and then fails. `/match` already refreshes this index
+        on EVERY download (via find_duplicate), so by the time any picker
+        opens the tally is warm and at most one TTL stale, which is ample for
+        a number nothing routes on.
+
+        The consequence, stated plainly: before the first `/match` of a
+        process the map is empty and the picker simply shows no counts. That
+        is the intended degradation, not an oversight.
+
+        Stale by construction in one more way: when the `max_files` cap is hit
+        the walk returns early, so the counts are partial. `stats()["truncated"]`
+        is where that is visible; nothing routes on these numbers.
+        """
+        with self._lock:
+            return dict(self._dir_counts)
 
     def stats(self) -> dict:
         self.refresh()

--- a/scripts/dl-router/dirindex.py
+++ b/scripts/dl-router/dirindex.py
@@ -292,19 +292,24 @@ class FileIndex:
         extension's snapshot fetch gives up after 4 s — so a large library
         would turn a cosmetic counter into a picker that shows "Loading
         directories..." and then fails. `/match` already refreshes this index
-        on EVERY download (via find_duplicate), so by the time any picker
-        opens the tally is warm and at most one TTL stale, which is ample for
-        a number nothing routes on.
+        on EVERY browser download (via find_duplicate), so by the time a
+        picker opens for one the tally is warm and at most one TTL stale,
+        which is ample for a number nothing routes on. The yt-dlp path also
+        runs /match, so it warms it too.
 
         The consequence, stated plainly: before the first `/match` of a
         process the map is empty and the picker simply shows no counts. That
         is the intended degradation, not an oversight.
 
-        Stale by construction in one more way: when the `max_files` cap is hit
-        the walk returns early, so the counts are partial. `stats()["truncated"]`
-        is where that is visible; nothing routes on these numbers.
+        A TRUNCATED WALK REPORTS NOTHING. When the `max_files` cap is hit the
+        walk returns early, so whatever it counted is a partial tally of an
+        unknown fraction of the library -- and it would be rendered next to a
+        directory name with no hint that it is wrong. The rest of this file's
+        rule applies: a wrong number is worse than no number.
         """
         with self._lock:
+            if self._truncated:
+                return {}
             return dict(self._dir_counts)
 
     def stats(self) -> dict:

--- a/scripts/dl-router/extension/manifest.json
+++ b/scripts/dl-router/extension/manifest.json
@@ -28,8 +28,14 @@
   ],
   "web_accessible_resources": [
     {
-      "resources": ["picker.html"],
-      "matches": ["http://*/*", "https://*/*"]
+      "resources": [
+        "picker.html",
+        "picker.js",
+        "sanitize.js",
+        "route_core.js"
+      ],
+      "matches": ["http://*/*", "https://*/*"],
+      "use_dynamic_url": true
     }
   ],
   "options_ui": {

--- a/scripts/dl-router/extension/manifest.json
+++ b/scripts/dl-router/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Media Download Router",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Files downloads into subject directories under a local media library, using page context, via a loopback token-authenticated sidecar. Local-only, authorized personal automation.",
   "permissions": [
     "downloads",
@@ -21,9 +21,15 @@
   "content_scripts": [
     {
       "matches": ["http://*/*", "https://*/*"],
-      "js": ["content_capture.js"],
+      "js": ["content_capture.js", "picker_overlay.js"],
       "all_frames": true,
       "run_at": "document_idle"
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["picker.html"],
+      "matches": ["http://*/*", "https://*/*"]
     }
   ],
   "options_ui": {

--- a/scripts/dl-router/extension/picker.html
+++ b/scripts/dl-router/extension/picker.html
@@ -5,15 +5,50 @@
   <title>Save to…</title>
   <style>
     :root { color-scheme: light dark; }
-    body { font: 13px/1.45 system-ui, sans-serif; margin: 0; padding: 10px 12px; }
+    /* Explicit, because this page is also framed as an in-page overlay, where
+       there is no browser chrome to supply a window background. */
+    body { font: 13px/1.45 system-ui, sans-serif; margin: 0; padding: 10px 12px;
+           background: Canvas; color: CanvasText; }
     #q { width: 100%; box-sizing: border-box; font: inherit; padding: 6px 8px; }
     #meta { margin: 6px 0; font-size: 12px; opacity: .7; word-break: break-word; }
     #dup { margin: 4px 0; font-size: 12px; color: #b45309; }
     #list { list-style: none; margin: 6px 0 0; padding: 0; max-height: 300px; overflow: auto; }
-    .row { padding: 4px 8px; border-radius: 4px; word-break: break-word; }
+    .row { padding: 4px 8px; border-radius: 4px; word-break: break-word;
+           display: flex; align-items: baseline; gap: 8px; cursor: pointer;
+           transition: background-color 110ms ease, transform 110ms ease; }
+    .row .label { flex: 1 1 auto; min-width: 0; }
+    /* How many files the directory already holds. Muted and tabular so the
+       column reads as a column and never competes with the name. */
+    .row .count { flex: 0 0 auto; font-size: 11px; opacity: .5;
+                  font-variant-numeric: tabular-nums; }
+    /* Hover is CSS-only ON PURPOSE: letting the pointer move the selection
+       would fight the keyboard, because the mouse sits wherever it was left
+       while someone types and arrows. Hover shows what a click would take;
+       only a click takes it. */
+    .row:hover { background: color-mix(in srgb, CanvasText 10%, transparent); }
+    .row:active { transform: scale(.99); }
     .row.sel { background: Highlight; color: HighlightText; }
+    .row.sel .count { opacity: .75; }
+    .row.sel:hover { background: Highlight; }
     .row.new { font-style: italic; }
+    /* The confirmation: one short pulse on the row that was taken. It is the
+       only feedback between the keypress and the window going away, and on the
+       refusal path it is the last thing seen before the error replaces it. */
+    .row.taken { animation: dlr-taken 260ms ease-out; }
+    @keyframes dlr-taken {
+      0%   { transform: scale(1); }
+      35%  { transform: scale(1.015); filter: brightness(1.18); }
+      100% { transform: scale(1); }
+    }
+    .row.loading, .row.failed { cursor: default; }
+    .row.loading:hover, .row.failed:hover { background: transparent; }
     #hint { margin-top: 8px; font-size: 11px; opacity: .55; }
+    @media (prefers-reduced-motion: reduce) {
+      .row { transition: none; }
+      .row:active { transform: none; }
+      .row.taken { animation: none;
+                   outline: 2px solid Highlight; outline-offset: -2px; }
+    }
   </style>
 </head>
 <body>
@@ -21,7 +56,7 @@
   <div id="meta"></div>
   <div id="dup"></div>
   <ul id="list"></ul>
-  <div id="hint">Enter accept · arrows move · Esc leave it in the catch-all folder</div>
+  <div id="hint">Enter or click accept · arrows move · Esc leave it in the catch-all folder</div>
   <script type="module" src="picker.js"></script>
 </body>
 </html>

--- a/scripts/dl-router/extension/picker.js
+++ b/scripts/dl-router/extension/picker.js
@@ -50,8 +50,13 @@ export function titleCase(phrase) {
 /**
  * Build the entry list for a query.
  * `dirs` is the array of existing directory names.
+ * `counts` is an optional {name -> number} map of how many files each holds.
+ *
+ * The count rides as its own field rather than being appended to `label`:
+ * `label` is what the new-directory proposal is built from and what the
+ * sidecar-facing flow reads, and a decorative number has no business in it.
  */
-export function filterEntries(dirs, query, suggestNew) {
+export function filterEntries(dirs, query, suggestNew, counts) {
   const q = String(query || "").trim();
   const qKey = normKey(q);
   const existing = new Set(dirs || []);
@@ -73,10 +78,16 @@ export function filterEntries(dirs, query, suggestNew) {
     return 2;
   };
 
+  const countOf = (name) => {
+    const n = counts && counts[name];
+    return typeof n === "number" && Number.isFinite(n) && n >= 0 ? n : undefined;
+  };
+
   const dirEntries = (dirs || [])
     .filter(matches)
     .sort((a, b) => (rank(a) - rank(b)) || a.localeCompare(b))
-    .map((name) => ({ kind: ENTRY_DIR, name, label: name }));
+    .map((name) => ({ kind: ENTRY_DIR, name, label: name,
+      count: countOf(name) }));
 
   const proposalRaw = q ? titleCase(q) : String(suggestNew || "");
   if (!proposalRaw || !isSafeDirName(proposalRaw) || existing.has(proposalRaw)) {
@@ -102,9 +113,10 @@ export function filterEntries(dirs, query, suggestNew) {
 }
 
 export function initialState({ dirs = [], suggestNew = "", downloadId = null,
-  reason = "", dup = "", otherDir = "other", loading = false } = {}) {
+  reason = "", dup = "", otherDir = "other", loading = false,
+  counts = null } = {}) {
   const state = {
-    dirs, suggestNew, downloadId, reason, dup, otherDir,
+    dirs, suggestNew, downloadId, reason, dup, otherDir, counts,
     // `loading` = the directory list has not arrived from the sidecar yet.
     // While it is set, Enter is DEFERRED rather than acted on: see reduce().
     loading: Boolean(loading),
@@ -117,7 +129,7 @@ export function initialState({ dirs = [], suggestNew = "", downloadId = null,
     pendingNew: null,
     query: "", index: 0, done: null,
   };
-  state.entries = filterEntries(dirs, "", suggestNew);
+  state.entries = filterEntries(dirs, "", suggestNew, counts);
   return state;
 }
 
@@ -155,6 +167,30 @@ export function reduce(state, event) {
     };
   }
   if (state.done) return state;
+  // --- click ------------------------------------------------------------- //
+  // Mouse selection, expressed as "move the highlight there, then Enter" so it
+  // reuses the Enter branch VERBATIM: the kind prompt, the new-directory
+  // sub-question, the failed/loading refusals and the `done` shape all come
+  // from one implementation. A second copy of "what does choosing mean" is
+  // exactly the drift this file already paid for once.
+  //
+  // Placed here -- after the `done` guard, before the kind prompt -- so it is
+  // dead once the flow has finished, and live while the kind prompt is up
+  // (clicking "performer" must work).
+  if (event.type === "click") {
+    const i = event.index;
+    if (!Number.isInteger(i) || i < 0 || i >= state.entries.length) return state;
+    // A click while the list is unavailable is DROPPED, not deferred.
+    //
+    // Enter defers (see `pendingEnter`) because a typed query survives the
+    // list arriving -- the user's intent is "the thing matching what I typed".
+    // A click's intent is a SCREEN POSITION, and position N of the loading
+    // placeholder has nothing to do with position N of the real list. Honouring
+    // it later would choose an arbitrary directory, or create one, which is the
+    // precise footgun the deferred Enter exists to close.
+    if (state.loading || state.failed) return state;
+    return reduce({ ...state, index: i }, { type: "key", key: "Enter" });
+  }
   const next = { ...state };
   // --- the kind prompt --------------------------------------------------- //
   // A modal sub-step, handled BEFORE the normal branches so a stray `input`
@@ -173,7 +209,8 @@ export function reduce(state, event) {
       // Back to the directory list, NOT out of the picker. Escaping a
       // sub-question should undo the sub-question.
       next.pendingNew = null;
-      next.entries = filterEntries(state.dirs, state.query, state.suggestNew);
+      next.entries = filterEntries(state.dirs, state.query, state.suggestNew,
+        state.counts);
       next.index = 0;
       return next;
     }
@@ -194,7 +231,8 @@ export function reduce(state, event) {
     next.error = "";
     next.status = "";
     next.query = String(event.value ?? "");
-    next.entries = filterEntries(state.dirs, next.query, state.suggestNew);
+    next.entries = filterEntries(state.dirs, next.query, state.suggestNew,
+      state.counts);
     next.index = 0;
     return next;
   }
@@ -212,8 +250,14 @@ export function reduce(state, event) {
     // The directory list arrived. Rebuild the entries against the CURRENT
     // query, then honour an Enter the user pressed while we were still empty.
     next.dirs = Array.isArray(event.dirs) ? event.dirs : [];
+    // Counts are cosmetic and optional: a snapshot without them (an older
+    // sidecar, or a file index that has not been walked yet) renders exactly
+    // as it always did rather than showing zeroes, which would be a lie.
+    next.counts = (event.counts && typeof event.counts === "object")
+      ? event.counts : null;
     next.loading = false;
-    next.entries = filterEntries(next.dirs, state.query, state.suggestNew);
+    next.entries = filterEntries(next.dirs, state.query, state.suggestNew,
+      next.counts);
     next.index = 0;
     if (state.pendingEnter) {
       next.pendingEnter = false;
@@ -300,6 +344,13 @@ export function mount(doc, chromeApi, { closeWindow } = {}) {
     loading: true,
   });
 
+  // Rendered as an in-page overlay (an iframe of THIS page inside a closed
+  // shadow root in the tab) rather than as a popup window. The document, the
+  // reducer and every branch below are identical; only "what does closing
+  // mean" differs, because an iframe cannot close itself.
+  const embedded = params.get("embed") === "1";
+  const overlayId = params.get("overlay") || "";
+
   const input = doc.getElementById("q");
   const list = doc.getElementById("list");
   const meta = doc.getElementById("meta");
@@ -318,8 +369,21 @@ export function mount(doc, chromeApi, { closeWindow } = {}) {
   };
   renderMeta();
 
-  const close = closeWindow
-    || (() => { if (typeof window !== "undefined") window.close(); });
+  const close = closeWindow || (() => {
+    if (embedded) {
+      // window.close() on an iframe is a no-op, so an embedded picker asks the
+      // service worker to tear the overlay down -- it is the side that knows
+      // which tab the overlay was injected into. Every other close path
+      // (accepted, cancelled, refused-then-Esc) funnels through here, so the
+      // overlay cannot outlive the flow.
+      try {
+        void chromeApi.runtime.sendMessage({
+          type: "dlr:picker-closed", overlay: overlayId });
+      } catch { /* worker restarting; the overlay is inert either way */ }
+      return;
+    }
+    if (typeof window !== "undefined") window.close();
+  });
 
   const render = () => {
     renderMeta();
@@ -333,11 +397,33 @@ export function mount(doc, chromeApi, { closeWindow } = {}) {
       list.appendChild(li);
       return;
     }
+    // The row the flow settled on. Both Enter and a click act on
+    // `state.index` -- the click event moves the highlight there first -- so
+    // the confirmation lands on what the user picked from either input, with
+    // no second notion of "the chosen row" to drift.
+    const takenIndex = (state.done && state.done.action === "choose")
+      ? state.index : -1;
     state.entries.forEach((entry, i) => {
       const li = doc.createElement("li");
-      li.textContent = entry.label;
+      const label = doc.createElement("span");
+      label.className = "label";
+      label.textContent = entry.label;
+      li.appendChild(label);
+      if (typeof entry.count === "number") {
+        // How many files the directory already holds. Decorative, and a
+        // separate node so it can be styled down and can never be mistaken
+        // for part of the directory name.
+        const badge = doc.createElement("span");
+        badge.className = "count";
+        badge.textContent = String(entry.count);
+        li.appendChild(badge);
+      }
       li.className = i === state.index ? "row sel" : "row";
       if (entry.kind === ENTRY_NEW) li.classList.add("new");
+      if (i === takenIndex) li.classList.add("taken");
+      // Mouse selection. `apply` is declared below; the handler only ever runs
+      // after mount() has returned, so the reference resolves.
+      li.addEventListener("click", () => apply({ type: "click", index: i }));
       list.appendChild(li);
     });
   };
@@ -459,12 +545,31 @@ export function mount(doc, chromeApi, { closeWindow } = {}) {
       const dirs = resp.snapshot.dirs
         .map((d) => d && d.name)
         .filter((n) => typeof n === "string" && n);
-      apply({ type: "dirs", dirs });
+      apply({ type: "dirs", dirs, counts: resp.snapshot.counts });
     });
   };
   askForDirs();
   render();
   input.focus();
+
+  if (embedded) {
+    // THE OVERLAY'S PROOF OF LIFE, and it is not decorative.
+    //
+    // The content script can create the host element and the iframe and still
+    // end up with a frame that never loaded: a content-script-injected iframe
+    // is subject to the PAGE's Content-Security-Policy, so a site with a
+    // restrictive `frame-src` blocks it outright. From the outside that failure
+    // is indistinguishable from success -- an overlay that is present, empty
+    // and silent -- and the download would be left with no picker at all.
+    //
+    // This message is the only signal that an extension context actually
+    // booted inside the frame. The service worker will not consider the
+    // overlay delivered without it, and falls back to the popup window.
+    try {
+      void chromeApi.runtime.sendMessage({
+        type: "dlr:picker-ready", overlay: overlayId });
+    } catch { /* the worker's timeout falls back to a window */ }
+  }
 
   return { state: () => state, apply, retry: askForDirs };
 }

--- a/scripts/dl-router/extension/picker.js
+++ b/scripts/dl-router/extension/picker.js
@@ -450,6 +450,12 @@ export function mount(doc, chromeApi, { closeWindow } = {}) {
         // selecting an existing directory sends exactly the message it always
         // did, with no `kind: undefined` riding along.
         if (done.kind) message.kind = done.kind;
+        // The per-open id, ONLY when embedded. `picker.html` is
+        // web-accessible, so any page can frame it and try to clickjack a pick
+        // out of the user; the worker refuses a choice from a SUBFRAME that
+        // cannot present an id it issued. The popup window is a top-level frame
+        // and deliberately still sends the message it always did.
+        if (embedded && overlayId) message.overlay = overlayId;
         resp = await chromeApi.runtime.sendMessage(message);
       } catch (err) {
         // `err.message`, not String(err): String() prepends "Error: ", the

--- a/scripts/dl-router/extension/picker.js
+++ b/scripts/dl-router/extension/picker.js
@@ -376,9 +376,14 @@ export function mount(doc, chromeApi, { closeWindow } = {}) {
       // which tab the overlay was injected into. Every other close path
       // (accepted, cancelled, refused-then-Esc) funnels through here, so the
       // overlay cannot outlive the flow.
+      // `.catch` as well as `try`: nothing answers this message, so Chrome
+      // settles the promise with "the message port closed before a response
+      // was received". Unhandled, that is a red error in the picker's console
+      // on EVERY successful pick.
       try {
-        void chromeApi.runtime.sendMessage({
+        const sent = chromeApi.runtime.sendMessage({
           type: "dlr:picker-closed", overlay: overlayId });
+        if (sent && typeof sent.catch === "function") sent.catch(() => {});
       } catch { /* worker restarting; the overlay is inert either way */ }
       return;
     }
@@ -566,8 +571,9 @@ export function mount(doc, chromeApi, { closeWindow } = {}) {
     // booted inside the frame. The service worker will not consider the
     // overlay delivered without it, and falls back to the popup window.
     try {
-      void chromeApi.runtime.sendMessage({
+      const sent = chromeApi.runtime.sendMessage({
         type: "dlr:picker-ready", overlay: overlayId });
+      if (sent && typeof sent.catch === "function") sent.catch(() => {});
     } catch { /* the worker's timeout falls back to a window */ }
   }
 

--- a/scripts/dl-router/extension/picker_overlay.js
+++ b/scripts/dl-router/extension/picker_overlay.js
@@ -163,14 +163,59 @@
     return { ok: true, id: msg.id };
   }
 
+  /** Is the live overlay still in the document? */
+  function stillAttached() {
+    if (!current || !current.host) return false;
+    if (typeof current.host.isConnected === "boolean") {
+      return current.host.isConnected;
+    }
+    return Boolean(current.host.parentNode);
+  }
+
+  /**
+   * THE OVERLAY CAN BE TAKEN AWAY BY THE PAGE, and that must not silently cost
+   * the user the question.
+   *
+   * `document.body.innerHTML = ...`, a DOM sanitiser, a framework re-render, or
+   * nine lines of hostile script all detach the host. The worker has already
+   * been told the overlay was delivered, so without this the download is left
+   * with no picker and nothing notices. Reporting it makes the worker re-ask in
+   * a popup window, which the page cannot reach.
+   *
+   * The closed shadow root is NOT what protects the pick here -- a page does
+   * not need the frame's URL to remove the element next to it. This is.
+   */
+  function reportLostIfDetached(notify) {
+    if (!current || stillAttached()) return false;
+    var lost = current.id;
+    current = null;
+    try {
+      if (typeof notify === "function") notify(lost);
+    } catch (e) { /* the worker will not learn; nothing else to try */ }
+    return true;
+  }
+
   /**
    * Handle `dlr:close-overlay`. An id that does not match the live overlay is
    * a no-op rather than a blind teardown: the worker retries and times out on
    * its own schedule, and a stale close must not remove a picker that a later
    * download legitimately opened.
    */
-  function closeOverlay(id) {
-    if (!current) return { ok: false, error: "no_overlay" };
+  function closeOverlay(id, doc) {
+    if (!current) {
+      // NO RECORD IS NOT "NOTHING TO DO". This content script is re-injected on
+      // every navigation, so a re-injected copy has `current === null` while a
+      // host element from before may still be sitting in the document. Without
+      // this sweep the user would face a 460x420 modal with no close button and
+      // no working Esc, and the only way out would be a page reload.
+      var stray = (doc && typeof doc.getElementById === "function")
+        ? doc.getElementById(HOST_ID) : null;
+      if (stray) {
+        detach({ host: stray });
+        return { ok: true, swept: true };
+      }
+      return { ok: false, error: "no_overlay" };
+    }
     if (id && current.id !== id) return { ok: false, error: "stale" };
     var removed = detach(current);
     current = null;
@@ -193,10 +238,30 @@
       return false;
     }
     if (msg.type === "dlr:close-overlay") {
-      sendResponse(closeOverlay(msg.overlay));
+      sendResponse(closeOverlay(msg.overlay, doc));
       return false;
     }
     return false;
+  }
+
+  /**
+   * Watch for the host being detached. `childList` on `body` only -- the host
+   * is a direct child of it, and `innerHTML =` or a `removeChild` both show up
+   * there. A `subtree: true` observer over every page the user visits would be
+   * a real cost for no extra coverage.
+   */
+  function watchAttachment(doc, notify) {
+    if (typeof MutationObserver !== "function") return null;
+    if (!doc || !doc.body) return null;
+    var obs = new MutationObserver(function () {
+      if (reportLostIfDetached(notify)) obs.disconnect();
+    });
+    try {
+      obs.observe(doc.body, { childList: true });
+    } catch (e) {
+      return null;
+    }
+    return obs;
   }
 
   /** Top frame only: `all_frames` is for capture, not for painting a picker. */
@@ -215,6 +280,9 @@
       closeOverlay: closeOverlay,
       handleMessage: handleMessage,
       hasOverlay: hasOverlay,
+      stillAttached: stillAttached,
+      reportLostIfDetached: reportLostIfDetached,
+      watchAttachment: watchAttachment,
       forget: forget,
       isTopFrame: isTopFrame,
     };
@@ -226,7 +294,28 @@
   if (typeof chrome === "undefined" || !chrome.runtime) return;
   if (!isTopFrame(typeof window !== "undefined" ? window : null)) return;
 
+  /** Tell the worker the overlay is gone, so it can re-ask in a window. */
+  function reportLost(lostId) {
+    try {
+      var sent = chrome.runtime.sendMessage(
+        { type: "dlr:overlay-lost", overlay: lostId });
+      if (sent && typeof sent.catch === "function") sent.catch(function () {});
+    } catch (e) { /* worker restarting */ }
+  }
+
+  var watcher = null;
+
   chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
-    return handleMessage(document, msg, sendResponse);
+    var out = handleMessage(document, msg, sendResponse);
+    // The watcher is armed only while an overlay is live: an always-on
+    // MutationObserver on every page the user visits would be a real cost.
+    if (msg && msg.type === "dlr:overlay-open" && hasOverlay()) {
+      if (watcher) watcher.disconnect();
+      watcher = watchAttachment(document, reportLost);
+    } else if (msg && msg.type === "dlr:close-overlay" && !hasOverlay()) {
+      if (watcher) watcher.disconnect();
+      watcher = null;
+    }
+    return out;
   });
 }());

--- a/scripts/dl-router/extension/picker_overlay.js
+++ b/scripts/dl-router/extension/picker_overlay.js
@@ -1,0 +1,232 @@
+// picker_overlay.js -- the picker delivered IN THE PAGE (classic content
+// script, same declaration as content_capture.js, so no new permissions).
+//
+// WHAT IT DOES NOT DO: it does not reimplement the picker. It frames
+// `picker.html` -- the same document, running the same `picker.js`, driven by
+// the same reducer -- inside a CLOSED shadow root on the page. A second copy of
+// the picker's state machine is precisely the drift that safety.py and
+// sanitize.js paid for, and this file exists to make sure there is only ever
+// one. Everything the reducer has learned (the `done` latch, single-flight
+// finish, choose-failed above the guard, a failed snapshot counting as still
+// loading, never creating a directory on Enter before the list lands) is
+// inherited rather than restated, because it is literally the same code.
+//
+// Why a frame and not a rendered list:
+//   * the picker needs `chrome.runtime.sendMessage` with an EXTENSION identity,
+//     and a content script's isolated world cannot import an ES module without
+//     making it web-accessible anyway;
+//   * an iframe is a separate document, so page CSS cannot reach the picker and
+//     the picker's CSS cannot reach the page -- stronger than a shadow root
+//     alone. The shadow root is still there, and is what stops the page styling
+//     or discovering the HOST element.
+//
+// It is NOT dismissed by an outside click or by losing focus. That is the exact
+// behaviour that ruled out `chrome.action.openPopup()`: a picker that vanishes
+// on blur silently discards the pick and leaves the file in the catch-all.
+//
+// Test hooks, matching content_capture.js: `globalThis.DL_ROUTER_NO_AUTOSTART`
+// suppresses listener install; `globalThis.__DLR_OVERLAY__` exposes the pure
+// functions.
+
+(function () {
+  "use strict";
+
+  var HOST_ID = "dl-router-picker-host";
+  var WIDTH = 460;
+  var HEIGHT = 420;
+
+  // Positioning lives on the HOST, inline and !important, because the host is
+  // the one node the page's stylesheets can see and match on.
+  var HOST_STYLE = [
+    "all: initial !important",
+    "position: fixed !important",
+    "top: 16px !important",
+    "right: 16px !important",
+    "width: " + WIDTH + "px !important",
+    "height: " + HEIGHT + "px !important",
+    // Above anything a page is likely to have parked at 2147483647-ish; this
+    // is a modal question about a download that already started.
+    "z-index: 2147483647 !important",
+    "display: block !important",
+    "visibility: visible !important",
+    "opacity: 1 !important",
+    "pointer-events: auto !important",
+    "margin: 0 !important",
+    "padding: 0 !important",
+    "border: 0 !important",
+  ].join("; ");
+
+  // Inside the shadow root, so none of it can leak onto the page.
+  var SHADOW_CSS = [
+    ":host { contain: layout style; }",
+    ".frame {",
+    "  display: block; width: 100%; height: 100%;",
+    "  border: 1px solid rgba(128,128,128,.45); border-radius: 8px;",
+    "  box-shadow: 0 8px 28px rgba(0,0,0,.28);",
+    "  background: Canvas; color-scheme: light dark;",
+    // Subtle entrance: the same 110-260ms register the picker's own rows use,
+    // so the overlay and its contents read as one piece of UI.
+    "  animation: dlr-overlay-in 140ms ease-out;",
+    "}",
+    "@keyframes dlr-overlay-in {",
+    "  from { opacity: 0; transform: translateY(-6px); }",
+    "  to   { opacity: 1; transform: translateY(0); }",
+    "}",
+    "@media (prefers-reduced-motion: reduce) {",
+    "  .frame { animation: none; }",
+    "}",
+  ].join("\n");
+
+  // The one live overlay, or null. Exactly one at a time: a second picker
+  // stacked on the first would make it ambiguous which download an Enter
+  // answers, and the reducer has no notion of "which download" -- the id is
+  // baked into the frame's URL.
+  var current = null;
+
+  function detach(overlay) {
+    if (!overlay || !overlay.host) return false;
+    try {
+      if (typeof overlay.host.remove === "function") {
+        overlay.host.remove();
+      } else if (overlay.host.parentNode) {
+        overlay.host.parentNode.removeChild(overlay.host);
+      }
+    } catch (e) {
+      return false;
+    }
+    return true;
+  }
+
+  /** Build the host + closed shadow root + frame. Throws on a hostile DOM. */
+  function build(doc, url, id) {
+    var host = doc.createElement("div");
+    host.setAttribute("id", HOST_ID);
+    host.setAttribute("style", HOST_STYLE);
+    // CLOSED, not open: the page must not be able to reach into the shadow to
+    // read the frame's URL. That URL carries the per-open nonce the service
+    // worker uses to match the overlay, and a page that could read it could
+    // forge a close and quietly discard the pick.
+    var shadow = host.attachShadow({ mode: "closed" });
+    var style = doc.createElement("style");
+    style.textContent = SHADOW_CSS;
+    var frame = doc.createElement("iframe");
+    frame.className = "frame";
+    frame.setAttribute("title", "Save to library");
+    frame.setAttribute("src", url);
+    shadow.appendChild(style);
+    shadow.appendChild(frame);
+    // FOCUS THE FRAME, AND AGAIN ON LOAD. The picker is keyboard-first, and
+    // `input.focus()` inside the framed document only moves focus WITHIN that
+    // document -- the frame element itself has to hold focus for keystrokes to
+    // reach it at all. The immediate call may land before the frame exists to
+    // focus, so the load handler is the one that usually does the work. Without
+    // this the user would have to click the overlay before they could type,
+    // which the popup window never required.
+    frame.addEventListener("load", function () {
+      try {
+        frame.focus();
+      } catch (e) { /* the page may have moved on */ }
+    });
+    var mountPoint = doc.body || doc.documentElement;
+    if (!mountPoint) throw new Error("no document to mount into");
+    mountPoint.appendChild(host);
+    try {
+      frame.focus();
+    } catch (e) { /* the load handler above is the reliable one */ }
+    return { id: id, host: host, shadow: shadow, frame: frame };
+  }
+
+  /**
+   * Handle `dlr:overlay-open`.
+   *
+   * `{ok: true}` here means ONLY "the host element and frame were created". It
+   * is deliberately not the delivery signal: a content-script-injected iframe
+   * is subject to the PAGE's Content-Security-Policy, so a site with a strict
+   * `frame-src` blocks the load while every DOM call here still succeeds. The
+   * service worker waits for `dlr:picker-ready`, which can only be sent from
+   * inside a booted extension context, and falls back to a popup window if it
+   * never arrives.
+   */
+  function openOverlay(doc, msg) {
+    if (!doc || !msg || typeof msg.url !== "string" || !msg.url
+        || typeof msg.id !== "string" || !msg.id) {
+      return { ok: false, error: "bad_request" };
+    }
+    if (current) detach(current);
+    current = null;
+    try {
+      current = build(doc, msg.url, msg.id);
+    } catch (e) {
+      current = null;
+      return { ok: false, error: "create_failed" };
+    }
+    return { ok: true, id: msg.id };
+  }
+
+  /**
+   * Handle `dlr:close-overlay`. An id that does not match the live overlay is
+   * a no-op rather than a blind teardown: the worker retries and times out on
+   * its own schedule, and a stale close must not remove a picker that a later
+   * download legitimately opened.
+   */
+  function closeOverlay(id) {
+    if (!current) return { ok: false, error: "no_overlay" };
+    if (id && current.id !== id) return { ok: false, error: "stale" };
+    var removed = detach(current);
+    current = null;
+    return { ok: removed };
+  }
+
+  function hasOverlay() {
+    return Boolean(current);
+  }
+
+  /** Reset hook for tests; also the honest answer after a navigation. */
+  function forget() {
+    current = null;
+  }
+
+  function handleMessage(doc, msg, sendResponse) {
+    if (!msg || typeof msg !== "object") return false;
+    if (msg.type === "dlr:overlay-open") {
+      sendResponse(openOverlay(doc, msg));
+      return false;
+    }
+    if (msg.type === "dlr:close-overlay") {
+      sendResponse(closeOverlay(msg.overlay));
+      return false;
+    }
+    return false;
+  }
+
+  /** Top frame only: `all_frames` is for capture, not for painting a picker. */
+  function isTopFrame(win) {
+    try {
+      return Boolean(win) && win.top === win.self;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  if (typeof globalThis !== "undefined") {
+    globalThis.__DLR_OVERLAY__ = {
+      HOST_ID: HOST_ID,
+      openOverlay: openOverlay,
+      closeOverlay: closeOverlay,
+      handleMessage: handleMessage,
+      hasOverlay: hasOverlay,
+      forget: forget,
+      isTopFrame: isTopFrame,
+    };
+  }
+
+  if (typeof globalThis !== "undefined" && globalThis.DL_ROUTER_NO_AUTOSTART) {
+    return;
+  }
+  if (typeof chrome === "undefined" || !chrome.runtime) return;
+  if (!isTopFrame(typeof window !== "undefined" ? window : null)) return;
+
+  chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
+    return handleMessage(document, msg, sendResponse);
+  });
+}());

--- a/scripts/dl-router/extension/picker_overlay.js
+++ b/scripts/dl-router/extension/picker_overlay.js
@@ -305,7 +305,10 @@
 
   var watcher = null;
 
-  chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
+  // `_sender` is unused: this listener only ever hears from OUR service worker,
+  // and the frame the message is about is identified by the overlay id in the
+  // payload. Named rather than dropped because sendResponse is the third arg.
+  chrome.runtime.onMessage.addListener(function (msg, _sender, sendResponse) {
     var out = handleMessage(document, msg, sendResponse);
     // The watcher is armed only while an overlay is live: an always-on
     // MutationObserver on every page the user visits would be a real cost.

--- a/scripts/dl-router/extension/service_worker.js
+++ b/scripts/dl-router/extension/service_worker.js
@@ -535,6 +535,61 @@ async function tellOverlayToClose(tabId, id) {
   } catch { /* tab gone or navigated -- the overlay went with the document */ }
 }
 
+/** The live overlay in a tab, if any. */
+function overlayInTab(tabId) {
+  for (const [id, record] of state.overlays) {
+    if (record.tabId === tabId) return id;
+  }
+  return null;
+}
+
+/**
+ * AN OVERLAY THAT STOPS EXISTING MUST BECOME A WINDOW.
+ *
+ * Gate 2 proves the frame booted. It proves nothing one millisecond later, and
+ * an overlay is a node in a document the extension does not own: the tab can
+ * close, navigate, or reload; the page can remove the node; and a second
+ * download into the same tab evicts the first (the content script keeps exactly
+ * one). In every one of those the picker vanishes, `openPicker` has already
+ * returned true, and the download would be left with NO picker at all -- the
+ * one outcome that is not allowed.
+ *
+ * So the worker keeps enough of the request (`info`) to re-ask, and re-asks in
+ * a popup window, which nothing on the page can touch. Re-delivery is
+ * idempotent: the record is removed first, so two triggers for the same overlay
+ * produce one window.
+ */
+async function redeliverAsWindow(id) {
+  const record = state.overlays.get(id);
+  if (!record) return false;
+  state.overlays.delete(id);
+  // Best effort: if anything IS still on screen, take it down first, so the
+  // user never faces two pickers for one download.
+  await tellOverlayToClose(record.tabId, id);
+  return openPickerWindow(record.info);
+}
+
+/** chrome.tabs.onRemoved: the tab holding the overlay is gone. */
+export function onTabRemoved(tabId) {
+  const id = overlayInTab(tabId);
+  if (id) void redeliverAsWindow(id);
+}
+
+/**
+ * chrome.tabs.onUpdated: the tab is navigating, so the overlay's document --
+ * and the overlay with it -- is about to be destroyed.
+ *
+ * Keyed on `status === "loading"` and NOT on `changeInfo.url`: a single-page
+ * app's pushState fires a url change without replacing the document, and
+ * yanking the picker into a window every time a SPA changes route would be a
+ * regression rather than a rescue.
+ */
+export function onTabUpdated(tabId, changeInfo) {
+  if (!changeInfo || changeInfo.status !== "loading") return;
+  const id = overlayInTab(tabId);
+  if (id) void redeliverAsWindow(id);
+}
+
 /**
  * The picker as an in-page overlay. Returns false -- never throws -- whenever
  * the page cannot host it, so the caller falls back to the window.
@@ -570,6 +625,12 @@ export async function openOverlayPicker(info) {
   }
   if (!tab || tab.discarded) return false;
   if (!overlayCapableUrl(tab.url || tab.pendingUrl)) return false;
+  // ONE OVERLAY PER TAB, decided HERE rather than discovered later. The content
+  // script keeps exactly one and evicts the incumbent, which for two downloads
+  // racing into the same tab means the first one's picker disappears while the
+  // worker still believes it was delivered. Refusing the second overlay sends
+  // it to a window instead: two questions, both asked, neither lost.
+  if (overlayInTab(tabId)) return false;
 
   const id = newOverlayId();
   const url = popupUrl("picker.html",
@@ -593,13 +654,28 @@ export async function openOverlayPicker(info) {
     return false;
   }
 
-  state.overlays.set(id, { tabId, downloadId: info.downloadId });
-  if (await ready) return true;
-  // gate 2 failed: tear the husk down before opening the window, so the user
-  // is never looking at two pickers for one download.
-  state.overlays.delete(id);
-  await tellOverlayToClose(tabId, id);
-  return false;
+  // `info` is kept so the question can be RE-ASKED in a window if the overlay
+  // stops existing -- see redeliverAsWindow.
+  state.overlays.set(id, { tabId, downloadId: info.downloadId, info });
+  if (!(await ready)) {
+    // gate 2 failed: tear the husk down before opening the window, so the user
+    // is never looking at two pickers for one download.
+    state.overlays.delete(id);
+    await tellOverlayToClose(tabId, id);
+    return false;
+  }
+  // BRING THE QUESTION TO THE USER. The popup window this replaces was created
+  // `focused: true`; an overlay painted into a background tab is a question
+  // nobody sees. The toast's `change` makes this concrete -- the user is looking
+  // at the toast's own window, and the overlay goes to the download's tab.
+  // Best effort: failing to raise a tab must not lose an overlay that works.
+  try {
+    await chrome.tabs.update(tabId, { active: true });
+    if (typeof tab.windowId === "number") {
+      await chrome.windows.update(tab.windowId, { focused: true });
+    }
+  } catch { /* the overlay is up either way */ }
+  return true;
 }
 
 /**
@@ -990,6 +1066,27 @@ export function onMessage(msg, sender, sendResponse) {
     return false;
   }
   if (msg.type === "dlr:choose") {
+    // A SUBFRAME MUST PRESENT A NONCE WE ISSUED.
+    //
+    // `picker.html` is web-accessible (it has to be, to be framed), so ANY page
+    // can embed it, point it at a recent download id and a chosen name, and
+    // clickjack two clicks out of the user: one to take the "+ new dir" row,
+    // one to answer the kind prompt. That is a /mkdir and a /relocate driven by
+    // a hostile page. Path traversal is already impossible, but "create a
+    // directory in the library and misfile a download into it" is not nothing,
+    // and click-to-select is what made two blind clicks sufficient.
+    //
+    // Our own overlay is a subframe too, so the discriminator is the per-open
+    // id: unguessable, issued by this worker, and never visible to the page
+    // (the shadow root holding the frame is closed). The popup-window picker is
+    // the TOP frame of its own tab and carries no nonce, which is why the test
+    // is on `frameId` rather than on the nonce being present.
+    if (typeof sender?.frameId === "number" && sender.frameId > 0
+        && !state.overlays.has(msg.overlay)) {
+      sendResponse({ ok: false,
+        error: "refusing a pick from an unrecognised frame" });
+      return false;
+    }
     ready()
       .then(() => applyChoice(msg.downloadId, msg.dir,
         { createdNew: msg.createdNew, kind: msg.kind }))
@@ -1017,6 +1114,14 @@ export function onMessage(msg, sender, sendResponse) {
       .then(() => sendResponse({ siteRules: state.snapshot?.siteRules || {} }))
       .catch(() => sendResponse({ siteRules: {} }));
     return true;
+  }
+  if (msg.type === "dlr:overlay-lost") {
+    // The content script noticed its host node was detached -- a page that
+    // rewrote document.body, a sanitiser, an SPA re-render, or a page
+    // deliberately removing it. Re-ask in a window, which the page cannot
+    // touch.
+    void redeliverAsWindow(msg.overlay);
+    return false;
   }
   if (msg.type === "dlr:picker-ready") {
     // Gate 2 of the overlay handshake -- see openOverlayPicker. Pure
@@ -1079,6 +1184,13 @@ export function registerListeners() {
   });
   // Ignores activation inside our own toast/picker popups -- see onTabActivated.
   chrome.tabs.onActivated.addListener(onTabActivated);
+  // An overlay lives in a document the extension does not own. When that
+  // document goes away the picker has to come back as a window, or the
+  // download is left unasked -- see redeliverAsWindow.
+  try {
+    chrome.tabs.onRemoved.addListener(onTabRemoved);
+    chrome.tabs.onUpdated.addListener(onTabUpdated);
+  } catch { /* older shapes without these events */ }
   try {
     chrome.windows.onRemoved.addListener(onWindowRemoved);
   } catch { /* older shapes without windows.onRemoved */ }

--- a/scripts/dl-router/extension/service_worker.js
+++ b/scripts/dl-router/extension/service_worker.js
@@ -31,6 +31,13 @@ const TOAST_H = 190;
 const PICKER_W = 460;
 const PICKER_H = 420;
 
+// How long the service worker waits for an injected overlay to prove it booted
+// before giving up and opening the popup window instead. The content script's
+// work is synchronous DOM building and the frame is a local extension page, so
+// a healthy path answers in single-digit milliseconds; this is the budget for a
+// page that is blocking the frame, not for a slow one.
+const OVERLAY_READY_MS = 1500;
+
 // How long onDeterminingFilename will wait for the cold-start config read
 // before giving up and declining to route. A chrome.storage.local read is
 // sub-millisecond; if it has not landed by now something is badly wrong and
@@ -49,6 +56,7 @@ export const state = {
   config: { port: DEFAULT_PORT, token: "", enabled: false },
   configLoaded: false,  // has loadConfig() completed at least once?
   ownWindowIds: new Set(),  // popup windows WE created (toast/picker)
+  overlays: new Map(),  // overlayId -> {tabId, downloadId} for in-page pickers
 };
 
 /**
@@ -146,8 +154,26 @@ export async function api(method, path, body, { timeoutMs, headers } = {}) {
 }
 
 // --- snapshot -------------------------------------------------------------- //
-export async function refreshSnapshot() {
-  const headers = state.etag ? { "If-None-Match": state.etag } : undefined;
+/**
+ * Fetch the /dirs snapshot.
+ *
+ * `revalidate` is what makes the picker's per-directory counts fresh.
+ *
+ * The sidecar deliberately leaves those counts OUT of the etag (see
+ * App.dirs_snapshot): they change on every download and would turn a cache
+ * validator for the ROUTING CONFIGURATION into a per-download counter. The
+ * price of that choice is that a 304 carries no body, so a revalidating client
+ * keeps whatever counts it already had -- and since the routing configuration
+ * changes about once a month, they would be frozen for about a month.
+ *
+ * So the ONE request a human is waiting on -- the picker asking for the list it
+ * is about to render -- skips If-None-Match and takes the full few-KB loopback
+ * body. Everything else (the five-minute alarm, startup, the post-/mkdir
+ * refresh) revalidates as before, so the steady-state traffic is unchanged.
+ */
+export async function refreshSnapshot({ revalidate = true } = {}) {
+  const headers = (revalidate && state.etag)
+    ? { "If-None-Match": state.etag } : undefined;
   const out = await api("GET", "/dirs", undefined, { timeoutMs: 4000, headers });
   if (out && out.notModified) return state.snapshot;
   state.snapshot = out;
@@ -297,6 +323,12 @@ function routeDownload(item, suggest) {
         decision: info.decision,
         payload,
         tier,
+        // Where to put an in-page picker: the tab the click came from. It is
+        // the capture's, not the DownloadItem's -- a DownloadItem carries no
+        // tabId, which is the whole reason the capture buffer exists. Absent
+        // when nothing correlated, and openOverlayPicker then falls back to the
+        // active tab and finally to a window.
+        tabId: capture?.tabId,
         ts: Date.now(),
       });
       // Fire-and-forget: the download is already answered.
@@ -396,16 +428,30 @@ export async function showToast(info) {
   }
 }
 
-export async function openPicker(info) {
+/** The query string both picker delivery paths are built from. ONE source. */
+function pickerParams(info) {
+  return {
+    id: String(info.downloadId ?? ""),
+    dir: info.dir || "",
+    reason: info.reason || "",
+    dup: info.dup || "",
+    suggestNew: info.suggestNew || "",
+  };
+}
+
+/**
+ * The picker as a dedicated popup window. THE FALLBACK, and it stays.
+ *
+ * Content scripts do not run on `brave://`/`chrome://`, the PDF viewer, the Web
+ * Store, `view-source:` or `file://`, and a download whose tab has already
+ * closed -- the self-closing file-host tab -- has nothing to inject into at
+ * all. Every one of those is a real case here, so this path is not legacy: it
+ * is the answer whenever the page cannot host the overlay.
+ */
+export async function openPickerWindow(info) {
   try {
     const win = await chrome.windows.create({
-      url: popupUrl("picker.html", {
-        id: String(info.downloadId ?? ""),
-        dir: info.dir || "",
-        reason: info.reason || "",
-        dup: info.dup || "",
-        suggestNew: info.suggestNew || "",
-      }),
+      url: popupUrl("picker.html", pickerParams(info)),
       type: "popup",
       width: PICKER_W,
       height: PICKER_H,
@@ -416,6 +462,160 @@ export async function openPicker(info) {
   } catch {
     return showToast({ ...info, source: "picker-failed" });
   }
+}
+
+/**
+ * Cheap pre-check on a tab's URL. NOT the real test.
+ *
+ * It rejects the schemes a content script provably never sees, so the common
+ * `brave://newtab` case costs no round-trip. It cannot cover the PDF viewer
+ * (an ordinary https URL whose document is a plugin), a tab still loading, or a
+ * discarded tab -- for those the probe below is the authority. Anything this
+ * misses falls back correctly; anything it rejects wrongly only costs a window.
+ */
+export function overlayCapableUrl(url) {
+  if (typeof url !== "string" || !/^https?:\/\//i.test(url)) return false;
+  // The Web Store is blocked to extensions by the browser itself.
+  if (/^https?:\/\/chromewebstore\.google\.com\//i.test(url)) return false;
+  if (/^https?:\/\/chrome\.google\.com\/webstore(\/|$)/i.test(url)) return false;
+  return true;
+}
+
+/** Which tab should host the overlay. */
+function overlayTabId(info) {
+  if (typeof info.tabId === "number") return info.tabId;
+  const entry = state.pending.get(info.downloadId);
+  if (entry && typeof entry.tabId === "number") return entry.tabId;
+  // Last resort: wherever the user is actually looking. A download's own tab
+  // often closes itself, and asking on the page in front of them beats a popup
+  // window. `state.activeTabId` already excludes our own popups.
+  return typeof state.activeTabId === "number" ? state.activeTabId : null;
+}
+
+function newOverlayId() {
+  try {
+    if (globalThis.crypto && typeof globalThis.crypto.randomUUID === "function") {
+      return globalThis.crypto.randomUUID();
+    }
+  } catch { /* fall through */ }
+  return `ov-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+// Resolvers for overlays whose `dlr:picker-ready` has not landed yet. Module
+// scope, not `state`: purely in-flight, and the wait is under two seconds.
+const overlayWaiters = new Map();
+
+function waitForOverlayReady(id, ms) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      overlayWaiters.delete(id);
+      resolve(false);
+    }, ms);
+    // `unref` exists only under node (the test runner); without it this timer
+    // holds the event loop open and hangs the suite.
+    if (timer && typeof timer.unref === "function") timer.unref();
+    overlayWaiters.set(id, (ok) => {
+      clearTimeout(timer);
+      overlayWaiters.delete(id);
+      resolve(ok !== false);
+    });
+  });
+}
+
+/** Abandon a readiness wait, so its timer does not outlive a failed open. */
+function cancelOverlayWait(id) {
+  const done = overlayWaiters.get(id);
+  if (done) done(false);
+}
+
+async function tellOverlayToClose(tabId, id) {
+  try {
+    await chrome.tabs.sendMessage(tabId,
+      { type: "dlr:close-overlay", overlay: id }, { frameId: 0 });
+  } catch { /* tab gone or navigated -- the overlay went with the document */ }
+}
+
+/**
+ * The picker as an in-page overlay. Returns false -- never throws -- whenever
+ * the page cannot host it, so the caller falls back to the window.
+ *
+ * `chrome.action.openPopup()` is deliberately not an option here: the manifest
+ * declares no `default_popup`, and an action popup dismisses on focus loss,
+ * which would silently discard a pick and leave the file in the catch-all.
+ *
+ * TWO gates, and both are needed:
+ *
+ *   1. the content script answers `dlr:overlay-open`. `chrome.tabs.sendMessage`
+ *      rejects with "receiving end does not exist" when there is no content
+ *      script -- which is one check covering `brave://`, the PDF viewer, the
+ *      Web Store, `view-source:`, `file://`, a closed or discarded tab, and a
+ *      page that has not reached `document_idle` yet.
+ *   2. the FRAME reports itself ready. A content-script-injected iframe is
+ *      subject to the page's CSP, so a strict `frame-src` blocks the load while
+ *      every DOM call in gate 1 still succeeds. Only an extension context that
+ *      actually booted can send `dlr:picker-ready`.
+ *
+ * Without gate 2 a CSP-restrictive site would leave an empty overlay and no
+ * window -- a download with no picker at all, which is the one outcome that is
+ * not allowed.
+ */
+export async function openOverlayPicker(info) {
+  const tabId = overlayTabId(info);
+  if (typeof tabId !== "number") return false;
+  let tab = null;
+  try {
+    tab = await chrome.tabs.get(tabId);
+  } catch {
+    return false;   // the tab has gone: the self-closing file-host tab
+  }
+  if (!tab || tab.discarded) return false;
+  if (!overlayCapableUrl(tab.url || tab.pendingUrl)) return false;
+
+  const id = newOverlayId();
+  const url = popupUrl("picker.html",
+    { ...pickerParams(info), embed: "1", overlay: id });
+  // ARM THE READINESS WAIT BEFORE THE PROBE. The content script returns as soon
+  // as the DOM nodes exist; the frame's own boot is a SEPARATE round trip and
+  // may land first. Registering the waiter after the send would drop a `ready`
+  // that won the race and fall back to a popup window for no reason at all --
+  // and, worse, intermittently.
+  const ready = waitForOverlayReady(id, OVERLAY_READY_MS);
+  let created = null;
+  try {
+    created = await chrome.tabs.sendMessage(tabId,
+      { type: "dlr:overlay-open", id, url }, { frameId: 0 });
+  } catch {
+    cancelOverlayWait(id);
+    return false;   // gate 1: no content script in this tab
+  }
+  if (!created || created.ok !== true) {
+    cancelOverlayWait(id);
+    return false;
+  }
+
+  state.overlays.set(id, { tabId, downloadId: info.downloadId });
+  if (await ready) return true;
+  // gate 2 failed: tear the husk down before opening the window, so the user
+  // is never looking at two pickers for one download.
+  state.overlays.delete(id);
+  await tellOverlayToClose(tabId, id);
+  return false;
+}
+
+/**
+ * Ask the user which directory. Overlay first, popup window as the automatic
+ * fallback -- and `openOverlayPicker` is written so that every failure mode
+ * reaches this fallback rather than throwing.
+ */
+export async function openPicker(info) {
+  let shown = false;
+  try {
+    shown = await openOverlayPicker(info);
+  } catch {
+    shown = false;
+  }
+  if (shown) return true;
+  return openPickerWindow(info);
 }
 
 // --- corrections ----------------------------------------------------------- //
@@ -712,6 +912,9 @@ export async function startFetch(url, info, tab) {
     dup: formatDup(decision?.dup) || "",
     suggestNew: decision?.suggestNew || "",
     candidates: decision?.candidates || [],
+    // A yt-dlp job has no entry in `state.pending`, so the tab has to be
+    // carried explicitly -- it is the tab the context menu was used in.
+    tabId: tab?.id ?? capture?.tabId,
   });
   return { ok: true, queued: true, dir: null };
 }
@@ -795,8 +998,11 @@ export function onMessage(msg, sender, sendResponse) {
     return true;   // async response
   }
   if (msg.type === "dlr:snapshot") {
+    // `revalidate: false` -- this is the picker asking for the list it is
+    // about to render, and the per-directory counts are not covered by the
+    // etag, so a 304 would hand it a stale tally. See refreshSnapshot.
     ready()
-      .then(() => refreshSnapshot())
+      .then(() => refreshSnapshot({ revalidate: false }))
       .then(() => sendResponse({ ok: Boolean(state.snapshot),
         snapshot: state.snapshot }))
       .catch(() => sendResponse({ ok: Boolean(state.snapshot),
@@ -811,6 +1017,27 @@ export function onMessage(msg, sender, sendResponse) {
       .then(() => sendResponse({ siteRules: state.snapshot?.siteRules || {} }))
       .catch(() => sendResponse({ siteRules: {} }));
     return true;
+  }
+  if (msg.type === "dlr:picker-ready") {
+    // Gate 2 of the overlay handshake -- see openOverlayPicker. Pure
+    // bookkeeping against an in-flight promise: it must NOT await ready(),
+    // because the whole point is to answer inside the readiness budget.
+    const resolve = overlayWaiters.get(msg.overlay);
+    if (resolve) resolve();
+    return false;
+  }
+  if (msg.type === "dlr:picker-closed") {
+    // The embedded picker finished (accepted, cancelled, or refused then
+    // escaped) and cannot close its own frame. Tear the overlay down.
+    const record = state.overlays.get(msg.overlay);
+    state.overlays.delete(msg.overlay);
+    // `sender.tab.id` is what survives an MV3 teardown. The picker can sit
+    // open well past the ~30 s idle timeout, and a restarted worker has an
+    // empty `state.overlays` -- keying only on that map would leave the
+    // overlay on screen forever with nothing able to remove it.
+    const tabId = record ? record.tabId : sender?.tab?.id;
+    if (typeof tabId === "number") void tellOverlayToClose(tabId, msg.overlay);
+    return false;
   }
   if (msg.type === "dlr:repick") {
     void ready().then(() => {

--- a/scripts/dl-router/extension/service_worker.js
+++ b/scripts/dl-router/extension/service_worker.js
@@ -501,6 +501,76 @@ function newOverlayId() {
   return `ov-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
+// --- the overlay registry, and why it is PERSISTED -------------------------- //
+//
+// `state.overlays` is in-memory, and MV3 tears this worker down after ~30 s
+// idle. The picker routinely outlives that: the user is CHOOSING, which is the
+// slowest thing they do here. Everything that consults the registry on the far
+// side of a teardown therefore has to read a durable copy first, or it reasons
+// from an empty map:
+//
+//   * `dlr:choose` -> the anti-clickjack guard would refuse a LEGITIMATE pick
+//     and discard it, precisely when the user had been deliberating longest;
+//   * `tabs.onRemoved`/`onUpdated` -> the tab closing would find no overlay to
+//     rescue, and the download would be left with no picker at all.
+//
+// `chrome.storage.session` has exactly the right lifetime: it survives the idle
+// teardown and dies with the browser, which is also when every overlay dies.
+// This is the same lesson as `Store.record_screened` -- a fact that must
+// outlive a teardown does not live in service-worker memory.
+async function persistOverlays() {
+  try {
+    await chrome.storage.session.set({ overlays: [...state.overlays] });
+  } catch { /* storage.session unavailable; the in-memory copy still works */ }
+}
+
+// Overlays already being converted back into a window. Single-flight, and a
+// TOMBSTONE: `persistOverlays` is fire-and-forget, so a restore that runs
+// before that write lands would otherwise RESURRECT an overlay that has just
+// been re-delivered -- and the user would get a second window for one download.
+// Ids are per-open and the worker is torn down every ~30 s idle, so this set
+// cannot grow unbounded.
+const redelivering = new Set();
+
+/** Merge the durable copy in. NEVER clobbers an overlay opened this turn. */
+export async function restoreOverlays() {
+  try {
+    const { overlays } = await chrome.storage.session.get("overlays");
+    if (!Array.isArray(overlays)) return;
+    for (const entry of overlays) {
+      if (!Array.isArray(entry) || typeof entry[0] !== "string") continue;
+      if (!entry[1] || typeof entry[1] !== "object") continue;
+      if (redelivering.has(entry[0])) continue;   // already asked in a window
+      if (!state.overlays.has(entry[0])) state.overlays.set(entry[0], entry[1]);
+    }
+  } catch { /* best effort */ }
+}
+
+function rememberOverlay(id, record) {
+  state.overlays.set(id, record);
+  void persistOverlays();
+}
+
+function forgetOverlay(id) {
+  const had = state.overlays.delete(id);
+  if (had) void persistOverlays();
+  return had;
+}
+
+/**
+ * Is this one of OUR overlays? Consults the durable copy before saying no.
+ *
+ * The lazy restore is here rather than only in `start()` so the answer does not
+ * depend on when readiness happened to resolve. Refusing a real pick is not a
+ * recoverable error: the user's choice is gone.
+ */
+async function overlayIsOurs(id) {
+  if (typeof id !== "string" || !id) return false;
+  if (state.overlays.has(id)) return true;
+  await restoreOverlays();
+  return state.overlays.has(id);
+}
+
 // Resolvers for overlays whose `dlr:picker-ready` has not landed yet. Module
 // scope, not `state`: purely in-flight, and the wait is under two seconds.
 const overlayWaiters = new Map();
@@ -560,19 +630,34 @@ function overlayInTab(tabId) {
  * produce one window.
  */
 async function redeliverAsWindow(id) {
+  // SINGLE-FLIGHT, CHECKED SYNCHRONOUSLY. onRemoved and onUpdated both fire for
+  // a closing tab, and the page can report the loss at the same moment -- and
+  // each of those now awaits `restoreOverlays()` first, so without this claim
+  // all three could pass the "is there an overlay?" test before any of them
+  // removed it. Two windows for one download is worse than none.
+  if (redelivering.has(id)) return false;
   const record = state.overlays.get(id);
   if (!record) return false;
-  state.overlays.delete(id);
+  redelivering.add(id);
+  forgetOverlay(id);
   // Best effort: if anything IS still on screen, take it down first, so the
   // user never faces two pickers for one download.
   await tellOverlayToClose(record.tabId, id);
   return openPickerWindow(record.info);
 }
 
-/** chrome.tabs.onRemoved: the tab holding the overlay is gone. */
-export function onTabRemoved(tabId) {
+/**
+ * chrome.tabs.onRemoved: the tab holding the overlay is gone.
+ *
+ * `await restoreOverlays()` first, for the same reason the choose guard does:
+ * this event is exactly the kind that WAKES a torn-down worker, and an empty
+ * in-memory registry would find nothing to rescue and leave the download
+ * unasked.
+ */
+export async function onTabRemoved(tabId) {
+  await restoreOverlays();
   const id = overlayInTab(tabId);
-  if (id) void redeliverAsWindow(id);
+  if (id) await redeliverAsWindow(id);
 }
 
 /**
@@ -584,10 +669,11 @@ export function onTabRemoved(tabId) {
  * yanking the picker into a window every time a SPA changes route would be a
  * regression rather than a rescue.
  */
-export function onTabUpdated(tabId, changeInfo) {
+export async function onTabUpdated(tabId, changeInfo) {
   if (!changeInfo || changeInfo.status !== "loading") return;
+  await restoreOverlays();
   const id = overlayInTab(tabId);
-  if (id) void redeliverAsWindow(id);
+  if (id) await redeliverAsWindow(id);
 }
 
 /**
@@ -656,11 +742,11 @@ export async function openOverlayPicker(info) {
 
   // `info` is kept so the question can be RE-ASKED in a window if the overlay
   // stops existing -- see redeliverAsWindow.
-  state.overlays.set(id, { tabId, downloadId: info.downloadId, info });
+  rememberOverlay(id, { tabId, downloadId: info.downloadId, info });
   if (!(await ready)) {
     // gate 2 failed: tear the husk down before opening the window, so the user
     // is never looking at two pickers for one download.
-    state.overlays.delete(id);
+    forgetOverlay(id);
     await tellOverlayToClose(tabId, id);
     return false;
   }
@@ -1081,15 +1167,23 @@ export function onMessage(msg, sender, sendResponse) {
     // (the shadow root holding the frame is closed). The popup-window picker is
     // the TOP frame of its own tab and carries no nonce, which is why the test
     // is on `frameId` rather than on the nonce being present.
-    if (typeof sender?.frameId === "number" && sender.frameId > 0
-        && !state.overlays.has(msg.overlay)) {
-      sendResponse({ ok: false,
-        error: "refusing a pick from an unrecognised frame" });
-      return false;
-    }
+    // THE CHECK IS ASYNC, and it has to be. The registry it consults must
+    // survive the ~30 s MV3 idle teardown -- the picker outlives that all the
+    // time, because choosing is the slowest thing the user does here -- so
+    // `overlayIsOurs` falls back to the durable copy in chrome.storage.session
+    // rather than reading an empty in-memory Map and refusing a REAL pick.
+    // Refusing a real pick is not recoverable: the choice is simply gone.
+    const fromSubframe = typeof sender?.frameId === "number"
+      && sender.frameId > 0;
     ready()
-      .then(() => applyChoice(msg.downloadId, msg.dir,
-        { createdNew: msg.createdNew, kind: msg.kind }))
+      .then(async () => {
+        if (fromSubframe && !(await overlayIsOurs(msg.overlay))) {
+          return { ok: false,
+            error: "refusing a pick from an unrecognised frame" };
+        }
+        return applyChoice(msg.downloadId, msg.dir,
+          { createdNew: msg.createdNew, kind: msg.kind });
+      })
       .then((r) => sendResponse(r))
       .catch((e) => sendResponse({ ok: false, error: errorMessage(e) }));
     return true;   // async response
@@ -1135,7 +1229,7 @@ export function onMessage(msg, sender, sendResponse) {
     // The embedded picker finished (accepted, cancelled, or refused then
     // escaped) and cannot close its own frame. Tear the overlay down.
     const record = state.overlays.get(msg.overlay);
-    state.overlays.delete(msg.overlay);
+    forgetOverlay(msg.overlay);
     // `sender.tab.id` is what survives an MV3 teardown. The picker can sit
     // open well past the ~30 s idle timeout, and a restarted worker has an
     // empty `state.overlays` -- keying only on that map would leave the
@@ -1210,6 +1304,10 @@ export function registerListeners() {
 export async function start() {
   await loadConfig();
   await restoreSnapshot();
+  // Overlays opened before the last idle teardown. Without this a woken worker
+  // has an empty registry, and the tab watchers would find no overlay to rescue
+  // when its tab closes.
+  await restoreOverlays();
   await installMenus();
   try {
     const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });

--- a/scripts/dl-router/server.py
+++ b/scripts/dl-router/server.py
@@ -238,7 +238,58 @@ class App:
             json.dumps(snap, sort_keys=True, ensure_ascii=False,
                        separators=(",", ":")).encode("utf-8")
         ).hexdigest()[:16]
+        # PER-DIRECTORY ITEM COUNTS, SERVED BUT DELIBERATELY OUTSIDE THE ETAG.
+        #
+        # This line is below the hash on purpose. The alternative -- folding the
+        # counts in, the way the kinds and aliases above are folded in -- was
+        # rejected for three reasons, in increasing order of how much they cost:
+        #
+        #   1. Churn. A count changes on EVERY completed download, so the etag
+        #      would change on every download and the extension's five-minute
+        #      revalidation would fetch the whole payload instead of a 304.
+        #      Cheap in bytes over loopback; not the real problem.
+        #   2. The etag would stop being a cache validator. These counts come
+        #      from FileIndex, which is TTL-cached and refreshed opportunistically
+        #      -- so the same unchanged library can answer with two different
+        #      counts a minute apart. An etag that changes when nothing changed
+        #      is not a validator, it is a random number.
+        #   3. It would destroy the one thing this etag is FOR. Everything else
+        #      in this payload is routing configuration: the directories, their
+        #      kinds, the aliases, the threshold. The extension's cached
+        #      fallback matcher runs off exactly that, and the comment above
+        #      exists because a stale kind kept auto-filing into a directory the
+        #      operator had reclassified. "The routing configuration changed" is
+        #      a question worth being able to answer -- from `dl-route status`,
+        #      whose /healthz etag is the same value, as much as from
+        #      If-None-Match. Mixing a per-download counter into it means the
+        #      answer is always yes.
+        #
+        # The cost of this choice, stated honestly: a 304 carries no body, so a
+        # revalidating client keeps the counts it already had. That is why the
+        # extension asks for the snapshot WITHOUT If-None-Match on the picker
+        # path (service_worker.refreshSnapshot's `revalidate` flag) -- the one
+        # request whose freshness a human is waiting on -- and keeps
+        # revalidating everywhere else. Counts are cosmetic: nothing routes on
+        # them, and no code path may start to.
+        #
+        # A SEPARATE MAP, not a `count` field on each `dirs` entry: the cached
+        # fallback matcher iterates `dirs`, and the entries it reads stay
+        # byte-identical to what they were before counts existed.
+        snap["counts"] = self.file_counts()
         return snap
+
+    def file_counts(self) -> dict:
+        """Files per subject directory, for the picker's per-directory count.
+
+        Restricted to directories that are actually in the index: the walk
+        tallies whatever top-level names it encountered, and a routing target
+        is the only thing worth showing a count for.
+        """
+        if self.files is None or self.dirs is None:
+            return {}
+        known = self.dirs.name_set()
+        return {name: n for name, n in self.files.dir_counts().items()
+                if name in known}
 
     def match(self, payload: dict) -> dict:
         ctx = MatchContext.from_payload(payload)

--- a/scripts/dl-router/tests/fake_page.mjs
+++ b/scripts/dl-router/tests/fake_page.mjs
@@ -11,13 +11,44 @@ class FakeEl {
     this.tagName = tagName;
     this.children = [];
     this._class = "";
+    this._attrs = new Map();
     this.text = "";
     this.value = "";
     this.checked = false;
     this.disabled = false;
     this.readOnly = false;
     this.focused = false;
+    this.parentNode = null;
+    this.shadowRoot = null;   // what attachShadow built, for assertions only
     this.listeners = new Map();
+  }
+
+  setAttribute(name, value) { this._attrs.set(String(name), String(value)); }
+
+  getAttribute(name) {
+    const v = this._attrs.get(String(name));
+    return v === undefined ? null : v;
+  }
+
+  /**
+   * Enough of Element.attachShadow for the overlay: it records the mode (the
+   * overlay must use "closed", so the page cannot read the frame's URL) and
+   * returns a node children can be appended to. A CLOSED root is not readable
+   * from the element in a real DOM, so `shadowRoot` here is a test-only handle.
+   */
+  attachShadow({ mode } = {}) {
+    const root = new FakeEl("#shadow-root");
+    root.mode = mode;
+    this.shadowRoot = root;
+    return root;
+  }
+
+  remove() {
+    if (!this.parentNode) return;
+    const siblings = this.parentNode.children;
+    const i = siblings.indexOf(this);
+    if (i >= 0) siblings.splice(i, 1);
+    this.parentNode = null;
   }
 
   get textContent() {
@@ -51,7 +82,11 @@ class FakeEl {
     };
   }
 
-  appendChild(child) { this.children.push(child); return child; }
+  appendChild(child) {
+    this.children.push(child);
+    if (child && typeof child === "object") child.parentNode = this;
+    return child;
+  }
 
   focus() { this.focused = true; }
 
@@ -74,8 +109,12 @@ export function makeDoc(ids, { search = "" } = {}) {
   const els = new Map();
   for (const id of ids) els.set(id, new FakeEl());
   const docListeners = new Map();
+  const body = new FakeEl("body");
   return {
     els,
+    // The in-page overlay mounts its host here (picker_overlay.js).
+    body,
+    documentElement: body,
     location: { search },
     getElementById: (id) => els.get(id) || null,
     createElement: (tag) => new FakeEl(tag),

--- a/scripts/dl-router/tests/picker.test.mjs
+++ b/scripts/dl-router/tests/picker.test.mjs
@@ -1235,3 +1235,24 @@ test("an accepted choice in an overlay closes it too", async () => {
   assert.ok(sent.some((m) => m.type === "dlr:choose"));
   assert.ok(sent.some((m) => m.type === "dlr:picker-closed"));
 });
+
+test("AN EMBEDDED PICK CARRIES THE ID THE WORKER ISSUED", () => {
+  // Half of a cross-component contract, and the half that fails LOUDLY if it
+  // rots: the worker refuses a `dlr:choose` from a subframe that cannot present
+  // an id it issued (any page may frame picker.html and clickjack two clicks).
+  // Stop sending it here and EVERY real overlay pick is refused.
+  const { doc, sent } = mountFree("?id=7&embed=1&overlay=ov-abc");
+  doc.getElementById("list").children[1].fire("click");
+  const choose = sent.find((m) => m.type === "dlr:choose");
+  assert.equal(choose.overlay, "ov-abc");
+});
+
+test("...and a windowed pick still carries none", () => {
+  // The other half: the popup window is the TOP frame of its own tab, which is
+  // what the worker's guard keys on. Adding an id here would be harmless but
+  // adding the ASSUMPTION that one is always present would not.
+  const { doc, sent } = mountFree("?id=7");
+  doc.getElementById("list").children[1].fire("click");
+  const choose = sent.find((m) => m.type === "dlr:choose");
+  assert.equal("overlay" in choose, false);
+});

--- a/scripts/dl-router/tests/picker.test.mjs
+++ b/scripts/dl-router/tests/picker.test.mjs
@@ -5,6 +5,7 @@
 // exactly where the suggest() ladder already put it — no move, no alias.
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 globalThis.DL_ROUTER_NO_AUTOSTART = true;
 
@@ -942,4 +943,295 @@ test("a caught sendMessage rejection is not Error-prefixed", async () => {
   const shown = doc.getElementById("meta").textContent;
   assert.match(shown, /the message port closed/);
   assert.ok(!shown.includes("Error:"), shown);
+});
+
+// --- per-directory item counts ----------------------------------------------- //
+//
+// The number rides as its own field and its own DOM node. It is decorative:
+// nothing routes on it, and it must never end up inside `label`, which is what
+// the new-directory proposal and the sidecar-facing flow are built from.
+const COUNTS = { "Jane Doe": 12, "john-smith": 3, "Mary_Major": 0 };
+
+test("filterEntries attaches each directory's count", () => {
+  const byName = Object.fromEntries(
+    filterEntries(DIRS, "", "", COUNTS).map((e) => [e.name, e.count]));
+  assert.equal(byName["Jane Doe"], 12);
+  assert.equal(byName["john-smith"], 3);
+  assert.equal(byName["Mary_Major"], 0, "zero is a count, not a missing one");
+  assert.equal(byName["acme-studio"], undefined, "absent stays absent");
+});
+
+test("no counts map at all leaves every entry countless", () => {
+  for (const entry of filterEntries(DIRS, "", "")) {
+    assert.equal(entry.count, undefined);
+  }
+});
+
+test("a malformed count is dropped rather than rendered", () => {
+  const hostile = { "Jane Doe": "12", "john-smith": NaN, "Mary_Major": -1,
+    "acme-studio": Infinity, other: null };
+  for (const entry of filterEntries(DIRS, "", "", hostile)) {
+    assert.equal(entry.count, undefined, entry.name);
+  }
+});
+
+test("the count NEVER leaks into the entry label", () => {
+  // `label` is what the "+ new dir" proposal is built from and what the flow
+  // reads; a decorative number in it would be a directory name with a number
+  // stuck on the end.
+  for (const entry of filterEntries(DIRS, "", "", COUNTS)) {
+    assert.equal(entry.label, entry.name);
+  }
+});
+
+test("the new-directory proposal carries no count", () => {
+  const entries = filterEntries(DIRS, "aster nightingale", "", COUNTS);
+  const proposal = entries.find((e) => e.kind === ENTRY_NEW);
+  assert.equal(proposal.count, undefined);
+});
+
+test("the dirs event carries the counts into the entries", () => {
+  let state = initialState({ dirs: [], loading: true });
+  state = reduce(state, { type: "dirs", dirs: DIRS, counts: COUNTS });
+  const jane = state.entries.find((e) => e.name === "Jane Doe");
+  assert.equal(jane.count, 12);
+  // ...and they survive a re-filter, which rebuilds the list from scratch.
+  state = reduce(state, input("jane"));
+  assert.equal(state.entries[0].count, 12);
+});
+
+test("a snapshot with no counts renders exactly as it always did", () => {
+  let state = initialState({ dirs: [], loading: true });
+  state = reduce(state, { type: "dirs", dirs: DIRS });
+  assert.equal(state.counts, null);
+  assert.ok(state.entries.every((e) => e.count === undefined));
+});
+
+test("mount renders the count beside the directory name", () => {
+  const { doc } = mountPicker({
+    snapshot: { dirs: DIRS.map((name) => ({ name })), counts: COUNTS } });
+  const rows = doc.getElementById("list").children;
+  const jane = rows.find((r) => r.textContent.includes("Jane Doe"));
+  const badge = jane.children.find((c) => c.className === "count");
+  assert.equal(badge.textContent, "12");
+  // The name is its own node, so the count can be styled down and can never be
+  // mistaken for part of it.
+  assert.equal(jane.children[0].textContent, "Jane Doe");
+});
+
+test("mount draws no count node when the sidecar sent none", () => {
+  const { doc } = mountPicker();
+  const rows = doc.getElementById("list").children;
+  for (const row of rows) {
+    assert.ok(!row.children.some((c) => c.className === "count"));
+  }
+});
+
+// --- click to select --------------------------------------------------------- //
+const click = (index) => ({ type: "click", index });
+
+test("a click chooses the clicked row, not the highlighted one", () => {
+  let state = initialState({ dirs: DIRS });
+  state = drive(state, [key("ArrowDown")]);           // highlight moves to 1
+  const target = state.entries[3].name;
+  state = drive(state, [click(3)]);
+  assert.deepEqual(state.done,
+    { action: "choose", dir: target, createdNew: false });
+  assert.equal(state.index, 3, "the highlight follows the click");
+});
+
+test("a click on the new-directory entry asks the kind first", () => {
+  // Creation by mouse must be exactly as deliberate as creation by keyboard.
+  let state = initialState({ dirs: DIRS, suggestNew: "Aster Vale" });
+  state = drive(state, [click(0)]);
+  assert.equal(state.done, null, "nothing is created before the kind is known");
+  assert.equal(state.pendingNew, "Aster Vale");
+  assert.deepEqual(state.entries.map((e) => e.name), ["performer", "category"]);
+});
+
+test("a click answers the kind prompt", () => {
+  let state = initialState({ dirs: DIRS, suggestNew: "Aster Vale" });
+  state = drive(state, [click(0), click(1)]);
+  assert.deepEqual(state.done, { action: "choose", dir: "Aster Vale",
+    createdNew: true, kind: "category" });
+});
+
+test("a click while the directory list is still loading is DROPPED", () => {
+  // THE pin. Enter DEFERS while loading because a typed query survives the
+  // list arriving. A click's intent is a screen position, and position N of the
+  // loading placeholder is not position N of the real list -- honouring it
+  // later would choose an arbitrary directory, or CREATE one, which is the
+  // exact footgun the deferred Enter exists to close.
+  const state = initialState({ dirs: [], suggestNew: "Aster Vale",
+    loading: true });
+  assert.equal(state.entries[0].kind, ENTRY_NEW,
+    "the proposal really is sitting at index 0 while loading");
+  const after = reduce(state, click(0));
+  assert.equal(after, state, "state is returned untouched");
+  assert.equal(after.done, null);
+  assert.equal(after.pendingNew, null);
+  assert.equal(after.pendingEnter, false, "and it is not queued for later");
+});
+
+test("a click is refused once the list is known to be unavailable", () => {
+  let state = initialState({ dirs: [], suggestNew: "Aster Vale", loading: true });
+  state = reduce(state, { type: "dirs-failed" });
+  const after = reduce(state, click(0));
+  assert.equal(after, state);
+  assert.equal(after.done, null);
+});
+
+test("a click with a nonsense index does nothing", () => {
+  const state = initialState({ dirs: DIRS });
+  for (const i of [-1, 99, 1.5, NaN, "2", null, undefined]) {
+    assert.equal(reduce(state, click(i)), state, String(i));
+  }
+});
+
+test("a click after the flow finished is ignored", () => {
+  let state = initialState({ dirs: DIRS });
+  state = drive(state, [key("Escape")]);
+  const after = reduce(state, click(1));
+  assert.equal(after, state);
+  assert.deepEqual(after.done, { action: "cancel", dir: "other" });
+});
+
+test("the reducer never mutates the previous state on a click", () => {
+  const before = initialState({ dirs: DIRS });
+  const snapshot = JSON.stringify(before);
+  reduce(before, click(2));
+  assert.equal(JSON.stringify(before), snapshot);
+});
+
+test("mount: clicking a rendered row chooses that directory", async () => {
+  const { doc, sent, closed } = mountPicker();
+  const rows = doc.getElementById("list").children;
+  const wanted = rows[3].children[0].textContent;
+  rows[3].fire("click");
+  const choose = sent.find((m) => m.type === "dlr:choose");
+  assert.deepEqual(choose, { type: "dlr:choose", downloadId: 7, dir: wanted,
+    createdNew: false });
+  await tick();
+  assert.equal(closed(), 1);
+});
+
+test("mount: the loading placeholder is not clickable at all", () => {
+  // Belt and braces around the reducer's refusal: the row that stands in for
+  // the list while it loads never even gets a handler.
+  const { doc } = mountPicker({ deferReply: true });
+  const rows = doc.getElementById("list").children;
+  assert.match(rows[0].textContent, /Loading directories/);
+  assert.equal(rows[0].listeners.has("click"), false);
+});
+
+test("mount: the keyboard still drives the list after a click", async () => {
+  // The keyboard-first flow must not become a second-class citizen. Clicking
+  // the new-directory row raises the kind prompt; arrows and Enter still answer
+  // it, without touching the mouse again.
+  const { doc, sent } = mountPicker();
+  doc.getElementById("list").children[0].fire("click");   // "+ new dir"
+  assert.equal(sent.filter((m) => m.type === "dlr:choose").length, 0);
+  doc.fire("keydown", { key: "ArrowDown" });
+  doc.fire("keydown", { key: "Enter" });
+  const choose = sent.find((m) => m.type === "dlr:choose");
+  assert.deepEqual(choose, { type: "dlr:choose", downloadId: 7,
+    dir: "Aster Vale", createdNew: true, kind: "category" });
+});
+
+test("mount: clicks during an in-flight choose do not re-send it", async () => {
+  // The same single-flight latch the keyboard is held to. A click is a much
+  // easier way to produce three of them in a row.
+  const { doc, sent } = mountPicker({
+    chooseResult: new Promise(() => {}) });
+  const rows = () => doc.getElementById("list").children;
+  rows()[2].fire("click");
+  await tick();
+  rows()[3].fire("click");
+  rows()[4].fire("click");
+  await tick();
+  assert.equal(sent.filter((m) => m.type === "dlr:choose").length, 1);
+});
+
+test("mount: the chosen row is marked for the confirmation animation", () => {
+  const { doc } = mountPicker({ deferReply: false });
+  const rows = doc.getElementById("list").children;
+  rows[2].fire("click");
+  // Re-read: render() rebuilds the list.
+  assert.ok(doc.getElementById("list").children[2].className.includes("taken"),
+    "the row the user picked is the one that pulses");
+  assert.ok(!doc.getElementById("list").children[1].className.includes("taken"));
+});
+
+test("mount: a keyboard choice marks the same way a click does", () => {
+  const { doc } = mountPicker();
+  doc.fire("keydown", { key: "ArrowDown" });
+  doc.fire("keydown", { key: "Enter" });
+  assert.ok(doc.getElementById("list").children[1].className.includes("taken"));
+});
+
+test("the picker's motion is opt-out", () => {
+  // The animation is CSS, so this is the only place it can be pinned headlessly
+  // -- but an unconditional animation is a real accessibility regression and
+  // deleting the media query must not be silent.
+  const css = readFileSync(
+    new URL("../extension/picker.html", import.meta.url), "utf8");
+  assert.match(css, /prefers-reduced-motion/);
+  assert.match(css, /\.row\.taken/);
+  // Hover is CSS-only on purpose: a pointer that moved the selection would
+  // fight the keyboard, because the mouse sits wherever it was left.
+  assert.match(css, /\.row:hover/);
+});
+
+// --- delivered as an in-page overlay ----------------------------------------- //
+//
+// Same document, same reducer, same finish() -- only "what does closing mean"
+// differs, because an iframe cannot close itself.
+function mountFree(search) {
+  const doc = makeDoc(PAGE_IDS, { search });
+  const sent = [];
+  const chromeApi = {
+    runtime: {
+      sendMessage: (msg, cb) => {
+        sent.push(msg);
+        if (typeof cb === "function") {
+          cb({ ok: true, snapshot: { dirs: DIRS.map((name) => ({ name })) } });
+        }
+        return Promise.resolve({ ok: true });
+      },
+    },
+  };
+  return { doc, sent, handle: mount(doc, chromeApi) };
+}
+
+test("an embedded picker announces that it actually booted", () => {
+  // The service worker will not consider the overlay delivered without this:
+  // a content-script-injected iframe is subject to the PAGE's CSP, so the host
+  // element can exist while the frame never loaded. Only an extension context
+  // that really started can send it.
+  const { sent } = mountFree("?id=7&embed=1&overlay=ov-abc");
+  assert.deepEqual(sent.find((m) => m.type === "dlr:picker-ready"),
+    { type: "dlr:picker-ready", overlay: "ov-abc" });
+});
+
+test("a windowed picker announces nothing", () => {
+  const { sent } = mountFree("?id=7");
+  assert.equal(sent.some((m) => m.type === "dlr:picker-ready"), false);
+});
+
+test("an embedded picker asks the worker to tear the overlay down", async () => {
+  // window.close() on an iframe is a no-op, so without this the overlay would
+  // outlive the pick and sit on the page forever.
+  const { doc, sent } = mountFree("?id=7&embed=1&overlay=ov-abc");
+  doc.fire("keydown", { key: "Escape" });
+  await tick();
+  assert.deepEqual(sent.find((m) => m.type === "dlr:picker-closed"),
+    { type: "dlr:picker-closed", overlay: "ov-abc" });
+});
+
+test("an accepted choice in an overlay closes it too", async () => {
+  const { doc, sent } = mountFree("?id=7&embed=1&overlay=ov-abc");
+  doc.getElementById("list").children[0].fire("click");
+  await tick();
+  assert.ok(sent.some((m) => m.type === "dlr:choose"));
+  assert.ok(sent.some((m) => m.type === "dlr:picker-closed"));
 });

--- a/scripts/dl-router/tests/picker_overlay.test.mjs
+++ b/scripts/dl-router/tests/picker_overlay.test.mjs
@@ -198,11 +198,23 @@ test("the manifest delivers the overlay through the EXISTING content script", ()
   assert.deepEqual(cs.js, ["content_capture.js", "picker_overlay.js"]);
   assert.deepEqual(manifest.permissions.slice().sort(),
     ["alarms", "contextMenus", "downloads", "notifications", "storage", "tabs"]);
-  // Framing an extension page from a web page needs it web-accessible. Only
-  // the page itself: its module imports are loaded by the extension, from the
-  // extension origin, and must NOT be exposed.
-  assert.deepEqual(manifest.web_accessible_resources,
-    [{ resources: ["picker.html"], matches: ["http://*/*", "https://*/*"] }]);
+  // Framing an extension page from a web page needs it web-accessible.
+  const [war] = manifest.web_accessible_resources;
+  assert.deepEqual(manifest.web_accessible_resources.length, 1);
+  assert.deepEqual(war.matches, ["http://*/*", "https://*/*"]);
+  // THE PRIMARY MITIGATION, ahead of the per-open id rather than instead of it.
+  // A static chrome-extension://<id>/picker.html is guessable, so any page
+  // could frame the picker and try to clickjack two clicks into a /mkdir and a
+  // /relocate. A dynamic URL rotates per session, so the page cannot construct
+  // the surface to load at all; the id stays as the authorisation check for
+  // anything that does get loaded.
+  assert.equal(war.use_dynamic_url, true);
+  // The framed page's OWN module graph has to be listed too: under a rotating
+  // origin its relative imports resolve against that origin, and an unlisted
+  // import would 404 -- which fails safe (gate 2 never fires, the worker opens
+  // a window) but would mean the overlay never worked at all.
+  assert.deepEqual(war.resources.slice().sort(),
+    ["picker.html", "picker.js", "route_core.js", "sanitize.js"]);
 });
 
 // --- the page can take the overlay away ------------------------------------- //

--- a/scripts/dl-router/tests/picker_overlay.test.mjs
+++ b/scripts/dl-router/tests/picker_overlay.test.mjs
@@ -205,6 +205,91 @@ test("the manifest delivers the overlay through the EXISTING content script", ()
     [{ resources: ["picker.html"], matches: ["http://*/*", "https://*/*"] }]);
 });
 
+// --- the page can take the overlay away ------------------------------------- //
+//
+// PINS ON A PERMISSIVE PATH. Gate 2 proves the frame booted; it proves nothing
+// a millisecond later. An overlay is a node in a document the extension does
+// not own, and the worker has ALREADY been told the picker was delivered. If
+// losing it were silent, the download would end up with no picker at all.
+
+test("a detached host is REPORTED, so the worker can re-ask in a window", () => {
+  const doc = freshDoc();
+  OV.openOverlay(doc, { id: "ov-a", url: URL_A });
+  const { host } = frameOf(doc);
+  assert.equal(OV.stillAttached(), true);
+
+  host.remove();                       // `body.innerHTML = ...`, a sanitiser,
+  assert.equal(OV.stillAttached(), false);   // an SPA re-render, or hostile JS
+
+  const lost = [];
+  assert.equal(OV.reportLostIfDetached((id) => lost.push(id)), true);
+  assert.deepEqual(lost, ["ov-a"]);
+  assert.equal(OV.hasOverlay(), false, "and it stops claiming to have one");
+});
+
+test("an attached overlay is NOT reported lost", () => {
+  const doc = freshDoc();
+  OV.openOverlay(doc, { id: "ov-a", url: URL_A });
+  const lost = [];
+  assert.equal(OV.reportLostIfDetached((id) => lost.push(id)), false);
+  assert.deepEqual(lost, []);
+  assert.equal(OV.hasOverlay(), true);
+});
+
+test("a detached host is reported exactly once", () => {
+  // Re-delivery must not produce two windows for one download.
+  const doc = freshDoc();
+  OV.openOverlay(doc, { id: "ov-a", url: URL_A });
+  frameOf(doc).host.remove();
+  const lost = [];
+  const notify = (id) => lost.push(id);
+  OV.reportLostIfDetached(notify);
+  OV.reportLostIfDetached(notify);
+  OV.reportLostIfDetached(notify);
+  assert.deepEqual(lost, ["ov-a"]);
+});
+
+test("a notify that throws does not wedge the content script", () => {
+  const doc = freshDoc();
+  OV.openOverlay(doc, { id: "ov-a", url: URL_A });
+  frameOf(doc).host.remove();
+  assert.equal(OV.reportLostIfDetached(() => { throw new Error("no worker"); }),
+    true);
+  assert.equal(OV.hasOverlay(), false);
+});
+
+test("the watcher is only armed while an overlay is live", () => {
+  // An always-on MutationObserver over every page the user visits is a real
+  // cost for no extra coverage; node has no MutationObserver, so the guard is
+  // what is asserted here.
+  const doc = freshDoc();
+  assert.equal(OV.watchAttachment(doc, () => {}), null,
+    "no MutationObserver, no watcher -- and no throw");
+  assert.equal(OV.watchAttachment(null, () => {}), null);
+});
+
+test("closing SWEEPS a stray host left by a previous injection", () => {
+  // The content script is re-injected on every navigation, so a re-injected
+  // copy has no record while a host element from before may still be in the
+  // document. Without the sweep the user faces a modal with no close button
+  // and no working Esc, and the only way out is a page reload.
+  const doc = freshDoc();
+  OV.openOverlay(doc, { id: "ov-a", url: URL_A });
+  OV.forget();                                   // as if freshly re-injected
+  assert.equal(OV.hasOverlay(), false);
+  // The fake's getElementById is id-keyed, so register the host under its id
+  // the way a real document would.
+  doc.els.set(OV.HOST_ID, doc.body.children[0]);
+  assert.deepEqual(OV.closeOverlay("ov-a", doc), { ok: true, swept: true });
+  assert.equal(doc.body.children.length, 0);
+});
+
+test("the sweep does not invent an overlay that was never there", () => {
+  const doc = freshDoc();
+  assert.deepEqual(OV.closeOverlay("ov-a", doc),
+    { ok: false, error: "no_overlay" });
+});
+
 test("the frame is focused, and again once it has loaded", () => {
   // The picker is keyboard-first. `input.focus()` inside the framed document
   // only moves focus WITHIN that document -- the frame element has to hold

--- a/scripts/dl-router/tests/picker_overlay.test.mjs
+++ b/scripts/dl-router/tests/picker_overlay.test.mjs
@@ -1,0 +1,221 @@
+// The in-page overlay content script: what it builds, and what it refuses.
+//
+// It deliberately contains NO picker logic -- it frames `picker.html`, which
+// runs the same `picker.js` and the same reducer. So the tests here are about
+// the delivery mechanism only: the closed shadow root, the frame's URL, one
+// overlay at a time, and the close protocol.
+//
+// Run: nix-shell -p nodejs --run "node --test 'scripts/dl-router/tests/*.test.mjs'"
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+globalThis.DL_ROUTER_NO_AUTOSTART = true;
+await import("../extension/picker_overlay.js");
+
+const OV = globalThis.__DLR_OVERLAY__;
+
+import { makeDoc } from "./fake_page.mjs";
+
+const URL_A = "chrome-extension://test/picker.html?id=7&embed=1&overlay=ov-a";
+
+function freshDoc() {
+  OV.forget();
+  return makeDoc([]);
+}
+
+function frameOf(doc) {
+  const host = doc.body.children[0];
+  return { host, shadow: host.shadowRoot,
+    frame: host.shadowRoot.children.find((c) => c.tagName === "iframe") };
+}
+
+test("the module exposes its pure functions without installing listeners", () => {
+  assert.equal(typeof OV.openOverlay, "function");
+  assert.equal(typeof OV.closeOverlay, "function");
+  assert.equal(typeof OV.handleMessage, "function");
+});
+
+test("opening builds a host with a frame pointing at the picker page", () => {
+  const doc = freshDoc();
+  const out = OV.openOverlay(doc, { type: "dlr:overlay-open", id: "ov-a",
+    url: URL_A });
+  assert.deepEqual(out, { ok: true, id: "ov-a" });
+  const { host, frame } = frameOf(doc);
+  assert.equal(host.getAttribute("id"), OV.HOST_ID);
+  assert.equal(frame.getAttribute("src"), URL_A);
+  assert.ok(OV.hasOverlay());
+});
+
+test("THE SHADOW ROOT IS CLOSED", () => {
+  // Not cosmetic. The frame's URL carries the per-open nonce the service worker
+  // matches on, and a page that could read it out of an open shadow root could
+  // forge `dlr:picker-closed` and quietly discard the pick.
+  const doc = freshDoc();
+  OV.openOverlay(doc, { id: "ov-a", url: URL_A });
+  assert.equal(frameOf(doc).shadow.mode, "closed");
+});
+
+test("the host is positioned inline and !important", () => {
+  // The host is the ONE node the page's stylesheets can see and match on, so
+  // its geometry cannot live in the shadow stylesheet.
+  const doc = freshDoc();
+  OV.openOverlay(doc, { id: "ov-a", url: URL_A });
+  const style = frameOf(doc).host.getAttribute("style");
+  assert.match(style, /position: fixed !important/);
+  assert.match(style, /z-index: 2147483647 !important/);
+});
+
+test("the shadow stylesheet honours prefers-reduced-motion", () => {
+  const doc = freshDoc();
+  OV.openOverlay(doc, { id: "ov-a", url: URL_A });
+  const css = frameOf(doc).shadow.children
+    .find((c) => c.tagName === "style").textContent;
+  assert.match(css, /animation: dlr-overlay-in/);
+  assert.match(css, /prefers-reduced-motion/);
+});
+
+test("opening twice REPLACES rather than stacks", () => {
+  // Two pickers for one download would make it ambiguous which one an Enter
+  // answers -- and the reducer has no notion of "which download", because the
+  // id is baked into the frame's URL.
+  const doc = freshDoc();
+  OV.openOverlay(doc, { id: "ov-a", url: URL_A });
+  OV.openOverlay(doc, { id: "ov-b", url: "chrome-extension://test/picker.html?x" });
+  assert.equal(doc.body.children.length, 1);
+  assert.equal(frameOf(doc).frame.getAttribute("src"),
+    "chrome-extension://test/picker.html?x");
+});
+
+test("a malformed open is refused rather than half-built", () => {
+  const doc = freshDoc();
+  for (const msg of [null, {}, { id: "ov-a" }, { url: URL_A },
+    { id: "", url: URL_A }, { id: "ov-a", url: "" },
+    { id: 7, url: URL_A }]) {
+    assert.equal(OV.openOverlay(doc, msg).ok, false, JSON.stringify(msg));
+  }
+  assert.equal(doc.body.children.length, 0);
+  assert.equal(OV.hasOverlay(), false);
+});
+
+test("a DOM that cannot host the overlay is a clean false, not a throw", () => {
+  // The service worker's whole fallback depends on this never throwing.
+  OV.forget();
+  const broken = { createElement: () => { throw new Error("no"); }, body: null };
+  assert.deepEqual(OV.openOverlay(broken, { id: "ov-a", url: URL_A }),
+    { ok: false, error: "create_failed" });
+  assert.equal(OV.hasOverlay(), false);
+});
+
+test("closing removes the host", () => {
+  const doc = freshDoc();
+  OV.openOverlay(doc, { id: "ov-a", url: URL_A });
+  assert.deepEqual(OV.closeOverlay("ov-a"), { ok: true });
+  assert.equal(doc.body.children.length, 0);
+  assert.equal(OV.hasOverlay(), false);
+});
+
+test("a STALE close is a no-op, not a blind teardown", () => {
+  // A close for a previous overlay must not remove a picker that a later
+  // download legitimately opened.
+  const doc = freshDoc();
+  OV.openOverlay(doc, { id: "ov-b", url: URL_A });
+  assert.deepEqual(OV.closeOverlay("ov-a"), { ok: false, error: "stale" });
+  assert.equal(doc.body.children.length, 1);
+});
+
+test("closing when there is nothing open says so", () => {
+  OV.forget();
+  assert.deepEqual(OV.closeOverlay("ov-a"), { ok: false, error: "no_overlay" });
+});
+
+test("handleMessage routes exactly the two overlay messages", () => {
+  const doc = freshDoc();
+  const replies = [];
+  const reply = (r) => replies.push(r);
+
+  OV.handleMessage(doc, { type: "dlr:overlay-open", id: "ov-a", url: URL_A },
+    reply);
+  assert.deepEqual(replies[0], { ok: true, id: "ov-a" });
+
+  OV.handleMessage(doc, { type: "dlr:close-overlay", overlay: "ov-a" }, reply);
+  assert.deepEqual(replies[1], { ok: true });
+
+  // Anything else is left alone -- content_capture.js and the picker share this
+  // message bus.
+  for (const msg of [null, "nope", { type: "dlr:capture" },
+    { type: "dlr:choose" }]) {
+    assert.equal(OV.handleMessage(doc, msg, reply), false);
+  }
+  assert.equal(replies.length, 2, "no stray replies");
+});
+
+test("handleMessage never returns true (it answers synchronously)", () => {
+  // Returning true would hold the message channel open waiting for a response
+  // that already went out, and Chrome would log a dangling-port error.
+  const doc = freshDoc();
+  assert.equal(
+    OV.handleMessage(doc, { type: "dlr:overlay-open", id: "ov-a", url: URL_A },
+      () => {}), false);
+});
+
+test("only the top frame paints an overlay", () => {
+  // `all_frames: true` is for the capture script; a picker in every iframe of a
+  // page would be absurd.
+  const top = {};
+  top.top = top;
+  top.self = top;
+  assert.equal(OV.isTopFrame(top), true);
+  assert.equal(OV.isTopFrame({ top: {}, self: {} }), false);
+  assert.equal(OV.isTopFrame(null), false);
+  assert.equal(OV.isTopFrame({ get top() { throw new Error("cross-origin"); } }),
+    false);
+});
+
+test("the overlay script reimplements none of the picker", () => {
+  // The architectural line this file exists to hold: the overlay and the
+  // window must share ONE reducer, and the way that is guaranteed is that the
+  // overlay frames the picker page rather than rendering a list itself.
+  // safety.py/sanitize.js already paid for a second implementation once.
+  const src = readFileSync(new URL("../extension/picker_overlay.js",
+    import.meta.url), "utf8");
+  for (const forbidden of ["filterEntries", "reduce(", "ArrowDown",
+    "dlr:choose", "titleCase", "ENTRY_NEW"]) {
+    assert.equal(src.includes(forbidden), false,
+      `picker_overlay.js must not contain ${forbidden}`);
+  }
+  // What it DOES do: frame whatever URL the worker hands it.
+  assert.match(src, /createElement\("iframe"\)/);
+});
+
+test("the manifest delivers the overlay through the EXISTING content script", () => {
+  // No new permissions: the overlay rides the declaration content_capture.js
+  // already has. If that ever changes, this is where it becomes visible.
+  const manifest = JSON.parse(readFileSync(
+    new URL("../extension/manifest.json", import.meta.url), "utf8"));
+  const [cs] = manifest.content_scripts;
+  assert.deepEqual(cs.matches, ["http://*/*", "https://*/*"]);
+  assert.deepEqual(cs.js, ["content_capture.js", "picker_overlay.js"]);
+  assert.deepEqual(manifest.permissions.slice().sort(),
+    ["alarms", "contextMenus", "downloads", "notifications", "storage", "tabs"]);
+  // Framing an extension page from a web page needs it web-accessible. Only
+  // the page itself: its module imports are loaded by the extension, from the
+  // extension origin, and must NOT be exposed.
+  assert.deepEqual(manifest.web_accessible_resources,
+    [{ resources: ["picker.html"], matches: ["http://*/*", "https://*/*"] }]);
+});
+
+test("the frame is focused, and again once it has loaded", () => {
+  // The picker is keyboard-first. `input.focus()` inside the framed document
+  // only moves focus WITHIN that document -- the frame element has to hold
+  // focus for keystrokes to reach it. Without this the user would have to click
+  // the overlay before typing, which the popup window never required.
+  const doc = freshDoc();
+  OV.openOverlay(doc, { id: "ov-a", url: URL_A });
+  const { frame } = frameOf(doc);
+  assert.equal(frame.focused, true);
+  assert.ok(frame.listeners.has("load"), "and re-focused when it loads");
+  frame.focused = false;
+  frame.fire("load");
+  assert.equal(frame.focused, true);
+});

--- a/scripts/dl-router/tests/service_worker.test.mjs
+++ b/scripts/dl-router/tests/service_worker.test.mjs
@@ -16,7 +16,7 @@ globalThis.DL_ROUTER_NO_AUTOSTART = true;
 const calls = {
   windowsCreate: [], notifications: [], downloads: [], search: [],
   fetches: [], menus: [], tabsGet: [], tabMessages: [],
-  tabsUpdate: [], windowsUpdate: [],
+  tabsUpdate: [], windowsUpdate: [], tabListeners: [],
 };
 let storageLocal = {};
 let storageSession = {};
@@ -121,6 +121,11 @@ globalThis.chrome = {
       return { ok: true };
     },
     onActivated: { addListener() {} },
+    // Registered by registerListeners so an overlay whose tab dies becomes a
+    // window again. Present here so that registration is real, not a silent
+    // no-op swallowed by its try/catch.
+    onRemoved: { addListener: (fn) => calls.tabListeners.push(["removed", fn]) },
+    onUpdated: { addListener: (fn) => calls.tabListeners.push(["updated", fn]) },
   },
   alarms: { create() {}, onAlarm: { addListener() {} } },
 };
@@ -1806,12 +1811,11 @@ test("A PICK FROM AN UNRECOGNISED SUBFRAME IS REFUSED", async () => {
   // made two blind clicks enough.
   reset();
   let answer = null;
-  const handled = SW.onMessage(
+  SW.onMessage(
     { type: "dlr:choose", downloadId: 1, dir: "Evil", createdNew: true,
       kind: "performer" },
     { frameId: 3, tab: { id: 42 } }, (r) => { answer = r; });
-  await settle();
-  assert.equal(handled, false, "answered synchronously, nothing dispatched");
+  await settle(20);
   assert.equal(answer.ok, false);
   assert.match(answer.error, /unrecognised frame/);
   assert.equal(calls.fetches.length, 0, "no /mkdir, no /relocate, no /learn");
@@ -1860,4 +1864,108 @@ test("a sender with no frame information at all is still served", async () => {
     (r) => { answer = r; });
   await settle(20);
   assert.equal(answer.ok, true);
+});
+
+// --- the registry must outlive the ~30s MV3 idle teardown ------------------- //
+//
+// Choosing a directory is the SLOWEST thing the user does here, so the picker
+// routinely outlives the worker that opened it. Every consumer of the overlay
+// registry therefore has to read the durable copy, or it reasons from an empty
+// Map on exactly the path that matters most.
+
+/** The worker being torn down and woken: memory gone, storage.session kept. */
+const tearDownWorker = () => SW.state.overlays.clear();
+
+test("A LEGITIMATE PICK SURVIVES AN MV3 TEARDOWN", async () => {
+  // THE regression. `state.overlays` is in-memory and nothing repopulated it on
+  // wake, so after ~30 s the anti-clickjack guard saw an empty registry and
+  // refused a real pick -- discarding the user's choice precisely when they had
+  // been deliberating longest. Same shape as the screened-refusal suppression
+  // map: a fact that must outlive a teardown does not live in worker memory.
+  const id = await liveOverlay();
+  await settle();
+  tearDownWorker();
+  assert.equal(SW.state.overlays.size, 0, "the worker really did lose it");
+
+  searchResult = [];
+  let answer = null;
+  SW.onMessage({ type: "dlr:choose", downloadId: 1, dir: "Jane Doe",
+    overlay: id }, { frameId: 7, tab: { id: 42 } }, (r) => { answer = r; });
+  await settle(20);
+  assert.equal(answer.ok, true, answer && answer.error);
+  assert.equal(answer.dir, "Jane Doe");
+});
+
+test("...but a forged id still cannot get through after one", async () => {
+  // The counterweight: restoring the durable copy must not degrade into a
+  // blanket allow. Delete the guard entirely and the test above still passes;
+  // this is the one that notices.
+  await liveOverlay();
+  await settle();
+  tearDownWorker();
+  let answer = null;
+  SW.onMessage({ type: "dlr:choose", downloadId: 1, dir: "Evil",
+    overlay: "ov-guessed" }, { frameId: 7, tab: { id: 42 } },
+  (r) => { answer = r; });
+  await settle(20);
+  assert.equal(answer.ok, false);
+  assert.match(answer.error, /unrecognised frame/);
+  assert.equal(calls.fetches.length, 0);
+});
+
+test("the tab watchers survive a teardown too", async () => {
+  // Otherwise a tab closing after the worker slept finds no overlay to rescue,
+  // and the download is left with no picker at all -- the same invariant, one
+  // wake later.
+  await liveOverlay();
+  await settle();
+  tearDownWorker();
+  await SW.onTabRemoved(42);
+  await settle();
+  assert.equal(calls.windowsCreate.length, 1, "the question is re-asked");
+});
+
+test("a navigation after a teardown re-asks too", async () => {
+  await liveOverlay();
+  await settle();
+  tearDownWorker();
+  await SW.onTabUpdated(42, { status: "loading" });
+  await settle();
+  assert.equal(calls.windowsCreate.length, 1);
+});
+
+test("restoreOverlays never clobbers an overlay opened this turn", async () => {
+  const live = await liveOverlay({ downloadId: 2, tabId: 43 });
+  await settle();
+  // A durable copy that disagrees about the live overlay, plus one the worker
+  // has genuinely forgotten. The live record must win; the forgotten one must
+  // come back.
+  storageSession.overlays = [
+    [live, { tabId: 999, downloadId: 999, info: { downloadId: 999 } }],
+    ["ov-older", { tabId: 42, downloadId: 1, info: { downloadId: 1 } }],
+  ];
+  await SW.restoreOverlays();
+  assert.equal(SW.state.overlays.get(live).tabId, 43, "the live one wins");
+  assert.equal(SW.state.overlays.has("ov-older"), true, "the other is restored");
+});
+
+test("a corrupt durable copy is ignored rather than trusted", async () => {
+  reset();
+  storageSession.overlays = ["nope", null, [1, 2], ["ov-x", "not-an-object"]];
+  await SW.restoreOverlays();
+  assert.equal(SW.state.overlays.size, 0);
+  storageSession.overlays = { not: "an array" };
+  await SW.restoreOverlays();
+  assert.equal(SW.state.overlays.size, 0);
+});
+
+test("registerListeners really registers the tab watchers", () => {
+  // They sit inside a try/catch for older shapes, which is exactly how a
+  // registration can silently become a no-op.
+  reset();
+  calls.tabListeners.length = 0;
+  SW.registerListeners();
+  const kinds = calls.tabListeners.map(([k]) => k);
+  assert.ok(kinds.includes("removed"), "tabs.onRemoved");
+  assert.ok(kinds.includes("updated"), "tabs.onUpdated");
 });

--- a/scripts/dl-router/tests/service_worker.test.mjs
+++ b/scripts/dl-router/tests/service_worker.test.mjs
@@ -15,13 +15,24 @@ globalThis.DL_ROUTER_NO_AUTOSTART = true;
 // --- chrome mock ------------------------------------------------------------ //
 const calls = {
   windowsCreate: [], notifications: [], downloads: [], search: [],
-  fetches: [], menus: [],
+  fetches: [], menus: [], tabsGet: [], tabMessages: [],
 };
 let storageLocal = {};
 let storageSession = {};
 let searchResult = [];
 let windowsCreateFails = false;
 let notificationsFail = false;
+
+// --- the in-page overlay path ----------------------------------------------- //
+// Defaults reproduce "this tab cannot host an overlay", so every pre-existing
+// picker test keeps asserting the popup-window fallback it was written for.
+// The overlay tests opt in explicitly.
+let tabUrl = "https://example-site.test/v/1";
+let tabDiscarded = false;
+let tabsGetFails = false;
+let contentScriptMissing = true;    // sendMessage rejects: no receiving end
+let overlayOpenResult = { ok: true };
+let overlayReports = "ready";       // "ready" | "silent"
 
 globalThis.chrome = {
   storage: {
@@ -70,7 +81,36 @@ globalThis.chrome = {
     create: (o) => calls.menus.push(o),
     onClicked: { addListener() {} },
   },
-  tabs: { query: async () => [], onActivated: { addListener() {} } },
+  tabs: {
+    query: async () => [],
+    get: async (id) => {
+      calls.tabsGet.push(id);
+      // Chrome rejects for a tab that no longer exists -- the self-closing
+      // file-host tab, which is a real case in this workflow.
+      if (tabsGetFails) throw new Error("No tab with id: " + id);
+      return { id, url: tabUrl, discarded: tabDiscarded };
+    },
+    sendMessage: async (id, msg, opts) => {
+      calls.tabMessages.push({ id, msg, opts });
+      if (msg && msg.type === "dlr:overlay-open") {
+        if (contentScriptMissing) {
+          throw new Error("Could not establish connection. "
+            + "Receiving end does not exist.");
+        }
+        // The frame booted and announced itself, via the same message the real
+        // picker page sends. WHEN it announces is a genuine race: the content
+        // script returns as soon as the DOM nodes exist, and the frame's boot
+        // is a separate round trip that can land on either side of that.
+        const announce = () => SW.onMessage(
+          { type: "dlr:picker-ready", overlay: msg.id }, {}, () => {});
+        if (overlayReports === "ready") queueMicrotask(announce);   // early
+        if (overlayReports === "ready-late") setTimeout(announce, 5);
+        return overlayOpenResult;
+      }
+      return { ok: true };
+    },
+    onActivated: { addListener() {} },
+  },
   alarms: { create() {}, onAlarm: { addListener() {} } },
 };
 
@@ -114,6 +154,13 @@ function reset({ enabled = true, snapshot = SNAPSHOT } = {}) {
   searchResult = [];
   windowsCreateFails = false;
   notificationsFail = false;
+  tabUrl = "https://example-site.test/v/1";
+  tabDiscarded = false;
+  tabsGetFails = false;
+  contentScriptMissing = true;
+  overlayOpenResult = { ok: true };
+  overlayReports = "ready";
+  SW.state.overlays.clear();
   SW.state.config = { port: 8791, token: "tok", enabled };
   SW.state.configLoaded = true;
   SW.state.pendingFetch.clear();
@@ -1306,4 +1353,292 @@ test("a refusal with no `first` field at all still notifies", () => {
     dir: "Jane Doe", written: [],
     skipped: [{ key: "jd", source: "tag", why: "too short" }],
   }), true);
+});
+
+// --- the picker as an in-page overlay, with the window as the fallback ------- //
+//
+// The overlay and the window run the SAME picker page and therefore the same
+// reducer -- there is no second implementation to keep in step. What is tested
+// here is only the delivery decision and, above all, that EVERY failure mode
+// reaches the window rather than leaving a download with no picker.
+
+const overlayOpen = () =>
+  calls.tabMessages.find((m) => m.msg.type === "dlr:overlay-open");
+const overlayClose = () =>
+  calls.tabMessages.find((m) => m.msg.type === "dlr:close-overlay");
+
+test("a page that can host it gets the picker in-page, with no popup window",
+  async () => {
+    reset();
+    contentScriptMissing = false;
+    SW.state.activeTabId = 42;
+    assert.equal(await SW.openPicker({ downloadId: 1, dir: "other",
+      reason: "no match", suggestNew: "Aster Vale" }), true);
+    assert.equal(calls.windowsCreate.length, 0, "no popup window");
+    const open = overlayOpen();
+    assert.equal(open.id, 42);
+    // Top frame only: `all_frames` is for the capture script.
+    assert.deepEqual(open.opts, { frameId: 0 });
+  });
+
+test("the overlay's URL is the picker page, marked embedded, with a nonce",
+  async () => {
+    reset();
+    contentScriptMissing = false;
+    SW.state.activeTabId = 42;
+    await SW.openPicker({ downloadId: 7, dir: "other", reason: "r",
+      dup: "d", suggestNew: "Aster Vale" });
+    const url = new URL(overlayOpen().msg.url);
+    assert.match(url.pathname, /picker\.html$/);
+    assert.equal(url.searchParams.get("id"), "7");
+    assert.equal(url.searchParams.get("suggestNew"), "Aster Vale");
+    assert.equal(url.searchParams.get("embed"), "1");
+    const nonce = url.searchParams.get("overlay");
+    assert.ok(nonce && nonce.length >= 8, "a per-open id the page cannot guess");
+    assert.equal(overlayOpen().msg.id, nonce);
+  });
+
+test("the popup window carries no embed marker", async () => {
+  // It CAN close its own window, and must not ask the worker to tear down an
+  // overlay that does not exist.
+  reset();
+  await SW.openPicker({ downloadId: 7, dir: "other", reason: "r" });
+  const url = new URL(calls.windowsCreate[0].url);
+  assert.equal(url.searchParams.get("embed"), null);
+  assert.equal(url.searchParams.get("overlay"), null);
+});
+
+test("the overlay goes to the tab the download came from, not the active tab",
+  async () => {
+    reset();
+    contentScriptMissing = false;
+    SW.state.activeTabId = 42;
+    SW.state.pending.set(5, { dir: "other", tabId: 11 });
+    await SW.openPicker({ downloadId: 5, dir: "other", reason: "r" });
+    assert.equal(overlayOpen().id, 11);
+  });
+
+// --- every fallback route --------------------------------------------------- //
+test("a tab that has already closed falls back to a window", async () => {
+  // The self-closing file-host tab: a real case in this workflow.
+  reset();
+  contentScriptMissing = false;
+  tabsGetFails = true;
+  SW.state.activeTabId = 42;
+  assert.equal(await SW.openPicker({ downloadId: 1, dir: "other" }), true);
+  assert.equal(calls.windowsCreate.length, 1);
+  assert.equal(overlayOpen(), undefined, "not even probed");
+});
+
+test("a discarded tab falls back to a window", async () => {
+  reset();
+  contentScriptMissing = false;
+  tabDiscarded = true;
+  SW.state.activeTabId = 42;
+  await SW.openPicker({ downloadId: 1, dir: "other" });
+  assert.equal(calls.windowsCreate.length, 1);
+});
+
+test("with no tab to inject into at all, a window", async () => {
+  reset();
+  contentScriptMissing = false;
+  SW.state.activeTabId = undefined;
+  SW.state.pending.clear();
+  await SW.openPicker({ downloadId: 1, dir: "other" });
+  assert.equal(calls.windowsCreate.length, 1);
+  assert.equal(calls.tabsGet.length, 0);
+});
+
+test("no content script in the tab falls back to a window", async () => {
+  // ONE check covering brave://, the PDF viewer (an https URL whose document is
+  // a plugin), view-source:, file://, and a page that has not reached
+  // document_idle: chrome.tabs.sendMessage rejects with "receiving end does not
+  // exist". That is why the URL test below is only a shortcut, never the proof.
+  reset();
+  contentScriptMissing = true;
+  SW.state.activeTabId = 42;
+  assert.equal(await SW.openPicker({ downloadId: 1, dir: "other" }), true);
+  assert.ok(overlayOpen(), "it was probed");
+  assert.equal(calls.windowsCreate.length, 1, "and fell back");
+});
+
+test("a content script that refuses to build falls back to a window", async () => {
+  reset();
+  contentScriptMissing = false;
+  overlayOpenResult = { ok: false, error: "create_failed" };
+  SW.state.activeTabId = 42;
+  await SW.openPicker({ downloadId: 1, dir: "other" });
+  assert.equal(calls.windowsCreate.length, 1);
+});
+
+test("GATE 2: a frame that never reports ready falls back, husk torn down first",
+  async () => {
+    // A content-script-injected iframe is subject to the PAGE's CSP, so a site
+    // with a strict `frame-src` blocks the load while every DOM call in the
+    // content script still succeeds. Without this gate the user would be left
+    // looking at an empty overlay and no picker at all.
+    reset();
+    contentScriptMissing = false;
+    overlayReports = "silent";
+    SW.state.activeTabId = 42;
+    assert.equal(await SW.openPicker({ downloadId: 1, dir: "other" }), true);
+    assert.ok(overlayClose(), "the empty overlay is removed");
+    assert.equal(calls.windowsCreate.length, 1, "and a window opens");
+    assert.equal(SW.state.overlays.size, 0);
+  });
+
+test("NOTHING leaves a download without a picker", async () => {
+  // The last rung: no overlay, no window -- a notification.
+  reset();
+  contentScriptMissing = true;
+  windowsCreateFails = true;
+  SW.state.activeTabId = 42;
+  await SW.openPicker({ downloadId: 1, dir: "other", reason: "no match" });
+  assert.equal(calls.notifications.length, 1);
+});
+
+test("an overlay that throws unexpectedly still reaches the window", async () => {
+  // openPicker's contract: openOverlayPicker may fail in any way at all.
+  reset();
+  const realGet = chrome.tabs.get;
+  chrome.tabs.get = async () => { throw { nope: true }; };  // not an Error
+  SW.state.activeTabId = 42;
+  try {
+    assert.equal(await SW.openPicker({ downloadId: 1, dir: "other" }), true);
+    assert.equal(calls.windowsCreate.length, 1);
+  } finally {
+    chrome.tabs.get = realGet;
+  }
+});
+
+// --- closing ---------------------------------------------------------------- //
+test("dlr:picker-closed tears the overlay down in the tab it was opened in",
+  async () => {
+    reset();
+    contentScriptMissing = false;
+    SW.state.activeTabId = 42;
+    await SW.openPicker({ downloadId: 1, dir: "other" });
+    const nonce = overlayOpen().msg.id;
+    assert.equal(SW.state.overlays.size, 1);
+    SW.onMessage({ type: "dlr:picker-closed", overlay: nonce }, {}, () => {});
+    await settle();
+    const close = overlayClose();
+    assert.equal(close.id, 42);
+    assert.equal(close.msg.overlay, nonce);
+    assert.equal(SW.state.overlays.size, 0);
+  });
+
+test("dlr:picker-closed survives an MV3 teardown via sender.tab.id", async () => {
+  // The picker can sit open well past the ~30 s idle timeout. A restarted
+  // worker has an empty `state.overlays`, so keying only on that map would
+  // leave the overlay on screen forever with nothing able to remove it.
+  reset();
+  SW.state.overlays.clear();
+  SW.onMessage({ type: "dlr:picker-closed", overlay: "ov-gone" },
+    { tab: { id: 77 } }, () => {});
+  await settle();
+  const close = overlayClose();
+  assert.equal(close.id, 77);
+  assert.equal(close.msg.overlay, "ov-gone");
+});
+
+test("dlr:picker-closed with nothing to go on is a silent no-op", async () => {
+  reset();
+  SW.state.overlays.clear();
+  assert.equal(
+    SW.onMessage({ type: "dlr:picker-closed", overlay: "ov-gone" }, {},
+      () => {}), false);
+  await settle();
+  assert.equal(overlayClose(), undefined);
+});
+
+test("dlr:picker-ready answers synchronously and holds no channel open", () => {
+  // It must not await ready(): the whole point is to answer inside the
+  // readiness budget the open path is waiting on.
+  reset();
+  assert.equal(
+    SW.onMessage({ type: "dlr:picker-ready", overlay: "ov-x" }, {}, () => {}),
+    false);
+});
+
+// --- the URL shortcut ------------------------------------------------------- //
+test("overlayCapableUrl rejects what a content script provably never sees", () => {
+  for (const url of ["https://example-site.test/v/1",
+    "http://example-site.test/v/1"]) {
+    assert.equal(SW.overlayCapableUrl(url), true, url);
+  }
+  for (const url of ["brave://newtab/", "chrome://extensions/",
+    "chrome-extension://abc/picker.html", "view-source:https://x.test/",
+    "file:///home/u/a.pdf", "about:blank", "",
+    "https://chromewebstore.google.com/detail/x",
+    "https://chrome.google.com/webstore/detail/x", null, undefined, 7]) {
+    assert.equal(SW.overlayCapableUrl(url), false, String(url));
+  }
+});
+
+test("a brave:// tab is not even probed", async () => {
+  reset();
+  contentScriptMissing = false;
+  tabUrl = "brave://settings/downloads";
+  SW.state.activeTabId = 42;
+  await SW.openPicker({ downloadId: 1, dir: "other" });
+  assert.equal(overlayOpen(), undefined);
+  assert.equal(calls.windowsCreate.length, 1);
+});
+
+// --- the snapshot freshness flag -------------------------------------------- //
+test("THE PICKER'S SNAPSHOT REQUEST DOES NOT REVALIDATE", async () => {
+  // The pin on the other half of the ETag decision. The sidecar keeps the
+  // per-directory counts OUT of the etag, so a 304 would hand the picker a
+  // stale tally -- frozen until the routing configuration next changed. This
+  // one request skips If-None-Match; add it back and this fails.
+  reset();
+  fetchHandler = async () => ({ ok: true, status: 200,
+    json: async () => SNAPSHOT });
+  SW.onMessage({ type: "dlr:snapshot" }, {}, () => {});
+  await settle();
+  const dirsFetch = calls.fetches.find((f) => f.url.endsWith("/dirs"));
+  assert.equal(dirsFetch.opts.headers["If-None-Match"], undefined);
+});
+
+test("but everything else still revalidates", async () => {
+  // The counterweight: `revalidate: false` must not have leaked into the
+  // five-minute alarm, startup, or the post-/mkdir refresh, or the steady-state
+  // traffic would become a full refetch every five minutes.
+  reset();
+  fetchHandler = async () => ({ ok: true, status: 304, json: async () => ({}) });
+  await SW.refreshSnapshot();
+  assert.equal(calls.fetches[0].opts.headers["If-None-Match"], '"abc123"');
+});
+
+test("the counts ride through to the picker", async () => {
+  reset();
+  const withCounts = { ...SNAPSHOT, counts: { "Jane Doe": 12 } };
+  fetchHandler = async () => ({ ok: true, status: 200,
+    json: async () => withCounts });
+  let answer = null;
+  SW.onMessage({ type: "dlr:snapshot" }, {}, (r) => { answer = r; });
+  await settle();
+  assert.deepEqual(answer.snapshot.counts, { "Jane Doe": 12 });
+});
+
+test("a `ready` that beats the probe's own answer is not lost", async () => {
+  // The readiness wait is armed BEFORE the open message goes out, precisely so
+  // this ordering works. Arming it afterwards drops the signal and falls back
+  // to a popup window for no reason -- intermittently, which is the worst kind.
+  reset();
+  contentScriptMissing = false;
+  overlayReports = "ready";      // announces in a microtask, before the send
+  SW.state.activeTabId = 42;                                   // has resolved
+  assert.equal(await SW.openPicker({ downloadId: 1, dir: "other" }), true);
+  assert.equal(calls.windowsCreate.length, 0);
+});
+
+test("...and so is one that arrives after it", async () => {
+  reset();
+  contentScriptMissing = false;
+  overlayReports = "ready-late";
+  SW.state.activeTabId = 42;
+  assert.equal(await SW.openPicker({ downloadId: 1, dir: "other" }), true);
+  assert.equal(calls.windowsCreate.length, 0);
 });

--- a/scripts/dl-router/tests/service_worker.test.mjs
+++ b/scripts/dl-router/tests/service_worker.test.mjs
@@ -16,6 +16,7 @@ globalThis.DL_ROUTER_NO_AUTOSTART = true;
 const calls = {
   windowsCreate: [], notifications: [], downloads: [], search: [],
   fetches: [], menus: [], tabsGet: [], tabMessages: [],
+  tabsUpdate: [], windowsUpdate: [],
 };
 let storageLocal = {};
 let storageSession = {};
@@ -32,7 +33,8 @@ let tabDiscarded = false;
 let tabsGetFails = false;
 let contentScriptMissing = true;    // sendMessage rejects: no receiving end
 let overlayOpenResult = { ok: true };
-let overlayReports = "ready";       // "ready" | "silent"
+let overlayReports = "ready";       // "ready" | "ready-late" | "silent"
+let tabsUpdateFails = false;
 
 globalThis.chrome = {
   storage: {
@@ -61,6 +63,10 @@ globalThis.chrome = {
       if (windowsCreateFails) throw new Error("no window");
       return { id: 900 + calls.windowsCreate.length };
     },
+    update: async (id, info) => {
+      calls.windowsUpdate.push({ id, info });
+      return { id };
+    },
     onRemoved: { addListener() {} },
   },
   notifications: {
@@ -88,7 +94,12 @@ globalThis.chrome = {
       // Chrome rejects for a tab that no longer exists -- the self-closing
       // file-host tab, which is a real case in this workflow.
       if (tabsGetFails) throw new Error("No tab with id: " + id);
-      return { id, url: tabUrl, discarded: tabDiscarded };
+      return { id, url: tabUrl, discarded: tabDiscarded, windowId: 5 };
+    },
+    update: async (id, info) => {
+      calls.tabsUpdate.push({ id, info });
+      if (tabsUpdateFails) throw new Error("no such tab");
+      return { id };
     },
     sendMessage: async (id, msg, opts) => {
       calls.tabMessages.push({ id, msg, opts });
@@ -160,6 +171,7 @@ function reset({ enabled = true, snapshot = SNAPSHOT } = {}) {
   contentScriptMissing = true;
   overlayOpenResult = { ok: true };
   overlayReports = "ready";
+  tabsUpdateFails = false;
   SW.state.overlays.clear();
   SW.state.config = { port: 8791, token: "tok", enabled };
   SW.state.configLoaded = true;
@@ -1641,4 +1653,211 @@ test("...and so is one that arrives after it", async () => {
   SW.state.activeTabId = 42;
   assert.equal(await SW.openPicker({ downloadId: 1, dir: "other" }), true);
   assert.equal(calls.windowsCreate.length, 0);
+});
+
+// --- AN OVERLAY THAT STOPS EXISTING BECOMES A WINDOW ------------------------ //
+//
+// PINS ON THE PERMISSIVE PATH. Gate 2 proves the frame booted; it proves
+// nothing a millisecond later, and `openPicker` has already returned true. The
+// overlay lives in a document the extension does not own, so every way it can
+// vanish needs a route back to a window -- or the download is left unasked,
+// which is the one outcome that is not allowed.
+
+async function liveOverlay({ downloadId = 1, tabId = 42 } = {}) {
+  reset();
+  contentScriptMissing = false;
+  SW.state.activeTabId = tabId;
+  await SW.openPicker({ downloadId, dir: "other", reason: "no match",
+    suggestNew: "Aster Vale" });
+  assert.equal(calls.windowsCreate.length, 0, "precondition: overlay is up");
+  return overlayOpen().msg.id;
+}
+
+test("the tab holding the overlay CLOSES -> the picker comes back as a window",
+  async () => {
+    // The self-closing file-host tab, arriving one beat later than the version
+    // chrome.tabs.get catches.
+    const id = await liveOverlay();
+    SW.onTabRemoved(42);
+    await settle();
+    assert.equal(calls.windowsCreate.length, 1, "the question is re-asked");
+    assert.equal(SW.state.overlays.size, 0);
+    // ...as the SAME question: same download, same proposal.
+    const url = new URL(calls.windowsCreate[0].url);
+    assert.equal(url.searchParams.get("id"), "1");
+    assert.equal(url.searchParams.get("suggestNew"), "Aster Vale");
+    assert.equal(url.searchParams.get("embed"), null, "and as a real window");
+    assert.equal(SW.state.overlays.has(id), false);
+  });
+
+test("the tab NAVIGATES -> the picker comes back as a window", async () => {
+  await liveOverlay();
+  SW.onTabUpdated(42, { status: "loading" });
+  await settle();
+  assert.equal(calls.windowsCreate.length, 1);
+  assert.equal(SW.state.overlays.size, 0);
+});
+
+test("a SPA route change does NOT yank the picker into a window", async () => {
+  // pushState fires onUpdated with a url but no `status`, and the document is
+  // not replaced -- the overlay is still there and still usable. Re-delivering
+  // on every route change would be a regression, not a rescue.
+  await liveOverlay();
+  SW.onTabUpdated(42, { url: "https://example-site.test/v/2" });
+  SW.onTabUpdated(42, { status: "complete" });
+  SW.onTabUpdated(42, { title: "something" });
+  await settle();
+  assert.equal(calls.windowsCreate.length, 0);
+  assert.equal(SW.state.overlays.size, 1);
+});
+
+test("the PAGE removes the overlay -> the picker comes back as a window",
+  async () => {
+    // `document.body.innerHTML = ...`, a DOM sanitiser, a framework re-render,
+    // or hostile script. The content script reports it; this is the other half.
+    const id = await liveOverlay();
+    SW.onMessage({ type: "dlr:overlay-lost", overlay: id }, {}, () => {});
+    await settle();
+    assert.equal(calls.windowsCreate.length, 1);
+    assert.equal(SW.state.overlays.size, 0);
+  });
+
+test("events for OTHER tabs leave the overlay alone", async () => {
+  await liveOverlay({ tabId: 42 });
+  SW.onTabRemoved(99);
+  SW.onTabUpdated(99, { status: "loading" });
+  await settle();
+  assert.equal(calls.windowsCreate.length, 0);
+  assert.equal(SW.state.overlays.size, 1);
+});
+
+test("re-delivery is idempotent: two triggers, ONE window", async () => {
+  // onRemoved and onUpdated can both fire for a closing tab, and the page can
+  // report the loss at the same moment. Two pickers for one download would be
+  // worse than none.
+  const id = await liveOverlay();
+  SW.onTabUpdated(42, { status: "loading" });
+  SW.onTabRemoved(42);
+  SW.onMessage({ type: "dlr:overlay-lost", overlay: id }, {}, () => {});
+  await settle();
+  assert.equal(calls.windowsCreate.length, 1);
+});
+
+test("a loss reported for an unknown overlay does nothing", async () => {
+  reset();
+  SW.onMessage({ type: "dlr:overlay-lost", overlay: "ov-nope" }, {}, () => {});
+  await settle();
+  assert.equal(calls.windowsCreate.length, 0);
+});
+
+test("a SECOND download into the same tab gets a window, not an eviction",
+  async () => {
+    // The content script keeps exactly ONE overlay and evicts the incumbent, so
+    // overlaying the second download would silently destroy the first one's
+    // picker while the worker still believed it was delivered. Both questions
+    // must be asked.
+    await liveOverlay({ downloadId: 1, tabId: 42 });
+    calls.windowsCreate.length = 0;
+    assert.equal(await SW.openPicker({ downloadId: 2, dir: "other" }), true);
+    assert.equal(calls.windowsCreate.length, 1, "the second gets a window");
+    assert.equal(SW.state.overlays.size, 1, "the first keeps its overlay");
+    const url = new URL(calls.windowsCreate[0].url);
+    assert.equal(url.searchParams.get("id"), "2");
+  });
+
+test("once the first overlay closes, the tab can host another", async () => {
+  const id = await liveOverlay({ downloadId: 1, tabId: 42 });
+  SW.onMessage({ type: "dlr:picker-closed", overlay: id }, {}, () => {});
+  await settle();
+  calls.windowsCreate.length = 0;
+  assert.equal(await SW.openPicker({ downloadId: 2, dir: "other" }), true);
+  assert.equal(calls.windowsCreate.length, 0, "overlaid again");
+});
+
+test("the overlay's tab is raised, or the question is asked where nobody looks",
+  async () => {
+    // The popup window this replaces was created `focused: true`. The toast's
+    // `change` makes it concrete: the user is looking at the toast's own
+    // window, and the overlay goes to the download's tab.
+    reset();
+    contentScriptMissing = false;
+    SW.state.activeTabId = 42;
+    await SW.openPicker({ downloadId: 1, dir: "other" });
+    assert.deepEqual(calls.tabsUpdate, [{ id: 42, info: { active: true } }]);
+    assert.deepEqual(calls.windowsUpdate, [{ id: 5, info: { focused: true } }]);
+  });
+
+test("a tab that refuses to be raised still keeps its working overlay",
+  async () => {
+    reset();
+    contentScriptMissing = false;
+    tabsUpdateFails = true;
+    SW.state.activeTabId = 42;
+    assert.equal(await SW.openPicker({ downloadId: 1, dir: "other" }), true);
+    assert.equal(calls.windowsCreate.length, 0, "no pointless second picker");
+  });
+
+// --- a hostile page may frame picker.html ----------------------------------- //
+test("A PICK FROM AN UNRECOGNISED SUBFRAME IS REFUSED", async () => {
+  // `picker.html` is web-accessible -- it has to be, to be framed at all -- so
+  // any page can embed it, point it at a recent download id, and clickjack two
+  // clicks: one to take the "+ new dir" row, one to answer the kind prompt.
+  // That is a /mkdir and a /relocate driven by a page. Click-to-select is what
+  // made two blind clicks enough.
+  reset();
+  let answer = null;
+  const handled = SW.onMessage(
+    { type: "dlr:choose", downloadId: 1, dir: "Evil", createdNew: true,
+      kind: "performer" },
+    { frameId: 3, tab: { id: 42 } }, (r) => { answer = r; });
+  await settle();
+  assert.equal(handled, false, "answered synchronously, nothing dispatched");
+  assert.equal(answer.ok, false);
+  assert.match(answer.error, /unrecognised frame/);
+  assert.equal(calls.fetches.length, 0, "no /mkdir, no /relocate, no /learn");
+});
+
+test("...and a guessed nonce does not help", async () => {
+  reset();
+  let answer = null;
+  SW.onMessage({ type: "dlr:choose", downloadId: 1, dir: "Evil",
+    overlay: "ov-guessed" }, { frameId: 3, tab: { id: 42 } },
+  (r) => { answer = r; });
+  await settle();
+  assert.equal(answer.ok, false);
+  assert.equal(calls.fetches.length, 0);
+});
+
+test("OUR overlay's pick, carrying the id we issued, goes through", async () => {
+  // The counterweight: the guard must not break the path it protects.
+  const id = await liveOverlay();
+  searchResult = [];
+  let answer = null;
+  SW.onMessage({ type: "dlr:choose", downloadId: 1, dir: "Jane Doe",
+    overlay: id }, { frameId: 7, tab: { id: 42 } }, (r) => { answer = r; });
+  await settle(20);
+  assert.equal(answer.ok, true);
+  assert.equal(answer.dir, "Jane Doe");
+});
+
+test("the popup window's pick is untouched by the guard", async () => {
+  // It is the TOP frame of its own tab and carries no nonce, which is exactly
+  // why the test is on frameId rather than on a nonce being present.
+  reset();
+  searchResult = [];
+  let answer = null;
+  SW.onMessage({ type: "dlr:choose", downloadId: 1, dir: "Jane Doe" },
+    { frameId: 0, tab: { id: 42 } }, (r) => { answer = r; });
+  await settle(20);
+  assert.equal(answer.ok, true);
+});
+
+test("a sender with no frame information at all is still served", async () => {
+  reset();
+  searchResult = [];
+  let answer = null;
+  SW.onMessage({ type: "dlr:choose", downloadId: 1, dir: "Jane Doe" }, {},
+    (r) => { answer = r; });
+  await settle(20);
+  assert.equal(answer.ok, true);
 });

--- a/scripts/dl-router/tests/test_dirindex.py
+++ b/scripts/dl-router/tests/test_dirindex.py
@@ -211,9 +211,76 @@ def test_file_index_ttl(library, clock, monkeypatch):
     idx = FileIndex(library, clock=clock, ttl=10.0)
     idx.refresh()
     calls = []
-    monkeypatch.setattr(idx, "_scan", lambda: (calls.append(1), ({}, 0, False))[1])
+    monkeypatch.setattr(idx, "_scan",
+                        lambda: (calls.append(1), ({}, {}, 0, False))[1])
     idx.refresh()
     assert calls == []
     clock.advance(11)
     idx.refresh()
     assert calls == [1]
+
+
+# --- per-directory item counts --------------------------------------------- #
+#
+# The picker shows how many files each subject directory holds. The tally is a
+# BY-PRODUCT of the dedupe walk, never a scan of its own -- see FileIndex's
+# docstring and, more importantly, `dir_counts`, which must not refresh.
+def test_file_index_counts_files_per_top_level_directory(library, clock):
+    (library / "Jane Doe" / "one.mp4").write_text("x")
+    (library / "Jane Doe" / "two.mp4").write_text("x")
+    (library / "john-smith" / "solo.mp4").write_text("x")
+    idx = FileIndex(library, clock=clock)
+    idx.refresh()
+    assert idx.dir_counts() == {"Jane Doe": 2, "john-smith": 1}
+
+
+def test_counts_include_files_nested_below_the_subject_directory(library, clock):
+    nested = library / "Jane Doe" / "2026" / "set-a"
+    nested.mkdir(parents=True)
+    (nested / "deep.mp4").write_text("x")
+    (library / "Jane Doe" / "shallow.mp4").write_text("x")
+    idx = FileIndex(library, clock=clock)
+    idx.refresh()
+    # A directory "holds" everything under it: a per-subject total that ignored
+    # the layout inside would be a different, less useful number.
+    assert idx.dir_counts()["Jane Doe"] == 2
+
+
+def test_a_loose_file_in_the_library_root_is_counted_under_no_directory(
+        library, clock):
+    (library / "unfiled.mp4").write_text("x")
+    (library / "Jane Doe" / "filed.mp4").write_text("x")
+    idx = FileIndex(library, clock=clock)
+    idx.refresh()
+    counts = idx.dir_counts()
+    assert counts == {"Jane Doe": 1}
+    assert "unfiled.mp4" not in counts
+
+
+def test_counts_skip_hidden_files_exactly_like_the_dedupe_index(library, clock):
+    (library / "Jane Doe" / ".partial.mp4").write_text("x")
+    (library / "Jane Doe" / "real.mp4").write_text("x")
+    idx = FileIndex(library, clock=clock)
+    idx.refresh()
+    assert idx.dir_counts() == {"Jane Doe": 1}
+
+
+def test_dir_counts_NEVER_triggers_a_scan(library, clock, monkeypatch):
+    """THE pin on the cost decision.
+
+    `dir_counts` is called from /dirs, which the extension hits on every picker
+    open. Adding a `self.refresh()` to it would put a whole-tree walk of a media
+    library on that path -- and the extension gives up on the snapshot after
+    4 s, so a large library would turn a decorative counter into a picker that
+    never loads. This test fails the moment that refresh is added.
+    """
+    (library / "Jane Doe" / "one.mp4").write_text("x")
+    idx = FileIndex(library, clock=clock)
+    calls = []
+    real_scan = idx._scan
+    monkeypatch.setattr(idx, "_scan", lambda: (calls.append(1), real_scan())[1])
+    assert idx.dir_counts() == {}, "no walk has happened yet, so no counts"
+    assert calls == [], "dir_counts must not scan"
+    idx.refresh()
+    assert idx.dir_counts() == {"Jane Doe": 1}
+    assert calls == [1], "the ONE walk is the dedupe index's own"

--- a/scripts/dl-router/tests/test_dirindex.py
+++ b/scripts/dl-router/tests/test_dirindex.py
@@ -284,3 +284,24 @@ def test_dir_counts_NEVER_triggers_a_scan(library, clock, monkeypatch):
     idx.refresh()
     assert idx.dir_counts() == {"Jane Doe": 1}
     assert calls == [1], "the ONE walk is the dedupe index's own"
+
+
+def test_a_TRUNCATED_walk_reports_no_counts_at_all(library, clock):
+    """A partial tally of an unknown fraction of the library would be rendered
+    next to a directory name with no hint that it is wrong. Same rule the
+    picker applies to a malformed count: a wrong number is worse than none.
+    """
+    for i in range(10):
+        (library / "Jane Doe" / f"f{i}.mp4").write_text("x")
+    idx = FileIndex(library, clock=clock, max_files=3)
+    idx.refresh()
+    assert idx.stats()["truncated"] is True
+    assert idx.dir_counts() == {}
+
+
+def test_an_untruncated_walk_of_the_same_tree_does_report_them(library, clock):
+    for i in range(10):
+        (library / "Jane Doe" / f"f{i}.mp4").write_text("x")
+    idx = FileIndex(library, clock=clock, max_files=1000)
+    idx.refresh()
+    assert idx.dir_counts() == {"Jane Doe": 10}

--- a/scripts/dl-router/tests/test_server.py
+++ b/scripts/dl-router/tests/test_server.py
@@ -864,3 +864,113 @@ def test_a_malformed_config_serves_503_instead_of_exiting(tmp_path):
 def test_a_valid_config_reports_no_error(cfg):
     app = S.App(cfg, store=Store(":memory:"))
     assert "configError" not in app.healthz()
+
+
+# --- per-directory counts, and the ETag decision --------------------------- #
+#
+# The picker shows how many files each subject directory holds. The counts are
+# served in the /dirs snapshot but are DELIBERATELY NOT part of its ETag, and
+# the tests below are what hold that line in both directions: one fails if the
+# counts disappear, the others fail if they are ever folded into the hash.
+def test_dirs_snapshot_carries_per_directory_counts(live, app, library):
+    (library / "Jane Doe" / "one.mp4").write_text("x")
+    (library / "Jane Doe" / "two.mp4").write_text("x")
+    (library / "john-smith" / "solo.mp4").write_text("x")
+    app.files.refresh(force=True)
+    _, body, _ = call(live, "GET", "/dirs")
+    assert body["counts"] == {"Jane Doe": 2, "john-smith": 1}
+
+
+def test_counts_are_reported_only_for_indexed_directories(app, library):
+    (library / "Jane Doe" / "one.mp4").write_text("x")
+    hidden = library / ".stash"
+    hidden.mkdir()
+    (hidden / "x.mp4").write_text("x")
+    app.files.refresh(force=True)
+    counts = app.dirs_snapshot()["counts"]
+    assert counts == {"Jane Doe": 1}
+
+
+def test_THE_ETAG_IGNORES_THE_COUNTS(app, library):
+    """THE pin on the ETag decision. Delete the deliberate exclusion in
+    App.dirs_snapshot -- fold `counts` back in above the hash -- and this fails.
+
+    A count changes on every completed download, and FileIndex is TTL-cached,
+    so an ETag covering the counts would change when the routing configuration
+    had not: it would stop being a cache validator for the thing the extension's
+    cached fallback matcher actually runs on.
+    """
+    (library / "Jane Doe" / "one.mp4").write_text("x")
+    app.files.refresh(force=True)
+    first = app.dirs_snapshot()
+    (library / "Jane Doe" / "two.mp4").write_text("x")
+    app.files.refresh(force=True)
+    second = app.dirs_snapshot()
+    assert second["counts"] != first["counts"], "the counts really did change"
+    assert second["etag"] == first["etag"], "but the routing payload did not"
+
+
+def test_dirs_still_304s_after_a_download_changed_the_counts(live, app, library):
+    """The same pin, end to end over HTTP -- the shape the extension sees."""
+    (library / "Jane Doe" / "one.mp4").write_text("x")
+    app.files.refresh(force=True)
+    _, body, headers = call(live, "GET", "/dirs")
+    assert body["counts"]["Jane Doe"] == 1
+    etag = headers["ETag"]
+    (library / "Jane Doe" / "two.mp4").write_text("x")
+    app.files.refresh(force=True)
+    status, body2, _ = call(live, "GET", "/dirs",
+                            headers={"If-None-Match": etag})
+    assert status == 304
+    assert body2 is None
+
+
+def test_the_etag_still_changes_when_the_ROUTING_payload_does(app, library):
+    """The other direction: excluding the counts must not have excluded
+    anything else. A new directory is a routing change and must invalidate."""
+    app.files.refresh(force=True)
+    first = app.dirs_snapshot()["etag"]
+    (library / "New Subject").mkdir()
+    app.dirs.refresh(force=True)
+    assert app.dirs_snapshot()["etag"] != first
+
+
+def test_serving_dirs_NEVER_walks_the_library(live, app, library,
+                                              monkeypatch):
+    """/dirs is the picker's own path and has a 4 s budget on the extension
+    side. It must read whatever tally the dedupe walk already produced and
+    never start one of its own -- a whole-tree walk here would turn a
+    decorative counter into a picker that fails to load on a big library.
+    """
+    (library / "Jane Doe" / "one.mp4").write_text("x")
+    calls = []
+    real_scan = app.files._scan
+    monkeypatch.setattr(app.files, "_scan",
+                        lambda: (calls.append(1), real_scan())[1])
+    status, body, _ = call(live, "GET", "/dirs")
+    assert status == 200
+    assert calls == [], "/dirs must not scan the library"
+    assert body["counts"] == {}, "and it reports no counts rather than blocking"
+
+
+def test_a_match_is_what_warms_the_counts(app, library):
+    """The intended degradation, made explicit: counts are empty until the
+    dedupe index has been walked, and /match walks it on every download -- so
+    by the time any picker opens they are there."""
+    (library / "Jane Doe" / "one.mp4").write_text("x")
+    assert app.dirs_snapshot()["counts"] == {}
+    app.match({"url": "https://example-site.test/dl/1", "filename": "clip.mp4",
+               "page": {"url": "https://example-site.test/v/1",
+                        "tags": ["Jane Doe"]}})
+    assert app.dirs_snapshot()["counts"] == {"Jane Doe": 1}
+
+
+def test_the_dirs_entries_are_untouched_by_the_counts(app, library):
+    """The counts are a SEPARATE map, not a field on each `dirs` entry: the
+    extension's cached fallback matcher iterates those entries, and they stay
+    exactly what they were before counts existed."""
+    (library / "Jane Doe" / "one.mp4").write_text("x")
+    app.files.refresh(force=True)
+    snap = app.dirs_snapshot()
+    for entry in snap["dirs"]:
+        assert set(entry) == {"name", "key", "tokens", "kind"}


### PR DESCRIPTION
Three changes to the download picker. Tests: **843 pytest** (was 828) / **413 node** (was 313).

An adversarial structural audit was run against the first three commits and found
three paths that broke the "no download may end up with no picker" invariant, plus
a clickjacking surface that click-to-select had made reachable. A review round then found that the
anti-clickjack guard refused legitimate picks after an MV3 teardown. All are
fixed in `42784a3`/`6c4224d`/`e46ee12` and described under *Remediation* below.

## 1. Per-directory item counts

Each row shows how many files that directory holds. The tally is a **by-product
of the whole-tree walk `FileIndex` already performs for dedupe** — no third
scan — and `FileIndex.dir_counts()` **deliberately does not refresh**, so
`/dirs` can never block on a walk of the library. `/match` warms it on every
download. Stated degradations: no counts before the first `/match` of a
process, and **no counts at all when the walk hit `file_index_max`** — a
partial tally of an unknown fraction of the library is a wrong number, and a
wrong number is worse than none.

### The ETag decision

Counts are added to the snapshot **below** the hash, with the reasoning written
at the line. Folding them in was rejected because:

1. a count changes on every completed download, so the ETag would too;
2. `FileIndex` is TTL-cached, so the *same unchanged library* can answer with
   two different counts a minute apart — an ETag that changes when nothing
   changed is not a validator;
3. it would destroy what the ETag is *for*. Everything else in that payload is
   routing configuration, which is what the extension's cached fallback matcher
   runs on inside the 400 ms `/match` budget (the reason the kinds were folded
   in), and what `dl-route status` reports. Mixing a per-download counter in
   means "did the routing config change?" is always yes.

The cost: a `304` carries no body, so a revalidating client keeps its old
counts. So the **one request a human waits on** — the picker asking for the
list it is about to render — skips `If-None-Match`; the five-minute alarm,
startup and the post-`/mkdir` refresh revalidate exactly as before.

Counts ride as their own map, not a field on each `dirs` entry, so the entries
the fallback matcher iterates stay byte-identical.

Pinned both ways and each pin verified failing when its guard is removed:
`test_THE_ETAG_IGNORES_THE_COUNTS`,
`test_dirs_still_304s_after_a_download_changed_the_counts`,
`THE PICKER'S SNAPSHOT REQUEST DOES NOT REVALIDATE`,
`test_serving_dirs_NEVER_walks_the_library`,
`test_dir_counts_NEVER_triggers_a_scan`,
`test_a_TRUNCATED_walk_reports_no_counts_at_all`.
`/match` is untouched — it already refreshed this index, and nothing was added to it.

## 2. Click to select, subtle animation

Click is expressed in the reducer as *"move the highlight there, then Enter"*,
so it reuses the Enter branch verbatim — the kind prompt, the new-directory
sub-question, the refusals and the `done` shape all come from one place. It
sits after the `done` guard and before the kind prompt: dead once the flow
finished, live while the kind prompt is up.

A click while the list is loading or unavailable is **dropped, not deferred**.
Enter defers because a typed query survives the list arriving; a click's intent
is a *screen position*, and honouring it against a different list would choose
an arbitrary directory or create one — the exact footgun the deferred Enter
exists to close. Pinned, and verified failing when the refusal is deleted.

Animation: hover/active feedback, a 260 ms pulse on the row that was taken
(keyboard and mouse alike, keyed on `state.index`, which both paths act on),
`prefers-reduced-motion` swapping the pulse for a static outline. Hover is
CSS-only on purpose — a pointer that moved the selection would fight the
keyboard, since the mouse sits wherever it was left.

The keyboard flow is unchanged and still pinned end-to-end, including
"the keyboard still drives the list after a click".

## 3. In-page overlay, window as the automatic fallback

**One reducer, guaranteed structurally.** `picker_overlay.js` frames
`picker.html` — the same document running the same `picker.js` — inside a
**closed** shadow root. There is no second implementation to drift: a test
asserts the overlay script contains none of the picker's vocabulary
(`filterEntries`, `reduce(`, `ArrowDown`, `dlr:choose`, `titleCase`,
`ENTRY_NEW`). The `done` latch, single-flight `finish()`, `choose-failed` above
the guard, failed-snapshot-is-still-loading, refusing to choose on final
failure and never creating a directory before the snapshot lands are therefore
identical in both paths by construction, and remain pinned.

Being a separate document also means page CSS cannot reach the picker or vice
versa; the shadow root is what stops the page styling or discovering the host.

No new permissions — it rides the content-script declaration
`content_capture.js` already has. Framing an extension page does need
`picker.html` in `web_accessible_resources`; its module imports are not
exposed. `use_dynamic_url` is **not** set: it would rotate the origin the
framed page's relative module imports resolve against, and a silently
never-working overlay is worse than the fingerprinting surface it saves.

### Fallback detection — two gates, every failure reaching the window

1. **the content script answers.** `chrome.tabs.sendMessage` rejects with
   "receiving end does not exist" where none runs — one check covering
   `brave://`/`chrome://`, the **PDF viewer** (an ordinary `https` URL whose
   document is a plugin, so a URL test cannot catch it), the Web Store,
   `view-source:`, `file://`, a discarded tab, and a page still loading. A tab
   that has **closed** — the self-closing file-host tab — fails a step earlier
   at `chrome.tabs.get`. The URL check is only a shortcut, never the proof.
2. **the frame reports itself ready.** A content-script-injected iframe is
   subject to the *page's* CSP, so a strict `frame-src` blocks the load while
   every DOM call in gate 1 still succeeds. Only a booted extension context can
   send `dlr:picker-ready`. Without gate 2 such a site would leave an empty
   overlay and no window — a download with **no picker at all**.

The readiness wait is armed **before** the probe: the frame's boot is a
separate round trip and can land on either side of the content script's answer.
Registering afterwards dropped a `ready` that won the race and fell back
intermittently — found by the tests, fixed, both orderings pinned.

Never dismissed on outside click or blur — precisely why
`chrome.action.openPopup()` was out. The iframe cannot close itself, so the
picker sends `dlr:picker-closed`; the worker falls back to `sender.tab.id` so a
pick made after an MV3 teardown still tears the overlay down, and the content
script sweeps a stray host by id if it was re-injected in between.

The **toast stays a popup window** unconditionally: passive, eight seconds, no
pick to lose. `chrome.notifications` is still the last rung under both.

## Remediation (`42784a3`, `6c4224d`, `e46ee12`)

Gate 2 proves the frame **booted**. It proves nothing a millisecond later, and
`openPicker` has already returned true by then. Three ways the overlay could
vanish with the download left unasked, now each with a route back to a window:

* **tab closes or navigates** — `tabs.onRemoved` / `tabs.onUpdated`, the latter
  keyed on `status === "loading"` so a SPA's `pushState` does not yank a working
  picker into a window;
* **the page removes the host node** — `body.innerHTML = …`, a sanitiser, a
  framework re-render, or hostile script. A `MutationObserver` on `body`, armed
  only while an overlay is live, reports `dlr:overlay-lost`. The closed shadow
  root was never protection here: a page does not need the frame's URL to remove
  the element next to it.
* **a second download into the same tab** — the content script keeps exactly one
  overlay and evicts the incumbent, so the first picker died silently while the
  worker believed it delivered. The worker now refuses the second overlay and
  gives it a window: two questions, both asked, neither lost.

Re-delivery is idempotent (record removed first) and re-asks the *same*
question from the kept `info`.

Also: **the overlay's tab is raised** (`tabs.update` + `windows.update`) — the
popup window it replaces was `focused: true`, and the toast's `change` makes it
concrete, since the user is looking at the toast's own window while the overlay
goes to the download's tab.

### The registry has to outlive the worker

`state.overlays` was in-memory only. MV3 tears the worker down after ~30 s idle
and the picker routinely outlives that, because **choosing a directory is the
slowest thing the user does here**. So the subframe guard saw an empty registry
and *discarded a legitimate pick*, and the tab watchers found no overlay to
rescue when its tab closed. I had already written this exact insight into the
`dlr:picker-closed` handler and failed to carry it to the handler where losing
is unrecoverable — the same shape as the screened-refusal suppression map.

The registry now lives in `chrome.storage.session`: it survives the idle
teardown and dies with the browser, which is also when every overlay dies.

That fix introduced its own race, caught by the idempotency test — the persist
is fire-and-forget, so a restore running before the write landed **resurrected**
an overlay that had just been re-delivered, producing two windows for one
download. Re-delivery is now single-flight on a synchronously-checked set that
doubles as a tombstone the restore skips.

### A pick from an unrecognised subframe is refused `picker.html` must be
web-accessible to be framed, so any page could embed it, point it at a recent
download id, and clickjack two clicks — "+ new dir", then the kind prompt —
into a `/mkdir` and a `/relocate`. **Click-to-select is what made two blind
clicks sufficient**, so this PR created the surface and closes it. Our own
overlay is a subframe too, so the discriminator is the per-open id:
unguessable, worker-issued, invisible to the page because the shadow root is
closed. The popup window is a top-level frame and is untouched — the test is on
`frameId`, not on an id being present. Both halves of that cross-component
contract are pinned.

Every guard above is pinned by a test **verified failing when the guard is
deleted** — pins on *permissive* behaviour, which is the kind this subsystem
keeps learning it needs.

Preserved and still pinned: the `first`-gated refusal notifications and the
screened-refusal ledger, the toast's `change` → repick path, and the relocate
provenance flow.

## What only a real download in Brave can settle

Nothing in this subsystem has ever run in a browser, and an extension change
needs a **full Brave restart, not the reload button** (the long-poll keeps the
old worker alive). The manifest version is bumped to `0.2.0` precisely so
`brave://extensions` shows whether the restart took. Unverifiable headlessly:

- that `web_accessible_resources` with **`use_dynamic_url: true`** lets a
  content script frame `picker.html` at all, and that the framed page's
  ES-module imports resolve under the rotating origin (which is why
  `picker.js`, `sanitize.js` and `route_core.js` are listed alongside it). This
  fails safe — the frame never boots, gate 2 fires, and every picker becomes a
  window — so the symptom would be "always windowed, never in-page", and
  SKILL.md names it as the first thing to suspect. `use_dynamic_url` does not
  change the full-Brave-restart requirement: it rotates per browser session,
  and the restart is already what picks up any extension code change;
- that `iframe.focus()` (immediate + on `load`) actually routes keystrokes into
  the frame, so the picker is keyboard-ready without a click first;
- whether real sites' CSPs block the frame often enough that the window
  fallback is the common case rather than the exception;
- that `chrome.tabs.sendMessage` **rejects** (rather than hangs) on the PDF
  viewer and `view-source:` — the whole of gate 1 rests on that;
- that `sender.frameId` is `0` for the popup-window picker, which is what the
  anti-clickjack guard keys on. If it is not, real windowed picks get refused —
  loud and immediate, but only a browser can show it;
- whether `tabs.onUpdated`'s `status === "loading"` fires often enough on real
  sites to bounce a working overlay into a window more than it rescues one;
- the overlay's visual fit: z-index against real pages, light/dark rendering,
  and whether 460x420 fixed top-right is the right placement;
- that `OVERLAY_READY_MS` (1500) is generous enough on a loaded machine.

The counts are exercised against a real 26-directory index only once a download
runs; the sidecar-side numbers are proven against synthetic trees.

Live sidecar left healthy (`dl-route status`: up, 26 dirs, `configured=true`).
