### PR TITLE
guard: close the reset --hard global-option-hop gap for Claude Code

### DIFF
--- a/scripts/claude-hooks/guard_core.py
+++ b/scripts/claude-hooks/guard_core.py
@@ -25,13 +25,17 @@ TWO CALLERS, TWO POLICIES
 -------------------------
 `POLICIES` maps a name to an ordered list of checks:
 
-  "claude-code" — EXACTLY the six checks bash-guard.py has always run. This
-                  policy is FROZEN by deliberate decision: bash-guard.py fires
-                  on every Bash call in every Claude Code session on both
-                  hosts, so a new deny here changes the operator's primary
-                  tool. Adding to it is a decision for the operator, not a side
-                  effect of hardening opencode.
-  "opencode"    — the six, plus the irreversible-action checks below. opencode
+  "claude-code" — the checks bash-guard.py runs. This policy is FROZEN by
+                  deliberate decision: bash-guard.py fires on every Bash call in
+                  every Claude Code session on both hosts, so a new deny here
+                  changes the operator's primary tool. Adding to it is a
+                  decision for the operator, not a side effect of hardening
+                  opencode. It was the original six raw-text checks until
+                  2026-08-02, when `check_git_reset_hard_argv` was added as
+                  exactly such an approved decision (the raw-text reset check
+                  was blind to `git -C <path> reset --hard`, the spelling
+                  RULES.md mandates). Pinned by name in test_guard_core.py.
+  "opencode"    — all of the above, plus the irreversible-action checks below. opencode
                   agents run unattended (`opencode run` AUTO-REJECTS an `ask`
                   rather than prompting — measured on 1.18.4), so a hard deny is
                   the only thing standing between the model and an irreversible
@@ -91,6 +95,10 @@ import sys, os, json, re, shlex, ipaddress
 # ORIGINAL SIX — raw-text checks, byte-for-byte the behaviour bash-guard.py has
 # always had. Do not modify without re-running scripts/claude-hooks/tests/
 # test_bash_guard.py, which is the regression suite for every bypass they close.
+#
+# NOTE: "the original six" describes the functions DEFINED in this section, not
+# the contents of the claude-code policy — that policy also carries the argv
+# check `check_git_reset_hard_argv` since 2026-08-02. See POLICIES at the bottom.
 # =========================================================================== #
 
 # Blind-stage forms. Quotes are STRIPPED from the argument text before matching,
@@ -719,9 +727,11 @@ def check_git_reset_hard_argv(cmd):
     ALLOW under the `review` agent's glob list AND was passed by the Claude Code
     guard.
 
