### PR TITLE
fix(browser-bridge): session id from the POSIX session, not $PPID — it drifted across a command substitution

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -1237,11 +1237,24 @@ per-session (multi-step **workflow**) isolation did not.
   `/cmd`, derived (in order) from `CLAUDE_CODE_SESSION_ID` (Claude Code's own
   session UUID — identical across every Bash-tool call in a session, verified on
   the 2.1.x CLI) → `CLAUDE_SESSION_ID` (defensive alternate) → `$TMUX_PANE` (each
-  session runs in its own tmux pane) → a random token cached under the shell's
-  PPID (the Claude Code process, stable across a session's calls). It is used for
+  session runs in its own tmux pane) → the **POSIX session id**
+  (`sid:<sid>:<leader-starttime>` from `/proc/self/stat`) → (procfs-less systems
+  only) a random token cached under the shell's PPID. It is used for
   **routing only** and is **never** trusted for auth — bearer + Host still gate
   every request. If two sessions ever resolve the same id they share a tab
   (documented degradation — no worse than before).
+- **⚠ Why the POSIX session id, and not `$PPID` (fixed 2026-08-01).** The
+  PPID-keyed token was **not stable across a command substitution**: a `$( … )`
+  that forks gives `browser` a different parent pid, so
+  `T=$(browser open … | …)` registered tab ownership under one id and the
+  following `browser --tab "$T" emulate` presented another → `not_owned_tab`.
+  Measured over ssh on the workbench (`CLAUDE_CODE_SESSION_ID` unset there, so
+  the fallback actually ran). A subshell cannot leave its POSIX session — only
+  `setsid(2)` can — so the session id is stable across subshells while still
+  differing between two ssh logins, two tmux panes and two systemd units, which
+  is what keeps per-session tab isolation intact. The `<leader-starttime>`
+  suffix defuses pid reuse. See
+  `reference/tabs-instances.md` → "The subshell hazard".
 - **⚠ Sibling subagents share identity (known limitation).** Per-session
   isolation covers concurrent **top-level** sessions, NOT sibling subagents of
   one parent. Empirically (dumped from inside two parallel subagents) a subagent

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -234,7 +234,12 @@ die() { echo "browser: $*" >&2; exit 1; }
 #   2. CLAUDE_SESSION_ID — defensive alternate spelling, in case a CLI build
 #      renames the var.
 #   3. $TMUX_PANE — the user runs each session in its own tmux pane, so the pane
-#      id is a good per-session proxy when no Claude var is exported.
+#      id is a good per-session proxy when no Claude var is exported. NOTE this
+#      step is COSMETIC, not structural: MEASURED 2026-08-01, each pane gets its
+#      own pty AND its own POSIX session (%0 sess=2982021 tty=pts/8, %1
+#      sess=2982024 tty=pts/9), so step 4 alone would already isolate panes.
+#      Kept because it is cheaper and more legible — do not "simplify" it away
+#      under the belief that removing it would break pane isolation.
 #   4. the POSIX SESSION id (`sid:<sid>:<leader-starttime>`), read from
 #      /proc/self/stat. See _session_from_proc below for why this — and NOT the
 #      PPID — is the right process-tree signal.
@@ -246,8 +251,13 @@ die() { echo "browser: $*" >&2; exit 1; }
 # and `browser --tab "$T" emulate` presented another → `not_owned_tab`. Measured
 # over ssh 2026-08-01; invisible wherever CLAUDE_CODE_SESSION_ID is set. Full
 # account: reference/tabs-instances.md → "The subshell hazard".
-# DEGRADATION: if two drivers ever resolve the SAME id they SHARE a tab — no
-# worse than the pre-fix behaviour. This is NOT hypothetical for one case:
+# DEGRADATION: if two drivers ever resolve the SAME id they SHARE a tab. This is
+# a TRADE, not a strict improvement (measured): two drivers with DIFFERENT
+# parents inside ONE POSIX session were distinct under the old ppid key and now
+# collide (sid:2983316:8395877 twice, vs ppid:2983326 / ppid:2983316) — reachable
+# only with all three env sources unset. In the commoner shape the new code is
+# better: three setsid'd runs from one shell were ONE id under the old key and
+# are three now. It is NOT hypothetical for one case:
 # **sibling subagents of one parent share identity.** Empirically (dumped from
 # inside two parallel subagents) a subagent inherits the PARENT's
 # CLAUDE_CODE_SESSION_ID *and* runs in the same $TMUX_PANE, and the harness
