### PR TITLE
hygiene: cap the ~/.claude logs, and fix the session-summary amplification

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -156,7 +156,18 @@
             # AND turns the version assertion red. That red is the point — the
             # config header's "measured on v1.18.4 — do not re-derive" claims are
             # otherwise pinned to nothing.
-            nativeBuildInputs = [ pyEnv pkgs.bash pkgs.ripgrep pkgs.git pkgs.util-linux pkgs.jq pkgs.gnugrep pkgs.curl pkgs.nodejs pkgs.nix pkgs.opencode ];
+            #
+            # logrotate: scripts/tests/test_claude_log_rotate.py drives the REAL
+            # binary against a temp directory — it asserts that an oversized log
+            # is rotated AND truncated in place (copytruncate), that a small one
+            # is left alone, that the generation cap holds, and 🔴 that the nine
+            # hand-made `.bak` config copies in ~/.claude are never touched. That
+            # last one is a data-loss fence, so it must not be a skipif: those
+            # tests FAIL naming the missing binary, the same deliberate choice as
+            # nix-instantiate and opencode above. Hermetic — logrotate only ever
+            # sees a pytest tmp_path, its own generated config and its own state
+            # file; no network, no ambient /var/lib/logrotate.status.
+            nativeBuildInputs = [ pyEnv pkgs.bash pkgs.ripgrep pkgs.git pkgs.util-linux pkgs.jq pkgs.gnugrep pkgs.curl pkgs.nodejs pkgs.nix pkgs.opencode pkgs.logrotate ];
           }
           ''
             cp -r ${./.} src

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1916,4 +1916,49 @@ in
       WantedBy = [ "timers.target" ];
     };
   };
+
+  # ~/.claude log rotation. NOT serverMode-gated, deliberately: both hosts run
+  # Claude Code and both accumulate these files. Measured on the workbench
+  # 2026-08-02 — notify.log 39.8 MB (dead writer, last touched 2026-07-06),
+  # clawgate-hook.log 12.0 MB (live), 51.6 MB unrotated in total and growing.
+  #
+  # Only ONE of those writers lives in this repo, which is why the cap is on the
+  # DIRECTORY rather than in each writer: `clawgate-hook.log` comes from the
+  # clawgate approval hook and `notify.log` from something no longer running.
+  # The wrapper uses logrotate's `copytruncate` so an open fd (that hook fires on
+  # every tool call) keeps writing to the same file instead of to an unlinked
+  # inode. Scope is `*.log` ONLY — the hand-made `.bak` config copies in that
+  # directory are never touched. See scripts/claude-log-rotate/rotate.sh.
+  systemd.user.services.claude-log-rotate = {
+    Unit = {
+      Description = "Size-cap the unrotated logs in ~/.claude (logrotate, copytruncate)";
+      OnFailure = [ "notify-failure@%n.service" ];
+    };
+    Service = {
+      Type = "oneshot";
+      Environment = [
+        "PATH=${lib.makeBinPath [ pkgs.logrotate pkgs.bash pkgs.coreutils ]}"
+        "HOME=%h"
+      ];
+      ExecStart = "${pkgs.bash}/bin/bash %h/workspace/devrc/scripts/claude-log-rotate/rotate.sh";
+      # Re-run the unit when the wrapper changes (cf. X-Restart-Triggers above).
+      X-Restart-Triggers = [ "${../scripts/claude-log-rotate/rotate.sh}" ];
+    };
+  };
+
+  # Daily. Persistent catches up a single missed run (host asleep / powered off),
+  # which matters here precisely because the growth is slow and unattended.
+  systemd.user.timers.claude-log-rotate = {
+    Unit = {
+      Description = "Daily timer for the ~/.claude log size cap";
+    };
+    Timer = {
+      OnCalendar = "*-*-* 04:00:00";
+      Persistent = true;
+      RandomizedDelaySec = 600;
+    };
+    Install = {
+      WantedBy = [ "timers.target" ];
+    };
+  };
 }

--- a/scripts/claude-log-rotate/rotate.sh
+++ b/scripts/claude-log-rotate/rotate.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Size-cap the unrotated logs in ~/.claude.
+#
+# WHY: nothing rotates them. Measured 2026-08-02 on the workbench:
+#   notify.log         39,822,110 B   (last written 2026-07-06 — a DEAD writer)
+#   clawgate-hook.log  12,033,179 B   (live)
+#   claude-notify.log      60,684 B
+#   daemon.log              6,091 B
+# 51.6 MB total, growing without bound. Only `claude-notify.log` has a writer in
+# this repo (scripts/claude-hooks/claude-notify.py); `notify.log` and
+# `clawgate-hook.log` are written by things OUTSIDE it, which is exactly why the
+# cap has to live at the DIRECTORY, not in each writer.
+#
+# `copytruncate` is load-bearing and not an optimisation: the writers hold open
+# file descriptors, they are not ours to signal, and one of them is a hook that
+# runs on every Claude Code tool call. Renaming the file out from under an open
+# fd would leave it appending to an unlinked inode — the log would appear frozen
+# while silently consuming the same disk. copytruncate copies then truncates in
+# place, so the open fd keeps writing to the same, now-empty, file.
+#
+# 🔴 SCOPE: `*.log` ONLY. It deliberately does NOT touch the 9 stale `.bak`
+# files in that directory (settings.json.bak.*, RULES.md.bak*, PRINCIPLES.md.bak*,
+# CLAUDE.md.bak-*). Those are hand-made safety copies of config; deleting them
+# from an automated job is not this script's call to make. They are listed in
+# the PR for manual removal.
+#
+# Run by hand or via systemd:
+#   systemctl --user start claude-log-rotate.service
+#   scripts/claude-log-rotate/rotate.sh [DIR]
+#   scripts/claude-log-rotate/rotate.sh --print-config [DIR]   # config only, no run
+set -euo pipefail
+
+PRINT_ONLY=0
+if [ "${1:-}" = "--print-config" ]; then
+  PRINT_ONLY=1
+  shift
+fi
+
+DIR="${1:-${HOME}/.claude}"
+
+# Tunables. Defaults chosen against the measured sizes above: a 10M cap turns the
+# 39.8 MB notify.log into one ≤10M live file plus at most 3 compressed
+# generations, and clawgate-hook.log stops being a 12 MB single file.
+SIZE="${CLAUDE_LOG_ROTATE_SIZE:-10M}"
+KEEP="${CLAUDE_LOG_ROTATE_KEEP:-3}"
+STATE="${CLAUDE_LOG_ROTATE_STATE:-${XDG_STATE_HOME:-${HOME}/.local/state}/claude-log-rotate.status}"
+
+emit_config() {
+  # NOTE the quoted glob: logrotate does its own globbing, and an unquoted
+  # pattern here would be expanded by the shell into a fixed file list captured
+  # at config-generation time — so a log created later would never be rotated.
+  cat <<CONF
+"${DIR}/*.log" {
+    size ${SIZE}
+    rotate ${KEEP}
+    copytruncate
+    compress
+    delaycompress
+    missingok
+    notifempty
+    nomail
+}
+CONF
+}
+
+if [ "$PRINT_ONLY" = "1" ]; then
+  emit_config
+  exit 0
+fi
+
+if ! command -v logrotate >/dev/null 2>&1; then
+  echo "claude-log-rotate: logrotate not on PATH — refusing to report success" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$STATE")"
+
+conf="$(mktemp -t claude-log-rotate.conf.XXXXXX)"
+trap 'rm -f "$conf"' EXIT
+emit_config >"$conf"
+
+logrotate --state "$STATE" "$conf"
+echo "claude-log-rotate: applied size=${SIZE} rotate=${KEEP} to ${DIR}/*.log (state=${STATE})"