-    This argv version closes it for opencode. It is deliberately NOT added to
-    the "claude-code" policy: that would be a new deny on the operator's primary
-    tool and is theirs to approve. See the PR body.
+    Enabled for BOTH policies since 2026-08-02. It first shipped opencode-only,
+    because switching it on for "claude-code" is a new deny on the operator's
+    primary tool and was theirs to approve; they approved it. It now lives in
+    `_CLAUDE_CODE_CHECKS`, which `POLICIES["opencode"]` includes, so opencode
+    keeps its coverage by inheritance rather than by a duplicate entry.
     """
     for argv in commands(cmd):
         if os.path.basename(argv[0]) != "git":
@@ -782,13 +792,37 @@ def _git_strip_global_opts(argv):
 # =========================================================================== #
 
 # 🔴 FROZEN. bash-guard.py runs this on EVERY Bash call in EVERY Claude Code
-# session on both hosts. These are the six checks it has always had, in the
-# order it has always run them. Adding to this list is a change to the
-# operator's primary tool and must be an explicit, reported decision — not a
-# side effect of hardening opencode.
+# session on both hosts. Adding to this list is a change to the operator's
+# primary tool and must be an explicit, reported decision — not a side effect
+# of hardening opencode.
+#
+# For a long time this was exactly SIX raw-text checks. `check_git_reset_hard_argv`
+# is the seventh, added 2026-08-02 as such an explicit decision: the raw-text
+# `check_git_reset_hard` is anchored on `\bgit\s+reset\b`, so it never saw
+# `git -C <path> reset --hard` — the worktree-first spelling RULES.md actively
+# MANDATES. Measured against the live hook before the move: `git reset --hard
+# origin/main` denied, `git -C /tmp/wt reset --hard origin/main` ALLOWED. The
+# irreversible half of the guard was blind to the spelling the rules push agents
+# toward. `check_git_add_all` already handled that same global-option hop; this
+# brings reset --hard into line.
+#
+# Both reset checks are kept. They are not redundant: the raw-text one matches
+# shapes the parser cannot reach (quoted prose, argv assembled from variables),
+# and the argv one matches hops the regex cannot reach. `evaluate` returns on the
+# FIRST hit, so a command matching both is reported ONCE, by the raw-text check
+# — which is why every deny message the raw-text check already produced is
+# unchanged.
+#
+# ORDER MATTERS, and it changes one message. The argv check is placed BEFORE
+# check_cd_then_git, so `cd /x && git -C <p> reset --hard` now reports the
+# reset --hard reason instead of the `cd`-then-git reason. The DECISION is
+# unchanged (it denied before and denies now, under both policies) — only the
+# text differs, and it now names the more serious of the two problems. That is
+# the sole message change; it is asserted in test_guard_core.py.
 _CLAUDE_CODE_CHECKS = [
     check_git_add_all,
     check_git_reset_hard,
+    check_git_reset_hard_argv,
     check_heredoc_to_file,
     check_cd_then_git,
     check_private_key,
@@ -806,7 +840,6 @@ _IRREVERSIBLE_CHECKS = [
     check_rm_rf_critical,
     check_git_stash,
     check_git_clean_force,
-    check_git_reset_hard_argv,
 ]
 
 POLICIES = {

--- a/scripts/claude-hooks/tests/test_guard_core.py
+++ b/scripts/claude-hooks/tests/test_guard_core.py
@@ -64,6 +64,19 @@ def test_unknown_policy_raises_rather_than_running_nothing():
 CLAUDE_CODE_EXPECTED = [
     "check_git_add_all",
     "check_git_reset_hard",
+    # 🔴 Added 2026-08-02 by explicit operator decision — the SEVENTH check, and
+    # the first ever added to this policy. The raw-text `check_git_reset_hard`
+    # above is anchored on `\bgit\s+reset\b`, so it never saw
+    # `git -C <path> reset --hard`: the worktree-first spelling RULES.md
+    # MANDATES. Measured against the live hook before the move —
+    #   DENY  `git reset --hard origin/main`
+    #   ALLOW `git -C /tmp/wt reset --hard origin/main`
+    # — i.e. the irreversible guard was blind to the spelling the rules push
+    # agents toward, while `check_git_add_all` already handled that same hop.
+    # It sits BEFORE check_cd_then_git deliberately: that ordering is what makes
+    # `cd /x && git -C <p> reset --hard` report the reset reason rather than the
+    # cd reason. See test_reset_hard_deny_is_attributed_to_the_reset_check.
+    "check_git_reset_hard_argv",
     "check_heredoc_to_file",
     "check_cd_then_git",
     "check_private_key",
@@ -71,7 +84,7 @@ CLAUDE_CODE_EXPECTED = [
 ]
 
 
-def test_claude_code_policy_is_frozen_at_the_original_six():
+def test_claude_code_policy_is_pinned_by_name():
     """🔴 bash-guard.py runs this policy on EVERY Bash call in EVERY Claude Code
     session on both hosts. Adding a check here changes the operator's primary
     tool and must be an explicit, reported decision.
@@ -107,7 +120,6 @@ IRREVERSIBLE_EXPECTED = [
     "check_rm_rf_critical",
     "check_git_stash",
     "check_git_clean_force",
-    "check_git_reset_hard_argv",
 ]
 
 
@@ -123,13 +135,9 @@ def test_opencode_policy_carries_the_irreversible_checks():
     "rm -rf /",
     "git stash push -m wip",
     "git clean -fd",
-    # 🔴 `git -C <path> reset --hard` is the ONE row here that is a GAP in
-    # Claude Code today, not merely a check we chose not to enable: the frozen
-    # `check_git_reset_hard` is a raw-text regex anchored on `git reset`, so the
-    # worktree-first spelling RULES.md mandates slips past it. Enabling the argv
-    # version for claude-code is a new deny on the operator's primary tool and
-    # is theirs to approve — see the PR body.
-    "git -C /tmp/x reset --hard",
+    # NOTE: `git -C <path> reset --hard` USED to be listed here, asserting that
+    # Claude Code allowed it. That was the gap, not a feature — it is now denied
+    # under both policies and is asserted positively in section 1b below.
 ])
 def test_the_new_checks_do_not_leak_into_claude_code(command):
     """🔴 The blast-radius assertion, by OUTCOME rather than by list membership.
@@ -140,6 +148,207 @@ def test_the_new_checks_do_not_leak_into_claude_code(command):
     """
     assert gc.evaluate(command, "opencode") is not None
     assert gc.evaluate(command, "claude-code") is None
