### PR TITLE
feat(browser-bridge): device emulation for real mobile testing (manifest 0.5.0)

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -213,6 +213,7 @@ has not been exercised against a third-party authenticated API beyond that.)
 | `screenshot` | **CDP `Page.captureScreenshot`** (png) — works on a BACKGROUND/occluded tab + each profile's own tab; a foreground tab uses the cheap `captureVisibleTab` fast path. `fullpage` grabs the whole document. The CLI decodes `dataUrl` to a **`.png` on disk** and prints a path, never the base64 (see below) | `{url,dataUrl,via}` |
 | `open`       | `chrome.tabs.create({url,active:false})` — **background/HIDDEN** (`visibilityState:"hidden"` → Chromium throttles it → a heavy SPA won't render → reads return a shell). The escape hatch is **`browser wake`** (or a `--wake` read): it un-throttles the tab and moves NO focus. Reads self-announce this via `hidden`/`note` | `{tabId,url}` |
 | `close`      | `chrome.tabs.remove(tabId)`                               | `{closed:tabId}` |
+| `emulate`    | **device emulation** — CDP `Emulation.setDeviceMetricsOverride` / `setTouchEmulationEnabled` / `setUserAgentOverride` (**+`userAgentMetadata`**) / `setEmulatedMedia` / `setTimezoneOverride` / `setGeolocationOverride`, from a named preset or raw params. **Sticky per tab** (re-applied inside every later CDP session) and **owned-tab-only**. `--reset` stops re-applying | `{tabId,url,emulation,applied,note}` or `{tabId,url,reset,wasEmulating,note}` |
 | `frames`     | **`chrome.webNavigation.getAllFrames`** — the tab's frames INCLUDING cross-origin OUT-OF-PROCESS iframes (OOPIFs) | `{url,title,frames:[{frameId,url,parentFrameId}]}` |
 | `click`      | top frame: **CDP** `getBoundingClientRect` → `Input.dispatchMouseEvent` (trusted); `--frame`: **SYNTHETIC** click via `chrome.scripting`; `selector` required, `frame` optional | `{url,clicked,x,y,frame,trusted}` |
 | `type`       | top frame: **CDP `Input.insertText`** (trusted); `--frame`: **SYNTHETIC** input via `chrome.scripting`; `text` required, `selector`/`frame` optional | `{url,typed,frame,trusted}` |
@@ -249,7 +250,7 @@ match failing `ambiguous_frame`. See the CDP section below. `screenshot`,
 `eval --frame`, and TOP-frame trusted input use **CDP (chrome.debugger)** (see the CDP
 section below). A `--frame` op reports the FRAME's own `url` (so a caller can confirm it
 read the intended frame, not the top document). The tab-scoped ops
-(`getHtml`/`text`/`eval`/`nav`/`screenshot`/`close`/`frames`/`click`/`type`/`key`/`wake`/`activate`)
+(`getHtml`/`text`/`eval`/`nav`/`screenshot`/`close`/`frames`/`click`/`type`/`key`/`wake`/`activate`/`emulate`)
 run against
 the calling session's owned tab when it has one (see Session isolation), else the
 active tab. `text` is the **cheap read**: it returns visible `innerText` (~KB)
@@ -456,6 +457,102 @@ Everything is bounded by the per-op CDP timeouts (a bad frame fails fast, never 
 and the never-silent-null contract holds: a genuine `null`/`undefined` is returned as a
 value, but a failure to execute is a clear `frame_not_found` / `frame_eval_failed:<reason>`
 error. Own-tab-only + typed-op invariants are unchanged (no raw-CDP passthrough).
+
+## `emulate` — device emulation (0.5.0)
+
+Full operator/agent documentation lives in `reference/emulation.md` (preset metrics
+and their provenance, every flag, every error). What follows is the design record.
+
+### The central problem: CDP emulation dies at detach
+
+`withCdpSession` **always** detaches in its `finally` — that is invariant #2, and it
+is load-bearing (a leaked `chrome.debugger` attachment is a stuck banner plus an
+open surface). CDP `Emulation.*` overrides are session-scoped, so they evaporate
+with that detach. A naive `emulate` op would therefore set device metrics that were
+already gone by the time the next command ran: a confident-wrong-answer bug of
+exactly the class this codebase keeps shipping.
+
+**The fix: store, and re-apply inside every session.** `emulate` normalizes the
+request into a state object held in a module-level `Map<tabId, state>`
+(`emulationState`, `service_worker.js`). `withCdp`'s `run` wrapper — the ONE place
+every CDP op in the file funnels through — applies the state's ordered step list
+before handing control to the op. Apply-then-act, every session.
+
+The choke point is deliberate. Patching `screenshot` and `click` individually would
+have fixed the two visible cases and regenerated the bug at the next CDP op anyone
+added. One rule, one place.
+
+### ✅ The safety property this buys
+
+**Because the overrides die at detach, the tab is not emulated between ops.** A
+crashed agent, a killed session, or an evicted MV3 service worker cannot leave the
+operator's real browser distorted — the worst case is a forgotten `Map` entry that
+dies with the worker.
+
+A held-open session would have been simpler to write and strictly worse to own: its
+failure mode is a permanently mangled tab plus a permanent debug banner,
+recoverable only by the operator finding and closing the tab. That trade is the
+whole reason for the design, and it is why `--reset` means "stop re-applying"
+rather than "undo" — there is nothing live to undo.
+
+The cost, stated plainly: a page that re-measures the viewport *after* an op (a
+`resize` listener, a late layout pass) sees the real window until the next op
+re-applies.
+
+### Blast radius: owned tabs only
+
+Enforced server-side via `OWNED_TAB_ONLY_OPS` in `_effective_tab_locked` — the one
+place that knows who owns what. The session must own a tab **and** the resolved
+target must BE that tab, so an explicit `--tab` cannot reach around ownership onto
+one of the operator's tabs. Refusal is `not_owned_tab` (409), distinct from
+`no_owned_tab` because the remedies differ.
+
+Every other tab-scoped op degrades to "the active tab" when the session owns
+nothing — the useful one-shot read path, and a read is harmless. `emulate` resizes
+the viewport, rewrites the UA and turns the mouse into a finger, so the fallback is
+removed for it specifically.
+
+### Two ops that had to change, or they would lie
+
+* **`screenshot`'s `captureVisibleTab` fast path is disabled while a tab is
+  emulated.** That call never attaches the debugger, so it would have returned a
+  valid PNG of the un-emulated desktop layout in answer to "screenshot my iPhone
+  viewport" — indistinguishable from a correct result, on the one op whose entire
+  job is showing what the device sees. `--fullpage` clips from
+  `Page.getLayoutMetrics`, which is read *after* the overrides land, so the clip is
+  the emulated one.
+* **`click` dispatches `Input.dispatchTouchEvent` under touch emulation**, as
+  DevTools does. Chromium synthesizes compatibility mouse events from touch but
+  never the reverse, so a `touchstart`-only handler never fires under a mouse
+  click — the tap "does nothing" and the agent reports a working page as broken.
+
+`nav` also routes through CDP `Page.navigate` on an emulated tab, so a page
+sniffing the UA at load time sees the emulated one rather than being served the
+desktop bundle before emulation is ever re-applied.
+
+### Budget interaction (the #249 bounds)
+
+The re-application runs inside `withCdpSession`'s `run`, so each step goes through
+the **wrapped** `send` and is individually bounded by `CDP_COMMAND_TIMEOUT_MS`
+(asserted: a hung override reports `cdp_timeout:Emulation.<method>` and still
+detaches). The apply plus the op's work stay bounded together by
+`CDP_OP_BUDGET_MS`, so the composed worst case is **unchanged** and no term in the
+`LOOP_STALL_MS` derivation moves. The step count is bounded by a constant
+(`EMULATION_MAX_STEPS` = 6), not by caller input.
+
+⚠ **Unmeasured:** how much of the 15s run budget a real apply consumes on a live
+tab. These are loopback `chrome.debugger` calls to a local renderer and are
+*expected* to be low-millisecond, but that is an expectation, not a measurement —
+there was no browser in the session that built this. If a legitimate op is ever
+seen timing out at 18s only when emulated, that is the first number to go measure.
+
+### Not exposed to the autonomous agent
+
+`emulate` is absent from `ALLOWED_OPS_DEFAULT` and `OP_TO_SERVER`, so `browser
+agent` cannot reach it even via `BROWSER_AGENT_ALLOWED_OPS`. The agent's op set is
+deliberately minimal; widening it is a separate decision. The ownership gate
+already confines the op to the caller's own tab, so this is scope discipline rather
+than a safety requirement.
 
 ## `wake` — un-throttling a background tab without stealing the screen
 

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -475,8 +475,14 @@ exactly the class this codebase keeps shipping.
 **The fix: store, and re-apply inside every session.** `emulate` normalizes the
 request into a state object held in a module-level `Map<tabId, state>`
 (`emulationState`, `service_worker.js`). `withCdp`'s `run` wrapper — the ONE place
-every CDP op in the file funnels through — applies the state's ordered step list
+every **CDP** op in the file funnels through — applies the state's ordered step list
 before handing control to the op. Apply-then-act, every session.
+
+⚠ **"every CDP op" is not "every op", and the difference is user-visible.**
+`text`, `html` and the default `eval` read via `chrome.scripting`, which never
+attaches the debugger, so they never reach that choke point and return the tab's
+REAL, un-emulated DOM. See "The read path is not emulated" below — that is the
+characteristic failure mode of this feature and it has its own annotation.
 
 The choke point is deliberate. Patching `screenshot` and `click` individually would
 have fixed the two visible cases and regenerated the bug at the next CDP op anyone
@@ -529,6 +535,27 @@ removed for it specifically.
 `nav` also routes through CDP `Page.navigate` on an emulated tab, so a page
 sniffing the UA at load time sees the emulated one rather than being served the
 desktop bundle before emulation is ever re-applied.
+
+### The read path is not emulated (and says so)
+
+`text` / `html` / `eval` take the `chrome.scripting` path. Verified by execution:
+after `emulate iphone-15` they issue **zero** CDP calls and zero attaches, so the
+DOM they read is the real desktop one — `innerWidth`, `getBoundingClientRect`,
+`matchMedia` and `navigator.userAgent` all come back un-emulated.
+
+This is correct-by-design (between ops the tab genuinely is not emulated, which is
+the safety property), but it is a trap: an agent screenshots a phone layout, then
+reads `text` and reasons about a desktop DOM with nothing to tell it apart. Same
+command, two answers — `js --wake 'innerWidth'` returns the emulated width because
+it routes `cdpWake` → `withCdp`; bare `js 'innerWidth'` returns the real one.
+
+So a read of a tab **that has emulation state** is annotated, in the same spirit as
+`HIDDEN_TAB_NOTE`: `{emulated:false, notEmulatedRead:true, emulationNote}` on the
+`chrome.scripting` paths (including `text`/`html --frame`), and
+`{emulated:true, emulation:{…}}` on the CDP paths (`--wake` reads, `eval --frame`).
+A tab with no emulation state gets neither field, so ordinary envelopes are
+unchanged. `viaCdp` is passed per CALL SITE rather than inferred from the op,
+because that is genuinely where the answer lives.
 
 ### Budget interaction (the #249 bounds)
 

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -47,6 +47,7 @@ Result payloads land under `.result.data`.
 | `wake [--wait MS]` | **UN-THROTTLE a hidden/background tab with NO focus movement** — the fix for an empty or `hidden` read. ~1.5s settle, cap **6s**. **Wake once per PAGE, not per read**: the un-throttled state ends at detach, but the DOM the page rendered PERSISTS for a following cheap read |
 | `text\|html\|js --wake[=MS]` | run THAT ONE read inside the woken CDP session — only when the read must observe live un-throttled state. `text`/`html --wake` read from an ISOLATED world; `js --wake` is MAIN world by definition. `--wake` + `--frame` is refused (`wake_with_frame_unsupported`) |
 | `activate` | **⚠⚠ STEALS THE OPERATOR'S SCREEN — the ONE intrusive op, a LAST RESORT.** It is **NOT** the fix for a hidden/unrendered tab — that is `wake`. Use it only for something needing the REAL foreground (a browser permission prompt, a native file picker, seeing it with your own eyes), at most **once per TAB, never per read**. i3-gated; unreachable by the autonomous agent |
+| `emulate <preset>\|--reset` | **device emulation** (mobile testing) on a tab you `open`ed. Sticky; owned-tab-only → `reference/emulation.md` |
 | `agent "<goal>"` | run the autonomous opencode browser-agent in its OWN isolated tab; returns compact `{answer,evidence,steps_used,status}` instead of page HTML → `reference/agent.md` |
 | `--print-session-id` | print the derived per-session id (debug) |
 
@@ -139,6 +140,7 @@ exact path — only `SKILL.md` and the `browser` CLI are symlinked into
 | `reference/frames-cdp.md` | `frame_not_found` / `ambiguous_frame` / `oopif_*_cap` / `cdp_attach_refused`; a `--frame` read returned the TOP page; you need to read or drive inside a cross-origin iframe; the debugger banner |
 | `reference/tabs-instances.md` | `ambiguous_instance` / `unknown_instance` / `superseded` / `no_owned_tab` / `owned_tab_gone`; two drivers fighting over one tab; multi-profile or multi-subagent workflows |
 | `reference/css-hit-test.md` | an element is present but invisible/unclickable/painted under something; a `z-index` change "does nothing"; a `data-testid` selector matches NOTHING on a prod page |
+| `reference/emulation.md` | `emulate`: presets, raw overrides, `not_owned_tab`, `unknown_preset:*` |
 | `reference/agent.md` | running `browser agent` — flags, guardrails, prereqs; it returned `blocked`; `op_not_allowed` / `nav_scheme_denied` |
 | `reference/security-ops.md` | 🔴 **you are MODIFYING browser-bridge** (the live-verify-on-real-Brave gate is mandatory); the user asks whether/what it records; first-time setup or a second profile |
 | `reference/x-fallback.md` | CDP `screenshot` is unsatisfactory and you must capture the raw X window (`DISPLAY`/`XAUTHORITY`, xdotool/maim) |

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -83,7 +83,8 @@
 #   browser emulate <preset> | --width N --height N [...] | --reset | --list
 #                             — DEVICE EMULATION on the tab THIS SESSION OWNS, for
 #                               real mobile testing. Presets: iphone-15 iphone-se
-#                               pixel-8 ipad-mini galaxy-s24 (`--list` prints them;
+#                               pixel-8 ipad-mini ipad-mini-2019 galaxy-s24
+#                               (`--list` prints them;
 #                               metrics + provenance in
 #                               scripts/browser-bridge/reference/emulation.md).
 #                               Sets viewport + deviceScaleFactor, touch emulation,
@@ -649,7 +650,7 @@ case "$sub" in
     # extension/protocol.js (bash cannot import the table). A test asserts the two
     # lists are identical, so this cannot silently drift — see
     # tests/emulation.test.mjs "CLI preset list matches PRESET_NAMES".
-    # PRESET_NAMES: iphone-15 iphone-se pixel-8 ipad-mini galaxy-s24
+    # PRESET_NAMES: iphone-15 iphone-se pixel-8 ipad-mini ipad-mini-2019 galaxy-s24
     emu_device=""; emu_reset=0; emu_list=0
     emu_width=""; emu_height=""; emu_dsf=""; emu_mobile=""; emu_touch=""
     emu_mtp=""; emu_ua=""; emu_orient=""; emu_cs=""; emu_geo=""; emu_tz=""
@@ -687,7 +688,7 @@ case "$sub" in
     done
     if [ "$emu_list" -eq 1 ]; then
       printf '%s\n' "device presets (metrics: scripts/browser-bridge/reference/emulation.md):"
-      printf '  %s\n' iphone-15 iphone-se pixel-8 ipad-mini galaxy-s24
+      printf '  %s\n' iphone-15 iphone-se pixel-8 ipad-mini ipad-mini-2019 galaxy-s24
       printf '%s\n' "raw override: browser emulate --width N --height N [--dsf F] [--mobile] [--touch] [--ua STR]"
       exit 0
     fi

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -80,6 +80,32 @@
 #                               `--wake` on that read instead (below).
 #                               THIS IS THE REMEDY FOR A HIDDEN/EMPTY READ — not
 #                               `activate`.
+#   browser emulate <preset> | --width N --height N [...] | --reset | --list
+#                             — DEVICE EMULATION on the tab THIS SESSION OWNS, for
+#                               real mobile testing. Presets: iphone-15 iphone-se
+#                               pixel-8 ipad-mini galaxy-s24 (`--list` prints them;
+#                               metrics + provenance in
+#                               scripts/browser-bridge/reference/emulation.md).
+#                               Sets viewport + deviceScaleFactor, touch emulation,
+#                               and a mobile UA **including UA-Client-Hints
+#                               metadata** — without that half, a site reading
+#                               navigator.userAgentData still sees your desktop.
+#                               Optional --color-scheme / --geo LAT,LON / --tz.
+#                               Raw override: --width/--height/--dsf/--mobile/
+#                               --touch/--ua for anything not in the table.
+#                               STICKY per tab: re-applied inside every later op's
+#                               CDP session, because CDP overrides die at detach.
+#                               ✅ That is also the SAFETY property — between ops
+#                               the tab is NOT emulated, so a crashed agent can
+#                               never leave your real browser distorted.
+#                               `--reset` stops re-applying (nothing to undo).
+#                               ⚠ OWNED TABS ONLY (`browser open` first): emulating
+#                               a tab you are browsing in is refused with
+#                               `not_owned_tab`. Screenshots on an emulated tab are
+#                               forced onto the CDP path — the captureVisibleTab
+#                               fast path would silently return the UN-emulated
+#                               view. `click` dispatches TOUCH events while touch
+#                               emulation is on, as DevTools does.
 #   browser activate [--wait MS | --no-wait]
 #                             — FOREGROUND the owned/active tab (--tab to target
 #                               one). ⚠⚠ STEALS THE OPERATOR'S SCREEN — the ONE
@@ -464,6 +490,11 @@ cmd_op() {
         printf '%s' "$resp" | render_instances
         exit 1
       fi
+      if printf '%s' "$resp" | grep -q '"not_owned_tab"'; then
+        # The emulation blast-radius refusal. Distinct from no_owned_tab: the
+        # session may well own a tab — this one is not it. Nothing was applied.
+        die "op '$op' may only run on a tab THIS session owns — run 'browser open [url]' first and drop --tab (device emulation is deliberately never allowed on your own browsing tabs)"
+      fi
       if printf '%s' "$resp" | grep -q '"no_owned_tab"'; then
         die "this session owns no tab to close — run 'browser open [url]' first (or pass --tab <id>)"
       fi
@@ -590,6 +621,142 @@ case "$sub" in
       extra="\"waitMs\":${wait}"
     fi
     cmd_op wake "$extra" | pretty
+    ;;
+  emulate)
+    # browser emulate <preset> [overrides…]
+    # browser emulate --width N --height N [--dsf F] [--mobile] [--touch] [--ua STR]
+    # browser emulate --reset
+    # browser emulate --list
+    #
+    # DEVICE EMULATION for real mobile testing. Sets the viewport +
+    # deviceScaleFactor, touch emulation, a mobile user agent INCLUDING
+    # UA-Client-Hints metadata (the half that is usually missed — modern sites read
+    # navigator.userAgentData, not the UA string), and optionally
+    # prefers-color-scheme / geolocation / timezone.
+    #
+    # STICKY PER TAB: the extension stores the state and re-applies it inside every
+    # subsequent op's CDP session. It has to — CDP emulation overrides die when the
+    # debugger detaches, and the bridge always detaches. The upside of that is the
+    # reason the design was chosen: BETWEEN ops the tab is NOT emulated, so a
+    # crashed agent or a dead service worker cannot leave your real browser
+    # distorted. `--reset` just stops the re-applying.
+    #
+    # OWNED TABS ONLY. `browser open` first. Emulating a tab you are browsing in is
+    # refused server-side with `not_owned_tab` — an agent must not be able to
+    # resize the operator's window.
+    #
+    # ⚠ The preset NAMES below are duplicated from DEVICE_PRESETS in
+    # extension/protocol.js (bash cannot import the table). A test asserts the two
+    # lists are identical, so this cannot silently drift — see
+    # tests/emulation.test.mjs "CLI preset list matches PRESET_NAMES".
+    # PRESET_NAMES: iphone-15 iphone-se pixel-8 ipad-mini galaxy-s24
+    emu_device=""; emu_reset=0; emu_list=0
+    emu_width=""; emu_height=""; emu_dsf=""; emu_mobile=""; emu_touch=""
+    emu_mtp=""; emu_ua=""; emu_orient=""; emu_cs=""; emu_geo=""; emu_tz=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --reset) emu_reset=1; shift ;;
+        --list) emu_list=1; shift ;;
+        --width) shift; [ $# -ge 1 ] || die "--width needs a value"; emu_width="$1"; shift ;;
+        --width=*) emu_width="${1#--width=}"; shift ;;
+        --height) shift; [ $# -ge 1 ] || die "--height needs a value"; emu_height="$1"; shift ;;
+        --height=*) emu_height="${1#--height=}"; shift ;;
+        --dsf) shift; [ $# -ge 1 ] || die "--dsf needs a value"; emu_dsf="$1"; shift ;;
+        --dsf=*) emu_dsf="${1#--dsf=}"; shift ;;
+        --mobile) emu_mobile="true"; shift ;;
+        --no-mobile) emu_mobile="false"; shift ;;
+        --touch) emu_touch="true"; shift ;;
+        --no-touch) emu_touch="false"; shift ;;
+        --max-touch-points) shift; [ $# -ge 1 ] || die "--max-touch-points needs a value"; emu_mtp="$1"; shift ;;
+        --max-touch-points=*) emu_mtp="${1#--max-touch-points=}"; shift ;;
+        --ua) shift; [ $# -ge 1 ] || die "--ua needs a value"; emu_ua="$1"; shift ;;
+        --ua=*) emu_ua="${1#--ua=}"; shift ;;
+        --orientation) shift; [ $# -ge 1 ] || die "--orientation needs a value"; emu_orient="$1"; shift ;;
+        --orientation=*) emu_orient="${1#--orientation=}"; shift ;;
+        --color-scheme) shift; [ $# -ge 1 ] || die "--color-scheme needs a value"; emu_cs="$1"; shift ;;
+        --color-scheme=*) emu_cs="${1#--color-scheme=}"; shift ;;
+        --geo) shift; [ $# -ge 1 ] || die "--geo needs LAT,LON[,ACCURACY]"; emu_geo="$1"; shift ;;
+        --geo=*) emu_geo="${1#--geo=}"; shift ;;
+        --tz) shift; [ $# -ge 1 ] || die "--tz needs an IANA zone (e.g. Europe/London)"; emu_tz="$1"; shift ;;
+        --tz=*) emu_tz="${1#--tz=}"; shift ;;
+        --) shift; break ;;
+        -*) die "browser emulate: unknown flag: $1 (try: <preset> | --width N --height N [--dsf F] [--mobile] [--touch] [--ua S] [--orientation portrait|landscape] [--color-scheme light|dark] [--geo LAT,LON] [--tz ZONE] | --reset | --list)" ;;
+        *) [ -z "$emu_device" ] || die "browser emulate takes at most one preset name (got extra: $1)"
+           emu_device="$1"; shift ;;
+      esac
+    done
+    if [ "$emu_list" -eq 1 ]; then
+      printf '%s\n' "device presets (metrics: scripts/browser-bridge/reference/emulation.md):"
+      printf '  %s\n' iphone-15 iphone-se pixel-8 ipad-mini galaxy-s24
+      printf '%s\n' "raw override: browser emulate --width N --height N [--dsf F] [--mobile] [--touch] [--ua STR]"
+      exit 0
+    fi
+    # Assemble the command fields in python so numbers stay JSON numbers, strings
+    # are escaped once, and --geo is parsed in one place. Validation of RANGES is
+    # deliberately NOT duplicated here — normalizeEmulation in the extension is the
+    # single authority (one rule, one place); this only rejects what it cannot even
+    # encode. An out-of-range value comes back as `invalid_emulation:<field>`.
+    extra="$(EMU_DEVICE="$emu_device" EMU_RESET="$emu_reset" EMU_WIDTH="$emu_width" \
+             EMU_HEIGHT="$emu_height" EMU_DSF="$emu_dsf" EMU_MOBILE="$emu_mobile" \
+             EMU_TOUCH="$emu_touch" EMU_MTP="$emu_mtp" EMU_UA="$emu_ua" \
+             EMU_ORIENT="$emu_orient" EMU_CS="$emu_cs" EMU_GEO="$emu_geo" \
+             EMU_TZ="$emu_tz" python3 -c '
+import json, os, sys
+
+def env(name):
+    v = os.environ.get(name, "")
+    return v if v != "" else None
+
+fields = {}
+if os.environ.get("EMU_RESET") == "1":
+    fields["reset"] = True
+else:
+    for key, name, cast in (
+            ("device", "EMU_DEVICE", str),
+            ("width", "EMU_WIDTH", int),
+            ("height", "EMU_HEIGHT", int),
+            ("dsf", "EMU_DSF", float),
+            ("maxTouchPoints", "EMU_MTP", int),
+            ("ua", "EMU_UA", str),
+            ("orientation", "EMU_ORIENT", str),
+            ("colorScheme", "EMU_CS", str),
+            ("tz", "EMU_TZ", str)):
+        raw = env(name)
+        if raw is None:
+            continue
+        try:
+            fields[key] = cast(raw)
+        except ValueError:
+            sys.stderr.write("browser emulate: --%s must be a number (got: %s)\n"
+                             % (key, raw))
+            sys.exit(1)
+    for key, name in (("mobile", "EMU_MOBILE"), ("touch", "EMU_TOUCH")):
+        raw = env(name)
+        if raw is not None:
+            fields[key] = (raw == "true")
+    geo = env("EMU_GEO")
+    if geo is not None:
+        parts = [p.strip() for p in geo.split(",")]
+        if len(parts) not in (2, 3):
+            sys.stderr.write("browser emulate: --geo takes LAT,LON[,ACCURACY]\n")
+            sys.exit(1)
+        try:
+            g = {"latitude": float(parts[0]), "longitude": float(parts[1])}
+            if len(parts) == 3:
+                g["accuracy"] = float(parts[2])
+        except ValueError:
+            sys.stderr.write("browser emulate: --geo values must be numbers\n")
+            sys.exit(1)
+        fields["geo"] = g
+
+if not fields:
+    sys.stderr.write("usage: browser emulate <preset> | --width N --height N [...] "
+                     "| --reset | --list\n")
+    sys.exit(1)
+# Emit WITHOUT the enclosing braces — cmd_op splices this into the command body.
+sys.stdout.write(json.dumps(fields)[1:-1])
+')" || exit 1
+    cmd_op emulate "$extra" | pretty
     ;;
   activate)
     # browser [--tab <id>] activate [--wait MS | --no-wait]
