### PR TITLE
docs(skills): compress activity, dl-router, mailbox, tekton SKILL.md (−23.7% per-invocation)

### DIFF
--- a/claude/skills/activity/SKILL.md
+++ b/claude/skills/activity/SKILL.md
@@ -5,35 +5,78 @@ description: Operate the personal activity-telemetry pipeline — 6 sources (zsh
 
 # activity-telemetry operations
 
-A personal activity dataset for productivity mining. Six sources emit events through one per-host collector daemon into a dedicated, authenticated ClickHouse on the homelab cluster; a Grafana dashboard surfaces time/attention + focus/context-switching, and a validation harness proves capture/query correctness. Full point-in-time state lives in memory `activity-telemetry-pipeline` (read it first) + the latest `devrc/claudedocs/handoff-activity-*.md`.
+Six sources emit through one per-host collector daemon into a dedicated, authenticated
+ClickHouse on the homelab cluster; a Grafana dashboard surfaces time/attention +
+focus/context-switching, and a validation harness proves capture/query correctness.
+Point-in-time state: memory `activity-telemetry-pipeline` (read it first) + the latest
+`devrc/claudedocs/handoff-activity-*.md`.
 
-**Data flow:** source → `emit` (or `spool_emit`) appends a v1 line to `~/.local/state/activity/spool/` → `collector.py` (systemd user daemon) batches → POST `JSONEachRow` to ClickHouse `activity.events` (offline-buffered, retried). The collector stamps `host` from `ACTIVITY_HOST`.
+**Data flow:** source → `emit` (or `spool_emit`) appends a v1 line to
+`~/.local/state/activity/spool/` → `collector.py` (systemd user daemon) batches → POST
+`JSONEachRow` to ClickHouse `activity.events` (offline-buffered, retried). The collector
+stamps `host` from `ACTIVITY_HOST`.
+
+**Reference files** (repo-absolute; read on demand):
+- `~/workspace/devrc/claude/skills/activity/reference/queries.md` — the non-obvious SQL
+  (i3 dwell, reading depth, i3-derived browser attention) + the column/JSON gotchas that
+  make it non-obvious. Read before writing a NEW query or touching the dashboard panels.
+- `~/workspace/devrc/claude/skills/activity/reference/session-insights.md` — the Layer B
+  anti-confabulation extraction contract + backlog-run lessons. Read before an extraction.
 
 ## Key facts (verify against live state before asserting)
 
 | Thing | Value |
 |---|---|
 | Code | `~/workspace/devrc/scripts/collector/` (`emit`, `collector.py`, `keylog/`, `browser-ext/`, `claude/`) + `scripts/validation/` |
-| Sources (6) | `zsh` (preexec/precmd, interactive-only → excludes Claude's Bash tool), `tmux` (focus hooks), `keys` (X11 XRecord keylogger, **full content**, GUI-only), `browser` (Brave MV3 ext → loopback receiver :8787; emits **nav events only** now — `text`=URL, `title`, **`scroll_pct`** (max reading depth) + **`scroll_ms`** (active-scroll time) per page view via a capture-phase content script that catches SPA inner-container scroll too; receiver labels `app` from `BROWSER_APP` env. **`active_ms` + the focus/idle events were RETIRED (PR #27, 2026-06-29)** — they were structurally wrong on i3 (`chrome.idle` is system-wide + blur unreliable → counted *other-app* time as browser-active). Browser ATTENTION is now derived downstream by intersecting i3 "Brave-focused" intervals with the active-tab domain timeline (see query patterns). **NOTE:** the URL is the **`text`** column (NOT `payload.url`); a nav event's `text`/`title` are the DESTINATION tab but its `scroll_pct`/`scroll_ms` belong to the LEAVING tab. Extract scroll with `JSONExtractInt(toString(payload),'scroll_pct')` — `payload.scroll_pct` subcolumn access is NOT available), `claude` (tails `~/.claude/projects/**/*.jsonl`, timer every 5min), `i3` (i3ipc window::focus + workspace::focus → `i3-source` daemon, GUI-only/laptop; captures attention even when NOT typing). Both `keys` and `i3` carry `app`=WM_CLASS + `payload.workspace` |
 | ClickHouse | dedicated, **authed**, homelab ns `activity` — NOT the shared clickstack one. Table `activity.events`, 180d TTL, monthly partitions |
 | Endpoint — workbench | `http://192.168.50.94:30123` (same LAN) |
 | Endpoint — laptop | `http://10.42.0.10:30123` (**nebula** — the laptop is nebula-only; it CANNOT reach the 192.168.50.x LAN IP) |
 | Endpoint — in-cluster | `clickhouse.activity.svc.cluster.local:8123` (NodePort `30123`) |
 | CH users | `default`=admin (`admin-password`), `activity_writer`=INSERT+SELECT (`writer-password`, collector uses this), `activity_reader`=SELECT (`reader-password`, dashboard + harness) |
-| CH creds | SOPS secret `homelab-talos/clusters/homelab/apps/activity/secrets.enc.yaml`. Decrypt: `SOPS_AGE_KEY_FILE=~/workspace/homelab-talos/.secrets/age.key sops -d --extract '["stringData"]["reader-password"]' <file>` |
+| CH creds | SOPS secret `homelab-talos/clusters/homelab/apps/activity/secrets.enc.yaml`. Decrypt: `SOPS_AGE_KEY_FILE=~/workspace/homelab-talos/.secrets/age.key sops -d --extract '["stringData"]["reader-password"]' <file>` (on a `<(git show …)` process substitution, add `--input-type yaml`) |
 | Collector config | `~/.config/activity-collector/env` per host (chmod 600, NOT in git/nix store): `CLICKHOUSE_URL/USER/PASSWORD`, `ACTIVITY_HOST` (=`workbench`/`laptop`), batch/flush/buffer caps |
-| Services (home-manager systemd **user**) | `activity-collector` (always), `keylog` (graphical-session.target — laptop only), `browser-activity-receiver` (:8787 loopback), `claude-activity-source` (oneshot + timer), `i3-source` (i3ipc focus daemon, graphical-session.target — laptop only) |
-| Browser extension (NOT fully nix-managed) | The MV3 ext (`scripts/collector/browser-ext/`) is **hand-loaded** in Brave (the laptop's daily browser) as an unpacked extension from `~/.local/share/activity-browser-ext/` (a real-file copy, since Chromium dislikes loading the nix-store symlink dir). It persists across restarts, but a `service_worker.js`/content-script change needs: ship → `cp -fL ~/.config/activity-collector/browser-ext/*.js ~/.local/share/activity-browser-ext/` → **reload the extension in `brave://extensions`** (+ reload the page, content scripts only inject post-reload). Manifest **v1.4.0** — the ext is now **nav + scroll ONLY** (the `active_ms` accumulator + focus/idle handlers + the `idle` permission were removed in PR #27; when stripping a deleted file like the old `active_time.js`, `rm` it from `~/.local/share/...` — `cp` won't remove it). |
+| Services (home-manager systemd **user**) | `activity-collector` (always), `keylog` (graphical-session.target — laptop only), `browser-activity-receiver` (:8787 loopback), `claude-activity-source` (oneshot + 5-min timer), `i3-source` (i3ipc focus daemon, graphical-session.target — laptop only) |
 | Dashboard | Grafana "Activity & Productivity" (uid `activity-productivity`), datasource `activity-clickhouse` → `https://grafana.homelab.lan` |
 | Cluster access | `KUBECONFIG=~/workspace/homelab-talos/homelab-kubeconfig` (context `admin@zach-homelab`); manifests in `clusters/homelab/apps/activity/` + dashboard in `clusters/homelab/flux-system/charts/prom-stack/`. **From the laptop** (nebula-only, can't reach the LAN API `192.168.50.94:6443`): `KUBECONFIG=~/.kube/homelab-nebula.yaml` — routes through the `homelab-kube-tunnel` systemd user service (ssh -D SOCKS via the workbench `10.42.0.30`) |
 | Schema columns | `ts DateTime64(3) (UTC), host, source, kind, project, cwd, session, app, text, duration_ms, exit_code, payload(JSON), ingested_at` |
 
-## ⚠ Gotchas (each cost real time this build)
-- **Timezone:** `ts` is stored as the **UTC instant** (tz-less DateTime64). Dashboard buckets hour-of-day / per-day with explicit `'America/Winnipeg'` (`toHour`/`toDate`); time-series stay UTC. If you add a query that groups by local hour/day, add the tz arg — but NEVER tz-shift `$__timeFilter`/range comparisons (they're UTC, aligned with `now()`).
-- **`home-manager switch` now RESTARTS these services on a script-only change** (FIXED — devrc PR #16, merged + shipped to both hosts 2026-06-24). `X-Restart-Triggers` (the script store path) on all 3 long-running daemons flips the unit definition whenever the code changes, so sd-switch restarts them; verified on both hosts (collector/keylog/receiver got new MainPIDs on the activating switch). `claude-activity-source` is excluded (5-min timer oneshot re-runs fresh code anyway). So a manual `systemctl --user restart` after a code ship is **no longer needed** — before #16, switch left STALE code running and you had to restart by hand.
-- **Both hosts are hostname `nixos`** → without `ACTIVITY_HOST` in the env, every row collides on `host=nixos`. Set it per host.
-- **keylog + browser are GUI-only** → they only run on the laptop (X11/i3). The workbench is headless (server-mode) — no keylog there.
-- **Full-content keylogging** → `activity.events` holds secrets. That is WHY the store is a dedicated authed ClickHouse, not the shared LAN-open clickstack. Treat reader/writer creds as sensitive.
+### The six sources
+| source | what |
+|---|---|
+| `zsh` | preexec/precmd, interactive-only → excludes Claude's Bash tool |
+| `tmux` | focus hooks |
+| `keys` | X11 XRecord keylogger, **full content**, GUI-only. Carries `app`=WM_CLASS + `payload.workspace` |
+| `browser` | Brave MV3 ext → loopback receiver :8787. **nav events only**: `text`=URL, `title`, `scroll_pct` (max reading depth), `scroll_ms` (active-scroll time) per page view. Receiver labels `app` from `BROWSER_APP` env. `active_ms` + focus/idle events were **RETIRED** (PR #27) — structurally wrong on i3 (`chrome.idle` is system-wide, blur unreliable → counted *other-app* time as browser-active). Browser attention is now derived downstream (i3 ∩ domain — see `reference/queries.md`) |
+| `claude` | tails `~/.claude/projects/**/*.jsonl`, 5-min timer. Three kinds: `prompt`/`command` (message stream), `session-summary` (Layer A rollups), `session-insight` (Layer B facets) |
+| `i3` | i3ipc `window::focus` + `workspace::focus` → `i3-source` daemon, GUI-only/laptop; captures attention even when NOT typing. Carries `app`=WM_CLASS + `payload.workspace` |
+
+**Browser extension is NOT fully nix-managed.** Hand-loaded unpacked in Brave (the laptop's
+daily browser) from `~/.local/share/activity-browser-ext/` — a real-file copy, since
+Chromium dislikes loading a nix-store symlink dir. It persists across restarts, but a
+`service_worker.js`/content-script change needs: ship →
+`cp -fL ~/.config/activity-collector/browser-ext/*.js ~/.local/share/activity-browser-ext/`
+→ **reload the extension in `brave://extensions`** (+ reload the page — content scripts only
+inject post-reload). Manifest **v1.4.0**. When a file is DELETED upstream (e.g. the old
+`active_time.js`), `rm` it from `~/.local/share/…` by hand — `cp` won't remove it.
+
+## ⚠ Gotchas (each cost real time)
+- **Timezone:** `ts` is the **UTC instant** (tz-less DateTime64). Dashboard buckets
+  hour-of-day / per-day with explicit `'America/Winnipeg'` (`toHour`/`toDate`); time-series
+  stay UTC. Add the tz arg when grouping by local hour/day — but NEVER tz-shift
+  `$__timeFilter` / range comparisons (they're UTC, aligned with `now()`).
+- **Both hosts are hostname `nixos`** → without `ACTIVITY_HOST` in the env, every row
+  collides on `host=nixos`. Set it per host.
+- **keylog + browser + i3 are GUI-only** → laptop only (X11/i3). The workbench is headless
+  (server-mode).
+- **Full-content keylogging** → `activity.events` holds secrets. That is WHY the store is a
+  dedicated authed ClickHouse, not the shared LAN-open clickstack. Treat reader/writer creds
+  as sensitive.
+- **`home-manager switch` RESTARTS these daemons on a script-only change** (devrc PR #16) —
+  `X-Restart-Triggers` flips the unit definition when the code changes. No manual
+  `systemctl --user restart` after a ship. (`claude-activity-source` is excluded — its 5-min
+  timer oneshot re-runs fresh code anyway.)
+- **`session-summary` / `session-insight` rows are APPEND-ONLY** — dedupe on read with
+  `argMax(<field>, ingested_at)` grouped by `session`.
 
 ## status
 ```bash
@@ -56,154 +99,75 @@ curl -s --user "activity_reader:$RPW" --data-binary "SELECT dateDiff('second', m
 CLICKHOUSE_URL=$CH CLICKHOUSE_USER=activity_reader CLICKHOUSE_PASSWORD=$RPW python3 ~/workspace/devrc/scripts/validation/validate.py
 # keystroke-replay assertions REQUIRE the laptop's X session — run there, not on the headless workbench
 ```
-Invariant changes (2026-06-29): `active_ms_capped` + `per_host_hour_active_cap` were **retired** (PR #26 — extension `active_ms` is no longer trusted/emitted) and replaced by **`derived_attention_consistent`** (per-domain i3-derived attention ≤ total Brave i3 dwell, trailing 48h); the `duration_ms` garbage bound was raised **24h → 7d** (PR #28 — multi-day interactive `claude --resume` is real, was a false positive).
-
-## analysis / mining tooling (deterministic, on-demand)
-- `~/workspace/devrc/scripts/session-analysis/activity-scan.py [--days N] [--json]` — weekly "where workflow time goes + what to automate" report over `activity.events`: automation candidates (top repeated zsh commands + binaries), bottlenecks (binaries by total wait time), signal-vs-noise (i3 switch rate, deep-work blocks, attention-by-app, browser-by-domain). Reads `CLICKHOUSE_URL/USER/PASSWORD` from env (reuses `validation/chquery.py`). Honest caveat baked in: "signal vs noise" = switch-rate/attention-split only; value judgment needs a human/LLM layer.
-- `~/workspace/devrc/scripts/session-analysis/initiative-scan.py [--days N] [--json] [--repo PATH]` — cross-repo **initiative + progress ledger**: fuses handoff docs (the registry) + git (commits/PRs by slug↔branch) + `activity.events` telemetry (recency/momentum by `gitBranch`) into a ranked report — each initiative's momentum (active/slowing/stalled), last-touched, next-step. Reuses the SAME reader creds (`CLICKHOUSE_*` env, `validation/chquery.py`); **degrades to handoff+git** when telemetry is off/unreachable. Surfaced via the **`/initiatives`** command AND folded into `/standup` (the `initiatives` scope, telemetry-OFF). Honest caveat: momentum = recency of touch, NOT % done; initiative↔commit linking is heuristic slug-matching. Collapses git worktrees to their canonical repo. **Momentum now times from the last genuine USER-turn timestamp, not the transcript file mtime** (Claude Code rewrites session `.jsonl` files in place → mtime falsely read as "active"; PR #149). ➜ **This scan is now the engine of a full durable subsystem** — the `initiatives` skill (store in the homelab mailbox Postgres → 15-min sync → live viewer at `192.168.50.250:8899` → LLM recaps → router + read-only assistant). Operate that layer via the **`initiatives` skill**; don't duplicate it here.
-- `~/workspace/devrc/scripts/dogfood-cycle` — collapses the manual civitai dogfood test loop (create→install→token→run→teardown→upgrade) into one command; surfaced as a top automation candidate by activity-scan. `--dry-run` + hard `rm` guards.
+Current invariant set: `active_ms_capped` + `per_host_hour_active_cap` are **retired**
+(extension `active_ms` no longer emitted), replaced by **`derived_attention_consistent`**
+(per-domain i3-derived attention ≤ total Brave i3 dwell, trailing 48h). The `duration_ms`
+garbage bound is **7d**, not 24h — a multi-day interactive `claude --resume` is real.
+`session_summary_rows_bounded` flags >24 rows/session ingested in 24h.
 
 ## troubleshoot a stalled source
-1. `journalctl --user -u <service> -n 30` — `urlopen timed out` = can't reach CH (check the endpoint matches the host: laptop must use the nebula IP).
-2. spool backlog growing = collector can't ship; check `CLICKHOUSE_URL`/creds in `~/.config/activity-collector/env`, then `systemctl --user restart activity-collector`.
-3. browser receiver crash (`ModuleNotFoundError: spool_emit`) = a symlink-resolution regression — receiver must NOT `.resolve()` `__file__`.
+1. `journalctl --user -u <service> -n 30` — `urlopen timed out` = can't reach CH (check the
+   endpoint matches the host: laptop must use the nebula IP).
+2. spool backlog growing = collector can't ship; check `CLICKHOUSE_URL`/creds in
+   `~/.config/activity-collector/env`, then `systemctl --user restart activity-collector`.
+3. browser receiver crash (`ModuleNotFoundError: spool_emit`) = a symlink-resolution
+   regression — the receiver must NOT `.resolve()` `__file__`.
 4. events landing as `host=nixos` = `ACTIVITY_HOST` missing/old code; set env + restart.
 
 ## deploy a change
 ```bash
 # 1. land the code (devrc PR → merge to main)
-# 2. converge both hosts (home-manager)
+# 2. converge both hosts (home-manager) — this also restarts the daemons (see gotchas)
 ~/workspace/devrc/scripts/ship.sh
-# 3. (No manual restart needed since PR #16 — switch restarts them via
-#    X-Restart-Triggers. Only restart by hand if you bypassed ship/switch.)
-#    systemctl --user restart activity-collector keylog browser-activity-receiver
-# Dashboard / CH-manifest changes live in homelab-talos (Flux: commit=deploy) — merge to trunk, then `flux reconcile kustomization charts-prom-stack` (dashboard) or `... apps` (CH).
+# Dashboard / CH-manifest changes live in homelab-talos (Flux: commit=deploy) — merge to
+# trunk, then `flux reconcile kustomization charts-prom-stack` (dashboard) or `... apps` (CH).
 ```
 
-## query patterns (the non-obvious ones)
-The dashboard's row **"Attention (i3 focus) & Reading (scroll)"** (homelab PR #78) has: Attention-by-app, Attention-by-i3-workspace, Reading-depth-by-domain, i3-window-switches-over-time. The old "Browser active time by domain (s)" panel was **replaced** by **"Browser attention by domain (i3-derived, s)"** (homelab-infra PR #79) — since extension `active_ms` is retired, browser attention is now the i3∩domain intersection below. Key reusable SQL:
-```sql
--- i3 "attention" / dwell: focus events are point-in-time (NO stored duration).
--- dwell = gap to the NEXT i3 focus event, CAPPED (30min) so an idle focus doesn't inflate.
-SELECT app, round(sum(dwell_ms)/60000,1) AS dwell_min FROM (
-  SELECT app, kind, least(
-    leadInFrame(toUnixTimestamp64Milli(ts),1,toUnixTimestamp64Milli(ts))
-      OVER (PARTITION BY host ORDER BY ts ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
-      - toUnixTimestamp64Milli(ts), 1800000) AS dwell_ms
-  FROM activity.events WHERE source='i3' AND host IN ('laptop') AND ts > now()-interval 7 day)
-WHERE kind='window-focus' AND app != '' GROUP BY app ORDER BY dwell_min DESC;
--- browser reading depth: scroll lives in payload; extract via toString (NO payload.scroll_pct subcol).
-SELECT domain(text) d, avg(JSONExtractInt(toString(payload),'scroll_pct')) avg_depth,
-       max(JSONExtractInt(toString(payload),'scroll_pct')) max_depth,
-       sum(JSONExtractInt(toString(payload),'scroll_ms'))/1000 scroll_s
-FROM activity.events WHERE source='browser' AND kind='nav' AND text!='' GROUP BY d ORDER BY scroll_s DESC;
--- browser ATTENTION by domain (i3-DERIVED — replaces the retired active_ms): intersect i3
--- "Brave-focused" intervals with the active-tab domain timeline (URL = the `text` column).
-WITH brave AS (SELECT bs, be FROM (SELECT toUnixTimestamp64Milli(ts) bs, app,
-    least(leadInFrame(toUnixTimestamp64Milli(ts),1,toUnixTimestamp64Milli(ts)) OVER (PARTITION BY host ORDER BY ts ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING), toUnixTimestamp64Milli(ts)+1800000) be
-  FROM activity.events WHERE source='i3' AND kind='window-focus' AND host='laptop' AND ts>now()-interval 7 day) WHERE app='Brave-browser'),
-dom AS (SELECT d, ds, least(de, ds+1800000) de FROM (SELECT if(domain(text)!='',domain(text),netloc(text)) d, toUnixTimestamp64Milli(ts) ds,
-    leadInFrame(toUnixTimestamp64Milli(ts),1,toUnixTimestamp64Milli(ts)+1800000) OVER (PARTITION BY host ORDER BY ts ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) de
-  FROM activity.events WHERE source='browser' AND kind='nav' AND text!='' AND host='laptop' AND ts>now()-interval 7 day))
-SELECT d domain, round(sum(greatest(0, least(be,de)-greatest(bs,ds)))/60000,1) min FROM brave CROSS JOIN dom WHERE be>ds AND de>bs GROUP BY d HAVING min>0 ORDER BY min DESC;
-```
-Caveats: i3/scroll exist only for **host=laptop** (GUI). `scroll_pct/ms` are on a SUBSET of nav events (only scrolled pages; un-scrolled report 0) and belong to the LEAVING tab. `workspace` empty on a small share of window-focus events.
+## analysis / mining tooling (deterministic, on-demand)
+All three read `CLICKHOUSE_URL/USER/PASSWORD` from env (via `validation/chquery.py`).
+
+- `~/workspace/devrc/scripts/session-analysis/activity-scan.py [--days N] [--json]` — "where
+  workflow time goes + what to automate": automation candidates (top repeated zsh commands +
+  binaries), bottlenecks (binaries by total wait time), signal-vs-noise (i3 switch rate,
+  deep-work blocks, attention-by-app, browser-by-domain). Caveat: "signal vs noise" =
+  switch-rate / attention-split only; value judgment needs a human/LLM layer.
+- `~/workspace/devrc/scripts/session-analysis/initiative-scan.py [--days N] [--json] [--repo PATH]`
+  — cross-repo initiative + progress ledger (handoff docs + git + telemetry recency by
+  `gitBranch` → momentum `active`/`slowing`/`stalled`, last-touched, next-step).
+  **Degrades to handoff+git** when telemetry is off/unreachable.
+  Surfaced via `/initiatives` and `/standup`. Caveats: momentum = recency of touch, NOT %
+  done; initiative↔commit linking is heuristic slug-matching; git worktrees collapse to
+  their canonical repo. Momentum times from the last genuine USER-turn timestamp, **not the
+  transcript file mtime** (Claude Code rewrites `.jsonl` in place → mtime falsely reads as
+  "active"). ➜ The durable subsystem built on this scan (store → 15-min sync → viewer at
+  `192.168.50.250:8899` → recaps → router + assistant) is the **`initiatives` skill** — don't
+  duplicate it here.
+- `~/workspace/devrc/scripts/session-analysis/insights.py [--days 14] [--insight-days 30] [--json] [--host H] [--html PATH]`
+  — the report over Layer A + the message stream + Layer B. Telemetry-native successor to
+  the built-in `/insights`; the built-in's numbers are NOT trusted (it confabulated).
+- `~/workspace/devrc/scripts/dogfood-cycle` — collapses the manual civitai dogfood loop
+  (create→install→token→run→teardown→upgrade) into one command. `--dry-run` + hard `rm` guards.
 
 ## the human validation only the operator can do
-The harness proves the machinery is correct. Whether it's *true* — pick an hour you remember and confirm the dashboard matches what you actually did — is the operator's spot-check once a day+ of data has accrued.
+The harness proves the machinery is correct. Whether it's *true* — pick an hour you remember
+and confirm the dashboard matches what you actually did — is the operator's spot-check.
 
 ## session insights (Layer B — LLM qualitative facets)
 
-Turns settled Claude sessions into `source=claude, kind=session-insight` rows in
-`activity.events`. Deterministic Python does the plumbing; THIS live session does the
-extraction (no `claude -p`, no external API). Manual/on-demand only. (Layer A =
-`kind=session-summary` deterministic rollups from `claude/session-tailer.py`, on the
-5-min timer; the report `scripts/session-analysis/insights.py` fuses A + B + the
-message stream and is the telemetry-native successor to the built-in `/insights`.)
+Turns settled Claude sessions into `source=claude, kind=session-insight` rows. Deterministic
+Python does the plumbing; **THIS live session does the extraction** (no `claude -p`, no
+external API). Manual/on-demand only, no timer. Prereqs: `CLICKHOUSE_URL/USER/PASSWORD` in
+env (reader creds via SOPS — see Key facts).
 
-**Layer A is EMIT-ON-SETTLE** (since 2026-07-30). It does NOT re-ship a live
-session's rollup every tick any more — it emits once on first sight, at most once
-per `CLAUDE_SUMMARY_INTERIM_HOURS` (default 4) while the session is still live,
-and again whenever the transcript has been idle for
-`CLAUDE_SUMMARY_SETTLE_MINUTES` (default 20) — so a resumed session still gets a
-correct final rollup. State: `~/.local/state/activity/session-summary-state.json`
-(v2: `{"sessions": {path: {sig, emitted_at}}}`; a corrupt/missing file degrades to
-"never emitted", never crashes the timer). Both knobs are read from the
-environment at run time; 0 disables that gate. **The `argMax(<field>,
-ingested_at)` per-`session` read contract is UNCHANGED** — every emit re-reads the
-whole transcript, so the newest row is still the most complete. Expect ~1–5 rows
-per session; the `session_summary_rows_bounded` invariant flags >24 rows/session
-ingested in 24h. Before the fix: 27,061 rows over 702 sessions (avg 38.5, worst
-486, ~1,800/day), 97.4% immediately superseded. The historical duplicates are NOT
-rewritten — they age out under the 180d TTL.
-
-Prereqs: `CLICKHOUSE_URL/USER/PASSWORD` in env (reader creds via SOPS — see top of this skill;
-`sops -d` on a `<(git show …)` process-substitution needs `--input-type yaml`).
-
-**1. See what's pending (no writes):**
 ```bash
-python3 ~/workspace/devrc/scripts/session-analysis/session_insight/cli.py status --json
+CLI=~/workspace/devrc/scripts/session-analysis/session_insight/cli.py
+python3 $CLI status --json                          # 1. what's pending (no writes)
+python3 $CLI prepare --days 14 --limit 6 --json     # 2. select settled+un-extracted, scrub,
+                                                    #    attach Layer A ground truth
+                                                    #    → prints run_id, staging dir, input.json paths
+# 3. EXTRACT — read each input.json, write results/<run-id>/<session>.result.json per the
+#    schema in the input. 🔴 FIRST read reference/session-insights.md (the anti-confabulation
+#    contract + how to batch/fan out) — do not extract from memory of these rules.
+python3 $CLI write --run-id <id> --json             # 4. validate + emit to ClickHouse
+python3 ~/workspace/devrc/scripts/session-analysis/insights.py --days 30   # 5. read the report
 ```
-
-**2. Prepare a batch (deterministic: select settled + un-extracted, scrub, attach ground truth):**
-```bash
-python3 ~/workspace/devrc/scripts/session-analysis/session_insight/cli.py \
-    prepare --days 14 --limit 20 --json
-# prints: run_id, staging dir, and the per-session input.json paths.
-```
-
-**3. Extract (THIS session does the work):** read each `input.json` and, per session,
-write `results/<run-id>/<session>.result.json` conforming to the schema in the input.
-- 1 session → do it inline.
-- A backlog (>3) → fan out with the Agent tool (`general-purpose`), one disjoint slice of
-  sessions per subagent, each writing its result.json. NO worktree isolation needed — the
-  agents only READ staging inputs and WRITE result files under `~/.local/state/…`, never the repo.
-- Per session it is MAP-REDUCE: note qualitative observations per `chunk`, then reduce to ONE
-  result.json. Counts come from `ground_truth` — never recount.
-
-**4. Write to ClickHouse (deterministic: validate + emit):**
-```bash
-python3 ~/workspace/devrc/scripts/session-analysis/session_insight/cli.py write --run-id <id> --json
-```
-
-**5. Read the report:**
-```bash
-CLICKHOUSE_URL=… CLICKHOUSE_USER=activity_reader CLICKHOUSE_PASSWORD=… \
-    python3 ~/workspace/devrc/scripts/session-analysis/insights.py --days 30
-```
-
-### Extraction rules (the anti-confabulation contract — NON-NEGOTIABLE)
-- The `ground_truth` block = DETERMINISTIC counts (tools, tokens, commits, files, lines, errors,
-  interruptions, models, durations). They are FACTS. Do NOT contradict, restate-as-if-counted,
-  or invent ANY count/limit/metric. There is **no "output-token maximum"** — that was a
-  confabulation by the old built-in; do not reproduce it.
-- Your job is ONLY the qualitative facets: underlying_goal, goal_categories, outcome,
-  session_type, claude_helpfulness (1–5: 5=Claude materially drove the win … 1=mostly got in the way),
-  friction_counts + friction_detail (INTERACTION friction — wrong approaches, repeated corrections
-  — distinct from mechanical tool_errors), primary_success, brief_summary, and the
-  automation_opportunity / recurring_toil / workflow_gap observations (these three are WHY this
-  data exists — be concrete and evidence-backed).
-- Use only the controlled enum values given in the input's `schema` block.
-- If a (chunked) transcript is too degraded/truncated/ambiguous to judge honestly, set
-  `unreadable=true` + a one-line `unreadable_reason` and leave qualitative fields empty.
-  **Flag it — never fabricate.**
-- `<REDACTED:…>` tokens are scrubbed secrets; treat as opaque, never guess the original.
-
-### Operating the backlog (real-run lessons)
-Lessons from an actual 8-session run:
-- **Scale**: ~90+ sessions are typically pending (`status --json` → `candidates`). Extract in
-  BOUNDED batches (`prepare --limit ~6`) — the real cost is THIS operating session's own tokens,
-  so never fan the whole backlog at once.
-- **Session sizes vary wildly** — some transcripts are 250–280 `chunks`. Give each such MONSTER
-  session its OWN extraction subagent, and tell subagents to SAMPLE strategically: first ~3 chunks
-  (goal), last ~3 (outcome), ~every 25th middle chunk (friction/automation/toil/gap signals).
-  NEVER read all chunks — it blows context and the counts come from `ground_truth` anyway. Batch
-  several SMALL sessions (<~40 chunks) per subagent.
-- **`write --run-id <id>`** validates + emits + PURGES each session's staging/result on success
-  (per-session); a session that's missing/conflict/rejected is RETAINED for re-run. Re-runs are
-  append-only (argMax-latest wins); `--force` re-extracts.
-- **What it produces** (so the value is legible): the first 8-session batch surfaced a dominant
-  **config-as-code gap for the storage/CDN layer** (CORS / CF-rules / egress-IPs managed
-  out-of-band, not in git — recurred ×5 across incidents) and **B2-incident tooling as repeated
-  toil** (~18 throwaway probe scripts / hand-launched diagnostic Jobs across ≥3 sessions) — the
-  leverage-ranked automation/toil/gap outputs.

--- a/claude/skills/activity/reference/queries.md
+++ b/claude/skills/activity/reference/queries.md
@@ -1,0 +1,71 @@
+# activity — query patterns (the non-obvious ones)
+
+Read this when writing a NEW query over `activity.events`, or when touching the
+Grafana dashboard's attention/reading panels. Everyday status/health queries are
+inline in `SKILL.md`.
+
+## Dashboard context
+
+Row **"Attention (i3 focus) & Reading (scroll)"** (homelab PR #78): Attention-by-app,
+Attention-by-i3-workspace, Reading-depth-by-domain, i3-window-switches-over-time.
+"Browser active time by domain (s)" was **replaced** by "Browser attention by domain
+(i3-derived, s)" (homelab-infra PR #79) — extension `active_ms` is retired, so browser
+attention is the i3∩domain intersection below.
+
+## Caveats that make these queries non-obvious
+
+- i3 focus events are **point-in-time — there is NO stored duration**. Dwell = the gap to
+  the NEXT focus event, CAPPED (30 min) so an idle focus does not inflate it.
+- The URL is the **`text`** column, NOT `payload.url`.
+- Scroll must be extracted with `JSONExtractInt(toString(payload),'scroll_pct')` —
+  **`payload.scroll_pct` subcolumn access is NOT available.**
+- A nav event's `text`/`title` are the **DESTINATION** tab, but its `scroll_pct`/`scroll_ms`
+  belong to the **LEAVING** tab.
+- `scroll_pct`/`scroll_ms` exist on a SUBSET of nav events only (scrolled pages;
+  un-scrolled report 0).
+- i3 + scroll exist only for **`host=laptop`** (GUI). `workspace` is empty on a small
+  share of window-focus events.
+- `ts` is the **UTC instant**. Group by local hour/day only with an explicit
+  `'America/Winnipeg'` tz arg (`toHour`/`toDate`); NEVER tz-shift `$__timeFilter` or a
+  range comparison against `now()`.
+
+## i3 attention / dwell by app
+
+```sql
+SELECT app, round(sum(dwell_ms)/60000,1) AS dwell_min FROM (
+  SELECT app, kind, least(
+    leadInFrame(toUnixTimestamp64Milli(ts),1,toUnixTimestamp64Milli(ts))
+      OVER (PARTITION BY host ORDER BY ts ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+      - toUnixTimestamp64Milli(ts), 1800000) AS dwell_ms
+  FROM activity.events WHERE source='i3' AND host IN ('laptop') AND ts > now()-interval 7 day)
+WHERE kind='window-focus' AND app != '' GROUP BY app ORDER BY dwell_min DESC;
+```
+
+## Browser reading depth by domain
+
+```sql
+SELECT domain(text) d, avg(JSONExtractInt(toString(payload),'scroll_pct')) avg_depth,
+       max(JSONExtractInt(toString(payload),'scroll_pct')) max_depth,
+       sum(JSONExtractInt(toString(payload),'scroll_ms'))/1000 scroll_s
+FROM activity.events WHERE source='browser' AND kind='nav' AND text!='' GROUP BY d ORDER BY scroll_s DESC;
+```
+
+## Browser ATTENTION by domain (i3-DERIVED — replaces the retired `active_ms`)
+
+Intersect i3 "Brave-focused" intervals with the active-tab domain timeline.
+
+```sql
+WITH brave AS (SELECT bs, be FROM (SELECT toUnixTimestamp64Milli(ts) bs, app,
+    least(leadInFrame(toUnixTimestamp64Milli(ts),1,toUnixTimestamp64Milli(ts)) OVER (PARTITION BY host ORDER BY ts ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING), toUnixTimestamp64Milli(ts)+1800000) be
+  FROM activity.events WHERE source='i3' AND kind='window-focus' AND host='laptop' AND ts>now()-interval 7 day) WHERE app='Brave-browser'),
+dom AS (SELECT d, ds, least(de, ds+1800000) de FROM (SELECT if(domain(text)!='',domain(text),netloc(text)) d, toUnixTimestamp64Milli(ts) ds,
+    leadInFrame(toUnixTimestamp64Milli(ts),1,toUnixTimestamp64Milli(ts)+1800000) OVER (PARTITION BY host ORDER BY ts ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) de
+  FROM activity.events WHERE source='browser' AND kind='nav' AND text!='' AND host='laptop' AND ts>now()-interval 7 day))
+SELECT d domain, round(sum(greatest(0, least(be,de)-greatest(bs,ds)))/60000,1) min FROM brave CROSS JOIN dom WHERE be>ds AND de>bs GROUP BY d HAVING min>0 ORDER BY min DESC;
+```
+
+## Append-only kinds — dedupe on read
+
+`kind=session-summary` and `kind=session-insight` are **append-only**: several rows exist
+per `session`. Always dedupe with `argMax(<field>, ingested_at)` grouped by `session` —
+the newest row is the most complete (every emit re-reads the whole transcript).

--- a/claude/skills/activity/reference/session-insights.md
+++ b/claude/skills/activity/reference/session-insights.md
@@ -1,0 +1,65 @@
+# activity — Layer B session insights: extraction contract + backlog operations
+
+Read this **before doing an extraction run** (step 3 of the Layer B flow in `SKILL.md`).
+It carries the anti-confabulation contract you must follow while extracting, and the
+lessons from running a real backlog.
+
+## Extraction rules (the anti-confabulation contract — NON-NEGOTIABLE)
+
+- The `ground_truth` block = DETERMINISTIC counts (tools, tokens, commits, files, lines,
+  errors, interruptions, models, durations). They are FACTS. Do NOT contradict,
+  restate-as-if-counted, or invent ANY count/limit/metric. There is **no "output-token
+  maximum"** — that was a confabulation by the old built-in; do not reproduce it.
+- Your job is ONLY the qualitative facets: `underlying_goal`, `goal_categories`, `outcome`,
+  `session_type`, `claude_helpfulness` (1–5: 5 = Claude materially drove the win … 1 =
+  mostly got in the way), `friction_counts` + `friction_detail` (INTERACTION friction —
+  wrong approaches, repeated corrections — distinct from mechanical `tool_errors`),
+  `primary_success`, `brief_summary`, and the `automation_opportunity` /
+  `recurring_toil` / `workflow_gap` observations (these three are WHY this data exists —
+  be concrete and evidence-backed).
+- Use only the controlled enum values given in the input's `schema` block.
+- If a (chunked) transcript is too degraded/truncated/ambiguous to judge honestly, set
+  `unreadable=true` + a one-line `unreadable_reason` and leave qualitative fields empty.
+  **Flag it — never fabricate.**
+- `<REDACTED:…>` tokens are scrubbed secrets; treat as opaque, never guess the original.
+- Per session it is MAP-REDUCE: note qualitative observations per `chunk`, then reduce to
+  ONE `result.json`. Counts come from `ground_truth` — never recount.
+
+## Operating the backlog (lessons from a real 8-session run)
+
+- **Scale**: ~90+ sessions are typically pending (`status --json` → `candidates`). Extract
+  in BOUNDED batches (`prepare --limit ~6`) — the real cost is THIS operating session's own
+  tokens, so never fan the whole backlog at once.
+- **Fan-out**: >3 sessions → use the Agent tool (`general-purpose`), one disjoint slice per
+  subagent, each writing its own `result.json`. **No worktree isolation needed** — agents
+  only READ staging inputs and WRITE results under `~/.local/state/…`, never the repo.
+- **Session sizes vary wildly** — some transcripts are 250–280 `chunks`. Give each such
+  MONSTER session its OWN subagent, and tell subagents to SAMPLE strategically: first ~3
+  chunks (goal), last ~3 (outcome), ~every 25th middle chunk (friction / automation / toil /
+  gap signals). NEVER read all chunks — it blows context, and the counts come from
+  `ground_truth` anyway. Batch several SMALL sessions (<~40 chunks) per subagent.
+- **`write --run-id <id>`** validates + emits + PURGES each session's staging/result on
+  success (per-session); a session that is missing/conflict/rejected is RETAINED for
+  re-run. Re-runs are append-only (argMax-latest wins); `--force` re-extracts.
+- **What it produces** (so the value is legible): the first 8-session batch surfaced a
+  dominant **config-as-code gap for the storage/CDN layer** (CORS / CF-rules / egress-IPs
+  managed out-of-band, not in git — recurred ×5 across incidents) and **B2-incident tooling
+  as repeated toil** (~18 throwaway probe scripts / hand-launched diagnostic Jobs across ≥3
+  sessions) — the leverage-ranked automation/toil/gap outputs.
+
+## Layer A emit-on-settle (why there are several rows per session)
+
+`kind=session-summary` (`claude/session-tailer.py`, 5-min timer) emits once on first sight,
+at most once per `CLAUDE_SUMMARY_INTERIM_HOURS` (default 4) while the session is live, and
+again whenever the transcript has been idle `CLAUDE_SUMMARY_SETTLE_MINUTES` (default 20) —
+so a `--resume`d session still gets a correct final rollup. Both knobs are read from the
+environment at run time; `0` disables that gate.
+
+State: `~/.local/state/activity/session-summary-state.json`
+(v2: `{"sessions": {path: {sig, emitted_at}}}`; a corrupt/missing file degrades to "never
+emitted", never crashes the timer).
+
+Expect ~1–5 rows per session; the `session_summary_rows_bounded` invariant flags >24
+rows/session ingested in 24h. Historical duplicates (pre-2026-07-30: 27,061 rows over 702
+sessions, avg 38.5, worst 486, 97.4% immediately superseded) are NOT rewritten — they age
+out under the 180d TTL.

--- a/claude/skills/mailbox/SKILL.md
+++ b/claude/skills/mailbox/SKILL.md
@@ -5,7 +5,9 @@ description: Operate the self-hosted personal mail inbox AND its email-automatio
 
 # self-hosted mail inbox operations
 
-Forward Gmail → an address you control → a durable, queryable Postgres store, fully self-hosted (no Gmail API, no third party). Built 2026-06-24 and verified end-to-end with a real MX-routed delivery. Full point-in-time state lives in memory `selfhosted-mail-inbox` (read it first).
+Gmail forwards → an address you control → a durable, queryable Postgres store, fully
+self-hosted (no Gmail API, no third party). Point-in-time state: memory
+`selfhosted-mail-inbox` (read it first).
 
 **Mail flow (the whole chain):**
 ```
@@ -19,6 +21,12 @@ homelab gateway 10.42.0.10:2525  (homelab nebula-gateway nginx: proxy_pass mail-
 mail-receiver (aiosmtpd)  parse → UPSERT (dedup on Message-ID) → Postgres `mail`
 ```
 
+**Reference file** (repo-absolute; read on demand):
+`~/workspace/devrc/claude/skills/mailbox/reference/build-dns-forwarding.md` — rebuilding the
+receiver image, the Cloudflare mail-DNS runbook, the postfix-relay test send, Gmail
+forwarding setup, and the gateway-restart / cutover-rollback / Mailpit notes. Read it before
+touching the image, DNS, the gateway ConfigMap, or forwarding.
+
 ## Key facts (verify against live state before asserting)
 
 | Thing | Value |
@@ -27,24 +35,56 @@ mail-receiver (aiosmtpd)  parse → UPSERT (dedup on Message-ID) → Postgres `m
 | App manifests | `clusters/homelab/apps/mailbox/` — `namespace`, `postgres.yaml`, `receiver.yaml`, `configmap-schema.yaml`, `secrets.enc.yaml`, `nodeport.yaml`, `kustomization.yaml`, `src/receiver.py` + `src/receiver_test.py`. Flux Kustomization `mailbox` (`root-kustomizations/system/mailbox.yaml`), parent ks `homelab` |
 | Receiver image | `harbor.homelab.lan/library/mail-receiver:0.1.2` (BAKED aiosmtpd+asyncpg, runs uid 10001 — NOT runtime-pip). Built from `src/receiver.py` |
 | Receiver | ns `mailbox`, Deployment `mail-receiver`, ClusterIP `mail-receiver.mailbox.svc:2525`, NodePort **30026**. Env: `PG_DSN` (secretKeyRef), `MAILPIT_HOST` (empty = onward relay OFF) |
-| Postgres | ns `mailbox`, `mailbox-postgres-0` (StatefulSet), ClusterIP `mailbox-postgres:5432`, db/user `mailbox`, PVC `openebs-nvme-1tb`. Password in secret `mailbox-postgres-auth` (key `pg-dsn`). **This same DB now ALSO hosts the `initiatives` schema** (store/recaps/assistant_log) — see the `initiatives` skill; the two schemas share the instance, `_db.py`, and the port-forward |
+| Postgres | ns `mailbox`, `mailbox-postgres-0` (StatefulSet), ClusterIP `mailbox-postgres:5432`, db/user `mailbox`, PVC `openebs-nvme-1tb`. Password in secret `mailbox-postgres-auth` (key `pg-dsn`). **Also hosts the `initiatives` schema** — same instance, `_db.py` and port-forward; see the `initiatives` skill |
 | `mail` schema | `id, message_id (UNIQUE), received_at, date_header, from_addr, to_addrs[], cc_addrs[], subject, headers jsonb, text_body, html_body, raw bytea, size_bytes, labels text[], processed_at, search tsvector (GIN)` |
-| Cluster access | mailbox app + receiver: `KUBECONFIG=~/workspace/homelab-talos/homelab-kubeconfig`. Gateway :25 + CF DNS + postfix test-send: `~/workspace/homelab-talos/production-kubeconfig`. **From the laptop** (nebula-only): `KUBECONFIG=~/.kube/homelab-nebula.yaml` (proxy-url SOCKS via the `homelab-kube-tunnel` service → workbench `10.42.0.30`); rebuild step still needs the workbench (Harbor is LAN) |
+| Cluster access | mailbox app + receiver: `KUBECONFIG=~/workspace/homelab-talos/homelab-kubeconfig`. Gateway :25 + CF DNS + postfix test-send: `~/workspace/homelab-talos/production-kubeconfig`. **From the laptop** (nebula-only): `KUBECONFIG=~/.kube/homelab-nebula.yaml` (proxy-url SOCKS via the `homelab-kube-tunnel` service → workbench `10.42.0.30`); the rebuild step still needs the workbench (Harbor is LAN) |
 | Gateway configs | homelab: `clusters/homelab/apps/nebula/gateway/gateway-nginx-config.yaml` (ConfigMap `nebula-gateway-nginx-config`, the `:2525 → mail-receiver.mailbox.svc` line). Hetzner: `clusters/production/apps/nebula/gateway/gateway-nginx-config.yaml` (`listen 0.0.0.0:25`). Both are the `nebula-gateway` DaemonSet (ns `nebula`, container `nginx-proxy`) |
-| Cloudflare | zone `zacx.dev` id `72f00688be30dfc863a2c84fa6ab771c`. Token: secret `cloudflare-api-token`/`cloudflare_api_token` in **production** ns `external-dns` (DNS-edit scope ONLY — NOT Email Routing admin). Mail records managed **directly via CF API** (NOT external-dns — avoids the flap) |
-| Build context | `/tmp/mail-receiver-build/` this session (`Dockerfile`, `receiver.py`, `requirements.txt` = `aiosmtpd==1.4.6` + `asyncpg==0.30.0`). `docker` on workbench is already authed to `harbor.homelab.lan` |
+| Cloudflare | zone `zacx.dev` id `72f00688be30dfc863a2c84fa6ab771c`. Token: secret `cloudflare-api-token`/`cloudflare_api_token` in **production** ns `external-dns` (DNS-edit scope ONLY — NOT Email Routing admin). Mail records managed **directly via CF API**, NOT external-dns (avoids the flap) |
 
-## Email-automation layer — `mail-actions` (shipped 2026-06-29/30)
-Built ON TOP of this `mail` table: **`~/workspace/devrc/scripts/mail-actions/`** (devrc, on `main`; PRs #31–35 + homelab-infra #80/#81). Operate from the **workbench** (reaches the cluster via `kubectl port-forward`). Deterministic-first; the only LLM/$ is the action-extractor's Stage 2 (OpenRouter, survivors only — sub-cent/run).
+## Email-automation layer — `mail-actions`
 
-**Three capabilities:**
-- **Action-required extractor** — `extract.py run` (needs `OPENROUTER_API_KEY`). Stage-1 DETERMINISTIC filter (`filter.py`: drops `category=alert`, bulk/`List-*`/`Feedback-ID`, operator denylists [github/npm/pagerduty/bugsnag/clickup/nasdaq/avianca/resend-dunning + voip "low balance"]; **billing exemption** rescues invoices that carry bulk headers) → LLM (`deepseek/deepseek-v4-flash`) on the few survivors → `mail_actions` rows. **Thread-aware:** one live action per thread (newer msg supersedes older OPEN action; your reply auto-closes). `extract.py list` = open actions. `--emit-clawgate` posts a Task card each. `--dry-run` / `--limit N`. **MANUAL / on-demand** (operator's choice — NOT scheduled).
-- **Invoice archiver** — `extract.py archive-invoices` (deterministic, no LLM). Scans ALL via_gmail mail w/ a PDF + billing signal (full backlog, incl. paid/fyi) → uploads PDF + JSON sidecar `{vendor,from,date,amount,subject,message_id,mail_id}` to the **minio-archive** tenant bucket `taxes-{year}-invoices` (key `{vendor}/{date}-{file}`). Idempotent via `invoice-archived` label. **SCHEDULED daily 06:00** — workbench home-manager systemd user timer `mail-actions-archive.timer` (wrapper `scripts/mail-actions/run-archive.sh`; check `systemctl --user list-timers | grep mail-actions`).
-- **Sent-mail poller** — captures YOUR sent replies so reconcile auto-closes actions. **LIVE in-cluster CronJob** `sent-poller` (ns `mailbox`, `*/10`, image `mail-sent-poller:0.1.1`, src `clusters/homelab/apps/mailbox/src/sent_poller.py`). IMAP-pulls Gmail `[Gmail]/Sent Mail` (app-password in SOPS secret `mailbox-gmail-imap`, encrypted to `age1g0nfddt…dqfdj64t`) → re-injects raw via SMTP into the receiver (deduped). Cold start = last `SENT_LOOKBACK_DAYS`=30 only (`UID SEARCH SINCE`); batched (`FETCH_BATCH`=25, commits `last_uid` per batch — the first design did `FETCH 1:*` and OOMKilled). Cursor in `mail_sync_state`.
+Built ON TOP of the `mail` table: **`~/workspace/devrc/scripts/mail-actions/`**. Operate from
+the **workbench** (reaches the cluster via `kubectl port-forward`). Deterministic-first; the
+only LLM/$ is the extractor's Stage 2 (OpenRouter, survivors only — sub-cent/run).
 
-**New tables (auto-created by the tools):** `mail_actions(mail_id,message_id,from_addr,subject,received_at,who,ask,deadline,amount,confidence,reason,status[open|done|superseded],thread_key,created_at)`; `mail_sync_state(folder,uidvalidity,last_uid)`. **New `mail.labels`:** `bulk|fyi|action-required|invoice|superseded|dismissed|sent|invoice-archived`.
+- **Action-required extractor** — `extract.py run` (needs `OPENROUTER_API_KEY`). Stage-1
+  DETERMINISTIC filter (`filter.py`: drops `category=alert`, bulk/`List-*`/`Feedback-ID`,
+  operator denylists [github/npm/pagerduty/bugsnag/clickup/nasdaq/avianca/resend-dunning +
+  voip "low balance"]; a **billing exemption** rescues invoices that carry bulk headers) →
+  LLM (`deepseek/deepseek-v4-flash`) on the few survivors → `mail_actions` rows.
+  **Thread-aware: ONE LIVE ACTION PER THREAD** — a newer message supersedes the older OPEN
+  action; your reply auto-closes it. `extract.py list` = open actions. `--emit-clawgate`
+  posts a Task card each. `--dry-run` / `--limit N`. **MANUAL / on-demand** by operator
+  choice — NOT scheduled.
+- **Invoice archiver** — `extract.py archive-invoices` (deterministic, no LLM). Scans ALL
+  `via_gmail` mail with a PDF + billing signal (full backlog, incl. paid/fyi) → uploads the
+  PDF + a JSON sidecar `{vendor,from,date,amount,subject,message_id,mail_id}` to the
+  **minio-archive** tenant bucket **`taxes-{year}-invoices`**, key **`{vendor}/{date}-{file}`**.
+  Idempotent via the `invoice-archived` label. **SCHEDULED daily 06:00** — workbench
+  home-manager systemd user timer `mail-actions-archive.timer` (wrapper
+  `scripts/mail-actions/run-archive.sh`; check `systemctl --user list-timers | grep mail-actions`).
+- **Sent-mail poller** — captures YOUR sent replies so reconcile auto-closes actions. **LIVE
+  in-cluster CronJob** `sent-poller` (ns `mailbox`, `*/10`, image `mail-sent-poller:0.1.1`,
+  src `clusters/homelab/apps/mailbox/src/sent_poller.py`). IMAP-pulls Gmail
+  `[Gmail]/Sent Mail` (app-password in SOPS secret `mailbox-gmail-imap`, encrypted to
+  `age1g0nfddt…dqfdj64t`) → re-injects raw via SMTP into the receiver (deduped). Cold start
+  = last `SENT_LOOKBACK_DAYS`=30 only (`UID SEARCH SINCE`); batched (`FETCH_BATCH`=25,
+  commits `last_uid` per batch — **the first design did `FETCH 1:*` and OOMKilled**). Cursor
+  in `mail_sync_state`.
 
-**`_db.py` (`MailDB`) — the shared DB access layer** (also used by repo-cos + the initiatives subsystem). Default = kubectl **port-forward** on an ephemeral local port (off-cluster workbench tools). PR #156 added an additive, opt-in **in-cluster DIRECT-DB mode** for a future in-cluster consumer (the initiatives agent): set **`MAILBOX_PG_HOST`** (e.g. `mailbox-postgres.mailbox.svc.cluster.local`, +optional `MAILBOX_PG_PORT`) OR **`MAILBOX_PG_DIRECT=1`** (uses the DSN's own host) → connects directly, **no kubectl/port-forward/subprocess**. Unset (existing callers) → the port-forward default, unchanged. Load `_db.py` by **explicit importlib path, NOT `sys.path`** (its `llm.py` shadows repo-cos's).
+**Tables auto-created by the tools:**
+`mail_actions(mail_id,message_id,from_addr,subject,received_at,who,ask,deadline,amount,confidence,reason,status[open|done|superseded],thread_key,created_at)`;
+`mail_sync_state(folder,uidvalidity,last_uid)`.
+**`mail.labels` values:** `bulk|fyi|action-required|invoice|superseded|dismissed|sent|invoice-archived`.
+
+**`_db.py` (`MailDB`) — the shared DB access layer** (also used by repo-cos + initiatives).
+Default = kubectl **port-forward** on an ephemeral local port (off-cluster workbench tools).
+Opt-in in-cluster DIRECT-DB mode: set **`MAILBOX_PG_HOST`** (e.g.
+`mailbox-postgres.mailbox.svc.cluster.local`, + optional `MAILBOX_PG_PORT`) **OR**
+**`MAILBOX_PG_DIRECT=1`** (uses the DSN's own host) → connects directly, no
+kubectl/port-forward/subprocess. Unset → the port-forward default, unchanged.
+⚠ Load `_db.py` by **explicit importlib path, NOT `sys.path`** — its `llm.py` shadows
+repo-cos's.
 
 ```bash
 # manual action extraction (workbench; needs OPENROUTER_API_KEY)
@@ -58,14 +98,26 @@ kubectl -n mailbox exec mailbox-postgres-0 -- psql -U mailbox -d mailbox -c \
 # sent-poller health:  kubectl -n mailbox get cronjob sent-poller; kubectl -n mailbox logs job/<sent-poller-…>
 ```
 
-**Automation gotchas:** (1) extractor `--limit` caps rows PULLED most-recent-first (default 150) → to drain a backlog use `--limit 4000`. (2) **invoices are NEVER action items** (auto-paid → archive only). (3) dead threads / handled items → mark `dismissed` in mail state, **NEVER** a filter rule (keeps future mail from that party flowing). (4) sent-poller needs a Gmail **app-password** (= full-mailbox IMAP) in `mailbox-gmail-imap`; cold-start only goes back 30d; a fully-failed inject batch still advances `last_uid` (won't wedge, won't retry — Message-ID dedup makes a manual rescan safe). (5) archive vendor-domain key uses a last-2-labels heuristic (wrong for `.co.uk`). (6) **ROTATE**: an OpenRouter key + the Gmail app-password were pasted into a 2026-06-29 session transcript.
+**Automation gotchas:**
+1. extractor `--limit` caps rows PULLED most-recent-first (default 150) → to drain a backlog
+   use `--limit 4000`.
+2. **Invoices are NEVER action items** (auto-paid → archive only).
+3. Dead threads / handled items → mark `dismissed` in mail state, **NEVER** a filter rule
+   (keeps future mail from that party flowing).
+4. The sent-poller needs a Gmail **app-password** (= full-mailbox IMAP) in
+   `mailbox-gmail-imap`; cold-start only goes back 30d; a fully-failed inject batch still
+   advances `last_uid` (won't wedge, won't retry — Message-ID dedup makes a manual rescan
+   safe).
+5. The archive vendor-domain key uses a last-2-labels heuristic (wrong for `.co.uk`).
+6. **ROTATE**: an OpenRouter key + the Gmail app-password were pasted into a 2026-06-29
+   session transcript.
 
-## send email AS the operator (Gmail SMTP + app-password) — to ANY recipient
+## Send email AS the operator (Gmail SMTP + app-password) — to ANY recipient
+
 The SAME Gmail app-password the sent-poller uses for IMAP **read** also authenticates SMTP
 **send** for that account — so an agent can send mail **as `zachlowden1@gmail.com` to
-anyone** (real Gmail deliverability; NOT the `@mail.zacx.dev` postfix-relay test-send below).
-This is the outbound counterpart to the inbound flow. Proven live by `repo-cos` (its weekly
-digest emails through this path).
+anyone** (real Gmail deliverability; NOT the `@mail.zacx.dev` postfix-relay test-send).
+Proven live by `repo-cos` (its weekly digest emails through this path).
 
 - **Credential:** SOPS secret `mailbox-gmail-imap` in homelab-talos trunk — key
   `IMAP_APP_PASSWORD`, user `IMAP_USER` (= `zachlowden1@gmail.com`).
@@ -88,8 +140,8 @@ PY'
 ```
 - **Caveats:** recipients see the operator's REAL Gmail address (`From:` = his Gmail); Gmail
   caps ~500 recipients/day; confirm the recipient + body with the operator before sending
-  outward-facing mail (this publishes as him). To send AS a `@mail.zacx.dev` domain
-  instead, use the postfix relay (see "test send"), not this path.
+  outward-facing mail (this publishes as him). To send AS a `@mail.zacx.dev` domain instead,
+  use the postfix relay (reference file), not this path.
 
 ## status / query
 ```bash
@@ -101,71 +153,35 @@ $PSQL "select count(*) total, max(received_at) latest from mail;"
 $PSQL "select id,left(from_addr,40),left(subject,46),received_at from mail order by received_at desc limit 10;"
 # full-text search (the STORED tsvector + GIN index):
 $PSQL "select id,from_addr,subject from mail where search @@ websearch_to_tsquery('english','sales audit');"
-# automation state columns: labels text[] + processed_at (claim/track messages)
-# SPAM / NOISE classification (STORED generated cols, auto-computed):
-#   via_gmail boolean — DETERMINISTIC spam filter: 100% of real mail is Gmail-
-#     forwarded (Delivered-To: <your gmail>), so via_gmail=FALSE = direct-to-MX
-#     junk (scanners) + the rare setup-confirmation. Filter: WHERE via_gmail.
-#   category text — coarse sender class (security/alert/notification/personal),
-#     a HEURISTIC (newsletters may land in 'personal'). Edit the CASE in
-#     configmap-schema.yaml (one ALTER) to refine.
 # "important mail" (drops spam AND the loud-but-legit Civitai/GitHub volume):
 $PSQL "select to_char(received_at,'MM-DD HH24:MI') t,category,from_addr,subject from mail where via_gmail and category in ('personal','security') order by received_at desc limit 20;"
 ```
-
-## rebuild the receiver (after editing src/receiver.py)
-The image is **baked** (no runtime pip) — a code change needs a rebuild + tag bump.
-```bash
-# 1. edit clusters/homelab/apps/mailbox/src/receiver.py (in a worktree off trunk — the
-#    main homelab-talos tree carries heavy pre-existing drift; NEVER git add -A there)
-cp <edited>/receiver.py /tmp/mail-receiver-build/receiver.py
-docker build -t harbor.homelab.lan/library/mail-receiver:<NEWTAG> /tmp/mail-receiver-build && \
-  docker push harbor.homelab.lan/library/mail-receiver:<NEWTAG>
-# 2. bump the image tag in clusters/homelab/apps/mailbox/receiver.yaml, commit → PR → merge trunk
-# 3. flux reconcile source git flux-system && flux reconcile kustomization mailbox
-#    kubectl -n mailbox rollout status deploy/mail-receiver
-# Test before relying: send to NodePort 30026 from the LAN, confirm a row lands (see "test send")
-```
-
-## test send (no Gmail needed — proves the real public path)
-```bash
-# From a PRODUCTION pod via the postfix relay → MX-routes through the real chain.
-# Relay allows From @mail.zacx.dev (ALLOWED_SENDER_DOMAINS); MYNETWORKS covers pods.
-KUBECONFIG=~/workspace/homelab-talos/production-kubeconfig kubectl -n nebula run mailtest-$RANDOM \
-  --rm -i --restart=Never --image=python:3.12-slim --command -- python3 -c '
-import smtplib; from email.message import EmailMessage
-m=EmailMessage(); m["Message-ID"]="<t@mail.zacx.dev>"; m["From"]="probe@mail.zacx.dev"
-m["To"]="test@inbox.zacx.dev"; m["Subject"]="E2E test"; m.set_content("x")
-s=smtplib.SMTP("postfix-relay.nebula.svc.cluster.local",587,timeout=25); s.send_message(m); s.quit()
-print("submitted")'
-# then check Postgres for subject "E2E test". A LAN-local quick test: SMTP to <nodeIP>:30026 directly.
-```
-
-## DNS (Cloudflare, managed directly via API)
-```bash
-KUBECONFIG=~/workspace/homelab-talos/production-kubeconfig
-CFT=$(kubectl -n external-dns get secret cloudflare-api-token -o jsonpath='{.data.cloudflare_api_token}' | base64 -d)
-ZID=72f00688be30dfc863a2c84fa6ab771c
-# list mail records:
-curl -s -H "Authorization: Bearer $CFT" "https://api.cloudflare.com/client/v4/zones/$ZID/dns_records?type=MX&per_page=100"
-# REQUIRED state: inbox.zacx.dev MX 10 mx-in.zacx.dev ; mx-in.zacx.dev A 5.161.118.55 with proxied=FALSE
-# (PATCH proxied:false on the A record id if it's ever orange — SMTP can't cross the CF proxy)
-```
-
-## Gmail forwarding (operator's manual step — NOT API-accessible)
-The Gmail-side toggle is a Settings action no API/MCP exposes (the Gmail integration can only draft/label/search). Operator: Gmail → Settings → Forwarding and POP/IMAP → add `<anything>@inbox.zacx.dev`. Gmail sends a verification email that **lands in Postgres** — pull the confirm link/code:
-```bash
-$PSQL "select id,from_addr,subject from mail where from_addr='forwarding-noreply@google.com' order by received_at desc;"
-$PSQL "select text_body from mail where id=<id>;"   # the 'vf-…' link CONFIRMS; the 'uf-…' link CANCELS
-```
-The operator must click the `vf-` link in a real browser — WebFetch reaches the page but can't press the final Confirm button (needs the Gmail session). Then set "Forward a copy…" (or a filter) in Gmail.
+STORED generated columns (auto-computed) + the automation state columns:
+- **`via_gmail boolean`** — the DETERMINISTIC spam filter: 100% of real mail is
+  Gmail-forwarded (`Delivered-To: <your gmail>`), so `via_gmail=FALSE` = direct-to-MX junk
+  (scanners) + the rare setup-confirmation. Filter with `WHERE via_gmail`.
+- **`category text`** — coarse sender class (security/alert/notification/personal), a
+  HEURISTIC (newsletters may land in `personal`). Refine by editing the CASE in
+  `configmap-schema.yaml` (one ALTER).
+- `labels text[]` + `processed_at` — claim/track messages.
 
 ## ⚠ Gotchas (each cost real time at go-live)
-- **Gateway nginx.conf is a `subPath` ConfigMap mount → it does NOT live-reload.** A gateway config change (e.g. the `:2525` target) needs a **DS pod restart** to apply: `kubectl -n nebula rollout restart daemonset/nebula-gateway`. This briefly blips ALL ~25 gateway-fronted services (Grafana/clawgate/ClickHouse/…). Validate first (nginx resolves `.svc` targets at parse; the pod must be able to resolve `mail-receiver.mailbox.svc`), then verify recovery after.
-- **Rollback for the cutover** = restore `proxy_pass 192.168.50.250:30025;` on the homelab `:2525` block + restart the DS.
-- **`mx-in.zacx.dev` A must be DNS-only (proxied=false).** external-dns has a global `--cloudflare-proxied` default that orange-clouds records; SMTP then can't reach the gateway. That's why these records are managed directly in CF, not external-dns. (Don't re-add an external-dns DNSEndpoint for them — two external-dns instances flap the shared zacx.dev zone.)
-- **Cloudflare Email Routing on zacx.dev is APEX-ONLY** (`route1/2/3.mx.cloudflare.net`), independent of the `inbox` subdomain — it does NOT conflict, leave it alone (removing it kills any `@zacx.dev` apex mail). A `dig` mid-flap once showed a misleading `_dc-mx` MX; trust the CF API record list, not a transient dig.
-- **Mailpit is DEAD** (was at `192.168.50.250:30025/30825`, gone from both clusters). The pre-existing `:25→Mailpit` path was already blackholed; the receiver's onward relay is therefore OFF (`MAILPIT_HOST` empty). Set it only to a live host, NEVER to the receiver's own front door (`10.42.0.10:2525`) — that loops.
-- **aiosmtpd + asyncpg event-loop:** the receiver MUST run the SMTP server on the asyncpg pool's loop (`loop.create_server(SMTP(...))`), NOT the threaded `Controller` (separate loop → every message 451s "another operation in progress"). Keep it that way if you edit `receiver.py`.
-- **Hetzner blocks OUTBOUND :25** for newish accounts (inbound for receiving is open). The **local workbench/laptop ISP also blocks outbound :25**, so you cannot test inbound by sending from here — use the postfix-relay path above or real Gmail.
-- **Receiver returns `451` on a Postgres write failure** (so the sending MTA retries — the store is authoritative); relay failures are logged, never rejected.
+- **aiosmtpd + asyncpg event-loop:** the receiver MUST run the SMTP server on the asyncpg
+  pool's loop (`loop.create_server(SMTP(...))`), **NOT** the threaded `Controller` (separate
+  loop → every message 451s "another operation in progress"). Keep it that way if you edit
+  `receiver.py`.
+- **Receiver returns `451` on a Postgres write failure** (so the sending MTA retries — the
+  store is authoritative); relay failures are logged, never rejected.
+- **Hetzner blocks OUTBOUND :25** for newish accounts (inbound for receiving is open), and
+  the local workbench/laptop ISP blocks outbound :25 too — you cannot test inbound by
+  sending from here. Use the postfix-relay path (reference file) or real Gmail.
+- **Gateway nginx.conf is a `subPath` ConfigMap mount → it does NOT live-reload**; applying a
+  change needs `kubectl -n nebula rollout restart daemonset/nebula-gateway`, which briefly
+  blips ALL ~25 gateway-fronted services. Rollback + validation steps: reference file.
+- **Mailpit is DEAD** (was `192.168.50.250:30025/30825`) → the receiver's onward relay is OFF
+  (`MAILPIT_HOST` empty). Set it only to a live host, **NEVER** to the receiver's own front
+  door (`10.42.0.10:2525`) — that loops.
+- **`mx-in.zacx.dev` A must be DNS-only (`proxied=false`)** — SMTP can't cross the CF proxy;
+  external-dns's global `--cloudflare-proxied` default is why these records are managed
+  directly in CF. **Cloudflare Email Routing on `zacx.dev` is APEX-ONLY and does NOT
+  conflict — leave it alone** (removing it kills `@zacx.dev` apex mail). Detail: reference file.

--- a/claude/skills/mailbox/reference/build-dns-forwarding.md
+++ b/claude/skills/mailbox/reference/build-dns-forwarding.md
@@ -1,0 +1,99 @@
+# mailbox — rebuild, DNS, test-send, Gmail forwarding
+
+Read this when you are **rebuilding the receiver image**, **changing the Cloudflare
+mail DNS**, **proving the public path end-to-end**, or **(re)wiring Gmail forwarding**.
+Day-to-day status/query/automation lives in `SKILL.md`.
+
+## Rebuild the receiver (after editing `src/receiver.py`)
+
+The image is **baked** (no runtime pip) — a code change needs a rebuild + tag bump.
+Build context `/tmp/mail-receiver-build/` (`Dockerfile`, `receiver.py`, `requirements.txt`
+= `aiosmtpd==1.4.6` + `asyncpg==0.30.0`). `docker` on the workbench is already authed to
+`harbor.homelab.lan`. Harbor is LAN-only, so this step needs the **workbench**.
+
+```bash
+# 1. edit clusters/homelab/apps/mailbox/src/receiver.py (in a worktree off trunk — the
+#    main homelab-talos tree carries heavy pre-existing drift; NEVER git add -A there)
+cp <edited>/receiver.py /tmp/mail-receiver-build/receiver.py
+docker build -t harbor.homelab.lan/library/mail-receiver:<NEWTAG> /tmp/mail-receiver-build && \
+  docker push harbor.homelab.lan/library/mail-receiver:<NEWTAG>
+# 2. bump the image tag in clusters/homelab/apps/mailbox/receiver.yaml, commit → PR → merge trunk
+# 3. flux reconcile source git flux-system && flux reconcile kustomization mailbox
+#    kubectl -n mailbox rollout status deploy/mail-receiver
+# 4. Test before relying: send to NodePort 30026 from the LAN, confirm a row lands.
+```
+
+## Test send (no Gmail needed — proves the real public path)
+
+```bash
+# From a PRODUCTION pod via the postfix relay → MX-routes through the real chain.
+# Relay allows From @mail.zacx.dev (ALLOWED_SENDER_DOMAINS); MYNETWORKS covers pods.
+KUBECONFIG=~/workspace/homelab-talos/production-kubeconfig kubectl -n nebula run mailtest-$RANDOM \
+  --rm -i --restart=Never --image=python:3.12-slim --command -- python3 -c '
+import smtplib; from email.message import EmailMessage
+m=EmailMessage(); m["Message-ID"]="<t@mail.zacx.dev>"; m["From"]="probe@mail.zacx.dev"
+m["To"]="test@inbox.zacx.dev"; m["Subject"]="E2E test"; m.set_content("x")
+s=smtplib.SMTP("postfix-relay.nebula.svc.cluster.local",587,timeout=25); s.send_message(m); s.quit()
+print("submitted")'
+# then check Postgres for subject "E2E test". A LAN-local quick test: SMTP to <nodeIP>:30026 directly.
+```
+
+⚠ **Hetzner blocks OUTBOUND :25** for newish accounts (inbound for receiving is open), and
+the **local workbench/laptop ISP also blocks outbound :25** — so you cannot test inbound by
+sending from here. Use the postfix-relay path above, or real Gmail.
+
+## DNS (Cloudflare, managed directly via API)
+
+Zone `zacx.dev` id `72f00688be30dfc863a2c84fa6ab771c`. Token: secret
+`cloudflare-api-token` / key `cloudflare_api_token` in the **production** ns `external-dns`
+(DNS-edit scope ONLY — NOT Email Routing admin).
+
+```bash
+KUBECONFIG=~/workspace/homelab-talos/production-kubeconfig
+CFT=$(kubectl -n external-dns get secret cloudflare-api-token -o jsonpath='{.data.cloudflare_api_token}' | base64 -d)
+ZID=72f00688be30dfc863a2c84fa6ab771c
+curl -s -H "Authorization: Bearer $CFT" "https://api.cloudflare.com/client/v4/zones/$ZID/dns_records?type=MX&per_page=100"
+# REQUIRED state: inbox.zacx.dev MX 10 mx-in.zacx.dev ; mx-in.zacx.dev A 5.161.118.55 with proxied=FALSE
+# (PATCH proxied:false on the A record id if it's ever orange — SMTP can't cross the CF proxy)
+```
+
+- **`mx-in.zacx.dev` A must be DNS-only (`proxied=false`).** external-dns has a global
+  `--cloudflare-proxied` default that orange-clouds records; SMTP then can't reach the
+  gateway. That is why these records are managed **directly in CF, NOT external-dns**.
+  Don't re-add an external-dns DNSEndpoint for them — two external-dns instances flap the
+  shared `zacx.dev` zone.
+- **Cloudflare Email Routing on `zacx.dev` is APEX-ONLY** (`route1/2/3.mx.cloudflare.net`),
+  independent of the `inbox` subdomain — it does NOT conflict; leave it alone (removing it
+  kills any `@zacx.dev` apex mail). A `dig` mid-flap once showed a misleading `_dc-mx` MX:
+  **trust the CF API record list, not a transient dig.**
+
+## Gmail forwarding (operator's manual step — NOT API-accessible)
+
+The Gmail-side toggle is a Settings action no API/MCP exposes (the Gmail integration can
+only draft/label/search). Operator: Gmail → Settings → Forwarding and POP/IMAP → add
+`<anything>@inbox.zacx.dev`. Gmail sends a verification email that **lands in Postgres** —
+pull the confirm link/code:
+
+```bash
+$PSQL "select id,from_addr,subject from mail where from_addr='forwarding-noreply@google.com' order by received_at desc;"
+$PSQL "select text_body from mail where id=<id>;"   # the 'vf-…' link CONFIRMS; the 'uf-…' link CANCELS
+```
+
+The operator must click the `vf-` link in a real browser — WebFetch reaches the page but
+can't press the final Confirm button (needs the Gmail session). Then set "Forward a copy…"
+(or a filter) in Gmail.
+
+## Gateway / cutover
+
+- **Gateway nginx.conf is a `subPath` ConfigMap mount → it does NOT live-reload.** A
+  gateway config change (e.g. the `:2525` target) needs a **DS pod restart**:
+  `kubectl -n nebula rollout restart daemonset/nebula-gateway`. This briefly blips ALL ~25
+  gateway-fronted services (Grafana/clawgate/ClickHouse/…). Validate first (nginx resolves
+  `.svc` targets at parse; the pod must be able to resolve `mail-receiver.mailbox.svc`),
+  then verify recovery after.
+- **Rollback for the cutover** = restore `proxy_pass 192.168.50.250:30025;` on the homelab
+  `:2525` block + restart the DS.
+- **Mailpit is DEAD** (was at `192.168.50.250:30025/30825`, gone from both clusters). The
+  pre-existing `:25→Mailpit` path was already blackholed; the receiver's onward relay is
+  therefore OFF (`MAILPIT_HOST` empty). Set it only to a live host, **NEVER** to the
+  receiver's own front door (`10.42.0.10:2525`) — that loops.

--- a/claude/skills/tekton/SKILL.md
+++ b/claude/skills/tekton/SKILL.md
@@ -5,119 +5,150 @@ description: Operate the homelab Tekton CI/CD platform. Tekton Operator + Pipeli
 
 # Tekton — homelab CI/CD platform
 
-GitOps CI on the **homelab** cluster (Flux-managed). Runs the **naida-ux-audit** pipeline: a naida push to `main` auto-walks the app, pushes the run to auditloop, and gates on regressions. Cross-ref: `auditloop` (read API + push), `ux-audit-loops` (the walk + `--fail-on-regression` gate).
+GitOps CI on the **homelab** cluster (Flux-managed). Cross-ref: `auditloop` (read API +
+push), `ux-audit-loops` (the walk + `--fail-on-regression` gate).
+
+**Reference file** (repo-absolute; read on demand):
+`~/workspace/devrc/claude/skills/tekton/reference/pipelines.md` — full per-pipeline detail
+for `naida-ux-audit`, `remix-ux-audit` and `clawgate-ci` (steps, sidecars, CEL filters,
+creds, gate semantics, and clawgate-ci's four known-open 🟡 issues). Read it before
+debugging, changing or copying a specific pipeline.
 
 ## 🔴 CRITICAL GOTCHAS — read first
 
-1. **hostNetwork gateway host-port collisions.** The nebula public gateway (BOTH prod + homelab) is `hostNetwork: true`, so any new nginx `listen` port must be verified free at the **HOST** level, NOT just in the nginx config. Decode `/proc/net/tcp` on the **LIVE** gateway pods (hex port column) — do not trust the configmap. **k0s reserves 9099; node-exporter binds 9100.** Using **9099 CRASHED the shared gateway and took down every public app this session.** Pick a high, verified-unused port (**19100**, matching MinIO's `19099` convention). The **homelab** gateway nginx has **no reloader sidecar** → after a configmap change `kubectl -n nebula rollout restart ds/nebula-gateway`, or it serves 502. Keep `git revert` + `flux reconcile` staged to restore the gateway in ~2 min.
-2. **Stale `~/workspace/homelab-talos` checkout (~100 commits behind).** NEVER read/edit it as authoritative — it caused a wrong "Tekton is already installed" conclusion. Verify cluster state against **origin/trunk of `homelab-infra`** AND the **LIVE cluster** (a running controller pod, not just a CRD's presence).
-3. **No RWX storage** — only local-path / openebs (RWO, node-pinned). Two RWO local-path PVCs in one pod would **DEADLOCK scheduling** (each binds a different node) UNLESS the pod is **node-pinned** (`taskRunTemplate.podTemplate.nodeSelector`), which forces both PVCs onto one node. **This is exactly how the persistent nix cache now works** (PR #115): a static `nix-store-cache` PVC + the per-run `source` PVC both pinned to `talos-xr6-r7p`. A `seed-nix` step copies the image's `/nix` into the PVC once (sentinel `.seeded` + atomic mkdir lock, self-healing on a dead seeder), then `walk-gate` overmounts `/nix`. MEASURED walk-gate **cold 3m04s → warm 1m15s** (~1m50s saved) — the old "~2–15 min cold" figure was **wrong** (cache.nixos.org is fast here; cold ≈ 3 min). Tradeoff: if `talos-xr6-r7p` is down, runs Pend.
-4. **Placeholder imagePullSecret breaks ALL pulls.** A `harbor-cred` dockerconfigjson with a non-base64 `auth` placeholder makes every pod fail image pull ("illegal base64 data"). **Do NOT attach a placeholder imagePullSecret** to the pipeline SA — public images (`nixos/nix`) need none.
-5. **Operator uninstall leaves orphans.** Deleting the Flux-managed operator does NOT remove operator-CREATED components/CRDs/webhooks. A clean teardown must manually delete the operator CRs (force-remove finalizers — no controller left to run them), admission webhooks, CRDs, namespaces, and cluster RBAC.
+1. **hostNetwork gateway host-port collisions.** The nebula public gateway (BOTH prod +
+   homelab) is `hostNetwork: true`, so any new nginx `listen` port must be verified free at
+   the **HOST** level, NOT just in the nginx config. Decode `/proc/net/tcp` on the **LIVE**
+   gateway pods (hex port column) — do not trust the configmap. **k0s reserves 9099;
+   node-exporter binds 9100.** Using **9099 CRASHED the shared gateway and took down every
+   public app.** Pick a high, verified-unused port (**19100**, matching MinIO's `19099`
+   convention). The **homelab** gateway nginx has **no reloader sidecar** → after a configmap
+   change `kubectl -n nebula rollout restart ds/nebula-gateway`, or it serves 502. Keep
+   `git revert` + `flux reconcile` staged to restore the gateway in ~2 min.
+2. **Stale `~/workspace/homelab-talos` checkout (~100 commits behind).** NEVER read/edit it
+   as authoritative — it caused a wrong "Tekton is already installed" conclusion. Verify
+   cluster state against **origin/trunk of `homelab-infra`** AND the **LIVE cluster** (a
+   running controller pod, not just a CRD's presence).
+3. **No RWX storage** — only local-path / openebs (RWO, node-pinned). Two RWO local-path PVCs
+   in one pod would **DEADLOCK scheduling** (each binds a different node) UNLESS the pod is
+   **node-pinned** (`taskRunTemplate.podTemplate.nodeSelector`), which forces both PVCs onto
+   one node. **That is exactly how the persistent nix cache works** (PR #115): a static
+   `nix-store-cache` PVC + the per-run `source` PVC both pinned to `talos-xr6-r7p`. A
+   `seed-nix` step copies the image's `/nix` into the PVC once (sentinel `.seeded` + atomic
+   mkdir lock, self-healing on a dead seeder), then `walk-gate` overmounts `/nix`. MEASURED
+   walk-gate **cold 3m04s → warm 1m15s** (~1m50s saved) — the old "~2–15 min cold" figure was
+   **wrong** (cache.nixos.org is fast here; cold ≈ 3 min). Tradeoff: if `talos-xr6-r7p` is
+   down, runs Pend.
+4. **Placeholder imagePullSecret breaks ALL pulls.** A `harbor-cred` dockerconfigjson with a
+   non-base64 `auth` placeholder makes every pod fail image pull ("illegal base64 data").
+   **Do NOT attach a placeholder imagePullSecret** to the pipeline SA — public images
+   (`nixos/nix`) need none.
+5. **Operator uninstall leaves orphans.** Deleting the Flux-managed operator does NOT remove
+   operator-CREATED components/CRDs/webhooks. A clean teardown must manually delete the
+   operator CRs (force-remove finalizers — no controller left to run them), admission
+   webhooks, CRDs, namespaces, and cluster RBAC.
 
 ## What / where
 
-- **Tekton Operator v0.80.0** → Pipelines **1.12.2** / Triggers **0.36.0** / Dashboard **0.68.0**. **Chains + Results OFF.** Pruner keep-**100**, daily. Dashboard **read-only**.
-- Namespaces: **`tekton-pipelines`** (control plane) + **`tekton-ci`** (CI workloads, EventListener, PipelineRuns).
-- GitOps via **Flux**, repo **`ZacxDev/homelab-infra`** branch **`trunk`**, under `clusters/homelab/apps/tekton-pipelines/`.
+- **Tekton Operator v0.80.0** → Pipelines **1.12.2** / Triggers **0.36.0** / Dashboard
+  **0.68.0**. **Chains + Results OFF.** Pruner keep-**100**, daily. Dashboard **read-only**.
+- Namespaces: **`tekton-pipelines`** (control plane) + **`tekton-ci`** (CI workloads,
+  EventListener, PipelineRuns).
+- GitOps via **Flux**, repo **`ZacxDev/homelab-infra`** branch **`trunk`**, under
+  `clusters/homelab/apps/tekton-pipelines/`.
 - Kubeconfig: `~/workspace/homelab-infra/homelab-kubeconfig`.
 
 ## GitHub App — `tekton-homelab`
 
-- App ID **4320115**, installation **147102541**, **org-wide**. Perms: **Contents:R + Commit-statuses:RW + Metadata:R**. Events: **push + pull_request**.
-- Creds sealed in **`github-app.enc.yaml`** (SOPS). Used to **mint installation tokens** at pipeline time → clone private repos + post commit statuses.
-- Org-wide install ⇒ **ALWAYS scope a trigger to a specific repo + branch via CEL** (see Adding a pipeline).
+- App ID **4320115**, installation **147102541**, **org-wide**. Perms: **Contents:R +
+  Commit-statuses:RW + Metadata:R**. Events: **push + pull_request**.
+- Creds sealed in **`github-app.enc.yaml`** (SOPS). Used to **mint installation tokens** at
+  pipeline time → clone private repos + post commit statuses.
+- Org-wide install ⇒ **ALWAYS scope a trigger to a specific repo + branch via CEL.**
 
 ## Public webhook
 
-`tekton-webhook.zacx.dev` → **`el-github-listener`** EventListener (`tekton-ci`), **HMAC-authed** (secret token), on **host port 19100** (see gotcha #1).
+`tekton-webhook.zacx.dev` → **`el-github-listener`** EventListener (`tekton-ci`),
+**HMAC-authed** (secret token), on **host port 19100** (see gotcha #1).
 
-Path: GitHub → Cloudflare → **prod Traefik** → prod nginx `0.0.0.0:19100` → `10.42.0.10:19100` → **homelab nginx** → `el-github-listener:8080`.
+Path: GitHub → Cloudflare → **prod Traefik** → prod nginx `0.0.0.0:19100` →
+`10.42.0.10:19100` → **homelab nginx** → `el-github-listener:8080`.
 
-## The ux-audit pipeline — `naida-ux-audit` (ns `tekton-ci`)
+## Pipelines (detail in `reference/pipelines.md`)
 
-naida push → `main` → EventListener → **CEL filter** (`ZacxDev/naida-ai` + `refs/heads/main`) → mint installation token → **clone** → post GitHub **`pending`** status → **`nix develop`** walk (`make ux-audit-lms`, boots DEV_MODE naida + chromium) → **push run to auditloop** (P5 plugin API) → **`fetch-findings.mjs --fail-on-regression`** gate → post **`success`** / **`failure`** commit status (context **`tekton/ux-audit-lms`**).
+| Pipeline | Trigger / scope | Gate + commit status |
+|---|---|---|
+| `naida-ux-audit` | `naida-push-main` — `ZacxDev/naida-ai` + `refs/heads/main` | a11y-rule delta → `tekton/ux-audit-lms` |
+| `remix-ux-audit` | `remix-push-trunk` — `homelab-infra` + `refs/heads/trunk` + path `containers/remix/**` | a11y-rule delta → `tekton/ux-audit-remix` |
+| `clawgate-ci` | `clawgate-ci-push` — push-only, ANY branch, path `containers/clawgate/` | go / extension / hook legs → commit status |
 
-- Image **`nixos/nix:2.24.9`** (flakes enabled).
-- auditloop creds (push URL/token + read `AUDITLOOP_API_TOKEN`) in the **`auditloop-creds`** secret.
-- Walk-gate uses the **persistent node-pinned nix cache** (gotcha #3) — warm walk-gate ~1m15s (cold ~3m04s). Cache PVC `nix-store-cache` on `talos-xr6-r7p`; nuke it (`kubectl -n tekton-ci delete pvc nix-store-cache`) to force a clean reseed if it ever corrupts.
-- Gate keys on the **deterministic a11y-rule delta only** (`new_a11y_rules`); visual pixel diff is **advisory, not gated** (fixed in naida #149 — the sub-1% LMS render non-determinism no longer reddens CI). Opt back into visual gating with `fetch-findings.mjs --fail-on-visual [--visual-threshold N]`. See `ux-audit-loops`.
-
-## 2nd pipeline — `remix-ux-audit` (ns `tekton-ci`) — BUILT + verified (homelab-infra #123)
-
-Same monorepo (`homelab-infra`), CEL-scoped to `refs/heads/trunk` + a commit touching
-`containers/remix/**`. Trigger `remix-push-trunk` on the SAME `el-github-listener` as naida.
-A push → walk remix (14 surfaces × mobile+desktop) → push run to the **`remix-funnel`** plugin
-target → gate on the a11y-rule delta → post commit status **`tekton/ux-audit-remix`** on
-`ZacxDev/homelab-infra`. On top of the naida pattern:
-- **Postgres + Redis SIDECARS** (Tekton pods have no Docker daemon). remix's harness reaches
-  them via **`REMIX_TEST_DATABASE_URL`** (`postgres://remix:x@127.0.0.1:5432/remix?sslmode=disable`)
-  + **`REMIX_TEST_REDIS_ADDR`** (`127.0.0.1:6379`) — the `internal/dbtest` external hooks +
-  `DockerAvailable()` bypass landed in remix via homelab-infra **#122**. A `wait-postgres` step
-  gates the walk on real sidecar readiness (the harness connect has no retry loop).
-- **CEL PATH filter** — `body.commits.exists(c, c.{added,modified,removed}.exists(f, f.startsWith('containers/remix/')))` with a **`head_commit` fallback** (GitHub truncates the `commits` array on large pushes → also test `head_commit`) (verified against cel-go).
-- **Impure nix-shell** — remix's `e2e/run.sh` uses `nix-shell -p ...` (not a flake devShell),
-  so the walk runs under an outer `nix-shell -p bash gnumake nix` with **`NIX_PATH` pinned** to
-  the repo's `flake.lock` nixpkgs rev. (Base `nixos/nix` image has neither `make` nor a
-  guaranteed `bash` on PATH — naida gets `make` from its flake devShell instead.)
-- Reuses the **SHARED `nix-store-cache` PVC** (both pipelines node-pin to `talos-xr6-r7p`, so
-  both pods mount the one RWO local PVC; the seed-nix mkdir-lock already tolerates concurrent
-  same-node seeders). Separate **`remix-auditloop-creds`** SOPS secret (remix Makefile reads
-  `AUDITLOOP_PUSH_TOKEN`, a single string, vs naida's `AUDITLOOP_PUSH_TOKENS` map).
-- Gate keys on the **deterministic a11y-rule delta only** (`diff.new_a11y_rules`); visual pixel
-  diff is advisory (matches naida #149).
-- **Verified LIVE end-to-end** via the REAL webhook: a trunk push touching `containers/remix/**`
-  (`e4300274`) auto-spawned PipelineRun `remix-ux-audit-99pvx` → walk (pushed run `626190dc`) →
-  gate PASS → `tekton/ux-audit-remix` **success** commit status. Plus a pre-merge manual PipelineRun
-  (GREEN), cel-go CEL validation (6 cases incl. truncated-tip + null-head), and a deterministic
-  RED-path gate proof. Adversarially audited (safe, no 🔴).
-- **Deferred fast-follow (advisory-only):** the gate reads `runs/latest`, not the SPECIFIC pushed `run_id` — a TOCTOU window where a concurrent push could shift the "latest" read. Harden by keying the gate to the `run_id` the walk pushed.
-
-Cross-ref: `auditloop` skill (remix producer + a11y-id contract), `ux-audit-loops` skill.
-
-## 3rd pipeline — `clawgate-ci` (ns `tekton-ci`) — the repo's REAL pre-merge gate
-
-**GitHub Actions is billing-blocked repo-wide.** Every workflow run fails in 3–16s with `steps: 0` and the annotation *"The job was not started because recent account payments have failed or your spending limit needs to be increased"* (verified 2026-07-30 via `gh api repos/ZacxDev/homelab-infra/actions/runs` + the job annotation; the log blob 404s). **Red Actions checks on this repo are noise, not signal** — do not debug them, and do not read a green/red Actions check as a gate. `.github/workflows/clawgate-ci.yml` survives only as `name: clawgate e2e (manual)`, `on: workflow_dispatch`, carrying the one e2e job that wasn't ported.
-
-Definition: `clusters/homelab/apps/tekton-pipelines/triggers/clawgate-ci-pipeline.yaml` + `clawgate-ci-triggertemplate.yaml`. ⚠ The three "legs" are **steps of ONE Task** (`clawgate-ci`), not three Pipeline tasks — `mint-token`, `clone`, `status-pending`, `wait-postgres`, `build-css`, then:
-- **`go`** — `go build ./... && go vet ./... && go test -race -cover ./...` against a **`postgres:16-alpine` SIDECAR** (`CLAWGATE_TEST_DATABASE_URL=…@127.0.0.1:5432/clawgate_test`).
-- **`extension`** — `npm install && npm run coverage` in `containers/clawgate/extension`.
-- **`hook`** — `bats hook/tests/clawgate-hook.bats hook/tests/clawgate-stop-hook.bats` on `bats/bats:1.11.0`.
-
-Then `verdict`, plus a `finally: report` task (`clawgate-ci-report`) posting the commit status. Trigger `clawgate-ci-push` on the shared `el-github-listener`: **push-only** (no `pull_request`), **any branch** (`body.ref.startsWith('refs/heads/')`), path-filtered to `containers/clawgate/` **and** `clusters/homelab/apps/tekton-pipelines/triggers/clawgate-ci-` (a self-guard, so a change to the pipeline re-tests itself) — the `commits`-array test is OR'd with a `head_commit` fallback for GitHub's truncation of large pushes.
-
-**Known-open 🟡 (all verified 2026-07-30, none fixed):**
-- **Branch creation over-matches.** `git push -u origin newbranch` sends `commits: []` (first disjunct false) **plus a pre-existing `head_commit`** — and the second disjunct only checks `has(body.head_commit) && != null`, so if that already-tested tip touched `containers/clawgate/` a **full run fires on branch creation**. The file's own comment covers branch *deletion* (null head_commit — correctly safe) and misses creation. `auditloop-push-main` carries a `(!has(body.deleted) || body.deleted == false)` guard; clawgate-ci has no `created`/`deleted` guard.
-- **PVC unpinned.** Per-run **6Gi** RWO `volumeClaimTemplate` with **no** `podTemplate.nodeSelector`, while *every* other pipeline pins `kubernetes.io/hostname: talos-xr6-r7p` (naida 8Gi, remix 12Gi, gitops-validate 6Gi, auditloop 10Gi). It works today (clawgate pods land on `talos-jkj-deb`) because it mounts only the one PVC — but it forgoes the shared nix cache and is the odd one out.
-- **No concurrency control at all** — every matching push gets an independent PipelineRun and its own 6Gi PVC.
-- **`error` vs `fail` is implemented for the CSS path ONLY** (`clawgate-ci-pipeline.yaml:329` writes `error` when `.css-failed` exists). The `extension` and `hook` legs only ever write `pass`/`fail`, so a crashed `npm install` or an unpullable bats image reports **"your change is bad"**. Partly compensated at aggregation: a *missing* verdict file is treated as the error class and the summary separates `FAILED:` from `COULD NOT RUN:`.
+`clawgate-ci` is the repo's **real pre-merge gate**: GitHub Actions is billing-blocked
+repo-wide, so **red Actions checks on `homelab-infra` are noise, not signal** — don't debug
+them and don't read them as a gate. Four known-open 🟡 issues (branch-creation over-match,
+unpinned PVC, no concurrency control, `error`-vs-`fail` on the CSS path only) are in the
+reference file. Six triggers share `el-github-listener`: `naida-push-main`,
+`remix-push-trunk`, `gitops-validate-pr`, `gitops-validate-push-trunk`, `clawgate-ci-push`,
+`auditloop-push-main`.
 
 ## 🔴 Merging a trigger does NOT fire the first run — reconcile FIRST
 
-The single most expensive Tekton gotcha here. **The webhook arrives within seconds of the merge; the Flux `tekton-triggers` Kustomization reconciles on a 5-minute interval; GitHub does not retry.** So the push that "should" have started CI hits an EventListener that does not yet carry the trigger, and is **silently dropped**. Absence of a PipelineRun is not evidence that anything is fine.
+The single most expensive Tekton gotcha here. **The webhook arrives within seconds of the
+merge; the Flux `tekton-triggers` Kustomization reconciles on a 5-minute interval; GitHub
+does not retry.** So the push that "should" have started CI hits an EventListener that does
+not yet carry the trigger, and is **silently dropped**. Absence of a PipelineRun is not
+evidence that anything is fine.
 
-**Correct sequence:** merge → `flux reconcile kustomization tekton-triggers` → confirm the trigger is live on the CR (`kubectl -n tekton-ci get eventlistener github-listener -o jsonpath='{.spec.triggers[*].name}'`) → **then** push, or create a PipelineRun by hand.
+**Correct sequence:** merge → `flux reconcile kustomization tekton-triggers` → confirm the
+trigger is live on the CR
+(`kubectl -n tekton-ci get eventlistener github-listener -o jsonpath='{.spec.triggers[*].name}'`)
+→ **then** push, or create a PipelineRun by hand.
 
-**Editing `spec.triggers` does NOT restart the EventListener sink pod** — triggers are hot-read from the CR. Verified: `el-github-listener-…` was **14d old with 0 restarts, deployment generation 1**, while `eventlistener.yaml` had been committed three times in the preceding day; the pod was serving all six triggers and clawgate PipelineRuns fired on it. So "the pod is old" tells you nothing about whether a trigger is live — **read the CR**, not the pod.
+**Editing `spec.triggers` does NOT restart the EventListener sink pod** — triggers are
+hot-read from the CR. Verified: `el-github-listener-…` was **14d old with 0 restarts,
+deployment generation 1**, while `eventlistener.yaml` had been committed three times in the
+preceding day; the pod was serving all six triggers and clawgate PipelineRuns fired on it.
+So "the pod is old" tells you nothing about whether a trigger is live — **read the CR**, not
+the pod.
 
 ## ⚠ The shared `eventlistener.yaml` is NOT safe to hand-edit
 
-One file serves **six** live triggers — `naida-push-main`, `remix-push-trunk`, `gitops-validate-pr`, `gitops-validate-push-trunk`, `clawgate-ci-push`, `auditloop-push-main` — each a multi-line CEL expression, several structurally near-identical (the same `(c.added + c.modified + c.removed).exists(f, f.startsWith('containers/<app>/'))` shape). A blind `count=1` text replace cannot be assumed to land on the trigger you meant, and a paren-level mistake in one trigger's CEL is a config error that can take **all six** down. **Put a `cel-go` harness in the loop for any CEL change** (the remix filter was validated that way over 6 cases incl. truncated-tip and null-head), and confirm by `git diff` which occurrence actually moved.
+One file serves **six** live triggers, each a multi-line CEL expression, several structurally
+near-identical (the same
+`(c.added + c.modified + c.removed).exists(f, f.startsWith('containers/<app>/'))` shape). A
+blind `count=1` text replace cannot be assumed to land on the trigger you meant, and a
+paren-level mistake in one trigger's CEL is a config error that can take **all six** down.
+**Put a `cel-go` harness in the loop for any CEL change** (the remix filter was validated
+that way over 6 cases incl. truncated-tip and null-head), and confirm by `git diff` which
+occurrence actually moved.
 
 ## Dashboard
 
-Read-only. `kubectl -n tekton-pipelines port-forward svc/tekton-dashboard 9097:9097` → http://localhost:9097. Public exposure (`tekton.zacx.dev` + Authelia) is **DEFERRED**.
+Read-only. `kubectl -n tekton-pipelines port-forward svc/tekton-dashboard 9097:9097` →
+http://localhost:9097. Public exposure (`tekton.zacx.dev` + Authelia) is **DEFERRED**.
 
 ## Deploy / change pattern
 
-- Work in a **worktree off `homelab-infra` origin/trunk** (NOT the stale `homelab-talos` checkout — gotcha #2) → PR → **Flux reconciles**.
-- `flux` is **not on PATH**: `nix-shell -p fluxcd --run "flux reconcile source git flux-system && flux reconcile kustomization <name>"`.
-- SOPS edits: `nix-shell -p sops --run "sops <file>.enc.yaml"`, **age key** `~/workspace/homelab-talos/.secrets/age.key` (the .secrets dir is fine; only the talos *manifests* are stale).
-- After a gateway configmap change: `kubectl -n nebula rollout restart ds/nebula-gateway` (no reloader — gotcha #1).
+- Work in a **worktree off `homelab-infra` origin/trunk** (NOT the stale `homelab-talos`
+  checkout — gotcha #2) → PR → **Flux reconciles**.
+- `flux` is **not on PATH**:
+  `nix-shell -p fluxcd --run "flux reconcile source git flux-system && flux reconcile kustomization <name>"`.
+- SOPS edits: `nix-shell -p sops --run "sops <file>.enc.yaml"`, **age key**
+  `~/workspace/homelab-talos/.secrets/age.key` (the `.secrets` dir is fine; only the talos
+  *manifests* are stale).
+- After a gateway configmap change: `kubectl -n nebula rollout restart ds/nebula-gateway`
+  (no reloader — gotcha #1).
 
 ## Adding a new pipeline / new repo
 
-1. Add a **Trigger** on `el-github-listener` with a **CEL filter** scoping the exact `repository.full_name` + `ref` (the App is org-wide → always scope, gotcha under GitHub App). Validate the CEL with `cel-go` before merging — the file is shared by six triggers (see the hand-edit warning above). Guard branch **creation** (`commits: []` + a live `head_commit`) and **deletion** (null `head_commit`) explicitly; clawgate-ci gets the creation case wrong.
-2. TriggerTemplate → PipelineRun (clone via minted installation token; public base image, **no imagePullSecret** — gotcha #4).
-3. To pull results back into a gate, use the **auditloop read API** (`AUDITLOOP_API_TOKEN`, `fetch-findings.mjs`) — see the `auditloop` + `ux-audit-loops` skills.
-4. Ephemeral workspace only (no RWX — gotcha #3); expect cold runs.
+1. Add a **Trigger** on `el-github-listener` with a **CEL filter** scoping the exact
+   `repository.full_name` + `ref` (the App is org-wide → always scope). Validate the CEL with
+   `cel-go` before merging — the file is shared by six triggers (see the hand-edit warning).
+   Guard branch **creation** (`commits: []` + a live `head_commit`) and **deletion** (null
+   `head_commit`) explicitly; clawgate-ci gets the creation case wrong.
+2. TriggerTemplate → PipelineRun (clone via minted installation token; public base image,
+   **no imagePullSecret** — gotcha #4).
+3. To pull results back into a gate, use the **auditloop read API** (`AUDITLOOP_API_TOKEN`,
+   `fetch-findings.mjs`) — see the `auditloop` + `ux-audit-loops` skills.
+4. Ephemeral workspace only (no RWX — gotcha #3); expect cold runs unless you node-pin to
+   `talos-xr6-r7p` and mount the shared `nix-store-cache` PVC.
+5. Merge → **`flux reconcile kustomization tekton-triggers` → confirm on the CR → THEN push.**

--- a/claude/skills/tekton/reference/pipelines.md
+++ b/claude/skills/tekton/reference/pipelines.md
@@ -1,0 +1,108 @@
+# tekton — per-pipeline detail
+
+Read this when you are **debugging, changing or copying a specific pipeline**. The
+platform facts, the 5 critical gotchas and the add-a-pipeline checklist are in `SKILL.md`.
+
+## `naida-ux-audit` (ns `tekton-ci`)
+
+naida push → `main` → EventListener → **CEL filter** (`ZacxDev/naida-ai` +
+`refs/heads/main`) → mint installation token → **clone** → post GitHub **`pending`**
+status → **`nix develop`** walk (`make ux-audit-lms`, boots DEV_MODE naida + chromium) →
+**push run to auditloop** (P5 plugin API) → **`fetch-findings.mjs --fail-on-regression`**
+gate → post **`success`** / **`failure`** commit status (context **`tekton/ux-audit-lms`**).
+
+- Image **`nixos/nix:2.24.9`** (flakes enabled). naida gets `make` from its flake devShell.
+- auditloop creds (push URL/token + read `AUDITLOOP_API_TOKEN`) in the **`auditloop-creds`**
+  secret.
+- Uses the **persistent node-pinned nix cache** — warm walk-gate ~1m15s, cold ~3m04s. Cache
+  PVC `nix-store-cache` on `talos-xr6-r7p`; nuke it
+  (`kubectl -n tekton-ci delete pvc nix-store-cache`) to force a clean reseed if it corrupts.
+- Gate keys on the **deterministic a11y-rule delta only** (`new_a11y_rules`); the visual
+  pixel diff is **advisory, not gated** (naida #149 — sub-1% LMS render non-determinism no
+  longer reddens CI). Opt back in with
+  `fetch-findings.mjs --fail-on-visual [--visual-threshold N]`.
+
+## `remix-ux-audit` (ns `tekton-ci`) — homelab-infra #123
+
+Same monorepo (`homelab-infra`), CEL-scoped to `refs/heads/trunk` + a commit touching
+`containers/remix/**`. Trigger `remix-push-trunk` on the SAME `el-github-listener`.
+Push → walk remix (14 surfaces × mobile+desktop) → push run to the **`remix-funnel`** plugin
+target → gate on the a11y-rule delta → post commit status **`tekton/ux-audit-remix`** on
+`ZacxDev/homelab-infra`. On top of the naida pattern:
+
+- **Postgres + Redis SIDECARS** (Tekton pods have no Docker daemon). remix's harness reaches
+  them via **`REMIX_TEST_DATABASE_URL`**
+  (`postgres://remix:x@127.0.0.1:5432/remix?sslmode=disable`) + **`REMIX_TEST_REDIS_ADDR`**
+  (`127.0.0.1:6379`) — the `internal/dbtest` external hooks + `DockerAvailable()` bypass
+  landed in remix via homelab-infra **#122**. A `wait-postgres` step gates the walk on real
+  sidecar readiness (the harness connect has no retry loop).
+- **CEL PATH filter** —
+  `body.commits.exists(c, c.{added,modified,removed}.exists(f, f.startsWith('containers/remix/')))`
+  with a **`head_commit` fallback** (GitHub truncates the `commits` array on large pushes →
+  also test `head_commit`). Verified against cel-go.
+- **Impure nix-shell** — remix's `e2e/run.sh` uses `nix-shell -p ...` (not a flake devShell),
+  so the walk runs under an outer `nix-shell -p bash gnumake nix` with **`NIX_PATH` pinned**
+  to the repo's `flake.lock` nixpkgs rev. (The base `nixos/nix` image has neither `make` nor
+  a guaranteed `bash` on PATH.)
+- Reuses the **SHARED `nix-store-cache` PVC** (both pipelines node-pin to `talos-xr6-r7p`, so
+  both pods mount the one RWO local PVC; the seed-nix mkdir-lock tolerates concurrent
+  same-node seeders). Separate **`remix-auditloop-creds`** SOPS secret (remix's Makefile
+  reads `AUDITLOOP_PUSH_TOKEN`, a single string, vs naida's `AUDITLOOP_PUSH_TOKENS` map).
+- Gate keys on `diff.new_a11y_rules` only; visual diff advisory (matches naida #149).
+- **Verified LIVE end-to-end via the REAL webhook**: a trunk push touching
+  `containers/remix/**` (`e4300274`) auto-spawned PipelineRun `remix-ux-audit-99pvx` → walk
+  (pushed run `626190dc`) → gate PASS → `tekton/ux-audit-remix` **success**. Plus a pre-merge
+  manual PipelineRun (GREEN), cel-go CEL validation (6 cases incl. truncated-tip and
+  null-head), and a deterministic RED-path gate proof.
+- **Deferred fast-follow (advisory only):** the gate reads `runs/latest`, not the SPECIFIC
+  pushed `run_id` — a TOCTOU window where a concurrent push could shift the "latest" read.
+  Harden by keying the gate to the `run_id` the walk pushed.
+
+## `clawgate-ci` (ns `tekton-ci`) — the repo's REAL pre-merge gate
+
+**GitHub Actions is billing-blocked repo-wide.** Every workflow run fails in 3–16s with
+`steps: 0` and the annotation *"The job was not started because recent account payments have
+failed or your spending limit needs to be increased"* (verified via
+`gh api repos/ZacxDev/homelab-infra/actions/runs` + the job annotation; the log blob 404s).
+**Red Actions checks on this repo are NOISE, not signal** — do not debug them, and do not
+read a green/red Actions check as a gate. `.github/workflows/clawgate-ci.yml` survives only
+as `name: clawgate e2e (manual)`, `on: workflow_dispatch`, carrying the one e2e job that was
+never ported.
+
+Definition: `clusters/homelab/apps/tekton-pipelines/triggers/clawgate-ci-pipeline.yaml` +
+`clawgate-ci-triggertemplate.yaml`.
+⚠ The three "legs" are **steps of ONE Task** (`clawgate-ci`), NOT three Pipeline tasks —
+`mint-token`, `clone`, `status-pending`, `wait-postgres`, `build-css`, then:
+- **`go`** — `go build ./... && go vet ./... && go test -race -cover ./...` against a
+  **`postgres:16-alpine` SIDECAR** (`CLAWGATE_TEST_DATABASE_URL=…@127.0.0.1:5432/clawgate_test`).
+- **`extension`** — `npm install && npm run coverage` in `containers/clawgate/extension`.
+- **`hook`** — `bats hook/tests/clawgate-hook.bats hook/tests/clawgate-stop-hook.bats` on
+  `bats/bats:1.11.0`.
+
+Then `verdict`, plus a `finally: report` task (`clawgate-ci-report`) posting the commit
+status. Trigger `clawgate-ci-push` on the shared `el-github-listener`: **push-only** (no
+`pull_request`), **any branch** (`body.ref.startsWith('refs/heads/')`), path-filtered to
+`containers/clawgate/` **and** `clusters/homelab/apps/tekton-pipelines/triggers/clawgate-ci-`
+(a self-guard, so a change to the pipeline re-tests itself) — the `commits`-array test is
+OR'd with a `head_commit` fallback for GitHub's truncation of large pushes.
+
+**Known-open 🟡 (all verified 2026-07-30, none fixed):**
+- **Branch creation over-matches.** `git push -u origin newbranch` sends `commits: []` (first
+  disjunct false) **plus a pre-existing `head_commit`** — and the second disjunct only checks
+  `has(body.head_commit) && != null`, so if that already-tested tip touched
+  `containers/clawgate/` a **full run fires on branch creation**. The file's own comment
+  covers branch *deletion* (null `head_commit` — correctly safe) and misses creation.
+  `auditloop-push-main` carries a `(!has(body.deleted) || body.deleted == false)` guard;
+  clawgate-ci has no `created`/`deleted` guard.
+- **PVC unpinned.** Per-run **6Gi** RWO `volumeClaimTemplate` with **no**
+  `podTemplate.nodeSelector`, while *every* other pipeline pins
+  `kubernetes.io/hostname: talos-xr6-r7p` (naida 8Gi, remix 12Gi, gitops-validate 6Gi,
+  auditloop 10Gi). It works today (clawgate pods land on `talos-jkj-deb`) because it mounts
+  only the one PVC — but it forgoes the shared nix cache and is the odd one out.
+- **No concurrency control at all** — every matching push gets an independent PipelineRun and
+  its own 6Gi PVC.
+- **`error` vs `fail` is implemented for the CSS path ONLY** (`clawgate-ci-pipeline.yaml:329`
+  writes `error` when `.css-failed` exists). The `extension` and `hook` legs only ever write
+  `pass`/`fail`, so a crashed `npm install` or an unpullable bats image reports **"your
+  change is bad"**. Partly compensated at aggregation: a *missing* verdict file is treated as
+  the error class, and the summary separates `FAILED:` from `COULD NOT RUN:`.

--- a/scripts/dl-router/SKILL.md
+++ b/scripts/dl-router/SKILL.md
@@ -20,7 +20,8 @@ systemctl --user status dl-router
 
 `dl-route status` reporting `library    (unset ...)` means `library_root` is not
 configured — the sidecar answers `/healthz` but every routing endpoint returns
-503. That is the normal state on a host that has not been set up.
+503. That is the normal state on a host that has not been set up, not a failure
+to fix.
 
 ## Where things live
 
@@ -37,11 +38,11 @@ configured — the sidecar answers `/healthz` but every routing endpoint returns
 | extension | `scripts/dl-router/extension/`, loaded unpacked per profile |
 | player rules | `~/.config/dl-router/config.toml` → `[site_rules."<host>".player]` |
 
-**Never print the library root, directory names, filenames, the route log,
-alias keys, real channel ids, forum names or host names into a commit message,
-a PR, a doc, or any file in this repo.** The repo is public; the library is
-private. Synthetic names only (`Jane Doe`, `acme-studio`, `example-site.test`,
-`someforum.test`, and made-up snowflakes). This includes the output of
+🔴 **The repo is public; the library is private. Never print the library root,
+directory names, filenames, the route log, alias keys, real channel ids, forum
+names or host names into a commit message, a PR, a doc, or any file in this
+repo.** Synthetic names only (`Jane Doe`, `acme-studio`, `example-site.test`,
+`someforum.test`, made-up snowflakes). This includes the output of
 `dl-route dirs classify` and `dl-route alias review` — both are lists of the
 operator's private taxonomy.
 
@@ -52,49 +53,41 @@ operator's private taxonomy.
 dl-route log -n 20            # each line shows the score and the REASON
 ```
 The reason string is the diagnosis: `alias(site:…)`, `tag=='…'`, `contains '…'
-(2/4 tokens)`, `filename tokens […]`, `tie: …`, `+host-prior`. Then either fix
-it in the UI (the toast's `change`, which writes an alias via `/learn`) or
-directly:
+(2/4 tokens)`, `filename tokens […]`, `tie: …`, `+host-prior`. Fix it in the UI
+(the toast's `change`, which writes an alias via `/learn`) or directly:
 ```bash
 dl-route alias set "<page tag>" "<Directory>" --site example-site.test
+dl-route match --tag "<page tag>" --site example-site.test    # re-check
 ```
-Site-scoped aliases score 1.00 and beat everything else. Re-check with
-`dl-route match --tag "<page tag>" --site example-site.test`.
+Site-scoped aliases score 1.00 and beat everything else.
 
 **"It keeps asking instead of auto-filing."** Check the reason string first —
-there are now four distinct causes and only one of them is the score:
+four distinct causes, and only one of them is the score:
 
 1. **`unclassified directory '<X>'`** — `~/.config/dl-router/dirs.toml` does not
-   list it. An unclassified directory NEVER auto-files. This is the most likely
-   cause on a host that has not run the classifier; `dl-route status` prints
-   `unclassified=N` for exactly this reason.
-   ```bash
-   dl-route dirs classify --out ~/.config/dl-router/dirs.toml   # then edit it
-   ```
-   The file is picked up live — no restart.
-2. **`category directory — always confirm`** — by design. A category is
-   confirmed every time, whatever it scores. Do not "fix" this by reclassifying
-   a genuine category as a performer.
+   list it. An unclassified directory NEVER auto-files. Most likely cause on a
+   host that has not run the classifier; `dl-route status` prints
+   `unclassified=N` for exactly this. Fix: `dl-route dirs classify --out
+   ~/.config/dl-router/dirs.toml`, then edit it — picked up live, no restart.
+2. **`category directory — always confirm`** — by design, whatever it scores. Do
+   not "fix" this by reclassifying a genuine category as a performer.
 3. **`tie: …`** — two candidates within `tie_margin`.
-4. the score is under `auto_threshold` (0.75). `dl-route match …` shows the
-   candidate list. Prefer adding an alias over lowering the threshold — the
-   threshold is what keeps a wrong guess out of a subject directory.
+4. score under `auto_threshold` (0.75). `dl-route match …` shows the candidate
+   list. Prefer adding an alias over lowering the threshold — the threshold is
+   what keeps a wrong guess out of a subject directory.
 
-**"Everything from this chat channel / forum thread opens the picker."** That
-is the FIRST download from it, by design. Confirm it once and the identity
-alias is written; later downloads match at 1.00 with nothing scraped. Check
-what was learned:
-```bash
-dl-route alias review          # evidence, provenance and hit count per row
-```
+**"Everything from this chat channel / forum thread opens the picker."** That is
+the FIRST download from it, by design. Confirm it once and the identity alias is
+written; later downloads match at 1.00 with nothing scraped.
+`dl-route alias review` shows evidence, provenance and hit count per row.
 
 **"It learned something wrong."** `dl-route alias review` flags global and
-suspicious rows, lists every **refused** candidate with its reason and how many
-times it has recurred, and prints the exact removal command. A refused
-candidate never auto-files — if one is a real subject,
-`dl-route alias set '<phrase>' '<Dir>' --site <host> --force`. A performer directory
-never learns a tag, and nothing is ever learned at global scope, so a bad row
-now means either a manual `alias set --force` or a category confirmation.
+suspicious rows, lists every **refused** candidate with its reason and recurrence
+count, and prints the exact removal command. A refused candidate never
+auto-files — if one is a real subject, `dl-route alias set '<phrase>' '<Dir>'
+--site <host> --force`. A performer directory never learns a tag, and nothing is
+ever learned at global scope, so a bad row means either a manual `alias set
+--force` or a category confirmation.
 ```bash
 dl-route alias rm '<key>' --site '*'          # `*` == global, as listed
 dl-route alias rm 'discord:<channel id>' --site discord.com
@@ -102,26 +95,23 @@ dl-route alias rm 'discord:<channel id>' --site discord.com
 
 **"The undo / `change` button says it could not move the file."**
 `/relocate` refuses anything it cannot prove this router created — the library
-root is a live seeding target and the move is an `os.rename`. It needs the
-file's name to match that download's (modulo `uniquify`'s ` (1)`) **and** the
-file to be no older than the routing decision.
-
-Two refusals are by design, not bugs:
+root is a live seeding target and the move is an `os.rename`. It needs the file's
+name to match that download's (modulo `uniquify`'s ` (1)`) **and** the file to be
+no older than the routing decision. Two refusals are by design, not bugs:
 
 * the file was already on disk (it predates its own routing decision);
 * **the download was never routed** — the sidecar was unreachable when it
   started, so `/match` never ran for it (or no `downloadId` was sent, or the
   route log was cleared). A restart does *not* cause this: the route log is
-  persistent SQLite and every decision is committed. There is no fallback here
-  on purpose — with no record to check against, anything else would just be
-  trusting the caller. Move that one file by hand.
+  persistent SQLite and every decision is committed. No fallback here on purpose:
+  with no record to check against, anything else would just be trusting the
+  caller. Move that one file by hand.
 
 `dl-route log` shows the decision it is checking against.
 
-**"It files things into the catch-all folder."** That is the designed
-below-threshold behaviour: an unconfident download must not pollute a subject
-directory, and the picker's Esc then costs nothing. Fix the *match*, not the
-fallback.
+**"It files things into the catch-all folder."** Designed below-threshold
+behaviour: an unconfident download must not pollute a subject directory, and the
+picker's Esc costs nothing. Fix the *match*, not the fallback.
 
 **"A site's tags are not being picked up."** Generic extraction (Open Graph,
 JSON-LD `Person`/`VideoObject`, `[itemprop=name]`, `meta[name=keywords]`) runs
@@ -131,50 +121,46 @@ everywhere. For a site that needs more, add a rule — **config, not code**:
 subject = ["a.performer-name"]
 tags    = [".tag-list a"]
 ```
-Then restart the sidecar (`systemctl --user restart dl-router`) so the snapshot
-carries the new rules. Selector subset: tag, `.class`, `#id`, `[attr]`,
-`[attr="v"]`, `[attr^="v"]`, descendant combinators, comma groups.
+Then `systemctl --user restart dl-router` so the snapshot carries the new rules.
+Selector subset: tag, `.class`, `#id`, `[attr]`, `[attr="v"]`, `[attr^="v"]`,
+descendant combinators, comma groups.
 
 **"The extension seems dead / changes did nothing."**
 1. `dl-route status` — is the sidecar up?
-2. Options page → *Test connection* — port and token right? Is *Enable routing
-   in this profile* ticked? It is **per-profile** and off by default.
-3. **An extension code change needs a FULL Brave restart**, not the reload
-   button — same gotcha as browser-bridge. The manifest version is bumped on
-   every code change specifically so `brave://extensions` can be checked:
-   if it still reads the old number, the restart did not take.
+2. Options page → *Test connection* — port and token right? Is *Enable routing in
+   this profile* ticked? It is **per-profile** and off by default.
+3. The extension is stale — see **FULL Brave restart** under Gotchas.
 
-**"The picker opens in a separate window instead of in the page."** That is the
-designed fallback, not a fault. The overlay needs a content script in the tab
-and a frame that boots, so it falls back for `brave://`/`chrome://`, the PDF
-viewer, the Web Store, `view-source:`, `file://`, a tab that already closed
-(the self-closing file-host tab), a page still loading, and any site whose CSP
-blocks a `frame-src`. Check the tab's URL first. A picker that never appears at
-all is a real fault; a windowed one is not.
+**"The picker opens in a separate window instead of in the page."** Designed
+fallback, not a fault — **a picker that never appears at all is a real fault; a
+windowed one is not.** The overlay needs a content script in the tab and a frame
+that boots, so it falls back for `brave://`/`chrome://`, the PDF viewer, the Web
+Store, `view-source:`, `file://`, a tab that already closed (the self-closing
+file-host tab), a page still loading, and any site whose CSP blocks a
+`frame-src`. Check the tab's URL first.
 
-It also **converts back to a window** if the overlay stops existing — the tab
-closed or navigated, the page removed the node, or a second download needed the
-same tab. That is the safety net, not a bug: the alternative is a download
-nobody was asked about.
+It also **converts back to a window** if the overlay stops existing (tab closed
+or navigated, page removed the node, a second download needed the same tab) —
+the safety net, not a bug: the alternative is a download nobody was asked about.
 
 **If the overlay NEVER works on any site**, suspect `use_dynamic_url` on the
 `web_accessible_resources` entry: the framed page's ES-module imports have to
 resolve under the rotating origin, which is why `picker.js`, `sanitize.js` and
-`route_core.js` are listed next to `picker.html`. This has never been exercised
-in a browser. It fails safe — the frame never boots, gate 2 fires, and every
-picker becomes a window — so the symptom is "always windowed, never in-page".
-Drop `use_dynamic_url` to test the hypothesis; the per-open id still authorises
-picks either way.
+`route_core.js` are listed next to `picker.html`. Never exercised in a browser.
+It fails safe — the frame never boots, gate 2 fires, every picker becomes a
+window — so the symptom is "always windowed, never in-page". Drop
+`use_dynamic_url` to test the hypothesis; the per-open id still authorises picks
+either way.
 
 **"Downloads still show a Save-As dialog."** The profile's
-`download.default_directory` is not the library root, or `prompt_for_download`
-is still on. Re-run `setup-brave-profile.sh` with Brave **fully closed** (it
-refuses otherwise, because Brave rewrites `Preferences` on exit). "Closed"
-means *this* profile: the guard asks whether any live process is using this
-`--user-data-dir` (open fd / main-process cmdline / a live `SingletonLock`), so
-headless automation on a throwaway `/tmp` profile does not block it, and a
-stale lock from a crash does not either. It names the pid to quit. `--list` and
-`--dry-run` write nothing and are never gated.
+`download.default_directory` is not the library root, or `prompt_for_download` is
+still on. Re-run `setup-brave-profile.sh` with Brave **fully closed** — it
+refuses otherwise, because Brave rewrites `Preferences` on exit. "Closed" means
+*this* profile: the guard asks whether any live process is using this
+`--user-data-dir` (open fd / main-process cmdline / live `SingletonLock`), so
+headless automation on a throwaway `/tmp` profile does not block it, nor does a
+stale lock from a crash. It names the pid to quit. `--list` and `--dry-run` write
+nothing and are never gated.
 
 ## Player buttons / embedded video downloads
 
@@ -191,49 +177,35 @@ The content script runs **inside the OOPIF** (out-of-process iframe) — that is
 where the `<video>` element lives, which is why player rules are keyed on the
 embed host, not the page host.
 
-### Config example
-
 ```toml
 [site_rules."example-forum.test".context]
 subject = [".p-title-value"]
 
 [site_rules."example-embed.test".player]
-container = ".plyr"
-media = { element = "#main-video", attr = "src" }
-mount = ".video-wrapper"
-label = "Save to library"
+container = ".plyr"                                  # wrapper the button mounts into
+media = { element = "#main-video", attr = "src" }    # <video>/<source> element + attr holding the URL
+mount = ".video-wrapper"                             # where the button is inserted
+label = "Save to library"                            # button text
 ```
 
-Key fields:
-- `container` — the player wrapper element the button mounts into
-- `media` — the `<video>` or `<source>` element + attribute holding the URL
-- `mount` — where the button is inserted in the DOM
-- `label` — button text
+Find the embed host with `browser frames` (it is the host serving the iframe, not
+the page embedding it), then inspect inside it for the video element structure.
 
-### How to identify embed hosts
-
-Use `browser frames` to find cross-origin iframes, then inspect inside them
-for the video element structure. The embed host is the one serving the iframe,
-not the page embedding it.
-
-### Important details
-
+**Important details**
 - The media URL is **signed and rotates** — `player_buttons.js` reads it **at
   click time**, never caches. A stale URL will fail.
 - The "Already have this" badge checks the **source URL ledger** on mount
   (`GET /have?url=…`).
-- `state.prevents` **double-clicks** via `chrome.storage.local` — the button
-  disables after click until the download is confirmed or the tab changes.
-- Only **HTML5 video with accessible `<video>` elements** are supported. DRM or
+- Double-clicks are prevented via `chrome.storage.local` — the button disables
+  after click until the download is confirmed or the tab changes.
+- Only **HTML5 video with accessible `<video>` elements** is supported. DRM or
   non-standard players (e.g. nested shadow DOM) will not work.
 
-### Troubleshooting
-
 **"Buttons don't appear"**
-1. Check `site_rules` config — both context and player rules must be present
-2. Verify the embed host matches the rule key exactly (use `browser frames` to
-   confirm the iframe origin)
-3. A **full Brave restart** is required after changing player rule config
+1. Both context AND player rules must be present in `site_rules` config.
+2. Verify the embed host matches the rule key exactly (`browser frames` confirms
+   the iframe origin).
+3. A **full Brave restart** is required after changing player rule config.
 
 ## Backfill — the one dangerous path
 
@@ -247,29 +219,28 @@ dl-route backfill apply --manifest <path>.tsv --dry-run
 dl-route backfill apply --manifest <path>.tsv
 ```
 
-* `plan` writes nothing — not into the tree, and **not into the alias
-  database**. It uses the aliases it would seed in memory; `--seed-aliases`
-  persists them.
-* **The TSV is the reviewed artefact.** Edit the `action` column to `SKIP` a
-  row and it takes effect — `apply` reads the TSV. Pointing `apply` at the
-  `.json` after editing the TSV is refused, not silently ignored.
-* `apply` refuses to run without an explicit manifest, and **re-derives every
-  row against live qBittorrent** before touching anything: the manifest's
-  `move`/`torrent_hash` are plan-time values. A disagreement aborts the run and
-  asks you to re-plan. It needs credentials whenever anything is going to move,
+* `plan` writes nothing — not into the tree, and **not into the alias database**.
+  It uses the aliases it would seed in memory; `--seed-aliases` persists them.
+* **The TSV is the reviewed artefact.** Edit the `action` column to `SKIP` a row
+  and it takes effect — `apply` reads the TSV. Pointing `apply` at the `.json`
+  after editing the TSV is refused, not silently ignored.
+* `apply` refuses to run without an explicit manifest, and **re-derives every row
+  against live qBittorrent** before touching anything (the manifest's
+  `move`/`torrent_hash` are plan-time values). A disagreement aborts the run and
+  asks you to re-plan. Credentials are needed whenever anything is going to move,
   not just for `qbt` rows.
-* Torrent-backed rows move via `torrents/setLocation` and are re-verified
-  afterwards, **waiting out the `moving` state** (setLocation returns before
-  the payload has arrived). Any failure aborts the remaining rows.
-* **Absence of proof is never proof.** Every row is `SKIP` if qBittorrent is
+* Torrent-backed rows move via **`torrents/setLocation` — never `mv`** — and are
+  re-verified afterwards, **waiting out the `moving` state** (setLocation returns
+  before the payload has arrived). Any failure aborts the remaining rows.
+* **Absence of proof is never proof.** A row is `SKIP` if qBittorrent is
   unreachable or the path mapping cannot be derived; no row may be `fs` if the
   torrents' FILE lists could not be read, because a no-root-folder torrent's
-  payload sits directly at the library root. That is correct, not a bug — fix
-  the credentials in `config.toml` rather than working around it.
-* The path mapping is derived at runtime from `torrents/info[].save_path`,
-  needs more than one corroborating torrent, and must be able to express the
-  library root. Do **not** hardcode it and do not read it from qBittorrent's
-  stored config — its `LastSavePath` points at a mount that no longer exists.
+  payload sits directly at the library root. Correct, not a bug — fix the
+  credentials in `config.toml` rather than working around it.
+* The path mapping is derived at runtime from `torrents/info[].save_path`, needs
+  more than one corroborating torrent, and must be able to express the library
+  root. Do **not** hardcode it and do **not** read it from qBittorrent's stored
+  config — its `LastSavePath` points at a mount that no longer exists.
 * The only signal that may carry a row is an explicit **alias** on the filename
   stem. The filename itself is capped at 0.50 (spec section 7), so a
   filename-only row can never auto-file; the `signal` column says which it is.
@@ -279,7 +250,7 @@ dl-route backfill apply --manifest <path>.tsv
 ## Changing the code
 
 ```bash
-# from the repo root — both commands are exact, see the gotchas below
+# from the repo root — both commands are exact, see the two notes below
 nix-shell -p 'python312.withPackages(ps:[ps.pytest])' --run "python3 -m pytest scripts/dl-router/tests -q"
 nix-shell -p nodejs --run "node --test 'scripts/dl-router/tests/*.test.mjs'"
 home-manager switch --flake ~/workspace/devrc --impure   # restarts the sidecar
@@ -291,7 +262,19 @@ home-manager switch --flake ~/workspace/devrc --impure   # restarts the sidecar
 * The node glob **must be quoted**. `node --test scripts/dl-router/tests` treats
   the directory as one test file and reports a bogus failure.
 
-Invariants the tests exist to protect — do not weaken them:
+Editing the sidecar requires a `home-manager switch` (it runs from the nix
+store). `SKILL.md` and `dl-route` are out-of-store symlinks and track the working
+tree immediately.
+
+**Deploying a matching change is TWO steps, not one.** The extension carries its
+own copy of the matcher (`route_core.js`) for the cached fallback, so a
+`home-manager switch` alone leaves the OLD service worker running with the old
+rules — including, after the directory-kinds change, a `localDecide` with no kind
+gate, which will keep auto-filing from cache into a directory you have just
+reclassified as a category. Finish with a **FULL Brave restart** (Gotchas), then
+re-check `dl-route status`.
+
+### Invariants the tests exist to protect — do not weaken them
 
 * **`suggest()` is called exactly once on every path and never hangs.** Chrome
   falls back to the default filename if the listener is slow. The timer racing
@@ -304,15 +287,15 @@ Invariants the tests exist to protect — do not weaken them:
   ```bash
   nix-shell -p nodejs python312 --run "python3 scripts/dl-router/tests/difffuzz.py"
   ```
-* **Identity signals must agree across the two languages too.**
-  `matcher.py` and `extension/route_core.js` both derive a Discord channel id
-  and a forum thread slug from a URL, and the extension's copy runs exactly
-  when the sidecar is unreachable — so a divergence is invisible until it
-  misfiles. `tests/fixtures/url_cases.json` is the one table both suites
-  assert. Add a row there before adding a URL shape to either implementation.
-* **Only a `performer` directory may auto-file**, in the cached fallback as
-  well as in the sidecar. Weakening the gate on one side only re-creates a
-  divergence that shows up solely when the sidecar is down.
+* **Identity signals must agree across the two languages too.** `matcher.py` and
+  `extension/route_core.js` both derive a Discord channel id and a forum thread
+  slug from a URL, and the extension's copy runs exactly when the sidecar is
+  unreachable — so a divergence is invisible until it misfiles.
+  `tests/fixtures/url_cases.json` is the one table both suites assert. Add a row
+  there before adding a URL shape to either implementation.
+* **Only a `performer` directory may auto-file**, in the cached fallback as well
+  as in the sidecar. Weakening the gate on one side only re-creates a divergence
+  that shows up solely when the sidecar is down.
 * **Nothing is ever learned at global scope**, and a performer directory never
   learns a tag. That is the fix for the mislearning incident, not a preference.
 * **yt-dlp is invoked as an argv list with a validated http(s) URL and a `--`
@@ -321,108 +304,101 @@ Invariants the tests exist to protect — do not weaken them:
 * **A duplicate is never acted on automatically.** The file is kept and filed;
   the toast asks. `POST /discard` is refused unless all five proofs hold, the
   refusal is surfaced (toast **and** notification), and the default is a move
-  into `.dl-router-trash/`. Making any part of this implicit turns a warning
-  into a data-loss mechanism.
-* **A schema migration must be additive, idempotent and re-runnable after a
-  crash between the DDL and the `PRAGMA user_version` bump.** sqlite3
-  autocommits DDL, so there is no transaction around a migration; every step is
-  `IF NOT EXISTS` or goes through `ADD_COLUMN_IF_MISSING`. This has bitten
-  here before (v2) and is pinned per version.
+  into `.dl-router-trash/`. Making any part of this implicit turns a warning into
+  a data-loss mechanism.
+* **A schema migration must be additive, idempotent and re-runnable after a crash
+  between the DDL and the `PRAGMA user_version` bump.** sqlite3 autocommits DDL,
+  so there is no transaction around a migration; every step is `IF NOT EXISTS` or
+  goes through `ADD_COLUMN_IF_MISSING`. This has bitten here before (v2) and is
+  pinned per version.
 * Tests never contact the live qBittorrent instance or touch the real library.
-
-Editing the sidecar requires a `home-manager switch` (it runs from the nix
-store). `SKILL.md` and `dl-route` are out-of-store symlinks and track the
-working tree immediately.
-
-**Deploying a matching change is TWO steps, not one.** The extension carries
-its own copy of the matcher (`route_core.js`) for the cached fallback, so a
-`home-manager switch` alone leaves the OLD service worker running with the old
-rules — including, after the directory-kinds change, a `localDecide` with no
-kind gate, which will keep auto-filing from cache into a directory you have
-just reclassified as a category. Finish the deploy with a **full Brave
-restart** (not the reload button — the long-poll keeps the old worker alive,
-same gotcha as browser-bridge), then re-check `dl-route status`.
 
 ## Gotchas
 
 * Port **8791** — 8790 is already taken on the workbench.
-* The picker's **per-directory counts are not covered by the `/dirs` ETag**, on
-  purpose: they change on every download and `FileIndex` is TTL-cached, so
-  including them would make the ETag change when the routing configuration had
-  not. `dl-route status`'s `etag` therefore still answers "did the routing
-  config change?". The picker's own snapshot request skips `If-None-Match` so
-  it still sees fresh counts; nothing else does.
+* `onDeterminingFilename` **cannot escape the download root**: no `..`, no
+  absolute paths. That is precisely why the profile's download directory has to
+  *be* the library root.
+* **An extension change needs a FULL Brave restart**, not `↻` on the extensions
+  page — same lesson as browser-bridge. A reload often leaves the old service
+  worker alive (the long-poll keeps it running). The manifest version is bumped
+  on every code change specifically so `brave://extensions` can be checked: if it
+  still reads the old number, the restart did not take.
+* Both hosts are hostname `nixos` — check `dl-route status` to know which one you
+  are on.
+* Existing directories are **never renamed** (three naming conventions coexist;
+  the matcher folds them). New ones are Title Case and never created silently.
+
+### Picker counts / the `/dirs` ETag
+* **Per-directory counts are not covered by the `/dirs` ETag**, on purpose: they
+  change on every download and `FileIndex` is TTL-cached, so including them would
+  make the ETag change when the routing configuration had not. `dl-route
+  status`'s `etag` therefore still answers "did the routing config change?". The
+  picker's own snapshot request skips `If-None-Match` so it still sees fresh
+  counts; nothing else does.
 * Counts are **suppressed entirely when the file index hit its `file_index_max`
   cap** — a partial tally of an unknown fraction of the library rendered next to
   a directory name would be a wrong number, which is worse than none.
-* Counts are **empty until the file index has been walked**. `/dirs` never
-  starts that walk (a whole-tree walk there would blow the extension's 4 s
-  snapshot budget on a large library); `/match` warms it on every download. A
-  picker with no counts means no `/match` has run in this sidecar process yet.
+* Counts are **empty until the file index has been walked**. `/dirs` never starts
+  that walk (a whole-tree walk there would blow the extension's 4 s snapshot
+  budget on a large library); `/match` warms it on every download. A picker with
+  no counts means no `/match` has run in this sidecar process yet.
+
+### Dedupe and `/discard` (the destructive path)
 * **Dedupe is size-first, and the hash is deliberately NOT on `/match`.** At
   `onDeterminingFilename` time the downloaded file does not exist, so there is
   nothing to hash and `totalBytes` is often `0`. `/match` reports a *possible*
   duplicate from the free size bucket; `POST /dedupe` after completion is the
-  authoritative answer, and that is where all the I/O lives — outside the
-  400 ms budget by construction, not by tuning. Do not move it onto `/match`.
+  authoritative answer, and that is where all the I/O lives — outside the 400 ms
+  budget by construction, not by tuning. Do not move it onto `/match`.
 * **The head+tail digest samples 128 KiB from each end, never the middle.** Two
   files of the same length that differ only in the middle read as duplicates.
   That is the price of a constant-cost check on multi-GB media, and it is only
-  affordable because the answer is a warning with a `keep` button. If a delete
-  is ever made automatic, this bound stops being acceptable.
+  affordable because the answer is a warning with a `keep` button. If a delete is
+  ever made automatic, this bound stops being acceptable.
+* **SAMPLING IS A WARNING; THE DELETE IS GATED ON A FULL COMPARISON.** This is
+  the single most important invariant in the subsystem and it took three rounds.
+  `/dedupe` samples (head + tail + eight 128 KiB mid-file windows); `/discard`
+  reads BOTH FILES IN FULL and compares them byte for byte. Do not "optimise"
+  that back into a digest comparison — no bounded read proves two multi-GB files
+  identical, it only fails to disprove.
 * **`POST /discard` is the only destructive path, and the SEEDING guard is the
   payload check — not the trash.** qBittorrent seeds by PATH, so a rename into
   `.dl-router-trash/` breaks a torrent exactly as `unlink` would. `/discard`
   refuses a hardlinked file (`nlink > 1` — the standard payload-into-subject-dir
-  layout), a symlink, a sparse file, and — when qBittorrent credentials are set
-  — anything live state calls a payload or cannot corroborate at all. Creds are
+  layout), a symlink, a sparse file, and — when qBittorrent credentials are set —
+  anything live state calls a payload or cannot corroborate at all. Creds are
   deliberately empty on this host, so the three local checks carry it there.
   `backfill apply` demands the same corroboration for a REVERSIBLE move; do not
-  let /discard end up weaker than it again.
-* **SAMPLING IS A WARNING; THE DELETE IS GATED ON A FULL COMPARISON.** This is
-  the single most important invariant in the subsystem and it took three
-  rounds. `/dedupe` samples (head + tail + eight 128 KiB mid-file windows);
-  `/discard` reads BOTH FILES IN FULL and compares them byte for byte. Do not
-  "optimise" that back into a digest comparison — no bounded read proves two
-  multi-GB files identical, it only fails to disprove.
+  let `/discard` end up weaker than it again.
 * **`st_blocks` cannot see a fallocated partial.** qBittorrent's "pre-allocate
-  disk space for all files" uses `posix_fallocate`, which reserves REAL
-  extents: identical size, identical block count, identical head and tail as
-  the finished file. Only reading the middle separates them — an all-zero mid
-  sample is an unfilled extent. The sparse check catches only the
-  `ftruncate` shape; it is not the guard, it is one of several.
+  disk space for all files" uses `posix_fallocate`, which reserves REAL extents:
+  identical size, identical block count, identical head and tail as the finished
+  file. Only reading the middle separates them — an all-zero mid sample is an
+  unfilled extent. The sparse check catches only the `ftruncate` shape; it is not
+  the guard, it is one of several.
 * **A verification that runs out of budget is a REFUSAL.** `files_identical`
-  returns True / False / **None**; None is "could not determine" and must
-  never collapse into either answer. Same for a stat that cannot answer
+  returns True / False / **None**; None is "could not determine" and must never
+  collapse into either answer. Same for a stat that cannot answer
   (`_looks_preallocated` fails CLOSED).
 * **One routing decision authorises ONE discard.** The route row is consumed
-  (`discards` table, v6). Unconsumed evidence is a capability, not a proof —
-  one downloadId used to remove `new.mp4`, `new (1).mp4` and `new (2).mp4` in
-  turn, because `names_match` tolerates the ` (N)` suffix by design.
+  (`discards` table, v6). Unconsumed evidence is a capability, not a proof — one
+  downloadId used to remove `new.mp4`, `new (1).mp4` and `new (2).mp4` in turn,
+  because `names_match` tolerates the ` (N)` suffix by design.
 * **The kept file must PREDATE the routing decision** by at least
-  `MTIME_SLACK_S`. That timestamp is the only thing distinguishing the two
-  halves of a uniquify pair; the two mtime windows are deliberately disjoint so
-  no file can satisfy both. Without it /discard could remove the ORIGINAL.
-* **Same file = same inode.** The self-check compares `(st_dev, st_ino)`, not
+  `MTIME_SLACK_S`. That timestamp is the only thing distinguishing the two halves
+  of a uniquify pair; the two mtime windows are deliberately disjoint so no file
+  can satisfy both. Without it `/discard` could remove the ORIGINAL.
+* **Same file = same inode.** The self-check compares `(st_dev, st_ino)`, **not**
   resolved paths — `resolve()` collapses symlinks but not hardlinks. Don't
   "simplify" it back to a path comparison.
-* **The trash is unbounded and invisible to `dl-route status`.** Nothing sweeps
-  it, nothing reports its size, and both index scans skip it by design. Check
-  by hand (`du -sh <library root>/.dl-router-trash`) if space goes missing. A
+
+### The trash
+* **Unbounded and invisible to `dl-route status`.** Nothing sweeps it, nothing
+  reports its size, and both index scans skip it by design. Check by hand
+  (`du -sh <library root>/.dl-router-trash`) if space goes missing. A
   cross-filesystem library root cannot use it: the move fails closed on EXDEV
   rather than degrading to a non-atomic copy-then-delete.
-* **The trash directory is hidden on purpose**: both index scans skip
-  dot-prefixed names, so its contents never become dedupe candidates or
-  routing targets. Do not rename it to something visible.
-* `onDeterminingFilename` **cannot escape the download root**: no `..`, no
-  absolute paths. That is precisely why the profile's download directory has to
-  *be* the library root.
-* **An extension change needs a FULL Brave restart**, not `↻` on the
-  extensions page — same lesson as browser-bridge. A reload often leaves the
-  old service worker alive.
-* Existing directories are **never renamed** (three naming conventions coexist;
-  the matcher folds them). New ones are Title Case and never created silently.
-* Both hosts are hostname `nixos` — check `dl-route status` to know which one
-  you are on.
-* The sidecar is inert on a host with no `library_root`; that is fine, not a
-  failure to fix.
+* **Hidden on purpose**: both index scans skip dot-prefixed names, so its
+  contents never become dedupe candidates or routing targets. Do not rename it to
+  something visible.


### PR DESCRIPTION
Compression pass on four dense skills. A `SKILL.md` loads into context **in full** whenever the skill triggers, so every redundant sentence is a per-invocation tax forever.

**No behaviour, command, flag, threshold or runbook order was changed.** Breaking changes are proposed below, not applied.

## Bytes

Baseline = `origin/main` @ `e673e6b`. "Per-invocation" = what every skill trigger pays.

| Skill | Before | After (SKILL.md) | Saved | Reference files added |
|---|---|---|---|---|
| `activity` | 22,309 | **13,833** | **−38.0%** | `queries.md` 4,047 · `session-insights.md` 4,470 |
| `tekton` | 16,408 | **10,149** | **−38.1%** | `pipelines.md` 7,579 |
| `mailbox` | 18,906 | **14,834** | **−21.5%** | `build-dns-forwarding.md` 5,843 |
| `dl-router` | 24,095 | **23,574** | **−2.2%** | none (see proposal #1) |
| **total per-invocation** | **81,718** | **62,390** | **−23.7%** | |

⚠ **`dl-router`'s baseline moved under me.** I started from `6346b21` (21,693 B); `b9617ea` then added the 2,402-byte player-buttons section. The rebase onto `e673e6b` merged cleanly, I re-ran the coverage check against the *correct* baseline (0 atoms missing), and I read the merged region to confirm no semantic conflict — the player-buttons section is intact and coherent. I then compressed that section too, since it landed in a file I own.

`dl-router` is the weak result: it is almost entirely hard-won gotcha prose where the prose **is** the fact, and I was scoped to `SKILL.md` only. See proposal #1.

## Coverage check — method and counts

Before compressing, a script extracted every operational-fact **atom** from each original: IPs/ports, URLs, hostnames, filesystem paths, every backticked token (commands, flags, columns, identifiers), `CONSTANT_CASE` env vars, versions, and numeric thresholds/quantities. After compressing, each atom was verified still present in the new `SKILL.md` **or** in a reference file the skill points at by repo-absolute path.

| Skill | Atoms | Present | Missing | Missing are |
|---|---|---|---|---|
| `activity` | 229 | 225 | 4 | PR refs `#26/#28/#149` (deliberate cruft removal) + regex artifacts |
| `dl-router` | 189 | 188 | 1 | `state.prevents` — a **typo** in the original (`` `state.prevents` **double-clicks** ``), rewritten as "Double-clicks are prevented via `chrome.storage.local`" |
| `mailbox` | 214 | 208 | 6 | PR refs `#31/#80/#81/#156` (deliberate) + regex artifacts |
| `tekton` | 217 | 217 | **0** | — |

Four genuine losses were caught by the check and **restored**: `gitBranch` (initiative-scan's telemetry key), the `active/slowing/stalled` momentum enum, `active_time.js` (the concrete delete-by-hand example), and the `~/workspace/devrc/` prefix on the session-analysis script paths (reachability — the skill deploys to `~/.claude/`, so relative repo paths don't resolve).

**Mutation test** (per the browser-bridge precedent) — deleted each reference file and re-ran the check to prove the facts genuinely live there and aren't just duplicated:

| Deleted | Atoms lost |
|---|---|
| `tekton/reference/pipelines.md` | **102** |
| `mailbox/reference/build-dns-forwarding.md` | **37** |
| `activity/reference/session-insights.md` | **18** |
| `activity/reference/queries.md` | 1 atom — **but** the atom extractor under-weights raw SQL (unquoted ClickHouse function names aren't atoms). Verified separately: all **18** non-comment SQL lines are byte-identical to the original. |

## Section decision tables

### `activity` (22,309 → 13,833)

| Section | Decision | Note |
|---|---|---|
| Frontmatter / description | KEEP AS-IS | trigger surface |
| Intro + data flow | COMPRESS | dropped narrative build-up; flow diagram + `ACTIVITY_HOST` stamping kept |
| Key-facts table | COMPRESS | endpoints/creds/SOPS/schema kept **verbatim**; the one-cell 6-source monster split out |
| Sources (was 1 table cell) | COMPRESS → own table | one row per source; browser cell's `active_ms` retirement + the "counted *other-app* time" reason kept |
| Browser-extension deploy | COMPRESS | `cp -fL` path, `brave://extensions` reload, v1.4.0, `rm`-deleted-files all kept |
| Gotchas | KEEP AS-IS | UTC-vs-local bucketing, hostname `nixos`/`ACTIVITY_HOST`, GUI-only, keylogging-secrets → verbatim. Added the argMax-dedupe rule here (was buried in the Layer B prose) |
| `home-manager switch` restarts | COMPRESS | was a 5-line finished-migration story; now 3 lines. Kept the operative fact + `claude-activity-source` exclusion |
| status / validate | KEEP AS-IS | commands verbatim |
| Invariant changes | COMPRESS | dropped PR archaeology (`#26/#28`), kept the current invariant set + the 7d bound + *why* |
| Analysis tooling | COMPRESS | all flags/caveats kept; repo-absolute paths restored |
| Query patterns (SQL) | **MOVE** → `reference/queries.md` | 18 SQL lines byte-identical; the `text`-not-`payload.url`, `JSONExtract`-not-subcolumn, DESTINATION-vs-LEAVING-tab and 30-min-cap caveats moved with it |
| Human validation | COMPRESS | 3 lines → 2 |
| Layer B — the 5-step flow | KEEP (reflowed) | now one copy-pasteable block |
| Layer B — extraction contract | **MOVE** → `reference/session-insights.md` | pointer at step 3 is 🔴-marked: read it *before* extracting, don't work from memory |
| Layer B — emit-on-settle history | **MOVE** | the 27,061-rows-over-702-sessions archaeology; the operative knobs stay reachable |

### `tekton` (16,408 → 10,149)

| Section | Decision | Note |
|---|---|---|
| 5 critical gotchas | KEEP AS-IS | hostNetwork/9099-crashed-the-gateway/19100, stale checkout, RWX+node-pin, imagePullSecret, orphans — **verbatim** |
| What/where, GitHub App, webhook | KEEP AS-IS | versions, App ID, install id, port 19100, full request path |
| `naida-ux-audit` detail | **MOVE** → `reference/pipelines.md` | |
| `remix-ux-audit` detail | **MOVE** | sidecars, `REMIX_TEST_*` DSNs, CEL path filter, impure nix-shell, live verification |
| `clawgate-ci` detail + 4 known-open 🟡 | **MOVE** | incl. the Actions-is-billing-blocked warning |
| Pipelines summary table | **NEW** | 3-row trigger/scope/gate table + the "red Actions checks are noise" warning stay inline |
| Merge→reconcile→push rule | KEEP AS-IS | the most expensive gotcha — verbatim, incl. the 14d-old-pod evidence |
| Shared `eventlistener.yaml` warning | KEEP AS-IS | verbatim |
| Dashboard, deploy pattern | KEEP AS-IS | |
| Adding a pipeline | COMPRESS | added step 5 (reconcile-before-push) so the checklist is self-contained |

### `mailbox` (18,906 → 14,834)

| Section | Decision | Note |
|---|---|---|
| Mail-flow diagram | KEEP AS-IS | the whole chain verbatim |
| Key-facts table | COMPRESS | image tags, NodePort 30026, DSN secret keys, both kubeconfigs, CF zone id kept verbatim |
| `mail-actions` × 3 capabilities | COMPRESS | **one-live-action-per-thread**, `taxes-{year}-invoices` + `{vendor}/{date}-{file}` key, 06:00 timer, `FETCH 1:*`-OOMKilled all kept verbatim |
| `_db.py` direct-mode | COMPRESS | dropped the PR-number framing; both env vars + the importlib-not-`sys.path` warning kept |
| Automation gotchas ×6 | KEEP AS-IS | incl. the ROTATE warning |
| Send-as-operator | KEEP AS-IS | credential location, `email_send.py` API, the full snippet, all caveats |
| status/query | COMPRESS | comments-in-SQL-block → prose bullets below; `via_gmail`/`category`/`labels` semantics kept |
| Rebuild receiver | **MOVE** → `reference/build-dns-forwarding.md` | incl. "NEVER git add -A in the drifted tree" |
| Test send | **MOVE** | the whole postfix-relay snippet |
| DNS runbook | **MOVE** | CF token path, zone id, required record state, proxied=false, Email-Routing-is-apex-only, trust-API-not-dig |
| Gmail forwarding | **MOVE** | `vf-` confirms / `uf-` cancels |
| Go-live gotchas | SPLIT | aiosmtpd-event-loop + 451-on-PG-failure + :25-blocked stay inline; gateway-restart/Mailpit/DNS get a 1-line inline summary **with the destructive part intact** ("blips ALL ~25 services", "NEVER point `MAILPIT_HOST` at `10.42.0.10:2525` — that loops") + a pointer |

### `dl-router` (24,095 → 23,574)

| Section | Decision | Note |
|---|---|---|
| Header, orient, where-things-live | KEEP AS-IS | |
| 🔴 private-library warning | KEEP AS-IS | promoted to a 🔴 block |
| Common tasks | COMPRESS | sentence-level only; every reason string, threshold and refusal case kept |
| FULL-Brave-restart rule | CONSOLIDATE | stated 3× → one canonical statement under Gotchas (now carrying the manifest-version check **and** the long-poll reason), 2 cross-refs |
| Player buttons | COMPRESS | two-layer rule system, OOPIF reasoning, signed-and-rotating-URL-read-at-click-time all kept; config comments inlined |
| Backfill | KEEP AS-IS | `torrents/setLocation`-never-`mv`, absence-of-proof-is-never-proof, `LastSavePath`-points-at-a-dead-mount → verbatim |
| Changing the code + invariants | KEEP AS-IS | incl. the `withPackages`-not-`python312Packages` and quote-the-node-glob corrections |
| Gotchas / dedupe / discard / trash | KEEP AS-IS, regrouped into 4 subsections | every destructive-path warning verbatim: SAMPLING-IS-A-WARNING, seeding-guard-is-the-payload-check, `st_blocks`-can't-see-fallocated, None-is-a-REFUSAL, ONE-decision-ONE-discard, PREDATE + `MTIME_SLACK_S`, same-inode-not-same-path, EXDEV-fails-closed |

## 🔴 PROPOSED BREAKING CHANGES — NOT APPLIED

**1. Split `dl-router`'s invariants + dedupe/discard blocks into `scripts/dl-router/reference/`.**
- *What*: move "Invariants the tests exist to protect" (~2.6 KB) and "Dedupe and `/discard`" (~4.4 KB) out, leaving pointers.
- *Why*: this is the only remaining lever — dl-router saved 2.2% because I was scoped to `SKILL.md` alone.
- *Saving*: ~7 KB, taking dl-router to roughly **−30%**.
- *Risk if wrong*: **the highest of any proposal here.** These blocks are the guardrails on the subsystem's only destructive path (`POST /discard`). A reader who doesn't open the reference file could weaken a data-loss guard. Unlike browser-bridge's reference files, `nix/home.nix` symlinks only `SKILL.md` + `dl-route` into `~/.claude/skills/dl-router/`, so a reference file is reachable **only** by repo-absolute path.
- *How to verify safe*: decide the deploy shape first (add `reference/` to the `home.nix` symlinks, or accept repo-absolute addressing as browser-bridge does). Then keep a one-line 🔴 summary of each destructive-path invariant inline, with the full text in the reference file.

**2. `dl-router`: drop the `use_dynamic_url` hypothesis block (~700 B).**
- *What / why*: it documents an untested theory ("This has never been exercised in a browser") about a symptom nobody has hit.
- *Risk if wrong*: if the overlay ever fails globally, the diagnosis has to be re-derived from scratch. Low frequency, high re-derivation cost.
- *Verify*: keep it if the overlay has ever failed this way; drop it if not.

**3. `mailbox`: fold the Gmail-forwarding section into the reference file's TOC only.**
- *What*: it is already moved; this would additionally remove the inline mention.
- *Risk*: forwarding setup is rare but load-bearing (the whole inbox depends on it). I kept a pointer; removing it entirely would make it unfindable without opening the file. **I recommend against.**

**4. `tekton`: drop the `remix-ux-audit` "Verified LIVE end-to-end" paragraph (~600 B).**
- *What*: the PipelineRun name, pushed run id and commit sha proving it worked once.
- *Risk*: it is provenance, not procedure — but it is also the only evidence the pipeline was ever green end-to-end. Currently preserved in the reference file at zero per-invocation cost, so there is no pressing reason to cut it.

## Cross-references checked

`git grep`ed every consumer. All still resolve — no anchor was renamed and no skill name changed.

- `CLAUDE.md` names all four explicitly ("Operate it via the `activity` skill", "Operate via the `mailbox` skill", "Operate via the `dl-router` skill", the tekton entry) — **all still accurate**; every gotcha CLAUDE.md summarises is still present in the corresponding skill.
- `claude/skills/clawgate/SKILL.md:170` → defers clawgate-ci's open sharp edges and the merge→reconcile→push rule to the tekton skill. The reconcile rule is still **inline** in `tekton/SKILL.md`; the four sharp edges moved to `tekton/reference/pipelines.md`, still reachable via the pointer. ✅
- `claude/skills/vetr-mailbox/SKILL.md:10` → "copy of the `/mailbox` skill's send-as pattern". Send-as section kept inline, unchanged. ✅
- `claude/commands/adoption-scan.md:16`, `claude/commands/initiatives.md:33` → both point at the `activity` skill for `CLICKHOUSE_*` reader creds and the laptop nebula endpoint. Both still in the Key-facts table. ✅
- `SECRETS.md:24` → activity collector env + "See the `activity` skill". ✅
- `scripts/session-analysis/{README.md,session_insight/*.py}` → four references to "the live Claude session operating the `activity` skill" doing the extraction. Layer B section retained inline with that division of labour stated. ✅
- `nix/home.nix:1206-1208` → `mkOutOfStoreSymlink` for `dl-router/{SKILL.md,dl-route}` only. Unchanged; no new dl-router file added, so nothing to stage there.

**Flake gotcha handled**: all four new reference files were `git add`ed explicitly (flakes only see tracked files). `claude/skills/` is symlinked **recursively** by `nix/home.nix:642`, so `activity/reference/`, `mailbox/reference/` and `tekton/reference/` deploy to `~/.claude/skills/<name>/reference/` automatically. Reference files are nonetheless addressed by **repo-absolute path**, matching the browser-bridge convention.

## 🔴 Finding — pre-existing privacy-rule violation in `dl-router` (NOT introduced here, NOT fixed here)

`scripts/dl-router/SKILL.md:168` (added by `b9617ea`, before this PR) contains two **real** host names from the operator's private taxonomy:

> `(e.g. `turbo.cr` iframes embedded on a forum page like `simpcity.cr`)`

This violates the skill's own 🔴 rule — "never print … forum names or host names into … any file in this repo" — in a **public** repo.

I deliberately did **not** silently edit it: the names are already in public git history, so removing them from `HEAD` would give false assurance rather than redaction. This needs an operator decision (rewrite to `example-embed.test`/`example-forum.test` and accept the history, or rewrite history). Flagging rather than acting.

Two smaller notes on the same commit's text, also not acted on: `state.prevents **double-clicks**` was a typo (I rewrote it as prose while compressing, hence the one "missing" atom above).

## Verification

- **node**: `454 pass / 0 fail` — matches the corrected baseline exactly.
- **pytest**: `342 passed / 3 failed` — matches the corrected baseline count. Failures are `test_manifest_version_reads_current`, `test_manifest_version_falls_back_to_repo_when_not_deployed`, `test_ping_op_set_mirrors_the_extension_protocol_js` (the third differs from the name I was given; all three are browser-bridge manifest/protocol literal-pinning tests being fixed separately).
- These failures are **structurally impossible** to be mine: `git diff --name-only origin/main` is exactly the 8 documentation files listed above — **zero** Python or JavaScript touched.
- **No live service was contacted**: no ClickHouse query, no Postgres, no deploy, no `home-manager switch`, no qBittorrent call, no mail sent, no Brave. Docs-only.

## ✅ Privacy confirmation

**No private `dl-router` path, directory name, filename or route-log line was introduced by this PR.** Every example in the compressed file is synthetic (`example-site.test`, `example-forum.test`, `example-embed.test`, `acme-studio`, `Jane Doe`, `new.mp4`). I scanned all added lines for real paths, `Title Case` directory-style names and library-root strings; the only real host names present are the two pre-existing ones flagged above, which arrived via `b9617ea` and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011L55ie18DYBHdq7KeqgK3k
