### PR TITLE
test(gate): run scripts/dl-router/tests — 989 tests no gate had ever run

### DIFF
--- a/scripts/collector/opencode/tests/test_plugin.py
+++ b/scripts/collector/opencode/tests/test_plugin.py
@@ -22,8 +22,10 @@ import pytest
 # Import collector for parse_line
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+# scripts/ — for the cross-suite helpers in testlib/.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 import collector as C  # noqa: E402
-import _mockbin as M  # noqa: E402
+from testlib import mockbin as M  # noqa: E402
 
 SCRIPT_DIR = Path(__file__).resolve().parent.parent
 PLUGIN_JS = SCRIPT_DIR / "activity-plugin.js"
@@ -47,7 +49,7 @@ def run_node(code: str, *, env: dict | None = None, cwd: str | None = None) -> s
 def write_mock_emit(path: Path, log_file: Path) -> None:
     """Write a mock `emit` script that records its arguments to log_file.
 
-    Shebang owned by `_mockbin.write_exec`: this used to be
+    Shebang owned by `testlib.mockbin.write_exec`: this used to be
     `#!/usr/bin/env bash`, which execs on a NixOS dev host but NOT in the nix
     build sandbox (no /usr/bin/env). That was invisible until this suite was
     added to run-tests.sh's target list.

--- a/scripts/collector/opencode/tests/test_plugin_tool_calls.py
+++ b/scripts/collector/opencode/tests/test_plugin_tool_calls.py
@@ -49,19 +49,16 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+# scripts/ — for the cross-suite helpers in testlib/.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 import collector as C  # noqa: E402
-import _mockbin as M  # noqa: E402
+from testlib import mockbin as M  # noqa: E402
 
 SCRIPT_DIR = Path(__file__).resolve().parent.parent
 PLUGIN_JS = SCRIPT_DIR / "activity-plugin.js"
 EMIT = SCRIPT_DIR.parent / "emit"
 
 NAME_CAPTURE_FAILED = "__name_capture_failed__"
-
-# `#!` and the quoted forms the shebang guard scans for, assembled from char
-# codes so this module's own source never contains the pattern it searches for.
-_HB = chr(35) + chr(33)
-_NEEDLES = (chr(34) + _HB, chr(39) + _HB)
 
 
 # --------------------------------------------------------------------------- #
@@ -74,7 +71,7 @@ def write_argv_recorder(path: Path, log: Path) -> None:
     spaces, which is exactly the corruption we are trying to detect, so a
     space-joined log cannot tell a mangled call from a clean one.
 
-    The shebang is owned by `_mockbin.write_exec` — see that module for why a
+    The shebang is owned by `testlib.mockbin.write_exec` — see that module for why a
     `#!/usr/bin/env` stub is green on the dev host and RED in the nix sandbox.
     """
     M.write_exec(
@@ -207,46 +204,13 @@ def test_brace_expansion_probe_agrees_with_the_shell_node_actually_uses():
         f"probe says {probe} but node's shell produced {r.stdout!r}")
 
 
-def test_no_runtime_written_shebang_uses_usr_bin_env():
-    """STRUCTURAL GUARD — the deterministic half of the fix.
+# The STRUCTURAL GUARD that used to live here (a scan for runtime-written
+# `/usr/bin/env` shebangs, plus its positive control) moved to
+# scripts/tests/test_runtime_shebangs.py and is now REPO-WIDE. It was scoped to
+# this one directory, which is exactly why it could not see the identical defect
+# in scripts/dl-router/tests/test_setup_script.py. The scanner itself lives in
+# scripts/testlib/shebang_scan.py.
 
-    A quoted `#!` anywhere in this suite's sources means a call site is writing
-    its own shebang instead of going through `_mockbin.write_exec`, which is how
-    `/usr/bin/env` came back the first time. `_mockbin` itself is exempt: it
-    owns the one shebang, and its docstring names the trap.
-    """
-    # ⚠ The needles are BUILT AT RUNTIME, character by character — including the
-    # `#!` itself. Written as literals they appear in this function's own source
-    # and the scan reports ITSELF, the same self-match that makes
-    # `pgrep -f <pattern>` find its own shell. (Measured: the first version of
-    # this guard failed on its own two source lines.)
-    needles = _NEEDLES
-    tests_dir = Path(__file__).resolve().parent
-    offenders = []
-    for py in sorted(tests_dir.glob("test_*.py")):
-        for i, line in enumerate(py.read_text(encoding="utf-8").splitlines(), 1):
-            if i == 1:
-                continue          # the module's own shebang; pytest imports, never execs
-            if any(n in line for n in needles):
-                offenders.append(f"{py.name}:{i}: {line.strip()}")
-    assert not offenders, (
-        "a test writes its own shebang — use _mockbin.write_exec instead:\n  "
-        + "\n  ".join(offenders))
-
-
-def test_positive_control_the_shebang_guard_can_detect_an_offender(tmp_path):
-    """POSITIVE CONTROL for the `not offenders` (== empty) assertion above.
-
-    An empty offender list is indistinguishable from a scan wired to nothing.
-    Feed the same matcher a file that MUST be flagged and watch the count move.
-    """
-    bad = tmp_path / "test_bad.py"
-    # Assembled at runtime for the same self-match reason as the guard itself.
-    offending = 'p.write_text(' + chr(34) + _HB + '/usr/bin/env bash' + chr(34) + ')'
-    bad.write_text("x = 1\n" + offending + "\n", encoding="utf-8")
-    hits = [i for i, line in enumerate(bad.read_text().splitlines(), 1)
-            if i != 1 and any(n in line for n in _NEEDLES)]
-    assert hits == [2], f"guard is wired to nothing — no hit on {offending!r}"
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/dl-router/tests/conftest.py
+++ b/scripts/dl-router/tests/conftest.py
@@ -7,6 +7,7 @@ All fixture data is SYNTHETIC (`Jane Doe`, `acme-studio`, `example-site.test`).
 from __future__ import annotations
 
 import json