@@ -918,6 +1085,6 @@ else:
     grep -E '^#( |$)' "$0" | sed -E 's/^# ?//'
     ;;
   *)
-    die "unknown subcommand: $sub (try: health whoami ping instances open close release wake activate html text js eval tabs nav screenshot frames click type key upload agent)"
+    die "unknown subcommand: $sub (try: health whoami ping instances open close release wake emulate activate html text js eval tabs nav screenshot frames click type key upload agent)"
     ;;
 esac

--- a/scripts/browser-bridge/extension/README.md
+++ b/scripts/browser-bridge/extension/README.md
@@ -167,8 +167,8 @@ come back).
    (`work` / `personal` — must be unique per profile), **Save**.
 8. Verify from a shell — this is the whole point of the change:
    ```bash
-   browser --instance <label> ping   # → {"pong":true,"extensionVersion":"0.4.0",
-                                     #     "id":"<ext-id>","ops":[…,"ping"]}
+   browser --instance <label> ping   # → {"pong":true,"extensionVersion":"0.5.0",
+                                     #     "id":"<ext-id>","ops":[…,"ping","emulate"]}
    browser whoami                    # → that instance: extension_stale:false
                                      #    + extension_id, and
                                      #    bridge.extension_dir_expected

--- a/scripts/browser-bridge/extension/manifest.json
+++ b/scripts/browser-bridge/extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Browser Bridge (command channel)",
-  "version": "0.4.0",
-  "description": "Lets a local Claude Code skill drive the active Brave tab (getHtml/eval/tabs/nav/screenshot/frames/click/type/key/activate/upload/ping) via a loopback, token-authenticated rendezvous server. Local-only, authorized personal automation.",
+  "version": "0.5.0",
+  "description": "Lets a local Claude Code skill drive the active Brave tab (getHtml/eval/tabs/nav/screenshot/frames/click/type/key/activate/upload/emulate/ping) via a loopback, token-authenticated rendezvous server. Local-only, authorized personal automation.",
   "permissions": ["scripting", "tabs", "activeTab", "storage", "alarms", "debugger", "webNavigation"],
   "host_permissions": ["http://127.0.0.1:8788/*", "<all_urls>"],
   "icons": {

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -39,9 +39,15 @@
 // yes/no. CONTRACT for any future extension change that must be provably loaded:
 // bump `manifest.json` version AND add a new discriminator (a new op name, or a
 // new field in `ping`'s reply), so the old build cannot fake a pass.
+// `emulate` puts the SESSION'S OWN tab into a device-emulation mode (viewport +
+// deviceScaleFactor, touch, mobile user-agent INCLUDING userAgentMetadata, and
+// media/geolocation/timezone) so an agent can do real mobile testing. See the
+// EMULATION section lower in this file for the persistence model and the safety
+// property that falls out of it.
 export const ALLOWED_OPS = [
   "getHtml", "text", "eval", "tabs", "nav", "screenshot", "open", "close",
   "frames", "click", "type", "key", "wake", "activate", "upload", "ping",
+  "emulate",
 ];
 
 // Per-op required fields (mirrors server.py REQUIRED_FIELDS). The server already
@@ -479,6 +485,570 @@ export async function applyWakeSteps(send, steps = WAKE_CDP_STEPS) {
     }
   }
   return { applied, skipped };
+}
+
+// --- EMULATION: device emulation for real mobile testing -------------------- //
+//
+// THE CENTRAL PROBLEM, and why this is shaped the way it is.
+//
+// `withCdpSession` ALWAYS detaches in its `finally` (that is invariant #2 — a
+// leaked chrome.debugger attachment is a stuck banner plus an open surface). CDP
+// Emulation overrides are SESSION-SCOPED: they die the instant the debugger
+// detaches. So a naive `emulate` op that just sent Emulation.setDeviceMetricsOverride
+// would set a viewport that has already evaporated by the time the NEXT command
+// (`screenshot`, `click`, a `text` read) runs — a confident-wrong-answer of exactly
+// the class this codebase keeps shipping.
+//
+// The design is therefore: `emulate` STORES a normalized emulation state per tab,
+// and EVERY op that attaches CDP to that tab RE-APPLIES the overrides inside its
+// own session, BEFORE doing its work. Apply-then-act, every session, no exceptions.
+// The state lives in a module-level Map in service_worker.js (`emulationState`);
+// everything in THIS file is the pure, browser-free half: the preset table, the
+// validation, and the ordered CDP step list.
+//
+// ✅ THE SAFETY PROPERTY THIS BUYS — state it explicitly, it is the REASON this
+// design was chosen over holding one long-lived debugger session open:
+//
+//   Because the overrides die at detach, the tab is NOT emulated between ops. A
+//   crashed agent, a killed Claude session, or an evicted MV3 service worker
+//   therefore CANNOT leave the operator's real browser distorted. The worst case
+//   is a forgotten entry in an in-memory Map that dies with the worker — not a
+//   Brave tab stuck at 393×852 pretending to be an iPhone with nothing left
+//   running that knows how to undo it.
+//
+// A held session would have been simpler to write and strictly worse to own: the
+// failure mode would be a permanently mangled tab plus a permanent debug banner,
+// recoverable only by the operator finding and closing the tab.
+//
+// BLAST RADIUS: enforced SERVER-side (see server.py OWNED_TAB_ONLY_OPS). Only a
+// tab the calling session opened via `open` may be emulated; anything else is
+// refused with `not_owned_tab`. The operator's own tabs are not resizable by an
+// agent, by construction, not by convention.
+
+// Bounds on the raw (`--width/--height/--dsf/...`) override path. Deliberately
+// generous but finite: the point is to refuse the nonsense values that would make
+// Chromium itself misbehave (a 0-height viewport, a negative scale factor), not to
+// curate a taste level. A preset always lands inside these by definition, which is
+// what the preset-integrity test asserts.
+export const EMULATION_LIMITS = Object.freeze({
+  minDimension: 1,
+  maxDimension: 10000,     // DevTools' own device-metrics inputs stop well below this
+  minScaleFactor: 0.1,
+  maxScaleFactor: 10,
+  maxTouchPoints: 16,      // CDP Emulation.setTouchEmulationEnabled caps at 16
+  maxUserAgentChars: 1024,
+  maxTimezoneChars: 64,
+});
+
+// The screenOrientation values CDP accepts.
+export const EMULATION_ORIENTATIONS = Object.freeze({
+  portrait: Object.freeze({ type: "portraitPrimary", angle: 0 }),
+  landscape: Object.freeze({ type: "landscapePrimary", angle: 90 }),
+});
+
+// The `prefers-color-scheme` values Emulation.setEmulatedMedia accepts. "" is not
+// offered — `emulate --reset` is how you stop emulating.
+export const EMULATION_COLOR_SCHEMES = Object.freeze(
+  ["light", "dark", "no-preference"]);
+
+// Every key a preset entry MUST carry. Asserted by the preset-integrity test so a
+// half-filled preset (the classic "I added a device and forgot the UA metadata")
+// cannot ship — it would silently emulate a phone-sized DESKTOP browser.
+export const PRESET_REQUIRED_KEYS = Object.freeze([
+  "label", "width", "height", "deviceScaleFactor", "mobile",
+  "maxTouchPoints", "userAgent", "userAgentMetadata", "source",
+]);
+
+// UA-Client-Hints metadata for Chrome-on-Android. WITHOUT this, a site that reads
+// navigator.userAgentData (which every modern Chromium-based stack does in
+// preference to the UA string) still sees the operator's DESKTOP Linux Chrome —
+// the most commonly missed half of "set a mobile user agent". `brands` mirrors the
+// GREASE-plus-two-real-brands shape Chrome actually sends.
+function androidUaMetadata(model, androidVersion, chromeMajor) {
+  return Object.freeze({
+    brands: Object.freeze([
+      Object.freeze({ brand: "Not/A)Brand", version: "8" }),
+      Object.freeze({ brand: "Chromium", version: String(chromeMajor) }),
+      Object.freeze({ brand: "Google Chrome", version: String(chromeMajor) }),
+    ]),
+    platform: "Android",
+    platformVersion: androidVersion,
+    architecture: "",
+    model,
+    mobile: true,
+  });
+}
+
+// UA-CH metadata for Apple devices. `brands: []` is CORRECT and deliberate, not an
+// omission: Safari does NOT implement UA-Client-Hints and sends no Sec-CH-UA at
+// all, so a site sniffing userAgentData on a real iPhone sees an empty brand list.
+// Setting it explicitly still MATTERS — omitting userAgentMetadata entirely leaves
+// Chrome reporting the operator's real desktop brands next to an iPhone UA string,
+// which is a combination no real client ever produces and which trips bot
+// detection on exactly the sites worth testing.
+function appleUaMetadata(model, platformVersion) {
+  return Object.freeze({
+    brands: Object.freeze([]),
+    platform: "iOS",
+    platformVersion,
+    architecture: "",
+    model,
+    mobile: true,
+  });
+}
+
+const IOS_UA = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) "
+  + "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 "
+  + "Safari/604.1";
+const IPADOS_UA = "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) "
+  + "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 "
+  + "Safari/604.1";
+const androidUa = (model, androidVersion, chromeMajor) =>
+  `Mozilla/5.0 (Linux; Android ${androidVersion}; ${model}) `
+  + "AppleWebKit/537.36 (KHTML, like Gecko) "
+  + `Chrome/${chromeMajor}.0.0.0 Mobile Safari/537.36`;
+
+// The curated preset table. Small ON PURPOSE: presets exist so an agent prompt can
+// say `browser emulate iphone-15` and get a REPRODUCIBLE result, not so this file
+// can mirror DevTools. Anything not here is covered by the raw
+// `--width/--height/--dsf/--mobile/--ua/--touch` path.
+//
+// ⚠ PROVENANCE, stated honestly per preset in `source`. The CSS-pixel viewport and
+// deviceScaleFactor values are the logical-resolution figures that Chrome DevTools'
+// device list (`front_end/models/emulation/EmulatedDevices.ts` in Chromium) uses,
+// which are in turn the vendors' published logical resolutions. They were sourced
+// from those published specs and cross-checked for internal consistency
+// (physical pixels ÷ deviceScaleFactor = the CSS viewport, asserted by the
+// preset-integrity test where a physical resolution is recorded).
+//
+// ⚠ NOT VERIFIED against a live DevTools device list in the session that wrote
+// this — there was no browser to open (this whole change was built without touching
+// live Brave, deliberately). Treat the exact figures as "the published logical
+// resolution", which is what matters for layout testing, rather than as "byte-equal
+// to whatever DevTools ships this month". If a preset ever disagrees with DevTools,
+// DevTools wins; fix it here and say so.
+export const DEVICE_PRESETS = Object.freeze({
+  "iphone-15": Object.freeze({
+    label: "iPhone 15",
+    width: 393, height: 852, deviceScaleFactor: 3, mobile: true,
+    maxTouchPoints: 5,
+    physical: Object.freeze({ width: 1179, height: 2556 }),
+    userAgent: IOS_UA,
+    userAgentMetadata: appleUaMetadata("iPhone", "17.0"),
+    source: "Apple published logical resolution 393x852 @3x (1179x2556 physical); "
+      + "matches the Chrome DevTools 'iPhone 15 Pro' entry.",
+  }),
+  "iphone-se": Object.freeze({
+    label: "iPhone SE",
+    width: 375, height: 667, deviceScaleFactor: 2, mobile: true,
+    maxTouchPoints: 5,
+    physical: Object.freeze({ width: 750, height: 1334 }),
+    userAgent: IOS_UA,
+    userAgentMetadata: appleUaMetadata("iPhone", "17.0"),
+    source: "Chrome DevTools' long-standing 'iPhone SE' entry: 375x667 @2x "
+      + "(750x1334 physical). The smallest viewport worth regression-testing.",
+  }),
+  "pixel-8": Object.freeze({
+    label: "Pixel 8",
+    width: 412, height: 915, deviceScaleFactor: 2.625, mobile: true,
+    maxTouchPoints: 5,
+    physical: Object.freeze({ width: 1080, height: 2400 }),
+    userAgent: androidUa("Pixel 8", "14", 126),
+    userAgentMetadata: androidUaMetadata("Pixel 8", "14", 126),
+    source: "Google published 1080x2400 physical; Chrome's Android dsf for this "
+      + "class is 2.625, giving the 412x915 CSS viewport DevTools uses for the "
+      + "Pixel 7/8 generation.",
+  }),
+  "ipad-mini": Object.freeze({
+    label: "iPad Mini",
+    width: 768, height: 1024, deviceScaleFactor: 2, mobile: true,
+    maxTouchPoints: 5,
+    physical: Object.freeze({ width: 1536, height: 2048 }),
+    userAgent: IPADOS_UA,
+    userAgentMetadata: appleUaMetadata("iPad", "17.0"),
+    source: "Chrome DevTools' 'iPad Mini' entry: 768x1024 @2x (1536x2048 "
+      + "physical). The tablet breakpoint — mobile:true but NOT phone-width.",
+  }),
+  "galaxy-s24": Object.freeze({
+    label: "Galaxy S24",
+    width: 360, height: 780, deviceScaleFactor: 3, mobile: true,
+    maxTouchPoints: 5,
+    physical: Object.freeze({ width: 1080, height: 2340 }),
+    userAgent: androidUa("SM-S921B", "14", 126),
+    userAgentMetadata: androidUaMetadata("SM-S921B", "14", 126),
+    source: "Samsung published 1080x2340 physical; Chrome reports dsf 3 on this "
+      + "device, giving a 360x780 CSS viewport — the narrowest mainstream "
+      + "Android width currently shipping.",
+  }),
+});
+
+export const PRESET_NAMES = Object.freeze(Object.keys(DEVICE_PRESETS));
+
+// A refusal an agent/operator is meant to READ and act on. Kept as plain Errors
+// with NAMED, greppable messages, exactly like `unknown_key` / `element_not_found`.
+function emuErr(name) { return new Error(name); }
+
+function requireInt(value, field, min, max) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < min || n > max) {
+    throw emuErr(`invalid_emulation:${field}`);
+  }
+  return n;
+}
+
+function requireNumber(value, field, min, max) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < min || n > max) {
+    throw emuErr(`invalid_emulation:${field}`);
+  }
+  return n;
+}
+
+function requireBool(value, field) {
+  if (typeof value === "boolean") return value;
+  if (value === "true" || value === 1 || value === "1") return true;
+  if (value === "false" || value === 0 || value === "0") return false;
+  throw emuErr(`invalid_emulation:${field}`);
+}
+
+// A UA string is echoed into a request HEADER by Chromium. A CR/LF in it is the
+// classic header-injection primitive, so it is REFUSED rather than stripped —
+// silently sanitizing input is how you end up unsure what actually went on the wire.
+function requireUserAgent(value) {
+  if (typeof value !== "string") throw emuErr("invalid_emulation:ua");
+  const s = value.trim();
+  if (!s || s.length > EMULATION_LIMITS.maxUserAgentChars) {
+    throw emuErr("invalid_emulation:ua");
+  }
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(s)) throw emuErr("invalid_emulation:ua");
+  return s;
+}
+
+function requireTimezone(value) {
+  if (typeof value !== "string") throw emuErr("invalid_emulation:tz");
+  const s = value.trim();
+  if (!s || s.length > EMULATION_LIMITS.maxTimezoneChars
+      || !/^[A-Za-z0-9_+\-/]+$/.test(s)) {
+    throw emuErr("invalid_emulation:tz");
+  }
+  return s;
+}
+
+// Normalize an `emulate` command into the STORED state (or a reset marker).
+//
+// Returns { reset: true } for `--reset`, else a frozen state object:
+//   { preset, label, metrics, touch, ua, media, geolocation, timezone }
+// where every sub-object is either the exact CDP params for its method or null.
+// Storing CDP-SHAPED params (rather than loose fields re-assembled at each apply)
+// is deliberate: the sticky re-application path then has no logic in it to drift.
+//
+// Pure — no chrome.*, no clock, no state. Throws a NAMED error on bad input.
+export function normalizeEmulation(cmd) {
+  const c = cmd || {};
+  const wantsReset = c.reset === true || c.reset === "true";
+
+  // Raw params are meaningful ONLY as a device description; combining them with
+  // --reset is contradictory (do you want the viewport or not?) and is refused
+  // rather than resolved by precedence, because either precedence would surprise
+  // half the callers.
+  const rawKeys = ["device", "width", "height", "dsf", "mobile", "ua", "touch",
+                   "maxTouchPoints", "orientation", "colorScheme", "geo", "tz"];
+  const supplied = rawKeys.filter((k) => c[k] !== undefined && c[k] !== null
+                                          && c[k] !== "");
+  if (wantsReset) {
+    if (supplied.length) throw emuErr("invalid_emulation:reset_with_params");
+    return Object.freeze({ reset: true });
+  }
+  if (!supplied.length) throw emuErr("emulate_needs_device_or_params");
+
+  let base = null;
+  let presetName = null;
+  if (c.device !== undefined && c.device !== null && c.device !== "") {
+    presetName = String(c.device);
+    base = DEVICE_PRESETS[presetName];
+    if (!base) throw emuErr(`unknown_preset:${presetName}`);
+  }
+
+  // --- viewport / device metrics ------------------------------------------- //
+  const width = c.width !== undefined && c.width !== null && c.width !== ""
+    ? requireInt(c.width, "width", EMULATION_LIMITS.minDimension,
+                 EMULATION_LIMITS.maxDimension)
+    : (base ? base.width : null);
+  const height = c.height !== undefined && c.height !== null && c.height !== ""
+    ? requireInt(c.height, "height", EMULATION_LIMITS.minDimension,
+                 EMULATION_LIMITS.maxDimension)
+    : (base ? base.height : null);
+  const dsf = c.dsf !== undefined && c.dsf !== null && c.dsf !== ""
+    ? requireNumber(c.dsf, "dsf", EMULATION_LIMITS.minScaleFactor,
+                    EMULATION_LIMITS.maxScaleFactor)
+    : (base ? base.deviceScaleFactor : null);
+  const mobile = c.mobile !== undefined && c.mobile !== null && c.mobile !== ""
+    ? requireBool(c.mobile, "mobile")
+    : (base ? base.mobile : null);
+
+  // A viewport needs BOTH dimensions. One alone is not a partial override you can
+  // resolve — Emulation.setDeviceMetricsOverride takes both or neither, and
+  // guessing the other from the real window would make the result depend on the
+  // operator's window size, i.e. not reproducible.
+  if ((width === null) !== (height === null)) {
+    throw emuErr("invalid_emulation:width_and_height_together");
+  }
+
+  let orientation = null;
+  if (c.orientation !== undefined && c.orientation !== null
+      && c.orientation !== "") {
+    const o = EMULATION_ORIENTATIONS[String(c.orientation)];
+    if (!o) throw emuErr("invalid_emulation:orientation");
+    orientation = o;
+  }
+
+  let metrics = null;
+  if (width !== null && height !== null) {
+    let w = width;
+    let h = height;
+    // `landscape` swaps the viewport as well as the reported orientation angle —
+    // setting the angle alone leaves a portrait-shaped "landscape" device, which
+    // is the least useful possible answer.
+    if (orientation && orientation.angle === 90 && h > w) { w = height; h = width; }
+    metrics = Object.freeze({
+      width: w,
+      height: h,
+      deviceScaleFactor: dsf === null ? 1 : dsf,
+      mobile: mobile === null ? false : mobile,
+      screenOrientation: orientation
+        || (w > h ? EMULATION_ORIENTATIONS.landscape
+                  : EMULATION_ORIENTATIONS.portrait),
+    });
+  }
+
+  // --- touch ---------------------------------------------------------------- //
+  // `--touch` / `--no-touch` explicitly, else the preset's implied touch support.
+  // maxTouchPoints without touch is a contradiction, refused rather than inferred.
+  let touchEnabled = null;
+  if (c.touch !== undefined && c.touch !== null && c.touch !== "") {
+    touchEnabled = requireBool(c.touch, "touch");
+  } else if (base) {
+    touchEnabled = base.maxTouchPoints > 0;
+  }
+  let maxTouchPoints = base ? base.maxTouchPoints : 1;
+  if (c.maxTouchPoints !== undefined && c.maxTouchPoints !== null
+      && c.maxTouchPoints !== "") {
+    if (touchEnabled === false) {
+      throw emuErr("invalid_emulation:max_touch_points_without_touch");
+    }
+    maxTouchPoints = requireInt(c.maxTouchPoints, "maxTouchPoints", 1,
+                                EMULATION_LIMITS.maxTouchPoints);
+    if (touchEnabled === null) touchEnabled = true;
+  }
+  const touch = touchEnabled === null ? null : Object.freeze({
+    enabled: touchEnabled,
+    maxTouchPoints: touchEnabled ? maxTouchPoints : 1,
+  });
+
+  // --- user agent (+ the half everyone forgets) ----------------------------- //
+  let ua = null;
+  if (c.ua !== undefined && c.ua !== null && c.ua !== "") {
+    const userAgent = requireUserAgent(c.ua);
+    // A RAW --ua carries no client-hints metadata of its own. Rather than leave
+    // the operator's real desktop brands showing through navigator.userAgentData,
+    // derive a minimal, internally-consistent metadata block from the mobile flag.
+    // Honest limitation, documented in reference/emulation.md: a raw UA gets
+    // GENERIC metadata, not a faithful per-device one. Use a preset for that.
+    ua = Object.freeze({
+      userAgent,
+      userAgentMetadata: base ? base.userAgentMetadata : Object.freeze({
+        brands: Object.freeze([]),
+        platform: mobile ? "Android" : "Linux",
+        platformVersion: "",
+        architecture: "",
+        model: "",
+        mobile: !!mobile,
+      }),
+    });
+  } else if (base) {
+    ua = Object.freeze({
+      userAgent: base.userAgent,
+      userAgentMetadata: base.userAgentMetadata,
+    });
+  }
+
+  // --- media / geolocation / timezone --------------------------------------- //
+  let media = null;
+  if (c.colorScheme !== undefined && c.colorScheme !== null
+      && c.colorScheme !== "") {
+    const cs = String(c.colorScheme);
+    if (!EMULATION_COLOR_SCHEMES.includes(cs)) {
+      throw emuErr("invalid_emulation:colorScheme");
+    }
+    media = Object.freeze({
+      media: "",   // "" = don't override the media TYPE, only the features
+      features: Object.freeze([
+        Object.freeze({ name: "prefers-color-scheme", value: cs }),
+      ]),
+    });
+  }
+
+  let geolocation = null;
+  if (c.geo !== undefined && c.geo !== null && c.geo !== "") {
+    const g = c.geo;
+    if (typeof g !== "object" || Array.isArray(g)) {
+      throw emuErr("invalid_emulation:geo");
+    }
+    geolocation = Object.freeze({
+      latitude: requireNumber(g.latitude, "geo.latitude", -90, 90),
+      longitude: requireNumber(g.longitude, "geo.longitude", -180, 180),
+      accuracy: g.accuracy === undefined || g.accuracy === null || g.accuracy === ""
+        ? 10
+        : requireNumber(g.accuracy, "geo.accuracy", 0, 100000),
+    });
+  }
+
+  const timezone = c.tz !== undefined && c.tz !== null && c.tz !== ""
+    ? requireTimezone(c.tz) : null;
+
+  if (!metrics && !touch && !ua && !media && !geolocation && !timezone) {
+    throw emuErr("emulate_needs_device_or_params");
+  }
+
+  return Object.freeze({
+    preset: presetName,
+    label: base ? base.label : null,
+    metrics, touch, ua, media, geolocation, timezone,
+  });
+}
+
+// The ORDERED CDP step list for a stored emulation state. Order is load-bearing
+// and asserted by the tests, not left to a comment:
+//
+//   1. setDeviceMetricsOverride  — the viewport every later measurement is taken
+//      against. It MUST precede anything that reads layout (Page.getLayoutMetrics
+//      for a --fullpage clip, an element rect for a click), or the op measures the
+//      real window and produces a confidently wrong coordinate.
+//   2. setTouchEmulationEnabled  — flips `pointer: coarse` / `hover: none`, which
+//      changes LAYOUT on responsive sites, so it lands before the page is asked
+//      anything.
+//   3. setUserAgentOverride      — a page that sniffs UA at load time must see it
+//      before `nav` navigates (which is why `nav` on an emulated tab goes through
+//      CDP at all).
+//   4-6. setEmulatedMedia / setTimezoneOverride / setGeolocationOverride — the
+//      soft ones, order-independent among themselves.
+//
+// NONE of these are `optional`. A half-applied emulation is worse than a refused
+// one: it returns a plausible screenshot of the wrong thing. If a step fails, the
+// op fails with a normal error envelope and the caller knows.
+//
+// ⏱ INTERACTION WITH THE POLL-LOOP BUDGETS (see EXEC_OP_BUDGET_MS above). The
+// re-application runs INSIDE withCdpSession's `run`, so:
+//   * each step goes through the WRAPPED `send` and is individually bounded by
+//     CDP_COMMAND_TIMEOUT_MS, exactly like every other CDP command (asserted by
+//     the "a hung emulation step is bounded" test — a hung override reports
+//     `cdp_timeout:Emulation.<method>`, it does not park the loop);
+//   * the apply plus the op's own work remain bounded together by
+//     CDP_OP_BUDGET_MS, so the composed worst case (attach 8s + run 15s +
+//     awaited safeDetach 8s, killed at the 18s EXEC bound) is UNCHANGED by this
+//     feature — no term in the LOOP_STALL_MS derivation moves;
+//   * the step COUNT is bounded by a CONSTANT — EMULATION_MAX_STEPS below — not
+//     by anything the caller supplies. A caller cannot lengthen the apply by
+//     sending a bigger payload, which is the property that keeps the cost
+//     analysable at all.
+// What this does NOT establish: how much of the 15s run budget a real apply
+// actually consumes on a live tab. These are loopback chrome.debugger calls to a
+// local renderer and are expected to be low-millisecond, but that is an
+// EXPECTATION, not a measurement — there was no browser in the session that wrote
+// this. If a legitimate op is ever seen timing out at 18s only when emulated,
+// that is the number to go measure first.
+export const EMULATION_MAX_STEPS = 6;
+
+export function emulationCdpSteps(state) {
+  if (!state || state.reset) return [];
+  const steps = [];
+  if (state.metrics) {
+    steps.push({ method: "Emulation.setDeviceMetricsOverride",
+                 params: state.metrics });
+  }
+  if (state.touch) {
+    steps.push({ method: "Emulation.setTouchEmulationEnabled",
+                 params: { enabled: state.touch.enabled,
+                           maxTouchPoints: state.touch.maxTouchPoints } });
+  }
+  if (state.ua) {
+    steps.push({ method: "Emulation.setUserAgentOverride",
+                 params: { userAgent: state.ua.userAgent,
+                           userAgentMetadata: state.ua.userAgentMetadata } });
+  }
+  if (state.media) {
+    steps.push({ method: "Emulation.setEmulatedMedia", params: state.media });
+  }
+  if (state.timezone) {
+    steps.push({ method: "Emulation.setTimezoneOverride",
+                 params: { timezoneId: state.timezone } });
+  }
+  if (state.geolocation) {
+    steps.push({ method: "Emulation.setGeolocationOverride",
+                 params: state.geolocation });
+  }
+  return steps;
+}
+
+// Apply the steps through `send`, IN ORDER, failing loudly on the first failure.
+// Deliberately NOT applyWakeSteps: that one swallows optional steps, and there is
+// no such thing as an optional emulation step (see above). Returns the applied
+// method names so the op can report exactly what took.
+export async function applyEmulationSteps(send, steps) {
+  const applied = [];
+  for (const step of steps || []) {
+    await send(step.method, step.params);
+    applied.push(step.method);
+  }
+  return applied;
+}
+
+// The compact, METADATA-ONLY summary of a stored state — what `emulate` returns,
+// what `tabs` annotates an emulated tab with, and what goes into telemetry. No
+// URL, no page content; the UA string is deliberately EXCLUDED (it is long, and
+// the preset name identifies it) but its presence is reported.
+export function emulationSummary(state) {
+  if (!state || state.reset) return null;
+  return {
+    preset: state.preset,
+    label: state.label,
+    width: state.metrics ? state.metrics.width : null,
+    height: state.metrics ? state.metrics.height : null,
+    deviceScaleFactor: state.metrics ? state.metrics.deviceScaleFactor : null,
+    mobile: state.metrics ? state.metrics.mobile : null,
+    touch: state.touch ? state.touch.enabled : false,
+    maxTouchPoints: state.touch ? state.touch.maxTouchPoints : 0,
+    userAgentOverridden: !!state.ua,
+    colorScheme: state.media && state.media.features[0]
+      ? state.media.features[0].value : null,
+    timezone: state.timezone,
+    geolocation: !!state.geolocation,
+  };
+}
+
+// Is this state's touch emulation ON? The predicate `click` branches on to decide
+// between Input.dispatchTouchEvent and Input.dispatchMouseEvent. ONE rule, ONE
+// place — a second copy of `state && state.touch && state.touch.enabled` at the
+// call site is how this grows a divergent third behaviour.
+export function isTouchEmulated(state) {
+  return !!(state && !state.reset && state.touch && state.touch.enabled);
+}
+
+// The ordered Input.dispatchTouchEvent pair for a tap at (x, y) — what DevTools
+// itself dispatches when touch emulation is on, and what a page's touch handlers
+// (and every touch-first UI library) actually listen for. A mouse event on a
+// touch-emulated tab is NOT equivalent: Chromium does synthesize compatibility
+// mouse events from touch, but not the reverse, so a `touchstart`-only handler
+// never fires. Pure data — unit-assertable, no caller-influenced method name.
+export function touchTapEvents(x, y) {
+  const point = { x, y, radiusX: 1, radiusY: 1, force: 1, id: 1 };
+  return [
+    { method: "Input.dispatchTouchEvent",
+      params: { type: "touchStart", touchPoints: [point] } },
+    { method: "Input.dispatchTouchEvent",
+      params: { type: "touchEnd", touchPoints: [] } },
+  ];
 }
 
 // --- hidden-tab self-announcing reads (prevent the "false outage") ---------- //

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -597,6 +597,39 @@ function appleUaMetadata(model, platformVersion) {
   });
 }
 
+// UA-CH metadata for a RAW `--ua` string, where there is no preset to copy from.
+//
+// The platform is DERIVED FROM THE UA STRING, never from the `--mobile` flag. An
+// earlier version keyed it off `mobile` alone, which produced
+// `platform: "Android"` for an iPhone UA — precisely the "combination no real
+// client ever produces" that appleUaMetadata above exists to avoid. Guessing wrong
+// is worse than not guessing: an inconsistent pair is a stronger bot-detection
+// signal than a blank platform.
+//
+// When the UA names a platform we recognise, say so; otherwise leave platform ""
+// (a client that declines to state it) rather than inventing one. Brands stay
+// empty either way — we have no basis to claim a Chromium version from an
+// arbitrary string, and a WRONG brand list is worse than none.
+export function rawUaMetadata(userAgent, mobile) {
+  const ua = String(userAgent || "");
+  let platform = "";
+  let model = "";
+  if (/\biPhone\b/.test(ua)) { platform = "iOS"; model = "iPhone"; }
+  else if (/\biPad\b/.test(ua)) { platform = "iOS"; model = "iPad"; }
+  else if (/\bAndroid\b/.test(ua)) { platform = "Android"; }
+  else if (/\bMac OS X\b|\bMacintosh\b/.test(ua)) { platform = "macOS"; }
+  else if (/\bWindows\b/.test(ua)) { platform = "Windows"; }
+  else if (/\bLinux\b|\bX11\b/.test(ua)) { platform = "Linux"; }
+  return Object.freeze({
+    brands: Object.freeze([]),
+    platform,
+    platformVersion: "",
+    architecture: "",
+    model,
+    mobile: !!mobile,
+  });
+}
+
 const IOS_UA = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) "
   + "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 "
   + "Safari/604.1";
@@ -659,15 +692,35 @@ export const DEVICE_PRESETS = Object.freeze({
       + "class is 2.625, giving the 412x915 CSS viewport DevTools uses for the "
       + "Pixel 7/8 generation.",
   }),
+  // ⚠ TWO iPad Minis, deliberately. The 5th-gen (2019) 768×1024 figure is what
+  // Chrome DevTools' long-standing "iPad Mini" entry uses, and it remains a
+  // legitimate tablet breakpoint — so it keeps a name of its own rather than being
+  // quietly re-pointed. `ipad-mini` (unqualified) tracks the CURRENT shipping
+  // device, the 6th-gen, whose 744×1133 viewport is materially narrower and is the
+  // one a "does this work on an iPad Mini" question actually means today.
+  // Re-pointing a stable name would have silently changed every existing caller's
+  // result AND made the older entry's honest `source` string false.
   "ipad-mini": Object.freeze({
-    label: "iPad Mini",
+    label: "iPad Mini (6th gen)",
+    width: 744, height: 1133, deviceScaleFactor: 2, mobile: true,
+    maxTouchPoints: 5,
+    physical: Object.freeze({ width: 1488, height: 2266 }),
+    userAgent: IPADOS_UA,
+    userAgentMetadata: appleUaMetadata("iPad", "17.0"),
+    source: "Apple published 1488x2266 physical @2x for the 6th-gen iPad Mini "
+      + "(2021), giving a 744x1133 CSS viewport — the current shipping device, "
+      + "and materially narrower than the 2019 model below.",
+  }),
+  "ipad-mini-2019": Object.freeze({
+    label: "iPad Mini (5th gen, 2019)",
     width: 768, height: 1024, deviceScaleFactor: 2, mobile: true,
     maxTouchPoints: 5,
     physical: Object.freeze({ width: 1536, height: 2048 }),
     userAgent: IPADOS_UA,
     userAgentMetadata: appleUaMetadata("iPad", "17.0"),
-    source: "Chrome DevTools' 'iPad Mini' entry: 768x1024 @2x (1536x2048 "
-      + "physical). The tablet breakpoint — mobile:true but NOT phone-width.",
+    source: "Chrome DevTools' long-standing 'iPad Mini' entry: 768x1024 @2x "
+      + "(1536x2048 physical). The classic tablet breakpoint — mobile:true but "
+      + "NOT phone-width.",
   }),
   "galaxy-s24": Object.freeze({
     label: "Galaxy S24",
@@ -857,14 +910,8 @@ export function normalizeEmulation(cmd) {
     // GENERIC metadata, not a faithful per-device one. Use a preset for that.
     ua = Object.freeze({
       userAgent,
-      userAgentMetadata: base ? base.userAgentMetadata : Object.freeze({
-        brands: Object.freeze([]),
-        platform: mobile ? "Android" : "Linux",
-        platformVersion: "",
-        architecture: "",
-        model: "",
-        mobile: !!mobile,
-      }),
+      userAgentMetadata: base ? base.userAgentMetadata
+        : rawUaMetadata(userAgent, mobile),
     });
   } else if (base) {
     ua = Object.freeze({
@@ -1025,6 +1072,56 @@ export function emulationSummary(state) {
     timezone: state.timezone,
     geolocation: !!state.geolocation,
   };
+}
+
+// --- the NON-EMULATED READ trap, and the annotation that defuses it --------- //
+//
+// `text`, `getHtml` and the default `eval` read via chrome.scripting. That path
+// NEVER attaches the debugger, so withCdp's re-application choke point never runs
+// and the DOM they see is the tab's REAL, un-emulated one.
+//
+// That is correct-by-design, not a bug: between ops the tab genuinely is not
+// emulated (the safety property above), so the at-rest DOM really is desktop.
+// But it is a TRAP, and it is this feature's characteristic failure mode on the
+// read path: an agent screenshots a phone layout, then reads `text`/`html` and
+// reasons about a DESKTOP DOM, with nothing in the envelope to tell it apart.
+// Layout-derived values (innerWidth, getBoundingClientRect, matchMedia) and
+// navigator.userAgent all come back REAL.
+//
+// So every read of a tab that HAS emulation state says which one it got. Same
+// pattern, and the same reasoning, as HIDDEN_TAB_NOTE: the read self-announces
+// rather than leaving a plausible-but-wrong answer to be discovered later.
+//
+// ⚠ THE WORDING IS LOAD-BEARING (see HIDDEN_TAB_NOTE). Whatever remedy this names
+// becomes the reflex an agent learns, so it names `--wake` — the flag that routes
+// the read through cdpWake → withCdp and therefore through the emulation apply.
+export const NOT_EMULATED_READ_NOTE =
+  "This tab has device emulation configured, but THIS read did not go through "
+  + "CDP — it read the tab's REAL, un-emulated DOM. Emulation overrides only "
+  + "exist inside a CDP session (they die at detach), so layout-derived values "
+  + "(innerWidth, getBoundingClientRect, matchMedia) and navigator.userAgent are "
+  + "the DESKTOP ones here. Re-run this read with --wake to read inside an "
+  + "emulated session.";
+
+// Annotate a READ result with whether it observed the emulated page.
+//   * no emulation state for the tab → returns `data` UNTOUCHED (a plain tab's
+//     envelope must not grow fields);
+//   * viaCdp → { emulated:true, emulation:<summary> };
+//   * otherwise → { emulated:false, notEmulatedRead:true, emulationNote }.
+// Pure; `summary` is emulationSummary(state) (metadata only) and `viaCdp` is
+// supplied per-CALL-SITE, because whether a read is emulated depends on the PATH
+// (--wake / --frame eval go through CDP; the default reads do not), not on the op.
+export function annotateEmulatedRead(data, summary, viaCdp) {
+  if (!data || typeof data !== "object" || !summary) return data;
+  if (viaCdp) {
+    data.emulated = true;
+    data.emulation = summary;
+  } else {
+    data.emulated = false;
+    data.notEmulatedRead = true;
+    data.emulationNote = NOT_EMULATED_READ_NOTE;
+  }
+  return data;
 }
 
 // Is this state's touch emulation ON? The predicate `click` branches on to decide

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -51,6 +51,11 @@ import {
   // the CDP < exec < server-cmd_timeout ordering).
   promiseWithTimeout, EXEC_OP_BUDGET_MS, POLL_BUDGET_MS, RESULT_BUDGET_MS,
   LOOP_STALL_MS, STORAGE_BUDGET_MS,
+  // `emulate` op: device emulation (viewport/touch/UA+UA-CH/media/geo/tz) that is
+  // STICKY per tab because CDP overrides die at detach — see the EMULATION section
+  // in protocol.js for the central problem and the safety property it buys.
+  normalizeEmulation, emulationCdpSteps, applyEmulationSteps, emulationSummary,
+  isTouchEmulated, touchTapEvents, DEVICE_PRESETS, PRESET_NAMES,
 } from "./protocol.js";
 
 const DEFAULT_PORT = 8788;
@@ -145,10 +150,25 @@ async function targetTab(cmd) {
     try {
       return await chrome.tabs.get(cmd.tabId);
     } catch (e) {
-      throw new Error("owned_tab_gone");   // the tab was closed out-of-band
+      throw ownedTabGone(cmd.tabId);       // the tab was closed out-of-band
     }
   }
   return activeTab();
+}
+
+// THE single "this tab is gone" reaction: drop any emulation state for it, then
+// produce the standard error. Two layers detect the same condition — targetTab (on
+// every op) and withCdp's attach (the CDP-readiness check) — and the CLEANUP must
+// not be written twice; one copy would inevitably be the one that got a later fix.
+//
+// Clearing here rather than relying on chrome.tabs.onRemoved matters because
+// onRemoved is an event whose timing we do not control, and it does not fire at
+// all for a tab that was already gone when we first looked. Chrome RECYCLES tabIds,
+// so a stale entry is not merely untidy — the next tab to inherit the id would be
+// silently emulated by a session that never asked for it.
+function ownedTabGone(tabId) {
+  clearEmulation(tabId);
+  return new Error("owned_tab_gone");
 }
 
 // Read the tab's `document.visibilityState` (top frame) so a read op can self-
@@ -179,6 +199,37 @@ async function tabVisibilityState(tabId) {
 // us out-of-band (tab crash/close, or the user hitting the debug banner's Cancel).
 const cdpAttached = new Set();
 
+// --- EMULATION state (the sticky half) -------------------------------------- //
+// tabId -> the normalized emulation state from normalizeEmulation(). This is the
+// ONLY mutable emulation state in the extension.
+//
+// It is IN-MEMORY on purpose (not chrome.storage): CDP overrides die at detach, so
+// state that outlived the service worker would describe an emulation that is not
+// actually applied anywhere — a lie that survives a restart is worse than a
+// forgotten one. Losing it on worker eviction is the correct, safe failure: the
+// operator's tab is already un-emulated at that point.
+//
+// Emptied by: `emulate --reset`, `close`, chrome.tabs.onRemoved, and a failed
+// tabs.get during CDP attach (the tab went away out-of-band).
+const emulationState = new Map();
+
+function emulationFor(tabId) {
+  return tabId == null ? null : (emulationState.get(tabId) || null);
+}
+
+function clearEmulation(tabId) {
+  if (tabId != null) emulationState.delete(tabId);
+}
+
+// Drop the state of a tab that no longer exists. Registered at module scope so it
+// runs for EVERY tab close, not only a `close` op — a tab the operator closed by
+// hand must not leave an entry behind that a recycled tabId could later inherit.
+try {
+  if (typeof chrome !== "undefined" && chrome.tabs && chrome.tabs.onRemoved) {
+    chrome.tabs.onRemoved.addListener((tabId) => clearEmulation(tabId));
+  }
+} catch (e) { /* bare unit-test global with no chrome.tabs — nothing to hook */ }
+
 function sendCdp(target, method, params) {
   return chrome.debugger.sendCommand(target, method, params || {});
 }
@@ -203,7 +254,7 @@ async function withCdp(tabId, url, run) {
       // other hang; this turns the common case into an immediate clear error.
       let tab;
       try { tab = await chrome.tabs.get(tabId); }
-      catch (e) { throw new Error("owned_tab_gone"); }
+      catch (e) { throw ownedTabGone(tabId); }   // clears emulation state too
       assertTabCdpReady(tab);
       await chrome.debugger.attach(target, CDP_VERSION);
       cdpAttached.add(tabId);
@@ -226,7 +277,25 @@ async function withCdp(tabId, url, run) {
     // {tabId, sessionId}); omitted → the tab's top session.
     send: (method, params, sessionId) =>
       sendCdp(sessionId != null ? { ...target, sessionId } : target, method, params),
-    run: (send) => run(send),
+    // ⚠ THE STICKY RE-APPLICATION CHOKE POINT. Every CDP op in this file goes
+    // through withCdp, so applying the tab's emulation HERE — once, before `run`
+    // — makes every one of them emulation-aware without a single call site
+    // knowing about it. That is deliberate: patching `screenshot` and `click`
+    // individually would fix today's two visible cases and regenerate the bug at
+    // the next CDP op someone adds. One rule, one place.
+    //
+    // Apply-then-act ordering matters and is asserted by the tests: the overrides
+    // must be live BEFORE anything measures layout (a --fullpage clip's
+    // Page.getLayoutMetrics, a click's element rect) or navigates.
+    //
+    // A failing apply propagates normally — withCdpSession still detaches in its
+    // finally and execute() turns it into an ordinary error envelope, so a bad
+    // emulation can fail an op but can never wedge the poll loop.
+    run: async (send) => {
+      const steps = emulationCdpSteps(emulationFor(tabId));
+      if (steps.length) await applyEmulationSteps(send, steps);
+      return run(send);
+    },
   });
 }
 
@@ -651,20 +720,59 @@ const OPS = {
     return annotateVisibility({ url: tab.url, value: inj.result }, vis);
   },
 
+  // Each tab additionally carries `emulation` when this service worker holds a
+  // device-emulation state for it (absent otherwise, so the common listing is
+  // unchanged). SURFACING IT HERE IS THE POINT: an emulation left on by a session
+  // that wandered off is otherwise invisible, and "why is this page rendering at
+  // 393px" becomes a mystery instead of a line in `browser tabs`. `emulatedTabs`
+  // repeats the ids at the top level so a caller does not have to scan.
   async tabs() {
     const tabs = await chrome.tabs.query({});
-    return {
-      tabs: tabs.map((t) => ({
+    const emulated = [];
+    const out = tabs.map((t) => {
+      const entry = {
         id: t.id, url: t.url, title: t.title,
         active: t.active, windowId: t.windowId,
-      })),
-    };
+      };
+      const summary = emulationSummary(emulationFor(t.id));
+      if (summary) { entry.emulation = summary; emulated.push(t.id); }
+      return entry;
+    });
+    return { tabs: out, emulatedTabs: emulated };
   },
 
+  // Navigate the owned/target tab.
+  //
+  // TWO paths, and the split exists BECAUSE of emulation. The plain path is
+  // chrome.tabs.update — cheap, no debugger banner, unchanged behaviour.
+  //
+  // On an EMULATED tab that is wrong: chrome.tabs.update navigates outside any CDP
+  // session, so the page's first paint, its `@media` evaluation and — critically —
+  // its server-side and client-side UA sniffing all happen with the REAL desktop
+  // metrics and the REAL user agent. The emulated values would only appear on the
+  // next op, by which time a UA-sniffing site has already served the desktop
+  // bundle. So an emulated tab navigates via CDP Page.navigate INSIDE a session
+  // that has already applied the overrides (withCdp's run wrapper does that before
+  // this callback is reached).
+  //
+  // Honest limitation, documented in reference/emulation.md: the overrides still
+  // die when this session detaches, moments after the navigation is committed. A
+  // page that re-measures the viewport LATER (after load, on a resize listener)
+  // will see the real window until the next op re-applies. Waking/reading with an
+  // op is what re-establishes it — that is inherent to the detach-scoped design,
+  // and it is the price of the safety property (see protocol.js EMULATION).
   async nav(cmd) {
     const tab = await targetTab(cmd);
+    const emu = emulationFor(tab.id);
+    if (emu) {
+      await withCdp(tab.id, tab.url, async (send) => {
+        await send("Page.navigate", { url: cmd.url });
+      });
+      return { tabId: tab.id, url: cmd.url, via: "cdp",
+               emulation: emulationSummary(emu) };
+    }
     await chrome.tabs.update(tab.id, { url: cmd.url });
-    return { tabId: tab.id, url: cmd.url };
+    return { tabId: tab.id, url: cmd.url, via: "tabs.update" };
   },
 
   // Screenshot the owned/target tab. PRIMARY path is CDP Page.captureScreenshot,
@@ -675,10 +783,20 @@ const OPS = {
   // --fullpage); any failure there falls through to the CDP path. `--fullpage`
   // captures the whole scrollable document (CDP only). Attach is REFUSED on a
   // privileged tab (assertCdpAttachable inside withCdp) before any attach.
+  //
+  // ⚠ THE FAST PATH IS DISABLED ON AN EMULATED TAB, and that is not an
+  // optimization detail — it is a correctness gate. chrome.tabs.captureVisibleTab
+  // never attaches the debugger, so it captures the tab's REAL, un-emulated
+  // rendering. On an emulated tab it would return a perfectly valid PNG of the
+  // desktop layout in answer to "screenshot my iPhone viewport": a confident wrong
+  // answer, indistinguishable from a correct one, on the single op whose entire
+  // job is to show you what the device sees. Forcing CDP costs a debugger banner
+  // and is unambiguously the right trade.
   async screenshot(cmd) {
     const tab = await targetTab(cmd);
     const fullpage = !!(cmd && cmd.fullpage);
-    if (tab.active && !fullpage) {
+    const emulated = !!emulationFor(tab.id);
+    if (tab.active && !fullpage && !emulated) {
       // Fast path — no debugger attach/banner. Chrome throttles captureVisibleTab to
       // ~2/sec; captureWithRetry spaces the (rare) retry ≥ the quota window.
       try {
@@ -690,6 +808,10 @@ const OPS = {
     const dataUrl = await withCdp(tab.id, tab.url, async (send) => {
       const params = { format: "png" };
       if (fullpage) {
+        // Page.getLayoutMetrics runs AFTER withCdp's run wrapper has applied the
+        // emulation (see the choke point in withCdp), so on an emulated tab these
+        // metrics — and therefore the --fullpage clip — are the EMULATED ones. The
+        // ordering is asserted by a test rather than trusted to this comment.
         const metrics = await send("Page.getLayoutMetrics");
         params.clip = fullPageClip(metrics);
         params.captureBeyondViewport = true;
@@ -697,7 +819,9 @@ const OPS = {
       const { data } = await send("Page.captureScreenshot", params);
       return `data:image/png;base64,${data}`;
     });
-    return { url: tab.url, dataUrl, via: "cdp" };
+    const summary = emulationSummary(emulationFor(tab.id));
+    return { url: tab.url, dataUrl, via: "cdp",
+             ...(summary ? { emulation: summary } : {}) };
   },
 
   // List the target tab's frames ({frameId,url,parentFrameId}) via
@@ -750,18 +874,32 @@ const OPS = {
       return { url: frame.url || tab.url, clicked: selector, x: res.x, y: res.y,
                frame: cmd.frame, trusted: false };
     }
+    // On a TOUCH-EMULATED tab the top-frame path dispatches Input.dispatchTouchEvent
+    // (touchStart/touchEnd) instead of mouse events — which is exactly what DevTools
+    // does with touch emulation on. This is not cosmetic: Chromium synthesizes
+    // compatibility MOUSE events from touch, but never touch events from mouse, so
+    // a mobile UI whose handler is `touchstart` (or a library that binds pointer
+    // events with `pointerType === "touch"`) simply never fires under a mouse click
+    // — the tap "does nothing" and the agent reports a broken page that is not
+    // broken. Mouse remains the behaviour on every non-touch-emulated tab.
+    const emu = emulationFor(tab.id);
+    const touch = isTouchEmulated(emu);
     const point = await withCdp(tab.id, tab.url, async (send) => {
       const rect = await cdpEval(send, undefined, elementRectExpression(selector));
       if (!rect) throw new Error(`element_not_found:${selector}`);
       const p = clickPoint(rect, { x: 0, y: 0 });
-      const mouse = (type) => send("Input.dispatchMouseEvent",
-        { type, x: p.x, y: p.y, button: "left", buttons: 1, clickCount: 1 });
-      await mouse("mousePressed");
-      await mouse("mouseReleased");
+      if (touch) {
+        for (const ev of touchTapEvents(p.x, p.y)) await send(ev.method, ev.params);
+      } else {
+        const mouse = (type) => send("Input.dispatchMouseEvent",
+          { type, x: p.x, y: p.y, button: "left", buttons: 1, clickCount: 1 });
+        await mouse("mousePressed");
+        await mouse("mouseReleased");
+      }
       return p;
     });
     return { url: tab.url, clicked: selector, x: point.x, y: point.y,
-             frame: null, trusted: true };
+             frame: null, trusted: true, via: touch ? "touch" : "mouse" };
   },
 
   // Type `text` (optionally focus `--selector` first). `--frame` → SYNTHETIC input
@@ -853,14 +991,76 @@ const OPS = {
   // closed out-of-band, `chrome.tabs.remove` rejects — treat that as success
   // (the desired end-state, tab absent, already holds) so the session's stale
   // ownership is cleanly dropped instead of surfacing a spurious error.
+  //
+  // Drops any emulation state for the tab FIRST, on both paths. onRemoved would
+  // normally do it, but it is an event we do not control the timing of (and does
+  // not fire at all on the already-gone path), and a stale entry is inheritable by
+  // a recycled tabId. Clearing here makes it deterministic.
   async close(cmd) {
     if (!cmd || cmd.tabId == null) throw new Error("missing_tabId");
+    clearEmulation(cmd.tabId);
     try {
       await chrome.tabs.remove(cmd.tabId);
       return { closed: cmd.tabId };
     } catch (e) {
       return { closed: cmd.tabId, alreadyGone: true };
     }
+  },
+
+  // --- `emulate`: device emulation for real mobile testing ------------------ //
+  //
+  // Stores (or clears) the tab's emulation state and applies it ONCE immediately so
+  // the caller gets a straight yes/no on whether Chromium accepted the overrides,
+  // rather than discovering a bad timezone id three ops later. Every subsequent op
+  // that attaches CDP re-applies it (see the choke point in withCdp).
+  //
+  // `--reset` means "STOP RE-APPLYING". It does not need to undo anything: the
+  // overrides died at the previous op's detach, and the tab is already un-emulated
+  // right now. That is the whole safety property (protocol.js EMULATION).
+  //
+  // OWNERSHIP is enforced SERVER-side (server.py OWNED_TAB_ONLY_OPS → the named
+  // `not_owned_tab` refusal), not here, because the server is the only side that
+  // knows which session owns which tab. The extension still refuses a privileged
+  // scheme before attaching, as every CDP op does.
+  async emulate(cmd) {
+    const tab = await targetTab(cmd);
+    const state = normalizeEmulation(cmd);   // throws a NAMED error on bad input
+
+    if (state.reset) {
+      const had = emulationSummary(emulationFor(tab.id));
+      clearEmulation(tab.id);
+      return {
+        tabId: tab.id, url: tab.url, reset: true,
+        wasEmulating: had,
+        note: "emulation stopped. Nothing had to be undone — CDP overrides die at "
+          + "debugger detach, so the tab was already un-emulated between ops.",
+      };
+    }
+
+    // Store BEFORE applying so the apply goes through the same withCdp choke point
+    // every other op uses — one code path, no second copy of the apply logic. A
+    // failed apply rolls the state back: leaving it stored would mean every later
+    // op re-attempts an emulation the caller was told had failed.
+    const previous = emulationState.get(tab.id) || null;
+    emulationState.set(tab.id, state);
+    let applied;
+    try {
+      applied = await withCdp(tab.id, tab.url, async () =>
+        emulationCdpSteps(state).map((s) => s.method));
+    } catch (e) {
+      if (previous) emulationState.set(tab.id, previous);
+      else emulationState.delete(tab.id);
+      throw e;
+    }
+    return {
+      tabId: tab.id, url: tab.url,
+      emulation: emulationSummary(state),
+      applied,
+      note: "sticky per tab: these overrides are re-applied inside every "
+        + "subsequent op's CDP session. Between ops the tab is NOT emulated (the "
+        + "overrides die at detach), so a crashed agent cannot leave your browser "
+        + "distorted. `browser emulate --reset` stops re-applying.",
+    };
   },
 
   // Bring the target tab to the FOREGROUND. THE ONE INTRUSIVE OP — it takes the
@@ -1290,7 +1490,10 @@ if (!(typeof globalThis !== "undefined" && globalThis.BROWSER_BRIDGE_NO_AUTOSTAR
 // (tests/loop_wedge.test.mjs) has to drive a real loop iteration against a
 // never-settling op and observe that it releases, which cannot be asserted from
 // the outside. Nothing in the extension imports them.
-export { execute, OPS, ALLOWED_OPS, cdpAttached, loop };
+// `emulationState` is exported for TESTS only — it is the sticky-emulation Map, and
+// asserting "close cleared it" / "a vanished tab dropped it" requires seeing it.
+// Nothing in production reads it from outside this module.
+export { execute, OPS, ALLOWED_OPS, cdpAttached, loop, emulationState };
 
 // A read/reset window onto the loop's private liveness state, for tests.
 export const loopState = {

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -56,6 +56,7 @@ import {
   // in protocol.js for the central problem and the safety property it buys.
   normalizeEmulation, emulationCdpSteps, applyEmulationSteps, emulationSummary,
   isTouchEmulated, touchTapEvents, DEVICE_PRESETS, PRESET_NAMES,
+  annotateEmulatedRead,
 } from "./protocol.js";
 
 const DEFAULT_PORT = 8788;
@@ -227,6 +228,21 @@ function clearEmulation(tabId) {
 try {
   if (typeof chrome !== "undefined" && chrome.tabs && chrome.tabs.onRemoved) {
     chrome.tabs.onRemoved.addListener((tabId) => clearEmulation(tabId));
+  }
+  // onReplaced fires when a tab is SWAPPED for another (a prerender/instant
+  // navigation activating): the old tabId is retired WITHOUT onRemoved firing. Left
+  // unhandled that strands a Map entry on an id Chrome can recycle. Narrow — the
+  // tab also loses its server-side ownership, and `ownedTabGone` catches the common
+  // vanish — but it costs two lines and the restart is already being paid for.
+  //
+  // The emulation deliberately does NOT follow the tab to its new id: the swapped-in
+  // document is a different page that was rendered WITHOUT the overrides, so
+  // carrying the state across would claim an emulation that was never applied.
+  if (typeof chrome !== "undefined" && chrome.tabs && chrome.tabs.onReplaced) {
+    chrome.tabs.onReplaced.addListener((addedTabId, removedTabId) => {
+      clearEmulation(removedTabId);
+      clearEmulation(addedTabId);
+    });
   }
 } catch (e) { /* bare unit-test global with no chrome.tabs — nothing to hook */ }
 
@@ -534,6 +550,18 @@ function assertWakeNotFramed(cmd, isWakeOp) {
 // session, so the visibilityState to report is the one the PROBE saw there — not a
 // separate chrome.scripting probe of the (already re-throttled) tab. `woke` is
 // true when the probe confirms the page was actually un-throttled during the read.
+// Annotate a READ result with whether it actually observed the EMULATED page.
+//
+// `viaCdp` is passed per CALL SITE, not inferred from the op, because that is
+// genuinely where the answer lives: `text --wake` and `eval --frame` route through
+// withCdp (→ emulated), while the default `text`/`html`/`eval` take
+// chrome.scripting (→ NOT emulated). Same op, different answer, depending on a
+// flag — which is exactly why the envelope has to say so rather than leaving the
+// caller to know this file's routing table. See NOT_EMULATED_READ_NOTE.
+function emuAnnotate(data, tabId, viaCdp) {
+  return annotateEmulatedRead(data, emulationSummary(emulationFor(tabId)), viaCdp);
+}
+
 function wakeAnnotate(data, w) {
   const vis = w && w.probe ? w.probe.visibilityState : null;
   annotateVisibility(data, vis);
@@ -557,8 +585,10 @@ const OPS = {
       const html = await execInFrame(tab.id, frame.frameId, frameReadHtmlFn, []);
       // Report the FRAME's own url (not the top tab url) so the caller can confirm it
       // read the intended frame (#190 reported the top url for a frame read).
-      return annotateVisibility(
-        { url: frame.url || tab.url, title: tab.title, html, frame: cmd.frame }, vis);
+      // chrome.scripting into the frame: NO CDP -> the REAL, un-emulated DOM.
+      return emuAnnotate(annotateVisibility(
+        { url: frame.url || tab.url, title: tab.title, html, frame: cmd.frame }, vis),
+        tab.id, false);
     }
     // --wake → un-throttle the tab and read INSIDE the same CDP session (the
     // un-throttled state does not survive detach — see protocol.js `wake`). This
@@ -579,7 +609,9 @@ const OPS = {
         });
         return inj ? inj.result : undefined;
       });
-      return wakeAnnotate({ url: tab.url, title: tab.title, html: w.value }, w);
+      return emuAnnotate(
+        wakeAnnotate({ url: tab.url, title: tab.title, html: w.value }, w),
+        tab.id, true);   // cdpWake -> withCdp -> emulation WAS applied
     }
     // No frame → the lighter chrome.scripting top-frame read (no debugger banner).
     const vis = await tabVisibilityState(tab.id);
@@ -587,7 +619,9 @@ const OPS = {
       target: { tabId: tab.id },
       func: () => document.documentElement.outerHTML,
     });
-    return annotateVisibility({ url: tab.url, title: tab.title, html: inj.result }, vis);
+    return emuAnnotate(
+      annotateVisibility({ url: tab.url, title: tab.title, html: inj.result }, vis),
+      tab.id, false);   // chrome.scripting: NO CDP -> the REAL, un-emulated DOM
   },
 
   // Cheap read: the tab's VISIBLE innerText (optionally scoped to a CSS
@@ -609,8 +643,10 @@ const OPS = {
       const raw = await execInFrame(tab.id, frame.frameId, frameReadTextFn, [sel]);
       const { text, truncated } = normalizeText(raw, cap);
       // Report the FRAME's own url (see getHtml) so the caller confirms the right frame.
-      return annotateVisibility(
-        { url: frame.url || tab.url, title: tab.title, text, truncated, frame: cmd.frame }, vis);
+      // chrome.scripting into the frame: NO CDP -> the REAL, un-emulated DOM.
+      return emuAnnotate(annotateVisibility(
+        { url: frame.url || tab.url, title: tab.title, text, truncated, frame: cmd.frame },
+        vis), tab.id, false);
     }
     // --wake → un-throttle + read in ONE CDP session (opt-in; see getHtml).
     if (cmd && cmd.wake) {
@@ -628,7 +664,9 @@ const OPS = {
         return inj ? inj.result : undefined;
       });
       const { text, truncated } = normalizeText(w.value, cap);
-      return wakeAnnotate({ url: tab.url, title: tab.title, text, truncated }, w);
+      return emuAnnotate(
+        wakeAnnotate({ url: tab.url, title: tab.title, text, truncated }, w),
+        tab.id, true);   // cdpWake -> withCdp -> emulation WAS applied
     }
     const vis = await tabVisibilityState(tab.id);
     const [inj] = await chrome.scripting.executeScript({
@@ -640,7 +678,9 @@ const OPS = {
       },
     });
     const { text, truncated } = normalizeText(inj.result, cap);
-    return annotateVisibility({ url: tab.url, title: tab.title, text, truncated }, vis);
+    return emuAnnotate(
+      annotateVisibility({ url: tab.url, title: tab.title, text, truncated }, vis),
+      tab.id, false);   // chrome.scripting: NO CDP -> the REAL, un-emulated DOM
   },
 
   async eval(cmd) {
@@ -659,7 +699,9 @@ const OPS = {
       // via CDP (the #190 fix), so this probe does not regress the eval mechanism.
       const vis = await tabVisibilityState(tab.id);
       const value = await cdpFrameEval(tab.id, tab.url, frame, cmd.js);
-      return annotateVisibility({ url: frame.url || tab.url, value, frame: cmd.frame }, vis);
+      return emuAnnotate(
+        annotateVisibility({ url: frame.url || tab.url, value, frame: cmd.frame }, vis),
+        tab.id, true);   // cdpFrameEval -> withCdp -> emulation WAS applied
     }
     // --wake → un-throttle + evaluate in ONE CDP session (opt-in; see getHtml).
     // Uses the SAME expression/statement pair + never-silent-null contract as
@@ -685,7 +727,8 @@ const OPS = {
         }
         return evalValueOrThrow(res);
       });
-      return wakeAnnotate({ url: tab.url, value: w.value }, w);
+      return emuAnnotate(wakeAnnotate({ url: tab.url, value: w.value }, w),
+                         tab.id, true);   // cdpWake -> withCdp -> emulated
     }
     const vis = await tabVisibilityState(tab.id);
     // chrome.scripting runs the top-frame eval in the page's MAIN world (world:
@@ -717,7 +760,9 @@ const OPS = {
         return fn();
       },
     });
-    return annotateVisibility({ url: tab.url, value: inj.result }, vis);
+    return emuAnnotate(
+      annotateVisibility({ url: tab.url, value: inj.result }, vis),
+      tab.id, false);   // chrome.scripting MAIN world: NO CDP -> un-emulated
   },
 
   // Each tab additionally carries `emulation` when this service worker holds a

--- a/scripts/browser-bridge/reference/emulation.md
+++ b/scripts/browser-bridge/reference/emulation.md
@@ -21,6 +21,10 @@ browser emulate --reset
 
 `browser emulate --list` prints the preset names without touching the browser.
 
+🔴 **Before you trust a `text`/`html`/`js` read on an emulated tab, read
+"`text` / `html` / `js` do NOT read the emulated page" below.** Those three ops
+return the REAL desktop DOM; `--wake` is what reads the emulated one.
+
 ---
 
 ## Why it is sticky, and the safety property that buys
@@ -83,7 +87,8 @@ not yours" (drop the `--tab`).
 | `iphone-15` | 393 × 852 | 3 | 5 pts | iOS 17 Safari · `iOS` |
 | `iphone-se` | 375 × 667 | 2 | 5 pts | iOS 17 Safari · `iOS` |
 | `pixel-8` | 412 × 915 | 2.625 | 5 pts | Chrome 126 Android · `Android` |
-| `ipad-mini` | 768 × 1024 | 2 | 5 pts | iPadOS 17 Safari · `iOS` |
+| `ipad-mini` | 744 × 1133 | 2 | 5 pts | iPadOS 17 Safari · `iOS` |
+| `ipad-mini-2019` | 768 × 1024 | 2 | 5 pts | iPadOS 17 Safari · `iOS` |
 | `galaxy-s24` | 360 × 780 | 3 | 5 pts | Chrome 126 Android · `Android` |
 
 **Provenance, stated honestly.** These are the vendors' published *logical*
@@ -116,9 +121,13 @@ Flags: `--width --height --dsf --mobile/--no-mobile --touch/--no-touch
 --color-scheme light|dark|no-preference --geo LAT,LON[,ACC] --tz ZONE --reset
 --list`.
 
-**⚠ A raw `--ua` gets GENERIC UA-Client-Hints metadata**, not a faithful
-per-device one — enough that a site never sees your real desktop brands, but not a
-convincing individual device. Use a preset when the UA actually matters.
+**⚠ A raw `--ua` gets MINIMAL UA-Client-Hints metadata**, not a faithful
+per-device one. `platform`/`model` are **derived from the UA string** (an iPhone UA
+gets `platform: "iOS"`, never `"Android"`), and `brands` is left **empty** — there
+is no basis to claim a Chromium version from an arbitrary string, and a wrong brand
+list is a stronger bot-detection signal than none. Where the UA names no platform
+we recognise, `platform` stays `""` rather than being guessed. Use a **preset** when
+the UA actually matters.
 
 ---
 
@@ -135,6 +144,53 @@ Apple presets carry `brands: []` **on purpose**: Safari does not implement UA-CH
 and sends no `Sec-CH-UA` at all. That is correct emulation, not a missing field.
 
 ---
+
+## 🔴 `text` / `html` / `js` do NOT read the emulated page
+
+**The single most important thing on this page.** Read it before you trust a read.
+
+`text`, `html` and the default `js`/`eval` go through `chrome.scripting`, which
+**never attaches the debugger** — so the emulation is never applied and they return
+the tab's **real, un-emulated DOM**. `innerWidth`, `getBoundingClientRect`,
+`matchMedia` and `navigator.userAgent` all come back **desktop**.
+
+That is correct-by-design, not a bug: between ops the tab genuinely is not emulated
+(see the safety property above), so the at-rest DOM really *is* desktop. But it is
+the trap this feature is most likely to spring — screenshot a phone layout, then
+read `text` and reason about a desktop DOM.
+
+**Which reads are emulated:**
+
+| read | path | emulated? |
+|---|---|---|
+| `text` / `html` / `js` | `chrome.scripting` | ❌ **no** |
+| `text --frame` / `html --frame` | `chrome.scripting` | ❌ **no** |
+| `text --wake` / `html --wake` / `js --wake` | CDP (`cdpWake` → `withCdp`) | ✅ yes |
+| `js --frame` | CDP (`cdpFrameEval` → `withCdp`) | ✅ yes |
+| `screenshot`, `click`, `nav`, `wake`, `upload` | CDP | ✅ yes |
+
+**The envelope tells you which one you got.** On a tab that has emulation state,
+every read carries either:
+
+```jsonc
+{ "emulated": false, "notEmulatedRead": true,
+  "emulationNote": "…read the tab's REAL, un-emulated DOM … Re-run with --wake …" }
+// or
+{ "emulated": true, "emulation": { "preset": "iphone-15", "width": 393, … } }
+```
+
+A tab with **no** emulation state gets neither field, so ordinary envelopes are
+unchanged.
+
+**So to measure the emulated viewport, use `--wake`:**
+
+```bash
+browser js --wake 'innerWidth+"x"+innerHeight'    # → 393x852
+browser js 'innerWidth+"x"+innerHeight'           # → the REAL window size
+```
+
+Same command, two answers, depending on the flag. That is why the annotation
+exists.
 
 ## What emulation changes about other ops
 
@@ -205,9 +261,21 @@ device, and the device does not interfere with the wake.
 | `unknown_op` | the loaded extension predates 0.5.0 → `errors.md` |
 
 A **failed apply is loud, never partial**: no emulation step is optional, because a
-half-applied emulation returns a plausible screenshot of the wrong thing. If a step
-fails, the op fails with a normal error envelope and the emulation state is rolled
-back, so later ops do not silently retry something you were told had failed.
+half-applied emulation returns a plausible screenshot of the wrong thing. A failing
+step fails the op with a normal error envelope, and the debugger is still released.
+
+What happens to the stored state depends on **which** apply failed, and the
+distinction matters:
+
+* **The initial `emulate` apply** — the state is **rolled back** (to the previous
+  emulation, or to none). You were told it failed, so nothing later re-attempts it.
+* **A sticky re-apply inside a later op** (`screenshot`, `click`, …) — the state is
+  **retained** and the *next* op will try again. That is deliberate: a transient
+  failure (a renderer briefly busy, a navigation in flight) should not silently
+  un-emulate a tab you asked to be emulated. The cost is that a *persistently*
+  failing override fails every subsequent op with the same error until you
+  `--reset`, rather than degrading to un-emulated — which is the safer direction,
+  since degrading silently is how you get a desktop screenshot labelled as a phone.
 
 ---
 

--- a/scripts/browser-bridge/reference/emulation.md
+++ b/scripts/browser-bridge/reference/emulation.md
@@ -1,0 +1,235 @@
+# `emulate` — device emulation for real mobile testing
+
+Read this when you need to test a page as a phone/tablet, or when you hit
+`not_owned_tab`, `unknown_preset:*`, `invalid_emulation:*`, or
+`emulate_needs_device_or_params`.
+
+Requires extension **0.5.0+**. On an older build the op fails with `unknown_op`
+(see `errors.md` — a reload ↻ is unreliable, it needs a FULL Brave restart).
+
+---
+
+## The 30-second version
+
+```bash
+browser open https://example.com     # emulation is OWNED-TAB-ONLY
+browser emulate iphone-15
+browser screenshot                   # ← captured at 393×852 @3x, as an iPhone
+browser click '#menu'                # ← dispatched as a TOUCH tap
+browser emulate --reset
+```
+
+`browser emulate --list` prints the preset names without touching the browser.
+
+---
+
+## Why it is sticky, and the safety property that buys
+
+CDP emulation overrides are **session-scoped**: they die the instant the debugger
+detaches. The bridge **always** detaches (`withCdpSession`'s `finally` — that is a
+load-bearing invariant; a leaked attachment is a stuck banner plus an open
+surface). So a naive `emulate` would set a viewport that had already evaporated
+before the next command ran.
+
+Instead, `emulate` **stores** the device state per tab, and **every op that
+attaches CDP re-applies it inside its own session, before doing its work.**
+
+✅ **The property this buys, and the reason this design beat holding one long-lived
+session open: between ops the tab is NOT emulated.** A crashed agent, a killed
+Claude session, or an evicted MV3 service worker cannot leave the operator's real
+browser distorted. The worst case is a forgotten entry in an in-memory Map that
+dies with the worker — not a Brave tab stuck pretending to be an iPhone with
+nothing left running that knows how to undo it.
+
+That is also why `--reset` has nothing to undo. It means **"stop re-applying"**;
+the overrides are already gone.
+
+**Consequence to plan around:** a page that re-measures the viewport *later* — on
+a `resize` listener, or well after load — sees the real window until your next op
+re-applies. Drive the page with bridge ops rather than expecting the emulation to
+persist while you sit idle.
+
+---
+
+## Blast radius: owned tabs only
+
+Only a tab **this session opened via `browser open`** may be emulated. Anything
+else is refused server-side with `not_owned_tab`, and the command never reaches
+the browser.
+
+| you did | result |
+|---|---|
+| `browser open` then `browser emulate iphone-15` | ✅ |
+| `browser emulate iphone-15` with no `open` | ❌ `not_owned_tab` |
+| `browser --tab 999 emulate iphone-15` (999 isn't yours) | ❌ `not_owned_tab` |
+| `browser --tab <your own tab id> emulate …` | ✅ (same tab) |
+
+Every *other* tab-scoped op falls back to "the active tab" when you own nothing —
+that is the useful one-shot read path, and a read is harmless. `emulate` is not:
+it resizes the viewport, rewrites the user agent and turns the mouse into a
+finger. Applied to the tab the human is looking at, an agent would be reshaping
+the operator's browser. So the fallback is removed for this op specifically.
+
+`not_owned_tab` is deliberately **distinct** from `no_owned_tab`: the latter means
+"you have nothing to act on" (run `browser open`), the former means "that tab is
+not yours" (drop the `--tab`).
+
+---
+
+## The preset table
+
+| preset | CSS viewport | dsf | touch | UA / UA-CH platform |
+|---|---|---|---|---|
+| `iphone-15` | 393 × 852 | 3 | 5 pts | iOS 17 Safari · `iOS` |
+| `iphone-se` | 375 × 667 | 2 | 5 pts | iOS 17 Safari · `iOS` |
+| `pixel-8` | 412 × 915 | 2.625 | 5 pts | Chrome 126 Android · `Android` |
+| `ipad-mini` | 768 × 1024 | 2 | 5 pts | iPadOS 17 Safari · `iOS` |
+| `galaxy-s24` | 360 × 780 | 3 | 5 pts | Chrome 126 Android · `Android` |
+
+**Provenance, stated honestly.** These are the vendors' published *logical*
+resolutions — the same figures Chrome DevTools' device list
+(`front_end/models/emulation/EmulatedDevices.ts`) uses. Each preset carries a
+`source` string in `extension/protocol.js` naming where its numbers came from, and
+a test asserts `physical ÷ dsf ≈ the CSS viewport` so a transcription error in
+either number fails CI.
+
+⚠ They were **not verified against a live DevTools device list** — the change was
+built deliberately without touching live Brave. Treat them as "the published
+logical resolution", which is what matters for layout testing, not as "byte-equal
+to whatever DevTools ships this month". **If a preset ever disagrees with
+DevTools, DevTools wins** — fix `DEVICE_PRESETS` and say so.
+
+### Raw overrides
+
+For anything not in the table, or to tweak a preset:
+
+```bash
+browser emulate --width 412 --height 883 --dsf 2.75 --mobile --touch
+browser emulate iphone-15 --orientation landscape      # swaps W/H, not just the angle
+browser emulate pixel-8 --color-scheme dark --tz Europe/London
+browser emulate iphone-15 --geo 51.5074,-0.1278        # LAT,LON[,ACCURACY]
+browser emulate --width 390 --height 844 --ua 'Mozilla/5.0 (custom) Mobile'
+```
+
+Flags: `--width --height --dsf --mobile/--no-mobile --touch/--no-touch
+--max-touch-points N --ua STR --orientation portrait|landscape
+--color-scheme light|dark|no-preference --geo LAT,LON[,ACC] --tz ZONE --reset
+--list`.
+
+**⚠ A raw `--ua` gets GENERIC UA-Client-Hints metadata**, not a faithful
+per-device one — enough that a site never sees your real desktop brands, but not a
+convincing individual device. Use a preset when the UA actually matters.
+
+---
+
+## The user-agent half everyone misses
+
+`emulate` always sets **both** `userAgent` **and** `userAgentMetadata`.
+
+Modern sites read `navigator.userAgentData` (UA-Client-Hints) in preference to the
+UA string. Setting only the string leaves a page seeing an iPhone UA next to the
+operator's real desktop Linux Chrome brands — a combination no real client ever
+produces, which trips bot detection on exactly the sites worth testing.
+
+Apple presets carry `brands: []` **on purpose**: Safari does not implement UA-CH
+and sends no `Sec-CH-UA` at all. That is correct emulation, not a missing field.
+
+---
+
+## What emulation changes about other ops
+
+### `screenshot` — the fast path is disabled
+
+`screenshot` normally takes a cheap, banner-free `chrome.tabs.captureVisibleTab`
+path when the tab is foreground and you did not pass `--fullpage`. That call
+**never attaches the debugger**, so on an emulated tab it would return a perfectly
+valid PNG of the **un-emulated desktop layout** — a confident wrong answer,
+indistinguishable from a correct one, on the single op whose whole job is showing
+what the device sees.
+
+So while a tab is emulated, `screenshot` is **forced onto the CDP path**
+(`via: "cdp"`, and the result carries an `emulation` summary). You get a debugger
+banner; you also get the right picture. `--fullpage` clips using the **emulated**
+layout metrics, because the metrics are read after the overrides land.
+
+### `click` — dispatches TOUCH
+
+On a touch-emulated tab, a top-frame `click` dispatches
+`Input.dispatchTouchEvent` (touchStart/touchEnd) instead of mouse events —
+exactly what DevTools does. The result reports `via: "touch"`.
+
+This is not cosmetic. Chromium synthesizes compatibility *mouse* events from
+touch, but never touch events from mouse, so a mobile UI whose handler is
+`touchstart` (or a library binding pointer events with `pointerType === "touch"`)
+simply never fires under a mouse click — the tap "does nothing" and you report a
+broken page that is not broken.
+
+Mouse remains the behaviour on every non-touch-emulated tab, and
+`--no-touch` restores it (`via: "mouse"`).
+
+### `nav` — navigates via CDP
+
+On an emulated tab, `nav` uses CDP `Page.navigate` **inside** the session that has
+already applied the overrides, instead of `chrome.tabs.update`. A page that sniffs
+the UA or measures the viewport at load time must see the emulated values *at
+navigation* — otherwise a UA-sniffing site has already served you the desktop
+bundle. The result reports `via: "cdp"`.
+
+### `tabs` — surfaces emulated tabs
+
+Emulated tabs carry an `emulation` summary in the listing, and the top-level
+`emulatedTabs` array lists their ids. A stuck override is then visible rather than
+mysterious.
+
+### `wake` — composes cleanly
+
+`wake` on an emulated tab re-applies the emulation *before* its own focus-emulation
+steps, and its teardown only disables **focus** emulation. Waking does not undo the
+device, and the device does not interfere with the wake.
+
+---
+
+## Errors
+
+| error | meaning |
+|---|---|
+| `not_owned_tab` | the target tab isn't one this session `open`ed — see the blast-radius table above |
+| `unknown_preset:<name>` | not in `DEVICE_PRESETS`; `browser emulate --list` |
+| `emulate_needs_device_or_params` | you passed neither a preset nor any override |
+| `invalid_emulation:width` / `:height` / `:dsf` / `:maxTouchPoints` | out of range (1–10000 px, 0.1–10 dsf, 1–16 touch points) |
+| `invalid_emulation:width_and_height_together` | one dimension alone — CDP takes both or neither, and guessing the other from the real window would make the result depend on your window size |
+| `invalid_emulation:reset_with_params` | `--reset` combined with a device description |
+| `invalid_emulation:ua` | empty, >1024 chars, or containing control characters. **CR/LF is refused, never stripped** — the UA is echoed into a request header, so that is a header-injection primitive |
+| `invalid_emulation:tz` / `:colorScheme` / `:orientation` / `:geo.*` | bad value; see the flag list above |
+| `max_touch_points_without_touch` | `--max-touch-points` with `--no-touch` |
+| `unknown_op` | the loaded extension predates 0.5.0 → `errors.md` |
+
+A **failed apply is loud, never partial**: no emulation step is optional, because a
+half-applied emulation returns a plausible screenshot of the wrong thing. If a step
+fails, the op fails with a normal error envelope and the emulation state is rolled
+back, so later ops do not silently retry something you were told had failed.
+
+---
+
+## Telemetry
+
+`emulate` emits the usual metadata-only `activity.events` row plus the preset name
+and viewport (`emu_device`, `emu_width`, `emu_height`, `emu_mobile`, `emu_touch`,
+`emu_geo`, `emu_reset`).
+
+Deliberately **excluded**: the UA string (long, operator-supplied free text; the
+preset name identifies it anyway) and the geolocation **coordinates** — an emulated
+lat/lon is a place the operator chose to pretend to be, and only its *presence* is
+recorded. No URL, no page content, as everywhere else.
+
+---
+
+## Not available to the autonomous agent
+
+`emulate` is **operator-only**: it is absent from `ALLOWED_OPS_DEFAULT` and
+`OP_TO_SERVER` in `opencode/tools/browser_tool_impl.mjs`, so `browser agent`
+cannot reach it even via `BROWSER_AGENT_ALLOWED_OPS`. The agent's op set is
+deliberately minimal and widening it is a separate decision. Adding it would mean
+mapping `emulate → emulate` in `OP_TO_SERVER` and listing it in
+`ALLOWED_OPS_DEFAULT`; the ownership gate already confines it to the agent's own
+tab, so the question is scope discipline, not safety.

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -134,9 +134,17 @@ from urllib.parse import unquote, urlsplit
 # a no-tab, no-page op whose only job is to be a NAME an older build does not
 # know, so probing it answers "is the new build loaded?" with unknown_op vs a
 # version — instead of two version strings a human has to eyeball.
+# `emulate` puts the SESSION'S OWN tab into device emulation (viewport +
+# deviceScaleFactor, touch, mobile UA including UA-Client-Hints metadata, and
+# media/geolocation/timezone) for real mobile testing. The overrides are
+# re-applied by the extension inside every subsequent CDP session because CDP
+# emulation dies at debugger detach — which is also why a crashed agent cannot
+# leave the operator's browser distorted (see extension/protocol.js EMULATION).
+# It is OWNED-TAB-ONLY (below): an agent must never be able to resize a tab the
+# operator is using.
 ALLOWED_OPS = ("getHtml", "text", "eval", "tabs", "nav", "screenshot",
                "open", "close", "frames", "click", "type", "key", "wake",
-               "activate", "upload", "ping")
+               "activate", "upload", "ping", "emulate")
 
 # Ops handled ENTIRELY server-side (never dispatched to the extension). `release`
 # relinquishes a session's owned-tab mapping without touching the real Brave tab.
@@ -148,7 +156,23 @@ SERVER_OPS = ("release",)
 # and `release` (server-side) do NOT contend for a single tab.
 TAB_SCOPED_OPS = frozenset({"getHtml", "text", "eval", "nav", "screenshot",
                             "close", "frames", "click", "type", "key",
-                            "wake", "activate", "upload"})
+                            "wake", "activate", "upload", "emulate"})
+
+# Ops that may run ONLY against a tab the calling session OWNS (opened via `open`).
+# This is the emulation blast-radius rule, enforced at the one place that knows who
+# owns what.
+#
+# Every other tab-scoped op degrades gracefully to "the active tab" when the session
+# owns nothing — that is the useful one-shot "read the tab I have open" path, and a
+# read is inherently safe. `emulate` is NOT safe that way: it resizes the viewport,
+# rewrites the user agent and turns the mouse into a finger. Applied to the tab the
+# OPERATOR is looking at, an agent would be reshaping the human's browser. So the
+# fallback is removed for it: no owned tab (or a `--tab` pointing anywhere else)
+# → a named `not_owned_tab` refusal, never a guess.
+#
+# Kept as a SET rather than an `if op == "emulate"` because the next op with this
+# property must land here and not grow a second copy of the predicate.
+OWNED_TAB_ONLY_OPS = frozenset({"emulate"})
 
 # Per-op required fields (skill-supplied). Absent → 400 bad_request. NOTE: `close`
 # takes NO skill-supplied field — the server injects the caller's owned tabId (or
@@ -592,6 +616,37 @@ def _session_hash(session_id) -> str:
     return hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:8]
 
 
+def _emulate_extra(body) -> dict:
+    """METADATA-ONLY telemetry fields for an `emulate` command.
+
+    Deliberately narrow, and the exclusions are the interesting part:
+      * the UA STRING is not emitted — it is long, operator-supplied free text, and
+        the preset name already identifies it for every non-raw call;
+      * geolocation COORDINATES are not emitted — an emulated lat/lon is a location
+        the operator chose to pretend to be at, which is not the bridge's business
+        to record. Only whether one was set.
+      * no URL, no title, no page content (the generic contract for every event).
+    What IS emitted is what makes a stuck override diagnosable later: the preset
+    name and the viewport.
+    """
+    if not isinstance(body, dict):
+        return {}
+    if body.get("reset"):
+        return {"emu_reset": True}
+    out = {"emu_device": body.get("device") or "raw"}
+    for src, dst in (("width", "emu_width"), ("height", "emu_height"),
+                     ("dsf", "emu_dsf")):
+        v = body.get(src)
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
+            out[dst] = v
+    for src, dst in (("mobile", "emu_mobile"), ("touch", "emu_touch")):
+        v = body.get(src)
+        if isinstance(v, bool):
+            out[dst] = v
+    out["emu_geo"] = bool(body.get("geo"))
+    return out
+
+
 def emit_cmd_event(op: str, key: str, outcome: str, duration_ms: int,
                    domain: str = "", exit_code: int = 0, extra: dict = None) -> None:
     """Append ONE metadata-only activity event for a handled command.
@@ -702,6 +757,17 @@ class BridgeSuperseded(Exception):
 class NoOwnedTab(Exception):
     """A `close` was issued by a session that owns no tab on the target instance
     (and gave no explicit --tab). Nothing to close → a clear error, not a guess."""
+
+
+class NotOwnedTab(Exception):
+    """An OWNED_TAB_ONLY_OPS op (today: `emulate`) targeted a tab this session does
+    not own — it owns none at all, or `--tab` named a different one.
+
+    DISTINCT from NoOwnedTab on purpose. NoOwnedTab means "you have nothing to act
+    on"; this means "that tab is not yours", which is a refusal with a security
+    reason behind it and deserves its own name in the logs, the HTTP body and the
+    CLI's guidance. Collapsing the two would tell an operator to run `browser open`
+    when the real problem is that they pointed `--tab` at their own window."""
 
 
 class RateLimited(Exception):
@@ -904,6 +970,11 @@ class Registry:
         resolved = tab if tab is not None else owned
         if op == "close" and resolved is None:
             raise NoOwnedTab()
+        # Blast-radius gate for OWNED_TAB_ONLY_OPS. The session must own a tab AND
+        # the resolved target must BE that tab — so an explicit `--tab <id>` cannot
+        # be used to reach around ownership onto one of the operator's own tabs.
+        if op in OWNED_TAB_ONLY_OPS and (owned is None or resolved != owned):
+            raise NotOwnedTab()
         # Active-tab ops with no concrete tab still share ONE physical tab per
         # instance, so they serialize under a synthetic "active" key.
         tab_key = (inst.key, resolved if resolved is not None else "active")
@@ -1033,6 +1104,8 @@ class Registry:
 
         Raises NoExtension / AmbiguousInstance / UnknownInstance if the target
         cannot be resolved, NoOwnedTab for a `close` with nothing to close,
+        NotOwnedTab for an OWNED_TAB_ONLY_OPS op (`emulate`) aimed at a tab this
+        session does not own,
         BridgeSuperseded if the servicing instance is dropped mid-flight, or
         BridgeTimeout on no reply within `timeout` (the upper bound that keeps a
         FIFO-queued command from blocking forever).
@@ -1823,6 +1896,9 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
             # it is acceptable and required for traceability of this exfil-capable
             # action. `body` still carries it (target/tab are popped, path is not).
             upload_path = body.get("path") if op == "upload" else None
+            # Captured BEFORE submit so the fields are still present regardless of
+            # which path (ok / refused / throttled) the request takes below.
+            emulate_extra = _emulate_extra(body) if op == "emulate" else None
             outcome, exit_code, domain = "ok", 0, ""
             # `release` is server-side: drop the session's ownership without ever
             # touching the real Brave tab or the extension.
@@ -1851,6 +1927,8 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                 self._send(429, {"ok": False, "error": e.reason,
                                  "retry_after": round(e.retry_after, 3)})
                 extra = {"reason": e.reason, "sess": sess}
+                if emulate_extra:
+                    extra.update(emulate_extra)
                 if op == "upload":
                     # AUDIT even a throttled upload attempt (it never reached the
                     # browser, so no file was read — but the attempt is traceable).
@@ -1866,6 +1944,13 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                 outcome, exit_code = "no_owned_tab", 1
                 log("cmd_no_owned_tab", op=op)
                 self._send(409, {"ok": False, "error": "no_owned_tab"})
+            except NotOwnedTab:
+                # The blast-radius refusal for OWNED_TAB_ONLY_OPS. Never reached the
+                # extension, so nothing was emulated — the operator's tab is
+                # untouched, which is the entire point of the gate.
+                outcome, exit_code = "not_owned_tab", 1
+                log("cmd_not_owned_tab", op=op)
+                self._send(409, {"ok": False, "error": "not_owned_tab"})
             except NoExtension:
                 outcome, exit_code = "no_extension", 1
                 log("cmd_no_extension", op=op)
@@ -1919,13 +2004,13 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
             # `upload` additionally carries the file PATH (audit metadata) + a
             # dedicated structured log line — this op is exfil-capable so EVERY
             # outcome is traceable (the path is local metadata, never file content).
-            upload_extra = {"path": upload_path} if op == "upload" else None
+            extra = {"path": upload_path} if op == "upload" else emulate_extra
             if op == "upload":
                 log("upload", outcome=outcome, domain=domain, path=upload_path,
                     key=(target or ""))
             emit_cmd_event(op=op, key=(target or ""), outcome=outcome,
                            duration_ms=int((time.monotonic() - t0) * 1000),
-                           domain=domain, exit_code=exit_code, extra=upload_extra)
+                           domain=domain, exit_code=exit_code, extra=extra)
 
         def _handle_result(self):
             body, err = self._read_body(MAX_RESULT_BODY)

--- a/scripts/browser-bridge/tests/emulation.test.mjs
+++ b/scripts/browser-bridge/tests/emulation.test.mjs
@@ -398,7 +398,10 @@ const sw = {
   events: [],              // ordered "attach"/"detach" + method names
   tabs: new Map(),
   gone: new Set(),         // tabIds chrome.tabs.get must reject for
+  frames: [],              // chrome.webNavigation.getAllFrames result
+  frameTree: null,         // CDP Page.getFrameTree result (same-process --frame)
   removedListeners: [],
+  replacedListeners: [],
   tabsUpdate: [],
   tabsRemove: [],
   layoutMetrics: { cssContentSize: { width: 393, height: 4200 } },
@@ -415,6 +418,8 @@ function resetSw() {
   sw.tabsRemove = [];
   sw.failMethod = null;
   sw.hangMethod = null;
+  sw.frames = [];
+  sw.frameTree = null;
   sw.tabs = new Map([
     [TAB_A, { id: TAB_A, url: "https://example.com/a", title: "A",
               active: true, status: "complete", windowId: 1 }],
@@ -427,7 +432,7 @@ resetSw();
 globalThis.BROWSER_BRIDGE_NO_AUTOSTART = true;
 globalThis.BROWSER_BRIDGE_ACTIVATE_TIMING = { settleMs: 0, pollMs: 1 };
 globalThis.chrome = {
-  webNavigation: { async getAllFrames() { return []; } },
+  webNavigation: { async getAllFrames() { return sw.frames; } },
   scripting: {
     async executeScript() { return [{ result: { visibilityState: "visible" } }]; },
   },
@@ -446,6 +451,7 @@ globalThis.chrome = {
     async update(id, props) { sw.tabsUpdate.push({ id, props }); return sw.tabs.get(id); },
     async remove(id) { sw.tabsRemove.push(id); sw.gone.add(id); sw.tabs.delete(id); },
     onRemoved: { addListener(fn) { sw.removedListeners.push(fn); } },
+    onReplaced: { addListener(fn) { sw.replacedListeners.push(fn); } },
   },
   windows: { async update() {} },
   debugger: {
@@ -461,6 +467,8 @@ globalThis.chrome = {
       if (sw.failMethod === method) throw new Error(`cdp_failed:${method}`);
       if (method === "Page.captureScreenshot") return { data: "QkJCQg==" };
       if (method === "Page.getLayoutMetrics") return sw.layoutMetrics;
+      if (method === "Page.getFrameTree") return { frameTree: sw.frameTree };
+      if (method === "Page.createIsolatedWorld") return { executionContextId: 42 };
       if (method === "Runtime.evaluate") {
         return { result: { value: sw.elementRect } };
       }
@@ -717,7 +725,8 @@ test("ISOLATION: emulating tab A never touches tab B", async () => {
     "tab A must still be the iPhone, not the iPad");
   sw.cdp = [];
   await OPS.screenshot({ tabId: TAB_B, fullpage: true });
-  assert.equal(paramsOf("Emulation.setDeviceMetricsOverride").width, 768);
+  assert.equal(paramsOf("Emulation.setDeviceMetricsOverride").width,
+    DEVICE_PRESETS["ipad-mini"].width);
 });
 
 test("`tabs` SURFACES emulated tabs (a stuck override is visible, not mysterious)", async () => {
@@ -833,6 +842,153 @@ test("NO-WEDGE: a HUNG emulation step is bounded like any other CDP command", as
     delete globalThis.BROWSER_BRIDGE_CDP_TIMEOUTS;
     sw.hangMethod = null;
   }
+});
+
+// --------------------------------------------------------------------------- //
+// F1: the NON-CDP read path is NOT emulated — and must say so
+//
+// `text`/`html`/`js` take the chrome.scripting path, which never attaches the
+// debugger, so withCdp's re-application choke point never runs. The DOM they read
+// is the tab's real, un-emulated one. That is correct-by-design (between ops the
+// tab genuinely is not emulated) but it is a TRAP: an agent screenshots a phone
+// layout, then reads `text` and reasons about the DESKTOP DOM. So the envelope has
+// to say which one it got.
+// --------------------------------------------------------------------------- //
+
+test("F1 REPRODUCTION: a default text/html/js read of an emulated tab issues ZERO CDP calls", async () => {
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  for (const op of ["text", "getHtml", "eval"]) {
+    sw.cdp = []; sw.events = [];
+    await OPS[op]({ tabId: TAB_A, js: "1" });
+    assert.deepEqual(sw.cdp, [],
+      `${op} took the chrome.scripting path — no CDP, so NO emulation was applied`);
+    assert.ok(!sw.events.includes("attach"), `${op} must not attach the debugger`);
+  }
+});
+
+test("F1: a NON-emulated read of an emulated tab is annotated `emulated:false` + a note", async () => {
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  for (const [op, cmd] of [["text", {}], ["getHtml", {}], ["eval", { js: "1" }]]) {
+    const out = await OPS[op]({ tabId: TAB_A, ...cmd });
+    assert.equal(out.emulated, false,
+      `${op} read the un-emulated DOM and must say so`);
+    assert.equal(out.notEmulatedRead, true);
+    assert.match(out.emulationNote, /--wake/,
+      "the note must name the remedy, like HIDDEN_TAB_NOTE does");
+    assert.match(out.emulationNote, /real|un-emulated/i);
+  }
+});
+
+test("F1: a CDP read (--wake) of an emulated tab is annotated `emulated:true`", async () => {
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  for (const [op, cmd] of [["text", {}], ["getHtml", {}], ["eval", { js: "1" }]]) {
+    const out = await OPS[op]({ tabId: TAB_A, wake: true, waitMs: 0, ...cmd });
+    assert.equal(out.emulated, true, `${op} --wake reads inside an emulated session`);
+    assert.equal(out.notEmulatedRead, undefined);
+    assert.equal(out.emulation.preset, "iphone-15");
+  }
+});
+
+test("F1: `eval --frame` goes through CDP, so it IS emulated", async () => {
+  // A SAME-PROCESS frame (resolved via Page.getFrameTree → createIsolatedWorld) —
+  // the cheapest path that still proves `eval --frame` routes through withCdp. The
+  // cross-origin OOPIF cascade is exercised in frame_oopif.test.mjs; replicating
+  // its auto-attach event machinery here would test the mock, not the annotation.
+  fresh();
+  const FRAME_URL = "https://example.com/a/inner";
+  sw.frames = [{ frameId: 0, parentFrameId: -1, url: "https://example.com/a" },
+               { frameId: 3, parentFrameId: 0, url: FRAME_URL }];
+  sw.frameTree = {
+    frame: { id: "TOPF", url: "https://example.com/a" },
+    childFrames: [{ frame: { id: "SUBF", url: FRAME_URL } }],
+  };
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  sw.cdp = [];
+  const out = await OPS.eval({ tabId: TAB_A, js: "1", frame: FRAME_URL });
+  assert.equal(out.emulated, true);
+  assert.equal(out.emulation.preset, "iphone-15");
+  // …and it really did apply the overrides before evaluating in the frame.
+  const m = methods();
+  assert.deepEqual(m.slice(0, 3), IPHONE_PREFIX);
+  assert.ok(m.indexOf("Runtime.evaluate") > m.indexOf("Emulation.setUserAgentOverride"));
+});
+
+test("F1: a NON-emulated tab gets NO emulation annotation at all (envelope unchanged)", async () => {
+  fresh();
+  for (const [op, cmd] of [["text", {}], ["getHtml", {}], ["eval", { js: "1" }]]) {
+    const out = await OPS[op]({ tabId: TAB_A, ...cmd });
+    assert.equal(out.emulated, undefined,
+      `${op} on a plain tab must not grow a field`);
+    assert.equal(out.notEmulatedRead, undefined);
+    assert.equal(out.emulationNote, undefined);
+  }
+});
+
+test("F3: a raw --ua derives platform FROM THE UA STRING, never from --mobile", () => {
+  // The bug this pins: keying platform off the `mobile` flag alone produced
+  // `platform:"Android"` for an iPhone UA — exactly the "combination no real client
+  // ever produces" that the preset metadata exists to avoid. An inconsistent pair
+  // is a STRONGER bot-detection signal than a blank platform.
+  const iphone = normalizeEmulation({
+    width: 393, height: 852, mobile: true,
+    ua: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148",
+  });
+  assert.equal(iphone.ua.userAgentMetadata.platform, "iOS");
+  assert.equal(iphone.ua.userAgentMetadata.model, "iPhone");
+  assert.equal(iphone.ua.userAgentMetadata.mobile, true);
+
+  const android = normalizeEmulation({
+    width: 412, height: 915, mobile: true,
+    ua: "Mozilla/5.0 (Linux; Android 14; Pixel 8) Chrome/126.0.0.0 Mobile",
+  });
+  assert.equal(android.ua.userAgentMetadata.platform, "Android");
+
+  const ipad = normalizeEmulation({
+    width: 744, height: 1133, mobile: true,
+    ua: "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) Mobile/15E148",
+  });
+  assert.equal(ipad.ua.userAgentMetadata.platform, "iOS");
+  assert.equal(ipad.ua.userAgentMetadata.model, "iPad");
+
+  // An unrecognised UA leaves platform EMPTY rather than guessing one.
+  const weird = normalizeEmulation({ width: 300, height: 600, mobile: true,
+                                     ua: "TotallyCustomAgent/1.0" });
+  assert.equal(weird.ua.userAgentMetadata.platform, "");
+  assert.equal(weird.ua.userAgentMetadata.model, "");
+
+  // brands stays EMPTY for every raw UA — a wrong brand list is worse than none.
+  for (const s of [iphone, android, ipad, weird]) {
+    assert.deepEqual(s.ua.userAgentMetadata.brands, []);
+  }
+});
+
+test("F4: both iPad Minis exist and are distinct (a stable name was not re-pointed)", () => {
+  assert.equal(DEVICE_PRESETS["ipad-mini"].width, 744,
+    "the unqualified name tracks the CURRENT shipping 6th-gen");
+  assert.equal(DEVICE_PRESETS["ipad-mini"].height, 1133);
+  assert.equal(DEVICE_PRESETS["ipad-mini-2019"].width, 768,
+    "the 2019 model keeps a name of its own rather than being silently replaced");
+  assert.equal(DEVICE_PRESETS["ipad-mini-2019"].height, 1024);
+  // The integrity + provenance tests above cover both entries automatically.
+});
+
+test("onReplaced (prerender/instant swap) drops BOTH tab ids' emulation state", async () => {
+  // A swapped-out tabId is retired WITHOUT onRemoved firing, which would strand a
+  // Map entry on a recyclable id. The emulation deliberately does NOT follow the
+  // tab: the swapped-in document was rendered WITHOUT the overrides, so carrying
+  // the state across would claim an emulation that was never applied.
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  await OPS.emulate({ tabId: TAB_B, device: "pixel-8" });
+  assert.ok(sw.replacedListeners.length >= 1,
+    "the SW must register an onReplaced listener at module scope");
+  for (const fn of sw.replacedListeners) fn(TAB_B, TAB_A);   // (added, removed)
+  assert.equal(emulationState.has(TAB_A), false, "the retired id is dropped");
+  assert.equal(emulationState.has(TAB_B), false,
+    "the swapped-IN id is dropped too — its document was never emulated");
 });
 
 test("a bad `emulate` is refused with its NAMED error through execute()", async () => {

--- a/scripts/browser-bridge/tests/emulation.test.mjs
+++ b/scripts/browser-bridge/tests/emulation.test.mjs
@@ -1,0 +1,846 @@
+// emulation.test.mjs — the `emulate` op: device emulation for real mobile testing.
+//
+// TWO halves, deliberately separated:
+//   * PURE (protocol.js): the preset table's integrity, the validation refusals,
+//     and the ORDERED CDP step list. No chrome, no mock, no I/O.
+//   * GLUE (service_worker.js against a mocked chrome): the properties that only
+//     exist once the pieces are wired — sticky re-application inside EVERY later
+//     op's CDP session, `nav` applying emulation BEFORE navigating, the screenshot
+//     fast-path being disabled, `click` switching to touch, per-tab isolation, and
+//     the state lifecycle (reset / close / vanished tab).
+//
+// ⚠ WHAT THESE TESTS DO NOT PROVE. Every CDP assertion here is against a MOCK
+// `chrome.debugger.sendCommand` that records method names and params. That proves
+// the bridge SENDS the right protocol calls in the right order — it does NOT prove
+// Chromium honours them, that the emulated viewport actually renders at 393px, or
+// that a real site's UA sniffing is fooled. Those need a live browser and are
+// listed as open items in the PR. Green here is a PREREQUISITE, not verification.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  DEVICE_PRESETS, PRESET_NAMES, PRESET_REQUIRED_KEYS, EMULATION_LIMITS,
+  normalizeEmulation, emulationCdpSteps, applyEmulationSteps, emulationSummary,
+  isTouchEmulated, touchTapEvents, ALLOWED_OPS, EMULATION_MAX_STEPS,
+  CDP_OP_BUDGET_MS, EXEC_OP_BUDGET_MS,
+} from "../extension/protocol.js";
+
+// --------------------------------------------------------------------------- //
+// PURE: the preset table
+// --------------------------------------------------------------------------- //
+
+test("preset table: every preset carries every required key", () => {
+  assert.ok(PRESET_NAMES.length >= 5, "the curated table must not be empty");
+  for (const name of PRESET_NAMES) {
+    const p = DEVICE_PRESETS[name];
+    for (const key of PRESET_REQUIRED_KEYS) {
+      assert.ok(Object.prototype.hasOwnProperty.call(p, key),
+        `preset ${name} is missing '${key}' — a half-filled preset silently `
+        + "emulates a phone-sized DESKTOP browser");
+    }
+  }
+});
+
+test("preset table: metrics are inside the raw-override limits and plausible", () => {
+  for (const name of PRESET_NAMES) {
+    const p = DEVICE_PRESETS[name];
+    assert.ok(Number.isInteger(p.width) && p.width >= EMULATION_LIMITS.minDimension
+      && p.width <= EMULATION_LIMITS.maxDimension, `${name}: width`);
+    assert.ok(Number.isInteger(p.height) && p.height >= EMULATION_LIMITS.minDimension
+      && p.height <= EMULATION_LIMITS.maxDimension, `${name}: height`);
+    // A device preset is a REAL handheld: narrower than 1024 CSS px and taller
+    // than it is wide. A preset that fails this is almost certainly a physical
+    // resolution pasted in where a logical one belongs — the classic error.
+    assert.ok(p.width <= 1024, `${name}: width ${p.width} is desktop-sized — did a `
+      + "PHYSICAL resolution get pasted in place of the logical one?");
+    assert.ok(p.height > p.width, `${name}: presets are defined portrait`);
+    assert.ok(p.deviceScaleFactor >= EMULATION_LIMITS.minScaleFactor
+      && p.deviceScaleFactor <= EMULATION_LIMITS.maxScaleFactor,
+      `${name}: deviceScaleFactor`);
+    assert.ok(p.deviceScaleFactor >= 1.5,
+      `${name}: every modern handheld is HiDPI — dsf < 1.5 is a typo`);
+    assert.equal(p.mobile, true, `${name}: mobile must be true`);
+    assert.ok(p.maxTouchPoints >= 1
+      && p.maxTouchPoints <= EMULATION_LIMITS.maxTouchPoints, `${name}: touch points`);
+  }
+});
+
+test("preset table: physical pixels / dsf reproduces the CSS viewport", () => {
+  // The internal-consistency check that catches a transcription error in either
+  // number. Tolerance 1px: vendors round the logical resolution.
+  for (const name of PRESET_NAMES) {
+    const p = DEVICE_PRESETS[name];
+    if (!p.physical) continue;
+    for (const dim of ["width", "height"]) {
+      const derived = p.physical[dim] / p.deviceScaleFactor;
+      assert.ok(Math.abs(derived - p[dim]) <= 1,
+        `${name}: ${p.physical[dim]}px physical / dsf ${p.deviceScaleFactor} = `
+        + `${derived.toFixed(2)}, but the preset says ${p[dim]}`);
+    }
+  }
+});
+
+test("preset table: every preset sets a UA *and* UA-Client-Hints metadata", () => {
+  // THE most commonly missed half. A preset with a mobile UA string and no
+  // userAgentMetadata leaves navigator.userAgentData reporting the operator's real
+  // desktop Chrome to any site that asks — which is most of them now.
+  for (const name of PRESET_NAMES) {
+    const p = DEVICE_PRESETS[name];
+    assert.ok(typeof p.userAgent === "string" && p.userAgent.length > 20,
+      `${name}: userAgent`);
+    assert.ok(/mobile/i.test(p.userAgent) || /iPad/.test(p.userAgent),
+      `${name}: a device preset's UA must read as a handheld`);
+    const m = p.userAgentMetadata;
+    assert.ok(m && typeof m === "object", `${name}: userAgentMetadata missing`);
+    assert.equal(m.mobile, true,
+      `${name}: userAgentMetadata.mobile must agree with the UA string`);
+    assert.ok(typeof m.platform === "string" && m.platform.length > 0,
+      `${name}: userAgentMetadata.platform`);
+    assert.ok(Array.isArray(m.brands), `${name}: brands must be an array`);
+    // Apple devices legitimately have NO brands (Safari sends no Sec-CH-UA);
+    // Android must carry them or client-hint sniffing sees nothing.
+    if (m.platform === "Android") {
+      assert.ok(m.brands.length >= 2,
+        `${name}: an Android preset must carry Chrome's brand list`);
+    }
+    assert.ok(typeof p.source === "string" && p.source.length > 20,
+      `${name}: 'source' must state where the metrics came from`);
+  }
+});
+
+test("preset table: the `browser` CLI's duplicated name list has not drifted", () => {
+  // bash cannot import DEVICE_PRESETS, so the CLI repeats the names in its usage
+  // text and in `--list`. This is the guard that makes that duplication safe.
+  const cliPath = fileURLToPath(new URL("../browser", import.meta.url));
+  const cli = readFileSync(cliPath, "utf8");
+  const marker = cli.match(/# PRESET_NAMES: (.+)/);
+  assert.ok(marker, "the `browser` CLI must carry a '# PRESET_NAMES:' marker line");
+  const listed = marker[1].trim().split(/\s+/);
+  assert.deepEqual(listed.slice().sort(), PRESET_NAMES.slice().sort(),
+    "the CLI's preset list disagrees with DEVICE_PRESETS");
+  // …and the `--list` output block prints exactly those names too.
+  const listBlock = cli.match(/printf '  %s\\n' ([^\n]+)/);
+  assert.ok(listBlock, "`browser emulate --list` must print the preset names");
+  assert.deepEqual(listBlock[1].trim().split(/\s+/).sort(), PRESET_NAMES.slice().sort());
+});
+
+test("`emulate` is in the extension's ALLOWED_OPS", () => {
+  assert.ok(ALLOWED_OPS.includes("emulate"));
+});
+
+// --------------------------------------------------------------------------- //
+// PURE: validation refusals
+// --------------------------------------------------------------------------- //
+
+function refusal(cmd) {
+  try {
+    normalizeEmulation(cmd);
+  } catch (e) {
+    return e.message;
+  }
+  throw new Error(`normalizeEmulation(${JSON.stringify(cmd)}) did NOT throw`);
+}
+
+test("unknown preset is refused by NAME (so the caller can see what they typed)", () => {
+  assert.equal(refusal({ device: "iphone-42" }), "unknown_preset:iphone-42");
+  assert.equal(refusal({ device: "IPHONE-15" }), "unknown_preset:IPHONE-15");
+});
+
+test("out-of-range raw params are refused, per field", () => {
+  assert.equal(refusal({ width: 0, height: 800 }), "invalid_emulation:width");
+  assert.equal(refusal({ width: -5, height: 800 }), "invalid_emulation:width");
+  assert.equal(refusal({ width: 400, height: 0 }), "invalid_emulation:height");
+  assert.equal(refusal({ width: EMULATION_LIMITS.maxDimension + 1, height: 800 }),
+    "invalid_emulation:width");
+  assert.equal(refusal({ width: 400.5, height: 800 }), "invalid_emulation:width");
+  assert.equal(refusal({ width: "wide", height: 800 }), "invalid_emulation:width");
+  assert.equal(refusal({ width: 400, height: 800, dsf: 0 }), "invalid_emulation:dsf");
+  assert.equal(refusal({ width: 400, height: 800, dsf: 99 }), "invalid_emulation:dsf");
+  assert.equal(refusal({ width: 400, height: 800, dsf: -2 }), "invalid_emulation:dsf");
+  assert.equal(refusal({ device: "pixel-8", maxTouchPoints: 0 }),
+    "invalid_emulation:maxTouchPoints");
+  assert.equal(refusal({ device: "pixel-8",
+                         maxTouchPoints: EMULATION_LIMITS.maxTouchPoints + 1 }),
+    "invalid_emulation:maxTouchPoints");
+});
+
+test("contradictory params are refused rather than silently resolved", () => {
+  // Half a viewport is not a partial override you can complete: guessing the other
+  // dimension from the real window would make the result depend on the operator's
+  // window size, i.e. not reproducible.
+  assert.equal(refusal({ width: 400 }), "invalid_emulation:width_and_height_together");
+  assert.equal(refusal({ height: 800 }), "invalid_emulation:width_and_height_together");
+  // --reset means "stop"; combining it with a device description is incoherent.
+  assert.equal(refusal({ reset: true, device: "iphone-15" }),
+    "invalid_emulation:reset_with_params");
+  assert.equal(refusal({ reset: true, width: 400, height: 800 }),
+    "invalid_emulation:reset_with_params");
+  // maxTouchPoints while explicitly disabling touch.
+  assert.equal(refusal({ device: "pixel-8", touch: false, maxTouchPoints: 5 }),
+    "invalid_emulation:max_touch_points_without_touch");
+});
+
+test("an `emulate` with nothing to do is refused, not treated as a no-op", () => {
+  assert.equal(refusal({}), "emulate_needs_device_or_params");
+  assert.equal(refusal({ device: "", width: "", ua: "" }),
+    "emulate_needs_device_or_params");
+});
+
+test("a UA carrying CR/LF is REFUSED, never sanitized", () => {
+  // The UA is echoed into a request header by Chromium; CR/LF is the classic
+  // header-injection primitive. Refusing beats stripping — silently rewriting
+  // input leaves you unsure what went on the wire.
+  assert.equal(refusal({ ua: "Mozilla/5.0\r\nX-Evil: 1" }), "invalid_emulation:ua");
+  assert.equal(refusal({ ua: "Mozilla/5.0\nX-Evil: 1" }), "invalid_emulation:ua");
+  assert.equal(refusal({ ua: "Mozilla /5.0" }), "invalid_emulation:ua");
+  assert.equal(refusal({ ua: "x".repeat(EMULATION_LIMITS.maxUserAgentChars + 1) }),
+    "invalid_emulation:ua");
+  assert.equal(refusal({ ua: 12345 }), "invalid_emulation:ua");
+});
+
+test("timezone / colour-scheme / orientation / geo are validated", () => {
+  assert.equal(refusal({ tz: "Europe/London; rm -rf" }), "invalid_emulation:tz");
+  assert.equal(refusal({ tz: "x".repeat(EMULATION_LIMITS.maxTimezoneChars + 1) }),
+    "invalid_emulation:tz");
+  assert.equal(refusal({ colorScheme: "sepia" }), "invalid_emulation:colorScheme");
+  assert.equal(refusal({ device: "iphone-15", orientation: "sideways" }),
+    "invalid_emulation:orientation");
+  assert.equal(refusal({ geo: { latitude: 91, longitude: 0 } }),
+    "invalid_emulation:geo.latitude");
+  assert.equal(refusal({ geo: { latitude: 0, longitude: 181 } }),
+    "invalid_emulation:geo.longitude");
+  assert.equal(refusal({ geo: [1, 2] }), "invalid_emulation:geo");
+});
+
+// --------------------------------------------------------------------------- //
+// PURE: the normalized state + the ordered CDP steps
+// --------------------------------------------------------------------------- //
+
+test("a preset normalizes to the preset's metrics, touch and UA", () => {
+  const s = normalizeEmulation({ device: "iphone-15" });
+  assert.equal(s.preset, "iphone-15");
+  assert.deepEqual(s.metrics, {
+    width: 393, height: 852, deviceScaleFactor: 3, mobile: true,
+    screenOrientation: { type: "portraitPrimary", angle: 0 },
+  });
+  assert.deepEqual(s.touch, { enabled: true, maxTouchPoints: 5 });
+  assert.equal(s.ua.userAgent, DEVICE_PRESETS["iphone-15"].userAgent);
+  assert.equal(s.ua.userAgentMetadata, DEVICE_PRESETS["iphone-15"].userAgentMetadata);
+});
+
+test("raw params override a preset's fields", () => {
+  const s = normalizeEmulation({ device: "iphone-15", width: 320, height: 480,
+                                 dsf: 1, touch: false });
+  assert.equal(s.metrics.width, 320);
+  assert.equal(s.metrics.height, 480);
+  assert.equal(s.metrics.deviceScaleFactor, 1);
+  assert.equal(s.metrics.mobile, true, "the preset's mobile flag survives");
+  assert.deepEqual(s.touch, { enabled: false, maxTouchPoints: 1 });
+  assert.equal(isTouchEmulated(s), false);
+});
+
+test("--orientation landscape swaps the viewport, not just the angle", () => {
+  const s = normalizeEmulation({ device: "iphone-15", orientation: "landscape" });
+  assert.equal(s.metrics.width, 852);
+  assert.equal(s.metrics.height, 393);
+  assert.deepEqual(s.metrics.screenOrientation, { type: "landscapePrimary", angle: 90 });
+});
+
+test("a RAW --ua still gets userAgentMetadata (never the operator's real brands)", () => {
+  const s = normalizeEmulation({ width: 390, height: 844, mobile: true,
+                                 ua: "Mozilla/5.0 (custom) Mobile" });
+  assert.ok(s.ua.userAgentMetadata, "raw --ua must not leave metadata unset");
+  assert.equal(s.ua.userAgentMetadata.mobile, true);
+  assert.deepEqual(s.ua.userAgentMetadata.brands, []);
+});
+
+test("the CDP step list is ORDERED, and every step is required", () => {
+  const s = normalizeEmulation({
+    device: "pixel-8", colorScheme: "dark", tz: "Europe/London",
+    geo: { latitude: 51.5, longitude: -0.12 },
+  });
+  const steps = emulationCdpSteps(s);
+  assert.deepEqual(steps.map((x) => x.method), [
+    "Emulation.setDeviceMetricsOverride",
+    "Emulation.setTouchEmulationEnabled",
+    "Emulation.setUserAgentOverride",
+    "Emulation.setEmulatedMedia",
+    "Emulation.setTimezoneOverride",
+    "Emulation.setGeolocationOverride",
+  ]);
+  // Metrics FIRST is load-bearing: anything that measures layout afterwards
+  // (a --fullpage clip, a click's element rect) must measure the emulated page.
+  assert.equal(steps[0].method, "Emulation.setDeviceMetricsOverride");
+  // No step is optional — a half-applied emulation returns a plausible screenshot
+  // of the wrong thing, which is worse than a refusal.
+  assert.ok(steps.every((x) => !x.optional));
+});
+
+test("the UA step carries BOTH userAgent and userAgentMetadata", () => {
+  const s = normalizeEmulation({ device: "pixel-8" });
+  const ua = emulationCdpSteps(s)
+    .find((x) => x.method === "Emulation.setUserAgentOverride");
+  assert.ok(ua, "a preset must produce a setUserAgentOverride step");
+  assert.ok(ua.params.userAgent.includes("Android"));
+  assert.ok(ua.params.userAgentMetadata, "userAgentMetadata is the missed half");
+  assert.equal(ua.params.userAgentMetadata.platform, "Android");
+  assert.equal(ua.params.userAgentMetadata.mobile, true);
+  assert.ok(ua.params.userAgentMetadata.brands.length >= 2);
+});
+
+test("media / timezone / geolocation each produce their exact CDP params", () => {
+  const s = normalizeEmulation({
+    colorScheme: "dark", tz: "America/Los_Angeles",
+    geo: { latitude: 37.77, longitude: -122.41, accuracy: 25 },
+  });
+  const by = Object.fromEntries(emulationCdpSteps(s).map((x) => [x.method, x.params]));
+  assert.deepEqual(by["Emulation.setEmulatedMedia"], {
+    media: "", features: [{ name: "prefers-color-scheme", value: "dark" }],
+  });
+  assert.deepEqual(by["Emulation.setTimezoneOverride"],
+    { timezoneId: "America/Los_Angeles" });
+  assert.deepEqual(by["Emulation.setGeolocationOverride"],
+    { latitude: 37.77, longitude: -122.41, accuracy: 25 });
+  // …and NO device metrics were invented for a media-only emulation.
+  assert.equal(by["Emulation.setDeviceMetricsOverride"], undefined);
+});
+
+test("`reset` yields no steps at all", () => {
+  const s = normalizeEmulation({ reset: true });
+  assert.deepEqual(s, { reset: true });
+  assert.deepEqual(emulationCdpSteps(s), []);
+  assert.equal(emulationSummary(s), null);
+  assert.equal(isTouchEmulated(s), false);
+});
+
+test("applyEmulationSteps propagates the FIRST failure (no optional swallowing)", () => {
+  const seen = [];
+  const send = async (method) => {
+    seen.push(method);
+    if (method === "Emulation.setUserAgentOverride") throw new Error("nope");
+    return {};
+  };
+  const s = normalizeEmulation({ device: "pixel-8", tz: "UTC" });
+  return assert.rejects(() => applyEmulationSteps(send, emulationCdpSteps(s)),
+    /nope/).then(() => {
+      // It stopped AT the failure — the later steps were never attempted, so the
+      // caller cannot be told "applied" about something that never ran.
+      assert.deepEqual(seen, [
+        "Emulation.setDeviceMetricsOverride",
+        "Emulation.setTouchEmulationEnabled",
+        "Emulation.setUserAgentOverride",
+      ]);
+    });
+});
+
+test("BUDGET: the step count is bounded by a CONSTANT, not by caller input", () => {
+  // The added per-op cost has to be analysable against EXEC_OP_BUDGET_MS. It is,
+  // because nothing a caller sends can make the apply longer — the step list is
+  // one entry per emulation FACET, and there are a fixed number of facets.
+  const maximal = normalizeEmulation({
+    device: "pixel-8", width: 400, height: 900, dsf: 3, mobile: true,
+    touch: true, maxTouchPoints: 10, ua: "Mozilla/5.0 (custom) Mobile",
+    orientation: "portrait", colorScheme: "dark", tz: "Europe/London",
+    geo: { latitude: 51.5, longitude: -0.12, accuracy: 5 },
+  });
+  assert.equal(emulationCdpSteps(maximal).length, EMULATION_MAX_STEPS,
+    "the maximal emulation must hit exactly the documented ceiling");
+  for (const name of PRESET_NAMES) {
+    assert.ok(emulationCdpSteps(normalizeEmulation({ device: name })).length
+      <= EMULATION_MAX_STEPS);
+  }
+  // And the budgets it composes against are the ones the comment names, so a
+  // change to either fails here rather than silently invalidating the analysis.
+  assert.equal(CDP_OP_BUDGET_MS, 15000);
+  assert.equal(EXEC_OP_BUDGET_MS, 18000);
+});
+
+test("touchTapEvents is the DevTools-shaped touchStart/touchEnd pair", () => {
+  const evs = touchTapEvents(10, 20);
+  assert.deepEqual(evs.map((e) => e.method),
+    ["Input.dispatchTouchEvent", "Input.dispatchTouchEvent"]);
+  assert.equal(evs[0].params.type, "touchStart");
+  assert.deepEqual(evs[0].params.touchPoints[0].x, 10);
+  assert.deepEqual(evs[0].params.touchPoints[0].y, 20);
+  assert.equal(evs[1].params.type, "touchEnd");
+  assert.deepEqual(evs[1].params.touchPoints, [],
+    "touchEnd carries no remaining points");
+});
+
+test("emulationSummary is METADATA ONLY — no UA string, no coordinates", () => {
+  const s = normalizeEmulation({
+    device: "iphone-15", colorScheme: "dark", tz: "UTC",
+    geo: { latitude: 51.5, longitude: -0.12 },
+  });
+  const sum = emulationSummary(s);
+  const blob = JSON.stringify(sum);
+  assert.ok(!blob.includes("AppleWebKit"), "the UA string must not be in the summary");
+  assert.ok(!blob.includes("51.5"), "coordinates must not be in the summary");
+  assert.ok(!blob.includes("-0.12"));
+  assert.equal(sum.geolocation, true, "…but its PRESENCE is reported");
+  assert.equal(sum.userAgentOverridden, true);
+  assert.equal(sum.preset, "iphone-15");
+  assert.equal(sum.width, 393);
+});
+
+// --------------------------------------------------------------------------- //
+// GLUE: service_worker.js against a mocked chrome
+// --------------------------------------------------------------------------- //
+
+const TAB_A = 11;
+const TAB_B = 22;
+
+const sw = {
+  cdp: [],                 // ordered [{method, params}] of every CDP send
+  events: [],              // ordered "attach"/"detach" + method names
+  tabs: new Map(),
+  gone: new Set(),         // tabIds chrome.tabs.get must reject for
+  removedListeners: [],
+  tabsUpdate: [],
+  tabsRemove: [],
+  layoutMetrics: { cssContentSize: { width: 393, height: 4200 } },
+  elementRect: { x: 10, y: 20, width: 100, height: 40 },
+  failMethod: null,        // make one CDP method reject (the failure path)
+  hangMethod: null,        // make one CDP method never settle (the no-wedge path)
+};
+
+function resetSw() {
+  sw.cdp = [];
+  sw.events = [];
+  sw.gone = new Set();
+  sw.tabsUpdate = [];
+  sw.tabsRemove = [];
+  sw.failMethod = null;
+  sw.hangMethod = null;
+  sw.tabs = new Map([
+    [TAB_A, { id: TAB_A, url: "https://example.com/a", title: "A",
+              active: true, status: "complete", windowId: 1 }],
+    [TAB_B, { id: TAB_B, url: "https://example.com/b", title: "B",
+              active: false, status: "complete", windowId: 1 }],
+  ]);
+}
+resetSw();
+
+globalThis.BROWSER_BRIDGE_NO_AUTOSTART = true;
+globalThis.BROWSER_BRIDGE_ACTIVATE_TIMING = { settleMs: 0, pollMs: 1 };
+globalThis.chrome = {
+  webNavigation: { async getAllFrames() { return []; } },
+  scripting: {
+    async executeScript() { return [{ result: { visibilityState: "visible" } }]; },
+  },
+  tabs: {
+    async get(id) {
+      if (sw.gone.has(id)) throw new Error("No tab with id");
+      const t = sw.tabs.get(id);
+      if (!t) throw new Error("No tab with id");
+      return { ...t };
+    },
+    async query() { return [sw.tabs.get(TAB_A)]; },
+    async captureVisibleTab() {
+      sw.events.push("captureVisibleTab");
+      return "data:image/png;base64,AAAA";
+    },
+    async update(id, props) { sw.tabsUpdate.push({ id, props }); return sw.tabs.get(id); },
+    async remove(id) { sw.tabsRemove.push(id); sw.gone.add(id); sw.tabs.delete(id); },
+    onRemoved: { addListener(fn) { sw.removedListeners.push(fn); } },
+  },
+  windows: { async update() {} },
+  debugger: {
+    async attach() { sw.events.push("attach"); },
+    async detach() { sw.events.push("detach"); },
+    async sendCommand(_t, method, params) {
+      sw.cdp.push({ method, params });
+      sw.events.push(method);
+      // A promise that NEVER settles — the real "hung chrome.debugger call" shape.
+      // Deliberately not a long timer: the point is that promiseWithTimeout settles
+      // the awaiter and abandons this, so nothing here may keep the loop alive.
+      if (sw.hangMethod === method) return new Promise(() => {});
+      if (sw.failMethod === method) throw new Error(`cdp_failed:${method}`);
+      if (method === "Page.captureScreenshot") return { data: "QkJCQg==" };
+      if (method === "Page.getLayoutMetrics") return sw.layoutMetrics;
+      if (method === "Runtime.evaluate") {
+        return { result: { value: sw.elementRect } };
+      }
+      return {};
+    },
+    onDetach: { addListener() {} },
+    onEvent: { addListener() {}, removeListener() {} },
+  },
+  storage: { local: { async get() { return {}; }, async set() {} } },
+  runtime: { onInstalled: { addListener() {} }, onStartup: { addListener() {} },
+             getManifest: () => ({ version: "0.5.0" }), id: "test-ext-id" },
+  alarms: { create() {}, onAlarm: { addListener() {} } },
+};
+
+const { OPS, execute, emulationState } =
+  await import("../extension/service_worker.js");
+
+function methods() { return sw.cdp.map((c) => c.method); }
+function paramsOf(method) {
+  const hit = sw.cdp.find((c) => c.method === method);
+  return hit ? hit.params : undefined;
+}
+function fresh() { resetSw(); emulationState.clear(); }
+
+// The exact ordered prefix an emulated tab's CDP session must open with.
+const IPHONE_PREFIX = [
+  "Emulation.setDeviceMetricsOverride",
+  "Emulation.setTouchEmulationEnabled",
+  "Emulation.setUserAgentOverride",
+];
+
+test("emulate: stores the state and applies the overrides in order, then detaches", async () => {
+  fresh();
+  const out = await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  assert.equal(out.tabId, TAB_A);
+  assert.equal(out.emulation.preset, "iphone-15");
+  assert.equal(out.emulation.width, 393);
+  assert.deepEqual(methods(), IPHONE_PREFIX);
+  // Attach → the overrides → detach. The session did not stay open.
+  assert.deepEqual(sw.events, ["attach", ...IPHONE_PREFIX, "detach"]);
+  assert.ok(emulationState.has(TAB_A));
+});
+
+test("STICKY: a SECOND, separate op re-applies the overrides — exact methods AND order", async () => {
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  sw.cdp = []; sw.events = [];
+
+  // A completely independent later command. Nothing about `screenshot` knows
+  // emulation exists — the re-application happens at withCdp's choke point.
+  await OPS.screenshot({ tabId: TAB_A });
+
+  assert.deepEqual(methods(), [...IPHONE_PREFIX, "Page.captureScreenshot"],
+    "the overrides must be re-applied BEFORE the op's own work, in order");
+  assert.deepEqual(sw.events,
+    ["attach", ...IPHONE_PREFIX, "Page.captureScreenshot", "detach"]);
+
+  // …and a THIRD op re-applies again (it is not a one-shot).
+  sw.cdp = [];
+  await OPS.click({ tabId: TAB_A, selector: "#go" });
+  assert.deepEqual(methods().slice(0, 3), IPHONE_PREFIX);
+});
+
+test("STICKY: the re-applied params are the SAME params, not a re-derived guess", async () => {
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "galaxy-s24", colorScheme: "dark",
+                      tz: "Europe/London" });
+  const first = JSON.parse(JSON.stringify(sw.cdp));
+  sw.cdp = [];
+  await OPS.screenshot({ tabId: TAB_A });
+  const second = sw.cdp.filter((c) => c.method.startsWith("Emulation."));
+  assert.deepEqual(second, first,
+    "a later op must send byte-identical emulation params");
+});
+
+test("nav on an emulated tab applies emulation BEFORE navigating (via CDP)", async () => {
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  sw.cdp = []; sw.events = [];
+
+  const out = await OPS.nav({ tabId: TAB_A, url: "https://example.com/next" });
+
+  assert.deepEqual(methods(), [...IPHONE_PREFIX, "Page.navigate"],
+    "the UA/viewport must be live BEFORE the navigation a page sniffs at load");
+  const navIdx = methods().indexOf("Page.navigate");
+  const uaIdx = methods().indexOf("Emulation.setUserAgentOverride");
+  assert.ok(uaIdx >= 0 && uaIdx < navIdx,
+    "setUserAgentOverride must precede Page.navigate");
+  assert.equal(paramsOf("Page.navigate").url, "https://example.com/next");
+  assert.equal(out.via, "cdp");
+  // The plain chrome.tabs.update path — which would navigate OUTSIDE the emulated
+  // session — must not have been taken.
+  assert.deepEqual(sw.tabsUpdate, []);
+});
+
+test("nav on a NON-emulated tab is unchanged: chrome.tabs.update, no debugger", async () => {
+  fresh();
+  const out = await OPS.nav({ tabId: TAB_A, url: "https://example.com/plain" });
+  assert.deepEqual(sw.cdp, []);
+  assert.deepEqual(sw.events, []);
+  assert.deepEqual(sw.tabsUpdate, [{ id: TAB_A, props: { url: "https://example.com/plain" } }]);
+  assert.equal(out.via, "tabs.update");
+});
+
+test("SCREENSHOT: the captureVisibleTab FAST PATH is refused on an emulated tab", async () => {
+  fresh();
+  // Precondition — the fast path IS taken for this tab when it is NOT emulated
+  // (tab.active === true, no --fullpage). Without this the next assertion could
+  // pass for the wrong reason.
+  const before = await OPS.screenshot({ tabId: TAB_A });
+  assert.equal(before.via, "captureVisibleTab");
+  assert.ok(sw.events.includes("captureVisibleTab"));
+  assert.deepEqual(sw.cdp, [], "the fast path attaches no debugger");
+
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  sw.cdp = []; sw.events = [];
+  const after = await OPS.screenshot({ tabId: TAB_A });
+
+  // THE BUG THIS GUARDS: captureVisibleTab never attaches the debugger, so under
+  // emulation it would return a valid PNG of the UN-emulated desktop layout — a
+  // confident wrong answer on the one op whose job is showing what the device sees.
+  assert.equal(after.via, "cdp");
+  assert.ok(!sw.events.includes("captureVisibleTab"),
+    "the fast path MUST NOT be taken while the tab is emulated");
+  assert.deepEqual(methods(), [...IPHONE_PREFIX, "Page.captureScreenshot"]);
+  assert.equal(after.emulation.preset, "iphone-15");
+});
+
+test("SCREENSHOT --fullpage: the clip is measured AFTER the emulated metrics land", async () => {
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  sw.cdp = [];
+  // The mock reports an emulated-width document; the point of the test is the
+  // ORDER, which is what makes the real Page.getLayoutMetrics emulated at all.
+  sw.layoutMetrics = { cssContentSize: { width: 393, height: 4200 } };
+  await OPS.screenshot({ tabId: TAB_A, fullpage: true });
+
+  const m = methods();
+  const metricsIdx = m.indexOf("Emulation.setDeviceMetricsOverride");
+  const layoutIdx = m.indexOf("Page.getLayoutMetrics");
+  assert.ok(metricsIdx >= 0 && layoutIdx > metricsIdx,
+    "Page.getLayoutMetrics must run AFTER setDeviceMetricsOverride, or the clip "
+    + "is the size of the operator's real window");
+  const clip = paramsOf("Page.captureScreenshot").clip;
+  assert.equal(clip.width, 393, "the clip uses the EMULATED width");
+  assert.equal(clip.height, 4200);
+});
+
+test("CLICK dispatches TOUCH under touch emulation, and MOUSE otherwise", async () => {
+  // Mouse is the control. A mobile UI whose handler is `touchstart` never fires
+  // under a mouse click — Chromium synthesizes mouse-from-touch, never the reverse.
+  fresh();
+  const plain = await OPS.click({ tabId: TAB_A, selector: "#go" });
+  assert.equal(plain.via, "mouse");
+  assert.deepEqual(methods().filter((x) => x.startsWith("Input.")),
+    ["Input.dispatchMouseEvent", "Input.dispatchMouseEvent"]);
+
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  sw.cdp = [];
+  const tapped = await OPS.click({ tabId: TAB_A, selector: "#go" });
+  assert.equal(tapped.via, "touch");
+  assert.deepEqual(methods().filter((x) => x.startsWith("Input.")),
+    ["Input.dispatchTouchEvent", "Input.dispatchTouchEvent"]);
+  assert.ok(!methods().includes("Input.dispatchMouseEvent"),
+    "no mouse event may be dispatched on a touch-emulated tab");
+  const touchParams = sw.cdp.filter((c) => c.method === "Input.dispatchTouchEvent");
+  assert.equal(touchParams[0].params.type, "touchStart");
+  assert.equal(touchParams[1].params.type, "touchEnd");
+  // The tap lands at the element's centre, exactly like the mouse path.
+  assert.equal(touchParams[0].params.touchPoints[0].x, plain.x);
+  assert.equal(touchParams[0].params.touchPoints[0].y, plain.y);
+});
+
+test("CLICK stays on MOUSE when emulation is on but touch is explicitly off", async () => {
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15", touch: false });
+  sw.cdp = [];
+  const out = await OPS.click({ tabId: TAB_A, selector: "#go" });
+  assert.equal(out.via, "mouse");
+  assert.deepEqual(methods().filter((x) => x.startsWith("Input.")),
+    ["Input.dispatchMouseEvent", "Input.dispatchMouseEvent"]);
+});
+
+test("--reset STOPS re-application (and reports what it stopped)", async () => {
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  const out = await OPS.emulate({ tabId: TAB_A, reset: true });
+  assert.equal(out.reset, true);
+  assert.equal(out.wasEmulating.preset, "iphone-15");
+  assert.equal(emulationState.has(TAB_A), false);
+
+  sw.cdp = []; sw.events = [];
+  await OPS.screenshot({ tabId: TAB_A });
+  assert.ok(!methods().some((m) => m.startsWith("Emulation.")),
+    "no emulation override may be re-applied after --reset");
+  // …and the fast path is available again.
+  assert.ok(sw.events.includes("captureVisibleTab"));
+});
+
+test("--reset on a tab that was never emulated is a clean no-op", async () => {
+  fresh();
+  const out = await OPS.emulate({ tabId: TAB_A, reset: true });
+  assert.equal(out.reset, true);
+  assert.equal(out.wasEmulating, null);
+  assert.deepEqual(sw.cdp, [], "reset touches no CDP at all");
+});
+
+test("`close` clears the tab's emulation state", async () => {
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  assert.ok(emulationState.has(TAB_A));
+  await OPS.close({ tabId: TAB_A });
+  assert.equal(emulationState.has(TAB_A), false);
+  assert.deepEqual(sw.tabsRemove, [TAB_A]);
+});
+
+test("a VANISHED tab drops its emulation state (a recycled tabId can't inherit it)", async () => {
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  assert.ok(emulationState.has(TAB_A));
+  // The tab goes away out-of-band (operator closed it, crash, …).
+  sw.gone.add(TAB_A);
+  await assert.rejects(() => OPS.screenshot({ tabId: TAB_A }), /owned_tab_gone/);
+  assert.equal(emulationState.has(TAB_A), false,
+    "the state must not survive the tab it describes");
+});
+
+test("chrome.tabs.onRemoved drops the state even with no `close` op", async () => {
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  assert.ok(sw.removedListeners.length >= 1,
+    "the SW must register an onRemoved listener at module scope");
+  for (const fn of sw.removedListeners) fn(TAB_A);
+  assert.equal(emulationState.has(TAB_A), false);
+});
+
+test("ISOLATION: emulating tab A never touches tab B", async () => {
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  sw.cdp = []; sw.events = [];
+
+  await OPS.screenshot({ tabId: TAB_B, fullpage: true });
+  assert.ok(!methods().some((m) => m.startsWith("Emulation.")),
+    "tab B must see NO emulation overrides");
+  assert.equal(emulationState.has(TAB_B), false);
+
+  // And B's own emulation does not disturb A's.
+  await OPS.emulate({ tabId: TAB_B, device: "ipad-mini" });
+  sw.cdp = [];
+  await OPS.screenshot({ tabId: TAB_A, fullpage: true });
+  assert.equal(paramsOf("Emulation.setDeviceMetricsOverride").width, 393,
+    "tab A must still be the iPhone, not the iPad");
+  sw.cdp = [];
+  await OPS.screenshot({ tabId: TAB_B, fullpage: true });
+  assert.equal(paramsOf("Emulation.setDeviceMetricsOverride").width, 768);
+});
+
+test("`tabs` SURFACES emulated tabs (a stuck override is visible, not mysterious)", async () => {
+  fresh();
+  let out = await OPS.tabs();
+  assert.deepEqual(out.emulatedTabs, []);
+  assert.ok(out.tabs.every((t) => t.emulation === undefined),
+    "a normal listing is unchanged");
+
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  out = await OPS.tabs();
+  assert.deepEqual(out.emulatedTabs, [TAB_A]);
+  const entry = out.tabs.find((t) => t.id === TAB_A);
+  assert.equal(entry.emulation.preset, "iphone-15");
+  assert.equal(entry.emulation.width, 393);
+});
+
+test("WAKE + EMULATE: neither clobbers the other", async () => {
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  sw.cdp = []; sw.events = [];
+
+  await OPS.wake({ tabId: TAB_A, waitMs: 0 });
+  const m = methods();
+
+  // The emulation is re-applied inside the wake's own session, BEFORE the wake
+  // steps — so a woken tab is still an emulated tab.
+  assert.deepEqual(m.slice(0, 3), IPHONE_PREFIX);
+  assert.ok(m.includes("Emulation.setFocusEmulationEnabled"),
+    "wake still does its own job");
+  const metricsIdx = m.indexOf("Emulation.setDeviceMetricsOverride");
+  const focusIdx = m.indexOf("Emulation.setFocusEmulationEnabled");
+  assert.ok(metricsIdx < focusIdx);
+
+  // wake's teardown disables FOCUS emulation only — it must not reach for
+  // setDeviceMetricsOverride/clearDeviceMetricsOverride and undo the device.
+  assert.ok(!m.includes("Emulation.clearDeviceMetricsOverride"),
+    "wake's teardown must not clear the device emulation");
+  const focusCalls = sw.cdp.filter(
+    (c) => c.method === "Emulation.setFocusEmulationEnabled");
+  assert.deepEqual(focusCalls.map((c) => c.params.enabled), [true, false],
+    "focus emulation is turned on then explicitly off — unchanged");
+  // The emulation state itself survives the wake.
+  assert.ok(emulationState.has(TAB_A));
+
+  // And the NEXT op after the wake is still emulated.
+  sw.cdp = [];
+  await OPS.screenshot({ tabId: TAB_A });
+  assert.deepEqual(methods().slice(0, 3), IPHONE_PREFIX);
+});
+
+test("FAILURE PATH: a failing emulation apply is a normal error envelope, and detaches", async () => {
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  sw.cdp = []; sw.events = [];
+  sw.failMethod = "Emulation.setUserAgentOverride";
+
+  // Through execute() — the poll loop's real entry point — so this exercises the
+  // envelope the loop actually posts.
+  const env = await execute({ id: "c1", op: "screenshot", tabId: TAB_A });
+  assert.equal(env.ok, false);
+  assert.equal(env.id, "c1");
+  assert.match(env.error, /cdp_failed:Emulation\.setUserAgentOverride/);
+  // Nothing threw past execute (the loop keeps going), and the debugger was
+  // released — a failed emulation cannot leak an attachment or wedge the loop.
+  assert.equal(sw.events[sw.events.length - 1], "detach");
+  // The op's own work never ran on a half-emulated page.
+  assert.ok(!methods().includes("Page.captureScreenshot"));
+});
+
+test("FAILURE PATH: a failing `emulate` does not leave the state stored", async () => {
+  fresh();
+  sw.failMethod = "Emulation.setDeviceMetricsOverride";
+  const env = await execute({ id: "c2", op: "emulate", tabId: TAB_A,
+                             device: "iphone-15" });
+  assert.equal(env.ok, false);
+  assert.match(env.error, /cdp_failed/);
+  assert.equal(emulationState.has(TAB_A), false,
+    "a rolled-back emulate must not have every later op retry an emulation the "
+    + "caller was told had failed");
+});
+
+test("NO-WEDGE: a HUNG emulation step is bounded like any other CDP command", async () => {
+  // The re-application runs inside withCdpSession's `run`, and is handed the
+  // WRAPPED send — so a hung Emulation.* override settles at CDP_COMMAND_TIMEOUT_MS
+  // with `cdp_timeout:<method>` instead of parking the poll loop forever. That is
+  // the property #249 exists to protect, and this feature adds CDP calls to every
+  // op, so it has to be re-asserted here rather than assumed to be inherited.
+  //
+  // Shrunk budgets via the same TEST-ONLY hook the wake/loop tests use, so this
+  // settles in milliseconds rather than 8 real seconds.
+  fresh();
+  await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+  sw.cdp = []; sw.events = [];
+  globalThis.BROWSER_BRIDGE_CDP_TIMEOUTS = { attachMs: 200, commandMs: 40,
+                                             budgetMs: 400 };
+  sw.hangMethod = "Emulation.setDeviceMetricsOverride";
+  try {
+    const t0 = Date.now();
+    const env = await execute({ id: "hung", op: "screenshot", tabId: TAB_A });
+    const elapsed = Date.now() - t0;
+    assert.equal(env.ok, false);
+    assert.equal(env.error, "cdp_timeout:Emulation.setDeviceMetricsOverride",
+      "the hung phase must be NAMED — a generic op_timeout sends the next "
+      + "diagnosis to the wrong place");
+    assert.ok(elapsed < 350,
+      `settled in ${elapsed}ms — it must be bounded by commandMs, not budgetMs`);
+    // The debugger was still released: a hung override cannot leak an attachment.
+    assert.equal(sw.events[sw.events.length - 1], "detach");
+    assert.ok(!methods().includes("Page.captureScreenshot"),
+      "the op's own work must not run after a failed apply");
+  } finally {
+    delete globalThis.BROWSER_BRIDGE_CDP_TIMEOUTS;
+    sw.hangMethod = null;
+  }
+});
+
+test("a bad `emulate` is refused with its NAMED error through execute()", async () => {
+  fresh();
+  const env = await execute({ id: "c3", op: "emulate", tabId: TAB_A,
+                             device: "nokia-3310" });
+  assert.equal(env.ok, false);
+  assert.equal(env.error, "unknown_preset:nokia-3310");
+  assert.deepEqual(sw.cdp, [], "a refused emulate touches no CDP");
+  assert.equal(emulationState.has(TAB_A), false);
+});

