### PR TITLE
guard: enforce talosctl reset / mkfs / dd-to-a-block-device for Claude Code (#295 follow-on)

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -664,11 +664,13 @@ in
   # The SAME source file is also deployed to ~/.config/opencode/guard_core.py
   # below and driven by the opencode plugin — one implementation, two harnesses,
   # two named policies. "claude-code" was the frozen original six until
-  # 2026-08-02, when three argv checks were added to it by explicit operator
-  # decision — `git -C <p> reset --hard`, `git stash` and `git clean -f`, all
-  # 🔴 in RULES.md and all measured ALLOW against the live hook beforehand.
-  # "opencode" = those plus the still-opencode-only irreversible families
-  # (talosctl reset / mkfs / dd to a block device / rm -rf of a critical path).
+  # 2026-08-02, when SIX argv checks were added to it by explicit operator
+  # decision — `git -C <p> reset --hard`, `git stash`, `git clean -f`,
+  # `talosctl … reset`, `mkfs*` and `dd of=/dev/<block-dev>`, all 🔴 in RULES.md
+  # or unconditionally destructive, and all measured ALLOW against the live hook
+  # beforehand. "opencode" = those plus the one still-opencode-only family,
+  # `rm -rf` of a critical path (held back deliberately — it has frequent
+  # legitimate use here, so a deny would train the operator to route around it).
   # POLICIES in guard_core.py is the authority; test_guard_core.py pins it.
   home.file.".claude/hooks/guard_core.py" = {
     source = ../scripts/claude-hooks/guard_core.py;

--- a/scripts/claude-hooks/bash-guard.py
+++ b/scripts/claude-hooks/bash-guard.py
@@ -17,6 +17,12 @@ operator decision. The list today:
     incident 2026-07-25). `git stash list`/`show` are reads and stay allowed.
   - git clean -f             -> deletes untracked files, which here are routinely
     real work (2026-08-02; RULES 🔴). `git clean -nd` stays allowed.
+  - talosctl … reset         -> WIPES a Talos node (2026-08-02). Reads such as
+    `talosctl version` / `talosctl -n <ip> get members` stay allowed.
+  - mkfs / mke2fs / mkswap … -> formats a filesystem (2026-08-02). Matched on the
+    PROGRAM name, so naming it in an argument is not a command.
+  - dd of=/dev/<block-dev>   -> overwrites a disk in place (2026-08-02).
+    `of=/dev/null` and the other pseudo sinks, and file-to-file dd, stay allowed.
   - large heredoc -> file    -> use the Write tool (token waste; audit-driven)
   - cd <path> && git ...     -> use git -C <path> (audit: #1 command shape, 1482x)
   - private key in a command -> reference the key file instead (never inline)
@@ -24,13 +30,18 @@ operator decision. The list today:
     committing/posting (insights: leaked ingress IP into a public repo once)
 
 This hook fires on EVERY Bash call in EVERY Claude Code session on both hosts,
-so adding a check here changes the operator's primary tool. FOUR
-irreversible-action families remain opencode-ONLY and are deliberately NOT
-enabled here: talosctl reset, mkfs, dd to a block device, and rm -r of
-/|$HOME|cwd|a top-level system dir. `rm -rf` in particular risks false positives
-on legitimate build-directory cleanup. Switching this adapter to the "opencode"
-policy is a one-word change — and a decision for the operator to make
-explicitly, not a side effect of hardening a different tool.
+so adding a check here changes the operator's primary tool. Exactly ONE
+irreversible-action family remains opencode-ONLY and is deliberately NOT enabled
+here: `rm -r` of /|$HOME|cwd|a top-level system dir. 🔴 That is a DECISION, not
+the leftover of an unfinished migration — `rm -rf` has frequent legitimate use
+on these hosts (build dirs, node_modules, throwaway worktrees), and a guard that
+fires during routine cleanup trains the operator to route around it, which is
+worse than no guard because it also reports safety. Claude Code additionally
+falls back to a PROMPT the operator sees, the control opencode lacks. Do not
+"finish the job" by adding it; see _IRREVERSIBLE_CHECKS in guard_core.py.
+Switching this adapter to the "opencode" policy is a one-word change — and a
+decision for the operator to make explicitly, not a side effect of hardening a
+different tool.
 
 I/O contract (unchanged): reads PreToolUse JSON on stdin (`tool_name`,
 `tool_input.command`), prints `hookSpecificOutput.permissionDecision = "deny"`

--- a/scripts/claude-hooks/guard_core.py
+++ b/scripts/claude-hooks/guard_core.py
@@ -37,13 +37,18 @@ TWO CALLERS, TWO POLICIES
                   RULES.md mandates), followed the same day by
                   `check_git_stash` + `check_git_clean_force` — both 🔴 in
                   RULES.md, both measured ALLOW against the live hook, and
-                  neither with a benign in-repo use. Pinned by name in
+                  neither with a benign in-repo use — and then, later the same
+                  day, by `check_talosctl_reset` + `check_mkfs` +
+                  `check_dd_to_block_device`, the three device/cluster-
+                  destruction families, on the same evidence. Pinned by name in
                   test_guard_core.py.
-  "opencode"    — all of the above, plus the irreversible-action checks below. opencode
-                  agents run unattended (`opencode run` AUTO-REJECTS an `ask`
-                  rather than prompting — measured on 1.18.4), so a hard deny is
-                  the only thing standing between the model and an irreversible
-                  action.
+  "opencode"    — all of the above, plus `check_rm_rf_critical`, which is now
+                  the ONLY opencode-only check. opencode agents run unattended
+                  (`opencode run` AUTO-REJECTS an `ask` rather than prompting —
+                  measured on 1.18.4), so a hard deny is the only thing standing
+                  between the model and an irreversible action. `rm -rf` was
+                  deliberately held back from "claude-code" because it has
+                  frequent legitimate use here — see _IRREVERSIBLE_CHECKS.
 
 A check is `f(cmd) -> reason|None`. Adding one to "opencode" is additive; adding
 one to "claude-code" is a behaviour change to report.
@@ -571,11 +576,34 @@ def _flags_and_operands(argv):
 # =========================================================================== #
 # ARGV-BASED CHECKS — the irreversible families globs handle badly.
 #
-# NOT all opencode-only any more. `check_git_reset_hard_argv` (2026-08-02),
-# `check_git_stash` and `check_git_clean_force` (2026-08-02) run under BOTH
-# policies; talosctl/mkfs/dd/rm stay opencode-only. POLICIES at the bottom is
-# the authority — read it rather than assuming from this section heading.
+# NOT opencode-only any more, and by now MOSTLY not: `check_git_reset_hard_argv`,
+# `check_git_stash` and `check_git_clean_force` (all 2026-08-02) run under BOTH
+# policies, and `check_talosctl_reset`, `check_mkfs` and `check_dd_to_block_device`
+# joined them later the same day. `check_rm_rf_critical` is the ONLY check in
+# this section that is still opencode-only, deliberately — see _IRREVERSIBLE_CHECKS.
+# POLICIES at the bottom is the authority — read it rather than assuming from
+# this section heading.
 # =========================================================================== #
+
+# The escape hatch every claude-code-policy deny message must carry. The guard
+# parses RAW TEXT, and the argv parser splits on newlines — so a heredoc body
+# LINE that documents a banned command is parsed as that command and denied.
+# `check_git_add_all` established this convention after the operator's own test
+# harness was blocked for containing the literal string `git add -A`; #295
+# extended it to the stash/clean messages. Every check that is in
+# `_CLAUDE_CODE_CHECKS` hands the caller the same documented way out, because a
+# check that fires on every Bash call in every session WILL eventually fire on
+# someone writing ABOUT the command.
+#
+# One string, one place: a message asserted to contain it in test_guard_core.py
+# should not be able to drift per-check.
+_QUOTING_ESCAPE_HATCH = (
+    " (Only QUOTING this command — e.g. a heredoc body documenting the ban, whose lines this "
+    "guard parses as real commands? Write the text to a file with the Write tool and use "
+    "`git commit -F <file>` / `gh pr create --body-file <file>` — which your RULES prefer over "
+    "heredocs anyway.)"
+)
+
 
 def check_talosctl_reset(cmd):
     """Wipes a Talos node.
@@ -589,6 +617,10 @@ def check_talosctl_reset(cmd):
     Enumerating which talosctl flags take a value is a moving target across
     versions, and getting it wrong fails OPEN. `talosctl get resetstatus` is not
     a bare `reset` token, so the obvious false positive does not occur.
+
+    Enabled for BOTH policies since 2026-08-02 (it shipped opencode-only). It
+    lives in `_CLAUDE_CODE_CHECKS`, which `POLICIES["opencode"]` includes, so
+    opencode keeps coverage by inheritance rather than a duplicate entry.
     """
     for argv in commands(cmd):
         if os.path.basename(argv[0]) != "talosctl":
@@ -599,7 +631,8 @@ def check_talosctl_reset(cmd):
                     "no prompt worth clicking through. If a node genuinely must be reset, run it "
                     "yourself with the exact `--system-labels-to-wipe` / `--graceful` flags you "
                     "intend. (This guard parses argv, so `talosctl -n <ip> reset`, "
-                    "`talosctl --nodes <ip> reset` and `sudo talosctl reset` are all caught.)")
+                    "`talosctl --nodes <ip> reset` and `sudo talosctl reset` are all caught.)"
+                    + _QUOTING_ESCAPE_HATCH)
     return None
 
 
