### PR TITLE
feat(activity): deadman check — a telemetry source that DIES can no longer be silent

### DIFF
--- a/claude/skills/activity/SKILL.md
+++ b/claude/skills/activity/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: activity
-description: Operate the personal activity-telemetry pipeline — 6 sources (zsh, tmux, X11 keylogger, browser, Claude Code sessions, i3 window/workspace focus) → per-host collector → homelab ClickHouse (activity.events) → Grafana "Activity & Productivity" dashboard + validation harness. Status, query the data, troubleshoot a stalled source, deploy a change, run validation. Use when the user mentions activity tracking, the keylogger, "where my time goes", the activity dashboard, activity.events, the collector, or productivity mining of their own behaviour.
+description: Operate the personal activity-telemetry pipeline — 9 sources (zsh, tmux, X11 keylogger, browser, Claude Code sessions, i3 window/workspace focus, opencode, browser-bridge, tool invocations) → per-host collector → homelab ClickHouse (activity.events) → Grafana "Activity & Productivity" dashboard + validation harness + a per-host/per-source deadman check. Status, query the data, troubleshoot a stalled source, find out whether a source has silently DIED, deploy a change, run validation. Use when the user mentions activity tracking, the keylogger, "where my time goes", the activity dashboard, activity.events, the collector, a dead/stale telemetry source, the `tlm` bar pill, or productivity mining of their own behaviour.
 ---
 
 # activity-telemetry operations
 
-Six sources emit through one per-host collector daemon into a dedicated, authenticated
+Nine sources emit through one per-host collector daemon into a dedicated, authenticated
 ClickHouse on the homelab cluster; a Grafana dashboard surfaces time/attention +
-focus/context-switching, and a validation harness proves capture/query correctness.
+focus/context-switching, a validation harness proves capture/query correctness, and a
+**deadman check** (`scripts/collector/deadman.py`, surfaced as the `tlm` bar pill) catches a
+source that has silently STOPPED emitting.
 Point-in-time state: memory `activity-telemetry-pipeline` (read it first) + the latest
 `devrc/claudedocs/handoff-activity-*.md`.
 
@@ -35,20 +37,41 @@ stamps `host` from `ACTIVITY_HOST`.
 | CH users | `default`=admin (`admin-password`), `activity_writer`=INSERT+SELECT (`writer-password`, collector uses this), `activity_reader`=SELECT (`reader-password`, dashboard + harness) |
 | CH creds | SOPS secret `homelab-talos/clusters/homelab/apps/activity/secrets.enc.yaml`. Decrypt: `SOPS_AGE_KEY_FILE=~/workspace/homelab-talos/.secrets/age.key sops -d --extract '["stringData"]["reader-password"]' <file>` (on a `<(git show …)` process substitution, add `--input-type yaml`) |
 | Collector config | `~/.config/activity-collector/env` per host (chmod 600, NOT in git/nix store): `CLICKHOUSE_URL/USER/PASSWORD`, `ACTIVITY_HOST` (=`workbench`/`laptop`), batch/flush/buffer caps |
