### PR TITLE
docs(browser-bridge): wake is not a passive read; tab discard loses injected state

### DIFF
--- a/scripts/browser-bridge/reference/errors.md
+++ b/scripts/browser-bridge/reference/errors.md
@@ -117,6 +117,13 @@ readable) — `null` is NOT "fine". `browser whoami` carries the same three fiel
 change shipped without a manifest bump is invisible to it. That is why the
 version bump is part of the change contract, and why `ping` exists.
 
+🔴 **The concrete shape that gap takes: an op answers `unknown_op` while `health`
+reports a MATCHING `extension_version`.** That combination reads as a
+contradiction and sends people debugging the server or the CLI instead. It is not
+a contradiction — the *loaded* worker predates the op even though the manifest
+version agrees. Observed on `wake` (2026-08-01). **Believe the op, not the
+version**, and go straight to the reload/restart ladder below.
+
 **⚠ Reload ↻ is UNRELIABLE — a full Brave restart is the reliable fix.** The
 extension's long-poll keeps the OLD service worker permanently alive, so clicking
 ↻ in `brave://extensions` often does NOT swap in the new build. If a reload

--- a/scripts/browser-bridge/reference/spa-wake.md
+++ b/scripts/browser-bridge/reference/spa-wake.md
@@ -4,7 +4,9 @@
 a read reported `data.hidden:true` or printed a hidden-tab warning on stderr · an SPA
 looks stuck "Loading…" · `frames` lists no OOPIF you know is there · in-frame
 `click`/`type` hits elements that "don't exist yet" · you are about to conclude a site
-is BROKEN from a browser read · before driving any heavy JS app in an `open`ed tab.
+is BROKEN from a browser read · before driving any heavy JS app in an `open`ed tab ·
+you are measuring anything the page gates on VISIBILITY (timers, refresh loops,
+readiness) · an injected `window.__x` hook vanished between reads.
 
 Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`.
 
@@ -78,6 +80,109 @@ session detaches (measured), but the **DOM the page rendered during the wake
 window persists** — so a following ordinary `text`/`html` sees the rendered page
 on the cheap, banner-free path. Re-wake after a navigation or when the app needs
 to do more rendering work.
+
+### 🔴 `wake` is NOT a passive read — one wake fires `visibilitychange` TWICE
+
+`wake` turns on `Emulation.setFocusEmulationEnabled`, which genuinely flips the
+document `hidden` → `visible` (that flip is the measured Chromium behaviour the
+op is built on — see the rAF/timer/visibility table in `extension/protocol.js`).
+It then **tears the emulation down** in a `finally`
+(`Emulation.setFocusEmulationEnabled{enabled:false}`, `WAKE_CDP_TEARDOWN`), which
+flips the document back `visible` → `hidden`.
+
+**So a single `wake` delivers TWO `visibilitychange` events to the page, not one.**
+
+✅ MEASURED 2026-08-01 — laptop (`192.168.50.155`), Brave profile `personal`,
+extension **0.7.0** (`extension_id bgbkamdlkdleahpgdgmjipjbgmepgenk`), a
+background `example.com` tab with a counting listener installed via `js`:
+
+| step | `window.__vc` | `document.visibilityState` |
+|---|---|---|
+| listener installed | 0 | `hidden` |
+| harness control — synthetic `dispatchEvent` | 1 | `hidden` |
+| reset, then **one `wake`** | **2** | `hidden` (after detach) |
+| a **second `wake`** | **4** | `hidden` |
+| reset, then `js --wake` — read *inside* the window | **1** | `visible` |
+| …the same tab read again *after* teardown | **2** | `hidden` |
+
+The `js --wake` rows are the clearest statement of the mechanism: **one** event
+has fired by the time your in-window read runs, and the **second** lands when the
+session detaches. (The counter was validated against a synthetic event first —
+a listener that cannot count would have reported a false 0.)
+
+Two consequences, in opposite directions:
+
+- ✅ **It is the NON-INTRUSIVE way to exercise visibility-gated behaviour.** Any
+  page whose logic is gated on being visible — deferred timers, refresh/keep-alive
+  loops, readiness handshakes that never complete while hidden — can be observed
+  *and driven* without `activate` and without stealing the operator's screen. A
+  woken background tab reaches the same state a foreground one would.
+- 🔴 **So every `wake` can RUN REAL PAGE LOGIC. Never treat one as a free look.**
+  Observed on a token-refresh page host: each `--wake` observation fired the page's
+  `visibilitychange` handler, which issued a **fresh credential mint** — so the act
+  of measuring reset the very clock being measured, and the request log contained
+  more entries than the page's own retry budget allows. If you are waiting for a
+  deadline, a keep-alive wake **past that deadline pushes the deadline out**.
+
+🔴 **If you are counting page-initiated requests/timers/retries, subtract `2 ×
+your wake count`, not one per wake** — for a handler bound to `visibilitychange`
+generally. A handler that early-returns on `document.hidden` (the common shape)
+does its work only on the `visible` edge and so runs **once** per wake; one that
+acts on both edges runs **twice**. Read the page's handler before choosing the
+multiplier — do not assume.
+
+Practical rule: decide *before* waking whether the thing you are measuring is
+visibility-sensitive. If it is, plan the wake schedule (including keep-alive
+wakes) as part of the experiment, not as incidental instrumentation.
+
+This is the page-facing half of a point `reference/agent.md` already makes about
+the operator-facing half — **"a read is passive, but a wake attaches the debugger
+to the operator's live tab"**, which is why `wake` counts as a MUTATING op for the
+autonomous agent's dry-run policy. Same conclusion, two blast radii: keep them in
+sync.
+
+### 🔴 A background tab can be DISCARDED — injected page state does not survive
+
+Chromium may **discard** a backgrounded tab under memory pressure and **reload it
+on activation**. The tab id and the URL are unchanged across the whole cycle.
+
+**A tab that is discarded RIGHT NOW is announced loudly — do not disbelieve it.**
+Any CDP op fails fast, *before* `chrome.debugger.attach`, with
+`tab_discarded: the target tab was unloaded by Chrome (memory saver) and has no
+live renderer to attach to …` (`assertTabCdpReady` in `extension/protocol.js`),
+and the load-settle poll treats `discarded` as terminal rather than waiting for a
+renderer that will never answer. That error is real and actionable: reload the
+tab or bring it to the foreground, then retry.
+
+**What is silent is the RELOAD afterwards.** Once the tab comes back, `discarded`
+is false again, the tab id and URL still match, nothing tracks document identity,
+and `browser tabs` reports no `discarded` field at all — so a later read looks
+completely ordinary. But the document is NEW, and everything you injected into the
+old one is gone: a `window.__x` instrumentation hook, a patched `window.fetch`,
+accumulated in-page logs. Same failure mode as the RE-THROTTLE-after-reload
+section below — a reload makes a new document, and a new document has none of your
+state.
+
+**Re-install after any `activate`, any `tab_discarded` you recovered from, or any
+suspected discard, and verify the hook is still there before trusting a reading:**
+
+```bash
+BB=~/workspace/devrc/scripts/browser-bridge/browser
+$BB --instance work --tab "$TAB" js 'typeof window.__mintLog'   # "undefined" ⇒ reinstall
+```
+
+A hook that reads `undefined` is the tell. An empty *array* means "installed, no
+events" — which is a completely different answer, and the one you must not
+confuse with a discarded tab. When the log itself is the evidence, prefer a
+storage that survives a bridge drop and re-read it defensively rather than
+assuming continuity across a long-running observation.
+
+⚠ **Open question (#273):** whether the emulation bookkeeping survives this cycle.
+`documentEmulation` is cleared only on tab *identity* change, and a discard-reload
+keeps the tab id — so on an **emulated** tab the `documentPredatesEmulation` hint
+may go silently wrong after a discard. Unsettled: it needs a forced discard via
+`brave://discards`. Until #273 closes, re-apply `emulate` after a suspected
+discard rather than trusting the absence of a warning.
 
 ### ⚠ After a RELOAD the tab is RE-THROTTLED — and htmx then silently stops firing
 


