### PR TITLE
feat(browser-bridge): a dead named instance can no longer hide behind extension_connected

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -785,6 +785,55 @@ load path is an open live-verification item.
 or a new field in `ping`'s reply). Without one, reload-vs-restart is
 unfalsifiable — that ambiguity cost three full Brave restarts in one session.
 
+### `known_instances` / `missing` — a dead named instance can no longer hide
+
+`/health`'s `extension_connected` is a bare OR across live instances, so with two
+profiles wired up it stayed `true` while `work` had been gone for an hour. It is
+**not** redefined (callers legitimately use it for "is anything up"); the truth is
+carried alongside:
+
+* `known_instances[]` — every routing key seen this process lifetime, each with
+  `connected`, `last_seen` (ISO-8601 UTC), `last_seen_age_s` and
+  `last_unanswered_op`;
+* `missing[]` — the subset that is no longer live.
+
+A key that has been gone longer than `KNOWN_FORGET_S` (24h) is dropped from both,
+so an operator who normally runs one profile does not get a permanent
+`other: DISCONNECTED` nag. A warning that is always on is a warning nobody reads.
+
+⚠ **`last_unanswered_op` means "not answered within `cmd_timeout`", not "never
+answered".** A late result that arrives after the caller's `submit` gave up is
+dropped, and `last_dispatch` is only cleared on the delivering path — so the field
+can name an op that eventually completed. It is a lead, not a verdict.
+
+`browser health` renders one **stderr** line per gone instance (stdout stays
+machine-parseable JSON):
+
+```
+browser: work: DISCONNECTED (last seen 2026-07-31T18:02:34Z, last unanswered op: frames)
+```
+
+The same `known_instances` block rides on the fail-fast `404 unknown_instance`
+and `503 extension_not_connected` bodies, so a mistyped `--instance` and a
+profile that silently died are distinguishable at the point of failure.
+
+**The detector.** The server logs `instance_lost` (edge-triggered, once per
+transition) naming the key, the staleness, and **the id/op of the last command
+dispatched to it that never produced a result** — the single fact that would have
+identified `frames` on 2026-07-29 without any code reading — plus
+`instance_connected` when it comes back. Before this, a drop left no trace at all
+unless somebody happened to send a command into it, which is exactly why one of
+the two observed drops appears nowhere in the journal.
+
+⚠ **The detector is PROBE-DRIVEN, not autonomous.** There is no reaper thread:
+liveness is evaluated inside `_live_instances_locked`, which only runs when
+something asks (`/health`, `/instances`, `/whoami`, a `/cmd` dispatch). So
+detection latency is "time until the next probe", and the `stale_s` in the event
+is measured at probe time, not at the moment of the drop. A bridge nobody touches
+for an hour logs `instance_lost` an hour late, with an hour of staleness. That is
+a deliberate trade — one definition of "live", no background thread that could
+disagree with it — but it is not a monitor.
+
 ### Where the extension loads from (git-immune deploy path)
 
 `home-manager switch` copies `extension/` to **`~/.local/share/browser-bridge-ext/`**

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -263,6 +263,36 @@ for i in (insts or []):
 '
 }
 
+# render_missing — read a JSON blob on stdin carrying "known_instances" and print
+# one STDERR line per key that is KNOWN but no longer connected:
+#   work: DISCONNECTED (last seen 2026-07-31T18:02:34Z, last op: frames)
+#
+# This exists because `extension_connected` is a bare OR across instances: with
+# two profiles wired up, `work` can be gone for an hour while /health still says
+# `"extension_connected": true`. Reading the boolean is what "is the bridge up?"
+# naturally reaches for, so the drop has to be made GLANCEABLE rather than
+# requiring the reader to diff instances[] against what they expected to be there.
+# Stderr on purpose — stdout stays machine-parseable JSON.
+render_missing() {
+  python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+if not isinstance(d, dict):
+    sys.exit(0)
+for i in (d.get("known_instances") or []):
+    if i.get("connected"):
+        continue
+    seen = i.get("last_seen") or "?"
+    op = i.get("last_unanswered_op")
+    sys.stderr.write("browser: %s: DISCONNECTED (last seen %s%s)\n"
+                     % (i.get("key", "?"), seen,
+                        ", last unanswered op: %s" % op if op else ""))
+'
+}
+
 # _curl METHOD PATH [JSON_BODY] — emits `<body>\n<http_code>` to stdout. The
 # caller splits it (globals can't cross the command-substitution subshell).
 _curl() {
@@ -403,7 +433,13 @@ cmd_op() {
   HTTP_CODE="${raw##*$'\n'}"; resp="${raw%$'\n'*}"
   case "$HTTP_CODE" in
     200) : ;;  # HTTP ok — still must inspect the inner op result below.
-    503) echo "$resp" >&2; die "no extension connected — load the browser-bridge extension in Brave (see SKILL.md)" ;;
+    503)
+      # Fail-FAST (no waiting on cmd_timeout): resolution failed before the
+      # command ever reached an instance. Name the profiles we HAVE seen drop.
+      printf '%s' "$resp" | render_missing
+      echo "$resp" >&2
+      die "no extension connected — load the browser-bridge extension in Brave (see SKILL.md)"
+      ;;
     504) echo "$resp" >&2; die "timeout waiting for the extension to answer (is Brave focused / responsive?)" ;;
     401) die "unauthorized — token mismatch (re-paste the token in the extension options)" ;;
     429)
@@ -431,8 +467,13 @@ cmd_op() {
       ;;
     404)
       if printf '%s' "$resp" | grep -q '"unknown_instance"'; then
+        # Fail-FAST: the server rejects an unresolvable target BEFORE enqueueing,
+        # so this never waits out the 20s cmd_timeout. Print the live instances
+        # AND any known-but-dropped ones — a mistyped label and a profile that
+        # silently died look identical from the CLI otherwise.
         echo "browser: no connected instance matches --instance '${INSTANCE}'. Connected:" >&2
         printf '%s' "$resp" | render_instances
+        printf '%s' "$resp" | render_missing
         exit 1
       fi
       echo "$resp" >&2; die "HTTP 404 from /cmd"