+import socket
 import sys
 from pathlib import Path
 
@@ -81,6 +82,37 @@ class FakeClock:
     def advance(self, seconds: float) -> float:
         self.now += float(seconds)
         return self.now
+
+
+def _free_port() -> int:
+    """A loopback port with NOTHING listening on it, chosen at call time.
+
+    🔴 Do not go back to a hard-coded number. Every "the sidecar is DOWN /
+    unreachable" assertion in this suite is really an assertion that nobody is
+    listening on the configured port, and a literal (8799) makes that a claim
+    about the WHOLE MACHINE rather than about the test.
+
+    MEASURED 2026-08-02 on the workbench: an orphaned `python3` from the
+    previous day (pid 2994086, started Aug 1 13:40, ppid 1) was listening on
+    127.0.0.1:8799, so `test_an_unreachable_sidecar_gives_an_actionable_message`
+    reached a REAL dl-router and failed with `sidecar HTTP 409: not_owned_tab`
+    instead of the expected message. The nix sandbox has no such listener, so
+    this failed on the dev-host tier ONLY — the two-tier hazard again, in the
+    opposite direction from the shebang one.
+
+    Asking the kernel for port 0 and closing gives a port that is free NOW.
+    That is not a lease — but it beats a constant, and the alternative (an
+    assertion whose truth depends on ambient host state) is not a test.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+def closed_port() -> int:
+    """See `_free_port`. Use this wherever a test needs a port that is DOWN."""
+    return _free_port()
 
 
 @pytest.fixture

--- a/scripts/dl-router/tests/test_cli.py
+++ b/scripts/dl-router/tests/test_cli.py
@@ -40,10 +40,15 @@ cli = _load_cli()
 
 
 @pytest.fixture
-def cli_env(tmp_path, library, dirs_file, monkeypatch):
-    """Point the CLI's config loader entirely at temp paths."""
+def cli_env(tmp_path, library, dirs_file, monkeypatch, closed_port):
+    """Point the CLI's config loader entirely at temp paths.
+
+    The port comes from the `closed_port` fixture, never a literal — see
+    conftest._free_port for the orphan-listener that made a hard-coded 8799 a
+    claim about the whole machine.
+    """
     cfg_path = tmp_path / "config.toml"
-    cfg_path.write_text(f'library_root = "{library}"\nport = 8799\n',
+    cfg_path.write_text(f'library_root = "{library}"\nport = {closed_port}\n',
                         encoding="utf-8")
     state = tmp_path / "state"
     monkeypatch.setenv("DL_ROUTER_CONFIG", str(cfg_path))
@@ -102,9 +107,10 @@ def test_status_reports_a_down_sidecar_without_raising(cli_env, capsys):
     assert "dirs       6" in out
 
 
-def test_status_reports_an_unset_library_root(tmp_path, monkeypatch, capsys):
+def test_status_reports_an_unset_library_root(tmp_path, monkeypatch, capsys,
+                                              closed_port):
     cfg = tmp_path / "config.toml"
-    cfg.write_text("port = 8799\n", encoding="utf-8")
+    cfg.write_text(f"port = {closed_port}\n", encoding="utf-8")
     monkeypatch.setenv("DL_ROUTER_CONFIG", str(cfg))
     monkeypatch.setenv("DL_ROUTER_STATE_DIR", str(tmp_path / "state"))
     monkeypatch.setenv("DL_ROUTER_TOKEN_FILE", str(tmp_path / "token"))
@@ -197,9 +203,10 @@ def test_a_malformed_config_is_reported_as_exit_2(tmp_path, monkeypatch,
 
 
 def test_an_unset_library_root_is_reported_not_a_traceback(tmp_path,
-                                                           monkeypatch, capsys):
+                                                           monkeypatch, capsys,
+                                                           closed_port):
     cfg = tmp_path / "config.toml"
-    cfg.write_text("port = 8799\n", encoding="utf-8")
+    cfg.write_text(f"port = {closed_port}\n", encoding="utf-8")
     monkeypatch.setenv("DL_ROUTER_CONFIG", str(cfg))
     monkeypatch.setenv("DL_ROUTER_STATE_DIR", str(tmp_path / "state"))
     monkeypatch.setenv("DL_ROUTER_TOKEN_FILE", str(tmp_path / "token"))

--- a/scripts/dl-router/tests/test_server_wiring.py
+++ b/scripts/dl-router/tests/test_server_wiring.py
@@ -74,9 +74,10 @@ def test_app_honours_the_ytdlp_section(tmp_path, library, monkeypatch):
 
 
 def test_an_unconfigured_app_builds_nothing_that_needs_a_root(tmp_path,
-                                                              monkeypatch):
+                                                              monkeypatch,
+                                                              closed_port):
     cfg = tmp_path / "config.toml"
