### PR TITLE
feat(hooks): PostToolUse[Bash] nudge toward the native Grep/Glob tools

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -699,6 +699,17 @@ in
   home.file.".claude/hooks/shell-env-nudge.py" = {
     source = ../scripts/claude-hooks/shell-env-nudge.py;
   };
+  # search-tool-nudge fires PostToolUse on Bash calls that are a TREE SEARCH (`grep -r`,
+  # bare `rg`, `find <path> -name`, `ls -R`, `find | xargs grep`) and points at the
+  # native Grep/Glob tools. Same "prose didn't work, so nudge structurally" reasoning as
+  # shell-env-nudge: over a 30-day telemetry window Bash was 71% of all tool calls
+  # (workbench 31,355 / laptop 6,164) against 50 Grep+Glob calls total — zero on the
+  # laptop — despite RULES.md already saying "Grep over bash grep, Glob over find".
+  # Conservative by design (false positives are expensive on a per-Bash-call hook) and
+  # deduped to once per kind per session.
+  home.file.".claude/hooks/search-tool-nudge.py" = {
+    source = ../scripts/claude-hooks/search-tool-nudge.py;
+  };
   # claude-notify is the turn-finished notifier: on UserPromptSubmit/Stop/SubagentStop
   # it fires a desktop toast (or, headless, a clawgate phone push as FALLBACK) when a
   # turn ran >= threshold (default 60s). Telemetry shows Claude runs mostly on the

--- a/scripts/claude-hooks/register-nudge-hook.py
+++ b/scripts/claude-hooks/register-nudge-hook.py
@@ -8,7 +8,7 @@ and NEVER clobbers hooks it doesn't own (clawgate PermissionRequest/Stop, bash-g
 tmux hooks, etc. are preserved — this only ever appends).
 
 Registers:
-  * PostToolUse(Bash): audit-pr-nudge.py, shell-env-nudge.py
+  * PostToolUse(Bash): audit-pr-nudge.py, shell-env-nudge.py, search-tool-nudge.py
   * UserPromptSubmit / Stop / SubagentStop: claude-notify.py (the turn-finished
     notifier — a best-effort side-effect hook, appended alongside any existing
     Stop/clawgate-stop/tmux hooks).
@@ -24,6 +24,7 @@ SETTINGS = os.path.expanduser("~/.claude/settings.json")
 POST_BASH_CMDS = [
     "python3 ~/.claude/hooks/audit-pr-nudge.py",
     "python3 ~/.claude/hooks/shell-env-nudge.py",
+    "python3 ~/.claude/hooks/search-tool-nudge.py",
 ]
 
 # The turn-finished notifier fires on these three events (single script,

