### PR TITLE
ci: gate the browser-bridge node suite in the flake (460 tests, counted)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,8 @@
       # Deps below cover the modules-under-test's import-time requirements
       # (requests/psycopg2/minio/pyyaml); the tests themselves mock the I/O.
       # ---------------------------------------------------------------------
-      checks.${system}.pytests =
+      checks.${system} = {
+        pytests =
         let
           pyEnv = pkgs.python312.withPackages (ps: with ps; [
             pytest
@@ -102,5 +103,55 @@
             bash scripts/run-tests.sh --set hermetic .
             touch "$out"
           '';
+
+      # ---------------------------------------------------------------------
+      # Node test gate — scripts/browser-bridge/tests/*.test.mjs (460 tests).
+      #
+      # Deliberately a SEPARATE check from `pytests`, not folded into it:
+      #  • distinct toolchain (nodejs vs python312) — keeping them apart means
+      #    the pytest gate's closure doesn't grow a node dependency, and a node
+      #    toolchain bump can't invalidate the python gate's build cache;
+      #  • distinct failure signal — `nix flake check` names the failing check,
+      #    so "nodetests failed" vs "pytests failed" is legible without reading
+      #    the log;
+      #  • they run in parallel under `nix flake check`, so the wall-clock cost
+      #    of adding this is ~0 next to the (much slower) python gate.
+      #
+      # Until this existed the .mjs suite gated NOTHING — flake.nix had zero
+      # references to node, so every "460 pass" claim was a MANUAL run and a
+      # .mjs regression could merge freely.
+      #
+      # HERMETIC (audited 2026-08-02): the suite has no `createServer`/`.listen()`,
+      # no `spawn`/`execFile`, and every `fetch` is a stub assigned onto
+      # `globalThis.fetch`. Its only I/O is reads of repo-relative files and
+      # writes under `tmpdir()`. Nothing needs the network the sandbox denies —
+      # so nothing is excluded, and the runner's test-count floor is what proves
+      # that stays true.
+      #
+      # nodejs is pinned from THIS flake's locked nixpkgs, NOT whatever node
+      # happens to be on the dev host's PATH. MEASURED 2026-08-02: the sandbox
+      # runs v24.18.0 while the workbench's PATH node is v26.5.0 — the runner
+      # echoes `node --version` on every run so the gate's toolchain is never a
+      # guess, and that divergence is the proof the pin is real.
+      # ---------------------------------------------------------------------
+        nodetests =
+        pkgs.runCommandLocal "devrc-nodetests"
+          {
+            nativeBuildInputs = [ pkgs.nodejs pkgs.bash pkgs.git pkgs.gnugrep pkgs.gawk pkgs.coreutils ];
+          }
+          ''
+            cp -r ${./.} src
+            chmod -R u+w src
+            export HOME="$TMPDIR/home"
+            mkdir -p "$HOME"
+            cd src
+            # The runner globs the .test.mjs files itself, asserts a file-count
+            # and a TEST-COUNT floor, and refuses to degrade to `node --test <dir>`
+            # (which silently yields a bogus `# tests 1 / # fail 1`). Read its
+            # header before changing this line.
+            bash scripts/run-node-tests.sh .
+            touch "$out"
+          '';
+      };
     };
 }