+
+
+# --------------------------------------------------------------------------- #
+# 1b. 🔴 `git reset --hard` under the CLAUDE-CODE policy
+#
+# Closes a gap that was live on both hosts until 2026-08-02. `check_git_add_all`
+# had always handled the `git [global-opts] <verb>` hop; the raw-text
+# `check_git_reset_hard` never did, so the IRREVERSIBLE one of the two was blind
+# to exactly the spelling RULES.md mandates. Probed against the live
+# ~/.claude/hooks/bash-guard.py before the change:
+#
+#     DENY   git reset --hard origin/main
+#     ALLOW  git -C /tmp/wt reset --hard origin/main      <- RULES-mandated
+#     ALLOW  sudo -n git -C /tmp/wt reset --hard HEAD~5
+#     DENY   git add -A
+#     DENY   git -C /tmp/wt add -A                        <- add DOES hop
+#
+# Every deny test below is asserted BY REASON, not merely by "something denied".
+# Three of these commands are ALSO caught by an unrelated check (check_cd_then_git
+# for the `cd &&` form, and the raw-text check for any spelling where the literal
+# bytes "git reset" happen to appear), so a bare `is not None` would pass with
+# this change fully reverted — green for the wrong reason.
+# --------------------------------------------------------------------------- #
+RESET_REASON_MARK = "`git reset --hard` is blocked"
+
+
+def _deny_reason(command, policy="claude-code"):
+    reason = gc.evaluate(command, policy)
+    assert reason is not None, f"{command!r} was ALLOWED under {policy}"
+    return reason
+
+
+def _assert_denied_as_reset_hard(command, policy="claude-code"):
+    """Deny AND attribute it to a reset-hard check.
+
+    The attribution is the load-bearing half: `cd /x && git -C <p> reset --hard`
+    is denied by check_cd_then_git with this change reverted, so asserting only
+    that it denies pins nothing about reset --hard at all.
+    """
+    reason = _deny_reason(command, policy)
+    assert RESET_REASON_MARK in reason, (
+        f"{command!r} denied under {policy}, but for the WRONG reason — got "
+        f"{reason[:120]!r}. Some other check fired first; this asserts nothing "
+        f"about reset --hard coverage."
+    )
+    return reason
+
+
+# Deny fixtures. Paths are pairwise DISTINCT and — 🔴 critically — none of them
+# ends in `.git`. A `--git-dir=/tmp/d/.git` fixture makes the raw command text
+# contain the substring "git reset" (from ".git reset"), so the frozen raw-text
+# regex matches the PATH and the case passes on unpatched code. That exact
+# fixture silently masked the --git-dir gap during this work until the paths
+# were made honest.
+RESET_HARD_DENY = [
+    "git reset --hard",
+    "git -C /srv/repos/alpha reset --hard",
+    "git -c core.fileMode=false reset --hard",
+    "git --git-dir=/var/lib/beta reset --hard",
+    "git --git-dir /opt/gamma reset --hard",
+    "git --work-tree=/home/u/delta reset --hard",
+    "sudo -n git -C /mnt/epsilon reset --hard HEAD~5",
+    "DEBUG=1 git -C /data/zeta reset --hard",
+    "cd /srv/eta && git -C /srv/repos/theta reset --hard",
+    # `--hard` AFTER a ref — the flag is not adjacent to the subcommand at all
+    "git -C /usr/local/iota reset origin/main --hard",
+    "git -C /tmp/kappa reset --hard; echo done",
+    "bash -c 'git -C /tmp/lambda reset --hard'",
+    "/usr/bin/git -C /tmp/mu reset --hard",
+]
+
+
+@pytest.mark.parametrize("command", RESET_HARD_DENY)
+def test_reset_hard_deny_is_attributed_to_the_reset_check(command):
+    """🔴 RED at origin/main for every row except the two the raw-text check
+    already covered (`git reset --hard`, which needs no hop). Attribution by
+    reason is what makes the `cd &&` row a real regression test: at origin/main
+    it denies with check_cd_then_git's message, so this assertion fails there.
+    """
+    _assert_denied_as_reset_hard(command, "claude-code")
+
+
+@pytest.mark.parametrize("command", RESET_HARD_DENY)
+def test_reset_hard_still_denied_under_opencode(command):
+    """The move must not COST opencode anything. `POLICIES["opencode"]` is
+    `_CLAUDE_CODE_CHECKS + _IRREVERSIBLE_CHECKS`, so the check is inherited
+    rather than duplicated — this asserts the inheritance actually holds.
+    """
+    _assert_denied_as_reset_hard(command, "opencode")
+
+
+def test_reset_hard_reason_is_reported_once_not_twice():
+    """Both reset checks can match the same command. `evaluate` returns on the
+    FIRST hit, so exactly one reason comes back — no double-reporting, and the
+    message existing denials already produced is unchanged."""
+    cmd = "git reset --hard origin/main"
+    matching = [c.__name__ for c in gc.POLICIES["claude-code"] if c(cmd)]
+    assert matching == ["check_git_reset_hard", "check_git_reset_hard_argv"], matching
+    assert gc.evaluate(cmd, "claude-code") == gc.check_git_reset_hard(cmd)
+
+
+def test_both_reset_checks_are_present_and_neither_is_redundant():
+    """They cover different shapes. Deleting either loses real coverage:
+      - raw-text only: `git -C <p> reset --hard` slips through;
+      - argv only: quoted prose (below) stops being caught.
+    """
+    names = [c.__name__ for c in gc.POLICIES["claude-code"]]
+    assert "check_git_reset_hard" in names and "check_git_reset_hard_argv" in names
+    # raw-text catches what argv cannot
+    assert gc.check_git_reset_hard("echo 'never use git reset --hard'") is not None
+    assert gc.check_git_reset_hard_argv("echo 'never use git reset --hard'") is None
+    # argv catches what raw-text cannot
+    assert gc.check_git_reset_hard("git -C /srv/repos/nu reset --hard") is None
+    assert gc.check_git_reset_hard_argv("git -C /srv/repos/nu reset --hard") is not None
+
+
+# --- the ALLOW half -------------------------------------------------------- #
+# 🔴 Built independently of the deny list — different paths, different refs,
+# different flags — so a copy-paste symmetry cannot make both halves agree with
+# the same bug. This half is what decides whether the new deny is safe to live
+# with: `git reset --soft/--mixed` and `git -C <p> reset <ref>` are ordinary,
+# non-destructive traffic and must not become collateral.
+RESET_ALLOW = [
+    "git reset",
+    "git reset --soft HEAD~1",
+    "git reset --mixed",
+    "git reset HEAD -- src/main.py",
+    "git -C /opt/service-xi reset HEAD~1",
+    "git -C /opt/service-xi reset --soft HEAD~3",
+    "git -c user.name=bot reset --mixed HEAD",
+    "git --git-dir=/net/omicron reset --keep HEAD~1",
+    "git -C /opt/service-xi log --oneline -3",
+    "git -C /opt/service-xi diff --stat",
+    "git restore src/app.ts",
+    "git restore --staged docs/README.md",
+    "git checkout -- src/app.ts",
+    "git checkout origin/main -- config/prod.yaml",
+    "git revert abc1234",
+    "git reflog -20",
+]
+
+
+@pytest.mark.parametrize("command", RESET_ALLOW)
+def test_non_destructive_reset_and_neighbours_stay_allowed(command):
+    """INVARIANT GUARD (green before and after) — the false-positive fence.
+
+    Not regression coverage for any bug: it pins that closing the gap did not
+    widen into ordinary traffic. `--soft`/`--mixed`/`--keep` do not touch the
+    working tree, and `git -C <p> reset <ref>` is the everyday index reset.
+    """
+    assert gc.evaluate(command, "claude-code") is None
+    assert gc.evaluate(command, "opencode") is None
+
+
+# --- pinned pre-existing behaviour ----------------------------------------- #
+@pytest.mark.parametrize("command", [
+    "echo 'never use git reset --hard'",
+    "grep -rn 'git reset --hard' RULES.md",
+])
+def test_quoted_prose_mentioning_reset_hard_stays_denied(command):
+    """INVARIANT GUARD, and a deliberate NON-fix.
+
+    The raw-text check matches these today and must keep doing so. This is the
+    accepted false positive the module docstring defends: a `_strip_message_text`
+    helper that would have "fixed" it was built and REVERTED in PR #217 after
+    three audit rounds each found a hole that let a genuinely-executing
+    destructive command through. Deciding which bytes are inert message vs.
+    executable command is shell parsing; regexes cannot do it.
+
+    The workaround costs one step — write the text to a file and use
+    `git commit -F <file>` / `gh pr create --body-file <file>`.
+
+    Do NOT "improve" this by making these allow.
+    """
+    reason = _assert_denied_as_reset_hard(command, "claude-code")
+    assert "commit -F" in reason  # the escape hatch is spelled out to the caller
+
+
+def test_git_dir_ending_in_dot_git_passes_for_the_WRONG_reason():
+    """🔴 Fixture-hygiene pin, kept as a warning to the next author.
+
+    `--git-dir=/tmp/d/.git` puts the literal bytes "git reset" into the command
+    text, so the RAW-TEXT check matches the PATH. Any --git-dir test written with
+    a `.git`-suffixed value therefore passes with the argv check removed
+    entirely, and proves nothing. The honest fixtures above avoid `.git`.
+    """
+    accidental = "git --git-dir=/tmp/d/.git reset --hard"
+    assert gc.check_git_reset_hard(accidental) is not None  # matches the PATH
+    honest = "git --git-dir=/tmp/d/objects-only reset --hard"
+    assert gc.check_git_reset_hard(honest) is None          # raw text cannot see it
+    assert gc.check_git_reset_hard_argv(honest) is not None  # argv can
+
+
+def test_add_all_and_reset_hard_now_agree_about_the_global_option_hop():
+    """The asymmetry that WAS the bug, pinned as a symmetry.
+
+    `git -C <p> add -A` was denied while `git -C <p> reset --hard` was allowed —
+    the guard was stricter about the recoverable action than the irreversible one.
+    """
+    for cmd in ("git -C /srv/repos/pi add -A", "git -C /srv/repos/pi reset --hard"):
+        assert gc.evaluate(cmd, "claude-code") is not None, cmd
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/opencode/README.md
+++ b/scripts/opencode/README.md
@@ -118,13 +118,32 @@ patterns has known bypasses, which is exactly why layer 2 exists.
 
 | Policy | Checks | Used by |
 |---|---|---|
