### PR TITLE
feat(browser): flip the skill to agent-first for open-ended reads

### DIFF
--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -14,10 +14,41 @@ $BB --instance <key> --tab <id> text   # cheap read of a specific tab
 ```
 
 🔴 **Run `whoami` first on every fresh browser task.** Both hosts are hostname
-`nixos`, and this session's loopback bridge could be either machine with several
-Brave profiles — confirm the host and pick the right `--instance` before acting.
+`nixos` and this bridge could be either, with several Brave profiles — confirm the
+host and pick the right `--instance` before acting.
 
 Full architecture / security model: `scripts/browser-bridge/README.md`.
+
+## FIRST DECISION: agent or direct?
+
+**Open-ended READ — "go find X and tell me Y" → reach for `browser agent` FIRST.**
+A cheap autonomous model works in its OWN isolated tab and returns a compact
+`{answer,evidence,steps_used,status}` — the page HTML (10K–100K tokens on a heavy
+page) never enters YOUR context.
+
+    browser agent "go to news.ycombinator.com and report the top 3 story titles"
+
+**Drive ops directly when** the task is **precise** (URL + selector/JS known, 1–3
+ops) · **interactive** (click/type/submit/upload) · **diagnostic** (you must SEE a
+screenshot, or hit-test paint order) · **secret** — agent-read pages go to
+**OpenRouter/DeepSeek**: never banking, private mail, credential managers, or
+anything you wouldn't hand a third party. Nor **virtualised/lazy-loaded lists**.
+
+SEE the page → drive. KNOW something from it → agent. Ambiguous → agent first;
+taking over costs ~200 tokens, so agent-first wins even at a low success rate.
+
+**Measured** (14 goals, each run ONCE; laptop `.155`, `personal`, opencode 1.18.4,
+`deepseek-v4-flash`, 2026-07-31): **13/14 correct**, ~**$0.0025**/run, median
+**22.65s**. One run per goal = wide CI; read it as "≈0.9", not a rate.
+
+`blocked` → non-zero exit, take over. `partial` → read `evidence`, drive the rest.
+Thin `evidence` is a weak smell, **NOT** protection against a wrong answer — the
+one wrong run quoted its unrendered page verbatim, and the check would have flagged
+a *correct* run. What protects you: the deterministic auto-`wake` on a hidden
+`text`/`html` read (that was the one failure; fixed), and cheap escalation — if the
+answer depends on rendered SPA state, confirm with ONE `text --wake`. **Ignore
+`steps_used`** (undercounted, 5/14). Keep `--allow-domains` TIGHT *and* list the
+frame hosts you expect. → `reference/agent.md`
 
 ## Ops
 
@@ -30,7 +61,7 @@ Result payloads land under `.result.data`.
 | `whoami` | **read-only identity** (global; no `--instance`/`--tab`) — host label (`laptop`/`workbench`), connected instances (active-tab **domain** only), bridge diagnostics + `extension_version_current` |
 | `health` | connected instances + count, each with an explicit `extension_stale` verdict (`true`/`false`; `null` = undecidable) vs `extension_version_current` |
 | `ping` | **which extension build+dir is loaded?** → `{pong,extensionVersion,id,ops}`; older build → `unknown_op`. The only deterministic answer after a ↻ reload |
-| `instances` | list connected instances as JSON (key, label, instanceId, active-tab url/title) |
+| `instances` | connected instances as JSON (key, label, instanceId, active-tab url/title) |
 | `open [url]` | open a NEW tab this session owns (default `about:blank`, **created in the BACKGROUND/hidden**), returns `tabId`. Idempotent. Use for multi-step work |
 | `close` / `release` | close this session's owned tab / drop ownership without closing it |
 | `tabs` | list open tabs (`.data.ownedTabId` flags yours) |
@@ -46,14 +77,11 @@ Result payloads land under `.result.data`.
 | `upload <selector> <path>` | populate an `<input type=file>` via CDP `DOM.setFileInputFiles` — Chrome reads the file by path, **no bytes cross the bridge**. AUDIT-LOGGED, **operator-only** (the agent gets `op_not_allowed:upload`) |
 | `wake [--wait MS]` | **UN-THROTTLE a hidden/background tab with NO focus movement** — the fix for an empty or `hidden` read. ~1.5s settle, cap **6s**. **Wake once per PAGE, not per read**: the un-throttled state ends at detach, but the DOM the page rendered PERSISTS for a following cheap read |
 | `text\|html\|js --wake[=MS]` | run THAT ONE read inside the woken CDP session — only when the read must observe live un-throttled state. `text`/`html --wake` read from an ISOLATED world; `js --wake` is MAIN world by definition. `--wake` + `--frame` is refused (`wake_with_frame_unsupported`) |
-| `activate` | **⚠⚠ STEALS THE OPERATOR'S SCREEN — the ONE intrusive op, a LAST RESORT.** It is **NOT** the fix for a hidden/unrendered tab — that is `wake`. Use it only for something needing the REAL foreground (a browser permission prompt, a native file picker, seeing it with your own eyes), at most **once per TAB, never per read**. i3-gated; unreachable by the autonomous agent |
+| `activate` | **⚠⚠ STEALS THE OPERATOR'S SCREEN — the ONE intrusive op, a LAST RESORT.** It is **NOT** the fix for a hidden/unrendered tab — that is `wake`. Read `reference/spa-wake.md` BEFORE using it |
 | `emulate <preset>\|--reset` | **device emulation** (mobile testing) on a tab you `open`ed. Sticky; owned-tab-only → `reference/emulation.md` |
-| `agent "<goal>"` | run the autonomous opencode browser-agent in its OWN isolated tab; returns compact `{answer,evidence,steps_used,status}` instead of page HTML → `reference/agent.md` |
-| `--print-session-id` | print the derived per-session id (debug) |
+| `agent "<goal>"` | the autonomous browser-agent — see **FIRST DECISION** above, then `reference/agent.md` |
 
-## 🔴 Four traps that return a WRONG answer SILENTLY
-
-These stay here because you only learn you needed them *after* being misled.
+## 🔴 Three traps that return a WRONG answer SILENTLY
 
 1. **`js`/`eval` evaluates ONE EXPRESSION, not a script.** A multi-statement body
    (`window.scrollBy(0,1400); "ok"`) returns **`null` with no error** — it looks
@@ -67,22 +95,6 @@ These stay here because you only learn you needed them *after* being misled.
    case. Check `data.hidden` / `document.visibilityState`, then **`wake`** — never
    `activate`, and spoofing `visibilityState` does not recover the page.
    → `reference/spa-wake.md`
-4. **A stale loaded extension answers `unknown_op`** for an op the CLI knows, and
-   **reload ↻ in `brave://extensions` is UNRELIABLE** (the long-poll keeps the old
-   service worker alive) — a **full quit-and-reopen of Brave** is the reliable fix.
-   → `reference/errors.md`
-
-**Cookies / authenticated requests.** There is no cookie op (no `cookies`
-permission, on purpose), and `document.cookie` is structurally blind to **HttpOnly**
-— which a session cookie always is. Don't extract the cookie; **make the request
-from inside the page**, so no credential ever enters the transcript:
-
-```bash
-browser js '(async function(){ const r = await fetch("/api/thing", {credentials:"include"}); return JSON.stringify({status:r.status, body:(await r.text()).slice(0,500)}) })()'
-```
-
-The promise IS awaited. ⚠ This does **not** work on CSP-strict origins (GitHub,
-Discord, …) — there, `text`/`html` are the only reads that work.
 
 ## When things look broken — triage
 
