### PR TITLE
guard: enforce `git stash` + `git clean -f` for Claude Code, not just opencode

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -663,8 +663,13 @@ in
   # with an actionable message rather than passing commands through unchecked).
   # The SAME source file is also deployed to ~/.config/opencode/guard_core.py
   # below and driven by the opencode plugin — one implementation, two harnesses,
-  # two named policies ("claude-code" = the frozen original six; "opencode" =
-  # those plus the irreversible-action checks).
+  # two named policies. "claude-code" was the frozen original six until
+  # 2026-08-02, when three argv checks were added to it by explicit operator
+  # decision — `git -C <p> reset --hard`, `git stash` and `git clean -f`, all
+  # 🔴 in RULES.md and all measured ALLOW against the live hook beforehand.
+  # "opencode" = those plus the still-opencode-only irreversible families
+  # (talosctl reset / mkfs / dd to a block device / rm -rf of a critical path).
+  # POLICIES in guard_core.py is the authority; test_guard_core.py pins it.
   home.file.".claude/hooks/guard_core.py" = {
     source = ../scripts/claude-hooks/guard_core.py;
     force = true;

--- a/scripts/claude-hooks/bash-guard.py
+++ b/scripts/claude-hooks/bash-guard.py
@@ -7,10 +7,16 @@ by nix/home.nix). Read guard_core.py's docstring first: it carries the DESIGN
 NOTE about why message-text stripping is forbidden, and the reasoning behind the
 argv parser.
 
-🔴 THIS ADAPTER RUNS THE "claude-code" POLICY, WHICH IS FROZEN AT THE ORIGINAL
-SIX CHECKS:
+🔴 THIS ADAPTER RUNS THE "claude-code" POLICY. It was FROZEN at the original six
+raw-text checks until 2026-08-02, when three argv checks were added by explicit
+operator decision. The list today:
   - git add -A / --all / .   -> stage specific paths instead (RULES: never blind-stage)
   - git reset --hard         -> use git restore/checkout, NOT stash (RULES: never reset --hard)
+  - git -C <p> reset --hard  -> the same, through git's global-option hop (2026-08-02)
+  - git stash                -> the stash stack is repo-GLOBAL (2026-08-02; RULES 🔴,
+    incident 2026-07-25). `git stash list`/`show` are reads and stay allowed.
+  - git clean -f             -> deletes untracked files, which here are routinely
+    real work (2026-08-02; RULES 🔴). `git clean -nd` stays allowed.
   - large heredoc -> file    -> use the Write tool (token waste; audit-driven)
   - cd <path> && git ...     -> use git -C <path> (audit: #1 command shape, 1482x)
   - private key in a command -> reference the key file instead (never inline)
@@ -18,12 +24,13 @@ SIX CHECKS:
     committing/posting (insights: leaked ingress IP into a public repo once)
 
 This hook fires on EVERY Bash call in EVERY Claude Code session on both hosts,
-so adding a check here changes the operator's primary tool. The extra
-irreversible-action checks added for opencode (talosctl reset, mkfs, dd to a
-block device, rm -r of /|$HOME|cwd, git stash, git clean -f) live in the
-"opencode" policy and are deliberately NOT enabled here. Switching this adapter
-to the "opencode" policy is a one-word change — and a decision for the operator
-to make explicitly, not a side effect of hardening a different tool.
+so adding a check here changes the operator's primary tool. FOUR
+irreversible-action families remain opencode-ONLY and are deliberately NOT
+enabled here: talosctl reset, mkfs, dd to a block device, and rm -r of
+/|$HOME|cwd|a top-level system dir. `rm -rf` in particular risks false positives
+on legitimate build-directory cleanup. Switching this adapter to the "opencode"
+policy is a one-word change — and a decision for the operator to make
+explicitly, not a side effect of hardening a different tool.
 
 I/O contract (unchanged): reads PreToolUse JSON on stdin (`tool_name`,
 `tool_input.command`), prints `hookSpecificOutput.permissionDecision = "deny"`

--- a/scripts/claude-hooks/guard_core.py
+++ b/scripts/claude-hooks/guard_core.py
@@ -34,7 +34,11 @@ TWO CALLERS, TWO POLICIES
                   2026-08-02, when `check_git_reset_hard_argv` was added as
                   exactly such an approved decision (the raw-text reset check
                   was blind to `git -C <path> reset --hard`, the spelling
-                  RULES.md mandates). Pinned by name in test_guard_core.py.
+                  RULES.md mandates), followed the same day by
+                  `check_git_stash` + `check_git_clean_force` — both 🔴 in
+                  RULES.md, both measured ALLOW against the live hook, and
+                  neither with a benign in-repo use. Pinned by name in
+                  test_guard_core.py.
   "opencode"    — all of the above, plus the irreversible-action checks below. opencode
                   agents run unattended (`opencode run` AUTO-REJECTS an `ask`
                   rather than prompting — measured on 1.18.4), so a hard deny is
