### PR TITLE
fix(browser-bridge): a BUILD MARKER that travels with the code — extension_stale can finally see a stale profile (#324)

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -80,18 +80,34 @@ design when two profiles were connected).
   `~/.local/share/browser-bridge-ext/`, falling back to the repo copy). It answers
   "am I on the laptop or the workbench, and which profile?" in one shot (both
   hosts are hostname `nixos`).
-  **Explicit staleness verdict.** Each instance carries `extension_version`
-  (loaded), `extension_version_expected`, and **`extension_stale`**: `true` (the
-  loaded build differs → reload it), `false` (versions match), or **`null` =
-  undecidable** — the instance reports no version (a build predating the
-  `X-Bridge-Ext-Version` poll header) or no manifest is readable. `null` is never
-  "fine"; the server does not guess. This replaces the earlier "eyeball two
-  strings" arrangement, which existed only because the manifest version was not
-  bumped per-change — bumping it is now part of the change contract.
-  ⚠ `extension_stale:false` is a **version** match, not a code match: a change
-  shipped without a manifest bump is invisible to it, and it says nothing about
-  WHICH DIRECTORY the build came from. The deterministic checks are
-  **`browser ping`** and the per-instance **`extension_id`** (below).
+  **Explicit staleness verdict — computed from the BUILD MARKER (#324).** Each
+  instance carries `extension_version` (loaded), `extension_version_expected`,
+  `extension_build`, `extension_build_expected`, and **`extension_stale`**:
+  `true` (this profile is running code that is not the deployed code → Remove +
+  Load unpacked it), `false` (**verified current**), or **`null` = undecidable**.
+  The bridge carries `extension_build_current` alongside
+  `extension_version_current`.
+
+  🔴 The verdict is **not** a version comparison, and cannot be. `extension_version`
+  is `chrome.runtime.getManifest().version` — read off the on-disk manifest at
+  call time — and `extension_id` is derived from the load PATH, so **both describe
+  the DIRECTORY, not the code that is executing**. MEASURED 2026-08-04: two Brave
+  profiles loading the SAME directory reported an identical id, an identical
+  `0.7.3` and `extension_stale: false`, while one ran `main` and the other an
+  unmerged 0.7.2 build whose source existed on no disk. `extension_build` is a
+  generated LITERAL (`extension/build_id.js`) that the service worker **imports**,
+  so it is frozen into the loaded module graph and travels with the code — a stale
+  worker reports the stale marker by construction.
+
+  🔴 **It FAILS CLOSED.** A marker missing on *either* side — an extension build
+  predating #324, or an unreadable/undeployed source tree — yields `null`, never
+  `false`. `false` means verified-current and nothing else; `null` is never
+  "fine". Staleness is also **per profile**: one can be current while another is
+  not, at the same instant, from one directory.
+  ⚠ A marker still cannot see a change you made and never deployed, and it says
+  nothing about WHICH DIRECTORY the build came from — for that, read
+  **`extension_id`** (below), and prefer a behavioural discriminator when the
+  change has one.
   Each instance also carries **`extension_id`** (`chrome.runtime.id`, path-derived
   for an unpacked extension), and the bridge carries **`extension_dir_expected`**
   (the directory Brave should be pointed at). The server never computes an
@@ -981,18 +997,28 @@ NOT swap in the new build. Symptom of a stale extension: a NEW op (e.g. `upload`
 on a pre-0.2.0 build) returns a server-side op-level **`unknown_op`** — the server
 knew the op and dispatched it, but the old service worker didn't. The **CLI maps
 that to a clear reload/restart message + non-zero exit**, and **`browser health`
-shows the loaded `extension_version` vs `extension_version_current` plus an
-explicit `extension_stale` verdict** so you can confirm. If a reload doesn't take,
-**fully quit and reopen Brave** (never `pkill` it — `restore_on_startup` is unset
-on both profiles, so the operator's tabs would be gone for good).
+shows the loaded `extension_build` vs `extension_build_current` plus an
+explicit `extension_stale` verdict** so you can confirm. 🔴 A full quit/reopen of
+Brave has been MEASURED not to be sufficient either (2026-08-04: oldest browser
+process 392 s, deploy 9 h earlier, still running the old code) — the reliable
+step is a **per-profile Remove + Load unpacked** at `brave://extensions`. Never
+`pkill` Brave — `restore_on_startup` is unset on both profiles, so the operator's
+tabs would be gone for good.
 
 ### `browser ping` — the deterministic "is the new build loaded?" probe
 
 ```bash
 browser --instance <label> ping
-# NEW → {"pong":true,"extensionVersion":"0.4.0","id":"<ext-id>","ops":[…,"ping"]}
+# NEW → {"pong":true,"extensionVersion":"0.8.0","buildMarker":"<hex>","id":"<ext-id>","ops":[…]}
 # OLD → op 'ping' returned unknown_op — … FULLY RESTART Brave …        (exit 1)
 ```
+
+🔴 **Read `buildMarker`.** It is the only field that describes the RUNNING CODE
+(a literal in the loaded module graph); `extensionVersion` and `id` both describe
+the load DIRECTORY, so two profiles on one directory report identical values
+while running different code (#324). Compare it against `whoami`'s
+`bridge.extension_build_current`, and check **every** profile — staleness is
+per-profile.
 
 Pass `--instance`: with two profiles connected, a bare call gets
 `409 ambiguous_instance` instead of an answer.
@@ -1406,14 +1432,17 @@ per-session (multi-step **workflow**) isolation did not.
   The multi-instance `--instance` targeting, ambiguity/supersede semantics, and
   telemetry are unchanged.
 
-`GET /health` → `{"ok":true,"extension_connected":bool,"count":N,"extension_version_current":"<deployed-else-repo manifest>","instances":[{key,label,instanceId,activeTab,extension_version,extension_id,extension_version_expected,extension_stale},…]}`.
+`GET /health` → `{"ok":true,"extension_connected":bool,"count":N,"extension_version_current":"<deployed-else-repo manifest>","extension_build_current":"<deployed-else-repo build_id.js>","instances":[{key,label,instanceId,activeTab,extension_version,extension_id,extension_build,extension_version_expected,extension_build_expected,extension_stale},…]}`.
 Each instance carries its **loaded `extension_version`** (from the `X-Bridge-Ext-Version`
 poll header; `null` until a build that reports it), its **`extension_id`** (from
 `X-Bridge-Ext-Id`; `null` likewise — this is the path-derived
-`chrome.runtime.id`, i.e. WHICH DIRECTORY was loaded), the
-`extension_version_expected`, and the explicit **`extension_stale`** verdict
-(`true`/`false`/`null`=undecidable).
-`extension_version_current` is the manifest the server expects Brave to have loaded:
+`chrome.runtime.id`, i.e. WHICH DIRECTORY was loaded), its **`extension_build`**
+(from `X-Bridge-Ext-Build` — the BUILD MARKER of the code actually EXECUTING,
+`null` on a build predating #324), both `_expected` values, and the explicit
+**`extension_stale`** verdict (`true`/`false`/`null`=undecidable), which is
+computed from the MARKER and **fails closed** to `null` when either side lacks one.
+`extension_version_current` is the manifest the server expects Brave to have loaded
+and `extension_build_current` the marker in the `build_id.js` beside it:
 the deployed `~/.local/share/browser-bridge-ext/` copy, else the repo one.
 `GET /instances` → `{"ok":true,"count":N,"instances":[…]}`.
 
@@ -1919,9 +1948,9 @@ systemctl --user status browser-bridge
 3. Open the extension's **options** (⋯ → Options / "Extension options"), paste the
    token from `~/.config/browser-bridge/token`, port `8788`, **Save**.
 4. `scripts/browser-bridge/browser health` → `{"ok":true,"extension_connected":true}`
-   with `extension_stale:false` on the instance, and
+   with `extension_stale:false` on the instance (`null` = undecidable, NOT ok), and
    `scripts/browser-bridge/browser --instance <label> ping` →
-   `{"pong":true,"extensionVersion":"0.4.0","id":"<ext-id>",…}` (an `unknown_op`
+   `{"pong":true,"extensionVersion":"0.8.0","buildMarker":"<hex>","id":"<ext-id>",…}` (an `unknown_op`
    here means Brave is still running an older build). Record that `id` — it is
    the per-profile baseline for "which directory is loaded".
 5. Focus a tab where you are **logged in** (e.g. Gmail), then

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -55,8 +55,8 @@ Result payloads land under `.result.data`.
 | command | does |
 |---|---|
 | `whoami` | **read-only identity** (global; no `--instance`/`--tab`) — host label (`laptop`/`workbench`), connected instances (active-tab **domain** only), bridge diagnostics, `extension_version_current` |
-| `health` / `instances` | connected instances + count (`instances` as JSON: key, label, instanceId, active-tab url/title), each with an explicit `extension_stale` verdict (`true`/`false`; `null` = undecidable) |
-| `ping` | **which extension build+dir is loaded?** → `{pong,extensionVersion,id,ops}`; older build → `unknown_op`. The only deterministic answer after a ↻ reload |
+| `health` / `instances` | connected instances + count (JSON: key, label, instanceId, tab url/title), each with an `extension_stale` verdict from the BUILD MARKER, not the version (`null` = undecidable, fails closed) |
+| `ping` | **which extension CODE is loaded?** → `{pong,extensionVersion,buildMarker,id,ops}`; read `buildMarker` — version+id describe the DIRECTORY. Staleness is PER PROFILE |
 | `context` | **page metadata, no DOM read** — url/domain/path/query/title/tabId, tab-scoped. Cheapest read; ⚠ NOT a render check → `reference/read-envelopes.md` |
 | `open [url] [--wake[=MS]]` | open a NEW tab this session owns (default `about:blank`, **created in the BACKGROUND/hidden**), returns `tabId`. Idempotent — a re-`open` does NOT navigate (url DISCARDED). Use for multi-step work |
 | `close` / `release` | close this session's owned tab / drop ownership without closing it |

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -41,12 +41,23 @@
 #                               ~/.local/share/browser-bridge-ext/, else the repo
 #                               copy). Each instance also carries an explicit
 #                               `extension_stale` verdict (true/false, or null =
-#                               undecidable) and its `extension_id`
+#                               undecidable) — computed from the BUILD MARKER
+#                               (`extension_build` vs bridge.extension_build_current),
+#                               NOT from the version: the version and the id both
+#                               describe the load DIRECTORY, so two profiles on one
+#                               directory reported identical values while running
+#                               different code (#324). It FAILS CLOSED: either side
+#                               missing a marker -> null, never false. And its
+#                               `extension_id`
 #                               (chrome.runtime.id — WHICH DIRECTORY it was
 #                               loaded from), plus bridge.extension_dir_expected.
 #                               Global (no --instance/--tab).
 #   browser ping              — BUILD-FRESHNESS PROBE: ask the loaded extension
-#                               what it is. Prints {pong,extensionVersion,id,ops}
+#                               what it is. Prints
+#                               {pong,extensionVersion,buildMarker,id,ops}.
+#                               `buildMarker` is the only field that describes the
+#                               RUNNING CODE (a literal in the loaded module graph);
+#                               extensionVersion + id describe the directory (#324)
 #                               on a CURRENT build; a build older than this op
 #                               fails with `unknown_op` and the reload/restart
 #                               hint. Use this — not two version strings — to

--- a/scripts/browser-bridge/extension/README.md
+++ b/scripts/browser-bridge/extension/README.md
@@ -12,6 +12,7 @@ or merge them.
 | `manifest.json`     | MV3 manifest (permissions, icons, background SW, options page) |
 | `service_worker.js` | long-poll loop + chrome.* op executors (needs real Brave) |
 | `protocol.js`       | pure op-set / validation / envelope / backoff + registration payload (unit-tested) |
+| `build_id.js`       | **GENERATED** — the `BUILD_MARKER` literal that travels with the CODE (#324). Regenerate with `python3 scripts/browser-bridge/gen-build-marker.py`; CI fails if it is stale |
 | `options.html/js`   | one-time setup: bearer token + port + optional **label** → `chrome.storage.local` |
 | `icons/icon.svg`    | gruvbox bridge/link glyph — the SVG source |
 | `icons/icon-{16,32,48,128}.png` | rasterised icons wired into the manifest (regenerate with `rsvg-convert`, see `../README.md`) |
@@ -257,21 +258,85 @@ MV3 service worker alive, so a reload often no-ops. Never assume it took —
 
 ```bash
 browser --instance <label> ping
-  # new build → {"pong":true,"extensionVersion":"<manifest version>","id":"…",…}
+  # new build → {"pong":true,"extensionVersion":"…","buildMarker":"…","id":"…",…}
   # old build → op 'ping' returned unknown_op …                  (non-zero exit)
 # --instance matters: with two profiles connected, a bare call gets
 # 409 ambiguous_instance rather than an answer.
 ```
 
-If `ping` still reports the old version after ↻, **fully quit and reopen Brave**
-(never `pkill` it — tabs are not restorable).
+🔴 **Read `buildMarker`, not `extensionVersion` — and check EVERY profile.**
+`extensionVersion` is `chrome.runtime.getManifest().version`, read off the
+on-disk manifest at call time, and `id` is derived from the load PATH. Both
+therefore describe the **directory**, not the code that is executing.
+
+> **MEASURED 2026-08-04 (laptop, #324).** Two Brave profiles loading the SAME
+> directory reported an identical `extension_id`, an identical `0.7.3`, and
+> `extension_stale: false` — while one was executing `main` and the other an
+> unmerged 0.7.2 build whose source was present **on no disk** (`grep -ra` over
+> the whole deployed tree and the whole repo found nothing). Three further facts
+> from that session, all re-measured at the time:
+>
+> * **A full browser restart is NOT sufficient.** Brave was genuinely fresh —
+>   oldest browser process 392 s old, deploy 9 h earlier — and still ran the old
+>   code. Restarting the `browser-bridge` service did not help either.
+> * **Per-profile Remove + Load unpacked at `brave://extensions` IS what
+>   reloads it.** After doing it in both profiles, both ran `main`.
+> * **Staleness is PER PROFILE.** One profile was current and the other was not,
+>   at the same instant, on one host, from one directory. Checking one profile
+>   tells you nothing about the other.
+>
+> The mechanism (how a freshly-started browser executes a service worker whose
+> source is on no disk) is still **UNEXPLAINED**. The operational facts above
+> are measured; do not let a plausible story about MV3 worker caching harden
+> into a finding.
+
+If `ping` still reports the old `buildMarker` after ↻, do the **per-profile
+Remove + Load unpacked** — a full Brave quit/reopen has been measured NOT to be
+enough (never `pkill` Brave — tabs are not restorable).
 
 > **CONTRACT for an extension change that must be provably loaded:** bump
-> `manifest.json`'s `version` AND add a new discriminator the old build cannot
-> fake — a new op name, or a new field in `ping`'s reply. `ping` itself exists
-> because "is the new build loaded?" was previously unfalsifiable, which cost
-> three full Brave restarts in a single session. (0.3.0 → 0.3.1 was exactly
-> this: adding `id` to `ping`'s reply is a discriminator, so it got a bump.)
+> `manifest.json`'s `version`, add a `> **X.Y.Z — …**` changelog block below
+> (gated), and **regenerate the build marker**:
+>
+> ```bash
+> python3 scripts/browser-bridge/gen-build-marker.py    # rewrites extension/build_id.js
+> ```
+>
+> The **build marker is now the mechanical discriminator** and it needs no
+> per-change cleverness: `BUILD_MARKER` is a generated literal in `build_id.js`
+> that `service_worker.js` **imports**, so it is frozen into the loaded module
+> graph and travels with the CODE. A stale worker reports the stale marker by
+> construction, and the server compares it against the marker in the deployed
+> source (`bridge.extension_build_current`) to produce `extension_stale` — which
+> **fails closed**: either side missing a marker yields `null`, never `false`.
+> `false` now means *verified current*.
+>
+> A behavioural discriminator (a new op name, a new `ping` field, a specific
+> string the old build cannot emit) is still worth adding when one is natural —
+> it exercises the changed line rather than a reported value, and it is the only
+> check that survives a spoofed or mis-generated marker. But it is no longer the
+> only thing standing between you and a false all-clear. (`ping` itself exists
+> because "is the new build loaded?" was once unfalsifiable, which cost three
+> full Brave restarts in a single session.)
+
+> **0.8.0 — the BUILD MARKER: `ping` gains `buildMarker`, and `extension_stale`
+> is computed from it instead of from the version (#324).** New generated file
+> `build_id.js` exporting a `BUILD_MARKER` literal, imported by
+> `service_worker.js` and sent on every `/poll` as `X-Bridge-Ext-Build`. The
+> discriminator is the new `ping` field itself — an older build cannot fake it:
+>
+> ```bash
+> browser --instance <label> ping
+>   # ≤0.7.3 → {"pong":true,"extensionVersion":"0.7.3","id":"…","ops":[…]}   (no buildMarker)
+>   # 0.8.0  → {"pong":true,"extensionVersion":"0.8.0","buildMarker":"<hex>","id":"…","ops":[…]}
+> browser whoami   # each instance: extension_build + extension_stale
+>                  # bridge.extension_build_current = the deployed source's marker
+> ```
+>
+> On a profile still running ≤0.7.3 the marker is absent, so `extension_stale`
+> reads **`null`** (undecidable) rather than `false` — that is the fail-closed
+> behaviour, not a bug. It becomes `false` only once a profile reports a marker
+> matching the deployed one.
 
 > **0.7.3 — the `emulate --reset` note stops claiming the viewport was restored.**
 > Prose only; no wire-op or behaviour change, so `ping`'s `ops` list cannot

--- a/scripts/browser-bridge/extension/build_id.js
+++ b/scripts/browser-bridge/extension/build_id.js
@@ -1,0 +1,27 @@
+// build_id.js — the browser-bridge extension's BUILD MARKER (#324).
+//
+// GENERATED. Do not hand-edit; regenerate with:
+//     python3 scripts/browser-bridge/gen-build-marker.py
+// `scripts/browser-bridge/tests/test_server.py` recomputes this value from the
+// extension source on every CI run and fails if it is stale, naming that
+// command.
+//
+// 🔴 WHY THIS IS A LITERAL, AND WHY EVERY RUNTIME-READ ALTERNATIVE IS WRONG.
+// The question this answers is "is the code executing right now the code I
+// deployed?". A value that a running service worker COMPUTES by reading disk
+// cannot answer it, because the disk is the thing that was updated — a stale
+// worker reads the NEW file and reports the NEW value. That is precisely the
+// bug in #324: `chrome.runtime.getManifest().version` reads the on-disk
+// manifest, and `chrome.runtime.id` is derived from the load PATH, so both
+// describe the DIRECTORY rather than the running code. Measured 2026-08-04:
+// two Brave profiles on ONE directory reported the same id, the same 0.7.3 and
+// `extension_stale: false` while executing different code.
+//
+// So do NOT "simplify" this to any of:
+//   * fetch(chrome.runtime.getURL("build_id.json"))  — reads disk at runtime
+//   * chrome.runtime.getManifest().version            — reads disk at runtime
+//   * a value written into chrome.storage.local       — survives a code swap
+//   * a hash computed in the worker over its own source — same disk read
+// The marker must be a LITERAL in a module the worker imported, so that it was
+// frozen into the loaded module graph at load time and travels with the code.
+export const BUILD_MARKER = "9ca73218873b35fa";

--- a/scripts/browser-bridge/extension/manifest.json
+++ b/scripts/browser-bridge/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Browser Bridge (command channel)",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "Lets a local Claude Code skill drive the active Brave tab (getHtml/eval/tabs/nav/screenshot/frames/click/type/key/activate/upload/emulate/ping) via a loopback, token-authenticated rendezvous server. Local-only, authorized personal automation.",
   "permissions": ["scripting", "tabs", "activeTab", "storage", "alarms", "debugger", "webNavigation"],
   "host_permissions": ["http://127.0.0.1:8788/*", "<all_urls>"],

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -2678,13 +2678,23 @@ export function capHeaderValue(s, max = MAX_HEADER_VALUE_CHARS) {
 // extensions, two paths): id = sha256(absolute path), first 32 hex chars, each
 // nibble 0-f mapped to a-p. PATH ONLY — no per-profile component. So the id is
 // computable in advance; see extension/README.md "The path→id derivation".
-export function pollHeaders(instanceId, label, active, extVersion, extId) {
+// `buildMarker` (#324) is the ONLY one of these three that describes the CODE
+// rather than the directory: it is a generated literal in build_id.js, imported
+// into the worker's module graph, so a stale worker sends the STALE value while
+// `extVersion` (read off the on-disk manifest at call time) and `extId`
+// (path-derived) both report the freshly-deployed directory. Measured
+// 2026-08-04 — two profiles, one directory, identical id + version +
+// `extension_stale: false`, different code. Omitted (→ undecidable, never
+// "current") by a build that predates the marker.
+export function pollHeaders(instanceId, label, active, extVersion, extId,
+                            buildMarker) {
   const h = { "X-Bridge-Instance-Id": String(instanceId || "") };
   if (label) h["X-Bridge-Label"] = encodeURIComponent(capHeaderValue(label));
   if (active && active.url) h["X-Bridge-Active-Url"] = encodeURIComponent(capHeaderValue(active.url));
   if (active && active.title) h["X-Bridge-Active-Title"] = encodeURIComponent(capHeaderValue(active.title));
   if (extVersion) h["X-Bridge-Ext-Version"] = encodeURIComponent(capHeaderValue(String(extVersion)));
   if (extId) h["X-Bridge-Ext-Id"] = encodeURIComponent(capHeaderValue(String(extId)));
+  if (buildMarker) h["X-Bridge-Ext-Build"] = encodeURIComponent(capHeaderValue(String(buildMarker)));
   return h;
 }
 

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -64,6 +64,12 @@ import {
   annotatedTextFn, ANNOTATED_TEXT_MAX_ITEMS_DEFAULT, byteCapElements,
 } from "./protocol.js";
 
+// The BUILD MARKER (#324) — a generated LITERAL that travels with THIS module
+// graph. Imported (not fetched, not read off the manifest) on purpose: see the
+// header comment in build_id.js for why every runtime-read alternative
+// reproduces the bug it fixes.
+import { BUILD_MARKER } from "./build_id.js";
+
 const DEFAULT_PORT = 8788;
 let running = false;
 // Wall-clock (Date.now) stamped at the START of each poll-loop iteration — NOT
@@ -105,6 +111,24 @@ function extensionVersion() {
   }
 }
 
+// The BUILD MARKER of the code that is ACTUALLY EXECUTING (#324) — the one
+// freshness signal that is not a statement about the load directory.
+// `extensionVersion()` above and `extensionId()` below both describe the
+// DIRECTORY: the version is read from the on-disk manifest at call time, and
+// the id is derived from the load path. Measured 2026-08-04 — two profiles on
+// one directory reported the same id, the same version and `extension_stale:
+// false` while running different code. BUILD_MARKER is a literal in an imported
+// module, so a stale worker reports the STALE value by construction.
+// Best-effort ("" if the import is somehow absent, e.g. under a unit-test
+// module mock) — the server treats "" as UNDECIDABLE, never as "current".
+function buildMarker() {
+  try {
+    return (typeof BUILD_MARKER === "string" && BUILD_MARKER) || "";
+  } catch (e) {
+    return "";
+  }
+}
+
 // `chrome.runtime.id` — the extension's ID, which for an UNPACKED extension is
 // derived from the absolute directory Brave loaded it from. That makes it the
 // only signal that distinguishes a repo-path load from a
@@ -128,6 +152,7 @@ async function config() {
     instanceId: await instanceId(),
     extVersion: extensionVersion(),
     extId: extensionId(),
+    extBuild: buildMarker(),
   };
 }
 
@@ -1371,8 +1396,17 @@ const OPS = {
   // component, so two profiles on one directory report one id. The expected id
   // is therefore computable in advance; see extension/README.md "The path→id
   // derivation (MEASURED)".
+  // `buildMarker` (#324) is the field that actually answers the question. Both
+  // `extensionVersion` and `id` describe the DIRECTORY Brave loaded from, so
+  // two profiles on one directory report identical values while running
+  // different code (measured 2026-08-04). The marker is a literal in this
+  // worker's own module graph, so it is a statement about the RUNNING code.
+  // `extensionVersion` is kept — it is still a useful hint and older tooling
+  // reads it — but the server's `extension_stale` verdict is computed from the
+  // marker now, and fails closed (null) when either side lacks one.
   async ping() {
     return { pong: true, extensionVersion: extensionVersion(),
+             buildMarker: buildMarker(),
              id: extensionId(), ops: ALLOWED_OPS.slice() };
   },
 
@@ -1510,7 +1544,7 @@ async function pollOnce(cfg, retired) {
     // Identify this instance so the server routes only its commands here.
     headers: { ...authHeaders(cfg.token),
                ...pollHeaders(cfg.instanceId, cfg.label, active, cfg.extVersion,
-                              cfg.extId) },
+                              cfg.extId, cfg.extBuild) },
     signal: abortAfter(loopTiming().pollMs),
   });
   const kind = classifyPollStatus(res.status);

--- a/scripts/browser-bridge/gen-build-marker.py
+++ b/scripts/browser-bridge/gen-build-marker.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Regenerate `extension/build_id.js` — the build marker that travels WITH the
+extension code.
+
+    python3 scripts/browser-bridge/gen-build-marker.py           # rewrite the file
+    python3 scripts/browser-bridge/gen-build-marker.py --check   # verify only
+
+WHY THIS EXISTS (#324). `ping` used to answer "is the build I just deployed the
+one Brave loaded?" with `chrome.runtime.getManifest().version` and
+`chrome.runtime.id`. Both describe the DIRECTORY the extension was loaded from,
+not the code that is executing: the id is derived from the load path, and the
+version is read off the manifest on disk at call time. Measured 2026-08-04 —
+two Brave profiles loading the SAME directory reported an identical id, an
+identical `0.7.3`, and `extension_stale: false`, while one was executing `main`
+and the other an unmerged 0.7.2 build whose source exists on no disk. No
+version-shaped signal can separate those two rows.
+
+The marker fixes that by being a **literal constant in the extension's own
+loaded module graph**: whatever code is running carries its own marker, so a
+stale worker necessarily reports the stale value.
+
+THE DERIVATION (`compute_marker`) is deliberately the ONE place that defines the
+marker, and both the generator and the CI drift test call it — a second copy is
+how a gate like this drifts into vacuousness.
+
+  sha256 over every `*.js` file in `extension/` (EXCEPT `build_id.js` itself —
+  it must not hash its own output) plus `manifest.json`, sorted by relative
+  path, each contributing `path\\0<len>\\0<bytes>` so a rename or a byte move
+  between files cannot collide. First MARKER_HEX_CHARS hex chars.
+
+`build_id.js` is excluded to avoid the self-reference; that is safe because the
+file contains nothing but the marker, so it has no behaviour of its own to go
+untracked.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+EXT_DIR = Path(__file__).resolve().parent / "extension"
+BUILD_ID_FILE = EXT_DIR / "build_id.js"
+MARKER_HEX_CHARS = 16
+
+# The regeneration command, quoted verbatim in every failure message so a red
+# gate tells you what to run instead of tempting you to delete it.
+REGEN_CMD = "python3 scripts/browser-bridge/gen-build-marker.py"
+
+# Matches the literal in build_id.js. Kept loose on whitespace/quote style but
+# strict on the value: lowercase hex only.
+MARKER_RE = re.compile(
+    r"""BUILD_MARKER\s*=\s*["']([0-9a-f]+)["']""")
+
+
+def marker_inputs(ext_dir=None):
+    """The files the marker hashes, sorted by relative path.
+
+    Every `*.js` under `extension/` except `build_id.js`, plus `manifest.json`.
+    Sorted so the digest is order-independent of the filesystem."""
+    ext_dir = Path(ext_dir) if ext_dir is not None else EXT_DIR
+    files = [p for p in sorted(ext_dir.glob("*.js")) if p.name != "build_id.js"]
+    manifest = ext_dir / "manifest.json"
+    if manifest.is_file():
+        files.append(manifest)
+    return sorted(files, key=lambda p: p.name)
+
+
+def compute_marker(ext_dir=None) -> str:
+    """The marker the extension source in `ext_dir` SHOULD carry.
+
+    Raises rather than returning a digest of nothing: an empty input set would
+    make every caller vacuous (a "matching" marker over zero files), which is
+    the exact harness failure this gate exists to prevent."""
+    files = marker_inputs(ext_dir)
+    if not files:
+        raise AssertionError(
+            f"HARNESS: hashed ZERO files out of {ext_dir or EXT_DIR} — the "
+            f"extension layout changed. Fix this function; do NOT read the "
+            f"empty result as 'nothing to check'.")
+    h = hashlib.sha256()
+    for p in files:
+        body = p.read_bytes()
+        h.update(p.name.encode("utf-8"))
+        h.update(b"\0")
+        h.update(str(len(body)).encode("ascii"))
+        h.update(b"\0")
+        h.update(body)
+    return h.hexdigest()[:MARKER_HEX_CHARS]
+
+
+def read_marker(path=None):
+    """The BUILD_MARKER literal declared in a build_id.js, or None (missing /
+    unreadable / no literal). Best-effort — never raises."""
+    path = Path(path) if path is not None else BUILD_ID_FILE
+    try:
+        m = MARKER_RE.search(path.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001 — best-effort.
+        return None
+    return m.group(1) if m else None
+
+
+def render(marker: str) -> str:
+    return f'''// build_id.js — the browser-bridge extension's BUILD MARKER (#324).
+//
+// GENERATED. Do not hand-edit; regenerate with:
+//     {REGEN_CMD}
+// `scripts/browser-bridge/tests/test_server.py` recomputes this value from the
+// extension source on every CI run and fails if it is stale, naming that
+// command.
+//
+// 🔴 WHY THIS IS A LITERAL, AND WHY EVERY RUNTIME-READ ALTERNATIVE IS WRONG.
+// The question this answers is "is the code executing right now the code I
+// deployed?". A value that a running service worker COMPUTES by reading disk
+// cannot answer it, because the disk is the thing that was updated — a stale
+// worker reads the NEW file and reports the NEW value. That is precisely the
+// bug in #324: `chrome.runtime.getManifest().version` reads the on-disk
+// manifest, and `chrome.runtime.id` is derived from the load PATH, so both
+// describe the DIRECTORY rather than the running code. Measured 2026-08-04:
+// two Brave profiles on ONE directory reported the same id, the same 0.7.3 and
+// `extension_stale: false` while executing different code.
+//
+// So do NOT "simplify" this to any of:
+//   * fetch(chrome.runtime.getURL("build_id.json"))  — reads disk at runtime
+//   * chrome.runtime.getManifest().version            — reads disk at runtime
+//   * a value written into chrome.storage.local       — survives a code swap
+//   * a hash computed in the worker over its own source — same disk read
+// The marker must be a LITERAL in a module the worker imported, so that it was
+// frozen into the loaded module graph at load time and travels with the code.
+export const BUILD_MARKER = "{marker}";
+'''
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--check", action="store_true",
+                    help="exit non-zero if the committed marker is stale")
+    args = ap.parse_args(argv)
+
+    want = compute_marker()
+    have = read_marker()
+    if args.check:
+        if have == want:
+            print(f"build marker OK: {want}")
+            return 0
+        print(f"build marker STALE: build_id.js has {have!r}, extension source "
+              f"hashes to {want!r}. Run: {REGEN_CMD}", file=sys.stderr)
+        return 1
+    BUILD_ID_FILE.write_text(render(want), encoding="utf-8")
+    print(f"wrote {BUILD_ID_FILE} ({have!r} -> {want!r})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/browser-bridge/reference/errors.md
+++ b/scripts/browser-bridge/reference/errors.md
@@ -123,29 +123,51 @@ pre-0.2.0 extension).
 The CLI **detects this for you**: any op the CLI dispatches that returns a
 server-side `unknown_op` is mapped to a clear message + non-zero exit telling you
 the loaded extension is OLDER than the CLI and to reload/restart. **`browser
-health` also shows the build** — each instance's loaded `extension_version`, the
-`extension_version_expected` (the DEPLOYED manifest at
-`~/.local/share/browser-bridge-ext/`, else the repo copy), and an explicit
-`extension_stale` verdict: `true` = reload it, `false` = versions match,
-**`null` = undecidable** (the build predates version reporting, or no manifest is
-readable) — `null` is NOT "fine". `browser whoami` carries the same three fields.
+health` also shows the build** — each instance's loaded `extension_version` and
+`extension_build`, the corresponding `_expected` values (from the DEPLOYED tree
+at `~/.local/share/browser-bridge-ext/`, else the repo copy), and an explicit
+`extension_stale` verdict: `true` = reload it, `false` = **verified current**,
+**`null` = undecidable** — `null` is NOT "fine". `browser whoami` carries the
+same fields plus `bridge.extension_build_current`.
 
-**`extension_stale:false` is a VERSION match, not a code match.** An extension
-change shipped without a manifest bump is invisible to it. That is why the
-version bump is part of the change contract, and why `ping` exists.
+🔴 **The verdict is computed from `extension_build`, NOT from the version
+(#324).** `extension_version` is `chrome.runtime.getManifest().version` (read
+off the on-disk manifest at call time) and `extension_id` is derived from the
+load PATH, so **both describe the DIRECTORY, not the code that is running**.
+MEASURED 2026-08-04: two Brave profiles loading the SAME directory reported an
+identical id, an identical `0.7.3` and `extension_stale: false`, while one ran
+`main` and the other an unmerged 0.7.2 build whose source existed **on no disk**.
+No version-shaped signal can separate those two rows.
 
-🔴 **The concrete shape that gap takes: an op answers `unknown_op` while `health`
+`extension_build` is a generated LITERAL (`extension/build_id.js`) that the
+service worker **imports**, so it is frozen into the loaded module graph and
+travels with the code — a stale worker reports the stale marker by construction.
+The verdict **fails closed**: either side missing a marker → `null`, never
+`false`. A profile still running ≤0.7.3 therefore reads `null`, which is correct.
+
+Two things follow, both measured in the same session:
+
+* **Staleness is PER PROFILE.** One profile can be current while another is not,
+  at the same instant, on one host, from one directory. Check each one.
+* **A full Brave restart is NOT sufficient.** Brave was genuinely fresh (oldest
+  process 392 s, deploy 9 h earlier) and still ran the old code; restarting the
+  bridge service did not help either. **Per-profile Remove + Load unpacked at
+  `brave://extensions` is what reloads it.** The mechanism is UNEXPLAINED —
+  don't let a story about MV3 worker caching harden into a finding.
+
+🔴 **The older shape of this gap: an op answers `unknown_op` while `health`
 reports a MATCHING `extension_version`.** That combination reads as a
 contradiction and sends people debugging the server or the CLI instead. It is not
 a contradiction — the *loaded* worker predates the op even though the manifest
-version agrees. Observed on `wake` (2026-08-01). **Believe the op, not the
-version**, and go straight to the reload/restart ladder below.
+version agrees. Observed on `wake` (2026-08-01). **Believe the op and the build
+marker, not the version**, and go to the reload ladder below.
 
-**⚠ Reload ↻ is UNRELIABLE — a full Brave restart is the reliable fix.** The
-extension's long-poll keeps the OLD service worker permanently alive, so clicking
-↻ in `brave://extensions` often does NOT swap in the new build. If a reload
-doesn't take (the op still returns `unknown_op`, or `health` still shows the old
-`extension_version`), tell the user to **fully quit and reopen Brave**.
+**⚠ Reload ↻ is UNRELIABLE, and a full Brave restart has been measured not to be
+enough either.** The extension's long-poll keeps the OLD service worker alive, so
+↻ often does NOT swap in the new build. If a reload doesn't take (the op still
+returns `unknown_op`, or `ping` still shows the old `buildMarker`), the reliable
+step is a **per-profile Remove + Load unpacked**; try a full quit/reopen first
+only because it is cheaper, not because it is sufficient.
 
 **Nuance (measured 2026-07-30): a ↻ reload DID take** — swapping in a new build after an
 earlier full restart in the same Brave session. So ↻ is worth trying **first**, but only

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -388,6 +388,14 @@ HDR_EXT_VERSION = "X-Bridge-Ext-Version"
 # needs its own PR (see extension/README.md "The path→id derivation (MEASURED)").
 HDR_EXT_ID = "X-Bridge-Ext-Id"
 
+# The BUILD MARKER of the code the instance is actually EXECUTING (#324) — a
+# generated literal in extension/build_id.js that the service worker IMPORTS,
+# so it is frozen into the loaded module graph and travels with the code. This
+# is the field `extension_stale` is computed from; the version is a hint only.
+# Absent from a build that predates the marker → the verdict is null, never
+# false (see annotate_staleness).
+HDR_EXT_BUILD = "X-Bridge-Ext-Build"
+
 # Server-side bounds on EVERY extension-supplied /poll string. protocol.js
 # already caps them, but a client-side cap only binds an honest client — these
 # values arrive over HTTP and are echoed back in every /health, /instances and
@@ -428,6 +436,19 @@ _EXT_MANIFEST_PATH = (_REPO_DIR / "scripts" / "browser-bridge" / "extension"
 # has not switched yet (or a bare checkout) keeps reporting a version.
 _DEPLOYED_EXT_DIR = Path.home() / ".local" / "share" / "browser-bridge-ext"
 _DEPLOYED_EXT_MANIFEST = _DEPLOYED_EXT_DIR / "manifest.json"
+
+# The build-marker source files, deployed-preferred exactly like the manifests
+# above. `build_marker()` reads the LITERAL out of these — it never recomputes a
+# hash at request time, because the expected value must be the one baked into
+# the tree Brave loads, not a fresh digest of whatever the repo looks like now.
+_DEPLOYED_EXT_BUILD_ID = _DEPLOYED_EXT_DIR / "build_id.js"
+_EXT_BUILD_ID_PATH = (_REPO_DIR / "scripts" / "browser-bridge" / "extension"
+                      / "build_id.js")
+
+# Matches the generated `export const BUILD_MARKER = "<hex>";` literal. Kept in
+# sync with gen-build-marker.py's MARKER_RE (the generator owns the derivation;
+# this only has to READ the value, and the drift test gates the pair).
+_BUILD_MARKER_RE = re.compile(r"""BUILD_MARKER\s*=\s*["']([0-9a-f]+)["']""")
 
 # ACTIVITY_HOST source-of-truth file (the activity-collector's env). Parsed as a
 # fallback host signal when ACTIVITY_HOST is not in the server's own environment.
@@ -588,27 +609,75 @@ def manifest_version(path=None):
             or _read_manifest_version(_EXT_MANIFEST_PATH))
 
 
-def annotate_staleness(instances, expected):
+def _read_build_marker(path):
+    """The BUILD_MARKER literal declared in the build_id.js at `path`, or None
+    (missing / unreadable / no literal). Best-effort — never raises."""
+    try:
+        m = _BUILD_MARKER_RE.search(Path(path).read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001 — best-effort.
+        return None
+    return m.group(1) if m else None
+
+
+def build_marker(path=None):
+    """The build marker the code Brave is running SHOULD carry: the deployed
+    extension's build_id.js (`~/.local/share/browser-bridge-ext/`) when present,
+    else the repo copy. None when neither is readable → the verdict goes
+    undecidable, never "current". Mirrors manifest_version()'s
+    deployed-before-repo precedence and its no-.resolve() absolute paths."""
+    if path is not None:
+        return _read_build_marker(path)
+    return (_read_build_marker(_DEPLOYED_EXT_BUILD_ID)
+            or _read_build_marker(_EXT_BUILD_ID_PATH))
+
+
+def annotate_staleness(instances, expected, expected_build=None):
     """Add an explicit loaded-vs-expected verdict to each instance descriptor,
-    IN PLACE, and return the list. `expected` is the manifest version the server
-    expects (manifest_version(), which may itself be None).
+    IN PLACE, and return the list.
+
+    `expected` is the manifest version the server expects (manifest_version()).
+    `expected_build` is the BUILD MARKER read from the deployed extension source
+    (build_marker()). Either may be None.
+
+    🔴 THE VERDICT IS COMPUTED FROM THE MARKER, NOT THE VERSION (#324). The
+    version cannot answer the question it was being asked. `extension_version`
+    is `chrome.runtime.getManifest().version`, read from the on-disk manifest at
+    call time, and `extension_id` is derived from the load PATH — so both
+    describe the DIRECTORY, not the executing code. Measured 2026-08-04: two
+    Brave profiles loading the SAME directory reported an identical id, an
+    identical `0.7.3` and `extension_stale: false`, while one ran `main` and the
+    other an unmerged 0.7.2 build whose source exists on no disk. The build
+    marker is a literal in the worker's own imported module graph, so a stale
+    worker reports the stale value by construction.
 
     `extension_stale` is a yes/no, not two strings to eyeball:
-      True  — this instance reports a version that differs from `expected`
-              (the loaded build is not the deployed one → reload/restart it)
-      False — they match
-      None  — undecidable: the instance predates version reporting, or no
-              manifest is readable. NEVER guess in that case.
-
-    A False here means the VERSION matches; it is not proof the code matches
-    (an unbumped change looks identical). That is exactly why the extension also
-    carries the `ping` op: a new op name cannot be faked by an old build.
+      True  — the marker this instance reports differs from `expected_build`
+              (this profile is running code that is not the deployed code →
+              Remove + Load unpacked it, per profile), or the markers agree but
+              the reported VERSION disagrees (a nonsense state worth flagging).
+      False — the markers are both present and identical. This, and only this,
+              means "verified current".
+      None  — 🔴 UNDECIDABLE, and it FAILS CLOSED to here. Either side missing a
+              marker (a build predating #324, an unreadable/undeployed source
+              tree) yields null. NEVER guess, and never let a version match
+              stand in for a marker: a False that is not marker-backed is
+              exactly the affirmative all-clear that #324 was filed about.
     """
     for inst in instances:
         loaded = inst.get("extension_version")
+        loaded_build = inst.get("extension_build")
         inst["extension_version_expected"] = expected
-        inst["extension_stale"] = (
-            None if (not expected or not loaded) else loaded != expected)
+        inst["extension_build_expected"] = expected_build
+        if not expected_build or not loaded_build:
+            inst["extension_stale"] = None
+            continue
+        stale = loaded_build != expected_build
+        if not stale and expected and loaded and loaded != expected:
+            # Markers agree but versions do not: the deployed tree changed its
+            # manifest without the marker moving, or a header was spoofed.
+            # Either way it is not a verified-current state.
+            stale = True
+        inst["extension_stale"] = stale
     return instances
 
 
@@ -907,11 +976,13 @@ class Instance:
     __slots__ = ("key", "instance_id", "label", "outbox", "results", "waiters",
                  "active_polls", "last_poll", "active_tab", "superseded",
                  "pending", "rl_tokens", "rl_last", "extension_version",
-                 "extension_id", "last_poll_wall", "lost_logged",
+                 "extension_id", "extension_build", "last_poll_wall",
+                 "lost_logged",
                  "last_dispatch", "inflight")
 
     def __init__(self, key, instance_id, label, now, burst=0.0,
-                 extension_version=None, extension_id=None):
+                 extension_version=None, extension_id=None,
+                 extension_build=None):
         self.key = key
         self.instance_id = instance_id
         self.label = label
@@ -929,6 +1000,11 @@ class Instance:
         # (path-derived for an unpacked extension). None until a build that
         # reports it polls. Reported only; never compared to a computed expected.
         self.extension_id = extension_id
+        # The BUILD MARKER of the code this instance is actually EXECUTING —
+        # a literal in the loaded module graph, reported via X-Bridge-Ext-Build.
+        # None until a build that carries it polls (#324). This, not the
+        # version, is what `extension_stale` is computed from.
+        self.extension_build = extension_build
         # Concurrency backstop (per-instance, guarded by the Registry's _cond):
         #   pending   = admitted /cmd dispatches not yet completed (depth cap).
         #   rl_tokens = token-bucket balance; starts FULL so the whole burst is
@@ -1007,7 +1083,7 @@ class Registry:
     # --- registration ------------------------------------------------------ #
     def _register_locked(self, instance_id: str, label: str,
                          active_tab=None, extension_version=None,
-                         extension_id=None) -> Instance:
+                         extension_id=None, extension_build=None) -> Instance:
         if not instance_id:
             # Legacy extension with no handshake → one synthetic unnamed instance.
             instance_id = LEGACY_INSTANCE_ID
@@ -1027,7 +1103,8 @@ class Registry:
             inst = Instance(key, instance_id, label, self._clock(),
                             burst=self._burst,
                             extension_version=extension_version,
-                            extension_id=extension_id)
+                            extension_id=extension_id,
+                            extension_build=extension_build)
             self._instances[key] = inst
         else:
             inst.label = label
@@ -1040,6 +1117,8 @@ class Registry:
             inst.extension_version = extension_version
         if extension_id is not None:
             inst.extension_id = extension_id
+        if extension_build is not None:
+            inst.extension_build = extension_build
         return inst
 
     def _supersede_locked(self, inst: Instance, reason: str) -> None:
@@ -1148,7 +1227,8 @@ class Registry:
 
     # --- extension side ---------------------------------------------------- #
     def poll(self, instance_id: str, label: str, wait_timeout: float,
-             active_tab=None, extension_version=None, extension_id=None):
+             active_tab=None, extension_version=None, extension_id=None,
+             extension_build=None):
         """Long-poll for `instance_id`/`label`: register the instance, then block
         up to `wait_timeout` for ITS next command. Returns the command dict (with
         its id), None on idle timeout, or the SUPERSEDED sentinel if this
@@ -1156,7 +1236,8 @@ class Registry:
         layer maps that to a distinct 409 so the extension backs off — not 204)."""
         with self._cond:
             inst = self._register_locked(instance_id, label, active_tab,
-                                         extension_version, extension_id)
+                                         extension_version, extension_id,
+                                         extension_build)
             inst.active_polls += 1
             inst.last_poll = self._clock()
             inst.last_poll_wall = time.time()
@@ -1673,10 +1754,14 @@ class Registry:
         # extension_id (chrome.runtime.id) says WHICH DIRECTORY that build was
         # loaded from — version alone cannot tell a repo-path load from a
         # deployed-path one, since both report the same manifest version.
+        # extension_build is the marker of the CODE that is running (#324) —
+        # the only one of these three that is not a statement about the load
+        # directory, and the one `extension_stale` is computed from.
         return {"key": inst.key, "label": inst.label,
                 "instanceId": inst.instance_id, "activeTab": inst.active_tab,
                 "extension_version": inst.extension_version,
-                "extension_id": inst.extension_id}
+                "extension_id": inst.extension_id,
+                "extension_build": inst.extension_build}
 
     def snapshot(self):
         """A list of currently-live instances (key/label/instanceId/activeTab)."""
