### PR TITLE
perf(browser-bridge): drop `health` from the quick start; fix + tighten the SKILL.md size gate

### DIFF
--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -7,8 +7,7 @@ description: Drive the user's LIVE, logged-in Brave browser from Claude Code —
 
 ```bash
 BB=~/workspace/devrc/scripts/browser-bridge/browser   # ← run it by this exact path
-$BB whoami                          # ORIENT FIRST: which HOST + which profiles are connected
-$BB health                          # is an extension connected? loaded vs repo extension_version
+$BB whoami                          # ORIENT FIRST: HOST + connected profiles + extension_stale
 $BB --instance <key> open <url>     # open a NEW tab THIS session owns → returns tabId
 $BB --instance <key> --tab <id> text   # cheap read of a specific tab
 ```

--- a/scripts/browser-bridge/tests/test_skill_size.py
+++ b/scripts/browser-bridge/tests/test_skill_size.py
@@ -27,18 +27,46 @@ MAX_BYTES = 12_288
 # Required working margin below the ceiling. A file sitting at 12,287 bytes
 # technically holds the line but leaves no room for a one-line correction --
 # and that is the exact position this file has been re-breached from. The
-# ENFORCED budget is therefore MAX_BYTES - MIN_HEADROOM_BYTES = 12,188.
-MIN_HEADROOM_BYTES = 100
+# ENFORCED budget is therefore MAX_BYTES - MIN_HEADROOM_BYTES = 12,038.
+#
+# The floor is sized in units of a REAL edit, not a round number. Measured on
+# the 2026-08-02 surface audit, the two tables that actually grow are:
+#   ops table       21 rows, 3,995 B -> mean 190 B/row
+#   reference table 11 rows, 1,823 B -> mean 166 B/row
+# At the old 100-byte floor -- BELOW both means -- the headroom test could not
+# fire before the ceiling did: one new row jumped straight past both, so the
+# "early warning" arrived as a surprise, which is the failure the docstring in
+# test_skill_md_keeps_working_headroom describes. 250 B is >= one mean
+# reference row and >= 1.3 mean ops rows, so the warning now genuinely precedes
+# the breach.
+MIN_HEADROOM_BYTES = 250
 
 SKILL_MD = Path(__file__).resolve().parent.parent / "SKILL.md"
+REFERENCE_DIR = SKILL_MD.parent / "reference"
 
-_EVICTION_PLAYBOOK = """
+
+def _existing_topics() -> str:
+    """The reference topics that exist RIGHT NOW, read off the filesystem.
+
+    Deliberately globbed rather than hard-coded: the previous hand-maintained
+    literal drifted to 8 of 11 topics (missing emulation, read-envelopes,
+    auth-pages), so the playbook steered a maintainer into creating a duplicate
+    topic for content that already had a home. A hard-coded list regrows that
+    bug on the next reference file added; this cannot.
+    """
+    topics = sorted(p.stem for p in REFERENCE_DIR.glob("*.md"))
+    if not topics:
+        return f"(none found under {REFERENCE_DIR} -- did reference/ move?)"
+    return ", ".join(topics)
+
+
+def _eviction_playbook() -> str:
+    return f"""
   How to fix (the #233/#235 pattern -- do NOT just delete content):
     1. Pick a coherent block of the core that is only needed for ONE kind of
        task (a subsystem, a failure mode, a fallback path).
     2. Move it whole into scripts/browser-bridge/reference/<topic>.md
-       (existing topics: agent, css-hit-test, errors, frames-cdp,
-       security-ops, spa-wake, tabs-instances, x-fallback).
+       (existing topics: {_existing_topics()}).
     3. Leave a ~110-byte pointer row in SKILL.md naming the topic and its
        REPO-ABSOLUTE path -- nix/home.nix symlinks only SKILL.md and the
        `browser` CLI into ~/.claude/skills/browser/, NOT reference/, so a
@@ -60,6 +88,25 @@ def test_skill_md_exists():
     )
 
 
