### PR TITLE
docs(browser-bridge): instanceId SURVIVES a re-add — it is not a did-the-reload-take signal

### DIFF
--- a/claudedocs/browser-bridge-silent-drop-diagnosis-2026-07-31.md
+++ b/claudedocs/browser-bridge-silent-drop-diagnosis-2026-07-31.md
@@ -136,9 +136,13 @@ That is the predicted asymmetry and it holds.
 ### 1.5 The stable `instanceId` is a red herring
 
 `instanceId()` (`service_worker.js:58-64`) reads `chrome.storage.local`, generating a UUID only if
-absent. It is **persistent across worker restarts, ↻, and browser restarts**. So `work`'s id being
-unchanged since session start tells us nothing about worker liveness and is *not* evidence that the
-worker survived. Worth stating explicitly so it is not re-derived as a clue.
+absent. It is **persistent across worker restarts, ↻, browser restarts — and (measured 2026-08-04,
+both hosts, four of four profiles) across a per-profile Remove + Load unpacked that demonstrably
+swapped the executing code**. So `work`'s id being unchanged since session start tells us nothing
+about worker liveness and is *not* evidence that the worker survived — nor, per that later
+measurement, that the extension was never re-added. Worth stating explicitly so it is not
+re-derived as a clue. (What *does* regenerate the id is unestablished. The did-the-reload-take
+signal is the build marker / `extension_stale`, not this.)
 
 ### 1.6 Confidence
 

--- a/claudedocs/handoff-browser-bridge-emulate-and-staleness.md
+++ b/claudedocs/handoff-browser-bridge-emulate-and-staleness.md
@@ -58,7 +58,20 @@ Recorded so nobody re-derives it.
   - BOTH reported `extension_id bgbkamdlkdleahpgdgmjipjbgmepgenk`, `extension_version 0.7.3`, `extension_stale false`
   - `grep -ra "CLEARED on the tab" ~/.local/share/browser-bridge-ext/ $DEVRC/scripts/browser-bridge/` → **no matches anywhere**
   - `ps -eo lstart,comm | grep brave` → oldest Brave process **392 s** old; deploy was **9 h** earlier
-  - `personal` `instanceId` `c0e5f081` was **constant across every restart of the session**, changing only on Remove + Load unpacked
+  - ~~`personal` `instanceId` `c0e5f081` was **constant across every restart of the session**, changing only on Remove + Load unpacked~~
+    🔴 **RETRACTED 2026-08-04 — the second half was never measured, and is now falsified.**
+    The id being constant across restarts is real; "changing only on Remove + Load unpacked" was
+    an assumption. Re-measured on BOTH hosts and all FOUR profiles: every profile kept its
+    `instanceId` verbatim through a Remove + Load unpacked that demonstrably swapped the executing
+    code (build marker moved in all four: `73f5438f18f395d2` → `04bbd6f9c695141d` on three, and
+    `null` → `04bbd6f9c695141d` on the workbench's `personal - other`, which also moved 0.7.1 → 0.8.1). **So this bullet is not evidence of anything here** —
+    a constant `instanceId` is equally consistent with "no re-add happened" and with "a re-add
+    happened and swapped the code", which are exactly the two branches this investigation was
+    trying to separate. It does **not** show the profile was never re-added, and it does not
+    narrow the unexplained mechanism below by one bit. **What instanceId actually regenerates on
+    is unestablished** (a fresh profile? storage cleared? neither was tested) — do not
+    substitute a new lifecycle claim for the retracted one. The only signal that answers
+    "did the reload take" is the build marker / `extension_stale`.
 - **Ruled out:** stale service worker surviving a restart (browser processes were minutes old);
   stale `browser-bridge` service (restarted, new PID, behaviour unchanged); wrong directory
   (`extension_id` is `sha256(abs path)[:32]` mapped `0-f`→`a-p`; computed id matched

--- a/scripts/browser-bridge/extension/README.md
+++ b/scripts/browser-bridge/extension/README.md
@@ -99,6 +99,23 @@ Options) if present, else the auto-id. **Give each profile a unique label** so
 best-effort active-tab snapshot for `browser instances`) and echoes its
 `instanceId` in each `/result`.
 
