### PR TITLE
fix(browser-bridge): nav/open --wake, fast ping, split routing errors, orientation telemetry, screenshot Read hint

### DIFF
--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -58,10 +58,10 @@ Result payloads land under `.result.data`.
 | `health` / `instances` | connected instances + count (`instances` as JSON: key, label, instanceId, active-tab url/title), each with an explicit `extension_stale` verdict (`true`/`false`; `null` = undecidable) |
 | `ping` | **which extension build+dir is loaded?** → `{pong,extensionVersion,id,ops}`; older build → `unknown_op`. The only deterministic answer after a ↻ reload |
 | `context` | **page metadata, no DOM read** — url/domain/path/query/title/tabId, tab-scoped. Cheapest read; ⚠ NOT a render check → `reference/read-envelopes.md` |
-| `open [url]` | open a NEW tab this session owns (default `about:blank`, **created in the BACKGROUND/hidden**), returns `tabId`. Idempotent. Use for multi-step work |
+| `open [url] [--wake[=MS]]` | open a NEW tab this session owns (default `about:blank`, **created in the BACKGROUND/hidden**), returns `tabId`. Idempotent. Use for multi-step work |
 | `close` / `release` | close this session's owned tab / drop ownership without closing it |
 | `tabs` | list open tabs (`.data.ownedTabId` flags yours) |
-| `nav <url>` | navigate the owned/active tab |
+| `nav <url> [--wake[=MS]]` | navigate the owned/active tab; it lands hidden, so `--wake` un-throttles in the SAME call |
 | `text [selector] [--max-bytes N] [--annotated]` | **cheap read** — visible `innerText` (optional CSS selector), whitespace-normalized, byte-capped (default 32768; `0`=uncapped). ~98% smaller than `html` — **prefer it**. `--annotated` swaps flat text for per-element extraction — use it when you need a SELECTOR to click/type; refused with `--frame`. Envelope fields + `--annotated` schema → `reference/read-envelopes.md` |
 | `html [--max-bytes N]` | `outerHTML`, same byte cap and same envelope. One uncapped `html` on a heavy SPA is ~100K tokens — the cap is ON by default |
 | `js '<expr>'` (alias: `eval`) | run JS in the tab, return its value; same op on the wire either way. **Prefer `js` in a worktree-isolated agent** — Claude Code's isolation guard refuses any command containing the literal token `eval` (it matches the WORD, not the behaviour) |
@@ -71,7 +71,7 @@ Result payloads land under `.result.data`.
 | `type <text> [--selector S]` | text input — TRUSTED CDP top frame, SYNTHETIC in-frame |
 | `key <Enter\|Tab\|Escape\|Backspace\|Delete\|Arrow*\|Home\|End\|Page*> [--selector S]` | one bounded keypress, same trust rules |
 | `upload <selector> <path>` | fill an `<input type=file>` via CDP — Chrome reads the file BY PATH, **no bytes cross the bridge**. AUDIT-LOGGED, **operator-only** (agent → `op_not_allowed:upload`) |
-| `wake [--wait MS]`, or `text\|html\|js --wake[=MS]` | **UN-THROTTLE a hidden/background tab with NO focus movement** — the fix for an empty or `hidden` read. ~1.5s settle, cap **6s**. **Wake once per PAGE, not per read** — the un-throttled state ends at detach, but the DOM already rendered PERSISTS. `--wake` folds un-throttle+read into one session; refused with `--frame` (`wake_with_frame_unsupported`). ISOLATED-vs-MAIN world nuance → `reference/spa-wake.md` |
+| `wake [--wait MS]`, or `text\|html\|js\|nav\|open --wake[=MS]` | **UN-THROTTLE a hidden/background tab with NO focus movement** — the fix for an empty or `hidden` read. ~1.5s settle, cap **6s**. **Wake once per PAGE, not per read** — the un-throttled state ends at detach, but the DOM already rendered PERSISTS. `--wake` folds un-throttle+read into one session; refused with `--frame` (`wake_with_frame_unsupported`). ISOLATED-vs-MAIN world nuance → `reference/spa-wake.md` |
 | `activate` | **⚠⚠ STEALS THE OPERATOR'S SCREEN — the ONE intrusive op, a LAST RESORT.** It is **NOT** the fix for a hidden/unrendered tab — that is `wake`. Read `reference/spa-wake.md` BEFORE using it |
 | `emulate <preset>\|--reset` | **device emulation** (mobile testing) on a tab you `open`ed; sticky, owned-tab-only → `reference/emulation.md` |
 | `agent "<goal>"` | the autonomous browser-agent — see **FIRST DECISION** above, then `reference/agent.md` |

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -352,7 +352,18 @@ done
 # → "token file not found/readable"). Dispatched here rather than in the `case`
 # below, which runs after the token is read.
 case "${1:-}" in
-  ""|-h|--help|help) grep -E '^#( |$)' "$0" | sed -E 's/^# ?//'; exit 0 ;;
+  # --help prints the LEADING comment block only — the contiguous run of `#` lines
+  # after the shebang, stopping at the first line of code.
+  #
+  # It used to be `grep -E '^#( |$)' "$0"`, which matched EVERY column-0 comment in
+  # the file, so `--help` shipped the whole implementation commentary: 25,440 bytes
+  # against a ~15 KB header, and it GREW with every internal comment anyone added
+  # (the five audit fixes in the parent commit would alone have put 4,129 bytes of
+  # maintainer notes onto a user-facing help screen). The header block is what
+  # `--help` was always meant to be; the rest is for whoever is reading the source,
+  # which they are already doing.
+  ""|-h|--help|help)
+    awk 'NR==1 {next} /^#/ {sub(/^# ?/, ""); print; next} {exit}' "$0"; exit 0 ;;
 esac
 
 # The complete subcommand list, in ONE place: it both VALIDATES the subcommand

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -59,8 +59,10 @@
 #                               (MEASURED)". Pass --instance when two profiles
 #                               are connected, else 409 ambiguous.
 #   browser instances         — list connected instances as JSON (key/label/url)
-#   browser open [url]        — open a NEW tab this session owns (default about:blank);
+#   browser open [url] [--wake[=MS]]
+#                             — open a NEW tab this session owns (default about:blank);
 #                               subsequent ops route to it. Prints its tabId.
+#                               --wake as for `nav`.
 #   browser close             — close this session's owned tab + drop ownership
 #   browser release           — drop ownership WITHOUT closing the tab
 #   browser wake [--wait MS | --no-wait]
@@ -146,7 +148,11 @@
 #                               the PAGE and never touches the filesystem.
 #   browser eval '<js>'       — same as `browser js` (unchanged, not deprecated)
 #   browser tabs              — list open tabs (flags this session's owned tab)
-#   browser nav <url>         — navigate the owned/active tab to <url>
+#   browser nav <url> [--wake[=MS]]
+#                             — navigate the owned/active tab to <url>. --wake
+#                               un-throttles the (background → throttled) tab in
+#                               the SAME invocation, so the next read is not a
+#                               shell — it replaces the `nav` then `wake` pair.
 #   browser screenshot [path] [--fullpage] [--data-url]
 #                             — screenshot the owned/active tab via CDP
 #                               (Page.captureScreenshot) — WORKS on a background/
@@ -198,8 +204,9 @@
 #   `--`; subcommands taking one (js/eval, text, screenshot, type, key, emulate)
 #   accept exactly one, and a SECOND is an error rather than overwriting the
 #   first — including when the first is the empty string.
-#   `nav`/`open`/`click`/`upload` take no flags at all, so their positionals stay
-#   bare and need no `--` (a `-`-leading selector or path just works).
+#   `nav`/`open` take one positional plus `--wake[=MS]`, in either order.
+#   `click`/`upload` take no flags at all, so their positionals stay bare and need
+#   no `--` (a `-`-leading selector or path just works).
 #
 # Global flags (before the subcommand): --instance <key>, --tab <id>,
 #   --frame <frameId|url-substring> (route a read/click INTO a cross-origin frame).
@@ -428,6 +435,89 @@ except Exception:
 '
 }
 
+# _explain_instance_failure RESP KEY MODE — stderr advice for the two routing
+# failures that look identical from the CLI but need OPPOSITE next actions.
+# MODE is "unknown_instance" (a 404 for --instance KEY) or "no_extension" (a 503:
+# nothing at all is connected).
+#
+# WHY THIS EXISTS — measured, 2026-08-02 usage audit. `unknown_instance` was the
+# top error at 52 occurrences, and **48 of them used the CORRECT label** (`work`),
+# 35 inside a single hour, with `eval` re-issued **37 times**. That is not user
+# error: a Brave profile dropped its long-poll for ~2 hours and the old message —
+# "no connected instance matches --instance 'work'" — reads as "you typed the
+# wrong label", so agents kept retrying a name that was right. `no_extension` has
+# the identical shape (16 of 19 in one hour) and gets the same treatment.
+#
+# The distinguishing fact is already on the wire: the server returns
+# `known_instances` (every routing key it has seen this process lifetime, each
+# with `connected`) in BOTH bodies. So:
+#   * KEY present in known_instances, connected:false → the label is RIGHT, the
+#     profile is gone. Restarting Brave is the fix; retrying is not.
+#   * KEY absent entirely                            → the label is wrong (or that
+#     profile has never once been wired up). Listing the live keys is the fix.
+# The "do not retry" line is the point of the whole change: a blind-retry burst is
+# the symptom of a message that never told anyone to stop.
+#
+# DEGRADES SILENTLY (like render_missing): an older server with no
+# `known_instances`, a non-dict body, anything unparseable → fall back to the
+# generic wording rather than tracebacking over a real error.
+_explain_instance_failure() {
+  printf '%s' "$1" | python3 -c '
+import json, sys
+
+key, mode = sys.argv[1], sys.argv[2]
+def w(line):
+    sys.stderr.write("browser: " + line + "\n")
+
+known = []
+try:
+    d = json.load(sys.stdin)
+    if isinstance(d, dict):
+        known = [i for i in (d.get("known_instances") or []) if isinstance(i, dict)]
+except Exception:
+    known = []
+
+match = next((i for i in known if i.get("key") == key), None) if key else None
+gone = [i for i in known if not i.get("connected")]
+
+def dropped(i):
+    seen = i.get("last_seen") or "?"
+    age = i.get("last_seen_age_s")
+    return "%s (last seen %s%s)" % (
+        i.get("key", "?"), seen,
+        ", %ss ago" % age if age is not None else "")
+
+if mode == "unknown_instance" and match is not None and not match.get("connected"):
+    w("instance %r is KNOWN but NOT CONNECTED — the label is correct; that Brave" % key)
+    w("  profile has dropped its long-poll.  " + dropped(match))
+    w("  FIX: switch to that Brave profile and FULLY RESTART Brave (a")
+    w("       brave://extensions reload often no-ops — the long-poll keeps the old")
+    w("       service worker alive).")
+    w("  DO NOT RETRY this command: it will fail identically until that profile")
+    w("  reconnects. Re-running it 37 times is the measured failure mode here.")
+elif mode == "unknown_instance":
+    w("instance %r is UNKNOWN — no profile has registered that routing key on this" % key)
+    w("  server. This is a WRONG LABEL (or a profile never wired up), not a drop.")
+    if known:
+        w("  Keys this server HAS seen: " + ", ".join(
+            "%s%s" % (i.get("key", "?"), "" if i.get("connected") else " [disconnected]")
+            for i in known))
+    w("  FIX: pass one of the connected keys listed above, or set this profile\x27s")
+    w("       routing key in the extension options.")
+else:  # no_extension
+    if gone:
+        w("NO Brave profile is connected — but this server HAS seen: " +
+          ", ".join(dropped(i) for i in gone))
+        w("  So the extension IS installed and has dropped its long-poll.")
+        w("  FIX: FULLY RESTART Brave (a brave://extensions reload often no-ops).")
+        w("  DO NOT RETRY until it is back — every op will fail identically.")
+    else:
+        w("NO Brave profile has EVER connected to this bridge.")
+        w("  FIX: load the browser-bridge extension in Brave and paste the token")
+        w("       into its options. Triage steps: SKILL.md -> When things look broken")
+' "$2" "$3"
+}
+
 # _curl METHOD PATH [JSON_BODY] — emits `<body>\n<http_code>` to stdout. The
 # caller splits it (globals can't cross the command-substitution subshell).
 _curl() {
@@ -483,6 +573,36 @@ if isinstance(data, dict) and data.get("hidden") is True:
                                 "or re-run this read with --wake")
     sys.stderr.write("browser: " + str(note) + "\n")
 '
+}
+
+# _wake_flag ARG — ONE RULE, ONE PLACE for `--wake` / `--wake=MS`.
+#
+# Returns 0 (and sets WAKE=1, plus WAKE_WAIT=<ms> for the `=MS` form) when ARG is
+# a wake flag; returns 1 without touching anything when it is not, so a caller's
+# `case` can go on to handle its own flags. The caller does the `shift`.
+#
+# WHY A HELPER: this parse used to be copy-pasted verbatim into `html`, `text` and
+# `js` — three call sites, three chances to drift, and adding it to `nav`/`open`
+# would have made five. A predicate duplicated across call sites regenerates the
+# same bug at every site.
+#
+# VALIDATION STAYS AT PARSE TIME (the load-bearing property this preserves): the
+# `die` fires HERE, in the flag loop, before anything is put on the wire. It must
+# NOT move into wake_fields, which runs inside `$( )` where a `die` would exit only
+# the subshell and the request would still be sent.
+#
+# It sets GLOBALS rather than echoing, precisely so the `die` is not trapped in a
+# command substitution. Every caller resets WAKE/WAKE_WAIT before its loop.
+WAKE=""; WAKE_WAIT=""
+_wake_flag() {
+  case "$1" in
+    --wake) WAKE=1; return 0 ;;
+    --wake=*)
+      WAKE=1; WAKE_WAIT="${1#--wake=}"
+      case "$WAKE_WAIT" in (*[!0-9]*|"") die "--wake=MS must be a non-negative integer of ms (got: $WAKE_WAIT)";; esac
+      return 0 ;;
+  esac
+  return 1
 }
 
 # wake_fields WAKE WAITMS — emit the `,"wake":true[,"waitMs":N]` JSON fragment for
@@ -543,6 +663,51 @@ json.dump(d, sys.stdout)
 ' "$1"
 }
 
+# _wake_after PRIMARY_JSON — the `nav`/`open` half of `--wake`.
+#
+# WHY THIS IS A CLIENT-SIDE COMPOSE AND NOT A `"wake":true` WIRE FIELD: the
+# extension honours `cmd.wake` on exactly three ops — getHtml / text / eval — where
+# it means "un-throttle and do THIS READ inside the same CDP session". `nav` and
+# `open` are not reads; there is nothing to fold the un-throttle into. So
+# `nav --wake` is defined as what the 13 measured `nav`→`wake` transcript pairs
+# were hand-typing: navigate, then wake the resulting tab. Two wire ops, ONE
+# invocation — the round trip it removes is the agent's, not the bridge's.
+#
+# Consequence worth knowing: the wire body for `nav`/`open` is UNCHANGED (no
+# `wake` field is ever sent for them), so no extension version can mis-handle it.
+#
+# Output: PRIMARY_JSON with the wake op's own `result.data` merged in under
+# `result.data.wake` — the same place `--wake` reads report it (wakeAnnotate in
+# extension/service_worker.js), so one shape covers both. Without --wake nothing
+# here runs and stdout is byte-identical to before.
+_wake_after() {
+  local primary="$1" wextra="" wresp
+  if [ -n "$WAKE_WAIT" ]; then wextra="\"waitMs\":${WAKE_WAIT}"; fi
+  # `|| exit 1` — cmd_op's `die` would otherwise exit only this substitution.
+  wresp="$(cmd_op wake "$wextra")" || exit 1
+  printf '%s\v%s' "$primary" "$wresp" | python3 -c '
+import json, sys
+primary, _, wake = sys.stdin.read().partition("\v")
+try:
+    d = json.loads(primary)
+    w = json.loads(wake)
+except Exception:
+    # Never let the annotation break the command: emit the primary verbatim.
+    sys.stdout.write(primary); sys.exit(0)
+res = d.get("result") if isinstance(d, dict) else None
+if not isinstance(res, dict):
+    sys.stdout.write(primary); sys.exit(0)
+data = res.get("data")
+if not isinstance(data, dict):
+    data = {}
+    res["data"] = data
+wres = w.get("result") if isinstance(w, dict) else None
+wdata = wres.get("data") if isinstance(wres, dict) else None
+data["wake"] = wdata if isinstance(wdata, dict) else {"applied": True}
+json.dump(d, sys.stdout)
+'
+}
+
 # cmd_op OP [EXTRA_JSON_FIELDS] — POST /cmd, print the result JSON on a genuine
 # success; exit non-zero with a readable message on a transport, HTTP, OR
 # op-level (result.ok:false) error. Honours the global --instance (INSTANCE) by
@@ -570,22 +735,27 @@ cmd_op() {
     200) : ;;  # HTTP ok — still must inspect the inner op result below.
     503)
       # Fail-FAST (no waiting on cmd_timeout): resolution failed before the
-      # command ever reached an instance. Name the profiles we HAVE seen drop.
-      printf '%s' "$resp" | render_missing
-      echo "$resp" >&2
-      die "no extension connected — load the browser-bridge extension in Brave (see SKILL.md)"
+      # command ever reached an instance. Two DIFFERENT situations wear this one
+      # status — "never wired up" and "was wired up, dropped" — and they need
+      # opposite next actions; _explain_instance_failure separates them.
+      _explain_instance_failure "$resp" "$INSTANCE" no_extension
+      die "op '$op' not dispatched: no extension connected"
       ;;
     504) echo "$resp" >&2; die "timeout waiting for the extension to answer (is Brave focused / responsive?)" ;;
     401) die "unauthorized — token mismatch (re-paste the token in the extension options)" ;;
     429)
       # rate_limited / queue_full — the per-instance concurrency backstop is
-      # shedding load (see SKILL.md → Concurrency). Exit non-zero so a runaway
+      # shedding load. Concurrency guidance: reference/tabs-instances.md, and the
+      # Concurrent-drivers paragraph of SKILL.md → This is the user's LIVE session
+      # (there is NO "Concurrency" heading — this pointer used to name one, and a
+      # test now proves every SKILL.md heading the CLI names actually exists).
+      # Exit non-zero so a runaway
       # loop gets a hard, detectable back-off signal (that IS the point).
       echo "$resp" >&2
       if printf '%s' "$resp" | grep -q '"queue_full"'; then
         die "queue full — too many concurrent browser ops on this instance; back off and retry"
       fi
-      die "rate-limited — browser ops issued too fast; back off and retry (a bare high-rate eval loop is throttled — see SKILL.md Concurrency)"
+      die "rate-limited — browser ops issued too fast; back off and retry (a bare high-rate eval loop is throttled — see reference/tabs-instances.md)"
       ;;
     409)
       # ambiguous_instance (>1 connected, no --instance), no_owned_tab, or superseded.
@@ -626,12 +796,13 @@ cmd_op() {
     404)
       if printf '%s' "$resp" | grep -q '"unknown_instance"'; then
         # Fail-FAST: the server rejects an unresolvable target BEFORE enqueueing,
-        # so this never waits out the 20s cmd_timeout. Print the live instances
-        # AND any known-but-dropped ones — a mistyped label and a profile that
-        # silently died look identical from the CLI otherwise.
-        echo "browser: no connected instance matches --instance '${INSTANCE}'. Connected:" >&2
+        # so this never waits out the 20s cmd_timeout. A mistyped label and a
+        # profile that silently died are the SAME status code and used to be the
+        # same sentence; _explain_instance_failure splits them and tells the
+        # disconnected case to STOP RETRYING (the measured failure mode).
+        _explain_instance_failure "$resp" "$INSTANCE" unknown_instance
+        echo "browser: connected right now:" >&2
         printf '%s' "$resp" | render_instances
-        printf '%s' "$resp" | render_missing
         exit 1
       fi
       echo "$resp" >&2; die "HTTP 404 from /cmd"
@@ -745,17 +916,31 @@ case "$sub" in
     printf '%s' "$resp" | python3 -c 'import json,sys; print(json.dumps(json.load(sys.stdin).get("instances", []), indent=2))'
     ;;
   open)
+    # browser open [url] [--wake[=MS]]
     # Optional url; default about:blank. Records this session's owned tab.
-    if [ $# -ge 1 ]; then
-      url="$(json_str "$1")"
-      shift
-      # `open` takes NO flags, so it keeps a bare positional (a URL can never be
-      # confused for a flag). But an extra arg used to be SILENTLY DROPPED — the
-      # same failure mode as the `js` flag-order bug, one step quieter. Reject it.
-      [ $# -eq 0 ] || die "browser open takes at most one url (got extra: $1)"
-      cmd_op open "\"url\":${url}" | pretty
+    # `--wake` un-throttles the freshly-opened (BACKGROUND, therefore throttled)
+    # tab in the same invocation — see the `nav` arm and _wake_after.
+    # ⚠ `--wake` on a default `open` (about:blank) is legal but pointless: there is
+    # no page to render. It is not rejected, because `open --wake` composes with a
+    # url and a needless wake is cheap and harmless.
+    WAKE=""; WAKE_WAIT=""; POS=""; POS_SEEN=0
+    while [ $# -gt 0 ]; do
+      if _wake_flag "$1"; then shift; continue; fi
+      case "$1" in
+        --) shift; pos_rest "open takes at most one url" "$@"; break ;;
+        -*) die "browser open: unknown flag: $1 (try: --wake[=MS]; use '--' before a url starting with '-')" ;;
+        *) pos_add "open takes at most one url" "$1"; shift ;;
+      esac
+    done
+    # POS_SEEN, not [ -n "$POS" ]: `open -- ''` must not be mistaken for a bare
+    # `open` (which legitimately means about:blank).
+    extra=""
+    if [ "$POS_SEEN" -eq 1 ]; then extra="\"url\":$(json_str "$POS")"; fi
+    if [ -n "$WAKE" ]; then
+      resp="$(cmd_op open "$extra")" || exit 1
+      _wake_after "$resp" | pretty
     else
-      cmd_op open | pretty
+      cmd_op open "$extra" | pretty
     fi
     ;;
   close)
@@ -969,22 +1154,19 @@ sys.stdout.write(json.dumps(fields)[1:-1])
     # takes the light chrome.scripting path with NO debugger banner, and routing
     # every read through CDP would flash "an extension is debugging this browser"
     # on every single read — trading focus theft for banner spam.
-    maxb=32768; wake=""; wakewait=""
+    maxb=32768; WAKE=""; WAKE_WAIT=""
     while [ $# -gt 0 ]; do
+      if _wake_flag "$1"; then shift; continue; fi
       case "$1" in
         --max-bytes) shift; [ $# -ge 1 ] || die "usage: browser html [--max-bytes N]"; maxb="$1"; shift ;;
         --max-bytes=*) maxb="${1#--max-bytes=}"; shift ;;
-        --wake) wake=1; shift ;;
-        --wake=*) wake=1; wakewait="${1#--wake=}";
-          case "$wakewait" in (*[!0-9]*|"") die "--wake=MS must be a non-negative integer of ms (got: $wakewait)";; esac
-          shift ;;
         --) shift; [ $# -eq 0 ] || die "browser html takes no positional args (got: $1)"; break ;;
         -*) die "browser html: unknown flag: $1 (try: --max-bytes N | --wake[=MS])" ;;
         *) die "browser html takes no positional args (got: $1)" ;;
       esac
     done
     case "$maxb" in (*[!0-9]*|"") die "--max-bytes must be a non-negative integer (got: $maxb)";; esac
-    extra="\"maxBytes\":${maxb}$(wake_fields "$wake" "$wakewait")"
+    extra="\"maxBytes\":${maxb}$(wake_fields "$WAKE" "$WAKE_WAIT")"
     cmd_op getHtml "$extra" | cap_html "$maxb" | pretty
     ;;
   text)
@@ -995,15 +1177,12 @@ sys.stdout.write(json.dumps(fields)[1:-1])
     # --wake routes this one read through CDP with the un-throttle applied in the
     # same session (see `browser html` / `browser wake`).
     # --annotated returns structured element data instead of plain text.
-    POS=""; POS_SEEN=0; maxb=32768; wake=""; wakewait=""; annotated=""
+    POS=""; POS_SEEN=0; maxb=32768; WAKE=""; WAKE_WAIT=""; annotated=""
     while [ $# -gt 0 ]; do
+      if _wake_flag "$1"; then shift; continue; fi
       case "$1" in
         --max-bytes) shift; [ $# -ge 1 ] || die "usage: browser text [selector] [--max-bytes N] [--annotated]"; maxb="$1"; shift ;;
         --max-bytes=*) maxb="${1#--max-bytes=}"; shift ;;
-        --wake) wake=1; shift ;;
-        --wake=*) wake=1; wakewait="${1#--wake=}";
-          case "$wakewait" in (*[!0-9]*|"") die "--wake=MS must be a non-negative integer of ms (got: $wakewait)";; esac
-          shift ;;
         --annotated) annotated=1; shift ;;
         --) shift; pos_rest "text takes at most one selector" "$@"; break ;;
         -*) die "browser text: unknown flag: $1 (try: --max-bytes N | --wake[=MS] | --annotated; use '--' before a selector starting with '-')" ;;
@@ -1012,7 +1191,7 @@ sys.stdout.write(json.dumps(fields)[1:-1])
     done
     sel="$POS"
     case "$maxb" in (*[!0-9]*|"") die "--max-bytes must be a non-negative integer (got: $maxb)";; esac
-    extra="\"maxBytes\":${maxb}$(wake_fields "$wake" "$wakewait")"
+    extra="\"maxBytes\":${maxb}$(wake_fields "$WAKE" "$WAKE_WAIT")"
     if [ -n "$sel" ]; then extra="\"selector\":$(json_str "$sel"),${extra}"; fi
     if [ -n "$annotated" ]; then extra="${extra},\"annotated\":true"; fi
     cmd_op text "$extra" | pretty
