### PR TITLE
fix(browser-bridge): position-independent CLI flags for js/eval + the emulate-before-nav rule

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -73,11 +73,19 @@
             # real safety_gate/severity_tag/build_summary via bash+jq+grep; without
             # these on PATH the suite pytest-skips and the gate goes green without
             # ever running the invariant (e.g. "TASK-with-risk STILL escalates").
-            # curl: the `browser` CLI talks to the bridge with curl, and
-            # test_browser_cli_args.py drives the REAL script against a stub
-            # LOOPBACK server (still hermetic — no outbound network). Without curl
-            # on PATH that suite pytest-skips and the gate goes green without ever
-            # running the flag-order invariant it exists to pin.
+            # curl: the `browser` CLI shells out to curl, and two suites drive the
+            # REAL script (test_server.py, and test_browser_cli_args.py against a
+            # stub LOOPBACK server — still hermetic, no outbound network).
+            #
+            # MEASURED, not assumed: `nix build .#checks.x86_64-linux.pytests` at
+            # 69f5334 (before this line) exited 1 with
+            #   5 failed, 258 passed, 41 skipped
+            # — four `AssertionError: browser: curl not found on PATH` in
+            # test_server.py (those callers are NOT skip-guarded), plus one
+            # `token file not found/readable` from the --help test. So the gate was
+            # RED, not "green while silently skipping": 41 test_server.py tests
+            # skipped AND five failed. Adding curl here (with the --help/token fix
+            # in the CLI) is what takes it green and makes those 41 actually run.
             nativeBuildInputs = [ pyEnv pkgs.bash pkgs.ripgrep pkgs.git pkgs.util-linux pkgs.jq pkgs.gnugrep pkgs.curl ];
           }
           ''

--- a/flake.nix
+++ b/flake.nix
@@ -73,7 +73,12 @@
             # real safety_gate/severity_tag/build_summary via bash+jq+grep; without
             # these on PATH the suite pytest-skips and the gate goes green without
             # ever running the invariant (e.g. "TASK-with-risk STILL escalates").
-            nativeBuildInputs = [ pyEnv pkgs.bash pkgs.ripgrep pkgs.git pkgs.util-linux pkgs.jq pkgs.gnugrep ];
+            # curl: the `browser` CLI talks to the bridge with curl, and
+            # test_browser_cli_args.py drives the REAL script against a stub
+            # LOOPBACK server (still hermetic — no outbound network). Without curl
+            # on PATH that suite pytest-skips and the gate goes green without ever
+            # running the flag-order invariant it exists to pin.
+            nativeBuildInputs = [ pyEnv pkgs.bash pkgs.ripgrep pkgs.git pkgs.util-linux pkgs.jq pkgs.gnugrep pkgs.curl ];
           }
           ''
             cp -r ${./.} src

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -463,6 +463,21 @@ error. Own-tab-only + typed-op invariants are unchanged (no raw-CDP passthrough)
 Full operator/agent documentation lives in `reference/emulation.md` (preset metrics
 and their provenance, every flag, every error). What follows is the design record.
 
+🔴 **Workflow rule — `emulate` BEFORE you load, not after.** Applying emulation to
+a tab that has **already committed a document** leaves that document without
+`ontouchstart` and without `TouchEvent` (measured 2026-07-31 on live Brave, ext
+0.5.0, `example.com`, `iphone-15`: `"ontouchstart" in window` → `false`,
+`typeof TouchEvent` → `undefined`) while `innerWidth`/`devicePixelRatio`,
+`navigator.maxTouchPoints` (5), `(pointer:coarse)`, `(hover:none)` and the UA/UA-CH
+values are all correct. Those two are installed on the global **at document
+creation**, so a live override cannot add them retroactively; everything else the
+page queries live. A feature-detecting site then reports "no touch support" and an
+agent believes it. The order that works is `browser open` (about:blank) →
+`browser emulate <preset>` → `browser nav <url>` → read/interact; if the tab is
+already on the page, **re-`nav` to it** after `emulate`. There is **no envelope
+warning for this yet** — see "Envelope hint (NOT implemented)" in
+`reference/emulation.md` for the follow-up and why it was not shipped here.
+
 ### The central problem: CDP emulation dies at detach
 
 `withCdpSession` **always** detaches in its `finally` — that is invariant #2, and it

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -140,7 +140,7 @@ exact path — only `SKILL.md` and the `browser` CLI are symlinked into
 | `reference/frames-cdp.md` | `frame_not_found` / `ambiguous_frame` / `oopif_*_cap` / `cdp_attach_refused`; a `--frame` read returned the TOP page; you need to read or drive inside a cross-origin iframe; the debugger banner |
 | `reference/tabs-instances.md` | `ambiguous_instance` / `unknown_instance` / `superseded` / `no_owned_tab` / `owned_tab_gone`; two drivers fighting over one tab; multi-profile or multi-subagent workflows |
 | `reference/css-hit-test.md` | an element is present but invisible/unclickable/painted under something; a `z-index` change "does nothing"; a `data-testid` selector matches NOTHING on a prod page |
-| `reference/emulation.md` | `emulate`: presets, raw overrides, `not_owned_tab`, `unknown_preset:*` |
+| `reference/emulation.md` | `emulate` BEFORE `nav` (else no touch API); presets, overrides, errors |
 | `reference/agent.md` | running `browser agent` — flags, guardrails, prereqs; it returned `blocked`; `op_not_allowed` / `nav_scheme_denied` |
 | `reference/security-ops.md` | 🔴 **you are MODIFYING browser-bridge** (the live-verify-on-real-Brave gate is mandatory); the user asks whether/what it records; first-time setup or a second profile |
 | `reference/x-fallback.md` | CDP `screenshot` is unsatisfactory and you must capture the raw X window (`DISPLAY`/`XAUTHORITY`, xdotool/maim) |

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -288,6 +288,19 @@ case "${1:-}" in
   ""|-h|--help|help) grep -E '^#( |$)' "$0" | sed -E 's/^# ?//'; exit 0 ;;
 esac
 
+# The complete subcommand list, in ONE place: it both VALIDATES the subcommand
+# here (before the token read — a typo must not be reported as a missing token)
+# and supplies the text of the unknown-subcommand error. Keeping it single-source
+# is why this is a variable rather than a second hand-maintained list.
+SUBCOMMANDS="health whoami ping instances open close release wake emulate activate html text js eval tabs nav screenshot frames click type key upload agent"
+_sub_known=0
+for _s in $SUBCOMMANDS; do
+  # A literal string compare, NOT a `case` glob — a subcommand like `*` would
+  # otherwise pattern-match its way past this check.
+  if [ "$_s" = "${1:-}" ]; then _sub_known=1; break; fi
+done
+[ "$_sub_known" -eq 1 ] || die "unknown subcommand: ${1:-} (try: $SUBCOMMANDS)"
+
 SESSION_ID="$(derive_session_id)"
 
 [ -r "$TOKEN_FILE" ] || die "token file not found/readable: $TOKEN_FILE (is the browser-bridge service running?)"
@@ -1194,6 +1207,10 @@ else:
   # ""|-h|--help|help is handled EARLIER (above the token-file read) so that
   # printing usage never requires a token. Nothing reaches this case for it.
   *)
-    die "unknown subcommand: $sub (try: health whoami ping instances open close release wake emulate activate html text js eval tabs nav screenshot frames click type key upload agent)"
+    # BACKSTOP: unreachable while $SUBCOMMANDS matches the arms above (the
+    # pre-token validation already rejected anything unknown). Kept so that a
+    # subcommand added to the list but not to this case fails loudly here rather
+    # than falling through silently.
+    die "unknown subcommand: $sub (try: $SUBCOMMANDS)"
     ;;
 esac

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -134,7 +134,13 @@
 #                               read; optional CSS selector; --max-bytes N caps
 #                               the returned text, default 32768, 0 = uncapped).
 #                               --wake as for `html`
-#   browser js '<js>'         — run JS in the owned/active tab, return its value.
+#   browser js '<js>' [--wake[=MS]]
+#                             — run JS in the owned/active tab, return its value.
+#                               FLAG ORDER IS FREE: `js --wake '<expr>'` and
+#                               `js '<expr>' --wake` are the same command (as are
+#                               the flags on `text`/`html`). For a JS expression
+#                               that STARTS with `-`, end the flags first:
+#                               `browser js -- '-1+2'`.
 #                               ALIAS of `browser eval` (identical semantics/flags,
 #                               and the wire op is `eval` either way). PREFER `js`
 #                               in a worktree-isolated agent: Claude Code's isolation
@@ -583,6 +589,11 @@ case "$sub" in
     # Optional url; default about:blank. Records this session's owned tab.
     if [ $# -ge 1 ]; then
       url="$(json_str "$1")"
+      shift
+      # `open` takes NO flags, so it keeps a bare positional (a URL can never be
+      # confused for a flag). But an extra arg used to be SILENTLY DROPPED — the
+      # same failure mode as the `js` flag-order bug, one step quieter. Reject it.
+      [ $# -eq 0 ] || die "browser open takes at most one url (got extra: $1)"
       cmd_op open "\"url\":${url}" | pretty
     else
       cmd_op open | pretty
@@ -611,7 +622,7 @@ case "$sub" in
         --wait) shift; [ $# -ge 1 ] || die "usage: browser wake [--wait MS]"; wait="$1"; shift ;;
         --wait=*) wait="${1#--wait=}"; shift ;;
         --no-wait) wait="0"; shift ;;
-        --) shift; break ;;
+        --) shift; [ $# -eq 0 ] || die "browser wake takes no positional args (got: $1)"; break ;;
         -*) die "browser wake: unknown flag: $1 (try: --wait MS | --no-wait)" ;;
         *) die "browser wake takes no positional args (got: $1)" ;;
       esac
@@ -680,7 +691,12 @@ case "$sub" in
         --geo=*) emu_geo="${1#--geo=}"; shift ;;
         --tz) shift; [ $# -ge 1 ] || die "--tz needs an IANA zone (e.g. Europe/London)"; emu_tz="$1"; shift ;;
         --tz=*) emu_tz="${1#--tz=}"; shift ;;