@@ -474,6 +515,8 @@ case "$sub" in
     HTTP_CODE="${raw##*$'\n'}"; resp="${raw%$'\n'*}"
     [ "$HTTP_CODE" = "200" ] || { echo "$resp" >&2; die "HTTP $HTTP_CODE from /health"; }
     printf '%s\n' "$resp" | pretty
+    # A known-but-gone instance is the failure `extension_connected` hides.
+    printf '%s' "$resp" | render_missing
     ;;
   whoami)
     # Read-only identity + diagnostics. A cheap diagnostic GET like /health (NOT

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -273,23 +273,28 @@ for i in (insts or []):
 # naturally reaches for, so the drop has to be made GLANCEABLE rather than
 # requiring the reader to diff instances[] against what they expected to be there.
 # Stderr on purpose — stdout stays machine-parseable JSON.
+# DEGRADES SILENTLY on anything unexpected — an older server with no
+# `known_instances`, a non-dict body, a malformed entry. This runs as the LAST
+# command of `browser health`, so it OWNS that arm's exit code; a traceback here
+# would turn a working health probe into rc 1. Hence the try wraps the whole
+# walk, not just the parse.
 render_missing() {
   python3 -c '
 import json, sys
 try:
     d = json.load(sys.stdin)
+    if not isinstance(d, dict):
+        sys.exit(0)
+    for i in (d.get("known_instances") or []):
+        if not isinstance(i, dict) or i.get("connected"):
+            continue
+        seen = i.get("last_seen") or "?"
+        op = i.get("last_unanswered_op")
+        sys.stderr.write("browser: %s: DISCONNECTED (last seen %s%s)\n"
+                         % (i.get("key", "?"), seen,
+                            ", last unanswered op: %s" % op if op else ""))
 except Exception:
     sys.exit(0)
-if not isinstance(d, dict):
-    sys.exit(0)
-for i in (d.get("known_instances") or []):
-    if i.get("connected"):
-        continue
-    seen = i.get("last_seen") or "?"
-    op = i.get("last_unanswered_op")
-    sys.stderr.write("browser: %s: DISCONNECTED (last seen %s%s)\n"
-                     % (i.get("key", "?"), seen,
-                        ", last unanswered op: %s" % op if op else ""))
 '
 }
 

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -1959,12 +1959,23 @@ def build_server(host: str, port: int, registry: Registry, token: str,
     return server
 
 
-# The extension races its own /poll fetch against a wall-clock budget
-# (POLL_BUDGET_MS in extension/protocol.js, 40s). That budget MUST exceed this
-# server's poll_timeout or every long-poll aborts client-side just before the
-# server's 204, and the extension backoff-spins instead of long-polling. The two
-# live in different languages and different processes, so nothing enforces the
-# relationship — the least we can do is say so out loud at startup.
+# ⚠ FORWARD-LOOKING, and scoped accordingly in the message below.
+#
+# From extension 0.4.0 onward, the extension races its own /poll fetch against a
+# wall-clock budget (POLL_BUDGET_MS, 40s, in extension/protocol.js). That budget
+# must strictly EXCEED this server's poll_timeout, or every long-poll aborts
+# client-side just before the server's 204 and the extension backoff-spins
+# instead of long-polling. Equality is a genuine race, hence `>=` below.
+#
+# Extensions BEFORE 0.4.0 — including 0.3.1, the build currently deployed — do
+# `pollOnce` as a bare unbounded `await fetch` with no AbortController and no
+# budget, so for them this misconfiguration has NO client-side abort: the poll
+# simply outlives the server's 204. The warning must not tell an operator (who is
+# by definition already debugging when they read it) that today's extension will
+# backoff-spin, because today's will not.
+#
+# The two sides live in different languages and different processes, so nothing
+# can enforce the relationship. Saying it out loud at startup is the fix.
 EXTENSION_POLL_BUDGET_S = 40.0
 
 
@@ -1974,11 +1985,14 @@ def _warn_poll_timeout_vs_extension_budget(poll_timeout: float) -> None:
             reason="poll_timeout_exceeds_extension_poll_budget",
             poll_timeout=poll_timeout,
             extension_poll_budget_s=EXTENSION_POLL_BUDGET_S,
-            detail="BROWSER_BRIDGE_POLL_TIMEOUT is at or above the extension's "
-                   "POLL_BUDGET_MS; every poll will abort client-side and the "
-                   "extension will backoff-spin. Lower it or raise "
-                   "POLL_BUDGET_MS in extension/protocol.js (needs a Brave "
-                   "reload).")
+            applies_to_extension="0.4.0+",
+            detail="BROWSER_BRIDGE_POLL_TIMEOUT is at or above the /poll budget "
+                   "used by extension 0.4.0 and later (POLL_BUDGET_MS in "
+                   "extension/protocol.js). On those builds every poll will "
+                   "abort client-side and the extension will backoff-spin; "
+                   "builds before 0.4.0 do not bound the poll fetch at all and "
+                   "are unaffected. Lower BROWSER_BRIDGE_POLL_TIMEOUT, or raise "
+                   "POLL_BUDGET_MS (needs a full Brave restart).")
 
 
 def main(argv=None) -> int:

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -81,6 +81,7 @@ Config (env):
 """
 from __future__ import annotations
 
+import datetime
 import hashlib
 import json
 import os
@@ -166,6 +167,15 @@ MAX_RESULT_BODY = 32 * 1024 * 1024  # a screenshot data URL can be a few MB.
 
 # A connection is considered "present" if a long-poll landed within this window.
 CONNECT_STALE_S = 40.0
+
+# How long a routing key stays in `known_instances`/`missing` after it stops
+# polling. Without a forget path the registry remembers every key for the whole
+# process lifetime, so an operator who normally runs ONE profile would get a
+# permanent `other: DISCONNECTED` nag from `browser health` forever — a warning
+# that is always on is a warning nobody reads. 24h is long enough to still name a
+# profile that dropped during a working day, short enough that a profile you
+# genuinely stopped using ages out.
+KNOWN_FORGET_S = 86400.0
 
 # Session isolation (fixes concurrent-session tab clobbering)
 # ----------------------------------------------------------
@@ -719,7 +729,8 @@ class Instance:
     __slots__ = ("key", "instance_id", "label", "outbox", "results", "waiters",
                  "active_polls", "last_poll", "active_tab", "superseded",
                  "pending", "rl_tokens", "rl_last", "extension_version",
-                 "extension_id")
+                 "extension_id", "last_poll_wall", "lost_logged",
+                 "last_dispatch")
 
     def __init__(self, key, instance_id, label, now, burst=0.0,
                  extension_version=None, extension_id=None):
@@ -748,6 +759,18 @@ class Instance:
         self.pending = 0
         self.rl_tokens = float(burst)
         self.rl_last = now
+        # --- silent-drop detector (see _live_instances_locked) --------------- #
+        # `last_poll` is on the registry's MONOTONIC clock, which is meaningless
+        # to a human reading `browser health`. Keep a wall-clock copy purely for
+        # the "last seen 18:02:34" rendering; never used for liveness math.
+        self.last_poll_wall = time.time()
+        # Edge-trigger for the `instance_lost` / `instance_connected` log events —
+        # log ONCE per transition, not once per health probe.
+        self.lost_logged = False
+        # The last command handed to this instance that has NOT produced a result:
+        # {"id","op","at"} or None. This is the field that would have NAMED
+        # `frames` as the wedging op on 2026-07-29 without any code-reading.
+        self.last_dispatch = None
 
 
 class Registry:
@@ -919,6 +942,7 @@ class Registry:
                                          extension_version, extension_id)
             inst.active_polls += 1
             inst.last_poll = self._clock()
+            inst.last_poll_wall = time.time()
             try:
                 deadline = self._clock() + wait_timeout
                 while True:
@@ -933,6 +957,7 @@ class Registry:
             finally:
                 inst.active_polls -= 1
                 inst.last_poll = self._clock()
+                inst.last_poll_wall = time.time()
 
     def deliver_result(self, cid: str, payload: dict,
                        instance_id: str = None) -> bool:
@@ -1071,6 +1096,11 @@ class Registry:
                     cmd["reuseTabId"] = reuse_tab_id
                 inst.outbox.append(cmd)
                 inst.waiters.add(cid)
+                # Remember what we handed this instance. Cleared only when a
+                # RESULT comes back, so if the instance goes silent this field
+                # still names the command it never answered — the single fact
+                # that turns the next silent drop from inference into evidence.
+                inst.last_dispatch = {"id": cid, "op": op, "at": time.time()}
                 self._cond.notify_all()  # wake this instance's waiting poller
                 while cid not in inst.results:
                     if inst.superseded:
@@ -1085,6 +1115,9 @@ class Registry:
                     self._cond.wait(remaining)
                 inst.waiters.discard(cid)
                 result = inst.results.pop(cid)
+                # Answered → no longer the outstanding command.
+                if (inst.last_dispatch or {}).get("id") == cid:
+                    inst.last_dispatch = None
                 self._record_ownership_locked(inst, op, session_id, tab_id,
                                               result)
                 return result
@@ -1163,9 +1196,69 @@ class Registry:
         for inst in self._instances.values():
             if inst.superseded:
                 continue
-            if inst.active_polls > 0 or (now - inst.last_poll) < CONNECT_STALE_S:
+            alive = (inst.active_polls > 0
+                     or (now - inst.last_poll) < CONNECT_STALE_S)
+            # Edge-triggered drop/return detector. Evaluated here because this is
+            # the ONE place liveness is decided — a separate reaper thread would
+            # be a second definition of "live" that could disagree with this one.
+            #
+            # Before this, a silent drop left NO trace anywhere: the server logs
+            # `dispatch`/`cmd_ok` but had no event for "an instance I knew about
+            # stopped polling", so a drop was invisible unless somebody happened
+            # to send a command into it (the operator's second drop of 2026-07-31
+            # produced no journal line at all for exactly that reason).
+            if alive:
                 live.append(inst)
+                if inst.lost_logged:
+                    inst.lost_logged = False
+                    log("instance_connected", key=inst.key,
+                        instance_id=inst.instance_id)
+            elif not inst.lost_logged:
+                inst.lost_logged = True
+                d = inst.last_dispatch or {}
+                log("instance_lost", key=inst.key,
+                    instance_id=inst.instance_id,
+                    stale_s=round(now - inst.last_poll, 1),
+                    # The last command dispatched to it that never came back —
+                    # empty when it went quiet while idle.
+                    last_op=d.get("op") or "", last_id=d.get("id") or "")
         return live
+
+    def _known_instances_locked(self):
+        """Every routing key this process has seen and not superseded, each with
+        whether it is live RIGHT NOW.
+
+        This is what makes a dead named instance visible. `extension_connected`
+        is a bare OR over live instances, so one healthy profile reports the
+        bridge as up while `work` has been gone for an hour; it cannot be
+        redefined without breaking callers that legitimately ask "is anything
+        up", so the honest answer is carried ALONGSIDE it.
+        """
+        live_ids = {id(i) for i in self._live_instances_locked()}
+        now = self._clock()
+        out = []
+        for inst in self._instances.values():
+            if inst.superseded:
+                continue
+            # Age out a key nobody has used in a day — see KNOWN_FORGET_S.
+            if id(inst) not in live_ids and (now - inst.last_poll) > KNOWN_FORGET_S:
+                continue
+            d = inst.last_dispatch or {}
+            out.append({
+                "key": inst.key, "label": inst.label,
+                "instanceId": inst.instance_id,
+                "connected": id(inst) in live_ids,
+                "last_seen": _iso_utc(inst.last_poll_wall),
+                "last_seen_age_s": round(self._clock() - inst.last_poll, 1),
+                "last_unanswered_op": d.get("op") or None,
+            })
+        return out
+
+    def known_snapshot(self):
+        """(known_instances, missing) — every seen key + the subset now gone."""
+        with self._cond:
+            known = self._known_instances_locked()
+        return known, [k for k in known if not k["connected"]]
 
     def _find_locked(self, target: str):
         for inst in self._instances.values():
@@ -1247,6 +1340,16 @@ class Registry:
 # --------------------------------------------------------------------------- #
 # Small scalar guards (module-level so they're directly unit-testable)
 # --------------------------------------------------------------------------- #
+def _iso_utc(wall: float) -> str:
+    """A wall-clock epoch as an ISO-8601 UTC string, for human-readable
+    `last seen` rendering. Never used for liveness math (that is monotonic)."""
+    try:
+        return (datetime.datetime.fromtimestamp(wall, datetime.timezone.utc)
+                .strftime("%Y-%m-%dT%H:%M:%SZ"))
+    except Exception:  # noqa: BLE001
+        return ""
+
+
 def _is_tab_gone(err) -> bool:
     """True if an op-level error string signals the target tab no longer exists.
 