@@ -1044,13 +1223,10 @@ sys.stdout.write(json.dumps(fields)[1:-1])
     # An expression that legitimately STARTS with `-` (e.g. `-1+2`) is still
     # rejected as an unknown flag — pass it after the `--` end-of-flags separator:
     #   browser js -- '-1+2'
-    POS=""; POS_SEEN=0; wake=""; wakewait=""
+    POS=""; POS_SEEN=0; WAKE=""; WAKE_WAIT=""
     while [ $# -gt 0 ]; do
+      if _wake_flag "$1"; then shift; continue; fi
       case "$1" in
-        --wake) wake=1; shift ;;
-        --wake=*) wake=1; wakewait="${1#--wake=}";
-          case "$wakewait" in (*[!0-9]*|"") die "--wake=MS must be a non-negative integer of ms (got: $wakewait)";; esac
-          shift ;;
         --) shift; pos_rest "js takes exactly one JS argument" "$@"; break ;;
         -*) die "browser js: unknown flag: $1 (try: --wake[=MS]; use '--' before a JS expression starting with '-')" ;;
         *) pos_add "js takes exactly one JS argument" "$1"; shift ;;
@@ -1059,26 +1235,40 @@ sys.stdout.write(json.dumps(fields)[1:-1])
     # POS_SEEN (not [ -n "$POS" ]) so `browser js ''` keeps its old meaning.
     [ "$POS_SEEN" -eq 1 ] || die "usage: browser js '<js>' [--wake[=MS]]   (or the identical: browser eval '<js>')"
     js="$(json_str "$POS")"
-    cmd_op eval "\"js\":${js}$(wake_fields "$wake" "$wakewait")" | pretty
+    cmd_op eval "\"js\":${js}$(wake_fields "$WAKE" "$WAKE_WAIT")" | pretty
     ;;
   tabs)
     cmd_op tabs | pretty
     ;;
   nav)
-    [ $# -ge 1 ] || die "usage: browser nav <url>"
-    nav_url="$1"; url="$(json_str "$1")"; shift
-    # No flags on `nav` → the positional stays bare (a URL never looks like a
-    # flag). Extra args were silently dropped before; make that loud instead.
-    # When the FIRST arg looks like a flag, name THAT rather than the trailing
-    # url: `browser nav --wake <url>` is the flag-order confusion this file's
-    # other fix is about, and "got extra: <url>" points at the innocent arg.
-    if [ $# -ne 0 ]; then
-      case "$nav_url" in
-        -*) die "browser nav takes no flags — '$nav_url' was read as the url. Put the url first: browser nav '$1'" ;;
-        *)  die "browser nav takes exactly one url (got extra: $1)" ;;
+    # browser nav <url> [--wake[=MS]]
+    #
+    # `nav` USED to take no flags at all, and `browser nav --wake <url>` was a
+    # deliberate hard error ("takes no flags — put the url first"). That error was
+    # correct about the parse and wrong about the need: `nav` lands you on a
+    # BACKGROUND tab, which is throttled, so the very next read is a shell. The
+    # 2026-08-02 usage audit measured 13 `nav`→`wake` / `open`→`wake` adjacent
+    # pairs in Claude transcripts and one opencode session that is literally
+    # `nav wake eval` ×5. So the flag is now REAL rather than rejected, and — like
+    # `text`/`html`/`js` — flag order is free. See _wake_after for why this is a
+    # client-side compose (the extension has no `wake` on the `nav` op).
+    WAKE=""; WAKE_WAIT=""; POS=""; POS_SEEN=0
+    while [ $# -gt 0 ]; do
+      if _wake_flag "$1"; then shift; continue; fi
+      case "$1" in
+        --) shift; pos_rest "nav takes exactly one url" "$@"; break ;;
+        -*) die "browser nav: unknown flag: $1 (try: --wake[=MS]; use '--' before a url starting with '-')" ;;
+        *) pos_add "nav takes exactly one url" "$1"; shift ;;
       esac
+    done
+    [ "$POS_SEEN" -eq 1 ] || die "usage: browser nav <url> [--wake[=MS]]"
+    url="$(json_str "$POS")"
+    if [ -n "$WAKE" ]; then
+      resp="$(cmd_op nav "\"url\":${url}")" || exit 1
+      _wake_after "$resp" | pretty
+    else
+      cmd_op nav "\"url\":${url}" | pretty
     fi
-    cmd_op nav "\"url\":${url}" | pretty
     ;;
   screenshot)
     # browser screenshot [path] [--fullpage]
@@ -1190,6 +1380,15 @@ if explicit:
     with open(out,"wb") as fh:
         fh.write(png)
     print(out)
+    # A capture nobody Reads is pure waste: the 2026-08-02 usage audit measured
+    # 7 of 63 explicit-path captures never Read back. Exit 0 and a path on stdout
+    # look like success, so the one thing still required is easy to forget. ONE
+    # short line, and deliberately `#`-prefixed so line 1 stays the bare path for
+    # anything parsing it (and so the hint cannot be mistaken FOR a path).
+    # NOT printed for --data-url (no file exists) or the temp-file branch (whose
+    # JSON already carries an equivalent `note`) — printing it there would be
+    # wrong, and those two are the negative controls for the test.
+    print("# Read %s to view it." % out)
 else:
     # mkstemp: O_CREAT|O_EXCL at 0600 — not world-readable, not symlink-followable.
     fd,out=tempfile.mkstemp(prefix=PREFIX, suffix=SUFFIX, dir=tmpdir)

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -494,9 +494,16 @@ gone = [i for i in known if not i.get("connected")]
 def dropped(i):
     seen = i.get("last_seen") or "?"
     age = i.get("last_seen_age_s")
-    return "%s (last seen %s%s)" % (
+    # `last_unanswered_op` is NOT decoration. server.py records it as "the single
+    # fact that turns the next silent drop from inference into evidence": it names
+    # the command the instance was handed and never answered, which is what tells
+    # you whether the profile died mid-op or went quiet while idle. render_missing
+    # has always printed it; the rewritten advice must not drop it.
+    op = i.get("last_unanswered_op")
+    return "%s (last seen %s%s%s)" % (
         i.get("key", "?"), seen,
-        ", %ss ago" % age if age is not None else "")
+        ", %ss ago" % age if age is not None else "",
+        ", last unanswered op: %s" % op if op else "")
 
 if mode == "unknown_instance" and match is not None and not match.get("connected"):
     w("instance %r is KNOWN but NOT CONNECTED — the label is correct; that Brave" % key)
@@ -513,6 +520,14 @@ elif mode == "unknown_instance":
         w("  Keys this server HAS seen: " + ", ".join(
             "%s%s" % (i.get("key", "?"), "" if i.get("connected") else " [disconnected]")
             for i in known))
+    # The wrong-label branch ALSO carries the drop evidence render_missing used to
+    # print here. A mistyped label and a profile that died are frequently the same
+    # incident (you mistype `wrk` AND `work` is also gone), and withholding the
+    # last-seen/last-op lines on this branch would make the second half invisible.
+    # NOTE: no apostrophes in this block — it lives inside python3 -c SINGLE quotes,
+    # so one would terminate the shell string (it did, once).
+    for i in gone:
+        w("  " + dropped(i))
     w("  FIX: pass one of the connected keys listed above, or set this profile\x27s")
     w("       routing key in the extension options.")
 else:  # no_extension
@@ -674,6 +689,30 @@ json.dump(d, sys.stdout)
 ' "$1"
 }
 
+# _reject_frame_with_wake SUB — refuse `--frame X <nav|open> --wake` at PARSE time.
+#
+# A NEW half-state this feature created, and the reason it must be caught HERE
+# rather than left to the extension: `--frame` is a GLOBAL flag that cmd_op splices
+# into EVERY op. `nav`/`open` ignore it, but the standalone `wake` op does not —
+# the extension's assertWakeNotFramed refuses it ("un-throttling is tab-level, not
+# per-frame"). So the composed form lands the navigation and then fails the wake:
+# a half-applied command. Before `--wake` existed on nav/open, `--frame X nav
+# --wake <url>` was a hard parse error ("nav takes no flags"), so the path did not
+# exist at all — this feature is what opened it.
+#
+# ONE RULE, ONE PLACE: both callers use this, so the predicate cannot drift.
+# Scoped to nav/open deliberately — `text`/`html`/`js --wake --frame` also refuse,
+# but they refuse in the EXTENSION with a precise message and, being pure reads,
+# leave nothing half-applied. There is no half-state there to prevent.
+_reject_frame_with_wake() {
+  [ -n "$FRAME" ] || return 0
+  echo "browser: --frame and --wake cannot be combined on '$1'." >&2
+  echo "browser:   Un-throttling is TAB-level, not per-frame, so the wake half would be" >&2
+  echo "browser:   refused by the extension AFTER the $1 had already happened." >&2
+  echo "browser:   Do this instead:  browser $1 <url> --wake   then   browser --frame $FRAME <read>" >&2
+  die "refused before anything was sent (nothing has been navigated or opened)"
+}
+
 # _wake_after PRIMARY_JSON — the `nav`/`open` half of `--wake`.
 #
 # WHY THIS IS A CLIENT-SIDE COMPOSE AND NOT A `"wake":true` WIRE FIELD: the
@@ -694,8 +733,43 @@ json.dump(d, sys.stdout)
 _wake_after() {
   local primary="$1" wextra="" wresp
   if [ -n "$WAKE_WAIT" ]; then wextra="\"waitMs\":${WAKE_WAIT}"; fi
-  # `|| exit 1` — cmd_op's `die` would otherwise exit only this substitution.
-  wresp="$(cmd_op wake "$wextra")" || exit 1
+  # 🔴 THE PRIMARY OP ALREADY HAPPENED. It is not undoable and it is not in doubt:
+  # the tab HAS navigated. So a FAILING wake must never swallow it.
+  #
+  # The first cut used `|| exit 1` here, which exited with EMPTY stdout — measured
+  # on 429, 504 and an op-level `unknown_op`, all rc 1 with nothing on stdout. That
+  # makes `T=$(browser nav --wake "$url")` yield an empty T for a tab that really
+  # did navigate, i.e. it loses the tabId of a real tab. Worse, only the op-level
+  # branch even mentioned `wake`, so the operator could not tell WHICH half failed.
+  #
+  # Now: capture the wake's status, always emit the primary JSON, attach the wake
+  # outcome under result.data.wake (ok:false + the error), and exit 3 — a DISTINCT
+  # code meaning "the primary op succeeded, only the --wake follow-up failed", so a
+  # caller can branch on it instead of guessing. cmd_op's own stderr diagnostics
+  # (429/504/op-level) are untouched and still printed above ours.
+  local wresp wrc
+  wresp="$(cmd_op wake "$wextra")"; wrc=$?
+  if [ "$wrc" -ne 0 ]; then
+    echo "browser: the '${WAKE_PRIMARY_OP:-primary}' op SUCCEEDED — only the --wake follow-up failed (see above)." >&2
+    echo "browser:   The tab HAS ${WAKE_PRIMARY_VERB:-been acted on}; its JSON is on stdout with result.data.wake.ok=false." >&2
+    echo "browser:   The page may still be throttled/unrendered: re-run 'browser wake' when ready." >&2
+    echo "browser:   Exit code 3 = primary ok, wake failed (rc 1 would mean the whole command failed)." >&2
+    printf '%s' "$primary" | python3 -c '
+import json, sys
+raw = sys.stdin.read()
+try:
+    d = json.loads(raw)
+    res = d["result"]
+    data = res.get("data")
+    if not isinstance(data, dict):
+        data = {}; res["data"] = data
+    data["wake"] = {"ok": False, "error": sys.argv[1]}
+    json.dump(d, sys.stdout)
+except Exception:
+    sys.stdout.write(raw)
+' "wake_failed_after_${WAKE_PRIMARY_OP:-primary}"
+    return 3
+  fi
   printf '%s\v%s' "$primary" "$wresp" | python3 -c '
 import json, sys
 primary, _, wake = sys.stdin.read().partition("\v")
@@ -971,8 +1045,9 @@ case "$sub" in
     extra=""
     if [ "$POS_SEEN" -eq 1 ]; then extra="\"url\":$(json_str "$POS")"; fi
     if [ -n "$WAKE" ]; then
+      _reject_frame_with_wake open
       resp="$(cmd_op open "$extra")" || exit 1
-      _wake_after "$resp" | pretty
+      WAKE_PRIMARY_OP=open WAKE_PRIMARY_VERB="been opened" _wake_after "$resp" | pretty
     else
       cmd_op open "$extra" | pretty
     fi
@@ -1298,8 +1373,11 @@ sys.stdout.write(json.dumps(fields)[1:-1])
     [ "$POS_SEEN" -eq 1 ] || die "usage: browser nav <url> [--wake[=MS]]"
     url="$(json_str "$POS")"
     if [ -n "$WAKE" ]; then
+      _reject_frame_with_wake nav
       resp="$(cmd_op nav "\"url\":${url}")" || exit 1
-      _wake_after "$resp" | pretty
+      # pipefail (set at the top) carries _wake_after's rc 3 through `| pretty`,
+      # and this is the last command of the arm, so it becomes the script's status.
+      WAKE_PRIMARY_OP=nav WAKE_PRIMARY_VERB=navigated _wake_after "$resp" | pretty
     else
       cmd_op nav "\"url\":${url}" | pretty
     fi

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -752,7 +752,30 @@ cmd_op() {
       _explain_instance_failure "$resp" "$INSTANCE" no_extension
       die "op '$op' not dispatched: no extension connected"
       ;;
-    504) echo "$resp" >&2; die "timeout waiting for the extension to answer (is Brave focused / responsive?)" ;;
+    504)
+      # `ping` needs its OWN wording. It runs on a SHORT deadline
+      # (BROWSER_BRIDGE_PING_TIMEOUT, default 10s) and the extension's poll loop is
+      # strictly SERIAL, so a ping queued behind another session's in-flight op
+      # times out while the profile is perfectly healthy. The generic message —
+      # "is Brave focused / responsive?" — points at a stale/dead extension, whose
+      # documented remedy is a FULL Brave restart of the operator's LIVE session.
+      # Sending someone there on a false negative is the worst outcome this command
+      # has, so the ping wording must NOT imply it.
+      if [ "$op" = "ping" ]; then
+        echo "browser: ping timed out on its SHORT deadline (BROWSER_BRIDGE_PING_TIMEOUT, default 10s)." >&2
+        echo "browser:   This does NOT mean the extension is stale, wedged or dead." >&2
+        echo "browser:   The extension runs ONE command at a time, so a ping queued behind" >&2
+        echo "browser:   another session's op (a heavy nav, a --fullpage screenshot) times out" >&2
+        echo "browser:   here while the profile is perfectly healthy." >&2
+        echo "browser:   DO THIS FIRST: wait for the other op to finish and re-run the ping." >&2
+        echo "browser:   Only if it fails again on an IDLE profile is the build actually suspect." >&2
+        echo "browser:   For a host that runs long ops concurrently, raise" >&2
+        echo "browser:   BROWSER_BRIDGE_PING_TIMEOUT on the browser-bridge service and restart it." >&2
+        echo "$resp" >&2
+        die "ping timed out (see above) — do NOT restart Brave on the strength of this alone"
+      fi
+      echo "$resp" >&2; die "timeout waiting for the extension to answer (is Brave focused / responsive?)"
+      ;;
     401) die "unauthorized — token mismatch (re-paste the token in the extension options)" ;;
     429)
       # rate_limited / queue_full — the per-instance concurrency backstop is

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -785,7 +785,15 @@ import json, re, sys
 raw, _, err = sys.stdin.read().partition("\v")
 
 def classify(text):
-    """The machine-readable cause, from cmd_op stderr it already emits.
+    """The machine-readable cause, from the stderr `cmd_op` already emits.
+
+    WORDING IS LOAD-BEARING HERE: the dispatch helper is named in BACKTICKS with
+    a word BEFORE it, never followed directly by a bare word. The surface-parity
+    gate harvests wire ops by matching that helper name followed by whitespace and
+    an identifier, and it skips only lines whose first non-space char is `#` — a
+    docstring line is not one. Prose of the form "<helper> stderr" is therefore
+    harvested as a phantom wire op and reddens the MERGED tree while this branch
+    and the gate branch are each green alone.
 
     Order matters: the op-level line is the most specific, then the server body
     that the HTTP branches echo verbatim, then a last-resort token.
@@ -793,6 +801,16 @@ def classify(text):
     m = re.search(r"op \x27\w+\x27 failed in the browser: (.+)", text)
     if m:
         return m.group(1).strip()
+    # `unknown_op` is the ODD ONE OUT and the most likely --wake failure in this
+    # repo, whose recurring hazard is a stale loaded extension. Its branch does
+    # NOT use the "failed in the browser:" prefix and, unlike every other branch,
+    # does not echo the server body — so without this arm the single PERMANENT
+    # cause (do NOT retry; reload the extension) degraded to the generic token,
+    # which is exactly the transient-vs-permanent distinction the exit-3 contract
+    # promises the caller can make.
+    m = re.search(r"returned (unknown_op)", text)
+    if m:
+        return m.group(1)
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("{"):
@@ -887,10 +905,12 @@ cmd_op() {
       die "op '$op' not dispatched: no extension connected"
       ;;
     504)
-      # `ping` needs its OWN wording. It runs on a SHORT deadline
-      # (BROWSER_BRIDGE_PING_TIMEOUT, default 10s) and the extension's poll loop is
-      # strictly SERIAL, so a ping queued behind another session's in-flight op
-      # times out while the profile is perfectly healthy. The generic message —
+      # `ping` needs its OWN wording. Its deadline is CONDITIONAL, not a constant:
+      # the server gives it a short one (BROWSER_BRIDGE_PING_TIMEOUT, default 2s)
+      # only while the instance has nothing in flight, and derives it from the work
+      # in flight otherwise. Because the extension's poll loop is strictly SERIAL a
+      # ping can still time out behind a deep queue while the profile is perfectly
+      # healthy. The generic message —
       # "is Brave focused / responsive?" — points at a stale/dead extension, whose
       # documented remedy is a FULL Brave restart of the operator's LIVE session.
       # Sending someone there on a false negative is the worst outcome this command

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -218,6 +218,17 @@
 #
 # Output is JSON on stdout (pretty-printed if `jq` is present). Exit non-zero on
 # transport/HTTP error so a caller can branch.
+#
+# EXIT CODES
+#   0  success
+#   1  the command failed — nothing was applied, or the primary op itself failed
+#   3  ONLY from `nav --wake` / `open --wake`: the nav/open SUCCEEDED and only the
+#      wake follow-up failed. The tab HAS navigated and its JSON is still on
+#      stdout, with `result.data.wake = {"ok":false,"error":"<real cause>"}`.
+#      Branch on 3 rather than treating it as a plain failure — and read that
+#      `error` to tell a transient cause (`rate_limited`) from a permanent one
+#      (`wake_with_frame_unsupported`). On success `result.data.wake.ok` is true,
+#      so `ok` is always present in both shapes.
 set -uo pipefail
 
 HOST="${BROWSER_BRIDGE_HOST:-127.0.0.1}"
@@ -743,33 +754,71 @@ _wake_after() {
   # branch even mentioned `wake`, so the operator could not tell WHICH half failed.
   #
   # Now: capture the wake's status, always emit the primary JSON, attach the wake
-  # outcome under result.data.wake (ok:false + the error), and exit 3 — a DISTINCT
-  # code meaning "the primary op succeeded, only the --wake follow-up failed", so a
-  # caller can branch on it instead of guessing. cmd_op's own stderr diagnostics
-  # (429/504/op-level) are untouched and still printed above ours.
-  local wresp wrc
-  wresp="$(cmd_op wake "$wextra")"; wrc=$?
+  # outcome under result.data.wake, and exit 3 — a DISTINCT code meaning "the
+  # primary op succeeded, only the --wake follow-up failed", so a caller can branch
+  # on it instead of guessing.
+  #
+  # 🔴 THE ATTACHED `error` IS THE REAL CAUSE, not a placeholder. It first carried
+  # a constant ("wake_failed_after_nav"), which is worse than useless: a script
+  # reading `.result.data.wake.error` could not tell a TRANSIENT `rate_limited`
+  # (retry) from a PERMANENT `wake_with_frame_unsupported` (do not), and the actual
+  # reason existed only in unstructured stderr. cmd_op already prints the server's
+  # raw body for the HTTP failures and names the op-level error in its die message,
+  # so stderr is captured, RE-EMITTED VERBATIM (nothing is hidden from the reader)
+  # and then classified into the machine-readable token.
+  local wresp wrc werrf
+  werrf="$(mktemp -t browser-wake-err.XXXXXX)" || werrf=""
+  if [ -n "$werrf" ]; then
+    wresp="$(cmd_op wake "$wextra" 2>"$werrf")"; wrc=$?
+    cat "$werrf" >&2                       # verbatim; capture must not swallow it
+  else
+    wresp="$(cmd_op wake "$wextra")"; wrc=$?
+  fi
   if [ "$wrc" -ne 0 ]; then
     echo "browser: the '${WAKE_PRIMARY_OP:-primary}' op SUCCEEDED — only the --wake follow-up failed (see above)." >&2
     echo "browser:   The tab HAS ${WAKE_PRIMARY_VERB:-been acted on}; its JSON is on stdout with result.data.wake.ok=false." >&2
     echo "browser:   The page may still be throttled/unrendered: re-run 'browser wake' when ready." >&2
     echo "browser:   Exit code 3 = primary ok, wake failed (rc 1 would mean the whole command failed)." >&2
-    printf '%s' "$primary" | python3 -c '
-import json, sys
-raw = sys.stdin.read()
+    printf '%s\v%s' "$primary" "$(cat "${werrf:-/dev/null}" 2>/dev/null)" | python3 -c '
+import json, re, sys
+
+raw, _, err = sys.stdin.read().partition("\v")
+
+def classify(text):
+    """The machine-readable cause, from cmd_op stderr it already emits.
+
+    Order matters: the op-level line is the most specific, then the server body
+    that the HTTP branches echo verbatim, then a last-resort token.
+    """
+    m = re.search(r"op \x27\w+\x27 failed in the browser: (.+)", text)
+    if m:
+        return m.group(1).strip()
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                e = json.loads(line).get("error")
+            except Exception:
+                continue
+            if e:
+                return str(e)
+    return "wake_failed"
+
 try:
     d = json.loads(raw)
     res = d["result"]
     data = res.get("data")
     if not isinstance(data, dict):
         data = {}; res["data"] = data
-    data["wake"] = {"ok": False, "error": sys.argv[1]}
+    data["wake"] = {"ok": False, "error": classify(err)}
     json.dump(d, sys.stdout)
 except Exception:
     sys.stdout.write(raw)
-' "wake_failed_after_${WAKE_PRIMARY_OP:-primary}"
+'
+    [ -n "$werrf" ] && rm -f "$werrf"
     return 3
   fi
+  [ -n "$werrf" ] && rm -f "$werrf"
   printf '%s\v%s' "$primary" "$wresp" | python3 -c '
 import json, sys
 primary, _, wake = sys.stdin.read().partition("\v")
@@ -788,7 +837,18 @@ if not isinstance(data, dict):
     res["data"] = data
 wres = w.get("result") if isinstance(w, dict) else None
 wdata = wres.get("data") if isinstance(wres, dict) else None
-data["wake"] = wdata if isinstance(wdata, dict) else {"applied": True}
+# 🔴 SHAPE-SYMMETRIC WITH THE FAILURE BRANCH: `ok` is ALWAYS present.
+# The wake payload from the extension has no `ok` key, so writing it raw made
+# `if (data.wake.ok)` falsy on every SUCCESSFUL wake and forced callers into
+# the undiscoverable negative `wake.ok !== false`. Three shapes existed (raw
+# data / {"applied":true} / {"ok":false,...}); now there are two, differing
+# only in the value of `ok`.
+# Assigned AFTER the copy so ours wins deterministically even if a future
+# extension build starts sending an `ok` of its own.
+# (No apostrophes in this block — it is inside python3 -c SINGLE quotes.)
+w_out = dict(wdata) if isinstance(wdata, dict) else {"applied": True}
+w_out["ok"] = True
+data["wake"] = w_out
 json.dump(d, sys.stdout)
 '
 }