+🔴 **`instanceId` is NOT a did-the-reload-take signal.** MEASURED 2026-08-04 on
+BOTH hosts and all FOUR profiles: every profile kept its `instanceId` verbatim
+through a per-profile **Remove + Load unpacked** that demonstrably swapped the
+executing code — the build marker moved in every one (three profiles
+`73f5438f18f395d2` → `04bbd6f9c695141d`; the workbench's `personal - other`
+`null` → `04bbd6f9c695141d`, its manifest version moving 0.7.1 → 0.8.1 too).
+An earlier claim that the id "changes only on Remove + Load unpacked" is
+therefore **false**, and reaching for it to check whether a reload took gives a
+confident wrong answer — precisely the failure class the build marker (#324)
+exists to close. **The only signal that answers that question is the build
+marker** (`buildMarker` from `ping`; `extension_build` vs
+`extension_build_current`, surfaced as the `extension_stale` verdict).
+
+⚠ **Scope:** that measurement establishes what `instanceId` does NOT tell you.
+What actually *does* regenerate it is **unestablished** — a fresh profile and an
+explicitly cleared `chrome.storage.local` were not tested. Don't invent one.
+
 **Duplicate-label safety.** If two profiles end up sharing one label (a
 misconfig), the server keeps only the newest and answers the displaced worker's
 `/poll` with a distinct `409 superseded` (not the idle `204`). On that signal the
@@ -160,9 +177,11 @@ come back).
    answers `unknown_op`.) You can also **compute what it should be** from the
    path — see [The path→id derivation](#the-pathid-derivation-measured) below —
    so this reading is now a confirmation, not the only source of truth. Then, if
-   the path is under `~/workspace/devrc/…`, click **Remove** (this drops that
-   profile's `chrome.storage.local` — token/port/label/`instanceId` — hence
-   step 7).
+   the path is under `~/workspace/devrc/…`, click **Remove** (you will have to
+   re-enter that profile's token/port/label — hence step 7). Do **not** expect
+   the `instanceId` to change: it was measured on 2026-08-04 to survive a
+   Remove + Load unpacked on all four profiles, so it is no evidence the re-add
+   happened. Read the `buildMarker` for that (step 8).
 5. **Load unpacked** → select `~/.local/share/browser-bridge-ext/`.
    (`Ctrl+L` in the GTK file chooser lets you type the path.)
 6. Confirm any permission re-prompt (`debugger`, `webNavigation`).
@@ -240,10 +259,12 @@ way:
 3. ⋯ → **Options**: re-paste the token, port `8788`, and the profile's label.
 4. `browser --instance <label> ping` to confirm it answers.
 
-⚠ **Rollback is not free.** Remove wipes that profile's
-`chrome.storage.local` — token, port, label and the persisted `instanceId` all
-go, which is why step 3 is mandatory and why the profile comes back with a NEW
-auto-id. Per profile. You are also back on the git-mutable path.
+⚠ **Rollback is not free.** Remove costs that profile its token, port and label,
+which is why step 3 is mandatory. Per profile. You are also back on the
+git-mutable path. What it does **not** cost is the `instanceId` — measured
+2026-08-04, four of four profiles came back with the SAME auto-id after a
+Remove + Load unpacked, so an unchanged id is **not** evidence the rollback
+failed to take. Use `ping`'s `buildMarker` (step 4) for that.
 
 ## Reload after every change (and how to know it took)
 


### PR DESCRIPTION
## What was measured

Project docs recorded that a profile's `instanceId` is stable across Brave restarts and
**changes ONLY on a per-profile "Remove + Load unpacked"** — i.e. that a changed instanceId
is evidence the extension was genuinely re-added.

**That is false.** Measured 2026-08-04 across BOTH hosts and all FOUR profiles:

| host | profile | instanceId (unchanged throughout) | build marker before → after re-add |
|---|---|---|---|
| laptop | `work` | `6eec093a-dff3-476c-87c8-9e43c5d52e7a` | `73f5438f18f395d2` → `04bbd6f9c695141d` |
| laptop | `personal` | `f9b3ce71-4294-4750-812f-137490d98cd6` | `73f5438f18f395d2` → `04bbd6f9c695141d` |
| workbench | `work` | `d173f66d-6a18-47e9-a5c7-e81a3012907e` | `73f5438f18f395d2` → `04bbd6f9c695141d` |
| workbench | `personal - other` | `245c7492-b6a8-4777-a395-93c5e49c0431` | `null` (v0.7.1) → `04bbd6f9c695141d` (v0.8.1) |

Every profile kept its instanceId through a Remove + Load unpacked that **demonstrably swapped
the executing code** — the build marker moved in all four, and on the last row the manifest
version moved 0.7.1 → 0.8.1 as well.

So **instanceId survives a re-add and cannot be used as a did-the-reload-take signal.** The only
signal that answers that question is the build marker (`extension_build` vs
`extension_build_current`, surfaced as the `extension_stale` verdict — #324 / PR #327).

Why it matters: reaching for instanceId to check whether a reload took gives a confident wrong
answer — precisely the failure class the build marker exists to close.

## Scope limit

This measurement establishes what instanceId does **NOT** tell you. It does **NOT** establish
what instanceId's actual lifecycle is. **The regeneration conditions are unestablished** — a
fresh profile and an explicitly cleared `chrome.storage.local` were not tested. No replacement
lifecycle claim is asserted anywhere in this diff, and each corrected site says so explicitly.

## Sites corrected

| site | what it said | what it says now |
|---|---|---|
| `scripts/browser-bridge/extension/README.md` §Multiple instances | described persistence only across "reloads/restarts within that profile" | adds the 🔴 measured block: not a did-the-reload-take signal, points at `buildMarker`/`extension_stale`, plus an explicit scope caveat |
| `scripts/browser-bridge/extension/README.md` §migration step 4 | "Remove … drops that profile's `chrome.storage.local` — token/port/label/`instanceId`" | keeps the load-bearing point (you must re-enter token/port/label — hence step 7); drops the falsified instanceId claim and warns not to read the id as evidence the re-add happened |
| `scripts/browser-bridge/extension/README.md` §rollback | "Remove wipes … the persisted `instanceId` … the profile comes back with a NEW auto-id" | keeps "step 3 is mandatory"; corrects to: the id does **not** change, so an unchanged id is not evidence the rollback failed to take — use `ping`'s `buildMarker` |
| `claudedocs/handoff-browser-bridge-emulate-and-staleness.md` "Open investigations" | listed instanceId constancy "changing only on Remove + Load unpacked" as an **observation** supporting the unexplained-stale-code diagnosis | bullet struck through + 🔴 RETRACTED note. Explicitly states the inference it was making is now **unsupported**: a constant instanceId is equally consistent with "no re-add happened" and "a re-add happened and swapped the code" — the two branches that investigation was trying to separate — so it does not narrow the unexplained mechanism by one bit |
| `claudedocs/browser-bridge-silent-drop-diagnosis-2026-07-31.md` §1.5 | already called the stable instanceId a red herring, but enumerated only worker restarts / ↻ / browser restarts | extends the enumeration with the measured Remove + Load unpacked case and names the build marker as the actual signal |

### Already correct — left alone
- `scripts/browser-bridge/reference/errors.md` — the whole reload ladder already points at
  `buildMarker` / `ping`, never at instanceId.
- `scripts/browser-bridge/README.md`, `server.py`, `reference/tabs-instances.md`,
  `SKILL.md`, `browser` — every instanceId mention is neutral routing/wire-shape
  documentation ("routing key = label else auto-id", the `/health` JSON shape). No
  reload-took claim.
- `scripts/browser-bridge/extension/build_id.js` + `gen-build-marker.py` — their comments
  already list "a value written into `chrome.storage.local` — survives a code swap" as a
  reason the marker must NOT be built that way. This measurement **confirms** them.
- `docs/LAYOUT.md`, `claude/` (skills + RULES.md), `CLAUDE.md` — no instanceId claim at all.
  RULES.md deliberately untouched: this is a browser-bridge fact, and RULES.md is a
  byte-capped always-on doc.

### Deliberately left
- `scripts/browser-bridge/extension/service_worker.js` — the `instanceId()` comment is the
  most natural home for this warning, but the build marker hashes **every `extension/*.js`**
  (`gen-build-marker.py:compute_marker`), so even a comment-only edit there fails
  `test_committed_build_marker_matches_the_extension_source` unless `build_id.js` is
  regenerated — which would flip all four deployed profiles to `extension_stale: true` and
  force a manual Remove + Load unpacked on two hosts, for a comment with zero behavioural
  effect. The correction instead lives in `extension/README.md`, immediately beside the code.
  Say the word if you'd rather pay the marker bump and have it in the source comment.

## Gates

- **pytest** (`scripts/browser-bridge/tests`): 481 passed, 0 failed (171 s)
- **node** (`tests/*.test.mjs`, glob form): `# tests 495`, `# pass 495`, `# fail 0`,
  `# cancelled 0`, `# skipped 0`, `# todo 0`
- **`test_skill_size.py`**: 4 passed. `SKILL.md` untouched at **11,988 bytes** — ceiling
  12,288, so **300 bytes** headroom against the 250-byte floor, unchanged by this PR.

No test asserted the falsified claim, so none needed fixing. Docs/prose only — the diff
touches no executable statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bJFGEUx1pLkFpxRkNkhAR