@@ -1622,11 +1725,23 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                 # comparison of two strings.
                 expected = manifest_version()
                 insts = annotate_staleness(registry.snapshot(), expected)
+                known, missing = registry.known_snapshot()
+                # `extension_connected` is DELIBERATELY left as-is: it is a bare
+                # OR over live instances ("is anything up"), which is what
+                # existing callers ask of it, and silently redefining it to
+                # "everything I ever saw is up" would break them. The dishonesty
+                # it enables — one healthy profile masking a `work` that dropped
+                # an hour ago — is fixed by carrying the truth alongside:
+                # `known_instances` (every key seen this process-lifetime, each
+                # with `connected`) and `missing` (the ones now gone). `browser
+                # health` renders `work: DISCONNECTED (last seen …)` from these.
                 self._send(200, {"ok": True,
                                  "extension_connected": bool(insts),
                                  "count": len(insts),
                                  "extension_version_current": expected,
-                                 "instances": insts})
+                                 "instances": insts,
+                                 "known_instances": known,
+                                 "missing": missing})
                 return
             if path == "/instances":
                 insts = registry.snapshot()
@@ -1754,8 +1869,13 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
             except NoExtension:
                 outcome, exit_code = "no_extension", 1
                 log("cmd_no_extension", op=op)
+                # Carry the keys we HAVE seen so "nothing connected" can say
+                # WHICH profile went away and when, instead of leaving the
+                # operator to guess whether Brave was ever wired up at all.
+                known, _missing = registry.known_snapshot()
                 self._send(503, {"ok": False,
-                                 "error": "extension_not_connected"})
+                                 "error": "extension_not_connected",
+                                 "known_instances": known})
             except AmbiguousInstance as e:
                 outcome, exit_code = "ambiguous", 1
                 log("cmd_ambiguous", op=op, count=len(e.instances))