-    cfg.write_text("port = 8799\n", encoding="utf-8")
+    cfg.write_text(f"port = {closed_port}\n", encoding="utf-8")
     monkeypatch.setenv("DL_ROUTER_STATE_DIR", str(tmp_path / "state"))
     monkeypatch.setenv("DL_ROUTER_TOKEN_FILE", str(tmp_path / "token"))
     app = S.App(config_mod.load(cfg, env={}))

--- a/scripts/dl-router/tests/test_setup_script.py
+++ b/scripts/dl-router/tests/test_setup_script.py
@@ -27,6 +27,10 @@ from pathlib import Path
 
 import pytest
 
+# scripts/ — for the cross-suite helpers in testlib/.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from testlib import mockbin  # noqa: E402
+
 SCRIPT = Path(__file__).resolve().parent.parent / "setup-brave-profile.sh"
 
 # Exit codes the script's own documentation commits to.
@@ -129,10 +133,50 @@ def write_pgrep(bin_dir: Path, *, exit_code: int):
 
     exit 0 = "a process with that binary name exists". That used to be the
     whole guard; it must not decide anything now.
+
+    🔴 The shebang is owned by `testlib.mockbin.write_exec` (/bin/sh), NOT
+    written here. This stub used to carry `#!/usr/bin/env bash`, which cannot
+    exec in the nix build sandbox — no /usr/bin/env there, while every NixOS dev
+    host has one. That made the defect invisible on the tier people look at and
+    red only on the tier that gates merges. See that module for the full account.
     """
-    (bin_dir / "pgrep").write_text(
-        f"#!/usr/bin/env bash\nexit {exit_code}\n", encoding="utf-8")
-    os.chmod(bin_dir / "pgrep", 0o755)
+    mockbin.write_exec(bin_dir / "pgrep", f"exit {exit_code}\n")
+
+
+@pytest.mark.parametrize("exit_code", [0, 1])
+def test_the_fake_pgrep_actually_execs(tmp_path, exit_code):
+    """🔴 SELF-CHECK on the harness — every `write_pgrep` test depends on it.
+
+    MEASURED 2026-08-02 in the nix build sandbox: with the old
+    `#!/usr/bin/env bash` shebang the stub could NOT exec (there is no
+    /usr/bin/env there — probed directly) and all 989 tests in this suite still
+    PASSED. The `exit 0` cases are exactly the ones asserting that "a brave
+    binary is running" must not decide anything, so a `pgrep` that cannot run at
+    all is indistinguishable from one answering "no": the harness was inert and
+    nothing in the suite could tell.
+
+    Asserting the stub's exit code directly makes the harness's own breakage a
+    loud failure HERE, rather than something only the repo-wide structural scan
+    (scripts/tests/test_runtime_shebangs.py) can see. Verified red: restoring
+    the bad shebang takes this suite to 991 collected / 989 passed / 2 failed.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    write_pgrep(bin_dir, exit_code=exit_code)
+    stub = bin_dir / "pgrep"
+    try:
+        out = subprocess.run([str(stub), "brave"], capture_output=True,
+                             text=True, timeout=30)
+    except OSError as exc:
+        # ⚠ execve reports ENOENT for a MISSING INTERPRETER, and Python renders
+        # that as "No such file or directory: <the stub>" — naming the file that
+        # does exist. Say what actually happened.
+        raise AssertionError(
+            f"{stub} exists ({stub.exists()}) but could not be exec'd: {exc}. "
+            f"Its shebang names an interpreter this environment lacks — "
+            f"see testlib.mockbin.") from exc
+    assert out.returncode == exit_code, (
+        f"the fake pgrep did not exec (rc={out.returncode}): {out.stderr!r}")
 
 
 def run(fake_env, *args, env_extra=None):

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -74,7 +74,17 @@
 #      before any suite runs, and a bad entry is named.
 #
 # Env overrides (defaults are the point — raise them, don't lower them casually):
