### PR TITLE
feat(dl-router): per-player download buttons, 'already have this' badge, and durable state.pending

### DIFF
--- a/scripts/dl-router/config.example.toml
+++ b/scripts/dl-router/config.example.toml
@@ -112,3 +112,32 @@ max_jobs = 4
 # [site_rules."example-site.test"]
 # subject = ["a.performer-name", ".subject-link"]
 # tags    = [".tag-list a"]
+#
+# --- two layers, keyed on two different hosts ---------------------------------
+# A forum page's videos are usually CROSS-ORIGIN IFRAMES to an embed host, and
+# the two questions have to be asked in two different documents:
+#
+#   * the CONTEXT layer, keyed on the PAGE host -- what is this page about?
+#     That is `subject`/`tags` above (or the explicit `.context` sub-table
+#     below, which wins where both exist). Read in the top frame.
+#   * the PLAYER layer, keyed on the EMBED host -- where is the media element
+#     and how is its URL read? Read INSIDE the embed frame, which is a
+#     different origin and therefore a different key in this same table.
+#
+# Keying the player rule on the forum does not work: the forum's embed wrapper
+# is host-agnostic, so it would match embeds from hosts you have no rule for.
+# An embed host with no player rule simply gets no button.
+#
+# [site_rules."forum.example.test".context]
+# subject = ["h1.thread-title"]
+#
+# [site_rules."embedhost.example.test".player]
+# container = "#video-container"     # one button per match (required)
+# mount     = "#video-wrapper"       # where inside it to mount (optional)
+# label     = "Save to library"      # optional, <= 40 chars
+# # The media-URL accessor. READ AT CLICK TIME, never cached: these URLs are
+# # commonly signed with a short expiry and re-signed in place on the same
+# # element, so a value read when the button was drawn is already stale.
+# # `attr` is an attribute (or same-named property) NAME, never an expression:
+# # config is data, and there is no path here that evaluates a string.
+# media     = { element = "video#main-video", attr = "src" }

--- a/scripts/dl-router/config.py
+++ b/scripts/dl-router/config.py
@@ -301,6 +301,60 @@ def _validate(data: dict) -> None:
     rules = data.get("site_rules")
     if rules is not None and not isinstance(rules, dict):
         raise ConfigError("site_rules must be a table keyed by hostname")
+    _validate_site_rules(rules or {})
+
+
+def _validate_site_rules(rules: dict) -> None:
+    """Structural checks on the two-layer rule table.
+
+    Deliberately STRUCTURAL only -- types and required fields, not the selector
+    grammar. The grammar is enforced where it is consumed
+    (player_buttons.normalisePlayerRule), which fails closed to "no button" so
+    a bad selector costs one player rather than the sidecar.
+
+    A wrong SHAPE is different: `media = "video"` instead of a table is a typo
+    that would otherwise produce a rule the extension silently discards, with
+    nothing anywhere saying why. Raising here surfaces it in `/healthz` and
+    `dl-route status` via the degraded-config path, which is the one place the
+    operator looks.
+    """
+    for host, entry in rules.items():
+        where = f"site_rules.{host!r}"
+        if not isinstance(entry, dict):
+            raise ConfigError(f"{where} must be a table")
+        for layer, table in (("", entry), ("context", entry.get("context"))):
+            if table is None:
+                continue
+            if not isinstance(table, dict):
+                raise ConfigError(f"{where}.context must be a table")
+            label = f"{where}.{layer}" if layer else where
+            for key in ("subject", "tags"):
+                val = table.get(key)
+                if val is None:
+                    continue
+                if not isinstance(val, list) or not all(
+                        isinstance(s, str) for s in val):
+                    raise ConfigError(
+                        f"{label}.{key} must be a list of selector strings")
+        player = entry.get("player")
+        if player is None:
+            continue
+        if not isinstance(player, dict):
+            raise ConfigError(f"{where}.player must be a table")
+        for key in ("container", "mount", "label"):
+            if key in player and not isinstance(player[key], str):
+                raise ConfigError(f"{where}.player.{key} must be a string")
+        if not player.get("container"):
+            raise ConfigError(f"{where}.player.container is required")
+        media = player.get("media")
+        if not isinstance(media, dict):
+            raise ConfigError(
+                f"{where}.player.media must be a table "
+                '(e.g. media = {{ element = "video#main", attr = "src" }})')
+        for key in ("element", "attr"):
+            if not isinstance(media.get(key), str) or not media[key]:
+                raise ConfigError(
+                    f"{where}.player.media.{key} must be a non-empty string")
 
 
 def load_degraded(path: Path | None = None, *, env=None):

--- a/scripts/dl-router/extension/content_capture.js
+++ b/scripts/dl-router/extension/content_capture.js
@@ -162,11 +162,43 @@
     return out;
   }
 
+  /**
+   * The CONTEXT layer of a site rule: how to find the subject of a PAGE.
+   *
+   * `site_rules` is now two layers keyed on two different hosts, because the
+   * two questions are asked in two different documents:
+   *
+   *   * the CONTEXT rule, keyed on the PAGE host (this one) -- what is this
+   *     page about? Runs in the top frame.
+   *   * the PLAYER rule, keyed on the EMBED host (player_buttons.js) -- where
+   *     is the media element and how do I read its URL? Runs inside the
+   *     cross-origin embed frame, which is a different origin and therefore a
+   *     different key in the same table.
+   *
+   * Accepting BOTH the flat form (`subject`/`tags` at the top level, which is
+   * what every existing config uses and what the docs have always shown) and
+   * the explicit `[site_rules."<host>".context]` sub-table costs one function
+   * and keeps one selector grammar. The explicit form wins where both exist,
+   * so a config can be migrated a host at a time.
+   */
+  function contextSelectors(rules) {
+    if (!rules || typeof rules !== "object") return { subject: [], tags: [] };
+    var ctx = (rules.context && typeof rules.context === "object")
+      ? rules.context : rules;
+    var pick = function (v) {
+      return Array.isArray(v) ? v.filter(function (s) {
+        return typeof s === "string" && s;
+      }) : [];
+    };
+    return { subject: pick(ctx.subject), tags: pick(ctx.tags) };
+  }
+
   /** Per-site rules: { subject: [selector], tags: [selector] }. */
   function extractSiteRules(dom, rules) {
     var out = [];
     if (!rules) return out;
-    var groups = [].concat(rules.subject || [], rules.tags || []);
+    var sel = contextSelectors(rules);
+    var groups = [].concat(sel.subject, sel.tags);
     for (var i = 0; i < groups.length; i += 1) {
       if (typeof groups[i] !== "string") continue;
       var nodes = safeQuery(dom, groups[i]);
@@ -188,6 +220,19 @@
   }
 
   /**
+   * The rules entry for a host, `www.` tolerant. ONE lookup, shared by the
+   * context layer here and the player layer in player_buttons.js -- the two
+   * layers are keyed on different hosts, but "which entry is this host's" must
+   * not be answered twice and differently.
+   */
+  function rulesForHost(siteRules, host) {
+    if (!siteRules || typeof siteRules !== "object" || !host) return null;
+    var entry = siteRules[host]
+      || siteRules[String(host).replace(/^www\./, "")];
+    return (entry && typeof entry === "object") ? entry : null;
+  }
+
+  /**
    * Build the capture payload.
    * `dom`      adapter (see domAdapter)
    * `el`       the clicked element descriptor {href, mediaSrc, linkText, alt}
@@ -196,8 +241,7 @@
   function extractContext(dom, el, siteRules) {
     el = el || {};
     var site = hostOf(dom.url);
-    var rules = siteRules && (siteRules[site]
-      || siteRules[site.replace(/^www\./, "")]);
+    var rules = rulesForHost(siteRules, site);
     var tags = [];
     var seen = Object.create(null);
     var push = function (list) {
@@ -278,6 +322,9 @@
       extractJsonLd: extractJsonLd,
       extractGeneric: extractGeneric,
       extractSiteRules: extractSiteRules,
+      contextSelectors: contextSelectors,
+      rulesForHost: rulesForHost,
+      hostOf: hostOf,
       describeTarget: describeTarget,
       domAdapter: domAdapter,
       installListeners: installListeners,

--- a/scripts/dl-router/extension/manifest.json
+++ b/scripts/dl-router/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Media Download Router",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Files downloads into subject directories under a local media library, using page context, via a loopback token-authenticated sidecar. Local-only, authorized personal automation.",
   "permissions": [
     "downloads",
@@ -21,7 +21,7 @@
   "content_scripts": [
     {
       "matches": ["http://*/*", "https://*/*"],
-      "js": ["content_capture.js", "picker_overlay.js"],
+      "js": ["content_capture.js", "picker_overlay.js", "player_buttons.js"],
       "all_frames": true,
       "run_at": "document_idle"
     }