--- a/scripts/claude-hooks/search-tool-nudge.py
+++ b/scripts/claude-hooks/search-tool-nudge.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""PostToolUse nudge: when a Bash call does a SEARCH that the native Grep/Glob tools
+already do (`grep -r`, bare `rg`, `find <path> -name …`, `ls -R`, `find | xargs grep`),
+inject context pointing at the native tool.
+
+Why this exists: measured over a 30-day window of activity telemetry, Bash is 71% of all
+Claude tool calls (workbench 31,355 / laptop 6,164) while Grep+Glob together were used
+50 times — and ZERO times on the laptop. RULES.md's "Tool Optimization" section already
+says "Grep over bash grep, Glob over find"; that prose rule demonstrably does not work.
+Per RULES.md "Deterministic Over Prose" the replacement has to be structural, so this
+fires at the moment the search-shaped command runs.
+
+Design constraints, in priority order:
+  1. NEVER blocks. It is a PostToolUse nudge — it only ever adds context, and always
+     exits 0. (bash-guard.py is the only hook here that denies; this is not that.)
+  2. False positives are expensive. This runs on EVERY Bash call, and a hook that cries
+     wolf trains the operator to ignore it. So the detector is deliberately conservative:
+     it fires only on the shapes that are unambiguously a tree search, and stays silent
+     on every narrow/legitimate use (single-file `grep`, `git log | grep`, `find -exec`
+     doing non-search work).
+  3. Once per KIND per session (two kinds: content-search, file-search), so a session
+     sees at most two of these ever.
+
+Fail-open: any error -> exit 0 silently; it must never break the Bash tool.
+"""
+import sys, json, os, re, shlex
+
+HOME = os.path.expanduser("~")
+CACHE_DIR = f"{HOME}/.cache/claude-search-tool-nudge"
+
+# Content-search binaries: they read file *contents*, so the native answer is Grep.
+GREP_BINS = {"grep", "egrep", "fgrep", "rgrep", "ggrep"}
+RG_BINS = {"rg", "ag", "ack", "ack-grep"}
+# Leading words that wrap a real command without changing what it is.
+WRAPPERS = {"sudo", "time", "nice", "ionice", "command", "builtin", "stdbuf", "env", "\\"}
+SEPARATORS = {"|", "|&", "||", "&&", ";", ";;", "&", "\n"}
+# `find` actions that mean the find is doing WORK, not searching for Claude to read.
+FIND_ACTIONS = {"-exec", "-execdir", "-ok", "-okdir"}
+FIND_NAME_PREDS = {"-name", "-iname", "-path", "-ipath", "-regex", "-iregex", "-wholename"}
+
+CONTENT = "content"
+FILES = "files"
+
+HINTS = {
+    CONTENT: (
+        "Grep tool",
+        "Grep(pattern=\"…\", path=\"…\", glob=\"*.py\", output_mode=\"content\")",
+    ),
+    FILES: (
+        "Glob tool",
+        "Glob(pattern=\"**/*.py\", path=\"…\")",
+    ),
+}
+
+
+def _strip_heredocs(cmd):
+    """Remove heredoc BODIES before lexing.
+
+    Measured against 27,187 real transcript Bash commands: without this, the body of an
+    `ssh host 'bash -s' <<'EOF' … EOF` block lexes as if it were local commands, so a
+    `find`/`grep -r` meant for a REMOTE host produced a nudge pointing at Grep/Glob —
+    which cannot reach that host at all. Also covers `cat > f <<'EOF'` file bodies.
+    An unterminated heredoc swallows the rest of the command, i.e. it fails SILENT.
+    """
+    lines = cmd.split("\n")
+    kept = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        kept.append(line)
+        delims = [d for _, d in re.findall(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1", line)]
+        i += 1
+        for d in delims:
+            while i < len(lines) and lines[i].strip() != d:
+                i += 1
+            i += 1  # drop the terminator line too
+    return "\n".join(kept)
+
+
+def _newlines_to_separators(cmd):
+    """Turn UNQUOTED newlines into `;` so a multi-line command lexes as several commands.
+
+    shlex treats `\\n` as ordinary whitespace, so without this a command like
+    `cd /repo\\ngrep -r foo .` lexes as ONE segment whose command name is `cd`, and the
+    grep is never seen. Quote state is tracked so a newline INSIDE a quoted string (a
+    multi-line `ssh host '…'` remote script, a quoted python -c body) stays inside its
+    token and cannot be mistaken for a local command. A backslash line-continuation is
+    likewise left alone so `git log \\<newline> | grep push` stays one command.
+
+    Honest scope note: the quote/backslash tracking is belt-and-braces, not observably
+    load-bearing — a mutation sweep showed both branches SURVIVE, because shlex re-parses
+    quotes and escapes itself, so a `;` injected inside a quoted region stays inside the
+    token anyway. It is kept because it makes this pass correct on its own terms; if the
+    lexer is ever swapped out, dropping it would silently regress.
+    """
+    out = []
+    quote = None
+    i = 0
+    while i < len(cmd):
+        c = cmd[i]
+        if quote is None and c == "\\" and i + 1 < len(cmd):
+            out.append(c)
+            out.append(cmd[i + 1])
+            i += 2
+            continue
+        if quote is None and c in "'\"":
+            quote = c
+        elif quote == c:
+            quote = None
+        out.append(";" if (c == "\n" and quote is None) else c)
+        i += 1
+    return "".join(out)
+
+
+def _tokenize(cmd):
+    """Split a shell command into [(tokens, piped_in, pipeline_id), …].
+
+    Uses shlex with punctuation_chars so `|`, `&&`, `;` come back as their own tokens and
+    quoting is honoured — a `grep -r` that only appears INSIDE a quoted string collapses
+    into one token and can therefore never be mistaken for a command. Returns [] on any
+    lexing error (unbalanced quotes etc.), which makes the whole hook silent: fail-open.
+    """
+    lexer = shlex.shlex(_newlines_to_separators(_strip_heredocs(cmd)),
+                        posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    lexer.commenters = ""  # '#' is only a comment at word start in sh; don't guess
+    try:
+        toks = list(lexer)
+    except ValueError:
+        return []
+
+    segments = []
+    cur = []
+    piped_in = False
+    pipeline_id = 0
+    skip_next = False
+    for t in toks:
+        if skip_next:  # redirection target, e.g. the /dev/null in `2>/dev/null`
+            skip_next = False
+            continue
+        if t in ("<", ">", ">>", "<<", "<<<", ">|", "&>", ">&"):
+            skip_next = True
+            continue
+        if t in SEPARATORS:
+            segments.append((cur, piped_in, pipeline_id))
+            cur = []
+            if t in ("|", "|&"):
+                piped_in = True
+            else:
+                piped_in = False
+                pipeline_id += 1
+            continue
+        cur.append(t)
+    segments.append((cur, piped_in, pipeline_id))
+    return [s for s in segments if s[0]]
+
+
+def _strip_wrappers(tokens):
+    """Drop leading `VAR=val` assignments and no-op wrappers (`sudo`, `time`, `xargs`…).
+
+    Returns (command_name, args, via_xargs). `via_xargs` matters because
+    `find … | xargs grep` is a tree content-search even though the grep has no -r.
+    """
+    i = 0
+    via_xargs = False
+    while i < len(tokens):
+        t = tokens[i]
+        if re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", t) or t in WRAPPERS:
+            i += 1
+            continue
+        if os.path.basename(t) == "xargs":
+            via_xargs = True
+            i += 1
+            # Skip xargs' own flags up to the child command. Flags that take a separate
+            # argument (`-I {}`, `-n 1`) consume the next token too.
+            while i < len(tokens) and tokens[i].startswith("-"):
+                takes_arg = tokens[i] in ("-I", "-n", "-P", "-L", "-d", "-s", "-E")
+                i += 2 if takes_arg else 1
+            continue
+        break
+    if i >= len(tokens):
+        return None, [], via_xargs
+    return os.path.basename(tokens[i]), tokens[i + 1:], via_xargs
+
+
+def _has_short_flag(args, letters):
+    """True if any short-flag token carries one of `letters` (handles clusters like -rn)."""
+    for a in args:
+        if a.startswith("--") or not a.startswith("-") or a == "-":
+            continue
+        body = a.split("=", 1)[0]
+        if any(c in body[1:] for c in letters):
+            return True
+    return False
+
+
+def _classify_segment(cmd_name, args, piped_in, via_xargs):
+    """Return CONTENT / FILES / None for one already-unwrapped command."""
+    if cmd_name is None:
+        return None
+
+    # --- grep family -----------------------------------------------------------
+    # Fires ONLY when recursive (or fed by xargs from a find). A non-recursive grep is
+    # either a single-file read or a pipeline filter (`git log | grep push`) — both
+    # legitimate, neither expressible as the Grep tool, so both stay silent.
+    if cmd_name in GREP_BINS:
+        recursive = _has_short_flag(args, "rR") or any(
+            a.split("=", 1)[0] in ("--recursive", "--dereference-recursive") for a in args
+        )
+        if recursive:
+            return CONTENT
+        if via_xargs:
+            return CONTENT
+        return None
+
+    # --- ripgrep / ag / ack ----------------------------------------------------
+    # These default to recursive-from-cwd, so a bare invocation IS a tree search. But
+    # `cmd | rg foo` is a stdin filter — same legitimate case as grep — so skip when
+    # the segment receives a pipe.
+    if cmd_name in RG_BINS:
+        if piped_in:
+            return None
+        return FILES if "--files" in args else CONTENT
+
+    # --- find ------------------------------------------------------------------
+    if cmd_name == "find":
+        if "-delete" in args:
+            return None  # a deletion, not a search
+        for i, a in enumerate(args):
+            if a in FIND_ACTIONS:
+                child = args[i + 1] if i + 1 < len(args) else ""
+                # `find … -exec grep …` is a tree content-search; `-exec rm/chmod/…`
+                # is real work and must stay silent.
+                return CONTENT if os.path.basename(child) in GREP_BINS else None
+        if any(a in FIND_NAME_PREDS for a in args):
+            return FILES
+        return None
+
+    # --- ls -R -----------------------------------------------------------------
+    if cmd_name == "ls" and _has_short_flag(args, "R"):
+        return FILES
+
+    return None
+
+
+def analyze(cmd):
+    """Pure: return the ordered, de-duplicated list of kinds (CONTENT/FILES) `cmd` earns.
+
+    Ordered so output is deterministic; de-duplicated so one command yields at most one
+    nudge per kind.
+    """
+    segments = _tokenize(cmd)
+    if not segments:
+        return []
+
+    kinds = []
+    # Pipeline-level pass first: `find … | xargs grep …` / `find … | grep …` is a tree
+    # content-search that neither segment alone reveals.
+    by_pipeline = {}
+    for tokens, piped_in, pid in segments:
+        by_pipeline.setdefault(pid, []).append((tokens, piped_in))
+    find_to_grep = set()
+    for pid, members in by_pipeline.items():
+        names = [_strip_wrappers(t)[0] for t, _ in members]
+        if "find" in names and any(n in GREP_BINS for n in names[names.index("find") + 1:]):
+            find_to_grep.add(pid)
+            if CONTENT not in kinds:
+                kinds.append(CONTENT)
+
+    for tokens, piped_in, pid in segments:
+        name, args, via_xargs = _strip_wrappers(tokens)
+        # In a `find … | xargs grep` pipeline the find is the *plumbing* for a content
+        # search, not a file search — one CONTENT nudge is the right answer, so don't
+        # also emit FILES for the find half.
+        if pid in find_to_grep and name == "find":
+            continue
+        k = _classify_segment(name, args, piped_in, via_xargs)
+        if k and k not in kinds:
+            kinds.append(k)
+    return kinds
+
+
+def _already_nudged(session, kind):
+    """Per-session dedupe: each kind is suggested at most once. Fail-open on IO error."""
+    if not session:
+        return False
+    try:
+        os.makedirs(CACHE_DIR, exist_ok=True)
+        f = os.path.join(CACHE_DIR, re.sub(r"[^A-Za-z0-9_.-]", "_", session))
+        seen = set()
+        if os.path.exists(f):
+            with open(f) as fh:
+                seen = set(fh.read().split())
+        if kind in seen:
+            return True
+        with open(f, "a") as fh:
+            fh.write(kind + "\n")
+        return False
+    except Exception:
+        return False
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+    try:
+        if data.get("tool_name") != "Bash":
+            sys.exit(0)
+        cmd = (data.get("tool_input") or {}).get("command", "")
+        if not cmd:
+            sys.exit(0)
+        session = data.get("session_id") or ""
+        fresh = [k for k in analyze(cmd) if not _already_nudged(session, k)]
+        if not fresh:
+            sys.exit(0)
+        lines = "\n".join(f"  • {HINTS[k][0]} → {HINTS[k][1]}" for k in fresh)
+        nudge = (
+            "search-tool: that Bash call was a tree search. The native tools do the same "
+            "job with structured results, no shell quoting, and far fewer tokens — and "
+            "measured over 30 days they are effectively unused (Bash 37.5k calls vs "
+            "Grep+Glob 50). Prefer them next time:\n"
+            f"{lines}"
+        )
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": nudge,
+            }
+        }))
+    except Exception:
+        pass
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/claude-hooks/tests/test_register_nudge_hook.py
+++ b/scripts/claude-hooks/tests/test_register_nudge_hook.py
@@ -20,6 +20,7 @@ SCRIPT = os.path.join(HERE, "..", "register-nudge-hook.py")
 
 NOTIFY = "python3 ~/.claude/hooks/claude-notify.py"
 CLAWGATE_STOP = "/home/zach/.claude/clawgate-stop-hook.sh"
+SEARCH_NUDGE = "python3 ~/.claude/hooks/search-tool-nudge.py"
 
 failures = []
 
@@ -80,6 +81,10 @@ with tempfile.TemporaryDirectory() as tmp:
     check("2: both PostToolUse nudges preserved",
           "python3 ~/.claude/hooks/audit-pr-nudge.py" in cmds(d, "PostToolUse")
           and "python3 ~/.claude/hooks/shell-env-nudge.py" in cmds(d, "PostToolUse"))
+    # search-tool-nudge is absent from BASE_SETTINGS, so this also proves the registrant
+    # ADDS a missing PostToolUse nudge rather than only preserving existing ones.
+    check("1: search-tool-nudge registered on PostToolUse",
+          SEARCH_NUDGE in cmds(d, "PostToolUse"))
 
     # Idempotency: a second run changes nothing and never duplicates.
     p2 = run(env)
@@ -88,6 +93,7 @@ with tempfile.TemporaryDirectory() as tmp:
     with open(settings) as f:
         d2 = json.load(f)
     check("3: no duplicate claude-notify on Stop", cmds(d2, "Stop").count(NOTIFY) == 1)
+    check("3: no duplicate search-tool-nudge", cmds(d2, "PostToolUse").count(SEARCH_NUDGE) == 1)
     check("3: clawgate Stop still single + present", cmds(d2, "Stop").count(CLAWGATE_STOP) == 1)
 
     # Atomicity: no temp litter left in the dir, and the source uses os.replace.

--- a/scripts/claude-hooks/tests/test_search_tool_nudge.py
+++ b/scripts/claude-hooks/tests/test_search_tool_nudge.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Unit tests for search-tool-nudge.analyze() + the hook's IO contract.
+
+Structure mirrors test_shell_env_nudge.py (hand-rolled asserts + sys.exit, not
+pytest-collectable) because run-tests.sh runs these directly.
+
+Two things this file does that a plain assert list does not, both required because the
+reassuring answer here is a ZERO (no false positives):
+
+  * HARNESS NEGATIVE CONTROL — feed check() a case it MUST fail and confirm it records
+    a failure. Until that has been watched go red, a green run is a fact about the
+    harness, not about the hook.
+  * BENIGN-SET POSITIVE CONTROL — the benign set is asserted to fire 0 times. A counter
+    wired to nothing also reports 0, so the SAME counting path is first fed a command
+    that MUST fire, and the count is asserted to be exactly 1.
+
+Run: python3 scripts/claude-hooks/tests/test_search_tool_nudge.py
+"""
+import os, sys, json, subprocess, importlib.util
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+HOOK = os.path.join(HERE, "..", "search-tool-nudge.py")
+HOME = os.path.expanduser("~")
+
+spec = importlib.util.spec_from_file_location("search_tool_nudge", HOOK)
+assert spec and spec.loader
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+analyze = mod.analyze
+CONTENT, FILES = mod.CONTENT, mod.FILES
+
+fails = []
+
+
+ran = []
+
+
+def check(name, got, want):
+    """Every assertion is COUNTED, not just exit-coded — the runner reports pass/fail
+    only, so the count printed at the end is how a silently-shrunk suite is spotted."""
+    ran.append(name)
+    if got != want:
+        fails.append(f"{name}: got {got!r} want {want!r}")
+
+
+# --------------------------------------------------------------------------- #
+# HARNESS NEGATIVE CONTROL — prove check() can go red before trusting any green.
+# --------------------------------------------------------------------------- #
+check("harness negative control", 1, 2)
+ran.clear()
+if len(fails) != 1:
+    print("HARNESS BROKEN: check() did not record a deliberate mismatch — a green "
+          "result from this file would mean nothing. Aborting.")
+    sys.exit(2)
+fails.clear()
+
+# --------------------------------------------------------------------------- #
+# MUST FIRE — tree searches the native tools already do.
+# --------------------------------------------------------------------------- #
+MUST_FIRE = [
+    # grep -r / -R across a tree
+    ("grep -r", "grep -r TODO src/", [CONTENT]),
+    ("grep -R", "grep -R 'def main' .", [CONTENT]),
+    ("grep clustered flags", "grep -rn --color=never foo lib/", [CONTENT]),
+    ("grep --recursive", "grep --recursive pattern .", [CONTENT]),
+    ("sudo grep -r", "sudo grep -r secret /etc", [CONTENT]),
+    # ripgrep and friends default to recursive-from-cwd
+    ("bare rg", "rg 'class Foo'", [CONTENT]),
+    ("rg with path", "rg -n TODO scripts/", [CONTENT]),
+    ("rg --files", "rg --files", [FILES]),
+    ("ag", "ag pattern src", [CONTENT]),
+    # find by name
+    ("find -name", "find . -name '*.py'", [FILES]),
+    ("find -iname abs path", f"find {HOME}/workspace -iname 'README*'", [FILES]),
+    ("find -path", "find . -path '*/tests/*'", [FILES]),
+    # find piped into grep
+    ("find | xargs grep", "find . -name '*.py' | xargs grep -l TODO", [CONTENT]),
+    ("find -print0 | xargs -0 grep", "find . -name '*.js' -print0 | xargs -0 grep foo", [CONTENT]),
+    ("find -exec grep", "find src -name '*.c' -exec grep -H TODO {} +", [CONTENT]),
+    ("xargs grep from a file list", "cat filelist.txt | xargs grep TODO", [CONTENT]),
+    # ls -R
+    ("ls -R", "ls -R nix/", [FILES]),
+    ("ls -Ral", "ls -Ral scripts", [FILES]),
+    # multi-command: a search hidden after a &&
+    ("chained after &&", "git status && grep -r foo .", [CONTENT]),
+    # multi-line: shlex treats \n as plain whitespace, so without an explicit
+    # newline->separator pass the whole block lexes as one `cd` command and the
+    # search is invisible. Caught by mutant M1.
+    ("search on a later LINE", "cd /repo\necho hi\ngrep -r foo src/", [CONTENT]),
+    ("find on a later LINE", "W=/tmp/x\nfind $W -name '*.py'", [FILES]),
+    # both kinds in one call
+    ("both kinds", "grep -r foo . && find . -name '*.md'", [CONTENT, FILES]),
+]
+for name, cmd, want in MUST_FIRE:
+    check("FIRE " + name, analyze(cmd), want)
+
+# --------------------------------------------------------------------------- #
+# MUST NOT FIRE — narrow/legitimate uses. False positives are the expensive
+# failure mode here: this runs on EVERY Bash call.
+# --------------------------------------------------------------------------- #
+BENIGN = [
+    # grep against a single named file
+    ("grep single file", "grep TODO README.md"),
+    ("grep -n single file", "grep -n 'def main' scripts/foo.py"),
+    ("grep -c single file", "grep -c error /var/log/syslog"),
+    # grep as a pipeline filter over another command's output
+    ("git log | grep push", "git log | grep push"),  # RULES.md notes this exact over-match hazard
+    ("systemctl | grep", "systemctl list-units | grep browser-bridge"),
+    ("ps | grep", "ps aux | grep -i python"),
+    ("kubectl | grep -v", "kubectl get pods | grep -v Running"),
+    ("cat | grep", "cat /etc/hosts | grep nixos"),
+    ("rg as stdin filter", "journalctl -u foo | rg error"),
+    # find doing non-search work
+    ("find -exec rm", "find /tmp/cache -name '*.png' -exec rm {} +"),
+    ("find -exec chmod", "find . -name '*.sh' -exec chmod +x {} \\;"),
+    ("find -delete", "find /tmp -name '*.tmp' -delete"),
+    ("find -mtime no name", "find /var/log -mtime +30"),
+    # ls without -R
+    ("plain ls", "ls -la scripts/"),
+    # search-shaped text that is only a string, not a command
+    ("grep -r inside a quoted string", "echo 'grep -r foo .'"),
+    ("grep -r in a quoted ssh remote command", "ssh host 'grep -r foo /etc'"),
+    # heredoc BODY: these run on a REMOTE host / are file content, not local searches.
+    # Found by running the detector over 27,201 real transcript Bash commands.
+    ("ssh heredoc body", "ssh host 'bash -s' <<'EOF'\ngrep -r foo /etc\nfind / -name '*.conf'\nEOF"),
+    ("cat > file heredoc body", "cat > /tmp/s.sh <<'SH'\nfind . -name '*.py'\nSH\nchmod +x /tmp/s.sh"),
+    # a multi-line remote script inside quotes is not a local search either
+    ("multi-line quoted ssh script", "ssh host '\ngrep -r foo /etc\n'"),
+    ("backslash line-continuation into a grep filter", "git log \\\n  | grep push"),
+    # ordinary non-search commands
+    ("git status", "git status && git log --oneline -3"),
+    ("home-manager switch", "home-manager switch --flake ~/workspace/devrc --impure"),
+    ("nix build", "nix build .#checks.x86_64-linux.pytests"),
+]
+
+
+def fire_count(cases):
+    """The single counting path used for BOTH the positive control and the benign set."""
+    return sum(1 for _, cmd in cases if analyze(cmd))
+
+
+# BENIGN-SET POSITIVE CONTROL — the counter must be able to move off zero.
+check("benign-counter positive control", fire_count([("pos", "grep -r foo src/")]), 1)
+check("benign-set false positives", fire_count(BENIGN), 0)
+# Per-case detail so a regression names the offender rather than just a number.
+for name, cmd in BENIGN:
+    check("BENIGN " + name, analyze(cmd), [])
+
+# --------------------------------------------------------------------------- #
+# Robustness — a malformed command must be silent, never an exception.
+# --------------------------------------------------------------------------- #
+check("unbalanced quote is silent", analyze("grep -r 'unterminated"), [])
+check("empty command", analyze(""), [])
+
+# --------------------------------------------------------------------------- #
+# IO contract: real subprocess, PostToolUse payload, exit 0 and never a deny.
+# --------------------------------------------------------------------------- #
+def run(payload):
+    p = subprocess.run([sys.executable, HOOK], input=json.dumps(payload),
+                       capture_output=True, text=True)
+    return p.returncode, p.stdout.strip()
+
+
+sid = "test-session-search-nudge-DO-NOT-COLLIDE"
+cache = os.path.join(HOME, ".cache", "claude-search-tool-nudge",
+                     "".join(c if c.isalnum() or c in "_.-" else "_" for c in sid))
+if os.path.exists(cache):
+    os.remove(cache)
+
+rc, out = run({"tool_name": "Bash", "session_id": sid,
+               "tool_input": {"command": "grep -r TODO src/"}})
+check("io rc", rc, 0)
+check("io first-fire emits", bool(out) and "Grep tool" in out and "additionalContext" in out, True)
+# It is a NUDGE: the payload must carry no deny/block decision of any kind.
+parsed = json.loads(out) if out else {}
+check("io hookEventName", parsed.get("hookSpecificOutput", {}).get("hookEventName"), "PostToolUse")
+check("io never denies", any(k in out for k in ("permissionDecision", "\"deny\"", "block")), False)
+
+# second search of the same kind in the same session -> deduped, silent
+rc2, out2 = run({"tool_name": "Bash", "session_id": sid,
+                 "tool_input": {"command": "grep -r other ."}})
+check("io dedupe silent", out2, "")
+# a DIFFERENT kind still fires once
+rc3, out3 = run({"tool_name": "Bash", "session_id": sid,
+                 "tool_input": {"command": "find . -name '*.md'"}})
+check("io other kind fires", "Glob tool" in out3, True)
+
+# benign command -> silent
+rc4, out4 = run({"tool_name": "Bash", "session_id": sid,
+                 "tool_input": {"command": "git log | grep push"}})
+check("io benign silent", (rc4, out4), (0, ""))
+
+# non-Bash tool -> silent, rc 0
+rc5, out5 = run({"tool_name": "Read", "tool_input": {"file_path": "/x"}})
+check("io non-bash silent", (rc5, out5), (0, ""))
+
+# malformed stdin -> never crashes
+p = subprocess.run([sys.executable, HOOK], input="not json", capture_output=True, text=True)
+check("io malformed rc", p.returncode, 0)
+
+if os.path.exists(cache):
+    os.remove(cache)
+
+MIN_CHECKS = 55  # floor: a suite that silently shrinks is a vacuous green
+if fails:
+    print("FAIL:")
+    for f in fails:
+        print("  -", f)
+    sys.exit(1)
+if len(ran) < MIN_CHECKS:
+    print(f"FAIL: only {len(ran)} checks ran, floor is {MIN_CHECKS} — the suite shrank.")
+    sys.exit(1)
+print(f"all search-tool-nudge tests passed ({len(ran)} checks: "
+      f"{len(MUST_FIRE)} must-fire, {len(BENIGN)} benign, "
+      f"1 harness negative control, 1 benign-counter positive control)")

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -402,12 +402,21 @@ done
 # no counts, so they are pass/fail only and are NOT part of the totals.
 HOOK_TESTS=(
   "scripts/claude-hooks/tests/test_shell_env_nudge.py"
+  "scripts/claude-hooks/tests/test_search_tool_nudge.py"
   "scripts/claude-hooks/tests/test_claude_notify.py"
   "scripts/claude-hooks/tests/test_register_nudge_hook.py"
   "scripts/claude-hooks/tests/test_bash_guard.py"
 )
 for HOOK_TEST in "${HOOK_TESTS[@]}"; do
