### PR TITLE
fix(opencode): guard.js could not find its core once deployed — every bash call refused (LIVE BREAKAGE)

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -765,10 +765,21 @@ in
   # non-recursive glob.
   home.file.".config/opencode/plugin/guard.js".source = ../scripts/opencode/plugin/guard.js;
 
-  # The plugin resolves `../guard_core.py` relative to its own module URL, so the
-  # SAME source file that backs ~/.claude/hooks/guard_core.py is deployed here
-  # too. Two independent deployments of one implementation: opencode's guard does
-  # not depend on ~/.claude/ existing, and Claude Code's does not depend on
+  # 🔴 THIS PATH IS LOAD-BEARING AND IS RESOLVED BY $HOME, NOT BY THE PLUGIN'S
+  # OWN LOCATION. The plugin used to compute `../guard_core.py` from
+  # `import.meta.url`, which reads correctly against THIS declaration and is
+  # wrong in reality: `home.file` makes the deploy path a symlink into the store,
+  # node resolves `import.meta.url` through it, and the store is FLAT
+  # (/nix/store/<hash>-hm_guard.js), so `..` was `/nix`. The guard failed closed
+  # on every bash call in opencode. guard.js now looks in
+  # `$HOME/.config/opencode/guard_core.py` — i.e. exactly the attrpath below —
+  # so moving or renaming this entry breaks the guard. See the resolution comment
+  # in scripts/opencode/plugin/guard.js and the deployed-layout regression tests
+  # in scripts/tests/test_opencode_guard_plugin.py.
+  #
+  # The SAME source file that backs ~/.claude/hooks/guard_core.py is deployed
+  # here too. Two independent deployments of one implementation: opencode's guard
+  # does not depend on ~/.claude/ existing, and Claude Code's does not depend on
   # ~/.config/opencode/ existing.
   home.file.".config/opencode/guard_core.py".source = ../scripts/claude-hooks/guard_core.py;
 

--- a/scripts/opencode/plugin/guard.js
+++ b/scripts/opencode/plugin/guard.js
@@ -36,29 +36,99 @@
 //   opencode.jsonc as globs. Globs are acceptable for friction and unacceptable
 //   as the only thing guarding an irreversible action.
 //
-// 🔴 FAILS CLOSED. If python is missing, the core is unreadable, the subprocess
-// times out, or the output is unparseable, this throws. A guard that silently
-// degrades to "allow" is worse than no guard: it reports safety it is not
-// providing.
+// 🔴 FAILS CLOSED. If the core cannot be FOUND, python is missing, the core is
+// unreadable, the subprocess times out, or the output is unparseable, this
+// throws — naming the paths it tried. A guard that silently degrades to "allow"
+// is worse than no guard: it reports safety it is not providing. (Fail-closed
+// is also why a path bug here is a TOTAL outage rather than a silent hole — see
+// the resolution comment below, which is the bug that actually shipped.)
 //
 // COST: one python3 subprocess per bash call. Measured 26 ms average over 10
 // runs on a representative command on this host — a rounding error next to a
 // model round-trip, and `spawnSync` keeps the ordering unambiguous (no chance
 // of the tool starting before the verdict lands).
 //
-// Test seams: DEVRC_GUARD_CORE (path to guard_core.py), DEVRC_GUARD_PYTHON
-// (interpreter), DEVRC_GUARD_POLICY (policy name), DEVRC_GUARD_DISABLE=1.
+// Test seams: DEVRC_GUARD_CORE (exact path to guard_core.py — an override, NOT
+// a hint: when set it is the ONLY candidate), DEVRC_GUARD_PYTHON (interpreter),
+// DEVRC_GUARD_POLICY (policy name), DEVRC_GUARD_DISABLE=1.
 
 import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// guard_core.py is deployed NEXT TO the config dir (nix/home.nix links it to
-// ~/.config/opencode/guard_core.py from the same source file bash-guard.py
-// imports). Resolving it relative to this module keeps opencode's guard from
-// depending on ~/.claude/ — one source file, two independent deployments.
-const CORE =
-  process.env.DEVRC_GUARD_CORE ||
-  fileURLToPath(new URL("../guard_core.py", import.meta.url));
+// 🔴 HOW guard_core.py IS LOCATED — and why NOT relative to this module.
+//
+// This file used to do, and ONLY do:
+//     fileURLToPath(new URL("../guard_core.py", import.meta.url))
+// on the reasoning that it lives at ~/.config/opencode/plugin/guard.js, so `..`
+// is ~/.config/opencode/ — exactly where nix/home.nix links the core.
+//
+// That reasoning is about the DEPLOY path, and the deploy path is a SYMLINK.
+// home-manager's `home.file` links ~/.config/opencode/plugin/guard.js into the
+// nix store, and node resolves `import.meta.url` through the symlink to the REAL
+// store path. The store is FLAT — the file lands as a single
+// /nix/store/<hash>-hm_guard.js, with no `plugin/` directory above it. MEASURED
+// on this host:
+//
+//     readlink -f ~/.config/opencode/plugin/guard.js
+//       -> /nix/store/5m6y63cj512ksn783j5nddlrchkca92p-hm_guard.js
+//     import.meta.url dir : /nix/store
+//     ../guard_core.py    -> /nix/guard_core.py          ← does not exist
+//
+// So the guard failed closed on EVERY bash call, with
+// "python3: can't open file '/nix/guard_core.py'". The logic was correct; only
+// the path was wrong. This is the hazard RULES.md names for home-manager-managed
+// dotfiles ("`readlink -f` is the arbiter") applied to a program reasoning about
+// its OWN location: a store-resolved `import.meta.url` invalidates every
+// relative-path assumption, and nothing about the source file reveals that.
+//
+// The fix resolves the core INDEPENDENTLY of where this module happens to sit:
+//
+//   1. DEVRC_GUARD_CORE, if set — an EXPLICIT override, used exactly as given
+//      with NO fallback. Silently ignoring a wrong override and quietly checking
+//      some other file is worse than failing: the operator would believe they
+//      had pointed the guard at their file.
+//   2. $HOME/.config/opencode/guard_core.py — the home-manager deploy target
+//      (itself a store symlink, which is fine: we open it, we don't `..` off it).
+//   3. `../guard_core.py` relative to this module — LAST RESORT, so a plain
+//      (non-home-manager) checkout that keeps the two files in their repo layout
+//      still works. It cannot weaken anything: it is only ever reached when 2
+//      does not exist, and a candidate is used only if it EXISTS.
+//
+// If none exists we throw, naming every path tried. Still fail-closed.
+function moduleRelativeCore() {
+  try {
+    return fileURLToPath(new URL("../guard_core.py", import.meta.url));
+  } catch {
+    return null;
+  }
+}
+
+function coreCandidates() {
+  const override = process.env.DEVRC_GUARD_CORE;
+  if (override) return [override];
+  return [
+    join(homedir(), ".config", "opencode", "guard_core.py"),
+    moduleRelativeCore(),
+  ].filter(Boolean);
+}
+
+// Resolved per call, not once at module load. The cost is a couple of stat()s
+// against a ~26 ms python subprocess, and resolving at load time would freeze a
+// verdict taken before a `home-manager switch` mid-session. 🔴 It must also NOT
+// throw at import time: a plugin that fails to LOAD is not a plugin that denies
+// — opencode would carry on without the hook, which is fail-OPEN. The throw
+// belongs inside `tool.execute.before`, where it hard-blocks the call.
+function resolveCore() {
+  const tried = coreCandidates();
+  for (const candidate of tried) {
+    if (existsSync(candidate)) return { core: candidate, tried };
+  }
+  return { core: null, tried };
+}
+
 const PYTHON = process.env.DEVRC_GUARD_PYTHON || "python3";
 const POLICY = process.env.DEVRC_GUARD_POLICY || "opencode";
 