--- a/scripts/browser-bridge/tests/protocol.test.mjs
+++ b/scripts/browser-bridge/tests/protocol.test.mjs
@@ -36,8 +36,9 @@ test("op set mirrors the server contract", () => {
   // frames/click/type/key are the CDP (chrome.debugger) ops.
   assert.deepEqual(
     [...ALLOWED_OPS].sort(),
-    ["activate", "click", "close", "eval", "frames", "getHtml", "key", "nav",
-     "open", "ping", "screenshot", "tabs", "text", "type", "upload", "wake"],
+    ["activate", "click", "close", "emulate", "eval", "frames", "getHtml", "key",
+     "nav", "open", "ping", "screenshot", "tabs", "text", "type", "upload",
+     "wake"],
   );
 });
 

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -983,7 +983,7 @@ def test_validate_command_contract():
     assert set(S.ALLOWED_OPS) == {"getHtml", "text", "eval", "tabs", "nav",
                                   "screenshot", "open", "close",
                                   "frames", "click", "type", "key", "wake",
-                                  "activate", "upload", "ping"}
+                                  "activate", "upload", "ping", "emulate"}
     # `upload` is a dispatched, tab-scoped CDP op requiring selector + path.
     assert S.validate_command({"op": "upload", "selector": "#f",
                                "path": "/tmp/x"}) == ("upload", None)