-| Services (home-manager systemd **user**) | `activity-collector` (always), `keylog` (graphical-session.target — laptop only), `browser-activity-receiver` (:8787 loopback), `claude-activity-source` (oneshot + 5-min timer), `i3-source` (i3ipc focus daemon, graphical-session.target — laptop only) |
+| Services (home-manager systemd **user**) | `activity-collector` (always), `keylog` + `i3-source` (graphical-session.target — **BOTH hosts run these; the workbench has a real X/i3 session**), `browser-activity-receiver` (:8787 loopback), `claude-activity-source` (oneshot + 5-min timer) |
 | Dashboard | Grafana "Activity & Productivity" (uid `activity-productivity`), datasource `activity-clickhouse` → `https://grafana.homelab.lan` |
 | Cluster access | `KUBECONFIG=~/workspace/homelab-talos/homelab-kubeconfig` (context `admin@zach-homelab`); manifests in `clusters/homelab/apps/activity/` + dashboard in `clusters/homelab/flux-system/charts/prom-stack/`. **From the laptop** (nebula-only, can't reach the LAN API `192.168.50.94:6443`): `KUBECONFIG=~/.kube/homelab-nebula.yaml` — routes through the `homelab-kube-tunnel` systemd user service (ssh -D SOCKS via the workbench `10.42.0.30`) |
 | Schema columns | `ts DateTime64(3) (UTC), host, source, kind, project, cwd, session, app, text, duration_ms, exit_code, payload(JSON), ingested_at` |
 
-### The six sources
-| source | what |
-|---|---|
-| `zsh` | preexec/precmd, interactive-only → excludes Claude's Bash tool |
-| `tmux` | focus hooks |
-| `keys` | X11 XRecord keylogger, **full content**, GUI-only. Carries `app`=WM_CLASS + `payload.workspace` |
-| `browser` | Brave MV3 ext → loopback receiver :8787. **nav events only**: `text`=URL, `title`, `scroll_pct` (max reading depth), `scroll_ms` (active-scroll time) per page view. Receiver labels `app` from `BROWSER_APP` env. `active_ms` + focus/idle events were **RETIRED** (PR #27) — structurally wrong on i3 (`chrome.idle` is system-wide, blur unreliable → counted *other-app* time as browser-active). Browser attention is now derived downstream (i3 ∩ domain — see `reference/queries.md`) |
-| `claude` | tails `~/.claude/projects/**/*.jsonl`, 5-min timer. Three kinds: `prompt`/`command` (message stream), `session-summary` (Layer A rollups), `session-insight` (Layer B facets) |
-| `i3` | i3ipc `window::focus` + `workspace::focus` → `i3-source` daemon, GUI-only/laptop; captures attention even when NOT typing. Carries `app`=WM_CLASS + `payload.workspace` |
+### The sources — MEASURED, not declared
+🔴 This table said "six sources" and got two things wrong; both were measured on
+2026-08-03 against `activity.events` and corrected. **Do not re-derive the
+expected-present set from prose — run `python3 ~/workspace/devrc/scripts/collector/deadman.py`,
+which derives it from the table.** Live pairs: **9 sources on the laptop, 8 on the
+workbench, 17 pairs total.**
+
+| source | what | laptop | workbench |
+|---|---|---|---|
+| `zsh` | preexec/precmd, interactive-only → excludes Claude's Bash tool | ✅ | ✅ |
+| `tmux` | focus hooks | ✅ | ✅ |
+| `keys` | X11 XRecord keylogger, **full content**. Carries `app`=WM_CLASS + `payload.workspace` | ✅ | ✅ **(the doc said laptop-only — wrong)** |
+| `browser` | Brave MV3 ext → loopback receiver :8787 | ✅ | ❌ **0 rows, correctly — the ext is laptop-only. This is the ONLY genuinely laptop-only source.** |
+| `claude` | Claude Code transcript tailer, 5-min timer | ✅ | ✅ |
+| `i3` | i3ipc focus daemon | ✅ | ✅ **(the doc said laptop-only — wrong)** |
+| `opencode` | opencode plugin + tailers (`prompt`/`assistant-turn`/`tool-call`/`session-summary`) | ✅ | ✅ |
+| `browser-bridge` | metadata-only telemetry from the agent browser-bridge | ✅ | ✅ |
+| `tool` | on-demand tool-invocation events (`scripts/collector/invocation.py`) | ✅ | ✅ |
+
+Per-source detail that matters when querying:
+- `browser` — **nav events only**: `text`=URL, `title`, `scroll_pct` (max reading depth),
+  `scroll_ms` (active-scroll time) per page view. Receiver labels `app` from `BROWSER_APP`.
+  `active_ms` + focus/idle were **RETIRED** (PR #27) — structurally wrong on i3
+  (`chrome.idle` is system-wide, blur unreliable → counted *other-app* time as
+  browser-active). Browser attention is derived downstream (i3 ∩ domain — see
+  `reference/queries.md`).
+- `claude` — tails `~/.claude/projects/**/*.jsonl`. Kinds: `prompt`/`command` (message
+  stream), `session-summary` (Layer A rollups), `session-insight` (Layer B facets).
+- `i3` — `window::focus` + `workspace::focus` → `i3-source`; captures attention even when
+  NOT typing. Carries `app`=WM_CLASS + `payload.workspace`.
 
 **Browser extension is NOT fully nix-managed.** Hand-loaded unpacked in Brave (the laptop's
 daily browser) from `~/.local/share/activity-browser-ext/` — a real-file copy, since
@@ -66,8 +89,13 @@ inject post-reload). Manifest **v1.4.0**. When a file is DELETED upstream (e.g. 
   `$__timeFilter` / range comparisons (they're UTC, aligned with `now()`).
 - **Both hosts are hostname `nixos`** → without `ACTIVITY_HOST` in the env, every row
   collides on `host=nixos`. Set it per host.
-- **keylog + browser + i3 are GUI-only** → laptop only (X11/i3). The workbench is headless
-  (server-mode).
+- 🔴 **CORRECTED 2026-08-03 — "keylog + browser + i3 are GUI-only → laptop only; the
+  workbench is headless" was FALSE and had been for a long time.** Measured against
+  `activity.events`: the workbench emits **i3 (41,001 rows) and keys (37,376 rows)**, both
+  fresh. The workbench runs a real X/i3 session; only the **Brave activity extension** is
+  laptop-only, so `browser` is the single source with 0 workbench rows. Anything that
+  decides "is this source expected here?" must read the TABLE, not this file — which is why
+  `deadman.py` derives the expected set from measured baselines instead of a hand-kept list.
 - **Full-content keylogging** → `activity.events` holds secrets. That is WHY the store is a
   dedicated authed ClickHouse, not the shared LAN-open clickstack. Treat reader/writer creds
   as sensitive.
@@ -75,6 +103,20 @@ inject post-reload). Manifest **v1.4.0**. When a file is DELETED upstream (e.g. 
   `X-Restart-Triggers` flips the unit definition when the code changes. No manual
   `systemctl --user restart` after a ship. (`claude-activity-source` is excluded — its 5-min
   timer oneshot re-runs fresh code anyway.)
+- 🔴 **opencode plugin: only `tool.execute.before` / `tool.execute.after` are real plugin
+  HOOK names. `session.created`, `message.updated` and `session.idle` are BUS EVENT TYPES,
+  not hooks — `activity-plugin.js` registers all three and none has ever fired.** MEASURED
+  2026-08-03 on opencode 1.18.4 with a probe plugin registering all 14 candidate names
+  against a throwaway `OPENCODE_CONFIG_DIR` + `opencode serve` + `POST /session`: the session
+  was created, the named `session.created` hook fired **0 times**, and the generic `event`
+  hook fired **once** with `event.type == "session.created"`. Corroborated in the data:
+  `kind=session-create` and `kind=session-idle` have **0 rows, ever**; every `prompt`/
+  `assistant-turn` row comes from `tailer.py`, not the plugin. Downstream consequence —
+  `currentSession` is only ever set by the dead `session.created` handler, so **2,736 of
+  2,799 `kind=tool-call` rows carry `session=''`** and cannot be attributed to a session.
+  The fix is to route these through a single `event` hook that switches on `event.type`;
+  🔴 do it in a dedicated PR with a live post-deploy check — this is the exact file whose
+  last edit (#298) killed ALL opencode telemetry on both hosts for ~11 hours.
 - **`session-summary` / `session-insight` rows are APPEND-ONLY** — dedupe on read with
   `argMax(<field>, ingested_at)` grouped by `session`.
 
@@ -104,6 +146,40 @@ Current invariant set: `active_ms_capped` + `per_host_hour_active_cap` are **ret
 (per-domain i3-derived attention ≤ total Brave i3 dwell, trailing 48h). The `duration_ms`
 garbage bound is **7d**, not 24h — a multi-day interactive `claude --resume` is real.
 `session_summary_rows_bounded` flags >24 rows/session ingested in 24h.
+
+## deadman — "has a source silently DIED?"
+`scripts/collector/deadman.py`. **Read its module docstring before changing any tunable** —
+every default in it is derived from a measurement that is named inline.
+
+```bash
+python3 ~/workspace/devrc/scripts/collector/deadman.py           # the per-pair table
+python3 ~/workspace/devrc/scripts/collector/deadman.py --json    # machine-readable
+# exit 0 = measured & clean · 1 = something is DEAD · 2 = CANNOT TELL (never "healthy")
+```
+Creds come from `~/.config/activity-collector/env` (the collector's own file) unless
+`CLICKHOUSE_URL/USER/PASSWORD` are already in the environment.
+
+- **Silence is counted in ACTIVE time, not wall time.** A host's *active* 5-min buckets are
+  the ones where any of its sources emitted; overnight/away time is simply not in the set.
+  This is what makes a per-source budget work for `keys` (continuous) and `tool` (on-demand)
+  at the same time.
+- **The budget is MEASURED per (host, source)**: `clamp(2 × p99 active-gap, 2h, 48h)`.
+  Measured 2026-08-03 — `keys`/`i3`/`tmux` land on the 2h floor; `workbench/opencode` 11.5h;
+  `workbench/tool` 31.1h. Nothing is hand-tuned and nothing is hand-listed.
+- **Expected-present is measured too**: a pair is judged only if it cleared a baseline in the
+  14-day window, so `workbench/browser` (0 rows, correctly absent) can never alarm, while a
+  source that *was* emitting and stopped keeps its baseline and does.
+- 🔴 **"Cannot tell" ≠ "healthy".** `not-configured` / `unreachable` / `query-failed` /
+  `no-data` are each their own state; `ok` is unreachable unless rows came back AND at least
+  one pair was actually measured (`evaluated > 0` is the verdict's own positive control).
+- 🔴 **Blind spot, by design:** this is a RELATIVE check. A simultaneous outage of every
+  source on every host produces zero active buckets and reads as "0 dead" — indistinguishable
+  from the operator being away. `newest_event_age_minutes` is reported for the human;
+  it is deliberately not an alarm.
+- **Surface:** the workbench `bar-status-poll` (~45s) runs it as its `telemetry` source →
+  `~/.cache/bar-status/telemetry.json` → the `tlm` pill (signal 17) + a rising-edge dunst
+  toast. One workbench runner covers BOTH hosts because it reads the shared table. See the
+  `bar` skill.
 
 ## troubleshoot a stalled source
 1. `journalctl --user -u <service> -n 30` — `urlopen timed out` = can't reach CH (check the

--- a/claude/skills/bar/SKILL.md
+++ b/claude/skills/bar/SKILL.md
@@ -30,7 +30,7 @@ X — your call"). Leave the setup a little more modern than you found it; never
 | Bar definition (blocks, theme, icons, thresholds) | `nix/graphical.nix` (`programs.i3status-rust.bars.top`) |
 | i3 WM config (binds, bar buttons) | `nix/i3/config.nix` → `~/.config/i3/config` |
 | Decoupled poller (workbench systemd-user timer) | `scripts/bar-status-poll` |
-| Instant block scripts (read cache, never network) | `scripts/i3status-{clawgate,mail,alerts,civitai,dnd,media,airvpn}` |
+| Instant block scripts (read cache, never network) | `scripts/i3status-{clawgate,mail,alerts,civitai,dnd,media,airvpn,telemetry}` |
 | Poller output (per-source JSON) | `~/.cache/bar-status/*.json` (0600) |
 | Generated bar TOML + symlinked scripts | `~/.config/i3status-rust/` |
 | **RETIRED — never edit** | `/etc/nixos/{i3config,i3blocks}.nix`, `/etc/nixos/i3blocks-scripts` (except `airvpn-sudo` + `airvpn-updown`, which MUST stay there for the NOPASSWD sudoers rule + the tunnel PostUp/PostDown; the old Mullvad `vpn-sudo` is dead) |
@@ -61,6 +61,7 @@ X — your call"). Leave the setup a little more modern than you found it; never
 | clawgate | `i3status-clawgate` | 11 | 0 (0→>0) | operator-pending Tasks |
 | DND | `i3status-dnd` | 15 | — | dunst paused indicator; `$mod+Shift+n` toggles |
 | media | `i3status-media` | 16 | n/a | qBit-POD AirVPN pill (net_down), **state-driven**: neutral=connected, **RED**=firewalled (tunnel/port-fwd broken), soft-yellow=stale. poller `parse_media`/`fetch_media` read creds from `~/.config/bar/media.env` (0600) — the same `media.env` also feeds `deep-search`, a media release search/grab CLI on PATH (workbench) after `home-manager switch`. **left → `media-menu`**; **right → qBit WebUI** |
+| telemetry deadman | `i3status-telemetry` | 17 | n/a | `tlm N` = N activity-telemetry (host, source) pairs have STOPPED emitting into ClickHouse; `tlm ?` = the check itself has been unable to evaluate for >30 min. 🔴 **The ONE block that does NOT render an unreachable backend as empty** — its reassuring answer is a zero, so "cannot tell" must not look like "all healthy". Measures BOTH hosts from the workbench poller (it reads the shared table). Logic + the per-source budget table: `scripts/collector/deadman.py` (run it bare for the table; left-click floats it). See the `activity` skill. |
 | airvpn (host) | `i3status-airvpn` | 10 | n/a | **HOST** AirVPN WireGuard pill (net_vpn), **state-driven**, default-OFF. **left → `airvpn-menu`**; **right → `airvpn-detail` float**. 🔴 Full detail + the killswitch re-test protocol: **`airvpn.md`** |
 
 Bars differ by host (`isLaptop` in `graphical.nix`): laptop gets `batteryBlock` and **omits** GPU

--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -200,6 +200,27 @@ let
       { button = "left"; cmd = "xdg-open https://grafana-new.civitai.com"; }
     ];
   };
+  # Telemetry deadman — which activity-telemetry (host, source) pairs have
+  # STOPPED emitting. Covers BOTH hosts from this one workbench poller, because
+  # the check reads the shared ClickHouse table rather than local state.
+  # `tlm N` (Critical) = N dead sources; `tlm ?` (Warning) = the check has been
+  # unable to evaluate for >30 min and CANNOT VOUCH for the pipeline — that
+  # second state exists because this is the one block whose reassuring answer is
+  # a zero, and a zero from a broken query must not read as "all healthy".
+  # No --red-above: there is no standing backlog here, any count is real.
+  telemetryBlock = {
+    block = "custom";
+    command = "${scriptsDir}/i3status-telemetry";
+    json = true;
+    interval = 30;
+    signal = 17;
+    click = [
+      # Float the full per-host/per-source table (measured budget vs measured
+      # silence, per pair). `read` holds the window open — deadman.py prints and
+      # exits, and i3status-rust runs a click cmd through `sh -c`.
+      { button = "left"; cmd = "alacritty --class float,float -o window.dimensions.columns=110 -o window.dimensions.lines=30 -e ${pkgs.bash}/bin/bash -c '${pollPyEnv}/bin/python3 ${home}/workspace/devrc/scripts/collector/deadman.py; echo; read -n 1 -r -s -p \"[any key to close]\"'"; }
+    ];
+  };
   mailBlock = {
     block = "custom";
     command = "${scriptsDir}/i3status-mail";
@@ -309,7 +330,7 @@ let
     ++ lib.optional (!isLaptop) gpuBlock
     ++ lib.optional isLaptop batteryBlock
     ++ [ soundBlock ]
-    ++ lib.optionals (!isLaptop) [ alertsBlock civitaiBlock mailBlock clawgateBlock mediaBlock airvpnBlock ]
+    ++ lib.optionals (!isLaptop) [ telemetryBlock alertsBlock civitaiBlock mailBlock clawgateBlock mediaBlock airvpnBlock ]
     ++ [ timeBlock ]
     ++ lib.optionals (!isLaptop) [ agentOpsBlock rigcontrolBlock ]
     ++ [ notifsBlock ];
@@ -409,6 +430,10 @@ lib.mkIf isNixOS {
     source = ../scripts/i3status-alerts;
     executable = true;
   };
+  home.file.".config/i3status-rust/scripts/i3status-telemetry" = lib.mkIf (!isLaptop) {
+    source = ../scripts/i3status-telemetry;
+    executable = true;
+  };
   home.file.".config/i3status-rust/scripts/i3status-civitai" = lib.mkIf (!isLaptop) {
     source = ../scripts/i3status-civitai;
     executable = true;
@@ -468,7 +493,7 @@ lib.mkIf isNixOS {
   # repo paths itself (no .zshenv handles under systemd).
   systemd.user.services.bar-status-poll = lib.mkIf (!isLaptop) {
     Unit = {
-      Description = "Poll clawgate/mail/alerts/civitai/media/airvpn → ~/.cache/bar-status for the i3 bar";
+      Description = "Poll clawgate/mail/alerts/civitai/media/airvpn/telemetry → ~/.cache/bar-status for the i3 bar";
       After = [ "network-online.target" ];
       Wants = [ "network-online.target" ];
       # Toast on failure (the notify-failure@ template lives in home.nix, installed
@@ -507,7 +532,13 @@ lib.mkIf isNixOS {
       ];
       ExecStart = "${pollPyEnv}/bin/python3 %h/workspace/devrc/scripts/bar-status-poll";
       # Re-run the unit when the poller changes (cf. X-Restart-Triggers in home.nix).
-      X-Restart-Triggers = [ "${../scripts/bar-status-poll}" ];
+      # deadman.py is listed too: the poller loads it by explicit path out of the
+      # working tree, so without this entry a change to the deadman logic would
+      # leave the unit definition identical and the timer would not re-arm.
+      X-Restart-Triggers = [
+        "${../scripts/bar-status-poll}"
+        "${../scripts/collector/deadman.py}"
+      ];
     };
   };
 

--- a/scripts/bar-status-poll
+++ b/scripts/bar-status-poll
@@ -26,6 +26,15 @@ Sources
              InfoInhibitor) from Alertmanager /api/v2/alerts, reached through a
              short bounded `kubectl port-forward`. homelab is REQUIRED; the
              production cluster is best-effort (added only if reachable).
+  telemetry: DEADMAN over the activity-telemetry pipeline — which (host, source)
+             pairs have STOPPED emitting into ClickHouse `activity.events`.
+             scripts/collector/deadman.py does the measuring (read its docstring
+             for what "dead" means for a source that only fires on demand); this
+             poller only maps the verdict onto a pill. UNLIKE every other source
+             here, an unreachable backend does NOT render as an empty block: a
+             check whose reassuring answer is a zero must never let "cannot tell"
+             look like "all healthy", so a persistent unknown gets a visible
+             `tlm ?` pill (grace-gated, see TELEMETRY_UNKNOWN_GRACE).
   civitai  : the SAME firing-alert filter, but against the civitai DataPacket
              prod cluster (a CLIENT prod cluster) via its own kubeconfig
              (CIVITAI_KUBECONFIG). Deliberately a SEPARATE block/count from the
@@ -65,7 +74,14 @@ IGNORE_ALERTNAMES = frozenset({"Watchdog", "InfoInhibitor"})
 # Real-time signal offset per source: the block's `signal = N` in graphical.nix
 # must match, so `pkill -RTMIN+N i3status-rs` refreshes exactly that block.
 SIGNALS = {"clawgate": 11, "mail": 12, "alerts": 13, "civitai": 14, "media": 16,
-           "airvpn": 10}
+           "airvpn": 10, "telemetry": 17}
+
+# telemetry deadman: how long the check must be CONTINUOUSLY unable to evaluate
+# before the bar shows the visible `tlm ?` pill. A ClickHouse restart or a nebula
+# blip between two 45s polls must not flicker the bar, but a persistent "cannot
+# tell" must NOT keep reading as "all healthy" — that is the entire point of the
+# check. 30 minutes = ~40 consecutive failed polls.
+TELEMETRY_UNKNOWN_GRACE = 1800
 
 # media (qBittorrent behind the gluetun AirVPN sidecar). The pill's ONLY content
 # is the qBit tunnel status + ↓/↑ speed; secondary metrics live behind the block's
@@ -314,6 +330,66 @@ def parse_airvpn(probe) -> dict:
     }
 
 
+def parse_telemetry(verdict, prev=None, now=None,
+                    grace: int = TELEMETRY_UNKNOWN_GRACE,
+                    unknown_states=None) -> dict:
+    """Map a deadman verdict -> bar status dict. PURE (given `now`).
+
+    Three outcomes, and the third is the one that matters:
+      state=ok, count=0   -> Idle, invisible pill.        "measured, all fresh"
+      state=ok, count>0   -> Critical `tlm N`.            "N sources are dead"
+      unknown state       -> `unknown` once it has PERSISTED past `grace`,
+                             rendering a visible `tlm ?`. "cannot tell"
+
+    "Cannot tell" must be distinguishable from "all healthy" — a check whose
+    reassuring answer is a zero is exactly the shape that can be wired to
+    nothing and report green forever, which is the bug class this check exists
+    to catch (PR #299 drew the same not-configured/unreachable/query-failed/ok
+    distinction in insights.py; this follows it).
+
+    `unknown_since` is carried forward from the PREVIOUS cache payload so the
+    grace timer survives the poller being a systemd oneshot with no memory
+    between runs — the same reason the edge-toast latch is a sidecar file.
+    """
+    if unknown_states is None:
+        unknown_states = _deadman_unknown_states()
+    now = int(time.time()) if now is None else int(now)
+    v = verdict if isinstance(verdict, dict) else {}
+    tstate = v.get("state") or "query-failed"
+    detail = str(v.get("detail") or "")
+    out = {
+        "telemetry_state": tstate,
+        "evaluated": int(v.get("evaluated") or 0),
+        "rows": int(v.get("rows") or 0),
+        "newest_event_age_minutes": v.get("newest_event_age_minutes"),
+    }
+    if tstate in unknown_states:
+        prev_since = None
+        if isinstance(prev, dict) and prev.get("telemetry_state") in unknown_states:
+            try:
+                prev_since = int(prev.get("unknown_since"))
+            except (TypeError, ValueError):
+                prev_since = None
+        since = prev_since if prev_since is not None else now
+        out.update({
+            "count": 0,
+            "state": "Warning",
+            "unknown": (now - since) >= grace,
+            "unknown_since": since,
+            "detail": "telemetry health UNKNOWN (%s): %s" % (tstate, detail),
+        })
+        return out
+    count = int(v.get("count") or 0)
+    out.update({
+        "count": count,
+        "state": "Critical" if count else "Idle",
+        "unknown": False,
+        "unknown_since": None,
+        "detail": detail or ("%d dead source(s)" % count),
+    })
+    return out
+
+
 def stale(reason: str, err=None) -> dict:
     """A neutral 'source unavailable' marker; the block renders it as empty."""
     d = {"count": 0, "state": "stale", "detail": reason}
@@ -456,6 +532,14 @@ def _toast_specs() -> dict:
                      "action": "xdg-open http://192.168.50.250:30302"},
         "mail": {"threshold": 0, "urgency": "low",
                  "summary": "New mail action", "action": None},
+        # Rare by construction (measured 2026-08-03: 0 dead across 17 live
+        # host/source pairs), and the thing it announces is invisible by
+        # definition — a telemetry source that stopped emitting. Critical
+        # urgency because the alternative is finding out weeks later that every
+        # analysis since has rested on stale data.
+        "telemetry": {"threshold": 0, "urgency": "critical",
+                      "summary": "🔴 Telemetry source DEAD",
+                      "action": "xdg-open http://grafana.homelab.lan"},
     }
 
 
@@ -552,6 +636,50 @@ def _load_maildb():
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+
+def _load_deadman():
+    """Load scripts/collector/deadman.py by explicit path (same idiom as
+    _load_maildb — never via sys.path, so nothing in scripts/collector/ can
+    shadow a name this poller relies on)."""
+    import importlib.util
+    path = os.path.join(DEVRC_DIR, "scripts", "collector", "deadman.py")
+    spec = importlib.util.spec_from_file_location("_bar_deadman", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _deadman_unknown_states():
+    """The deadman module's UNKNOWN_STATES, with a fallback so this poller does
+    not silently treat an unknown verdict as healthy if the import breaks."""
+    try:
+        return _load_deadman().UNKNOWN_STATES
+    except Exception:
+        return frozenset({"no-data", "unreachable", "query-failed",
+                          "not-configured"})
+
+
+def read_prev_status(name: str):
+    """The previous poll's cache payload for `name`, or None. Read-only."""
+    try:
+        with open(os.path.join(cache_dir(), name + ".json")) as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def fetch_telemetry() -> dict:
+    """Deadman check over activity.events: which (host, source) pairs stopped?
+
+    Runs on the WORKBENCH only (this whole poller does), but covers BOTH hosts:
+    the check reads the shared ClickHouse table, so one runner sees the fleet.
+    Credentials come from the collector's own 0600 env file — the same ones the
+    collector is already proven to work with, and nothing new in the nix store.
+    """
+    mod = _load_deadman()
+    prev = read_prev_status("telemetry")
+    return parse_telemetry(mod.check(), prev=prev)
 
 
 def fetch_mail() -> dict:
@@ -896,11 +1024,15 @@ def main(argv=None) -> int:
                     help="parse this JSON file as the host-AirVPN probe payload")
     ap.add_argument("--mock-mail", metavar="N", type=int,
                     help="use N as the open-mail_actions count")
+    ap.add_argument("--mock-telemetry", metavar="FILE",
+                    help="parse this JSON file as a deadman verdict (see "
+                         "scripts/collector/deadman.py --json)")
     args = ap.parse_args(argv)
 
     mocking = any(x is not None for x in
                   (args.mock_clawgate, args.mock_alerts, args.mock_civitai,
-                   args.mock_media, args.mock_airvpn, args.mock_mail))
+                   args.mock_media, args.mock_airvpn, args.mock_mail,
+                   args.mock_telemetry))
 
     if mocking:
         if args.mock_clawgate is not None:
@@ -920,6 +1052,11 @@ def main(argv=None) -> int:
         if args.mock_airvpn is not None:
             with open(args.mock_airvpn) as f:
                 run_source("airvpn", lambda: parse_airvpn(json.load(f)))
+        if args.mock_telemetry is not None:
+            with open(args.mock_telemetry) as f:
+                verdict = json.load(f)
+            prev = read_prev_status("telemetry")
+            run_source("telemetry", lambda: parse_telemetry(verdict, prev=prev))
         return 0
 
     # Live poll: each source is independent + fail-safe. After writing each
@@ -929,9 +1066,17 @@ def main(argv=None) -> int:
     specs = _toast_specs()
     for name, fn in (("clawgate", fetch_clawgate), ("mail", fetch_mail),
                      ("alerts", fetch_alerts), ("civitai", fetch_civitai),
-                     ("media", fetch_media), ("airvpn", fetch_airvpn)):
+                     ("media", fetch_media), ("airvpn", fetch_airvpn),
+                     ("telemetry", fetch_telemetry)):
         payload = run_source(name, fn)
         spec = specs.get(name)   # media has no edge-toast spec (alarm is in-pill)
