### PR TITLE
chore: rescue seven untracked scripts stranded in the main checkout

### DIFF
--- a/nix/system/apply-file-manager-backend.sh
+++ b/nix/system/apply-file-manager-backend.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Install the system-level backend needed for a working default file manager.
+#
+# Approach (robust, avoids fragile sed-address edits):
+#   1. cp a complete standalone module to /etc/nixos/file-manager-backend.nix
+#   2. add one import line to configuration.nix via awk (line-based, idempotent)
+#
+# The module enables services.gvfs + programs.dconf and installs
+# shared-mime-info / file / desktop-file-utils so Brave's "Show in folder"
+# path classification has a working backend. The home-manager layer
+# (nix/home.nix xdg.mimeApps) already pins inode/directory -> thunar.desktop.
+#
+# Run with: sudo bash nix/system/apply-file-manager-backend.sh
+set -euo pipefail
+
+CFG=/etc/nixos/configuration.nix
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_SRC="${SRC_DIR}/file-manager-backend.nix"
+MODULE_DST=/etc/nixos/file-manager-backend.nix
+IMPORT_LINE='      ./file-manager-backend.nix'
+ANCHOR='      ./hardware-configuration.nix'
+
+[ -f "$CFG" ] || { echo "ERROR: $CFG not found"; exit 1; }
+[ -f "$MODULE_SRC" ] || { echo "ERROR: module source $MODULE_SRC not found"; exit 1; }
+
+ts=$(date +%Y%m%d-%H%M%S)
+cp -v "$CFG" "${CFG}.bak-${ts}"
+
+# 1. Drop the complete module in place (full-file cp, never a surgical edit).
+cp -v "$MODULE_SRC" "$MODULE_DST"
+
+# 2. Idempotently add the import line right after the hardware-config import.
+if grep -qF "$IMPORT_LINE" "$CFG"; then
+  echo "SKIP: import already present in $CFG"
+else
+  grep -qF "$ANCHOR" "$CFG" || { echo "ERROR: import anchor not found: $ANCHOR"; exit 1; }
+  tmp=$(mktemp)
+  awk -v anchor="$ANCHOR" -v ins="$IMPORT_LINE" '
+    { print }
+    $0 == anchor { print ins }
+  ' "$CFG" > "$tmp"
+  # Sanity: exactly one import line added, file grew by exactly one line.
+  before=$(wc -l < "$CFG"); after=$(wc -l < "$tmp")
+  if [ "$after" -ne "$((before + 1))" ]; then
+    echo "ERROR: unexpected line delta ($before -> $after); not applying"; rm -f "$tmp"; exit 1
+  fi
+  mv "$tmp" "$CFG"
+  echo "ADDED import: $IMPORT_LINE"
+fi
+
+echo
+echo "Validating with a dry build (no activation)..."
+nixos-rebuild dry-build 2>&1 | tail -5
+
+echo
+echo "Backup saved at ${CFG}.bak-${ts}"
+echo "If the dry build looks good, apply with:  sudo nixos-rebuild switch"
+echo "Then verify in Brave: download something -> 'Show in folder' should open Thunar."