@@ -1703,7 +1788,8 @@ class Registry:
                 "instanceId": inst.instance_id,
                 "activeTabDomain": domain,
                 "extension_version": inst.extension_version,
-                "extension_id": inst.extension_id}
+                "extension_id": inst.extension_id,
+                "extension_build": inst.extension_build}
 
     def whoami_snapshot(self):
         """Per-live-instance whoami descriptors (metadata only — domain, not URL)."""
@@ -2017,8 +2103,8 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
             return obj, None
 
         def _poll_identity(self):
-            """(instance_id, label, active_tab, ext_version, ext_id) from the
-            /poll headers.
+            """(instance_id, label, active_tab, ext_version, ext_id,
+            ext_build) from the /poll headers.
 
             Missing instance id → "" (registry assigns the legacy synthetic id).
             Label + active-tab + ext-version + ext-id strings are URL-encoded by
@@ -2060,7 +2146,12 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
             raw_id = self.headers.get(HDR_EXT_ID)
             ext_id = (unquote(raw_id).strip()[:MAX_IDENTITY_CHARS]
                       if raw_id else None)
-            return instance_id, label, active, ext_version, ext_id
+            # The build marker (#324) — same tight identity cap as the rest; a
+            # build predating it omits the header → None → undecidable verdict.
+            raw_build = self.headers.get(HDR_EXT_BUILD)
+            ext_build = (unquote(raw_build).strip()[:MAX_IDENTITY_CHARS]
+                         if raw_build else None)
+            return instance_id, label, active, ext_version, ext_id, ext_build
 
         def _whoami(self) -> dict:
             """Assemble the read-only whoami snapshot: which HOST + which browser
@@ -2069,7 +2160,9 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
             so it is safe to expose exactly like /health (bearer + Host guarded,
             NOT rate-limited). Reached only after _guard() in do_GET."""
             expected = manifest_version()
