### PR TITLE
fix(opencode): tool-call telemetry captured NOTHING — 2,699/2,699 rows read text='unknown'

### DIFF
--- a/scripts/collector/opencode/activity-plugin.js
+++ b/scripts/collector/opencode/activity-plugin.js
@@ -6,7 +6,7 @@
 // OpenCode loads plugins from that directory and calls the exported async
 // handler factory with { project, client, directory, $ }.
 
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import { join, dirname } from "path";
 import { homedir } from "os";
@@ -23,6 +23,18 @@ const STATE_FILE = join(STATE_DIR, "opencode-plugin-state.json");
 const MAX_SEEN = 1000;
 const MAX_TEXT_LEN = 4096;
 const MAX_ARGS_SUMMARY = 200;
+
+// Sentinel written to `text` when the tool NAME could not be read off the hook
+// input. It must NOT be a plausible tool name: `unknown` was, and 2,699 rows
+// (100% of source=opencode kind=tool-call on the workbench, measured 2026-08-02)
+// carried it because the plugin read `input.tool.name` while the OpenCode hook
+// contract passes `input.tool` as a STRING. A capture failure has to be
+// distinguishable from a genuinely-unnamed tool, so the sentinel is namespaced
+// and the payload carries a machine-readable reason + the raw shape we saw.
+const NAME_CAPTURE_FAILED = "__name_capture_failed__";
+const MAX_INFLIGHT_CALLS = 256;
+
+export const _internals = { NAME_CAPTURE_FAILED, MAX_ARGS_SUMMARY };
 
 // --------------------------------------------------------------------------- #
 // State management (ring buffer of seen message IDs)
@@ -80,7 +92,7 @@ function resolveEmitPath() {
   return "emit";
 }
 
