### PR TITLE
test(gate): count skips in the pytest gate — tool precondition, pinned skip set, collected-test floors

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,22 @@
             # RED, not "green while silently skipping": 41 test_server.py tests
             # skipped AND five failed. Adding curl here (with the --help/token fix
             # in the CLI) is what takes it green and makes those 41 actually run.
-            nativeBuildInputs = [ pyEnv pkgs.bash pkgs.ripgrep pkgs.git pkgs.util-linux pkgs.jq pkgs.gnugrep pkgs.curl ];
+            #
+            # nodejs: MEASURED 2026-08-02 — scripts/initiatives/tests/{test_viewer,
+            # test_streaming}.py extract the viewer's inline JS and run it under
+            # `node`; without node on PATH they `pytest.skip("node not on PATH")`.
+            # That was 123 of this check's 125 skips (`660 passed, 123 skipped` in
+            # the initiatives suite vs `783 passed, 0 skipped` on a host with node).
+            # Adding it recovers all 123. This does grow the pytest gate's closure
+            # by a node toolchain — accepted deliberately: 123 silently-unrun tests
+            # cost more than a cache invalidation on a nodejs bump. The `nodetests`
+            # check below stays separate for its OWN reasons (distinct failure
+            # signal, parallel execution), which this does not change.
+            #
+            # 🔴 run-tests.sh now ASSERTS every one of these is on PATH
+            # (`REQUIRED_TOOLS`) and fails naming the missing binary. Deleting one
+            # from this list no longer silently skips tests — it fails the gate.
+            nativeBuildInputs = [ pyEnv pkgs.bash pkgs.ripgrep pkgs.git pkgs.util-linux pkgs.jq pkgs.gnugrep pkgs.curl pkgs.nodejs ];
           }
           ''
             cp -r ${./.} src
@@ -100,6 +115,10 @@
             export HOME="$TMPDIR/home"
             mkdir -p "$HOME"
             cd src
+            # The runner asserts a tool precondition, a pinned expected-skip set,
+            # a global + per-directory collected-test floor, and parses pytest's
+            # summary instead of reading its exit code. Read its header before
+            # changing this line or the nativeBuildInputs above.
             bash scripts/run-tests.sh --set hermetic .
             touch "$out"
           '';

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -22,13 +22,56 @@
 # per-directory sys.path (bare `import collector` / `import extract` etc. would
 # collide if collected together under one rootdir).
 #
+# 🔴 FOUR STRUCTURAL GUARDS — each exists because a green exit code lies here.
+#    They mirror scripts/run-node-tests.sh (which asserts a test-count floor and
+#    parses node's TAP summary instead of reading an exit code). Read that file
+#    too before changing this one.
+#
+#   1. TOOL PRECONDITION (`REQUIRED_TOOLS`). The suites carry ~55 `skipif`s keyed
+#      on external binaries. If one goes missing from the environment the tests
+#      that need it SILENTLY SKIP and the gate stays green while testing less.
+#      This exact failure shipped: `curl` was absent from the flake check's
+#      inputs, so 41 test_server.py tests skipped (fixed in #251 — but nothing
+#      asserted the fix kept working, which is what this guard is for). We now
+#      check each binary UP FRONT and abort naming it, so "41 tests silently
+#      skipped" becomes "the gate says curl is missing".
+#      ⚠ This binds the pre-push tier too, which supplies only python via
+#      nix-shell and takes the rest from the ambient PATH (all 10 verified
+#      present on the workbench 2026-08-02). A host missing one now BLOCKS the
+#      push with the named tool instead of pushing a silently-thinner run;
+#      `DEVRC_SKIP_TESTS=1 git push …` is the documented override.
+#
+#   2. PINNED EXPECTED-SKIP SET (`EXPECTED_SKIPS`). Not a numeric ceiling: every
+#      skip must match a pinned (directory, reason-regex) entry, and the observed
+#      skip TOTAL must equal the number of pinned entries. So a new skip fails,
+#      a skip that moves to a different suite fails, one skip swapped for another
+#      fails, and a pinned skip that stops firing ALSO fails (remove it from the
+#      pin — that is the accounting). A bare ceiling would let a curl regression
+#      hide behind an unrelated skip disappearing; the set is small enough (2)
+#      that pinning costs nothing. Suites run with `-rs` so every skip's reason
+#      is printed, not just counted.
+#
+#   3. COLLECTED-TEST FLOORS (`MIN_TESTS`, and >=1 per directory). We parse
+#      pytest's summary line and count what actually ran rather than reading the
+#      exit code — a collection error, an import breakage or an empty glob can
+#      produce "0 tests" with a zero exit. A per-directory floor is checked too,
+#      so one suite collapsing to nothing cannot be absorbed by the global total.
+#
+#   4. PARSE GUARD. If a suite's summary line cannot be parsed at all, the run
+#      FAILS — an unparseable summary means this runner cannot vouch for the run,
+#      which is not the same as a pass.
+#
+# Env overrides (defaults are the point — raise them, don't lower them casually):
+#   MIN_TESTS  minimum tests the whole run must REPORT  (default 2850; 2920 today)
+#
 # Usage:
 #   scripts/run-tests.sh [--set hermetic|all] [ROOT]
 #     --set hermetic  (default) — dirs safe to run offline in the nix sandbox.
 #     --set all                 — hermetic + any dirs deferred to the dev host.
 #   ROOT defaults to the git repo root (or the script's parent-parent).
 #