--- a/scripts/run-node-tests.sh
+++ b/scripts/run-node-tests.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# devrc NODE test-suite runner — the single source of truth for "run the .mjs tests".
+#
+# Used by BOTH:
+#   1. the flake check  (nix flake check / nix build .#checks.x86_64-linux.nodetests)
+#      — runs in the nix sandbox (no network, nodejs pinned by flake.nix).
+#   2. a dev-host invocation: `bash scripts/run-node-tests.sh` from the repo root.
+#
+# The caller is responsible for putting `node` on PATH (the flake check does this
+# via the derivation's nativeBuildInputs). This script only ORCHESTRATES.
+#
+# The suite under test is scripts/browser-bridge/tests/*.test.mjs. It is HERMETIC:
+# audited 2026-08-02 — no `createServer`/`.listen()`, no `spawn`/`execFile`, every
+# `fetch` is a stub assigned onto `globalThis.fetch`, and the only I/O is reads of
+# repo-relative files (extension/protocol.js, browser-agent, server.py) plus writes
+# under `tmpdir()`. Nothing reaches the network or a subprocess.
+#
+# 🔴 TWO STRUCTURAL GUARDS — both exist because a green exit code lies here:
+#
+#   1. NEVER PASS A DIRECTORY. `node --test scripts/browser-bridge/tests/` silently
+#      collapses to `# tests 1 / # fail 1` (MODULE_NOT_FOUND) — a FALSE RED that a
+#      future edit could just as easily turn into a false green. This script globs
+#      the files itself into an array and refuses to run if any element is not a
+#      regular file ending in `.test.mjs`, so it CANNOT degrade to the dir form.
+#
+#   2. COUNT THE TESTS, don't read the exit code. A collection failure, a bad glob,
+#      or a toolchain breakage can produce "0 tests, exit 0". We parse node's TAP
+#      summary and fail unless the run reports at least MIN_TESTS. Without this the
+#      gate can go green while testing nothing — which is exactly how the pytest
+#      gate silently skipped 41 test_server.py tests for want of `curl` on PATH.
+#
+# Env overrides (defaults are the point — raise them, don't lower them casually):
+#   MIN_TESTS  minimum tests the run must REPORT   (default 450; 460 pass today)
+#   MIN_FILES  minimum .test.mjs files to collect  (default 14; 14 exist today)
+#
+# Exit non-zero if the suite fails OR either floor is not met.
+
+set -uo pipefail
+
+ROOT=""
+[ $# -gt 0 ] && ROOT="$1"
+if [ -z "$ROOT" ]; then
+  ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null || true)"
+  [ -n "$ROOT" ] || ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+cd "$ROOT" || { echo "run-node-tests: cannot cd to ROOT=$ROOT" >&2; exit 2; }
+
+MIN_TESTS="${MIN_TESTS:-450}"
+MIN_FILES="${MIN_FILES:-14}"
+
+command -v node >/dev/null 2>&1 || {
+  echo "run-node-tests: FATAL — no \`node\` on PATH (the caller must provide one)" >&2
+  exit 2
+}
+echo "run-node-tests: node $(node --version)"
+
+# --- collect (guard 1) ---------------------------------------------------------
+shopt -s nullglob
+FILES=(scripts/browser-bridge/tests/*.test.mjs)
+shopt -u nullglob
+
+if [ "${#FILES[@]}" -lt "$MIN_FILES" ]; then
+  echo "run-node-tests: FATAL — collected ${#FILES[@]} test file(s), expected >= $MIN_FILES." >&2
+  echo "  The glob matched nothing or almost nothing. Do NOT 'fix' this by passing the" >&2
+  echo "  tests DIRECTORY to \`node --test\` — that yields a bogus 1-test failure." >&2
+  exit 2
+fi
+for f in "${FILES[@]}"; do
+  case "$f" in
+    *.test.mjs) ;;
+    *) echo "run-node-tests: FATAL — refusing non-test argument: $f" >&2; exit 2 ;;
+  esac
+  [ -f "$f" ] || { echo "run-node-tests: FATAL — not a regular file: $f" >&2; exit 2; }
+done
+echo "run-node-tests: collected ${#FILES[@]} test files"
+
+# --- run -----------------------------------------------------------------------
+LOG="$(mktemp)"
+trap 'rm -f "$LOG"' EXIT
+node --test --test-reporter=tap "${FILES[@]}" >"$LOG" 2>&1
+rc=$?
+cat "$LOG"
+
+# --- count (guard 2) -----------------------------------------------------------
+# node's TAP summary lines: "# tests N", "# pass N", "# fail N". Take the LAST of
+# each (one summary per run) and default to a sentinel that fails the check if the
+# line is absent entirely.
+sum() { grep -E "^# $1 [0-9]+$" "$LOG" | tail -1 | awk '{print $3}'; }
+T="$(sum tests)"; P="$(sum pass)"; F="$(sum fail)"; S="$(sum skipped)"; TD="$(sum todo)"
+: "${T:=-1}"; : "${P:=-1}"; : "${F:=-1}"; : "${S:=0}"; : "${TD:=0}"
+
+echo "======================== NODE SUMMARY ========================"
+echo "  files=${#FILES[@]}  tests=$T  pass=$P  fail=$F  skipped=$S  todo=$TD  (floor: $MIN_TESTS)"
+
+status=0
+if [ "$T" -lt 0 ] || [ "$P" -lt 0 ] || [ "$F" -lt 0 ]; then
+  echo "  ERROR: could not parse node's TAP summary — the runner cannot vouch for this run." >&2
+  status=1
+fi
+if [ "$T" -lt "$MIN_TESTS" ]; then
+  echo "  ERROR: only $T tests ran, floor is $MIN_TESTS. Something collected far fewer" >&2
+  echo "         tests than exist — a VACUOUS GREEN, not a pass. Investigate before" >&2
+  echo "         lowering MIN_TESTS." >&2
+  status=1
+fi
+if [ "$F" -gt 0 ]; then
+  echo "  ERROR: $F test(s) failed." >&2
+  status=1
+fi
+if [ "$rc" -ne 0 ] && [ "$status" -eq 0 ]; then
+  echo "  ERROR: node exited $rc with no failing test — a crash or unhandled rejection." >&2
+  status=1
+fi
+
+if [ "$status" -ne 0 ]; then
+  echo "RESULT: FAIL"
+else
+  echo "RESULT: PASS"
+fi
+exit "$status"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -7,6 +7,14 @@
 #      — runs the HERMETIC set in the nix sandbox (no network, pinned python).
 #   2. githooks/pre-push — runs the fuller set on the dev host before a push.
 #
+# SCOPE: this script runs the PYTHON suites ONLY. The browser-bridge `.mjs` suite
+# (scripts/browser-bridge/tests/*.test.mjs) is NOT run here — it has its own
+# runner, scripts/run-node-tests.sh, gated by its own flake check
+# (`nix build .#checks.x86_64-linux.nodetests`). `nix flake check` runs both.
+# Note that `HERMETIC_DIRS` below includes scripts/browser-bridge/tests, but that
+# entry collects only the `test_*.py` files in that directory — pytest does not
+# see the `.mjs` files at all.
+#
 # The caller is responsible for putting a pytest-capable `python` on PATH (the
 # flake check does this via the derivation's buildInputs; the pre-push hook wraps
 # this in a nix-shell with the deps). This script only ORCHESTRATES: each test


### PR DESCRIPTION
ci: gate the browser-bridge node suite in the flake (460 tests, counted)

The 460-test `.mjs` suite gated NOTHING. flake.nix had zero references to
node/mjs; `checks.pytests` runs scripts/run-tests.sh, which invokes
`python -m pytest` only. Every "460 pass" claim in recent PRs was a MANUAL
run, and a .mjs regression could merge freely.

Adds `checks.x86_64-linux.nodetests` + scripts/run-node-tests.sh.

Separate check, not folded into pytests: distinct toolchain (so the python
gate's closure doesn't grow node, and a node bump can't invalidate its
cache), distinct failure signal from `nix flake check`, and they run in
parallel so the wall-clock cost is ~0.

Two structural guards in the runner, because a green exit code lies here:

  1. Never pass a directory. `node --test <dir>` silently collapses to
     `# tests 1 / # fail 1` (MODULE_NOT_FOUND). The runner globs the files
     into an array and refuses any element that is not a regular file
     ending in .test.mjs, so it cannot degrade to the dir form.
  2. COUNT the tests. Parses node's TAP summary and fails below MIN_TESTS
     (450; 460 today) and MIN_FILES (14). Without this the gate can go
     green while testing nothing -- exactly how the pytest gate silently
     skipped 41 test_server.py tests for want of curl on PATH.

Hermeticity audited AND measured: the suite has no createServer/.listen(),
no spawn/execFile, every fetch is a stub on globalThis.fetch, and its only
I/O is repo-relative reads plus tmpdir() writes. All 460 run in the
sandbox -- nothing excluded, nothing skipped.

nodejs is pinned from this flake's nixpkgs: the sandbox runs v24.18.0 while
the host PATH node is v26.5.0, and the runner echoes node --version each
run so the toolchain is never a guess.

run-tests.sh's header claimed to be the source of truth for the flake gate;
it now states it covers the PYTHON suites only and points at the node
runner + check.

Verification:
  * negative control: mutating one assertion in browser_tool.test.mjs made
    `nix build .#checks.x86_64-linux.nodetests` exit 1 with
    "files=14 tests=460 pass=459 fail=1 / RESULT: FAIL". Reverted -> exit 0.
  * runner guards proven reachable individually: MIN_TESTS=99999 -> exit 1
    with the vacuous-green error; MIN_FILES=999 -> exit 2; no node on PATH
    -> exit 2.
  * `nix flake check` -> "running 2 flake checks ... all checks passed!"
  * pytests unchanged and still green.

Timing: nodetests ~8s. `nix flake check` 3m30s vs 3m28s for pytests alone.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
