### PR TITLE
test(gate): run every *.test.mjs suite — 529 node tests no gate had ever run

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -189,7 +189,16 @@
           '';
 
       # ---------------------------------------------------------------------
-      # Node test gate — scripts/browser-bridge/tests/*.test.mjs (460 tests).
+      # Node test gate — every scripts/**/*.test.mjs suite (997 tests, measured
+      # 2026-08-03 in this sandbox across three suites: browser-bridge 468,
+      # dl-router 508, collector/browser-ext 21).
+      #
+      # 🔴 It covered ONLY browser-bridge until 2026-08-03, because the runner
+      # hard-coded `FILES=(scripts/browser-bridge/tests/*.test.mjs)`. dl-router's
+      # 508 tests and browser-ext's 21 were gated by NOTHING from the day each
+      # suite was written — the #276/#298/#306 shape in a fourth costume. The
+      # runner now DISCOVERS suites and pins them both ways; read its header
+      # before changing this.
       #
       # Deliberately a SEPARATE check from `pytests`, not folded into it:
       #  • distinct toolchain (nodejs vs python312) — keeping them apart means

--- a/scripts/run-node-tests.sh
+++ b/scripts/run-node-tests.sh
@@ -10,44 +10,180 @@
 # The caller is responsible for putting `node` on PATH (the flake check does this
 # via the derivation's nativeBuildInputs). This script only ORCHESTRATES.
 #
-# The suite under test is scripts/browser-bridge/tests/*.test.mjs. It is HERMETIC:
-# audited 2026-08-02 — no `createServer`/`.listen()`, no `spawn`/`execFile`, every
-# `fetch` is a stub assigned onto `globalThis.fetch`, and the only I/O is reads of
-# repo-relative files (extension/protocol.js, browser-agent, server.py) plus writes
-# under `tmpdir()`. Nothing reaches the network or a subprocess.
+# 🔴 THIS FILE USED TO HARD-CODE ONE DIRECTORY.
+#    `FILES=(scripts/browser-bridge/tests/*.test.mjs)` was the entire collection
+#    step, so `scripts/dl-router/tests/*.test.mjs` (508 tests) and
+#    `scripts/collector/browser-ext/tests/*.test.mjs` (21 tests) had NEVER been
+#    run by any gate — 529 tests, ungated since each suite was written. Exactly
+#    the shape of #306 (989 ungated pytest tests) and #298 (166) and #276 (913),
+#    one language over: a target list that only grows when somebody remembers.
 #
-# 🔴 TWO STRUCTURAL GUARDS — both exist because a green exit code lies here:
+#    The fix is not "add two more lines to the list" — that leaves the next suite
+#    ungated the same way. Collection is now DISCOVERY (every `*.test.mjs` under
+#    `scripts/`), so a new suite is gated the moment it exists.
+#
+# 🔴 FOUR STRUCTURAL GUARDS — all four exist because a green exit code lies here:
 #
 #   1. NEVER PASS A DIRECTORY. `node --test scripts/browser-bridge/tests/` silently
 #      collapses to `# tests 1 / # fail 1` (MODULE_NOT_FOUND) — a FALSE RED that a
 #      future edit could just as easily turn into a false green. This script globs
-#      the files itself into an array and refuses to run if any element is not a
-#      regular file ending in `.test.mjs`, so it CANNOT degrade to the dir form.
+#      the files itself and refuses to run if any element is not a regular file
+#      ending in `.test.mjs`, so it CANNOT degrade to the dir form.
 #
 #   2. COUNT THE TESTS, don't read the exit code. A collection failure, a bad glob,
 #      or a toolchain breakage can produce "0 tests, exit 0". We parse node's TAP
-#      summary and fail unless the run reports at least MIN_TESTS. Without this the
+#      summary and fail unless the run reports at least the floor. Without this the
 #      gate can go green while testing nothing — which is exactly how the pytest
 #      gate silently skipped 41 test_server.py tests for want of `curl` on PATH.
 #
-# Env overrides (defaults are the point — raise them, don't lower them casually):
-#   MIN_TESTS  minimum tests the run must REPORT   (default 450; 460 pass today)
-#   MIN_FILES  minimum .test.mjs files to collect  (default 14; 14 exist today)
+#   3. DISCOVERY + A TWO-WAY PIN (`SUITES`). Discovery alone would make a whole
+#      suite going silent invisible again: if `scripts/dl-router/tests` were
+#      emptied, deleted or renamed, a bare repo-wide glob would just collect fewer
+#      files and — above the global floor — still say PASS. So every discovered
+#      suite directory must appear in `SUITES`, and every `SUITES` entry must be
+#      discovered. It fails BOTH ways, which is the property #306 established for
+#      its shebang allowlist:
+#        * a NEW suite directory not in SUITES     -> FATAL (forces an accounting
+#          entry with a floor, instead of being silently swept in under the total)
+#        * a PINNED suite that discovery misses    -> FATAL (the suite vanished)
+#      This is the guard that answers "if the dl-router tests silently stopped
+#      executing, would anything go red?" — before this change the honest answer
+#      was no, because they were never executing in the first place.
 #