-#   MIN_TESTS  minimum tests the whole run must REPORT  (default 2850; 2920 today)
+#   MIN_TESTS  minimum tests the whole run must REPORT
+#              MEASURED 2026-08-02 in the nix sandbox (`nix build
+#              .#checks.x86_64-linux.pytests`) at 4eb5798+this change: 5658
+#              collected / 5657 passed / 1 skipped / 0 failed. The dev-host
+#              tier (scripts/run-tests.sh under nix-shell) reports the same
+#              5658. origin/main alone measures 4662.
+#              Floor set at 5600 — the previous 2850 had drifted to less
+#              than HALF the real total,
+#              which is a floor that can no longer detect the collapse it
+#              exists for (an entire 989-test suite could vanish under it).
+#              Raise it when suites are added; never lower it to get green.
 #
 # Usage:
 #   scripts/run-tests.sh [--set hermetic|all] [--check-targets] [ROOT]
@@ -112,7 +122,7 @@ fi
 
 cd "$ROOT" || { echo "run-tests: cannot cd to ROOT=$ROOT" >&2; exit 2; }
 
-MIN_TESTS="${MIN_TESTS:-2850}"
+MIN_TESTS="${MIN_TESTS:-5600}"
 
 # --- GUARD 1: tool precondition ------------------------------------------------
 # Every binary the suites `skipif` on. Absence must be an ERROR, never a skip.
