### PR TITLE
fix(browser-bridge): `emulate --reset` now CLEARS the CDP overrides — the viewport was permanently sticky (#319)

### DIFF
--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -98,11 +98,11 @@
 #                               Raw override: --width/--height/--dsf/--mobile/
 #                               --touch/--ua for anything not in the table.
 #                               STICKY per tab: re-applied inside every later op's
-#                               CDP session, because CDP overrides die at detach.
-#                               ✅ That is also the SAFETY property — between ops
-#                               the tab is NOT emulated, so a crashed agent can
-#                               never leave your real browser distorted.
-#                               `--reset` stops re-applying (nothing to undo).
+#                               CDP session, because most CDP overrides die at
+#                               detach. 🔴 The VIEWPORT SIZE does NOT (measured) —
+#                               it survives the detach, so a crashed agent CAN
+#                               leave a tab phone-sized. `--reset` sends the CDP
+#                               clears to undo it; closing the tab also works.
 #                               ⚠ OWNED TABS ONLY (`browser open` first): emulating
 #                               a tab you are browsing in is refused with
 #                               `not_owned_tab`. Screenshots on an emulated tab are

--- a/scripts/browser-bridge/extension/README.md
+++ b/scripts/browser-bridge/extension/README.md
@@ -273,6 +273,24 @@ If `ping` still reports the old version after ↻, **fully quit and reopen Brave
 > three full Brave restarts in a single session. (0.3.0 → 0.3.1 was exactly
 > this: adding `id` to `ping`'s reply is a discriminator, so it got a bump.)
 
+> **0.7.2 — `emulate --reset` actually CLEARS the overrides (#319).** No new wire
+> op, so `ping`'s `ops` list is byte-identical to 0.7.1's. The discriminator is
+> the **behaviour**, and it is exact — a post-reset viewport read:
+>
+> ```bash
+> browser --instance <label> open https://example.com          # note the tabId
+> browser --instance <label> --tab <id> js --wake 'innerWidth'  # e.g. 1124 (desktop)
+> browser --instance <label> --tab <id> emulate iphone-15
+> browser --instance <label> --tab <id> emulate --reset
+> browser --instance <label> --tab <id> js --wake 'innerWidth'
+>   # 0.7.1 → 393   (the reset was a no-op; the tab is stuck as an iPhone)
+>   # 0.7.2 → 1124  (Emulation.clearDeviceMetricsOverride was sent)
+> browser --instance <label> --tab <id> close
+> ```
+>
+> The `--reset` reply also grows a `cleared: [...]` array on 0.7.2, which is a
+> second, cheaper tell.
+
 > **0.7.1 — `text --annotated` inside `--frame`.** No new wire op, so `ping`'s
 > `ops` list is byte-identical to 0.7.0's and cannot discriminate this build.
 > The discriminator is the **capability itself**, and it is exact — it exercises

--- a/scripts/browser-bridge/extension/manifest.json
+++ b/scripts/browser-bridge/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Browser Bridge (command channel)",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Lets a local Claude Code skill drive the active Brave tab (getHtml/eval/tabs/nav/screenshot/frames/click/type/key/activate/upload/emulate/ping) via a loopback, token-authenticated rendezvous server. Local-only, authorized personal automation.",
   "permissions": ["scripting", "tabs", "activeTab", "storage", "alarms", "debugger", "webNavigation"],
   "host_permissions": ["http://127.0.0.1:8788/*", "<all_urls>"],

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -561,19 +561,32 @@ export async function applyWakeSteps(send, steps = WAKE_CDP_STEPS) {
 // everything in THIS file is the pure, browser-free half: the preset table, the
 // validation, and the ordered CDP step list.
 //
-// ✅ THE SAFETY PROPERTY THIS BUYS — state it explicitly, it is the REASON this
-// design was chosen over holding one long-lived debugger session open:
+// 🔴 THE "DIE AT DETACH" PREMISE IS ONLY MOSTLY TRUE — measured, do not restate
+// the old claim. This block used to assert that because every override dies at
+// detach, the tab is never emulated between ops and a crashed agent CANNOT leave
+// the operator's browser distorted. Issue #319 falsified it, and the follow-up
+// measurement (2026-08-03, live Brave, extension 0.7.1, laptop, `iphone-15`,
+// read via `js --wake`, against a never-emulated control tab in the same window)
+// says exactly which half is which:
 //
-//   Because the overrides die at detach, the tab is NOT emulated between ops. A
-//   crashed agent, a killed Claude session, or an evicted MV3 service worker
-//   therefore CANNOT leave the operator's real browser distorted. The worst case
-//   is a forgotten entry in an in-memory Map that dies with the worker — not a
-//   Brave tab stuck at 393×852 pretending to be an iPhone with nothing left
-//   running that knows how to undo it.
+//   * setDeviceMetricsOverride's VIEWPORT SIZE does NOT die at detach. After
+//     `--reset` — and after a further navigation — innerWidth×innerHeight was
+//     still 393×852 while the control tab read 1124×1400. Interestingly
+//     devicePixelRatio, set by the same call, DID revert to 1, which points at
+//     the residue being the resized render widget rather than a live override.
+//   * touch, UA/UA-CH, emulated media and the timezone override DO die at
+//     detach: after `--reset` they all read as the real desktop values.
 //
-// A held session would have been simpler to write and strictly worse to own: the
-// failure mode would be a permanently mangled tab plus a permanent debug banner,
-// recoverable only by the operator finding and closing the tab.
+// So the honest statement of what the design buys: between ops the tab keeps the
+// emulated VIEWPORT SIZE and nothing else. A crashed agent, a killed Claude
+// session or an evicted MV3 service worker CAN leave a tab sized as a phone —
+// closing the tab, or `emulate --reset` (which since #319 sends
+// Emulation.clearDeviceMetricsOverride and the matching clears — see
+// emulationResetCdpSteps below), is what undoes it.
+//
+// A held session would still have been worse to own: its failure mode adds a
+// permanent debug banner and leaves the UA, touch and media overrides live too,
+// none of which survive today.
 //
 // BLAST RADIUS: enforced SERVER-side (see server.py OWNED_TAB_ONLY_OPS). Only a
 // tab the calling session opened via `open` may be emulated; anything else is
@@ -1106,6 +1119,103 @@ export async function applyEmulationSteps(send, steps) {
   return applied;
 }
 
+// --- UNDOING an emulation: the ordered CDP CLEAR list ----------------------- //
+//
+// 🔴 THIS EXISTS BECAUSE THE "OVERRIDES DIE AT DETACH" PREMISE IS ONLY MOSTLY
+// TRUE. See the EMULATION header comment above for the measurement. The short
+// version: the DEVICE-METRICS VIEWPORT SIZE survives the debugger detach, so
+// dropping the `emulationState` entry — which is all `--reset` used to do — left
+// the tab permanently sized as the phone, with nothing left that knew how to undo
+// it. Issue #319.
+//
+// Which class needs which clear, and how strong the evidence is (measured
+// 2026-08-03, live Brave, extension 0.7.1, laptop, `iphone-15` + `--color-scheme
+// dark --tz Europe/London --geo …`, read through `js --wake`, against a control
+// tab in the same window that was never emulated):
+//
+//   * Emulation.clearDeviceMetricsOverride — 🔴 MEASURED NECESSARY.
+//     innerWidth×innerHeight stayed 393×852 after `--reset` AND after a further
+//     navigation; the control tab read 1124×1400 throughout. (devicePixelRatio,
+//     set by the SAME CDP call, DID revert to 1 — consistent with the residue
+//     being the resized render widget rather than a live override.)
+//   * the other five — MEASURED to clear themselves at detach: after `--reset`,
+//     maxTouchPoints was 0, `pointer:coarse` false, `prefers-color-scheme: dark`
+//     false, the UA was the real desktop one and the timezone was back to the
+//     host's. They are cleared here ANYWAY, deliberately: the measurement is one
+//     Chromium build on one host, the clears run inside a session that is already
+//     open (so they cost a loopback round-trip each and nothing else), and a clear
+//     on a domain that holds no override is a no-op. "Undo what was applied" is a
+//     property worth having independent of which Chromium you are on.
+//
+// What a clear CANNOT undo: properties Chromium installs at DOCUMENT CREATION.
+// `"ontouchstart" in window` was still true immediately after `--reset` (the
+// document had been BUILT under touch emulation) and only went false after a
+// re-navigation. Same asymmetry as the `documentPredatesEmulation` hint, in the
+// other direction.
+//
+// Derived from the state that was in force, not from a fixed list, so `--reset`
+// sends exactly the undo of what this bridge applied. A tab with NO stored state
+// yields NO steps — reset stays a zero-CDP, zero-debugger-banner no-op there.
+export const EMULATION_RESET_MAX_STEPS = 6;
+
+export function emulationResetCdpSteps(state) {
+  if (!state || state.reset) return [];
+  const steps = [];
+  // Metrics first: it is the one measured to actually be stuck, so it lands even
+  // if a later clear fails (they are applied best-effort, see below).
+  if (state.metrics) {
+    steps.push({ method: "Emulation.clearDeviceMetricsOverride", params: {} });
+  }
+  if (state.touch) {
+    // maxTouchPoints is meaningless with enabled:false and CDP rejects 0, so it
+    // is omitted rather than sent as a placeholder.
+    steps.push({ method: "Emulation.setTouchEmulationEnabled",
+                 params: { enabled: false } });
+  }
+  if (state.ua) {
+    // An EMPTY userAgent is how CDP spells "no override" — the same call DevTools
+    // makes when you untick its custom-user-agent box. userAgentMetadata is
+    // omitted so it reverts with it.
+    steps.push({ method: "Emulation.setUserAgentOverride",
+                 params: { userAgent: "" } });
+  }
+  if (state.media) {
+    steps.push({ method: "Emulation.setEmulatedMedia",
+                 params: { media: "", features: [] } });
+  }
+  if (state.timezone) {
+    steps.push({ method: "Emulation.setTimezoneOverride",
+                 params: { timezoneId: "" } });
+  }
+  if (state.geolocation) {
+    steps.push({ method: "Emulation.clearGeolocationOverride", params: {} });
+  }
+  return steps;
+}
+
+// Apply the CLEAR steps through `send`, IN ORDER, BEST-EFFORT — the exact
+// opposite policy to applyEmulationSteps, and the difference is deliberate.
+//
+// An apply must fail loudly: a half-applied emulation returns a plausible
+// screenshot of the wrong thing. An UNDO must not: aborting on the first failure
+// would leave the remaining overrides in place, which is the very state this
+// function exists to escape. So every step is attempted and the outcome is
+// REPORTED — { cleared: [method], failed: [{ method, error }] } — rather than
+// thrown. The caller drops the stored state regardless.
+export async function applyEmulationResetSteps(send, steps) {
+  const cleared = [];
+  const failed = [];
+  for (const step of steps || []) {
+    try {
+      await send(step.method, step.params);
+      cleared.push(step.method);
+    } catch (e) {
+      failed.push({ method: step.method, error: String((e && e.message) || e) });
+    }
+  }
+  return { cleared, failed };
+}
+
 // The compact, METADATA-ONLY summary of a stored state — what `emulate` returns,
 // what `tabs` annotates an emulated tab with, and what goes into telemetry. No
 // URL, no page content; the UA string is deliberately EXCLUDED (it is long, and
@@ -1135,13 +1245,14 @@ export function emulationSummary(state) {
 // NEVER attaches the debugger, so withCdp's re-application choke point never runs
 // and the DOM they see is the tab's REAL, un-emulated one.
 //
-// That is correct-by-design, not a bug: between ops the tab genuinely is not
-// emulated (the safety property above), so the at-rest DOM really is desktop.
-// But it is a TRAP, and it is this feature's characteristic failure mode on the
-// read path: an agent screenshots a phone layout, then reads `text`/`html` and
-// reasons about a DESKTOP DOM, with nothing in the envelope to tell it apart.
-// Layout-derived values (innerWidth, getBoundingClientRect, matchMedia) and
-// navigator.userAgent all come back REAL.
+// That is correct-by-design, not a bug: between ops the tab is not emulated
+// EXCEPT for the viewport size, which is measured to survive the detach (see the
+// EMULATION header). But it is a TRAP, and it is this feature's characteristic
+// failure mode on the read path: an agent screenshots a phone layout, then reads
+// `text`/`html` and reasons about a DESKTOP DOM, with nothing in the envelope to
+// tell it apart. navigator.userAgent, matchMedia and the touch surface come back
+// REAL; innerWidth/innerHeight are the one pair that may still read emulated,
+// which makes the mixture WORSE than a uniformly-desktop read, not better.
 //
 // So every read of a tab that HAS emulation state says which one it got. Same
 // pattern, and the same reasoning, as HIDDEN_TAB_NOTE: the read self-announces
@@ -1152,11 +1263,13 @@ export function emulationSummary(state) {
 // the read through cdpWake → withCdp and therefore through the emulation apply.
 export const NOT_EMULATED_READ_NOTE =
   "This tab has device emulation configured, but THIS read did not go through "
-  + "CDP — it read the tab's REAL, un-emulated DOM. Emulation overrides only "
-  + "exist inside a CDP session (they die at detach), so layout-derived values "
-  + "(innerWidth, getBoundingClientRect, matchMedia) and navigator.userAgent are "
-  + "the DESKTOP ones here. Re-run this read with --wake to read inside an "
-  + "emulated session.";
+  + "CDP — it read the tab's REAL, un-emulated DOM. Most emulation overrides only "
+  + "exist inside a CDP session (they die at detach), so navigator.userAgent, "
+  + "matchMedia and the touch surface are the DESKTOP ones here — while "
+  + "innerWidth/innerHeight may still be the EMULATED ones, because the device-"
+  + "metrics viewport size is measured to survive the detach. A mixture, not a "
+  + "clean desktop read. Re-run this read with --wake to read inside an emulated "
+  + "session.";
 
 // Annotate a READ result with whether it observed the emulated page.
 //   * no emulation state for the tab → returns `data` UNTOUCHED (a plain tab's

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -52,9 +52,10 @@ import {
   promiseWithTimeout, EXEC_OP_BUDGET_MS, POLL_BUDGET_MS, RESULT_BUDGET_MS,
   LOOP_STALL_MS, STORAGE_BUDGET_MS,
   // `emulate` op: device emulation (viewport/touch/UA+UA-CH/media/geo/tz) that is
-  // STICKY per tab because CDP overrides die at detach — see the EMULATION section
-  // in protocol.js for the central problem and the safety property it buys.
+  // STICKY per tab because most CDP overrides die at detach (the viewport size
+  // does NOT — see the EMULATION section in protocol.js for the measurement).
   normalizeEmulation, emulationCdpSteps, applyEmulationSteps, emulationSummary,
+  emulationResetCdpSteps, applyEmulationResetSteps,
   isTouchEmulated, touchTapEvents, DEVICE_PRESETS, PRESET_NAMES,
   annotateEmulatedRead, emulationCreateTimeSignature, documentPredatesEmulation,
   annotateDocumentPredates,
@@ -209,11 +210,17 @@ const cdpAttached = new Set();
 // tabId -> the normalized emulation state from normalizeEmulation(). This is the
 // ONLY mutable emulation state in the extension.
 //
-// It is IN-MEMORY on purpose (not chrome.storage): CDP overrides die at detach, so
-// state that outlived the service worker would describe an emulation that is not
-// actually applied anywhere — a lie that survives a restart is worse than a
-// forgotten one. Losing it on worker eviction is the correct, safe failure: the
-// operator's tab is already un-emulated at that point.
+// It is IN-MEMORY on purpose (not chrome.storage): the touch/UA/media/timezone
+// overrides die at detach, so state that outlived the service worker would
+// describe an emulation that is mostly not applied anywhere — a lie that survives
+// a restart is worse than a forgotten one.
+//
+// ⚠ The cost, measured (#319): losing this map on worker eviction is NOT a clean
+// failure. The device-metrics VIEWPORT SIZE survives the detach, so the tab stays
+// phone-sized while the map that knew how to undo it is gone — and `--reset`
+// derives its clears from that map, so it can no longer help. Closing the tab is
+// the remedy. Persisting the map instead would trade this for the lie above; the
+// trade has not been re-litigated, it is just no longer free.
 //
 // Emptied by: `emulate --reset`, `close`, chrome.tabs.onRemoved, and a failed
 // tabs.get during CDP attach (the tab went away out-of-band).
@@ -1181,9 +1188,23 @@ const OPS = {
   // rather than discovering a bad timezone id three ops later. Every subsequent op
   // that attaches CDP re-applies it (see the choke point in withCdp).
   //
-  // `--reset` means "STOP RE-APPLYING". It does not need to undo anything: the
-  // overrides died at the previous op's detach, and the tab is already un-emulated
-  // right now. That is the whole safety property (protocol.js EMULATION).
+  // `--reset` STOPS RE-APPLYING **and UNDOES** what was applied. It has to do
+  // both: the device-metrics viewport size is measured NOT to die at the previous
+  // op's detach (2026-08-03 — see protocol.js emulationResetCdpSteps), so dropping
+  // the Map entry alone left the tab permanently sized as the phone with nothing
+  // left that knew how to undo it. That was issue #319.
+  //
+  // Shape of the undo, and why:
+  //   * the Map entry is dropped FIRST and unconditionally — whatever the browser
+  //     does with the clears, this op must never leave the tab still being
+  //     re-emulated by later ops;
+  //   * the clears are BEST-EFFORT and their outcome is REPORTED, not thrown. A
+  //     closed tab or a refused attach yields `clearError`; an individual step
+  //     that rejects yields a `clearFailed` entry. Either way the state is gone
+  //     and the caller can see exactly what did and did not get undone;
+  //   * a tab with NO stored state yields NO steps, so reset stays a zero-CDP,
+  //     zero-debugger-banner no-op there. It also means reset cannot repair a tab
+  //     whose state died with an evicted service worker — closing it still can.
   //
   // OWNERSHIP is enforced SERVER-side (server.py OWNED_TAB_ONLY_OPS → the named
   // `not_owned_tab` refusal), not here, because the server is the only side that
@@ -1194,14 +1215,47 @@ const OPS = {
     const state = normalizeEmulation(cmd);   // throws a NAMED error on bad input
 
     if (state.reset) {
-      const had = emulationSummary(emulationFor(tab.id));
+      const previous = emulationFor(tab.id);
+      const had = emulationSummary(previous);
       clearEmulation(tab.id);
-      return {
+
+      const steps = emulationResetCdpSteps(previous);
+      let cleared = [];
+      let failed = [];
+      let clearError = null;
+      if (steps.length) {
+        try {
+          const outcome = await withCdp(tab.id, tab.url, (send) =>
+            applyEmulationResetSteps(send, steps));
+          cleared = outcome.cleared;
+          failed = outcome.failed;
+        } catch (e) {
+          // Tab already closed, a scheme CDP may not attach to, a wedged
+          // renderer. The state is already dropped; say so instead of throwing.
+          clearError = String((e && e.message) || e);
+        }
+      }
+
+      const out = {
         tabId: tab.id, url: tab.url, reset: true,
         wasEmulating: had,
-        note: "emulation stopped. Nothing had to be undone — CDP overrides die at "
-          + "debugger detach, so the tab was already un-emulated between ops.",
+        cleared,
+        note: steps.length
+          ? "emulation stopped and the overrides CLEARED on the tab. This is "
+            + "required, not belt-and-braces: the device-metrics viewport size "
+            + "survives the debugger detach (measured), so dropping the state "
+            + "alone would leave the tab stuck at the emulated size. Properties "
+            + "installed at DOCUMENT CREATION are not undone by a clear — "
+            + "`\"ontouchstart\" in window` stays true on the document that was "
+            + "built emulated; re-`nav` for a fully desktop document."
+          : "emulation stopped. This tab had no stored emulation, so nothing was "
+            + "sent to the browser and no debugger attached. NOTE this cannot "
+            + "repair a tab whose emulation state was lost (evicted service "
+            + "worker) — closing the tab is the remedy there.",
       };
+      if (failed.length) out.clearFailed = failed;
+      if (clearError) out.clearError = clearError;
+      return out;
     }
 
     // Store BEFORE applying so the apply goes through the same withCdp choke point
@@ -1241,9 +1295,12 @@ const OPS = {
       emulation: emulationSummary(state),
       applied,
       note: "sticky per tab: these overrides are re-applied inside every "
-        + "subsequent op's CDP session. Between ops the tab is NOT emulated (the "
-        + "overrides die at detach), so a crashed agent cannot leave your browser "
-        + "distorted. `browser emulate --reset` stops re-applying.",
+        + "subsequent op's CDP session. Between ops the touch, UA, media and "
+        + "timezone overrides are gone (they die at detach) but the VIEWPORT SIZE "
+        + "is NOT — it survives the detach (measured), so this tab stays at the "
+        + "emulated width until something clears it. `browser emulate --reset` "
+        + "now sends that clear; closing the tab also works. A crashed agent that "
+        + "does neither leaves the tab at the emulated size.",
     }, documentPredatesEmulation(tab.url, emulationCreateTimeSignature(state),
                                  documentEmulation.get(tab.id)));
   },

--- a/scripts/browser-bridge/reference/emulation.md
+++ b/scripts/browser-bridge/reference/emulation.md
@@ -107,31 +107,73 @@ document that was not built under this emulation. See "The
 
 ---
 
-## Why it is sticky, and the safety property that buys
+## Why it is sticky, and what actually survives a detach
 
-CDP emulation overrides are **session-scoped**: they die the instant the debugger
-detaches. The bridge **always** detaches (`withCdpSession`'s `finally` — that is a
-load-bearing invariant; a leaked attachment is a stuck banner plus an open
-surface). So a naive `emulate` would set a viewport that had already evaporated
-before the next command ran.
+Most CDP emulation overrides are **session-scoped**: they die the instant the
+debugger detaches. The bridge **always** detaches (`withCdpSession`'s `finally` —
+that is a load-bearing invariant; a leaked attachment is a stuck banner plus an
+open surface). So a naive `emulate` would set a viewport that had already
+evaporated before the next command ran.
 
 Instead, `emulate` **stores** the device state per tab, and **every op that
 attaches CDP re-applies it inside its own session, before doing its work.**
 
-✅ **The property this buys, and the reason this design beat holding one long-lived
-session open: between ops the tab is NOT emulated.** A crashed agent, a killed
-Claude session, or an evicted MV3 service worker cannot leave the operator's real
-browser distorted. The worst case is a forgotten entry in an in-memory Map that
-dies with the worker — not a Brave tab stuck pretending to be an iPhone with
-nothing left running that knows how to undo it.
+### 🔴 One override does NOT die at detach: the viewport size
 
-That is also why `--reset` has nothing to undo. It means **"stop re-applying"**;
-the overrides are already gone.
+This page used to claim that *every* override dies at detach, that the tab is
+therefore never emulated between ops, and that `--reset` consequently has nothing
+to undo. **That was wrong** (issue #319), and it is the reason `--reset` was a
+no-op that left tabs permanently phone-sized until you closed them.
 
-**Consequence to plan around:** a page that re-measures the viewport *later* — on
-a `resize` listener, or well after load — sees the real window until your next op
-re-applies. Drive the page with bridge ops rather than expecting the emulation to
-persist while you sit idle.
+**Measured 2026-08-03** — live Brave, extension 0.7.1, laptop, `personal`
+profile, `https://example.com` in an owned tab, `emulate iphone-15
+--color-scheme dark --tz Europe/London --geo 51.5074,-0.1278`, every read taken
+the same way (`js --wake`), with a control tab opened in the same window that was
+never emulated:
+
+| signal | control (never emulated) | after `emulate`+`nav` | after `--reset` | after `--reset`+re-`nav` |
+|---|---|---|---|---|
+| `innerWidth`×`innerHeight` | 1124×1400 | 393×852 | 🔴 **393×852** | 🔴 **393×852** |
+| `devicePixelRatio` | 1 | 3 | 1 | 1 |
+| `navigator.maxTouchPoints` | 0 | 5 | 0 | 0 |
+| `"ontouchstart" in window` | false | true | true¹ | false |
+| `matchMedia("(pointer:coarse)")` | false | true | false | false |
+| `prefers-color-scheme: dark` | false | true | false | false |
+| `navigator.userAgent` | X11 Linux | iPhone OS 17 | X11 Linux | X11 Linux |
+| `Intl…resolvedOptions().timeZone` | America/Winnipeg | Europe/London | America/Winnipeg | America/Winnipeg |
+
+¹ not an override — the *document* was built under touch emulation, and
+`ontouchstart` is installed on the global at document creation. A clear cannot
+remove it; the re-`nav` does.
+
+Note `devicePixelRatio` reverts while the width does not, even though both come
+from the same `setDeviceMetricsOverride` call — which points at the residue being
+the resized **render widget** rather than a live override.
+
+Geolocation was not measured (reading it needs a permission grant).
+
+### What `--reset` does now
+
+`--reset` drops the stored state **and** sends the undo inside one CDP session:
+`Emulation.clearDeviceMetricsOverride` (the measured-necessary one) plus
+`setTouchEmulationEnabled{enabled:false}`, `setUserAgentOverride{userAgent:""}`,
+`setEmulatedMedia{}`, `setTimezoneOverride{""}` and `clearGeolocationOverride` for
+whichever classes were in force. The reply carries `cleared: [...]`, and
+`clearFailed` / `clearError` if the browser refused any of it.
+
+The clears are **best-effort**: a closed tab or a refused attach is reported, not
+thrown, and the stored state is dropped either way — `--reset` must never leave a
+tab still being re-emulated.
+
+⚠ **A reset cannot repair a tab whose stored state is gone.** If the MV3 service
+worker was evicted, or a different session owns the tab, there is nothing to
+derive the undo from and `--reset` sends nothing. **Closing the tab** is the
+remedy there — and it is the reason a `SIGKILL`'d agent run (which bypasses
+`browser-agent`'s cleanup trap) can still strand a phone-sized tab.
+
+**Consequence to plan around:** a page that re-measures *touch, UA or media*
+later — on a `resize` listener, or well after load — sees the real desktop values
+until your next op re-applies. The viewport size is the exception; it stays.
 
 ---
 
@@ -244,10 +286,12 @@ and sends no `Sec-CH-UA` at all. That is correct emulation, not a missing field.
 the tab's **real, un-emulated DOM**. `innerWidth`, `getBoundingClientRect`,
 `matchMedia` and `navigator.userAgent` all come back **desktop**.
 
-That is correct-by-design, not a bug: between ops the tab genuinely is not emulated
-(see the safety property above), so the at-rest DOM really *is* desktop. But it is
-the trap this feature is most likely to spring — screenshot a phone layout, then
-read `text` and reason about a desktop DOM.
+That is correct-by-design, not a bug: between ops the tab's touch/UA/media/timezone
+overrides really are gone (see the measurement above). But the at-rest DOM is a
+**mixture**, not a clean desktop read — the viewport size survives the detach, so
+`innerWidth` may still be the emulated one next to a desktop `navigator.userAgent`.
+That is the trap this feature is most likely to spring — screenshot a phone layout,
+then read `text` and reason about a half-desktop DOM.
 
 **Which reads are emulated:**
 

--- a/scripts/browser-bridge/tests/emulation.test.mjs
+++ b/scripts/browser-bridge/tests/emulation.test.mjs
@@ -24,6 +24,7 @@ import { fileURLToPath } from "node:url";
 import {
   DEVICE_PRESETS, PRESET_NAMES, PRESET_REQUIRED_KEYS, EMULATION_LIMITS,
   normalizeEmulation, emulationCdpSteps, applyEmulationSteps, emulationSummary,
+  emulationResetCdpSteps, applyEmulationResetSteps, EMULATION_RESET_MAX_STEPS,
   isTouchEmulated, touchTapEvents, ALLOWED_OPS, EMULATION_MAX_STEPS,
   CDP_OP_BUDGET_MS, EXEC_OP_BUDGET_MS,
   hasCommittedDocument, emulationCreateTimeSignature, documentPredatesEmulation,
@@ -319,6 +320,103 @@ test("`reset` yields no steps at all", () => {
   assert.equal(isTouchEmulated(s), false);
 });
 
+// --------------------------------------------------------------------------- //
+// PURE: the RESET (undo) step list — issue #319
+//
+// The bug this pins: `--reset` used to drop the in-memory state and send NOTHING
+// to CDP, on the premise that every override dies at the debugger detach. The
+// device-metrics VIEWPORT SIZE does not (measured 2026-08-03, live Brave 0.7.1:
+// innerWidth stayed 393 after `--reset` AND after a further nav, against a
+// never-emulated control tab reading 1124), so the tab was left permanently
+// phone-sized with nothing left that knew how to undo it.
+//
+// ⚠ These assert the CDP CLEAR LIST, deliberately — NOT that reset returns
+// ok/reset:true. The broken behaviour returned `reset: true` with a populated
+// `wasEmulating`, so any test asserting only the envelope shape passes against
+// the bug.
+// --------------------------------------------------------------------------- //
+
+test("RESET STEPS: a full emulation undoes EVERY class it applied, in order", () => {
+  const s = normalizeEmulation({
+    device: "iphone-15", colorScheme: "dark", tz: "Europe/London",
+    geo: { latitude: 51.5074, longitude: -0.1278 },
+  });
+  const steps = emulationResetCdpSteps(s);
+  assert.deepEqual(steps.map((x) => x.method), [
+    // Metrics FIRST: it is the one measured to actually be stuck, so it lands
+    // even if a later clear fails.
+    "Emulation.clearDeviceMetricsOverride",
+    "Emulation.setTouchEmulationEnabled",
+    "Emulation.setUserAgentOverride",
+    "Emulation.setEmulatedMedia",
+    "Emulation.setTimezoneOverride",
+    "Emulation.clearGeolocationOverride",
+  ]);
+  // Every apply step has an undo: same count, and never more than the constant.
+  assert.equal(steps.length, emulationCdpSteps(s).length);
+  assert.ok(steps.length <= EMULATION_RESET_MAX_STEPS);
+
+  // The PARAMS are the point, not just the method names — a clear that carries
+  // the wrong payload is a no-op that looks like an undo.
+  const by = Object.fromEntries(steps.map((x) => [x.method, x.params]));
+  assert.deepEqual(by["Emulation.clearDeviceMetricsOverride"], {});
+  assert.deepEqual(by["Emulation.setTouchEmulationEnabled"], { enabled: false });
+  assert.deepEqual(by["Emulation.setUserAgentOverride"], { userAgent: "" });
+  assert.deepEqual(by["Emulation.setEmulatedMedia"], { media: "", features: [] });
+  assert.deepEqual(by["Emulation.setTimezoneOverride"], { timezoneId: "" });
+  assert.deepEqual(by["Emulation.clearGeolocationOverride"], {});
+});
+
+test("RESET STEPS: derived from what was APPLIED, not a fixed list", () => {
+  // A metrics-only raw emulation undoes metrics and nothing else — sending a
+  // timezone or UA clear here would reset overrides this bridge never set.
+  const metricsOnly = normalizeEmulation({ width: 400, height: 800 });
+  assert.equal(metricsOnly.touch, null, "harness check: this state sets no touch");
+  assert.deepEqual(emulationResetCdpSteps(metricsOnly).map((x) => x.method),
+    ["Emulation.clearDeviceMetricsOverride"]);
+
+  // An EXPLICIT --no-touch still applied a touch override, so it still gets undone.
+  const noTouch = normalizeEmulation({ width: 400, height: 800, touch: false });
+  assert.deepEqual(emulationResetCdpSteps(noTouch).map((x) => x.method),
+    ["Emulation.clearDeviceMetricsOverride", "Emulation.setTouchEmulationEnabled"]);
+
+  // A media-only emulation invents no device-metrics clear.
+  const mediaOnly = normalizeEmulation({ colorScheme: "dark" });
+  assert.deepEqual(emulationResetCdpSteps(mediaOnly).map((x) => x.method),
+    ["Emulation.setEmulatedMedia"]);
+
+  // Nothing stored → nothing to undo → no CDP session, no debugger banner.
+  assert.deepEqual(emulationResetCdpSteps(null), []);
+  assert.deepEqual(emulationResetCdpSteps(normalizeEmulation({ reset: true })), []);
+});
+
+test("RESET STEPS: applyEmulationResetSteps is BEST-EFFORT and reports the damage",
+  async () => {
+    // The opposite policy to applyEmulationSteps on purpose: aborting an UNDO at
+    // the first failure would leave the remaining overrides in place, which is
+    // the state the undo exists to escape.
+    const seen = [];
+    const send = async (method) => {
+      seen.push(method);
+      if (method === "Emulation.setUserAgentOverride") throw new Error("nope");
+      return {};
+    };
+    const s = normalizeEmulation({ device: "pixel-8", tz: "UTC" });
+    const steps = emulationResetCdpSteps(s);
+    const out = await applyEmulationResetSteps(send, steps);
+
+    assert.deepEqual(seen, steps.map((x) => x.method),
+      "every step must be ATTEMPTED — a failure must not abort the undo");
+    assert.deepEqual(out.cleared, [
+      "Emulation.clearDeviceMetricsOverride",
+      "Emulation.setTouchEmulationEnabled",
+      "Emulation.setTimezoneOverride",
+    ]);
+    assert.equal(out.failed.length, 1);
+    assert.equal(out.failed[0].method, "Emulation.setUserAgentOverride");
+    assert.match(out.failed[0].error, /nope/);
+  });
+
 test("applyEmulationSteps propagates the FIRST failure (no optional swallowing)", () => {
   const seen = [];
   const send = async (method) => {
@@ -411,6 +509,7 @@ const sw = {
   elementRect: { x: 10, y: 20, width: 100, height: 40 },
   failMethod: null,        // make one CDP method reject (the failure path)
   hangMethod: null,        // make one CDP method never settle (the no-wedge path)
+  failAttach: false,       // make chrome.debugger.attach reject (refused attach)
 };
 
 function resetSw() {
@@ -421,6 +520,7 @@ function resetSw() {
   sw.tabsRemove = [];
   sw.failMethod = null;
   sw.hangMethod = null;
+  sw.failAttach = false;
   sw.frames = [];
   sw.frameTree = null;
   sw.tabs = new Map([
@@ -458,7 +558,10 @@ globalThis.chrome = {
   },
   windows: { async update() {} },
   debugger: {
-    async attach() { sw.events.push("attach"); },
+    async attach() {
+      sw.events.push("attach");
+      if (sw.failAttach) throw new Error("cdp_attach_refused:test");
+    },
     async detach() { sw.events.push("detach"); },
     async sendCommand(_t, method, params) {
       sw.cdp.push({ method, params });
@@ -672,6 +775,78 @@ test("--reset STOPS re-application (and reports what it stopped)", async () => {
   // …and the fast path is available again.
   assert.ok(sw.events.includes("captureVisibleTab"));
 });
+
+// 🔴 THE REGRESSION TEST FOR #319. It asserts the CDP CALLS `--reset` makes, not
+// the envelope: pre-fix, `--reset` returned reset:true + a populated wasEmulating
+// and sent NOTHING, leaving the tab stuck at the emulated viewport (measured live
+// 2026-08-03: innerWidth still 393 after reset and after a further nav).
+test("--reset SENDS the CDP clears — the tab is actually un-emulated", async () => {
+  fresh();
+  await OPS.emulate({
+    tabId: TAB_A, device: "iphone-15", colorScheme: "dark", tz: "Europe/London",
+    geo: { latitude: 51.5074, longitude: -0.1278 },
+  });
+  sw.cdp = []; sw.events = [];
+
+  const out = await OPS.emulate({ tabId: TAB_A, reset: true });
+
+  const CLEARS = [
+    "Emulation.clearDeviceMetricsOverride",
+    "Emulation.setTouchEmulationEnabled",
+    "Emulation.setUserAgentOverride",
+    "Emulation.setEmulatedMedia",
+    "Emulation.setTimezoneOverride",
+    "Emulation.clearGeolocationOverride",
+  ];
+  assert.deepEqual(methods(), CLEARS,
+    "--reset must UNDO the overrides on the tab; dropping the Map entry alone "
+    + "leaves the viewport permanently emulated (#319)");
+  // Inside ONE session, and it did not stay open.
+  assert.deepEqual(sw.events, ["attach", ...CLEARS, "detach"]);
+  // The clear that the live measurement proved necessary carries the right shape.
+  assert.deepEqual(paramsOf("Emulation.clearDeviceMetricsOverride"), {});
+  assert.deepEqual(paramsOf("Emulation.setTouchEmulationEnabled"), { enabled: false });
+
+  // …and it is REPORTED, so the caller can see what was undone.
+  assert.deepEqual(out.cleared, CLEARS);
+  assert.equal(out.clearFailed, undefined);
+  assert.equal(out.clearError, undefined);
+  assert.equal(emulationState.has(TAB_A), false);
+});
+
+test("--reset REPORTS a clear that the browser refused, and still drops the state",
+  async () => {
+    fresh();
+    await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+    sw.cdp = []; sw.events = [];
+    sw.failMethod = "Emulation.setUserAgentOverride";
+
+    const out = await OPS.emulate({ tabId: TAB_A, reset: true });
+
+    // Best-effort: the failure did not abort the undo…
+    assert.deepEqual(out.cleared, ["Emulation.clearDeviceMetricsOverride",
+                                   "Emulation.setTouchEmulationEnabled"]);
+    assert.equal(out.clearFailed.length, 1);
+    assert.equal(out.clearFailed[0].method, "Emulation.setUserAgentOverride");
+    // …and the metrics clear — the one that matters — went out anyway.
+    assert.ok(methods().includes("Emulation.clearDeviceMetricsOverride"));
+    assert.equal(emulationState.has(TAB_A), false);
+  });
+
+test("--reset does not THROW when CDP refuses to attach — state is dropped anyway",
+  async () => {
+    fresh();
+    await OPS.emulate({ tabId: TAB_A, device: "iphone-15" });
+    sw.cdp = []; sw.events = [];
+    sw.failAttach = true;
+
+    const out = await OPS.emulate({ tabId: TAB_A, reset: true });
+    assert.equal(out.reset, true);
+    assert.deepEqual(out.cleared, []);
+    assert.match(out.clearError, /cdp_attach_refused/);
+    assert.equal(emulationState.has(TAB_A), false,
+      "a reset that cannot reach the browser must still stop re-applying");
+  });
 
 test("--reset on a tab that was never emulated is a clean no-op", async () => {
   fresh();

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -3862,10 +3862,12 @@ def test_git_short_head_none_on_missing_dir(tmp_path):
 
 def test_manifest_version_reads_current():
     v = S.manifest_version(path=EXT_DIR / "manifest.json")
-    # Bumped to 0.7.1 for `text --annotated` inside `--frame` (the extension's
-    # service_worker/protocol changed; no new wire op, so `ping`'s `ops` list
-    # CANNOT discriminate this build — the version and the capability probe are
-    # the only tells). 0.7.0 was the `context` op + enriched read envelopes;
+    # Bumped to 0.7.2 for `emulate --reset` actually CLEARING the CDP overrides
+    # (#319 — the device-metrics viewport survives the debugger detach, so the
+    # old reset left the tab permanently phone-sized). No new wire op, so
+    # `ping`'s `ops` list CANNOT discriminate this build — the version and a
+    # post-reset innerWidth read are the only tells. 0.7.1 was `text
+    # --annotated` inside `--frame`; 0.7.0 the `context` op + enriched read envelopes;
     # 0.6.0 the `documentPredatesEmulation` hint; 0.5.0 the `emulate` op itself;
     # 0.4.0 the poll-loop no-wedge change. The bump is the operator's only
     # falsifiable "is the new build loaded?" signal, so this assertion is
@@ -3878,7 +3880,7 @@ def test_manifest_version_reads_current():
     # answer is a pre-merge gate on the bump, NOT deleting the literal — a
     # derived assertion here would compare the manifest to itself and pin
     # nothing at all.
-    assert isinstance(v, str) and v == "0.7.1"
+    assert isinstance(v, str) and v == "0.7.2"
 
 
 def test_manifest_version_prefers_the_deployed_copy_over_the_repo(tmp_path,
@@ -3899,7 +3901,7 @@ def test_manifest_version_falls_back_to_repo_when_not_deployed(tmp_path,
     reporting the repo manifest instead of going null."""
     monkeypatch.setattr(S, "_DEPLOYED_EXT_MANIFEST", tmp_path / "absent.json")
     monkeypatch.setattr(S, "_EXT_MANIFEST_PATH", EXT_DIR / "manifest.json")
-    assert S.manifest_version() == "0.7.1"
+    assert S.manifest_version() == "0.7.2"
 
 
 def test_manifest_version_none_when_neither_exists(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #319. Related: #316 (the two-width verification pass that found it), #318.

`browser emulate --reset` deleted the in-memory `emulationState` entry and sent
**nothing** to CDP. The premise — asserted in five places as *the* safety property
of the store-and-re-apply design — was that every `Emulation.*` override dies at
the debugger detach. It does not. The device-metrics **viewport size** survives,
so `--reset` reported success while leaving the operator's tab permanently
phone-sized, with `emulationState` empty and nothing left that knew how to undo it.

---

## STEP 1 — which overrides actually survive a `--reset`

#319 measured `innerWidth` only. The fix's step list depends on the rest, so I
measured every class before writing it.

**Method.** 2026-08-03, laptop (`192.168.50.155`), live Brave, extension **0.7.1**,
`personal` profile, operator CLI only (no agent, no PR-branch code — the deployed
extension is unchanged `main`). `https://example.com` in a tab this session opened.
`emulate iphone-15 --color-scheme dark --tz Europe/London --geo 51.5074,-0.1278`,
then a re-`nav` under emulation so the create-time touch API applies. **Every read
taken the same way** (`js --wake` → the CDP path), so the columns are comparable.

🔴 **CONTROL**: a second tab, opened in the same window at the same URL under a
*different* session id, never emulated, read through the identical `js --wake`
path — before and after the whole sequence. It read desktop both times, which is
what makes a "still 393" result on the test tab attributable to the tab rather
than to a broken read or a resized window.

| signal | **CONTROL** (never emulated) | (a) before emulate | (b) after emulate + re-`nav` | (c) after `--reset` | (d) after `--reset` + re-`nav` | verdict |
|---|---|---|---|---|---|---|
| `innerWidth`x`innerHeight` | **1124x1400** | 1124x1400 | 393x852 | 🔴 **393x852** | 🔴 **393x852** | **PERSISTS** |
| `devicePixelRatio` | 1 | 1 | 3 | 1 | 1 | clears at detach |
| `navigator.maxTouchPoints` | 0 | 0 | 5 | 0 | 0 | clears at detach |
| `"ontouchstart" in window` | false | false | true | true¹ | false | document-build residue |
| `matchMedia("(pointer:coarse)")` | false | false | true | false | false | clears at detach |
| `prefers-color-scheme: dark` | false | false | true | false | false | clears at detach |
| `navigator.userAgent` | `X11; Linux x86_64` | `X11; Linux x86_64` | `iPhone; CPU iPhone OS 17_0` | `X11; Linux x86_64` | `X11; Linux x86_64` | clears at detach |
| `Intl…resolvedOptions().timeZone` | `America/Winnipeg` | `America/Winnipeg` | `Europe/London` | `America/Winnipeg` | `America/Winnipeg` | clears at detach |

The control read `1124x1400` again after the sequence finished — the same value as
at the start.

¹ Not an override. The *document* was built under touch emulation and
`ontouchstart` is installed on the global at document creation, so no CDP clear
can remove it; the re-`nav` in column (d) does. Same asymmetry as the
`documentPredatesEmulation` hint, in the opposite direction.

**So exactly one class is sticky: the device-metrics viewport size.** Note that
`devicePixelRatio` — set by the *same* `setDeviceMetricsOverride` call — **does**
revert, which points at the residue being the resized **render widget** rather
than a live override that outlived its session.

Not measured: **geolocation** (reading it requires a permission grant, which would
have meant a prompt on the operator's screen). It is cleared by the fix anyway.

🔴 Both tabs opened for this were closed, the emulated one last. `browser tabs`
afterwards: no leftover tabs, `emulatedTabs: []`.

---

## STEP 2 — the fix

`extension/protocol.js` (pure, browser-free, matching the file's existing split):

* `emulationResetCdpSteps(state)` — the ordered CLEAR list, **derived from the
  state that was in force** rather than a fixed list, so a reset sends exactly the
  undo of what this bridge applied. `Emulation.clearDeviceMetricsOverride` goes
  **first** (it is the one measured to be stuck, so it lands even if a later step
  fails), then `setTouchEmulationEnabled{enabled:false}`,
  `setUserAgentOverride{userAgent:""}`, `setEmulatedMedia{media:"",features:[]}`,
  `setTimezoneOverride{timezoneId:""}`, `clearGeolocationOverride`.
* `applyEmulationResetSteps(send, steps)` — **best-effort**, the deliberate
  opposite of `applyEmulationSteps`. An *apply* must fail loudly (a half-applied
  emulation is a plausible screenshot of the wrong thing); an *undo* must not —
  aborting at the first failure leaves the remaining overrides in place, which is
  the state the undo exists to escape. Returns `{cleared, failed}`.

`extension/service_worker.js` — the browser-facing half. The Map entry is dropped
**first and unconditionally**; the clears then run in one CDP session. A refused
attach or a closed tab is caught and reported as `clearError`, an individual
rejected step as `clearFailed[]` — reset never throws, and never leaves a tab
still being re-emulated. A tab with **no** stored state yields no steps, so reset
stays a zero-CDP, zero-debugger-banner no-op there (the existing test for that is
unchanged and still passes).

**Why the five self-clearing classes are cleared anyway**, stated plainly: they
are not needed by this measurement, but that measurement is one Chromium build on
one host (RULES: one measurement is not a general claim), the clears run inside a
session that is already open, and a clear against a domain holding no override is
a no-op. "Undo what was applied" is worth having independent of which Chromium you
are on. The code comment says which one is measured-necessary and which five are
defensive, so nobody later mistakes the second group for evidence.

**Honest limitation, now documented in the code:** `--reset` derives its clears
from the Map, so it **cannot repair a tab whose state died with an evicted MV3
service worker** — closing the tab remains the remedy there, and that is still the
`SIGKILL`'d-agent path #319 describes.

Extension **0.7.1 → 0.7.2**. `tests/test_server.py`'s version literal is bumped in
the same commit, as that test's own comment requires.

---

## STEP 3 — the false claims, corrected

Each rewritten from what the code now does, not from intent:

* `extension/protocol.js` EMULATION header (the old `:557-580`) — the "overrides
  die at detach → a crashed agent CANNOT leave the browser distorted" block. Now
  states which half dies and which does not, with the measurement and its
  date/host/build.
* `extension/service_worker.js` (the old `:1184`) — "`--reset` … does not need to
  undo anything" → what the undo is, its ordering, and its failure modes.
* the `emulate` response `note` — "Between ops the tab is NOT emulated" → touch/
  UA/media/timezone are gone between ops, the viewport size is not, and a crashed
  agent **can** leave a tab at the emulated size.
* the `--reset` response `note` — "Nothing had to be undone" → what was cleared,
  plus the fact that document-creation properties (`ontouchstart`) are **not**
  undone by a clear and need a re-`nav`. There is now a second `note` for the
  no-stored-state case that says reset sent nothing and cannot repair an evicted
  tab.
* `reference/emulation.md` — the safety-property section is replaced by the
  measurement table above, a "what `--reset` does now" section, and the
  evicted-worker limitation.
* **Two more the issue did not list, same false claim:** `NOT_EMULATED_READ_NOTE`
  (the user-facing string on every non-CDP read) told the caller that
  layout-derived values "are the DESKTOP ones here" — false for
  `innerWidth`/`innerHeight`. It now says a non-CDP read is a **mixture**, which
  is worse than a uniformly-desktop read, not better. And the `browser` CLI's own
  `emulate` help repeated the "a crashed agent can never leave your real browser
  distorted" claim.

**On the `emulated` / `notEmulatedRead` annotation** (raised in the issue, so
saying it explicitly rather than leaving it implied): it keys off the
`emulationState` Map, so pre-fix a reset-but-still-overridden tab carried **no**
emulation fields at all while its viewport was still 393 — the envelope actively
asserted an un-emulated read on an emulated tab. This fix removes that
inconsistency by construction: after a successful `--reset` the tab really is
un-emulated, so "no emulation fields" is true again. It is **not** fixed for the
evicted-worker case, where the Map is empty for a reason the extension cannot
observe — the annotation cannot report state that no longer exists. Nothing was
changed in `annotateEmulatedRead` itself.

---

## STEP 4 — tests

6 new tests in `tests/emulation.test.mjs`, 3 pure + 3 glue. 🔴 They assert the
**reset step list and the resulting CDP calls**, never `ok:true` — the broken
behaviour returned `ok:true`, `reset:true` **and** a populated `wasEmulating`, so
an envelope-shape test passes against the bug.

| # | test | asserts |
|---|---|---|
| 1 | `RESET STEPS: a full emulation undoes EVERY class it applied, in order` | the exact ordered 6 methods **and their params** (a clear with the wrong payload is a no-op that looks like an undo) |
| 2 | `RESET STEPS: derived from what was APPLIED, not a fixed list` | metrics-only → 1 step; media-only → 1 step; an explicit `--no-touch` still gets its undo; `null`/reset → `[]` |
| 3 | `RESET STEPS: applyEmulationResetSteps is BEST-EFFORT and reports the damage` | every step attempted despite a mid-list rejection; the `cleared`/`failed` split |
| 4 | `--reset SENDS the CDP clears — the tab is actually un-emulated` | **the regression test.** `methods()` after reset == the 6 clears, inside one `attach…detach` |
| 5 | `--reset REPORTS a clear that the browser refused, and still drops the state` | `clearFailed`, metrics clear still sent, Map entry gone |
| 6 | `--reset does not THROW when CDP refuses to attach — state is dropped anyway` | `clearError`, no throw, Map entry gone |

### RED → GREEN matrix

Ran by checking out `origin/main`'s **implementation** files (never the test file),
re-running, then restoring:

| tree | node suite | which tests, and with what error |
|---|---|---|
| `origin/main` (all files) | **468 pass / 0 fail** | the stated baseline |
| HEAD, `extension/service_worker.js` reverted to `origin/main` | **471 pass / 3 fail** | tests **4, 5, 6**. #4 fails on its own assertion message with `actual []` against the 6 expected clears — pre-fix, reset sends **nothing** |
| HEAD, **both** `protocol.js` + `service_worker.js` reverted | **0 pass / 1 fail** | `SyntaxError: … does not provide an export named 'EMULATION_RESET_MAX_STEPS'` — a whole-file red. Tests 1–3's red is therefore attributable to the missing implementation but is **not** a per-assertion red; stated rather than glossed. |
| HEAD (all files) | **474 pass / 0 fail** | |

### Counts (parsed from TAP / pytest output, not from exit codes)

```
node --test --test-reporter=tap scripts/browser-bridge/tests/*.test.mjs
  # tests 474   # pass 474   # fail 0   # skipped 0        (main: 468)

nix-shell -p 'python312.withPackages(p:[p.pytest p.psycopg2 p.requests p.minio])' \
  --run "python -m pytest scripts/browser-bridge/tests -q"
  436 passed in 161.41s                                    (main: 436)
```

---

## 🔴 NOT VERIFIED

**This fix is not live-verified.** The measurement in STEP 1 is of the **bug**,
against the currently-deployed 0.7.1 extension. The **fix** has been exercised only
against a mocked `chrome.debugger` — that proves the bridge *sends*
`Emulation.clearDeviceMetricsOverride` in the right order with the right params; it
does **not** prove Chromium restores the viewport when it receives it.

Why it was not verified: a deployed extension change needs `home-manager switch`
**and a FULL Brave restart**, and the operator's `restore_on_startup` is unset, so
a restart loses their tabs. That was deliberately not done.

Specifically unproven:

* that `Emulation.clearDeviceMetricsOverride` actually restores the render widget
  (the widget-residue reading in STEP 1 is an *inference* from `devicePixelRatio`
  reverting, not a measurement of the clear);
* that `setUserAgentOverride{userAgent:""}` is accepted as "no override" on this
  Brave build (it is what DevTools sends; it was not exercised live);
* the geolocation clear at all — never measured in either direction.

### Exact post-restart check, for the operator

After `home-manager switch` on the target host and a **full Brave quit + reopen**:

```bash
export CLAUDE_CODE_SESSION_ID=verify319
B=~/workspace/devrc/scripts/browser-bridge/browser

$B --instance personal ping     # expect extensionVersion 0.7.2 — if 0.7.1, Brave did
                                # not reload; the ↻ button is unreliable, quit fully

T=$($B --instance personal open https://example.com | grep -o '"tabId": [0-9]*' | grep -o '[0-9]*')
$B --instance personal --tab $T js --wake 'innerWidth'   # A: desktop, e.g. 1124
$B --instance personal --tab $T emulate iphone-15
$B --instance personal --tab $T nav https://example.com
$B --instance personal --tab $T js --wake 'innerWidth'   # B: 393
$B --instance personal --tab $T emulate --reset          # reply now carries cleared:[…]
$B --instance personal --tab $T js --wake 'innerWidth'   # <- THE DISCRIMINATING READ
$B --instance personal --tab $T close
```

**The discriminating check is the last read.** It must return the **desktop** width
from step A (e.g. `1124`). `393` means the fix did not take — either Brave is still
running 0.7.1 (check `ping` first) or `clearDeviceMetricsOverride` does not do what
this PR assumes.

Two secondary tells, both cheap: the `--reset` reply should carry a
`cleared: ["Emulation.clearDeviceMetricsOverride", …]` array (absent on 0.7.1), and
`browser tabs` should show `emulatedTabs: []` with no `emulation` block on that tab.

If the last read still says `393` on a confirmed-0.7.2 build, **that is a real
finding, not a deploy problem** — reopen #319 with it; the reset would then need a
different remedy (e.g. an explicit `setDeviceMetricsOverride` back to the real
window metrics before clearing).

Nothing was deployed, no `home-manager switch` was run, Brave was never restarted,
and PR #318's branch was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