+        # An UNKNOWN telemetry verdict carries count=0, which would clear the
+        # rising-edge latch and re-toast a still-dead source when ClickHouse came
+        # back. Skip it, exactly as evaluate_edge_toast already skips stale
+        # payloads for the other sources: a blackout must never move the latch.
+        if name == "telemetry" and isinstance(payload, dict) \
+                and payload.get("unknown_since") is not None:
+            spec = None
         if spec is not None:
             with contextlib.suppress(Exception):
                 evaluate_edge_toast(name, payload, spec)

--- a/scripts/collector/deadman.py
+++ b/scripts/collector/deadman.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""Deadman check for the activity-telemetry pipeline: which (host, source) pairs
+have STOPPED emitting into `activity.events`?
+
+WHY THIS EXISTS
+---------------
+2026-08-02: devrc PR #298 added `export const _internals = {...}` to
+`activity-plugin.js`. opencode's plugin loader rejects the WHOLE module if any
+named export is not a function, so every opencode telemetry hook died on both
+hosts for ~11 hours. `emitEvent` swallows every error by design, so nothing
+reported it — it was found because someone happened to run a manual check.
+Two more of the same shape were sitting in the data unnoticed: the laptop had
+ZERO `kind=tool-call` rows for its entire existence (a hand-run deploy script was
+never run there), and `kind=session-create` has never emitted a single row ever.
+
+A dead source is SILENT by construction. Nothing else in the pipeline can notice
+it, because "no rows" is exactly what a healthy-but-idle source looks like too.
+
+WHAT "DEAD" MEANS HERE
+----------------------
+Wall-clock staleness cannot work: `keys`/`i3`/`tmux` emit continuously while
+`opencode`/`tool` fire only when the operator happens to run them. One threshold
+either misses the outage or cries wolf, and alert fatigue is the failure mode
+this repo's own bar design (hide-at-zero) is built around.
+
+So silence is measured in ACTIVE TIME, not wall time, and the budget is
+MEASURED per (host, source) rather than declared:
+
+  1. Bucket every event into 5-minute buckets, per host and source
+     (one GROUP BY — ~11k rows for 14 days across both hosts, measured).
+  2. A host's ACTIVE buckets = the buckets in which ANY source on that host
+     emitted. Overnight and away-from-desk time simply is not in this set, so an
+     on-demand source is not punished for the operator being asleep.
+  3. For each (host, source), the historical gap between consecutive emitting
+     buckets is counted IN ACTIVE BUCKETS. Its Nth percentile (default p99) is
+     that source's own normal worst-case silence.
+  4. budget = clamp(K * p99_gap, FLOOR, CAP), and the pair is DEAD when the
+     active-time silence since its last event exceeds that budget.
+
+This is what "an on-demand source needs last-seen tracking, not a fixed window"
+cashes out to: `tool` is allowed ~31 active hours of silence on the workbench and
+`keys` only 2, and neither number was typed by hand.
+
+EXPECTED-PRESENT IS ALSO MEASURED, NOT DECLARED
+-----------------------------------------------
+A pair is evaluated iff it cleared MIN_BASELINE_BUCKETS in the window. A source
+that legitimately does not exist on a host (measured 2026-08-03: `browser` has
+0 rows on the workbench — the Brave activity extension is laptop-only) is simply
+absent from the evaluated set and can never alarm. A source that WAS emitting and
+stopped keeps its baseline for the whole window and does alarm. No table of
+per-host expectations is maintained anywhere, so no table can go stale — and one
+had: the `activity` SKILL.md claimed keylog/i3/browser were "GUI-only -> laptop
+only; the workbench is headless", while the workbench was in fact emitting 41,001
+`i3` and 37,376 `keys` rows.
+
+🔴 SCOPE — THE BLIND SPOT, STATED PLAINLY
+-----------------------------------------
+This is a RELATIVE check: it detects a source dying WHILE ITS PEERS KEEP
+EMITTING. A simultaneous outage of every source on every host produces zero
+active buckets after the blackout starts, so every silence measures as 0 and the
+check reports "0 dead" — which is also exactly what the operator being asleep
+looks like. The two are not distinguishable from this table, so the check does
+not pretend to distinguish them; `newest_event_age_minutes` is reported so the
+operator can see it, and it is deliberately NOT an alarm.
+The motivating outage IS in scope: opencode died on both hosts while zsh/tmux/
+keys/i3/claude kept emitting.
+
+🔴 "CANNOT TELL" IS NOT "HEALTHY"
+---------------------------------
+A health check whose reassuring answer is a zero is precisely the shape that can
+be wired to nothing and report green forever. So every non-evaluable condition
+gets its OWN state and none of them is `ok`:
+
+  not-configured  no CLICKHOUSE_URL/USER/PASSWORD available
+  unreachable     the HTTP request to ClickHouse failed
+  query-failed    ClickHouse answered, but the response would not parse
+  no-data         the query returned zero rows, or no pair cleared the baseline
+                  -- i.e. we cannot prove we read the table at all
+  ok              the table was read and at least one pair was evaluated
+
+`ok` therefore carries its own positive control: it is unreachable unless rows
+came back AND at least one pair was actually measured. `evaluated` is in the
+payload for the same reason -- a count that must be non-zero for the verdict to
+mean anything.
+
+CLI
+---
+    python3 deadman.py --json                 # live query (env or --env-file)
+    python3 deadman.py --tsv FILE [--now N]   # evaluate a captured/seeded TSV
+                                              #   (the control harness: seed a
+                                              #   stale source and watch the
+                                              #   count move off zero)
+Exit code is 0 for ok-and-clean, 1 when something is dead, 2 for any unknown
+state. Never raises.
+"""
+from __future__ import annotations
+
+import argparse
+import bisect
+import collections
+import json
+import math
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+# --------------------------------------------------------------------------- #
+# Tunables. Every default below is derived from a MEASUREMENT, named inline.
+# --------------------------------------------------------------------------- #
+BUCKET_SECONDS = 300          # 5-minute buckets
+BASELINE_DAYS = 14
+
+# A pair needs this many emitting buckets in the window before it is judged at
+# all. Below it the gap statistics are noise, and a brand-new source would alarm
+# before it had a normal to compare against. Measured 2026-08-03: the thinnest
+# LIVE pair was laptop/tool at 45 buckets, so 20 leaves real headroom while still
+# excluding a source that fired twice.
+MIN_BASELINE_BUCKETS = 20
+
+# p99 rather than p95: p95 tracks the typical lull, p99 tracks the worst NORMAL
+# lull, which is the number a budget has to clear to avoid crying wolf.
+GAP_QUANTILE = 0.99
+
+# Slack on top of the measured worst normal lull.
+BUDGET_K = 2.0
+
+# Floor: 24 buckets = 2 ACTIVE hours. Applies to the continuous sources, whose
+# p99 gap is 1-6 buckets -- without a floor they would alarm on a coffee break.
+FLOOR_BUCKETS = 24
+
+# Cap: 576 buckets = 48 ACTIVE hours (~5-6 wall days at the measured ~8.3 active
+# hours/day). Chosen to sit well ABOVE the largest gap observed anywhere in the
+# 14-day window (224 buckets, workbench/tool) so it cannot manufacture a false
+# alarm, while still bounding a pathological budget.
+CAP_BUCKETS = 576
+
+DEFAULT_ENV_FILE = "~/.config/activity-collector/env"
+DEFAULT_TIMEOUT = 8.0
+
+STATE_OK = "ok"
+STATE_NO_DATA = "no-data"
+STATE_UNREACHABLE = "unreachable"
+STATE_QUERY_FAILED = "query-failed"
+STATE_NOT_CONFIGURED = "not-configured"
+
+# Everything that is NOT a measured verdict. The whole point of the module is
+# that these are distinguishable from `ok`, so they are enumerated once here and
+# every consumer asks this set rather than re-deriving the list.
+UNKNOWN_STATES = frozenset(
+    {STATE_NO_DATA, STATE_UNREACHABLE, STATE_QUERY_FAILED, STATE_NOT_CONFIGURED}
+)
+
+
+# --------------------------------------------------------------------------- #
+# Query
+# --------------------------------------------------------------------------- #
+def bucket_query(days: int = BASELINE_DAYS, bucket_seconds: int = BUCKET_SECONDS,
+                 database: str = "activity", table: str = "events") -> str:
+    """The ONE query the check runs: per host/source/bucket event counts.
+
+    Deliberately a plain GROUP BY rather than a window function -- all of the
+    gap/percentile work happens in `evaluate`, which is pure and therefore
+    testable against a fixture with no ClickHouse anywhere near it.
+    """
+    return (
+        "SELECT host, source, "
+        "toUnixTimestamp(toStartOfInterval(ts, INTERVAL %d SECOND)) AS b, "
+        "count() AS n "
+        "FROM %s.%s WHERE ts > now() - INTERVAL %d DAY "
+        "GROUP BY host, source, b ORDER BY host, source, b FORMAT TSV"
+        % (int(bucket_seconds), database, table, int(days))
+    )
+
+
+def parse_buckets(text: str):
+    """TSV -> [(host, source, bucket_epoch, n)]. Raises ValueError on junk.
+
+    Strict on purpose. Silently dropping unparseable lines would let a changed
+    output format read as "fewer rows" and, at the limit, as "no staleness" --
+    the exact way a parsed-output harness lies (RULES.md: a tool's output format
+    is a dependency you did not pin).
+    """
+    rows = []
+    for lineno, line in enumerate(text.splitlines(), 1):
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) != 4:
+            raise ValueError("line %d: expected 4 tab-separated fields, got %d"
+                             % (lineno, len(parts)))
+        host, source, b, n = parts
+        try:
+            rows.append((host, source, int(b), int(n)))
+        except ValueError:
+            raise ValueError("line %d: non-integer bucket/count: %r" % (lineno, line))
+    return rows
+
+
+def fetch_buckets(url: str, user: str, password: str, query: str,
+                  timeout: float = DEFAULT_TIMEOUT) -> str:
+    """POST the query to ClickHouse and return the raw TSV body. Raises."""
+    req = urllib.request.Request(url.rstrip("/") + "/",
+                                 data=query.encode("utf-8"), method="POST")
+    if user:
+        import base64
+        token = base64.b64encode(("%s:%s" % (user, password)).encode()).decode()
+        req.add_header("Authorization", "Basic " + token)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read().decode("utf-8", "replace")
+
+
+# --------------------------------------------------------------------------- #
+# Pure evaluation
+# --------------------------------------------------------------------------- #
+def percentile(values, p: float) -> float:
+    """Linear-interpolated percentile over a list. [] -> 0.0."""
+    if not values:
+        return 0.0
+    v = sorted(values)
+    if len(v) == 1:
+        return float(v[0])
+    k = (len(v) - 1) * p
+    lo = math.floor(k)
+    hi = math.ceil(k)
+    if lo == hi:
+        return float(v[int(k)])
+    return float(v[lo]) + (float(v[hi]) - float(v[lo])) * (k - lo)
+
+
+def budget_for(gap_p: float, k: float = BUDGET_K, floor: int = FLOOR_BUCKETS,
+               cap: int = CAP_BUCKETS) -> int:
+    """clamp(k * gap_p, floor, cap), in active buckets."""
+    return int(min(cap, max(floor, round(k * gap_p))))
+
+
+def evaluate(rows, now=None, *, bucket_seconds: int = BUCKET_SECONDS,
+             min_baseline: int = MIN_BASELINE_BUCKETS,
+             quantile: float = GAP_QUANTILE, k: float = BUDGET_K,
+             floor: int = FLOOR_BUCKETS, cap: int = CAP_BUCKETS) -> dict:
+    """Pure: bucket rows -> verdict dict. No I/O, no clock unless `now` is None.
+
+    Returns {"state", "rows", "evaluated", "dead", "count", "sources",
+             "newest_event_age_minutes"}.
+    `state` is STATE_OK only when rows came back AND at least one pair was
+    actually measured -- see the module docstring on why the zero needs that.
+    """
+    now = int(time.time()) if now is None else int(now)
+    if not rows:
+        return {"state": STATE_NO_DATA, "rows": 0, "evaluated": 0,
+                "dead": [], "count": 0, "sources": [],
+                "newest_event_age_minutes": None,
+                "detail": "query returned no rows — cannot tell"}
+
+    active_by_host = collections.defaultdict(set)
+    buckets_by_pair = collections.defaultdict(set)
+    for host, src, b, _n in rows:
+        active_by_host[host].add(b)
+        buckets_by_pair[(host, src)].add(b)
+
+    newest = max(b for _h, _s, b, _n in rows)
+
+    sources = []
+    for (host, src), bset in sorted(buckets_by_pair.items()):
+        active = sorted(active_by_host[host])
+        ev = sorted(bset)
+        last = ev[-1]
+        # Active buckets strictly AFTER the pair's last emitting bucket. The
+        # pair's own buckets are in `active`, so "strictly after" is what makes
+        # a live source measure 0 rather than 1.
+        silent = len(active) - bisect.bisect_right(active, last)
+        rec = {
+            "host": host,
+            "source": src,
+            "baseline_buckets": len(ev),
+            "last_event_epoch": last,
+            "wall_silent_minutes": max(0, (now - last) // 60),
+            "silent_active_buckets": silent,
+            "silent_active_hours": round(silent * bucket_seconds / 3600.0, 2),
+        }
+        if len(ev) < min_baseline:
+            # Not enough history to have a normal. Never alarms — this is also
+            # what makes a legitimately-absent source (workbench/browser: 0 rows)
+            # silent rather than noisy: it is not in `rows` at all.
+            rec.update({"evaluated": False, "reason": "insufficient-baseline",
+                        "gap_p": None, "budget_buckets": None,
+                        "budget_active_hours": None, "dead": False})
+            sources.append(rec)
+            continue
+        gaps = []
+        for i in range(len(ev) - 1):
+            lo = bisect.bisect_right(active, ev[i])
+            hi = bisect.bisect_left(active, ev[i + 1])
+            gaps.append(hi - lo)
+        gap_p = percentile(gaps, quantile)
+        budget = budget_for(gap_p, k=k, floor=floor, cap=cap)
+        rec.update({
+            "evaluated": True,
+            "reason": None,
+            "gap_p": round(gap_p, 2),
+            "budget_buckets": budget,
+            "budget_active_hours": round(budget * bucket_seconds / 3600.0, 2),
+            "dead": silent > budget,
+        })
+        sources.append(rec)
+
+    evaluated = [s for s in sources if s["evaluated"]]
+    dead = [s for s in evaluated if s["dead"]]
+    if not evaluated:
+        return {"state": STATE_NO_DATA, "rows": len(rows), "evaluated": 0,
+                "dead": [], "count": 0, "sources": sources,
+                "newest_event_age_minutes": max(0, (now - newest) // 60),
+                "detail": "no (host, source) pair cleared the baseline — cannot tell"}
+
+    return {
+        "state": STATE_OK,
+        "rows": len(rows),
+        "evaluated": len(evaluated),
+        "dead": dead,
+        "count": len(dead),
+        "sources": sources,
+        "newest_event_age_minutes": max(0, (now - newest) // 60),
+        "detail": describe(dead, len(evaluated)),
+    }
+
+
+def describe(dead, evaluated: int) -> str:
+    """One-line human summary — the toast body and the block's popup text."""
+    if not dead:
+        return "%d source(s) fresh" % evaluated
+    parts = ["%s/%s silent %.1fh active (budget %.1fh)"
+             % (d["host"], d["source"], d["silent_active_hours"],
+                d["budget_active_hours"]) for d in dead[:4]]
+    more = "" if len(dead) <= 4 else " (+%d more)" % (len(dead) - 4)
+    return "; ".join(parts) + more
+
+
+# --------------------------------------------------------------------------- #
+# Config + the live check
+# --------------------------------------------------------------------------- #
+def load_env_file(path: str = DEFAULT_ENV_FILE) -> dict:
+    """Read KEY=VALUE lines from the collector's 0600 env file. Never raises.
+
+    This is the same file the collector itself uses, so the check reads exactly
+    the credentials that are known to work on this host, and no new secret is
+    introduced anywhere (nothing lands in the nix store).
+    """
+    out = {}
+    try:
+        with open(os.path.expanduser(path)) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, _, val = line.partition("=")
+                out[key.strip()] = val.strip()
+    except Exception:
+        return {}
+    return out
+
+
+def resolve_config(env=None, env_file: str = DEFAULT_ENV_FILE) -> dict:
+    """Process env wins; the collector env file fills the gaps."""
+    env = os.environ if env is None else env
+    fromfile = load_env_file(env_file)
+
+    def pick(name, default=""):
+        v = env.get(name)
+        if v:
+            return v
+        return fromfile.get(name, default)
+
+    return {
+        "url": pick("CLICKHOUSE_URL"),
+        "user": pick("CLICKHOUSE_USER"),
+        "password": pick("CLICKHOUSE_PASSWORD"),
+        "database": pick("CLICKHOUSE_DATABASE", "activity"),
+        "table": pick("CLICKHOUSE_TABLE", "events"),
+    }
+
+
+def check(env=None, env_file: str = DEFAULT_ENV_FILE, now=None,
+          timeout: float = DEFAULT_TIMEOUT, fetch=None, **kw) -> dict:
+    """Full live check. Returns a verdict dict; NEVER raises.
+
+    `fetch(url, user, password, query, timeout) -> str` is injectable so the
+    whole path (including every failure branch) is testable offline.
+    """
+    cfg = resolve_config(env=env, env_file=env_file)
+    if not cfg["url"]:
+        return {"state": STATE_NOT_CONFIGURED, "rows": 0, "evaluated": 0,
+                "dead": [], "count": 0, "sources": [],
+                "newest_event_age_minutes": None,
+                "detail": "no CLICKHOUSE_URL — telemetry not configured here"}
+    query = bucket_query(database=cfg["database"], table=cfg["table"])
+    fetch = fetch or fetch_buckets
+    try:
+        body = fetch(cfg["url"], cfg["user"], cfg["password"], query, timeout)
+    except Exception as e:  # noqa: BLE001 — unreachable must not look healthy
+        return {"state": STATE_UNREACHABLE, "rows": 0, "evaluated": 0,
+                "dead": [], "count": 0, "sources": [],
+                "newest_event_age_minutes": None,
+                "detail": "ClickHouse unreachable: %s" % str(e)[:160]}
+    try:
+        rows = parse_buckets(body)
+    except Exception as e:  # noqa: BLE001
+        return {"state": STATE_QUERY_FAILED, "rows": 0, "evaluated": 0,
+                "dead": [], "count": 0, "sources": [],
+                "newest_event_age_minutes": None,
+                "detail": "unparseable ClickHouse response: %s" % str(e)[:160]}
+    return evaluate(rows, now=now, **kw)
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _render_text(v: dict) -> str:
+    lines = ["state: %s   rows=%d evaluated=%d dead=%d"
+             % (v["state"], v.get("rows", 0), v.get("evaluated", 0),
+                v.get("count", 0)),
+             "detail: %s" % v.get("detail", "")]
+    if v.get("newest_event_age_minutes") is not None:
+        lines.append("newest event: %d min ago (informational — a total blackout "
+                     "is NOT an alarm, see module docstring)"
+                     % v["newest_event_age_minutes"])
+    if v.get("sources"):
+        lines.append("")
+        lines.append("%-10s %-15s %8s %8s %9s %9s  %s"
+                     % ("host", "source", "baseline", "p99gap", "budget_h",
+                        "silent_h", "verdict"))
+        for s in v["sources"]:
+            lines.append("%-10s %-15s %8d %8s %9s %9s  %s"
+                         % (s["host"], s["source"], s["baseline_buckets"],
+                            "-" if s["gap_p"] is None else "%.0f" % s["gap_p"],
+                            "-" if s["budget_active_hours"] is None
+                            else "%.1f" % s["budget_active_hours"],
+                            "%.1f" % s["silent_active_hours"],
+                            "DEAD" if s["dead"] else
+                            ("skip:%s" % s["reason"] if not s["evaluated"] else "ok")))
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="activity-telemetry deadman check")
+    ap.add_argument("--json", action="store_true", help="emit the verdict as JSON")
+    ap.add_argument("--tsv", metavar="FILE",
+                    help="evaluate this captured/seeded bucket TSV instead of "
+                         "querying ClickHouse (the control harness)")
+    ap.add_argument("--now", type=int, help="override 'now' (unix seconds)")
+    ap.add_argument("--env-file", default=DEFAULT_ENV_FILE)
+    ap.add_argument("--print-query", action="store_true",
+                    help="print the SQL and exit")
+    args = ap.parse_args(argv)
+
+    if args.print_query:
+        sys.stdout.write(bucket_query() + "\n")
+        return 0
+
+    if args.tsv:
+        try:
+            with open(args.tsv) as f:
+                rows = parse_buckets(f.read())
+            verdict = evaluate(rows, now=args.now)
+        except Exception as e:  # noqa: BLE001
+            verdict = {"state": STATE_QUERY_FAILED, "rows": 0, "evaluated": 0,
+                       "dead": [], "count": 0, "sources": [],
+                       "newest_event_age_minutes": None,
+                       "detail": "unreadable TSV: %s" % str(e)[:160]}
+    else:
+        verdict = check(env_file=args.env_file, now=args.now)
+
+    sys.stdout.write((json.dumps(verdict, indent=2) if args.json
+                      else _render_text(verdict)) + "\n")
+    if verdict["state"] in UNKNOWN_STATES:
+        return 2
+    return 1 if verdict["count"] else 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write("deadman: %s\n" % e)
+        sys.exit(2)

