### PR TITLE
docs(browser-bridge): the last two path→id hedges say MEASURED

### DIFF
--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -52,11 +52,12 @@
 #                               hint. Use this — not two version strings — to
 #                               answer "did my ↻ actually load the new
 #                               extension?". `id` is path-derived, so it also
-#                               answers "from WHICH directory?" (INFERRED from
-#                               Chromium docs, not measured — compare it against
-#                               the id you recorded after re-pointing, not
-#                               against a guess). Pass --instance when two
-#                               profiles are connected, else 409 ambiguous.
+#                               answers "from WHICH directory?" — MEASURED, and
+#                               PREDICTABLE in advance: sha256(abs path), first
+#                               32 hex chars, each nibble 0-f mapped to a-p. See
+#                               extension/README.md -> "The path→id derivation
+#                               (MEASURED)". Pass --instance when two profiles
+#                               are connected, else 409 ambiguous.
 #   browser instances         — list connected instances as JSON (key/label/url)
 #   browser open [url]        — open a NEW tab this session owns (default about:blank);
 #                               subsequent ops route to it. Prints its tabId.

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -3630,9 +3630,12 @@ def test_whoami_stale_verdict_is_null_for_an_unreporting_extension():
 # The version fields cannot answer this — a repo-path 0.3.1 and a deployed-path
 # 0.3.1 are identical on every version field. chrome.runtime.id is path-derived,
 # so it is the only signal that can confirm the migration off the git-mutable
-# path took. (The path→id derivation itself is INFERRED from documented Chromium
-# behaviour, not measured here — which is exactly why the server only REPORTS
-# the id and never computes an expected one.)
+# path took. (The path→id derivation is now MEASURED — sha256(abs path), first 32
+# hex chars, nibbles mapped a-p; see extension/README.md. The server still only
+# REPORTS the id and never computes an expected one: that is a deliberate
+# separate decision, because an unknown path — a hand-loaded third profile, or a
+# rollback to the repo path — must degrade to null, never to a false "wrong
+# directory" alarm.)
 def test_health_and_whoami_surface_the_reported_extension_id():
     srv, _ = _serve()
     ext = FakeExtension(srv, instance_id="a", label="alpha",


### PR DESCRIPTION
Follow-up to #252, which upgraded nine sites but left two it did not own:

- `scripts/browser-bridge/browser:55-56` — the CLI `ping` help comment
- `scripts/browser-bridge/tests/test_server.py:3633-3634` — the rationale above the ext-id header test

Both said the path→id derivation was `INFERRED from Chromium docs, not measured`. It is measured now (see #252 and `extension/README.md` → "The path→id derivation (MEASURED)").

`git grep -nE 'INFERRED|not measured'` over `scripts/browser-bridge` now returns **no** path→id hits.

The test comment additionally records why the server still only *reports* the id and never computes an expected one — an unknown path (hand-loaded third profile, or a rollback to the repo path) must degrade to `null`, never to a false "wrong directory" alarm.

Comments only, no behaviour change. `bash -n` clean; pytest **345 passed** (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)