### PR TITLE
fix(insights): reported a HEALTHY pipeline as "telemetry unavailable" and exited 0

### DIFF
--- a/scripts/session-analysis/insights.py
+++ b/scripts/session-analysis/insights.py
@@ -36,9 +36,23 @@ Usage:
   --html   ALSO write a styled, self-contained HTML report to PATH
            (default when the flag is given bare: ~/.claude/usage-data/insights-<today>.html)
 
-Degrades gracefully: if telemetry is unconfigured/unreachable it prints a clear
-message and exits 0 (only a real error — e.g. an unwritable --html path — is
-non-zero), exactly like initiative-scan.
+FAILURE REPORTING (🔴 this is load-bearing — see the exit codes below):
+"telemetry is switched off", "the server is unreachable" and "the server
+rejected my query" are THREE DIFFERENT FACTS. Until 2026-08-02 this tool
+collapsed all three into one `TelemetryUnavailable` and exited 0, so a healthy
+pipeline whose message-stream query was being OvercommitTracker-killed by
+ClickHouse reported "telemetry unavailable; nothing to report" and no caller
+could tell. (That query is also gone now — see the block above `q_summaries`.)
+
+    exit 0  ok                — the full report
+    exit 0  not-configured    — no CLICKHOUSE_URL; the documented optional path
+    exit 3  unreachable       — could not reach the server at all
+    exit 4  query-failed      — server reachable, ALL queries rejected
+    exit 5  degraded          — server reachable, SOME queries failed; the
+                                report renders with a loud banner naming which
+                                query died and which sections are missing
+
+`--json` always carries `status`, and `error`/`errors`/`failed_queries`.
 """
 from __future__ import annotations
 
@@ -69,7 +83,50 @@ _LEVERAGE_ORDER = {lv: i for i, lv in enumerate(SCH.LEVERAGES)}
 
 
 class TelemetryUnavailable(Exception):
-    """Telemetry is not configured / not reachable — degrade, don't crash."""
+    """Base class. Kept so older `except TelemetryUnavailable` callers still work.
+
+    🔴 Do NOT catch this to mean "telemetry is off". The three cases below are
+    different facts and must be reported (and exited) differently — conflating
+    them is the bug this taxonomy exists to kill.
+    """
+
+
+class TelemetryNotConfigured(TelemetryUnavailable):
+    """No CLICKHOUSE_URL in the environment. Not a failure: the tool is
+    optional and this is the documented graceful path (exit 0)."""
+
+
+class TelemetryUnreachable(TelemetryUnavailable):
+    """The ClickHouse server could not be reached (connect/DNS/timeout).
+    A genuine failure — exit non-zero."""
+
+
+class TelemetryQueryFailed(TelemetryUnavailable):
+    """The server answered and REJECTED our queries. The pipeline is up and the
+    report is wrong; the loudest possible failure. Exit non-zero."""
+
+    def __init__(self, message: str, errors: dict[str, str] | None = None):
+        super().__init__(message)
+        self.errors = errors or {}
+
+
+# Exit codes — distinct so a caller/cron can branch without parsing text.
+EXIT_OK = 0
+EXIT_NOT_CONFIGURED = 0     # documented graceful degradation, not a failure
+EXIT_UNREACHABLE = 3
+EXIT_QUERY_FAILED = 4
+EXIT_DEGRADED = 5           # some queries succeeded, some failed
+
+# Which report sections each query feeds, so a partial failure can say exactly
+# what is missing instead of silently rendering zeros.
+QUERY_SECTIONS = {
+    "summaries": "ACTIVITY totals, TOOLS, LANGUAGES, PROJECTS, PER-HOST session counts",
+    "messages": "message counts, PER-HOST messages, ACTIVITY OVER TIME",
+    "commands": "TOP SLASH-COMMANDS",
+    "first_words": "TOP PROMPT FIRST-WORDS",
+    "themes": "TOP PROMPT THEMES",
+    "insights": "OUTCOMES, AUTOMATION CANDIDATES, RECURRING TOIL, WORKFLOW GAPS (Layer B)",
+}
 
 
 # --------------------------------------------------------------------------- #
@@ -135,6 +192,52 @@ def _host_filter(host: str | None) -> str:
     return f" AND host={Q.sql_quote(host)}" if host else ""
 
 
+# --------------------------------------------------------------------------- #
+# 🔴 WHY THE MESSAGE STREAM IS AGGREGATED SERVER-SIDE
+# --------------------------------------------------------------------------- #
+# This tool used to stream the whole `text` column to the client and count in
+# Python. `activity.events.text` is wide (mean 2,498 B, max 27,136 B over 14d —
+# measured 2026-08-02) and the `activity` ClickHouse runs under a hard 2.5 GiB
+# total-memory ceiling, so materializing those strings into an HTTP result set
+# is what the server cannot do. That is the whole bug: the report said
+# "telemetry unavailable" while the pipeline was healthy.
+#
+# MEASURED on the laptop → nebula endpoint, 2026-08-02, interleaved with
+# `SELECT 1` (0.04s) and `count()` (0.20s) controls so a server outage could not
+# be mistaken for a query problem:
+#
+#   ROW STREAM  `SELECT kind, host, text, ts … ts>now()-N`
+#      1d / 2d / 4d / 7d / 14d ....... TIMEOUT, every one, at 60s
+#      14d, second attempt ............ HTTP 500 `Code: 241 MEMORY_LIMIT_EXCEEDED
+#                                       … (while reading column text)`
+#      14d + max_block_size=1024 ...... TIMEOUT
+#      14d + max_threads=1 ............ TIMEOUT
+#      14d + both ..................... TIMEOUT
+#   SERVER-SIDE AGGREGATES (what this file now issues, same 14d window)
+#      counts by kind/host/day ........ 0.59s,  56 rows,  3,581 B
+#      top slash-commands ............. 0.51s,  30 rows,    986 B
+#      prompt first-words ............. 0.46s,  20 rows,    466 B
+#      10 × countIf(match(…)) themes .. 0.72s,   1 row,     120 B
+#
+# So: capping block size / threads does NOT fix it (an earlier single
+# observation suggested it did and did not reproduce — one measurement is not a
+# general claim), and neither does chunking by day, because even a 1-day slice
+# times out. Not sending 15.8 MB of prompt text over the wire does fix it, and
+# it drops the payload for these sections from ~15.8 MB to ~5 KB.
+#
+# SEMANTICS: the SQL below is generated FROM the Python definitions above
+# (THEMES / _WORD_RX) so the two cannot drift, and was cross-checked against the
+# Python implementation over 200 real rows — themes, first-words and
+# slash-command tokens all matched EXACTLY. Caveat on that check: only 4 of the
+# 200 sampled rows were slash-commands, so the command-token comparison is thin.
+#
+# Ordering is the one deliberate difference: ties used to fall out in row order
+# (which was never pinned — the old query had no ORDER BY, so the "top 15" was
+# not reproducible run to run). Ties now break on the key, ascending.
+_WORD_PATTERN = "[a-zA-Z']+"           # must stay in step with _WORD_RX above
+_TOP_N_SQL = 200                       # generous head; the report renders 15
+
+
 def q_summaries(win: int, host: str | None = None) -> str:
     """Latest session-summary per session (argMax on ingested_at — the read contract)."""
     return (
@@ -155,12 +258,52 @@ def q_summaries(win: int, host: str | None = None) -> str:
     )
 
 