+def test_eviction_playbook_lists_every_reference_topic():
+    """Guard the guard, part 2: the playbook only renders on FAILURE, so a
+    wrong topic list is invisible until the day someone needs it -- which is
+    exactly how it drifted to 8 of 11. Exercise the derivation directly."""
+    on_disk = sorted(p.stem for p in REFERENCE_DIR.glob("*.md"))
+    assert on_disk, (
+        f"no reference/*.md found under {REFERENCE_DIR} -- either the eviction "
+        "pattern was abandoned or REFERENCE_DIR is wrong; either way the "
+        "playbook below would name no topics."
+    )
+    playbook = _eviction_playbook()
+    missing = [t for t in on_disk if t not in playbook]
+    assert not missing, (
+        f"the eviction playbook omits existing reference topics {missing}; a "
+        "maintainer following it would create a duplicate topic. The list must "
+        "stay derived from the filesystem, never hard-coded."
+    )
+
+
 def test_skill_md_under_hard_ceiling():
     size = _size()
     assert size <= MAX_BYTES, (
@@ -67,7 +114,7 @@ def test_skill_md_under_hard_ceiling():
         f"  current:  {size:,} bytes\n"
         f"  ceiling:  {MAX_BYTES:,} bytes\n"
         f"  OVER BY:  {size - MAX_BYTES:,} bytes\n"
-        f"{_EVICTION_PLAYBOOK}"
+        f"{_eviction_playbook()}"
     )
 
 
@@ -77,6 +124,12 @@ def test_skill_md_keeps_working_headroom():
     Fails in the MAX_BYTES-MIN_HEADROOM .. MAX_BYTES band (and above, where the
     ceiling test also fires with the overage). "You are one word from breaking
     it" becomes a signal instead of a surprise.