@@ -179,6 +189,14 @@ HERMETIC_TARGETS=(
   # `tool.execute.after` handler mis-read the hook contract shipped and produced
   # 2,699 rows of `text='unknown'` before anyone noticed.
   scripts/collector/opencode/tests
+  # Added 2026-08-02, the SAME shape as the opencode entry above and found the
+  # same day: 989 tests that no gate had ever run since dl-router was written.
+  # The suite is hermetic by construction (temp roots, temp SQLite, a stub
+  # qBittorrent, an injected clock — see its conftest) and passed 989/989 in
+  # both tiers once two portability defects were fixed: a stub script written
+  # with `#!/usr/bin/env bash` (dead in the sandbox) and a hard-coded port 8799
+  # that an orphaned listener on the workbench was answering.
+  scripts/dl-router/tests
   scripts/browser-bridge/tests
   scripts/validation/tests
   scripts/session-analysis/tests

--- a/scripts/testlib/__init__.py
+++ b/scripts/testlib/__init__.py
@@ -1,0 +1,13 @@
+"""Test helpers shared ACROSS suites.
+
+Not a test directory — nothing here is collected by pytest (it is not in
+`scripts/run-tests.sh`'s target list, and no module here is named `test_*`).
+It exists so a rule that applies to more than one suite lives in ONE place;
+`claude/RULES.md` → "One rule, one place".
+
+Import it by putting `scripts/` on sys.path, e.g. from
+`scripts/<area>/tests/test_x.py`:
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))  # scripts/
+    from testlib import mockbin
+"""

--- a/scripts/testlib/mockbin.py
+++ b/scripts/testlib/mockbin.py
@@ -2,7 +2,7 @@
 """One place that writes an executable test helper, with a shebang that execs in
 BOTH tiers.
 
-🔴 THE TRAP (cost this suite 14 red tests on 2026-08-02)
+🔴 THE TRAP (cost the OpenCode suite 14 red tests on 2026-08-02)
 --------------------------------------------------------
 A test that writes a stub script at RUNTIME and then execs it must not use
 `#!/usr/bin/env <interp>`:
@@ -19,10 +19,19 @@ test creates while running. So the defect is invisible on the dev host and only
 the sandbox can observe it. That is the two-tier hazard in RULES.md, and the
 failure reads as "my mock emit exited 1", not as "wrong shebang".
 
-Worse, in this suite the symptom was mostly SILENT: `emitEvent` swallows every
+Worse, in the OpenCode suite the symptom was mostly SILENT: `emitEvent` swallows every
 error by design (telemetry must never crash OpenCode), so a stub that cannot
 exec produces an EMPTY log and a node exit code of 0 — the tests failed later,
 on an empty list, pointing at the wrong thing.
+
+🔴 IT CAME BACK THE NEXT DAY, in another suite (2026-08-02, same day)
+---------------------------------------------------------------------
+`scripts/dl-router/tests` had been absent from `scripts/run-tests.sh`'s target
+list since it was written — **989 tests no gate had ever run** — and
+`test_setup_script.py`'s `write_pgrep()` wrote exactly this shebang. Adding the
+suite to the gate would have gone red in the sandbox on day one. It lives in
+`scripts/testlib/` (rather than inside one suite's tests dir) precisely so the
+NEXT suite can import it instead of re-deriving it a seventh time.
 
 WHY THIS FILE EXISTS AT ALL
 ---------------------------

--- a/scripts/testlib/shebang_scan.py
+++ b/scripts/testlib/shebang_scan.py
@@ -1,0 +1,66 @@
+"""THE structural scan for runtime-written shebangs — one implementation.
+
+A test that writes an executable stub while running must not give it
+`#!/usr/bin/env <interp>`: the nix build sandbox (the AUTHORITATIVE gate,
+`nix build .#checks.x86_64-linux.pytests`) has no `/usr/bin/env`, while every
+NixOS dev host does. See `testlib.mockbin` for the full account. This module is
+the deterministic half: it finds the call sites, so the rule is enforced rather
+than remembered.
+
+🔴 SELF-MATCH. The needles are assembled from CHARACTER CODES, never written as
+literals, because a scan whose pattern appears in its own source reports ITSELF
+— the same failure mode as `pgrep -f <pattern>` matching its own shell. The
+first version of this guard (#298) failed on its own two source lines. Keep it
+that way: no literal quoted `#!` anywhere in this file.
+
+Scope note (2026-08-02): #298's version scanned ONE directory —
+`scripts/collector/opencode/tests` — so it could not see
+`scripts/dl-router/tests/test_setup_script.py`, which carried the identical
+defect the whole time. The scan is repo-wide now, with a PINNED allowlist for
+the sites that handle it a different (still-correct) way.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+# `#!` and the two quoted forms a source line can carry it in, built at runtime.
+_HB = chr(35) + chr(33)
+NEEDLES = (chr(34) + _HB, chr(39) + _HB)
+
+
+def line_is_offender(lineno: int, line: str) -> bool:
+    """True when `line` embeds a quoted shebang.
+
+    Line 1 is always exempt: that is the module's OWN shebang, and pytest
+    imports test modules rather than exec'ing them, so it never runs.
+    """
+    if lineno == 1:
+        return False
+    return any(n in line for n in NEEDLES)
+
+
+def scan_file(path: Path) -> list[tuple[int, str]]:
+    """Return `(lineno, stripped_line)` for every offending line in `path`."""
+    out = []
+    text = path.read_text(encoding="utf-8", errors="replace")
+    for i, line in enumerate(text.splitlines(), 1):
+        if line_is_offender(i, line):
+            out.append((i, line.strip()))
+    return out
+
+
+def scan_tree(root: Path, pattern: str = "test_*.py") -> list[tuple[Path, int, str]]:
+    """Scan every `pattern` file under `root`, recursively, sorted by path."""
+    hits = []
+    for py in sorted(root.rglob(pattern)):
+        for lineno, line in scan_file(py):
+            hits.append((py, lineno, line))
+    return hits
+
+
+def offending_source_line(interp: str = "/usr/bin/env bash") -> str:
+    """Build a line that MUST be flagged — for positive controls.
+
+    Assembled the same way as the needles, for the same self-match reason.
+    """
+    return "p.write_text(" + chr(34) + _HB + interp + chr(34) + ")"

--- a/scripts/tests/test_runtime_shebangs.py
+++ b/scripts/tests/test_runtime_shebangs.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""REPO-WIDE structural guard: no test may write `#!/usr/bin/env …` at runtime.
+
+WHY
+---
+`/usr/bin/env` exists on every NixOS dev host (a symlink into the coreutils
+store path) and does NOT exist in the nix build sandbox, which is where the
+authoritative gate runs (`nix build .#checks.x86_64-linux.pytests`).
+`patchShebangs` fixes shebangs in the SOURCE TREE; it cannot touch a file a test
+writes while running. So the defect is structurally invisible on the tier people
+look at and only ever red on the tier that gates merges. Full account:
+`scripts/testlib/mockbin.py`.
+
+WHY REPO-WIDE
+-------------
+#298 shipped this scan pointed at ONE directory
+(`scripts/collector/opencode/tests`). On the same day
+`scripts/dl-router/tests/test_setup_script.py` was found carrying the identical
+defect — the scan could not see it, because the hazard is a property of the
+repo, not of one suite. Directory-scoped guards regenerate the bug in the next
+directory; `claude/RULES.md` → "One rule, one place".
+
+HOW TO SATISFY IT
+-----------------
+Use `testlib.mockbin.write_exec(path, body)` — it owns the shebang (`/bin/sh`)
+and RAISES if a call site supplies its own. Do not add an ALLOWLIST entry to get
+green; the allowlist is for sites that solve the problem a different, verified
+way, and every entry must say which way.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "scripts"))
+
+from testlib import shebang_scan as S  # noqa: E402
+
+SCAN_ROOT = REPO / "scripts"
+PATTERNS = ("test_*.py", "conftest.py")
+
+# --- THE PINNED ALLOWLIST ------------------------------------------------------
+# (relative path, substring the offending line must contain, why it is safe).
+#
+# Accounting works in BOTH directions, deliberately — the same discipline as
+# run-tests.sh's EXPECTED_SKIPS:
+#   * an offender matching no entry  → FAIL (a new call site appeared);
+#   * an entry matching no offender  → FAIL (the site changed; re-verify and
+#     delete the pin, rather than leaving a rubber stamp behind).
+#
+# 🔴 Nothing here may be `/usr/bin/env`. Two shapes qualify:
+#   (a) the literal interpreter path is already absolute and sandbox-present
+#       (`/bin/sh`, `sys.executable`);
+#   (b) the string is not a shebang at all.
+ALLOWLIST = [
+    ("scripts/tests/test_playwright_nixos.py", "/bin/sh",
+     "writes /bin/sh directly — absolute, present in the sandbox"),
+    ("scripts/tests/test_notify_failure.py", "_bash",
+     "interpolates a RESOLVED bash path (shutil.which), not /usr/bin/env"),
+    ("scripts/claude-hooks/tests/test_claude_notify.py", "/bin/sh",
+     "writes /bin/sh directly — absolute, present in the sandbox"),
+    ("scripts/task-spec-drafter/tests/test_allowlist_covers_prompt_shapes.py",
+     "/bin/sh",
+     "writes /bin/sh directly — absolute, present in the sandbox"),
+    ("scripts/task-spec-drafter/tests/test_ticket_status.py", "sys.executable",
+     "points the stub at the RUNNING interpreter"),
+    ("scripts/browser-bridge/tests/test_browser_agent.py", "sys.executable",
+     "_write_exec() rewrites #!/usr/bin/env python3 -> sys.executable before "
+     "writing; the two literal stub bodies below it are inputs to that rewrite"),
+    ("scripts/browser-bridge/tests/test_browser_agent.py", "_write_exec(path,",
+     "the two literal stub bodies are ARGUMENTS to _write_exec(), which rewrites "
+     "the shebang before writing (see the entry above)"),
+    ("scripts/dl-router/tests/test_backfill.py", "root",
+     "not a shebang: a dl-router manifest header sentinel being mutated"),
+]
+
+
+def _offenders() -> list[tuple[str, int, str]]:
+    hits: list[tuple[str, int, str]] = []
+    for pattern in PATTERNS:
+        for path, lineno, line in S.scan_tree(SCAN_ROOT, pattern):
+            hits.append((str(path.relative_to(REPO)), lineno, line))
+    return sorted(hits)
+
+
+def _matches(entry, hit) -> bool:
+    rel, needle, _why = entry
+    return hit[0] == rel and needle in hit[2]
+
+
+def test_no_test_writes_a_usr_bin_env_shebang_at_runtime():
+    """The scan itself. Every hit must be pinned."""
+    unpinned = [h for h in _offenders()
+                if not any(_matches(e, h) for e in ALLOWLIST)]
+    assert not unpinned, (
+        "a test writes its own shebang — use testlib.mockbin.write_exec:\n  "
+        + "\n  ".join(f"{p}:{n}: {l}" for p, n, l in unpinned))
+
+
+def test_every_allowlist_entry_still_matches_something():
+    """Stale-pin accounting — the complement of the scan above.
+
+    An entry that stops matching means the call site moved or changed. Left in
+    place it silently pre-approves whatever appears at that path next.
+    """
+    hits = _offenders()
+    stale = [f"{rel} ~ {needle!r} ({why})"
+             for rel, needle, why in ALLOWLIST
+             if not any(_matches((rel, needle, why), h) for h in hits)]
+    assert not stale, (
+        "ALLOWLIST entries match nothing — the site changed. Re-verify how that "
+        "file writes its shebang, then delete the pin:\n  " + "\n  ".join(stale))
+
+
+def test_positive_control_the_scan_can_actually_find_an_offender(tmp_path):
+    """🔴 POSITIVE CONTROL for the two empty-list assertions above.
+
+    `not unpinned` and `not stale` are ZEROS, and a zero is indistinguishable
+    from a scan wired to nothing (RULES.md). Feed the SAME `scan_tree` a tree
+    that MUST produce a non-zero count and watch the number move.
+    """
+    bad = tmp_path / "nested" / "test_bad.py"
+    bad.parent.mkdir(parents=True)
+    bad.write_text("x = 1\n" + S.offending_source_line() + "\n",
+                   encoding="utf-8")
+    hits = S.scan_tree(tmp_path, "test_*.py")
+    assert len(hits) == 1, f"scan is wired to nothing: {hits}"
+    assert hits[0][1] == 2
+
+
+def test_positive_control_an_unpinned_offender_is_reported(tmp_path):
+    """POSITIVE CONTROL for the ALLOWLIST filter, not just the scanner.
+
+    The scan finding a line and the assertion REPORTING it are two different
+    things — an allowlist entry that is too broad would swallow a real offender
+    silently. Push a fabricated hit through `_matches` against the real list.
+    """
+    fabricated = ("scripts/some-new-suite/tests/test_new.py", 7,
+                  S.offending_source_line())
+    assert not any(_matches(e, fabricated) for e in ALLOWLIST), (
+        "the ALLOWLIST matched a file that is not in it — an entry is too broad")
+
+
+def test_scan_root_actually_contains_test_files():
+    """Guard the guard's INPUT. A wrong SCAN_ROOT yields an empty file set, and
+    every assertion above then passes vacuously."""
+    files = [p for pat in PATTERNS for p in SCAN_ROOT.rglob(pat)]
+    assert len(files) > 50, f"SCAN_ROOT={SCAN_ROOT} found only {len(files)} files"
+
+
+def test_the_first_line_exemption_is_line_one_only():
+    """`line_is_offender` exempts line 1 (the module's own shebang, never
+    exec'd). Pin that the exemption does not leak to line 2."""
+    offending = S.offending_source_line()
+    assert S.line_is_offender(1, offending) is False
+    assert S.line_is_offender(2, offending) is True
+
+
+def test_this_guards_source_does_not_match_itself():
+    """The self-match trap: a scan whose needles appear in its own source
+    reports itself. Both this file and the scanner must come back clean."""
+    for path in (Path(__file__).resolve(), Path(S.__file__).resolve()):
+        assert S.scan_file(path) == [], f"{path.name} matches its own scan"


