### PR TITLE
fix(browser-bridge): bound every await in the poll loop so a hung chrome.* call can't wedge it (manifest 0.4.0)

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -753,7 +753,7 @@ on both profiles, so the operator's tabs would be gone for good).
 
 ```bash
 browser --instance <label> ping
-# NEW → {"pong":true,"extensionVersion":"0.3.1","id":"<ext-id>","ops":[…,"ping"]}
+# NEW → {"pong":true,"extensionVersion":"0.4.0","id":"<ext-id>","ops":[…,"ping"]}
 # OLD → op 'ping' returned unknown_op — … FULLY RESTART Brave …        (exit 1)
 ```
 
@@ -784,6 +784,71 @@ load path is an open live-verification item.
 `extension/manifest.json`'s `version` AND add a new discriminator (a new op name,
 or a new field in `ping`'s reply). Without one, reload-vs-restart is
 unfalsifiable — that ambiguity cost three full Brave restarts in one session.
+
+### The no-wedge guarantee (0.4.0) — why an instance used to need a manual ↻
+
+Until 0.4.0 an instance would silently stop answering and stay dead until the
+operator clicked ↻ in `brave://extensions`. Root cause (diagnosed 2026-07-31,
+`claudedocs/browser-bridge-silent-drop-diagnosis-2026-07-31.md`): an **unbounded
+`await` inside `execute()`** parks the `while (true)` poll loop forever. `loop()`
+is guarded by a non-reentrant module global — `if (running) return` — whose reset
+lives in a `finally` a parked loop can never reach, so the 1-minute
+`bridge-keepalive` alarm fired on time, called `loop()`, hit the guard and did
+nothing. Only a fresh service-worker evaluation cleared it.
+
+**The counter-intuitive part: the CDP path was never the culprit — it is the one
+path that was already bounded** (`withCdpSession`, 8s attach / 8s command / 15s
+op). The unbounded awaits were the *non*-CDP `chrome.*` calls: `frames` →
+`webNavigation.getAllFrames`, the `screenshot` fast path →
+`tabs.captureVisibleTab`, `targetTab()` → `tabs.get`/`tabs.query`, and
+`pollOnce`'s bare `fetch`. Both recorded drops are immediately preceded by a
+`cmd_timeout` on exactly those ops, while ops that timed out through the bounded
+CDP path did **not** kill the instance.
+
+Two changes close it:
+
+1. **Every op is bounded at ONE choke point** — `execute()` races
+   `OPS[cmd.op](cmd)` against `EXEC_OP_BUDGET_MS` (18s). `frames`/`screenshot`
+   are deliberately **not** patched individually — one rule, one place, or the bug
+   regenerates at the next op added (`targetTab()` alone is on the path of every
+   op). Every *other* await in the loop body is bounded too: the poll fetch
+   (`POLL_BUDGET_MS` 40s), the result POST (`RESULT_BUDGET_MS` 10s), and the
+   `chrome.storage.local` reads in `config()`/`clearSuperseded()`
+   (`STORAGE_BUDGET_MS` 5s) — the last of which runs on *every* healthy iteration,
+   i.e. more often than `frames`/`screenshot` ever did. Fetches additionally carry
+   an `AbortSignal` so the socket is torn down rather than abandoned.
+
+   ⚠ **The budget ordering is not the tidy `CDP 15s < exec 18s < server 20s` it
+   looks like.** `withCdpSession` *composes* its phases: attach ≤8s + run ≤15s +
+   an awaited detach ≤8s = up to 31s. So a hung CDP `run` with a slow detach hits
+   the 18s exec bound first and reports `op_timeout:<op>`, losing the precise
+   `cdp_timeout:` label. That is accepted deliberately — the caller-visible
+   ceiling is the *server's* 20s `cmd_timeout`, so raising the exec budget past
+   31s would only park the loop longer for an envelope that could never arrive,
+   and pre-change that same case produced a bare `cmd_timeout` with no phase at
+   all. The attach-hang and per-CDP-command-hang cases still surface their exact
+   `cdp_timeout:attach` / `cdp_timeout:<method>` (they fire at 8s). Known cost: a
+   slow-but-successful CDP op in the 18–20s band is now killed at 18s.
+2. **The keepalive can now recover** — `keepaliveTick()` (not a bare `loop()`)
+   compares `lastLoopTickAt` against `LOOP_STALL_MS` (180s, >2.5× the worst
+   legitimate iteration). A loop that has not ticked in that long is retired via a
+   generation bump and a fresh one takes the latch. This is the defence against
+   the *next* unbounded await someone adds, not the primary fix.
+
+   Duplicate **polling** is prevented structurally: the retired loop re-checks its
+   generation *immediately before each poll* and its `finally` declines to clear
+   `running` unless it still owns the generation. A top-of-iteration check alone
+   is **not** sufficient — it only fires between iterations, so a loop retired
+   while parked mid-iteration resumes and completes that whole iteration,
+   including its poll (measured: polls went 8 → 9). A retired loop *may* still
+   finish posting a result it had already dequeued; that is deliberate, since
+   dropping it would strand the caller until its `cmd_timeout`, and the server
+   correlates results by command id.
+
+Regression coverage: `tests/loop_wedge.test.mjs` wedges a real op with a
+never-settling promise and asserts the loop releases and keeps polling. It is
+**mutation-tested** — removing the `promiseWithTimeout` from `execute()` turns
+both wedge tests red.
 
 ### `known_instances` / `missing` — a dead named instance can no longer hide
 
@@ -1558,7 +1623,7 @@ systemctl --user status browser-bridge
 4. `scripts/browser-bridge/browser health` → `{"ok":true,"extension_connected":true}`
    with `extension_stale:false` on the instance, and
    `scripts/browser-bridge/browser --instance <label> ping` →