@@ -566,7 +570,11 @@ def _flags_and_operands(argv):
 
 # =========================================================================== #
 # ARGV-BASED CHECKS — the irreversible families globs handle badly.
-# opencode policy only (see POLICIES).
+#
+# NOT all opencode-only any more. `check_git_reset_hard_argv` (2026-08-02),
+# `check_git_stash` and `check_git_clean_force` (2026-08-02) run under BOTH
+# policies; talosctl/mkfs/dd/rm stay opencode-only. POLICIES at the bottom is
+# the authority — read it rather than assuming from this section heading.
 # =========================================================================== #
 
 def check_talosctl_reset(cmd):
@@ -698,6 +706,10 @@ def check_git_stash(cmd):
     agent's `git -C * diff*` allow-list let `git -C <path> stash push -m 'wip on
     the diff'` EXECUTE, because the glob's middle `*` is greedy across spaces.
     argv[1] is `stash` regardless of how many global options precede it.
+
+    Enabled for BOTH policies since 2026-08-02 (it shipped opencode-only). It
+    lives in `_CLAUDE_CODE_CHECKS`, which `POLICIES["opencode"]` includes, so
+    opencode keeps coverage by inheritance rather than a duplicate entry.
     """
     for argv in commands(cmd):
         if os.path.basename(argv[0]) != "git":
@@ -713,7 +725,11 @@ def check_git_stash(cmd):
                 "ZERO isolation and a concurrent agent or session can pop your entry (observed "
                 "twice — two parallel subagents stole each other's work). To set work aside, COPY "
                 "it aside (`cp <file> /tmp/…`) or commit it to a throwaway branch. "
-                "`git stash list` and `git stash show` are reads and remain allowed.")
+                "`git stash list` and `git stash show` are reads and remain allowed. "
+                "(Only QUOTING this command — e.g. a heredoc body documenting the ban, whose "
+                "lines this guard parses as real commands? Write the text to a file with the "
+                "Write tool and use `git commit -F <file>` / `gh pr create --body-file <file>` — "
+                "which your RULES prefer over heredocs anyway.)")
     return None
 
 
@@ -749,7 +765,13 @@ def check_git_reset_hard_argv(cmd):
 
 def check_git_clean_force(cmd):
     """`git clean -f` deletes untracked files — including the un-committed docs
-    RULES warns are one routine command away from silent loss."""
+    RULES warns are one routine command away from silent loss.
+
+    Enabled for BOTH policies since 2026-08-02 (it shipped opencode-only), by
+    inheritance from `_CLAUDE_CODE_CHECKS`. The dry-run spellings (`-n`,
+    `--dry-run`) are untouched: `git clean -nd` is the diagnostic the deny
+    message points at, so denying it would push the operator toward guessing.
+    """
     for argv in commands(cmd):
         if os.path.basename(argv[0]) != "git":
             continue
@@ -761,7 +783,11 @@ def check_git_clean_force(cmd):
             return ("`git clean -f` is blocked — it permanently deletes untracked files, and in "
                     "this repo untracked files are routinely real work (handoff docs, scratch "
                     "analyses) rather than junk. Run `git clean -nd` to see what it would remove, "
-                    "then delete the specific paths you mean.")
+                    "then delete the specific paths you mean. "
+                    "(Only QUOTING this command — e.g. a heredoc body documenting the ban, whose "
+                    "lines this guard parses as real commands? Write the text to a file with the "
+                    "Write tool and use `git commit -F <file>` / `gh pr create --body-file "
+                    "<file>` — which your RULES prefer over heredocs anyway.)")
     return None
 
 
@@ -819,27 +845,57 @@ def _git_strip_global_opts(argv):
 # unchanged (it denied before and denies now, under both policies) — only the
 # text differs, and it now names the more serious of the two problems. That is
 # the sole message change; it is asserted in test_guard_core.py.
