### PR TITLE
fix(browser-agent): deterministic hidden-tab auto-wake — stop handing the model a throttled shell

### DIFF
--- a/scripts/browser-bridge/browser-agent
+++ b/scripts/browser-bridge/browser-agent
@@ -401,7 +401,7 @@ run_opencode() {  # <transcript-out> [continue] — returns opencode's exit code
   BROWSER_AGENT_TAB="$TAB" BROWSER_AGENT_INSTANCE="$INSTANCE" \
   BROWSER_AGENT_ALLOW_DOMAINS="$ALLOW" BROWSER_AGENT_DENY_DOMAINS="$DENY" \
   BROWSER_AGENT_DRY_RUN="$DRYRUN" BROWSER_AGENT_AUDIT="$AUDIT_LOG" \
-  BROWSER_AGENT_SESSION_ID="$SESSION_ID" \
+  BROWSER_AGENT_SESSION_ID="$SESSION_ID" BROWSER_AGENT_STEPS="$STEPS" \
     setsid "$OPENCODE_BIN" "${oc[@]}" "${msg[@]}" >"$out" 2>>"$ERRLOG" </dev/null &
   local leader=$!               # setsid makes opencode the group leader → PGID == leader
   # Watchdog: after $TIMEOUT, mark + TERM opencode's whole group, then (grace) KILL

--- a/scripts/browser-bridge/opencode/browser-agent.md
+++ b/scripts/browser-bridge/opencode/browser-agent.md
@@ -28,7 +28,7 @@ fetch). Your tab is FIXED: you cannot choose or change which tab you act on.
 | `browser(op="click", selector="…")` (opt. `frame`) | **trusted** click at the element's center |
 | `browser(op="type", text="…")` (opt. `selector`, `frame`) | **trusted** text input (focus `selector` first if given) |
 | `browser(op="key", key="Enter")` (opt. `selector`, `frame`) | dispatch one **trusted** key (Enter/Tab/Escape/Arrow*/…) |
-| `browser(op="wake")` (opt. `waitMs`)   | **UN-THROTTLE your tab** so a throttled SPA actually renders. It does NOT move the operator's screen. **You rarely need to call this** — a hidden `text`/`html` read wakes and re-reads automatically (see Rules); call it by hand only when a page needs more render time after you drove it |
+| `browser(op="wake")` (opt. `waitMs`)   | **UN-THROTTLE your tab** so a throttled SPA actually renders. It does NOT move the operator's screen. **You almost never need to call this** — a hidden `text`/`html` read wakes and re-reads automatically, including the first read after you drove the page (see Rules) |
 | `browser(op="whoami")`                 | read-only identity + diagnostics: which HOST (laptop/workbench), YOUR OWN browser profile, and bridge/extension versions — call it to CONFIRM which host/profile you're on before acting (metadata only; you cannot see the operator's other profiles or what any tab is browsing) |
 
 ## Rules
@@ -50,12 +50,14 @@ fetch). Your tab is FIXED: you cannot choose or change which tab you act on.
   and gives you the RE-READ. The reply says so explicitly, and it says so again if
   the wake FAILED — in that case treat the content as possibly unrendered and do
   NOT report it as fact.
-- **Do not spend a step calling `op="wake"` yourself after a read** — it already
-  happened. Only call it by hand when a read was fine but the page needs more time
-  to finish rendering (e.g. after a `click` that starts a long load), and wake once
-  per page, not before every read: waking is not free (it briefly attaches the
-  debugger and holds a settle). You have NO way to foreground a tab; that is
-  deliberate and not a gap to work around.
+- **Do not spend a step calling `op="wake"` yourself** — it already happened, and
+  it happens again automatically on the first read after a `nav`/`click`/`key`/
+  `eval` (those replace the document, so the tool wakes the new one for you). Just
+  read, and believe what the reply says about the wake. Waking is not free (it
+  briefly attaches the debugger and holds a settle), so the tool budgets it; if a
+  reply says the wake budget is spent, stop trying to re-read the same page and
+  answer with what you have, or say you could not read it. You have NO way to
+  foreground a tab; that is deliberate and not a gap to work around.
 - **`op="screenshot"` now works on your (background) tab** via CDP — but you still
   only get a NOTE, never the image, so it rarely helps you answer. Read with
   `text`/`html`/`eval` instead; don't spend steps on a screenshot unless asked.

--- a/scripts/browser-bridge/opencode/browser-agent.md
+++ b/scripts/browser-bridge/opencode/browser-agent.md
@@ -28,7 +28,7 @@ fetch). Your tab is FIXED: you cannot choose or change which tab you act on.
 | `browser(op="click", selector="…")` (opt. `frame`) | **trusted** click at the element's center |
 | `browser(op="type", text="…")` (opt. `selector`, `frame`) | **trusted** text input (focus `selector` first if given) |
 | `browser(op="key", key="Enter")` (opt. `selector`, `frame`) | dispatch one **trusted** key (Enter/Tab/Escape/Arrow*/…) |
-| `browser(op="wake")` (opt. `waitMs`)   | **UN-THROTTLE your tab** so a throttled SPA actually renders — use when a heavy JS app is stuck on "Loading…" or a read comes back empty because your tab is backgrounded. It does NOT move the operator's screen |
+| `browser(op="wake")` (opt. `waitMs`)   | **UN-THROTTLE your tab** so a throttled SPA actually renders. It does NOT move the operator's screen. **You rarely need to call this** — a hidden `text`/`html` read wakes and re-reads automatically (see Rules); call it by hand only when a page needs more render time after you drove it |
 | `browser(op="whoami")`                 | read-only identity + diagnostics: which HOST (laptop/workbench), YOUR OWN browser profile, and bridge/extension versions — call it to CONFIRM which host/profile you're on before acting (metadata only; you cannot see the operator's other profiles or what any tab is browsing) |
 
 ## Rules
@@ -42,14 +42,20 @@ fetch). Your tab is FIXED: you cannot choose or change which tab you act on.
 - **Driving the app:** use `op="click"` to reach an in-app tab/button, `op="type"`
   to fill a field, and `op="key"` (e.g. `Enter`) to submit. These are TRUSTED
   input events. Pass `frame` when the control lives inside a cross-origin iframe.
-- **App stuck on "Loading…"? Read came back empty?** Your tab runs in the
-  background, and Chrome THROTTLES background tabs (no animation frames, ~1 Hz
-  timers) — a heavy JS SPA may never paint. Call `op="wake"` ONCE to un-throttle
-  YOUR tab, then read/drive it. `wake` does not touch the operator's screen, so it
-  is safe to use whenever a read looks empty — but it is not free (it briefly
-  attaches the debugger), so wake once per page, not before every read.
-  You have NO way to foreground a tab; that is deliberate and not a gap to work
-  around.
+- **Your tab is ALWAYS in the background, and Chrome THROTTLES background tabs**
+  (no animation frames, ~1 Hz timers) — a heavy JS SPA may never paint, so a read
+  can return a plausible-looking SHELL that is not the real page. **This is handled
+  FOR you:** the first `op="text"` / `op="html"` read of a page whose tab is hidden
+  automatically issues `wake` (un-throttle via CDP, no screen movement), re-reads,
+  and gives you the RE-READ. The reply says so explicitly, and it says so again if
+  the wake FAILED — in that case treat the content as possibly unrendered and do
+  NOT report it as fact.
+- **Do not spend a step calling `op="wake"` yourself after a read** — it already
+  happened. Only call it by hand when a read was fine but the page needs more time
+  to finish rendering (e.g. after a `click` that starts a long load), and wake once
+  per page, not before every read: waking is not free (it briefly attaches the
+  debugger and holds a settle). You have NO way to foreground a tab; that is
+  deliberate and not a gap to work around.
 - **`op="screenshot"` now works on your (background) tab** via CDP — but you still
   only get a NOTE, never the image, so it rarely helps you answer. Read with
   `text`/`html`/`eval` instead; don't spend steps on a screenshot unless asked.

