### PR TITLE
docs(opencode): restore the ask-vs-allow cost claim a sed flattened into a tautology

### DIFF
--- a/scripts/opencode/opencode.jsonc
+++ b/scripts/opencode/opencode.jsonc
@@ -76,7 +76,7 @@
 //     --tool` AUTO-APPROVES it. So `ask` means "friction for a human", never
 //     "a control on an unattended agent".
 //   * only a `"*": "deny"` removes a tool from the request schema; a narrow
-//     deny does not, and `"allow"` costs exactly what `"allow"` costs.
+//     deny does not, and `"ask"` costs exactly what `"allow"` costs.
 //   * `small_model` drives TITLE GENERATION ONLY — not compaction. The real
 //     cheap-model lever is pinning the hidden title/summary/compaction agents
 //     in the `agent` block below.


### PR DESCRIPTION
One line. `scripts/opencode/opencode.jsonc:79` read:

> `"allow"` costs exactly what `"allow"` costs.

which asserts nothing. The original claim is a measured fact about opencode 1.18.4's request schema: only a `"*": "deny"` removes a tool from the schema, a narrow `deny` does not — so choosing `ask` over `allow` buys human friction **at no token cost**. That is the reason the surrounding permission block is shaped the way it is, and flattening the sentence deleted it.

## Provenance (traced, not assumed)

- Authored correctly in `e21985a`.
- Flattened by **`1fb8c2b`** ("Provision opencode commands+skills from Claude Code sources; tune permissions").
- The restored line is **byte-identical** to `e21985a`'s — sha256 `066e87c1827873b6124d8ff7c3c7b0acf55e43883cddadff18f9caf5388cfedb`.

## Correcting an attribution

PR #340's commit message states that it rewrote this comment into a tautology. **It did not.** `df52fbf^` already carried the tautological form, and the line does not appear anywhere in #340's diff. The corruption is older and unrelated to the workbench `ask`→`allow` change. Noted here so the wrong attribution isn't re-derived from #340's message later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)