### PR DESCRIPTION
`scripts/dl-router/tests` was absent from `scripts/run-tests.sh`'s `HERMETIC_TARGETS`
since the suite was written. **989 tests that no gate has ever run.** Same
declarations-vs-instances shape as #298 (166 opencode tests) and #276 (913
guard-core tests): one missing line in a target list gating hundreds of instances.

## Numbers — BOTH tiers, base ref `4eb5798` (#302)

Baseline re-measured tonight at `4eb5798` itself, not carried over from an earlier ref.

| tier | `4eb5798` (base) | `4eb5798` + this PR |
|---|---|---|
| **sandbox** — `nix build .#checks.x86_64-linux.pytests` (authoritative) | 4662 collected / 4661 passed / 1 skipped / **0 failed** | **5658 collected / 5657 passed / 1 skipped / 0 failed** |
| **dev host** — `scripts/run-tests.sh --set all` under nix-shell | 4662 / 4661 / 1 / 0 | **5658 / 5657 / 1 / 0** |

The two tiers report the **same** numbers before and after — deliberately checked,
because the defects this PR fixes are exactly the kind that make them disagree.

`+996` accounted for exactly, no silent uncollection:

```
+991  scripts/dl-router/tests   (989 pre-existing + 2 new harness self-checks)
  +7  scripts/tests/test_runtime_shebangs.py   (new repo-wide guard)
  -2  scripts/collector/opencode/tests         (the directory-scoped scan it replaces)
```