@@ -94,44 +106,32 @@ Discord, …) — there, `text`/`html` are the only reads that work.
    connected count can be coming from a DIFFERENT instance. → `reference/errors.md`
 2. **A read is empty / half-built / `data.hidden:true`** → the tab is throttled.
    `browser wake`, then re-read. → `reference/spa-wake.md`
-3. **`null` from `js`/`eval`** → multi-statement body first, then page CSP. Fall
-   back to `text`/`html` before concluding the bridge is down.
-4. **`unknown_op` on an op the CLI knows** → stale extension; full Brave restart.
+3. **`null` from `js`/`eval`** → trap 1, then trap 2. Fall back to `text`/`html`
+   before concluding the bridge is down.
+4. **`unknown_op` on an op the CLI knows** → stale extension. Reload ↻ is
+   UNRELIABLE (the long-poll keeps the old worker alive) — full Brave restart.
 5. **Any other unrecognised error string** → look it up in `reference/errors.md`.
-6. **Never diagnose a site OUTAGE from a browser read.** "Is this broken for real
-   users?" is answered by server-side evidence (RUM, metrics, pod health, an
-   anonymous `curl`). A hidden-tab read once produced a confident, false, site-wide
-   outage report. → `reference/spa-wake.md`
+6. **Never diagnose a site OUTAGE from a browser read** — a hidden-tab read once
+   produced a confident, false, site-wide outage report. "Broken for real users?"
+   needs server-side evidence (RUM, metrics, pod health, an anonymous `curl`).
+   → `reference/spa-wake.md`
 
 ## This is the user's LIVE session
 
 It's their real browser, not a scratch VM. Don't `nav` a tab that may hold unsaved
