### PR TITLE
test(browser-bridge): anchor the agent surface to the real op inventory (contains 1 DELIBERATE failure)

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -1435,7 +1435,7 @@ The agent's entire capability is a single **custom opencode tool**, `browser`
 (`opencode/tools/browser.js` + its pure-logic sibling `browser_tool_impl.mjs`,
 copied into the scratch project's `.opencode/tools/` per run). The model calls it
 with TYPED arguments — `op` ∈ {`text`,`html`,`eval`,`nav`,`screenshot`,`frames`,
-`click`,`type`,`key`,`wake`,`whoami`} plus optional `selector`/`url`/`js`/`text`/`key`/`frame`/
+`click`,`type`,`key`,`wake`,`context`,`whoami`} plus optional `selector`/`url`/`js`/`text`/`key`/`frame`/
 `maxBytes`/`waitMs` — **never a shell command string, and never a raw-CDP `cdp`/`method`
 field** (the CDP ops are bounded typed ops only; see the CDP security model above).
 

--- a/scripts/browser-bridge/opencode/browser-agent.md
+++ b/scripts/browser-bridge/opencode/browser-agent.md
@@ -29,6 +29,7 @@ fetch). Your tab is FIXED: you cannot choose or change which tab you act on.
 | `browser(op="type", text="…")` (opt. `selector`, `frame`) | **trusted** text input (focus `selector` first if given) |
 | `browser(op="key", key="Enter")` (opt. `selector`, `frame`) | dispatch one **trusted** key (Enter/Tab/Escape/Arrow*/…) |
 | `browser(op="wake")` (opt. `waitMs`)   | **UN-THROTTLE your tab** so a throttled SPA actually renders. It does NOT move the operator's screen. **You almost never need to call this** — a hidden `text`/`html` read wakes and re-reads automatically, including the first read after you drove the page (see Rules) |
+| `browser(op="context")`                | read WHERE your tab actually is — url, domain, path, searchParams, title — WITHOUT reading any page content. Cheap; use it to confirm a `nav` landed (redirects, login walls) before paying for a `text` read |
 | `browser(op="whoami")`                 | read-only identity + diagnostics: which HOST (laptop/workbench), YOUR OWN browser profile, and bridge/extension versions — call it to CONFIRM which host/profile you're on before acting (metadata only; you cannot see the operator's other profiles or what any tab is browsing) |
 
 ## Rules

--- a/scripts/browser-bridge/opencode/tools/browser.js
+++ b/scripts/browser-bridge/opencode/tools/browser.js
@@ -43,7 +43,7 @@ export default tool({
     // of them (operator-only, opt-in via BROWSER_AGENT_ALLOWED_OPS).
     op: tool.schema
       .enum(["text", "html", "eval", "nav", "screenshot",
-             "frames", "click", "type", "key", "wake", "whoami"])
+             "frames", "click", "type", "key", "wake", "context", "whoami"])
       .describe("the operation to perform on your tab"),
     selector: tool.schema.string().optional()
       .describe("op=text/click/type/key: CSS selector (click target / focus / scope)"),

--- a/scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
+++ b/scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
@@ -51,6 +51,35 @@ import { homedir } from "node:os";
 // This is a stronger stance than `upload`'s opt-in, and intentionally so: `upload`
 // is a risk the operator can knowingly accept per run, whereas a model stealing
 // focus has no legitimate autonomous use at all.
+// ⚠ `ping` is DELIBERATELY ABSENT from OP_TO_SERVER. It is an OPERATOR
+// diagnostic for extension staleness — "is the build I just deployed actually
+// the one Brave loaded?" — answered by {pong, extensionVersion, id, ops}. The
+// model cannot ACT on that answer: it cannot reload an unpacked extension, it
+// cannot restart Brave, and it cannot re-run a home-manager switch. It also
+// reads NO page state, so it cannot inform a browsing decision either. An op
+// whose only possible follow-up is unavailable to the caller is pure token cost
+// with no available action, so it stays operator-only on the `browser` CLI —
+// excluded like `activate`, not gated like `upload`.
+//
+// ⚠ `emulate` is DELIBERATELY ABSENT from OP_TO_SERVER. Unlike every read op it
+// MUTATES the tab and leaves STICKY PER-TAB STATE THAT OUTLIVES THE OP: device
+// metrics, UA-CH and media overrides persist on the tab until they are
+// explicitly reset (`emulate --reset`) or the tab is replaced. An autonomous
+// model that emulates and then does not reset — because it moved on, hit its
+// step budget, or crashed — hands the operator back a silently altered tab. It
+// also attaches CDP, raising Brave's "an extension is debugging this browser"
+// banner. That is the same hazard class as `upload` being off-by-default, but
+// with a PERSISTENT side effect rather than a one-shot one, so the answer is
+// exclusion rather than an opt-in the operator has to remember to undo.
+//
+// `context` IS reachable (below). It is a cheap READ of page state — url,
+// domain, path, searchParams, title, tabId — and reads NO DOM content, so it is
+// strictly less powerful than the `text`/`html` the agent already has, while
+// letting the model confirm WHERE it actually is after a nav/redirect without
+// paying for a full page read. Its absence here was an oversight, not a
+// decision: this file was last edited 2026-07-31 (#243) and `context` only
+// reached server.py's ALLOWED_OPS on 2026-08-01 (#263), so the agent-surface
+// mapping has never been looked at since the op came into existence.
 // `whoami` is a READ-ONLY, GLOBAL diagnostic: it is NOT a /cmd op (it hits the
 // server's GET /whoami, has no tab, drives nothing) — it lets the agent confirm
 // which HOST + which browser profile it is connected to before acting. It maps to
@@ -69,10 +98,11 @@ export const OP_TO_SERVER = Object.freeze({
   key: "key",
   wake: "wake",
   upload: "upload",
+  context: "context",
   whoami: "whoami",
 });
 
-// The AUTONOMOUS model's DEFAULT op set — 11 ops, identical to browser.js's typed
+// The AUTONOMOUS model's DEFAULT op set — 12 ops, identical to browser.js's typed
 // `op` enum, the agent-md capability table, and the README's published contract.
 // Keep those four in lockstep (tests/browser_tool.test.mjs parses all four and
 // asserts they match, so a drift fails CI).
