### PR TITLE
chore: triage workbench's uncommitted state — rescue 2 stranded docs, make the deployed i3/opencode config reproducible

### DIFF
--- a/claudedocs/espanso-typing-toil-2026-07-25.md
+++ b/claudedocs/espanso-typing-toil-2026-07-25.md
@@ -1,0 +1,166 @@
+# Espanso typing toil — hand-typed long-form vs. existing shortcuts
+
+**Date:** 2026-07-25
+**Scope:** Read-only analysis. Goal — find cases where an espanso snippet **already
+exists** but Zach hand-types the long-form expansion anyway (the trigger→habit
+transfer failed). This is distinct from `/espanso-audit` (which decides
+add/shorten/remove from transcript phrase-mining); here we correlate the **raw
+keylog typing stream** against the **live snippet definitions**.
+
+---
+
+## TL;DR — top findings
+
+| Rank | Snippet | Fires (used) | Hand-typed long-form | Miss rate | Chars saved/use | **Toil score** |
+|---|---|---|---|---|---|---|
+| 1 | `:ds` → `dispatch subagent to ` | **1** | **94** | 99% | 18 | **1692** |
+| 2 | `:rns` → `recommend next steps` | **1** | **20** | 95% | 16 | **320** |
+| 3 | `:acq` → `ask me clarifying questions and recommend anything you think would be useful to include` | 2 | 2 | 50% | 83 | 166 |
+
+Everything else has **zero** hand-typed toil: `:eos` (44 fires / 0 typed) and
+`:kickoff` (24 fires / 0 typed) are the shortcuts that **stuck**; all paths
+(`:hlt` `:kuc` `:nixos` `:cc*` …) and all `:ssh*` snippets show 0 hand-typed
+full-form occurrences (tab-completion / rarely typed verbatim).
+
+**Headline:** the shortcuts that failed are the **short, mid-sentence prefixes**
+(`:ds`, `:rns`); the ones that stuck are the **long, whole-message rituals**
+invoked via the Ctrl+Space search UI (`:eos`, `:kickoff`).
+
+---
+
+## Method
+
+### Data source and why reconstruction is possible (NOT a proxy)
+The X11 keylogger (`scripts/collector/keylog/`) does **not** store raw keystrokes
+— `chunker.py` reconstructs **typing units** (flushed on Enter / focus-change /
+2s-idle / maxlen) and **applies BackSpace in place**, so the `text` column of
+`source='keys', kind='typing'` rows holds *what was actually left standing on
+screen*. That means true typed-text reconstruction is available — **this is
+keylog-derived, not a transcript proxy.**
+
+Critically, this **resolves the ambiguity** that `espanso-usage.py` flags for
+`:ds`/`:rns` in the transcript signal. When a snippet *fires*, espanso backspaces
+the trigger and inserts the expansion via a **clipboard paste** — a paste is not
+a KeyPress, so RECORD never captures it. Therefore:
+
+- **A fire → the expansion text never enters the keylog typing stream.**
+- **The expansion text appearing in a `kind='typing'` chunk ⇒ it was physically
+  typed** (i.e. the shortcut was *not* used).
+
+### Queries run (ClickHouse `activity.events`, reader creds via SOPS)
+1. **Fires:** `count()` of `source='keys' AND kind='espanso'` grouped by
+   `text` (trigger) × `host` × `payload.method` (direct vs search).
+2. **Hand-typed:** for each text-detectable expansion, `countIf(
+   positionCaseInsensitive(text, '<distinctive-substring>') > 0)` over
+   `source='keys' AND kind='typing'`. Distinctive substrings were chosen to avoid
+   cross-matching (e.g. `:cc`'s `civit/civitai ` won't match `civitai-gpu-fleet`).
+3. **Contamination check:** `countIf(position(text, ':ds ') …)` etc. — literal
+   triggers in the typing stream (would indicate a *failed* expansion inflating
+   nothing, or trigger typed in prose). **Result: 0 for every trigger** → no
+   failed-expansion contamination.
+
+### Window
+Keylog is **forward-only** (detector deployed mid-June). Coverage:
+- laptop: 2026-06-24 → 2026-07-26 (~32 days, 80.4k typing chunks)
+- workbench: 2026-07-05 → 2026-07-26 (~21 days, 25.7k typing chunks)
+
+### Confidence & false-positive/negative risk
+- **Confidence: HIGH** for the ranking. Three independent corroborations:
+  (a) fires paste via clipboard so expansion-in-keystream can only be manual;
+  (b) literal triggers = 0 in the typing stream (no failed-fire noise);
+  (c) manual inspection of `:ds`/`:rns`/`:acq` samples — all are genuine Claude
+  prompts typed in Alacritty (e.g. `dispatch subagent to process feedback:`,
+  `dispatch subagent to research kubeclaw…`), not config/doc editing.
+- **False-positive risk (small):** the expansion phrase could be typed for
+  another reason — quoting it, or editing `nix/home.nix` line 92 / RULES.md
+  where `dispatch subagent to` literally appears. Bounded: a config edit is ≤1
+  occurrence, and the samples are overwhelmingly prompts. A few could trace to
+  the `/espanso-audit` sessions themselves. Net effect on 94 is minor.
+- **False-negative risk (undercount):** if the expansion is split across a
+  focus-change or 2s-idle chunk boundary it won't substring-match. So **94/20 are
+  lower bounds** — real toil is ≥ these.
+- **App split:** `:ds` = 92 Alacritty + 2 Brave; `:rns` = 20 Alacritty. Alacritty
+  = the Claude Code CLI → these are prompt-composition toil.
+
+---
+
+## Full ranked table (all text-detectable existing snippets)
+
+| Snippet | Expansion (abridged) | Fires (direct/search) | Hand-typed | Chars saved | Toil score | Interpretation |
+|---|---|---|---|---|---|---|
+| `:ds` | `dispatch subagent to ` | 1 (1/0) | **94** | 18 | **1692** | Shortcut exists but you type the long form ~every time → trigger never transferred |
+| `:rns` | `recommend next steps` | 1 (1/0) | **20** | 16 | **320** | Same pattern — short end/mid-prompt phrase, typed not expanded |
+| `:acq` | `ask me clarifying questions and recommend anything…` | 2 (1/1) | 2 | 83 | 166 | 50/50; low volume but big per-use save when used |
+| `:eos` | `review work done this session and identify skills…` (192 ch) | 44 (0/44) | **0** | 188 | 0 | **Stuck** — invoked via Ctrl+Space search every time |
+| `:kickoff` | `give me the kickoff message to copy paste…` | 24 (0/24) | **0** | 49 | 0 | **Stuck** — search-invoked ritual |
+| `:hlt` | `…/workspace/homelab-talos ` | 2 (0/2) | 0 | — | 0 | No verbatim hand-typing (tab-completion) |
+| `:kuc` `:nixos` `:cc` `:cdp` `:cgf` `:cmo` `:csc` `:cpk` `:subk` | paths | 0 | 0 | — | 0 | Not typed verbatim; low/zero usage |
+| `:sshwn` `:sshwl` `:sshln` `:sshll` | `ssh zach@…` | 0 | 0 | — | 0 | No verbatim hand-typing captured |
+
+Toil score = `hand_typed_occurrences × chars_saved_per_expansion` (the manual
+keystrokes an existing shortcut would have eliminated). Not text-detectable
+(excluded): `:date :time :datetime :iso :uuid :clip` (dynamic output) and the
+typo-corrections `dashbaord`/`reocmmend` (correct spelling isn't toil).
+
+---
+
+## Findings — why the failures failed
+
+1. **`:ds` is the dominant toil (99% miss).** It fired **once** in the whole
+   window but the expansion was typed **94×**. Root cause is structural, not a
+   bad trigger string: `:ds` is a **mid-sentence prefix** ("dispatch subagent to
+   X"). Expanding requires deciding "expand" at the *start* of composing a
+   thought, then continuing to type the object anyway. The saving is marginal
+   (18 chars, 3-char trigger already), so there's little pull to build the habit.
+   It also **duplicates a RULES.md standing default** ("dispatch a subagent … as
+   the default implementation workflow"), so the phrase is already muscle-memory.
+
+2. **`:rns` is the same failure mode, smaller** (95% miss, 20 typed). Short
+   end-of-prompt phrase; typing 20 chars is barely slower than reaching for a
+   trigger, and it overlaps conceptually with `/resume` (which already proposes
+   ranked next steps).
+
+3. **`:acq` half-sticks (2/2).** Low frequency, but each use saves 83 chars, so
+   the ROI per fire is high. The two hand-typings were near-verbatim
+   (`ask me clarifying questions and recommend anything…` /
+   `ask me any clarifying questions and recommend…`) — the intent is habitual,
+   the trigger just isn't top-of-mind at that moment.
+
+4. **The snippets that stuck share a profile:** long expansion (49–192 chars
+   saved), a *whole-message ritual* (not a prefix), and invocation via the
+   **Ctrl+Space search UI** keyed on memorable search_terms (`handoff`, `wrap`,
+   `kickoff`) rather than a typed trigger. Zach's espanso muscle-memory is
+   **search-first**, not direct-trigger — every `:eos`/`:kickoff` fire was a
+   search fire, and `:ds`/`:rns`'s only fires were direct. The direct-trigger
+   habit essentially doesn't exist for the short prefixes.
+
+---
+
+## Recommendations
+
+Deterministic where possible. This complements `/espanso-audit` (which already
+pruned the 0-fire snippets on 2026-07-25) — it does **not** redo it.
+
+- **`:ds` → DROP (primary) / accept as-is (fallback).** The trigger did not
+  transfer (1 fire in a month), the per-use saving is marginal (18 chars), and
+  it duplicates a RULES.md default Zach already types fluently 94×. A shorter
+  trigger won't help — `:ds` is already 3 chars and the failure is behavioral
+  (prefix-at-sentence-start), not length. Dropping loses ~nothing; keeping is
+  harmless clutter. **Recommend drop** unless he wants it purely as a
+  search-menu entry (then it's fine — search is how his espanso habit actually
+  works).
+- **`:rns` → DROP / repoint.** Same reasoning (95% miss, 16-char save, overlaps
+  `/resume`). Lowest-effort: drop it. If kept, only worthwhile as a search entry.
+- **`:acq` → KEEP as-is.** Only text-detectable snippet with genuinely high
+  per-use value (83 chars) that Zach *does* reach for. Low frequency, no change
+  needed; don't drop it.
+- **`:eos`, `:kickoff` → KEEP.** Working exactly as intended (44 / 24 fires, 0
+  toil). These are the model to emulate.
+- **Paths & `:ssh*` → no typing-toil action here.** Zero verbatim hand-typing.
+  (`:hlt` fires occasionally; the rest are near-dormant — a *usage* question for
+  `/espanso-audit`, not a *toil* question.)
+- **Structural takeaway for future snippets:** short mid-sentence prefixes don't
+  build a direct-trigger habit for this operator. Snippets stick when they are
+  (a) long, (b) a whole-message ritual, and (c) discoverable via Ctrl+Space
+  search terms. Design new snippets to that profile; don't add short prefixes
+  and expect trigger transfer.

--- a/claudedocs/gametape-session-review-2026-07-20.md
+++ b/claudedocs/gametape-session-review-2026-07-20.md
@@ -1,0 +1,65 @@
+# Gametape — Claude Code session review (2026-07-20)
+
+**Ask:** read past Claude Code sessions on both hosts, extract my inputs + the agent's
+delivery, then identify where to skip steps / simplify / speed up / automate.
+
+## Method (so you can trust or discount the numbers)
+- **Corpus:** 57 settled, un-extracted sessions from the **last 10 days**, both hosts
+  (53 workbench + 4 laptop), via the Layer-B `session-insight` pipeline → `activity.events`.
+  Report aggregates over 65 deduped extracted sessions (trailing 30d insight window).
+- **Sampling:** 32 giant sessions (up to 635 chunks) were deterministically capped to a
+  42-chunk head+middle+tail sample so they didn't dominate the read. Facets for those judge
+  the session *arc*, not every turn.
+- **Extraction:** 9 subagents, anti-confabulation contract (counts are deterministic ground
+  truth; the model only writes qualitative facets). 10 empty-stub sessions correctly flagged
+  unreadable and excluded.
+- **Honest caveats:** leverage tags are model-surfaced, **not measured savings**. The
+  theme-recurrence counts below are heuristic keyword clustering — directional, not exact.
+  Corpus skews to **datapacket-talos** (client infra, 74 sessions) so themes lean that way.
+
+## Scorecard — what the tape shows
+- **Outcomes (n=55):** 51% fully / 45% mostly / 4% partially achieved. **0 not-achieved.**
+- **Mean Claude-helpfulness: 4.85/5** (47×5, 8×4, none below 4).
+- **Session shape:** feature_build (22) + investigation (17) dominate; goal mix ops/feature/bugfix/deploy/infra.
+- **Interaction friction (qualitative):** wrong_approach 41, env_breakage 23, tool_error 16, slow_feedback 15.
+- **Positive signal worth keeping:** repeated, correct **"flag before acting"** (refused a
+  value-inverted spec, stopped before pushing release commits), **"deployed ≠ verified"**
+  discipline, and honest self-correction against live metrics (refuted a false handoff claim
+  about an orphan pool net-growing; corrected a wrong "CF-cache is the dominant lever"
+  diagnosis when challenged). The tape is *not* a story of a struggling agent — it's a
+  high-functioning loop with specific, repeated toil sinks.
+
+## The opportunities — ranked by recurrence × leverage
+
+Recurrence = distinct sessions the theme appeared in (heuristic).
+
+| # | Pattern | Sessions | Move | Fix |
+|---|---------|:---:|------|-----|
+| 1 | **Hand-rolled observability queries** — port-forward → PromQL/LogQL/Pyroscope → python-parse → re-aggregate, rebuilt per read; a wrong service label silently returns zero | 12 | automate / speed-up | A standing `obs-read <cluster> <preset>` tool/skill that owns the port-forward lifecycle + a library of *validated* presets (503-by-service, single-pod CPU saturation, B2 Class-B breakdown) returning parsed tables. Kills the silent-zero footgun. |
+| 2 | **Silent cross-surface drift, no detector** — a change lands on one surface, the co-requisite surface rots: stale DB hosts post-migration, `pr-deploy` auth drift, `schema.prisma` vs live indexes, cross-repo manifest mirroring, out-of-band Cloudflare/B2 config not in git | 12 | automate | Extend repo-cos into a weekly **drift detector**: DB conn-strings resolve? prisma-schema vs live indexes? cross-repo manifest parity? committed assert-scripts for out-of-band CF/B2 config. Emit to bar/mail. |
+| 3 | **Proactive-alerting blind spots** — Pyroscope backend NotReady ~2d (no liveness probe), face-pass had no restart alert, HPA scales on fleet-avg CPU (blind to single-pod core saturation); several caught *only* because a human noticed Discord noise | 10 | automate | Alertmanager coverage audit: liveness probes present, single-pod-saturation rule, NotReady>N-min. |
+| 4 | **"Merged ≠ live" verification** — hand-driving PR→release-cut→image-build→canary→live-artifact + multi-DB "did the prod write land" diffs against hand-captured baselines | 9 | simplify | A **`/verify-deploy` skill already exists but went un-invoked** ("a real efficiency miss", in-session). Surface it in kickoff/resume; extend it to the multi-DB last-mile so "is it live + did it write" is one command. |
+| 5 | **Trust-but-verify subagent claims** — agents claim "build green"/"committed" but stop early or leave stale worktree state (`node_modules` symlink removed → false LSP flood; `vite build` doesn't typecheck) → Claude re-runs the authoritative gate every time | 8 | automate | A deterministic **post-agent verification gate** (audit-pr shape): re-run authoritative build/test/-race + assert the agent actually finished. Fix gopls workspace to include per-task worktrees. **Highest leverage given you work entirely via agents.** |
+| 6 | **Browser automation broken on NixOS** — Playwright Chromium `GLIBC_ABI_GNU2_TLS not found` → every click-path / OAuth e2e is undrivable, forcing DB-baseline *proxies* for verification | 6 | fix-env (skips a whole workaround class) | Get Playwright working (nix `playwright-driver`, working chromium, or a container). Directly shrinks #4's toil and unblocks real e2e. |
+| 7 | **No cheap "are my agents done?" signal** — sessions burned ~22 `ScheduleWakeup` polls ("agents still working") because the only done-signal is dumping full transcripts | 6 | automate | A completion webhook / clawgate task-status the loop can cheaply poll. (agent-ops dashboard partially covers the *human* view; the *agent* still polls.) |
+| 8 | **Regenerable-cache / disk GC unautomated** — disk left to hit 82% before a manual scan; the green-tier reclaim (~40–751G) is deterministic | 6 | automate | Scheduled green-tier reclaim `systemd --user` timer (the scan is already written). |
+| 9 | **Existing skill/knowledge un-invoked or no durable home** — hand-rolled sequences that a skill already covers; new platforms (remix, bar) had no skill until session close; MEMORY.md manual byte-cap compaction | 4 | simplify | Surface relevant skills at session start; auto-flag when a hand-rolled sequence matches an existing skill. |
+| 10 | **"Where can I see the latest runs?"** asked 3× in one session — no surfaced run index | 3 | simplify | A "latest runs" index/link surfaced by the pipeline that produces them. |
+| 11 | **Stale local build artifacts break pre-push/CI** — `node_modules` behind a pinned dep, ungenerated Prisma model, dirty tracked `output.css`/`go.sum` | 2+ | automate | Auto-sync (`pnpm install` + `prisma generate`) in the pre-push hook before the typecheck. |
+| 12 | **Destructive/inline-shell footguns** — `git worktree remove --force` + a shell glob nuked unrelated worktrees' uncommitted work; inline-python-in-bash quoting failed repeatedly until rewritten as files | 2+ | guardrail | Extend the bash-guard hook: block glob-driven `worktree remove --force`; nudge inline-python → file. |
+
+## Cut list — quick wins vs bigger builds
+- **Quick wins (cheap, high-frequency):** #11 pre-push auto-sync · #8 disk-GC timer · #5b gopls-worktree config · #6 fix Playwright on NixOS · #4b surface `/verify-deploy` at kickoff.
+- **Bigger builds (worth it — top recurrence):** #1 `obs-read` tool · #2 cross-surface drift detector · #5 post-agent verification gate.
+
+## What's already being attacked (don't rebuild)
+- Context re-gathering at session start → **resume-state digest** (`/resume` step 3) already targets this; extend it with the obs presets (#1) and skill-surfacing (#9).
+- Human "what are my agents doing / blocked on me" → **agent-ops dashboard** exists; the gap is the *agent-facing* done-signal (#7), not the human view.
+- Cross-repo improvement signals → **repo-cos** exists; the drift detector (#2) is a natural new signal class for it.
+
+## Single highest-leverage pick
+**#5 — the post-agent verification gate.** You work entirely through agents, "trust-but-verify
+subagent claims" recurs in 8 sessions, and it compounds with #6 (fixing Playwright lets that
+gate include real e2e). It converts a per-PR manual re-verification ritual into one deterministic
+step and closes the "agent claimed green but stopped early" failure mode that shipped at least
+one real money-path 500 regression (self-caught four PRs later).

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -145,14 +145,6 @@ in
     };
   };
 
-  # Compositor disabled — NVIDIA forceFullCompositionPipeline handles vsync/tearing
-  # picom conflicts with NVIDIA's composition pipeline causing workspace switch flicker
-  # services.picom = {
-  #   enable = true;
-  #   backend = "glx";
-  #   vSync = true;
-  # };
-
   # Notification daemon (Gruvbox-themed, CALM). Value formats verified parse-clean
   # against dunst 1.13.2 (the running version): `width`/`offset` take a paren-tuple
   # `(min, max)` / `(x, y)` (v1.11- used NxN); the home-manager module quotes string

--- a/nix/i3/config.nix
+++ b/nix/i3/config.nix
@@ -207,6 +207,9 @@ bindsym $mod+minus move scratchpad
 # Notifications (dunst). dunstctl ships with the dunst package on PATH.
 bindsym $mod+n exec --no-startup-id dunstctl history-pop            # recall last dismissed
 bindsym $mod+Shift+n exec --no-startup-id dunstctl set-paused toggle && pkill -RTMIN+15 i3status-rs # manual DND (quiet mode) + refresh the notifications bar block
+
+# Background blur toggle (picom dual_kawase)
+bindsym $mod+Shift+b exec --no-startup-id ~/workspace/devrc/scripts/toggle-blur.sh
 bindsym $mod+grave exec --no-startup-id dunstctl close-all          # clear the whole stack
 
 # Thin borders

--- a/scripts/opencode/opencode.jsonc
+++ b/scripts/opencode/opencode.jsonc
@@ -76,7 +76,7 @@
 //     --tool` AUTO-APPROVES it. So `ask` means "friction for a human", never
 //     "a control on an unattended agent".
 //   * only a `"*": "deny"` removes a tool from the request schema; a narrow
-//     deny does not, and `"ask"` costs exactly what `"allow"` costs.
+//     deny does not, and `"allow"` costs exactly what `"allow"` costs.
 //   * `small_model` drives TITLE GENERATION ONLY — not compaction. The real
 //     cheap-model lever is pinning the hidden title/summary/compaction agents
 //     in the `agent` block below.
@@ -93,7 +93,7 @@
 {
   "$schema": "https://opencode.ai/config.json",
 
-  "model": "openrouter/deepseek/deepseek-v4-pro",
+  "model": "openrouter/xiaomi/mimo-v2.5",
   // Title generation only. Compaction is pinned via the `agent` block.
   "small_model": "openrouter/deepseek/deepseek-v4-flash",
 
@@ -190,8 +190,8 @@
 
     // Ask before burning a long unproductive loop, and before reaching outside
     // the project directory.
-    "doom_loop": "ask",
-    "external_directory": "ask",
+    "doom_loop": "allow",
+    "external_directory": "allow",
 
     "bash": {
       "*": "allow",
@@ -205,77 +205,77 @@
       // rather than prompting. Anything irreversible belongs in guard_core.py.
 
       // --- git ---
-      "*git*push*": "ask",
-      "*git*commit*": "ask",
-      "*git*rebase*": "ask",
-      "*git*checkout*": "ask",
-      "*git*restore*": "ask",
-      "*git*branch -D*": "ask",
-      "*git*worktree remove*": "ask",
-      "*gh*pr merge*": "ask",
+      "*git*push*": "allow",
+      "*git*commit*": "allow",
+      "*git*rebase*": "allow",
+      "*git*checkout*": "allow",
+      "*git*restore*": "allow",
+      "*git*branch -D*": "allow",
+      "*git*worktree remove*": "allow",
+      "*gh*pr merge*": "allow",
 
       // --- kubernetes / gitops ---
-      "*kubectl*delete*": "ask",
-      "*kubectl*apply*": "ask",
-      "*kubectl*patch*": "ask",
-      "*kubectl*scale*": "ask",
-      "*kubectl*drain*": "ask",
-      "*kubectl*edit*": "ask",
-      "*kubectl*replace*": "ask",
-      "*kubectl*exec*": "ask",
-      "*kubectl*cp*": "ask",
-      "*kubectl*rollout undo*": "ask",
+      "*kubectl*delete*": "allow",
+      "*kubectl*apply*": "allow",
+      "*kubectl*patch*": "allow",
+      "*kubectl*scale*": "allow",
+      "*kubectl*drain*": "allow",
+      "*kubectl*edit*": "allow",
+      "*kubectl*replace*": "allow",
+      "*kubectl*exec*": "allow",
+      "*kubectl*cp*": "allow",
+      "*kubectl*rollout undo*": "allow",
       // `get secret -o yaml` prints every value base64-encoded, i.e. plaintext.
-      "*kubectl*secret*": "ask",
-      "*helm*upgrade*": "ask",
-      "*helm*uninstall*": "ask",
-      "*helm*rollback*": "ask",
-      "*flux*suspend*": "ask",
-      "*flux*resume*": "ask",
-      "*flux*delete*": "ask",
+      "*kubectl*secret*": "allow",
+      "*helm*upgrade*": "allow",
+      "*helm*uninstall*": "allow",
+      "*helm*rollback*": "allow",
+      "*flux*suspend*": "allow",
+      "*flux*resume*": "allow",
+      "*flux*delete*": "allow",
 
       // --- talos --- (the RESET verb is enforced by guard_core.py, which is
       // the only layer that catches `talosctl -n <ip> reset`. This broad ask is
       // friction for every other node-level verb.)
-      "*talosctl*": "ask",
+      "*talosctl*": "allow",
 
       // --- secrets to plaintext ---
-      "*sops*-d*": "ask",
-      "*sops*--decrypt*": "ask",
-      "*sops*exec-env*": "ask",
-      "*age*-d*": "ask",
-      "*age*--decrypt*": "ask",
+      "*sops*-d*": "allow",
+      "*sops*--decrypt*": "allow",
+      "*sops*exec-env*": "allow",
+      "*age*-d*": "allow",
+      "*age*--decrypt*": "allow",
 
       // --- whole-system state ---
-      "*nixos-rebuild*": "ask",
-      "*home-manager*switch*": "ask",
-      "*nix-collect-garbage*": "ask",
-      "*nix*profile remove*": "ask",
+      "*nixos-rebuild*": "allow",
+      "*home-manager*switch*": "allow",
+      "*nix-collect-garbage*": "allow",
+      "*nix*profile remove*": "allow",
       // Only the MUTATING systemctl verbs. `systemctl status`/`list-timers` are
       // read-only and high-frequency — gating those is pure prompt fatigue,
       // which trains the operator to click through the ones that matter.
-      "*systemctl*start*": "ask",
-      "*systemctl*stop*": "ask",
-      "*systemctl*restart*": "ask",
-      "*systemctl*enable*": "ask",
-      "*systemctl*disable*": "ask",
-      "*systemctl*daemon-reload*": "ask",
+      "*systemctl*start*": "allow",
+      "*systemctl*stop*": "allow",
+      "*systemctl*restart*": "allow",
+      "*systemctl*enable*": "allow",
+      "*systemctl*disable*": "allow",
+      "*systemctl*daemon-reload*": "allow",
 
       // --- privilege escalation: gate the WRAPPER itself ---
-      "sudo*": "ask",
-      "*sudo *": "ask",
-      "*doas *": "ask",
+      "sudo*": "allow",
+      "*sudo *": "allow",
+      "*doas *": "allow",
 
       // --- filesystem blast radius ---
-      "*chmod -R*": "ask",
-      "*chown -R*": "ask",
-      "*rm*-r*": "ask",
+      "*chmod -R*": "allow",
+      "*chown -R*": "allow",
+      "*rm*-r*": "allow",
       // `dd` stays ANCHORED / operand-scoped on purpose: a leading-`*` `"*dd *"`
       // also matches `git add src/` (…"add "…), and gating every `git add` is
       // exactly the prompt fatigue that trains an operator to click through.
-      "dd *": "ask",
-      "*dd if=*": "ask",
-      "*dd of=*": "ask",
+      "dd *": "allow",
+      "*dd if=*": "allow",
+      "*dd of=*": "allow",
 
       // ================= DENY: naive-spelling backstop ONLY ================ //
       // 🔴 READ THE HEADER. These are NOT airtight and are NOT the control.

--- a/scripts/toggle-blur.sh
+++ b/scripts/toggle-blur.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Toggle picom background blur on/off via SIGUSR1 config re-read.
+# State file tracks the current blur state across restarts.
+set -euo pipefail
+
+STATE_FILE="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/picom-blur-state"
+PICOM_CONF="${HOME}/.config/picom/picom.conf"
+
+if [[ ! -f "$PICOM_CONF" ]]; then
+    notify-send -u critical "Blur toggle" "picom.conf not found"
+    exit 1
+fi
+
+if [[ -f "$STATE_FILE" ]] && grep -q "off" "$STATE_FILE"; then
+    CURRENT="off"
+else
+    CURRENT="on"
+fi
+
+if [[ "$CURRENT" == "on" ]]; then
+    sed -i 's/strength = [0-9]*/strength = 0/' "$PICOM_CONF"
+    echo "off" > "$STATE_FILE"
+    notify-send -t 1500 " " "Blur off"
+else
+    sed -i 's/strength = [0-9]*/strength = 5/' "$PICOM_CONF"
+    echo "on" > "$STATE_FILE"
+    notify-send -t 1500 " " "Blur on"
+fi
+
+pkill -USR1 picom || true


### PR DESCRIPTION
Triage of the workbench host's (192.168.50.250) uncommitted devrc state, so that
host becomes reproducible from git. **Diagnostic applied to every modified file:**
hashed the working copy against that file's recent commits to distinguish a
*stale orphan* (older copy of already-merged work — safe to discard) from
*genuinely new* work. **All four modified/untracked code files matched NO commit
in their history — none is a stale orphan.**

| File | Verdict | What it is |
|---|---|---|
| `nix/i3/config.nix` | **genuinely new** (0/9 commits matched; full history scanned) | Adds `$mod+Shift+b` → `scripts/toggle-blur.sh`. **Already in the deployed store path** `0np8h0xig3j...-hm_i3config`. |
| `scripts/toggle-blur.sh` | **untracked, new** | The script that binding execs. Never in git. |
| `nix/home.nix` | **genuinely new** (0/60 commits matched) | 8-line deletion of the commented-out `services.picom` block *and its NVIDIA rationale*. |
| `scripts/opencode/opencode.jsonc` | **genuinely new** (0/1 commits matched; full history) | All 53 `"ask"` globs → `"allow"`, model swap. **Deployed**: `s4lhms83f...-hm_opencode.jsonc` is byte-identical (sha `867c02cb…`). |
| `claudedocs/espanso-typing-toil-2026-07-25.md` | **not upstream** | 166-line analysis, untracked since 2026-07-25. |
| `claudedocs/gametape-session-review-2026-07-20.md` | **not upstream** | 65-line session review, untracked since 2026-07-20. |

Checked `origin/main` for equivalents of both docs by exact path and by
name-grep over `claudedocs/` — neither exists under any name. They are unsaved
work, not duplicates.

## Commits are separable on purpose

1. `docs:` — the two rescued analyses. Uncontroversial.
2. `chore(i3):` — the picom blur binding + script + the home.nix hunk.
   🔴 **Known non-functional.** picom is not running on workbench, is enabled
   nowhere in this repo, and `~/.config/picom/picom.conf` does not exist — so
   pressing the live binding only raises the script's "picom.conf not found"
   critical notification. Committed for *reproducibility*, not because it works.
   The rationale the home.nix hunk deletes (picom conflicts with NVIDIA
   `forceFullCompositionPipeline`, causing workspace-switch flicker) is
   preserved in that commit message.
3. `chore(opencode):` — 🔴 **weakens the permission posture; this is the commit
   to drop if unwanted.** Removes every human-friction prompt (git push/commit/
   rebase, gh pr merge, kubectl delete/apply/exec/secret, helm, flux, talosctl,
   sops/age decrypt, nixos-rebuild, home-manager switch, sudo/doas, `rm -r`,
   `dd`, …), leaving only `guard_core.py` as a control. Evidence it was a blind
   global replace rather than a considered edit: it also rewrote a doc comment
   into a tautology — "`allow` costs exactly what `allow` costs". Left
   byte-identical to the deployed file deliberately; fix that comment before
   merging, or drop the commit.

## Not done here
No deploy, no `ship.sh`, no `nixos-rebuild` — convergence is the operator's.
The workbench working tree was left dirty and untouched; nothing was discarded.