--- a/scripts/collector/claude/session-tailer.py
+++ b/scripts/collector/claude/session-tailer.py
@@ -29,10 +29,16 @@ transcript takes exactly one of these branches:
 
   unchanged   signature == the one we last emitted for  -> skip (nothing new)
   settled     changed AND idle >= CLAUDE_SUMMARY_SETTLE_MINUTES (default 20)
-              -> EMIT. This is the authoritative final rollup for the session.
-              A session that is later RESUMED (`claude --resume` is real here)
-              changes signature again, settles again, and re-emits — so the
-              latest row is always the complete rollup.
+              AND (never emitted, or last emit older than
+              CLAUDE_SUMMARY_INTERIM_HOURS) -> EMIT. This is the authoritative
+              final rollup for the session. A session that is later RESUMED
+              (`claude --resume` is real here) changes signature again, settles
+              again, and re-emits — so the latest row is always the complete
+              rollup.
+  settled-recently
+              settled, but emitted within CLAUDE_SUMMARY_INTERIM_HOURS -> skip.
+              The new signature is deliberately NOT recorded, so the session
+              still owes a rollup and emits on the first tick past the window.
   first-seen  changed, still active, never emitted before -> EMIT once, so an
               in-flight session (or one interrupted by a reboot) is present in
               the report instead of missing entirely.
@@ -40,6 +46,20 @@ transcript takes exactly one of these branches:
               CLAUDE_SUMMARY_INTERIM_HOURS (default 4) -> EMIT a bounded
               interim rollup (backstop for very long sessions).
   active      changed, still active, emitted recently -> skip.
+
+🔴 `settled-recently` was added 2026-08-02 and it closes a REAL, MEASURED
+amplification. The settled branch used to emit unconditionally, without
+consulting `emitted_at` — so an ACTIVE session was bounded to one emit per
+interim window while a session idling BETWEEN BURSTS was not bounded at all: one
+full rollup per burst, forever. That is the ordinary `claude --resume` shape, so
+the bound was missing from exactly the common case. Measured over the 30 days to
+2026-08-02: 31,815 rows across 482 sessions — median 2/session, but p90 209, max
+572, mean 66 — against validation/invariants.py's `session_summary_rows_bounded`,
+which flags >24 rows/session/24h. The fix is to make the settled branch consult
+the same `emitted_at` with the same interval, so there is ONE knob rather than
+two that can disagree; worst case becomes 1 + 24h/interim ≈ 7 rows/session/24h.
+No backfill: reads dedupe with argMax(…, ingested_at) and the existing rows age
+out of the invariant's trailing window.
 
 WHY: the previous rule was "re-emit whenever the signature changed", i.e. once
 per 5-min tick for the whole life of a live session. Measured on 2026-07-28 that
@@ -537,17 +557,65 @@ def emit_decision(prev: dict | None, sig: str, mtime: float, now: float,
                   settle_s: float, interim_s: float) -> tuple[bool, str]:
     """(should_emit, reason) for one transcript. See the module docstring.
 
-    Reasons: unchanged | settled | first-seen | interim | active.
+    Reasons: unchanged | settled | settled-recently | first-seen | interim |
+    active.
     """
     if prev and prev.get("sig") == sig:
         return (False, "unchanged")
     idle = now - mtime
-    if settle_s <= 0 or idle >= settle_s:
+    last = prev.get("emitted_at") if prev else None
+    known_last = isinstance(last, (int, float))
+    if settle_s <= 0:
+        # Documented escape hatch, unchanged: 0 disables the settle gate
+        # ENTIRELY and restores the pre-emit-on-settle "every change emits"
+        # behaviour. Rate-limiting it would make the knob a no-op, so the
+        # bounding below deliberately does not apply here.
         return (True, "settled")
+    if idle >= settle_s:
+        # 🔴 The settled branch is rate-limited on `emitted_at`, exactly as the
+        # interim branch below is. It was NOT, until 2026-08-02, and that
+        # asymmetry is the whole bug:
+        #
+        #   an ACTIVE session was bounded to one emit per `interim_s`, while a
+        #   session that went idle BETWEEN BURSTS was unbounded — every burst
+        #   followed by >= settle_s of quiet re-entered this branch and shipped
+        #   a fresh full rollup. That is the ordinary `claude --resume` shape,
+        #   so the bound was missing from precisely the common case. Measured
+        #   over 30 days: 31,815 rows across 482 sessions, median 2/session but
+        #   p90 209, max 572, mean 66 — against a documented invariant
+        #   (`session_summary_rows_bounded`, validation/invariants.py) that
+        #   flags >24 rows/session/24h.
+        #
+        # The fix is the missing consult, not a clamp on a counter: the same
+        # `emitted_at` the interim branch already reads, with the same interval,
+        # so there is ONE knob (CLAUDE_SUMMARY_INTERIM_HOURS) rather than two
+        # that can disagree. Worst case per session per 24h becomes
+        # 1 first-seen + 24h/interim_s ≈ 7 at the 4h default, well under the
+        # invariant's cap of 24.
+        #
+        # 🔴 The legitimate case is deliberately PRESERVED, two ways:
+        #   * a session with no known last-emit (never emitted, or a v1/corrupt
+        #     state entry) ALWAYS emits — so a session's first rollup is never
+        #     deferred, and `session_summary_no_orphans` cannot start failing;
+        #   * a session that settles, is resumed DAYS later and settles again
+        #     has an `emitted_at` far older than the interval, so it emits
+        #     again. That is the case the rate limit must not swallow, and it is
+        #     pinned by test_decision_settled_reemits_after_a_long_gap and
+        #     test_resumed_after_settle_reemits_the_final_rollup.
+        #
+        # Cost, stated honestly: a deferred settle means the newest row can lag
+        # the transcript's final content by up to `interim_s`. Nothing is lost —
+        # the deferral does NOT record the new signature (see run()), so the
+        # session still owes a rollup and emits on the first tick past the
+        # window, and reads take argMax(…, ingested_at) anyway.
+        if not known_last:
+            return (True, "settled")
+        if interim_s <= 0 or (now - last) >= interim_s:
+            return (True, "settled")
+        return (False, "settled-recently")
     if not prev:
         return (True, "first-seen")
-    last = prev.get("emitted_at")
-    if not isinstance(last, (int, float)):
+    if not known_last:
         # Unknown last-emit (v1 state / corrupt entry): emit once to establish it.
         return (True, "interim")
     if interim_s > 0 and (now - last) >= interim_s:

--- a/scripts/collector/claude/tests/test_session_tailer.py
+++ b/scripts/collector/claude/tests/test_session_tailer.py
@@ -39,6 +39,16 @@ _spec.loader.exec_module(S)
 
 EMIT = _COLLECTOR_DIR / "emit"
 