-def q_messages(win: int, host: str | None = None) -> str:
-    """The user's typed prompts + slash-commands over the window."""
-    return (
-        "SELECT kind, host, text, ts FROM activity.events "
-        f"WHERE source='claude' AND kind IN ('prompt','command') AND ts>now()-{win}{_host_filter(host)}"
-    )
+def _msg_where(win: int, host: str | None, kind: str | None = None) -> str:
+    k = f" AND kind={Q.sql_quote(kind)}" if kind else " AND kind IN ('prompt','command')"
+    return (f"WHERE source='claude'{k} AND ts>now()-{win}{_host_filter(host)}")
+
+
+def q_message_counts(win: int, host: str | None = None) -> str:
+    """Message volume per (kind, host, day) — feeds every message COUNT in the
+    report (totals, per-host, activity-by-day). Tens of rows, no `text`."""
+    return ("SELECT kind, host, toDate(ts) AS day, count() AS n "
+            f"FROM activity.events {_msg_where(win, host)} "
+            "GROUP BY kind, host, day ORDER BY day ASC, host ASC, kind ASC")
+
+
+def q_top_commands(win: int, host: str | None = None, limit: int = _TOP_N_SQL) -> str:
+    """Slash-command leaderboard. `splitByWhitespace(trimBoth(text))[1]` is the
+    SQL twin of `_first_token` (Python's str.split() also splits on ANY
+    whitespace — splitByChar(' ') would NOT be equivalent)."""
+    return ("SELECT splitByWhitespace(trimBoth(text))[1] AS cmd, count() AS n "
+            f"FROM activity.events {_msg_where(win, host, 'command')} "
+            f"GROUP BY cmd ORDER BY n DESC, cmd ASC LIMIT {int(limit)}")
+
+
+def q_first_words(win: int, host: str | None = None, limit: int = _TOP_N_SQL) -> str:
+    """First word of each typed prompt. `extract` returns the FIRST match of the
+    pattern, which is what `_WORD_RX.findall(...)[0]` does."""
+    return (f"SELECT lower(extract(text, {Q.sql_quote(_WORD_PATTERN)})) AS w, count() AS n "
+            f"FROM activity.events {_msg_where(win, host, 'prompt')} "
+            f"GROUP BY w ORDER BY n DESC, w ASC LIMIT {int(limit)}")
+
+
+def q_prompt_themes(win: int, host: str | None = None) -> str:
+    """One row of 10 `countIf(match(lower(text), <THEMES pattern>))` columns.
+
+    Generated from THEMES so the SQL and the Python regexes cannot drift. The
+    aliases are positional (`t0`…`tN`) because a theme name like `deploy/infra`
+    is not a bare SQL identifier; `theme_aliases()` is the decoder.
+    """
+    cols = ", ".join(f"countIf(match(lower(text), {Q.sql_quote(pat)})) AS t{i}"
+                     for i, pat in enumerate(THEMES.values()))
+    return (f"SELECT {cols} FROM activity.events "
+            f"{_msg_where(win, host, 'prompt')}")
+
+
+def theme_aliases() -> list[str]:
+    """Positional SQL alias → theme name, in THEMES declaration order."""
+    return list(THEMES)
 
 
 def q_insights(win: int, host: str | None = None) -> str:
@@ -172,6 +315,60 @@ def q_insights(win: int, host: str | None = None) -> str:
         f"WHERE source='claude' AND kind='session-insight' AND ts>now()-{win}{_host_filter(host)} "
         "GROUP BY session"
     )
+
+
+# --------------------------------------------------------------------------- #
+# Message-stream aggregation from the SERVER-SIDE rollups — pure
+# --------------------------------------------------------------------------- #
+def aggregate_message_stats(count_rows: list[dict], command_rows: list[dict],
+                            word_rows: list[dict], theme_rows: list[dict]) -> dict:
+    """Fold the four server-side rollups into the shape `aggregate()` renders.
+
+    Mirrors, exactly, what the old client-side loop over raw message rows
+    produced — same keys, same numbers. Only tie-breaking differs (see the note
+    beside the query builders). Zero-count themes are DROPPED, because
+    `Counter.most_common()` never emitted a theme that matched nothing.
+    """
+    prompts = commands = 0
+    by_day: Counter = Counter()
+    hosts: dict[str, dict] = {}
+    for r in count_rows:
+        n = int(num(r.get("n")))
+        kind = r.get("kind")
+        h = r.get("host") or "?"
+        day = str(r.get("day") or "")[:10]
+        if day:
+            by_day[day] += n
+        hp = hosts.setdefault(h, {"messages": 0, "prompts": 0, "commands": 0})
+        hp["messages"] += n
+        if kind == "command":
+            commands += n
+            hp["commands"] += n
+        else:
+            prompts += n
+            hp["prompts"] += n
+
+    top_commands = [(r.get("cmd") or "", int(num(r.get("n")))) for r in command_rows]
+    top_first_words = [(r.get("w") or "", int(num(r.get("n")))) for r in word_rows]
+
+    themes: list[tuple[str, int]] = []
+    if theme_rows:
+        row = theme_rows[0]
+        for i, name in enumerate(theme_aliases()):
+            n = int(num(row.get(f"t{i}")))
+            if n:
+                themes.append((name, n))
+        themes.sort(key=lambda kv: -kv[1])   # stable → ties keep THEMES order
+
+    return {
+        "prompts": prompts,
+        "commands": commands,
+        "activity_by_day": dict(sorted(by_day.items())),
+        "hosts": hosts,
+        "top_commands": top_commands,
+        "top_first_words": top_first_words,
+        "top_themes": themes,
+    }
 
 
 # --------------------------------------------------------------------------- #
@@ -284,7 +481,12 @@ def aggregate_insights(insight_rows: list[dict]) -> dict:
 # --------------------------------------------------------------------------- #
 def aggregate(summary_rows: list[dict], message_rows: list[dict],
               insight_rows: list[dict], days: int, host: str | None,
-              insight_days: int | None = None) -> dict:
+              insight_days: int | None = None,
+              message_stats: dict | None = None) -> dict:
+    """`message_stats`, when given, REPLACES the client-side loop over
+    `message_rows` — that is the server-side-aggregation path gather() uses.
+    The raw-rows path is kept because it is the pure, fixture-driven reference
+    the tests exercise (and it is what `message_stats` is validated against)."""
     tool_counts: Counter = Counter()
     languages: Counter = Counter()
     projects: Counter = Counter()