+#
+# 🔴 `check_git_stash` and `check_git_clean_force` were added 2026-08-02 as the
+# EIGHTH and NINTH checks, by the same kind of explicit operator decision.
+# Measured against the live hook before the move (PreToolUse JSON piped into
+# ~/.claude/hooks/bash-guard.py, with `git add -A` and `git reset --hard HEAD`
+# as positive controls that came back DENY):
+#     ALLOW  git stash
+#     ALLOW  git stash push -m wip
+#     ALLOW  git stash pop
+#     ALLOW  git -C <repo> stash
+#     ALLOW  git clean -fd
+# i.e. the two operations RULES.md treats as 🔴 CRITICAL data-loss — `git stash`
+# with a documented incident (two parallel subagents stole each other's work,
+# 2026-07-25; the ban was re-BROADENED 2026-08-01 after a subagent read the
+# narrow wording and stashed anyway) and `git clean -f`, which deletes exactly
+# the untracked handoff docs RULES calls unsaved work — were enforced for
+# opencode and silently allowed for the operator's primary tool.
+#
+# They sit BEFORE check_cd_then_git for the same reason the reset argv check
+# does: `cd /x && git stash` now reports the stash reason, which names the more
+# serious of the two problems.
+#
+# The four remaining families (talosctl reset / mkfs / dd / rm -rf) stay
+# opencode-ONLY and were deliberately NOT moved here — see _IRREVERSIBLE_CHECKS.
 _CLAUDE_CODE_CHECKS = [
     check_git_add_all,
     check_git_reset_hard,
     check_git_reset_hard_argv,
+    check_git_stash,
+    check_git_clean_force,
     check_heredoc_to_file,
     check_cd_then_git,
     check_private_key,
     check_secret_or_ip_publish,
 ]
 
-# The irreversible families. opencode only: `opencode run` AUTO-REJECTS an
-# `ask` rather than prompting (measured on 1.18.4), and the interactive TUI is
-# the only place a human sees one — so for an unattended agent a hard deny is
-# the only real control.
+# The irreversible families that remain opencode-ONLY: `opencode run`
+# AUTO-REJECTS an `ask` rather than prompting (measured on 1.18.4), and the
+# interactive TUI is the only place a human sees one — so for an unattended
+# agent a hard deny is the only real control.
+#
+# 🔴 These four are NOT in the claude-code policy, and that narrowness is a
+# DECISION, not an oversight. `rm -rf` in particular risks false positives on
+# legitimate build-directory cleanup, and the other three are hardware/cluster
+# operations an interactive Claude Code session can be prompted about. Widening
+# any of them to claude-code is a separate operator decision.
 _IRREVERSIBLE_CHECKS = [
     check_talosctl_reset,
     check_mkfs,
     check_dd_to_block_device,
     check_rm_rf_critical,
-    check_git_stash,
-    check_git_clean_force,
 ]
 
 POLICIES = {

--- a/scripts/claude-hooks/tests/test_guard_core.py
+++ b/scripts/claude-hooks/tests/test_guard_core.py
@@ -77,6 +77,23 @@ CLAUDE_CODE_EXPECTED = [
     # `cd /x && git -C <p> reset --hard` report the reset reason rather than the
     # cd reason. See test_reset_hard_deny_is_attributed_to_the_reset_check.
     "check_git_reset_hard_argv",
+    # 🔴 Added 2026-08-02 by explicit operator decision — the EIGHTH and NINTH.
+    # Both are 🔴 CRITICAL in RULES.md and both were measured ALLOW against the
+    # live ~/.claude/hooks/bash-guard.py before the move, with `git add -A` and
+    # `git reset --hard HEAD` as DENY positive controls in the same sweep:
+    #   ALLOW  git stash / git stash push -m wip / git stash pop
+    #   ALLOW  git -C <repo> stash
+    #   ALLOW  git clean -fd
+    # `git stash` carries a documented incident (two parallel subagents stole
+    # each other's work, 2026-07-25) and the ban was re-BROADENED 2026-08-01
+    # after a subagent read the narrow wording and stashed anyway. `git clean
+    # -f` deletes exactly the untracked handoff docs RULES calls unsaved work.
+    # Neither has a benign in-repo use; the READ spellings (`stash list`,
+    # `stash show`, `clean -n`) are untouched.
+    # They sit BEFORE check_cd_then_git for the same reason the reset argv check
+    # does — `cd /x && git stash` reports the stash reason, not the cd reason.
+    "check_git_stash",
+    "check_git_clean_force",
     "check_heredoc_to_file",
     "check_cd_then_git",
     "check_private_key",
@@ -113,13 +130,18 @@ def test_opencode_policy_is_a_strict_superset():
     assert set(CLAUDE_CODE_EXPECTED) < set(oc)
 
 
+# 🔴 The families that remain opencode-ONLY. `check_git_stash` and
+# `check_git_clean_force` USED to be listed here; they moved into the
+# claude-code policy on 2026-08-02. These four did NOT move, deliberately:
+# `rm -rf` risks false positives on legitimate build-directory cleanup, and
+# talosctl/mkfs/dd are hardware/cluster operations an interactive Claude Code
+# session can be prompted about rather than hard-denied. Widening any of them
+# is a separate operator decision.
 IRREVERSIBLE_EXPECTED = [
     "check_talosctl_reset",
     "check_mkfs",
     "check_dd_to_block_device",
     "check_rm_rf_critical",
-    "check_git_stash",
-    "check_git_clean_force",
 ]
 
 
@@ -133,18 +155,18 @@ def test_opencode_policy_carries_the_irreversible_checks():
     "mkfs.ext4 /dev/sda",
     "dd if=x of=/dev/sda",
     "rm -rf /",
-    "git stash push -m wip",
-    "git clean -fd",
     # NOTE: `git -C <path> reset --hard` USED to be listed here, asserting that
     # Claude Code allowed it. That was the gap, not a feature — it is now denied
     # under both policies and is asserted positively in section 1b below.
+    # NOTE: `git stash push -m wip` and `git clean -fd` were listed here for the
+    # same reason and moved for the same reason — see section 1c.
 ])
 def test_the_new_checks_do_not_leak_into_claude_code(command):
     """🔴 The blast-radius assertion, by OUTCOME rather than by list membership.
 
     Each of these is denied under "opencode" and must resolve to no-deny under
-    "claude-code" — that is what "Claude Code's behaviour is unchanged" means
-    operationally.
+    "claude-code" — the four families that stayed opencode-only. This is the
+    fence that keeps a later "while I'm here" widening honest.
     """
     assert gc.evaluate(command, "opencode") is not None
     assert gc.evaluate(command, "claude-code") is None
