### PR TITLE
fix(scrub): point the drift guard at the REPO source so it can never be tier-invisible

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -269,16 +269,23 @@ EXPECTED_SKIPS=(
   # REPO_COS_LIVE_DRIFT_CHECK=1.
   "scripts/repo-cos/tests|live-store drift check is opt-in"
 )
-# test_scrub.py::test_patterns_cover_bash_guard compares scrub.py's
-# SECRET_PATTERNS against the DEPLOYED hook, and skips iff that file is absent —
-# `_BASH_GUARD = Path.home() / ".claude" / "hooks" / "bash-guard.py"`, which is
-# exactly the test below. It is ABSENT in the nix sandbox (synthetic $HOME) and
-# PRESENT on a switched dev host, so the test genuinely runs in one and not the
-# other. Pinning it unconditionally would fail the pre-push tier; pinning it
-# conditionally still fails if it skips on a host where the hook exists.
-if [ ! -e "$HOME/.claude/hooks/bash-guard.py" ]; then
-  EXPECTED_SKIPS+=("scripts/session-analysis/session_insight/tests|bash-guard\.py absent")
-fi
+# ⚠ REMOVED, deliberately — do not re-add. test_scrub.py's drift guard used to
+# compare scrub.py's SECRET_PATTERNS against the DEPLOYED hook
+# (`Path.home()/".claude"/"hooks"/"bash-guard.py"`) and skip when that file was
+# absent, so it ran on a switched dev host and skipped in the sandbox — and this
+# entry existed to pin that environment-dependent skip.
+#
+# That HOME-keyed referent was the bug: the check was structurally unobservable
+# in the tier that gates merges, so when #276 moved SECRET_PATTERNS into
+# guard_core.py the parser returned [] and the test failed on every dev host
+# while the hermetic gate stayed green. The test now compares two files that are
+# both TRACKED IN THIS REPO (session_insight/scrub.py vs claude-hooks/
+# guard_core.py), so it runs in every tier and NEVER skips — which is why there
+# is nothing left to pin here.
+#
+# If you find yourself re-adding a conditional skip for this suite, the drift
+# guard has been re-pointed at something environment-dependent again. Fix that
+# instead.
 
 fail=0
 declare -a RESULTS

--- a/scripts/session-analysis/session_insight/tests/test_scrub.py
+++ b/scripts/session-analysis/session_insight/tests/test_scrub.py
@@ -3,8 +3,6 @@ redacted; internal IPs survive; public IPs redacted only when enabled."""
 import ast
 from pathlib import Path
 
-import pytest
-
 import scrub
 
 
@@ -82,15 +80,35 @@ def test_empty_text():
 
 
 # --------------------------------------------------------------------------- #
-# FIX 4 — best-effort drift guard against the vendored source of truth.
+# FIX 4 — drift guard against the source of truth.
 # --------------------------------------------------------------------------- #
-_BASH_GUARD = Path.home() / ".claude" / "hooks" / "bash-guard.py"
+# 🔴 This points at the REPO file, not at ~/.claude/hooks/. Two reasons, and the
+# second is the one that bit:
+#
+#   1. CORRECT REFERENT. The deployed copy is *generated from* this file by
+#      home-manager. Comparing against the deployed copy tested whichever build
+#      the host last switched to — i.e. it answered a question about the machine,
+#      not about the commit. The drift that matters is between two files that
+#      live side by side IN THIS REPO.
+#
+#   2. IT COULD NOT FAIL IN CI. Keyed on $HOME, the test SKIPPED in the nix
+#      sandbox (synthetic HOME, no hook) and RAN only on a switched dev host —
+#      so the hermetic gate structurally could not observe it. #276 then moved
+#      SECRET_PATTERNS out of bash-guard.py into guard_core.py; the parser
+#      returned [] and this test failed on every dev host while the gate stayed
+#      green and silent. See claude/RULES.md, "A suite that runs in TWO TIERS
+#      must be green in BOTH".
+#
+# Both files are tracked, so this now runs EVERYWHERE and never skips.
+_GUARD_CORE = (
+    Path(__file__).resolve().parents[3] / "claude-hooks" / "guard_core.py"
+)
 
 
-def _bash_guard_patterns():
-    """Extract the regex strings from bash-guard.py's SECRET_PATTERNS literal by
+def _guard_core_patterns():
+    """Extract the regex strings from guard_core.py's SECRET_PATTERNS literal by
     parsing the module (never executing it)."""