-  [ -f "$HOOK_TEST" ] || continue
+  # Was `|| continue` — a SILENT skip, the exact #276 shape GUARD 5 exists to stop:
+  # an entry added to this list that the runner quietly rejects, leaving the gate
+  # green while the tests never ran. A missing entry is now a loud failure.
+  if [ ! -f "$HOOK_TEST" ]; then
+    echo "run-tests: ERROR — hook test '$HOOK_TEST' does not exist (typo, or moved?)." >&2
+    RESULTS+=("FAIL  $HOOK_TEST (missing)")
+    fail=1
+    continue
+  fi
   echo "=== script $HOOK_TEST ==="
   if python "$HOOK_TEST"; then
     RESULTS+=("PASS  $HOOK_TEST (script)")


### PR DESCRIPTION
## Why

RULES.md's "Tool Optimization" section already says *"Grep over bash grep, Glob over find"*. Measured over a 30-day activity-telemetry window, it does not work:

| host | Bash calls | Grep | Glob |
|---|---:|---:|---:|
| workbench | 31,355 | 33 | 17 |
| laptop | 6,164 | **0** | **0** |

Bash is 71% of all tool calls; compliance is 50 calls against 37,519. Per RULES.md "Deterministic Over Prose", the replacement has to be structural — so nudge at the moment the search-shaped command runs.