+
+    That promise only holds if the margin is bigger than one edit. It is sized
+    off the MEASURED mean table row (190 B ops / 166 B reference -- see the
+    comment on MIN_HEADROOM_BYTES); the earlier 100 B floor was smaller than
+    both, so it fired at the same moment as the ceiling and delivered the
+    surprise it exists to prevent.
     """
     size = _size()
     headroom = MAX_BYTES - size
@@ -89,5 +142,5 @@ def test_skill_md_keeps_working_headroom():
         f"  budget:    {MAX_BYTES - MIN_HEADROOM_BYTES:,} bytes "
         f"(ceiling minus the required margin)\n"
         f"  RECLAIM:   {MIN_HEADROOM_BYTES - headroom:,} bytes\n"
-        f"{_EVICTION_PLAYBOOK}"
+        f"{_eviction_playbook()}"
     )


### PR DESCRIPTION
Three token/gate items from the 2026-08-02 browser-bridge surface audit (`claudedocs/browser-bridge-surface-audit-2026-08-02.md`, #274) — F1, F7, F8. Done in order: S3 is red until S1 has freed the bytes.

Out of scope by operator decision, deliberately untouched: the frontmatter `description` (trigger surface — a dropped keyword silently stops the skill activating) and symlinking `reference/` (204 B of gain, recreates a "which copy is live?" hazard). `MAX_BYTES` stays `12_288`.

## Byte count and headroom

| | SKILL.md | ceiling | floor | enforced budget | free vs budget |
|---|---|---|---|---|---|
| before | 12,007 B | 12,288 | 100 | 12,188 | 181 B |
| after | **11,911 B** | 12,288 | **250** | **12,038** | **127 B** |

Headroom against the ceiling: 281 B → **377 B** (≥ the 250 B floor). S1 freed 96 B.

⚠️ **One correction to the task premise, stated because it was measured rather than assumed.** The brief said S3 would be *red* until S1 landed, on the basis of "181 B free". That 181 B is free-against-the-**old** budget (12,188 − 12,007); against the ceiling, `origin/main` had **281 B** of headroom, which already clears the new 250 B floor. So raising the floor alone would have been **green — by 31 B**, about one sixth of a mean ops row. The order was still the right one to work in (31 B is not a margin), but the claim "S3 is red without S1" is false and should not be repeated. The audit's own version of the sequencing assumed P1 **and** P2 (the frontmatter trim), and P2 is out of scope here.

## S1 — `health` dropped from the quick start

`whoami` already answers everything the orientation step asks. Verified on `origin/main`, not assumed:

- `server.py:1750 _whoami` returns `bridge.connected = len(insts)` (the count) and `instances = annotate_staleness(...)`, so every entry carries the explicit `extension_stale` true/false/null verdict.
- `health`'s *unique* content is the full active-tab URL + title and `known_instances` liveness ages — triage material.

**Surviving reader paths to `health` (S1 removed a pointer, not the only pointer):**

1. **`SKILL.md:58`** — the ops table row: `` | `health` / `instances` | connected instances + count … each with an explicit `extension_stale` verdict | ``
2. **`SKILL.md:97-98`**, triage item 1 — *"A call that WORKED now fails, errors, or returns nothing → re-run `browser health` BEFORE debugging the page or the CLI"*. This is the route the audit cited, and it exists and covers the case.

Both confirmed present on `origin/main` **before** the removal and present in this branch after it (`grep -n health SKILL.md` → lines 58, 98, 108).

**Secondary (the privacy half):** `health` prints the *full* active-tab URL of *every* connected profile into the caller's context — the audit's own run captured a Discord channel URL and a `claude.ai` settings URL. `whoami` reports `activeTabDomain` only, by design, and `opencode/tools/browser_tool_impl.mjs:680-691` documents at length why cross-profile URL exposure is the leak to close ("a `banking` profile sitting on chase.com while the agent runs on `work`"). A reflexive `health` on every task re-opened exactly that, one layer up. `health` itself is unchanged — it is the right tool for triage, where the URLs are the point.

## S2 — eviction playbook derived from the filesystem

The playbook named 8 topics; `reference/` holds 11 (`emulation`, `read-envelopes`, `auth-pages` were missing). It now globs `reference/*.md`. Hard-coding 11 names would have reintroduced the bug on the next file added.

New test `test_eviction_playbook_lists_every_reference_topic` exercises the derivation directly — the playbook string only renders on assertion *failure*, which is precisely why the drift stayed invisible for three files.

## S3 — `MIN_HEADROOM_BYTES` 100 → 250

`test_skill_size.py`'s docstring promises *"you are one word from breaking it becomes a signal instead of a surprise."* The audit measured the two tables that actually grow:

| table | rows | bytes | mean/row |
|---|---|---|---|
| ops | 21 | 3,995 | **190 B** |
| reference | 11 | 1,823 | **166 B** |

100 B is below both means, so one new row cleared the floor and the ceiling in the same edit — the floor fired *simultaneously* with the ceiling and delivered the surprise it exists to prevent. 250 B is ≥ one mean reference row and ≥ 1.3 mean ops rows. The `MIN_HEADROOM_BYTES` comment (which restated `12,188`) and the headroom test's docstring are both updated in the same commit.

## Negative controls — run, not assumed

**NC-B (S3 — the two size tests must discriminate).** A SKILL.md padded to **12,100 B**, i.e. between the new budget (12,038) and the ceiling (12,288):

```
tests/test_skill_size.py::test_skill_md_exists                          PASSED
tests/test_skill_size.py::test_eviction_playbook_lists_every_ref_topic  PASSED
tests/test_skill_size.py::test_skill_md_under_hard_ceiling              PASSED   ← ceiling stays green
tests/test_skill_size.py::test_skill_md_keeps_working_headroom          FAILED
  current: 12,100 / ceiling: 12,288 / free: 188 (minimum required: 250)
  budget:  12,038 / RECLAIM: 62
  assert 188 >= 250
1 failed, 3 passed
```

Red for **its own** reason (`assert 188 >= 250`, the headroom message), not the ceiling's. Floor discrimination at that same 12,100 B:

```
headroom=188   old floor 100  -> GREEN
headroom=188   new floor 250  -> RED
ceiling test at 12,100        -> GREEN (ceiling 12,288)
```

So the new floor is what fires, and it fires *ahead* of the ceiling — the whole point. SKILL.md was restored from a copy (never `git stash`) and the sha256 verified identical to the pre-pad file: `3fad971e8222430d9d0941e6f798fbbaac2dfff205b078341a3b5eed617e1cd7`, 11,911 B.

**NC-A (S2 — the new test must see the drift it was written for).** Monkeypatched `_existing_topics` back to the old hard-coded 8-name literal:

```
RESULT: RED (correct) -> the eviction playbook omits existing reference topics
['auth-pages', 'emulation', 'read-envelopes']; a maintainer following it would
create a duplicate topic. …
```

Names exactly the three that were missing.

## Suites — counted from the reporter lines, not exit codes

- `pytest tests/` (under `nix-shell -p python3Packages.pytest python3Packages.requests`) → **370 passed**, 0 failed, 0 skipped, 104 s. Baseline 369; +1 is the new playbook test.
- `node --test tests/*.test.mjs` → `tests 454 / pass 454 / fail 0 / cancelled 0 / skipped 0 / todo 0`, 7.3 s. Run to catch doc-consistency breakage from the SKILL.md edit; none. (454 is the `origin/main` count — the audit's 460 was measured on a worktree carrying another session's WIP. `git status` confirms this branch changes only `SKILL.md` and `test_skill_size.py`, no `.mjs`.)

## Notes for the reviewer

- **Touches `SKILL.md`, so it overlaps PR #266.** Per `RULES.md`, `gh pr view 266 --json mergeable,mergeStateStatus` is the only authority on whether they conflict — do not infer it from a local merge trial. The regions differ (this PR: line 11 of the quick start; #266: `spa-wake`/`errors` reference rows), but a clean textual merge is not a clean merge — read the merged quick-start block.
- **`CLAUDE.md` says "281 B free today"** in the browser-bridge section. That is now 377 B. Left untouched — outside this PR's file ownership, and that file's own instruction is not to restate the gate's numbers.