-work (a half-typed comment, a form, a logged-in console) — `open` your own tab, or
-use an obviously disposable one. If anything moved their focus, **restore it**
+work (a half-typed comment, a form) — `open` your own tab, or use an obviously
+disposable one. If anything moved their focus, **restore it**
 (`i3-msg '[id="<prev-winid>"] focus'`).
 
-**Concurrent drivers (esp. sibling subagents) → each `open` and thread its own
-`--tab <id>`.** Sibling subagents of one parent SHARE a session id (they inherit
-`CLAUDE_CODE_SESSION_ID` + `$TMUX_PANE`), so without an explicit `--tab` they fight
-over the SAME tab. Do **not** run a bare high-rate `eval` loop — it saturates the
-single serial extension connection and gets `429 rate_limited`.
-→ `reference/tabs-instances.md`
-
-## Before you rely on it
-
-1. `browser health` — if `extension_connected:false` or it errors, the extension
-   isn't loaded/paired. Tell the user to load + pair it (`reference/security-ops.md`);
-   you cannot do this for them (it's a manual Brave step).
-2. **Verify it's the LIVE authenticated session**: after a read, confirm the content
-   contains **logged-in-only** material (their name, account menu, inbox). If it
-   looks logged-out/anonymous, the wrong tab is active or they aren't logged in —
-   say so rather than proceeding.
+**Concurrent drivers (esp. sibling subagents, which SHARE one session id) → each
+`open` and thread its own `--tab <id>`**; and no high-rate `js` loop (the extension
+connection is serial → `429 rate_limited`). → `reference/tabs-instances.md`
 
 ## Reference files — load ONE only when its trigger fires
 
-**Read them at `~/workspace/devrc/scripts/browser-bridge/reference/<file>`.** (That
-exact path — only `SKILL.md` and the `browser` CLI are symlinked into
-`~/.claude/skills/browser/`; `reference/` is not.)
+**Read them at `~/workspace/devrc/scripts/browser-bridge/reference/<file>`** — that
+exact path; only `SKILL.md` + the `browser` CLI are symlinked into
+`~/.claude/skills/browser/`, `reference/` is not.
 
 | file | load it when… |
 |---|---|
@@ -142,5 +142,6 @@ exact path — only `SKILL.md` and the `browser` CLI are symlinked into
 | `reference/css-hit-test.md` | an element is present but invisible/unclickable/painted under something; a `z-index` change "does nothing"; a `data-testid` selector matches NOTHING on a prod page |
 | `reference/emulation.md` | `emulate` BEFORE `nav` (else no touch API); presets, overrides, errors |
 | `reference/agent.md` | running `browser agent` — flags, guardrails, prereqs; it returned `blocked`; `op_not_allowed` / `nav_scheme_denied` |
+| `reference/auth-pages.md` | an authenticated request; you were about to read a cookie; a read looks logged-OUT; `extension_connected:false` |
 | `reference/security-ops.md` | 🔴 **you are MODIFYING browser-bridge** (the live-verify-on-real-Brave gate is mandatory); the user asks whether/what it records; first-time setup or a second profile |
 | `reference/x-fallback.md` | CDP `screenshot` is unsatisfactory and you must capture the raw X window (`DISPLAY`/`XAUTHORITY`, xdotool/maim) |

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -44,8 +44,9 @@ taking over costs ~200 tokens, so agent-first wins even at a low success rate.
 `blocked` → non-zero exit, take over. `partial` → read `evidence`, drive the rest.
 Thin `evidence` is a weak smell, **NOT** protection against a wrong answer — the
 one wrong run quoted its unrendered page verbatim, and the check would have flagged
-a *correct* run. What protects you: the deterministic auto-`wake` on a hidden
-`text`/`html` read (that was the one failure; fixed), and cheap escalation — if the
+a *correct* run. What protects you: the agent tool's auto-`wake` on a hidden
+`text`/`html` read (that was the one failure; closed by construction, NOT
+live-verified), and cheap escalation — if the
 answer depends on rendered SPA state, confirm with ONE `text --wake`. **Ignore
 `steps_used`** (undercounted, 5/14). Keep `--allow-domains` TIGHT *and* list the
 frame hosts you expect. → `reference/agent.md`

--- a/scripts/browser-bridge/reference/agent.md
+++ b/scripts/browser-bridge/reference/agent.md
@@ -54,8 +54,15 @@ different model, or run-to-run variance.
   at 48.7s and 59.0s / 8–12 tool calls.
 - The **one wrong answer** (`status:"ok"`, confidently wrong) came from reading an
   unrendered shell in a throttled hidden tab — 1 of 13 `ok` runs (7.7%). That is the
-  failure the deterministic auto-wake below now closes; it was not a reasoning
-  failure and no other run produced a wrong `ok`.
+  failure the agent tool's deterministic auto-wake below closes **by construction**
+  — it is NOT yet live-verified against that run, because F2 has not been
+  reproducible since (2026-08-01: with auto-wake disabled, and again with `wake`
+  denied outright, the rig rendered before the agent's slower read landed and both
+  controls returned the CORRECT answer). The auto-wake mechanism itself IS
+  live-verified: a real run's audit shows `auto_wake` → `auto_wake_exec` (wake) →
+  `auto_wake_exec` (re-read) → `auto_wake_ok woke:true settleMs:1500`. Closing the
+  gap needs a fixture that stays an unrendered shell for ≥30s. It was not a
+  reasoning failure, and no other run produced a wrong `ok`.
 - The out-of-allowlist guardrail behaved exactly as documented: clean
   `status:"blocked"`, exit 1, empty evidence, no fabrication, no hang.
 

--- a/scripts/browser-bridge/reference/agent.md
+++ b/scripts/browser-bridge/reference/agent.md
@@ -29,10 +29,77 @@ command unrunnable, which is why fixing the first didn't appear to help:
 entire arc.** They are not version-related — both hosts run opencode 1.18.4 and both
 resolve browser-only. Do not re-open that hypothesis.
 
-⚠ **Capability is still UNMEASURED** beyond two trivial tasks — "it runs" is not "it
-is good at this". The proposed default flip to `browser agent`-first is deliberately
-**NOT shipped**, pending a ~10-goal / ~$0.06 measurement of real success rate. Do not
-flip it on arithmetic (token-cost) reasoning alone.
+✅ **The `browser agent`-first default IS shipped** (SKILL.md → `## FIRST DECISION`).
+It was held back until capability was measured rather than argued from token
+arithmetic; the measurement is
+`~/workspace/devrc/claudedocs/browser-bridge-deepseek-measurement-2026-07-31.md`.
+
+## What was measured — and the scope it was measured at
+
+**Scope, so the numbers carry it:** host **laptop `192.168.50.155`**, instance
+**`personal`**, extension 0.2.0, `opencode` **1.18.4**, model
+**`openrouter/deepseek/deepseek-v4-flash`** as OpenRouter routed it on
+**2026-07-31**, defaults `--steps 12` / `--timeout 120`, **14 goals each run exactly
+ONCE**. Nothing here is evidence about the workbench (`.250`), the `work` profile, a
+different model, or run-to-run variance.
+
+- **13/14 answers correct.** Excluding the deliberate out-of-allowlist guardrail
+  case: 12/13. One run per goal, so the 95% binomial CI is ≈**0.66–0.998** — read it
+  as "≈0.9", not as a rate.
+- **~$0.0025 per run** (sum of attributed per-run deltas, $0.0345 over 14 runs;
+  the campaign credit delta $0.0702 is an upper bound — that OpenRouter key is
+  shared with other tooling).
+- **Median wall-clock 22.65s**, range 11.9s–59.0s. Simple single-page reads: median
+  18.1s, always 2 tool calls. Blind-click interactive goals were the expensive shape
+  at 48.7s and 59.0s / 8–12 tool calls.
+- The **one wrong answer** (`status:"ok"`, confidently wrong) came from reading an
+  unrendered shell in a throttled hidden tab — 1 of 13 `ok` runs (7.7%). That is the
+  failure the deterministic auto-wake below now closes; it was not a reasoning
+  failure and no other run produced a wrong `ok`.
+- The out-of-allowlist guardrail behaved exactly as documented: clean
+  `status:"blocked"`, exit 1, empty evidence, no fabrication, no hang.
+
+### 🔴 Do NOT sell `evidence` as protection against a wrong answer
+
+The design doc proposed "`status:"ok"` but empty/unquoted `evidence` → treat as
+`partial`" as a **prerequisite** for the flip. The measurement **falsified that as a
+safety net** and it was demoted:
+
+- It would have flagged goal **B**, which was **correct** (its evidence was a
+  paraphrase, not a substring of any tool output) — a false positive.
+- It would **not** have flagged **F2**, the only wrong answer, because F2 quoted its
+  unrendered page **verbatim**. The evidence was perfectly faithful; the *page* was
+  in the wrong state.
+
+Evidence grounding is anti-**confabulation** hygiene, and worth keeping as such. It
+is not a correctness check. The real protections are (a) the deterministic
+auto-`wake` below, and (b) escalation being cheap — taking over from the agent costs
+~200 tokens, which is why agent-first wins even at a low success rate.
+
+### Guardrails the measurement named
+
+1. **Don't default to the agent for virtualised / lazy-loaded list content.** The
+   civitai card-list goal only worked because the model woke the tab twice and then
+   read `html`; the list could not be reproduced through `text` on a hidden tab even
+   after waking.
+2. **Keep `--allow-domains` tight, and include the frame hosts you expect.** Measured
+   at two points on the same nested-OOPIF goal: with the frame hosts allowlisted the
+   model **skipped `frames`** and top-level-`nav`'d to each iframe URL in turn (right
+   answer, 7 calls); with the allowlist tightened to `127.0.0.1` only, it called
+   `frames`, picked the deepest `frameId`, and used `eval --frame` (right answer).
+   A tight allowlist is what pushes it onto the correct path.
+3. **Ignore `steps_used`.** It disagreed with the tool audit in **5 of 14** runs and
+   **always undercounted** (5 vs 7, 8 vs 12, 5 vs 7, 4 vs 6, 7 vs 8). Don't reason
+   from it; `BROWSER_AGENT_KEEP_SCRATCH=1` + `tool-audit.jsonl` is the ground truth.
+4. **Privacy is a hard boundary, not a preference** — see the ⚠ Privacy bullet below.
+
+### Measured but NOT measured — don't over-claim
+
+`status:"partial"` was **never produced** by any run, so its behaviour is unmeasured.
+Nor were: needle-in-a-haystack reads over long innerText, the step-budget/timeout
+boundaries (nothing exhausted either), failure paths other than the domain guardrail,
+authenticated/high-secret pages (deliberately excluded), prompt injection or hostile
+pages, and `activate` (never invoked).
 
 Offload an open-ended "go read X and tell me Y" browsing task to a **cheap
 autonomous agent** (opencode + DeepSeek `deepseek-v4-flash` via OpenRouter) so it