-   `{"pong":true,"extensionVersion":"0.3.1","id":"<ext-id>",…}` (an `unknown_op`
+   `{"pong":true,"extensionVersion":"0.4.0","id":"<ext-id>",…}` (an `unknown_op`
    here means Brave is still running an older build). Record that `id` — it is
    the per-profile baseline for "which directory is loaded".
 5. Focus a tab where you are **logged in** (e.g. Gmail), then

--- a/scripts/browser-bridge/extension/README.md
+++ b/scripts/browser-bridge/extension/README.md
@@ -167,7 +167,7 @@ come back).
    (`work` / `personal` — must be unique per profile), **Save**.
 8. Verify from a shell — this is the whole point of the change:
    ```bash
-   browser --instance <label> ping   # → {"pong":true,"extensionVersion":"0.3.1",
+   browser --instance <label> ping   # → {"pong":true,"extensionVersion":"0.4.0",
                                      #     "id":"<ext-id>","ops":[…,"ping"]}
    browser whoami                    # → that instance: extension_stale:false
                                      #    + extension_id, and

--- a/scripts/browser-bridge/extension/manifest.json
+++ b/scripts/browser-bridge/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Browser Bridge (command channel)",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Lets a local Claude Code skill drive the active Brave tab (getHtml/eval/tabs/nav/screenshot/frames/click/type/key/activate/upload/ping) via a loopback, token-authenticated rendezvous server. Local-only, authorized personal automation.",
   "permissions": ["scripting", "tabs", "activeTab", "storage", "alarms", "debugger", "webNavigation"],
   "host_permissions": ["http://127.0.0.1:8788/*", "<all_urls>"],

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -634,23 +634,90 @@ export const CDP_COMMAND_TIMEOUT_MS = 8000;
 export const CDP_OP_BUDGET_MS = 15000;
 
 // Race `promise` against a `ms` deadline. On timeout, REJECT with
-// `cdp_timeout:<label>` (the phase — attach / a CDP method / op / detach) so the
-// caller sees WHICH call hung; the underlying promise is left pending (abandoned)
-// but the returned promise SETTLES, so the awaiter is never blocked past `ms`. A
+// `<prefix>:<label>` — by default `cdp_timeout:<label>` (the phase — attach / a
+// CDP method / op / detach) so the caller sees WHICH call hung; the underlying
+// promise is left pending (abandoned) but the returned promise SETTLES, so the
+// awaiter is never blocked past `ms`. A
 // promise that settles on its own (resolve OR reject) wins the race and its
 // value/error passes through unchanged, and the timer is cleared so nothing lingers.
 // `ms <= 0` disables the bound (returns the promise as-is). Timers injectable.
-export function promiseWithTimeout(promise, ms, label, timers = {}) {
+//
+// `prefix` exists because this helper is no longer CDP-only: the poll loop uses
+// it to bound the NON-CDP chrome.* ops (`frames` → webNavigation.getAllFrames,
+// `screenshot` fast path → tabs.captureVisibleTab, targetTab → tabs.get/query)
+// and its own fetches, and mislabelling those `cdp_timeout:` would send the next
+// diagnosis straight back at the debugger — the one path that was already bounded.
+export function promiseWithTimeout(promise, ms, label, timers = {},
+                                   prefix = "cdp_timeout") {
   const p = Promise.resolve(promise);
   if (!(ms > 0)) return p;
   const setT = timers.setTimeout || setTimeout;
   const clearT = timers.clearTimeout || clearTimeout;
   let handle;
   const timeout = new Promise((_, reject) => {
-    handle = setT(() => reject(new Error(`cdp_timeout:${label}`)), ms);
+    handle = setT(() => reject(new Error(`${prefix}:${label}`)), ms);
   });
   return Promise.race([p, timeout]).finally(() => clearT(handle));
 }
+
+// --- poll-loop wall-clock budgets (the no-wedge guarantee, generalized) ------ //
+// The CDP path has been bounded since #—: withCdpSession races every
+// chrome.debugger call. Everything ELSE the worker awaits was unbounded, and an
+// unbounded await inside execute() parks the `while (true)` poll loop FOREVER —
+// `running` (the loop's non-reentrant guard) is only cleared by the finally the
+// parked loop can never reach, so the 1-minute keepalive alarm calls loop(), hits
+// `if (running) return`, and does nothing. Only a fresh worker evaluation (the
+// operator clicking ↻ in brave://extensions) recovered it.
+//
+// These budgets bound every await in the loop body (op, poll, result, and the
+// chrome.storage.local reads via STORAGE_BUDGET_MS below).
+//
+// ⚠ The ordering is NOT the tidy `CDP 15s < exec 18s < server 20s` it looks like.
+// `withCdpSession` composes its phases rather than sharing one wall clock:
+// attach ≤ CDP_ATTACH_TIMEOUT_MS (8s) + run ≤ CDP_OP_BUDGET_MS (15s) + an AWAITED
+// safeDetach ≤ CDP_COMMAND_TIMEOUT_MS (8s) = up to 31s, plus a frame resolve.
+// Measured on a 10×-scaled probe: a hung `run` with a slow detach settles at the
+// EXEC bound and reports `op_timeout:<op>`, NOT `cdp_timeout:op`.
+//
+// That mislabel is accepted deliberately, because the alternative is worse:
+//   * The caller-visible ceiling is the SERVER's cmd_timeout (20s), not this one.
+//     Raising EXEC_OP_BUDGET_MS above 31s to "let CDP finish labelling" would put
+//     it past 20s, so the envelope could never reach the caller anyway — the
+//     server would answer `cmd_timeout` first and the loop would stay parked ~11s
+//     longer for nothing.
+//   * Pre-change, that same case produced a bare server-side `cmd_timeout` with NO
+//     phase at all. `op_timeout:frames` at 18s is strictly more information,
+//     sooner, and it is the case where the loop is provably released.
+//   * The attach-hang and per-CDP-command-hang cases still surface their precise
+//     `cdp_timeout:attach` / `cdp_timeout:<method>` — those fire at 8s, well
+//     inside this bound.
+// Known cost: a slow-but-SUCCESSFUL CDP op in the 18–20s band is now killed at 18s
+// where it previously had until the server's 20s. That band was already mostly
+// lost to the server, so the trade is small and deliberate.
+//
+// Lowering the CDP composition below 18s instead would mean shrinking the attach
+// or detach budgets, which are load-bearing for the debugger-leak invariants —
+// not worth reopening without a live measurement.
+export const EXEC_OP_BUDGET_MS = 18000;
+// chrome.storage.local reads/writes on the loop's own path — config() (every
+// iteration) and the superseded flag. Same unbounded-chrome.* class as the ops,
+// and clearSuperseded() runs on EVERY healthy iteration, i.e. far more often than
+// `frames`/`screenshot` ever did. Bounded so "every await in the loop body is
+// bounded" is literally true rather than nearly true.
+export const STORAGE_BUDGET_MS = 5000;
+// A /poll blocks server-side for BROWSER_BRIDGE_POLL_TIMEOUT (default 25s) before
+// its 204. 40s leaves generous headroom for a slow loopback round-trip plus the
+// activeTabSnapshot() that precedes the fetch, while still being a bound.
+export const POLL_BUDGET_MS = 40000;
+// POST /result is a loopback write the server answers immediately.
+export const RESULT_BUDGET_MS = 10000;
+// If the loop has not completed an iteration in this long it is WEDGED, not slow.
+// Worst legitimate iteration: POLL_BUDGET + EXEC_OP_BUDGET + RESULT_BUDGET = 68s,
+// or a SUPERSEDE_BACKOFF_MS (30s) / max nextBackoffMs (30s) sleep after a poll
+// budget = 70s. 180s is >2.5x the worst legitimate case, so this can only fire on
+// a genuine wedge — it is the defence against the NEXT unbounded await, not the
+// primary fix.
+export const LOOP_STALL_MS = 180000;
 
 // Orchestrate a CDP op with a per-op attach→run→ALWAYS-detach lifecycle, every
 // chrome.debugger side effect INJECTED so the invariants are unit-testable without

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -46,10 +46,25 @@ import {
   // `wake` op / `--wake` reads: un-throttle a background tab via CDP WITHOUT
   // touching focus (the non-intrusive replacement for reflexive `activate`).
   clampWakeMs, applyWakeSteps, wakeProbeFn, WAKE_CDP_TEARDOWN,
+  // The no-wedge guarantee, generalized past CDP: every await in the poll loop
+  // body is raced against a wall-clock budget (see protocol.js for why and for
+  // the CDP < exec < server-cmd_timeout ordering).
+  promiseWithTimeout, EXEC_OP_BUDGET_MS, POLL_BUDGET_MS, RESULT_BUDGET_MS,
+  LOOP_STALL_MS, STORAGE_BUDGET_MS,
 } from "./protocol.js";
 
 const DEFAULT_PORT = 8788;
 let running = false;
+// Wall-clock (Date.now) of the last completed poll-loop iteration. `running` is a
+// LATCH — it says a loop was started, not that one is alive — so the keepalive
+// alarm needs an independent liveness signal to tell "wedged" from "idle-polling".
+// null = no iteration has completed yet (the loop was only just kicked).
+let lastLoopTickAt = null;
+// Monotonically increasing loop generation. The keepalive force-restart bumps it,
+// which retires any loop still parked on an abandoned await: that loop exits at
+// its next iteration and its finally declines to clear `running` (it no longer
+// owns the flag), so a force-restart can never leave two pollers racing.
+let loopGeneration = 0;
 
 // The stable per-profile auto-id: generated ONCE and persisted in
 // chrome.storage.local so it survives service-worker restarts/reloads within
@@ -941,14 +956,71 @@ const OPS = {
   },
 };
 
+// The extension-side breadcrumb (the §2.2 detector). ONE rolling slot in
+// chrome.storage.local, so it cannot grow: {op, id, phase, ts}. After a drop this
+// answers "wedged in `frames` since 18:02:34" from OBSERVATION instead of from
+// inference over the server's journal — the operator's second drop left no trace
+// anywhere because nothing was dispatched while the instance was down.
+//
+// FIRE-AND-FORGET on purpose: it is never awaited. A storage write is itself a
+// chrome.* call, and awaiting it inside execute() would add exactly the class of
+// unbounded await this whole change exists to remove.
+// The loop's wall-clock budgets, with a test-injectable override (the same
+// `globalThis.BROWSER_BRIDGE_*_TIMING` convention the `activate` op already uses)
+// so a unit test can drive a 20ms budget instead of waiting 18 real seconds.
+// Production reads the protocol.js constants unchanged.
+function loopTiming() {
+  const t = (typeof globalThis !== "undefined"
+    && globalThis.BROWSER_BRIDGE_LOOP_TIMING) || {};
+  return {
+    execMs: t.execMs == null ? EXEC_OP_BUDGET_MS : t.execMs,
+    pollMs: t.pollMs == null ? POLL_BUDGET_MS : t.pollMs,
+    resultMs: t.resultMs == null ? RESULT_BUDGET_MS : t.resultMs,
+    stallMs: t.stallMs == null ? LOOP_STALL_MS : t.stallMs,
+    storageMs: t.storageMs == null ? STORAGE_BUDGET_MS : t.storageMs,
+  };
+}
+
+// Bound a chrome.storage.local call. These are the loop's remaining non-op
+// chrome.* awaits; a hang in one is the same fault class as a hung `frames`.
+function storageBounded(promise, label) {
+  return promiseWithTimeout(promise, loopTiming().storageMs, label, {},
+                            "op_timeout");
+}
+
+function breadcrumb(op, id, phase) {
+  try {
+    const p = chrome.storage.local.set(
+      { lastExec: { op, id, phase, ts: Date.now() } });
+    if (p && typeof p.catch === "function") p.catch(() => {});
+  } catch (e) { /* storage unavailable — a breadcrumb must never break an op */ }
+}
+
+// execute — THE choke point where every op is bounded.
+//
+// The bound lives here and NOWHERE else on purpose. Patching `frames` and
+// `screenshot` individually (the two ops the journal caught wedging) would fix
+// today's two call sites and regenerate the bug at the next op someone adds —
+// `targetTab()` alone is on the path of every single op. One rule, one place.
+//
+// A timed-out op returns a NORMAL error envelope (`op_timeout:<op>`) through the
+// existing catch, so the poll loop takes the same path it takes for any op that
+// threw in the page: post the result, iterate, keep polling. Nothing throws past
+// the loop.
 async function execute(cmd) {
   const v = validateCommand(cmd);
   if (!v.ok) return errorEnvelope(cmd.id, v.error);
+  breadcrumb(cmd.op, cmd.id, "start");
   try {
-    const data = await OPS[cmd.op](cmd);
+    const data = await promiseWithTimeout(
+      OPS[cmd.op](cmd), loopTiming().execMs, cmd.op, {}, "op_timeout");
+    breadcrumb(cmd.op, cmd.id, "done");
     return resultEnvelope(cmd.id, data);
   } catch (e) {
-    return errorEnvelope(cmd.id, e && e.message ? e.message : e);
+    const msg = e && e.message ? e.message : e;
+    breadcrumb(cmd.op, cmd.id,
+               String(msg).startsWith("op_timeout:") ? "timeout" : "error");
+    return errorEnvelope(cmd.id, msg);
   }
 }
 
@@ -966,6 +1038,20 @@ async function activeTabSnapshot() {
 // pollOnce returns a tagged result: { kind } where kind ∈ POLL_IDLE /
 // POLL_SUPERSEDED, or { kind: POLL_COMMAND, cmd } — so the loop can tell the
 // distinct "you were superseded" signal (409) apart from a normal idle 204.
+// An AbortSignal that fires after `ms`, or undefined where AbortSignal.timeout is
+// unavailable (a bare unit-test global). Aborting the SOCKET is complementary to
+// racing the promise: promiseWithTimeout settles the awaiter but abandons the
+// underlying fetch, which would leak a socket per wedged poll; the signal actually
+// tears the request down.
+function abortAfter(ms) {
+  try {
+    if (typeof AbortSignal !== "undefined" && AbortSignal.timeout) {
+      return AbortSignal.timeout(ms);
+    }
+  } catch (e) { /* fall through — the promise race is still the hard bound */ }
+  return undefined;
+}
+
 async function pollOnce(cfg) {
   const active = await activeTabSnapshot();
   const res = await fetch(`${base(cfg.port)}/poll`, {
@@ -973,6 +1059,7 @@ async function pollOnce(cfg) {
     headers: { ...authHeaders(cfg.token),
                ...pollHeaders(cfg.instanceId, cfg.label, active, cfg.extVersion,
                               cfg.extId) },
+    signal: abortAfter(loopTiming().pollMs),
   });
   const kind = classifyPollStatus(res.status);
   if (kind === POLL_COMMAND) return { kind, cmd: await res.json() };
@@ -987,9 +1074,12 @@ async function pollOnce(cfg) {
 // state change so a steady-state loser doesn't spam storage.
 async function setSuperseded(cfg) {
   try {
-    const { superseded } = await chrome.storage.local.get("superseded");
+    const { superseded } = await storageBounded(
+      chrome.storage.local.get("superseded"), "superseded.get");
     if (!superseded) {
-      await chrome.storage.local.set({ superseded: true, supersededSince: Date.now() });
+      await storageBounded(
+        chrome.storage.local.set({ superseded: true, supersededSince: Date.now() }),
+        "superseded.set");
       // eslint-disable-next-line no-console
       console.warn(
         "[browser-bridge] superseded by another instance sharing this routing key" +
@@ -1001,9 +1091,14 @@ async function setSuperseded(cfg) {
 
 async function clearSuperseded() {
   try {
-    const { superseded } = await chrome.storage.local.get("superseded");
-    if (superseded) await chrome.storage.local.set({ superseded: false, supersededSince: 0 });
-  } catch (e) { /* ignore */ }
+    const { superseded } = await storageBounded(
+      chrome.storage.local.get("superseded"), "superseded.get");
+    if (superseded) {
+      await storageBounded(
+        chrome.storage.local.set({ superseded: false, supersededSince: 0 }),
+        "superseded.set");
+    }
+  } catch (e) { /* ignore — including our own bound expiring */ }
 }
 
 async function postResult(cfg, envelope) {
@@ -1012,20 +1107,80 @@ async function postResult(cfg, envelope) {
     headers: authHeaders(cfg.token),
     // Stamp our instanceId so the server scopes the reply to this instance.
     body: JSON.stringify(resultWithInstance(envelope, cfg.instanceId)),
+    signal: abortAfter(loopTiming().resultMs),
   });
+}
+
+// The alarm-side recovery. `running` alone cannot distinguish "a loop is polling
+// happily" from "a loop is parked on an await that will never settle", so the
+// alarm consults lastLoopTickAt: a loop that has not completed an iteration in
+// LOOP_STALL_MS is wedged, and we retire it (bump the generation, clear the
+// latch) before kicking a fresh one. Exported for unit tests.
+//
+// Safety against duplicate POLLING is structural, not timing-based: the retired
+// loop re-checks its generation immediately before each /poll (see `retired()` in
+// loop() — a top-of-iteration check alone is NOT enough, it only fires between
+// iterations) and its finally only clears `running` if it still owns the
+// generation. So even if the abandoned await settles LATER, that loop exits
+// without polling alongside the new one. It MAY still finish posting a result it
+// had already dequeued, which is deliberate — see the note in loop().
+export function keepaliveTick(now = Date.now()) {
+  if (running && lastLoopTickAt !== null
+      && (now - lastLoopTickAt) > loopTiming().stallMs) {
+    // eslint-disable-next-line no-console
+    console.warn("[browser-bridge] poll loop wedged for "
+      + Math.round((now - lastLoopTickAt) / 1000) + "s — force-restarting");
+    loopGeneration += 1;      // retire the wedged loop
+    running = false;          // release the latch it can never release itself
+    lastLoopTickAt = now;     // don't re-fire on the very next alarm
+    breadcrumb("(loop)", null, "force-restart");
+  }
+  loop();
 }
 
 async function loop() {
   if (running) return;
   running = true;
+  const myGen = loopGeneration;
+  lastLoopTickAt = Date.now();
   let attempt = 0;
+  // Have we been retired by a keepalive force-restart? A generation check at the
+  // TOP of the while body is NOT sufficient: it only fires BETWEEN iterations, so
+  // a loop retired while parked mid-iteration resumes and completes that whole
+  // iteration — including its /poll — alongside its replacement. Measured: parking
+  // the loop inside config()'s storage read, retiring it, then releasing produced
+  // one extra poll from the retired loop.
+  const retired = () => myGen !== loopGeneration;
   try {
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      const cfg = await config();
-      if (!cfg.token) { await sleep(5000); continue; }
+      // A force-restart retired us: exit WITHOUT clearing `running` (the finally
+      // checks the generation) so the replacement loop keeps the latch.
+      if (retired()) return;
+      lastLoopTickAt = Date.now();
       try {
-        const r = await pollOnce(cfg);
+        // config() reads chrome.storage.local — the SAME unbounded chrome.* class
+        // this whole change exists to close, and it sits on EVERY iteration. It is
+        // inside the try so a timed-out read becomes a backoff+retry rather than
+        // an escape that kills the loop until the next alarm.
+        const cfg = await promiseWithTimeout(config(), loopTiming().storageMs,
+                                             "config", {}, "op_timeout");
+        if (!cfg.token) { await sleep(5000); continue; }
+        // ⚠ THE check that actually prevents duplicate pollers. It must sit
+        // immediately before the poll, not merely at the top of the iteration:
+        // being retired mid-`config()` is the COMMON case (after this change the
+        // storage reads are the loop's slowest awaits), and a retired loop that
+        // polls is exactly the concurrency the generation mechanism promises to
+        // prevent.
+        //
+        // Deliberately NOT gating execute()/postResult(): a command already
+        // dequeued from the server has no other owner, so dropping it would
+        // strand the caller until its cmd_timeout. Posting a finished result from
+        // a retired loop is harmless (the server correlates by command id) —
+        // POLLING from one is not.
+        if (retired()) return;
+        const r = await promiseWithTimeout(pollOnce(cfg), loopTiming().pollMs,
+                                           "poll", {}, "op_timeout");
         attempt = 0;                             // healthy round-trip
         if (r.kind === POLL_SUPERSEDED) {
           // Another instance on this host claimed our routing key (a duplicate
@@ -1039,17 +1194,25 @@ async function loop() {
         }
         await clearSuperseded();
         if (r.kind === POLL_COMMAND && r.cmd) {
+          // execute() self-bounds at EXEC_OP_BUDGET_MS and NEVER throws — it
+          // always returns an envelope, so a timed-out op is reported to the
+          // server as a normal error and the loop iterates.
           const envelope = await execute(r.cmd);
-          await postResult(cfg, envelope);
+          await promiseWithTimeout(postResult(cfg, envelope),
+                                   loopTiming().resultMs, "result", {},
+                                   "op_timeout");
         }
       } catch (e) {
-        // Transport error (server down, unauthorized, network) → backoff.
+        // Transport error (server down, unauthorized, network, a poll/result
+        // budget expiring) → backoff. Bounded: nextBackoffMs caps at 30s.
         const wait = nextBackoffMs(attempt++) + Math.floor(Math.random() * 250);
         await sleep(wait);
       }
     }
   } finally {
-    running = false;
+    // Only clear the latch if we still OWN it — a loop retired by a
+    // keepalive force-restart must not clear the flag its replacement set.
+    if (myGen === loopGeneration) running = false;
   }
 }
 
@@ -1067,7 +1230,10 @@ function startBackground() {
   chrome.runtime.onStartup.addListener(() => loop());
   chrome.alarms.create("bridge-keepalive", { periodInMinutes: 1 });
   chrome.alarms.onAlarm.addListener((a) => {
-    if (a.name === "bridge-keepalive") loop();
+    // keepaliveTick, NOT loop(): a bare loop() call hits `if (running) return`
+    // and is structurally incapable of clearing a wedged loop — which is exactly
+    // why the pre-0.4.0 alarm never recovered the instance and only a manual ↻ did.
+    if (a.name === "bridge-keepalive") keepaliveTick();
   });
   // If Chrome detaches our debugger out-of-band (tab crash/close, DevTools opened, or
   // the user hitting the "an extension is debugging this browser" banner's Cancel),
@@ -1091,4 +1257,25 @@ if (!(typeof globalThis !== "undefined" && globalThis.BROWSER_BRIDGE_NO_AUTOSTAR
 // `cdpAttached` is exported for TESTS only — it is the leak-visibility invariant
 // (a failed detach must leave the tab tracked), which cannot be asserted from the
 // outside otherwise. Nothing in the extension imports it.
-export { execute, OPS, ALLOWED_OPS, cdpAttached };
+// `loop` + `loopState` are exported for TESTS only — the wedge regression
+// (tests/loop_wedge.test.mjs) has to drive a real loop iteration against a
+// never-settling op and observe that it releases, which cannot be asserted from
+// the outside. Nothing in the extension imports them.
+export { execute, OPS, ALLOWED_OPS, cdpAttached, loop };
+
+// A read/reset window onto the loop's private liveness state, for tests.
+export const loopState = {
+  get running() { return running; },
+  get lastLoopTickAt() { return lastLoopTickAt; },
+  get generation() { return loopGeneration; },
+  // Reset between tests (each test file gets its own module instance, but a
+  // single file may drive the loop more than once).
+  reset() { running = false; lastLoopTickAt = null; loopGeneration = 0; },
+  // Pretend the loop last ticked `ms` ago — lets a test exercise the stall
+  // branch of keepaliveTick without waiting LOOP_STALL_MS of real time.
+  backdate(ms) { lastLoopTickAt = Date.now() - ms; },
+  // Retire the current loop (the same mechanism keepaliveTick uses): it exits at
+  // the top of its next iteration. A test needs this because loop() is a
+  // deliberate `while (true)` with no other exit.
+  retire() { loopGeneration += 1; },
+};

--- a/scripts/browser-bridge/reference/errors.md
+++ b/scripts/browser-bridge/reference/errors.md
@@ -124,7 +124,7 @@ profiles are normally connected, so a bare call gets `409 ambiguous_instance`:
 
 ```bash
 browser --instance <label> ping