--- a/scripts/collector/tests/test_deadman.py
+++ b/scripts/collector/tests/test_deadman.py
@@ -1,0 +1,392 @@
+"""Tests for the activity-telemetry deadman check (scripts/collector/deadman.py).
+
+ALL OFFLINE — every test builds a synthetic bucket table and calls the pure
+`evaluate`, or injects a fake `fetch` into `check`. No ClickHouse is contacted.
+
+🔴 THE CONTROL PAIR IS THE POINT OF THIS FILE. The check's reassuring answer is a
+ZERO, which is indistinguishable from a check wired to nothing. So the zero is
+never asserted alone: `test_control_pair_*` asserts a NON-zero on a deliberately
+staled fixture and a zero on the same fixture left alone, through the same code
+path. A harness that could only ever produce 0 would fail those tests.
+
+Run: pytest scripts/collector/tests/test_deadman.py
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import deadman as D  # noqa: E402
+
+MODULE = Path(__file__).resolve().parent.parent / "deadman.py"
+B = D.BUCKET_SECONDS  # 300
+
+
+# --------------------------------------------------------------------------- #
+# Fixture builders
+# --------------------------------------------------------------------------- #
+def contiguous(host, source, start, count, step=1):
+    """`count` emitting buckets for one pair, every `step` buckets from `start`."""
+    return [(host, source, start + i * step * B, 1) for i in range(count)]
+
+
+def healthy_table(now_bucket, n=400):
+    """A busy host: two continuous sources filling every bucket up to now."""
+    start = now_bucket - (n - 1) * B
+    return (contiguous("h1", "keys", start, n)
+            + contiguous("h1", "i3", start, n))
+
+
+NOW_BUCKET = 1_700_000_000 // B * B
+
+
+# --------------------------------------------------------------------------- #
+# percentile / budget — pure arithmetic
+# --------------------------------------------------------------------------- #
+def test_percentile_empty_is_zero():
+    assert D.percentile([], 0.99) == 0.0
+
+
+def test_percentile_single_value():
+    assert D.percentile([7], 0.99) == 7.0
+
+
+def test_percentile_interpolates():
+    # p50 of [0, 10] is the midpoint, not an endpoint.
+    assert D.percentile([0, 10], 0.5) == 5.0
+
+
+def test_percentile_picks_the_tail():
+    """p99 must land in the tail, not near the median — the budget is sized off
+    the worst NORMAL lull, so a percentile that ignored the tail would produce a
+    budget that cries wolf."""
+    vals = [0] * 90 + [1000] * 10
+    assert D.percentile(vals, 0.99) == 1000.0
+    assert D.percentile(vals, 0.50) == 0.0
+
+
+def test_budget_floor_applies_to_a_continuous_source():
+    # p99 gap of 1 bucket must NOT yield a 2-bucket budget — that would alarm on
+    # a coffee break. The floor is what stops the wolf-crying.
+    assert D.budget_for(1.0) == D.FLOOR_BUCKETS
+
+
+def test_budget_scales_with_the_measured_gap():
+    assert D.budget_for(100.0, k=2.0) == 200
+
+
+def test_budget_is_capped():
+    assert D.budget_for(100000.0) == D.CAP_BUCKETS
+
+
+# --------------------------------------------------------------------------- #
+# parse_buckets — strict on purpose
+# --------------------------------------------------------------------------- #
+def test_parse_buckets_happy():
+    rows = D.parse_buckets("h1\tkeys\t100\t3\nh1\ti3\t100\t1\n")
+    assert rows == [("h1", "keys", 100, 3), ("h1", "i3", 100, 1)]
+
+
+def test_parse_buckets_skips_blank_lines():
+    assert D.parse_buckets("\n\nh1\tkeys\t100\t3\n\n") == [("h1", "keys", 100, 3)]
+
+
+def test_parse_buckets_rejects_wrong_field_count():
+    # A changed output format must be an ERROR, not "fewer rows" silently
+    # decaying into "no staleness".
+    with pytest.raises(ValueError):
+        D.parse_buckets("h1\tkeys\t100\n")
+
+
+def test_parse_buckets_rejects_non_integer():
+    with pytest.raises(ValueError):
+        D.parse_buckets("h1\tkeys\tnotanumber\t3\n")
+
+
+def test_bucket_query_mentions_table_and_window():
+    q = D.bucket_query(days=14, database="activity", table="events")
+    assert "activity.events" in q
+    assert "INTERVAL 14 DAY" in q
+    assert "FORMAT TSV" in q
+
+
+# --------------------------------------------------------------------------- #
+# evaluate — the core verdict
+# --------------------------------------------------------------------------- #
+def test_healthy_table_reports_ok_and_zero_dead():
+    rows = healthy_table(NOW_BUCKET)
+    v = D.evaluate(rows, now=NOW_BUCKET + 60)
+    assert v["state"] == D.STATE_OK
+    assert v["count"] == 0
+    assert v["evaluated"] == 2
+
+
+def test_a_source_that_stopped_is_dead():
+    """POSITIVE CONTROL. `keys` stops 200 active buckets before now while `i3`
+    keeps emitting; 200 > the 24-bucket floor budget, so it must be DEAD."""
+    rows = healthy_table(NOW_BUCKET)
+    rows = [r for r in rows if not (r[1] == "keys" and r[2] > NOW_BUCKET - 200 * B)]
+    v = D.evaluate(rows, now=NOW_BUCKET + 60)
+    assert v["count"] == 1
+    assert v["dead"][0]["source"] == "keys"
+    assert v["dead"][0]["silent_active_buckets"] == 200
+
+
+def test_control_pair_same_path_zero_and_nonzero():
+    """The pair, reported together — a zero alone proves nothing about a harness."""
+    rows = healthy_table(NOW_BUCKET)
+    staled = [r for r in rows
+              if not (r[1] == "keys" and r[2] > NOW_BUCKET - 200 * B)]
+    clean = D.evaluate(rows, now=NOW_BUCKET + 60)
+    positive = D.evaluate(staled, now=NOW_BUCKET + 60)
+    assert (positive["count"], clean["count"]) == (1, 0)
+
+
+def test_a_brief_lull_under_the_floor_is_not_dead():
+    """ALERT-FATIGUE GUARD: 10 active buckets (50 min) of silence on a
+    continuous source must stay quiet — the floor is 24."""
+    rows = healthy_table(NOW_BUCKET)
+    rows = [r for r in rows if not (r[1] == "keys" and r[2] > NOW_BUCKET - 10 * B)]
+    v = D.evaluate(rows, now=NOW_BUCKET + 60)
+    assert v["count"] == 0
+
+
+def test_silence_is_measured_in_ACTIVE_time_not_wall_time():
+    """The on-demand answer. Two pairs on one host: `keys` emits in a dense
+    recent window, `od` last emitted long before it in WALL time but with only a
+    handful of ACTIVE buckets in between — so it is NOT dead, even though wall
+    staleness would call it stale by days."""
+    # One old island of activity where BOTH sources emit, then a long stretch in
+    # which the host is idle (nothing at all), then `keys` alone emits 3 recent
+    # buckets. `od` has been silent for ~347 WALL days but only 3 ACTIVE buckets.
+    old = NOW_BUCKET - 100000 * B
+    rows = contiguous("h1", "keys", old, 30) + contiguous("h1", "od", old, 30)
+    rows += contiguous("h1", "keys", NOW_BUCKET - 2 * B, 3)
+    v = D.evaluate(rows, now=NOW_BUCKET + 60)
+    od = [s for s in v["sources"] if s["source"] == "od"][0]
+    assert od["evaluated"] is True
+    assert od["silent_active_buckets"] == 3
+    # Wall time says months; active time says 15 minutes. The verdict follows
+    # active time — this is the whole reason a fixed staleness window was
+    # rejected for on-demand sources.
+    assert od["wall_silent_minutes"] > 100 * 24 * 60
+    assert od["dead"] is False
+
+
+def test_pair_below_baseline_is_skipped_not_alarmed():
+    """A source with too little history has no normal to compare against, and a
+    source that legitimately does not exist on a host (measured: workbench has
+    zero `browser` rows) is simply not in the table. Neither may alarm."""
+    rows = healthy_table(NOW_BUCKET)
+    rows += contiguous("h1", "brandnew", NOW_BUCKET - 100000 * B, 3)
+    v = D.evaluate(rows, now=NOW_BUCKET + 60)
+    rec = [s for s in v["sources"] if s["source"] == "brandnew"][0]
+    assert rec["evaluated"] is False
+    assert rec["reason"] == "insufficient-baseline"
+    assert rec["dead"] is False
+    assert v["count"] == 0
+
+
+def test_absent_source_on_a_host_cannot_alarm():
+    """h2 never emits `keys` at all — it must not appear as a dead pair."""
+    rows = healthy_table(NOW_BUCKET) + contiguous("h2", "i3", NOW_BUCKET - 399 * B, 400)
+    v = D.evaluate(rows, now=NOW_BUCKET + 60)
+    assert ("h2", "keys") not in {(s["host"], s["source"]) for s in v["sources"]}
+    assert v["count"] == 0
+
+
+def test_hosts_are_scored_independently():
+    """h1's activity must not supply active buckets to an h2 source."""
+    rows = healthy_table(NOW_BUCKET)
+    rows += contiguous("h2", "zsh", NOW_BUCKET - 399 * B, 400)
+    # h2/zsh stops but h2 has no other source, so h2 has NO active buckets after
+    # it stopped -> silence measures 0 and it cannot be judged dead. That is the
+    # documented relative-check blind spot, asserted so it stays documented.
+    rows = [r for r in rows if not (r[0] == "h2" and r[2] > NOW_BUCKET - 200 * B)]
+    v = D.evaluate(rows, now=NOW_BUCKET + 60)
+    h2 = [s for s in v["sources"] if s["host"] == "h2"][0]
+    assert h2["silent_active_buckets"] == 0
+    assert h2["dead"] is False
+
+
+def test_empty_rows_is_no_data_not_ok():
+    """NEGATIVE CONTROL: nothing came back -> we cannot prove we read the table."""
+    v = D.evaluate([], now=NOW_BUCKET)
+    assert v["state"] == D.STATE_NO_DATA
+    assert v["state"] in D.UNKNOWN_STATES
+    assert v["count"] == 0
+
+
+def test_all_pairs_below_baseline_is_no_data_not_ok():
+    """Rows came back but nothing was measurable — still cannot tell."""
+    rows = contiguous("h1", "x", NOW_BUCKET - 5 * B, 3)
+    v = D.evaluate(rows, now=NOW_BUCKET)
+    assert v["state"] == D.STATE_NO_DATA
+    assert v["evaluated"] == 0
+
+
+def test_ok_state_requires_a_nonzero_evaluated_count():
+    """The positive control baked into the verdict itself: `ok` is unreachable
+    unless at least one pair was actually measured."""
+    v = D.evaluate(healthy_table(NOW_BUCKET), now=NOW_BUCKET)
+    assert v["state"] == D.STATE_OK
+    assert v["evaluated"] > 0
+    assert v["rows"] > 0
+
+
+def test_newest_event_age_is_reported_but_never_alarms():
+    """A total blackout (every source on every host) is out of scope and must
+    NOT be faked into an alarm — it is indistinguishable from the operator being
+    away. It is reported, not alarmed."""
+    rows = healthy_table(NOW_BUCKET)
+    v = D.evaluate(rows, now=NOW_BUCKET + 30 * 86400)
+    assert v["state"] == D.STATE_OK
+    assert v["count"] == 0
+    assert v["newest_event_age_minutes"] > 30 * 24 * 60 - 60
+
+
+def test_describe_lists_dead_pairs():
+    rows = healthy_table(NOW_BUCKET)
+    rows = [r for r in rows if not (r[1] == "keys" and r[2] > NOW_BUCKET - 200 * B)]
+    v = D.evaluate(rows, now=NOW_BUCKET + 60)
+    assert "h1/keys" in v["detail"]
+
+
+def test_describe_clean_names_the_evaluated_count():
+    assert D.describe([], 17) == "17 source(s) fresh"
+
+
+# --------------------------------------------------------------------------- #
+# check() — every failure branch is its OWN state, none of them `ok`
+# --------------------------------------------------------------------------- #
+def test_check_not_configured_when_no_url(tmp_path):
+    v = D.check(env={}, env_file=str(tmp_path / "nope"))
+    assert v["state"] == D.STATE_NOT_CONFIGURED
+    assert v["state"] in D.UNKNOWN_STATES
+
+
+def test_check_unreachable_when_fetch_raises(tmp_path):
+    def boom(*a, **kw):
+        raise OSError("timed out")
+    v = D.check(env={"CLICKHOUSE_URL": "http://x"}, env_file=str(tmp_path / "nope"),
+                fetch=boom)
+    assert v["state"] == D.STATE_UNREACHABLE
+    assert "timed out" in v["detail"]
+
+
+def test_check_query_failed_on_unparseable_body(tmp_path):
+    v = D.check(env={"CLICKHOUSE_URL": "http://x"}, env_file=str(tmp_path / "nope"),
+                fetch=lambda *a, **kw: "Code: 62. DB::Exception: Syntax error")
+    assert v["state"] == D.STATE_QUERY_FAILED
+
+
+def test_check_no_data_on_empty_body(tmp_path):
+    v = D.check(env={"CLICKHOUSE_URL": "http://x"}, env_file=str(tmp_path / "nope"),
+                fetch=lambda *a, **kw: "")
+    assert v["state"] == D.STATE_NO_DATA
+
+
+def test_check_ok_on_a_healthy_body(tmp_path):
+    body = "".join("%s\t%s\t%d\t1\n" % (h, s, b)
+                   for (h, s, b, _n) in healthy_table(NOW_BUCKET))
+    v = D.check(env={"CLICKHOUSE_URL": "http://x"}, env_file=str(tmp_path / "nope"),
+                fetch=lambda *a, **kw: body, now=NOW_BUCKET + 60)
+    assert v["state"] == D.STATE_OK
+    assert v["count"] == 0
+    assert v["evaluated"] == 2
+
+
+def test_no_unknown_state_is_ok():
+    """INVARIANT GUARD (not regression coverage): `ok` is never in the set of
+    states that mean 'cannot tell'."""
+    assert D.STATE_OK not in D.UNKNOWN_STATES
+    assert len(D.UNKNOWN_STATES) == 4
+
+
+# --------------------------------------------------------------------------- #
+# resolve_config / load_env_file
+# --------------------------------------------------------------------------- #
+def test_env_file_supplies_credentials(tmp_path):
+    p = tmp_path / "env"
+    p.write_text("# comment\nCLICKHOUSE_URL=http://ch:8123\n"
+                 "CLICKHOUSE_USER=reader\nCLICKHOUSE_PASSWORD=pw\njunkline\n")
+    cfg = D.resolve_config(env={}, env_file=str(p))
+    assert cfg["url"] == "http://ch:8123"
+    assert cfg["user"] == "reader"
+    assert cfg["password"] == "pw"
+    assert cfg["database"] == "activity"
+
+
+def test_process_env_wins_over_the_file(tmp_path):
+    p = tmp_path / "env"
+    p.write_text("CLICKHOUSE_URL=http://from-file\n")
+    cfg = D.resolve_config(env={"CLICKHOUSE_URL": "http://from-env"}, env_file=str(p))
+    assert cfg["url"] == "http://from-env"
+
+
+def test_missing_env_file_is_not_an_error(tmp_path):
+    assert D.load_env_file(str(tmp_path / "absent")) == {}
+
+
+# --------------------------------------------------------------------------- #
+# CLI — exit codes carry the verdict
+# --------------------------------------------------------------------------- #
+def _run_cli(args, cwd=None):
+    return subprocess.run([sys.executable, str(MODULE)] + args,
+                          capture_output=True, text=True, timeout=60)
+
+
+def test_cli_tsv_clean_exits_zero(tmp_path):
+    tsv = tmp_path / "clean.tsv"
+    tsv.write_text("".join("%s\t%s\t%d\t1\n" % (h, s, b)
+                           for (h, s, b, _n) in healthy_table(NOW_BUCKET)))
+    p = _run_cli(["--tsv", str(tsv), "--now", str(NOW_BUCKET + 60), "--json"])
+    assert p.returncode == 0, p.stderr
+    v = json.loads(p.stdout)
+    assert (v["state"], v["count"]) == ("ok", 0)
+
+
+def test_cli_tsv_with_a_dead_source_exits_one(tmp_path):
+    """POSITIVE CONTROL through the CLI: the same file minus one source's recent
+    buckets must move the count off zero AND change the exit code."""
+    rows = [r for r in healthy_table(NOW_BUCKET)
+            if not (r[1] == "keys" and r[2] > NOW_BUCKET - 200 * B)]
+    tsv = tmp_path / "stale.tsv"
+    tsv.write_text("".join("%s\t%s\t%d\t1\n" % (h, s, b) for (h, s, b, _n) in rows))
+    p = _run_cli(["--tsv", str(tsv), "--now", str(NOW_BUCKET + 60), "--json"])
+    assert p.returncode == 1, p.stderr
+    v = json.loads(p.stdout)
+    assert v["count"] == 1
+
+
+def test_cli_unreadable_tsv_exits_two(tmp_path):
+    p = _run_cli(["--tsv", str(tmp_path / "absent.tsv"), "--json"])
+    assert p.returncode == 2
+    assert json.loads(p.stdout)["state"] == "query-failed"
+
+
+def test_cli_not_configured_exits_two(tmp_path):
+    p = _run_cli(["--env-file", str(tmp_path / "absent"), "--json"])
+    # No CLICKHOUSE_URL in the sandbox env and no env file -> not-configured.
+    if p.returncode == 2:
+        assert json.loads(p.stdout)["state"] in D.UNKNOWN_STATES
+    else:  # a dev host WITH the collector env file configured reaches ClickHouse
+        assert p.returncode in (0, 1)
+
+
+def test_cli_print_query():
+    p = _run_cli(["--print-query"])
+    assert p.returncode == 0
+    assert "activity.events" in p.stdout
+
+
+def test_cli_text_render_shows_the_table(tmp_path):
+    tsv = tmp_path / "clean.tsv"
+    tsv.write_text("".join("%s\t%s\t%d\t1\n" % (h, s, b)
+                           for (h, s, b, _n) in healthy_table(NOW_BUCKET)))
+    p = _run_cli(["--tsv", str(tsv), "--now", str(NOW_BUCKET + 60)])
+    assert "budget_h" in p.stdout
+    assert "keys" in p.stdout