-| `claude-code` | the original six, **frozen** | `~/.claude/hooks/bash-guard.py` |
-| `opencode` | those six **plus** `talosctl reset`, `mkfs`, `dd` to a block device, `rm -r` of `/`/`$HOME`/cwd/system dirs, `git stash`, `git clean -f`, and `git reset --hard` through a `-C` hop | `plugin/guard.js` |
+| `claude-code` | the original six, **plus** `git reset --hard` through a global-option hop | `~/.claude/hooks/bash-guard.py` |
+| `opencode` | those seven **plus** `talosctl reset`, `mkfs`, `dd` to a block device, `rm -r` of `/`/`$HOME`/cwd/system dirs, `git stash`, and `git clean -f` | `plugin/guard.js` |
 
 `bash-guard.py` fires on **every** Bash call in **every** Claude Code session on
 both hosts, so adding a check to `claude-code` changes the operator's primary
-tool. It is deliberately unchanged: a before/after decision matrix over a
-2,097-command corpus differs on **0** rows.
+tool. It is added to only by explicit, reported decision.
+
+**Changed 2026-08-02** — `check_git_reset_hard_argv` moved from the
+irreversible set into `_CLAUDE_CODE_CHECKS` (which `POLICIES["opencode"]`
+includes, so opencode keeps it by inheritance, not duplication). Before the
+move, the raw-text `check_git_reset_hard` was anchored on `\bgit\s+reset\b` and
+so never matched `git -C <path> reset --hard` — the worktree-first spelling
+`RULES.md` **mandates**. Probed against the live hook:
+
+```
+DENY   git reset --hard origin/main
+ALLOW  git -C /tmp/wt reset --hard origin/main      <- RULES-mandated spelling
+ALLOW  sudo -n git -C /tmp/wt reset --hard HEAD~5
+DENY   git add -A
+DENY   git -C /tmp/wt add -A                        <- add ALREADY hopped
+```
+
+The guard was stricter about the recoverable action (`add -A`) than the
+irreversible one. A before/after decision matrix over a 66-command corpus
+differs on **12** rows under `claude-code` — every one a `reset --hard`
+spelling going ALLOW → DENY — and on **0** rows under `opencode`.
 
 ## Why `AGENTS.md` is generated rather than symlinked
 