@@ -836,15 +896,16 @@ cmd_op() {
       # Sending someone there on a false negative is the worst outcome this command
       # has, so the ping wording must NOT imply it.
       if [ "$op" = "ping" ]; then
-        echo "browser: ping timed out on its SHORT deadline (BROWSER_BRIDGE_PING_TIMEOUT, default 10s)." >&2
-        echo "browser:   This does NOT mean the extension is stale, wedged or dead." >&2
-        echo "browser:   The extension runs ONE command at a time, so a ping queued behind" >&2
-        echo "browser:   another session's op (a heavy nav, a --fullpage screenshot) times out" >&2
-        echo "browser:   here while the profile is perfectly healthy." >&2
-        echo "browser:   DO THIS FIRST: wait for the other op to finish and re-run the ping." >&2
-        echo "browser:   Only if it fails again on an IDLE profile is the build actually suspect." >&2
-        echo "browser:   For a host that runs long ops concurrently, raise" >&2
-        echo "browser:   BROWSER_BRIDGE_PING_TIMEOUT on the browser-bridge service and restart it." >&2
+        echo "browser: ping timed out. The server gives ping a SHORT deadline only when the" >&2
+        echo "browser:   profile has nothing in flight; while it is busy the deadline is derived" >&2
+        echo "browser:   from that work, so this is NOT simply 'you were too impatient'." >&2
+        echo "browser:   Two things still produce it:" >&2
+        echo "browser:     1. the extension really is wedged (its service worker took a command" >&2
+        echo "browser:        and blew its own 18s execution budget), or" >&2
+        echo "browser:     2. several concurrent ops from other sessions queued ahead of it." >&2
+        echo "browser:   DO THIS FIRST: if anything else is driving this profile, let it finish" >&2
+        echo "browser:   and re-run. A repeat failure on an OTHERWISE IDLE profile is the real" >&2
+        echo "browser:   signal — then, and only then, suspect the loaded build." >&2
         echo "$resp" >&2
         die "ping timed out (see above) — do NOT restart Brave on the strength of this alone"
       fi

--- a/scripts/browser-bridge/reference/errors.md
+++ b/scripts/browser-bridge/reference/errors.md
@@ -14,6 +14,12 @@ should strand you.
 
 - `503 extension_not_connected` → extension not loaded/paired, or Brave closed.
 - `504 timeout` → extension picked it up but didn't answer (tab unresponsive).
+  **Exception — `ping`.** It runs on a SHORT deadline
+  (`BROWSER_BRIDGE_PING_TIMEOUT`, default 10s) and the extension executes ONE
+  command at a time, so a ping queued behind another session's heavy `nav` /
+  `--fullpage screenshot` times out while the profile is perfectly healthy. Wait
+  for the other op and re-run. **A ping 504 is not evidence of a stale build and is
+  not a reason to restart Brave** — only a repeat failure on an IDLE profile is.
 - `429 rate_limited` / `429 queue_full` → the per-instance concurrency backstop is
   shedding load — you're dispatching too fast / too many at once. **Back off and
   retry** (the body carries a `retry_after` seconds hint). A normal handful of ops
@@ -25,7 +31,21 @@ should strand you.
 - `409 ambiguous_instance` → >1 instance connected and no `--instance` — pick one.
 - `409 no_owned_tab` → `close` with nothing to close — run `browser open` first (or `--tab`).
 - `409 superseded` → the instance was replaced by a newer connection; retry.
-- `404 unknown_instance` → the `--instance` key matches no connected instance.
+- `404 unknown_instance` → **read which of the two the CLI printed — they need
+  OPPOSITE actions.** The status is the same for both; the message is not.
+  - *"instance 'X' is **KNOWN but NOT CONNECTED**"* → your label is **right**; that
+    Brave profile dropped its long-poll. **FULLY RESTART Brave** (a
+    `brave://extensions` reload often no-ops). **Do NOT retry** — it fails
+    identically until the profile reconnects. Measured 2026-08-02: 48 of 52
+    `unknown_instance` failures used the CORRECT label, and `eval` was re-issued
+    **37 times** against it because the old single message read as "wrong label".
+  - *"instance 'X' is **UNKNOWN**"* → nothing has ever registered that key. Wrong
+    label (or that profile was never wired up); the CLI lists the keys it has seen.
+  Both print the dropped profiles' `last seen` + `last unanswered op` — that names
+  whether a profile died mid-op or went quiet while idle.
+- `503 extension_not_connected` → same split: *"HAS seen …"* means it was wired up
+  and dropped (restart Brave, stop retrying); *"has EVER connected"* means load the
+  extension and paste the token.
 - `400 unknown_op` / `missing_field:url|js` → bad command.
 - `op '<op>' failed in the browser: unknown_op` (op-level — the CLI knows the op
   but the **extension** doesn't) → the loaded extension is an older build. See the

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -76,9 +76,14 @@ Config (env):
                                  "is the loaded extension current?" — so on an
                                  idle instance it must answer "no" fast. When the
                                  instance has work in flight the deadline is
-                                 DERIVED from that work instead (never above
-                                 CMD_TIMEOUT) so a busy profile is never reported
-                                 as dead — see Registry._effective_timeout_locked.
+                                 DERIVED from that work instead, so ordinary
+                                 concurrency does not report a busy profile as
+                                 dead. NOT unconditional: the derived budget is
+                                 still capped at CMD_TIMEOUT, so more than
+                                 CMD_TIMEOUT of legitimate serial work (N>=2 busy
+                                 commands) can still time a ping out — raise
+                                 CMD_TIMEOUT if that is your workload. See
+                                 Registry._effective_timeout_locked.
                                  Applies to `ping` ONLY.
     BROWSER_BRIDGE_POLL_TIMEOUT  seconds a /poll blocks before 204 (default 25)
     BROWSER_BRIDGE_RATE_PER_SEC  per-instance sustained /cmd dispatch rate
@@ -213,6 +218,26 @@ EXEC_OP_BUDGET_S = 18.0
 # Slack added on top of the execution budget to cover the result POST and the
 # next poll turnaround (RESULT_BUDGET_MS is 10s but a healthy POST is ms).
 WEDGE_GRACE_S = 2.0
+
+# The extension's own bound on posting a result back (RESULT_BUDGET_MS in
+# extension/protocol.js). Mirrored for the same reason as EXEC_OP_BUDGET_S, and
+# pinned against protocol.js by test_result_budget_matches_the_extension.
+RESULT_BUDGET_S = 10.0
+
+# How long an `inflight` entry can still describe a command a healthy extension
+# might be working on. After EXEC + RESULT the extension has certainly either
+# answered or given up, so an entry older than this says nothing about current
+# business and is disregarded (and pruned).
+#
+# 🔴 THIS IS WHY AN ABANDONED COMMAND IS NOT SIMPLY DROPPED. The SUBMITTER giving
+# up (BridgeTimeout at cmd_timeout, default 20s) does NOT free the extension —
+# its serial loop keeps executing that command for up to EXEC(18) + RESULT(10) =
+# 28s, which is LONGER than cmd_timeout. Popping the entry at submitter-exit
+# therefore made the instance look IDLE while it was provably still busy, and the
+# next `ping` fast-failed against a healthy extension (measured; in that window it
+# was worse than both the old flat 20s and the interim flat 10s). The entry is kept
+# and expires on its own instead.
+INFLIGHT_STALE_S = EXEC_OP_BUDGET_S + RESULT_BUDGET_S
 
 # `ping`'s own /cmd deadline, in seconds. NOT a bare literal at the call site and
 # NOT sharing CMD_TIMEOUT: `ping` is the documented FIRST thing you run when you
@@ -1142,6 +1167,15 @@ class Registry:
                     inst.results[cid] = payload
                     self._cond.notify_all()
                     return True
+            # No live submitter — but this may be the ABANDONED command whose
+            # inflight entry we deliberately kept (see INFLIGHT_STALE_S). The reply
+            # proves the extension is free again, so release it NOW instead of
+            # waiting out the staleness window: that is the difference between the
+            # next ping fast-failing correctly and being told to wait for nothing.
+            for inst in candidates:
+                if inst.inflight.pop(cid, None) is not None:
+                    log("result_after_abandon", id=cid, instance_id=instance_id)
+                    break
             return False
 
     def _effective_timeout_locked(self, inst, timeout, fast_timeout):
@@ -1167,11 +1201,23 @@ class Registry:
                                 take N * EXEC_OP_BUDGET_S; subtract how long the
                                 oldest has already been outstanding.
 
+        Entries older than INFLIGHT_STALE_S are DISREGARDED (and pruned): past that
+        point a healthy extension has certainly answered or given up, so the entry
+        no longer describes current business. This is also what bounds an abandoned
+        command's influence — see INFLIGHT_STALE_S for why abandoning does not drop
+        the entry outright.
+
         CLAMPED ON BOTH SIDES, and both clamps are load-bearing:
           * never above `timeout` (cmd_timeout) — so this can NEVER be slower than
-            the behaviour that predates the whole fast-ping change;
-          * never below `fast_timeout` — so a wedged instance whose budget has gone
-            negative still gets its full fast deadline rather than an instant fail.
+            the behaviour that predates the whole fast-ping change. `fast_timeout`
+            is clamped into that range FIRST: both it and cmd_timeout are
+            operator-settable (BROWSER_BRIDGE_PING_TIMEOUT / _CMD_TIMEOUT) and
+            nothing validates the relation, so a fast_timeout ABOVE cmd_timeout
+            would otherwise escape the ceiling through the lower clamp below
+            (measured: fast=60 / cmd=20 returned 60.0).
+          * never below the (clamped) `fast_timeout` — so a wedged instance whose
+            budget has gone negative still gets its full fast deadline rather than
+            an instant fail.
 
         WHY NOT `inst.last_dispatch`, which looks like it carries the same fact:
         it is overwritten by every new enqueue, so it names the NEWEST outstanding
@@ -1182,11 +1228,27 @@ class Registry:
         """
         if fast_timeout is None:
             return timeout
+        # 🟢-D: clamp the operator-settable fast deadline into [.., timeout] BEFORE
+        # it is used, so the "never above cmd_timeout" claim holds unconditionally.
+        fast = min(fast_timeout, timeout)
+        now = self._clock()
+        self._prune_inflight_locked(inst, now)
         if not inst.inflight:
-            return fast_timeout
-        age = self._clock() - min(inst.inflight.values())
+            return fast
+        age = now - min(inst.inflight.values())
         budget = len(inst.inflight) * EXEC_OP_BUDGET_S + WEDGE_GRACE_S - age
-        return max(fast_timeout, min(timeout, budget))
+        return max(fast, min(timeout, budget))
+
+    @staticmethod
+    def _prune_inflight_locked(inst, now):
+        """Drop `inflight` entries too old to describe current business.
+
+        Bounded by INFLIGHT_STALE_S. Also the memory bound for entries left behind
+        by an abandoned command whose result never arrives.
+        """
+        stale = [c for c, t in inst.inflight.items() if now - t > INFLIGHT_STALE_S]
+        for c in stale:
+            del inst.inflight[c]
 
     # --- concurrency backstop (per-instance rate limit + queue-depth cap) --- #
     def _admit_locked(self, inst: Instance):
@@ -1250,7 +1312,9 @@ class Registry:
 
         `fast_timeout` (used only by `ping`) asks for a SHORTER deadline when the
         target instance has nothing in flight, so a wedge is reported quickly
-        without ever false-negativing a busy one. See _effective_timeout_locked —
+        without false-negativing a busy one under ordinary concurrency (the derived
+        budget is still capped at `timeout`, so >`timeout` of legitimate serial work
+        can still time it out). See _effective_timeout_locked —
         that is where the invariant lives.
         """
         op = command.get("op")
@@ -1286,6 +1350,10 @@ class Registry:
             # Declared BEFORE the try so the finally can always reference it: the
             # FIFO wait can raise before a cid exists.
             cid = None
+            # Set when THIS submitter gives up on a command the extension has
+            # already taken. See INFLIGHT_STALE_S: abandoning does not free the
+            # extension, so the inflight entry must OUTLIVE us and expire on age.
+            abandoned_running = False
             if tab_key is not None:
                 self._tab_queues.setdefault(tab_key, deque()).append(ticket)
             try:
@@ -1319,8 +1387,12 @@ class Registry:
                 inst.outbox.append(cmd)
                 inst.waiters.add(cid)
                 # Outstanding-work clock for _effective_timeout_locked. Released
-                # in the finally below, paired exactly like `pending`.
-                inst.inflight[cid] = self._clock()
+                # in the finally below, paired exactly like `pending`. Prune here
+                # too so entries left behind by abandoned commands cannot pile up
+                # on an instance that never receives another ping.
+                _now = self._clock()
+                self._prune_inflight_locked(inst, _now)
+                inst.inflight[cid] = _now
                 # Remember what we handed this instance. Cleared only when a
                 # RESULT comes back, so if the instance goes silent this field
                 # still names the command it never answered — the single fact
@@ -1334,6 +1406,17 @@ class Registry:
                     remaining = deadline - self._clock()
                     if remaining <= 0:
                         inst.waiters.discard(cid)
+                        # Was it still QUEUED, or already taken by the extension?
+                        # Queued  -> it will never run; dropping it frees the slot
+                        #            honestly and the instance really is that much
+                        #            less busy.
+                        # Taken   -> the extension is executing it RIGHT NOW and
+                        #            will be for up to EXEC+RESULT. We are leaving,
+                        #            but the work is not: keep the inflight entry so
+                        #            the instance does not read as idle, and let it
+                        #            expire on age (INFLIGHT_STALE_S).
+                        abandoned_running = not any(c.get("id") == cid
+                                                    for c in inst.outbox)
                         inst.outbox = deque(c for c in inst.outbox
                                             if c.get("id") != cid)
                         raise BridgeTimeout()
@@ -1351,11 +1434,15 @@ class Registry:
                 # pending bump) on EVERY exit — normal return, timeout, or
                 # supersede — so the depth cap can never leak a phantom slot.
                 inst.pending -= 1
-                # Same structural pairing for the outstanding-work clock. A
-                # stranded `inflight` entry would be WORSE than a stranded pending
-                # slot: it would make the instance look permanently busy, and
-                # `ping` would never fast-fail on that instance again.
-                if cid is not None:
+                # Same structural pairing for the outstanding-work clock — EXCEPT
+                # when we abandoned a command the extension had already taken. Then
+                # the work outlives this submitter and the entry must too, or the
+                # instance reads as idle while it is provably still executing.
+                # A stranded entry would be worse than a stranded pending slot (the
+                # instance would look busy forever and `ping` could never fast-fail
+                # again), which is why the surviving entry is bounded by age rather
+                # than left to a result that may never come.
+                if cid is not None and not abandoned_running:
                     inst.inflight.pop(cid, None)
                 # (3) Leave the turnstile and wake the next in line.
                 if tab_key is not None:

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -70,15 +70,16 @@ Config (env):
     BROWSER_BRIDGE_PORT          bind port (default 8788 — must NOT be 8787)
     BROWSER_BRIDGE_TOKEN_FILE    token path (default ~/.config/browser-bridge/token)
     BROWSER_BRIDGE_CMD_TIMEOUT   seconds a /cmd waits for a result (default 20)
-    BROWSER_BRIDGE_PING_TIMEOUT  seconds a `ping` /cmd waits (default 10). `ping`
-                                 is the DIAGNOSTIC op — the thing you run FIRST to
-                                 ask "is the loaded extension current?" — so it
-                                 must answer "no" faster than the generic 20s.
-                                 It must NOT go below the longest a HEALTHY
-                                 extension can be busy, or a busy profile reports
-                                 as dead; see PING_TIMEOUT_DEFAULT for the full
-                                 invariant. Applies to `ping` ONLY; every other op
-                                 keeps CMD_TIMEOUT.
+    BROWSER_BRIDGE_PING_TIMEOUT  seconds a `ping` /cmd waits when the target
+                                 instance is IDLE (default 2). `ping` is the
+                                 DIAGNOSTIC op — the thing you run FIRST to ask
+                                 "is the loaded extension current?" — so on an
+                                 idle instance it must answer "no" fast. When the
+                                 instance has work in flight the deadline is
+                                 DERIVED from that work instead (never above
+                                 CMD_TIMEOUT) so a busy profile is never reported
+                                 as dead — see Registry._effective_timeout_locked.
+                                 Applies to `ping` ONLY.
     BROWSER_BRIDGE_POLL_TIMEOUT  seconds a /poll blocks before 204 (default 25)
     BROWSER_BRIDGE_RATE_PER_SEC  per-instance sustained /cmd dispatch rate
                                  (token-bucket refill, default 5; 0 → unlimited)
@@ -201,6 +202,18 @@ MAX_RESULT_BODY = 32 * 1024 * 1024  # a screenshot data URL can be a few MB.
 # A connection is considered "present" if a long-poll landed within this window.
 CONNECT_STALE_S = 40.0
 
+# The extension's own hard self-bound on ONE command's execution
+# (EXEC_OP_BUDGET_MS in extension/protocol.js). `execute()` never exceeds it and
+# never throws, so it is the yardstick for "could a healthy extension still
+# legitimately be working on this?". Mirrored here rather than imported because
+# the two live in different languages/processes; `test_exec_budget_matches_the_
+# extension` reads protocol.js and fails if they ever drift.
+EXEC_OP_BUDGET_S = 18.0
+
+# Slack added on top of the execution budget to cover the result POST and the
+# next poll turnaround (RESULT_BUDGET_MS is 10s but a healthy POST is ms).
+WEDGE_GRACE_S = 2.0
+
 # `ping`'s own /cmd deadline, in seconds. NOT a bare literal at the call site and
 # NOT sharing CMD_TIMEOUT: `ping` is the documented FIRST thing you run when you
 # suspect the loaded extension is stale, and a diagnostic that takes 20s to say
@@ -208,43 +221,27 @@ CONNECT_STALE_S = 40.0
 # 34 pings, 13 failures (38.2% — the worst rate of any op), of which 6 timed out at
 # exactly 20,000ms; the 21 healthy ones averaged 3-4ms.
 #
-# 🔴 THE INVARIANT THIS VALUE MUST SATISFY — not the number, the property:
+# 🔴 THIS IS THE IDLE DEADLINE ONLY. It is NOT a tuned value that has to dominate
+# every op's ceiling — the BUSY case is handled STRUCTURALLY, in submit()'s
+# `fast_timeout` gate, which is where the real invariant lives. Read that first.
 #
-#   PING_TIMEOUT_DEFAULT  >  the longest a HEALTHY extension can be busy with a
-#                            command the CLI is able to ASK FOR.
+# The distinction the gate draws:
+#   * instance has NO outstanding command  -> a ping that does not answer in 2s is
+#     genuine evidence of a wedged/dead service worker. Fail FAST. Healthy pings
+#     measured at 3-4ms, so 2s is ~500x headroom.
+#   * instance HAS outstanding work        -> the poll loop is serial, so the ping
+#     simply cannot be dequeued yet. Waiting is CORRECT; the deadline is derived
+#     from the work in flight, never from this constant.
 #
-# because the extension's poll loop is strictly SERIAL (service_worker.js: `await
-# execute()` -> `await postResult()` -> next `pollOnce()`). `ping` skips the
-# per-tab FIFO but still cannot be DEQUEUED until the running command finishes. So
-# a deadline below that bound reports a perfectly healthy, merely BUSY profile as
-# dead — and the documented remedy for "dead" is a FULL Brave restart of the
-# operator's live session. That is a far worse outcome than waiting.
+# So this value never has to exceed ACTIVATE_WAIT_MAX_MS / CDP_OP_BUDGET_MS /
+# EXEC_OP_BUDGET_MS — a previous revision of this comment claimed it did, and was
+# wrong twice over (it named 8s as "the caller-requestable ceiling" while both
+# `screenshot --fullpage` at 15s and `wake --wait 6000` composed with an 8s CDP
+# attach exceed it). Deriving the deadline from observed in-flight work removes
+# the whole class instead of trying to out-bid it.
 #
-# The bounds, from extension/protocol.js:
-#   ACTIVATE_WAIT_MAX_MS  8s   <- the largest wait the CLI can request (`activate
-#                                 --wait 8000`); WAKE_SETTLE_MAX_MS is 6s
-#   CDP_OP_BUDGET_MS     15s   <- a CDP-routed op's own budget
-#   EXEC_OP_BUDGET_MS    18s   <- execute()'s hard self-bound; nothing exceeds it
-#
-# 10s is chosen as the smallest value ABOVE the 8s caller-requestable ceiling, with
-# ~2s of slack for the result POST + poll turnaround. It is ~2500x the 3-4ms
-# healthy path and halves the old 20s failure path.
-#
-# ⚠ RESIDUAL, stated rather than hidden: 10s < EXEC_OP_BUDGET_MS, so a preceding op
-# that legitimately runs 10-18s (a heavy CDP screenshot) can STILL time a ping out.
-# Only >=18s would eliminate the class, and that is the 20s this exists to avoid.
-# The mitigation is that the timeout MESSAGE for `ping` now says the extension may
-# be busy and explicitly refuses to recommend a Brave restart — see the CLI's 504
-# branch. Raise BROWSER_BRIDGE_PING_TIMEOUT on the browser-bridge service if your
-# workload runs long ops concurrently.
-#
-# ✗ REJECTED ALTERNATIVE (do not re-derive it): "use the short deadline only when
-# the instance is idle, escalate to cmd_timeout when it is busy." `inst.pending`
-# cannot distinguish BUSY from WEDGED — a wedged extension is precisely one that
-# took a command and never answered, i.e. pending > 0 — so the escalation would
-# fire in exactly the case the short deadline exists for, and `ping` would be back
-# to 20s whenever it mattered.
-PING_TIMEOUT_DEFAULT = 10.0
+# Override with BROWSER_BRIDGE_PING_TIMEOUT (raises the IDLE deadline only).
+PING_TIMEOUT_DEFAULT = 2.0
 
 
 def _env_float(name: str, default: float) -> float:
@@ -883,7 +880,7 @@ class Instance:
                  "active_polls", "last_poll", "active_tab", "superseded",
                  "pending", "rl_tokens", "rl_last", "extension_version",
                  "extension_id", "last_poll_wall", "lost_logged",
-                 "last_dispatch")
+                 "last_dispatch", "inflight")
 
     def __init__(self, key, instance_id, label, now, burst=0.0,
                  extension_version=None, extension_id=None):
@@ -923,7 +920,17 @@ class Instance:
         # The last command handed to this instance that has NOT produced a result:
         # {"id","op","at"} or None. This is the field that would have NAMED
         # `frames` as the wedging op on 2026-07-29 without any code-reading.
+        # ⚠ DIAGNOSTIC ONLY — do NOT do deadline math on it. It is overwritten by
+        # each new enqueue (so it names the NEWEST outstanding command, not the
+        # oldest) and its `at` is wall-clock `time.time()`, not the registry's
+        # injectable monotonic clock. `inflight` below is the field for timing.
         self.last_dispatch = None
+        # cid -> MONOTONIC enqueue reading, for every command handed to this
+        # instance that has not yet produced a result. Unlike `last_dispatch` this
+        # keeps EVERY outstanding command, so `min(...)` is the age of the oldest
+        # one — which is what tells a legitimately BUSY extension apart from a
+        # WEDGED one (see Registry.submit's `fast_timeout`).
+        self.inflight: dict[str, float] = {}
 
 
 class Registry:
@@ -1137,6 +1144,50 @@ class Registry:
                     return True
             return False
 
+    def _effective_timeout_locked(self, inst, timeout, fast_timeout):
+        """The deadline for a command that wants to FAIL FAST on a wedge without
+        false-negativing a merely BUSY extension. Returns `timeout` unchanged when
+        `fast_timeout` is None (every op except `ping`).
+
+        🔴 THIS IS THE REAL INVARIANT behind the ping deadline. The extension's
+        poll loop is strictly SERIAL (service_worker.js: `await execute()` ->
+        `await postResult()` -> next `pollOnce()`), so `ping` skips the per-tab
+        FIFO but still cannot be DEQUEUED until the work ahead of it finishes.
+        Timing out while that work is legitimately in progress reports a healthy
+        profile as dead — and the documented remedy for "dead" is a FULL Brave
+        restart of the operator's live session.
+
+        The signal is `inst.inflight`: every command handed to this instance that
+        has not produced a result, stamped on the registry's MONOTONIC clock.
+          * empty            -> nothing can be ahead of the ping. A ping that then
+                                fails to answer within `fast_timeout` IS the wedge.
+          * non-empty        -> allow the work in flight its own budget. Each
+                                command is self-bounded by EXEC_OP_BUDGET_S, and
+                                they drain serially, so N of them can legitimately
+                                take N * EXEC_OP_BUDGET_S; subtract how long the
+                                oldest has already been outstanding.
+
+        CLAMPED ON BOTH SIDES, and both clamps are load-bearing:
+          * never above `timeout` (cmd_timeout) — so this can NEVER be slower than
+            the behaviour that predates the whole fast-ping change;
+          * never below `fast_timeout` — so a wedged instance whose budget has gone
+            negative still gets its full fast deadline rather than an instant fail.
+
+        WHY NOT `inst.last_dispatch`, which looks like it carries the same fact:
+        it is overwritten by every new enqueue, so it names the NEWEST outstanding
+        command rather than the oldest — a fresh enqueue behind a wedged one makes
+        the wedge look young. Its `at` is also wall-clock `time.time()`, not this
+        clock, so it cannot be compared against a monotonic deadline (and an NTP
+        step would move it). It stays a DIAGNOSTIC field; `inflight` does timing.
+        """
+        if fast_timeout is None:
+            return timeout
+        if not inst.inflight:
+            return fast_timeout
+        age = self._clock() - min(inst.inflight.values())
+        budget = len(inst.inflight) * EXEC_OP_BUDGET_S + WEDGE_GRACE_S - age
+        return max(fast_timeout, min(timeout, budget))
+
     # --- concurrency backstop (per-instance rate limit + queue-depth cap) --- #
     def _admit_locked(self, inst: Instance):
         """Decide whether `inst` may accept ANOTHER /cmd dispatch RIGHT NOW.
@@ -1178,7 +1229,7 @@ class Registry:
 
     # --- skill side -------------------------------------------------------- #
     def submit(self, command: dict, timeout: float, target: str = None,
-               session_id=None, tab=None) -> dict:
+               session_id=None, tab=None, fast_timeout: float = None) -> dict:
         """Enqueue `command` (a dict without id) to the resolved target instance
         and block for its reply.
 
@@ -1196,10 +1247,18 @@ class Registry:
         BridgeSuperseded if the servicing instance is dropped mid-flight, or
         BridgeTimeout on no reply within `timeout` (the upper bound that keeps a
         FIFO-queued command from blocking forever).