-    tree = ast.parse(_BASH_GUARD.read_text(encoding="utf-8"))
+    tree = ast.parse(_GUARD_CORE.read_text(encoding="utf-8"))
     for node in ast.walk(tree):
         if (isinstance(node, ast.Assign)
                 and any(getattr(t, "id", None) == "SECRET_PATTERNS"
@@ -106,15 +124,27 @@ def _bash_guard_patterns():
     return []
 
 
-def test_patterns_cover_bash_guard():
-    """scrub.py's pattern set must be a SUPERSET of bash-guard's SECRET_PATTERNS.
-    Skipped on a fresh checkout where the hook file is absent (so CI is green)."""
-    if not _BASH_GUARD.exists():
-        pytest.skip(f"{_BASH_GUARD} absent (vendored source not on this host)")
-    theirs = _bash_guard_patterns()
-    assert theirs, "could not parse SECRET_PATTERNS from bash-guard.py"
+def test_patterns_cover_guard_core():
+    """scrub.py's pattern set must be a SUPERSET of guard_core's SECRET_PATTERNS.
+
+    Never skips: both files are tracked in this repo, so every tier runs it.
+    A NEVER-SKIPPING drift guard is the entire point — the previous version
+    keyed on $HOME and was therefore unobservable in the sandbox.
+    """
+    assert _GUARD_CORE.is_file(), (
+        f"{_GUARD_CORE} not found — this guard would be vacuous. guard_core.py "
+        "is the source of truth for the Bash hook's SECRET_PATTERNS; if it "
+        "moved, update _GUARD_CORE rather than deleting the check."
+    )
+    theirs = _guard_core_patterns()
+    assert theirs, (
+        "could not parse SECRET_PATTERNS from guard_core.py. That is a PARSER "
+        "failure, not a pass — the literal may have changed shape (it must stay "
+        "a list of (regex, label) tuples for the ast walk to see it). This exact "
+        "silence is how the check sat broken after #276 moved the patterns."
+    )
     ours = {rx.pattern for rx, _label in scrub.SECRET_PATTERNS}
     missing = [p for p in theirs if p not in ours]
     assert not missing, (
-        "scrub.py drifted from bash-guard.py — these SECRET_PATTERNS are no "
+        "scrub.py drifted from guard_core.py — these SECRET_PATTERNS are no "
         f"longer covered: {missing}")


### PR DESCRIPTION
Second of the three regressions #276 shipped. #289 fixed the first, #290 the third.

## The bug

`test_patterns_cover_bash_guard` asserted that `scrub.py`'s `SECRET_PATTERNS` is a superset of the Bash hook's, by `ast.parse`ing **the deployed hook**:

```python
_BASH_GUARD = Path.home() / ".claude" / "hooks" / "bash-guard.py"
if not _BASH_GUARD.exists():
    pytest.skip(...)
```

#276 moved `SECRET_PATTERNS` out of `bash-guard.py` into `guard_core.py`. The parser returned `[]` and the test began failing:

```
AssertionError: could not parse SECRET_PATTERNS from bash-guard.py
```

## Why it stayed broken — the part that matters

Keyed on `$HOME`, the test **skipped in the nix sandbox** (synthetic HOME, no hook) and **ran only on a switched dev host**. So it failed on every dev host — breaking the pre-push tier — while the hermetic gate, *the tier that actually gates merges*, stayed green and silent.

That is the property you asked me to make sure I addressed: **the sandbox tier could not fail on it.** It is the exact complement of #290's defect, which failed *only* in the sandbox. Both hid behind #289's red.

I also caught it changing under me mid-session: the same tree passed at 16:45 and failed at 17:03, because a concurrent `home-manager switch` swapped the deployed hook.

## The fix, and the options I considered

I did **not** pick silently. Three ways to fix it:

**A — repoint at the deployed `~/.claude/hooks/guard_core.py`.** Smallest diff. **Rejected:** keeps the tier-invisibility. It would still skip in the sandbox, so the next time this breaks, the gate again cannot see it.

**B — compare repo ↔ repo (chosen).** Both `session_insight/scrub.py` and `claude-hooks/guard_core.py` are tracked in this repo, so the test **runs in every tier and never skips**. The deployed copy is *generated from* the repo file by home-manager, so the repo is the correct referent anyway: pointing at `$HOME` answered a question about the machine, not about the commit. It also **removes a pinned skip** rather than adding one.

**C — B plus an extra deployed-copy check that skips when absent.** Strictly more coverage on dev hosts. **Rejected for now:** it re-introduces an environment-dependent skip and a pin to maintain, to catch a case (deployed copy diverging from its own generator) that home-manager makes structurally impossible. Happy to add it if you disagree — it is additive.

The empty-parse case is now a **loud, named assertion** instead of the silence that hid #276.

## 🔴 A required companion change, not a cosmetic one

The test no longer skips, so the conditional `EXPECTED_SKIPS` entry pinning that skip **must** go — otherwise #284's accounting fails the gate with *"FEWER than pinned: a pinned skip now RUNS"*. Removed, with a comment explaining why it must not come back:

> If you find yourself re-adding a conditional skip for this suite, the drift guard has been re-pointed at something environment-dependent again. Fix that instead.

## Reachability — both assertions broken on purpose

Each fails for **its own** reason, not a neighbour's:

| mutation | result |
|---|---|
| inject a pattern into `guard_core.py` that `scrub.py` lacks | `scrub.py drifted from guard_core.py — these SECRET_PATTERNS are no longer covered: ['\bmutant-XYZ-[0-9]{9}\b']` |
| rename the literal, reproducing #276's move | `could not parse SECRET_PATTERNS from guard_core.py …` |

`guard_core.py` restored **byte-identical** after each (verified against HEAD, not assumed).

## Counts

- `session_insight` suite: **57 passed, 0 skipped** — was `56 passed + 1 skipped` in the sandbox and `56 passed + 1 FAILED` on a dev host.
- Gate verification is on the **merged tree**, not this branch alone: this branch has no #290, so a sandbox run here would fail on #290's 10 handle tests and tell me nothing. I built an integration branch off `main` merging **#290 + this PR** — both touch `run-tests.sh` in different regions; `ort` auto-merged, and I checked the merged result is semantically coherent (`nix-instantiate` present in `REQUIRED_TOOLS`, conditional skip gone, `EXPECTED_SKIPS` down to one entry) rather than trusting a clean textual merge. `nix flake check` result on that tree is in a follow-up comment.

## Merge order

Independent of #290 textually, but **#290 should land first** — on current `main` this branch alone leaves the sandbox red for #290's reason. Neither is stacked on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