### PR DESCRIPTION
## 🔴 This changes Claude Code behaviour on BOTH hosts

`bash-guard.py` fires on **every** Bash call in **every** Claude Code session on
both hosts. This PR adds a check to the `claude-code` policy — the first ever
added to it. That is the point of the PR, not a side effect, and it is the thing
to veto if you disagree.

**It is not live yet.** `~/.claude/hooks/guard_core.py` resolves to
`/nix/store/…-hm_guard_core.py` — a read-only **copy**, not an out-of-store
symlink — so this is inert until a `home-manager switch`. I did not run one.

## The gap

The guard had two `reset --hard` checks that disagreed about git's
global-option hop, and the **irreversible** one was the loser.

`check_git_add_all` has long handled `git [global-opts] add`. The raw-text
`check_git_reset_hard` is anchored on `\bgit\s+reset\b` and never did — so
`git -C <path> reset --hard`, the worktree-first spelling **`RULES.md`
mandates**, sailed through. Probed against the live
`~/.claude/hooks/bash-guard.py` **before** this change:

```
DENY   git reset --hard origin/main
ALLOW  git -C /tmp/wt reset --hard origin/main       <- RULES-mandated spelling
ALLOW  sudo -n git -C /tmp/wt reset --hard HEAD~5
DENY   git add -A
DENY   git -C /tmp/wt add -A                         <- add DOES hop
ALLOW  git -C /tmp/wt reset --soft HEAD~1
ALLOW  git -C /tmp/wt log --oneline -3
```