## What

`scripts/claude-hooks/search-tool-nudge.py` — a PostToolUse[Bash] hook that detects a tree search and injects `additionalContext` pointing at Grep/Glob.

🔴 **It is a NUDGE, not a block.** It never emits a deny decision and always exits 0 (asserted by a test: `io never denies`). Same shape as `shell-env-nudge.py` / `audit-pr-nudge.py`; `bash-guard.py` remains the only hook that denies.

**Fires on:** `grep -r`/`-R`/`--recursive` (incl. clusters like `-rn`) · bare `rg`/`ag`/`ack` · `find <path> -name/-iname/-path/-regex` · `ls -R` · `find … | xargs grep` · `find … -exec grep`. Deduped **once per KIND per session** (kinds: content→Grep, files→Glob), so a session sees at most two of these ever.

**Deliberately silent on** (false positives are the expensive failure mode on a per-Bash-call hook):
- `grep TODO README.md` — a single named file
- `git log | grep push` — a pipeline filter (called out in the task as a known over-match hazard), plus `ps aux | grep`, `systemctl … | grep`, `kubectl … | grep -v`, `journalctl | rg`
- `find … -exec rm/chmod`, `find … -delete`, `find /var/log -mtime +30` (no name predicate)
- plain `ls -la`
- search-shaped text inside a quoted string, incl. `ssh host 'grep -r foo /etc'`
- **heredoc bodies** — `ssh host 'bash -s' <<'EOF' … EOF` runs on a REMOTE host that Grep/Glob cannot reach. Found only by running the detector over the real transcript corpus.