-        --) shift; break ;;
+        --) shift
+          while [ $# -gt 0 ]; do
+            [ -z "$emu_device" ] || die "browser emulate takes at most one preset name (got extra: $1)"
+            emu_device="$1"; shift
+          done
+          break ;;
         -*) die "browser emulate: unknown flag: $1 (try: <preset> | --width N --height N [--dsf F] [--mobile] [--touch] [--ua S] [--orientation portrait|landscape] [--color-scheme light|dark] [--geo LAT,LON] [--tz ZONE] | --reset | --list)" ;;
         *) [ -z "$emu_device" ] || die "browser emulate takes at most one preset name (got extra: $1)"
            emu_device="$1"; shift ;;
@@ -774,7 +790,7 @@ sys.stdout.write(json.dumps(fields)[1:-1])
         --wait) shift; [ $# -ge 1 ] || die "usage: browser activate [--wait MS]"; wait="$1"; shift ;;
         --wait=*) wait="${1#--wait=}"; shift ;;
         --no-wait) wait="0"; shift ;;
-        --) shift; break ;;
+        --) shift; [ $# -eq 0 ] || die "browser activate takes no positional args (got: $1)"; break ;;
         -*) die "browser activate: unknown flag: $1 (try: --wait MS | --no-wait)" ;;
         *) die "browser activate takes no positional args (got: $1)" ;;
       esac
@@ -808,7 +824,7 @@ sys.stdout.write(json.dumps(fields)[1:-1])
         --wake=*) wake=1; wakewait="${1#--wake=}";
           case "$wakewait" in (*[!0-9]*|"") die "--wake=MS must be a non-negative integer of ms (got: $wakewait)";; esac
           shift ;;
-        --) shift; break ;;
+        --) shift; [ $# -eq 0 ] || die "browser html takes no positional args (got: $1)"; break ;;
         -*) die "browser html: unknown flag: $1 (try: --max-bytes N | --wake[=MS])" ;;
         *) die "browser html takes no positional args (got: $1)" ;;
       esac
@@ -833,8 +849,13 @@ sys.stdout.write(json.dumps(fields)[1:-1])
         --wake=*) wake=1; wakewait="${1#--wake=}";
           case "$wakewait" in (*[!0-9]*|"") die "--wake=MS must be a non-negative integer of ms (got: $wakewait)";; esac
           shift ;;
-        --) shift; break ;;
-        -*) die "browser text: unknown flag: $1" ;;
+        --) shift
+          while [ $# -gt 0 ]; do
+            [ -z "$sel" ] || die "browser text takes at most one selector (got extra: $1)"
+            sel="$1"; shift
+          done
+          break ;;
+        -*) die "browser text: unknown flag: $1 (try: --max-bytes N | --wake[=MS]; use '--' before a selector starting with '-')" ;;
         *) [ -z "$sel" ] || die "browser text takes at most one selector (got extra: $1)"; sel="$1"; shift ;;
       esac
     done
@@ -855,24 +876,43 @@ sys.stdout.write(json.dumps(fields)[1:-1])
     # un-deprecated (a deprecation warning would just re-introduce the token).
     # ⚠ The WIRE op stays `eval` for BOTH spellings — the extension only knows
     # `eval`, and this is a CLI-surface alias only.
-    [ $# -ge 1 ] || die "usage: browser js '<js>'   (or the identical: browser eval '<js>')"
-    js="$(json_str "$1")"
-    shift
     # --wake evaluates inside a woken (un-throttled, focus-untouched) CDP session —
     # the shape to use when the expression MEASURES live un-throttled state (rAF
     # ticks, a lazily-hydrating SPA) rather than reading persisted DOM.
-    wake=""; wakewait=""
+    #
+    # FLAG ORDER IS FREE (fixed after a live miss): the JS expression used to be
+    # taken as `$1` BEFORE this loop ran, so `browser js --wake '<expr>'` swallowed
+    # the literal string `--wake` as the JS and then rejected the real expression
+    # as "extra" — while `browser js '<expr>' --wake` worked. Both orders are the
+    # SAME command now (matching `text`, which was already order-free). This is not
+    # only a usability wart: the documented emulation verification probe is written
+    # flags-first, so following the docs produced a parse error that read as the
+    # feature being broken.
+    # An expression that legitimately STARTS with `-` (e.g. `-1+2`) is still
+    # rejected as an unknown flag — pass it after the `--` end-of-flags separator:
+    #   browser js -- '-1+2'
+    js=""; js_seen=0; wake=""; wakewait=""
     while [ $# -gt 0 ]; do
       case "$1" in
         --wake) wake=1; shift ;;
         --wake=*) wake=1; wakewait="${1#--wake=}";
           case "$wakewait" in (*[!0-9]*|"") die "--wake=MS must be a non-negative integer of ms (got: $wakewait)";; esac
           shift ;;
-        --) shift; break ;;
-        -*) die "browser js: unknown flag: $1 (try: --wake[=MS])" ;;
-        *) die "browser js takes exactly one JS argument (got extra: $1)" ;;
+        --) # everything after `--` is positional, even if it starts with `-`.
+          shift
+          while [ $# -gt 0 ]; do
+            [ "$js_seen" -eq 0 ] || die "browser js takes exactly one JS argument (got extra: $1)"
+            js="$1"; js_seen=1; shift
+          done
+          break ;;
+        -*) die "browser js: unknown flag: $1 (try: --wake[=MS]; use '--' before a JS expression starting with '-')" ;;
+        *) [ "$js_seen" -eq 0 ] || die "browser js takes exactly one JS argument (got extra: $1)"
+           js="$1"; js_seen=1; shift ;;
       esac
     done
+    # js_seen (not [ -n "$js" ]) so `browser js ''` keeps its old meaning.
+    [ "$js_seen" -eq 1 ] || die "usage: browser js '<js>' [--wake[=MS]]   (or the identical: browser eval '<js>')"
+    js="$(json_str "$js")"
     cmd_op eval "\"js\":${js}$(wake_fields "$wake" "$wakewait")" | pretty
     ;;
   tabs)
@@ -880,7 +920,10 @@ sys.stdout.write(json.dumps(fields)[1:-1])
     ;;
   nav)
     [ $# -ge 1 ] || die "usage: browser nav <url>"
-    url="$(json_str "$1")"
+    url="$(json_str "$1")"; shift
+    # No flags on `nav` → the positional stays bare (a URL never looks like a
+    # flag). Extra args were silently dropped before; make that loud instead.
+    [ $# -eq 0 ] || die "browser nav takes exactly one url (got extra: $1)"
     cmd_op nav "\"url\":${url}" | pretty
     ;;
   screenshot)
@@ -899,8 +942,13 @@ sys.stdout.write(json.dumps(fields)[1:-1])
       case "$1" in
         --fullpage) full="\"fullpage\":true"; shift ;;
         --data-url) dataurl=1; shift ;;
-        --) shift; break ;;
-        -*) die "browser screenshot: unknown flag: $1 (try: --fullpage, --data-url)" ;;
+        --) shift
+          while [ $# -gt 0 ]; do
+            [ -z "$out" ] || die "browser screenshot takes at most one path (got extra: $1)"
+            out="$1"; shift
+          done
+          break ;;
+        -*) die "browser screenshot: unknown flag: $1 (try: --fullpage, --data-url; use '--' before a path starting with '-')" ;;
         *) [ -z "$out" ] || die "browser screenshot takes at most one path (got extra: $1)"; out="$1"; shift ;;
       esac
     done
@@ -1013,7 +1061,10 @@ else:
     # browser [--frame <f>] click <selector> — click the element's center. Top frame:
     # TRUSTED CDP. Cross-origin --frame: SYNTHETIC click injected via chrome.scripting.
     [ $# -ge 1 ] || die "usage: browser [--frame <f>] click <css-selector>"
-    sel="$(json_str "$1")"
+    sel="$(json_str "$1")"; shift
+    # No flags on `click` → the selector stays bare (so a `-`-leading selector
+    # keeps working). Extra args were silently dropped before; make that loud.
+    [ $# -eq 0 ] || die "browser click takes exactly one css-selector (got extra: $1)"
     cmd_op click "\"selector\":${sel}" | pretty
     ;;
   type)
@@ -1025,8 +1076,13 @@ else:
       case "$1" in
         --selector) shift; [ $# -ge 1 ] || die "usage: browser type <text> [--selector <sel>]"; tsel="$1"; shift ;;
         --selector=*) tsel="${1#--selector=}"; shift ;;
-        --) shift; break ;;
-        -*) die "browser type: unknown flag: $1 (try: --selector <sel>)" ;;
+        --) shift
+          while [ $# -gt 0 ]; do
+            [ -z "$txt" ] || die "browser type takes one text arg (got extra: $1)"
+            txt="$1"; shift
+          done
+          break ;;
+        -*) die "browser type: unknown flag: $1 (try: --selector <sel>; use '--' before text starting with '-')" ;;
         *) [ -z "$txt" ] || die "browser type takes one text arg (got extra: $1)"; txt="$1"; shift ;;
       esac
     done
@@ -1043,7 +1099,12 @@ else:
       case "$1" in
         --selector) shift; [ $# -ge 1 ] || die "usage: browser key <name> [--selector <sel>]"; ksel="$1"; shift ;;
         --selector=*) ksel="${1#--selector=}"; shift ;;
-        --) shift; break ;;
+        --) shift
+          while [ $# -gt 0 ]; do
+            [ -z "$kname" ] || die "browser key takes one key name (got extra: $1)"
+            kname="$1"; shift
+          done
+          break ;;
         -*) die "browser key: unknown flag: $1 (try: --selector <sel>)" ;;
         *) [ -z "$kname" ] || die "browser key takes one key name (got extra: $1)"; kname="$1"; shift ;;
       esac

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -136,11 +136,7 @@
 #                               --wake as for `html`
 #   browser js '<js>' [--wake[=MS]]
 #                             — run JS in the owned/active tab, return its value.
-#                               FLAG ORDER IS FREE: `js --wake '<expr>'` and
-#                               `js '<expr>' --wake` are the same command (as are
-#                               the flags on `text`/`html`). For a JS expression
-#                               that STARTS with `-`, end the flags first:
-#                               `browser js -- '-1+2'`.
+#                               FLAG ORDER IS FREE (see "End of flags" below).
 #                               ALIAS of `browser eval` (identical semantics/flags,
 #                               and the wire op is `eval` either way). PREFER `js`
 #                               in a worktree-isolated agent: Claude Code's isolation
@@ -185,6 +181,24 @@
 #   browser agent "<goal>"    — run the autonomous opencode browser-agent in its
 #                               OWN isolated tab against <goal> (see browser-agent)
 #   browser --print-session-id — print the derived per-session id and exit
