### PR TITLE
feat(espanso): give the :eos ritual an eviction half

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -102,8 +102,21 @@ in
 
           # Workflows
           # (:whn removed 2026-07-06 — 0 fires over the audit window, superseded by
-          #  /handoff + :eos which ends "…then write the handoff to proceed in next session")
-          { trigger = ":eos"; replace = "reflect on work done and key learnings this session then identify skills and documentation that may need updating, then dispatch subagent to update those skills and any relevant docs, then do the handoff to proceed in next session"; label = "End-of-session ritual: review → update skills/docs → handoff"; search_terms = ["end" "session" "wrap" "handoff" "skills" "review" "update" "docs" "ritual"]; }
+          #  /handoff + :eos, which now OPENS with the handoff rather than ending on it)
+          # 2026-08-04: rewritten to carry an EVICTION half. Every verb in the old text
+          # was additive ("identify skills that may need updating" → "update those
+          # skills"), and the subagent it dispatched arrived with no byte budget and no
+          # view of the file's size, so appending was the cheapest way to comply.
+          # Measured downstream over 30 days: 5,355 lines added vs 863 deleted across
+          # every SKILL.md — 84% of edit volume pure addition. app-blocks/SKILL.md grew
+          # 42,425 B in a single day (2026-08-03→04), more than the whole 40,960 B cap.
+          # The ritual also asked for a reflection on "work done this session", which is
+          # session-SHAPED, so the subagent wrote session-shaped blocks: 42 dated
+          # `### Session …` headings, 43% of that file. Handoff now comes FIRST so the
+          # narrative has a home before any skill is touched. This is the weak half —
+          # a snippet enforces nothing; the gate is what makes it stick. See
+          # /prune-skill + scripts/skill-audit.py.
+          { trigger = ":eos"; replace = "reflect on work done and key learnings this session, then write the handoff FIRST — all session narrative, status and what-shipped goes THERE, never into a skill. Then extract only the durable reusable lessons, and name the single skill or doc that should own each. Then dispatch subagent to fold them in under these rules: report each target file's byte size before and after; every edit must be net-neutral or smaller — evict, merge or demote something stale in the SAME edit; never append a dated session block to a SKILL.md; collapse a retraction to a one-line do-not-re-derive tell rather than preserving the superseded belief; if a file is over budget with nowhere to demote to, say so instead of appending. Then give me the kickoff message."; label = "End-of-session ritual: handoff first → durable lessons only → net-neutral skill edits"; search_terms = ["end" "session" "wrap" "handoff" "skills" "review" "update" "docs" "ritual" "prune" "evict" "bloat"]; }
           { trigger = ":acq"; replace = "dispatch subagent to process feedback\nask me clarifying questions and recommend anything you think would be useful to include before dispatching (include complete test coverage)"; label = "Ask clarifying questions + suggest additions"; search_terms = ["ask" "clarify" "clarifying" "questions" "elicit" "scope" "include"]; }
           { trigger = ":kickoff"; replace = "give me the kickoff message to copy paste to next session"; label = "Kickoff message for next session"; search_terms = ["kickoff" "kick off" "next session" "copy paste" "handoff" "message"]; }
           # Removed 2026-07-25 via /espanso-audit — all keylog-evidence-backed:


### PR DESCRIPTION
feat(espanso): give the :eos ritual an eviction half

The end-of-session ritual was the bloat engine for every SKILL.md in the
fleet. Every verb in it was additive — "identify skills and documentation
that may need updating, then dispatch subagent to update those skills" — and
the subagent it dispatched arrived with a narrow mandate, no byte budget, and
no view of the target file's size. Appending was the cheapest way to comply.

Measured downstream in datapacket-talos over 30 days: 5,355 lines added
against 863 deleted across all SKILL.md files, i.e. 84% of edit volume was
pure addition. app-blocks/SKILL.md grew 42,425 B in a single day
(2026-08-03 to 08-04) — more than the entire 40,960 B hard cap, in one file,
in 24 hours. It now sits at 784,861 B, about 196k tokens, which does not fit
a 200k context at all.

The ritual also asked for a reflection on "work done this session", which is
session-SHAPED output, so the subagent wrote session-shaped blocks: 42 dated
"### Session ..." headings making up 43% of that file. And because the
handoff came LAST and separately, the same narrative got written twice — once
into the skill, where it costs tokens on every future invocation forever, and
once into the handoff doc, where it belongs and costs nothing.

Four changes: the handoff moves FIRST so the narrative has a home before any
skill is touched; "documentation that may need updating" becomes durable
reusable lessons only, each named to a single owning file; the dispatched
subagent is given an explicit net-neutral-or-smaller constraint plus a
before/after byte report; and it is given permission to REFUSE — to say a
file is over budget with nowhere to demote to, rather than append anyway.

What this does NOT do is enforce anything. A snippet is steering, and it will
decay: the subagent can ignore it and a future session can reword it. It
lowers the rate of bloat. The structural fix is a size gate, and the intended
companion is a no-growth ratchet in the datapacket-talos delta-gate engine.
Treat this as the weak half of the pair.

Pairs with /prune-skill and scripts/skill-audit.py (#300).