@@ -174,7 +241,9 @@ browser agent "go to news.ycombinator.com and report the top 3 story titles" \
   opencode JSON transcript + a metadata-only tool audit are kept
   in a scratch dir. **Domain deny is best-effort** (see note below).
 - **⚠ Privacy:** the pages the agent reads are sent to **OpenRouter/DeepSeek**.
-  Do NOT point it at high-secret authenticated pages casually.
+  Never point it at banking, private mail, a credential manager, or anything you
+  would not hand to a third party. This is the one part of the agent-first default
+  that is not a judgement call.
 - **⚠ Domain deny is a mitigation, not a guarantee.** The tool refuses a `nav` to
   a denied host, but it cannot see a page's own client-side redirect (meta-refresh
   / `location=` after an allowed nav) — the bridge navigates the tab and the tool

--- a/scripts/browser-bridge/reference/auth-pages.md
+++ b/scripts/browser-bridge/reference/auth-pages.md
@@ -1,0 +1,67 @@
+# Authenticated pages — cookies, in-page requests, and proving it's the live session
+
+**Load this when:** you need an **authenticated request** against a site the user is
+logged into · you were about to read or extract a **cookie** · a read looks
+logged-OUT and you need to decide whether to proceed · `browser health` says
+`extension_connected:false` and you're wondering what you can do about it.
+
+Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`.
+Full architecture + the verification log for the measurements below:
+`~/workspace/devrc/scripts/browser-bridge/README.md`.
+
+## There is no cookie op — and `document.cookie` can't see the one that matters
+
+The extension deliberately holds **no `cookies` permission**, so there is no
+`browser cookies`. The only cookie surface is `document.cookie` via `js`/`eval`, and
+it is **structurally blind to `HttpOnly`** — which a session/auth cookie essentially
+always is. The cookie that matters is exactly the invisible one.
+
+On a **CSP-strict** origin the injected script does not run at all, so a cookie read
+there returns `null` with **no error** — indistinguishable from a broken bridge.
+
+This was considered and rejected on purpose (README records the decision so it isn't
+re-litigated): a real cookie op would mean a broad new permission, hard-denying it to
+the autonomous browser-agent the way `upload` is, and accepting that session tokens
+land in Claude transcripts, which persist on disk.
+
+## Sanctioned pattern: don't extract the cookie — make the request INSIDE the page
+
+An in-page `fetch(url, {credentials:"include"})` attaches the cookies (HttpOnly
+included) automatically and returns only the response data. No new permission, and no
+credential *value* ever enters the transcript or hits disk.
+
+`js`/`eval` takes ONE expression, so use an async IIFE. The promise **is** awaited
+(`chrome.scripting` on the top frame; CDP `awaitPromise:true` for `--frame`), so you
+get the resolved value, not a pending Promise:
+
+```bash
+browser js '(async function(){ const r = await fetch("/api/thing", {credentials:"include"}); return JSON.stringify({status:r.status, body:(await r.text()).slice(0,500)}) })()'
+```
+
+Verified live 2026-07-30 against real Brave (laptop, both profiles):
+
+- Same origin (`openrouter.ai`), same path, status only: `credentials:"include"` →
+  **404**, `credentials:"omit"` → **401**. The differing status proves the HttpOnly
+  session cookie WAS attached by the in-page fetch, with no cookie value crossing
+  into the transcript.
+- `(async function(){ return "resolved:"+(1+1) })()` → `"resolved:2"` — the async-IIFE
+  shape yields a resolved value.
+- CSP contrast: on a `github.com` tab `browser js 'location.host'` → `null` (no
+  error) while `text`/`html` work; the identical eval on `openrouter.ai` →
+  `"openrouter.ai"`.
+
+🔴 **Limitation, stated plainly:** the in-page fetch pattern does **NOT** work on
+CSP-strict origins (GitHub, Discord, …) — no injected script runs there, so an
+authenticated API call through the page is unavailable and `text`/`html` are the
+only reads that work.
+
+## Before you rely on a read: prove it's the LIVE authenticated session
+
+1. **`browser health`** — if `extension_connected:false` or it errors, the extension
+   isn't loaded/paired. **Tell the user to load + pair it** (→ `reference/security-ops.md`);
+   you **cannot** do this for them, it is a manual Brave step.
+2. **Confirm the content is logged-in-only.** After a read, look for material that
+   only an authenticated session would show — their name, an account menu, an inbox.
+   If it looks logged-out or anonymous, either the wrong tab is active or they aren't
+   logged in on that profile. **Say so rather than proceeding** — a logged-out read
+   silently answers a different question than the one you were asked.


### PR DESCRIPTION
Ships the `browser agent`-first default flip. Designed in
`claudedocs/browser-bridge-token-and-agent-design-2026-07-30.md` §B.1–B.2, deliberately held
pending a capability measurement. That measurement is now done
(`claudedocs/browser-bridge-deepseek-measurement-2026-07-31.md`, verdict **SHIP WITH NAMED
GUARDRAILS**) and its one blocker — the throttled-tab trap — shipped as the deterministic
auto-wake in #243. So the gate is closed.

## What changed

**`## FIRST DECISION: agent or direct?` now lives in the CORE**, immediately after Quick start
and **before** the op table. Before this, `agent` was one row in a 13-row table with no decision
rule, while the core actively steered toward `text`.