+#
+# FLAG ORDER / END OF FLAGS
+#   A subcommand's flags may appear BEFORE or AFTER its positional — the two are
+#   the same command. `js --wake '<expr>'` and `js '<expr>' --wake` are identical,
+#   as are `text --max-bytes 64 'h1'` and `text 'h1' --max-bytes 64`.
+#   (`js`/`eval` did NOT honour this before 2026-08-01: it read the positional
+#   before its flags, so a leading --wake was swallowed AS the JS expression.)
+#
+#   `--` ends the flags: every argument after it is positional, even one starting
+#   with `-`. Use it whenever a value could be mistaken for a flag:
+#       browser js -- '-1+2'          browser text -- '-webkit-any'
+#       browser type -- '--force'     browser screenshot -- -weird-name.png
+#   Subcommands taking NO positional (html/wake/activate) reject anything after
+#   `--`; subcommands taking one (js/eval, text, screenshot, type, key, emulate)
+#   accept exactly one, and a SECOND is an error rather than overwriting the
+#   first — including when the first is the empty string.
+#   `nav`/`open`/`click`/`upload` take no flags at all, so their positionals stay
+#   bare and need no `--` (a `-`-leading selector or path just works).
 #
 # Global flags (before the subcommand): --instance <key>, --tab <id>,
 #   --frame <frameId|url-substring> (route a read/click INTO a cross-origin frame).
@@ -263,6 +277,16 @@ while [ $# -gt 0 ]; do
     *) break ;;
   esac
 done
+
+# --help BEFORE the token check. `-h`/`--help`/`help`/no-args reach neither the
+# server nor the token file, so requiring a token to print usage was pure
+# friction — and it FAILED the hermetic nix gate, where no ~/.config exists
+# (measured at 69f5334: test_browser_cli_help_lists_js_alias_and_screenshot_data_url
+# → "token file not found/readable"). Dispatched here rather than in the `case`
+# below, which runs after the token is read.
+case "${1:-}" in
+  ""|-h|--help|help) grep -E '^#( |$)' "$0" | sed -E 's/^# ?//'; exit 0 ;;
+esac
 
 SESSION_ID="$(derive_session_id)"
 
@@ -551,6 +575,44 @@ cmd_op() {
 # JSON-escape a string via python (available everywhere here; avoids jq dep).
 json_str() { python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$1"; }
 
+# --------------------------------------------------------------------------- #
+# "At most one positional" — ONE RULE, ONE PLACE.
+#
+# Six subcommands (js/eval, text, screenshot, type, key, emulate) each accept
+# flags plus AT MOST ONE positional. That rule used to be open-coded per
+# subcommand as `[ -z "$var" ] || die …`, which is WRONG for an empty positional:
+# `""` is falsy, so a second positional silently OVERWRITES the first and goes on
+# the wire with exit 0 — the same wrong-value-on-the-wire class this file's
+# flag-order fix exists to eliminate. Measured before consolidation:
+#
+#   browser type -- '' SECOND   → rc 0, {"op":"type","text":"SECOND"}   ✗
+#   browser text -- '' '#b'     → rc 0, {"selector":"#b"}               ✗
+#
+# Tracking "a positional was SEEN" (not "the variable is non-empty") is the fix.
+# It lives HERE rather than being repeated with a `<sub>_seen` flag six ways,
+# because six copies of one predicate is how a divergent seventh behaviour grows
+# back — which is exactly how this bug reached five call sites in the first place.
+#
+# Contract: a flag loop sets POS="" / POS_SEEN=0 before parsing, calls pos_add in
+# its `*)` arm and pos_rest in its `--` arm, then reads POS / POS_SEEN after.
+# POS_SEEN answers "was one given at all?"; POS is its (possibly empty) value.
+POS=""; POS_SEEN=0
+
+# pos_add LABEL VALUE — record ONE positional, or die naming LABEL.
+pos_add() {
+  [ "$POS_SEEN" -eq 0 ] || die "browser $1 (got extra: $2)"
+  POS="$2"; POS_SEEN=1
+}
+
+# pos_rest LABEL "$@" — everything after `--` is positional, even if it starts
+# with `-`. Routed through pos_add so the one-positional rule cannot diverge
+# between the `*)` arm and the `--` arm (it previously did: `--` silently DROPPED
+# the remainder in all nine loops that had it).
+pos_rest() {
+  local label="$1"; shift
+  while [ $# -gt 0 ]; do pos_add "$label" "$1"; shift; done
+}
+
 sub="${1:-}"; shift || true
 case "$sub" in
   health)
@@ -662,7 +724,7 @@ case "$sub" in
     # lists are identical, so this cannot silently drift — see
     # tests/emulation.test.mjs "CLI preset list matches PRESET_NAMES".
     # PRESET_NAMES: iphone-15 iphone-se pixel-8 ipad-mini ipad-mini-2019 galaxy-s24
-    emu_device=""; emu_reset=0; emu_list=0
+    POS=""; POS_SEEN=0; emu_device=""; emu_reset=0; emu_list=0
     emu_width=""; emu_height=""; emu_dsf=""; emu_mobile=""; emu_touch=""
     emu_mtp=""; emu_ua=""; emu_orient=""; emu_cs=""; emu_geo=""; emu_tz=""
     while [ $# -gt 0 ]; do
@@ -691,17 +753,12 @@ case "$sub" in
         --geo=*) emu_geo="${1#--geo=}"; shift ;;
         --tz) shift; [ $# -ge 1 ] || die "--tz needs an IANA zone (e.g. Europe/London)"; emu_tz="$1"; shift ;;
         --tz=*) emu_tz="${1#--tz=}"; shift ;;
-        --) shift
-          while [ $# -gt 0 ]; do
-            [ -z "$emu_device" ] || die "browser emulate takes at most one preset name (got extra: $1)"
-            emu_device="$1"; shift
-          done
-          break ;;
-        -*) die "browser emulate: unknown flag: $1 (try: <preset> | --width N --height N [--dsf F] [--mobile] [--touch] [--ua S] [--orientation portrait|landscape] [--color-scheme light|dark] [--geo LAT,LON] [--tz ZONE] | --reset | --list)" ;;
-        *) [ -z "$emu_device" ] || die "browser emulate takes at most one preset name (got extra: $1)"
-           emu_device="$1"; shift ;;
+        --) shift; pos_rest "emulate takes at most one preset name" "$@"; break ;;
+        -*) die "browser emulate: unknown flag: $1 (use '--' before a preset name starting with '-'; try: <preset> | --width N --height N [--dsf F] [--mobile] [--touch] [--ua S] [--orientation portrait|landscape] [--color-scheme light|dark] [--geo LAT,LON] [--tz ZONE] | --reset | --list)" ;;
+        *) pos_add "emulate takes at most one preset name" "$1"; shift ;;
       esac
     done
+    emu_device="$POS"
     if [ "$emu_list" -eq 1 ]; then
       printf '%s\n' "device presets (metrics: scripts/browser-bridge/reference/emulation.md):"
       printf '  %s\n' iphone-15 iphone-se pixel-8 ipad-mini ipad-mini-2019 galaxy-s24
@@ -840,7 +897,7 @@ sys.stdout.write(json.dumps(fields)[1:-1])
     # passed to the extension, which normalizes + byte-caps the text.
     # --wake routes this one read through CDP with the un-throttle applied in the
     # same session (see `browser html` / `browser wake`).
-    sel=""; maxb=32768; wake=""; wakewait=""
+    POS=""; POS_SEEN=0; maxb=32768; wake=""; wakewait=""
     while [ $# -gt 0 ]; do
       case "$1" in
         --max-bytes) shift; [ $# -ge 1 ] || die "usage: browser text [selector] [--max-bytes N]"; maxb="$1"; shift ;;
@@ -849,16 +906,12 @@ sys.stdout.write(json.dumps(fields)[1:-1])
         --wake=*) wake=1; wakewait="${1#--wake=}";
           case "$wakewait" in (*[!0-9]*|"") die "--wake=MS must be a non-negative integer of ms (got: $wakewait)";; esac
           shift ;;
-        --) shift
-          while [ $# -gt 0 ]; do
-            [ -z "$sel" ] || die "browser text takes at most one selector (got extra: $1)"
-            sel="$1"; shift
-          done
-          break ;;
+        --) shift; pos_rest "text takes at most one selector" "$@"; break ;;
         -*) die "browser text: unknown flag: $1 (try: --max-bytes N | --wake[=MS]; use '--' before a selector starting with '-')" ;;
-        *) [ -z "$sel" ] || die "browser text takes at most one selector (got extra: $1)"; sel="$1"; shift ;;
+        *) pos_add "text takes at most one selector" "$1"; shift ;;
       esac
     done
+    sel="$POS"
     case "$maxb" in (*[!0-9]*|"") die "--max-bytes must be a non-negative integer (got: $maxb)";; esac
     extra="\"maxBytes\":${maxb}$(wake_fields "$wake" "$wakewait")"
     if [ -n "$sel" ]; then extra="\"selector\":$(json_str "$sel"),${extra}"; fi
@@ -891,28 +944,21 @@ sys.stdout.write(json.dumps(fields)[1:-1])
     # An expression that legitimately STARTS with `-` (e.g. `-1+2`) is still
     # rejected as an unknown flag — pass it after the `--` end-of-flags separator:
     #   browser js -- '-1+2'
-    js=""; js_seen=0; wake=""; wakewait=""
+    POS=""; POS_SEEN=0; wake=""; wakewait=""
     while [ $# -gt 0 ]; do
       case "$1" in
         --wake) wake=1; shift ;;
         --wake=*) wake=1; wakewait="${1#--wake=}";
           case "$wakewait" in (*[!0-9]*|"") die "--wake=MS must be a non-negative integer of ms (got: $wakewait)";; esac
           shift ;;
-        --) # everything after `--` is positional, even if it starts with `-`.
-          shift
-          while [ $# -gt 0 ]; do
-            [ "$js_seen" -eq 0 ] || die "browser js takes exactly one JS argument (got extra: $1)"
-            js="$1"; js_seen=1; shift
-          done
-          break ;;
+        --) shift; pos_rest "js takes exactly one JS argument" "$@"; break ;;
         -*) die "browser js: unknown flag: $1 (try: --wake[=MS]; use '--' before a JS expression starting with '-')" ;;
