### PR TITLE
fix(browser-bridge): emulate --reset really undoes the viewport — the CDP clear needs an ARMED session (#319)

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -230,7 +230,7 @@ has not been exercised against a third-party authenticated API beyond that.)
 | `screenshot` | **CDP `Page.captureScreenshot`** (png) — works on a BACKGROUND/occluded tab + each profile's own tab; a foreground tab uses the cheap `captureVisibleTab` fast path. `fullpage` grabs the whole document. The CLI decodes `dataUrl` to a **`.png` on disk** and prints a path, never the base64 (see below) | `{url,dataUrl,via}` |
 | `open`       | `chrome.tabs.create({url,active:false})` — **background/HIDDEN** (`visibilityState:"hidden"` → Chromium throttles it → a heavy SPA won't render → reads return a shell). The escape hatch is **`browser wake`** (or a `--wake` read): it un-throttles the tab and moves NO focus. Reads self-announce this via `hidden`/`note` | `{tabId,url}` |
 | `close`      | `chrome.tabs.remove(tabId)`                               | `{closed:tabId}` |
-| `emulate`    | **device emulation** — CDP `Emulation.setDeviceMetricsOverride` / `setTouchEmulationEnabled` / `setUserAgentOverride` (**+`userAgentMetadata`**) / `setEmulatedMedia` / `setTimezoneOverride` / `setGeolocationOverride`, from a named preset or raw params. **Sticky per tab** (re-applied inside every later CDP session) and **owned-tab-only**. `--reset` only stops re-applying — it sends NOTHING to CDP — and 🔴 **does NOT restore the viewport size** (#319); `--reset --recreate` replaces the tab (new tab id) and is the only known remedy | `{tabId,url,emulation,applied,note}` or `{tabId,url,reset,wasEmulating,note}` |
+| `emulate`    | **device emulation** — CDP `Emulation.setDeviceMetricsOverride` / `setTouchEmulationEnabled` / `setUserAgentOverride` (**+`userAgentMetadata`**) / `setEmulatedMedia` / `setTimezoneOverride` / `setGeolocationOverride`, from a named preset or raw params. **Sticky per tab** (re-applied inside every later CDP session) and **owned-tab-only**. `--reset` stops re-applying **and restores the viewport** — it sends an arm-then-clear pair, because a bare `clearDeviceMetricsOverride` is a measured no-op (#319). `--reset --recreate` replaces the tab (new tab id) instead, and is the only remedy for a tab the extension cannot reach | `{tabId,url,emulation,applied,note}` or `{tabId,url,reset,wasEmulating,cleared,restored,note}` |
 | `frames`     | **`chrome.webNavigation.getAllFrames`** — the tab's frames INCLUDING cross-origin OUT-OF-PROCESS iframes (OOPIFs) | `{url,title,frames:[{frameId,url,parentFrameId}]}` |
 | `click`      | top frame: **CDP** `getBoundingClientRect` → `Input.dispatchMouseEvent` (trusted); `--frame`: **SYNTHETIC** click via `chrome.scripting`; `selector` required, `frame` optional | `{url,clicked,x,y,frame,trusted}` |
 | `type`       | top frame: **CDP `Input.insertText`** (trusted); `--frame`: **SYNTHETIC** input via `chrome.scripting`; `text` required, `selector`/`frame` optional | `{url,typed,frame,trusted}` |
@@ -548,11 +548,11 @@ The choke point is deliberate. Patching `screenshot` and `click` individually wo
 have fixed the two visible cases and regenerated the bug at the next CDP op anyone
 added. One rule, one place.
 
-### 🔴 `--reset` does NOT restore the viewport (#319)
+### `--reset` restores the viewport — and why it took two steps (#319)
 
-This section used to claim the opposite — that because the overrides die at detach
-"the tab is not emulated between ops", so nothing could stick. **Measured false**
-(2026-08-03, laptop, extension 0.7.2, with a fresh-tab control):
+This section has been wrong twice. It first claimed that because the overrides die
+at detach "the tab is not emulated between ops", so nothing could stick. **Measured
+false** (2026-08-03, laptop, extension 0.7.2, with a fresh-tab control):
 
 | step | `innerWidth` |
 | --- | --- |
@@ -563,28 +563,49 @@ This section used to claim the opposite — that because the overrides die at de
 
 That measurement was taken on a build whose reset really did report
 `cleared: [Emulation.clearDeviceMetricsOverride, Emulation.setTouchEmulationEnabled,
-Emulation.setUserAgentOverride]`, and the size survived them anyway. **Sending
-`clearDeviceMetricsOverride` simply does not bring the viewport back** — which is
-why the clears were not carried into the shipped build. 🔴 **On the current build
-`--reset` sends nothing at all**: it deletes the tab's stored emulation state, so
-later ops stop re-applying it. No debugger is attached and no CDP message is
-issued.
+Emulation.setUserAgentOverride]`, and the size survived them anyway. It is correct,
+and it is why PR #320 was closed. It then became the second wrong claim — that the
+size *could not* be restored and the mechanism was unknown.
 
-Everything else *does* revert on its own, measured in the same pass:
-`devicePixelRatio`, `maxTouchPoints`, `pointer: coarse`, `prefers-color-scheme`,
-`userAgent`, `timeZone` — and it reverts because **a CDP override dies when the
-debugger detaches**, not because anything cleared it. Only the viewport **size**
-is sticky. (`"ontouchstart" in window` also stays true on a document that was
-*built* emulated — that one is document-creation residue and a re-`nav` clears
-it.)
+Everything else *does* revert on its own: `devicePixelRatio`, `maxTouchPoints`,
+`pointer: coarse`, `prefers-color-scheme`, `userAgent`, `timeZone` — because **a
+CDP override dies with the debugger session that set it**, not because anything
+cleared it. Only the viewport **size** is sticky. (`"ontouchstart" in window` also
+stays true on a document that was *built* emulated — that one is document-creation
+residue and a re-`nav` clears it.)
 
-**The mechanism is not established.** The leading hypothesis is a render-widget
-resize residue — consistent with `devicePixelRatio` reverting while the width does
-not, though both come from the same CDP call — but it is a hypothesis. Do not
-restate it as a finding.
+**The mechanism, established 2026-08-04** in a throwaway Brave 147.0.7727.56 under
+Xvfb, driven over raw CDP with no extension in the loop, control tab every round:
 
-**Closing the tab is the only known remedy.** So `--reset` means "stop
-re-applying", never "undo". The workaround:
+| what was done | victim `innerWidth` | control |
+| --- | --- | --- |
+| `setDeviceMetricsOverride{393×852}` in session A, then **detach** | **394** | 1055 |
+| `clearDeviceMetricsOverride` in a **fresh** session B | **394** ← no-op | 1055 |
+| `setDeviceMetricsOverride{…}` **then** the clear, in session B | **1055** ← restored | 1055 |
+
+🔴 **`clearDeviceMetricsOverride` does nothing when the session sending it never
+set an override itself** — and it reports success either way. Every earlier attempt
+to undo this sent the clear from a fresh session, so it was a no-op that looked
+acknowledged.
+
+**That is also the dpr-vs-width asymmetry** #319 could not explain. One call, two
+destinations: dpr/touch/UA/media/timezone are renderer-side session state that dies
+at detach; the size additionally resizes the **browser-side render widget**, and
+only an explicit clear from an armed session undoes that. Nothing does it at
+detach. (Inference from the table, not from Chromium's source.)
+
+**So `--reset` now sends an arm-then-clear pair** in one session
+(`EMULATION_RESET_CDP_STEPS`) and reports `restored` + `cleared`. The arming
+override is `{width:0,height:0,deviceScaleFactor:0,mobile:false}` — measured not to
+resize anything by itself, so there is no flash to a wrong size. It fires
+**unconditionally**, even when the worker holds no state for the tab, because an
+evicted MV3 worker forgets the state while the tab stays stuck; measured safe on a
+never-emulated tab. It is **best-effort**: a refused attach yields
+`restored:false` + `restoreError`, never an exception.
+
+**`--reset --recreate` stays**, and is still the right tool twice over — it needs
+no CDP, and it is the **only** remedy for a tab the extension cannot reach (an
+un-upgraded build, or a tab orphaned by a `SIGKILL`'d agent):
 
 ```
 browser emulate --reset --recreate
@@ -596,13 +617,18 @@ to it). It refuses on a non-http(s) url and always opens the replacement *before
 closing the original, so no failure path leaves you with no tab. Plain `--reset`
 never swaps tab ids.
 
+⚠ **Not verified against the operator's live Brave.** The fix was measured in a
+throwaway instance and pinned by unit tests against a browser model calibrated to
+those measurements. The live check is in the PR for #319.
+
 The apply-then-act design is still the right shape — a held-open session would add
 a permanent debug banner on top of the same stuck viewport — but it buys strictly
 less than this section used to claim.
 
-The other cost, stated plainly: a page that re-measures the viewport *after* an op
-(a `resize` listener, a late layout pass) sees the real window until the next op
-re-applies.
+The other cost, stated plainly: a page that re-measures its *capabilities* after an
+op (a `resize` listener reading `devicePixelRatio` or `matchMedia`, a late layout
+pass) sees the desktop ones until the next op re-applies. The width it measures
+stays the emulated one, because that half is physically stuck on the tab.
 
 ### Blast radius: owned tabs only
 
@@ -638,15 +664,18 @@ desktop bundle before emulation is ever re-applied.
 ### The read path is not emulated (and says so)
 
 `text` / `html` / `eval` take the `chrome.scripting` path. Verified by execution:
-after `emulate iphone-15` they issue **zero** CDP calls and zero attaches, so the
-DOM they read is the real desktop one — `innerWidth`, `getBoundingClientRect`,
-`matchMedia` and `navigator.userAgent` all come back un-emulated.
+after `emulate iphone-15` they issue **zero** CDP calls and zero attaches, so no
+override is applied to them.
 
-This is correct-by-design (between ops the tab genuinely is not emulated, which is
-the safety property), but it is a trap: an agent screenshots a phone layout, then
-reads `text` and reasons about a desktop DOM with nothing to tell it apart. Same
-command, two answers — `js --wake 'innerWidth'` returns the emulated width because
-it routes `cdpWake` → `withCdp`; bare `js 'innerWidth'` returns the real one.
+What comes back is a **mixture**: `navigator.userAgent`, `devicePixelRatio`,
+`maxTouchPoints` and `matchMedia('(pointer: coarse)')` are the real desktop values
+(those overrides died at detach), while `innerWidth` and every
+`getBoundingClientRect` are the **emulated** ones, because the widget is physically
+that size until a reset clears it. So the read describes a page laid out at the
+phone width with desktop capability signals — a document no real device produces,
+and a trap: an agent screenshots a phone layout, then reads `text` and reasons
+about that hybrid. `js --wake 'devicePixelRatio'` returns the emulated dpr because
+it routes `cdpWake` → `withCdp`; bare `js 'devicePixelRatio'` returns the real one.
 
 So a read of a tab **that has emulation state** is annotated, in the same spirit as
 `HIDDEN_TAB_NOTE`: `{emulated:false, notEmulatedRead:true, emulationNote}` on the
@@ -685,11 +714,11 @@ by `maxTouchPoints`).
 It was excluded until #316 with the comment in `browser_tool_impl.mjs` saying
 emulation "leaves STICKY per-tab state that outlives the op … until an explicit
 `emulate --reset` or the tab is replaced", so a crashed agent would hand back a