### PR DESCRIPTION
Three durable learnings from a 2026-07-31 → 08-01 session that used `wake` to observe a visibility-gated token-refresh loop on a real page host.

## `wake` fires `visibilitychange` — it is not a passive read

`wake` uses `Emulation.setFocusEmulationEnabled`, so it genuinely flips the document `hidden` → `visible` and the page **receives a real `visibilitychange` event**. Two consequences, in opposite directions:

- ✅ It is the **non-intrusive alternative to `activate`** for any page whose behaviour is gated on visibility — deferred timers, refresh/keep-alive loops, readiness handshakes that never complete while hidden. A woken background tab reaches the same state a foreground one would, with no screen steal.
- 🔴 **Every wake can run real page logic.** Measured: each observation wake fired the page's own handler, which issued a **fresh credential mint** — so the act of measuring reset the clock being measured, and the request log held more entries than the page's retry budget allows. A keep-alive wake past a deadline **pushes the deadline out**.

Practical rule added: decide before waking whether the thing you are measuring is visibility-sensitive, and plan the wake schedule as part of the experiment.

## A background tab can be DISCARDED, losing injected page state

Chromium may discard a backgrounded tab under memory pressure and silently reload it on activation. Tab id and URL are unchanged and nothing in the bridge output announces it — but a `window.__x` instrumentation hook or a patched `window.fetch` is gone. Documented the re-install-and-verify step, plus the tell: `typeof window.__x === "undefined"` means discarded, whereas an **empty array** means "installed, no events" — a completely different answer.

## `errors.md`: name the concrete shape of the version-vs-code gap

An op answering `unknown_op` while `health` reports a **matching** `extension_version` reads as a contradiction and sends people debugging the server. It is just the existing "version match ≠ code match" case. Observed on `wake` (2026-08-01). Believe the op, not the version; reload ↻ is unreliable, full Brave quit-and-reopen is the fix.

## Correction

The session also hit `browser js --wake '<expr>'` failing with *"takes exactly one JS argument"* — but that was **already fixed by #251** earlier the same day. Rather than document a stale gotcha, the `--wake` row now states that flag order is free, so it no longer implies a trailing-flag requirement.

Docs only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)