The guard was stricter about the recoverable action (`add -A`, which stages
files) than about the irreversible one (`reset --hard`, which destroys them).

## The change

`check_git_reset_hard_argv` already closed this, but lived in
`_IRREVERSIBLE_CHECKS` — opencode-only. It is **moved** into
`_CLAUDE_CODE_CHECKS`, not appended to both. Verified before editing that
`POLICIES["opencode"] == _CLAUDE_CODE_CHECKS + _IRREVERSIBLE_CHECKS`, so
opencode keeps coverage by inheritance and gains no duplicate entry.

Both reset checks are kept — they cover different shapes, proven by test:
- raw-text catches quoted prose (`echo 'never use git reset --hard'`); argv does not.
- argv catches `git -C <p> reset --hard`; raw-text does not.

`evaluate` returns on the first hit, so nothing double-reports. **No
message-text stripping is introduced** — see the PR #217 revert the module
docstring documents.

## Blast radius — every decision that changes

Before/after decision matrix over a 66-command corpus under **both** policies.
The harness was validated against a known-bad mutant first (neutering
`check_git_add_all` flipped exactly the three `git add` rows), so its verdict
is a fact about the code and not about the harness.

**`claude-code`: 12 changes — all `reset --hard`, all ALLOW → DENY:**

| command | before | after |
|---|---|---|
| `git -C /tmp/wt reset --hard origin/main` | ALLOW | DENY |
| `git -C /tmp/wt reset --hard HEAD~5` | ALLOW | DENY |
| `git -c core.fileMode=false reset --hard` | ALLOW | DENY |
| `git --git-dir=/srv/repos/alpha reset --hard` | ALLOW | DENY |
| `git --git-dir /srv/repos/alpha reset --hard` | ALLOW | DENY |
| `git --work-tree=/srv/trees/beta reset --hard` | ALLOW | DENY |
| `sudo -n git -C /tmp/wt reset --hard HEAD~5` | ALLOW | DENY |
| `DEBUG=1 git -C /srv/app reset --hard` | ALLOW | DENY |
| `git -C /var/p reset origin/main --hard` | ALLOW | DENY |
| `git -C /tmp/wt reset --hard; echo done` | ALLOW | DENY |
| `bash -c 'git -C /tmp/wt reset --hard'` | ALLOW | DENY |
| `/usr/bin/git -C /tmp/wt reset --hard` | ALLOW | DENY |

**`opencode`: 0 decision changes.** Effective behaviour preserved.