-# Exit non-zero if ANY selected suite fails. Prints a per-dir + total summary.
+# Exit non-zero if ANY selected suite fails OR any guard above trips. Prints a
+# per-dir + total summary (collected / passed / skipped / failed).
 
 set -uo pipefail
 
@@ -48,6 +91,34 @@ if [ -z "$ROOT" ]; then
 fi
 
 cd "$ROOT" || { echo "run-tests: cannot cd to ROOT=$ROOT" >&2; exit 2; }
+
+MIN_TESTS="${MIN_TESTS:-2850}"
+
+# --- GUARD 1: tool precondition ------------------------------------------------
+# Every binary the suites `skipif` on. Absence must be an ERROR, never a skip.
+# Sources (grep `shutil.which` under scripts/):
+#   curl    scripts/browser-bridge/tests/{test_server,test_browser_cli_args}.py (41+ tests)
+#   bash    the `browser` CLI + drafter + ship-converge suites
+#   node    scripts/initiatives/tests/{test_viewer,test_streaming}.py  (123 tests)
+#   rg      scripts/repo-cos/tests/test_prescan.py
+#   git     scripts/repo-cos/tests/test_prescan.py, scripts/tests/test_ship_converge.py
+#   awk     scripts/browser-bridge/tests/test_browser_session_id.py
+#   jq,grep scripts/task-spec-drafter/tests/test_severity_and_gate_skip.py
+#   setsid  scripts/browser-bridge/tests/test_browser_agent.py (process-group kill)
+#   python3 scripts/browser-bridge/tests/test_browser_agent.py
+REQUIRED_TOOLS=(bash curl node rg git awk jq grep setsid python3)
+missing_tools=()
+for t in "${REQUIRED_TOOLS[@]}"; do
+  command -v "$t" >/dev/null 2>&1 || missing_tools+=("$t")
+done
+if [ "${#missing_tools[@]}" -gt 0 ]; then
+  echo "run-tests: FATAL — required tool(s) missing from PATH: ${missing_tools[*]}" >&2
+  echo "  The suites SKIP the tests that need these, so the run would go green while" >&2
+  echo "  testing less. Add them to the caller's inputs (flake.nix checks.pytests" >&2
+  echo "  nativeBuildInputs / the pre-push nix-shell) — do NOT drop them from" >&2
+  echo "  REQUIRED_TOOLS to make this pass." >&2
+  exit 2
+fi
 
 # --- HERMETIC set --------------------------------------------------------------
 # Verified to pass in the offline nix sandbox: every third-party call