@@ -601,6 +623,178 @@ def test_git_clean_force_is_denied(hop, spelling):
                                      "git clean -n", "git status"])
 def test_git_clean_dry_run_stays_allowed(command):
     assert gc.check_git_clean_force(command) is None
+
+
+# --------------------------------------------------------------------------- #
+# 3b. 🔴 `git stash` and `git clean -f` under the CLAUDE-CODE policy
+#
+# Closes a gap that was live on both hosts until 2026-08-02. The two checks
+# existed and were correct — they were simply not in the policy bash-guard.py
+# runs. Probed against the live ~/.claude/hooks/bash-guard.py before the change,
+# by piping PreToolUse JSON into it, WITH positive controls in the same sweep so
+# a wired-to-nothing harness could not produce the reassuring answer:
+#
+#     DENY   git add -A                      <- positive control (guard is live)
+#     DENY   git reset --hard HEAD           <- positive control
+#     ALLOW  git stash
+#     ALLOW  git stash push -m wip
+#     ALLOW  git stash pop
+#     ALLOW  git -C <repo> stash
+#     ALLOW  git clean -fd
+#     ALLOW  ls -la /tmp                     <- benign control
+#
+# Every deny below is asserted BY REASON. `cd /x && git stash` is denied by
+# check_cd_then_git with this change fully reverted, so a bare `is not None`
+# would be green for the wrong reason — the exact trap section 1b records.
+# --------------------------------------------------------------------------- #
+STASH_REASON_MARK = "`git stash` is blocked"
+CLEAN_REASON_MARK = "`git clean -f` is blocked"
+
+
+def _assert_denied_as(command, mark, policy="claude-code"):
+    reason = _deny_reason(command, policy)
+    assert mark in reason, (
+        f"{command!r} denied under {policy}, but for the WRONG reason — got "
+        f"{reason[:120]!r}. Some other check fired first; this asserts nothing "
+        f"about {mark} coverage."
+    )
+    return reason
+
+
+# The wrapped/prefixed spellings RULES requires the guard to survive. Paths are
+# pairwise distinct and none of them contains the substring `stash`/`clean`,
+# so a fixture cannot pass by accident of its own text.
+STASH_DENY = [
+    "git stash",
+    "git stash push -m wip",
+    "git stash pop",
+    "git stash apply",
+    "git stash drop",
+    "VAR=1 git stash",
+    "sudo git stash",
+    "sudo -n git -C /srv/repos/alpha stash push -m wip",
+    "git -C /srv/repos/beta stash",
+    "git --git-dir=/var/lib/gamma stash pop",
+    "bash -c 'git stash'",
+    "echo ok && git stash",
+    "cd /srv/delta && git stash",
+    "git -C /tmp/epsilon stash; echo done",
+    "/usr/bin/git -C /tmp/zeta stash push -m wip",
+]
+
+CLEAN_DENY = [
+    "git clean -f",
+    "git clean -fd",
+    "git clean -fdx",
+    "git clean --force -d",
+    "VAR=1 git clean -fd",
+    "sudo git clean -fd",
+    "git -C /srv/repos/eta clean -fd",
+    "bash -c 'git clean -fd'",
+    "echo ok && git clean -fd",
+    "cd /srv/theta && git clean -fd",
+    "/usr/bin/git -C /tmp/iota clean -xf",
+]
+
+
+@pytest.mark.parametrize("command", STASH_DENY)
+def test_git_stash_is_denied_under_claude_code(command):
+    """🔴 RED at origin/main for every row: the check was opencode-only, so
+    `claude-code` returned None (the `cd &&` row denied with the WRONG reason,
+    which the attribution assertion catches)."""
+    _assert_denied_as(command, STASH_REASON_MARK, "claude-code")
+
+
+@pytest.mark.parametrize("command", CLEAN_DENY)
+def test_git_clean_force_is_denied_under_claude_code(command):
+    """🔴 RED at origin/main for every row — same mechanism as stash above."""
+    _assert_denied_as(command, CLEAN_REASON_MARK, "claude-code")
+
+
+@pytest.mark.parametrize("command", STASH_DENY)
+def test_git_stash_still_denied_under_opencode(command):
+    """The move must not COST opencode anything: `POLICIES["opencode"]` is
+    `_CLAUDE_CODE_CHECKS + _IRREVERSIBLE_CHECKS`, so the check is inherited
+    rather than duplicated. This asserts the inheritance actually holds."""
+    _assert_denied_as(command, STASH_REASON_MARK, "opencode")
+
+
+@pytest.mark.parametrize("command", CLEAN_DENY)
+def test_git_clean_force_still_denied_under_opencode(command):
+    _assert_denied_as(command, CLEAN_REASON_MARK, "opencode")
+
+
+def test_cd_then_git_stash_reports_the_stash_reason_not_the_cd_reason():
+    """🔴 The ORDERING pin. check_git_stash sits before check_cd_then_git, so
+    the more serious of the two problems is the one named. At origin/main this
+    command denies with the `cd` message — i.e. this is regression coverage for
+    the ordering, not just for the policy membership."""
+    reason = _deny_reason("cd /srv/kappa && git stash", "claude-code")
+    assert STASH_REASON_MARK in reason
+    assert "use `git -C <path>" not in reason
+
+
+# --- the ALLOW half -------------------------------------------------------- #
+# 🔴 Built independently of the deny list — different paths, different
+# subcommands — so a copy-paste symmetry cannot make both halves agree with the
+# same bug. INVARIANT GUARDS (green before and after): they are the
+# false-positive fence, not regression coverage for any shipped bug.
+STASH_CLEAN_ALLOW = [
+    "git stash list",
+    "git stash show -p",
+    "git -C /opt/service-lambda stash list",
+    "git clean -nd",
+    "git clean --dry-run",
+    "git clean -n -d",
+    "git -C /opt/service-lambda clean -nd",
+    "git status",
+    "git -C /opt/service-lambda diff --stat",
+    "git checkout -- src/app.ts",
+    "git worktree list",
+    "rm -rf /tmp/scratch-mu",
+    # merely NAMING the commands, as an argument rather than as a command
+    "echo 'git stash is banned'",
+    "grep -rn 'git clean -fd' RULES.md",
+    "rg 'git stash' claude/RULES.md",
+    "git commit -m 'document why git stash is banned'",
+]
+
+
+@pytest.mark.parametrize("command", STASH_CLEAN_ALLOW)
+def test_stash_and_clean_neighbours_stay_allowed_under_claude_code(command):
+    """INVARIANT GUARD. `git stash list` is the diagnostic RULES tells you to
+    run, `git clean -nd` is the one the deny message points at, and the argv
+    parser means quoting the command as an ARGUMENT is not a command."""
+    assert gc.evaluate(command, "claude-code") is None
+    assert gc.evaluate(command, "opencode") is None
+
+
+# --- the escape hatch ------------------------------------------------------ #
+def test_new_deny_messages_carry_the_quoting_escape_hatch():
+    """🔴 The convention `check_git_add_all` set, and the reason it exists: the
+    operator's own test harness was blocked because an ARGUMENT contained the
+    literal string `git add -A`. Both new messages must hand the caller the same
+    documented way out."""
+    for reason in (gc.check_git_stash("git stash"),
+                   gc.check_git_clean_force("git clean -fd")):
+        assert reason is not None
+        assert "commit -F" in reason, reason
+        assert "--body-file" in reason, reason
+        assert "Write tool" in reason, reason
+
+
+def test_the_one_real_quoting_false_positive_is_a_heredoc_body():
+    """The accepted false positive, MEASURED rather than assumed.
+
+    The argv parser splits on newlines, so a heredoc body LINE that begins with
+    the command is parsed as a command. That is the case the escape hatch is
+    for. The same text passed as a single quoted ARGUMENT is one token and is
+    correctly allowed — asserted here so the docstring above cannot drift.
+    """
+    heredoc = "cat > /tmp/doc.md <<'EOF'\ngit stash push -m wip\nEOF"
+    reason = _assert_denied_as(heredoc, STASH_REASON_MARK, "claude-code")
+    assert "commit -F" in reason
+    assert gc.evaluate("git commit -m 'git stash push -m wip'", "claude-code") is None
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What changed