-        *) [ "$js_seen" -eq 0 ] || die "browser js takes exactly one JS argument (got extra: $1)"
-           js="$1"; js_seen=1; shift ;;
+        *) pos_add "js takes exactly one JS argument" "$1"; shift ;;
       esac
     done
-    # js_seen (not [ -n "$js" ]) so `browser js ''` keeps its old meaning.
-    [ "$js_seen" -eq 1 ] || die "usage: browser js '<js>' [--wake[=MS]]   (or the identical: browser eval '<js>')"
-    js="$(json_str "$js")"
+    # POS_SEEN (not [ -n "$POS" ]) so `browser js ''` keeps its old meaning.
+    [ "$POS_SEEN" -eq 1 ] || die "usage: browser js '<js>' [--wake[=MS]]   (or the identical: browser eval '<js>')"
+    js="$(json_str "$POS")"
     cmd_op eval "\"js\":${js}$(wake_fields "$wake" "$wakewait")" | pretty
     ;;
   tabs)
@@ -920,10 +966,18 @@ sys.stdout.write(json.dumps(fields)[1:-1])
     ;;
   nav)
     [ $# -ge 1 ] || die "usage: browser nav <url>"
-    url="$(json_str "$1")"; shift
+    nav_url="$1"; url="$(json_str "$1")"; shift
     # No flags on `nav` → the positional stays bare (a URL never looks like a
     # flag). Extra args were silently dropped before; make that loud instead.
-    [ $# -eq 0 ] || die "browser nav takes exactly one url (got extra: $1)"
+    # When the FIRST arg looks like a flag, name THAT rather than the trailing
+    # url: `browser nav --wake <url>` is the flag-order confusion this file's
+    # other fix is about, and "got extra: <url>" points at the innocent arg.
+    if [ $# -ne 0 ]; then
+      case "$nav_url" in
+        -*) die "browser nav takes no flags — '$nav_url' was read as the url. Put the url first: browser nav '$1'" ;;
+        *)  die "browser nav takes exactly one url (got extra: $1)" ;;
+      esac
+    fi
     cmd_op nav "\"url\":${url}" | pretty
     ;;
   screenshot)
@@ -937,21 +991,23 @@ sys.stdout.write(json.dumps(fields)[1:-1])
     # DEFAULT (no path) now writes the PNG to a temp file and prints a compact
     # JSON result carrying the PATH + metadata. `--data-url` is the explicit
     # escape hatch that restores the old raw-data-URL output.
-    full=""; out=""; dataurl=0
+    full=""; POS=""; POS_SEEN=0; dataurl=0
     while [ $# -gt 0 ]; do
       case "$1" in
         --fullpage) full="\"fullpage\":true"; shift ;;
         --data-url) dataurl=1; shift ;;
-        --) shift
-          while [ $# -gt 0 ]; do
-            [ -z "$out" ] || die "browser screenshot takes at most one path (got extra: $1)"
-            out="$1"; shift
-          done
-          break ;;
+        --) shift; pos_rest "screenshot takes at most one path" "$@"; break ;;
         -*) die "browser screenshot: unknown flag: $1 (try: --fullpage, --data-url; use '--' before a path starting with '-')" ;;
-        *) [ -z "$out" ] || die "browser screenshot takes at most one path (got extra: $1)"; out="$1"; shift ;;
+        *) pos_add "screenshot takes at most one path" "$1"; shift ;;
       esac
     done
+    # An explicitly-given but EMPTY path is a usage error, not "write a temp file":
+    # POS_SEEN distinguishes `screenshot` from `screenshot -- ''`, and the latter
+    # would otherwise silently fall through to the temp-file branch.
+    if [ "$POS_SEEN" -eq 1 ] && [ -z "$POS" ]; then
+      die "browser screenshot: the path must not be empty"
+    fi
+    out="$POS"
     if [ "$dataurl" -eq 1 ] && [ -n "$out" ]; then
       die "browser screenshot: --data-url and an explicit path are mutually exclusive"
     fi
@@ -1071,21 +1127,17 @@ else:
     # browser [--frame <f>] type <text> [--selector <sel>] — text input into the
     # focused element (or --selector first). Top frame: TRUSTED CDP. Cross-origin
     # --frame: SYNTHETIC input (set value + input/change) via chrome.scripting.
-    txt=""; tsel=""
+    POS=""; POS_SEEN=0; tsel=""
     while [ $# -gt 0 ]; do
       case "$1" in
         --selector) shift; [ $# -ge 1 ] || die "usage: browser type <text> [--selector <sel>]"; tsel="$1"; shift ;;
         --selector=*) tsel="${1#--selector=}"; shift ;;
-        --) shift
-          while [ $# -gt 0 ]; do
-            [ -z "$txt" ] || die "browser type takes one text arg (got extra: $1)"
-            txt="$1"; shift
-          done
-          break ;;
+        --) shift; pos_rest "type takes one text arg" "$@"; break ;;
         -*) die "browser type: unknown flag: $1 (try: --selector <sel>; use '--' before text starting with '-')" ;;
-        *) [ -z "$txt" ] || die "browser type takes one text arg (got extra: $1)"; txt="$1"; shift ;;
+        *) pos_add "type takes one text arg" "$1"; shift ;;
       esac
     done
+    txt="$POS"
     [ -n "$txt" ] || die "usage: browser [--frame <f>] type <text> [--selector <sel>]"
     extra="\"text\":$(json_str "$txt")"
     if [ -n "$tsel" ]; then extra="${extra},\"selector\":$(json_str "$tsel")"; fi
@@ -1094,21 +1146,17 @@ else:
   key)
     # browser [--frame <f>] key <Enter|Tab|Escape|Backspace|Delete|Arrow*|Home|End|Page*>
     #         [--selector <sel>] — dispatch one TRUSTED key to the focused element.
-    ksel=""; kname=""
+    ksel=""; POS=""; POS_SEEN=0
     while [ $# -gt 0 ]; do
       case "$1" in
         --selector) shift; [ $# -ge 1 ] || die "usage: browser key <name> [--selector <sel>]"; ksel="$1"; shift ;;
         --selector=*) ksel="${1#--selector=}"; shift ;;
-        --) shift
-          while [ $# -gt 0 ]; do
-            [ -z "$kname" ] || die "browser key takes one key name (got extra: $1)"
-            kname="$1"; shift
-          done
-          break ;;
-        -*) die "browser key: unknown flag: $1 (try: --selector <sel>)" ;;
-        *) [ -z "$kname" ] || die "browser key takes one key name (got extra: $1)"; kname="$1"; shift ;;
+        --) shift; pos_rest "key takes one key name" "$@"; break ;;
+        -*) die "browser key: unknown flag: $1 (try: --selector <sel>; use '--' before a key name starting with '-')" ;;
+        *) pos_add "key takes one key name" "$1"; shift ;;
       esac
     done
+    kname="$POS"
     [ -n "$kname" ] || die "usage: browser [--frame <f>] key <Enter|Tab|Escape|...> [--selector <sel>]"
     extra="\"key\":$(json_str "$kname")"
     if [ -n "$ksel" ]; then extra="${extra},\"selector\":$(json_str "$ksel")"; fi
@@ -1143,9 +1191,8 @@ else:
     aargs+=("$@")
     exec "$HERE/browser-agent" "${aargs[@]}"
     ;;
-  ""|-h|--help|help)
-    grep -E '^#( |$)' "$0" | sed -E 's/^# ?//'
-    ;;
+  # ""|-h|--help|help is handled EARLIER (above the token-file read) so that
+  # printing usage never requires a token. Nothing reaches this case for it.
   *)
     die "unknown subcommand: $sub (try: health whoami ping instances open close release wake emulate activate html text js eval tabs nav screenshot frames click type key upload agent)"
     ;;

--- a/scripts/browser-bridge/browser-agent
+++ b/scripts/browser-bridge/browser-agent
@@ -78,7 +78,7 @@ print(json.dumps({"answer": sys.argv[1], "evidence": [],
 }
 
 # --- parse args -------------------------------------------------------------- #
-GOAL=""; INSTANCE=""; ALLOW=""; DENY=""; STEPS=12; TIMEOUT=120; DRYRUN=0
+GOAL=""; GOAL_SEEN=0; INSTANCE=""; ALLOW=""; DENY=""; STEPS=12; TIMEOUT=120; DRYRUN=0
 _csv_to_ws() { printf '%s' "$1" | tr ',' ' '; }
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -94,9 +94,19 @@ while [ $# -gt 0 ]; do
     --timeout=*) TIMEOUT="${1#--timeout=}" ;;
     --dry-run) DRYRUN=1 ;;
     -h|--help) grep -E '^#( |$)' "$0" | sed -E 's/^# ?//'; exit 0 ;;
-    --) shift; [ $# -ge 1 ] && GOAL="$1"; break ;;
+    # `--` ends the flags: everything after it is the goal, even if it starts with
+    # `-`. It used to take only the FIRST remaining arg and silently DROP the rest
+    # (`browser agent -- g1 g2` ran with goal "g1"), the same drop-after-`--` shape
+    # fixed in the `browser` CLI's nine loops. GOAL_SEEN (not [ -z "$GOAL" ]) so an
+    # empty first goal cannot be silently overwritten by a second.
+    --) shift
+        while [ $# -gt 0 ]; do
+          [ "$GOAL_SEEN" -eq 0 ] || die "only one goal is accepted (got extra: $1)"
+          GOAL="$1"; GOAL_SEEN=1; shift
+        done
+        break ;;
     -*) die "unknown flag: $1" ;;
-    *) [ -z "$GOAL" ] || die "only one goal is accepted (got extra: $1)"; GOAL="$1" ;;
+    *) [ "$GOAL_SEEN" -eq 0 ] || die "only one goal is accepted (got extra: $1)"; GOAL="$1"; GOAL_SEEN=1 ;;
   esac
   shift
 done