**Nothing else moves.** Explicitly re-confirmed still ALLOW: `git reset`,
`git reset --soft HEAD~1`, `git reset --mixed`, `git reset HEAD -- <path>`,
`git -C <p> reset HEAD~1`, `git -C <p> reset --soft HEAD~3`,
`git -c user.name=bot reset --mixed HEAD`, `git --git-dir=<d> reset --keep HEAD~1`,
`git -C <p> log`, `git -C <p> diff`, `git restore <path>`, `git restore --staged`,
`git checkout -- <path>`, `git checkout <ref> -- <paths>`, `git revert`,
`git reflog`, plus ordinary non-git traffic.

### One deny MESSAGE changes (decision does not)

`cd /x && git -C <p> reset --hard` was denied before (by `check_cd_then_git`)
and is denied now (by the argv reset check, which is ordered ahead of it). Same
decision under both policies; the text now names the more serious of the two
problems. This is the only message change.

## Tests

`scripts/claude-hooks/tests/test_guard_core.py`: **913 → 960** (+48; one
now-false parametrize row removed). `test_bash_guard.py`: **113 PASS / 0 FAIL**,
unchanged. `test_shell_env_nudge` / `test_claude_notify` /
`test_register_nudge_hook`: all pass.

**Red/green matrix.** New tests run against `origin/main`'s `guard_core.py`:
**19 red**, all green at HEAD. (3 further failures in that run were scratch-dir
artifacts — `test_plugin_*` read `scripts/opencode/plugin/guard.js`, absent from
the harness dir — and are excluded.)

Red at `origin/main`:
- `test_claude_code_policy_is_pinned_by_name`
- `test_opencode_policy_is_a_strict_superset`
- `test_opencode_policy_carries_the_irreversible_checks`
- `test_reset_hard_deny_is_attributed_to_the_reset_check` × 12 of 13 rows
- `test_reset_hard_still_denied_under_opencode[cd /x && git -C …]`
- `test_reset_hard_reason_is_reported_once_not_twice`
- `test_both_reset_checks_are_present_and_neither_is_redundant`
- `test_add_all_and_reset_hard_now_agree_about_the_global_option_hop`

**Mutation-tested.** Reverting only the policy move takes the deny tests red on
**their own assertions**, not collateral:

```
AssertionError: 'git -C /srv/repos/alpha reset --hard' was ALLOWED under claude-code
AssertionError: 'cd /srv/eta && git -C /srv/repos/theta reset --hard' denied under
  claude-code, but for the WRONG reason — got '`cd <path> && git …` is blocked…'.
  Some other check fired first; this asserts nothing about reset --hard coverage.
```

That second one is why every deny case asserts **by reason**: three of these
commands are also caught by an unrelated check, so a bare `is not None` would
pass with this change fully reverted.

### Honest labelling

Two required cases are **invariant guards, not regression coverage** — they were
already denied at `origin/main`:
- `git reset --hard` (bare) — the raw-text check always caught it.
- `cd /x && git -C <p> reset --hard` — caught by `check_cd_then_git`. It *is* red
  at `origin/main`, but only because of the reason assertion; the decision never
  changed.

The ALLOW half is likewise an invariant guard (green before and after) — it is
the false-positive fence, built independently of the deny list with pairwise-
distinct fixtures.

### A fixture that lied, now pinned as a test

`git --git-dir=/tmp/d/.git reset --hard` passes **on unpatched code**: the path's
`.git` suffix puts the literal bytes `git reset` into the command text, so the
raw-text regex matches the *path*. That masked the `--git-dir` gap during this
work until the fixtures were changed to paths without a `.git` suffix.
`test_git_dir_ending_in_dot_git_passes_for_the_WRONG_reason` pins the trap.

## Docs

`scripts/opencode/README.md` claimed `claude-code` was "the original six,
**frozen**" and that the before/after matrix differed on **0** rows. Both are
now false; corrected with the measured numbers. Stale comments in
`guard_core.py` (including the docstring saying the argv check is "deliberately
NOT added to claude-code") updated.

## Not verified

- Not exercised through a real `home-manager switch` on either host — the change
  is inert until you run one. Post-switch, the check to re-run is the live probe
  above: `git -C /tmp/wt reset --hard origin/main` should flip ALLOW → DENY.
- Corpus is 66 hand-picked commands, not a transcript-mined corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