`guard_core.py` had 13 checks across two policies; `"claude-code"` (the policy
`bash-guard.py` runs on every Bash call, both hosts) carried 7 of them. This PR
moves **two** into it — `check_git_stash` and `check_git_clean_force`.

It is a **list change, not a second implementation** (RULES: one rule, one
place). Both checks already existed, were already argv-aware, and were already
covered by the multi-spelling matrix. They move from `_IRREVERSIBLE_CHECKS` into
`_CLAUDE_CODE_CHECKS`; `POLICIES["opencode"]` is `_CLAUDE_CODE_CHECKS +
_IRREVERSIBLE_CHECKS`, so **opencode keeps coverage by inheritance, not by a
duplicate entry** (asserted, see `test_git_stash_still_denied_under_opencode`).

Files: `scripts/claude-hooks/guard_core.py` (policy lists + the two deny
messages), `scripts/claude-hooks/bash-guard.py` (the adapter docstring listed
the policy as "the frozen original six"), `nix/home.nix` (same stale claim at
the `guard_core.py` `home.file`), `scripts/claude-hooks/tests/test_guard_core.py`.

**Behaviour change to your primary tool, on both hosts** — that is the point of
the PR, and it is the thing to veto if you disagree.

### Reads stay allowed
`git stash list`, `git stash show -p`, `git clean -n`, `git clean -nd`,
`git clean --dry-run` — including through `git -C <path>`. `git stash list` is
the diagnostic RULES tells you to run and `git clean -nd` is the one the deny
message points you at; denying either would push toward guessing.