## Design decision: new file, not an extension of `shell-env-nudge.py`

**New file.** Trade-off, stated plainly: it adds a *third* per-Bash-call subprocess — **measured at 28 ms mean** for a non-firing call. Extending `shell-env-nudge.py` would avoid that but give one hook two unrelated responsibilities, two dedupe namespaces in one cache, and a name that lies about half of what it does. Two PostToolUse[Bash] nudge subprocesses already exist, so this follows an established one-hook-one-concern pattern rather than introducing a new one. If the per-call cost ever matters, the right consolidation is *all three* nudges behind one dispatcher — not folding two of them together now.

## Also in this PR: a silent-skip fix in `run-tests.sh`

⚠️ **This PR edits `scripts/run-tests.sh`** (the hand-rolled `HOOK_TESTS` list, ~line 400) — flagged for merge-order checking against the sibling PRs touching `guard_core.py` and `session-analysis/insights.py`.

Two changes there:
1. Added `scripts/claude-hooks/tests/test_search_tool_nudge.py` to `HOOK_TESTS`.
2. The loop's `[ -f "$HOOK_TEST" ] || continue` was a **silent skip** — the exact #276 shape (a file added to a target list, silently rejected, gate green while 913 tests never ran). A missing entry is now a loud `FAIL`.

## Verification