@@ -340,6 +542,22 @@ def aggregate(summary_rows: list[dict], message_rows: list[dict],
     first_words: Counter = Counter()
     by_day: Counter = Counter()
     prompt_n = command_n = 0
+    if message_stats is not None:
+        # Server-side path: the counts already exist; only merge the per-host
+        # message columns into the host map the summary loop just built.
+        prompt_n = int(num(message_stats.get("prompts")))
+        command_n = int(num(message_stats.get("commands")))
+        by_day = Counter(message_stats.get("activity_by_day") or {})
+        for h, hp_src in (message_stats.get("hosts") or {}).items():
+            hp = hosts.setdefault(h, {"sessions": 0, "messages": 0, "prompts": 0,
+                                      "commands": 0, "commits": 0,
+                                      "output_tokens": 0})
+            for k in ("messages", "prompts", "commands"):
+                hp[k] += int(num(hp_src.get(k)))
+        commands = None      # rendered straight from message_stats below
+        first_words = None
+        themes = None
+        message_rows = []
     for row in message_rows:
         kind = row.get("kind")
         h = row.get("host") or "?"
@@ -388,9 +606,12 @@ def aggregate(summary_rows: list[dict], message_rows: list[dict],
         "projects": dict(projects.most_common()),
         "models": dict(models.most_common()),
         "tool_error_categories": dict(err_cats.most_common()),
-        "top_commands": commands.most_common(15),
-        "top_themes": themes.most_common(),
-        "top_first_words": first_words.most_common(15),
+        "top_commands": (message_stats["top_commands"][:15] if message_stats is not None
+                         else commands.most_common(15)),
+        "top_themes": (message_stats["top_themes"] if message_stats is not None
+                       else themes.most_common()),
+        "top_first_words": (message_stats["top_first_words"][:15] if message_stats is not None
+                            else first_words.most_common(15)),
         "activity_by_day": dict(sorted(by_day.items())),
         "hosts": hosts,
         # Layer B qualitative aggregates (spec §11).
@@ -418,14 +639,49 @@ def gather(client, days: int, host: str | None = None,
     win = window_seconds(days)
     # Layer B uses a wider window than Layer A (qualitative facets accrue slower).
     iwin = window_seconds(max(insight_days or DEFAULT_INSIGHT_DAYS, days))
-    try:
-        summaries = client.rows(q_summaries(win, host))
-        messages = client.rows(q_messages(win, host))
-        insights = client.rows(q_insights(iwin, host))
-    except Exception as e:  # noqa: BLE001 — telemetry is optional; degrade cleanly
-        raise TelemetryUnavailable(str(e)) from e
-    return aggregate(summaries, messages, insights, days, host,
-                     insight_days=insight_days)
+
+    # 🔴 Run the three queries INDEPENDENTLY and account for each one.
+    #
+    # The old code wrapped all three in one `except Exception` and re-raised a
+    # single "telemetry unavailable", so (a) a query rejected by a healthy
+    # server was reported as the pipeline being off, and (b) if query 1 blew up,
+    # queries 2 and 3 never ran and their sections rendered as zeros with no
+    # indication anything was missing. Silently-dropped sections are the failure
+    # mode this whole taxonomy exists to prevent.
+    #
+    # An UNREACHABLE server is different: no query can possibly succeed, so
+    # abort immediately rather than paying three timeouts.
+    plan = (
+        ("summaries", q_summaries(win, host)),
+        ("messages", q_message_counts(win, host)),
+        ("commands", q_top_commands(win, host)),
+        ("first_words", q_first_words(win, host)),
+        ("themes", q_prompt_themes(win, host)),
+        ("insights", q_insights(iwin, host)),
+    )
+    results: dict[str, list[dict]] = {}
+    errors: dict[str, str] = {}
+    for name, sql in plan:
+        try:
+            results[name] = client.rows(sql)
+        except Q.CHUnreachable as e:
+            raise TelemetryUnreachable(str(e)) from e
+        except Exception as e:  # noqa: BLE001 — record and carry on, degraded
+            errors[name] = f"{type(e).__name__}: {e}"
+            results[name] = []
+
+    if len(errors) == len(plan):
+        raise TelemetryQueryFailed(
+            "every query was rejected by the server (it IS reachable — this is "
+            "a query failure, not a telemetry outage)", errors)
+
+    stats = aggregate_message_stats(results["messages"], results["commands"],
+                                    results["first_words"], results["themes"])
+    data = aggregate(results["summaries"], [], results["insights"],
+                     days, host, insight_days=insight_days, message_stats=stats)
+    data["failed_queries"] = errors
+    data["status"] = "degraded" if errors else "ok"
+    return data
 
 
 # --------------------------------------------------------------------------- #
@@ -438,12 +694,30 @@ def _bar(n, peak, width=18):
     return "█" * (max(1, round(n / peak * width)) if n > 0 else 0)
 
 
+def render_failure_banner(failed: dict) -> list[str]:
+    """A LOUD, unmissable header naming every query that failed and the report
+    sections that are consequently empty. A degraded report that looks like a
+    quiet one is worse than no report."""
+    if not failed:
+        return []
+    out = ["", "!" * 78,
+           f"!! DEGRADED REPORT — {len(failed)} of {len(QUERY_SECTIONS)} queries FAILED.",
+           "!! The server IS reachable; these numbers are INCOMPLETE, not low."]
+    for name, err in failed.items():
+        out.append(f"!!   {name}: {err}")
+        out.append(f"!!     → missing: {QUERY_SECTIONS.get(name, '?')}")
+    out.append("!" * 78)
+    return out
+
+
 def render(data: dict) -> str:
     t = data["totals"]
     out = []
     scope = data["host"] or "all hosts"
+    failed = data.get("failed_queries") or {}
     out.append(f"=== Claude Code insights — trailing {data['days']}d ({scope}) ===")
     out.append(f"    {data['window_start_utc']} → now (UTC) · generated {data['generated_utc']}")
+    out.extend(render_failure_banner(failed))
 
     out.append("\n## ACTIVITY")
     out.append(f"  sessions:   {data['sessions']}"
@@ -496,6 +770,11 @@ def render(data: dict) -> str:
                    f"{hp['commits']} commits · {hp['output_tokens']:,} out-tokens")
 
     out.append(f"\n## OUTCOMES (qualitative — Layer B · trailing {data['insight_days']}d)")
+    if "insights" in failed:
+        # NOT "nothing here yet" — that would read a query failure as an empty
+        # dataset, which is exactly the conflation this PR removes.
+        out.append(f"  UNAVAILABLE — the session-insight query FAILED: {failed['insights']}")
+        return "\n".join(out)
     if data["qualitative_pending"]:
         out.append("  (no qualitative insights yet — run session_insight via the activity skill)")
         out.append("  This report shows ONLY deterministic facts — no fabricated outcomes.")
@@ -586,6 +865,17 @@ def render_html(data: dict) -> str:
     scope = data["host"] or "all hosts"
     total_in = (num(t.get('input_tokens', 0)) + num(t.get('cache_read_tokens', 0))
                 + num(t.get('cache_creation_tokens', 0)))
+    failed = data.get("failed_queries") or {}
+    degraded_html = ""
+    if failed:
+        items = "".join(
+            f"<li><b>{html.escape(n)}</b>: {html.escape(e)}<br>"
+            f"<span class=mut>missing: {html.escape(QUERY_SECTIONS.get(n, '?'))}</span></li>"
+            for n, e in failed.items())
+        degraded_html = (
+            f'<div class="note" style="border-left-color:#c0392b"><b>DEGRADED — '
+            f'{len(failed)} of {len(QUERY_SECTIONS)} queries FAILED.</b> The server is reachable; the '
+            f'numbers below are <b>incomplete, not low</b>.<ul>{items}</ul></div>')
     hosts_rows = "".join(
         f"<tr><td>{html.escape(h)}</td><td>{hp['sessions']}</td><td>{hp['messages']}</td>"
         f"<td>{hp['commits']}</td><td>{hp['output_tokens']:,}</td></tr>"
@@ -649,6 +939,7 @@ footer{{color:var(--mut);font-size:12px;margin-top:40px;border-top:1px solid var
 <div class="note">Deterministic view built from <code>activity.events</code> (Layer&nbsp;A
 session rollups + the prompt/command stream). No LLM, no confabulation. The qualitative
 layer (goal/outcome/friction) arrives in PR-2.</div>
+{degraded_html}
 {unreadable_note}
 <h2>ACTIVITY</h2>
 <div class="grid">
@@ -716,17 +1007,37 @@ def main(argv=None) -> int:
     if a.days <= 0:
         print("error: --days must be positive", file=sys.stderr)
         return 2
+    # 🔴 THREE separable states, three exit codes, an error carried in --json.
+    # Previously all of these printed one "telemetry unavailable" line and
+    # exited 0, so a broken query looked identical to telemetry being off and
+    # nothing downstream could ever notice.
+    def _fail(status: str, message: str, rc: int, errors: dict | None = None) -> int:
+        if a.json:
+            print(json.dumps({"status": status, "error": message,
+                              "errors": errors or {}, "days": a.days,
+                              "host": a.host}, indent=2))
+        print(f"insights: {message}", file=sys.stderr)
+        return rc
+
     try:
         conn = Q.CHConn.from_env()
     except RuntimeError as e:
-        print(f"insights: telemetry not configured — {e}", file=sys.stderr)
-        return 0
+        # Not a failure: the tool is optional and this is the documented path.
+        return _fail("not-configured",
+                     f"telemetry NOT CONFIGURED — {e}", EXIT_NOT_CONFIGURED)
     client = Q.CHClient(conn)
     try:
         data = gather(client, a.days, a.host, insight_days=a.insight_days)
-    except TelemetryUnavailable as e:
-        print(f"insights: telemetry unavailable ({e}); nothing to report.", file=sys.stderr)
-        return 0
+    except TelemetryUnreachable as e:
+        return _fail("unreachable",
+                     f"telemetry UNREACHABLE at {conn.url} — {e}. "
+                     "The report was NOT produced.", EXIT_UNREACHABLE)
+    except TelemetryQueryFailed as e:
+        return _fail("query-failed",
+                     f"telemetry QUERY FAILED at {conn.url} — {e}. The server is "
+                     "reachable; the queries are broken or the server rejected "
+                     "them. The report was NOT produced.",
+                     EXIT_QUERY_FAILED, errors=e.errors)
 
     if a.json:
         print(json.dumps(data, indent=2, default=str))
@@ -739,7 +1050,14 @@ def main(argv=None) -> int:
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(render_html(data), encoding="utf-8")
         print(f"\nwrote HTML report → {p}", file=sys.stderr)
-    return 0
+
+    failed = data.get("failed_queries") or {}
+    if failed:
+        print(f"insights: DEGRADED — {len(failed)} of {len(QUERY_SECTIONS)} queries failed "
+              f"({', '.join(failed)}); the sections they feed are EMPTY, not zero.",
+              file=sys.stderr)
+        return EXIT_DEGRADED
+    return EXIT_OK
 
 
 if __name__ == "__main__":

--- a/scripts/session-analysis/tests/test_insights.py
+++ b/scripts/session-analysis/tests/test_insights.py
@@ -11,6 +11,7 @@ formatting. We test:
 """
 import importlib.util
 import json
+from collections import Counter
 import sys
 from pathlib import Path
 
@@ -57,12 +58,19 @@ def test_summaries_query_is_argmax_windowed_and_scoped():
 def test_host_filter_is_quoted():
     sql = I.q_summaries(86400, "o'brien")
     assert "host='o\\'brien'" in sql
-    assert "host='laptop'" in I.q_messages(86400, "laptop")
+    assert "host='laptop'" in I.q_message_counts(86400, "laptop")
 
 
 def test_messages_and_insights_queries():
-    assert "kind IN ('prompt','command')" in I.q_messages(86400)
+    # The message stream is now aggregated SERVER-SIDE (see insights.py) — the
+    # old `q_messages` row-stream is gone because the server could not execute
+    # it under its memory ceiling.
+    assert "kind IN ('prompt','command')" in I.q_message_counts(86400)
+    assert "kind='command'" in I.q_top_commands(86400)
+    assert "kind='prompt'" in I.q_first_words(86400)
+    assert "kind='prompt'" in I.q_prompt_themes(86400)
     assert "kind='session-insight'" in I.q_insights(86400)
+    assert not hasattr(I, "q_messages"), "the unbounded text row-stream must stay gone"
 
 
 def test_summaries_host_alias_is_not_shadowing():
@@ -82,7 +90,10 @@ def test_no_select_alias_shadows_a_where_filtered_column():
     op = re.compile(r"\b([a-zA-Z_]\w*)\s*(?:>=|<=|=|>|<)")
     for sql in (I.q_summaries(86400, "workbench"),
                 I.q_insights(86400, "workbench"),
-                I.q_messages(86400, "workbench")):
+                I.q_message_counts(86400, "workbench"),
+                I.q_top_commands(86400, "workbench"),
+                I.q_first_words(86400, "workbench"),
+                I.q_prompt_themes(86400, "workbench")):
         aliases = set(re.findall(r"\bAS\s+(\w+)", sql))
         where = sql.split("WHERE", 1)[1] if "WHERE" in sql else ""
         where_cols = set(op.findall(where))
@@ -185,16 +196,67 @@ def test_aggregate_host_scope_recorded():
 # --------------------------------------------------------------------------- #
 # gather() + graceful degrade
 # --------------------------------------------------------------------------- #
+def query_name(sql: str) -> str:
+    """Map a gather() query back to its plan name (the message stream is now
+    FOUR server-side rollups, not one row-stream)."""
+    if "session-summary" in sql:
+        return "summaries"
+    if "session-insight" in sql:
+        return "insights"
+    if "splitByWhitespace" in sql:
+        return "commands"
+    if "extract(" in sql:
+        return "first_words"
+    if "countIf(match" in sql:
+        return "themes"
+    return "messages"
+
+
+def rollups_from_messages(rows):
+    """Compute the four server-side rollups from raw message rows, in PYTHON.
+
+    This is the equivalence harness: it lets a fixture of raw rows drive the
+    server-side code path, so the two paths can be compared directly.
+    """
+    counts, cmds, words, themes = Counter(), Counter(), Counter(), Counter()
+    for r in rows:
+        kind = r.get("kind")
+        counts[(kind, r.get("host") or "?", str(r.get("ts") or "")[:10])] += 1
+        text = r.get("text") or ""
+        if kind == "command":
+            cmds[I._first_token(text)] += 1
+        else:
+            low = text.lower()
+            for name, rx in I._THEME_RX.items():
+                if rx.search(low):
+                    themes[name] += 1
+            w = I._WORD_RX.findall(low)
+            if w:
+                words[w[0]] += 1
+    return {
+        "messages": [{"kind": k, "host": h, "day": d, "n": n}
+                     for (k, h, d), n in counts.items()],
+        "commands": [{"cmd": c, "n": n} for c, n in
+                     sorted(cmds.items(), key=lambda kv: (-kv[1], kv[0]))],
+        "first_words": [{"w": w, "n": n} for w, n in
+                        sorted(words.items(), key=lambda kv: (-kv[1], kv[0]))],
+        "themes": [{f"t{i}": themes.get(name, 0)
+                    for i, name in enumerate(I.theme_aliases())}],
+    }
+
+
 class FakeClient:
     def __init__(self, summaries, messages, insights):
-        self._s, self._m, self._i = summaries, messages, insights
+        self._s, self._i = summaries, insights
+        self._roll = rollups_from_messages(messages)
 
     def rows(self, sql):
-        if "session-summary" in sql:
+        name = query_name(sql)
+        if name == "summaries":
             return self._s
-        if "session-insight" in sql:
+        if name == "insights":
             return self._i
-        return self._m
+        return self._roll[name]
 
 
 def test_gather_assembles_from_client():

--- a/scripts/session-analysis/tests/test_insights_failure_reporting.py
+++ b/scripts/session-analysis/tests/test_insights_failure_reporting.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""insights.py must be LOUD and SPECIFIC when a query fails.
+
+THE BUG THIS PINS (measured 2026-08-02, laptop → nebula CH endpoint)
+-------------------------------------------------------------------
+    $ insights.py --days 3 --json
+      insights: telemetry unavailable (timed out); nothing to report.   exit 0
+    $ <same creds, same server> SELECT count(DISTINCT session) …  →  66
+
+The pipeline was healthy. `q_messages` was being OvercommitTracker-killed by a
+memory-capped ClickHouse (`Code: 241 MEMORY_LIMIT_EXCEEDED … while reading
+column text`, or a stall past the 15s client timeout). Every one of those
+outcomes arrived at the same `except Exception` → one "telemetry unavailable"
+line → **exit 0**, so nothing downstream could distinguish:
+
+    (a) telemetry not configured    — fine, optional
+    (b) server unreachable          — real failure
+    (c) server rejected the query   — real failure, and the loudest, because
+                                      the data IS there and the tool is lying
+
+...and because all three queries were in ONE try block, a failure in the first
+meant the other two never ran and their sections silently rendered as zeros.
+
+HARNESS VALIDATION (RULES: "validate the harness against a known-bad state").
+`test_harness_negative_control_*` prove the harness can observe both the
+classification and the exit code before any green result here is believed.
+
+POSITIVE CONTROL (RULES: "where the reassuring answer is a zero").
+`len(failed_queries) == 0` is the reassuring answer on the happy path.
+`test_positive_control_failed_query_counter_moves` requires that same counter to
+read exactly 1 and exactly 3 when queries do fail. Reported as a pair.
+
+Environment: pure Python, no network, no `node` — runs identically in the
+hermetic sandbox and on a dev host. No skipif; nothing here can silently skip.
+"""
+from __future__ import annotations
+
+import io
+import json
+import re
+import sys
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+SA = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SA))
+sys.path.insert(0, str(SA.parent / "validation"))
+import chquery as Q  # noqa: E402
+import insights as I  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+def _summaries():
+    return [{"session": "s1", "sess_host": "laptop", "project": "devrc",
+             "payload": json.dumps({"tool_counts": {"Bash": 3}, "git_commits": 1,
+                                    "user_message_count": 2,
+                                    "assistant_message_count": 2})}]
+
+
+def _insights():
+    return [{"session": "s1", "payload": json.dumps(
+        {"outcome": "shipped", "claude_helpfulness": 4})}]
+
+
+# The message stream is aggregated SERVER-SIDE, so gather() issues six queries.
+PLAN = ["summaries", "messages", "commands", "first_words", "themes", "insights"]
+
+
+def _query_name(sql: str) -> str:
+    if "session-summary" in sql:
+        return "summaries"
+    if "session-insight" in sql:
+        return "insights"
+    if "splitByWhitespace" in sql:
+        return "commands"
+    if "extract(" in sql:
+        return "first_words"
+    if "countIf(match" in sql:
+        return "themes"
+    return "messages"
+
+
+_ROLLUPS = {
+    "messages": [{"kind": "prompt", "host": "laptop", "day": "2026-08-01", "n": 1},
+                 {"kind": "command", "host": "laptop", "day": "2026-08-01", "n": 1}],
+    "commands": [{"cmd": "/standup", "n": 1}],
+    "first_words": [{"w": "fix", "n": 1}],
+    "themes": [{"t0": 1, "t1": 0, "t2": 0, "t3": 0, "t4": 0,
+                "t5": 0, "t6": 0, "t7": 0, "t8": 0, "t9": 0}],
+}
+
+
+class SelectiveClient:
+    """Answers each query normally unless it is named in `fail_with`."""
+
+    def __init__(self, fail_with: dict | None = None):
+        self.fail_with = fail_with or {}
+        self.seen: list[str] = []
+
+    def rows(self, sql):
+        name = _query_name(sql)
+        data = ({"summaries": _summaries(), "insights": _insights()}
+                .get(name) or _ROLLUPS[name])
+        self.seen.append(name)
+        exc = self.fail_with.get(name)
+        if exc is not None:
+            raise exc
+        return data
+
+
+MEMORY_LIMIT_BODY = (
+    "Code: 241. DB::Exception: (total) memory limit exceeded: would use 2.31 GiB "
+    "(attempt to allocate chunk of 10.44 MiB bytes), current RSS: 2.50 GiB, "
+    "maximum: 2.50 GiB. … (while reading column text) … (MEMORY_LIMIT_EXCEEDED)"
+)
+
+
+def _http_error(status=500, body=MEMORY_LIMIT_BODY):
+    return urllib.error.HTTPError(
+        "http://ch/", status, "Internal Server Error", {},
+        io.BytesIO(body.encode()))
+
+
+# --------------------------------------------------------------------------- #
+# HARNESS NEGATIVE CONTROLS
+# --------------------------------------------------------------------------- #
+def test_harness_negative_control_a_plain_exception_is_still_caught():
+    """KNOWN-BAD shape: a client that raises a bare RuntimeError on everything
+    must still be seen as a total failure. If this ever passes silently, the
+    harness is not observing gather()'s error path at all."""
+    class Boom:
+        def rows(self, sql):
+            raise RuntimeError("connection refused")
+
+    with pytest.raises(I.TelemetryUnavailable):
+        I.gather(Boom(), days=14, host=None)
+
+
+def test_harness_negative_control_capsys_sees_the_exit_code_and_stderr(capsys):
+    """The exit-code assertions below are only evidence if main()'s return value
+    and stderr are actually reaching this test. Prove it with a case whose
+    answer is unambiguous and independent of the taxonomy: --days 0."""
+    rc = I.main(["--days", "0"])
+    assert rc == 2
+    assert "must be positive" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------- #
+# chquery: unreachable vs query-failed
+# --------------------------------------------------------------------------- #
+def test_http_error_is_classified_as_a_QUERY_error_with_the_ch_code():
+    """RED at origin/main: urlopen raises HTTPError, which the old `_request`
+    never caught — it escaped as a bare HTTPError (an OSError), and insights.py
+    turned every OSError into 'telemetry unavailable'."""
+    def opener(req, timeout=None):
+        raise _http_error()
+
+    c = Q.CHClient(Q.CHConn(url="http://ch", user="u", password="p"), opener=opener)
+    with pytest.raises(Q.CHQueryError) as ei:
+        c.rows("SELECT 1")
+    assert ei.value.code == 241
+    assert ei.value.http_status == 500
+    assert "MEMORY_LIMIT_EXCEEDED" in str(ei.value)
+    # ...and it is NOT the unreachable case.
+    assert not isinstance(ei.value, Q.CHUnreachable)
+
+
+def test_timeout_is_classified_as_UNREACHABLE():
+    """RED at origin/main (no such class)."""
+    def opener(req, timeout=None):
+        raise TimeoutError("timed out")
+
+    c = Q.CHClient(Q.CHConn(url="http://ch", user="u", password="p"), opener=opener)
+    with pytest.raises(Q.CHUnreachable):
+        c.rows("SELECT 1")
+
+
+def test_connection_refused_is_classified_as_UNREACHABLE():
+    def opener(req, timeout=None):
+        raise urllib.error.URLError(ConnectionRefusedError("refused"))
+
+    c = Q.CHClient(Q.CHConn(url="http://ch", user="u", password="p"), opener=opener)
+    with pytest.raises(Q.CHUnreachable) as ei:
+        c.rows("SELECT 1")
+    assert "http://ch" in str(ei.value)      # names WHERE it failed
+
+
+def test_both_error_classes_stay_runtimeerror_for_old_callers():
+    """INVARIANT GUARD (held before this change too): validation callers do
+    `except RuntimeError`. Keep that contract."""
+    assert issubclass(Q.CHQueryError, RuntimeError)
+    assert issubclass(Q.CHUnreachable, RuntimeError)
+
+
+def test_ch_error_code_extraction():
+    assert Q.ch_error_code("Code: 241. DB::Exception: nope") == 241
+    assert Q.ch_error_code("no code here") is None
+
+
+# --------------------------------------------------------------------------- #
+# gather(): partial degradation is REPORTED, never dropped
+# --------------------------------------------------------------------------- #
+def test_partial_failure_names_the_failed_query_and_keeps_the_rest():
+    """RED at origin/main: one failing query aborted the whole gather."""
+    c = SelectiveClient({"messages": Q.CHQueryError("boom", code=241)})
+    d = I.gather(c, days=14, host=None)
+    assert d["status"] == "degraded"
+    assert list(d["failed_queries"]) == ["messages"]
+    assert "241" in d["failed_queries"]["messages"] or "boom" in d["failed_queries"]["messages"]
+    # every OTHER query still ran and still populated its section
+    assert c.seen == PLAN
+    assert d["sessions"] == 1
+    assert d["tool_counts"] == {"Bash": 3}
+    assert d["outcomes"] == {"shipped": 1}
+
+
+def test_all_queries_failing_raises_query_failed_not_unavailable():
+    """RED at origin/main. 'Reachable but rejecting' must not read as an outage."""
+    c = SelectiveClient({n: Q.CHQueryError("boom") for n in PLAN})
+    with pytest.raises(I.TelemetryQueryFailed) as ei:
+        I.gather(c, days=14, host=None)
+    assert set(ei.value.errors) == set(PLAN)
+
+
+def test_unreachable_aborts_immediately_without_trying_the_rest():
+    """No point paying three timeouts when nothing can succeed."""
+    c = SelectiveClient({"summaries": Q.CHUnreachable("timed out")})
+    with pytest.raises(I.TelemetryUnreachable):
+        I.gather(c, days=14, host=None)
+    assert c.seen == ["summaries"]
+
+
+def test_positive_control_failed_query_counter_moves():
+    """POSITIVE CONTROL for the `0` that the happy path reports.
+
+    `len(failed_queries) == 0` is only meaningful once the same counter has been
+    shown to produce a non-zero. Reported as the pair 0 / 1 / 3.
+    """
+    ok = I.gather(SelectiveClient(), days=14, host=None)
+    assert len(ok["failed_queries"]) == 0 and ok["status"] == "ok"
+
+    one = I.gather(SelectiveClient({"insights": Q.CHQueryError("x")}),
+                   days=14, host=None)
+    assert len(one["failed_queries"]) == 1
+
+    with pytest.raises(I.TelemetryQueryFailed) as ei:
+        I.gather(SelectiveClient({n: Q.CHQueryError("x") for n in PLAN}),
+                 days=14, host=None)
+    assert len(ei.value.errors) == len(PLAN)
+
+
+# --------------------------------------------------------------------------- #
+# render(): a degraded report cannot look like a quiet one
+# --------------------------------------------------------------------------- #
+def test_render_shouts_about_a_failed_query():
+    d = I.gather(SelectiveClient({"messages": Q.CHQueryError("Code: 241 boom")}),
+                 days=14, host=None)
+    txt = I.render(d)
+    assert "DEGRADED REPORT" in txt
+    assert "messages" in txt
+    assert "TOP PROMPT THEMES" in txt          # names the missing sections
+    assert "incomplete, not low" in txt.lower() or "INCOMPLETE, not low" in txt
+
+
+def test_failed_layer_b_query_is_not_reported_as_no_data():
+    """The 'no qualitative insights yet' message must NOT appear when the Layer B
+    query FAILED — an empty result and a failed query are different facts."""
+    d = I.gather(SelectiveClient({"insights": Q.CHQueryError("boom")}),
+                 days=14, host=None)
+    txt = I.render(d)
+    assert "no qualitative insights yet" not in txt
+    assert "UNAVAILABLE" in txt
+
+
+def test_render_html_carries_the_degraded_banner():
+    d = I.gather(SelectiveClient({"messages": Q.CHQueryError("boom")}),
+                 days=14, host=None)
+    assert "DEGRADED" in I.render_html(d)
+
+
+def test_healthy_report_has_no_banner():
+    """Mutation guard: the banner must be conditional, not always-on."""
+    d = I.gather(SelectiveClient(), days=14, host=None)
+    assert "DEGRADED" not in I.render(d)
+    assert "DEGRADED" not in I.render_html(d)
+
+
+# --------------------------------------------------------------------------- #
+# main(): three states, three exit codes, error in --json
+# --------------------------------------------------------------------------- #
+def _run_main(monkeypatch, capsys, *, argv, conn_raises=None, gather_raises=None,
+              client_fail=None):
+    if conn_raises is not None:
+        monkeypatch.setattr(I.Q.CHConn, "from_env",
+                            classmethod(lambda cls, env=None: (_ for _ in ()).throw(conn_raises)))
+    else:
+        monkeypatch.setattr(I.Q.CHConn, "from_env",
+                            classmethod(lambda cls, env=None: I.Q.CHConn(
+                                url="http://ch", user="u", password="p")))
+        monkeypatch.setattr(I.Q, "CHClient",
+                            lambda conn: SelectiveClient(client_fail or {}))
+    if gather_raises is not None:
+        monkeypatch.setattr(I, "gather",
+                            lambda *a, **k: (_ for _ in ()).throw(gather_raises))
+    rc = I.main(argv)
+    return rc, capsys.readouterr()
+
+
+def test_exit_0_and_status_not_configured(monkeypatch, capsys):
+    rc, cap = _run_main(monkeypatch, capsys, argv=["--json"],
+                        conn_raises=RuntimeError("CLICKHOUSE_URL not set"))
+    assert rc == 0
+    assert json.loads(cap.out)["status"] == "not-configured"
+    assert "NOT CONFIGURED" in cap.err
+
+
+def test_exit_3_and_status_unreachable(monkeypatch, capsys):
+    """RED at origin/main: this exited 0."""
+    rc, cap = _run_main(monkeypatch, capsys, argv=["--json"],
+                        gather_raises=I.TelemetryUnreachable("timed out"))
+    assert rc == 3
+    body = json.loads(cap.out)
+    assert body["status"] == "unreachable"
+    assert "timed out" in body["error"]
+    assert "UNREACHABLE" in cap.err
+
+
+def test_exit_4_and_status_query_failed(monkeypatch, capsys):
+    """RED at origin/main: this exited 0 with 'telemetry unavailable'."""
+    rc, cap = _run_main(monkeypatch, capsys, argv=["--json"],
+                        client_fail={n: Q.CHQueryError("Code: 241 boom") for n in PLAN})
+    assert rc == 4
+    body = json.loads(cap.out)
+    assert body["status"] == "query-failed"
+    assert set(body["errors"]) == set(PLAN)
+    assert "QUERY FAILED" in cap.err
+
+
+def test_exit_5_and_status_degraded(monkeypatch, capsys):
+    """RED at origin/main: a partial failure was not representable at all."""
+    rc, cap = _run_main(monkeypatch, capsys, argv=["--json"],
+                        client_fail={"messages": Q.CHQueryError("boom")})
+    assert rc == 5
+    body = json.loads(cap.out)
+    assert body["status"] == "degraded"
+    assert list(body["failed_queries"]) == ["messages"]
+    assert "DEGRADED" in cap.err
+
+
+def test_exit_0_on_a_healthy_run(monkeypatch, capsys):
+    rc, cap = _run_main(monkeypatch, capsys, argv=["--json"])
+    assert rc == 0
+    body = json.loads(cap.out)
+    assert body["status"] == "ok"
+    assert body["failed_queries"] == {}
+    assert "DEGRADED" not in cap.err
+
+
+def test_every_state_has_a_distinct_exit_code():
+    """The three states must be SEPARABLE — same code twice would defeat it."""
+    codes = [I.EXIT_OK, I.EXIT_UNREACHABLE, I.EXIT_QUERY_FAILED, I.EXIT_DEGRADED]
+    assert len(set(codes)) == 4
+    assert I.EXIT_NOT_CONFIGURED == I.EXIT_OK   # deliberate: not a failure
+
+
+# --------------------------------------------------------------------------- #
+# The query itself: `text` must never be row-streamed again
+# --------------------------------------------------------------------------- #
+def test_no_query_row_streams_the_text_column():
+    """RED at origin/main. THE fix: the server cannot materialize this column
+    into a result set under its memory ceiling — measured, every window from 1d
+    to 14d timed out while `count()` answered in 0.20s. So no query may SELECT
+    `text` as an output column; it may only be consumed inside an aggregate."""
+    assert not hasattr(I, "q_messages")
+    for sql in (I.q_summaries(1209600), I.q_message_counts(1209600),
+                I.q_top_commands(1209600), I.q_first_words(1209600),
+                I.q_prompt_themes(1209600), I.q_insights(2592000)):
+        select = sql.split(" FROM ", 1)[0]
+        # strip function calls, then look for a bare `text` identifier
+        stripped = re.sub(r"\w+\([^()]*text[^()]*\)", "", select)
+        assert not re.search(r"(?<![a-zA-Z_(])text(?![a-zA-Z_])", stripped), sql
+
+
+def test_theme_sql_is_generated_from_the_python_regexes():
+    """One rule, one place: a THEMES edit must move the SQL, or the two drift
+    and the report quietly reports different numbers than the code says."""
+    sql = I.q_prompt_themes(100)
+    assert len(I.theme_aliases()) == len(I.THEMES)
+    for i, pat in enumerate(I.THEMES.values()):
+        assert f"AS t{i}" in sql
+        assert Q.sql_quote(pat) in sql
+
+
+def test_word_pattern_matches_the_python_word_regex():
+    assert I._WORD_PATTERN == I._WORD_RX.pattern
+
+
+def test_command_token_sql_splits_on_any_whitespace_like_python():
+    """`splitByChar(' ')` would NOT match Python's str.split()."""
+    assert "splitByWhitespace(trimBoth(text))[1]" in I.q_top_commands(100)
+
+
+def test_queries_are_ordered_so_the_top_n_is_reproducible():
+    assert "ORDER BY n DESC, cmd ASC" in I.q_top_commands(100)
+    assert "ORDER BY n DESC, w ASC" in I.q_first_words(100)
+
+
+# --------------------------------------------------------------------------- #
+# Server-side rollups == the old client-side loop
+# --------------------------------------------------------------------------- #
+def _raw_messages():
+    """Fixture with pairwise-distinct fields: two hosts, two days, both kinds,
+    ties in the leaderboards, and themes that must NOT appear (count 0)."""
+    return [
+        {"kind": "prompt", "host": "laptop", "ts": "2026-08-01 09:00:00",
+         "text": "fix the failing deploy on the k8s cluster"},
+        {"kind": "prompt", "host": "workbench", "ts": "2026-08-01 10:00:00",
+         "text": "Fix the broken test"},
+        {"kind": "prompt", "host": "laptop", "ts": "2026-08-02 11:00:00",
+         "text": "rebase the branch and push"},
+        {"kind": "command", "host": "laptop", "ts": "2026-08-01 12:00:00",
+         "text": "/standup now"},
+        {"kind": "command", "host": "workbench", "ts": "2026-08-02 13:00:00",
+         "text": "/handoff"},
+        {"kind": "command", "host": "workbench", "ts": "2026-08-02 14:00:00",
+         "text": "/standup"},
+    ]
+
+
+def _stats_from_raw(raw):
+    from test_insights import rollups_from_messages          # noqa: PLC0415
+    r = rollups_from_messages(raw)
+    return I.aggregate_message_stats(r["messages"], r["commands"],
+                                     r["first_words"], r["themes"])
+
+
+def test_server_side_rollups_match_the_client_side_loop():
+    """EQUIVALENCE: driving aggregate() through the new server-side path must
+    produce the same numbers as the original raw-row loop over the same data.
+
+    (Live cross-check, separately: over 200 REAL rows the SQL and the Python
+    agreed EXACTLY on themes, first-words and command tokens — see the PR body.)
+    """
+    raw = _raw_messages()
+    old = I.aggregate(_summaries(), raw, [], 14, None)
+    new = I.aggregate(_summaries(), [], [], 14, None, message_stats=_stats_from_raw(raw))
+
+    for key in ("messages", "prompts", "commands", "activity_by_day", "hosts"):
+        assert new[key] == old[key], key
+    # leaderboards: same (key → count) mapping; order may differ only on ties
+    assert dict(new["top_commands"]) == dict(old["top_commands"])
+    assert dict(new["top_first_words"]) == dict(old["top_first_words"])
+    assert dict(new["top_themes"]) == dict(old["top_themes"])
+
+
+def test_positive_control_the_equivalence_fixture_is_not_empty():
+    """POSITIVE CONTROL: the equivalence test compares dicts, and two EMPTY
+    dicts compare equal — so it would pass just as well against a fixture that
+    produces nothing. Pin literal non-zero counts."""
+    s = _stats_from_raw(_raw_messages())
+    assert s["prompts"] == 3 and s["commands"] == 3
+    assert dict(s["top_commands"]) == {"/standup": 2, "/handoff": 1}
+    assert dict(s["top_first_words"]) == {"fix": 2, "rebase": 1}
+    assert len(s["top_themes"]) >= 2
+    assert s["activity_by_day"] == {"2026-08-01": 3, "2026-08-02": 3}
+    assert s["hosts"]["laptop"] == {"messages": 3, "prompts": 2, "commands": 1}
+
+
+def test_zero_count_themes_are_dropped_like_counter_most_common():
+    stats = I.aggregate_message_stats(
+        [], [], [], [{f"t{i}": (3 if i == 2 else 0) for i in range(len(I.THEMES))}])
+    assert stats["top_themes"] == [(I.theme_aliases()[2], 3)]

--- a/scripts/validation/chquery.py
+++ b/scripts/validation/chquery.py
@@ -36,10 +36,57 @@ from __future__ import annotations
 
 import json
 import os
+import re
+import socket
+import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from datetime import datetime
+
+
+# --------------------------------------------------------------------------- #
+# Error taxonomy
+# --------------------------------------------------------------------------- #
+# 🔴 "could not reach the server" and "the server rejected my query" are
+# DIFFERENT FACTS and callers must be able to tell them apart. Collapsing them
+# is how `insights.py` reported a healthy pipeline as "telemetry unavailable"
+# and exited 0: a MEMORY_LIMIT_EXCEEDED on one query was indistinguishable from
+# telemetry being switched off. Both subclass RuntimeError so pre-existing
+# `except RuntimeError` call sites keep working unchanged.
+class CHError(RuntimeError):
+    """Base class for ClickHouse client failures."""
+
+
+class CHUnreachable(CHError):
+    """The server could not be reached at all (DNS, connect, reset, timeout).
+
+    Nothing can be said about any query — retrying a DIFFERENT query is
+    pointless, so callers should abort the whole gather.
+    """
+
+
+class CHQueryError(CHError):
+    """The server answered and REJECTED or FAILED this specific query.
+
+    The pipeline is up. Another query may well succeed, so callers should
+    record which one failed and carry on — degraded, not dead.
+    """
+
+    def __init__(self, message: str, *, code: int | None = None,
+                 http_status: int | None = None):
+        super().__init__(message)
+        self.code = code                # ClickHouse error code, e.g. 241
+        self.http_status = http_status
+
+
+_CH_CODE_RX = re.compile(r"Code:\s*(\d+)")
+
+
+def ch_error_code(body: str) -> int | None:
+    """Pull ClickHouse's numeric error code out of an error body, if present."""
+    m = _CH_CODE_RX.search(body or "")
+    return int(m.group(1)) if m else None
 
 
 # --------------------------------------------------------------------------- #
@@ -94,7 +141,28 @@ class CHClient:
             req.add_header("X-ClickHouse-User", self.conn.user)
         if self.conn.password:
             req.add_header("X-ClickHouse-Key", self.conn.password)
-        resp = self._opener(req, timeout=self.conn.timeout)
+        try:
+            resp = self._opener(req, timeout=self.conn.timeout)
+        except urllib.error.HTTPError as e:
+            # The server ANSWERED — with an error status. urlopen raises before
+            # the status check below ever runs, which is why the old
+            # `RuntimeError(f"ClickHouse HTTP {code}")` branch was unreachable
+            # for the common case (a query that CH rejects → HTTP 500 + a
+            # `Code: NNN. DB::Exception: …` body). Classify it as a QUERY error.
+            try:
+                body = e.read().decode("utf-8", "replace")
+            except Exception:  # noqa: BLE001 — never mask the original failure
+                body = ""
+            raise CHQueryError(
+                f"ClickHouse HTTP {e.code}: {body[:500] or e.reason}",
+                code=ch_error_code(body), http_status=e.code,
+            ) from e
+        except (urllib.error.URLError, socket.timeout, TimeoutError, OSError) as e:
+            # No usable answer: DNS, refused, reset, or the read timed out.
+            raise CHUnreachable(
+                f"{type(e).__name__}: {e} (url={self.conn.url}, "
+                f"timeout={self.conn.timeout}s)"
+            ) from e
         try:
             code = getattr(resp, "status", None) or resp.getcode()
             body = resp.read()
@@ -105,7 +173,8 @@ class CHClient:
         if isinstance(body, bytes):
             body = body.decode("utf-8", "replace")
         if not (200 <= code < 300):
-            raise RuntimeError(f"ClickHouse HTTP {code}: {body[:500]}")
+            raise CHQueryError(f"ClickHouse HTTP {code}: {body[:500]}",
+                               code=ch_error_code(body), http_status=code)
         return body
 
     def scalar(self, sql: str):


### PR DESCRIPTION
## The bug

```
$ insights.py --days 3 --json
  insights: telemetry unavailable (timed out); nothing to report.    exit 0    (15.2s)

$ <same creds, same server> SELECT count(DISTINCT session) … ts>now()-259200
  66
```

The pipeline was healthy. The tool reported it as down, **and exited 0**, so nothing downstream could notice.

## Root cause 1 — the query the server cannot run

Verified before fixing, not taken on trust. `q_messages` row-streamed the whole `text` column and counted in Python. `text` is wide (mean **2,498 B**, max **27,136 B** over 14d) and the `activity` ClickHouse runs under a hard **2.5 GiB** total-memory ceiling, so materializing those strings into a result set is the thing it cannot do:

```
Code: 241. DB::Exception: (total) memory limit exceeded: would use 2.31 GiB
(attempt to allocate chunk of 10.44 MiB bytes), current RSS: 2.50 GiB, maximum: 2.50 GiB.
OvercommitTracker decision: … (while reading column text) … (MEMORY_LIMIT_EXCEEDED)
```

**MEASURED** 2026-08-02, laptop → `10.42.0.10:30123`, every run interleaved with `SELECT 1` and `count()` controls so a server outage could not be mistaken for a query problem:

| query | result |
|---|---|
| `SELECT 1` (control) | **0.04s** |
| `count()` over the same 14d window (control) | **0.20s**, 6,335 rows |
| row stream, **1d** | TIMEOUT (60s) |
| row stream, **2d / 4d / 7d / 14d** | TIMEOUT, every one |
| row stream, 3d, separate attempt | HTTP 500 `Code: 241`, 0.40s |
| row stream 14d + `max_block_size=1024` | TIMEOUT |
| row stream 14d + `max_threads=1` | TIMEOUT |
| row stream 14d + both | TIMEOUT |
| **server-side** counts by kind/host/day | **0.59s**, 56 rows, 3,581 B |
| **server-side** top slash-commands | **0.51s**, 30 rows, 986 B |
| **server-side** prompt first-words | **0.46s**, 20 rows, 466 B |
| **server-side** 10 × `countIf(match(…))` themes | **0.72s**, 1 row, 120 B |

So capping block size / threads does **not** help, and neither does chunking by day — a **1-day** slice times out.

⚠ **A retracted measurement, recorded on purpose.** One early run of `… SETTINGS max_block_size=1024, max_threads=1` returned all 6,334 rows in **0.71s**, and I nearly shipped it as "the fix, 254× faster" with that number in a code comment. It did not reproduce on any subsequent attempt — including a run that explicitly isolated each setting. One measurement was not a general claim; the re-run is what caught it.

**The fix:** never send the text. The message stream is aggregated server-side into four small rollups. Payload for those sections: **~15.8 MB → ~5 KB**.

### Semantics preserved, not approximated

* SQL is **generated from** the existing Python definitions (`THEMES`, `_WORD_RX`) so the two cannot drift; a test asserts every pattern appears in the SQL.
* `splitByWhitespace(trimBoth(text))[1]` is the exact twin of `_first_token` — `splitByChar(' ')` would **not** be, since Python's `str.split()` splits on any whitespace.
* **Cross-checked against the Python implementation over 200 REAL rows** pulled from the table (`LIMIT` reads still work): themes, first-words and command tokens matched **EXACTLY**, all three. Caveat: only **4** of those 200 rows were slash-commands, so the command-token half of that check is thin.
* A pure equivalence test drives both code paths off one fixture with pairwise-distinct fields (2 hosts × 2 days × both kinds, ties in every leaderboard).
* **One deliberate difference:** leaderboard ties now break on the key ascending. They previously fell out in row order — and the old query had **no `ORDER BY` at all**, so the "top 15" was not reproducible run to run.

## Root cause 2 — three different facts, one message, exit 0

"telemetry is off", "unreachable" and "the server rejected my query" all hit one `except Exception`. Worse, all three queries shared **one** try block, so a failure in the first meant the others never ran and their sections rendered as **zeros** with no indication anything was missing.

`chquery` now classifies (both still subclass `RuntimeError`, so existing `except RuntimeError` call sites are unaffected):

* **`CHUnreachable`** — DNS / connect / reset / timeout; no query can succeed, so `gather()` aborts immediately.
* **`CHQueryError`** — the server answered and rejected it; carries the parsed ClickHouse `Code: NNN` and HTTP status. **This path was previously unreachable**: `urlopen` raises `HTTPError` *before* the old non-2xx check could run, so the `RuntimeError(f"ClickHouse HTTP {code}")` branch was dead code for the common case.

`insights.py` runs its six queries independently and records per-query errors:

| exit | status | meaning |
|---|---|---|
| 0 | `ok` | full report |
| 0 | `not-configured` | no `CLICKHOUSE_URL` — the documented optional path, not a failure |
| **3** | `unreachable` | could not reach the server |
| **4** | `query-failed` | reachable, **all** queries rejected |
| **5** | `degraded` | reachable, **some** failed — report renders behind a loud banner naming the query **and the sections that are consequently missing** |

`--json` always carries `status` plus `error` / `errors` / `failed_queries`. A failed Layer-B query no longer prints "no qualitative insights yet" — that would read a query failure as an empty dataset.

## Live verification — the original failing command

```
$ insights.py --days 3 --json          # the exact invocation from the report
exit=0  status=ok  elapsed=1.98s
sessions 68 · messages 1401 (1377 prompts + 24 commands)
by_day   {'2026-07-31': 626, '2026-08-01': 204, '2026-08-02': 536, '2026-08-03': 35}
themes   AI/agents 745 · git/PR 621 · deploy/infra 608 · debug/errors 590
```

Controls, same run: bad port → `exit 3 status=unreachable`; `CLICKHOUSE_URL` unset → `exit 0 status=not-configured`.

## What this does NOT fix

The server genuinely is at its ceiling and intermittently cannot serve even the cheap aggregates. **Five consecutive live `--days 3 --json` runs on this branch:**

```
run 1: exit=0 status=ok        2.04s
run 2: exit=0 status=ok        1.98s
run 3: exit=5 status=degraded 17.12s
run 4: exit=5 status=degraded 18.23s
run 5: exit=0 status=ok        1.07s
```

3/5 complete in ~2s; 2/5 degrade **loudly**, naming the failed query. That is the intended behaviour under a sick server — never a silent exit 0, never a report that looks quiet when it is incomplete. **Cluster capacity is out of scope here** and is being handled separately.

Also observed live and worth knowing: `q_summaries` (`argMax(toString(payload))`) **does** run in 0.21s / 331 rows at 14d, but timed out on one run under pressure. It is not restructured here — the taxonomy now surfaces that state instead of hiding it.

## Harness validation + control pair

**Negative controls** (harness must be able to go RED before its green means anything):

| control | asserts |
|---|---|
| `test_harness_negative_control_a_plain_exception_is_still_caught` | a client that raises on everything is still seen as total failure |
| `test_harness_negative_control_capsys_sees_the_exit_code_and_stderr` | `main()`'s return value **and** stderr actually reach the test, via `--days 0` → `rc == 2` — a case whose answer is independent of the new taxonomy |

**Positive controls** for the reassuring zeros:

| counter | positive control | under test |
|---|---|---|
| `len(failed_queries)` | **1** (one query fails) and **6** (all fail) | **0** on the healthy path |
| equivalence fixture (two empty dicts compare equal!) | prompts **3**, commands **3**, `{"/standup": 2, "/handoff": 1}`, `{"fix": 2, "rebase": 1}`, 2 days, 2 hosts | — |

## Red/green matrix

Base ref **`origin/main` = 73f5ec0**. Method: `git checkout origin/main -- scripts/session-analysis/insights.py scripts/validation/chquery.py`, run the new file, restore.

| | at 73f5ec0 | at HEAD |
|---|---|---|
| new file `test_insights_failure_reporting.py` | **20 failed**, 4 passed | **29 passed** |
| `scripts/session-analysis/tests/` + `scripts/validation/tests/` | 368 passed | **397 passed**, 0 skipped |

The 4 green-at-both are the 2 harness negative controls (green by construction — they must be) and 2 **labelled invariant guards**: `test_both_error_classes_stay_runtimeerror_for_old_callers` and `test_healthy_report_has_no_banner` (a mutation guard that the banner is conditional, not always-on). They are **not** counted as regression coverage.

Full gate on the merged tree: `TOTAL collected=4568 passed=4567 skipped=1 failed=0 (floor: 2850)`. **Skips stay at the pinned 1** — nothing added here can skip.

## Tier

Run on the **dev host** (laptop) under `nix-shell` with the flake gate's package set, plus a live run against the real ClickHouse. Every test in the new file is **pure Python — no network, no `node`, no external binary** — so it behaves identically in the hermetic sandbox and on a dev host. No `skipif` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