--- a/scripts/i3status-telemetry
+++ b/scripts/i3status-telemetry
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""i3status-rust custom block: DEAD activity-telemetry sources.
+
+Reads the cache file written by scripts/bar-status-poll's `telemetry` source
+(scripts/collector/deadman.py does the actual measuring) and emits ONE
+i3status-rust JSON line. INSTANT local file read — never touches the network,
+never blocks the bar.
+
+CALM rendering (colour == "look at me"):
+  missing / poller-stale / malformed / count<=0  -> empty, invisible block
+  count > 0                                     -> `tlm N`, Critical
+  unknown (grace-gated by the poller)           -> `tlm ?`, Warning
+
+🔴 THE `tlm ?` STATE IS THE WHOLE POINT. Every other block in this bar renders a
+"cannot reach the source" as an EMPTY block, because for those a blackout is a
+non-event. Here it is not: this block's reassuring answer IS a zero, so a zero
+that came from a broken query is indistinguishable from a zero that came from a
+healthy pipeline — which is exactly the bug class the deadman check exists to
+catch, and it must not embody it. So `unknown` gets its own visible pill.
+
+The pill is grace-gated IN THE POLLER (not here): the poller only sets
+`unknown: true` once the check has been unable to evaluate CONTINUOUSLY for
+TELEMETRY_UNKNOWN_GRACE seconds (default 1800), so a nebula blip or a ClickHouse
+restart between two 45s polls never flickers the bar. This script stays a pure
+function of the cache payload and holds no clock of its own.
+
+A TEXT label (`tlm`) rather than a nerd-font glyph, deliberately: the two
+existing count pills that carry meaning by GLYPH (alerts/notifs) are already a
+pair a reader has to tell apart, and `civ` set the precedent that a short text
+label reads unambiguously. It also cannot silently render as a tofu box if the
+icon set changes.
+"""
+import json
+import os
+import sys
+
+NAME = "telemetry"
+LABEL = "tlm"
+_VALID_STATES = ("Idle", "Info", "Good", "Warning", "Critical")
+_EMPTY = {"text": "", "state": "Idle"}
+
+
+def cache_path() -> str:
+    base = os.environ.get("BAR_STATUS_DIR") or os.path.join(
+        os.path.expanduser("~"), ".cache", "bar-status")
+    return os.path.join(base, NAME + ".json")
+
+
+def load(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def render(payload, label: str = LABEL) -> dict:
+    """Pure: cache payload (or None) -> i3status-rust block dict.
+
+    Fail-safe: None / malformed / poller-stale all map to the empty block.
+    `unknown` (already grace-gated by the poller) renders a visible `tlm ?`.
+    """
+    if not isinstance(payload, dict):
+        return dict(_EMPTY)
+    # A poller-level failure (the fetch itself raised) — the unit's OnFailure
+    # toast covers that, and it is NOT the check's own "cannot tell".
+    if payload.get("error") or payload.get("state") == "stale":
+        return dict(_EMPTY)
+    if payload.get("unknown"):
+        text = "%s ?" % label
+        return {"text": text, "short_text": text, "state": "Warning"}
+    try:
+        count = int(payload.get("count", 0))
+    except (TypeError, ValueError):
+        return dict(_EMPTY)
+    if count <= 0:
+        return dict(_EMPTY)
+    state = payload.get("state")
+    if state not in _VALID_STATES or state == "Idle":
+        state = "Critical"
+    text = "%s %d" % (label, count)
+    return {"text": text, "short_text": text, "state": state}
+
+
+def main() -> int:
+    sys.stdout.write(json.dumps(render(load(cache_path()))) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        sys.stdout.write(json.dumps(_EMPTY) + "\n")
+        sys.exit(0)

--- a/scripts/tests/test_bar_status.py
+++ b/scripts/tests/test_bar_status.py
@@ -41,6 +41,13 @@ mail_block = _load("i3status-mail", "i3status_mail")
 alerts_block = _load("i3status-alerts", "i3status_alerts")
 civitai_block = _load("i3status-civitai", "i3status_civitai")
 media_block = _load("i3status-media", "i3status_media")
+telemetry_block = _load("i3status-telemetry", "i3status_telemetry")
+
+# The deadman states the telemetry pill treats as "cannot tell". Pinned here as
+# a LITERAL rather than imported from deadman.py: a test expectation derived
+# from the implementation it tests proves nothing (RULES.md).
+UNKNOWN_STATES = frozenset(
+    {"no-data", "unreachable", "query-failed", "not-configured"})
 
 
 # --------------------------------------------------------------------------- #
@@ -776,3 +783,169 @@ def test_fire_toast_dispatches_with_action(monkeypatch):
     joined = " ".join(argv)
     assert "-A open,Open" in joined                            # clickable action
     assert "--setenv=DISPLAY=:0" in argv
+
+
+# --------------------------------------------------------------------------- #
+# poller parse + block: telemetry deadman
+#
+# 🔴 This is the ONE block whose reassuring answer is a ZERO, so its tests are
+# written as PAIRS: every "renders empty" assertion has a sibling that makes the
+# same code path produce a visible pill. A renderer wired to nothing would pass
+# the first half of each pair and fail the second.
+# --------------------------------------------------------------------------- #
+def _verdict(state="ok", count=0, detail="", **kw):
+    v = {"state": state, "count": count, "detail": detail,
+         "evaluated": 17, "rows": 11103, "newest_event_age_minutes": 2}
+    v.update(kw)
+    return v
+
+
+def test_telemetry_uses_a_free_signal():
+    """INVARIANT GUARD: 17 must not collide with any existing block's signal, or
+    `pkill -RTMIN+17` would refresh the wrong pill."""
+    assert poll.SIGNALS["telemetry"] == 17
+    others = [v for k, v in poll.SIGNALS.items() if k != "telemetry"]
+    assert 17 not in others
+    assert len(set(poll.SIGNALS.values())) == len(poll.SIGNALS)
+
+
+def test_parse_telemetry_clean_is_idle_and_invisible():
+    out = poll.parse_telemetry(_verdict(count=0, detail="17 source(s) fresh"),
+                               now=1000)
+    assert out["count"] == 0 and out["state"] == "Idle"
+    assert out["unknown"] is False
+    assert telemetry_block.render(out) == {"text": "", "state": "Idle"}
+
+
+def test_parse_telemetry_dead_source_is_critical_and_visible():
+    """POSITIVE CONTROL for the pair above — same path, non-zero count."""
+    out = poll.parse_telemetry(
+        _verdict(count=2, detail="workbench/opencode silent 19.0h active"),
+        now=1000)
+    assert out["count"] == 2 and out["state"] == "Critical"
+    blk = telemetry_block.render(out)
+    assert blk["text"] == "tlm 2"
+    assert blk["state"] == "Critical"
+
+
+@pytest.mark.parametrize("state", sorted(UNKNOWN_STATES))
+def test_parse_telemetry_unknown_is_not_reported_as_healthy(state):
+    """Each non-evaluable state must be carried through as UNKNOWN, never
+    collapsed into the clean/Idle branch."""
+    out = poll.parse_telemetry(_verdict(state=state, detail="nope"), now=1000,
+                               unknown_states=UNKNOWN_STATES)
+    assert out["telemetry_state"] == state
+    assert out["unknown_since"] == 1000
+    assert "UNKNOWN" in out["detail"]
+
+
+def test_parse_telemetry_unknown_is_grace_gated_then_visible():
+    """The pair that proves the grace timer is REACHABLE, not just present."""
+    first = poll.parse_telemetry(_verdict(state="unreachable"), now=1000,
+                                 grace=1800, unknown_states=UNKNOWN_STATES)
+    # A single failed poll must NOT flicker the bar.
+    assert first["unknown"] is False
+    assert telemetry_block.render(first) == {"text": "", "state": "Idle"}
+    # ...but a persistent one must become visible, carrying `unknown_since`
+    # forward across the oneshot poller's restarts.
+    later = poll.parse_telemetry(_verdict(state="unreachable"), prev=first,
+                                 now=1000 + 1800, grace=1800,
+                                 unknown_states=UNKNOWN_STATES)
+    assert later["unknown_since"] == 1000
+    assert later["unknown"] is True
+    assert telemetry_block.render(later) == {
+        "text": "tlm ?", "short_text": "tlm ?", "state": "Warning"}
+
+
+def test_parse_telemetry_unknown_clock_resets_after_recovery():
+    bad = poll.parse_telemetry(_verdict(state="unreachable"), now=1000,
+                               unknown_states=UNKNOWN_STATES)
+    good = poll.parse_telemetry(_verdict(count=0), prev=bad, now=2000,
+                                unknown_states=UNKNOWN_STATES)
+    assert good["unknown_since"] is None
+    bad2 = poll.parse_telemetry(_verdict(state="unreachable"), prev=good,
+                                now=3000, unknown_states=UNKNOWN_STATES)
+    assert bad2["unknown_since"] == 3000      # fresh clock, not the old one
+
+
+def test_parse_telemetry_junk_verdict_is_unknown_not_healthy():
+    """A garbage verdict must NOT read as 'all fresh'."""
+    for junk in (None, "x", 3, []):
+        out = poll.parse_telemetry(junk, now=1000, unknown_states=UNKNOWN_STATES)
+        assert out["telemetry_state"] == "query-failed"
+        assert out["unknown_since"] == 1000
+
+
+def test_telemetry_block_hides_on_missing_and_poller_stale():
+    assert telemetry_block.render(None) == {"text": "", "state": "Idle"}
+    assert telemetry_block.render({"state": "stale", "count": 0}) == {
+        "text": "", "state": "Idle"}
+    assert telemetry_block.render({"error": "boom", "count": 5}) == {
+        "text": "", "state": "Idle"}
+    assert telemetry_block.render({"count": "NaN"}) == {"text": "", "state": "Idle"}
+
+
+def test_telemetry_block_main_emits_one_json_line(tmp_path, monkeypatch):
+    monkeypatch.setenv("BAR_STATUS_DIR", str(tmp_path))
+    (tmp_path / "telemetry.json").write_text(json.dumps(
+        {"count": 3, "state": "Critical", "unknown": False}))
+    out = subprocess.run([sys.executable, str(SCRIPTS / "i3status-telemetry")],
+                         capture_output=True, text=True,
+                         env={**os.environ, "BAR_STATUS_DIR": str(tmp_path)})
+    assert out.returncode == 0
+    blk = json.loads(out.stdout.strip())
+    assert blk["text"] == "tlm 3" and blk["state"] == "Critical"
+
+
+def test_mock_run_writes_telemetry(tmp_path, monkeypatch):
+    """The whole write+signal path, driven from a fixture verdict."""
+    monkeypatch.setenv("BAR_STATUS_DIR", str(tmp_path))
+    monkeypatch.setattr(poll, "signal_bar", lambda name: None)
+    f = tmp_path / "verdict.json"
+    f.write_text(json.dumps(_verdict(count=1, detail="laptop/keys silent 9h")))
+    assert poll.main(["--mock-telemetry", str(f)]) == 0
+    written = json.loads((tmp_path / "telemetry.json").read_text())
+    assert written["count"] == 1
+    assert written["source"] == "telemetry"
+    assert telemetry_block.render(written)["text"] == "tlm 1"
+
+
+def test_mock_run_telemetry_clean_writes_zero(tmp_path, monkeypatch):
+    """The zero half of the pair, through the same write path."""
+    monkeypatch.setenv("BAR_STATUS_DIR", str(tmp_path))
+    monkeypatch.setattr(poll, "signal_bar", lambda name: None)
+    f = tmp_path / "verdict.json"
+    f.write_text(json.dumps(_verdict(count=0)))
+    assert poll.main(["--mock-telemetry", str(f)]) == 0
+    written = json.loads((tmp_path / "telemetry.json").read_text())
+    assert written["count"] == 0
+    assert telemetry_block.render(written)["text"] == ""
+
+
+def test_telemetry_toast_spec_fires_from_zero():
+    spec = poll._toast_specs()["telemetry"]
+    assert spec["threshold"] == 0
+    assert spec["urgency"] == "critical"
+    fired = []
+    poll.evaluate_edge_toast(
+        "telemetry", _verdict(count=1, detail="d"), spec,
+        fire=lambda *a, **kw: fired.append(a), read=lambda n: False,
+        write=lambda n, v: None)
+    assert len(fired) == 1
+
+
+def test_telemetry_fetch_stale_when_deadman_module_missing(monkeypatch):
+    """FAIL-SAFE: a broken deadman import must become a poller `stale` marker
+    (block renders empty, unit's OnFailure covers it) — never a crash."""
+    monkeypatch.setattr(poll, "DEVRC_DIR", "/no/such/repo")
+    out = poll.source("telemetry", poll.fetch_telemetry)
+    assert out["state"] == "stale" and out["count"] == 0
+
+
+def test_deadman_unknown_states_fallback_is_not_empty(monkeypatch):
+    """If the deadman module cannot be loaded the fallback set must still be
+    non-empty — an empty set would make EVERY unknown verdict read as healthy,
+    which is precisely the failure this check exists to prevent."""
+    monkeypatch.setattr(poll, "DEVRC_DIR", "/no/such/repo")
+    assert poll._deadman_unknown_states() == UNKNOWN_STATES
+


### PR DESCRIPTION
## Why

PR #298 added a named export to `activity-plugin.js`; opencode's loader rejects the whole module if any named export is not a function, so **all opencode telemetry stopped on both hosts for ~11 hours**. `emitEvent` swallows every error by design, so nothing reported it — it was found by luck. Two more of the same shape were already in the data unnoticed: the laptop had **zero `kind=tool-call` rows for its entire existence** (2026-07-29 → 2026-08-02), and **`kind=session-create` has never emitted a single row, ever**.

A dead source is silent by construction. "No rows" is exactly what healthy-but-idle looks like, so nothing downstream can notice.

## What this adds

**`scripts/collector/deadman.py`** — per `(host, source)` liveness over `activity.events`, plus a CLI (`--json`, `--tsv FILE` for control runs, exit 0/1/2).

**Surface: the workbench i3 bar.** A new `telemetry` source in `bar-status-poll` (~45s timer, already exists) → `~/.cache/bar-status/telemetry.json` → the `tlm` pill (`scripts/i3status-telemetry`, signal 17) + a rising-edge dunst toast. Chosen over `agent-ops` because agent-ops is on-demand ("what's blocked on me *right now*"), and a source that died three days ago is exactly the thing you never think to go look for — it has to come to you. **No new timer, no new unit, no new secret**: it rides the existing workbench-only poller and reads the collector's own 0600 env file. **The laptop does not run the poller** (`lib.mkIf (!isLaptop)` — verified, it is nebula-only) and does not need to: the check reads the shared ClickHouse table, so one workbench runner covers both hosts.

## What makes it not cry wolf

Cadence differs ~1000× across sources, so a single threshold either misses the outage or trains you to ignore the pill.

- **Silence is counted in ACTIVE time, not wall time.** A host's *active* 5-minute buckets are the ones in which any of its sources emitted; overnight and away-from-desk time is simply not in the set. This is what "an on-demand source needs last-seen tracking, not a fixed window" cashes out to.
- **The budget is MEASURED per pair**, not declared: `clamp(2 × p99 active-gap, 2h, 48h)`. One `GROUP BY` (11k rows for 14 days, ~0.14 s measured) feeds a pure Python evaluator.
- **Expected-present is measured too.** A pair is judged only if it cleared `MIN_BASELINE_BUCKETS` in the window, so a source that legitimately does not exist on a host is absent from the evaluated set and can never alarm, while a source that *was* emitting and stopped keeps its baseline and does. **No per-host expectation table exists anywhere, so none can go stale** — and one had (see the doc fix below).

Measured budgets, 2026-08-03 (`deadman.py` prints this table; left-click on the pill floats it):

| host | source | baseline | p99 active-gap | budget | silence now |
|---|---|---|---|---|---|
| laptop | browser | 861 | 8 | 2.0 h | 0.2 h |
| laptop | browser-bridge | 100 | 54 | 9.0 h | 1.0 h |
| laptop | claude | 648 | 16 | 2.7 h | 0.1 h |
| laptop | i3 | 1212 | 4 | 2.0 h | 0.0 h |
| laptop | keys | 1405 | 2 | 2.0 h | 0.0 h |
| laptop | opencode | 69 | 124 | 20.6 h | 0.0 h |
| laptop | tmux | 405 | 20 | 3.3 h | 0.1 h |
| laptop | tool | 45 | 93 | 15.6 h | 0.6 h |
| laptop | zsh | 63 | 150 | 25.0 h | 4.7 h |
| workbench | browser-bridge | 256 | 26 | 4.4 h | 1.1 h |
| workbench | claude | 1647 | 2 | 2.0 h | 0.2 h |
| workbench | i3 | 1167 | 11 | 2.0 h | 0.2 h |
| workbench | keys | 1368 | 6 | 2.0 h | 0.0 h |
| workbench | opencode | 144 | 69 | 11.5 h | 0.9 h |
| workbench | tmux | 1349 | 6 | 2.0 h | 0.1 h |
| workbench | tool | 68 | 186 | 31.1 h | 2.6 h |
| workbench | zsh | 296 | 34 | 5.7 h | 1.2 h |

`workbench/browser` is **absent — 0 rows, correctly**: the Brave activity extension is laptop-only. The cap (48 active hours) sits above the largest gap observed anywhere in the 14-day window (224 buckets), so it cannot manufacture a false alarm.

## "Cannot tell" is not "healthy"

This is the one block on the bar whose reassuring answer is a **zero**, which is the exact shape that can be wired to nothing and report green forever — the bug class it exists to catch. So:

- `not-configured` / `unreachable` / `query-failed` / `no-data` are **each their own state** (following #299's precedent in `insights.py`), and none of them is `ok`.
- **`ok` is unreachable unless rows came back AND ≥1 pair was actually measured.** `evaluated > 0` is the verdict's own positive control — an empty result set cannot read as "no staleness".
- A **persistent** unknown renders a visible `tlm ?` pill, not the empty block every other source renders. Grace-gated at 30 min in the poller (`unknown_since` carried across the oneshot's restarts via the cache file) so a nebula blip never flickers the bar; and an unknown verdict is skipped for the edge-toast latch so a blackout can't reset it.

### 🔴 Stated blind spot

This is a **relative** check: it detects a source dying **while its peers keep emitting**. A simultaneous outage of every source on every host yields zero active buckets and reads "0 dead" — indistinguishable from the operator being away, so it does not pretend to distinguish them. `newest_event_age_minutes` is reported for the human and deliberately is **not** an alarm. The motivating outage is in scope (opencode died on both hosts while zsh/tmux/keys/i3/claude kept emitting).

## Controls — the zero is never reported alone

**Positive control, on live data, through the real poller path** (`fetch_telemetry` → `write_status` → the block renderer):

```
LIVE (unmodified)                             -> count=0   pill: ""        (state ok, rows=11126, evaluated=17)
LIVE with workbench/keys silenced 6h          -> count=1   pill: "tlm 1"   "workbench/keys silent 5.7h active (budget 2.0h)"
LIVE with workbench/opencode silenced 30h     -> count=1   "silent 19.0h active (budget 11.8h)"
LIVE with workbench/zsh silenced 40h          -> count=1   "silent 27.9h active (budget 5.8h)"
```

**Negative control**, same path: `CLICKHOUSE_URL=http://127.0.0.1:1/` → `unreachable`, `count=0`, and after the grace window `pill: "tlm ?"` (Warning). Never green.

**Mutation sweep: 17/17 killed**, each by its own named test, with a **byte-identical no-op mutation that stayed green** as the harness's own control (so a harness that reported red for everything would have been visible):

| mutation | killed |
|---|---|
| empty result reads as OK | yes |
| deadness never fires | yes (2 tests) |
| budget floor removed | yes |
| budget cap removed | yes |
| silence measured in WALL time | yes |
| `parse_buckets` becomes tolerant | yes |
| unreachable reads as OK | yes |
| baseline gate removed | yes |
| `evaluated==0` reads as OK | yes |
| poller: unknown collapses to clean | yes (7 tests) |
| poller: grace gate always open / never gates | yes / yes |
| poller: signal collides with alerts | yes |
| poller: fallback unknown-set empty | yes |
| block: ignores the unknown flag | yes |
| block: shows a pill at count 0 | yes |
| *no-op control (byte-identical)* | *stayed green* |

## Doc correction

The `activity` SKILL.md said **"keylog + browser + i3 are GUI-only → laptop only. The workbench is headless (server-mode)."** That is **false**, and had been for a long time: measured against `activity.events`, the workbench emits **i3 (41,001 rows)** and **keys (37,376 rows)**, both fresh. Only the Brave activity extension is laptop-only, so `browser` is the single source with 0 workbench rows. Also corrected: "six sources" → **nine** (`opencode`, `browser-bridge`, `tool` were undocumented), and the services table which repeated the laptop-only claim.

## Gate

| tier | result |
|---|---|
| `nix build .#checks.x86_64-linux.pytests` (sandbox) | **5850 collected / 5849 passed / 1 skipped / 0 failed** (floor 5600) |
| `scripts/run-tests.sh --set all` (dev host, pinned nix-shell) | **5850 / 5849 / 1 / 0** — identical |
| `nix build .#checks.x86_64-linux.nodetests` | 468/468, 14 files |

+58 tests (41 in `scripts/collector/tests/test_deadman.py`, 17 in `scripts/tests/test_bar_status.py`); the pre-change baseline of 5792 + 58 = 5850 reconciles exactly, so nothing pre-existing was lost. `MIN_TESTS` is untouched (5600 still clears). `nix-instantiate --parse nix/graphical.nix` OK. **`scripts/run-tests.sh` and `scripts/run-node-tests.sh` are deliberately NOT touched** — a sibling agent owns those.

### Red/green honesty

The new tests are **guards for new behaviour, not regression tests** — the code they exercise does not exist at `13bc8bd`, so there is no "red at base" to report and I am not claiming one. Their reachability is established by the 17/17 mutation sweep above (each mutant killed by its *own* named test), which is the stronger claim available here. Two tests are labelled in-file as **invariant guards** (`test_no_unknown_state_is_ok`, `test_telemetry_uses_a_free_signal`) and are not counted as regression coverage.

## Separate finding — `session-create` has never fired, and it is not alone

**Answer: the hook is not implemented, because `session.created` is not a plugin hook name.** Measured 2026-08-03 on **opencode 1.18.4** with a probe plugin registering all 14 candidate names into a throwaway `OPENCODE_CONFIG_DIR`, then `opencode serve` + `POST /session`:

```
--- create session ---
{"id":"ses_039e79285ffeY2GQXHVtOgMCze", ... "title":"probe-session", "version":"1.18.4"}
--- probe log ---
  1 FACTORY ["client","project","worktree","directory","experimental_workspace","serverUrl","$"]
  1 HOOK event type=session.created
```

The session **was** created; the named `session.created` hook fired **0 times**; the generic `event` hook fired **once** with `event.type === "session.created"`. `session.created`, `message.updated` and `session.idle` are **bus event types, not hook names** — `activity-plugin.js` registers all three and none has ever fired. Only `tool.execute.before/after` are real hook names.

Corroborated three ways in the data:
- `kind=session-create` and `kind=session-idle`: **0 rows, ever**.
- Every `prompt`/`assistant-turn` row comes from `tailer.py`, not from the plugin's dead `message.updated` handler.
- `currentSession` is only ever assigned by the dead `session.created` handler → **2,736 of 2,799 `kind=tool-call` rows carry `session=''`** and cannot be attributed to a session. That is the real cost of this bug.

**Not fixed here, deliberately.** The fix is to route these through a single `event` hook switching on `event.type`, which is a rewrite of the plugin's hook surface — and this is the exact file whose last edit (#298) killed all opencode telemetry on both hosts for 11 hours. It deserves its own PR with a live post-deploy check, not a ride-along. Recorded in the `activity` SKILL.md gotchas with the measurement so the next person does not re-derive it.

## Deploy

`home-manager switch` on the **workbench** (staged, not run — no switch and no unit restart from this agent). The poller's `X-Restart-Triggers` now lists `deadman.py` too, so a change to the check re-arms the timer. Post-deploy verification: `python3 ~/workspace/devrc/scripts/collector/deadman.py` on the workbench should print the 17-row table with `state: ok`, and `~/.cache/bar-status/telemetry.json` should appear within ~45 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