@@ -68,6 +138,17 @@ export const GuardPlugin = async () => ({
     if (process.env.DEVRC_GUARD_DISABLE === "1") return;
     const command = output?.args?.command;
     if (typeof command !== "string" || command === "") return;
+
+    const { core: CORE, tried } = resolveCore();
+    if (!CORE) {
+      throw new Error(
+        `bash guard cannot find guard_core.py — tried: ${tried.join(", ")}. ` +
+          `Refusing the command rather than running it unchecked. Fix: run ` +
+          `\`home-manager switch\` (it deploys ~/.config/opencode/guard_core.py ` +
+          `from devrc/scripts/claude-hooks/guard_core.py), or point ` +
+          `DEVRC_GUARD_CORE at the file.`,
+      );
+    }
 
     let res;
     try {

--- a/scripts/tests/fixtures/guard_plugin_driver.mjs
+++ b/scripts/tests/fixtures/guard_plugin_driver.mjs
@@ -1,0 +1,71 @@
+// guard_plugin_driver.mjs — exercise opencode's guard plugin THROUGH ITS REAL
+// ENTRY POINT.
+//
+// 🔴 WHY THIS EXISTS. The bug this fixture was written for (guard.js resolving
+// its python core via `import.meta.url`, which node resolves through the
+// home-manager store symlink to a FLAT /nix/store path, so `../guard_core.py`
+// became `/nix/guard_core.py`) was invisible to every existing test, because
+// every existing test either read guard.js as TEXT or imported guard_core.py
+// DIRECTLY in python. Neither ever ran the plugin. A test that does not execute
+// the deployed artifact cannot see a deployment bug.
+//
+// So: import the module the way opencode does, call the hook opencode calls,
+// and report the outcome as JSON on stdout.
+//
+//   usage: node guard_plugin_driver.mjs <path-to-guard.js> <command>
+//   stdout: {"outcome":"allow"}
+//         | {"outcome":"throw","message":"…"}
+//         | {"outcome":"no-hook"}
+//         | {"outcome":"import-error","message":"…"}
+//
+// The driver NEVER exits non-zero for a guard verdict — a throw from the hook is
+// the guard working, not the driver failing. It exits non-zero only when it
+// could not run at all, so the caller can tell those two apart instead of
+// reading one exit code for both.
+
+const [, , pluginPath, command] = process.argv;
+
+if (!pluginPath || command === undefined) {
+  console.error("usage: guard_plugin_driver.mjs <path-to-guard.js> <command>");
+  process.exit(2);
+}
+
+const { pathToFileURL } = await import("node:url");
+
+let mod;
+try {
+  // Import BY THE PATH GIVEN. When the caller passes a symlink (the deployed
+  // ~/.config/opencode/plugin/guard.js), node resolves it to the real file and
+  // `import.meta.url` inside guard.js becomes the STORE path — which is exactly
+  // the condition under test. Do not `realpath` it here.
+  mod = await import(pathToFileURL(pluginPath).href);
+} catch (e) {
+  console.log(
+    JSON.stringify({ outcome: "import-error", message: String((e && e.message) || e) }),
+  );
+  process.exit(0);
+}
+
+const factory = mod.GuardPlugin;
+if (typeof factory !== "function") {
+  console.log(JSON.stringify({ outcome: "no-hook", message: "no GuardPlugin export" }));
+  process.exit(0);
+}
+
+const plugin = await factory({});
+const hook = plugin && plugin["tool.execute.before"];
+if (typeof hook !== "function") {
+  console.log(
+    JSON.stringify({ outcome: "no-hook", message: "no tool.execute.before hook" }),
+  );
+  process.exit(0);
+}
+
+try {
+  // The two arguments opencode passes: the tool identity, and the mutable
+  // output whose `args.command` is the shell command about to run.
+  await hook({ tool: "bash" }, { args: { command } });
+  console.log(JSON.stringify({ outcome: "allow" }));
+} catch (e) {
+  console.log(JSON.stringify({ outcome: "throw", message: String((e && e.message) || e) }));
+}

--- a/scripts/tests/test_opencode_config.py
+++ b/scripts/tests/test_opencode_config.py
@@ -1366,13 +1366,31 @@ def test_every_source_path_home_nix_claims_actually_exists():
 
 
 def test_plugin_resolves_the_core_next_to_the_config_dir():
-    """🔴 The two deployments must AGREE. guard.js does
-    `new URL("../guard_core.py", import.meta.url)` from
+    """🔴 The two deployments must AGREE — but NOT via the plugin's own location.
+
+    🔴 THIS TEST USED TO ASSERT THE BUG. Its previous body was:
+
+        assert 'new URL("../guard_core.py", import.meta.url)' in GUARD_PLUGIN.read_text()
+
+    with a docstring reasoning that guard.js "does `../guard_core.py` from
     ~/.config/opencode/plugin/, i.e. ~/.config/opencode/guard_core.py — which is
-    exactly where home.nix links it. If someone moves either, the plugin fails
-    CLOSED (every bash call refused), which is loud but total.
+    exactly where home.nix links it." That reasoning is about the DEPLOY path,
+    and the deploy path is a SYMLINK: `home.file` links the plugin into the nix
+    store, node resolves `import.meta.url` THROUGH it, and the store is FLAT, so
+    `..` was `/nix`. The guard failed closed on every bash call in opencode while
+    this test — which pinned the broken line as the contract — stayed green.
+
+    A substring assertion over source text cannot see a deployment bug. The real
+    coverage now lives in scripts/tests/test_opencode_guard_plugin.py, which
+    builds the store-symlink layout on disk and RUNS the plugin. What is left
+    here is the structural half: the plugin must resolve the core from $HOME, and
+    home.nix must deploy it there.
     """
-    assert 'new URL("../guard_core.py", import.meta.url)' in GUARD_PLUGIN.read_text()
+    src = GUARD_PLUGIN.read_text()
+    assert "homedir()" in src, (
+        "guard.js must locate guard_core.py from $HOME, not from its own module "
+        "URL — `import.meta.url` resolves into the FLAT nix store"
+    )
     assert '.config/opencode/guard_core.py' in HOME_NIX.read_text()
 
 

--- a/scripts/tests/test_opencode_guard_plugin.py
+++ b/scripts/tests/test_opencode_guard_plugin.py
@@ -1,0 +1,511 @@
+r"""Tests for opencode's guard plugin AS DEPLOYED — executed, not read.
+
+🔴 WHY THIS FILE EXISTS — the bug that shipped, and why the suite was green.
+
+`scripts/opencode/plugin/guard.js` located its python core with
+
+    fileURLToPath(new URL("../guard_core.py", import.meta.url))
+
+reasoning that it lives at ~/.config/opencode/plugin/guard.js, so `..` is
+~/.config/opencode/ — exactly where nix/home.nix links the core. That reasoning
+is about the DEPLOY path, and the deploy path is a SYMLINK. home-manager's
+`home.file` links the plugin into the nix store; node resolves `import.meta.url`
+THROUGH the symlink to the real store path; and the store is FLAT — the file
+lands as a single `/nix/store/<hash>-hm_guard.js` with no `plugin/` directory
+above it. MEASURED on the live host, 2026-08-02:
+
+    readlink -f ~/.config/opencode/plugin/guard.js
+      -> /nix/store/5m6y63cj512ksn783j5nddlrchkca92p-hm_guard.js
+    import.meta.url dir : /nix/store
+    ../guard_core.py    -> /nix/guard_core.py          ← does not exist
+
+The guard FAILS CLOSED, so this was not a silent hole — it was a total outage:
+every bash call in opencode was refused with
+
+    bash guard failed (status=2, stderr=python3: can't open file
+    '/nix/guard_core.py': [Errno 2] No such file or directory).
+
+🔴 AND THE SUITE WAS GREEN. test_opencode_config.py asserted, verbatim:
+
+    assert 'new URL("../guard_core.py", import.meta.url)' in GUARD_PLUGIN.read_text()
+
+i.e. it pinned the BROKEN LINE as if it were the contract, and its docstring
+restated the (wrong) `~/.config/opencode/plugin/` reasoning as justification. The
+rest of the coverage was the same shape: substring checks over guard.js's text,
+existence checks on home.nix `source =` paths, and python tests that imported
+`guard_core` DIRECTLY. Every one of them passes with the plugin 100% inert.
+Nothing anywhere ever LOADED guard.js and called its hook.
+
+That is the finding, and it is what this file fixes. These tests build the
+store-symlink layout on disk and run the plugin through its real entry point
+(scripts/tests/fixtures/guard_plugin_driver.mjs), so a path that does not resolve
+in the deployed shape fails here.
+
+🔴 RED/GREEN MATRIX — measured, so this file carries its own scope.
+Run at origin/main (88eb6d0, pre-fix): **5 failed, 15 passed**. The five REGRESSION
+tests, red at base and green at HEAD, are:
+
+    test_plugin_finds_its_core_in_the_deployed_store_symlink_layout
+    test_plugin_still_blocks_an_irreversible_command_in_the_deployed_layout
+    test_plugin_refuses_when_the_core_cannot_be_found_anywhere
+    test_the_home_candidate_beats_the_module_relative_one
+    test_guard_js_does_not_rely_solely_on_its_own_module_url
+
+Everything else in this file PASSED at base and is therefore an INVARIANT GUARD,
+not regression coverage — it pins behaviour the bug never violated (the harness
+controls, the python-missing limb, the override seam, the repo-checkout layout,
+the non-bash passthrough). Counted honestly, this PR adds 5 regression tests and
+15 guards.
+
+MUTATION SWEEP (5/5 killed, each by its NAMED test; control green before and
+after, and the restore re-verified):
+    M1 drop the $HOME candidate            -> ..._deployed_store_symlink_layout
+    M2 skip the existsSync check           -> ..._plain_repo_checkout_layout_still_works
+    M3 module-relative first (the bug)     -> ..._home_candidate_beats_the_module_relative_one
+    M4 DEVRC_GUARD_CORE as hint not override -> ..._override_is_used_verbatim...
+    M5 FAIL OPEN when no core is found     -> ..._refuses_when_the_core_cannot_be_found_anywhere
+
+    run:  python -m pytest scripts/tests/test_opencode_guard_plugin.py -q
+
+`node` and `python3` are hard REQUIRED_TOOLS in scripts/run-tests.sh, so their
+absence is a runner FATAL rather than a skip here — a skip in this file would
+restore exactly the vacuous green it exists to end.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+GUARD_JS = ROOT / "scripts" / "opencode" / "plugin" / "guard.js"
+GUARD_CORE = ROOT / "scripts" / "claude-hooks" / "guard_core.py"
+DRIVER = Path(__file__).resolve().parent / "fixtures" / "guard_plugin_driver.mjs"
+
+# A plausible store basename. The two things that matter are that it is FLAT
+# (no `plugin/` parent) and that the deployed name is `hm_<basename>`, which is
+# what home-manager produces.
+STORE_GUARD = "5m6y63cj512ksn783j5nddlrchkca92p-hm_guard.js"
+STORE_CORE = "y1g22dzhwkqcmqx89cb6j79pkr92961v-hm_guard_core.py"
+
+# Representative commands. `mkswap /dev/…` is deliberately one of the GLOB BLIND
+# SPOTS listed in test_opencode_config.py — a command the glob layer never
+# caught, so only the guard can refuse it. `ls -la` is on that file's MUST_ALLOW
+# list.
+BLOCKED_COMMAND = "mkswap /dev/zzz-nonexistent-device"
+BENIGN_COMMAND = "ls -la"
+
+
+# --------------------------------------------------------------------------- #
+# harness
+# --------------------------------------------------------------------------- #
+def run_plugin(plugin_path: Path, command: str, *, home: Path, env: dict | None = None):
+    """Load `plugin_path` in node and invoke its `tool.execute.before` hook.
+
+    Returns the driver's decoded JSON: {"outcome": "allow"|"throw"|…}.
+
+    The environment is built from scratch rather than inherited: every
+    DEVRC_GUARD_* seam is stripped unless the caller asks for it, so a variable
+    set in the developer's shell cannot decide a test's outcome.
+    """
+    child = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith("DEVRC_GUARD_") and k != "HOME"
+    }
+    child["HOME"] = str(home)
+    if env:
+        child.update(env)
+
+    proc = subprocess.run(
+        ["node", str(DRIVER), str(plugin_path), command],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=child,
+    )
+    assert proc.returncode == 0, (
+        f"the DRIVER itself failed (rc={proc.returncode}). That is a harness "
+        f"fault, not a guard verdict.\nstdout: {proc.stdout}\nstderr: {proc.stderr}"
+    )
+    assert proc.stdout.strip(), f"driver produced no stdout; stderr: {proc.stderr}"
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def build_deployed_layout(tmp_path: Path, *, with_core: bool = True) -> tuple[Path, Path]:
+    """Reproduce the home-manager deployment on disk.
+
+        <tmp>/store/<hash>-hm_guard.js            (FLAT regular file)
+        <tmp>/store/<hash>-hm_guard_core.py       (FLAT regular file)
+        <tmp>/home/.config/opencode/plugin/guard.js  -> the store guard
+        <tmp>/home/.config/opencode/guard_core.py    -> the store core
+
+    Returns (home, plugin_symlink). The caller imports the SYMLINK, which is
+    what opencode does, so node performs the same resolution it performs live.
+    """
+    store = tmp_path / "store"
+    store.mkdir(exist_ok=True)
+    home = tmp_path / "home"
+    cfg = home / ".config" / "opencode"
+    (cfg / "plugin").mkdir(parents=True, exist_ok=True)
+
+    store_guard = store / STORE_GUARD
+    shutil.copy2(GUARD_JS, store_guard)
+    link = cfg / "plugin" / "guard.js"
+    link.symlink_to(store_guard)
+
+    if with_core:
+        store_core = store / STORE_CORE
+        shutil.copy2(GUARD_CORE, store_core)
+        (cfg / "guard_core.py").symlink_to(store_core)
+
+    return home, link
+
+
+def build_repo_layout(tmp_path: Path) -> tuple[Path, Path]:
+    """A plain (non-home-manager) checkout: the two files in their repo shape.
+
+        <tmp>/checkout/plugin/guard.js
+        <tmp>/checkout/guard_core.py
+
+    Returns (empty_home, plugin_path).
+    """
+    checkout = tmp_path / "checkout"
+    (checkout / "plugin").mkdir(parents=True, exist_ok=True)
+    plugin = checkout / "plugin" / "guard.js"
+    shutil.copy2(GUARD_JS, plugin)
+    shutil.copy2(GUARD_CORE, checkout / "guard_core.py")
+
+    home = tmp_path / "empty-home"
+    home.mkdir(exist_ok=True)
+    return home, plugin
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 harness self-validation (negative controls)
+#
+# A harness that reports green while testing nothing is worse than no test.
+# Before reading any verdict below, prove that this layout actually reproduces
+# the mechanism, and that the driver can actually report a failure.
+# --------------------------------------------------------------------------- #
+def test_the_layout_really_resolves_import_meta_url_into_the_flat_store(tmp_path):
+    """🔴 THE load-bearing harness control.
+
+    If node did NOT resolve the symlink — or if the store dir were not flat —
+    the "deployed layout" below would be a fiction and every test in this file
+    would be green for the wrong reason.
+
+    A standalone probe (NOT guard.js, so this control is independent of the code
+    under test) is placed in the store dir and imported via a symlink from the
+    plugin dir. It must report that `../guard_core.py` off its own module URL
+    lands at <tmp>/guard_core.py — i.e. one level ABOVE the store, missing the
+    real core entirely. That is the bug, reproduced.
+    """
+    store = tmp_path / "store"
+    store.mkdir()
+    probe = store / "deadbeef-hm_probe.mjs"
+    probe.write_text(
+        'import { fileURLToPath } from "node:url";\n'
+        'console.log(JSON.stringify({\n'
+        '  self: fileURLToPath(import.meta.url),\n'
+        '  parentRelative: fileURLToPath(new URL("../guard_core.py", import.meta.url)),\n'
+        "}));\n"
+    )
+    plugin_dir = tmp_path / "home" / ".config" / "opencode" / "plugin"
+    plugin_dir.mkdir(parents=True)
+    real_core = tmp_path / "home" / ".config" / "opencode" / "guard_core.py"
+    real_core.write_text("# the core lives here\n")
+    link = plugin_dir / "probe.mjs"
+    link.symlink_to(probe)
+
+    proc = subprocess.run(
+        ["node", str(link)], capture_output=True, text=True, timeout=60
+    )
+    assert proc.returncode == 0, proc.stderr
+    got = json.loads(proc.stdout.strip())
+
+    assert got["self"] == str(probe), (
+        f"node did NOT resolve the symlink — import.meta.url is {got['self']!r}, "
+        f"expected the store path {str(probe)!r}. Without that resolution this "
+        f"whole file tests a layout that does not occur in production."
+    )
+    assert got["parentRelative"] == str(tmp_path / "guard_core.py"), (
+        f"`../guard_core.py` resolved to {got['parentRelative']!r}; the layout is "
+        f"not reproducing the flat-store shape"
+    )
+    assert got["parentRelative"] != str(real_core), (
+        "the module-relative path found the real core — the bug is NOT reproduced"
+    )
+    assert not Path(got["parentRelative"]).exists()
+
+
+def test_the_driver_reports_a_throw_rather_than_swallowing_it(tmp_path):
+    """Negative control for the driver: a hook that throws must come back as
+    `outcome: throw` with the message, not as a silent allow and not as a
+    non-zero exit. Without this, a broken driver would report every command
+    allowed and the block assertions below would be untestable."""
+    fake = tmp_path / "throwing-plugin.js"
+    fake.write_text(
+        "export const GuardPlugin = async () => ({\n"
+        '  "tool.execute.before": async () => { throw new Error("SENTINEL-BOOM"); },\n'
+        "});\n"
+    )
+    got = run_plugin(fake, "anything", home=tmp_path)
+    assert got["outcome"] == "throw"
+    assert "SENTINEL-BOOM" in got["message"]
+
+
+def test_the_driver_reports_an_allow_when_the_hook_returns(tmp_path):
+    """The other half of the control: the driver must be able to say `allow`.
+    A driver that reported `throw` unconditionally would make every block
+    assertion below pass vacuously."""
+    fake = tmp_path / "permissive-plugin.js"
+    fake.write_text(
+        "export const GuardPlugin = async () => ({\n"
+        '  "tool.execute.before": async () => {},\n'
+        "});\n"
+    )
+    assert run_plugin(fake, "anything", home=tmp_path)["outcome"] == "allow"
+
+
+def test_the_real_core_is_the_file_home_nix_deploys():
+    """The copy this file makes must be the same source home.nix links to both
+    ~/.claude/hooks/ and ~/.config/opencode/. If it drifts, these tests exercise
+    a core nobody deploys."""
+    nix = (ROOT / "nix" / "home.nix").read_text()
+    assert nix.count("../scripts/claude-hooks/guard_core.py") == 2
+    assert GUARD_CORE.is_file()
+    assert DRIVER.is_file()
+
+
+# --------------------------------------------------------------------------- #
+# 1. 🔴 THE REGRESSION TEST — the deployed store-symlink layout
+#
+# RED on origin/main (88eb6d0): the plugin resolved /nix-style `../guard_core.py`
+# off the flat store dir, found nothing, and threw
+# "bash guard failed (status=2, stderr=python3: can't open file …)".
+# --------------------------------------------------------------------------- #
+def test_plugin_finds_its_core_in_the_deployed_store_symlink_layout(tmp_path):
+    """🔴 A benign command must RUN when the plugin is deployed as a store symlink.
+
+    This is the live breakage, verbatim: on origin/main every bash call in
+    opencode was refused because the core could not be found. The assertion is
+    on the OUTCOME (`allow`), so it cannot be satisfied by the plugin throwing
+    for a different reason.
+    """
+    home, plugin = build_deployed_layout(tmp_path)
+    got = run_plugin(plugin, BENIGN_COMMAND, home=home)
+    assert got["outcome"] == "allow", (
+        f"a benign command was refused in the DEPLOYED layout: {got}. The plugin "
+        f"cannot locate guard_core.py when it is a store symlink — every bash "
+        f"call in opencode is blocked."
+    )
+
+
+def test_plugin_still_blocks_an_irreversible_command_in_the_deployed_layout(tmp_path):
+    """The guard must still DENY, and deny for its OWN reason.
+
+    🔴 Asserting merely "it threw" would be green on origin/main too — the broken
+    build threw on every command, including this one. The discriminating claim is
+    WHICH error: "BLOCKED by the devrc bash guard" (a verdict) versus "bash guard
+    failed"/"cannot find guard_core.py" (an outage). So the message is pinned,
+    and the outage strings are asserted ABSENT.
+    """
+    home, plugin = build_deployed_layout(tmp_path)
+    got = run_plugin(plugin, BLOCKED_COMMAND, home=home)
+    assert got["outcome"] == "throw", f"{BLOCKED_COMMAND!r} was not blocked: {got}"
+    assert "BLOCKED by the devrc bash guard" in got["message"], (
+        f"blocked, but not by a guard VERDICT: {got['message']!r}"
+    )
+    for outage in ("cannot find guard_core.py", "bash guard failed", "could not run"):
+        assert outage not in got["message"], (
+            f"the throw is an OUTAGE, not a verdict: {got['message']!r}"
+        )
+
+
+def test_plugin_leaves_non_bash_tools_alone_in_the_deployed_layout(tmp_path):
+    """A deployed-layout pin that the hook does not throw for tools it does not
+    guard — a core-resolution error raised unconditionally would break `edit`,
+    `read` and `write` too."""
+    home, plugin = build_deployed_layout(tmp_path)
+    child = {k: v for k, v in os.environ.items() if not k.startswith("DEVRC_GUARD_")}
+    child["HOME"] = str(home)
+    probe = tmp_path / "non-bash-driver.mjs"
+    probe.write_text(
+        'const { pathToFileURL } = await import("node:url");\n'
+        "const mod = await import(pathToFileURL(process.argv[2]).href);\n"
+        "const hook = (await mod.GuardPlugin({}))['tool.execute.before'];\n"
+        "try { await hook({ tool: 'read' }, { args: { command: 'mkswap /dev/x' } });\n"
+        '  console.log("allow"); } catch (e) { console.log("throw:" + e.message); }\n'
+    )
+    proc = subprocess.run(
+        ["node", str(probe), str(plugin)],
+        capture_output=True, text=True, timeout=60, env=child,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "allow", proc.stdout
+
+
+# --------------------------------------------------------------------------- #
+# 2. fail-closed
+# --------------------------------------------------------------------------- #
+def test_plugin_refuses_when_the_core_cannot_be_found_anywhere(tmp_path):
+    """🔴 FAIL CLOSED, and say which paths were tried.
+
+    Deployed layout with the core NOT deployed. There is no candidate anywhere,
+    so the command must be REFUSED — never allowed through unchecked — and the
+    message must name the path it looked at, or the operator has an outage with
+    no lead.
+    """
+    home, plugin = build_deployed_layout(tmp_path, with_core=False)
+    got = run_plugin(plugin, BENIGN_COMMAND, home=home)
+    assert got["outcome"] == "throw", (
+        f"the core is ABSENT and the command was allowed through unchecked: {got}. "
+        f"A guard that degrades to allow reports safety it is not providing."
+    )
+    assert "cannot find guard_core.py" in got["message"]
+    expected = str(home / ".config" / "opencode" / "guard_core.py")
+    assert expected in got["message"], (
+        f"the refusal does not name the path it tried. Wanted {expected!r} in "
+        f"{got['message']!r}"
+    )
+
+
+def test_plugin_refuses_a_destructive_command_when_the_core_is_absent(tmp_path):
+    """The dangerous direction of the same case: no core must never mean the
+    irreversible command runs."""
+    home, plugin = build_deployed_layout(tmp_path, with_core=False)
+    got = run_plugin(plugin, BLOCKED_COMMAND, home=home)
+    assert got["outcome"] == "throw"
+
+
+def test_plugin_refuses_when_python_is_missing(tmp_path):
+    """The other fail-closed limb: the core is found but the interpreter is not.
+    Pinned because the resolution rewrite moved the throw sites around."""
+    home, plugin = build_deployed_layout(tmp_path)
+    got = run_plugin(
+        plugin, BENIGN_COMMAND, home=home,
+        env={"DEVRC_GUARD_PYTHON": str(tmp_path / "no-such-python")},
+    )
+    assert got["outcome"] == "throw", f"no interpreter, yet allowed: {got}"
+
+
+# --------------------------------------------------------------------------- #
+# 3. the DEVRC_GUARD_CORE override, and the last-resort repo layout
+# --------------------------------------------------------------------------- #
+def test_explicit_core_override_is_used_verbatim_with_no_silent_fallback(tmp_path):
+    """🔴 An override is an override.
+
+    A correctly-deployed core sits at $HOME/.config/opencode/guard_core.py, but
+    DEVRC_GUARD_CORE points somewhere that does not exist. Falling back to the
+    working core would be the WRONG kindness: the operator believes the guard is
+    checking the file they named. Refuse, and name what they named.
+    """
+    home, plugin = build_deployed_layout(tmp_path)
+    bogus = tmp_path / "not-a-real-core.py"
+    got = run_plugin(
+        plugin, BENIGN_COMMAND, home=home, env={"DEVRC_GUARD_CORE": str(bogus)}
+    )
+    assert got["outcome"] == "throw", (
+        f"an explicit DEVRC_GUARD_CORE override was silently ignored in favour "
+        f"of the deployed core: {got}"
+    )
+    assert str(bogus) in got["message"]
+    assert str(home / ".config") not in got["message"], (
+        "the override must be the ONLY candidate — the message shows the "
+        "resolver also considered $HOME"
+    )
+
+
+def test_explicit_core_override_is_honoured_when_it_does_exist(tmp_path):
+    """The positive half: a valid override must actually be used. Without this,
+    the test above would pass with the override handling deleted entirely (no
+    candidate would ever be found in a bare temp home)."""
+    home = tmp_path / "empty-home"
+    home.mkdir()
+    plugin = tmp_path / "flat-hm_guard.js"
+    shutil.copy2(GUARD_JS, plugin)
+    core = tmp_path / "elsewhere" / "guard_core.py"
+    core.parent.mkdir()
+    shutil.copy2(GUARD_CORE, core)
+
+    assert run_plugin(
+        plugin, BENIGN_COMMAND, home=home, env={"DEVRC_GUARD_CORE": str(core)}
+    )["outcome"] == "allow"
+    got = run_plugin(
+        plugin, BLOCKED_COMMAND, home=home, env={"DEVRC_GUARD_CORE": str(core)}
+    )
+    assert got["outcome"] == "throw"
+    assert "BLOCKED by the devrc bash guard" in got["message"]
+
+
+def test_plain_repo_checkout_layout_still_works(tmp_path):
+    """The LAST-RESORT candidate: a non-home-manager checkout with the two files
+    in their repo shape, and nothing at $HOME. This is the case the original
+    module-relative resolution served, and it must not regress.
+
+    It cannot weaken the fix: it is reached only when $HOME has no core, and a
+    candidate is used only if it EXISTS.
+    """
+    home, plugin = build_repo_layout(tmp_path)
+    assert run_plugin(plugin, BENIGN_COMMAND, home=home)["outcome"] == "allow"
+    got = run_plugin(plugin, BLOCKED_COMMAND, home=home)
+    assert got["outcome"] == "throw"
+    assert "BLOCKED by the devrc bash guard" in got["message"]
+
+
+def test_the_home_candidate_beats_the_module_relative_one(tmp_path):
+    """🔴 ORDER, pinned by behaviour rather than by reading the source.
+
+    Both candidates exist, and the module-relative one is a decoy that DENIES
+    everything. If the resolver consulted it first, the benign command would be
+    refused. This is what stops a later "simplification" from reinstating
+    module-relative-first, which is the exact shape of the shipped bug.
+    """
+    home, plugin = build_deployed_layout(tmp_path)
+    # <tmp>/guard_core.py — where `../guard_core.py` off the flat store dir lands.
+    decoy = tmp_path / "guard_core.py"
+    decoy.write_text(
+        "import json, sys\n"
+        "sys.stdin.read()\n"
+        'print(json.dumps({"decision": "deny", "reason": "DECOY-CORE"}))\n'
+    )
+    got = run_plugin(plugin, BENIGN_COMMAND, home=home)
+    assert got["outcome"] == "allow", (
+        f"the module-relative candidate won over $HOME: {got}. In the real "
+        f"deployment that path is /nix/<something>, which is how the outage "
+        f"happened."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 4. source-level pins
+#
+# These are INVARIANT GUARDS, not regression coverage — they are cheap and they
+# localise a failure, but the tests above are the protection. They replace
+# test_opencode_config.py::test_plugin_resolves_the_core_next_to_the_config_dir,
+# which asserted the BROKEN line was present.
+# --------------------------------------------------------------------------- #
+def test_guard_js_does_not_rely_solely_on_its_own_module_url():
+    src = GUARD_JS.read_text()
+    assert "homedir()" in src, (
+        "guard.js must resolve the core from $HOME, independently of where the "
+        "module itself sits — `import.meta.url` resolves into the flat nix store"
+    )
+    assert ".config" in src and "opencode" in src
+
+
+def test_home_nix_still_deploys_the_core_where_the_plugin_looks():
+    """The plugin now hard-codes `$HOME/.config/opencode/guard_core.py`, so that
+    attrpath in home.nix is load-bearing. Moving it breaks the guard."""
+    nix = (ROOT / "nix" / "home.nix").read_text()
+    assert 'home.file.".config/opencode/guard_core.py".source' in nix
+
+
+@pytest.mark.parametrize("seam", ["DEVRC_GUARD_CORE", "DEVRC_GUARD_PYTHON",
+                                  "DEVRC_GUARD_POLICY", "DEVRC_GUARD_DISABLE"])
+def test_documented_test_seams_survive(seam):
+    assert seam in GUARD_JS.read_text()


### PR DESCRIPTION
## 🔴 This is a live-breakage fix

**Every bash call in opencode is currently refused on the dev host.** Not a hypothetical — the guard is a hard gate on `tool.execute.before`, and it has been throwing on every command.

```
bash guard failed (status=2, stderr=python3: can't open file '/nix/guard_core.py':
[Errno 2] No such file or directory). Refusing the command rather than running it unchecked.
```

The guard **logic** is correct and the fail-closed behaviour worked exactly as designed — which is why this is a total outage rather than a silent hole. Only path resolution was broken.

## The broken path resolution

`scripts/opencode/plugin/guard.js` located its Python core with:

```js
fileURLToPath(new URL("../guard_core.py", import.meta.url));
```

The reasoning was: the plugin lives at `~/.config/opencode/plugin/guard.js`, so `..` is `~/.config/opencode/` — exactly where `nix/home.nix` links the core.

That reasoning is about the **deploy path**, and the deploy path is a **symlink**. `home.file` links the plugin into the nix store; Node resolves `import.meta.url` **through** the symlink to the real store path; and the store is **flat** — the file lands as one `/nix/store/<hash>-hm_guard.js`, with no `plugin/` directory above it. Measured on the host:

```
readlink -f ~/.config/opencode/plugin/guard.js
  -> /nix/store/5m6y63cj512ksn783j5nddlrchkca92p-hm_guard.js
import.meta.url dir : /nix/store
../guard_core.py    -> /nix/guard_core.py        ← does not exist
```

This is the hazard RULES.md already names for home-manager-managed dotfiles (*"`readlink -f` is the arbiter — never infer it from a `diff`"*), applied to a program reasoning about **its own** location. A store-resolved `import.meta.url` invalidates every relative-path assumption, and nothing in the source file reveals it.

## The fix

Resolve the core **independently of where the module sits**:

1. `DEVRC_GUARD_CORE`, if set — an **explicit override**, used verbatim with **no fallback**. Silently ignoring a wrong override and quietly checking some other file would be the wrong kindness: the operator would believe the guard was checking the file they named.
2. `$HOME/.config/opencode/guard_core.py` — the home-manager deploy target. (Itself a store symlink, which is fine: we *open* it, we don't `..` off it.)
3. `../guard_core.py` off the module URL — **last resort**, so a plain non-home-manager checkout still works. It cannot weaken anything: it is reached only when (2) does not exist, and a candidate is used only if it **exists**.

A candidate is used only if `existsSync`. If none exists the hook **throws, naming every path tried** — still fail-closed, now with a lead.

🔴 The throw stays **inside** `tool.execute.before`. Throwing at import time would make the plugin fail to **load**, and opencode would carry on without the hook — which is **fail-OPEN**. Resolution happens per call (two `stat()`s against a ~26 ms Python subprocess), so a `home-manager switch` mid-session is picked up.

No `/home/zach/...` literal is baked into the JS; `os.homedir()` needs no nix templating.

## 🔴 Why the existing tests missed it — the real finding

`test_opencode_config.py` asserted, verbatim:

```python
assert 'new URL("../guard_core.py", import.meta.url)' in GUARD_PLUGIN.read_text()
```

**It pinned the broken line as the contract**, with a docstring restating the wrong deploy-path reasoning as its justification. The surrounding coverage had the same shape:

- substring checks over `guard.js`'s **text**,
- existence checks on `home.nix` `source =` paths,
- Python tests importing `guard_core` **directly**.

Every one of them passes with the plugin **100% inert**. Nothing anywhere ever *loaded* `guard.js` and called its hook. A test that does not execute the deployed artifact cannot see a deployment bug.

`scripts/tests/test_opencode_guard_plugin.py` now does: it builds the store-symlink layout on disk (flat store file + a symlink from the plugin dir, so Node performs the same resolution it performs live) and drives the plugin through its **real entry point** via `scripts/tests/fixtures/guard_plugin_driver.mjs`.

## Red/green matrix

**`origin/main` (88eb6d0): 5 failed, 15 passed. HEAD: 20 passed.**

Regression tests (RED at base, green at HEAD):

| test | what it pins |
|---|---|
| `test_plugin_finds_its_core_in_the_deployed_store_symlink_layout` | benign command **runs** in the deployed layout — the outage itself |
| `test_plugin_still_blocks_an_irreversible_command_in_the_deployed_layout` | `mkswap` blocked **by a verdict**, asserting the message is `BLOCKED by the devrc bash guard` and *not* an outage string — "it threw" alone would be green at base too |
| `test_plugin_refuses_when_the_core_cannot_be_found_anywhere` | fail-closed, message names the tried path |
| `test_the_home_candidate_beats_the_module_relative_one` | ordering, via a decoy core that denies everything |
| `test_guard_js_does_not_rely_solely_on_its_own_module_url` | source-level pin |

The other **15 passed at base** and are labelled **INVARIANT GUARDS** in the module docstring, not counted as regression coverage.

**Mutation sweep — 5/5 killed, each by its NAMED test**, control green before *and* after the sweep (with the restore re-verified, so a crashed sweep can't poison the baseline):

| mutation | killed by |
|---|---|
| drop the `$HOME` candidate | `..._deployed_store_symlink_layout` |
| skip the `existsSync` check | `..._plain_repo_checkout_layout_still_works` |
| module-relative first (the shipped bug) | `..._home_candidate_beats_the_module_relative_one` |
| `DEVRC_GUARD_CORE` as a hint, not an override | `..._override_is_used_verbatim...` |
| **fail OPEN** when no core is found | `..._refuses_when_the_core_cannot_be_found_anywhere` |

**Harness validated against a known-bad state first** — an independent probe module (not `guard.js`) proves Node resolves the symlink into the flat store dir, so the layout genuinely reproduces the mechanism; and two driver controls prove the driver can report both a `throw` and an `allow`. Without those, every verdict below them would be unreadable.

## Verified end-to-end against the LIVE deployed core

Fixed plugin placed at a flat store-like path, real `$HOME`, resolving `/home/zach/.config/opencode/guard_core.py`:

```
echo GUARD_OK                        -> {"outcome":"allow"}
mkswap /dev/zzz-nonexistent-device   -> {"outcome":"throw","message":"BLOCKED by the devrc bash guard: `mkswap` is blocked — it FORMATS a filesystem …"}
```

Control — the `origin/main` plugin at the same path reproduces the outage verbatim.

## Full suite

`4373 collected, 4371 passed, 1 skipped (pinned), 1 failed`.

The one failure is `session_insight/tests/test_scrub.py::test_patterns_cover_bash_guard` — **confirmed RED on an unmodified `origin/main` worktree**, so pre-existing and not this change. It parses `SECRET_PATTERNS` out of the **deployed** `~/.claude/hooks/bash-guard.py`, which no longer defines them (they moved into `guard_core.py`). Worth a separate fix: it is an environment-coupled test that now asserts against a refactor.

## 🔴 Same-class audit — one NEW breakage found (not fixed here)

Audited every `home.file`-deployed artifact for code computing a path from its own location (`import.meta.url`, `__dirname`, `__file__`, `$0`, `readlink -f "$0"`).

The languages differ, and that difference decides each case:
- **Node** resolves `import.meta.url` through the symlink to the real store path → relative sibling/parent lookups **break**.
- **Python** sets `__file__` to the path **as invoked** → `dirname(abspath(__file__))` lands correctly. Breaks only if `.resolve()` / `realpath()` is used.
- **Bash** `$0` is the invoked path (safe); `readlink -f "$0"` resolves into the store (breaks).

**`~/.claude/hooks/bash-guard.py` — VERIFIED HEALTHY, not assumed.** It uses `sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))`; `abspath` normalises but does **not** resolve symlinks, so it lands in `~/.claude/hooks/` where `guard_core.py` is a sibling. Exercised live: `git add -A` → correct `permissionDecision: "deny"` with the RULES reason; `ls -la` → pass-through. The two guards differ *only* in `abspath` (Python, safe) vs `new URL(…, import.meta.url)` (Node, resolves).

**🔴 NEW — `browser agent` is broken in the deployed skill (separate issue, not in scope here):**

```
$ ~/.claude/skills/browser/browser agent --dry-run "test"
browser: browser-agent wrapper not found/executable: /home/zach/.claude/skills/browser/browser-agent
```

`nix/home.nix` deploys only `SKILL.md` and `browser` into that directory. `browser` computes `HERE="$(cd "$(dirname "$0")" && pwd)"` and looks for a sibling `browser-agent` that was never deployed. The `mkOutOfStoreSymlink` does **not** save it: bash `$0` is the *invoked* path and `dirname` is textual, so `HERE` is the skill dir, not the repo dir the symlink points at. The `agent` subcommand is unreachable via the skill (it works when run from the repo checkout). Fix shape: deploy the siblings (`browser-agent`, `browser-agent-parse.py`, `opencode/{browser-agent.md,tools/}`), **or** resolve `HERE` via `readlink -f "$0"` — which for an *out-of-store* symlink correctly lands in the repo, the inverse of the store case.

Everything else audited clean, with the mechanical reason: `home.file` with `recursive = true` on a **directory** produces a real store **directory**, so intra-directory sibling lookups survive `.resolve()`. Only single-file entries flatten, and only cross-directory traversal breaks — which is why the collector modules already carry explicit "do NOT `.resolve()`" comments. `plugin/env.js` is generated with absolute paths from `config.home.homeDirectory` and does no self-location. All systemd user units invoke `%h/...` deploy paths, so Python `__file__` is the `~` path.

Not deployed via `home.file`, but **same bug class if ever moved there**: `scripts/collector/opencode/activity-plugin.js` (`dirname(new URL(import.meta.url).pathname)`) and its `deploy-plugin.sh` (`readlink -f "$(dirname "$0")/…")`.

## Not verified

- Not run through a real `opencode` session — the fix is not deployed. **`home-manager switch` is yours to run**; I did not run it and did not touch `~/.config/opencode/` or `~/.claude/`. Post-switch check: `readlink -f ~/.config/opencode/plugin/guard.js` should be a flat store path, and a bash call in opencode should now work.
- The live end-to-end probe ran the **fixed source from the worktree** placed at a store-like path against the **live deployed core**. That is evidence about this branch's `guard.js` + the deployed core — not about the store object a switch will produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