### The correction: the drafted evidence rule is NOT shipped as written

The §B.2 draft told the reader that `status:"ok"` with empty/unquoted `evidence` should be
treated as `partial` — presented as the safety net for the flip. The measurement **falsified
that**:

- it **would** have flagged goal **B**, which was **correct** (its evidence was a paraphrase,
  not a substring of any tool output) — a false positive;
- it would **not** have flagged **F2**, the only wrong answer, because F2 quoted its
  (unrendered shell) page **verbatim**. The evidence was perfectly faithful; the *page* was in
  the wrong state.

Kept as a weak smell, explicitly **not** sold as protection. The section states the real
protections instead: the deterministic auto-`wake` on a hidden `text`/`html` read (#243), and
the fact that taking over costs ~200 tokens, so agent-first wins even at a low success rate.
`reference/agent.md` records the demotion with both counter-examples.

### Guardrails the measurement named, now stated with the flip

- Don't default to the agent for **virtualised / lazy-loaded list content**.
- Keep `--allow-domains` **tight, including expected frame hosts** — measured at two points: with
  frame hosts allowlisted it top-level-nav'd to each iframe URL; tightened to `127.0.0.1` it
  correctly discovered `frames` and used `--frame`.
- **Ignore `steps_used`** — it undercounted in 5/14 runs, always low.
- **Privacy**: agent-read pages go to OpenRouter/DeepSeek. Never banking, private mail,
  credential managers, or anything you wouldn't hand a third party.

Numbers are cited as measured, with scope attached (laptop `.155`, `personal`, opencode 1.18.4,
`deepseek-v4-flash`, 2026-07-31, **each goal run exactly once**): 13/14 correct, ~$0.0025/run,
median 22.65s, CI ≈0.66–0.998. `reference/agent.md` also lists what was **not** measured
(`status:"partial"` never occurred, needle-in-haystack, budget boundaries, hostile pages,
the other host/profile, variance).

## The byte budget

`SKILL.md` **12,277 → 12,182** of the **12,288**-byte ceiling — **106 bytes headroom**.

Per the prior audit's guidance, no aggressive compression of the fat `activate`/`screenshot`/`js`
rows (that would have cost exactly the warnings that stop `activate` stealing the operator's
screen). Instead, the #233/#235 pattern — coherent blocks moved wholesale, chosen by what a
reader does **not** need before choosing an op:

| evicted | bytes | went to |
|---|---|---|
| Cookies / authenticated-request recipe | 653 | **new** `reference/auth-pages.md` |
| `## Before you rely on it` (health prereq + verify-logged-in) | 540 | **new** `reference/auth-pages.md` |
| `activate` row detail → 120 B stub keeping the ⚠⚠ screen-theft warning | ~263 net | `reference/spa-wake.md` (already owns it) |
| trap #4 (stale extension / ↻ unreliable) | ~330 | `reference/errors.md`; triage #4 absorbs the fix |
| `--print-session-id` op row | 63 | `reference/tabs-instances.md` |
| concurrent-drivers paragraph → one-liner | ~220 | `reference/tabs-instances.md` |

Plus small wording trims (whoami note, triage 3/6, LIVE-session para, reference-table intro).
One pointer row added for `auth-pages.md`; the reference table's repo-absolute-path convention is
unchanged (the prefix is stated once for the whole table).

## How I verified nothing was lost

A **52-fact coverage check** plus one ordering assertion, over the corpus a reader is actually
pointed at (`SKILL.md` ∪ `reference/*.md` ∪ `README.md` ∪ project `CLAUDE.md`), whitespace-
normalized and case-insensitive so a fact still matches under a different line wrap. Every
evicted or trimmed operational fact is an entry — the HttpOnly blindness, the exact in-page
`fetch` recipe, the CSP-strict limitation, "you cannot pair it for them", the logged-out guard,
each `activate` caveat, `↻ is UNRELIABLE`, the shared-session-id hazard, `429 rate_limited`,
`--print-session-id` — plus the new FIRST DECISION content and its placement.

**Mutation-tested before trusting it** (a check I haven't watched fail proves nothing):
- delete `reference/auth-pages.md` → **red**, 6 facts;
- delete `reference/spa-wake.md` → **red**, 5 `activate` facts;
- move FIRST DECISION below the op table → **red** on the ordering assertion;
- revert the evidence-rule correction to the draft wording → **red**.

One deliberate non-failure worth naming: mutating the `fetch` recipe *inside* `auth-pages.md`
alone stays green, because `README.md` also carries it and the check's contract is "reachable",
not "in one specific file".

## Tests + gate (measured here, vs the stated baseline at `9b50458`)

| | baseline | this branch |
|---|---|---|
| `node --test scripts/browser-bridge/tests/*.test.mjs` | 407 | **407 pass / 0 fail** |
| `pytest scripts/browser-bridge/tests -q` | 345 | **345 passed** |
| `nix build .#checks.x86_64-linux.pytests` | green (#251) | **green** |

No code changed, so no behavioural claim is made here beyond what the measurement doc and #243
already establish. Nothing was run against live Brave, no `browser agent` invocation, no
`home-manager switch`, no `activate`.

## Files I did NOT touch (flagged instead, per the dispatch)

Owned by sibling agents this round: `README.md`, `extension/README.md`, `reference/errors.md`,
`reference/emulation.md`, `CLAUDE.md`, `server.py`, `extension/**`.

Two things a follow-up should consider:
1. **`CLAUDE.md`'s browser-bridge paragraph** still describes `agent` as one op among many and
   carries the "capability unmeasured" framing implicitly. It should mention the agent-first
   default and the `reference/auth-pages.md` file (the reference list there names 8 files; it's
   now 10 with `emulation.md` and `auth-pages.md`).
2. **`README.md`** duplicates the cookies/in-page-fetch material that now also lives in
   `reference/auth-pages.md`. I left README as the architecture + verification-log home and made
   the reference file the operational one; if you'd rather have one copy, README's version should
   shrink to a pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