-            insts = annotate_staleness(registry.whoami_snapshot(), expected)
+            expected_build = build_marker()
+            insts = annotate_staleness(registry.whoami_snapshot(), expected,
+                                       expected_build)
             rl = registry.rate_limit_config()
             srv_host, srv_port = (self.server.server_address[0],
                                   self.server.server_address[1])
@@ -2093,6 +2186,14 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                     # verdict rather than two strings to compare by eye. null
                     # means undecidable, never "fine".
                     "extension_version_current": expected,
+                    # The BUILD MARKER the server expects the running code to
+                    # carry, read from the deployed extension/build_id.js (#324).
+                    # This is what each instance's `extension_stale` is computed
+                    # against — the version above is a hint only, because it (and
+                    # `extension_id`) describe the load DIRECTORY rather than the
+                    # executing code. null here → every verdict is null, which is
+                    # the honest answer, not "fine".
+                    "extension_build_current": expected_build,
                     # The deploy directory Brave SHOULD have been pointed at.
                     # Reported so an operator can read it next to each instance's
                     # path-derived `extension_id`. The path→id derivation is now
@@ -2122,7 +2223,9 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                 # verdict (true/false/null) so this is a yes/no, not an eyeball
                 # comparison of two strings.
                 expected = manifest_version()
-                insts = annotate_staleness(registry.snapshot(), expected)
+                expected_build = build_marker()
+                insts = annotate_staleness(registry.snapshot(), expected,
+                                           expected_build)
                 known, missing = registry.known_snapshot()
                 # `extension_connected` is DELIBERATELY left as-is: it is a bare
                 # OR over live instances ("is anything up"), which is what