--- a/scripts/browser-bridge/reference/emulation.md
+++ b/scripts/browser-bridge/reference/emulation.md
@@ -12,8 +12,9 @@ Requires extension **0.5.0+**. On an older build the op fails with `unknown_op`
 ## The 30-second version
 
 ```bash
-browser open https://example.com     # emulation is OWNED-TAB-ONLY
-browser emulate iphone-15
+browser open                         # emulation is OWNED-TAB-ONLY (about:blank)
+browser emulate iphone-15            # ← emulate FIRST …
+browser nav https://example.com      # ← … then LOAD. This order is load-bearing.
 browser screenshot                   # ← captured at 393×852 @3x, as an iPhone
 browser click '#menu'                # ← dispatched as a TOUCH tap
 browser emulate --reset
@@ -21,9 +22,77 @@ browser emulate --reset
 
 `browser emulate --list` prints the preset names without touching the browser.
 
-🔴 **Before you trust a `text`/`html`/`js` read on an emulated tab, read
-"`text` / `html` / `js` do NOT read the emulated page" below.** Those three ops
-return the REAL desktop DOM; `--wake` is what reads the emulated one.
+🔴 **Two traps, both of which produce a confident wrong answer. Read both before
+you trust anything you read off an emulated tab:**
+
+1. **Order:** `emulate` **then** `nav`. Emulating an already-loaded page does not
+   give it the touch **API** — see "🔴 Emulate BEFORE you load" immediately below.
+2. **Read path:** `text`/`html`/`js` return the REAL desktop DOM; `--wake` is what
+   reads the emulated one — see "`text` / `html` / `js` do NOT read the emulated
+   page".
+
+---
+
+## 🔴 Emulate BEFORE you load — a live override cannot add the touch API
+
+**Applying `emulate` to a tab that has already committed a document leaves the
+page without `ontouchstart` and without `TouchEvent`, while every other mobile
+signal reads correctly.** A feature-detecting site therefore concludes it is on a
+non-touch device, and an agent reading that concludes the site has no touch
+support. Wrong, confidently, and in exactly the shape this feature exists to
+prevent.
+
+The cause is where each signal lives. `window.ontouchstart` and the `TouchEvent`
+constructor are installed on the global **at document creation** — CDP's
+`Emulation.setTouchEmulationEnabled` sets the flag the *next* document is built
+with, and cannot retroactively install properties on a global that already exists.
+Viewport metrics, media features and the UA/UA-CH values are queried **live** by
+the page every time it asks, so overriding them takes effect immediately.
+
+**Measured** (2026-07-31, live Brave, extension 0.5.0, `https://example.com` in an
+owned tab, `iphone-15`):
+
+| signal | `emulate` on an ALREADY-LOADED page | after `nav` UNDER emulation |
+|---|---|---|
+| `innerWidth` × `innerHeight` | ✅ `393` × `852` | ✅ `393` × `852` |
+| `devicePixelRatio` | ✅ `3` | ✅ `3` |
+| `navigator.maxTouchPoints` | ✅ `5` | ✅ `5` |
+| `matchMedia("(pointer:coarse)")` | ✅ `true` | ✅ `true` |
+| `matchMedia("(hover:none)")` | ✅ `true` | ✅ `true` |
+| `navigator.userAgent` + `userAgentData` | ✅ iPhone / `{mobile:true, platform:"iOS"}` | ✅ same |
+| `"ontouchstart" in window` | ❌ **`false`** | ✅ `true` |
+| `typeof TouchEvent` | ❌ **`undefined`** | ✅ `"function"` |
+
+So: **anything queried live applies at once; anything installed on the global at
+document creation needs a document load.** Today that second set is the touch API
+surface. Treat the list as the measured cases, not as proven exhaustive — any
+other create-time global would behave the same way.
+
+### The rule
+
+```bash
+browser open                      # about:blank — nothing committed yet
+browser emulate iphone-15
+browser nav <url>                 # the document is BUILT under emulation
+# ... now read / click / screenshot
+```
+
+If the tab is already on the page you want, **re-`nav` to it** after `emulate`
+(`browser nav <same-url>`) before reading or interacting. `nav` on an emulated tab
+goes through CDP inside the session that has already applied the overrides, so the
+new document is created with touch enabled and with the mobile UA visible to any
+load-time sniffing.
+
+⚠ The natural-looking order — `open <url>` → `emulate` → interact — is the WRONG
+one, which is why the 30-second recipe above opens `about:blank`. `browser click`
+still dispatches touch *events* on such a tab (that is driven by the stored
+emulation state, not by the page's API surface), so a tap can work while the
+page's own `'ontouchstart' in window` feature-detect has already sent it down the
+desktop branch.
+
+**There is no envelope warning for this yet** — the `emulated`/`notEmulatedRead`
+annotation covers the read-path trap, not this one. See "Envelope hint (not
+implemented)" at the end of this page.
 
 ---
 
@@ -289,6 +358,32 @@ Deliberately **excluded**: the UA string (long, operator-supplied free text; the
 preset name identifies it anyway) and the geolocation **coordinates** — an emulated
 lat/lon is a place the operator chose to pretend to be, and only its *presence* is
 recorded. No URL, no page content, as everywhere else.
+
+---
+
+## Envelope hint (NOT implemented — deliberate, and why)
+
+The lesson from the read-path trap is that **the envelope is the protection that
+works regardless of which docs were read**: `notEmulatedRead` + `emulationNote`
+warn a model that never opened this file. The document-order trap deserves the
+same treatment — `emulate` returning something like
+`documentPredatesEmulation: true` when the target tab already has a committed
+document (anything other than a fresh `about:blank`), with a note saying "re-`nav`
+before reading; the touch API is not installed on this document".
+
+It is **not implemented here on purpose.** The check has to run where the tab's
+state is known — `handleEmulate` in `extension/protocol.js` — so it is an
+extension code change, and the deployed extension is loaded from
+`~/.local/share/browser-bridge-ext/`: shipping it means a manifest bump and a FULL
+Brave restart on **both** profiles, which had just been done for 0.5.0. Doing it
+inside a docs-and-CLI fix would also have meant claiming a behaviour change that
+cannot be live-verified without driving the browser.
+
+**Follow-up, when the next extension bump happens anyway:** add the flag in
+`handleEmulate`, surface it in the CLI as a stderr warning next to the existing
+`_hidden_warn`, and cover it in `tests/emulation.test.mjs`. Until then this page
+and the `README` pointer are the only warning, which is precisely the weaker form
+of protection that motivates doing it.
 
 ---
 

--- a/scripts/browser-bridge/tests/test_browser_agent.py
+++ b/scripts/browser-bridge/tests/test_browser_agent.py
@@ -347,6 +347,33 @@ def test_goal_required(rig):
     assert _browser_calls(rig.frb_log) == []          # no tab opened
 
 
+def test_a_second_goal_after_the_separator_is_rejected_not_dropped(rig):
+    """`--` used to take only the FIRST remaining arg and silently DROP the rest,
+    so `browser agent -- g1 g2` ran with goal "g1" and never said so — the same
+    drop-after-`--` shape fixed in the `browser` CLI's nine loops."""
+    r = rig.run(["--", "goal one", "goal two"])
+    assert r.returncode == 2
+    assert "only one goal" in r.stderr.lower()
+    assert _browser_calls(rig.frb_log) == []          # no tab opened
+
+
+def test_an_empty_first_goal_is_not_silently_overwritten(rig):
+    """GOAL_SEEN, not `[ -z "$GOAL" ]`: an empty first goal must still occupy the
+    slot rather than being overwritten by the next arg."""
+    r = rig.run(["--", "", "sneaky second"])
+    assert r.returncode == 2
+    assert "only one goal" in r.stderr.lower()
+    assert _browser_calls(rig.frb_log) == []
+
+
+def test_a_goal_beginning_with_a_dash_is_reachable_via_the_separator(rig):
+    """The point of keeping `--`: a goal that looks like a flag still parses. It
+    gets past arg-parsing (no "unknown flag"), which is all this asserts."""
+    r = rig.run(["--", "--not-a-flag"])
+    assert "unknown flag" not in r.stderr.lower()
+    assert "goal is required" not in r.stderr.lower()
+
+
 def test_bad_steps_rejected(rig):
     r = rig.run(["do a thing", "--steps", "abc"])
     assert r.returncode == 2

--- a/scripts/browser-bridge/tests/test_browser_cli_args.py
+++ b/scripts/browser-bridge/tests/test_browser_cli_args.py
@@ -20,6 +20,14 @@ a parse error that reads as the FEATURE being broken.
 The invariant pinned here: for every subcommand that accepts both flags and a
 positional, the two orders must produce a BYTE-IDENTICAL request body.
 
+MUTATION RESULT (`git checkout origin/main -- scripts/browser-bridge/browser`,
+control verified non-empty: 21 insertions / 82 deletions):
+  - 14 of these tests go RED on the pre-fix parser — they are genuine REGRESSION
+    coverage.
+  - 5 stay green on the pre-fix parser and are labelled `INVARIANT GUARD` below.
+    They pin behaviour the bug never broke (back-compat that the fix must not
+    take away); they are NOT evidence the fix works.
+
 Run: nix-shell -p python312Packages.pytest curl --run \\
        "pytest scripts/browser-bridge/tests/test_browser_cli_args.py"
 """
@@ -155,7 +163,7 @@ def test_wake_with_ms_is_order_independent(bridge, sub):
 
 
 def test_js_without_wake_sends_no_wake_field(bridge):
-    """The load-bearing half of wake_fields: a plain read must go over the wire
+    """INVARIANT GUARD (green pre-fix). The load-bearing half of wake_fields: a plain read must go over the wire
     byte-identically to before, so the extension keeps the light no-banner path."""
     b = _body(bridge, "js", "document.title")
     assert "wake" not in b and "waitMs" not in b