**All verification was done by invoking the committed source directly with PostToolUse JSON payloads. Nothing was deployed; `home-manager switch` was NOT run. These are claims about the source in this commit, not about a deployed artifact.**

### Control pair (requirement 4)

The reassuring answer here is a zero, so the zero is never reported alone:

- **Harness negative control** — `check()` is fed a deliberate mismatch at the top of the file and the run **aborts with exit 2** if that does not register as a failure. Until it has been watched go red, a green from this file is a fact about the harness.
- **Benign-set positive control** — `1 on the positive control (`grep -r foo src/` through the same `fire_count()` path), 0 false positives on the 23-case benign set.` A counter wired to nothing also reports 0; this one is shown to move.

### Runner-entry controls (requirement 3 — verified EXECUTED, not assumed)

- **Positive:** flake check output contains `PASS scripts/claude-hooks/tests/test_search_tool_nudge.py (script)`.
- **Negative:** with the test file moved aside, the runner printed `run-tests: ERROR — hook test 'scripts/claude-hooks/tests/test_search_tool_nudge.py' does not exist` and `FAIL … (missing)`. Before this PR's fix that case was silent.

### Red/green matrix (requirement 5)

| ref | result |
|---|---|
| `origin/main` @ `73f5ec0` (`git archive` of `scripts/claude-hooks/`, test dropped in) | 🔴 **RED** — `FileNotFoundError: …/search-tool-nudge.py`, rc=1 |
| HEAD of this branch | 🟢 **GREEN** — `all search-tool-nudge tests passed (58 checks: 22 must-fire, 23 benign, 1 harness negative control, 1 benign-counter positive control)` |

