### PR TITLE
fix(skill-audit): split work-status history from dated lessons

### DIFF
--- a/claude/commands/prune-skill.md
+++ b/claude/commands/prune-skill.md
@@ -27,7 +27,8 @@ BK=/tmp/skill-prune-$(date +%s); mkdir -p "$BK"; cp -a <SKILL_DIR>/. "$BK"/; ech
 
 ## 3. Classify every over-budget block (the judgment cut)
 For a big pass, dispatch read-only classifier subagents (one per fat H2) that check each block against the always-loaded files (`CLAUDE.md`, `~/.claude/RULES.md`) and the sibling skills, returning one verdict each:
-- **EVICT_HISTORY** — dated session/changelog/"what we shipped" narrative → a `claudedocs/` doc, leaving at most **one ≤200-char durable tell**. Biggest single win; this is `/prune-memory`'s "work-STATUS doesn't belong in the index" rule one level down.
+- **EVICT_HISTORY** — **work-status** narrative (`### Session …`, `Changelog`, "what we shipped") → a `claudedocs/` doc, leaving at most **one ≤200-char durable tell**. This is `/prune-memory`'s "work-STATUS doesn't belong in the index" rule one level down.
+  🔴 **A date in a heading is NOT this verdict.** `## Common silent-failure modes (from the 2026-05-22 audit)` is durable guidance that cites a date; evicting it guts the skill. The auditor reports the two separately for exactly this reason — measured across the 67-skill datapacket corpus on 2026-08-04, **app-blocks holds 45 work-status headings and every other skill holds ZERO**, while carrying 8–17 dated-but-topical ones. Read the auditor's "dated lessons" section as DEMOTE candidates, never as eviction candidates.
 - **DEMOTE_TO_REFERENCE** — long-but-real procedures, tables, gotcha-depth → `reference/<topic>.md` beside the skill, with **ONE routing line** left in the core ("load it when…"). Free, exactly like the index's topic files.
 - **DROP_REDUNDANT** — already in an always-loaded file or another skill; **cite where**, then delete.
 - **MERGE_DUP** — the same gotcha restated across N appended sections → one statement.

--- a/scripts/skill-audit.py
+++ b/scripts/skill-audit.py
@@ -9,8 +9,9 @@ was accretion into existing files. Worst case `app-blocks/SKILL.md` = 726 KB
 ~= 182k tokens, which does not fit a 200k context at all.
 
 Reports, per skill: size vs budget, per-section (H2, then H3 inside the fattest
-H2) byte weights, dated session/changelog history blocks (the top eviction
-candidate) with a projected saving, fat lines (>500 B), and reference-file
+H2) byte weights, work-status history blocks (the top eviction candidate) with a
+projected saving, dated LESSONS reported separately because they are NOT
+evictable, fat lines (>500 B), and reference-file
 integrity in BOTH directions (a referenced file that is missing, and a file on
 disk that nothing routes to — an orphan reference file is invisible, therefore
 dead). Pure measurement — makes NO edits. The /prune-skill command runs this,
@@ -57,12 +58,27 @@ HEADING = re.compile(r"^(#{1,6})\s+(.+)$")
 # deciding whether a marker opens or closes — see _fence_map.
 FENCE = re.compile(r"^ {0,3}(?P<f>`{3,}|~{3,})(?P<info>.*)$")
 