--- a/nix/system/apply-mullvad-enable.sh
+++ b/nix/system/apply-mullvad-enable.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Enable Mullvad WireGuard VPN, server: ca-mtr-wg-301 (Montreal, 20Gbps)
+# Run: sudo bash nix/system/apply-mullvad-enable.sh
+set -euo pipefail
+
+CFG="/etc/nixos/configuration.nix"
+TS=$(date +%Y%m%d-%H%M%S)
+
+cp "$CFG" "${CFG}.bak-${TS}"
+echo "[1/3] Backed up configuration.nix to ${CFG}.bak-${TS}"
+
+python3 - "$CFG" << 'PYBLOCK'
+import sys
+p = sys.argv[1]
+content = open(p).read()
+
+old = '''# ==========================================
+  # Mullvad WireGuard VPN (Bogota)
+  # ==========================================
+  #networking.wg-quick.interfaces.mullvad = {
+   # address = [ "10.67.129.86/32" ];
+   # privateKeyFile = "/etc/nixos/mullvad-wg.key";
+#
+#    preUp = ''
+#      # Save default gateway before VPN changes routing
+#      ip route | grep '^default' | ${pkgs.gawk}/bin/awk '{print $3}' > /run/mullvad-gateway
+#      ip route | grep '^default' | ${pkgs.gawk}/bin/awk '{print $5}' > /run/mullvad-iface
+#    '';
+
+#    postUp = ''
+#      GW=$(cat /run/mullvad-gateway)
+#      IFACE=$(cat /run/mullvad-iface)
+#      # Bypass VPN for Mullvad endpoint
+#      ip route add 154.47.16.34 via $GW dev $IFACE || true
+#      # Bypass VPN for LAN
+#      ip route add 192.168.50.0/24 via $GW dev $IFACE || true
+#      # Bypass VPN for Nebula endpoints (Hetzner + homelab public)
+#      ip route add 5.161.118.55 via $GW dev $IFACE || true
+#      ip route add 24.79.61.66 via $GW dev $IFACE || true
+#    '';
+
+#    preDown = ''
+#      ip route del 154.47.16.34 || true
+#      ip route del 192.168.50.0/24 || true
+#      ip route del 5.161.118.55 || true
+#      ip route del 24.79.61.66 || true
+#    '';
+
+#    peers = [
+#      {
+#        publicKey = "iaMa84nCHK+v4TnQH4h2rxkqwwxemORXM12VbJDRZSU=";
+#        endpoint = "154.47.16.34:51820";
+#        persistentKeepalive = 25;
+#        allowedIPs = [ "0.0.0.0/1" "128.0.0.0/1" ];
+#      }
+#    ];
+#  };
+#
+#  systemd.services."wg-quick-mullvad".after = [ "network-online.target" ];
+#  systemd.services."wg-quick-mullvad".wants = [ "network-online.target" ];'''
+
+new = '''# ==========================================
+  # Mullvad WireGuard VPN (ca-mtr-wg-301 - Montreal)
+  # ==========================================
+  networking.wg-quick.interfaces.mullvad = {
+    address = [ "10.67.129.86/32" ];
+    privateKeyFile = "/etc/nixos/mullvad-wg.key";
+
+    preUp = ''
+      # Save default gateway before VPN changes routing
+      ip route | grep '^default' | ${pkgs.gawk}/bin/awk '{print $3}' > /run/mullvad-gateway
+      ip route | grep '^default' | ${pkgs.gawk}/bin/awk '{print $5}' > /run/mullvad-iface
+    '';
+
+    postUp = ''
+      GW=$(cat /run/mullvad-gateway)
+      IFACE=$(cat /run/mullvad-iface)
+      # Bypass VPN for Mullvad endpoint
+      ip route add 23.234.120.2 via $GW dev $IFACE || true
+      # Bypass VPN for LAN
+      ip route add 192.168.50.0/24 via $GW dev $IFACE || true
+      # Bypass VPN for Nebula endpoints (Hetzner + homelab public)
+      ip route add 5.161.118.55 via $GW dev $IFACE || true
+      ip route add 24.79.61.66 via $GW dev $IFACE || true
+    '';
+
+    preDown = ''
+      ip route del 23.234.120.2 || true
+      ip route del 192.168.50.0/24 || true
+      ip route del 5.161.118.55 || true
+      ip route del 24.79.61.66 || true
+    '';
+
+    peers = [
+      {
+        publicKey = "iV7uZuw8vbqrW/p4YhsxkIxXaUuI4Uj2hTl8TaJZfAA=";
+        endpoint = "23.234.120.2:51820";
+        persistentKeepalive = 25;
+        allowedIPs = [ "0.0.0.0/1" "128.0.0.0/1" ];
+      }
+    ];
+  };
+
+  systemd.services."wg-quick-mullvad".after = [ "network-online.target" ];
+  systemd.services."wg-quick-mullvad".wants = [ "network-online.target" ];'''
+
+if old not in content:
+    print("ERROR: expected commented mullvad block not found in configuration.nix")
+    print("       (the file may have already been edited or has drifted from expected layout)")
+    sys.exit(1)
+
+content = content.replace(old, new)
+open(p, 'w').write(content)
+print("[2/3] Enabled Mullvad block (server: ca-mtr-wg-301, 23.234.120.2)")
+PYBLOCK
+
+echo "[3/3] Rebuilding NixOS..."
+nixos-rebuild switch
+
+echo ""
+echo "=== Done ==="
+echo "Verify exit IP:"
+echo "  curl -s --max-time 10 https://am.i.mullvad.net/json | python3 -m json.tool"
+echo ""
+echo "Expect: mullvad_exit_ip: true, hostname: ca-mtr-wg-301, city: Montreal"
+echo ""
+echo "If something is wrong, restore with:"
+echo "  sudo cp /etc/nixos/configuration.nix.bak-* /etc/nixos/configuration.nix && sudo nixos-rebuild switch"