dl-router collects **991 / skips 0** in both tiers. **Nothing is gated, nothing is
skipped, no assertion was weakened.** The single skip in the run is the pre-existing
pinned `repo-cos` live-store drift check.

`MIN_TESTS` 2850 → 5600. The old floor had drifted to **less than half** the real
total — a floor under which an entire 989-test suite could have vanished undetected.

## What adding the suite surfaced — two SANDBOX-ONLY portability defects

Both are the two-tier hazard from RULES.md, and they point in **opposite** directions.

**1. `test_setup_script.py:134` wrote a stub with `#!/usr/bin/env bash`.**
Probed directly: the nix build sandbox has **no `/usr/bin/env`**; every NixOS dev
host does. `patchShebangs` fixes the source tree and cannot touch a file a test
writes while running. Now goes through the helper #298 landed.

🔴 **The finding that matters more than the fix:** with the bad shebang restored,
**all 989 tests still PASSED in the sandbox.** The stub could not exec at all, and
the `exit 0` cases are precisely the ones asserting that "a brave binary is running"
must *not* decide anything — so a `pgrep` that cannot run is indistinguishable from
one answering "no". The harness was **inert and nothing in the suite could tell.**
So this PR adds `test_the_fake_pgrep_actually_execs[0,1]` (the +2), which asserts the
stub's exit code directly and makes the harness's own breakage loud *in this suite*
rather than visible only to the structural scan.

**2. `test_cli.py` / `test_server_wiring.py` hard-coded port 8799** for their
"sidecar is DOWN / unreachable" assertions. That is a claim about the whole machine,
not about the test. MEASURED on the workbench: an **orphaned `python3` (pid 2994086,
started Aug 1 13:40, ppid 1, in a stale tmux-spawn scope)** was listening on
`127.0.0.1:8799`, so `test_an_unreachable_sidecar_gives_an_actionable_message`
reached a **real dl-router** and failed with `sidecar HTTP 409: not_owned_tab`.
Ports now come from a `closed_port` fixture (bind `:0`, read, release). Failed on the
dev-host tier only — the mirror image of defect 1.

## One rule, one place

* `scripts/collector/opencode/tests/_mockbin.py` → **`scripts/testlib/mockbin.py`**
  (`git mv`, content unchanged but for the docstring), importable by any suite.
  Reused, not reinvented — it still owns the shebang and still raises if a call site
  supplies its own.
* #298's runtime-shebang scan was scoped to **one directory**, which is exactly why
  it could not see the dl-router defect sitting in the repo the whole time. The
  scanner moved to `scripts/testlib/shebang_scan.py` and the guard is now
  **repo-wide** (`scripts/tests/test_runtime_shebangs.py`), covering every
  `test_*.py` and `conftest.py` under `scripts/`. Needles are still assembled from
  char codes so the scan cannot match its own source.