@@ -3115,12 +3115,11 @@ def test_git_short_head_none_on_missing_dir(tmp_path):
 
 def test_manifest_version_reads_current():
     v = S.manifest_version(path=EXT_DIR / "manifest.json")
-    # Bumped to 0.4.0 for the poll-loop no-wedge change (every op bounded +
-    # a keepalive that can actually recover a wedged loop). The bump is the
-    # operator's only falsifiable "is the new build loaded?" signal, so this
-    # assertion is deliberately a literal — it MUST be updated in the same
-    # commit as manifest.json, which is the point.
-    assert isinstance(v, str) and v == "0.4.0"
+    # Bumped to 0.5.0 for the `emulate` op (device emulation). 0.4.0 was the
+    # poll-loop no-wedge change. The bump is the operator's only falsifiable "is
+    # the new build loaded?" signal, so this assertion is deliberately a literal
+    # — it MUST be updated in the same commit as manifest.json, which is the point.
+    assert isinstance(v, str) and v == "0.5.0"
 
 
 def test_manifest_version_prefers_the_deployed_copy_over_the_repo(tmp_path,
@@ -3141,7 +3140,7 @@ def test_manifest_version_falls_back_to_repo_when_not_deployed(tmp_path,
     reporting the repo manifest instead of going null."""
     monkeypatch.setattr(S, "_DEPLOYED_EXT_MANIFEST", tmp_path / "absent.json")
     monkeypatch.setattr(S, "_EXT_MANIFEST_PATH", EXT_DIR / "manifest.json")
-    assert S.manifest_version() == "0.4.0"
+    assert S.manifest_version() == "0.5.0"
 
 
 def test_manifest_version_none_when_neither_exists(tmp_path, monkeypatch):
@@ -4742,3 +4741,185 @@ def test_no_extension_fails_fast_and_names_the_instance_that_dropped():
         assert body["known_instances"][0]["connected"] is False
     finally:
         srv.shutdown(); srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# `emulate`: device emulation — the OWNED-TAB-ONLY blast-radius gate
+#
+# The extension-side behaviour (sticky re-application, the screenshot fast-path
+# refusal, touch clicks) is covered by tests/emulation.test.mjs. What lives HERE is
+# the half only the server knows: which tab a session may emulate at all.
+# --------------------------------------------------------------------------- #
+def test_emulate_is_a_known_tab_scoped_op():
+    assert "emulate" in S.ALLOWED_OPS
+    assert "emulate" in S.TAB_SCOPED_OPS, \
+        "emulate acts on ONE tab, so it must serialize per-tab like every other"
+    assert "emulate" in S.OWNED_TAB_ONLY_OPS
+
+
+def test_emulate_refused_when_the_session_owns_no_tab():
+    """No `open` -> `not_owned_tab`, NOT the active-tab fallback every other
+    tab-scoped op gets. The fallback is safe for a READ; for `emulate` it would
+    resize the tab the OPERATOR is looking at."""
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_echo_exec([]))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _cmd(srv, {"op": "emulate", "device": "iphone-15"}, session="A")
+        assert st == 409
+        assert body["error"] == "not_owned_tab"
+        # It never reached the browser — nothing was emulated.
+        assert all(c["op"] != "emulate" for c in ext.dispatched)
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_emulate_refused_when_tab_override_points_at_someone_elses_tab():
+    """THE reach-around: the session DOES own a tab, but `--tab` names another.
+    Without this check an agent could emulate any tab id it can guess, including
+    the operator's."""
+    srv, reg = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_echo_exec([101]))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        _cmd(srv, {"op": "open"}, session="A")
+        assert reg.owners_snapshot() == {("only", "A"): 101}
+        st, body = _req(srv, "POST", "/cmd",
+                        {"op": "emulate", "device": "iphone-15", "tab": 999},
+                        headers={S.HDR_SESSION_ID: "A"})
+        assert st == 409
+        assert body["error"] == "not_owned_tab"
+        assert all(c["op"] != "emulate" for c in ext.dispatched)
+        # A plain read with the same override is STILL allowed — the gate is
+        # scoped to OWNED_TAB_ONLY_OPS, it did not tighten everything.
+        st, body = _req(srv, "POST", "/cmd", {"op": "getHtml", "tab": 999},
+                        headers={S.HDR_SESSION_ID: "A"})
+        assert st == 200 and body["result"]["data"]["tabId"] == 999
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_emulate_refused_for_a_session_with_no_session_id_at_all():
+    """No X-Session-Id -> owns nothing -> refused. A raw token-holder cannot skip
+    the gate by simply omitting the routing header."""
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_echo_exec([]))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _req(srv, "POST", "/cmd", {"op": "emulate", "device": "iphone-15"})
+        assert st == 409
+        assert body["error"] == "not_owned_tab"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_emulate_on_the_owned_tab_is_dispatched_with_that_tabId():
+    srv, reg = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_echo_exec([101]))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        _cmd(srv, {"op": "open"}, session="A")
+        st, body = _cmd(srv, {"op": "emulate", "device": "iphone-15"}, session="A")
+        assert st == 200
+        assert body["result"]["data"]["tabId"] == 101
+        emu = [c for c in ext.dispatched if c["op"] == "emulate"]
+        assert len(emu) == 1
+        assert emu[0]["tabId"] == 101
+        # The device field is forwarded verbatim — the extension is the single
+        # authority on validating it (one rule, one place).
+        assert emu[0]["device"] == "iphone-15"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_emulate_with_an_explicit_tab_equal_to_the_owned_tab_is_allowed():
+    """`--tab <my own tab>` is the same tab, so it passes. The gate is 'not
+    yours', not 'never use --tab'."""
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_echo_exec([101]))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        _cmd(srv, {"op": "open"}, session="A")
+        st, body = _req(srv, "POST", "/cmd",
+                        {"op": "emulate", "device": "iphone-15", "tab": 101},
+                        headers={S.HDR_SESSION_ID: "A"})
+        assert st == 200
+        assert body["result"]["data"]["tabId"] == 101
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_emulate_telemetry_is_metadata_only(telemetry):
+    """device/viewport are fine; the UA string and the geolocation COORDINATES
+    are not. An emulated lat/lon is a place the operator chose to pretend to be
+    — its presence is worth recording, its value is not the bridge's business."""
+    spool_dir = telemetry
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_tab_echo_exec([101]))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        _cmd(srv, {"op": "open"}, session="A")
+        _wait_events(spool_dir, 1)
+        st, _ = _cmd(srv, {"op": "emulate", "device": "pixel-8",
+                           "width": 412, "height": 915, "mobile": True,
+                           "touch": True,
+                           "ua": "Mozilla/5.0 (Linux; Android 14; SECRETMODEL)",
+                           "geo": {"latitude": 51.5074, "longitude": -0.1278}},
+                      session="A")
+        assert st == 200
+        evs = _wait_events(spool_dir, 2)
+        e = [x for x in evs if json.loads(x["payload"])["op"] == "emulate"][0]
+        p = json.loads(e["payload"])
+        assert p["emu_device"] == "pixel-8"
+        assert p["emu_width"] == 412 and p["emu_height"] == 915
+        assert p["emu_mobile"] is True and p["emu_touch"] is True
+        assert p["emu_geo"] is True, "the PRESENCE of a geo override is recorded"
+        blob = json.dumps(p)
+        assert "SECRETMODEL" not in blob, "the UA string must never be emitted"
+        assert "51.5074" not in blob and "-0.1278" not in blob, \
+            "emulated coordinates must never be emitted"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_emulate_reset_telemetry_says_reset_and_nothing_else():
+    assert S._emulate_extra({"reset": True}) == {"emu_reset": True}  # noqa: SLF001
+    # A raw (preset-less) emulation is labelled "raw", never left absent.
+    out = S._emulate_extra({"width": 390, "height": 844})            # noqa: SLF001
+    assert out["emu_device"] == "raw"
+    assert out["emu_geo"] is False
+    # A non-dict body cannot raise (telemetry is best-effort by contract).
+    assert S._emulate_extra(None) == {}                              # noqa: SLF001
+
+
+def test_not_owned_tab_is_distinct_from_no_owned_tab():
+    """Two different refusals with two different remedies. Collapsing them would
+    tell an operator to run `browser open` when the real problem is that they
+    pointed --tab at their own window."""
+    assert S.NotOwnedTab is not S.NoOwnedTab
+    assert not issubclass(S.NotOwnedTab, S.NoOwnedTab)
+    assert not issubclass(S.NoOwnedTab, S.NotOwnedTab)
+
+
+def test_poll_budget_warning_still_claims_extension_0_4_0_plus():
+    """#248's `applies_to_extension: "0.4.0+"` claim must stay accurate after the
+    manifest bump to 0.5.0 — 0.5.0 IS 0.4.0+, so the claim holds and the string
+    must NOT have been 'helpfully' bumped along with the manifest."""
+    manifest = json.loads(
+        (Path(__file__).resolve().parents[1] / "extension" / "manifest.json")
+        .read_text())
+    major, minor, _ = (int(x) for x in manifest["version"].split("."))
+    assert (major, minor) >= (0, 4), \
+        f"manifest {manifest['version']} no longer satisfies 0.4.0+"