@@ -2137,6 +2240,7 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                                  "extension_connected": bool(insts),
                                  "count": len(insts),
                                  "extension_version_current": expected,
+                                 "extension_build_current": expected_build,
                                  "instances": insts,
                                  "known_instances": known,
                                  "missing": missing})
@@ -2166,11 +2270,12 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                 return
             if path == "/poll":
                 (instance_id, label, active, ext_version,
-                 ext_id) = self._poll_identity()
+                 ext_id, ext_build) = self._poll_identity()
                 cmd = registry.poll(instance_id, label, poll_timeout,
                                     active_tab=active,
                                     extension_version=ext_version,
-                                    extension_id=ext_id)
+                                    extension_id=ext_id,
+                                    extension_build=ext_build)
                 if cmd is SUPERSEDED:
                     # Distinct from the idle 204: THIS connection was displaced by
                     # a newer one sharing its routing key (duplicate label). Still

--- a/scripts/browser-bridge/tests/protocol.test.mjs
+++ b/scripts/browser-bridge/tests/protocol.test.mjs
@@ -267,6 +267,29 @@ test("pollHeaders carries the extension ID — WHICH DIRECTORY Brave loaded", ()
   assert.deepEqual(pollHeaders("uuid-3", ""), { "X-Bridge-Instance-Id": "uuid-3" });
 });
 