@@ -89,17 +160,112 @@ if [ ! -w "$HOME" ]; then
   export HOME="$(mktemp -d)"
 fi
 
+# --- GUARD 2: the pinned expected-skip set -------------------------------------
+# One "<dir>|<reason-regex>" per LEGITIMATELY skipped test. Both halves must match
+# a pytest `SKIPPED [n] <path>:<line>: <reason>` line, and the skip TOTAL must
+# equal the number of entries. Adding an entry is a deliberate act of accounting
+# — do it only when the skip is genuinely unavoidable, and say why.
+#
+# Built AFTER $HOME is settled: an entry may be conditional, but its condition
+# must be the SAME predicate the test itself uses — never a blanket allowance,
+# or the pin degrades into the numeric ceiling it exists to beat.
+EXPECTED_SKIPS=(
+  # Opt-in drift check against the LIVE homelab store — needs a kubeconfig and
+  # network, neither of which a hermetic gate may have. Skips everywhere unless
+  # REPO_COS_LIVE_DRIFT_CHECK=1.
+  "scripts/repo-cos/tests|live-store drift check is opt-in"
+)
+# test_scrub.py::test_patterns_cover_bash_guard compares scrub.py's
+# SECRET_PATTERNS against the DEPLOYED hook, and skips iff that file is absent —
+# `_BASH_GUARD = Path.home() / ".claude" / "hooks" / "bash-guard.py"`, which is
+# exactly the test below. It is ABSENT in the nix sandbox (synthetic $HOME) and
+# PRESENT on a switched dev host, so the test genuinely runs in one and not the
+# other. Pinning it unconditionally would fail the pre-push tier; pinning it
+# conditionally still fails if it skips on a host where the hook exists.
+if [ ! -e "$HOME/.claude/hooks/bash-guard.py" ]; then
+  EXPECTED_SKIPS+=("scripts/session-analysis/session_insight/tests|bash-guard\.py absent")
+fi
+
 fail=0
 declare -a RESULTS
+declare -a SKIP_LINES
+TOT_COLLECTED=0
+TOT_PASSED=0
+TOT_SKIPPED=0
+TOT_FAILED=0
+
+# Pull "<N> <word>" out of a pytest summary line; 0 when the word is absent.
+_count_of() { # $1 = alternation regex, $2 = summary line
+  local n
+  n="$(printf '%s\n' "$2" | grep -oE "[0-9]+ ($1)([^a-z]|$)" | tail -1 | grep -oE '^[0-9]+')"
+  printf '%s' "${n:-0}"
+}
+
 run_pytest() {
   local d="$1"
   echo "=== pytest $d ==="
-  if python -m pytest "$d" -q -p no:cacheprovider --no-header; then
-    RESULTS+=("PASS  $d")
-  else
-    RESULTS+=("FAIL  $d")
+
+  if [ ! -d "$d" ]; then
+    echo "run-tests: FATAL — test directory does not exist: $d" >&2
+    RESULTS+=("FAIL  $d (missing directory)")
     fail=1
+    echo
+    return
   fi
+
+  local log rc
+  log="$(mktemp)"
+  python -m pytest "$d" -q -p no:cacheprovider --no-header -rs >"$log" 2>&1
+  rc=$?
+  cat "$log"
+
+  # GUARD 4: parse pytest's summary line. `-q` emits it undecorated, e.g.
+  #   "660 passed, 123 skipped in 15.10s"   /   "1 failed, 2 passed in 0.1s"
+  #   "no tests ran in 0.01s"               /   "1 error in 0.05s"
+  local summary p s f e x xp collected
+  summary="$(grep -aE '^(=+ )?([0-9]+ (passed|failed|errors?|skipped|xfailed|xpassed|deselected)|no tests ran)' "$log" | tail -1)"
+  if [ -z "$summary" ]; then
+    echo "run-tests: ERROR — could not parse pytest's summary for $d." >&2
+    echo "  This runner cannot vouch for that run; treating it as a FAILURE." >&2
+    RESULTS+=("FAIL  $d (unparseable summary)")
+    fail=1
+    rm -f "$log"
+    echo
+    return
+  fi
+
+  p="$(_count_of 'passed' "$summary")"
+  s="$(_count_of 'skipped' "$summary")"
+  f="$(_count_of 'failed' "$summary")"
+  e="$(_count_of 'errors?' "$summary")"
+  x="$(_count_of 'xfailed' "$summary")"
+  xp="$(_count_of 'xpassed' "$summary")"
+  collected=$(( p + s + f + e + x + xp ))
+
+  # Collect the `-rs` short-summary skip lines for GUARD 2.
+  while IFS= read -r line; do
+    [ -n "$line" ] && SKIP_LINES+=("$line")
+  done < <(grep -aE '^SKIPPED \[[0-9]+\]' "$log")
+
+  TOT_COLLECTED=$(( TOT_COLLECTED + collected ))
+  TOT_PASSED=$(( TOT_PASSED + p ))
+  TOT_SKIPPED=$(( TOT_SKIPPED + s ))
+  TOT_FAILED=$(( TOT_FAILED + f + e ))
+
+  # GUARD 3 (per-directory): a suite that collects nothing is a vacuous green.
+  if [ "$collected" -lt 1 ]; then
+    echo "run-tests: ERROR — $d collected 0 tests (summary: $summary)." >&2
+    echo "  A collection error or an import breakage, not a pass." >&2
+    RESULTS+=("FAIL  $d (collected 0 tests)")
+    fail=1
+  elif [ "$rc" -ne 0 ] || [ "$f" -gt 0 ] || [ "$e" -gt 0 ]; then
+    RESULTS+=("FAIL  $d  (collected=$collected passed=$p skipped=$s failed=$f errors=$e)")
+    fail=1
+  else
+    RESULTS+=("PASS  $d  (collected=$collected passed=$p skipped=$s)")
+  fi
+
+  rm -f "$log"
   echo
 }
 
