### PR TITLE
docs(clawgate): the picker privacy choke point, and why the obvious test can't fail

### DIFF
--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -287,3 +287,24 @@ adjacent text → selector → accessible name. Full procedure, worked example, 
   first (`reference/telemetry.md`).
 - **Red GitHub Actions checks on `homelab-infra` are NOISE** (billing-blocked repo-wide). The real
   gate is the Tekton `clawgate-ci` pipeline — see the `tekton` skill before touching CI.
+- 🔴 **The browser extension does NOT ship via Flux — merging to `trunk` deploys NOTHING.** Brave
+  loads it unpacked from a **flat copy** at `~/clawgate-extension` **on the workbench** (that is
+  where Zach's Brave runs — `localhost:8972` civitai-manager answers there, not on the desktop).
+  Delivery is `scripts/sync-clawgate-extension.sh` (`--check` = drift only, rc 1 on drift), and
+  **Brave does not hot-reload unpacked extensions** — a sync without a `brave://extensions` ↻ leaves
+  the OLD build running. After adding a command, also check `brave://extensions/shortcuts`: Brave
+  routinely leaves newly-added hotkeys unbound on an in-place reload.
+  **A missing `.synced-from` stamp means someone hand-copied it out of band.** That is exactly how a
+  build that never passed CI ran live for ~11 hours on 2026-08-01 while `trunk` looked clean — it
+  was copied straight from a working tree, so `clawgate-ci` never saw it (it leaked typed text;
+  fixed in `fcaca875`/PR #276). Check the stamp before trusting any claim about which build is
+  loaded:
+  ```bash
+  ssh 192.168.50.250 'cat ~/clawgate-extension/.synced-from; grep "\"version\"" ~/clawgate-extension/manifest.json'
+  ssh 192.168.50.250 '~/workspace/homelab-talos/scripts/sync-clawgate-extension.sh --check'
+  ```
+  ⚠ Serving a scratch test page **to** that Brave: the workbench firewall `allowedTCPPorts` is a
+  short allowlist (80/443/6443/7844/8110/8180/25565/58012), so an ad-hoc port is unreachable over
+  the LAN — serve it on the workbench and open **`http://localhost:<port>`** rather than opening a
+  firewall port for a throwaway. Verifying the picker's privacy guard by hand has a trap that makes
+  the obvious test vacuous → `reference/element-references.md`.

--- a/claude/skills/clawgate/reference/element-references.md
+++ b/claude/skills/clawgate/reference/element-references.md
@@ -43,4 +43,38 @@ Resolution strategy:
 
 ### Developer note
 
-The enrichment is built by `buildEnrichment` in `extension/content.js`. It reads `window.location` for page context and walks `previousElementSibling` / `nextElementSibling` for adjacent text, capping each at 120 chars. To modify enrichment behaviour, edit that function — `lib.js` stays pure and handles only selector building and accessible name computation.
+The enrichment is built by `buildEnrichment` in `extension/content.js`. It reads `window.location`
+for page context and walks `previousSibling` / `nextSibling` (the **node** variants — text nodes
+count) for adjacent text, slicing each side at 40 chars; `refText` in `lib.js` then caps at
+`MAX_REF_TEXT_CHARS` (80). To modify enrichment behaviour, edit that function — `lib.js` stays pure
+and handles only selector building and accessible name computation.
+
+🔴 **Every page-text read in the walk MUST go through `adjacentText` → `pageText`.** That is the
+privacy choke point: element siblings get `pageText` (self / ancestor / descendant via the derived
+`TYPING_SURFACE_SEL`), text siblings are withheld unless `nearTypingSurface(parentElement)` is
+false, and anything unrecognised returns `""` — fail-closed. Reading `.textContent` directly here is
+the bug that shipped in the first cut of 1.4.0 (fixed in `fcaca875`, PR #276): it put the operator's
+typed text on the wire. **Never add a second "is this a text field" predicate** — derive from the
+shared sets so a new role covers self, ancestor and descendant at once. This same root cause
+recurred through six audit rounds on the picker and a seventh here.
+
+### 🔴 Testing the privacy guard: most obvious tests CANNOT fail
+
+**A native `<input>` or `<textarea>` never exposes its current value through `textContent`.** Typing
+updates `.value`; `.textContent` stays whatever the server rendered (empty, if it was empty). So a
+test that types a canary into a form field and picks the neighbouring element **passes under the
+leaking build too** and proves nothing. Three consecutive live captures were wasted this way on
+2026-08-02 (tasks #147–#149), each read as a pass.
+
+Only these carry user text in `textContent`:
+- `contenteditable` elements and `role="textbox"` divs (Gmail / Slack / Notion compose boxes)
+- a `<textarea>`'s **server-rendered initial** content — not what was typed into it
+
+A capture is only discriminating if the withheld neighbour's text was **server-rendered**. The
+fixture that settled it (task #150): a button flanked by two `contenteditable` divs holding known
+canaries, plus a second button beside a plain `<span>` as a positive control — the guard must
+withhold the canaries *and* still capture the span, or it is a blanket refusal rather than a fix.
+
+⚠ The keystroke path itself (`chrome.commands`) is **not reachable from Playwright** — every spec
+posts to the service worker directly. A live capture by hand is the only way to verify the build
+actually loaded in Brave, which is why an out-of-band flat copy (below) is dangerous.


### PR DESCRIPTION
Captures two lessons from the clawgate extension 1.4.0 element-ref enrichment leak (homelab-infra `fcaca875` / PR #276), and corrects a developer note that had been wrong since it was written.

## `reference/element-references.md`

**Three factual corrections.** The note claimed the enrichment walks `previousElementSibling` / `nextElementSibling` and caps "each at 120 chars". Both false: it walks `previousSibling` / `nextSibling` — the **node** variants, so text nodes count, which is a distinct leak surface — and slices at 40 chars, with `refText` capping at `MAX_REF_TEXT_CHARS` (80). Verified against the merged code, not restated from intent.

**The choke point, recorded.** Every page-text read in the walk must go through `adjacentText` → `pageText`. Reading `.textContent` directly is what shipped the leak, and adding a second "is this a text field" predicate is the root cause that has now recurred **seven** times — six audit rounds on the picker, then again in the enrichment.

**New section: the obvious test cannot fail.** A native `<input>` or `<textarea>` never exposes its current value through `textContent` — typing updates `.value`, while `.textContent` keeps whatever the server rendered. So a canary typed into a form field and picked from a neighbouring element **passes under the leaking build too**. Three consecutive live captures were burned this way (tasks #147–#149), each initially read as a pass. Only `contenteditable` / `role="textbox"` surfaces and a `<textarea>`'s *server-rendered initial* content actually carry user text.

Documents the fixture that settled it (task #150): a button flanked by two `contenteditable` divs holding known canaries, plus a second button beside a plain `<span>` as a **positive control** — the guard must withhold the canaries *and* still capture the span, or it's a blanket refusal rather than a fix. Also notes that `chrome.commands` is unreachable from Playwright, so a hand capture is the only way to prove which build Brave actually loaded.

## `SKILL.md`

The skill had **no mention of extension delivery at all**, which is part of how this went wrong:

- The extension does **not** ship via Flux — merging to `trunk` deploys nothing. Brave loads a flat copy at `~/clawgate-extension` **on the workbench**, delivered by `scripts/sync-clawgate-extension.sh`, and does not hot-reload unpacked extensions.
- **A missing `.synced-from` stamp means a hand-copy.** That is exactly how a build which never passed CI ran live for ~11 hours on 2026-08-01 while `trunk` looked clean — copied straight from a working tree, so `clawgate-ci` never saw it.
- Brave routinely leaves newly-added hotkeys unbound on an in-place reload — check `brave://extensions/shortcuts`.
- The workbench firewall `allowedTCPPorts` is a short allowlist, so serve scratch test pages on `localhost` rather than opening a port for a throwaway.

## Scope

Docs only — two files, no code. Unaffected by the `test_skill_size.py` byte gate, which resolves to `scripts/browser-bridge/SKILL.md`.

⚠ These files resolve into `/nix/store` (read-only copies), so they need a **`home-manager switch`** to go live — editing the devrc source alone does not update `~/.claude/skills/clawgate/`.