### PR DESCRIPTION
**Stacked on #249** (`fix/browser-bridge-poll-loop-no-wedge`), branched from `70e2642`. #249 already costs the operator a full Brave restart; stacking means one restart covers both. Manifest **0.4.0 → 0.5.0**.

An agent doing mobile testing hit: *"the bridge has no emulation op."* This adds one.

## Op surface

```bash
browser open https://example.com     # emulation is OWNED-TAB-ONLY
browser emulate iphone-15
browser screenshot                   # captured at 393x852 @3x, as an iPhone
browser click '#menu'                # dispatched as a TOUCH tap
browser emulate --reset

browser emulate --list
browser emulate pixel-8 --color-scheme dark --tz Europe/London --geo 51.5074,-0.1278
browser emulate iphone-15 --orientation landscape
browser emulate --width 412 --height 883 --dsf 2.75 --mobile --touch --ua '...'
```

Flags: `--width --height --dsf --mobile/--no-mobile --touch/--no-touch --max-touch-points N --ua STR --orientation portrait|landscape --color-scheme light|dark|no-preference --geo LAT,LON[,ACC] --tz ZONE --reset --list`.

Covers all four requested areas: `Emulation.setDeviceMetricsOverride`, `setTouchEmulationEnabled`, `setUserAgentOverride` (**with `userAgentMetadata`**), `setEmulatedMedia` / `setGeolocationOverride` / `setTimezoneOverride`.

