### PR TITLE
docs(browser-bridge): commit the six arc docs stranded in the shared working tree

### DIFF
--- a/claudedocs/browser-bridge-audit-opencode-design-2026-07-28.md
+++ b/claudedocs/browser-bridge-audit-opencode-design-2026-07-28.md
@@ -1,0 +1,110 @@
+# Browser-Bridge: Usage Audit, Token-Efficiency, and opencode "browser-agent" Design
+
+_2026-07-28. Read-only analysis. Repo `/home/zach/workspace/devrc`, both hosts (laptop + workbench `192.168.50.250`). Numbers are **measured** from ClickHouse `activity.events` (source=`browser-bridge`), systemd journals, transcripts, and code unless labelled **(est.)**. Data window 2026-07-28 → 2026-07-29 02:31 UTC._
+
+## Executive summary — top 5 actions
+
+1. **The #178 backstop is deployed but has NEVER been exercised by a real storm — treat it as PRODUCTION-UNVERIFIED.** The 44,043-eval flood ran ~13/sec on 2026-07-28 17:xx UTC; the workbench service carrying the rate-limiter (re)started 20:01 CDT = 01:01 UTC 29th, ~8h *after*. Zero `throttled` events on either host (`Counter({'dispatch':44154,'cmd_ok':44154,'reject':1})`). The guard exists + is unit-tested but has never fired under load. **Action: synthetic load-test (`for i in $(seq 40); do browser eval '1' & done`) to confirm a real 429.**
+2. **Ship `browser text [selector]`.** `getHtml` returns full `outerHTML`, no truncation (`service_worker.js:87-94`); ~139 KB ≈ ~35 K tokens. innerText → ~2 KB ≈ ~500 tok (**~98% cut**). Biggest single per-call lever.
+3. **Build the opencode browser-agent — feasible today, cheap.** Both hosts have opencode with an **`openrouter` key in `~/.local/share/opencode/auth.json`** (the "no key" caveat was looking in env files; it's in opencode's auth store). `deepseek/deepseek-v4-flash` is real ($0.14/$0.28 per M, 1M ctx), listed by opencode. `opencode run --format json -m … --agent … --auto` is the headless primitive.
+4. **Real browser-driving is ~nonexistent outside one pathological loop.** Laptop's 29 events are the bridge's own dev/test; workbench's 44K are the persona-fleet storm. No organic day-to-day usage yet — design is for latent demand.
+5. **The subagent-shared-session-id gap is the top remaining correctness risk** and is exactly what the opencode agent (own isolated tab + #178 rate-limit) sidesteps. Prioritise it as the MVP.
+
+---
+
+## Part A — Usage audit (both hosts, measured)
+
+### A.1 Volume & op distribution
+| host | total | eval | nav | screenshot | getHtml | tabs | open | close | release |
+|---|---|---|---|---|---|---|---|---|---|
+| **workbench** | **44,140** | 44,043 | 50 | 14 | 14 | 13 | 6 | 0 | 0 |
+| **laptop** | **29** | 1 | 4 | 0 | 11 | 3 | 4 | 4 | 2 |
+
+`key` on workbench: `""` (implicit single-instance) = 44,049; `work` = 91 → the storm ran with **no `--instance`, no `open`** (the exact unisolated pattern SKILL.md warns against).
+
+### A.2 The eval storm (the only heavy real usage)
+- Sustained ~770–815 eval/min all afternoon 2026-07-28 17:xx UTC = ~13/sec.
+- Driver: unisolated persona-fleet hammering the single shared active tab. Domain rotation confirms an un-pinned tab: civitai.com 30,327 · 192.168.50.250 (initiatives viewer) 5,793 · grafana-new.civitai.com 3,979 · discord.com 2,135 · empty 1,684 · google/github/youtube/claude.ai tails.
+- **Not in transcripts** — the 44K storm was an external loop/persona process, not a logged Claude-Code session → un-attributable at session level (predates the coarse `sess` hash).
+- Latency: eval avg=10.3ms p50=5 p95=23 p99=35 **max=5,525ms** — the queue-saturation balloon, produced with NO throttling (predates the guard).
+
+### A.3 Outcome / error catalogue (every non-ok)
+Only 2 non-ok in telemetry, both laptop: `close no_owned_tab` ×2 (domains a.test/b.test → **test-suite artifacts**, not organic friction — the intended `release → close(no_owned_tab)` path). The laptop journal `cmd_ambiguous` is from work/personal test instances. The workbench journal `reject unauthorized path:"/"` is a bare unauthenticated probe (auth gate working). **Net: no organic error patterns — the surface is untested-in-anger or exercised only by its own harness.**
+
+### A.4 Throttle backstop status (#178) — NOT firing
+Zero `throttled`/`sess`/`reason` rows either host; zero journal `throttled` lines. Deployed workbench `server.py` *contains* the guard (active since 20:01 CDT 28th; defaults 5/sec, burst 20, queue 32); post-restart traffic is 1–3/min, orders under the limit. **Verdict: deployed + unit-tested but PRODUCTION-UNVERIFIED. Don't claim it "protects against the storm" until a synthetic burst produces a real 429.**
+
+### A.5 Toil / gaps — SKILL (`browser`)
+| sev | finding | evidence |
+|---|---|---|
+| High | **Sibling subagents share session id → no auto-isolation.** Workaround (each subagent `open`+`--tab` on every op) is manual/verbose/forgettable — the gap the storm embodies. | `browser:75-84`, `server.py:127-150` |
+| Med | **No cheap-read op** — `html` is all-or-nothing full outerHTML; no `text`/`--selector`/`--max-bytes`. | `browser:283-285`, `service_worker.js:87-94` |
+| Med | **`eval` return unbounded** — structured-cloned raw; `innerHTML` eval as costly as `html`. | `service_worker.js:96-127` |
+| Low | Discoverability fix **in place** (symlink + SKILL.md path-first). Resolved. | SKILL.md:6-11 |
+| Low | `close` after release/expiry → `no_owned_tab` exit-1 reads as an error; a "nothing-to-close is success" flag would cut noise. | `server.py:401-403` |
+
+### A.6 Toil / gaps — EXTENSION (`service_worker.js`)
+| sev | finding | evidence |
+|---|---|---|
+| High | **Single serial connection ceiling (~13/sec)** — one long-poll, one in-flight command; #178 caps rather than widens it. | `server.py:157-166`, `service_worker.js:237-320` |
+| Med | **Screenshot foreground-flicker under concurrency** (activate→capture→restore). | `service_worker.js:145-170` |
+| Med | **Mandatory manual reload after any `extension/` edit** (Brave won't hot-reload unpacked). Real deploy toil. | `README.md`, SKILL.md |
+| Med | **MV3 SW lifecycle risk** — keepalive = pending `/poll` + 1-min alarm; eviction between a 204 and next poll → silent gap until `/health` staleness (40s). | `service_worker.js:326-335` |
+| Med | **`<all_urls>` host permission** — maximal scope (justified, flagged scope-down-later). | `manifest.json:7` |
+| Low | `owned_tab_gone` handling solid; no silent-wrong-tab path found. | `service_worker.js:73-82`, `server.py:820-833` |
+
+### A.7 Subagents vs top-level
+Laptop transcripts' 10 subagent files referencing the CLI are the **build/audit subagents of this work**, not browser-drivers. **~0% of real browser-driving is organic top-level; ~100% of volume is the one external storm-loop (workbench) or the bridge's own dev/test (laptop).** The subagent-isolation gap is latent — the storm shows what it looks like when it bites.
+
+---
+
+## Part B — Token-efficiency proposals (ranked by savings × ease)
+| # | proposal | before → after (est.) | effort | risk |
+|---|---|---|---|---|
+| B1 | **`browser text [selector]`** (innerText/Readability) | 139KB ≈ 35K tok → ~2KB ≈ 0.5K tok (~98%) | S | Low |
+| B2 | **opencode offload (Part C)** — move nav→read→iterate off Claude's context | ~50K Claude in-tok → ~0 in Claude; ~300-tok result returns | M | Med |
+| B3 | **`--max-bytes` / server truncation** for html & eval (default ~32KB) | caps worst-case; 35K→~8K tok | S | Low |
+| B4 | **`--selector` scoping** on html/eval | 35K → ~1–3K tok | S | Low |
+| B5 | **Structured extractors** (`links`/`forms`/`meta` → JSON) | html+parse → ~200-tok JSON | M | Low |
+| B6 | **`eval` result cap + summary** | bounds accidental innerHTML evals | S | Low |
+
+B1+B3+B4 turn the read path from ~35K to sub-2K tok for the common case; **B2 removes the iterative multiplier** (each nav→read cycle re-costs Claude today) — the structural win.
+
+---
+
+## Part C — opencode "browser-agent" DESIGN (design only)
+
+**Locked:** model `openrouter/deepseek/deepseek-v4-flash` · full autonomy · own isolated tab (#175 `open`+`--tab` + #178 rate-limit). **Privacy:** page content goes to OpenRouter/DeepSeek — consciously accepted; don't route high-secret pages casually.
+
+### C.1 Feasibility — VERIFIED
+- opencode present: laptop 1.18.4, workbench 1.17.20.
+- **OpenRouter key ALREADY on both hosts** in `~/.local/share/opencode/auth.json` (not env files — that's the correct store). No new key needed unless a dedicated/budget-capped one is wanted.
+- Slug: `deepseek/deepseek-v4-flash` on OpenRouter (in $0.14/M · out $0.28/M · ctx 1,048,576); opencode lists `openrouter/deepseek/deepseek-v4-flash`. Fallbacks: `deepseek/deepseek-v3.2` ($0.27/$0.40) → `deepseek/deepseek-chat-v3.1`.
+- Headless: `opencode run [msg] --format json -m <slug> --agent <name> --auto`.
+- Custom tools: (a) built-in `bash` tool calling the `browser` CLI, permission-gated; or (b) a TS custom tool. **Recommend (a).**
+- **Live model call UNTESTED** (would spend money) — invocation surface + key existence verified, not a real completion.
+
+### C.2 Interface — recommend opencode's `bash` tool calling the existing `browser` CLI (least new code)
+```
+browser agent "<goal>" [--instance K] [--allow-domains …] [--deny-domains …] [--steps N] [--timeout S] [--dry-run]
+```
+Wrapper around `opencode run`: (1) `open about:blank` → capture `tabId` (agent's OWN tab); (2) `opencode run --format json -m openrouter/deepseek/deepseek-v4-flash --agent browser-agent --auto "<harness+goal+tabId>"`; (3) the `browser-agent` agent is permission-locked so its ONLY capability is `bash` matching `<abs>/browser --tab <tabId> *` (edit/read/webfetch/websearch denied) — it can run browser ops **only against its own tab**; (4) on exit `close` the tab, parse opencode's final JSON, return a compact structured result — never raw HTML.
+
+**Agent def** (`~/.config/opencode/agents/browser-agent.md`): `mode: subagent`, `model: openrouter/deepseek/deepseek-v4-flash`, `temperature: 0.1`, `steps: 12`, `permission: {edit:deny, read:deny, webfetch:deny, websearch:deny, bash:{"*":"deny","<abs>/browser --tab *":"allow"}}`.
+
+**Harness scaffolding ("bridge the gap"):** strict single-tool contract; forced own-tab (wrapper injects `--tab`); step budget (`steps:12` + wall-clock `--timeout` kill); **required final-answer schema** `{"answer","evidence":[…],"steps_used","status":"ok|partial|blocked"}`; retry-on-malformed once (`--continue`); prefer `browser text` over `html` (needs B1); domain allow/deny in prompt + defensively enforced by the wrapper.
+
+### C.3 Guardrails (recommended defaults; user chose full autonomy)
+Own-tab isolation caps blast radius (structural — can't touch the active tab); #178 rate-limit throttles runaways (verify it fires first); log every op (telemetry + opencode JSON transcript); step + wall-clock budget with hard kill; `--allow/deny-domains`; `--dry-run` intercept for form-submits (off by default); never the active tab (structural).
+
+### C.4 Cost / latency **(est.)**
+Per task ≈ open + 5–8 model steps + close ≈ 25–40K in-tok, 1–2K out. **DeepSeek v4-flash: ~$0.005–0.008/task, ~10–25s wall-clock.** Same loop in Claude/Opus ≈ ~$0.75+ **and burns the main session's context on transient HTML**. Offload ≈ ~100× cheaper on $ and frees Claude's context (only a ~300-tok result returns). Thesis holds.
+
+### C.5 Complete test plan (design-first)
+**Unit (opencode mocked — no live model in CI):** arg parsing; own-tab lifecycle (open→capture→inject→close on every exit path via a fake `browser` shim); final-answer schema parse + exactly-one retry then `blocked` (no infinite retry); guardrail enforcement (`--steps`, `--timeout` kill, `--deny-domains` blocks nav); failure modes (opencode missing → clean error, no orphaned tab; non-zero exit surfaced; `owned_tab_gone` mid-run → `partial`, still closes). **Integration/smoke:** fake `opencode` emitting a canned `--format json` tool-call stream against the in-process fake extension; assert ops routed to the owned tab, tab opened+closed once, result parsed. **Manual live (real key, real Brave):** `browser agent "go to news.ycombinator.com and report the top 3 titles"` → new background tab (not active), navigates+reads, returns compact schema, active tab untouched, tab closed; plus a 40-op burst → real 429/`throttled` in journal (closes A.4). Repo conventions: stdlib unittest + `node --test`, reuse fake extension, no live model in CI.
+
+### C.6 Recommendation — **GO**
+Feasibility confirmed; reuses the audited CLI + #175/#178 semantics with minimal new code.
+**MVP slice:** (1) `browser text` (B1) — the agent needs a cheap read first or v4-flash drowns in HTML; (2) the permission-locked `browser-agent` opencode agent def + a thin `browser agent "<goal>"` wrapper (open own tab → `opencode run` → parse schema → close); (3) final-answer schema + one retry. **Defer:** MCP wrapper, structured extractors (B5), `--dry-run`.
+**Open risks:** cheap-model reliability (mitigate: single-tool permission, step budget, retry; escalate model if >~1/5 tasks blocked/wrong); full-autonomy safety (bounded by own-tab + #178, but **#178 unverified** — verify first); privacy (page content → DeepSeek); opencode headless quirks (`--format json`/`steps`/permission semantics differ between 1.17.20 and 1.18.4 — pin/align versions).
+**Escalate the model** on repeated schema-parse failures, stalls under `steps:12`, or wrong extractions → `deepseek/deepseek-v3.2` → a small Claude model.

--- a/claudedocs/browser-bridge-code-audit-2026-07-30.md
+++ b/claudedocs/browser-bridge-code-audit-2026-07-30.md
@@ -1,0 +1,572 @@
+# browser-bridge code audit — 2026-07-30
+
+Read-only audit of `~/workspace/devrc/scripts/browser-bridge/` for tool gaps,
+error-handling gaps, test-coverage gaps, and docs-vs-code drift.
+
+> **Live-verification disclaimer (read first).** Nothing in this report is
+> live-verified against real Brave. CI cannot drive a logged-in browser, so every
+> finding below is either (a) VERIFIED by running the unit/integration suites and
+> reading code, or (b) INFERRED by reading. Each finding is labelled. The
+> live-behaviour gate — does the op actually do the right thing in Brave — belongs
+> to the operator and is explicitly out of scope here.
+
+---
+
+## 1. Method + actual test-run output
+
+### What I ran
+
+The canonical invocations (per `README.md` / the test layout):
+
+```
+node --test scripts/browser-bridge/tests/*.test.mjs
+python -m pytest scripts/browser-bridge/tests -q
+```
+
+The system `python` on this host has no `pytest`, so pytest was run under
+`nix-shell -p python312Packages.pytest python312Packages.requests`.
+
+### Actual output (VERIFIED)
+
+**node (`node --test tests/*.test.mjs`)**
+
+```
+ℹ tests 186
+ℹ suites 0
+ℹ pass 186
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 587.591785
+```
+
+**pytest (`python -m pytest tests -q`)**
+
+```
+........................................................................ [ 34%]
+........................................................................ [ 69%]
+................................................................         [100%]
+208 passed in 64.52s (0:01:04)
+```
+
+**Totals: 394 tests, 394 pass, 0 fail, 0 skipped, 0 todo.** No test was modified.
+
+Note: several pytest tests are `@pytest.mark.skipif(shutil.which("curl") is None)`
+(e.g. `tests/test_server.py:2638`). `curl` IS present on this host, so those ran —
+on a host without curl the real-CLI end-to-end tests would silently vanish from the
+count without the run being marked skipped in aggregate. Worth knowing before
+trusting a green run elsewhere.
+
+### What the suites do and do not reach
+
+| layer | file(s) | reached? |
+|---|---|---|
+| extension pure helpers (`protocol.js`) | `protocol.test.mjs`, `cdp_protocol.test.mjs`, `hidden_tab.test.mjs` | yes, densely |
+| extension glue (`service_worker.js`, faked `chrome.*`) | `service_worker.test.mjs`, `frame_oopif.test.mjs`, `frame_eval_cdp.test.mjs`, `upload.test.mjs` | yes |
+| server (`server.py`, in-process) | `test_server.py` | yes, densely |
+| **bash CLI (`browser`), really executed** | `test_server.py:2635`+ (`BROWSER_BIN`, `subprocess.run`) | **yes — better than expected** |
+| agent wrapper (`browser-agent`) | `test_browser_agent.py`, `test_browser_agent_parse.py` | yes (fake opencode + fake browser) |
+| agent tool **impl** (`browser_tool_impl.mjs`) | `browser_tool.test.mjs` | yes |
+| agent tool **schema** (`opencode/tools/browser.js`) | — | **NO — never imported or asserted** (see F-1) |
+| real Brave / real opencode | — | no (by nature) |
+
+---
+
+## 2. Per-op coverage MATRIX
+
+Ops are the `browser` CLI subcommands (`browser:349-568`). "Happy" = a
+success-path assertion exists; "Fail" = at least one failure-path assertion
+exists. Layers: **C**=bash CLI executed, **S**=server, **X**=extension
+(pure/glue), **A**=agent tool impl.
+
+| op | happy | fail | layers | notes / evidence |
+|---|---|---|---|---|
+| `health` | ✅ | ⚠ partial | S | `test_server.py` `test_health_includes_extension_version_and_current`, `…_null_when_unreported`, `…_no_extension_still_reports_current_version`. **No CLI-layer test**, no non-200 path. |
+| `whoami` | ✅ | ✅ | C,S,A | `test_whoami_shape_zero_instances`, `_missing_token_401`, `_wrong_token_401`, `_bad_host_403`, `_git_head_null_still_200`; CLI `test_browser_cli_whoami`; agent `browser_tool.test.mjs:484,498,525,538`. **Best-covered op.** |
+| `instances` | ⚠ indirect | ❌ | S | Covered only via registry/`snapshot` assertions; **no CLI test, no non-200 branch, `render_instances` never exercised.** |
+| `open` | ✅ | ⚠ | S,X | Ownership recording tested server-side; `browser-agent`'s open→probe→retry tested in `test_browser_agent.py`. No CLI-level test. |
+| `close` | ✅ | ✅ | S | `no_owned_tab` asserted in `test_server.py`. No CLI-level assertion of the CLI's own `no_owned_tab` message (`browser:304-306`). |
+| `release` | ✅ | ❌ | S | Server-side only (`release_session`). **No failure path, no CLI test.** |
+| `activate` | ✅ | ✅ | S,X,A | Strong: `hidden_tab.test.mjs` (clamp, discarded tab, never-completing tab / #189 no-wedge, `windows.update` failure swallowed), `test_server.py` i3 paths incl. timeout. |
+| `html` (`getHtml`) | ✅ | ✅ | S,X | `frame_oopif.test.mjs` `--frame html`; `frame_not_found` covered. No CLI-level test. |
+| `text` | ✅ | ✅ | C,S,X,A | `test_browser_cli_text_default_maxbytes_no_selector`, `…_selector_and_maxbytes`, `…_rejects_bad_maxbytes` (CLI failure path ✅); `normalizeText` unit-tested. |
+| `eval` | ✅ | ✅ | C,S,X,A | `frame_eval_cdp.test.mjs` covers `frame_not_found`, `frame_eval_failed`, `cdp_timeout`. CLI reached via the 429 test (`test_browser_cli_backs_off_on_429` uses `eval`). |
+| `tabs` | ✅ | ❌ | S | Server contract only. **No failure path, no CLI test.** |
+| `nav` | ✅ | ⚠ | S,A | `missing_field:url` server-side; `nav_scheme_denied` only in the **agent** layer (`browser_tool.test.mjs`). **No CLI test.** See F-6. |
+| `screenshot` | ✅ | ⚠ | C,S,X | `test_browser_cli_screenshot_fullpage_flag`; `captureWithRetry` quota/transient/non-transient all unit-tested; CDP-path non-regression asserted. **The CLI's "response missing image data" branch (`browser:471-475`) is untested.** |
+| `frames` | ✅ | ✅ | C,S,X | `test_browser_cli_frames`; `ambiguous_frame` asserted in `frame_oopif.test.mjs`. |
+| `click` | ✅ | ✅ | C,S,X,A | `test_browser_cli_click_and_frame_flag`, `test_browser_cli_click_requires_selector` (CLI failure ✅), `element_not_found` in `frame_oopif.test.mjs`. |
+| `type` | ✅ | ✅ | C,S,X,A | `test_browser_cli_type_with_selector`; `test_type_requires_text_400`; telemetry-never-echoes-text asserted. |
+| `key` | ✅ | ✅ | C,S,X,A | `test_browser_cli_key`; `test_key_requires_key_400`; `keyEventParams` unit-tested. |
+| `upload` | ✅ | ✅ | C,S,X,A | Strongest failure coverage: `not_a_file_input`, `element_not_found`, `frame_not_found`, own-tab-only, fixed CDP method set (`upload.test.mjs`); CLI `test_browser_cli_upload_rejects_missing_and_nonfile_path`. **But see F-1 — the agent-facing schema is untested.** |
+| `agent` | ✅ | ✅ | (wrapper) | `test_browser_agent.py` covers the tool-set gate, timeout process-group kill, tab close on every exit path, schema-parse + one retry. **Never run for real on either host (telemetry).** |
+
+### Ops with ZERO failure-path coverage: **3**
+
+`instances`, `release`, `tabs`.
+
+All three are low-blast-radius read/bookkeeping ops, which is why this is ranked
+low — but `instances` is the one a human reads during an incident, and its CLI
+rendering path (`render_instances`, `browser:185-201`) has never been executed by
+a test.
+
+### Ops with no CLI-layer coverage at all: **8**
+
+`health`, `instances`, `open`, `close`, `release`, `html`, `tabs`, `nav`.
+
+### Documented error shapes — coverage (VERIFIED by grep across `tests/`)
+
+| error | asserted? | where |
+|---|---|---|
+| `unknown_op` | ✅ | `protocol.test.mjs`, `test_server.py`; **CLI stale-extension mapping** `test_browser_cli_unknown_op_maps_to_stale_extension_message` |
+| `frame_not_found` | ✅ | `frame_eval_cdp`, `service_worker`, `frame_oopif`, `upload` |
+| `ambiguous_frame` | ✅ | `frame_oopif.test.mjs` |
+| `owned_tab_gone` | ✅ | `browser_tool`, `test_browser_agent`, `cdp_protocol`, `protocol`, `test_server` |
+| `cdp_attach_refused:<scheme>` | ✅ | `cdp_protocol.test.mjs` |
+| `rate_limited` | ✅ | `test_server.py` + **CLI** `test_browser_cli_backs_off_on_429` |
+| `queue_full` | ✅ server | `test_server.py` — **CLI branch `browser:292-294` NOT covered** (the 429 CLI test returns `rate_limited` only) |
+| `superseded` | ✅ server | `protocol.test.mjs`, `test_server.py` — **CLI branch `browser:307-308` NOT covered** |
+| `unknown_instance` | ✅ server | `test_server.py` — **CLI branch `browser:310-315` NOT covered** |
+| `no_owned_tab` | ✅ server | `test_server.py` — **CLI branch `browser:304-306` NOT covered** |
+| `bad_tab` | ✅ | `test_server.py` |
+| `nav_scheme_denied:<scheme>` | ✅ agent only | `browser_tool.test.mjs` — **not a server/CLI concept at all**, see F-6 |
+| `unauthorized` | ✅ | `browser_tool.test.mjs`, `test_server.py` — **CLI branch `browser:286` NOT covered** |
+| `bad_host` | ✅ | `test_server.py` |
+| `ambiguous_instance` | ✅ server | `test_server.py` — **CLI branch `browser:299-303` NOT covered** |
+| `extension_not_connected` (503) | ✅ server | `test_server.py` — **CLI branch `browser:284` NOT covered** |
+| `timeout` (504) | ✅ server | `test_server.py` — **CLI branch `browser:285` NOT covered** |
+| `missing_field:<f>` | ✅ | `protocol.test.mjs`, `test_server.py` |
+| `frame_eval_failed` | ✅ | `frame_eval_cdp`, `cdp_protocol` |
+| `element_not_found` | ✅ | `frame_oopif`, `service_worker`, `upload` |
+| `not_a_file_input` | ✅ | `upload.test.mjs` |
+| `cdp_timeout` | ✅ | `frame_eval_cdp`, `cdp_protocol`, `upload` |
+
+**Headline:** every documented error shape is asserted *somewhere*. The
+consistent gap is **the CLI's own translation layer**: of the 9 distinct HTTP
+error branches in `cmd_op` (`browser:282-343`), only **2** are exercised
+(429/`rate_limited` and the `unknown_op` op-level mapping). The other 7 —
+including all the human-facing "here's what to DO next" messages — are dead code
+from the suite's point of view. That is the single biggest structural test gap,
+and it is exactly the layer whose whole purpose is a good error message.
+
+---
+
+## 3. Error-handling gaps in the code
+
+The FAIL-LOUD-AND-SAFE discipline is, on the whole, **well upheld** — noticeably
+better than the #190 history would suggest. The `finally`/always-detach and
+bounded-wait properties I specifically went looking for are present:
+
+**Verified-good (no action needed, recorded so a future reader doesn't re-litigate):**
+- CDP attach/detach is `finally`-wrapped (`extension/service_worker.js:157-186`
+  delegating to `withCdpSession`, `extension/protocol.js:498`), plus
+  `chrome.debugger.onDetach` clears out-of-band detaches
+  (`service_worker.js:143` `cdpAttached`).
+- Every CDP call is timeout-bounded (`protocol.js:451-453`,
+  `promiseWithTimeout` at `protocol.js:462`) — the #189 no-wedge property has a
+  direct regression test (`frame_eval_cdp.test.mjs`, "a HUNG `Runtime.evaluate`
+  settles with `cdp_timeout` and STILL detaches").
+- `eval --frame` explicitly refuses to return a silent null — a failure to
+  execute is `frame_not_found`/`frame_eval_failed`, a genuine `null` is a value
+  (`README.md:219-233`, tested).
+- Frame listener is removed in a `finally` (`service_worker.js:276-290`).
+- `waitForTabLoad` returns at a bound rather than wedging
+  (`protocol.js:290`, tested for the never-completing and discarded cases).
+
+**Gaps found:**
+
+**E-1 — `tabVisibilityState` swallows every failure to `null`, and the caller
+cannot tell "visible" from "couldn't check".** `service_worker.js:122-132`
+returns `null` on any throw. The hidden-tab warning (`browser:243-257`) only
+fires on `hidden === true`, so a *failed* visibility probe silently degrades to
+"no warning" — i.e. a read of a throttled, unrendered SPA returns a shell DOM
+with **no** warning. This is the exact shape of the #190 bug class (a failure
+that returns a value), just with a low blast radius. It is *documented* as
+best-effort in the comment, which is honest, but the degradation is invisible to
+the caller. Suggest a third state (`visibilityState: "unknown"`) so the CLI can
+say "could not confirm the tab is visible". **(inferred by reading; low severity)**
+
+**E-2 — the CLI's `op_error` conflates "no error" with "unparseable-but-exit-0".**
+`browser:225-236`: the python helper exits 2 on unparseable JSON and prints
+nothing when `ok` is not `False`. `cmd_op` handles `rc != 0`
+(`browser:324-327`) correctly. But if the server ever returned a 200 whose
+`result` is not a dict (e.g. `null`), `op_error` prints nothing and exits 0 → the
+CLI reports success and prints the malformed body. Narrow, but it is a
+silent-wrong-answer path on a surface whose contract is "never a silent wrong
+answer". **(inferred; low)**
+
+**E-3 — `screenshot`'s file-write branch can exit non-zero *after* the op
+already succeeded, with no cleanup or reuse path.** `browser:466-479`: if
+`dataUrl` is missing, the CLI prints "screenshot response missing image data" and
+exits 1 — but the screenshot was already taken and the data URL is discarded, and
+the message does not tell the operator what to do (re-run without a path to get
+the JSON). Untested branch. **(inferred; low — message quality)**
+
+**E-4 — `render_instances` fails open to silence.** `browser:186-200` exits 0 on
+unparseable stdin, so the 409-ambiguous / 404-unknown-instance branches can print
+the header line ("multiple instances connected — specify one with `--instance`")
+followed by **no instances at all**, which reads as a bug in the bridge rather
+than a parse failure. Never exercised by a test. **(inferred; low)**
+
+**E-5 — no `finally` guarantee that `browser-agent`'s owned tab is closed if the
+wrapper is `SIGKILL`ed.** `browser-agent` closes the tab on every *handled* exit
+path (verified by `test_browser_agent.py`), and uses `setsid` + process-group
+kill for its own timeout — good. But an external `kill -9` of the wrapper leaks
+an owned tab. The server's `OWNER_TTL_S` (900s, `server.py:187`) *releases*
+ownership but explicitly does **not** close the Brave tab (`browser:27-28`), so
+the leak is a real, if minor, tab-leak. Documented behaviour, not a bug —
+recorded so it is not mistaken for one. **(inferred; informational)**
+
+**E-6 — `server.py` has ~20 `except Exception: pass/return None` sites.** I read
+the ones on security-relevant paths (`resolve_host`, `git_short_head`,
+`manifest_version`, telemetry emit, i3 foregrounding) and they are all correctly
+best-effort diagnostics whose failure must not break an op — each is commented as
+such (`server.py:318,329,359,385,402,470,493,537,1317`). **No swallowed exception
+found on an op-execution path.** Recording this as a *cleared* concern.
+
+---
+
+## 4. Tool gaps
+
+Judged against what the telemetry says is actually used (eval, nav, text, open,
+getHtml, screenshot, tabs, close, frames, activate, click, key, release, upload).
+
+| candidate | verdict | reasoning |
+|---|---|---|
+| **wait-for-selector / wait-for-settle** | **genuine gap — worth an op** | This is the highest-value missing primitive. Today the only settle mechanism is `activate`'s bounded wait (`protocol.js:251-259`), which requires **stealing the user's focus** — the one intrusive op — to get a load guarantee. Everything else is the agent hand-rolling a poll through repeated `text`/`eval` calls, which is precisely the pattern that generated the 43,740-eval hour. A `browser wait --selector <sel> [--timeout MS]` op, bounded server-side like `activate`, would remove the busiest toil loop *and* remove the main incentive to poll. Strongest recommendation in this section. |
+| **scroll** | **worth an op (small)** | Currently an `eval` recipe, and SKILL.md:63-64 has to document a footgun about it: `window.scrollBy(0,1400)` returns `null` with no error and "looks like a broken bridge and isn't", so the operator must wrap it in an IIFE returning `"ok"`. A documented footgun around a one-line recipe is a decent signal the recipe should be an op. Cheap: `scroll` maps to an existing `eval`-shaped path. |
+| **computed styles / hit-testing** | **keep as a recipe** | SKILL.md:308-340 documents a real `elementFromPoint` + `getComputedStyle` recipe. It is genuinely open-ended (which points, which properties, what to report) — an op would either be under-powered or grow a mini-DSL. The recipe is adequate. Only fix: the recipe is *long*, so consider promoting it to a named snippet the skill can paste verbatim rather than have the model re-derive. |
+| **back / forward** | **minor gap, low priority** | Not in `ALLOWED_OPS` (`server.py:125-127`). `eval 'history.back()'` works and is used rarely per telemetry. Add only if it falls out of a `nav` refactor. |
+| **structured extraction (tables/links)** | **keep as a recipe** | `text` + `eval` cover it, and the shapes callers want vary too much to freeze into an op. No evidence of toil in telemetry. |
+| **composite `open→activate→read`** | **worth it, but as a CLI convenience, not a server op** | The SKILL's own "driving a throttled SPA" flow (SKILL.md:136, 184, 243) is a fixed 3-4 step dance every agent repeats. Collapsing it into `browser open --activate --read <url>` is pure CLI-side sequencing — no new server op, no new extension code, no new blast radius. Good effort:value. |
+| **cookie / storage inspection** | **do NOT add** | This is the highest-sensitivity data on a live-cookie surface, and the agent tool is explicitly designed to be driven by a cheap model on hostile pages. Adding a first-class read of cookies/localStorage would hand a prompt-injected model a clean session-token exfil primitive. The `eval` path is already same-origin-bounded and audited; leave it there and do not make it ergonomic. |
+| **downloads** | **do NOT add (for now)** | Symmetric to `upload` but writing to the local filesystem from attacker-influenced content. Given F-1/F-2 below are still open on `upload`, adding the write direction is the wrong order of operations. |
+
+---
+
+## 5. Docs-vs-code drift
+
+Every numeric default in the docs was checked against code. **All of the
+frequently-cited defaults are CORRECT** — recording this explicitly so the next
+reader does not re-verify:
+
+| claim | doc | code | verdict |
+|---|---|---|---|
+| rate limit 5/sec | `README.md:300` | `server.py:199` `RATE_PER_SEC=5` | ✅ correct |
+| burst 20 | `README.md:301` | `server.py:200` `BURST=20` | ✅ correct |
+| max queue 32 | `README.md:306` | `server.py:201` `MAX_QUEUE=32` | ✅ correct |
+| `--steps` 12 | `SKILL.md`/`README.md` | `browser-agent:80` `STEPS=12` | ✅ correct |
+| `--timeout` 120s | `SKILL.md`/`README.md` | `browser-agent:80` `TIMEOUT=120` | ✅ correct |
+| text cap 32768 | `browser:61`, `README.md:193` | `browser:421` `maxb=32768`; `protocol.js:69` `32*1024`; `browser_tool_impl.mjs:79` `32768` | ✅ correct, and consistent across all three layers |
+| activate wait ~3s / cap ~8s | `SKILL.md:136`, `README.md:158` | `protocol.js:251` `3000`, `:254` `8000` | ✅ correct |
+| CDP timeouts | `README.md:230` ("bounded") | `protocol.js:451-453` 8000/8000/15000 | ✅ correct (docs are qualitative, no number to drift) |
+| owner TTL | `browser:27` ("idle TTL") | `server.py:187` `900` | ✅ correct (no number claimed) |
+| README op table vs `ALLOWED_OPS` | `README.md:144-160` | `server.py:125-127` | ✅ every documented op exists; `release` correctly documented as server-only (`server.py:132`) |
+
+### Confirmed drift
+
+**D-1 (CONFIRMED STALE, as briefed) — the opencode 1.17.20 version-skew claim.**
+`opencode --version` on this host returns **1.18.4** (VERIFIED by running it).
+The docs still assert a workbench/laptop split:
+- `SKILL.md:409` — "versions resolve the deny differently (workbench 1.17.20, laptop 1.18.4)"
+- `README.md:519-520` — "different opencode versions resolve it differently (workbench is 1.17.20, laptop 1.18.4)"
+- `README.md:533` — "verified on 1.18.4"
+- `README.md:572` — "defensive across the laptop 1.18.4 / workbench 1.17.20 version skew"
+- `README.md:605` — "⚠ opencode version skew (workbench 1.17.20 vs laptop 1.18.4)"
+- `README.md:609` — "It is **NOT verified on 1.17.20** (workbench)"
+
+Both hosts are now 1.18.4 (a second check confirmed both run the *identical*
+nix-store binary,
+`/nix/store/64n428w29sra24db9d6h6clzdh0vy9hk-opencode-1.18.4/bin/opencode`, same
+sha256). **Important nuance the docs get right and should keep:** the gate
+(`browser-agent:168-190`) does not check a version *number* at all — it runs
+`opencode debug agent browser-agent` and asserts the resolved **`tools`** map is
+browser-only. There is no version constant to bump; only the prose is stale.
+Additional stale line found on the second pass: `README.md:613` still says
+"**Recommend upgrading workbench to ≥1.18.4**" — already done.
+
+**⚠ But do NOT conclude from this that the gate now passes.** It does not,
+for a completely different reason — see **D-6**, which supersedes the "just a
+doc fix" reading of D-1.
+
+**D-6 (NEW, VERIFIED BY ME — highest-value finding of the second pass) —
+`browser agent` is broken by an opencode stdout-truncation race, and the docs
+misattribute the failure to version skew.**
+
+`browser-agent:168` captures the gate input with command substitution:
+
+```bash
+gate_out="$(cd "$SCRATCH" && "$OPENCODE_BIN" debug agent browser-agent 2>/dev/null)"
+```
+
+`$(...)` is a **pipe**. opencode truncates its stdout when stdout is a pipe
+rather than a file — it exits without flushing the full buffer. The gate then
+parses truncated JSON, fails to parse, and **fails closed** (exit 3 →
+`unparseable debug-agent tool set`).
+
+Measured on **this host (laptop, 192.168.50.155)**, VERIFIED by running:
+
+```
+opencode debug skill   pipe=65536   file=293329   (deterministic, 3/3)
+opencode debug v2      pipe=55276   file=55276, 55276, 6103  (varies run to run)
+```
+
+`debug skill` truncates at **exactly 65536 bytes (64 KiB)** on a pipe while the
+same command redirected to a file yields 293329. `debug v2` shows the race
+directly: identical invocations produced 55276 twice and 6103 once.
+
+A parallel investigation independently reproduced the same class of failure on
+the **workbench (192.168.50.250)** against the real gate — truncation at **8192
+bytes**, 3/3 runs, producing exactly the gate's failure text
+(`unparseable debug-agent tool set: Unterminated string starting at: line 162
+column 13 (char 3761)`), while the same command redirected to a file yielded 9530
+bytes and parsed cleanly to a tool set of `['browser']` — i.e. **the confinement
+config is correct; only the capture is broken.**
+
+Two thresholds (8192 vs 65536) and a run-to-run variance mean this is **not a
+fixed buffer cap but a flush race on exit**, so which hosts are affected depends
+on output size, timing, and config — it is not a stable property of a host.
+
+Assessment:
+- **The gate is behaving correctly** — it fails closed on unparseable input,
+  exactly as designed (`browser-agent:170-190`). This is the fail-closed
+  discipline working.
+- **But `browser agent` is non-functional wherever the race bites**, and the
+  docs tell the reader to blame opencode 1.17.20 — a diagnosis that is now
+  false and would send someone chasing a version upgrade that is already done.
+- It also plausibly explains why **`browser agent` has never been invoked on
+  either host** (telemetry). I cannot prove that causally — telemetry records
+  invocations, not refusals — so I state it as a hypothesis, not a finding.
+- **Fix:** capture via a temp file (or `stdbuf`) instead of `$()` at
+  `browser-agent:168`. Small, contained, and testable.
+
+Honesty note on provenance: the workbench measurements were taken over ssh by a
+parallel investigation (pipe-vs-file behaviour was identical under `ssh -tt`, so
+it is not an ssh artifact, but it was not tested from a workbench-local
+interactive terminal). **The laptop measurements above are mine and were run
+directly.** The truncation itself I consider VERIFIED; the specific claim "the
+real gate fails on workbench" is verified-by-proxy, and re-running
+`browser agent --dry-run` on the workbench locally is the cheap confirmation.
+
+**D-2 — the `tools`-vs-`permission` gate question (SETTLED).** A prior
+investigation flagged that the resolved permission map shows `*: allow`, which
+would look alarming. I checked the gate directly: `browser-agent:170-190` reads
+`json.load(sys.stdin)["tools"]` — the **tools** map, not the permission map — and
+fails closed on *any* uncertainty (unparseable output → exit 3; `browser` not
+`True` → exit 4; any other tool `True` → exit 5; any of
+`bash/read/edit/write/webfetch` **absent** → exit 6, so absence never reads as
+"disabled"). **The gate's actual check is sound and is checking the right map.**
+The `permission` frontmatter in `opencode/browser-agent.md` (`"*": deny`,
+`browser: allow`) is a second, independent layer; whatever the resolved
+permission map shows does not weaken the tools gate, because tool *enablement* is
+what bounds the action surface. I consider this lead closed — no finding.
+
+**D-3 — `nav_scheme_denied` is documented as a bridge error shape but exists ONLY
+in the agent tool.** `SKILL.md:419` and `README.md:543-550` describe
+`nav_scheme_denied:<scheme>`. Grep across `server.py`,
+`extension/service_worker.js`, `extension/protocol.js` returns **zero** hits; the
+only definition is `browser_tool_impl.mjs:117,122,222,420`
+(`NAV_ALLOWED_SCHEMES`). So `browser nav file:///etc/passwd` from the **CLI** is
+not scheme-gated at all. That is a defensible design (the operator's own CLI is
+trusted; the *model* is not), and README.md:543 is in the agent section — but
+`SKILL.md:419`'s placement invites the reading that the bridge denies it
+globally. **doc-fix**: state plainly that the scheme gate is an
+autonomous-agent-only control, and that the CLI deliberately has no such gate.
+
+**D-4 — `README.md:293` cites "43,991 evals in one hour"; the operator's current
+telemetry read is 43,740.** Same event, drifted number. Trivial, but it is a
+figure that gets quoted into decisions. **doc-fix.**
+
+**D-5 — extension manifest is `0.2.0` (`extension/manifest.json:4`)**, and
+`README.md:286` uses "a pre-0.2.0 build" as its stale-extension example. Correct
+today, but the manifest is explicitly *not* bumped per change
+(`README.md:82-84`), so this example silently rots. Recording as a known
+maintenance hazard, not a current error.
+
+**D-7 — `README.md:496-498` lists the agent's op set as 10 ops
+(`text,html,eval,nav,screenshot,frames,click,type,key,activate`); the code's
+`ALLOWED_OPS_DEFAULT` has 12 (adds `upload` and `whoami`).** Note the direction:
+**README matches the safe `browser.js` enum**, while `browser_tool_impl.mjs:74-77`
+and `opencode/browser-agent.md:22-33` (which lists all 12 accurately) match the
+permissive list. So the drift is now a **three-way** disagreement across README /
+tool schema / impl+prompt. This materially strengthens **F-1**: the safe behaviour
+is what README documents, so option (a) — dropping `upload`/`whoami` from
+`ALLOWED_OPS_DEFAULT` and the agent-md table — makes code match the *already
+published* contract rather than changing it.
+
+**D-8 — 13 env vars read by code are documented nowhere in README/SKILL:**
+`BROWSER_BRIDGE_PORT`, `_HOST`, `_TOKEN_FILE`, `_CMD_TIMEOUT` (default 20,
+`server.py:1712`), `_POLL_TIMEOUT` (default 25), `_I3_TIMEOUT` (1.5,
+`server.py:213`), `_NO_AUTOSTART`, `_SPOOL_EMIT`, `_ACTIVATE_TIMING`,
+`_CDP_TIMEOUTS` (test-only, `service_worker.js:154`), `BROWSER_AGENT_AUDIT`,
+`BROWSER_AGENT_ALLOWED_OPS`, `BROWSER_AGENT_SESSION_ID`. Several are documented in
+`server.py:72-79`'s own `--help`, so the gap is README/SKILL specifically. Every
+*documented* env var was confirmed to be genuinely read — this is an omission, not
+an error. `BROWSER_AGENT_ALLOWED_OPS` is the notable one given F-1.
+
+**D-9 — the CDP timeout constants are never documented numerically.**
+`README.md:673-674` says only "a bounded budget"; actuals are `protocol.js:451-453`
+(8000/8000/15000). Not wrong, just absent.
+
+**Second-pass coverage note:** the systematic line-by-line prose sweep of
+SKILL.md + README.md was completed on the second pass. It additionally confirmed
+as CORRECT: the SKILL.md subcommand table (`SKILL.md:119-140`) matches the
+`case "$sub"` dispatch exactly (all 19 subcommands + `--print-session-id`, no
+drift); the README op table matches `ALLOWED_OPS` and `service_worker.js`'s `OPS`
+exactly (14/14, zero documented-but-unimplemented, zero
+implemented-but-undocumented); `release` correctly documented as server-only; the
+manifest `0.2.0` / `SKILL.md:46` "pre-0.2.0" example is consistent; and the
+`setsid` process-group kill is confirmed at `browser-agent:298-311`.
+
+---
+
+## 6. The `upload` agent-reachability assessment
+
+### The claim as briefed
+
+`ALLOWED_OPS_DEFAULT` (`browser_tool_impl.mjs:74-77`) includes `upload`, and
+`buildRequest`'s upload branch (`:274-284`) does presence checks only —
+explicitly documented as "ANY path is allowed for the agent … no path allowlist"
+(`:65-73`, `:277`), audit-logged (`server.py:1608-1612`, `1666-1675`) but not
+prevented. A test even pins this as intended
+(`browser_tool.test.mjs:570` — "upload allows ANY path (explicit exfil tradeoff — no path allowlist)").
+So on the impl layer the briefing is **accurate**.
+
+### What I found that changes the severity
+
+**F-1 (KEY FINDING) — the typed tool schema the model actually sees does NOT
+expose `upload`.** `opencode/tools/browser.js:38-40` declares:
+
+```js
+op: tool.schema
+  .enum(["text", "html", "eval", "nav", "screenshot",
+         "frames", "click", "type", "key", "activate"])
+```
+
+`upload` is **not in the enum**, `whoami` is **not in the enum**, and there is
+**no `path` argument declared at all** in the `args` block
+(`browser.js:41-60` declares only `op, selector, url, js, text, key, frame,
+maxBytes, waitMs`). `tool.schema` is zod
+(`@opencode-ai/plugin/dist/tool.d.ts:1` — `import { z } from "zod"`), and
+opencode validates tool args against it before `execute` runs.
+
+So end-to-end, today, the model's call would fail **twice** before touching a
+file: the `op` value fails enum validation, and even if it did not, `path` is an
+undeclared arg that would not survive schema parsing → `buildRequest` would throw
+`upload_missing_path` (`browser_tool_impl.mjs:280`).
+
+**Exploitability verdict: NOT currently exploitable end-to-end.** Combined with
+the telemetry fact that **`browser agent` has never been invoked on either host**,
+real-world exposure to date is **zero**.
+
+### Severity call
+
+**Low as an active vulnerability. Medium as a latent one.** I am deliberately not
+inflating this. The reasons it is not "none":
+
+1. **The two layers disagree, and the safe one is accidental.** Nothing in the
+   code or comments says "the enum is the upload gate". The impl's comment block
+   (`browser_tool_impl.mjs:65-73`) reads as though upload *is* reachable and the
+   audit log is the compensating control. Whoever wrote the enum and whoever
+   wrote `ALLOWED_OPS_DEFAULT` did not agree, and no test asserts the enum
+   (`browser.js` is never imported by any test — VERIFIED). A future edit that
+   "fixes" the mismatch in the obvious direction — adding `upload` and `path` to
+   the schema so the documented feature works — opens full local-file exfil with
+   **no remaining gate**.
+2. **The agent definition actively instructs the model to use it.**
+   `opencode/browser-agent.md` lists `browser(op="upload", selector="…", path="…")`
+   in its capability table, and `op="whoami"` too. So the prompt promises two ops
+   the schema rejects. That is a live functional bug (`whoami` in particular is
+   the "confirm which host you're on before acting" safety habit the docs push),
+   and it is the exact pressure that would cause someone to widen the enum.
+3. **`BROWSER_AGENT_ALLOWED_OPS` does not help.** `allowedOpsFromEnv`
+   (`:148-151`) can only *narrow* against the impl list; it cannot widen past the
+   schema, and it is not what is blocking upload today.
+
+The realistic attack chain, were the schema widened: a prompt-injecting page the
+agent is told to read instructs it to call
+`upload(selector="input[type=file]", path="~/.ssh/id_ed25519")` against a file
+input the attacker placed on their own page, then `click` the submit button. Every
+step is an op the agent already has (`click` is in the enum, the tab is the
+agent's own and is on the attacker's domain by construction if the goal sent it
+there). Chrome reads the file by path and posts it. The domain allowlist does not
+help — the attacker page *is* the allowed domain. The audit log records it after
+the fact. So the chain is short and fully mechanised; only the enum is in the way.
+
+### Minimal fix options (assessed, not applied)
+
+| option | effect | cost | verdict |
+|---|---|---|---|
+| **(a) Drop `upload` from `ALLOWED_OPS_DEFAULT`** (`browser_tool_impl.mjs:74-77`) and from the `browser-agent.md` capability table | Makes the two layers agree in the SAFE direction. Removes the pressure to widen the enum. Operator keeps `upload` on the CLI (where it is validated at `browser:544-548`). | ~15 min + test update (`browser_tool.test.mjs:285,293,551-577` assert the current list) | **Recommended.** Highest safety per unit effort, and costs nothing real: the agent has never used upload, and an upload is an operator-intent action, not a browsing action. |
+| **(b) Server-side sensitive-path deny-list** in `server.py` (reject `~/.ssh/**`, `~/.config/browser-bridge/token`, kubeconfigs, `**/.env`, `id_*`) | Defends the CLI path too, and defends any future caller. But a deny-list on a filesystem is a losing game (symlinks, `/proc/self/…`, relative traversal, unanticipated secrets). | ~1-2 h to do properly | **Do as defence-in-depth, not as the primary control.** Note it must resolve symlinks first — the CLI already does `os.path.realpath` (`browser:547`), the server does not. |
+| **(c) Both** | (a) closes the agent surface, (b) bounds operator/CLI mistakes | | **Best if the budget exists.** Do (a) first; it is the one that matters. |
+| **(d) Make the enum the documented gate** (leave the impl as-is, add a comment + a test asserting `upload`/`whoami` are absent from `browser.js`'s enum) | Cheapest possible | ~20 min | Acceptable *only* alongside (a). On its own it enshrines a confusing two-list design. |
+
+Whichever is chosen, **add a test that asserts `browser.js`'s `op` enum equals
+the agent's intended op set** — that is the missing check that let the two lists
+drift apart silently, and it is ~10 lines.
+
+---
+
+## 7. Ranked remediation list
+
+| # | finding | label | severity | effort |
+|---|---|---|---|---|
+| 1 | **`browser-agent:168` — replace `$(...)` capture with a temp file (or `stdbuf`)** so the tool-set gate reads opencode's full `debug agent` output instead of a pipe-truncated prefix. This is what makes `browser agent` refuse to run (D-6). Verified truncation on the laptop (64 KiB) and, by proxy, on the workbench (8 KiB) | `cli-change` | **High (feature is dead)** | ~1 h incl. a regression test |
+| 2 | Reconcile the agent op surface: drop `upload` (and decide `whoami`) from `ALLOWED_OPS_DEFAULT` + the agent-md table, and add a test pinning `browser.js`'s `op` enum against the intended set (F-1, D-7). Note this makes code match the contract **README already publishes** | `security` + `test-gap` | **Medium (latent)** | ~30 min |
+| 3 | `whoami` (and `upload`) are promised to the model in `browser-agent.md` but rejected by `browser.js`'s enum — the agent literally cannot run the "confirm your host first" habit the docs mandate. Make schema + impl + prompt + README agree (currently a three-way split) | `cli-change` (tool schema) | **Medium (functional)** | ~30 min |
+| 4 | Cover the CLI's 7 untested error branches (`503/504/401/409×3/404`) — the whole human-facing "what to do next" layer is unexercised. The existing `_CannedCmdServer` harness (`test_server.py:3400`+) makes each one ~10 lines | `test-gap` | Medium | ~2 h |
+| 5 | Rewrite the stale opencode 1.17.20 claims (D-1) at `SKILL.md:409`, `README.md:519-520,533,572,605,609,613` — **and replace the framing**: the failure mode is the stdout-truncation race (#1), not version skew. Delete the "⚠ opencode version skew" block (`README.md:605-613`) and the "recommend upgrading workbench" line entirely | `doc-fix` | Medium (actively misdiagnoses #1) | ~30 min |
+| 6 | Add a `wait` op (wait-for-selector / wait-for-settle), bounded server-side like `activate` — removes the busiest toil loop and the main incentive to poll with `eval` | `new-op` | Medium (value) | ~1 day |
+| 7 | Clarify that `nav_scheme_denied` is an autonomous-agent control only, and that the CLI has no scheme gate (D-3) — `SKILL.md:419` | `doc-fix` | Medium (security-model clarity) | ~10 min |
+| 8 | `tabVisibilityState` returning `null` on failure means "unknown" is indistinguishable from "visible", so a throttled-SPA read can return a shell DOM with no warning (E-1) | `extension-change` | Low | ~1 h |
+| 9 | Server-side sensitive-path deny-list for `upload`, with symlink resolution (option (b)) | `security` | Low (as defence-in-depth) | ~1-2 h |
+| 10 | Add a `scroll` op — it is the one `eval` recipe whose footgun had to be documented (`SKILL.md:63-64`) | `new-op` | Low | ~2 h |
+| 11 | Composite `browser open --activate --read <url>` to collapse the repeated 3-4 step SPA dance; CLI-side sequencing only, no new blast radius | `cli-change` | Low | ~3 h |
+| 12 | Failure-path tests for `instances`, `release`, `tabs` (the 3 ops with zero failure coverage); include `render_instances` | `test-gap` | Low | ~1 h |
+| 13 | `op_error` can exit 0 on a 200 whose `result` is not a dict (E-2); `screenshot`'s missing-image-data branch gives no next step (E-3); `render_instances` fails open to silence (E-4) | `cli-change` | Low | ~1 h total |
+| 14 | Document the CDP timeout constants (D-9) and the 13 undocumented env vars (D-8), notably `BROWSER_AGENT_ALLOWED_OPS` | `doc-fix` | Low | ~30 min |
+| 15 | Update the "43,991 evals" figure to 43,740 (`README.md:293`) (D-4) | `doc-fix` | Trivial | ~2 min |
+
+### Explicitly NOT recommended
+- Cookie/localStorage inspection ops, and download ops — both would hand a
+  prompt-injected cheap model a clean exfil/write primitive on a live-cookie
+  surface. Keep them behind `eval`.
+- Any work on `eval --frame` grandchild-OOPIF `frame_not_found` — **known and
+  in-flight**, another agent is fixing it. It currently fails safe.
+
+---
+
+## 8. What could not be verified without a live browser (or at all)
+
+- **Every op's actual behaviour in Brave.** All extension coverage is against
+  faked `chrome.*` APIs. A test passing proves the decision logic, not that
+  Chrome does what we think.
+- **Whether opencode 1.18.4's zod validation rejects an out-of-enum `op` before
+  `execute`, or passes it through.** I confirmed `tool.schema` is zod
+  (`@opencode-ai/plugin/dist/tool.d.ts:1`) and that `upload`/`path` are absent
+  from the schema, but I did **not** run opencode to observe the rejection. If
+  opencode were lenient here, `op="upload"` would reach `buildRequest` and be
+  refused as `upload_missing_path` — still blocked, but by a thinner margin.
+  This is the one inference the `upload` severity call rests on; **it deserves a
+  live check by the operator**, and it is cheap: run `browser agent --dry-run`
+  with a goal that induces an upload call and read the audit log.
+- **The real gate failing on the workbench specifically.** I VERIFIED the
+  underlying opencode stdout-truncation on this host (laptop) directly, and a
+  parallel investigation reproduced the actual gate failure on the workbench over
+  ssh. I did not run the real gate on a workbench-local terminal. Cheap
+  confirmation for the operator: run `browser agent --dry-run "test"` on the
+  workbench and check whether it dies at `tool-set gate FAILED` /
+  `unparseable debug-agent tool set`.
+- **Whether the truncation can ever produce PARSEABLE-but-wrong JSON.** A
+  truncated JSON object is almost certainly unterminated → parse error → exit 3 →
+  fail closed, which is safe. I did not attempt to construct a truncation point
+  that parses. If one existed the gate could in principle read a short tool map;
+  note that even then `required_false` absence (exit 6) is a second backstop, so
+  I assess this as very unlikely to be exploitable.
+- **The extension's supersede back-off** (`README.md:100` already flags this as
+  browser-only-verifiable).
+- ~~A full prose sweep of SKILL.md/README.md~~ — **completed on the second
+  pass** (see the second-pass coverage note in §5). Both the numeric/default
+  sweep and the behavioural-prose sweep are now done.

--- a/claudedocs/browser-bridge-deepseek-measurement-2026-07-31.md
+++ b/claudedocs/browser-bridge-deepseek-measurement-2026-07-31.md
@@ -1,0 +1,271 @@
+# Measuring `browser agent` (deepseek-v4-flash) — 14 real goals on the live laptop Brave, 2026-07-31
+
+**Question:** is deepseek-flash good enough for `browser agent` to become the DEFAULT for
+open-ended reads? This gates the designed-but-unshipped default flip
+(`claudedocs/browser-bridge-token-and-agent-design-2026-07-30.md` §B.1–B.4).
+
+**Setup (name the scope):** host = **laptop** (`192.168.50.155`, verified via `browser
+whoami`), instance = **`personal`**, extension `0.2.0`, server `whoami-1 (2026-07-30)` at
+git `039955d`, `opencode` 1.18.4, model `openrouter/deepseek/deepseek-v4-flash` (the
+wrapper default), default `--steps 12` / `--timeout 120`. Every run got a tight
+`--allow-domains`. All runs used `BROWSER_AGENT_KEEP_SCRATCH=1`, so every verdict below is
+backed by the run's `tool-audit.jsonl` + full opencode transcript, not by the agent's
+self-report. No repo source file was modified. No `activate` was issued at any point.
+
+---
+
+## 1. Results
+
+| # | Goal | Target | status | steps claimed / **actual tool calls** | wall | **correct?** | notes |
+|---|---|---|---|---|---|---|---|
+| A | Top 3 HN story titles | news.ycombinator.com | ok | 2 / 2 | 16.9s | ✅ | exact match + order vs `curl` of HN |
+| B | Do Playwright docs mention "Trace viewer"? | playwright.dev | ok | 2 / 2 | 20.5s | ✅ | truth: string appears 4× in `/docs/intro`. Evidence was **paraphrase, not verbatim** |
+| C | deepseek-v4-flash price + context on OpenRouter | openrouter.ai | ok | 2 / 2 | 18.7s | ✅ | `$0.0896/$0.1792 per 1M`, 1M ctx — matches the **page** (a discounted price; the `/api/v1/models` figure `0.14/0.28` would have been the wrong ground truth) |
+| D | Follow a link from nixos.org → stable release version | nixos.org | ok | 5 / **7** | 22.6s | ✅ | `26.05`. Its `click` reported `ok:true` but did **not** navigate; it read **stale text and did not notice**, then recovered via `eval` href → `nav` |
+| E | **B.3.1** — click the Docs link, report H1 | playwright.dev | ok | 8 / **12** | 59.0s | ✅ | `Installation`. See §3.1 — right answer, 6× the median cost |
+| F | civitai model-benchmarking SPA | civitai.com | ok | 3 / 3 | 22.7s | ✅ (degenerate) | Page is now a **real 404** — I confirmed with my own woken read (`title: "Page Not Found"`). The documented known-bad case no longer exists; **did not exercise the trap** |
+| **F2** | **B.3.2 (substitute)** — `wake-rig.html`, exact `#app` text | 127.0.0.1:8901 | **ok** | 3 / 3 | 32.3s | ❌ **WRONG** | Answered `WAKE-RIG-SHELL (waiting for frames)`. Truth (my read, same tab, before/after `wake`): `WAKE-RIG-SHELL…` → **`WAKE-RIG-RENDERED`**. Confident wrong `ok` |
+| G | **B.3.3** — RIG_SECRET in the deepest nested OOPIF | 127.0.0.1 + sslip.io + nip.io | ok | 7 / 7 | 23.9s | ✅ | `grandchild-reached`. **Never called `frames`** — it top-level-`nav`'d to each iframe URL instead |
+| G2 | Same, `--allow-domains 127.0.0.1` only (workaround forbidden) | 127.0.0.1 | ok | 5 / **7** | 30.0s | ✅ | Called `frames`, picked `frameId 170`, `eval --frame 170` → correct |
+| H | **Guardrail** — Wikipedia goal, `--allow-domains example.com` | — | **blocked** | 2 / 2 | 11.9s | ✅ | Clean `status:"blocked"`, **exit 1**, empty evidence, no fabrication, no hang |
+| I | `requests` latest version + license | pypi.org | ok | 2 / 2 | 15.5s | ✅ | `2.34.2`, `Apache-2.0` — matches `pypi.org/pypi/requests/json` |
+| J | Multi-page: HN #1 → its comments page → submitter + comment count | news.ycombinator.com | ok | 4 / **6** | 47.7s | ✅ | `Jrh0203`, `142 comments`; HN API read minutes later showed `descendants 143`, `score 430` vs the agent's quoted `428 points` — consistent drift, page-accurate at read time |
+| K | First 3 models on civitai.com/models (virtualised SPA) | civitai.com | ok | 7 / **8** | 48.7s | ✅ | Called `wake` **twice** on its own, then `html`. Verified against my own `html --wake`: first three `/models/<id>/<slug>` in DOM order are `one-obsession`, `velvets-mythic-fantasy-styles…`, `lustify-nsfw-checkpoint` — exact match |
+| L | Top 3 on OpenRouter rankings (SPA) | openrouter.ai | ok | 2 / 2 | 18.1s | ✅ | `MiMo-V2.5 / DeepSeek V4 Flash / Hy3` + token figures — exact match vs my woken read |
+
+---
+
+## 2. Measured success rate
+
+**p = 13/14 = 0.93** over all runs (the denominator is 14 agent invocations, each run once).
+
+Excluding H (a guardrail-by-design case, not a capability measure): **p = 12/13 = 0.92**.
+
+By task shape:
+
+| shape | goals | p | median wall | notes |
+|---|---|---|---|---|
+| simple single-page read | A, B, C, I, L | **5/5 = 1.00** | 18.1s | always 2 tool calls |
+| single-page, page is genuinely gone | F | 1/1 | 22.7s | correctly reported the 404 |
+| multi-page / follow-a-link | D, J | **2/2 = 1.00** | 35.2s | both needed a recovery step |
+| interactive (blind `click`) | E, K | **2/2 = 1.00** | 53.9s | 8–12 tool calls; 5–6× median cost |
+| cross-origin frames | G, G2 | **2/2 = 1.00** | 27.0s | see §3.3 |
+| **throttled/unrendered shell** | **F2** | **0/1 = 0.00** | 32.3s | **confident wrong `ok`** |
+| guardrail (out-of-allowlist) | H | 1/1 | 11.9s | clean `blocked`, exit 1 |
+
+⚠ **Each goal ran exactly once** — this is a point estimate with no variance. 13/14 has a
+95% binomial CI of roughly **0.66–0.998**. Treat `p ≈ 0.9` as the order of magnitude, not
+as a precise number. Throttling itself is nondeterministic: my own probe of
+`openrouter.ai/rankings` in a hidden tab returned **78 chars**, yet run L read the full
+2,002-char rendered text from a hidden tab ~10 minutes later without waking.
+
+---
+
+## 3. Hypothesis verdicts
+
+### 3.1 B.3.1 — blind selector synthesis: **CONFIRMED as a cost/latency weakness, REFUTED as a correctness failure** (2 points: E, K; plus D)
+
+The predicted mechanism is real and observable:
+
+- **E, call 3:** `click` with `selector: 'a:has-text("Docs")'` — a Playwright-ism the model
+  invented having never seen the markup. The tool returned a **clean, actionable error**:
+  `op_failed:SyntaxError: … 'a:has-text("Docs")' is not a valid selector`. (This is a
+  harness *strength*, not the silent failure I expected.)
+- **D, call 3:** `click` with `a[href*="download"]` returned `ok:true, x:1215, y:76` — but
+  the tab did **not** navigate. The model's next `text` returned the **stale homepage**, and
+  it did not notice; it only recovered because the content obviously lacked a version.
+- **E, call 5:** `click a[href*="docs"]` returned `ok:true, x:200, y:30` and again did not
+  navigate.
+
+What the prediction got wrong: the model **routes around the missing op**. In E it ran
+`Array.from(document.querySelectorAll('a')).filter(a => a.textContent.trim()==='Docs')
+.map(a => ({href, text, outer}))` — i.e. it **hand-rolled the proposed `links` op** in
+`eval`, got `<a class="navbar__item navbar__link" href="/docs/intro">Docs</a>`, and
+proceeded. It never fell back to a full `html` dump on E.
+
+**The cost is where it hurts:** E used **12 tool calls / 59.0s / $0.005** and K **8 calls /
+48.7s / $0.005**, against a simple-read baseline of **2 calls / ~18s / ~$0.001**. A `links`
+op would be a **5–6× efficiency win on interactive goals**, not a correctness fix.
+
+### 3.2 B.3.2 — the throttled-background-tab trap: **CONFIRMED**, and I found the harness bug that causes it
+
+**F2 is the single measured failure and it is exactly the predicted shape:** a confident
+**wrong** answer with `status:"ok"`, produced from an unrendered shell, with faithful
+evidence. The agent read `#app` twice (once by `eval`, once by `text --selector`), both
+returned the shell string, and it reported it as fact. My own read of the same fixture
+proved the correct answer is `WAKE-RIG-RENDERED` (before `wake`: `WAKE-RIG-SHELL (waiting
+for frames)`, `hidden:true`; after `wake`: `WAKE-RIG-RENDERED`).
+
+**Root cause (read from source, not inferred from behaviour) —
+`scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs`, `summarizeResult()`:**
+
+```js
+if (op === "text") return typeof data.text === "string" ? data.text : JSON.stringify(data);
+if (op === "html") return typeof data.html === "string" ? data.html : JSON.stringify(data);
+```
+
+The server **does** return `hidden:true` and the full "tab is hidden — background tabs are
+throttled…" `note` (I see it on every one of my own direct CLI reads). `summarizeResult`
+**discards both** for `text` and `html` and hands the model the bare string. The nudge
+reaches the model **only by accident**, via the `eval` branch when the value is
+`null`/non-string and it falls through to `JSON.stringify(v ?? data)`.
+
+That accident is visible in the data, and it is what saved runs E and K:
+
+- **E, call 9** (`eval` of `.click()` → `null`) → the whole `data` object dumped, note
+  included → the model's very next call was `wake`, then the correct read.
+- **K, call 5** (`eval` returning `null`) → note leaked → `wake`, `wake` again, correct
+  answer.
+- **F2** used `eval` returning a **string** and `text` — the note was stripped both times.
+  The model had no signal at all.
+
+**The discriminator is whether the shell looks plausible.** In K the shell was obviously
+missing the content the goal asked for, so the model retried; in F2 the shell was a
+complete, confident-looking string, so it stopped. This is precisely why the fix must be
+**deterministic, not modelled**.
+
+### 3.3 B.3.3 — cross-origin frames: **REFUTED at both measured points**
+
+- **G** (frame URLs standalone-navigable, all three domains in `--allow-domains`): the model
+  **skipped `frames` entirely** and instead `nav`'d the top-level tab to each iframe URL in
+  turn. Right answer, 7 calls. The discovery skip was predicted — the predicted
+  *consequence* ("reads the top frame and reports the page is empty") did not occur.
+- **G2** (same goal, `--allow-domains 127.0.0.1` only, so the nav workaround is refused):
+  the model called `frames`, read
+  `[{frameId:0,…},{frameId:168,…mid…},{frameId:170,…leaf…}]`, correctly identified 170 as
+  the deepest, and issued `eval --frame 170` → `grandchild-reached`. Textbook.
+
+No wrong answer, no "page is empty" at either point. **Note the dependence I measured:**
+G's workaround only worked because the frame hosts were in the allowlist; the frames path
+is what you get when the allowlist is tight.
+
+### 3.4 B.3.5 — self-reported `steps_used`: **CONFIRMED** (bonus finding)
+
+`steps_used` disagreed with the audit log in **5 of 14 runs**, and **always undercounted**:
+D 5 vs 7, E 8 vs 12, G2 5 vs 7, J 4 vs 6, K 7 vs 8. The deterministic fix already proposed
+(compute from `tool-audit.jsonl` in `browser-agent-parse.py`) is correct and trivial.
+
+### 3.5 B.3.6 — evidence grounding: **would NOT have caught the one wrong answer**
+
+This is the most important negative result in the report. The design doc calls the
+evidence-substring check "a prerequisite for the default flip". Against this sample:
+
+- It **would** have flagged **B**, whose evidence is a paraphrase ("Sidebar navigation lists
+  'Trace viewer' under both 'Getting Started' and 'Guides' sections") that is not a
+  substring of anything the tool returned — a **false positive**, since B was correct.
+- It would **not** have flagged **F2**, the only wrong answer, because F2's evidence
+  (`document.getElementById('app').innerText returned 'WAKE-RIG-SHELL (waiting for
+  frames)'`) is a **faithful verbatim quote of what the tool actually returned**. The model
+  did not confabulate; the *page was in the wrong state*.
+
+Evidence grounding defends against confabulation. It does **not** defend against a
+correctly-quoted unrendered page. Different failure, different fix.
+
+---
+
+## 4. How many `status:"ok"` answers were actually WRONG
+
+**1 out of 13 `ok` runs (7.7%).** That run is **F2**, and its cause is a single
+deterministic, already-diagnosed harness gap (§3.2) — not a general reasoning failure. No
+other run produced a wrong `ok`; no run hallucinated an answer for a page it could not
+reach (H returned `blocked` rather than guessing, with empty evidence).
+
+---
+
+## 5. Cost and latency
+
+- **Campaign credit delta:** `total_usage` 1017.931128 → 1018.001309 = **$0.0702** across
+  the whole window. ⚠ This OpenRouter key is **shared with other tooling** (repo-cos et al.),
+  so $0.070 is an **upper bound**.
+- **Sum of per-run attributed deltas:** **$0.0345 over 14 runs ≈ $0.0025/run mean.**
+  Per-run attribution is unreliable — OpenRouter's usage accounting lags the request by
+  more than the polling window, so cost smears into the next run's reading (run A read
+  $0.00000 and its ~$0.0022 landed in the following sample).
+- **Budget:** well inside the $0.06–0.10 target; nowhere near the $0.25 stop.
+- **Median wall-clock: 22.65s** (n=14; range 11.9s–59.0s).
+  - simple single-page read: **median 18.1s**, always 2 tool calls
+  - interactive (blind click): **48.7s and 59.0s** — the expensive shape
+
+At ~$0.0025 and ~20s for a read that would otherwise put 10K–100K tokens of page HTML into
+context, the economic case in §B.4 holds up under measurement.
+
+---
+
+## 6. Recommendation: **SHIP WITH NAMED GUARDRAILS**
+
+`p ≈ 0.93` with one wrong `ok` traced to a fixable determinism gap is good enough to flip
+the default for open-ended reads — **but not before the hidden-tab signal reaches the
+model**. The wrong-`ok` rate is the number that decides this, and it is entirely
+attributable to §3.2.
+
+### Prerequisite (blocker) — must ship *with* or *before* the flip
+
+1. **Propagate `hidden`/`note` through `summarizeResult()` for `text` and `html`.**
+   Today the model is *structurally blind* to throttling on exactly the two ops the agent
+   def tells it to prefer. Minimum fix: when `data.hidden === true`, return the text
+   **plus** the note (or a compact `{text, hidden:true, note}`), so the signal is not
+   contingent on an `eval` happening to return `null`.
+   *Stronger and preferred:* **deterministic auto-`wake`-and-re-read on the first
+   `text`/`html` where `hidden === true`**, returning the re-read. `wake` does **not** move
+   focus (that's the whole point of #225), so unlike the design doc's original auto-
+   `activate` proposal this carries **no screen-theft risk** — open question #4 in the
+   design doc is resolved by `wake` and should be closed. This alone converts the one
+   measured failure into a pass.
+
+### Guardrails to state in SKILL.md alongside the flip
+
+2. **Do not default to the agent for virtualised/lazy list content.** K only worked because
+   the model woke the tab twice and then read `html`; I could not reproduce the card list
+   at all through `text` on a hidden tab even after waking. Off-viewport virtualised rows
+   need the real foreground and are outside what the agent can be trusted with.
+3. **Keep `--allow-domains` tight and *include the frame hosts you expect*.** G showed the
+   model will substitute top-level navigation for frame reads when the allowlist permits;
+   G2 showed a tight allowlist is what pushes it onto the correct `frames` path.
+4. **The existing "empty `evidence` → treat as `partial`" rule stays** (H behaved exactly as
+   documented), but §3.5 means it must **not** be sold as protection against wrong answers.
+5. **Escalation stays cheap and explicit:** on any answer that depends on rendered SPA
+   state, verify with one direct `text --wake` before reporting. That is ~200 tokens.
+
+### Should ship, not blocking
+
+6. **Deterministic `steps_used`** computed from `tool-audit.jsonl` (§3.4) — 5/14 runs
+   currently report a number that is wrong, always low.
+7. **A `links` / `interactive` op** (compact `[{text, tag, selector, href}]`). Measured
+   value: it collapses the 8–12-call interactive shape toward the 2-call read shape, a
+   **5–6× cost/latency win on E- and K-type goals**. It is an efficiency lever, **not** a
+   correctness prerequisite — the model already hand-rolls it in `eval` and gets the right
+   answer.
+8. **Evidence-substring grounding (B.3.6)** — worth having as anti-confabulation hygiene,
+   but **demote it from "prerequisite"**: on this sample it produces one false positive (B)
+   and zero true positives. Do not let it stand in for #1.
+
+---
+
+## 7. What I did NOT measure
+
+- **B.3.4 (needle-in-a-haystack over long innerText).** No goal targeted a long dashboard or
+  a big table where the answer is one number among thousands. Untested; the §B.3.4
+  prediction remains unmeasured.
+- **Variance.** Every goal ran **once**. No repeat runs, so no per-goal flakiness estimate
+  and a wide CI on `p` (§2). Throttling is demonstrably nondeterministic (L vs my probe of
+  the same URL), so a rerun of F2 might pass and a rerun of L might fail.
+- **The step-budget and timeout boundaries.** All runs used the defaults (`--steps 12`,
+  `--timeout 120`) and none exhausted either — max observed was 12 tool calls (E) and 59.0s
+  (E). I never saw a `partial`, a timeout, or a process-group kill. **`status:"partial"` was
+  never produced by any run**, so its behaviour is unmeasured.
+- **Failure/error paths** other than the domain guardrail: no disconnected extension, no
+  tab-gone, no gate failure, no non-http(s) `nav` scheme denial.
+- **Authenticated/high-secret pages** — deliberately excluded per the brief. Civitai was the
+  only logged-in surface touched, and only for public model listings.
+- **The other host and the other profile.** Laptop `.155` / `personal` **only**. Nothing
+  here is evidence about the workbench (`.250`) or the `work` profile.
+- **Model identity over time.** `openrouter/deepseek/deepseek-v4-flash` as OpenRouter routed
+  it on 2026-07-31. No comparison against a second model, and no re-measurement if
+  OpenRouter re-points that slug.
+- **Prompt injection / hostile pages.** No test of whether a page can steer the agent's
+  `nav` or its reported answer. The §B.3 security caveats (best-effort domain deny vs
+  client-side redirects) were not exercised.
+- **The `civitai.com/apps/run/model-benchmarking` case named in the brief** — it is now a
+  genuine 404 (verified), so the documented known-bad SPA no longer exists and F is a
+  degenerate data point. F2/K/L are the substitutes, and only F2 is deterministic.
+- **`activate` behaviour** — never invoked, per the hard constraint.

--- a/claudedocs/browser-bridge-session-audit-2026-07-30.md
+++ b/claudedocs/browser-bridge-session-audit-2026-07-30.md
@@ -1,0 +1,246 @@
+# browser-bridge — session audit (how it was ACTUALLY used)
+
+**Date:** 2026-07-30 · **Scope:** all Claude Code transcripts on both hosts (laptop 192.168.50.155, workbench 192.168.50.250) · **Mode:** read-only
+
+---
+
+## 1. Corpus & method
+
+### Corpus selection
+
+The bare string `browser-bridge` matches ~708 transcript files, almost all false positives (the devrc project `CLAUDE.md` names `scripts/browser-bridge/` and is injected into every devrc session). The corpus is files containing a CLI invocation:
+
+```
+grep -rlE '(browser-bridge/browser|\$BB) +(--instance|--tab|health|whoami|html|text|eval|tabs|nav|
+screenshot|frames|click|type|key|upload|activate|agent|open|close)' ~/.claude/projects --include=*.jsonl
+```
+
+→ **20 files (laptop) + 26 files (workbench) = 46 candidate files.**
+
+That grep still over-counts: it matches **documentation text** (SKILL.md/README.md quoted inside a transcript) as well as executed commands. I re-filtered by parsing the JSONL and counting only `tool_use` blocks where `name == "Bash"` and the `command` field contains an invocation, then joined each command to its `tool_result` by `tool_use_id` so every error is attributed to the op that produced it.
+
+**After that filter: 7 of 20 laptop files and 1 of 26 workbench files contain ZERO real invocations** — they only quote the docs. Real corpus: **13 laptop + 25 workbench = 38 files, 630 invocations.**
+
+### Use-vs-build classification
+
+Classified by the **project directory** of the transcript, which is a clean proxy here:
+
+| Population | Projects | Files | Invocations |
+|---|---|---|---|
+| **USE** — driving the browser for an unrelated task | `civit-datapacket-talos`, `civit-civitai-manager`, `homelab-talos` | 22 | **469 (74%)** |
+| **BUILD** — developing browser-bridge itself | `devrc` (laptop `829b4ba7…` arc, workbench `f408ad47…`) | 15 | **147 (23%)** |
+| **META** — this audit's own orchestration session | `devrc` `e339cf06…` | 1 | 14 (2%) |
+
+⚠ **This corrects the brief's framing.** By *file count* the build arc dominates the laptop (13/13 laptop files are BUILD). By *invocation volume* the picture inverts: **74% of all real browser-bridge commands ever run were USE, and every one of them ran on the workbench.** The laptop has never driven the browser in anger — it is the development host only. Findings below are weighted accordingly.
+
+### Sources
+
+- **Transcripts** for *why* and *what it cost* (only source before 2026-07-28).
+- **`activity.events` ClickHouse telemetry** for *what / how often*, window 2026-07-28 → 07-30 only. Every rate below **excludes the 2026-07-28 17:00 workbench storm hour** (43,740 eval events, the pathological run that motivated the rate limiter).
+
+### Honesty about measurement quality
+
+- Op counts, error-to-op attribution, n-gram sequences, and telemetry counts are **MEASURED**.
+- The `null`-result counts are a **noisy text proxy** (a page can legitimately evaluate to `null`). I report them as a bucket but do not rank on them alone.
+- Anything labelled INFERRED is my reading of the evidence, not a count.
+
+---
+
+## 2. Findings
+
+### 2.1 Turn-burn: Claude misdiagnosing the bridge (highest value)
+
+#### A. The background-tab false production incident — the single most expensive event in the corpus
+
+Session `4acd5483-e6cb-4629-b138-d6d1aa3ae97b.jsonl` (workbench, datapacket-talos, USE, 1043 messages, 102 browser invocations — the largest single USE session).
+
+Claude read a civitai page through an **owned background tab**, saw an empty DOM, and concluded production was broken site-wide. It then retracted:
+
+> **"I was wrong when I said the `/apps` store is broken — it isn't, and neither is anything else.** I read a *background* tab the whole time (`visibilityState: "hidden"`). Background tabs never painted, so content never rendered and queries never fired. Everything I inferred from that — 'empty grid', 'site-wide breakage', 'hydration crash' — was an artifact of my own measurement, not production."
+
+Corroborating measurement from the same session: `bodyLen: 214`, `trpcCount: 0`, `swControllers: false` — i.e. a shell-only DOM that Claude read as real.
+
+**Cost:** a full false-positive incident investigation — the fabricated symptoms ("hydration crash", React error #423) were themselves generated *by* the bridge (`next.router.push` inside a hidden tab), and disproving them required pulling 23,906 Faro RUM LCP samples and a 45/45 SSR health check. This is the highest-cost failure in the entire corpus and it is a **direct consequence of the bridge's own semantics**: `open` deliberately does not foreground, and `text`/`html`/`eval` silently return the unpainted DOM with no signal that the tab never rendered.
+
+MEASURED: the retraction and the diagnostic values. INFERRED: the turn count (the arc spans messages ~93→249 of that session, but not all are browser turns).
+
+#### B. The stale-extension source hunt
+
+Same session. `screenshot` failed with `not visible on-screen`; Claude did **not** treat it as the documented stale-extension symptom and instead debugged the *repo source*:
+
+> "Extension predates the CDP screenshot path. Let me get the decisive diagnostics another way."
+
+then, over the following turns: read `protocol.js` lines 190–240, ran `git log` on the extension dir, and finally launched a filesystem-wide hunt for a second extension copy —
+
+> `find ~ -name "service_worker.js" -path "*extension*" …` → **`Exit code 143  Command timed out after 2m 0s`**
+
+Only after `frames` also returned `unknown_op` did it land on the right answer:
+
+> "`frames` → `unknown_op`. The running service worker is **still the old build** — the reload didn't take (MV3 workers are sticky, and the manifest newly gained `debugger`)."
+
+Critically, **the user had already said "extension reloaded"** earlier in that arc — and it was still stale. This is exactly the documented `↻`-reload-is-unreliable gotcha, and Claude still burned a source-code investigation plus a 2-minute command timeout on it.
+
+**Why the docs didn't save it (MEASURED):** SKILL.md's stale-extension section illustrates the symptom with `open`. The failures actually seen were on `frames` (×4), `text` (×2), `upload` (×1), `open` (×1). Only the **`upload`** path emits the helpful message —
+
+> `browser: op 'upload' returned unknown_op — your loaded browser-bridge extension is OLDER than this CLI.`
+
+— while `frames`/`text`/`open` emit the bare, uninterpretable:
+
+> `browser: op 'frames' failed in the browser: unknown_op`
+
+**`browser health` could not help either:** its output in that very session reads `work loaded=None   personal loaded=None`. The one command whose job is "is the extension OK" reports the loaded build as `None`.
+
+#### C. No misdiagnosis of the *server*
+
+Searched for server-blaming: `systemctl --user restart browser-bridge` appears in **1** laptop BUILD file and **0** workbench files; `journalctl` in 5 laptop / 4 workbench files, all BUILD-context. **No USE session ever wrongly restarted or debugged the rendezvous server.** Stated plainly: this category is clean — the failure mode is always the *extension*, never the server.
+
+---
+
+### 2.2 Toil — repeated hand-assembled sequences
+
+From n-gram analysis over the ordered op sequence of every USE session:
+
+| Sequence | Occurrences (workbench USE) | What it is |
+|---|---|---|
+| `eval → eval` | **105** | scrape-loop; 87 3-grams, **73 4-grams** of consecutive evals |
+| `nav → eval` / `eval → nav` | **16 / 12** | navigate, then poll the page for readiness |
+| `nav → eval → eval` | 11 | as above, plus a retry |
+| `html → html` | 8 (5 as 3-grams) | paginating/re-reading a doc |
+| `eval → screenshot` / `screenshot → eval` | 8 / 6 | screenshot, then extract what the screenshot couldn't show |
+| `health → health` | 6 | redundant orientation |
+| `open → activate`, `tabs → activate`, `activate → eval` | 3 each | the foreground dance before a screenshot |
+
+**Longest observed unbroken eval chain: 27 consecutive `eval` calls** in `4acd5483…` (messages 96–123), and 18 consecutive in `agent-a5335fc72438de0d9.jsonl`.
+
+Telemetry confirms the shape: **`eval` is 728 of ~1,280 non-storm ops (57%)**. The bridge is, in practice, a JS-injection pipe — the higher-level ops are a thin veneer.
+
+Two concrete toil signatures worth collapsing:
+
+1. **`nav` then poll** (28 bigram occurrences). Every one is Claude hand-writing a readiness check because `nav` returns as soon as navigation is issued. A `nav --wait-for <selector>` (or `--settle`) removes 1–3 commands per navigation.
+2. **`eval 'document.body.innerText…'` as a substitute for `text`.** Seen every time `text` returned `unknown_op` (2×) *and* independently. This is a 2-command dance where 1 should do.
+
+---
+
+### 2.3 Errors & failure modes
+
+Counted by joining each browser `tool_use` to its `tool_result` (USE population unless noted):
+
+| Bucket | Count | Recovery |
+|---|---|---|
+| **`unknown_op` (stale extension)** — `frames` ×4, `text` ×2, `upload` ×1, `open` ×1 | **8** | Mixed. `text`→`eval` fallback was **immediate** (1 turn, twice). `frames`/`screenshot` cost the multi-turn source hunt in §2.1B. |
+| **Result contains literal `null`** (multi-statement eval proxy) | ~27 | Usually 1 retry with a wrapped IIFE. *Noisy metric.* |
+| **`eval` timeout** (`timeout waiting for the extension to answer (is Brave focused / responsive?)`) | **4** (all in `314e6d60…`) | Retried; no diagnosis attempted. |
+| **`screenshot` not-visible** | **3** | Poor — triggered §2.1B. |
+| **Worktree-guard refusal of `eval`** (see §2.4) | **18** across 6 files | Fell back to non-eval ops or gave up on the check. |
+| **`rate_limit` / throttled** | 2 (`whoami`) | Immediate, no cost. |
+| **`ambiguous`** | 1 | Immediate. |
+| **`element_not_found:input[type=file]`** (`upload`) | 1 | Immediate. |
+| **CLI `usage:` error** (`upload` arg order) | 1 | Immediate. |
+
+BUILD population adds: `frame_not_found` ×2 (both deliberate negative tests), `owned_tab_gone` ×1, `activate` Traceback ×1, `nav` timeout ×1.
+
+**Not observed anywhere in the corpus:** auth/token failures, `no_extension` in a USE session, wrong-instance/wrong-host confusion causing a visible error, CSP-blocked eval on GitHub. Telemetry records `*_unknown_instance` ×7 and `no_extension` ×3 in the window, but **no transcript shows them costing a turn** — they were absorbed silently.
+
+---
+
+### 2.4 Tool gaps
+
+#### Gap 1 — worktree-isolated subagents cannot use `browser eval` (NEW, high impact)
+
+**18 refusals across 6 workbench USE subagent transcripts.** The harness guard rejects it:
+
+> "This agent is isolated in the worktree `…/.claude/worktrees/agent-a1861933e709b89ad`, but **this command runs a string through eval, which can't be verified to stay inside the worktree**; run the command directly instead. Refusing to run it."
+
+Files: `agent-a2b9359565aab4a45` (3), `agent-a6d4d9bb639600e4f` (2), `agent-a2ee1bcdbca1ed9da` (1), `agent-a55c5ae81bb9de137` (1), `agent-a5ab3da52fb411aeb` (1), `agent-ac41edb5184f4dec9` (1) — 9 refusal *events*, 18 string occurrences.
+
+This collides head-on with the standing global rule that **any file-modifying subagent runs in an isolated worktree**. The result: the default agent configuration cannot use the bridge's single most-used op (57% of all traffic). Immediately after one refusal, the agent fell back to `html` and then abandoned the check.
+
+#### Gap 2 — no way to read a *rendered* page without stealing focus
+
+The bridge offers `activate` (best-effort, and the source itself concedes "activating it does NOT guarantee its Brave WINDOW is raised/composited — Chrome can't force i3 to raise a window") or nothing. There is no `open --foreground`, no `--wait-for-paint`, and no op that *reports* `visibilityState`. §2.1A is the direct consequence.
+
+#### Gap 3 — X-server fallbacks are BUILD-only, not a USE workaround
+
+`xdotool` appears in 199 workbench / 61 laptop occurrences and `maim` in 60 / 34. I checked the file distribution: on the laptop all 5 files are the BUILD arc and the meta session (`agent-a76859b5ddd8a7323` alone has 12). **These are the browser-bridge test harness driving i3/X to verify `activate`, not a session working around a missing op.** Stated plainly: there is no evidence of a USE session falling back to xdotool/maim/scrot because the bridge couldn't do something. Category is smaller than the brief anticipated.
+
+---
+
+### 2.5 Docs-vs-reality drift
+
+1. **opencode version gate (CONFIRMED, already known).** Memory recorded workbench at 1.17.20 with the `browser agent` fail-closed gate refusing to run there. Verified live in `e339cf06…`: `laptop 1.18.4`, `workbench 1.18.4`. The blocker is stale; the memory file was corrected during this audit's parent session.
+
+2. **`browser health` reports `loaded=None`.** MEASURED in `4acd5483…`: `connected: True  work loaded=None  personal loaded=None  repo manifest version: 0.2.0`. The docs position `health` as the "is the extension connected/OK" check, but it cannot report the loaded build — the exact fact needed to diagnose the #1 failure mode. Docs imply a capability the output does not deliver.
+
+3. **The stale-extension symptom is documented for `open` only.** Real failures were on `frames`, `text`, `upload`, `open`. Only `upload` emits the "your loaded extension is OLDER than this CLI" hint (MEASURED, §2.1B).
+
+4. **Orientation order.** `CLAUDE.md` says "run `browser whoami` FIRST". Measured first-op across the 22 USE sessions: **`health` is the opening op in 13 of them; `whoami` in 2** (both in one civitai session). The `whoami`-first instruction is not being followed — and SKILL.md's own Quick-start block, which is injected verbatim at the top of every browser task, leads with `$BB health`. The two docs contradict each other, and the injected one wins.
+
+5. **Possible manifest-version inconsistency (INFERRED, low confidence).** In `4acd5483…`, `browser health` printed `repo manifest version: 0.2.0` while a direct read of `extension/manifest.json` in the same session printed `version 0.1.0`. These reads are separated in time and the extension files were modified mid-session (`Jul 29 18:58`), so this may be an artifact. Flagging for a check, not asserting a bug.
+
+6. **`screenshot --fullpage` semantics.** Claude reasoned: "`--fullpage` bypasses `captureVisibleTab` entirely in the current source, so a CDP failure could never produce that readback message." It still did — because the *loaded* build was old. The docs describe `--fullpage` as CDP-backed with no caveat that the guarantee is void on a stale worker.
+
+---
+
+### 2.6 Adoption — which ops are alive
+
+Telemetry, excluding the storm hour (workbench + laptop):
+
+| Op | workbench | laptop | Total |
+|---|---|---|---|
+| `eval` | 641 | 87 | **728** |
+| `nav` | 117 | 6 | 123 |
+| `text` | 91 | 9 | 100 |
+| `open` | 68 | 23 | 91 |
+| `getHtml` | 43 | 14 | 57 |
+| `key` | 47 | 0 | 47 |
+| `tabs` | 38 | 19 | 57 |
+| `screenshot` | 43 | 11 | 54 |
+| `close` | 24 | 21 | 45 |
+| `frames` | 6 | 17 | 23 |
+| `activate` | 15 | 3 | 18 |
+| `click` | 2 | 4 | 6 |
+| `release` | 2 | 2 | 4 |
+| `upload` | 2 | 1 | 3 |
+
+**15 ops carry all traffic. Dead in the telemetry window: `type`, `agent`** — plus every op in the CLI's 34-op surface that never reaches the extension.
+
+**`browser agent`: zero real dispatches, confirmed.** My raw regex initially credited ~10 `agent` hits on the laptop; on inspection **all are path false positives** from the sibling files `browser-agent`, `browser-agent-guard`, `browser-agent-parse.py` (13 + 8 + 10 mentions). The parent session's independent grep for `browser agent "<task>"` returned **0 on both hosts**. It was built, RCE-hardened, documented at ~$0.006/task vs ~$0.75 in Claude context — and never once used.
+
+**Why (INFERRED, no direct evidence):** nothing in any transcript shows a session considering and rejecting `browser agent`. The absence is consistent with it being buried inside a 41 KB SKILL.md whose injected quick-start block shows only `health`/`open`/`html` — an agent reading the top of the skill never learns the op exists. `type` is likely dead for the same reason plus `key` covering the same ground (47 uses).
+
+**Also notable:** `click` was used **6 times total** across all history while `eval` was used 728 times. Sessions synthesise clicks in JS rather than using the trusted-input op. In `agent-a55c5ae81bb9de137` both `click` calls returned `null` results.
+
+---
+
+## 3. Ranked improvement opportunities
+
+Score = frequency × cost-per-occurrence. Ordered by total expected value.
+
+| # | Opportunity | Label | Frequency (measured) | Cost/occurrence | Evidence |
+|---|---|---|---|---|---|
+| **1** | **Surface `visibilityState` / never-painted status in every `text`/`html`/`eval` envelope**, and add a loud warning when a read comes from a tab that has never painted. Optionally `open --foreground` / `--wait-for-paint`. | `extension-change` + `cli-change` | 1 catastrophic occurrence, but it is a *systemic* property of the default `open` path used 91× | Catastrophic — a retracted false production-incident diagnosis | §2.1A |
+| **2** | **Map every `unknown_op` to the stale-extension message** the `upload` path already emits, with the remediation inline ("a FULL Brave restart, not ↻"). One-line change in the CLI's error handler. | `cli-change` | 8 failures | 1 turn (best) to a multi-turn source hunt + a 2-min timeout (worst) | §2.1B, §2.3 |
+| **3** | **Make `health` report the LOADED extension build** (version in the SW hello, compared to the repo manifest). It currently prints `loaded=None`. Turns the #1 failure mode into a one-command diagnosis. | `extension-change` | Every session opens with `health` (13/22 USE sessions) | Removes the need for #2 entirely | §2.1B, §2.5.2 |
+| **4** | **Unblock `eval` for worktree-isolated subagents** — e.g. `browser eval --file <path>` (no inline string for the guard to reject), or a documented sanctioned pattern. | `cli-change` + `doc-fix` | 9 refusal events / 6 sessions; blocks the op that is 57% of all traffic, under the *standing default* agent config | Agent abandons the check or degrades to `html` | §2.4 Gap 1 |
+| **5** | **`nav --wait-for <selector>`** (and/or `--settle`) to collapse the navigate-then-poll dance. | `new-op` | 28 `nav↔eval` bigrams | 1–3 commands each | §2.2 |
+| **6** | **Rewrite SKILL.md's injected quick-start.** It is 41 KB (~10K tokens) loaded on every browser task, leads with `health` (contradicting `CLAUDE.md`'s `whoami`-first rule), and never mentions `browser agent`. Lean core + reference files. | `doc-fix` | Every browser task, both hosts | ~10K tokens/task; causes #7 and the `whoami` drift | §2.5.4, §2.6 |
+| **7** | **Decide `browser agent`'s fate** — promote it to the quick-start as the default for open-ended browsing, or delete it. Zero uses since it shipped. | `doc-fix` (or removal) | 0 uses vs a built, hardened, documented feature | Sunk cost + maintenance + test surface | §2.6 |
+| **8** | **Test gap: no test asserts the `unknown_op`→stale-extension message on `frames`/`text`/`open`.** The `upload` path has it; the others regressed silently into bare `unknown_op`. | `test-gap` | Latent behind 8 real failures | — | §2.1B |
+| **9** | **Test gap: nothing exercises a hidden/unpainted tab.** The audit that shipped the CDP screenshot path did not catch that background reads return a shell-only DOM with no signal. | `test-gap` | Latent behind finding #1 | — | §2.1A |
+| **10** | **Fix `screenshot` docs** to state that `--fullpage`'s CDP guarantee is void on a stale worker, since that exact reasoning misled a session. | `doc-fix` | 3 failures | Contributed to §2.1B | §2.5.6 |
+| **11** | **Investigate the `eval` timeout cluster** — 4 timeouts all in one session (`314e6d60…`), all `is Brave focused / responsive?`. Possibly the same background-tab root cause as #1. | (investigate) | 4 | 1 retry each | §2.3 |
+| **12** | **Check the `0.2.0` vs `0.1.0` manifest-version report.** Low confidence, cheap to settle. | `cli-change`? | 1 observation | — | §2.5.5 |
+
+---
+
+## 4. What I could NOT determine
+
+- **Whether the ~27 `null` results were genuine failures.** I used a text-match proxy on the tool result; a page can legitimately evaluate to `null`. Settling this needs per-case reading of ~27 windows. The multi-statement-eval-returns-null mode is real and documented, but I cannot give it a trustworthy count.
+- **Exact turn counts for the two turn-burn incidents.** I can bound the message-index range of each arc (§2.1A spans messages ~93→249 of a 1043-message session) but not all messages in the range are browser turns, and I declined to read the transcript whole.
+- **Anything before 2026-07-28** from telemetry — the table starts then. All earlier history is transcript-only, and transcripts do not record ops that succeeded silently in a `for` loop.
+- **Why `browser agent` was never used.** No transcript shows it being considered and rejected. My SKILL.md-burial explanation is INFERRED from the injected quick-start's contents, not observed.
+- **Whether the telemetry's `*_unknown_instance` ×7 and `no_extension` ×3 cost anything.** They appear in `activity.events` but I found no matching transcript turn, which suggests they were absorbed by retry logic or occurred outside a Claude session.
+
+---
+
+*All counts in this document derive from parsing `tool_use`/`tool_result` pairs in the 38-file corpus and from `activity.events` with the 2026-07-28 17:00 workbench storm hour excluded. Sections are complete; no section was truncated for budget.*

--- a/claudedocs/browser-bridge-silent-drop-diagnosis-2026-07-31.md
+++ b/claudedocs/browser-bridge-silent-drop-diagnosis-2026-07-31.md
@@ -1,0 +1,307 @@
+# browser-bridge: silent instance drop requiring a manual ↻ — diagnosis
+
+**Date:** 2026-07-31 · **Host:** laptop (192.168.50.155) · **Method:** read-only (journal, deployed
+server, loaded extension source, live `health` probes). No service restart, no repo modification,
+no Brave interaction beyond read-only CLI ops.
+
+**Artifacts read**
+- Deployed server: `/nix/store/gfqxad8c71hfi53nzqjhhpdb9r6378q4-home-manager-files/.config/browser-bridge/server.py`
+  (1738 lines, symlinked from `~/.config/browser-bridge/server.py`) — this is what PID 2231 runs.
+- Loaded extension (v0.2.0): `/home/zach/workspace/devrc/scripts/browser-bridge/extension/service_worker.js`
+  and `.../extension/protocol.js`.
+- `journalctl --user -u browser-bridge`, 3-day window.
+
+---
+
+## Summary
+
+| Question | Answer |
+|---|---|
+| Q1 root cause | **An unbounded `await` inside `execute()` wedges the poll loop permanently**, because `loop()` is guarded by a non-reentrant `running` flag that only a fresh service-worker evaluation can reset. Strongly supported, not yet mutation-proven — see *Confidence*. |
+| Case (a) or (b)? | **Primarily (a), with a bounded (b) window of ≤ ~65 s.** The server *does* correctly forget the instance. |
+| Q2 defect | `/health`'s `extension_connected` is `bool(insts)` — a bare OR across all instances, so one live profile masks a dead one forever. |
+
+---
+
+## 1. Root cause for Q1
+
+### 1.1 The mechanism
+
+`extension/service_worker.js:983-1019`:
+
+```js
+async function loop() {
+  if (running) return;          // :984  ← non-reentrant guard
+  running = true;               // :985
+  try {
+    while (true) {
+      ...
+      const r = await pollOnce(cfg);
+      if (r.kind === POLL_COMMAND && r.cmd) {
+        const envelope = await execute(r.cmd);   // ← unbounded await
+        await postResult(cfg, envelope);
+      }
+    }
+  } finally {
+    running = false;            // :1017 ← unreachable while awaiting
+  }
+}
+```
+
+`running` is a module-global (`:52`) and is assigned in exactly three places (`:52`, `:985`, `:1017`).
+The `finally` at `:1017` can only run if the `while (true)` loop exits — which never happens while the
+loop is parked on an `await`. So:
+
+1. A command arrives and `execute()` is awaited.
+2. `execute()` never settles.
+3. `pollOnce()` is never called again → the server stops seeing `/poll` for this instance.
+4. The MV3 keepalive (`chrome.alarms` `bridge-keepalive`, `periodInMinutes: 1`, `:1033-1035`)
+   fires on schedule and calls `loop()` — which hits `if (running) return` at `:984` and **does nothing**.
+5. The instance is dead until the worker is re-evaluated. `↻` in `brave://extensions` does exactly
+   that, which is why it is the only thing that fixes it.
+
+**The keepalive alarm is structurally incapable of recovering from this failure.** It only recovers
+from worker *termination*, not from a wedged-but-alive worker. This is the crux, and it is why the
+alarm's existence does not rebut the diagnosis.
+
+### 1.2 What can hang unboundedly
+
+There is **no `AbortController`, no `AbortSignal`, and no `Promise.race`** anywhere in
+`service_worker.js` (grepped: zero hits). `execute()` (`:910-919`) wraps the op in `try/catch` but
+applies **no wall-clock bound**:
+
+```js
+const data = await OPS[cmd.op](cmd);   // :914 — no timeout
+```
+
+CDP-routed ops *are* bounded — `withCdpSession` (`protocol.js:670`) enforces
+`CDP_ATTACH_TIMEOUT_MS = 8000`, `CDP_COMMAND_TIMEOUT_MS = 8000`, `CDP_OP_BUDGET_MS = 15000`
+(`protocol.js:623-625`) via `promiseWithTimeout`. **That is the important nuance: the CDP path is
+not the culprit — it is the one path with a budget.**
+
+The unbounded awaits are the **non-CDP `chrome.*` extension APIs**:
+
+| Op | Path | Bounded? |
+|---|---|---|
+| `frames` (`:674-680`) | `chrome.webNavigation.getAllFrames` + `tabVisibilityState` — comment explicitly says *"No debugger"* | **No** |
+| `screenshot` fast path (`:644-655`) | `chrome.tabs.captureVisibleTab` via `captureWithRetry` | **No** |
+| `targetTab(cmd)` (every op) | `chrome.tabs.get` / `chrome.tabs.query` | **No** |
+| `pollOnce` (`:935-947`) | bare `fetch()`, no `signal` | **No** |
+
+### 1.3 The evidence that selects this hypothesis
+
+**Both recorded drops in the 3-day journal are immediately preceded by a `cmd_timeout` on exactly
+these unbounded ops, and by nothing else.**
+
+Drop 1 — `work`, 2026-07-29 (the operator's report):
+```
+18:02:34  dispatch  frames      key=work      ← last command the worker ever picked up
+18:02:54  cmd_timeout op=frames               ← 20 s server-side timeout
+18:03:14  cmd_timeout op=screenshot
+18:03:14  cmd_unknown_instance op=tabs   target=work   ← instance now stale/forgotten
+18:03:45  cmd_unknown_instance × 5 (eval, open, frames, screenshot, close)
+```
+Note `18:02:34 dispatch frames` has **no matching `cmd_ok`** — every other dispatch in the window
+does. The worker took the command and never came back.
+
+Drop 2 — `personal`, 2026-07-30 (same signature, *different profile*):
+```
+15:59:56  cmd_timeout op=screenshot
+16:00:22  cmd_timeout op=screenshot
+16:00:31  cmd_unknown_instance op=screenshot  target=personal
+```
+
+This second drop is the single most useful piece of evidence, because it **falsifies the
+profile-specific and heavy-SPA-specific framings**. The fault reproduced on `personal` too. It is
+op-correlated, not profile-correlated. `work` is over-represented only because that profile is the
+one that gets driven at `frames`/`screenshot`.
+
+Counter-check (the ops that timed out but did *not* kill the instance): `10:43 eval` on 07-29 and
+`18:48 open` on 07-30 both produced a `cmd_timeout` with **no** subsequent `cmd_unknown_instance`.
+`eval` routes through `withCdp` → bounded → the op fails, the loop iterates, the instance survives.
+That is the predicted asymmetry and it holds.
+
+### 1.4 Hypotheses eliminated
+
+| Hypothesis | Verdict | Discriminating evidence |
+|---|---|---|
+| MV3 evicted the worker; nothing revived it | **Eliminated** | `chrome.alarms` survives worker termination and wakes it. A terminated worker re-evaluates with `running = false` → `loop()` runs → auto-recovery within ≤60 s. Observed behaviour requires a *manual* ↻, which only makes sense if the worker is **alive and wedged**. |
+| Laptop suspend/resume killed the long-poll | **Eliminated** | Zero suspend/resume events in the 3-day journal (`PM: suspend`, `systemd-sleep`, `Suspending system` — no matches). The machine did not sleep. |
+| Wifi transition dropped the socket | **Eliminated as the cause** | Only one wlan event in the drop window (`17:48:34` GTK rekey, 14 min before the drop). A transport error is also *survivable*: it lands in the `catch` at `:1011` and retries. |
+| Backoff reaches a state it never leaves | **Eliminated** | `nextBackoffMs` (`protocol.js:142-145`) caps at `capMs = 30000`. Worst case is a 30 s retry cadence, which recovers. |
+| Re-entrant `loop()` spawns duplicate fighting pollers | **Eliminated** | The `running` guard at `:984` makes `loop()` strictly non-reentrant. The guard is not the *cause* of duplication — it is the cause of the *wedge*. |
+| Server evicts a live instance (instance-level TTL) | **Eliminated as a false-positive source** | `CONNECT_STALE_S = 40.0` (`server.py:164`) is evaluated in `_live_instances_locked` (`:1081-1088`) as `active_polls > 0 or (now - last_poll) < 40`. A *polling* instance can never be reaped: `active_polls` is incremented for the whole poll and `last_poll` is refreshed in a `finally` (`server.py:841-856`). The server drops the instance only because the extension genuinely stopped polling. `_owner_ttl` (900 s) governs **tab ownership only**, never instance liveness. |
+| Heavy civitai SPA / long CDP op exceeding the ~5-min worker limit | **Weakened, not required** | The CDP path is the one with a 15 s budget. Drop 2 (`personal`, on `auditloop`) had no heavy SPA involved. |
+
+### 1.5 The stable `instanceId` is a red herring
+
+`instanceId()` (`service_worker.js:58-64`) reads `chrome.storage.local`, generating a UUID only if
+absent. It is **persistent across worker restarts, ↻, and browser restarts**. So `work`'s id being
+unchanged since session start tells us nothing about worker liveness and is *not* evidence that the
+worker survived. Worth stating explicitly so it is not re-derived as a clue.
+
+### 1.6 Confidence
+
+**High on the mechanism, not yet proven on the trigger.**
+
+- *Proven by code reading:* `execute()` is unbounded; `frames`/`screenshot`/`targetTab`/`pollOnce`
+  have no timeout; `running` is only reset by a fresh worker evaluation; the keepalive alarm cannot
+  clear it. These are direct reads of the loaded v0.2.0 source, not inference.
+- *Proven by log:* the poll loop stopped iterating immediately after taking a `frames` command that
+  never returned a result; identical signature on a second profile.
+- **Not proven:** *which* `chrome.*` call actually hung, and *why* it hung. I did not observe a
+  hanging `getAllFrames`/`captureVisibleTab` live, and could not without an extension-side log.
+  A wedged `pollOnce` `fetch()` is an equally-fitting sub-hypothesis (same bug class, same fix) and
+  the journal cannot distinguish it — a wedged fetch and a wedged `execute` look identical from the
+  server, which sees only "polls stopped".
+
+That residual ambiguity does **not** change the fix: every candidate is *an unbounded await under a
+non-reentrant `running` guard*, and all of them are closed by the same two changes (§4).
+
+---
+
+## 2. Reproduction / detection
+
+### 2.1 Reproduction
+
+I could not reproduce on demand read-only — triggering it requires driving `frames`/`screenshot`
+against the operator's live tabs and would have knocked the bridge out. Deliberately not attempted.
+
+A safe reproduction that does not depend on winning the hang race, for use once a fix branch exists:
+add a temporary op that `await new Promise(() => {})`, dispatch it, then confirm (i) the instance
+goes stale in ~40 s, (ii) the keepalive alarm fires and does not recover it, (iii) only ↻ restores it.
+That directly mutation-tests the `running`-guard claim rather than assuming it.
+
+### 2.2 Detection — the cheap always-on detector (recommended regardless)
+
+The reason this case is still partly open is that **the extension side is completely unobservable**.
+The server logs `dispatch`/`cmd_ok` but has no `poll_start` / `poll_gap` / `instance_lost` event, so
+a drop leaves no trace at all unless someone happens to send a command. That is exactly why the
+operator's second drop appears nowhere in the journal.
+
+Two low-cost additions that would close the case on the next occurrence:
+
+1. **Server-side `instance_lost` / `instance_connected` events** — in
+   `_live_instances_locked` (or a small reaper), log once when a known instance transitions
+   live→stale, with `key`, `instance_id`, `last_poll` age, and **the id/op of the last command
+   dispatched to it that never produced a result**. That last field alone would have named `frames`
+   as the wedging op without any of the above inference.
+2. **Extension-side heartbeat breadcrumb** — before and after `await execute(cmd)`, write
+   `{op, id, phase, ts}` to `chrome.storage.local` (a single rolling slot, no growth). After the
+   next drop, the options page (or `browser whoami`) can report *"wedged in `frames` since
+   18:02:34"*. This converts the diagnosis from inference to observation.
+
+---
+
+## 3. The Q2 contract defect (precise)
+
+**Defect:** `/health`'s `extension_connected` is a bare disjunction over all instances.
+
+`server.py:1504`:
+```python
+self._send(200, {"ok": True,
+                 "extension_connected": bool(insts),   # ← true if ANY instance is live
+                 "count": len(insts),
+                 "extension_version_current": manifest_version(),
+                 "instances": insts})
+```
+Backed by `Registry.connected` (`server.py:1156-1158`), same `bool(...)` shape.
+
+**Measured behaviour when an instance dies** (from the 07-29/07-30 logs plus live probes today):
+
+| Surface | Behaviour | Honest? |
+|---|---|---|
+| `instances[]` | The dead instance **disappears** after ≤ `CONNECT_STALE_S` (40 s) | ✅ |
+| `count` | Drops 2 → 1 | ✅ |
+| `extension_connected` | **Stays `true`** as long as *any* profile lives | ❌ **the defect** |
+| `browser --instance work <op>` | Fails **fast and clearly** — measured **0.15 s**: `no connected instance matches --instance 'work'. Connected: …` | ✅ |
+| An op during the ≤65 s transition window | Queued, hangs the full **20 s** `cmd_timeout` (observed twice, 07-29 18:02:54 / 18:03:14) | ⚠ bounded |
+
+**What a caller can and cannot tell today:** a caller that reads `instances[]`/`count`, or that
+names `--instance work`, gets the truth immediately and cheaply. A caller that reads only the
+`extension_connected` boolean — which is what "is the bridge up?" naturally reaches for — is
+**lied to indefinitely**. The field's name promises a global property it does not have; it means
+"at least one instance is connected".
+
+**Case (a) vs (b), settled:** this is **case (a)** — the extension really disconnected and the
+server correctly forgot it. There is a genuine but **bounded** case-(b) window of at most
+~65 s (≤25 s for an in-flight `/poll` thread to reach its deadline + 40 s `CONNECT_STALE_S`) during
+which the instance is still listed and ops queue and hang for 20 s. The operator's *"reads as a
+working bridge until an op fails"* is explained by the `extension_connected` aggregate, **not** by
+a phantom instance entry. That is the better outcome of the two: the fix is an honesty fix on one
+field, not a lifecycle rewrite.
+
+---
+
+## 4. Proposed fixes, ranked
+
+> 🔴 **Sequencing constraint — PR #242 owns nearly every file below.** #242
+> (*"git-immune extension deploy path + ping probe, manifest 0.3.0"*, currently `MERGEABLE`/`CLEAN`)
+> touches `server.py` (+156/−42), `browser` (+31/−3), `service_worker.js` (+36/−1),
+> `protocol.js` (+19/−2), `manifest.json`, and all four test files. **Every fix below will conflict
+> with it. Sequence all of this after #242 merges.** PR #243 touches only `opencode/` +
+> `browser-agent` and does not overlap.
+
+### Fix 1 — durability: bound every op (closes the root cause)
+**Files:** `extension/service_worker.js`, `extension/protocol.js`, `tests/service_worker.test.mjs`
+
+Wrap `await OPS[cmd.op](cmd)` in `execute()` (`:914`) in `promiseWithTimeout` — the helper already
+exists in `protocol.js:639-644`. Give it a wall-clock ceiling above the CDP budget
+(`CDP_OP_BUDGET_MS = 15000`) but below the server's 20 s `cmd_timeout` — ~18 s — so the extension
+returns a *clean* `op_timeout` error envelope rather than letting the server time out blind.
+Also give `pollOnce`'s `fetch` an `AbortSignal.timeout` of ~`poll_timeout + 5 s`.
+
+This is the fix that stops the drop. It is one choke point (`execute`), consistent with *one rule,
+one place* — do **not** patch `frames` and `screenshot` individually, that regenerates the bug at
+every future op.
+
+### Fix 2 — durability: make the keepalive able to recover (defence in depth)
+**Files:** `extension/service_worker.js`
+
+`running` must be a *liveness* claim, not a latch. Record `lastLoopTickAt` on each iteration; in the
+alarm handler, if `running && now - lastLoopTickAt > ~90 s`, treat the loop as dead and restart it.
+Worth doing even with Fix 1, because Fix 1 only bounds the awaits we currently know about — Fix 2
+recovers from the next unbounded await someone adds.
+
+### Fix 3 — honesty: `extension_connected` must not mask a dead named instance
+**Files:** `scripts/browser-bridge/server.py`, `scripts/browser-bridge/browser`, `tests/test_server.py`
+
+The field cannot be silently redefined (callers depend on "is anything up"). Preferred shape:
+keep `extension_connected` as-is, add an explicit **`known_instances`** / **`missing`** pair —
+the server remembers keys it has seen this process-lifetime and reports which are no longer live —
+and have `browser health` render a visible `work: DISCONNECTED (last seen 18:02:34)` line. That
+turns the operator's silent failure into a glanceable one.
+
+Note #242 already adds `extension_stale`; this should be designed to sit alongside it, not collide.
+
+### Fix 4 — observability: the detector from §2.2
+**Files:** `scripts/browser-bridge/server.py` (`instance_lost` log event), `extension/service_worker.js`
+(storage breadcrumb)
+
+Lowest risk of the four and the only one that would let the *next* occurrence be diagnosed from
+evidence rather than inference. If only one thing ships before #242 merges, this is the one worth
+carving out — though it too touches `server.py`.
+
+**Recommended order:** #242 merges → Fix 1 + Fix 4 together (fix + the evidence to confirm it) →
+Fix 3 → Fix 2.
+
+---
+
+## 5. What I could not determine
+
+- **Which specific `chrome.*` call hung, and why.** The candidates (`webNavigation.getAllFrames`,
+  `tabs.captureVisibleTab`, `tabs.get`, `pollOnce`'s `fetch`) are indistinguishable from the server's
+  vantage point, which observes only "polls stopped". Closing this needs the §2.2 breadcrumb.
+- **Whether the wedge is in `execute()` or in `pollOnce()`.** Same bug class, same fix, but I cannot
+  prove which. I have deliberately not asserted `frames` *caused* the hang — only that the worker
+  took a `frames` command and never returned, twice with `screenshot` alongside.
+- **The operator's second drop of this session has no journal trace.** Only one `work` drop
+  (2026-07-29 18:03) and one `personal` drop (2026-07-30 16:00) appear in the 3-day window. The
+  second `work` drop produced no evidence because no command was sent while it was down. I did not
+  correlate it to a timestamp and am not going to guess one.
+- **Whether Chrome honours `periodInMinutes: 1`** for this extension (Chrome has historically floored
+  alarm periods for unpacked/MV3 extensions). Not determinable read-only, and **not load-bearing**:
+  the alarm demonstrably cannot clear the `running` latch at any period.
+- **Not tested live:** I did not drive `frames`/`screenshot` against either profile to attempt a
+  reproduction, since a successful reproduction would have taken the operator's bridge down.
+- **Not verified:** none of the proposed fixes were written or run. This document is diagnosis only.

--- a/claudedocs/browser-bridge-token-and-agent-design-2026-07-30.md
+++ b/claudedocs/browser-bridge-token-and-agent-design-2026-07-30.md
@@ -1,0 +1,786 @@
+# browser-bridge — Token-Efficiency Plan + `browser agent`-as-Default Design
+
+Date: 2026-07-30 · Status: **DESIGN ONLY — nothing implemented, awaiting operator approval**
+Scope: `~/workspace/devrc/scripts/browser-bridge/`
+Method: read-only analysis of `SKILL.md`, `README.md`, `browser`, `browser-agent`,
+`opencode/browser-agent.md`, `opencode/tools/browser.js`,
+`opencode/tools/browser_tool_impl.mjs`, `extension/protocol.js`, `extension/service_worker.js`,
+plus ONE model-free `opencode debug agent browser-agent` run.
+
+---
+
+## 0. FIRST: the fail-closed gate on opencode 1.18.4 — settled
+
+### 0.1 What I ran (read-only, model-free)
+
+I reproduced exactly what `browser-agent` does before it opens a tab or spends a token:
+built a scratch project (`.opencode/agents/` + `.opencode/agent/` + `.opencode/tools/` +
+`.opencode/tool/`), copied `browser.js` + `browser_tool_impl.mjs`, templated the agent md
+(`__STEPS__`→12, `__MODEL__`→`openrouter/deepseek/deepseek-v4-flash`), and ran
+`opencode debug agent browser-agent` in it. No model was invoked, no tab was opened,
+`browser agent` was never run.
+
+`opencode --version` → **1.18.4** on this host (workbench).
+
+### 0.2 The resolved `tools` map — what the gate actually inspects
+
+```json
+{"bash": false, "browser": true, "edit": false, "glob": false, "grep": false,
+ "invalid": false, "question": false, "read": false, "skill": false, "task": false,
+ "todowrite": false, "webfetch": false, "write": false}
+```
+
+Running the gate's **verbatim** Python predicate against this output:
+
+```
+GATE RC=0
+```
+
+**The gate PASSES on opencode 1.18.4.** `browser` is `true`; every host tool the gate
+requires (`bash`, `read`, `edit`, `write`, `webfetch`) is **present and `false`**; no
+non-`browser` tool is `true`. The tool set is browser-ONLY, exactly as designed.
+
+### 0.3 The `permission` map — FALSE ALARM, killed cleanly
+
+The dangling thread was that the resolved `permission` array's **first** entry is
+`{"permission":"*","action":"allow","pattern":"*"}`, which looked like the agent def's
+`permission: {"*": deny}` had failed to take. It had not. The array is an **ordered,
+merged** list of 30 entries; the agent def's own entries are at the **end**:
+
+```
+ 0  {'permission': '*',       'action': 'allow', 'pattern': '*'}   ← opencode built-in default
+ 1..26                                                             ← global/plugin defaults
+27  {'permission': '*',       'action': 'deny',  'pattern': '*'}   ← THE AGENT DEF's deny-all
+28  {'permission': 'browser', 'action': 'allow', 'pattern': '*'}   ← THE AGENT DEF's allow
+29  {'permission': 'external_directory', …}
+```
+
+The agent's `"*": deny` and `browser: allow` **are present and are last**, i.e. they
+override the built-in `*: allow` at index 0. Index 0 is opencode's default seed, not a
+leak.
+
+**More decisive than the ordering question:** `permission` and `tools` are two different
+mechanisms, and the gate deliberately checks the **stronger** one. A tool with
+`tools: false` is **not registered and is never advertised to the model at all** — there
+is no tool call for a permission entry to adjudicate. So even if the permission ordering
+were the other way round, `bash: false` in the `tools` map means the model has no shell.
+
+**Verdict — plainly: `*: allow` in the permission map does NOT affect the `tools` map the
+gate checks, and does NOT give the cheap model access to anything beyond `browser`. This
+is a false alarm. The RCE-hardening the design rests on IS in force on opencode 1.18.4.**
+The recommendation on making `browser agent` the default is **unchanged by this** — but
+see §0.5 for a *different*, real finding.
+
+### 0.4 The stale doc claim
+
+`SKILL.md` L410-413 and `README.md` state *"Different opencode versions resolve the deny
+differently (workbench 1.17.20, laptop 1.18.4)"*, implying the gate may refuse on the
+workbench. **This is STALE.** Workbench is 1.18.4 and the gate passes. This stale sentence
+is, in my assessment, a material contributor to zero adoption (§B.5) — it tells a reader
+the feature is unreliable on one of the two hosts.
+
+### 0.5 A DIFFERENT, real finding: `upload` op-surface mismatch (flag for the security audit)
+
+While reading the typed tool I found an inconsistency across the three layers that
+describe the agent's op set:
+
+| layer | includes `upload`? | includes `whoami`? |
+|---|---|---|
+| `opencode/browser-agent.md` tool table (what the MODEL is told it can do) | **YES** (documented with a `path` arg) | **YES** |
+| `opencode/tools/browser.js` — the typed `op` **enum** | **NO** — enum is `["text","html","eval","nav","screenshot","frames","click","type","key","activate"]` | **NO** |
+| `opencode/tools/browser_tool_impl.mjs` — `ALLOWED_OPS_DEFAULT` | **YES** | **YES** |
+
+So the model is **told** it has `upload` with an arbitrary caller-chosen `path`, and the
+in-process enforcement layer would **allow** it, but the typed schema enum would reject
+it — *if* opencode validates args against the declared schema before `execute()`.
+**I did not verify whether opencode 1.18.4 enforces the enum**, and determining that would
+require invoking the model, which is out of scope for this dispatch.
+
+Either branch is a problem worth fixing before the agent becomes the default path:
+- **If the enum IS enforced:** the agent md lies to the model about a capability it does
+  not have — wasted steps and a confusing `refused` on any upload task.
+- **If the enum is NOT enforced:** a prompt-injecting page can induce
+  `upload(selector, path="/home/zach/.ssh/id_ed25519")` and exfiltrate a local file to the
+  page's origin. The server audit-logs it, which is detection, not prevention.
+
+**Recommendation (defer to the dedicated security audit for the fix, but gate the default
+on it):** the wrapper already has the knob — `BROWSER_AGENT_ALLOWED_OPS` overrides
+`ALLOWED_OPS_DEFAULT`. Set it to the read/drive ops only (drop `upload`) for the
+`browser agent` path, and remove the `upload` row from `browser-agent.md`. That closes the
+gap deterministically at the enforcement layer regardless of enum behaviour. Making the
+agent the DEFAULT multiplies exposure of this surface, so **I recommend treating this as a
+blocker for the default flip, not a follow-up.**
+
+---
+
+# PART A — Token efficiency
+
+## A.1 The measured baseline
+
+| artifact | bytes | ≈ tokens (bytes/4) | loaded when |
+|---|---:|---:|---|
+| `SKILL.md` | 41,177 | **~10,294** | **EVERY browser task** |
+| `README.md` | 55,526 | ~13,882 | on demand (already) |
+| `browser` CLI | 29,340 | ~7,335 | never loaded (executed) |
+
+Section-by-section measurement of `SKILL.md` (byte spans, measured this session):
+
+| bytes | lines | section |
+|---:|---|---|
+| 911 | 1-12 | frontmatter (name + description) |
+| 920 | 13-28 | Quick start / binary path |
+| 1,681 | 29-59 | ⚠ The LOADED extension may be older than this doc |
+| 848 | 60-74 | `eval` gotchas — a `null` result… |
+| 395 | 75-82 | The user is USING this browser |
+| 801 | 83-95 | Concurrency / don't do this |
+| 618 | 96-108 | `# browser — drive the live Brave session` (preamble) |
+| **9,145** | 109-173 | **Entrypoint (the op table + `--frame` prose)** ← largest |
+| 3,414 | 174-225 | Frame ops (webNavigation+scripting) & CDP ops (debugger) |
+| 1,682 | 226-259 | The X-server fallback (xdotool/maim) |
+| 2,016 | 260-295 | Driving a throttled/backgrounded SPA (`activate`) |
+| 3,579 | 296-370 | Diagnosing a CSS/layout bug (hit-test playbook) |
+| **4,606** | 371-436 | **`browser agent "<goal>"`** ← 2nd largest, at 61% depth |
+| 2,994 | 437-480 | Per-session tab isolation |
+| 1,224 | 481-500 | Multiple instances (per host) |
+| 379 | 501-508 | Security contract (why it's safe) |
+| 633 | 509-519 | Telemetry (metadata-only) |
+| 557 | 520-529 | Before you rely on it |
+| 2,446 | 530-563 | Error shapes (from `/cmd`) |
+| 695 | 564-574 | Gotcha: reload the unpacked extension after any change |
+| 999 | 575-589 | Changing the bridge: live-verify is the ONLY gate |
+| 634 | 590-602 | One-time setup |
+| **41,177** | | **total** |
+
+## A.2 Proposed split — lean core + on-demand references
+
+**Every gotcha is PRESERVED. Nothing is deleted — only relocated, with an explicit
+trigger line in the core telling the reader when to load it.**
+
+### A.2.1 Core `SKILL.md` budget
+
+**Budget: 12,000 bytes / ~3,000 tokens as a hard CEILING. Draft below lands at ~8,400
+bytes / ~2,100 tokens.**
+
+Justification for 12,000 as the ceiling (not smaller, not larger):
+- The frontmatter alone is 911 bytes and is non-negotiable (it is the skill's trigger text).
+- The op table cannot shrink below ~2,600 bytes without losing an op name or its
+  one-line "what it does", and an op the reader doesn't know exists is an op they
+  re-derive expensively or replace with a worse one.
+- The **silent-wrong-result** gotchas MUST stay in the core, because a reader only learns
+  they need the reference file *after* they have already been misled. There are exactly
+  four of these: `eval` takes one expression (silent `null`); page-CSP blocks `eval`
+  (silent `null`, notably GitHub); a background tab returns a shell-only DOM
+  (indistinguishable from a broken site); a stale extension returns `unknown_op` and reload
+  ↻ is unreliable. Anything that produces a **loud** error can live in a reference file,
+  because the error text itself is the trigger to go read it.
+- The agent-first decision rule is new core content (~1,200 bytes) and is the whole point
+  of Part B.
+- 12,000 leaves ~3,600 bytes of headroom above the draft for future core-worthy gotchas
+  without needing another restructure.
+
+### A.2.2 Core outline (the actual proposed structure)
+
+```
+frontmatter (unchanged)                                              ~911 B
+## Quick start — orient first                                        ~700 B
+    BB= path; whoami; health; the orientation rule (both hosts are 'nixos')
+## FIRST DECISION: agent or direct?          ← NEW, see Part B      ~1,200 B
+    the decision rule + one worked example each side
+## Ops (one line each)                                               ~2,600 B
+    table: op | what it does | ⚠marker
+    ⚠markers point at the reference file, e.g. "⚠frames→ref/frames.md"
+## Four traps that return a WRONG answer silently                    ~1,100 B
+    1. eval takes ONE expression → wrap in (function(){…})()
+    2. page CSP blocks eval (GitHub) → use text/html
+    3. a backgrounded tab is throttled → shell-only DOM → activate
+    4. a stale extension answers unknown_op; ↻ is unreliable → full Brave restart
+## This is the user's live session                                     ~395 B
+## Concurrent drivers → each `open` + thread its own --tab              ~350 B
+## Before you rely on it (health; confirm it's the AUTHENTICATED page)  ~400 B
+## Reference files — load ONE only when its trigger fires              ~750 B
+                                                                  ≈ 8,406 B
+```
+
+### A.2.3 Reference files and their trigger conditions
+
+All under `scripts/browser-bridge/reference/` (skill dir), pointed at from the core.
+
+| file | absorbs (bytes) | **load it when…** |
+|---|---:|---|
+| `ref/frames-cdp.md` | Frame ops & CDP 3,414 + the `--frame` picking prose lifted out of Entrypoint (~1,900) = **~5,300** | you need to read/drive INSIDE an iframe; you saw `ambiguous_frame` or `frame_not_found`; you need to know why in-frame input is synthetic; you hit nested-OOPIF `frame_not_found` |
+| `ref/spa-activate.md` | 2,016 | a read came back empty/half-built, or `data.hidden:true`, or an SPA is stuck "Loading…"; before driving any heavy JS app |
+| `ref/css-hit-test.md` | 3,579 | you are diagnosing a CSS/layout/paint-order/z-index bug — "it's there but you can't see/click it" |
+| `ref/x-fallback.md` | 1,682 | CDP `screenshot` is unsatisfactory and you must capture the raw X window (needs `DISPLAY`/`XAUTHORITY`) |
+| `ref/agent.md` | 4,606 − ~1,200 promoted to core = **~3,400** | you are running `browser agent` and need flags, guardrails, the RCE-fix rationale, the domain-deny caveat, or prereqs; or the agent returned `blocked` |
+| `ref/tabs-instances.md` | per-session tabs 2,994 + instances 1,224 = **4,218** | you got `ambiguous_instance` / `unknown_instance` / `superseded` / `owned_tab_gone` / `no_owned_tab`; or you are designing a multi-session or multi-profile workflow |
+| `ref/errors.md` | error catalogue 2,446 + reload gotcha 695 = **3,141** | any op returned an error you don't recognise — look up the exact string |
+| `ref/security-ops.md` | security contract 379 + telemetry 633 + live-verify gate 999 + setup 634 = **2,645** | you are MODIFYING browser-bridge (the live-verify gate is mandatory); or the user asks how/whether it's safe; or first-time setup |
+
+**Design note on the trigger lines:** each is phrased as an *observable symptom* (an error
+string, an empty read, a visible behaviour), not a topic. A topic-phrased trigger ("read
+this to understand frames") gets skipped; a symptom-phrased one ("you saw
+`ambiguous_frame`") fires deterministically. The error catalogue is deliberately the
+catch-all: the core says "any unrecognised error → `ref/errors.md`", so no error string can
+strand a reader.
+
+## A.3 Estimated saving per browser task — arithmetic
+
+```
+Baseline SKILL.md                     41,177 B  → 41,177/4 = 10,294 tokens
+Proposed core                          8,406 B  →  8,406/4 =  2,102 tokens
+Gross saving per task                 32,771 B  →              8,192 tokens
+```
+
+Net of reference loads. I have no measurement of how often a reference will be needed, so
+I state the assumption explicitly: **assume 30% of browser tasks load exactly one
+reference file, at the mean reference size of (5,300+2,016+3,579+1,682+3,400+4,218+3,141+2,645)/8 = 3,248 B ≈ 812 tokens.**
+
+```
+Expected reference cost = 0.30 × 812 = 244 tokens
+NET saving per browser task = 8,192 − 244 = ~7,950 tokens
+```
+
+Sensitivity — this holds up under pessimistic assumptions:
+```
+if 100% of tasks load one reference:  8,192 − 812   = 7,380 tokens saved
+if 100% load TWO references:          8,192 − 1,624 = 6,568 tokens saved
+if every task loaded ALL eight:       8,192 − 6,496 = 1,696 tokens saved  (still positive)
+```
+Even the absurd worst case is net-positive, which is the property that makes progressive
+disclosure the right call here rather than a gamble.
+
+**Caveat I want on the record:** the `bytes/4` token estimate is a standard rule of thumb,
+not a measurement. For English prose with markdown tables it is typically accurate to
+±15%. All figures above should be read as ±15%.
+
+## A.4 Other token levers
+
+Ranked by expected saving. Each shows its arithmetic and a risk note.
+
+---
+
+### Lever 1 — `getHtml` has NO byte cap while `text` has one (VERIFIED IN CODE)
+
+**Finding.** `extension/protocol.js` defines `TEXT_MAX_BYTES_DEFAULT = 32 * 1024` and
+`normalizeText()` applies it to every `text` read. The `getHtml` path
+(`service_worker.js`: `func: () => document.documentElement.outerHTML`) applies **no cap at
+all** — there is no `maxBytes` handling on the html op anywhere in the extension, server,
+or CLI. Confirmed by grep: `--max-bytes` exists only on the `text` subcommand in the CLI
+(`browser` L417-434).
+
+**Arithmetic.** Telemetry: `getHtml` 57 calls, `text` 100 calls over 3 days.
+- A `text` read is bounded: ≤ 32,768 B → ≤ **8,192 tokens**, hard ceiling.
+- An `html` read is unbounded. A modern SPA's `outerHTML` is routinely 300 KB–1.5 MB.
+  At 400 KB: 400,000/4 = **100,000 tokens in one call.** At 1.5 MB: **375,000 tokens** —
+  which exceeds most context windows outright.
+- The `~98% smaller` claim in `protocol.js` L10 implies a ~50:1 ratio, consistent with
+  400 KB html ↔ 8 KB text.
+
+**One uncapped `html` on a heavy page costs more than 12× the entire SKILL.md saving from
+§A.3.** This is the single largest *variance* in the system.
+
+**Proposal.** (a) Give `html` the same `--max-bytes` flag, **defaulting to 65,536**
+(2× the text cap — html is legitimately denser), `0` = uncapped, with the same truncation
+note appended. (b) When `html` is called with no selector on a page whose `text` would fit
+under the cap, print a one-line **stderr** nudge: `hint: 'text' would have returned ~N B
+(vs ~M B of html) — use text unless you need markup`. stderr keeps stdout JSON unbroken
+(the CLI already uses this pattern for the `hidden:true` warning, `browser` L340).
+
+**Expected saving.** If half of the 57 `html` calls could have used `text` or a cap:
+`28 × (100,000 − 8,192) ≈ 2.6M tokens / 3 days`. I flag this number as **directionally
+right but not measured** — I have no per-call byte log. The defensible claim is the
+structural one: an unbounded op exists next to a bounded one, and the unbounded one has no
+guardrail.
+
+**Risk.** Medium-low. Truncating html can cut off the element someone needed — mitigated
+by the appended truncation note (same contract as `text`) and `--max-bytes 0`. Real risk is
+a *silently* truncated html read being parsed as complete; the truncation note must be
+inside the returned data, not only on stderr.
+
+---
+
+### Lever 2 — `screenshot` with no path prints the base64 data URL to stdout (VERIFIED IN CODE)
+
+**Finding.** `browser` L465-482: `resp="$(cmd_op screenshot "$full")"`; **if `$out` is
+empty** (no path argument) it falls to `printf '%s\n' "$resp" | pretty` — i.e. the entire
+JSON response **including `data.dataUrl`** (a `data:image/png;base64,…` string) goes to
+stdout, straight into Claude's context. The base64 decode-to-file path runs **only** when a
+path argument was supplied.
+
+**Arithmetic.** A 1920×1080 PNG screenshot is typically 300 KB–2 MB; `--fullpage` on a long
+document is larger. Base64 inflates by 4/3:
+- 300 KB PNG → 400 KB base64. Base64 tokenizes poorly (~3 chars/token, worse than prose's
+  ~4): 400,000/3 ≈ **133,000 tokens**.
+- 2 MB PNG → 2.7 MB base64 → ≈ **890,000 tokens** — exceeds a 1M context on its own.
+
+Telemetry shows **53 screenshot calls** in the window. I cannot tell from telemetry how
+many omitted the path. **A single path-less screenshot costs 16× the entire SKILL.md
+restructure saving.** And the data URL is *useless* in context anyway — Claude cannot see
+an image from a base64 string in a bash result; it must Read the `.png` file.
+
+**Proposal (highest leverage / lowest risk change in this document).** Invert the default:
+with no path argument, write to `${TMPDIR}/browser-screenshot-<ts>.png` and print
+`{"ok":true,"path":"…","bytes":N,"width":W,"height":H}`. Add `--stdout-data-url` as an
+explicit opt-in for the rare programmatic caller. Update the one SKILL.md line.
+
+**Expected saving.** Bounded by usage, but per-occurrence it is 133,000–890,000 tokens →
+~40 tokens. If even 10 of the 53 calls omitted a path, that is **~1.3M–8.9M tokens** over
+three days.
+
+**Risk.** Very low. No information is lost — the file is on disk and Claude reads it with
+the Read tool, which is the *only* way it could ever see the image. The only breakage is a
+caller that pipes the data URL somewhere, preserved behind the opt-in flag.
+
+---
+
+### Lever 3 — unwrap the envelope + stop pretty-printing large payloads
+
+**Finding.** Every op returns `{"ok":true,"result":{"id":"…","ok":true,"data":{…}}}` and
+the CLI pipes it through `pretty()` = `jq .` (`browser` L179-181).
+
+**Arithmetic.**
+- *Envelope:* ~60 B of wrapper per call. Telemetry total ops ≈ 700+131+100+85+57+53+50+40+21+13+6+5+4+3 = **1,268 calls**. `1,268 × 60 = 76,080 B ≈ 19,000 tokens / 3 days`. Real but small.
+- *Pretty-printing:* `jq .` adds indentation + a newline per key. On a deep object this is
+  typically **+15–30%** of payload bytes. On a 32 KB `text` read: `32,768 × 0.20 ≈ 6,550 B ≈ 1,640 tokens per read`. Across 100 `text` calls (assuming they average even a quarter of the cap): `100 × 8,192 × 0.20 / 4 ≈ 41,000 tokens / 3 days`.
+- *Combined:* **~60,000 tokens / 3 days ≈ 20,000/day.**
+
+**Proposal.** (a) Default the CLI to printing **`.result.data` only**, with `--raw` for the
+full envelope. Non-zero exit + a stderr message already carries failure, so `ok` in stdout
+is redundant for the CLI's own callers. This *also* deletes the "results land under
+`.result.data`" instruction from SKILL.md. (b) Pretty-print only when the payload is under
+~2 KB; emit compact JSON above that.
+
+**Risk.** Medium — this is a **breaking output-shape change**. `browser-agent` parses
+`["result"]["data"]["tabId"]` from `open` (L211-215) and `browser-agent-parse.py` may
+depend on shapes; the tests almost certainly assert on the envelope. Needs a coordinated
+change + `--raw` used internally by `browser-agent`. Given it's the smallest saving of the
+top three and the highest breakage risk, **I rank it third and would ship it last.**
+
+---
+
+### Lever 4 — a composite `read` command (open → nav → activate → text in ONE call)
+
+**Finding.** Telemetry shows exactly this shape dominating: `nav` 131, `open` 85,
+`text` 100, `activate` 13. The `activate` count being *far* below `open` is itself a
+signal — most sessions `open` a background tab and read it **without** activating, which is
+precisely the shell-only-DOM trap (`SKILL.md` L122).
+
+**Proposal.** `browser read <url> [selector] [--no-activate]` = `open` → `nav` → `activate`
+→ `text`, returning ONE result: `{url, title, hidden, text}`. Similarly `browser grab <url>`
+= the same but ending in a screenshot-to-file.
+
+**Arithmetic.** Each collapsed call removes a full agent round-trip. Per round-trip in
+Claude's harness: the command echo (~150 B) + the JSON envelope/result framing (~80 B) +
+the model's own tool-call and reasoning overhead (~100–150 tokens, conservatively). Three
+calls → one saves **~2 round-trips ≈ 250 tokens**. At ~85 `open`-led sequences per 3 days:
+`85 × 250 = ~21,000 tokens / 3 days`.
+
+The *bigger* win is correctness, not tokens: it makes `activate` un-forgettable, killing
+the shell-only-DOM failure that currently produces confidently-wrong reads.
+
+**Risk.** Low — purely additive; the primitive ops stay. Risk is `activate` **stealing the
+user's focus** on a task that didn't need it — hence `--no-activate`, and the composite
+should skip activation when the first read already returns `hidden:false` with substantive
+text.
+
+---
+
+### Lever 5 — make the `eval` one-expression trap a loud error instead of a silent `null`
+
+**Finding.** `eval` is by far the most-used op (**~700 calls**, excluding the excluded
+43,740-eval storm hour). `SKILL.md` spends bytes on this trap **twice** (L62-65 and again at
+L366-369, "Reiterating, because it bites hardest here") — the doc itself is evidence of how
+often it costs a debugging loop.
+
+**Proposal (deterministic, per the standing preference over prose).** In the CLI, before
+dispatch, detect a body that is a **multi-statement script** — contains a top-level `;`
+that is not inside a string/regex, or starts with a statement keyword (`const`/`let`/`var`/
+`if`/`for`/`return`) — and **refuse with a non-zero exit + the exact corrected command**:
+```
+browser eval: this is a script, not an expression — eval returns null (no error) for a
+multi-statement body. Re-run wrapped:
+  browser eval '(function(){ <your body> })()'
+```
+**Detect-and-refuse, not auto-wrap.** Auto-wrapping would change semantics for a
+legitimate comma-sequence expression and would silently alter what the operator asked to
+run — worse than the disease.
+
+**Arithmetic.** Not a per-call byte saving; it removes retry loops. One trap costs (bad
+eval + a `health` check + a re-read + the corrected eval) ≈ 4 round-trips ≈ 600 tokens,
+plus the SKILL.md bytes spent warning about it twice (848 + 900 = 1,748 B ≈ 437 tokens,
+which the core split already reduces to one mention). If the trap fires on even 2% of 700
+evals: `14 × 600 = ~8,400 tokens / 3 days`, plus removing the second warning entirely.
+
+**Risk.** Low-medium. False positives on an expression containing a `;` inside a string
+literal — mitigated by a string/regex-aware scan, and by making the refusal overridable
+with `--force-expression`.
+
+---
+
+### A.5 Part A summary table
+
+| # | lever | est. saving | risk | breaking? |
+|---|---|---|---|---|
+| 0 | **SKILL.md progressive disclosure** | **~7,950 tok / task** | low | no |
+| 2 | screenshot → file by default | 133K–890K tok **per occurrence** | very low | opt-in flag preserves old |
+| 1 | cap `html` + stderr nudge to `text` | ~100K tok per avoided call | med-low | new default cap |
+| 3 | unwrap envelope + compact large JSON | ~20K tok/day | **medium** | **YES** |
+| 4 | composite `read`/`grab` | ~21K tok / 3 days + correctness | low | no |
+| 5 | eval script-detection refusal | ~8.4K tok / 3 days | low-med | overridable |
+
+---
+
+# PART B — `browser agent` as the default for open-ended browsing
+
+## B.1 THE DECISION RULE
+
+> **Dispatch `browser agent "<goal>"` when the task is an open-ended READ** — "go find X
+> and tell me Y" — where you do **not** need to see the page yourself and the answer fits
+> in a few sentences. **Drive ops directly** when the task is **precise** (you already know
+> the exact URL and selector/JS and it's 1–3 ops), **interactive** (click/type/submit/
+> upload, driving an SPA), **diagnostic** (you must look at a screenshot or hit-test paint
+> order), or touches a **high-secret authenticated page** (agent-read pages go to
+> OpenRouter/DeepSeek). **When a read task is ambiguous, dispatch the agent first** —
+> escalation costs ~200 tokens, so agent-first wins even at a low success rate (§B.4).
+
+Concrete task shapes:
+
+| **→ `browser agent`** | **→ drive ops directly** |
+|---|---|
+| "what are the top 3 HN stories right now" | "read the active tab" (one `text`, done) |
+| "find the current price of X on this site" | "click the Grid tab in the benchmark app" |
+| "does their docs page mention feature Y" | "fill in this form and submit it" |
+| "summarise what's on my dashboard" | "screenshot this and tell me if the popover is covered" |
+| "search their changelog for when Z shipped" | "upload this file to the input" |
+| "go through these 3 pages and tell me which mentions Q" | "run this specific JS in the page and give me the value" |
+| research spanning several unknown-in-advance URLs | anything on a page with secrets you would not send to a third party |
+
+The discriminator, stated once so it doesn't get re-litigated: **do you need to SEE the
+page, or do you need to KNOW something from it?** See → drive. Know → agent.
+
+## B.2 Proposed SKILL.md wording (draft for review)
+
+This is the `## FIRST DECISION: agent or direct?` core section from §A.2.2 (~1,200 B),
+placed **immediately after Quick start** — i.e. before the op table, so it is read before
+the reader has picked an op.
+
+---
+
+```markdown
+## FIRST DECISION: agent or direct?
+
+**For open-ended reading — "go find X and tell me Y" — reach for `browser agent` FIRST.**
+It runs an autonomous cheap model (DeepSeek flash) in its OWN isolated tab and returns a
+compact `{answer,evidence,steps_used,status}` — the page HTML never enters YOUR context.
+A direct read of a heavy page costs you 10K–100K tokens; the agent costs ~$0.006 and
+about 200 tokens of your context.
+
+    browser agent "go to news.ycombinator.com and report the top 3 story titles"
+
+**Use the agent when** the task is an open-ended READ and you don't need to see the page
+yourself: research across pages you don't know in advance, "does this site mention X",
+"what's the current value of Y", "summarise this dashboard".
+
+**Drive ops directly when** the task is:
+- **precise** — you already know the URL and the selector/JS, and it's 1–3 ops
+- **interactive** — click / type / submit / upload, or driving an SPA
+- **diagnostic** — you must LOOK at a screenshot, or hit-test paint order
+- **secret** — pages the agent reads are sent to OpenRouter/DeepSeek. Do not point it at
+  banking, credentials, private mail, or anything you wouldn't hand a third party.
+
+The discriminator: **do you need to SEE the page, or to KNOW something from it?**
+See → drive. Know → agent. When a read task is ambiguous, try the agent first — taking
+over afterwards costs you ~200 tokens, so it's cheaper than deciding carefully.
+
+**Checking the agent's answer (do this every time):**
+- `status:"blocked"` → non-zero exit. Take over and drive directly.
+- `status:"partial"` → it found some of it. Read `evidence`; drive directly for the rest.
+- `status:"ok"` **but `evidence` is empty or has no concrete quote/URL** → treat it as
+  `partial`. Verify the claim with ONE direct `text` read before you report it.
+
+Flags and guardrails: `--instance`, `--allow-domains`, `--deny-domains`, `--steps`,
+`--timeout`, `--dry-run` → `ref/agent.md`.
+```
+
+---
+
+Note on placement: the current doc buries this at L371 of 601. Placing it at ~L30 of a
+~200-line core is the single structural change most likely to move adoption.
+
+## B.3 Where deepseek-flash will be too weak — and the harness scaffolding to bridge it
+
+Based on `opencode/browser-agent.md` and `opencode/tools/browser.js` as they actually are.
+**I have not run the model** (out of scope for this dispatch), so each item below is a
+*structural* prediction from the tool surface, plus a cheap test to confirm it.
+
+### B.3.1 Blind selector synthesis — STRUCTURAL, the clearest weakness
+
+The agent def tells the model to **prefer `op="text"`** (L36) and warns that `html` "will
+drown you" (L23). But `text` returns innerText — **all selectors are stripped**. So for any
+`click`/`type` task the model must **invent** a CSS selector having never seen the markup.
+Its only recourse is `html`, which the def actively discourages and which will blow its
+step budget. There is no middle op.
+
+- **Bridge (highest value): add a `links` / `interactive` op** returning a compact
+  `[{text, tag, selector, href}]` list — a few KB instead of 400 KB, and it hands the model
+  the exact selectors it cannot otherwise guess. This is a *typed, bounded* op, so it does
+  not widen the security surface.
+- **Cheap test:** `browser agent "on <page>, click the 'Docs' link and report the first
+  heading"`. If it fails or falls back to `html`, confirmed.
+
+### B.3.2 The throttled-tab trap — STRUCTURAL, and the most dangerous
+
+The agent's tab is **always** background (the wrapper `open`s it with `active:false`). The
+def tells the model to call `activate` "when a heavy JS app is stuck on 'Loading…'" (L46-49).
+But a throttled SPA usually does **not** say "Loading…" — it renders a sparse but plausible
+shell. A flash-class model will read the shell and report a **confident wrong answer with
+`status:"ok"`**. This is the failure mode that makes a default dangerous.
+
+- **Bridge (deterministic, do NOT leave it to the model): the bridge already returns
+  `data.hidden:true` on reads from a hidden tab** (`SKILL.md` L122). Have
+  `browser_tool_impl.mjs` act on it: on the first `text`/`html` where `hidden===true`,
+  auto-issue `activate`, re-read, and return the re-read. The model never has to notice.
+  Alternatively have the *wrapper* `activate` once immediately after the tab is opened.
+- **Cheap test:** point the agent at the known-bad case already documented in SKILL.md
+  (`civitai.com/apps/run/model-benchmarking`) and see whether it reports content or a blank.
+
+### B.3.3 Cross-origin frames — two-step indirection it will skip
+
+Reading inside an OOPIF requires `frames` → pick an id → pass `frame`. Flash models
+commonly skip the discovery call, read the top frame, and report "the page is empty."
+Same class of failure as B.3.2: a confident wrong `ok`.
+
+- **Bridge:** when a `text` read returns fewer than ~200 bytes **and** the tab has >1
+  frame, have the tool append a deterministic note to the returned string: *"top frame is
+  nearly empty; this tab has N frames — call op=frames and re-read with `frame`."* Nudging
+  the model with a fact it can act on beats hoping it read rule #2.
+
+### B.3.4 Needle-in-a-haystack over 32 KB innerText
+
+With a 12-step budget the model can pull up to ~384 KB of innerText. The 1M context holds
+it; flash-class attention over long noisy text does not. Expect failures on dashboards and
+long tables where the answer is one number.
+
+- **Bridge:** encourage `selector` scoping (already supported on `text`) in the per-run
+  message; and `maxBytes` is already exposed. Lower-confidence bridge — this one is a
+  genuine model-capability limit, not a harness gap.
+- **This is where an escalate-to-Claude path matters most** (§B.4).
+
+### B.3.5 Self-reported `steps_used` is not trustworthy
+
+The schema asks the **model** for `steps_used` (`browser-agent.md` L67). A model that
+miscounts its own turns is routine. The wrapper already writes a metadata-only tool audit
+(`BROWSER_AGENT_AUDIT="$AUDIT_LOG"`).
+
+- **Bridge (trivial, deterministic):** compute `steps_used` from the audit log in
+  `browser-agent-parse.py` and **overwrite** whatever the model claimed.
+
+### B.3.6 Evidence grounding — the anti-confabulation lever
+
+`evidence` is currently whatever the model types. Nothing checks it came from a page.
+
+- **Bridge:** have the tool record the (truncated) strings it returned, and in the parser
+  verify each `evidence` entry is a **substring** of something the tool actually returned
+  (or a URL the tool actually navigated to). If not: **downgrade `ok` → `partial`** and
+  append a note. This is exactly the contract already used for Layer-B session insights
+  ("deterministic Python does the plumbing… an anti-confabulation contract forbids the
+  model from inventing counts"), so it is a proven in-house pattern, not a new invention.
+- This is what turns "a default that silently returns bad answers" into a default that
+  **fails loudly**. **I consider it a prerequisite for the default flip, alongside §0.5.**
+
+### B.3.7 Step budget
+
+12 is likely fine for a 1–2 page read and too small for "check 3 pages". Don't tune blind:
+once the audit log yields real step counts, raise the default only if runs are hitting the
+ceiling. Add a `budget_exhausted:true` field so it's visible rather than inferred.
+
+## B.4 Failure / escalation design
+
+### Detection (deterministic, cheap)
+
+The wrapper emits exactly one JSON object and its exit code is meaningful
+(`browser-agent` L61-77): exit 0 for `ok`/`partial`, non-zero for `blocked`/errors. So:
+
+| signal | Claude's action |
+|---|---|
+| non-zero exit / `status:"blocked"` | take over: drive directly from scratch |
+| `status:"partial"` | read `answer`+`evidence`; drive directly for the missing part only |
+| `status:"ok"` + grounded, concrete `evidence` | accept |
+| `status:"ok"` + empty/vague `evidence` | **treat as `partial`** — verify with ONE `text` read |
+
+The last row is the human-side guard for the confident-wrong-answer case; §B.3.6 is the
+machine-side guard. **Ship both** — B.3.6 is deterministic and should carry the weight;
+the SKILL.md rule is the backstop for whatever B.3.6 can't check.
+
+### Cost of escalation — this is the argument for agent-first
+
+Let `C_d` = tokens to do the task by driving directly, `C_a` ≈ 200 tokens (the bash call +
+the one-line JSON result) + ~$0.006, `p` = agent success rate.
+
+```
+cost(agent-first) = C_a + (1 − p) × C_d
+cost(direct)      = C_d
+
+agent-first is cheaper whenever   C_a + (1 − p)·C_d  <  C_d
+                            i.e.  C_a  <  p · C_d
+                            i.e.  p    >  C_a / C_d  =  200 / C_d
+```
+
+For open-ended browsing `C_d` is realistically **10,000–100,000 tokens** (one uncapped
+`html` alone is ~100K — §A.4 Lever 1). So:
+
+```
+C_d = 10,000  → agent-first wins if p > 200/10,000  = 2%
+C_d = 100,000 → agent-first wins if p > 200/100,000 = 0.2%
+```
+
+**Agent-first is the right default even if the cheap agent only works 5% of the time.**
+That is the strongest argument in this document, and it holds *because* escalation is
+cheap — which in turn holds *only if* detection is reliable. **The whole case rests on
+B.3.6 + the B.4 detection table.** If a wrong answer can pass as `ok`, the expected cost
+isn't 200 tokens, it's the downstream cost of acting on bad information, which is
+unbounded. **Do not flip the default without the grounding check.**
+
+Latency is the one cost this arithmetic ignores: a `--timeout 120` agent run that fails
+costs up to 2 minutes of wall clock. For an interactive session that is a real irritation
+even when the tokens are free. Suggest lowering the default timeout to ~60s for the
+default path (a "go read X" task that needs >60s is usually one the agent will fail anyway).
+
+## B.5 Zero-adoption diagnosis
+
+**Zero invocations on both hosts.** Ranked causes, with evidence:
+
+**1. (RULED OUT) The gate fails closed.** Disproved this session: `opencode debug agent
+browser-agent` on 1.18.4 resolves a browser-only tool set and the gate's verbatim predicate
+returns **RC=0**. The gate is not the blocker. Killing this hypothesis matters because it
+was the most plausible one and it would have changed the recommendation.
+
+**2. (PRIMARY) The doc tells the reader it won't work on the workbench.** `SKILL.md`
+L410-413: *"Different opencode versions resolve the deny differently (workbench 1.17.20,
+laptop 1.18.4), so this is the one place the fail-closed property is verified at runtime…
+on a version where the host-tool denial didn't take, `browser agent` refuses instead of
+running the model unconfined."* A careful reader on the workbench concludes: *this will
+probably refuse, don't bother.* **This is now factually false** (both hosts 1.18.4, gate
+passes) but it has been sitting in the always-loaded doc. Combined with the "Prereqs" para
+(L432-435: opencode on PATH, key in the auth store, BOTH the agent def AND the tool
+symlinked) it reads as a fragile, probably-broken feature.
+
+**3. (PRIMARY) There is no decision rule, and it is never framed as a default.** The
+section opens *"Offload an open-ended … task"* — an **option**, not a preference. Nothing in
+the doc says *prefer this*, and the ~$0.006-vs-~$0.75 cost comparison that makes the case
+lives in `README.md`/the audit doc, **not in SKILL.md**. Meanwhile the op table on L117-138
+lists `agent` as **one row among twenty**, next to ops the reader already knows work. Absent
+an explicit rule, a model picks the deterministic primitive it understands. This is the
+mechanism; #2 is the deterrent.
+
+**4. (AMPLIFIER) Burial.** The section starts at **line 371 of 601** — 61% into a
+41 KB doc — and the **Quick start (L13-28) does not mention it at all**. Anything a reader
+must reach line 371 to discover is effectively opt-in.
+
+**5. (CONTRIBUTING) Two consecutive ⚠ blocks read as "this is risky."** L424-431 is
+`⚠ Privacy: pages … sent to OpenRouter/DeepSeek` immediately followed by `⚠ Domain deny is
+a mitigation, not a guarantee`. Both are **correct and must be preserved**, but stacked
+back-to-back with no counterweight they bias a cautious model away. The fix is not to
+soften them — it's to put the *benefit* (cost + context savings) adjacent, and scope the
+privacy warning to what it actually covers (don't point it at secrets) rather than leaving
+it as a general aura of risk.
+
+**6. (MINOR) No worked example beyond one HN one-liner.** L379 is the only example, and
+it's inside the buried section. No example anywhere shows the *choice* between agent and
+direct.
+
+**Diagnosis in one line:** it was never a capability failure — the gate works. It is a
+**documentation-position and framing failure (#2 + #3, amplified by #4)**, with a stale
+factual claim (#2) actively telling readers not to try it on one of the two hosts. That is
+good news: the fix is cheap and is exactly the SKILL.md restructure Part A already
+proposes.
+
+## B.6 Security interaction with the default flip
+
+Covered in §0.5 and not repeated. The recommendation stands: **the `upload`-with-arbitrary-
+path surface must be closed at the enforcement layer (`BROWSER_AGENT_ALLOWED_OPS` /
+`ALLOWED_OPS_DEFAULT`) and removed from `browser-agent.md`'s tool table BEFORE the agent
+becomes the default path.** Making it the default multiplies how often a prompt-injecting
+page gets to talk to a cheap, credulous model that has been *told* it can upload arbitrary
+local files. Audit-logging is detection, not prevention.
+
+---
+
+# PART C — Combined ranked implementation plan
+
+Ordered by (value ÷ risk), with blockers first.
+
+| # | item | effort | risk | test coverage needed |
+|---|---|---|---|---|
+| **1** | **Close the agent `upload` gap** — drop `upload` (and `whoami` if unused) from the agent's effective op list via `ALLOWED_OPS_DEFAULT`/`BROWSER_AGENT_ALLOWED_OPS`; remove the `upload` row from `browser-agent.md`. **BLOCKER for #5.** | S (~1h) | low | unit: `runBrowserOp({op:"upload"})` throws a refusal; assert the agent md table matches `ALLOWED_OPS_DEFAULT` (a test that catches future drift) |
+| **2** | **Screenshot → file by default**, `--stdout-data-url` opt-in | S (~1h) | very low | CLI test: no-path → writes a png + prints `{path,bytes}`, no `data:` in stdout; with `--stdout-data-url` → old behaviour; with explicit path → unchanged |
+| **3** | **Fix the stale opencode-version claim** in SKILL.md + README + project memory (both hosts 1.18.4, gate passes) | XS (~15m) | none | none (doc); optionally a CI check that the gate predicate passes against a recorded `debug agent` fixture |
+| **4** | **SKILL.md progressive-disclosure split** (§A.2) — core ≤12 KB + 8 reference files, every gotcha relocated | M (~4h) | **low but irreversible-ish** — a lost gotcha is expensive | a mechanical check that every heading/⚠ paragraph in today's SKILL.md appears in exactly one of {core, ref/*}; **a human diff review is the real gate** |
+| **5** | **Agent-default wording** (§B.2) into the new core, at position 2 | S (~1h) | med — behaviour change | manual: a fresh session given a "go find X" prompt reaches for `browser agent`; and given "click this button" does not |
+| **6** | **Evidence-grounding check** in `browser-agent-parse.py` (downgrade ungrounded `ok`→`partial`) + compute `steps_used` from the audit log | M (~3h) | low | unit over canned transcripts: grounded `ok` survives; fabricated evidence → `partial` + note; model-claimed `steps_used` is overwritten. **Prerequisite for #5 being safe** |
+| **7** | **Auto-activate on `hidden:true`** in `browser_tool_impl.mjs` (+ the "N frames, top frame empty" hint) | M (~3h) | med — `activate` steals focus | unit: a `hidden:true` read triggers one `activate` + one re-read, and only once per run; live-verify against the documented `model-benchmarking` case |
+| **8** | **Cap `html`** (`--max-bytes`, default 65536, truncation note **in the payload**) + stderr nudge toward `text` | S (~2h) | med-low | unit: cap applied, note present in data, `0` uncaps; regression: an existing `html` caller isn't silently truncated without the note |
+| **9** | **Composite `browser read <url>` / `grab <url>`** | M (~3h) | low | integration against the fake extension: one call performs open→nav→activate→text and returns one payload; `--no-activate` skips |
+| **10** | **`eval` script-detection refusal** (`--force-expression` override) | S (~2h) | low-med | unit: multi-statement bodies refused with the wrapped suggestion; expressions containing `;` inside a string literal are NOT refused |
+| **11** | **Add a `links`/`interactive` op** (typed, bounded) — bridges the blind-selector gap | M (~4h) | low | unit + live-verify; agent-level: a click task that fails today succeeds |
+| **12** | **Unwrap the envelope** to `.result.data` by default + compact large JSON | M (~3h) | **HIGH — breaking** | full suite; `browser-agent` switched to `--raw`; every internal parser audited. **Ship last, or not at all** |
+
+**Reminder that applies to every code item here:** per the subsystem's own rule, a green
+test suite is a *prerequisite, not verification*. Items 2, 7, 8, 9, 11 all need
+**live-verify against real Brave** before they can be called done.
+
+---
+
+# PART D — Open questions for the operator
+
+1. **§0.5 — does opencode 1.18.4 enforce the typed `op` enum before `execute()`?**
+   `browser.js`'s enum omits `upload`; `browser_tool_impl.mjs` allows it; the agent md
+   advertises it. I could not determine which wins without invoking a model. **Do you want
+   me to dispatch a narrowly-scoped test (a stub tool that logs whether an out-of-enum arg
+   reaches `execute`, no browser, no page)?** Regardless of the answer I recommend closing
+   it at the enforcement layer (item #1).
+
+2. **Reference-file location and format.** Do you want `reference/*.md` inside
+   `scripts/browser-bridge/` (symlinked with the skill), or as a `SKILL.md` + `references/`
+   pair following the pattern used by the bundled skills? This affects the paths in the
+   trigger lines.
+
+3. **Envelope unwrap (item #12) — worth the breakage?** It's ~20K tokens/day but it's the
+   only breaking change in the plan and it touches `browser-agent`'s own parsing. I lean
+   **defer**; your call.
+
+4. **Auto-activate (item #7) steals focus.** The agent's tab is always background, so
+   auto-activating on `hidden:true` means an autonomous background agent can grab the
+   operator's screen. Acceptable, or should it be opt-in per run (`browser agent --activate`)?
+
+5. **Default `--timeout` for the agent path.** 120s is fine for a deliberate call; as a
+   *default* for every open-ended read it's a 2-minute stall on failure. Lower to 60s?
+
+6. **How should the agent's success rate be measured?** The case for agent-first is robust
+   to a low `p` (§B.4) but I'm guessing at `p` entirely. Cheapest honest measurement: run
+   the agent on ~10 representative real goals, record `status` + whether the answer was
+   right. ~$0.06 and ~20 minutes. **Worth doing before the default flip?** I'd say yes —
+   it also directly tests B.3.1/B.3.2/B.3.3.
+
+7. **Privacy scoping.** Should the default path carry a standing `--deny-domains` list
+   (bank, mail, credential managers) so the "don't point it at secrets" rule is enforced
+   rather than advisory? Note the doc's own caveat that domain-deny is best-effort against
+   client-side redirects.
+
+---
+
+## Confidence and what is guessed
+
+- **Measured / verified in code:** all SKILL.md byte figures; the gate result on 1.18.4;
+  the permission-array ordering; the `tools` map; `TEXT_MAX_BYTES_DEFAULT = 32768` and the
+  **absence** of any html cap; the screenshot no-path → data-URL-to-stdout path; the
+  `upload` three-layer mismatch; `pretty()` = `jq .`.
+- **Rule-of-thumb:** every `bytes/4 = tokens` conversion (±15%).
+- **Estimated, not measured:** typical page `outerHTML` size (300 KB–1.5 MB) and PNG
+  screenshot size — these drive the Lever 1 and Lever 2 magnitudes. The *structural*
+  findings (no cap; data URL to stdout) are certain; the *magnitudes* are estimates.
+- **Guessed:** the 30% reference-load rate in §A.3 (sensitivity analysis provided);
+  deepseek-flash's actual success rate `p` (see open question #6); the per-round-trip
+  harness overhead (~100–150 tokens) used in Lever 4.
+- **Not tested, deliberately:** deepseek-flash behaviour. Every §B.3 claim is derived from
+  the tool surface and agent def, with a cheap confirming test named for each.

--- a/claudedocs/handoff-browser-bridge-2026-07-31.md
+++ b/claudedocs/handoff-browser-bridge-2026-07-31.md
@@ -1,0 +1,137 @@
+# Handoff: browser-bridge — wake, nested-OOPIF, agent unblocked, skill restructure — 2026-07-31
+
+## Goal
+Take browser-bridge from "feature-complete but partly broken in reality" to verified, and
+cut its per-task token cost. **10 PRs merged, every behavioural one live-verified against
+real Brave.** `browser agent` executed successfully for the first time ever.
+
+## State now
+- Branch: `main`, both hosts converged (laptop `.155`, workbench `.250`), `home-manager
+  switch` applied, `browser-bridge` service **active** on the current `server.py`.
+- ⚠ `main` moves FAST — other sessions merged 6+ PRs *during* this session. **Always
+  `git fetch` and check which branch you are on before any pull/checkout** (see Gotchas).
+- Working tree carries long-standing operator-owned uncommitted files on both hosts
+  (~17 laptop / ~33 workbench). **Not mine, left untouched.**
+
+### DONE — merged + live-verified
+| PR | What | How verified |
+|---|---|---|
+| #212 | Nested-OOPIF cascade (`eval --frame` / `upload --frame`) | grandchild → `"grandchild-reached"`; depth 6 → `oopif_depth_cap:5` |
+| #215 | `screenshot`→`.png` @0600 +24h prune; `html --max-bytes`; `js` alias | `js '1+1'`→2 (telemetry logs `op=eval`); cap truncated 492,211 B; PNG mode `-rw-------` |
+| #216 | Agent gate file-capture; `upload` out of agent op set; `whoami` narrowed | gate resolves browser-only |
+| #222 | Cookie limits + in-page credentialed-fetch pattern | `credentials:"include"`→404 vs `"omit"`→401 (cookie attached, no value leaked) |
+| #225 | **`wake`** — un-throttle a hidden tab, NO focus theft | `WAKE-RIG-SHELL`→`WAKE-RIG-RENDERED`; `xdotool getactivewindow` unchanged |
+| #226 | Rescued false-outage post-mortem; remedy `activate`→`wake` | docs |
+| #233 | **SKILL.md restructure** 56,031→11,322 B + 8 reference files | 75-string coverage check, independently spot-checked |
+| #234 | **Readiness probe** — `browser agent` could not start at all | live: first-ever successful agent run |
+| #235 | Rescued 3 stranded gotchas (incl. `data-testid` stripped in prod) | docs; core 11,870 B (ceiling 12,288) |
+| (in flight) | `docs/session-lessons-browser-bridge` — RULES.md / CLAUDE.md / agent.md | — |
+
+**`browser agent` end-to-end proof (2026-07-31):**
+```
+$ browser --instance personal agent --allow-domains example.com \
+    "go to https://example.com and report the exact H1 heading text"
+{"answer":"Example Domain","evidence":["browser(op=\"text\", selector=\"h1\") returned: Example Domain"],"steps_used":2,"status":"ok"}
+```
+
+## Open investigations — live diagnosis state
+
+### 1. Is deepseek-flash good enough to be the DEFAULT for open-ended browsing?
+- **UNMEASURED.** Only two trivial tasks have ever run. This gates the `browser agent`-first
+  default flip, which is deliberately NOT shipped.
+- **Ruled out as causes of the historical zero-adoption:** opencode version (both hosts
+  1.18.4); the `*: allow` permission-map scare (false alarm — the gate checks the `tools`
+  map, which resolves browser-only). The real causes were the two blockers, both now fixed.
+- **Next probe:** ~10 real goals drawn from transcripts, ~$0.06, ~20 min. Watch for: blind
+  selector synthesis; the throttled-background-tab trap producing confident wrong `ok`s (now
+  mitigable — the agent can call `wake`); skipped `frames` discovery. Design + decision rule:
+  `claudedocs/browser-bridge-token-and-agent-design-2026-07-30.md`.
+
+### 2. Can a hidden tab read the clipboard during a `wake`? (SUSPECTED, low stakes)
+- `navigator.clipboard.readText()` needs a focused document + granted `clipboard-read`;
+  `wake` supplies the "focused" half via focus emulation.
+- **Mitigated regardless:** #225 sends `setFocusEmulationEnabled({enabled:false})` in a
+  `finally`, so the window is bounded to the wake. Confirmed live: tab reports `hidden`
+  immediately after.
+- **Next probe:** on a site with `clipboard-read` already granted, copy a sentinel, then
+  `browser js 'navigator.clipboard.readText()' --wake` on a hidden tab.
+
+## Next steps (ranked)
+1. **Measure deepseek** (investigation 1) → then ship the agent-default flip as its own PR.
+2. **Stable extension path + manifest version bump.** The session's biggest cost was
+   infrastructure, not bugs: 3 Brave restarts, a silently-reverted staged build, a deleted
+   fixture dir. Move the extension to `~/.local/share/browser-bridge-ext/` so no git
+   operation can invalidate a verification; bump the manifest per change so `whoami`'s
+   loaded-vs-repo actually answers "is the new build loaded?".
+3. Optional: symlink `reference/` in `nix/home.nix` so the core can use relative paths
+   (today it uses repo-absolute paths — works on both hosts, no Nix change needed).
+4. Smaller: `nav --wait-for <selector>` (28 hand-rolled polling bigrams in real sessions);
+   failure-path coverage for `instances`/`release`/`tabs` (currently zero); CLI
+   error-translation layer (only 2 of 9 HTTP branches tested).
+
+## Gotchas / decisions / dead-ends
+- 🔴 **An audit/review fix RESETS the verification gate.** Twice this session an adversarial
+  audit correctly identified a gap, and the fix for it broke the feature live. The
+  own-tab `source.tabId` check silently ate every nested CDP event → a **completely inert**
+  feature that still passed 428 green tests and a second clean audit.
+- 🔴 **Four features passed tests AND clean audits while broken in reality**: inert cascade,
+  screen-stealing wake predecessor, unrunnable agent, world-readable screenshots in `/tmp`.
+- 🔴 **Chrome does NOT populate `source.tabId` on sub-session `Target.attachedToTarget`**
+  (flat mode). Prove ownership by **session parentage**. Signature of this bug class:
+  `frame_not_found` and *never* a depth cap — "inert, not capped".
+- **Build a deterministic "is the new build loaded?" tell into every extension change**
+  (a new op name → `unknown_op` on the old build). Without one, reload-vs-restart is
+  unfalsifiable — that ambiguity cost 3 full Brave restarts.
+- **DEAD END (verified):** dropping the server so the long-poll dies and letting the MV3
+  worker idle-evict does **NOT** load new code. Chrome pins the loaded version until an
+  explicit reload/restart. Don't retry.
+- ⚠ **Never kill Brave to force a reload** — `restore_on_startup` is UNSET on both profiles,
+  so the operator's tabs would NOT return. Ask for the ↻ click; ↻ *does* work (it worked
+  twice this session) — it's just unfalsifiable without a tell.
+- **The server runs `~/.config/browser-bridge/server.py` (nix-managed), NOT the repo file.**
+  Editing the repo changes nothing until `home-manager switch`. To live-test an unmerged
+  server change: stop the service, run the branch's `server.py` manually on 8788, restore
+  after. The EXTENSION loads from the repo path — so another session's checkout silently
+  reverts a staged build.
+- **`vcap.me` now resolves to a REAL PUBLIC IP** (103.224.182.214) — do not use it as a
+  loopback alias. Use `lvh.me`, `127.0.0.1.sslip.io`, `127.0.0.1.nip.io`.
+  ⚠ **`lvh.me` is on Phantom Wallet's phishing blocklist** and gets tabs hijacked to
+  `chrome-extension://…/phishing.html` — the rig uses `sslip.io`.
+- **`pkill -f <pat>` matches your OWN shell** and killed the running command twice (exit
+  144). Resolve PIDs first: `pgrep -f <pat>`, skip `$$`, verify `/proc/<pid>/cmdline`, `kill`.
+- **`gh pr view --json mergeable` is the ONLY conflict authority** — `git merge-tree` with
+  two args gave a confident false "no conflicts".
+- **Counting a string that also appears in a fixture's own source proves nothing.** A grep
+  for `POISON` "failed" the isolated-world check; the real discriminator was the returned
+  document's SIZE and content.
+
+## ⚠ Stranded work (NOT mine — needs owners' decisions)
+- **`standup.sh` in a workbench stash** — `ssh 192.168.50.250`, `git -C ~/workspace/devrc
+  stash list` → `stash@{0}`/`stash@{1}` hold `claude/skills/standup/standup.sh` at **288
+  lines vs main's 272**. **Do not drop these stashes.**
+- **`docs/auditloop-skill-push-grounding`** was accidentally rebased onto main by this
+  session. Content verified byte-identical; only the base moved. Restore with
+  `git reset --hard origin/docs/auditloop-skill-push-grounding` if preferred.
+- Laptop has 9 stashes, mostly repeated `ship-auto` snapshots. Left in place.
+
+## How to verify
+```bash
+BB=~/workspace/devrc/scripts/browser-bridge/browser
+$BB whoami                       # ORIENT FIRST — host + instances + loaded-vs-repo version
+$BB wake                         # woke:true; visibilityState visible → hidden after
+$BB agent --allow-domains example.com "go to https://example.com and report the H1"
+# Full wake proof (rig on 8901):
+python3 -m http.server 8901 --bind 127.0.0.1 \
+  --directory ~/workspace/devrc/scripts/browser-bridge/tests/fixtures/oopif-rig &
+export DISPLAY=:0 XAUTHORITY=/home/zach/.Xauthority
+nix-shell -p xdotool --run 'xdotool getactivewindow getwindowname'   # BEFORE
+T=$($BB open http://127.0.0.1:8901/wake-rig.html | grep -oE '"tabId": [0-9]+' | grep -oE '[0-9]+')
+$BB --tab $T text   # WAKE-RIG-SHELL, hidden:true
+$BB --tab $T wake   # woke:true
+$BB --tab $T text   # WAKE-RIG-RENDERED
+nix-shell -p xdotool --run 'xdotool getactivewindow getwindowname'   # AFTER — MUST MATCH
+$BB --tab $T close
+# Suites (prerequisite, NOT verification):
+node --test scripts/browser-bridge/tests/*.test.mjs
+nix-shell -p python3Packages.pytest --run "python -m pytest scripts/browser-bridge/tests -q"
+```

--- a/claudedocs/kickoff-browser-bridge-2026-07-31.md
+++ b/claudedocs/kickoff-browser-bridge-2026-07-31.md
@@ -1,0 +1,23 @@
+Continue the browser-bridge work. Canonical handoff (read first):
+  ~/workspace/devrc/claudedocs/handoff-browser-bridge-2026-07-31.md
+
+First action: measure deepseek-flash on ~10 real goals (~$0.06, ~20 min) — it gates the
+`browser agent`-first default flip, which is designed and approved but deliberately
+unshipped. `browser agent` NOW WORKS (verified 2026-07-31, first successful run ever)
+but its capability is unmeasured beyond two trivial tasks. Do not flip the default on
+arithmetic alone.
+
+Then: stable extension path + manifest version bump (biggest infra win — cost 3 Brave
+restarts and a silently-reverted staged build last session).
+
+Non-negotiables:
+- Run `browser whoami` FIRST. Both hosts are hostname `nixos`.
+- Live-verify against real Brave is the ONLY gate. Last session FOUR features passed full
+  test suites AND clean adversarial audits while broken in reality. Twice the breaking
+  change was one an audit had requested — an audit fix RESETS the verification gate.
+- Build a deterministic "is the new build loaded?" tell into any extension change (a new
+  op name → `unknown_op` on the old build). Without one, reload-vs-restart is unfalsifiable.
+- devrc is a SHARED checkout other sessions mutate mid-task. Check which branch you're on
+  before any pull/checkout; re-verify files on disk immediately before a live check.
+- Never kill Brave to force a reload (`restore_on_startup` is unset — tabs are lost).
+  Ask for the ↻ click.


### PR DESCRIPTION
Six browser-bridge docs were sitting **untracked** in the devrc working tree:

- `browser-bridge-audit-opencode-design-2026-07-28.md`
- `browser-bridge-code-audit-2026-07-30.md`
- `browser-bridge-session-audit-2026-07-30.md`
- `browser-bridge-token-and-agent-design-2026-07-30.md`
- `handoff-browser-bridge-2026-07-31.md`
- `kickoff-browser-bridge-2026-07-31.md`

`claudedocs/handoff-browser-bridge-2026-07-30.md` is already tracked, so this is
the established home for them.

**Why now:** devrc is a shared checkout that concurrent sessions mutate mid-task.
Untracked docs there are one routine `checkout`/`stash`/deploy away from silent,
unreported deletion — three such pieces were found stranded in a single session,
including a production false-outage post-mortem.

Byte-identical copies of the working-tree files; no content changes. Scanned for
credentials before staging (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)