@@ -607,14 +640,20 @@ _MKFS = re.compile(r"^(?:mkfs(?:\.[A-Za-z0-9_-]+)?|mke2fs|mkswap|newfs|mkntfs|mk
 
 
 def check_mkfs(cmd):
-    """Formats a filesystem — destroys every byte on the target device."""
+    """Formats a filesystem — destroys every byte on the target device.
+
+    Enabled for BOTH policies since 2026-08-02 (it shipped opencode-only), by
+    inheritance from `_CLAUDE_CODE_CHECKS`. It matches on the PROGRAM NAME, so
+    it cannot fire on a `mkfs` substring inside an argument — `grep -rn 'mkfs'`
+    and `echo 'mkfs.ext4 is banned'` stay allowed, asserted in the tests.
+    """
     for argv in commands(cmd):
         base = os.path.basename(argv[0])
         if _MKFS.match(base):
             return (f"`{base}` is blocked — it FORMATS a filesystem and destroys everything on "
                     "the target device. No agent on these hosts has a reason to run it. If you "
                     "are provisioning a disk, do it yourself with the device path in front of "
-                    "you.")
+                    "you." + _QUOTING_ESCAPE_HATCH)
     return None
 
 
@@ -623,7 +662,13 @@ _DD_SAFE_DEV = re.compile(r"^/dev/(?:null|zero|stdout|stderr|stdin|tty|full|rand
 
 
 def check_dd_to_block_device(cmd):
-    """`dd of=/dev/sdX` overwrites a disk in place. `of=/dev/null` is fine."""
+    """`dd of=/dev/sdX` overwrites a disk in place. `of=/dev/null` is fine.
+
+    Enabled for BOTH policies since 2026-08-02 (it shipped opencode-only), by
+    inheritance from `_CLAUDE_CODE_CHECKS`. Only an `of=` under `/dev/` that is
+    not one of the pseudo sinks denies, so the ordinary file-to-file `dd` an
+    agent might legitimately run is untouched.
+    """
     for argv in commands(cmd):
         if os.path.basename(argv[0]) != "dd":
             continue
@@ -635,7 +680,7 @@ def check_dd_to_block_device(cmd):
                 return (f"`dd of={target}` is blocked — writing to a block device overwrites the "
                         "disk in place, past every filesystem and every backup tool. If you are "
                         "imaging a device, run it yourself. (`of=/dev/null` and the other pseudo "
-                        "sinks are allowed.)")
+                        "sinks are allowed.)" + _QUOTING_ESCAPE_HATCH)
     return None
 
 