@@ -109,7 +275,8 @@ done
 
 # The claude-hooks tests are hand-rolled scripts (asserts + sys.exit, not
 # pytest-collectable) — run them directly. Hermetic (pure string logic + a
-# subprocess of the hook itself). Always part of the hermetic set.
+# subprocess of the hook itself). Always part of the hermetic set. They report
+# no counts, so they are pass/fail only and are NOT part of the totals.
 HOOK_TESTS=(
   "scripts/claude-hooks/tests/test_shell_env_nudge.py"
   "scripts/claude-hooks/tests/test_claude_notify.py"
@@ -130,6 +297,61 @@ done
 
 echo "======================== SUMMARY ($SET set) ========================"
 for r in "${RESULTS[@]}"; do echo "  $r"; done
+echo "  ----"
+echo "  TOTAL collected=$TOT_COLLECTED  passed=$TOT_PASSED  skipped=$TOT_SKIPPED  failed=$TOT_FAILED  (floor: $MIN_TESTS)"
+
+# --- GUARD 3 (global): collected-test floor ------------------------------------
+if [ "$TOT_COLLECTED" -lt "$MIN_TESTS" ]; then
+  echo "  ERROR: only $TOT_COLLECTED tests were collected, floor is $MIN_TESTS." >&2
+  echo "         Far fewer tests ran than exist — a VACUOUS GREEN, not a pass." >&2
+  echo "         Investigate before lowering MIN_TESTS." >&2
+  fail=1
+fi
+
+# --- GUARD 2 (evaluation): pinned expected-skip set ----------------------------
+echo "  ---- skips (pinned: ${#EXPECTED_SKIPS[@]}) ----"
+if [ "${#SKIP_LINES[@]}" -eq 0 ]; then
+  echo "    (none reported)"
+else
+  for line in "${SKIP_LINES[@]}"; do echo "    $line"; done
+fi
+
+unexpected=()
+for line in "${SKIP_LINES[@]}"; do
+  matched=0
+  for entry in "${EXPECTED_SKIPS[@]}"; do
+    edir="${entry%%|*}"
+    ere="${entry#*|}"
+    # "SKIPPED [n] <path>:<line>: <reason>" — require BOTH the owning directory
+    # and the reason, so a skip that migrates to another suite is not absorbed.
+    if printf '%s\n' "$line" | grep -qE "\] $edir/" && printf '%s\n' "$line" | grep -qE "$ere"; then
+      matched=1
+      break
+    fi
+  done
+  [ "$matched" -eq 0 ] && unexpected+=("$line")
+done
+
+if [ "${#unexpected[@]}" -gt 0 ]; then
+  echo "  ERROR: ${#unexpected[@]} UNPINNED skip group(s) — coverage silently collapsed:" >&2
+  for line in "${unexpected[@]}"; do echo "         $line" >&2; done
+  echo "         A skip is a test that did not run. Fix the environment (see" >&2
+  echo "         REQUIRED_TOOLS) or, if the skip is genuinely unavoidable here," >&2
+  echo "         add it to EXPECTED_SKIPS with a comment saying why." >&2
+  fail=1
+fi
+
+if [ "$TOT_SKIPPED" -ne "${#EXPECTED_SKIPS[@]}" ]; then
+  echo "  ERROR: $TOT_SKIPPED test(s) skipped, but ${#EXPECTED_SKIPS[@]} are pinned in EXPECTED_SKIPS." >&2
+  if [ "$TOT_SKIPPED" -lt "${#EXPECTED_SKIPS[@]}" ]; then
+    echo "         FEWER than pinned: a pinned skip now RUNS (good) — delete its" >&2
+    echo "         EXPECTED_SKIPS entry so the pin keeps meaning something." >&2
+  else
+    echo "         MORE than pinned: tests stopped running. See the skip list above." >&2
+  fi
+  fail=1
+fi
+
 if [ "$fail" -ne 0 ]; then
   echo "RESULT: FAIL"
 else


### PR DESCRIPTION
## Problem

`checks.x86_64-linux.pytests` read an exit code and counted **nothing** about skips, while carrying **125 skipped tests**. A skipped test reports safety without providing it.

Not hypothetical: 41 `test_server.py` tests are gated on `skipif(shutil.which("curl"))`, and that condition already made this gate meaningless once (fixed in #251 by adding `curl` to the check's inputs). Nothing asserted the fix kept working — remove `curl` and those tests silently skip again, gate still green.

## What this does

Follows #280's pattern for the node suite. `scripts/run-tests.sh` now parses pytest's summary line instead of reading its exit code, and enforces four guards:

| # | Guard | Fails when |
|---|---|---|
| 1 | `REQUIRED_TOOLS` | any of `bash curl node rg git awk jq grep setsid python3` is off PATH — named, up front, before a single test runs |
| 2 | `EXPECTED_SKIPS` | any skip doesn't match a pinned `(dir, reason-regex)` entry, **or** the skip total ≠ the entry count |
| 3 | `MIN_TESTS` (2850 global) + ≥1 per directory | collection collapses, globally or in one suite |
| 4 | parse guard | a suite's summary line can't be parsed at all |

`flake.nix` adds `pkgs.nodejs` to `checks.pytests` (see below) and both files' comments were updated in this commit — a stale comment about a test gate is how people conclude a suite is covered when it is not.

## Ceiling vs pinned set — and why pinned

**Chose the pinned set.** A numeric ceiling is simpler but lets one skip be swapped for another, which is *precisely* the curl failure mode: 41 tests could start skipping while an unrelated skip disappears and the count stays under the bar. The pinned set costs almost nothing here because after recovering the node tests there are only **2** skips left, and it is self-documenting — each entry carries a comment saying why the skip is unavoidable.

The pin is symmetric on purpose: it fails if skips **increase** (coverage collapsed) *and* if they **decrease** (a pinned skip now runs → delete the entry, so the pin keeps meaning something). Suites run with `-rs` so every skip's reason is printed, not merely counted.

One entry is **conditional**, on the same predicate the test itself uses:

```bash
if [ ! -e "$HOME/.claude/hooks/bash-guard.py" ]; then
  EXPECTED_SKIPS+=("scripts/session-analysis/session_insight/tests|bash-guard\.py absent")
fi
```

`test_patterns_cover_bash_guard` compares `scrub.py` against the *deployed* hook, which is genuinely absent in the sandbox (synthetic `$HOME`) and genuinely present on a switched dev host. Pinning it unconditionally would break the pre-push tier; pinning it conditionally still fails if it skips on a host where the hook exists. That is the only allowance — an unconditional "0 or 1 is fine" would have degraded the pin back into the ceiling it exists to beat.

## The 2 node skips were actually 123

The task described 2 `node not on PATH` skips. **Measured: it is 123.** `scripts/initiatives/tests/{test_viewer,test_streaming}.py` extract the viewer's inline JS and run it under `node`:

- sandbox without node: `660 passed, 123 skipped`
- dev host with node: `783 passed, 0 skipped`

Adding `pkgs.nodejs` recovers **all 123**. This grows the pytest gate's closure by a node toolchain — accepted deliberately and documented inline; `nodetests` stays a separate check for its own reasons (distinct failure signal, parallel execution), which this doesn't change.

**Final skip count: 125 → 2**, both pinned, both genuinely unavoidable in the sandbox.

## Verification — every guard broken individually

Each guard was broken on its own and shown to fail with **its own** message, not a neighbour's.

| Guard | Mutation | Result |
|---|---|---|
| 1 tool precondition | drop `pkgs.curl` from the check's inputs | `run-tests: FATAL — required tool(s) missing from PATH: curl`, build fails in seconds |
| 2 skip pin | drop `pkgs.curl` **and** remove `curl` from `REQUIRED_TOOLS` (so guard 1 can't shield it) | `ERROR: 76 UNPINNED skip group(s)` + `ERROR: 111 test(s) skipped, but 2 are pinned` |
| 2 skip pin (decrease branch) | observed live — the first host run had 1 skip against 2 pinned | `FEWER than pinned: a pinned skip now RUNS` |
| 3 global floor | trim `HERMETIC_DIRS` to one dir | `ERROR: only 331 tests were collected, floor is 2850` — **alone**; every suite `PASS`, skip pin satisfied |
| 3 per-dir floor | add a dir containing no tests, `MIN_TESTS=1` | `FAIL  nix (collected 0 tests)` — **alone**, global floor satisfied |
| 4 parse guard | a `conftest.py` that raises (pytest emits no summary line at all) | `FAIL  _nc5tmp (unparseable summary)` — **alone** |

Guard 1 does shield guard 2 for the curl case specifically — that's the intended ordering (a missing tool should be reported as a missing tool). Guard 2's reachability is therefore proven with guard 1 explicitly bypassed, per (a) in the "guard must be proven REACHABLE" rule.

Green after every revert, both in-sandbox and on the host.

## Results

```
nix flake check   → green, 3:36 wall
  devrc-pytests    TOTAL collected=2920  passed=2918  skipped=2  failed=0  (floor: 2850)
  devrc-nodetests  files=14  tests=468  pass=468  fail=0  skipped=0  (floor: 450)
```

Baselines held: browser-bridge pytest **436 passed**, node **468/468**.

**Timing:** added test time is ~**5s** — the recovered node tests take the initiatives suite from 15.1s to 20.5s; every other suite is within noise. `browser-bridge/tests` still dominates at 158s. `nodejs` was already in the store for `nodetests`, so there is no new download; the real cost is that a `nodejs` bump now invalidates the pytest gate's build cache too.

## Note on the pre-push tier

`githooks/tests-on-push.sh` supplies only python via `nix-shell` and takes the other tools from the ambient PATH (all 10 verified present on the workbench). A host missing one now **blocks the push** naming the tool, rather than pushing a silently-thinner run. `DEVRC_SKIP_TESTS=1 git push …` remains the documented override. Called out in the runner's header.

## Not done, on purpose

No `skipif` was deleted or loosened. The 2 remaining skips stay skipped — they are now *accounted for* rather than invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