-distorted browser. **That observation is correct** (see "🔴 `--reset` does not
-restore the viewport" above) — what was wrong was the counter-argument this section
-used to make, that overrides "die at detach" so nothing can stick. They do not all
-die at detach: the viewport size survives the detach, the `--reset` clears and a
-re-navigation, and closing the tab is the only known remedy.
+distorted browser. **That observation was correct** — what was wrong was the
+counter-argument this section used to make, that overrides "die at detach" so
+nothing can stick. They do not all die at detach: the viewport size survives it,
+and survives a re-navigation. Since #319 a *clean* `--reset` does repair it (see
+"`--reset` restores the viewport" above); a **crashed** agent still cannot run one.
 
 **The honest argument for shipping it default-on is ownership, not harmlessness:
 the `browser-agent` wrapper owns its tab's whole lifecycle.** It `open`s the run's
@@ -701,9 +730,11 @@ with `not_owned_tab` on any tab the calling session did not `open`. So on the ag
 path the sticky residue cannot reach one of the operator's own tabs.
 
 **The residual, stated plainly:** a `SIGKILL` bypasses the trap, and then the run's
-tab is orphaned **stuck at the emulated size**. `--reset` cannot repair it; it has
-to be closed. That is the agent's own tab rather than the operator's, but it is a
-real leak and nothing in #316 fixes it.
+tab is orphaned **stuck at the emulated size** with nothing left running that will
+issue a reset. A later `browser emulate --reset` against that tab id would repair
+it, but nothing does so automatically; `--reset --recreate` or a close is the
+practical fix. That is the agent's own tab rather than the operator's, but it is a
+real leak and nothing in #316 or #319 removes it.
 
 The other residual is the transient "an extension is debugging this browser" banner
 from the CDP attach — which `eval`, `screenshot` and `wake` already raise. Like

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -73,7 +73,7 @@ Result payloads land under `.result.data`.
 | `upload <selector> <path>` | fill an `<input type=file>` via CDP — Chrome reads the file BY PATH, **no bytes cross the bridge**. AUDIT-LOGGED, **operator-only** (agent → `op_not_allowed:upload`) |
 | `wake [--wait MS]`, or `text\|html\|js\|nav\|open --wake[=MS]` | **UN-THROTTLE a hidden/background tab with NO focus movement** — the fix for an empty or `hidden` read. ~1.5s settle, cap **6s**. **Wake once per PAGE, not per read** — the un-throttled state ends at detach, but the DOM already rendered PERSISTS. `--wake` folds un-throttle+read into one session; refused with `--frame` (`wake_with_frame_unsupported`). ISOLATED-vs-MAIN world nuance → `reference/spa-wake.md` |
 | `activate` | **⚠⚠ STEALS THE OPERATOR'S SCREEN — the ONE intrusive op, a LAST RESORT.** It is **NOT** the fix for a hidden/unrendered tab — that is `wake`. Read `reference/spa-wake.md` BEFORE using it |