--- a/nix/system/apply-nebula-443.sh
+++ b/nix/system/apply-nebula-443.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Add UDP 443 fallback for prod lighthouse in nebula static host map
+# Run: sudo bash nix/system/apply-nebula-443.sh
+set -euo pipefail
+
+CFG="/etc/nixos/configuration.nix"
+
+if grep -q '5.161.118.55:443' "$CFG"; then
+  echo "Already configured — skipping"
+  exit 0
+fi
+
+cp "$CFG" "$CFG.bak-nebula443"
+sed -i 's|"10.42.0.2" = \[ "5.161.118.55:4242" \];|"10.42.0.2" = [ "5.161.118.55:4242" "5.161.118.55:443" ];|' "$CFG"
+
+if grep -q '5.161.118.55:443' "$CFG"; then
+  echo "[1/2] Added 5.161.118.55:443 to staticHostMap"
+else
+  echo "ERROR: sed failed"
+  cp "$CFG.bak-nebula443" "$CFG"
+  exit 1
+fi
+
+echo "[2/2] Rebuilding..."
+nixos-rebuild switch
+echo "Done. Nebula will try UDP 443 as fallback if 4242 is blocked."

--- a/nix/system/apply-remove-gtk-portal.sh
+++ b/nix/system/apply-remove-gtk-portal.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Remove GTK_USE_PORTAL=1 from /etc/nixos/configuration.nix.
+#
+# Why: GTK_USE_PORTAL=1 tells Brave/Chromium and GTK apps to render
+# Save/Open/Upload dialogs via xdg-desktop-portal's FileChooser. No portal is
+# installed on this i3/X11 host, so the flag drops apps to a bare built-in
+# picker. Removing it lets Chromium/GTK use their in-process GTK3 chooser
+# directly (places sidebar, recent, bookmarks) with no portal daemon needed.
+# XDG_CURRENT_DESKTOP is intentionally kept.
+#
+# Idempotent: re-running after removal is a no-op (SKIP).
+# Robust: line-based awk filter + sanity check on exactly one line removed.
+#
+# Run with: sudo bash nix/system/apply-remove-gtk-portal.sh
+set -euo pipefail
+
+CFG=/etc/nixos/configuration.nix
+[ -f "$CFG" ] || { echo "ERROR: $CFG not found"; exit 1; }
+
+if ! grep -q 'GTK_USE_PORTAL' "$CFG"; then
+  echo "SKIP: GTK_USE_PORTAL already absent from $CFG"
+  exit 0
+fi
+
+n=$(grep -c 'GTK_USE_PORTAL' "$CFG")
+if [ "$n" -ne 1 ]; then
+  echo "ERROR: expected exactly 1 GTK_USE_PORTAL line, found $n; not editing"; exit 1
+fi
+
+ts=$(date +%Y%m%d-%H%M%S)
+cp -v "$CFG" "${CFG}.bak-${ts}"
+
+tmp=$(mktemp)
+awk '!/GTK_USE_PORTAL/ { print }' "$CFG" > "$tmp"
+
+before=$(wc -l < "$CFG"); after=$(wc -l < "$tmp")
+if [ "$after" -ne "$((before - 1))" ]; then
+  echo "ERROR: unexpected line delta ($before -> $after); not applying"; rm -f "$tmp"; exit 1
+fi
+mv "$tmp" "$CFG"
+echo "REMOVED: GTK_USE_PORTAL line"
+
+echo
+echo "Validating with a dry build (no activation)..."
+nixos-rebuild dry-build 2>&1 | tail -5
+
+echo
+echo "Backup saved at ${CFG}.bak-${ts}"
+echo "If the dry build looks good, apply with:  sudo nixos-rebuild switch"
+echo "Then LOG OUT and back into i3 so the removed env var clears from the session,"
+echo "quit Brave fully, reopen, and test: right-click image -> Save image as."