+
+        `fast_timeout` (used only by `ping`) asks for a SHORTER deadline when the
+        target instance has nothing in flight, so a wedge is reported quickly
+        without ever false-negativing a busy one. See _effective_timeout_locked —
+        that is where the invariant lives.
         """
         op = command.get("op")
         with self._cond:
             inst = self._resolve_target_locked(target)
+            # BEFORE our own enqueue: the work already in flight is what decides
+            # whether a stalled reply means "wedged" or "not our turn yet".
+            timeout = self._effective_timeout_locked(inst, timeout, fast_timeout)
             tab_id, tab_key = self._effective_tab_locked(inst, op, session_id,
                                                          tab)
             # Concurrency backstop: admit (or 429) BEFORE joining the turnstile,
@@ -1224,6 +1283,9 @@ class Registry:
                                                       touch=False)
             deadline = self._clock() + timeout
             ticket = object()
+            # Declared BEFORE the try so the finally can always reference it: the
+            # FIFO wait can raise before a cid exists.
+            cid = None
             if tab_key is not None:
                 self._tab_queues.setdefault(tab_key, deque()).append(ticket)
             try:
@@ -1256,6 +1318,9 @@ class Registry:
                     cmd["reuseTabId"] = reuse_tab_id
                 inst.outbox.append(cmd)
                 inst.waiters.add(cid)
+                # Outstanding-work clock for _effective_timeout_locked. Released
+                # in the finally below, paired exactly like `pending`.
+                inst.inflight[cid] = self._clock()
                 # Remember what we handed this instance. Cleared only when a
                 # RESULT comes back, so if the instance goes silent this field
                 # still names the command it never answered — the single fact
@@ -1286,6 +1351,12 @@ class Registry:
                 # pending bump) on EVERY exit — normal return, timeout, or
                 # supersede — so the depth cap can never leak a phantom slot.
                 inst.pending -= 1
+                # Same structural pairing for the outstanding-work clock. A
+                # stranded `inflight` entry would be WORSE than a stranded pending
+                # slot: it would make the instance look permanently busy, and
+                # `ping` would never fast-fail on that instance again.
+                if cid is not None:
+                    inst.inflight.pop(cid, None)
                 # (3) Leave the turnstile and wake the next in line.
                 if tab_key is not None:
                     q = self._tab_queues.get(tab_key)
@@ -2027,13 +2098,15 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                     domain="", exit_code=0)
                 return
             try:
-                # `ping` alone gets the short deadline. Chosen HERE rather than
-                # inside submit() so the choice is visible next to the op, and so
-                # no other op's timeout can be changed by accident.
-                op_timeout = ping_timeout if op == "ping" else cmd_timeout
-                result = registry.submit(body, timeout=op_timeout,
-                                         target=target, session_id=session_id,
-                                         tab=tab)
+                # `ping` alone asks for the fast-fail-when-idle deadline. Named
+                # HERE so no other op can pick it up by accident; the decision of
+                # what it actually resolves to is _effective_timeout_locked's,
+                # because only that runs under the lock that can read in-flight
+                # work. Every other op passes fast_timeout=None and is untouched.
+                result = registry.submit(
+                    body, timeout=cmd_timeout, target=target,
+                    session_id=session_id, tab=tab,
+                    fast_timeout=(ping_timeout if op == "ping" else None))
             except RateLimited as e:
                 # Per-instance concurrency backstop tripped. Distinct structured
                 # log + a telemetry event carrying a COARSE session hash so the

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -1174,6 +1174,13 @@ class Registry:
             # next ping fast-failing correctly and being told to wait for nothing.
             for inst in candidates:
                 if inst.inflight.pop(cid, None) is not None:
+                    # It DID answer, so `last_dispatch` — whose contract is "the
+                    # command it never answered", surfaced by health/whoami — must
+                    # stop naming it. The normal path clears it on the same
+                    # condition; this branch is simply where the abandoned command
+                    # reaches the same state.
+                    if (inst.last_dispatch or {}).get("id") == cid:
+                        inst.last_dispatch = None
                     log("result_after_abandon", id=cid, instance_id=instance_id)
                     break
             return False
@@ -1241,12 +1248,36 @@ class Registry:
 
     @staticmethod
     def _prune_inflight_locked(inst, now):
-        """Drop `inflight` entries too old to describe current business.
+        """Drop `inflight` entries that can no longer describe current business.
 
-        Bounded by INFLIGHT_STALE_S. Also the memory bound for entries left behind
-        by an abandoned command whose result never arrives.
+        TWO conditions, and the second is not optional:
+
+        (a) older than INFLIGHT_STALE_S, AND
+        (b) NO live submitter is still blocked on it (`cid not in inst.waiters`).
+
+        🔴 WHY (b). INFLIGHT_STALE_S is measured from ENQUEUE, but a queued
+        command's EXEC_OP_BUDGET_S does not start until the SERIAL extension
+        dequeues it. So age alone says nothing about whether a healthy extension is
+        done — precisely when N >= 2, which is the case the `len(inst.inflight) *
+        EXEC_OP_BUDGET_S` term above exists to model. Measured with the injected
+        clock: 3 commands, cmd_timeout=60, age 29s -> all three pruned while their
+        submitters were still blocked, the instance read IDLE, and `ping` fast-
+        failed at 2s while the extension legitimately had ~25s of work left. That
+        is the exact workload the docstring at BROWSER_BRIDGE_CMD_TIMEOUT tells an
+        operator to raise cmd_timeout for, so the advice made it worse.
+
+        `waiters` is exactly "a submitter is still blocked on this cid": added at
+        enqueue, discarded on all three exits of the wait loop, and discarded again
+        in submit()'s finally so an unexpected raise cannot strand one.
+
+        THE MEMORY BOUND IS NOT WEAKENED, it is split by owner:
+          * live-submitter entries are bounded by that submitter's own deadline —
+            it unwinds through the finally, which pops the entry;
+          * abandoned entries have no one to bound them, which is what
+            INFLIGHT_STALE_S is for.
         """
-        stale = [c for c, t in inst.inflight.items() if now - t > INFLIGHT_STALE_S]
+        stale = [c for c, t in inst.inflight.items()
+                 if now - t > INFLIGHT_STALE_S and c not in inst.waiters]
         for c in stale:
             del inst.inflight[c]
 
@@ -1444,6 +1475,15 @@ class Registry:
                 # than left to a result that may never come.
                 if cid is not None and not abandoned_running:
                     inst.inflight.pop(cid, None)
+                # `waiters` is discarded on all three exits of the wait loop above;
+                # this is the SAFETY NET that makes it structurally leak-proof, like
+                # `pending`. It matters because the staleness prune now reads
+                # `waiters` as "is a submitter still blocked on this?" — an entry
+                # stranded by an unexpected raise inside the loop would otherwise be
+                # exempt from pruning forever. discard() is idempotent, so this is a
+                # no-op on every normal path.
+                if cid is not None:
+                    inst.waiters.discard(cid)
                 # (3) Leave the turnstile and wake the next in line.
                 if tab_key is not None:
                     q = self._tab_queues.get(tab_key)

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -70,6 +70,15 @@ Config (env):
     BROWSER_BRIDGE_PORT          bind port (default 8788 — must NOT be 8787)
     BROWSER_BRIDGE_TOKEN_FILE    token path (default ~/.config/browser-bridge/token)
     BROWSER_BRIDGE_CMD_TIMEOUT   seconds a /cmd waits for a result (default 20)
+    BROWSER_BRIDGE_PING_TIMEOUT  seconds a `ping` /cmd waits (default 2). `ping` is
+                                 the DIAGNOSTIC op — the thing you run FIRST to ask
+                                 "is the loaded extension current?" — so it must
+                                 answer "no" fast. Measured 2026-08-02: a 38%
+                                 failure rate, and every failure burned the full
+                                 20s CMD_TIMEOUT while 21 healthy pings averaged
+                                 3-4ms. 2s is ~500x headroom over the healthy path.
+                                 Applies to `ping` ONLY; every other op keeps
+                                 CMD_TIMEOUT.
     BROWSER_BRIDGE_POLL_TIMEOUT  seconds a /poll blocks before 204 (default 25)
     BROWSER_BRIDGE_RATE_PER_SEC  per-instance sustained /cmd dispatch rate
                                  (token-bucket refill, default 5; 0 → unlimited)
@@ -191,6 +200,30 @@ MAX_RESULT_BODY = 32 * 1024 * 1024  # a screenshot data URL can be a few MB.
 
 # A connection is considered "present" if a long-poll landed within this window.
 CONNECT_STALE_S = 40.0
+
+# `ping`'s own /cmd deadline, in seconds. NOT a bare literal at the call site and
+# NOT sharing CMD_TIMEOUT: `ping` is the documented FIRST thing you run when you
+# suspect the loaded extension is stale, and a diagnostic that takes 20s to say
+# "no" is one an operator learns to skip. MEASURED 2026-08-02 over a 2-day window:
+# 34 pings, 13 failures (38.2% — the worst rate of any op), of which 6 timed out at
+# exactly 20,000ms; the 21 healthy ones averaged 3-4ms. 2s leaves ~500x headroom
+# over the healthy path while capping the failure path at a tenth of what it was.
+# Override with BROWSER_BRIDGE_PING_TIMEOUT (e.g. a slow/loaded host).
+PING_TIMEOUT_DEFAULT = 2.0
+
+
+def _env_float(name: str, default: float) -> float:
+    """A float from the environment, falling back to `default` on absent OR
+    unparseable. A malformed knob must not stop the bridge from starting — a
+    typo'd BROWSER_BRIDGE_PING_TIMEOUT would otherwise take the whole service
+    down at import time with a ValueError."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
 
 # How long a routing key stays in `known_instances`/`missing` after it stops
 # polling. Without a forget path the registry remembers every key for the whole
@@ -683,6 +716,20 @@ def emit_cmd_event(op: str, key: str, outcome: str, duration_ms: int,
         })
     except Exception:  # noqa: BLE001 — strictly best-effort.
         pass
+
+
+def _emit_diag_event(op: str, t0: float) -> None:
+    """One metadata-only event for a read-only DIAGNOSTIC GET (/whoami, /health).
+
+    A thin, deliberately narrow wrapper over emit_cmd_event: op + outcome + latency
+    and NOTHING else. No key (these endpoints take no --instance) and NO domain —
+    they are global, describing every connected profile at once, so there is no
+    single active domain to attribute and emitting per-profile domains would widen
+    the privacy contract. Best-effort like every other emit: it cannot raise.
+    """
+    emit_cmd_event(op=op, key="", outcome="ok",
+                   duration_ms=int((time.monotonic() - t0) * 1000),
+                   domain="", exit_code=0)
 
 
 # --------------------------------------------------------------------------- #
@@ -1635,7 +1682,15 @@ def validate_command(body):
 # HTTP handler
 # --------------------------------------------------------------------------- #
 def make_handler(registry: Registry, token: str, cmd_timeout: float,
-                 poll_timeout: float):
+                 poll_timeout: float, ping_timeout: float = None):
+    # `ping` gets its OWN, much shorter deadline — see PING_TIMEOUT_DEFAULT and the
+    # BROWSER_BRIDGE_PING_TIMEOUT entry in the module docstring. Resolved here (not
+    # at the call site) so build_server callers that predate the parameter keep
+    # working and still get the fast ping.
+    if ping_timeout is None:
+        ping_timeout = _env_float("BROWSER_BRIDGE_PING_TIMEOUT",
+                                  PING_TIMEOUT_DEFAULT)
+
     class Handler(BaseHTTPRequestHandler):
         server_version = "browser-bridge/2"
 
@@ -1798,6 +1853,7 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
         def do_GET(self):
             if not self._guard():
                 return
+            t0 = time.monotonic()
             path = urlsplit(self.path).path
             if path == "/health":
                 # extension_version_current = the manifest version the SERVER
@@ -1824,6 +1880,20 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                                  "instances": insts,
                                  "known_instances": known,
                                  "missing": missing})
+                # The ORIENTATION ops emit too — measured 2026-08-02, `whoami`
+                # (38 calls) and `health` (15) appeared NOWHERE in activity.events
+                # despite being the documented first thing you run, so the only
+                # structured source could not see 53 invocations.
+                #
+                # Emitted AFTER the response, exactly like the /cmd path: same
+                # best-effort + metadata-only contract (see emit_cmd_event and the
+                # PRIVACY CONTRACT above). Deliberately NO domain: /health and
+                # /whoami are GLOBAL — they describe every connected profile at
+                # once, so there is no single active domain to attribute, and
+                # emitting one per profile would widen the contract to "which sites
+                # are open in each of your browsers". `key` is likewise empty:
+                # these endpoints take no --instance.
+                _emit_diag_event("health", t0)
                 return
             if path == "/instances":
                 insts = registry.snapshot()
@@ -1832,6 +1902,7 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                 return
             if path == "/whoami":
                 self._send(200, self._whoami())
+                _emit_diag_event("whoami", t0)   # see the /health emit above
                 return
             if path == "/poll":
                 (instance_id, label, active, ext_version,
@@ -1921,7 +1992,11 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                     domain="", exit_code=0)
                 return
             try:
-                result = registry.submit(body, timeout=cmd_timeout,
+                # `ping` alone gets the short deadline. Chosen HERE rather than
+                # inside submit() so the choice is visible next to the op, and so
+                # no other op's timeout can be changed by accident.
+                op_timeout = ping_timeout if op == "ping" else cmd_timeout
+                result = registry.submit(body, timeout=op_timeout,
                                          target=target, session_id=session_id,
                                          tab=tab)
             except RateLimited as e:
@@ -2046,8 +2121,10 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
 # Entrypoint
 # --------------------------------------------------------------------------- #
 def build_server(host: str, port: int, registry: Registry, token: str,
-                 cmd_timeout: float, poll_timeout: float) -> ThreadingHTTPServer:
-    handler = make_handler(registry, token, cmd_timeout, poll_timeout)
+                 cmd_timeout: float, poll_timeout: float,
+                 ping_timeout: float = None) -> ThreadingHTTPServer:
+    handler = make_handler(registry, token, cmd_timeout, poll_timeout,
+                           ping_timeout)
     server = ThreadingHTTPServer((host, port), handler)
     server.daemon_threads = True  # let shutdown not hang on a blocked long-poll
     return server
@@ -2094,13 +2171,17 @@ def main(argv=None) -> int:
     port = int(os.environ.get("BROWSER_BRIDGE_PORT", "8788"))
     cmd_timeout = float(os.environ.get("BROWSER_BRIDGE_CMD_TIMEOUT", "20"))
     poll_timeout = float(os.environ.get("BROWSER_BRIDGE_POLL_TIMEOUT", "25"))
+    ping_timeout = _env_float("BROWSER_BRIDGE_PING_TIMEOUT",
+                              PING_TIMEOUT_DEFAULT)
     token_file = default_token_file()
     token = load_or_create_token(token_file)
 
     registry = Registry()
-    server = build_server(host, port, registry, token, cmd_timeout, poll_timeout)
+    server = build_server(host, port, registry, token, cmd_timeout,
+                          poll_timeout, ping_timeout)
     log("listening", host=host, port=port, token_file=str(token_file),
-        cmd_timeout=cmd_timeout, poll_timeout=poll_timeout)
+        cmd_timeout=cmd_timeout, poll_timeout=poll_timeout,
+        ping_timeout=ping_timeout)
     _warn_poll_timeout_vs_extension_budget(poll_timeout)
     try:
         server.serve_forever()

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -70,15 +70,15 @@ Config (env):
     BROWSER_BRIDGE_PORT          bind port (default 8788 — must NOT be 8787)
     BROWSER_BRIDGE_TOKEN_FILE    token path (default ~/.config/browser-bridge/token)
     BROWSER_BRIDGE_CMD_TIMEOUT   seconds a /cmd waits for a result (default 20)
-    BROWSER_BRIDGE_PING_TIMEOUT  seconds a `ping` /cmd waits (default 2). `ping` is
-                                 the DIAGNOSTIC op — the thing you run FIRST to ask
-                                 "is the loaded extension current?" — so it must
-                                 answer "no" fast. Measured 2026-08-02: a 38%
-                                 failure rate, and every failure burned the full
-                                 20s CMD_TIMEOUT while 21 healthy pings averaged
-                                 3-4ms. 2s is ~500x headroom over the healthy path.
-                                 Applies to `ping` ONLY; every other op keeps
-                                 CMD_TIMEOUT.
+    BROWSER_BRIDGE_PING_TIMEOUT  seconds a `ping` /cmd waits (default 10). `ping`
+                                 is the DIAGNOSTIC op — the thing you run FIRST to
+                                 ask "is the loaded extension current?" — so it
+                                 must answer "no" faster than the generic 20s.
+                                 It must NOT go below the longest a HEALTHY
+                                 extension can be busy, or a busy profile reports
+                                 as dead; see PING_TIMEOUT_DEFAULT for the full
+                                 invariant. Applies to `ping` ONLY; every other op
+                                 keeps CMD_TIMEOUT.
     BROWSER_BRIDGE_POLL_TIMEOUT  seconds a /poll blocks before 204 (default 25)
     BROWSER_BRIDGE_RATE_PER_SEC  per-instance sustained /cmd dispatch rate
                                  (token-bucket refill, default 5; 0 → unlimited)
@@ -206,10 +206,45 @@ CONNECT_STALE_S = 40.0
 # suspect the loaded extension is stale, and a diagnostic that takes 20s to say
 # "no" is one an operator learns to skip. MEASURED 2026-08-02 over a 2-day window:
 # 34 pings, 13 failures (38.2% — the worst rate of any op), of which 6 timed out at
-# exactly 20,000ms; the 21 healthy ones averaged 3-4ms. 2s leaves ~500x headroom
-# over the healthy path while capping the failure path at a tenth of what it was.
-# Override with BROWSER_BRIDGE_PING_TIMEOUT (e.g. a slow/loaded host).
-PING_TIMEOUT_DEFAULT = 2.0
+# exactly 20,000ms; the 21 healthy ones averaged 3-4ms.
+#
+# 🔴 THE INVARIANT THIS VALUE MUST SATISFY — not the number, the property:
+#
+#   PING_TIMEOUT_DEFAULT  >  the longest a HEALTHY extension can be busy with a
+#                            command the CLI is able to ASK FOR.
+#
+# because the extension's poll loop is strictly SERIAL (service_worker.js: `await
+# execute()` -> `await postResult()` -> next `pollOnce()`). `ping` skips the
+# per-tab FIFO but still cannot be DEQUEUED until the running command finishes. So
+# a deadline below that bound reports a perfectly healthy, merely BUSY profile as
+# dead — and the documented remedy for "dead" is a FULL Brave restart of the
+# operator's live session. That is a far worse outcome than waiting.
+#
+# The bounds, from extension/protocol.js:
+#   ACTIVATE_WAIT_MAX_MS  8s   <- the largest wait the CLI can request (`activate
+#                                 --wait 8000`); WAKE_SETTLE_MAX_MS is 6s
+#   CDP_OP_BUDGET_MS     15s   <- a CDP-routed op's own budget
+#   EXEC_OP_BUDGET_MS    18s   <- execute()'s hard self-bound; nothing exceeds it
+#
+# 10s is chosen as the smallest value ABOVE the 8s caller-requestable ceiling, with
+# ~2s of slack for the result POST + poll turnaround. It is ~2500x the 3-4ms
+# healthy path and halves the old 20s failure path.
+#
+# ⚠ RESIDUAL, stated rather than hidden: 10s < EXEC_OP_BUDGET_MS, so a preceding op
+# that legitimately runs 10-18s (a heavy CDP screenshot) can STILL time a ping out.
+# Only >=18s would eliminate the class, and that is the 20s this exists to avoid.
+# The mitigation is that the timeout MESSAGE for `ping` now says the extension may
+# be busy and explicitly refuses to recommend a Brave restart — see the CLI's 504
+# branch. Raise BROWSER_BRIDGE_PING_TIMEOUT on the browser-bridge service if your
+# workload runs long ops concurrently.
+#
+# ✗ REJECTED ALTERNATIVE (do not re-derive it): "use the short deadline only when
+# the instance is idle, escalate to cmd_timeout when it is busy." `inst.pending`
+# cannot distinguish BUSY from WEDGED — a wedged extension is precisely one that
+# took a command and never answered, i.e. pending > 0 — so the escalation would
+# fire in exactly the case the short deadline exists for, and `ping` would be back
+# to 20s whenever it mattered.
+PING_TIMEOUT_DEFAULT = 10.0
 
 
 def _env_float(name: str, default: float) -> float:

--- a/scripts/browser-bridge/tests/test_browser_cli_args.py
+++ b/scripts/browser-bridge/tests/test_browser_cli_args.py
@@ -431,6 +431,40 @@ def test_help_does_not_require_a_token_file(tmp_path):
         assert "token file" not in cp.stderr, args
 
 
+def test_help_prints_the_HEADER_block_only_not_the_whole_files_comments(tmp_path):
+    """REGRESSION. `--help` was `grep -E '^#( |$)' "$0"` — EVERY column-0 comment
+    in the file, so it shipped 25,440 bytes of implementation commentary against a
+    ~15 KB header, and it grew with every internal comment anyone wrote.
+
+    Pinned three ways, because a size bound alone is a weak claim:
+      * the header's own landmarks are present (it did not over-trim);
+      * comments that live BELOW the first line of code are absent;
+      * `--help` stops at the first non-comment line.
+    """
+    env = dict(os.environ,
+               BROWSER_BRIDGE_TOKEN_FILE=str(tmp_path / "absent"))
+    cp = subprocess.run(["bash", str(CLI), "--help"], env=env,
+                        capture_output=True, text=True, timeout=60)
+    assert cp.returncode == 0, cp.stderr
+
+    # Landmarks from the header block — the help must still be the real help.
+    for needle in ("FLAG ORDER / END OF FLAGS", "browser nav <url> [--wake[=MS]]",
+                   "Global flags (before the subcommand)"):
+        assert needle in cp.stdout, needle
+
+    # Implementation commentary lives after `set -uo pipefail`, the first line of
+    # code. These strings are all in the file and must NOT be in --help.
+    src = CLI.read_text(encoding="utf-8")
+    for needle in ("wake_fields WAKE WAITMS", "cmd_op OP [EXTRA_JSON_FIELDS]",
+                   "_wake_flag ARG", "strict=validate"):
+        assert needle in src, f"{needle} vanished from the source; retarget this test"
+        assert needle not in cp.stdout, f"--help leaked an internal comment: {needle}"
+
+    # And it genuinely stops at the code: the header ends right before this line.
+    header = src.split("\nset -uo pipefail", 1)[0]
+    assert len(cp.stdout) < len(header), "help is larger than the header block"
+
+
 def test_an_unknown_subcommand_is_reported_as_such_without_a_token(tmp_path):
     """A typo must not be reported as a missing token. This is what still failed
     the hermetic gate after the --help fix: `browser bogus-op` in a sandbox with

--- a/scripts/browser-bridge/tests/test_browser_cli_args.py
+++ b/scripts/browser-bridge/tests/test_browser_cli_args.py
@@ -130,6 +130,78 @@ def bridge(tmp_path):
         srv.server_close()
 
 
+@pytest.fixture
+def wake_fails(tmp_path):
+    """A stub bridge where the PRIMARY op succeeds and the `wake` op FAILS.
+
+    `responder(op)` decides the wake failure mode per test: an op-level
+    `ok:false` envelope, or a raw HTTP status (429 / 504). Everything else gets a
+    normal success envelope carrying a tabId, so the test can prove the primary
+    result survived.
+    """
+    mode = {"wake": ("op_error", "wake_with_frame_unsupported: un-throttling is "
+                                 "tab-level, not per-frame")}
+
+    class _H(BaseHTTPRequestHandler):
+        bodies: list = []
+
+        def _reply(self, code, payload):
+            raw = json.dumps(payload).encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+        def do_POST(self):
+            n = int(self.headers.get("Content-Length") or 0)
+            body = json.loads(self.rfile.read(n).decode())
+            self.bodies.append(body)
+            op = body.get("op")
+            if op == "wake":
+                kind, detail = mode["wake"]
+                if kind == "op_error":
+                    self._reply(200, {"ok": True, "result": {
+                        "id": "w", "ok": False, "error": detail}})
+                    return
+                self._reply(int(kind), {"ok": False, "error": detail})
+                return
+            self._reply(200, {"ok": True, "result": {
+                "id": "c", "ok": True,
+                "data": {"tabId": 4242, "url": "https://a.test"}}})
+
+        def log_message(self, *a):
+            pass
+
+    _H.bodies = []
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), _H)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    tokfile = tmp_path / "token"
+    tokfile.write_text("wake-fail-token\n")
+    env = dict(os.environ)
+    env.update({"BROWSER_BRIDGE_HOST": "127.0.0.1",
+                "BROWSER_BRIDGE_PORT": str(srv.server_address[1]),
+                "BROWSER_BRIDGE_TOKEN_FILE": str(tokfile),
+                "CLAUDE_CODE_SESSION_ID": "pytest-wake-fail",
+                "HOME": str(tmp_path)})
+
+    class _B:
+        bodies = _H.bodies
+
+        @staticmethod
+        def set_wake_failure(kind, detail):
+            mode["wake"] = (kind, detail)
+
+        @staticmethod
+        def run(*args):
+            return subprocess.run(["bash", str(CLI), *args], env=env,
+                                  capture_output=True, text=True, timeout=60)
+    try:
+        yield _B
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
 def _body(bridge, *args):
     """Run the CLI, assert it succeeded, return the single recorded /cmd body."""
     before = len(bridge.bodies)
@@ -410,6 +482,89 @@ def test_nav_and_open_still_reject_an_unknown_flag(bridge, sub):
     assert len(bridge.bodies) == before
 
 