Absence-at-base is a weak red, so it is backed by a **mutation sweep** (13 mutants + an identity control). Every mutant went RED *naming the specific check*, and the identity control passed — proving the sweep harness can distinguish. Two examples: `M2 grep fires even when not recursive` → `BENIGN grep single file: got ['content'] want []`; `M11 newlines not turned into separators` → `FIRE search on a later LINE: got [] want ['content']`.

**M11 was a real bug the sweep found**, not a synthetic one: shlex treats `\n` as ordinary whitespace, so `cd /repo\ngrep -r foo .` lexed as a single `cd` command and the search was invisible. Fixed with a quote-aware newline→separator pass. Two mutants (`M11b`) are reported as **EQUIVALENT** — the pre-pass's quote/backslash tracking survives mutation because shlex re-parses quotes itself. That is stated in the code's docstring rather than papered over with a contrived test.

### Real-corpus false-positive audit

The detector was run over **27,315 real Bash commands** from the local Claude transcripts: **2,589 fire (9.5%)**. Two random samples of 30 firing commands (one general, one restricted to multi-line commands) were read individually — **all 60 were genuine local tree searches**; no false positive found. This audit is what surfaced the heredoc class, which was then pinned as a test.

### Suite counts (requirement 8 — counted, not exit-coded)

`nix build .#checks.x86_64-linux.pytests` → `TOTAL collected=4373 passed=4372 skipped=1 failed=0 (floor: 2850)`, `RESULT: PASS`. Hook tests are pass/fail only and by design not part of `TOTAL`, so that number is unchanged; what moved is `HOOK_TESTS` **4 → 5 entries** and this file's own **58 counted checks** (with a `MIN_CHECKS = 55` floor so a silently-shrunk suite fails).

## 🔴 Per-host action required after merge

`~/.claude/settings.json` is per-host and NOT nix-managed. `register-nudge-hook.py` was extended to register this hook (append-only, idempotent, atomic write — covered by two new assertions in `test_register_nudge_hook.py`). **It must be re-run on BOTH hosts after the `home-manager switch`:**

```
python3 ~/workspace/devrc/scripts/claude-hooks/register-nudge-hook.py
```

Sequence is merge → pull → `ship.sh` (switch) → run the registrant per host. Until the registrant runs, the script is deployed but never invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