@@ -867,34 +912,69 @@ def _git_strip_global_opts(argv):
 # does: `cd /x && git stash` now reports the stash reason, which names the more
 # serious of the two problems.
 #
-# The four remaining families (talosctl reset / mkfs / dd / rm -rf) stay
-# opencode-ONLY and were deliberately NOT moved here — see _IRREVERSIBLE_CHECKS.
+# 🔴 `check_talosctl_reset`, `check_mkfs` and `check_dd_to_block_device` were
+# added later on 2026-08-02 as the TENTH, ELEVENTH and TWELFTH checks, by the
+# same kind of explicit operator decision. Measured against the live
+# ~/.claude/hooks/bash-guard.py BEFORE the move, with `git add -A` and
+# `git reset --hard` as positive controls that came back DENY in the same sweep:
+#     ALLOW  talosctl -n 192.168.50.94 reset
+#     ALLOW  mkfs.ext4 /dev/sdc
+#     ALLOW  dd if=/dev/zero of=/dev/sdc
+# i.e. wiping a cluster node, formatting a disk and overwriting a block device
+# were all permitted, unprompted, on the operator's primary tool. None of the
+# three has ANY benign use from an agent on these hosts: the read/inspect
+# neighbours (`talosctl version`, `talosctl -n <ip> get members`, a file-to-file
+# `dd`, `dd of=/dev/null`) do not match, and `mkfs` matches on the PROGRAM name
+# so merely naming it in an argument is not a command.
+#
+# They sit BEFORE check_heredoc_to_file and check_cd_then_git so that a command
+# tripping both reports the DEVICE-DESTRUCTION reason rather than the token-waste
+# or use-`git -C` reason — the more serious of the two problems, the same
+# ordering rationale the git argv checks above use.
+#
+# 🔴 `check_rm_rf_critical` was deliberately NOT moved with them. See
+# _IRREVERSIBLE_CHECKS below for why, and do not "finish the job".
 _CLAUDE_CODE_CHECKS = [
     check_git_add_all,
     check_git_reset_hard,
     check_git_reset_hard_argv,
     check_git_stash,
     check_git_clean_force,
+    check_talosctl_reset,
+    check_mkfs,
+    check_dd_to_block_device,
     check_heredoc_to_file,
     check_cd_then_git,
     check_private_key,
     check_secret_or_ip_publish,
 ]
 
-# The irreversible families that remain opencode-ONLY: `opencode run`
-# AUTO-REJECTS an `ask` rather than prompting (measured on 1.18.4), and the
-# interactive TUI is the only place a human sees one — so for an unattended
-# agent a hard deny is the only real control.
+# 🔴 THE ONE CHECK THAT REMAINS opencode-ONLY — and it stays that way.
 #
-# 🔴 These four are NOT in the claude-code policy, and that narrowness is a
-# DECISION, not an oversight. `rm -rf` in particular risks false positives on
-# legitimate build-directory cleanup, and the other three are hardware/cluster
-# operations an interactive Claude Code session can be prompted about. Widening
-# any of them to claude-code is a separate operator decision.
+# `opencode run` AUTO-REJECTS an `ask` rather than prompting (measured on
+# 1.18.4), and the interactive TUI is the only place a human sees one, so for an
+# unattended agent a hard deny is the only real control. That justifies the deny
+# for opencode. It does NOT justify it for Claude Code, and the difference is
+# specific to this check:
+#
+#   `rm -rf` has legitimate, FREQUENT use on these hosts — build directories,
+#   `node_modules`, `.direnv`, throwaway worktrees, scratch trees under /tmp.
+#   `check_rm_rf_critical` is narrow (only `/`, `~`/`$HOME`, `.`/`..`, and the
+#   top-level system dirs), but "narrow" is not "never": the operator's own
+#   cleanup habits put `rm -rf` in front of this guard routinely, and a guard
+#   that fires during routine cleanup trains its subject to route around it.
+#   A guard that has been routed around is worse than no guard, because it also
+#   reports safety. In Claude Code the fallback is a PROMPT the operator sees —
+#   the exact control opencode lacks — so the deny buys much less there.
+#
+# 🔴 This narrowness is a DECISION, not an oversight, and it is NOT the residue
+# of a half-finished migration: talosctl/mkfs/dd moved to the claude-code policy
+# on 2026-08-02 and `check_rm_rf_critical` was held back in the SAME change, on
+# purpose. Do not "finish the job". Moving it is its own operator decision with
+# its own evidence, and the thing to bring is a measurement of how often the
+# fatal-target set would fire on real sessions — not the observation that it is
+# the last one left.
 _IRREVERSIBLE_CHECKS = [
-    check_talosctl_reset,
-    check_mkfs,
-    check_dd_to_block_device,
     check_rm_rf_critical,
 ]
 