### Error-message convention
Both new messages now carry the same escape hatch `check_git_add_all` has —
"write the text to a file with the Write tool and use `git commit -F <file>` /
`gh pr create --body-file <file>`".

I **measured** which quoting shapes actually false-positive rather than assuming,
because these are argv checks, not raw-text ones:

| shape | verdict |
|---|---|
| `git commit -m "never git stash"` | ALLOW (one token, not argv[0]) |
| `echo 'git stash is banned'` | ALLOW |
| `grep -rn 'git clean -fd' RULES.md` | ALLOW |
| `gh pr create --body "$(cat <<'EOF' … git stash … EOF)"` | ALLOW |
| ``cat > /tmp/doc.md <<'EOF'\ngit stash push -m wip\nEOF`` | **DENY** |

The one real false positive is a **heredoc body line that begins with the
command** — the parser splits on newlines, so that line is parsed as a command.
That is exactly the case the escape hatch is for, and it is pinned in
`test_the_one_real_quoting_false_positive_is_a_heredoc_body` so the docstring
cannot drift from the behaviour.

## Left opencode-ONLY (your call, separately)

Not touched here, per your instruction and because `nix/home.nix`'s narrowness
looked deliberate:

| check | shape | why it stayed |
|---|---|---|
| `check_rm_rf_critical` | `rm -rf $HOME` etc. | false-positive risk on legitimate build-dir cleanup |
| `check_talosctl_reset` | `talosctl -n <ip> reset` | cluster op; an interactive session can be prompted |
| `check_mkfs` | `mkfs.ext4 /dev/sdc` | hardware op; same |
| `check_dd_to_block_device` | `dd of=/dev/sdc` | hardware op; same |

All four still resolve **ALLOW** under `claude-code` today, and
`test_the_new_checks_do_not_leak_into_claude_code` now pins exactly those four
so a later "while I'm here" widening cannot slip in unreported.

## Red/green matrix

**Base ref: `origin/main` @ `73f5ec0`.** Method: `git archive origin/main` into a
clean tree, drop **this PR's** test file into it, run. That isolates the code
change from the test change.

| | at `origin/main` (73f5ec0) | at HEAD |
|---|---|---|
| `test_guard_core.py` total | **34 failed** / 995 passed | **0 failed** / 1029 passed |

The 34 reds, by test:

| test | reds at base | why red |
|---|---|---|
| `test_git_stash_is_denied_under_claude_code` | 15 | `evaluate(…, "claude-code")` returned None |
| `test_git_clean_force_is_denied_under_claude_code` | 11 | same |
| `test_git_stash_still_denied_under_opencode` | 1 | the `cd /x && git stash` row denied with the **cd** reason |
| `test_git_clean_force_still_denied_under_opencode` | 1 | same |
| `test_cd_then_git_stash_reports_the_stash_reason_not_the_cd_reason` | 1 | ordering |
| `test_new_deny_messages_carry_the_quoting_escape_hatch` | 1 | messages had no escape hatch |
| `test_the_one_real_quoting_false_positive_is_a_heredoc_body` | 1 | allowed at base |
| `test_claude_code_policy_is_pinned_by_name` | 1 | policy pin |
| `test_opencode_policy_is_a_strict_superset` | 1 | policy pin |
| `test_opencode_policy_carries_the_irreversible_checks` | 1 | policy pin |