-# NEW build → {"pong":true,"extensionVersion":"0.3.1","id":"<ext-id>","ops":[…,"ping"]}
+# NEW build → {"pong":true,"extensionVersion":"0.4.0","id":"<ext-id>","ops":[…,"ping"]}
 # OLD build → op 'ping' returned unknown_op — … FULLY RESTART Brave …   (exit 1)
 ```
 

--- a/scripts/browser-bridge/tests/loop_wedge.test.mjs
+++ b/scripts/browser-bridge/tests/loop_wedge.test.mjs
@@ -1,0 +1,428 @@
+// loop_wedge.test.mjs — THE regression for the silent long-poll disconnect.
+//
+// The fault (diagnosed 2026-07-31, `claudedocs/browser-bridge-silent-drop-diagnosis-2026-07-31.md`):
+// an UNBOUNDED await inside execute() permanently wedges the poll loop. loop() is
+// guarded by a non-reentrant module global (`if (running) return`) whose reset
+// lives in a `finally` that a loop parked on an await can never reach — so the
+// 1-minute keepalive alarm fires on time, calls loop(), hits the guard and does
+// nothing. Only a fresh service-worker evaluation (the operator clicking ↻ in
+// brave://extensions) recovered the instance.
+//
+// Crucially the CDP path was NOT the culprit — it is the one path that was
+// already bounded (withCdpSession, 8s/8s/15s). The unbounded awaits were the
+// NON-CDP chrome.* calls: `frames` → webNavigation.getAllFrames, `screenshot`
+// fast path → tabs.captureVisibleTab, targetTab() → tabs.get/query, and
+// pollOnce's bare fetch. Both recorded drops are immediately preceded by a
+// cmd_timeout on exactly those ops, while ops that timed out through the BOUNDED
+// CDP path did not kill the instance.
+//
+// So these tests deliberately wedge a NON-CDP op with a promise that never
+// settles — the exact shape of the real fault — and assert the loop RELEASES and
+// KEEPS POLLING.
+//
+// MUTATION-TESTED (this is not a vacuous invariant guard): with the
+// promiseWithTimeout removed from execute() — i.e. `await OPS[cmd.op](cmd)` as it
+// was before this change — "a WEDGED op releases the loop" and "the loop keeps
+// polling after a wedged op" both go RED (the loop never posts a result and never
+// polls a second time; the test's own watchdog fires). Re-verify by reverting
+// that single line before trusting this file.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Suppress the SW's auto-start (poll loop + chrome listeners) so importing the
+// module does not begin networking — the tests drive loop() explicitly.
+globalThis.BROWSER_BRIDGE_NO_AUTOSTART = true;
+// Drive the real budgets at test speed. Production reads the protocol.js
+// constants (18s exec / 40s poll / 10s result / 180s stall) unchanged; only the
+// NUMBERS are injected here, never the mechanism.
+globalThis.BROWSER_BRIDGE_LOOP_TIMING = {
+  execMs: 40, pollMs: 200, resultMs: 200, stallMs: 1000, storageMs: 300,
+};
+
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+const NEVER = () => new Promise(() => {});   // the wedge: never settles, ever
+
+// --- mock chrome + fetch ------------------------------------------------------ //
+const store = { port: 8788, token: "test-token", label: "work",
+                instanceId: "11111111-2222-3333-4444-555555555555" };
+const breadcrumbs = [];
+// When set, every storage READ parks on this promise — the handle used to hold
+// the loop INSIDE config() so a retirement can land mid-iteration (the exact
+// window a top-of-loop generation check cannot see).
+let storageGate = null;
+// Hang the next N storage READS outright (never settling). Separate from
+// storageGate because a test that asserts the BOUND fires must not also have to
+// release the hang — releasing it is what the bound is replacing.
+let hangStorageReads = 0;
+globalThis.chrome = {
+  storage: {
+    local: {
+      async get(keys) {
+        if (hangStorageReads > 0) { hangStorageReads -= 1; await NEVER(); }
+        // storageGate parks ONLY config()'s read (the array-form key list).
+        // Gating every read parks at whichever chrome.storage call comes next —
+        // which may be clearSuperseded()'s, i.e. AFTER the poll, making the
+        // mid-iteration test vacuous (it passed against the mutant that way).
+        if (storageGate && Array.isArray(keys)) await storageGate;
+        const ks = Array.isArray(keys) ? keys : [keys];
+        const out = {};
+        for (const k of ks) if (k in store) out[k] = store[k];
+        return out;
+      },
+      async set(obj) {
+        Object.assign(store, obj);
+        if (obj.lastExec) breadcrumbs.push(obj.lastExec);
+      },
+    },
+  },
+  runtime: { id: "testextid", getManifest: () => ({ version: "0.4.0" }) },
+  tabs: {
+    async query() { return [{ id: 5, url: "https://example.com/", title: "T" }]; },
+    async get(id) { return { id, url: "https://example.com/", title: "T" }; },
+  },
+  webNavigation: { async getAllFrames() { return []; } },
+};
+
+const wire = { polls: 0, posted: [] };
+function res(status, body) {
+  return { status, async json() { return body; } };
+}
+
+// The fetch mock: the FIRST poll hands out one command, every later poll is a
+// normal 204 idle. `stopAfter` retires the loop (the same generation mechanism
+// keepaliveTick uses) so this `while (true)` has an exit in a test.
+function installFetch({ command, stopAfter, onPoll }) {
+  wire.polls = 0;
+  wire.posted.length = 0;
+  globalThis.fetch = async (url, opts) => {
+    const u = String(url);
+    if (u.endsWith("/poll")) {
+      wire.polls += 1;
+      if (onPoll) onPoll(wire.polls);
+      if (wire.polls === 1 && command) return res(200, command);
+      await delay(2);                       // don't hot-spin the idle path
+      if (wire.polls >= stopAfter) loopState.retire();
+      return res(204, null);
+    }
+    if (u.endsWith("/result")) {
+      wire.posted.push(JSON.parse(opts.body));
+      return res(200, { ok: true });
+    }
+    throw new Error(`unexpected fetch: ${u}`);
+  };
+}
+
+const { OPS, loop, loopState, keepaliveTick, execute } =
+  await import("../extension/service_worker.js");
+
+// A hard watchdog: loop() only returns once retired. If the bound is missing the
+// loop parks forever, and WITHOUT this the test would hang rather than fail —
+// a hang is not a legible red.
+// Same reasoning for a DIRECT execute() call: an unbounded execute() awaits a
+// never-settling op forever, which would stall the whole test FILE instead of
+// producing a red test. Turn the hang into an assertion failure.
+async function withWatchdog(promise, ms = 3000) {
+  const sentinel = Symbol("watchdog");
+  const out = await Promise.race([promise, delay(ms).then(() => sentinel)]);
+  assert.notEqual(out, sentinel,
+    `never settled within ${ms}ms — execute() is unbounded again`);
+  return out;
+}
+
+// ⚠ The watchdog timer MUST be cancelled once the loop returns. An uncancelled
+// `setTimeout(() => loopState.retire())` fires during a LATER test and silently
+// retires ITS loop — which cost a green-looking run here: the config-bound test
+// saw zero polls and failed for a reason that had nothing to do with the code.
+async function runLoop(ms = 3000) {
+  let timedOut = false;
+  let handle;
+  const watchdog = new Promise((resolve) => {
+    handle = setTimeout(() => { timedOut = true; loopState.retire(); resolve(); }, ms);
+  });
+  try {
+    await Promise.race([loop(), watchdog.then(() => delay(50))]);
+  } finally {
+    clearTimeout(handle);
+  }
+  return timedOut;
+}
+
+test.beforeEach(() => {
+  loopState.reset();
+  breadcrumbs.length = 0;
+  storageGate = null;
+  hangStorageReads = 0;
+});
+
+// --- the wedge ---------------------------------------------------------------- //
+test("REGRESSION: a WEDGED op (never-settling await) RELEASES the loop instead of parking it forever", async () => {
+  const original = OPS.frames;
+  OPS.frames = NEVER;                       // the exact real-world fault shape
+  try {
+    installFetch({ command: { id: "cmd-1", op: "frames" }, stopAfter: 4 });
+    const timedOut = await runLoop();
+    assert.equal(timedOut, false,
+      "the loop never released — execute() is unbounded again");
+    assert.equal(wire.posted.length, 1, "the wedged op must still post a result");
+    const env = wire.posted[0];
+    assert.equal(env.ok, false);
+    assert.equal(env.id, "cmd-1");
+    assert.equal(env.error, "op_timeout:frames",
+      "a timed-out op must name the op, and must NOT be labelled cdp_timeout — "
+      + "the CDP path is the one that was already bounded");
+  } finally {
+    OPS.frames = original;
+  }
+});
+
+test("REGRESSION: the loop KEEPS POLLING after a wedged op (the instance survives)", async () => {
+  const original = OPS.screenshot;
+  OPS.screenshot = NEVER;                   // the other op the journal caught
+  try {
+    installFetch({ command: { id: "cmd-2", op: "screenshot" }, stopAfter: 4 });
+    const timedOut = await runLoop();
+    assert.equal(timedOut, false);
+    assert.ok(wire.polls >= 3,
+      `the loop must resume polling after a wedged op (saw ${wire.polls} polls)`);
+  } finally {
+    OPS.screenshot = original;
+  }
+});
+
+test("a timed-out op does NOT throw past the loop — the envelope is a normal error", async () => {
+  const original = OPS.frames;
+  OPS.frames = NEVER;
+  try {
+    const env = await withWatchdog(execute({ id: "x", op: "frames" }));
+    assert.equal(env.ok, false);
+    assert.equal(env.error, "op_timeout:frames");
+    assert.equal(env.id, "x");
+  } finally {
+    OPS.frames = original;
+  }
+});
+
+test("a HEALTHY op is untouched by the bound (no false timeout, result passes through)", async () => {
+  const original = OPS.frames;
+  OPS.frames = async () => ({ frames: [{ frameId: 0 }] });
+  try {
+    installFetch({ command: { id: "cmd-3", op: "frames" }, stopAfter: 3 });
+    const timedOut = await runLoop();
+    assert.equal(timedOut, false);
+    assert.equal(wire.posted.length, 1);
+    assert.equal(wire.posted[0].ok, true);
+    assert.deepEqual(wire.posted[0].data, { frames: [{ frameId: 0 }] });
+  } finally {
+    OPS.frames = original;
+  }
+});
+
+// --- the detector breadcrumb --------------------------------------------------- //
+test("execute() leaves a storage breadcrumb naming the op it is IN (start → timeout)", async () => {
+  const original = OPS.frames;
+  OPS.frames = NEVER;
+  try {
+    await withWatchdog(execute({ id: "bc-1", op: "frames" }));
+    await delay(5);                          // breadcrumbs are fire-and-forget
+    const phases = breadcrumbs.map((b) => b.phase);
+    assert.deepEqual(phases, ["start", "timeout"]);
+    assert.equal(breadcrumbs[0].op, "frames");
+    assert.equal(breadcrumbs[0].id, "bc-1");
+    assert.ok(typeof breadcrumbs[0].ts === "number");
+  } finally {
+    OPS.frames = original;
+  }
+});
+
+test("the breadcrumb is ONE rolling slot — it cannot grow storage", async () => {
+  const original = OPS.frames;
+  OPS.frames = async () => ({ frames: [] });
+  try {
+    for (let i = 0; i < 5; i += 1) await execute({ id: `n${i}`, op: "frames" });
+    await delay(5);
+    // Many writes, but always to the same key.
+    assert.equal(store.lastExec.op, "frames");
+    assert.equal(store.lastExec.id, "n4");
+    assert.equal(store.lastExec.phase, "done");
+  } finally {
+    OPS.frames = original;
+  }
+});
+
+test("a breadcrumb write that REJECTS never breaks (or wedges) the op", async () => {
+  const set = chrome.storage.local.set;
+  chrome.storage.local.set = async () => { throw new Error("storage full"); };
+  const original = OPS.frames;
+  OPS.frames = async () => ({ frames: [] });
+  try {
+    const env = await execute({ id: "bc-2", op: "frames" });
+    assert.equal(env.ok, true, "a failing breadcrumb must not fail the op");
+  } finally {
+    chrome.storage.local.set = set;
+    OPS.frames = original;
+  }
+});
+
+// --- the keepalive recovery (defence against the NEXT unbounded await) --------- //
+test("keepaliveTick does NOT disturb a loop that is merely SLOW", async () => {
+  loopState.reset();
+  installFetch({ command: null, stopAfter: 3 });
+  const running = loop();
+  await delay(20);
+  const genBefore = loopState.generation;
+  keepaliveTick();                           // ticked recently → no restart
+  assert.equal(loopState.generation, genBefore,
+    "a healthy loop must never be retired — that would create two pollers");
+  loopState.retire();
+  await running;
+});
+
+test("keepaliveTick FORCE-RESTARTS a loop whose last tick is older than the stall threshold", async () => {
+  loopState.reset();
+  installFetch({ command: null, stopAfter: 2 });
+  // Simulate the wedge the OLD code could not clear: the latch is set, no tick.
+  const parked = loop();
+  await delay(20);
+  loopState.backdate(5000);                  // stallMs is 1000 in this file
+  const genBefore = loopState.generation;
+  keepaliveTick();
+  assert.equal(loopState.generation, genBefore + 1,
+    "a wedged loop must be retired so a fresh one can take the latch");
+  await delay(30);
+  assert.equal(loopState.running, true, "the replacement loop holds the latch");
+  loopState.retire();
+  await parked;
+  await delay(20);
+});
+
+test("REGRESSION: a retired loop does NOT clear `running` out from under its replacement", async () => {
+  // This is the duplicate-poller hazard the generation check exists for: if the
+  // retired loop's finally cleared the shared latch, the NEXT alarm would start a
+  // second loop alongside the replacement and the two would fight over /poll.
+  loopState.reset();
+  installFetch({ command: null, stopAfter: 100 });
+  const first = loop();
+  await delay(10);
+  loopState.retire();                        // retire without starting a replacement
+  await first;
+  assert.equal(loopState.running, true,
+    "the retired loop must leave the latch to whoever owns the current generation");
+  // Now genuinely release it so the file exits clean.
+  loopState.reset();
+});
+
+test("REGRESSION: a loop retired MID-ITERATION must not issue another /poll", async () => {
+  // The concurrency half of the generation invariant, and the half a
+  // top-of-iteration check does NOT cover. Park the loop inside config()'s
+  // storage read, retire it there (keepaliveTick's exact mechanism), then
+  // release: the retired loop resumes INSIDE the iteration, past the top check.
+  //
+  // Measured before the fix: polls went 8 → 9. The retired loop polled.
+  loopState.reset();
+  installFetch({ command: null, stopAfter: 1e9 });
+  let release;
+  const running = loop();
+  await delay(30);                             // let it complete some iterations
+  storageGate = new Promise((r) => { release = r; });
+  await delay(30);                             // it is now parked inside config()
+  const before = wire.polls;
+  loopState.retire();                          // retired WHILE mid-iteration
+  storageGate = null;
+  release();
+  await delay(60);                             // give the retired loop every chance
+  assert.equal(wire.polls, before,
+    `a retired loop issued ${wire.polls - before} extra poll(s) — the generation `
+    + "check must sit immediately before the poll, not only at the top of the loop");
+  await running;
+});
+
+test("REGRESSION: a hung POST /result releases the loop (bound is wired to loopTiming)", async () => {
+  // 🟡-4: this race previously used the raw RESULT_BUDGET_MS constant, so the
+  // test-injected resultMs did not apply and NOTHING exercised a hanging /result.
+  loopState.reset();
+  wire.polls = 0;
+  wire.posted.length = 0;
+  let resultHangs = true;
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.endsWith("/poll")) {
+      wire.polls += 1;
+      if (wire.polls === 1) return res(200, { id: "cmd-r", op: "tabs" });
+      await delay(2);
+      if (wire.polls >= 4) loopState.retire();
+      return res(204, null);
+    }
+    if (u.endsWith("/result")) {
+      if (resultHangs) { resultHangs = false; return NEVER(); }
+      return res(200, { ok: true });
+    }
+    throw new Error(`unexpected fetch: ${u}`);
+  };
+  const original = OPS.tabs;
+  OPS.tabs = async () => ({ tabs: [] });
+  try {
+    const timedOut = await runLoop();
+    assert.equal(timedOut, false,
+      "a hung /result parked the loop — the result bound is not wired to loopTiming()");
+    assert.ok(wire.polls >= 3,
+      `the loop must keep polling after a hung /result (saw ${wire.polls})`);
+  } finally {
+    OPS.tabs = original;
+  }
+});
+
+test("REGRESSION: a never-settling POLL fetch releases the loop and it retries", async () => {
+  // The fourth unbounded await named in the diagnosis (pollOnce's bare fetch),
+  // which also had no coverage.
+  loopState.reset();
+  wire.polls = 0;
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.endsWith("/poll")) {
+      wire.polls += 1;
+      if (wire.polls === 1) return NEVER();    // the wedge
+      await delay(2);
+      if (wire.polls >= 3) loopState.retire();
+      return res(204, null);
+    }
+    throw new Error(`unexpected fetch: ${u}`);
+  };
+  const timedOut = await runLoop(5000);        // 1 poll bound + a backoff sleep
+  assert.equal(timedOut, false, "a hung /poll parked the loop");
+  assert.ok(wire.polls >= 2,
+    `the loop must re-poll after a hung poll fetch (saw ${wire.polls})`);
+});
+
+test("REGRESSION: a hung chrome.storage read in config() releases the loop", async () => {
+  // 🟡-2: config() runs on EVERY iteration and is the same unbounded chrome.*
+  // class the root cause blames. Bounded via STORAGE_BUDGET_MS.
+  loopState.reset();
+  installFetch({ command: null, stopAfter: 1e9 });
+  hangStorageReads = 1;                        // config()'s FIRST read never settles
+  const running = loop();
+  await delay(80);
+  assert.equal(wire.polls, 0, "precondition: parked before ever polling");
+  // storageMs is 300ms here; the bound must expire, back off (~1s), and carry on.
+  const timedOut = await Promise.race([
+    delay(4000).then(() => true),
+    (async () => {
+      while (wire.polls === 0) await delay(20);
+      return false;
+    })(),
+  ]);
+  loopState.retire();                          // ALWAYS release the loop first —
+  await delay(20);                             // an assert here must not hang the file
+  assert.equal(timedOut, false,
+    "a hung storage read parked the loop — config() is unbounded");
+  await running;
+});
+
+test("the keepalive is wired to keepaliveTick, not to a bare loop() call", async () => {
+  // The pre-0.4.0 alarm called loop() directly, which hits `if (running) return`
+  // and is structurally incapable of clearing a wedge. Pin the mechanism.
+  const src = await (await import("node:fs/promises"))
+    .readFile(new URL("../extension/service_worker.js", import.meta.url), "utf8");
+  assert.match(src, /bridge-keepalive"\)\s*keepaliveTick\(\)/,
+    "the alarm handler must call keepaliveTick()");
+});

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -3115,7 +3115,12 @@ def test_git_short_head_none_on_missing_dir(tmp_path):
 
 def test_manifest_version_reads_current():
     v = S.manifest_version(path=EXT_DIR / "manifest.json")
-    assert isinstance(v, str) and v == "0.3.1"
+    # Bumped to 0.4.0 for the poll-loop no-wedge change (every op bounded +
+    # a keepalive that can actually recover a wedged loop). The bump is the
+    # operator's only falsifiable "is the new build loaded?" signal, so this
+    # assertion is deliberately a literal — it MUST be updated in the same
+    # commit as manifest.json, which is the point.
+    assert isinstance(v, str) and v == "0.4.0"
 
 
 def test_manifest_version_prefers_the_deployed_copy_over_the_repo(tmp_path,
@@ -3136,7 +3141,7 @@ def test_manifest_version_falls_back_to_repo_when_not_deployed(tmp_path,
     reporting the repo manifest instead of going null."""
     monkeypatch.setattr(S, "_DEPLOYED_EXT_MANIFEST", tmp_path / "absent.json")
     monkeypatch.setattr(S, "_EXT_MANIFEST_PATH", EXT_DIR / "manifest.json")
-    assert S.manifest_version() == "0.3.1"
+    assert S.manifest_version() == "0.4.0"
 
 
 def test_manifest_version_none_when_neither_exists(tmp_path, monkeypatch):


### PR DESCRIPTION
**Extension half of the silent-drop work.** Split out of the original #247 on the audit's recommendation; **stacked on #248** (server/CLI half), which carries the diagnostic payoff and needs no browser restart. Retarget this to `main` once #248 merges.

> ⚠ **Needs a FULL Brave restart on both profiles** — the long-poll keeps the old service worker alive, so ↻ is unreliable — and `restore_on_startup` is unset, so the operator loses tabs. Sequence it with them. Every audit 🟡 landed in these files precisely so this restart is only paid once.

## The fault

An **unbounded `await` inside `execute()` permanently wedges the MV3 poll loop, and the keepalive alarm is structurally incapable of clearing it.** `loop()` is guarded by `if (running) return`, and `running` is only reset by a `finally` a parked loop can never reach. The 1-minute alarm fired on time, called `loop()`, hit the guard and did nothing. Only a fresh worker evaluation (clicking ↻) recovered the instance.

**The CDP path was never the culprit — it is the one path that was already bounded** (`withCdpSession`, 8s/8s/15s). The unbounded awaits were the *non*-CDP `chrome.*` calls: `frames` → `getAllFrames`, the `screenshot` fast path → `captureVisibleTab`, `targetTab()` → `tabs.get`/`query`, and `pollOnce`'s bare `fetch`.

Full diagnosis: `claudedocs/browser-bridge-silent-drop-diagnosis-2026-07-31.md`.

## 1. Every await in the loop body is bounded

`execute()` races `OPS[cmd.op](cmd)` against `EXEC_OP_BUDGET_MS` (18s) and returns a normal `op_timeout:<op>` envelope, so the loop iterates exactly as it does for an op that threw in the page. `frames`/`screenshot` are deliberately **not** patched individually — `targetTab()` alone is on the path of every op, so per-op patches regenerate the bug at the next op added.

**Fixed after audit 🟡-2:** the first pass left `config()`, `setSuperseded()` and `clearSuperseded()` unbounded — `chrome.storage.local`, the *same* fault class the root cause blames, and `clearSuperseded()` runs on **every healthy iteration**, i.e. more often than `frames`/`screenshot` ever did. All three are now bounded at `STORAGE_BUDGET_MS` (5s), and `config()` moved inside the inner `try` so a timeout becomes a backoff-and-retry rather than an escape that kills the loop until the next alarm. The claim is now literally true rather than nearly true.

## 2. A keepalive that can recover

`keepaliveTick()` (not a bare `loop()`) compares `lastLoopTickAt` against `LOOP_STALL_MS` (180s) and retires a stalled loop via a generation bump so a fresh one takes the latch.

**Fixed after audit 🟡-1 — the previous "duplicate pollers are prevented structurally" claim was FALSE.** The generation check sat at the *top* of the `while` body, so it only fired *between* iterations: a loop retired while parked mid-iteration resumed and completed that whole iteration, poll included. The check now sits **immediately before each poll**. Reproduced the auditor's probe as a test — park the loop inside `config()`'s storage read, retire it there, release — and it showed **polls 8 → 9** before the fix.

This is the common case, not a corner: after fix 1 the storage reads are the loop's slowest awaits, so a retirement will usually land exactly there.

A retired loop **may** still finish posting a result it had already dequeued. Deliberate, and now documented rather than implied: dropping it would strand the caller until `cmd_timeout`, and the server correlates results by command id. Gating the *poll* is what prevents concurrency; gating the *post* would only lose work.

## 3. Budget ordering — the doc over-claimed (audit 🟡-3)

The tidy `CDP 15s < exec 18s < server 20s` was wrong. `withCdpSession` **composes** its phases: attach ≤8s + run ≤15s + an **awaited** `safeDetach` ≤8s = up to **31s**. So a hung CDP `run` with a slow detach hits the 18s exec bound first and reports `op_timeout:<op>`, losing the precise `cdp_timeout:` label — the exact inversion the `prefix` argument exists to prevent.

**Decision: keep 18s, fix the documentation.** Reasoning:

* The caller-visible ceiling is the **server's** 20s `cmd_timeout`, not this one. Raising `EXEC_OP_BUDGET_MS` above 31s puts it past 20s, so the precisely-labelled envelope could never reach the caller anyway — the server would answer `cmd_timeout` first and the loop would stay parked ~11s longer for nothing.
* Pre-change, that same case produced a bare server-side `cmd_timeout` with **no phase at all**. `op_timeout:frames` at 18s is strictly more information, sooner, in the case where the loop is provably released.
* The attach-hang and per-CDP-command-hang cases still surface their exact `cdp_timeout:attach` / `cdp_timeout:<method>` — they fire at 8s, well inside the bound.
* Lowering the CDP composition instead means shrinking the attach or detach budgets, which are load-bearing for the debugger-leak invariants. Not worth reopening without a live measurement.

**Known cost, stated rather than hidden:** a slow-but-successful CDP op in the 18–20s band is now killed at 18s where it previously had until 20s. That band was already mostly lost to the server. Written into `protocol.js` and the README.

## 4. The breadcrumb

One rolling `chrome.storage.local` slot (`{op,id,phase,ts}`) around `execute()`, fire-and-forget so it cannot itself add an unbounded await.

## Manifest

**0.3.1 → 0.4.0**, so `browser ping` gives a falsifiable "is the new build loaded?" answer.

## Tests

Baseline on `origin/main` @ `2ab85f2`: **node 336 / pytest 277**. Here: **node 351 / pytest 289** (pytest delta comes from #248 underneath).

`tests/loop_wedge.test.mjs` wedges the loop with never-settling promises. **Five mutations, each watched red:**

| Mutation | Test that goes red |
|---|---|
| remove the exec bound | both wedge regressions (3.05s each, watchdog-tripped) |
| remove the pre-poll generation check | "retired MID-ITERATION" — reports the +1 poll |
| `postResult` race back to the raw constant (the 🟡-4 bug) | hung-`/result` test |
| unbind `config()` | hung-storage test |
| remove the poll race | hung-poll-fetch test |

**🟡-4 is why two of those tests exist at all:** `postResult`'s race used the literal `RESULT_BUDGET_MS` while everything else used `loopTiming()`, so the injected `resultMs` silently did not apply and *nothing* exercised a hanging `/result` — nor a never-settling poll fetch. Two of the four awaits named as the original culprit had zero coverage. Both now covered and mutation-proven.

**One test was found vacuous and fixed.** The mid-iteration test initially passed *against* its mutant: the storage gate parked the loop at whichever `chrome.storage` call came next, which was often `clearSuperseded()`'s — *after* the poll. It now gates only `config()`'s array-form read so the park point is deterministic and provably pre-poll. Separately, `runLoop`'s watchdog `setTimeout` was not being cancelled and fired during a *later* test, retiring its loop — a harness bug that produced one red test for a reason unrelated to the code.

## What still needs a live browser

Nothing here was run against real Brave — no `home-manager switch`, no service restart, no live op, no `browser agent`.

- Manifest 0.4.0 is loaded (`browser --instance <label> ping` → `extensionVersion: 0.4.0`; record the `id`).
- A real hung `frames`/`screenshot` returns `op_timeout:<op>` rather than the server's blind `cmd_timeout`.
- The breadcrumb is readable after a real wedge.
- 🔴 **The real-world effect — that the operator no longer needs a manual ↻ — is inherently unprovable in a single session and needs soak time.** The honest claim is *the mechanism is bounded and tested*, not *the disconnect is fixed*. Watch `instance_lost` (from #248): if a drop recurs, it should now name the op it died on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
