### PR TITLE
git: disable autoStash — the one path that uses the SHARED stash with nothing typed

### DIFF
--- a/nix/programs/git/default.nix
+++ b/nix/programs/git/default.nix
@@ -10,6 +10,28 @@
     rerere.enabled = true;
     merge.conflictstyle = "zdiff3";
     diff.algorithm = "histogram";
-    rebase.autoStash = true;
+    # 🔴 autoStash must stay FALSE on both counts — it is the one way the
+    # repo-global stash gets used WITHOUT anyone typing `git stash`.
+    #
+    # RULES.md forbids `git stash` in any repo shared with other sessions or
+    # agents: `refs/stash` lives in the COMMON git dir, so every worktree of a
+    # repo shares one stack. Two parallel subagents stole each other's work that
+    # way (2026-07-25). The PreToolUse guard (scripts/claude-hooks/guard_core.py,
+    # `check_git_stash`) enforces that ban — but it matches COMMAND TEXT, and
+    # autoStash is git pushing and popping the shared stack INTERNALLY. Nobody
+    # types `git stash`, so the guard structurally cannot fire.
+    #
+    # With `pull.rebase = true` above, that made every `git pull` on a dirty
+    # tree a silent stash push/pop against a stack shared with every concurrent
+    # worktree. MEASURED 2026-08-03: a subagent's routine `git rebase` printed
+    # "Created autostash" against a stack holding 9 entries belonging to other
+    # sessions.
+    #
+    # false is the FAIL-CLOSED choice: rebase/merge now REFUSE on a dirty tree
+    # instead of silently reaching for the shared stack. The refusal is the
+    # signal — resolve it by committing, or by copying the file aside
+    # (`cp <file> /tmp/…`), which is what RULES.md prescribes.
+    rebase.autoStash = false;
+    merge.autoStash = false;
   };
 }

--- a/scripts/tests/test_git_autostash_disabled.py
+++ b/scripts/tests/test_git_autostash_disabled.py
@@ -1,0 +1,82 @@
+"""Pin `rebase.autoStash` / `merge.autoStash` to false.
+
+WHY THIS TEST EXISTS. RULES.md forbids `git stash` in any repo shared with
+other sessions or agents: `refs/stash` lives in the COMMON git dir, so all
+worktrees of a repo share ONE stack, and two parallel subagents stole each
+other's work that way (2026-07-25). `guard_core.py`'s `check_git_stash`
+enforces that ban -- but it matches COMMAND TEXT, and autoStash is git pushing
+and popping the shared stack INTERNALLY. Nobody types `git stash`, so the guard
+structurally CANNOT fire. With `pull.rebase = true` also set, every `git pull`
+on a dirty tree became a silent stash push/pop against a shared stack.
+
+MEASURED 2026-08-03: a subagent's routine `git rebase` printed "Created
+autostash" against a stack holding 9 entries belonging to other sessions.
+
+This test reads the NIX SOURCE, which is the only thing that ships. The
+deployed `~/.config/git/config` is a read-only store symlink -- `git config
+--global` against it fails with "Read-only file system", so a runtime fix is
+not even possible, and asserting on the live file would pass on a host that had
+simply never switched.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+GIT_NIX = ROOT / "nix" / "programs" / "git" / "default.nix"
+
+
+def _eval_git_settings():
+    if not shutil.which("nix-instantiate"):
+        pytest.fail(
+            "nix-instantiate not on PATH. This test pins a SAFETY setting that "
+            "the bash guard structurally cannot enforce; a skip here is exactly "
+            "how autoStash silently comes back. Run under nix-shell / the flake "
+            "gate, where `nix-instantiate` is a declared required tool."
+        )
+    p = subprocess.run(
+        ["nix-instantiate", "--eval", "--strict", "--json", "-E",
+         f"(import {GIT_NIX} {{}}).settings"],
+        capture_output=True, text=True, cwd=ROOT, timeout=180,
+    )
+    assert p.returncode == 0, f"nix eval failed:\n{p.stderr}"
+    return json.loads(p.stdout)
+
+
+@pytest.mark.parametrize("key", ["rebase.autoStash", "merge.autoStash"])
+def test_autostash_is_disabled(key):
+    settings = _eval_git_settings()
+    section, leaf = key.split(".")
+    # home-manager accepts both `rebase.autoStash = x` and a nested attrset.
+    val = settings.get(key, settings.get(section, {}).get(leaf)
+                       if isinstance(settings.get(section), dict) else None)
+    assert val is not None, (
+        f"{key} is not set at all in nix/programs/git/default.nix. Unset means "
+        f"git's own default applies, which for a `git pull --rebase` on a dirty "
+        f"tree can still reach the repo-global stash. Set it explicitly false."
+    )
+    assert val is False, (
+        f"{key} is {val!r}, must be False. autoStash uses the REPO-GLOBAL stash "
+        f"without anyone typing `git stash`, so guard_core.py's check_git_stash "
+        f"cannot see it. See RULES.md -> 'git stash is repo-GLOBAL'."
+    )
+
+
+def test_pull_rebase_is_still_on_so_the_hazard_is_real():
+    """Non-vacuity control.
+
+    The autoStash assertions only matter because `pull.rebase = true` routes
+    every `git pull` through rebase. If that were ever turned off this test
+    fails loudly rather than letting the pair above quietly become decorative.
+    """
+    settings = _eval_git_settings()
+    val = settings.get("pull.rebase", settings.get("pull", {}).get("rebase")
+                       if isinstance(settings.get("pull"), dict) else None)
+    assert val is True, (
+        f"pull.rebase is {val!r}. The autoStash pins above were written for a "
+        f"rebase-by-default setup; re-read them against the new behaviour "
+        f"rather than assuming they still cover the hazard."
+    )


### PR DESCRIPTION
`rebase.autoStash = true` (with `pull.rebase = true`) made every `git pull` on a dirty tree a silent push/pop against the **repo-global** stash — a stack shared by every worktree, holding 9 entries belonging to other sessions.

The PreToolUse guard cannot see this. It matches **command text**; autoStash happens **inside git**. Nobody types anything, so `check_git_stash` structurally cannot fire.

**Measured 2026-08-03:** a subagent's routine rebase printed `Created autostash` against that shared stack. Transient, nothing lost — which is exactly why it's worth pinning. Nothing failed and nothing alerted.

`false` is the fail-closed choice: rebase/merge now **refuse** on a dirty tree rather than reaching for the shared stack. The refusal is the signal.

### Why declarative and not `git config`
`~/.config/git/config` is a read-only store symlink — `git config --global rebase.autoStash false` fails with `Read-only file system`. Measured, not assumed.

### Evidence
- **Red at `origin/main`**: 2 failed (base has `rebase.autoStash = true`, and `merge.autoStash` unset).
- **4/4 mutants killed, each by its own assertion**: `rebase.autoStash = true`; `merge.autoStash` deleted; `pull.rebase = false`; restored → green.
- **Non-vacuity control**: asserts `pull.rebase` is still `true`, so the pins can't quietly become decorative if the rebase default changes.
- The test reads the **nix source**, not the deployed file — asserting on `~/.config/git/config` would pass on a host that had simply never switched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