--- a/nix/system/file-manager-backend.nix
+++ b/nix/system/file-manager-backend.nix
@@ -1,0 +1,20 @@
+# File manager backend for Chrome/Brave "Show in folder" + xdg-open under i3.
+#
+# Brave/Chrome classify a directory path with gio/mimetype before launching a
+# file manager; under bare i3 these helpers and their daemons aren't present,
+# so "Show in folder" silently no-ops even when inode/directory is correctly
+# pinned to thunar.desktop (done at the home-manager layer in nix/home.nix).
+#
+# Imported from /etc/nixos/configuration.nix. services.tumbler is intentionally
+# NOT set here — it's already enabled in configuration.nix.
+{ pkgs, ... }:
+{
+  services.gvfs.enable = true;    # gio + gvfsd + volume monitor
+  programs.dconf.enable = true;   # ca.desrt.dconf: stops thunar/nemo dconf-commit errors
+
+  environment.systemPackages = with pkgs; [
+    shared-mime-info     # mimetype + update-mime-database
+    file                 # libmagic type-detection fallback
+    desktop-file-utils   # update-desktop-database
+  ];
+}

--- a/scripts/session-analysis/extract_genesis.py
+++ b/scripts/session-analysis/extract_genesis.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Extract the FIRST genuine user-typed message per session transcript."""
+import json, os, sys, glob, re
+
+ROOT = os.path.expanduser("~/.claude/projects")
+OUT = sys.argv[1] if len(sys.argv) > 1 else "/tmp/genesis.jsonl"
+SYS_REMINDER = re.compile(r"<system-reminder>.*?</system-reminder>", re.S)
+COMMAND_STDOUT = re.compile(r"<local-command-stdout>.*?</local-command-stdout>", re.S)
+COMMAND_NAME = re.compile(r"<command-name>(.*?)</command-name>", re.S)
+COMMAND_ARGS = re.compile(r"<command-args>(.*?)</command-args>", re.S)
+HARNESS = ("<task-notification>", "<task-reminder>", "<post-tool-use", "<bash-",
+           "<user-prompt-submit", "<local-command-stdout>")
+
+def clean(t):
+    t = SYS_REMINDER.sub("", t)
+    t = COMMAND_STDOUT.sub("", t)
+    return t.strip()
+
+def first_text(content):
+    """Return (kind, text) of first usable user block, or None."""
+    if isinstance(content, str):
+        return ("typed", content)
+    if isinstance(content, list):
+        for b in content:
+            if isinstance(b, dict) and b.get("type") == "text":
+                return ("typed", b.get("text", ""))
+    return None
+
+def main():
+    n = 0
+    with open(OUT, "w") as fout:
+        for path in glob.glob(os.path.join(ROOT, "**", "*.jsonl"), recursive=True):
+            project = os.path.basename(os.path.dirname(path))
+            if project == "subagents" or project.startswith("wf_"):
+                continue
+            try:
+                with open(path, errors="replace") as f:
+                    lines = f.readlines()
+            except Exception:
+                continue
+            ts = None
+            for line in lines:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except Exception:
+                    continue
+                if obj.get("type") != "user" or obj.get("isMeta") or obj.get("isSidechain"):
+                    continue
+                msg = obj.get("message") or {}
+                if msg.get("role") != "user":
+                    continue
+                ft = first_text(msg.get("content"))
+                if not ft:
+                    continue
+                kind, raw = ft
+                if not raw:
+                    continue
+                cmd = COMMAND_NAME.search(raw)
+                if cmd:
+                    cargs = COMMAND_ARGS.search(raw)
+                    txt = ("/" + cmd.group(1).strip() + " " + (cargs.group(1).strip() if cargs else "")).strip()
+                    kind = "command"
+                else:
+                    txt = clean(raw)
+                    if not txt or txt.lstrip().startswith(HARNESS):
+                        continue
+                    if txt.startswith("[Request interrupted") or txt.startswith("Caveat: The messages below"):
+                        continue
+                # first usable message for this session
+                ts = obj.get("timestamp")
+                rec = {"project": project, "session": os.path.basename(path)[:8],
+                       "ts": ts, "kind": kind, "text": txt}
+                fout.write(json.dumps(rec) + "\n")
+                n += 1
+                break  # only first per file
+    print(f"sessions_with_first_msg={n} out={OUT}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/session-analysis/extract_user_msgs.py
+++ b/scripts/session-analysis/extract_user_msgs.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Extract genuine user-typed messages from Claude Code JSONL transcripts."""
+import json, os, sys, glob, re, hashlib
+
+ROOT = os.path.expanduser("~/.claude/projects")
+OUT = sys.argv[1] if len(sys.argv) > 1 else "/tmp/user_msgs.jsonl"
+
+# patterns that mark non-typed / synthetic content
+SYS_REMINDER = re.compile(r"<system-reminder>.*?</system-reminder>", re.S)
+COMMAND_STDOUT = re.compile(r"<local-command-stdout>.*?</local-command-stdout>", re.S)
+COMMAND_NAME = re.compile(r"<command-name>(.*?)</command-name>", re.S)
+COMMAND_ARGS = re.compile(r"<command-args>(.*?)</command-args>", re.S)
+TAG_BLOCK = re.compile(r"<command-message>.*?</command-message>", re.S)
+
+def clean_text(t):
+    t = SYS_REMINDER.sub("", t)
+    t = COMMAND_STDOUT.sub("", t)
+    return t.strip()
+
+def extract_from_content(content):
+    """Return list of (kind, text) where kind is 'typed' or 'command'."""
+    out = []
+    if isinstance(content, str):
+        txt = content
+        out.append(("typed", txt))
+        return out
+    if isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "text":
+                out.append(("typed", block.get("text", "")))
+            # ignore tool_result, image, tool_use, thinking
+    return out
+
+def main():
+    n_files = 0
+    n_msgs = 0
+    seen = set()
+    with open(OUT, "w") as fout:
+        for path in glob.glob(os.path.join(ROOT, "**", "*.jsonl"), recursive=True):
+            project = os.path.basename(os.path.dirname(path))
+            # skip synthetic agent transcript dirs
+            if project == "subagents" or project.startswith("wf_"):
+                continue
+            n_files += 1
+            try:
+                with open(path, errors="replace") as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            obj = json.loads(line)
+                        except Exception:
+                            continue
+                        if obj.get("type") != "user":
+                            continue
+                        if obj.get("isMeta"):
+                            continue
+                        # sidechain == subagent's own transcript, not user-typed
+                        if obj.get("isSidechain"):
+                            continue
+                        msg = obj.get("message") or {}
+                        if msg.get("role") != "user":
+                            continue
+                        content = msg.get("content")
+                        for kind, raw in extract_from_content(content):
+                            if not raw:
+                                continue
+                            # detect slash command
+                            cmd = COMMAND_NAME.search(raw)
+                            if cmd:
+                                cname = cmd.group(1).strip()
+                                cargs_m = COMMAND_ARGS.search(raw)
+                                cargs = cargs_m.group(1).strip() if cargs_m else ""
+                                rec = {"project": project, "kind": "command",
+                                       "text": (cname + " " + cargs).strip()}
+                                key = hashlib.md5(rec["text"].encode()).hexdigest()
+                                if rec["text"] and key not in seen:
+                                    seen.add(key)
+                                    fout.write(json.dumps(rec) + "\n")
+                                    n_msgs += 1
+                                continue
+                            txt = clean_text(raw)
+                            # skip pure tool/stdout leftovers and tiny noise
+                            if not txt:
+                                continue
+                            if txt.startswith("<") and txt.endswith(">") and len(txt) < 80:
+                                continue
+                            # skip interrupted/caveat boilerplate
+                            if txt.startswith("[Request interrupted"):
+                                continue
+                            if txt.startswith("Caveat: The messages below"):
+                                continue
+                            if txt.startswith("API Error") or txt.startswith("API request failed"):
+                                continue
+                            rec = {"project": project, "kind": "typed", "text": txt}
+                            # dedup exact repeats (same text pasted across sessions)
+                            key = hashlib.md5((project + txt).encode()).hexdigest()
+                            if key in seen:
+                                continue
+                            seen.add(key)
+                            fout.write(json.dumps(rec) + "\n")
+                            n_msgs += 1
+            except Exception as e:
+                print(f"ERR {path}: {e}", file=sys.stderr)
+    print(f"files={n_files} msgs={n_msgs} out={OUT}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Seven scripts had been sitting **untracked** in `/home/zach/workspace/devrc` while the repo moved 77+ commits ahead of that checkout. Untracked files are invisible to a flake build, so none of them were reaching a `home-manager switch` — and they were one routine `checkout` away from silent loss.

## What's here

**`nix/system/`** — three apply scripts, siblings of the five already tracked in that directory (`apply-airvpn-host.sh`, `apply-travel-prep.sh`, `apply-dns-travel.sh`, …), plus a paired backend module:

| file | |
|---|---|
| `apply-mullvad-enable.sh` | 4.4K |
| `apply-nebula-443.sh` | 732 B |
| `apply-remove-gtk-portal.sh` | 1.8K |
| `apply-file-manager-backend.sh` + `file-manager-backend.nix` | 2.3K + 928 B, paired |

**`scripts/session-analysis/`** — two extractors alongside the existing `adoption-scan.py` / `initiative-scan.py` / `insights.py`:

| file | |
|---|---|
| `extract_genesis.py` | 3.3K |
| `extract_user_msgs.py` | 5.2K |

## Checks run before committing

- **gitleaks clean** across all seven (18.75 KB) — **with the scanner validated against a canary first.** That mattered: gitleaks' default config allowlists the canonical `AKIAIOSFODNN7EXAMPLE` fixture, so my first negative control came back "no leaks found" on a file that was nothing but an AWS key pair. A realistic canary produced `leaks found: 2`, which is what makes the clean result on the real files meaningful. An unvalidated green here would have been worthless.
- The only secret-shaped match in the real files is a `privateKeyFile` **path** (`"/etc/nixos/mullvad-wg.key"`), not key material.
- `bash -n` on all four shell scripts, `py_compile` on both Python files, `nix-instantiate --parse` on the nix module — all pass.
- Modes match the directory's convention (`apply-*.sh` at 755; the Python files at 644, matching `adoption-scan.py` / `insights.py`).

## Deliberately NOT included

- **`nix/pkgs/tools/screenarc.nix` and its import** in `nix/pkgs/tools/default.nix` — the import line is **commented out** (`#++ (import ./screenarc.nix …)`), i.e. parked on purpose. Left exactly as-is rather than guessing it was meant to ship.
- **The uncommitted `.npmrc` deletion** (dropping `prefix = $HOME/.npm-packages`) and the **`.serena/project.yml`** churn — operator decisions, not work at risk of loss.

## Context

Found while triaging the main checkout's dirty tree ahead of a `home-manager switch`. Two other dirty files there turned out to be **stale March orphans** — `scripts/tmux-task-hook.sh` and `scripts/tmux-task-resume.sh` were byte-identical to their state at `f69e583` (2026-03-24), so committing them would have reverted four months of work and reinstated a `tmux rename-window` call a later commit deliberately removed. Those were restored from HEAD, not carried here. Dirty ≠ WIP.