@@ -1764,8 +1884,10 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
             except UnknownInstance as e:
                 outcome, exit_code = "unknown_instance", 1
                 log("cmd_unknown_instance", op=op, target=e.target)
+                known, _missing = registry.known_snapshot()
                 self._send(404, {"ok": False, "error": "unknown_instance",
-                                 "target": e.target, "instances": e.instances})
+                                 "target": e.target, "instances": e.instances,
+                                 "known_instances": known})
             except BridgeSuperseded as e:
                 outcome, exit_code = "superseded", 1
                 log("cmd_superseded", op=op, key=e.key)
@@ -1837,6 +1959,28 @@ def build_server(host: str, port: int, registry: Registry, token: str,
     return server
 
 
+# The extension races its own /poll fetch against a wall-clock budget
+# (POLL_BUDGET_MS in extension/protocol.js, 40s). That budget MUST exceed this
+# server's poll_timeout or every long-poll aborts client-side just before the
+# server's 204, and the extension backoff-spins instead of long-polling. The two
+# live in different languages and different processes, so nothing enforces the
+# relationship — the least we can do is say so out loud at startup.
+EXTENSION_POLL_BUDGET_S = 40.0
+
+
+def _warn_poll_timeout_vs_extension_budget(poll_timeout: float) -> None:
+    if poll_timeout >= EXTENSION_POLL_BUDGET_S:
+        log("config_warning",
+            reason="poll_timeout_exceeds_extension_poll_budget",
+            poll_timeout=poll_timeout,
+            extension_poll_budget_s=EXTENSION_POLL_BUDGET_S,
+            detail="BROWSER_BRIDGE_POLL_TIMEOUT is at or above the extension's "
+                   "POLL_BUDGET_MS; every poll will abort client-side and the "
+                   "extension will backoff-spin. Lower it or raise "
+                   "POLL_BUDGET_MS in extension/protocol.js (needs a Brave "
+                   "reload).")
+
+
 def main(argv=None) -> int:
     host = os.environ.get("BROWSER_BRIDGE_HOST", "127.0.0.1")
     port = int(os.environ.get("BROWSER_BRIDGE_PORT", "8788"))
@@ -1849,6 +1993,7 @@ def main(argv=None) -> int:
     server = build_server(host, port, registry, token, cmd_timeout, poll_timeout)
     log("listening", host=host, port=port, token_file=str(token_file),
         cmd_timeout=cmd_timeout, poll_timeout=poll_timeout)
+    _warn_poll_timeout_vs_extension_budget(poll_timeout)
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -4356,3 +4356,238 @@ def test_wake_telemetry_is_metadata_only(telemetry):
         assert "secret" not in json.dumps(e), "no full URL / query ever in telemetry"
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# Silent-drop honesty + detector (2026-07-31 diagnosis)
+#
+# `extension_connected` is a bare OR across live instances, so one healthy Brave
+# profile reported the bridge as UP for as long as it lived while a named
+# instance (`work`) had silently dropped. The field cannot be redefined without
+# breaking callers that legitimately ask "is anything up", so the truth is
+# carried alongside it: `known_instances` (every routing key seen this process
+# lifetime, each with `connected`) and `missing`.
+#
+# Alongside that, `instance_lost` gives the drop a journal trace naming the last
+# command the instance never answered — the operator's second drop produced no
+# evidence at all because nothing was dispatched while it was down.
+# --------------------------------------------------------------------------- #
+def _drop_registry():
+    """A registry on a controllable clock, with `work` and `personal` polled in
+    once so both are KNOWN. Returns (reg, clock-list)."""
+    clock = [1000.0]
+    reg = S.Registry(clock=lambda: clock[0])
+    with reg._cond:  # noqa: SLF001 — white-box on purpose: no HTTP needed
+        reg._register_locked("id-work", "work")          # noqa: SLF001
+        reg._register_locked("id-personal", "personal")  # noqa: SLF001
+    return reg, clock
+
+
+def test_known_instances_reports_a_dropped_instance_as_not_connected():
+    reg, clock = _drop_registry()
+    known, missing = reg.known_snapshot()
+    assert {k["key"] for k in known} == {"work", "personal"}
+    assert all(k["connected"] for k in known)
+    assert missing == []
+    # `work` stops polling; `personal` keeps polling.
+    clock[0] += S.CONNECT_STALE_S + 1
+    with reg._cond:  # noqa: SLF001
+        reg._instances["personal"].last_poll = clock[0]  # noqa: SLF001
+    known, missing = reg.known_snapshot()
+    by_key = {k["key"]: k for k in known}
+    assert by_key["work"]["connected"] is False
+    assert by_key["personal"]["connected"] is True
+    assert [m["key"] for m in missing] == ["work"]
+
+
+def test_a_long_gone_instance_is_forgotten_so_health_does_not_nag_forever():
+    """Without a forget path the registry remembers every key for its whole
+    process lifetime, so an operator who normally runs ONE profile would see a
+    permanent `other: DISCONNECTED` line — a warning that is always on is a
+    warning nobody reads."""
+    reg, clock = _drop_registry()
+    clock[0] += S.CONNECT_STALE_S + 1
+    _known, missing = reg.known_snapshot()
+    assert {m["key"] for m in missing} == {"work", "personal"}
+    clock[0] += S.KNOWN_FORGET_S            # both now long past the cutoff
+    known, missing = reg.known_snapshot()
+    assert known == [] and missing == []
+
+
+def test_a_LIVE_instance_is_never_forgotten_however_long_it_has_run():
+    """The age-out must key off staleness, not uptime — a profile connected for
+    a week is not 'gone'."""
+    reg, clock = _drop_registry()
+    clock[0] += S.KNOWN_FORGET_S * 3
+    with reg._cond:  # noqa: SLF001
+        for inst in reg._instances.values():  # noqa: SLF001
+            inst.last_poll = clock[0]         # still polling
+    known, missing = reg.known_snapshot()
+    assert {k["key"] for k in known} == {"work", "personal"}
+    assert missing == []
+
+
+def test_poll_timeout_at_or_above_the_extension_poll_budget_warns(capsys):
+    """The extension aborts its own /poll at POLL_BUDGET_MS (40s). Raising the
+    server's poll_timeout to/past that makes every poll abort client-side and the
+    extension backoff-spin. Nothing can enforce it across the two processes, so
+    it must at least be said out loud."""
+    capsys.readouterr()
+    S._warn_poll_timeout_vs_extension_budget(25.0)   # noqa: SLF001 — the default
+    assert capsys.readouterr().err == "", "the default must be silent"
+    S._warn_poll_timeout_vs_extension_budget(45.0)   # noqa: SLF001
+    lines = [json.loads(x) for x in capsys.readouterr().err.splitlines() if x]
+    assert [x["event"] for x in lines] == ["config_warning"]
+    assert lines[0]["reason"] == "poll_timeout_exceeds_extension_poll_budget"
+
+
+def test_extension_connected_still_true_but_known_instances_tells_the_truth():
+    """REGRESSION for the exact reported dishonesty: with two profiles wired up
+    and one dropped, the boolean stays true (by design, for its existing
+    callers) — and the drop is now visible in the SAME payload."""
+    reg, clock = _drop_registry()
+    clock[0] += S.CONNECT_STALE_S + 1
+    with reg._cond:  # noqa: SLF001
+        reg._instances["personal"].last_poll = clock[0]  # noqa: SLF001
+    assert reg.connected is True, \
+        "extension_connected must NOT be silently redefined — callers depend on it"
+    _known, missing = reg.known_snapshot()
+    assert [m["key"] for m in missing] == ["work"], \
+        "the dropped instance must be nameable from the same payload"
+
+
+def test_health_payload_carries_known_instances_and_missing():
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="fake-1", label="work")
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _req(srv, "GET", "/health")
+        assert st == 200
+        assert [k["key"] for k in body["known_instances"]] == ["work"]
+        assert body["known_instances"][0]["connected"] is True
+        assert body["known_instances"][0]["last_seen"].endswith("Z")
+        assert body["missing"] == []
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_instance_lost_is_logged_once_and_names_the_unanswered_command(capsys):
+    """The detector. A drop must leave a journal trace naming the op the
+    instance never came back from — the fact that would have identified `frames`
+    on 2026-07-29 without any code reading."""
+    clock = [1000.0]
+    reg = S.Registry(clock=lambda: clock[0])
+    with reg._cond:  # noqa: SLF001
+        inst = reg._register_locked("id-work", "work")  # noqa: SLF001
+        # Model a dispatched-but-never-answered command (what `submit` records).
+        inst.last_dispatch = {"id": "abc123", "op": "frames", "at": 0.0}
+    capsys.readouterr()                       # drop registration noise
+    clock[0] += S.CONNECT_STALE_S + 5
+    reg.snapshot()
+    reg.snapshot()                            # a second probe must NOT re-log
+    lines = [json.loads(x) for x in capsys.readouterr().err.splitlines() if x]
+    lost = [x for x in lines if x["event"] == "instance_lost"]
+    assert len(lost) == 1, f"edge-triggered, not per-probe: {lines}"
+    assert lost[0]["key"] == "work"
+    assert lost[0]["last_op"] == "frames"
+    assert lost[0]["last_id"] == "abc123"
+    assert lost[0]["stale_s"] >= S.CONNECT_STALE_S
+
+
+def test_instance_connected_is_logged_when_a_dropped_instance_returns(capsys):
+    clock = [1000.0]
+    reg = S.Registry(clock=lambda: clock[0])
+    with reg._cond:  # noqa: SLF001
+        reg._register_locked("id-work", "work")  # noqa: SLF001
+    clock[0] += S.CONNECT_STALE_S + 5
+    reg.snapshot()                            # → instance_lost
+    with reg._cond:  # noqa: SLF001
+        reg._instances["work"].last_poll = clock[0]  # noqa: SLF001
+    capsys.readouterr()
+    reg.snapshot()                            # → instance_connected
+    lines = [json.loads(x) for x in capsys.readouterr().err.splitlines() if x]
+    assert [x["event"] for x in lines if x["event"].startswith("instance_")] \
+        == ["instance_connected"]
+
+
+def test_last_dispatch_is_cleared_once_the_command_is_answered():
+    """A healthy instance must not report a phantom `last_unanswered_op` — that
+    would make every future drop report a stale, misleading op name."""
+    srv, reg = _serve()
+    ext = FakeExtension(srv, instance_id="fake-1", label="work")
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, _ = _req(srv, "POST", "/cmd", {"op": "tabs"})
+        assert st == 200
+        known, _missing = reg.known_snapshot()
+        assert known[0]["last_unanswered_op"] is None
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_last_unanswered_op_survives_a_swallowed_command():
+    """The wedge signature: the extension picked the command up and never
+    answered. That op name is exactly what the detector must retain."""
+    srv, reg = _serve(cmd_timeout=0.3)
+    ext = FakeExtension(srv, instance_id="fake-1", label="work", swallow=True)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, _ = _req(srv, "POST", "/cmd", {"op": "frames"})
+        assert st == 504
+        known, _missing = reg.known_snapshot()
+        assert known[0]["last_unanswered_op"] == "frames"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --- fail FAST on an unresolvable target (never wait out cmd_timeout) -------- #
+def test_unknown_instance_fails_fast_not_after_cmd_timeout():
+    """MEASURED, not asserted-by-construction: a mistyped/unknown --instance must
+    be rejected in well under the 20s cmd_timeout. `cmd_timeout` here is 5s, so a
+    resolution error that took the timeout path would be unmissable."""
+    srv, _ = _serve(cmd_timeout=5.0)
+    ext = FakeExtension(srv, instance_id="fake-1", label="work")
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        t0 = time.monotonic()
+        st, body = _req(srv, "POST", "/cmd",
+                        {"op": "tabs", "target": "nosuchlabel"})
+        elapsed = time.monotonic() - t0
+        assert st == 404 and body["error"] == "unknown_instance"
+        assert elapsed < 1.0, f"took {elapsed:.2f}s — it went down a waiting path"
+        # And it names what IS known, so a typo and a silent drop are separable.
+        assert [k["key"] for k in body["known_instances"]] == ["work"]
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_no_extension_fails_fast_and_names_the_instance_that_dropped():
+    """A profile that HAS dropped (no in-flight poll, last_poll older than
+    CONNECT_STALE_S) must fail fast and be NAMED.
+
+    ⚠ Scope of this claim, measured: this is the settled state AFTER the
+    transition window. While an instance still has a poll thread in flight the
+    server correctly considers it live and the command waits out `cmd_timeout` —
+    that bounded (≤ poll_timeout + CONNECT_STALE_S) window is unchanged here and
+    is not something a resolution-time check can remove.
+    """
+    clock = [1000.0]
+    reg = S.Registry(clock=lambda: clock[0])
+    with reg._cond:  # noqa: SLF001
+        reg._register_locked("fake-1", "work")  # noqa: SLF001
+    clock[0] += S.CONNECT_STALE_S + 1          # it stopped polling; nothing in flight
+    srv, _ = _serve(cmd_timeout=5.0, registry=reg)
+    try:
+        t0 = time.monotonic()
+        st, body = _req(srv, "POST", "/cmd", {"op": "tabs", "target": "work"})
+        elapsed = time.monotonic() - t0
+        assert st == 503 and body["error"] == "extension_not_connected"
+        assert elapsed < 1.0, f"took {elapsed:.2f}s — it went down a waiting path"
+        assert [k["key"] for k in body["known_instances"]] == ["work"]
+        assert body["known_instances"][0]["connected"] is False
+    finally:
+        srv.shutdown(); srv.server_close()

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -4414,9 +4414,18 @@ def test_a_long_gone_instance_is_forgotten_so_health_does_not_nag_forever():
     assert known == [] and missing == []
 
 