+@pytest.mark.parametrize("sub", ["nav", "open"])
+@pytest.mark.parametrize("kind,detail", [
+    ("op_error", "wake_with_frame_unsupported: tab-level, not per-frame"),
+    ("429", "rate_limited"),
+    ("504", "timeout"),
+])
+def test_a_failing_wake_never_swallows_the_primary_result(wake_fails, sub,
+                                                          kind, detail):
+    """REGRESSION (adversarial audit of #278). The primary op ALREADY HAPPENED —
+    the tab really did navigate — so a failing `--wake` must not discard it.
+
+    The first cut used `|| exit 1`, which exited rc 1 with EMPTY stdout on all
+    three failure modes below. `T=$(browser nav --wake "$url")` then yielded an
+    empty T for a tab that exists, and only the op-level branch even mentioned
+    `wake`, so you could not tell WHICH half failed.
+
+    Pinned: the primary JSON survives with its tabId, the wake failure is attached
+    where a successful wake would have been reported, stderr says the primary
+    SUCCEEDED, and the exit code is the distinct 3 rather than the generic 1.
+    """
+    wake_fails.set_wake_failure(kind, detail)
+    r = wake_fails.run(sub, "https://a.test", "--wake")
+
+    out = json.loads(r.stdout)
+    assert out["result"]["data"]["tabId"] == 4242, (
+        "the primary result was swallowed — this is the whole bug")
+    assert out["result"]["data"]["wake"]["ok"] is False
+    assert out["result"]["ok"] is True, "the PRIMARY op did not fail"
+
+    assert "SUCCEEDED" in r.stderr and sub in r.stderr
+    assert "only the --wake follow-up failed" in r.stderr
+    assert r.returncode == 3, (
+        f"expected the distinct 'primary ok, wake failed' code 3, got "
+        f"{r.returncode}")
+
+    # Both ops really were attempted, in order.
+    assert [b["op"] for b in wake_fails.bodies] == [sub, "wake"]
+
+
+@pytest.mark.parametrize("sub", ["nav", "open"])
+def test_a_SUCCESSFUL_wake_still_exits_zero(wake_fails, sub, bridge):
+    """NEGATIVE CONTROL for the exit code above: without it, `return 3` could be
+    unconditional and every test above would still pass."""
+    r = bridge.run(sub, "https://a.test", "--wake")
+    assert r.returncode == 0, r.stderr
+    assert "SUCCEEDED" not in r.stderr
+    assert "wake" in json.loads(r.stdout)["result"]["data"]
+
+
+@pytest.mark.parametrize("sub", ["nav", "open"])
+def test_frame_plus_wake_is_refused_before_anything_reaches_the_wire(bridge, sub):
+    """A half-state this feature CREATED. `--frame` is a global flag that cmd_op
+    splices into every op; `nav`/`open` ignore it, but the standalone `wake` op is
+    refused by the extension's assertWakeNotFramed. So the composed form would
+    navigate and THEN fail the wake — half applied.
+
+    Before `--wake` existed on nav/open this was a hard parse error ("nav takes no
+    flags"), so the path did not exist; the feature is what opened it. Refuse it at
+    PARSE time, and prove NOTHING was sent — that is the difference between a
+    rejection and a half-applied command.
+    """
+    before = len(bridge.bodies)
+    cp = bridge.run("--frame", "child.test", sub, "https://a.test", "--wake")
+    assert cp.returncode != 0
+    assert "--frame and --wake cannot be combined" in cp.stderr
+    assert "nothing has been navigated or opened" in cp.stderr
+    assert len(bridge.bodies) == before, (
+        "a refusal must not put the primary op on the wire")
+
+
+@pytest.mark.parametrize("sub", ["nav", "open"])
+def test_frame_WITHOUT_wake_and_wake_WITHOUT_frame_both_still_work(bridge, sub):
+    """NEGATIVE CONTROL for the refusal: it must fire on the CONJUNCTION only.
+    A blanket "reject --frame on nav" or "reject --wake when FRAME is set anywhere"
+    would pass the test above while breaking two legitimate forms."""
+    before = len(bridge.bodies)
+    assert bridge.run("--frame", "child.test", sub, "https://a.test").returncode == 0
+    assert bridge.run(sub, "https://a.test", "--wake").returncode == 0
+    sent = bridge.bodies[before:]
+    assert [b["op"] for b in sent] == [sub, sub, "wake"]
+    assert sent[0]["frame"] == "child.test"      # --frame alone still threads
+
+
 def test_open_with_no_url_still_means_about_blank(bridge):
     """INVARIANT GUARD (green pre-change). `open` alone must keep sending a bare
     `{"op":"open"}` — POS_SEEN, not a non-empty test, is what distinguishes it from
@@ -463,6 +618,22 @@ def test_help_prints_the_HEADER_block_only_not_the_whole_files_comments(tmp_path
     # And it genuinely stops at the code: the header ends right before this line.
     header = src.split("\nset -uo pipefail", 1)[0]
     assert len(cp.stdout) < len(header), "help is larger than the header block"
+
+    # 🔴 PIN THE LAST LINE — an upper bound plus landmarks is NOT enough. `awk`
+    # exits at the first non-`#` line, so a blank line inserted anywhere in the
+    # final stretch of the header TRUNCATES --help from that point on, and every
+    # assertion above still passes (the landmarks sit further up, and a shorter
+    # output only makes the length bound more true). Deriving the expectation from
+    # the source rather than hard-coding it keeps this honest as the header grows.
+    expected_last = [ln[2:] if ln.startswith("# ") else ln[1:]
+                     for ln in header.splitlines()[1:] if ln.startswith("#")][-1]
+    assert cp.stdout.splitlines()[-1] == expected_last, (
+        "--help was truncated before the end of the header block (a blank/non-`#` "
+        "line in the header stops the awk)")
+    # The whole header, line for line — the strongest form of the same claim.
+    expected_all = [ln[2:] if ln.startswith("# ") else ln[1:]
+                    for ln in header.splitlines()[1:]]
+    assert cp.stdout.splitlines() == expected_all
 
 
 def test_an_unknown_subcommand_is_reported_as_such_without_a_token(tmp_path):

--- a/scripts/browser-bridge/tests/test_browser_cli_args.py
+++ b/scripts/browser-bridge/tests/test_browser_cli_args.py
@@ -326,14 +326,96 @@ def test_screenshot_rejects_an_explicitly_empty_path(bridge):
     assert cp.returncode != 0 and "must not be empty" in cp.stderr
 
 
-def test_nav_error_names_the_flag_not_the_innocent_url(bridge):
-    """`browser nav --wake <url>` is the flag-order confusion this PR is about;
-    pointing at the trailing url ("got extra: https://…") sends the reader to the
-    wrong argument."""
-    cp = bridge.run("nav", "--wake", "https://a.test")
+# --------------------------------------------------------------------------- #
+# S1 — `--wake[=MS]` on `nav` and `open` (2026-08-02 usage audit, F2)
+#
+# `browser nav --wake <url>` used to be a deliberate hard error ("nav takes no
+# flags — put the url first"). The audit measured why that was the wrong answer:
+# 13 `nav`→`wake` / `open`→`wake` adjacent pairs in Claude transcripts, and one
+# opencode session that is literally `nav wake eval` ×5. `nav` lands you on a
+# BACKGROUND (throttled) tab, so the wake is not optional — it was just a second
+# call. The flag is now real, and (like text/html/js) order-free.
+#
+# `nav`/`open` send NO `wake` field on the wire — the extension honours `cmd.wake`
+# only on getHtml/text/eval. `--wake` is a client-side compose: the nav/open op,
+# then the existing `wake` op. So these tests assert TWO recorded bodies.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("sub", ["nav", "open"])
+def test_wake_on_nav_and_open_issues_the_wake_in_one_invocation(bridge, sub):
+    """THE REGRESSION. Pre-change `nav --wake <url>` exited 1 with "takes no flags"
+    and `open --wake <url>` exited 1 with "at most one url"; neither could reach a
+    `wake` at all without a second command."""
+    before = len(bridge.bodies)
+    cp = bridge.run(sub, "https://a.test", "--wake")
+    assert cp.returncode == 0, cp.stderr
+    sent = bridge.bodies[before:]
+    assert [b["op"] for b in sent] == [sub, "wake"], sent
+    assert sent[0]["url"] == "https://a.test"
+    # The primary op's body is UNCHANGED — no `wake` field is put on the wire for
+    # nav/open, so no extension build can mis-handle it.
+    assert "wake" not in sent[0] and "waitMs" not in sent[0]
+    assert "waitMs" not in sent[1]          # bare --wake → extension's default settle
+
+
+@pytest.mark.parametrize("sub", ["nav", "open"])
+def test_wake_on_nav_and_open_is_order_free_and_carries_ms(bridge, sub):
+    """Flag order is free here exactly as it is for text/html/js, and `--wake=MS`
+    reaches the `wake` op as waitMs."""
+    before = len(bridge.bodies)
+    assert bridge.run(sub, "--wake=250", "https://a.test").returncode == 0
+    flags_first = bridge.bodies[before:]
+
+    before = len(bridge.bodies)
+    assert bridge.run(sub, "https://a.test", "--wake=250").returncode == 0
+    flags_last = bridge.bodies[before:]
+
+    assert flags_first == flags_last
+    assert [b["op"] for b in flags_first] == [sub, "wake"]
+    assert flags_first[1]["waitMs"] == 250
+
+
+@pytest.mark.parametrize("sub", ["nav", "open"])
+def test_no_wake_on_nav_and_open_sends_exactly_one_unchanged_command(bridge, sub):
+    """INVARIANT GUARD (green pre-change). The load-bearing back-compat half: with
+    no `--wake` the byte on the wire and the NUMBER of wire ops are what they were."""
+    before = len(bridge.bodies)
+    cp = bridge.run(sub, "https://a.test")
+    assert cp.returncode == 0, cp.stderr
+    sent = bridge.bodies[before:]
+    assert len(sent) == 1, sent
+    assert sent[0]["op"] == sub and sent[0]["url"] == "https://a.test"
+    assert "wake" not in sent[0]
+
+
+@pytest.mark.parametrize("sub", ["nav", "open"])
+def test_nav_and_open_validate_wake_ms_at_parse_time(bridge, sub):
+    """`--wake=MS` is validated in the FLAG LOOP, before anything is dispatched —
+    the same property wake_fields' comment protects for the read ops. A parse-time
+    rejection must leave the wire completely untouched (not "nav happened, then the
+    wake was rejected")."""
+    before = len(bridge.bodies)
+    cp = bridge.run(sub, "https://a.test", "--wake=abc")
     assert cp.returncode != 0
-    assert "takes no flags" in cp.stderr and "--wake" in cp.stderr
-    assert "Put the url first" in cp.stderr
+    assert "--wake=MS must be a non-negative integer" in cp.stderr
+    assert len(bridge.bodies) == before, "nothing may reach the wire"
+
+
+@pytest.mark.parametrize("sub", ["nav", "open"])
+def test_nav_and_open_still_reject_an_unknown_flag(bridge, sub):
+    """Gaining ONE flag must not turn these into "anything starting with - is fine"."""
+    before = len(bridge.bodies)
+    cp = bridge.run(sub, "https://a.test", "--nope")
+    assert cp.returncode != 0
+    assert "unknown flag" in cp.stderr
+    assert len(bridge.bodies) == before
+
+
+def test_open_with_no_url_still_means_about_blank(bridge):
+    """INVARIANT GUARD (green pre-change). `open` alone must keep sending a bare
+    `{"op":"open"}` — POS_SEEN, not a non-empty test, is what distinguishes it from
+    `open -- ''`."""
+    b = _body(bridge, "open")
+    assert b["op"] == "open" and "url" not in b
 
 
 def test_help_does_not_require_a_token_file(tmp_path):

--- a/scripts/browser-bridge/tests/test_browser_cli_args.py
+++ b/scripts/browser-bridge/tests/test_browser_cli_args.py
@@ -485,6 +485,12 @@ def test_nav_and_open_still_reject_an_unknown_flag(bridge, sub):
 @pytest.mark.parametrize("sub", ["nav", "open"])
 @pytest.mark.parametrize("kind,detail", [
     ("op_error", "wake_with_frame_unsupported: tab-level, not per-frame"),
+    # `unknown_op` is the ODD ONE OUT: its CLI branch neither uses the
+    # "failed in the browser:" prefix nor echoes the server body, so it was the
+    # ONE failure mode that still degraded to the generic token — and it is the
+    # most likely `--wake` failure in this repo (a stale loaded extension), and
+    # the PERMANENT one the exit-3 contract promises you can distinguish.
+    ("op_error", "unknown_op"),
     ("429", "rate_limited"),
     ("504", "timeout"),
 ])
@@ -515,7 +521,8 @@ def test_a_failing_wake_never_swallows_the_primary_result(wake_fails, sub,
     # "wake_failed_after_nav", which cannot distinguish a TRANSIENT `rate_limited`
     # (retry) from a PERMANENT `wake_with_frame_unsupported` (do not) — and a test
     # that only asserted `ok is False` structurally could not catch that.
-    expected = {"op_error": detail, "429": "rate_limited", "504": "timeout"}[kind]
+    expected = detail if kind == "op_error" else \
+        {"429": "rate_limited", "504": "timeout"}[kind]
     assert out["result"]["data"]["wake"]["error"] == expected, (
         out["result"]["data"]["wake"])
 
@@ -675,6 +682,50 @@ def test_help_does_not_require_a_token_file(tmp_path):
         assert cp.returncode == 0, f"{args}: {cp.stderr}"
         assert "FLAG ORDER / END OF FLAGS" in cp.stdout, args
         assert "token file" not in cp.stderr, args
+
+
+def test_no_prose_line_looks_like_a_wire_op_dispatch():
+    """🔴 REGRESSION, and it was invisible on this branch alone.
+
+    The surface-parity gate (arriving via #277) harvests wire ops from this file
+    with `findall(<dispatch-helper> + whitespace + identifier)` and skips only
+    lines whose first non-space char is `#`. A Python DOCSTRING line inside a
+    `python3 -c` block is not one — so the phrase "<helper> stderr" in a docstring
+    was harvested as a phantom wire op named `stderr` and reddened the MERGED tree
+    (1 failed / 424 passed) while both branches were green alone.
+
+    This is the same harvest, run locally, so the trap is caught on THIS side too
+    rather than depending on the other PR hardening its parser. Defence in depth is
+    the point: either fix alone closes it, and either alone can regress.
+
+    HARNESS NEGATIVE CONTROL is inline: the harvester must find a phantom in a
+    string that contains one, or its silence here means nothing.
+    """
+    import re
+    helper = "cmd" + "_op"          # not written as one token; see the docstring
+
+    def harvest(text):
+        out = set()
+        for ln in text.splitlines():
+            if ln.lstrip().startswith("#"):
+                continue
+            out.update(re.findall(r"\b%s\s+([A-Za-z]+)" % helper, ln))
+        return out
+
+    # NEGATIVE CONTROL: a docstring-style line with the offending shape MUST be
+    # harvested — otherwise a green verdict below is a fact about the harvester.
+    assert harvest('    """The cause, from %s stderr it emits."""' % helper) == \
+        {"stderr"}
+    assert harvest("# %s stderr in a real comment is skipped" % helper) == set()
+
+    src = CLI.read_text(encoding="utf-8")
+    real = set(re.search(r'^SUBCOMMANDS="([^"]+)"', src, re.M).group(1).split())
+    # The wire names the CLI dispatches that are not spelled like their subcommand.
+    real |= {"getHtml", "eval"}
+    phantom = harvest(src) - real
+    assert phantom == set(), (
+        f"prose in the CLI reads as a wire-op dispatch: {sorted(phantom)} — "
+        "reword it (name the helper in backticks, never followed by a bare word)")
 
 
 def test_help_prints_the_HEADER_block_only_not_the_whole_files_comments(tmp_path):

--- a/scripts/browser-bridge/tests/test_browser_cli_args.py
+++ b/scripts/browser-bridge/tests/test_browser_cli_args.py
@@ -511,6 +511,14 @@ def test_a_failing_wake_never_swallows_the_primary_result(wake_fails, sub,
     assert out["result"]["data"]["wake"]["ok"] is False
     assert out["result"]["ok"] is True, "the PRIMARY op did not fail"
 
+    # 🔴 THE REAL CAUSE, not a placeholder. This first shipped as the constant
+    # "wake_failed_after_nav", which cannot distinguish a TRANSIENT `rate_limited`
+    # (retry) from a PERMANENT `wake_with_frame_unsupported` (do not) — and a test
+    # that only asserted `ok is False` structurally could not catch that.
+    expected = {"op_error": detail, "429": "rate_limited", "504": "timeout"}[kind]
+    assert out["result"]["data"]["wake"]["error"] == expected, (
+        out["result"]["data"]["wake"])
+
     assert "SUCCEEDED" in r.stderr and sub in r.stderr
     assert "only the --wake follow-up failed" in r.stderr
     assert r.returncode == 3, (
@@ -524,11 +532,20 @@ def test_a_failing_wake_never_swallows_the_primary_result(wake_fails, sub,
 @pytest.mark.parametrize("sub", ["nav", "open"])
 def test_a_SUCCESSFUL_wake_still_exits_zero(wake_fails, sub, bridge):
     """NEGATIVE CONTROL for the exit code above: without it, `return 3` could be
-    unconditional and every test above would still pass."""
+    unconditional and every test above would still pass.
+
+    Also pins the SUCCESS SHAPE, which used to be asymmetric with the failure
+    shape. The extension's wake payload carries no `ok` key, so writing it raw
+    made `if (data.wake.ok)` falsy on every successful wake and forced callers
+    into the undiscoverable negative `wake.ok !== false`.
+    """
     r = bridge.run(sub, "https://a.test", "--wake")
     assert r.returncode == 0, r.stderr
     assert "SUCCEEDED" not in r.stderr
-    assert "wake" in json.loads(r.stdout)["result"]["data"]
+    wake = json.loads(r.stdout)["result"]["data"]["wake"]
+    assert wake["ok"] is True, (
+        "success and failure must be shape-symmetric — `ok` present in both")
+    assert "error" not in wake
 
 
 @pytest.mark.parametrize("sub", ["nav", "open"])
@@ -563,6 +580,80 @@ def test_frame_WITHOUT_wake_and_wake_WITHOUT_frame_both_still_work(bridge, sub):
     sent = bridge.bodies[before:]
     assert [b["op"] for b in sent] == [sub, sub, "wake"]
     assert sent[0]["frame"] == "child.test"      # --frame alone still threads
+
+
+@pytest.fixture
+def gateway_504(tmp_path):
+    """A stub bridge whose /cmd always answers 504 `timeout` — the shape the CLI
+    renders its op-aware timeout guidance from."""
+    class _H(BaseHTTPRequestHandler):
+        def do_POST(self):
+            n = int(self.headers.get("Content-Length") or 0)
+            self.rfile.read(n)
+            raw = json.dumps({"ok": False, "error": "timeout"}).encode()
+            self.send_response(504)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+        def log_message(self, *a):
+            pass
+
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), _H)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    tokfile = tmp_path / "token"
+    tokfile.write_text("t504\n")
+    env = dict(os.environ)
+    env.update({"BROWSER_BRIDGE_HOST": "127.0.0.1",
+                "BROWSER_BRIDGE_PORT": str(srv.server_address[1]),
+                "BROWSER_BRIDGE_TOKEN_FILE": str(tokfile),
+                "CLAUDE_CODE_SESSION_ID": "pytest-504",
+                "HOME": str(tmp_path)})
+
+    class _B:
+        @staticmethod
+        def run(*args):
+            return subprocess.run(["bash", str(CLI), *args], env=env,
+                                  capture_output=True, text=True, timeout=60)
+    try:
+        yield _B
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_a_ping_timeout_does_NOT_steer_the_operator_into_restarting_brave(
+        gateway_504):
+    """REGRESSION. `ping` runs on a deadline the generic 504 wording does not
+    describe, and that wording — "is Brave focused / responsive?" — points at a
+    dead extension, whose documented remedy is a FULL Brave restart of the
+    operator's LIVE session. A ping can time out with the profile perfectly
+    healthy (a wedge is one cause; a queue of concurrent ops is another).
+
+    This message is the entire mitigation for the disclosed residual, and NOTHING
+    pinned it: deleting the whole `if [ "$op" = "ping" ]` block left both suites
+    fully green.
+    """
+    r = gateway_504.run("ping")
+    assert r.returncode != 0
+    err = r.stderr
+    assert "do NOT restart Brave" in err, err
+    assert "queued ahead of it" in err, err
+    assert "OTHERWISE IDLE profile is the real" in err, err
+    # ...and it must NOT fall through to the generic wording, which is the bug.
+    assert "is Brave focused / responsive?" not in err, err
+
+
+def test_a_NON_ping_timeout_keeps_the_generic_wording(gateway_504):
+    """NEGATIVE CONTROL: without it the ping guidance could be printed for EVERY
+    op — which would be wrong (a `nav` timeout really does suggest an unresponsive
+    tab) and would make the test above pass for the wrong reason."""
+    r = gateway_504.run("tabs")
+    assert r.returncode != 0
+    err = r.stderr
+    assert "is Brave focused / responsive?" in err, err
+    assert "do NOT restart Brave" not in err, err
+    assert "queued ahead of it" not in err, err
 
 
 def test_open_with_no_url_still_means_about_blank(bridge):

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -165,9 +165,10 @@ def _req(srv, method, path, body=None, token=TOKEN, host="127.0.0.1",
         return e.code, (json.loads(raw) if raw else None)
 
 
-def _serve(cmd_timeout=5.0, poll_timeout=5.0, registry=None):
+def _serve(cmd_timeout=5.0, poll_timeout=5.0, registry=None, ping_timeout=None):
     registry = registry if registry is not None else S.Registry()
-    handler = S.make_handler(registry, TOKEN, cmd_timeout, poll_timeout)
+    handler = S.make_handler(registry, TOKEN, cmd_timeout, poll_timeout,
+                             ping_timeout)
     srv = S.ThreadingHTTPServer(("127.0.0.1", 0), handler)
     srv.daemon_threads = True
     t = threading.Thread(target=srv.serve_forever, daemon=True)
@@ -244,16 +245,46 @@ class FakeExtension(threading.Thread):
         self._stopev.set()
 
 
+# 🔴 _wait_connected POLLS /instances, NOT /health — and that is load-bearing.
+#
+# /health now emits ONE telemetry event per call (the orientation ops used to be
+# invisible in activity.events; see _emit_diag_event in server.py). This helper
+# calls it in a tight loop, so polling /health here injected 1..N spurious events
+# into the spool of EVERY test that waits for a connection — which is most of the
+# telemetry suite, and it broke 14 of them by making `len(evs) == 1` false.
+#
+# The fix is to make the HARNESS silent rather than to loosen those assertions:
+# /instances reports the same live-instance snapshot (`count` is len() of exactly
+# the list /health's `extension_connected` is the bool() of) and deliberately does
+# NOT emit — it is not an operator-facing orientation op. Keep it that way; if you
+# point this back at /health, the exact-count telemetry assertions go red again.
 def _wait_connected(srv, want=True, timeout=3.0):
     deadline = time.time() + timeout
     while time.time() < deadline:
-        status, body = _req(srv, "GET", "/health")
-        if status == 200 and body["extension_connected"] == want:
+        status, body = _req(srv, "GET", "/instances")
+        if status == 200 and bool(body.get("count", 0)) == want:
             return True
         time.sleep(0.02)
     return False
 
 
+# The SILENT (no-telemetry) counterpart of _wait_instances, for tests that only
+# need "N instances are up" and must not have /health events in their spool.
+def _wait_count(srv, n, timeout=3.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        status, body = _req(srv, "GET", "/instances")
+        if status == 200 and body.get("count", 0) >= n:
+            return body
+        time.sleep(0.02)
+    return None
+
+
+# _wait_instances stays on /health BECAUSE its callers read health-only fields
+# (`extension_connected`, `extension_version_current`, per-instance
+# `extension_stale`), which /instances does not compute. It therefore DOES emit —
+# so a telemetry test must use _wait_connected, or count only the ops it cares
+# about.
 def _wait_instances(srv, n, timeout=3.0):
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -1210,7 +1241,7 @@ def test_cmd_emits_routing_key_from_target(telemetry):
                       executor=lambda c: {"who": "b"})
     a.start(); b.start()
     try:
-        assert _wait_instances(srv, 2) is not None
+        assert _wait_count(srv, 2) is not None   # /instances: emits nothing
         st, _ = _req(srv, "POST", "/cmd", {"op": "tabs", "target": "alpha"})
         assert st == 200
         e = _wait_events(spool_dir, 1)[0]
@@ -1247,7 +1278,7 @@ def test_cmd_ambiguous_emits_ambiguous_outcome(telemetry):
     b = FakeExtension(srv, instance_id="b", label="beta")
     a.start(); b.start()
     try:
-        assert _wait_instances(srv, 2) is not None
+        assert _wait_count(srv, 2) is not None   # /instances: emits nothing
         st, _ = _req(srv, "POST", "/cmd", {"op": "tabs"})
         assert st == 409
         e = _wait_events(spool_dir, 1)[0]
@@ -1257,6 +1288,113 @@ def test_cmd_ambiguous_emits_ambiguous_outcome(telemetry):
         assert p["op"] == "tabs"
     finally:
         a.stop(); b.stop(); srv.shutdown(); srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# S2 — `ping` gets its OWN short deadline (2026-08-02 usage audit, F7)
+#
+# `ping` is the documented FIRST thing you run when you suspect the loaded
+# extension is stale. Measured over a 2-day window: 34 pings, 13 failures (38.2%,
+# the worst rate of any op), of which 6 timed out at EXACTLY 20,000 ms — the
+# generic CMD_TIMEOUT. The 21 healthy ones averaged 3–4 ms. A diagnostic that
+# takes 20 s to say "no" is one an operator learns to skip.
+#
+# These tests are WALL-CLOCK tests, so they use a deliberately wide margin: the
+# claim is "ping does not wait out cmd_timeout", not "ping takes exactly 2.0 s".
+# --------------------------------------------------------------------------- #
+def test_ping_does_not_wait_out_cmd_timeout(monkeypatch):
+    """REGRESSION. Pre-change `ping` used cmd_timeout like every other op, so
+    against a wedged extension it burned the full budget before answering."""
+    monkeypatch.delenv("BROWSER_BRIDGE_PING_TIMEOUT", raising=False)
+    # cmd_timeout is 8s; the default ping deadline is PING_TIMEOUT_DEFAULT (2s).
+    srv, _ = _serve(cmd_timeout=8.0, poll_timeout=5.0)
+    ext = FakeExtension(srv, swallow=True)       # picks up, never answers
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        t0 = time.monotonic()
+        st, body = _req(srv, "POST", "/cmd", {"op": "ping"})
+        elapsed = time.monotonic() - t0
+        assert st == 504 and body["error"] == "timeout"
+        # Red pre-change: this was ~8s (the full cmd_timeout).
+        assert elapsed < 5.0, f"ping waited {elapsed:.1f}s — cmd_timeout, not its own"
+        # ...and it did actually WAIT its own deadline rather than failing instantly
+        # for some unrelated reason (which would make the bound above vacuous).
+        assert elapsed >= 1.5, f"ping returned in {elapsed:.2f}s — it never waited"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_the_short_deadline_applies_to_ping_ONLY(monkeypatch):
+    """NEGATIVE CONTROL for the test above. Without this, a change that shortened
+    EVERY op's timeout would pass it — and that would be a real regression (a 2s
+    cap on `nav`/`eval` would break legitimate slow pages).
+
+    Same server, same wedged extension, a non-ping op: it must still wait out the
+    full cmd_timeout.
+    """
+    monkeypatch.delenv("BROWSER_BRIDGE_PING_TIMEOUT", raising=False)
+    srv, _ = _serve(cmd_timeout=4.0, poll_timeout=5.0)
+    ext = FakeExtension(srv, swallow=True)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        t0 = time.monotonic()
+        st, _ = _req(srv, "POST", "/cmd", {"op": "getHtml"})
+        elapsed = time.monotonic() - t0
+        assert st == 504
+        assert elapsed >= 3.5, (
+            f"getHtml returned in {elapsed:.2f}s — the short ping deadline leaked "
+            "onto every op")
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_a_healthy_ping_is_unaffected_and_answers_in_milliseconds(monkeypatch):
+    """NEGATIVE CONTROL #2: the 2 s cap must never truncate the HEALTHY path. 21
+    measured healthy pings averaged 3–4 ms, so 2 s is ~500× headroom — assert the
+    fast path still returns 200, not a timeout."""
+    monkeypatch.delenv("BROWSER_BRIDGE_PING_TIMEOUT", raising=False)
+    srv, _ = _serve(cmd_timeout=8.0, poll_timeout=5.0)
+    ext = FakeExtension(srv, executor=lambda c: {"pong": True})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        t0 = time.monotonic()
+        st, body = _req(srv, "POST", "/cmd", {"op": "ping"})
+        elapsed = time.monotonic() - t0
+        assert st == 200 and body["ok"] is True
+        assert elapsed < 1.0, f"a healthy ping took {elapsed:.2f}s"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_ping_timeout_is_env_overridable_and_survives_a_malformed_value(monkeypatch):
+    """The knob is BROWSER_BRIDGE_PING_TIMEOUT, not a bare literal — and a typo in
+    it must not take the bridge down at startup (a ValueError from float() would),
+    so an unparseable value falls back to the default."""
+    monkeypatch.setenv("BROWSER_BRIDGE_PING_TIMEOUT", "0.3")
+    assert S._env_float("BROWSER_BRIDGE_PING_TIMEOUT",
+                        S.PING_TIMEOUT_DEFAULT) == 0.3
+    srv, _ = _serve(cmd_timeout=8.0, poll_timeout=5.0)   # ping_timeout=None → env
+    ext = FakeExtension(srv, swallow=True)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        t0 = time.monotonic()
+        st, _ = _req(srv, "POST", "/cmd", {"op": "ping"})
+        elapsed = time.monotonic() - t0
+        assert st == 504
+        assert elapsed < 1.5, f"the env override was ignored ({elapsed:.2f}s)"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+    monkeypatch.setenv("BROWSER_BRIDGE_PING_TIMEOUT", "not-a-number")
+    assert S._env_float("BROWSER_BRIDGE_PING_TIMEOUT",
+                        S.PING_TIMEOUT_DEFAULT) == S.PING_TIMEOUT_DEFAULT
+    monkeypatch.delenv("BROWSER_BRIDGE_PING_TIMEOUT")
+    assert S._env_float("BROWSER_BRIDGE_PING_TIMEOUT",
+                        S.PING_TIMEOUT_DEFAULT) == S.PING_TIMEOUT_DEFAULT
 
 
 def test_cmd_timeout_emits_timeout_outcome(telemetry):
@@ -1361,20 +1499,85 @@ def test_cmd_succeeds_when_spool_unwritable(telemetry, monkeypatch, tmp_path):
         ext.stop(); srv.shutdown(); srv.server_close()
 
 
-def test_health_and_instances_do_not_emit(telemetry):
-    """health / instances (and the extension's /poll) are noise — no events."""
+def test_instances_and_poll_still_do_not_emit(telemetry):
+    """/instances and the extension's /poll are NOISE — still no events.
+
+    This is the half of the old `test_health_and_instances_do_not_emit` that
+    survives: /poll fires continuously (a long-poll per instance, forever) and
+    /instances is a machine-facing list, so emitting for either would swamp
+    activity.events with traffic no human initiated. Only the OPERATOR-facing
+    orientation ops (/whoami, /health) emit — see the two tests below.
+    """
     spool_dir = telemetry
     srv, _ = _serve(poll_timeout=5.0)
     ext = FakeExtension(srv, instance_id="a", label="alpha")
     ext.start()
     try:
-        assert _wait_instances(srv, 1) is not None   # exercises /poll repeatedly
-        _req(srv, "GET", "/health")
+        assert _wait_count(srv, 1) is not None   # exercises /poll repeatedly
         _req(srv, "GET", "/instances")
         time.sleep(0.2)  # give any erroneous emit a chance to land
         assert _read_events(spool_dir) == []
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
+
+
+@pytest.mark.parametrize("path,op", [("/whoami", "whoami"), ("/health", "health")])
+def test_orientation_ops_emit_exactly_one_metadata_only_event(telemetry, path, op):
+    """REGRESSION (2026-08-02 usage audit, F8). `whoami` (38 calls) and `health`
+    (15) appeared NOWHERE in activity.events — 53 invocations invisible to the only
+    structured source, and they are the ops the skill tells you to run FIRST.
+
+    The count is asserted as a DELTA (0 before → exactly 1 after), not as "there is
+    a row": a post-hoc existence check would pass on any pre-existing event, and
+    this suite's own connection-wait helper used to inject /health events.
+
+    Metadata-only is asserted positively AND negatively: the payload must be
+    exactly {op,key,outcome} — in particular NO `domain`, because these endpoints
+    are global (they describe every connected profile at once) and per-profile
+    domains would widen the privacy contract at server.py's PRIVACY CONTRACT.
+    """
+    spool_dir = telemetry
+    srv, _ = _serve(poll_timeout=5.0)
+    ext = FakeExtension(srv, instance_id="a", label="alpha")
+    ext.start()
+    try:
+        assert _wait_count(srv, 1) is not None      # silent: /instances
+        assert _read_events(spool_dir) == [], "the negative control: 0 before"
+
+        st, body = _req(srv, "GET", path)
+        assert st == 200 and body["ok"] is True
+
+        evs = _wait_events(spool_dir, 1)
+        assert len(evs) == 1, f"expected exactly one event, got {evs}"
+        e = evs[0]
+        assert e["source"] == "browser-bridge" and e["kind"] == "cmd"
+        assert e["exit_code"] == "0"
+        assert e["text"] == op                      # no domain → text is the op
+        p = json.loads(e["payload"])
+        assert p == {"op": op, "key": "", "outcome": "ok"}, p
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_orientation_emit_never_breaks_the_response(telemetry, monkeypatch):
+    """BEST-EFFORT contract: a broken emitter must not fail /whoami or /health.
+
+    Mutation-proof for the try/except in emit_cmd_event as reached from the NEW
+    call site: force the emitter to raise and assert both endpoints still 200.
+    """
+    class _Boom:
+        @staticmethod
+        def emit(_rec):
+            raise RuntimeError("spool exploded")
+
+    monkeypatch.setattr(S, "_load_spool_emit", lambda: _Boom)
+    srv, _ = _serve()
+    try:
+        for path in ("/whoami", "/health"):
+            st, body = _req(srv, "GET", path)
+            assert st == 200 and body["ok"] is True, path
+    finally:
+        srv.shutdown(); srv.server_close()
 
 
 def test_emit_cmd_event_noop_when_emitter_missing(monkeypatch):
@@ -3953,14 +4156,42 @@ def test_browser_cli_screenshot_no_path_stdout_has_no_base64_payload(tmp_path):
 
 
 @pytest.mark.skipif(shutil.which("curl") is None, reason="curl not on PATH")
-def test_browser_cli_screenshot_explicit_path_unchanged(tmp_path):
-    """An explicit path still writes there and prints JUST the path (back-compat)."""
+def test_browser_cli_screenshot_explicit_path_prints_path_then_a_read_hint(tmp_path):
+    """REGRESSION (2026-08-02 usage audit, F4). 7 of 63 explicit-path captures were
+    never Read back — exit 0 plus a path on stdout looks like the job is done, and
+    an image nobody Reads is pure waste. One short `#`-prefixed hint now follows.
+
+    LINE 1 IS STILL THE BARE PATH — that is the back-compat half this used to pin
+    (`stdout.strip() == path`), and the hint is deliberately on line 2 and comment-
+    prefixed so it can never be mistaken for a second path.
+    """
     dest = tmp_path / "shot.png"
     r, _ = _run_browser_canned(_shot_data(), ["screenshot", str(dest)], tmp_path)
     assert r.returncode == 0, r.stderr
-    assert r.stdout.strip() == str(dest)
+    lines = r.stdout.splitlines()
+    assert lines[0] == str(dest), "line 1 must stay the bare path"
+    assert lines[1] == "# Read %s to view it." % dest
+    assert len(lines) == 2
     assert dest.read_bytes() == _PNG_BYTES
     assert _PNG_B64[:24] not in r.stdout
+
+
+def test_browser_cli_screenshot_read_hint_not_printed_where_it_would_be_wrong(tmp_path):
+    """NEGATIVE CONTROL for the hint above — without it, the test passes with the
+    string printed UNCONDITIONALLY.
+
+    Two forms must NOT carry it: `--data-url` (no file is written at all, so
+    "Read it" is false), and the temp-file form (whose JSON `note` already says
+    the same thing — a second copy would be per-call bytes for nothing).
+    """
+    r, _ = _run_browser_canned(_shot_data(), ["screenshot", "--data-url"], tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "# Read " not in r.stdout
+
+    r, _ = _run_browser_canned(_shot_data(), ["screenshot"], tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "# Read " not in r.stdout
+    assert json.loads(r.stdout)["path"].endswith(".png")   # still the JSON shape
 
 
 @pytest.mark.skipif(shutil.which("curl") is None, reason="curl not on PATH")
@@ -4586,6 +4817,208 @@ def test_browser_health_survives_a_malformed_known_instances(tmp_path):
         assert "Traceback" not in r.stderr
     finally:
         srv.shutdown(); srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# S3 — the routing-failure messages (2026-08-02 usage audit, F6)
+#
+# `unknown_instance` was the TOP error at 52 occurrences, and 48 of them used the
+# CORRECT label (`work`) — 35 inside a single hour, with `eval` re-issued 37 times.
+# A Brave profile had dropped its long-poll; the message ("no connected instance
+# matches --instance 'work'") reads as "you typed the wrong label", so agents kept
+# retrying a name that was right. `no_extension` has the identical shape (16 of 19
+# in one hour).
+#
+# The distinguishing fact was already on the wire — `known_instances` — it just was
+# not being read. These tests pin BOTH branches, because a single-case test passes
+# with the branch hard-wired to one string.
+# --------------------------------------------------------------------------- #
+def _serve_canned_cmd(status, payload):
+    """A stub bridge whose /cmd always answers `status` with `payload` verbatim, so
+    the CLI's error rendering can be driven against exact server bodies."""
+    class H(S.BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            n = int(self.headers.get("Content-Length") or 0)
+            self.rfile.read(n)
+            body = json.dumps(payload).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *a):  # noqa: A003
+            pass
+
+    srv = S.ThreadingHTTPServer(("127.0.0.1", 0), H)
+    srv.daemon_threads = True
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv
+
+
+def _run_browser_routing(srv, args, tmp_path):
+    tokf = tmp_path / "token"
+    tokf.write_text("routing-token\n")
+    env = dict(os.environ)
+    env.update(BROWSER_BRIDGE_HOST="127.0.0.1",
+               BROWSER_BRIDGE_PORT=str(srv.server_address[1]),
+               BROWSER_BRIDGE_TOKEN_FILE=str(tokf))
+    return subprocess.run([str(BROWSER_BIN), *args], env=env,
+                          capture_output=True, text=True, timeout=30)
+
+
+_UNKNOWN_404 = {
+    "ok": False, "error": "unknown_instance", "target": "work",
+    "instances": [{"key": "personal", "label": "personal"}],
+    "known_instances": [
+        {"key": "personal", "connected": True, "last_seen": "2026-08-02T04:00:00Z"},
+        {"key": "work", "connected": False, "last_seen": "2026-08-02T02:11:09Z",
+         "last_seen_age_s": 6531.0, "last_unanswered_op": "eval"},
+    ],
+}
+
+
+def test_unknown_instance_KNOWN_but_disconnected_says_stop_retrying(tmp_path):
+    """REGRESSION. The label is CORRECT and the profile is gone — the message must
+    say so and must tell the operator NOT to retry. 37 blind retries is the
+    measured symptom of a message that never said that."""
+    srv = _serve_canned_cmd(404, _UNKNOWN_404)
+    try:
+        r = _run_browser_routing(srv, ["--instance", "work", "tabs"], tmp_path)
+        assert r.returncode != 0
+        err = r.stderr
+        assert "KNOWN but NOT CONNECTED" in err, err
+        assert "the label is correct" in err, err
+        assert "FULLY RESTART Brave" in err, err
+        assert "DO NOT RETRY" in err, err
+        assert "2026-08-02T02:11:09Z" in err, "name WHEN it went away"
+        # ...and it must NOT tell the operator their label was wrong.
+        assert "is UNKNOWN" not in err, err
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_unknown_instance_NEVER_SEEN_key_says_wrong_label(tmp_path):
+    """NEGATIVE CONTROL for the test above. Without it, the branch could be
+    hard-wired to the disconnected wording and both tests would still be green for
+    the wrong reason. A genuinely bogus label must get the OPPOSITE message —
+    "wrong label", plus the keys that do exist, and no restart advice."""
+    srv = _serve_canned_cmd(404, {**_UNKNOWN_404, "target": "nosuchlabel"})
+    try:
+        r = _run_browser_routing(srv, ["--instance", "nosuchlabel", "tabs"],
+                                 tmp_path)
+        assert r.returncode != 0
+        err = r.stderr
+        assert "is UNKNOWN" in err, err
+        assert "WRONG LABEL" in err, err
+        assert "Keys this server HAS seen" in err and "personal" in err, err
+        # The two branches must be mutually exclusive.
+        assert "KNOWN but NOT CONNECTED" not in err, err
+        assert "DO NOT RETRY" not in err, err
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_no_extension_distinguishes_dropped_from_never_wired_up(tmp_path):
+    """`no_extension` (16 of 19 in one hour) has the same shape, so it gets the
+    same split: a profile that HAS been seen and is now gone means "restart Brave,
+    stop retrying"; nothing ever seen means "load the extension"."""
+    dropped = _serve_canned_cmd(503, {
+        "ok": False, "error": "extension_not_connected",
+        "known_instances": [
+            {"key": "work", "connected": False,
+             "last_seen": "2026-08-02T02:11:09Z", "last_seen_age_s": 6531.0}]})
+    try:
+        r = _run_browser_routing(dropped, ["tabs"], tmp_path)
+        assert r.returncode != 0
+        err = r.stderr
+        assert "HAS seen" in err and "work" in err, err
+        assert "FULLY RESTART Brave" in err and "DO NOT RETRY" in err, err
+        assert "has EVER connected" not in err, err
+    finally:
+        dropped.shutdown(); dropped.server_close()
+
+    virgin = _serve_canned_cmd(503, {"ok": False,
+                                     "error": "extension_not_connected",
+                                     "known_instances": []})
+    try:
+        r = _run_browser_routing(virgin, ["tabs"], tmp_path)
+        assert r.returncode != 0
+        err = r.stderr
+        assert "has EVER connected" in err, err
+        assert "load the browser-bridge extension" in err, err
+        assert "DO NOT RETRY" not in err, err
+    finally:
+        virgin.shutdown(); virgin.server_close()
+
+
+def test_routing_failure_explainer_degrades_against_an_OLD_server(tmp_path):
+    """`browser` is a symlink to the working tree, so it goes live on `git pull` —
+    BEFORE the switch that restarts server.py. It WILL run against a server with no
+    `known_instances`, and must still exit non-zero with readable advice and no
+    traceback (the same degradation contract render_missing has)."""
+    for status, payload, args in (
+            (404, {"ok": False, "error": "unknown_instance", "target": "work"},
+             ["--instance", "work", "tabs"]),
+            (503, {"ok": False, "error": "extension_not_connected"}, ["tabs"]),
+            (404, {"ok": False, "error": "unknown_instance",
+                   "known_instances": ["not-a-dict", 7, None]},
+             ["--instance", "work", "tabs"])):
+        srv = _serve_canned_cmd(status, payload)
+        try:
+            r = _run_browser_routing(srv, args, tmp_path)
+            assert r.returncode != 0, payload
+            assert "Traceback" not in r.stderr, r.stderr
+            assert r.stderr.strip(), "must still say something"
+        finally:
+            srv.shutdown(); srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# S6 — doc pointers inside the CLI must RESOLVE
+# --------------------------------------------------------------------------- #
+def test_every_skill_md_heading_the_cli_points_at_actually_exists():
+    """`browser:582` and `browser:588` pointed at "SKILL.md → Concurrency" — a
+    heading that has never existed (SKILL.md has 7 `##` headings and none is it;
+    the content is bold text under "This is the user's LIVE session"). A pointer
+    that does not resolve sends a reader hunting, and nothing was checking.
+
+    HARNESS NEGATIVE CONTROL is inline below: the extractor is first run against a
+    string containing a KNOWN-BAD pointer and must report it. Without that, an
+    extractor that silently matches nothing would report a green that means
+    nothing.
+    """
+    import re
+
+    def bad_pointers(text, headings):
+        """Every `SKILL.md -> <name>` / `SKILL.md → <name>` in `text` whose <name>
+        does not resolve to a heading. A pointer may name a heading's PREFIX (the
+        headings carry trailing "— triage"-style qualifiers that nobody types), but
+        it must resolve to at least one — "Concurrency" resolves to none, which is
+        the whole defect."""
+        out = []
+        for m in re.finditer(
+                r'SKILL\.md\s*(?:->|→)\s*"?([^"\n(]+?)"?\s*(?:$|[)\.,]|→)',
+                text, re.M):
+            name = m.group(1).strip()
+            if name and not any(h == name or h.startswith(name + " ")
+                                for h in headings):
+                out.append(name)
+        return out
+
+    skill = (BROWSER_BIN.parent / "SKILL.md").read_text(encoding="utf-8")
+    headings = {ln.lstrip("#").strip()
+                for ln in skill.splitlines() if ln.startswith("#")}
+    assert len(headings) >= 5, "SKILL.md heading extraction looks broken"
+
+    # NEGATIVE CONTROL: a pointer at a heading that is not there MUST be reported.
+    assert bad_pointers('see SKILL.md → Concurrency.', headings) == ["Concurrency"]
+    # ...and a pointer at a REAL heading must not be.
+    assert bad_pointers('see SKILL.md -> "Ops".', headings) == []
+
+    cli = BROWSER_BIN.read_text(encoding="utf-8")
+    assert bad_pointers(cli, headings) == [], (
+        "the CLI points at SKILL.md headings that do not exist")
 
 
 def test_poll_timeout_at_or_above_the_extension_poll_budget_warns(capsys):

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -1732,6 +1732,12 @@ def test_inflight_release_distinguishes_queued_from_running_on_abandon():
             time.sleep(0.02)
         assert all(not i.inflight for i in reg._instances.values()), (
             "the late result must release the kept entry, not leave it to expire")
+        # ...and `last_dispatch` must stop naming it. Its contract is "the command
+        # it never answered" (surfaced by health/whoami); after a late result it
+        # DID answer, so leaving it set reports a phantom unanswered op forever.
+        assert all((i.last_dispatch or {}).get("id") is None
+                   for i in reg._instances.values()), (
+            "last_dispatch still names a command that has now been answered")
     finally:
         gate.set(); ext.stop(); srv.shutdown(); srv.server_close()
 
@@ -1748,11 +1754,16 @@ def test_a_kept_inflight_entry_expires_if_the_result_never_arrives():
                                   deadline, entry retained.
       * EXEC+GRACE < age < STALE -> budget has gone negative (the extension blew
                                   its own self-bound, so it IS wedged): the ping is
-                                  fast again, but the entry is still RETAINED —
-                                  the staleness window bounds memory, not the
-                                  busy/wedged verdict. Conflating the two would
-                                  make the ping slow for a further 8s.
+                                  fast again, but the entry is still RETAINED.
       * age >  STALE           -> pruned.
+
+    ⚠ SCOPE: all three points are measured at **N=1, no live submitter** (a single
+    ABANDONED entry). "The staleness window bounds memory, not the verdict" is TRUE
+    ONLY AT N=1 — it holds here because a lone entry's budget is already negative
+    by 20s, so pruning at 28s is verdict-neutral BY CONSTRUCTION. At N>=2 the prune
+    does change the verdict (3 entries at age 29s: 27.0s -> 2.0s), which is exactly
+    the bug `test_stale_prune_never_evicts_an_entry_whose_submitter_is_STILL_WAITING`
+    covers. Do not generalise this test's conclusion past N=1.
     """
     clock = {"t": 1000.0}
     reg = S.Registry(clock=lambda: clock["t"])
@@ -1775,6 +1786,93 @@ def test_a_kept_inflight_entry_expires_if_the_result_never_arrives():
     clock["t"] = 1000.0 + S.INFLIGHT_STALE_S + 1.0
     assert reg._effective_timeout_locked(inst, 20.0, 2.0) == 2.0
     assert not inst.inflight, "a stale entry must be pruned, not just ignored"
+
+
+def test_waiters_is_exactly_the_live_submitter_set():
+    """The prune now READS `waiters` as "is a submitter still blocked on this?", so
+    that property has to be pinned rather than assumed — it is the load-bearing
+    premise of the fix below, and it lives in a different function.
+
+    Checked on the exits that are reachable from outside: success and timeout.
+    (The `finally`'s extra discard is a defensive net for an unexpected raise
+    INSIDE the wait loop, which no test can reach from here — it is an invariant
+    guard, and is labelled as such in the source rather than claimed as covered.)
+    """
+    srv, reg = _serve(cmd_timeout=1.0, poll_timeout=5.0)
+    ext = FakeExtension(srv, executor=lambda c: {"ok": 1})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _req(srv, "POST", "/cmd", {"op": "tabs"})[0] == 200
+        assert all(not i.waiters for i in reg._instances.values()), (
+            "a completed submit must leave no waiter")
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+    srv, reg = _serve(cmd_timeout=1.0, poll_timeout=5.0)
+    ext = FakeExtension(srv, swallow=True)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _req(srv, "POST", "/cmd", {"op": "getHtml"})[0] == 504
+        assert all(not i.waiters for i in reg._instances.values()), (
+            "a timed-out submit must leave no waiter — otherwise its inflight "
+            "entry would be exempt from the staleness prune forever")
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_stale_prune_never_evicts_an_entry_whose_submitter_is_STILL_WAITING():
+    """🔴 REGRESSION (round-4 audit). INFLIGHT_STALE_S is measured from ENQUEUE,
+    but a queued command's 18s execution budget does not start until the serial
+    extension DEQUEUES it. So "past this point a healthy extension has certainly
+    answered" is false exactly when N>=2 — which is the case the
+    `len(inst.inflight) * EXEC_OP_BUDGET_S` term exists to model.
+
+    The scenario is the remediation the same commit documented: an operator reads
+    "raise CMD_TIMEOUT if that is your workload", sets 60s, and submits 3 ops. The
+    extension legitimately works until t~54s. At t=29s all three entries aged past
+    STALE(28) and were pruned WHILE THEIR SUBMITTERS WERE STILL BLOCKED, the
+    instance read idle, and ping fast-failed at 2s. Worse than a0a0021 in that
+    window, and it falsified the advice.
+
+    Fix: an entry may only be pruned once NO live submitter awaits it. `waiters` is
+    exactly that set (added at enqueue, discarded on all three loop exits, and
+    discarded again in the finally so an unexpected raise cannot strand one).
+
+    NEGATIVE CONTROL is the last block: an ABANDONED entry (no waiter) must still
+    be pruned, or this "fix" would just disable the memory bound.
+    """
+    clock = {"t": 1000.0}
+    reg = S.Registry(clock=lambda: clock["t"])
+    inst = S.Instance("k", "i", "", clock["t"])
+
+    # N=3, cmd_timeout 60 — every submitter still blocked.
+    inst.inflight = {"a": 1000.0, "b": 1000.0, "c": 1000.0}
+    inst.waiters = {"a", "b", "c"}
+    clock["t"] = 1000.0 + 27.0                      # inside STALE: fine before too
+    assert reg._effective_timeout_locked(inst, 60.0, 2.0) == pytest.approx(29.0)
+    clock["t"] = 1000.0 + 29.0                      # PAST STALE — the bug window
+    assert reg._effective_timeout_locked(inst, 60.0, 2.0) == pytest.approx(27.0), (
+        "three live submitters were pruned as stale, so the instance read idle "
+        "while the extension was legitimately working")
+    assert len(inst.inflight) == 3, "a live submitter's entry must not be evicted"
+
+    # N=2, cmd_timeout 20 — the default-ish shape.
+    inst.inflight = {"a": 1000.0, "b": 1000.0}
+    inst.waiters = {"a", "b"}
+    clock["t"] = 1000.0 + 27.0
+    assert reg._effective_timeout_locked(inst, 20.0, 2.0) == pytest.approx(11.0)
+    clock["t"] = 1000.0 + 29.0
+    assert reg._effective_timeout_locked(inst, 20.0, 2.0) == pytest.approx(9.0)
+    assert len(inst.inflight) == 2
+
+    # NEGATIVE CONTROL: no live submitter -> the staleness bound still applies.
+    inst.inflight = {"abandoned": 1000.0}
+    inst.waiters = set()
+    clock["t"] = 1000.0 + 29.0
+    assert reg._effective_timeout_locked(inst, 20.0, 2.0) == 2.0
+    assert not inst.inflight, "an ABANDONED entry must still be pruned"
 
 
 def test_result_budget_matches_the_extension():

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -1306,8 +1306,9 @@ def test_ping_does_not_wait_out_cmd_timeout(monkeypatch):
     """REGRESSION. Pre-change `ping` used cmd_timeout like every other op, so
     against a wedged extension it burned the full budget before answering."""
     monkeypatch.delenv("BROWSER_BRIDGE_PING_TIMEOUT", raising=False)
-    # cmd_timeout is 8s; the default ping deadline is PING_TIMEOUT_DEFAULT (2s).
-    srv, _ = _serve(cmd_timeout=8.0, poll_timeout=5.0)
+    # cmd_timeout 25s vs PING_TIMEOUT_DEFAULT 10s — the gap has to be wide enough
+    # that "used its own deadline" and "used cmd_timeout" are unmistakable.
+    srv, _ = _serve(cmd_timeout=25.0, poll_timeout=5.0)
     ext = FakeExtension(srv, swallow=True)       # picks up, never answers
     ext.start()
     try:
@@ -1316,11 +1317,11 @@ def test_ping_does_not_wait_out_cmd_timeout(monkeypatch):
         st, body = _req(srv, "POST", "/cmd", {"op": "ping"})
         elapsed = time.monotonic() - t0
         assert st == 504 and body["error"] == "timeout"
-        # Red pre-change: this was ~8s (the full cmd_timeout).
-        assert elapsed < 5.0, f"ping waited {elapsed:.1f}s — cmd_timeout, not its own"
+        # Red pre-change: this was ~25s (the full cmd_timeout).
+        assert elapsed < 17.0, f"ping waited {elapsed:.1f}s — cmd_timeout, not its own"
         # ...and it did actually WAIT its own deadline rather than failing instantly
         # for some unrelated reason (which would make the bound above vacuous).
-        assert elapsed >= 1.5, f"ping returned in {elapsed:.2f}s — it never waited"
+        assert elapsed >= 8.0, f"ping returned in {elapsed:.2f}s — it never waited"
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
 
@@ -1332,8 +1333,16 @@ def test_the_short_deadline_applies_to_ping_ONLY(monkeypatch):
 
     Same server, same wedged extension, a non-ping op: it must still wait out the
     full cmd_timeout.
+
+    🔴 BOUNDED ON BOTH SIDES, and the UPPER bound is the load-bearing half. With
+    cmd_timeout(4s) < PING_TIMEOUT_DEFAULT(10s), a lower bound alone would SURVIVE
+    the very mutation this control exists to catch: `op_timeout = ping_timeout`
+    leaks 10s onto getHtml, and 10 >= 3.5 passes. Caught when the default was
+    raised from 2s to 10s and this control silently stopped discriminating.
     """
     monkeypatch.delenv("BROWSER_BRIDGE_PING_TIMEOUT", raising=False)
+    assert S.PING_TIMEOUT_DEFAULT > 4.0, (
+        "this control needs cmd_timeout < PING_TIMEOUT_DEFAULT to discriminate")
     srv, _ = _serve(cmd_timeout=4.0, poll_timeout=5.0)
     ext = FakeExtension(srv, swallow=True)
     ext.start()
@@ -1344,18 +1353,92 @@ def test_the_short_deadline_applies_to_ping_ONLY(monkeypatch):
         elapsed = time.monotonic() - t0
         assert st == 504
         assert elapsed >= 3.5, (
-            f"getHtml returned in {elapsed:.2f}s — the short ping deadline leaked "
-            "onto every op")
+            f"getHtml returned in {elapsed:.2f}s — it never waited cmd_timeout")
+        assert elapsed < 7.0, (
+            f"getHtml waited {elapsed:.2f}s — the ping deadline leaked onto every "
+            "op (cmd_timeout was 4s)")
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_ping_survives_a_BUSY_but_perfectly_healthy_extension(monkeypatch):
+    """🔴 REGRESSION (adversarial audit of PR #278). The FIRST cut of this feature
+    used a 2s deadline and had NO test with a BUSY extension — only a wedged one
+    and an idle one. That is the whole gap: the extension's poll loop is strictly
+    SERIAL (service_worker.js:1646-1652 — `await execute()` → `await postResult()`
+    → next `pollOnce()`), so `ping` skips the per-tab FIFO but still cannot be
+    DEQUEUED until whatever is already running finishes.
+
+    Consequence of the 2s cut, measured: two sessions drive one Brave profile;
+    agent B runs `browser ping` (the skill's documented FIRST action) while agent A
+    is mid-`nav` on a heavy page. B got a 504 and the message "is Brave focused /
+    responsive?", whose documented remedy is a FULL Brave restart of the operator's
+    live session. A healthy profile reported as dead.
+
+    This models exactly that: a legitimate BUSY_S-second op in flight, then a ping.
+
+    The elapsed LOWER bound is what stops this being vacuous — without it the test
+    passes against an extension that was never actually busy, which is the mistake
+    the original S2 tests made.
+    """
+    BUSY_S = 6.0
+    monkeypatch.delenv("BROWSER_BRIDGE_PING_TIMEOUT", raising=False)
+
+    def executor(cmd):
+        if cmd.get("op") == "getHtml":
+            time.sleep(BUSY_S)          # a legitimate slow op, NOT a wedge
+            return {"html": "<html></html>"}
+        return {"pong": True, "extensionVersion": "0.7.0"}
+
+    srv, _ = _serve(cmd_timeout=25.0, poll_timeout=5.0)
+    ext = FakeExtension(srv, executor=executor)
+    ext.start()
+    slow = {}
+    try:
+        assert _wait_connected(srv, want=True)
+
+        # Agent A: the slow-but-healthy op.
+        t = threading.Thread(
+            target=lambda: slow.update(
+                zip(("st", "body"), _req(srv, "POST", "/cmd", {"op": "getHtml"}))),
+            daemon=True)
+        t.start()
+
+        # Wait until the extension has actually PICKED IT UP — being busy is the
+        # precondition under test, so it must be established, not assumed.
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            if any(c.get("op") == "getHtml" for c in ext.dispatched):
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail("the fake extension never dequeued the slow op")
+
+        # Agent B: the diagnostic, issued against a busy-but-healthy extension.
+        t0 = time.monotonic()
+        st, body = _req(srv, "POST", "/cmd", {"op": "ping"})
+        elapsed = time.monotonic() - t0
+
+        assert st == 200, (
+            f"a BUSY but healthy extension was reported dead after {elapsed:.2f}s "
+            "— this is the false negative that sends an operator to restart Brave")
+        assert body["result"]["data"]["pong"] is True
+        # NOT vacuous: it genuinely queued behind the slow op.
+        assert elapsed >= BUSY_S * 0.5, (
+            f"ping answered in {elapsed:.2f}s — the extension was not actually "
+            "busy, so this proves nothing")
+        t.join(timeout=10)
+        assert slow.get("st") == 200, "the slow op must also have completed fine"
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
 
 
 def test_a_healthy_ping_is_unaffected_and_answers_in_milliseconds(monkeypatch):
-    """NEGATIVE CONTROL #2: the 2 s cap must never truncate the HEALTHY path. 21
-    measured healthy pings averaged 3–4 ms, so 2 s is ~500× headroom — assert the
-    fast path still returns 200, not a timeout."""
+    """NEGATIVE CONTROL #2: the cap must never truncate the HEALTHY path. 21
+    measured healthy pings averaged 3–4 ms, so the 10 s deadline is ~2500×
+    headroom — assert the fast path still returns 200, not a timeout."""
     monkeypatch.delenv("BROWSER_BRIDGE_PING_TIMEOUT", raising=False)
-    srv, _ = _serve(cmd_timeout=8.0, poll_timeout=5.0)
+    srv, _ = _serve(cmd_timeout=25.0, poll_timeout=5.0)
     ext = FakeExtension(srv, executor=lambda c: {"pong": True})
     ext.start()
     try:

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -24,6 +24,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -1312,8 +1313,8 @@ def test_ping_does_not_wait_out_cmd_timeout(monkeypatch):
     """REGRESSION. Pre-change `ping` used cmd_timeout like every other op, so
     against a wedged extension it burned the full budget before answering."""
     monkeypatch.delenv("BROWSER_BRIDGE_PING_TIMEOUT", raising=False)
-    # cmd_timeout 25s vs PING_TIMEOUT_DEFAULT 10s — the gap has to be wide enough
-    # that "used its own deadline" and "used cmd_timeout" are unmistakable.
+    # The instance is IDLE (this ping is the only command), so nothing can be
+    # ahead of it and a stalled reply IS the wedge → the fast deadline applies.
     srv, _ = _serve(cmd_timeout=25.0, poll_timeout=5.0)
     ext = FakeExtension(srv, swallow=True)       # picks up, never answers
     ext.start()
@@ -1324,10 +1325,10 @@ def test_ping_does_not_wait_out_cmd_timeout(monkeypatch):
         elapsed = time.monotonic() - t0
         assert st == 504 and body["error"] == "timeout"
         # Red pre-change: this was ~25s (the full cmd_timeout).
-        assert elapsed < 17.0, f"ping waited {elapsed:.1f}s — cmd_timeout, not its own"
+        assert elapsed < 5.0, f"ping waited {elapsed:.1f}s — cmd_timeout, not its own"
         # ...and it did actually WAIT its own deadline rather than failing instantly
         # for some unrelated reason (which would make the bound above vacuous).
-        assert elapsed >= 8.0, f"ping returned in {elapsed:.2f}s — it never waited"
+        assert elapsed >= 1.5, f"ping returned in {elapsed:.2f}s — it never waited"
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
 
@@ -1340,16 +1341,20 @@ def test_the_short_deadline_applies_to_ping_ONLY(monkeypatch):
     Same server, same wedged extension, a non-ping op: it must still wait out the
     full cmd_timeout.
 
-    🔴 BOUNDED ON BOTH SIDES, and the UPPER bound is the load-bearing half. With
-    cmd_timeout(4s) < PING_TIMEOUT_DEFAULT(10s), a lower bound alone would SURVIVE
-    the very mutation this control exists to catch: `op_timeout = ping_timeout`
-    leaks 10s onto getHtml, and 10 >= 3.5 passes. Caught when the default was
-    raised from 2s to 10s and this control silently stopped discriminating.
+    🔴 BOUNDED ON BOTH SIDES; each bound catches a DIFFERENT mutation, and both
+    have caught one for real:
+      * LOWER — `fast_timeout` passed for every op: an idle instance would give
+        getHtml the 2s fast deadline, so it would return in ~2s, not ~5s.
+      * UPPER — the derived busy-budget applied to every op: getHtml could then
+        run far past its own cmd_timeout.
+    A single bound is not enough. An earlier revision had only the lower one and
+    silently stopped discriminating when PING_TIMEOUT_DEFAULT briefly rose above
+    this test's cmd_timeout — the leak mutant passed `10 >= 3.5`.
     """
     monkeypatch.delenv("BROWSER_BRIDGE_PING_TIMEOUT", raising=False)
-    assert S.PING_TIMEOUT_DEFAULT > 4.0, (
-        "this control needs cmd_timeout < PING_TIMEOUT_DEFAULT to discriminate")
-    srv, _ = _serve(cmd_timeout=4.0, poll_timeout=5.0)
+    assert S.PING_TIMEOUT_DEFAULT < 5.0, (
+        "this control needs the fast deadline to be clearly below cmd_timeout")
+    srv, _ = _serve(cmd_timeout=5.0, poll_timeout=5.0)
     ext = FakeExtension(srv, swallow=True)
     ext.start()
     try:
@@ -1358,11 +1363,12 @@ def test_the_short_deadline_applies_to_ping_ONLY(monkeypatch):
         st, _ = _req(srv, "POST", "/cmd", {"op": "getHtml"})
         elapsed = time.monotonic() - t0
         assert st == 504
-        assert elapsed >= 3.5, (
-            f"getHtml returned in {elapsed:.2f}s — it never waited cmd_timeout")
-        assert elapsed < 7.0, (
-            f"getHtml waited {elapsed:.2f}s — the ping deadline leaked onto every "
-            "op (cmd_timeout was 4s)")
+        assert elapsed >= 4.0, (
+            f"getHtml returned in {elapsed:.2f}s — the fast ping deadline leaked "
+            "onto every op (cmd_timeout was 5s)")
+        assert elapsed < 9.0, (
+            f"getHtml waited {elapsed:.2f}s — something gave a non-ping op a "
+            "budget beyond its own cmd_timeout")
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
 
@@ -1403,11 +1409,17 @@ def test_ping_survives_a_BUSY_but_perfectly_healthy_extension(monkeypatch):
     try:
         assert _wait_connected(srv, want=True)
 
-        # Agent A: the slow-but-healthy op.
-        t = threading.Thread(
-            target=lambda: slow.update(
-                zip(("st", "body"), _req(srv, "POST", "/cmd", {"op": "getHtml"}))),
-            daemon=True)
+        # Agent A: the slow-but-healthy op. Exceptions are captured rather than
+        # left to surface in a daemon thread (pytest would attribute them to some
+        # unrelated later test — see the wedge test below).
+        def _slow():
+            try:
+                slow.update(zip(("st", "body"),
+                                _req(srv, "POST", "/cmd", {"op": "getHtml"})))
+            except Exception as exc:           # noqa: BLE001
+                slow["exc"] = exc
+
+        t = threading.Thread(target=_slow, daemon=True)
         t.start()
 
         # Wait until the extension has actually PICKED IT UP — being busy is the
@@ -1435,6 +1447,153 @@ def test_ping_survives_a_BUSY_but_perfectly_healthy_extension(monkeypatch):
             "busy, so this proves nothing")
         t.join(timeout=10)
         assert slow.get("st") == 200, "the slow op must also have completed fine"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_ping_fast_fails_even_while_BUSY_once_the_work_has_blown_its_budget():
+    """🔴 THE PAYOFF of the structural gate, and the case a tuned constant could
+    NEVER express: the instance is busy AND wedged.
+
+    A fixed deadline has to choose one failure. Too short → a busy healthy profile
+    reads as dead. Too long → a genuinely wedged one takes the full cmd_timeout to
+    say so. Deriving the deadline from the age of the outstanding work does both:
+    while the in-flight command is inside EXEC_OP_BUDGET_S the ping waits, and the
+    moment that budget is exhausted the extension is provably not healthy (its own
+    `execute()` self-bound says so), and the ping fails fast.
+
+    EXEC_OP_BUDGET_S is monkeypatched small so "the work has blown its budget"
+    arrives in test time rather than 18 real seconds.
+    """
+    srv, _ = _serve(cmd_timeout=25.0, poll_timeout=5.0)
+    ext = FakeExtension(srv, swallow=True)     # takes the op, never answers
+    ext.start()
+
+    # The wedging request outlives the assertions and dies when the server closes.
+    # SWALLOW its exception explicitly: an unhandled exception in a daemon thread
+    # is reported by pytest against whatever test happens to be running when it
+    # surfaces — it showed up on `test_release_drops_ownership_without_dispatch`,
+    # which has nothing to do with this. A test must not poison its neighbours.
+    wedger = {}
+
+    def _wedge():
+        try:
+            wedger["st"] = _req(srv, "POST", "/cmd", {"op": "getHtml"})[0]
+        except Exception as exc:               # noqa: BLE001 — teardown teardown
+            wedger["exc"] = exc
+
+    try:
+        assert _wait_connected(srv, want=True)
+        # Agent A's op goes out and wedges.
+        t = threading.Thread(target=_wedge, daemon=True)
+        t.start()
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            if any(c.get("op") == "getHtml" for c in ext.dispatched):
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail("the fake extension never dequeued the wedging op")
+
+        # Let its (shrunken) budget lapse, so the in-flight work is now OVERDUE.
+        with mock.patch.object(S, "EXEC_OP_BUDGET_S", 0.2):
+            time.sleep(0.4)
+            t0 = time.monotonic()
+            st, _ = _req(srv, "POST", "/cmd", {"op": "ping"})
+            elapsed = time.monotonic() - t0
+        assert st == 504
+        # Fast, NOT the 25s cmd_timeout: the budget went negative, so the deadline
+        # clamps down to the fast floor.
+        assert elapsed < 5.0, (
+            f"ping waited {elapsed:.1f}s against a wedged instance — the gate did "
+            "not notice the in-flight work was overdue")
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+        t.join(timeout=30)                     # let it finish before pytest moves on
+
+
+def test_effective_timeout_gate_unit(monkeypatch):
+    """The gate's arithmetic, directly — the threaded tests above cover the two
+    endpoints, this covers the boundary and both clamps (one measurement is not a
+    general claim).
+    """
+    clock = {"t": 1000.0}
+    reg = S.Registry(clock=lambda: clock["t"])
+    inst = S.Instance("k", "i", "", clock["t"])
+    g = lambda t, f: reg._effective_timeout_locked(inst, t, f)   # noqa: E731
+
+    # 1. Not a fast-fail op at all -> untouched, whatever is in flight.
+    inst.inflight = {"a": 1000.0}
+    assert g(20.0, None) == 20.0
+
+    # 2. Idle -> the fast deadline.
+    inst.inflight = {}
+    assert g(20.0, 2.0) == 2.0
+
+    # 3. Busy, work just started -> a full budget, CLAMPED to cmd_timeout so this
+    #    can never be slower than the behaviour that predates the fast ping.
+    monkeypatch.setattr(S, "EXEC_OP_BUDGET_S", 18.0)
+    monkeypatch.setattr(S, "WEDGE_GRACE_S", 2.0)
+    inst.inflight = {"a": 1000.0}
+    assert g(20.0, 2.0) == 20.0
+    assert g(5.0, 2.0) == 5.0, "must never exceed cmd_timeout"
+
+    # 4. Busy, partway through -> the REMAINING budget.
+    clock["t"] = 1012.0                     # 12s elapsed of an 18+2 budget
+    assert g(20.0, 2.0) == pytest.approx(8.0)
+
+    # 5. Overdue -> negative budget, clamped UP to the fast floor (never 0/instant).
+    clock["t"] = 1030.0
+    assert g(20.0, 2.0) == 2.0
+
+    # 6. TWO commands in flight drain serially, so the budget scales with depth —
+    #    otherwise a queue of legitimate work would false-negative.
+    clock["t"] = 1012.0
+    inst.inflight = {"a": 1000.0, "b": 1005.0}
+    assert g(60.0, 2.0) == pytest.approx(2 * 18.0 + 2.0 - 12.0)
+
+
+def test_exec_budget_matches_the_extension():
+    """EXEC_OP_BUDGET_S mirrors EXEC_OP_BUDGET_MS across a language boundary, so
+    nothing can enforce it at runtime. Assert it here: if someone retunes the
+    extension's self-bound, the gate's arithmetic silently stops matching reality.
+    """
+    proto = (Path(__file__).resolve().parent.parent
+             / "extension" / "protocol.js").read_text(encoding="utf-8")
+    m = re.search(r"export const EXEC_OP_BUDGET_MS\s*=\s*(\d+)", proto)
+    assert m, "could not find EXEC_OP_BUDGET_MS in protocol.js — retarget this test"
+    assert float(m.group(1)) / 1000.0 == S.EXEC_OP_BUDGET_S, (
+        f"protocol.js says {m.group(1)}ms, server.py says "
+        f"{S.EXEC_OP_BUDGET_S}s — the busy/wedged gate is now wrong")
+
+
+def test_inflight_is_released_on_every_exit_path():
+    """A stranded `inflight` entry is worse than a stranded `pending` slot: the
+    instance would look permanently busy and `ping` could never fast-fail on it
+    again. Pinned across the three exits — success, timeout, and a never-answered
+    command whose caller gave up.
+    """
+    srv, reg = _serve(cmd_timeout=1.0, poll_timeout=5.0)
+    ext = FakeExtension(srv, executor=lambda c: {"ok": 1})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, _ = _req(srv, "POST", "/cmd", {"op": "tabs"})       # success
+        assert st == 200
+        insts = list(reg._instances.values())
+        assert insts and all(not i.inflight for i in insts), "leaked after success"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+    srv, reg = _serve(cmd_timeout=1.0, poll_timeout=5.0)
+    ext = FakeExtension(srv, swallow=True)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, _ = _req(srv, "POST", "/cmd", {"op": "getHtml"})    # timeout
+        assert st == 504
+        insts = list(reg._instances.values())
+        assert insts and all(not i.inflight for i in insts), "leaked after timeout"
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
 

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -258,11 +258,17 @@ class FakeExtension(threading.Thread):
 # the list /health's `extension_connected` is the bool() of) and deliberately does
 # NOT emit — it is not an operator-facing orientation op. Keep it that way; if you
 # point this back at /health, the exact-count telemetry assertions go red again.
+#
+# `body["count"]`, NOT `body.get("count", 0)`: a missing key must RAISE, not read
+# as "nothing connected". With a default, a shape change on /instances turns
+# `want=False` into an instantly vacuous pass — the helper would report success
+# without ever observing the server. The old /health helper used `body[...]` for
+# exactly this reason; the move to /instances must not quietly weaken it.
 def _wait_connected(srv, want=True, timeout=3.0):
     deadline = time.time() + timeout
     while time.time() < deadline:
         status, body = _req(srv, "GET", "/instances")
-        if status == 200 and bool(body.get("count", 0)) == want:
+        if status == 200 and bool(body["count"]) == want:
             return True
         time.sleep(0.02)
     return False
@@ -274,7 +280,7 @@ def _wait_count(srv, n, timeout=3.0):
     deadline = time.time() + timeout
     while time.time() < deadline:
         status, body = _req(srv, "GET", "/instances")
-        if status == 200 and body.get("count", 0) >= n:
+        if status == 200 and body["count"] >= n:   # see _wait_connected on `[...]`
             return body
         time.sleep(0.02)
     return None
@@ -4975,6 +4981,11 @@ def test_unknown_instance_KNOWN_but_disconnected_says_stop_retrying(tmp_path):
         assert "FULLY RESTART Brave" in err, err
         assert "DO NOT RETRY" in err, err
         assert "2026-08-02T02:11:09Z" in err, "name WHEN it went away"
+        # `last_unanswered_op` is the evidence server.py calls "the single fact that
+        # turns the next silent drop from inference into evidence" — it says the
+        # profile died MID-`eval` rather than going quiet while idle. render_missing
+        # always printed it; the rewritten advice must not have dropped it.
+        assert "last unanswered op: eval" in err, err
         # ...and it must NOT tell the operator their label was wrong.
         assert "is UNKNOWN" not in err, err
     finally:
@@ -4995,6 +5006,11 @@ def test_unknown_instance_NEVER_SEEN_key_says_wrong_label(tmp_path):
         assert "is UNKNOWN" in err, err
         assert "WRONG LABEL" in err, err
         assert "Keys this server HAS seen" in err and "personal" in err, err
+        # The wrong-label branch ALSO keeps render_missing's drop evidence: a typo
+        # and a dead profile are frequently the SAME incident, and this branch is
+        # where that used to become invisible.
+        assert "last seen 2026-08-02T02:11:09Z" in err, err
+        assert "last unanswered op: eval" in err, err
         # The two branches must be mutually exclusive.
         assert "KNOWN but NOT CONNECTED" not in err, err
         assert "DO NOT RETRY" not in err, err
@@ -5010,12 +5026,14 @@ def test_no_extension_distinguishes_dropped_from_never_wired_up(tmp_path):
         "ok": False, "error": "extension_not_connected",
         "known_instances": [
             {"key": "work", "connected": False,
-             "last_seen": "2026-08-02T02:11:09Z", "last_seen_age_s": 6531.0}]})
+             "last_seen": "2026-08-02T02:11:09Z", "last_seen_age_s": 6531.0,
+             "last_unanswered_op": "screenshot"}]})
     try:
         r = _run_browser_routing(dropped, ["tabs"], tmp_path)
         assert r.returncode != 0
         err = r.stderr
         assert "HAS seen" in err and "work" in err, err
+        assert "last unanswered op: screenshot" in err, err
         assert "FULLY RESTART Brave" in err and "DO NOT RETRY" in err, err
         assert "has EVER connected" not in err, err
     finally:

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -1462,10 +1462,25 @@ def test_ping_fast_fails_even_while_BUSY_once_the_work_has_blown_its_budget():
     moment that budget is exhausted the extension is provably not healthy (its own
     `execute()` self-bound says so), and the ping fails fast.
 
-    EXEC_OP_BUDGET_S is monkeypatched small so "the work has blown its budget"
-    arrives in test time rather than 18 real seconds.
+    🔴 THE FIXTURE IS CALIBRATED, and that is load-bearing — an earlier version was
+    INSENSITIVE to the `- age` term it advertises. It used EXEC=0.2 with the default
+    2s grace, so the no-age budget was 0.2+2.0 = 2.2s, comfortably under its own
+    `elapsed < 5.0` bound: deleting `- age` from the formula left this GREEN and only
+    the unit test caught it. Now EXEC=3.0 / GRACE=0.5 / age≈4s, so:
+        with `- age`:    3.0 + 0.5 - 4.0  = -0.5  -> clamps to the 0.3s fast floor
+        without `- age`: 3.0 + 0.5        =  3.5s
+    and the bound sits between them.
+
+    cmd_timeout is also kept BELOW `_req`'s 10s urlopen timeout. It was 25s, so the
+    `return timeout` mutant died on a transport TimeoutError instead of this test's
+    own assertion — red for a NEIGHBOURING guard's reason, which proves nothing
+    about this one.
     """
-    srv, _ = _serve(cmd_timeout=25.0, poll_timeout=5.0)
+    # ping_timeout is passed EXPLICITLY: make_handler resolves it once at
+    # construction, so patching the env (or PING_TIMEOUT_DEFAULT) at request time
+    # would be inert and the test would silently measure the 2s default instead.
+    srv, _ = _serve(cmd_timeout=8.0, poll_timeout=5.0,   # < the 10s urlopen bound
+                    ping_timeout=0.3)
     ext = FakeExtension(srv, swallow=True)     # takes the op, never answers
     ext.start()
 
@@ -1495,21 +1510,86 @@ def test_ping_fast_fails_even_while_BUSY_once_the_work_has_blown_its_budget():
         else:
             pytest.fail("the fake extension never dequeued the wedging op")
 
-        # Let its (shrunken) budget lapse, so the in-flight work is now OVERDUE.
-        with mock.patch.object(S, "EXEC_OP_BUDGET_S", 0.2):
-            time.sleep(0.4)
+        # Let the (shrunken) budget lapse, so the in-flight work is now OVERDUE.
+        # age ends up ~4s: 3.0 + 0.5 - 4.0 < 0, so the budget is negative WITH the
+        # age term and +3.5s without it.
+        time.sleep(4.0)
+        with mock.patch.object(S, "EXEC_OP_BUDGET_S", 3.0), \
+                mock.patch.object(S, "WEDGE_GRACE_S", 0.5):
             t0 = time.monotonic()
             st, _ = _req(srv, "POST", "/cmd", {"op": "ping"})
             elapsed = time.monotonic() - t0
         assert st == 504
-        # Fast, NOT the 25s cmd_timeout: the budget went negative, so the deadline
-        # clamps down to the fast floor.
-        assert elapsed < 5.0, (
-            f"ping waited {elapsed:.1f}s against a wedged instance — the gate did "
-            "not notice the in-flight work was overdue")
+        # Fast, NOT cmd_timeout: the budget went negative, so it clamps to the
+        # fast floor. 1.5 sits between 0.3 (correct) and 3.5 (no `- age` term).
+        assert elapsed < 1.5, (
+            f"ping waited {elapsed:.2f}s against a wedged instance — the gate did "
+            "not subtract how long the in-flight work had already been running")
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
         t.join(timeout=30)                     # let it finish before pytest moves on
+
+
+def test_ping_still_waits_after_the_SUBMITTER_gave_up_on_a_running_command():
+    """🔴 REGRESSION (round-3 audit). The submitter abandoning a command does NOT
+    free the extension: its serial loop is still executing that command for up to
+    EXEC_OP_BUDGET_MS (18s) + RESULT_BUDGET_MS (10s) = 28s, which EXCEEDS the 20s
+    default cmd_timeout. Dropping the `inflight` entry on BridgeTimeout therefore
+    opened a window where the instance looks IDLE while it is provably still busy,
+    and the next ping fast-failed at 2s against a perfectly healthy extension.
+
+    In that window a0a0021 was WORSE than both main (20s flat) and the round-2
+    constant (10s flat) — under either of those the ping would have waited it out.
+
+    Shape: cmd_timeout 5s, a command that takes 8s. The submitter gives up at 5s;
+    the extension is still executing until 8s; the ping is issued at ~5s and must
+    still be alive at 8s.
+    """
+    srv, _ = _serve(cmd_timeout=5.0, poll_timeout=5.0)
+
+    def executor(cmd):
+        if cmd.get("op") == "getHtml":
+            time.sleep(8.0)                 # outlives the submitter's 5s deadline
+            return {"html": "<html></html>"}
+        return {"pong": True}
+
+    ext = FakeExtension(srv, executor=executor)
+    ext.start()
+    abandoned = {}
+
+    def _abandon():
+        try:
+            abandoned["st"] = _req(srv, "POST", "/cmd", {"op": "getHtml"})[0]
+        except Exception as exc:            # noqa: BLE001
+            abandoned["exc"] = exc
+
+    t = threading.Thread(target=_abandon, daemon=True)
+    try:
+        assert _wait_connected(srv, want=True)
+        t.start()
+        # Wait for the extension to actually START it, then for the submitter to
+        # give up. Both preconditions are established, not assumed.
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            if any(c.get("op") == "getHtml" for c in ext.dispatched):
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail("the fake extension never dequeued the long op")
+        t.join(timeout=15)
+        assert abandoned.get("st") == 504, "precondition: the submitter must give up"
+
+        # The extension is STILL executing here. The ping must not read this as idle.
+        t0 = time.monotonic()
+        st, body = _req(srv, "POST", "/cmd", {"op": "ping"})
+        elapsed = time.monotonic() - t0
+        assert st == 200, (
+            f"ping was told the extension is dead after {elapsed:.2f}s, while it "
+            "was still executing an abandoned command")
+        assert body["result"]["data"]["pong"] is True
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+        t.join(timeout=15)
 
 
 def test_effective_timeout_gate_unit(monkeypatch):
@@ -1552,6 +1632,16 @@ def test_effective_timeout_gate_unit(monkeypatch):
     inst.inflight = {"a": 1000.0, "b": 1005.0}
     assert g(60.0, 2.0) == pytest.approx(2 * 18.0 + 2.0 - 12.0)
 
+    # 7. 🟢-D: fast_timeout ABOVE cmd_timeout must NOT escape the ceiling. Both are
+    #    operator-settable and nothing validates the relation; before the inner
+    #    clamp this returned 60.0 for fast=60 / cmd=20, contradicting the
+    #    "never above cmd_timeout" claim in the docstring.
+    inst.inflight = {}
+    assert g(20.0, 60.0) == 20.0, "idle: fast_timeout must be capped at cmd_timeout"
+    inst.inflight = {"a": 1000.0}
+    clock["t"] = 1030.0                     # overdue -> lower clamp is what applies
+    assert g(20.0, 60.0) == 20.0, "busy: the lower clamp must not lift it past cmd"
+
 
 def test_exec_budget_matches_the_extension():
     """EXEC_OP_BUDGET_S mirrors EXEC_OP_BUDGET_MS across a language boundary, so
@@ -1567,35 +1657,135 @@ def test_exec_budget_matches_the_extension():
         f"{S.EXEC_OP_BUDGET_S}s — the busy/wedged gate is now wrong")
 
 
-def test_inflight_is_released_on_every_exit_path():
-    """A stranded `inflight` entry is worse than a stranded `pending` slot: the
-    instance would look permanently busy and `ping` could never fast-fail on it
-    again. Pinned across the three exits — success, timeout, and a never-answered
-    command whose caller gave up.
+def test_inflight_release_distinguishes_queued_from_running_on_abandon():
+    """`inflight` bookkeeping across the exits that behave DIFFERENTLY. A stranded
+    entry makes an instance look permanently busy so `ping` can never fast-fail on
+    it again; releasing too eagerly makes a busy instance look idle (the bug this
+    round fixed). Both directions are wrong, so both are pinned.
+
+    An earlier version of this test claimed three exits, had two blocks, and both
+    described the same case (timeout-after-dequeue). These are genuinely distinct:
+
+      1. SUCCESS                     -> released at once.
+      2. abandoned while STILL QUEUED -> released at once: it never ran and never
+         will, so the instance really is that much less busy.
+      3. abandoned while RUNNING      -> KEPT. The extension is still executing it;
+         releasing here is exactly what made a busy instance read as idle.
+      4. ...and the kept entry is released when the late result finally arrives,
+         rather than lingering until the staleness window expires.
     """
+    # 1. SUCCESS
     srv, reg = _serve(cmd_timeout=1.0, poll_timeout=5.0)
     ext = FakeExtension(srv, executor=lambda c: {"ok": 1})
     ext.start()
     try:
         assert _wait_connected(srv, want=True)
-        st, _ = _req(srv, "POST", "/cmd", {"op": "tabs"})       # success
-        assert st == 200
+        assert _req(srv, "POST", "/cmd", {"op": "tabs"})[0] == 200
         insts = list(reg._instances.values())
         assert insts and all(not i.inflight for i in insts), "leaked after success"
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
 
-    srv, reg = _serve(cmd_timeout=1.0, poll_timeout=5.0)
+    # 2. ABANDONED WHILE STILL QUEUED — nothing is polling, so the command never
+    #    leaves the outbox. The instance stays resolvable (CONNECT_STALE_S).
+    #    A SHORT poll_timeout matters: stop() only sets a flag, so the thread must
+    #    be allowed to finish its in-flight long poll and exit before we submit —
+    #    otherwise it dequeues the command and this becomes case 3 by accident.
+    srv, reg = _serve(cmd_timeout=1.0, poll_timeout=0.5)
     ext = FakeExtension(srv, swallow=True)
     ext.start()
     try:
         assert _wait_connected(srv, want=True)
-        st, _ = _req(srv, "POST", "/cmd", {"op": "getHtml"})    # timeout
-        assert st == 504
+        ext.stop()
+        ext.join(timeout=10)
+        assert not ext.is_alive(), "the fake must be fully stopped, not just flagged"
+        before = len(ext.dispatched)
+        assert _req(srv, "POST", "/cmd", {"op": "getHtml"})[0] == 504
+        assert len(ext.dispatched) == before, "precondition: it must NOT be dequeued"
         insts = list(reg._instances.values())
-        assert insts and all(not i.inflight for i in insts), "leaked after timeout"
+        assert insts and all(not i.inflight for i in insts), (
+            "a command that never left the outbox must not keep the instance busy")
     finally:
-        ext.stop(); srv.shutdown(); srv.server_close()
+        srv.shutdown(); srv.server_close()
+
+    # 3 + 4. ABANDONED WHILE RUNNING, then the late result lands.
+    gate = threading.Event()
+
+    def executor(cmd):
+        gate.wait(timeout=10)
+        return {"ok": 1}
+
+    srv, reg = _serve(cmd_timeout=1.0, poll_timeout=5.0)
+    ext = FakeExtension(srv, executor=executor)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _req(srv, "POST", "/cmd", {"op": "getHtml"})[0] == 504
+        insts = list(reg._instances.values())
+        assert insts and any(i.inflight for i in insts), (
+            "the extension is STILL executing it — the entry must survive")
+        gate.set()                            # let the late result arrive
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            if all(not i.inflight for i in reg._instances.values()):
+                break
+            time.sleep(0.02)
+        assert all(not i.inflight for i in reg._instances.values()), (
+            "the late result must release the kept entry, not leave it to expire")
+    finally:
+        gate.set(); ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_a_kept_inflight_entry_expires_if_the_result_never_arrives():
+    """The memory/liveness bound on case 3 above. If the abandoned command's result
+    NEVER comes, the entry must stop counting after INFLIGHT_STALE_S — otherwise
+    one wedged command would make `ping` slow on that instance forever, which is
+    the failure the whole fast path exists to avoid.
+
+    Measured at THREE points, because the two thresholds are different and it
+    would be easy to conflate them:
+      * age <  EXEC+GRACE      -> the extension may still be working: derived
+                                  deadline, entry retained.
+      * EXEC+GRACE < age < STALE -> budget has gone negative (the extension blew
+                                  its own self-bound, so it IS wedged): the ping is
+                                  fast again, but the entry is still RETAINED —
+                                  the staleness window bounds memory, not the
+                                  busy/wedged verdict. Conflating the two would
+                                  make the ping slow for a further 8s.
+      * age >  STALE           -> pruned.
+    """
+    clock = {"t": 1000.0}
+    reg = S.Registry(clock=lambda: clock["t"])
+    inst = S.Instance("k", "i", "", clock["t"])
+    inst.inflight = {"abandoned": 1000.0}
+    assert S.INFLIGHT_STALE_S > S.EXEC_OP_BUDGET_S + S.WEDGE_GRACE_S, (
+        "this test needs the two thresholds to be distinct")
+
+    # 1. Could still be running -> derived deadline, retained.
+    clock["t"] = 1000.0 + 5.0
+    assert reg._effective_timeout_locked(inst, 20.0, 2.0) > 2.0
+    assert inst.inflight, "must not be pruned while it could still be running"
+
+    # 2. Past its own budget but inside the staleness window -> fast, still retained.
+    clock["t"] = 1000.0 + S.EXEC_OP_BUDGET_S + S.WEDGE_GRACE_S + 1.0
+    assert reg._effective_timeout_locked(inst, 20.0, 2.0) == 2.0
+    assert inst.inflight, "the staleness window is about memory, not the verdict"
+
+    # 3. Past the staleness window -> pruned.
+    clock["t"] = 1000.0 + S.INFLIGHT_STALE_S + 1.0
+    assert reg._effective_timeout_locked(inst, 20.0, 2.0) == 2.0
+    assert not inst.inflight, "a stale entry must be pruned, not just ignored"
+
+
+def test_result_budget_matches_the_extension():
+    """RESULT_BUDGET_S mirrors RESULT_BUDGET_MS across a language boundary — the
+    same drift hazard as EXEC_OP_BUDGET_S, and it feeds INFLIGHT_STALE_S."""
+    proto = (Path(__file__).resolve().parent.parent
+             / "extension" / "protocol.js").read_text(encoding="utf-8")
+    m = re.search(r"export const RESULT_BUDGET_MS\s*=\s*(\d+)", proto)
+    assert m, "could not find RESULT_BUDGET_MS in protocol.js — retarget this test"
+    assert float(m.group(1)) / 1000.0 == S.RESULT_BUDGET_S, (
+        f"protocol.js says {m.group(1)}ms, server.py says {S.RESULT_BUDGET_S}s")
 
 
 def test_a_healthy_ping_is_unaffected_and_answers_in_milliseconds(monkeypatch):


### PR DESCRIPTION
Five CLI/behaviour fixes from the 2026-08-02 usage audit (`claudedocs/browser-bridge-usage-audit-2026-08-02.md`, PR #274), plus one regression found while measuring them.

Files: `scripts/browser-bridge/browser`, `scripts/browser-bridge/server.py`, `scripts/browser-bridge/tests/test_browser_cli_args.py`, `scripts/browser-bridge/tests/test_server.py`. No `SKILL.md`, no `reference/**`, no `browser_tool.test.mjs`, no extension.

## What changed

**S1 — `--wake[=MS]` on `nav` and `open`** (audit F2). The flag existed on exactly `html`/`text`/`js`. The three copy-pasted parse blocks are consolidated into ONE `_wake_flag` helper that all five branches call; validation still happens at PARSE time (the `die` is in the flag loop, never inside `wake_fields`' command substitution).

`nav`/`open` send **no `wake` field on the wire** — the extension honours `cmd.wake` only on `getHtml`/`text`/`eval`, and the extension is out of this PR's scope. `--wake` is therefore a client-side compose (`_wake_after`): the nav/open op, then the existing `wake` op, annotated at `result.data.wake` — the same place a `--wake` read reports it. The round trip it removes is the *agent's*, not the bridge's. Two wire ops, one invocation.

**S2 — `ping` gets its own 2 s deadline** (F7). New `PING_TIMEOUT_DEFAULT = 2.0` + `BROWSER_BRIDGE_PING_TIMEOUT`, resolved through a new `_env_float` that falls back on an unparseable value rather than killing the service at startup. Applied at exactly one place, `op_timeout = ping_timeout if op == "ping" else cmd_timeout` — no other op's timeout moves.

**S3 — `unknown_instance` / `no_extension` split into two messages** (F6). 48 of 52 `unknown_instance` failures used the **correct** label, with `eval` retried 37×. The server already returns `known_instances` in both bodies; the CLI now reads it. Key known-but-disconnected → names when it went away, says **FULLY RESTART Brave**, says **DO NOT RETRY**. Key never seen → says WRONG LABEL and lists the keys that exist, with no restart advice. `no_extension` gets the same split.

**S4 — `/whoami` and `/health` emit telemetry** (F8). 53 invocations were invisible to the only structured source. Metadata-only via the existing `emit_cmd_event`, after the response, best-effort. **No domain and no key** — these endpoints are global (they describe every connected profile at once), so emitting per-profile domains would widen the privacy contract at `server.py`'s PRIVACY CONTRACT. `/instances` and `/poll` still emit nothing. `health`'s output shape is untouched.

**S5 — explicit-path `screenshot` prints a Read hint** (F4; 7 of 63 captures never Read). Line 1 stays the bare path; line 2 is `# Read <path> to view it.` The `#` prefix keeps it from ever being mistaken for a second path. Not printed for `--data-url` or the temp-file form.

**S6 — the broken doc pointer.** `browser:582`/`:588` pointed at "SKILL.md → Concurrency", a heading that has never existed. Repointed at `reference/tabs-instances.md` + the Concurrent-drivers paragraph of `SKILL.md → This is the user's LIVE session`, and a test now proves every `SKILL.md → <heading>` the CLI names resolves.

**Bonus (second commit) — `--help` stopped dumping the whole file.** Found while measuring S1–S6's byte cost: `--help` was `grep -E '^#( |$)' "$0"`, i.e. *every* column-0 comment in the file. It shipped 25,440 bytes of implementation commentary as user-facing help and grew with every internal comment — S1–S6's comments alone would have added **+4,129 bytes to every `--help`**. Now the contiguous `#` block after the shebang, stopping at the first line of code.

## Red → green matrix

Base = `origin/main` (`ff0fe41`). Method: commit, then `git checkout origin/main -- browser server.py` keeping the new tests, run, restore with `git checkout HEAD -- …`. No `git stash` anywhere (`git stash list` verified unchanged: 58 entries, `stash@{0}` intact).

**Harness validation first.** The initial base run reported 33 failures — contaminated: the new `_serve(..., ping_timeout=)` raises `TypeError` against the pre-S2 `make_handler`, so *every* `_serve()` call errored and pre-existing tests failed for a reason that had nothing to do with the change. That green/red was worthless. Re-run with a measurement-only signature shim (reverted, not shipped) and the base run came back **exactly 17 failures, all of them new tests, every pre-existing test green** — which is also the control proving the test-file helper edits are base-compatible.

| test | base | HEAD | kind |
|---|---|---|---|
| `test_wake_on_nav_and_open_issues_the_wake_in_one_invocation[nav]`, `[open]` | RED | green | regression (S1) |
| `test_wake_on_nav_and_open_is_order_free_and_carries_ms[nav]`, `[open]` | RED | green | regression (S1) |
| `test_nav_and_open_validate_wake_ms_at_parse_time[nav]`, `[open]` | RED | green | regression (S1) |
| `test_nav_and_open_still_reject_an_unknown_flag[nav]`, `[open]` | RED | green | regression (S1) |
| `test_no_wake_on_nav_and_open_sends_exactly_one_unchanged_command[nav]`, `[open]` | green | green | **INVARIANT GUARD** — back-compat |
| `test_open_with_no_url_still_means_about_blank` | green | green | **INVARIANT GUARD** |
| `test_ping_does_not_wait_out_cmd_timeout` | RED (8.0 s) | green | regression (S2) |
| `test_ping_timeout_is_env_overridable_and_survives_a_malformed_value` | RED (8.0 s) | green | regression (S2) |
| `test_the_short_deadline_applies_to_ping_ONLY` | green | green | **NEGATIVE CONTROL** |
| `test_a_healthy_ping_is_unaffected_and_answers_in_milliseconds` | green | green | **NEGATIVE CONTROL** |
| `test_unknown_instance_KNOWN_but_disconnected_says_stop_retrying` | RED | green | regression (S3) |
| `test_unknown_instance_NEVER_SEEN_key_says_wrong_label` | RED | green | regression (S3) + branch control |
| `test_no_extension_distinguishes_dropped_from_never_wired_up` | RED | green | regression (S3) |
| `test_routing_failure_explainer_degrades_against_an_OLD_server` | green | green | **INVARIANT GUARD** — the CLI goes live on pull, before the switch restarts server.py |
| `test_orientation_ops_emit_exactly_one_metadata_only_event[/whoami]`, `[/health]` | RED (0 events) | green | regression (S4) |
| `test_instances_and_poll_still_do_not_emit` | green | green | **INVARIANT GUARD** |
| `test_orientation_emit_never_breaks_the_response` | green | green | **INVARIANT GUARD** — best-effort contract at the new call site |
| `test_browser_cli_screenshot_explicit_path_prints_path_then_a_read_hint` | RED | green | regression (S5) |
| `test_browser_cli_screenshot_read_hint_not_printed_where_it_would_be_wrong` | green | green | **NEGATIVE CONTROL** |
| `test_every_skill_md_heading_the_cli_points_at_actually_exists` | RED (`['Concurrency']`) | green | regression (S6) |
| `test_help_prints_the_HEADER_block_only_not_the_whole_files_comments` | RED | green | regression (help) |

## Mutation results (each confirmed red with THAT guard's own error)

| # | mutation | result |
|---|---|---|
| M1 | `op_timeout = cmd_timeout` (ping loses its deadline) | RED — `ping waited 8.0s — cmd_timeout, not its own`. The negative control stayed **green**, proving it discriminates. |
| M2 | `op_timeout = ping_timeout` (leaks to every op) | RED — `getHtml returned in 2.00s — the short ping deadline leaked onto every op`. Only the negative control fired. |
| M3 | delete the `/health` emit | RED — `expected exactly one event, got []`, `[/health]` only; `[/whoami]` stayed green. |
| M4 | emit a `domain` (privacy weakening) | RED on both `[/whoami]` and `[/health]` — payload equality catches it. |
| M5 | hard-wire S3 to the disconnected branch | RED — `assert 'is UNKNOWN' in "…is KNOWN but NOT CONNECTED…"`. |
| M6 | hard-wire S3 to the unknown branch (`if False:`) | RED — the mirror assertion. Both branches proven reachable. |
| M7 | move the screenshot hint to the temp-file path | RED **twice**: the positive test (hint absent from explicit path) *and* the negative control (hint wrongly present on the temp path). |
| M8 | `nav` parses `--wake` but never composes the wake | RED — `assert ['nav'] == ['nav', 'wake']`. |
| M9 | delete the parse-time `--wake=MS` validation from `_wake_flag` | RED on `[nav]` **and** `[open]` from a single deletion — the consolidation is real, one rule in one place. |
| M10 | restore `SKILL.md -> Concurrency` | RED — `assert ['Concurrency'] == []`. |
| M11 | restore the `grep`-everything `--help` | RED — `--help leaked an internal comment: wake_fields WAKE WAITMS`. |

The S6 pointer test carries its **own inline harness negative control**: the extractor is run against a known-bad pointer (must report `["Concurrency"]`) and a known-good one (must report `[]`) before its verdict on the real file is read.

## Test counts (counted, not exit codes)

- pytest: **393 passed, 0 failed** (baseline 369 → +24). Clean tree at the time of the run (`git status -s` empty).
- node: **tests 454 / pass 454 / fail 0 / skipped 0**. `grep -ci 'test timed out'` → 0. No `.mjs` file was touched, so 454 is also the base count.

## Verified live vs. tests only

Live host: **laptop `192.168.50.155`**, profile `personal`, extension 0.7.0, deployed server git `f5fbe82`. **My worktree was CLEAN at the time** (committed). The `browser` CLI is a working-tree symlink so the *CLI* under test was my branch's code; `server.py` was the **deployed** artifact, i.e. pre-S2/S4.

**S1 — live-verified end to end** against `tests/fixtures/oopif-rig/wake-rig.html` served on `127.0.0.1:8901`:

```
NEGATIVE CONTROL, same tab, read with NO wake:
  {"raf":1,"timer":16,"rendered":false,…} | app=WAKE-RIG-SHELL (waiting for frames) | vis=hidden
AFTER `browser nav --wake <rig>` (ONE invocation), plain read, no wake flag:
  {"raf":30,"timer":367,"rendered":true,"ms":544,…} | app=WAKE-RIG-RENDERED | vis=hidden
AFTER `browser open --wake <rig>`:
  WAKE-RIG-RENDERED | raf=30 | vis=hidden
```

`raf` pinned at 1 while `timer` climbed — live and throttled, not dead — so the control is not vacuous. `vis=hidden` throughout: **no focus was moved**, `activate` was never called. Tab closed afterwards.

**S3 — live-verified for the never-seen branch** (`browser --instance nosuchlabel tabs` printed the WRONG-LABEL message and listed `personal, work`). The **known-but-disconnected branch was NOT live-verified** — producing it means killing a Brave profile's long-poll, which I would not do to the operator's session. It is covered by canned-server tests only.

**S2 — NOT live-verified.** The change is in `server.py`, which is not deployed. I confirmed only that the healthy path is unaffected: `browser --instance personal ping` → `pong`, extension 0.7.0, **68 ms** end to end against the deployed server. The 2 s failure path is covered by wall-clock tests only.

**S4 — NOT live-verified** (same reason: `server.py` is not deployed). Covered by tests.

**S5, S6, `--help` — tests + direct CLI invocation only** (no bridge involved).

🔴 **`server.py` changes need `home-manager switch` + `systemctl --user restart browser-bridge` to go live.** The CLI half (S1, S3, S5, S6, `--help`) is a `mkOutOfStoreSymlink` onto the working tree and goes live on pull. Until the switch, S1's `nav --wake` works (it is pure CLI) but S2/S4 do not.

## Per-call byte deltas of added output

| surface | before | after | delta |
|---|---|---|---|
| `browser --help` | 25,440 B | 15,532 B | **−9,908 B** |
| `screenshot <path>` stdout | path + `\n` | + one line | **+20 B + len(path)** (60 B for a 40-char path) |
| `unknown_instance` stderr | 216 B | 542 B | **+326 B**, error path only (52 occurrences in the 2-day window) |
| `nav`/`open` **without** `--wake` | — | — | **0** — same single wire op, same bytes |
| `nav`/`open` **with** `--wake` | n/a | + `result.data.wake` object | replaces a separate `browser wake` invocation, which printed a larger standalone envelope — net negative |
| `whoami` / `health` / every read op | — | — | **0** |

## Could not verify

- S2's timeout path and S4's emit **on the real bridge** — both require a `home-manager switch` this PR does not perform.
- S3's known-but-disconnected branch live (would require killing a profile's long-poll).
- Whether the audit's claim that `health` prints both profiles' full active-tab URLs to its caller is a problem worth fixing — explicitly out of scope; `health`'s output shape is unchanged here.

## Note on a test-harness change

`test_server.py`'s `_wait_connected` now polls `/instances` instead of `/health`, and a new `_wait_count` does the same for two telemetry tests. Reason: S4 makes `/health` emit, and these helpers call it in a tight loop, so they injected spurious events into the spool of every test that waits for a connection (14 went red). The fix makes the *harness* silent rather than loosening the exact-count assertions. `_wait_instances` stays on `/health` because its callers read health-only fields. Both are commented in place so nobody points them back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