+test("pollHeaders carries the BUILD MARKER — WHICH CODE is executing (#324)", () => {
+  // The version and the id both describe the load DIRECTORY: the version is read
+  // off the on-disk manifest at call time, the id is path-derived. MEASURED
+  // 2026-08-04 — two profiles on ONE directory reported an identical id, an
+  // identical 0.7.3 and `extension_stale:false` while running different code.
+  // The marker is a literal in the loaded module graph, so it travels with the
+  // code and is the field the server's staleness verdict is computed from.
+  const h = pollHeaders("uuid-1", "work", null, "0.8.0", "abcdefghijklmnop",
+    "00000000fakemark");
+  assert.equal(h["X-Bridge-Ext-Build"], "00000000fakemark");
+  assert.equal(h["X-Bridge-Ext-Version"], "0.8.0");
+  assert.equal(h["X-Bridge-Ext-Id"], "abcdefghijklmnop");
+  // Optional + backwards-safe like the other identity headers: a build that
+  // predates the marker omits it, and the server then reports the verdict as
+  // null (undecidable) rather than false.
+  assert.equal(
+    pollHeaders("uuid-2", "work", null, "0.7.3", "abcdefghijklmnop")["X-Bridge-Ext-Build"],
+    undefined);
+  assert.equal(pollHeaders("uuid-3", "", null, null, null, "")["X-Bridge-Ext-Build"],
+    undefined);
+  assert.deepEqual(pollHeaders("uuid-4", ""), { "X-Bridge-Instance-Id": "uuid-4" });
+});
+
 // --- poll-response classification: the distinct supersede signal ------------ //
 test("classifyPollStatus distinguishes command / idle / superseded / auth", () => {
   assert.equal(classifyPollStatus(200), POLL_COMMAND);

--- a/scripts/browser-bridge/tests/service_worker.test.mjs
+++ b/scripts/browser-bridge/tests/service_worker.test.mjs
@@ -348,6 +348,33 @@ test("ping: degrades to empty version + id when runtime is bare", async () => {
   assert.equal(out.id, "");
 });
 
+test("ping: reports the BUILD MARKER, and it is INDEPENDENT of chrome.* (#324)", async () => {
+  // 🔴 The property that makes the marker worth having: it comes from the
+  // module graph, NOT from anything the browser can be asked at call time.
+  // extensionVersion and id both come from chrome.runtime — stub those to a
+  // different build entirely and the marker must not move, because it describes
+  // the CODE that is executing rather than the directory it was loaded from.
+  const { BUILD_MARKER } = await import("../extension/build_id.js");
+  assert.match(BUILD_MARKER, /^[0-9a-f]{8,}$/);
+
+  const origRuntime = globalThis.chrome.runtime;
+  globalThis.chrome.runtime = { ...origRuntime, id: "zzzzzzzzzzzzzzzz",
+    getManifest: () => ({ version: "99.99.99" }) };
+  try {
+    const out = await OPS.ping({});
+    assert.equal(out.buildMarker, BUILD_MARKER);
+    assert.equal(out.extensionVersion, "99.99.99");   // control: chrome.* DID move
+    assert.equal(out.id, "zzzzzzzzzzzzzzzz");
+  } finally {
+    globalThis.chrome.runtime = origRuntime;
+  }
+  // …and with a bare runtime (no getManifest, no id) the marker is STILL there:
+  // it never depended on chrome.* in the first place.
+  const bare = await OPS.ping({});
+  assert.equal(bare.buildMarker, BUILD_MARKER);
+  assert.equal(bare.extensionVersion, "");
+});
+
 // --------------------------------------------------------------------------- //
 // `emulate --reset` — THE RUNTIME NOTE IS PINNED CHARACTER FOR CHARACTER.
 //

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -58,6 +58,25 @@ def pinned_manifest(tmp_path, monkeypatch):
     monkeypatch.setattr(S, "_EXT_MANIFEST_PATH", tmp_path / "no-repo-manifest.json")
     return PINNED_VERSION
 
+
+# The build marker the staleness tests pin. Same hermeticity argument as
+# PINNED_VERSION: build_marker() prefers the DEPLOYED extension tree, so a test
+# that asserts a verdict must pin it or it reads the operator's live deploy
+# state. Deliberately not a real marker so a leak is obvious.
+PINNED_BUILD = "deadbeefcafef00d"
+
+
+@pytest.fixture
+def pinned_build(tmp_path, monkeypatch):
+    """Pin build_marker() to PINNED_BUILD, hermetically: a tmp deployed
+    build_id.js + a non-existent repo fallback. Never reads host state."""
+    deployed = tmp_path / "pinned-build_id.js"
+    deployed.write_text(f'export const BUILD_MARKER = "{PINNED_BUILD}";\n',
+                        encoding="utf-8")
+    monkeypatch.setattr(S, "_DEPLOYED_EXT_BUILD_ID", deployed)
+    monkeypatch.setattr(S, "_EXT_BUILD_ID_PATH", tmp_path / "no-repo-build_id.js")
+    return PINNED_BUILD
+
 # The in-repo activity spool emitter (single source of truth for the v1 line
 # format). scripts/browser-bridge/tests/ -> parent.parent.parent == scripts/.
 SPOOL_EMIT_PY = (Path(__file__).resolve().parent.parent.parent
@@ -183,7 +202,7 @@ class FakeExtension(threading.Thread):
 
     def __init__(self, srv, instance_id="fake-1", label="", executor=None,
                  swallow=False, active_url=None, active_title=None,
-                 ext_version=None, ext_id=None):
+                 ext_version=None, ext_id=None, ext_build=None):
         super().__init__(daemon=True)
         self.srv = srv
         self.instance_id = instance_id
@@ -194,6 +213,7 @@ class FakeExtension(threading.Thread):
         self.active_title = active_title
         self.ext_version = ext_version  # reported via X-Bridge-Ext-Version (or None)
         self.ext_id = ext_id            # reported via X-Bridge-Ext-Id (or None)
+        self.ext_build = ext_build      # reported via X-Bridge-Ext-Build (or None)
         self.dispatched = []    # every command this fake picked up (for assertions)
         self._stopev = threading.Event()
 
@@ -209,6 +229,8 @@ class FakeExtension(threading.Thread):
             h[S.HDR_EXT_VERSION] = urllib.parse.quote(self.ext_version)
         if self.ext_id:
             h[S.HDR_EXT_ID] = urllib.parse.quote(self.ext_id)
+        if self.ext_build:
+            h[S.HDR_EXT_BUILD] = urllib.parse.quote(self.ext_build)
         return h
 
     def run(self):
@@ -4023,6 +4045,126 @@ def test_manifest_version_matches_the_declared_build():
 PINNED_EXT_VERSION = declared_ext_versions()[0]
 
 
+# --------------------------------------------------------------------------- #
+# 🔴 THE BUILD-MARKER DRIFT GATE (#324) — read this before "fixing" a failure
+# here by editing a hex string.
+#
+# extension/build_id.js is GENERATED. Its `BUILD_MARKER` literal is a digest over
+# the extension source, and it is the value `extension_stale` is computed from —
+# so a marker that silently goes stale reintroduces the bug this whole change
+# exists to fix: a profile running old code would report a marker matching the
+# new deployed source and read `extension_stale: false`.
+#
+# The derivation lives in gen-build-marker.py and is IMPORTED here rather than
+# reimplemented — a second copy of the rule is how a gate like this drifts into
+# agreeing with itself. To fix a red:
+#
+#     python3 scripts/browser-bridge/gen-build-marker.py
+#
+# and commit the regenerated build_id.js in the SAME commit as the source change.
+# --------------------------------------------------------------------------- #
+def _load_gen_build_marker():
+    """Import gen-build-marker.py by path (the filename has dashes, so it is not
+    importable by name)."""
+    import importlib.util
+    path = Path(__file__).resolve().parent.parent / "gen-build-marker.py"
+    spec = importlib.util.spec_from_file_location("gen_build_marker", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+GEN = _load_gen_build_marker()
+COMMITTED_BUILD_MARKER = GEN.read_marker(EXT_DIR / "build_id.js")
+
+
+def test_build_marker_generator_is_wired_to_something(tmp_path):
+    """HARNESS SELF-CHECK for the drift gate below — its positive and negative
+    controls. Without these, a generator that hashed nothing (or hashed a
+    constant) would make the gate report success while testing NOTHING.
+
+    POSITIVE control: change an extension source file and the computed marker
+    MUST move. That is the exact failure the gate is supposed to catch, so if
+    this cannot move the number the gate can only ever pass."""
+    src = tmp_path / "ext"
+    src.mkdir()
+    shutil.copy(EXT_DIR / "manifest.json", src / "manifest.json")
+    for js in EXT_DIR.glob("*.js"):
+        shutil.copy(js, src / js.name)
+    before = GEN.compute_marker(src)
+    assert before == GEN.compute_marker(src), "must be deterministic"
+
+    # (1) touching a hashed source file moves the marker
+    sw = src / "service_worker.js"
+    sw.write_text(sw.read_text(encoding="utf-8") + "\n// positive control\n",
+                  encoding="utf-8")
+    after = GEN.compute_marker(src)
+    assert after != before, (before, after)
+
+    # (2) so does a manifest bump
+    src2 = tmp_path / "ext2"
+    shutil.copytree(src, src2)
+    (src2 / "manifest.json").write_text('{"version": "0.0.0"}', encoding="utf-8")
+    assert GEN.compute_marker(src2) != GEN.compute_marker(src)
+
+    # (3) build_id.js is EXCLUDED (no self-reference): rewriting it must NOT move
+    #     the marker, or regeneration could never converge.
+    (src / "build_id.js").write_text('export const BUILD_MARKER = "ffff";\n',
+                                     encoding="utf-8")
+    assert GEN.compute_marker(src) == after
+    names = [p.name for p in GEN.marker_inputs(src)]
+    assert "build_id.js" not in names, names
+    assert "service_worker.js" in names and "protocol.js" in names, names
+    assert "manifest.json" in names, names
+
+    # NEGATIVE control: fed a directory with nothing to hash, it must FAIL
+    # LOUDLY rather than returning a digest of the empty string.
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(AssertionError, match="hashed ZERO files"):
+        GEN.compute_marker(empty)
+
+
+def test_committed_build_marker_matches_the_extension_source():
+    """THE GATE. extension/build_id.js must be the digest of the extension
+    source it ships with. Any extension change that forgets to regenerate it
+    fails here, naming the command to run."""
+    want = GEN.compute_marker(EXT_DIR)
+    assert COMMITTED_BUILD_MARKER == want, (
+        f"extension/build_id.js declares BUILD_MARKER "
+        f"{COMMITTED_BUILD_MARKER!r} but the extension source hashes to "
+        f"{want!r}. The marker is what `extension_stale` compares, so a stale "
+        f"one lets a profile running OLD code report `false`. Regenerate it in "
+        f"the SAME commit as the source change:\n\n    {GEN.REGEN_CMD}\n\n"
+        f"Do NOT 'fix' this by editing the hex string by hand.")
+
+
+def test_build_marker_check_mode_agrees_with_the_gate():
+    """`gen-build-marker.py --check` is what a human runs; it must give the same
+    verdict as the CI gate above (a check mode that could disagree would be a
+    second source of truth about what is current)."""
+    assert GEN.main(["--check"]) == 0
+
+
+def test_service_worker_imports_the_marker_as_a_literal():
+    """🔴 The marker must travel with the CODE, and that property comes entirely
+    from it being a static import of a literal. Anything the worker reads at
+    RUNTIME (getManifest, fetch(getURL(...)), chrome.storage) reproduces the
+    exact bug #324 documents, because a stale worker reads the NEW file.
+
+    So: build_id.js must declare a literal and reach for no runtime read, and
+    service_worker.js must import it statically and report it from `ping`."""
+    body = (EXT_DIR / "build_id.js").read_text(encoding="utf-8")
+    assert re.search(r'export const BUILD_MARKER = "[0-9a-f]+";', body), body
+    code = [ln for ln in body.splitlines() if not ln.lstrip().startswith("//")]
+    code = "\n".join(code)
+    assert "fetch(" not in code and "getManifest" not in code, code
+    sw = (EXT_DIR / "service_worker.js").read_text(encoding="utf-8")
+    assert 'import { BUILD_MARKER } from "./build_id.js";' in sw
+    # ping must report it — the discriminator an older build cannot fake.
+    assert "buildMarker: buildMarker()" in sw
+
+
 def test_manifest_version_reads_current():
     v = S.manifest_version(path=EXT_DIR / "manifest.json")
     assert isinstance(v, str) and v == PINNED_EXT_VERSION
@@ -4055,31 +4197,138 @@ def test_manifest_version_none_when_neither_exists(tmp_path, monkeypatch):
     assert S.manifest_version() is None
 
 
+# --------------------------------------------------------------------------- #
+# 🔴 THE BUILD MARKER (#324) — where `extension_stale` gets its answer from.
+#
+# It is NOT the version. `extension_version` is chrome.runtime.getManifest()
+# .version (read from the on-disk manifest at call time) and `extension_id` is
+# derived from the load PATH, so both describe the DIRECTORY, not the running
+# code. MEASURED 2026-08-04: two Brave profiles loading the SAME directory
+# reported an identical id, an identical 0.7.3 and `extension_stale: false`
+# while one ran `main` and the other an unmerged 0.7.2 build whose source was on
+# no disk. A version-shaped signal cannot separate those rows.
+#
+# The marker is a generated LITERAL in extension/build_id.js that
+# service_worker.js imports, so it is frozen into the loaded module graph and
+# travels with the code. The server reads the expected value out of the DEPLOYED
+# build_id.js (build_marker()) and compares.
+#
+# The verdict FAILS CLOSED: either side missing a marker -> None. `False` is
+# only ever reachable with two present, equal markers.
+# --------------------------------------------------------------------------- #
+def test_build_marker_reads_the_literal(tmp_path):
+    f = tmp_path / "build_id.js"
+    f.write_text('export const BUILD_MARKER = "abc123def456abcd";\n',
+                 encoding="utf-8")
+    assert S.build_marker(path=f) == "abc123def456abcd"
+
+
+def test_build_marker_none_on_missing_unreadable_or_absent_literal(tmp_path):
+    assert S.build_marker(path=tmp_path / "nope.js") is None
+    bad = tmp_path / "build_id.js"
+    bad.write_text("// a file with no marker in it at all\n", encoding="utf-8")
+    assert S.build_marker(path=bad) is None
+
+
+def test_build_marker_prefers_the_deployed_copy_over_the_repo(tmp_path,
+                                                              monkeypatch):
+    """The marker the server calls EXPECTED is the one in the tree Brave loads —
+    the deployed copy — not the repo working tree, which any concurrent
+    session's checkout can change under a live verification."""
+    deployed = tmp_path / "deployed_build_id.js"
+    deployed.write_text('export const BUILD_MARKER = "0000deb10ded0000";\n',
+                        encoding="utf-8")
+    monkeypatch.setattr(S, "_DEPLOYED_EXT_BUILD_ID", deployed)
+    monkeypatch.setattr(S, "_EXT_BUILD_ID_PATH", EXT_DIR / "build_id.js")
+    assert S.build_marker() == "0000deb10ded0000"
+
+
+def test_build_marker_falls_back_to_the_repo_when_not_deployed(tmp_path,
+                                                               monkeypatch):
+    monkeypatch.setattr(S, "_DEPLOYED_EXT_BUILD_ID", tmp_path / "absent.js")
+    monkeypatch.setattr(S, "_EXT_BUILD_ID_PATH", EXT_DIR / "build_id.js")
+    assert S.build_marker() == COMMITTED_BUILD_MARKER
+
+
+def test_build_marker_none_when_neither_exists(tmp_path, monkeypatch):
+    monkeypatch.setattr(S, "_DEPLOYED_EXT_BUILD_ID", tmp_path / "a.js")
+    monkeypatch.setattr(S, "_EXT_BUILD_ID_PATH", tmp_path / "b.js")
+    assert S.build_marker() is None
+
+
 # --- annotate_staleness: the explicit loaded-vs-expected verdict ------------ #
-def test_annotate_staleness_flags_a_mismatch_true():
-    insts = [{"key": "work", "extension_version": "0.2.0"}]
-    S.annotate_staleness(insts, expected="0.3.0")
+def test_annotate_staleness_flags_a_marker_mismatch_true():
+    """A profile running code whose marker differs from the deployed source's is
+    STALE — regardless of what version it reports. This is the #324 case: the
+    version agreed and the code did not."""
+    insts = [{"key": "personal", "extension_version": "0.7.3",
+              "extension_build": "0000000000000002"}]
+    S.annotate_staleness(insts, expected="0.7.3",
+                         expected_build="0000000000000001")
     assert insts[0]["extension_stale"] is True
-    assert insts[0]["extension_version_expected"] == "0.3.0"
+    assert insts[0]["extension_build_expected"] == "0000000000000001"
+    assert insts[0]["extension_version_expected"] == "0.7.3"
 
 
-def test_annotate_staleness_flags_a_match_false():
-    insts = [{"key": "work", "extension_version": "0.3.0"}]
-    S.annotate_staleness(insts, expected="0.3.0")
+def test_annotate_staleness_flags_a_marker_match_false():
+    insts = [{"key": "work", "extension_version": "0.3.0",
+              "extension_build": "0000000000000001"}]
+    S.annotate_staleness(insts, expected="0.3.0",
+                         expected_build="0000000000000001")
     assert insts[0]["extension_stale"] is False
 
 
-def test_annotate_staleness_is_none_when_undecidable():
-    """NEVER guess: an instance that reports no version (a build predating
-    version reporting), or an unreadable manifest, yields null — not False."""
-    insts = [{"key": "a", "extension_version": None},
-             {"key": "b", "extension_version": ""}]
-    S.annotate_staleness(insts, expected="0.3.0")
-    assert [i["extension_stale"] for i in insts] == [None, None]
+def test_annotate_staleness_fails_closed_when_a_marker_is_missing():
+    """🔴 FAIL CLOSED. A missing marker on EITHER side is undecidable — null,
+    never False. `false` must mean "verified current", so a build predating the
+    marker, or an unreadable/undeployed source tree, cannot produce one. Note
+    the version MATCHES in every case below: under the old version-based rule
+    each of these returned False, which is exactly the affirmative all-clear
+    #324 was filed about."""
+    # (a) the instance reports no marker (a build predating #324)
+    insts = [{"key": "a", "extension_version": "0.3.0",
+              "extension_build": None},
+             {"key": "b", "extension_version": "0.3.0",
+              "extension_build": ""},
+             {"key": "c", "extension_version": "0.3.0"}]     # key absent entirely
+    S.annotate_staleness(insts, expected="0.3.0",
+                         expected_build="0000000000000001")
+    assert [i["extension_stale"] for i in insts] == [None, None, None]
 
-    insts2 = [{"key": "c", "extension_version": "0.3.0"}]
-    S.annotate_staleness(insts2, expected=None)
-    assert insts2[0]["extension_stale"] is None
+    # (b) the SERVER cannot read a marker (no deployed/repo build_id.js)
+    for missing in (None, ""):
+        insts2 = [{"key": "d", "extension_version": "0.3.0",
+                   "extension_build": "0000000000000001"}]
+        S.annotate_staleness(insts2, expected="0.3.0", expected_build=missing)
+        assert insts2[0]["extension_stale"] is None, missing
+
+    # (c) the default (no expected_build passed at all) is also undecidable —
+    #     a caller that forgets to pass it cannot accidentally get a False.
+    insts3 = [{"key": "e", "extension_version": "0.3.0",
+               "extension_build": "0000000000000001"}]
+    S.annotate_staleness(insts3, expected="0.3.0")
+    assert insts3[0]["extension_stale"] is None
+
+
+def test_annotate_staleness_a_version_match_alone_never_yields_false():
+    """The regression this PR exists to prevent: two profiles reporting the same
+    version as the deployed manifest must NOT read `false` on the strength of
+    that alone. Without markers the honest answer is null."""
+    insts = [{"key": "personal", "extension_version": "0.7.3"},
+             {"key": "work", "extension_version": "0.7.3"}]
+    S.annotate_staleness(insts, expected="0.7.3", expected_build=None)
+    assert [i["extension_stale"] for i in insts] == [None, None]
+    assert not any(i["extension_stale"] is False for i in insts)
+
+
+def test_annotate_staleness_marker_match_with_version_mismatch_is_stale():
+    """Markers equal but versions not: the deployed manifest moved without the
+    marker moving (or a header was spoofed). Not a verified-current state."""
+    insts = [{"key": "a", "extension_version": "0.7.1",
+              "extension_build": "0000000000000001"}]
+    S.annotate_staleness(insts, expected="0.7.3",
+                         expected_build="0000000000000001")
+    assert insts[0]["extension_stale"] is True
 
 
 def test_manifest_version_none_on_missing(tmp_path):
@@ -4472,27 +4721,35 @@ def test_health_no_extension_still_reports_current_version():
         srv.shutdown(); srv.server_close()
 
 
-def test_health_carries_an_explicit_stale_verdict_per_instance(pinned_manifest):
-    """The point of the change: a yes/no, not two version strings to eyeball.
-    An instance reporting 0.1.0 against the expected manifest is STALE=True."""
+def test_health_carries_an_explicit_stale_verdict_per_instance(
+        pinned_manifest, pinned_build):
+    """The point of the change: a yes/no, not two strings to eyeball. An
+    instance whose reported BUILD MARKER differs from the deployed source's is
+    STALE=True — note it reports the EXPECTED VERSION here, which is the #324
+    case exactly: the version agreed and the code did not."""
     srv, _ = _serve()
-    ext = FakeExtension(srv, instance_id="a", label="alpha", ext_version="0.1.0")
+    ext = FakeExtension(srv, instance_id="a", label="alpha",
+                        ext_version=PINNED_VERSION,
+                        ext_build="0000000000000bad")
     ext.start()
     try:
         body = _wait_instances(srv, 1)
         assert body is not None
         inst = body["instances"][0]
         assert inst["extension_version_expected"] == PINNED_VERSION
+        assert inst["extension_build_expected"] == PINNED_BUILD
+        assert inst["extension_build"] == "0000000000000bad"
         assert inst["extension_stale"] is True
+        assert body["extension_build_current"] == PINNED_BUILD
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
 
 
 def test_health_stale_verdict_is_false_when_the_loaded_build_matches(
-        pinned_manifest):
+        pinned_manifest, pinned_build):
     srv, _ = _serve()
     ext = FakeExtension(srv, instance_id="a", label="alpha",
-                        ext_version=PINNED_VERSION)
+                        ext_version=PINNED_VERSION, ext_build=PINNED_BUILD)
     ext.start()
     try:
         body = _wait_instances(srv, 1)
@@ -4502,9 +4759,31 @@ def test_health_stale_verdict_is_false_when_the_loaded_build_matches(
         ext.stop(); srv.shutdown(); srv.server_close()
 
 
-def test_whoami_carries_the_stale_verdict_per_instance(pinned_manifest):
+def test_health_stale_verdict_is_null_when_only_the_version_matches(
+        pinned_manifest, pinned_build):
+    """🔴 FAIL CLOSED end-to-end: an instance that reports the EXPECTED VERSION
+    but NO marker reads null, not false. Under the old rule this exact instance
+    read `false` — the affirmative all-clear #324 was filed about."""
     srv, _ = _serve()
-    ext = FakeExtension(srv, instance_id="a", label="alpha", ext_version="0.1.0")
+    ext = FakeExtension(srv, instance_id="a", label="alpha",
+                        ext_version=PINNED_VERSION)   # no ext_build
+    ext.start()
+    try:
+        body = _wait_instances(srv, 1)
+        assert body is not None
+        inst = body["instances"][0]
+        assert inst["extension_version"] == PINNED_VERSION
+        assert inst["extension_build"] is None
+        assert inst["extension_stale"] is None
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_whoami_carries_the_stale_verdict_per_instance(pinned_manifest,
+                                                       pinned_build):
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="a", label="alpha",
+                        ext_version="0.1.0", ext_build="0000000000000bad")
     ext.start()
     try:
         _wait_instances(srv, 1)
@@ -4513,15 +4792,18 @@ def test_whoami_carries_the_stale_verdict_per_instance(pinned_manifest):
         inst = body["instances"][0]
         assert inst["extension_stale"] is True
         assert inst["extension_version_expected"] == PINNED_VERSION
+        assert inst["extension_build_expected"] == PINNED_BUILD
         assert body["bridge"]["extension_version_current"] == PINNED_VERSION
+        assert body["bridge"]["extension_build_current"] == PINNED_BUILD
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
 
 
-def test_whoami_stale_verdict_is_null_for_an_unreporting_extension():
-    """A build that predates version reporting is UNDECIDABLE, never "fine"."""
+def test_whoami_stale_verdict_is_null_for_an_unreporting_extension(
+        pinned_build):
+    """A build that predates the marker is UNDECIDABLE, never "fine"."""
     srv, _ = _serve()
-    ext = FakeExtension(srv, instance_id="a", label="alpha")  # no ext_version
+    ext = FakeExtension(srv, instance_id="a", label="alpha")  # no ext_build
     ext.start()
     try:
         _wait_instances(srv, 1)
@@ -4530,6 +4812,55 @@ def test_whoami_stale_verdict_is_null_for_an_unreporting_extension():
         assert body["instances"][0]["extension_stale"] is None
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_stale_verdict_is_null_when_the_server_cannot_read_a_marker(
+        pinned_manifest, tmp_path, monkeypatch):
+    """The other half of fail-closed: an unreadable/undeployed extension source
+    tree makes the verdict undecidable even for an instance that DOES report a
+    marker and the expected version."""
+    monkeypatch.setattr(S, "_DEPLOYED_EXT_BUILD_ID", tmp_path / "absent-a.js")
+    monkeypatch.setattr(S, "_EXT_BUILD_ID_PATH", tmp_path / "absent-b.js")
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="a", label="alpha",
+                        ext_version=PINNED_VERSION, ext_build="abcabcabcabcabca")
+    ext.start()
+    try:
+        body = _wait_instances(srv, 1)
+        assert body is not None
+        assert body["extension_build_current"] is None
+        assert body["instances"][0]["extension_stale"] is None
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_two_profiles_one_directory_are_distinguishable(pinned_manifest,
+                                                        pinned_build):
+    """🔴 THE MEASURED #324 CASE, reproduced. Two instances loaded from the SAME
+    directory: identical extension_id (it is path-derived, so it MUST be) and
+    identical reported version — but different running code. The old verdict
+    said `false` for both. The marker separates them."""
+    srv, _ = _serve()
+    same_id = "bgbkamdlkdleahpgdgmjipjbgmepgenk"
+    personal = FakeExtension(srv, instance_id="p", label="personal",
+                             ext_version=PINNED_VERSION, ext_id=same_id,
+                             ext_build="0000000000000bad")   # unmerged build
+    work = FakeExtension(srv, instance_id="w", label="work",
+                         ext_version=PINNED_VERSION, ext_id=same_id,
+                         ext_build=PINNED_BUILD)             # main
+    personal.start(); work.start()
+    try:
+        body = _wait_instances(srv, 2)
+        assert body is not None
+        by_key = {i["key"]: i for i in body["instances"]}
+        assert by_key["personal"]["extension_id"] == \
+               by_key["work"]["extension_id"] == same_id
+        assert by_key["personal"]["extension_version"] == \
+               by_key["work"]["extension_version"] == PINNED_VERSION
+        assert by_key["personal"]["extension_stale"] is True
+        assert by_key["work"]["extension_stale"] is False
+    finally:
+        personal.stop(); work.stop(); srv.shutdown(); srv.server_close()
 
 
 # --- extension_id: WHICH DIRECTORY Brave loaded ---------------------------- #

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -4782,8 +4782,12 @@ def test_health_stale_verdict_is_null_when_only_the_version_matches(
 def test_whoami_carries_the_stale_verdict_per_instance(pinned_manifest,
                                                        pinned_build):
     srv, _ = _serve()
+    # Reports the EXPECTED version on purpose, so the True can ONLY have come
+    # from the marker comparison. (With a mismatching version this test passes
+    # even against a build that ignores the marker entirely — measured while
+    # mutation-testing this PR.)
     ext = FakeExtension(srv, instance_id="a", label="alpha",
-                        ext_version="0.1.0", ext_build="0000000000000bad")
+                        ext_version=PINNED_VERSION, ext_build="0000000000000bad")
     ext.start()
     try:
         _wait_instances(srv, 1)