-# Exit non-zero if the suite fails OR either floor is not met.
+#   4. PER-SUITE FLOORS, not just a global one. Each suite runs in its OWN
+#      `node --test` invocation with its own TAP summary and its own minimum, so
+#      one suite collapsing to near-zero cannot be absorbed by the others' totals.
+#      A single global floor of 970 would be fully satisfied by browser-bridge
+#      (468) + dl-router (508) with browser-ext's 21 tests silently gone.
+#
+# Env overrides (defaults are the point — raise them, don't lower them casually):
+#   MIN_TESTS  minimum tests the WHOLE run must REPORT (default 970; 997 today)
+#
+# Usage:
+#   scripts/run-node-tests.sh [--check-suites] [ROOT]
+#     --check-suites  run GUARD 3 only (discovery + the two-way pin) and exit.
+#                     No node, no tests — cheap enough to be exercised by a unit
+#                     test, mirroring run-tests.sh's --check-targets.
+#
+# Exit non-zero if any suite fails OR any guard above trips.
 
 set -uo pipefail
 
+CHECK_SUITES_ONLY=0
 ROOT=""
-[ $# -gt 0 ] && ROOT="$1"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --check-suites) CHECK_SUITES_ONLY=1; shift ;;
+    *) ROOT="$1"; shift ;;
+  esac
+done
+
 if [ -z "$ROOT" ]; then
   ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null || true)"
   [ -n "$ROOT" ] || ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fi
 cd "$ROOT" || { echo "run-node-tests: cannot cd to ROOT=$ROOT" >&2; exit 2; }
 