+# The row-count cap this emitter must respect is OWNED by the validation
+# harness, not by this file — read it from there so the two cannot drift. (The
+# module must be registered in sys.modules before exec_module: it defines a
+# @dataclass, and dataclasses resolves annotations via sys.modules[__module__].)
+_INV_PATH = _COLLECTOR_DIR.parent / "validation" / "invariants.py"
+_inv_spec = importlib.util.spec_from_file_location("devrc_invariants", _INV_PATH)
+INV = importlib.util.module_from_spec(_inv_spec)
+sys.modules["devrc_invariants"] = INV
+_inv_spec.loader.exec_module(INV)
+
 # Settle policy in seconds, from the module's own defaults (no magic numbers).
 SETTLE = S.DEFAULT_SETTLE_MINUTES * 60.0
 INTERIM = S.DEFAULT_INTERIM_HOURS * 3600.0
@@ -345,7 +355,16 @@ def test_idempotent_no_reemit_when_unchanged(env):
 
 def test_settled_growth_reemits_the_complete_rollup(env):
     """A session that grew and then SETTLED re-emits, and the newest row is the
-    complete rollup (the argMax-on-read contract stays correct)."""
+    complete rollup (the argMax-on-read contract stays correct).
+
+    🔴 UPDATED 2026-08-02. This test used to settle 20 minutes after the
+    first-seen emit and assert the row landed immediately. That is precisely the
+    amplification being fixed — the settled branch now consults `emitted_at`, so
+    a settle inside the interim window DEFERS. Both halves are asserted here:
+    the deferral, and that the deferral costs nothing but latency (the rollup
+    still lands, still complete, on the first tick past the window). Reverting
+    the fix turns the first half red.
+    """
     t0 = time.time()
     p = _write(env["projects"], "-home-zach-workspace-devrc", "s1", [
         user_typed("hello", ts="2026-07-11T10:00:00.000Z"),
@@ -356,8 +375,12 @@ def test_settled_growth_reemits_the_complete_rollup(env):
     _append(p, assistant([("Edit", {"file_path": "b.go",
                                     "old_string": "x", "new_string": "y"})],
                          ts="2026-07-11T11:00:00.000Z"), mtime=t0)
-    # … then goes idle past the settle window → re-emit with the full rollup
+    # … and settles, but only SETTLE after the last emit → DEFERRED, no new row
     assert S.run(now=t0 + SETTLE + 1) == 0
+    assert len(_spool_events(env["spool"])) == 1
+    # … and once the interim window has passed it lands, complete. The deferral
+    # did NOT record the new signature, which is what makes this re-evaluate.
+    assert S.run(now=t0 + INTERIM + SETTLE + 1) == 0
     evs = _spool_events(env["spool"])
     assert len(evs) == 2  # append-only: two rows for the same session
     latest = json.loads(evs[-1]["payload"])
@@ -448,8 +471,78 @@ def test_decision_unchanged_signature_never_emits():
 
 
 def test_decision_settled_emits():
+    """🔴 UPDATED 2026-08-02: the fixture's last emit must now be older than the
+    interim window, because the settled branch is rate-limited on `emitted_at`.
+    The old fixture (`emitted_at=100.0`, `now=1000+SETTLE`) is only ~35 min past
+    the last emit and is now the DEFERRED case — see
+    test_decision_settled_is_rate_limited_by_the_last_emit, which pins it."""
     prev = {"sig": "old", "emitted_at": 100.0}
-    assert _decide(prev, "new", mtime=1000.0, now=1000.0 + SETTLE) == (True, "settled")
+    assert _decide(prev, "new", mtime=1000.0,
+                   now=100.0 + INTERIM + SETTLE) == (True, "settled")
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 The settled-branch rate limit (2026-08-02).
+#
+# THE BUG: the settled branch returned (True, "settled") without ever consulting
+# `emitted_at`, while the interim branch immediately below it was rate-limited.
+# So an ACTIVE session was bounded to one emit per interim window, and a session
+# idling BETWEEN BURSTS was bounded by nothing — one full rollup per burst,
+# forever. That is the ordinary `claude --resume` shape, i.e. the bound was
+# missing from exactly the common case. Measured over the 30 days to 2026-08-02:
+# 31,815 rows / 482 sessions, median 2 but p90 209, max 572, mean 66, against
+# validation/invariants.py's `session_summary_rows_bounded` (>24/session/24h).
+# --------------------------------------------------------------------------- #
+def test_decision_settled_is_rate_limited_by_the_last_emit():
+    """🔴 THE regression pin. RED before the fix: this returned
+    (True, "settled") because the branch never read `emitted_at`."""
+    prev = {"sig": "old", "emitted_at": 1000.0}
+    # settled (idle >= SETTLE) but the last emit was only an hour ago
+    assert _decide(prev, "new", mtime=1000.0,
+                   now=1000.0 + 3600) == (False, "settled-recently")
+
+
+def test_decision_settled_reemits_after_a_long_gap():
+    """🔴 The case the rate limit MUST NOT swallow, pinned explicitly: a session
+    that genuinely settled, was resumed DAYS later, and settles again. Its
+    `emitted_at` is far older than the interval, so it emits."""
+    prev = {"sig": "old", "emitted_at": 1000.0}
+    two_days = 2 * 86400
+    assert _decide(prev, "new", mtime=1000.0 + two_days,
+                   now=1000.0 + two_days + SETTLE) == (True, "settled")
+
+
+def test_decision_settled_with_no_known_last_emit_always_emits():
+    """A session's FIRST rollup is never deferred — neither for a transcript we
+    have never emitted for, nor for a v1/corrupt state entry with no timestamp.
+    This is what keeps `session_summary_no_orphans` (2h grace) satisfiable."""
+    assert _decide(None, "new", mtime=1000.0,
+                   now=1000.0 + SETTLE) == (True, "settled")
+    assert _decide({"sig": "old", "emitted_at": None}, "new", mtime=1000.0,
+                   now=1000.0 + SETTLE) == (True, "settled")
+
+
+def test_decision_settle_zero_bypasses_the_rate_limit():
+    """The documented `CLAUDE_SUMMARY_SETTLE_MINUTES=0` escape hatch restores
+    the pre-emit-on-settle "every change emits" behaviour, so the rate limit
+    deliberately does not apply to it — otherwise the knob would be a no-op."""
+    prev = {"sig": "old", "emitted_at": 1000.0}
+    assert _decide(prev, "new", mtime=1000.0, now=1000.0,
+                   settle=0) == (True, "settled")
+
+
+def test_decision_settled_rate_limit_follows_the_interim_knob():
+    """One knob, not two: the settled bound IS `interim_s`. Shrinking the knob
+    shrinks the bound, and `interim=0` (the documented "no interim emits"
+    setting) restores the old unbounded settled behaviour — which is what makes
+    it usable as the positive control in the end-to-end test below."""
+    prev = {"sig": "old", "emitted_at": 1000.0}
+    assert _decide(prev, "new", mtime=1000.0, now=1000.0 + 3600,
+                   interim=1800)[0] is True          # bound below the gap
+    assert _decide(prev, "new", mtime=1000.0, now=1000.0 + 3600,
+                   interim=7200) == (False, "settled-recently")
+    assert _decide(prev, "new", mtime=1000.0, now=1000.0 + 3600,
+                   interim=0) == (True, "settled")
 
 
 def test_decision_active_first_seen_emits_once_then_defers():
@@ -561,7 +654,13 @@ def test_resumed_after_settle_reemits_the_final_rollup(env):
         assert S.run(now=t_resume + tick * 300) == 0
     assert len(_spool_events(env["spool"])) == 2
     # Once it settles again it re-emits, and the newest row is complete.
+    # 🔴 UPDATED 2026-08-02: the settle must now be past the interim window from
+    # the previous emit (at t_resume+300), because the settled branch is
+    # rate-limited. Inside the window it defers — asserted first, so this test
+    # covers BOTH sides of the fix rather than quietly moving the goalposts.
     assert S.run(now=t_resume + 8 * 300 + SETTLE) == 0
+    assert len(_spool_events(env["spool"])) == 2         # deferred, not emitted
+    assert S.run(now=t_resume + 300 + INTERIM + SETTLE) == 0
     evs = _spool_events(env["spool"])
     assert len(evs) == 3
     latest = json.loads(evs[-1]["payload"])
@@ -587,6 +686,68 @@ def test_interim_backstop_bounds_a_never_settling_session(env):
     expected = 1 + int(12 * 3600 // INTERIM)        # first-seen + 3 interims
     assert n == expected, f"expected {expected} bounded emits, got {n}"
     assert n < 10                                   # vs 145 under the old rule
+
+
+def test_bursty_resumed_session_stays_under_the_invariant_cap(env, monkeypatch):
+    """🔴 The end-to-end regression, WITH its own positive control.
+
+    Scenario = the measured one: a session worked on in short bursts, each
+    followed by enough quiet to cross the settle window. Before the fix every
+    such burst re-entered the settled branch and shipped a full rollup, so the
+    row count tracked the burst count with no ceiling at all.
+
+    The reassuring answer here is a SMALL NUMBER, and a small number is exactly
+    what a harness wired to nothing produces. So the same scenario is run twice
+    through the same code path, and the only thing that changes is the knob:
+
+      POSITIVE CONTROL  interim=0 -> the settled branch is unbounded, which IS
+                        the pre-fix behaviour. The count MUST move well past the
+                        cap. If it does not, the harness is not generating
+                        bursts and the bounded number below means nothing.
+      UNDER TEST        the 4h default -> bounded.
+
+    Cap is validation/invariants.py's SUMMARY_ROWS_PER_SESSION_CAP (24 rows per
+    session per 24h), read from the module rather than restated here.
+    """
+    def burst_run(interim_hours):
+        """36 bursts over 24h (one every 40 min), each settling before the next.
+        Returns the number of session-summary rows emitted."""
+        monkeypatch.setenv("CLAUDE_SUMMARY_INTERIM_HOURS", str(interim_hours))
+        for f in env["spool"].glob("*"):
+            f.unlink()
+        if env["state"].exists():
+            env["state"].unlink()
+        t0 = time.time()
+        p = _write(env["projects"], "-home-zach-workspace-devrc", "bursty", [
+            user_typed("burst 0", ts="2026-07-11T10:00:00.000Z"),
+        ])
+        assert S.run(now=t0) == 0                      # first-seen
+        step = 40 * 60                                 # > SETTLE, so each settles
+        for i in range(1, 37):
+            t = t0 + i * step
+            _append(p, assistant([("Read", {"file_path": f"f{i}.py"})],
+                                 ts="2026-07-11T10:00:00.000Z"), mtime=t)
+            # tick once right after the write (active) and once after it settles
+            assert S.run(now=t + 60) == 0
+            assert S.run(now=t + SETTLE + 60) == 0
+        return len(_spool_events(env["spool"]))
+
+    cap = INV.SUMMARY_ROWS_PER_SESSION_CAP
+
+    unbounded = burst_run(0)          # POSITIVE CONTROL — pre-fix behaviour
+    assert unbounded > cap, (
+        f"positive control produced only {unbounded} rows, which is under the "
+        f"cap of {cap} — the scenario is not generating bursts, so the bounded "
+        f"number below would be a fact about the harness, not about the fix"
+    )
+
+    bounded = burst_run(S.DEFAULT_INTERIM_HOURS)
+    assert bounded <= cap, (
+        f"{bounded} rows for one session in 24h, cap is {cap} "
+        f"(session_summary_rows_bounded)"
+    )
+    # and it is a real reduction, not a rounding difference
+    assert bounded < unbounded / 2
 
 
 def test_state_survives_a_restart(env):

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -138,7 +138,11 @@ MIN_TESTS="${MIN_TESTS:-2850}"
 #           pytest.FAIL, not skip, when absent: this is the ONLY file that can
 #           see a resolver-semantics change under an unchanged config, so a skip
 #           there is precisely the silent green the version pin exists to stop.
-REQUIRED_TOOLS=(bash curl node rg git awk jq grep setsid python3 nix-instantiate opencode)
+# logrotate: scripts/tests/test_claude_log_rotate.py drives the REAL binary
+# against a temp directory (rotation, truncation, generation cap, and the .bak
+# scope fence). Those tests FAIL rather than skip when it is absent — a skipped
+# rotation test reports safety it never measured — so it belongs here.
+REQUIRED_TOOLS=(bash curl node rg git awk jq grep setsid python3 nix-instantiate opencode logrotate)
 missing_tools=()
 for t in "${REQUIRED_TOOLS[@]}"; do
   command -v "$t" >/dev/null 2>&1 || missing_tools+=("$t")

--- a/scripts/tests/test_claude_log_rotate.py
+++ b/scripts/tests/test_claude_log_rotate.py
@@ -1,0 +1,303 @@
+"""Tests for scripts/claude-log-rotate/rotate.sh — the ~/.claude log size cap.
+
+Two layers, deliberately:
+
+  1. CONFIG — `--print-config` is pure text, so these run everywhere and pin the
+     policy (size cap, generation count, copytruncate, `*.log` only).
+  2. BEHAVIOUR — a real `logrotate` run against a real temp directory. 🔴 These
+     do NOT skip when the binary is missing: `logrotate` is in the pytests
+     check's PATH (flake.nix) and in REQUIRED_TOOLS, and a skip here would be a
+     test reporting safety while measuring nothing. If the binary is absent the
+     tests FAIL and name the fix.
+
+Every behavioural assertion is paired with a control that moves the number the
+other way, because the reassuring answer in most of them ("the file is small
+now", "the .bak files are untouched") is also what a harness wired to nothing
+produces.
+"""
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+ROTATE = ROOT / "scripts" / "claude-log-rotate" / "rotate.sh"
+
+
+def _print_config(target="/home/someone/.claude", **env):
+    e = dict(os.environ)
+    e.update(env)
+    p = subprocess.run(["bash", str(ROTATE), "--print-config", target],
+                       capture_output=True, text=True, env=e)
+    assert p.returncode == 0, p.stderr
+    return p.stdout
+
+
+def _run(target, **env):
+    e = dict(os.environ)
+    e.update(env)
+    return subprocess.run(["bash", str(ROTATE), str(target)],
+                          capture_output=True, text=True, env=e)
+
+
+# --------------------------------------------------------------------------- #
+# 0. harness self-validation
+# --------------------------------------------------------------------------- #
+def test_the_script_exists_and_is_executable():
+    assert ROTATE.is_file(), f"{ROTATE} missing — every test below is vacuous"
+    assert os.access(ROTATE, os.X_OK), f"{ROTATE} is not executable"
+
+
+def test_logrotate_is_on_path():
+    """🔴 NOT a skipif. `logrotate` is declared in flake.nix's pytests check and
+    in run-tests.sh's REQUIRED_TOOLS. If it is missing, the behavioural tests
+    below would silently stop measuring anything — so fail loudly instead."""
+    assert shutil.which("logrotate") is not None, (
+        "logrotate is not on PATH. Add it to the pytests check in flake.nix "
+        "(and REQUIRED_TOOLS in scripts/run-tests.sh) rather than skipping "
+        "these tests — a skipped rotation test reports safety it never checked."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 1. the generated config — the policy, pinned
+# --------------------------------------------------------------------------- #
+def test_config_caps_size_and_keeps_a_few_generations():
+    conf = _print_config()
+    assert "size 10M" in conf
+    assert "rotate 3" in conf
+
+
+def test_config_uses_copytruncate():
+    """🔴 Load-bearing, not an optimisation. The writers (a hook that runs on
+    every tool call, plus two out-of-repo processes) hold open fds. Renaming out
+    from under them would leave them appending to an unlinked inode — the log
+    would look frozen while consuming the same disk."""
+    assert "copytruncate" in _print_config()
+
+
+def test_config_targets_only_log_files_and_never_the_bak_files():
+    """🔴 The scope fence. ~/.claude holds 9 stale hand-made `.bak` copies of
+    config (settings.json.bak.*, RULES.md.bak*, PRINCIPLES.md.bak*,
+    CLAUDE.md.bak-*). An automated job must not be the thing that decides to
+    delete a config backup."""
+    conf = _print_config()
+    assert '"/home/someone/.claude/*.log"' in conf
+    assert ".bak" not in conf
+    # exactly one glob stanza, so a second pattern cannot creep in unnoticed
+    assert conf.count("{") == 1
+
+
+def test_config_glob_is_quoted_so_it_is_evaluated_at_rotate_time():
+    """An unquoted pattern would be expanded by the SHELL when the config is
+    generated, freezing the file list — a log created later would never rotate.
+    logrotate must do the globbing itself."""
+    conf = _print_config()
+    assert conf.lstrip().startswith('"')
+
+
+def test_config_honours_the_env_tunables():
+    conf = _print_config(CLAUDE_LOG_ROTATE_SIZE="1k", CLAUDE_LOG_ROTATE_KEEP="7")
+    assert "size 1k" in conf
+    assert "rotate 7" in conf
+    # negative control: the defaults are gone, so this is really reading the env
+    assert "size 10M" not in conf
+    assert "rotate 3" not in conf
+
+
+def test_config_target_directory_is_the_argument():
+    assert '"/tmp/elsewhere/*.log"' in _print_config("/tmp/elsewhere")
+
+
+# --------------------------------------------------------------------------- #
+# 2. behaviour — a real logrotate run
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def logdir(tmp_path):
+    d = tmp_path / "dot-claude"
+    d.mkdir()
+    return d
+
+
+def _mk(path: Path, size: int):
+    path.write_bytes(b"x" * size)
+    return path
+
+
+def test_an_oversized_log_is_rotated_and_truncated(logdir, tmp_path):
+    """POSITIVE CONTROL for the whole harness: the number must MOVE. A big log
+    becomes a small live file plus a rotated generation."""
+    big = _mk(logdir / "notify.log", 200_000)
+    assert big.stat().st_size == 200_000
+    p = _run(logdir, CLAUDE_LOG_ROTATE_SIZE="1k",
+             CLAUDE_LOG_ROTATE_STATE=str(tmp_path / "st"))
+    assert p.returncode == 0, p.stderr
+    assert big.exists(), "copytruncate must keep the original file in place"
+    assert big.stat().st_size == 0, "the live file was not truncated"
+    rotated = list(logdir.glob("notify.log.*"))
+    assert rotated, f"nothing was rotated; dir={list(logdir.iterdir())}"
+
+
+def test_a_small_log_is_left_alone(logdir, tmp_path):
+    """NEGATIVE CONTROL, same harness, same code path: under the threshold
+    nothing happens. Paired with the test above, a rotation result cannot be
+    'this script rotates unconditionally'."""
+    small = _mk(logdir / "daemon.log", 100)
+    p = _run(logdir, CLAUDE_LOG_ROTATE_SIZE="1M",
+             CLAUDE_LOG_ROTATE_STATE=str(tmp_path / "st"))
+    assert p.returncode == 0, p.stderr
+    assert small.stat().st_size == 100
+    assert list(logdir.glob("daemon.log.*")) == []
+
+
+def test_bak_and_other_files_are_never_touched(logdir, tmp_path):
+    """🔴 The scope fence, measured rather than read off the config. Each of
+    these is far OVER the threshold, so 'untouched' cannot be an accident of
+    them being small — the ONLY reason they survive is the `*.log` glob."""
+    victims = {
+        "settings.json.bak.1769397206": 200_000,
+        "RULES.md.bak.20260608-081434": 200_000,
+        "PRINCIPLES.md.bak-20260616-204947": 200_000,
+        "CLAUDE.md.bak-2026-07-30": 200_000,
+        "settings.json": 200_000,
+        "notes.md": 200_000,
+    }
+    for name, size in victims.items():
+        _mk(logdir / name, size)
+    # a real .log in the same directory, so the run definitely DOES something —
+    # otherwise "nothing was touched" would also be true of a no-op run.
+    canary = _mk(logdir / "notify.log", 200_000)
+    before = {f.name for f in logdir.iterdir()}
+
+    p = _run(logdir, CLAUDE_LOG_ROTATE_SIZE="1k",
+             CLAUDE_LOG_ROTATE_STATE=str(tmp_path / "st"))
+    assert p.returncode == 0, p.stderr
+    assert canary.stat().st_size == 0, (
+        "the canary .log was not rotated, so this run proves nothing about "
+        "what the glob spared"
+    )
+    for name, size in victims.items():
+        f = logdir / name
+        assert f.exists(), f"{name} was DELETED"
+        assert f.stat().st_size == size, f"{name} was modified"
+    # Nothing NEW may appear except a rotation of the canary. Checked as a set
+    # difference rather than per-file globs: `settings.json.*` would match the
+    # victim `settings.json.bak.…`, i.e. the obvious per-file glob reports a
+    # rotation that never happened.
+    created = {f.name for f in logdir.iterdir()} - before
+    assert created and all(n.startswith("notify.log.") for n in created), (
+        f"unexpected files created: {sorted(created)}"
+    )
+
+
+def test_generations_are_capped(logdir, tmp_path):
+    """`rotate N` must actually bound the number of kept generations, or the
+    directory grows without limit in a different shape."""
+    state = tmp_path / "st"
+    log = logdir / "clawgate-hook.log"
+    for _ in range(8):
+        _mk(log, 200_000)
+        p = _run(logdir, CLAUDE_LOG_ROTATE_SIZE="1k",
+                 CLAUDE_LOG_ROTATE_KEEP="2", CLAUDE_LOG_ROTATE_STATE=str(state))
+        assert p.returncode == 0, p.stderr
+    gens = list(logdir.glob("clawgate-hook.log.*"))
+    assert 0 < len(gens) <= 2, f"expected at most 2 generations, got {gens}"
+
+
+def test_a_missing_directory_is_not_an_error(tmp_path):
+    """`missingok`: the timer fires on both hosts and must not spam
+    notify-failure@ on a host that has no ~/.claude logs yet."""
+    p = _run(tmp_path / "nope", CLAUDE_LOG_ROTATE_STATE=str(tmp_path / "st"))
+    assert p.returncode == 0, p.stderr
+
+
+# --------------------------------------------------------------------------- #
+# 3. wiring — a rotation script nothing runs rotates nothing
+#
+# The script is only half the change; the timer is the other half, and a
+# perfectly green script test says nothing about whether it ever fires. These
+# read nix/home.nix directly, the same way test_opencode_guard_plugin.py pins
+# the guard's deploy path.
+# --------------------------------------------------------------------------- #
+HOME_NIX = (ROOT / "nix" / "home.nix").read_text()
+
+
+def test_home_nix_declares_the_service_and_the_timer():
+    assert "systemd.user.services.claude-log-rotate" in HOME_NIX
+    assert "systemd.user.timers.claude-log-rotate" in HOME_NIX
+
+
+def test_the_unit_runs_the_script_this_file_tests():
+    """The ExecStart must point at the script under test, or these tests are
+    about a file nothing executes.
+
+    🔴 Asserted on the ExecStart LINE, not on the file. A mutation sweep caught
+    the whole-file version surviving: the path also appears in the surrounding
+    comment and in `X-Restart-Triggers`, so a substring test over home.nix
+    stayed green with ExecStart repointed at a completely different script.
+    """
+    execs = [l.strip() for l in HOME_NIX.splitlines() if "ExecStart" in l
+             and "claude-log-rotate" in l]
+    assert len(execs) == 1, f"expected one claude-log-rotate ExecStart, got {execs}"
+    assert execs[0].endswith('scripts/claude-log-rotate/rotate.sh";'), execs[0]
+
+
+def test_the_unit_puts_logrotate_on_its_path():
+    """🔴 The unit env is minimal, so PATH is explicit. Without pkgs.logrotate
+    the wrapper exits non-zero every night (loudly, by design — see
+    test_it_fails_loudly_when_logrotate_is_absent) and nothing is ever capped."""
+    svc = HOME_NIX.split("systemd.user.services.claude-log-rotate", 1)[1]
+    svc = svc.split("systemd.user.timers.claude-log-rotate", 1)[0]
+    assert "pkgs.logrotate" in svc
+
+
+def test_the_timer_is_not_server_mode_gated():
+    """Both hosts run Claude Code and both accumulate these logs. A
+    `lib.mkIf serverMode` here would silently leave the laptop uncapped —
+    the exact shape of "shipped, but not where the problem is"."""
+    timer = HOME_NIX.split("systemd.user.timers.claude-log-rotate", 1)[1]
+    timer = timer.split("Install", 1)[0]
+    assert "serverMode" not in timer
+    svc = HOME_NIX.split("systemd.user.services.claude-log-rotate", 1)[1]
+    svc = svc.split("Unit", 1)[0]
+    assert "serverMode" not in svc
+
+
+def test_the_timer_is_persistent():
+    """Growth is slow and unattended; a host powered off at 04:00 must catch up
+    rather than skip the cycle."""
+    timer = HOME_NIX.split("systemd.user.timers.claude-log-rotate", 1)[1]
+    assert "Persistent = true" in timer.split("Install", 1)[0]
+
+
+def test_logrotate_is_pinned_in_both_gate_tiers():
+    """🔴 The two-tier lesson: a tool present in one tier and absent in the
+    other makes these tests' verdict depend on where they ran. `logrotate` must
+    be in the flake check's inputs AND in run-tests.sh's REQUIRED_TOOLS."""
+    flake = (ROOT / "flake.nix").read_text()
+    assert "pkgs.logrotate" in flake
+    runner = (ROOT / "scripts" / "run-tests.sh").read_text()
+    required = [l for l in runner.splitlines() if l.startswith("REQUIRED_TOOLS=")]
+    assert len(required) == 1, f"expected one REQUIRED_TOOLS line, got {required}"
+    assert "logrotate" in required[0]
+
+
+def test_it_fails_loudly_when_logrotate_is_absent(logdir, tmp_path):
+    """🔴 The wrapper must not report success when it did nothing. Simulated by
+    handing it an empty PATH — the same shape as a unit whose PATH= line lost
+    the package."""
+    _mk(logdir / "notify.log", 200_000)
+    e = dict(os.environ)
+    e["PATH"] = str(tmp_path / "empty-bin")
+    e["CLAUDE_LOG_ROTATE_STATE"] = str(tmp_path / "st")
+    # bash by ABSOLUTE path: emptying PATH also hides the interpreter, and
+    # "bash not found" would be a different failure wearing this test's name.
+    bash = shutil.which("bash")
+    assert bash, "bash not on PATH — this test cannot run"
+    p = subprocess.run([bash, str(ROTATE), str(logdir)],
+                       capture_output=True, text=True, env=e)
+    assert p.returncode != 0
+    assert "logrotate not on PATH" in p.stderr


### PR DESCRIPTION
Two unrelated-but-small hygiene items. A third was scoped out after inspection — **see "What I left out" at the bottom**; it is not an oversight and it has a security finding attached.

---

## (b) Rotate the `~/.claude` logs

### Measured, on the workbench 2026-08-02

| file | bytes | last written |
|---|---:|---|
| `notify.log` | 39,822,110 | 2026-07-06 — a **dead** writer |
| `clawgate-hook.log` | 12,033,179 | live |
| `claude-notify.log` | 60,684 | live |
| `daemon.log` | 6,091 | 2026-07-31 |

**51.6 MB unrotated and growing**, nothing rotating any of it.

### Why the cap is on the DIRECTORY, not in the writers

Only **one** of those writers lives in this repo (`scripts/claude-hooks/claude-notify.py` → `claude-notify.log`, the 60 KB one). `clawgate-hook.log` comes from the clawgate approval hook and `notify.log` from something that no longer runs at all — a per-writer fix cannot reach either.

New `claude-log-rotate` `systemd --user` service + daily timer (following the `mail-actions-archive` pattern already in `home.nix`) running `scripts/claude-log-rotate/rotate.sh`: `size 10M`, `rotate 3`, `compress`, `delaycompress`, `missingok`, `notifempty`, and — load-bearing — **`copytruncate`**.

`copytruncate` is not an optimisation. The writers hold open file descriptors, they are not ours to signal, and one of them fires on **every Claude Code tool call**. Renaming the file out from under an open fd would leave it appending to an unlinked inode: the log would look frozen while silently consuming the same disk.

**Not `serverMode`-gated** — both hosts run Claude Code and both accumulate these logs. Gating it would have left the laptop uncapped, which is the "shipped, but not where the problem is" shape; there is a test for exactly that.

### 🔴 The `.bak` files are NOT touched

Scope is `*.log` only. These nine stale hand-made config backups are left entirely alone — **for you to remove by hand**, since deciding to delete a config backup is not an automated job's call:

```
settings.json.bak.1769397206              161 B   2026-01-25
settings.json.bak.clawgate.1780707021     751 B   2026-06-05
settings.json.bak.20260623-190634         840 B   2026-06-09
settings.json.bak.20260724-192550       1,264 B   2026-07-06
RULES.md.bak.20260608-081434           16,132 B   2025-10-18
RULES.md.bak-20260616-204947           19,385 B   2026-06-16
RULES.md.bak.20260623-153503            7,103 B   2026-06-16
PRINCIPLES.md.bak-20260616-204947       2,573 B   2026-06-16
CLAUDE.md.bak-2026-07-30                1,406 B   2026-07-30
```

That fence is **measured, not read off the config**: the test creates over-threshold `.bak` / `settings.json` / `notes.md` files next to a `.log` **canary**, and requires the canary to have rotated before it believes "nothing else was touched". Otherwise a no-op run would pass it.

`logrotate` is added to **both** gate tiers (`flake.nix`'s pytests check and `run-tests.sh`'s `REQUIRED_TOOLS`), so the behavioural tests **fail** rather than skip when it is absent — a skipped rotation test reports safety it never measured.

---

## (c) The session-summary amplification — root-caused

### The bug

`emit_decision`'s `settled` branch returned `(True, "settled")` **without ever consulting `emitted_at`**, while the `interim` branch immediately below it was rate-limited. The rate limiting was therefore *asymmetric in exactly the wrong direction*:

- an **ACTIVE** session (never goes idle) → bounded to one emit per interim window;
- a session idling **BETWEEN BURSTS** → bounded by *nothing*. Every burst followed by ≥ the settle window re-entered the settled branch and shipped a fresh full rollup.

The second is the ordinary `claude --resume` shape. So the bound was missing from precisely the common case, which is why the tail is so heavy while the median looks fine.

Measured over the 30 days to 2026-08-02: **31,815 rows / 482 sessions — median 2, p90 209, max 572, mean 66**, against `validation/invariants.py`'s `session_summary_rows_bounded` (>24 rows/session/24h). A documented invariant, violated.

### The fix

The **missing consult**, not a clamp on a counter: the settled branch now reads the same `emitted_at` with the same interval, so there is **one** knob (`CLAUDE_SUMMARY_INTERIM_HOURS`) rather than two that can disagree. New reason `settled-recently`, which deliberately does **not** record the new signature — so the session still owes a rollup and emits on the first tick past the window.

### 🔴 The legitimate cases, preserved and pinned

- **Resumed days later.** A session that settles, is resumed days later and settles again has an `emitted_at` far older than the interval, so it emits. `test_decision_settled_reemits_after_a_long_gap` (pure) and `test_resumed_after_settle_reemits_the_final_rollup` (end-to-end). Mutant **c3** makes the limit permanent and both go red.
- **A session's FIRST rollup is never deferred** — no known `emitted_at` (never emitted, or a v1/corrupt state entry) always emits, which is what keeps `session_summary_no_orphans` (2 h grace) satisfiable. Mutant **c2** removes that and it goes red.
- **`CLAUDE_SUMMARY_SETTLE_MINUTES=0`** still bypasses the gate entirely, as documented — rate-limiting it would make the knob a no-op. Mutant **c4**.

**Cost, stated honestly:** a deferred settle means the newest row can lag the transcript's final content by up to the interim window (4 h default). Nothing is lost — the deferral does not record the signature, the rollup lands on the first tick past the window, and reads take `argMax(…, ingested_at)` anyway.

**No backfill, no DELETE against ClickHouse.** Existing rows dedupe on read and age out of the invariant's trailing window.

### End-to-end, with a positive control

36 bursts over 24 h, each settling before the next. Same scenario, same code path, twice — the only thing that changes is the knob, because a small number is also what a harness wired to nothing produces:

| run | rows for one session in 24 h |
|---|---:|
| **POSITIVE CONTROL** (`interim=0` → unbounded settled = pre-fix behaviour) | **37** |
| **UNDER TEST** (4 h default) | **7** |
| cap (`SUMMARY_ROWS_PER_SESSION_CAP`, read from `invariants.py`, not restated) | 24 |

7 = `1 first-seen + 24h/4h`, as predicted. The test asserts the control **exceeds** the cap before it believes the bounded number.

---

## Red/green matrix — base ref `26d5268`

Method: `git archive 26d5268 scripts nix flake.nix` into a temp tree, drop in this PR's test files (plus `rotate.sh` itself — a test for a file that does not exist is an import error, not a red test), run. **Collection is 64 in both runs**, so the two are comparable.

| run | result |
|---|---|
| NEW tests vs BASE sources | **11 failed**, 53 passed |
| NEW tests vs HEAD sources | **64 passed**, 0 failed |
| BASE tests vs BASE sources (control) | 56 passed, 0 failed |

Red at base:

| test | item |
|---|---|
| `test_decision_settled_is_rate_limited_by_the_last_emit` | (c) — **the** regression pin |
| `test_decision_settled_rate_limit_follows_the_interim_knob` | (c) |
| `test_bursty_resumed_session_stays_under_the_invariant_cap` | (c) end-to-end |
| `test_settled_growth_reemits_the_complete_rollup` | (c) — *changed*, see below |
| `test_resumed_after_settle_reemits_the_final_rollup` | (c) — *changed*, see below |
| `test_home_nix_declares_the_service_and_the_timer` | (b) wiring |
| `test_the_unit_runs_the_script_this_file_tests` | (b) wiring |
| `test_the_unit_puts_logrotate_on_its_path` | (b) wiring |
| `test_the_timer_is_not_server_mode_gated` | (b) wiring |
| `test_the_timer_is_persistent` | (b) wiring |
| `test_logrotate_is_pinned_in_both_gate_tiers` | (b) two-tier pin |

**Labelled as invariant guards / new-feature coverage, NOT regression coverage:** `test_decision_settled_with_no_known_last_emit_always_emits` and `test_decision_settle_zero_bypasses_the_rate_limit` (green before *and* after — they are the fence around what the rate limit must not swallow), and all of the `rotate.sh` **behavioural** tests, which are green at base because the script is new. They earn their keep in the mutation matrix, not here.

**Two existing tests were CHANGED, not just added to**, and both were changed because this PR correctly turns them red — they encoded the unbounded settle. Neither had its goalposts quietly moved: each now asserts **both** sides, the deferral *and* that the deferral costs only latency (the rollup still lands, still complete, past the window). Reverting the fix turns the new first half red.

---

## Mutation matrix — 16 mutants, all KILLED **and attributed**

A mutant must produce failures matching **that thing's own** test names; one that merely trips some other test is reported UNATTRIBUTED, not KILLED.

| # | mutant | verdict |
|---|---|---|
| c1 | **revert the fix** — settled emits without consulting `emitted_at` | KILLED (5, attributed) |
| c2 | rate-limit the FIRST rollup too | KILLED (3) |
| c3 | make the limit PERMANENT — a resume days later never re-emits | KILLED (6) |
| c4 | rate-limit the `settle=0` escape hatch | KILLED (2) |
| c5 | decouple the bound from the interim knob (hard-code 1 s) | KILLED (5) |
| b1 | widen the glob to every file (would eat the `.bak` copies) | KILLED (4) |
| b2 | drop `copytruncate` | KILLED (3) |
| b3 | remove the size cap | KILLED (5) |
| b4 | unbounded generations | KILLED (3) |
| b5 | report success when `logrotate` is missing | KILLED (1) |
| b6 | unquote the glob (shell-expands at config time) | KILLED (3) |
| b7 | drop `logrotate` from the flake check | KILLED (1) |
| b8 | drop `logrotate` from `REQUIRED_TOOLS` | KILLED (1) |
| b9 | `serverMode`-gate the timer (laptop left uncapped) | KILLED (1) |
| b10 | point the unit at a different script | KILLED (1) |
| b11 | drop `pkgs.logrotate` from the unit PATH | KILLED (1) |

**b10 SURVIVED on the first sweep** and that is the most useful thing here. `test_the_unit_runs_the_script_this_file_tests` originally grepped the whole of `home.nix` for the script path — which also appears in the surrounding comment and in `X-Restart-Triggers` — so it stayed green with `ExecStart` repointed at `ship.sh`. The test now asserts on the `ExecStart` **line**. The sweep found a real hole in my own test; without it that test would have shipped proving nothing.

**Harness controls, both required before any verdict above was believed:**
- **POSITIVE** — unmutated baseline before *and* after the sweep: `collected=64 failed=0`. The sweep aborts on an implausible count, and restores the source after every mutant so a left-applied mutation cannot poison the next baseline.
- **NEGATIVE (two, run explicitly via `--self-check`)** — an absent needle reported `SKIP-BROKEN` (a never-applied mutant must not read as green) and a no-op replacement reported `🔴 SURVIVED`. The harness can go red in both shapes.

The sweep **counts** `N failed, N passed` and fails loudly if that format does not match; it never reads an exit code.

---

## Both tiers

| tier | result |
|---|---|
| **`nix build .#checks.x86_64-linux.pytests`** (authoritative) | **collected=4688 passed=4687 skipped=1 failed=0** |
| dev host, `scripts/run-tests.sh` | see comment below |

**⚠️ Baseline note — read this before comparing to 4660.** `origin/main` advanced from `26d5268` to `4eb5798` (#301, #302) while this work was in progress, and **this branch is based on `4eb5798`** (PR #303 is based on `26d5268`; it is being rebased). So the arithmetic is against `4eb5798`, not against the 4660 figure:

- `scripts/tests` 998 → 1018 (**+20**, this PR)
- `scripts/collector/claude/tests` 56 → 62 (**+6**, this PR)
- `scripts/collector/opencode/tests` 170 → 172 (**+2, NOT this PR** — #302; verified by diffing collected node IDs at both refs: base has 3 tests HEAD lacks, HEAD has 5 base lacks, all of them `test_deploy_*` / plugin-export tests from #302)

**+26 from this PR**, exactly the tests added. The single skip is the pre-existing opt-in `repo-cos` live-store drift check.

---

## `git merge-tree` against PR #303

```
git merge-tree --write-tree guard-widen-three-families hygiene-logrotate-and-session-tailer
-> exit code 0   (tree 686e1435e349b2ed511ad6a678e51643656dd435)
```

Exit 0 = **no textual conflict** — branched on the exit code, not on a marker grep, since two-arg `merge-tree` prints only a tree OID on success and never emits `<<<<<<<`.

Both PRs touch `nix/home.nix`, so a clean git merge is not by itself a clean merge. I read the merged region: PR #303's hunk is a **6-line comment** in the `home.file.".claude/hooks/guard_core.py"` block (~line 666); this PR's is a **new block appended at the end of the file**. Verified on the actual merged tree — it carries both changes and `nix-instantiate --parse` is clean. Full merged-tree gate run is reported in a comment below.

---

## Files touched

`scripts/claude-log-rotate/rotate.sh` (new), `scripts/tests/test_claude_log_rotate.py` (new), `scripts/collector/claude/session-tailer.py`, `scripts/collector/claude/tests/test_session_tailer.py`, `flake.nix`, `scripts/run-tests.sh`, `nix/home.nix`.

Two of these are shared with sibling agents, so, explicitly:
- **`nix/home.nix`** — one new `systemd.user.{services,timers}.claude-log-rotate` block **appended at the end**. Nothing existing modified.
- **`scripts/run-tests.sh`** — **one line**, `REQUIRED_TOOLS=…` gains `logrotate`. The target list is untouched, so it should not collide with the agent adding `scripts/dl-router/tests`.

## Deployment

The timer only exists after a `home-manager switch` / `ship.sh` — merging changes nothing. `session-tailer.py` likewise: the `claude-activity-source` unit picks up the new emit policy on switch (X-Restart-Triggers). Neither was run here, per the task constraints.

**First run reclaims ~50 MB** (the 39.8 MB `notify.log` becomes an empty live file plus one compressed generation).

---

## 🔴 What I left out: (a) bringing the `clickup` skill under nix

Correct on the facts — `~/.claude/skills/clickup/` is a hand-placed regular-file tree, `readlink` returns nothing, and every other skill is nix-managed from `claude/skills/`. But it is **not a skill directory**; it is a **5.9 MB vendored third-party Node application** with its own `.git`, `node_modules/`, `package-lock.json` *and* `pnpm-lock.yaml`, `flake.nix`, `api/`, `lib/`, `test/`, an 86 KB `query.mjs` and a 15 KB `listen.mjs`. `SKILL.md` is one file inside it.

Three separate blockers, each of which alone rules out a hygiene-sized change:

1. **🔴 Credentials.** It contains `accounts.json` (mode 0600) holding a live ClickUp `pk_` API token, and `SKILL.md` instructs the operator to *"Create `accounts.json` in this skill directory"*. Under a `home.file` deploy that directory becomes a read-only `/nix/store` symlink — **the documented credential flow becomes impossible**. And devrc is a **public** repo; the upstream project gitignores `accounts.json` for exactly this reason.
2. **It is load-bearing for a running production timer.** `scripts/task-spec-drafter/drafter.sh` hard-depends on both paths — `CLICKUP_CLI=$HOME/.claude/skills/clickup/query.mjs`, `CLICKUP_ACCOUNTS=$HOME/.claude/skills/clickup/accounts.json`, a `[ -f "$CLICKUP_CLI" ] || FATAL` precondition, and the absolute path baked into `DRAFTER_ALLOWED_TOOLS` (`Bash(node /home/zach/.claude/skills/clickup/query.mjs get*)`, ×3). Making that path a store symlink breaks a daily job; making it read-only breaks the token read.
3. **The runtime needs `node_modules`.** Shipping `SKILL.md` alone would propagate a skill to the workbench that triggers and then fails, which is worse than the drift.

Doing this properly is its own PR: relocate credentials to `~/.config/clickup/`, package the Node deps with nix (or add the upstream repo as a flake input rather than vendoring third-party JS into a public repo), update `drafter.sh`'s three hard-coded paths and its allowed-tools string, and re-verify the drafter end-to-end. Landing a half-version would break a working skill and a running timer, so I stopped rather than ship it partly done.

On the `dropStaleClaudeHooks` question you asked me to check: it exists in `nix/home.nix` and is the right precedent — `home.file.force` cannot displace a pre-existing *foreign regular file*, so a pre-switch `rm` step is genuinely needed for this pattern. It just cannot be applied here until the three blockers above are resolved, because the thing that would need removing is a live credential store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