-def test_a_LIVE_instance_is_never_forgotten_however_long_it_has_run():
-    """The age-out must key off staleness, not uptime — a profile connected for
-    a week is not 'gone'."""
+def test_INVARIANT_GUARD_a_freshly_polled_instance_is_not_aged_out():
+    """⚠ INVARIANT GUARD, **not** coverage of the live-exemption clause.
+
+    This pins only "a recent `last_poll` beats the age-out", i.e. that the cutoff
+    keys off staleness rather than uptime. It CANNOT fail if the
+    `id(inst) not in live_ids` term is deleted from the age-out, because
+    `now - last_poll == 0` already makes the predicate false on its own. The
+    clause itself is pinned by
+    test_forget_exempts_an_instance_live_via_an_in_flight_poll below.
+
+    Kept because it is the case an operator actually has (a profile polling for a
+    week must never be reported as gone), and it is cheap."""
     reg, clock = _drop_registry()
     clock[0] += S.KNOWN_FORGET_S * 3
     with reg._cond:  # noqa: SLF001
@@ -4427,11 +4436,145 @@ def test_a_LIVE_instance_is_never_forgotten_however_long_it_has_run():
     assert missing == []
 
 
+def test_forget_exempts_an_instance_live_via_an_in_flight_poll():
+    """The live-exemption term in the age-out, pinned for real.
+
+    `_live_instances_locked` calls an instance alive on EITHER a fresh
+    `last_poll` OR `active_polls > 0`. Only the second disjunct can be true while
+    `last_poll` is ancient, so that is the state this constructs: a stale
+    timestamp AND a poll thread in flight. Such an instance must NOT be forgotten
+    — forgetting a connection that is mid-request is the one thing the age-out
+    must never do.
+
+    ⚠ Honest scope: this state is believed UNREACHABLE in production. `poll()`
+    stamps `last_poll` at entry and again in its `finally`, so an in-flight poll's
+    timestamp can be at most `poll_timeout` old — never past KNOWN_FORGET_S. The
+    exemption is defensive. This test exists so the clause cannot be deleted as
+    'dead' without a red test, since the reasoning that makes it dead lives in a
+    different method."""
+    clock = [1000.0]
+    reg = S.Registry(clock=lambda: clock[0])
+    with reg._cond:  # noqa: SLF001
+        inst = reg._register_locked("id-work", "work")  # noqa: SLF001
+        inst.active_polls = 1                 # a poll thread is parked in _cond.wait
+    clock[0] += S.KNOWN_FORGET_S * 2          # ...with an ancient last_poll
+    known, missing = reg.known_snapshot()
+    assert [k["key"] for k in known] == ["work"], \
+        "an instance with a poll IN FLIGHT must never be aged out"
+    assert known[0]["connected"] is True
+    assert missing == []
+
+
+# --- `browser health`'s DISCONNECTED line (the only operator-visible surface) - #
+def _serve_canned_health(payload):
+    """A stub bridge that answers /health with `payload` verbatim, so the CLI's
+    rendering can be driven against server shapes the real Registry cannot
+    produce (an OLD server with no `known_instances`, a malformed entry)."""
+    class H(S.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            body = json.dumps(payload).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *a):  # silence
+            pass
+
+    srv = S.ThreadingHTTPServer(("127.0.0.1", 0), H)
+    srv.daemon_threads = True
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv
+
+
+def _run_health(srv, tmp_path):
+    tokf = tmp_path / "token"
+    tokf.write_text("health-token\n")
+    env = dict(os.environ)
+    env.update(BROWSER_BRIDGE_HOST="127.0.0.1",
+               BROWSER_BRIDGE_PORT=str(srv.server_address[1]),
+               BROWSER_BRIDGE_TOKEN_FILE=str(tokf))
+    return subprocess.run([str(BROWSER_BIN), "health"], env=env,
+                          capture_output=True, text=True, timeout=30)
+
+
+def test_browser_health_prints_one_DISCONNECTED_line_and_keeps_stdout_json(tmp_path):
+    """The whole point of this PR, exercised through the REAL CLI: a dropped
+    named instance is glanceable, and stdout stays machine-parseable."""
+    srv = _serve_canned_health({
+        "ok": True, "extension_connected": True, "count": 1, "instances": [],
+        "known_instances": [
+            {"key": "personal", "connected": True, "last_seen": "2026-07-31T22:00:00Z",
+             "last_unanswered_op": None},
+            {"key": "work", "connected": False, "last_seen": "2026-07-31T18:02:34Z",
+             "last_unanswered_op": "frames"},
+        ],
+        "missing": [{"key": "work"}]})
+    try:
+        r = _run_health(srv, tmp_path)
+        assert r.returncode == 0, r.stderr
+        json.loads(r.stdout)                    # stdout is UNBROKEN JSON
+        lines = [x for x in r.stderr.splitlines() if x.strip()]
+        assert lines == [
+            "browser: work: DISCONNECTED (last seen 2026-07-31T18:02:34Z, "
+            "last unanswered op: frames)"], r.stderr
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_browser_health_is_SILENT_when_every_known_instance_is_connected(tmp_path):
+    srv = _serve_canned_health({
+        "ok": True, "extension_connected": True, "count": 1, "instances": [],
+        "known_instances": [{"key": "work", "connected": True,
+                             "last_seen": "2026-07-31T22:00:00Z"}],
+        "missing": []})
+    try:
+        r = _run_health(srv, tmp_path)
+        assert r.returncode == 0 and r.stderr.strip() == "", r.stderr
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_browser_health_degrades_silently_against_an_OLD_server(tmp_path):
+    """`browser` is deployed as a symlink to the working tree, so it goes live on
+    `git pull` — BEFORE the switch that restarts server.py. It therefore WILL run
+    against a server with no `known_instances`, and must stay silent and rc 0."""
+    srv = _serve_canned_health({"ok": True, "extension_connected": True,
+                                "count": 1, "instances": [{"key": "work"}]})
+    try:
+        r = _run_health(srv, tmp_path)
+        assert r.returncode == 0 and r.stderr.strip() == "", r.stderr
+        json.loads(r.stdout)
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_browser_health_survives_a_malformed_known_instances(tmp_path):
+    """render_missing is the LAST command of the `health` arm, so it owns the
+    exit code — a traceback would turn a working probe into rc 1. The try must
+    wrap the whole walk, not just the JSON parse."""
+    srv = _serve_canned_health({"ok": True, "extension_connected": True,
+                                "count": 0, "instances": [],
+                                "known_instances": ["not-a-dict", 7, None]})
+    try:
+        r = _run_health(srv, tmp_path)
+        assert r.returncode == 0, r.stderr
+        assert "Traceback" not in r.stderr
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
 def test_poll_timeout_at_or_above_the_extension_poll_budget_warns(capsys):