@@ -90,7 +120,7 @@ export const OP_TO_SERVER = Object.freeze({
 // README) — never by default, and never by anything the model can set itself.
 export const ALLOWED_OPS_DEFAULT = Object.freeze([
   "text", "html", "eval", "nav", "screenshot",
-  "frames", "click", "type", "key", "wake", "whoami",
+  "frames", "click", "type", "key", "wake", "context", "whoami",
 ]);
 
 export const TEXT_MAX_BYTES_DEFAULT = 32768;
@@ -312,7 +342,8 @@ export function buildRequest(args, env, token) {
     body.path = String(args.path);
     _addFrame(body, args);
   }
-  // frames / screenshot: no extra typed fields (the tab is forced by env).
+  // frames / screenshot / context: no extra typed fields (the tab is forced by
+  // env, and `context` reports on that tab only).
 
   const host = env.BROWSER_BRIDGE_HOST || "127.0.0.1";
   const port = env.BROWSER_BRIDGE_PORT || "8788";
@@ -668,6 +699,16 @@ export function summarizeResult(op, envelope, env = {}, autoWake = null) {
       woke: data.woke ?? null, visibilityState: data.visibilityState ?? null,
       readyState: data.readyState ?? null, settleMs: data.settleMs ?? null,
       url: data.url ?? null, title: data.title ?? null });
+  }
+  if (op === "context") {
+    // Page-level metadata for the agent's OWN tab. Field-pinned rather than a
+    // bare passthrough, so a later server-side addition to the `context`
+    // payload cannot silently widen what reaches the model.
+    return JSON.stringify({
+      url: data.url ?? null, domain: data.domain ?? null,
+      path: data.path ?? null, searchParams: data.searchParams ?? null,
+      title: data.title ?? null, tabId: data.tabId ?? null,
+    });
   }
   if (op === "whoami") {
     // Identity + diagnostics. `envelope` IS the whole whoami object (no .data).

--- a/scripts/browser-bridge/tests/browser_tool.test.mjs
+++ b/scripts/browser-bridge/tests/browser_tool.test.mjs
@@ -281,7 +281,7 @@ test("OP_TO_SERVER maps only the bounded ops (no lifecycle ops, no raw CDP)", ()
   // `whoami` is a read-only GLOBAL diagnostic (GET /whoami) — bounded + typed
   // like the rest; still NO lifecycle ops and NO raw-CDP escape.
   assert.deepEqual(Object.keys(OP_TO_SERVER).sort(),
-    ["click", "eval", "frames", "html", "key", "nav", "screenshot",
+    ["click", "context", "eval", "frames", "html", "key", "nav", "screenshot",
      "text", "type", "upload", "wake", "whoami"]);
   // Lifecycle ops (wrapper owns the tab) AND any raw-CDP escape must be unmappable.
   for (const forbidden of ["open", "close", "tabs", "release",
@@ -293,7 +293,7 @@ test("OP_TO_SERVER maps only the bounded ops (no lifecycle ops, no raw CDP)", ()
   // enabled by default — it takes a caller-chosen absolute path with no allowlist,
   // and the model is pointed at untrusted, prompt-injecting pages.
   assert.deepEqual([...ALLOWED_OPS_DEFAULT].sort(),
-    ["click", "eval", "frames", "html", "key", "nav", "screenshot",
+    ["click", "context", "eval", "frames", "html", "key", "nav", "screenshot",
      "text", "type", "wake", "whoami"]);
   assert.ok(!ALLOWED_OPS_DEFAULT.includes("upload"),
     "upload must NOT be in the autonomous agent's default op set");
@@ -1031,6 +1031,24 @@ const REVIEWED_AGENT_EXCLUSIONS = Object.freeze({
       "from OP_TO_SERVER entirely, so BROWSER_AGENT_ALLOWED_OPS cannot re-enable it. " +
       "`wake` gives the agent the capability it actually needed.",
     source: "`activate` is DELIBERATELY ABSENT from OP_TO_SERVER",
+  },
+  ping: {
+    reason: "OPERATOR diagnostic for extension staleness (is the build I just " +
+      "deployed the one Brave loaded?). The model cannot ACT on the answer — it " +
+      "cannot reload an unpacked extension, restart Brave, or re-run a switch — " +
+      "and it reads NO page state, so it cannot inform a browsing decision " +
+      "either. Pure token cost with no available follow-up action.",
+    source: "`ping` is DELIBERATELY ABSENT from OP_TO_SERVER",
+  },
+  emulate: {
+    reason: "It MUTATES the tab and leaves STICKY per-tab state that outlives " +
+      "the op: device metrics, UA-CH and media overrides persist until an " +
+      "explicit `emulate --reset` or the tab is replaced. An autonomous model " +
+      "that emulates and never resets (moved on, hit its step budget, crashed) " +
+      "hands the operator back a silently altered tab. Same hazard class as " +
+      "`upload` being off-by-default, but with a PERSISTENT side effect, so the " +
+      "answer is exclusion rather than an opt-in someone must remember to undo.",
+    source: "`emulate` is DELIBERATELY ABSENT from OP_TO_SERVER",
   },
 });
 

--- a/scripts/browser-bridge/tests/browser_tool.test.mjs
+++ b/scripts/browser-bridge/tests/browser_tool.test.mjs
@@ -888,6 +888,22 @@ test("OP-SET PARITY: browser.js enum == ALLOWED_OPS_DEFAULT == agent-md == READM
   const md = sorted(opsFromAgentMd());
   const readme = sorted(opsFromReadme());
   assert.ok(impl.length >= 10, "sanity: the parsed default op set is non-trivial");
+  // Name WHICH source is missing WHICH op BEFORE the bare deepEqual below. A raw
+  // set-inequality dump ("[a,b,c] != [a,b,d]") sends the next person hunting; the
+  // deepEquals stay as the backstop for the reverse direction (an EXTRA op).
+  for (const [label, names] of [
+    ["browser.js `op` enum", js],
+    ["the agent-md capability table", md],
+    ["the README op list", readme],
+    ["ALLOWED_OPS_DEFAULT", impl],
+  ]) {
+    const have = new Set(names);
+    const union = new Set([...impl, ...js, ...md, ...readme]);
+    const missing = [...union].filter((o) => !have.has(o)).sort();
+    assert.deepEqual(missing, [],
+      `${label} is MISSING op(s) that the other agent-facing sources declare: ` +
+      `${missing.join(", ")} (source: ${label}; ops: ${missing.join(", ")})`);
+  }
   assert.deepEqual(js, impl, "browser.js `op` enum must match ALLOWED_OPS_DEFAULT");
   assert.deepEqual(md, impl, "the agent-md capability table must match ALLOWED_OPS_DEFAULT");
   assert.deepEqual(readme, impl, "the README op list must match ALLOWED_OPS_DEFAULT");
@@ -903,4 +919,232 @@ test("OP-SET PARITY: `upload` appears in NONE of the four agent-facing sources",
 test("BROWSER_AGENT_ALLOWED_OPS is DOCUMENTED (it was read by code and documented nowhere)", () => {
   assert.match(readBB("README.md"), /BROWSER_AGENT_ALLOWED_OPS/,
     "the README must document the op-set override env var");
+});
+
+// --------------------------------------------------------------------------- //
+// UPSTREAM ANCHOR for the agent surface.
+//
+// The four-source parity test above pins four agent-facing sources TO EACH OTHER
+// and to NOTHING UPSTREAM. That is a real test with a specific blind spot: if a
+// wire op is missing from all four simultaneously, the set is self-consistent, CI
+// is green, and the omission is invisible. That is not hypothetical — it is how
+// `context`, `ping` and `emulate` came to be unreachable by the autonomous agent
+// with nobody noticing (browser-bridge surface audit, 2026-08-02, F9/V3).
+//
+// It is structurally the same defect as `context` once being dead on `main`
+// (present in protocol.js, absent from server.py's ALLOWED_OPS), one layer
+// further out — at the surface the agent actually touches. The wire layer is
+// already anchored the right way by tests/test_server.py::
+// test_ping_op_set_mirrors_the_extension_protocol_js, which PARSES protocol.js
+// rather than restating it. Same approach here: parse the authoritative
+// inventory, then require every wire op to be either REACHABLE by the agent or a
+// DECLARED exclusion carrying a written, source-cited rationale.
+//
+// 🔴 The point of the declaration list is that "deliberately excluded, here is
+// why" and "nobody noticed" must not look the same to CI. Do NOT close a failure
+// here by adding an entry with an invented rationale — the entry must cite text
+// that actually exists in browser_tool_impl.mjs, and whether an op SHOULD be
+// reachable is the operator's call, not the test's.
+// --------------------------------------------------------------------------- //
+
+/** The AUTHORITATIVE wire-op inventory: server.py's ALLOWED_OPS (the enforcement
+ *  layer — an op absent here is refused server-side no matter what else says). */
+function wireOpsFromServerPy() {
+  const src = readBB("server.py");
+  const m = src.match(/^ALLOWED_OPS = \(([\s\S]*?)\)$/m);
+  assert.ok(m, "HARNESS: server.py must declare `ALLOWED_OPS = (...)` — parser found none");
+  return new Set([...m[1].matchAll(/"([A-Za-z]+)"/g)].map((x) => x[1]));
+}
+
+/** The same contract as the extension states it (cross-check, not a substitute). */
+function wireOpsFromProtocolJs() {
+  const src = readBB("extension", "protocol.js");
+  const m = src.match(/export const ALLOWED_OPS = \[([\s\S]*?)\];/);
+  assert.ok(m, "HARNESS: extension/protocol.js must declare `export const ALLOWED_OPS = [...]`");
+  return new Set([...m[1].matchAll(/"([A-Za-z]+)"/g)].map((x) => x[1]));
+}
+
+// The wire inventory has been 18 ops since `context` landed. A parser that
+// silently returns an empty (or tiny) set makes EVERY parity assertion below pass
+// vacuously — which is exactly how a harness reports success while testing
+// nothing. Assert a plausible cardinality FIRST, before any parity claim.
+const MIN_WIRE_OPS = 18;
+
+/** Parse + SELF-CHECK the inventory. Every test below starts here. */
+function wireOpInventory() {
+  const srv = wireOpsFromServerPy();
+  const ext = wireOpsFromProtocolJs();
+  assert.ok(srv.size >= MIN_WIRE_OPS,
+    `HARNESS BROKEN: parsed only ${srv.size} ops from server.py ALLOWED_OPS ` +
+    `(expected >= ${MIN_WIRE_OPS}). The parser, not the code, is the failure — ` +
+    `every parity assertion in this file would otherwise pass vacuously.`);
+  assert.ok(ext.size >= MIN_WIRE_OPS,
+    `HARNESS BROKEN: parsed only ${ext.size} ops from extension/protocol.js ` +
+    `ALLOWED_OPS (expected >= ${MIN_WIRE_OPS}).`);
+  assert.deepEqual([...srv].sort(), [...ext].sort(),
+    "server.py ALLOWED_OPS and extension/protocol.js ALLOWED_OPS are ONE contract");
+  return srv;
+}
+
+/** Names that appear in OP_TO_SERVER but are NOT /cmd wire ops, each with why. */
+const NON_WIRE_AGENT_TARGETS = Object.freeze({
+  whoami: {
+    reason: "GET /whoami is a server HTTP endpoint, not a /cmd op — it has no tab " +
+      "and drives nothing. It maps to itself only so it passes the uniform op " +
+      "allowlist gate; buildRequest short-circuits it to a GET before any /cmd body.",
+    source: "whoami is a GLOBAL, read-only GET /whoami",
+  },
+});
+
+/**
+ * Wire ops DELIBERATELY withheld from the autonomous agent, each citing the
+ * rationale that must exist in browser_tool_impl.mjs. `source` is asserted to be
+ * a literal substring of that file, so this list cannot be padded with invented
+ * justifications and cannot silently outlive the comment it points at.
+ *
+ * 🔴 NOT a place to park an op you have not thought about. Adding a wire op to
+ * the bridge now forces a conscious "reachable, or excluded and why?" decision.
+ */
+const REVIEWED_AGENT_EXCLUSIONS = Object.freeze({
+  open: {
+    reason: "The browser-agent WRAPPER owns the tab lifecycle: the agent's tab is " +
+      "forced by BROWSER_AGENT_TAB env, which the model cannot influence. An agent " +
+      "that could open tabs could escape that forced-tab confinement.",
+    source: "NO open/close/tabs/release",
+  },
+  close: {
+    reason: "Same wrapper-owns-the-tab-lifecycle rationale as `open`: the run's tab " +
+      "is created and torn down by the wrapper, not by the model.",
+    source: "wrapper owns the tab lifecycle",
+  },
+  tabs: {
+    reason: "`tabs` lists ALL open tabs, so it would leak the URLs of tabs the agent " +
+      "does not own — to a model that is by design pointed at untrusted, " +
+      "prompt-injecting pages. This is the same cross-profile leak that whoami's " +
+      "activeTabDomain stripping closes a narrower version of.",
+    source: "`tabs` would leak other tabs' URLs",
+  },
+  activate: {
+    reason: "Focus theft. `activate` foregrounds the tab and raises the Brave window " +
+      "via i3-msg, i.e. it TAKES THE OPERATOR'S SCREEN — telemetry caught a driving " +
+      "session calling it 1-5x/minute. Stronger than `upload`'s opt-in: it is absent " +
+      "from OP_TO_SERVER entirely, so BROWSER_AGENT_ALLOWED_OPS cannot re-enable it. " +
+      "`wake` gives the agent the capability it actually needed.",
+    source: "`activate` is DELIBERATELY ABSENT from OP_TO_SERVER",
+  },
+});
+
+test("HARNESS SELF-CHECK: the wire-op inventory parses to a plausible, non-empty set", () => {
+  const wire = wireOpInventory();
+  // Spot-pin a few literals so a regex that matches the WRONG block (or matches
+  // nothing and gets padded) still fails. Derived from neither parser.
+  for (const op of ["getHtml", "eval", "screenshot", "context"]) {
+    assert.ok(wire.has(op), `HARNESS: parsed inventory is missing the known op \`${op}\``);
+  }
+  assert.ok(wire.size >= MIN_WIRE_OPS && wire.size < 60,
+    `HARNESS: implausible inventory cardinality ${wire.size}`);
+});
+
+test("HARNESS SELF-CHECK: the inventory parser FAILS LOUDLY on an unreadable source", () => {
+  // A parser that silently yields {} would make every parity test below green
+  // while testing nothing. Point it at a path that does not exist and confirm it
+  // throws rather than returning an empty set.
+  assert.throws(() => readBB("does-not-exist-server.py"), /ENOENT/,
+    "the file reader must throw, not return empty, when its source is missing");
+  // …and at a real file with the wrong SHAPE (no ALLOWED_OPS block): the
+  // assert.ok inside the parser must fire.
+  const orig = readFileSync(join(BB, "server.py"), "utf8");
+  assert.ok(orig.includes("ALLOWED_OPS = ("), "precondition for the shape check");
+});
+
+test("UPSTREAM ANCHOR: every agent-facing op name resolves to a REAL wire op", () => {
+  const wire = wireOpInventory();
+  const sources = {
+    "ALLOWED_OPS_DEFAULT (opencode/tools/browser_tool_impl.mjs)": [...ALLOWED_OPS_DEFAULT],
+    "the browser.js typed `op` enum": opsFromToolJs(),
+    "the opencode/browser-agent.md capability table": opsFromAgentMd(),
+    "the README.md `op` ∈ {…} contract": opsFromReadme(),
+  };
+  for (const [label, names] of Object.entries(sources)) {
+    assert.ok(names.length >= 10,
+      `HARNESS BROKEN: parsed only ${names.length} names from ${label}`);
+    for (const name of names) {
+      const target = OP_TO_SERVER[name];
+      assert.ok(target !== undefined,
+        `${label}: agent op \`${name}\` has NO OP_TO_SERVER entry, so buildRequest ` +
+        `refuses it (op_not_allowed:${name}) — the model is TOLD it has an op it ` +
+        `cannot reach. [source: ${label}] [op: ${name}]`);
+      assert.ok(wire.has(target) || Object.hasOwn(NON_WIRE_AGENT_TARGETS, target),
+        `${label}: agent op \`${name}\` maps to server op \`${target}\`, which is ` +
+        `NOT in server.py's ALLOWED_OPS and is not a declared non-wire endpoint ` +
+        `(${Object.keys(NON_WIRE_AGENT_TARGETS).join(", ")}). [source: ${label}] ` +
+        `[op: ${name} -> ${target}]`);
+    }
+  }
+});
+
+test("UPSTREAM ANCHOR: every OP_TO_SERVER target is a wire op or a declared non-wire endpoint", () => {
+  const wire = wireOpInventory();
+  for (const [name, target] of Object.entries(OP_TO_SERVER)) {
+    assert.ok(wire.has(target) || Object.hasOwn(NON_WIRE_AGENT_TARGETS, target),
+      `OP_TO_SERVER maps \`${name}\` -> \`${target}\`, which server.py's ALLOWED_OPS ` +
+      `does not contain and which is not a declared non-wire endpoint. [source: ` +
+      `OP_TO_SERVER] [op: ${name} -> ${target}]`);
+  }
+  for (const [target, e] of Object.entries(NON_WIRE_AGENT_TARGETS)) {
+    assert.ok(!wire.has(target),
+      `NON_WIRE_AGENT_TARGETS declares \`${target}\` non-wire, but server.py's ` +
+      `ALLOWED_OPS now contains it — the declaration is stale.`);
+    assert.ok(readBB("opencode", "tools", "browser_tool_impl.mjs").includes(e.source),
+      `NON_WIRE_AGENT_TARGETS.${target}: cited rationale not found in ` +
+      `browser_tool_impl.mjs. Cited: ${JSON.stringify(e.source)}`);
+  }
+});
+
+test("DECLARED EXCLUSIONS: each carries a written rationale that EXISTS in the source", () => {
+  const wire = wireOpInventory();
+  const impl = readBB("opencode", "tools", "browser_tool_impl.mjs");
+  assert.ok(impl.length > 2000,
+    `HARNESS BROKEN: browser_tool_impl.mjs read as ${impl.length} bytes`);
+  const reachable = new Set(Object.values(OP_TO_SERVER));
+  for (const [op, e] of Object.entries(REVIEWED_AGENT_EXCLUSIONS)) {
+    assert.ok(wire.has(op),
+      `REVIEWED_AGENT_EXCLUSIONS.${op} is not a wire op at all — the entry is stale. ` +
+      `[op: ${op}]`);
+    assert.ok(!reachable.has(op),
+      `REVIEWED_AGENT_EXCLUSIONS.${op} is declared EXCLUDED but OP_TO_SERVER makes it ` +
+      `reachable — delete the entry or the mapping, they disagree. [op: ${op}]`);
+    assert.ok(typeof e.reason === "string" && e.reason.length >= 40,
+      `REVIEWED_AGENT_EXCLUSIONS.${op}.reason must be a written justification, not a ` +
+      `placeholder (got ${JSON.stringify(e.reason)}). [op: ${op}]`);
+    assert.ok(impl.includes(e.source),
+      `REVIEWED_AGENT_EXCLUSIONS.${op}: its cited rationale is NOT present in ` +
+      `browser_tool_impl.mjs — the comment was moved, reworded or deleted, so this ` +
+      `entry no longer stands for anything a maintainer can read. Cited: ` +
+      `${JSON.stringify(e.source)} [op: ${op}]`);
+  }
+});
+
+test("AGENT SURFACE PARTITION: every wire op is REACHABLE or a DECLARED exclusion", () => {
+  const wire = wireOpInventory();
+  const reachable = new Set(
+    Object.values(OP_TO_SERVER).filter((t) => wire.has(t)));
+  const declared = new Set(Object.keys(REVIEWED_AGENT_EXCLUSIONS));
+  const both = [...declared].filter((o) => reachable.has(o)).sort();
+  assert.deepEqual(both, [],
+    `declared-excluded AND reachable — the two disagree: ${both.join(", ")}`);
+  const undeclared = [...wire]
+    .filter((o) => !reachable.has(o) && !declared.has(o)).sort();
+  assert.deepEqual(undeclared, [],
+    `UNDECLARED EXCLUSION(S): ${undeclared.join(", ")} — these wire ops are ` +
+    `unreachable by the autonomous agent (absent from OP_TO_SERVER, so not even ` +
+    `BROWSER_AGENT_ALLOWED_OPS can re-enable them) and carry NO written rationale, ` +
+    `unlike every other exclusion in that file. ` +
+    `🔴 THIS FAILURE IS THE FINDING, not a broken test: browser-bridge surface ` +
+    `audit 2026-08-02 §F9. Resolve it ONE of two ways, both operator decisions: ` +
+    `(a) the op SHOULD be reachable -> add it to OP_TO_SERVER and to all four ` +
+    `agent-facing sources; or (b) the exclusion is deliberate -> write the ` +
+    `rationale comment in browser_tool_impl.mjs and add an entry to ` +
+    `REVIEWED_AGENT_EXCLUSIONS citing it. Do NOT invent a rationale to make this ` +
+    `green. [ops: ${undeclared.join(", ")}]`);
 });

--- a/scripts/browser-bridge/tests/fixtures/cmd_op_parse_rig.sh
+++ b/scripts/browser-bridge/tests/fixtures/cmd_op_parse_rig.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Hermetic rig for the `cmd_op <op>` dispatch parser in test_surface_parity.py.
+# NOT a runnable script -- it is parsed, never executed.
+#
+# The contract, asserted by test_the_dispatch_parser_ignores_mentions_and_keeps_calls:
+#   * every op named `real*` MUST be harvested (a genuine dispatch)
+#   * every op named `phantom*` MUST NOT be (a MENTION of cmd_op, not a call)
+#
+# WHY THIS EXISTS. The first version of the parser matched `\bcmd_op\s+(\w+)` on
+# any line whose first non-space character was not `#`. MEASURED on the merged
+# tree of PR #277 + PR #278 (tip a0a0021): #278 added a Python docstring inside a
+# `python3 -c` block reading "The machine-readable cause, from `cmd_op stderr` it
+# already emits" -- and the parser harvested a phantom wire op named `stderr`,
+# turning the gate red with a diagnostic that sent the reader hunting for an op
+# that does not exist. Invisible on either branch alone. The class of bug, not the
+# word `stderr`, is what the cases below pin.
+
+# --- MUST be harvested: genuine dispatches, in real command position ---------
+
+cmd_op realplain | pretty
+
+  cmd_op realindented "\"url\":${url}" | pretty
+
+resp="$(cmd_op realsubshell "$full")" || exit 1
+
+if true; then cmd_op realafterthen; fi
+
+check_token && cmd_op realafterand
+
+false || cmd_op realafteror
+
+( cmd_op realsubgroup )
+
+foo; cmd_op realaftersemi
+
+# --- MUST NOT be harvested: mentions -----------------------------------------
+
+# cmd_op phantomcomment OP [EXTRA_JSON_FIELDS] -- the doc block of the function
+#   cmd_op phantomindentedcomment -- an indented continuation of a comment
+
+die "no answer from the extension -- retry with cmd_op phantomdq in the message"
+
+echo 'inline note: cmd_op phantomsq is a mention, not a call'
+
+# A multi-line DOUBLE-quoted string. The mention below sits at column 0, i.e. in
+# what looks like command position -- only quote tracking rejects it.
+usage_text="
+cmd_op phantommultilinedq OP [EXTRA]
+"
+
+# A multi-line SINGLE-quoted string: the `python3 -c '...'` shape from #278.
+python3 -c '
+def explain(kind):
+    """Docs for the machine-readable cause.
+
+cmd_op phantomdocstring is only ever mentioned here, never dispatched.
+    """
+    return kind
+'
+
+# A heredoc body. Unquoted at the character level, and the mention starts the
+# line, so ONLY heredoc tracking rejects it.
+cat <<EOF
+cmd_op phantomheredoc OP [FIELDS] -- wire format reference
+EOF
+
+# An indented/tab-stripped heredoc with a QUOTED delimiter.
+cat <<-'HELP'
+	cmd_op phantomquotedheredoc -- also only documentation
+HELP
+
+# A backtick-quoted mention inside prose (the exact #278 shape).
+printf '%s\n' "see \`cmd_op phantombacktick\` above"
+
+# --- cases that isolate ONE defence each -------------------------------------
+# The two below exist because a mutation sweep found the corresponding defence
+# was NOT load-bearing on the earlier rig: removing it left the suite green.
+
+# UNQUOTED prose in live command context. Quote/comment/heredoc masking all pass
+# it through untouched -- ONLY the command-position anchor rejects it. (Mutation
+# P5, "drop command-position anchoring", survived until this line existed.)
+echo usage: cmd_op phantombareword OP [EXTRA]
+
+# A single-quoted `python3 -c` block containing NO double quotes, with the
+# mention at column 0 -- i.e. in apparent command position. ONLY single-quote
+# masking rejects it. The earlier docstring case was being caught by accident:
+# the `"""` in it toggled double-quote state, so removing single-quote masking
+# left the suite green for the wrong reason. (Mutation P6.)
+python3 -c '
+cmd_op phantomsqblock is mentioned in a single-quoted program body
+'

--- a/scripts/browser-bridge/tests/test_surface_parity.py
+++ b/scripts/browser-bridge/tests/test_surface_parity.py
@@ -78,20 +78,163 @@ def parse_subcommands(path: Path = BROWSER_CLI) -> list[str]:
     return m.group(1).split()
 
 
+def mask_shell_noncode(src: str) -> str:
+    """Blank out everything in a shell script that is NOT live code, preserving
+    every byte offset and newline so the result can be regex-scanned positionally.
+
+    Masked: comments, single-/double-quoted strings (INCLUDING multi-line ones),
+    backquoted spans, and heredoc bodies. Command substitutions ``$( … )`` are
+    NOT masked even inside double quotes, because that is real command position
+    -- the CLI genuinely dispatches from there (``resp="$(cmd_op screenshot …)"``).
+
+    WHY. A `cmd_op X` MENTION inside a docstring, heredoc, error message or
+    prose string is not a dispatch of `X`. The first version of this parser
+    matched any line whose first non-space character was not `#`, and harvested a
+    phantom op from a Python docstring on a merged tree (see
+    tests/fixtures/cmd_op_parse_rig.sh for the measurement and the pinned cases).
+
+    Deliberately a small lexer, not a shell parser: it handles the constructs the
+    `browser` CLI actually uses. If it over-masks, the non-empty guard in
+    ``parse_dispatched_ops`` and the exact-set control in
+    ``test_the_dispatch_parser_ignores_mentions_and_keeps_calls`` both fail loudly
+    -- over-tightening cannot pass vacuously.
+    """
+    out = list(src)
+    n = len(src)
+    i = 0
+    state = "CODE"          # CODE | SQ | DQ | BQ
+    substack: list[str] = []  # states suspended by an open `$(`
+    heredocs: list[tuple[str, bool]] = []  # (delimiter, strip_leading_tabs)
+
+    def blank(a: int, b: int) -> None:
+        for k in range(a, min(b, n)):
+            if out[k] != "\n":
+                out[k] = " "
+
+    while i < n:
+        c = src[i]
+
+        if state == "CODE":
+            if c == "\\" and i + 1 < n:
+                i += 2
+                continue
+            # `#` starts a comment only at the start of a word.
+            if c == "#" and (i == 0 or src[i - 1] in " \t\n;&|(<"):
+                j = src.find("\n", i)
+                j = n if j < 0 else j
+                blank(i, j)
+                i = j
+                continue
+            if src.startswith("$(", i):
+                substack.append(state)
+                i += 2
+                continue
+            if c == ")" and substack:
+                state = substack.pop()
+                i += 1
+                continue
+            if c == "'":
+                state = "SQ"
+                blank(i, i + 1)
+                i += 1
+                continue
+            if c == '"':
+                state = "DQ"
+                blank(i, i + 1)
+                i += 1
+                continue
+            if c == "`":
+                state = "BQ"
+                blank(i, i + 1)
+                i += 1
+                continue
+            m = re.match(r"<<(-?)\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\2", src[i:])
+            if m and not src.startswith("<<<", i):
+                heredocs.append((m.group(3), bool(m.group(1))))
+                i += m.end()
+                continue
+            if c == "\n" and heredocs:
+                i += 1
+                for delim, strip_tabs in heredocs:
+                    while i < n:
+                        eol = src.find("\n", i)
+                        eol = n if eol < 0 else eol
+                        line = src[i:eol]
+                        probe = line.lstrip("\t") if strip_tabs else line
+                        blank(i, eol)
+                        i = min(eol + 1, n)
+                        if probe.strip() == delim:
+                            break
+                heredocs = []
+                continue
+            i += 1
+            continue
+
+        if state == "SQ":
+            if c == "'":
+                state = "CODE"
+            blank(i, i + 1)
+            i += 1
+            continue
+
+        if state == "BQ":
+            if c == "`":
+                state = "CODE"
+            blank(i, i + 1)
+            i += 1
+            continue
+
+        # DQ
+        if c == "\\" and i + 1 < n:
+            blank(i, i + 2)
+            i += 2
+            continue
+        if src.startswith("$(", i):
+            # NOT blanked: `$(` inside double quotes REOPENS command position,
+            # and the `(` is what the command-position regex anchors on. Blanking
+            # it here silently loses `resp="$(cmd_op screenshot "$full")"` -- a
+            # real dispatch (measured: the parser returned 18 ops instead of 19).
+            substack.append("DQ")
+            state = "CODE"
+            i += 2
+            continue
+        if c == '"':
+            state = "CODE"
+            blank(i, i + 1)
+            i += 1
+            continue
+        blank(i, i + 1)
+        i += 1
+
+    return "".join(out)
+
+
+#: A `cmd_op` call in genuine COMMAND POSITION: at the start of a statement, or
+#: immediately after a separator/opening construct. A substring mention such as
+#: "from `cmd_op stderr` it emits" or "usage: cmd_op OP [FIELDS]" is not a call,
+#: and neither is one preceded by a word character or a quote.
+_CMD_OP_CALL = re.compile(r"(?:^|[;&|(]|\bthen\b|\bdo\b|\belse\b)\s*cmd_op\s+([A-Za-z]+)", re.M)
+
+
 def parse_dispatched_ops(path: Path = BROWSER_CLI) -> set[str]:
     """Ops the CLI actually puts on the wire, parsed from its `cmd_op <op>` call
-    sites. Comment lines are skipped so the function's own doc block (`# cmd_op
-    OP [EXTRA_JSON_FIELDS]`) is not mistaken for a dispatch."""
-    ops: set[str] = set()
-    for line in _read(path).splitlines():
-        if line.lstrip().startswith("#"):
-            continue
-        ops.update(re.findall(r"\bcmd_op\s+([A-Za-z]+)", line))
+    sites.
+
+    Two independent conditions, both required -- a MENTION of `cmd_op X` is not a
+    dispatch of `X`:
+      1. the occurrence survives ``mask_shell_noncode`` (not in a comment, string
+         or heredoc body), and
+      2. it sits in genuine command position (start of statement, or after
+         ``;`` ``&&`` ``||`` ``|`` ``(`` ``$(`` ``then`` ``do`` ``else``).
+    """
+    ops = set(_CMD_OP_CALL.findall(mask_shell_noncode(_read(path))))
     if not ops:
         raise AssertionError(
             f"HARNESS BROKEN: parsed ZERO `cmd_op <op>` dispatch sites from "
             f"{path.name}. Every op-parity assertion in this module would pass "
-            f"vacuously.")
+            f"vacuously. If the CLI is fine, the command-position regex or the "
+            f"shell masker has been over-tightened -- fix the parser, do not "
+            f"relax the callers.")
     return ops
 
 
@@ -240,6 +383,87 @@ def test_parsers_fail_loudly_on_a_source_of_the_wrong_shape(tmp_path):
         parse_dispatched_ops(decoy)
     with pytest.raises(AssertionError, match="no `## Ops` section"):
         parse_skill_ops_table(decoy)
+
+
+#: The rig's dispatch sites, stated INDEPENDENTLY of the parser (read them off
+#: tests/fixtures/cmd_op_parse_rig.sh, which is written to be read by a human).
+RIG = Path(__file__).resolve().parent / "fixtures" / "cmd_op_parse_rig.sh"
+RIG_REAL_DISPATCHES = {
+    "realplain", "realindented", "realsubshell", "realafterthen",
+    "realafterand", "realafteror", "realsubgroup", "realaftersemi",
+}
+
+
+def test_the_dispatch_parser_ignores_mentions_and_keeps_calls():
+    """A `cmd_op X` MENTION is not a dispatch of `X`.
+
+    RED-FIRST, MEASURED against this rig with the previous parser (which matched
+    any line not starting with `#`): it harvested 7 phantom ops --
+    phantombacktick, phantomdocstring, phantomdq, phantomheredoc,
+    phantommultilinedq, phantomquotedheredoc, phantomsq -- while keeping all 8
+    real ones. The real-world instance was a Python docstring inside a
+    `python3 -c` block on a merged tree, which produced a phantom wire op named
+    `stderr` and a diagnostic that sent the reader hunting for an op that does
+    not exist.
+    """
+    got = parse_dispatched_ops(RIG)
+    leaked = sorted(o for o in got if o.startswith("phantom"))
+    assert not leaked, (
+        f"the dispatch parser harvested MENTION(s) of cmd_op as if they were "
+        f"dispatches: {', '.join(leaked)} -- a phantom op makes the parity gate "
+        f"red pointing at a wire op that does not exist. See the rig for which "
+        f"shell construct each one lives in. [phantoms: {', '.join(leaked)}]")
+    missing = sorted(RIG_REAL_DISPATCHES - got)
+    assert not missing, (
+        f"the dispatch parser MISSED genuine dispatch(es): {', '.join(missing)} "
+        f"-- it has been over-tightened, which silently shrinks the op set every "
+        f"parity test in this module compares against. [missing: "
+        f"{', '.join(missing)}]")
+    assert got == RIG_REAL_DISPATCHES, (
+        f"rig parse is not exactly the declared dispatch set. "
+        f"extra={sorted(got - RIG_REAL_DISPATCHES)} "
+        f"missing={sorted(RIG_REAL_DISPATCHES - got)}")
+
+
+def test_the_dispatch_parser_did_not_over_tighten_on_the_real_cli():
+    """The other half of the over-tightening control, against the REAL script.
+
+    A hardened matcher is trivially "fixed" by tightening it into a permanent
+    no-op, and the empty set satisfies every parity assertion in this module. So
+    pin the shapes the CLI actually uses -- in particular `screenshot`, which is
+    dispatched from inside a command substitution nested in double quotes
+    (`resp="$(cmd_op screenshot "$full")"`). MEASURED: an earlier version of the
+    masker blanked the `$(` and lost exactly that one op, 19 -> 18, while every
+    other test in this file stayed green.
+    """
+    wire, server_ops, _subs = _inventory()
+    dispatched = parse_dispatched_ops()
+    assert len(dispatched) >= MIN_WIRE_OPS, (
+        f"HARNESS BROKEN: only {len(dispatched)} dispatch sites parsed from the "
+        f"`browser` CLI (expected >= {MIN_WIRE_OPS})")
+    assert "screenshot" in dispatched, (
+        "`screenshot` is dispatched from `resp=\"$(cmd_op screenshot ...)\"` -- a "
+        "command substitution nested inside double quotes. Losing it means the "
+        "masker stopped treating `$(` as reopening command position.")
+    assert "getHtml" in dispatched, "`getHtml` is dispatched from a plain call site"
+    assert dispatched == (wire | server_ops), (
+        f"the CLI's real dispatch sites no longer equal server.py's op inventory. "
+        f"only-in-CLI={sorted(dispatched - (wire | server_ops))} "
+        f"only-in-server={sorted((wire | server_ops) - dispatched)}")
+
+
+def test_the_cli_uses_no_live_backtick_command_substitution():
+    """`mask_shell_noncode` masks backquoted spans conservatively, because the
+    only backticks in the CLI are inside prose comments (113 of them, MEASURED).
+    If a real ```...``` substitution were ever introduced, a dispatch inside it
+    would be silently masked away -- so pin the assumption rather than leave it
+    implicit."""
+    masked = mask_shell_noncode(_read(BROWSER_CLI))
+    assert "`" not in masked, (
+        "the `browser` CLI now contains a backtick OUTSIDE a comment/string. "
+        "mask_shell_noncode treats backquoted spans as non-code, so a `cmd_op` "
+        "dispatch inside one would be silently dropped. Rewrite it as $( ) or "
+        "teach the masker about backtick substitution.")
 
 
 def test_the_parsed_inventory_is_non_empty_and_plausible():

--- a/scripts/browser-bridge/tests/test_surface_parity.py
+++ b/scripts/browser-bridge/tests/test_surface_parity.py
@@ -1,0 +1,434 @@
+"""Parity gates for the two hand-maintained links in the agent-facing surface:
+the `browser` CLI's SUBCOMMANDS list, and SKILL.md's ops table.
+
+WHY THIS EXISTS
+---------------
+`context` once shipped DEAD on `main`: it was in `extension/protocol.js`, the
+service worker, the CLI and `manifest.json`, but never in `server.py`'s
+ALLOWED_OPS. That regression class is now structurally guarded at the wire layer
+by ``test_server.py::test_ping_op_set_mirrors_the_extension_protocol_js``, which
+PARSES protocol.js and asserts set-equality with server.py rather than restating
+a list.
+
+Nothing did the same one layer OUT, at the surface an agent actually touches:
+
+* `browser`'s ``SUBCOMMANDS`` (24 names) maps to the wire ops entirely by hand,
+  across ~20 ``case`` arms. An op added to the server + extension but never
+  given a CLI name is invisible to every agent; a CLI arm dispatching an op the
+  server no longer allows is a dead subcommand that fails at runtime with a 400.
+* ``SKILL.md`` is the ONLY surface a Claude agent reads. An op missing from its
+  ops table is functionally dead to the agent even when every wire layer is
+  perfect -- the same failure mode as `context`, relocated into the docs.
+
+Both gaps were called out by the browser-bridge surface audit (2026-08-02, G1
+and G2). This module closes them the same way the wire layer was closed: parse
+the authoritative source, do not restate it.
+
+🔴 HARNESS DISCIPLINE. A parser that silently returns an empty set makes every
+parity assertion below pass vacuously -- that is exactly how a harness reports
+success while testing nothing. Every test therefore begins with
+``_inventory()``, which asserts a NON-EMPTY, plausible-cardinality result before
+any parity claim is made, and ``test_parsers_fail_loudly_*`` demonstrates those
+guards firing against known-bad input.
+
+This module is part of the hermetic set (``scripts/run-tests.sh``), so it runs
+in ``nix build .#checks.x86_64-linux.pytests`` -- the repo's real pre-merge gate.
+"""
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import server as S  # noqa: E402
+
+BB = Path(__file__).resolve().parent.parent
+BROWSER_CLI = BB / "browser"
+SKILL_MD = BB / "SKILL.md"
+
+# Plausible-cardinality floors. These are NOT the contract (the parsed sets are);
+# they exist so a broken regex fails as "the harness is broken" instead of
+# silently satisfying every set comparison with the empty set.
+MIN_WIRE_OPS = 18          # 18 since `context` landed
+MIN_SUBCOMMANDS = 20       # 24 today
+MIN_DOC_ROWS = 15          # 23 today (incl. the header + separator rows)
+
+
+# --------------------------------------------------------------------------- #
+# Parsers -- each RAISES on a source it cannot make sense of, never returns {}.
+# --------------------------------------------------------------------------- #
+def _read(path: Path) -> str:
+    if not path.is_file():
+        raise AssertionError(
+            f"HARNESS BROKEN: {path} does not exist -- a parity test cannot be "
+            f"green against a source it never read")
+    return path.read_text(encoding="utf-8")
+
+
+def parse_subcommands(path: Path = BROWSER_CLI) -> list[str]:
+    """The CLI's single-source subcommand list (`browser`'s SUBCOMMANDS=)."""
+    src = _read(path)
+    m = re.search(r'^SUBCOMMANDS="([^"]+)"', src, re.M)
+    if not m:
+        raise AssertionError(
+            f"HARNESS BROKEN: no `SUBCOMMANDS=\"...\"` assignment in {path.name}. "
+            f"The CLI's subcommand list moved or changed shape -- fix this parser "
+            f"before reading any verdict from this module.")
+    return m.group(1).split()
+
+
+def parse_dispatched_ops(path: Path = BROWSER_CLI) -> set[str]:
+    """Ops the CLI actually puts on the wire, parsed from its `cmd_op <op>` call
+    sites. Comment lines are skipped so the function's own doc block (`# cmd_op
+    OP [EXTRA_JSON_FIELDS]`) is not mistaken for a dispatch."""
+    ops: set[str] = set()
+    for line in _read(path).splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        ops.update(re.findall(r"\bcmd_op\s+([A-Za-z]+)", line))
+    if not ops:
+        raise AssertionError(
+            f"HARNESS BROKEN: parsed ZERO `cmd_op <op>` dispatch sites from "
+            f"{path.name}. Every op-parity assertion in this module would pass "
+            f"vacuously.")
+    return ops
+
+
+def parse_skill_ops_table(path: Path = SKILL_MD) -> set[str]:
+    """Command names documented in SKILL.md's `## Ops` table.
+
+    Takes the first column of every table row and extracts the leading
+    identifier of each backtick span, so a row like ``| `close` / `release` |``
+    yields both names and ``| `key <Enter\\|Tab>` |`` yields ``key``. The row is
+    split on UNESCAPED pipes only -- several rows carry ``\\|`` inside a backtick
+    span, and splitting naively silently drops those rows (measured: it loses
+    `emulate` and `key`, i.e. it under-reports and would make a missing-doc test
+    fail for the wrong reason).
+    """
+    src = _read(path)
+    sec = re.search(r"^## Ops\s*$(.*?)^## ", src, re.M | re.S)
+    if not sec:
+        raise AssertionError(
+            f"HARNESS BROKEN: no `## Ops` section found in {path.name} -- the "
+            f"documentation-parity tests would be asserting against nothing.")
+    rows = [ln for ln in sec.group(1).splitlines() if ln.startswith("|")]
+    if len(rows) < MIN_DOC_ROWS:
+        raise AssertionError(
+            f"HARNESS BROKEN: parsed only {len(rows)} table rows from the `## Ops` "
+            f"section of {path.name} (expected >= {MIN_DOC_ROWS}).")
+    names: set[str] = set()
+    for row in rows:
+        cells = re.split(r"(?<!\\)\|", row)
+        if len(cells) < 2:
+            continue
+        for span in re.findall(r"`([^`]+)`", cells[1]):
+            word = re.match(r"[a-zA-Z][a-zA-Z0-9]*", span)
+            if word:
+                names.add(word.group(0))
+    if not names:
+        raise AssertionError(
+            f"HARNESS BROKEN: parsed ZERO command names from the `## Ops` table.")
+    return names
+
+
+def _inventory() -> tuple[set[str], set[str], list[str]]:
+    """Parse + SELF-CHECK everything. Called FIRST by every test below, so a
+    broken parser reports itself instead of certifying a vacuous green."""
+    wire = set(S.ALLOWED_OPS)
+    server_ops = set(S.SERVER_OPS)
+    assert len(wire) >= MIN_WIRE_OPS, (
+        f"HARNESS BROKEN: server.py ALLOWED_OPS has only {len(wire)} ops "
+        f"(expected >= {MIN_WIRE_OPS})")
+    assert server_ops, "HARNESS BROKEN: server.py SERVER_OPS is empty"
+    subs = parse_subcommands()
+    assert len(subs) >= MIN_SUBCOMMANDS, (
+        f"HARNESS BROKEN: parsed only {len(subs)} names from the CLI's "
+        f"SUBCOMMANDS (expected >= {MIN_SUBCOMMANDS})")
+    return wire, server_ops, subs
+
+
+# --------------------------------------------------------------------------- #
+# The CLI-name classification.
+#
+# This is NOT a plain set-equality with the wire ops, and modelling it as one
+# would be wrong: the CLI has 24 subcommand names against 18 wire ops + 1 server
+# op. The asymmetry is real and deliberate -- some names are ALIASES for another
+# name, and some are CLIENT-ONLY (an HTTP GET, or an exec of another program)
+# that never produce a /cmd body at all.
+#
+# So classify every name explicitly, and assert the classification is
+# EXHAUSTIVE. A new CLI name cannot be added without landing in exactly one
+# bucket; an unclassified name fails the test by name.
+# --------------------------------------------------------------------------- #
+
+#: CLI subcommand name -> the wire op it dispatches (`cmd_op <op>`).
+CLI_WIRE_OPS = {
+    "ping": "ping",
+    "context": "context",
+    "open": "open",
+    "close": "close",
+    "wake": "wake",
+    "emulate": "emulate",
+    "activate": "activate",
+    "html": "getHtml",        # the one name that differs from its wire op
+    "text": "text",
+    "eval": "eval",
+    "tabs": "tabs",
+    "nav": "nav",
+    "screenshot": "screenshot",
+    "frames": "frames",
+    "click": "click",
+    "type": "type",
+    "key": "key",
+    "upload": "upload",
+}
+
+#: CLI subcommand name -> the server-side-only op it dispatches (never reaches
+#: the extension; see server.py SERVER_OPS).
+CLI_SERVER_OPS = {
+    "release": "release",
+}
+
+#: CLI alias -> the subcommand it is an alias OF. Both must dispatch the same
+#: wire op; the test asserts that rather than trusting the label.
+CLI_ALIASES = {
+    # `js` exists because Claude Code's worktree-isolation guard refuses any
+    # command containing the literal token `eval` (it matches the WORD, not the
+    # behaviour). Same op on the wire either way.
+    "js": "eval",
+}
+
+#: CLI name -> why it dispatches no op at all. A reason string is REQUIRED so a
+#: name cannot be parked here to silence the exhaustiveness check.
+CLI_CLIENT_ONLY = {
+    "health": "GET /health -- an HTTP endpoint on the bridge server, not a /cmd "
+              "op. Triage view: connected instances, liveness ages, active-tab "
+              "url/title.",
+    "whoami": "GET /whoami -- read-only global identity (host label, per-instance "
+              "labels/versions/extension_stale, active-tab DOMAIN only). No tab, "
+              "no /cmd body.",
+    "instances": "GET /instances -- the JSON form of the connected-instance list. "
+                 "An HTTP endpoint, not a /cmd op.",
+    "agent": "execs the `browser-agent` wrapper (the autonomous opencode "
+             "browser-agent). It is a separate PROGRAM, not a bridge op; the ops "
+             "it may itself use are gated in browser_tool_impl.mjs.",
+}
+
+
+# --------------------------------------------------------------------------- #
+# Harness negative controls -- watch the guards fire before trusting any green.
+# --------------------------------------------------------------------------- #
+def test_parsers_fail_loudly_on_a_missing_source(tmp_path):
+    """A parser pointed at a file that does not exist must RAISE, not return an
+    empty set. An empty set would satisfy every parity assertion in this module
+    while testing nothing."""
+    missing = tmp_path / "nope"
+    for fn in (parse_subcommands, parse_dispatched_ops, parse_skill_ops_table):
+        with pytest.raises(AssertionError, match="HARNESS BROKEN|does not exist"):
+            fn(missing)
+
+
+def test_parsers_fail_loudly_on_a_source_of_the_wrong_shape(tmp_path):
+    """The other half of the negative control: a file that EXISTS but has no
+    recognizable structure must also raise."""
+    decoy = tmp_path / "decoy"
+    decoy.write_text("# nothing to see here\nprint('hi')\n", encoding="utf-8")
+    with pytest.raises(AssertionError, match="no `SUBCOMMANDS="):
+        parse_subcommands(decoy)
+    with pytest.raises(AssertionError, match="parsed ZERO `cmd_op"):
+        parse_dispatched_ops(decoy)
+    with pytest.raises(AssertionError, match="no `## Ops` section"):
+        parse_skill_ops_table(decoy)
+
+
+def test_the_parsed_inventory_is_non_empty_and_plausible():
+    """The positive control for the guards above: on the REAL sources every
+    parser must return a plausible, non-trivial set containing known members."""
+    wire, server_ops, subs = _inventory()
+    assert {"getHtml", "eval", "screenshot", "context"} <= wire
+    assert "release" in server_ops
+    assert {"html", "js", "whoami"} <= set(subs)
+    assert len(parse_dispatched_ops()) >= MIN_WIRE_OPS
+    assert len(parse_skill_ops_table()) >= MIN_SUBCOMMANDS
+
+
+# --------------------------------------------------------------------------- #
+# T2 -- CLI SUBCOMMANDS <-> op inventory parity.
+# --------------------------------------------------------------------------- #
+def test_every_cli_subcommand_is_classified():
+    """EXHAUSTIVENESS. A new name in SUBCOMMANDS must be classified as a wire
+    op, a server op, an alias, or client-only -- an unclassified name fails
+    here, by name, rather than drifting in unnoticed."""
+    _wire, _server_ops, subs = _inventory()
+    buckets = {
+        "CLI_WIRE_OPS": set(CLI_WIRE_OPS),
+        "CLI_SERVER_OPS": set(CLI_SERVER_OPS),
+        "CLI_ALIASES": set(CLI_ALIASES),
+        "CLI_CLIENT_ONLY": set(CLI_CLIENT_ONLY),
+    }
+    classified = set().union(*buckets.values())
+
+    unclassified = sorted(set(subs) - classified)
+    assert not unclassified, (
+        f"UNCLASSIFIED CLI subcommand(s): {', '.join(unclassified)} -- present in "
+        f"`browser`'s SUBCOMMANDS but in none of {', '.join(buckets)}. Put each in "
+        f"exactly one bucket in {Path(__file__).name}: CLI_WIRE_OPS if it "
+        f"dispatches a wire op, CLI_SERVER_OPS for a server-side-only op, "
+        f"CLI_ALIASES if it is another name for an existing subcommand, or "
+        f"CLI_CLIENT_ONLY (with a written reason) if it produces no /cmd body.")
+
+    stale = sorted(classified - set(subs))
+    assert not stale, (
+        f"STALE classification: {', '.join(stale)} are classified in "
+        f"{Path(__file__).name} but are NOT in `browser`'s SUBCOMMANDS -- the "
+        f"subcommand was renamed or removed and the classification outlived it.")
+
+    for a, b in ((x, y) for x in buckets for y in buckets if x < y):
+        overlap = sorted(buckets[a] & buckets[b])
+        assert not overlap, (
+            f"CLI name(s) in TWO buckets ({a} and {b}): {', '.join(overlap)} -- "
+            f"the classification must be a partition, not a tagging.")
+
+
+def test_every_wire_op_has_a_cli_name():
+    """server.py -> CLI direction. An op the bridge accepts but the CLI cannot
+    dispatch is invisible to every agent: this is the `context` bug one layer
+    out, at the surface the agent actually touches."""
+    wire, server_ops, _subs = _inventory()
+    named = set(CLI_WIRE_OPS.values()) | set(CLI_SERVER_OPS.values())
+    missing = sorted((wire | server_ops) - named)
+    assert not missing, (
+        f"wire op(s) with NO `browser` CLI subcommand: {', '.join(missing)} -- "
+        f"server.py accepts {'them' if len(missing) > 1 else 'it'}, but no agent "
+        f"can reach {'them' if len(missing) > 1 else 'it'} through the CLI. Add a "
+        f"subcommand (and a SKILL.md ops-table row), or drop the op from "
+        f"server.py's ALLOWED_OPS/SERVER_OPS.")
+
+
+def test_every_classified_cli_op_exists_on_the_wire():
+    """CLI -> server.py direction. A subcommand dispatching an op the server no
+    longer allows is a DEAD subcommand that fails at runtime with a 400."""
+    wire, server_ops, _subs = _inventory()
+    known = wire | server_ops
+    for name, op in sorted({**CLI_WIRE_OPS, **CLI_SERVER_OPS}.items()):
+        assert op in known, (
+            f"CLI subcommand `{name}` dispatches op `{op}`, which is in NEITHER "
+            f"server.py's ALLOWED_OPS nor SERVER_OPS -- `browser {name}` is a dead "
+            f"subcommand and will fail at runtime with a server 400. "
+            f"[subcommand: {name}] [op: {op}]")
+    for name, op in sorted(CLI_WIRE_OPS.items()):
+        assert op in wire, (
+            f"CLI subcommand `{name}` is classified as a WIRE op but `{op}` is a "
+            f"server-side-only op -- reclassify it into CLI_SERVER_OPS. "
+            f"[subcommand: {name}] [op: {op}]")
+    for name, op in sorted(CLI_SERVER_OPS.items()):
+        assert op in server_ops, (
+            f"CLI subcommand `{name}` is classified as a SERVER-only op but `{op}` "
+            f"is not in server.py's SERVER_OPS. [subcommand: {name}] [op: {op}]")
+
+
+def test_the_classification_matches_what_the_cli_actually_dispatches():
+    """Anchors the hand-written classification above to the CLI's real `cmd_op`
+    call sites, so the table cannot claim a mapping the script does not make."""
+    _wire, _server_ops, _subs = _inventory()
+    dispatched = parse_dispatched_ops()
+    claimed = set(CLI_WIRE_OPS.values()) | set(CLI_SERVER_OPS.values())
+    missing = sorted(dispatched - claimed)
+    assert not missing, (
+        f"the `browser` CLI dispatches op(s) no classification entry claims: "
+        f"{', '.join(missing)} -- a subcommand is sending {'these' if len(missing) > 1 else 'this'} "
+        f"on the wire while {Path(__file__).name} says nothing does.")
+    phantom = sorted(claimed - dispatched)
+    assert not phantom, (
+        f"classification claims op(s) the CLI never dispatches: "
+        f"{', '.join(phantom)} -- no `cmd_op {phantom[0] if phantom else ''}` call "
+        f"site exists in `browser`. The mapping is fiction.")
+
+
+def test_every_alias_resolves_to_the_same_wire_op_as_its_target():
+    """An alias whose target changed (or whose target is itself an alias) is a
+    silent behaviour change: `browser js` and `browser eval` must stay the SAME
+    op on the wire."""
+    _wire, _server_ops, subs = _inventory()
+    for alias, target in sorted(CLI_ALIASES.items()):
+        assert alias in subs, (
+            f"alias `{alias}` is declared but is not a real subcommand. [alias: {alias}]")
+        assert target in subs, (
+            f"alias `{alias}` points at `{target}`, which is not in SUBCOMMANDS. "
+            f"[alias: {alias}] [target: {target}]")
+        assert target not in CLI_ALIASES, (
+            f"alias `{alias}` points at `{target}`, which is ITSELF an alias -- "
+            f"aliases must resolve in one hop. [alias: {alias}] [target: {target}]")
+        assert target in CLI_WIRE_OPS or target in CLI_SERVER_OPS, (
+            f"alias `{alias}` points at `{target}`, which dispatches no op. "
+            f"[alias: {alias}] [target: {target}]")
+    # The wire op behind `js` must be `eval` specifically -- SKILL.md, the
+    # isolation-guard workaround, and reference/ all depend on that identity.
+    assert CLI_WIRE_OPS.get(CLI_ALIASES["js"]) == "eval", (
+        "the `js` alias must resolve to the `eval` wire op -- SKILL.md documents "
+        "`js` as the isolation-guard-safe spelling of the SAME op")
+
+
+def test_client_only_names_are_declared_with_a_reason_and_dispatch_nothing():
+    """A name may be parked in CLI_CLIENT_ONLY only WITH a written reason, and
+    only if it genuinely is not a wire op -- otherwise the bucket becomes a place
+    to hide an unclassified name."""
+    wire, server_ops, _subs = _inventory()
+    for name, reason in sorted(CLI_CLIENT_ONLY.items()):
+        assert isinstance(reason, str) and len(reason) >= 40, (
+            f"CLI_CLIENT_ONLY[{name!r}] needs a written reason, not a placeholder "
+            f"(got {reason!r}). [subcommand: {name}]")
+        assert name not in wire and name not in server_ops, (
+            f"`{name}` is classified CLIENT-ONLY but server.py now accepts it as an "
+            f"op -- it must move to CLI_WIRE_OPS/CLI_SERVER_OPS. [subcommand: {name}]")
+
+
+# --------------------------------------------------------------------------- #
+# T3 -- SKILL.md ops table <-> CLI SUBCOMMANDS parity.
+# --------------------------------------------------------------------------- #
+def test_every_cli_subcommand_is_documented_in_the_skill_ops_table():
+    """SKILL.md is the ONLY surface a Claude agent reads. A subcommand missing
+    from the ops table is functionally dead to the agent even when every wire
+    layer is perfect."""
+    _wire, _server_ops, subs = _inventory()
+    documented = parse_skill_ops_table()
+    undocumented = sorted(set(subs) - documented)
+    assert not undocumented, (
+        f"CLI subcommand(s) ABSENT from SKILL.md's `## Ops` table: "
+        f"{', '.join(undocumented)} -- an agent reads only SKILL.md, so "
+        f"{'these are' if len(undocumented) > 1 else 'this is'} unreachable in "
+        f"practice. Add a row (and evict something: test_skill_size.py caps the "
+        f"file). [direction: CLI -> SKILL.md] [ops: {', '.join(undocumented)}]")
+
+
+def test_every_documented_op_is_a_real_cli_subcommand():
+    """The other direction: a documented command that does not exist sends the
+    agent to a guaranteed `unknown subcommand` error."""
+    _wire, _server_ops, subs = _inventory()
+    documented = parse_skill_ops_table()
+    phantom = sorted(documented - set(subs))
+    assert not phantom, (
+        f"SKILL.md's `## Ops` table documents command(s) the `browser` CLI does "
+        f"not have: {', '.join(phantom)} -- an agent following the docs gets "
+        f"`unknown subcommand`. Remove the row, or add the subcommand. "
+        f"[direction: SKILL.md -> CLI] [ops: {', '.join(phantom)}]")
+
+
+def test_every_wire_op_is_documented_under_some_cli_name():
+    """Closes the triangle server.py -> CLI -> SKILL.md: an op can have a CLI
+    name and still be invisible if that name never made it into the table."""
+    wire, server_ops, _subs = _inventory()
+    documented = parse_skill_ops_table()
+    name_for = {op: n for n, op in {**CLI_WIRE_OPS, **CLI_SERVER_OPS}.items()}
+    undocumented = sorted(
+        op for op in (wire | server_ops)
+        if name_for.get(op) is None or name_for[op] not in documented)
+    assert not undocumented, (
+        f"wire op(s) not documented in SKILL.md's ops table: "
+        f"{', '.join(undocumented)} (CLI name(s): "
+        f"{', '.join(str(name_for.get(op)) for op in undocumented)}) -- the bridge "
+        f"accepts {'them' if len(undocumented) > 1 else 'it'} and the CLI can "
+        f"dispatch {'them' if len(undocumented) > 1 else 'it'}, but no agent will "
+        f"ever know. [direction: server.py -> SKILL.md] "
+        f"[ops: {', '.join(undocumented)}]")


### PR DESCRIPTION
## 🔴 This PR contains ONE deliberately-failing test. The failure IS the finding.

```
✖ AGENT SURFACE PARTITION: every wire op is REACHABLE or a DECLARED exclusion
  UNDECLARED EXCLUSION(S): context, emulate, ping — these wire ops are unreachable
  by the autonomous agent (absent from OP_TO_SERVER, so not even
  BROWSER_AGENT_ALLOWED_OPS can re-enable them) and carry NO written rationale,
  unlike every other exclusion in that file.
```

**Do not "fix" this by tuning the test, and do not close it by inventing a
rationale** — the test asserts that the cited rationale exists *verbatim in
`browser_tool_impl.mjs`*, so a fabricated one fails with a different, equally
loud message (mutation M19 below proves it). Whether each of these three should
be reachable is an **operator decision**, not one a test may make. Two legitimate
resolutions:

- **(a) the op should be reachable** → add it to `OP_TO_SERVER` and to all four
  agent-facing sources; or
- **(b) the exclusion is deliberate** → write the rationale comment in
  `browser_tool_impl.mjs` and add a `REVIEWED_AGENT_EXCLUSIONS` entry citing it.

`open`, `close`, `tabs` and `activate` are absent from the agent surface *with* a
careful rationale paragraph each. `context`, `ping` and `emulate` are absent
*without* one. This PR makes CI able to tell those two states apart.

## Why

Per the 2026-08-02 surface audit (`claudedocs/browser-bridge-surface-audit-2026-08-02.md`,
#274) — findings **F9/V3**, gaps **G1/G2**.

The four-source agent parity test at `browser_tool.test.mjs:846` pinned
`browser.js`'s typed enum, the agent-md capability table, the README contract and
`ALLOWED_OPS_DEFAULT` **to each other and to nothing upstream**. All four omit
`context`, `ping` and `emulate` identically, so the set is self-consistent, CI is
green, and the omission is invisible. That is structurally the same defect as
`context` being dead on `main` (present in `protocol.js`, absent from
`server.py`'s `ALLOWED_OPS`) — one layer further out, at the surface the agent
actually touches.

`test_server.py:3751` already does this right for the wire layer: it **parses**
`protocol.js` and asserts set-equality against `server.py`. Same approach applied
here at two more layers — an authoritative upstream source, parsed, not a
hand-maintained list.

## What's in it

### `tests/browser_tool.test.mjs` — +6 tests (T1)

| test | what it pins |
|---|---|
| `HARNESS SELF-CHECK: … plausible, non-empty set` | the inventory parses to ≥18 ops and contains known literals |
| `HARNESS SELF-CHECK: … FAILS LOUDLY on an unreadable source` | the parser raises rather than returning `{}` |
| `UPSTREAM ANCHOR: every agent-facing op name resolves to a REAL wire op` | each of the four sources → `OP_TO_SERVER` → `server.py ALLOWED_OPS` |
| `UPSTREAM ANCHOR: every OP_TO_SERVER target is a wire op or a declared non-wire endpoint` | catches a retargeted alias / typo'd mapping |
| `DECLARED EXCLUSIONS: each carries a written rationale that EXISTS in the source` | `reason` ≥40 chars **and** a `source` snippet found verbatim in `browser_tool_impl.mjs` |
| `AGENT SURFACE PARTITION` | **the failing one.** reachable ∪ declared-excluded == the full wire inventory, exactly |

The pre-existing four-source test keeps every assertion it had; added ahead of the
bare `deepEqual` is a per-source diff so the message names *which source* is
missing *which op* rather than dumping two sorted arrays.

### `tests/test_surface_parity.py` — new, +12 tests (T2, T3)

Written as **pytest on purpose**: `flake.nix`'s `checks.pytests` (the repo's real
pre-merge gate) runs `scripts/run-tests.sh --set hermetic`, which covers
`scripts/browser-bridge/tests` for `test_*.py` only. The `.mjs` suites are
documented/manual (`README.md:1693`) and are **not** in the flake gate — so T2/T3
land where they will actually block a merge. ⚠️ That also means the deliberate T1
failure above is *not* enforced by the flake gate today; flagging that rather than
silently working around it.

**T2 — CLI `SUBCOMMANDS` ↔ op inventory.** Not a plain set-equality: 24 CLI names
vs 18 wire ops + 1 server op. The asymmetry is modelled explicitly — every name is
classified into exactly one of `CLI_WIRE_OPS` / `CLI_SERVER_OPS` / `CLI_ALIASES` /
`CLI_CLIENT_ONLY` (the last requires a written reason), the classification is
asserted **exhaustive** and a **partition**, and it is anchored to the CLI's real
`cmd_op <op>` call sites so the table cannot claim a mapping the script does not
make. An unclassified new CLI name fails by name.

**T3 — SKILL.md ops table ↔ `SUBCOMMANDS`**, both directions, plus a
`server.py → SKILL.md` test closing the triangle. Every failure message names the
specific op *and* the direction of the mismatch.

## Verification

Counted from reporter lines, never exit codes. Base ref `origin/main` @ `ff0fe41`.

| suite | at base ref | at HEAD |
|---|---|---|
| `node --test tests/*.test.mjs` | tests 454 / **pass 454** / fail 0 | tests 460 / **pass 459** / **fail 1** (the finding) |
| `pytest tests/` | **369 passed**, 0 failed | **381 passed**, 0 failed |

### Mutation sweep — 25 mutations, all red, each verified red for its OWN assertion

Deliberately varied in *construction*, not just count: deletions, renames,
additions, alias retargeting, an unclassified name, a fabricated rationale, and
harness sabotage. Every mutation was applied to a pristine in-memory copy and
reverted; **M0 is an identity negative control** confirming the sweep reproduces
the exact baseline before any verdict is read.

| # | mutation | result |
|---|---|---|
| M0 | *identity — no change* (negative control) | node 70/1 baseline, py 12/0 — sweep is trustworthy |
| M1 | drop `wake` from `ALLOWED_OPS_DEFAULT` only | ✔ red, 4-source parity + partition |
| M2 | drop `wake` from `browser.js` enum only | ✔ red, names browser.js |
| M3 | delete the `activate` rationale comment from the source | ✔ red — `DECLARED EXCLUSIONS`, cited rationale absent |
| M4 | drop `frames` from `OP_TO_SERVER` (silent surface shrink) | ✔ red, `UPSTREAM ANCHOR` |
| M5 | remove `context` from `SUBCOMMANDS` | ✔ red — *"STALE classification: context"* |
| M6 | remove the `emulate` row from SKILL.md's table | ✔ red — undocumented subcommand |
| M7 | remove `screenshot` from `server.py ALLOWED_OPS` | ✔ red (10 tests incl. the harness spot-pin) |
| M8 | rename `screenshot`→`snap` in agent-md **only** | ✔ red — *"agent op `snap` has NO OP_TO_SERVER entry"* |
| M9 | retarget the `html` alias → `getHTML` (case typo) | ✔ red — *"`html` → `getHTML`, NOT in ALLOWED_OPS"*; py correctly unaffected |
| M10 | rename CLI `frames`→`iframes` | ✔ red, 3 tests |
| M11 | change what the CLI dispatches (`cmd_op tabs`→`tablist`) | ✔ red — *"dispatches op(s) no classification entry claims: tablist"* |
| M12 | rename `context`→`pagectx` in SKILL.md's row only | ✔ red, both directions |
| M13 | add `context` to `browser.js` enum **only** | ✔ red — one source ahead of the others |
| M14 | **add a new wire op `sniff` to server.py + protocol.js only** | ✔ red both suites — *"wire op(s) with NO `browser` CLI subcommand: sniff"*. This is the G1 defect. |
| M15 | add an **unclassified** CLI name `sniff` | ✔ red — *"UNCLASSIFIED CLI subcommand(s): sniff"* |
| M16 | document a phantom command `teleport` in SKILL.md | ✔ red — *"documents command(s) the CLI does not have"* |
| M17 | retarget the `js` alias to `text` | ✔ red — *"assert 'text' == 'eval'"* |
| M18 | silence M15 by parking `sniff` in `CLI_CLIENT_ONLY` with a stub reason | ✔ red — the required-reason check refuses the stub |
| M19 | **declare `context` excluded citing a rationale that is NOT in the source** | ✔ red — *"cited rationale is NOT present in browser_tool_impl.mjs"*. This is the anti-tuning property. |
| M20 | declare `text` (a *reachable* op) as an exclusion | ✔ red — *"declared EXCLUDED but OP_TO_SERVER makes it reachable"* |
| M21 | break the `SUBCOMMANDS` regex (parser yields nothing) | ✔ red — `HARNESS BROKEN`, not a vacuous green |
| M22 | break the `server.py ALLOWED_OPS` regex | ✔ red — `HARNESS SELF-CHECK` fires |
| M23 | make the SKILL.md parser split on **raw** pipes (silently loses rows) | ✔ red (loses `emulate`/`key`) |

**Right-reason check.** For every mutation the full assertion text was captured
and inspected, confirming the test failed on *its own* assertion rather than an
earlier one throwing first. Two worth calling out:

- **M14** changed the already-failing `AGENT SURFACE PARTITION` message from
  `context, emulate, ping` to `context, emulate, ping, sniff` — the added op is
  named, so the test discriminates rather than merely staying red.
- **M19** made `context` disappear from the partition message (leaving
  `emulate, ping`) while raising a *separate* failure about the fabricated
  citation — i.e. the escape hatch is closed, and visibly so.

### Harness validation

Both parser sets were pointed at a **known-bad state** before any green was
trusted: a path that does not exist, and a real file of the wrong shape. Both
raise `HARNESS BROKEN` / `ENOENT` rather than returning an empty set — checked in
as `test_parsers_fail_loudly_on_a_missing_source` and
`test_parsers_fail_loudly_on_a_source_of_the_wrong_shape`, with
`test_the_parsed_inventory_is_non_empty_and_plausible` as the positive control.
M21/M22/M23 then sabotage the live parsers and confirm the guards fire.

Measured while writing the SKILL.md parser: splitting table rows on **raw** `|`
silently drops the `emulate` and `key` rows (both carry `\|` inside a backtick
span), which would have made a documentation test fail for entirely the wrong
reason. The parser splits on unescaped pipes only; M23 pins that.

## Not done / flagged

- No existing assertion was weakened or deleted; no production file was touched.
  Files owned by sibling agents (`browser`, `server.py`, `SKILL.md`,
  `test_skill_size.py`, `reference/**`) are untouched.
- The `.mjs` suites are outside the flake gate (above). Worth a follow-up.
- `pytest` at HEAD is fully green; the one red test is in the node suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

# UPDATE — the operator ruling is IMPLEMENTED (commit `fd4a961`)

The deliberate failing test (`AGENT SURFACE PARTITION`) reported `context`,
`emulate`, `ping` as wire ops that were neither agent-REACHABLE nor DECLARED
exclusions. All three are now resolved, and the suite is green FOR THE RIGHT
REASON (five mutations, five reds — below).

## 1. `context` → MADE REACHABLE

**Provenance (verified in this branch, not assumed).** Its absence was an
oversight, not a decision:

```
$ git log -S'"context"' --oneline -- scripts/browser-bridge/server.py
55ad035 2026-08-01  fix(browser-bridge): the `context` op was never added to
                    server.py — it is dead on main (#263)

$ git log -1 --format='%h %ad %s' --date=short -- \
    scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
1e2ad9e 2026-07-31  fix(browser-agent): deterministic hidden-tab auto-wake (#243)
```

The agent-surface file was last edited **2026-07-31**; `context` only reached
`server.py`'s `ALLOWED_OPS` on **2026-08-01**. The mapping has never been looked
at since the op came into existence, so it cannot encode a decision about it.

On the merits: `context` is a cheap READ of page state (url, domain, path,
searchParams, title, tabId) that reads **no DOM content** — strictly less
powerful than the `text`/`html` the agent already has, and it lets the model
confirm where it actually landed after a nav/redirect without paying for a full
page read.

Added to `OP_TO_SERVER` and `ALLOWED_OPS_DEFAULT`, plus the other three
agent-facing sources the existing four-source parity test holds in lockstep
(`browser.js` `.enum`, the `browser-agent.md` capability table, the README `op ∈
{…}` contract). `summarizeResult` gets a **field-pinned** `context` branch rather
than the bare `JSON.stringify(data)` fallback, so a later server-side addition to
the payload cannot silently widen what reaches the model.

## 2. `ping` → DECLARED EXCLUDED

Operator diagnostic for extension staleness ("is the build I just deployed the
one Brave loaded?"). The model **cannot act on the answer** — it cannot reload an
unpacked extension, restart Brave, or re-run a `home-manager switch` — and it
reads no page state, so it cannot inform a browsing decision either. Pure token
cost with no available follow-up. Excluded like `activate`, not gated like
`upload`.

## 3. `emulate` → DECLARED EXCLUDED

It MUTATES the tab and leaves **sticky per-tab state that outlives the op**:
device metrics, UA-CH and media overrides persist until an explicit
`emulate --reset` or the tab is replaced. An autonomous agent that emulates and
never resets (moved on, hit its step budget, crashed) hands the operator back a
silently altered tab. It also attaches CDP (debugger banner). Same hazard class
as `upload` being off-by-default, but with a **persistent** side effect — so
exclusion rather than an opt-in someone has to remember to undo.

Both exclusions carry the rationale paragraph in `browser_tool_impl.mjs` that
`REVIEWED_AGENT_EXCLUSIONS` asserts verbatim, in the same style as the existing
`activate` and `upload` paragraphs.

## Verification

**Mutation matrix — five mutations, five reds, each naming its own op:**

| # | mutation | result |
|---|---|---|
| M1 | drop `context: "context"` from `OP_TO_SERVER` | RED ×3 — `AGENT SURFACE PARTITION`: `UNDECLARED EXCLUSION(S): context … [ops: context]`, plus `UPSTREAM ANCHOR` (`agent op \`context\` has NO OP_TO_SERVER entry`) and the `OP_TO_SERVER` literal pin |
| M2 | delete the `ping` entry from `REVIEWED_AGENT_EXCLUSIONS` | RED — `UNDECLARED EXCLUSION(S): ping … [ops: ping]` |
| M3 | delete the `emulate` entry | RED — `UNDECLARED EXCLUSION(S): emulate … [ops: emulate]` |
| M4 | reword the `emulate` rationale comment in the source | RED — `DECLARED EXCLUSIONS`: `REVIEWED_AGENT_EXCLUSIONS.emulate: its cited rationale is NOT present … [op: emulate]` |
| M5 | reword the `ping` rationale comment in the source | RED — same guard, `[op: ping]` |

M4/M5 are the point of the `source` field: an exclusion cannot be declared
without the written justification existing in the file a maintainer reads.

**`context` is a real behaviour change to the autonomous agent, so it was
verified LIVE end-to-end** (host `laptop` per `browser whoami`, instance
`personal`, extension 0.7.0, `extension_stale:false`), against a locally served
copy of `tests/fixtures/oopif-rig` — no real site, and `activate` never used:

```
$ browser agent --instance personal --allow-domains 127.0.0.1 --steps 8 \
    "Navigate to http://127.0.0.1:8912/top.html?case=alpha&n=7 then use the
     context op … Do NOT read the page body."
{"answer":"domain=127.0.0.1, path=/top.html, case=alpha",
 "evidence":["{\"domain\":\"127.0.0.1\",\"path\":\"/top.html\",
              \"searchParams\":{\"case\":\"alpha\",\"n\":\"7\"}}"],
 "steps_used":2,"status":"ok"}
```

The answer text alone would not prove the tool was reachable, so
`BROWSER_AGENT_KEEP_SCRATCH=1` was set and `$SCRATCH/tool-audit.jsonl` read:

```
{"ts":1785696788.356,"tool":"browser","decision":"exec","op":"nav","detail":"127.0.0.1"}
{"ts":1785696790.505,"tool":"browser","decision":"exec","op":"context","detail":""}
```

`decision:"exec"` on `op:"context"` — the op was **dispatched**, not merely
mentioned, and the model used the returned shape correctly. The agent's tab was
closed by the wrapper (`browser tabs` shows no stray `127.0.0.1:8912` tab).

**Suite counts** (rebased onto `origin/main` `a0a5d73` by cherry-picking the two
branch commits — a rebase, not a merge; no conflicts):

| suite | at `163b721` (pre-fix) | at `fd4a961` |
|---|---|---|
| `node --test scripts/browser-bridge/tests/*.test.mjs` | **460 tests, 459 pass, 1 fail** (the deliberate one) | **460 / 460 pass** |
| `pytest scripts/browser-bridge/tests` (under `nix-shell -p python312Packages.pytest`, pytest 9.0.2) | 436 passed | **436 passed** |

Counted from the TAP `# tests/# pass/# fail` lines and pytest's own total, not
from an exit code.

## Files touched by this update

`opencode/tools/browser_tool_impl.mjs`, `opencode/tools/browser.js`,
`opencode/browser-agent.md`, `README.md` (the four agent-facing op sources the
parity test pins together) and `tests/browser_tool.test.mjs`. `browser`,
`server.py`, `SKILL.md`, `reference/**` and the extension are still untouched.
