### PR TITLE
fix(browser-bridge): a version MISMATCH decides extension_stale even with no build marker

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -80,7 +80,7 @@ design when two profiles were connected).
   `~/.local/share/browser-bridge-ext/`, falling back to the repo copy). It answers
   "am I on the laptop or the workbench, and which profile?" in one shot (both
   hosts are hostname `nixos`).
-  **Explicit staleness verdict — computed from the BUILD MARKER (#324).** Each
+  **Explicit staleness verdict — an ALL-CLEAR comes from the BUILD MARKER (#324).** Each
   instance carries `extension_version` (loaded), `extension_version_expected`,
   `extension_build`, `extension_build_expected`, and **`extension_stale`**:
   `true` (this profile is running code that is not the deployed code → Remove +
@@ -88,10 +88,10 @@ design when two profiles were connected).
   The bridge carries `extension_build_current` alongside
   `extension_version_current`.
 
-  🔴 The verdict is **not** a version comparison, and cannot be. `extension_version`
-  is `chrome.runtime.getManifest().version` — read off the on-disk manifest at
-  call time — and `extension_id` is derived from the load PATH, so **both describe
-  the DIRECTORY, not the code that is executing**. MEASURED 2026-08-04: two Brave
+  🔴 An all-clear is **not** a version comparison, and cannot be. `extension_version`
+  is `chrome.runtime.getManifest().version` — it describes the manifest of the
+  extension the worker LOADED — and `extension_id` is derived from the load PATH,
+  so **neither describes the code that is executing**. MEASURED 2026-08-04: two Brave
   profiles loading the SAME directory reported an identical id, an identical
   `0.7.3` and `extension_stale: false`, while one ran `main` and the other an
   unmerged 0.7.2 build whose source existed on no disk. `extension_build` is a
@@ -99,10 +99,14 @@ design when two profiles were connected).
   so it is frozen into the loaded module graph and travels with the code — a stale
   worker reports the stale marker by construction.
 
-  🔴 **It FAILS CLOSED.** A marker missing on *either* side — an extension build
-  predating #324, or an unreadable/undeployed source tree — yields `null`, never
-  `false`. `false` means verified-current and nothing else; `null` is never
-  "fine". Staleness is also **per profile**: one can be current while another is
+  🔴 **It FAILS CLOSED — asymmetrically.** `false` means two markers present and
+  identical, and nothing else can produce it: a marker missing on *either* side —
+  an extension build predating #324, or an unreadable/undeployed source tree —
+  never yields `false`. It yields `null` *unless* both versions are known and
+  DISAGREE, which yields `true` — a mismatch is positive proof that the loaded
+  code is not the deployed code, so a missing marker must not discard it. Only
+  `true` is ever reachable from versions alone; `null` is never "fine".
+  Staleness is also **per profile**: one can be current while another is
   not, at the same instant, from one directory.
   ⚠ A marker still cannot see a change you made and never deployed, and it says
   nothing about WHICH DIRECTORY the build came from — for that, read
@@ -1470,8 +1474,10 @@ poll header; `null` until a build that reports it), its **`extension_id`** (from
 `chrome.runtime.id`, i.e. WHICH DIRECTORY was loaded), its **`extension_build`**
 (from `X-Bridge-Ext-Build` — the BUILD MARKER of the code actually EXECUTING,
 `null` on a build predating #324), both `_expected` values, and the explicit
-**`extension_stale`** verdict (`true`/`false`/`null`=undecidable), which is
-computed from the MARKER and **fails closed** to `null` when either side lacks one.
+**`extension_stale`** verdict (`true`/`false`/`null`=undecidable): `false`
+requires two present, identical MARKERS and nothing else, so a marker missing on
+either side **fails closed** — to `null`, except that two known but DISAGREEING
+versions still decide `true`.
 `extension_version_current` is the manifest the server expects Brave to have loaded
 and `extension_build_current` the marker in the `build_id.js` beside it:
 the deployed `~/.local/share/browser-bridge-ext/` copy, else the repo one.

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -55,7 +55,7 @@ Result payloads land under `.result.data`.
 | command | does |
 |---|---|
 | `whoami` | **read-only identity** (global; no `--instance`/`--tab`) — host label (`laptop`/`workbench`), connected instances (active-tab **domain** only), bridge diagnostics, `extension_version_current` |
-| `health` / `instances` | connected instances + count (JSON: key, label, instanceId, tab url/title), each with an `extension_stale` verdict from the BUILD MARKER, not the version (`null` = undecidable, fails closed) |
+| `health` / `instances` | connected instances + count (JSON: key, label, instanceId, tab url/title), each with an `extension_stale` verdict (`false` is BUILD-MARKER-backed only; `null` = undecidable, fails closed) |
 | `ping` | **which extension CODE is loaded?** → `{pong,extensionVersion,buildMarker,id,ops}`; read `buildMarker` — version+id describe the DIRECTORY. Staleness is PER PROFILE |
 | `context` | **page metadata, no DOM read** — url/domain/path/query/title/tabId, tab-scoped. Cheapest read; ⚠ NOT a render check → `reference/read-envelopes.md` |
 | `open [url] [--wake[=MS]]` | open a NEW tab this session owns (default `about:blank`, **created in the BACKGROUND/hidden**), returns `tabId`. Idempotent — a re-`open` does NOT navigate (url DISCARDED). Use for multi-step work |

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -55,7 +55,7 @@ Result payloads land under `.result.data`.
 | command | does |
 |---|---|
 | `whoami` | **read-only identity** (global; no `--instance`/`--tab`) — host label (`laptop`/`workbench`), connected instances (active-tab **domain** only), bridge diagnostics, `extension_version_current` |
-| `health` / `instances` | connected instances + count (JSON: key, label, instanceId, tab url/title), each with an `extension_stale` verdict (`false` is BUILD-MARKER-backed only; `null` = undecidable, fails closed) |
+| `health` / `instances` | connected instances + count (JSON: key, label, instanceId, tab url/title). `extension_stale` on `health` ONLY (`false` is MARKER-backed; version MISMATCH → `true`; `null` = undecidable) |
 | `ping` | **which extension CODE is loaded?** → `{pong,extensionVersion,buildMarker,id,ops}`; read `buildMarker` — version+id describe the DIRECTORY. Staleness is PER PROFILE |
 | `context` | **page metadata, no DOM read** — url/domain/path/query/title/tabId, tab-scoped. Cheapest read; ⚠ NOT a render check → `reference/read-envelopes.md` |
 | `open [url] [--wake[=MS]]` | open a NEW tab this session owns (default `about:blank`, **created in the BACKGROUND/hidden**), returns `tabId`. Idempotent — a re-`open` does NOT navigate (url DISCARDED). Use for multi-step work |

--- a/scripts/browser-bridge/extension/build_id.js
+++ b/scripts/browser-bridge/extension/build_id.js
@@ -11,17 +11,17 @@
 // deployed?". A value that a running service worker COMPUTES by reading disk
 // cannot answer it, because the disk is the thing that was updated — a stale
 // worker reads the NEW file and reports the NEW value. That is precisely the
-// bug in #324: `chrome.runtime.getManifest().version` reads the on-disk
-// manifest, and `chrome.runtime.id` is derived from the load PATH, so both
-// describe the DIRECTORY rather than the running code. Measured 2026-08-04:
+// bug in #324: `chrome.runtime.getManifest().version` describes the manifest of
+// the extension that was LOADED, and `chrome.runtime.id` is derived from the
+// load PATH, so neither describes the running code. Measured 2026-08-04:
 // two Brave profiles on ONE directory reported the same id, the same 0.7.3 and
 // `extension_stale: false` while executing different code.
 //
 // So do NOT "simplify" this to any of:
 //   * fetch(chrome.runtime.getURL("build_id.json"))  — reads disk at runtime
-//   * chrome.runtime.getManifest().version            — reads disk at runtime
+//   * chrome.runtime.getManifest().version            — describes the LOAD
 //   * a value written into chrome.storage.local       — survives a code swap
 //   * a hash computed in the worker over its own source — same disk read
 // The marker must be a LITERAL in a module the worker imported, so that it was
 // frozen into the loaded module graph at load time and travels with the code.
-export const BUILD_MARKER = "73f5438f18f395d2";
+export const BUILD_MARKER = "04bbd6f9c695141d";

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -2743,11 +2743,12 @@ export function capHeaderValue(s, max = MAX_HEADER_VALUE_CHARS) {
 // `buildMarker` (#324) is the ONLY one of these three that describes the CODE
 // rather than the directory: it is a generated literal in build_id.js, imported
 // into the worker's module graph, so a stale worker sends the STALE value while
-// `extVersion` (read off the on-disk manifest at call time) and `extId`
+// `extVersion` (the manifest of the extension this worker LOADED) and `extId`
 // (path-derived) both report the freshly-deployed directory. Measured
 // 2026-08-04 — two profiles, one directory, identical id + version +
-// `extension_stale: false`, different code. Omitted (→ undecidable, never
-// "current") by a build that predates the marker.
+// `extension_stale: false`, different code. Omitted by a build that predates the
+// marker → that instance can never be called "current"; it is undecidable
+// unless the two known versions DISAGREE, which still decides "stale".
 export function pollHeaders(instanceId, label, active, extVersion, extId,
                             buildMarker) {
   const h = { "X-Bridge-Instance-Id": String(instanceId || "") };

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -1436,9 +1436,11 @@ const OPS = {
   // two profiles on one directory report identical values while running
   // different code (measured 2026-08-04). The marker is a literal in this
   // worker's own module graph, so it is a statement about the RUNNING code.
-  // `extensionVersion` is kept — it is still a useful hint and older tooling
-  // reads it — but the server's `extension_stale` verdict is computed from the
-  // marker now, and fails closed (null) when either side lacks one.
+  // `extensionVersion` is kept — a version MISMATCH is still positive proof of
+  // staleness, and older tooling reads it — but the server's `extension_stale`
+  // ALL-CLEAR is computed from the marker alone: with a marker missing on either
+  // side it fails closed, never to `false`, and to `null` unless the two known
+  // versions disagree.
   async ping() {
     return { pong: true, extensionVersion: extensionVersion(),
              buildMarker: buildMarker(),

--- a/scripts/browser-bridge/gen-build-marker.py
+++ b/scripts/browser-bridge/gen-build-marker.py
@@ -9,7 +9,7 @@ WHY THIS EXISTS (#324). `ping` used to answer "is the build I just deployed the
 one Brave loaded?" with `chrome.runtime.getManifest().version` and
 `chrome.runtime.id`. Both describe the DIRECTORY the extension was loaded from,
 not the code that is executing: the id is derived from the load path, and the
-version is read off the manifest on disk at call time. Measured 2026-08-04 —
+version describes the manifest of the extension that was LOADED. Measured 2026-08-04 —
 two Brave profiles loading the SAME directory reported an identical id, an
 identical `0.7.3`, and `extension_stale: false`, while one was executing `main`
 and the other an unmerged 0.7.2 build whose source exists on no disk. No
@@ -115,15 +115,15 @@ def render(marker: str) -> str:
 // deployed?". A value that a running service worker COMPUTES by reading disk
 // cannot answer it, because the disk is the thing that was updated — a stale
 // worker reads the NEW file and reports the NEW value. That is precisely the
-// bug in #324: `chrome.runtime.getManifest().version` reads the on-disk
-// manifest, and `chrome.runtime.id` is derived from the load PATH, so both
-// describe the DIRECTORY rather than the running code. Measured 2026-08-04:
+// bug in #324: `chrome.runtime.getManifest().version` describes the manifest of
+// the extension that was LOADED, and `chrome.runtime.id` is derived from the
+// load PATH, so neither describes the running code. Measured 2026-08-04:
 // two Brave profiles on ONE directory reported the same id, the same 0.7.3 and
 // `extension_stale: false` while executing different code.
 //
 // So do NOT "simplify" this to any of:
 //   * fetch(chrome.runtime.getURL("build_id.json"))  — reads disk at runtime
-//   * chrome.runtime.getManifest().version            — reads disk at runtime
+//   * chrome.runtime.getManifest().version            — describes the LOAD
 //   * a value written into chrome.storage.local       — survives a code swap
 //   * a hash computed in the worker over its own source — same disk read
 // The marker must be a LITERAL in a module the worker imported, so that it was

--- a/scripts/browser-bridge/reference/errors.md
+++ b/scripts/browser-bridge/reference/errors.md
@@ -130,20 +130,29 @@ at `~/.local/share/browser-bridge-ext/`, else the repo copy), and an explicit
 **`null` = undecidable** — `null` is NOT "fine". `browser whoami` carries the
 same fields plus `bridge.extension_build_current`.
 
-🔴 **The verdict is computed from `extension_build`, NOT from the version
-(#324).** `extension_version` is `chrome.runtime.getManifest().version` (read
-off the on-disk manifest at call time) and `extension_id` is derived from the
-load PATH, so **both describe the DIRECTORY, not the code that is running**.
-MEASURED 2026-08-04: two Brave profiles loading the SAME directory reported an
-identical id, an identical `0.7.3` and `extension_stale: false`, while one ran
-`main` and the other an unmerged 0.7.2 build whose source existed **on no disk**.
-No version-shaped signal can separate those two rows.
+🔴 **An ALL-CLEAR is computed from `extension_build`, NEVER from the version
+(#324).** `extension_version` is `chrome.runtime.getManifest().version` — it
+describes the manifest of the extension the worker LOADED — and `extension_id`
+is derived from the load PATH, so **neither describes the code that is
+running**. MEASURED 2026-08-04: two Brave profiles loading the SAME directory
+reported an identical id, an identical `0.7.3` and `extension_stale: false`,
+while one ran `main` and the other an unmerged 0.7.2 build whose source existed
+**on no disk**. No version-shaped signal can separate those two rows, so a
+version MATCH can never produce `false`.
 
 `extension_build` is a generated LITERAL (`extension/build_id.js`) that the
 service worker **imports**, so it is frozen into the loaded module graph and
 travels with the code — a stale worker reports the stale marker by construction.
-The verdict **fails closed**: either side missing a marker → `null`, never
-`false`. A profile still running ≤0.7.3 therefore reads `null`, which is correct.
+
+The verdict is **ASYMMETRIC**, because the two directions are not equally
+knowable. `false` requires two markers that are present and identical — that is
+the whole of it, and nothing else can produce it. `true` additionally comes from
+a version MISMATCH with both sides known, marker or no marker: a mismatch is
+positive proof that the loaded code is not the deployed code, so a missing
+marker must not discard it. Everything else **fails closed** to `null` — a
+marker missing on either side with versions that agree, or with either version
+unknown. A profile still running ≤0.7.3 therefore reads `null` (or `true`, if
+its version disagrees), which is correct.
 
 Two things follow, both measured in the same session:
 

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -650,9 +650,10 @@ def annotate_staleness(instances, expected, expected_build=None):
     marker is a literal in the worker's own imported module graph, so a stale
     worker reports the stale value by construction.
 
-    (Also measured 2026-08-04, same host: profile "personal - other" reported
-    `0.7.1` and profile "personal" `0.8.1` under one `extension_id` — i.e. one
-    load path — while the directory on disk held only `0.8.1`. That is evidence
+    (Also measured 2026-08-04, on the OTHER host — workbench: profile
+    "personal - other" reported `0.7.1` and profile "work" `0.8.1` under one
+    `extension_id` — i.e. one load path — while the directory on disk held
+    only `0.8.1` (`manifest.json` + `build_id.js`, both stamped 09:31). Evidence
     the version is metadata parsed at extension-LOAD time rather than re-read
     from disk per call. ONE observation, a hypothesis, not established — it
     changes nothing here either way: the version still cannot certify the code.)

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -391,9 +391,10 @@ HDR_EXT_ID = "X-Bridge-Ext-Id"
 # The BUILD MARKER of the code the instance is actually EXECUTING (#324) — a
 # generated literal in extension/build_id.js that the service worker IMPORTS,
 # so it is frozen into the loaded module graph and travels with the code. This
-# is the field `extension_stale` is computed from; the version is a hint only.
-# Absent from a build that predates the marker → the verdict is null, never
-# false (see annotate_staleness).
+# is the only field an ALL-CLEAR can be computed from; the version can never
+# certify code as current. Absent from a build that predates the marker → the
+# verdict is NEVER false; it is null unless the two versions are both known and
+# DISAGREE, which decides true on its own (see annotate_staleness).
 HDR_EXT_BUILD = "X-Bridge-Ext-Build"
 
 # Server-side bounds on EVERY extension-supplied /poll string. protocol.js
@@ -2210,11 +2211,13 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                     "extension_version_current": expected,
                     # The BUILD MARKER the server expects the running code to
                     # carry, read from the deployed extension/build_id.js (#324).
-                    # This is what each instance's `extension_stale` is computed
-                    # against — the version above is a hint only, because it (and
-                    # `extension_id`) describe the load DIRECTORY rather than the
-                    # executing code. null here → every verdict is null, which is
-                    # the honest answer, not "fine".
+                    # An ALL-CLEAR is computed against THIS and nothing else —
+                    # the version above can never certify code as current,
+                    # because it (and `extension_id`) describe the load DIRECTORY
+                    # rather than the executing code. null here → no verdict can
+                    # be false; each is null unless that instance's version is
+                    # known and DISAGREES, which still decides true. Either way,
+                    # null is the honest answer, not "fine".
                     "extension_build_current": expected_build,
                     # The deploy directory Brave SHOULD have been pointed at.
                     # Reported so an operator can read it next to each instance's

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -639,29 +639,46 @@ def annotate_staleness(instances, expected, expected_build=None):
     `expected_build` is the BUILD MARKER read from the deployed extension source
     (build_marker()). Either may be None.
 
-    🔴 THE VERDICT IS COMPUTED FROM THE MARKER, NOT THE VERSION (#324). The
+    🔴 AN ALL-CLEAR IS COMPUTED FROM THE MARKER, NEVER THE VERSION (#324). The
     version cannot answer the question it was being asked. `extension_version`
-    is `chrome.runtime.getManifest().version`, read from the on-disk manifest at
-    call time, and `extension_id` is derived from the load PATH — so both
-    describe the DIRECTORY, not the executing code. Measured 2026-08-04: two
+    is `chrome.runtime.getManifest().version` — it describes the manifest of the
+    extension the worker LOADED, and `extension_id` is derived from the load
+    PATH, so neither describes the executing code. Measured 2026-08-04: two
     Brave profiles loading the SAME directory reported an identical id, an
     identical `0.7.3` and `extension_stale: false`, while one ran `main` and the
     other an unmerged 0.7.2 build whose source exists on no disk. The build
     marker is a literal in the worker's own imported module graph, so a stale
     worker reports the stale value by construction.
 
+    (Also measured 2026-08-04, same host: profile "personal - other" reported
+    `0.7.1` and profile "personal" `0.8.1` under one `extension_id` — i.e. one
+    load path — while the directory on disk held only `0.8.1`. That is evidence
+    the version is metadata parsed at extension-LOAD time rather than re-read
+    from disk per call. ONE observation, a hypothesis, not established — it
+    changes nothing here either way: the version still cannot certify the code.)
+
+    But the uselessness is ASYMMETRIC, and only one direction of it is real. A
+    version MATCH proves nothing (the paragraph above is exactly that case). A
+    version MISMATCH, both sides known, is positive proof that what was loaded
+    is not what is deployed — that direction was never in doubt, so a missing
+    marker must not discard it.
+
     `extension_stale` is a yes/no, not two strings to eyeball:
       True  — the marker this instance reports differs from `expected_build`
               (this profile is running code that is not the deployed code →
-              Remove + Load unpacked it, per profile), or the markers agree but
-              the reported VERSION disagrees (a nonsense state worth flagging).
+              Remove + Load unpacked it, per profile); or the markers agree but
+              the reported VERSION disagrees (a nonsense state worth flagging);
+              or a marker is MISSING on either side and the two versions are
+              both known and disagree (the asymmetry above).
       False — the markers are both present and identical. This, and only this,
               means "verified current".
-      None  — 🔴 UNDECIDABLE, and it FAILS CLOSED to here. Either side missing a
-              marker (a build predating #324, an unreadable/undeployed source
-              tree) yields null. NEVER guess, and never let a version match
+      None  — 🔴 UNDECIDABLE, and it FAILS CLOSED to here. A marker missing on
+              either side (a build predating #324, an unreadable/undeployed
+              source tree) with versions that agree, or with either version
+              unknown, yields null. NEVER guess, and never let a version match
               stand in for a marker: a False that is not marker-backed is
-              exactly the affirmative all-clear that #324 was filed about.
+              exactly the affirmative all-clear that #324 was filed about. Only
+              True is ever reachable from versions alone.
     """
     for inst in instances:
         loaded = inst.get("extension_version")
@@ -669,7 +686,11 @@ def annotate_staleness(instances, expected, expected_build=None):
         inst["extension_version_expected"] = expected
         inst["extension_build_expected"] = expected_build
         if not expected_build or not loaded_build:
-            inst["extension_stale"] = None
+            # No marker on one side → no all-clear is available. A known version
+            # DISAGREEMENT is still positive proof of staleness; agreement, or
+            # an unknown version on either side, stays undecidable.
+            inst["extension_stale"] = (
+                True if expected and loaded and loaded != expected else None)
             continue
         stale = loaded_build != expected_build
         if not stale and expected and loaded and loaded != expected:

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -4282,9 +4282,11 @@ def test_annotate_staleness_fails_closed_when_a_marker_is_missing():
     """🔴 FAIL CLOSED. A missing marker on EITHER side is undecidable — null,
     never False. `false` must mean "verified current", so a build predating the
     marker, or an unreadable/undeployed source tree, cannot produce one. Note
-    the version MATCHES in every case below: under the old version-based rule
-    each of these returned False, which is exactly the affirmative all-clear
-    #324 was filed about."""
+    the version MATCHES in every case below — deliberately, and that is the
+    whole scope of this test: under the old version-based rule each of these
+    returned False, which is exactly the affirmative all-clear #324 was filed
+    about. A marker-missing case whose versions DISAGREE is decidable (True)
+    and lives in test_annotate_staleness_version_mismatch_decides_true_*."""
     # (a) the instance reports no marker (a build predating #324)
     insts = [{"key": "a", "extension_version": "0.3.0",
               "extension_build": None},

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -4331,6 +4331,88 @@ def test_annotate_staleness_marker_match_with_version_mismatch_is_stale():
     assert insts[0]["extension_stale"] is True
 
 
+@pytest.mark.parametrize("loaded_build,expected_build", [
+    (None, "73f5438f18f395d2"),   # instance reports no marker (the LIVE case)
+    ("a1b2c3d4e5f60718", None),   # server cannot read a marker
+    (None, None),                 # neither side has one
+    ("", "73f5438f18f395d2"),     # empty string is "missing" too
+    ("a1b2c3d4e5f60718", ""),
+])
+def test_annotate_staleness_version_mismatch_decides_true_without_markers(
+        loaded_build, expected_build):
+    """🔴 THE ASYMMETRY. A version MATCH proves nothing (two profiles loading one
+    directory report one version while running different code — #324), but a
+    version MISMATCH is positive proof the loaded code is not the deployed code.
+    That direction was never in doubt, so a missing marker must not discard it.
+
+    The first parameter set is the LIVE observation from the workbench on
+    2026-08-04 that motivated this: profile "personal - other" reported
+    extension_version 0.7.1 / extension_build null against an expected 0.8.1 /
+    73f5438f18f395d2, and the verdict came back null."""
+    insts = [{"key": "personal - other", "extension_version": "0.7.1",
+              "extension_build": loaded_build}]
+    S.annotate_staleness(insts, expected="0.8.1",
+                         expected_build=expected_build)
+    assert insts[0]["extension_stale"] is True
+    assert insts[0]["extension_version_expected"] == "0.8.1"
+    assert insts[0]["extension_build_expected"] == expected_build
+
+
+@pytest.mark.parametrize("loaded_build,expected_build", [
+    (None, "73f5438f18f395d2"),
+    ("a1b2c3d4e5f60718", None),
+    (None, None),
+])
+def test_annotate_staleness_missing_marker_version_agreement_stays_none(
+        loaded_build, expected_build):
+    """A marker is missing and the versions AGREE: still undecidable. Agreement
+    is exactly the signal #324 proved worthless, so it may not upgrade the
+    verdict in either direction."""
+    insts = [{"key": "work", "extension_version": "0.9.2",
+              "extension_build": loaded_build}]
+    S.annotate_staleness(insts, expected="0.9.2",
+                         expected_build=expected_build)
+    assert insts[0]["extension_stale"] is None
+
+
+@pytest.mark.parametrize("loaded_version,expected_version", [
+    (None, "0.8.1"),    # instance reported no version
+    ("0.7.1", None),    # server could not read a manifest version
+    (None, None),
+    ("", "0.8.1"),      # empty string is "unknown", not a mismatch
+    ("0.7.1", ""),
+])
+def test_annotate_staleness_missing_marker_and_unknown_version_stays_none(
+        loaded_version, expected_version):
+    """With a marker missing, a verdict may only come from two KNOWN versions.
+    An absent version is not evidence of disagreement."""
+    insts = [{"key": "other", "extension_version": loaded_version,
+              "extension_build": None}]
+    S.annotate_staleness(insts, expected=expected_version,
+                         expected_build="73f5438f18f395d2")
+    assert insts[0]["extension_stale"] is None
+
+
+def test_annotate_staleness_false_stays_strictly_marker_backed():
+    """🔴 THE INVARIANT. `False` is the affirmative all-clear; only two present,
+    identical markers may produce one. Sweep every marker-missing shape — with
+    versions agreeing, disagreeing, and unknown — and assert not one yields
+    False. Only True becomes newly reachable from versions alone."""
+    versions = [("0.7.1", "0.8.1"), ("0.9.2", "0.9.2"), (None, "0.8.1"),
+                ("0.7.1", None), (None, None), ("", "0.8.1"), ("0.7.1", "")]
+    markers = [(None, "73f5438f18f395d2"), ("a1b2c3d4e5f60718", None),
+               (None, None), ("", "73f5438f18f395d2"),
+               ("a1b2c3d4e5f60718", "")]
+    for loaded_v, expected_v in versions:
+        for loaded_b, expected_b in markers:
+            insts = [{"key": "k", "extension_version": loaded_v,
+                      "extension_build": loaded_b}]
+            S.annotate_staleness(insts, expected=expected_v,
+                                 expected_build=expected_b)
+            assert insts[0]["extension_stale"] is not False, (
+                loaded_v, expected_v, loaded_b, expected_b)
+
+
 def test_manifest_version_none_on_missing(tmp_path):
     assert S.manifest_version(path=tmp_path / "nope.json") is None
 


### PR DESCRIPTION
## The live observation

Measured on the workbench, 2026-08-04, via `browser health`:

```
profile "personal - other":
  extension_version           0.7.1
  extension_build             null
  extension_version_expected  0.8.1
  extension_build_expected    73f5438f18f395d2
  extension_stale             null      <-- decidably stale, reported as unknown
```

`annotate_staleness()` returned `None` the moment either build marker was
absent — **before ever looking at the versions**. That threw away a decidable
case.

#324's asymmetry is that a version **MATCH** proves nothing: two profiles
loading one directory report the same version while running different code.
A version **MISMATCH** was never in doubt — it is positive proof that what was
loaded is not what is deployed. Only that direction is newly used.

## Verdict table as implemented

| markers | versions | verdict |
|---|---|---|
| both present, **disagree** | any | `True` (unchanged) |
| both present, agree | disagree | `True` (unchanged) |
| both present, agree | agree or either unknown | `False` (unchanged) |
| **missing on either side** | both known and **disagree** | **`True` (new)** |
| missing on either side | agree | `None` (unchanged) |
| missing on either side | either unknown/None/"" | `None` (unchanged) |

## 🔴 The invariant that survives

**`False` stays strictly marker-backed.** A version match can never produce
`False` — only `True` becomes newly reachable from versions alone. Pinned by
`test_annotate_staleness_false_stays_strictly_marker_backed`, which sweeps
7 version shapes x 5 marker-missing shapes (35 combinations) and asserts
`is not False` on every one.

## Red at base / green at HEAD

`red at 1d8249b, green at HEAD (56da81e).`

Tests were committed first (2798b06) and run against **unmodified** `server.py`:

```
FAILED test_annotate_staleness_version_mismatch_decides_true_without_markers[None-73f5438f18f395d2]
FAILED test_annotate_staleness_version_mismatch_decides_true_without_markers[a1b2c3d4e5f60718-None]
FAILED test_annotate_staleness_version_mismatch_decides_true_without_markers[None-None]
FAILED test_annotate_staleness_version_mismatch_decides_true_without_markers[-73f5438f18f395d2]
FAILED test_annotate_staleness_version_mismatch_decides_true_without_markers[a1b2c3d4e5f60718-]
5 failed, 14 passed, 280 deselected in 1.16s
```

with, for the live-observation fixture:

```
loaded_build = None, expected_build = '73f5438f18f395d2'
>       assert insts[0]["extension_stale"] is True
E       assert None is True
scripts/browser-bridge/tests/test_server.py:4356: AssertionError
```

**Honesty note:** the other three new tests are **invariant guards, not
regression coverage** — they pass at `1d8249b` and pin behaviour the fix must
not change (`marker-missing + versions agree ⇒ None`, `marker-missing + either
version unknown ⇒ None`, and the `False` invariant). They are labelled as such
in the test commit message.

## Mutation sweep (`-k annotate_staleness`, 19 selected)

All four mutants of the new expression were killed; the tree restored green.

| mutant | result |
|---|---|
| `loaded != expected` → `loaded == expected` | 10 failed |
| `True if …` → `False if …` | 6 failed |
| drop the `expected and loaded` known-version guard | 4 failed |
| revert to plain `None` (the pre-fix body) | 5 failed |
| restored | 19 passed |

The `False`-invariant guard was separately confirmed **reachable and killed by
its own assertion** under the `True → False` mutant:
`assert False is not False` at `test_server.py:4414`.

## Both tiers, before and after (counts parsed from output, not exit status)

| tier | before | after |
|---|---|---|
| pytest `scripts/browser-bridge/tests` | 467 passed, 0 failed | **481 passed, 0 failed** (+14) |
| `node --test --test-reporter=tap …/*.test.mjs` | 495 tests / 495 pass / 0 fail / 0 skipped | **495 / 495 / 0 fail / 0 skipped** (unchanged) |

## The factual correction folded in

The 🔴 docstring asserted `extension_version` is "read from the on-disk manifest
at call time". Today's observation contradicts it: two profiles sharing one
`extension_id` (hence one load path) reported `0.7.1` and `0.8.1` while the
directory on disk holds only `0.8.1`. The sentence is softened to what is
actually known — the version describes the manifest of the extension the worker
**loaded**, and still does not describe the executing code — with the
observation, its date and both profiles' values recorded as the evidence, and
explicitly flagged as **one observation, a hypothesis, not established**.
Nothing was re-architected around it. The load-bearing conclusion ("the version
cannot answer the question, use the marker") is unchanged.

## SKILL.md

`SKILL.md` documents the verdict in its `health`/`instances` row and the old
wording ("verdict from the BUILD MARKER, not the version") is now inaccurate for
`true`. Corrected **in place, 2 bytes smaller** — no eviction needed, and
`test_skill_size.py` stays green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bJFGEUx1pLkFpxRkNkhAR