-    """The extension aborts its own /poll at POLL_BUDGET_MS (40s). Raising the
-    server's poll_timeout to/past that makes every poll abort client-side and the
-    extension backoff-spin. Nothing can enforce it across the two processes, so
-    it must at least be said out loud."""
+    """From extension 0.4.0 on, the extension aborts its own /poll at
+    POLL_BUDGET_MS (40s); raising the server's poll_timeout to/past that makes
+    every poll abort client-side and the extension backoff-spin. Nothing can
+    enforce it across the two processes, so it must at least be said out loud.
+
+    The warning MUST carry its version scope: the extension this server currently
+    ships against (0.3.1) does not bound the poll fetch at all, so an unscoped
+    message would describe behaviour that does not exist yet to an operator who
+    is already debugging."""
     capsys.readouterr()
     S._warn_poll_timeout_vs_extension_budget(25.0)   # noqa: SLF001 — the default
     assert capsys.readouterr().err == "", "the default must be silent"
@@ -4439,6 +4582,9 @@ def test_poll_timeout_at_or_above_the_extension_poll_budget_warns(capsys):
     lines = [json.loads(x) for x in capsys.readouterr().err.splitlines() if x]
     assert [x["event"] for x in lines] == ["config_warning"]
     assert lines[0]["reason"] == "poll_timeout_exceeds_extension_poll_budget"
