### PR TITLE
fix(opencode): remove three plugin handlers that could never fire

### DIFF
--- a/claude/skills/activity/SKILL.md
+++ b/claude/skills/activity/SKILL.md
@@ -105,18 +105,24 @@ inject post-reload). Manifest **v1.4.0**. When a file is DELETED upstream (e.g. 
   timer oneshot re-runs fresh code anyway.)
 - 🔴 **opencode plugin: only `tool.execute.before` / `tool.execute.after` are real plugin
   HOOK names. `session.created`, `message.updated` and `session.idle` are BUS EVENT TYPES,
-  not hooks — `activity-plugin.js` registers all three and none has ever fired.** MEASURED
-  2026-08-03 on opencode 1.18.4 with a probe plugin registering all 14 candidate names
-  against a throwaway `OPENCODE_CONFIG_DIR` + `opencode serve` + `POST /session`: the session
-  was created, the named `session.created` hook fired **0 times**, and the generic `event`
-  hook fired **once** with `event.type == "session.created"`. Corroborated in the data:
-  `kind=session-create` and `kind=session-idle` have **0 rows, ever**; every `prompt`/
-  `assistant-turn` row comes from `tailer.py`, not the plugin. Downstream consequence —
-  `currentSession` is only ever set by the dead `session.created` handler, so **2,736 of
-  2,799 `kind=tool-call` rows carry `session=''`** and cannot be attributed to a session.
-  The fix is to route these through a single `event` hook that switches on `event.type`;
-  🔴 do it in a dedicated PR with a live post-deploy check — this is the exact file whose
-  last edit (#298) killed ALL opencode telemetry on both hosts for ~11 hours.
+  not hooks.** MEASURED 2026-08-03 on opencode 1.18.4 with a probe plugin registering all 14
+  candidate names against a throwaway `OPENCODE_CONFIG_DIR` + `opencode serve` +
+  `POST /session`: the session was created, the named `session.created` hook fired **0
+  times**, and the generic `event` hook fired **once** with
+  `event.type == "session.created"`. Corroborated in the data: `kind=session-create` and
+  `kind=session-idle` had **0 rows, ever**; every `prompt`/`assistant-turn` row comes from
+  `tailer.py`, not the plugin. `activity-plugin.js` registered all three from 2026-07-29
+  until they were **removed** (nothing consumed those kinds and `tailer.py` already covers
+  the message path). `test_plugin.py` now pins the registered hook keys to exactly the two
+  real ones. To add session lifecycle later, use ONE `event` handler switching on
+  `event.type` — 🔴 in a dedicated PR with a live post-deploy check, this being the file
+  whose #298 edit killed ALL opencode telemetry on both hosts for ~11 hours.
+- **`session=''` on opencode `tool-call` rows is FIXED** (#298) — `tool.execute.after`
+  carries `sessionID` on its own hook input, so attribution never needed a session handler.
+  Verified 2026-08-03: last empty row `02:32:26`, first filled `03:28:27` (the deploy),
+  **188/188 filled, 0 empty since, both hosts**. The often-quoted "2,736 of 2,799 empty" is a
+  stale LIFETIME aggregate dominated by pre-fix rows — always window the query by deploy
+  time before re-opening this.
 - **`session-summary` / `session-insight` rows are APPEND-ONLY** — dedupe on read with
   `argMax(<field>, ingested_at)` grouped by `session`.
 

--- a/claudedocs/handoff-agent-setup-audit.md
+++ b/claudedocs/handoff-agent-setup-audit.md
@@ -84,34 +84,38 @@ issues, token inefficiency and tool opportunities — then fix what was found.
   is dead and the next suspect is the NodePort path, not the tunnel.
 - **Priority: LOW.** Workaround is real — run it from the workbench.
 
-### 2. `session=''` on 97.7% of opencode `tool-call` rows
+### 2. ~~`session=''` on opencode `tool-call` rows~~ — **CLOSED 2026-08-03**
 
-- **Symptom:** `2,736 of 2,799` `source='opencode', kind='tool-call'` rows carry
-  an empty `session`, so tool calls cannot be grouped into sessions.
-- **Observed / root cause (MEASURED, not inferred):** `session.created` is **not
-  a plugin hook name** on opencode 1.18.4 — it is a **bus event type**. Probed
-  with a throwaway `OPENCODE_CONFIG_DIR` + `opencode serve` + `POST /session`:
-  the named `session.created` hook fired **0 times**; the generic `event` hook
-  fired **once** with `event.type === "session.created"`. Same for
-  `message.updated` and `session.idle`. Only `tool.execute.before/after` are real
-  hooks. Corroborated: `kind='session-create'` and `kind='session-idle'` have
-  **0 rows ever**; all `prompt`/`assistant-turn` rows come from `tailer.py`, not
-  the plugin.
-- **Ruled out:** a deployment problem — the plugin IS loaded and IS emitting
-  (verified live on both hosts post-#302, real tool names, `name_captured=true`,
-  exactly 1 row per call).
-- **Leading hypothesis:** none needed; the cause is established. `currentSession`
-  is only ever assigned by the dead handler.
-- **Next probe:** none — go straight to the fix: subscribe to the generic
-  `event` hook and switch on `event.type`, in
-  `scripts/collector/opencode/activity-plugin.js`.
-- 🔴 **Handle with care.** That file's last edit (#298, a stray
-  `export const _internals`) killed ALL opencode telemetry on both hosts for
-  ~11 hours, silently. opencode's loader rejects the ENTIRE module if any named
-  export is not a function, AND invokes every *function* export as a plugin
-  factory. **`ActivityPlugin` must remain the only export.** After any change:
-  `home-manager switch`, run a real `opencode run` that makes a tool call, then
-  confirm rows land — do not trust the switch.
+**It was already fixed by #298, before the session that wrote this entry.** No
+`event`-hook work was needed.
+
+- **Why the entry was wrong:** `tool.execute.after` carries `sessionID` on its
+  own hook input, so attribution never depended on a session-lifecycle handler.
+  #298 added `session: input?.sessionID || currentSession` (line 367) at
+  2026-08-02 21:47; it deployed with the `home-manager switch` at 01:10.
+- **The "2,736 of 2,799 (97.7%)" figure was a stale LIFETIME aggregate**,
+  dominated by the 2,699 pre-fix rows from 2026-07-29→08-02 when the filled
+  count was 0. 🔴 **Window any re-check by deploy time** — a lifetime aggregate
+  over a fixed bug will keep reporting the bug forever.
+- **Measured (2026-08-03):** clean cliff — last empty row `02:32:26` (an opencode
+  process still holding the pre-deploy module), first filled `03:28:27`.
+  Since then **188 filled / 0 empty**, laptop 4 + workbench 184. Live positive
+  control: a real `opencode run` making a `glob` call landed at `16:48:48` with
+  `session=ses_037791641ffe1wbFfgX3Ib0UG3`.
+- **Residual, now also closed:** the three handlers that *were* dead —
+  `session.created`, `message.updated`, `session.idle` (bus event types, not hook
+  names) — have been **removed**, along with the seen-ID ring buffer and
+  `extractText` that only they used. Nothing consumed `session-create` /
+  `session-idle` (0 rows ever, no readers outside the plugin's own tests) and
+  `tailer.py` already covers `prompt`/`assistant-turn`. `test_plugin.py` now pins
+  the registered hook keys to exactly `tool.execute.before/after`.
+- 🔴 **Still handle this file with care.** #298's stray `export const _internals`
+  killed ALL opencode telemetry on both hosts for ~11 hours, silently. opencode's
+  loader rejects the ENTIRE module if any named export is not a function, AND
+  invokes every *function* export as a plugin factory. **`ActivityPlugin` must
+  remain the only export.** After any change: `home-manager switch`, run a real
+  `opencode run` that makes a tool call, then confirm rows land — never trust the
+  switch.
 
 ### 3. ClickHouse regrowth — untestable now, and will therefore go unchecked
 
@@ -160,9 +164,8 @@ by content, not by branch topology**, before deleting any worktree.
 
 ## Next steps (ranked)
 
-1. **Fix `session=''`** (investigation 2). Highest value: it makes opencode tool
-   telemetry groupable, and the cause is already established — no diagnosis left.
-   Respect the single-export constraint and verify live.
+1. ~~Fix `session=''`~~ — **DONE** (investigation 2); it was already fixed by
+   #298 and the dead handlers are now removed. Nothing left here.
 2. **Schedule the ClickHouse regrowth check** (investigation 3). It is a
    two-command check that will simply not happen unless it is on a calendar.
    Add `system.error_log` / `query_metric_log` TTLs at the same time.
@@ -220,6 +223,11 @@ by content, not by branch topology**, before deleting any worktree.
 - **A local worktree branch ref can resolve to `origin/main`**, making a
   `merge-tree` test compare main with main and return a confident clean. A
   positive control (the diffstat must be non-empty) is what caught it.
+- 🔴 **A LIFETIME aggregate over a fixed bug reports the bug forever.** The
+  "97.7% of tool-call rows have `session=''`" figure was true across all time and
+  false for every row since the fix — the fix was already deployed when the
+  number was quoted as an open problem. **Window by deploy time, and check for a
+  cliff, before opening or re-opening a data-quality investigation.**
 - **Deadman returns `count=0` for BOTH `ok` and `unreachable`.** Read `state`,
   never `count`. The bar already does this correctly (`tlm ?` Warning on
   sustained unknown) — do not "simplify" it to a count check.

--- a/scripts/collector/opencode/activity-plugin.js
+++ b/scripts/collector/opencode/activity-plugin.js
@@ -2,6 +2,17 @@
 // activity-plugin.js — OpenCode plugin that emits activity telemetry events
 // to the activity collector pipeline via the `emit` CLI.
 //
+// SCOPE: `tool.execute.before` / `tool.execute.after` ONLY — those are the only
+// real plugin HOOK names on opencode 1.18.4. `session.created`,
+// `message.updated` and `session.idle` are BUS EVENT TYPES, delivered through a
+// generic `event` hook; registering them as hook keys does nothing. This file
+// used to register all three, and none ever fired: `kind=session-create` and
+// `kind=session-idle` recorded 0 rows for the plugin's entire existence, and
+// `prompt`/`assistant-turn` rows all come from `tailer.py`. They were removed
+// rather than revived — nothing consumes those kinds, and `tailer.py` already
+// covers the message path. If session lifecycle is ever wanted here, add ONE
+// `event` handler that switches on `event.type`.
+//
 // DEPLOYMENT: home-manager, `home.file.".config/opencode/plugin/activity.js"`
 // in nix/home.nix — the same declarative mechanism as guard.js and env.js.
 // There is deliberately no deploy script: a hand-run one left the laptop
@@ -14,7 +25,7 @@
 // double-emit every event.
 
 import { execFileSync } from "child_process";
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import { existsSync } from "fs";
 import { join, dirname } from "path";
 import { homedir } from "os";
 
@@ -22,13 +33,6 @@ import { homedir } from "os";
 // Constants
 // --------------------------------------------------------------------------- #
 
-const STATE_DIR = join(
-  process.env.XDG_STATE_HOME || join(homedir(), ".local", "state"),
-  "activity"
-);
-const STATE_FILE = join(STATE_DIR, "opencode-plugin-state.json");
-const MAX_SEEN = 1000;
-const MAX_TEXT_LEN = 4096;
 const MAX_ARGS_SUMMARY = 200;
 
 // Sentinel written to `text` when the tool NAME could not be read off the hook
@@ -54,38 +58,6 @@ const MAX_INFLIGHT_CALLS = 256;
 // `export const _internals = {...}` plus three exported helpers, and emission
 // stopped dead at the moment ship.sh deployed it. Helpers stay module-private;
 // if a test needs one, hang it off ActivityPlugin rather than exporting it.
-
-// --------------------------------------------------------------------------- #
-// State management (ring buffer of seen message IDs)
-// --------------------------------------------------------------------------- #
-
-function loadState() {
-  try {
-    const raw = readFileSync(STATE_FILE, "utf-8");
-    const data = JSON.parse(raw);
-    if (data && data.version === 1 && Array.isArray(data.seen)) {
-      return data.seen;
-    }
-  } catch {
-    // corrupt or missing — start fresh
-  }
-  return [];
-}
-
-function saveState(seen) {
-  try {
-    mkdirSync(dirname(STATE_FILE), { recursive: true });
-    // Ring buffer: keep last MAX_SEEN entries
-    const trimmed = seen.slice(-MAX_SEEN);
-    writeFileSync(
-      STATE_FILE,
-      JSON.stringify({ version: 1, seen: trimmed }),
-      "utf-8"
-    );
-  } catch {
-    // best-effort, never crash
-  }
-}
 
 // --------------------------------------------------------------------------- #
 // Emit helper
@@ -157,23 +129,6 @@ function emitEvent({ kind, text, project, cwd, session, app, payload }) {
 }
 
 // --------------------------------------------------------------------------- #
-// Extract text from message parts
-// --------------------------------------------------------------------------- #
-
-function extractText(msg) {
-  if (!msg) return "";
-  const parts = msg.parts || msg.content;
-  if (!parts) return "";
-  if (typeof parts === "string") return parts;
-  if (!Array.isArray(parts)) return "";
-  return parts
-    .filter((p) => p && p.type === "text")
-    .map((p) => p.text || "")
-    .join("\n")
-    .trim();
-}
-
-// --------------------------------------------------------------------------- #
 // Tool-call field extraction
 // --------------------------------------------------------------------------- #
 
@@ -241,77 +196,12 @@ function summarizeArgs(args) {
 // --------------------------------------------------------------------------- #
 
 export const ActivityPlugin = async ({ project, directory }) => {
-  let currentSession = null;
-  const seen = loadState();
-  let dirty = false;
   // callID → Date.now() at `tool.execute.before`, so `.after` can report a real
   // duration. Bounded (insertion-ordered Map, oldest evicted) so an abandoned
   // call can never leak memory in a long-lived OpenCode process.
   const callStarts = new Map();
 
   return {
-    // --- Session lifecycle ---
-    "session.created": async (_input, output) => {
-      try {
-        currentSession = output?.session?.id || null;
-        const title = output?.session?.title || "";
-        emitEvent({
-          kind: "session-create",
-          text: title,
-          project: project?.name || "",
-          cwd: directory || "",
-          session: currentSession,
-          app: "opencode",
-          payload: {
-            agent: output?.session?.agent || "",
-            model: output?.session?.model || "",
-            title,
-          },
-        });
-      } catch {
-        // best-effort
-      }
-    },
-
-    // --- User messages ---
-    "message.updated": async (input, _output) => {
-      try {
-        const msg = input?.message || input;
-        if (!msg) return;
-        if (msg.role !== "user") return;
-
-        const id = msg.id;
-        if (!id) return;
-        if (seen.includes(id)) return;
-
-        const text = extractText(msg);
-        if (!text || text.length < 2) return;
-
-        const truncated =
-          text.length > MAX_TEXT_LEN ? text.slice(0, MAX_TEXT_LEN) : text;
-        const kind = truncated.startsWith("/") ? "command" : "prompt";
-
-        emitEvent({
-          kind,
-          text: truncated,
-          project: project?.name || "",
-          cwd: directory || "",
-          session: currentSession,
-          app: "opencode",
-          payload: { role: "user", messageId: id },
-        });
-
-        seen.push(id);
-        dirty = true;
-        if (seen.length > MAX_SEEN) {
-          saveState(seen);
-          dirty = false;
-        }
-      } catch {
-        // best-effort
-      }
-    },
-
     // --- Tool calls ---
     // `tool.execute.before` only records a start time so `.after` can report a
     // REAL duration. The hook `output` carries {title, output, metadata} — it
@@ -362,39 +252,16 @@ export const ActivityPlugin = async ({ project, directory }) => {
           text: name.name,
           project: project?.name || "",
           cwd: directory || "",
-          // sessionID is on the hook input; `currentSession` is only set by the
-          // session.created handler, which the plugin contract never calls.
-          session: input?.sessionID || currentSession,
+          // `sessionID` is carried on the hook input itself — this hook needs no
+          // session-lifecycle handler to attribute a call. MEASURED 2026-08-03:
+          // every tool-call row emitted after this landed (#298) carries a real
+          // session; 188/188 across both hosts, 0 empty.
+          session: input?.sessionID || null,
           app: "opencode",
           payload,
         });
       } catch {
         // best-effort
-      }
-    },
-
-    // --- Session end ---
-    "session.idle": async (_input, _output) => {
-      try {
-        emitEvent({
-          kind: "session-idle",
-          text: "",
-          project: project?.name || "",
-          cwd: directory || "",
-          session: currentSession,
-          app: "opencode",
-        });
-        currentSession = null;
-      } catch {
-        // best-effort
-      }
-    },
-
-    // --- Cleanup: persist state if dirty ---
-    _cleanup: () => {
-      if (dirty) {
-        saveState(seen);
-        dirty = false;
       }
     },
   };

--- a/scripts/collector/opencode/tests/test_plugin.py
+++ b/scripts/collector/opencode/tests/test_plugin.py
@@ -2,10 +2,10 @@
 """Tests for the OpenCode activity plugin.
 
 Covers:
-  - State file round-trip and ring-buffer pruning (shell-level via node)
   - Emit round-trip: plugin calls emit → collector.parse_line succeeds
   - opencode plugin-loader contract: exactly one named export, and it is a
     function (a non-function export makes opencode reject the whole module)
+  - Registered hook keys are ONLY the two real ones (`tool.execute.before/after`)
   - Declarative deployment via nix/home.nix into the singular plugin/ dir
 """
 from __future__ import annotations
@@ -58,40 +58,53 @@ def write_mock_emit(path: Path, log_file: Path) -> None:
 
 
 # --------------------------------------------------------------------------- #
-# State round-trip + ring buffer (JS logic, tested via node)
+# Registered hook keys  (regression: three handlers that could never fire)
 # --------------------------------------------------------------------------- #
+#
+# `session.created`, `message.updated` and `session.idle` are opencode BUS EVENT
+# TYPES, not plugin hook names — they are delivered through a generic `event`
+# hook. Registering them as hook keys is a silent no-op. The plugin carried all
+# three from 2026-07-29 to 2026-08-03 and none ever fired: `kind=session-create`
+# and `kind=session-idle` recorded 0 rows for the plugin's entire existence.
+#
+# This test pins the SCOPE decision: only real hooks are registered, so a
+# handler that cannot run can never be re-added silently.
 
-def test_state_file_roundtrip(tmp_path):
-    """Write state JSON, read it back, verify contents."""
-    state_file = tmp_path / "state.json"
-    state_file.write_text(
-        json.dumps({"version": 1, "seen": ["a", "b", "c"]}),
-        encoding="utf-8",
+REAL_HOOKS = ["tool.execute.after", "tool.execute.before"]
+# Bus event types — hook keys that opencode will never call.
+DEAD_HOOKS = ["session.created", "message.updated", "session.idle"]
+
+
+def _hook_keys() -> list:
+    """Instantiate ActivityPlugin and return the hook keys it registers."""
+    code = (
+        f'const m = await import({json.dumps(PLUGIN_JS.as_uri())});\n'
+        'const hooks = await m.ActivityPlugin({\n'
+        '  project: { name: "p" }, directory: "/tmp", worktree: "/tmp",\n'
+        '  client: {}, serverUrl: "", $: {},\n'
+        '});\n'
+        'console.log(JSON.stringify(Object.keys(hooks).sort()));\n'
     )
-    data = json.loads(state_file.read_text(encoding="utf-8"))
-    assert data["version"] == 1
-    assert data["seen"] == ["a", "b", "c"]
+    rc = run_node(code)
+    assert rc.returncode == 0, f"plugin factory threw: {rc.stderr}"
+    return json.loads(rc.stdout)
 
 
-def test_state_ring_buffer():
-    """Add 1100 IDs to state, verify oldest 100 are pruned (keeps last 1000)."""
-    code = '''
-import { readFileSync, writeFileSync } from "fs";
-const MAX_SEEN = 1000;
-let seen = [];
-for (let i = 0; i < 1100; i++) seen.push("msg_" + i);
-// Ring buffer logic (mirrors plugin)
-const trimmed = seen.slice(-MAX_SEEN);
-const state = JSON.stringify({ version: 1, seen: trimmed });
-const parsed = JSON.parse(state);
-console.log(JSON.stringify({ count: parsed.seen.length, first: parsed.seen[0], last: parsed.seen[parsed.seen.length - 1] }));
-'''
-    result = run_node(code)
-    assert result.returncode == 0, result.stderr
-    out = json.loads(result.stdout.strip())
-    assert out["count"] == 1000
-    assert out["first"] == "msg_100"  # first 100 pruned
-    assert out["last"] == "msg_1099"
+def test_only_real_hooks_are_registered():
+    """Every registered key must be a hook opencode actually calls."""
+    assert _hook_keys() == REAL_HOOKS
+
+
+def test_no_bus_event_types_registered_as_hooks():
+    """A bus event type registered as a hook key is dead code that reads live."""
+    registered = set(_hook_keys())
+    revived = registered & set(DEAD_HOOKS)
+    assert not revived, (
+        f"{sorted(revived)} registered as hook key(s) — these are opencode BUS "
+        f"EVENT TYPES, not hooks, and will never fire. They emitted 0 rows over "
+        f"5 days. Route them through a single `event` hook that switches on "
+        f"`event.type` instead."
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -110,11 +123,14 @@ def test_plugin_emit_roundtrip(tmp_path):
     payload = json.dumps({"agent": "code", "model": "gpt-4"})
 
     env = dict(os.environ, ACTIVITY_SPOOL_DIR=str(spool))
-    # Build emit args the same way the JS plugin would
+    # Build emit args the same way the JS plugin would. `tool-call` is the only
+    # kind the plugin emits — using a kind it does not emit would encode a claim
+    # about the plugin that is false (this test read `session-create` while that
+    # handler was dead).
     rc = subprocess.run(
         [
             "bash", str(EMIT),
-            "source=opencode", "kind=session-create",
+            "source=opencode", "kind=tool-call",
             f"b64:text={text}", f"b64:project={project}",
             f"b64:cwd={cwd}", f"b64:session={session}",
             "b64:app=opencode", f"b64:payload={payload}",
@@ -129,7 +145,7 @@ def test_plugin_emit_roundtrip(tmp_path):
     ev = C.parse_line(lines[0])
     assert ev is not None
     assert ev["source"] == "opencode"
-    assert ev["kind"] == "session-create"
+    assert ev["kind"] == "tool-call"
     assert ev["text"] == text
     assert ev["project"] == project
     assert ev["cwd"] == cwd
@@ -320,7 +336,7 @@ function emitEvent({{ kind, text, project, cwd, session, app, payload }}) {{
 }}
 
 emitEvent({{
-  kind: "session-create",
+  kind: "tool-call",
   text: "test session",
   project: "my-proj",
   cwd: "/tmp",
@@ -334,7 +350,7 @@ emitEvent({{
 
     log_content = log_file.read_text(encoding="utf-8").strip()
     assert "source=opencode" in log_content
-    assert "kind=session-create" in log_content
+    assert "kind=tool-call" in log_content
     assert "b64:project=" in log_content
     assert "b64:session=s1" in log_content
     assert "b64:app=opencode" in log_content


### PR DESCRIPTION
## What this closes

The handoff's investigation 2 — "`session=''` on 97.7% of opencode `tool-call` rows" — **was already fixed by #298 before this work started.** No `event`-hook change was needed.

`tool.execute.after` carries `sessionID` on its own hook input, so attribution never depended on a session-lifecycle handler. #298 added `session: input?.sessionID || currentSession` at 2026-08-02 21:47; it went live with the `home-manager switch` at 01:10.

The "2,736 of 2,799" figure was a **lifetime aggregate** dominated by the 2,699 pre-fix rows. Windowed by deploy time, the cliff is clean:

| | |
|---|---|
| Last empty-session row | `2026-08-03 02:32:26` (process still holding the pre-deploy module) |
| First filled-session row | `2026-08-03 03:28:27` |
| Since then, both hosts | **188 filled / 0 empty** (laptop 4, workbench 184) |

Live positive control: a real `opencode run` making a `glob` call landed at `16:48:48` with `session=ses_037791641ffe1wbFfgX3Ib0UG3`.

## What this changes

The genuine residual: three handlers that **could never fire**.

`session.created`, `message.updated` and `session.idle` are opencode **bus event types**, not plugin hook names — they arrive through a generic `event` hook, so registering them as hook keys is a silent no-op. They were carried from 2026-07-29 and emitted nothing: `kind=session-create` and `kind=session-idle` have **0 rows, ever**.

Removed rather than revived, because nothing consumes those kinds (no readers outside the plugin's own tests) and `tailer.py` already covers `prompt`/`assistant-turn`. The seen-ID ring buffer, `extractText`, the state file and `_cleanup` existed only to serve `message.updated`, so they go too — 167 lines out of the plugin.

If session lifecycle is ever wanted, the note in the file says to add **one** `event` handler switching on `event.type`.

## Safety — this is the file whose last edit caused an 11-hour silent outage

`ActivityPlugin` remains the **only** export, and still a function. This change only deletes, so the constraint holds by construction; verified anyway by import probe and by the existing `test_every_named_export_is_a_function` / `test_exactly_one_named_export`.

## Test coverage

`test_only_real_hooks_are_registered` and `test_no_bus_event_types_registered_as_hooks` instantiate the plugin factory and pin the registered hook keys.

Watched red at base, green at HEAD:

```
OLD (origin/main): ["_cleanup","message.updated","session.created",
                    "session.idle","tool.execute.after","tool.execute.before"]
NEW (this branch): ["tool.execute.after","tool.execute.before"]
```

Also: two vestigial ring-buffer tests removed — they mirrored the logic locally and never imported the plugin, so they stayed green regardless of what it did. And the emit round-trip tests were retargeted off `kind=session-create` (a kind the plugin does not emit) onto `tool-call` (which it does), so the fixture stops encoding a false claim.

## Gates

Authoritative tier, not `nix-shell`:

- `nix build .#checks.x86_64-linux.pytests` → **5868 collected / 5867 passed / 1 skipped / 0 failed** (floor 5600); `scripts/collector/opencode/tests` 170/170
- `nix build .#checks.x86_64-linux.nodetests` → **997/997**, 3 suites, 29 files (floor 970)

## Docs corrected

`claude/skills/activity/SKILL.md` and `claudedocs/handoff-agent-setup-audit.md` both stated `session=''` as open with an `event`-hook fix pending. Both now record it as closed, with the measured cliff and the instruction to **window by deploy time** before re-opening — a lifetime aggregate over a fixed bug reports the bug forever.

## Not yet verified

Deployment. `home-manager switch` + a live `opencode run` confirming rows still land is the gate that matters for this file, and it has **not** been run for this branch — merging and switching does not by itself prove the plugin still loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