* The allowlist fails **both ways**: an unpinned offender fails, and a pin that
  matches nothing fails (a stale pin otherwise pre-approves whatever lands at that
  path next). 8 entries, each naming *how* that site avoids `/usr/bin/env`
  (`/bin/sh`, a resolved `which` result, or `sys.executable`). **No entry is
  `/usr/bin/env`** — the allowlist is not an escape hatch for this hazard.

## Verification — red/green matrix

Honest labelling: **989 of the 991 dl-router tests are pre-existing and are NOT
regression coverage for this change.** Their value is that they now run at all.

| test | at `4eb5798` | at `c76a4b1` | proves |
|---|---|---|---|
| `scripts/dl-router/tests` (989) | **never ran** — not in the target list | 989 pass, both tiers | the suite is gated at all |
| `test_no_test_writes_a_usr_bin_env_shebang_at_runtime` | **RED in the sandbox** — reported `test_setup_script.py:134` on real code | green | genuine new coverage; reachable, not hypothetical |
| `test_the_fake_pgrep_actually_execs[0,1]` | **RED in the sandbox** (dl-router → 991 collected / 989 passed / **2 failed**) with the old shebang restored | green | genuine new coverage |
| `test_every_allowlist_entry_still_matches_something` | n/a (new) | green — and observed **RED** during development on a too-narrow pin | the accounting is wired to something |
| the other 5 guard tests | n/a (new) | green | invariant guards, labelled as such — not regression coverage |

**Harness validation** (RULES.md — validate against a known-bad state; pair every
reassuring zero with a positive control):

* **Negative control, at the authoritative gate.** Reintroduced the exact defect and
  re-ran `nix build .#checks.x86_64-linux.pytests`: `RESULT: FAIL`, `5658 collected /
  5656 passed / 2 failed`, failing in **both** places — `scripts/tests` (the scan) and
  `scripts/dl-router/tests` (the self-check). Restored → green. The gate can go red.
* **Positive control for the sandbox claim.** Did not assume the sandbox lacks
  `/usr/bin/env` — probed it: a throwaway `runCommandLocal` printed `NO-USR-BIN-ENV`.
* **Positive controls for the zeros.** `not unpinned` and `not stale` are both empty
  lists, indistinguishable from a scan wired to nothing. Two tests feed the *same*
  `scan_tree` / `_matches` a case that MUST produce a non-zero count and assert the
  number moves (**1 on the positive control, 0 under test**). A third pins that
  `SCAN_ROOT` actually resolves to >50 files, so the scan cannot pass vacuously on an
  empty file set.
* **Positive control for the port fix.** The orphan on `:8799` was **still listening
  at the time of the final run** (re-checked, not remembered) — so the dev-host green
  is measured *against* the state that produced the original failure, not after
  quietly clearing it. The orphan was left alone; it is not mine to kill.
* The two `_write_exec` allowlist needles were **caught being wrong** by the stale-pin
  test before this was committed.

## Merged-tree check

Rebased onto current `origin/main` (`4eb5798`, which landed after this work started
and touches `test_plugin.py` — a file this PR also edits). `git merge-tree
--write-tree` exited 0; the rebase applied clean; **both tiers were then re-run on
the merged tree**, not on the pre-rebase branch. The final numbers above are from
commit `c76a4b1` itself, re-measured after the last amend.

## Reported, NOT fixed here

* 🔴 **`scripts/dl-router/tests/*.test.mjs` — 508 tests, also completely ungated.**
  `scripts/run-node-tests.sh` hard-codes `FILES=(scripts/browser-bridge/tests/*.test.mjs)`,
  so `checks.nodetests` has never seen dl-router's 13 `.mjs` files. Measured: **508
  tests, 508 pass, 0 fail.** Identical shape to this PR, other language, and it is
  the larger remaining hole — the sidecar's routing logic and the extension's cached
  fallback are asserted against shared fixture tables, and only half of that pair is
  gated. Separate PR; note that node's spec reporter emits `ℹ tests 508`, not the
  `# tests` TAP line the runner greps for.
* **No real pre-existing dl-router bugs found.** Both defects were test-portability,
  not product logic. The 989 tests pass on the code as it stands.
* **`rebase.autoStash` appears to be enabled for this repo** — `git rebase` printed
  `Created autostash`, i.e. git reached for the **repo-global** stash on my behalf.
  It was transient and the stack was verified intact afterwards (9 pre-existing
  entries, none mine, `stash@{0}` untouched), but per RULES.md this is the exact
  mechanism that let two parallel agents steal each other's work, and the #295 guard
  cannot see it because git does it internally. Worth turning off.

## Privacy

`scripts/dl-router` handles a private library and this repo is public. The suite's
fixtures are entirely synthetic by construction (`Jane Doe`, `acme-studio`,
`example-site.test`, `tmp_path` roots) — **no real path, directory name, filename or
route-log content is committed, and none appears in this PR.** The only literal path
added anywhere is `/bin/sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