-| `emulate <preset>\|--reset` | **device emulation** (mobile testing) on a tab you `open`ed; sticky, owned-tab-only. 🔴 `--reset` does NOT restore the viewport — use `--reset --recreate` (#319) → `reference/emulation.md` |
+| `emulate <preset>\|--reset` | **device emulation** (mobile testing) on a tab you `open`ed; sticky, owned-tab-only. `--reset` undoes it, viewport included (#319); `--recreate` replaces the tab → `reference/emulation.md` |
 | `agent "<goal>"` | the autonomous browser-agent — see **FIRST DECISION** above, then `reference/agent.md` |
 
 ## 🔴 Three traps that return a WRONG answer SILENTLY

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -111,17 +111,20 @@
 #                               --touch/--ua for anything not in the table.
 #                               STICKY per tab: re-applied inside every later op's
 #                               CDP session, because CDP overrides die at detach.
-#                               🔴 `--reset` STOPS RE-APPLYING AND SENDS THE CDP
-#                               CLEARS, BUT DOES NOT RESTORE THE VIEWPORT SIZE
-#                               (#319, measured 2026-08-03: 1124 → emulate → 393 →
-#                               --reset → 393 → re-nav → 393). UA, timezone, dpr,
-#                               touch points and prefers-color-scheme DO revert;
-#                               only the viewport size sticks, and the mechanism is
-#                               NOT established. Closing the tab is the only known
-#                               remedy — `--reset --recreate` does that for you
-#                               (opens a fresh tab at the same url, closes the
-#                               stuck one, and REPORTS THE NEW TAB ID; plain
-#                               `--reset` never swaps tab ids).
+#                               `--reset` stops re-applying AND restores the
+#                               viewport (#319, 0.8.1): it sends an ARM-then-CLEAR
+#                               pair in one session, because a bare
+#                               clearDeviceMetricsOverride from a session that did
+#                               not itself set an override is a measured NO-OP —
+#                               that is why every earlier attempt failed. UA,
+#                               timezone, dpr, touch points and prefers-color-scheme
+#                               need no clear; they die at detach. Only the size
+#                               had to be undone. `--reset --recreate` replaces the
+#                               tab instead (opens a fresh tab at the same url,
+#                               closes the old one, and REPORTS THE NEW TAB ID) —
+#                               the remedy that needs no CDP, and the only one for
+#                               a tab orphaned by a killed agent or an un-upgraded
+#                               build; plain `--reset` never swaps tab ids.
 #                               ⚠ OWNED TABS ONLY (`browser open` first): emulating
 #                               a tab you are browsing in is refused with
 #                               `not_owned_tab`. Screenshots on an emulated tab are
@@ -1046,17 +1049,17 @@ cmd_op() {
 json_str() { python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$1"; }
 
 # --------------------------------------------------------------------------- #
-# `emulate --reset --recreate` — the #319 workaround for the STICKY VIEWPORT.
+# `emulate --reset --recreate` — REPLACE a tab instead of repairing it (#319).
 #
-# MEASURED 2026-08-03 (laptop, extension 0.7.2, fresh-tab control): a tab that has
-# been emulated keeps the emulated viewport SIZE after `--reset` and after a
-# re-navigation — 1124 → 393 → 393 → 393. That build's reset demonstrably sent and
-# reported `Emulation.clearDeviceMetricsOverride` / `setTouchEmulationEnabled` /
-# `setUserAgentOverride` and the size survived them, so the shipped build does not
-# send them at all: `--reset` only stops re-applying. Every other override (dpr,
-# maxTouchPoints, pointer, prefers-color-scheme, UA, timezone) DOES revert — at
-# the debugger detach, on its own. The mechanism behind the sticky viewport is NOT
-# established. Closing the tab is the only known remedy.
+# Since 0.8.1 plain `--reset` DOES repair the stuck viewport (arm-then-clear; see
+# extension/protocol.js EMULATION_RESET_CDP_STEPS for the measurement). This path
+# is deliberately kept, because repairing needs the extension to be able to reach
+# the tab and two cases defeat that:
+#   * the profile is running an UN-UPGRADED build whose `--reset` still sends
+#     nothing (or sends a bare clear, which is a measured no-op);
+#   * the tab was orphaned by a SIGKILL'd agent — nothing is left running that
+#     would issue a reset for it, and `--recreate` is the one-command cleanup.
+# It also needs no CDP at all, so it works where the debugger is refused.
 #
 # So this is a REPLACEMENT, not a repair: reset → note the url → drop ownership →
 # `open` a fresh tab at that url (now owned by this same session) → close the
@@ -1218,9 +1221,12 @@ out = {
     "newTabId": int(os.environ["RECREATE_NEW"]),
     "url": os.environ["RECREATE_URL"],
     "closedOldTab": os.environ["RECREATE_CLOSED"] == "true",
-    "note": ("THE TAB ID CHANGED: %s -> %s. `--reset` alone does NOT restore the "
-             "viewport size (measured); replacing the tab is the only known remedy, "
-             "so this opened a fresh tab at the same url and closed the stuck one. "
+    "note": ("THE TAB ID CHANGED: %s -> %s. You asked to REPLACE the tab rather "
+             "than repair it, so this opened a fresh tab at the same url and closed "
+             "the old one. (Plain `--reset` does restore the viewport since 0.8.1 — "
+             "see the `reset` field for whether it did. `--recreate` remains the "
+             "remedy that needs no CDP, and the only one for an un-upgraded build "
+             "or a tab orphaned by a killed agent.) "
              "Later ops in this session route to %s."
              % (os.environ["RECREATE_OLD"], os.environ["RECREATE_NEW"],
                 os.environ["RECREATE_NEW"])),
@@ -1390,33 +1396,34 @@ case "$sub" in
     # STICKY PER TAB: the extension stores the state and re-applies it inside every
     # subsequent op's CDP session. It has to — CDP emulation overrides die when the
     # debugger detaches, and the bridge always detaches. `--reset` stops the
-    # re-applying and NOTHING ELSE: it sends no CDP clears and attaches no
-    # debugger. The non-viewport overrides come back on their own, because the
-    # overrides died at the last detach and reset simply stops re-installing them.
+    # re-applying, AND — since 0.8.1 — undoes the one override that does not clean
+    # itself up.
     #
-    # 🔴 `--reset` DOES NOT RESTORE THE VIEWPORT (#319, measured 2026-08-03 on
-    # extension 0.7.2, laptop, with a fresh-tab control):
+    # WHAT STICKS, AND WHY (#319, mechanism established 2026-08-04 in a throwaway
+    # Brave over raw CDP, never-emulated control tab every round):
     #
-    #   fresh tab, never emulated   innerWidth 1124   (control — the read path works)
-    #   after `emulate iphone-15`   innerWidth  393
-    #   after `emulate --reset`     innerWidth  393   ← NOT restored
-    #   after `--reset` + re-nav    innerWidth  393   ← still NOT restored
+    #   setDeviceMetricsOverride{393x852} in session A, detach   innerWidth  394
+    #   clearDeviceMetricsOverride in a FRESH session B          innerWidth  394 ← no-op
+    #   setDeviceMetricsOverride{...} THEN the clear, session B  innerWidth 1055 ← restored
+    #   (control tab, same window, untouched)                    innerWidth 1055
     #
-    # That measurement was taken on a build whose reset DID send and report the
-    # clears (`Emulation.clearDeviceMetricsOverride`, `setTouchEmulationEnabled`,
-    # `setUserAgentOverride`) — and the size survived them, which is why the
-    # clears were NOT carried into the shipped build. Every OTHER override does
-    # revert on its own — devicePixelRatio, maxTouchPoints, pointer:coarse,
-    # prefers-color-scheme, userAgent, timeZone — because CDP overrides die at
-    # debugger detach, not because they were cleared. Only the viewport SIZE is
-    # sticky; it survives the detach AND a re-navigation. The MECHANISM IS NOT ESTABLISHED (the
-    # leading hypothesis is a render-widget resize residue; do not repeat it as
-    # fact). Closing the tab is the only known remedy.
+    # `Emulation.clearDeviceMetricsOverride` does NOTHING when the session sending
+    # it never set an override itself — and it reports success anyway. That is why
+    # PR #320, which sent exactly that, changed nothing. Arming the session with
+    # any setDeviceMetricsOverride first makes the clear work.
     #
-    # `--reset --recreate` is that remedy, automated: it resets, then replaces the
-    # stuck tab with a fresh one at the SAME url owned by the same session, and
-    # closes the stuck one. THE TAB ID CHANGES — it is reported. Plain `--reset`
-    # never swaps tab ids.
+    # It is also the dpr-vs-width asymmetry the issue could not explain: dpr,
+    # maxTouchPoints, pointer:coarse, prefers-color-scheme, userAgent and timeZone
+    # are renderer-side session state that dies at detach, while the viewport SIZE
+    # additionally resizes the browser-side render widget, and only an armed
+    # session's clear undoes that. So only the size survived the detach and a
+    # re-navigation.
+    #
+    # `--reset --recreate` is kept as the REPLACEMENT path: it needs no CDP, and it
+    # is the only remedy for an un-upgraded build or a tab orphaned by a killed
+    # agent. It resets, opens a fresh tab at the SAME url owned by the same
+    # session, and closes the old one. THE TAB ID CHANGES — it is reported. Plain
+    # `--reset` never swaps tab ids.
     #
     # OWNED TABS ONLY. `browser open` first. Emulating a tab you are browsing in is
     # refused server-side with `not_owned_tab` — an agent must not be able to

--- a/scripts/browser-bridge/extension/README.md
+++ b/scripts/browser-bridge/extension/README.md
@@ -319,6 +319,37 @@ enough (never `pkill` Brave — tabs are not restorable).
 > because "is the new build loaded?" was once unfalsifiable, which cost three
 > full Brave restarts in a single session.)
 
+> **0.8.1 — `emulate --reset` actually UNDOES the viewport (#319).** The reset
+> branch was a Map delete that sent nothing; it now attaches one CDP session and
+> sends `Emulation.setDeviceMetricsOverride{width:0,height:0,deviceScaleFactor:0,
+> mobile:false}` followed by `Emulation.clearDeviceMetricsOverride`, and reports
+> them as `cleared` + `restored`. **Both steps are required**: measured
+> 2026-08-04 in a throwaway Brave 147.0.7727.56 under Xvfb over raw CDP, a bare
+> `clearDeviceMetricsOverride` sent from a session that did not itself set an
+> override is a **no-op that reports success** — which is why PR #320 changed
+> nothing. Arming the session first makes the clear resize the widget back.
+> That also explains the dpr-vs-width asymmetry #319 could not: dpr/touch/UA/
+> media/timezone are renderer-side session state that dies at detach, while the
+> size additionally resizes the browser-side render widget.
+>
+> New response fields are the discriminator — an older build cannot emit them:
+>
+> ```bash
+> browser open https://example.com && browser emulate iphone-15
+> browser emulate --reset          # read `.cleared` / `.restored`
+>   # ≤0.8.0 → {"reset":true,"wasEmulating":{…},"note":"…NOTHING WAS SENT…"}   (no `cleared`)
+>   # 0.8.1  → {"reset":true,"restored":true,
+>   #           "cleared":["Emulation.setDeviceMetricsOverride",
+>   #                      "Emulation.clearDeviceMetricsOverride"], …}
+> browser js --wake 'innerWidth'   # ← the REAL check: back to the desktop width
+> ```
+>
+> `--reset --recreate` is unchanged and still needed: it needs no CDP, and it is
+> the only remedy for an un-upgraded build or a tab orphaned by a `SIGKILL`'d
+> agent. ⚠ Verified in a scratch Brave and in unit tests against a browser model
+> calibrated to the measurements above — **not** against the operator's live
+> profile.
+
 > **0.8.0 — the BUILD MARKER: `ping` gains `buildMarker`, and `extension_stale`
 > is computed from it instead of from the version (#324).** New generated file
 > `build_id.js` exporting a `BUILD_MARKER` literal, imported by

--- a/scripts/browser-bridge/extension/build_id.js
+++ b/scripts/browser-bridge/extension/build_id.js
@@ -24,4 +24,4 @@
 //   * a hash computed in the worker over its own source — same disk read
 // The marker must be a LITERAL in a module the worker imported, so that it was
 // frozen into the loaded module graph at load time and travels with the code.
-export const BUILD_MARKER = "9ca73218873b35fa";
+export const BUILD_MARKER = "73f5438f18f395d2";

--- a/scripts/browser-bridge/extension/manifest.json
+++ b/scripts/browser-bridge/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Browser Bridge (command channel)",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Lets a local Claude Code skill drive the active Brave tab (getHtml/eval/tabs/nav/screenshot/frames/click/type/key/activate/upload/emulate/ping) via a loopback, token-authenticated rendezvous server. Local-only, authorized personal automation.",
   "permissions": ["scripting", "tabs", "activeTab", "storage", "alarms", "debugger", "webNavigation"],
   "host_permissions": ["http://127.0.0.1:8788/*", "<all_urls>"],

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -561,46 +561,42 @@ export async function applyWakeSteps(send, steps = WAKE_CDP_STEPS) {
 // everything in THIS file is the pure, browser-free half: the preset table, the
 // validation, and the ordered CDP step list.
 //
-// 🔴 THE VIEWPORT SIZE DOES **NOT** COME BACK. This block used to claim the
-// opposite — that because the overrides die at detach "the tab is NOT emulated
-// between ops", so a crashed agent could never leave the operator's browser
-// distorted. MEASURED FALSE, 2026-08-03, extension 0.7.2, with a fresh-tab
-// control:
+// 🔴 THE VIEWPORT SIZE DOES **NOT** DIE AT DETACH — it is the ONE exception, and
+// this block twice claimed something false about it. It first claimed the tab is
+// "NOT emulated between ops", so a crashed agent could never leave the operator's
+// browser distorted; that was measured false on 2026-08-03 (fresh-tab control
+// 1124, after `emulate iphone-15` 393, after `--reset` 393, after a re-nav 393).
+// It then claimed the size could not be restored at all and that the mechanism was
+// unknown. That second claim is ALSO false, and it is now fixed — see
+// EMULATION_RESET_CDP_STEPS below for the measurement and the mechanism.
 //
-//   fresh tab, never emulated   innerWidth 1124   (control — the read path works)
-//   after `emulate iphone-15`   innerWidth  393
-//   after `emulate --reset`     innerWidth  393   ← NOT restored
-//   after `--reset` + re-nav    innerWidth  393   ← still NOT restored
+// The accurate statement:
 //
-// That measurement was taken on a build whose reset DID send and report
-// `cleared: [Emulation.clearDeviceMetricsOverride,
-// Emulation.setTouchEmulationEnabled, Emulation.setUserAgentOverride]`, and the
-// size survived them anyway. Sending `clearDeviceMetricsOverride` simply does not
-// restore the viewport — which is why THIS build does not send it: `--reset` here
-// only stops re-applying (service_worker.js's reset branch is a Map delete; no
-// debugger attach, no CDP message). The measurement stands; the clears do not.
+//   * devicePixelRatio, maxTouchPoints, pointer:coarse, prefers-color-scheme,
+//     userAgent and timeZone are renderer-side session state and DO revert on
+//     their own at detach — because the override dies with the session that set
+//     it, not because anything cleared them;
+//   * the viewport SIZE additionally resizes the BROWSER-side render widget, and
+//     nothing undoes that at detach. So between ops the tab is visibly still the
+//     emulated size, and it survives a re-navigation.
+//   * (`"ontouchstart" in window` also stays true on a document that was BUILT
+//     emulated — that one is document-creation residue and a re-nav does clear it.)
 //
-// What DOES revert by itself, measured in the same pass: devicePixelRatio,
-// maxTouchPoints, pointer:coarse, prefers-color-scheme, userAgent, timeZone —
-// and they revert because a CDP override dies with the debugger session that set
-// it, NOT because anything cleared them. Only the viewport SIZE is sticky.
-// (`"ontouchstart" in window` also stays true on a document that was BUILT
-// emulated — that one is document-creation residue and a re-nav does clear it.)
+// `--reset` therefore has to UNDO the size explicitly, and it does: it attaches a
+// session and sends EMULATION_RESET_CDP_STEPS (arm, then clear). The arming step
+// is the whole trick — a bare clearDeviceMetricsOverride from a session that never
+// set an override is a no-op, which is why PR #320 sent exactly that and changed
+// nothing. Full measurement lives next to the step list, deliberately: it is the
+// justification for a two-step list that looks like it should be one step.
 //
-// THE MECHANISM IS NOT ESTABLISHED. The leading hypothesis is a render-widget
-// resize residue — consistent with devicePixelRatio reverting while the width does
-// not, even though both come from the same CDP call — but that is a hypothesis,
-// not a finding. Do not restate it as known, and do not build a fix on it.
-//
-// THE ONLY KNOWN REMEDY IS TO CLOSE THE TAB. `--reset` therefore means "stop
-// re-applying" and nothing more — it is NOT an undo. That is issue #319; the
-// operator-facing workaround is `browser emulate --reset --recreate`, which
-// replaces the stuck tab with a fresh one at the same url (the tab id changes).
+// `browser emulate --reset --recreate` stays. It is the remedy that needs no CDP
+// at all, and it is the ONLY one for a tab the extension can no longer reach —
+// an un-upgraded build, or a tab orphaned by a SIGKILL'd agent that never got to
+// run its reset. See issue #319.
 //
 // The apply-then-act design above is still the right shape — a held-open session
-// would add a permanent debug banner on top of the same stuck viewport — but it
-// buys strictly less than this comment used to claim, and the difference is
-// exactly what the operator gets stuck with.
+// would add a permanent debug banner — but it buys less than this comment
+// originally claimed: it bounds the renderer-side overrides, not the size.
 //
 // BLAST RADIUS: enforced SERVER-side (see server.py OWNED_TAB_ONLY_OPS). Only a
 // tab the calling session opened via `open` may be emulated; anything else is
@@ -1133,6 +1129,64 @@ export async function applyEmulationSteps(send, steps) {
   return applied;
 }
 
+// --- UNDOING the viewport: the ARM-THEN-CLEAR pair -------------------------- //
+//
+// The ordered CDP step list `emulate --reset` sends. TWO steps, and the FIRST one
+// is the entire reason this works — deleting it silently restores the #319 bug
+// while every response field still says `ok`.
+//
+// WHAT WAS MEASURED (2026-08-04, throwaway Brave 147.0.7727.56 under Xvfb, raw
+// CDP over the DevTools websocket, never-emulated control tab every round):
+//
+//   session A: setDeviceMetricsOverride{393x852} → detach       innerWidth 394
+//   session B: clearDeviceMetricsOverride        → detach       innerWidth 394  ← no-op
+//   session B: setDeviceMetricsOverride{…} then clear → detach  innerWidth 1055 ← restored
+//
+// `Emulation.clearDeviceMetricsOverride` sent from a session that never itself set
+// a device-metrics override DOES NOTHING. The clear is conditional on the calling
+// session's own emulation handler believing emulation is on; a fresh session's is
+// off, so the clear returns success and never reaches the browser-side widget
+// resize. Sending ANY setDeviceMetricsOverride first flips that bit — the params
+// are irrelevant: {393x852}, {800x600}, {1x1} and {0,0,0,false} all made the
+// following clear restore the true width (5 restores / 5 attempts on the shipped
+// pair, plus 2 no-op runs on a never-emulated tab).
+//
+// THAT IS ALSO THE dpr-VS-WIDTH ASYMMETRY (#319's sharpest clue, previously
+// unexplained). Both come from the same call, but they live in different places:
+// devicePixelRatio, touch points, pointer:coarse, UA, timezone and emulated media
+// are renderer-side session state that dies with the debugger session — measured
+// reverting on their own at detach. The viewport SIZE additionally resizes the
+// BROWSER-side render widget, and that resize is undone only by an explicit clear
+// from a session that has emulation armed. Nothing does that at detach, so the
+// size — and only the size — survives. This is an inference from the observable
+// behaviour above, not from reading Chromium's source; the measurements are the
+// finding, this paragraph is the explanation they support.
+//
+// WHY {width:0, height:0, deviceScaleFactor:0, mobile:false} for the arming step:
+// it is the least invasive override that still flips the bit. Measured in-session
+// after arming, the width was still the EMULATED one (394, not the real 1055) —
+// so arming does not itself resize anything and there is no intermediate flash to
+// the wrong size. The restore happens on the clear.
+//
+// NOTHING ELSE IS SENT, deliberately. There is no clear for touch/UA/media/tz/geo
+// here because they need none: they were measured reverting at detach on their
+// own. A clear for them would be ceremony that makes the reset look thorough
+// while doing nothing.
+//
+// BEST-EFFORT AT THE CALL SITE: the reset must not fail because a tab was closed,
+// discarded, or sits on a privileged scheme the debugger refuses. service_worker's
+// reset branch catches and reports (`restored`/`restoreError`) rather than throwing
+// — the in-memory state is dropped either way.
+export const EMULATION_RESET_CDP_STEPS = Object.freeze([
+  // 1. ARM. Without this the next step is a no-op. See above.
+  Object.freeze({
+    method: "Emulation.setDeviceMetricsOverride",
+    params: Object.freeze({ width: 0, height: 0, deviceScaleFactor: 0, mobile: false }),
+  }),
+  // 2. CLEAR. This is the step that resizes the render widget back.
+  Object.freeze({ method: "Emulation.clearDeviceMetricsOverride", params: Object.freeze({}) }),
+]);
+
 // The compact, METADATA-ONLY summary of a stored state — what `emulate` returns,
 // what `tabs` annotates an emulated tab with, and what goes into telemetry. No
 // URL, no page content; the UA string is deliberately EXCLUDED (it is long, and
@@ -1162,13 +1216,18 @@ export function emulationSummary(state) {
 // NEVER attaches the debugger, so withCdp's re-application choke point never runs
 // and the DOM they see is the tab's REAL, un-emulated one.
 //
-// That is correct-by-design, not a bug: between ops the tab genuinely is not
-// emulated (the safety property above), so the at-rest DOM really is desktop.
-// But it is a TRAP, and it is this feature's characteristic failure mode on the
-// read path: an agent screenshots a phone layout, then reads `text`/`html` and
-// reasons about a DESKTOP DOM, with nothing in the envelope to tell it apart.
-// Layout-derived values (innerWidth, getBoundingClientRect, matchMedia) and
-// navigator.userAgent all come back REAL.
+// The at-rest DOM is a MIXTURE, and that is worse than either pure case. Measured
+// (2026-08-04, scratch Brave, a session that applies no overrides — the exact
+// shape of a non-CDP read): navigator.userAgent, devicePixelRatio,
+// maxTouchPoints and `pointer: coarse` all come back REAL/desktop, because those
+// overrides died with the session that set them — but `innerWidth` comes back
+// EMULATED (394, against a 1055 control), because the widget really is that size
+// until something clears it.
+//
+// So the trap is not "you get the desktop DOM"; it is that you get a page laid out
+// at the phone WIDTH while every capability signal says desktop. An agent that
+// screenshots a phone layout, then reads `text`/`html`, reasons about a document
+// that no real device would ever produce.
 //
 // So every read of a tab that HAS emulation state says which one it got. Same
 // pattern, and the same reasoning, as HIDDEN_TAB_NOTE: the read self-announces
@@ -1179,11 +1238,14 @@ export function emulationSummary(state) {
 // the read through cdpWake → withCdp and therefore through the emulation apply.
 export const NOT_EMULATED_READ_NOTE =
   "This tab has device emulation configured, but THIS read did not go through "
-  + "CDP — it read the tab's REAL, un-emulated DOM. Emulation overrides only "
-  + "exist inside a CDP session (they die at detach), so layout-derived values "
-  + "(innerWidth, getBoundingClientRect, matchMedia) and navigator.userAgent are "
-  + "the DESKTOP ones here. Re-run this read with --wake to read inside an "
-  + "emulated session.";
+  + "CDP, so the overrides were NOT applied to it — and what you got is a MIXTURE, "
+  + "not a clean desktop read. navigator.userAgent, devicePixelRatio, "
+  + "maxTouchPoints and matchMedia('(pointer: coarse)') are the REAL desktop "
+  + "values, because those overrides die when the debugger detaches. But the "
+  + "VIEWPORT SIZE persists on the tab, so innerWidth and every "
+  + "getBoundingClientRect are the EMULATED ones: this is a page laid out at the "
+  + "phone width while every capability signal says desktop. Re-run this read "
+  + "with --wake to read inside a properly emulated session.";
 
 // Annotate a READ result with whether it observed the emulated page.
 //   * no emulation state for the tab → returns `data` UNTOUCHED (a plain tab's

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -55,6 +55,7 @@ import {
   // STICKY per tab because CDP overrides die at detach — see the EMULATION section
   // in protocol.js for the central problem and the safety property it buys.
   normalizeEmulation, emulationCdpSteps, applyEmulationSteps, emulationSummary,
+  EMULATION_RESET_CDP_STEPS,
   isTouchEmulated, touchTapEvents, DEVICE_PRESETS, PRESET_NAMES,
   annotateEmulatedRead, emulationCreateTimeSignature, documentPredatesEmulation,
   annotateDocumentPredates,
@@ -1206,25 +1207,32 @@ const OPS = {
   // rather than discovering a bad timezone id three ops later. Every subsequent op
   // that attaches CDP re-applies it (see the choke point in withCdp).
   //
-  // `--reset` means "STOP RE-APPLYING", and NOTHING ELSE. Read the branch below:
-  // it calls clearEmulation(), which is `emulationState.delete(tabId)` and no more
-  // — no debugger is attached and NOT ONE CDP message is sent. It is NOT an undo,
-  // and it must not be described as one.
+  // `--reset` does TWO things: it stops re-applying, AND it actively restores the
+  // emulated viewport by attaching a CDP session and sending the arm-then-clear
+  // pair (protocol.js EMULATION_RESET_CDP_STEPS). It IS an undo now — #319.
   //
-  // WHY IT LOOKS LIKE AN UNDO ANYWAY. The non-viewport overrides (UA, tz, dpr,
-  // touch points, prefers-color-scheme) revert ON THEIR OWN, because a CDP
-  // override lives only as long as the debugger session that set it and withCdp
-  // always detaches. Reset does not clear them; it simply stops re-installing
-  // them on the next attach. That distinction is load-bearing — anyone who
-  // believes a clear was sent will mis-diagnose the viewport.
+  // THE ORDER IN THE BRANCH IS LOAD-BEARING: clearEmulation() runs FIRST, before
+  // the attach. withCdp's re-application choke point reads `emulationFor(tabId)`
+  // at attach time, so resetting the Map afterwards would have this very session
+  // re-install the phone metrics on the way in, and the clear would then be
+  // undoing an override the reset itself had just applied.
   //
-  // THE VIEWPORT SIZE IS THE EXCEPTION and it does NOT come back: measured
-  // 2026-08-03 (ext 0.7.2, fresh-tab control), 1124 → emulate → 393 → reset →
-  // 393 → re-nav → 393. That build DID send `Emulation.clearDeviceMetricsOverride`
-  // and the size survived it anyway, which is exactly why the clears were NOT
-  // carried into this build: they are not the remedy. Mechanism unestablished
-  // (#319); replacing the tab (`--reset --recreate`) is the only known remedy.
-  // See protocol.js EMULATION.
+  // WHY THE ARMING STEP EXISTS — do not "simplify" it away. A bare
+  // clearDeviceMetricsOverride from a fresh session is a NO-OP (measured); that is
+  // why PR #320, which sent exactly that, changed nothing and was closed. Full
+  // measurement and the dpr-vs-width explanation live in protocol.js next to the
+  // step list.
+  //
+  // The other overrides (UA, tz, dpr, touch points, prefers-color-scheme) need no
+  // clear — they die with the debugger session that set them, measured. Reset just
+  // stops re-installing them.
+  //
+  // BEST-EFFORT, ALWAYS. A closed/discarded tab or a privileged scheme makes the
+  // attach throw; the state is dropped regardless and the failure is REPORTED
+  // (`restored:false` + `restoreError`) rather than raised, because the caller's
+  // "stop emulating" did succeed. `--reset --recreate` remains the remedy that
+  // needs no CDP at all — and the only one for a tab orphaned by a SIGKILL'd agent
+  // or an un-upgraded build.
   //
   // OWNERSHIP is enforced SERVER-side (server.py OWNED_TAB_ONLY_OPS → the named
   // `not_owned_tab` refusal), not here, because the server is the only side that
@@ -1236,25 +1244,48 @@ const OPS = {
 
     if (state.reset) {
       const had = emulationSummary(emulationFor(tab.id));
-      clearEmulation(tab.id);
+      clearEmulation(tab.id);            // FIRST — see the ordering note above.
+      let cleared = [];
+      let restoreError = null;
+      try {
+        cleared = await withCdp(tab.id, tab.url, (send) =>
+          applyEmulationSteps(send, EMULATION_RESET_CDP_STEPS));
+      } catch (e) {
+        restoreError = String((e && e.message) || e);
+      }
+      const restored = restoreError === null;
       return {
         tabId: tab.id, url: tab.url, reset: true,
         wasEmulating: had,
+        // The METHODS actually acknowledged by the browser, in order. Empty when
+        // the attach failed. This is the field that makes the note's claim
+        // checkable instead of trusted.
+        cleared,
+        restored,
+        ...(restoreError === null ? {} : { restoreError }),
         // 🔴 PINNED, character for character, by tests/service_worker.test.mjs
-        // ("emulate --reset: the runtime note"). That test also asserts NO
-        // debugger call is made, so the "nothing was sent" sentence cannot rot
-        // into a claim while the code does something else. If you change this
-        // string, change the test in the SAME commit — that is the point.
-        note: "emulation stopped: this tab will no longer have overrides re-applied. "
-          + "NOTHING WAS SENT TO THE BROWSER — no debugger was attached and no CDP "
-          + "clears were issued. THIS IS NOT AN UNDO. The UA, timezone, "
-          + "devicePixelRatio, touch points and prefers-color-scheme revert on "
-          + "their own, because CDP overrides die when the debugger detaches — not "
-          + "because anything cleared them. The emulated VIEWPORT SIZE does NOT "
-          + "come back: it survives the detach and a re-navigation (measured; "
-          + "mechanism unknown, issue #319). Replacing the tab is the only known "
-          + "remedy: `browser emulate --reset --recreate` opens a fresh tab at the "
-          + "same url and closes this one (the tab id changes).",
+        // ("emulate --reset: the runtime note"). Written AFTER the branch above,
+        // from what it does. If you change this string, change the test in the
+        // SAME commit — that is the point.
+        note: restored
+          ? "emulation stopped AND the emulated viewport was restored: a CDP "
+            + "session was attached and Emulation.setDeviceMetricsOverride "
+            + "{width:0,height:0} then Emulation.clearDeviceMetricsOverride were "
+            + "sent (see `cleared`). Both steps are required — a bare "
+            + "clearDeviceMetricsOverride from a session that did not itself set "
+            + "an override is a measured no-op, which is why earlier attempts to "
+            + "undo this changed nothing (#319). The UA, timezone, "
+            + "devicePixelRatio, touch points and prefers-color-scheme were NOT "
+            + "cleared and did not need to be: they die with the debugger session "
+            + "that set them. If you still see the emulated size, `browser "
+            + "emulate --reset --recreate` opens a fresh tab at the same url and "
+            + "closes this one (the tab id changes)."
+          : "emulation stopped, but the viewport restore did NOT reach the tab "
+            + "(see `restoreError`): no CDP clears were acknowledged, so this tab "
+            + "may still be stuck at the emulated size. Nothing will be re-applied "
+            + "to it from now on. The remedy that needs no CDP is `browser emulate "
+            + "--reset --recreate`, which opens a fresh tab at the same url and "
+            + "closes this one (the tab id changes).",
       };
     }
 
@@ -1295,9 +1326,13 @@ const OPS = {
       emulation: emulationSummary(state),
       applied,
       note: "sticky per tab: these overrides are re-applied inside every "
-        + "subsequent op's CDP session. Between ops the tab is NOT emulated (the "
-        + "overrides die at detach), so a crashed agent cannot leave your browser "
-        + "distorted. `browser emulate --reset` stops re-applying.",
+        + "subsequent op's CDP session. Between ops the UA, timezone, "
+        + "devicePixelRatio, touch points and prefers-color-scheme are NOT in "
+        + "force (they die at detach), but the VIEWPORT SIZE stays: it resizes the "
+        + "browser-side widget and survives the detach, so this tab is visibly the "
+        + "emulated size until you undo it. `browser emulate --reset` undoes it "
+        + "(it sends the arm-then-clear pair — #319); if the tab is orphaned by a "
+        + "killed agent, `--reset --recreate` replaces it.",
     }, documentPredatesEmulation(tab.url, emulationCreateTimeSignature(state),
                                  documentEmulation.get(tab.id)));
   },

--- a/scripts/browser-bridge/reference/emulation.md
+++ b/scripts/browser-bridge/reference/emulation.md
@@ -19,9 +19,9 @@ browser emulate iphone-15            # ← replies documentPredatesEmulation: tr
 browser nav https://example.com      # ← … so RE-NAV: the document is rebuilt emulated
 browser screenshot                   # ← captured at 393×852 @3x, as an iPhone
 browser click '#menu'                # ← dispatched as a TOUCH tap
-browser emulate --reset --recreate   # ← the viewport does NOT come back on
-                                     #   --reset alone (#319); --recreate
-                                     #   replaces the tab. THE TAB ID CHANGES.
+browser emulate --reset              # ← undoes it, viewport included (0.8.1, #319)
+                                     #   --reset --recreate replaces the tab
+                                     #   instead; THE TAB ID CHANGES.
 ```
 
 `browser emulate --list` prints the preset names without touching the browser.
@@ -109,7 +109,7 @@ document that was not built under this emulation. See "The
 
 ---
 
-## Why it is sticky — and 🔴 why `--reset` does NOT undo it (#319)
+## Why it is sticky — and how `--reset` undoes it (#319)
 
 CDP emulation overrides are **session-scoped**: they die the instant the debugger
 detaches. The bridge **always** detaches (`withCdpSession`'s `finally` — that is a
@@ -132,31 +132,78 @@ crashed agent could never leave the operator's browser distorted. **Measured fal
 | after `emulate --reset` | **393** ← not restored |
 | after `--reset` **and** a re-`nav` | **393** ← still not restored |
 
-The build under test genuinely sent and reported its clears
+The build under test genuinely sent and reported a clear
 (`cleared: [Emulation.clearDeviceMetricsOverride,
 Emulation.setTouchEmulationEnabled, Emulation.setUserAgentOverride]`) and the size
-survived them. **Sending `clearDeviceMetricsOverride` does not bring the viewport
-back.** The size survives the detach, the clear and a re-navigation.
+survived it. That measurement is correct, and it is why PR #320 was closed. What
+it did **not** establish is *why* — and the reason turns out to be the fix.
 
-🔴 **The shipped build therefore sends nothing.** `emulate --reset` deletes the
-tab's stored emulation state and stops later ops re-applying it — no debugger
-attach, no CDP message, no `cleared` field. The clears were deliberately not
-carried over, because the measurement above shows they are not the remedy.
+Everything else *does* revert on its own: `devicePixelRatio`, `maxTouchPoints`,
+`pointer: coarse`, `prefers-color-scheme`, `userAgent`, `timeZone` — **because a
+CDP override dies with the debugger session that set it**, not because a clear was
+sent. **Only the viewport size is sticky.** (`'ontouchstart' in window` also stays
+true on a document that was *built* emulated — that one is document-creation
+residue, and a re-`nav` clears it.)
 
-Everything else *does* revert on its own, measured in the same pass:
-`devicePixelRatio`, `maxTouchPoints`, `pointer: coarse`, `prefers-color-scheme`,
-`userAgent`, `timeZone` — **because a CDP override dies when the debugger
-detaches**, not because a clear was sent. **Only the viewport size is sticky.**
-(`'ontouchstart' in window` also stays true on a document that was *built*
-emulated — that one is document-creation residue, and a re-`nav` clears it.)
+### The mechanism (established 2026-08-04)
 
-**The mechanism is not established.** The leading hypothesis is a render-widget
-resize residue — consistent with `devicePixelRatio` reverting while the width does
-not, though both come from the same CDP call — but that is a hypothesis, not a
-finding. Do not repeat it as fact.
+Measured against a **throwaway Brave 147.0.7727.56 under Xvfb**, driven over the
+raw DevTools websocket with no extension in the loop, with a never-emulated control
+tab read every round:
 
-**Closing the tab is the only known remedy.** So `--reset` means *"stop
-re-applying"*, never *"undo"*. The workaround is:
+| what was done | victim `innerWidth` | control |
+| --- | --- | --- |
+| `setDeviceMetricsOverride{393×852}` in session A, then **detach** | **394** | 1055 |
+| `clearDeviceMetricsOverride` in a **fresh** session B, then detach | **394** ← no-op | 1055 |
+| `setDeviceMetricsOverride{…}` **then** `clearDeviceMetricsOverride` in session B | **1055** ← restored | 1055 |
+
+🔴 **`Emulation.clearDeviceMetricsOverride` does nothing when the session sending
+it never set an override itself.** It returns success either way. Every previous
+attempt to undo this sent the clear from a fresh session — so it was a no-op, and
+the acknowledgement made it look like it had worked.
+
+**That also explains the dpr-vs-width asymmetry**, which was the open question in
+#319. The two values live in different places even though one call sets both:
+`devicePixelRatio`, touch, UA, media and timezone are **renderer-side session
+state** that dies at detach; the viewport size additionally resizes the
+**browser-side render widget**, and that resize is undone *only* by an explicit
+clear from a session that has emulation armed. Nothing does that at detach — so
+the size, and only the size, survives. (Inference from the behaviour above, not
+from reading Chromium's source. The table is the finding.)
+
+The arming params do not matter — `{393×852}`, `{800×600}`, `{1×1}` and
+`{0,0,0,false}` all made the following clear restore the true width. The shipped
+pair uses `{width:0,height:0,deviceScaleFactor:0,mobile:false}` because it was
+measured **not to resize anything on its own** (still 394 in-session after arming),
+so there is no intermediate flash to a wrong size.
+
+### What `--reset` does now (0.8.1)
+
+`emulate --reset` drops the stored state **and then** attaches one CDP session and
+sends `EMULATION_RESET_CDP_STEPS` — the arming override, then the clear. It
+reports them:
+
+```json
+{ "reset": true, "wasEmulating": {…}, "restored": true,
+  "cleared": ["Emulation.setDeviceMetricsOverride",
+              "Emulation.clearDeviceMetricsOverride"] }
+```
+
+Three properties worth knowing:
+
+* **Both steps ride one session.** Splitting them reintroduces the bug exactly.
+* **It is unconditional** — it fires even when this service worker holds no state
+  for the tab. That is the case that matters: an evicted MV3 worker forgets the
+  state while the tab stays physically stuck. Measured safe on a never-emulated
+  tab (2/2 runs left it at its true width).
+* **It is best-effort.** A closed/discarded tab or a privileged scheme makes the
+  attach fail; you get `restored: false` + `restoreError` and no exception, because
+  "stop emulating" did succeed.
+
+`--reset --recreate` **stays**, and is still the right tool twice over: it is the
+remedy that needs no CDP at all, and it is the **only** one for a tab the extension
+can no longer reach — an un-upgraded build, or a tab orphaned by a `SIGKILL`'d
+agent that never ran its reset.
 
 ```
 browser emulate --reset --recreate
@@ -167,6 +214,11 @@ the stuck one, and reports the **new tab id** (it changes — later ops route to
 It refuses on a non-http(s) url, and always opens the replacement *before* closing
 the original, so no failure path leaves you with no tab. Plain `--reset` never
 swaps tab ids.
+
+⚠ **Not verified against the operator's live Brave.** Everything above was
+measured in a throwaway instance and in unit tests against a browser model
+calibrated to those measurements. See the PR for the exact live-verification
+commands.
 
 **Consequence to plan around:** a page that re-measures the viewport *later* — on
 a `resize` listener, or well after load — sees whatever the tab's physical size now
@@ -280,17 +332,18 @@ and sends no `Sec-CH-UA` at all. That is correct emulation, not a missing field.
 **The single most important thing on this page.** Read it before you trust a read.
 
 `text`, `html` and the default `js`/`eval` go through `chrome.scripting`, which
-**never attaches the debugger** — so the emulation is never applied and they return
-the tab's **real, un-emulated DOM**. `innerWidth`, `getBoundingClientRect`,
-`matchMedia` and `navigator.userAgent` all come back **desktop**.
+**never attaches the debugger** — so the emulation is never applied. What you get
+back is a **MIXTURE**, which is worse than either pure case:
 
-That is by design for the *override* half — UA, `matchMedia`, timezone and dpr
-really do come back desktop on these reads, because nothing re-applies them. ⚠ The
-**viewport size is the exception**: it is physically stuck on the tab (see "🔴 why
-`--reset` does NOT undo it" above), so `innerWidth` on an emulated tab reads the
-emulated width even on the un-emulated path. Either way this is the trap the
-feature is most likely to spring — screenshot a phone layout, then read `text` and
-reason about a half-desktop DOM.
+| on a `text`/`html`/`js` read of an emulated tab | value |
+| --- | --- |
+| `navigator.userAgent`, `devicePixelRatio`, `maxTouchPoints`, `matchMedia('(pointer: coarse)')`, timezone | **real / desktop** — the overrides died at detach |
+| `innerWidth`, every `getBoundingClientRect` | **emulated** — the widget is physically that size (see "Why it is sticky" above) |
+
+So the page you read is laid out at the phone **width** while every capability
+signal says desktop — a document no real device would produce. This is the trap the
+feature is most likely to spring: screenshot a phone layout, then read `text` and
+reason about that hybrid. Use `--wake`.
 
 **Which reads are emulated:**
 

--- a/scripts/browser-bridge/tests/emulation.test.mjs
+++ b/scripts/browser-bridge/tests/emulation.test.mjs
@@ -673,12 +673,24 @@ test("--reset STOPS re-application (and reports what it stopped)", async () => {
   assert.ok(sw.events.includes("captureVisibleTab"));
 });
 
-test("--reset on a tab that was never emulated is a clean no-op", async () => {
+// --reset sends the restore pair UNCONDITIONALLY — including when this service
+// worker holds no state for the tab. That is deliberate and it is the case that
+// matters most: an evicted MV3 worker forgets `emulationState`, but the tab is
+// still physically stuck at the emulated size (the widget resize survives the
+// detach — #319). Gating the restore on `wasEmulating` would leave exactly the
+// orphaned tab unrescuable, which is the situation the operator actually hits.
+// Measured safe: arm-then-clear on a never-emulated tab left it at its true width
+// (2/2 runs, scratch Brave 2026-08-04) — see EMULATION_RESET_CDP_STEPS.
+test("--reset on a tab that was never emulated still sends the restore pair", async () => {
   fresh();
   const out = await OPS.emulate({ tabId: TAB_A, reset: true });
   assert.equal(out.reset, true);
-  assert.equal(out.wasEmulating, null);
-  assert.deepEqual(sw.cdp, [], "reset touches no CDP at all");
+  assert.equal(out.wasEmulating, null, "nothing was stored, and it says so");
+  assert.deepEqual(methods(),
+    ["Emulation.setDeviceMetricsOverride", "Emulation.clearDeviceMetricsOverride"],
+    "the restore is unconditional: a worker that forgot the state must still be " +
+    "able to un-stick the tab");
+  assert.deepEqual(out.cleared, methods());
 });
 
 test("`close` clears the tab's emulation state", async () => {

--- a/scripts/browser-bridge/tests/emulation_reset.test.mjs
+++ b/scripts/browser-bridge/tests/emulation_reset.test.mjs
@@ -1,0 +1,246 @@
+// emulation_reset.test.mjs — `emulate --reset` must UNDO the emulated viewport.
+//
+// Issue #319: device-metrics emulation was permanently sticky per tab. It survived
+// the debugger detach, it survived `--reset`, and it survived a re-navigation. The
+// only remedy was closing the tab.
+//
+// 🔴 WHY THIS FILE EXISTS AND WHY IT DOES NOT ASSERT `ok:true`.
+// The broken behaviour ALREADY returned `{ok:true, reset:true, wasEmulating:{…}}`.
+// A test that checks the envelope passes on the bug. So does a test that checks
+// "clearDeviceMetricsOverride was sent" — PR #320 sent exactly that, it was
+// deployed to a real profile, the clear was acknowledged, and the viewport did not
+// come back. The ONLY assertion that discriminates is the VIEWPORT AFTER RESET.
+//
+// So this file models the browser's measured behaviour and asserts the width.
+//
+// --- THE MODEL, AND WHAT CALIBRATES IT --------------------------------------- //
+//
+// Measured 2026-08-04 against a throwaway Brave 147.0.7727.56 under Xvfb, driven
+// over the raw DevTools websocket (no extension in the loop), with a never-emulated
+// control tab read every round:
+//
+//   session A: setDeviceMetricsOverride{393x852,dsf3,mobile} → detach   innerWidth 394
+//              (control tab, same window, untouched)                    innerWidth 1055
+//   session B: clearDeviceMetricsOverride → detach                      innerWidth 394
+//   session B: setDeviceMetricsOverride{…} then clear → detach          innerWidth 1055
+//
+// i.e. THREE rules, and rule 2 is the whole bug:
+//   1. a device-metrics override resizes the browser-side widget, and that resize
+//      SURVIVES the detach (devicePixelRatio, touch points, pointer:coarse, UA and
+//      timezone do not — they revert on their own, measured);
+//   2. clearDeviceMetricsOverride is a NO-OP unless the CALLING session has itself
+//      set an override — a fresh session's clear silently does nothing;
+//   3. any setDeviceMetricsOverride arms the session, and {width:0,height:0} arms
+//      it WITHOUT resizing anything (measured: still 394 in-session after arming),
+//      so the arm-then-clear pair restores with no intermediate flash.
+//
+// The model below implements exactly those three rules and nothing else. It is
+// validated in BOTH directions before any product assertion is read (see the two
+// HARNESS tests): it must be able to report a STUCK viewport, and it must be able
+// to report a RESTORED one. A model that could only ever say "restored" would make
+// every test here vacuous.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const TAB_ID = 11;
+const TAB_URL = "https://example.com/";
+const REAL_WIDTH = 1055;      // the never-emulated control's innerWidth
+const PHONE_WIDTH = 393;
+
+// --- the browser model -------------------------------------------------------- //
+const browser = {
+  widgetWidth: REAL_WIDTH,    // what innerWidth reports; survives detach (rule 1)
+  session: null,              // { armed } while the debugger is attached
+  commands: [],               // [{ session, method, params }] for ordering assertions
+  sessions: 0,
+  attachThrows: null,
+};
+
+function resetBrowser() {
+  browser.widgetWidth = REAL_WIDTH;
+  browser.session = null;
+  browser.commands = [];
+  browser.sessions = 0;
+  browser.attachThrows = null;
+}
+
+function cdp(method, params) {
+  browser.commands.push({ session: browser.sessions, method, params });
+  if (method === "Emulation.setDeviceMetricsOverride") {
+    browser.session.armed = true;                       // rule 3
+    if (params && params.width > 0) browser.widgetWidth = params.width;
+  } else if (method === "Emulation.clearDeviceMetricsOverride") {
+    if (browser.session.armed) {                        // rule 2
+      browser.session.armed = false;
+      browser.widgetWidth = REAL_WIDTH;
+    }
+  }
+  if (method === "Page.captureScreenshot") return { data: "QkJCQg==" };
+  return {};
+}
+
+globalThis.BROWSER_BRIDGE_NO_AUTOSTART = true;
+globalThis.chrome = {
+  webNavigation: { async getAllFrames() { return [{ frameId: 0, parentFrameId: -1, url: TAB_URL }]; } },
+  scripting: { async executeScript() { return [{ result: { ok: true }, frameId: 0 }]; } },
+  tabs: {
+    async get(id) { return { id, url: TAB_URL, title: "t", active: false, status: "complete", windowId: 1 }; },
+    async query() { return [{ id: TAB_ID, url: TAB_URL, active: false, status: "complete", windowId: 1 }]; },
+    async update(id) { return { id, url: TAB_URL }; },
+    async remove() {},
+  },
+  windows: { async update() {} },
+  debugger: {
+    async attach() {
+      if (browser.attachThrows) throw new Error(browser.attachThrows);
+      browser.sessions += 1;
+      browser.session = { armed: false };
+    },
+    async detach() { browser.session = null; },          // rule 1: width unchanged
+    async sendCommand(_t, method, params) { return cdp(method, params); },
+    onDetach: { addListener() {} },
+    onEvent: { addListener() {}, removeListener() {} },
+  },
+  storage: { local: { async get() { return {}; }, async set() {} } },
+  runtime: { onInstalled: { addListener() {} }, onStartup: { addListener() {} },
+             getManifest: () => ({ version: "0.0.0" }), id: "test" },
+  alarms: { create() {}, onAlarm: { addListener() {} } },
+};
+
+const { OPS } = await import("../extension/service_worker.js");
+const { EMULATION_RESET_CDP_STEPS } = await import("../extension/protocol.js");
+
+// Drive the model directly, the way a raw CDP client would.
+async function rawSession(fn) {
+  await globalThis.chrome.debugger.attach();
+  try { await fn((m, p) => cdp(m, p)); } finally { await globalThis.chrome.debugger.detach(); }
+}
+const PHONE_METRICS = { width: PHONE_WIDTH, height: 852, deviceScaleFactor: 3, mobile: true };
+
+// --------------------------------------------------------------------------- //
+// HARNESS VALIDATION — both directions, before any product assertion is read.
+// --------------------------------------------------------------------------- //
+
+test("HARNESS: the model reproduces #319 — a fresh session's bare clear is a NO-OP", async () => {
+  resetBrowser();
+  await rawSession(async (send) => send("Emulation.setDeviceMetricsOverride", PHONE_METRICS));
+  assert.equal(browser.widgetWidth, PHONE_WIDTH,
+    "rule 1: the widget resize must SURVIVE the detach, or this file cannot see the bug");
+  await rawSession(async (send) => send("Emulation.clearDeviceMetricsOverride"));
+  assert.equal(browser.widgetWidth, PHONE_WIDTH,
+    "rule 2 (measured): clearDeviceMetricsOverride from an UNARMED session does " +
+    "nothing — this is the negative control; if it restores, every assertion " +
+    "below is vacuous and the model is wrong");
+});
+
+test("HARNESS: the model CAN restore — arm-then-clear in one session works", async () => {
+  resetBrowser();
+  await rawSession(async (send) => send("Emulation.setDeviceMetricsOverride", PHONE_METRICS));
+  assert.equal(browser.widgetWidth, PHONE_WIDTH);
+  await rawSession(async (send) => {
+    await send("Emulation.setDeviceMetricsOverride", { width: 0, height: 0, deviceScaleFactor: 0, mobile: false });
+    assert.equal(browser.widgetWidth, PHONE_WIDTH,
+      "rule 3 (measured): arming with {0,0} must NOT itself resize — no flash");
+    await send("Emulation.clearDeviceMetricsOverride");
+  });
+  assert.equal(browser.widgetWidth, REAL_WIDTH,
+    "positive control: the model must be able to report a RESTORED viewport too");
+});
+
+// --------------------------------------------------------------------------- //
+// THE REGRESSION TEST (#319).
+// --------------------------------------------------------------------------- //
+
+test("emulate --reset RESTORES the viewport (#319) — the width, not the envelope", async () => {
+  resetBrowser();
+  await OPS.emulate({ tabId: TAB_ID, width: PHONE_WIDTH, height: 852, dsf: 3, mobile: true });
+  assert.equal(browser.widgetWidth, PHONE_WIDTH,
+    "precondition: the emulate must actually have moved the viewport");
+
+  const out = await OPS.emulate({ tabId: TAB_ID, reset: true });
+
+  // 🔴 THE assertion. `ok:true`/`reset:true`/`wasEmulating` were ALL true while
+  // the bug shipped; only this line discriminates.
+  assert.equal(browser.widgetWidth, REAL_WIDTH,
+    "emulate --reset must leave the tab at its REAL viewport width — this is #319 " +
+    "and it is the only assertion the broken behaviour fails");
+  assert.equal(out.restored, true);
+  assert.ok(out.wasEmulating, "the reset still reports the state it dropped");
+});
+
+test("emulate --reset survives a re-navigation in between (#319 step 6)", async () => {
+  resetBrowser();
+  await OPS.emulate({ tabId: TAB_ID, width: PHONE_WIDTH, height: 852, dsf: 3, mobile: true });
+  // A navigation does not restore the width — that was measured, and it is why
+  // "just re-nav" was ruled out as a remedy. Model it by leaving the width alone.
+  assert.equal(browser.widgetWidth, PHONE_WIDTH);
+  await OPS.emulate({ tabId: TAB_ID, reset: true });
+  assert.equal(browser.widgetWidth, REAL_WIDTH);
+});
+
+test("emulate --reset: sends the ARM-then-CLEAR pair, in that order", async () => {
+  resetBrowser();
+  await OPS.emulate({ tabId: TAB_ID, width: PHONE_WIDTH, height: 852, dsf: 3, mobile: true });
+  const before = browser.commands.length;
+  const out = await OPS.emulate({ tabId: TAB_ID, reset: true });
+
+  assert.deepEqual(out.cleared,
+    ["Emulation.setDeviceMetricsOverride", "Emulation.clearDeviceMetricsOverride"],
+    "the reported step list IS the fix: the arming override first, then the clear");
+  assert.deepEqual(EMULATION_RESET_CDP_STEPS.map((s) => s.method), out.cleared,
+    "the op must report exactly the pure step list, not a hand-rolled copy");
+
+  const sent = browser.commands.slice(before);
+  assert.deepEqual(sent.map((c) => c.method), out.cleared,
+    "and exactly those two commands reached the browser — nothing else");
+  assert.equal(new Set(sent.map((c) => c.session)).size, 1,
+    "both steps must ride ONE session: the clear is a no-op in a session that did " +
+    "not arm itself, so splitting them reintroduces #319");
+  assert.deepEqual(sent[0].params, { width: 0, height: 0, deviceScaleFactor: 0, mobile: false },
+    "the arming override must be the neutral one — it must not resize the tab to " +
+    "some other wrong size on the way out");
+});
+
+test("emulate --reset does NOT re-apply the emulation on its way in", async () => {
+  resetBrowser();
+  await OPS.emulate({ tabId: TAB_ID, width: PHONE_WIDTH, height: 852, dsf: 3, mobile: true });
+  const before = browser.commands.length;
+  await OPS.emulate({ tabId: TAB_ID, reset: true });
+  const sent = browser.commands.slice(before);
+  assert.equal(sent.some((c) => c.method === "Emulation.setDeviceMetricsOverride"
+                             && c.params && c.params.width === PHONE_WIDTH), false,
+    "the state must be dropped BEFORE the attach, or withCdp's re-application " +
+    "choke point re-installs the phone metrics inside the reset's own session");
+  assert.equal(sent.some((c) => c.method === "Emulation.setTouchEmulationEnabled"), false,
+    "likewise for touch — reset re-applies nothing");
+});
+
+test("emulate --reset is BEST-EFFORT: a refused attach reports, never throws", async () => {
+  resetBrowser();
+  await OPS.emulate({ tabId: TAB_ID, width: PHONE_WIDTH, height: 852, dsf: 3, mobile: true });
+  browser.attachThrows = "Cannot access a chrome:// URL";
+
+  const out = await OPS.emulate({ tabId: TAB_ID, reset: true });
+  assert.equal(out.reset, true, "the reset itself still succeeds");
+  assert.equal(out.restored, false);
+  assert.deepEqual(out.cleared, [], "nothing was acknowledged, so nothing is claimed");
+  assert.match(out.restoreError, /chrome:\/\//);
+  assert.match(out.note, /--reset --recreate/,
+    "the failure note must name the remedy that needs no CDP");
+
+  // …and the in-memory state is gone regardless, so nothing gets re-applied later.
+  browser.attachThrows = null;
+  const again = await OPS.emulate({ tabId: TAB_ID, reset: true });
+  assert.equal(again.wasEmulating, null);
+});
+
+test("emulate --reset on a never-emulated tab is a safe no-op on the viewport", async () => {
+  resetBrowser();
+  const out = await OPS.emulate({ tabId: TAB_ID, reset: true });
+  assert.equal(browser.widgetWidth, REAL_WIDTH,
+    "arm-then-clear on a tab that was never emulated must not move it (measured: " +
+    "2/2 runs left a never-emulated tab at its true width)");
+  assert.equal(out.wasEmulating, null);
+  assert.equal(out.restored, true);
+});

--- a/scripts/browser-bridge/tests/service_worker.test.mjs
+++ b/scripts/browser-bridge/tests/service_worker.test.mjs
@@ -389,21 +389,30 @@ test("ping: reports the BUILD MARKER, and it is INDEPENDENT of chrome.* (#324)",
 // normalised string, or this test is theatre.
 //
 // The two tests below are COMPLEMENTS and both are required:
-//   * the text says nothing was sent to the browser;
-//   * `state.calls.debugger` is empty, which is the code-side fact that makes
-//     that sentence true. Either alone can go green while the other rots.
+//   * the text says an arm-then-clear pair was sent;
+//   * `state.calls.debugger` shows exactly that pair, which is the code-side fact
+//     that makes the sentence true. Either alone can go green while the other rots.
+//
+// ⚠ The note was rewritten in 0.8.1 (#319): reset now DOES undo the viewport. The
+// old literal asserted "NOTHING WAS SENT TO THE BROWSER" and a matching empty
+// debugger list — both were true of the broken behaviour, and pinning them is
+// exactly what kept the false safety claim honest until the fix landed. The
+// VIEWPORT assertion itself lives in tests/emulation_reset.test.mjs, against a
+// browser model; this file pins the wording and the wire traffic.
 // --------------------------------------------------------------------------- //
 const RESET_NOTE =
-  "emulation stopped: this tab will no longer have overrides re-applied. " +
-  "NOTHING WAS SENT TO THE BROWSER — no debugger was attached and no CDP " +
-  "clears were issued. THIS IS NOT AN UNDO. The UA, timezone, " +
-  "devicePixelRatio, touch points and prefers-color-scheme revert on " +
-  "their own, because CDP overrides die when the debugger detaches — not " +
-  "because anything cleared them. The emulated VIEWPORT SIZE does NOT " +
-  "come back: it survives the detach and a re-navigation (measured; " +
-  "mechanism unknown, issue #319). Replacing the tab is the only known " +
-  "remedy: `browser emulate --reset --recreate` opens a fresh tab at the " +
-  "same url and closes this one (the tab id changes).";
+  "emulation stopped AND the emulated viewport was restored: a CDP " +
+  "session was attached and Emulation.setDeviceMetricsOverride " +
+  "{width:0,height:0} then Emulation.clearDeviceMetricsOverride were " +
+  "sent (see `cleared`). Both steps are required — a bare " +
+  "clearDeviceMetricsOverride from a session that did not itself set " +
+  "an override is a measured no-op, which is why earlier attempts to " +
+  "undo this changed nothing (#319). The UA, timezone, " +
+  "devicePixelRatio, touch points and prefers-color-scheme were NOT " +
+  "cleared and did not need to be: they die with the debugger session " +
+  "that set them. If you still see the emulated size, `browser " +
+  "emulate --reset --recreate` opens a fresh tab at the same url and " +
+  "closes this one (the tab id changes).";
 
 test("emulate --reset: the runtime note is pinned VERBATIM", async () => {
   resetCalls();
@@ -418,18 +427,24 @@ test("emulate --reset: the runtime note is pinned VERBATIM", async () => {
     "to the LLM agent — update this literal in the same commit as the string");
 });
 
-test("emulate --reset: sends NOTHING to CDP (the fact the note asserts)", async () => {
+test("emulate --reset: sends the arm-then-clear pair (the fact the note asserts)", async () => {
   resetCalls();
   const out = await OPS.emulate({ tabId: TAB_ID, reset: true });
-  assert.deepEqual(state.calls.debugger, [],
-    "reset must attach NO debugger and send NO CDP command — a non-empty list " +
-    "makes the note's 'NOTHING WAS SENT TO THE BROWSER' sentence false");
+  assert.deepEqual(state.calls.debugger,
+    ["attach",
+     "Emulation.setDeviceMetricsOverride",
+     "Emulation.clearDeviceMetricsOverride",
+     "detach"],
+    "reset attaches ONE session and sends the arming override then the clear — " +
+    "in that order, nothing else. A bare clear is a measured no-op (#319), so " +
+    "dropping the first command silently reinstates the bug");
   assert.deepEqual(state.calls.executeScript, [],
-    "reset must not inject into the page either");
-  // It must not invent a `cleared` field either: the recreate stub in
-  // tests/test_browser_cli_args.py used to model one the code cannot emit.
-  assert.equal("cleared" in out, false,
-    "there is no `cleared` field — nothing is cleared, so nothing is reported");
+    "reset must not inject into the page");
+  assert.deepEqual(out.cleared,
+    ["Emulation.setDeviceMetricsOverride", "Emulation.clearDeviceMetricsOverride"],
+    "`cleared` reports exactly what was acknowledged — the note points at it");
+  assert.equal(out.restored, true);
+  assert.equal("restoreError" in out, false, "no error key on the success path");
 });
 
 test("emulate --reset: reports what WAS in force, then forgets it", async () => {

--- a/scripts/run-node-tests.sh
+++ b/scripts/run-node-tests.sh
@@ -98,7 +98,7 @@ MIN_TESTS="${MIN_TESTS:-970}"
 # Raise a floor when a suite grows. NEVER lower one to get green — that is the
 # move that turned the pytest global floor into less than half the real total.
 SUITES=(
-  "scripts/browser-bridge/tests|14|450"
+  "scripts/browser-bridge/tests|15|490"
   # Ungated until 2026-08-03: `FILES=` above named browser-bridge alone, so these
   # 508 tests had never run under any gate since dl-router was written.
   "scripts/dl-router/tests|13|500"


### PR DESCRIPTION
Fixes #319.

`emulate --reset` now actually undoes the emulated viewport. The mechanism the issue called "unexplained" is explained, and it is a one-line-shaped cause with a two-step fix.

## TL;DR

`Emulation.clearDeviceMetricsOverride` **does nothing when the session sending it never set an override itself** — and it returns success either way. Every previous attempt to un-stick an emulated tab sent the clear from a fresh session, so it was a no-op that looked acknowledged. That is why PR #320 shipped, deployed, fired its clears, and changed nothing.

Arming the session with *any* `setDeviceMetricsOverride` first makes the clear work.

## Reproduction — my instrument

Throwaway Brave **147.0.7727.56** (Brave package 1.89.132) on a scratch profile under Xvfb (`-screen 0 1280x1024x24`), `--remote-debugging-port=9333`, driven from Python over the raw DevTools websocket. **No extension in the loop, and the operator's live Brave was never touched** — no `browser` subcommand, no `browser-bridge` service, no `~/.config/BraveSoftware`. A never-emulated control tab in the same window was read every round.

It reproduces exactly as #319 describes:

| step | victim `innerWidth` | `devicePixelRatio` | `maxTouchPoints` | control tab |
|---|---|---|---|---|
| before emulate | 1053 | 1.0469 | 0 | 1053 |
| in-session, after `setDeviceMetricsOverride{393×852,dsf3,mobile}` | 394 | 3.0 | 5 | — |
| **after detach**, read from a fresh session | **394** | **1.0469** | **0** | 1053 |
| after `clearDeviceMetricsOverride` from a fresh session + detach | **394** | 1.0469 | 0 | 1053 |
| after a full `Page.navigate` re-nav | **394** | 1.0469 | 0 | 1053 |

Sticky under Xvfb, with no extension involved. So this is not an extension bug, not a `chrome.debugger` bug, and not display/compositor-specific.

## The asymmetry, explained

Same `setDeviceMetricsOverride` call, two destinations:

- `devicePixelRatio`, `maxTouchPoints`, `pointer: coarse`, `prefers-color-scheme`, `userAgent`, `timeZone` are **renderer-side session state**. They die with the DevTools session that set them — measured reverting on their own at detach, with nothing cleared.
- the viewport **size** additionally resizes the **browser-side render widget**. That resize is undone only by an explicit clear *from a session that has emulation armed*. Nothing does that at detach, so the size — and only the size — survives.

The discriminating measurement:

```
session A: setDeviceMetricsOverride{393x852} -> detach          innerWidth  394
session B: clearDeviceMetricsOverride        -> detach          innerWidth  394   <- NO-OP
session B: setDeviceMetricsOverride{...} then clear -> detach   innerWidth 1055   <- RESTORED
control tab, same window, untouched                             innerWidth 1055
```

The middle row is the whole bug. It is also visible **in-session**: in the original repro a fresh session's clear reverted `devicePixelRatio` immediately (3.0 → 1.0469) while `innerWidth` stayed at 394 in the same read. Two values from one call, one reverting and one not, inside a single session — that is the asymmetry, and it is the widget-vs-renderer split.

This paragraph is an **inference from the observed behaviour, not from reading Chromium's source**. The tables are the finding.

## What I ruled out, with measurements

Each case ran on a fresh victim tab with a never-emulated control read in the same round. `RESTORED` = victim width returned to the control's.

| candidate sequence | result |
|---|---|
| `clearDeviceMetricsOverride` from a **fresh** session | ❌ sticky |
| `setDeviceMetricsOverride{0,0,0,false}` **alone**, no clear | ❌ sticky (so "width 0 disables the override" does not resize the widget back) |
| `clear` + `Emulation.setPageScaleFactor(1)` | ❌ sticky |
| `clear` + `Emulation.resetPageScaleFactor` | ❌ sticky |
| `clear` + `Browser.setWindowBounds` +1px then −1px | ❌ sticky (and it moved the **control** too — a real window resize is not the lever) |
| `clear` + `Page.reload` | ❌ sticky |
| a re-navigation | ❌ sticky |
| **any** `setDeviceMetricsOverride` **then** `clear`, same session | ✅ restored |

Arming params are irrelevant to *whether* it works — `{393×852}`, `{800×600}`, `{1×1}` and `{0,0,0,false}` all restored. I ship `{0,0,0,false}` because it was measured **not to resize anything on its own** (still 394 in-session after arming), so there is no intermediate flash to a wrong size.

## The working sequence

One CDP session, two steps, in this order — `EMULATION_RESET_CDP_STEPS` in `extension/protocol.js`:

```js
Emulation.setDeviceMetricsOverride { width: 0, height: 0, deviceScaleFactor: 0, mobile: false }  // ARM
Emulation.clearDeviceMetricsOverride                                                             // CLEAR
```

Final confirmation of exactly the shipped pair — **5 restores / 5 attempts**, plus **2/2** safe no-ops:

```
iter 1 emulate -> 2-step reset   stuck=394   after=1055  ctl=1055  -> RESTORED
iter 2 emulate -> 2-step reset   stuck=394   after=1055  ctl=1055  -> RESTORED
iter 3 emulate -> 2-step reset   stuck=394   after=1055  ctl=1055  -> RESTORED
emulate -> renav -> reset        stuck=394   after=1055  ctl=1055  -> RESTORED   (x2)
never emulated -> reset          stuck=1055  after=1055  ctl=1055  -> no-op      (x2)
```

## What changed

- **`extension/protocol.js`** — `EMULATION_RESET_CDP_STEPS`, pure frozen data, with the measurement and the mechanism next to it (that comment is the justification for a two-step list that looks like it should be one step).
- **`extension/service_worker.js`** — the reset branch drops the stored state **first** (so `withCdp`'s re-application choke point cannot re-install the phone metrics inside the reset's own session), then attaches one session and applies the pair. Reports `cleared` + `restored`.
  - **Unconditional** — it fires even when the worker holds no state for the tab. That is the case that matters most: an evicted MV3 worker forgets `emulationState` while the tab stays physically stuck. Measured safe on a never-emulated tab.
  - **Best-effort** — a closed/discarded tab or a privileged scheme gives `restored:false` + `restoreError` and a different note, never an exception.
- **`--reset --recreate` is unchanged and stays.** It needs no CDP, and it is the **only** remedy for a tab the extension cannot reach: an un-upgraded build, or a tab orphaned by a `SIGKILL`'d agent that never ran its reset.
- **Claims corrected, each written from the code after the code**: the runtime `emulate` note, the `--reset` note (both variants), `NOT_EMULATED_READ_NOTE`, protocol.js's `EMULATION` header, `README.md`, `reference/emulation.md`, `SKILL.md`, and the `browser` CLI help + recreate note.
  - One of these is a **new correctness finding**, not just a rewrite: `NOT_EMULATED_READ_NOTE` claimed a non-CDP `text`/`html`/`js` read returns the tab's "REAL, un-emulated DOM" with layout values "the DESKTOP ones". Measured false. It returns a **mixture** — desktop `userAgent`/`devicePixelRatio`/`maxTouchPoints`/`pointer:coarse`, but an **emulated** `innerWidth`, because the widget really is that size. A page laid out at the phone width with desktop capability signals. That was actively misleading on the read path.
- Extension **0.8.0 → 0.8.1** + the matching `extension/README.md` changelog block; build marker regenerated (`73f5438f18f395d2`).
- `scripts/run-node-tests.sh` browser-bridge floors raised `14|450` → `15|490`.

## Tests

New file `tests/emulation_reset.test.mjs` (8 tests). 🔴 Per the issue's requirement it asserts the **viewport after reset**, never `ok:true` — the broken behaviour already returned `ok:true`, `reset:true` and a populated `wasEmulating`.

It drives the ops against a **browser model calibrated to the measurements above**: the widget resize survives detach; a clear from an unarmed session is a no-op; `{0,0}` arms without resizing. The model is **validated in both directions before any product assertion is read**:

- a **negative control** asserting the model can report a STUCK viewport (it reproduces #319 — a fresh session's bare clear leaves it at 393);
- a **positive control** asserting the model can report a RESTORED one.

Without both, a model that could only ever say "restored" would make every assertion in the file vacuous.

### Counts — both tiers

| suite | result |
|---|---|
| `node --test --test-reporter=tap scripts/browser-bridge/tests/*.test.mjs` | `# tests 495` · `# pass 495` · `# fail 0` · `# skipped 0` |
| `pytest scripts/browser-bridge/tests -q` | **467 passed**, 0 failed |
| `bash scripts/run-node-tests.sh .` (the gated runner) | browser-bridge 495 / dl-router 508 / browser-ext 21 — **TOTAL 1024, fail 0**, RESULT: PASS |

### Red/green matrix

Committed first, then reverted implementation only (never a test file), re-ran, confirmed red **with that test's own assertion message**, restored.

| mutation | node result | failing assertion |
|---|---|---|
| `git checkout origin/main -- extension/service_worker.js` (reset = Map delete, sends nothing) | 3 pass / **5 fail** of 8 | *"emulate --reset must leave the tab at its REAL viewport width — this is #319 and it is the only assertion the broken behaviour fails"* |
| delete **only** the arming step from `EMULATION_RESET_CDP_STEPS` (i.e. the naive clear-only fix, = PR #320) | **5 fail** across 3 files | *"reset attaches ONE session and sends the arming override then the clear … dropping the first command silently reinstates the bug"* + the viewport assertion above |
| restored | 495/495, runner PASS | — |

The second mutation is the one that matters: it proves the test discriminates the **arming step specifically**, not merely "some CDP was sent". A clear-only fix goes red here — the check #320 never had.

Note the two HARNESS control tests stay **green** under both mutations. That is correct: they test the model, not the product, which is what makes them controls rather than coverage.

## 🔴 NOT VERIFIED

- **Not verified against the operator's live Brave, and not deployed.** No `home-manager switch`, no Brave restart, no `browser` subcommand, no touch of the `browser-bridge` service or the operator's profile — the operator was working in that browser.
- The fix is verified **only** in a throwaway Brave 147.0.7727.56 under Xvfb on a scratch profile, plus unit tests against a model calibrated to those measurements. Chromium's emulation handling can differ by version and by profile state; treat this as "measured on one build" until it is measured on the live one.
- The unit tests do **not** prove Chromium honours the calls. They prove the bridge sends the arm-then-clear pair, in one session, in that order — and the browser model says that is what restores the viewport.
- I did not measure whether a **`chrome.debugger`** session behaves identically to a raw websocket session. Both are DevTools sessions on the same tab agent host and the whole mechanism is session-scoped handler state, so it should — but "should" is not a measurement, and it is the single largest gap between this PR and a live verification.
- The Chromium-internals wording ("browser-side render widget resize" vs "renderer-side session state") is an **inference from the behaviour**, not from reading the source. The tables are the finding; do not re-quote the explanation as source-verified.
- Unchanged and still unmeasured: how much of the 15s run budget a real emulation apply consumes on a live tab.

### Live verification, after `home-manager switch` + a FULL Brave restart

```bash
browser whoami                      # which host + profile; check extension_stale is false
browser --instance <label> ping     # expect extensionVersion 0.8.1 + buildMarker 73f5438f18f395d2

browser open https://example.com
browser js --wake 'innerWidth'      # baseline, e.g. 1124
browser emulate iphone-15
browser js --wake 'innerWidth'      # expect 393
browser emulate --reset             # expect .restored true and
                                    # .cleared == ["Emulation.setDeviceMetricsOverride",
                                    #              "Emulation.clearDeviceMetricsOverride"]
browser js --wake 'innerWidth'      # 🔴 THE CHECK: back at the baseline, not 393
browser nav https://example.com
browser js --wake 'innerWidth'      # still the baseline
```

Read a **never-emulated tab** in the same window as a control in the same pass and record both numbers — a window resized for some other reason would otherwise read as a fix. `.restored: true` alone proves nothing; only the width does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