-# A heading that names WORK DONE rather than HOW TO DO IT. An ISO date in a
-# heading is the strongest single signal (`### Session 2026-08-02 — ...`), so it
-# is matched anywhere in the title; the word forms cover undated changelogs.
-DATED_HEADING = re.compile(
-    r"\b\d{4}-\d{2}-\d{2}\b"
-    r"|\bsessions?\b"
+# 🔴 TWO DIFFERENT THINGS, and conflating them costs you your best content.
+#
+# WORK_STATUS names WORK DONE — `### Session 2026-07-29→30 — dogfood + audit`.
+# It is narrative about a past session and belongs in a claudedocs/ handoff, so
+# it is the genuine EVICT_HISTORY bucket.
+#
+# DATED_LESSON is durable guidance whose heading merely CITES a date —
+# `## Common silent-failure modes (from the 2026-05-22 audit)`, `## 🔴 The
+# INERT-ALERT defect class … (2026-08-01)`. Evicting it guts the skill. It is at
+# most a DEMOTE_TO_REFERENCE candidate.
+#
+# These were one bucket keyed on the ISO date, which made the date the dominant
+# signal. MEASURED 2026-08-04 across the 67-skill datapacket-talos corpus:
+# app-blocks carries 45 work-status headings, and EVERY OTHER SKILL CARRIES
+# ZERO — while manage-alerts has 17 dated-but-topical headings, manage-redis 15,
+# profile-dp 10. So the merged metric reported 59% "evictable history" for
+# manage-alerts whose two largest blocks were its most valuable operational
+# content. The single bucket was a true signal on 1 skill of 67 and a false one
+# on the other 66.
+WORK_STATUS_HEADING = re.compile(
+    r"\bsessions?\b"
     r"|\bchangelog\b"
     r"|\bwork\s*log\b"
     r"|\bwhat\s+(?:we\s+)?shipped\b"
@@ -70,6 +86,9 @@ DATED_HEADING = re.compile(
     r"|\bhistory\b",
     re.I,
 )
+# Only consulted for a heading that is NOT work-status; a bare date is the
+# weakest signal, so it downgrades to "review", never to "evict".
+ISO_DATE = re.compile(r"\b\d{4}-\d{2}-\d{2}\b")
 
 # A reference path mentioned in the core. Placeholders (`reference/<file>.md`)
 # deliberately do NOT match — `<` is outside the character class — so a doc that
@@ -170,15 +189,25 @@ def sections(lines, headings, level, lo=0, hi=None):
     return out
 
 
-def dated_blocks(lines, headings):
-    """Dated/changelog blocks, outermost-only (a nested one is already inside).
+def dated_blocks(lines, headings, kind="work_status"):
+    """Work-status OR dated-lesson blocks, outermost-only (a nested one is
+    already inside its parent).
+
+    kind="work_status" -> the EVICT_HISTORY bucket: narrative about a past
+    session, which belongs in a claudedocs/ handoff.
+    kind="dated_lesson" -> durable guidance that merely cites a date. NOT
+    evictable; reported separately so a reader cannot mistake one for the other.
 
     Returns (title, start, end, bytes), in file order.
     """
     out = []
     covered_until = -1
     for i, lv, title in headings:
-        if i < covered_until or not DATED_HEADING.search(title):
+        if i < covered_until:
+            continue
+        ws = bool(WORK_STATUS_HEADING.search(title))
+        hit = ws if kind == "work_status" else (not ws and bool(ISO_DATE.search(title)))
+        if not hit:
             continue
         end = _extent(headings, i, lv, len(lines))
         out.append((title, i, end, _bytes(lines[i:end])))
@@ -254,7 +283,8 @@ def audit_one(skill_md):
     heads = _headings(lines)
     size = len(text.encode())
     h2 = sections(lines, heads, 2)
-    dated = dated_blocks(lines, heads)
+    dated = dated_blocks(lines, heads, "work_status")
+    lessons = dated_blocks(lines, heads, "dated_lesson")
     fat = fat_lines(lines)
     refs, missing, orphans, n_rel, abs_base = reference_integrity(skill_md, text)
     first_h2 = h2[0][1] if h2 else len(lines)
@@ -274,6 +304,8 @@ def audit_one(skill_md):
         "h3_of_fattest": sections(lines, heads, 3, fattest[1], fattest[2]) if fattest else [],
         "dated": dated,
         "dated_bytes": sum(b for *_, b in dated),
+        "lessons": lessons,
+        "lesson_bytes": sum(b for *_, b in lessons),
         "fat": fat,
         "fat_bytes": sum(b for b, _ in fat),
         "refs": refs,
@@ -357,7 +389,7 @@ def render(audits, show_all, n_sections, n_detail, out=sys.stdout):
             if len(a["h3_of_fattest"]) > n_sections:
                 p(f"    ... {len(a['h3_of_fattest']) - n_sections} more H3 section(s)")
 
-        p("\n  dated history (EVICT_HISTORY — the top candidate)")
+        p("\n  work-status history (EVICT_HISTORY — genuinely evictable)")
         if a["dated"]:
             pct = 100.0 * a["dated_bytes"] / a["size"]
             after = a["size"] - a["dated_bytes"]
@@ -366,6 +398,20 @@ def render(audits, show_all, n_sections, n_detail, out=sys.stdout):
             p(f"    {len(a['dated'])} block(s), {a['dated_bytes']:,} B ({pct:.1f}% of the file)")
             p(f"    → evicting them to a claudedocs/ doc leaves {after:,} B — {verdict}")
             for title, _s, _e, b in sorted(a["dated"], key=lambda s: -s[3])[:5]:
+                p(f"      {b:>8,} B  {title[:64]}")
+        else:
+            p("    (none detected)")
+
+        # Reported SEPARATELY and never added to the eviction total. These were
+        # one bucket with the above, keyed on the ISO date; that read a skill's
+        # best operational content as evictable narrative on 66 of 67 skills.
+        p("\n  dated lessons (NOT evictable — durable guidance that cites a date)")
+        if a["lessons"]:
+            lpct = 100.0 * a["lesson_bytes"] / a["size"]
+            p(f"    {len(a['lessons'])} block(s), {a['lesson_bytes']:,} B ({lpct:.1f}% of the file)")
+            p("    → DEMOTE_TO_REFERENCE at most. Do NOT evict to claudedocs/: the")
+            p("      date is a citation, not a work-status marker. Read each before moving it.")
+            for title, _s, _e, b in sorted(a["lessons"], key=lambda s: -s[3])[:5]:
                 p(f"      {b:>8,} B  {title[:64]}")
         else:
             p("    (none detected)")

--- a/scripts/tests/test_skill_audit.py
+++ b/scripts/tests/test_skill_audit.py
@@ -258,19 +258,75 @@ def test_bad_fixture_verdict_says_prune_needed(tmp_path):
 
 # --- the detectors, exercised on their edges ------------------------------------
 
-def test_a_date_only_heading_is_dated_history(tmp_path):
-    """The ISO-date alternative must carry its own weight.
+def test_a_date_only_heading_is_a_LESSON_not_evictable_history(tmp_path):
+    """The ISO-date alternative must carry its own weight — but into the RIGHT bucket.
 
-    Added because a mutation sweep KILLED nothing when that alternative was
-    neutered — the word forms in the shared fixture were covering for it. A
-    real datapacket heading, `## Marketplace (F-E — E1–E5, all merged
-    2026-06-15, DARK behind the mod gate)`, contains no Session/Changelog word
-    at all; with only the word forms it would be invisible.
+    This test previously asserted a date-only heading was EVICT_HISTORY. That
+    assertion was WRONG and is why it now reads differently: it pinned a
+    classification that, measured across the 67-skill datapacket-talos corpus on
+    2026-08-04, was correct on exactly ONE skill. app-blocks carries 45
+    work-status headings; every other skill carries ZERO while carrying 8-17
+    dated-but-topical ones. The merged metric therefore reported 59% "evictable
+    history" for manage-alerts, whose two largest such blocks were its most
+    valuable operational content ("Common silent-failure modes", "The INERT-ALERT
+    defect class"). Evicting on that signal would have gutted the skill.
+
+    The date branch is still pinned — it just resolves to `lessons`, not `dated`.
     """
     body = "## Marketplace (E1–E5, all merged 2026-06-15, DARK behind the gate)\n\nbody\n"
     a = sa.audit_one(_write_skill(tmp_path, "dateonly", body))
-    assert [t for t, *_ in a["dated"]] == [
-        "Marketplace (E1–E5, all merged 2026-06-15, DARK behind the gate)"]
+    title = "Marketplace (E1–E5, all merged 2026-06-15, DARK behind the gate)"
+    assert [t for t, *_ in a["lessons"]] == [title]
+    assert a["dated"] == [], "a date CITATION is not work-status narrative"
+    assert a["dated_bytes"] == 0
+
+
+def test_work_status_and_lessons_are_disjoint(tmp_path):
+    """No block may appear in both buckets — the whole point of the split is that
+    a reader can act on one and not the other."""
+    body = ("## Session 2026-08-02 — what we did\n\nnarrative\n\n"
+            "## Failure modes (from the 2026-05-22 audit)\n\nguidance\n")
+    a = sa.audit_one(_write_skill(tmp_path, "disjoint", body))
+    ws = {t for t, *_ in a["dated"]}
+    ls = {t for t, *_ in a["lessons"]}
+    assert ws == {"Session 2026-08-02 — what we did"}
+    assert ls == {"Failure modes (from the 2026-05-22 audit)"}
+    assert not (ws & ls)
+
+
+def test_a_dated_work_status_heading_goes_to_work_status_not_lessons(tmp_path):
+    """Precedence: a heading carrying BOTH a work-status word and a date is
+    work-status. Without this, `### Session 2026-07-29` would land in the
+    non-evictable bucket and app-blocks' 45 real Session blocks would go
+    unreported."""
+    body = "### Session 2026-07-29→30 — dogfood + audit\n\nnarrative\n"
+    a = sa.audit_one(_write_skill(tmp_path, "both", body))
+    assert len(a["dated"]) == 1 and a["lessons"] == []
+
+
+def test_real_skills_classify_the_way_the_corpus_measurement_says():
+    """Regression pin against the live corpus, so the conflation cannot return.
+
+    Skipped when the clone is absent so the suite stays hermetic. Measured
+    2026-08-04: manage-alerts has ZERO work-status blocks (15 dated lessons),
+    app-blocks has 46 work-status blocks. If manage-alerts ever reports
+    work-status history, the buckets have re-merged.
+    """
+    root = Path("/home/zach/workspace/civit/datapacket-talos/.claude/skills")
+    if not root.is_dir():
+        pytest.skip("datapacket-talos clone not present")
+    for name, expect_ws in (("manage-alerts", False), ("app-blocks", True)):
+        p = root / name / "SKILL.md"
+        if not p.is_file():
+            pytest.skip(f"{name} absent")
+        a = sa.audit_one(p)
+        if expect_ws:
+            assert a["dated"], f"{name}: expected work-status blocks, found none"
+        else:
+            assert not a["dated"], (
+                f"{name}: reported {len(a['dated'])} work-status block(s); its dated "
+                "headings are durable lessons, so the buckets have re-merged")
+            assert a["lessons"], f"{name}: expected dated lessons, found none"
 
 
 @pytest.mark.parametrize("heading", [


### PR DESCRIPTION
fix(skill-audit): split work-status history from dated lessons

The EVICT_HISTORY bucket keyed on an ISO date in a heading, which made the
date the dominant signal and conflated two things that call for opposite
actions.

Work-status narrative ("### Session 2026-07-29 -> 30 - dogfood + audit") is
about a past session and belongs in a claudedocs/ handoff. A dated lesson
("## Common silent-failure modes (from the 2026-05-22 audit)", "## The
INERT-ALERT defect class ... (2026-08-01)") is durable operational guidance
whose heading merely cites a date. Evicting the second gutts the skill.

Measured across the 67-skill datapacket-talos corpus on 2026-08-04:
app-blocks carries 45 work-status headings and EVERY OTHER SKILL CARRIES
ZERO, while manage-alerts carries 17 dated-but-topical headings, manage-redis
15, profile-dp 10. So the merged metric was a true signal on 1 skill of 67 and
a false one on the other 66. Concretely it reported manage-alerts as 59%
"evictable history" when its two largest such blocks were its most valuable
content: a four-way taxonomy of how an alert becomes structurally incapable of
firing, and six silent-failure modes with mitigations.

The auditor now reports the two separately and never adds lessons to the
eviction total. Precedence is explicit: a heading carrying both a work-status
word and a date is work-status, so app-blocks' 45 real Session blocks are
still caught (46 blocks / 299,883 B / 38.2% of that file).

One existing test asserted the old classification and has been rewritten
rather than deleted; its docstring records that the assertion it used to make
was wrong, and the ISO-date branch it was added to pin is still pinned, just
into the correct bucket. Three new tests cover disjointness, work-status
precedence over a date, and a regression pin against the live corpus
(manage-alerts must report zero work-status blocks; app-blocks must report
some) so the buckets cannot silently re-merge.

Tests 36 -> 39. Mutation-checked: re-merging the buckets fails 3 tests,
including the live-corpus pin. Full scripts suite shows no failure not already
present on origin/main (24 on this branch vs 26 on main).
