### PR TITLE
fix(browser-bridge): the `context` op is dead on main — server.py never got it

### DIFF
--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -144,7 +144,7 @@ from urllib.parse import unquote, urlsplit
 # operator is using.
 ALLOWED_OPS = ("getHtml", "text", "eval", "tabs", "nav", "screenshot",
                "open", "close", "frames", "click", "type", "key", "wake",
-               "activate", "upload", "ping", "emulate")
+               "activate", "upload", "ping", "emulate", "context")
 
 # Ops handled ENTIRELY server-side (never dispatched to the extension). `release`
 # relinquishes a session's owned-tab mapping without touching the real Brave tab.
@@ -156,7 +156,7 @@ SERVER_OPS = ("release",)
 # and `release` (server-side) do NOT contend for a single tab.
 TAB_SCOPED_OPS = frozenset({"getHtml", "text", "eval", "nav", "screenshot",
                             "close", "frames", "click", "type", "key",
-                            "wake", "activate", "upload", "emulate"})
+                            "wake", "activate", "upload", "emulate", "context"})
 
 # Ops that may run ONLY against a tab the calling session OWNS (opened via `open`).
 # This is the emulation blast-radius rule, enforced at the one place that knows who

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -980,10 +980,18 @@ def test_registry_deliver_unknown_id_false():
 
 def test_validate_command_contract():
     # The op set is the shared contract with extension/protocol.js.
+    #
+    # NOTE: equality between THIS list and protocol.js's is pinned separately and
+    # structurally by test_ping_op_set_mirrors_the_extension_protocol_js, which
+    # parses both real files. What this literal adds is a deliberate speed bump:
+    # adding an op has to be acknowledged in a second place. That is a weaker
+    # signal than the drift test — consider dropping it if it keeps costing a red
+    # `main` — but it is a live check today, so it gets updated, not deleted.
     assert set(S.ALLOWED_OPS) == {"getHtml", "text", "eval", "tabs", "nav",
                                   "screenshot", "open", "close",
                                   "frames", "click", "type", "key", "wake",
-                                  "activate", "upload", "ping", "emulate"}
+                                  "activate", "upload", "ping", "emulate",
+                                  "context"}
     # `upload` is a dispatched, tab-scoped CDP op requiring selector + path.
     assert S.validate_command({"op": "upload", "selector": "#f",
                                "path": "/tmp/x"}) == ("upload", None)
@@ -3115,12 +3123,19 @@ def test_git_short_head_none_on_missing_dir(tmp_path):
 
 def test_manifest_version_reads_current():
     v = S.manifest_version(path=EXT_DIR / "manifest.json")
-    # Bumped to 0.6.0 for the `documentPredatesEmulation` hint on `emulate`.
-    # 0.5.0 was the `emulate` op itself; 0.4.0 the poll-loop no-wedge change. The
-    # bump is the operator's only falsifiable "is the new build loaded?" signal,
-    # so this assertion is deliberately a literal — it MUST be updated in the
-    # same commit as manifest.json, which is the point.
-    assert isinstance(v, str) and v == "0.6.0"
+    # Bumped to 0.7.0 for the `context` op + enriched read envelopes. 0.6.0 was
+    # the `documentPredatesEmulation` hint; 0.5.0 the `emulate` op itself; 0.4.0
+    # the poll-loop no-wedge change. The bump is the operator's only falsifiable
+    # "is the new build loaded?" signal, so this assertion is deliberately a
+    # literal — it MUST be updated in the same commit as manifest.json.
+    #
+    # ⚠ That contract has now been broken once: 0.7.0 shipped without touching
+    # this file and left `main` RED on three tests. The literal did its job (it
+    # noticed) but nobody was watching at bump time. If it breaks again, the
+    # answer is a pre-merge gate on the bump, NOT deleting the literal — a
+    # derived assertion here would compare the manifest to itself and pin
+    # nothing at all.
+    assert isinstance(v, str) and v == "0.7.0"
 
 
 def test_manifest_version_prefers_the_deployed_copy_over_the_repo(tmp_path,
@@ -3141,7 +3156,7 @@ def test_manifest_version_falls_back_to_repo_when_not_deployed(tmp_path,
     reporting the repo manifest instead of going null."""
     monkeypatch.setattr(S, "_DEPLOYED_EXT_MANIFEST", tmp_path / "absent.json")
     monkeypatch.setattr(S, "_EXT_MANIFEST_PATH", EXT_DIR / "manifest.json")
-    assert S.manifest_version() == "0.6.0"
+    assert S.manifest_version() == "0.7.0"
 
 
 def test_manifest_version_none_when_neither_exists(tmp_path, monkeypatch):


### PR DESCRIPTION
## The real finding

`e673e6b` shipped the `context` op into `extension/protocol.js`, the service worker, the CLI and the manifest (0.7.0) — **but not into `server.py`'s `ALLOWED_OPS`**. The server rejects an unknown op *before* dispatching to the extension, so `browser context` returns `unknown_op` for anyone who pulls `main`. It also never entered `TAB_SCOPED_OPS`, so it wouldn't have participated in per-tab FIFO serialization.

```
server.py   on main contains "context": 0
protocol.js on main contains "context": 1
```

**Why nobody noticed:** the fix existed as an *uncommitted* edit in one laptop's working tree, which a `home-manager switch` then baked into the deployed server. Live-testing `browser context` there returned real data. A live probe run against a dirty tree is not evidence — this is the "works here, broken in the repo" shape.

**The guard worked.** `test_ping_op_set_mirrors_the_extension_protocol_js` (the drift test from #242, which parses *both* real lists instead of trusting either) failed on the first op added since it landed. Three separate agents reported it correctly; I misread it as a stale-literal problem because my own checkout carried the uncommitted fix.

## Also: three stale literals from the same commit

| test | was | now |
|---|---|---|
| `test_validate_command_contract` | op set without `context` | + `context`, plus a note that the drift test is the real guard and this literal is only a speed bump |
| `test_manifest_version_reads_current` | `0.6.0` | `0.7.0` |
| `test_manifest_version_falls_back_to_repo_when_not_deployed` | `0.6.0` | `0.7.0` |

An audit earlier flagged that the manifest version isn't single-sourced — *"every bump costs two test edits"* — and recommended keeping the literal because it forces a conscious update. That tradeoff has now cost a red `main` once. The comment records it, and records that the answer is a **pre-merge gate on the bump**, not deleting the literal: a derived assertion here would compare the manifest to itself and pin nothing.

## Verification

pytest **342 passed / 3 failed → 345 passed / 0 failed**. node **454 / 0**, unchanged.

⚠ After merge, both hosts need a `home-manager switch` so the deployed `server.py` matches the repo. No Brave reload needed — this is server-side only, manifest untouched at 0.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)