## Presets and where the metrics came from

| preset | CSS viewport | dsf | UA-CH platform |
|---|---|---|---|
| `iphone-15` | 393 x 852 | 3 | `iOS` |
| `iphone-se` | 375 x 667 | 2 | `iOS` |
| `pixel-8` | 412 x 915 | 2.625 | `Android` |
| `ipad-mini` | 768 x 1024 | 2 | `iOS` |
| `galaxy-s24` | 360 x 780 | 3 | `Android` |

These are the vendors' published **logical** resolutions — the figures Chrome DevTools' device list (`front_end/models/emulation/EmulatedDevices.ts`) uses. Each preset carries a `source` string naming its origin, and a test asserts `physical / dsf ~= CSS viewport` so a transcription error in either number fails CI.

:warning: **Not verified against a live DevTools device list** — this was built without touching a browser, deliberately. Treat them as "the published logical resolution", not "byte-equal to whatever DevTools ships this month". If a preset ever disagrees with DevTools, DevTools wins.

Apple presets carry `brands: []` **on purpose** — Safari sends no `Sec-CH-UA` at all. Setting `userAgentMetadata` explicitly still matters: omitting it leaves an iPhone UA next to the operator's real desktop Linux Chrome brands, a combination no real client produces.

## How stickiness is wired