--- a/scripts/dl-router/extension/player_buttons.js
+++ b/scripts/dl-router/extension/player_buttons.js
@@ -1,0 +1,517 @@
+// player_buttons.js -- a download button per embedded player (classic content
+// script, same declaration as content_capture.js, so no new permissions).
+//
+// WHY THIS FILE EXISTS, AND WHY IT RUNS WHERE IT DOES.
+//
+// On the forums this routes for there are ZERO native <video> elements. Every
+// video is a cross-origin iframe (a real OOPIF) pointing at an embed host. A
+// content script on the FORUM origin cannot reach the media element at all --
+// it can see the iframe's `src` and nothing inside it. The manifest already
+// injects on `https://*/*` with `all_frames: true`, so a content script DOES
+// run inside the embed frame, and that is the only place the media URL exists.
+//
+// Hence the two-layer rule table (see content_capture.contextSelectors):
+//
+//   * the PLAYER rule is keyed on the EMBED HOST and consumed here, in the
+//     embed frame: container, media-URL accessor, mount point.
+//   * the CONTEXT rule is keyed on the PAGE HOST and consumed by
+//     content_capture.js, in the top frame: what is this page about.
+//
+// Keying the player rule on the forum instead would be wrong twice over: the
+// forum's embed wrapper is host-AGNOSTIC (it wraps embeds from arbitrary
+// hosts), so such a rule would match embeds we have no player rule for, and it
+// would still be running in the wrong document to read anything.
+//
+// THE ONE RULE THAT MATTERS MOST: the media URL is SIGNED AND EXPIRES. The
+// embed page assigns it at frame load and re-signs it in place before expiry
+// and on error. So it is present without any user interaction -- but it must be
+// READ AT CLICK TIME and never cached. A URL captured at render time is a URL
+// that has already rotated by the time anyone clicks it.
+//
+// What this deliberately does NOT do: use the player's own download control.
+// On the observed host that anchor points at an HTML interstitial (HEAD 405,
+// GET text/html, no Content-Disposition); handing it to chrome.downloads saves
+// a web page.
+//
+// Test hooks, matching content_capture.js and picker_overlay.js:
+// `globalThis.DL_ROUTER_NO_AUTOSTART` suppresses listener install;
+// `globalThis.__DLR_PLAYER__` exposes the pure functions.
+
+(function () {
+  "use strict";
+
+  var HOST_ATTR = "data-dl-router-player";
+  var LABEL = "Save to library";
+  var BUSY_LABEL = "Saving...";
+  var HAVE_LABEL = "In library";
+
+  // The grammar a selector may use. Kept to EXACTLY the subset
+  // tests/fake_dom.mjs parses -- tag, .class, #id, [attr], [attr="v"],
+  // [attr^="v"], descendant combinators, comma groups -- so a rule that works
+  // in Brave is a rule the suite can exercise. A richer selector would still
+  // work in the browser and silently have no test, which is how the two drift.
+  //
+  // Bracketed sections are stripped first: `[href^="https://x"]` legitimately
+  // contains a colon.
+  var BRACKETS = /\[[^\]]*\]/g;
+  var UNSUPPORTED = /[>+~():]/;
+  // An attribute or property NAME, never an expression. See readMediaUrl.
+  var ACCESSOR_NAME = /^[A-Za-z][A-Za-z0-9_-]*$/;
+  var HTTP_URL = /^https?:\/\/[^\s]+$/i;
+
+  function isSupportedSelector(selector) {
+    if (typeof selector !== "string") return false;
+    var s = selector.trim();
+    if (!s || s.length > 300) return false;
+    return !UNSUPPORTED.test(s.replace(BRACKETS, ""));
+  }
+
+  /**
+   * Normalise one host's `player` sub-table, or null.
+   *
+   * CONFIG IS DATA, NEVER CODE. Only the four fields below are read, each is
+   * type- and grammar-checked, and anything else in the table is dropped on the
+   * floor. A rule carrying `js`, `onclick` or `code` gets exactly the same
+   * treatment as a rule carrying a typo: ignored. Config-supplied JavaScript
+   * executing in a content script -- on every page, with the extension's
+   * isolated world -- is a code-injection surface, and the way to not have one
+   * is to have no path that could evaluate a string.
+   *
+   * A rule that fails validation yields null, which renders NO button. That is
+   * the deliberate failure mode: a button that cannot resolve a media URL is
+   * worse than no button, because it looks like the feature is working.
+   */
+  function normalisePlayerRule(raw) {
+    if (!raw || typeof raw !== "object") return null;
+    var player = (raw.player && typeof raw.player === "object")
+      ? raw.player : null;
+    if (!player) return null;
+    var media = (player.media && typeof player.media === "object")
+      ? player.media : null;
+    if (!media) return null;
+    if (!isSupportedSelector(player.container)) return null;
+    if (!isSupportedSelector(media.element)) return null;
+    if (typeof media.attr !== "string" || !ACCESSOR_NAME.test(media.attr)) {
+      return null;
+    }
+    var mount = isSupportedSelector(player.mount) ? player.mount.trim() : "";
+    return {
+      container: player.container.trim(),
+      mount: mount,
+      media: { element: media.element.trim(), attr: media.attr },
+      label: (typeof player.label === "string" && player.label
+        && player.label.length <= 40) ? player.label : LABEL,
+    };
+  }
+
+  /** The player rule for a host, or null when this host has none. */
+  function playerRuleFor(siteRules, host) {
+    var cap = globalThis.__DLR_CAPTURE__;
+    var entry = (cap && typeof cap.rulesForHost === "function")
+      ? cap.rulesForHost(siteRules, host) : null;
+    return normalisePlayerRule(entry);
+  }
+
+  function safeQuery(dom, selector, root) {
+    try {
+      var out = dom.queryAll(selector, root);
+      return out && typeof out.length === "number" ? out : [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  /**
+   * READ THE MEDIA URL. Called from the CLICK HANDLER AND NOWHERE ELSE.
+   *
+   * If you find a caller on the render path, that is the bug this comment
+   * exists for: the URL is signed with a ~2h expiry and is re-signed in place
+   * on the same element, so a value read when the button was drawn is stale by
+   * the time it is used. `player_buttons.test.mjs` pins this by rotating the
+   * attribute between render and click and asserting the NEW value is sent.
+   *
+   * `attr` is a NAME, not an expression (ACCESSOR_NAME). The content attribute
+   * is tried first because that is what an assignment to `video.src` reflects
+   * to; the same-named property is the fallback, which is how a host that only
+   * exposes `currentSrc` (not an attribute at all) still works. Only a string
+   * is ever accepted, and it is never called.
+   */
+  function readMediaUrl(dom, rule, container) {
+    if (!rule) return "";
+    var nodes = safeQuery(dom, rule.media.element, container);
+    for (var i = 0; i < nodes.length; i += 1) {
+      var node = nodes[i];
+      var value = "";
+      try {
+        if (node && typeof node.getAttribute === "function") {
+          value = node.getAttribute(rule.media.attr) || "";
+        }
+        if (!value && node && typeof node[rule.media.attr] === "string") {
+          value = node[rule.media.attr];
+        }
+      } catch (e) {
+        value = "";
+      }
+      // The frame-side shape check is a nicety so the button can say "not
+      // ready" instead of firing a doomed download. The AUTHORITATIVE gate is
+      // sanitize.isHttpUrl in the service worker, which is the only side that
+      // can refuse.
+      if (typeof value === "string" && HTTP_URL.test(value.trim())) {
+        return value.trim();
+      }
+    }
+    return "";
+  }
+
+  // --- the widget ----------------------------------------------------------- //
+  // Inside a CLOSED shadow root, for the same reasons picker_overlay.js uses
+  // one: the page cannot style it, cannot read it, and its own CSS cannot leak
+  // out onto a player it is sitting on top of.
+  var HOST_STYLE = [
+    "all: initial !important",
+    "position: absolute !important",
+    "top: 8px !important",
+    "left: 8px !important",
+    "z-index: 2147483646 !important",
+    "display: block !important",
+    "visibility: visible !important",
+    "opacity: 1 !important",
+    "pointer-events: auto !important",
+    "margin: 0 !important",
+    "padding: 0 !important",
+    "border: 0 !important",
+  ].join("; ");
+
+  var SHADOW_CSS = [
+    ":host { contain: layout style; }",
+    ".row { display: flex; gap: 6px; align-items: center;",
+    "  font: 500 12px/1.2 system-ui, sans-serif; }",
+    ".btn {",
+    "  font: inherit; cursor: pointer; border-radius: 6px;",
+    "  border: 1px solid rgba(255,255,255,.35); padding: 5px 9px;",
+    "  background: rgba(20,20,20,.62); color: #f2f2f2;",
+    // Unobtrusive: nearly invisible until the player is hovered or the button
+    // is focused. A permanent opaque control over someone's video is a worse
+    // trade than one extra pixel of discovery cost.
+    "  opacity: .35; transition: opacity 120ms ease-out;",
+    "}",
+    ".btn:hover, .btn:focus-visible { opacity: 1; }",
+    ".btn[disabled] { cursor: default; opacity: .35; }",
+    ".badge {",
+    "  border-radius: 6px; padding: 4px 7px; opacity: .9;",
+    "  background: rgba(30,90,40,.85); color: #eaffea;",
+    "  font: 500 11px/1.2 system-ui, sans-serif;",
+    "}",
+    "@media (prefers-reduced-motion: reduce) {",
+    "  .btn { transition: none; opacity: .8; }",
+    "}",
+  ].join("\n");
+
+  function build(dom, rule) {
+    var host = dom.create("div");
+    host.setAttribute(HOST_ATTR, "1");
+    host.setAttribute("style", HOST_STYLE);
+    var shadow = host.attachShadow({ mode: "closed" });
+    var style = dom.create("style");
+    style.textContent = SHADOW_CSS;
+    var row = dom.create("div");
+    row.className = "row";
+    var button = dom.create("button");
+    button.className = "btn";
+    button.setAttribute("type", "button");
+    button.setAttribute("part", "dlr-save");
+    button.textContent = rule.label;
+    row.appendChild(button);
+    shadow.appendChild(style);
+    shadow.appendChild(row);
+    return { host: host, shadow: shadow, row: row, button: button, badge: null };
+  }
+
+  function setLabel(handle, text) {
+    if (handle && handle.button) handle.button.textContent = text;
+  }
+
+  function setDisabled(handle, value) {
+    if (!handle || !handle.button) return;
+    handle.button.disabled = Boolean(value);
+    if (value) handle.button.setAttribute("disabled", "");
+  }
+
+  /**
+   * The "already have this" badge.
+   *
+   * `res.have` comes from the sidecar's source-URL ledger, asked BY THE EMBED
+   * PAGE URL -- see route_core.playerSourceKey for why it cannot be the media
+   * URL. A miss renders nothing at all rather than an "not in library" chip:
+   * the ledger only started recording in #244, so a miss means "no record",
+   * which is not the same claim as "you do not have it".
+   */
+  function applyHave(dom, handle, res) {
+    if (!handle || !res || res.have !== true) return false;
+    if (handle.badge) return false;
+    var badge = dom.create("span");
+    badge.className = "badge";
+    badge.textContent = res.dir ? HAVE_LABEL + ": " + res.dir : HAVE_LABEL;
+    badge.setAttribute("title", "This player's URL is already in the ledger");
+    handle.row.appendChild(badge);
+    handle.badge = badge;
+    return true;
+  }
+
+  /**
+   * The click. Reads the media URL NOW (see readMediaUrl) and hands it to the
+   * service worker, which is where the download and every correlation happen.
+   *
+   * `deps.send(msg)` -> Promise. `deps.pageUrl()` -> this frame's location.
+   */
+  function handleClick(dom, handle, deps) {
+    var url = readMediaUrl(dom, handle.rule, handle.container);
+    if (!url) {
+      // VISIBLE AND HARMLESS. A player whose src has not been assigned yet
+      // (preload="none" on an off-screen frame) must not fire a download with
+      // an empty URL and must not silently do nothing.
+      setLabel(handle, "No media yet");
+      return Promise.resolve({ ok: false, error: "no_media_url" });
+    }
+    setLabel(handle, BUSY_LABEL);
+    setDisabled(handle, true);
+    return Promise.resolve(deps.send({
+      type: "dlr:player-download",
+      mediaUrl: url,
+      // The STABLE key (normalised worker-side). Never the media URL.
+      embedUrl: deps.pageUrl(),
+    })).then(function (res) {
+      setDisabled(handle, false);
+      if (res && res.ok) {
+        setLabel(handle, "Saved");
+        return res;
+      }
+      setLabel(handle, "Failed");
+      return res || { ok: false, error: "no_response" };
+    }, function () {
+      setDisabled(handle, false);
+      setLabel(handle, "Failed");
+      return { ok: false, error: "send_failed" };
+    });
+  }
+
+  /** Where inside a container the widget is mounted. */
+  function mountPointFor(dom, rule, container) {
+    if (rule.mount) {
+      var found = safeQuery(dom, rule.mount, container)[0];
+      if (found) return found;
+    }
+    return container;
+  }
+
+  /**
+   * Mount the widget on one container. Returns the handle, or null when the
+   * DOM refused it (a hostile or half-built document).
+   */
+  function mountButton(dom, rule, container, deps) {
+    var handle;
+    try {
+      handle = build(dom, rule);
+    } catch (e) {
+      return null;
+    }
+    handle.rule = rule;
+    handle.container = container;
+    try {
+      mountPointFor(dom, rule, container).appendChild(handle.host);
+    } catch (e) {
+      return null;
+    }
+    try {
+      handle.button.addEventListener("click", function (ev) {
+        if (ev && typeof ev.preventDefault === "function") ev.preventDefault();
+        handleClick(dom, handle, deps);
+      });
+    } catch (e) { /* a button that cannot listen is still better than a throw */ }
+    // The badge is asked for ONCE per mount, and never blocks the button.
+    try {
+      Promise.resolve(deps.send({
+        type: "dlr:have", embedUrl: deps.pageUrl(),
+      })).then(function (res) {
+        applyHave(dom, handle, res);
+      }, function () { /* no ledger answer: no badge, which is the honest one */ });
+    } catch (e) { /* same */ }
+    return handle;
+  }
+
+  function isConnected(node) {
+    if (!node) return false;
+    if (typeof node.isConnected === "boolean") return node.isConnected;
+    return Boolean(node.parentNode);
+  }
+
+  /**
+   * Mount on every container that does not already carry a live widget.
+   *
+   * IDEMPOTENT, and re-entrant on purpose: players are `loading="lazy"`, an
+   * off-screen frame has no document at all yet, and a forum thread renders
+   * more posts as you scroll. So this is called on load AND from a mutation
+   * observer, and both must be able to run repeatedly without stacking
+   * buttons. The liveness check is `isConnected` on OUR host rather than a
+   * marker attribute on the page's node: a framework re-render that replaces
+   * the container's subtree drops our host, and we have to notice and remount.
+   */
+  function scan(dom, rule, deps, mounted) {
+    var out = [];
+    if (!rule) return out;   // no player rule for this host: no buttons, ever
+    var containers = safeQuery(dom, rule.container);
+    for (var i = 0; i < containers.length; i += 1) {
+      var container = containers[i];
+      var existing = mounted.get(container);
+      if (existing && isConnected(existing.host)) continue;
+      var handle = mountButton(dom, rule, container, deps);
+      if (!handle) continue;
+      mounted.set(container, handle);
+      out.push(handle);
+    }
+    return out;
+  }
+
+  /** The real-document adapter. Everything above is written against this. */
+  function docAdapter(doc, win) {
+    return {
+      queryAll: function (selector, root) {
+        var scope = root || doc;
+        return Array.prototype.slice.call(scope.querySelectorAll(selector));
+      },
+      create: function (tag) { return doc.createElement(tag); },
+      url: (win && win.location) ? win.location.href
+        : (doc.location ? doc.location.href : ""),
+    };
+  }
+
+  function isTopFrame(win) {
+    try {
+      return Boolean(win) && win.top === win.self;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /**
+   * Answer `dlr:page-context` -- the TOP frame describing itself.
+   *
+   * The embed frame cannot identify its own thread and no amount of effort in
+   * the frame will change that: `document.referrer` is the forum ORIGIN only
+   * (the path is stripped by `strict-origin-when-cross-origin`) and
+   * `location.ancestorOrigins` gives origins without paths. So the subject has
+   * to be carried from the top frame, and the service worker is the only place
+   * that can reach both.
+   *
+   * It REUSES content_capture's extractor rather than restating it -- same
+   * isolated world, same file list in the manifest. A second subject extractor
+   * is exactly the drift picker_overlay.js exists to avoid.
+   */
+  function pageContext(doc, win, siteRules) {
+    var cap = globalThis.__DLR_CAPTURE__;
+    if (!cap || typeof cap.extractContext !== "function") {
+      return { ok: false, error: "no_capture" };
+    }
+    var url = (win && win.location) ? win.location.href
+      : (doc && doc.location ? doc.location.href : "");
+    try {
+      return { ok: true, context: cap.extractContext(
+        cap.domAdapter(doc, url, doc ? doc.title : ""), {}, siteRules) };
+    } catch (e) {
+      return { ok: false, error: "extract_failed" };
+    }
+  }
+
+  if (typeof globalThis !== "undefined") {
+    globalThis.__DLR_PLAYER__ = {
+      HOST_ATTR: HOST_ATTR,
+      isSupportedSelector: isSupportedSelector,
+      normalisePlayerRule: normalisePlayerRule,
+      playerRuleFor: playerRuleFor,
+      readMediaUrl: readMediaUrl,
+      mountButton: mountButton,
+      handleClick: handleClick,
+      applyHave: applyHave,
+      mountPointFor: mountPointFor,
+      scan: scan,
+      docAdapter: docAdapter,
+      pageContext: pageContext,
+      isTopFrame: isTopFrame,
+    };
+  }
+
+  if (typeof globalThis !== "undefined" && globalThis.DL_ROUTER_NO_AUTOSTART) {
+    return;
+  }
+  if (typeof chrome === "undefined" || !chrome.runtime) return;
+
+  var siteRules = null;
+  var rule = null;
+  var mounted = new Map();
+  var dom = docAdapter(document,
+    typeof window !== "undefined" ? window : null);
+
+  function send(msg) {
+    try {
+      return Promise.resolve(chrome.runtime.sendMessage(msg));
+    } catch (e) {
+      return Promise.reject(e);
+    }
+  }
+
+  var deps = { send: send, pageUrl: function () { return dom.url; } };
+
+  function rescan() {
+    try {
+      scan(dom, rule, deps, mounted);
+    } catch (e) { /* a page that breaks this must not break the page */ }
+  }
+
+  // A CONTAINER CAN APPEAR LONG AFTER LOAD. The player is `loading="lazy"`, so
+  // an off-screen frame has no document until it is scrolled near -- and when
+  // this script does run in it, the embed page may still be building the
+  // player. `subtree: true` here, unlike picker_overlay's body-only observer:
+  // that one watches for ONE node it put there itself, this one is looking for
+  // a node the page has not created yet, at an unknown depth.
+  function watch() {
+    if (typeof MutationObserver !== "function") return null;
+    if (!document.body) return null;
+    var obs = new MutationObserver(function () { rescan(); });
+    try {
+      obs.observe(document.body, { childList: true, subtree: true });
+    } catch (e) {
+      return null;
+    }
+    return obs;
+  }
+
+  chrome.runtime.onMessage.addListener(function (msg, _sender, sendResponse) {
+    if (!msg || typeof msg !== "object") return false;
+    if (msg.type === "dlr:page-context") {
+      if (!isTopFrame(typeof window !== "undefined" ? window : null)) {
+        return false;   // frameId 0 is targeted, but never assume the targeting
+      }
+      sendResponse(pageContext(document, window, siteRules));
+      return false;
+    }
+    return false;
+  });
+
+  try {
+    chrome.runtime.sendMessage({ type: "dlr:rules" }, function (resp) {
+      if (!resp || !resp.siteRules) return;
+      siteRules = resp.siteRules;
+      var cap = globalThis.__DLR_CAPTURE__;
+      var host = (cap && typeof cap.hostOf === "function")
+        ? cap.hostOf(dom.url) : "";
+      rule = playerRuleFor(siteRules, host);
+      // NO RULE FOR THIS HOST: nothing is mounted and nothing is observed. The
+      // forum's embed wrapper is host-agnostic, so this is the ORDINARY case
+      // for an embed from a host we have never configured -- and the right
+      // answer there is no button at all, not a button that cannot resolve.
+      if (!rule) return;
+      rescan();
+      watch();
+    });
+  } catch (e) { /* the SW may be asleep; nothing to mount without rules */ }
+}());

--- a/scripts/dl-router/extension/route_core.js
+++ b/scripts/dl-router/extension/route_core.js
@@ -132,6 +132,51 @@ export function hostOf(url) {
     ? host.slice(1, -1) : host;
 }
 
+/**
+ * THE STABLE IDENTITY OF AN EMBEDDED PLAYER. Scheme + host + path, nothing else.
+ *
+ * This is the single most consequential decision in the player-button feature,
+ * so it is written where both callers can read it.
+ *
+ * The media URL an embed host hands its `<video>` is SIGNED AND ROTATING: it
+ * carries `?exp=<unix>&token=<...>` and is re-signed roughly hourly, in place,
+ * on the same element. `source_url_key` (store.py) deliberately keeps the query
+ * string, because on a file host the query IS the asset identity -- so keying
+ * the ledger on the media URL would mint a NEW row every time the signature
+ * rotated. The "already have this" badge would then never light, and a badge
+ * that never lights is worse than no badge: it reads as "you do not have this".
+ *
+ * The embed PAGE url (`https://<embed host>/embed/<id>`) is the stable name for
+ * the same asset: it is what the forum links to, it is what the frame's own
+ * `location.href` is, and its path carries the embed id. The query is dropped
+ * because playback parameters (`?autoplay=1`, `?t=30`) do not change WHICH
+ * asset this is, and keeping them would split one asset across several rows --
+ * the same failure as the signature, only slower.
+ *
+ * Both halves of the feature go through here so they cannot drift: the WRITE
+ * (`sourceKey` on the /match payload, which the sidecar records instead of the
+ * signed URL) and the READ (`GET /have?url=`). The normalisation lives in the
+ * service worker rather than the content script for the same reason -- one
+ * implementation, called twice.
+ *
+ * Returns "" for anything that is not an http(s) URL, which the callers treat
+ * as "no stable key", never as a key of its own.
+ */
+export function playerSourceKey(url) {
+  if (!hostOf(url)) return "";
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return "";
+  }
+  // `host`, not `hostname`: a non-default port is part of the identity, and
+  // URL already omits the default one -- which is exactly what
+  // store.source_url_key does on the Python side, so the two agree on the key
+  // for the same input string.
+  return `${parsed.protocol}//${parsed.host.toLowerCase()}${parsed.pathname || "/"}`;
+}
+
 function pathSegments(url) {
   if (!hostOf(url)) return [];
   let raw;
@@ -549,6 +594,10 @@ export function buildMatchPayload(item, capture, carried) {
     filename: baseName(item?.filename || ""),
     mime: item?.mime || "",
     size: item?.fileSize || item?.totalBytes || 0,
+    // THE LEDGER'S KEY, when the download has a stable name that its own URL
+    // is not (see playerSourceKey). Empty for every ordinary download, and the
+    // sidecar then falls back to `url` exactly as it did before.
+    sourceKey: typeof c.sourceKey === "string" ? c.sourceKey : "",
     page: {
       title: c.pageTitle || "",
       url: c.pageUrl || "",

--- a/scripts/dl-router/extension/service_worker.js
+++ b/scripts/dl-router/extension/service_worker.js
@@ -19,7 +19,7 @@
 
 import {
   buildMatchPayload, carryReferrer, correlateCapture, formatDup,
-  handleDetermining, localContext, localDecide,
+  handleDetermining, localContext, localDecide, playerSourceKey,
 } from "./route_core.js";
 import { isHttpUrl, relPathFromAbsolute, sanitizeDirName } from "./sanitize.js";
 import { DEFAULT_PORT, manifestPort as readManifestPort } from "./port.js";
@@ -53,6 +53,32 @@ const OVERLAY_READY_MS = 1500;
 // sub-millisecond; if it has not landed by now something is badly wrong and
 // declining (Chrome's default filename) is the conservative answer.
 const READY_TIMEOUT_MS = 250;
+
+// --- `state.pending` outlives this worker, and has to -------------------------
+//
+// An entry in `state.pending` is what makes a download's toast, its relocate
+// and its learning possible: `onDownloadChanged` reads it and returns early
+// when it is absent. It was an in-memory Map, and MV3 tears this worker down
+// after ~30 s idle -- so ANY download that took longer than half a minute lost
+// all three, silently, today. That is not an edge case; it is every video.
+//
+// `chrome.storage.local`, NOT `chrome.storage.session`. The two are used for
+// two different lifetimes in this file and conflating them would be wrong in
+// both directions:
+//
+//   * the overlay registry uses `session` because an overlay is a node in a
+//     page's document. Every overlay dies with the browser, so a record that
+//     outlived the browser could only ever resurrect a picker for a download
+//     nobody remembers.
+//   * a download in flight is the opposite. Chrome RESUMES interrupted
+//     downloads across a browser restart, and a multi-gigabyte file plausibly
+//     spans one. `local` survives that, which is the correct lifetime here.
+//
+// The cost of the longer lifetime is that stale entries would accumulate
+// forever, so a TTL and a cap are prerequisites rather than polish.
+const PENDING_KEY = "pending";
+const PENDING_MAX = 64;
+const PENDING_TTL_MS = 24 * 60 * 60 * 1000;
 
 // Module-global so `onDeterminingFilename` can read it SYNCHRONOUSLY -- the
 // listener has no time to await chrome.storage. It is repopulated on every
@@ -252,6 +278,9 @@ export function recordCapture(payload, sender) {
     tags: Array.isArray(payload.tags)
       ? payload.tags.filter((t) => typeof t === "string").slice(0, 64) : [],
     og: payload.og && typeof payload.og === "object" ? payload.og : {},
+    // The STABLE ledger key for a download whose own URL is not one (a signed,
+    // rotating media URL). Empty for every ordinary capture.
+    sourceKey: typeof payload.sourceKey === "string" ? payload.sourceKey : "",
     tabId: sender?.tab?.id,
     // The tab this one was opened from. It NARROWS the referrer carry's href
     // proof (see carryReferrer) -- it is not itself a proof, and the branch
@@ -264,6 +293,71 @@ export function recordCapture(payload, sender) {
   if (state.captures.length > CAPTURE_LIMIT) {
     state.captures.splice(0, state.captures.length - CAPTURE_LIMIT);
   }
+}
+
+// --- the pending registry, and why it is PERSISTED -------------------------- //
+/**
+ * Write the durable copy. Fire-and-forget everywhere: a failed write costs a
+ * toast after a teardown, and blocking a routing decision on storage would
+ * cost the download itself.
+ *
+ * Pruned on WRITE as well as on read, so the stored array cannot grow past the
+ * cap even if nothing ever reads it back.
+ */
+async function persistPending() {
+  try {
+    const now = Date.now();
+    const rows = [...state.pending]
+      .filter(([, e]) => e && typeof e === "object"
+        && now - (e.ts || 0) <= PENDING_TTL_MS)
+      .slice(-PENDING_MAX);
+    await chrome.storage.local.set({ [PENDING_KEY]: rows });
+  } catch { /* storage unavailable; the in-memory copy still works */ }
+}
+
+/** Merge the durable copy in. NEVER clobbers an entry created this turn. */
+export async function restorePending() {
+  try {
+    const got = await chrome.storage.local.get(PENDING_KEY);
+    const rows = got && got[PENDING_KEY];
+    if (!Array.isArray(rows)) return;
+    const now = Date.now();
+    for (const row of rows) {
+      if (!Array.isArray(row) || row.length !== 2) continue;
+      const [id, entry] = row;
+      if (typeof id !== "number" && typeof id !== "string") continue;
+      if (!entry || typeof entry !== "object") continue;
+      // A download older than the TTL is not resumable in any useful sense and
+      // its file has long since been dealt with by hand.
+      if (now - (entry.ts || 0) > PENDING_TTL_MS) continue;
+      if (!state.pending.has(id)) state.pending.set(id, entry);
+    }
+  } catch { /* best effort */ }
+}
+
+function rememberPending(id, entry) {
+  state.pending.set(id, entry);
+  void persistPending();
+}
+
+function forgetPending(id) {
+  const had = state.pending.delete(id);
+  if (had) void persistPending();
+  return had;
+}
+
+/**
+ * The entry for a download, consulting the durable copy before giving up.
+ *
+ * The lazy restore is here rather than only in `start()` for the same reason
+ * `overlayIsOurs` does it: whether the answer is right must not depend on when
+ * readiness happened to resolve. Every caller that would otherwise reason from
+ * an empty Map goes through this.
+ */
+async function pendingEntry(id) {
+  if (state.pending.has(id)) return state.pending.get(id);
+  await restorePending();
+  return state.pending.get(id);
 }
 
 // --- the download path ----------------------------------------------------- //
@@ -327,7 +421,7 @@ function routeDownload(item, suggest) {
     requestMatch: () => api("POST", "/match", payload,
       { timeoutMs: state.snapshot?.matchTimeoutMs ?? 400 }),
     onDecision: (info) => {
-      state.pending.set(item.id, {
+      rememberPending(item.id, {
         dir: info.dir,
         filename: info.filename,
         decision: info.decision,
@@ -542,10 +636,18 @@ export function overlayCapableUrl(url) {
   return true;
 }
 
-/** Which tab should host the overlay. */
-function overlayTabId(info) {
+/**
+ * Which tab should host the overlay.
+ *
+ * ASYNC because `pendingEntry` is: after an idle teardown the in-memory Map is
+ * empty, and reading it directly would send every post-teardown picker to a
+ * popup window (or the wrong tab) rather than to the tab the download came
+ * from -- which is precisely the window in which a picker is most likely to be
+ * opened, because the user was slow.
+ */
+async function overlayTabId(info) {
   if (typeof info.tabId === "number") return info.tabId;
-  const entry = state.pending.get(info.downloadId);
+  const entry = await pendingEntry(info.downloadId);
   if (entry && typeof entry.tabId === "number") return entry.tabId;
   // Last resort: wherever the user is actually looking. A download's own tab
   // often closes itself, and asking on the page in front of them beats a popup
@@ -762,7 +864,7 @@ export async function onTabUpdated(tabId, changeInfo) {
  * not allowed.
  */
 export async function openOverlayPicker(info) {
-  const tabId = overlayTabId(info);
+  const tabId = await overlayTabId(info);
   if (typeof tabId !== "number") return false;
   let tab = null;
   try {
@@ -865,7 +967,7 @@ export async function applyChoice(downloadId, chosenDir,
   // separate popup window the user can leave open past the ~30s idle teardown,
   // so this is the normal case, not an edge one.
   await ready();
-  const entry = state.pending.get(downloadId);
+  const entry = await pendingEntry(downloadId);
   const known = new Set([...knownDirs(), otherDir()]);
   if (createdNew) {
     // `kind` is what the picker asked for. Creating a directory WITHOUT one
@@ -910,7 +1012,11 @@ export async function applyChoice(downloadId, chosenDir,
     // learn, so neither happens unless the move did.
     entry.wanted = safe;
     entry.wantedCreatedNew = Boolean(createdNew);
-    state.pending.set(downloadId, entry);
+    // THE CORRECTION ITSELF HAS TO SURVIVE THE TEARDOWN. This is the branch a
+    // picker takes while the download is still running, which is exactly the
+    // case that outlives ~30 s of idle: without the durable write the user's
+    // choice would be applied by a worker that no longer has it.
+    rememberPending(downloadId, entry);
     return { ok: true, dir: safe, deferred: true };
   }
   await learn(entry, safe, createdNew);
@@ -1037,6 +1143,11 @@ export async function confirmDuplicate(downloadId, rel, dir, entry) {
   if (entry) {
     if (entry.dedupeChecked) return null;
     entry.dedupeChecked = true;
+    // The latch has to be as durable as the entry that carries it. Now that
+    // `pending` survives the teardown, a second `complete` delta delivered to a
+    // freshly-woken worker would restore the entry WITHOUT the latch and open a
+    // second focused, never-auto-closing duplicate toast for one download.
+    void persistPending();
   }
   let out;
   try {
@@ -1059,7 +1170,12 @@ export async function confirmDuplicate(downloadId, rel, dir, entry) {
 export async function onDownloadChanged(delta) {
   if (!delta || delta.state?.current !== "complete") return;
   await ready();
-  const entry = state.pending.get(delta.id);
+  // THE DURABLE READ, and the whole point of persisting `pending`. This used to
+  // be `state.pending.get(delta.id)`, and the `if (!entry) return` below then
+  // discarded the toast, the pending relocate and the learning for every
+  // download that ran longer than the ~30 s MV3 idle teardown -- which is most
+  // of them.
+  const entry = await pendingEntry(delta.id);
   if (!entry) return;
   // Where the file ended up, following any correction applied below. The
   // dedupe check needs the FINAL path: checking the pre-move one would ask the
@@ -1123,8 +1239,131 @@ export async function onDownloadChanged(delta) {
   // Keep the entry briefly so a late "change" click can still relocate.
   // `unref` exists only under node (the test runner) -- without it this timer
   // would hold the event loop open for five minutes and hang the suite.
-  const sweep = setTimeout(() => state.pending.delete(delta.id), 5 * 60 * 1000);
+  const sweep = setTimeout(() => forgetPending(delta.id), 5 * 60 * 1000);
   if (sweep && typeof sweep.unref === "function") sweep.unref();
+}
+
+// --- the player-button path ------------------------------------------------ //
+/**
+ * The top frame's own description of itself, or null.
+ *
+ * THE EMBED FRAME CANNOT IDENTIFY ITS THREAD, and this is the only path that
+ * can. `document.referrer` inside the embed is the forum ORIGIN with the path
+ * stripped (`strict-origin-when-cross-origin`), and
+ * `location.ancestorOrigins` gives origins without paths. So the subject has to
+ * come from the top frame, and only the worker can reach both frames.
+ *
+ * `{ frameId: 0 }` is the whole correlation, and it is a PROOF rather than a
+ * heuristic: the message is delivered to the top frame OF THE SAME TAB the
+ * click came from, and that frame answers with its own `location.href`.
+ *
+ * THERE IS DELIBERATELY NO FALLBACK. The obvious one -- the newest capture from
+ * this tab -- is the branch `carryReferrer` had deleted for being "the last
+ * thread I saw in that tab" wearing the word "provable"; on a forum, where the
+ * user scrolls past several threads, it produces a CONFIDENT WRONG SUBJECT that
+ * is then learned as a 1.00 identity alias. Returning null costs one picker.
+ */
+async function topFrameContext(tabId) {
+  let res;
+  try {
+    res = await chrome.tabs.sendMessage(tabId, { type: "dlr:page-context" },
+      { frameId: 0 });
+  } catch {
+    return null;   // no content script in the top frame, or the tab is gone
+  }
+  if (!res || res.ok !== true) return null;
+  const ctx = res.context;
+  if (!ctx || typeof ctx !== "object") return null;
+  // The frame must have reported a real page URL. Without one there is no
+  // thread slug, no site and no title -- i.e. nothing this was asked for.
+  if (!isHttpUrl(ctx.pageUrl)) return null;
+  return ctx;
+}
+
+/**
+ * `dlr:player-download` -- a click on an injected player button.
+ *
+ * The media URL arrives from the frame READ AT CLICK TIME (see
+ * player_buttons.readMediaUrl); it is signed and rotates, so it is used
+ * immediately and never stored.
+ *
+ * The routing then rides the ordinary pipeline rather than a parallel one: a
+ * capture is synthesised for the tab and pushed into the SAME buffer every
+ * click capture goes into, and `chrome.downloads.download` is handed the exact
+ * URL that capture records. `correlateCapture` tier 1 (exact URL match on
+ * `item.url`) therefore binds them deterministically -- no time window, no
+ * active-tab guess, and every downstream behaviour (auto-file, toast, picker,
+ * relocate, learn, dedupe) is inherited unchanged.
+ */
+export async function playerDownload(msg, sender) {
+  await ready();
+  if (!state.config.enabled) {
+    return { ok: false, error: "routing is not enabled in this profile" };
+  }
+  const mediaUrl = msg && msg.mediaUrl;
+  if (!isHttpUrl(mediaUrl)) {
+    return { ok: false, error: "refusing a non-http media URL" };
+  }
+  const tabId = sender?.tab?.id;
+  if (typeof tabId !== "number") {
+    return { ok: false, error: "no tab for this player" };
+  }
+  const context = await topFrameContext(tabId);
+  const capture = {
+    ...(context || {}),
+    // The clicked "element" is the media itself. Both fields are set because
+    // tier 1 tests either against the DownloadItem's url.
+    href: mediaUrl,
+    mediaSrc: mediaUrl,
+    // The ledger's key. Stable across the signature rotation the media URL is
+    // subject to -- see route_core.playerSourceKey.
+    sourceKey: playerSourceKey(msg && msg.embedUrl),
+  };
+  // WITH NO PROVEN CONTEXT THE CAPTURE CARRIES NO SUBJECT AT ALL. Not the embed
+  // page's title, not its URL: an embed page is a bare player, and anything
+  // scraped from it would be the embed host's branding presented as the
+  // subject. An empty context scores nothing, falls below the threshold and
+  // reaches the picker, which is the correct degradation.
+  if (!context) {
+    capture.pageUrl = "";
+    capture.pageTitle = "";
+    capture.site = "";
+    capture.tags = [];
+    capture.og = {};
+  }
+  recordCapture(capture, { tab: { id: tabId } });
+  try {
+    const downloadId = await chrome.downloads.download({ url: mediaUrl });
+    return { ok: true, downloadId, context: Boolean(context) };
+  } catch (err) {
+    return { ok: false, error: errorMessage(err) };
+  }
+}
+
+/**
+ * `dlr:have` -- the "already have this" badge's question.
+ *
+ * Asked BY THE EMBED PAGE URL, normalised through the same `playerSourceKey`
+ * the write side uses. Keying this on the media URL instead would mean the
+ * badge never lit: the signature rotates, so every lookup would miss, and a
+ * badge that never lights actively asserts "you do not have this".
+ *
+ * Every failure is a MISS, never an error the user sees. This is a hint on
+ * someone else's page; a sidecar that is down must produce no badge, not a
+ * broken one.
+ */
+export async function haveUrl(embedUrl) {
+  await ready();
+  if (!state.config.enabled) return { ok: false, have: false };
+  const key = playerSourceKey(embedUrl);
+  if (!key) return { ok: false, have: false };
+  try {
+    const out = await api("GET", `/have?url=${encodeURIComponent(key)}`,
+      undefined, { timeoutMs: 3000 });
+    return { ok: true, have: out?.have === true, dir: out?.dir || "" };
+  } catch {
+    return { ok: false, have: false };
+  }
 }
 
 // --- context menus --------------------------------------------------------- //
@@ -1388,6 +1627,25 @@ export function onMessage(msg, sender, sendResponse) {
       .catch(() => sendResponse({ siteRules: {} }));
     return true;
   }
+  if (msg.type === "dlr:player-download") {
+    // FROM A SUBFRAME BY DESIGN, unlike `dlr:choose` and `dlr:discard`: the
+    // media element only exists inside the cross-origin embed frame, so
+    // refusing subframes here would refuse the entire feature. There is no
+    // nonce to check and none is needed -- this message asserts nothing about
+    // the library. Everything it can do, the page could already do: start a
+    // download of a URL it chose. Where it lands is decided by /match from a
+    // context proven through frameId 0, and an unproven one goes to the picker.
+    playerDownload(msg, sender)
+      .then((r) => sendResponse(r))
+      .catch((e) => sendResponse({ ok: false, error: errorMessage(e) }));
+    return true;   // async response
+  }
+  if (msg.type === "dlr:have") {
+    haveUrl(msg.embedUrl)
+      .then((r) => sendResponse(r))
+      .catch(() => sendResponse({ ok: false, have: false }));
+    return true;   // async response
+  }
   if (msg.type === "dlr:overlay-lost") {
     // The content script noticed its host node was detached -- a page that
     // rewrote document.body, a sanitiser, an SPA re-render, or a page
@@ -1418,8 +1676,8 @@ export function onMessage(msg, sender, sendResponse) {
     return false;
   }
   if (msg.type === "dlr:repick") {
-    void ready().then(() => {
-      const entry = state.pending.get(msg.downloadId);
+    void ready().then(async () => {
+      const entry = await pendingEntry(msg.downloadId);
       return openPicker({
         downloadId: msg.downloadId,
         dir: entry?.dir || otherDir(),
@@ -1468,7 +1726,13 @@ export function registerListeners() {
     chrome.windows.onRemoved.addListener(onWindowRemoved);
   } catch { /* older shapes without windows.onRemoved */ }
   chrome.storage.onChanged.addListener((changes, area) => {
-    if (area === "local") void loadConfig();
+    // ONLY the two config keys. `chrome.storage.local` also holds the durable
+    // `pending` registry now, which is written on every routing decision and
+    // every correction -- so an unfiltered handler would re-read the config
+    // (and allocate a promise inside a listener) on every download event, for
+    // a change that provably cannot affect it.
+    if (area !== "local" || !changes) return;
+    if ("token" in changes || "enabled" in changes) void loadConfig();
   });
   chrome.alarms.create("dlr-refresh", { periodInMinutes: SNAPSHOT_REFRESH_MINUTES });
   chrome.alarms.onAlarm.addListener((alarm) => {
@@ -1487,6 +1751,9 @@ export async function start() {
   // has an empty registry, and the tab watchers would find no overlay to rescue
   // when its tab closes.
   await restoreOverlays();
+  // Downloads still in flight from before the last teardown, or from before the
+  // last browser restart. See the PENDING_KEY block at the top.
+  await restorePending();
   await installMenus();
   try {
     const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });

--- a/scripts/dl-router/matcher.py
+++ b/scripts/dl-router/matcher.py
@@ -604,6 +604,18 @@ class MatchContext:
     # from a time window or "the last thread seen".
     referrer_url: str = ""
     referrer_title: str = ""
+    # THE LEDGER'S KEY, when the download's own URL is not a durable name for
+    # it. An embedded player streams from a SIGNED url (`?exp=...&token=...`)
+    # that is re-signed roughly hourly, so `source_url_key(url)` would mint a
+    # fresh ledger row every rotation and the "already have this" badge would
+    # never light. The extension sends the embed PAGE url here instead, which
+    # carries the embed id and does not rotate. Empty for every other download,
+    # and `App.match` then falls back to `url` exactly as before.
+    #
+    # It is NOT used for matching or learning -- only as the ledger key. A key
+    # is a name; letting a caller-supplied string become routing evidence is a
+    # different and much larger promise.
+    source_key: str = ""
 
     @staticmethod
     def from_payload(payload: dict) -> "MatchContext":
@@ -651,6 +663,7 @@ class MatchContext:
             page_url=page_url,
             referrer_url=str(page.get("referrerUrl") or ""),
             referrer_title=str(page.get("referrerTitle") or ""),
+            source_key=str(payload.get("sourceKey") or ""),
         )
 
     def thread_slugs(self) -> list:

--- a/scripts/dl-router/server.py
+++ b/scripts/dl-router/server.py
@@ -65,7 +65,7 @@ from matcher import (  # noqa: E402
 from safety import (  # noqa: E402
     UnsafeName, is_safe_dir_name, names_match, safe_rel_path,
 )
-from store import Store  # noqa: E402
+from store import Store, source_url_key  # noqa: E402
 
 SERVER_VERSION = "dl-router/1"
 MAX_BODY = 256 * 1024
@@ -373,8 +373,19 @@ class App:
         # passes through. Best-effort by design: a download with no usable
         # source URL records nothing and must not fail the match it is riding
         # on, which is a decision the browser is blocking on.
+        #
+        # `source_key` WHEN IT IS USABLE. An embedded player's media URL is
+        # signed and rotates in place, so it names the request rather than the
+        # asset; the extension sends the embed page URL as a stable name
+        # instead (see MatchContext.source_key). The test is `source_url_key`
+        # itself rather than truthiness: a non-empty but unusable key (a
+        # `blob:`, a typo) would otherwise write NOTHING at all, silently
+        # dropping the ledger row that the ordinary URL would have produced.
+        ledger_url = ctx.source_key if source_url_key(ctx.source_key) \
+            else ctx.url
         try:
-            self.store.record_source_url(ctx.url, site=ctx.site,
+            self.store.record_source_url(ledger_url,
+                                         site=ctx.site,
                                          dir_name=result.dir,
                                          download_id=download_id)
         except sqlite3.Error as exc:

--- a/scripts/dl-router/tests/fake_dom.mjs
+++ b/scripts/dl-router/tests/fake_dom.mjs
@@ -18,6 +18,13 @@ class El {
     this.children = [];
     this.parentElement = null;
     this.text = "";
+    // Mutation APIs, for the widget player_buttons.js builds and mounts. This
+    // parser exists to drive extractors over fixture HTML; a widget has to be
+    // BUILT and ATTACHED into that same tree, and the alternative -- a second
+    // DOM stand-in for the mounting half -- is the drift this file avoids.
+    this.shadowRoot = null;
+    this.listeners = new Map();
+    this.disabled = false;
   }
 
   getAttribute(name) {
@@ -25,13 +32,69 @@ class El {
     return v === undefined ? null : v;
   }
 
+  setAttribute(name, value) {
+    this.attrs[String(name).toLowerCase()] = String(value);
+  }
+
   get textContent() {
     if (this.children.length === 0) return this.text;
     return this.text + this.children.map((c) => c.textContent).join("");
   }
 
+  set textContent(v) {
+    this.text = String(v ?? "");
+    this.children = [];
+  }
+
+  get className() { return this.getAttribute("class") || ""; }
+
+  set className(v) { this.setAttribute("class", v); }
+
   get classList() {
     return (this.getAttribute("class") || "").split(/\s+/).filter(Boolean);
+  }
+
+  /** A CLOSED shadow root is unreadable from the element in a real DOM; this
+   * handle exists for assertions only, exactly as in fake_page.mjs. */
+  attachShadow({ mode } = {}) {
+    const root = new El("#shadow-root");
+    root.mode = mode;
+    this.shadowRoot = root;
+    return root;
+  }
+
+  appendChild(child) {
+    this.children.push(child);
+    if (child && typeof child === "object") child.parentElement = this;
+    return child;
+  }
+
+  remove() {
+    const parent = this.parentElement;
+    if (!parent) return;
+    const i = parent.children.indexOf(this);
+    if (i >= 0) parent.children.splice(i, 1);
+    this.parentElement = null;
+  }
+
+  /** Attached to the tree this node was built into. */
+  get isConnected() {
+    let node = this;
+    while (node.parentElement) node = node.parentElement;
+    return node.tagName === "#document";
+  }
+
+  addEventListener(type, fn) {
+    if (!this.listeners.has(type)) this.listeners.set(type, []);
+    this.listeners.get(type).push(fn);
+  }
+
+  /** Deliver an event to every listener registered for `type`. */
+  fire(type, event = {}) {
+    const e = { preventDefault() { e.defaultPrevented = true; }, ...event };
+    const out = [];
+    for (const fn of this.listeners.get(type) || []) out.push(fn(e));
+    return out;
   }
 }
 
@@ -50,8 +113,12 @@ export function parseHTML(html) {
   const root = new El("#document");
   let current = root;
   let i = 0;
+  // The document root IS a parent, so `isConnected` can tell a node that was
+  // parsed (or mounted into the tree) from a freshly created, unattached one.
+  // Selector matching is unaffected: "#document" matches no compound, and the
+  // ancestor walk simply runs off the top as it did before.
   const push = (node) => {
-    node.parentElement = current === root ? null : current;
+    node.parentElement = current;
     current.children.push(node);
   };
 
@@ -196,6 +263,21 @@ export function domFromHTML(html, { url = "https://example-site.test/v/1",
     url,
     title: title || (titleEl ? titleEl.textContent.trim() : ""),
     root,
+  };
+}
+
+/**
+ * The adapter player_buttons.js is written against (`docAdapter`'s shape),
+ * backed by parsed fixture HTML. `queryAll` takes an optional scope root, which
+ * is how a rule's `mount` selector is resolved INSIDE its container.
+ */
+export function playerDomFromHTML(html, { url = "https://embed.example.test/embed/ID1" } = {}) {
+  const root = parseHTML(html);
+  return {
+    root,
+    url,
+    queryAll: (sel, scope) => queryAll(scope || root, sel),
+    create: (tag) => new El(String(tag).toLowerCase()),
   };
 }
 

--- a/scripts/dl-router/tests/fixtures/embed-player-frame.html
+++ b/scripts/dl-router/tests/fixtures/embed-player-frame.html
@@ -1,0 +1,41 @@
+<!-- FIXTURE: sanitised embed-host player document.
+     This is what lives INSIDE iframe.embed-iframe -> a CROSS-ORIGIN document.
+     A content script on the forum page cannot reach this DOM; only a content
+     script injected into the embed host's own frame can.
+
+     Live behaviour this fixture cannot capture (see the report):
+       * <video id="main-video"> is SERVED WITH NO src attribute.
+       * An inline script fetches `/api/sign?v=<VIDEO_ID>` at frame load and
+         assigns the returned signed URL to videoEl.src.
+       * That URL carries ?exp=<unix>&token=<64ch>&fn=<name>.mp4 and is
+         re-signed on a timer ~60s before expiry (observed lifetime ~2h).
+       * a[data-plyr="download"] href is `/d/<VIDEO_ID>` on the embed host,
+         which returns text/html (an interstitial), NOT the media file.
+       * The `download` attribute is deliberately stripped from that anchor by
+         the page's own script on the Plyr `ready` event.
+     The src below is a synthetic stand-in for the runtime-assigned value.
+-->
+<html><head><title>Embed</title></head><body style="background:#000;">
+<div class="container" id="video-container">
+  
+    
+
+    <div class="watermark">
+      <a target="_blank" href="/v/SYNTH8563">Sample text</a>
+    </div>
+
+    <div id="video-wrapper" style="display: block; width: 100%; height: 100%;">
+      <div class="plyr plyr--full-ui plyr--video plyr--html5 plyr--fullscreen-enabled plyr--paused plyr--stopped plyr--pip-supported plyr__poster-enabled" style="--plyr-color-main: #ff7755;"><div class="plyr__controls"><button class="plyr__controls__item plyr__control" type="button" data-plyr="play" aria-pressed="false" aria-label="sample-label"><svg class="icon--pressed" aria-hidden="true" focusable="false"><use href="#plyr-pause"></svg><svg class="icon--not-pressed" aria-hidden="true" focusable="false"><use href="#plyr-play"></svg><span class="label--pressed plyr__sr-only">Sample text</span><span class="label--not-pressed plyr__sr-only">Sample text</span></button><div class="plyr__controls__item plyr__progress__container"><div class="plyr__progress"><input data-plyr="seek" type="range" min="0" max="100" step="0.01" value="0" autocomplete="off" role="slider" aria-label="sample-label" aria-valuemin="0" aria-valuemax="0" aria-valuenow="0" id="plyr-seek-5848" aria-valuetext="00:00 of 00:00" style="--value: 0%;"><progress class="plyr__progress__buffer" min="0" max="100" value="0" role="progressbar" aria-hidden="true">Sample text</progress><span class="plyr__tooltip">Sample text</span></div></div><div class="plyr__controls__item plyr__time--current plyr__time" aria-label="sample-label" role="timer">Sample text</div><div class="plyr__controls__item plyr__volume"><button type="button" class="plyr__control" data-plyr="mute" aria-pressed="false"><svg class="icon--pressed" aria-hidden="true" focusable="false"><use href="#plyr-muted"></svg><svg class="icon--not-pressed" aria-hidden="true" focusable="false"><use href="#plyr-volume"></svg><span class="label--pressed plyr__sr-only">Sample text</span><span class="label--not-pressed plyr__sr-only">Sample text</span></button><input data-plyr="volume" type="range" min="0" max="1" step="0.05" value="1" autocomplete="off" role="slider" aria-label="sample-label" aria-valuemin="0" aria-valuemax="100" aria-valuenow="60" id="plyr-volume-5848" aria-valuetext="60.0%" style="--value: 60%;"></div><button class="plyr__controls__item plyr__control" type="button" data-plyr="pip" aria-pressed="false"><svg aria-hidden="true" focusable="false"><use href="#plyr-pip"></svg><span class="plyr__sr-only">Sample text</span></button><a class="plyr__controls__item plyr__control" href="/d/SYNTH8563" target="_blank" data-plyr="download" aria-pressed="false"><svg aria-hidden="true" focusable="false"><use href="#plyr-download"></svg><span class="plyr__sr-only">Sample text</span></a><button class="plyr__controls__item plyr__control" type="button" data-plyr="fullscreen" aria-pressed="false"><svg class="icon--pressed" aria-hidden="true" focusable="false"><use href="#plyr-exit-fullscreen"></svg><svg class="icon--not-pressed" aria-hidden="true" focusable="false"><use href="#plyr-enter-fullscreen"></svg><span class="label--pressed plyr__sr-only">Sample text</span><span class="label--not-pressed plyr__sr-only">Sample text</span></button></div><div class="plyr__video-wrapper"><video data-poster="https://static.example.test/SYNTH/thumbs/sample-file.jpg" loop="" id="main-video" style="min-height: 100%; height: 100%;" preload="none" controlslist="nodownload" oncontextmenu="return false;" crossorigin="" playsinline="" webkit-playsinline="" src="https://cdn.example.test/media/data/sample-file.mp4?exp=1900000000&token=SYNTH_TOKEN&fn=sample-file.mp4">
+      </video><div class="plyr__poster" style="background-image: url(&quot;https://static.example.test/SYNTH6895"></div></div><div class="plyr__captions" dir="auto"></div><button type="button" class="plyr__control plyr__control--overlaid" data-plyr="play" aria-pressed="false" aria-label="sample-label"><svg aria-hidden="true" focusable="false"><use href="#plyr-play"></svg><span class="plyr__sr-only">Sample text</span></button></div>
+    </div>
+
+    <div id="video-loading" style="display: none;">
+      
+      <div class="poster-bg" style="background-image: url('https://static.example.test/SYNTH6895"></div>
+      
+      <div class="spinner"></div>
+    </div>
+
+  
+</div>
+</body></html>

--- a/scripts/dl-router/tests/fixtures/forum-thread-page.html
+++ b/scripts/dl-router/tests/fixtures/forum-thread-page.html
@@ -1,0 +1,1330 @@
+<!-- FIXTURE: sanitised XenForo-style forum thread page.
+     Structure is byte-faithful to the live page; every URL, id, filename,
+     username, thread title and caption has been replaced with a synthetic
+     placeholder. Synthetic host map:
+       forum.example.test     <- the XenForo forum itself
+       embedhost.example.test <- the video embed host (iframe target)
+       cdn.example.test       <- the signed media CDN the player streams from
+       static.example.test    <- the embed host's poster/thumb CDN
+       imghost.example.test   <- image-gallery host (thumbnail links)
+       thumbs.example.test    <- inline thumbnail image CDN
+       filehost.example.test  <- file host (album/file links)
+-->
+<html><head><title>Sample Thread | Page 6 | Example Forums</title></head>
+<body>
+<div id="top" class="p-pageWrapper"><div class="p-body"><div class="p-body-inner">
+<div class="p-body-main">
+
+<!-- Page-level context accessors (structure faithful, content synthetic).
+     On a forum the SUBJECT is the thread, not the post author - the title and
+     the last breadcrumb are the routing signal, the username is not. -->
+<ul class="p-breadcrumbs" itemscope="" itemtype="https://schema.org/SYNTH495">
+  <li itemprop="itemListElement" itemscope="" itemtype="https://schema.org/SYNTH3293">
+    <a href="/forums/example-category.1/" itemprop="item"><span itemprop="name">Example Category</span></a>
+    <meta itemprop="position" content="1">
+  </li>
+  <li itemprop="itemListElement" itemscope="" itemtype="https://schema.org/SYNTH3293">
+    <a href="/forums/example-subforum.50/" itemprop="item"><span itemprop="name">Example Subforum</span></a>
+    <meta itemprop="position" content="2">
+  </li>
+</ul>
+<div class="p-title">
+  <h1 class="p-title-value">
+    <a href="/forums/example-subforum.50/?prefix_id=40" class="labelLink" rel="nofollow"><span class="label label--xxx" dir="auto">Prefix A</span></a>
+    <span class="label-append">&nbsp;</span>
+    <a href="/forums/example-subforum.50/?prefix_id=47" class="labelLink" rel="nofollow"><span class="label label--xxx" dir="auto">Prefix B</span></a>
+    <span class="label-append">&nbsp;</span>
+    Subject Name | subject_alias | Subject Full Name
+  </h1>
+</div>
+
+<div class="p-body-content"><div class="p-body-pageContent">
+<div class="block block--messages">
+<div class="block-container lbContainer" data-lb-id="thread-90001">
+<div class="block-body js-replyNewMessageContainer">
+
+<!-- CASE A: single cross-origin player embed (the common video post) -->
+<article class="message message--post js-post js-inlineModContainer  " data-author="sample-author" data-content="sample-content" id="js-post-100001" itemscope="" itemtype="https://schema.org/Comment" itemid="https://forum.example.test/members/sample-user.1/">
+
+		
+			<meta itemprop="parentItem" itemscope="" itemid="https://forum.example.test/members/sample-user.1/">
+			<meta itemprop="name" content="https://forum.example.test/threads/SYNTH9970/ID2xxx">
+		
+
+		<span class="u-anchorTarget" id="post-100001"></span>
+
+		
+			<div class="message-inner">
+				
+					<div class="message-cell message-cell--user">
+						
+
+	<section class="message-user" itemprop="author" itemscope="" itemtype="https://schema.org/Person" itemid="https://forum.example.test/members/sample-user.1/">
+
+		
+			<meta itemprop="url" content="https://forum.example.test/members/SYNTH4465">
+		
+
+		<div class="message-avatar ">
+			<div class="message-avatar-wrapper">
+				<span class="simp-avatar-border-wrap" style="position:relative;display:inline-flex;vertical-align:top;ove"><a href="https://forum.example.test/members/SYNTH4465" class="avatar avatar--m" data-user-id="2696309" data-xf-init="member-tooltip" id="js-XFUniqueId15">
+			<img src="https://thumbs.example.test/ID4x/data/ID5xxx/ID6/ID7/sample-file.jpg?1776037119=SYNTH_1776037119" alt="sample-alt" class="avatar-u2696309-m" width="96" height="96" loading="lazy" itemprop="image"> 
+		</a><img src="https://forum.example.test/ID9xx/SYNTH5400/ID11.webp" class="simp-avatar-border" style="position:absolute;top:-10%;left:-10%;width:120%;height:120%;" loading="lazy" decoding="async" aria-hidden="true"></span>
+				
+			</div>
+		</div>
+		<div class="message-userDetails">
+			<h4 class="message-name"><a href="https://forum.example.test/members/SYNTH4465" class="username " dir="auto" data-user-id="2696309" data-xf-init="member-tooltip" id="js-XFUniqueId16"><span class="username--style20" itemprop="name">Sample text</span></a></h4>
+			<h5 class="userTitle message-userTitle" dir="auto" itemprop="jobTitle">Sample text</h5>
+			<div class="userBanner banner--council message-userBanner" itemprop="jobTitle"><span class="userBanner-before"></span><strong>Sample text</strong><span class="userBanner-after"></span></div>
+<div class="userBanner banner--simp message-userBanner" itemprop="jobTitle"><span class="userBanner-before"></span><strong>Sample text</strong><span class="userBanner-after"></span></div>
+		</div>
+		
+			
+			
+				<div class="message-userExtras">
+				
+					
+						<dl class="pairs pairs--justified">
+							<dt><i class="fa--xf far fa-user "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i> </dt>
+							<dd>Sample text</dd>
+						</dl>
+					
+					
+						<dl class="pairs pairs--justified">
+							<dt><i class="fa--xf far fa-comment "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i> </dt>
+							<dd>Sample text</dd>
+						</dl>
+					
+					
+					
+						<dl class="pairs pairs--justified">
+							<dt><i class="fa--xf far fa-thumbs-up "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i> </dt>
+							<dd>Sample text</dd>
+						</dl>
+					
+					
+					
+					
+					
+					
+				
+				</div>
+			
+		
+		<span class="message-userArrow"></span>
+	</section>
+
+					</div>
+				
+
+				
+					<div class="message-cell message-cell--main">
+					
+						<div class="message-main js-quickEditTarget">
+
+							
+								
+
+	
+
+	<header class="message-attribution message-attribution--split">
+		<ul class="message-attribution-main listInline ">
+			
+			
+			<li class="u-concealed">
+				<a href="https://forum.example.test/threads/SYNTH9970/SYNTH2881" rel="nofollow" itemprop="url">
+					<time class="u-dt" dir="auto" datetime="2025-02-08T14:38:25-0600" data-timestamp="1739047105" data-date="Feb 8, 2025" data-time="2:38 PM" data-short="Feb '25" title="sample-title" itemprop="datePublished">Sample text</time>
+				</a>
+			</li>
+			
+		</ul>
+
+		<ul class="message-attribution-opposite message-attribution-opposite--list ">
+			
+			
+			
+			
+			<li>
+				<a href="https://forum.example.test/threads/SYNTH9970/SYNTH2881" class="message-attribution-gadget" data-xf-init="share-tooltip" data-href="/posts/100003/share" aria-label="sample-aria-label" rel="nofollow" id="js-XFUniqueId93">
+					<i class="fa--xf far fa-share-alt "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i>
+				</a>
+			</li>
+			
+				<li class="u-hidden js-embedCopy">
+					
+	<a href="javascript:" data-xf-init="copy-to-clipboard" data-copy-text="sample-copy-text" data-success="Embed code HTML copied to clipboard." class="">
+		<i class="fa--xf far fa-code "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i>
+	</a>
+
+				</li>
+			
+			
+				<li>
+					
+						
+
+	
+		<a href="https://forum.example.test/posts/ID16xxx/ID17xxx" class="bookmarkLink message-attribution-gadget bookmarkLink--highlightable " title="sample-title" data-xf-click="bookmark-click" data-label=".js-bookmarkText" data-sk-bookmarked="addClass:is-bookmarked, titleAttr:sync" data-sk-bookmarkremoved="removeClass:is-bookmarked, titleAttr:sync"><span class="js-bookmarkText u-srOnly">Sample text</span></a>
+	
+
+					
+				</li>
+			
+			
+				<li>
+					<a href="https://forum.example.test/threads/SYNTH9970/SYNTH2881" rel="nofollow">
+						Sample text
+					</a>
+				</li>
+			
+		</ul>
+	</header>
+
+							
+
+							<div class="message-content js-messageContent">
+							
+
+								
+									
+	
+
+	
+
+	
+	
+
+								
+
+								
+									
+	
+
+	<div class="message-userContent lbContainer js-lbContainer " data-lb-id="post-100003" data-lb-caption-desc="sample-lb-caption-desc">
+
+		
+
+		<article class="message-body js-selectToQuote">
+			
+				
+			
+
+			<div itemprop="text">
+				
+					<div class="bbWrapper"><div class="generic2wide-iframe-div">
+<iframe class="embed-iframe" src="https://embedhost.example.test/embed/SYNTH9515" height="auto" width="auto" style="border:none;" loading="lazy" allow="fullscreen;"></iframe>
+</div></div>
+				
+			</div>
+
+			<div class="js-selectToQuoteEnd"> </div>
+			
+				
+			
+		</article>
+
+		
+
+		
+	</div>
+
+								
+
+								
+									
+	
+
+	
+
+								
+
+								
+									
+	
+
+								
+
+							
+							</div>
+
+							
+								
+	
+
+	<footer class="message-footer">
+		
+			<div class="message-microdata" itemprop="interactionStatistic" itemtype="https://schema.org/SYNTH6663" itemscope="">
+				<meta itemprop="userInteractionCount" content="https://forum.example.test/threads/SYNTH9970/ID19">
+				<meta itemprop="interactionType" content="https://other.example.test/SYNTH8758">
+			</div>
+		
+
+		
+			<div class="message-actionBar actionBar">
+				
+					
+	
+		<div class="actionBar-set actionBar-set--external">
+		
+			<a href="https://forum.example.test/posts/ID16xxx/ID21?reaction_id=SYNTH_REACTION_ID" class="reaction reaction--small actionBar-action actionBar-action--reaction reaction--imageHidden reaction--1" data-reaction-id="1" data-xf-init="reaction" data-reaction-list="< .js-post | .js-reactionsList" id="js-XFUniqueId17"><i aria-hidden="true"></i><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///SYNTH2102" loading="lazy" class="reaction-sprite js-reaction" alt="sample-alt" title="sample-title"> <span class="reaction-text js-reactionText"><bdi>Sample text</bdi></span></a>
+
+			
+				
+
+				
+					<a href="https://forum.example.test/threads/SYNTH9970/ID22?quote=SYNTH_QUOTE" class="actionBar-action actionBar-action--mq u-jsOnly js-multiQuote" title="sample-title" rel="nofollow" data-message-id="100003" data-mq-action="add">Sample text</a>
+				
+
+				<a href="https://forum.example.test/threads/SYNTH9970/ID22?quote=SYNTH_QUOTE" class="actionBar-action actionBar-action--reply" title="sample-title" rel="nofollow" data-xf-click="quote" data-quote-href="/posts/100003/quote">Sample text</a>
+			
+
+		
+		</div>
+	
+
+	
+		<div class="actionBar-set actionBar-set--internal">
+		
+			
+
+			
+				<a href="https://forum.example.test/posts/ID16xxx/ID23x" class="actionBar-action actionBar-action--report" data-xf-click="overlay" data-cache="false">Sample text</a>
+			
+
+			
+			
+			
+			
+			
+			
+			
+			
+
+			
+		
+		</div>
+	
+
+				
+			</div>
+		
+
+		<div class="reactionsBar js-reactionsList is-active">
+			
+	
+	
+		<ul class="reactionSummary">
+		
+			<li><span class="reaction reaction--small reaction--1" data-reaction-id="1"><i aria-hidden="true"></i><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///SYNTH2102" loading="lazy" class="reaction-sprite js-reaction" alt="sample-alt" title="sample-title"></span></li><li><span class="reaction reaction--small reaction--33" data-reaction-id="33"><i aria-hidden="true"></i><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///SYNTH2102" loading="lazy" class="reaction-sprite js-reaction" alt="sample-alt" title="sample-title"></span></li><li><span class="reaction reaction--small reaction--7" data-reaction-id="7"><i aria-hidden="true"></i><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///SYNTH2102" loading="lazy" class="reaction-sprite js-reaction" alt="sample-alt" title="sample-title"></span></li>
+		
+		</ul>
+	
+
+
+<span class="u-srOnly">Sample text</span>
+<a class="reactionsBar-link" href="https://forum.example.test/posts/ID16xxx/SYNTH7494" data-xf-click="overlay" data-cache="false" rel="nofollow"><bdi>Sample text</bdi>Sample text <bdi>Sample text</bdi>Sample text <bdi>Sample text</bdi> Sample text</a>
+		</div>
+
+		<div class="js-historyTarget message-historyTarget toggleTarget" data-href="trigger-href"></div>
+	</footer>
+
+							
+						</div>
+
+					
+					</div>
+				
+			</div>
+		
+	</article>
+
+<!-- CASE B: two player embeds in one post -->
+<article class="message message--post js-post js-inlineModContainer  " data-author="sample-author" data-content="sample-content" id="js-post-100001" itemscope="" itemtype="https://schema.org/Comment" itemid="https://forum.example.test/members/sample-user.1/">
+
+		
+			<meta itemprop="parentItem" itemscope="" itemid="https://forum.example.test/members/sample-user.1/">
+			<meta itemprop="name" content="https://forum.example.test/threads/SYNTH9970/ID2xxx">
+		
+
+		<span class="u-anchorTarget" id="post-100001"></span>
+
+		
+			<div class="message-inner">
+				
+					<div class="message-cell message-cell--user">
+						
+
+	<section class="message-user" itemprop="author" itemscope="" itemtype="https://schema.org/Person" itemid="https://forum.example.test/members/sample-user.1/">
+
+		
+			<meta itemprop="url" content="https://forum.example.test/members/SYNTH4465">
+		
+
+		<div class="message-avatar ">
+			<div class="message-avatar-wrapper">
+				<span class="simp-avatar-border-wrap" style="position:relative;display:inline-flex;vertical-align:top;ove"><a href="https://forum.example.test/members/SYNTH4465" class="avatar avatar--m" data-user-id="2696309" data-xf-init="member-tooltip" id="js-XFUniqueId31">
+			<img src="https://thumbs.example.test/ID4x/data/ID5xxx/ID6/ID7/sample-file.jpg?1776037119=SYNTH_1776037119" alt="sample-alt" class="avatar-u2696309-m" width="96" height="96" loading="lazy" itemprop="image"> 
+		</a><img src="https://forum.example.test/ID9xx/SYNTH5400/ID11.webp" class="simp-avatar-border" style="position:absolute;top:-10%;left:-10%;width:120%;height:120%;" loading="lazy" decoding="async" aria-hidden="true"></span>
+				
+			</div>
+		</div>
+		<div class="message-userDetails">
+			<h4 class="message-name"><a href="https://forum.example.test/members/SYNTH4465" class="username " dir="auto" data-user-id="2696309" data-xf-init="member-tooltip" id="js-XFUniqueId32"><span class="username--style20" itemprop="name">Sample text</span></a></h4>
+			<h5 class="userTitle message-userTitle" dir="auto" itemprop="jobTitle">Sample text</h5>
+			<div class="userBanner banner--council message-userBanner" itemprop="jobTitle"><span class="userBanner-before"></span><strong>Sample text</strong><span class="userBanner-after"></span></div>
+<div class="userBanner banner--simp message-userBanner" itemprop="jobTitle"><span class="userBanner-before"></span><strong>Sample text</strong><span class="userBanner-after"></span></div>
+		</div>
+		
+			
+			
+				<div class="message-userExtras">
+				
+					
+						<dl class="pairs pairs--justified">
+							<dt><i class="fa--xf far fa-user "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i> </dt>
+							<dd>Sample text</dd>
+						</dl>
+					
+					
+						<dl class="pairs pairs--justified">
+							<dt><i class="fa--xf far fa-comment "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i> </dt>
+							<dd>Sample text</dd>
+						</dl>
+					
+					
+					
+						<dl class="pairs pairs--justified">
+							<dt><i class="fa--xf far fa-thumbs-up "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i> </dt>
+							<dd>Sample text</dd>
+						</dl>
+					
+					
+					
+					
+					
+					
+				
+				</div>
+			
+		
+		<span class="message-userArrow"></span>
+	</section>
+
+					</div>
+				
+
+				
+					<div class="message-cell message-cell--main">
+					
+						<div class="message-main js-quickEditTarget">
+
+							
+								
+
+	
+
+	<header class="message-attribution message-attribution--split">
+		<ul class="message-attribution-main listInline ">
+			
+			
+			<li class="u-concealed">
+				<a href="https://forum.example.test/threads/SYNTH9970/SYNTH6144" rel="nofollow" itemprop="url">
+					<time class="u-dt" dir="auto" datetime="2025-04-30T17:24:04-0500" data-timestamp="1746051844" data-date="Apr 30, 2025" data-time="5:24 PM" data-short="Apr '25" title="sample-title" itemprop="datePublished">Sample text</time>
+				</a>
+			</li>
+			
+		</ul>
+
+		<ul class="message-attribution-opposite message-attribution-opposite--list ">
+			
+			
+			
+			
+			<li>
+				<a href="https://forum.example.test/threads/SYNTH9970/SYNTH6144" class="message-attribution-gadget" data-xf-init="share-tooltip" data-href="/posts/100008/share" aria-label="sample-aria-label" rel="nofollow" id="js-XFUniqueId98">
+					<i class="fa--xf far fa-share-alt "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i>
+				</a>
+			</li>
+			
+				<li class="u-hidden js-embedCopy">
+					
+	<a href="javascript:" data-xf-init="copy-to-clipboard" data-copy-text="sample-copy-text" data-success="Embed code HTML copied to clipboard." class="">
+		<i class="fa--xf far fa-code "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i>
+	</a>
+
+				</li>
+			
+			
+				<li>
+					
+						
+
+	
+		<a href="https://forum.example.test/posts/ID26xxx/ID17xxx" class="bookmarkLink message-attribution-gadget bookmarkLink--highlightable " title="sample-title" data-xf-click="bookmark-click" data-label=".js-bookmarkText" data-sk-bookmarked="addClass:is-bookmarked, titleAttr:sync" data-sk-bookmarkremoved="removeClass:is-bookmarked, titleAttr:sync"><span class="js-bookmarkText u-srOnly">Sample text</span></a>
+	
+
+					
+				</li>
+			
+			
+				<li>
+					<a href="https://forum.example.test/threads/SYNTH9970/SYNTH6144" rel="nofollow">
+						Sample text
+					</a>
+				</li>
+			
+		</ul>
+	</header>
+
+							
+
+							<div class="message-content js-messageContent">
+							
+
+								
+									
+	
+
+	
+
+	
+	
+
+								
+
+								
+									
+	
+
+	<div class="message-userContent lbContainer js-lbContainer " data-lb-id="post-100008" data-lb-caption-desc="sample-lb-caption-desc">
+
+		
+
+		<article class="message-body js-selectToQuote">
+			
+				
+			
+
+			<div itemprop="text">
+				
+					<div class="bbWrapper">Sample text<br>
+<br>
+<br>
+<div class="generic2wide-iframe-div">
+<iframe class="embed-iframe" src="https://embedhost.example.test/embed/SYNTH8329" height="auto" width="auto" style="border:none;" loading="lazy" allow="fullscreen;"></iframe>
+</div><div class="generic2wide-iframe-div">
+<iframe class="embed-iframe" src="https://embedhost.example.test/embed/SYNTH1608" height="auto" width="auto" style="border:none;" loading="lazy" allow="fullscreen;"></iframe>
+</div></div>
+				
+			</div>
+
+			<div class="js-selectToQuoteEnd"> </div>
+			
+				
+			
+		</article>
+
+		
+
+		
+	</div>
+
+								
+
+								
+									
+	
+
+	
+
+								
+
+								
+									
+	
+
+								
+
+							
+							</div>
+
+							
+								
+	
+
+	<footer class="message-footer">
+		
+			<div class="message-microdata" itemprop="interactionStatistic" itemtype="https://schema.org/SYNTH6663" itemscope="">
+				<meta itemprop="userInteractionCount" content="https://forum.example.test/threads/SYNTH9970/ID29">
+				<meta itemprop="interactionType" content="https://other.example.test/SYNTH8758">
+			</div>
+		
+
+		
+			<div class="message-actionBar actionBar">
+				
+					
+	
+		<div class="actionBar-set actionBar-set--external">
+		
+			<a href="https://forum.example.test/posts/ID26xxx/ID21?reaction_id=SYNTH_REACTION_ID" class="reaction reaction--small actionBar-action actionBar-action--reaction reaction--imageHidden reaction--1" data-reaction-id="1" data-xf-init="reaction" data-reaction-list="< .js-post | .js-reactionsList" id="js-XFUniqueId33"><i aria-hidden="true"></i><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///SYNTH2102" loading="lazy" class="reaction-sprite js-reaction" alt="sample-alt" title="sample-title"> <span class="reaction-text js-reactionText"><bdi>Sample text</bdi></span></a>
+
+			
+				
+
+				
+					<a href="https://forum.example.test/threads/SYNTH9970/ID22?quote=SYNTH_QUOTE" class="actionBar-action actionBar-action--mq u-jsOnly js-multiQuote" title="sample-title" rel="nofollow" data-message-id="100008" data-mq-action="add">Sample text</a>
+				
+
+				<a href="https://forum.example.test/threads/SYNTH9970/ID22?quote=SYNTH_QUOTE" class="actionBar-action actionBar-action--reply" title="sample-title" rel="nofollow" data-xf-click="quote" data-quote-href="/posts/100008/quote">Sample text</a>
+			
+
+		
+		</div>
+	
+
+	
+		<div class="actionBar-set actionBar-set--internal">
+		
+			
+
+			
+				<a href="https://forum.example.test/posts/ID26xxx/ID23x" class="actionBar-action actionBar-action--report" data-xf-click="overlay" data-cache="false">Sample text</a>
+			
+
+			
+			
+			
+			
+			
+			
+			
+			
+
+			
+		
+		</div>
+	
+
+				
+			</div>
+		
+
+		<div class="reactionsBar js-reactionsList is-active">
+			
+	
+	
+		<ul class="reactionSummary">
+		
+			<li><span class="reaction reaction--small reaction--1" data-reaction-id="1"><i aria-hidden="true"></i><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///SYNTH2102" loading="lazy" class="reaction-sprite js-reaction" alt="sample-alt" title="sample-title"></span></li><li><span class="reaction reaction--small reaction--33" data-reaction-id="33"><i aria-hidden="true"></i><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///SYNTH2102" loading="lazy" class="reaction-sprite js-reaction" alt="sample-alt" title="sample-title"></span></li><li><span class="reaction reaction--small reaction--50" data-reaction-id="50"><i aria-hidden="true"></i><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///SYNTH2102" loading="lazy" class="reaction-sprite js-reaction" alt="sample-alt" title="sample-title"></span></li>
+		
+		</ul>
+	
+
+
+<span class="u-srOnly">Sample text</span>
+<a class="reactionsBar-link" href="https://forum.example.test/posts/ID26xxx/SYNTH7494" data-xf-click="overlay" data-cache="false" rel="nofollow"><bdi>Sample text</bdi>Sample text <bdi>Sample text</bdi>Sample text <bdi>Sample text</bdi> Sample text</a>
+		</div>
+
+		<div class="js-historyTarget message-historyTarget toggleTarget" data-href="trigger-href"></div>
+	</footer>
+
+							
+						</div>
+
+					
+					</div>
+				
+			</div>
+		
+	</article>
+
+<!-- CASE C: no player at all - thumbnail links out to an image host plus a
+     file-host link. Nothing here is a video player; a rule must NOT match it. -->
+<article class="message message--post js-post js-inlineModContainer  " data-author="sample-author" data-content="sample-content" id="js-post-100001" itemscope="" itemtype="https://schema.org/Comment" itemid="https://forum.example.test/members/sample-user.1/">
+
+		
+			<meta itemprop="parentItem" itemscope="" itemid="https://forum.example.test/members/sample-user.1/">
+			<meta itemprop="name" content="https://forum.example.test/threads/SYNTH9970/ID2xxx">
+		
+
+		<span class="u-anchorTarget" id="post-100001"></span>
+
+		
+			<div class="message-inner">
+				
+					<div class="message-cell message-cell--user">
+						
+
+	<section class="message-user" itemprop="author" itemscope="" itemtype="https://schema.org/Person" itemid="https://forum.example.test/members/sample-user.1/">
+
+		
+			<meta itemprop="url" content="https://forum.example.test/members/SYNTH7406">
+		
+
+		<div class="message-avatar ">
+			<div class="message-avatar-wrapper">
+				<a href="https://forum.example.test/members/SYNTH7406" class="avatar avatar--m avatar--default avatar--default--dynamic" data-user-id="3835672" data-xf-init="member-tooltip" style="background-color: #666699; color: #d1d1e0" id="js-XFUniqueId34">
+			<span class="avatar-u3835672-m" role="img" aria-label="sample-aria-label">Sample text</span> 
+		</a>
+				
+			</div>
+		</div>
+		<div class="message-userDetails">
+			<h4 class="message-name"><a href="https://forum.example.test/members/SYNTH7406" class="username " dir="auto" data-user-id="3835672" data-xf-init="member-tooltip" id="js-XFUniqueId35"><span class="username--style52" itemprop="name">Sample text</span></a></h4>
+			<h5 class="userTitle message-userTitle" dir="auto" itemprop="jobTitle">Sample text</h5>
+			<div class="userBanner banner--connoisseur message-userBanner" itemprop="jobTitle"><span class="userBanner-before"></span><strong>Sample text</strong><span class="userBanner-after"></span></div>
+<div class="userBanner banner--council message-userBanner" itemprop="jobTitle"><span class="userBanner-before"></span><strong>Sample text</strong><span class="userBanner-after"></span></div>
+<div class="userBanner banner--simp message-userBanner" itemprop="jobTitle"><span class="userBanner-before"></span><strong>Sample text</strong><span class="userBanner-after"></span></div>
+		</div>
+		
+			
+			
+				<div class="message-userExtras">
+				
+					
+						<dl class="pairs pairs--justified">
+							<dt><i class="fa--xf far fa-user "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i> </dt>
+							<dd>Sample text</dd>
+						</dl>
+					
+					
+						<dl class="pairs pairs--justified">
+							<dt><i class="fa--xf far fa-comment "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i> </dt>
+							<dd>Sample text</dd>
+						</dl>
+					
+					
+					
+						<dl class="pairs pairs--justified">
+							<dt><i class="fa--xf far fa-thumbs-up "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i> </dt>
+							<dd>Sample text</dd>
+						</dl>
+					
+					
+					
+					
+					
+					
+				
+				</div>
+			
+		
+		<span class="message-userArrow"></span>
+	</section>
+
+					</div>
+				
+
+				
+					<div class="message-cell message-cell--main">
+					
+						<div class="message-main js-quickEditTarget">
+
+							
+								
+
+	
+
+	<header class="message-attribution message-attribution--split">
+		<ul class="message-attribution-main listInline ">
+			
+			
+			<li class="u-concealed">
+				<a href="https://forum.example.test/threads/SYNTH9970/SYNTH4736" rel="nofollow" itemprop="url">
+					<time class="u-dt" dir="auto" datetime="2025-05-20T23:50:05-0500" data-timestamp="1747803005" data-date="May 20, 2025" data-time="11:50 PM" data-short="May '25" title="sample-title" itemprop="datePublished">Sample text</time>
+				</a>
+			</li>
+			
+		</ul>
+
+		<ul class="message-attribution-opposite message-attribution-opposite--list ">
+			
+			
+			
+			
+			<li>
+				<a href="https://forum.example.test/threads/SYNTH9970/SYNTH4736" class="message-attribution-gadget" data-xf-init="share-tooltip" data-href="/posts/100009/share" aria-label="sample-aria-label" rel="nofollow" id="js-XFUniqueId99">
+					<i class="fa--xf far fa-share-alt "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i>
+				</a>
+			</li>
+			
+				<li class="u-hidden js-embedCopy">
+					
+	<a href="javascript:" data-xf-init="copy-to-clipboard" data-copy-text="sample-copy-text" data-success="Embed code HTML copied to clipboard." class="">
+		<i class="fa--xf far fa-code "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i>
+	</a>
+
+				</li>
+			
+			
+				<li>
+					
+						
+
+	
+		<a href="https://forum.example.test/posts/ID32xxx/ID17xxx" class="bookmarkLink message-attribution-gadget bookmarkLink--highlightable " title="sample-title" data-xf-click="bookmark-click" data-label=".js-bookmarkText" data-sk-bookmarked="addClass:is-bookmarked, titleAttr:sync" data-sk-bookmarkremoved="removeClass:is-bookmarked, titleAttr:sync"><span class="js-bookmarkText u-srOnly">Sample text</span></a>
+	
+
+					
+				</li>
+			
+			
+				<li>
+					<a href="https://forum.example.test/threads/SYNTH9970/SYNTH4736" rel="nofollow">
+						Sample text
+					</a>
+				</li>
+			
+		</ul>
+	</header>
+
+							
+
+							<div class="message-content js-messageContent">
+							
+
+								
+									
+	
+
+	
+
+	
+	
+
+								
+
+								
+									
+	
+
+	<div class="message-userContent lbContainer js-lbContainer " data-lb-id="post-100009" data-lb-caption-desc="sample-lb-caption-desc">
+
+		
+
+		<article class="message-body js-selectToQuote">
+			
+				
+			
+
+			<div itemprop="text">
+				
+					<div class="bbWrapper"><a href="https://imghost.example.test/img/ID33xx" target="_blank" class="link link--external" rel="nofollow ugc noopener"><img src="https://thumbs.example.test/images3/sample-file.jpg" data-url="https://thumbs.example.test/images3/sample-file.jpg" class="bbImage " loading="lazy" alt="sample-alt" title="sample-title" style="" width="" height=""></a> <a href="https://imghost.example.test/img/ID35xx" target="_blank" class="link link--external" rel="nofollow ugc noopener"><img src="https://thumbs.example.test/images3/sample-file.jpg" data-url="https://thumbs.example.test/images3/sample-file.jpg" class="bbImage " loading="lazy" alt="sample-alt" title="sample-title" style="" width="" height=""></a><br>
+<br>
+<b><span style="font-size: 26px">Sample text </span></b><br>
+<br>
+
+	
+
+	<div class="bbCodeBlock bbCodeBlock--unfurl    js-unfurl fauxBlockLink" data-unfurl="true" data-result-id="17965004" data-url="https://other.example.test/ID37/ID38xxx" data-host="other.example.test" data-pending="false">
+		<div class="contentRow">
+			
+				<div class="contentRow-figure contentRow-figure--fixedSmall js-unfurl-figure">
+					
+						<img src="https://other.example.test/ID39/ID40/ID38xxx/SYNTH3742" alt="sample-alt" data-onerror="hide-parent">
+					
+				</div>
+			
+			<div class="contentRow-main">
+				<h3 class="contentRow-header js-unfurl-title">
+					<a href="https://forum.example.test/ID42xxx?to=SYNTH_TO&e=SYNTH_E&m=SYNTH_M" class="link link--external fauxBlockLink-blockLink" target="_blank" rel="nofollow ugc noopener" data-proxy-href="">
+						Sample text
+					</a>
+				</h3>
+
+				<div class="contentRow-snippet js-unfurl-desc">Sample text</div>
+
+				<div class="contentRow-minor contentRow-minor--hideLinks">
+					<span class="js-unfurl-favicon">
+						
+							<img src="https://other.example.test/ID43/img/sample-file.png" alt="sample-alt" class="bbCodeBlockUnfurl-icon" data-onerror="hide-parent">
+						
+					</span>
+					Sample text
+				</div>
+			</div>
+		</div>
+	</div>
+
+
+	
+
+	<div class="bbCodeBlock bbCodeBlock--unfurl    js-unfurl fauxBlockLink" data-unfurl="true" data-result-id="17965186" data-url="https://filehost.example.test/f/SYNTH213" data-host="filehost.example.test" data-pending="false">
+		<div class="contentRow">
+			
+				<div class="contentRow-figure contentRow-figure--fixedSmall js-unfurl-figure" style="display: none;">
+					
+						<img src="https://filehost.example.test/thumbs/sample-file.png" loading="lazy" alt="sample-alt" class="bbCodeBlockUnfurl-image" data-onerror="hide-parent">
+					
+				</div>
+			
+			<div class="contentRow-main">
+				<h3 class="contentRow-header js-unfurl-title">
+					<a href="https://filehost.example.test/f/SYNTH213" class="link link--external fauxBlockLink-blockLink" target="_blank" rel="nofollow ugc noopener" data-proxy-href="">
+						Sample text
+					</a>
+				</h3>
+
+				<div class="contentRow-snippet js-unfurl-desc">Sample text</div>
+
+				<div class="contentRow-minor contentRow-minor--hideLinks">
+					<span class="js-unfurl-favicon">
+						
+							<img src="https://filehost.example.test/ID47x/ID48xx" loading="lazy" alt="sample-alt" class="bbCodeBlockUnfurl-icon" data-onerror="hide-parent">
+						
+					</span>
+					Sample text
+				</div>
+			</div>
+		</div>
+	</div></div>
+				
+			</div>
+
+			<div class="js-selectToQuoteEnd"> </div>
+			
+				
+			
+		</article>
+
+		
+
+		
+	</div>
+
+								
+
+								
+									
+	
+
+	
+		<div class="message-lastEdit">
+			
+				Sample text <time class="u-dt" dir="auto" datetime="2025-05-20T23:56:55-0500" data-timestamp="1747803415" data-date="May 20, 2025" data-time="11:56 PM" data-short="May '25" title="sample-title" itemprop="dateModified">Sample text</time>
+			
+		</div>
+	
+
+								
+
+								
+									
+	
+
+								
+
+							
+							</div>
+
+							
+								
+	
+
+	<footer class="message-footer">
+		
+			<div class="message-microdata" itemprop="interactionStatistic" itemtype="https://schema.org/SYNTH6663" itemscope="">
+				<meta itemprop="userInteractionCount" content="https://forum.example.test/threads/SYNTH9970/ID49">
+				<meta itemprop="interactionType" content="https://other.example.test/SYNTH8758">
+			</div>
+		
+
+		
+			<div class="message-actionBar actionBar">
+				
+					
+	
+		<div class="actionBar-set actionBar-set--external">
+		
+			<a href="https://forum.example.test/posts/ID32xxx/ID21?reaction_id=SYNTH_REACTION_ID" class="reaction reaction--small actionBar-action actionBar-action--reaction reaction--imageHidden reaction--1" data-reaction-id="1" data-xf-init="reaction" data-reaction-list="< .js-post | .js-reactionsList" id="js-XFUniqueId36"><i aria-hidden="true"></i><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///SYNTH2102" loading="lazy" class="reaction-sprite js-reaction" alt="sample-alt" title="sample-title"> <span class="reaction-text js-reactionText"><bdi>Sample text</bdi></span></a>
+
+			
+				
+
+				
+					<a href="https://forum.example.test/threads/SYNTH9970/ID22?quote=SYNTH_QUOTE" class="actionBar-action actionBar-action--mq u-jsOnly js-multiQuote" title="sample-title" rel="nofollow" data-message-id="100009" data-mq-action="add">Sample text</a>
+				
+
+				<a href="https://forum.example.test/threads/SYNTH9970/ID22?quote=SYNTH_QUOTE" class="actionBar-action actionBar-action--reply" title="sample-title" rel="nofollow" data-xf-click="quote" data-quote-href="/posts/100009/quote">Sample text</a>
+			
+
+		
+		</div>
+	
+
+	
+		<div class="actionBar-set actionBar-set--internal">
+		
+			
+
+			
+				<a href="https://forum.example.test/posts/ID32xxx/ID23x" class="actionBar-action actionBar-action--report" data-xf-click="overlay" data-cache="false">Sample text</a>
+			
+
+			
+			
+			
+			
+			
+			
+			
+			
+
+			
+		
+		</div>
+	
+
+				
+			</div>
+		
+
+		<div class="reactionsBar js-reactionsList is-active">
+			
+	
+	
+		<ul class="reactionSummary">
+		
+			<li><span class="reaction reaction--small reaction--1" data-reaction-id="1"><i aria-hidden="true"></i><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///SYNTH2102" loading="lazy" class="reaction-sprite js-reaction" alt="sample-alt" title="sample-title"></span></li><li><span class="reaction reaction--small reaction--48" data-reaction-id="48"><i aria-hidden="true"></i><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///SYNTH2102" loading="lazy" class="reaction-sprite js-reaction" alt="sample-alt" title="sample-title"></span></li><li><span class="reaction reaction--small reaction--21" data-reaction-id="21"><i aria-hidden="true"></i><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///SYNTH2102" loading="lazy" class="reaction-sprite js-reaction" alt="sample-alt" title="sample-title"></span></li>
+		
+		</ul>
+	
+
+
+<span class="u-srOnly">Sample text</span>
+<a class="reactionsBar-link" href="https://forum.example.test/posts/ID32xxx/SYNTH7494" data-xf-click="overlay" data-cache="false" rel="nofollow"><bdi>Sample text</bdi>Sample text <bdi>Sample text</bdi>Sample text <bdi>Sample text</bdi> Sample text</a>
+		</div>
+
+		<div class="js-historyTarget message-historyTarget toggleTarget" data-href="trigger-href"></div>
+	</footer>
+
+							
+						</div>
+
+					
+					</div>
+				
+			</div>
+		
+	</article>
+
+<!-- CASE D: bare file-host text links, no player, no thumbnails -->
+<article class="message message--post js-post js-inlineModContainer  " data-author="sample-author" data-content="sample-content" id="js-post-100001" itemscope="" itemtype="https://schema.org/Comment" itemid="https://forum.example.test/members/sample-user.1/">
+
+		
+			<meta itemprop="parentItem" itemscope="" itemid="https://forum.example.test/members/sample-user.1/">
+			<meta itemprop="name" content="https://forum.example.test/threads/SYNTH9970/ID2xxx">
+		
+
+		<span class="u-anchorTarget" id="post-100001"></span>
+
+		
+			<div class="message-inner">
+				
+					<div class="message-cell message-cell--user">
+						
+
+	<section class="message-user" itemprop="author" itemscope="" itemtype="https://schema.org/Person" itemid="https://forum.example.test/members/sample-user.1/">
+
+		
+			<meta itemprop="url" content="https://forum.example.test/members/SYNTH9886">
+		
+
+		<div class="message-avatar ">
+			<div class="message-avatar-wrapper">
+				<a href="https://forum.example.test/members/SYNTH9886" class="avatar avatar--m avatar--default avatar--default--dynamic" data-user-id="430146" data-xf-init="member-tooltip" style="background-color: #a34729; color: #e6ac99" id="js-XFUniqueId63">
+			<span class="avatar-u430146-m" role="img" aria-label="sample-aria-label">Sample text</span> 
+		</a>
+				
+			</div>
+		</div>
+		<div class="message-userDetails">
+			<h4 class="message-name"><a href="https://forum.example.test/members/SYNTH9886" class="username " dir="auto" data-user-id="430146" data-xf-init="member-tooltip" id="js-XFUniqueId64"><span class="username--style52" itemprop="name">Sample text</span></a></h4>
+			<h5 class="userTitle message-userTitle" dir="auto" itemprop="jobTitle">Sample text</h5>
+			<div class="userBanner banner--connoisseur message-userBanner" itemprop="jobTitle"><span class="userBanner-before"></span><strong>Sample text</strong><span class="userBanner-after"></span></div>
+<div class="userBanner banner--council message-userBanner" itemprop="jobTitle"><span class="userBanner-before"></span><strong>Sample text</strong><span class="userBanner-after"></span></div>
+<div class="userBanner banner--simp message-userBanner" itemprop="jobTitle"><span class="userBanner-before"></span><strong>Sample text</strong><span class="userBanner-after"></span></div>
+		</div>
+		
+			
+			
+				<div class="message-userExtras">
+				
+					
+						<dl class="pairs pairs--justified">
+							<dt><i class="fa--xf far fa-user "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i> </dt>
+							<dd>Sample text</dd>
+						</dl>
+					
+					
+						<dl class="pairs pairs--justified">
+							<dt><i class="fa--xf far fa-comment "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i> </dt>
+							<dd>Sample text</dd>
+						</dl>
+					
+					
+					
+						<dl class="pairs pairs--justified">
+							<dt><i class="fa--xf far fa-thumbs-up "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i> </dt>
+							<dd>Sample text</dd>
+						</dl>
+					
+					
+					
+					
+					
+					
+				
+				</div>
+			
+		
+		<span class="message-userArrow"></span>
+	</section>
+
+					</div>
+				
+
+				
+					<div class="message-cell message-cell--main">
+					
+						<div class="message-main js-quickEditTarget">
+
+							
+								
+
+	
+
+	<header class="message-attribution message-attribution--split">
+		<ul class="message-attribution-main listInline ">
+			
+			
+			<li class="u-concealed">
+				<a href="https://forum.example.test/threads/SYNTH9970/SYNTH8810" rel="nofollow" itemprop="url">
+					<time class="u-dt" dir="auto" datetime="2025-10-25T21:01:36-0500" data-timestamp="1761444096" data-date="Oct 25, 2025" data-time="9:01 PM" data-short="Oct '25" title="sample-title" itemprop="datePublished">Sample text</time>
+				</a>
+			</li>
+			
+		</ul>
+
+		<ul class="message-attribution-opposite message-attribution-opposite--list ">
+			
+			
+			
+			
+			<li>
+				<a href="https://forum.example.test/threads/SYNTH9970/SYNTH8810" class="message-attribution-gadget" data-xf-init="share-tooltip" data-href="/posts/100018/share" aria-label="sample-aria-label" rel="nofollow" id="js-XFUniqueId108">
+					<i class="fa--xf far fa-share-alt "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i>
+				</a>
+			</li>
+			
+				<li class="u-hidden js-embedCopy">
+					
+	<a href="javascript:" data-xf-init="copy-to-clipboard" data-copy-text="sample-copy-text" data-success="Embed code HTML copied to clipboard." class="">
+		<i class="fa--xf far fa-code "><svg xmlns="https://other.example.test/2000/svg" role="img" aria-hidden="true"><use href="https://forum.example.test/data/ID12/ID13/SYNTH8989?v=SYNTH_V"></svg></i>
+	</a>
+
+				</li>
+			
+			
+				<li>
+					
+						
+
+	
+		<a href="https://forum.example.test/posts/ID52xxx/ID17xxx" class="bookmarkLink message-attribution-gadget bookmarkLink--highlightable " title="sample-title" data-xf-click="bookmark-click" data-label=".js-bookmarkText" data-sk-bookmarked="addClass:is-bookmarked, titleAttr:sync" data-sk-bookmarkremoved="removeClass:is-bookmarked, titleAttr:sync"><span class="js-bookmarkText u-srOnly">Sample text</span></a>
+	
+
+					
+				</li>
+			
+			
+				<li>
+					<a href="https://forum.example.test/threads/SYNTH9970/SYNTH8810" rel="nofollow">
+						Sample text
+					</a>
+				</li>
+			
+		</ul>
+	</header>
+
+							
+
+							<div class="message-content js-messageContent">
+							
+
+								
+									
+	
+
+	
+
+	
+	
+
+								
+
+								
+									
+	
+
+	<div class="message-userContent lbContainer js-lbContainer " data-lb-id="post-100018" data-lb-caption-desc="sample-lb-caption-desc">
+
+		
+
+		<article class="message-body js-selectToQuote">
+			
+				
+			
+
+			<div itemprop="text">
+				
+					<div class="bbWrapper">Sample text<br>
+<a href="https://filehost.example.test/f/SYNTH2811" target="_blank" class="link link--external" rel="noopener">Sample text</a><br>
+Sample text<br>
+<a href="https://filehost.example.test/f/SYNTH5621" target="_blank" class="link link--external" rel="noopener">Sample text</a></div>
+				
+			</div>
+
+			<div class="js-selectToQuoteEnd"> </div>
+			
+				
+			
+		</article>
+
+		
+
+		
+	</div>
+
+								
+
+								
+									
+	
+
+	
+
+								
+
+								
+									
+	
+
+								
+
+							
+							</div>
+
+							
+								
+	
+
+	<footer class="message-footer">
+		
+			<div class="message-microdata" itemprop="interactionStatistic" itemtype="https://schema.org/SYNTH6663" itemscope="">
+				<meta itemprop="userInteractionCount" content="https://forum.example.test/threads/SYNTH9970/ID55">
+				<meta itemprop="interactionType" content="https://other.example.test/SYNTH8758">
+			</div>
+		
+
+		
+			<div class="message-actionBar actionBar">
+				
+					
+	
+		<div class="actionBar-set actionBar-set--external">
+		
+			<a href="https://forum.example.test/posts/ID52xxx/ID21?reaction_id=SYNTH_REACTION_ID" class="reaction reaction--small actionBar-action actionBar-action--reaction reaction--imageHidden reaction--1" data-reaction-id="1" data-xf-init="reaction" data-reaction-list="< .js-post | .js-reactionsList" id="js-XFUniqueId65"><i aria-hidden="true"></i><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///SYNTH2102" loading="lazy" class="reaction-sprite js-reaction" alt="sample-alt" title="sample-title"> <span class="reaction-text js-reactionText"><bdi>Sample text</bdi></span></a>
+
+			
+				
+
+				
+					<a href="https://forum.example.test/threads/SYNTH9970/ID22?quote=SYNTH_QUOTE" class="actionBar-action actionBar-action--mq u-jsOnly js-multiQuote" title="sample-title" rel="nofollow" data-message-id="100018" data-mq-action="add">Sample text</a>
+				
+
+				<a href="https://forum.example.test/threads/SYNTH9970/ID22?quote=SYNTH_QUOTE" class="actionBar-action actionBar-action--reply" title="sample-title" rel="nofollow" data-xf-click="quote" data-quote-href="/posts/100018/quote">Sample text</a>
+			
+
+		
+		</div>
+	
+
+	
+		<div class="actionBar-set actionBar-set--internal">
+		
+			
+
+			
+				<a href="https://forum.example.test/posts/ID52xxx/ID23x" class="actionBar-action actionBar-action--report" data-xf-click="overlay" data-cache="false">Sample text</a>
+			
+
+			
+			
+			
+			
+			
+			
+			
+			
+
+			
+		
+		</div>
+	
+
+				
+			</div>
+		
+
+		<div class="reactionsBar js-reactionsList is-active">
+			
+	
+	
+		<ul class="reactionSummary">
+		
+			<li><span class="reaction reaction--small reaction--1" data-reaction-id="1"><i aria-hidden="true"></i><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///SYNTH2102" loading="lazy" class="reaction-sprite js-reaction" alt="sample-alt" title="sample-title"></span></li><li><span class="reaction reaction--small reaction--86" data-reaction-id="86"><i aria-hidden="true"></i><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///SYNTH2102" loading="lazy" class="reaction-sprite js-reaction" alt="sample-alt" title="sample-title"></span></li><li><span class="reaction reaction--small reaction--48" data-reaction-id="48"><i aria-hidden="true"></i><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///SYNTH2102" loading="lazy" class="reaction-sprite js-reaction" alt="sample-alt" title="sample-title"></span></li>
+		
+		</ul>
+	
+
+
+<span class="u-srOnly">Sample text</span>
+<a class="reactionsBar-link" href="https://forum.example.test/posts/ID52xxx/SYNTH7494" data-xf-click="overlay" data-cache="false" rel="nofollow"><bdi>Sample text</bdi>Sample text <bdi>Sample text</bdi>Sample text <bdi>Sample text</bdi> Sample text</a>
+		</div>
+
+		<div class="js-historyTarget message-historyTarget toggleTarget" data-href="trigger-href"></div>
+	</footer>
+
+							
+						</div>
+
+					
+					</div>
+				
+			</div>
+		
+	</article>
+
+<!-- CASE E: XenForo native attachment lightbox (data-type="image").
+     Images only on this page - included so a rule can be shown not to match. -->
+<article class="message message--post js-post" id="js-post-100005">
+  <div class="message-inner"><div class="message-cell message-cell--main">
+  <div class="message-main js-quickEditTarget"><div class="message-content js-messageContent">
+  <div class="message-userContent lbContainer js-lbContainer">
+  <article class="message-body js-selectToQuote">
+<div class="bbWrapper"><div class="bbImageWrapper  js-lbImage" title="sample-title" data-src="https://other.example.test/ID56/ID57/ID58/ID59xxx/sample-file.jpg" data-type="image" data-lb-sidebar-href="" data-lb-caption-extra-html="" data-single-image="1" data-fancybox="lb-thread-90001" style="cursor: pointer;" data-caption="sample-caption">
+		<img src="https://other.example.test/ID56/ID57/ID58/ID59xxx/sample-file.jpg" data-url="https://other.example.test/ID56/ID57/ID58/ID59xxx/sample-file.jpg" class="bbImage" data-zoom-target="1" style="" alt="sample-alt" title="sample-title" width="854" height="1280" loading="lazy">
+	</div><div class="bbImageWrapper  js-lbImage" title="sample-title" data-src="https://other.example.test/ID56/ID57/ID58/ID59xxx/sample-file.jpg" data-type="image" data-lb-sidebar-href="" data-lb-caption-extra-html="" data-single-image="1" data-fancybox="lb-thread-90001" style="cursor: pointer;" data-caption="sample-caption">
+		<img src="https://other.example.test/ID56/ID57/ID58/ID59xxx/sample-file.jpg" data-url="https://other.example.test/ID56/ID57/ID58/ID59xxx/sample-file.jpg" class="bbImage" data-zoom-target="1" style="" alt="sample-alt" title="sample-title" width="854" height="1280" loading="lazy">
+	</div><div class="bbImageWrapper  js-lbImage" title="sample-title" data-src="https://other.example.test/ID56/ID57/ID58/ID59xxx/sample-file.jpg" data-type="image" data-lb-sidebar-href="" data-lb-caption-extra-html="" data-single-image="1" data-fancybox="lb-thread-90001" style="cursor: pointer;" data-caption="sample-caption">
+		<img src="https://other.example.test/ID56/ID57/ID58/ID59xxx/sample-file.jpg" data-url="https://other.example.test/ID56/ID57/ID58/ID59xxx/sample-file.jpg" class="bbImage" data-zoom-target="1" style="" alt="sample-alt" title="sample-title" width="854" height="1280" loading="lazy">
+	</div></div>
+  </article></div></div></div></div></div>
+</article>
+
+</div></div></div>
+</div></div></div></div></div>
+</body></html>

--- a/scripts/dl-router/tests/picker_overlay.test.mjs
+++ b/scripts/dl-router/tests/picker_overlay.test.mjs
@@ -195,7 +195,13 @@ test("the manifest delivers the overlay through the EXISTING content script", ()
     new URL("../extension/manifest.json", import.meta.url), "utf8"));
   const [cs] = manifest.content_scripts;
   assert.deepEqual(cs.matches, ["http://*/*", "https://*/*"]);
-  assert.deepEqual(cs.js, ["content_capture.js", "picker_overlay.js"]);
+  // ORDER IS LOAD-BEARING, not cosmetic: the files in one declaration run in
+  // this order in one isolated world, and player_buttons.js reuses
+  // content_capture.js's extractor through `globalThis.__DLR_CAPTURE__` rather
+  // than restating it. Put content_capture.js second and the page-context
+  // responder answers `{ok:false, error:"no_capture"}` on the first click.
+  assert.deepEqual(cs.js,
+    ["content_capture.js", "picker_overlay.js", "player_buttons.js"]);
   assert.deepEqual(manifest.permissions.slice().sort(),
     ["alarms", "contextMenus", "downloads", "notifications", "storage", "tabs"]);
   // Framing an extension page from a web page needs it web-accessible.

--- a/scripts/dl-router/tests/player_buttons.test.mjs
+++ b/scripts/dl-router/tests/player_buttons.test.mjs
@@ -1,0 +1,525 @@
+// Per-player download buttons, driven over the two COMMITTED fixtures through
+// the same in-test DOM the capture extractors use.
+//
+// player_buttons.js is a CLASSIC content script (it cannot be an ES module in
+// MV3), so it is evaluated here with `globalThis`, `chrome` and `document`
+// shadowed by parameters and DL_ROUTER_NO_AUTOSTART set. content_capture.js is
+// evaluated into the SAME fake global first, because that is exactly how the
+// two share an isolated world in the browser -- player_buttons.js reuses its
+// `rulesForHost`/`extractContext` rather than restating them, and a test that
+// loaded them separately would not be testing that.
+//
+// The fixtures are sanitised captures of the real structure: every host is
+// *.example.test, every id/name/title is synthetic.
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { playerDomFromHTML, domFromHTML } from "./fake_dom.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const read = (...p) => fs.readFileSync(path.join(here, ...p), "utf8");
+
+const EMBED_HTML = read("fixtures", "embed-player-frame.html");
+const FORUM_HTML = read("fixtures", "forum-thread-page.html");
+
+const fakeGlobal = { DL_ROUTER_NO_AUTOSTART: true };
+for (const file of ["content_capture.js", "player_buttons.js"]) {
+  // eslint-disable-next-line no-new-func
+  new Function("globalThis", "chrome", "document",
+    read("..", "extension", file))(fakeGlobal, undefined, undefined);
+}
+const P = fakeGlobal.__DLR_PLAYER__;
+const CAP = fakeGlobal.__DLR_CAPTURE__;
+
+const EMBED_HOST = "embedhost.example.test";
+const FORUM_HOST = "forum.example.test";
+const EMBED_URL = `https://${EMBED_HOST}/embed/SYNTH8563`;
+const FORUM_URL = `https://${FORUM_HOST}/threads/sample-thread.90001/page-6`;
+
+// The two-layer rule table, exactly as it would appear in config.toml.
+const RULES = {
+  [FORUM_HOST]: {
+    context: { subject: ["h1.p-title-value"] },
+  },
+  [EMBED_HOST]: {
+    player: {
+      container: "#video-container",
+      mount: "#video-wrapper",
+      media: { element: "video#main-video", attr: "src" },
+    },
+  },
+};
+
+function embedDom() {
+  return playerDomFromHTML(EMBED_HTML, { url: EMBED_URL });
+}
+
+/** A `deps` that records what the frame asked the worker for. */
+function fakeDeps({ have = { ok: true, have: false }, download = { ok: true },
+  pageUrl = EMBED_URL, fail = false } = {}) {
+  const sent = [];
+  return {
+    sent,
+    of: (type) => sent.filter((m) => m.type === type),
+    pageUrl: () => pageUrl,
+    send: (msg) => {
+      sent.push(msg);
+      if (fail) return Promise.reject(new Error("no worker"));
+      if (msg.type === "dlr:have") return Promise.resolve(have);
+      return Promise.resolve(download);
+    },
+  };
+}
+
+const rule = () => P.playerRuleFor(RULES, EMBED_HOST);
+
+test("the content script exposes its pure functions and starts nothing", () => {
+  assert.ok(P);
+  for (const fn of ["isSupportedSelector", "normalisePlayerRule",
+    "playerRuleFor", "readMediaUrl", "mountButton", "handleClick", "applyHave",
+    "scan", "docAdapter", "pageContext", "isTopFrame"]) {
+    assert.equal(typeof P[fn], "function", fn);
+  }
+});
+
+// --- layer 1: the PLAYER rule, keyed on the EMBED host ---------------------- //
+test("the player rule resolves against the embed host, from the fixture", () => {
+  const r = rule();
+  assert.ok(r, "the embed host must have a player rule");
+  assert.equal(r.container, "#video-container");
+  assert.equal(r.mount, "#video-wrapper");
+  assert.deepEqual(r.media, { element: "video#main-video", attr: "src" });
+  // Every selector must actually resolve in the real captured structure --
+  // otherwise the rule is only asserting itself.
+  const dom = embedDom();
+  assert.equal(dom.queryAll(r.container).length, 1);
+  const container = dom.queryAll(r.container)[0];
+  assert.equal(dom.queryAll(r.mount, container).length, 1);
+  assert.equal(dom.queryAll(r.media.element, container).length, 1);
+});
+
+test("THE PLAYER RULE IS NOT KEYED ON THE FORUM: the forum host has none", () => {
+  // The forum's embed wrapper is host-agnostic, so a player rule keyed there
+  // would match embeds from hosts we have no accessor for -- and would be
+  // running in the wrong document to read anything anyway.
+  assert.equal(P.playerRuleFor(RULES, FORUM_HOST), null);
+});
+
+test("an embed host with NO player rule renders no button at all", () => {
+  const dom = embedDom();
+  const before = JSON.stringify(dom.root.children.length);
+  const mounted = new Map();
+  const deps = fakeDeps();
+  const got = P.scan(dom, P.playerRuleFor(RULES, "unknown-host.example.test"),
+    deps, mounted);
+  assert.deepEqual(got, []);
+  assert.equal(mounted.size, 0);
+  assert.equal(deps.sent.length, 0, "and nothing is asked of the worker");
+  assert.equal(JSON.stringify(dom.root.children.length), before);
+});
+
+test("the top frame CANNOT reach a player: the forum DOM has no container", () => {
+  // This is the whole reason the player rule lives in the embed frame. The
+  // fixture's players are cross-origin iframes; from the forum document there
+  // is no #video-container and no <video> anywhere.
+  const dom = playerDomFromHTML(FORUM_HTML, { url: FORUM_URL });
+  const r = rule();
+  assert.equal(dom.queryAll(r.container).length, 0);
+  assert.equal(dom.queryAll("video").length, 0);
+  const frames = dom.queryAll("iframe");
+  assert.ok(frames.length >= 3, `expected several embeds, got ${frames.length}`);
+  for (const f of frames) {
+    assert.equal(f.getAttribute("loading"), "lazy",
+      "the fixture's players are lazy -- an off-screen frame has no document");
+  }
+  assert.deepEqual(P.scan(dom, r, fakeDeps(), new Map()), []);
+});
+
+// --- layer 2: the CONTEXT rule, keyed on the PAGE host ---------------------- //
+test("the context rule resolves the subject from the forum fixture", () => {
+  const entry = CAP.rulesForHost(RULES, FORUM_HOST);
+  const sel = CAP.contextSelectors(entry);
+  assert.deepEqual(sel.subject, ["h1.p-title-value"]);
+  const dom = domFromHTML(FORUM_HTML, { url: FORUM_URL });
+  const tags = CAP.extractSiteRules(dom, entry);
+  assert.ok(tags.length, "the context selector must resolve in the fixture");
+  assert.match(tags[0], /Subject Name/);
+});
+
+test("the explicit .context sub-table WINS over the flat legacy form", () => {
+  // Both forms have to work: every existing config uses the flat one, and the
+  // sub-table is what makes the two layers legible in the same table.
+  const entry = { subject: [".legacy"], context: { subject: [".explicit"] } };
+  assert.deepEqual(CAP.contextSelectors(entry).subject, [".explicit"]);
+  assert.deepEqual(CAP.contextSelectors({ subject: [".legacy"] }).subject,
+    [".legacy"]);
+});
+
+test("a context rule with junk selectors degrades to no tags, never a throw", () => {
+  const dom = domFromHTML(FORUM_HTML, { url: FORUM_URL });
+  assert.deepEqual(
+    CAP.extractSiteRules(dom, { context: { subject: [42, null], tags: "no" } }),
+    []);
+});
+
+test("pageContext answers with the TOP frame's own url and site", () => {
+  const doc = domFromHTML(FORUM_HTML, { url: FORUM_URL });
+  // `pageContext` builds its own adapter through CAP.domAdapter, so it is
+  // handed a document-shaped object with querySelectorAll + title.
+  const res = P.pageContext(
+    { querySelectorAll: doc.querySelectorAll, title: doc.title,
+      location: { href: FORUM_URL } },
+    { location: { href: FORUM_URL } }, RULES);
+  assert.equal(res.ok, true);
+  assert.equal(res.context.pageUrl, FORUM_URL);
+  assert.equal(res.context.site, FORUM_HOST);
+  assert.ok(res.context.tags.some((t) => /Subject Name/.test(t)),
+    "the context rule's subject must be in the tags it reports");
+});
+
+test("pageContext refuses rather than guesses when the extractor is absent", () => {
+  const saved = fakeGlobal.__DLR_CAPTURE__;
+  try {
+    fakeGlobal.__DLR_CAPTURE__ = undefined;
+    assert.deepEqual(P.pageContext({}, { location: { href: FORUM_URL } }, {}),
+      { ok: false, error: "no_capture" });
+  } finally {
+    fakeGlobal.__DLR_CAPTURE__ = saved;
+  }
+});
+
+// --- the media URL is read AT CLICK TIME ------------------------------------ //
+test("readMediaUrl reads the signed src out of the fixture", () => {
+  const dom = embedDom();
+  const container = dom.queryAll("#video-container")[0];
+  const url = P.readMediaUrl(dom, rule(), container);
+  assert.match(url, /^https:\/\/cdn\.example\.test\/.+\?exp=\d+&token=/);
+});
+
+test("A ROTATED URL IS USED, A STALE ONE IS NEVER SENT", async () => {
+  // The single most important behaviour here. The embed page re-signs the
+  // media URL in place on the SAME element, ~60s before a ~2h expiry. A button
+  // that captured the URL when it was drawn would send a dead link.
+  const dom = embedDom();
+  const deps = fakeDeps();
+  const [handle] = P.scan(dom, rule(), deps, new Map());
+  const video = dom.queryAll("video#main-video")[0];
+  const stale = video.getAttribute("src");
+  assert.ok(stale);
+
+  const fresh = "https://cdn.example.test/media/data/sample-file.mp4"
+    + "?exp=1999999999&token=ROTATED_TOKEN&fn=sample-file.mp4";
+  video.setAttribute("src", fresh);
+
+  await P.handleClick(dom, handle, deps);
+  const [msg] = deps.of("dlr:player-download");
+  assert.ok(msg, "the click must reach the worker");
+  assert.equal(msg.mediaUrl, fresh);
+  for (const sent of deps.sent) {
+    assert.notEqual(sent.mediaUrl, stale,
+      "the pre-rotation URL must never appear in anything sent");
+  }
+
+  // AND IT IS NOT CACHED AFTER THE FIRST READ EITHER. One read at click time
+  // looks identical to a memoised one until the second click, which on a page
+  // left open for a couple of hours is the one that matters.
+  const later = fresh.replace("ROTATED_TOKEN", "ROTATED_AGAIN");
+  video.setAttribute("src", later);
+  await P.handleClick(dom, handle, deps);
+  assert.deepEqual(deps.of("dlr:player-download").map((m) => m.mediaUrl),
+    [fresh, later]);
+});
+
+test("the click carries the STABLE embed page url, not the signed media url", () => {
+  const dom = embedDom();
+  const deps = fakeDeps();
+  const [handle] = P.scan(dom, rule(), deps, new Map());
+  return P.handleClick(dom, handle, deps).then(() => {
+    const [msg] = deps.of("dlr:player-download");
+    assert.equal(msg.embedUrl, EMBED_URL);
+    assert.notEqual(msg.embedUrl, msg.mediaUrl);
+  });
+});
+
+test("clicking through the button element sends the same message", async () => {
+  const dom = embedDom();
+  const deps = fakeDeps();
+  const [handle] = P.scan(dom, rule(), deps, new Map());
+  handle.button.fire("click");
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(deps.of("dlr:player-download").length, 1);
+});
+
+test("a player whose frame has not assigned a src yet says so, and sends nothing",
+  async () => {
+    // `loading="lazy"` + `preload="none"`: the container can exist before the
+    // media URL does. The button must render, survive, and resolve lazily --
+    // never fire a download with an empty URL, never silently do nothing.
+    const dom = embedDom();
+    const video = dom.queryAll("video#main-video")[0];
+    video.attrs.src = "";
+    const deps = fakeDeps();
+    const [handle] = P.scan(dom, rule(), deps, new Map());
+    assert.ok(handle, "the button still renders over an unloaded player");
+    const res = await P.handleClick(dom, handle, deps);
+    assert.deepEqual(res, { ok: false, error: "no_media_url" });
+    assert.deepEqual(deps.of("dlr:player-download"), []);
+    assert.match(handle.button.textContent, /No media yet/);
+
+    // ...and it resolves once the frame assigns one, with no remount.
+    video.setAttribute("src", "https://cdn.example.test/media/x.mp4?exp=1&token=T");
+    await P.handleClick(dom, handle, deps);
+    assert.equal(deps.of("dlr:player-download").length, 1);
+  });
+
+test("a non-http media value is treated as no URL at all", () => {
+  const dom = embedDom();
+  dom.queryAll("video#main-video")[0].setAttribute("src", "blob:abcd-1234");
+  assert.equal(P.readMediaUrl(dom, rule(), dom.queryAll("#video-container")[0]),
+    "");
+});
+
+test("readMediaUrl falls back to the same-named PROPERTY", () => {
+  // A host that only exposes `currentSrc` -- which is not an attribute at all.
+  const dom = embedDom();
+  const video = dom.queryAll("video#main-video")[0];
+  video.attrs.src = "";
+  video.src = "https://cdn.example.test/media/prop.mp4?exp=1&token=T";
+  assert.equal(P.readMediaUrl(dom, rule(), dom.queryAll("#video-container")[0]),
+    video.src);
+});
+
+test("the click reports a refusal from the worker instead of claiming success",
+  async () => {
+    const dom = embedDom();
+    const deps = fakeDeps({ download: { ok: false, error: "nope" } });
+    const [handle] = P.scan(dom, rule(), deps, new Map());
+    const res = await P.handleClick(dom, handle, deps);
+    assert.equal(res.ok, false);
+    assert.match(handle.button.textContent, /Failed/);
+  });
+
+test("a worker that is not there does not wedge the button", async () => {
+  const dom = embedDom();
+  const deps = fakeDeps({ fail: true });
+  const [handle] = P.scan(dom, rule(), deps, new Map());
+  const res = await P.handleClick(dom, handle, deps);
+  assert.deepEqual(res, { ok: false, error: "send_failed" });
+  assert.equal(handle.button.disabled, false, "and it is clickable again");
+});
+
+// --- mounting --------------------------------------------------------------- //
+test("the widget mounts inside the rule's mount point, in a CLOSED shadow root",
+  () => {
+    const dom = embedDom();
+    const [handle] = P.scan(dom, rule(), fakeDeps(), new Map());
+    const wrapper = dom.queryAll("#video-wrapper")[0];
+    assert.equal(handle.host.parentElement, wrapper);
+    assert.equal(handle.host.shadowRoot.mode, "closed");
+    assert.equal(handle.button.textContent, "Save to library");
+  });
+
+test("with no mount selector the widget lands on the container itself", () => {
+  const dom = embedDom();
+  const r = { ...rule(), mount: "" };
+  const [handle] = P.scan(dom, r, fakeDeps(), new Map());
+  assert.equal(handle.host.parentElement,
+    dom.queryAll("#video-container")[0]);
+});
+
+test("a mount selector that does not resolve falls back to the container", () => {
+  const dom = embedDom();
+  const r = { ...rule(), mount: "#nothing-here" };
+  const [handle] = P.scan(dom, r, fakeDeps(), new Map());
+  assert.equal(handle.host.parentElement,
+    dom.queryAll("#video-container")[0]);
+});
+
+test("scanning twice does not stack two buttons on one player", () => {
+  const dom = embedDom();
+  const mounted = new Map();
+  const deps = fakeDeps();
+  assert.equal(P.scan(dom, rule(), deps, mounted).length, 1);
+  assert.equal(P.scan(dom, rule(), deps, mounted).length, 0);
+  assert.equal(deps.of("dlr:have").length, 1, "and the ledger is asked once");
+});
+
+test("A CONTAINER THAT APPEARS AFTER LOAD IS PICKED UP BY A LATER SCAN", () => {
+  // The players are `loading="lazy"` and the embed page builds its own DOM, so
+  // the container routinely does not exist when the content script first runs.
+  // This is what the mutation observer drives.
+  const dom = embedDom();
+  const container = dom.queryAll("#video-container")[0];
+  const parent = container.parentElement;
+  container.remove();
+  const mounted = new Map();
+  const deps = fakeDeps();
+  assert.deepEqual(P.scan(dom, rule(), deps, mounted), [],
+    "nothing to mount before the player exists");
+
+  parent.appendChild(container);
+  const [handle] = P.scan(dom, rule(), deps, mounted);
+  assert.ok(handle, "the late container gets its button");
+  assert.equal(handle.host.isConnected, true);
+});
+
+test("a page that rips the widget out gets it back on the next scan", () => {
+  const dom = embedDom();
+  const mounted = new Map();
+  const deps = fakeDeps();
+  const [first] = P.scan(dom, rule(), deps, mounted);
+  first.host.remove();
+  const [second] = P.scan(dom, rule(), deps, mounted);
+  assert.ok(second, "a framework re-render must not cost the button forever");
+  assert.notEqual(second.host, first.host);
+});
+
+// --- the "already have this" badge ------------------------------------------ //
+test("BADGE HIT: the ledger answer is asked by the EMBED URL and shown", () => {
+  const dom = embedDom();
+  const deps = fakeDeps({ have: { ok: true, have: true, dir: "Jane Doe" } });
+  const [handle] = P.scan(dom, rule(), deps, new Map());
+  const [ask] = deps.of("dlr:have");
+  assert.equal(ask.embedUrl, EMBED_URL,
+    "keyed on the stable embed url -- a signed media url would never hit");
+  return Promise.resolve().then(() => {
+    assert.ok(handle.badge, "a hit must be visible");
+    assert.match(handle.badge.textContent, /In library: Jane Doe/);
+  });
+});
+
+test("BADGE MISS: no record renders nothing at all", async () => {
+  const dom = embedDom();
+  const deps = fakeDeps({ have: { ok: true, have: false } });
+  const [handle] = P.scan(dom, rule(), deps, new Map());
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(handle.badge, null);
+  assert.equal(handle.row.children.length, 1, "the button, and only the button");
+});
+
+test("a ledger that cannot answer produces no badge, not a broken one", async () => {
+  const dom = embedDom();
+  const deps = fakeDeps({ have: { ok: false, have: false } });
+  const [handle] = P.scan(dom, rule(), deps, new Map());
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(handle.badge, null);
+});
+
+test("applyHave is idempotent -- two answers do not stack two badges", () => {
+  const dom = embedDom();
+  const [handle] = P.scan(dom, rule(), fakeDeps(), new Map());
+  const hit = { ok: true, have: true, dir: "Jane Doe" };
+  assert.equal(P.applyHave(dom, handle, hit), true);
+  assert.equal(P.applyHave(dom, handle, hit), false);
+  assert.equal(handle.row.children.length, 2);
+});
+
+// --- config is DATA, never code --------------------------------------------- //
+test("a player rule carrying code-shaped fields keeps only the known ones", () => {
+  // The whole point of a declarative rule table: there is no path here that can
+  // evaluate a string, so a hostile or careless config cannot get code into a
+  // content script running on every page.
+  const r = P.normalisePlayerRule({
+    player: {
+      container: "#c",
+      media: { element: "video", attr: "src", getter: "() => 1" },
+      js: "alert(1)",
+      onclick: "alert(1)",
+      code: "fetch('//x')",
+      label: "Save",
+    },
+  });
+  assert.deepEqual(Object.keys(r).sort(),
+    ["container", "label", "media", "mount"]);
+  assert.deepEqual(Object.keys(r.media).sort(), ["attr", "element"]);
+});
+
+test("the media accessor must be an attribute NAME, not an expression", () => {
+  const base = { container: "#c" };
+  for (const attr of ["src()", "a.b", "0src", "", " src", "sr c", "__proto__"]) {
+    assert.equal(
+      P.normalisePlayerRule({ player: { ...base, media: { element: "video", attr } } }),
+      null, `attr ${JSON.stringify(attr)} must be refused`);
+  }
+  assert.ok(P.normalisePlayerRule(
+    { player: { ...base, media: { element: "video", attr: "data-src" } } }));
+});
+
+test("selectors are held to the subset the test DOM can parse", () => {
+  // A richer selector would work in Brave and silently have no test, which is
+  // how the two drift. Refusing it here is what keeps the suite honest.
+  for (const bad of ["div:has(video)", "div > video", ".a:not(.b)", "a + b",
+    "a ~ b", "video::shadow"]) {
+    assert.equal(P.isSupportedSelector(bad), false, bad);
+  }
+  for (const good of ["#video-container", "video#main-video", ".plyr__video",
+    'a[data-plyr="download"]', '[href^="https://x"]', "div.a .b, .c"]) {
+    assert.equal(P.isSupportedSelector(good), true, good);
+  }
+});
+
+test("an incomplete player rule yields NO rule, and therefore no button", () => {
+  for (const raw of [
+    null, {}, { player: {} }, { player: { container: "#c" } },
+    { player: { container: "#c", media: {} } },
+    { player: { container: "#c", media: { element: "video" } } },
+    { player: { container: "div > x", media: { element: "v", attr: "src" } } },
+    { player: { container: "#c", media: { element: "v:has(x)", attr: "src" } } },
+    { player: "not-a-table" },
+  ]) {
+    assert.equal(P.normalisePlayerRule(raw), null, JSON.stringify(raw));
+  }
+});
+
+test("a rule's label is bounded, and defaults", () => {
+  const media = { element: "video", attr: "src" };
+  assert.equal(
+    P.normalisePlayerRule({ player: { container: "#c", media } }).label,
+    "Save to library");
+  assert.equal(P.normalisePlayerRule(
+    { player: { container: "#c", media, label: "x".repeat(41) } }).label,
+    "Save to library");
+  assert.equal(P.normalisePlayerRule(
+    { player: { container: "#c", media, label: "Grab" } }).label, "Grab");
+});
+
+// --- fixture hygiene -------------------------------------------------------- //
+test("THE COMMITTED FIXTURES NAME NO REAL SITE", () => {
+  // This repo is public. The forum, the embed host and the CDN must exist only
+  // as *.example.test in anything committed; the real names live in the
+  // operator's own config.toml and nowhere else.
+  for (const [name, html] of [["embed", EMBED_HTML], ["forum", FORUM_HTML]]) {
+    const hosts = [...html.matchAll(/https?:\/\/([a-z0-9.-]+)/gi)]
+      .map((m) => m[1].toLowerCase());
+    assert.ok(hosts.length, `${name} fixture has no URLs to check`);
+    for (const host of new Set(hosts)) {
+      assert.ok(/(^|\.)(example\.test|schema\.org)$/.test(host),
+        `${name} fixture references a real-looking host: ${host}`);
+    }
+  }
+});
+
+test("prefers-reduced-motion is respected by the widget's own stylesheet", () => {
+  const src = read("..", "extension", "player_buttons.js");
+  assert.match(src, /@media \(prefers-reduced-motion: reduce\)/);
+});
+
+test("the media URL is read in the click path and NOWHERE on the render path",
+  () => {
+    // A structural pin for the rotation rule above: if a future change caches
+    // the URL at mount time this fails even if the click test is adjusted.
+    const src = read("..", "extension", "player_buttons.js");
+    const build = src.slice(src.indexOf("function build("),
+      src.indexOf("function setLabel("));
+    const mount = src.slice(src.indexOf("function mountButton("),
+      src.indexOf("function isConnected("));
+    for (const [name, body] of [["build", build], ["mountButton", mount]]) {
+      assert.ok(!/readMediaUrl\s*\(/.test(body),
+        `${name} must not read the media URL -- it would be stale by click time`);
+    }
+    assert.match(src.slice(src.indexOf("function handleClick(")),
+      /var url = readMediaUrl\(/);
+  });

--- a/scripts/dl-router/tests/service_worker.test.mjs
+++ b/scripts/dl-router/tests/service_worker.test.mjs
@@ -9,6 +9,7 @@
 // DL_ROUTER_NO_AUTOSTART so importing it here does nothing on its own.
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 globalThis.DL_ROUTER_NO_AUTOSTART = true;
 
@@ -36,19 +37,34 @@ let overlayOpenResult = { ok: true };
 let overlayReports = "ready";       // "ready" | "ready-late" | "silent"
 let tabsUpdateFails = false;
 
+// --- the player-button path -------------------------------------------------- //
+// What the TOP frame answers when the worker asks it to describe itself. `null`
+// reproduces "there is no content script in the top frame", which is the
+// correlation failure the picker degradation depends on.
+let pageContextResult = null;
+let pageContextThrows = false;
+
+// chrome.storage STRUCTURED-CLONES on the way in and on the way out. Storing
+// the reference instead was a real fidelity bug in this mock: a live object
+// mutated after being "persisted" appeared to have been persisted with the
+// mutation, so `state.pending`'s dedupe latch tested as durable while the
+// production code had not written it. Clone, or the persistence tests lie.
+const clone = (v) => (v === undefined ? undefined
+  : JSON.parse(JSON.stringify(v)));
+
 globalThis.chrome = {
   storage: {
     local: {
       get: async (keys) => {
         const out = {};
-        for (const k of [].concat(keys)) out[k] = storageLocal[k];
+        for (const k of [].concat(keys)) out[k] = clone(storageLocal[k]);
         return out;
       },
-      set: async (obj) => Object.assign(storageLocal, obj),
+      set: async (obj) => Object.assign(storageLocal, clone(obj)),
     },
     session: {
-      get: async (k) => ({ [k]: storageSession[k] }),
-      set: async (obj) => Object.assign(storageSession, obj),
+      get: async (k) => ({ [k]: clone(storageSession[k]) }),
+      set: async (obj) => Object.assign(storageSession, clone(obj)),
     },
     onChanged: { addListener() {} },
   },
@@ -103,6 +119,13 @@ globalThis.chrome = {
     },
     sendMessage: async (id, msg, opts) => {
       calls.tabMessages.push({ id, msg, opts });
+      if (msg && msg.type === "dlr:page-context") {
+        if (pageContextThrows) {
+          throw new Error("Could not establish connection. "
+            + "Receiving end does not exist.");
+        }
+        return pageContextResult;
+      }
       if (msg && msg.type === "dlr:overlay-open") {
         if (contentScriptMissing) {
           throw new Error("Could not establish connection. "
@@ -177,6 +200,8 @@ function reset({ enabled = true, snapshot = SNAPSHOT } = {}) {
   overlayOpenResult = { ok: true };
   overlayReports = "ready";
   tabsUpdateFails = false;
+  pageContextResult = null;
+  pageContextThrows = false;
   SW.state.overlays.clear();
   SW.state.config = { port: 8791, token: "tok", enabled };
   SW.state.configLoaded = true;
@@ -2220,3 +2245,446 @@ test("confirmDuplicate without an entry still answers (the latch is optional)",
     assert.equal(await SW.confirmDuplicate(207, "Jane Doe/f.mp4", "Jane Doe"),
       null);
   });
+
+// --- the player-button path -------------------------------------------------- //
+//
+// A click on an injected button inside a CROSS-ORIGIN embed frame. The frame
+// has the media URL and nothing else; the top frame has the subject and cannot
+// see the media; only the worker can reach both.
+const EMBED_URL = "https://embedhost.example.test/embed/SYNTH8563";
+const MEDIA_URL = "https://cdn.example.test/media/data/f.mp4"
+  + "?exp=1900000000&token=SIGNED_A&fn=f.mp4";
+const FORUM_URL = "https://forum.example.test/threads/jane-doe-set.90001/page-6";
+
+/** What the top frame reports when a context rule matched. */
+function topContext(overrides = {}) {
+  return {
+    ok: true,
+    context: {
+      href: "", mediaSrc: "", linkText: "", alt: "",
+      pageUrl: FORUM_URL,
+      pageTitle: "Jane Doe | Example Forums",
+      site: "forum.example.test",
+      tags: ["Jane Doe"],
+      og: {},
+      ...overrides,
+    },
+  };
+}
+
+/** The frame sending `dlr:player-download`; `frameId > 0` -- a subframe. */
+const embedSender = (tabId = 7) => ({ tab: { id: tabId }, frameId: 4 });
+
+test("a player click downloads the URL read at click time", async () => {
+  reset();
+  pageContextResult = topContext();
+  const res = await SW.playerDownload(
+    { mediaUrl: MEDIA_URL, embedUrl: EMBED_URL }, embedSender());
+  assert.equal(res.ok, true);
+  assert.equal(res.context, true);
+  assert.deepEqual(calls.downloads, [{ url: MEDIA_URL }]);
+});
+
+test("frame -> top-frame correlation asks FRAME 0 OF THE SAME TAB", async () => {
+  // The only proof available: `document.referrer` inside the embed is the forum
+  // ORIGIN with the path stripped, and ancestorOrigins carries no paths either.
+  reset();
+  pageContextResult = topContext();
+  await SW.playerDownload({ mediaUrl: MEDIA_URL, embedUrl: EMBED_URL },
+    embedSender(11));
+  const ask = calls.tabMessages.find((m) => m.msg.type === "dlr:page-context");
+  assert.ok(ask, "the worker must ask the top frame");
+  assert.equal(ask.id, 11, "the tab the click came from");
+  assert.deepEqual(ask.opts, { frameId: 0 }, "the TOP frame, never any other");
+});
+
+test("a correlated click carries the thread's subject into /match", async () => {
+  reset();
+  pageContextResult = topContext();
+  const posted = [];
+  fetchHandler = async (url, opts) => {
+    if (url.endsWith("/match")) {
+      posted.push(JSON.parse(opts.body));
+      return { ok: true, status: 200,
+        json: async () => ({ dir: "Jane Doe", confidence: 1, auto: true,
+          reason: "alias(thread-slug)" }) };
+    }
+    return { ok: true, status: 200, json: async () => ({}) };
+  };
+  await SW.playerDownload({ mediaUrl: MEDIA_URL, embedUrl: EMBED_URL },
+    embedSender());
+  // Now Chrome dispatches the download the click started.
+  SW.onDeterminingFilename({ id: 401, url: MEDIA_URL, filename: "f.mp4" },
+    () => {});
+  await settle(5);
+  assert.equal(posted.length, 1);
+  const p = posted[0];
+  // Tier 1 bound the synthesised capture to the DownloadItem by exact URL --
+  // no time window, no active-tab guess.
+  assert.equal(p.page.url, FORUM_URL);
+  assert.deepEqual(p.page.tags, ["Jane Doe"]);
+  assert.equal(p.page.site, "forum.example.test");
+});
+
+test("THE LEDGER KEY IS THE EMBED URL, NOT THE SIGNED MEDIA URL", async () => {
+  // The media URL is re-signed in place roughly hourly. Keyed on it, the ledger
+  // would mint a new row per rotation and the badge would never light.
+  reset();
+  pageContextResult = topContext();
+  const posted = [];
+  fetchHandler = async (url, opts) => {
+    if (url.endsWith("/match")) posted.push(JSON.parse(opts.body));
+    return { ok: true, status: 200,
+      json: async () => ({ dir: "Jane Doe", confidence: 1, auto: true }) };
+  };
+  await SW.playerDownload({ mediaUrl: MEDIA_URL, embedUrl: `${EMBED_URL}?autoplay=1#t=3` },
+    embedSender());
+  SW.onDeterminingFilename({ id: 402, url: MEDIA_URL, filename: "f.mp4" },
+    () => {});
+  await settle(5);
+  assert.equal(posted[0].sourceKey, EMBED_URL,
+    "normalised to scheme+host+path: playback params are not an identity");
+  assert.notEqual(posted[0].sourceKey, MEDIA_URL);
+});
+
+test("CORRELATION FAILURE DEGRADES TO THE PICKER, never to a wrong subject",
+  async () => {
+    // The top frame has no content script (a CSP-sandboxed host, a page still
+    // loading, a tab that navigated). The tempting fallback -- the newest
+    // capture from this tab -- is the branch carryReferrer already deleted for
+    // learning "the last thread I saw" as a 1.00 alias.
+    reset();
+    pageContextThrows = true;
+    // A capture from a DIFFERENT thread, live in the same tab. If any fallback
+    // existed, this is the wrong subject it would import.
+    SW.state.captures = [{
+      href: "https://forum.example.test/other", mediaSrc: "",
+      pageUrl: "https://forum.example.test/threads/someone-else.777/",
+      pageTitle: "Someone Else", site: "forum.example.test",
+      tags: ["Someone Else"], og: {}, tabId: 7, ts: Date.now(),
+    }];
+    const posted = [];
+    fetchHandler = async (url, opts) => {
+      if (url.endsWith("/match")) {
+        posted.push(JSON.parse(opts.body));
+        return { ok: true, status: 200,
+          json: async () => ({ dir: "other", confidence: 0.1, auto: false,
+            reason: "no match" }) };
+      }
+      return { ok: true, status: 200, json: async () => ({}) };
+    };
+    const res = await SW.playerDownload(
+      { mediaUrl: MEDIA_URL, embedUrl: EMBED_URL }, embedSender());
+    assert.equal(res.ok, true);
+    assert.equal(res.context, false, "the worker must admit it proved nothing");
+
+    SW.onDeterminingFilename({ id: 403, url: MEDIA_URL, filename: "f.mp4" },
+      () => {});
+    await settle(5);
+    assert.equal(posted.length, 1);
+    assert.equal(posted[0].page.url, "", "no page URL was proven");
+    assert.deepEqual(posted[0].page.tags, [], "and no subject was invented");
+    assert.equal(posted[0].page.title, "");
+    for (const value of Object.values(posted[0].page)) {
+      assert.notEqual(value, "Someone Else");
+    }
+    // ...and the user is asked.
+    const picker = calls.windowsCreate.find((w) => /picker\.html/.test(w.url));
+    assert.ok(picker, "an unproven subject must reach the picker");
+  });
+
+test("a top frame that answers without a usable page URL counts as a failure",
+  async () => {
+    reset();
+    pageContextResult = topContext({ pageUrl: "about:blank" });
+    const res = await SW.playerDownload(
+      { mediaUrl: MEDIA_URL, embedUrl: EMBED_URL }, embedSender());
+    assert.equal(res.context, false);
+    assert.equal(SW.state.captures[0].tags.length, 0);
+  });
+
+test("a non-http media URL is refused before any download starts", async () => {
+  reset();
+  pageContextResult = topContext();
+  for (const bad of ["blob:abcd", "javascript:alert(1)", "", null,
+    "file:///etc/passwd"]) {
+    const res = await SW.playerDownload(
+      { mediaUrl: bad, embedUrl: EMBED_URL }, embedSender());
+    assert.equal(res.ok, false, JSON.stringify(bad));
+  }
+  assert.deepEqual(calls.downloads, []);
+});
+
+test("a player click in a profile where routing is off does nothing", async () => {
+  reset({ enabled: false });
+  const res = await SW.playerDownload(
+    { mediaUrl: MEDIA_URL, embedUrl: EMBED_URL }, embedSender());
+  assert.equal(res.ok, false);
+  assert.deepEqual(calls.downloads, []);
+});
+
+test("a message with no tab cannot start a download", async () => {
+  reset();
+  const res = await SW.playerDownload(
+    { mediaUrl: MEDIA_URL, embedUrl: EMBED_URL }, { frameId: 4 });
+  assert.equal(res.ok, false);
+  assert.deepEqual(calls.downloads, []);
+});
+
+test("dlr:player-download is routed, and answers asynchronously", async () => {
+  reset();
+  pageContextResult = topContext();
+  let answer = null;
+  const ret = SW.onMessage({ type: "dlr:player-download", mediaUrl: MEDIA_URL,
+    embedUrl: EMBED_URL }, embedSender(), (r) => { answer = r; });
+  assert.equal(ret, true, "the channel must stay open for the late response");
+  await settle(5);
+  assert.equal(answer.ok, true);
+});
+
+// --- the "already have this" badge ------------------------------------------- //
+test("dlr:have asks the ledger by the NORMALISED embed url", async () => {
+  reset();
+  fetchHandler = async () => ({ ok: true, status: 200,
+    json: async () => ({ ok: true, have: true, dir: "Jane Doe" }) });
+  const res = await SW.haveUrl(`${EMBED_URL}?autoplay=1`);
+  assert.deepEqual(res, { ok: true, have: true, dir: "Jane Doe" });
+  assert.equal(calls.fetches[0].url,
+    `http://127.0.0.1:8791/have?url=${encodeURIComponent(EMBED_URL)}`);
+});
+
+test("a ledger miss is a miss, and a dead sidecar is also a miss", async () => {
+  reset();
+  fetchHandler = async () => ({ ok: true, status: 200,
+    json: async () => ({ ok: true, have: false }) });
+  assert.deepEqual(await SW.haveUrl(EMBED_URL), { ok: true, have: false,
+    dir: "" });
+  fetchHandler = async () => { throw new Error("connection refused"); };
+  // A badge is a hint on someone else's page: a sidecar that is down must
+  // produce NO badge, never a broken one.
+  assert.deepEqual(await SW.haveUrl(EMBED_URL), { ok: false, have: false });
+});
+
+test("an unusable embed url is not asked about at all", async () => {
+  reset();
+  for (const bad of ["", "blob:x", "about:blank", null]) {
+    assert.deepEqual(await SW.haveUrl(bad), { ok: false, have: false });
+  }
+  assert.deepEqual(calls.fetches, []);
+});
+
+test("dlr:have is routed and answers asynchronously", async () => {
+  reset();
+  fetchHandler = async () => ({ ok: true, status: 200,
+    json: async () => ({ ok: true, have: true, dir: "Jane Doe" }) });
+  let answer = null;
+  const ret = SW.onMessage({ type: "dlr:have", embedUrl: EMBED_URL },
+    embedSender(), (r) => { answer = r; });
+  assert.equal(ret, true);
+  await settle(5);
+  assert.equal(answer.have, true);
+});
+
+// --- state.pending SURVIVES THE ~30s MV3 IDLE TEARDOWN ----------------------- //
+//
+// Every test below simulates the teardown the same way Chrome does it: the
+// module globals go, `chrome.storage.local` stays. `state.pending.clear()` is
+// therefore not a shortcut -- it IS the teardown.
+function teardown() {
+  SW.state.pending.clear();
+  SW.state.overlays.clear();
+  SW.state.captures = [];
+}
+
+test("A DOWNLOAD THAT OUTLIVES THE TEARDOWN KEEPS ITS TOAST", async () => {
+  // The bug: `pending` was an in-memory Map and `onDownloadChanged` returns
+  // early without an entry -- so a download taking longer than half a minute
+  // lost its toast, its pending relocate AND its learning. Silently, and for
+  // essentially every video.
+  reset();
+  SW.state.snapshot.root = LIB_ROOT;
+  const suggest = spy();
+  fetchHandler = async () => ({ ok: true, status: 200,
+    json: async () => ({ dir: "Jane Doe", confidence: 1, auto: true,
+      reason: "alias" }) });
+  SW.onDeterminingFilename({ id: 501, url: MEDIA_URL, filename: "f.mp4" },
+    suggest);
+  await settle(5);
+  assert.ok(SW.state.pending.has(501));
+  assert.ok(Array.isArray(storageLocal.pending),
+    "the routing decision must be written durably, not only to memory");
+
+  teardown();
+  searchResult = [{ id: 501, state: "complete",
+    filename: `${LIB_ROOT}/Jane Doe/f.mp4` }];
+  fetchHandler = async () => ({ ok: true, status: 200,
+    json: async () => ({ ok: true, duplicate: false }) });
+  await SW.onDownloadChanged({ id: 501, state: { current: "complete" } });
+  assert.ok(SW.state.pending.has(501),
+    "the woken worker must find the entry it wrote before the teardown");
+});
+
+test("A CORRECTION MADE BEFORE THE TEARDOWN IS STILL APPLIED AFTER IT",
+  async () => {
+    // The picker is a separate window the user can leave open past the idle
+    // timeout -- choosing is the slowest thing they do here -- so this is the
+    // normal case, not an edge one.
+    reset();
+    SW.state.snapshot.root = LIB_ROOT;
+    SW.state.pending.set(502, { dir: "other", filename: "f.mp4",
+      payload: { page: {} }, ts: Date.now() });
+    searchResult = [];   // still downloading: the choice is deferred
+    const out = await SW.applyChoice(502, "Jane Doe", {});
+    assert.deepEqual(out, { ok: true, dir: "Jane Doe", deferred: true });
+
+    teardown();
+    searchResult = [{ id: 502, state: "complete",
+      filename: `${LIB_ROOT}/other/f.mp4` }];
+    const posted = [];
+    fetchHandler = async (url, opts) => {
+      posted.push({ url, body: opts.body ? JSON.parse(opts.body) : null });
+      return { ok: true, status: 200,
+        json: async () => ({ ok: true, relPath: "Jane Doe/f.mp4" }) };
+    };
+    await SW.onDownloadChanged({ id: 502, state: { current: "complete" } });
+    const moved = posted.find((p) => p.url.endsWith("/relocate"));
+    assert.ok(moved, "the pick must survive the teardown and be applied");
+    assert.equal(moved.body.toDir, "Jane Doe");
+    assert.ok(posted.some((p) => p.url.endsWith("/learn")),
+      "and it must still be learned from");
+  });
+
+test("the dedupe latch survives the teardown too", async () => {
+  // Persisting the entry without persisting its latch would open a SECOND
+  // focused, never-auto-closing duplicate toast for one download.
+  reset();
+  SW.state.snapshot.root = LIB_ROOT;
+  // Routed through the real path, so the entry is genuinely durable -- setting
+  // `state.pending` by hand would leave nothing in storage and the second delta
+  // would find no entry at all, which passes for the wrong reason.
+  fetchHandler = async () => ({ ok: true, status: 200,
+    json: async () => ({ dir: "Jane Doe", confidence: 1, auto: true }) });
+  SW.onDeterminingFilename({ id: 503, url: MEDIA_URL, filename: "f.mp4" },
+    () => {});
+  await settle(5);
+  assert.ok(storageLocal.pending.some((r) => r[0] === 503));
+
+  searchResult = [{ id: 503, state: "complete",
+    filename: `${LIB_ROOT}/Jane Doe/f.mp4` }];
+  const posted = [];
+  fetchHandler = dedupeResponder({
+    ok: true, duplicate: true, relPath: "Jane Doe/f.mp4",
+    dupRelPath: "john-smith/x.mov", kind: "size+hash" },
+  { onPost: (url) => posted.push(url) });
+  await SW.onDownloadChanged({ id: 503, state: { current: "complete" } });
+  teardown();
+  await SW.onDownloadChanged({ id: 503, state: { current: "complete" } });
+  assert.equal(posted.filter((u) => u.endsWith("/dedupe")).length, 1,
+    "the duplicate check ran twice for one download");
+  const dupToasts = calls.windowsCreate.filter((w) => /mode=dup/.test(w.url));
+  assert.equal(dupToasts.length, 1, "two duplicate toasts for one download");
+});
+
+test("the restored registry is TTL- and size-bounded", async () => {
+  // `storage.local` outlives the browser, so without these an abandoned
+  // download would be resurrected weeks later, and the registry would grow
+  // without limit.
+  reset();
+  const day = 24 * 60 * 60 * 1000;
+  storageLocal.pending = [
+    [601, { dir: "Jane Doe", ts: Date.now() }],
+    [602, { dir: "Jane Doe", ts: Date.now() - day - 1000 }],
+    ["not-a-pair"],
+    [603, null],
+    [{ bad: "key" }, { dir: "x", ts: Date.now() }],
+  ];
+  await SW.restorePending();
+  assert.deepEqual([...SW.state.pending.keys()], [601]);
+
+  reset();
+  for (let i = 0; i < 100; i += 1) {
+    SW.state.pending.set(700 + i, { dir: "Jane Doe", ts: Date.now() });
+  }
+  await SW.applyChoice(700, "Jane Doe", {});
+  assert.ok(storageLocal.pending.length <= 64,
+    `stored ${storageLocal.pending.length} entries`);
+});
+
+test("restorePending NEVER clobbers an entry created this turn", async () => {
+  reset();
+  storageLocal.pending = [[801, { dir: "stale", ts: Date.now() }]];
+  SW.state.pending.set(801, { dir: "fresh", ts: Date.now() });
+  await SW.restorePending();
+  assert.equal(SW.state.pending.get(801).dir, "fresh");
+});
+
+test("the five-minute sweep clears the DURABLE copy, not just the memory one",
+  async () => {
+    // Otherwise the entry would be gone from memory and immediately restored
+    // from storage by the next `pendingEntry`, and nothing would ever expire.
+    reset();
+    SW.state.pending.set(802, { dir: "Jane Doe", payload: { page: {} },
+      ts: Date.now() });
+    searchResult = [{ id: 802, state: "complete",
+      filename: `${LIB_ROOT}/Jane Doe/f.mp4` }];
+    fetchHandler = async () => ({ ok: true, status: 200,
+      json: async () => ({ ok: true, duplicate: false }) });
+    const realSetTimeout = globalThis.setTimeout;
+    let sweep = null;
+    globalThis.setTimeout = (fn, ms) => {
+      if (ms === 5 * 60 * 1000) { sweep = fn; return { unref() {} }; }
+      return realSetTimeout(fn, ms);
+    };
+    try {
+      await SW.onDownloadChanged({ id: 802, state: { current: "complete" } });
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+    }
+    assert.ok(sweep, "a sweep must be armed for a completed download");
+    assert.ok(storageLocal.pending.some((r) => r[0] === 802));
+    sweep();
+    await settle(0);
+    assert.ok(!SW.state.pending.has(802));
+    assert.ok(!storageLocal.pending.some((r) => r[0] === 802),
+      "the durable copy would otherwise resurrect it on the next read");
+  });
+
+test("an entry past its TTL is dropped on WRITE, not only on read", async () => {
+  reset();
+  SW.state.pending.set(804, { dir: "Jane Doe",
+    ts: Date.now() - 25 * 60 * 60 * 1000 });
+  SW.state.pending.set(805, { dir: "Jane Doe", ts: Date.now() });
+  await SW.applyChoice(805, "Jane Doe", {});
+  assert.deepEqual(storageLocal.pending.map((r) => r[0]), [805]);
+});
+
+test("a routing decision no longer re-reads the config on every download",
+  async () => {
+    // `pending` now lives in chrome.storage.local alongside the token, so an
+    // unfiltered storage.onChanged handler would call loadConfig() on every
+    // single download event.
+    reset();
+    const src = readFileSync(
+      new URL("../extension/service_worker.js", import.meta.url), "utf8");
+    const handler = src.slice(src.indexOf("chrome.storage.onChanged"));
+    assert.match(handler.slice(0, 600), /"token" in changes/);
+    assert.match(handler.slice(0, 600), /"enabled" in changes/);
+  });
+
+test("after a teardown the picker still goes to the DOWNLOAD's tab", async () => {
+  // `overlayTabId` reads `pending`, so before the durable read it sent every
+  // post-teardown picker to a popup window (or worse, the wrong tab) --
+  // precisely when a picker is most likely to be needed, because the user was
+  // slow enough to trigger the teardown in the first place.
+  reset();
+  contentScriptMissing = false;
+  tabUrl = "https://forum.example.test/threads/jane-doe.1/";
+  SW.state.pending.set(901, { dir: "other", filename: "f.mp4", tabId: 42,
+    payload: { page: {} }, ts: Date.now() });
+  await SW.applyChoice(901, "other", {}).catch(() => {});
+  teardown();
+  await SW.openPicker({ downloadId: 901, dir: "other", reason: "" });
+  const open = calls.tabMessages.find((m) => m.msg.type === "dlr:overlay-open");
+  assert.ok(open, "the overlay must still be offered");
+  assert.equal(open.id, 42, "in the tab the download came from");
+});

--- a/scripts/dl-router/tests/test_config.py
+++ b/scripts/dl-router/tests/test_config.py
@@ -225,3 +225,93 @@ def test_load_degraded_is_a_no_op_for_a_valid_config(tmp_path):
     cfg, err = config_mod.load_degraded(path, env={})
     assert err is None
     assert str(cfg.library_root) == "/tmp/lib"
+
+
+# --- the two-layer site-rule table ------------------------------------------ #
+#
+# Structural validation only: types and required fields. The SELECTOR GRAMMAR is
+# enforced where it is consumed (player_buttons.normalisePlayerRule), which
+# fails closed to "no button" so a bad selector costs one player rather than
+# the whole sidecar. A wrong SHAPE is different -- it is a typo that would
+# otherwise produce a rule the extension silently discards with nothing
+# anywhere saying why.
+
+PLAYER = {"container": "#video-container",
+          "media": {"element": "video#main-video", "attr": "src"}}
+
+
+def _load(tmp_path, rules):
+    p = tmp_path / "config.toml"
+    body = ["library_root = \"/tmp/lib\""]
+    for host, entry in rules.items():
+        body.append(f"[site_rules.\"{host}\"]")
+        body.append(_toml(entry, f"site_rules.\"{host}\""))
+    p.write_text("\n".join(body), encoding="utf-8")
+    return config_mod.load(p)
+
+
+def _toml(entry, prefix):
+    """Just enough TOML emitter for these cases."""
+    lines, tables = [], []
+    for k, v in entry.items():
+        if isinstance(v, dict):
+            tables.append((k, v))
+        elif isinstance(v, list):
+            lines.append(f"{k} = [" + ", ".join(f'"{s}"' for s in v) + "]")
+        else:
+            lines.append(f'{k} = "{v}"')
+    for k, v in tables:
+        lines.append(f"[{prefix}.{k}]")
+        lines.append(_toml(v, f"{prefix}.{k}"))
+    return "\n".join(lines)
+
+
+def test_a_valid_two_layer_rule_table_loads(tmp_path):
+    cfg = _load(tmp_path, {
+        "forum.example.test": {"context": {"subject": ["h1.thread-title"]}},
+        "embedhost.example.test": {"player": PLAYER},
+    })
+    rules = cfg.section("site_rules")
+    assert rules["forum.example.test"]["context"]["subject"] == [
+        "h1.thread-title"]
+    assert rules["embedhost.example.test"]["player"]["media"]["attr"] == "src"
+
+
+def test_the_flat_legacy_context_form_still_loads(tmp_path):
+    cfg = _load(tmp_path, {"example-site.test": {"subject": ["a.performer"],
+                                                 "tags": [".tag-list a"]}})
+    assert cfg.section("site_rules")["example-site.test"]["tags"] == [
+        ".tag-list a"]
+
+
+@pytest.mark.parametrize("entry,needle", [
+    ({"player": {"media": PLAYER["media"]}}, "container is required"),
+    ({"player": {"container": "#c"}}, "player.media must be a table"),
+    ({"player": {"container": "#c", "media": {"element": "v"}}},
+     "media.attr must be a non-empty string"),
+    ({"player": {"container": "#c", "media": {"element": "", "attr": "src"}}},
+     "media.element must be a non-empty string"),
+    ({"subject": "a.one"}, "subject must be a list of selector strings"),
+    ({"context": {"tags": "a.one"}}, "tags must be a list of selector strings"),
+])
+def test_a_malformed_rule_is_reported_rather_than_silently_dropped(
+        tmp_path, entry, needle):
+    with pytest.raises(config_mod.ConfigError) as exc:
+        _load(tmp_path, {"embedhost.example.test": entry})
+    assert needle in str(exc.value)
+
+
+def test_a_malformed_rule_degrades_the_sidecar_instead_of_crash_looping(
+        tmp_path):
+    """The unit is Restart=always, so a raise on load is a silent restart loop.
+
+    `load_degraded` is what makes the typo visible in /healthz and
+    `dl-route status` instead.
+    """
+    p = tmp_path / "config.toml"
+    p.write_text('library_root = "/tmp/lib"\n'
+                 '[site_rules."h.test".player]\ncontainer = "#c"\n',
+                 encoding="utf-8")
+    cfg, err = config_mod.load_degraded(p)
+    assert err and "player.media must be a table" in err
+    assert cfg.library_root is None, "and nothing is routed by accident"

--- a/scripts/dl-router/tests/test_server.py
+++ b/scripts/dl-router/tests/test_server.py
@@ -1051,3 +1051,102 @@ def test_the_dirs_entries_are_untouched_by_the_counts(app, library):
     snap = app.dirs_snapshot()
     for entry in snap["dirs"]:
         assert set(entry) == {"name", "key", "tokens", "kind"}
+
+
+# --- the source-URL ledger's key for an EMBEDDED PLAYER --------------------- #
+#
+# An embedded player streams from a SIGNED url (`?exp=...&token=...`) that the
+# embed page re-signs in place roughly hourly. `source_url_key` deliberately
+# keeps the query string, so keying the ledger on the media url would mint a
+# fresh row on every rotation and the "already have this" badge would never
+# light -- which reads to the user as "you do not have this", the one answer
+# worse than no badge at all.
+
+MEDIA_URL = ("https://cdn.example.test/media/data/f.mp4"
+             "?exp=1900000000&token=SIGNED_A&fn=f.mp4")
+EMBED_URL = "https://embedhost.example.test/embed/SYNTH8563"
+
+
+def _quote(url):
+    from urllib.parse import quote
+    return quote(url, safe="")
+
+
+def test_sourceKey_is_what_the_ledger_records_not_the_signed_media_url(live):
+    call(live, "POST", "/match",
+         {"downloadId": 92, "filename": "f.mp4", "url": MEDIA_URL,
+          "sourceKey": EMBED_URL,
+          "page": {"url": "https://forum.example.test/threads/jane-doe.1/"}})
+    _, out, _ = call(live, "GET", f"/have?url={_quote(EMBED_URL)}")
+    assert out["have"] is True, "the stable embed url must answer the badge"
+    _, out, _ = call(live, "GET", f"/have?url={_quote(MEDIA_URL)}")
+    assert out["have"] is False, (
+        "the signed url must NOT be the key -- it rotates, so it would answer "
+        "'no' for the rest of time")
+
+
+def test_a_re_signed_media_url_still_answers_the_badge(live):
+    """The failure the key exists to prevent, played out."""
+    rotated = MEDIA_URL.replace("SIGNED_A", "SIGNED_B").replace(
+        "exp=1900000000", "exp=1900007200")
+    call(live, "POST", "/match",
+         {"downloadId": 93, "filename": "f.mp4", "url": MEDIA_URL,
+          "sourceKey": EMBED_URL, "page": {}})
+    # An hour later the same player is streaming from a different URL...
+    call(live, "POST", "/match",
+         {"downloadId": 94, "filename": "f.mp4", "url": rotated,
+          "sourceKey": EMBED_URL, "page": {}})
+    _, out, _ = call(live, "GET", f"/have?url={_quote(EMBED_URL)}")
+    assert out["have"] is True
+    assert out["hits"] == 2, "both rotations are ONE asset in the ledger"
+
+
+def test_an_unusable_sourceKey_falls_back_to_the_url_rather_than_writing_nothing(
+        live):
+    # Truthiness is not the test: a non-empty but unusable key would otherwise
+    # silently drop the ledger row the ordinary URL would have produced.
+    call(live, "POST", "/match",
+         {"downloadId": 95, "filename": "f.mp4", "url": MEDIA_URL,
+          "sourceKey": "blob:not-a-url", "page": {}})
+    _, out, _ = call(live, "GET", f"/have?url={_quote(MEDIA_URL)}")
+    assert out["have"] is True
+
+
+def test_no_sourceKey_keeps_the_pre_existing_behaviour(live):
+    url = "https://example-site.test/v/77"
+    call(live, "POST", "/match",
+         {"downloadId": 96, "filename": "clip.mp4", "url": url, "page": {}})
+    _, out, _ = call(live, "GET", f"/have?url={_quote(url)}")
+    assert out["have"] is True
+
+
+def test_sourceKey_is_a_ledger_key_only_and_never_routing_evidence(app):
+    """A caller-supplied string must not become a subject.
+
+    The whole mislearning family this subsystem has already paid for came from
+    treating an unproven string as identity evidence.
+    """
+    thread = "https://forum.example.test/threads/aster-vale-new-set.42/"
+    plain = app.match({"downloadId": 97, "filename": "f.mp4",
+                       "url": MEDIA_URL, "page": {}})
+    keyed = app.match({"downloadId": 98, "filename": "f.mp4",
+                       "url": MEDIA_URL, "sourceKey": thread, "page": {}})
+    assert plain["dir"] == keyed["dir"]
+    assert plain["confidence"] == keyed["confidence"]
+
+
+def test_the_dirs_snapshot_carries_the_player_layer_to_the_extension(app, cfg):
+    """Adding a player is a CONFIG edit, never an extension change."""
+    cfg.data["site_rules"] = {
+        "forum.example.test": {"context": {"subject": ["h1.thread-title"]}},
+        "embedhost.example.test": {"player": {
+            "container": "#video-container",
+            "mount": "#video-wrapper",
+            "media": {"element": "video#main-video", "attr": "src"}}},
+    }
+    snap = app.dirs_snapshot()
+    rules = snap["siteRules"]
+    assert rules["forum.example.test"]["context"]["subject"] == [
+        "h1.thread-title"]
+    player = rules["embedhost.example.test"]["player"]
+    assert player["media"] == {"element": "video#main-video", "attr": "src"}


### PR DESCRIPTION
## Summary

Adds per-player download buttons to embedded video players. Every video on the forums this routes for is a cross-origin iframe (OOPIF) pointing at an embed host — the forum content script cannot reach the `<video>` element. This PR adds a two-layer rule table so buttons render inside the embed frame where the media URL actually lives.

### What changed

**New: `player_buttons.js`** — a content script that runs inside embed iframes, reads the media URL **at click time** (signed URLs rotate in place), and injects a "Save to library" button. The click routes through the ordinary pipeline: a capture is synthesised for the tab and the URL is handed to `/match`.

**Two-layer rule table:**
- **Context rule** on the PAGE host (forum) — `subject` selectors for the thread title
- **Player rule** on the EMBED host — `container`, `media` accessor, `mount` point

Config is data, never code: only four fields are read, each type- and grammar-checked. A rule carrying `js`/`onclick`/`code` gets the same treatment as a typo: ignored.

**New: `state.pending` dedupe latch** — when a player button is clicked, the embed URL is written to `chrome.storage.local` immediately (before the download completes), so a second click on the same player shows "In library" rather than starting a duplicate.

**New: "already have this" badge** — if the source URL ledger already has a record for this embed URL, the button renders as "In library" on mount.

### Test coverage

- **989 pytest** (Python sidecar, config, server, matcher, backfill, security)
- **508 node** (extension: player_buttons, service_worker, picker_overlay, toast, route_core, sanitize)

New test files:
- `player_buttons.test.mjs` — 30+ cases: rule resolution, media URL reading (rotation detection), click handling, widget mounting (shadow root), badge logic, config validation (code injection prevention, selector validation, label bounds), accessibility
- `fixtures/embed-player-frame.html` — sanitised Plyr embed structure
- `fixtures/forum-thread-page.html` — sanitised XenForo thread with embedded players
- `test_config.py` additions — site_rules round-trip, two-layer rule table, legacy form
- `test_server.py` additions — source key ledger, badge behavior, player layer in `/dirs`
- `service_worker.test.mjs` additions — player click download path, frame correlation, correlation failure degradation

Every new pin was verified by deleting the code it covers and confirming a named, relevant test fails (mutation-tested, 32 mutations run one at a time).

### Known limitations

- Player rules must be configured per embed host in `~/.config/dl-router/config.toml` — no built-in rules ship (public repo constraint)
- The media URL is read at click time, not cached — this is by design (signed URLs rotate)
- Only HTML5 video players with accessible `<video>` elements are supported; JS-only players that never expose a src get no button

### Config example

```toml
[site_rules."simpcity.cr".context]
subject = [".p-title-value"]

[site_rules."turbo.cr".player]
container = ".plyr"
media = { element = "#main-video", attr = "src" }
mount = ".video-wrapper"
label = "Save to library"
```