### PR TITLE
docs(skills): compress initiatives + auditloop SKILL.md (-33% always-loaded bytes)

### DIFF
--- a/claude/skills/auditloop/SKILL.md
+++ b/claude/skills/auditloop/SKILL.md
@@ -5,59 +5,89 @@ description: Operate auditloop — the generic UX-audit crawler web app (auditlo
 
 # auditloop operations
 
-auditloop is a **generic UX-audit crawler web app** — a Go single-binary (web + worker roles) chromedp crawler, gomponents+htmx+Tailwind **PWA**, spun out of the naida/vetr `ux-audit-loops` harness to be a hosted hub. Live at **https://auditloop.zacx.dev**. Repo **`ZacxDev/auditloop`** (default `main`), source at `~/workspace/auditloop`. Cross-session state: memory `auditloop-project` (read first). Sibling harnesses feed it — see the `ux-audit-loops` skill.
+A **generic UX-audit crawler web app** — a Go single-binary (web + worker roles) chromedp
+crawler, gomponents+htmx+Tailwind **PWA**, spun out of the naida/vetr `ux-audit-loops`
+harness to be a hosted hub. Cross-session state: memory `auditloop-project` (read first).
+Sibling harnesses feed it — see the `ux-audit-loops` skill.
 
 | | |
 |---|---|
-| Repo / source | `ZacxDev/auditloop` · `~/workspace/auditloop` (Go 1.26 module `auditloop`) |
+| Repo / source | `ZacxDev/auditloop` (default `main`) · `~/workspace/auditloop` (Go 1.26 module `auditloop`) |
 | Live | https://auditloop.zacx.dev · GoTrue https://auditloop-auth.zacx.dev |
 | Clusters | **app** on homelab-talos **workbench** (ns `auditloop`); **GoTrue** on **homelab** (ns `supabase-auditloop`); public routing via **production+homelab** nebula gateways |
-| Kubeconfigs | `~/workspace/homelab-infra/{workbench,homelab,production}-kubeconfig` |
+| Kubeconfigs | `~/workspace/homelab-infra/{workbench,homelab,production}-kubeconfig` — **NOT the repo root** |
 | Image | `harbor.homelab.lan/library/auditloop:main-<ts>` (Flux image-automation picks newest) · current live: check the pod |
 | GitOps | app manifests in `homelab-infra` (checked out at `~/workspace/homelab-talos`) `clusters/workbench/apps/auditloop/`; GoTrue `clusters/homelab/apps/supabase-auditloop/`; monitoring `clusters/homelab/apps/auditloop-monitoring/` |
 | Auth | Supabase (self-hosted GoTrue), **invite-only**; smoke user `smoke@auditloop.zacx.dev` |
 | Test | `go test ./...` (incl. hermetic chromium e2e) · `make ux-audit` (the self-audit harness) |
 
+**Reference files** (`~/.claude/skills/auditloop/reference/`, source
+`~/workspace/devrc/claude/skills/auditloop/reference/`) — read on demand:
+- `persona-evaluator.md` — Phases 1–4 detail (personas, tables, migrations 0039–0063, routes, metrics, DOM/a11y grounding, token tiers). Read when working ON the evaluator/driver.
+- `internal-naida-drive.md` — driving a private in-cluster target via `AUDITLOOP_INTERNAL_ALLOW_HOSTS`. Read when driving a ClusterIP app or auditing that allowlist.
+- `ui-and-meta-run.md` — design-system tokens/conventions + the meta-run dogfood recipe. Read when writing auditloop UI.
+
 ## What it does (P0–P5, all live)
 - **P0/P1** — generic same-origin BFS crawl (chromedp), multi-viewport (desktop 1440 + mobile 390) screenshots + **axe a11y** + **origin-classified console/network** → MinIO. **SSRF-guarded** (`internal/crawler/ssrf.go` + runtime `intercept.go` guards redirect hops). Crawl only verified target domains. **Per-run favicon capture** (#33/#34, `internal/crawler/favicon.go`): best-effort/non-fatal server-side fetch of the attacker-influenced favicon URL, SSRF-safe — `GuardConfig.CheckURL` before connect + **IP-pinning dialer** (closes DNS-rebind) + no-redirect (3xx dropped) + **raster-only** (`DetectContentType`, SVG/HTML rejected) + ≤512 KiB; stored run-scoped `{target}/{run}/favicon.<ext>` (migration 0059 `runs.favicon_key`).
 - **P2** — regression diffing vs the previous done run: pure-Go pixel diff (`internal/diff`), new/removed pages, new axe rules, console/network deltas. **Full-page height shifts → "layout changed", NOT a false ~100% regression** (gated on `!SizeChanged`); >24MP captures skip the viz alloc.
-- **P3** — opt-in multi-model **vision-LLM draft UX notes** (`internal/llm` OpenRouter + `internal/notes`): each selected model × each page, both viewports + grounded (axe/console/diff) → editable notes side-by-side. Server-side, key-gated, `page_notes` table.
+- **P3** — opt-in multi-model **vision-LLM draft UX notes** (`internal/llm` OpenRouter + `internal/notes`): each selected model × each page, both viewports + grounded (axe/console/diff) → editable notes side-by-side. Server-side, key-gated, `page_notes` table. The prompt is **purely-visual critique** — the LLM no longer re-narrates axe/console/network/perf (all deterministic now); `Grounding` dropped the a11y/console fields.
 - **P4** — **login recipes** (`internal/recipe` + `internal/crypto`): authed crawl behind a same-domain login; creds **AES-256-GCM at rest** (`AUDITLOOP_ENCRYPTION_KEY`), write-only UI, redacted; test-login button.
-- **P5** — **plugin push ingestion** (`internal/plugin` + `cmd/auditloop-push`): push-only targets w/ hashed rotatable token; `POST /api/plugins/runs` (Bearer, multipart) → ingested run gets the P2 diff. The three harnesses feed this. The push carries optional raw `perf`/`layout` blocks + a run-level **`environment` (lab|staging|prod)**; auditloop computes the perf/layout FINDINGS server-side via `internal/signals` — and **`environment:"lab"` SUPPRESSES the perf findings** (localhost numbers aren't field-representative; raw columns kept, amber run-view banner). The naida/vetr harnesses push `lab`.
-- **Deterministic signals** (shipped, replaced LLM re-narration) — every page+viewport, native crawl AND pushed runs share `internal/signals` (one source of truth for thresholds):
-  - **Perf/web-vitals**: LCP/CLS/**TBT (a headless LAB PROXY — no field input, labelled honestly)** via injected buffered PerformanceObserver (`internal/crawler/perf-capture.js`) + page-weight/req-count via CDP; `type=perf` findings on threshold breach. Cols `pages.lcp_ms/cls/tbt_ms/weight_bytes/req_count`.
-  - **Layout smells** (`internal/crawler/layout-smells.js`): horizontal-overflow, tap-target <44px, text <12px, missing viewport-meta, `<img>` w/o dims → `type=layout` (tap-target/overflow mobile-gated).
-  - **Broken links**: status-aware severity (`sevForNetwork`: 5xx/first-party-4xx serious, third-party minor).
-  - **Cold-load crawl**: `network.SetCacheDisabled(true)` so EVERY page+viewport is a cold load (2nd viewport was warm-cache → undercounted); page-weight uses `dataReceived` fallback (Chromium reports `encodedDataLength=0` for the main doc).
-  - The **P3 prompt was trimmed** to purely-visual critique — the LLM no longer re-narrates axe/console/network/perf (all deterministic now); `Grounding` dropped the a11y/console fields.
-- **Trend view** — a per-target findings-count-over-time inline-SVG sparkline above the run list (`internal/db/trend.go` `TargetFindingTrend`, owner-scoped) — catches slow creep the pairwise P2 diff can't.
-- **Read API — machine consumers** (per-user, read-only): mint a key in the dashboard **"API access"** card (crypto/rand→base64url, sha256-stored, rotatable, shown once), consumer sets **`AUDITLOOP_API_TOKEN`** + `Authorization: Bearer`. Owner-scoped routes (SQL-scoped, foreign→404): `GET /api/audit/targets/{id-or-name}/runs`, `…/runs/latest` (→report.json bytes), `/api/audit/runs/{id}` (→report.json), `/api/audit/artifacts/{key}` (bytes, per-object owner-checked). Target resolves by **name OR UUID** (symmetric with the name-keyed push). This is how CI/Tekton + the naida `fetch-findings` helper pull findings back. `curl -H "Authorization: Bearer $AUDITLOOP_API_TOKEN" https://auditloop.zacx.dev/api/audit/targets/<spec>/runs/latest`.
-- **LLM cost tracking** — per-run + per-cell USD/tokens + Prometheus metrics (see Monitoring).
+- **P5** — **plugin push ingestion** (`internal/plugin` + `cmd/auditloop-push`): push-only targets w/ hashed rotatable token; `POST /api/plugins/runs` (Bearer, multipart) → ingested run gets the P2 diff. The push carries optional raw `perf`/`layout` blocks + a run-level **`environment` (lab|staging|prod)**; auditloop computes the perf/layout FINDINGS server-side via `internal/signals` — and **`environment:"lab"` SUPPRESSES the perf findings** (localhost numbers aren't field-representative; raw columns kept, amber run-view banner). The naida/vetr harnesses push `lab`.
+
+### Deterministic signals (shipped, replaced LLM re-narration)
+Every page+viewport; native crawl AND pushed runs share `internal/signals` (**one source of
+truth for thresholds**).
+- **Perf/web-vitals**: LCP/CLS/**TBT (a headless LAB PROXY — no field input, labelled honestly)** via injected buffered PerformanceObserver (`internal/crawler/perf-capture.js`) + page-weight/req-count via CDP; `type=perf` findings on threshold breach. Cols `pages.lcp_ms/cls/tbt_ms/weight_bytes/req_count`.
+- **Layout smells** (`internal/crawler/layout-smells.js`): horizontal-overflow, tap-target <44px, text <12px, missing viewport-meta, `<img>` w/o dims → `type=layout` (tap-target/overflow mobile-gated).
+- **Broken links**: status-aware severity (`sevForNetwork`: 5xx/first-party-4xx serious, third-party minor).
+- **Cold-load crawl**: `network.SetCacheDisabled(true)` so EVERY page+viewport is a cold load (the 2nd viewport was warm-cache → undercounted); page-weight uses `dataReceived` fallback (Chromium reports `encodedDataLength=0` for the main doc).
+
+### Trend view
+A per-target findings-count-over-time inline-SVG sparkline above the run list
+(`internal/db/trend.go` `TargetFindingTrend`, owner-scoped) — catches slow creep the pairwise
+P2 diff can't.
+
+### Read API — machine consumers (per-user, read-only)
+Mint a key in the dashboard **"API access"** card (crypto/rand→base64url, sha256-stored,
+rotatable, **shown once**); consumer sets **`AUDITLOOP_API_TOKEN`** + `Authorization: Bearer`.
+Owner-scoped routes (SQL-scoped, foreign→404):
+`GET /api/audit/targets/{id-or-name}/runs` · `…/runs/latest` (→report.json bytes) ·
+`/api/audit/runs/{id}` (→report.json) · `/api/audit/artifacts/{key}` (bytes, per-object
+owner-checked). Target resolves by **name OR UUID** (symmetric with the name-keyed push).
+This is how CI/Tekton + the naida `fetch-findings` helper pull findings back.
+```bash
+curl -H "Authorization: Bearer $AUDITLOOP_API_TOKEN" https://auditloop.zacx.dev/api/audit/targets/<spec>/runs/latest
+```
+
+**LLM cost tracking** — per-run + per-cell USD/tokens + Prometheus metrics (see Monitoring).
 
 ## Persona-walkthrough evaluator (Phases 1–4, live — PRs #20–#25, #35–#38)
-A SECOND opt-in LLM subsystem *parallel* to P3 vision-notes (they coexist), gated on the SAME `OPENROUTER_API_KEY` (no new required secret; buttons hidden + routes 503/403 without it). Runs on `AUDITLOOP_LLM_MODELS[0]` (ONE model; **PERSONA is the axis, not model**). Migrations through **0063** (0059 = `runs.favicon_key` #33; 0060/0061 = DOM/a11y digest #35/#37; 0062/0063 = walkthrough regression #38).
-- **Phase 1 — persona walkthrough** (`internal/eval`, table `page_evaluations`, migrations 0039–0049): evaluates a completed run as a **task + persona walkthrough**. Four **code-defined** personas (`eval.Personas`): `first-time-nontechnical` · `returning-power-user` · `skeptical-evaluator` · `accessibility-constrained`. Per (page × persona) STRUCTURED findings `{comprehension, blockers, frictions, top_fix{selector,change,impact}}` + a **verification pass** (drops/flags unsubstantiated findings) + a run-level **synthesis "story"**. Routes: `POST /api/runs/{id}/evaluate` (body `personas[]`, 503-gated, run must be `done`), `GET /runs/{id}/eval-status` (htmx poll). Read-API: `GET /api/audit/runs/{id}/evaluation` (owner-scoped). Metrics `auditloop_eval_{generated_total{persona,status},duration_seconds,cost_usd_total{persona},prompt/completion_tokens_total{persona}}` (synthesis logs under `_synthesis`).
-- **Phase 2 — goal inference + per-target config** (`target_audit_config` table, migration 0050; `internal/eval/infer.go`): `InferConfig` = ONE synchronous LLM call over the latest done run's landing screenshot + URL digest → a DRAFT config (product_summary, primary_job, primary_cta, applicable personas, inferred/confirmed flags) the owner CONFIRMS/edits (hybrid infer-then-confirm). Routes: `POST /api/targets/{id}/audit-config/infer`, `POST /api/targets/{id}/audit-config`. Read-API `GET /api/audit/targets/{id}/audit-config`. The evaluate trigger **pre-fills** job + personas from the confirmed config.
-- **Phase 3 — goal-directed DRIVER + personas over the driven trace** (`internal/action` closed no-eval action set, `crawler.Drive` LLM-planner loop, `internal/walkthrough`; tables `walkthroughs` + `walkthrough_steps`, migrations 0051–0058). The driver DRIVES the app toward a goal and reports a **deterministic** outcome — success is **OBSERVED via a P4-style success-assertion** (selector / url_contains), NEVER LLM-judged; `outcome ∈ {success, stuck@stepK, failed}` set by the loop. Routes: `POST /api/targets/{id}/walkthrough`, `GET /targets/{id}/walkthrough-status`, `POST /api/targets/{id}/walkthroughs/{wid}/evaluate` (materializes the driven trace as a synthetic run → runs the Phase-1 personas over each driven step, in flow order). Read-API `GET /api/audit/walkthroughs/{id}` (returns `eval_run_id` → pull persona findings via `…/runs/{eval_run_id}/evaluation`). Metrics `auditloop_walkthrough_{runs_total{outcome},steps_total{outcome},duration_seconds,cost_usd_total}`. **Synthetic walkthrough runs (`trigger='walkthrough'`) are EXCLUDED from the P2 baseline queries, the findings trend, and the run list.**
-- **Driver safety model (🔴 foreground it):**
-  - **`driving_enabled` default-OFF per-target opt-in** (migration 0054) — enforced at **BOTH** the route (403) AND the generator (defense in depth). Driving is off until the owner opts in.
-  - **Dry-run submit-guard is the DEFAULT** — the Fetch interceptor **aborts (network-layer, deterministic) every non-GET/HEAD request** (POST/PUT/PATCH/DELETE). SCOPED GUARANTEE: covers every TOP-FRAME HTTP(S) request incl. XHR/`fetch`/`sendBeacon`. **Residual (NOT covered):** WebSocket frames, cross-origin (OOPIF) iframe requests, service-worker requests → for real-submit / prod driving **point at STAGING with a DISPOSABLE account**, don't treat dry-run as an absolute "never writes".
-  - **Real submits require the loud DEFAULT-OFF `allow_real_submit` flag** (migration 0058; `DryRun = !allow_real_submit`) — two independent opt-ins (drive-at-all vs. mutate-live-data).
-  - The **login phase is EXEMPT from the mutation submit-guard** (its credential POST must go through); the SSRF/same-origin IP-guard stays active the ENTIRE time (every nav + redirect). Closed action set, **NO eval**; action budget + per-action/overall timeouts; guard-blocked navs never screenshotted.
-- **LLM completion-token tiers** (all per-call via `llm.WithMaxTokens`, all reuse `OPENROUTER_API_KEY`): `AUDITLOOP_LLM_MAX_TOKENS`=1024 (notes) · `AUDITLOOP_LLM_EVAL_MAX_TOKENS`=2000 (per-page persona gen/verify) · `AUDITLOOP_LLM_SYNTH_MAX_TOKENS`=3000 (run-level synthesis) · `AUDITLOOP_LLM_DRIVE_MAX_TOKENS`≈256 (per-turn driver planner, one action JSON).
-- **Live-smoked this session** (each feature verified against prod): persona eval 6/6 cells + synthesis story on a remix-funnel run · goal inference drafted an accurate remix config · driver example.com dry-run → success in 2 steps · PR-B per-step persona findings over the driven trace. Smoke path = the **smoke-user JWT** in the session scratchpad `login.json` + the **`remix-ci-reader` read key**. No new secret — the credential-rotation batch (OPENROUTER key etc.) now also covers the eval/driver, but the smoke JWT/read keys were the only creds exercised.
-- **✅ shipped as #27 (click-nav SSRF hardening):** the driver's same-origin host-allowlist is now enforced on **every** paused Document nav (click-triggered navs included), not just explicit `navigate` actions — `intercept.go` `checkNav` gates each nav's host against `GuardConfig.hostAllowed` AND the IP guard (`checkHostIP`), closing the click-can-follow-a-public-off-domain-link gap (observed live: example.com → iana.org via a click).
-- **🔴 DOM/a11y grounding for the evaluator** (PRs **#35** Phase-1 crawl path + **#37** Phase-2 driven path + issue **#36** structural label gate). The persona evaluator was **screenshot-only**, so it invented a11y false positives. Fix: a **bounded DOM/a11y digest** is captured per page/step (`internal/crawler/a11y-digest.js` → an `a11y.json` artifact + `pages.a11y_digest_key`, migrations **0060/0061**; the driver's per-step digest is carried through `MaterializeWalkthroughRun`), then a **deterministic** `internal/eval/verify.go` `dropContradicted` gate **drops findings the digest REFUTES** (e.g. "card not keyboard-operable" when it's an `<a>`; "no label" when an `sr-only <label for>` exists) — **no LLM call**. #36 made the label refute STRUCTURAL (a `label_source` field on interactive elements). **Measured ~20% precision lift on objective a11y claims.**
-- **Phase 4 — walkthrough regression (PR #38):** a walkthrough is diffed vs the target's **previous terminal walkthrough** (baseline `walkthroughs.prev_walkthrough_id`, migration **0062**; the diff in `walkthroughs.diff_json`, **0063**) — the `outcome`/`stuck_step` transition + new/resolved **task-blockers** (only VERIFIED blockers count). Read-API `GET /api/audit/walkthroughs/{id}` gains a **`regression` block** (`is_regression`, `new_task_blockers`, `reason_changed`) so a CI `--fail-on-regression` gate keys on it. Metric `auditloop_walkthrough_regressions_total`.
+A SECOND opt-in LLM subsystem *parallel* to P3 vision-notes (they coexist), gated on the SAME
+`OPENROUTER_API_KEY` (no new required secret; buttons hidden + routes 503/403 without it).
+Runs on `AUDITLOOP_LLM_MODELS[0]` (**ONE model; PERSONA is the axis, not model**). Phase 1
+evaluates a completed run as a **task + persona walkthrough** over four code-defined personas;
+Phase 2 infers a per-target audit config the owner confirms; Phase 3 DRIVES the app toward a
+goal (success **OBSERVED via a success-assertion, NEVER LLM-judged**) and runs the personas
+over the driven trace; Phase 4 diffs a walkthrough vs the previous terminal one for a CI
+`--fail-on-regression` gate. Migrations through **0063**.
+**Full detail (tables, routes, metrics, DOM/a11y grounding, LLM token tiers) →
+`reference/persona-evaluator.md`.**
 
-## Drive an INTERNAL, in-cluster DEV_MODE naida (`AUDITLOOP_INTERNAL_ALLOW_HOSTS`) — live 2026-07-18
-The hosted auditloop can DRIVE (Phase-3 driver + persona eval, above) an **internal, in-cluster DEV_MODE naida** for full goal-directed walkthroughs — viewable/interactive on auditloop.zacx.dev **without exposing naida publicly**. The prod SSRF guard blocks private IPs, so a ClusterIP naida is normally unreachable by the driver; a *public* DEV_MODE naida would be an auth-bypassed app on the internet. A narrow exact-host allowlist keeps naida-dev fully internal — the safer topology. Three PRs:
-- **auditloop #26 (`8fd2102`) — SSRF-guard internal-host allowlist.** New env **`AUDITLOOP_INTERNAL_ALLOW_HOSTS`** (comma-separated **EXACT** hostnames, empty default = byte-for-byte prior behavior). In `internal/crawler/ssrf.go` `checkHostIP`, the private-IP refusal became **soft** (bypassable) for an exact-allowlisted host, while **metadata / link-local / multicast / unspecified stay HARD-blocked** (`isHardBlocked`, fail-safe `default:` = hard). Exact map match (NOT suffix), same-domain `AllowedHosts` gate unchanged, redirect hops still IP-checked (composes through `intercept.go checkNav`). Threaded like `AllowLoopback` through crawl/drive/login/login-save guards. Adversarially security-audited: **no 🔴** (metadata-hard-block, exact-host-no-widening, redirect composition all hold; the allowlist is admin env config, NOT user-triggerable). **Reversible** — clear the env var → guard blocks all private again.
-- **homelab-infra #138 (`dec1ff5`) — `naida-dev` on the WORKBENCH cluster** (co-located with auditloop): `clusters/workbench/apps/naida-dev/` reuses image `harbor.homelab.lan/library/naida-ai-demo:latest` with `DEV_MODE=true`+`SEED_DEMO=true` (lazy auto-seeds the `/sales-audits` funnel), emptyDir, `/healthz` probes, ClusterIP **`naida-dev.naida-dev.svc.cluster.local:8080`**, **NO ingress/DNS** (internal-only), its own Flux Kustomization.
-- **homelab-infra #139 (`c603ae6`) — set `AUDITLOOP_INTERNAL_ALLOW_HOSTS=naida-dev.naida-dev.svc.cluster.local`** in the auditloop SOPS secret (`clusters/workbench/apps/auditloop/secrets.enc.yaml`; auditloop loads all config via `envFrom` that secret). A secret change alone doesn't restart the pod → needed `kubectl rollout restart deploy/auditloop` (workbench) to pick up the envFrom change.
-
-**Recipe — drive a fresh internal naida-dev walkthrough** (uses the persona-walkthrough evaluator above): on auditloop.zacx.dev (logged in), create/register a **non-plugin** target with `base_url=http://naida-dev.naida-dev.svc.cluster.local:8080/<path>` (the host auto-becomes its `verified_domain`, matching the allowlist); set the audit-config goal + a reachable **success selector** + `driving_enabled=on` (leave `allow_real_submit=off` = dry-run); trigger the walkthrough; then optionally "Evaluate with personas". naida-dev **re-seeds on restart** (emptyDir + SEED_DEMO) → prefer a **selector-based** success assertion (restart-safe) over a URL/id-based one. Reach naida-dev directly for debugging via `kubectl -n naida-dev port-forward` (no ingress). Activate/deactivate the whole capability via the `AUDITLOOP_INTERNAL_ALLOW_HOSTS` env in the auditloop secret.
-- **Live-verified end-to-end (2026-07-18):** target `naida-dev-internal` (base_url `…:8080/sales-audits`, `driving_enabled=on`, success_selector `#audit-create-form`), dry-run → the hosted auditloop drove the INTERNAL ClusterIP naida → `outcome=success, 2 steps` (planner clicked `button#new-audit-btn` → `#audit-create-form` visible → success), then persona eval over the driven trace.
+### 🔴 Driver safety model (foreground it)
+- **`driving_enabled` default-OFF per-target opt-in** (migration 0054) — enforced at **BOTH**
+  the route (403) AND the generator (defense in depth). Driving is off until the owner opts in.
+- **Dry-run submit-guard is the DEFAULT** — the Fetch interceptor **aborts (network-layer,
+  deterministic) every non-GET/HEAD request** (POST/PUT/PATCH/DELETE). **SCOPED GUARANTEE:**
+  covers every TOP-FRAME HTTP(S) request incl. XHR/`fetch`/`sendBeacon`. **Residual (NOT
+  covered): WebSocket frames, cross-origin (OOPIF) iframe requests, service-worker requests**
+  → for real-submit / prod driving **point at STAGING with a DISPOSABLE account**; do NOT
+  treat dry-run as an absolute "never writes".
+- **Real submits require the loud DEFAULT-OFF `allow_real_submit` flag** (migration 0058;
+  `DryRun = !allow_real_submit`) — two independent opt-ins (drive-at-all vs. mutate-live-data).
+- The **login phase is EXEMPT from the mutation submit-guard** (its credential POST must go
+  through); the SSRF/same-origin IP-guard stays active the ENTIRE time (every nav + redirect).
+  Closed action set, **NO eval**; action budget + per-action/overall timeouts; guard-blocked
+  navs never screenshotted.
 
 ## Deploy — `./deploy.sh` (Flux-native, no kubectl)
 ```bash
@@ -65,55 +95,156 @@ cd ~/workspace/auditloop
 ./deploy.sh          # go vet gate → docker build+push harbor main-<ts> (+:latest) → prints watch cmds
 # SKIP_VET=1 ./deploy.sh   # skip the vet gate (faster; use after you've tested)
 ```
-Flux **image-automation** rolls it in ~1–2 min: the homelab ImageRepository/ImagePolicy `auditloop` (`^main-(?P<ts>[0-9]+)$`) picks the newest tag, and **`flux-system-workbench` ImageUpdateAutomation** bumps the `images:` setter on `clusters/workbench/flux-system/kustomizations/system/auditloop.yaml` + commits to trunk → workbench Flux rolls the pod. Wiring lives in `clusters/homelab/flux-system/image-automation/`.
-- **⚠ `flux-system-workbench` used a READ-ONLY git key** (never pushed in 202d) — fixed this session to `flux-system-write`. If auto-rollout stalls, check `kubectl -n flux-system logs deploy/image-automation-controller | grep read.only` on homelab.
-- **Force a roll** (impatient): `flux -n flux-system reconcile image repository auditloop` + `... image update flux-system-workbench` (homelab kubeconfig), then reconcile source + kustomization `auditloop` (workbench kubeconfig). Watch `-n auditloop get pod -l app=auditloop -o jsonpath='{...spec.containers[0].image}'` until it == the new tag + ready.
+Flux **image-automation** rolls it in ~1–2 min: the homelab ImageRepository/ImagePolicy
+`auditloop` (`^main-(?P<ts>[0-9]+)$`) picks the newest tag, and **`flux-system-workbench`
+ImageUpdateAutomation** bumps the `images:` setter on
+`clusters/workbench/flux-system/kustomizations/system/auditloop.yaml` + commits to trunk →
+workbench Flux rolls the pod. Wiring lives in `clusters/homelab/flux-system/image-automation/`.
+- **⚠ `flux-system-workbench` used a READ-ONLY git key** (never pushed in 202d) — fixed to
+  `flux-system-write`. If auto-rollout stalls, check
+  `kubectl -n flux-system logs deploy/image-automation-controller | grep read.only` on homelab.
+- **Force a roll** (impatient): `flux -n flux-system reconcile image repository auditloop` +
+  `... image update flux-system-workbench` (homelab kubeconfig), then reconcile source +
+  kustomization `auditloop` (workbench kubeconfig). Watch
+  `-n auditloop get pod -l app=auditloop -o jsonpath='{...spec.containers[0].image}'` until it
+  == the new tag + ready.
 - Harness-only PRs (self-audit, docs) **don't need a deploy** (not in the Go binary).
 
 ## Secrets (SOPS, in the `auditloop-secrets` k8s secret + supabase-auditloop secrets)
-Edit via a worktree off `origin/trunk` (the main `~/workspace/homelab-talos` checkout is **~100 commits behind** — never edit there). `sops --set '["stringData"]["KEY"] "val"' clusters/workbench/apps/auditloop/secrets.enc.yaml` with `SOPS_AGE_KEY_FILE=~/workspace/homelab-talos/.secrets/age.key`, then reconcile the `auditloop` ks (workbench).
-- App secret: `OPENROUTER_API_KEY` (dedicated key, **$50 cap** — 🔴 chat-pasted, ROTATE), `AUDITLOOP_ENCRYPTION_KEY` (32-byte hex, P4 creds), `DATABASE_URL`, `S3_*` (endpoint = **bare `minio.homelab.lan`**, NOT a URL — minio-go rejects a scheme), `SUPABASE_*`, `AUDITLOOP_LLM_MODELS` default.
-- GoTrue jwt-secret ↔ app `SUPABASE_JWT_SECRET` are load-bearing-equal; anon key signed by it.
+Edit via a worktree off `origin/trunk` — the main `~/workspace/homelab-talos` checkout is
+**~100 commits behind; never edit there**.
+```bash
+SOPS_AGE_KEY_FILE=~/workspace/homelab-talos/.secrets/age.key \
+  sops --set '["stringData"]["KEY"] "val"' clusters/workbench/apps/auditloop/secrets.enc.yaml
+# then reconcile the `auditloop` ks (workbench). ⚠ a secret change alone does NOT restart the
+# pod — `kubectl rollout restart deploy/auditloop` (workbench) to pick up an envFrom change.
+```
+- App secret: `OPENROUTER_API_KEY` (dedicated key, **$50 cap** — 🔴 chat-pasted, ROTATE),
+  `AUDITLOOP_ENCRYPTION_KEY` (32-byte hex, P4 creds), `DATABASE_URL`, `S3_*`
+  (endpoint = **bare `minio.homelab.lan`**, NOT a URL — minio-go rejects a scheme),
+  `SUPABASE_*`, `AUDITLOOP_LLM_MODELS` default.
+- GoTrue jwt-secret ↔ app `SUPABASE_JWT_SECRET` are **load-bearing-equal**; anon key signed by it.
 
 ## Auth / access
-Supabase invite-only (signup disabled). Smoke login: **`smoke@auditloop.zacx.dev`** / password in the session scratchpad `auditloop-secrets.env` (🔴 chat-exposed → rotate). Create invited users via the GoTrue admin API with a `service_role` JWT signed by the jwt-secret. Bearer header on htmx + `auditloop_at` cookie for full-page nav (naida pattern). `/metrics` is **public** (Prometheus scrape).
+Supabase invite-only (signup disabled). Smoke login: **`smoke@auditloop.zacx.dev`** / password
+in the session scratchpad `auditloop-secrets.env` (🔴 chat-exposed → rotate). Create invited
+users via the GoTrue admin API with a `service_role` JWT signed by the jwt-secret. Bearer
+header on htmx + `auditloop_at` cookie for full-page nav (naida pattern). `/metrics` is
+**public** (Prometheus scrape).
 
 ## Monitoring — cost dashboard + alerts (homelab)
-Data path: **workbench Alloy scrapes the auditloop pod** (`clusters/workbench/apps/alloy/configmap.yaml`, a verbatim clawgate-clone block: `app=auditloop`, `http:8112`, `job=auditloop`) → **remote-writes to homelab Prometheus** → Grafana + PrometheusRule.
-- **⚠ Editing the Alloy config is BLAST-RADIUS** (shared scraper for THC/promptver). Validate with `nix-shell -p grafana-alloy --run "alloy fmt <extracted-river>"` BEFORE, then `kubectl -n monitoring rollout restart deploy/alloy` (workbench) — the rollout succeeding == config loaded OK; confirm the `auditloop` components evaluate with no errors in the logs. The data key is `config.alloy` (strip the nix devshell banner when extracting).
-- Grafana **"auditloop"** dashboard (uid `auditloop`) at **grafana.homelab.lan** — 14 cost panels (LLM cost total / per-model / $/hr / tokens / cost-per-pass) via a `grafana_dashboard:"1"` ConfigMap; Grafana sidecar auto-imports.
-- PrometheusRule `auditloop-alerts` (label `release: kube-prometheus-stack`): **AuditloopLLMSpendHigh** (`increase(auditloop_notes_cost_usd_total[1h]) > 2`, tunable) + **AuditloopScrapeDown** (`up{job="auditloop"}==0`).
-- Metric names: `auditloop_notes_cost_usd_total{model}`, `auditloop_notes_{prompt,completion}_tokens_total{model}`, plus `auditloop_notes_generated_total{model,status}`, `auditloop_runs_total{status}`, `auditloop_plugin_pushes_total{status}`, `auditloop_login_attempts_total{status}`, `auditloop_visual_regressions_total`. Persona subsystem: `auditloop_eval_{generated_total{persona,status},duration_seconds,cost_usd_total{persona},prompt/completion_tokens_total{persona}}` + `auditloop_walkthrough_{runs_total{outcome},steps_total{outcome},duration_seconds,cost_usd_total}`.
-- Query prod Prometheus (it's **distroless — no `sh`**): `kubectl -n monitoring exec prometheus-kube-prometheus-stack-prometheus-0 -c prometheus -- promtool query instant http://localhost:9090 '<query>'`.
+Data path: **workbench Alloy scrapes the auditloop pod**
+(`clusters/workbench/apps/alloy/configmap.yaml`, a verbatim clawgate-clone block:
+`app=auditloop`, `http:8112`, `job=auditloop`) → **remote-writes to homelab Prometheus** →
+Grafana + PrometheusRule.
+- **⚠ Editing the Alloy config is BLAST-RADIUS** (shared scraper for THC/promptver). Validate
+  with `nix-shell -p grafana-alloy --run "alloy fmt <extracted-river>"` BEFORE, then
+  `kubectl -n monitoring rollout restart deploy/alloy` (workbench) — the rollout succeeding ==
+  config loaded OK; confirm the `auditloop` components evaluate with no errors in the logs. The
+  data key is `config.alloy` (strip the nix devshell banner when extracting).
+- Grafana **"auditloop"** dashboard (uid `auditloop`) at **grafana.homelab.lan** — 14 cost
+  panels (LLM cost total / per-model / $/hr / tokens / cost-per-pass) via a
+  `grafana_dashboard:"1"` ConfigMap; Grafana sidecar auto-imports.
+- PrometheusRule `auditloop-alerts` (label `release: kube-prometheus-stack`):
+  **AuditloopLLMSpendHigh** (`increase(auditloop_notes_cost_usd_total[1h]) > 2`, tunable) +
+  **AuditloopScrapeDown** (`up{job="auditloop"}==0`).
+- Metrics: `auditloop_notes_cost_usd_total{model}`,
+  `auditloop_notes_{prompt,completion}_tokens_total{model}`,
+  `auditloop_notes_generated_total{model,status}`, `auditloop_runs_total{status}`,
+  `auditloop_plugin_pushes_total{status}`, `auditloop_login_attempts_total{status}`,
+  `auditloop_visual_regressions_total`. Persona subsystem:
+  `auditloop_eval_{generated_total{persona,status},duration_seconds,cost_usd_total{persona},prompt/completion_tokens_total{persona}}`
+  + `auditloop_walkthrough_{runs_total{outcome},steps_total{outcome},duration_seconds,cost_usd_total}`
+  + `auditloop_walkthrough_regressions_total`.
+- Query prod Prometheus (it's **distroless — no `sh`**):
+  `kubectl -n monitoring exec prometheus-kube-prometheus-stack-prometheus-0 -c prometheus -- promtool query instant http://localhost:9090 '<query>'`.
 
 ## The producers (all merged)
-naida (4 specs), vetr (`vetr-funnel`, PR #108), auditloop **self-audit** (PR #5, `make ux-audit`), **remix** (`remix-funnel`, homelab-infra #119 — remix's Go/chromedp e2e harness in `containers/remix/e2e/uxaudit/`, `make ux-audit`), and **civitai-manager** (`civitai-manager-funnel`) — a Go/chromedp ux-audit harness in `ZacxDev/civitai-manager` `e2e/uxaudit/` (a SEPARATE module so chromedp stays out of the shipped binary), `make ux-audit`, pushes `environment=lab`. Each pushes via P5 — enable with `AUDITLOOP_PUSH_URL=https://auditloop.zacx.dev` + `AUDITLOOP_PUSH_TOKENS='{"<spec>":"<token>"}'` (or `AUDITLOOP_PUSH_TOKEN` for the single-target remix walk); create a plugin target per spec in the UI → one-time token. See the `ux-audit-loops` skill.
+naida (4 specs), vetr (`vetr-funnel`, PR #108), auditloop **self-audit** (PR #5,
+`make ux-audit`), **remix** (`remix-funnel`, homelab-infra #119 — remix's Go/chromedp e2e
+harness in `containers/remix/e2e/uxaudit/`, `make ux-audit`), and **civitai-manager**
+(`civitai-manager-funnel`) — a Go/chromedp ux-audit harness in `ZacxDev/civitai-manager`
+`e2e/uxaudit/` (**a SEPARATE module so chromedp stays out of the shipped binary**),
+`make ux-audit`, pushes `environment=lab`.
+
+Each pushes via P5 — enable with `AUDITLOOP_PUSH_URL=https://auditloop.zacx.dev` +
+`AUDITLOOP_PUSH_TOKENS='{"<spec>":"<token>"}'` (or `AUDITLOOP_PUSH_TOKEN` for the
+single-target remix walk); create a plugin target per spec in the UI → one-time token.
+See the `ux-audit-loops` skill.
+
+## Drive an INTERNAL, in-cluster DEV_MODE naida — live 2026-07-18
+The hosted auditloop can DRIVE (Phase-3 driver + persona eval) a **private ClusterIP** app —
+e.g. an in-cluster DEV_MODE naida at `naida-dev.naida-dev.svc.cluster.local:8080` — viewable
+on auditloop.zacx.dev **without exposing it publicly**. The prod SSRF guard blocks private IPs;
+the exact-hostname env **`AUDITLOOP_INTERNAL_ALLOW_HOSTS`** (in the auditloop SOPS secret) makes
+the private-IP refusal **soft for an exact-allowlisted host only**, while metadata/link-local/
+multicast/unspecified stay **HARD-blocked**. **Reversible** — clear the env → all private
+blocked again. **Recipe, the three PRs (auditloop #26, homelab-infra #138/#139) and the
+live-verified run → `reference/internal-naida-drive.md`.**
 
 ## 🔴 a11y gate only works for pushed runs since #18 (2026-07-17)
-The P2 a11y-rule delta (`new_a11y_rules`, what the CI `--fail-on-regression` gate keys on) reads a **top-level `id`** from each stored a11y finding's detail. Pre-#18, `MapPage` wrapped pushed finding details as `{"detail":..}` (no `id`) → `new_a11y_rules` was **always empty for every plugin push** (silent no-op gate). #18 (`internal/plugin/map.go` `a11yDetail`) preserves a structured pushed a11y detail's `id` and derives one from legacy `"rule — help"` strings. So a producer should push a11y findings with a **structured detail carrying `id`** (the raw axe violation object — what remix does). **Transition:** a target's FIRST diff after #18 deployed compares vs a pre-fix baseline (no ids) → all rules flag "new" once (transient RED, self-heals next run). Verify a pushed-run gate with: clean baseline → exit 0; a genuinely new axe rule → `new_a11y_rules` non-empty → exit 2.
+The P2 a11y-rule delta (`new_a11y_rules`, what the CI `--fail-on-regression` gate keys on)
+reads a **top-level `id`** from each stored a11y finding's detail. Pre-#18, `MapPage` wrapped
+pushed finding details as `{"detail":..}` (no `id`) → `new_a11y_rules` was **always empty for
+every plugin push** (a silent no-op gate). #18 (`internal/plugin/map.go` `a11yDetail`)
+preserves a structured pushed a11y detail's `id` and derives one from legacy
+`"rule — help"` strings.
+
+So a producer should push a11y findings with a **structured detail carrying `id`** (the raw
+axe violation object — what remix does). **Transition:** a target's FIRST diff after #18
+deployed compares vs a pre-fix baseline (no ids) → all rules flag "new" once (transient RED,
+self-heals next run). Verify a pushed-run gate with: clean baseline → exit 0; a genuinely new
+axe rule → `new_a11y_rules` non-empty → exit 2.
 
 ## 🔴 Meta-audit finding — the persona evaluator is screenshot-only by default (durable)
-The persona evaluator reasons over **screenshots only** unless DOM-grounded, so it is BLIND to `sr-only` labels, ARIA, `<a>`/`<button>` semantics, and JS focus/keyboard behaviour → it **invents a11y false positives AND can't confirm its own a11y fixes**. The DOM/a11y grounding (#35 crawl path + #37 driven path + #36 structural label gate, above) fixes the **crawl + driven** paths (the `dropContradicted` gate refutes contradicted findings deterministically). **⚠ plugin-PUSH runs remain screenshot-only (NOT DOM-grounded)** — treat their a11y/keyboard findings with skepticism. Refs: `claudedocs/evaluator-meta-audit-naida-outreach-2026-07-24.md`, `claudedocs/scoping-dom-a11y-evaluator-grounding-2026-07-24.md`.
+The persona evaluator reasons over **screenshots only** unless DOM-grounded, so it is BLIND to
+`sr-only` labels, ARIA, `<a>`/`<button>` semantics, and JS focus/keyboard behaviour → it
+**invents a11y false positives AND can't confirm its own a11y fixes**. The DOM/a11y grounding
+(#35 crawl path + #37 driven path + #36 structural label gate) fixes the **crawl + driven**
+paths (the `dropContradicted` gate refutes contradicted findings deterministically).
+**⚠ plugin-PUSH runs remain screenshot-only (NOT DOM-grounded)** — treat their a11y/keyboard
+findings with skepticism. Refs:
+`claudedocs/evaluator-meta-audit-naida-outreach-2026-07-24.md`,
+`claudedocs/scoping-dom-a11y-evaluator-grounding-2026-07-24.md`.
 
-## Live-bug playbook (patterns that bit this session)
-- **PWA service worker MUST NOT intercept navigations** — page routes 302 (auth/trailing-slash); a cached redirected `/dashboard` shell → "a redirected response was used for a request whose redirect mode is not follow". SW now skips `mode==='navigate'` + caches only `/static/`. Users with the old SW must **unregister** (DevTools → Application → SW) once.
-- **Artifacts stream through the app, NOT presigned MinIO** — presigned `minio.homelab.lan` URLs are internal-only (browser: `ERR_CERT_AUTHORITY_INVALID`). `handleArtifact` streams from either backend over auditloop's public origin; run/diff/login-test views build `/artifacts/{key}` (helper `artifactURL`). Never reintroduce a presign redirect for browser-facing artifacts.
+## Live-bug playbook
+- **PWA service worker MUST NOT intercept navigations** — page routes 302
+  (auth/trailing-slash); a cached redirected `/dashboard` shell → *"a redirected response was
+  used for a request whose redirect mode is not follow"*. SW now skips `mode==='navigate'` +
+  caches only `/static/`. Users with the old SW must **unregister** (DevTools → Application →
+  SW) once.
+- **Artifacts stream through the app, NOT presigned MinIO** — presigned `minio.homelab.lan`
+  URLs are internal-only (browser: `ERR_CERT_AUTHORITY_INVALID`). `handleArtifact` streams from
+  either backend over auditloop's public origin; run/diff/login-test views build
+  `/artifacts/{key}` (helper `artifactURL`). **Never reintroduce a presign redirect for
+  browser-facing artifacts.**
 - **`UID` is a reserved shell var** (zsh) — use `USR`/`uid2` in scripts.
-- Kubeconfigs are under `~/workspace/homelab-infra/`, NOT the repo root.
+- Kubeconfigs are under `~/workspace/homelab-infra/`, **NOT the repo root**.
 
 ## Security posture + deferred hardening (all low, from adversarial reviews)
-Crypto (P4) + credential non-leakage: clean. Upload-XSS + unauth-DoS (P5): clean. The **artifact route is now per-object owner-checked** (both the browser `/artifacts/` proxy and the read-API `/api/audit/artifacts/`), and P4 login-test screenshots were re-keyed `{target_id}/login-tests/{id}.png` (bind authz to the owning target, not a collidable name-slug). Deferred (all low): no per-IP throttle on bad plugin/read tokens (per-token rate limits exist; both limiters are in-memory single-replica); `verified_domains` is user-asserted (real DNS-TXT verification is future — the runtime IP guard closes the practical SSRF).
+Crypto (P4) + credential non-leakage: clean. Upload-XSS + unauth-DoS (P5): clean. The
+**artifact route is now per-object owner-checked** (both the browser `/artifacts/` proxy and
+the read-API `/api/audit/artifacts/`), and P4 login-test screenshots were re-keyed
+`{target_id}/login-tests/{id}.png` (bind authz to the owning target, not a collidable
+name-slug). Deferred (all low): no per-IP throttle on bad plugin/read tokens (per-token rate
+limits exist; **both limiters are in-memory single-replica**); `verified_domains` is
+user-asserted (real DNS-TXT verification is future — the runtime IP guard closes the practical
+SSRF).
 
 ## UI / design system (redesign 2026-07-20, PRs #27–#34)
-A meta-run (auditloop audited its OWN UI → "information overload") drove an 8-PR redesign. **Tailwind bumped 4.3.2 → 4.3.3** (latest; no v5 exists). `static/input.css` now defines `@theme` semantic tokens (`info`/`success`/`warning`/`danger` + `-fg`, `brand-hover`, `card-hover`, `--radius-sm/lg/xl`, `--font-mono`, motion easings/durations) + an `@layer components` set (`.card`/`.card-interactive`, `.btn-primary`/`.btn-secondary`/`.btn-accent`, `.section-title`, `.badge`+`.badge-{info,success,warning,danger}`) + `motion-safe:`-gated keyframes (`animate-enter`/`animate-fade`/`animate-live`) over a `prefers-reduced-motion: reduce` baseline. **Durable convention:** new UI uses these tokens/component classes, NOT raw `blue/red/emerald/amber` utilities; all motion is `motion-safe:`-gated; **NEVER animate an htmx self-poll root** (re-fires every 3s = a blink); progressive disclosure = native `<details>` accordions. Redesigned views: **dashboard** = first-class project cards (favicon/monogram + run-screenshot carousel + auth/status/stats), **target** = overview header + `<details>`-collapsed config (Auth accordion auto-opens when `auth_mode=login`), **run** = a professional report (exec summary → P2 "Changes since" → worst-first per-page cards → "Deeper analysis" = eval+notes). Audit doc: `claudedocs/design-system-audit-2026-07-19.md`.
-
-## Meta-run dogfood — run the persona evaluator on auditloop's OWN UI
-How the redesign findings were generated (~$0.28/pass). `make ux-audit` captures 9 views → boot a LOCAL **persistent** DEV_MODE auditloop with the **REAL `OPENROUTER_API_KEY`** + sqlite/fs storage + `CRAWL_ALLOW_LOOPBACK` → create a plugin target (mint token) → re-run the walk with `AUDITLOOP_PUSH_URL` + `AUDITLOOP_PUSH_TOKENS` pushing to it → `POST /api/runs/{id}/evaluate` (personas `first-time-nontechnical` + `skeptical-evaluator`) + Draft UX notes → collect via the read API or the sqlite DB. Extract the real key from the k8s secret:
-```bash
-KUBECONFIG=~/workspace/homelab-infra/workbench-kubeconfig kubectl get secret auditloop-secrets -n auditloop \
-  -o jsonpath='{.data.OPENROUTER_API_KEY}' | base64 -d
-```
-Findings → `claudedocs/meta-run-ux-findings-2026-07-18.md`.
+A meta-run (auditloop audited its OWN UI → "information overload") drove an 8-PR redesign.
+**Tailwind bumped 4.3.2 → 4.3.3** (latest; no v5 exists). `static/input.css` defines `@theme`
+semantic tokens + an `@layer components` set + `motion-safe:`-gated keyframes.
+**Durable convention: new UI uses these tokens/component classes, NOT raw
+`blue/red/emerald/amber` utilities; all motion is `motion-safe:`-gated; NEVER animate an htmx
+self-poll root** (re-fires every 3s = a blink); progressive disclosure = native `<details>`
+accordions. Full token/component list, the redesigned views, and the meta-run dogfood recipe
+(~$0.28/pass, incl. extracting the real `OPENROUTER_API_KEY` from the k8s secret) →
+`reference/ui-and-meta-run.md`. Audit doc:
+`claudedocs/design-system-audit-2026-07-19.md`.
 
 ## Conventions carried from naida (see naida CLAUDE.md)
-gomponents aliases, htmx (`hx-boost` body, wire on `htmx:load`, `hx-boost=false` on JS forms), cache-busted app.js, dual-dialect sqlite/postgres query layer, atomic claim + startup sweep, adversarial-review-before-merge on every substantive PR. **Every file-modifying subagent gets a worktree.**
+gomponents aliases, htmx (`hx-boost` body, wire on `htmx:load`, `hx-boost=false` on JS forms),
+cache-busted app.js, dual-dialect sqlite/postgres query layer, atomic claim + startup sweep,
+adversarial-review-before-merge on every substantive PR. **Every file-modifying subagent gets a
+worktree.**

--- a/claude/skills/auditloop/reference/internal-naida-drive.md
+++ b/claude/skills/auditloop/reference/internal-naida-drive.md
@@ -1,0 +1,57 @@
+# Drive an INTERNAL, in-cluster DEV_MODE naida (`AUDITLOOP_INTERNAL_ALLOW_HOSTS`)
+
+Live 2026-07-18. Read this when driving a **private, in-cluster** target (naida-dev or any
+other ClusterIP app), or when changing/auditing the internal-host allowlist.
+
+The hosted auditloop can DRIVE (Phase-3 driver + persona eval) an **internal, in-cluster
+DEV_MODE naida** for full goal-directed walkthroughs — viewable/interactive on
+auditloop.zacx.dev **without exposing naida publicly**. The prod SSRF guard blocks private
+IPs, so a ClusterIP naida is normally unreachable by the driver; a *public* DEV_MODE naida
+would be an auth-bypassed app on the internet. A narrow exact-host allowlist keeps naida-dev
+fully internal — the safer topology.
+
+## The three PRs
+- **auditloop #26 (`8fd2102`) — SSRF-guard internal-host allowlist.** New env
+  **`AUDITLOOP_INTERNAL_ALLOW_HOSTS`** (comma-separated **EXACT** hostnames; empty default =
+  byte-for-byte prior behavior). In `internal/crawler/ssrf.go` `checkHostIP`, the private-IP
+  refusal became **soft** (bypassable) for an exact-allowlisted host, while **metadata /
+  link-local / multicast / unspecified stay HARD-blocked** (`isHardBlocked`, fail-safe
+  `default:` = hard). **Exact map match (NOT suffix)**, same-domain `AllowedHosts` gate
+  unchanged, redirect hops still IP-checked (composes through `intercept.go checkNav`).
+  Threaded like `AllowLoopback` through crawl/drive/login/login-save guards.
+  Adversarially security-audited: **no 🔴** (metadata-hard-block, exact-host-no-widening,
+  redirect composition all hold; the allowlist is **admin env config, NOT user-triggerable**).
+  **Reversible** — clear the env var → guard blocks all private again.
+- **homelab-infra #138 (`dec1ff5`) — `naida-dev` on the WORKBENCH cluster** (co-located with
+  auditloop): `clusters/workbench/apps/naida-dev/` reuses image
+  `harbor.homelab.lan/library/naida-ai-demo:latest` with `DEV_MODE=true`+`SEED_DEMO=true`
+  (lazy auto-seeds the `/sales-audits` funnel), emptyDir, `/healthz` probes, ClusterIP
+  **`naida-dev.naida-dev.svc.cluster.local:8080`**, **NO ingress/DNS** (internal-only), its
+  own Flux Kustomization.
+- **homelab-infra #139 (`c603ae6`) — set
+  `AUDITLOOP_INTERNAL_ALLOW_HOSTS=naida-dev.naida-dev.svc.cluster.local`** in the auditloop
+  SOPS secret (`clusters/workbench/apps/auditloop/secrets.enc.yaml`; auditloop loads all
+  config via `envFrom` that secret). ⚠ **A secret change alone doesn't restart the pod** →
+  needed `kubectl rollout restart deploy/auditloop` (workbench) to pick up the envFrom change.
+
+## Recipe — drive a fresh internal naida-dev walkthrough
+On auditloop.zacx.dev (logged in):
+1. Create/register a **non-plugin** target with
+   `base_url=http://naida-dev.naida-dev.svc.cluster.local:8080/<path>` (the host
+   auto-becomes its `verified_domain`, matching the allowlist).
+2. Set the audit-config goal + a reachable **success selector** + `driving_enabled=on`
+   (leave `allow_real_submit=off` = dry-run).
+3. Trigger the walkthrough; then optionally "Evaluate with personas".
+
+⚠ naida-dev **re-seeds on restart** (emptyDir + SEED_DEMO) → prefer a **selector-based**
+success assertion (restart-safe) over a URL/id-based one.
+
+Reach naida-dev directly for debugging via `kubectl -n naida-dev port-forward` (no ingress).
+Activate/deactivate the whole capability via the `AUDITLOOP_INTERNAL_ALLOW_HOSTS` env in the
+auditloop secret.
+
+**Live-verified end-to-end (2026-07-18):** target `naida-dev-internal` (base_url
+`…:8080/sales-audits`, `driving_enabled=on`, success_selector `#audit-create-form`), dry-run
+→ the hosted auditloop drove the INTERNAL ClusterIP naida → `outcome=success, 2 steps`
+(planner clicked `button#new-audit-btn` → `#audit-create-form` visible → success), then
+persona eval over the driven trace.

--- a/claude/skills/auditloop/reference/persona-evaluator.md
+++ b/claude/skills/auditloop/reference/persona-evaluator.md
@@ -1,0 +1,105 @@
+# auditloop persona-walkthrough evaluator — Phases 1–4
+
+PRs #20–#25, #35–#38. All live. Read this when working ON the evaluator/driver
+(phases, tables, migrations, routes, metrics). The **driver safety model** lives in
+SKILL.md — it is a destructive-action warning and is deliberately NOT moved here.
+
+A SECOND opt-in LLM subsystem *parallel* to P3 vision-notes (they coexist), gated on the
+SAME `OPENROUTER_API_KEY` (no new required secret; buttons hidden + routes 503/403 without
+it). Runs on `AUDITLOOP_LLM_MODELS[0]` (**ONE model; PERSONA is the axis, not model**).
+
+Migrations through **0063**: 0059 = `runs.favicon_key` (#33); 0060/0061 = DOM/a11y digest
+(#35/#37); 0062/0063 = walkthrough regression (#38).
+
+## Phase 1 — persona walkthrough
+`internal/eval`, table `page_evaluations`, migrations **0039–0049**. Evaluates a completed
+run as a **task + persona walkthrough**.
+
+Four **code-defined** personas (`eval.Personas`): `first-time-nontechnical` ·
+`returning-power-user` · `skeptical-evaluator` · `accessibility-constrained`.
+
+Per (page × persona) STRUCTURED findings
+`{comprehension, blockers, frictions, top_fix{selector,change,impact}}` + a **verification
+pass** (drops/flags unsubstantiated findings) + a run-level **synthesis "story"**.
+
+- Routes: `POST /api/runs/{id}/evaluate` (body `personas[]`, 503-gated, run must be `done`),
+  `GET /runs/{id}/eval-status` (htmx poll).
+- Read-API: `GET /api/audit/runs/{id}/evaluation` (owner-scoped).
+- Metrics: `auditloop_eval_{generated_total{persona,status},duration_seconds,cost_usd_total{persona},prompt/completion_tokens_total{persona}}`
+  (synthesis logs under `_synthesis`).
+
+## Phase 2 — goal inference + per-target config
+Table `target_audit_config`, migration **0050**; `internal/eval/infer.go`.
+
+`InferConfig` = ONE synchronous LLM call over the latest done run's landing screenshot +
+URL digest → a DRAFT config (product_summary, primary_job, primary_cta, applicable
+personas, inferred/confirmed flags) the owner CONFIRMS/edits (hybrid infer-then-confirm).
+
+- Routes: `POST /api/targets/{id}/audit-config/infer`, `POST /api/targets/{id}/audit-config`.
+- Read-API: `GET /api/audit/targets/{id}/audit-config`.
+- The evaluate trigger **pre-fills** job + personas from the confirmed config.
+
+## Phase 3 — goal-directed DRIVER + personas over the driven trace
+`internal/action` (closed no-eval action set), `crawler.Drive` (LLM-planner loop),
+`internal/walkthrough`; tables `walkthroughs` + `walkthrough_steps`, migrations **0051–0058**.
+
+The driver DRIVES the app toward a goal and reports a **deterministic** outcome — success is
+**OBSERVED via a P4-style success-assertion** (selector / url_contains), **NEVER LLM-judged**;
+`outcome ∈ {success, stuck@stepK, failed}` set by the loop.
+
+- Routes: `POST /api/targets/{id}/walkthrough`, `GET /targets/{id}/walkthrough-status`,
+  `POST /api/targets/{id}/walkthroughs/{wid}/evaluate` (materializes the driven trace as a
+  synthetic run → runs the Phase-1 personas over each driven step, in flow order).
+- Read-API: `GET /api/audit/walkthroughs/{id}` (returns `eval_run_id` → pull persona findings
+  via `…/runs/{eval_run_id}/evaluation`).
+- Metrics: `auditloop_walkthrough_{runs_total{outcome},steps_total{outcome},duration_seconds,cost_usd_total}`.
+
+**Synthetic walkthrough runs (`trigger='walkthrough'`) are EXCLUDED from the P2 baseline
+queries, the findings trend, and the run list.**
+
+## Phase 4 — walkthrough regression (PR #38)
+A walkthrough is diffed vs the target's **previous terminal walkthrough** (baseline
+`walkthroughs.prev_walkthrough_id`, migration **0062**; the diff in `walkthroughs.diff_json`,
+**0063**) — the `outcome`/`stuck_step` transition + new/resolved **task-blockers** (only
+VERIFIED blockers count).
+
+Read-API `GET /api/audit/walkthroughs/{id}` gains a **`regression` block** (`is_regression`,
+`new_task_blockers`, `reason_changed`) so a CI `--fail-on-regression` gate keys on it.
+Metric `auditloop_walkthrough_regressions_total`.
+
+## LLM completion-token tiers
+All per-call via `llm.WithMaxTokens`, all reuse `OPENROUTER_API_KEY`:
+
+| env | value | scope |
+|---|---|---|
+| `AUDITLOOP_LLM_MAX_TOKENS` | 1024 | notes |
+| `AUDITLOOP_LLM_EVAL_MAX_TOKENS` | 2000 | per-page persona gen/verify |
+| `AUDITLOOP_LLM_SYNTH_MAX_TOKENS` | 3000 | run-level synthesis |
+| `AUDITLOOP_LLM_DRIVE_MAX_TOKENS` | ≈256 | per-turn driver planner (one action JSON) |
+
+## 🔴 DOM/a11y grounding for the evaluator
+PRs **#35** (Phase-1 crawl path) + **#37** (Phase-2 driven path) + issue **#36** (structural
+label gate).
+
+The persona evaluator was **screenshot-only**, so it invented a11y false positives. Fix: a
+**bounded DOM/a11y digest** is captured per page/step (`internal/crawler/a11y-digest.js` → an
+`a11y.json` artifact + `pages.a11y_digest_key`, migrations **0060/0061**; the driver's
+per-step digest is carried through `MaterializeWalkthroughRun`), then a **deterministic**
+`internal/eval/verify.go` `dropContradicted` gate **drops findings the digest REFUTES** (e.g.
+"card not keyboard-operable" when it's an `<a>`; "no label" when an `sr-only <label for>`
+exists) — **no LLM call**. #36 made the label refute STRUCTURAL (a `label_source` field on
+interactive elements). **Measured ~20% precision lift on objective a11y claims.**
+
+## ✅ #27 — click-nav SSRF hardening
+The driver's same-origin host-allowlist is now enforced on **every** paused Document nav
+(click-triggered navs included), not just explicit `navigate` actions — `intercept.go`
+`checkNav` gates each nav's host against `GuardConfig.hostAllowed` AND the IP guard
+(`checkHostIP`), closing the click-can-follow-a-public-off-domain-link gap (observed live:
+example.com → iana.org via a click).
+
+## Live-smoke record
+Each feature verified against prod: persona eval 6/6 cells + synthesis story on a
+remix-funnel run · goal inference drafted an accurate remix config · driver example.com
+dry-run → success in 2 steps · PR-B per-step persona findings over the driven trace.
+Smoke path = the **smoke-user JWT** in the session scratchpad `login.json` + the
+**`remix-ci-reader`** read key.

--- a/claude/skills/auditloop/reference/ui-and-meta-run.md
+++ b/claude/skills/auditloop/reference/ui-and-meta-run.md
@@ -1,0 +1,52 @@
+# auditloop UI / design system + the meta-run dogfood
+
+Read this when **writing UI** in auditloop (token/component conventions are durable and
+binding) or when reproducing the meta-run that generated the redesign findings.
+
+## UI / design system (redesign 2026-07-20, PRs #27–#34)
+A meta-run (auditloop audited its OWN UI → "information overload") drove an 8-PR redesign.
+**Tailwind bumped 4.3.2 → 4.3.3** (latest; no v5 exists).
+
+`static/input.css` now defines `@theme` semantic tokens (`info`/`success`/`warning`/`danger`
++ `-fg`, `brand-hover`, `card-hover`, `--radius-sm/lg/xl`, `--font-mono`, motion
+easings/durations) + an `@layer components` set (`.card`/`.card-interactive`,
+`.btn-primary`/`.btn-secondary`/`.btn-accent`, `.section-title`,
+`.badge`+`.badge-{info,success,warning,danger}`) + `motion-safe:`-gated keyframes
+(`animate-enter`/`animate-fade`/`animate-live`) over a `prefers-reduced-motion: reduce`
+baseline.
+
+**🟡 Durable convention:**
+- New UI uses these tokens/component classes, **NOT raw `blue/red/emerald/amber`** utilities.
+- All motion is `motion-safe:`-gated.
+- **NEVER animate an htmx self-poll root** — it re-fires every 3s = a blink.
+- Progressive disclosure = native `<details>` accordions.
+
+Redesigned views:
+- **dashboard** — first-class project cards (favicon/monogram + run-screenshot carousel +
+  auth/status/stats).
+- **target** — overview header + `<details>`-collapsed config (Auth accordion auto-opens when
+  `auth_mode=login`).
+- **run** — a professional report (exec summary → P2 "Changes since" → worst-first per-page
+  cards → "Deeper analysis" = eval+notes).
+
+Audit doc: `claudedocs/design-system-audit-2026-07-19.md`.
+
+## Meta-run dogfood — run the persona evaluator on auditloop's OWN UI
+How the redesign findings were generated (**~$0.28/pass**):
+
+1. `make ux-audit` captures 9 views.
+2. Boot a LOCAL **persistent** DEV_MODE auditloop with the **REAL `OPENROUTER_API_KEY`** +
+   sqlite/fs storage + `CRAWL_ALLOW_LOOPBACK`.
+3. Create a plugin target (mint token).
+4. Re-run the walk with `AUDITLOOP_PUSH_URL` + `AUDITLOOP_PUSH_TOKENS` pushing to it.
+5. `POST /api/runs/{id}/evaluate` (personas `first-time-nontechnical` +
+   `skeptical-evaluator`) + Draft UX notes.
+6. Collect via the read API or the sqlite DB.
+
+Extract the real key from the k8s secret:
+```bash
+KUBECONFIG=~/workspace/homelab-infra/workbench-kubeconfig kubectl get secret auditloop-secrets -n auditloop \
+  -o jsonpath='{.data.OPENROUTER_API_KEY}' | base64 -d
+```
+
+Findings → `claudedocs/meta-run-ux-findings-2026-07-18.md`.

--- a/claude/skills/initiatives/SKILL.md
+++ b/claude/skills/initiatives/SKILL.md
@@ -6,30 +6,38 @@ description: Operate the initiatives subsystem — a durable, cross-repo initiat
 # initiatives subsystem operations
 
 The **durable, queryable counterpart** to the on-demand `/initiatives` scan and the ephemeral
-agent-ops TUI. `session-analysis/initiative-scan.py` is the deterministic engine. **Discovery is
-SESSION/ACTIVITY-FIRST:** initiatives are `(repo, topic)` groups mined from Claude SESSIONS +
-activity telemetry — topic = the transcript `ai-title` (`~/.claude/projects/*/<sid>.jsonl`
-`{"type":"ai-title"}`), recency = last user-turn ts — behind a noise floor (`MIN_SESSION_TURNS=1`,
-`MIN_TOPIC_TOKENS=2`; constants in initiative-scan.py). **SESSIONS-ONLY:** a card is ALWAYS
-session-backed (`source ∈ {session, both}`). A handoff doc of ANY filename can ANCHOR a session
-group (`best_title_match` → `source=both`, adopting its slug/summary/next_step/investigations for
-ENRICHMENT) but NEVER creates or times a standalone card (pure `source=doc` is DROPPED in
-`combine_docs_and_groups`). **Timing is session-only** — `last_touch`/momentum come from the session
-last-user-turn (+ git/telemetry/live signals); `doc_touch_epoch` does NOT feed `last_touch`.
-`undocumented=true` tags a session-only (no doc-anchor) card. Store is **v6** (`source`/`undocumented`
-@v4; `opening_message` genesis prompt @v5; `search_text` — full per-session user-turn text, capped
-6000, search-only-never-rendered — @v6). **Title-drift MERGE is OFF** (`ENABLE_TITLE_DRIFT_MERGE=False`):
-only Pass-1 EXACT-title grouping, so distinct sessions don't over-merge into token-salad slugs.
-Recognizability comes from the card's `start ›`/`you ›` lines + a client-side **FUZZY** `matchQ`
-SEARCH (substring + bounded-Levenshtein ≥4-char + ordered-subsequence ≥5-char, per-token AND) over
-title/summary/status/opening/latest/`search_text`/next_step/slug/repo (a match in the collapsed
-Emerging lane auto-expands it). Fusion (git + telemetry + live tmux → momentum/last-touch/next-step)
-persists to Postgres. Four layers **store → sync → viewer → recaps** + a **router** (signal→initiative)
-+ a **read-only assistant** (Q&A over the store). Code: `~/workspace/devrc/scripts/initiatives/`
-(sync.py, viewer.py, route.py, assistant.py, recap.py, run-sync.sh, run-viewer.sh). Arc:
-`devrc/claudedocs/handoff-initiatives-nextstep-dispatch-shipped-2026-07-26.md` +
-`handoff-initiatives-consolidation-2026-07-22.md` (read first). Everything is
-**workbench-only, serverMode-gated** — the laptop (no `~/.server-mode`) correctly runs none of it.
+agent-ops TUI. Four layers **store → sync → viewer → recaps** + a **router** (signal→initiative)
++ a **read-only assistant**. Code: `~/workspace/devrc/scripts/initiatives/` (sync.py, viewer.py,
+route.py, assistant.py, recap.py, run-sync.sh, run-viewer.sh); engine =
+`scripts/session-analysis/initiative-scan.py`. Everything is **workbench-only,
+serverMode-gated** — the laptop (no `~/.server-mode`) correctly runs none of it.
+Arc: `devrc/claudedocs/handoff-initiatives-nextstep-dispatch-shipped-2026-07-26.md` +
+`handoff-initiatives-consolidation-2026-07-22.md` (read first).
+
+**Reference files** (`~/.claude/skills/initiatives/reference/`, source
+`~/workspace/devrc/claude/skills/initiatives/reference/`) — read on demand:
+- `viewer-board.md` — board layout, states/chips/search, per-card actions, archive lifecycle. Read when changing the viewer UI or debugging a card's lane/state.
+- `clawgate-tasks.md` — the `initiative:<slug>` tag join, dispatch guard, fetch shape + a known thread/FD leak. Read when a dispatched task doesn't link, or when touching tagging.
+- `agent-devpod.md` — devpod deploy, kubeclaw 0.7.x hardening values, image `2026.6.11-py` + web-search-off, identity pin, least-priv DB role. Read when deploying/bumping the agent pod or debugging a crash-loop.
+
+## How a card comes to exist (discovery model)
+- **SESSION/ACTIVITY-FIRST.** Initiatives are `(repo, topic)` groups mined from Claude SESSIONS
+  + activity telemetry. topic = the transcript `ai-title` (`~/.claude/projects/*/<sid>.jsonl`,
+  `{"type":"ai-title"}`); recency = last user-turn ts. Noise floor `MIN_SESSION_TURNS=1`,
+  `MIN_TOPIC_TOKENS=2` (constants in initiative-scan.py).
+- **SESSIONS-ONLY.** A card is ALWAYS session-backed (`source ∈ {session, both}`). A handoff doc
+  of ANY filename can ANCHOR a session group (`best_title_match` → `source=both`, adopting its
+  slug/summary/next_step/investigations for ENRICHMENT) but NEVER creates a standalone card
+  (pure `source=doc` is DROPPED in `combine_docs_and_groups`).
+- **Timing is session-only** — `last_touch`/momentum come from the session last-user-turn
+  (+ git/telemetry/live signals); `doc_touch_epoch` does NOT feed `last_touch`.
+  `undocumented=true` tags a session-only (no doc-anchor) card.
+- **Title-drift MERGE is OFF** (`ENABLE_TITLE_DRIFT_MERGE=False`): only Pass-1 EXACT-title
+  grouping, so distinct sessions don't over-merge into token-salad slugs. Recognizability comes
+  from the card's `start ›`/`you ›` lines + the client-side fuzzy `matchQ` search.
+- Store is **v6**: `source`/`undocumented` @v4; `opening_message` genesis prompt @v5;
+  `search_text` (full per-session user-turn text, capped 6000, search-only-never-rendered) @v6.
+- Fusion (git + telemetry + live tmux → momentum/last-touch/next-step) persists to Postgres.
 
 ## Key facts (verify against live state before asserting)
 
@@ -37,31 +45,29 @@ persists to Postgres. Four layers **store → sync → viewer → recaps** + a *
 |---|---|
 | Code | `~/workspace/devrc/scripts/initiatives/` + the engine `scripts/session-analysis/initiative-scan.py` |
 | Store | **`initiatives` schema in the homelab `mailbox` Postgres** (SAME DB as `mail_actions`; ns `mailbox`, `mailbox-postgres-0`). `KUBECONFIG=$KC_HOMELAB` |
-| Store reach | via **`scripts/mail-actions/_db.py`** (`MailDB`), loaded by **explicit importlib path — NOT `sys.path`** (its sibling `llm.py` shadows repo-cos's). Default = kubectl port-forward; **direct in-cluster mode** (PR #156) via `MAILBOX_PG_HOST` (+`MAILBOX_PG_PORT`) or `MAILBOX_PG_DIRECT=1` — for a future in-cluster agent |
-| Tables | `snapshots` (one row/run: `id,captured_at,host,days_window,telemetry_available`); `initiative_snapshot` (**append-only**, one row/initiative/run: slug/repo/title/momentum/last_touch/commits/merged_prs/open_prs/session_count/telem_*/summary/current_doc/open_investigations/docs + recent_messages/recent_commits jsonb); `recaps` (standalone: `repo,slug` + `identity`/`identity_hash` + `status`/`status_hash` + legacy `recap`); `assistant_log` (standalone audit); **`archived`** (standalone: `repo,slug` PK + `title`/`reason`/`archived_at` — the Phase-2 done/archive set; in NO view → no VIEW_VERSION bump) |
+| Store reach | via **`scripts/mail-actions/_db.py`** (`MailDB`), loaded by **explicit importlib path — NOT `sys.path`** (its sibling `llm.py` shadows repo-cos's). Default = kubectl port-forward; **direct in-cluster mode** (PR #156) via `MAILBOX_PG_HOST` (+`MAILBOX_PG_PORT`) or `MAILBOX_PG_DIRECT=1` |
+| Tables | `snapshots` (one row/run: `id,captured_at,host,days_window,telemetry_available`); `initiative_snapshot` (**append-only**, one row/initiative/run: slug/repo/title/momentum/last_touch/commits/merged_prs/open_prs/session_count/telem_*/summary/current_doc/open_investigations/docs + recent_messages/recent_commits jsonb); `recaps` (standalone: `repo,slug` + `identity`/`identity_hash` + `status`/`status_hash` + legacy `recap`); `assistant_log` (standalone audit); **`archived`** (standalone: `repo,slug` PK + `title`/`reason`/`archived_at`; in NO view → no VIEW_VERSION bump) |
 | Views | **`latest`** = rows from `max(snapshot_id)` (ghost-free; the **viewer** reads this). **`current`** = `DISTINCT ON (repo,slug)` newest across ALL history → includes aged-out "**ghosts**" (the **router** reads this — matching dormant initiatives is desirable). Both DROP+CREATE-guarded by a `COMMENT ON VIEW` version marker (`VIEW_VERSION`/`LATEST_VIEW_VERSION`, both `v6`) |
-| Sync | `initiatives-sync.timer` (`systemd --user`, **workbench**, ~15min, `OnUnitActiveSec=15min`) → `run-sync.sh` → `sync.py --days 5` → `initiative-scan.py --json`. **Lookback = 5d** (2026-07-27, Zach's call — a tight recent board; 14d was too cluttered at ~105 cards, 5d ≈ 48; override via `INITIATIVES_SYNC_DAYS`). Momentum buckets are absolute last-touch ages (<2d active / 2-7d slowing / ≥7d stalled), so **at 5d "stalled" (≥7d) is structurally EMPTY and "cooling"/slowing (2-5d) is the going-quiet triage signal**; widen the window if deep-stalled work is wanted. Double-gated `serverMode && enableInitiativesSync`. **Timeout 600s** (headroom for a cold-recap batch on a widened window; warm runs ~6-15s). 90-day retention prune each run |
+| Sync | `initiatives-sync.timer` (`systemd --user`, **workbench**, `OnUnitActiveSec=15min`) → `run-sync.sh` → `sync.py --days 5` → `initiative-scan.py --json`. **Lookback = 5d** (Zach's call — a tight recent board; 14d was too cluttered; override via `INITIATIVES_SYNC_DAYS`). Momentum buckets are absolute last-touch ages (<2d active / 2-7d slowing / ≥7d stalled), so **at 5d "stalled" (≥7d) is structurally EMPTY and "cooling"/slowing (2-5d) is the going-quiet triage signal**; widen the window if deep-stalled work is wanted. Double-gated `serverMode && enableInitiativesSync`. **Timeout 600s** (headroom for a cold-recap batch; warm runs ~6-15s). 90-day retention prune each run |
 | Sync creds | `run-sync.sh` **runtime sops-decrypts** the ClickHouse **reader** password from homelab-talos trunk (`clusters/homelab/apps/activity/secrets.enc.yaml`, host age key) → `CLICKHOUSE_*` exported → scan runs **telemetry-on**. Every step guarded → missing key/repo/sops ⇒ telemetry-off (still writes a useful handoff+git snapshot). `--input-type yaml` is REQUIRED (mktemp has no `.yaml` ext) |
 | Viewer | `initiatives-viewer.service` (`systemd --user`, **workbench**, serverMode-gated, `Restart=on-failure`) → `run-viewer.sh` → `viewer.py` (stdlib `http.server`). **LIVE at http://192.168.50.250:8899/** |
-| Viewer bind | ⚠ binds the workbench **eth1 LAN IP `192.168.50.250`** — **NOT `192.168.50.94`, which is a HOMELAB node** (kube-apiserver/NodePorts/ClickHouse); binding `.94` → `OSError: Cannot assign requested address` crash-loop (bit us in #140→#141). See `[[workbench-lan-ip]]`. Internal work data — deliberately NOT wired to the public gateway |
-| Viewer board ("triage" board) | **Default view GROUPED by repo** (collapsible; `VIEW_KEY` v3; flat/recency in the toggle). Cards are **two-line collapsed** (state glyph + slug + title + age; one actionable `line2`) → **click to expand** the full current/start/you/live/PRs/investigations detail. **`derive_state`** per card (precedence `needs_you > stalled > slowing > active`; ⚠ needs_you=orange, ◑ stalled=gray ≥7d, ~ cooling=yellow 2-7d, → active=blue). **`live` is a separate OVERLAY BADGE** (● green, render-time tmux overlay via `buildLiveNow`), NOT a state. **Layout = 4 sections:** §3 `⚠ Needs you` **PINNED top** (rendered once, excluded from groups) → §4 **`● N live · newest:<task>` ONE-LINE strip** (`LIVENOW_OPEN_KEY='-v2'`, click→top-6 `＋more` activity-sorted; rows clickable→`focusCard`; scoped by the active filter) → §5 active cards grouped by repo (**live-badged float to top**, stable `vis.sort`) → §6 `~ Cooling` collapsed fold (slowing+stalled). **State chips** `[⚠ Needs you][◑ Stalled][~ Cooling][→ Active][All]` (filter, compose AND with search; `⚠ Needs you` pulses when >0) + a **SEPARATE `[✓ Archived]`** view toggle. **Search** (`matchQ`) AND-composes with the chip, scopes the Live-now rows too, and **auto-widens to All** when a filter hides every hit (`shouldWidenFilter`, sticky); the active chip stays visible+highlighted at 0; matches show a `match: …snippet…` reason. **Per-card actions state-driven** (`cardActions`): needs_you `[resolve][⤴ dispatch?][⤓ archive]` (`[resolve]` prefills+submits the `/api/ask/stream` sidebar), stalled/cooling `[⤴ resume?][drop][⤓ archive]` (`resume`=`/api/dispatch` with a RESUME-framed body via `dispatch.py _task_lead`), active `[⤴ dispatch?][⤓ archive]` (`?`=only when a grounded rec exists); `drop`/`⤓ archive` are **two-tap** (`armConfirm`). **`needs_you` is SEVERITY-aware** — `assistant.SEVERITY_MARKERS` over `status`+`next_step` promote an active RISK card with a `⚠ risk` cue (single-sourced from `assistant._severity_hits`; `tool_blocked_on_me` = `_blocking_hits OR _severity_hits`, so `/api/ask` "blocked/at-risk" has PARITY with the chip). **Emerging/undocumented = an inline `emerging` badge**; the glyph **legend is behind a `?`** toggle (`.legend-toggle`, hidden by default). **ARCHIVE lifecycle:** `POST /api/archive {repo,slug,reason?}` (viewer-side, never-500) hides the card + persists to the standalone `initiatives.archived` table (`archive.py`: `archive`/`unarchive`/`read_archived`/`list_archived`); **suppress IFF archived AND `last_touch <= archived_at`** → **auto-resurfaces on new activity**; `[✓ Archived]` opens the archived view (`POST /api/unarchive` restores). ⚠ `load_latest()` returns **`(rows, archived)`** — 2 callers (`DataProvider.snapshot`, `assistant.load_initiatives`) handle the tuple. Plus recaps (identity primary / status secondary), a `POST /refresh` ↻, `POST /api/dispatch`, the `POST /api/ask` sidebar. Full dogfood-evolution history: `devrc/claudedocs/handoff-initiatives-nextstep-dispatch-shipped-2026-07-26.md`. |
+| Viewer bind | ⚠ binds the workbench **eth1 LAN IP `192.168.50.250`** — **NOT `192.168.50.94`, which is a HOMELAB node** (kube-apiserver/NodePorts/ClickHouse); binding `.94` → `OSError: Cannot assign requested address` crash-loop (bit us in #140→#141), and **a `127.0.0.1` smoke test will NOT catch it**. See `[[workbench-lan-ip]]`. Internal work data — deliberately NOT wired to the public gateway |
+| Viewer board | Grouped-by-repo triage board, two-line collapsed cards, 4 sections, state chips + fuzzy search, state-driven per-card actions, archive lifecycle. **Full detail → `reference/viewer-board.md`** |
 | Recap model | **`vllm-recap`** — homelab vLLM, **ns `promptver`, svc `vllm-recap:8000`, served model `recap` = Qwen2.5-7B-Instruct-AWQ**. Wired via the unit env (`INITIATIVES_RECAP_ENABLED=1`, `RECAP_NAMESPACE=promptver`, `RECAP_SERVICE=svc/vllm-recap`, `RECAP_SERVICE_PORT=8000`, `RECAP_MODEL=recap`) — recap.py's in-code defaults are PLACEHOLDERs |
 | Router | `route.py` — `route(signal,repo,limit)` / `rank_matches()` / `classify()`. Reads `initiatives.current`; scoring single-sourced from the scan's `best_title_match` (word-equality, no stemming). Read-only, suggests-never-acts. Wired into repo-cos digests (#138) + mail-actions (#139, adds `related_initiative` col) |
-| Assistant (Phase 1 agent) | **PRIMARY `/api/ask` = a model-driven OpenClaw devpod** (homelab ns `devpod-initiatives`, svc `initiatives-devpod:18789`, `openclaw/initiatives`, **DeepSeek V4 Pro via OpenRouter**). The MODEL selects which deterministic skill-tool(s) to run (incl. MULTIPLE for compound Qs) — the tools are `scripts/initiatives/skills/query.py` (reuses assistant.py's `run_tool`/`build_facts`/`sources_of`), reached via `_db.py` **direct in-cluster mode** (#156) with a **least-priv `initiatives_agent` PG role** (SELECT-only on `initiatives.*`). Viewer's `agent_client.py` proxies via kubectl port-forward + gateway token `sha256("gw-"+HOOKS_TOKEN)`, **streams** the answer (SSE `/api/ask/stream`) and **renders markdown**; **graceful FALLBACK** to the deterministic regex `assistant.py` if the devpod is down. Every ask audit-logged to `initiatives.assistant_log` (`intent=agent`). Manifests: `homelab-talos clusters/homelab/apps/agent-pods/initiatives/`. This RETIRED the brittle regex classifier from the routing role (kept only as fallback). Phase 2 (write/dispatch) stays deferred behind a structural server-side gate. Full arc: `handoff-initiatives-agent-phase1-2026-07-24.md` |
+| Assistant (Phase 1 agent) | **PRIMARY `/api/ask` = a model-driven OpenClaw devpod** (ns `devpod-initiatives`, svc `initiatives-devpod:18789`, `openclaw/initiatives`, **DeepSeek V4 Pro via OpenRouter**). The MODEL selects which deterministic skill-tool(s) to run (incl. MULTIPLE for compound Qs) — the tools are `scripts/initiatives/skills/query.py` (reuses assistant.py's `run_tool`/`build_facts`/`sources_of`), reached via `_db.py` **direct in-cluster mode** (#156) with a **least-priv `initiatives_agent` PG role** (SELECT-only on `initiatives.*`). Viewer's `agent_client.py` proxies via kubectl port-forward + gateway token `sha256("gw-"+HOOKS_TOKEN)`, **streams** the answer (SSE `/api/ask/stream`) and **renders markdown**; **graceful FALLBACK** to the deterministic regex `assistant.py` if the devpod is down. Every ask audit-logged to `initiatives.assistant_log` (`intent=agent`). Phase 2 (write/dispatch) stays deferred behind a structural server-side gate. **Deploy/hardening → `reference/agent-devpod.md`** |
 
 ## status
 ```bash
-export KUBECONFIG=$KC_HOMELAB   # homelab-kubeconfig; the store is only reachable via port-forward here
-# units (workbench):
+export KUBECONFIG=$KC_HOMELAB   # the store is only reachable via port-forward here
 systemctl --user status initiatives-sync.timer initiatives-viewer.service --no-pager | head -30
 systemctl --user list-timers | grep initiatives
-journalctl --user -u initiatives-sync.service -n 30 --no-pager      # last sync; grep -i telemetry for on/off
+journalctl --user -u initiatives-sync.service -n 30 --no-pager      # grep -i telemetry for on/off
 curl -sf http://192.168.50.250:8899/healthz; echo                   # viewer health
-# is the store fresh? (read via _db.py port-forward)
 PSQL='kubectl -n mailbox exec mailbox-postgres-0 -- psql -U mailbox -d mailbox -c'
 $PSQL "select id,captured_at,host,days_window,telemetry_available from initiatives.snapshots order by id desc limit 5;"
 $PSQL "select count(*) from initiatives.latest;"                    # viewer's set (ghost-free)
-$PSQL "select count(*) from initiatives.current;"                   # router's set (may exceed latest by N ghosts)
+$PSQL "select count(*) from initiatives.current;"                   # router's set (latest + N ghosts)
 $PSQL "select repo,slug,momentum,last_touch from initiatives.latest order by last_touch desc limit 15;"
 $PSQL "select repo,slug,left(identity,60),left(status,50) from initiatives.recaps order by slug limit 10;"
 ```
@@ -71,7 +77,7 @@ $PSQL "select repo,slug,left(identity,60),left(status,50) from initiatives.recap
 ```bash
 # run a sync NOW (both routes go through run-sync.sh → telemetry-on):
 KUBECONFIG=$KC_HOMELAB systemctl --user start initiatives-sync.service
-#   confirm telemetry-on: journalctl --user -u initiatives-sync.service | grep -i "telemetry\|recap"
+#   confirm: journalctl --user -u initiatives-sync.service | grep -i "telemetry\|recap"
 #   expect "reader creds provisioned — telemetry-on" and a "recap N new/M cached" line.
 # dry-run the transform without writing (needs the DB port-forward for the read only):
 nix-shell -p 'python3.withPackages(p:[p.psycopg2 p.requests])' --run \
@@ -84,7 +90,7 @@ nix-shell -p 'python3.withPackages(p:[p.psycopg2 p.requests])' --run \
 # assistant PRIMARY path = the OpenClaw agent devpod (ask via the viewer):
 curl -s -X POST http://192.168.50.250:8899/api/ask -H 'Content-Type: application/json' \
   -d '{"question":"whats stalled and waiting on me"}' | python3 -m json.tool   # intent=agent when the devpod answered
-# agent devpod status/logs/gateway (homelab):
+# agent devpod status/logs (homelab):
 KUBECONFIG=$KC_HOMELAB kubectl -n devpod-initiatives get pods,helmrelease -A 2>/dev/null; \
   KUBECONFIG=$KC_HOMELAB kubectl -n flux-system get helmrelease initiatives-agent
 POD=$(KUBECONFIG=$KC_HOMELAB kubectl -n devpod-initiatives get pods -l app.kubernetes.io/instance=initiatives -o name | tail -1)
@@ -103,145 +109,80 @@ nix-shell -p 'python3.withPackages(p:[p.psycopg2 p.requests])' --run \
 # force an out-of-band viewer refresh (same as the ↻ button):
 curl -sf -X POST http://192.168.50.250:8899/refresh; echo
 
-# --- NEXT-STEP RECOMMENDATION + DISPATCH (Phase 2a, shipped 2026-07-26, origin/main 835fe0c) ---
-# Every card carries a GROUNDED recommended next step (nextstep.py, read-only): documented cards show
-# their parsed `next_step`; EMERGING cards show a distinct `next (suggested) ›` line inferred from a real
-# field (open-PR/investigation/last-prompt/status/stalled) — NEVER invented. Chat: "what should I do next
-# on <initiative>" → the `recommend_next_step` tool (agent + regex fallback).
-# ONE-TAP DISPATCH → a clawgate Task card (viewer-side; the VIEWER holds ~/.claude/clawgate.env, the
-#   in-cluster devpod does NOT). Two human gates: this creates a card; you still tap Dispatch in clawgate.
+# ONE-TAP DISPATCH → a clawgate Task card (Phase 2a, origin/main 835fe0c). The VIEWER holds
+#   ~/.claude/clawgate.env; the in-cluster devpod does NOT. Two human gates: this creates a
+#   card; you still tap Dispatch in clawgate.
 curl -s -X POST http://192.168.50.250:8899/api/dispatch -H 'Content-Type: application/json' \
   -d '{"repo":"<repo full path OR repo_name>","slug":"<slug>"}'   # 200 {ok,task_id} / 400 / 404 / 502
 # dispatch.py mirrors repo-cos/clawgate.py: POST clawgate /api/tasks {directory(=label),body,repo?,tags} —
 #   model OMITTED → clawgate default deepseek. Confirm the card: GET {CLAWGATE_API_URL}/api/tasks (Bearer).
-# Full arc: devrc/claudedocs/handoff-initiatives-nextstep-dispatch-shipped-2026-07-26.md
-
-# --- LINKED CLAWGATE TASKS (PR #202, origin/main e3e7b07) — the CONSUMER side of the tag ---
-# tasks.py joins initiatives → clawgate tasks on the `initiative:<slug>` tag. Rendered ONLY in the
-#   EXPANDED card detail (the collapsed card stays two-line for scanning).
-# 🔴 The join is EXACT / case-sensitive / VERBATIM — a plain dict lookup on the raw slug, no case
-#   folding. `initiative:Foo` keys `Foo` and therefore NEVER matches the ledger slug `foo`. That is
-#   why repo-cos's `taggable_slug` drops any non-lowercase slug rather than lowercasing it.
-# ⤴ dispatch is GUARDED: when linked tasks are open it arms a two-tap "already has N open task —
-#   dispatch anyway?" via the pre-existing `armConfirm` (armConfirm is NOT from #202).
-#   OPEN_STATUSES = ("open","in_progress","ready_for_review") — a closed ALLOW-list, so an unknown
-#   status is non-blocking (fail-open). ⚠ clawgate has NO `dismissed` task status; the vocabulary is
-#   exactly {open,in_progress,ready_for_review,complete} and dismissing DELETES. (`dismissed` exists
-#   only in clawgate's unrelated *suggestions* table.)
-# dispatch.py tags what it creates (`initiative:<slug>`, exact-or-nothing) and FAILS OPEN TWICE:
-#   build_tags emits [] on any doubt, then post_task retries ONCE untagged on HTTP 400 only.
-#   ⚠ its normalize_tag/normalize_tags are a DELIBERATE DUPLICATE of repo-cos/clawgate.py (the
-#   documented source of truth) — change both together. They have ALREADY DRIFTED: repo-cos gained
-#   `guard_tags` (per-tag, rejects non-list/non-string input, #206); dispatch.py has no equivalent.
-# Fetch shape: ONE fetch per BOARD RENDER (not per card — the board carries ~140 cards), 2.0s
-#   WALL-CLOCK deadline, 1 MiB cap, performed OUTSIDE `DataProvider._lock` (deliberate — keep it
-#   that way), 30s cache keyed on last ATTEMPT, serve-stale-on-failure, single-flight. Silent
-#   best-effort: any clawgate failure logs to stderr and the board renders unchanged.
-# 🟡 KNOWN, MEASURED, NOT FIXED: the abandoned fetch worker does NOT self-terminate. `resp.read(n)`
-#   blocks on a BufferedReader until n bytes or EOF, so with READ_CHUNK=64 KiB the wall-clock
-#   re-check is never reached for bodies >=64 KiB (measured: 6 fetches → 6 live threads, +12 FDs,
-#   none reclaimed). Bounded today only because the real payload is ~16 KB. Fix = `read1()`.
-#   Also: serve-stale has NO upper age bound (clawgate down → last good map served forever), and
-#   `group_by_slug` keys on slug ALONE, not (repo, slug) — zero collisions measured, still latent.
-# ⚠ `assistant.py` is MISSING from the viewer's X-Restart-Triggers (nix/home.nix) though it is an
-#   importlib-cached long-lived sibling → an assistant.py-only change switches cleanly and silently
-#   does nothing until a manual restart. Same trap the block's own comment warns about for tasks.py.
+# Linked-task join, dispatch guard, fetch shape + the known leak → reference/clawgate-tasks.md
 ```
+
+**Grounded next step (nextstep.py, read-only):** every card carries one — documented cards
+show their parsed `next_step`; EMERGING cards show a distinct `next (suggested) ›` line
+inferred from a real field (open-PR/investigation/last-prompt/status/stalled) — **NEVER
+invented**. Chat: *"what should I do next on \<initiative\>"* → the `recommend_next_step` tool
+(agent + regex fallback).
 
 ## deploy a change
 ```bash
 # scripts (sync.py/route.py/assistant.py/recap.py + wrappers) ship via home-manager:
 home-manager switch --flake ~/workspace/devrc --impure          # workbench; or scripts/ship.sh after merge
-# after a viewer.py change, restart the long-running service (X-Restart-Triggers covers viewer.py+run-viewer.sh
-# on switch, but restart explicitly if you edited out of band):
+# after a viewer.py change (X-Restart-Triggers covers viewer.py+run-viewer.sh on switch;
+# restart explicitly if you edited out of band):
 systemctl --user restart initiatives-viewer.service
-# to regenerate the store immediately (e.g. after a sync.py or recap change):
+# regenerate the store immediately (e.g. after a sync.py or recap change):
 KUBECONFIG=$KC_HOMELAB systemctl --user start initiatives-sync.service
 # tests: scripts/initiatives/tests/ via nix-shell pytest (pure fixtures; query/agent_client/assistant/sync)
-
-# --- AGENT DEVPOD deploy (homelab) ---
-# GitOps record is on homelab-infra `origin/trunk` (verified: the 0.7.x-values hardening + 2026.6.11-py
-#   initiatives helmrelease + task-drafter hardening are all ancestors of origin/trunk). ⚠ the LOCAL
-#   ~/workspace/homelab-talos checkout may be STALE/dirty (another session left uncommitted files + a
-#   behind `trunk`) — always base edits on `origin/trunk` (fetch first), never the local working copy.
-#   agent-pods flux is suspend=true, so trunk changes are applied SURGICALLY by hand (below).
-# query.py/skill ship in devrc → the devpod autoPulls `main` (~5min) — merge to devrc main, done.
-# HelmRelease / secret / identity-pin (extraInitCommands) changes: edit the manifest, then apply
-# SURGICALLY (agent-pods flux Kustomization is suspend=true → git won't auto-apply):
-KUBECONFIG=$KC_HOMELAB kubectl apply -f ~/workspace/homelab-talos/clusters/homelab/apps/agent-pods/initiatives/helmrelease.yaml
-KUBECONFIG=$KC_HOMELAB kubectl -n flux-system annotate helmrelease initiatives-agent reconcile.fluxcd.io/requestedAt="$(date +%s)" --overwrite
-# secret is sops-encrypted in git BUT the workbench lacks the homelab age PRIVATE key → apply the
-#   live secret from plaintext via kubectl (git .enc.yaml is the GitOps record); encrypt with
-#   `sops --encrypt --age <homelab-recipient> --config /dev/null` (no agent-pods creation_rule).
+# agent devpod deploy → reference/agent-devpod.md
 ```
 
 ## ⚠ gotchas (each cost real time)
-- **Running `run-viewer.sh` from an INTERACTIVE shell needs `env -u shellHook`.** `homelab-talos/.envrc` is `use flake`, and that flake's `shellHook` exports a **relative** `KUBECONFIG=homelab-kubeconfig`. The wrapper only defaults (`${KUBECONFIG:-<absolute>}`) so it defers to the relative one, and the inner `nix-shell -p …` re-executes the **inherited `$shellHook`**, re-exporting it even if you fixed `KUBECONFIG` first — the store read then fails silently from any cwd that isn't the repo root. `env -u shellHook ./run-viewer.sh`. **Systemd is unaffected** (minimal env, no direnv).
-- **Don't pin absolute slug counts in docs or tests.** The live store drifted **139→144 over ~3 days**; every doc or assertion carrying a total goes stale within days. Assert/state **properties** (floors, set-equality, ratios) instead — this already rotted repo-cos's corpus tests three days running before they were rewritten.
-- **Hardening = first-class kubeclaw 0.7.x chart VALUES (postRenderers + hand-written CNP RETIRED).**
-  The chart (kubeclaw ≥0.7.0) exposes the three knobs the initiatives agent uses directly in `values`:
-  **`securityContext`** (toYaml full-replace → `capabilities.drop:[ALL]` + `allowPrivilegeEscalation:false`
-  + seccomp `RuntimeDefault`; CapEff=0 verified), **`tls.verify:true`** (→ `NODE_TLS_REJECT_UNAUTHORIZED=1`,
-  overriding the chart's historical hardcoded `0`), and **`networkPolicy`** (Cilium egress default-deny +
-  per-agent FQDN allowlist: kube-dns[+rules.dns]/apiserver/mailbox-postgres:5432/openrouter.ai/github.com/
-  api.github.com/codeload/*.githubusercontent/*.debian.org on 443+80). Verify in-pod: `curl openrouter.ai`→200,
-  `curl example.com`→blocked. This REPLACED the old `spec.postRenderers` strategic-merge (needed because
-  `extraEnv` duplicate-keys made SSA reject the Deployment) + the standalone `network-policy.yaml` — both
-  DELETED (functional no-op: identically hardened, cleaner). ⚠ `networkPolicy.enabled` with an EMPTY
-  allowlist silently bricks egress to DNS+API only — always set the full `egress.fqdns`/`endpoints`
-  (kubeclaw 0.7.1 adds a fail-loud guard for this; 0.7.0 does not). `cap-drop:[ALL]` is safe ONLY because
-  deps are baked (no dpkg at runtime); **non-root is DEFERRED** — the chart hardcodes `/root/.openclaw|.ssh|
-  .kube` writes with no runAsUser knob (needs a chart change).
-- **Image `2026.6.11-py` + web-search OFF (the two are coupled).** query.py's deps (psycopg2/requests) are
-  BAKED into the derived image (`initiatives/image/Dockerfile`, base `ghcr.io/zacxdev/openclaw-image`) so
-  there is NO apt-at-init to race the Cilium FQDN/DNS warmup — this is why `cap-drop:[ALL]` is safe.
-  **`tools.web.search.enabled:false`** is load-bearing for booting 2026.6.11 under the locked egress: with
-  search on, `openclaw doctor --fix` (pre-gateway) auto-enables a brave/perplexity plugin and does a blocking
-  `npm view @openclaw/<plugin>` fetch to registry.npmjs.org (NOT allowlisted) → doctor hangs → gateway never
-  binds :18789 → crash-loop. Off = no plugin auto-fetch → doctor completes offline → gateway binds. The
-  read-only Q&A agent never needs web search anyway; egress stays locked (no npm allowlist added).
-  `config.updateCheckOnStart:false` is set belt-and-suspenders. Rollback tag `2026.6.1-py` (a first 2026.6.11
-  attempt rolled back before web-search-off was found). The shared `openclaw-image` base rebuilds via
-  `--legacy-peer-deps` (npm arborist `edgesOut` bug on node:22-slim, openclaw-image #3). To bump OpenClaw
-  further: keep web-search off + egress locked, verify the gateway binds. (Historical: if you ever reintroduce
-  apt-at-init it RACES the Cilium policy — baking deps mooted this.)
-- **Agent identity must be PINNED or first-person questions confabulate.** OpenClaw ships a generic
-  "figure out who you are" onboarding (`BOOTSTRAP.md` + empty `IDENTITY.md` in `/data/workspace`). Without
-  a pin, "what am **I** working on" made the agent read BOOTSTRAP and answer about ITSELF ("fresh start, who
-  are you?"). Fix (in `extraInitCommands`): `rm BOOTSTRAP.md` + overwrite `AGENTS.md`/`IDENTITY.md` so the
-  agent is "already born" as the read-only initiatives assistant and "I/me/my/you" = **Zach**. Clearly-matching
-  Qs ("blocked on me", "whats stalled") routed to the skill fine; ambiguous first-person ones did not.
-- **Agent DB reach = least-priv SELECT-only role → the audit log write stays VIEWER-side.** The
-  `initiatives_agent` PG role is SELECT-only; `CREATE TABLE IF NOT EXISTS` (assistant.py's log self-heal)
-  needs CREATE on the schema **even when the table exists** (it errors before the existence check), so the
-  agent can't write `assistant_log`. `agent_client._log_agent_ask` writes it from the viewer (full mailbox
-  creds). Don't grant the agent role INSERT to "fix" a missing audit row — check the viewer path.
-- **Repo-name tokens are STRIPPED before a live tmux pane → initiative match** (2026-07-28). `best_title_match`'s `title_overlap >= 2` gate was clearing on the REPO-NAME tokens alone (civitai-manager → {civitai, manager}) — which every session AND initiative in the repo shares — so a generic pane ("Continue civitai-manager development work") got badged `● live` on an unrelated card (the SECURITY-AUDIT one) while that session did other work. Fix in `match_tmux_to_initiatives`: `ptoks -= set(text_tokens(os.path.basename(repo)))` so a pane must share a DISTINGUISHING word to attach; a pane with none falls to `live_unmatched` (honest "live but untied" miss, per the scan's "a wrong tag costs more than a miss"). ⚠ **the VIEWER caches the scan module in memory** (`attach_tmux` reuses `scan.match_tmux_to_initiatives` verbatim; importlib-loaded once at startup) — a scan-only change ships via `home-manager switch` but the viewer's X-Restart-Triggers only cover `viewer.py`+`run-viewer.sh`, NOT `initiative-scan.py`, so you MUST `systemctl --user restart initiatives-viewer.service` for a scan/matching fix to take effect in the live overlay (a fresh sync alone won't do it — the live badge is a render-time overlay, not stored).
-- **Momentum times from the last genuine USER-turn timestamp, NOT the transcript file mtime** (PR #149).
-  Claude Code rewrites session `.jsonl` files in place (title/mode metadata) → mtime-driven momentum read
-  18-day-idle sessions as "active ~47m ago". `initiative-scan.py` parses `turns[].ts` for the last user turn;
-  mtime is a rare fallback only (mirrors `doc_touch_epoch`). Buckets: **<2d active / 2–7d slowing / ≥7d
-  stalled**; the scan's ~4-day window filters older initiatives out of the view.
+- **🔴 X-Restart-Triggers does NOT cover every long-lived sibling — a "shipped" change can be silently INERT.**
+  The viewer importlib-caches its siblings at startup and `nix/home.nix` only triggers on
+  `viewer.py`+`run-viewer.sh`. So a change to **`initiative-scan.py`** (the viewer's `attach_tmux`
+  reuses `scan.match_tmux_to_initiatives` verbatim for the live overlay) or **`assistant.py`** switches
+  cleanly and does **nothing** until you `systemctl --user restart initiatives-viewer.service`.
+  A fresh sync alone won't do it — the live badge is a render-time overlay, not stored.
+- **Running `run-viewer.sh` from an INTERACTIVE shell needs `env -u shellHook`.** `homelab-talos/.envrc`
+  is `use flake`, and that flake's `shellHook` exports a **relative** `KUBECONFIG=homelab-kubeconfig`.
+  The wrapper only defaults (`${KUBECONFIG:-<absolute>}`) so it defers to the relative one, and the
+  inner `nix-shell -p …` re-executes the **inherited `$shellHook`**, re-exporting it even if you fixed
+  `KUBECONFIG` first — the store read then fails silently from any cwd that isn't the repo root.
+  Use `env -u shellHook ./run-viewer.sh`. **Systemd is unaffected** (minimal env, no direnv).
+- **Don't pin absolute slug counts in docs or tests.** The live store drifted **139→144 over ~3 days**;
+  every doc or assertion carrying a total goes stale within days. Assert/state **properties** (floors,
+  set-equality, ratios) instead — this already rotted repo-cos's corpus tests three days running.
 - **Schema migration = DROP+CREATE the views, never CREATE OR REPLACE.** Adding a column to
-  `initiative_snapshot` reorders the `latest`/`current` views' columns; `CREATE OR REPLACE VIEW` REJECTS a
-  column-name/order change (`cannot change name of view column …`) → froze the whole store on the v1→v2
-  deploy. Fix: **bump the `VIEW_VERSION`/`LATEST_VIEW_VERSION` marker** so `_ensure_view` does DROP VIEW IF
-  EXISTS + CREATE (ACCESS EXCLUSIVE, momentary). `recaps` + `assistant_log` are **standalone tables** (in no
-  view) → adding columns there needs NO view-marker bump. **Validate a migration by replaying it on a
-  throwaway Postgres first** — the unit fixtures only assert SQL strings, they can't catch this.
-- **Viewer bind IP** — `192.168.50.250` (workbench eth1), **NOT `192.168.50.94`** (a homelab node). See the
-  Key-facts row; crash-loops if wrong and a 127.0.0.1 smoke test won't catch it.
+  `initiative_snapshot` reorders the `latest`/`current` views' columns; `CREATE OR REPLACE VIEW`
+  REJECTS a column-name/order change (`cannot change name of view column …`) → froze the whole store
+  on the v1→v2 deploy. Fix: **bump the `VIEW_VERSION`/`LATEST_VIEW_VERSION` marker** so `_ensure_view`
+  does DROP VIEW IF EXISTS + CREATE (ACCESS EXCLUSIVE, momentary). `recaps` + `assistant_log` are
+  **standalone tables** (in no view) → adding columns there needs NO view-marker bump. **Validate a
+  migration by replaying it on a throwaway Postgres first** — the unit fixtures only assert SQL
+  strings, they can't catch this.
+- **Repo-name tokens are STRIPPED before a live tmux pane → initiative match** (2026-07-28).
+  `best_title_match`'s `title_overlap >= 2` gate was clearing on the REPO-NAME tokens alone
+  (civitai-manager → {civitai, manager}) — which every session AND initiative in the repo shares —
+  so a generic pane ("Continue civitai-manager development work") got badged `● live` on an unrelated
+  card while that session did other work. Fix in `match_tmux_to_initiatives`:
+  `ptoks -= set(text_tokens(os.path.basename(repo)))` so a pane must share a DISTINGUISHING word;
+  a pane with none falls to `live_unmatched` (an honest miss — "a wrong tag costs more than a miss").
+- **Momentum times from the last genuine USER-turn timestamp, NOT the transcript file mtime** (PR #149).
+  Claude Code rewrites session `.jsonl` files in place (title/mode metadata) → mtime-driven momentum
+  read 18-day-idle sessions as "active ~47m ago". `initiative-scan.py` parses `turns[].ts` for the
+  last user turn; mtime is a rare fallback only (mirrors `doc_touch_epoch`).
 - **Recap VRAM contention** — `vllm-recap` shares a single 5080 (16.3GB, time-sliced ×4); to free VRAM,
   **`vllm-joycaption` + `comfyui` are scaled to `replicas: 0` in homelab git**. Scale them back for a
   captioning/comfy pass — but VRAM then contends with recap. Recap is **best-effort**: model down → the
   sync/store are unaffected and the card falls back to the deterministic `summary`.
-- **Recap identity vs status** (PR #154): the recap is **two independently-cached fields** — `identity`
-  ("what it is", from the handoff's durable head, hash-keyed on the HANDOFF so it's stable across prompt
-  churn) + `status` ("current", hash-keyed on recent activity). Two `vllm-recap` calls. Viewer renders
-  identity primary (fallback identity→recap→summary), status secondary.
-- **`_db.py` importlib load** — never add `mail-actions/` to `sys.path` (its `llm.py` shadows repo-cos's and
-  breaks synthesis). route/assistant/sync all load it by explicit path.
+- **Recap identity vs status** (PR #154): two independently-cached fields — `identity` ("what it is",
+  from the handoff's durable head, hash-keyed on the HANDOFF so it's stable across prompt churn) +
+  `status` ("current", hash-keyed on recent activity). Two `vllm-recap` calls. Viewer renders identity
+  primary (fallback identity→recap→summary), status secondary.
+- **`_db.py` importlib load** — never add `mail-actions/` to `sys.path` (its `llm.py` shadows
+  repo-cos's and breaks synthesis). route/assistant/sync all load it by explicit path.
 - **Assistant is read-only by design** — no write/dispatch/devpod/MCP; worst prompt-injection case is a
   skewed but grounded answer, never an action. The Phase-2 write/dispatch path is DEFERRED behind a
   **structural** server-side write-gate (NOT the voluntary `agent_checkpoint`) + a least-privilege DB role.
-```

--- a/claude/skills/initiatives/reference/agent-devpod.md
+++ b/claude/skills/initiatives/reference/agent-devpod.md
@@ -1,0 +1,101 @@
+# initiatives agent devpod — deploy, hardening, identity, DB reach
+
+The Phase-1 `/api/ask` agent. Read this when **deploying/bumping the devpod**, changing its
+HelmRelease/secret/egress, or debugging a crash-loop / confabulated first-person answer.
+Not needed to simply ask a question or to operate the sync/viewer.
+
+Homelab ns **`devpod-initiatives`**, svc **`initiatives-devpod:18789`**, model
+`openclaw/initiatives` (**DeepSeek V4 Pro via OpenRouter**). Manifests:
+`homelab-talos clusters/homelab/apps/agent-pods/initiatives/`.
+Full arc: `handoff-initiatives-agent-phase1-2026-07-24.md`.
+
+## Deploy
+GitOps record is on homelab-infra **`origin/trunk`** (verified: the 0.7.x-values hardening
++ `2026.6.11-py` initiatives helmrelease + task-drafter hardening are all ancestors of
+`origin/trunk`).
+
+⚠ the LOCAL `~/workspace/homelab-talos` checkout may be **STALE/dirty** (another session
+left uncommitted files + a behind `trunk`) — **always base edits on `origin/trunk` (fetch
+first), never the local working copy.** agent-pods flux is `suspend=true`, so trunk changes
+are applied **SURGICALLY by hand**.
+
+`query.py`/skill ship in devrc → the devpod **autoPulls `main` (~5min)** — merge to devrc
+main, done.
+
+HelmRelease / secret / identity-pin (`extraInitCommands`) changes: edit the manifest, then
+apply surgically:
+```bash
+KUBECONFIG=$KC_HOMELAB kubectl apply -f ~/workspace/homelab-talos/clusters/homelab/apps/agent-pods/initiatives/helmrelease.yaml
+KUBECONFIG=$KC_HOMELAB kubectl -n flux-system annotate helmrelease initiatives-agent reconcile.fluxcd.io/requestedAt="$(date +%s)" --overwrite
+```
+The secret is sops-encrypted in git BUT the workbench **lacks the homelab age PRIVATE
+key** → apply the live secret from plaintext via `kubectl` (the git `.enc.yaml` is the
+GitOps record); encrypt with
+`sops --encrypt --age <homelab-recipient> --config /dev/null` (no agent-pods
+`creation_rule`).
+
+## Hardening = first-class kubeclaw 0.7.x chart VALUES
+(postRenderers + hand-written CNP are **RETIRED**.) The chart (kubeclaw ≥0.7.0) exposes the
+three knobs directly in `values`:
+- **`securityContext`** — toYaml full-replace → `capabilities.drop:[ALL]` +
+  `allowPrivilegeEscalation:false` + seccomp `RuntimeDefault` (CapEff=0 verified).
+- **`tls.verify:true`** → `NODE_TLS_REJECT_UNAUTHORIZED=1`, overriding the chart's
+  historical hardcoded `0`.
+- **`networkPolicy`** — Cilium egress default-deny + per-agent FQDN allowlist:
+  kube-dns[+`rules.dns`]/apiserver/`mailbox-postgres:5432`/openrouter.ai/github.com/
+  api.github.com/codeload/`*.githubusercontent`/`*.debian.org` on 443+80.
+
+Verify in-pod: `curl openrouter.ai`→200, `curl example.com`→blocked.
+
+This REPLACED the old `spec.postRenderers` strategic-merge (needed because `extraEnv`
+duplicate-keys made SSA reject the Deployment) + the standalone `network-policy.yaml` —
+both DELETED (functional no-op: identically hardened, cleaner).
+
+⚠ **`networkPolicy.enabled` with an EMPTY allowlist silently bricks egress to DNS+API
+only** — always set the full `egress.fqdns`/`endpoints` (kubeclaw 0.7.1 adds a fail-loud
+guard for this; 0.7.0 does not).
+
+`cap-drop:[ALL]` is safe **ONLY** because deps are baked (no dpkg at runtime).
+**non-root is DEFERRED** — the chart hardcodes `/root/.openclaw|.ssh|.kube` writes with no
+`runAsUser` knob (needs a chart change).
+
+## Image `2026.6.11-py` + web-search OFF (the two are COUPLED)
+`query.py`'s deps (psycopg2/requests) are **BAKED** into the derived image
+(`initiatives/image/Dockerfile`, base `ghcr.io/zacxdev/openclaw-image`) so there is NO
+apt-at-init to race the Cilium FQDN/DNS warmup — this is why `cap-drop:[ALL]` is safe.
+
+**`tools.web.search.enabled:false`** is load-bearing for booting 2026.6.11 under the locked
+egress: with search on, `openclaw doctor --fix` (pre-gateway) auto-enables a
+brave/perplexity plugin and does a blocking `npm view @openclaw/<plugin>` fetch to
+`registry.npmjs.org` (**NOT allowlisted**) → doctor hangs → gateway never binds `:18789` →
+**crash-loop**. Off = no plugin auto-fetch → doctor completes offline → gateway binds. The
+read-only Q&A agent never needs web search anyway; egress stays locked (no npm allowlist
+added).
+
+`config.updateCheckOnStart:false` is set belt-and-suspenders. **Rollback tag `2026.6.1-py`**
+(a first 2026.6.11 attempt rolled back before web-search-off was found).
+
+The shared `openclaw-image` base rebuilds via `--legacy-peer-deps` (npm arborist `edgesOut`
+bug on `node:22-slim`, openclaw-image #3).
+
+**To bump OpenClaw further:** keep web-search off + egress locked, verify the gateway
+binds. (Historical: if you ever reintroduce apt-at-init it RACES the Cilium policy — baking
+deps mooted this.)
+
+## Agent identity must be PINNED or first-person questions confabulate
+OpenClaw ships a generic "figure out who you are" onboarding (`BOOTSTRAP.md` + empty
+`IDENTITY.md` in `/data/workspace`). Without a pin, *"what am **I** working on"* made the
+agent read BOOTSTRAP and answer about **ITSELF** ("fresh start, who are you?").
+
+Fix (in `extraInitCommands`): `rm BOOTSTRAP.md` + overwrite `AGENTS.md`/`IDENTITY.md` so the
+agent is "already born" as the read-only initiatives assistant and "I/me/my/you" = **Zach**.
+Clearly-matching Qs ("blocked on me", "whats stalled") routed to the skill fine; ambiguous
+first-person ones did not.
+
+## Agent DB reach = least-priv SELECT-only → the audit-log write stays VIEWER-side
+The `initiatives_agent` PG role is SELECT-only. `CREATE TABLE IF NOT EXISTS`
+(assistant.py's log self-heal) needs CREATE on the schema **even when the table exists** (it
+errors before the existence check), so the agent can't write `assistant_log`.
+`agent_client._log_agent_ask` writes it from the viewer (full mailbox creds).
+
+**Don't grant the agent role INSERT to "fix" a missing audit row** — check the viewer path.

--- a/claude/skills/initiatives/reference/clawgate-tasks.md
+++ b/claude/skills/initiatives/reference/clawgate-tasks.md
@@ -1,0 +1,51 @@
+# Linked clawgate tasks — the `initiative:<slug>` tag contract
+
+PR #202, `origin/main` e3e7b07. Read this when a dispatched task does **not** show up
+linked on its card, when changing `dispatch.py`'s tagging, or when touching the board's
+clawgate fetch.
+
+`tasks.py` joins initiatives → clawgate tasks on the `initiative:<slug>` tag. Rendered
+**ONLY in the EXPANDED card detail** (the collapsed card stays two-line for scanning).
+
+## 🔴 The join is EXACT / case-sensitive / VERBATIM
+A plain dict lookup on the raw slug, **no case folding**. `initiative:Foo` keys `Foo` and
+therefore **NEVER** matches the ledger slug `foo`. That is why repo-cos's `taggable_slug`
+**drops** any non-lowercase slug rather than lowercasing it.
+
+## Dispatch guard
+⤴ dispatch is GUARDED: when linked tasks are open it arms a two-tap *"already has N open
+task — dispatch anyway?"* via the pre-existing `armConfirm` (armConfirm is **NOT** from #202).
+
+`OPEN_STATUSES = ("open","in_progress","ready_for_review")` — a closed ALLOW-list, so an
+unknown status is non-blocking (fail-open).
+
+⚠ clawgate has **NO `dismissed` task status**; the vocabulary is exactly
+`{open,in_progress,ready_for_review,complete}` and dismissing DELETES. (`dismissed` exists
+only in clawgate's unrelated *suggestions* table.)
+
+## Tagging — fails open TWICE
+`dispatch.py` tags what it creates (`initiative:<slug>`, exact-or-nothing):
+`build_tags` emits `[]` on any doubt, then `post_task` retries ONCE untagged on **HTTP 400
+only**.
+
+⚠ its `normalize_tag`/`normalize_tags` are a **DELIBERATE DUPLICATE** of
+`repo-cos/clawgate.py` (the documented source of truth) — **change both together**. They
+have **ALREADY DRIFTED**: repo-cos gained `guard_tags` (per-tag, rejects
+non-list/non-string input, #206); `dispatch.py` has no equivalent.
+
+## Fetch shape
+ONE fetch per **BOARD RENDER** (not per card — the board carries ~140 cards), **2.0s
+WALL-CLOCK deadline**, **1 MiB cap**, performed **OUTSIDE `DataProvider._lock`**
+(deliberate — keep it that way), 30s cache keyed on last **ATTEMPT**,
+serve-stale-on-failure, single-flight. Silent best-effort: any clawgate failure logs to
+stderr and the board renders unchanged.
+
+## 🟡 KNOWN, MEASURED, NOT FIXED
+The abandoned fetch worker does **NOT self-terminate**. `resp.read(n)` blocks on a
+`BufferedReader` until n bytes or EOF, so with `READ_CHUNK=64 KiB` the wall-clock re-check
+is never reached for bodies ≥64 KiB (**measured: 6 fetches → 6 live threads, +12 FDs, none
+reclaimed**). Bounded today only because the real payload is ~16 KB. **Fix = `read1()`.**
+
+Also: serve-stale has **NO upper age bound** (clawgate down → last good map served
+forever), and `group_by_slug` keys on **slug ALONE, not (repo, slug)** — zero collisions
+measured, still latent.

--- a/claude/skills/initiatives/reference/viewer-board.md
+++ b/claude/skills/initiatives/reference/viewer-board.md
@@ -1,0 +1,77 @@
+# initiatives viewer — board layout & interaction reference
+
+Read this when you are **changing the viewer UI**, debugging why a card renders in
+the wrong lane/state, or wiring a new per-card action. Day-to-day operation does
+not need it. Live at **http://192.168.50.250:8899/**.
+
+## Default view
+**GROUPED by repo** (collapsible; `VIEW_KEY` v3; flat/recency in the toggle). Cards are
+**two-line collapsed** (state glyph + slug + title + age; one actionable `line2`) →
+**click to expand** the full current/start/you/live/PRs/investigations detail.
+
+## State
+**`derive_state`** per card, precedence `needs_you > stalled > slowing > active`:
+
+| glyph | state | meaning |
+|---|---|---|
+| ⚠ orange | `needs_you` | blocked on Zach |
+| ◑ gray | `stalled` | ≥7d |
+| ~ yellow | `cooling` | 2–7d |
+| → blue | `active` | <2d |
+
+**`live` is a separate OVERLAY BADGE** (● green, render-time tmux overlay via
+`buildLiveNow`), **NOT a state**.
+
+**`needs_you` is SEVERITY-aware** — `assistant.SEVERITY_MARKERS` over `status`+`next_step`
+promote an active RISK card with a `⚠ risk` cue (single-sourced from
+`assistant._severity_hits`; `tool_blocked_on_me` = `_blocking_hits OR _severity_hits`, so
+`/api/ask` "blocked/at-risk" has PARITY with the chip).
+
+## Layout — 4 sections
+1. §3 `⚠ Needs you` **PINNED top** (rendered once, excluded from groups).
+2. §4 **`● N live · newest:<task>` ONE-LINE strip** (`LIVENOW_OPEN_KEY='-v2'`, click→top-6
+   `＋more` activity-sorted; rows clickable→`focusCard`; scoped by the active filter).
+3. §5 active cards grouped by repo (**live-badged float to top**, stable `vis.sort`).
+4. §6 `~ Cooling` collapsed fold (slowing+stalled).
+
+## Filters & search
+**State chips** `[⚠ Needs you][◑ Stalled][~ Cooling][→ Active][All]` — filter, compose AND
+with search; `⚠ Needs you` pulses when >0. A **SEPARATE `[✓ Archived]`** view toggle.
+
+**Search** (`matchQ`) AND-composes with the chip, scopes the Live-now rows too, and
+**auto-widens to All** when a filter hides every hit (`shouldWidenFilter`, sticky); the
+active chip stays visible+highlighted at 0; matches show a `match: …snippet…` reason.
+
+`matchQ` is client-side **FUZZY**: substring + bounded-Levenshtein ≥4-char +
+ordered-subsequence ≥5-char, per-token AND, over
+title/summary/status/opening/latest/`search_text`/next_step/slug/repo. A match in the
+collapsed Emerging lane auto-expands it.
+
+## Per-card actions (`cardActions`, state-driven)
+- `needs_you` → `[resolve][⤴ dispatch?][⤓ archive]`. `[resolve]` prefills+submits the
+  `/api/ask/stream` sidebar.
+- `stalled`/`cooling` → `[⤴ resume?][drop][⤓ archive]`. `resume` = `/api/dispatch` with a
+  RESUME-framed body via `dispatch.py _task_lead`.
+- `active` → `[⤴ dispatch?][⤓ archive]`.
+- `?` = only when a grounded rec exists. `drop`/`⤓ archive` are **two-tap** (`armConfirm`).
+
+**Emerging/undocumented = an inline `emerging` badge**; the glyph **legend is behind a `?`**
+toggle (`.legend-toggle`, hidden by default).
+
+## Archive lifecycle
+`POST /api/archive {repo,slug,reason?}` (viewer-side, never-500) hides the card + persists
+to the standalone `initiatives.archived` table (`archive.py`:
+`archive`/`unarchive`/`read_archived`/`list_archived`).
+
+**Suppress IFF archived AND `last_touch <= archived_at`** → **auto-resurfaces on new
+activity**. `[✓ Archived]` opens the archived view (`POST /api/unarchive` restores).
+
+⚠ `load_latest()` returns **`(rows, archived)`** — 2 callers (`DataProvider.snapshot`,
+`assistant.load_initiatives`) handle the tuple.
+
+## Also on the board
+Recaps (identity primary / status secondary), a `POST /refresh` ↻, `POST /api/dispatch`,
+the `POST /api/ask` sidebar.
+
+Full dogfood-evolution history:
+`devrc/claudedocs/handoff-initiatives-nextstep-dispatch-shipped-2026-07-26.md`.


### PR DESCRIPTION
Compression pass on the two largest skills I own. A SKILL.md loads **in full** whenever the skill triggers, so every redundant byte is a per-invocation tax forever.

| skill | before | after | saved |
|---|---|---|---|
| `claude/skills/initiatives/SKILL.md` | 30,685 B | **19,265 B** | **−11,420 B (−37.2%)** |
| `claude/skills/auditloop/SKILL.md` | 29,353 B | **20,718 B** | **−8,635 B (−29.4%)** |
| **always-loaded total** | **60,038 B** | **39,983 B** | **−20,055 B (−33.4%)** |

Bulk moved to six on-demand reference files (12,461 B, cost 0 until read), following the pattern proven by `scripts/browser-bridge/reference/`.

**Deployment:** `nix/home.nix` sets `home.file.".claude/skills" = { source = ../claude/skills; recursive = true; }`, so `reference/` lands at `~/.claude/skills/<name>/reference/` automatically — no home.nix change needed. (Unlike the `browser` skill, which symlinks only `SKILL.md` and must address its refs by repo-absolute path.) All six new files are `git add`ed explicitly, per the flake gotcha.

Docs-only. No behaviour change, **no breaking change applied**.

---

## `initiatives` — section decisions

| Section | Decision | Note |
|---|---|---|
| frontmatter `description` | **KEEP AS-IS** | trigger surface; see proposal 1 |
| Intro paragraph (25 lines of dense prose) | **COMPRESS** | 7-line intro + a scannable `## How a card comes to exist` bullet list. Every constant kept (`MIN_SESSION_TURNS=1`, `MIN_TOPIC_TOKENS=2`, `ENABLE_TITLE_DRIFT_MERGE=False`, v4/v5/v6 schema history, `search_text` cap 6000) |
| Key facts table (most rows) | **KEEP AS-IS** | store, reach, tables, views, sync, sync creds, viewer, recap model, router |
| Key facts → **Viewer board** row (~4 KB in one table cell) | **MOVE** | → `reference/viewer-board.md` + a one-line pointer |
| Key facts → **Viewer bind** row | **COMPRESS + ABSORB** | merged in the duplicate gotcha bullet's two unique facts (`127.0.0.1` smoke test won't catch it; `[[workbench-lan-ip]]`) |
| Key facts → **Sync** row | **COMPRESS** | dropped the absolute card counts (~105 / ~48) — the skill's own "don't pin absolute slug counts" gotcha forbids them; the *rationale* is kept |
| Key facts → **Assistant** row | **COMPRESS** | manifests path + handoff ref relocated to `reference/agent-devpod.md` |
| `## status` | **COMPRESS** | redundant inline comments only; all 8 commands verbatim |
| `## operate` (commands) | **KEEP AS-IS** | every curl/kubectl/nix-shell line verbatim |
| `## operate` → LINKED CLAWGATE TASKS (30 prose lines *inside* a bash fence) | **MOVE** | → `reference/clawgate-tasks.md` |
| `## operate` → NEXT-STEP RECOMMENDATION prose | **COMPRESS + LIFT** | out of the bash fence into real prose |
| `## deploy a change` (scripts) | **KEEP AS-IS** | |
| `## deploy a change` → AGENT DEVPOD block | **MOVE** | → `reference/agent-devpod.md` |
| gotchas → kubeclaw 0.7.x hardening / image `2026.6.11-py` / identity pin / least-priv DB role | **MOVE** | → `reference/agent-devpod.md` (~5.9 KB of devpod-only detail) |
| gotchas → X-Restart-Triggers trap | **CONSOLIDATE + PROMOTE** | was split across two places (`assistant.py` buried in a bash-fence comment; `initiative-scan.py` buried at the end of the repo-name-token bullet). Now one 🔴 bullet at the top. **One rule, one place.** |
| gotchas → "Viewer bind IP" | **DELETE (duplicate)** | restated the Key-facts row; its two unique facts were absorbed there first |
| remaining gotchas (shellHook, slug counts, migrations, tmux match, momentum, VRAM, recap identity, `_db.py`, read-only) | **COMPRESS** | prose only — every command, symbol and threshold verbatim |

## `auditloop` — section decisions

| Section | Decision | Note |
|---|---|---|
| frontmatter `description` | **KEEP AS-IS** | trigger surface; see proposal 2 |
| Intro + header table | **COMPRESS** | dropped the duplicated "Live at …" sentence (it's a table row); folded the "kubeconfigs NOT the repo root" correction into the table |
| P0–P5 | **KEEP** | P3 absorbed the orphaned "the P3 prompt was trimmed" bullet that lived under *Deterministic signals* |
| Deterministic signals | **COMPRESS** | promoted to a sub-heading; all thresholds/filenames/columns verbatim |
| Trend view · Read API · cost tracking | **KEEP AS-IS** | read-API routes, `AUDITLOOP_API_TOKEN`, the curl |
| Persona evaluator Phases 1–4 (~9 KB) | **MOVE** | → `reference/persona-evaluator.md`; a 10-line summary stays |
| **Driver safety model** | **KEEP AS-IS — deliberately not moved** | destructive-action warning. The scoped guarantee *and* the explicit residual list (WebSockets / OOPIF iframes / service workers) and "point at STAGING with a DISPOSABLE account" stay in the always-loaded file |
| LLM token tiers · live-smoke record · #27 click-nav · DOM/a11y grounding detail | **MOVE** | → `reference/persona-evaluator.md` |
| Drive an INTERNAL naida (~4.5 KB) | **MOVE** | → `reference/internal-naida-drive.md`; an 8-line summary keeps `AUDITLOOP_INTERNAL_ALLOW_HOSTS`, the ClusterIP host:port, the hard-block list and the reversibility note |
| `## Deploy` | **KEEP AS-IS** | deploy.sh, `SKIP_VET=1`, the Flux tag regex, the read-only-key gotcha, the force-a-roll recipe |
| `## Secrets` | **COMPRESS + ABSORB** | reflowed to a code block; **pulled in** the `kubectl rollout restart deploy/auditloop` gotcha, which previously only existed inside the naida-dev section — it applies to *any* secret edit |
| Auth · Monitoring · Producers | **KEEP AS-IS** | all metric names, the PromQL, the distroless promtool recipe, push env vars |
| 🔴 a11y gate since #18 | **KEEP AS-IS** | |
| 🔴 Meta-audit (screenshot-only) | **KEEP AS-IS** | |
| Live-bug playbook | **KEEP** | prose tightened; kubeconfig line kept (it's a real repeat-mistake) |
| Security posture | **KEEP AS-IS** | |
| UI / design system | **COMPRESS + MOVE** | the durable convention (tokens not raw utilities; `motion-safe:`; never animate an htmx self-poll root) stays inline — it binds every future PR. Token/component inventory + redesigned-view detail → `reference/ui-and-meta-run.md` |
| Meta-run dogfood | **MOVE** | → `reference/ui-and-meta-run.md` |
| Conventions from naida | **KEEP AS-IS** | |

---

## Coverage check — method and counts

Deterministic, not eyeballed. `facts.py` extracts every **backtick code span, URL, `IP[:port]`, filesystem path, and `SCREAMING_SNAKE` identifier** from each *original* file, then re-checks each string (whitespace-normalised) against the new SKILL.md **plus** its reference files.

| skill | facts extracted | present after | genuinely missing |
|---|---|---|---|
| initiatives | **460** | **442** | **0** |
| auditloop | **467** | **465** | **0** |

The 18 + 2 nominal misses are all **regex artifacts**, individually inspected:
- initiatives: 12 are bare SCREAMING-CAPS *emphasis words* lifted out of headings I rewrote (`ARCHIVE`, `LINKED`, `TASKS`, `CONSUMER`, `GROUNDED`, `SECURITY`, …) — not facts; 6 are path *fragments* split by the regex (`/apiserver/mailbox-postgres`, `/codeload/*.githubusercontent/*.debian.org`, `/normalize_tags`, `/cooling`, `/matching`, `/logs/gateway`) whose full forms I grep-confirmed present in `reference/agent-devpod.md` / `reference/clawgate-tasks.md`.
- auditloop: both are `https://auditloop.zacx.dev**` — the URL regex swallowing a trailing markdown bold marker. The URL is present.

The first run caught **3 real losses**, which I then restored: the `127.0.0.1`-smoke-test-won't-catch-it note, the `[[workbench-lan-ip]]` link, and the `attach_tmux` symbol. That is the check earning its keep.

**Mutation test** — delete each reference file and confirm facts actually go missing (i.e. the file is load-bearing, not decorative):

| dropped file | facts lost |
|---|---|
| `initiatives/reference/agent-devpod.md` | **70** |
| `initiatives/reference/viewer-board.md` | **66** |
| `initiatives/reference/clawgate-tasks.md` | **31** |
| `auditloop/reference/persona-evaluator.md` | **81** |
| `auditloop/reference/internal-naida-drive.md` | **37** |
| `auditloop/reference/ui-and-meta-run.md` | **28** |

Every reference file is reachable from a named pointer in its SKILL.md that says *when* you'd open it.

### Explicitly preserved verbatim
Endpoints/ports/services/timers: `192.168.50.250:8899`, `initiatives-sync.timer`, `initiatives-viewer.service`, `mailbox-postgres-0`, `vllm-recap:8000` (ns `promptver`, model `recap` = Qwen2.5-7B-Instruct-AWQ), `initiatives-devpod:18789`, `auditloop.zacx.dev`, `auditloop-auth.zacx.dev`, `http:8112`, `naida-dev.naida-dev.svc.cluster.local:8080`.
Credential paths: `clusters/homelab/apps/activity/secrets.enc.yaml`, `clusters/workbench/apps/auditloop/secrets.enc.yaml`, `~/workspace/homelab-talos/.secrets/age.key`, `~/workspace/homelab-infra/{workbench,homelab,production}-kubeconfig`, `~/.claude/clawgate.env`, `sha256("gw-"+HOOKS_TOKEN)`.

**Every "NOT x, it's y" correction was treated as load-bearing and kept**, per the reviewer note — these read like redundant prose and are the most expensive lines in the file to lose:
`192.168.50.250` **not** `.94` · endpoint is bare `minio.homelab.lan` **not** a URL · momentum from the last user-turn ts **not** file mtime · DROP+CREATE **not** `CREATE OR REPLACE VIEW` · kubeconfigs in `homelab-infra/` **not** the repo root · exact map match **not** suffix · success observed **not** LLM-judged · `_db.py` by importlib path **not** `sys.path` · artifacts streamed **not** presigned.

---

## 🔴 PROPOSED BREAKING CHANGES — NOT APPLIED

Each changes what an operator/agent would *do*, or removes something another file may rely on. Clear them individually and I'll apply the approved set in a second round.

### 1. Trim the `initiatives` frontmatter `description` (1,096 B → ~400 B)
- **Why** — this is the single highest-leverage byte in either file: a skill *description* is in context on **every session**, whereas the body only loads on trigger. It currently restates the whole architecture and ends in a long disambiguation clause.
- **Saving** — ~700 B/session, always-on. Larger real-world saving than the entire body compression.
- **Risk if wrong** — the description **is** the trigger surface. Over-trimming makes the skill stop firing on a phrasing it used to catch (e.g. "initiatives.current/latest", "vllm-recap model", "what's on my board"). Silent failure — you'd never see it not fire.
- **Verify** — enumerate the trigger phrases in the current description, then confirm each still routes to the skill before/after against a set of real prompts.

### 2. Trim the `auditloop` frontmatter `description` (1,293 B → ~450 B)
Same rationale, risk and verification as 1.

### 3. Remove the dead `[[workbench-lan-ip]]` wiki-link
- **What** — `initiatives` Key-facts "Viewer bind" row says "See `[[workbench-lan-ip]]`".
- **Why** — I grepped the whole repo: **nothing defines that anchor**. It's a dangling pointer to a note that either never landed or lives outside the repo.
- **Saving** — ~28 B. Trivial; proposed for correctness, not bytes.
- **Risk if wrong** — it may target a personal note store outside `devrc`, in which case removing it loses a real pointer.
- **Verify** — confirm no vault/notes system resolves it. If one does, replace with the real path instead of deleting.

### 4. Drop the `auditloop` "Live-smoked this session" record (~600 B)
- **What** — the paragraph listing the 4 features smoked against prod, plus "Smoke path = the smoke-user JWT in the session scratchpad `login.json`". (Currently in `reference/persona-evaluator.md`.)
- **Why** — "this session" is long over and the scratchpad is gone, so the *path* is unusable. It's a historical verification record, not a runbook.
- **Saving** — ~600 B (from a reference file, so 0 per-invocation; propose only if you want the file to stay honest).
- **Risk if wrong** — `remix-ci-reader` may be a **live read-key name** worth keeping; and the record is evidence that these features were actually verified against prod, which per the repo's own verification-honesty rules is worth retaining.
- **Verify** — check whether `remix-ci-reader` is still a minted key. If yes, keep that name and drop only the ephemeral `login.json` path.

### 5. Re-check the two 🔴 "chat-exposed → ROTATE" credential notes
- **What** — `auditloop`: `OPENROUTER_API_KEY` ("chat-pasted, ROTATE") and the smoke password in `auditloop-secrets.env` ("chat-exposed → rotate").
- **Why** — if rotation already happened these are stale alarms; a standing 🔴 that's already handled trains readers to skim 🔴s. If rotation did **not** happen, this is an open security item that should be escalated, not compressed.
- **Saving** — ~120 B, but that is not the point.
- **Risk if wrong** — deleting a live "rotate me" warning for a key with a **$50 cap** on a public-internet app. **Do not clear this one on byte-saving grounds.**
- **Verify** — check the key's creation date in OpenRouter and the GoTrue user's password-changed timestamp. Only drop after confirming both rotated; otherwise leave and action it.

---

## Cross-references found (no anchors broken)

`git grep` across skills, `CLAUDE.md`, READMEs and `scripts/`:

| Referrer | Reference |
|---|---|
| `CLAUDE.md:25` | "**Operate via the `initiatives` skill.**" |
| `claude/skills/activity/SKILL.md:63` | "Operate that layer via the **`initiatives` skill**" |
| `claude/skills/mailbox/SKILL.md:30` | "see the `initiatives` skill" |
| `claude/skills/tekton/SKILL.md` (8, 42, 76, 122) | "Cross-ref: `auditloop`", read API + push, remix producer |
| `claude/skills/close-the-loop/STATE.md:14` | `/initiatives` command (not this skill) |

**All are skill-name-level — none targets a heading, anchor or section inside either SKILL.md.** No section I moved or renamed is pointed at from anywhere, so nothing is broken and no anchor stub was needed. `CLAUDE.md` needs no edit: it names both skills and describes the *subsystems*, not the skills' internal structure.

### Noted elsewhere, not touched (outside my ownership)
- `claude/skills/tekton/SKILL.md` is 3rd-party to this PR but duplicates auditloop's push/read-API contract in four places — a candidate for the same treatment by whoever owns it.
- `claude/skills/close-the-loop/STATE.md` carries a very large single-paragraph status blob; per `RULES.md` "Memory Hygiene", shipped status like that belongs in a `claudedocs/` handoff, not a loaded skill file.

---

## Verification

- `node --test scripts/browser-bridge/tests/*.test.mjs` → **pass 454 / fail 0** (counted from the runner summary, not the exit code).
- `nix-shell -p python3Packages.pytest --run "python -m pytest scripts/browser-bridge/tests -q"` → **342 passed / 3 failed**, matching the stated pre-existing baseline. The 3 (`test_manifest_version_reads_current`, `test_manifest_version_falls_back_to_repo_when_not_deployed`, `test_ping_op_set_mirrors_the_extension_protocol_js`) are browser-bridge manifest/op-set literal assertions on `main`, untouched by this docs-only PR.
- Rebased onto current `origin/main` (`e673e6b`) — clean, no conflict (that commit is browser-bridge only).
- No `home-manager switch`, no service restart, no live Brave, no API calls against any service these skills describe. Nothing was staged with `git add -A`; no `git stash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011L55ie18DYBHdq7KeqgK3k