`withCdpSession` **always** detaches in its `finally`, and CDP `Emulation.*` overrides are session-scoped — so they die with that detach. A naive `emulate` would set metrics that had evaporated before the next command ran.

**State**: a module-level `Map<tabId, state>` (`emulationState` in `service_worker.js`), in-memory on purpose — state that outlived the worker would describe an emulation applied nowhere.

**Re-application**: at **`withCdp`'s `run` wrapper**, the one place every CDP op in the file funnels through. Apply-then-act, every session, no call site aware of it. Patching `screenshot` and `click` individually would have fixed today's two cases and regenerated the bug at the next CDP op anyone added.

**Cleared by**: `--reset`, `close`, `chrome.tabs.onRemoved`, and `ownedTabGone()` — a single helper both `targetTab()` and `withCdp`'s attach route through. (A test caught that `targetTab` throws `owned_tab_gone` *before* `withCdp` ever attaches, so clearing only at the attach site left the state stranded; tabIds are recycled, so a stale entry would silently emulate whatever tab inherits the id.)

### The safety property — the reason this beat a held session

**Because the overrides die at detach, the tab is not emulated between ops.** A crashed agent, a killed session, or an evicted MV3 service worker **cannot leave the operator's real browser distorted** — the worst case is a forgotten `Map` entry that dies with the worker. A held-open session would have been simpler to write and strictly worse to own: its failure mode is a permanently mangled tab plus a permanent debug banner, recoverable only by finding and closing the tab.