@@ -176,12 +184,13 @@ def test_js_expression_beginning_with_a_dash_needs_the_end_of_flags_separator(br
 
 
 def test_js_still_accepts_an_empty_expression(bridge):
-    """`browser js ''` kept its old meaning — the parser tracks "a positional was
+    """INVARIANT GUARD (green pre-fix). `browser js ''` kept its old meaning — the parser tracks "a positional was
     SEEN", not "the positional is non-empty"."""
     assert _body(bridge, "js", "")["js"] == ""
 
 
 def test_js_rejects_a_second_expression_and_an_unknown_flag(bridge):
+    """INVARIANT GUARD (green pre-fix) — back-compat on the rejection paths."""
     for args in (("js", "1", "2"), ("js", "--", "1", "2")):
         cp = bridge.run(*args)
         assert cp.returncode != 0, args
@@ -202,6 +211,8 @@ def test_js_with_no_expression_at_all_is_a_usage_error(bridge):
 # pin that it STAYS so, and cover the `--` handling that was fixed alongside).
 # --------------------------------------------------------------------------- #
 def test_text_selector_and_flags_are_order_independent(bridge):
+    """INVARIANT GUARD (green pre-fix) — `text` was ALREADY order-free; this pins
+    that the js/eval fix did not regress the op it was modelled on."""
     a = _body(bridge, "text", "--wake", "--max-bytes", "64", "main h1")
     b = _body(bridge, "text", "main h1", "--wake", "--max-bytes", "64")
     c = _body(bridge, "text", "--max-bytes=64", "main h1", "--wake")
@@ -221,6 +232,8 @@ def test_text_end_of_flags_separator_does_not_swallow_the_selector(bridge):
 # `-`-leading value keeps working), but an extra arg is no longer dropped.
 # --------------------------------------------------------------------------- #
 def test_nav_open_click_keep_a_bare_positional(bridge):
+    """INVARIANT GUARD (green pre-fix) — these take NO flags, so their positional
+    stays bare and a `-`-leading value must keep working with no `--`."""
     assert _body(bridge, "nav", "https://example.com")["url"] == "https://example.com"
     assert _body(bridge, "open", "https://example.com")["url"] == "https://example.com"
     # A selector that starts with `-` must NOT need an escape here.

--- a/scripts/browser-bridge/tests/test_browser_cli_args.py
+++ b/scripts/browser-bridge/tests/test_browser_cli_args.py
@@ -271,6 +271,92 @@ def test_no_positional_subcommands_reject_a_stray_arg_after_the_separator(bridge
 # `emulate` — flags already work on either side of the preset; pin it, and pin
 # that `--` feeds the preset rather than dropping it.
 # --------------------------------------------------------------------------- #
+SINGLE_POSITIONAL = [
+    # subcommand, args producing "empty first positional then a second one",
+    # the fragment of the duplicate-rejection message
+    ("js", ["--", "", "SECOND"], "exactly one JS argument"),
+    ("text", ["--", "", "#second"], "at most one selector"),
+    ("type", ["--", "", "SECOND"], "one text arg"),
+    ("key", ["--", "", "Enter"], "one key name"),
+    ("emulate", ["--", "", "iphone-15"], "at most one preset name"),
+    ("screenshot", ["--", "", "/tmp/x.png"], "at most one path"),
+]
+
+
+@pytest.mark.parametrize("sub,args,needle", SINGLE_POSITIONAL)
+def test_an_empty_first_positional_is_not_silently_overwritten(bridge, sub, args,
+                                                               needle):
+    """REGRESSION (audit finding on PR #251). The five sibling `--` loops used the
+    OLD `[ -z "$var" ] || die` guard, which is FALSY for an empty positional — so a
+    second one silently OVERWROTE the first and went on the wire with exit 0:
+
+        browser type -- '' SECOND   → rc 0, {"op":"type","text":"SECOND"}
+        browser text -- '' '#second' → rc 0, {"selector":"#second"}
+
+    Wrong value on the wire, exit 0 — the exact class this PR exists to remove.
+    All six now route through the single pos_add/pos_rest choke point, which
+    tracks "a positional was SEEN" instead."""
+    before = len(bridge.bodies)
+    cp = bridge.run(sub, *args)
+    assert cp.returncode != 0, f"{sub} {args}: expected a usage error"
+    assert needle in cp.stderr, cp.stderr
+    assert len(bridge.bodies) == before, "nothing may reach the wire on a usage error"
+
+
+@pytest.mark.parametrize("sub,args,needle", SINGLE_POSITIONAL)
+def test_the_same_duplicate_is_rejected_without_the_separator(bridge, sub, args,
+                                                              needle):
+    """The `*)` arm and the `--` arm must agree — they are the same choke point.
+    Same inputs, minus the `--`."""
+    before = len(bridge.bodies)
+    cp = bridge.run(sub, *args[1:])
+    assert cp.returncode != 0, f"{sub} {args[1:]}: expected a usage error"
+    assert needle in cp.stderr, cp.stderr
+    assert len(bridge.bodies) == before
+
+
+def test_screenshot_rejects_an_explicitly_empty_path(bridge):
+    """`screenshot` alone means "write a temp file"; `screenshot -- ''` is a
+    mistake, and POS_SEEN is what distinguishes them."""
+    cp = bridge.run("screenshot", "--", "")
+    assert cp.returncode != 0 and "must not be empty" in cp.stderr
+
+
+def test_nav_error_names_the_flag_not_the_innocent_url(bridge):
+    """`browser nav --wake <url>` is the flag-order confusion this PR is about;
+    pointing at the trailing url ("got extra: https://…") sends the reader to the
+    wrong argument."""
+    cp = bridge.run("nav", "--wake", "https://a.test")
+    assert cp.returncode != 0
+    assert "takes no flags" in cp.stderr and "--wake" in cp.stderr
+    assert "Put the url first" in cp.stderr
+
+
+def test_help_does_not_require_a_token_file(tmp_path):
+    """The hermetic nix gate has no ~/.config, so a token-gated --help FAILED it
+    (measured at 69f5334). --help touches neither the server nor the token."""
+    env = dict(os.environ,
+               BROWSER_BRIDGE_TOKEN_FILE=str(tmp_path / "definitely-absent"))
+    for args in (["--help"], ["-h"], ["help"], []):
+        cp = subprocess.run(["bash", str(CLI), *args], env=env,
+                            capture_output=True, text=True, timeout=60)
+        assert cp.returncode == 0, f"{args}: {cp.stderr}"
+        assert "FLAG ORDER / END OF FLAGS" in cp.stdout, args
+        assert "token file" not in cp.stderr, args
+
+
+def test_help_documents_the_end_of_flags_separator_generally(tmp_path):
+    """`--` semantics changed for six subcommands, so the doc entry must not live
+    only under `js`."""
+    env = dict(os.environ,
+               BROWSER_BRIDGE_TOKEN_FILE=str(tmp_path / "absent"))
+    out = subprocess.run(["bash", str(CLI), "--help"], env=env,
+                         capture_output=True, text=True, timeout=60).stdout
+    head = out.split("FLAG ORDER / END OF FLAGS")[1]
+    for sub in ("js", "text", "type", "screenshot"):
+        assert sub in head, f"{sub} missing from the end-of-flags entry"
+
+
 def test_emulate_preset_and_flags_are_order_independent(bridge):
     a = _body(bridge, "emulate", "--color-scheme", "dark", "iphone-15")
     b = _body(bridge, "emulate", "iphone-15", "--color-scheme", "dark")

--- a/scripts/browser-bridge/tests/test_browser_cli_args.py
+++ b/scripts/browser-bridge/tests/test_browser_cli_args.py
@@ -349,6 +349,41 @@ def test_help_does_not_require_a_token_file(tmp_path):
         assert "token file" not in cp.stderr, args
 
 
+def test_an_unknown_subcommand_is_reported_as_such_without_a_token(tmp_path):
+    """A typo must not be reported as a missing token. This is what still failed
+    the hermetic gate after the --help fix: `browser bogus-op` in a sandbox with
+    no ~/.config died with "token file not found/readable"."""
+    env = dict(os.environ,
+               BROWSER_BRIDGE_TOKEN_FILE=str(tmp_path / "absent"))
+    cp = subprocess.run(["bash", str(CLI), "bogus-op"], env=env,
+                        capture_output=True, text=True, timeout=60)
+    assert cp.returncode != 0
+    assert "unknown subcommand: bogus-op" in cp.stderr
+    assert "token file" not in cp.stderr
+    assert " js " in cp.stderr and " eval " in cp.stderr
+
+
+def test_a_glob_subcommand_cannot_pattern_match_past_the_validation(tmp_path):
+    """The validation compares literally rather than via `case`, so `*` is an
+    unknown subcommand and not a wildcard that matches every known one."""
+    env = dict(os.environ,
+               BROWSER_BRIDGE_TOKEN_FILE=str(tmp_path / "absent"))
+    for bogus in ("*", "?ealth", "[hw]ealth"):
+        cp = subprocess.run(["bash", str(CLI), bogus], env=env,
+                            capture_output=True, text=True, timeout=60)
+        assert cp.returncode != 0, bogus
+        assert f"unknown subcommand: {bogus}" in cp.stderr, cp.stderr
+
+
+def test_a_real_subcommand_still_requires_a_token(tmp_path):
+    """The validation must not have moved the token check off the real path."""
+    env = dict(os.environ,
+               BROWSER_BRIDGE_TOKEN_FILE=str(tmp_path / "absent"))
+    cp = subprocess.run(["bash", str(CLI), "health"], env=env,
+                        capture_output=True, text=True, timeout=60)
+    assert cp.returncode != 0 and "token file not found" in cp.stderr
+
+
 def test_help_documents_the_end_of_flags_separator_generally(tmp_path):
     """`--` semantics changed for six subcommands, so the doc entry must not live
     only under `js`."""

--- a/scripts/browser-bridge/tests/test_browser_cli_args.py
+++ b/scripts/browser-bridge/tests/test_browser_cli_args.py
@@ -20,13 +20,17 @@ a parse error that reads as the FEATURE being broken.
 The invariant pinned here: for every subcommand that accepts both flags and a
 positional, the two orders must produce a BYTE-IDENTICAL request body.
 
-MUTATION RESULT (`git checkout origin/main -- scripts/browser-bridge/browser`,
-control verified non-empty: 21 insertions / 82 deletions):
-  - 14 of these tests go RED on the pre-fix parser — they are genuine REGRESSION
-    coverage.
-  - 5 stay green on the pre-fix parser and are labelled `INVARIANT GUARD` below.
-    They pin behaviour the bug never broke (back-compat that the fix must not
-    take away); they are NOT evidence the fix works.
+MUTATION RESULTS (each control verified genuinely non-empty first):
+
+  Round 1 — `git checkout origin/main -- browser` (21 ins / 82 del):
+    14 RED (regression coverage), 5 green (labelled `INVARIANT GUARD` below —
+    back-compat the fix must not take away; NOT evidence the fix works).
+
+  Round 2 — `git checkout d15e211 -- browser browser-agent` (66/113 and 3/13):
+    14 RED here + 2 in test_browser_agent.py. The `[js-...]` cases of the two
+    empty-first-positional parametrizations stay green because `js` was already
+    fixed in round 1 — for THIS round they are invariant guards, and they are the
+    control that proves the parametrization is pointed at the right defect.
 
 Run: nix-shell -p python312Packages.pytest curl --run \\
        "pytest scripts/browser-bridge/tests/test_browser_cli_args.py"

--- a/scripts/browser-bridge/tests/test_browser_cli_args.py
+++ b/scripts/browser-bridge/tests/test_browser_cli_args.py
@@ -1,0 +1,266 @@
+"""Argument-parsing contract for the `browser` CLI (scripts/browser-bridge/browser).
+
+Fully HEADLESS: no Brave, no extension, no real bridge. A tiny loopback stub HTTP
+server stands in for server.py — it records the exact JSON body the CLI POSTs to
+/cmd and answers with a canned success envelope. So these tests assert on the
+WIRE SHAPE the parser produced, which is the thing that was wrong.
+
+WHY THIS FILE EXISTS (found live on real Brave, 2026-07-31, after PR #250):
+
+    $ browser js --wake 'innerWidth+"x"+innerHeight'
+    browser: browser js takes exactly one JS argument (got extra: innerWidth+...)
+
+`js`/`eval` grabbed its positional as `$1` BEFORE its flag loop ran, so a leading
+`--wake` was swallowed AS the JS expression and the real expression was then
+rejected as "extra". Only the trailing-flag order worked. That is not just a
+usability wart: PR #250's own documented emulation-verification probe (and
+reference/emulation.md) is written flags-first, so an agent following the docs got
+a parse error that reads as the FEATURE being broken.
+
+The invariant pinned here: for every subcommand that accepts both flags and a
+positional, the two orders must produce a BYTE-IDENTICAL request body.
+
+Run: nix-shell -p python312Packages.pytest curl --run \\
+       "pytest scripts/browser-bridge/tests/test_browser_cli_args.py"
+"""
+import json
+import os
+import shutil
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+BB = Path(__file__).resolve().parent.parent          # scripts/browser-bridge
+CLI = BB / "browser"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("curl") is None,
+    reason="the browser CLI is bash and talks to the bridge with curl")
+
+
+# --------------------------------------------------------------------------- #
+# Stub bridge — records every /cmd body, answers a canned success envelope.
+# --------------------------------------------------------------------------- #
+class _Recorder(BaseHTTPRequestHandler):
+    bodies: list = []                                # class-level, per-server reset
+
+    def _reply(self, code, payload):
+        raw = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(n).decode()
+        try:
+            self.bodies.append(json.loads(raw))
+        except ValueError:
+            self.bodies.append({"__unparseable__": raw})
+        # A generic success envelope. `data` deliberately carries no `hidden`
+        # flag, so the CLI's stderr hidden-warning never fires here.
+        self._reply(200, {"ok": True, "result": {"id": "c", "ok": True,
+                                                 "data": {"value": 1}}})
+
+    def do_GET(self):                                # /health etc., unused here
+        self._reply(200, {"ok": True, "instances": []})
+
+    def log_message(self, *a):                       # keep pytest output clean
+        pass
+
+
+@pytest.fixture
+def bridge(tmp_path):
+    """A running stub bridge + the env that points the CLI at it.
+
+    Yields an object with `.run(*args)` → CompletedProcess and `.bodies` (the
+    /cmd request bodies recorded so far, in order).
+    """
+    class _Handler(_Recorder):
+        bodies = []                                  # fresh list per test
+
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+
+    tokfile = tmp_path / "token"
+    tokfile.write_text("test-token-abc123\n")
+
+    env = dict(os.environ)
+    env.update({
+        "BROWSER_BRIDGE_HOST": "127.0.0.1",
+        "BROWSER_BRIDGE_PORT": str(srv.server_address[1]),
+        "BROWSER_BRIDGE_TOKEN_FILE": str(tokfile),
+        # Pin the session id so it can never fall back to the PPID-cached token
+        # (which would write into XDG_RUNTIME_DIR from a test).
+        "CLAUDE_CODE_SESSION_ID": "pytest-cli-args",
+        # `pretty` uses jq when present; not having it just means raw JSON.
+        "HOME": str(tmp_path),
+    })
+
+    class _Bridge:
+        bodies = _Handler.bodies
+
+        @staticmethod
+        def run(*args):
+            return subprocess.run(["bash", str(CLI), *args], env=env,
+                                  capture_output=True, text=True, timeout=60)
+
+    try:
+        yield _Bridge
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def _body(bridge, *args):
+    """Run the CLI, assert it succeeded, return the single recorded /cmd body."""
+    before = len(bridge.bodies)
+    cp = bridge.run(*args)
+    assert cp.returncode == 0, f"args={args!r} rc={cp.returncode} err={cp.stderr}"
+    new = bridge.bodies[before:]
+    assert len(new) == 1, f"args={args!r} produced {len(new)} /cmd requests"
+    return new[0]
+
+
+# --------------------------------------------------------------------------- #
+# Defect 1 — flag order must not change the command (js / eval)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("sub", ["js", "eval"])
+def test_wake_before_and_after_the_js_expression_are_the_same_command(bridge, sub):
+    """THE REGRESSION. Pre-fix, the flags-first form exited 1 with
+    "takes exactly one JS argument (got extra: ...)" and never reached the wire."""
+    expr = 'innerWidth+"x"+innerHeight'
+    flags_first = _body(bridge, sub, "--wake", expr)
+    flags_last = _body(bridge, sub, expr, "--wake")
+    assert flags_first == flags_last
+    # Pin the literal contract, not just the equality (a parser that dropped BOTH
+    # the expression and the flag would also make the two sides equal).
+    assert flags_first["op"] == "eval", "the wire op is `eval` for both spellings"
+    assert flags_first["js"] == expr
+    assert flags_first["wake"] is True
+
+
+@pytest.mark.parametrize("sub", ["js", "eval"])
+def test_wake_with_ms_is_order_independent(bridge, sub):
+    a = _body(bridge, sub, "--wake=250", "1+1")
+    b = _body(bridge, sub, "1+1", "--wake=250")
+    assert a == b
+    assert a["js"] == "1+1" and a["wake"] is True and a["waitMs"] == 250
+
+
+def test_js_without_wake_sends_no_wake_field(bridge):
+    """The load-bearing half of wake_fields: a plain read must go over the wire
+    byte-identically to before, so the extension keeps the light no-banner path."""
+    b = _body(bridge, "js", "document.title")
+    assert "wake" not in b and "waitMs" not in b
+
+
+def test_js_expression_beginning_with_a_dash_needs_the_end_of_flags_separator(bridge):
+    """A positional that legitimately starts with `-` is still reachable — via `--`,
+    which is the documented escape hatch (and is NOT silently dropped)."""
+    b = _body(bridge, "js", "--", "-1+2")
+    assert b["js"] == "-1+2"
+    # ... and it composes with a flag on either side of the separator.
+    assert _body(bridge, "js", "--wake", "--", "-1+2") == \
+        {**b, "wake": True}
+    # Without `--` it is rejected as an unknown flag rather than silently guessed.
+    cp = bridge.run("js", "-1+2")
+    assert cp.returncode != 0
+    assert "unknown flag" in cp.stderr
+
+
+def test_js_still_accepts_an_empty_expression(bridge):
+    """`browser js ''` kept its old meaning — the parser tracks "a positional was
+    SEEN", not "the positional is non-empty"."""
+    assert _body(bridge, "js", "")["js"] == ""
+
+
+def test_js_rejects_a_second_expression_and_an_unknown_flag(bridge):
+    for args in (("js", "1", "2"), ("js", "--", "1", "2")):
+        cp = bridge.run(*args)
+        assert cp.returncode != 0, args
+        assert "exactly one JS argument" in cp.stderr, args
+    cp = bridge.run("js", "1+1", "--nope")
+    assert cp.returncode != 0 and "unknown flag" in cp.stderr
+
+
+def test_js_with_no_expression_at_all_is_a_usage_error(bridge):
+    for args in (("js",), ("js", "--wake")):
+        cp = bridge.run(*args)
+        assert cp.returncode != 0, args
+        assert "usage: browser js" in cp.stderr, args
+
+
+# --------------------------------------------------------------------------- #
+# The other read op with flags + a positional: `text` (already order-free; these
+# pin that it STAYS so, and cover the `--` handling that was fixed alongside).
+# --------------------------------------------------------------------------- #
+def test_text_selector_and_flags_are_order_independent(bridge):
+    a = _body(bridge, "text", "--wake", "--max-bytes", "64", "main h1")
+    b = _body(bridge, "text", "main h1", "--wake", "--max-bytes", "64")
+    c = _body(bridge, "text", "--max-bytes=64", "main h1", "--wake")
+    assert a == b == c
+    assert a["selector"] == "main h1" and a["maxBytes"] == 64 and a["wake"] is True
+
+
+def test_text_end_of_flags_separator_does_not_swallow_the_selector(bridge):
+    """`--` used to `break` the loop and DROP everything after it, so
+    `browser text -- '#id'` read the WHOLE page while looking like it scoped."""
+    b = _body(bridge, "text", "--max-bytes", "99", "--", "#id")
+    assert b["selector"] == "#id" and b["maxBytes"] == 99
+
+
+# --------------------------------------------------------------------------- #
+# Subcommands with a positional and NO flags: the positional stays bare (so a
+# `-`-leading value keeps working), but an extra arg is no longer dropped.
+# --------------------------------------------------------------------------- #
+def test_nav_open_click_keep_a_bare_positional(bridge):
+    assert _body(bridge, "nav", "https://example.com")["url"] == "https://example.com"
+    assert _body(bridge, "open", "https://example.com")["url"] == "https://example.com"
+    # A selector that starts with `-` must NOT need an escape here.
+    assert _body(bridge, "click", "-foo")["selector"] == "-foo"
+
+
+@pytest.mark.parametrize("args,needle", [
+    (("nav", "https://a.test", "https://b.test"), "exactly one url"),
+    (("open", "https://a.test", "https://b.test"), "at most one url"),
+    (("click", "#a", "#b"), "exactly one css-selector"),
+])
+def test_extra_positionals_are_rejected_not_silently_dropped(bridge, args, needle):
+    """Pre-fix these exited 0 having acted on the FIRST arg only — so a
+    flag-order mistake like `browser nav --wake <url>` navigated to "--wake"."""
+    before = len(bridge.bodies)
+    cp = bridge.run(*args)
+    assert cp.returncode != 0, args
+    assert needle in cp.stderr, cp.stderr
+    assert len(bridge.bodies) == before, "nothing may reach the wire on a usage error"
+
+
+# --------------------------------------------------------------------------- #
+# No-positional subcommands: `--` must not hide a stray argument either.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("sub", ["wake", "activate", "html"])
+def test_no_positional_subcommands_reject_a_stray_arg_after_the_separator(bridge, sub):
+    before = len(bridge.bodies)
+    cp = bridge.run(sub, "--", "junk")
+    assert cp.returncode != 0
+    assert "no positional args" in cp.stderr
+    assert len(bridge.bodies) == before
+
+
+# --------------------------------------------------------------------------- #
+# `emulate` — flags already work on either side of the preset; pin it, and pin
+# that `--` feeds the preset rather than dropping it.
+# --------------------------------------------------------------------------- #
+def test_emulate_preset_and_flags_are_order_independent(bridge):
+    a = _body(bridge, "emulate", "--color-scheme", "dark", "iphone-15")
+    b = _body(bridge, "emulate", "iphone-15", "--color-scheme", "dark")
+    c = _body(bridge, "emulate", "--color-scheme", "dark", "--", "iphone-15")
+    assert a == b == c
+    assert a["device"] == "iphone-15" and a["colorScheme"] == "dark"


### PR DESCRIPTION
Two defects found during **live verification** of PR #250 (device emulation, manifest 0.5.0) on real Brave, plus four audit follow-ups. All fixes are **restart-free** — `browser` is deployed as an `mkOutOfStoreSymlink` onto the working tree, and the rest is documentation. **`extension/` is untouched and the manifest is still 0.5.0.**

---

## Defect 1 — `browser js --wake '<expr>'` was rejected

```
$ browser --instance personal --tab N js --wake 'innerWidth+"x"+innerHeight'
browser: browser js takes exactly one JS argument (got extra: innerWidth+"x"+innerHeight)
```

`js`/`eval` took its positional as `$1` **before** its flag loop ran, so a leading `--wake` was swallowed **as** the JS expression and the real expression was then rejected as "extra". Only the trailing-flag order worked.

More than a usability wart: PR #250's own corrected open-item #2 — the probe written to verify the F1 un-emulated-read finding — and `reference/emulation.md:188` are both written **flags-first**, so following the documented verification step produced a parse error that reads as the feature being broken. Those doc sites are now correct rather than rewritten.

### Parser coverage

| subcommand | shape | action |
|---|---|---|
| `js` / `eval` | `--wake[=MS]` + one positional, **grabbed before the loop** | ✅ **FIXED** — both orders now identical |
| `text`, `screenshot`, `type`, `key`, `emulate` | flags + one positional, loop-parsed | already order-free; `--` + duplicate handling fixed |
| `html`, `wake`, `activate` | flags, no positional | `--` handling fixed |
| `nav`, `open`, `click`, `upload` | **no flags at all** | ⏸ **deliberately left bare** |

`js`/`eval` was the only subcommand with both a flag and a pre-loop positional — the only one that could exhibit the reported bug. **Left bare:** `nav`/`open`/`click`/`upload` accept no flags, so there is no both-orders question, and a flag loop would newly reject a `-`-leading URL/selector/path for zero benefit. `browser click '-foo'` still works with no escape, pinned by test.

### Three adjacent silent-drop bugs of the same family

1. **`--` silently discarded everything after it** in **9** flag loops. `browser text -- '#id'` read the whole page while looking like it scoped. Now `--` feeds the positional, or errors if there is nothing to feed.
2. **`nav`/`open`/`click` silently dropped extra positionals** — `browser nav --wake <url>` exited 0 having navigated to the literal `--wake`. Now rejected, and the error names **the flag**, not the innocent trailing url.
3. **An empty first positional was silently overwritten** (audit finding — the one that put a wrong value on the wire with exit 0). See below.

### Follow-up 1 — one choke point, not a sixth copy of the flag

The first round fixed `js` with a `js_seen` flag but left five sibling loops on the old `[ -z "$var" ]` guard, which is **falsy for an empty positional**, so a second one overwrote the first:

```
type -- '' SECOND        →  rc 0  {"op":"type","text":"SECOND"}       ✗
text -- '' '#second'     →  rc 0  {"selector":"#second"}              ✗
emulate -- '' iphone-15  →  rc 0  {"device":"iphone-15"}              ✗
key  -- '' Enter         →  rc 0  {"key":"Enter"}                     ✗
```

Rather than copy `<sub>_seen` a sixth way, all six now route through **one** `pos_add`/`pos_rest` choke point that tracks "a positional was SEEN". Six copies of one predicate is how the divergent seventh grows back — which is how this reached five call sites to begin with.

`browser-agent`'s goal loop was the last member of the family (`browser agent -- g1 g2` silently dropped `g2`) and is fixed the same way.

### Test coverage + mutation

`scripts/browser-bridge/tests/test_browser_cli_args.py` — **38 tests, fully headless**. A stub loopback HTTP server stands in for `server.py` and records the exact JSON body the real `browser` script POSTs to `/cmd`, so assertions are on the **wire shape the parser produced**.

| round | control (verified non-empty first) | RED at control | green at control |
|---|---|---|---|
| 1 | `checkout origin/main -- browser` (21 ins / 82 del) | **14** | 5 — labelled `INVARIANT GUARD` |
| 2 | `checkout d15e211 -- browser browser-agent` (66/113, 3/13) | **14** + 2 in `test_browser_agent.py` | 3 (`js`, already fixed in round 1) |

All green at HEAD. The invariant guards are labelled in the file and are **not** counted as regression coverage.

---

## Defect 2 — emulating an already-loaded page does not install the touch API

Measured on `https://example.com`, owned tab, `iphone-15`, ext 0.5.0, 2026-07-31:

| signal | `emulate` on an ALREADY-LOADED page | after `nav` UNDER emulation |
|---|---|---|
| `innerWidth` × `innerHeight` | ✅ 393 × 852 | ✅ 393 × 852 |
| `devicePixelRatio` | ✅ 3 | ✅ 3 |
| `navigator.maxTouchPoints` | ✅ 5 | ✅ 5 |
| `matchMedia("(pointer:coarse)")` | ✅ true | ✅ true |
| `matchMedia("(hover:none)")` | ✅ true | ✅ true |
| `navigator.userAgent` + `userAgentData` | ✅ iPhone / `{mobile:true, platform:"iOS"}` | ✅ same |
| `"ontouchstart" in window` | ❌ **false** | ✅ true |
| `typeof TouchEvent` | ❌ **undefined** | ✅ `"function"` |

`ontouchstart` and the `TouchEvent` constructor are installed on the global **at document creation**, so a live override cannot add them retroactively. Everything else the page queries **live**, so it applies immediately. A feature-detecting site therefore concludes there is no touch support and an agent believes it.

**Documented:**
- **`reference/emulation.md`** — new 🔴 "Emulate BEFORE you load" section with the measured table, the mechanism, and the rule. The 30-second recipe itself was fixed (it opened a URL first, i.e. taught the wrong order), and its lead-in now names **both** traps.
- **`README.md`** — a workflow-rule pointer carrying the measured values so it stands alone.
- **`SKILL.md`** — the reference row now reads ``` `emulate` BEFORE `nav` (else no touch API) ```, **byte-neutral at 12,277** (ceiling 12,288).

**Envelope hint (`documentPredatesEmulation`) — considered, deliberately NOT implemented.** It is the right answer for the F1 reason (the envelope protects regardless of which docs were read), but the check must run in `handleEmulate` in `extension/protocol.js` → manifest bump → full Brave restart on both profiles, which the operator had just done. Written up as a follow-up in `reference/emulation.md` with the code and test locations; the docs say plainly *"there is no envelope warning for this yet"*.

---

## Follow-up 2/3 — the hermetic flake gate was RED at base, and is now GREEN

The first round's `flake.nix` comment asserted an unmeasured property ("the gate goes green having never run the invariant"). **I measured it. The truth was worse and the comment is now the measurement:**

| | `nix build .#checks.x86_64-linux.pytests` |
|---|---|
| base `69f5334` | **rc 1** — `5 failed, 258 passed, 41 skipped` (4× `browser: curl not found on PATH` in `test_server.py`, 1× `token file not found/readable`) |
| this branch | **rc 0** — browser-bridge suite `345 passed`, 0 skipped |

The gate was never green-while-skipping; it was **red**, with 41 `test_server.py` tests silently skipping *and* five failing. Two CLI changes were needed to close it:

1. **`--help` above the token check.** Printing usage required a token file, which the sandbox has no `~/.config` for.
2. **Subcommand validation above the token check.** `--help` alone was not enough — `browser bogus-op` still died with "token file not found/readable" instead of "unknown subcommand", which is exactly what `test_browser_cli_help_lists_js_alias_and_screenshot_data_url` asserts on. The subcommand list now lives in a single `$SUBCOMMANDS` variable used by **both** the validation and the error text, compared **literally** rather than via a `case` glob (so `browser '*'` is an unknown subcommand, not a wildcard matching every known one).

Taking the repo's hermetic gate from red to green is worth more than the rest of this PR.

---

## Follow-up 4 — small items

- `-*)` "use `--` before …" hints added for `emulate` and `key` (their `--` semantics changed identically to the ones that already had it).
- `browser nav --wake <url>` now errors with *"takes no flags — '--wake' was read as the url. Put the url first"* rather than naming the innocent trailing url.
- `--` is documented as a **general** `FLAG ORDER / END OF FLAGS` entry in `--help`, not only under `js`.
- Loop count corrected: `--) shift; break` was in **9** loops at base, not 8. All nine are fixed.
- `browser-agent`'s `--` no longer drops a second goal.

---

## Test results vs measured baseline

Baselines measured in this worktree, not taken on trust.

| suite | base `69f5334` | HEAD |
|---|---|---|
| node (`browser-bridge/tests/*.test.mjs`) | 407 pass / 0 fail | **407 pass / 0 fail** (no JS touched) |
| pytest (`browser-bridge/tests`, dev host) | 304 passed | **345 passed** (+41) |
| **`nix build .#checks…pytests`** (hermetic gate) | **rc 1 — 5 failed, 258 passed, 41 skipped** | **rc 0 — green** |

Green tests are a **prerequisite, not verification**.

## Could not settle without a live browser

- The parser is verified against a **stub** bridge. The wire body is asserted byte-for-byte, so the parse is proven; that the extension then behaves is inherited from #250 and unchanged.
- The Defect 2 table is the operator's live measurements, transcribed — **not** re-measured here (this PR ran zero browser ops).
- Whether any signal *besides* `ontouchstart`/`TouchEvent` is create-time-only is **not** proven; the docs state the list is the measured cases, not an exhaustive one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