Every deny assertion is **by reason**, not by `is not None` — `cd /x && git
stash` denies at base via `check_cd_then_git`, so a bare deny assertion would be
green for the wrong reason.

### Labelled INVARIANT GUARDS (green at base *and* HEAD — not regression coverage)
`test_stash_and_clean_neighbours_stay_allowed_under_claude_code` (16 rows). It is
the false-positive fence: `git stash list`, `git clean -nd`, `git worktree list`,
`rm -rf /tmp/scratch-mu`, and the prose/argument spellings. Labelled as such in
the docstring.

## Mutation matrix

Harness: each mutant applied to a **fresh copy** of the tree (a crashed sweep
must not leave a mutation applied and poison the next baseline), `py_compile`d
first so a SyntaxError cannot masquerade as a kill, then the full file run and
the failing test names + assertion *kinds* recorded.

**Harness validation (requirement 5):**
- **POSITIVE control** `CONTROL-none` (unmutated copy): **0 failed / 1029
  passed** → the harness runs the code it thinks it does.
- **NEGATIVE control** `NEG-allow-everything` (`evaluate` iterates an empty
  list): **318 failed / 711 passed** → the harness can go red, and the counter
  observes something. Killed by, among others, `test_evaluate_can_return_a_reason`.

| mutant | result | killed by | assertion kind |
|---|---|---|---|
| `M1b` — stash restored to opencode-only (**exact `origin/main` arrangement**) | 21 failed / 1008 passed | `test_git_stash_is_denied_under_claude_code`, `…_still_denied_under_opencode`, `test_cd_then_git_stash_reports_the_stash_reason…`, `test_the_one_real_quoting_false_positive…`, 3 policy pins | ALLOWED-under-policy, WRONG-reason-attribution, policy-list-pin |
| `M2b` — clean restored to opencode-only (exact base arrangement) | 15 failed / 1014 passed | `test_git_clean_force_is_denied_under_claude_code`, `…_still_denied_under_opencode`, 3 policy pins | ALLOWED-under-policy, WRONG-reason-attribution, policy-list-pin |
| `M1` — stash removed from **both** policies | 63 failed / 966 passed | the above + the opencode matrix | same |
| `M2` — clean removed from both policies | 45 failed / 984 passed | ditto | same |
| `M3` — stash moved **after** `check_cd_then_git` | 5 failed / 1024 passed | `test_cd_then_git_stash_reports_the_stash_reason_not_the_cd_reason` | WRONG-reason-attribution |
| `M4` — escape hatch stripped from the stash message | 2 failed / 1027 passed | `test_new_deny_messages_carry_the_quoting_escape_hatch` | escape-hatch-missing |
| `M5` — escape hatch stripped from the clean message | 1 failed / 1028 passed | same test | escape-hatch-missing |
| `M6` — `check_git_stash` allows `push`/`pop` | 101 failed / 928 passed | `test_git_stash_is_denied_under_claude_code` + the pre-existing spelling matrix | ALLOWED-under-policy |
| `M7` — `check_git_stash` stops stripping git global opts | 57 failed / 972 passed | `test_git_stash_is_denied_through_every_global_option_hop`, `…_under_claude_code` | ALLOWED-under-policy |
| `M8` — `check_git_clean_force` stops stripping git global opts | 22 failed / 1007 passed | `test_git_clean_force_is_denied`, `…_under_claude_code` | ALLOWED-under-policy |

**10/10 mutants killed, 0 survivors.** Each kill was checked to come from
**this** guard's assertion — "was ALLOWED under `<policy>`" or the explicit
"denied … but for the WRONG reason" attribution message — never from an
unrelated guard's error. `M1b`/`M2b` are the load-bearing pair: they restore the
*exact* `origin/main` arrangement (check still exists, opencode still gets it,
only `claude-code` loses it), so anything they kill is killed by the policy move
itself.

**Reachability, not just breakability:** the guard is proven to execute, because
the deny reasons come back attributed to `check_git_stash` /
`check_git_clean_force` specifically. No earlier check can win — `M3` shows that
when `check_cd_then_git` *is* placed first, the attribution assertion goes red.

## Test counts (counted, not exit codes)