+    assert lines[0]["applies_to_extension"] == "0.4.0+"
+    assert "0.4.0" in lines[0]["detail"], \
+        "the claim must name the extension version it applies to"
 
 
 def test_extension_connected_still_true_but_known_instances_tells_the_truth():


### PR DESCRIPTION
**Server + CLI half of the silent-drop work — split out of #247 on the audit's recommendation.** Ships the entire diagnostic payoff with **no Brave reload**: `server.py` restarts via `X-Restart-Triggers` on switch, and `browser` is a `mkOutOfStoreSymlink` to the working tree, so both are live on pull. `manifest.json` is deliberately **not** bumped here — `manifest_version()` reads the *deployed* manifest first, so bumping it without the extension behind it would instantly flip both instances to `extension_stale: true`.

The extension half (the actual wedge fix) is #247, stacked on this branch.

## The dishonesty

`/health`'s `extension_connected` is a bare OR across live instances. With two profiles wired up it stayed `true` while `work` had been gone for an hour — and "is the bridge up?" is exactly what reaches for that boolean.

It is **not** redefined; callers legitimately use it for "is anything up". The truth is carried alongside:

* **`known_instances[]`** — every routing key seen this process lifetime, each with `connected`, `last_seen` (ISO-8601 UTC), `last_seen_age_s`, `last_unanswered_op`
* **`missing[]`** — the subset no longer live