### PR DESCRIPTION
Closes #324.

## The problem, and why no version-shaped fix works

`extension_stale` was computed from `extension_version`. That value is
`chrome.runtime.getManifest().version` — read from the **on-disk manifest at
call time** — and its companion `extension_id` is derived from the **load
path**. Both describe the **directory**, not the code that is executing.

Measured 2026-08-04 (in #324): two Brave profiles loading the **same** directory
reported an identical `extension_id`, an identical `0.7.3`, and
`extension_stale: false`, while one was executing `main` and the other an
unmerged 0.7.2 build whose source existed **on no disk**. Those two rows are
identical on every field the verdict was computed from, so this is not a weak
signal — it is a structurally blind one, and the per-profile dimension was
invisible entirely.

## The design: a marker that travels with the CODE

`extension/build_id.js` (**generated**) exports a `BUILD_MARKER` **literal**
which `service_worker.js` **statically imports**. It is therefore frozen into
the loaded module graph at load time, so a stale worker reports the **stale**
marker by construction.

🔴 **Every runtime-read alternative reproduces the exact bug**, and the file says
so at length so nobody "simplifies" it back:

| approach | why it fails |
|---|---|
| `chrome.runtime.getManifest().version` | reads disk at call time — a stale worker reads the NEW manifest. This *is* the bug. |
| `fetch(chrome.runtime.getURL("build_id.json"))` | same: the stale worker fetches the freshly-deployed file |
| a hash the worker computes over its own source | same disk read, one level of indirection away |
| a value in `chrome.storage.local` | survives a code swap entirely; also wiped by Remove |

The common failure is that **the disk is the thing that was updated**. Only a
value baked into the loaded module graph can answer "is the code running right
now the code I deployed?".

Plumbing:

* `ping` reports `buildMarker` (and keeps `extensionVersion` + `id` as hints).
  The new field is itself the discriminator — an older build cannot fake it.
* `/poll` carries it as `X-Bridge-Ext-Build`, so the **per-instance** verdict
  needs no round-trip and `health`/`whoami` can answer per profile.
* The server reads the **expected** marker out of the **deployed**
  `~/.local/share/browser-bridge-ext/build_id.js` (repo copy as fallback,
  mirroring `manifest_version()`'s precedence and its no-`.resolve()` absolute
  paths) and `annotate_staleness` compares **that**. `/health` and `/whoami`
  gain `extension_build`, `extension_build_expected`, `extension_build_current`.

### Fail-closed

`extension_stale` is `None` unless **both** markers are present, and `False`
only when they are present **and equal**. A build predating this change, or an
unreadable/undeployed source tree, reads `null` — never `false`. A version match
alone can no longer produce a `false`. (`True` also covers the odd case of equal
markers with disagreeing versions: not a verified-current state.)

### The marker cannot go stale silently

`gen-build-marker.py` **owns** the derivation — sha256 over the extension's
`*.js` files + `manifest.json`, sorted, each contributing `name\0len\0bytes`,
excluding `build_id.js` itself to avoid self-reference — and the pytest gate
**imports** it rather than reimplementing it, so there is no second copy of the
rule to drift. Regeneration, named in the failure message:

```bash
python3 scripts/browser-bridge/gen-build-marker.py          # rewrite
python3 scripts/browser-bridge/gen-build-marker.py --check   # verify
```

This is consistent with #323 rather than a rival source of truth: the **version**
is still declared in `extension/README.md`'s changelog and gated against
`manifest.json`; the **marker** is derived from the source and gated against
`build_id.js`. Neither is a literal anyone edits by hand.

## Suites — both tiers, counted

| suite | main | this branch |
|---|---|---|
| `node --test --test-reporter=tap scripts/browser-bridge/tests/*.test.mjs` | 485 pass / 0 fail | **487 pass / 0 fail / 0 skipped** |
| `pytest scripts/browser-bridge/tests -q` (nix-shell) | 453 passed | **467 passed / 0 failed** |

## Red-before-green matrix

Committed first, then reverted **only** implementation files (never a test file).

| what was reverted/mutated | test | verdict |
|---|---|---|
| `server.py` → `origin/main` | the 17 new/updated marker + staleness tests | **RED** — 11 failed, 6 errored (`AttributeError: module 'server' has no attribute '_DEPLOYED_EXT_BUILD_ID'`, and `annotate_staleness()` rejecting `expected_build`). Whole-file revert of a new API, so these are import/attribute errors, not the tests' own assertion text — the mutations below are the discriminating reds. |
| `extension/{protocol.js,service_worker.js}` → `origin/main`, `build_id.js` deleted | `protocol.test.mjs` + `service_worker.test.mjs` | **RED** — `not ok 25 … X-Bridge-Ext-Build: + undefined - '00000000fakemark'`; `not ok 83 … Cannot find module …/build_id.js`. 84/86 pass, 2 fail. |
| same | `test_service_worker_imports_the_marker_as_a_literal` | **RED** — `FileNotFoundError: …/extension/build_id.js` |
| restored | all of the above | **GREEN** (22/22 marker+staleness selected; 467 / 487 full) |

## Fail-closed evidence (mutation, with THIS guard's own assertion)

**Mutant 1 — fall back to the version when a marker is missing** (the exact
regression the rule forbids):

```python
 if not expected_build or not loaded_build:
-    inst["extension_stale"] = None
+    inst["extension_stale"] = (None if (not expected or not loaded) else loaded != expected)
```

4 tests RED, each on its own assertion:

```
assert [False, False, False] == [None, None, None]   # fails_closed_when_a_marker_is_missing
assert [False, False] == [None, None]                # a_version_match_alone_never_yields_false
assert False is None                                 # health …null_when_only_the_version_matches
assert False is None                                 # …null_when_the_server_cannot_read_a_marker
```

**Mutant 2 — ignore a marker mismatch** (`stale = loaded_build != expected_build`
→ `stale = False`): 3 tests RED with `assert False is True`, including
`test_two_profiles_one_directory_are_distinguishable`, which reproduces the
measured #324 case (same path-derived `extension_id`, same version, different
markers → `personal: true`, `work: false`).