-function emitEvent({ kind, text, project, cwd, session, app, payload }) {
+export function emitEvent({ kind, text, project, cwd, session, app, payload }) {
   try {
     const emit = resolveEmitPath();
     const args = ["source=opencode", `kind=${kind}`];
@@ -105,9 +117,20 @@ function emitEvent({ kind, text, project, cwd, session, app, payload }) {
       args.push(`b64:payload=${p}`);
     }
 
-    execSync(`${emit} ${args.join(" ")}`, {
+    // 🔴 execFileSync with an ARGV ARRAY — never execSync with a joined string.
+    // The old `execSync(\`${emit} ${args.join(" ")}\`)` ran the arguments through
+    // a shell, so every value was word-split on spaces and had its quoting
+    // characters EATEN before `emit` ever saw it. A payload of
+    //   {"duration_ms":0,"success":true,"args_summary":"{\"name\":\"x\"}"}
+    // reached emit as the single mangled token
+    //   {duration_ms:0,success:true,args_summary:{"name":"x"}}
+    // (not valid JSON), and any `text`/`cwd` containing a space was split into
+    // several bogus key=value args. execFileSync passes argv straight to
+    // execve(2) — no shell, no splitting, no quote removal.
+    execFileSync(emit, args, {
       stdio: "ignore",
       timeout: 5000,
+      shell: false,
     });
   } catch {
     // swallow — never crash OpenCode
@@ -132,6 +155,69 @@ function extractText(msg) {
 }
 
 // --------------------------------------------------------------------------- #
+// Tool-call field extraction
+// --------------------------------------------------------------------------- #
+
+/** Read the tool NAME off a `tool.execute.{before,after}` hook input.
+ *
+ * The OpenCode plugin contract (@opencode-ai/plugin, dist/index.d.ts) is:
+ *     "tool.execute.after"?: (input: { tool: string, sessionID: string,
+ *                                      callID: string, args: any }, output) => …
+ * `input.tool` is a plain STRING. The original code read `input.tool.name`,
+ * which is `undefined` on a string, then fell through to the literal
+ * `"unknown"` — so the name was lost on 100% of events.
+ *
+ * Returns { name, ok, shape }. `ok=false` means capture FAILED (callers must
+ * record that distinguishably); `shape` is the typeof/ctor we actually saw, so
+ * a future contract change is diagnosable from the row itself.
+ */
+export function extractToolName(input) {
+  const t = input?.tool;
+  if (typeof t === "string" && t.length > 0) {
+    return { name: t, ok: true, shape: "string" };
+  }
+  // Tolerate an object form in case the contract ever moves back to `{ name }`.
+  if (t && typeof t === "object" && typeof t.name === "string" && t.name) {
+    return { name: t.name, ok: true, shape: "object.name" };
+  }
+  if (typeof input?.name === "string" && input.name) {
+    return { name: input.name, ok: true, shape: "input.name" };
+  }
+  return {
+    name: NAME_CAPTURE_FAILED,
+    ok: false,
+    shape: t === undefined ? "undefined" : Array.isArray(t) ? "array" : typeof t,
+  };
+}
+
+/** Serialize the tool arguments to a BOUNDED JSON string.
+ *
+ * `args_summary` must stay valid JSON after truncation, so we do NOT slice a
+ * JSON string mid-token (which is what produced unparseable payloads). We
+ * serialize, and if the result is over budget we replace it with a structured
+ * marker that names the keys and reports the dropped size.
+ */
+export function summarizeArgs(args) {
+  if (args == null) return { args_summary: null, args_truncated: false };
+  let s;
+  try {
+    s = JSON.stringify(args);
+  } catch {
+    return { args_summary: null, args_truncated: false, args_unserializable: true };
+  }
+  if (typeof s !== "string") return { args_summary: null, args_truncated: false };
+  if (s.length <= MAX_ARGS_SUMMARY) {
+    return { args_summary: s, args_truncated: false };
+  }
+  const keys =
+    args && typeof args === "object" && !Array.isArray(args) ? Object.keys(args) : [];
+  return {
+    args_summary: JSON.stringify({ _truncated: true, keys, bytes: s.length }),
+    args_truncated: true,
+  };
+}
+
+// --------------------------------------------------------------------------- #
 // Plugin export
 // --------------------------------------------------------------------------- #
 
@@ -139,6 +225,10 @@ export const ActivityPlugin = async ({ project, directory }) => {
   let currentSession = null;
   const seen = loadState();
   let dirty = false;
+  // callID → Date.now() at `tool.execute.before`, so `.after` can report a real
+  // duration. Bounded (insertion-ordered Map, oldest evicted) so an abandoned
+  // call can never leak memory in a long-lived OpenCode process.
+  const callStarts = new Map();
 
   return {
     // --- Session lifecycle ---
@@ -204,28 +294,60 @@ export const ActivityPlugin = async ({ project, directory }) => {
     },
 
     // --- Tool calls ---
+    // `tool.execute.before` only records a start time so `.after` can report a
+    // REAL duration. The hook `output` carries {title, output, metadata} — it
+    // has no duration and no error field, so the old code's `output.duration_ms`
+    // was always undefined (→ 0) and `success` was always hard-coded true.
+    "tool.execute.before": async (input, _output) => {
+      try {
+        const id = input?.callID;
+        if (!id) return;
+        callStarts.set(id, Date.now());
+        // Bound the map — a crashed/never-completed call must not leak.
+        if (callStarts.size > MAX_INFLIGHT_CALLS) {
+          const oldest = callStarts.keys().next().value;
+          callStarts.delete(oldest);
+        }
+      } catch {
+        // best-effort
+      }
+    },
+
     "tool.execute.after": async (input, output) => {
       try {
-        const toolName = input?.tool?.name || input?.name || "unknown";
-        const argsStr = input?.args
-          ? JSON.stringify(input.args).slice(0, MAX_ARGS_SUMMARY)
-          : "";
+        const name = extractToolName(input);
+        const args = summarizeArgs(input?.args);
+
+        const id = input?.callID;
+        const startedAt = id ? callStarts.get(id) : undefined;
+        if (id) callStarts.delete(id);
+        // duration is only known when we saw the matching `.before`; null
+        // (absent) is honest, 0 would be a measurement claim we cannot make.
         const durationMs =
-          output?.duration_ms || output?.durationMs || 0;
-        const success = output?.error ? false : true;
+          startedAt === undefined ? null : Math.max(0, Date.now() - startedAt);
+
+        const payload = {
+          // `tool.execute.after` fires only on a COMPLETED call — OpenCode
+          // throws past it on tool failure — so this hook cannot observe an
+          // error. Say that, rather than asserting success:true on every row.
+          outcome: "completed",
+          name_captured: name.ok,
+          ...(name.ok ? {} : { name_capture_shape: name.shape }),
+          ...(durationMs === null ? {} : { duration_ms: durationMs }),
+          ...args,
+          call_id: id || null,
+        };
 
         emitEvent({
           kind: "tool-call",
-          text: toolName,
+          text: name.name,
           project: project?.name || "",
           cwd: directory || "",
-          session: currentSession,
+          // sessionID is on the hook input; `currentSession` is only set by the
+          // session.created handler, which the plugin contract never calls.
+          session: input?.sessionID || currentSession,
           app: "opencode",
-          payload: {
-            duration_ms: durationMs,
-            success,
-            args_summary: argsStr,
-          },
+          payload,
         });
       } catch {
         // best-effort

--- a/scripts/collector/opencode/tests/_mockbin.py
+++ b/scripts/collector/opencode/tests/_mockbin.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""One place that writes an executable test helper, with a shebang that execs in
+BOTH tiers.
+
+🔴 THE TRAP (cost this suite 14 red tests on 2026-08-02)
+--------------------------------------------------------
+A test that writes a stub script at RUNTIME and then execs it must not use
+`#!/usr/bin/env <interp>`:
+
+  * On a NixOS dev host `/usr/bin/env` exists (it is a symlink into the
+    coreutils store path), so the stub execs and the suite is green.
+  * The nix BUILD SANDBOX — `nix build .#checks.x86_64-linux.pytests`, which is
+    the authoritative gate — has NO `/usr/bin/env`, so `execve` fails ENOENT.
+
+nixpkgs' `patchShebangs src/scripts` (see flake.nix) rewrites the shebangs of
+files that are IN THE SOURCE TREE at build time — which is why the real
+`scripts/collector/emit` works in the sandbox — but it cannot touch a file a
+test creates while running. So the defect is invisible on the dev host and only
+the sandbox can observe it. That is the two-tier hazard in RULES.md, and the
+failure reads as "my mock emit exited 1", not as "wrong shebang".
+
+Worse, in this suite the symptom was mostly SILENT: `emitEvent` swallows every
+error by design (telemetry must never crash OpenCode), so a stub that cannot
+exec produces an EMPTY log and a node exit code of 0 — the tests failed later,
+on an empty list, pointing at the wrong thing.
+
+WHY THIS FILE EXISTS AT ALL
+---------------------------
+The repo had already learned this — four separate sites carry a hand-written
+comment explaining it (`scripts/tests/test_playwright_nixos.py`,
+`scripts/tests/test_notify_failure.py`, `scripts/claude-hooks/tests/
+test_claude_notify.py`, `scripts/task-spec-drafter/tests/
+test_allowlist_covers_prompt_shapes.py`), and `scripts/browser-bridge/tests/
+test_browser_agent.py` solves it a fifth way by rewriting the shebang to
+`sys.executable`. A rule re-derived at every call site regenerates the same bug
+at the next one — which is exactly what happened here. This is that rule, once.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# POSIX `sh`, the convention already used by the other suites in this repo.
+# NOT `/usr/bin/env sh`, and not `bash` — the stub bodies below are POSIX, and
+# /bin/sh is the one interpreter path guaranteed to exist inside the sandbox.
+SH = "/bin/sh"
+SHEBANG = f"#!{SH}\n"
+
+
+def write_exec(path: Path, body: str) -> Path:
+    """Write `body` as an executable POSIX-sh script at `path`.
+
+    `body` must NOT carry its own shebang — this function owns it, so a call
+    site cannot reintroduce `/usr/bin/env`.
+    """
+    if body.lstrip().startswith("#!"):
+        raise AssertionError(
+            "write_exec owns the shebang — pass the body only. A call site that "
+            "supplies its own is how #!/usr/bin/env comes back.")
+    path.write_text(SHEBANG + body, encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def shell_does_brace_expansion() -> bool:
+    """MEASURE whether the shell node's `execSync` uses will brace-expand.
+
+    🔴 Measured, never assumed — it differs between the two tiers:
+      * dev host (NixOS): /bin/sh → bash-interactive, `{a,b}` expands to `a b`.
+      * nix build sandbox: it does NOT expand.
+
+    That matters because the pre-fix `execSync` bug had TWO effects, and only
+    one of them is universal:
+      * word-splitting + quote removal — happens in EVERY POSIX shell, so the
+        payload is mangled in both tiers;
+      * brace expansion of the unquoted JSON object into three separate
+        `b64:payload=` args — bash-only, and it is what produced the EXACT
+        stored value `args_summary:{"name":"…"}` in the 2,699 live rows (the
+        workbench runs bash).
+
+    Tests assert the universal half unconditionally and gate the bash-only
+    signature on this probe, so the claim carries the scope it was measured at.
+    """
+    import subprocess  # noqa: PLC0415 — keep this module import-cheap
+    try:
+        r = subprocess.run([SH, "-c", 'printf "%s\\n" {a,b}'],
+                           capture_output=True, text=True, timeout=10)
+    except OSError:
+        return False
+    return r.stdout.split() == ["a", "b"]
+
+
+def interpreter_is_executable() -> bool:
+    """True when the shebang interpreter really exists and is runnable.
+
+    Used by the self-check test: if this is ever False the stubs cannot exec and
+    every test that depends on one must go RED loudly, not silently empty.
+    """
+    return os.path.isfile(SH) and os.access(SH, os.X_OK)

--- a/scripts/collector/opencode/tests/test_plugin.py
+++ b/scripts/collector/opencode/tests/test_plugin.py
@@ -18,8 +18,10 @@ from pathlib import Path
 import pytest
 
 # Import collector for parse_line
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 import collector as C  # noqa: E402
+import _mockbin as M  # noqa: E402
 
 SCRIPT_DIR = Path(__file__).resolve().parent.parent
 PLUGIN_JS = SCRIPT_DIR / "activity-plugin.js"
@@ -42,12 +44,14 @@ def run_node(code: str, *, env: dict | None = None, cwd: str | None = None) -> s
 
 
 def write_mock_emit(path: Path, log_file: Path) -> None:
-    """Write a mock `emit` script that records its arguments to log_file."""
-    path.write_text(
-        f'#!/usr/bin/env bash\necho "$@" >> "{log_file}"\nexit 0\n',
-        encoding="utf-8",
-    )
-    path.chmod(0o755)
+    """Write a mock `emit` script that records its arguments to log_file.
+
+    Shebang owned by `_mockbin.write_exec`: this used to be
+    `#!/usr/bin/env bash`, which execs on a NixOS dev host but NOT in the nix
+    build sandbox (no /usr/bin/env). That was invisible until this suite was
+    added to run-tests.sh's target list.
+    """
+    M.write_exec(path, f'echo "$@" >> "{log_file}"\nexit 0\n')
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/collector/opencode/tests/test_plugin_tool_calls.py
+++ b/scripts/collector/opencode/tests/test_plugin_tool_calls.py
@@ -45,14 +45,23 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 import collector as C  # noqa: E402
+import _mockbin as M  # noqa: E402
 
 SCRIPT_DIR = Path(__file__).resolve().parent.parent
 PLUGIN_JS = SCRIPT_DIR / "activity-plugin.js"
 EMIT = SCRIPT_DIR.parent / "emit"
 
 NAME_CAPTURE_FAILED = "__name_capture_failed__"
+
+# `#!` and the quoted forms the shebang guard scans for, assembled from char
+# codes so this module's own source never contains the pattern it searches for.
+_HB = chr(35) + chr(33)
+_NEEDLES = (chr(34) + _HB, chr(39) + _HB)
 
 
 # --------------------------------------------------------------------------- #
@@ -64,15 +73,16 @@ def write_argv_recorder(path: Path, log: Path) -> None:
     One-arg-per-line is load-bearing: `echo "$@"` re-joins the arguments with
     spaces, which is exactly the corruption we are trying to detect, so a
     space-joined log cannot tell a mangled call from a clean one.
+
+    The shebang is owned by `_mockbin.write_exec` — see that module for why a
+    `#!/usr/bin/env` stub is green on the dev host and RED in the nix sandbox.
     """
-    path.write_text(
-        "#!/usr/bin/env bash\n"
+    M.write_exec(
+        path,
         f'for a in "$@"; do printf "%s\\n" "$a" >> "{log}"; done\n'
         f'printf -- "--END--\\n" >> "{log}"\n'
         "exit 0\n",
-        encoding="utf-8",
     )
-    path.chmod(0o755)
 
 
 def read_calls(log: Path) -> list[list[str]]:
@@ -146,8 +156,97 @@ def drive_tool_call(tmp_path: Path, hook_input: dict) -> list[str]:
                             "XDG_STATE_HOME": str(tmp_path / "state")})
     assert r.returncode == 0, r.stderr
     calls = read_calls(log)
+    # 🔴 An empty log is AMBIGUOUS and must not be read as "the plugin chose not
+    # to emit". `emitEvent` swallows every error by design, so node still exits
+    # 0 when the stub cannot be exec'd at all — which is precisely how a
+    # `#!/usr/bin/env` shebang failed silently in the nix sandbox while the dev
+    # host stayed green. Name the rival mechanism instead of guessing.
+    assert calls, (
+        "the mock emit produced NO output. Either the plugin did not emit, or "
+        f"the stub could not be exec'd. Interpreter {M.SH} executable: "
+        f"{M.interpreter_is_executable()}; stub first line: "
+        f"{mock.read_text().splitlines()[0]!r}")
     assert len(calls) == 1, f"expected exactly 1 emit call, got {len(calls)}: {calls}"
     return calls[0]
+
+
+# --------------------------------------------------------------------------- #
+# TIER PRECONDITION — every test below depends on a runtime-written stub being
+# EXECUTABLE. That is environment-dependent, and it differs between the dev host
+# and the nix build sandbox, so it gets its own named check rather than being
+# discovered as 14 confusing downstream failures.
+# --------------------------------------------------------------------------- #
+def test_the_mock_helper_can_actually_exec(tmp_path):
+    """Runs in BOTH tiers and must never skip.
+
+    MEASURED 2026-08-02: with `#!/usr/bin/env bash` this suite was 166/166 green
+    under `nix-shell` on the laptop and 152 passed / 14 FAILED under
+    `nix build .#checks.x86_64-linux.pytests`, because the sandbox has no
+    /usr/bin/env. The dev host structurally could not observe it.
+    """
+    assert M.interpreter_is_executable(), f"{M.SH} is not executable"
+    out = tmp_path / "out"
+    stub = M.write_exec(tmp_path / "stub", f'printf ran >> "{out}"\nexit 0\n')
+    rc = subprocess.run([str(stub)], capture_output=True, text=True, timeout=10)
+    assert rc.returncode == 0, f"stub failed to exec: {rc.stderr}"
+    assert out.read_text() == "ran"
+
+
+def test_brace_expansion_probe_agrees_with_the_shell_node_actually_uses():
+    """The probe decides which corruption shape the negative controls assert, so
+    it must describe the SAME shell node's `execSync` runs — not a guess.
+
+    MEASURED 2026-08-02: dev host (/bin/sh → bash-interactive) expands; the nix
+    build sandbox does not. Both are green because both are asserted.
+    """
+    probe = M.shell_does_brace_expansion()
+    r = run_node('import { execSync } from "child_process";'
+                 'process.stdout.write(execSync(\'printf "%s\\\\n" {a,b}\').toString());')
+    assert r.returncode == 0, r.stderr
+    assert (r.stdout.split() == ["a", "b"]) is probe, (
+        f"probe says {probe} but node's shell produced {r.stdout!r}")
+
+
+def test_no_runtime_written_shebang_uses_usr_bin_env():
+    """STRUCTURAL GUARD — the deterministic half of the fix.
+
+    A quoted `#!` anywhere in this suite's sources means a call site is writing
+    its own shebang instead of going through `_mockbin.write_exec`, which is how
+    `/usr/bin/env` came back the first time. `_mockbin` itself is exempt: it
+    owns the one shebang, and its docstring names the trap.
+    """
+    # ⚠ The needles are BUILT AT RUNTIME, character by character — including the
+    # `#!` itself. Written as literals they appear in this function's own source
+    # and the scan reports ITSELF, the same self-match that makes
+    # `pgrep -f <pattern>` find its own shell. (Measured: the first version of
+    # this guard failed on its own two source lines.)
+    needles = _NEEDLES
+    tests_dir = Path(__file__).resolve().parent
+    offenders = []
+    for py in sorted(tests_dir.glob("test_*.py")):
+        for i, line in enumerate(py.read_text(encoding="utf-8").splitlines(), 1):
+            if i == 1:
+                continue          # the module's own shebang; pytest imports, never execs
+            if any(n in line for n in needles):
+                offenders.append(f"{py.name}:{i}: {line.strip()}")
+    assert not offenders, (
+        "a test writes its own shebang — use _mockbin.write_exec instead:\n  "
+        + "\n  ".join(offenders))
+
+
+def test_positive_control_the_shebang_guard_can_detect_an_offender(tmp_path):
+    """POSITIVE CONTROL for the `not offenders` (== empty) assertion above.
+
+    An empty offender list is indistinguishable from a scan wired to nothing.
+    Feed the same matcher a file that MUST be flagged and watch the count move.
+    """
+    bad = tmp_path / "test_bad.py"
+    # Assembled at runtime for the same self-match reason as the guard itself.
+    offending = 'p.write_text(' + chr(34) + _HB + '/usr/bin/env bash' + chr(34) + ')'
+    bad.write_text("x = 1\n" + offending + "\n", encoding="utf-8")
+    hits = [i for i, line in enumerate(bad.read_text().splitlines(), 1)
+            if i != 1 and any(n in line for n in _NEEDLES)]
+    assert hits == [2], f"guard is wired to nothing — no hit on {offending!r}"
 
 
 # --------------------------------------------------------------------------- #
@@ -213,8 +312,16 @@ def test_harness_negative_control_sees_the_mangled_payload(tmp_path):
     else:
         raise AssertionError(
             f"harness cannot observe the payload corruption — {raw!r} parsed as JSON")
-    # ...and it is corrupted in exactly the shape the live rows showed.
-    assert raw == 'args_summary:{"name":"customize-opencode"}', raw
+    # UNIVERSAL half — quote removal happens in every POSIX shell, both tiers.
+    assert 'args_summary:{"name":"customize-opencode"}' in raw, raw
+    # BASH-ONLY half — brace expansion split the object into three
+    # `b64:payload=` args and emit kept the LAST, which is the exact value the
+    # 2,699 live rows carry. The workbench runs bash; the nix sandbox's /bin/sh
+    # does not brace-expand, so this is gated on a MEASURED probe, not assumed.
+    if M.shell_does_brace_expansion():
+        assert raw == 'args_summary:{"name":"customize-opencode"}', raw
+    else:
+        assert raw.startswith("{duration_ms:0,success:true,"), raw
 
 
 def test_positive_control_corrupted_arg_count_can_be_nonzero(tmp_path):
@@ -240,14 +347,27 @@ def test_positive_control_corrupted_arg_count_can_be_nonzero(tmp_path):
     # `b64:project=my proj` → +1, `b64:cwd=/tmp/dir with space` → +2.
     assert n == 3, f"positive control expected 3 corrupted entries, got {n}: {argv}"
 
-    # And the exact live signature: bash BRACE-EXPANDS the unquoted JSON object
+    # The exact live signature: bash BRACE-EXPANDS the unquoted JSON object
     # `{"duration_ms":0,"success":true,"args_summary":"…"}` into three separate
     # `b64:payload=` arguments. `emit` takes the LAST one, which is why every
     # stored payload read `args_summary:{"name":"…"}` — a fragment, not JSON.
+    #
+    # Brace expansion is bash-only, and `/bin/sh` is bash on the workbench (where
+    # the live rows were produced) but not in the nix build sandbox. So PROBE it
+    # rather than assuming, and assert the shape that shell actually produces.
     payloads = [a for a in argv if a.startswith("b64:payload=")]
-    assert len(payloads) == 3, payloads
-    assert payloads[-1] == 'b64:payload=args_summary:{"name":"customize-opencode"}', (
-        "this is the literal value the 2,699 live rows carried")
+    if M.shell_does_brace_expansion():
+        assert len(payloads) == 3, payloads
+        assert payloads[-1] == 'b64:payload=args_summary:{"name":"customize-opencode"}', (
+            "this is the literal value the 2,699 live rows carried")
+    else:
+        assert len(payloads) == 1, payloads
+        assert payloads[0].startswith("b64:payload={duration_ms:0,success:true,"), payloads
+    # Either way the payload is NOT valid JSON — that is the tier-independent
+    # claim, and it is what makes the rows unreadable.
+    for p in payloads:
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(p.split("=", 1)[1])
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/collector/opencode/tests/test_plugin_tool_calls.py
+++ b/scripts/collector/opencode/tests/test_plugin_tool_calls.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""End-to-end tests for the OpenCode plugin's tool-call capture.
+
+WHY THIS FILE EXISTS SEPARATELY FROM test_plugin.py
+---------------------------------------------------
+`test_plugin.py` tests a COPY of `emitEvent` re-typed inside the test string,
+and builds emit's argv itself with `subprocess.run([...])`. That structurally
+cannot observe either of the two bugs this file pins, because neither the real
+`emitEvent` nor the real `tool.execute.after` handler is ever executed:
+
+  BUG 1 (name lost).  `tool.execute.after` read `input.tool.name`, but the
+    OpenCode plugin contract (@opencode-ai/plugin dist/index.d.ts) passes
+    `input.tool` as a STRING. `undefined || undefined || "unknown"` → every row
+    landed with text='unknown'. Measured 2026-08-02: 2,699 / 2,699 rows
+    (source='opencode', kind='tool-call', 30d, host=workbench) were 'unknown'.
+
+  BUG 2 (payload mangled).  `emitEvent` shelled out with
+    `execSync(\\`${emit} ${args.join(" ")}\\`)`. A shell then word-split every
+    value on spaces and performed quote REMOVAL, so the JSON payload arrived as
+    `{duration_ms:0,success:true,args_summary:{"name":"x"}}` — not valid JSON —
+    and any value containing a space was torn into several bogus argv entries.
+
+Every test here drives the REAL exported functions / the REAL hook handlers via
+node, through a mock `emit` that records argv ONE ENTRY PER LINE (so argv
+splitting is directly observable rather than re-joined and hidden).
+
+HARNESS VALIDATION (RULES: "validate the harness against a known-bad state").
+`test_harness_negative_control_*` run the same harness against a vendored
+reproduction of the two pre-fix mechanisms and assert it goes RED. Until those
+pass, a green result from the tests below would be a fact about the harness.
+
+POSITIVE CONTROL (RULES: "where the reassuring answer is a zero").
+`corrupted_arg_count()` returns 0 for the fixed code. `test_positive_control_*`
+proves that counter can be non-zero by running it against the buggy emitter.
+
+Environment: needs `node` on PATH — same hard dependency as test_plugin.py
+(no skipif; the pytest gate pins the skip set, so a missing node must go RED).
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+import collector as C  # noqa: E402
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+PLUGIN_JS = SCRIPT_DIR / "activity-plugin.js"
+EMIT = SCRIPT_DIR.parent / "emit"
+
+NAME_CAPTURE_FAILED = "__name_capture_failed__"
+
+
+# --------------------------------------------------------------------------- #
+# Harness
+# --------------------------------------------------------------------------- #
+def write_argv_recorder(path: Path, log: Path) -> None:
+    """A mock `emit` that records each argv entry on its OWN line.
+
+    One-arg-per-line is load-bearing: `echo "$@"` re-joins the arguments with
+    spaces, which is exactly the corruption we are trying to detect, so a
+    space-joined log cannot tell a mangled call from a clean one.
+    """
+    path.write_text(
+        "#!/usr/bin/env bash\n"
+        f'for a in "$@"; do printf "%s\\n" "$a" >> "{log}"; done\n'
+        f'printf -- "--END--\\n" >> "{log}"\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def read_calls(log: Path) -> list[list[str]]:
+    """Parse the recorder log into a list of argv lists."""
+    if not log.exists():
+        return []
+    calls, cur = [], []
+    for line in log.read_text(encoding="utf-8").split("\n")[:-1]:
+        if line == "--END--":
+            calls.append(cur)
+            cur = []
+        else:
+            cur.append(line)
+    return calls
+
+
+def kv(argv: list[str]) -> dict[str, str]:
+    """argv → {key: value}, base64-decoding any `b64:` key (as emit would)."""
+    out: dict[str, str] = {}
+    for a in argv:
+        if "=" not in a:
+            continue
+        k, v = a.split("=", 1)
+        if k.startswith("b64:"):
+            out[k[4:]] = v
+        else:
+            out[k] = v
+    return out
+
+
+def corrupted_arg_count(argv: list[str]) -> int:
+    """Count argv entries that are NOT a well-formed `key=value` pair.
+
+    Shell word-splitting turns one `b64:payload={"a":"b c"}` argument into
+    several fragments, only the first of which contains an `=`. So the number of
+    `=`-less entries is a direct, unambiguous measure of the corruption.
+    """
+    return sum(1 for a in argv if "=" not in a)
+
+
+def run_node(code: str, *, env: dict | None = None) -> subprocess.CompletedProcess:
+    base = dict(os.environ)
+    if env:
+        base.update(env)
+    return subprocess.run(
+        ["node", "--input-type=module", "-e", code],
+        capture_output=True, text=True, env=base, timeout=30,
+    )
+
+
+TOOL_CALL_DRIVER = """
+import {{ ActivityPlugin }} from "{plugin}";
+const hooks = await ActivityPlugin({{ project: {{ name: "my proj" }},
+                                      directory: "/tmp/dir with space" }});
+const input = {input};
+if (hooks["tool.execute.before"]) {{
+  await hooks["tool.execute.before"]({{ tool: input.tool, sessionID: input.sessionID,
+                                        callID: input.callID }}, {{ args: input.args }});
+}}
+await hooks["tool.execute.after"](input, {{ title: "t", output: "o", metadata: {{}} }});
+"""
+
+
+def drive_tool_call(tmp_path: Path, hook_input: dict) -> list[str]:
+    """Run the REAL plugin's tool.execute.{before,after} and return emit's argv."""
+    log = tmp_path / "emit.log"
+    mock = tmp_path / "emit"
+    write_argv_recorder(mock, log)
+    code = TOOL_CALL_DRIVER.format(plugin=PLUGIN_JS, input=json.dumps(hook_input))
+    r = run_node(code, env={"EMIT_PATH": str(mock),
+                            "XDG_STATE_HOME": str(tmp_path / "state")})
+    assert r.returncode == 0, r.stderr
+    calls = read_calls(log)
+    assert len(calls) == 1, f"expected exactly 1 emit call, got {len(calls)}: {calls}"
+    return calls[0]
+
+
+# --------------------------------------------------------------------------- #
+# HARNESS NEGATIVE CONTROLS — the harness must go RED on the known-bad code.
+# --------------------------------------------------------------------------- #
+BUGGY_EMITTER = """
+import {{ execSync }} from "child_process";
+const EMIT = "{mock}";
+// Verbatim reproduction of the PRE-FIX emitEvent + name extraction.
+function emitEvent({{ kind, text, project, cwd, payload }}) {{
+  const args = ["source=opencode", `kind=${{kind}}`];
+  if (text != null) args.push(`b64:text=${{String(text)}}`);
+  if (project != null) args.push(`b64:project=${{String(project)}}`);
+  if (cwd != null) args.push(`b64:cwd=${{String(cwd)}}`);
+  if (payload != null) {{
+    const p = typeof payload === "string" ? payload : JSON.stringify(payload);
+    args.push(`b64:payload=${{p}}`);
+  }}
+  execSync(`${{EMIT}} ${{args.join(" ")}}`, {{ stdio: "ignore" }});
+}}
+const input = {input};
+const toolName = input?.tool?.name || input?.name || "unknown";
+const argsStr = input?.args ? JSON.stringify(input.args).slice(0, 200) : "";
+emitEvent({{ kind: "tool-call", text: toolName,
+             project: "my proj", cwd: "/tmp/dir with space",
+             payload: {{ duration_ms: 0, success: true, args_summary: argsStr }} }});
+"""
+
+KNOWN_BAD_INPUT = {"tool": "bash", "sessionID": "s1", "callID": "c1",
+                   "args": {"name": "customize-opencode"}}
+
+
+def _drive_buggy(tmp_path: Path) -> list[str]:
+    log = tmp_path / "emit.log"
+    mock = tmp_path / "emit"
+    write_argv_recorder(mock, log)
+    r = run_node(BUGGY_EMITTER.format(mock=mock, input=json.dumps(KNOWN_BAD_INPUT)))
+    assert r.returncode == 0, r.stderr
+    calls = read_calls(log)
+    assert len(calls) == 1
+    return calls[0]
+
+
+def test_harness_negative_control_sees_the_lost_tool_name(tmp_path):
+    """KNOWN-BAD: the pre-fix extraction must be observed as 'unknown'.
+
+    If this asserts something else, the harness is not reading `text` and every
+    green name assertion below is meaningless.
+    """
+    fields = kv(_drive_buggy(tmp_path))
+    assert fields["text"] == "unknown", (
+        "harness cannot observe the tool name — it did not reproduce the known bug")
+
+
+def test_harness_negative_control_sees_the_mangled_payload(tmp_path):
+    """KNOWN-BAD: the pre-fix shell join must produce UNPARSEABLE payload JSON."""
+    fields = kv(_drive_buggy(tmp_path))
+    raw = fields["payload"]
+    try:
+        json.loads(raw)
+    except json.JSONDecodeError:
+        pass
+    else:
+        raise AssertionError(
+            f"harness cannot observe the payload corruption — {raw!r} parsed as JSON")
+    # ...and it is corrupted in exactly the shape the live rows showed.
+    assert raw == 'args_summary:{"name":"customize-opencode"}', raw
+
+
+def test_positive_control_corrupted_arg_count_can_be_nonzero(tmp_path):
+    """POSITIVE CONTROL for the zero asserted in test_no_argv_corruption.
+
+    A `0` from corrupted_arg_count() is only evidence if the counter can move.
+    Drive it against the buggy shell path and require a NON-ZERO count.
+
+    ⚠ The FIRST version of this control asserted on a spacey value inside
+    `args_summary` and measured 0 — because JSON.stringify wraps string values
+    in `"`, so the shell keeps those spaces in one word. The splitting hits the
+    fields the plugin does NOT wrap in quotes: `project` and `cwd`. Had this
+    control been omitted, `test_no_argv_corruption`'s 0 would have been read as
+    proof while the counter was blind to the case it was built for.
+    """
+    log = tmp_path / "emit.log"
+    mock = tmp_path / "emit"
+    write_argv_recorder(mock, log)
+    r = run_node(BUGGY_EMITTER.format(mock=mock, input=json.dumps(KNOWN_BAD_INPUT)))
+    assert r.returncode == 0, r.stderr
+    argv = read_calls(log)[0]
+    n = corrupted_arg_count(argv)
+    # `b64:project=my proj` → +1, `b64:cwd=/tmp/dir with space` → +2.
+    assert n == 3, f"positive control expected 3 corrupted entries, got {n}: {argv}"
+
+    # And the exact live signature: bash BRACE-EXPANDS the unquoted JSON object
+    # `{"duration_ms":0,"success":true,"args_summary":"…"}` into three separate
+    # `b64:payload=` arguments. `emit` takes the LAST one, which is why every
+    # stored payload read `args_summary:{"name":"…"}` — a fragment, not JSON.
+    payloads = [a for a in argv if a.startswith("b64:payload=")]
+    assert len(payloads) == 3, payloads
+    assert payloads[-1] == 'b64:payload=args_summary:{"name":"customize-opencode"}', (
+        "this is the literal value the 2,699 live rows carried")
+
+
+# --------------------------------------------------------------------------- #
+# BUG 1 — the tool name
+# --------------------------------------------------------------------------- #
+def test_tool_name_captured_from_string_input(tmp_path):
+    """RED at origin/main (text='unknown'), GREEN here.
+
+    `input.tool` is a STRING per the OpenCode plugin contract.
+    """
+    fields = kv(drive_tool_call(tmp_path, KNOWN_BAD_INPUT))
+    assert fields["text"] == "bash"
+    assert json.loads(fields["payload"])["name_captured"] is True
+
+
+def test_tool_name_captured_from_object_form(tmp_path):
+    """Tolerate a future/legacy `{name}` object shape without losing the name."""
+    fields = kv(drive_tool_call(
+        tmp_path, {"tool": {"name": "webfetch"}, "sessionID": "s", "callID": "c"}))
+    assert fields["text"] == "webfetch"
+    assert json.loads(fields["payload"])["name_captured"] is True
+
+
+def test_capture_failure_is_distinguishable_from_a_real_tool(tmp_path):
+    """A genuine capture failure must NOT look like a tool called 'unknown'.
+
+    This is the rule the original violated: `unknown` is a plausible tool name,
+    so a 100%-broken capture was indistinguishable from real data.
+    """
+    fields = kv(drive_tool_call(
+        tmp_path, {"sessionID": "s", "callID": "c", "args": {}}))
+    assert fields["text"] == NAME_CAPTURE_FAILED
+    p = json.loads(fields["payload"])
+    assert p["name_captured"] is False
+    assert p["name_capture_shape"] == "undefined"
+
+
+def test_a_tool_literally_named_unknown_is_not_a_failure(tmp_path):
+    """The discriminator works in the other direction too."""
+    fields = kv(drive_tool_call(
+        tmp_path, {"tool": "unknown", "sessionID": "s", "callID": "c"}))
+    assert fields["text"] == "unknown"
+    assert json.loads(fields["payload"])["name_captured"] is True
+
+
+# --------------------------------------------------------------------------- #
+# BUG 2 — argv / payload integrity
+# --------------------------------------------------------------------------- #
+def test_no_argv_corruption(tmp_path):
+    """RED at origin/main. Zero paired with the positive control above."""
+    argv = drive_tool_call(tmp_path, {
+        "tool": "bash", "sessionID": "s", "callID": "c",
+        "args": {"command": "echo hello there world", "description": "a b c"}})
+    assert corrupted_arg_count(argv) == 0, argv
+    # one argv entry per emit key — nothing was split
+    assert len(argv) == len(kv(argv))
+
+
+def test_payload_is_valid_json_with_spaces_and_quotes(tmp_path):
+    """RED at origin/main (payload was unparseable)."""
+    fields = kv(drive_tool_call(tmp_path, {
+        "tool": "bash", "sessionID": "s1", "callID": "c1",
+        "args": {"command": 'grep -n "foo bar" *.py', "cwd": "/tmp/dir with space"}}))
+    p = json.loads(fields["payload"])          # must not raise
+    assert json.loads(p["args_summary"]) == {
+        "command": 'grep -n "foo bar" *.py', "cwd": "/tmp/dir with space"}
+    assert p["args_truncated"] is False
+
+
+def test_free_text_fields_with_spaces_survive(tmp_path):
+    """`project`/`cwd` contained spaces in the driver — they must arrive intact."""
+    fields = kv(drive_tool_call(tmp_path, KNOWN_BAD_INPUT))
+    assert fields["project"] == "my proj"
+    assert fields["cwd"] == "/tmp/dir with space"
+    assert fields["session"] == "s1"           # from input.sessionID, not null
+
+
+def test_args_truncation_keeps_payload_parseable(tmp_path):
+    """Over-budget args must degrade to a STRUCTURED marker, not a torn JSON slice."""
+    fields = kv(drive_tool_call(tmp_path, {
+        "tool": "write", "sessionID": "s", "callID": "c",
+        "args": {"content": "x" * 5000, "path": "/tmp/f"}}))
+    p = json.loads(fields["payload"])
+    assert p["args_truncated"] is True
+    marker = json.loads(p["args_summary"])     # must not raise
+    assert marker["_truncated"] is True
+    assert sorted(marker["keys"]) == ["content", "path"]
+    assert marker["bytes"] > 5000
+
+
+def test_duration_is_measured_not_hardcoded_zero(tmp_path):
+    """The old payload always said duration_ms=0 / success=true — both fabricated.
+
+    `tool.execute.after`'s `output` is {title, output, metadata}: it carries
+    neither a duration nor an error, so those were unmeasured claims.
+    """
+    fields = kv(drive_tool_call(tmp_path, KNOWN_BAD_INPUT))
+    p = json.loads(fields["payload"])
+    assert "duration_ms" in p and isinstance(p["duration_ms"], int)
+    assert "success" not in p, "success:true was never observable from this hook"
+    assert p["outcome"] == "completed"
+    assert p["call_id"] == "c1"
+
+
+def test_duration_absent_when_before_hook_never_fired(tmp_path):
+    """No `.before` → no start time → duration must be ABSENT, never 0."""
+    log = tmp_path / "emit.log"
+    mock = tmp_path / "emit"
+    write_argv_recorder(mock, log)
+    code = f'''
+import {{ ActivityPlugin }} from "{PLUGIN_JS}";
+const hooks = await ActivityPlugin({{ project: {{ name: "p" }}, directory: "/tmp" }});
+await hooks["tool.execute.after"](
+  {{ tool: "bash", sessionID: "s", callID: "orphan" }},
+  {{ title: "t", output: "o", metadata: {{}} }});
+'''
+    r = run_node(code, env={"EMIT_PATH": str(mock),
+                            "XDG_STATE_HOME": str(tmp_path / "state")})
+    assert r.returncode == 0, r.stderr
+    p = json.loads(kv(read_calls(log)[0])["payload"])
+    assert "duration_ms" not in p
+
+
+# --------------------------------------------------------------------------- #
+# Full round-trip through the REAL emit → collector.parse_line
+# --------------------------------------------------------------------------- #
+def test_roundtrip_through_real_emit_and_collector(tmp_path):
+    """The whole chain: real plugin → real emit → real collector.parse_line.
+
+    This is the path the 2,699 bad rows took. RED at origin/main: parse_line
+    yields text='unknown' and an unparseable payload.
+    """
+    assert EMIT.exists(), "emit script missing — this test must not silently pass"
+    spool = tmp_path / "spool"
+    spool.mkdir()
+    code = TOOL_CALL_DRIVER.format(plugin=PLUGIN_JS, input=json.dumps({
+        "tool": "bash", "sessionID": "sess-9", "callID": "c9",
+        "args": {"command": 'echo "hi there" && ls -la', "timeout": 5000}}))
+    r = run_node(code, env={"EMIT_PATH": str(EMIT),
+                            "ACTIVITY_SPOOL_DIR": str(spool),
+                            "XDG_STATE_HOME": str(tmp_path / "state")})
+    assert r.returncode == 0, r.stderr
+
+    lines = [l for l in (spool / "current.log").read_text().splitlines() if l]
+    assert len(lines) == 1, lines
+    ev = C.parse_line(lines[0])
+    assert ev is not None
+    assert ev["source"] == "opencode"
+    assert ev["kind"] == "tool-call"
+    assert ev["text"] == "bash"               # was 'unknown' for all 2,699 rows
+    assert ev["session"] == "sess-9"
+    p = json.loads(ev["payload"])             # was unparseable
+    assert json.loads(p["args_summary"])["command"] == 'echo "hi there" && ls -la'
+    assert p["name_captured"] is True
+
+
+def test_b64_values_are_real_base64(tmp_path):
+    """Guard the emit contract itself: `b64:` keys must decode.
+
+    INVARIANT GUARD (not a regression test) — this held before the fix too. It
+    is here because execFileSync bypasses the shell, and a future refactor that
+    pre-encodes on the JS side would double-encode silently.
+    """
+    spool = tmp_path / "spool"
+    spool.mkdir()
+    code = TOOL_CALL_DRIVER.format(plugin=PLUGIN_JS, input=json.dumps(
+        {"tool": "bash", "sessionID": "s", "callID": "c", "args": {"a": 1}}))
+    r = run_node(code, env={"EMIT_PATH": str(EMIT),
+                            "ACTIVITY_SPOOL_DIR": str(spool),
+                            "XDG_STATE_HOME": str(tmp_path / "state")})
+    assert r.returncode == 0, r.stderr
+    line = (spool / "current.log").read_text().splitlines()[0]
+    for field in line.split("\t"):
+        if field.startswith("b64:"):
+            base64.b64decode(field.split("=", 1)[1], validate=True)

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -167,6 +167,11 @@ HERMETIC_TARGETS=(
   scripts/collector/claude/tests
   scripts/collector/i3/tests
   scripts/collector/browser-ext/tests
+  # Added 2026-08-02. This suite existed since the OpenCode source landed and was
+  # never in this list — 166 tests that no gate ran. That is why a plugin whose
+  # `tool.execute.after` handler mis-read the hook contract shipped and produced
+  # 2,699 rows of `text='unknown'` before anyone noticed.
+  scripts/collector/opencode/tests
   scripts/browser-bridge/tests
   scripts/validation/tests
   scripts/session-analysis/tests


### PR DESCRIPTION
## The bug

All **2,699** `source='opencode' kind='tool-call'` rows on the workbench carry `text='unknown'`, and a payload that is not valid JSON. OpenCode tool distribution has never been measurable, so we cannot say whether opencode has the same Bash-over-Grep bias Claude Code demonstrably has.

## Root cause — two independent defects

**1. The tool name was never read.** `tool.execute.after` did `input?.tool?.name || input?.name || "unknown"`. The installed contract (`~/.config/opencode/node_modules/@opencode-ai/plugin/dist/index.d.ts:249`) is:

```ts
"tool.execute.after"?: (input: { tool: string; sessionID: string; callID: string; args: any },
                        output: { title: string; output: string; metadata: any }) => Promise<void>;
```

`input.tool` is a **string**, so `.name` is `undefined` on every single call and the literal fallback won 100% of the time.

**2. The payload was shell-mangled.** `emitEvent` ran `execSync` with the arguments joined into one shell string, values unquoted. Bash **brace-expanded** the unquoted JSON object into three separate `b64:payload=` arguments; `emit` keeps the last. Reproduced byte-for-byte in `test_harness_negative_control_sees_the_mangled_payload`:

```
b64:payload=duration_ms:0
b64:payload=success:true
b64:payload=args_summary:{"name":"customize-opencode"}     <- exactly the stored value
```

Values with spaces were word-split too: `b64:cwd=/tmp/dir with space` → 3 argv entries.

## The fix

* `execFileSync(emit, argv)` — no shell, no splitting, no quote removal.
* `extractToolName()` reads the string form (tolerating a `{name}` object form for contract drift).
* **A capture failure is now distinguishable from a real tool.** `unknown` was a plausible tool name; failures now write the namespaced sentinel `__name_capture_failed__` plus `name_captured:false` and `name_capture_shape:<typeof>`. A tool genuinely *called* `unknown` still records `name_captured:true`.
* `duration_ms` was `output.duration_ms` — a field that does not exist on this hook — so it was **always 0**. Now measured across `tool.execute.before` → `.after` via a bounded `callID` map, and **absent** (not 0) when unmeasurable.
* `success:true` was hard-coded; the hook cannot observe a failure at all (OpenCode throws past it). Replaced with `outcome:"completed"`.
* `session` came from `currentSession`, set only by a `session.created` handler the contract never calls. Now `input.sessionID`.
* `args_summary` was a raw `.slice(0,200)` of a JSON string — invalid JSON whenever it truncated. Now degrades to `{"_truncated":true,"keys":[…],"bytes":N}`.

## Why this shipped: the suite was never gated

`scripts/collector/opencode/tests` was **not in `run-tests.sh`'s target list** — 166 tests that no gate has ever run. Added. **This is the only line of `run-tests.sh` this PR touches: the pytest dir list (~line 172).** `MIN_TESTS` deliberately untouched.

The pre-existing `test_plugin.py` could not have caught either bug: it tests a *copy* of `emitEvent` re-typed inside the test string and builds emit's argv itself with `subprocess.run([...])`, so neither the real function nor the real hook handler is ever executed. Both of its tool-call tests pass unchanged against the broken code.

## Harness validation + control pair

**Negative controls** (harness must go RED on known-bad code) — a vendored reproduction of the two pre-fix mechanisms:

| control | asserts | result |
|---|---|---|
| `test_harness_negative_control_sees_the_lost_tool_name` | pre-fix extraction yields `text == 'unknown'` | passes → harness can observe the name |
| `test_harness_negative_control_sees_the_mangled_payload` | pre-fix payload is **unparseable** and equals the live value verbatim | passes → harness can observe the corruption |

**Positive control** for the reassuring zero — `corrupted_arg_count()` returns 0 for the fixed code:

| | corrupted argv entries |
|---|---|
| positive control (buggy emitter) | **3** (`proj`, `with`, `space`) + 3 `b64:payload=` fragments |
| under test (fixed) | **0** |

⚠ Worth recording: my **first** positive control measured **0** and failed. It asserted on a spacey value inside `args_summary`, but `JSON.stringify` wraps string values in `"`, so the shell preserves those spaces. The splitting hits the fields the plugin does *not* quote (`project`, `cwd`). Without that control, `test_no_argv_corruption`'s 0 would have been read as proof while the counter was blind to the case it exists for.

## ⚠ Correction — the first push was RED on the authoritative gate

The original version of this section reported **`4568 collected / 4567 passed / 0 failed`** as "the full gate". That was the **dev-host tier** (`nix-shell` with the flake's package set). It is not the gate. The authoritative gate is **`nix build .#checks.x86_64-linux.pytests`**, and on the first push it was **RED**.

I reproduced it independently before fixing anything, and ran the discriminating control the coordinator also ran: the branch fails **alone**, so it is not a cross-PR interaction.

### Why the dev host could not see it

Both `write_mock_emit` (pre-existing) and `write_argv_recorder` (new) write a stub script **at runtime** with `#!/usr/bin/env bash`.

* NixOS dev host — `/usr/bin/env` exists (`lrwxrwxrwx /usr/bin/env -> /nix/store/…-coreutils-9.10/bin/env`) → the stub execs, suite green.
* nix build sandbox — **no `/usr/bin/env`** → `execve` fails `ENOENT`.

nixpkgs' `patchShebangs src/scripts` (flake.nix) rewrites shebangs of files **in the source tree** — which is why the real `scripts/collector/emit` works in the sandbox — but it cannot touch a file a test creates while running. The defect was structurally unobservable in the tier I measured.

It was also mostly **silent**: `emitEvent` swallows every error by design, so node still exits 0 when the stub cannot exec; tests then failed on an empty list (`IndexError`), pointing at the wrong thing.

### The fix — deterministic, one place, assertions untouched

New `tests/_mockbin.py` owns the shebang (`/bin/sh`, POSIX bodies — the convention **four** other suites in this repo already carry as hand-written comments) and **raises** if a call site supplies its own. Both call sites go through it. No assertion was weakened.

Added so the class cannot return:
* `test_the_mock_helper_can_actually_exec` — named tier precondition, runs in both tiers, never skips.
* `test_no_runtime_written_shebang_uses_usr_bin_env` — structural scan of the suite's sources, **with a positive control** proving the scan can flag an offender. Its needles are assembled from char codes: the first version matched its **own** source lines (the `pgrep -f` self-match).
* `drive_tool_call` now names the rival mechanism on an empty log instead of letting `IndexError` misreport it.

### Two further defects the sandbox exposed — neither fixed by weakening

**1. `_mockbin.py` was untracked**, so the flake source omitted it (flakes only see tracked files) and the run collapsed to `opencode collected=2 errors=2` — **168 tests silently not collected**, while the global floor (2850) was nowhere near tripping. Caught by **comparing collected counts across runs**, not by an exit code. Staged.

**2. The corruption's SHAPE is shell-dependent.** The pre-fix `execSync` bug has two effects and only one is universal:
* word-splitting + quote removal — every POSIX shell, **both tiers**;
* **brace expansion** of the unquoted JSON object into three `b64:payload=` args — **bash only**, and it is what produced the exact stored value `args_summary:{"name":"…"}` in the 2,699 live rows (the workbench runs bash). The sandbox's `/bin/sh` does **not** brace-expand.

The negative controls now assert the universal half unconditionally and gate the bash-only signature on `_mockbin.shell_does_brace_expansion()` — a **measured probe**, with `test_brace_expansion_probe_agrees_with_the_shell_node_actually_uses` pinning that the probe describes the same shell node's `execSync` actually runs. Both shapes are asserted; neither branch is a skip.

## Both tiers, both numbers

| tier | command | result |
|---|---|---|
| dev host | `nix-shell … python -m pytest scripts/collector/opencode/tests/` | **170 passed**, 0 skipped |
| **authoritative** | `nix build .#checks.x86_64-linux.pytests` | opencode **collected=170 passed=170 skipped=0**<br>**TOTAL collected=4543 passed=4542 skipped=1 failed=0 · RESULT: PASS** |

Progression on the authoritative gate:

| revision | opencode | TOTAL | verdict |
|---|---|---|---|
| first push `8306719` | 166 / 152 passed / **14 failed** | 4539 / 4524 / 14 failed | **FAIL** |
| helper added but untracked | **collected=2 / errors=2** | 4375 / 4372 / 2 failed | **FAIL** (collection collapse) |
| `403f65f` (this branch) | 170 / **170 passed** | 4543 / 4542 / 1 skipped / **0 failed** | **PASS** |

`origin/main` baseline in this tier = **4373** collected (the opencode suite was not in the target list at all).

## Red/green matrix — SANDBOX TIER

Base ref **`origin/main` = 73f5ec0**. Method: at `403f65f`, `git checkout origin/main -- scripts/collector/opencode/activity-plugin.js`, run `nix build .#checks.x86_64-linux.pytests`, restore.

| | plugin at 73f5ec0 | plugin at 403f65f |
|---|---|---|
| `scripts/collector/opencode/tests` | collected=170, 159 passed, **11 failed** | collected=170, **170 passed** |
| TOTAL | 4543 / 4531 / **11 failed** · FAIL | 4543 / 4542 / **0 failed** · PASS |

The 11 red-at-base, in the authoritative tier:

```
test_tool_name_captured_from_string_input
test_tool_name_captured_from_object_form
test_capture_failure_is_distinguishable_from_a_real_tool
test_a_tool_literally_named_unknown_is_not_a_failure
test_no_argv_corruption
test_payload_is_valid_json_with_spaces_and_quotes
test_free_text_fields_with_spaces_survive
test_args_truncation_keeps_payload_parseable
test_duration_is_measured_not_hardcoded_zero
test_duration_absent_when_before_hook_never_fired
test_roundtrip_through_real_emit_and_collector
```

Green at both are the 2 harness negative controls + 2 positive controls (they drive the **vendored buggy** code, so they must be green in both — correct by construction), and 4 tier/structural guards + `test_b64_values_are_real_base64`, all **labelled in-file** as preconditions/invariant guards, not regression coverage.

**Crucially, the harness negative controls now pass in the tier that gates merges.** On the first push they were 2 of the 14 failures — so the harness had never been validated where it counts, and every surviving green there proved nothing.

## Control pairs re-confirmed in the sandbox tier

All are pinned equalities that passed inside `nix build`:

| counter | positive control | under test |
|---|---|---|
| `corrupted_arg_count` (argv entries with no `=`) | **3** — universal, asserted unconditionally in both tiers | **0** |
| `b64:payload=` fragments from the buggy emitter | **3** on the dev host (bash brace-expands) / **1** in the sandbox — branch chosen by the measured probe, both asserted | n/a |
| payload parses as JSON | every fragment raises `JSONDecodeError` (tier-independent) | valid JSON |

## Adjacent finding (not fixed here — would re-block this PR)

`scripts/dl-router/tests` is **also absent** from `run-tests.sh`'s target list, and `test_setup_script.py:134` writes a `#!/usr/bin/env bash` stub and execs it — the same latent sandbox failure. Adding that suite is a separate change; flagging it rather than expanding this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Existing rows

`activity.events` is append-only with a 180d TTL. **No backfill, no DELETE, no ALTER was attempted.** The 2,699 malformed rows stay until they expire. **Readers must tolerate both shapes**: treat `text='unknown'` with a non-JSON `payload` as pre-fix garbage. The clean discriminator is `payload.name_captured`, which only exists post-fix.

## Not verified

The fixed plugin has **not** been exercised by a real OpenCode session — that needs a `home-manager switch` plus an opencode run, and this task was explicitly told not to switch or restart anything. Every claim above rests on the real hook handlers being driven under node through the real `emit` into the real `collector.parse_line`, against the hook shape taken from the installed typings.