-MIN_TESTS="${MIN_TESTS:-450}"
-MIN_FILES="${MIN_FILES:-14}"
+MIN_TESTS="${MIN_TESTS:-970}"
+
+# --- the pinned suite table ----------------------------------------------------
+# "<dir>|<min_files>|<min_tests>". MEASURED 2026-08-03 in the nix sandbox
+# (`nix build .#checks.x86_64-linux.nodetests`); floors sit just under the real
+# totals so ordinary test-writing does not trip them but a collapse does.
+#
+#   scripts/browser-bridge/tests        14 files   468 tests
+#   scripts/dl-router/tests             13 files   508 tests
+#   scripts/collector/browser-ext/tests  2 files    21 tests
+#
+# Raise a floor when a suite grows. NEVER lower one to get green — that is the
+# move that turned the pytest global floor into less than half the real total.
+SUITES=(
+  "scripts/browser-bridge/tests|14|450"
+  # Ungated until 2026-08-03: `FILES=` above named browser-bridge alone, so these
+  # 508 tests had never run under any gate since dl-router was written.
+  "scripts/dl-router/tests|13|500"
+  # Ungated for the same reason. Small, but 21 tests reporting safety they never
+  # measured is the same defect as 508 of them.
+  "scripts/collector/browser-ext/tests|2|20"
+)
+
+# --- GUARD 3: discovery + the two-way pin --------------------------------------
+# Discovery is filesystem-based, NOT `git ls-files`: the flake check builds from
+# `cp -r ${./.} src`, which carries no .git, so a git-based discovery would find
+# nothing in the exact tier that gates merges.
+#
+# 🔴 And it is BASH GLOBSTAR, not `find`. The first draft of this used
+# `find scripts -name '*.test.mjs' -printf '%h\n'` and discovery came back EMPTY
+# on the dev host — `-printf` is a GNU extension and the `find` on bash's PATH
+# here is BUSYBOX (~/.nix-profile/bin/find), which rejects it. Three different
+# `find`s are reachable from this repo: busybox under bash, `bfs` 4.1.1 under the
+# interactive zsh, GNU findutils in the nix sandbox — and only two support
+# `-printf`. The original also wrote `2>/dev/null`, which turned the error into
+# a silent empty list: the exact "an EMPTY RESULT cannot distinguish two
+# mechanisms" trap. Globstar is a bash builtin, so it depends on no external
+# binary at all and behaves identically in every tier.
+shopt -s globstar nullglob
+DISCOVERED_DIRS=()
+_seen=""
+for f in scripts/**/*.test.mjs; do
+  [ -f "$f" ] || continue
+  d="${f%/*}"
+  case "$_seen" in
+    *"|$d|"*) continue ;;
+  esac
+  _seen="$_seen|$d|"
+  DISCOVERED_DIRS+=("$d")
+done
+shopt -u globstar nullglob
+
+PINNED_DIRS=()
+for entry in "${SUITES[@]}"; do
+  PINNED_DIRS+=("${entry%%|*}")
+done
+
+pin_problems=()
+
+# (a) a discovered suite that nobody pinned — the ungated-suite defect itself.
+for d in "${DISCOVERED_DIRS[@]}"; do
+  found=0
+  for p in "${PINNED_DIRS[@]}"; do
+    [ "$d" = "$p" ] && { found=1; break; }
+  done
+  if [ "$found" -eq 0 ]; then
+    shopt -s nullglob; _n=("$d"/*.test.mjs); shopt -u nullglob
+    pin_problems+=("$d  — holds ${#_n[@]} .test.mjs file(s) but is NOT in SUITES, so it would run UNGATED. Add it with a measured floor.")
+  fi
+done
+
+# (b) a pinned suite discovery did not find — the suite vanished.
+for p in "${PINNED_DIRS[@]}"; do
+  found=0
+  for d in "${DISCOVERED_DIRS[@]}"; do
+    [ "$d" = "$p" ] && { found=1; break; }
+  done
+  if [ "$found" -eq 0 ]; then
+    pin_problems+=("$p  — pinned in SUITES but discovery found no .test.mjs there (deleted, emptied, or renamed?)")
+  fi
+done
+
+if [ "${#pin_problems[@]}" -gt 0 ]; then
+  echo "run-node-tests: FATAL — ${#pin_problems[@]} suite-pin problem(s):" >&2
+  for b in "${pin_problems[@]}"; do echo "    $b" >&2; done
+  echo "  SUITES must match the .test.mjs directories on disk EXACTLY, both ways." >&2
+  echo "  Do NOT delete an entry to make this pass — that is how a suite stops" >&2
+  echo "  running while the gate stays green (508 dl-router tests, ungated for" >&2
+  echo "  the whole life of the suite, is what this guard exists to prevent)." >&2
+  exit 2
+fi
+
+if [ "$CHECK_SUITES_ONLY" -eq 1 ]; then
+  echo "run-node-tests: all ${#PINNED_DIRS[@]} pinned suite(s) match discovery."
+  for entry in "${SUITES[@]}"; do
+    d="${entry%%|*}"; rest="${entry#*|}"
+    echo "  suite $d  (min_files=${rest%%|*} min_tests=${rest##*|})"
+  done
+  exit 0
+fi
 
 command -v node >/dev/null 2>&1 || {
   echo "run-node-tests: FATAL — no \`node\` on PATH (the caller must provide one)" >&2
@@ -55,67 +191,110 @@ command -v node >/dev/null 2>&1 || {
 }
 echo "run-node-tests: node $(node --version)"
 
-# --- collect (guard 1) ---------------------------------------------------------
-shopt -s nullglob
-FILES=(scripts/browser-bridge/tests/*.test.mjs)
-shopt -u nullglob
+# --- run each suite in its own invocation (GUARD 1, 2, 4) ----------------------
+sum() { grep -E "^# $2 [0-9]+$" "$1" | tail -1 | awk '{print $3}'; }
 
-if [ "${#FILES[@]}" -lt "$MIN_FILES" ]; then
-  echo "run-node-tests: FATAL — collected ${#FILES[@]} test file(s), expected >= $MIN_FILES." >&2
-  echo "  The glob matched nothing or almost nothing. Do NOT 'fix' this by passing the" >&2
-  echo "  tests DIRECTORY to \`node --test\` — that yields a bogus 1-test failure." >&2
-  exit 2
-fi
-for f in "${FILES[@]}"; do
-  case "$f" in
-    *.test.mjs) ;;
-    *) echo "run-node-tests: FATAL — refusing non-test argument: $f" >&2; exit 2 ;;
-  esac
-  [ -f "$f" ] || { echo "run-node-tests: FATAL — not a regular file: $f" >&2; exit 2; }
+fail=0
+declare -a RESULTS
+TOT_TESTS=0
+TOT_PASS=0
+TOT_FAIL=0
+TOT_SKIP=0
+TOT_FILES=0
+
+for entry in "${SUITES[@]}"; do
+  dir="${entry%%|*}"
+  rest="${entry#*|}"
+  min_files="${rest%%|*}"
+  min_tests="${rest##*|}"
+
+  echo "=== node --test $dir ==="
+
+  # GUARD 1: glob the files ourselves; never hand `node --test` a directory.
+  shopt -s nullglob
+  FILES=("$dir"/*.test.mjs)
+  shopt -u nullglob
+
+  if [ "${#FILES[@]}" -lt "$min_files" ]; then
+    echo "run-node-tests: FATAL — $dir collected ${#FILES[@]} test file(s), expected >= $min_files." >&2
+    echo "  The glob matched nothing or almost nothing. Do NOT 'fix' this by passing" >&2
+    echo "  the tests DIRECTORY to \`node --test\` — that yields a bogus 1-test failure." >&2
+    RESULTS+=("FAIL  $dir (collected ${#FILES[@]} files, floor $min_files)")
+    fail=1
+    echo
+    continue
+  fi
+  for f in "${FILES[@]}"; do
+    case "$f" in
+      *.test.mjs) ;;
+      *) echo "run-node-tests: FATAL — refusing non-test argument: $f" >&2; exit 2 ;;
+    esac
+    [ -f "$f" ] || { echo "run-node-tests: FATAL — not a regular file: $f" >&2; exit 2; }
+  done
+
+  LOG="$(mktemp)"
+  node --test --test-reporter=tap "${FILES[@]}" >"$LOG" 2>&1
+  rc=$?
+  cat "$LOG"
+
+  # GUARD 2: parse node's TAP summary; a missing line becomes a sentinel that fails.
+  T="$(sum "$LOG" tests)"; P="$(sum "$LOG" pass)"; F="$(sum "$LOG" fail)"
+  S="$(sum "$LOG" skipped)"; TD="$(sum "$LOG" todo)"
+  : "${T:=-1}"; : "${P:=-1}"; : "${F:=-1}"; : "${S:=0}"; : "${TD:=0}"
+  rm -f "$LOG"
+
+  suite_bad=0
+  if [ "$T" -lt 0 ] || [ "$P" -lt 0 ] || [ "$F" -lt 0 ]; then
+    echo "run-node-tests: ERROR — could not parse node's TAP summary for $dir;" >&2
+    echo "  this runner cannot vouch for that run, which is not the same as a pass." >&2
+    suite_bad=1
+  fi
+  # GUARD 4: per-suite floor.
+  if [ "$T" -ge 0 ] && [ "$T" -lt "$min_tests" ]; then
+    echo "run-node-tests: ERROR — $dir ran only $T tests, floor is $min_tests." >&2
+    echo "  Far fewer tests than exist — a VACUOUS GREEN, not a pass. Investigate" >&2
+    echo "  before lowering the floor in SUITES." >&2
+    suite_bad=1
+  fi
+  if [ "$F" -gt 0 ]; then
+    echo "run-node-tests: ERROR — $F test(s) failed in $dir." >&2
+    suite_bad=1
+  fi
+  if [ "$rc" -ne 0 ] && [ "$suite_bad" -eq 0 ]; then
+    echo "run-node-tests: ERROR — node exited $rc for $dir with no failing test —" >&2
+    echo "  a crash or an unhandled rejection." >&2
+    suite_bad=1
+  fi
+
+  [ "$T" -gt 0 ] && TOT_TESTS=$(( TOT_TESTS + T ))
+  [ "$P" -gt 0 ] && TOT_PASS=$(( TOT_PASS + P ))
+  [ "$F" -gt 0 ] && TOT_FAIL=$(( TOT_FAIL + F ))
+  TOT_SKIP=$(( TOT_SKIP + S ))
+  TOT_FILES=$(( TOT_FILES + ${#FILES[@]} ))
+
+  if [ "$suite_bad" -ne 0 ]; then
+    RESULTS+=("FAIL  $dir  (files=${#FILES[@]} tests=$T pass=$P fail=$F skipped=$S)")
+    fail=1
+  else
+    RESULTS+=("PASS  $dir  (files=${#FILES[@]} tests=$T pass=$P skipped=$S floor=$min_tests)")
+  fi
+  echo
 done
-echo "run-node-tests: collected ${#FILES[@]} test files"
-
-# --- run -----------------------------------------------------------------------
-LOG="$(mktemp)"
-trap 'rm -f "$LOG"' EXIT
-node --test --test-reporter=tap "${FILES[@]}" >"$LOG" 2>&1
-rc=$?
-cat "$LOG"
-
-# --- count (guard 2) -----------------------------------------------------------
-# node's TAP summary lines: "# tests N", "# pass N", "# fail N". Take the LAST of
-# each (one summary per run) and default to a sentinel that fails the check if the
-# line is absent entirely.
-sum() { grep -E "^# $1 [0-9]+$" "$LOG" | tail -1 | awk '{print $3}'; }
-T="$(sum tests)"; P="$(sum pass)"; F="$(sum fail)"; S="$(sum skipped)"; TD="$(sum todo)"
-: "${T:=-1}"; : "${P:=-1}"; : "${F:=-1}"; : "${S:=0}"; : "${TD:=0}"
 
 echo "======================== NODE SUMMARY ========================"
-echo "  files=${#FILES[@]}  tests=$T  pass=$P  fail=$F  skipped=$S  todo=$TD  (floor: $MIN_TESTS)"
+for r in "${RESULTS[@]}"; do echo "  $r"; done
+echo "  ----"
+echo "  TOTAL suites=${#SUITES[@]} files=$TOT_FILES tests=$TOT_TESTS pass=$TOT_PASS fail=$TOT_FAIL skipped=$TOT_SKIP  (floor: $MIN_TESTS)"
 
-status=0
-if [ "$T" -lt 0 ] || [ "$P" -lt 0 ] || [ "$F" -lt 0 ]; then
-  echo "  ERROR: could not parse node's TAP summary — the runner cannot vouch for this run." >&2
-  status=1
-fi
-if [ "$T" -lt "$MIN_TESTS" ]; then
-  echo "  ERROR: only $T tests ran, floor is $MIN_TESTS. Something collected far fewer" >&2
-  echo "         tests than exist — a VACUOUS GREEN, not a pass. Investigate before" >&2
-  echo "         lowering MIN_TESTS." >&2
-  status=1
-fi
-if [ "$F" -gt 0 ]; then
-  echo "  ERROR: $F test(s) failed." >&2
-  status=1
-fi
-if [ "$rc" -ne 0 ] && [ "$status" -eq 0 ]; then
-  echo "  ERROR: node exited $rc with no failing test — a crash or unhandled rejection." >&2
-  status=1
+if [ "$TOT_TESTS" -lt "$MIN_TESTS" ]; then
+  echo "  ERROR: only $TOT_TESTS tests ran in total, floor is $MIN_TESTS." >&2
+  echo "         A VACUOUS GREEN, not a pass. Investigate before lowering MIN_TESTS." >&2
+  fail=1
 fi
 
-if [ "$status" -ne 0 ]; then
+if [ "$fail" -ne 0 ]; then
   echo "RESULT: FAIL"
 else
   echo "RESULT: PASS"
 fi
-exit "$status"
+exit "$fail"

--- a/scripts/tests/test_run_node_tests_suites.py
+++ b/scripts/tests/test_run_node_tests_suites.py
@@ -1,0 +1,340 @@
+"""Regression + invariant guards for `scripts/run-node-tests.sh`'s SUITE LIST.
+
+WHY THIS EXISTS
+---------------
+`run-node-tests.sh` collected its files with ONE hard-coded glob::
+
+    FILES=(scripts/browser-bridge/tests/*.test.mjs)
+
+so every other `.test.mjs` directory in the repo was invisible to the only gate
+that runs node. Measured 2026-08-03 on origin/main (13bc8bd):
+
+  * ``scripts/dl-router/tests``             — 508 tests, **never gated**
+  * ``scripts/collector/browser-ext/tests`` —  21 tests, **never gated**
+
+529 tests that no CI run had ever executed, in a repo whose gate had already
+been bitten by this exact shape three times (#276: 913 pytest tests behind one
+list entry, #298: 166, #306: 989). The runner reported ``RESULT: PASS`` and a
+468-test total the whole time, because a hard-coded list cannot know what it is
+not looking at.
+
+Collection is now DISCOVERY (bash globstar over ``scripts/**/*.test.mjs``) plus
+a TWO-WAY PIN (``SUITES``), and this file guards the pin.
+
+WHAT IS REGRESSION COVERAGE HERE AND WHAT IS NOT
+------------------------------------------------
+Per claude/RULES.md ("a guard that pins an invariant the bug never violated is
+an INVARIANT GUARD -- label it as one, don't count it as regression coverage"):
+
+  * ``test_every_test_mjs_directory_is_pinned`` is REGRESSION coverage, and is
+    the direct statement of the bug. It is RED at origin/main: two directories
+    hold ``.test.mjs`` files that the shipped SUITES list (which does not exist
+    there, and whose predecessor named browser-bridge alone) does not cover.
+
+  * ``test_check_suites_accepts_the_real_repo`` is REGRESSION coverage. RED at
+    origin/main, where there is no ``--check-suites`` flag at all: the old arg
+    parser has no case for it, so it is swallowed as ROOT and the run dies
+    ``cannot cd to ROOT=--check-suites``.
+
+  * ``test_dl_router_and_browser_ext_are_pinned`` is an INVARIANT GUARD. It pins
+    that nobody "fixes" a future failure by deleting the entry -- the move the
+    runner's own error message warns against. The bug never violated it (the
+    entries did not exist), so it is not regression coverage.
+
+  * the mutation tests are REACHABILITY proofs: they patch a COPY of the runner
+    and assert it goes red **naming the offending directory**, so a green result
+    from the real list means the guard can actually fire rather than being
+    unreachable behind an earlier check.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+RUNNER = REPO_ROOT / "scripts" / "run-node-tests.sh"
+
+# The two suites that were ungated until 2026-08-03, with the totals measured
+# that day in the nix sandbox. Named literally so that a suite being dropped
+# from SUITES fails HERE with its own reason, not as an anonymous count change.
+FORMERLY_UNGATED = {
+    "scripts/dl-router/tests": 508,
+    "scripts/collector/browser-ext/tests": 21,
+}
+
+
+def _require_check_suites() -> None:
+    """Fail FAST, and for the right reason, if the runner predates the fix.
+
+    Without this the pre-fix behaviour is not merely red but red SLOWLY: the old
+    arg parser has no ``--check-suites`` case, so the flag falls through to
+    ``*) ROOT="$1"`` and the runner tries to ``cd`` to it. Worse, when a ROOT is
+    also supplied the flag is simply overwritten and the runner executes THE
+    ENTIRE 997-test suite once per test. A capability check on the source turns
+    that into an instant, named failure.
+    """
+    src = RUNNER.read_text()
+    assert "--check-suites" in src, (
+        f"{RUNNER} has no --check-suites flag, so the suite-discovery pin "
+        "(GUARD 3) does not exist in this revision. This is the PRE-FIX state: "
+        "collection was the single hard-coded glob "
+        "`FILES=(scripts/browser-bridge/tests/*.test.mjs)`, leaving 529 tests "
+        "in scripts/dl-router/tests and scripts/collector/browser-ext/tests "
+        "ungated by any CI check."
+    )
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", *args],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def _pinned_suites() -> dict[str, tuple[int, int]]:
+    """Parse SUITES out of the runner: {dir: (min_files, min_tests)}.
+
+    Deliberately parsed from the shell source rather than re-listed here -- a
+    second hand-maintained copy of the list is how a list and its guard drift
+    apart, which is the defect class this whole file is about.
+    """
+    src = RUNNER.read_text()
+    m = re.search(r"^SUITES=\((.*?)^\)", src, re.S | re.M)
+    assert m, (
+        "could not find a SUITES=( ... ) block in run-node-tests.sh. If the "
+        "array was renamed, update this parser -- do NOT delete the test, or "
+        "the suite list goes back to being unguarded."
+    )
+    out: dict[str, tuple[int, int]] = {}
+    for raw in m.group(1).splitlines():
+        line = raw.strip().strip('"')
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("|")
+        assert len(parts) == 3, f"malformed SUITES entry: {line!r}"
+        out[parts[0]] = (int(parts[1]), int(parts[2]))
+    assert out, "parsed SUITES as EMPTY -- the parser is broken, not the list"
+    return out
+
+
+def _discovered_dirs() -> set[str]:
+    """Every directory under scripts/ holding a .test.mjs file.
+
+    Uses pathlib rather than shelling out to `find`: the `find` on this host's
+    bash PATH is BUSYBOX and rejects GNU's `-printf` (that exact trap produced a
+    silently EMPTY discovery list while building this change), and the runner
+    itself now uses bash globstar for the same portability reason. A second,
+    independently-implemented discovery here is the point -- it cross-checks the
+    runner's own rather than restating it.
+    """
+    return {
+        str(p.parent.relative_to(REPO_ROOT))
+        for p in (REPO_ROOT / "scripts").rglob("*.test.mjs")
+    }
+
+
+# --------------------------------------------------------------------------
+# Guard the guard: both harness halves must actually see something.
+# --------------------------------------------------------------------------
+
+def test_parsers_are_positive_controlled():
+    """POSITIVE CONTROL for the two parsers this file rests on.
+
+    Every assertion below compares a parsed set against a discovered set. If
+    EITHER quietly stopped matching, the comparisons would run over empty sets
+    and pass vacuously -- a harness reporting success while testing nothing, and
+    the reassuring answer here ("no unpinned directories") is exactly the zero
+    that an unwired harness also produces. So pin that both are non-empty and
+    plausibly sized before believing any result derived from them.
+    """
+    pinned = _pinned_suites()
+    discovered = _discovered_dirs()
+    assert len(pinned) >= 3, f"only {len(pinned)} suites parsed: {pinned}"
+    assert len(discovered) >= 3, f"only {len(discovered)} dirs discovered: {discovered}"
+    assert all(d.startswith("scripts/") for d in pinned), pinned
+    # The floors must be real numbers, not a parse artefact of zeros.
+    assert all(mt > 0 and mf > 0 for mf, mt in pinned.values()), pinned
+
+
+# --------------------------------------------------------------------------
+# REGRESSION: the bug itself.
+# --------------------------------------------------------------------------
+
+def test_every_test_mjs_directory_is_pinned():
+    """RED at origin/main. Every .test.mjs directory must be gated.
+
+    This is the whole defect in one assertion: on origin/main the runner ran
+    scripts/browser-bridge/tests and nothing else, so dl-router's 508 tests and
+    browser-ext's 21 were collected by no gate at all.
+    """
+    pinned = set(_pinned_suites())
+    discovered = _discovered_dirs()
+    unpinned = discovered - pinned
+    assert not unpinned, (
+        f"{len(unpinned)} directory/ies hold .test.mjs files that no gate runs: "
+        f"{sorted(unpinned)}. Add each to SUITES in scripts/run-node-tests.sh "
+        "with a measured floor. This is the #276/#298/#306 shape: a suite that "
+        "exists, passes locally, and is gated by nothing."
+    )
+
+
+def test_no_pinned_suite_has_vanished():
+    """The other direction: a pinned suite must still exist.
+
+    Without this, deleting or renaming a suite directory would quietly shrink
+    the gate -- the failure mode a discovery-only collection step reintroduces.
+    """
+    pinned = set(_pinned_suites())
+    discovered = _discovered_dirs()
+    missing = pinned - discovered
+    assert not missing, (
+        f"SUITES pins {sorted(missing)} but no .test.mjs was found there. "
+        "If the suite genuinely moved, update SUITES; do not drop the entry."
+    )
+
+
+def test_check_suites_accepts_the_real_repo():
+    """RED at origin/main (no --check-suites), GREEN after the fix."""
+    _require_check_suites()
+    proc = _run([str(RUNNER), "--check-suites", str(REPO_ROOT)])
+    assert proc.returncode == 0, (
+        "run-node-tests.sh --check-suites rejected the shipped suite list.\n"
+        f"exit={proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+
+
+def test_dl_router_and_browser_ext_are_pinned():
+    """INVARIANT GUARD (not regression coverage).
+
+    Pins the two suites this change rescued, by name, so they cannot be dropped
+    from the gate as a way of turning a future red green -- which is exactly
+    what the runner's own error text warns against.
+    """
+    pinned = _pinned_suites()
+    for suite, measured in FORMERLY_UNGATED.items():
+        assert suite in pinned, (
+            f"{suite} is no longer in SUITES. It held {measured} tests that no "
+            "gate ran until 2026-08-03. If it genuinely moved, update SUITES "
+            "and this constant; do not simply drop the entry."
+        )
+        _, min_tests = pinned[suite]
+        assert min_tests > measured * 0.9, (
+            f"{suite}'s floor ({min_tests}) has drifted well below its measured "
+            f"total ({measured}). A floor under ~90% of reality stops being able "
+            "to detect the collapse it exists for -- the pytest global floor was "
+            "allowed to fall below HALF before #306 caught it."
+        )
+
+
+def test_check_suites_runs_no_tests():
+    """--check-suites must stay cheap.
+
+    If it ever started executing node, the mutation tests below would take
+    minutes each and would be disabled by the first person who noticed.
+    """
+    _require_check_suites()
+    proc = _run([str(RUNNER), "--check-suites", str(REPO_ROOT)])
+    assert "=== node --test " not in proc.stdout, (
+        f"--check-suites ran a suite; it validates the list only.\n{proc.stdout}"
+    )
+
+
+# --------------------------------------------------------------------------
+# REACHABILITY: prove GUARD 3 can go red, naming the offending directory.
+# --------------------------------------------------------------------------
+
+def _runner_copy(tmp_path: Path, *, drop: str | None = None, add: str | None = None) -> Path:
+    """Copy the runner, optionally dropping or adding one SUITES entry."""
+    src = RUNNER.read_text()
+    if drop is not None:
+        patched, n = re.subn(
+            rf'^\s*"{re.escape(drop)}\|\d+\|\d+"\s*$\n', "", src, count=1, flags=re.M
+        )
+        assert n == 1, f"failed to drop {drop!r} from the copied runner"
+        src = patched
+    if add is not None:
+        patched, n = re.subn(r"^SUITES=\(\n", f'SUITES=(\n  "{add}|1|1"\n', src, count=1, flags=re.M)
+        assert n == 1, "failed to inject a suite into the copied runner"
+        src = patched
+    dst = tmp_path / "run-node-tests.sh"
+    dst.write_text(src)
+    return dst
+
+
+@pytest.mark.parametrize("victim", sorted(FORMERLY_UNGATED))
+def test_dropping_a_pinned_suite_is_loud(tmp_path, victim):
+    """MUTATION: remove a suite from the pin and the guard must name it.
+
+    This is the answer to "if the dl-router node tests silently stopped
+    executing, would anything go red?" -- and it asserts the guard fails with
+    ITS OWN reason (the directory named, "NOT in SUITES"), not merely that the
+    run was non-zero, which an unrelated guard tripping first would also satisfy.
+    """
+    _require_check_suites()
+    runner = _runner_copy(tmp_path, drop=victim)
+    proc = _run([str(runner), "--check-suites", str(REPO_ROOT)])
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 2, (
+        f"dropping {victim} from SUITES did NOT fail the guard (exit "
+        f"{proc.returncode}) -- the pin is inert.\n{out}"
+    )
+    assert victim in out, f"guard failed but never named {victim!r}.\n{out}"
+    assert "NOT in SUITES" in out, (
+        f"guard named {victim!r} but not WHY (expected the unpinned-suite "
+        f"reason, so this test cannot be satisfied by a different guard).\n{out}"
+    )
+
+
+def test_pinning_a_nonexistent_suite_is_loud(tmp_path):
+    """MUTATION, the other direction: a pinned suite that does not exist."""
+    _require_check_suites()
+    ghost = "scripts/does-not-exist/tests"
+    runner = _runner_copy(tmp_path, add=ghost)
+    proc = _run([str(runner), "--check-suites", str(REPO_ROOT)])
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 2, (
+        f"a pinned-but-absent suite did NOT fail the guard (exit "
+        f"{proc.returncode}).\n{out}"
+    )
+    assert ghost in out, f"guard failed but never named {ghost!r}.\n{out}"
+    assert "discovery found no" in out, (
+        f"guard named {ghost!r} but not WHY (expected the vanished-suite "
+        f"reason).\n{out}"
+    )
+
+
+def test_runner_does_not_use_find_printf():
+    """Portability pin, measured rather than assumed.
+
+    The first draft discovered suites with `find -printf`, which is a GNU
+    extension. THREE different `find`s are reachable from this repo -- busybox
+    under bash (~/.nix-profile/bin/find, no -printf), bfs 4.1.1 under the
+    interactive zsh, and GNU findutils in the nix sandbox. Only two accept it,
+    and the draft paired it with `2>/dev/null`, so on the dev host discovery
+    returned an EMPTY list with no error: a false "no suites found" that the
+    two-way pin caught only by accident of failing in the other direction.
+    """
+    # Comment lines are stripped first: the header DESCRIBES the trap, and a
+    # naive substring search over the whole file matches that prose and reports
+    # a defect that is not there. (Caught while writing this test -- the same
+    # "your pattern matched the wrong thing" class the check itself is about.)
+    code = "\n".join(
+        line for line in RUNNER.read_text().splitlines() if not line.lstrip().startswith("#")
+    )
+    assert "-printf" not in code, (
+        "run-node-tests.sh uses `find -printf`, a GNU extension that the "
+        "busybox `find` on this host's bash PATH rejects. Use bash globstar "
+        "(a builtin, identical in every tier) instead."
+    )
+    # POSITIVE CONTROL: the stripper must not have eaten the whole file, or the
+    # assertion above passes vacuously on an empty string.
+    assert "SUITES=(" in code and len(code) > 2000, (
+        "comment-stripping left no executable shell behind -- this check would "
+        "pass against anything. Fix the stripper, not the assertion."
+    )


### PR DESCRIPTION
## The defect

`scripts/run-node-tests.sh` hard-coded its collection to one directory:

```bash
FILES=(scripts/browser-bridge/tests/*.test.mjs)
```

so every other `.test.mjs` suite in the repo was invisible to the only check that runs node. Measured at `origin/main` (`13bc8bd`):

| suite | tests | gated before this PR |
|---|---:|---|
| `scripts/browser-bridge/tests` | 468 | yes |
| `scripts/dl-router/tests` | **508** | **no** |
| `scripts/collector/browser-ext/tests` | **21** | **no** |

**529 tests, ungated since each suite was written.** The gate reported `RESULT: PASS` and a 468-test total the whole time — a hard-coded list cannot know what it is not looking at. This is the fourth instance of the shape: #276 (913 pytest tests behind one list entry), #298 (166), #306 (989).

`scripts/collector/browser-ext/tests` was **not in the brief** — it surfaced from auditing every `*.test.mjs` in the repo rather than only the directory named. Its `test_receiver.py` was already gated by `run-tests.sh`; only its two `.mjs` files were orphaned.

## Why not just add two lines

That leaves the *next* suite ungated identically. Collection is now **discovery** (bash globstar over `scripts/**/*.test.mjs`) plus a **two-way pin** (`SUITES`), which fails in both directions:

- a discovered directory absent from `SUITES` → **FATAL** (forces an accounting entry with a measured floor, instead of being swept in under a global total)
- a pinned suite discovery does not find → **FATAL** (the suite vanished)

Discovery alone would reintroduce a hole the hard-coded glob did not have: an emptied `dl-router/tests` would simply collect fewer files and still pass over a global floor.

Each suite also runs in its **own** `node --test` invocation with its own TAP summary and its own floor. A single global floor of 970 is fully satisfied by browser-bridge (468) + dl-router (508) with browser-ext's 21 tests entirely gone — per-suite floors make that loud.

## A portability defect found while building this

The first draft discovered suites with `find -printf '%h\n' 2>/dev/null`. `-printf` is a GNU extension, and **three different `find`s are reachable from this repo**:

| tier | `find` | `-printf` |
|---|---|---|
| bash on the dev host | busybox (`~/.nix-profile/bin/find`) | **rejected** |
| interactive zsh | `bfs` 4.1.1 | ok |
| nix build sandbox | GNU findutils | ok |

Paired with `2>/dev/null`, the rejection became an **empty discovery list with no error** — a false "no suites found", the "an empty result cannot distinguish two mechanisms" trap. Collection is now a bash builtin (globstar), which depends on no external binary and behaves identically in every tier. `test_runner_does_not_use_find_printf` pins it (and strips comment lines first, because the header *describes* the trap and a naive substring search matched that prose).

## Measured — both tiers

| tier | command | result |
|---|---|---|
| authoritative | `nix build .#checks.x86_64-linux.nodetests` | **997 tests / 997 pass / 0 fail**, `RESULT: PASS`, exit 0 |
| dev host | `bash scripts/run-node-tests.sh` | **997 tests / 997 pass / 0 fail**, `RESULT: PASS`, exit 0 |

**Delta accounted exactly:** 468 (baseline) + 508 + 21 = **997**. No unexplained gap.

Baseline at `origin/main` (`13bc8bd`), sandbox: 468 tests / 14 files / `RESULT: PASS`.

## Red/green matrix

`scripts/tests/test_run_node_tests_suites.py`, base ref `origin/main` (`13bc8bd`), measured by swapping `origin/main`'s runner into place:

| revision | result |
|---|---|
| `origin/main` runner | **10 failed / 0 passed** |
| this branch | **0 failed / 10 passed** |

Labelled honestly in the module docstring:

- **regression coverage** — `test_every_test_mjs_directory_is_pinned` (the defect in one assertion), `test_check_suites_accepts_the_real_repo`, `test_no_pinned_suite_has_vanished`
- **invariant guard, not regression coverage** — `test_dl_router_and_browser_ext_are_pinned` (pins that the entries cannot be deleted to turn a future red green; the bug never violated it because the entries did not exist)
- **reachability/mutation proofs** — dropping each pinned suite, and pinning a nonexistent one, each asserting the guard goes red **naming the directory and its specific reason**, so the test cannot be satisfied by a different guard tripping first

**The 529 newly-gated tests are NOT regression coverage for this change.** They are pre-existing tests whose value is that they now run at all.

## Control pair

The reassuring answer for `test_every_test_mjs_directory_is_pinned` is an **empty set** — which an unwired harness also produces. `test_parsers_are_positive_controlled` is the positive control: it asserts both independently-implemented discovery paths (the runner's bash globstar, the test's `pathlib.rglob`) return non-empty, plausibly-sized sets with real floors, so a silently-broken parser fails loudly instead of passing vacuously.

Reported as a pair: **3 suites discovered / 3 pinned / 0 unpinned**, not the zero alone.

## Files touched

- `scripts/run-node-tests.sh`
- `scripts/tests/test_run_node_tests_suites.py` (new)
- `flake.nix` (the `nodetests` header comment claimed the check covered browser-bridge only — a comment is a claim too)

No overlap with `nix/home.nix`, `scripts/bar-status-poll`, or `scripts/collector/**` source (the browser-ext suite is *referenced* by path, not edited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