⚠ **Mutant 2 also found one of my own tests green for the wrong reason.**
`test_whoami_carries_the_stale_verdict_per_instance` originally had the fake
report a *mismatching* version, so the version branch turned the verdict `True`
even with the marker comparison defeated. Fixed in the second commit (report the
**expected** version, so only the marker can produce the `True`); it is RED
against mutant 2 now.

## Positive control for the drift gate

A gate that can only ever pass is worthless. Appended one comment line to
`extension/protocol.js` **without** regenerating:

```
AssertionError: extension/build_id.js declares BUILD_MARKER '9ca73218873b35fa'
but the extension source hashes to 'f47245592d36f4e4'. … Regenerate it in the
SAME commit as the source change:

    python3 scripts/browser-bridge/gen-build-marker.py

Do NOT 'fix' this by editing the hex string by hand.
```

`gen-build-marker.py --check` agreed (`exit 1`, same two values) — a second,
differently-shaped read of the same fact. The harness self-check test also
carries its own positive controls (touch a source file → marker moves; bump the
manifest → marker moves; rewrite `build_id.js` → marker does **not** move, so
regeneration converges) and a negative control (hash an empty directory → raises
`hashed ZERO files`, never a digest of the empty string).

## Docs

* `extension/README.md` — the provably-loaded **CONTRACT** now names the marker
  as the mechanical discriminator (bump + changelog block + regenerate), and
  records the measured facts: a **full browser restart is NOT sufficient**
  (oldest process 392 s, deploy 9 h earlier, still old code), **per-profile
  Remove + Load unpacked IS**, and staleness is **per profile**. The mechanism is
  recorded as UNEXPLAINED, not as a finding. New 0.8.0 changelog block; manifest
  0.7.3 → 0.8.0.