`browser health` renders one **stderr** line per gone instance (stdout stays machine-parseable JSON):

```
browser: work: DISCONNECTED (last seen 2026-07-31T22:09:48Z, last unanswered op: frames)
```

The same block rides on the fail-fast `404 unknown_instance` and `503 extension_not_connected` bodies, so a mistyped `--instance` and a profile that silently died are distinguishable at the point of failure.

## The detector

`instance_lost` (edge-triggered, once per transition) names the key, the staleness, and **the id/op of the last command dispatched to it that never produced a result** — the single fact that would have identified `frames` on 2026-07-29 without any code reading — plus `instance_connected` on return. Before this, a drop left no journal trace at all unless somebody happened to send a command into it, which is exactly why one of the two observed drops appears nowhere.

## What it does NOT do — stated in the README and the code

* **The detector is probe-driven, not autonomous.** There is no reaper; liveness is evaluated inside `_live_instances_locked`, which only runs when something asks. Detection latency is "time to the next probe", and `stale_s` is measured at probe time, not at the drop. A bridge nobody touches for an hour logs `instance_lost` an hour late. Deliberate trade — one definition of "live", no background thread to disagree with it — but it is not a monitor.
* **`last_unanswered_op` means "not answered within `cmd_timeout`", not "never answered".** A late result is dropped and the field is only cleared on the delivering path, so it can name an op that eventually completed. A lead, not a verdict.
* **A key gone longer than `KNOWN_FORGET_S` (24h) is forgotten**, so an operator who normally runs one profile does not get a permanent `other: DISCONNECTED` nag. A warning that is always on is a warning nobody reads.
* **The ~65s drop-transition window is unchanged and is not fixable here.** An op issued while the instance still has an in-flight poll waits out `cmd_timeout`, because `active_polls > 0` is a real `_cond.wait` that cannot observe a client disconnect until it writes. The test documents that scope explicitly rather than asserting the tidy claim.

Also added: a startup `config_warning` when `BROWSER_BRIDGE_POLL_TIMEOUT` is at or above the extension's `POLL_BUDGET_MS` (40s) — above that, every long-poll aborts client-side and the extension backoff-spins. The two live in different processes and languages so nothing can enforce the relationship; saying it out loud at startup is the fix.

## Measured end-to-end (no live Brave)

Against a local `server.py` on port 8799 with a synthetic long-polling extension: killed it, waited out the settle window, then measured

- `browser health` → `extension_connected:false`, `missing:[work]`, plus the stderr `DISCONNECTED` line;
- `browser --instance work ping` → fail-fast in **0.045 s** with `extension_not_connected` + `known_instances`;
- journal → `{"event":"instance_lost","key":"work","stale_s":51.0,…}`.

## Tests

Baseline on `origin/main` @ `2ab85f2`: **pytest 277**. Here: **pytest 294**. Node unchanged at **336** (no extension code on this branch).

Mutation-tested — each watched red:

| Mutation | Test that goes red |
|---|---|
| drop the `instance_lost` edge-trigger | once-per-transition test (logged twice) |
| remove the `last_dispatch` clear | answered-command test (phantom `last_unanswered_op`) |
| remove the `KNOWN_FORGET_S` staleness cutoff | long-gone-instance forget test |
| remove the age-out's **liveness term** (`id(inst) not in live_ids`) | live-via-in-flight-poll test |
| remove `render_missing` from the `health` arm | the DISCONNECTED-line CLI test |

## Follow-up commit — three audit findings

**A vacuous test was removed, not just renamed.** `test_a_LIVE_instance_is_never_forgotten_however_long_it_has_run` set `last_poll = now`, so `now - last_poll == 0` made the age-out predicate false on its own and the `id(inst) not in live_ids` term was never exercised — deleting that term left the test **green**. Split into an honestly-labelled invariant guard (which now states in its docstring what it cannot catch) plus `test_forget_exempts_an_instance_live_via_an_in_flight_poll`, which constructs the only state where the clause matters — ancient `last_poll` **and** `active_polls > 0` — and dies against that mutant.

The exemption is believed **unreachable** in production: `poll()` stamps `last_poll` at entry and in its `finally`, so an in-flight poll is at most `poll_timeout` old. That reasoning lives in a *different method*, which is precisely why the clause needs a test rather than a comment — otherwise the next reader deletes it as dead code.

**The startup `config_warning` described a bound that does not exist in the tree that ships it.** `POLL_BUDGET_MS` arrives with extension 0.4.0 (#247); the extension this server actually deploys against — 0.3.1 — does `pollOnce` as a bare unbounded `await fetch`, so *"every poll will abort client-side and the extension will backoff-spin"* was **false for today's build**, and the code comment referenced a symbol not in its own tree. Threshold and direction unchanged (`>=`, 40s; equality is a genuine race). Now scoped: the event carries `applies_to_extension: "0.4.0+"`, the detail names the version and says older builds are unaffected, and the comment explains why the scope matters — anyone reading this warning is already debugging.

**`render_missing` now has CI coverage.** It was the only operator-visible surface of the PR with none. Four tests through the real `browser` binary against a canned-`/health` stub: the line is emitted exactly once with stdout still valid JSON; silence when everything is connected; silent degradation + rc 0 against an **old** server with no `known_instances` (the real ordering — `browser` is a `mkOutOfStoreSymlink` to the working tree, so it goes live on *pull*, before the switch that restarts `server.py`); and survival of a malformed `known_instances`. Its `try` was also widened to wrap the whole walk rather than just `json.load`, since it is the last command of the `health` arm and therefore owns that arm's exit code.

**On the "missing duplicate-comment removal":** there is nothing to remove. The duplicate existed only transiently in my working tree while restoring a mutation; it was never committed. `server.py` on this branch has exactly one `# Answered → no longer the outstanding command.` and `origin/main` has zero, so relative to the base it is an *addition* — which is why the auditor correctly found no deleted comment line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
