### PR TITLE
fix(browser-bridge): bump extension to 0.7.3 so the corrected reset note is detectable

### DIFF
--- a/scripts/browser-bridge/extension/README.md
+++ b/scripts/browser-bridge/extension/README.md
@@ -273,6 +273,27 @@ If `ping` still reports the old version after ↻, **fully quit and reopen Brave
 > three full Brave restarts in a single session. (0.3.0 → 0.3.1 was exactly
 > this: adding `id` to `ping`'s reply is a discriminator, so it got a bump.)
 
+> **0.7.3 — the `emulate --reset` note stops claiming the viewport was restored.**
+> Prose only; no wire-op or behaviour change, so `ping`'s `ops` list cannot
+> discriminate it. The version bump exists because the corrected note shipped in
+> #321 with NO bump, which made it undetectable — and because 0.7.2 (an unmerged
+> branch build) was live on the laptop, so on-disk 0.7.1 read as OLDER than the
+> running build and `extension_stale` went true for both profiles on a tree that
+> was actually current. 0.7.2 is deliberately skipped: it was never on `main`.
+> The discriminator is the note text itself:
+>
+> ```bash
+> browser open https://example.com && browser emulate iphone-15
+> browser emulate --reset          # read `.note`
+>   # ≤0.7.1 → "…overrides CLEARED on the tab" (false for the viewport)
+>   # 0.7.3  → says the viewport is NOT restored; points at --reset --recreate
+> ```
+>
+> 🔴 The viewport stickiness itself is UNFIXED and the mechanism is unexplained —
+> `Emulation.clearDeviceMetricsOverride` is sent and acknowledged and the size
+> survives it, along with a re-nav. Replacing the tab is the only known remedy
+> (`emulate --reset --recreate`). See #319.
+
 > **0.7.1 — `text --annotated` inside `--frame`.** No new wire op, so `ping`'s
 > `ops` list is byte-identical to 0.7.0's and cannot discriminate this build.
 > The discriminator is the **capability itself**, and it is exact — it exercises

--- a/scripts/browser-bridge/extension/manifest.json
+++ b/scripts/browser-bridge/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Browser Bridge (command channel)",
-  "version": "0.7.1",
+  "version": "0.7.3",
   "description": "Lets a local Claude Code skill drive the active Brave tab (getHtml/eval/tabs/nav/screenshot/frames/click/type/key/activate/upload/emulate/ping) via a loopback, token-authenticated rendezvous server. Local-only, authorized personal automation.",
   "permissions": ["scripting", "tabs", "activeTab", "storage", "alarms", "debugger", "webNavigation"],
   "host_permissions": ["http://127.0.0.1:8788/*", "<all_urls>"],


### PR DESCRIPTION
Follow-up to #321, which corrected the `emulate --reset` note but shipped it with **no manifest bump**.

## Why this is needed

Per this repo's own contract (`extension/README.md`): an extension change that must be provably loaded needs a version bump **and** a discriminator. As merged, #321's note fix had neither — `ping` returns the same version and a byte-identical `ops` list, so "is the corrected note loaded?" was unfalsifiable.

It also left staleness detection **inverted** on the laptop. An unmerged 0.7.2 branch build was deployed there during the #319 investigation, so on-disk `main` (0.7.1) read as *older* than the running build:

```
LIVE ext version: 0.7.2
server expects:   0.7.1
  personal live 0.7.2 stale=True
  work     live 0.7.2 stale=True
```

Both profiles reported stale against a tree that was actually current. 0.7.2 is skipped deliberately — it was never on `main`.

## Discriminator

Prose-only change, so the note text is the discriminator:

```bash
browser open https://example.com && browser emulate iphone-15
browser emulate --reset          # read .note
  # <=0.7.1 -> "...overrides CLEARED on the tab"  (false for the viewport)
  # 0.7.3   -> says the viewport is NOT restored; points at --reset --recreate
```

## Scope

- `manifest.json` 0.7.1 -> 0.7.3
- `extension/README.md` version-history entry

Node suite **480/480** on this branch (unchanged from `main` — no code paths touched). Nothing pinned 0.7.1 as a current version; the remaining references are historical notes.

🔴 **Still unfixed, and stated in the entry:** the sticky viewport itself. `Emulation.clearDeviceMetricsOverride` is sent and acknowledged and the size survives it, along with a re-nav. Tab replacement (`emulate --reset --recreate`) is the only known remedy. Mechanism unexplained — see #319.

**Not verified:** takes effect only after `home-manager switch` + a FULL Brave restart, which this PR does not perform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)