* `reference/errors.md`, `README.md`, `SKILL.md`, `browser` CLI help — all
  corrected to point at `buildMarker`/`extension_build` and to stop describing
  `extension_stale` as a version match. `SKILL.md` is byte-gated: 11,927 →
  11,944 B, ceiling 12,288, headroom 344 ≥ the 250 floor, `test_skill_size.py`
  green.

## 🔴 NOT VERIFIED — and what you have to run

Everything extension-side is **inert until deployed**, and I did not deploy or
drive the browser (both out of scope for this task):

* **No `home-manager switch` was run**, so `~/.local/share/browser-bridge-ext/`
  still holds 0.7.3 and the server (whichever copy is live) still has the old
  `annotate_staleness`.
* **No Brave profile was touched** — no restart, no Remove/Load unpacked.
* Therefore: **no live `ping`, `whoami` or `health` output in this PR is
  measured.** Every claim here is about the source and the two test suites.
* The **hex marker values** in this PR body are from the working tree; they will
  differ if anything in `extension/` changes before merge.

Live sequence after merge (workbench and laptop are independent, and each Brave
**profile** is independent):

```bash
# 1. deploy — nothing nix-managed changes on a bare `git pull`
scripts/ship.sh                       # or: home-manager switch --flake ~/workspace/devrc --impure

# 2. confirm the DEPLOYED tree carries the new marker (not the repo's)
grep BUILD_MARKER ~/.local/share/browser-bridge-ext/build_id.js
grep '"version"' ~/.local/share/browser-bridge-ext/manifest.json     # 0.8.0

# 3. confirm the SERVER restarted into the new code and is the process on the port
systemctl --user show browser-bridge -p MainPID -p SubState
ss -lptn 'sport = :8788'                                             # PID must match
browser whoami                                                       # bridge.extension_build_current must be set

# 4. BEFORE reloading anything, capture the stale reading per profile
browser --instance personal ping     # expect: NO buildMarker field (0.7.3 build)
browser --instance work ping
browser whoami                       # expect: extension_stale = null for both — NOT false
```

Step 4 is the important one and is where the fix is demonstrated: on the old
extension the verdict is **`null`** (undecidable), where the old code said
`false`. That is the fail-closed behaviour, live.

To see a genuinely stale profile report **`true`** rather than `false`, reload
**one** profile and leave the other:

```bash
# brave://extensions in ONE profile only: Remove the card, then Load unpacked
#   → ~/.local/share/browser-bridge-ext/   (a full Brave restart is NOT enough —
#     measured), then re-paste token/port/label in the extension's Options.
browser --instance work ping         # → {"pong":true,…,"buildMarker":"<hex>",…}
browser whoami
#   work     → extension_build = <deployed marker>, extension_stale = false
#   personal → extension_build = null,              extension_stale = null
```

Then, for a **`true`**: check out this branch's parent (or any earlier commit),
`home-manager switch` so the *deployed* `build_id.js` carries a different marker
while the reloaded profile keeps running the newer code — `whoami` must report
`extension_stale: true` for that profile. Equivalently, and more cheaply: edit
`~/.local/share/browser-bridge-ext/build_id.js`'s hex by hand and re-read
`whoami` (the next switch overwrites it).

⚠ Recording the disagreement I have with my own change: `extension_stale` will
read `null` on every profile until each one is manually Removed + re-Loaded.
That is correct and intended, but it means the field is **less** informative
immediately after merge than it was before — honestly so, rather than falsely
reassuring. If a profile is never re-added, it stays `null` forever, and nothing
in the system nags about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