| suite | at `origin/main` | at HEAD |
|---|---|---|
| `test_guard_core.py` — pytest functions | 69 | 77 |
| `test_guard_core.py` — parametrized cases | **960 passed** | **1029 passed** |
| `test_bash_guard.py` — `PASS` lines (script, 110 CASES + 3 extra checks) | **113 PASS**, `RESULT: all good` | **113 PASS**, `RESULT: all good` |

No pre-existing test was deleted or weakened. Three existing tests were *edited*,
all to record the move: `CLAUDE_CODE_EXPECTED` (+2 names),
`IRREVERSIBLE_EXPECTED` (−2 names), and
`test_the_new_checks_do_not_leak_into_claude_code` (the `git stash push -m wip`
and `git clean -fd` rows moved out, with a NOTE left behind pointing at the new
section — the same convention the `git -C <p> reset --hard` row used).

## Full-repo suite

`scripts/run-tests.sh` on the merged worktree tree:

```
TOTAL collected=4442  passed=4441  skipped=1  failed=0  (floor: 2850)
PASS  scripts/claude-hooks/tests/test_guard_core.py  (collected=1029 passed=1029 skipped=0)
PASS  scripts/claude-hooks/tests/test_bash_guard.py (script)
RESULT: PASS
```

The 1 skip is the pre-existing pinned `REPO_COS_LIVE_DRIFT_CHECK` opt-in.

**No `scripts/run-tests.sh` edit was needed** — `test_guard_core.py` is already a
named target and `MIN_TESTS` is a floor, which this change only raises. So there
is no merge-order interaction with the sibling agent working in that file.

## Two-tier note (sandbox vs dev host)

Ran on the **dev host** (workbench), under `nix-shell -p python3Packages.pytest
… nodejs ripgrep curl jq nix bash gawk gnugrep util-linux git` so
`REQUIRED_TOOLS` was satisfied and nothing skipped itself. **Nothing I touched is
environment-dependent**: the new tests are pure in-process string logic — no
subprocess, no network, no `shutil.which`, no `node`/`nix-instantiate`, no
filesystem, no viewport/locale/timezone. So the sandbox tier cannot observe
anything different here. Worth reading the CI tier's output anyway on principle.

*(Aside, not caused by this PR: an ad-hoc shell missing PyYAML makes
`scripts/tests/test_opencode_config.py` fail to import and `mail-actions` lose 3
tests — the run-tests.sh precondition doesn't list `python3Packages.pyyaml`,
since the flake supplies it. Mentioning it only so the intermediate output above
isn't mis-read; not in scope.)*

## End-to-end verification (real PreToolUse JSON)

Piped `{"tool_name":"Bash","tool_input":{"command":…}}` into a `bash-guard.py`,
exactly as you did. **Run against BOTH artifacts, reported separately**:

| command | DEPLOYED `~/.claude/hooks/bash-guard.py` | this PR's source |
|---|---|---|
| `git add -A` *(positive control)* | DENY | DENY |
| `git reset --hard HEAD` *(positive control)* | DENY | DENY |
| `git stash` | ALLOW | **DENY** ``​`git stash` is blocked`` |
| `git stash push -m wip` | ALLOW | **DENY** |
| `git stash pop` | ALLOW | **DENY** |
| `VAR=1 git stash` | ALLOW | **DENY** |
| `sudo git stash` | ALLOW | **DENY** |
| `git -C /srv/repos/alpha stash` | ALLOW | **DENY** |
| `bash -c 'git stash'` | ALLOW | **DENY** |
| `echo ok && git stash` | ALLOW | **DENY** |
| `git clean -fd` | ALLOW | **DENY** ``​`git clean -f` is blocked`` |
| `git clean --force` | ALLOW | **DENY** |
| `git stash list` | ALLOW | ALLOW |
| `git clean -nd` | ALLOW | ALLOW |
| `ls -la /tmp` *(benign control)* | ALLOW | ALLOW |

🔴 **The DEPLOYED column is still ALLOW and that is expected, not a failure.**
`readlink -f ~/.claude/hooks/bash-guard.py` →
`/nix/store/qlp2yjm91l292b67cfmkxi5bspj2x0kk-hm_bashguard.py` (and `guard_core.py`
→ `…-hm_guard_core.py`) — nix-store regular files, so a worktree edit is inert
until a `home-manager switch`. **I did not run one.** What I verified is the
source this PR commits; **the hook on both hosts still allows `git stash` until
`scripts/ship.sh` (or a per-host switch) runs after merge.** Deployed ≠ verified,
stated separately.

The `git add -A` / `git reset --hard HEAD` DENYs in the deployed column are the
positive controls proving the deployed hook was live and reading my payloads —
so its ALLOWs are real ALLOWs, not a wired-to-nothing harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