@@ -281,7 +291,12 @@ _session_from_proc() {
   [ $# -ge 4 ] || return 1
   sid="$4"
   case "$sid" in ''|0|*[!0-9]*) return 1 ;; esac
-  st="x"                                   # leader already gone → sid alone
+  # `x` = the session leader has already exited, so no starttime is available
+  # and the id degrades to `sid:<sid>:x` — the pid-reuse guard is OFF for that
+  # session. Recorded, not acted on: an orphaned session that then collides with
+  # a recycled sid is far-fetched, and server-side ownership self-releases on the
+  # 900s idle TTL anyway.
+  st="x"
   if [ -r "${procfs}/${sid}/stat" ] && IFS= read -r line < "${procfs}/${sid}/stat"; then
     rest="${line##*\) }"
     set -- $rest

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -20,7 +20,7 @@
 #   Two Claude sessions driving one browser used to interleave on ONE shared
 #   active tab. Now each session can `open` its OWN tab; the server records the
 #   ownership under a stable per-session id (X-Session-Id header, derived from
-#   CLAUDE_CODE_SESSION_ID → $TMUX_PANE → a per-process-tree token — see
+#   CLAUDE_CODE_SESSION_ID → $TMUX_PANE → the POSIX session id — see
 #   derive_session_id below) and routes that session's html/eval/nav/screenshot/
 #   close to ITS tab. A session that never `open`ed falls back to the active tab
 #   (the one-shot read path — inherently safe). `--tab <id>` overrides the target
@@ -235,9 +235,17 @@ die() { echo "browser: $*" >&2; exit 1; }
 #      renames the var.
 #   3. $TMUX_PANE — the user runs each session in its own tmux pane, so the pane
 #      id is a good per-session proxy when no Claude var is exported.
-#   4. a random token cached under the controlling process tree (keyed by the
-#      shell's PPID = the Claude Code process managing the Bash tool, stable
-#      across a session's calls), persisted so repeated calls read the same id.
+#   4. the POSIX SESSION id (`sid:<sid>:<leader-starttime>`), read from
+#      /proc/self/stat. See _session_from_proc below for why this — and NOT the
+#      PPID — is the right process-tree signal.
+#   5. LAST RESORT (no procfs): a random token cached under
+#      $XDG_RUNTIME_DIR/browser-bridge, keyed by PPID. Kept only as a
+#      non-Linux safety net — it is NOT stable across a subshell.
+# 🔴 Step 4 used to BE the PPID-keyed token, and that DRIFTS across a `$( … )`
+# that forks — so `T=$(browser open … | …)` registered ownership under one id
+# and `browser --tab "$T" emulate` presented another → `not_owned_tab`. Measured
+# over ssh 2026-08-01; invisible wherever CLAUDE_CODE_SESSION_ID is set. Full
+# account: reference/tabs-instances.md → "The subshell hazard".
 # DEGRADATION: if two drivers ever resolve the SAME id they SHARE a tab — no
 # worse than the pre-fix behaviour. This is NOT hypothetical for one case:
 # **sibling subagents of one parent share identity.** Empirically (dumped from
@@ -249,10 +257,46 @@ die() { echo "browser: $*" >&2; exit 1; }
 # drivers that may share a session id should each `open` and then pass the
 # returned `--tab <id>` explicitly on every subsequent op — an explicit --tab
 # overrides owned-tab routing entirely, so they never collide. See SKILL.md.
+
+# _session_from_proc — `sid:<session-id>:<leader-starttime>` from procfs, or
+# non-zero if procfs is unreadable. WHY the POSIX session id and not $PPID/$$:
+# setsid(2) is the ONLY way to leave a session, so every subshell/pipeline
+# stage/command substitution of one shell reports the same sid (stable — $PPID
+# is not), while sshd, tmux (per pane), a terminal, a systemd unit and cron all
+# setsid, so genuinely distinct sessions still get distinct ids (isolation is
+# preserved). `<leader-starttime>` (stat field 22, ticks since boot) defuses PID
+# REUSE — a recycled sid cannot inherit a dead session's tab.
+# Parsing: comm (field 2) is parenthesised and may contain spaces, so cut
+# through the LAST ") " first; after the cut fields are 1=state 2=ppid 3=pgrp
+# 4=session … 20=starttime (the 1-based stat index minus 2).
+# BROWSER_BRIDGE_PROC is a TEST seam (point it at a nonexistent path to exercise
+# the last-resort branch), not an operator knob.
+_session_from_proc() {
+  local procfs="${BROWSER_BRIDGE_PROC:-/proc}"
+  local line rest sid st
+  [ -r "${procfs}/self/stat" ] || return 1
+  IFS= read -r line < "${procfs}/self/stat" || return 1
+  rest="${line##*\) }"
+  set -- $rest
+  [ $# -ge 4 ] || return 1
+  sid="$4"
+  case "$sid" in ''|0|*[!0-9]*) return 1 ;; esac
+  st="x"                                   # leader already gone → sid alone
+  if [ -r "${procfs}/${sid}/stat" ] && IFS= read -r line < "${procfs}/${sid}/stat"; then
+    rest="${line##*\) }"
+    set -- $rest
+    if [ $# -ge 20 ]; then
+      case "${20}" in ''|*[!0-9]*) : ;; *) st="${20}" ;; esac
+    fi
+  fi
+  printf 'sid:%s:%s' "$sid" "$st"
+}
+
 derive_session_id() {
   if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then printf 'claude:%s' "$CLAUDE_CODE_SESSION_ID"; return; fi
   if [ -n "${CLAUDE_SESSION_ID:-}" ];      then printf 'claude:%s' "$CLAUDE_SESSION_ID"; return; fi
   if [ -n "${TMUX_PANE:-}" ];              then printf 'tmux:%s' "$TMUX_PANE"; return; fi
+  local sid; sid="$(_session_from_proc)" && [ -n "$sid" ] && { printf '%s' "$sid"; return; }
   local dir="${XDG_RUNTIME_DIR:-/tmp}/browser-bridge"
   local f="${dir}/session-${PPID}"
   if [ -r "$f" ]; then cat "$f"; return; fi
@@ -538,7 +582,25 @@ cmd_op() {
       if printf '%s' "$resp" | grep -q '"not_owned_tab"'; then
         # The emulation blast-radius refusal. Distinct from no_owned_tab: the
         # session may well own a tab — this one is not it. Nothing was applied.
-        die "op '$op' may only run on a tab THIS session owns — run 'browser open [url]' first and drop --tab (device emulation is deliberately never allowed on your own browsing tabs)"
+        #
+        # The two shapes need DIFFERENT advice. The old single message said
+        # "drop --tab", which sends you hunting the flag when the real cause is
+        # usually a session-id mismatch (the `open` ran under a different id).
+        # So print the id THIS call presented — it is a routing token, never a
+        # secret; `--print-session-id` already prints it.
+        if [ -n "$TAB" ]; then
+          echo "browser: tab ${TAB} is not owned by THIS session." >&2
+          echo "browser:   this call's session id: ${SESSION_ID}" >&2
+          echo "browser:   Either that tab belongs to another driver/session, or the" >&2
+          echo "browser:   'browser open' that created it ran under a DIFFERENT id." >&2
+          echo "browser:   Compare them: run 'browser --print-session-id' the same way" >&2
+          echo "browser:   you ran the 'open' (e.g. inside the same \$( … ) or pipeline)" >&2
+          echo "browser:   and again directly — if they differ, that is the bug." >&2
+          die "op '$op' refused (device emulation is deliberately never allowed on a tab this session does not own)"
+        fi
+        echo "browser: this session owns no tab, so '$op' has nothing it may act on." >&2
+        echo "browser:   this call's session id: ${SESSION_ID}" >&2
+        die "run 'browser open [url]' first, then re-run '$op' (device emulation is deliberately never allowed on your own browsing tabs)"
       fi
       if printf '%s' "$resp" | grep -q '"no_owned_tab"'; then
         die "this session owns no tab to close — run 'browser open [url]' first (or pass --tab <id>)"

--- a/scripts/browser-bridge/reference/emulation.md
+++ b/scripts/browser-bridge/reference/emulation.md
@@ -156,7 +156,17 @@ the operator's browser. So the fallback is removed for this op specifically.
 
 `not_owned_tab` is deliberately **distinct** from `no_owned_tab`: the latter means
 "you have nothing to act on" (run `browser open`), the former means "that tab is
-not yours" (drop the `--tab`).
+not yours".
+
+⚠ **If you passed `--tab <id>` you captured from `browser open`, suspect the
+SESSION ID before you suspect the flag.** Until 2026-08-01 the fallback id was
+keyed on `$PPID`, so `T=$(browser open … | …)` registered ownership under a
+*different* id than the following `browser --tab "$T" emulate` presented — and
+the old message ("drop `--tab`") pointed straight at the wrong thing. The CLI now
+prints the session id the failing call presented; run `browser --print-session-id`
+both inside the same `$( … )` you used for the `open` and directly, and compare.
+Full account: `~/workspace/devrc/scripts/browser-bridge/reference/tabs-instances.md`
+→ "The subshell hazard".
 
 ---
 

--- a/scripts/browser-bridge/reference/tabs-instances.md
+++ b/scripts/browser-bridge/reference/tabs-instances.md
@@ -31,10 +31,43 @@ Now each session can own its own tab:
   with `owned_tab_gone` and the bridge drops your ownership — your NEXT command
   automatically falls back to the active tab. `browser close` always clears the
   mapping, even if the tab was already gone.
-- **Session id source:** `CLAUDE_CODE_SESSION_ID` → `$TMUX_PANE` → a
-  per-process-tree token (see README). It is routing-only, never trusted for
-  auth. If two drivers ever resolve the same id they share a tab (degrades to
-  the old behaviour — no worse). `browser --print-session-id` prints the derived id.
+- **Session id source (precedence):** `CLAUDE_CODE_SESSION_ID` → `CLAUDE_SESSION_ID`
+  → `$TMUX_PANE` → the **POSIX session id** (`sid:<sid>:<leader-starttime>`, from
+  `/proc/self/stat`) → (no procfs only) a PPID-keyed cached token. It is
+  routing-only, never trusted for auth. If two drivers ever resolve the same id
+  they share a tab (degrades to the old behaviour — no worse).
+  `browser --print-session-id` prints the derived id.
+- **⚠ The subshell hazard (fixed 2026-08-01 — read this if you script `open`).**
+  Capturing a tab id is naturally written inside a command substitution:
+
+  ```bash
+  T=$(browser open https://example.com | grep -oE '"tabId": *[0-9]+' | grep -oE '[0-9]+')
+  browser --tab "$T" emulate iphone-15
+  ```
+
+  Until 2026-08-01 the last-resort fallback was keyed on `$PPID`, and a `$( … )`
+  that forks gives `browser` a different parent pid — so the `open` registered
+  ownership under one session id and the later call presented another. The
+  refusal (`op 'emulate' may only run on a tab THIS session owns`) points at
+  `--tab`, which is the wrong place to look. **Measured over ssh on the
+  workbench**, where `CLAUDE_CODE_SESSION_ID` is unset:
+
+  ```
+  $ echo "in subst: $(browser --print-session-id)"
+  in subst:  ppid:2484606:c4b88b1d9de41681
+  $ browser --print-session-id
+             ppid:2484584:3216410da01ef5e2      # DIFFERENT → not_owned_tab
+  ```
+
+  Invisible under normal Claude Code use (`CLAUDE_CODE_SESSION_ID` is set, so the
+  fallback never runs); it bites over **ssh, cron, and any non-Claude shell**.
+  The POSIX session id fixes it: a subshell cannot leave its session (only
+  `setsid(2)` can), so every process in one login/pane/unit agrees — while two
+  ssh logins, two tmux panes and two systemd units still get distinct ids, so
+  per-session tab isolation is preserved. **If you hit `not_owned_tab` anyway**,
+  the CLI now prints the session id THIS call presented; run
+  `browser --print-session-id` both inside the same `$( … )`/pipeline you used
+  for the `open` and directly, and compare.
 - **⚠ Concurrent drivers that may share a session id (subagents): pass explicit
   `--tab`.** Sibling subagents of ONE parent share identity — a subagent inherits
   the parent's `CLAUDE_CODE_SESSION_ID` and the same `$TMUX_PANE`, and there is NO

--- a/scripts/browser-bridge/reference/tabs-instances.md
+++ b/scripts/browser-bridge/reference/tabs-instances.md
@@ -67,7 +67,10 @@ Now each session can own its own tab:
   per-session tab isolation is preserved. **If you hit `not_owned_tab` anyway**,
   the CLI now prints the session id THIS call presented; run
   `browser --print-session-id` both inside the same `$( … )`/pipeline you used
-  for the `open` and directly, and compare.
+  for the `open` and directly, and compare. **No migration needed** across the
+  id change: ownership lives in the server's memory with a 900s idle TTL reaped
+  on every touch, so a tab still mapped to an old `ppid:` id self-releases
+  within 15 minutes (and the real Brave tab is never closed by a reclaim).
 - **⚠ Concurrent drivers that may share a session id (subagents): pass explicit
   `--tab`.** Sibling subagents of ONE parent share identity — a subagent inherits
   the parent's `CLAUDE_CODE_SESSION_ID` and the same `$TMUX_PANE`, and there is NO

--- a/scripts/browser-bridge/tests/test_browser_session_id.py
+++ b/scripts/browser-bridge/tests/test_browser_session_id.py
@@ -160,6 +160,146 @@ def test_harness_control_old_algorithm_drifts(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
+# 3b. THE /proc PARSE ITSELF.
+#
+# An independent 9-mutant sweep found 5 survivors, ALL here — the tests above
+# pin the *outcome* (stable / distinct) and every one of these mutations happens
+# to preserve it on THIS host's process tree. Two are not cosmetic:
+#   • `sid="$4"` → `"$3"` reads the process GROUP instead of the session.
+#     Measured under a real pty: at an interactive prompt a bare command gets its
+#     OWN process group while `$( … )` keeps the shell's — so pgrp-instead-of-
+#     session silently REINTRODUCES the exact bug this file exists for.
+#     `test_session_id_is_the_real_posix_session_id` cannot see it because
+#     `start_new_session=True` makes pid == pgid == sid there (an incidental
+#     value-pin). The discriminator below forces pgid ≠ sid instead.
+#   • `st="${20}"` → `${19}` reads stat field 21 (`itrealvalue`, always 0), which
+#     silently kills the PID-reuse guard.
+# BROWSER_BRIDGE_PROC (the seam already used by the harness control) lets these
+# pin the field indices against a synthetic /proc with known values.
+# --------------------------------------------------------------------------- #
+def _stat(pid, comm, ppid, pgrp, sess, starttime):
+    """One /proc/<pid>/stat line with EXPLICIT field values.
+
+    1=pid 2=(comm) 3=state 4=ppid 5=pgrp 6=session 7..21=filler 22=starttime.
+    The filler is `2xx` per index so an off-by-one lands on a recognisable
+    wrong number instead of on something that happens to look plausible.
+    """
+    filler = " ".join(str(200 + i) for i in range(7, 22))     # fields 7..21
+    return f"{pid} ({comm}) S {ppid} {pgrp} {sess} {filler} {starttime} 0 0\n"
+
+
+def _fake_proc(tmp_path, self_stat, leader=None, leader_stat=None):
+    root = tmp_path / "fakeproc"
+    (root / "self").mkdir(parents=True, exist_ok=True)
+    (root / "self" / "stat").write_text(self_stat)
+    if leader is not None:
+        (root / str(leader)).mkdir(parents=True, exist_ok=True)
+        (root / str(leader) / "stat").write_text(leader_stat)
+    return root
+
+
+def _run_id(env):
+    return subprocess.run(["bash", str(CLI), "--print-session-id"], env=env,
+                          capture_output=True, text=True, timeout=60)
+
+
+def test_comm_containing_a_close_paren_space_is_parsed_by_the_LAST_paren(tmp_path):
+    """A process whose comm contains `") "` must not truncate the field split.
+
+    With a first-`)` cut the remainder starts mid-comm and field 4 lands on the
+    pgrp (555) instead of the session (888).
+    """
+    root = _fake_proc(
+        tmp_path,
+        _stat(123, "my (weird) proc", 1, 555, 888, 111),
+        leader=888, leader_stat=_stat(888, "bash", 1, 888, 888, 987654))
+    cp = _run_id(_env(tmp_path, BROWSER_BRIDGE_PROC=str(root)))
+    assert cp.stdout.strip() == "sid:888:987654", (cp.stdout, cp.stderr)
+
+
+def test_session_field_is_used_not_the_process_group_synthetic(tmp_path):
+    """Field 6 (session), not field 5 (pgrp). Pinned with the two set apart."""
+    root = _fake_proc(
+        tmp_path,
+        _stat(123, "bash", 1, 555, 888, 111),
+        leader=888, leader_stat=_stat(888, "bash", 1, 888, 888, 987654))
+    cp = _run_id(_env(tmp_path, BROWSER_BRIDGE_PROC=str(root)))
+    assert cp.stdout.strip() == "sid:888:987654", (cp.stdout, cp.stderr)
+
+
+def test_session_field_is_used_not_the_process_group_live(tmp_path):
+    """The same pin against the REAL kernel, in the shape that actually bit.
+
+    `process_group=0` gives the child its own process group while leaving it in
+    our session — exactly what an interactive shell does to a foreground command
+    (and what a forking `$( … )` does NOT). So pgid ≠ sid here, and a `$3` read
+    would return the child's own pid.
+    """
+    sess = os.getsid(0)
+    p = subprocess.Popen(["bash", str(CLI), "--print-session-id"],
+                         env=_env(tmp_path), stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE, text=True, process_group=0)
+    out, err = p.communicate(timeout=60)
+    assert p.returncode == 0, err
+    # The discriminator must actually discriminate, or this test is vacuous.
+    assert p.pid != sess, "child pid == session id — no pgrp/sid discrimination"
+    assert out.strip().startswith(f"sid:{sess}:"), (out, p.pid, sess)
+    assert not out.strip().startswith(f"sid:{p.pid}:"), (
+        f"read the process GROUP ({p.pid}), not the session ({sess}): {out!r}")
+
+
+def test_leader_starttime_is_stat_field_22_synthetic(tmp_path):
+    """Field 22 (starttime), not 21 (`itrealvalue`). The leader's field 21 is
+    the filler 221, so an off-by-one is unmistakable."""
+    root = _fake_proc(
+        tmp_path,
+        _stat(123, "bash", 1, 888, 888, 111),
+        leader=888, leader_stat=_stat(888, "bash", 1, 888, 888, 987654))
+    cp = _run_id(_env(tmp_path, BROWSER_BRIDGE_PROC=str(root)))
+    assert cp.stdout.strip() == "sid:888:987654", (cp.stdout, cp.stderr)
+    assert "221" not in cp.stdout, f"read stat field 21, not 22: {cp.stdout!r}"
+
+
+@pytest.mark.skipif(shutil.which("awk") is None, reason="cross-check uses awk")
+def test_leader_starttime_matches_awk_field_22_live(tmp_path):
+    """Cross-check the real value with a DIFFERENT tool (awk whitespace split),
+    so the expectation is not derived from the implementation's own parse."""
+    sess = os.getsid(0)
+    raw = Path(f"/proc/{sess}/stat").read_text()
+    if " " in raw[raw.index("(") + 1:raw.rindex(")")]:
+        pytest.skip("session leader's comm contains a space; awk $22 would shift")
+    expect = subprocess.run(["awk", "{print $22}", f"/proc/{sess}/stat"],
+                            capture_output=True, text=True).stdout.strip()
+    assert expect.isdigit(), expect
+    assert _print_id(_env(tmp_path)) == f"sid:{sess}:{expect}"
+
+
+@pytest.mark.parametrize("label,self_stat", [
+    # Too few fields after the comm cut → the `[ $# -ge 4 ]` guard.
+    ("no-parens", "garbage\n"),
+    ("truncated", "123 (bash) S 1\n"),
+    # Session 0 / non-numeric → the `case "$sid"` guard.
+    ("session-zero", _stat(123, "bash", 1, 0, 0, 111)),
+    ("session-nan", "123 (bash) S 1 555 notanumber 1 2 3\n"),
+])
+def test_malformed_stat_degrades_to_the_ppid_fallback_silently(
+        tmp_path, label, self_stat):
+    """Every malformed shape must fall through to `ppid:` — never to an empty
+    id, a constant, or `sid:0:`/`sid:notanumber:`.
+
+    stderr MUST stay empty: with the `[ $# -ge 4 ]` guard removed, `set -u`
+    makes `$4` an unbound-variable error, which still lands on the ppid
+    fallback but spews a shell diagnostic on every single invocation. Asserting
+    silence is what distinguishes the two.
+    """
+    root = _fake_proc(tmp_path, self_stat)
+    cp = _run_id(_env(tmp_path, BROWSER_BRIDGE_PROC=str(root)))
+    assert cp.returncode == 0, cp.stderr
+    assert cp.stdout.strip().startswith("ppid:"), (label, cp.stdout)
+    assert cp.stderr == "", (label, cp.stderr)
+
+
+# --------------------------------------------------------------------------- #
 # 4. Precedence chain, explicitly.
 # --------------------------------------------------------------------------- #
 def test_claude_code_session_id_wins_over_everything(tmp_path):

--- a/scripts/browser-bridge/tests/test_browser_session_id.py
+++ b/scripts/browser-bridge/tests/test_browser_session_id.py
@@ -1,0 +1,262 @@
+"""Session-id derivation contract for the `browser` CLI.
+
+WHY THIS FILE EXISTS (measured live, workbench over ssh, 2026-08-01):
+
+    $ echo "in subst:  $(browser --print-session-id)"
+    in subst:  ppid:2484606:c4b88b1d9de41681
+    $ browser --print-session-id
+               ppid:2484584:3216410da01ef5e2      # DIFFERENT
+
+The last-resort fallback was a random token cached under `$PPID`. A `$( … )`
+that forks gives `browser` a different parent pid, so the cache key missed and a
+brand-new id was minted. That silently breaks per-session tab ownership in the
+idiom the docs teach:
+
+    T=$(browser open https://example.com | grep -oE '[0-9]+')   # owner = id A
+    browser --tab "$T" emulate iphone-15                        # presents id B
+    → browser: op 'emulate' may only run on a tab THIS session owns …
+
+Invisible under normal Claude Code use (`CLAUDE_CODE_SESSION_ID` is set, so the
+fallback never runs); it bites over ssh, cron, and any non-Claude shell.
+
+Fix: derive from the POSIX SESSION id (`sid:<sid>:<leader-starttime>`). A
+subshell cannot leave its session — only setsid(2) can — so it is stable across
+a command substitution, while sshd / tmux / systemd / cron all setsid, so
+genuinely distinct sessions still get distinct ids and keep their tab isolation.
+
+BOTH directions are asserted here on purpose: a "fix" that collapsed every
+invocation onto one shared id would pass the stability test and destroy the
+isolation the ownership model exists for.
+
+HARNESS VALIDATION (how I know these tests can fail):
+`BROWSER_BRIDGE_PROC` lets a test point the procfs read at a nonexistent path,
+which forces the OLD last-resort branch. `test_harness_control_old_algorithm_drifts`
+runs the exact stability probe against that branch and asserts it DRIFTS — so the
+probe is proven able to detect the bug it guards, in-process, every run. (It is
+the in-suite counterpart of `git checkout 127090e -- browser`, which was also
+run; see the PR body's mutation table.)
+
+Run: nix-shell -p python312Packages.pytest --run \\
+       "pytest scripts/browser-bridge/tests/test_browser_session_id.py -q"
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+BB = Path(__file__).resolve().parent.parent          # scripts/browser-bridge
+CLI = BB / "browser"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="the browser CLI is bash")
+
+# Env vars that would short-circuit the derivation before the fallback we are
+# testing. Cleared for every fallback test.
+HIGHER_PRECEDENCE = ("CLAUDE_CODE_SESSION_ID", "CLAUDE_SESSION_ID", "TMUX_PANE")
+
+SID_RE = re.compile(r"^sid:([1-9][0-9]*):([0-9]+|x)$")
+
+
+def _env(tmp_path, **over):
+    env = dict(os.environ)
+    for k in HIGHER_PRECEDENCE:
+        env.pop(k, None)
+    env["HOME"] = str(tmp_path)
+    env["XDG_RUNTIME_DIR"] = str(tmp_path)          # keep any cache file local
+    env.update(over)
+    return env
+
+
+def _print_id(env, **kw):
+    cp = subprocess.run(["bash", str(CLI), "--print-session-id"], env=env,
+                        capture_output=True, text=True, timeout=60, **kw)
+    assert cp.returncode == 0, cp.stderr
+    return cp.stdout.strip()
+
+
+# --------------------------------------------------------------------------- #
+# The subshell probe: one shell, three ways of invoking the CLI.
+#
+# `direct` MUST NOT be captured with $( ) — that is the whole point. It goes to
+# a file. `subst` and `pipe` are the two shapes a caller actually writes; `pipe`
+# is the one that is guaranteed to fork (`$(a | b)` cannot be exec-optimised).
+# --------------------------------------------------------------------------- #
+PROBE = r"""
+set -u
+CLI="$1"; OUT="$2"
+bash "$CLI" --print-session-id > "$OUT/direct"
+printf '%s' "$(bash "$CLI" --print-session-id)"        > "$OUT/subst"
+printf '%s' "$(bash "$CLI" --print-session-id | cat)"  > "$OUT/pipe"
+printf '%s' "$$" > "$OUT/shellpid"
+"""
+
+
+def _probe(tmp_path, env, new_session=False):
+    out = tmp_path / f"probe-{'ns' if new_session else 'inh'}"
+    out.mkdir(exist_ok=True)
+    cp = subprocess.run(["bash", "-c", PROBE, "probe", str(CLI), str(out)],
+                        env=env, capture_output=True, text=True, timeout=60,
+                        start_new_session=new_session)
+    assert cp.returncode == 0, cp.stderr
+    return {n: (out / n).read_text().strip()
+            for n in ("direct", "subst", "pipe", "shellpid")}
+
+
+# --------------------------------------------------------------------------- #
+# 1. THE LOAD-BEARING TEST — stable across a command substitution …
+# --------------------------------------------------------------------------- #
+def test_session_id_stable_across_command_substitution(tmp_path):
+    r = _probe(tmp_path, _env(tmp_path))
+    assert r["direct"] == r["subst"] == r["pipe"], (
+        "session id drifts between a direct call and a command substitution "
+        f"in the SAME shell: {r!r}")
+    assert SID_RE.match(r["direct"]), r["direct"]
+
+
+# --------------------------------------------------------------------------- #
+# 2. … and DISTINCT across genuinely different sessions.
+#    Without this, "return one constant" would pass test 1 and silently destroy
+#    per-session tab isolation (concurrent drivers would fight over one tab).
+# --------------------------------------------------------------------------- #
+def test_session_id_distinct_across_distinct_sessions(tmp_path):
+    env = _env(tmp_path)
+    a = _print_id(env, start_new_session=True)
+    b = _print_id(env, start_new_session=True)
+    assert SID_RE.match(a) and SID_RE.match(b), (a, b)
+    assert a != b, f"two separate POSIX sessions collapsed onto one id: {a}"
+
+
+def test_session_id_is_the_real_posix_session_id(tmp_path):
+    """Pin the VALUE, not just the shape.
+
+    `start_new_session=True` makes the child bash a session leader, so its sid
+    IS its pid — a number this test learns from the OS (`$$`), independently of
+    the implementation under test.
+    """
+    r = _probe(tmp_path, _env(tmp_path), new_session=True)
+    assert r["direct"].startswith(f"sid:{r['shellpid']}:"), r
+    m = SID_RE.match(r["direct"])
+    assert m and m.group(2).isdigit(), (
+        f"expected a numeric leader starttime (pid-reuse guard), got {r['direct']}")
+
+
+# --------------------------------------------------------------------------- #
+# 3. HARNESS CONTROL — the same probe, pointed at the OLD algorithm, must FAIL.
+#    BROWSER_BRIDGE_PROC=/nonexistent forces the PPID-cached last-resort branch.
+# --------------------------------------------------------------------------- #
+def test_harness_control_old_algorithm_drifts(tmp_path):
+    env = _env(tmp_path, BROWSER_BRIDGE_PROC=str(tmp_path / "no-such-procfs"))
+    r = _probe(tmp_path, env)
+    assert r["direct"].startswith("ppid:"), r
+    assert r["pipe"] != r["direct"], (
+        "the probe did NOT detect drift on the known-bad algorithm — it is "
+        f"proving nothing: {r!r}")
+
+
+# --------------------------------------------------------------------------- #
+# 4. Precedence chain, explicitly.
+# --------------------------------------------------------------------------- #
+def test_claude_code_session_id_wins_over_everything(tmp_path):
+    env = _env(tmp_path, CLAUDE_CODE_SESSION_ID="uuid-A",
+               CLAUDE_SESSION_ID="uuid-B", TMUX_PANE="%9")
+    assert _print_id(env) == "claude:uuid-A"
+
+
+def test_claude_session_id_is_the_defensive_alternate(tmp_path):
+    env = _env(tmp_path, CLAUDE_SESSION_ID="uuid-B", TMUX_PANE="%9")
+    assert _print_id(env) == "claude:uuid-B"
+
+
+def test_tmux_pane_beats_the_process_tree(tmp_path):
+    assert _print_id(_env(tmp_path, TMUX_PANE="%9")) == "tmux:%9"
+
+
+def test_posix_session_id_is_used_when_no_env_source_exists(tmp_path):
+    assert SID_RE.match(_print_id(_env(tmp_path)))
+
+
+def test_ppid_cache_is_the_last_resort_only(tmp_path):
+    """With procfs unreadable the CLI still produces an id — it must not die."""
+    env = _env(tmp_path, BROWSER_BRIDGE_PROC=str(tmp_path / "no-such-procfs"))
+    assert _print_id(env).startswith("ppid:")
+
+
+def test_claude_var_still_wins_with_procfs_available(tmp_path):
+    """The laptop relies on this: CLAUDE_CODE_SESSION_ID must never be shadowed
+    by the new sid branch."""
+    r = _probe(tmp_path, _env(tmp_path, CLAUDE_CODE_SESSION_ID="uuid-A"))
+    assert r["direct"] == r["subst"] == r["pipe"] == "claude:uuid-A", r
+
+
+# --------------------------------------------------------------------------- #
+# 5. The not_owned_tab error message.
+#
+# A stub bridge that always answers 409 not_owned_tab, so the CLI's guidance is
+# asserted on the wire shape the real server produces.
+# --------------------------------------------------------------------------- #
+class _Refuser(BaseHTTPRequestHandler):
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length") or 0))
+        raw = json.dumps({"ok": False, "error": "not_owned_tab"}).encode()
+        self.send_response(409)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def log_message(self, *a):
+        pass
+
+
+@pytest.fixture
+def refuser(tmp_path):
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), _Refuser)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    tok = tmp_path / "token"
+    tok.write_text("test-token-abc123\n")
+    env = _env(tmp_path, BROWSER_BRIDGE_HOST="127.0.0.1",
+               BROWSER_BRIDGE_PORT=str(srv.server_address[1]),
+               BROWSER_BRIDGE_TOKEN_FILE=str(tok),
+               CLAUDE_CODE_SESSION_ID="uuid-under-test")
+
+    class _R:
+        @staticmethod
+        def run(*args):
+            return subprocess.run(["bash", str(CLI), *args], env=env,
+                                  capture_output=True, text=True, timeout=60)
+    try:
+        yield _R
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+@pytest.mark.skipif(shutil.which("curl") is None, reason="the CLI uses curl")
+def test_not_owned_tab_with_explicit_tab_names_the_tab_and_this_session_id(refuser):
+    cp = refuser.run("--tab", "4242", "emulate", "iphone-15")
+    assert cp.returncode != 0
+    err = cp.stderr
+    assert "tab 4242 is not owned by THIS session" in err, err
+    assert "claude:uuid-under-test" in err, err
+    assert "--print-session-id" in err, err
+    # The old message's advice, which sent a real operator hunting the flag for
+    # 20 minutes while the cause was a session-id mismatch.
+    assert "drop --tab" not in err, err
+
+
+@pytest.mark.skipif(shutil.which("curl") is None, reason="the CLI uses curl")
+def test_not_owned_tab_without_a_tab_flag_says_open_first(refuser):
+    cp = refuser.run("emulate", "iphone-15")
+    assert cp.returncode != 0
+    err = cp.stderr
+    assert "this session owns no tab" in err, err
+    assert "browser open" in err, err
+    assert "claude:uuid-under-test" in err, err
+    # No --tab was passed, so nothing may accuse a tab id.
+    assert "is not owned by THIS session" not in err, err


### PR DESCRIPTION
## The defect

`derive_session_id`'s fallback was a random token cached under **`$PPID`**. A `$( … )` that forks gives `browser` a different parent pid, so the cache key missed and a **brand-new id was minted** — the id is not stable across a command substitution.

That silently breaks per-session tab ownership in the idiom the docs teach:

```bash
T=$(browser open https://example.com | grep -oE '"tabId": *[0-9]+' | grep -oE '[0-9]+')
browser --tab "$T" emulate iphone-15
# browser: op 'emulate' may only run on a tab THIS session owns — … drop --tab
```

The `open` registers ownership under the subshell's id; the later call presents another. Measured on the workbench over ssh (2026-08-01):

```
$ echo "in subst:  $(browser --print-session-id)"
in subst:  ppid:2484606:c4b88b1d9de41681
$ browser --print-session-id
           ppid:2484584:3216410da01ef5e2      # DIFFERENT
```

Invisible on the laptop and under normal Claude Code use (`CLAUDE_CODE_SESSION_ID` is set, so the fallback never runs). It bites wherever that var is absent: **ssh, cron, a non-Claude shell, any script.**

## Precedence chain as it existed at 127090e (verified, not summarised)

1. `CLAUDE_CODE_SESSION_ID` → `claude:<uuid>`
2. `CLAUDE_SESSION_ID` → `claude:<uuid>`
3. `$TMUX_PANE` → `tmux:%N`
4. `$XDG_RUNTIME_DIR/browser-bridge/session-$PPID` → cached `ppid:<PPID>:<8 random bytes>`, minted on miss

`$TMUX_PANE` **is** in the chain (step 3) and it would **not** have saved the ssh case — it is unset over a plain ssh, which is why step 4 ran. All of 1–3 are env vars and are inherently stable across a subshell; only step 4 was not.

## The fix

New step 4: the **POSIX session id**, `sid:<sid>:<leader-starttime>`, parsed from `/proc/self/stat`. The PPID cache is demoted to step 5, a procfs-less last resort.

**Why this signal:**

- **Stable across a subshell** — `setsid(2)` is the only way to leave a session, so every subshell, pipeline stage, command substitution and exec'd child of one shell reports the same sid. (`$$` in a bash subshell also reports the parent's pid, but that is a bash-specific quirk that does not hold generally, and the drift was hit from zsh.)
- **Distinct across real sessions** — sshd, tmux (per pane), a terminal emulator, a systemd unit and cron all `setsid`, so two ssh logins / two tmux panes / two concurrent drivers get different sids and keep their tab isolation. Collapsing them would have been worse than the bug; that is asserted as a test in its own right.
- **`<leader-starttime>`** (stat field 22, ticks since boot) defuses **pid reuse** — a later session handed a recycled pid as its sid cannot inherit a dead session's tab.

`CLAUDE_CODE_SESSION_ID` stays highest-precedence (pinned by two tests).

**Restart-free, CLI-only.** `scripts/browser-bridge/browser` is an `mkOutOfStoreSymlink` onto the working tree, so this is live on `git pull` — no `home-manager switch`, no Brave reload, no manifest bump. `extension/` and `server.py` are untouched.

## Improved error message

Before (one message for both shapes, pointing at the wrong thing):

```
browser: op 'emulate' may only run on a tab THIS session owns — run 'browser open [url]' first and drop --tab …
```

After, with `--tab`:

```
browser: tab 4242 is not owned by THIS session.
browser:   this call's session id: sid:2484584:8290795
browser:   Either that tab belongs to another driver/session, or the
browser:   'browser open' that created it ran under a DIFFERENT id.
browser:   Compare them: run 'browser --print-session-id' the same way
browser:   you ran the 'open' (e.g. inside the same $( … ) or pipeline)
browser:   and again directly — if they differ, that is the bug.
browser: op 'emulate' refused (device emulation is deliberately never allowed on a tab this session does not own)
```

and without `--tab` (the session genuinely owns nothing):

```
browser: this session owns no tab, so 'emulate' has nothing it may act on.
browser:   this call's session id: claude:…
browser: run 'browser open [url]' first, then re-run 'emulate' …
```

⚠ **Honest scope:** the *other* session's id is **not** printed. The running server does not return the owner in the `not_owned_tab` body and exposes no owners endpoint, and `server.py` is deployed as a nix-store copy — adding a field there would need a `home-manager switch` + service restart, which this PR is explicitly forbidden to require. The message instead prints the id this call presented and tells you exactly how to obtain the other one. If you want both printed automatically, that is a follow-up PR that touches the server.

## Docs

- `reference/tabs-instances.md` — full precedence chain + a "**The subshell hazard**" section with the measured ssh transcript (this is where anyone scripting `open` will look).
- `reference/emulation.md` — the `not_owned_tab` vs `no_owned_tab` note no longer says "drop the `--tab`"; it says suspect the session id first.
- `README.md` — chain updated + why the POSIX session id and not `$PPID`.
- `SKILL.md` deliberately **not** touched (12,217 / 12,288-byte ceiling).

## Testing

New: `scripts/browser-bridge/tests/test_browser_session_id.py` (12 tests, headless, stub loopback bridge for the error-message cases).

**How the harness was validated** (this session has burned eight harnesses that tested nothing):

1. **In-suite control, runs every time.** `BROWSER_BRIDGE_PROC` is a test seam that points the procfs read at a nonexistent path, forcing the OLD last-resort branch. `test_harness_control_old_algorithm_drifts` runs the *exact same* stability probe against it and asserts it **DRIFTS**. If the probe ever stops being able to see the bug, that test fails loudly.
2. **The probe cannot self-deceive via `$$`.** The "direct" invocation is written to a **file**, never captured with `$( )`; the "subst" and "pipe" variants are the real caller shapes, and `$(a | b)` is guaranteed to fork.
3. **Whole-file control** — `git checkout 127090e -- browser`, byte-difference asserted non-zero (125 diff lines) and `grep -q _session_from_proc` asserted absent before running, then the new suite: **6 RED / 6 green**. The 6 green are labelled invariant guards (the precedence rules the fix must not take away), not regression coverage.
4. **Restoration verified** — every sweep ends with `cmp` against a pre-mutation backup (byte-identical) so a crashed sweep can't leave a mutant applied.
5. **Gate log read, not just the exit code** — `nix log` confirms `=== pytest scripts/browser-bridge/tests === 357 passed` *inside* the sandbox, so `/proc` and `setsid` work there and the new tests actually ran rather than skipping.

### Whole-file control at 127090e (6 RED / 6 invariant-guard green)

| test | verdict at 127090e |
|---|---|
| `stable_across_command_substitution` | 🔴 RED — the defect |
| `distinct_across_distinct_sessions` | 🔴 RED (on the `sid:` shape assertion — the old ppid ids *were* distinct, so this one is honestly a shape failure, not a distinctness regression) |
| `is_the_real_posix_session_id` | 🔴 RED |
| `posix_session_id_is_used_when_no_env_source_exists` | 🔴 RED |
| `not_owned_tab_with_explicit_tab_…` | 🔴 RED |
| `not_owned_tab_without_a_tab_flag_…` | 🔴 RED |
| `claude_code_session_id_wins_over_everything` | 🟢 INVARIANT GUARD |
| `claude_session_id_is_the_defensive_alternate` | 🟢 INVARIANT GUARD |
| `tmux_pane_beats_the_process_tree` | 🟢 INVARIANT GUARD |
| `ppid_cache_is_the_last_resort_only` | 🟢 INVARIANT GUARD |
| `claude_var_still_wins_with_procfs_available` | 🟢 INVARIANT GUARD |
| `harness_control_old_algorithm_drifts` | 🟢 (127090e *is* the old algorithm — passing is correct) |

### Mutation sweep (7 mutants, each verified applied before running; all caught)

| # | mutation | result | caught by |
|---|---|---|---|
| M0 | none (baseline) | 12 passed | — |
| M1 | `sid="$2"` (read ppid instead of the session field) | **2 failed** | stability, value-pin |
| M2 | `derive_session_id` returns the constant `sid:1:1` | **10 failed** | distinctness, value-pin, control, all 4 precedence, both error msgs |
| M3 | drop the `<leader-starttime>` suffix (pid-reuse guard) | **1 failed** | value-pin |
| M4 | sid branch moved above `$TMUX_PANE` | **1 failed** | tmux precedence |
| M5 | sid branch moved above `CLAUDE_CODE_SESSION_ID` | **1 failed** | claude precedence |
| M6 | `not_owned_tab` message reverted to the old single line | **2 failed** | both error-message tests |
| M7 | `BROWSER_BRIDGE_PROC` seam ignored (hard-coded `/proc`) | **2 failed** | control + last-resort |

M2 is the "collapse everything onto one id" mutant — the one that would have passed a stability-only test suite.

### Suites vs the measured 127090e baseline

| | baseline (127090e) | this branch |
|---|---|---|
| `node --test scripts/browser-bridge/tests/*.test.mjs` | 422 | **422 pass** |
| `pytest scripts/browser-bridge/tests` | 345 | **357 pass** (+12 new) |
| `nix build .#checks.x86_64-linux.pytests` | green | **PASS** (log read: browser-bridge 357 in-sandbox) |

## Needs a live check I could not do

Everything here is headless by construction. **Not verified live:** the end-to-end `open` → `--tab` → `emulate` path against real Brave, because that needs a browser and this PR is scoped away from live interaction. The ssh reproduction is the cheap confirmation — on the workbench, after `git pull`:

```
$ echo "in subst:  $(browser --print-session-id)"
$ browser --print-session-id
# expect: identical, and of the form sid:<pid>:<ticks>
$ T=$(browser open https://example.com | grep -oE '"tabId": *[0-9]+' | grep -oE '[0-9]+')
$ browser --tab "$T" emulate iphone-15      # expect: succeeds, no not_owned_tab
```

Also unverified across hosts: the laptop, where `CLAUDE_CODE_SESSION_ID` is set and this changes nothing (the two claude-precedence tests pin that, but on this host only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