--- a/scripts/browser-bridge/opencode/tools/browser.js
+++ b/scripts/browser-bridge/opencode/tools/browser.js
@@ -25,11 +25,11 @@ export default tool({
     "(TRUSTED text input, pass `text`, optional `selector`), 'key' (one key: " +
     "Enter/Tab/Escape/Backspace/Delete/Arrow*/Home/End/Page*, optional `selector`), " +
     "'wake' (UN-THROTTLE your background tab so a throttled SPA actually renders " +
-    "— does NOT move the user's focus; optional `waitMs` settle. You RARELY need " +
-    "to call this: a 'text'/'html' read of a hidden tab already wakes and re-reads " +
-    "AUTOMATICALLY, and the reply tells you it did. Do NOT spend a step waking " +
-    "after a read — only call it when you drove the page (click/key) and it needs " +
-    "more time to render, and at most once per page), " +
+    "— does NOT move the user's focus; optional `waitMs` settle. You almost NEVER " +
+    "need to call this: a 'text'/'html' read of a hidden tab already wakes and " +
+    "re-reads AUTOMATICALLY, and that includes the read right after a " +
+    "nav/click/key/eval. Do NOT spend a step on 'wake' — just read, and trust what " +
+    "the reply tells you about the wake), " +
     "'whoami' (read-only host/instance/version diagnostics — metadata only). " +
     "There is NO 'upload' op: file upload is off by default for the autonomous " +
     "agent. text/html/eval/click/type/key accept `frame` (a frameId or " +

--- a/scripts/browser-bridge/opencode/tools/browser.js
+++ b/scripts/browser-bridge/opencode/tools/browser.js
@@ -25,8 +25,11 @@ export default tool({
     "(TRUSTED text input, pass `text`, optional `selector`), 'key' (one key: " +
     "Enter/Tab/Escape/Backspace/Delete/Arrow*/Home/End/Page*, optional `selector`), " +
     "'wake' (UN-THROTTLE your background tab so a throttled SPA actually renders " +
-    "— does NOT move the user's focus; optional `waitMs` settle. Use this when a " +
-    "read comes back empty or the page looks stuck on 'Loading…'), " +
+    "— does NOT move the user's focus; optional `waitMs` settle. You RARELY need " +
+    "to call this: a 'text'/'html' read of a hidden tab already wakes and re-reads " +
+    "AUTOMATICALLY, and the reply tells you it did. Do NOT spend a step waking " +
+    "after a read — only call it when you drove the page (click/key) and it needs " +
+    "more time to render, and at most once per page), " +
     "'whoami' (read-only host/instance/version diagnostics — metadata only). " +
     "There is NO 'upload' op: file upload is off by default for the autonomous " +
     "agent. text/html/eval/click/type/key accept `frame` (a frameId or " +

--- a/scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
+++ b/scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
@@ -329,6 +329,125 @@ export function buildRequest(args, env, token) {
   };
 }
 
+// --- deterministic hidden-tab auto-wake ------------------------------------ //
+// WHY (measured, browser-bridge-deepseek-measurement-2026-07-31.md §3.2): the
+// agent's tab is ALWAYS opened `active:false`, so it is ALWAYS hidden and always
+// throttled. The server already self-announces that (`data.hidden:true` +
+// HIDDEN_TAB_NOTE on every read — extension/protocol.js annotateVisibility), but
+// summarizeResult used to return a BARE `data.text`/`data.html` and throw both
+// away. When a throttled SPA renders a sparse-but-PLAUSIBLE shell, the model read
+// the shell, could not tell the tab was hidden, and returned a confident WRONG
+// answer with `status:"ok"` and evidence that quoted the shell verbatim. That was
+// 1 of 13 `ok` runs (7.7%) and the ONLY failure mode found.
+//
+// The note reached the model only BY ACCIDENT before: via the `eval` branch, when
+// the value happened to be non-string and fell through to JSON.stringify(data).
+// That accident saved two runs and was absent in the failing one. So the fix is
+// DETERMINISTIC, not modelled: on the first hidden `text`/`html` read of a page
+// the tool ITSELF issues `wake`, re-reads, and returns the re-read. The model
+// never has to notice or decide.
+//
+// `wake`, NOT `activate` — wake un-throttles via CDP focus emulation and moves NO
+// focus; `activate` takes the operator's screen and is unreachable by the agent by
+// design (absent from OP_TO_SERVER). This is what makes an automatic un-throttle
+// acceptable for an autonomous background agent at all.
+
+// The ops that trigger an automatic wake. Deliberately NOT `eval`: an eval is a
+// caller-authored expression whose re-execution may not be idempotent. eval still
+// gets the SIGNAL (see HIDDEN_SIGNAL_OPS) — it just is not re-run automatically.
+export const AUTO_WAKE_OPS = Object.freeze(["text", "html"]);
+
+// The ops whose summary carries the hidden/throttle signal when `data.hidden` is
+// true. This is the "stop discarding the signal REGARDLESS" half of the fix: even
+// with auto-wake, a still-hidden or failed-wake read must be VISIBLE, not silent.
+export const HIDDEN_SIGNAL_OPS = Object.freeze(["text", "html", "eval"]);
+
+// Bound the per-tab page-key set so a long run that navigates many times cannot
+// grow it without limit. On overflow the set is cleared (worst case: one extra
+// wake), never allowed to grow.
+export const AUTO_WAKE_PAGE_CAP = 32;
+
+// tabId -> Set<pageKey>. Module-level, i.e. per browser-agent PROCESS — which is
+// exactly the lifetime of one `browser agent` run. Nothing is persisted to disk.
+const _wokenPages = new Map();
+
+// Test/seam hook: forget every recorded wake.
+export function resetAutoWakeState() { _wokenPages.clear(); }
+
+// The identity of the PAGE a read observed. Every read result carries the url it
+// read (extension/service_worker.js: `{url: tab.url, ...}`; for a `--frame` read
+// it is the FRAME's url). Using the url as the key means an in-page navigation
+// the agent caused with `click`/`eval` — not just an explicit `nav` — produces a
+// new key, so the new (freshly throttled) page is woken again.
+export function pageKeyOf(data) {
+  return typeof (data && data.url) === "string" ? data.url : "";
+}
+
+export function hasWokenPage(tab, key) {
+  const s = _wokenPages.get(tab);
+  return !!(s && s.has(key));
+}
+
+export function markPageWoken(tab, key) {
+  let s = _wokenPages.get(tab);
+  if (!s) { s = new Set(); _wokenPages.set(tab, s); }
+  if (s.size >= AUTO_WAKE_PAGE_CAP) s.clear();
+  s.add(key);
+}
+
+// A `nav` puts a BRAND-NEW document in the tab, and that document is throttled
+// again from scratch — so every recorded wake for the tab is void.
+export function forgetPageWakes(tab) { _wokenPages.delete(tab); }
+
+// Kill switch (reversibility): BROWSER_AGENT_AUTO_WAKE=0 restores the pre-fix
+// behaviour of never auto-waking. The signal-preservation half stays on either
+// way — turning auto-wake off must not put us back to a SILENT wrong answer.
+export function autoWakeEnabled(env) {
+  return String((env && env.BROWSER_AGENT_AUTO_WAKE) ?? "1").trim() !== "0";
+}
+
+// Fallback wording if the server's own note is missing (older extension / a mock).
+export const HIDDEN_FALLBACK_NOTE =
+  "tab is hidden — background tabs are throttled, so SPA content may not have rendered.";
+
+// The one-line, model-facing banner prepended to a read whose tab was hidden.
+// `autoWake` is null (no wake was attempted — e.g. `eval`, or the kill switch) or
+// {state, woke, detail}. Pure + exported so the wording is unit-assertable.
+export function hiddenNotice(data, autoWake) {
+  const note = (data && typeof data.note === "string" && data.note)
+    ? data.note : HIDDEN_FALLBACK_NOTE;
+  const st = autoWake && autoWake.state;
+  if (st === "woke" && autoWake.woke === true) {
+    return "[browser-tool] your tab was HIDDEN and throttled, so 'wake' was issued " +
+      `AUTOMATICALLY (${autoWake.detail}) and the content below is the RE-READ after ` +
+      "waking. No further wake is needed for this page.";
+  }
+  if (st === "woke") {
+    return "[browser-tool] WARNING: your tab was HIDDEN; an automatic 'wake' ran but " +
+      `could NOT confirm the tab un-throttled (${autoWake.detail}). The content below ` +
+      "is the re-read and may STILL be an unrendered shell — do not report it as fact " +
+      "if it looks like a loading/placeholder state.";
+  }
+  if (st === "already") {
+    return "[browser-tool] note: your tab is hidden, but 'wake' already ran for this " +
+      "page — the DOM it rendered persists, so the content below is post-wake.";
+  }
+  if (st === "failed") {
+    return "[browser-tool] WARNING: your tab is HIDDEN and the automatic 'wake' FAILED " +
+      `(${autoWake.detail}). The content below may be an unrendered shell, NOT the real ` +
+      `page. ${note}`;
+  }
+  return "[browser-tool] WARNING: your tab is HIDDEN and Chromium throttles it — the " +
+    `content below may be an unrendered shell, NOT the real page. ${note}`;
+}
+
+// Prepend the banner when the read was hidden (or when a wake was attempted at
+// all, so a wake that un-hid the tab is still reported honestly).
+function _withHiddenNotice(data, body, autoWake) {
+  if (data.hidden !== true && !autoWake) return body;
+  return `${hiddenNotice(data, autoWake)}\n\n${body}`;
+}
+
 // Pull a compact, model-facing string out of the server's 200 envelope. NEVER
 // dumps a base64 screenshot blob into the model context.
 //
@@ -337,13 +456,23 @@ export function buildRequest(args, env, token) {
 // every existing caller/test — is unaffected; an absent env simply means "no
 // instance forced", which is already the safe shape (no browsing domains are ever
 // emitted regardless).
-export function summarizeResult(op, envelope, env = {}) {
+// `autoWake` (4th arg, default null) carries what runBrowserOp did about a hidden
+// tab — see hiddenNotice. It only affects text/html/eval; every other op and every
+// existing caller/test is unaffected.
+export function summarizeResult(op, envelope, env = {}, autoWake = null) {
   const data = (envelope && envelope.data) || {};
-  if (op === "text") return typeof data.text === "string" ? data.text : JSON.stringify(data);
-  if (op === "html") return typeof data.html === "string" ? data.html : JSON.stringify(data);
+  if (op === "text") {
+    const body = typeof data.text === "string" ? data.text : JSON.stringify(data);
+    return _withHiddenNotice(data, body, autoWake);
+  }
+  if (op === "html") {
+    const body = typeof data.html === "string" ? data.html : JSON.stringify(data);
+    return _withHiddenNotice(data, body, autoWake);
+  }
   if (op === "eval") {
     const v = "value" in data ? data.value : data.result;
-    return typeof v === "string" ? v : JSON.stringify(v ?? data);
+    const body = typeof v === "string" ? v : JSON.stringify(v ?? data);
+    return _withHiddenNotice(data, body, autoWake);
   }
   if (op === "nav") {
     return JSON.stringify({ ok: true, url: data.url ?? null, title: data.title ?? null });
@@ -515,6 +644,54 @@ export async function runBrowserOp(args, opts = {}) {
   }
 
   _audit(env, "exec", op, op === "nav" ? hostOf(args.url) : "");
+  const outer = await _send(req, fetchImpl);
+  // whoami returns the diagnostic object DIRECTLY ({ok,host,bridge,instances}) —
+  // there is no {result:<envelope>} wrapper like /cmd. Summarize it as-is.
+  if (op === "whoami") return summarizeResult("whoami", outer, env);
+  let envelope = outer && outer.result;
+  if (envelope && envelope.ok === false) {
+    // An op-level failure in the page (e.g. owned_tab_gone) — surface to the model.
+    throw new BrowserToolRefusal(`op_failed:${envelope.error || "unknown"}`);
+  }
+
+  // A `nav` replaced the document: every wake recorded for this tab is void, the
+  // new page is throttled from scratch.
+  if (op === "nav") {
+    try { forgetPageWakes(forcedTab(env)); } catch { /* no tab → nothing to forget */ }
+  }
+
+  // --- the hidden-tab auto-wake (see AUTO_WAKE_OPS above) --------------------
+  let autoWake = null;
+  const data = (envelope && envelope.data) || {};
+  if (data.hidden === true && HIDDEN_SIGNAL_OPS.includes(op)) {
+    const tab = forcedTab(env);          // already validated by buildRequest
+    const key = pageKeyOf(data);
+    if (hasWokenPage(tab, key)) {
+      // WAKE ONCE PER PAGE. The un-throttled state itself dies with the CDP
+      // detach, but the DOM the page rendered during the wake PERSISTS — so a
+      // following read is cheap and correct without paying another ~1.5s settle.
+      autoWake = { state: "already", woke: null, detail: "" };
+    } else if (AUTO_WAKE_OPS.includes(op) && autoWakeEnabled(env)) {
+      // Marked BEFORE the attempt on purpose: if the wake fails, every later read
+      // of this page must NOT retry it. One failed wake per page, not one per read.
+      markPageWoken(tab, key);
+      _audit(env, "auto_wake", op, "hidden");
+      const r = await _autoWakeAndReRead(args, env, token, fetchImpl);
+      if (r.ok) {
+        envelope = r.envelope || envelope;
+        autoWake = { state: "woke", woke: r.woke, detail: r.detail };
+      } else {
+        // FAIL-OPEN: never turn a working read into an error. Return the original
+        // read, loudly labelled.
+        autoWake = { state: "failed", woke: null, detail: r.detail };
+      }
+    }
+  }
+  return summarizeResult(op, envelope || {}, env, autoWake);
+}
+
+// POST/GET a prepared request and return the parsed outer JSON body.
+async function _send(req, fetchImpl) {
   let resp;
   try {
     const method = req.method || "POST";
@@ -525,26 +702,54 @@ export async function runBrowserOp(args, opts = {}) {
   } catch (e) {
     throw new Error(`browser-tool: transport error talking to the bridge: ${e && e.message}`);
   }
-  const status = resp.status;
+  const st = resp.status;
   const textBody = await resp.text();
-  if (status !== 200) {
-    throw new Error(`browser-tool: bridge returned HTTP ${status}: ${textBody.slice(0, 300)}`);
+  if (st !== 200) {
+    throw new Error(`browser-tool: bridge returned HTTP ${st}: ${textBody.slice(0, 300)}`);
   }
-  let outer;
   try {
-    outer = JSON.parse(textBody);
+    return JSON.parse(textBody);
   } catch {
     throw new Error("browser-tool: unparseable bridge response");
   }
-  // whoami returns the diagnostic object DIRECTLY ({ok,host,bridge,instances}) —
-  // there is no {result:<envelope>} wrapper like /cmd. Summarize it as-is.
-  if (op === "whoami") return summarizeResult("whoami", outer, env);
-  const envelope = outer && outer.result;
-  if (envelope && envelope.ok === false) {
-    // An op-level failure in the page (e.g. owned_tab_gone) — surface to the model.
-    throw new BrowserToolRefusal(`op_failed:${envelope.error || "unknown"}`);
+}
+
+function _msg(e) { return String((e && e.message) || e).slice(0, 200); }
+
+// Issue `wake` on the agent's (env-forced) tab, then RE-RUN the caller's original
+// read and return its envelope. Never throws: every failure comes back as
+// {ok:false, detail} so the caller can fall back to the original read.
+//
+// `wake` goes through buildRequest like any other op, so the op allowlist still
+// applies — an operator who narrowed BROWSER_AGENT_ALLOWED_OPS to exclude `wake`
+// gets a clean refusal here and the fail-open path, not a bypass.
+async function _autoWakeAndReRead(args, env, token, fetchImpl) {
+  let woke = null;
+  let detail = "";
+  try {
+    const wakeOuter = await _send(buildRequest({ op: "wake" }, env, token), fetchImpl);
+    const wEnv = wakeOuter && wakeOuter.result;
+    if (wEnv && wEnv.ok === false) {
+      return { ok: false, detail: `wake failed: ${wEnv.error || "unknown"}` };
+    }
+    const wd = (wEnv && wEnv.data) || {};
+    woke = wd.woke === true;
+    detail = `woke:${wd.woke ?? "unknown"} settleMs:${wd.settleMs ?? "unknown"}`;
+  } catch (e) {
+    return { ok: false, detail: `wake failed: ${_msg(e)}` };
   }
-  return summarizeResult(op, envelope || {});
+  // The wake's un-throttle does not survive its own CDP detach, but the DOM the
+  // page rendered during it does — which is exactly what this re-read collects.
+  try {
+    const outer = await _send(buildRequest(args, env, token), fetchImpl);
+    const envelope = outer && outer.result;
+    if (envelope && envelope.ok === false) {
+      return { ok: false, detail: `re-read failed: ${envelope.error || "unknown"}` };
+    }
+    return { ok: true, envelope, woke, detail };
+  } catch (e) {
+    return { ok: false, detail: `re-read failed: ${_msg(e)}` };
+  }
 }
 
 function _readTokenFile(env) {

--- a/scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
+++ b/scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
@@ -384,15 +384,28 @@ export const AUTO_WAKE_PAGE_CAP = 32;
 // (hash routing, `?t=` cache-busters, history.replaceState on infinite scroll)
 // every read yields a fresh key, so "wake once per page" silently degrades to
 // "wake per read": 3 bridge calls + a ~1.5s settle each, against a per-instance
-// 5/s + burst-20 limiter. Past the cap the tool stops waking and says so LOUDLY —
-// it never falls back to the silent shell this whole change exists to remove.
-// Override with BROWSER_AGENT_AUTO_WAKE_MAX.
-export const AUTO_WAKE_TAB_CAP = 8;
+// 5/s + burst-20 limiter.
+//
+// The cap is BOUND TO THE RUN'S STEP BUDGET (`BROWSER_AGENT_STEPS`, which the
+// browser-agent wrapper already knows and now exports). A fixed 8 STARVED
+// legitimate runs: 12 distinct pages reached by nav+text is not churn, yet pages
+// 8-11 were never woken, silently reverting the back half of a default
+// `--steps 12` run to BROWSER_AGENT_AUTO_WAKE=0 behaviour. Binding it to STEPS
+// gives the provable bound "at most ONE injected wake per model step" — a run
+// cannot read more pages than it has steps — while still capping churn at what a
+// churny run could have cost anyway.
+export const AUTO_WAKE_TAB_CAP = 8;         // fallback when STEPS is unknown
+export const AUTO_WAKE_CAP_FLOOR = 4;       // a 1-2 step run still gets a few
 
+// Precedence: the operator's explicit override > the run's step budget > the
+// fallback. A junk value at either source falls through rather than producing NaN
+// (`NaN >= n` is false, i.e. a junk cap would silently mean UNCAPPED).
 export function autoWakeTabCap(env) {
-  const raw = String((env && env.BROWSER_AGENT_AUTO_WAKE_MAX) ?? "").trim();
-  if (!/^[0-9]+$/.test(raw)) return AUTO_WAKE_TAB_CAP;
-  return Number(raw);
+  const override = String((env && env.BROWSER_AGENT_AUTO_WAKE_MAX) ?? "").trim();
+  if (/^[0-9]+$/.test(override)) return Number(override);
+  const steps = String((env && env.BROWSER_AGENT_STEPS) ?? "").trim();
+  if (/^[0-9]+$/.test(steps)) return Math.max(Number(steps), AUTO_WAKE_CAP_FLOOR);
+  return AUTO_WAKE_TAB_CAP;
 }
 
 // tabId -> { pages: Map<pageKey, {ok, detail}>, wakes: number }. Module-level,
@@ -441,15 +454,22 @@ export function wakeCountForTab(tab) {
 // read) and charge the tab's wake budget. The placeholder verdict is a FAILURE:
 // if the process is interrupted between the attempt and its outcome, the
 // conservative reading — "we cannot vouch for this page" — is what survives.
+//
+// An EMPTY key means the read carried no url, i.e. we cannot identify the page.
+// The budget is still charged (so an urlless page cannot wake without limit) but
+// NOTHING is stored: an empty key would collide with every other urlless read and
+// vouch for a document it never saw.
 export function markPageWakeAttempt(tab, key) {
   const s = _tabState(tab);
+  s.wakes += 1;
+  if (!key) return s.wakes;
   if (s.pages.size >= AUTO_WAKE_PAGE_CAP) s.pages.clear();
   s.pages.set(key, { ok: false, detail: "the wake did not complete" });
-  s.wakes += 1;
   return s.wakes;
 }
 
 export function recordPageWakeOutcome(tab, key, ok, detail) {
+  if (!key) return;   // never write a verdict that any urlless read would match
   _tabState(tab).pages.set(key, { ok: !!ok, detail: String(detail || "") });
 }
 
@@ -519,6 +539,12 @@ export function hiddenNotice(data, autoWake) {
     return "[browser-tool] WARNING: your tab is HIDDEN and the automatic 'wake' FAILED " +
       `(${autoWake.detail}). The content below may be an unrendered shell, NOT the real ` +
       `page. ${note}`;
+  }
+  if (st === "dryrun") {
+    return "[browser-tool] WARNING: your tab is HIDDEN and Chromium throttles it. The " +
+      "automatic 'wake' was SKIPPED because this is a DRY RUN (a wake attaches the " +
+      "debugger to a live tab). The content below may be an unrendered shell, NOT the " +
+      `real page. ${note}`;
   }
   if (st === "capped") {
     return "[browser-tool] WARNING: your tab is HIDDEN and the automatic wake was SKIPPED " +
@@ -743,17 +769,19 @@ export async function runBrowserOp(args, opts = {}) {
     throw new BrowserToolRefusal(`op_failed:${envelope.error || "unknown"}`);
   }
 
-  // A wake the MODEL asked for counts as this page's wake — otherwise a manual
-  // `wake` followed by a read would pay for a second one immediately. It does NOT
-  // charge the tab cap: that budget bounds the traffic THIS TOOL injects on its
-  // own initiative, not the model's own (already step-budgeted) calls.
-  if (op === "wake") {
-    const wd = (envelope && envelope.data) || {};
-    try {
-      recordPageWakeOutcome(forcedTab(env), pageKeyOf(wd), wd.woke === true,
-        `woke:${wd.woke ?? "unknown"} settleMs:${wd.settleMs ?? "unknown"} (called directly)`);
-    } catch { /* no tab → nothing to record */ }
-  }
+  // ⚠ A `wake` the MODEL called is deliberately NOT recorded as this page's wake.
+  // It looks like a free optimisation (skip the tool's own wake right after a
+  // manual one) and it is a correctness trap: the extension reports the url from a
+  // `chrome.tabs.get` taken AFTER the settle, so if the URL changed during the
+  // ~1.5s window — a redirect completing, history.replaceState, an SPA route
+  // settling — the verdict lands on document B while the settle was spent on
+  // document A, and B's shell then gets a `note: … the DOM it rendered persists`.
+  // That is exactly the reassured-wrong-answer failure this whole change exists to
+  // remove. The AUTO path is immune because it keys on the PRE-wake read's url, so
+  // a URL change during the wake fails safe. Closing the gap properly needs the
+  // extension to also return the pre-attach url — an extension change, hence a
+  // manifest bump and a full Brave re-point — which is not worth saving one wake.
+  // DO NOT reintroduce this without that pre-attach url.
 
   // --- the hidden-tab auto-wake (see AUTO_WAKE_OPS above) --------------------
   // NOTE the ORDER: the banner for THIS read is decided first, from the
@@ -776,6 +804,13 @@ export async function runBrowserOp(args, opts = {}) {
       autoWake = prior.ok
         ? { state: "already-woke", woke: true, detail: prior.detail }
         : { state: "already-failed", woke: false, detail: prior.detail };
+    } else if (dry) {
+      // A dry-run's contract is "logs, never actually drives the browser". A read
+      // is passive, but a `wake` ATTACHES THE DEBUGGER to the operator's live tab
+      // for ~1.5s and raises Brave's "an extension is debugging this browser"
+      // banner — a categorical step past that. Skip it and say what would have
+      // happened; the signal is preserved either way.
+      autoWake = { state: "dryrun", woke: null, detail: "" };
     } else if (AUTO_WAKE_OPS.includes(op) && autoWakeEnabled(env)) {
       const cap = autoWakeTabCap(env);
       if (wakeCountForTab(tab) >= cap) {
@@ -862,8 +897,11 @@ async function _autoWakeAndReRead(args, env, token, fetchImpl) {
   let woke = null;
   let detail = "";
   try {
+    // Audited AFTER buildRequest, never before: a wake the op-allowlist refuses
+    // never reaches the bridge, so logging an `exec` for it would be untrue.
+    const wakeReq = buildRequest({ op: "wake" }, env, token);
     _audit(env, "auto_wake_exec", "wake", "");
-    const wakeOuter = await _send(buildRequest({ op: "wake" }, env, token), fetchImpl);
+    const wakeOuter = await _send(wakeReq, fetchImpl);
     const wEnv = wakeOuter && wakeOuter.result;
     if (wEnv && wEnv.ok === false) {
       return { ok: false, detail: `wake failed: ${_msg(wEnv.error) || "unknown"}` };
@@ -877,8 +915,9 @@ async function _autoWakeAndReRead(args, env, token, fetchImpl) {
   // The wake's un-throttle does not survive its own CDP detach, but the DOM the
   // page rendered during it does — which is exactly what this re-read collects.
   try {
+    const reReadReq = buildRequest(args, env, token);
     _audit(env, "auto_wake_exec", String((args && args.op) || ""), "re-read");
-    const outer = await _send(buildRequest(args, env, token), fetchImpl);
+    const outer = await _send(reReadReq, fetchImpl);
     const envelope = outer && outer.result;
     if (envelope && envelope.ok === false) {
       return { ok: false, detail: `re-read failed: ${_msg(envelope.error) || "unknown"}` };

--- a/scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
+++ b/scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
@@ -340,8 +340,12 @@ export function buildRequest(args, env, token) {
 // answer with `status:"ok"` and evidence that quoted the shell verbatim. That was
 // 1 of 13 `ok` runs (7.7%) and the ONLY failure mode found.
 //
-// The note reached the model only BY ACCIDENT before: via the `eval` branch, when
-// the value happened to be non-string and fell through to JSON.stringify(data).
+// The note reached the model only BY ACCIDENT before: via the `eval` branch, and
+// ONLY when the value was NULLISH — `JSON.stringify(v ?? data)` falls back to the
+// whole `data` (note included) for null/undefined alone. A non-string but non-null
+// value (a number, an object, an array) stringifies the VALUE and strips the note
+// exactly like the string path did. (The original PR text said "non-string"; that
+// was wrong and is corrected here — the accident was narrower than described.)
 // That accident saved two runs and was absent in the failing one. So the fix is
 // DETERMINISTIC, not modelled: on the first hidden `text`/`html` read of a page
 // the tool ITSELF issues `wake`, re-reads, and returns the re-read. The model
@@ -362,42 +366,100 @@ export const AUTO_WAKE_OPS = Object.freeze(["text", "html"]);
 // with auto-wake, a still-hidden or failed-wake read must be VISIBLE, not silent.
 export const HIDDEN_SIGNAL_OPS = Object.freeze(["text", "html", "eval"]);
 
-// Bound the per-tab page-key set so a long run that navigates many times cannot
-// grow it without limit. On overflow the set is cleared (worst case: one extra
+// Ops that REPLACE the document without necessarily changing the URL — a form
+// POST to the same URL, `location.reload()`, a same-URL SPA remount. The page key
+// is the read's url, so those are INVISIBLE to it: the key matches, the page is
+// reported as already-woken, and a freshly-throttled document gets read as a shell
+// and labelled post-wake. So a successful one of these voids the tab's records.
+// Over-forgetting costs one extra wake; under-forgetting costs a WRONG ANSWER.
+export const PAGE_INVALIDATING_OPS = Object.freeze(["nav", "click", "key", "eval"]);
+
+// Bound the per-tab page-key map so a long run that navigates many times cannot
+// grow it without limit. On overflow the map is cleared (worst case: one extra
 // wake), never allowed to grow.
 export const AUTO_WAKE_PAGE_CAP = 32;
 
-// tabId -> Set<pageKey>. Module-level, i.e. per browser-agent PROCESS — which is
-// exactly the lifetime of one `browser agent` run. Nothing is persisted to disk.
-const _wokenPages = new Map();
+// TOTAL automatic wakes per tab per run, INDEPENDENT of the page key — the
+// backstop for URL churn. On a page that rewrites its URL on every interaction
+// (hash routing, `?t=` cache-busters, history.replaceState on infinite scroll)
+// every read yields a fresh key, so "wake once per page" silently degrades to
+// "wake per read": 3 bridge calls + a ~1.5s settle each, against a per-instance
+// 5/s + burst-20 limiter. Past the cap the tool stops waking and says so LOUDLY —
+// it never falls back to the silent shell this whole change exists to remove.
+// Override with BROWSER_AGENT_AUTO_WAKE_MAX.
+export const AUTO_WAKE_TAB_CAP = 8;
+
+export function autoWakeTabCap(env) {
+  const raw = String((env && env.BROWSER_AGENT_AUTO_WAKE_MAX) ?? "").trim();
+  if (!/^[0-9]+$/.test(raw)) return AUTO_WAKE_TAB_CAP;
+  return Number(raw);
+}
+
+// tabId -> { pages: Map<pageKey, {ok, detail}>, wakes: number }. Module-level,
+// i.e. per browser-agent PROCESS — exactly the lifetime of one `browser agent`
+// run. Nothing is persisted to disk.
+//
+// ⚠ The VERDICT is stored, not just the key. Storing only "we tried" was a real
+// defect: a failed wake then read as a SUCCESSFUL one, and every later read of
+// that page was handed a throttled shell plus an authoritative assurance that it
+// was rendered — a reassured wrong answer, strictly worse than the silent one.
+const _wakeState = new Map();
+
+function _tabState(tab) {
+  let s = _wakeState.get(tab);
+  if (!s) { s = { pages: new Map(), wakes: 0 }; _wakeState.set(tab, s); }
+  return s;
+}
 
 // Test/seam hook: forget every recorded wake.
-export function resetAutoWakeState() { _wokenPages.clear(); }
+export function resetAutoWakeState() { _wakeState.clear(); }
 
 // The identity of the PAGE a read observed. Every read result carries the url it
 // read (extension/service_worker.js: `{url: tab.url, ...}`; for a `--frame` read
 // it is the FRAME's url). Using the url as the key means an in-page navigation
 // the agent caused with `click`/`eval` — not just an explicit `nav` — produces a
-// new key, so the new (freshly throttled) page is woken again.
+// new key, so the new (freshly throttled) page is woken again. It does NOT catch
+// a same-URL document replacement; PAGE_INVALIDATING_OPS covers that.
 export function pageKeyOf(data) {
   return typeof (data && data.url) === "string" ? data.url : "";
 }
 
-export function hasWokenPage(tab, key) {
-  const s = _wokenPages.get(tab);
-  return !!(s && s.has(key));
+// The recorded wake VERDICT for a page: {ok, detail}, or undefined if none.
+export function getPageWake(tab, key) {
+  const s = _wakeState.get(tab);
+  return s ? s.pages.get(key) : undefined;
 }
 
-export function markPageWoken(tab, key) {
-  let s = _wokenPages.get(tab);
-  if (!s) { s = new Set(); _wokenPages.set(tab, s); }
-  if (s.size >= AUTO_WAKE_PAGE_CAP) s.clear();
-  s.add(key);
+export function hasWokenPage(tab, key) { return getPageWake(tab, key) !== undefined; }
+
+export function wakeCountForTab(tab) {
+  const s = _wakeState.get(tab);
+  return s ? s.wakes : 0;
 }
 
-// A `nav` puts a BRAND-NEW document in the tab, and that document is throttled
-// again from scratch — so every recorded wake for the tab is void.
-export function forgetPageWakes(tab) { _wokenPages.delete(tab); }
+// Reserve the page BEFORE the attempt (so a failure is never retried once per
+// read) and charge the tab's wake budget. The placeholder verdict is a FAILURE:
+// if the process is interrupted between the attempt and its outcome, the
+// conservative reading — "we cannot vouch for this page" — is what survives.
+export function markPageWakeAttempt(tab, key) {
+  const s = _tabState(tab);
+  if (s.pages.size >= AUTO_WAKE_PAGE_CAP) s.pages.clear();
+  s.pages.set(key, { ok: false, detail: "the wake did not complete" });
+  s.wakes += 1;
+  return s.wakes;
+}
+
+export function recordPageWakeOutcome(tab, key, ok, detail) {
+  _tabState(tab).pages.set(key, { ok: !!ok, detail: String(detail || "") });
+}
+
+// A document replacement voids every page verdict for the tab. The wake COUNT is
+// deliberately NOT reset: the cap is a per-RUN backstop against churn, and churn
+// is exactly the case that navigates repeatedly.
+export function forgetPageWakes(tab) {
+  const s = _wakeState.get(tab);
+  if (s) s.pages.clear();
+}
 
 // Kill switch (reversibility): BROWSER_AGENT_AUTO_WAKE=0 restores the pre-fix
 // behaviour of never auto-waking. The signal-preservation half stays on either
@@ -410,9 +472,25 @@ export function autoWakeEnabled(env) {
 export const HIDDEN_FALLBACK_NOTE =
   "tab is hidden — background tabs are throttled, so SPA content may not have rendered.";
 
+// The hedge every post-wake banner carries. `woke` is probed by reading
+// visibilityState INSIDE the CDP attach (service_worker.js wakeProbeFn) — it says
+// the tab was un-throttled, and NOTHING about whether the SPA finished rendering
+// inside the bounded settle (1500ms default, 6000ms cap). A heavy app that needs
+// longer yields woke:true AND an unrendered shell, so a flat "this is the rendered
+// page" claim would over-promise on exactly the class of page this fix targets.
+const WAKE_HEDGE =
+  "The wake holds only a bounded settle, so a slow app may still not have finished: " +
+  "if the content below looks like a loading/placeholder state, it IS one — say so " +
+  "instead of reporting it as fact.";
+
 // The one-line, model-facing banner prepended to a read whose tab was hidden.
 // `autoWake` is null (no wake was attempted — e.g. `eval`, or the kill switch) or
 // {state, woke, detail}. Pure + exported so the wording is unit-assertable.
+//
+// ⚠ Grading is load-bearing. `note:` is only ever used for a wake this tool can
+// VOUCH for; anything unproven — failed, not-retried, skipped, never attempted —
+// is `WARNING:` and names the reason. A `note:` on an unrendered page is worse
+// than no banner at all, because it actively reassures the model.
 export function hiddenNotice(data, autoWake) {
   const note = (data && typeof data.note === "string" && data.note)
     ? data.note : HIDDEN_FALLBACK_NOTE;
@@ -420,22 +498,33 @@ export function hiddenNotice(data, autoWake) {
   if (st === "woke" && autoWake.woke === true) {
     return "[browser-tool] your tab was HIDDEN and throttled, so 'wake' was issued " +
       `AUTOMATICALLY (${autoWake.detail}) and the content below is the RE-READ after ` +
-      "waking. No further wake is needed for this page.";
+      `waking. ${WAKE_HEDGE}`;
   }
   if (st === "woke") {
     return "[browser-tool] WARNING: your tab was HIDDEN; an automatic 'wake' ran but " +
       `could NOT confirm the tab un-throttled (${autoWake.detail}). The content below ` +
-      "is the re-read and may STILL be an unrendered shell — do not report it as fact " +
-      "if it looks like a loading/placeholder state.";
+      `is the re-read and may STILL be an unrendered shell. ${WAKE_HEDGE}`;
   }
-  if (st === "already") {
-    return "[browser-tool] note: your tab is hidden, but 'wake' already ran for this " +
-      "page — the DOM it rendered persists, so the content below is post-wake.";
+  if (st === "already-woke") {
+    return "[browser-tool] note: your tab is hidden, but 'wake' already SUCCEEDED for " +
+      "this page — the DOM it rendered persists, so the content below is post-wake. " +
+      WAKE_HEDGE;
+  }
+  if (st === "already-failed") {
+    return "[browser-tool] WARNING: your tab is HIDDEN and the automatic 'wake' for this " +
+      `page FAILED earlier (${autoWake.detail}); it is deliberately not retried per read. ` +
+      `The content below may be an unrendered shell, NOT the real page. ${note}`;
   }
   if (st === "failed") {
     return "[browser-tool] WARNING: your tab is HIDDEN and the automatic 'wake' FAILED " +
       `(${autoWake.detail}). The content below may be an unrendered shell, NOT the real ` +
       `page. ${note}`;
+  }
+  if (st === "capped") {
+    return "[browser-tool] WARNING: your tab is HIDDEN and the automatic wake was SKIPPED " +
+      `— this run has spent its wake budget (${autoWake.detail}), which usually means the ` +
+      "page rewrites its URL on every read. The content below may be an unrendered shell, " +
+      `NOT the real page. ${note}`;
   }
   return "[browser-tool] WARNING: your tab is HIDDEN and Chromium throttles it — the " +
     `content below may be an unrendered shell, NOT the real page. ${note}`;
@@ -654,39 +743,79 @@ export async function runBrowserOp(args, opts = {}) {
     throw new BrowserToolRefusal(`op_failed:${envelope.error || "unknown"}`);
   }
 
-  // A `nav` replaced the document: every wake recorded for this tab is void, the
-  // new page is throttled from scratch.
-  if (op === "nav") {
-    try { forgetPageWakes(forcedTab(env)); } catch { /* no tab → nothing to forget */ }
+  // A wake the MODEL asked for counts as this page's wake — otherwise a manual
+  // `wake` followed by a read would pay for a second one immediately. It does NOT
+  // charge the tab cap: that budget bounds the traffic THIS TOOL injects on its
+  // own initiative, not the model's own (already step-budgeted) calls.
+  if (op === "wake") {
+    const wd = (envelope && envelope.data) || {};
+    try {
+      recordPageWakeOutcome(forcedTab(env), pageKeyOf(wd), wd.woke === true,
+        `woke:${wd.woke ?? "unknown"} settleMs:${wd.settleMs ?? "unknown"} (called directly)`);
+    } catch { /* no tab → nothing to record */ }
   }
 
   // --- the hidden-tab auto-wake (see AUTO_WAKE_OPS above) --------------------
+  // NOTE the ORDER: the banner for THIS read is decided first, from the
+  // bookkeeping as it stood when the read happened, and only then does a
+  // document-replacing op void the records. An `eval` is both — its value was
+  // produced by the OLD document, so it is described against the old verdict and
+  // invalidates only what comes after it.
   let autoWake = null;
   const data = (envelope && envelope.data) || {};
   if (data.hidden === true && HIDDEN_SIGNAL_OPS.includes(op)) {
     const tab = forcedTab(env);          // already validated by buildRequest
     const key = pageKeyOf(data);
-    if (hasWokenPage(tab, key)) {
+    const prior = getPageWake(tab, key);
+    if (prior) {
       // WAKE ONCE PER PAGE. The un-throttled state itself dies with the CDP
       // detach, but the DOM the page rendered during the wake PERSISTS — so a
       // following read is cheap and correct without paying another ~1.5s settle.
-      autoWake = { state: "already", woke: null, detail: "" };
+      // The stored VERDICT decides the wording: a page whose wake FAILED must
+      // never be described as post-wake.
+      autoWake = prior.ok
+        ? { state: "already-woke", woke: true, detail: prior.detail }
+        : { state: "already-failed", woke: false, detail: prior.detail };
     } else if (AUTO_WAKE_OPS.includes(op) && autoWakeEnabled(env)) {
-      // Marked BEFORE the attempt on purpose: if the wake fails, every later read
-      // of this page must NOT retry it. One failed wake per page, not one per read.
-      markPageWoken(tab, key);
-      _audit(env, "auto_wake", op, "hidden");
-      const r = await _autoWakeAndReRead(args, env, token, fetchImpl);
-      if (r.ok) {
-        envelope = r.envelope || envelope;
-        autoWake = { state: "woke", woke: r.woke, detail: r.detail };
+      const cap = autoWakeTabCap(env);
+      if (wakeCountForTab(tab) >= cap) {
+        // Churn backstop (URL-rewriting pages defeat the per-page key). Stop
+        // waking, but say so LOUDLY — never silently hand back the shell.
+        autoWake = { state: "capped", woke: null, detail: `${wakeCountForTab(tab)}/${cap} wakes used` };
+        _audit(env, "auto_wake_capped", op, `${wakeCountForTab(tab)}/${cap}`);
       } else {
-        // FAIL-OPEN: never turn a working read into an error. Return the original
-        // read, loudly labelled.
-        autoWake = { state: "failed", woke: null, detail: r.detail };
+        // Reserved BEFORE the attempt on purpose: if the wake fails, every later
+        // read of this page must NOT retry it. One failed wake per page, not one
+        // per read — and the failure VERDICT is what gets stored.
+        markPageWakeAttempt(tab, key);
+        _audit(env, "auto_wake", op, "hidden");
+        const r = await _autoWakeAndReRead(args, env, token, fetchImpl);
+        if (r.ok) {
+          envelope = r.envelope || envelope;
+          autoWake = { state: "woke", woke: r.woke, detail: r.detail };
+          // `woke !== true` is NOT a page we can vouch for later: record it as a
+          // failure so a follow-up read gets the WARNING, not the `note:`.
+          recordPageWakeOutcome(tab, key, r.woke === true, r.detail);
+          _audit(env, r.woke === true ? "auto_wake_ok" : "auto_wake_unconfirmed", op, r.detail);
+        } else {
+          // FAIL-OPEN: never turn a working read into an error. Return the original
+          // read, loudly labelled.
+          autoWake = { state: "failed", woke: null, detail: r.detail };
+          recordPageWakeOutcome(tab, key, false, r.detail);
+          _audit(env, "auto_wake_failed", op, r.detail);
+        }
       }
     }
   }
+
+  // A successful nav/click/key/eval can put a BRAND-NEW document in the tab — and
+  // a form POST, a reload or a same-URL SPA remount does it WITHOUT changing the
+  // url, so the page key cannot see it. Void the tab's verdicts; the new document
+  // is throttled from scratch. (The wake COUNT survives — see forgetPageWakes.)
+  if (PAGE_INVALIDATING_OPS.includes(op)) {
+    try { forgetPageWakes(forcedTab(env)); } catch { /* no tab → nothing to forget */ }
+  }
+
   return summarizeResult(op, envelope || {}, env, autoWake);
 }
 
@@ -714,7 +843,9 @@ async function _send(req, fetchImpl) {
   }
 }
 
-function _msg(e) { return String((e && e.message) || e).slice(0, 200); }
+// Every `detail` that reaches a model-facing banner or the audit log goes through
+// here — an op error is server-supplied and must not be interpolated unbounded.
+function _msg(e) { return String((e && e.message) || e || "").slice(0, 200); }
 
 // Issue `wake` on the agent's (env-forced) tab, then RE-RUN the caller's original
 // read and return its envelope. Never throws: every failure comes back as
@@ -723,14 +854,19 @@ function _msg(e) { return String((e && e.message) || e).slice(0, 200); }
 // `wake` goes through buildRequest like any other op, so the op allowlist still
 // applies — an operator who narrowed BROWSER_AGENT_ALLOWED_OPS to exclude `wake`
 // gets a clean refusal here and the fail-open path, not a bypass.
+//
+// Both injected calls are AUDITED (`auto_wake_exec`), so a reader of
+// BROWSER_AGENT_AUDIT sees the wake and the re-read the tool issued on its own
+// initiative — not just the model's own calls. The caller then logs the outcome.
 async function _autoWakeAndReRead(args, env, token, fetchImpl) {
   let woke = null;
   let detail = "";
   try {
+    _audit(env, "auto_wake_exec", "wake", "");
     const wakeOuter = await _send(buildRequest({ op: "wake" }, env, token), fetchImpl);
     const wEnv = wakeOuter && wakeOuter.result;
     if (wEnv && wEnv.ok === false) {
-      return { ok: false, detail: `wake failed: ${wEnv.error || "unknown"}` };
+      return { ok: false, detail: `wake failed: ${_msg(wEnv.error) || "unknown"}` };
     }
     const wd = (wEnv && wEnv.data) || {};
     woke = wd.woke === true;
@@ -741,10 +877,11 @@ async function _autoWakeAndReRead(args, env, token, fetchImpl) {
   // The wake's un-throttle does not survive its own CDP detach, but the DOM the
   // page rendered during it does — which is exactly what this re-read collects.
   try {
+    _audit(env, "auto_wake_exec", String((args && args.op) || ""), "re-read");
     const outer = await _send(buildRequest(args, env, token), fetchImpl);
     const envelope = outer && outer.result;
     if (envelope && envelope.ok === false) {
-      return { ok: false, detail: `re-read failed: ${envelope.error || "unknown"}` };
+      return { ok: false, detail: `re-read failed: ${_msg(envelope.error) || "unknown"}` };
     }
     return { ok: true, envelope, woke, detail };
   } catch (e) {

--- a/scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
+++ b/scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
@@ -372,6 +372,29 @@ export const HIDDEN_SIGNAL_OPS = Object.freeze(["text", "html", "eval"]);
 // reported as already-woken, and a freshly-throttled document gets read as a shell
 // and labelled post-wake. So a successful one of these voids the tab's records.
 // Over-forgetting costs one extra wake; under-forgetting costs a WRONG ANSWER.
+//
+// KNOWN COST, deliberately accepted: this is unconditional, so a purely READ-ONLY
+// `eval` also voids the verdict and the next read pays a fresh wake. There is no
+// cheap, sound way to tell a read-only eval from a document-replacing one — a
+// keyword scan of the `js` string is a heuristic on attacker-adjacent input and
+// misses `el.click()` on a submit button entirely.
+//
+// ⚠ THE RIGHT FIX IS NOT "make these four ops precise" — do not build that.
+// A `click` can start a navigation that COMMITS ASYNCHRONOUSLY, so any per-op
+// probe (including a CDP `Page.getFrameTree` loaderId sampled right after the
+// click) still sees the OLD document and would UNDER-invalidate — the dangerous
+// direction. The sound design is to attach a per-document identity to EVERY
+// READ'S PAYLOAD and key the wake verdict on `(url, documentId)`. Then a document
+// replacement changes the key by construction, sync or async; this whole list
+// disappears; and the same-URL remount the url key cannot see is fixed for free.
+// Prefer `performance.timeOrigin` read from the ISOLATED world over a CDP
+// loaderId: it rides the existing read path with no debugger attach (the
+// expensive thing this design avoids) and is naturally per-frame, which `--frame`
+// reads need. Where a content script cannot inject (`chrome://`, the PDF viewer)
+// the id is absent and MUST fail CLOSED — unknown document, never reuse a verdict
+// — which is exactly the empty-key handling markPageWakeAttempt already has.
+// That is an extension-side change, so it belongs in the next batch that already
+// requires a manifest bump and a full Brave re-point.
 export const PAGE_INVALIDATING_OPS = Object.freeze(["nav", "click", "key", "eval"]);
 
 // Bound the per-tab page-key map so a long run that navigates many times cannot
@@ -390,10 +413,21 @@ export const AUTO_WAKE_PAGE_CAP = 32;
 // browser-agent wrapper already knows and now exports). A fixed 8 STARVED
 // legitimate runs: 12 distinct pages reached by nav+text is not churn, yet pages
 // 8-11 were never woken, silently reverting the back half of a default
-// `--steps 12` run to BROWSER_AGENT_AUTO_WAKE=0 behaviour. Binding it to STEPS
-// gives the provable bound "at most ONE injected wake per model step" — a run
-// cannot read more pages than it has steps — while still capping churn at what a
-// churny run could have cost anyway.
+// `--steps 12` run to BROWSER_AGENT_AUTO_WAKE=0 behaviour.
+//
+// ⚠ Be precise about what this buys, because the obvious phrasing is a claim
+// nothing enforces. `STEPS` is a PROMPTED budget only — the wrapper `sed`s it into
+// the agent md and the task message ("Hard budget: N steps"); the `opencode` argv
+// carries NO step-limit flag, so nothing stops a model from exceeding it. So this
+// is NOT "a run cannot read more pages than it has steps". What it actually gives
+// is: at most one injected wake per tool call, and no more than the model's own
+// prompted budget in total unless the operator raises it. The REAL ceiling on a
+// runaway run is `--timeout` (default 120s, enforced by a process-group kill).
+// Consequently the cap is close to non-binding by construction — it only engages
+// after the model has already blown its unenforced budget. That is the accepted
+// price of killing the starvation: worst case for a churny `--steps 12` run went
+// from 8 wakes (~24 bridge calls, ~12s of settles) to 12 (~36 calls, ~18s), and it
+// scales linearly with an operator-chosen `--steps`.
 export const AUTO_WAKE_TAB_CAP = 8;         // fallback when STEPS is unknown
 export const AUTO_WAKE_CAP_FLOOR = 4;       // a 1-2 step run still gets a few
 
@@ -459,6 +493,13 @@ export function wakeCountForTab(tab) {
 // The budget is still charged (so an urlless page cannot wake without limit) but
 // NOTHING is stored: an empty key would collide with every other urlless read and
 // vouch for a document it never saw.
+//
+// ⚠ So "one failed wake per page, not one per read" holds for every IDENTIFIABLE
+// page and NOT for an urlless one: with no verdict stored, a failed wake there is
+// re-attempted on each subsequent read until the tab's budget runs out. That is a
+// cost, cap-bounded, and it is the correct side to err on — the alternative is a
+// shared empty-key verdict that a different urlless document would inherit.
+// Reads carry a url on every path the extension implements, so this is degenerate.
 export function markPageWakeAttempt(tab, key) {
   const s = _tabState(tab);
   s.wakes += 1;
@@ -719,11 +760,22 @@ export async function runBrowserOp(args, opts = {}) {
   // forced tab (a bad op/tab is refused even in dry-run).
   const MUTATING = op === "nav" || op === "eval" ||
                    op === "click" || op === "type" || op === "key" ||
-                   op === "upload";      // upload populates a file input → never in a dry-run
+                   op === "upload" ||    // upload populates a file input → never in a dry-run
+                   op === "wake";        // wake ATTACHES THE DEBUGGER → see below
   // (`activate` used to be listed here. It is now unreachable for the agent at
   //  all — absent from OP_TO_SERVER — so buildRequest refuses it long before this
-  //  point. `wake` is deliberately NOT mutating: it changes no page state and
-  //  moves no focus, so a dry-run may still exercise it like a read.)
+  //  point.)
+  //
+  // `wake` USED to be excluded here, on the reasoning that it changes no page
+  // state and moves no focus, so a dry-run could exercise it like a read. That is
+  // true of the PAGE and false of the OPERATOR: a wake attaches chrome.debugger to
+  // their live tab for up to a 6s settle, which raises Brave's "an extension is
+  // debugging this browser" banner. A dry-run promises "logs, doesn't drive", and
+  // the auto-wake path + reference/agent.md now both justify skipping the wake
+  // with exactly that promise. Leaving the MANUAL `op="wake"` able to attach in a
+  // dry run made the documented guarantee stronger than the code — so the code is
+  // hardened to match, not the doc softened. A dry-run wake now synthesizes like
+  // any other mutating op.
   if (dry && MUTATING) {
     const allowed = allowedOpsFromEnv(env);
     if (!allowed.includes(op)) throw new BrowserToolRefusal(`op_not_allowed:${op}`);
@@ -804,14 +856,22 @@ export async function runBrowserOp(args, opts = {}) {
       autoWake = prior.ok
         ? { state: "already-woke", woke: true, detail: prior.detail }
         : { state: "already-failed", woke: false, detail: prior.detail };
+    } else if (!AUTO_WAKE_OPS.includes(op)) {
+      // `eval`: signal only, never auto-re-run. autoWake stays null → the generic
+      // hidden WARNING, which is the honest description (nothing was attempted).
+    } else if (!autoWakeEnabled(env)) {
+      // Kill switch. Checked BEFORE the dry-run branch so a run with BOTH set is
+      // told which one actually stopped the wake — the more specific cause first.
+      // autoWake stays null → the generic hidden WARNING.
     } else if (dry) {
       // A dry-run's contract is "logs, never actually drives the browser". A read
       // is passive, but a `wake` ATTACHES THE DEBUGGER to the operator's live tab
-      // for ~1.5s and raises Brave's "an extension is debugging this browser"
-      // banner — a categorical step past that. Skip it and say what would have
-      // happened; the signal is preserved either way.
+      // and raises Brave's "an extension is debugging this browser" banner — a
+      // categorical step past that. (The MANUAL `op="wake"` is now intercepted the
+      // same way, via MUTATING.) Skip it and say what would have happened; the
+      // signal is preserved either way.
       autoWake = { state: "dryrun", woke: null, detail: "" };
-    } else if (AUTO_WAKE_OPS.includes(op) && autoWakeEnabled(env)) {
+    } else {
       const cap = autoWakeTabCap(env);
       if (wakeCountForTab(tab) >= cap) {
         // Churn backstop (URL-rewriting pages defeat the per-page key). Stop

--- a/scripts/browser-bridge/reference/agent.md
+++ b/scripts/browser-bridge/reference/agent.md
@@ -108,12 +108,34 @@ browser agent "go to news.ycombinator.com and report the top 3 story titles" \
     re-read, and return the re-read — inside one model tool call, no step spent, no
     decision asked of the model. `wake`, never `activate`.
   - **once per PAGE**, keyed by the read's `url` per forced tab. The un-throttle dies
-    with the CDP detach but the DOM it produced persists, so later reads are cheap. A
-    `nav` clears the tab's record (new document → throttled again); a click/eval-driven
-    URL change produces a new key, so it wakes again.
+    with the CDP detach but the DOM it produced persists, so later reads are cheap.
+    A successful `nav`/`click`/`key`/`eval` clears the tab's records — the URL key
+    cannot see a same-URL document replacement (form POST, `location.reload()`, a
+    same-URL SPA remount), and under-forgetting costs a wrong answer while
+    over-forgetting costs one extra wake. A `wake` the MODEL calls also marks the
+    page, so a manual wake is not immediately paid for twice.
+  - the **VERDICT** is stored, not just the key — `{ok, detail}`. A page whose wake
+    FAILED is never later described as post-wake: `note:` is reserved for a wake the
+    tool can vouch for (`woke === true`); a failed / unconfirmed / skipped / never-
+    attempted page gets `WARNING:` and the recorded reason. Storing only the key made
+    every later read of a failed page a *reassured* wrong answer — worse than the
+    silent one this change exists to remove.
   - **fail-open**: a failed/forbidden wake, or a failed re-read, returns the ORIGINAL
     read prefixed with a loud `[browser-tool] WARNING: … 'wake' FAILED (<reason>)`.
     A read never becomes an error. A failed wake is not retried per-read.
+  - **budget**: `AUTO_WAKE_TAB_CAP` = 8 automatic wakes per tab per run
+    (`BROWSER_AGENT_AUTO_WAKE_MAX` overrides), independent of the page key. On a page
+    that rewrites its URL on every read (hash routing, `?t=` cache-busters,
+    `history.replaceState` on infinite scroll) every read yields a fresh key, so
+    once-per-page would degrade to once-per-read: 3 bridge calls + a ~1.5 s settle
+    each against the 5/s + burst-20 per-instance limiter. Past the cap it stops waking
+    and says so loudly.
+  - the banner **hedges**: `woke` is probed from `visibilityState` inside the CDP
+    attach, so it proves the tab was un-throttled and says nothing about whether the
+    app finished rendering inside the bounded settle. Every post-wake banner tells the
+    model that a loading/placeholder state below is real.
+  - both injected calls are audited (`auto_wake_exec`) and so is the outcome
+    (`auto_wake_ok` / `auto_wake_unconfirmed` / `auto_wake_failed` / `auto_wake_capped`).
   - `hidden` + the server's note now survive `summarizeResult` for `text`/`html`/`eval`
     regardless, so a still-hidden read is visible rather than silent. (`eval` gets the
     signal but is never auto-re-run — an arbitrary expression is not idempotent.)

--- a/scripts/browser-bridge/reference/agent.md
+++ b/scripts/browser-bridge/reference/agent.md
@@ -112,8 +112,16 @@ browser agent "go to news.ycombinator.com and report the top 3 story titles" \
     A successful `nav`/`click`/`key`/`eval` clears the tab's records — the URL key
     cannot see a same-URL document replacement (form POST, `location.reload()`, a
     same-URL SPA remount), and under-forgetting costs a wrong answer while
-    over-forgetting costs one extra wake. A `wake` the MODEL calls also marks the
-    page, so a manual wake is not immediately paid for twice.
+    over-forgetting costs one extra wake.
+  - a `wake` the MODEL calls is deliberately **NOT** recorded as the page's wake. It
+    looks like a free optimisation and is a correctness trap: the extension reports
+    the url from a `chrome.tabs.get` taken AFTER the settle, so a URL change during
+    the ~1.5s window (a redirect completing, `history.replaceState`, an SPA route
+    settling) lands the verdict on document **B** while the settle was spent on **A** —
+    and B's shell then gets the `note: … post-wake` banner. The auto path is immune
+    because it keys on the PRE-wake read's url. Fixing it properly needs the extension
+    to return the pre-attach url too (manifest bump + full Brave re-point), which is
+    not worth saving one wake. Do not reintroduce it without that.
   - the **VERDICT** is stored, not just the key — `{ok, detail}`. A page whose wake
     FAILED is never later described as post-wake: `note:` is reserved for a wake the
     tool can vouch for (`woke === true`); a failed / unconfirmed / skipped / never-
@@ -123,13 +131,22 @@ browser agent "go to news.ycombinator.com and report the top 3 story titles" \
   - **fail-open**: a failed/forbidden wake, or a failed re-read, returns the ORIGINAL
     read prefixed with a loud `[browser-tool] WARNING: … 'wake' FAILED (<reason>)`.
     A read never becomes an error. A failed wake is not retried per-read.
-  - **budget**: `AUTO_WAKE_TAB_CAP` = 8 automatic wakes per tab per run
-    (`BROWSER_AGENT_AUTO_WAKE_MAX` overrides), independent of the page key. On a page
-    that rewrites its URL on every read (hash routing, `?t=` cache-busters,
-    `history.replaceState` on infinite scroll) every read yields a fresh key, so
-    once-per-page would degrade to once-per-read: 3 bridge calls + a ~1.5 s settle
-    each against the 5/s + burst-20 per-instance limiter. Past the cap it stops waking
-    and says so loudly.
+  - **budget**: automatic wakes per tab per run are capped, independent of the page
+    key, because a page that rewrites its URL on every read (hash routing, `?t=`
+    cache-busters, `history.replaceState` on infinite scroll) yields a fresh key each
+    time, degrading once-per-page into once-per-read: 3 bridge calls + a ~1.5 s settle
+    each against the 5/s + burst-20 per-instance limiter. The cap is **the run's step
+    budget** (`BROWSER_AGENT_STEPS`, exported by the `browser-agent` wrapper), floored
+    at `AUTO_WAKE_CAP_FLOOR` (4), falling back to `AUTO_WAKE_TAB_CAP` (8) when unknown;
+    `BROWSER_AGENT_AUTO_WAKE_MAX` overrides everything. A **fixed** 8 starved legitimate
+    runs — 12 distinct pages reached by nav+text is not churn, yet pages 8–11 were never
+    woken, silently reverting the back half of a default `--steps 12` run to
+    `BROWSER_AGENT_AUTO_WAKE=0`. Binding it to STEPS gives the provable bound "at most
+    one injected wake per model step". Past the cap it stops waking and says so loudly.
+  - **dry-run**: `BROWSER_AGENT_DRY_RUN=1` skips the auto-wake and says so. A read is
+    passive, but a wake attaches the debugger to the operator's live tab for ~1.5 s and
+    raises Brave's "an extension is debugging this browser" banner — past what
+    "logs, doesn't drive" promises.
   - the banner **hedges**: `woke` is probed from `visibilityState` inside the CDP
     attach, so it proves the tab was un-throttled and says nothing about whether the
     app finished rendering inside the bounded settle. Every post-wake banner tells the

--- a/scripts/browser-bridge/reference/agent.md
+++ b/scripts/browser-bridge/reference/agent.md
@@ -143,10 +143,14 @@ browser agent "go to news.ycombinator.com and report the top 3 story titles" \
     woken, silently reverting the back half of a default `--steps 12` run to
     `BROWSER_AGENT_AUTO_WAKE=0`. Binding it to STEPS gives the provable bound "at most
     one injected wake per model step". Past the cap it stops waking and says so loudly.
-  - **dry-run**: `BROWSER_AGENT_DRY_RUN=1` skips the auto-wake and says so. A read is
-    passive, but a wake attaches the debugger to the operator's live tab for ~1.5 s and
-    raises Brave's "an extension is debugging this browser" banner — past what
-    "logs, doesn't drive" promises.
+  - **dry-run**: `BROWSER_AGENT_DRY_RUN=1` skips the auto-wake and says so, **and
+    `wake` is now one of the MUTATING ops** — so a *manual* `op="wake"` in a dry run is
+    synthesized (`{"ok":true,"dryRun":true,"op":"wake"}`) rather than reaching the
+    bridge, while still being policy-checked (a forbidden op or a disowned tab is
+    still refused). A read is passive, but a wake attaches the debugger to the
+    operator's live tab for up to a 6 s settle and raises Brave's "an extension is
+    debugging this browser" banner — past what "logs, doesn't drive" promises. Both
+    paths now match that promise; previously the doc was stronger than the code.
   - the banner **hedges**: `woke` is probed from `visibilityState` inside the CDP
     attach, so it proves the tab was un-throttled and says nothing about whether the
     app finished rendering inside the bounded settle. Every post-wake banner tells the
@@ -164,8 +168,10 @@ browser agent "go to news.ycombinator.com and report the top 3 story titles" \
   bridge), a **non-http(s) nav scheme hard-denial** (a `nav` to `file:`/`data:`/
   `about:`/`javascript:`/`chrome:`/… is refused as `nav_scheme_denied:<scheme>`
   before any fetch — those have no host and would otherwise bypass
-  `--allow-domains`), and `--dry-run` (intercepts `nav`/`eval` — logs, doesn't
-  execute). The full opencode JSON transcript + a metadata-only tool audit are kept
+  `--allow-domains`), and `--dry-run` (intercepts every mutating op —
+  `nav`/`eval`/`click`/`type`/`key`/`upload`/`wake` — logs, doesn't execute; reads
+  still hit the browser, and the auto-wake is skipped with a WARNING). The full
+  opencode JSON transcript + a metadata-only tool audit are kept
   in a scratch dir. **Domain deny is best-effort** (see note below).
 - **⚠ Privacy:** the pages the agent reads are sent to **OpenRouter/DeepSeek**.
   Do NOT point it at high-secret authenticated pages casually.

--- a/scripts/browser-bridge/reference/agent.md
+++ b/scripts/browser-bridge/reference/agent.md
@@ -95,6 +95,29 @@ browser agent "go to news.ycombinator.com and report the top 3 story titles" \
   still: it is not reachable by the model at ALL**, not even via that opt-in,
   because it takes the operator's screen. The agent gets `wake` instead — the
   un-throttling it actually needed, with no focus theft.
+- **Hidden-tab AUTO-WAKE (deterministic, not modelled).** The agent's tab is always
+  opened `active:false`, so it is always hidden and always throttled. The bridge
+  already flags that (`data.hidden:true` + the throttle note on every read), but the
+  tool's `summarizeResult` used to return a bare `data.text`/`data.html` and DISCARD
+  both — so on a throttled SPA that rendered a plausible-looking shell the model read
+  the shell and returned a **confident wrong answer with `status:"ok"`**, quoting the
+  shell verbatim as evidence. Measured at **1 of 13 successful runs (7.7%)**, and it
+  was the only failure mode found (`claudedocs/browser-bridge-deepseek-measurement-
+  2026-07-31.md` §3.2). Now, in `opencode/tools/browser_tool_impl.mjs`:
+  - the **first** hidden `text`/`html` read of a page makes the TOOL issue `wake`,
+    re-read, and return the re-read — inside one model tool call, no step spent, no
+    decision asked of the model. `wake`, never `activate`.
+  - **once per PAGE**, keyed by the read's `url` per forced tab. The un-throttle dies
+    with the CDP detach but the DOM it produced persists, so later reads are cheap. A
+    `nav` clears the tab's record (new document → throttled again); a click/eval-driven
+    URL change produces a new key, so it wakes again.
+  - **fail-open**: a failed/forbidden wake, or a failed re-read, returns the ORIGINAL
+    read prefixed with a loud `[browser-tool] WARNING: … 'wake' FAILED (<reason>)`.
+    A read never becomes an error. A failed wake is not retried per-read.
+  - `hidden` + the server's note now survive `summarizeResult` for `text`/`html`/`eval`
+    regardless, so a still-hidden read is visible rather than silent. (`eval` gets the
+    signal but is never auto-re-run — an arbitrary expression is not idempotent.)
+  - kill switch: `BROWSER_AGENT_AUTO_WAKE=0` disables the auto-wake; the warning stays.
 - **Guardrails:** a step budget (`--steps`, default 12), a wall-clock `--timeout`
   (default 120s) enforced with a **process-group kill** (`setsid` + kill the whole
   group, so no opencode child survives), `--deny-domains`/`--allow-domains`

--- a/scripts/browser-bridge/tests/auto_wake.test.mjs
+++ b/scripts/browser-bridge/tests/auto_wake.test.mjs
@@ -1,0 +1,380 @@
+// auto_wake.test.mjs — the DETERMINISTIC hidden-tab auto-wake in
+// `opencode/tools/browser_tool_impl.mjs`.
+//
+// WHY this exists (measured, claudedocs/browser-bridge-deepseek-measurement-
+// 2026-07-31.md §3.2): the browser-agent's tab is ALWAYS opened `active:false`, so
+// it is ALWAYS hidden and throttled. The server self-announces that on every read
+// (`data.hidden:true` + the throttle note), but `summarizeResult` used to return a
+// BARE `data.text`/`data.html` and discard both. On a throttled SPA that rendered a
+// sparse-but-plausible shell, the model read the shell, could not tell the tab was
+// hidden, and returned a CONFIDENT WRONG answer with `status:"ok"` whose evidence
+// quoted the shell verbatim — 1 of 13 successful runs (7.7%), and the only failure
+// mode found.
+//
+// These tests pin the fix's four properties:
+//   1. hidden → the tool ITSELF issues `wake` and returns the RE-READ.
+//   2. wake ONCE PER PAGE (a second read of the same page does NOT re-wake), and a
+//      `nav` (new document → throttled again) RESETS that.
+//   3. a wake failure FAILS OPEN — the original read comes back, loudly labelled,
+//      never as an error.
+//   4. a non-hidden read is byte-identical to before (no wake, no banner).
+//
+// ⚠ Green here is a PREREQUISITE, not verification: whether auto-wake actually
+// fixes the measured F2 case can only be settled against a live browser.
+
+import test, { beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  runBrowserOp, summarizeResult, resetAutoWakeState, hiddenNotice,
+  AUTO_WAKE_OPS, HIDDEN_SIGNAL_OPS, AUTO_WAKE_PAGE_CAP,
+  pageKeyOf, hasWokenPage, markPageWoken, forgetPageWakes, autoWakeEnabled,
+} from "../opencode/tools/browser_tool_impl.mjs";
+import { HIDDEN_TAB_NOTE } from "../extension/protocol.js";
+
+const TOK = "secret-token";
+const TAB = "4242";
+const PAGE = "https://app.test/dashboard";
+
+function baseEnv(extra = {}) {
+  return { BROWSER_AGENT_TAB: TAB, BROWSER_BRIDGE_HOST: "127.0.0.1",
+    BROWSER_BRIDGE_PORT: "8788", BROWSER_AGENT_SESSION_ID: "claude:sess", ...extra };
+}
+
+const run = (args, env, fetchImpl) =>
+  runBrowserOp(args, { env, fetchImpl, readToken: () => TOK });
+
+// A bridge stub that models the ONE behaviour that matters: the tab is hidden, and
+// a `wake` makes the page render. Before any wake a read returns the SHELL; after a
+// wake it returns the RENDERED content. `hidden` stays true throughout, because it
+// does — the tab is still a background tab; only the DOM changed.
+function bridge(opts = {}) {
+  const st = {
+    shell: opts.shell ?? "SHELL (waiting for frames)",
+    rendered: opts.rendered ?? "RENDERED ANSWER",
+    hidden: opts.hidden ?? true,
+    woke: opts.woke ?? true,
+    url: opts.url ?? PAGE,
+    wakeStatus: opts.wakeStatus ?? 200,     // non-200 → transport-level wake failure
+    wakeEnvelopeError: opts.wakeEnvelopeError ?? null, // op-level wake failure
+    reReadError: opts.reReadError ?? null,  // op-level failure on the RE-read only
+    awake: false,
+    reads: 0,
+  };
+  const calls = [];
+  const impl = async (url, init) => {
+    const body = JSON.parse(init.body);
+    calls.push(body);
+    if (body.op === "wake") {
+      if (st.wakeStatus !== 200) {
+        return { status: st.wakeStatus, async text() { return "bridge exploded"; } };
+      }
+      if (st.wakeEnvelopeError) {
+        return { status: 200, async text() {
+          return JSON.stringify({ ok: true,
+            result: { id: "c", ok: false, error: st.wakeEnvelopeError } });
+        } };
+      }
+      if (st.woke) st.awake = true;
+      return { status: 200, async text() {
+        return JSON.stringify({ ok: true, result: { id: "c", ok: true, data: {
+          tabId: 4242, woke: st.woke, visibilityState: st.woke ? "visible" : "hidden",
+          readyState: "complete", settleMs: 1500, url: st.url, title: "T" } } });
+      } };
+    }
+    if (body.op === "nav") {
+      st.awake = false;                       // a new document is throttled again
+      st.url = body.url;
+      return { status: 200, async text() {
+        return JSON.stringify({ ok: true,
+          result: { id: "c", ok: true, data: { url: body.url, title: "T" } } });
+      } };
+    }
+    // text / getHtml
+    st.reads += 1;
+    if (st.reReadError && st.reads > 1) {
+      return { status: 200, async text() {
+        return JSON.stringify({ ok: true,
+          result: { id: "c", ok: false, error: st.reReadError } });
+      } };
+    }
+    const content = st.awake ? st.rendered : st.shell;
+    const data = { url: st.url, title: "T" };
+    if (body.op === "getHtml") data.html = `<div id=app>${content}</div>`;
+    else data.text = content;
+    if (st.hidden) { data.hidden = true; data.visibilityState = "hidden";
+                     data.note = HIDDEN_TAB_NOTE; }
+    else { data.visibilityState = "visible"; }
+    return { status: 200, async text() {
+      return JSON.stringify({ ok: true, result: { id: "c", ok: true, data } });
+    } };
+  };
+  impl.calls = calls;
+  impl.state = st;
+  return impl;
+}
+
+const ops = (f) => f.calls.map((c) => c.op);
+
+// A note WITHOUT the server's own `activate` caveat, so the "never says activate"
+// assertion tests THIS module's wording rather than the extension's (HIDDEN_TAB_NOTE
+// deliberately mentions `activate` in order to say DON'T).
+const HIDDEN_FALLBACK_NOTE_PROBE = "tab is hidden — background tabs are throttled.";
+
+beforeEach(() => resetAutoWakeState());
+
+// --------------------------------------------------------------------------- //
+// 1. hidden → auto-wake → the RE-READ is what the model sees
+// --------------------------------------------------------------------------- //
+test("hidden text read: the tool auto-issues `wake` and returns the RE-READ, not the shell", async () => {
+  const f = bridge();
+  const out = await run({ op: "text" }, baseEnv(), f);
+
+  assert.deepEqual(ops(f), ["text", "wake", "text"],
+    "read → wake → re-read, all inside ONE model tool call");
+  assert.match(out, /RENDERED ANSWER/, "the model must receive the POST-wake content");
+  assert.doesNotMatch(out, /SHELL \(waiting for frames\)/,
+    "REGRESSION: the unrendered shell must NOT be what the model reads");
+  assert.match(out, /auto-wake|AUTOMATICALLY/i, "the auto-wake must be disclosed");
+});
+
+test("hidden html read auto-wakes the same way", async () => {
+  const f = bridge();
+  const out = await run({ op: "html" }, baseEnv(), f);
+  assert.deepEqual(ops(f), ["getHtml", "wake", "getHtml"]);
+  assert.match(out, /RENDERED ANSWER/);
+});
+
+test("the wake it issues is `wake` — NEVER `activate` (which steals the operator's screen)", async () => {
+  const f = bridge();
+  await run({ op: "text" }, baseEnv(), f);
+  assert.ok(!ops(f).includes("activate"),
+    "activate is unreachable by the agent by design and must stay that way");
+  const wake = f.calls.find((c) => c.op === "wake");
+  assert.equal(wake.tab, 4242, "the wake is scoped to the agent's OWN forced tab");
+});
+
+test("the auto-wake `wake` carries no model-supplied field (typed, tab forced by env)", async () => {
+  const f = bridge();
+  await run({ op: "text", selector: "#app", waitMs: 999999 }, baseEnv(), f);
+  const wake = f.calls.find((c) => c.op === "wake");
+  assert.deepEqual(Object.keys(wake).sort(), ["op", "tab"],
+    "no waitMs/selector smuggled into the auto-wake");
+  // …and the RE-read reuses the caller's ORIGINAL typed args.
+  const reads = f.calls.filter((c) => c.op === "text");
+  assert.equal(reads.length, 2);
+  assert.equal(reads[1].selector, "#app", "the re-read repeats the original read exactly");
+});
+
+// --------------------------------------------------------------------------- //
+// 2. wake ONCE PER PAGE
+// --------------------------------------------------------------------------- //
+test("wake-once-per-page: a SECOND hidden read of the same page does NOT re-wake", async () => {
+  const f = bridge();
+  await run({ op: "text" }, baseEnv(), f);
+  f.calls.length = 0;
+
+  const out2 = await run({ op: "text" }, baseEnv(), f);
+  assert.deepEqual(ops(f), ["text"], "one read, ZERO wakes — the rendered DOM persists");
+  assert.match(out2, /RENDERED ANSWER/);
+  assert.match(out2, /already ran for this page/,
+    "the hidden signal must still survive on the cheap follow-up read");
+});
+
+test("wake-once-per-page holds across read SHAPES (text then html) on one page", async () => {
+  const f = bridge();
+  await run({ op: "text" }, baseEnv(), f);
+  f.calls.length = 0;
+  await run({ op: "html" }, baseEnv(), f);
+  assert.deepEqual(ops(f), ["getHtml"], "the page, not the op, is what was woken");
+});
+
+test("a `nav` RESETS the per-page wake — the new document is throttled again", async () => {
+  const f = bridge();
+  await run({ op: "text" }, baseEnv(), f);              // wakes page 1
+  await run({ op: "nav", url: "https://app.test/other" }, baseEnv(), f);
+  f.calls.length = 0;
+
+  await run({ op: "text" }, baseEnv(), f);
+  assert.deepEqual(ops(f), ["text", "wake", "text"],
+    "REGRESSION: after a nav the tool MUST wake again — the new page is a new document");
+});
+
+test("an in-page navigation (the read's url changed) also re-wakes, without a `nav`", async () => {
+  const f = bridge();
+  await run({ op: "text" }, baseEnv(), f);
+  f.state.url = "https://app.test/detail";   // e.g. a click-driven SPA route change
+  f.state.awake = false;
+  f.calls.length = 0;
+
+  await run({ op: "text" }, baseEnv(), f);
+  assert.deepEqual(ops(f), ["text", "wake", "text"]);
+});
+
+test("BROWSER_AGENT_AUTO_WAKE=0 disables the auto-wake but KEEPS the warning", async () => {
+  const f = bridge();
+  const out = await run({ op: "text" }, baseEnv({ BROWSER_AGENT_AUTO_WAKE: "0" }), f);
+  assert.deepEqual(ops(f), ["text"], "the kill switch must issue no wake at all");
+  assert.match(out, /SHELL \(waiting for frames\)/);
+  assert.match(out, /WARNING: your tab is HIDDEN/,
+    "turning auto-wake off must NOT return us to a silent wrong answer");
+});
+
+// --------------------------------------------------------------------------- //
+// 3. fail-open
+// --------------------------------------------------------------------------- //
+test("wake FAILURE (op-level) falls back to the original read + a loud warning", async () => {
+  const f = bridge({ wakeEnvelopeError: "cdp_timeout:wake" });
+  const out = await run({ op: "text" }, baseEnv(), f);
+  assert.deepEqual(ops(f), ["text", "wake"], "no re-read after a failed wake");
+  assert.match(out, /SHELL \(waiting for frames\)/, "FAIL-OPEN: the original read survives");
+  assert.match(out, /automatic 'wake' FAILED/);
+  assert.match(out, /cdp_timeout:wake/, "the reason must be nameable by the model");
+});
+
+test("wake FAILURE (transport/HTTP) also fails open — never turns a read into an error", async () => {
+  const f = bridge({ wakeStatus: 503 });
+  const out = await run({ op: "text" }, baseEnv(), f);
+  assert.match(out, /SHELL \(waiting for frames\)/);
+  assert.match(out, /automatic 'wake' FAILED/);
+});
+
+test("a wake the operator's op-allowlist forbids fails open (no bypass, no crash)", async () => {
+  const f = bridge();
+  const out = await run({ op: "text" },
+    baseEnv({ BROWSER_AGENT_ALLOWED_OPS: "text,html" }), f);
+  assert.deepEqual(ops(f), ["text"], "a forbidden wake must never reach the bridge");
+  assert.match(out, /automatic 'wake' FAILED/);
+  assert.match(out, /op_not_allowed:wake/);
+});
+
+test("a failed wake is NOT retried on every subsequent read of the same page", async () => {
+  const f = bridge({ wakeEnvelopeError: "cdp_timeout:wake" });
+  await run({ op: "text" }, baseEnv(), f);
+  f.calls.length = 0;
+  await run({ op: "text" }, baseEnv(), f);
+  assert.deepEqual(ops(f), ["text"], "one failed wake per page, not one per read");
+});
+
+test("a RE-READ failure falls back to the original read too", async () => {
+  const f = bridge({ reReadError: "owned_tab_gone" });
+  const out = await run({ op: "text" }, baseEnv(), f);
+  assert.deepEqual(ops(f), ["text", "wake", "text"]);
+  assert.match(out, /SHELL \(waiting for frames\)/);
+  assert.match(out, /re-read failed: owned_tab_gone/);
+});
+
+test("wake reporting woke:false is surfaced honestly, and the re-read is not trusted blindly", async () => {
+  const f = bridge({ woke: false });
+  const out = await run({ op: "text" }, baseEnv(), f);
+  assert.deepEqual(ops(f), ["text", "wake", "text"], "the re-read still happens");
+  assert.match(out, /could NOT confirm the tab un-throttled/);
+  assert.match(out, /woke:false/);
+});
+
+// --------------------------------------------------------------------------- //
+// 4. a non-hidden read is UNCHANGED
+// --------------------------------------------------------------------------- //
+test("a VISIBLE tab: no wake is issued and the summary is the bare content (unchanged)", async () => {
+  const f = bridge({ hidden: false, rendered: "RENDERED ANSWER" });
+  f.state.awake = true;
+  const out = await run({ op: "text" }, baseEnv(), f);
+  assert.deepEqual(ops(f), ["text"], "a visible tab must never be woken");
+  assert.equal(out, "RENDERED ANSWER", "byte-identical to the pre-fix summary");
+});
+
+test("summarizeResult keeps its exact old output for every non-hidden payload", () => {
+  assert.equal(summarizeResult("text", { data: { text: "hi" } }), "hi");
+  assert.equal(summarizeResult("html", { data: { html: "<b>x</b>" } }), "<b>x</b>");
+  assert.equal(summarizeResult("eval", { data: { value: "42" } }), "42");
+});
+
+// --------------------------------------------------------------------------- //
+// signal preservation (the "stop discarding it regardless" half)
+// --------------------------------------------------------------------------- //
+test("summarizeResult no longer DISCARDS data.hidden + the server note on text/html", () => {
+  for (const [op, data] of [
+    ["text", { text: "SHELL", hidden: true, note: HIDDEN_TAB_NOTE }],
+    ["html", { html: "<i>SHELL</i>", hidden: true, note: HIDDEN_TAB_NOTE }],
+  ]) {
+    const s = summarizeResult(op, { data });
+    assert.match(s, /HIDDEN/, `${op}: REGRESSION — the hidden flag was dropped again`);
+    assert.match(s, /background tabs are throttled/, `${op}: the server note was dropped`);
+    assert.match(s, /SHELL/, `${op}: the content must still be returned`);
+  }
+});
+
+test("`eval` gets the hidden SIGNAL even for a STRING value (the F2 hole)", () => {
+  // F2's eval returned a STRING, so the old code's `typeof v === 'string'` fast path
+  // stripped the note — the accident that leaked it only fired on a non-string value.
+  const s = summarizeResult("eval",
+    { data: { value: "WAKE-RIG-SHELL", hidden: true, note: HIDDEN_TAB_NOTE } });
+  assert.match(s, /WARNING: your tab is HIDDEN/);
+  assert.match(s, /WAKE-RIG-SHELL/);
+});
+
+test("`eval` is NOT auto-re-run (not idempotent) but IS told the page was already woken", async () => {
+  const f = bridge();
+  await run({ op: "text" }, baseEnv(), f);   // wakes the page
+  f.calls.length = 0;
+  const out = await run({ op: "eval", js: "document.title" }, baseEnv(), f);
+  assert.deepEqual(ops(f), ["eval"], "an eval must never be silently re-executed");
+  assert.match(out, /already ran for this page/);
+  assert.ok(!AUTO_WAKE_OPS.includes("eval"));
+  assert.ok(HIDDEN_SIGNAL_OPS.includes("eval"));
+});
+
+test("the banner is a PREFIX — the page content is never truncated or reordered", async () => {
+  const f = bridge();
+  const out = await run({ op: "text" }, baseEnv(), f);
+  const [banner, blank, ...rest] = out.split("\n");
+  assert.match(banner, /^\[browser-tool\]/);
+  assert.equal(blank, "");
+  assert.equal(rest.join("\n"), "RENDERED ANSWER");
+});
+
+// --------------------------------------------------------------------------- //
+// the per-page bookkeeping, directly
+// --------------------------------------------------------------------------- //
+test("pageKeyOf uses the read's url; a urlless payload degrades to a stable ''", () => {
+  assert.equal(pageKeyOf({ url: PAGE }), PAGE);
+  assert.equal(pageKeyOf({}), "");
+  assert.equal(pageKeyOf(null), "");
+  assert.equal(pageKeyOf({ url: 7 }), "");
+});
+
+test("mark/has/forget: forgetPageWakes drops the whole tab (what a nav does)", () => {
+  assert.equal(hasWokenPage(1, PAGE), false);
+  markPageWoken(1, PAGE);
+  assert.equal(hasWokenPage(1, PAGE), true);
+  assert.equal(hasWokenPage(1, "https://other"), false, "keyed per PAGE, not per tab");
+  assert.equal(hasWokenPage(2, PAGE), false, "keyed per TAB too");
+  forgetPageWakes(1);
+  assert.equal(hasWokenPage(1, PAGE), false);
+});
+
+test("the per-tab page-key set is BOUNDED (a long run cannot grow it without limit)", () => {
+  for (let i = 0; i < AUTO_WAKE_PAGE_CAP * 3; i++) markPageWoken(9, `https://p/${i}`);
+  assert.equal(hasWokenPage(9, `https://p/${AUTO_WAKE_PAGE_CAP * 3 - 1}`), true,
+    "the most recent page is always remembered");
+});
+
+test("autoWakeEnabled defaults ON; only an explicit '0' turns it off", () => {
+  assert.equal(autoWakeEnabled({}), true);
+  assert.equal(autoWakeEnabled({ BROWSER_AGENT_AUTO_WAKE: "1" }), true);
+  assert.equal(autoWakeEnabled({ BROWSER_AGENT_AUTO_WAKE: "" }), true);
+  assert.equal(autoWakeEnabled({ BROWSER_AGENT_AUTO_WAKE: "0" }), false);
+  assert.equal(autoWakeEnabled({ BROWSER_AGENT_AUTO_WAKE: " 0 " }), false);
+});
+
+test("hiddenNotice never recommends `activate` (the wording is load-bearing)", () => {
+  const data = { hidden: true, note: HIDDEN_FALLBACK_NOTE_PROBE };
+  for (const aw of [null, { state: "woke", woke: true, detail: "woke:true settleMs:1500" },
+                    { state: "woke", woke: false, detail: "woke:false settleMs:1500" },
+                    { state: "already", woke: null, detail: "" },
+                    { state: "failed", woke: null, detail: "wake failed: boom" }]) {
+    const s = hiddenNotice(data, aw);
+    assert.ok(s.length > 0);
+    assert.doesNotMatch(s, /\bactivate\b/,
+      "the tool's OWN banner must never teach the model to steal the screen");
+  }
+});

--- a/scripts/browser-bridge/tests/auto_wake.test.mjs
+++ b/scripts/browser-bridge/tests/auto_wake.test.mjs
@@ -497,10 +497,17 @@ test("the budget is per TAB, not per page", () => {
   assert.equal(wakeCountForTab(12), 0, "budgets do not leak between tabs");
 });
 
-// A FIXED cap of 8 starved legitimate runs: 12 distinct pages reached by nav+text
-// is not churn, but pages 8-11 were never woken — silently reverting the back half
-// of a default `--steps 12` run to BROWSER_AGENT_AUTO_WAKE=0 behaviour.
-test("REGRESSION: 12 distinct pages in a --steps 12 run are ALL woken (no starvation)", async () => {
+// A FIXED cap of 8 starved legitimate runs: reaching 12 distinct pages is not
+// churn, but pages 8-11 were never woken — silently reverting the back half of a
+// long run to BROWSER_AGENT_AUTO_WAKE=0 behaviour.
+//
+// ⚠ Framing note: this drives 12 nav+text PAIRS = 24 tool calls, so this exact
+// shape does not fit inside a prompted `--steps 12` budget (and `STEPS` is only
+// prompted — nothing enforces it; see the AUTO_WAKE_TAB_CAP comment). What the
+// test discriminates is the cap ARITHMETIC at cap=12: with the cap bound to STEPS
+// all 12 pages wake; with a fixed 8 the last four are starved. The "exactly 12
+// wakes" assertion is the load-bearing one.
+test("REGRESSION: 12 distinct pages at cap=12 are ALL woken (no starvation)", async () => {
   const f = bridge();
   const env = baseEnv({ BROWSER_AGENT_STEPS: "12" });
   for (let i = 0; i < 12; i++) {
@@ -628,6 +635,40 @@ test("BROWSER_AGENT_DRY_RUN=1: no wake is issued, and the WARNING says why", asy
   assert.match(out, /DRY RUN/);
   assert.match(out, /SHELL \(waiting for frames\)/, "the read itself still returns");
   assert.equal(wakeCountForTab(4242), 0, "and no budget is charged");
+});
+
+// The auto-path skip and reference/agent.md both justify themselves with "a dry
+// run never drives the browser". A MANUAL op="wake" that still attached the
+// debugger would make the documented guarantee stronger than the code.
+test("REGRESSION: a MANUAL op='wake' in a dry run never reaches the bridge either", async () => {
+  const f = bridge();
+  const out = await run({ op: "wake" }, baseEnv({ BROWSER_AGENT_DRY_RUN: "1" }), f);
+  assert.deepEqual(ops(f), [],
+    "a dry-run wake must be synthesized, not attached to the operator's live tab");
+  assert.deepEqual(JSON.parse(out), { ok: true, dryRun: true, op: "wake" });
+});
+
+test("a dry-run wake is still policy-checked (bad tab / forbidden op refused, not synthesized)", async () => {
+  const f = bridge();
+  const dryEnv = { BROWSER_AGENT_DRY_RUN: "1" };
+  await assert.rejects(
+    () => run({ op: "wake" }, baseEnv({ ...dryEnv, BROWSER_AGENT_ALLOWED_OPS: "text" }), f),
+    /op_not_allowed:wake/);
+  await assert.rejects(
+    () => runBrowserOp({ op: "wake" },
+      { env: { ...dryEnv, BROWSER_BRIDGE_HOST: "127.0.0.1" }, fetchImpl: f, readToken: () => TOK }),
+    /disowned_tab/);
+  assert.deepEqual(ops(f), [], "and still nothing on the wire");
+});
+
+test("with BOTH the kill switch and dry-run set, the banner blames the kill switch", async () => {
+  const f = bridge();
+  const out = await run({ op: "text" },
+    baseEnv({ BROWSER_AGENT_AUTO_WAKE: "0", BROWSER_AGENT_DRY_RUN: "1" }), f);
+  assert.deepEqual(ops(f), ["text"]);
+  assert.match(out, /^\[browser-tool\] WARNING:/);
+  assert.doesNotMatch(out, /DRY RUN/,
+    "the more specific cause (auto-wake is off entirely) is the honest one to name");
 });
 
 // --------------------------------------------------------------------------- //

--- a/scripts/browser-bridge/tests/auto_wake.test.mjs
+++ b/scripts/browser-bridge/tests/auto_wake.test.mjs
@@ -26,10 +26,14 @@ import test, { beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import {
   runBrowserOp, summarizeResult, resetAutoWakeState, hiddenNotice,
-  AUTO_WAKE_OPS, HIDDEN_SIGNAL_OPS, AUTO_WAKE_PAGE_CAP,
-  pageKeyOf, hasWokenPage, markPageWoken, forgetPageWakes, autoWakeEnabled,
+  AUTO_WAKE_OPS, HIDDEN_SIGNAL_OPS, AUTO_WAKE_PAGE_CAP, AUTO_WAKE_TAB_CAP,
+  PAGE_INVALIDATING_OPS, pageKeyOf, hasWokenPage, getPageWake,
+  markPageWakeAttempt, recordPageWakeOutcome, wakeCountForTab, autoWakeTabCap,
+  forgetPageWakes, autoWakeEnabled,
 } from "../opencode/tools/browser_tool_impl.mjs";
 import { HIDDEN_TAB_NOTE } from "../extension/protocol.js";
+import { readFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
 
 const TOK = "secret-token";
 const TAB = "4242";
@@ -57,6 +61,9 @@ function bridge(opts = {}) {
     wakeStatus: opts.wakeStatus ?? 200,     // non-200 → transport-level wake failure
     wakeEnvelopeError: opts.wakeEnvelopeError ?? null, // op-level wake failure
     reReadError: opts.reReadError ?? null,  // op-level failure on the RE-read only
+    // click/key/eval replace the document AT THE SAME URL (form POST, reload,
+    // same-URL SPA remount) → freshly throttled, invisible to the page key.
+    replacesDocument: opts.replacesDocument ?? false,
     awake: false,
     reads: 0,
   };
@@ -87,6 +94,28 @@ function bridge(opts = {}) {
       return { status: 200, async text() {
         return JSON.stringify({ ok: true,
           result: { id: "c", ok: true, data: { url: body.url, title: "T" } } });
+      } };
+    }
+    if (body.op === "click" || body.op === "key" || body.op === "type") {
+      // Models the case the page key CANNOT see: the document is replaced (a form
+      // POST / reload / same-URL SPA remount) and is throttled again, at the SAME url.
+      if (st.replacesDocument) st.awake = false;
+      return { status: 200, async text() {
+        return JSON.stringify({ ok: true, result: { id: "c", ok: true,
+          data: { url: st.url, clicked: body.selector ?? null, key: body.key ?? null,
+                  typed: body.text ? body.text.length : null } } });
+      } };
+    }
+    if (body.op === "eval") {
+      // The value comes from the CURRENT document; any replacement it triggers
+      // lands after — which is exactly why the banner is decided before the
+      // invalidation in runBrowserOp.
+      const data = { url: st.url, value: st.awake ? st.rendered : st.shell };
+      if (st.replacesDocument) st.awake = false;
+      if (st.hidden) { data.hidden = true; data.visibilityState = "hidden";
+                       data.note = HIDDEN_TAB_NOTE; }
+      return { status: 200, async text() {
+        return JSON.stringify({ ok: true, result: { id: "c", ok: true, data } });
       } };
     }
     // text / getHtml
@@ -176,7 +205,7 @@ test("wake-once-per-page: a SECOND hidden read of the same page does NOT re-wake
   const out2 = await run({ op: "text" }, baseEnv(), f);
   assert.deepEqual(ops(f), ["text"], "one read, ZERO wakes — the rendered DOM persists");
   assert.match(out2, /RENDERED ANSWER/);
-  assert.match(out2, /already ran for this page/,
+  assert.match(out2, /already SUCCEEDED for this page/,
     "the hidden signal must still survive on the cheap follow-up read");
 });
 
@@ -255,6 +284,47 @@ test("a failed wake is NOT retried on every subsequent read of the same page", a
   assert.deepEqual(ops(f), ["text"], "one failed wake per page, not one per read");
 });
 
+// 🔴 THE REGRESSION THIS SECTION EXISTS FOR: not retrying a failed wake must not
+// mean FORGETTING that it failed. The first cut stored only the page key, so every
+// later read of that page was graded `note: … the content below is post-wake` —
+// a throttled shell plus an authoritative assurance that it was rendered. That is
+// a REASSURED wrong answer, strictly worse than the silent one this PR removes.
+test("REGRESSION: after a FAILED wake, later reads keep the WARNING — never 'post-wake'", async () => {
+  const f = bridge({ wakeEnvelopeError: "cdp_timeout:wake" });
+  await run({ op: "text" }, baseEnv(), f);           // wake fails, page recorded
+  f.calls.length = 0;
+
+  for (const args of [{ op: "text" }, { op: "html" }, { op: "eval", js: "x" }]) {
+    const out = await run(args, baseEnv(), f);
+    assert.match(out, /^\[browser-tool\] WARNING:/,
+      `${args.op}: a page whose wake FAILED must stay a WARNING, not a note:`);
+    assert.match(out, /'wake' for this page FAILED earlier/);
+    assert.match(out, /cdp_timeout:wake/, "the recorded REASON must survive, not just the key");
+    assert.match(out, /may be an unrendered shell/);
+    assert.doesNotMatch(out, /the content below is post-wake/,
+      `${args.op}: REGRESSION — a failed wake was described as a successful one`);
+    assert.doesNotMatch(out, /^\[browser-tool\] note:/);
+  }
+  assert.deepEqual(ops(f), ["text", "getHtml", "eval"], "and still no retry");
+});
+
+test("REGRESSION: an allowlist-refused wake also stays a WARNING on later reads", async () => {
+  const f = bridge();
+  const env = baseEnv({ BROWSER_AGENT_ALLOWED_OPS: "text,html" });
+  await run({ op: "text" }, env, f);
+  const out = await run({ op: "text" }, env, f);
+  assert.match(out, /WARNING/);
+  assert.match(out, /op_not_allowed:wake/, "the reason must still be nameable much later");
+});
+
+test("a wake that reported woke:false is recorded as UNVOUCHED, not as a success", async () => {
+  const f = bridge({ woke: false });
+  await run({ op: "text" }, baseEnv(), f);
+  const out = await run({ op: "text" }, baseEnv(), f);
+  assert.match(out, /WARNING/, "woke:false is not something the tool may vouch for later");
+  assert.doesNotMatch(out, /already SUCCEEDED/);
+});
+
 test("a RE-READ failure falls back to the original read too", async () => {
   const f = bridge({ reReadError: "owned_tab_gone" });
   const out = await run({ op: "text" }, baseEnv(), f);
@@ -318,7 +388,7 @@ test("`eval` is NOT auto-re-run (not idempotent) but IS told the page was alread
   f.calls.length = 0;
   const out = await run({ op: "eval", js: "document.title" }, baseEnv(), f);
   assert.deepEqual(ops(f), ["eval"], "an eval must never be silently re-executed");
-  assert.match(out, /already ran for this page/);
+  assert.match(out, /already SUCCEEDED for this page/);
   assert.ok(!AUTO_WAKE_OPS.includes("eval"));
   assert.ok(HIDDEN_SIGNAL_OPS.includes("eval"));
 });
@@ -333,6 +403,175 @@ test("the banner is a PREFIX — the page content is never truncated or reordere
 });
 
 // --------------------------------------------------------------------------- //
+// the woke:true banner must not OVER-claim
+// --------------------------------------------------------------------------- //
+// `woke` is probed by reading visibilityState INSIDE the CDP attach — it proves
+// the tab was un-throttled and says NOTHING about whether the SPA finished
+// rendering inside the bounded settle. A heavy app needing >1.5s yields woke:true
+// AND an unrendered shell.
+test("the woke:true banner HEDGES on the settle and never says 'no further wake is needed'", async () => {
+  const f = bridge();
+  const out = await run({ op: "text" }, baseEnv(), f);
+  assert.match(out, /bounded settle/);
+  assert.match(out, /loading\/placeholder state, it IS one/);
+  assert.doesNotMatch(out, /No further wake is needed/i,
+    "the tool cannot promise the render completed — only that the tab was un-throttled");
+});
+
+test("the already-woke banner hedges the same way (same claim, same limits)", async () => {
+  const f = bridge();
+  await run({ op: "text" }, baseEnv(), f);
+  const out = await run({ op: "text" }, baseEnv(), f);
+  assert.match(out, /bounded settle/);
+});
+
+// --------------------------------------------------------------------------- //
+// same-URL document replacement (invisible to the page key)
+// --------------------------------------------------------------------------- //
+test("a click that REPLACES the document at the SAME url re-wakes (key cannot see it)", async () => {
+  const f = bridge({ replacesDocument: true });
+  await run({ op: "text" }, baseEnv(), f);                      // wakes the page
+  await run({ op: "click", selector: "#submit" }, baseEnv(), f); // form POST, same url
+  f.calls.length = 0;
+
+  await run({ op: "text" }, baseEnv(), f);
+  assert.deepEqual(ops(f), ["text", "wake", "text"],
+    "REGRESSION: a same-url document replacement must void the page verdict");
+  assert.equal(f.state.url, PAGE, "…and the url genuinely did NOT change");
+});
+
+test("`key` and `eval` invalidate the page too (reload / same-url SPA remount)", async () => {
+  for (const drive of [{ op: "key", key: "Enter" }, { op: "eval", js: "location.reload()" }]) {
+    resetAutoWakeState();
+    const f = bridge({ replacesDocument: true });
+    await run({ op: "text" }, baseEnv(), f);
+    await run(drive, baseEnv(), f);
+    f.calls.length = 0;
+    await run({ op: "text" }, baseEnv(), f);
+    assert.deepEqual(ops(f), ["text", "wake", "text"], `${drive.op} must invalidate`);
+  }
+});
+
+test("an eval's OWN banner is decided BEFORE its invalidation (its value predates it)", async () => {
+  const f = bridge({ replacesDocument: true });
+  await run({ op: "text" }, baseEnv(), f);
+  const out = await run({ op: "eval", js: "location.reload()" }, baseEnv(), f);
+  assert.match(out, /already SUCCEEDED for this page/,
+    "the value came from the OLD, woken document — describe it against that verdict");
+});
+
+test("PAGE_INVALIDATING_OPS is exactly the document-replacing set", () => {
+  assert.deepEqual([...PAGE_INVALIDATING_OPS].sort(), ["click", "eval", "key", "nav"]);
+});
+
+// --------------------------------------------------------------------------- //
+// the per-tab wake budget (URL-churn backstop)
+// --------------------------------------------------------------------------- //
+// On a page that rewrites its url on every read (hash routing, `?t=` cache
+// busters, history.replaceState on infinite scroll) every read yields a FRESH key,
+// so wake-once-per-page degrades to wake-per-read: 3 bridge calls + a ~1.5s settle
+// each against a 5/s + burst-20 per-instance limiter.
+test("URL churn: the wake budget caps the injected traffic and says so LOUDLY", async () => {
+  const f = bridge();
+  const env = baseEnv({ BROWSER_AGENT_AUTO_WAKE_MAX: "3" });
+  let out;
+  for (let i = 0; i < 6; i++) {
+    f.state.url = `${PAGE}?t=${i}`;   // a fresh page key on every single read
+    f.state.awake = false;
+    out = await run({ op: "text" }, env, f);
+  }
+  assert.equal(f.calls.filter((c) => c.op === "wake").length, 3,
+    "exactly the budget — never one wake per read");
+  assert.match(out, /^\[browser-tool\] WARNING:/, "past the cap it must NOT go quiet");
+  assert.match(out, /wake budget/);
+  assert.match(out, /3\/3 wakes used/);
+  assert.match(out, /may be an unrendered shell/);
+});
+
+test("the default budget is 8 and it is per TAB, not per page", () => {
+  assert.equal(AUTO_WAKE_TAB_CAP, 8);
+  assert.equal(wakeCountForTab(11), 0);
+  markPageWakeAttempt(11, "https://a");
+  markPageWakeAttempt(11, "https://b");
+  assert.equal(wakeCountForTab(11), 2);
+  assert.equal(wakeCountForTab(12), 0, "budgets do not leak between tabs");
+});
+
+// --------------------------------------------------------------------------- //
+// a MANUAL wake counts as the page's wake
+// --------------------------------------------------------------------------- //
+test("a wake the MODEL called marks the page — the next read does not wake again", async () => {
+  const f = bridge();
+  await run({ op: "wake" }, baseEnv(), f);
+  f.calls.length = 0;
+  const out = await run({ op: "text" }, baseEnv(), f);
+  assert.deepEqual(ops(f), ["text"], "REGRESSION: a manual wake must not be paid for twice");
+  assert.match(out, /already SUCCEEDED for this page/);
+  // the recorded verdict names its provenance, so the audit/debug story is clear
+  assert.match(getPageWake(4242, PAGE).detail, /called directly/);
+});
+
+test("a manual wake does NOT charge the auto-wake budget (that bounds injected traffic)", async () => {
+  const f = bridge();
+  await run({ op: "wake" }, baseEnv(), f);
+  assert.equal(wakeCountForTab(4242), 0);
+});
+
+test("a manual wake that reported woke:false does NOT vouch for the page", async () => {
+  const f = bridge({ woke: false });
+  await run({ op: "wake" }, baseEnv(), f);
+  f.calls.length = 0;
+  const out = await run({ op: "text" }, baseEnv(), f);
+  assert.deepEqual(ops(f), ["text"], "still not retried");
+  assert.match(out, /WARNING/);
+});
+
+// --------------------------------------------------------------------------- //
+// audit trail + bounded details
+// --------------------------------------------------------------------------- //
+test("the audit log distinguishes a SUCCESSFUL auto-wake from a FAILED one", async () => {
+  const path = `${tmpdir()}/browser-auto-wake-audit-${process.pid}-${Math.random()}.jsonl`;
+  const env = baseEnv({ BROWSER_AGENT_AUDIT: path });
+  try {
+    await run({ op: "text" }, env, bridge());
+    resetAutoWakeState();
+    await run({ op: "text" }, env, bridge({ wakeEnvelopeError: "cdp_timeout:wake" }));
+    const lines = readFileSync(path, "utf8").trim().split("\n").map((l) => JSON.parse(l));
+    const decisions = lines.map((l) => l.decision);
+    // The injected wake AND the injected re-read are both visible as exec lines…
+    assert.equal(decisions.filter((d) => d === "auto_wake_exec").length, 3,
+      "wake+re-read on the success path, wake only on the failure path");
+    // …and the OUTCOME is recorded, which is the whole point (a discarded failure
+    // verdict is what 🔴-1 was about).
+    assert.ok(decisions.includes("auto_wake_ok"));
+    assert.ok(decisions.includes("auto_wake_failed"));
+    const failed = lines.find((l) => l.decision === "auto_wake_failed");
+    assert.match(failed.detail, /cdp_timeout:wake/);
+    // Metadata only — no page content may reach the audit log.
+    for (const l of lines) {
+      assert.doesNotMatch(JSON.stringify(l), /SHELL \(waiting|RENDERED ANSWER/);
+    }
+  } finally {
+    try { unlinkSync(path); } catch { /* best-effort */ }
+  }
+});
+
+test("a hostile/huge server error is BOUNDED before it reaches the banner", async () => {
+  const f = bridge({ wakeEnvelopeError: "E".repeat(50000) });
+  const out = await run({ op: "text" }, baseEnv(), f);
+  const banner = out.split("\n")[0];
+  assert.ok(banner.length < 1500,
+    `the banner must not be inflatable by a server-supplied error (got ${banner.length})`);
+  assert.match(banner, /automatic 'wake' FAILED/);
+});
+
+test("a huge RE-READ error is bounded the same way", async () => {
+  const f = bridge({ reReadError: "R".repeat(50000) });
+  const out = await run({ op: "text" }, baseEnv(), f);
+  assert.ok(out.split("\n")[0].length < 1500);
+});
+
+// --------------------------------------------------------------------------- //
 // the per-page bookkeeping, directly
 // --------------------------------------------------------------------------- //
 test("pageKeyOf uses the read's url; a urlless payload degrades to a stable ''", () => {
@@ -342,9 +581,9 @@ test("pageKeyOf uses the read's url; a urlless payload degrades to a stable ''",
   assert.equal(pageKeyOf({ url: 7 }), "");
 });
 
-test("mark/has/forget: forgetPageWakes drops the whole tab (what a nav does)", () => {
+test("mark/record/forget: forgetPageWakes drops the tab's VERDICTS (what a nav does)", () => {
   assert.equal(hasWokenPage(1, PAGE), false);
-  markPageWoken(1, PAGE);
+  markPageWakeAttempt(1, PAGE);
   assert.equal(hasWokenPage(1, PAGE), true);
   assert.equal(hasWokenPage(1, "https://other"), false, "keyed per PAGE, not per tab");
   assert.equal(hasWokenPage(2, PAGE), false, "keyed per TAB too");
@@ -352,10 +591,37 @@ test("mark/has/forget: forgetPageWakes drops the whole tab (what a nav does)", (
   assert.equal(hasWokenPage(1, PAGE), false);
 });
 
-test("the per-tab page-key set is BOUNDED (a long run cannot grow it without limit)", () => {
-  for (let i = 0; i < AUTO_WAKE_PAGE_CAP * 3; i++) markPageWoken(9, `https://p/${i}`);
+test("the RESERVED verdict is a FAILURE — an interrupted wake must not read as success", () => {
+  markPageWakeAttempt(1, PAGE);
+  assert.deepEqual(getPageWake(1, PAGE), { ok: false, detail: "the wake did not complete" });
+  recordPageWakeOutcome(1, PAGE, true, "woke:true settleMs:1500");
+  assert.equal(getPageWake(1, PAGE).ok, true);
+  recordPageWakeOutcome(1, PAGE, false, "boom");
+  assert.deepEqual(getPageWake(1, PAGE), { ok: false, detail: "boom" });
+});
+
+test("forgetPageWakes does NOT refund the wake budget (churn navigates a lot)", () => {
+  markPageWakeAttempt(3, "https://a");
+  markPageWakeAttempt(3, "https://b");
+  assert.equal(wakeCountForTab(3), 2);
+  forgetPageWakes(3);
+  assert.equal(wakeCountForTab(3), 2, "the cap is a per-RUN backstop, not per-page");
+  assert.equal(hasWokenPage(3, "https://a"), false);
+});
+
+test("the per-tab page-key map is BOUNDED (a long run cannot grow it without limit)", () => {
+  for (let i = 0; i < AUTO_WAKE_PAGE_CAP * 3; i++) markPageWakeAttempt(9, `https://p/${i}`);
   assert.equal(hasWokenPage(9, `https://p/${AUTO_WAKE_PAGE_CAP * 3 - 1}`), true,
     "the most recent page is always remembered");
+});
+
+test("autoWakeTabCap defaults to AUTO_WAKE_TAB_CAP; a numeric env overrides it", () => {
+  assert.equal(autoWakeTabCap({}), AUTO_WAKE_TAB_CAP);
+  assert.equal(autoWakeTabCap({ BROWSER_AGENT_AUTO_WAKE_MAX: "3" }), 3);
+  assert.equal(autoWakeTabCap({ BROWSER_AGENT_AUTO_WAKE_MAX: "0" }), 0);
+  assert.equal(autoWakeTabCap({ BROWSER_AGENT_AUTO_WAKE_MAX: "junk" }), AUTO_WAKE_TAB_CAP,
+    "a junk value must fall back to the default, never to NaN (NaN >= n is false → uncapped)");
+  assert.equal(autoWakeTabCap({ BROWSER_AGENT_AUTO_WAKE_MAX: "-2" }), AUTO_WAKE_TAB_CAP);
 });
 
 test("autoWakeEnabled defaults ON; only an explicit '0' turns it off", () => {
@@ -370,7 +636,9 @@ test("hiddenNotice never recommends `activate` (the wording is load-bearing)", (
   const data = { hidden: true, note: HIDDEN_FALLBACK_NOTE_PROBE };
   for (const aw of [null, { state: "woke", woke: true, detail: "woke:true settleMs:1500" },
                     { state: "woke", woke: false, detail: "woke:false settleMs:1500" },
-                    { state: "already", woke: null, detail: "" },
+                    { state: "already-woke", woke: true, detail: "" },
+                    { state: "already-failed", woke: false, detail: "wake failed: boom" },
+                    { state: "capped", woke: null, detail: "8/8 wakes used" },
                     { state: "failed", woke: null, detail: "wake failed: boom" }]) {
     const s = hiddenNotice(data, aw);
     assert.ok(s.length > 0);

--- a/scripts/browser-bridge/tests/auto_wake.test.mjs
+++ b/scripts/browser-bridge/tests/auto_wake.test.mjs
@@ -27,6 +27,7 @@ import assert from "node:assert/strict";
 import {
   runBrowserOp, summarizeResult, resetAutoWakeState, hiddenNotice,
   AUTO_WAKE_OPS, HIDDEN_SIGNAL_OPS, AUTO_WAKE_PAGE_CAP, AUTO_WAKE_TAB_CAP,
+  AUTO_WAKE_CAP_FLOOR,
   PAGE_INVALIDATING_OPS, pageKeyOf, hasWokenPage, getPageWake,
   markPageWakeAttempt, recordPageWakeOutcome, wakeCountForTab, autoWakeTabCap,
   forgetPageWakes, autoWakeEnabled,
@@ -488,8 +489,7 @@ test("URL churn: the wake budget caps the injected traffic and says so LOUDLY", 
   assert.match(out, /may be an unrendered shell/);
 });
 
-test("the default budget is 8 and it is per TAB, not per page", () => {
-  assert.equal(AUTO_WAKE_TAB_CAP, 8);
+test("the budget is per TAB, not per page", () => {
   assert.equal(wakeCountForTab(11), 0);
   markPageWakeAttempt(11, "https://a");
   markPageWakeAttempt(11, "https://b");
@@ -497,33 +497,76 @@ test("the default budget is 8 and it is per TAB, not per page", () => {
   assert.equal(wakeCountForTab(12), 0, "budgets do not leak between tabs");
 });
 
-// --------------------------------------------------------------------------- //
-// a MANUAL wake counts as the page's wake
-// --------------------------------------------------------------------------- //
-test("a wake the MODEL called marks the page — the next read does not wake again", async () => {
+// A FIXED cap of 8 starved legitimate runs: 12 distinct pages reached by nav+text
+// is not churn, but pages 8-11 were never woken — silently reverting the back half
+// of a default `--steps 12` run to BROWSER_AGENT_AUTO_WAKE=0 behaviour.
+test("REGRESSION: 12 distinct pages in a --steps 12 run are ALL woken (no starvation)", async () => {
   const f = bridge();
-  await run({ op: "wake" }, baseEnv(), f);
-  f.calls.length = 0;
-  const out = await run({ op: "text" }, baseEnv(), f);
-  assert.deepEqual(ops(f), ["text"], "REGRESSION: a manual wake must not be paid for twice");
-  assert.match(out, /already SUCCEEDED for this page/);
-  // the recorded verdict names its provenance, so the audit/debug story is clear
-  assert.match(getPageWake(4242, PAGE).detail, /called directly/);
+  const env = baseEnv({ BROWSER_AGENT_STEPS: "12" });
+  for (let i = 0; i < 12; i++) {
+    await run({ op: "nav", url: `https://app.test/p${i}` }, env, f);
+    const out = await run({ op: "text" }, env, f);
+    assert.doesNotMatch(out, /wake budget/,
+      `page ${i}: a legitimate new document must not be starved by the churn backstop`);
+    assert.match(out, /RENDERED ANSWER/);
+  }
+  assert.equal(f.calls.filter((c) => c.op === "wake").length, 12,
+    "one injected wake per page — the provable bound is one per STEP");
 });
 
-test("a manual wake does NOT charge the auto-wake budget (that bounds injected traffic)", async () => {
-  const f = bridge();
-  await run({ op: "wake" }, baseEnv(), f);
-  assert.equal(wakeCountForTab(4242), 0);
+test("the cap binds to the run's step budget, floored, with the override winning", () => {
+  assert.equal(autoWakeTabCap({ BROWSER_AGENT_STEPS: "12" }), 12);
+  assert.equal(autoWakeTabCap({ BROWSER_AGENT_STEPS: "30" }), 30);
+  assert.equal(autoWakeTabCap({ BROWSER_AGENT_STEPS: "1" }), AUTO_WAKE_CAP_FLOOR,
+    "a 1-step run still gets a usable floor");
+  assert.equal(autoWakeTabCap({}), AUTO_WAKE_TAB_CAP, "unknown STEPS → the fallback");
+  assert.equal(autoWakeTabCap({ BROWSER_AGENT_STEPS: "junk" }), AUTO_WAKE_TAB_CAP);
+  assert.equal(autoWakeTabCap({ BROWSER_AGENT_STEPS: "12", BROWSER_AGENT_AUTO_WAKE_MAX: "2" }),
+    2, "the operator's explicit override beats the step budget");
 });
 
-test("a manual wake that reported woke:false does NOT vouch for the page", async () => {
-  const f = bridge({ woke: false });
+test("the browser-agent wrapper exports BROWSER_AGENT_STEPS (the cap's source)", () => {
+  const wrapper = readFileSync(new URL("../browser-agent", import.meta.url), "utf8");
+  assert.match(wrapper, /BROWSER_AGENT_STEPS="\$STEPS"/,
+    "the cap silently falls back to 8 if the wrapper stops exporting the step budget");
+});
+
+// --------------------------------------------------------------------------- //
+// a MANUAL wake must NOT vouch for a page
+// --------------------------------------------------------------------------- //
+// The extension reports the url from a chrome.tabs.get taken AFTER the settle, so
+// a URL change during the ~1.5s window lands the verdict on document B while the
+// settle was spent on A — and B's shell would then be graded `note: … post-wake`.
+// Byte for byte the reassured wrong answer this whole file exists to prevent. The
+// AUTO path is immune because it keys on the PRE-wake read's url.
+test("REGRESSION: a `wake` the MODEL called records NOTHING (its url is post-settle)", async () => {
+  const f = bridge();
   await run({ op: "wake" }, baseEnv(), f);
+  assert.equal(getPageWake(4242, PAGE), undefined,
+    "a manual wake must never write a verdict — it cannot know which document it settled");
+  assert.equal(wakeCountForTab(4242), 0, "…and it does not charge the injected-traffic budget");
+});
+
+test("REGRESSION: a manual wake whose URL CHANGED mid-settle cannot vouch for the new page", async () => {
+  const f = bridge();
+  // The wake op returns the url as it was AFTER the settle — document B.
+  f.state.url = "https://app.test/after-redirect";
+  await run({ op: "wake" }, baseEnv(), f);
+  f.state.awake = false;             // B was never settled; it is a fresh shell
   f.calls.length = 0;
+
   const out = await run({ op: "text" }, baseEnv(), f);
-  assert.deepEqual(ops(f), ["text"], "still not retried");
-  assert.match(out, /WARNING/);
+  assert.deepEqual(ops(f), ["text", "wake", "text"],
+    "B must be woken on its own merits, not inherit A's verdict");
+  assert.doesNotMatch(out, /already SUCCEEDED/,
+    "REGRESSION: a shell was about to be labelled post-wake off a manual wake's url");
+});
+
+test("the auto path keys on the PRE-wake read's url, so a mid-wake URL change fails safe", async () => {
+  const f = bridge();
+  const out = await run({ op: "text" }, baseEnv(), f);   // keyed on PAGE (pre-wake)
+  assert.ok(hasWokenPage(4242, PAGE), "the verdict belongs to the document that was read");
+  assert.match(out, /RENDERED ANSWER/);
 });
 
 // --------------------------------------------------------------------------- //
@@ -554,6 +597,62 @@ test("the audit log distinguishes a SUCCESSFUL auto-wake from a FAILED one", asy
   } finally {
     try { unlinkSync(path); } catch { /* best-effort */ }
   }
+});
+
+test("an `exec` line is logged only for a wake that REACHED the bridge", async () => {
+  const path = `${tmpdir()}/browser-auto-wake-audit-${process.pid}-${Math.random()}.jsonl`;
+  const env = baseEnv({ BROWSER_AGENT_AUDIT: path, BROWSER_AGENT_ALLOWED_OPS: "text,html" });
+  try {
+    const f = bridge();
+    await run({ op: "text" }, env, f);
+    assert.deepEqual(ops(f), ["text"], "the allowlist refused the wake pre-bridge");
+    const lines = readFileSync(path, "utf8").trim().split("\n").map((l) => JSON.parse(l));
+    assert.equal(lines.filter((l) => l.decision === "auto_wake_exec").length, 0,
+      "REGRESSION: an exec was logged for a wake that never left the process");
+    assert.ok(lines.some((l) => l.decision === "auto_wake_failed"),
+      "the refusal itself is still recorded");
+  } finally {
+    try { unlinkSync(path); } catch { /* best-effort */ }
+  }
+});
+
+// --------------------------------------------------------------------------- //
+// dry-run must not attach the debugger to the operator's live tab
+// --------------------------------------------------------------------------- //
+test("BROWSER_AGENT_DRY_RUN=1: no wake is issued, and the WARNING says why", async () => {
+  const f = bridge();
+  const out = await run({ op: "text" }, baseEnv({ BROWSER_AGENT_DRY_RUN: "1" }), f);
+  assert.deepEqual(ops(f), ["text"],
+    "a dry-run must never attach the debugger to a live tab");
+  assert.match(out, /^\[browser-tool\] WARNING:/);
+  assert.match(out, /DRY RUN/);
+  assert.match(out, /SHELL \(waiting for frames\)/, "the read itself still returns");
+  assert.equal(wakeCountForTab(4242), 0, "and no budget is charged");
+});
+
+// --------------------------------------------------------------------------- //
+// an unidentifiable page must never be vouched for
+// --------------------------------------------------------------------------- //
+test("an EMPTY page key is never stored — two urlless reads must not share a verdict", () => {
+  markPageWakeAttempt(21, "");
+  assert.equal(getPageWake(21, ""), undefined, "nothing may be written under the empty key");
+  assert.equal(wakeCountForTab(21), 1, "…but the budget IS charged, so it cannot loop");
+  recordPageWakeOutcome(21, "", true, "woke:true");
+  assert.equal(getPageWake(21, ""), undefined,
+    "REGRESSION: a vouched empty key would match every other urlless read");
+});
+
+test("a read with no url wakes, is warned about, and never becomes 'already SUCCEEDED'", async () => {
+  const f = bridge();
+  f.state.url = null;                       // the read carries no identifiable url
+  const first = await run({ op: "text" }, baseEnv(), f);
+  assert.match(first, /RENDERED ANSWER/);
+  f.calls.length = 0;
+  f.state.awake = false;
+  const second = await run({ op: "text" }, baseEnv(), f);
+  assert.doesNotMatch(second, /already SUCCEEDED/,
+    "an unidentifiable page may never be vouched for");
+  assert.deepEqual(ops(f), ["text", "wake", "text"], "it re-wakes instead — budget-bounded");
 });
 
 test("a hostile/huge server error is BOUNDED before it reaches the banner", async () => {
@@ -639,6 +738,7 @@ test("hiddenNotice never recommends `activate` (the wording is load-bearing)", (
                     { state: "already-woke", woke: true, detail: "" },
                     { state: "already-failed", woke: false, detail: "wake failed: boom" },
                     { state: "capped", woke: null, detail: "8/8 wakes used" },
+                    { state: "dryrun", woke: null, detail: "" },
                     { state: "failed", woke: null, detail: "wake failed: boom" }]) {
     const s = hiddenNotice(data, aw);
     assert.ok(s.length > 0);


### PR DESCRIPTION
Closes the ONE blocker the DeepSeek measurement identified as a prerequisite for making `browser agent` the default for open-ended browsing.

## The defect

The agent's tab is always opened `active:false`, so it is **always hidden and always throttled**. The bridge already self-announces that on every read (`data.hidden:true` + the throttle note — `extension/protocol.js` `annotateVisibility`), but `summarizeResult()` in `opencode/tools/browser_tool_impl.mjs` returned a bare `data.text` / `data.html` and **discarded both**.

Measured consequence (`claudedocs/browser-bridge-deepseek-measurement-2026-07-31.md` §3.2): on a throttled SPA that rendered a sparse-but-plausible shell, the model read the shell, could not see that the tab was hidden, and returned a **confident wrong answer with `status:"ok"`** whose evidence quoted the shell verbatim. **1 of 13 successful runs (7.7%)** and the only failure mode found. The evidence-grounding check would not have caught it — the quote was faithful; the *page* was in the wrong state.

The throttle note reached the model only **by accident**, via the `eval` branch — and, corrected since the first revision of this PR, **only when the value was nullish**. `JSON.stringify(v ?? data)` falls back to the whole `data` (note included) for `null`/`undefined` alone; a number, object or array stringifies the *value* and strips the note exactly like the string path. The accident was narrower than originally described. It still saved two runs and was absent in the failing one.

## The fix — deterministic, not modelled

- **Auto-wake-and-re-read.** The first hidden `text`/`html` read of a page makes the tool itself issue `wake`, re-read, and return the re-read — inside one model tool call. No step spent, no decision asked of the model.
- **`wake`, never `activate`.** `wake` un-throttles via CDP focus emulation and moves no focus. This is what makes an automatic un-throttle acceptable for an autonomous background agent, and it closes design-doc open question #4 (whose objection was screen theft). `activate` is unreachable by the agent regardless.
- **Wake ONCE PER PAGE**, keyed by the read's `url` per forced tab. The un-throttled state dies with the CDP detach but the DOM it produced persists (live-probed on the wake rig by the operator: `text` → shell, `wake` → `woke:true`, a *separate* `text` → rendered, no focus movement). A successful `nav`/`click`/`key`/`eval` clears the tab's records — the URL key cannot see a same-URL document replacement (form POST, `location.reload()`, a same-URL SPA remount), and under-forgetting costs a wrong answer while over-forgetting costs one extra wake.
- **The wake VERDICT is stored, not just the key** (`{ok, detail}`). A page whose wake failed is never later described as post-wake. `note:` is reserved for a wake the tool can vouch for (`woke === true`); a failed, unconfirmed, skipped or never-attempted page gets `WARNING:` plus the recorded reason.
- **A `wake` the *model* calls is deliberately NOT recorded** as the page's wake. It looks like a free optimisation and is a correctness trap: the extension reports the url from a `chrome.tabs.get` taken *after* the settle, so a URL change during the ~1.5 s window lands the verdict on document B while the settle was spent on A — and B's shell would then be graded `note: … post-wake`. The auto path is immune because it keys on the **pre-wake** read's url. Closing it properly needs the extension to return the pre-attach url too (manifest bump + full Brave re-point), which is not worth saving one wake.
- **Fail-open.** A failed, forbidden or non-200 wake — or a failed re-read — returns the **original** read prefixed with a loud `[browser-tool] WARNING: … 'wake' FAILED (<reason>)`. A working read never becomes an error, and a failed wake is not retried once per read.
- **Wake budget bound to the run's step budget.** `BROWSER_AGENT_AUTO_WAKE_MAX` > `BROWSER_AGENT_STEPS` (floored at `AUTO_WAKE_CAP_FLOOR` = 4) > `AUTO_WAKE_TAB_CAP` = 8. That is the provable bound "at most one injected wake per model step" — a run cannot read more pages than it has steps — while still capping URL churn (hash routing, `?t=` cache-busters, `history.replaceState` on infinite scroll), where a fresh key per read would degrade once-per-page into once-per-read: 3 bridge calls + a ~1.5 s settle each against a 5/s + burst-20 per-instance limiter. A *fixed* cap starved legitimate runs — 12 distinct pages via nav+text left pages 8–11 never woken. Past the cap it stops waking and says so loudly.
- **Dry-run skips the auto-wake** and says so. A read is passive; a wake attaches the debugger to the operator's live tab for ~1.5 s and raises Brave's "an extension is debugging this browser" banner, past what "logs, doesn't drive" promises.
- **The banner hedges.** `woke` is probed from `visibilityState` inside the CDP attach, so it proves the tab was un-throttled and says nothing about whether the app finished rendering inside the bounded settle. Every post-wake banner tells the model that a loading/placeholder state below is real.
- **Signal preserved regardless.** `hidden` + the server's note now survive `summarizeResult()` for `text`/`html`/`eval`. `eval` gets the signal but is never auto-re-run (an arbitrary expression is not idempotent).
- **Kill switch** `BROWSER_AGENT_AUTO_WAKE=0` disables the auto-wake; the warning stays either way.
- **Audited.** `auto_wake_exec` (logged *after* `buildRequest`, so a refused wake never logs an exec it did not perform) plus `auto_wake_ok` / `auto_wake_unconfirmed` / `auto_wake_failed` / `auto_wake_capped`.

The `wake` it issues goes through `buildRequest` like any other op, so the op allowlist still binds, and it carries only `{op, tab}`. Server-supplied error strings are capped at 200 chars before reaching a banner or the log. An unidentifiable page (a read with no `url`) charges the budget but is never stored, so it cannot be vouched for.

## Tests

`scripts/browser-bridge/tests/auto_wake.test.mjs` — **53 tests**. Four guards are **mutation-verified**, not merely green: reintroducing the manual-wake marking (2 red), making the cap ignore `BROWSER_AGENT_STEPS` (2 red), removing the empty-key guard (2 red) and removing the dry-run skip (1 red) each turn the corresponding tests red.

| suite | baseline (`origin/main` @ 8fdbfa0) | with this change |
|---|---|---|
| `node --test scripts/browser-bridge/tests/*.test.mjs` | 274 passing | **327 passing** |
| `pytest scripts/browser-bridge/tests -q` | 259 passing | **259 passing** (no Python touched) |

## ⚠ Not verified live

**Green tests are a prerequisite, not verification.** Nothing here was deployed: no `home-manager switch`, no service restart, no `browser agent`, no Brave interaction. Specifically **unverified**: that auto-wake fixes the measured F2 run; that the real `wake` envelope's `{woke, settleMs}` matches the stub; that `BROWSER_AGENT_STEPS` survives the wrapper's env into the tool process; whether the step-bound cap is right against real multi-page goals; real wall-clock cost against the 22.65 s median; and rate-limiter interaction. DOM persistence — the assumption the two-step design rests on — *was* live-probed by the operator on the wake rig and holds, on one synthetic fixture, one host, not a real heavy SPA.

## Scope

No file touched here is touched by open PR #242 (`feat/browser-bridge-stable-ext-path`). Note this PR now also edits `scripts/browser-bridge/browser-agent` (one line, to export `BROWSER_AGENT_STEPS`) — that is the *agent wrapper*, distinct from `scripts/browser-bridge/browser` (the CLI), which #242 owns. `SKILL.md`, `server.py`, `extension/*` and `nix/home.nix` are untouched, and the default-flip wording is left to its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