--- a/scripts/claude-hooks/tests/test_guard_core.py
+++ b/scripts/claude-hooks/tests/test_guard_core.py
@@ -94,6 +94,23 @@ CLAUDE_CODE_EXPECTED = [
     # does — `cd /x && git stash` reports the stash reason, not the cd reason.
     "check_git_stash",
     "check_git_clean_force",
+    # 🔴 Added later on 2026-08-02 by explicit operator decision — the TENTH,
+    # ELEVENTH and TWELFTH. The three device/cluster-destruction families, each
+    # measured ALLOW against the live ~/.claude/hooks/bash-guard.py before the
+    # move, with `git add -A` and `git reset --hard` as DENY positive controls
+    # in the same sweep:
+    #   ALLOW  talosctl -n 192.168.50.94 reset
+    #   ALLOW  mkfs.ext4 /dev/sdc
+    #   ALLOW  dd if=/dev/zero of=/dev/sdc
+    # None has a benign use from an agent here; the read/inspect neighbours
+    # (`talosctl version`, `talosctl -n <ip> get members`, file-to-file `dd`,
+    # `dd of=/dev/null`) do not match, and `mkfs` matches on the PROGRAM name so
+    # naming it in an argument is not a command. See section 3c.
+    # They sit BEFORE check_heredoc_to_file / check_cd_then_git so a command
+    # tripping both reports the device-destruction reason.
+    "check_talosctl_reset",
+    "check_mkfs",
+    "check_dd_to_block_device",
     "check_heredoc_to_file",
     "check_cd_then_git",
     "check_private_key",
@@ -130,17 +147,29 @@ def test_opencode_policy_is_a_strict_superset():
     assert set(CLAUDE_CODE_EXPECTED) < set(oc)
 
 
-# 🔴 The families that remain opencode-ONLY. `check_git_stash` and
-# `check_git_clean_force` USED to be listed here; they moved into the
-# claude-code policy on 2026-08-02. These four did NOT move, deliberately:
-# `rm -rf` risks false positives on legitimate build-directory cleanup, and
-# talosctl/mkfs/dd are hardware/cluster operations an interactive Claude Code
-# session can be prompted about rather than hard-denied. Widening any of them
-# is a separate operator decision.
+# 🔴 THE ONE CHECK THAT REMAINS opencode-ONLY — and this list is expected to
+# STAY a list of one.
+#
+# `check_git_stash` + `check_git_clean_force` were listed here and moved into
+# the claude-code policy on 2026-08-02; `check_talosctl_reset`, `check_mkfs` and
+# `check_dd_to_block_device` followed later the same day. `check_rm_rf_critical`
+# was held back IN THAT SAME CHANGE, on purpose — it is not the residue of an
+# unfinished migration:
+#
+#   `rm -rf` has legitimate, FREQUENT use on these hosts (build directories,
+#   node_modules, .direnv, throwaway worktrees, /tmp scratch trees). The check
+#   is narrow — only `/`, `~`/`$HOME`, `.`/`..` and the top-level system dirs —
+#   but narrow is not never, and a guard that fires during routine cleanup
+#   trains its subject to route around it. A routed-around guard is worse than
+#   no guard because it still reports safety. Claude Code also falls back to a
+#   PROMPT the operator sees, which is exactly the control opencode lacks
+#   (`opencode run` auto-rejects an `ask`), so the deny buys much less here.
+#
+# 🔴 Do not "finish the job" by moving it. That is its own operator decision and
+# it needs its own evidence — a measurement of how often the fatal-target set
+# would actually fire on real sessions, not the observation that it is the last
+# one left.
 IRREVERSIBLE_EXPECTED = [
-    "check_talosctl_reset",
-    "check_mkfs",
-    "check_dd_to_block_device",
     "check_rm_rf_critical",
 ]
 
@@ -151,22 +180,28 @@ def test_opencode_policy_carries_the_irreversible_checks():
 
 
 @pytest.mark.parametrize("command", [
-    "talosctl -n 192.168.50.94 reset",
-    "mkfs.ext4 /dev/sda",
-    "dd if=x of=/dev/sda",
     "rm -rf /",
+    "rm -rf $HOME",
+    "sudo rm -rf /etc",
+    "rm -fr /usr",
     # NOTE: `git -C <path> reset --hard` USED to be listed here, asserting that
     # Claude Code allowed it. That was the gap, not a feature — it is now denied
     # under both policies and is asserted positively in section 1b below.
     # NOTE: `git stash push -m wip` and `git clean -fd` were listed here for the
     # same reason and moved for the same reason — see section 1c.
+    # NOTE: `talosctl -n <ip> reset`, `mkfs.ext4 /dev/sda` and
+    # `dd if=x of=/dev/sda` were listed here for the same reason and moved for
+    # the same reason — see section 3c.
 ])
 def test_the_new_checks_do_not_leak_into_claude_code(command):
     """🔴 The blast-radius assertion, by OUTCOME rather than by list membership.
 
     Each of these is denied under "opencode" and must resolve to no-deny under
-    "claude-code" — the four families that stayed opencode-only. This is the
-    fence that keeps a later "while I'm here" widening honest.
+    "claude-code" — the ONE family that stayed opencode-only, `rm -rf` of a
+    critical path. This is the fence that keeps a later "while I'm here"
+    widening honest, and after 2026-08-02 it is the whole fence: if these rows
+    start denying under claude-code, someone finished a job that was
+    deliberately left unfinished. Read IRREVERSIBLE_EXPECTED above first.
     """
     assert gc.evaluate(command, "opencode") is not None
     assert gc.evaluate(command, "claude-code") is None
@@ -798,6 +833,225 @@ def test_the_one_real_quoting_false_positive_is_a_heredoc_body():
 
 
 # --------------------------------------------------------------------------- #
+# 3c. 🔴 talosctl reset / mkfs / dd-to-a-block-device under the CLAUDE-CODE policy
+#
+# Closes a gap that was live on both hosts until 2026-08-02. All three checks
+# existed and were correct — they were simply not in the policy bash-guard.py
+# runs, so wiping a cluster node, formatting a disk and overwriting a block
+# device were all permitted, unprompted, on the operator's primary tool.
+#
+# Probed against the repo's guard_core under BOTH policies before the change,
+# WITH controls in the same sweep so a wired-to-nothing harness could not have
+# produced the reassuring answer:
+#
+#     DENY   git add -A                          <- positive control (guard live)
+#     DENY   git reset --hard HEAD               <- positive control
+#     ALLOW  talosctl -n 192.168.50.94 reset
+#     ALLOW  mkfs.ext4 /dev/sdc
+#     ALLOW  dd if=/dev/zero of=/dev/sdc
+#     ALLOW  ls -la /tmp                         <- benign control
+#
+# (Independently measured against the DEPLOYED ~/.claude/hooks/bash-guard.py by
+# the operator the same evening, with the same verdicts.)
+#
+# Every deny below is asserted BY REASON, not by `is not None`. The heredoc row
+# is the reason that matters: with this change reverted it still DENIES, via
+# check_heredoc_to_file — so a bare truthiness assertion would be green for the
+# wrong reason and would pass with check_mkfs deleted from the policy entirely.
+# --------------------------------------------------------------------------- #
+TALOS_REASON_MARK = "`talosctl reset` is blocked"
+# mkfs/dd interpolate the program name and the device into the message, so the
+# mark is the stable clause rather than the leading backtick phrase.
+MKFS_REASON_MARK = "FORMATS a filesystem"
+DD_REASON_MARK = "writing to a block device overwrites the disk in place"
+
+
+# The wrapped/prefixed spellings the parser exists to survive. Device paths and
+# node IPs are pairwise distinct so no fixture can pass by accident of another's
+# text, and none of the paths contains the substring `reset`/`mkfs`/`dd`.
+TALOS_DENY = [
+    "talosctl reset",
+    "talosctl -n 192.168.50.94 reset",
+    "talosctl --nodes 192.168.50.95 reset",
+    "talosctl -n 192.168.50.96 reset --graceful=false",
+    "VAR=1 talosctl reset",
+    "sudo talosctl reset",
+    "sudo -n talosctl -n 192.168.50.97 reset",
+    "env talosctl reset",
+    "timeout 60 talosctl -n 192.168.50.98 reset",
+    "bash -c 'talosctl -n 192.168.50.99 reset'",
+    "echo ok && talosctl reset",
+    "kubectl get nodes; talosctl -n 192.168.50.100 reset",
+    "/usr/local/bin/talosctl -n 192.168.50.101 reset",
+]
+
+MKFS_DENY = [
+    "mkfs.ext4 /dev/sdc",
+    "mkfs.xfs /dev/sdd1",
+    "mkfs -t ext4 /dev/sde",
+    "mke2fs /dev/sdf",
+    "mkswap /dev/sdg",
+    "mkdosfs /dev/sdh1",
+    "VAR=1 mkfs.ext4 /dev/sdi",
+    "sudo mkfs.ext4 /dev/sdj",
+    "sudo -n mkfs.btrfs /dev/sdk",
+    "env mkfs.ext4 /dev/sdl",
+    "bash -c 'mkfs.ext4 /dev/sdm'",
+    "echo ok && mkfs.ext4 /dev/sdn",
+    "lsblk; mkfs.ext4 /dev/sdo",
+    "/usr/sbin/mkfs.ext4 /dev/sdp",
+]
+
+DD_DENY = [
+    "dd if=/dev/zero of=/dev/sdc",
+    "dd if=image.iso of=/dev/sdd bs=4M status=progress",
+    "dd of=/dev/sde if=/dev/zero",
+    "dd if=/dev/zero of=/dev/nvme0n1",
+    "dd if=/dev/zero of=/dev/mapper/vg0-lv0",
+    "VAR=1 dd if=/dev/zero of=/dev/sdf",
+    "sudo dd if=/dev/zero of=/dev/sdg",
+    "sudo -n dd if=/dev/zero of=/dev/sdh",
+    "env dd if=/dev/zero of=/dev/sdi",
+    "bash -c 'dd if=/dev/zero of=/dev/sdj'",
+    "echo ok && dd if=/dev/zero of=/dev/sdk",
+    "lsblk; dd if=/dev/zero of=/dev/sdl",
+    "/usr/bin/dd if=/dev/zero of=/dev/sdm",
+]
+
+
+@pytest.mark.parametrize("command", TALOS_DENY)
+def test_talosctl_reset_is_denied_under_claude_code(command):
+    """🔴 RED at origin/main for every row: the check was opencode-only, so
+    `claude-code` returned None."""
+    _assert_denied_as(command, TALOS_REASON_MARK, "claude-code")
+
+
+@pytest.mark.parametrize("command", MKFS_DENY)
+def test_mkfs_is_denied_under_claude_code(command):
+    """🔴 RED at origin/main for every row — same mechanism."""
+    _assert_denied_as(command, MKFS_REASON_MARK, "claude-code")
+
+
+@pytest.mark.parametrize("command", DD_DENY)
+def test_dd_to_block_device_is_denied_under_claude_code(command):
+    """🔴 RED at origin/main for every row — same mechanism."""
+    _assert_denied_as(command, DD_REASON_MARK, "claude-code")
+
+
+@pytest.mark.parametrize("command", TALOS_DENY)
+def test_talosctl_reset_still_denied_under_opencode(command):
+    """The move must not COST opencode anything: `POLICIES["opencode"]` is
+    `_CLAUDE_CODE_CHECKS + _IRREVERSIBLE_CHECKS`, so the check is inherited
+    rather than duplicated. This asserts the inheritance actually holds."""
+    _assert_denied_as(command, TALOS_REASON_MARK, "opencode")
+
+
+@pytest.mark.parametrize("command", MKFS_DENY)
+def test_mkfs_still_denied_under_opencode(command):
+    _assert_denied_as(command, MKFS_REASON_MARK, "opencode")
+
+
+@pytest.mark.parametrize("command", DD_DENY)
+def test_dd_to_block_device_still_denied_under_opencode(command):
+    _assert_denied_as(command, DD_REASON_MARK, "opencode")
+
+
+def test_mkfs_in_a_heredoc_body_reports_the_mkfs_reason_not_the_heredoc_reason():
+    """🔴 The ORDERING pin, and the one row that is NOT green-by-default.
+
+    With this change reverted this command still denies — via
+    check_heredoc_to_file, which sits later in the list but was the only check
+    of the two in the claude-code policy. So `assert reason is not None` passes
+    at origin/main and pins nothing. The attribution is the whole test: the
+    three new checks sit BEFORE check_heredoc_to_file, so the reason names the
+    device destruction rather than the token waste.
+    """
+    heredoc = (
+        "cat > /tmp/runbook.md <<'EOF'\n"
+        "mkfs.ext4 /dev/sdq\n"
+        + ("filler line to clear the heredoc size threshold\n" * 40)
+        + "EOF"
+    )
+    assert gc.check_heredoc_to_file(heredoc) is not None, (
+        "fixture no longer trips the heredoc check, so this test would pass "
+        "trivially — the ordering is no longer being exercised"
+    )
+    _assert_denied_as(heredoc, MKFS_REASON_MARK, "claude-code")
+
+
+# --- the ALLOW half -------------------------------------------------------- #
+# 🔴 Built independently of the deny lists — different subcommands, different
+# device paths — so a copy-paste symmetry cannot make both halves agree with the
+# same bug. INVARIANT GUARDS (green before and after): this is the
+# false-positive fence, not regression coverage for any shipped bug.
+DEVICE_ALLOW = [
+    # talosctl reads and non-reset verbs
+    "talosctl version",
+    "talosctl -n 192.168.50.110 get members",
+    "talosctl -n 192.168.50.111 get resetstatus",
+    "talosctl -n 192.168.50.112 dmesg",
+    "talosctl -n 192.168.50.113 health",
+    "talosctl --nodes 192.168.50.114 services",
+    # dd that is not aimed at a block device
+    "dd if=in.img of=out.img bs=1M",
+    "dd if=/dev/urandom of=/tmp/seed.bin count=1",
+    "dd if=/dev/zero of=/dev/null bs=1M count=10",
+    "dd if=/dev/sdz of=/tmp/backup.img",
+    # mkfs matched on the PROGRAM name, so naming it is not running it
+    "echo 'mkfs.ext4 is banned on these hosts'",
+    "grep -rn 'mkfs' claude/RULES.md",
+    "rg 'dd if=/dev/zero of=/dev/sda' docs/",
+    "git commit -m 'document why mkfs is blocked'",
+    # near-miss program names
+    "mkdir -p /tmp/scratch-nu",
+    "mktemp -d",
+    "ddrescue --help",
+]
+
+
+@pytest.mark.parametrize("command", DEVICE_ALLOW)
+def test_device_check_neighbours_stay_allowed_under_claude_code(command):
+    """INVARIANT GUARD. Reads and inspections are how an operator diagnoses the
+    thing the deny message tells them to do by hand; blocking those would push
+    them toward guessing. `dd if=/dev/sdz of=/tmp/backup.img` is the asymmetry
+    that matters — reading a device is not writing one."""
+    assert gc.evaluate(command, "claude-code") is None
+    assert gc.evaluate(command, "opencode") is None
+
+
+# --- the escape hatch ------------------------------------------------------ #
+def test_device_deny_messages_carry_the_quoting_escape_hatch():
+    """🔴 The convention `check_git_add_all` set and #295 extended: every check
+    in the claude-code policy fires on RAW TEXT in every Bash call in every
+    session, so it WILL eventually fire on someone writing ABOUT the command.
+    All three new messages must hand the caller the same documented way out."""
+    for reason in (gc.check_talosctl_reset("talosctl reset"),
+                   gc.check_mkfs("mkfs.ext4 /dev/sdr"),
+                   gc.check_dd_to_block_device("dd if=/dev/zero of=/dev/sds")):
+        assert reason is not None
+        assert "commit -F" in reason, reason
+        assert "--body-file" in reason, reason
+        assert "Write tool" in reason, reason
+
+
+def test_rm_rf_is_the_only_check_left_out_of_claude_code():
+    """🔴 The DECISION pin, stated as an assertion so it cannot quietly become
+    an oversight in either direction.
+
+    Down: if `check_rm_rf_critical` is later added to claude-code this fails,
+    and whoever does it must come with the evidence IRREVERSIBLE_EXPECTED asks
+    for (how often the fatal-target set fires on real sessions) rather than the
+    observation that it is the last one left.
+
+    Up: it also fails if a NEW check is parked in `_IRREVERSIBLE_CHECKS` as a
+    way of adding a guard without the claude-code conversation.
+    """
+    oc = [f.__name__ for f in gc.POLICIES["opencode"]]
+    cc = [f.__name__ for f in gc.POLICIES["claude-code"]]
+    assert [n for n in oc if n not in cc] == ["check_rm_rf_critical"]
+
+
+# --------------------------------------------------------------------------- #
 # 4. end-to-end through the policy, over the full spelling product
 # --------------------------------------------------------------------------- #
 IRREVERSIBLE_SAMPLES = [
@@ -1133,9 +1387,14 @@ def test_cli_denies_with_a_reason():
 
 
 def test_cli_honours_the_policy_flag():
+    """The discriminating command must be one the two policies DISAGREE about,
+    and after 2026-08-02 `talosctl reset` is no longer such a command — it moved
+    into the claude-code policy, which turned this test red (correctly: it was
+    asserting the gap). `rm -rf /` is the one remaining disagreement, so it is
+    the only fixture that can still exercise the flag."""
     import json
-    assert json.loads(_cli("talosctl reset", "claude-code").stdout)["decision"] == "allow"
-    assert json.loads(_cli("talosctl reset", "opencode").stdout)["decision"] == "deny"
+    assert json.loads(_cli("rm -rf /", "claude-code").stdout)["decision"] == "allow"
+    assert json.loads(_cli("rm -rf /", "opencode").stdout)["decision"] == "deny"
 
 
 def test_cli_reports_bad_input_with_a_nonzero_exit():


### PR DESCRIPTION
Follow-on to #295. Three of the four remaining opencode-only families move into the `claude-code` policy that `bash-guard.py` runs. This is a **list change, not a reimplementation** — the checks already existed and were already correct.

## What was measured, before the change

Probed against the repo's `guard_core.py` under both policies, **with positive and benign controls in the same sweep** so a wired-to-nothing probe could not have produced the reassuring answer:

```
DENY   git add -A                          <- positive control (guard is live)
DENY   git reset --hard HEAD               <- positive control
ALLOW  talosctl -n 192.168.50.94 reset
ALLOW  talosctl --nodes 192.168.50.94 reset
ALLOW  sudo talosctl reset
ALLOW  mkfs.ext4 /dev/sdc
ALLOW  mke2fs /dev/sdc
ALLOW  dd if=/dev/zero of=/dev/sdc
ALLOW  dd if=/dev/zero of=/dev/nvme0n1 bs=4M
ALLOW  ls -la /tmp                         <- benign control
```

Zach independently measured the three headline rows ALLOW against the **deployed** `~/.claude/hooks/bash-guard.py` the same evening, with the same verdicts. So: wiping a Talos node, formatting a disk and overwriting a block device were all permitted, unprompted, on the operator's primary tool.

## What changed

- `check_talosctl_reset`, `check_mkfs`, `check_dd_to_block_device` move from `_IRREVERSIBLE_CHECKS` into `_CLAUDE_CODE_CHECKS`. `POLICIES["opencode"]` is `_CLAUDE_CODE_CHECKS + _IRREVERSIBLE_CHECKS`, so **opencode keeps coverage by inheritance, not duplication** — asserted, not assumed.
- All three deny messages now carry the #295 "if you are only QUOTING this" escape hatch (write the text to a file, `git commit -F` / `gh pr create --body-file`). The guard matches raw text and the argv parser splits on newlines, so a heredoc body line documenting the ban parses as the command. Factored into one `_QUOTING_ESCAPE_HATCH` constant so a message asserted to contain it cannot drift per-check.
- **Ordering**: they sit before `check_heredoc_to_file` / `check_cd_then_git`, so a command tripping both reports the device-destruction reason rather than the token-waste one. Same rationale as #295's placement of the git argv checks.
- Docs updated at all four places that describe the policy split: `guard_core.py`'s module docstring, the ARGV-CHECKS section header, `bash-guard.py`'s header, and `nix/home.nix`.

### 🔴 `check_rm_rf_critical` was deliberately NOT moved

It is now the **only** opencode-only check, and it stays that way. `rm -rf` has legitimate, frequent use on these hosts — build directories, `node_modules`, `.direnv`, throwaway worktrees, `/tmp` scratch trees. The check is narrow (only `/`, `~`/`$HOME`, `.`/`..`, top-level system dirs), but narrow is not never, and **a guard that fires during routine cleanup trains its subject to route around it — worse than no guard, because it also reports safety.** Claude Code additionally falls back to a prompt the operator sees, which is exactly the control opencode lacks (`opencode run` auto-rejects an `ask`).

The reasoning is written into `_IRREVERSIBLE_CHECKS`, `bash-guard.py`'s header and `IRREVERSIBLE_EXPECTED` — three places a future reader might look before "finishing the job" — and pinned by `test_rm_rf_is_the_only_check_left_out_of_claude_code`, which **fails in both directions**: if `check_rm_rf_critical` is added to claude-code, and if a *new* check is parked in `_IRREVERSIBLE_CHECKS` as a way of adding a guard without the claude-code conversation.

## Allow-fence (preserved, asserted)

`talosctl version`, `talosctl -n <ip> get members`, `talosctl -n <ip> get resetstatus`, `talosctl … dmesg/health/services`; file-to-file `dd`, `dd of=/dev/null` and the other pseudo sinks, and `dd if=/dev/sdz of=/tmp/backup.img` (**reading** a device is not writing one); `mkfs` appearing only inside a quoted string — the check matches on the *program name*, so `echo 'mkfs.ext4 is banned'` and `grep -rn 'mkfs' RULES.md` are arguments, not commands; near-miss program names `mkdir`, `mktemp`, `ddrescue`. 18 rows, all invariant guards — green before and after, so they are the false-positive fence, **not** regression coverage.

## Red/green matrix — base ref `26d5268` (`origin/main`)

Method: `git archive 26d5268 scripts/claude-hooks` into a temp tree, drop in the NEW test file, run. Collection is identical in both runs (1129), so the two are comparable — a "red" here cannot just mean "the file did not import".

| run | result |
|---|---|
| **NEW tests vs BASE `guard_core.py`** | **48 failed**, 1081 passed |
| NEW tests vs HEAD `guard_core.py` | **1129 passed**, 0 failed |
| BASE tests vs BASE (control) | 3 failed, 1026 passed |

The 3 control failures (`test_plugin_*`) are environmental — the `git archive` tree lacks the opencode plugin the test reads — and appear identically in the base run. **Net genuinely-red: 45.**

| test | rows red at base |
|---|---|
| `test_mkfs_is_denied_under_claude_code` | 14 |
| `test_talosctl_reset_is_denied_under_claude_code` | 13 |
| `test_dd_to_block_device_is_denied_under_claude_code` | 13 |
| `test_claude_code_policy_is_pinned_by_name` | 1 |
| `test_opencode_policy_is_a_strict_superset` | 1 |
| `test_rm_rf_is_the_only_check_left_out_of_claude_code` | 1 |
| `test_mkfs_in_a_heredoc_body_reports_the_mkfs_reason_not_the_heredoc_reason` | 1 |
| `test_device_deny_messages_carry_the_quoting_escape_hatch` | 1 |

**Labelled as invariant guards, NOT regression coverage** (green before and after): the 18-row `DEVICE_ALLOW` fence, and `test_the_new_checks_do_not_leak_into_claude_code` / `test_cli_honours_the_policy_flag`, which now use `rm -rf` fixtures that behave identically at base.

`test_cli_honours_the_policy_flag` was *changed*, not added: it used `talosctl reset` as its "claude-code allows this" fixture, which this PR correctly turns red. `rm -rf /` is the only remaining disagreement between the two policies, so it is now the only fixture that can exercise the `--policy` flag at all.

## Mutation matrix — 10 mutants, all KILLED **and attributed**

Every mutant must produce failures matching **that guard's own** test names. A mutant that only trips a *different* guard's test is reported UNATTRIBUTED (the RULES failure mode "a different guard's error kills your test"), not KILLED.

| mutant | verdict |
|---|---|
| talosctl: drop from claude-code policy | KILLED — 129 failed, attributed |
| mkfs: drop from claude-code policy | KILLED — 58 failed, attributed |
| dd: drop from claude-code policy | KILLED — 51 failed, attributed |
| talosctl: neuter the verb match | KILLED — 215 failed, attributed |
| mkfs: neuter the program regex | KILLED — 110 failed, attributed |
| dd: treat every `/dev/` target as a safe sink | KILLED — 85 failed, attributed |
| dd: **drop** the safe-sink exemption (over-broad) | KILLED — 4 failed, hits the ALLOW fence |
| mkfs: strip the quoting escape hatch | KILLED — 1 failed, attributed |
| ordering: move the three AFTER `check_heredoc_to_file` | KILLED — 3 failed, attributed |
| `rm -rf`: "finish the job" — add it to claude-code | KILLED — 7 failed, attributed |

**Harness controls, both run and both required before any verdict above was believed:**
- **POSITIVE** — unmutated baseline before and after the sweep: `collected=1129 failed=0`. A zero/one collected count is what a broken harness looks like; the sweep aborts on it. The source is restored after every mutant so a left-applied mutation cannot poison the next baseline.
- **NEGATIVE (two, run explicitly)** — a mutant whose needle is absent reported `SKIP-BROKEN` (a never-applied mutant must not read as green), and a no-op mutation reported `🔴 SURVIVED`. The harness can go red in both shapes, so its greens mean something.

The sweep **counts** `N failed, N passed` from the summary line and fails loudly if that format does not match; it never reads an exit code.

`test_mkfs_in_a_heredoc_body_reports_the_mkfs_reason_not_the_heredoc_reason` is the one row that is **not** green-by-default: with this change reverted the command still DENIES, via `check_heredoc_to_file`. A bare `is not None` would be green for the wrong reason and would pass with `check_mkfs` removed from the policy entirely. It also asserts its own fixture still trips the heredoc check, so it cannot degrade into passing trivially.

## Both tiers

| tier | result |
|---|---|
| **`nix build .#checks.x86_64-linux.pytests`** (authoritative) | **collected=4760 passed=4759 skipped=1 failed=0** |
| dev host, `scripts/run-tests.sh` | see comment below |

Main is `4660 / 4659 / 1`. Delta **+100**, exactly the tests added here (`test_guard_core.py`: 1029 → 1129). The single skip is the pre-existing opt-in `repo-cos` live-store drift check.

## Files touched

`scripts/claude-hooks/guard_core.py`, `scripts/claude-hooks/bash-guard.py`, `scripts/claude-hooks/tests/test_guard_core.py`, and **`nix/home.nix`** — the `nix/home.nix` hunk is a **6-line comment change only**, in the `home.file.".claude/hooks/guard_core.py"` block, describing the new policy split. No option or path changed. Flagged because sibling agents are also touching that file.

## Deployment

`bash-guard.py` and `guard_core.py` are `home.file` targets — **merging changes nothing**. This takes effect on `home-manager switch` / `ship.sh`. Not run here, per the task constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