That is why `--reset` means *"stop re-applying"* — there is nothing live to undo.

Documented in `reference/emulation.md`, `README.md`, and the `protocol.js` header.

**Cost, stated plainly**: a page that re-measures the viewport *after* an op (a `resize` listener, a late layout pass) sees the real window until the next op re-applies.

## Screenshot fast path and the touch click

**`screenshot`**: the `chrome.tabs.captureVisibleTab` fast path is **disabled whenever the tab is emulated**. It never attaches the debugger, so under emulation it would return a perfectly valid PNG of the **un-emulated desktop layout** — a confident wrong answer, indistinguishable from a correct one, on the single op whose entire job is showing what the device sees. Forced to CDP (`via: "cdp"`), and `--fullpage` clips from `Page.getLayoutMetrics` read *after* the overrides land, so the clip is the emulated one. A test asserts both the path choice and the ordering, with a control proving the fast path *is* taken when not emulated.

**`click`**: on a touch-emulated tab the top-frame path dispatches `Input.dispatchTouchEvent` (touchStart/touchEnd) instead of mouse events, as DevTools does. Not cosmetic — Chromium synthesizes compatibility mouse events *from* touch but never touch *from* mouse, so a `touchstart`-only handler never fires under a mouse click, the tap "does nothing", and the agent reports a working page as broken. Mouse remains the behaviour everywhere else; `--no-touch` restores it. Both directions tested.

**`nav`** also routes through CDP `Page.navigate` on an emulated tab, so a UA-sniffing site sees the emulated UA *at navigation* rather than being served the desktop bundle first.

## Blast radius

Owned tabs only, enforced server-side in `_effective_tab_locked` via a new `OWNED_TAB_ONLY_OPS` set. The session must own a tab **and** the resolved target must BE that tab — so an explicit `--tab` cannot reach around ownership onto one of the operator's tabs. Refused with **`not_owned_tab`** (409), deliberately distinct from `no_owned_tab` (different remedies: "run `browser open`" vs "drop the `--tab`").

## Budget interaction with #249

- The apply uses the **wrapped** `send`, so each step is bounded by `CDP_COMMAND_TIMEOUT_MS` — a hung override reports `cdp_timeout:Emulation.<method>` and still detaches (tested with a never-settling promise and shrunk budgets; settles in ~42ms).
- Apply + the op's work stay bounded together by `CDP_OP_BUDGET_MS`, so the **composed worst case is unchanged** and **no term in the `LOOP_STALL_MS` derivation moves** — `execute` was already the 18s term.
- Step count is bounded by a **constant** (`EMULATION_MAX_STEPS` = 6), not by caller input; asserted, along with the two budget values the analysis names.

:warning: **Unmeasured**: how much of the 15s run budget a real apply consumes on a live tab. Loopback `chrome.debugger` calls to a local renderer, *expected* low-millisecond — an expectation, not a measurement. If a legitimate op is ever seen timing out at 18s only when emulated, that is the first number to measure.

## Autonomous agent: deliberately excluded

`emulate` is **not** in `ALLOWED_OPS_DEFAULT` / `OP_TO_SERVER`, so `browser agent` cannot reach it even via `BROWSER_AGENT_ALLOWED_OPS`. Operator-only for now — the agent's op set is deliberately minimal and widening it is a separate decision. To change it: map `emulate -> emulate` in `OP_TO_SERVER` and list it in `ALLOWED_OPS_DEFAULT`. The ownership gate already confines the op to the caller's own tab, so the question is scope discipline, not safety.

## Telemetry

Metadata-only, consistent with existing bridge events: `emu_device`, `emu_width`, `emu_height`, `emu_dsf`, `emu_mobile`, `emu_touch`, `emu_geo`, `emu_reset`. **Excluded**: the UA string (long, operator-supplied; the preset name identifies it) and the geolocation **coordinates** — only their presence is recorded. Asserted by a test that plants a sentinel UA and coordinates and greps the emitted payload.

## Docs

`SKILL.md` gained one row + one reference pointer: **12,028 -> 12,277 bytes**, under the 12,288 ceiling. Detail lives in the new `scripts/browser-bridge/reference/emulation.md`, addressed by repo-absolute path (only `SKILL.md` + the `browser` CLI are symlinked into `~/.claude/skills/browser/`).

`#248`'s `applies_to_extension: "0.4.0+"` claim **stays accurate and was left unchanged** — 0.5.0 satisfies it. A new test asserts the manifest still satisfies `>= 0.4.0`, so the string cannot be "helpfully" bumped along with the manifest.

## Tests

Baseline measured at the branch point `70e2642`: **node 354 / pytest 294**.
This PR: **node 399 / pytest 304**. Both suites green.

New: `tests/emulation.test.mjs` (45 tests) + 10 in `test_server.py`. Coverage includes preset-table integrity (required keys, plausible ranges, physical/dsf consistency, UA-CH present, CLI name-list drift guard), every validation refusal, sticky re-application asserted by **exact CDP method *and* order** against a mock, `nav` ordering, `--reset`/`close`/vanished-tab lifecycle, ownership (including the `--tab` reach-around), screenshot path forcing + fullpage clip, touch-vs-mouse click both ways, UA + metadata together, media/geo/tz, cross-tab isolation, `wake`+`emulate` composition, and the no-wedge failure path.

### Mutation table — 20/20 caught

**Harness validated against known-bad states before any result was read:** it refuses to print a table unless (1) `node`/`nix-shell` resolve *and* the output yields a parseable test count — not merely an exit code; (2) the unmutated control is green on both runners; (3) each mutation's anchor occurs **exactly once** and the file's sha256 **changes** (a byte-identical "mutation" is a hard abort, the documented rig failure here); (4) a deliberately-sabotaged **sentinel** (`emulate` returns a constant) goes **red** — proving a red verdict is reachable at all — and the revert restores green.

Self-check output: `node control GREEN: 45 pass / 0 fail` - `pytest control GREEN: 9 pass / 0 fail` - `sentinel CAUGHT: 28 pass / 17 fail` - `revert restored GREEN: 45 pass / 0 fail`.

| id | mutation | file | result | tests |
|----|----------|------|--------|-------|
| M1 | screenshot fast path no longer checks for emulation | `service_worker.js` | **CAUGHT** | 39 pass / 6 fail |
| M2 | withCdp stops re-applying emulation (sticky removed) | `service_worker.js` | **CAUGHT** | 35 pass / 10 fail |
| M3 | emulation applied AFTER the op's work instead of before | `service_worker.js` | **CAUGHT** | 38 pass / 7 fail |
| M4 | click always dispatches mouse, never touch | `service_worker.js` | **CAUGHT** | 44 pass / 1 fail |
| M5 | UA override drops userAgentMetadata (the missed half) | `protocol.js` | **CAUGHT** | 44 pass / 1 fail |
| M6 | nav ignores emulation and uses chrome.tabs.update | `service_worker.js` | **CAUGHT** | 44 pass / 1 fail |
| M7 | close no longer clears emulation state | `service_worker.js` | **CAUGHT** | 44 pass / 1 fail |
| M8 | a vanished tab keeps its state (recycled-tabId hazard) | `service_worker.js` | **CAUGHT** | 44 pass / 1 fail |
| M9 | `--reset` no longer clears the state | `service_worker.js` | **CAUGHT** | 44 pass / 1 fail |
| M10 | emulationFor ignores the tabId (cross-tab leak) | `service_worker.js` | **CAUGHT** | 44 pass / 1 fail |
| M11 | CDP step order: UA before device metrics | `protocol.js` | **CAUGHT** | 37 pass / 8 fail |
| M12 | applyEmulationSteps swallows a failed step | `protocol.js` | **CAUGHT** | 41 pass / 4 fail |
| M13 | a preset loses its userAgentMetadata | `protocol.js` | **CAUGHT** | 44 pass / 1 fail |
| M14 | width lower bound drops to 0 | `protocol.js` | **CAUGHT** | 44 pass / 1 fail |
| M15 | UA accepts control chars (header-injection primitive) | `protocol.js` | **CAUGHT** | 44 pass / 1 fail |
| M16 | withCdpSession hands `run` the UNBOUNDED send | `protocol.js` | **CAUGHT** | 44 pass / 1 fail |
| M17 | ownership gate removed entirely | `server.py` | **CAUGHT** | 6 pass / 3 fail |
| M18 | ownership gate drops the `--tab` reach-around half | `server.py` | **CAUGHT** | 8 pass / 1 fail |
| M19 | telemetry leaks the UA string and geo coordinates | `server.py` | **CAUGHT** | 7 pass / 2 fail |
| M20 | `emulate` no longer owned-tab-only (set emptied) | `server.py` | **CAUGHT** | 5 pass / 4 fail |

## :red_circle: What still needs a live browser — NOT verified

Green tests are a prerequisite, not verification. **Every CDP assertion here is against a mocked `chrome.debugger.sendCommand`.** That proves the bridge sends the right protocol calls in the right order; it proves nothing about Chromium's behaviour. No live Brave was touched, no service restarted, no `home-manager switch` run, per the brief.

Open items, after the Brave restart #249 already requires:

1. **`browser ping` reports `0.5.0` and lists `emulate`** — the build-freshness gate. Until this passes, nothing below is testable.
2. **`emulate iphone-15` then `browser js --wake 'innerWidth+"x"+innerHeight'` -> `393x852`** — that Chromium actually honours `setDeviceMetricsOverride`, and that it survives to the *next* op (the whole stickiness claim). **`--wake` is required**: bare `js` takes the `chrome.scripting` path and returns the REAL window (see F1 below).
3. **`screenshot` on an emulated tab is visibly a phone-width render**, not a desktop one. The fast-path test proves the *path*; only eyes prove the *pixels*.
4. **`js 'navigator.userAgent'` and `js 'JSON.stringify(navigator.userAgentData)'`** both report the emulated device — the UA-CH half is the one most likely to be subtly wrong.
5. **A real touch-first UI responds to `click`** — that `Input.dispatchTouchEvent` reaches page handlers as a genuine tap.
6. **`nav` on an emulated tab gets the mobile bundle** from a site that serves by UA.
7. **`--geo` / `--tz` / `--color-scheme` take** (`Intl.DateTimeFormat().resolvedOptions().timeZone`, `matchMedia('(prefers-color-scheme: dark)').matches`).
8. **The safety property, observed**: emulate, then confirm the tab is at its *real* size between ops — the claim that a crash cannot leave the browser distorted.
9. **Emulation-apply latency** on a live tab — how much of the 15s run budget 6 `Emulation.*` round-trips actually consume (see the unmeasured budget note above).
10. **`browser text` / `browser html` on an emulated tab return the DESKTOP DOM**, carrying `emulated:false` + `notEmulatedRead:true` + the note — confirming F1's annotation reads correctly in practice, and that a `--wake` read flips it to `emulated:true`.

---

## Audit round (commit `ecfa9c2`)

Adversarial audit returned **merge**; it independently reproduced the test counts and re-derived its own 14 mutations (14/14 caught). Four findings, all taken — extension-side, so they are free against the restart #249 already owes.

**F1 (:red_circle:) — the read path is not emulated, and nothing said so.** `text` / `html` / the default `js` take the `chrome.scripting` path, never attach the debugger, and therefore never reach `withCdp`'s choke point: they return the tab's **real, un-emulated DOM**. Reproduced by a test that asserts **zero** CDP calls and zero attaches on those three ops after `emulate iphone-15`.

Correct-by-design (between ops the tab genuinely isn't emulated — that *is* the safety property), but it is this feature's characteristic failure mode on the read path: screenshot a phone layout, then read `text` and reason about a desktop DOM. `js --wake 'innerWidth'` returns 393 while bare `js 'innerWidth'` returns the real window — same command, two answers.

Fixed **structurally**, not just in prose. Every read of a tab that *has* emulation state now self-announces, in the same spirit as `HIDDEN_TAB_NOTE`:

| path | annotation |
|---|---|
| `text` / `html` / `js`, and `text`/`html --frame` (chrome.scripting) | `{emulated:false, notEmulatedRead:true, emulationNote}` |
| `--wake` reads, `js --frame` (CDP) | `{emulated:true, emulation:{…}}` |
| a tab with **no** emulation state | *neither field* — envelopes unchanged |

`viaCdp` is passed **per call site**, not inferred from the op, because that is genuinely where the answer lives. Docs: a new leading :red_circle: section in `reference/emulation.md` with the per-read table, and `README.md`'s *"the ONE place every CDP op funnels through"* now states plainly that "every CDP op" is not "every op". PR open-item #2 corrected to use `--wake`.

**F2 (:yellow_circle:) — rollback was over-claimed.** Rollback exists only in the **initial** `emulate` apply; a failed **sticky re-apply** retains state and the next op retries. The sentence sat in the general Errors section. Now states both cases, and why retrying is the safer direction — degrading silently to un-emulated is how a desktop screenshot gets labelled as a phone.

**F3 (:yellow_circle:) — raw `--ua` produced incoherent UA-CH.** `platform` came from the `--mobile` *flag*, so an iPhone UA + `--mobile` yielded `platform: "Android"` — exactly the "combination no real client ever produces" the design exists to prevent. Now derived from the **UA string** (new `rawUaMetadata`); an unrecognised UA leaves `platform: ""` rather than guessing, and `brands` stays empty (a wrong brand list is a stronger bot-detection signal than none). Preset metadata was already coherent and is unchanged.

**F4 (:yellow_circle:) — `ipad-mini` renamed, not re-pointed.** `ipad-mini-2019` = 768×1024 (the DevTools entry, still a legitimate tablet breakpoint, `source` string stays true); `ipad-mini` = **744×1133 @2** (1488×2266 physical, 6th-gen — the current shipping device). Renaming avoids silently changing existing callers' results. The `physical ÷ dsf` integrity test covers the new entry for free.

**:green_circle: `chrome.tabs.onReplaced`** is now handled — a prerender/instant swap retires a tabId **without** firing `onRemoved`, stranding a `Map` entry on a recyclable id. Both ids are cleared, and the emulation deliberately does **not** follow the tab: the swapped-in document was rendered without the overrides, so carrying state across would claim an emulation that was never applied.

**Tests after the audit round: 407 node (from 399) / 304 pytest**, both green.

**Mutation sweep re-run and extended: 27 mutants, 27/27 caught**, same self-validating harness (parseable counts, green control on both runners, exactly-one anchor + changed sha256, sabotage sentinel proven RED first). The 7 new mutants target exactly the new guards:

| id | mutation | result |
|----|----------|--------|
| M21 | F1: the read annotation removed entirely | **CAUGHT** (50 pass / 3 fail) |
| M22 | F1: every read claims `emulated:true` (the desktop-DOM lie) | **CAUGHT** (52 / 1) |
| M23 | F1: every read claims `emulated:false` (even `--wake`) | **CAUGHT** (51 / 2) |
| M24 | F3: raw `--ua` platform keyed off the `mobile` flag again | **CAUGHT** (52 / 1) |
| M25 | `onReplaced` handler removed | **CAUGHT** (52 / 1) |
| M26 | F4: `ipad-mini` silently re-pointed to the 2019 metrics | **CAUGHT** (51 / 2) |
| M27 | F1: the note stops naming `--wake` (the remedy an agent learns) | **CAUGHT** (52 / 1) |

`SKILL.md` is unchanged at **12,277 bytes** — the F1 protection is the envelope annotation, which works regardless of which docs were read, so no headroom was spent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
