### PR TITLE
docs: rescue the remaining 27 stranded workbench claudedocs (follow-on to #340)

### DIFF
--- a/claudedocs/gametape-session-review-2026-07-24.md
+++ b/claudedocs/gametape-session-review-2026-07-24.md
@@ -1,0 +1,65 @@
+# Gametape — Claude Code session review (2026-07-24, trailing 4 days)
+
+Second gametape run (prior: `gametape-session-review-2026-07-20.md`). Window: 2026-07-20 → 24.
+
+## Method
+- **Corpus:** 83 settled, un-extracted sessions from the last 4 days (all workbench — the
+  laptop had nothing new in-window), via the Layer-B `session-insight` pipeline. 4 giant
+  sessions capped to a 42-chunk head/mid/tail sample; 8 extraction subagents; 0 unreadable.
+- **Caveat that shapes everything below:** this window is **dominated by the headless
+  `task-spec-drafter` fleet** — ~63 short `claude -p` runs, one per ClickUp ticket. The
+  drafter fires *per ticket*, so it produces many sessions; this is not "76% of your work,"
+  it's "one automation fires often and each fire is a session." That's *why* fixing it is
+  high-leverage: the fix is cheap/deterministic and improves every future run.
+
+## Scorecard
+- **Outcomes (n=84):** 88% fully / 7% mostly / 4% partially / 1% not — the drafter reaches
+  correct, honest verdicts (dissolves already-done tickets, escalates NEEDS-DECISION rather
+  than fabricating specs).
+- **Mean helpfulness 4.27/5** (down from 4.85 last run) — not a regression in quality; the
+  mix shifted to haiku triage runs that "clearly help" (4) rather than "materially drive" (5).
+- **The deterministic friction counts tell the story:** **`permission_block` = 57** (was **1**
+  last run) and `wrong_approach` = 89 — almost entirely the drafter being denied its read-only
+  verbs and retrying `cd && git` → `git -C`.
+
+## The finding: your ticket-triage drafter works, but the harness is starving it
+Every theme below is the same drafter, hamstrung four ways. Recurrence = distinct sessions.
+
+| # | Pattern | Sessions | Fix |
+|---|---------|:---:|-----|
+| 1 | **"Is this ticket already done / where does it live?" reconstructed by hand** — every run hand-iterates 5–15 near-identical `git log --all --grep` / `gh pr list` / `find` permutations (the bulk of the tool_errors are empty searches) | 44 | A deterministic **`ticket-status <CU-id>` primitive** (see below) |
+| 2 | **Allowlist/shell-guard blocks the drafter's own read-only verbs in headless** — `gh pr --search`, `kubectl get`, `git branch/rev-parse/for-each-ref`, compound `&&`, `$VAR` expansion all hit "requires approval," which a `claude -p` run **cannot grant**; 6–30 blocked calls/run, silently-failed PR cross-checks, some runs interrupted with no record | 32 | Whitelist the literal read verbs (expansion/pipe-safe) for the headless drafter context |
+| 3 | **Env-handles don't resolve in `claude -p`** — `$CIVITAI`/`$KC_DPPROD` (the `.zshenv` handles shipped for *interactive* agents) aren't in the non-interactive shell, so nearly every run wastes calls on `cd civitai && git` → `git -C $CIVITAI` failures before falling back to absolute paths | 23 | Inject absolute repo roots into the drafter prompt, or export the handles into the `claude -p` env |
+| 4 | **"Is commit X merged AND deployed/serving?" resolver missing** — reconstructed each time from `branch --contains` + `merge-base --is-ancestor` + reflog + image-hash checks; also blurs partial-vs-full-fix judgment | 22 | Fold into the `ticket-status` primitive (merge + deploy state) |
+| 5 | **No code-symbol index** — locating the relevant function in large civitai service files takes dozens of find/grep/read-offset probes | 15 | Give the drafter serena/ctags (or a prebuilt symbol index) |
+| 6 | **ClickUp structural metadata ignored** — title-only / bodyless / milestone-container / Phase-2 tickets burn a full code-probe before dissolving to NEEDS-DECISION/FYI | 8 | Upfront metadata short-circuit (type/child-count/empty-body) + cross-ticket dependency lookup before code search |
+
+### The highest-leverage build: `ticket-status <CU-id>`
+Themes 1+4 (44+22 sessions) are one missing deterministic primitive. Given a ClickUp ticket id, resolve **prior-art + ship-state** in one call:
+- **First-class:** grep the `CU <id>` commit convention (the decisive, fastest signal whenever it's followed — sessions confirmed it) across `--all`, plus `gh pr list --search`.
+- Then: is the matching commit **merged to trunk** and **deployed/serving** (the theme-4 chain).
+- Return a structured verdict (ALREADY-DONE / PARTIAL / NOT-FOUND + evidence links).
+This is a specialized cousin of `obs-read` / the existing `/verify-deploy` — deterministic, testable, and it collapses the drafter's dominant per-run toil while sharpening its judgments.
+
+### Correctness bug worth fixing regardless of leverage
+- **Anti-confabulation failure (1 session, `3d4df59b`):** for a live-incident ticket the drafter emitted "no git commits, merged PRs, or live cluster alerts found" having run **zero tools** — a fabricated verification (safe bucket, wrong process). Add a gate: **require ≥1 real read before emitting a non-`unreadable` record.**
+
+## Tail — single-session but real (interactive arcs, not the drafter)
+- **Incident probe-ladder classifier** — a clawgate-502 dig took ~11 hand-built kubectl steps to reach "CNI outage, not app bug"; the probe ladder (pod→svc-IP / pod→host-apiserver / pod→pod / DNS) belongs in the incident toolkit as a one-shot "app-bug vs CNI-outage" classifier.
+- **Dev-clone schema drift** — the weekly Sunday dev-DB clone vs mid-week prod migrations silently turns newer PR-previews into all-model-page 404s (swallowed Prisma P2022); auto-reconcile prod migrations onto the dev clone or flag affected PRs.
+- **Release-cycle manual driving** — the per-package "watch CI → merge Version PR → wait for OIDC publish → verify live on npm" loop was hand-driven across 4 releases.
+- **Doc-vs-code gap** — no check that shipped component CSS matches `MARKUP.md` defaults; 4 components shipped unstyled until a real-app dogfood caught it.
+- **Pre-merge typecheck gate** — an unrelated PR's type break reached main and blocked ALL releases (echoes last run's stale-artifact theme + the shipped `/verify-agent`).
+
+## How this run differs from 2026-07-20
+Last run's gametape → we built general tools (`verify-agent`, `obs-read`, `playwright-nixos`).
+This run says the highest-leverage work is **hardening your own autonomous drafter** — it runs
+constantly but is starved by permission/env gaps and re-derives the same ticket→code lookup
+every time. Themes 2+3 (the harness/env fixes) are pure config, deterministic, and the
+cheapest wins; the `ticket-status` primitive (themes 1+4) is the biggest build.
+
+## Honest caveats
+Leverage tags are model-surfaced, not measured savings. Recurrence is heuristic keyword
+clustering. The window is skewed by the drafter's high run-frequency (per-ticket), so it
+dominates the sample — real, but read it as "fix the thing that fires often," not "this is
+most of your work."

--- a/claudedocs/handoff-activity-telemetry-2026-06-24.md
+++ b/claudedocs/handoff-activity-telemetry-2026-06-24.md
@@ -1,0 +1,54 @@
+# Handoff: activity-telemetry pipeline — 2026-06-24
+
+## Goal
+A personal activity dataset for productivity mining: capture what Zach actually does across hosts (shell, terminal, keystrokes, browser, Claude sessions) into a queryable store, and surface time/attention + focus/context-switching. Built this session from the "mine Claude Code sessions" thread, extended to full system activity.
+
+**Operate it via the `activity` skill** (authoritative ops doc). Cross-session state: memory `activity-telemetry-pipeline`.
+
+## State now — LIVE + verified end-to-end
+- **devrc** `main` @ `5bb6a3d`; **all PRs merged** (devrc #7,#9,#10,#11,#12,#13,#14; homelab #67,#68,#69). Open homelab PRs are unrelated renovate bots.
+- **5 sources flowing**, per-host attributed, UTC-stamped: `zsh`, `tmux`, `keys` (X11 keylogger, full content, laptop only), `browser` (Chrome MV3 + receiver :8787), `claude` (transcript tailer, timer 5min).
+- **Sink:** dedicated authed ClickHouse, homelab ns `activity`, table `activity.events` (180d TTL). NOT the shared clickstack. Endpoints: workbench `http://192.168.50.94:30123`, laptop `http://10.42.0.10:30123` (nebula).
+- **Dashboard:** Grafana "Activity & Productivity" (uid `activity-productivity`), datasource `activity-clickhouse` → `https://grafana.homelab.lan`. Deployed + datasource health OK.
+- **Validation harness** (`devrc/scripts/collector`… no — `devrc/scripts/validation/`): **8/8 invariants PASS**, controlled-replay assertions pass.
+- **Both hosts shipped + services restarted** on the latest code. Claude backfill was in progress (~7159 msgs/host; trickles via the 5-min timer thereafter).
+- **TZ FIX verified:** `ts↔now()` lag = **3s** (was the ~5–6h local/UTC offset). Table was truncated for a clean UTC start (data prior to 2026-06-24 ~13:30 UTC is gone — it was <1 day of thin local-ts data).
+
+### What's IN FLIGHT / not yet done
+- **Panel CONTENT unverified** — dashboard panels are structurally correct + query-valid, but won't show meaningful patterns until a day+ of data accrues. The human spot-check (below) is the remaining validation.
+- **Keystroke-replay assertion** in the harness only runs on the **laptop** (needs X); skipped on the headless workbench.
+
+## Next steps (ranked)
+1. **Let data accrue ~a day, then do the human ground-truth check** (the one validation no harness can do): open the dashboard, pick an hour you remember, confirm it matches reality. This is the real "is it true" test.
+2. **Ops fix — `X-Restart-Triggers`** on the collector/keylog/receiver systemd user services so `home-manager switch` restarts them on a script-only change. This bit us twice this session (switch leaves stale code running; I worked around it with manual `systemctl --user restart`). Small devrc PR.
+3. **Run the keystroke-replay assertion on the laptop** to close the one validation gap that the headless workbench couldn't exercise: `ssh zach@10.42.0.100`, then `... validate.py --replay` with reader creds (DISPLAY=:0 present).
+4. **Optional next layer:** an LLM-summarized daily digest (task-drafter pattern) on top of the deterministic dashboard. CAVEAT (carried from the session): this is a measurement layer — mining describes the present, it doesn't pick the next altitude. Don't let it become a well-instrumented saw-sharpen.
+5. **Housekeeping:** workbench is intentionally NOT on a clean branch (it's on `feat/activity-collector-slice` fast-forwarded to main, with unrelated WIP) — fine, collector works; converge later if desired. The homelab-talos local `.sops.yaml` has pre-existing drift — resolve before committing there.
+
+## Gotchas / decisions / dead-ends
+- **`ts` is the UTC instant** (tz-less DateTime64). Dashboard buckets hour-of-day/per-day with explicit `'America/Winnipeg'` (`toHour`/`toDate`); time-series stay UTC. NEVER tz-shift `$__timeFilter`/`now()` comparisons.
+- **`home-manager switch` does NOT restart these services** on a script-only change → manual `systemctl --user restart activity-collector keylog browser-activity-receiver` per host after a code ship. (Next-steps #2 fixes this.)
+- **Laptop is nebula-only** — it cannot reach the `192.168.50.x` LAN IP; its collector env uses `http://10.42.0.10:30123`. Workbench uses the LAN `.94`.
+- **Both hosts are hostname `nixos`** → `ACTIVITY_HOST` (=`workbench`/`laptop`) in each `~/.config/activity-collector/env` disambiguates; without it everything collides on `host=nixos` (fixed PR #11).
+- **keylog + browser are GUI-only** → laptop only (workbench is headless/server-mode).
+- **Full-content keystrokes land in CH** → that's WHY it's a dedicated authed store (default user password-protected; reader/writer creds in SOPS). Treat as sensitive.
+- **SOPS decrypt:** write the encrypted file to a temp path first — `sops -d` on a `<(...)` process-sub `/dev/fd` path fails to sniff the format (cost a failed snapshot this session). Pattern: `git show origin/trunk:…secrets.enc.yaml > /tmp/s.yaml; sops -d --extract '["stringData"]["reader-password"]' /tmp/s.yaml; rm /tmp/s.yaml`.
+- **Bug history (all fixed under verification this session):** receiver `ModuleNotFoundError: spool_emit` (don't `.resolve()` `__file__` — home-manager flattens the symlink); laptop LAN-vs-nebula endpoint; `host=nixos` collision; stale-code-after-switch; the auth/exposure redesign onto a dedicated authed store; the UTC tz bug.
+- **Decision: deterministic dashboard over LLM digest** as the first insight layer (no per-run cost, directly serves the lead insights). Full content + dedicated authed ClickHouse were Zach's explicit choices.
+
+## How to verify
+```bash
+# creds (write to temp file — NOT process-sub)
+git -C ~/workspace/homelab-talos show origin/trunk:clusters/homelab/apps/activity/secrets.enc.yaml > /tmp/s.yaml
+RPW=$(SOPS_AGE_KEY_FILE=~/workspace/homelab-talos/.secrets/age.key sops -d --extract '["stringData"]["reader-password"]' /tmp/s.yaml); rm -f /tmp/s.yaml
+CH=http://192.168.50.94:30123   # on the laptop: http://10.42.0.10:30123
+
+# data flowing, per-host, all sources:
+curl -s --user "activity_reader:$RPW" --data-binary "SELECT host, source, count(), max(ts) FROM activity.events GROUP BY host, source ORDER BY host, source FORMAT TSV" "$CH/"
+# UTC sanity — lag should be SECONDS, not hours:
+curl -s --user "activity_reader:$RPW" --data-binary "SELECT dateDiff('second', max(ts), now()) FROM activity.events WHERE source IN ('zsh','keys','browser') FORMAT TSV" "$CH/"
+# full harness (invariants + reconcile):
+CLICKHOUSE_URL=$CH CLICKHOUSE_USER=activity_reader CLICKHOUSE_PASSWORD=$RPW python3 ~/workspace/devrc/scripts/validation/validate.py
+# dashboard: https://grafana.homelab.lan → "Activity & Productivity"
+# cluster: KUBECONFIG=~/workspace/homelab-talos/homelab-kubeconfig kubectl -n activity get pods,svc
+```

--- a/claudedocs/handoff-activity-telemetry-2026-06-27.md
+++ b/claudedocs/handoff-activity-telemetry-2026-06-27.md
@@ -1,0 +1,62 @@
+# Handoff: activity-telemetry + self-hosted mail — 2026-06-27
+
+## Goal
+Two personal self-instrumentation systems, both now BUILT and LIVE: (1) the activity-telemetry pipeline (where time/attention/reading goes, 6 sources → ClickHouse → Grafana), and (2) a self-hosted mail inbox (forward Gmail → Postgres for automation). We're past "build it" and at the **decision point: use the data, or stop instrumenting.**
+
+**Operate via skills** (authoritative, both updated + synced to laptop this session): `activity`, `mailbox`. Cross-session detail in memories: `activity-telemetry-pipeline`, `selfhosted-mail-inbox`, `laptop_host`.
+
+## State now
+- **devrc** `main` @ `7f192e9` (both hosts CONVERGED to main this session — workbench was 10 behind, now clean). No open devrc PRs.
+- **homelab-talos** `trunk` — all activity/mail PRs merged (note: trunk tip is unrelated clawgate/task-drafter work from elsewhere).
+
+**Activity pipeline — DONE + GREEN + VISUALIZED:**
+- **6 sources live** (laptop has all; headless workbench has only `zsh`/`claude`): `zsh`, `tmux`, `keys`, `browser`, `claude`, **`i3`** (new — window/workspace focus = attention even when not typing; devrc PR #20).
+- **browser source**: idle-aware `active_ms` (PR #21), **scroll capture** `scroll_pct`+`scroll_ms` (PR #23+#24), `app=brave`, icon (PR #22), manifest v1.3.0. Hand-loaded in Brave (see gotchas).
+- **harness 8/8 GREEN** (PR #19 fixed the duration-vs-active conflation). X-Restart-Triggers (PR #16) means `ship.sh` restarts daemons on code change.
+- **Dashboard**: new row "Attention (i3 focus) & Reading (scroll)" deployed (homelab PR #78) — attention-by-app (Alacritty 705m/Brave 231m/7d), by-workspace, reading-depth-by-domain, i3-switches. Live at `https://grafana.homelab.lan`.
+- Laptop can now run homelab `kubectl` via the `homelab-kube-tunnel` SOCKS service (PR #18); `ship.sh` syncs skills laptop-ward (PR #17).
+
+**Mail inbox — LIVE + verified:**
+- Gmail (2 accounts) forward → `inbox.zacx.dev` (Cloudflare grey-cloud MX → Hetzner gateway :25 → nebula → homelab) → `mail-receiver` (aiosmtpd, Harbor image) → Postgres `mail` table (ns `mailbox`). Real mail flowing.
+- **Spam-filtered** (PR #77): `via_gmail` (deterministic — 100% of real mail is Gmail-forwarded) + `category` generated columns. Query: `WHERE via_gmail AND category IN ('personal','security')`.
+
+**CORRECTION (later same session): harness was NOT green — browser `active_ms` was ~20× inflated.** Re-verifying live state (not trusting the "8/8 GREEN" claim above) surfaced `OVERALL: FAIL` on `per_host_hour_active_cap`: **12h of browser "active" time logged in one 24h day** (true ~30min). Root cause: `service_worker.js` did a **non-atomic** `getState → mutate → setState` on `chrome.storage.session`; the concurrent handlers (`onActivated`/`onCommitted`/focus/idle) clobbered each other → lost idle-pauses (spans ran to the 1h cap) + double-fired tab switches each carrying the full span (proven: 2× 3.6M at one ts = 2h phantom). Idle/blur *detection* was fine. **FIXED + MERGED: PR #25** (`fix/browser-active-ms-race`, on `main` @ `ab6df86`) — extracted a mutex-serialized `state_store.js`, added redundant-nav suppression, and windowed the `per_host_hour_active_cap` invariant to a trailing 48h (append-only store can't recover from a one-time glitch on an all-time scan). 31 JS + 68 py tests green.
+
+**CORRECTION 2 (next day): the mutex fix was INCOMPLETE — browser `active_ms` is structurally unfixable in-extension on i3.** After PR #25 deployed (laptop reloaded), the double-fire was gone (0 duplicate-ts) BUT per-hour active was still impossible (8.87h "active" in ~7h wall-clock; two 60-min caps 27min apart). **Decisive i3 cross-check:** during a window where Brave logged 60 min active, the i3 source showed the user was in **Alacritty for a straight ~10-min stretch** (focus share Alacritty 29 vs Brave 11). Root cause #2 (the real one): `chrome.idle` measures **system-wide** input (terminal typing keeps Chrome "active") and `chrome.windows.onFocusChanged(blur)` is **unreliable on i3** → the extension counts other-app time as browser engagement. The "is Brave focused" truth lives in **i3, not Chrome** — so no in-extension accounting can fix it.
+
+**RESOLUTION (merged, verified): retire extension `active_ms`, derive attention downstream.**
+- **Derived metric = i3 "Brave-focused" intervals ∩ active-tab domain timeline** (domain from browser `nav` events — note URL is in the **`text` column**, not `payload.url`). Mathematically bounded by i3 dwell, so it *cannot* inflate. **Verified:** the 11:00 UTC hour reads **11.9 min** (was 144.4) = matches i3 Brave dwell 12.4 min; sum-per-domain 315min ≤ Brave i3 dwell 342min (7d).
+- **homelab-infra PR #79 (MERGED):** dashboard panel "Browser active time by domain (s)" → "Browser attention by domain (i3-derived, s)".
+- **devrc PR #26 (MERGED, `main`):** harness — *retired* `active_ms_capped` + `per_host_hour_active_cap` (metric gone, not silenced), added `derived_attention_consistent` guard (per-domain ≤ Brave i3 dwell). **Live harness `OVERALL: PASS`.** (Supersedes the PR-#25 48h-window stopgap.)
+- Lesson: extension `active_ms` was untrue the WHOLE time the dashboard showed it; the i3-dwell attention panel was always the correct number.
+
+**DONE (was deferred): vestigial-event stripping — devrc PR #27 (MERGED).** Removed the dead `active_ms` accumulator (`active_time.js`), focus/idle listeners, `active_ms`/`state` payload fields, and matching harness helpers; `idle` permission gone; manifest v1.4.0; receiver tolerant of a legacy client during the reload window. Ext is now nav(url/title)+scroll only (~2000 dead focus/idle events/day stop flowing). JS 21/21 + py 83/83 green. **Operator: needs a Brave reload to activate** (`cp -fL ~/.config/activity-collector/browser-ext/*.js ~/.local/share/activity-browser-ext/` → reload in brave://extensions).
+
+**IN FLIGHT / not done:**
+- **Human spot-check** still never formally done, but the i3 cross-check + derived-metric validation effectively ground-truthed the data this session. The activity thread is otherwise WRAPPED.
+
+## Next steps (ranked)
+1. **THE FORK is now live and on TRUSTWORTHY data.** The measurement layer is correct + complete + guarded. Recommendation carried into the decision: **STOP on activity and pivot to email automation on the live `mail` table** (the original "heavy automation" goal — triage, task/receipt extraction, digests, alerting). The activity thread has hit diminishing returns; further mining risks a well-instrumented saw-sharpen. A thin **weekly LLM digest** over the (now-true) activity data is the only remaining activity-side option if a digest is actually wanted — but it's a cap, not a new altitude.
+2. **Lower:** browser ext is hand-loaded (not nix-declarative) — if it churns, wire a `--load-extension`/auto-copy step. Optional Civitai-alert Gmail filter (95/day noise; already hidden by `category`).
+
+## Gotchas / decisions / dead-ends
+- **Browser ext is NOT fully nix-managed.** Loaded unpacked in Brave from `~/.local/share/activity-browser-ext/` (real-file copy; Chromium dislikes the nix-store symlink dir). A `service_worker.js`/content-script change needs: ship → `cp -fL ~/.config/activity-collector/browser-ext/*.js ~/.local/share/activity-browser-ext/` → **reload in `brave://extensions`** (+ reload the page — content scripts only inject post-reload).
+- **Scroll capture dead-end → fix:** the first impl used `import(chrome.runtime.getURL("scroll_track.js"))` in the content script — **fails silently on CSP**. PR #24 replaced it with a shared-isolated-world-global pattern (two ordered content scripts; `scroll_track.js` sets `globalThis.__activityScrollTracker`, no `web_accessible_resources`). Uses **capture-phase** scroll listening to catch SPA inner-container scroll.
+- **Query gotchas:** extract scroll with `JSONExtractInt(toString(payload),'scroll_pct')` — `payload.scroll_pct` subcolumn is NOT available. i3 dwell = gap-to-next-focus via `leadInFrame`, capped 30min. nav `url`=destination tab but `active_ms`/`scroll_*`=LEAVING tab.
+- **STALE-`origin/main`-ref bit repeatedly:** after merging a PR via `gh`, the local `origin/main` ref is stale until `git fetch`. Always `git fetch origin main` before `git show origin/main:...` or building from it.
+- **Tmux stale hooks:** `home-manager switch` does NOT reload a running tmux server's hooks → new hooks don't take until `tmux source-file` / fresh server. (Caught the `tmux` source emitting nothing.)
+- **Decisions:** raw data is never destroyed in this fidelity dataset (capped contributions in the harness/dashboard, not mutated rows). Mail spam is TAGGED not rejected (a hard reject would drop Gmail's own forwarding-confirmation emails). i3 stores NO dwell (computed from ts-gaps downstream) to avoid the same inflation `duration_ms` had.
+
+## How to verify
+```bash
+# Activity: all 6 sources flowing + harness green (workbench)
+git -C ~/workspace/homelab-talos show origin/trunk:clusters/homelab/apps/activity/secrets.enc.yaml > /tmp/s.yaml
+RPW=$(SOPS_AGE_KEY_FILE=~/workspace/homelab-talos/.secrets/age.key sops -d --extract '["stringData"]["reader-password"]' /tmp/s.yaml); rm -f /tmp/s.yaml
+CH=http://192.168.50.94:30123
+curl -s --user "activity_reader:$RPW" --data-binary "SELECT source,count(),max(ts) FROM activity.events WHERE ts>now()-1800 GROUP BY source ORDER BY source FORMAT PrettyCompact" "$CH/"
+CLICKHOUSE_URL=$CH CLICKHOUSE_USER=activity_reader CLICKHOUSE_PASSWORD=$RPW python3 ~/workspace/devrc/scripts/validation/validate.py   # expect OVERALL: PASS
+# Mail: classified inbox
+export KUBECONFIG=~/workspace/homelab-talos/homelab-kubeconfig
+kubectl -n mailbox exec mailbox-postgres-0 -- psql -U mailbox -d mailbox -c "select category,count(*) from mail where via_gmail group by category;"
+# Dashboard (the spot-check): https://grafana.homelab.lan → Activity & Productivity → host=laptop
+```

--- a/claudedocs/handoff-agent-facing-workbench-2026-07-11.md
+++ b/claudedocs/handoff-agent-facing-workbench-2026-07-11.md
@@ -1,0 +1,37 @@
+# Handoff — agent-facing workbench modernization (2026-07-11)
+
+**Thread:** Zach works ENTIRELY via agents now (Claude Code in tmux; ~20+ parallel sessions), so we stopped modernizing the *interactive* layer (shell/editor/CLI — atuin/starship/nvim were explicitly rejected as the wrong layer) and modernized the **agent-facing layer**: the i3 bar, notifications, and a new agent-ops dashboard. All merged to `devrc` `main`, live on the **workbench** (laptop pending). Repo: `~/workspace/devrc` (`$DEVRC`).
+
+## Live finding (2026-07-11) — civitai prod disk-space, REAL
+The civitai-prod alert pill went red because criticals GREW **63→128 this session** (firing ~312→367) — **not noise.** Pulled from civitai's Alertmanager: **125 of 128 criticals are `NodeFilesystemAlmostOutOfSpace`** (node filesystems within ~3-5% of full, cluster-wide and spreading) + 3× `PrometheusRemoteStorageFailures` (monitoring ns, possibly the leading edge). If any mount hits 100% → real outages (evictions, failed writes). civitai's `--red-above` was deliberately **NOT** tuned — its red is correct. Read-only recon (which nodes/mounts closest to 100%, imminent-vs-slow) was offered but **not yet run**; Zach directs remediation on client prod. **This is next-step #1.**
+
+## What shipped (devrc PRs, all merged)
+**i3 bar migration + polish**
+- **#74** — migrated the bar **i3blocks (/etc/nixos) → i3status-rust under home-manager** (`nix/graphical.nix`) + i3 config → home-manager (`nix/i3/config.nix` → `~/.config/i3/config`). ⚠ Cutover crashed once: the fix/rule is **finish with `sudo systemctl restart display-manager`, NOT `i3-msg restart`** (the running i3 had `-c /etc/i3/config` baked in argv; deleting that file + in-place restart = dead session). Staged apply script: `nix/system/apply-i3-to-hm.sh`.
+- **#75** removed dictation (reclaimed 2.3 GB venv). **#76** nerd-font icons + volume block + tuned thresholds. **#77** quieted colors (VPN-off + normal-CPU neutral). **#81** GPU icon → `expansion_card` (gpu icon override via `[icons.overrides]` — must use the icons TABLE form, not the `icons=` shortcut, or all icons drop to text).
+- **#78** GPU block (RTX 5080) + **decoupled poller** `scripts/bar-status-poll` (workbench `systemd --user` timer ~45s → `~/.cache/bar-status/*.json`) feeding hide-at-zero **count blocks**: clawgate/mail/homelab-alerts. **Audited** (#78 audit → hardening: `TimeoutStartSec=90`, `0600` caches). **#79** civitai-prod alerts as a separate block (its own kubeconfig, standing prod port-forward). **#80** `--red-above` thresholds so the standing alert backlogs (homelab ~22, civitai ~312) read **neutral** and only redden when something NEW crosses (30 / 340). **#97** — homelab `--red-above` bumped 30→34 (`nix/graphical.nix`) after the homelab backlog drifted to ~24-27 (all known noise); homelab pill neutral again. civitai's threshold was left as-is on purpose (see Live finding).
+
+**Notifications (#85, audited)** — dunst hardened (`fullscreen=pushback` DND, JetBrainsMono, positioning), i3 binds `$mod+n`/`$mod+Shift+n`/`$mod+grave`, a DND bar block, and **edge-triggered toasts** from `bar-status-poll` (fire once on the rising edge; click-action via detached `systemd-run` dunstify).
+
+**agent-ops "mission-control" dashboard** — `scripts/agent-ops`, opened 3 ways: **`$mod+i`** (i3, floating alacritty), tmux **`prefix+A`** (popup), and the **▦ bar button**. Read-only, fail-safe, deterministic. Sections: Blocked-on-me (bar-status caches), **Active runs** (live Claude-in-tmux via `/proc` scan; each row = the pane's **actual task from its title** + scratch codename + busy marker), Open PRs (`gh pr list` per repo, cached), Momentum/Done (`initiative-scan --json`), Health.
+- #86 initial → #89 scroll (`j/k/g/G`) + scratch codenames + bar button → #90 real PRs + task-titled runs + `$mod+i` → **#91 fix**: the `$mod+i` exec MUST be a single **quoted** string (unquoted/multiline i3 exec → parser-error nagbar at key-press).
+- Removed the old `tmux-initiatives.sh` **Alt+i** HUD (unused) — agent-ops supersedes it.
+
+**Docs/skills (#92 + per-host)** — refreshed `CLAUDE.md` (new "Graphical / agent-facing layer" bullet), `claude/commands/{i3,initiatives,devrc-dx}.md`, and the per-host `standup` skill to match (i3blocks→i3status-rust, /etc/nixos→home-manager, Alt+i→agent-ops).
+
+## Load-bearing facts / gotchas
+- **Edit the bar/i3 in home-manager (`nix/graphical.nix`, `nix/i3/config.nix`), NEVER /etc/nixos** — the old `/etc/nixos/{i3config,i3blocks}.nix` + `i3blocks-scripts` are RETIRED.
+- **Cutover = `systemctl restart display-manager`, not `i3-msg restart`.**
+- **fuzzyclaw is UNTRUSTED** — Zach doesn't use it; `~/.tmux/tasks/*.json` is stale. `tmux-claude-counters.sh` still reads it (grain of salt). Active-runs uses live `/proc` + pane titles instead.
+- The **bar-status poller holds standing read-only port-forwards into TWO prod clusters every ~45s** (homelab-prod + civitai DataPacket client-prod, `civit/datapacket-talos/prod-kubeconfig`, Alertmanager `monitoring/kube-prometheus-stack-alertmanager:9093`) — Zach accepted this; bounded + fail-safe + cgroup-killed.
+- **Alert backlogs — homelab is noise, civitai is NOT.** Homelab (~24-27) is standing noise → `--red-above` bumped to 34 (#97), pill neutral. **civitai criticals grew 63→128 this session (disk, `NodeFilesystemAlmostOutOfSpace`) — real; its red pill is correct, do NOT tune it away** (see Live finding).
+- Memories updated: `i3-bar-i3status-rust-migration`, `agent-ops-dashboard-direction`.
+
+## Next steps (ranked)
+1. **civitai prod disk-space recon + remediation** (real, growing, client-facing — see Live finding). The recon is cheap + read-only: pull `NodeFilesystemAlmostOutOfSpace` from civitai's Alertmanager, rank nodes/mounts by fullness, split imminent-vs-slow. Remediation (freeing/expanding disk) is on client prod → Zach directs; surface findings, don't act autonomously.
+2. **Scoped secrets (sops-nix)** — the *other* agent-native modernization Zach flagged: ~26 plaintext cred refs (kubeconfigs, `~/.claude/clawgate.env`, tokens) and agents run *with* that access. Consolidate to least-privilege injection.
+3. **Laptop (Phase 6)** — still on the old bar; needs its own `/etc/nixos/configuration.nix` inspected, then `apply-i3-to-hm.sh` + rebuild + `systemctl restart display-manager`. It inherits everything except workbench-only blocks (GPU/clawgate/mail/alerts/civitai).
+4. **Screen-share auto-DND** (dunst #3, deferred) — needs Zach's screen-share tool name to wire the pause hook.
+
+## Kickoff message for next session
+> Continuing the agent-facing workbench modernization (devrc). Live finding to pick up first: the **civitai-prod alert pill is red for a REAL reason** — criticals grew 63→128 this session and 125/128 are `NodeFilesystemAlmostOutOfSpace` (node disks cluster-wide within ~3-5% of full and spreading); if a mount hits 100% → outages. Read `claudedocs/handoff-agent-facing-workbench-2026-07-11.md`. Want me to run the (cheap, read-only) recon — rank which civitai nodes/mounts are closest to full and split imminent-vs-slow — so you can direct remediation? Or pick up **scoped secrets (sops-nix)** (~26 plaintext creds agents run with) or the **laptop bar rollout** instead. Reminders: civitai's red pill is correct, don't tune it (homelab was bumped to 34 in #97, that one's noise); edit the bar/i3 in home-manager not /etc/nixos; cutover ends with `systemctl restart display-manager`; fuzzyclaw is untrusted.

--- a/claudedocs/handoff-airvpn-host-tunnel-2026-07-21.md
+++ b/claudedocs/handoff-airvpn-host-tunnel-2026-07-21.md
@@ -1,0 +1,96 @@
+# Handoff — Host AirVPN tunnel: shipped live + killswitch hardened (2026-07-21)
+
+## TL;DR
+The workbench **host AirVPN WireGuard tunnel** (the bar's `airvpn` pill) went from
+"the vpn control doesn't work" → **live, verified, leak-safe, cluster-safe,
+lockout-safe**. Phase-2 is applied; the fail-closed killswitch survived two
+self-inflicted outages and now uses a durable uplink-policing model. **Nothing is
+outstanding** — this doc is a record + operating guide for the next session.
+
+## What shipped (all merged to `main`)
+| PR | what |
+|---|---|
+| #118 | Phase-2 apply script (`nix/system/apply-airvpn-host.sh`) + minimal icon-only pill + nebula-overlay killswitch exemption |
+| #119 | Removed dead speech-to-text dictation section from README (unrelated rot) |
+| #122 | Apply script handles a split multi-line `imports =` / `[` in `configuration.nix` |
+| #126 | Killswitch → **uplink-only policing** + `skuid` nebula match + orphan-teardown (fixes the k3s outage) |
+| #128 | Police **all physical NICs** (union w/ default-route egress iface) + fail-closed on nft error / no-NIC / bridge uplink + active-pill display fix (`???`→`CA?`) |
+
+## Live state (verified end-to-end 2026-07-21)
+- Tunnel **UP**, exit `CA` (e.g. 184.75.208.162), **not** home `24.79.61.66`.
+- Killswitch armed **policing all 3 physical NICs** — journal: `up: killswitch armed
+  (fwmark=…) policing [enp18s0u2u2c2 eth1 wlp15s0]`.
+- **k3s cluster healthy**, **nebula overlay** reachable (homelab 4 nodes), and
+  **off-LAN `ssh zach@10.42.0.30` works** under the live killswitch (Zach confirmed).
+- Pill display: **icon-only dim** when off · **`CA?`** when up.
+
+## The killswitch model (why it's shaped this way — read before touching it)
+`scripts/airvpn-updown` PostUp/PreDown. **Polices ONLY physical uplinks:**
+- Rule 1: `oifname != { <all physical NICs> } accept` — set = `/sys/class/net/*/device`
+  hardware NICs **UNION** the live default-route egress iface (catches a bridge/bond/
+  VLAN uplink that has no `/sys` device). Everything non-physical (lo, airvpn tunnel,
+  `nebula.mesh`, `cni0`/`flannel.1` CNI, docker0, veth) is always allowed → durable,
+  no rule per new internal net.
+- Uplink allows: wg `fwmark`, LAN `192.168.50.0/24`, **`meta skuid "nebula-mesh"`**
+  (nebula runs `listen.port:0` → random source port, so match by SOCKET OWNER, not a
+  port), lighthouse `/32`, endpoint `/32`, gateway `/32`, ip6 link-local, multicast →
+  else **`drop`**.
+- **Fail-closed** on: no physical NIC found, OR `nft -f` load failure → blanket
+  fallback (internal ifaces + skuid + LAN + lighthouse → drop). Killswitch ALWAYS
+  arms (the old fail-open `exit 0` is gone).
+- `airvpn-sudo down` force-deletes the `airvpn_ks` table (orphan guard: wg-quick down
+  no-ops PostDown when the iface is already gone → table would stay armed).
+
+**History (why not simpler):** an "enumerate every internal network to ALLOW"
+killswitch first dropped the nebula overlay (→ would lock Zach out of his own remote
+host, #118) then dropped k3s apiserver→pod replies (→ whole cluster CrashLooped,
+#126). Uplink-only policing is leak-equivalent AND doesn't need to know about internal
+nets. **Do not revert to an allow-list model.**
+
+## How to operate it (also in the `bar` skill, refined this session)
+- **Connect / disconnect:** left-click the pill → menu, or `sudo /etc/nixos/i3blocks-scripts/airvpn-sudo {up,down}` (NOPASSWD). DEFAULT-OFF.
+- **Apply a killswitch edit without a reconnect:** re-install then re-arm in place —
+  `sudo install -m 0755 -o root -g root ~/workspace/devrc/scripts/airvpn-updown /etc/nixos/i3blocks-scripts/airvpn-updown`
+  then `sudo /etc/nixos/i3blocks-scripts/airvpn-updown up airvpn` (flush+reload, tunnel stays up).
+- **🔴 Re-test ANY killswitch change from an OFF-LAN nebula path** (a LAN test can't
+  reach the direct-punch lockout mode): LAN session held open (recovery), then check
+  k3s health + `$KC_HOMELAB kubectl get nodes` (4) + `curl ipinfo.io` (CA) + off-LAN
+  `ssh zach@10.42.0.30`.
+- **Bail (keeps tunnel up):** `sudo nft delete table inet airvpn_ks`.
+- **Debug:** `journalctl -t airvpn-updown -n5` (arm line lists the policed NICs).
+
+## Gotchas hit this session (so next session doesn't relearn them)
+- **Installed helpers ≠ repo.** `/etc/nixos/i3blocks-scripts/airvpn-{updown,sudo}` are
+  plain copies (not nix-store, for the NOPASSWD sudoers path). Editing the repo does
+  nothing until you re-`install` them; a running killswitch keeps the OLD rules until
+  a re-arm/reconnect.
+- **`nft -c` can't validate rulesets in this sandbox** (rootless netlink init fails) —
+  render the chain offline + reason; not machine-validated.
+- **Concurrent `ship.sh` mangled the working tree mid-session** (a stale June-29
+  autostash stash-pop left conflict markers in `CLAUDE.md` + reverted files). It
+  self-resolved when ship.sh finished; the 2 stale autostashes were dropped. If the
+  tree looks corrupted, check `git stash list` + whether a ship is running before
+  touching anything.
+- **My commit once landed on local `main`** (concurrent merges shifted refs under a
+  `checkout -b`). Fixed with `git branch -f` surgery (no reset --hard). Watch the
+  current branch after branch ops when merges are landing concurrently.
+
+## Follow-ups / not done (all optional — nothing blocking)
+- **Laptop applicability:** host AirVPN is **workbench-only** today. The multi-NIC +
+  fail-closed killswitch was explicitly built with the multi-homed laptop in mind, but
+  applying host AirVPN to the laptop is not done (would need its own conf + apply).
+- Audit 🟢 items left by choice: broadcast-DHCP on a policed NIC is dropped (desirable);
+  forwarded/pod/container egress is unpoliced by design (`hook output` only); stale
+  endpoint `/32` left on `down` (harmless). See PR #128 comments.
+- The poller doesn't populate the connected **server** country for a hostname endpoint
+  (`ca3.vpn.airdns.org`) → pill shows `CA?` via the exit-country fallback. Fine as-is;
+  could map the endpoint hostname → country if a clean `CA` (no `?`) is wanted.
+
+## Kickoff message for next session
+> Host AirVPN tunnel is live + verified on the workbench (PRs #118/#122/#126/#128
+> merged). Killswitch polices all physical NICs, `skuid`-matches nebula, fail-closed.
+> Operate via the `bar` skill's "AirVPN host tunnel — ops" section. Nothing
+> outstanding. If asked to touch the killswitch: re-install to
+> `/etc/nixos/i3blocks-scripts/`, re-arm in place (`airvpn-updown up airvpn`), and
+> re-test from an OFF-LAN nebula path with a LAN recovery session — a LAN-only test
+> can't reach the direct-punch lockout mode.

--- a/claudedocs/handoff-clawgate-agent-loop-close-2026-07-03.md
+++ b/claudedocs/handoff-clawgate-agent-loop-close-2026-07-03.md
@@ -1,0 +1,38 @@
+# Handoff — clawgate: the agent loop CLOSES end-to-end (2026-07-02→03)
+
+**One line:** a clawgate Task now goes card → pre-filled Dispatch → provisioned agent → **real PR** → `ready_for_review` → PWA done-push, with a phone-first operator UX. Shipped 0.7.44 → **0.7.58** (live). The load-bearing fix was a file-based git credential (openclaw's exec sandbox strips `$GITHUB_TOKEN`).
+
+Operate everything via the **`/clawgate`** skill (updated this session) + the authoritative `homelab-talos/containers/clawgate/HANDOFF.md` (updated this session, see caveat below).
+
+---
+
+## What shipped (0.7.44–0.7.58, all live + verified)
+
+- **Dispatch config on the Task** (migration **0014** `task_dispatch_config`): a Task carries `model`/`repo`/`repo_branch`/`grant_profiles`. From-card **Dispatch is a pre-filled confirm, not a blank form** (0.7.45). Machine reads **`GET /api/tasks[/{id}]`** (0.7.44). Both producers (repo-cos `clawgate.py` + the drafter) fill the config on POST. Default model = **deepseek** ("I'll override if needed").
+- **🔴 Close-the-loop (0.7.48–0.7.49):** repo-backed TASK agents branch→push→open a PR (REST API; `gh` not in image)→comment→`ready_for_review`. **The fix that made push work:** openclaw's exec sandbox STRIPS `$GITHUB_TOKEN` from the agent's shell — so the git helper reads a FILE `/root/.gh-token` written at pod startup (`internal/agents/values.go buildHelmValues` extraInitCommands). Proven: container `printenv`=40 chars, agent's own=0. **Verified live: PR #49.**
+- **Tasks UI:** [Requests|Tasks] segmented tab + horizontal swipe; pending-count badge; grouped In-progress/Open/Done; **live dispatch feedback** (`agent.changed` SSE → status chip + Open-chat CTA, no reload); optimistic auto-approve; relative timestamp; **discoverable dismiss** that **tears down the linked agent pod** (0.7.56).
+- **Agent chat:** LIVE kickoff streaming (`agent.stream` SSE + shared WS/SSE renderer, 0.7.50+0.7.57); completion banner (Mark complete → /tasks); working indicator; smaller header / model-name-only / repo chip; markdown code-protection + clickable bare URLs.
+- **PWA task-lifecycle push (0.7.53):** created (4s-debounce coalesced) / provisioned / done. Decoupled via `SetStatusChangeHook`/`SetChatReplyHook`/`SetStreamHook` + `Broadcast*` (agents pkg stays free of api/push).
+
+Gate every release: `go build/vet/test -race` + **e2e 70 pass / 2 skip** (flaky `agent-selfservice.spec.ts:33` = pg cold-start) + hook bats.
+
+## Docs/skills updated this session (the actual ask)
+- **`~/.claude/skills/clawgate/SKILL.md`** — version 0.7.42→0.7.58, dense 0.7.44–0.7.58 arc, migrations →0014, e2e 61→70, VER hint →0.7.59 + collision warning, and the Repos-tab git-credential fact rewritten to the file-based `/root/.gh-token` + exec-sandbox-strip gotcha.
+- **`~/.claude/skills/repo-cos/SKILL.md`** — the approve→Task line now notes the payload carries the resolved `owner/name` repo + deepseek model (migration 0014).
+- **`homelab-talos/containers/clawgate/HANDOFF.md`** — header/status/next-version →0.7.58/0.7.59, a new 0.7.44–0.7.58 section, footer e2e/version, and the loop-CLOSED reframing of the #1 soak item.
+- **Memories written this session:** `openclaw-exec-sandbox-strips-env`, `task-dispatch-default-deepseek`, `clawgate-version-before-build`, `agent-pods-flux-suspended`.
+
+⚠ **HANDOFF.md is uncommitted in the homelab-talos working tree** (that repo's tree is permanently dirty; the deploy pipeline stages HANDOFF.md with the clawgate paths). It'll land with the **next** clawgate deploy commit — if the next change is unrelated, stage it explicitly so the doc update isn't orphaned.
+
+## Gotchas that bit (don't relearn)
+- **Version-collision:** `git fetch origin trunk` + check the LIVE deployment pin BEFORE numbering a release — Zach ships concurrently and Harbor tags are mutable (clobbered his 0.7.47 once). Memory `clawgate-version-before-build`.
+- **Secret env is stripped in the agent sandbox** — prefer a startup-written FILE over an env var for any agent-run secret. Memory `openclaw-exec-sandbox-strips-env`.
+- **agent-pods Flux kustomization is SUSPENDED** → drafter configmap/cronjob edits are `kubectl apply`'d surgically, not GitOps'd. Memory `agent-pods-flux-suspended`.
+- `g.If` gomponents args eval EAGERLY → nil-guard maybe-nil values.
+- "notes" = internal name for user-facing "Tasks" (pkg `internal/notes`, table `notes`, `/tasks`→`handleNotesContent`).
+
+## Next / open
+1. **SOAK — the build is done, the value is in USE.** The loop is closed (PR #49 proved it); the real test is Zach adjudicating + dispatching drafter cards over ≥3 real runs. Don't add loop features until a few cycles show it earns its place.
+2. **#3 (unstarted):** fold the dead Suggestions tab into the queue as a generative SOURCE (session-end → drafts next task-spec → `POST /api/tasks`), NOT a standalone feature. Plan in `close-the-loop` STATE.md.
+3. A deterministic server-side `agent_open_pull_request` native tool would beat a weak model hand-rolling the REST call (noted in `openclaw-exec-sandbox-strips-env`).
+4. Orphan sweep done this session (deleted `sharp-wren`, task #51 complete); only the `#10` operator + unrelated old devpods remain.

--- a/claudedocs/handoff-clawgate-chat-polish-2026-07-05.md
+++ b/claudedocs/handoff-clawgate-chat-polish-2026-07-05.md
@@ -1,0 +1,48 @@
+# Handoff: clawgate agent-chat polish + structured transcript + e2e green — 2026-07-05
+
+## Goal
+Continue the clawgate "USE + SOAK" phase: the Task→Dispatch→agent→PR loop is proven; this session was soak-driven agent-chat UX polish + a structured transcript + greening the e2e suite. Keep USING the loop, not building new loop features.
+
+## State now
+- **Repo:** `~/workspace/homelab-talos`, GitOps from `trunk` (commit = deploy). Trunk head `3a4b489a`. All work pushed; nothing in flight.
+- **Live:** `harbor.homelab.lan/library/clawgate:0.7.66` on the workbench cluster, healthy. Verified live per feature (below).
+- **Authoritative point-in-time state:** `homelab-talos/containers/clawgate/HANDOFF.md` (current through 0.7.66 — read it first). Operate via the **`/clawgate` skill** (updated this session).
+- **Shipped this session (0.7.59→0.7.66), each deployed + live-verified:**
+  - 0.7.59 mobile dispatch-confirm stack + one-row chat header + gated feedback Send
+  - 0.7.60 task push notifications flatten markdown (`notificationText()`) — a Web Push body is plain text everywhere, not an Android limit
+  - 0.7.61 **idle-task reaper** — daily sweep auto-dismisses >7d-idle tasks + tears down their pods (env `CLAWGATE_TASK_TTL`, `off`/`0` disables; centralized in `dismissTask`)
+  - 0.7.62 markdown chat title + status icon removed + sticky autoscroll
+  - 0.7.63 **scroll ROOT fix** (`h-dvh` app shell → `#chat-log` is the real scroller) + live tool/text interleave + task-detail modal
+  - 0.7.64 **STRUCTURED transcript** — turn persists as ordered parts (migration **0015**, `PartCollector`), full response with interleaved tool chips on reload
+  - 0.7.65 **dismissing a task regroups sections LIVE** (broadcast `EventTaskChanged`)
+  - 0.7.66 full-height input (in-flow `flex-none`, no dead gap) + scroll-to-working (`forceScroll`) + drop the openclaw `NO_REPL` "no reply" sentinel (`isSentinelReply`)
+  - **e2e suite GREENED (73 pass / 2 skip):** `login()`→`waitAppSettled` (fixes FAB detach flake), retries 1/2 + 45s timeout, `NoopProvisioner` (env `CLAWGATE_FAKE_PROVISIONER=1`, inert in prod) enables `agent-chat.spec.ts`. Committed `2f12ad03`.
+- **Soak:** ~7 real test tasks dispatched (#58–#64), each produced a genuine PR against `innovation-upstream/devrc` — loop works end-to-end. **Task #64 (`.shellcheckrc`) is OPEN, ready to dispatch** for the next feedback pass.
+- **Skills/docs updated:** `~/.claude/skills/clawgate/SKILL.md` (version log→0.7.66, migrations→0015, e2e→73/2 + greening + gotchas, deploy VER→0.7.67); `~/.claude/skills/close-the-loop/STATE.md` (loop SOAKED+VALIDATED note). clawgate `HANDOFF.md` current on trunk.
+
+## Open investigations — live diagnosis state
+_No mid-diagnosis bugs. Two known, non-blocking items:_
+
+### e2e full-suite flakes under high box load (not a code regression)
+- **Symptom:** `tasks.spec.ts` FAB tests (`#fab-tasks` `toBeVisible`) time out when the shared workbench box is at load ~9.
+- **Observed:** with load ~9 the FAB resolves but paints late → Playwright times out; in isolation under normal load it passes; full suite was green twice (73/2). Root aggravator found + fixed at source (`waitAppSettled`). **19 leaked `clawgate-e2e-pg-*` containers** (from `make e2e` runs killed by `timeout` before fixture teardown) were starving the box — cleaned this session.
+- **Ruled out:** my chat changes (they don't touch the FAB/tasks path; suite green at 0.7.65 before them).
+- **Leading hypothesis:** pure resource starvation on the shared box (a farm-web Playwright run under `appuser` was also live).
+- **Next probe (if it recurs):** `docker ps -q --filter name=clawgate-e2e-pg | wc -l` (clean leaks) + `uptime`; run the suite when load is low.
+
+## Next steps (ranked)
+1. **Keep soaking** — dispatch **task #64** (`.shellcheckrc`), do a feedback pass on the 0.7.66 chat (input flush / working-bubble scroll / no `NO_REPL`). Resist building new loop features.
+2. If more chat feedback lands, batch into one version; always `git -C ~/workspace/homelab-talos fetch origin trunk` + check the LIVE pin before numbering (Zach ships concurrently).
+3. (Chore, not urgent) Add a trap/`--forbid-only` so a killed `make e2e` stops leaking `clawgate-e2e-pg-*` containers.
+
+## Gotchas / decisions / dead-ends
+- **Deploy = worktree off `origin/trunk`** (never the permanently-dirty main checkout — it has uncommitted `.sops.yaml`/`.serena` and is far behind). Build docker → smoke → push harbor → bump pin → commit explicit paths → rebase → push → flux reconcile → wait for pod → live-verify. Full recipe in the `/clawgate` skill.
+- **Playwright vs the agent-detail page:** use `waitUntil:'domcontentloaded'` (NOT `networkidle` — the SSE `/events` conn never idles); for elements that read "not stable"/"outside viewport" under SSE layout churn, use `evaluate(el=>el.click())` / class-toggle assertions.
+- **`NO_REPL`** is an openclaw *gateway* sentinel (not clawgate) emitted when a turn ends via tool calls with no closing narration — filtered in `isSentinelReply` (render + `PartCollector`).
+- **Structured transcript** persists parts via a `PartCollector` that OBSERVES the stream — NO signature churn to `runToolLoop`; the tool loop still returns only its final text, the collector captures the full ordered turn.
+
+## How to verify
+- Live health/pin: `KUBECONFIG=$KC_WORKBENCH kubectl get pod -n clawgate -l app=clawgate -o jsonpath='{.items[0].spec.containers[0].image}'` → `clawgate:0.7.66`.
+- Chat fixes (live, on a real task chat e.g. lively-lynx/task 63): input flush to `#chat-log` (gap ≈8px, was 43), `#chat-form` not `fixed`, no `NO_REPL` bubble, structured tool chips present.
+- e2e: `make -C ~/workspace/homelab-talos/containers/clawgate e2e` → 73 pass / 2 skip (when box load is normal; clean `clawgate-e2e-pg-*` leaks first).
+- Go: `go test -race ./...` + `bats hook/tests/*.bats` green.

--- a/claudedocs/handoff-dl-router-2026-07-31.md
+++ b/claudedocs/handoff-dl-router-2026-07-31.md
@@ -1,0 +1,95 @@
+# dl-router — shipped + open follow-ups
+
+**Date:** 2026-07-31 · **State:** merged and deployed to both hosts · **Not yet exercised in a browser**
+
+## What shipped
+
+- **PR #220** (`56babdd`) — the subsystem: loopback sidecar (`127.0.0.1:8791`, bearer token,
+  systemd user unit), deterministic matcher, SQLite alias/route store, qBittorrent client, yt-dlp
+  fetcher, backfill, CLI, MV3 extension, `setup-brave-profile.sh`.
+- **PR #224** (`7fe0fb8`) — adversarial-audit remediation. 20 original findings + 10 regressions the
+  first fix round introduced + 3 further rounds. Tests grew 341/151 → **581 pytest / 272 node**.
+- **PR #228** — `setup-brave-profile.sh` gates on the user-data-dir, not the binary name (headless
+  Brave automation on throwaway profiles was blocking the real setup).
+- **PR #232** (`b3b58f0`) — matching rewrite driven by the first evening of real use, which produced
+  **zero auto-files in nine downloads**. Identity signals (`discord:<channel id>` from the attachment
+  URL, `thread:<slug>` from unambiguous forum routes), performer/category directory kinds, a learning
+  rule that only learns the discriminating signal, provable-only cross-host referrer carry, and a
+  screened-refusal ledger. Five audit rounds; tests **828 pytest / 313 node**.
+
+## Deployed state (2026-07-31, both hosts)
+
+Schema **v4** (migrated from v2 in place; 9 routes + 5 examples preserved — verified on a copy first).
+`dirs.toml` classified **performer=24, category=2 (`Bbc`, `other`), unclassified=0**.
+
+⚠ The `dirs classify` generator's one proof rule — *a single word ⇒ category* — is **inverted for this
+library**, where performer directories are single-token handles. It filed ten performers as
+`category`, which would have taught tag→performer aliases: the exact mislearning PR #232 removed.
+Corrected by hand; draft kept at `dirs.toml.draft-bak`. Fix the heuristic before anyone reruns it.
+
+⚠ The store is **WAL-mode** and the main `.sqlite3` file is ~4 KB — all data lives in the `-wal`
+sidecar. Copying only the `.sqlite3` yields an empty database (this silently invalidated a migration
+test). Back up all three files, or checkpoint first.
+
+Design spec: `claudedocs/dl-router-design-2026-07-30.md` (gitignored — contains host specifics).
+
+## Deploy state (verified 2026-07-31)
+
+- Workbench: unit `active`, 25 dirs indexed, `configured=true`. Store migrated **v1 → v2**
+  (`routes.download_id` added, `routed_files` table created).
+- Laptop: unit `active`, inert (`library_root` unset → routing endpoints 503). Harmless.
+- `~/.config/dl-router/config.toml` exists; **qBittorrent credentials deliberately empty** — the
+  backfill refuses to move anything without them, which is the safe default.
+
+## Remaining manual steps (require Brave, or credentials)
+
+1. **Brave fully closed** → `scripts/dl-router/setup-brave-profile.sh --list`, then
+   `--profile '<dir>' --dry-run`, then for real. Target profile is display-named "other".
+   Sets `download.default_directory` + `prompt_for_download=false` — unavoidable, because
+   `onDeterminingFilename` cannot write outside the browser's download root.
+2. `brave://extensions` → Developer mode → Load unpacked → `scripts/dl-router/extension/`.
+3. Options page → paste `dl-route token`, tick **Enable routing in this profile**, *Test connection*.
+4. Backfill only: qBittorrent credentials in `config.toml`, then `plan` → **review the TSV** →
+   `apply --dry-run` → apply.
+
+## Open follow-ups (none blocking, all recorded deliberately)
+
+1. **Structural: the picker `reduce`/`apply` pair generates one bug family repeatedly.** Five
+   findings across five audit rounds were the same shape — `reduce` returns unchanged state while
+   `apply` re-reads the post-state and fires the side effect anyway. Each fix was correct and each
+   left the consequence unguarded one step further out. The real fix is for `apply` to act on the
+   **transition** rather than the post-state. Deliberately not attempted inside a PR already five
+   rounds deep, because that round's own lesson was that mechanism swaps introduce regressions.
+2. **`names_match` gaps** (unchanged since first noticed, fail closed): `my.long.title (1)` vs
+   `my.long.title` — `uniquify_base` reads `title (1)` as an extension; and names within 1–3 chars
+   of `MAX_FILE_NAME=200` can collide or diverge after truncation.
+3. **HTTP 200 with `{ok:false}` is treated as success** by the extension. Unreachable against this
+   sidecar (every refusal maps to 400/404/409/500 with `detail`), but it is an undocumented contract
+   dependency in the swallow-and-learn family.
+4. **`chrome.downloads.search` rejection** would leave a `state.pending` entry leaked, since the
+   sweep timer never arms. Realistically does not reject.
+5. **`Take.mp4` → `Take (12).mp4` over-accept** in `names_match` — irreducible given any uniquify
+   tolerance. Pinned by a test named as a design cost so it is not later mistaken for an oversight.
+
+## Verified vs unverified — be honest about this line
+
+**Verified:** sidecar endpoints over a real socket (auth, `Host` allowlist, non-loopback refusal,
+path traversal against `..`/absolute/NUL/bidi/symlinked source and destination); the matcher against
+the real 25-dir index; the store migration including the crash window; `RLock` behaviour under a
+concurrent scan; every fix pinned by a failing-before test.
+
+**Never exercised:** the extension has **never run in Brave**, and **qBittorrent has never been
+contacted**. Every extension-side behaviour is proven against a mocked `chrome` API only. Unproven
+specifically — that Chrome's own filename sanitiser leaves the name byte-identical to what
+`sanitizeFileName` produced (if it differs, `names_match` fails and *every* correction for that file
+is refused); that `conflictAction: "uniquify"` produces ` (N)` on this build; that `window.close()`
+on a popup is instant (this was masking finding F1); qBittorrent's `hashes=` case sensitivity; and
+the backfill against ~1000 real torrents.
+
+**Not one of the ~35 defects found across five audit rounds was caught by the test suite first.**
+Every one came from structural analysis. Weight a structural sweep over a green suite here.
+
+## First real checks to run
+
+The first actual download in the routed profile, and a `backfill plan` (never `apply`) against the
+live qBittorrent. Those settle what no amount of further auditing can.

--- a/claudedocs/handoff-initiatives-agent-phase1-2026-07-24.md
+++ b/claudedocs/handoff-initiatives-agent-phase1-2026-07-24.md
@@ -1,0 +1,74 @@
+# Handoff — Initiatives Agent, Phase 1 kickoff (build read-only on the OpenClaw+skills stack), 2026-07-24
+
+**Next session's job:** rebuild the initiatives **assistant** (read-only Q&A + routing) as a **model-driven
+OpenClaw agent with skills** — the stack we researched — replacing the brittle hand-rolled regex classifier
+that shipped in Phase 1. Read-only, so none of the write/dispatch security work is needed yet.
+
+## Why this pivot (read before building)
+Phase 1 shipped a scripted assistant (`scripts/initiatives/assistant.py`) with a **regex intent-classifier +
+keyword-marker tools + a synthesis prompt**. It is **brittle** — three real failures found via the audit log
+in one sitting, all the same root cause (regex can't understand language):
+1. `blocked_on_me` matched the marker `"for zach to"` against an initiative's *purpose* ("cards **for Zach to**
+   adjudicate") → false positive (fixed PR #161 by narrowing fields/markers — a patch).
+2. Compound question "whats stalled **and** waiting" → single-intent classifier collapsed to `stalled` only,
+   **missed** the waiting item (spend-analytics), and phrased "None are stalled and waiting" (over-claimed).
+3. Confabulated reasons when a marker hit but no real reason existed.
+Patching the classifier is whack-a-mole. **The determinism is in the wrong place:** we made *intent
+understanding* deterministic (regex) and left the model to only phrase — backwards. The fix is to **flip it**:
+the model does intent-understanding + tool-selection (what LLMs are reliably good at), the **tools stay
+deterministic** (grounded store/route queries), and **sources are computed from tool output** (no fabricated
+facts). Worst case of a wrong tool pick = a less-relevant but still-grounded answer, never a made-up fact —
+a graceful, improvable failure vs the regex's hard wall.
+
+And we already **researched the right stack** for exactly this (see `claudedocs/initiatives-agent-proposal-2026-07-24.md`
++ the red-team `…-eval-2026-07-24.md`): an **OpenClaw agent** deployed by **kubeclaw**, tools exposed as
+**skills** (the `civit/support-agent-*` `SKILL.md` + `query.mjs` subprocess pattern — MCP is off on the pinned
+openclaw 2026.6.x), chat via the **support-agent/clawgate operator-chat**. The eval re-scoped Phase 1 to a
+"scripted/**skills** assistant" — we took the *scripted* fork; the *skills* fork is the non-brittle one.
+
+## Phase 1 plan (read-only OpenClaw + skills agent)
+- **Retire** the regex intent-classifier in `assistant.py`. **REUSE** its deterministic tools — `query_initiatives`
+  (store reads: blocked-on-me/active/slowing/stalled/status-of/live-sessions/by-repo), `route_signal`
+  (`route.rank_matches`), `read_handoff` (guarded doc read) — as **skills** (`SKILL.md` + a query script). The
+  keyword fixes from #161 carry over as skill *internals*; only the routing layer is replaced.
+- **Model-driven tool-calling:** the OpenClaw agent reads the question, calls the skill tools (multiple for
+  compound questions), and synthesizes from the grounded results. It must **report which tools it ran** (no
+  over-claiming). Keep sources = tool output (grounded).
+- **Runtime:** an OpenClaw devpod via **kubeclaw**. The eval deferred the devpod for *write/dispatch* reasons
+  (voluntary gate, cross-cluster mutation) — **none apply to read-only** (no write tools = nothing to gate;
+  blast radius = a wrong answer). This read-only agent is the **foundation** for the full agent (Phase 2 just
+  adds write/dispatch skills behind a STRUCTURAL server-side gate + a least-privilege DB role) — not a throwaway.
+- **Store reach:** use the `_db.py` **direct in-cluster mode** shipped in #156 (`MAILBOX_PG_HOST=mailbox-postgres.mailbox.svc`
+  …) so the in-cluster agent connects directly — no per-query kubectl port-forward. Give the agent a
+  **read-only/least-privilege DB role** (it only SELECTs `initiatives.*` + appends `assistant_log`).
+- **Chat:** keep the viewer's `/api/ask` + sidebar pane as the surface, now backed by the agent (or adapt the
+  support-agent operator-chat). Keep the **`initiatives.assistant_log`** audit table — it's what caught every bug.
+- **Model:** OPEN DECISION — the local `vllm-recap` Qwen2.5-7B may be too weak for reliable tool-selection;
+  candidates: deepseek (Zach's dispatch default, [[task-dispatch-default-deepseek]]) or a larger local model.
+  **Validate tool-calling reliability early** (does it pick the right tools on 8-10 varied questions incl.
+  compound?) — if the 7B under-performs, switch the model, NOT back to regex.
+
+## Reuse / retire / defer
+- REUSE: `assistant.py` tools → skills; the store (`initiatives.latest`/`recaps`/`assistant_log`); `route.py`;
+  the viewer chat pane + `/api/ask`; `_db.py` direct-mode (#156); the support-agent skills pattern; clawgate/kubeclaw.
+- RETIRE: the regex `classify_intent` / `_PATTERNS` / marker-scan routing.
+- DEFER (Phase 2+): write/dispatch tools — behind a **structural server-side write-gate** (NOT the voluntary
+  `agent_checkpoint`, per the eval) + least-privilege DB role. Dispatch (clawgate `/api/tasks`, title as
+  `directory`) is structurally safe (card only). Cross-cluster/shared-`mailbox`-DB blast radius: scoped role.
+
+## Current live state (all workbench-only, serverMode-gated)
+- Store: `initiatives` schema in the homelab **mailbox** Postgres — `snapshots`, `initiative_snapshot`,
+  views `latest`/`current` (DROP+CREATE on a column add + marker bump), `recaps` (identity/status), `assistant_log`.
+- Sync: `initiatives-sync.timer` (15min) → `run-sync.sh` (sops-decrypts CH reader creds) → `sync.py` →
+  `initiative-scan.py --json`. Recaps generated here via `vllm-recap` (homelab Qwen2.5-7B-AWQ, ns `promptver`,
+  svc `vllm-recap`, served model `recap`; joycaption+comfyui scaled to 0 in git to free the shared 5080).
+- Viewer: `initiatives-viewer.service` at **http://192.168.50.250:8899** (workbench eth1 — NOT .94, a homelab
+  node). Flat/grouped/**recency(default, rolling)** views + live-unmatched sessions + recaps + `/api/ask` chat.
+- Operate via the (to-be-written) **`initiatives` skill**. Full arc: `handoff-initiatives-consolidation-2026-07-22.md`.
+
+## First steps next session
+1. Read the proposal + eval + this doc + the `initiatives` skill. 2. Confirm the model (validate 7B tool-calling
+   or pick deepseek/bigger). 3. Turn the `assistant.py` tools into skills. 4. Stand up the read-only OpenClaw
+   devpod via kubeclaw with the least-privilege DB role + `_db.py` direct-mode. 5. Wire the agent to the
+   `/api/ask` chat. 6. Verify with the same audit-log loop: re-ask "whats stalled and waiting" → expects BOTH
+   the stalled set AND spend-analytics (waiting), correctly. Then build→verify→ship per standing autonomy.

--- a/claudedocs/handoff-initiatives-agent-phase1-shipped-2026-07-25.md
+++ b/claudedocs/handoff-initiatives-agent-phase1-shipped-2026-07-25.md
@@ -1,0 +1,75 @@
+# Handoff — Initiatives Agent Phase 1 SHIPPED (model-driven OpenClaw agent + skills), 2026-07-25
+
+**Supersedes** `handoff-initiatives-agent-phase1-2026-07-24.md` (the kickoff). Phase 1 is **built,
+verified live, and shipped**: the read-only initiatives assistant is now a **model-driven OpenClaw
+devpod agent** — the model does intent-understanding + tool-selection, deterministic skills query the
+store, sources are computed from tool output. The brittle regex intent-classifier is **retired from the
+routing role** (kept only as a graceful fallback). Operate it via the **`initiatives` skill** (updated).
+
+## What shipped (all verified against live state)
+
+1. **Model decision (the gate).** Validated the local `vllm-recap` **Qwen2.5-7B-Instruct-AWQ** as a
+   single-shot JSON **tool-selection planner**: 13/15 full-pass, **compound 4/4**, stable over 3 runs
+   (harness: `scratchpad/toolsel_eval.py`). It correctly returns BOTH tools for "whats stalled and
+   waiting". BUT the endpoint has **no `--enable-auto-tool-choice`**, and a 7B can't drive a full
+   OpenClaw agentic loop → the devpod's backing model is **DeepSeek V4 Pro via OpenRouter** (Zach's
+   dispatch default, [[task-dispatch-default-deepseek]]). The 7B finding stays relevant if we ever
+   want a cheaper local planner step.
+
+2. **Skills (devrc `scripts/initiatives/skills/`).** `query.py <tool> [--target]` → grounded JSON,
+   REUSING `assistant.py`'s pure `run_tool`/`build_facts`/`sources_of` verbatim (tools KEPT, regex
+   routing RETIRED). `initiatives.SKILL.md` = the agent's tool-selection brain (compound-decomposition,
+   anti-confabulation, read-only). Store reached via `_db.py` **direct in-cluster mode (#156)** — no
+   port-forward in-pod. Tests: `test_query.py` (17) + `test_agent_client.py` (32) → **suite 333 pass**.
+
+3. **Least-privilege DB role.** `initiatives_agent` on the homelab **mailbox** Postgres — **SELECT-only
+   on `initiatives.*`**; INSERT + the `mail` schema are denied (verified). DSN in the sops secret as
+   `MAILBOX_PG_DSN`. NOTE: SELECT-only can't run `assistant.py`'s log self-heal (`CREATE TABLE IF NOT
+   EXISTS` needs schema CREATE even when the table exists) → the **audit-log write stays viewer-side**.
+
+4. **Devpod (homelab `devpod-initiatives`).** kubeclaw HelmRelease at
+   `homelab-talos clusters/homelab/apps/agent-pods/initiatives/` (modeled on `task-drafter`). Clones
+   PUBLIC devrc over HTTPS; `extraInitCommands` apt-installs `python3-psycopg2/requests` and **PINS the
+   agent identity** (removes OpenClaw's onboarding `BOOTSTRAP.md`; without this, first-person "what am I
+   working on" made the agent talk about ITSELF). **Namespace read-only RBAC only** (no cluster RBAC —
+   tighter than task-drafter); no trigger cron. Applied SURGICALLY (agent-pods flux Kustomization is
+   `suspend=true`); live secret via kubectl from local plaintext (workbench lacks the homelab age
+   private key), git `.enc.yaml` is the GitOps record.
+
+5. **Viewer `/api/ask` → agent.** `agent_client.py` proxies to the gateway (kubectl port-forward, token
+   `sha256("gw-"+HOOKS_TOKEN)` read from the in-cluster secret), **deterministic whole-token slug
+   sources** (fixed a substring false-positive found in review), reuse of the `assistant_log` write
+   (`intent=agent`). `viewer.build_asker` = agent-first with **graceful fallback to the regex
+   assistant** if the devpod is down. Env on the viewer unit (`nix/home.nix`): `INITIATIVES_AGENT_ENABLED`
+   + `AGENT_*` (+ `RECAP_*` kept as the fallback model). Shipped via `home-manager switch`.
+
+6. **Verification (the audit-log loop).** `POST /api/ask "whats stalled and waiting on me"` →
+   `intent=agent`, runs BOTH `stalled`+`blocked_on_me`, grounded ("nothing stalled" + spend-analytics
+   waiting), audit row id 7 nsrc=6. Compare the OLD regex row: `intent=stalled` (collapsed the compound),
+   **0 sources** (missed the waiting item). **The exact bug is fixed.** First-person "what am I working
+   on" → 12 grounded active initiatives (post identity-pin).
+
+## Live state
+- Agent: HelmRelease `initiatives-agent` (flux-system) → pod `initiatives-devpod-*` in
+  `devpod-initiatives`, chart kubeclaw@0.5.2, image `openclaw-image:2026.6.1`, model
+  `openrouter/deepseek/deepseek-v4-pro`, gateway `svc/initiatives-devpod:18789`. Tracks devrc `main`.
+- Viewer: `http://192.168.50.250:8899` (workbench), agent-enabled, regex fallback.
+- Merged: devrc `main` (query.py/SKILL.md/agent_client/viewer/nix); homelab-talos `trunk` (`71c9dbb2`).
+
+## ⚠ Loose ends / caveats
+- **Concurrent homelab-talos work** (another session: remix + vllm-joycaption + many `claudedocs/`) was
+  UNCOMMITTED and got briefly swept into my first commit; unwound cleanly (my commit pushed via a
+  throwaway worktree, their work untouched in the working tree + backed up in `git stash@{0}`). That
+  session still needs to commit/reconcile its work with the remix advance on trunk. **Do not drop
+  `stash@{0}` until confirmed.**
+- The devpod pod's local git branch may read as the old feature name (PVC-persisted clone); it PULLS
+  `origin main` via autoPull, so content tracks main. A clean `git checkout -B main origin/main` in-pod
+  was run once; a PVC wipe re-clones `main` fresh.
+- Each `/api/ask` spawns a kubectl port-forward + a full agentic loop (~13-23s). Fine for a sidebar; if
+  it feels slow, a persistent gateway route (nebula/NodePort via `AGENT_BASE_URL`) skips the port-forward.
+
+## Phase 2 (deferred — needs a STRUCTURAL gate, per the eval)
+Write/dispatch tools behind a **server-side write-gate** (NOT the voluntary `agent_checkpoint`) +
+the least-priv role widened only as needed. Dispatch (clawgate `POST /api/tasks`, `directory` field —
+NOT `title`) is structurally safe (card only). Reuse the SAME skills; the read-only devpod is the
+foundation, not a throwaway. See `initiatives-agent-proposal-eval-2026-07-24.md` §5.

--- a/claudedocs/handoff-initiatives-consolidation-2026-07-22.md
+++ b/claudedocs/handoff-initiatives-consolidation-2026-07-22.md
@@ -1,0 +1,233 @@
+# Handoff — initiatives consolidation (live store for a viewer + router), 2026-07-22
+
+**Goal:** consolidate the on-demand `initiative-scan.py` output into a durable, queryable
+Postgres store so apps can build on live initiatives data. First two use cases: a **live
+viewer** and a **router** (route an incoming signal — a new task / repo-cos proposal /
+mail-action — to the right existing initiative). Router is the reason it's Postgres and not
+a JSON cache: it joins against `mail_actions` / clawgate tasks, which already live in the
+homelab `mailbox` Postgres.
+
+## Status — ALL THREE PHASES + BOTH WIRINGS SHIPPED & LIVE-VERIFIED (2026-07-22)
+
+**store → router → viewer, all reading one consolidated Postgres dataset. Fully live.**
+
+- **Initiatives agent — Phase 1 (PR #158, merged, deployed, live-verified) + gaps (PR #156).** Researched
+  containerized-agent best practice + Zach's claw stack (kubeclaw/openclaw-image/clankup/support-agent/
+  clawgate/crabbox) → proposal (`claudedocs/initiatives-agent-proposal-2026-07-24.md`) → independent
+  **red-team** (`…-eval-2026-07-24.md`, verdict *sound-with-caveats*): the proposed write-gate was
+  **voluntary** (prompt-injection-defeatable) + cross-cluster shared-DB blast radius under-scoped + the
+  devpod over-built for read-only. **Re-scoped Phase 1 = a READ-ONLY assistant** (`scripts/initiatives/
+  assistant.py`): deterministic regex intent-classifier (11 intents) over the store + `route()`, the local
+  `vllm-recap` model only phrases answers, sources computed from tool output (not the model). Sidebar chat
+  = `POST /api/ask` + a collapsible pane in the viewer. **NO write/dispatch/devpod/clawgate/MCP** — worst
+  prompt-injection case is a skewed answer, never an action. Live: "what's blocked on me" → the truly-blocked
+  initiatives; routing works. **crabbox** = an openclaw execution *control plane* (leases box/rsync/run/
+  release), NOT an isolation tech → wrong shape for a persistent assistant (rejected as runtime; possible
+  future runner for dispatched CI/verify jobs). **Gaps fixed (#156):** clawgate task `title` was a CLIENT
+  bug (clawgate `/api/tasks` has no `title` field; title renders from `directory`) → send it as `directory`;
+  `_db.py` gained an additive opt-in **in-cluster direct-DB mode** (`MAILBOX_PG_HOST`/`MAILBOX_PG_DIRECT`) for
+  a future in-cluster agent. **DEFERRED to Phase 2+ (needs its safety story first):** the openclaw-devpod
+  runtime, dispatch (via clawgate `/api/tasks` — structurally safe: card only), and STATE MUTATION — which
+  must have a **structural server-side write-gate** (not the voluntary `agent_checkpoint`) + a least-privilege
+  scoped DB role before it ships.
+
+- **Recap identity/status split (PR #154, merged, deployed, live-verified).** The single recap
+  conflated *what a project is* with *what was just done in it* — `remix-session` (a video-remix
+  platform) recapped as "focusing on cloudflare reliance" (a recent tangent) because it over-weighted
+  `recent_messages` and barely used the handoff. Fix (user-chosen: feed the handoff, stay LOCAL, split,
+  no journal): recap is now **two independently-cached fields** — **`identity`** ("what it is",
+  generated from the handoff's durable head via `identity_blob` which stops at the first volatile
+  heading; cache-keyed on the HANDOFF so it doesn't churn as prompts change) + **`status`** ("current",
+  from recent activity; cache-keyed on activity). Two separate `vllm-recap` calls, additive columns on
+  the standalone `initiatives.recaps` table (identity/identity_hash/status/status_hash — NO view
+  migration), viewer renders identity primary (fallback identity→recap→summary) + status secondary.
+  Live: remix identity = "explore, stash, publish… age-gating + moderation" (cloudflare GONE from
+  identity). ⚠ **Known residual:** `status` still inherits the thin-context/boilerplate-prompt vagueness
+  (now on the secondary line, lower harm) — fix if needed via the same substantive-prompt filter as the
+  card face. dspy-eval/ (#148, report-only) still imports the retired single-recap API — harmless (not
+  run by run-tests.sh), left as the point-in-time eval record.
+
+- **Coverage fix (PRs #150 viewer + #151 matcher, merged, deployed, live-verified).** A reconciliation of
+  the viewer's live-tmux overlay against RAW tmux (44 live claude panes) found the overlay was **precise
+  (0 phantoms) but low-recall — showed 7 of ~44 threads**. Root: the viewer COMPUTED the `unmatched` live
+  panes (`match_tmux_to_initiatives` returns them) but **discarded** the list; ~90% of live work is in the
+  `datapacket-talos` client monorepo with no handoff → structurally uncoverable. Fixes: (#150) the viewer
+  now renders a "**Live sessions — not tied to an initiative**" section (collapsible, by repo) — board went
+  from 7 → **40** visible live threads (7 tagged + 33 unmatched); + multi-pane `live_task` shows all panes.
+  (#151) date-only-slug **title-fingerprint fallback** (`2026-07-21` now matches its comfyui panes;
+  strictly additive, `is_real_slug` rank guard so a fallback can't steal a pane). **Deliberately NOT fixed
+  (precision > recall):** the remix sibling-dilution tiebreak was built, proven to create a `civitai`-token
+  phantom (structurally indistinguishable from the good case without a RULES-forbidden keyword stoplist),
+  and REVERTED with a regression test; cross-repo `civitai-cli` mis-filing deferred as a data-modeling
+  issue (handoff filed under datapacket-talos, work in civitai-manager). **Strategic takeaway:** the durable
+  board is handoff-anchored by design; the live-sessions catch-all is the right answer to "show everything
+  running" — do NOT model the ephemeral client firehose as initiatives.
+
+- **Momentum-accuracy fix (PR #149, merged, deployed, live-verified).** `last_touch`/momentum was
+  driven by the transcript **file mtime**, which Claude Code clobbers with in-place session-file
+  rewrites (title/mode metadata) → 18-day-idle sessions read as "active ~47m ago" (root-caused via
+  `root-cause-analyst`; 3 confirmed false-actives, 14/15 "active" were mtime-driven). Fix: time
+  `last_session` from the **last genuine USER-turn timestamp** (`_read_session_turns` already parses
+  `turns[].ts`; threaded through `collect_session_records`→`build_report`→`attribute_sessions`),
+  mtime only as a rare fallback — mirrors the `doc_touch_epoch` precedent. Live: clawgate-chat-polish
+  + sysredis-buffer + dp-500-sweep correctly aged out of the 4-day window (real last-touch 9–18d);
+  snapshot dropped 24→19 rows, active count now truthful. **DSPy recap eval (PR #148, merged,
+  report-only): measured DSPy vs the hand prompt → within-noise (+0.012 ±0.011); kept the prompt.**
+
+- **Phase B — LLM recap (SHIPPED, deployed, live-verified).** Cards now lead with a synthesized
+  plain-language recap of what each initiative is + where it stands.
+  - **B1 — homelab model** (homelab-infra PR #193): a vLLM serving **Qwen2.5-7B-Instruct-AWQ** as
+    `svc/vllm-recap:8000` (ns `promptver`, served model `recap`), patterned on `vllm-joycaption`.
+    ⚠ The GPU is a SINGLE shared 5080 (16.3GB, time-sliced ×4) — 7B not 14B, and **`vllm-joycaption`
+    + `comfyui` were scaled to `replicas: 0` in git** to free VRAM (both idle; joycaption's manifest
+    already documents this scale-0/1 pattern). If you need them back for a pass, scale up — but VRAM
+    then contends with recap. Endpoint verified live (real completion).
+  - **B2 — generator/store/viewer** (devrc PR #146 + the config-wire commit): `scripts/initiatives/recap.py`
+    generates a recap per initiative **in the sync**, **best-effort** (model down → sync/store unaffected,
+    card falls back to `summary`), **cached + regenerated only on input-hash change**, stored in a
+    standalone `initiatives.recaps` table (NO view migration — markers stay v3). **Anti-confabulation**
+    enforced structurally (model sees only the context JSON). Viewer renders `recap || summary` as the
+    primary line; **the `N commits · N merged · N sess · N ev` stat strip is removed** (per Zach). Config
+    lives in the `initiatives-sync` unit env (`INITIATIVES_RECAP_ENABLED=1`, `RECAP_NAMESPACE=promptver`,
+    `RECAP_SERVICE=svc/vllm-recap`, `RECAP_MODEL=recap`). Live: 24/24 recaps generated (snapshot #40,
+    `recap 24 new/0 cached`), legible + status-aware (e.g. spend-analytics → "awaiting Zach's monthly
+    Cloudflare cost figure"), anti-confab held. Weak recaps only where input context is thin (fall back
+    to honest, not wrong). The 15-min sync regenerates only changed initiatives.
+
+- **PR #143** (merged, deployed, live-verified) — **card legibility Phase A (deterministic, no LLM)**:
+  "bring the conversation onto the card". Adds per initiative — **recent sent messages** (user's own
+  prompts, read from `~/.claude/projects` transcripts, attributed via the scan's existing genesis +
+  branch/cwd session matching; new `recent_messages jsonb` col), **recent commit subjects** (new
+  `recent_commits jsonb` col), and a render-time **live-session task** line (the matched tmux pane
+  title). Card face shows summary + latest prompt + live task; expand adds the full message/commit
+  lists. Migration v2→**v3** (marker bump → DROP+CREATE views; replayed on a throwaway PG 18.4 first,
+  then applied live — snapshot #31, 20/24 initiatives now carry messages). Live cards are now genuinely
+  legible (real prompts like "relabel the node as web", "fix bad-eyes then launch round 3").
+  **Precision fix — PR #145** (merged, deployed, live-verified): message attribution is now
+  **single-best-credit** (each session → the most-specific initiative via `best_matching_initiative`'s
+  ranking, factored into `_specificity_key`; `sess:` counts unchanged) + the card FACE shows the most
+  recent **substantive** prompt (viewer-side `_is_trivial_prompt`/`pick_face_message`, skips
+  dispatch/proceed/short boilerplate; expand keeps the full verbatim list). Verified live: the genuine
+  multi-credit dup is GONE (the Comfy-Cloud resume msg now on ONE card, not 3).
+  ⚠ **Residual (honest, NOT the bug):** Zach's **session-ritual prompts** ("give me the kickoff message…",
+  "review work done this session…") are genuinely typed across many sessions, so they legitimately appear
+  on several cards (each single-credited to its own initiative) and can occupy a card FACE — the
+  length/stopword filter can't catch them without brittle keyword-whacking (against RULES). **Next clean
+  deterministic lever:** pick the face prompt by **token-overlap with the initiative's own slug/title**
+  (structural, reuses the matcher) so the face prefers the on-topic prompt over a ritual one. If that's
+  still insufficient, that's the **Phase B trigger**.
+  **Phase B (LLM recap) NOT built** — homelab-served model, cached/regen-on-change, deterministic-first
+  per Zach; the ritual-prompt residual above is the concrete evidence that would justify standing it up.
+
+- **PR #142** (merged, deployed, live-verified) — **viewer v2 feedback round**: (1) **flat view default**
+  + flat/grouped toggle (localStorage) + client-side search, ordered most-recently-active, repo label
+  per card; (2) **realtime**: sync cadence 1h→**15min**, a debounced/single-flight **`POST /refresh`**
+  button (runs `run-sync.sh` as a subprocess, killpg on timeout, 60s debounce, scrubbed stderr; LAN-open
+  + rate-limited by choice — no auth), honest footer (`live ● realtime · store synced Xm ago`); (3)
+  **legible cards**: a deterministic **`summary`** field parsed from each handoff (new scan→store column,
+  no LLM) + **PR titles** + **click-to-expand** that live-reads the handoff doc (full next-steps +
+  open-investigations; realpath-allowlisted under `<repo>/claudedocs/`, 512KB cap). ⚠ **Migration gotcha
+  (audit-caught, fixed):** the new `summary` column reorders the `latest`/`current` views' columns, which
+  `CREATE OR REPLACE VIEW` REJECTS (`cannot change name of view column …`) → froze the whole v1 store on
+  deploy. Fixed to **DROP+CREATE on a version-marker bump** (`_ensure_view`); validated by replaying the
+  real v1→v2 migration on a throwaway PG 18.4 (fixtures can't — they only assert SQL strings). Live:
+  summary populated, refresh runs a real sync + debounces, detail endpoint reads handoffs, traversal
+  guard returns 404. Minor open polish: `parse_summary` sometimes keeps a leading `> ` blockquote marker.
+
+- **PR #140** (merged, deployed) — **Phase 3, the live web viewer**: `scripts/initiatives/viewer.py`,
+  a stdlib-`http.server` service. Grouped by repo, momentum badges, next-step, PRs, **live-tmux
+  overlay at render time** (reuses the scan's tmux funcs), auto-refresh 30s, gruvbox, LAN-only.
+  Workbench `systemd --user` service (`initiatives-viewer.service`, serverMode-gated). Adds an
+  **`initiatives.latest` view** (rows from `max(snapshot_id)`) to sync.py's DDL to kill the ghost
+  problem — the viewer reads `latest` (inline-fallback before the first post-deploy sync). Router
+  keeps reading `current` (ghosts are desirable there). **LIVE at http://192.168.50.250:8899/**
+  (service active; `/healthz`→ok; renders real data + live tmux tags; `latest`=23==snapshot#12,
+  `current`=25 so 2 ghosts correctly excluded).
+- **PR #141** (merged, deployed) — **viewer bind-IP fix**. #140 hardcoded
+  `INITIATIVES_VIEWER_HOST=192.168.50.94` → crash-loop `OSError: Cannot assign requested address`.
+  **192.168.50.94 is a HOMELAB node (kube-apiserver/NodePorts/ClickHouse), NOT the workbench** —
+  the workbench's own LAN IP is **192.168.50.250 (eth1)**. Caught on live deploy-verify (the
+  pre-merge worktree smoke test passed only on 127.0.0.1). See [[workbench-lan-ip]].
+- **PR #138** (merged) — **router → repo-cos**: tags each synthesized proposal with its related
+  initiative in the digest ("↳ relates to: <slug>"), surface-only, best-effort (store outage →
+  digest byte-identical). `scripts/repo-cos/routing.py`.
+- **PR #139** (merged, ALTER applied) — **router → mail-actions**: tags each extracted action with
+  its related initiative. **Added an additive/nullable `related_initiative text` column to the live
+  `mail_actions` table** (idempotent, same pattern as `thread_key`; verified PRESENT in prod).
+  Surfaced in `extract.py list`, the clawgate card `source_ref`, and a `routed` run-counter.
+  Best-effort (router/DB failure → action queued untagged). `MailDB.fetch_current_initiatives()`
+  reads `initiatives.current` on the already-open connection (no 2nd port-forward).
+
+### Phase 1 (sync) + Phase 2 (router) — SHIPPED earlier same day
+
+- **PR #137** (merged, `e2ac53e`) — **Phase 2, the router**: `scripts/initiatives/route.py`.
+  `route(signal_text, repo=None, limit=5)` ranks a free-text signal (task title / repo-cos
+  proposal / mail subject) against `initiatives.current`, reusing the scan's `best_title_match`
+  gate verbatim (lazy importlib load — no `chquery` side-effect until a match runs). Returns a
+  score + `confident` flag; `classify()` → "confident match: <slug>" vs "likely new work".
+  Read-only, **not wired to any caller** (Zach's pick — ship the primitive, eyeball via CLI
+  first). 18 tests. LIMITATION: word-equality, no stemming (`polish`≠`polishing`) — inherited
+  from the scan; callers feeding raw prose should expect misses on morphological variants.
+
+### Phase 1 (below) — SHIPPED + ENABLED + live-verified
+
+- **PR #135** (merged, `209b59f`) — the sync: `scripts/initiatives/sync.py` shells out to
+  `initiative-scan.py --days N --json` (no `--tmux`), transforms → rows, writes to a new
+  `initiatives` schema in the `mailbox` Postgres via `mail-actions/_db.py`'s kubectl
+  port-forward. Self-migrating idempotent DDL under a `pg_advisory_xact_lock`. Workbench-only
+  `systemd --user` timer, hourly.
+- **PR #136** (merged, `2dfb870`) — provisions the ClickHouse **reader** creds into the unit
+  at runtime (sops decrypt in `run-sync.sh`, host age key, no plaintext at rest, degrades to
+  telemetry-off if key/repo/sops absent) and flipped `enableInitiativesSync = true`.
+- **Deployed** to workbench (`home-manager switch`); timer armed. Verified live: unit ran via
+  its own cred path → `telemetry-on`, wrote snapshots #2/#3 (both telemetry_available=true,
+  host=workbench). Two near-concurrent runs both succeeded → advisory-lock DDL race fix holds.
+- **DSN role has `CREATE SCHEMA`** (the audit's top first-run risk) — confirmed by the live write.
+
+### Schema (`initiatives` schema in the `mailbox` DB)
+- `snapshots` — one row per run (`id, captured_at, host, days_window, telemetry_available`).
+- `initiative_snapshot` — one row per initiative per run (slug/repo/title/momentum/last_touch/
+  commits/merged_prs/open_prs jsonb/session_count/telem_*/current_doc/open_investigations jsonb/
+  docs jsonb). Indexes: `(repo,slug,snapshot_id)`, `(snapshot_id)`, `snapshots(captured_at)`.
+  FK `ON DELETE CASCADE`. 90-day retention prune each run.
+- `current` view — `DISTINCT ON (repo,slug)` newest across ALL history; guarded re-create via
+  a `COMMENT ON VIEW … 'initiatives-sync view v1'` version marker (bump `VIEW_VERSION` in
+  sync.py to force a recreate after a hand-edit).
+
+### Operate
+- By hand: `KUBECONFIG=$KC_HOMELAB systemctl --user start initiatives-sync.service` (or run
+  `scripts/initiatives/sync.py --dry-run` under `nix-shell -p "python3.withPackages(p:[p.psycopg2 p.requests])"`).
+- Check it's telemetry-on: `journalctl --user -u initiatives-sync.service | grep -i telemetry`
+  → expect "reader creds provisioned — telemetry-on" and "… telemetry on" (NOT OFF).
+- Read-back: reuse `mail-actions/_db.py` and query `initiatives.current` / `initiatives.snapshots`.
+
+## Open investigations
+
+### `current` view accumulates aged-out ("ghost") initiatives
+`current` is newest-per-`(repo,slug)` across *all* snapshots, so an initiative that drops out
+of the scan's N-day window still appears with stale last-seen state until the 90-day retention
+prunes it (live: `current`=24 while the latest snapshot had 22). Fine for the router (matching
+against recently-dormant initiatives is desirable); wrong for a live viewer (shows ghosts).
+
+## Next steps (the platform is built; these are remaining reach)
+1. **Dual-host merge (deferred).** Phase 1 is workbench-only. Do NOT naively sum a laptop push:
+   the rollup already embeds central-ClickHouse telemetry, so summing double-counts `ev`. Merge
+   by `max(last_touch)` per `(repo,slug)`, telemetry from one host only.
+2. **Viewer hardening (optional).** Bind is a hardcoded LAN IP (`192.168.50.250`); if eth1's IP
+   ever changes, `Restart=on-failure` crash-loops every 10s. Consider binding `0.0.0.0` (LAN+nebula,
+   no public iface on this host) or a fail-soft fallback to `127.0.0.1`. Also: public exposure via
+   the homelab gateway is a deliberate un-taken choice (internal work data).
+3. **Matcher limitation.** Word-equality, no stemming (`polish`≠`polishing`) — inherited from the
+   scan. Both wirings feed it prose (proposal text / mail subject) so expect silent misses on
+   morphological variants. If misses matter, add light stemming to `text_tokens` (touches the scan
+   + its tests — keep behavior green).
+
+## Notes / gotchas
+- The transform is a pure function (`report_to_rows`) separate from I/O — unit-tested with
+  fixtures (`scripts/initiatives/tests/test_sync.py`), no live infra. Registered in
+  `scripts/run-tests.sh`.
+- `_db.py` is loaded by **explicit importlib path** (NOT via `sys.path`) — its sibling `llm.py`
+  shadows repo-cos's; do not add `mail-actions/` to `sys.path`. If Phase 2 grows more shared DB
+  helpers, promote the port-forward/DSN plumbing into a proper shared module.
+- CH reader endpoint `http://192.168.50.94:30123` is workbench-LAN-only → a laptop copy of the
+  unit degrades to telemetry-off (intended).

--- a/claudedocs/handoff-initiatives-nextstep-dispatch-2026-07-26.md
+++ b/claudedocs/handoff-initiatives-nextstep-dispatch-2026-07-26.md
@@ -1,0 +1,125 @@
+# Handoff — Initiatives: next-step recommendation + dispatch (Phase 2a), 2026-07-26
+
+**Next session's focus:** integrate a **logical next-step recommendation + one-tap dispatch** into the
+initiatives subsystem — the read→act loop the whole thing points at. Everything below the "Next
+session" heading is the plan; above it is the state you're resuming from. Operate via the **`initiatives`**
++ **`clawgate`** skills (both updated this session).
+
+---
+
+## What shipped this session (the arc)
+
+1. **Initiatives agent Phase 1 — read-only, model-driven.** Retired the brittle regex intent-classifier;
+   `/api/ask` is now a **model-driven OpenClaw devpod** (`devpod-initiatives`, `openclaw/initiatives`,
+   **DeepSeek V4 Pro via OpenRouter**). The MODEL picks which deterministic skill-tool(s) to run
+   (`scripts/initiatives/skills/query.py`, reusing assistant.py's pure `run_tool`/`build_facts`/
+   `sources_of`); store via `_db.py` direct in-cluster mode + a **least-priv `initiatives_agent`
+   SELECT-only PG role**. Viewer `/api/ask` proxies to the gateway (`agent_client.py`), **streams** the
+   answer (`/api/ask/stream`, SSE) and **renders markdown**, falling back to the deterministic regex
+   assistant when the devpod is down. Audit-logged (`intent=agent`).
+2. **Session/activity-first discovery** (the big scan rework). Replaced `claudedocs/handoff-*.md`-glob
+   discovery with `(repo, topic)` groups mined from Claude sessions + telemetry — topic = the transcript
+   **`ai-title`** — behind a noise floor; handoff docs of ANY filename anchor by title. `source=doc|both|
+   session`; session-only → `undocumented=true` → viewer **"Emerging" lane** (collapsed). Store **v4**.
+   Fixed civitai-manager ("Pool 6") being invisible. 0 doc-slug churn.
+3. **Hardening**, now via **kubeclaw 0.7.x chart VALUES** (postRenderers retired): egress default-deny
+   CiliumNetworkPolicy, `securityContext` (cap-drop:[ALL] — safe because deps are baked into the
+   `2026.6.11-py` image), `tls.verify:true`, `tools.web.search.enabled:false`. OpenClaw **2026.6.11**
+   adopted (works because web-search-off avoids the doctor's npm plugin-fetch hang under locked egress).
+4. **kubeclaw 0.6.0 → 0.7.0 → 0.7.1**: 0.6.0 = native `mcp.servers` key + `update.checkOnStart` (compat
+   w/ latest OpenClaw); 0.7.0 = hardening as first-class values (securityContext/TLS/NetworkPolicy);
+   0.7.1 = netpol fail-loud-on-empty-allowlist guard + full GitHub host doc. All audited.
+5. **openclaw-image rebuild fixed** (PR #3): `--legacy-peer-deps` on the nested matrix-bot-sdk install
+   (npm arborist `edgesOut` bug on node:22-slim's npm 10.9.8) — the base builds from source again.
+6. **clawgate 0.7.69**: re-synced its vendored kubeclaw chart to 0.7.0 + rebuilt/redeployed.
+7. **task-drafter hardened** (fleet rollout start): egress CNP + securityContext + tls.verify via 0.7.1
+   values; NO cap-drop (non-baked 2026.6.1 image); web-search off; validated end-to-end (a real ticket
+   drafted under the locked egress).
+
+## Current live state (concrete)
+- **Initiatives agent:** `devpod-initiatives` (homelab), image `2026.6.1-py`→now **`2026.6.11-py`**,
+  DeepSeek V4 Pro, hardened via 0.7.x values, store **v4**, session-first discovery + Emerging lane.
+- **Viewer:** http://192.168.50.250:8899 (workbench eth1, NOT .94). `/api/ask` = agent (stream+markdown),
+  fallback = regex assistant on `vllm-recap` Qwen-7B.
+- **task-drafter:** hardened, image `2026.6.1`, web-search off, netpol `task-drafter-egress`.
+- **kubeclaw:** trunk **0.7.1** (`fbd13aa`). **clawgate:** **0.7.69** (embeds kubeclaw **0.7.0** — 0.7.1
+  re-sync+rebuild PENDING). **openclaw-image** ghcr tags: `2026.6.1`, `2026.6.1-py`, `2026.6.11`,
+  `2026.6.11-py`.
+- Merged to devrc `main` + homelab-infra `trunk` throughout; the initiatives feature is 3 commits +
+  hardening; task-drafter = `34a786b3`.
+
+---
+
+## NEXT SESSION — next-step recommendation + dispatch INTO initiatives (Phase 2a)
+
+**Goal:** each initiative (documented AND emerging) surfaces a **recommended logical next step**, and a
+**one-tap dispatch** that kicks that step off as a clawgate Task. This closes the read→act loop and is the
+natural Phase 2 — but scoped to the STRUCTURALLY-SAFE tiers first (recommend = read-only; dispatch = a
+card a human taps), deferring the write tier behind the structural gate the eval requires.
+
+### The three tiers (ship in order; risk rises with each)
+1. **Recommend next step (READ-ONLY — ship first, no new risk).** For each initiative derive/recommend
+   the next logical step from data already in the store: the handoff doc's `next_step` (parsed), the
+   session's `last-prompt` (current focus), momentum/state, open_investigations — PLUS the agent's
+   synthesis (the OpenClaw agent reads the initiative's context and recommends). Add a
+   `recommend_next_step(initiative)` skill-tool (or an agent synthesis prompt over the existing grounded
+   tools). Especially valuable for **emerging/undocumented** initiatives (no handoff doc → infer the next
+   step from sessions). Surface: a "next step" line per viewer card + an agent-chat answer ("what should I
+   do next on X?"). Pure read — no state change, no new gate.
+2. **Dispatch (STRUCTURALLY SAFE — a card, human-tapped).** One-tap → POST a **clawgate Task**
+   (`POST /api/tasks`, `Authorization: Bearer $CLAWGATE_HOOK_TOKEN`; body `{directory:<repo>, body:<the
+   next-step spec + the initiative's evidence>, model:<deepseek per [[task-dispatch-default-deepseek]]>,
+   repo?, branch?}` — send `directory` NOT `title`, the known contract bug). Creates a durable card;
+   NOTHING runs until Zach taps **Dispatch** (→ clawgate `helm install`s a worker devpod). This is the
+   repo-cos pattern (`scripts/repo-cos/clawgate.py` `post_task` gets the contract right). The eval
+   confirmed the **dispatch tier is structurally safe** (the agent only creates a card), so this needs NO
+   structural write-gate. New capability = the agent/viewer gets a scoped clawgate hook token to POST
+   tasks. Surface: a "Dispatch next step" button per viewer card + a chat action.
+3. **Write (DEFERRED — needs the structural server-side gate).** Updating an initiative's `next_step` /
+   writing-or-updating a handoff doc is the ONLY part that mutates durable state. Per the eval
+   (`claudedocs/initiatives-agent-proposal-eval-2026-07-24.md` §3/§5), this needs a **structural
+   server-side write-gate** (the tool refuses to write until a human approves — NOT the voluntary
+   `agent_checkpoint`, which prompt-injection defeats) + the least-priv role widened narrowly. Do this
+   LAST, only after 1+2 prove the loop.
+
+### Why this order / what's already in place
+- The store has the data; `query.py`/assistant tools + the agent exist; `route.py` already matches
+  signals→initiatives (useful for shaping a dispatchable task). So tier 1 is mostly a synthesis surface;
+  tier 2 is the repo-cos `/api/tasks` wiring + a scoped token. Tiers 1+2 are additive with no new
+  security surface beyond "the agent can POST a task card" (bounded — worst case = spam cards, no
+  execution; the eval verified `/api/auto-approve` is session-gated so a token-holding injected agent
+  can't self-approve/execute).
+- A natural first cut: wire it for the **Emerging lane** — an emerging initiative's biggest value is
+  "here's the next step, dispatch it or promote it to a documented initiative."
+
+### Guardrails to carry
+- Recommendation is grounded (from store/session data + cited sources) — same anti-confabulation
+  discipline as the read-only agent; never invent a next step not supported by the data.
+- Dispatch = card only; keep the human tap.
+- If you add write (tier 3): structural gate, not voluntary.
+
+---
+
+## Open items / loose ends (triage next session)
+- **clawgate embed is at kubeclaw 0.7.0, not 0.7.1** — a re-sync (`make sync-chart`) + clawgate rebuild is
+  pending to give newly-provisioned agents the 0.7.1 netpol fail-guards. Low urgency (existing agents
+  unaffected).
+- **task-drafter web-search** was disabled (its VERIFY never used it — confirmed against its SKILL). If
+  Zach wants it back, allowlist `registry.npmjs.org` + `api.search.brave.com` and re-enable.
+- **Workbench/client devpods NOT hardened** — deliberately left (per-agent egress mapping; `neverdat-sales`
+  are client agents = different risk class). Needs Zach's direction per agent.
+- **Emerging-lane precision** — kept the floor (Zach triages); tunable via `MIN_SESSION_TURNS`. Slug
+  quality is ugly (over-merged token strings) — an audit 🟡; only affects the collapsed lane.
+- **Audit 🟡s on discovery** (non-blocking): add `DISTINCT ON (repo,slug)` to the `latest` view
+  (defense-in-depth vs the scan's no-dup guarantee); batch the `git rev-parse` fork-burst.
+- **homelab-talos main checkout is dirty** — another session left ~42 uncommitted files (remix/joycaption/
+  claudedocs + a STALE `initiatives/helmrelease.yaml` at `2026.6.1-py` that diverges from live/trunk).
+  All my commits were based on `origin/trunk` (matches live); the dirty tree will confuse the next
+  hand-edit — Zach should reconcile/discard it.
+- **Unused ghcr tags** `2026.6.11`/`2026.6.11-py` left pushed (harmless; ready images).
+
+## Verify-before-acting (memory-is-hypothesis)
+Before Phase 2a, re-confirm live: the initiatives agent answers (`curl /api/ask/stream`), the store is v4
++ fresh (sync green), civitai-manager on the board + the Emerging lane populated, clawgate's `POST /api/tasks`
+contract (`directory` not `title`). Standing release autonomy applies (merge+ship without gating, KEEP the
+audit/verify gates) — see [[release-autonomy-standing]].

--- a/claudedocs/handoff-initiatives-nextstep-dispatch-shipped-2026-07-26.md
+++ b/claudedocs/handoff-initiatives-nextstep-dispatch-shipped-2026-07-26.md
@@ -1,0 +1,60 @@
+# Handoff — Initiatives Phase 2a SHIPPED: next-step recommendation + dispatch, 2026-07-26
+
+**Status: shipped, deployed to both hosts, verified end-to-end.** This is the "shipped" successor to
+`handoff-initiatives-nextstep-dispatch-2026-07-26.md` (the plan). Operate via the **`initiatives`** +
+**`clawgate`** skills.
+
+## What shipped (origin/main `835fe0c`, 3 commits)
+1. **Tier 1 — grounded next-step recommendation (READ-ONLY).** New pure `scripts/initiatives/nextstep.py`
+   `recommend_next_step(view) -> {text, basis} | None` under a strict anti-confabulation contract: the text
+   is always a close paraphrase/quote of a REAL view field, never invented; None when nothing supports one.
+   Fixed priority: `next_step` (basis=`handoff`, the parsed documented step) → `open_prs` (`open-pr`) →
+   `open_investigations` (`investigation`) → `face_message` (`focus`, your last prompt) → `status`
+   (`status`) → momentum==stalled (`stalled`) → None. Only `handoff` is a step you wrote down; the rest are
+   labelled INFERRED. Attached in `viewer.build_model` (`recommended_next_step`), rides the view into
+   `/api/initiatives.json`. **Card** renders a distinct `next (suggested) ›` line + basis hint ONLY when
+   `!v.next_step` (documented cards unchanged) — targets the **Emerging** gap. **Chat**: new
+   `recommend_next_step` tool wired through `assistant.py` (INTENTS/run_tool/build_facts/sources_of/
+   render_plain + 3 classify patterns), `skills/query.py` catalog, and `skills/initiatives.SKILL.md` — so
+   "what should I do next on X" works via the OpenClaw agent AND the regex fallback.
+2. **Tier 2 — one-tap dispatch (STRUCTURALLY SAFE, human-tapped).** New `scripts/initiatives/dispatch.py`
+   mirroring `repo-cos/clawgate.py` (best-effort, stdlib urllib, NEVER raises): `load_creds` /
+   `build_task_title` / `build_task_body` / `resolve_repo_fullname` / `post_task` / `dispatch_initiative`.
+   Viewer endpoint **`POST /api/dispatch`** `{repo, slug}` → 200 `{ok,task_id}` / 400 / 404 / 502 (never an
+   uncaught 500). Per-card **Dispatch** button (renders only when a recommendation exists). **Trust model:**
+   the VIEWER (workbench, LAN-bound, `~/.claude/clawgate.env`) holds the clawgate token and POSTs — the
+   in-cluster read-only devpod gets NOTHING new (audit-verified: query.py/assistant.py have zero token/
+   dispatch refs). Two human gates: tap in viewer → creates a clawgate Task card; tap Dispatch in clawgate →
+   runs. clawgate `/api/tasks` contract (from Go source): `{directory(=display label), body(req), model?,
+   repo?, branch?}`; OMIT model → clawgate default deepseek. Task-drafter-style card body.
+3. **Audit fix** (`835fe0c`): the lazy `_dispatch()` load was OUTSIDE the error-wrapping try → an import
+   failure would be a caught-500 not a 502. Moved inside the try + 2 regression tests for the live
+   lazy-load path.
+
+**Tier 3 (write — updating next_step / handoff docs) stays DEFERRED** behind the structural server-side
+write-gate per `claudedocs/initiatives-agent-proposal-eval-2026-07-24.md`.
+
+## Verification (memory-is-hypothesis — done, not assumed)
+- `444` hermetic tests pass. `/audit-pr`: no 🔴; anti-confabulation, XSS/textContent, token isolation,
+  never-raises dispatch, clawgate payload contract, no regressions all positively verified.
+- **Real end-to-end:** dispatched `naida-ai · HANDOFF` via the exact production chain → clawgate Task **#68**
+  created (`repo=ZacxDev/naida-ai`, `model=''`→deepseek), confirmed by an independent `GET /api/tasks`.
+- **Deployed** to both hosts via `scripts/ship.sh` (origin/main `835fe0c`); live viewer serves
+  `/api/dispatch` (bad body→400, unknown slug→404 with the new error message).
+
+## Loose ends / notes
+- **Emerging-lane slugs are ugly** (sorted-token strings) — the dispatch `directory` label uses
+  `repo_name · slug`, so an ugly slug → an ugly-but-harmless label. Tunable with the discovery floor.
+- **A `handoff`-basis recommendation can be a mid-sentence heading fragment** (the scan parses the handoff's
+  "next steps" heading). Faithful/grounded, occasionally truncated — acceptable; improving the scan's
+  next-step parse is a separate nicety.
+- **Stale-snapshot**: the dispatched body is rebuilt from the TTL-cached view at POST time (freshest wins;
+  the clawgate human-gate is the backstop). Acknowledged, acceptable.
+- **Loose ends inherited (not addressed this session):** clawgate embed still at kubeclaw 0.7.0 (0.7.1
+  re-sync pending); workbench/client devpods unhardened; the dirty local `homelab-talos` checkout.
+- **Concurrent-session hazard observed:** this devrc working tree was under heavy concurrent git activity
+  during the session (my build agent's 2 commits initially landed on `main` not the feature branch, the
+  shared HEAD moved under me, transient ref-lock `rev-parse` failures). Resolved safely — origin/main is
+  clean at `835fe0c`, the feature branch + main coincide, and ship.sh's stash→pop restored the concurrent
+  session's uncommitted `nix/home.nix`. If dispatching parallel agents against a busy repo, use worktree
+  isolation.

--- a/claudedocs/handoff-insights-telemetry-unify-2026-07-28.md
+++ b/claudedocs/handoff-insights-telemetry-unify-2026-07-28.md
@@ -1,0 +1,406 @@
+# Insights ↔ telemetry — session 2026-07-28
+
+**Supersedes `handoff-insights-telemetry-unify-2026-07-11.md`.** That doc's priority
+list was stale in all three items by the time it was picked up; this one records what
+was actually true on 2026-07-28 and what the extraction produced.
+
+## Why the old handoff misled
+
+| Old claim (07-11) | Reality on 07-28 |
+|---|---|
+| Layer B: 8 sessions extracted, ~90 backlog | **148 already extracted** — batches ran 07-21 (57) and 07-24 (83) |
+| Layer A: 373 `session-summary` rows | **27,061 rows / 702 sessions**, +~1,800/day |
+| "Dominant finding: config-as-code for storage/CDN" | **Superseded** — now a ×1 tail item |
+
+No code touched Layer A/B between 07-11 and 07-28; the intervening sessions were
+operating runs only. **Lesson: a handoff doc's *findings* section ages as fast as the
+data behind it. Re-run the report before acting on a remembered conclusion.**
+
+## The dominant finding at 148 sessions — and its twist
+
+52 of 148 sessions carried a `config_gap`; **33 named the headless drafter's allowlist**
+(`gh pr list` ×23, multi-op `&&` ×15, `$CIVITAI` ×12, `git branch` ×10, kubectl ×7).
+The largest toil category — `context-gathering` ×~20 — was the downstream symptom
+(brute-force `git log --grep` archaeology as a substitute for "is this merged?").
+
+**The twist: it was already fixed.** All 33 gap sessions fall in 07-10 → 07-24, and 29
+strictly before **PR #157** (2026-07-24, "harden headless runtime") + **#159**
+(deterministic `ticket-status` probe). The report couldn't know — the extraction
+batches predated the fix, so *no post-fix session had been extracted*.
+
+That inverted the value of the "just extract more" option: the pending sessions were
+**the verifier for #157/#159**, not more of the same.
+
+## What the extraction actually proved
+
+Extracted 8 sessions (run `20260728T231415Z-07c4`), all post-07-20, → Layer B now
+**156 sessions**. Six of the eight were the drafter's own per-ticket `claude -p` runs
+from today's 08:02 pass (note: `ground_truth` timestamps are **UTC** — `13:03Z` =
+`08:03 CDT`).
+
+**Verdict: PR #157 did NOT close the gap.** Session `1d05e840` recorded `gh pr view`
+still blocked. Root cause found and confirmed against the transcript:
+
+- `drafter-prompt.md:99-100` mandates `gh -R civitai/civitai pr list|view|checks …`
+- `drafter.sh:198` allowlisted only `Bash(gh pr list*)` / `view*` / `checks*`
+- `-R <repo>` sits between binary and subcommand → **prefix pattern can never match**
+
+Proof it was the pattern and not the environment: six sibling `git -C … log` calls in
+the same session matched `Bash(git -C * log*)` and ran fine.
+
+### Deterministic baseline (all 81 drafter transcripts)
+**192 of 1,419 Bash calls rejected (13.5%)**, split by cause:
+- **106 true allowlist gaps** — 77 of them `gh -R … pr …` (73%), 11 `git branch -a/--merged`, 4 `KUBECONFIG=… kubectl`
+- **86 shape-guard rejections** — model violating the prompt's own no-chaining contract. *Not* allowlist bugs; must not be "fixed" by loosening the allowlist.
+
+Blocked rate by run-day: 14.2% (07-21) → 12.2% (07-25) → 8.0% (07-28) — #157 helped
+but never approached zero, because the largest cause was untouched.
+
+## What shipped
+
+**PR #177** (merged, `cba98a9`) — allowlist the `gh -R` form; add read-only
+`git -C * branch --merged*` / `branch -a` / `branch --all`; new
+`tests/test_allowlist_covers_prompt_shapes.py` (a port of Claude Code's Bash matcher +
+prompt-shape extraction) asserting every prompt-mandated shape is allowlisted. 87 tests.
+- Adversarial audit caught that `Bash(gh -R * pr view*)` admitted **gh write verbs**
+  via substring smuggle → repo pinned to `civitai/civitai` + `civitai/talos-infra`.
+- Audit also caught the anti-drift test could be evaded (fenced blocks stripped before
+  extraction; placeholder-bearing spans dropped) → both closed.
+- The author correctly **refused** an instruction to add `Bash(git -C * branch -a*)`:
+  `git branch -a -m old new` renames (verified rc=0). Shipped exact `branch -a` instead.
+
+**PR #179** (merged `d5c46c2`, shipped to both hosts) — closes **two confirmed
+pre-existing RCEs**. 102 tests. Two adversarial-audit rounds; both rounds found real
+blockers that were fixed before merge.
+
+**Live state verified on the exact file the timer runs**
+(`~/workspace/devrc/scripts/task-spec-drafter/drafter.sh` — the unit runs the working
+tree directly, so `git pull` is the deploy): 71 allow entries, node pinned, **0
+mid-pattern wildcards**, 13 deny entries, runtime `CIVITAI_REPO` guard, `bash -n` OK.
+Next run **2026-07-29 08:03:13 CDT**.
+
+## 🔴 The RCE (pre-existing since 2026-06-23, NOT introduced by #177)
+
+`Bash(git -C * log*)`'s mid-pattern `*` matches **across spaces**, so git's global
+`-c` options can be inserted between path and verb. Reproduced by execution:
+
+```
+git -C <repo> -c diff.external='sh -c "id > /tmp/M" --' log -p --ext-diff
+→ executed; uid=1000(zach) groups=wheel,docker
+```
+
+Threat model: untrusted ClickUp ticket text → prompt injection → code execution as
+`zach` (docker group ⇒ root) on a host holding a **production kubeconfig**, unattended
+at 08:02 daily. No evidence of exploitation — this is a capability finding.
+
+**Fix = structural, not blocklist:** pin the `-C` path to the three literal repos the
+drafter actually uses (civitai 782 calls, datapacket-talos 16, homelab-talos 4), so the
+verb must follow the literal path immediately. Verified premise: git **refuses `-c`
+after the subcommand** (rc=128).
+
+Two further holes found while fixing, both verified by execution:
+1. **`git grep -O'<cmd>'` executes** — a *post*-subcommand flag, so pinning does not
+   close it → the `grep` verb was **dropped** (native `Grep` tool + `git log --grep/-S`).
+2. **`git log --output=<path> --pretty=format:'<text>'` = arbitrary-path truncating
+   file write** (aimed at `~/.zshenv` ⇒ RCE). A prefix *allow* pattern cannot forbid a
+   suffix → added a **`--disallowedTools` deny layer**.
+
+Also corrected: `drafter.sh`'s header claimed the pass runs under
+`--permission-mode plan`. **It does not.** That materially misstated the safety posture.
+
+### A SECOND RCE of the same class — `node` (found by the #179 audit)
+
+`Bash(node *query.mjs get*)` (plus `comments*` / `search*`) has the mid-glob exactly
+where node's `-e` lives. Verified by execution:
+
+```
+node -e '<arbitrary JS>' query.mjs get 1   → matches the pattern; node runs the -e
+                                              payload and ignores the trailing file
+```
+
+Arbitrary JS as `zach`. **Pre-existing**, same mechanism as the git `-c` hole, and it
+survived the first cut of #179 — which meanwhile asserted "no mid-pattern wildcard,
+test-guarded." Fixed by pinning to the literal `query.mjs` path.
+
+**Generalise the lesson:** a `*` is safe at the END of a `Bash(...)` pattern and
+dangerous in the MIDDLE. Audit every mid-pattern wildcard for what can be inserted at
+the `*`. (Recorded in memory as `claude-allowlist-glob-matches-spaces`.)
+
+### The deny layer is a speed bump, not a boundary
+
+`--disallowedTools` does correctly override `--allowedTools` (verified from the shipped
+bundle: `SKe`/`wko`/`gvd`/`r8y` all consult deny first). But a substring deny is
+**bypassable by quoting** — the regex needs a literal space before the flag and only
+the first token is de-quoted:
+
+```
+git -C R log --output=OUT --pretty=format:x -1     → denied
+git -C R log '--output=OUT' --pretty=format:x -1   → EXECUTED, file written
+```
+
+Treat it as raising the bar, never as closure.
+
+## Still open (honest residual)
+
+- ~~Not verified against a live run.~~ **✅ VERIFIED 2026-07-29** against the 08:00:20
+  → 08:10:48 run (`Result=success`). **Blocked rate 13.5% baseline → 2.7%**; **zero
+  `gh -R … pr …` blocks** (pass criterion met); and **no over-restriction** —
+  git 55 ran/2 blocked, gh 9/1, kubectl 11/0, node 22/0, ticket-status 11/0.
+  The 3 remaining blocks are benign: `gh … issue view` (never allowlisted — a real but
+  small new gap), `git … tag -l` (deliberately out of remit), and `git -C … find .`
+  (malformed — git has no `find` subcommand; model error, not an allowlist issue).
+
+  Re-run this any time to recompute the same table:
+
+  ```bash
+  python3 - <<'PY'
+  import json,glob,os,collections,re,datetime
+  pure=collections.Counter(); chained=collections.Counter(); byday=collections.Counter(); tot=collections.Counter()
+  for f in glob.glob(os.path.expanduser('~/.claude/projects/-home-zach/*.jsonl')):
+      day=datetime.date.fromtimestamp(os.path.getmtime(f)).isoformat(); tools={}
+      for line in open(f,errors='replace'):
+          try: d=json.loads(line)
+          except: continue
+          c=(d.get('message') or {}).get('content')
+          if not isinstance(c,list): continue
+          for b in c:
+              if not isinstance(b,dict): continue
+              if b.get('type')=='tool_use' and b.get('name')=='Bash':
+                  tools[b.get('id')]=b.get('input',{}).get('command',''); tot[day]+=1
+              if b.get('type')=='tool_result':
+                  t=b.get('content')
+                  if isinstance(t,list): t=' '.join(x.get('text','') for x in t if isinstance(x,dict))
+                  if 'requires approval' not in str(t).lower(): continue
+                  cmd=tools.get(b.get('tool_use_id'),''); byday[day]+=1
+                  (chained if re.search(r'[|;]|&&|\$\(|`',cmd) else pure)[' '.join(cmd.split()[:4])]+=1
+  for d in sorted(tot): print(f"{d}  bash={tot[d]:4d}  blocked={byday[d]:3d}  {100*byday[d]/max(tot[d],1):.1f}%")
+  print("\nTRUE allowlist gaps:", sum(pure.values()))
+  for c,n in pure.most_common(8): print(f"  {n:3d}  {c}")
+  print("\nchained (shape-guard, NOT allowlist):", sum(chained.values()))
+  PY
+  ```
+
+  **Pass criteria:** `gh -R … pr …` disappears from the TRUE-gaps list entirely.
+  **Watch for the opposite failure — OVER-restriction.** The realistic residual risk is
+  now a legitimate read being blocked, which is unanswerable headless. Eyeball the
+  digest (`~/.claude/task-spec-drafter/latest.md`) for
+  `verification: "unverified — all reads failed/blocked"`. If git reads all fail, the
+  first suspect is a `CIVITAI_REPO` outside the three pinned paths (the new runtime
+  guard should `exit 1` loudly rather than fail silently).
+- **The allowlist is reduced, not proven safe.** Known-remaining surface, all
+  pre-existing and none claimed closed:
+  - `Bash(kubectl get*)` + prod `KUBECONFIG` ⇒ `kubectl get secret -A -o yaml`
+    exfiltrates **production secrets** into model context, and thence into the digest
+    email. **Largest single remaining item.**
+  - `Bash(cat*)` / `Bash(grep*)` ⇒ arbitrary file read (`~/.claude/.credentials.json`,
+    kubeconfigs, `~/.ssh/*`).
+  - `Bash(jq*)` ⇒ `$ENV` / `input_filename` env + path disclosure (no exec, no write).
+  - `git … diff --no-index <a> <b>` reads any two files (subsumed by `cat*`).
+  The durable fix is moving raw git/node behind `ticket-status`-style wrappers rather
+  than continuing to enumerate flags.
+- ~~**🔴 Permission blast radius**~~ — **CLOSED by PR #185** (merged `da6b9af`,
+  shipped both hosts, 2026-07-29). See "PR #185" below. What remains is the
+  *credential*, not the string matching: the pass still holds a cluster-admin cert.
+
+<details><summary>Original finding (kept for the record)</summary>
+  `claude -p` **unions** the CLI allowlist with `~/.claude/settings.json` — 248 allow
+  entries, `deny: []`, `ask: []`. So the headless drafter also holds `Bash(curl:*)`,
+  `Bash(ssh:*)`, `Bash(git add:*)`, `Bash(git commit:*)` and
+  `kubectl apply/delete/scale` against homelab **and** workbench kubeconfigs. This is
+  what turns an RCE into full prod access. `drafter.sh`'s careful read-only design is
+  **not a ceiling**.
+</details>
+
+- **clawgate `PermissionRequest` hook** has `matcher: None`, `timeout: 180`, vs
+  `DRAFTER_TIMEOUT=240` — one non-allowlisted call at 08:00 can burn most of a ticket's
+  budget waiting for an approval nobody is awake to give.
+- **`shell-env-nudge` PostToolUse hook** pushes the drafter toward `$CIVITAI`, which
+  `drafter-prompt.md:38` explicitly forbids. Contradictory guidance to a headless agent.
+
+## PR #185 — the settings.json union (merged `da6b9af`, shipped 2026-07-29)
+
+**The problem.** `claude -p` UNIONS its `--allowedTools` with `~/.claude/settings.json`
+(248 allow, `deny: []`, `ask: []`). So closing the git/node doors achieved less than it
+looked: `Bash(python3:*)` is a PREFIX rule matching `python3 -c '<code>'`, and python3
+is on the unit's PATH — **arbitrary execution had been wide open the whole time**, as
+had `docker run --privileged` (⇒ root), `curl`, `wget`, `nc`, `ssh`, `git commit`,
+`sudo lsof`, and (found by audit) `sops` (decrypts secrets), `sqlite3` (`.shell`),
+`find -exec`, `xargs`, `sort --compress-program`, `dig`, `env`.
+
+**The fix.** `DRAFTER_DENIED_TOOLS` 13 → **253 fields** across grouped
+`DRAFTER_DENY_<GROUP>` vars, all whole-binary `Bash(name:*)` PREFIX form. Whole-binary
+denies matter: the `--output` flag-substring deny from #179 fell to quoting
+(`'--output=x'`), but the first token is de-quoted by `rae()`, so a binary deny holds.
+Deny beats allow in every path (`SKe`/`wko`/`gvd`/`r8y`) and is evaluated with
+`stripAllEnvVars` + wrapper unwrapping + `xargs` broadening + per-sub-command
+compound checks — so `KUBECONFIG=… kubectl delete`, `sudo python3 -c`, `xargs python3`
+and `git log && python3 -c` are all covered without leading wildcards.
+
+**🔴 the audit caught, that the tests hid.** The first cut denied kubectl per-verb —
+29 `Bash(kubectl <verb>:*)` PREFIX rules, which only match **verb-first**. Any global
+flag before the verb missed all 29, and `Bash(kubectl:*)` then allowed it against
+**production**:
+
+| | |
+|---|---|
+| `kubectl delete pod -n prod api-0` | denied |
+| `kubectl -n prod delete deploy web` | **ALLOWED** |
+| `kubectl --kubeconfig=<prod> delete ns prod` | **ALLOWED** |
+
+`-n <ns>` before the verb is the most ordinary kubectl idiom there is. The tests missed
+it because every kubectl case was built as `f"kubectl {verb}"` — while the same file
+already ran this exact attack class against `git` via `_GLOBAL_OPTION_INJECTIONS`.
+
+**Fix = `scripts/task-spec-drafter/kubectl-ro`** (the `ticket-status` pattern): deny
+`kubectl` wholesale, allow ONE pinned wrapper that validates in code we control —
+parses flags-before-verb properly, permits only `get`/`logs`/`describe`/`top`, refuses
+identity/endpoint overrides and Secret objects.
+
+**A second 🔴, found only by exercising the wrapper at runtime:** `--raw` takes an
+arbitrary API path, so `get --raw /api/v1/namespaces/x/secrets` read **every Secret in
+the client's production cluster** past the object-level block — and `is_secret_token`
+couldn't catch it because `${1%%/*}` on a leading-slash path strips to empty. `--raw`
+is now refused outright and the secret check walks every path segment. **No pattern
+test could have found this** — the allow/deny patterns are identical either way. That
+is why the suite now exercises the wrapper as a subprocess against a stub kubectl.
+
+**Two kill-switches closed:** appending `DRAFTER_DENIED_TOOLS=""`, or flipping the
+wiring conditional `-n`→`-z`, each disabled the whole layer *with the suite green*.
+`--disallowedTools` is now passed unconditionally, the optional-array pattern is banned
+by test, and an integrity guard aborts on an empty/short value while probing the
+critical denies by name. `${VAR:-}` not `${VAR-}`.
+
+Tests **102 → 119**. Live state verified on the deployed files: 70 allow entries, 0
+mid-pattern wildcards, one kubectl allow (`Bash($SELF_DIR/kubectl-ro *)`), 253 deny
+fields, wrapper behaviour re-checked against a stub.
+
+**Honesty note on "0 false positives":** true for the 07-29 corpus, and partly because
+that run used no `find`. Over the full 8-day window **55/1,172 (4.7%) would now be
+denied, all `find`**. Kept deliberately (`find -exec` is RCE; `Glob`/`Grep` remain; the
+prompt already steers to `Grep`/`rg`) — but it is a real capability reduction, and the
+README recipe now mines the full window instead of one morning.
+
+## 2026-07-30 — the loop closes, and corrects one of its own calls
+
+Four PRs merged + shipped to both hosts.
+
+**#208 — Layer A emit-on-settle (the 07-11 item, finally closed).** Each tick a
+transcript takes one branch: `unchanged` · `settled` (idle ≥ `CLAUDE_SUMMARY_SETTLE_MINUTES`,
+default **20**) · `first-seen` · `interim` (bounded backstop, `CLAUDE_SUMMARY_INTERIM_HOURS`,
+default **4**) · `active`. Settle-only was rejected deliberately: an in-flight session or
+a mid-session reboot would vanish from the report entirely, which is worse than
+duplication. A 12h agent run now yields ~5 rows instead of ~145. Read contract
+unchanged (append-only, `argMax` per session). New invariant
+`session_summary_rows_bounded` is scoped to **`ingested_at`**, so it measures the
+current emitter and passes as soon as the fix deploys rather than waiting on the TTL.
+Settle (20m) sits deliberately under `SUMMARY_ORPHAN_GRACE_HOURS = 2`.
+*Verified independently against the LIVE v1 state file (420 entries): 420/420 migrate,
+0 lost, unchanged transcripts skip on the first post-deploy tick (no migration storm),
+changed-and-idle emits the final rollup once.*
+
+**✅ VERIFIED LIVE on the first two post-deploy ticks:**
+```
+12:27:44  scanned=420 emitted=8  [interim=8 unchanged=412]
+12:32:45  scanned=420 emitted=4  [active=7 interim=4 unchanged=409]
+```
+`active=7` is the proof — seven CHANGED transcripts suppressed because they were
+already stamped and still live; under the old code all seven would have re-emitted a
+full rollup. Tick 2 saw 11 changed and emitted 4. Stamps accumulate correctly (8 then
+12 of 420), so persistence works. The residual `interim` emits are the one-time
+post-migration stamping of the 420-session backlog and decay as it converges; steady
+state is genuine settles plus bounded 4h interims. Confirm the aggregate after ~a day
+with the `count()/uniq(session)` query in item 1b.
+
+**#207 — `git tag -l`: reversing my own call.** #185 excluded `git tag` as "low volume,
+outside the remit". **That was wrong and the telemetry proved it.** Extraction over four
+drafter runs converged on one gap: `ticket-status` prints `deploy_status: unknown —
+release-chain resolution is out of scope`, and the only substitute
+(`git tag -l "v5.0.21*" --sort=-version:refname`) was refused — which is what drove the
+long compensating archaeology chains. Safe because `-l` structurally pins list mode
+(verified: `tag -l -d`, `tag -l --delete`, `tag --list -d` all rc=129, tag intact; bare
+`git tag -d` DOES delete, so `tag*` stays forbidden).
+
+**#205** — the unattended pass opts out of the clawgate `PermissionRequest` hook
+(`CLAWGATE_REMOTE_APPROVAL=off`, the hook's own documented switch). A permission prompt
+at 08:00 is unanswerable by construction. Interactive sessions untouched.
+
+**civitai/talos-infra #753 (DRAFT, not merged)** — least-privilege read-only SA for the
+drafter. ⚠ **In that repo merging IS deploying** (Flux tracks `trunk`, `prune: true`,
+`interval: 1m` → live in ~1–2 min; upside: reverting the merge deletes the objects).
+Grant is `get`/`list`/`watch` only on pods, pods/log, events, cronjobs, jobs,
+deployments (+ an optional `metrics` block for `top`, which the evidence shows was used
+**0 times**). **No secrets** — deliberately, since `kubectl-ro` refuses Secret reads and
+the credential must not grant what the wrapper refuses. Scope mined from the real 07-29
+/07-30 runs. **Sufficiency is UNVERIFIED** — nothing tested against the API server;
+step 0 of its runbook is an `auth can-i --as` matrix. Failure mode is silent: too-tight
+RBAC makes the drafter go quiet (`verification: "unverified"`), not crash.
+
+**Layer B: 164 sessions** (+8). Findings worth carrying forward:
+- **No GC for agent git worktrees** — confirmed: **47 `worktree-agent-*` branches**,
+  oldest 2026-06-24, and **zero have commits not on `origin/main`**. Safe to delete.
+- A **guard-integrity detector** — flag checks that fail identically across consecutive
+  PRs or that can pass vacuously (empty test dir exiting 0, stale floor, grep matching
+  its own echoed input). Two independent sessions converged on "our guards pass
+  vacuously", which is exactly what the #185 audit found.
+- Nothing in CI builds the published install paths, so an advertised Nix flake had
+  silently broken for all users.
+
+## Layer A re-emit storm — RESOLVED by #208 (kept below for the original numbers)
+
+**97.4% of `session-summary` rows are superseded duplicates** (26,359 of 27,061),
+20.4 MiB payload for ~700 sessions, avg 38.5 rows/session, worst 486, +~1,800/day.
+Reads stay correct via `argMax(…, ingested_at)`; it is pure waste that compounds.
+Fix: **emit-on-settle** (emit once idle N min) and/or a **ClickHouse TTL** on
+superseded rollups.
+
+## Next session — priority order (re-derive before trusting this)
+
+1. ~~Verify #185~~ — **✅ VERIFIED 2026-07-30** against the 08:04:52 → 08:21:15 run
+   (`Result=success`, no guard aborts). **Blocked rate 0.6% (1/154)**, the full arc
+   being 13.5% baseline → 2.7% (#177/#179) → 0.6% (#185). **No over-restriction:**
+   `kubectl-ro` 7 ran / 0 blocked (the wrapper serves real cluster reads), `node`
+   44/0, `gh` 12/0, `git` 67/1, `ticket-status` 23/0. The one block was
+   `git … branch -a --sort=-committerdate | head -20` — a PIPE, so a shape-contract
+   rejection, not an allowlist gap (and `branch -a` is exact-form-only by design,
+   per #177). 22 queue records, 1 `unverified`.
+1b. **Verify #208 on live data after ~a day:**
+   `SELECT count()/uniq(session) FROM activity.events WHERE kind='session-summary' AND ingested_at > now() - INTERVAL 24 HOUR` — expect a small number, not 38.5. The
+   `session_summary_rows_bounded` invariant should pass. The 26,359 historical dupes are
+   NOT cleaned (they age out under the 180d TTL; a one-off cleanup is a separate
+   homelab-side call). Also open: `scripts/collector/opencode/session_tailer.py` has the
+   identical per-tick re-emit design and was left alone.
+
+2. **🔴 Least-privilege the prod credential — DRAFTED, DECISION PENDING (PR #753).** `PROD_KUBECONFIG`
+   points at `admin@civit-datapacket-talos` (**cluster-admin, client certificate**).
+   `kubectl-ro` is a wrapper in front of an admin cert; three distinct shell-reaching
+   paths were found and closed in two days, so assume a fourth. Durable fix: a
+   read-only ServiceAccount + ClusterRole (get/list/watch on pods, deployments,
+   cronjobs, jobs, events, logs) on the datapacket prod cluster, and point
+   `PROD_KUBECONFIG` at it. **Not started — it's client production infra in another
+   repo (`datapacket-talos`) and needs an RBAC review. Zach's call.**
+3. **Layer A re-emit storm** — bounded, clearly scoped, untouched since 07-11.
+4. **Keep extracting** — ~49 pending. Now that the drafter gap is closed, the next
+   dominant finding is unknown; that's the point of continuing.
+5. Small: the clawgate `PermissionRequest` hook timeout, and the `shell-env-nudge`
+   contradiction (both above).
+
+### The meta-lesson from this session
+Every fix here was found by exercising the real thing, and every one of the four
+security findings was missed by the tests that were supposed to cover it:
+- the `gh -R` gap — invisible until a post-fix session was extracted;
+- the `git -c` RCE — invisible until someone ran the exploit;
+- the kubectl flag-ordering bypass — the tests only built `f"kubectl {verb}"`;
+- the `--raw` Secret read — the allow/deny patterns are identical either way.
+
+**Pattern-level reasoning kept agreeing with itself and being wrong.** Prefer
+structural fixes (pin the literal prefix; validate in a wrapper you control;
+least-privilege the credential) over enumerating strings, and test the artifact's
+runtime behaviour, not your model of it.
+
+## Operating notes
+- Reader creds + the `sops -d --input-type yaml` gotcha: the `activity` skill.
+- Extraction flow: `cli.py status|prepare|write`, monster sessions (>~250 chunks) get
+  their own subagent and are SAMPLED; small ones batch. Do **not** bias extractors
+  toward an expected finding — it destroys the verification value.
+- Parallel agents in this repo **need `isolation: "worktree"`** — a mid-task
+  `git checkout` on the shared tree disrupted an agent this session.

--- a/claudedocs/handoff-productivity-tooling-2026-06-16.md
+++ b/claudedocs/handoff-productivity-tooling-2026-06-16.md
@@ -1,0 +1,51 @@
+# Handoff: Claude Code productivity tooling — 2026-06-16
+
+**Repo:** devrc (harness/dotfiles) + `~/.claude` (global commands/config). Spans both the **main** host and the **laptop** (`zach@10.42.0.100`).
+**Origin:** a session that analyzed all Zach's Claude Code transcripts → themes → built productivity commands. This continues that thread (and explicitly drops the unrelated prod-infra rabbit hole that the same session drifted into — see `civit/datapacket-talos/claudedocs/handoff-grafana-alert-provisioning-drift-2026-06-16.md`, separate owner).
+
+---
+
+## Goal
+Reduce the two friction sinks the transcript analysis surfaced — **repeated ritual typing** and **cross-session continuity** — by turning hand-typed genesis patterns into commands, and finish per-project/per-host gaps. (Corrections were only 1.9% of messages, so **do NOT invest in guardrails/mistake-prevention** — that's not the bottleneck.)
+
+## What was DELIVERED (done, verify before re-doing)
+- **`/handoff` + `/resume`** — `~/.claude/commands/{handoff,resume}.md`, synced to BOTH hosts. Canonical handoff doc → `claudedocs/handoff-<topic>.md` + re-entry that re-verifies against live state.
+- **`/audit-pr`** — `~/.claude/commands/audit-pr.md`, both hosts. Zach's verbatim 9-point adversarial checklist (risks/regressions/assumptions/gaps/bugs/issues/behaviour-changes/leaks/second-order).
+- **Standing CLAUDE.md rule** — "implementation tasks default to subagent + test coverage + branch/PR" — now on **BOTH** hosts (`~/.claude/CLAUDE.md`). Laptop append done 2026-06-16 (`zach@10.42.0.100`, hostname `nixos`; the LAN addr `192.168.50.155` was unreachable today — use the nebula addr).
+- **`/analyze-service <name> [then …]`** — `~/.claude/commands/analyze-service.md`, BOTH hosts. Live (not frozen-map) recon of an infra subsystem: locate across `homelab-talos`/`datapacket-talos`, load config, check live state (kubectl/flux, states the context used, never fabricates), recent git changes → dense brief, then proceeds to the follow-on (impl → subagent per standing rule). Retires the "analyze the X setup, then …" genesis (~31).
+- **`/find-session <terms>`** — `~/.claude/commands/find-session.md` + `devrc/scripts/find-session.py`, BOTH hosts. Deterministic ranked search over `~/.claude/projects/**/*.jsonl` (AND by default, `--any`/`--project`/`--since`/`--limit`/`--json`, phrase via quotes). Prints date/project/branch/genesis/snippet + `claude --resume <id>`. Verified: `"pr 235"` returns the exact "find the session where we did pr 235" session. Retires the session-archaeology genesis (~5). NOTE: `find-session.py` is untracked in devrc working tree on both hosts (not committed — same as `session-analysis/`).
+- **`/ux-audit <app/flow> [url]`** — `~/.claude/commands/ux-audit.md`, BOTH hosts (md5 `517975f8…`). Captures the verbatim, 9×-hand-typed "dispatch a subagent to use playwright to click through … and evaluate" UX sweep. Dispatches a subagent that drives the **Playwright MCP** through every view, screenshots all, and scores against the user's standing 7-point rubric (intuitive-for-a-non-technical-easily-deterred-user / broken / overwhelming / confusing / walls / unnecessary friction / simpler?) → prioritized 🔴/🟡/🟢 report + top-3. Distinct from the built-in `/verify` (that = "does this fix work"; this = "is this UX good for a first-timer"). Targets the product projects (vetr/naida/app onboarding), mostly worked on the laptop. NOT adoption-measured.
+- **Rules-layer deletion (the Algorithm step 2, applied + LIVE on BOTH hosts)** — `~/.claude/RULES.md` 331→90L, `PRINCIPLES.md` 60→8L (governing layer 405→~120L incl. untouched 14-line CLAUDE.md). Deleted: PM-Agent meta-layer, `/sc:` session-lifecycle prose, the parallelization fake-metric rule (self-contradictory), SOLID/decision-tree recitations. Kept verbatim (the earned ~10%): Token Hygiene, Verification Honesty, Memory-is-Hypothesis, Deterministic/Push-Back; trimmed Git/Failure/Honesty/Temporal/Scope/Files. Both hosts md5-identical (`RULES` `0fd559cc…`, `PRINCIPLES` `5162398e…`). Reversible: `~/.claude/{RULES,PRINCIPLES}.md.bak-2026061{6}-2049*` on each host; staged copy in `claudedocs/proposed-rules-cut/`. Full analysis: `claudedocs/the-algorithm-applied-2026-06-17.md`. Laptop RULES had drifted (319L, missing Token Hygiene) — the cut net-added that section back.
+- **Analysis pipeline preserved** → `devrc/scripts/session-analysis/` (was ephemeral in /tmp):
+  - `extract_user_msgs.py` — pulls genuinely-typed messages from `~/.claude/projects/**/*.jsonl` (filters sidechain/meta/task-notifications/system-reminders/command-stdout; dedups). Run on each host, combine. Produces ~6,028 records.
+  - `extract_genesis.py` + `classify_genesis.py` + `genesis_detail.py` — first-message-per-session ("genesis") extraction + continuation-vs-fresh classification + taxonomy.
+  - `analyze.py`, `prod.py` — theme buckets, per-project friction (steering %, correction %), repeated-prompt clustering.
+  - Data (`user_msgs_clean.jsonl`, `genesis_only.jsonl`) is **regenerable** — re-run the scripts; don't rely on /tmp.
+
+## Key findings to carry forward (the evidence base)
+- **6,028 typed messages**, median 46 chars — short imperative directives. Top themes: delegation-to-subagents, an adversarial-audit ritual, PR→deploy→verify loop, terse steering, multi-day handoff continuity.
+- **Genesis analysis:** 273 fresh-start sessions; **53% open with a slash command** (your command library IS your launch surface — and it's well matched). Signature unbuilt pattern: **"analyze the X setup, then …"** recon (31 geneses).
+- **Friction is NOT mistakes** (1.9% corrections). It's (a) re-typing rituals and (b) finding/rebuilding context across sessions.
+- **Methodological caveat (from `close-the-loop/STATE.md`):** mining transcripts is *recency-biased* — great for "what hand-typed ritual can become a command," useless for "what's the highest-leverage NEW thing." For net-new, run `/close-the-loop` explore-F (interview), not more mining.
+
+## Backlog — the highest-ROI UNBUILT items (ranked)
+1. ✅ **DONE — `/analyze-service`** (see DELIVERED). Built live-discovery, not a frozen map (per Zach's deterministic/memory-is-hypothesis principles). NOT yet adoption-measured.
+2. ✅ **DONE — `/find-session`** (see DELIVERED). NOT yet adoption-measured.
+3. ✅ **DONE — standing rule synced to laptop** (see DELIVERED).
+4. **Per-project: wire civitai `verify` skill to real click-paths.** `civit-civitai` is the highest-correction big repo (2.7%) and the only one with UI regressions ("you broke the sample-carousel"). Make "done" require reproducing the actual user click-path (Playwright) before claiming fixed.
+5. **Measure adoption (the validation loop).** In ~1 week (≈2026-06-23), re-run `extract_user_msgs.py` on BOTH hosts and recount the ritual stems. If a command isn't used, fix its description/trigger or kill it — don't let it rot. **Captured BASELINE (hand-typed ritual occurrences, 2026-06-17, both hosts, BEFORE the commands could displace them):** `/analyze-service` 33 · `/find-session` 5 · `/ux-audit` 11 · `/audit-pr` 52 · `/handoff` 80. Re-grep these same patterns post-adoption; a drop = the command displaced the hand-typing, a flat/rising count = adoption failure (fix the trigger or kill it). Recount recipe is in `the-algorithm-applied-2026-06-17.md` appendix + the grep in this session's transcript.
+
+## Explicitly DEFERRED / out of scope here
+- Scheduled homelab health-check (Zach didn't pick it).
+- Guardrail hooks (correction rate too low to justify).
+- The `cronjob-stale` Grafana alert + GoAlert paging outage — different thread, own handoff doc (above). Note: the cronjob-stale alert (talos-infra PR #158) is merged + verified.
+
+## How to verify when "taken further"
+- New commands exist on BOTH hosts (`ls ~/.claude/commands/`), laptop CLAUDE.md has the rule.
+- Re-run `scripts/session-analysis/extract_user_msgs.py` post-adoption: the targeted hand-typed patterns (recon "analyze X", "write the handoff", session-hunting) measurably decline, or the new commands appear in the command-frequency table.
+- `/analyze-service` and `/find-session` each retire a named genesis mode (recon / session-archaeology).
+
+## Gotchas
+- `~/.claude/commands/*.md` are global (both hosts) — additive syncs are safe (`scp`), but CLAUDE.md differs per host (don't overwrite wholesale).
+- Don't re-run the heavy extraction inside a transcript you're also writing to (it reads `~/.claude/projects/**`).
+- `/tmp` is ephemeral — the analysis data there from the original session is gone/going; regenerate from `scripts/session-analysis/`.

--- a/claudedocs/handoff-qa-automation-2026-06-29.md
+++ b/claudedocs/handoff-qa-automation-2026-06-29.md
@@ -1,0 +1,39 @@
+# Handoff — QA-audit automation + activity-telemetry correction — 2026-06-29
+
+## What this session was
+Started from "use the activity telemetry to find automation opportunities," which led to: (1) **correcting** the activity pipeline (a 20× browser-data bug), (2) building **deterministic automation** off the telemetry, and (3) the big thread — building **re-runnable UX-audit loops for naida + vetr** to replace manual in-browser QA, which **caught a live revenue bug in vetr**.
+
+Operate via skills (all updated this session): `activity`, **`ux-audit-loops`** (NEW). Cross-session detail: memories `activity-telemetry-pipeline`, **`qa-ux-audit-harness`**.
+
+## State now (all merged unless noted)
+**Activity telemetry — corrected + extended:**
+- Browser `active_ms` was ~20× inflated (structurally broken on i3: `chrome.idle` is system-wide + blur unreliable → counted other-app time as browser-active). **RETIRED** it; attention is now **i3-derived** (i3 "Brave-focused" intervals ∩ active-tab domain). devrc #25 (mutex race fix), #26 (harness: retire active_ms invariants, add `derived_attention_consistent`), #27 (strip active_ms/focus/idle from the ext → nav+scroll only, manifest 1.4.0), #28 (duration garbage bound 24h→7d). homelab-infra #79 (dashboard panel → "Browser attention by domain (i3-derived)"). Harness `OVERALL: PASS`. Ext re-deployed on laptop + verified (focus/active_ms events at 0).
+- New tooling: `scripts/session-analysis/activity-scan.py` (weekly automation/bottleneck/signal report) + `scripts/dogfood-cycle` (collapses the manual civitai dogfood loop). devrc #29/#30.
+
+**naida UX-audit loop — DONE.** `ZacxDev/naida-ai` #38/#39/#40/#41/#42. `make ux-audit` (walk) / `make ux-audit-draft` (Haiku-drafted notes). Local DEV_MODE, keys-stripped. Nix flake. Laptop copy: `~/workspace/scratch/naida-ai`.
+
+**vetr UX-audit loop — DONE + already paid off.** `vetrllc/vetr-app` #67 (hermetic stack on NixOS) / #68 (the loop, 14 funnel views) / #69 (authnet default) / #70 (telemetry off + origin-classified findings) / #71 (CDPATH fix). Runs the team's hermetic E2E stack (docker MySQL + Laravel + SPA + Playwright). **Authnet sandbox validated** (creds in workbench `~/.config/vetr/authnet.env`).
+- **🔴 Found a LIVE revenue bug** (the payoff): under Authorize.net (prod), pooled-consult + servicer-booking **pay-now checkout is broken** — renders Stripe `<PaymentElement>` with a null `client_secret` → empty form, can't pay. Documented: `vetrllc/vetr-workspace` `payment-rails-paynow-checkout-bug.md` (#1, merged). **Another agent is handling the fix** — do not touch it; when it lands, add a regression-guard assertion to the vetr loop.
+
+## Next steps (ranked)
+1. **THE ORIGINAL UNTOUCHED THREAD — email automation on the live `mail` table** (skill `mailbox`, memory `selfhosted-mail-inbox`). This was the higher-leverage "heavy automation" goal from session start (triage / task+receipt extraction / digests) and is STILL not started — we went deep on activity+QA instead. Strong candidate for next focus.
+2. **Operator: laptop housekeeping for the loops** — replace `~/workspace/scratch/vetr`-side `~/.config/vetr/authnet.env` PROD creds with the SANDBOX ones (harness forces sandbox endpoint → prod bounces E00007); use a FRESH OpenRouter key for draft passes (the one pasted this session is in transcript — rotate it).
+3. **Verifier (run in ~a week):** `activity-scan --days 7` — if the manual vetr/naida QA browser-time + the civitai/dogfood command counts DROP, these automations are real leverage; if not, cut them.
+4. **Lower / standing:** revive the dead vetr `e2e (hermetic)` CI (expired `VETR_API_REPO_TOKEN`, failing since ~2026-06-12); fix the vetr X-Timezone availability-display prod bug (its regression spec is red); the activity "weekly LLM digest" cap (only if it'd drive a decision — else don't reflexively build more).
+
+## Gotchas / decisions
+- **active_ms is RETIRED — do not reintroduce it.** Browser attention = i3∩domain (query in the `activity` skill). The URL is the `text` column, NOT `payload.url`.
+- **Both prod payment targets are UNSAFE to automate:** vetr `app.vetr.com` (live Authorize.net) + naida `naida-ai-demo.zacx.dev` (live AI/email/LinkedIn + shared org). Loops are LOCAL-ONLY; vetr forces `ANET_ENDPOINT=sandbox`.
+- vetr migrated Stripe→Authorize.net via env flag (code default still `stripe` for rollback; prod runs `authnet`). The harness defaults authnet to match prod.
+- Memory-is-a-hypothesis bit twice this session: the "8/8 GREEN" handoff claim (harness was actually red), and "sandbox creds exist" (the file held PROD creds). Re-verify live before acting.
+- Skills updated: `activity` (active_ms retirement, i3-derived query, harness invariants, activity-scan); `ux-audit-loops` (NEW). devrc `CLAUDE.md` activity line corrected (6 sources, restart-gotcha fixed) — UNCOMMITTED, part of the working-tree drift.
+
+## How to verify
+```bash
+# Activity harness green + sources flowing (workbench)
+RPW=$(SOPS_AGE_KEY_FILE=~/workspace/homelab-talos/.secrets/age.key sops -d --extract '["stringData"]["reader-password"]' <(git -C ~/workspace/homelab-talos show origin/trunk:clusters/homelab/apps/activity/secrets.enc.yaml))
+CLICKHOUSE_URL=http://192.168.50.94:30123 CLICKHOUSE_USER=activity_reader CLICKHOUSE_PASSWORD=$RPW python3 ~/workspace/devrc/scripts/validation/validate.py   # expect OVERALL: PASS
+# naida loop:  cd ~/workspace/scratch/naida-ai && nix develop -c make ux-audit
+# vetr loop:   cd ~/workspace/vetr-app && make ux-audit   (authnet default; sandbox creds in ~/.config/vetr/authnet.env)
+# activity-scan: CLICKHOUSE_URL/USER/PASSWORD env → python3 ~/workspace/devrc/scripts/session-analysis/activity-scan.py --days 7
+```

--- a/claudedocs/handoff-repo-cos-precision-iteration-2026-07-13.md
+++ b/claudedocs/handoff-repo-cos-precision-iteration-2026-07-13.md
@@ -1,0 +1,46 @@
+# Handoff: repo-cos precision iteration — the 0/5 week (3 FP classes fixed) — 2026-07-13
+
+## What this session was
+First real "read + evaluate the weekly digest with Zach" cycle since the self-hosted build (see `handoff-repo-cos-selfhosted-complete-2026-07-02.md`). The instrument ran two Mondays (2026-07-06, 2026-07-13); this session evaluated the **2026-07-13** digest collaboratively. Outcome doubled as the first hard test of the CEO-model loop's *precision*.
+
+## Headline: the 2026-07-13 digest was **0/5 actionable**
+None of the 5 proposals were worth doing. Breakdown + disposition:
+
+| # | Proposal | Verdict | Disposition |
+|---|----------|---------|-------------|
+| 1 | homelab-talos: enable 7 "skipped" clawgate e2e tests via Docker/Postgres in CI | **False positive** — `test.skip(!dockerAvailable(),…)` is a *conditional* graceful-degradation guard; specs **already run in CI** (Docker present since PR #83, 2026-07-06). Removing guards = local-run regression, 0 CI gain. Subagent pushed back + refused to ship; independently verified (`clawgate-ci.yml` `docker info`+`playwright test`, PR #83 `bc5b6e04`, CI run 28797316953 = 72/75 pass). | Dismissed (7 refs) |
+| 2 | civitai: fix `RETURN 'XXX'` "placeholder" in DB init SQL | **False positive** — `'XXX'` is a real NSFW-rating enum value (`PG/PG13/R/X/XXX/Blocked`) | Dismissed |
+| 3 | civitai: enable 5 app-auth/preview-apps e2e via stub OAuth + minted key | Real but **out of lane** (client *app* code, not Zach's infra) + deeper than effort:M | Dismissed |
+| 4 | devrc: remove "stale TODO" from RULES.md | **False positive** — the line is a rule *about* TODOs; `.md` subject-match. Proposal wanted to delete a real behavioral rule. | Dismissed |
+| 5 | datapacket: resolve TODO markers in handoff `*.md` docs | Low value — TODOs in dated handoff docs, not live work | Dismissed |
+
+## Three false-positive CLASSES → all fixed in code (not just dismissed)
+The 3 FPs came from 3 distinct structural blind spots in `scripts/repo-cos/prescan.py`:
+1. **rg/walk `.md` divergence** — `_walk_markers` honored `SCAN_EXTS` (no `.md`); `_rg_markers` ignored it and grepped *every* file. Results depended on whether `rg` was installed (non-deterministic). Leaked `.md` matches → #4, #5. **Fixed: PR #106** (`_rg_markers` now drops non-`SCAN_EXTS` files).
+2. **quoted string literals** — marker regex matched `XXX`/`TODO` inside `'…'`/`"…"`/`` `…` `` (enum values, not comments) → #2. **Fixed: PR #106** (`_has_unquoted_marker` — keep line only if a marker occurrence is NOT quote-wrapped).
+3. **conditional skip-guards** — `SKIP_PATTERNS` `js.skip` matched `test.skip(` regardless of whether it's the *conditional* runtime form `test.skip(<expr>, …)` (runs in CI) or the *unconditional* disabled-block form `it.skip('name', fn)` → #1. **Fixed: PR #107** (`_is_conditional_js_skip` — first arg is a string literal/empty → disabled → flag; anything else → conditional guard → drop).
+
+## State now (all on `main`, both PRs merged + workbench deployed + verified)
+- **PR #106** `fix(repo-cos): stop two prescan marker false positives` — merged `7cd3dc8`, tests 203→210.
+- **PR #107** `fix(repo-cos): don't flag conditional test.skip() runtime guards` — merged `0422af8`, tests 210→214.
+- **Workbench HEAD = `0422af8`**, `ship.sh --no-laptop` ×2 (HM-switched + verified at `origin/main`). Both helpers confirmed live in the checkout the weekly timer runs from. **Laptop NOT deployed** (doesn't run the repo-cos timer; picks up on its next normal `ship.sh`).
+- **`~/.config/repo-cos/exclusions.json` — 26 dismissals** guarding recurrence: #1 (7), #2 (1), #4 (3) added first; #3 (5), #5 (3) added after. #4/#5 are `.md` → also structurally excluded by #106 (belt-and-suspenders); #1/#3 (`.spec.ts`) are the ones that genuinely needed the explicit dismissal.
+
+## Next steps
+1. **Watch the 2026-07-20 digest** — the real verifier: did precision improve? Prediction after #106+#107: the `.md`/quoted/conditional-skip noise is gone; whatever surfaces should be closer to real signal. If it's *still* mostly noise → escalate to signal **down-weighting** (see below).
+2. **If ≥2 more weeks come back mostly-noise:** the deeper move is to down-weight the string-match signals (`marker`, `skipped_test` — "the token appears" ≠ "a defect exists") relative to `churn`/`large_file`/`stale_lock` (no string-match failure mode). Do NOT do this preemptively — let #106+#107 run a cycle first. This is the honest read on repo-cos's ceiling: it's grounded + cheap by design, but marker/skip signals are inherently FP-prone.
+3. **Nothing dispatched to implement** from this digest — correctly, it was all noise/out-of-lane.
+
+## Gotchas / notes
+- **The two most valuable moves this session were REFUSALS**, not builds: the clawgate subagent refused to remove the guards (would've been a regression), and I reversed my own "dispatch #1" after the evidence. Evaluate-with-Zach caught what the LLM synthesis + passing tests would not have.
+- Dismissals are keyed on the exact prescan `.ref` = `{repo}/{file}:{line}` (matches digest evidence strings verbatim); `_canon_ref` only normalizes whitespace/slashes. `resume <repo>` / edit the JSON to reverse.
+- `exclusions.json` edits were done directly (skill-supported) rather than via the reply loop — immediate + reliable vs the async mail round-trip.
+
+## How to verify
+```bash
+cd ~/workspace/devrc
+git log --oneline -2        # expect 0422af8 (#107) + 7cd3dc8 (#106)
+grep -n "_is_conditional_js_skip\|_has_unquoted_marker" scripts/repo-cos/prescan.py
+nix-shell -p 'python3.withPackages(p:[p.pytest p.requests p.psycopg2])' --run 'python -m pytest scripts/repo-cos/tests -q'   # 214
+python scripts/repo-cos/scan.py --show-exclusions    # 26 dismissed + the repo/approved sections
+```

--- a/claudedocs/handoff-repo-cos-precision-iteration-2026-07-27.md
+++ b/claudedocs/handoff-repo-cos-precision-iteration-2026-07-27.md
@@ -1,0 +1,41 @@
+# Handoff: repo-cos precision iteration — 3-week arc (structural roots fixed) — 2026-07-27
+
+Supersedes `handoff-repo-cos-precision-iteration-2026-07-13.md`. Tracks the "does the weekly digest earn its place / iterate on precision" thread. Operate via the `repo-cos` skill.
+
+## The arc: each week's noise pointed at a real instrument defect (not just cleared)
+| Week | Digest result | Root cause found | Fix (all merged + workbench-deployed) |
+|------|---------------|------------------|----------------------------------------|
+| **07-13** | 0/5 actionable | 3 false-positive classes: rg/walk `.md` divergence, quoted-string-literal markers, JS conditional-skips | PR #106 (`.md` align + `_has_unquoted_marker`), PR #107 (`_is_conditional_js_skip`) |
+| **07-20** | 1 actionable (+1 real-but-yours) — **verifier PASSED** | none new; the 1 actionable was a REAL coverage gap | PR #178 (homelab-talos: Postgres service in clawgate-ci.yml `go` job + `CLAWGATE_TEST_DATABASE_URL`) — **enabling the test uncovered + fixed a latent FK bug** |
+| **07-27** | 0/4 actionable | two STRUCTURAL roots: (1) stale local checkouts, (2) Go/Python conditional-skips not suppressed | PR #170 (fetch-before-scan), PR #171 (`_is_conditional_go_skip`/`_is_conditional_py_skip`) |
+
+## State now (all on `main`, workbench deployed + verified; laptop picks up on its next ship)
+- **devrc HEAD `fbf5358`** (`ship.sh --no-laptop` after each merge; both PRs' helpers confirmed live in the checkout the weekly timer runs from).
+- **PR #170 — fetch-before-scan (the trust fix):** prescan now `git fetch`es each repo and scans `origin/<default-branch>` in a **throwaway detached worktree** (system temp, cleaned in `finally`), NOT the drifted/dirty working copy. Working tree provably untouched (no pull/checkout/reset). Real repo basename preserved in evidence refs (`resolve_scan_root`/`scan_repo_fresh`, `repo_name` override). `stale_lock` deliberately reads the ORIGINAL working tree (real mtimes — a fresh checkout stamps mtime=now). Robust fallback to working-tree scan (no remote/offline/`--no-fetch`) + per-repo mode logged. 245 tests.
+  - **Why it mattered:** `~/workspace/homelab-talos` was **181 commits behind `origin/trunk`** and missing merged PR #178 → the digest re-proposed already-done work (07-27 #2) and could cite stale line numbers. This is why 07-27 #2 recurred despite being fixed in wk2.
+- **PR #171 — Go/Python conditional-skip suppression:** generalized #107's JS conditional-vs-disabled logic. `_enclosing_opener(lines, idx)` (nearest strictly-shallower preceding line) + drop `t.Skip`/`t.Skipf`/`t.SkipNow` inside `if …{`/`} else if`/`} else` and `pytest.skip(` under `if`/`elif`/`else:`. KEEPS bare body skips, `@pytest.mark.skip`, `allow_module_level=True`. Conservative (only if-family openers count; `for`/`with`/`func`/`def` nesting stays flagged). 257 tests. Verified: the real `pgstore_test.go` now yields **0 `go.skip` candidates** (all 6 `t.Skip` classify conditional).
+- **`~/.config/repo-cos/exclusions.json` — 43 dismissals.** 07-27 added 17 (#1 devrc no-CI FP, #2 done-via-#178 with forward-looking `origin/trunk` line refs 23/94/166, #3+#4 civitai out-of-lane).
+
+## The accepted tradeoff (state it honestly next week)
+Conditional-skip suppression (#107 + #171) is a **recall/precision tradeoff**: prescan can't tell "real gap" (CI lacks the dep) from "already handled" (CI provides it) by reading the test file alone. **Wk2's #178 win — a real FK bug found by enabling a conditional-skip — would NOT surface under the new suppression.** That was a conscious call (Zach, 07-27): the FP is a *weekly* tax forever; the real-gap catch was a *one-time* win already banked. If a real conditional-skip CI gap ever needs catching, it won't come from repo-cos now — flag it another way.
+
+## Next step — the verifier is 2026-08-03
+Next Monday's digest tests BOTH 07-27 fixes at once:
+1. **#170:** homelab-talos should scan `origin/trunk` (fresh) — no more re-proposing merged work, no stale line refs. Confirm the run log shows `fresh-ref (origin/<branch>)` per repo.
+2. **#171:** the clawgate `pgstore` + devrc optional-dep conditional skips should NOT reappear.
+If clean → the instrument has been meaningfully de-noised over 3 weeks and the marker/skip signals are trustworthy. If STILL mostly noise → the deeper move (deferred twice now, deliberately) is **down-weighting the string-match signals** (`marker`/`skipped_test`) relative to `churn`/`large_file`/`stale_lock`. Don't do it preemptively.
+
+## Loose ends (not acted on, low priority)
+- 07-20 #4 Tekton placeholder secrets (`github-app.enc.yaml`) — a REAL `TODO` blocked on **Zach** creating the org-level GitHub App. Not agent-dispatchable; a genuine reminder, left un-dismissed on purpose.
+- `kubeclaw` exclusion gap: bare `~/workspace/kubeclaw` is a THIRD kubeclaw repo in `DEFAULT_REPOS`, distinct from the paused `kubeclaw-cloud`/`kubeclaw-embed`. If the whole family is paused, exclude bare `kubeclaw` too (surfaced 07-20 #5, not yet excluded).
+
+## How to verify
+```bash
+cd ~/workspace/devrc && git log --oneline -3   # expect fbf5358 (#171), 359e0c1 (#170)
+grep -n "_is_conditional_go_skip\|resolve_scan_root\|scan_repo_fresh" scripts/repo-cos/prescan.py
+nix-shell -p 'python3.withPackages(p:[p.pytest p.requests p.psycopg2])' --run 'python -m pytest scripts/repo-cos/tests -q'   # 257
+python scripts/repo-cos/scan.py --show-exclusions   # 43 dismissed
+# prove fresh-ref scanning + untouched tree:
+nix-shell -p 'python3.withPackages(p:[p.requests])' --run 'python scripts/repo-cos/scan.py --no-llm --repos "$HOME/workspace/homelab-talos" 2>&1 | grep -i "fresh-ref\|fallback"'
+git -C ~/workspace/homelab-talos worktree list   # no leftover /tmp/repo-cos-wt-*
+```

--- a/claudedocs/handoff-task-spec-drafter-2026-06-24.md
+++ b/claudedocs/handoff-task-spec-drafter-2026-06-24.md
@@ -1,0 +1,62 @@
+# Handoff: the task-spec drafter + the 10x productivity thread — 2026-06-24
+
+**Repo/threads:** spans `devrc` (harness), `civit/datapacket-talos` (ADS, A-1), `homelab-talos`/`ZacxDev/homelab-infra` (the drafter agent). The living ledger is `~/.claude/skills/close-the-loop/STATE.md` (read its START HERE first — it's current as of this handoff). This doc is the session capture.
+
+---
+
+## Copy-paste kickoff for the next session
+> Continue the productivity / task-spec-drafter thread. Read first: `devrc/claudedocs/handoff-task-spec-drafter-2026-06-24.md` and `~/.claude/skills/close-the-loop/STATE.md` (START HERE). The deep-context task-spec drafter is LIVE in SHADOW as a DeepSeek-V4-Pro kubeclaw agent on the homelab cluster, verified producing good cards. The next move is to accumulate a few daily shadow runs, read them, and graduate shadow→live. Don't rebuild — verify and graduate. App Blocks *execution* is handled in other sessions; don't touch it.
+
+---
+
+## What this thread is (the reframe that matters)
+Started as "build productivity commands," but the real finding drove a reframe:
+- **Opt-in commands don't get adopted** (measured: a week after building `/analyze-service`/`/find-session`/`/ux-audit`/`/audit-pr`/`/handoff`, only `/find-session` saw real use; the audit ritual was still hand-typed ~51×/wk). **"Remember to type the command" is itself an input that fails.**
+- So the leverage layer is **autonomous (fires on its own)**, not opt-in. Zach's directive: *"treat all my input as a failure of the system to figure out the right next step."*
+- Then: execution is **already** autonomous (clawgate auto-approve handles most tasks). So the bottleneck moved upstream to **NEW-TASK SPECIFICATION**. **10x = autonomously verifying + triaging inbound into decision-ready cards Zach adjudicates, instead of authoring specs himself.** That is the task-spec drafter.
+
+## THE MAIN DELIVERABLE — the deep-context task-spec drafter (LIVE, SHADOW, VERIFIED)
+**Canonical implementation = a kubeclaw OpenClaw agent on the HOMELAB cluster, DeepSeek V4 Pro via OpenRouter.** Runs off Zach's Claude subscription AND off civitai prod, while keeping the deep-context tool-use VERIFY (the value vs a tools-less classifier).
+- **Location:** `ZacxDev/homelab-infra` → `clusters/homelab/apps/agent-pods/task-drafter/` (helmrelease, rbac-readonly, trigger-cronjob, trigger-configmap=`trigger.py`, SOPS secret, README). Chart `kubeclaw` 0.5.2, image `ghcr.io/zacxdev/openclaw-image:2026.6.1` (public GHCR, no pull secret), model `openrouter/deepseek/deepseek-v4-pro`.
+- **The loop:** daily CronJob `task-drafter-trigger` @ 13:00 America/Winnipeg → fetch ClickUp "To Schedule" view (`6-901111220963-1`) → **delta-scope** (PVC state, only new/changed) → POST each to the agent gateway → agent runs ENRICH→VERIFY (git over mounted `civitai/civitai` read-only + ClickUp; `gh` PR-search NOT yet authed)→CORRELATE→CLASSIFY→DRAFT one decision-ready JSON card → trigger applies the deterministic `safety_gate()` post-processor (security/money/destructive → force NEEDS-DECISION) → routes action-worthy cards (TASK/NEEDS-DECISION/VERIFY/DUPLICATE/safety-flagged; drops already-done/stale/FYI) to clawgate.
+- **Where it surfaces:** **SHADOW now → logs only** (`kubectl -n devpod-task-drafter logs job/<trigger>`). When live (`CLAWGATE_MODE=on` + add `CLAWGATE_HOOK_TOKEN` to the secret) → ONE `type:"permission"` digest card per daily run to **clawgate** (`/api/send`, `192.168.50.250:30302`) = a card on Zach's phone listing the action-worthy tickets with their drafted goal/recommendation.
+- **VERIFIED 2026-06-24** (read the live shadow cards): DeepSeek V4 Pro produces **Opus-tier** verification — real `file:line` + commit SHAs, git-log checks, ticket correlation (duplicate-of/adjacent-to), honest limits. **Critically it shows the judgment Haiku LACKED** — on the Merch+Blue-Buzz ticket it self-chose NEEDS-DECISION and flagged the payments risk on its own (Haiku confidently mis-drafted these; needed the gate to save it). It's the keeper.
+- **Caveats:** ~6 min/ticket (fine for daily delta of a handful; the 25-ticket first-run is ~2.5h); `gh` not authed in-pod (wire `GITHUB_TOKEN` for PR-search); real DeepSeek $/ticket not yet measured (metered OpenRouter — check usage); the safety gate **over-fires** (≈9/10 → NEEDS-DECISION on incidental keywords), so today the win is *faster decisions* (pre-verified glance), not auto-dispatch — tune gate false-positives later to recover auto-dispatch on the safe class.
+- **A second prototype exists** in shadow: `devrc/scripts/task-spec-drafter/` (Haiku via `claude -p` on Zach's subscription, local systemd timer). **Retire it** once the homelab/DeepSeek one proves out — it's superseded.
+
+## What else shipped this arc (the infra focus-shield — funds the above)
+- **ADS alert auto-investigation** (`civitai/talos-infra` PR #162 + #163, both MERGED + VERIFIED on real traffic). Inverted the deviation-gate so recurring known alerts auto-investigate instead of staying silent; allowlist now `MongoDisk*`, `CivitaiDpProdHighLatency`, `CivitaiDpProdUpstreamTimeout` (the operator dropped the Redis ones via `e0a449558`, retuning them instead). Confirmed firing on real alerts, 0 errors, conservative on Draft-PRs.
+- **Rules-layer cut** (Algorithm pass): `~/.claude/RULES.md` 331→90L, `PRINCIPLES.md` 60→8L, BOTH hosts. Reversible via the `.bak-20260616-2049*` files.
+- **auto-audit-on-push hook** (`devrc/githooks/`, shadow/flag-off) — auto-runs `/audit-pr` on feature-branch push. Does NOT fire in `datapacket-talos` (it pins its own hooksPath). Opt-in install.
+- Productivity commands (`/analyze-service`, `/find-session`, `/ux-audit`) + the standing "subagent+tests+PR" CLAUDE.md rule, both hosts — but see the adoption verdict above (mostly unused; don't invest more here).
+
+## Ranked next steps
+**UPDATE 2026-06-24 (graduation session): #1, #2, #3 are DONE.** See STATE.md START HERE for the full record.
+1. ✅ **GRADUATED shadow→LIVE** — live cluster patched (`CLAWGATE_HOOK_TOKEN` in secret + `CLAWGATE_MODE=on` on cronjob); send path verified end-to-end (homelab pod → clawgate `/api/send` HTTP 200 + a labeled test card landed). Nothing auto-fires until the daily 13:00 Winnipeg cron. **Card quality re-verified** (5 fresh cards from the live first-run, all with real file:line citations + correct self-chosen NEEDS-DECISION judgment). **Caveat:** live kubectl edit, NOT yet mirrored to homelab-infra trunk — safe because agent-pods Flux is operator-suspended; commit to trunk for durability when convenient.
+2. ✅ **`gh` PR-search already works in-pod** (gh 2.93.0, authed as `CivitaiDevOpsAgent`, `gh search prs` returns results) — wiring done; only a prompt nudge left so VERIFY actually calls it. **$/ticket MEASURED: $0.027** (n=9 live tickets; median $0.026) → ~$0.11/day delta. ~5× cheaper than Haiku, ~21× cheaper than Opus.
+3. ✅ **Retired** the `devrc/scripts/task-spec-drafter/` Haiku prototype — systemd `.timer` disabled+unlinked (no longer double-triages on the Claude subscription); scripts remain on disk.
+4. **Tune the over-firing safety gate** (incidental-keyword false-positives) to recover auto-dispatch on the genuinely-safe class — only worth it once the live soak shows it matters. **Plus:** finding — shadow cards are NOT persisted (only `processed.json`), so clawgate IS the review surface; and the ~25-ticket backlog the first-run baselined will NOT surface (trickle-only going forward) unless you run an on-demand live backlog pass (reset `/state/processed.json` → manual job with MODE=on; ~$0.68, ~2h).
+
+## Open loose ends (not the lever — route/decide when convenient)
+- **A-1 spine-controller crashloop (civitai dp-1):** Flux image-automation auto-shipped broken **v2.17.3** (the whole v2.17.x line is broken — Kiota serializer bug in `civitai/civitai-spine-controller`, `WorkerRegistrationManager.cs:589`). Degraded-not-down (old v2.16.15 still serving). Manual rollback gets re-bumped by Flux (semver `>=1.0.0`). **Handoff ready:** fix-forward v2.17.4 (register the JSON serializer) OR constrain the ImagePolicy semver. **Needs the source-repo owner.** Bigger systemic finding: **image-automation has no health gate** — it'll keep auto-shipping broken tags. Candidate loop.
+- **Homelab infra findings (surfaced during the deploy):** `openebs-hostpath` provisioner is BROKEN (logs provisioned, never creates the dir → PVCs hang; used `local-path` instead); `.sops.yaml` had 10 rules silently stripped in the working tree pre-session (caught + restored additive-only — worth checking why).
+- `agent-pods` Flux Kustomization on homelab is operator-SUSPENDED (~37 agents); the task-drafter was deployed via direct `kubectl apply` matching the committed trunk manifests — Flux adopts it cleanly when you resume agent-pods.
+- The `kubeclaw-agents` SKILL.md (`datapacket-talos/.claude/skills/`) is civitai-cluster-scoped; the homelab task-drafter reuses the pattern but is NOT in its "Existing agents" table by design. If folding in homelab notes later, the new gotchas are: deepseek-v4-pro works on image `2026.6.1` (Gotcha #4 cleared), and homelab's `openebs-hostpath` is broken (use local-path).
+
+## Re-entry / verify commands
+```bash
+# the drafter's shadow cards (homelab):
+export KUBECONFIG=/home/zach/workspace/homelab-talos/homelab-kubeconfig
+kubectl -n devpod-task-drafter get pods,cronjob,jobs
+kubectl -n devpod-task-drafter logs job/<latest-trigger-job>            # the one-line outcomes
+kubectl -n devpod-task-drafter logs <agent-pod> -c openclaw-log-tailer  # the full JSON cards
+# fire a run on demand:
+kubectl -n devpod-task-drafter create job --from=cronjob/task-drafter-trigger td-manual-$(date +%s)
+
+# civitai prod (ADS, A-1):  export KUBECONFIG=/home/zach/workspace/civit/datapacket-talos/prod-kubeconfig
+```
+
+## Gotchas
+- Civitai prod cluster default context `admin@civitai-talos` has a STALE CA — use `KUBECONFIG=.../datapacket-talos/prod-kubeconfig` (context `admin@civit-datapacket-talos`).
+- The drafter's "$/ticket" Haiku figures earlier in STATE.md were the API-LIST-PRICE equivalent (Zach's `claude -p` runs on his Claude SUBSCRIPTION, not a metered key) — the real cost there was subscription quota. The homelab/DeepSeek path is genuinely metered OpenRouter (the whole point).
+- "Verify don't assume" bit twice this session (the A-1 diagnosis was inverted; a cross-source incident "correlation" was a false merge) — re-verify diagnoses against live state before acting.

--- a/claudedocs/initiatives-agent-proposal-2026-07-24.md
+++ b/claudedocs/initiatives-agent-proposal-2026-07-24.md
@@ -1,0 +1,228 @@
+# Initiatives Agent — Proposal (containerized full-capability agent + sidebar chat)
+
+**Date:** 2026-07-24
+**Status:** Proposal for review. READ-ONLY research; nothing built. `claudedocs/` is untracked — no PR, no code change.
+**Author:** research + synthesis pass (Claude).
+
+---
+
+## A. Executive summary + recommendation
+
+Build the **initiatives agent** as an **OpenClaw agent devpod, deployed by the existing `kubeclaw` Helm chart, driven and gated by `clawgate`, and reached through a sidebar chat embedded in the initiatives viewer** — *reusing the `support-agent` operator-chat pattern that clawgate has already re-implemented as a self-hosted service.* The agent's "brain" is not rebuilt: the initiatives **Postgres store** (`initiatives.latest`/`current`/`recaps`) and the pure **`route()`** matcher are exposed to the agent as an **MCP server** (`query_initiatives`, `route_signal`, `read_handoff`, `get_recap`, plus the *mutating* `write_handoff`/`update_next_step` and `dispatch_task`). Reads/routing run autonomously; every **state mutation and every dispatch is gated through clawgate** — either as a durable Task card (`POST /api/tasks`) that you tap "Dispatch" on, or as a blocking `agent_checkpoint` that returns your approve-with-comment steering to the agent.
+
+**Runtime pick: openclaw-container via kubeclaw — NOT crabbox, NOT a from-scratch runtime.** Rationale in one line: crabbox is a *CI/test-execution lease broker* whose own docs say "do not use it as an isolation boundary" and which is built for ephemeral hermetic test runs, not a persistent interactive agent; the openclaw devpod is the runtime clawgate *already* provisions (via the kubeclaw chart's Helm-SDK path), so choosing it means the initiatives agent inherits clawgate's dispatch + checkpoint + chat plumbing for free instead of re-earning it. The one real weakness of that runtime — a plain container running as root with no egress policy — is closed with **modern best-practice hardening** (NetworkPolicy egress allowlist, file-based scoped credentials to dodge the known strip-env gotcha, and optionally a Kata/gVisor RuntimeClass), which matters here because the agent's threat model is **prompt-injection-driven tool misuse** (it triages *untrusted* inbound mail/proposals), not hostile multi-tenant code execution.
+
+**Headline architecture:** `initiatives store + route()` → **initiatives-MCP** (read tools autonomous; write/dispatch tools gated) → **OpenClaw devpod** (kubeclaw) → **clawgate** (task cards + `agent_checkpoint` approvals + existing agent-chat) → **sidebar chat** embedded in `viewer.py`. Reuse over rebuild at every layer.
+
+Confidence: high on the ecosystem mapping and the reuse path (read from source); medium on crabbox internals (public docs only, no local checkout); medium on the exact MCP-registration ergonomics inside openclaw 2026.6.x (the chart ships an MCP configmap but currently defaults it **off** — see the gotcha in §F/§H).
+
+---
+
+## B. Ecosystem findings — the "claw" stack and how the pieces fit
+
+Zach has, in effect, already built most of a self-hosted "dockerized agent + operator chat + approval" platform. The initiatives agent should compose these, not re-derive them.
+
+### B.1 `openclaw-image` — the agent container (the "openclaw container option")
+`/home/zach/workspace/openclaw-image/Dockerfile`:
+- Base `node:22-slim` (Debian); installs `jq git curl openssh-client gnupg python3 tini rclone poppler-utils unzip` **and `gh`** (GitHub CLI).
+- `npm install -g openclaw@${OPENCLAW_VERSION}` (default `2026.6.1`, Renovate-bumped) plus `matrix-bot-sdk`.
+- Runs as **root** (writes `/root/.openclaw/...`). README: "designed to be used with the KubeClaw Helm chart for deploying OpenClaw agent devpods."
+- So this is the *unit of compute*: an npm-distributed OpenClaw agent runtime in a Debian container. It is a **container, not a microVM** — shared host kernel.
+
+### B.2 `kubeclaw` — deploy the agent on k8s (`ZacxDev/kubeclaw`, chart v0.5.2)
+`/home/zach/workspace/kubeclaw/` — Helm chart, "deploying OpenClaw AI agent **devpods**." Key facts from `templates/deployment.yaml` + `values.yaml`:
+- The agent runs as a **`kind: Deployment`, `replicas: 1`** — **persistent, not an ephemeral Job**. `values.yaml`: *"Almost always 1 (the agent holds local session state and a single gateway)."* Backed by a **PVC** (`persistence.enabled`, workspace at `/data/workspace`).
+- Two ports: **`18789`** (the OpenClaw gateway — OpenAI-compatible `/v1/chat/completions`) and **`18790`** (a skills API endpoint the container serves).
+- **Credential model:** an *existing* Secret (`values.yaml` `existingSecret`) with keys `MATRIX_ACCESS_TOKEN, TELEGRAM_BOT_TOKEN, HOOKS_TOKEN, GITHUB_TOKEN, BRAVE_API_KEY, ANTHROPIC_API_KEY, git-ssh-key, …`, delivered via `envFrom`, then **jq-injected** into the OpenClaw config at init. The gateway auth token is **derived**: `GATEWAY_TOKEN = sha256("gw-" + HOOKS_TOKEN)` (deployment.yaml:462) — the exact contract clawgate and support-agent both speak.
+- **`extraInitCommands`** hook runs after secret setup, before the gateway starts — *this is precisely where the strip-env credential-file fix belongs* (see §D.4/§B.6).
+- **RBAC**: `Role`/`RoleBinding`/`ServiceAccount` + an orchestrator `ClusterRole` and a read-only one; the init even sets `kubectl` creds from the pod SA token. So the devpod can be given cluster reach — powerful, and a thing to scope carefully.
+- **MCP**: `values.yaml` has an `mcpServers` block and the chart ships `configmap-clank-task-mcp.yaml` (a typed-task MCP server), **but it defaults OFF** with an explicit note: *"openclaw 2026.6.x rejects the `mcpServers` root key … gateway won't start."* → MCP-tool exposure is designed-for but has a live compatibility caveat to verify (§H).
+- **Isolation posture:** no `NetworkPolicy` in the chart; container runs as root; no `RuntimeClass`. This is the gap best-practice hardening closes (§D, §F.6).
+
+### B.3 `kubeclaw-cloud` = **clankup** (`ZacxDev/clankup`) — the SaaS control plane
+`/home/zach/workspace/kubeclaw-cloud/` — a Go server (`main.go`, `handlers/`, `internal/`) that is the multi-tenant/cloud version of the stack. It ships **`Dockerfile.clawdbot`** (the agent image variant clawgate actually pulls — `harbor.homelab.lan/library/clawdbot:2026.5.7`), plus **`clankup-dspy`** (a DSPy sidecar for cheap typed structured-output, the same pattern support-agent adopted — see §B.5), **`clankup-stt`** (speech-to-text), and **`client-onboarding`**. It provisions/deploys agents and fronts them with an operator chat. *(Detail here is from directory shape + cross-references; a deeper read of `clankup`'s handlers was in flight and not fully folded in — treat clankup specifics as medium-confidence. It is the "productized" sibling of what we're building internally; the internal build does not need clankup, but it is where the DSPy sidecar source lives.)*
+
+### B.4 `kubeclaw-embed` = **clankstack-embed** — embeddable variant
+`/home/zach/workspace/kubeclaw-embed/` — `README.md`, `docker-compose.yml`, `charts/`, plus a **`broker/`** and **`embed/`**. This is the "drop a chat widget into someone else's page" variant: the `embed` is the front-end surface, the `broker` mediates between the embed and the agent runtime. Conceptually the same shape we want (a chat surface embedded in an app), but productized for external embedding; for the internal sidebar we can borrow the *idea* (a broker in front of the gateway) without adopting the whole embed stack.
+
+### B.5 `support-agent` (civitai) — the prior-art blueprint we're copying
+`/home/zach/workspace/civit/support-agent*` (four worktrees of `github.com/civitai/support-agent`). This is an **already-built dockerized agent + operator-chat UI**. Extracted pattern:
+- **Daemon**: pure Node ESM `node:http` server (`src/server.mjs`), one vanilla-JS SPA (`src/ui.html`) + Tailwind; `/sse`, `/metrics`, REST. Multi-stage Dockerfile, **non-root uid 10001**, `tini` PID-1, creds via K8s Secret `envFrom` (never baked). Deployed as a **`Deployment`, replicas 1, `strategy: Recreate`** behind oauth2-proxy + Traefik.
+- **Operator-chat** (`src/lib/operator-chat.mjs`, `operator-agent-client.mjs`, `operator-chat-session.mjs`): a fixed bottom **chatbar** that `POST`s `{message, session_id}` with `Accept: text/event-stream`, consumed in-browser via **`fetch()` + `ReadableStream.getReader()`** (POST-streaming, not `EventSource`). Server side is an **async-generator SSE proxy** to the agent's OpenAI-compatible gateway (`POST ${gatewayUrl}/v1/chat/completions`, bearer `sha256("gw-"+HOOKS_TOKEN)`), re-emitting deltas as `data:{"delta":"…"}`. Conversation persisted to a ClickHouse `ReplacingMergeTree` sessions table (30-day TTL, last-8-turns replay). Gates in order: **same-origin CSRF → per-IP token bucket → operator identity (`x-auth-request-email`) → feature flag → daily budget.**
+- **HITL split**: operator-chat itself is *read-only Q&A* (its only "action" is a suggested dashboard filter emitted as a fenced ` ```action ` block). Real mutations live in a **drafter pipeline**: the agent *proposes* structured JSON, an operator **Approve/Reject/feedback**s in a Tickets tab, and only on Approve does the daemon's `executor.js` `switch(action.type)` execute the outbound action — with **pre/at-execution state-hash guards + idempotency markers**.
+- **Tools = Claude-Code "skills"** (`.claude/skills/<name>/{SKILL.md,query.mjs}` invoked as subprocesses), not MCP/native-function-calling. ~35 skills (freshdesk, postgres-query, clickhouse-query, stripe, discord, …).
+- **Model wiring**: migrated the *structured* drafting step from an OpenClaw agent to an in-pod **DSPy FastAPI sidecar on `localhost:9000`** — commit claims *"~100x cheaper per call, ~30x faster, 100% schema compliance via `dspy.Predict(DraftReply)` typed Literal fields."* Interactive chat stays on the agent gateway; typed extraction goes to DSPy. **Takeaway for us: route()/summary/triage typed outputs → DSPy or a small model; conversational Q&A → the agent.**
+
+### B.6 `clawgate` — the action/approval path (already integrates agent + chat + dispatch)
+Source: `/home/zach/workspace/homelab-talos/containers/clawgate/` (Go, gomponents+htmx, Postgres). Live `clawgate:0.7.67` on the workbench cluster, ns `clawgate`; NodePort **30302**, public `clawgate.zacx.dev` behind **Authelia forward-auth** (not basic-auth). **clawgate is, in effect, Zach's self-hosted re-implementation of the support-agent operator-chat + a dispatch/approval layer.** Concretely it already provides:
+- **Task cards** — a "Task" is a `notes` row (statuses `open → in_progress → ready_for_review → complete`; agents may never set `complete`). Create via **`POST /api/tasks`** (auth: `Authorization: Bearer $CLAWGATE_HOOK_TOKEN`; body `{directory, body, model?, repo?, branch?, privileges?}`; returns `{"id": <int>}`). This is the repo-cos "approve → durable one-tap Dispatch" path.
+- **Agent provisioning** — tapping Dispatch runs `Provisioner.Dispatch` (`internal/agents/provision.go`) which uses the **Helm Go SDK + client-go** to `helm install` the **embedded kubeclaw chart** of the **`clawdbot`** image into a per-agent namespace `devpod-<name>`, then kicks it off with the task body. So clawgate → kubeclaw → openclaw-devpod is a *working, deployed* pipeline today.
+- **Agent chat** — WebSocket `GET /agents/{name}/ws`; server proxies to the devpod gateway `http://<name>-devpod.devpod-<name>.svc.cluster.local:18789/v1/chat/completions` with bearer `sha256("gw-"+HOOKS_TOKEN)`; sessions in Postgres `chat_sessions`/`chat_messages`. Same gateway contract as support-agent.
+- **`agent_checkpoint`** (native tool, `internal/api/agent.go`) — the agent files a checkpoint (summary), which **reuses the permission-request inbox** as an Approve/Deny card, **blocks the agent** (poll 1s, 1h backstop), and returns `{approved, response, comment, guidance}` — i.e. **your approve-with-comment steering is returned to the agent.** This is the blocking human-in-the-loop primitive for risky/mutating steps.
+- **Privilege requests** (`agent_request_privilege`) — a third, non-blocking, human-notified gate.
+- Known contract bug to fix opportunistically: `scripts/mail-actions/clawgate.py` posts `{"title", "body"}` but the server only reads `directory/body/model/repo/branch/privileges` → the `title` is silently dropped (`repo-cos/clawgate.py` gets it right with `{directory, body, repo?, model?}`). Flagged for §H.
+
+### B.7 The initiatives "brain" (built this session) — what we reuse verbatim
+`/home/zach/workspace/devrc/scripts/initiatives/` + `scripts/session-analysis/initiative-scan.py`.
+- **Store** (homelab `mailbox` Postgres, schema `initiatives`; reached via `mail-actions/_db.py` = kubectl port-forward + psycopg2 + DSN-from-secret, needs `KUBECONFIG=$KC_HOMELAB`):
+  - `initiatives.snapshots` (append-only capture headers) + `initiatives.initiative_snapshot` (one row per initiative per snapshot). Columns: `host, repo, slug, title, summary, doc_date, momentum, last_touch, next_step, commits, commits_unknown, merged_prs, open_prs(jsonb), session_count, telem_events, telem_last, current_doc, open_investigations(jsonb), docs(jsonb), recent_messages(jsonb), recent_commits(jsonb)`.
+  - View **`initiatives.current`** = newest row per (repo, slug) across *all* history (keeps recently-dormant "ghosts" — deliberately, for the router). View **`initiatives.latest`** = rows from the *most recent* snapshot only (for the viewer; no ghosts). Plus **`initiatives.recaps`** (`identity, identity_hash, status, status_hash` — a Layer-B LLM qualitative recap cache, LEFT-JOINed on (repo, slug), fail-soft).
+- **Router** `route.py`: `route(signal_text, repo=None, limit=5) -> list[dict]` reads `initiatives.current` and calls the **pure** `rank_matches(...)`, which reuses the scan's `text_tokens`/`slug_tokens`/`best_title_match` scoring (slug_overlap + 0.25·title_overlap; df-uniqueness confidence gate). Returns ranked `{slug, repo, title, score, slug_overlap, title_overlap, matched_tokens, confident}`; `classify(ranked)` → "confident match: <slug>" vs "no confident match — likely new work." **It suggests, never acts.** This is `route_signal` for free.
+- **Recaps** `recap.py`: builds `identity` + `status` recaps via a port-forwarded vLLM (OpenAI-compat) client, hashed for idempotent regen, upserted into `initiatives.recaps`.
+- **Viewer** `viewer.py`: a stdlib `ThreadingHTTPServer` on **port 8899**; routes `/` (HTML), `/healthz`, `/api/initiatives.json` (the embedded JSON the SPA renders), `/api/initiative?repo=&slug=` (per-card detail incl. a live handoff read). Client-side vanilla-JS SPA with a few-second in-process cache. **Minimal** — good for a read view; not a place to bolt an LLM streaming proxy (§F.4).
+- **Scan** `initiative-scan.py`: fuses handoff docs + git + activity telemetry + live tmux into momentum (●active/◐slowing/○stalled), next-step, and the live tmux session; `--json` output; it's what `sync.py` writes into the store.
+
+---
+
+## C. crabbox findings
+
+**What it is (medium confidence — public docs only, no local checkout):** `openclaw/crabbox` is a **remote software-testing / execution *control plane*** in the OpenClaw ecosystem — a Go CLI + optional coordinator that **leases a box, syncs your dirty checkout (rsync), runs a command, streams output, and releases**, with central credential-holding, spend caps, idle expiry, and TTL. Tagline: *"warm a box, sync the diff, run the suite."* Latest public release ~v0.12.0.
+
+Crucially, **crabbox is not itself a sandbox/isolation technology** — it *brokers* other providers. Its docs list providers including AWS EC2 / Azure VM / GCE / Hetzner / **Daytona** (managed, coordinator-brokered), plus direct/delegated: **E2B, Modal Sandbox, Islo, Sprites microVM (SSH), Tensorlake Firecracker, Semaphore CI**. Isolation is whatever the chosen provider gives. Its own README is explicit: *"Do not use it as a replacement for CI, a hostile multi-tenant sandbox, a secrets scrubber, or an **isolation boundary** between mutually untrusted users."* It's positioned for **hermetic test/agent CI evidence** (history, logs, JUnit, screenshots, recordings, PR publishing) via a repo-local **`.crabbox.yaml`** defining warmup/run/cleanup jobs. Defaults seen: idle 30m, TTL 90m, per-lease + monthly spend caps. It sits in an OpenClaw stack sketch as: **mitos** (snapshot-fork microVM engine) → **crabbox** (lease/sync/run) → **crabfleet** (mission control for agent runs).
+
+**Verdict for this proposal:** crabbox is the wrong *shape* for the initiatives agent. We want a **persistent, interactive, chat-fronted agent that mutates durable state**; crabbox is an **ephemeral, fire-and-forget, hermetic command-runner** aimed at tests and agentic *jobs* — and it disclaims being an isolation boundary. It's an excellent tool for a *different* job (running the repo-cos/verify-agent style hermetic checks, or CI-shaped agent tasks that produce evidence), and worth keeping in mind for that. It is not the runtime for a long-lived initiatives assistant.
+
+---
+
+## D. Modern containerized-agent best practice (2026, cited)
+
+The 2026 consensus, grounded in current sources:
+
+**D.1 Isolation is threat-model-driven; containers are fine for *trusted* code, microVMs for *untrusted* code.** The three tiers ([Northflank](https://northflank.com/blog/how-to-sandbox-ai-agents), [emirb](https://emirb.github.io/blog/microvm-2026/)):
+
+| Tier | Boundary | Boot | Overhead | Use when |
+|---|---|---|---|---|
+| Docker container | Shared kernel (process) | ms | minimal | **Trusted** workloads only |
+| gVisor | User-space kernel (syscall interception) | ms | ~10–30% on I/O-heavy | Compute-heavy agents, cheap upgrade over plain containers |
+| Firecracker microVM | Own kernel in KVM | ~125ms | <5 MiB/VM | **Untrusted code**, multi-tenant |
+| Kata Containers | VMM-backed, OCI-compatible **RuntimeClass** | ~200ms | minimal mem | k8s teams wanting VM isolation without changing workflow |
+
+Repeated guidance: *"For LLM-generated code execution, microVMs (Firecracker, Kata) are the only production-safe isolation layer."* But that's specifically about **executing untrusted/model-generated code**. The initiatives agent runs *curated tools*, not arbitrary attacker code — so the dominant risk is **prompt-injection → tool misuse**, and the highest-leverage controls are egress + credential scoping + HITL, with a RuntimeClass as a cheap defense-in-depth add.
+
+**D.2 Egress/network control is the single most-emphasized control.** [Northflank](https://northflank.com/blog/how-to-sandbox-ai-agents): *"Block all outbound connections by default. Whitelist only required API endpoints."* Plus DNS restriction and segmentation from prod. For k8s that's a **default-deny `NetworkPolicy`** + an allowlist (the store's port-forward target, the model endpoint, clawgate, GitHub).
+
+**D.3 Ephemeral vs persistent.** ([slavadubrov 2026](https://slavadubrov.github.io/blog/2026/05/26/ai-agent-runtime/)) Ephemeral = fresh sandbox per task, strongest isolation, pays cold-start; persistent (pause/resume, snapshot/fork) = warm cache for multi-hour/repeated sessions. **"The session must live *outside* the worker process"** — an append-only event log so a restarted worker can `wake(sessionId) → resume`. For a chat assistant, persistent-with-external-session is the right default (which is exactly clawgate's `chat_sessions` in Postgres).
+
+**D.4 Credentials: never expose raw secrets to the model or sandbox.** The Anthropic pattern ([slavadubrov](https://slavadubrov.github.io/blog/2026/05/26/ai-agent-runtime/)): store secrets in a vault, **wire them into the sandbox at init**, and put an **MCP/proxy broker in front that holds the token and never returns it to agent code** — *"`git push` works; `cat ~/.ssh/id_rsa` does not,"* *"the harness is never made aware of any credentials."* This is the general form of Zach's **strip-env gotcha** (`openclaw-exec-sandbox-strips-env`): the openclaw exec sandbox strips secret env from agent-run commands, so write the secret to a **file** at container init (full env, via `extraInitCommands`) and have the tool read the file. Same principle: the tool boundary, not the env, holds the credential.
+
+**D.5 State/memory: the "three-store" default** ([slavadubrov](https://slavadubrov.github.io/blog/2026/05/26/ai-agent-runtime/)): a **checkpoint DB (Postgres)** for graph/tool/approval state at every step; **git** for code/doc-shaped work; **object storage** for large artifacts. We already have Postgres (initiatives store + clawgate) and git (handoff docs) — no new infra needed.
+
+**D.6 Per-agent k8s orchestration: Job-per-run is the textbook pattern, but adopt k8s only if you already run it.** ([slavadubrov](https://slavadubrov.github.io/blog/2026/05/26/ai-agent-runtime/)) One **Job per session** with `activeDeadlineSeconds`, a workspace PVC, an **MCP sidecar**, a RuntimeClass + NetworkPolicy; *"cold-start is too slow for sub-second startup … only adopt Kubernetes for agents if you already operate it."* Zach does → this is the natural fit, and clawgate's per-agent `devpod-<name>` namespace already realizes "per-agent isolation."
+
+**D.7 MCP is the standard tool-exposure interface — and a real attack surface.** The Nov-2025 MCP spec formalized **OAuth 2.1** for remote servers ([WorkOS](https://workos.com/blog/everything-your-team-needs-to-know-about-mcp-in-2026)). But 2026 saw 30+ MCP CVEs; scans found large fractions of public MCP servers with **command injection, SSRF, path traversal, and no auth** ([Wiz](https://www.wiz.io/academy/ai-security/model-context-protocol-security), [CSA best-practices](https://labs.cloudsecurityalliance.org/agentic/agentic-mcp-security-best-practices-v1/)). Implication: our initiatives-MCP must be **local-only (sidecar/cluster-internal, not public), authenticated, input-validated (parameterized SQL), and egress-scoped** — and the *mutating* tools must be gated, not merely exposed.
+
+**D.8 Human-in-the-loop is durable-async, tiered by reversibility.** ([digitalapplied](https://www.digitalapplied.com/blog/human-in-the-loop-escalation-design-ai-agents-2026), [slavadubrov](https://slavadubrov.github.io/blog/2026/05/26/ai-agent-runtime/)) The approval is *"a durable sleep that consumes no compute, not a polling loop"*: persist state as `waiting_for_human`, enqueue a task with a TTL, resume from checkpoint on response; use an **idempotency key** and **hash the proposed action** at interrupt, verify at execution. The ecosystem-native framing ([getclaw](https://getclaw.sh/blog/human-in-the-loop-ai-agents-approvals-2026), *built on OpenClaw*) is a **four-tier model by reversibility/exposure**: **Autopilot (read-only)** → **Batch approval (reversible)** → **One-by-one (expensive/mutating)** → **Human-only (irreversible)**, each request showing *source evidence, expected result, downside if wrong*. This maps 1:1 onto clawgate's primitives (§F.5).
+
+---
+
+## E. Runtime comparison + pick
+
+Framing: "which runtime hosts the initiatives agent?" — kubeclaw (deploy openclaw devpods on k8s) vs the raw openclaw container vs crabbox. These aren't fully mutually exclusive (kubeclaw deploys the openclaw container), so the table compares *the realistic deployment options*.
+
+| Dimension | **openclaw-container via kubeclaw** (recommended) | raw openclaw-container (compose/bare) | crabbox |
+|---|---|---|---|
+| What it is | Helm chart deploying a persistent OpenClaw devpod `Deployment` | The `node:22-slim` OpenClaw image run directly | Lease-broker CLI for ephemeral hermetic runs over pluggable providers |
+| Lifecycle | **Persistent** devpod (session state + gateway) | Persistent, hand-managed | **Ephemeral** lease (idle 30m / TTL 90m) |
+| Isolation (out of box) | Container, root, no NetworkPolicy/RuntimeClass — **must harden** | Same, plus no RBAC scoping | Delegated to provider (E2B/Modal/Firecracker/…); *disclaims* being an isolation boundary |
+| Fit for interactive chat | **Strong** — gateway `:18789`, clawgate already chats to it | Possible, but you rebuild the plumbing | **Poor** — designed for fire-and-forget command runs, not a chat loop |
+| Coherence w/ existing stack | **Highest** — clawgate already `helm install`s this exact chart+image | Low — orphan from the deployed pipeline | Low for this use; good for CI/verify-style jobs |
+| Dispatch + approval | **Free** via clawgate (`/api/tasks`, `agent_checkpoint`) | Build it | N/A (no HITL chat approval model) |
+| MCP tool exposure | Chart supports it (mcpServers/clank-task configmap) — *caveat: default-off on 2026.6.x* | Manual | Not the interface |
+| Credential model | Existing-Secret + jq-inject + `extraInitCommands` (strip-env file fix belongs here) | Manual | Coordinator holds provider creds; not app secrets |
+| Cost/latency | 1 warm pod; ~0 dispatch latency once running | 1 pod | Per-lease cloud spend; cold lease each run |
+| **Verdict** | **Pick** | Rejected (loses the integrated pipeline) | Rejected as the *agent runtime* (right tool for hermetic CI jobs, not a persistent assistant) |
+
+**Pick: openclaw-container via kubeclaw, hardened.** It is the only option that (a) is a persistent interactive runtime, (b) is *already wired* to clawgate's dispatch/checkpoint/chat, and (c) matches best-practice "Job/pod-per-agent with MCP sidecar" once we add the missing NetworkPolicy + RuntimeClass + file-creds. Keep **crabbox in the back pocket** for evidence-producing hermetic *jobs* the initiatives agent might dispatch (e.g. "run the verify gate on repo X"), not as its home.
+
+---
+
+## F. Initiatives-agent architecture
+
+### F.1 Capabilities → design consequence
+The four confirmed capabilities decide the shape: (1) **Q&A over initiatives** (read), (2) **dispatch work** (act), (3) **create/update handoffs & durable state** (mutate), (4) **route & triage incoming** (route). Because it reads *and* mutates *and* dispatches *and* ingests untrusted signals, both the **runtime** (§E pick) and a **safe action/approval path** (§F.5) are load-bearing.
+
+### F.2 The brain is already built — expose it as an MCP server (`initiatives-mcp`)
+A small **local MCP server** (sidecar to the devpod, or cluster-internal service) wrapping the existing Python. No context re-derivation; the agent calls tools. Proposed tools and their exact backing:
+
+| MCP tool | Backing (existing) | Kind | Gate |
+|---|---|---|---|
+| `query_initiatives(repo?, slug?, momentum?)` | `SELECT … FROM initiatives.latest` (+ `attach_recaps`) — as `viewer.py` does | read | autopilot |
+| `route_signal(text, repo?, limit?)` | `route.route()` → `rank_matches` + `classify` | read | autopilot |
+| `read_handoff(repo, slug)` | `viewer.py`'s `/api/initiative` live-doc read (`current_doc`) | read | autopilot |
+| `get_recap(repo, slug)` | `initiatives.recaps` (`identity`/`status`) | read | autopilot |
+| `list_stalled() / momentum_report()` | `query_initiatives` filtered on `momentum` (○/◐) | read | autopilot |
+| `update_next_step(repo, slug, text)` | **new**: write a handoff/`next_step` (state mutation) | mutate | **clawgate `agent_checkpoint`** |
+| `write_handoff(repo, slug, body)` | **new**: create/update a `claudedocs/handoff-*.md` (+ git) | mutate | **clawgate checkpoint** (+ git commit) |
+| `dispatch_task(directory, body, repo?, model?)` | **existing**: `POST clawgate /api/tasks` (repo-cos pattern) | act | **clawgate Task card → human Dispatch** |
+
+What's **missing** and must be built: the two write tools (`update_next_step`, `write_handoff`) — the store is currently *write-only via `sync.py` from the scan*; there's no human/agent-facing mutation path yet. These should write handoff docs (the durable source of truth the scan already reads) and/or the store, and must be **idempotent + hashed** (§D.8). `dispatch_task` already exists as a contract; the agent just needs the token (file-based, §D.4).
+
+Note the **MCP compatibility caveat** (§B.2/§H): the kubeclaw chart's `mcpServers` is default-off because openclaw 2026.6.x rejected the config key. Verify the current openclaw MCP-registration syntax before committing to in-agent MCP; the fallback is the **support-agent "skills" convention** (`SKILL.md` + `query.mjs` subprocess) which needs no gateway MCP support and is proven in production.
+
+### F.3 Model wiring
+Two-speed, copying support-agent: **conversational Q&A** on the OpenClaw agent gateway (interactive, tool-calling); **typed/structured steps** (route classification, triage tagging, recap regen) on a **small model or a DSPy sidecar** (`clankup-dspy` is the existing source) — cheaper, schema-compliant, no agent-loop overhead. `route()` itself is *deterministic* already (no LLM), so triage is: `route_signal` (free, deterministic) → if `classify` says "new work," an LLM step drafts the new-initiative stub for approval.
+
+### F.4 Sidebar chat — reuse, don't rebuild on the stdlib viewer
+`viewer.py` is a deliberately minimal stdlib `http.server` (embedded-JSON SPA). **Do not** bolt an LLM streaming proxy, session store, CSRF/rate-limit/budget gates, and WebSocket handling onto it — that's the whole support-agent daemon, and clawgate *already is* that daemon. Two viable options:
+
+- **Option A (recommended, lowest cost): embed clawgate's existing agent-chat as the sidebar.** clawgate already has a dockerized-agent + operator-chat + dispatch + checkpoint, all deployed. Provision one long-lived agent ("initiatives") in clawgate, give its devpod the `initiatives-mcp` tools, and embed clawgate's chat panel (`/agents/initiatives/...`) as a sidebar iframe/panel in the viewer. The viewer stays a read view; the chat is clawgate. Cross-origin/auth handled by Authelia (public) or LAN-trusted. **This reuses the most and builds the least.**
+- **Option B (if a tighter in-app feel is needed): a thin support-agent-style broker beside the viewer.** A small Go/Node service (the `kubeclaw-embed` `broker` shape) that does the SSE async-generator proxy to the devpod gateway + a Postgres `chat_sessions` table + the support-agent gate stack, served as a sidebar `POST /chat` next to `viewer.py`. More work; only choose it if embedding clawgate's UI is too coupled.
+
+Recommendation: **start with Option A** (validate the whole loop against clawgate's proven chat), and only graduate to Option B if the in-app UX demands it.
+
+### F.5 Action/approval path (the guardrail, explicit)
+Map the four-tier reversibility model (§D.8) onto clawgate's primitives:
+
+- **Autopilot (read-only):** `query_initiatives`, `route_signal`, `read_handoff`, `get_recap`, momentum/stalled reports. No gate. (Sample-audit periodically.)
+- **One-by-one / checkpoint (mutating state):** `update_next_step`, `write_handoff` → the agent calls **`agent_checkpoint`** with a summary + the proposed diff; it **blocks** until you Approve/Deny-with-comment; your comment steers it; the request + outcome are written to the task thread. Use idempotency-key + action-hash so a resumed approval applies exactly once.
+- **One-by-one / task card (dispatching work):** `dispatch_task` → **`POST /api/tasks`** creates a durable card (evidence in the body); *nothing runs* until you tap **Dispatch**, which `helm install`s the worker devpod. This is the repo-cos pattern, already deployed.
+- **Human-only (irreversible):** the agent never does these — no prod changes, no deletes, no secret rotation. It can only *propose* (a task card).
+
+Each gated request must show, per getclaw's rule, **source evidence, expected result, and downside if wrong** — trivially satisfied because the checkpoint/task body carries the initiative slug + the `route()` evidence + the proposed change.
+
+### F.6 Security posture (concrete)
+The agent can act on Zach's infra and ingests untrusted mail/proposals → prompt-injection is the primary threat. Controls, in leverage order:
+1. **Gate all mutation/dispatch through clawgate** (§F.5) — the single most important control; a hijacked prompt still can't mutate/dispatch without a human tap.
+2. **Default-deny `NetworkPolicy`** on the `devpod-initiatives` namespace, allowlisting only: the mailbox-Postgres port-forward target, the model endpoint (OpenRouter/vLLM), clawgate (`:30302`/svc), and `github.com`. Closes the SSRF/exfil path (§D.2, §D.7).
+3. **File-based, scoped credentials** via `extraInitCommands` (§D.4) — dodge the strip-env gotcha; the `GITHUB_TOKEN` and clawgate hook token go to `0600` files, not agent-run env. Scope the GitHub token to the repos the agent may touch; scope the DB role to `SELECT` on `initiatives.*` + `INSERT` on what writes need.
+4. **MCP server is local-only** (sidecar/cluster-internal, never public), authenticated, **parameterized SQL** only (the store helpers already use psycopg2 params) (§D.7).
+5. **RuntimeClass upgrade (defense-in-depth):** run the devpod under **Kata or gVisor** RuntimeClass. Cheap, and it contains a container-escape from any tool bug. Not strictly required (no untrusted *code* execution), but low-cost insurance given the agent's reach.
+6. **Scope the pod's k8s RBAC** — the chart can grant an orchestrator ClusterRole; for the initiatives agent grant *read-only* (or none) cluster RBAC. It doesn't need to touch the cluster; it needs the store + clawgate + git.
+7. **Reuse support-agent's chat gates** if Option B: same-origin CSRF + per-IP token bucket + identity + daily budget.
+
+---
+
+## G. Phased build plan (smallest shippable first)
+
+**Phase 0 — MCP over the store, read-only (Q&A).** Build `initiatives-mcp` exposing `query_initiatives`, `route_signal`, `read_handoff`, `get_recap` (thin wrappers over the existing `viewer.py`/`route.py`/recap reads; parameterized SQL; local-only). Wire it to a clawgate-provisioned "initiatives" devpod. *Ship = you can chat "what's stalled / where did I leave clawgate" and get grounded answers.* No mutations, no new risk.
+
+**Phase 1 — routing/triage.** Add `route_signal` into a triage flow: feed an inbound signal (a mail subject, a repo-cos proposal) → `route()` → confident match vs new-work; the agent *proposes* (in chat) where it belongs. Still read-only (proposal only). *Ship = "triage this idea" returns the right initiative + evidence.*
+
+**Phase 2 — dispatch via clawgate (gated action).** Add `dispatch_task` → `POST /api/tasks`. Agent drafts a task body with evidence; a **card** appears in clawgate; you tap Dispatch. *Ship = "kick off work on the stalled X initiative" produces a one-tap card.* (Fix the `title`-field contract bug while here.) Credentials become file-based here.
+
+**Phase 3 — state mutation via checkpoint (gated mutate).** Add `update_next_step` + `write_handoff`, each guarded by `agent_checkpoint` (blocking approve-with-comment) + idempotency/action-hash + a git commit for handoff writes. *Ship = "update the handoff for X with what we just decided" → checkpoint card → approve → handoff written.* This closes the loop: the agent maintains its own durable memory under your approval.
+
+**Phase 4 — harden + embed.** NetworkPolicy egress allowlist, scoped RBAC, RuntimeClass (Kata/gVisor); embed the clawgate chat as the viewer sidebar (Option A). *Ship = the sidebar chat in the initiatives app, secured.*
+
+Each phase is independently useful and independently reversible; Phases 0–1 add no mutation risk, Phases 2–3 add risk only behind a human tap.
+
+---
+
+## H. Open questions / risks for Zach
+
+1. **MCP vs skills for tool exposure.** The kubeclaw chart ships an MCP configmap but defaults it **off** because openclaw 2026.6.x rejected the `mcpServers` root key. Do you want to (a) verify/patch the current openclaw MCP-registration syntax and use real MCP, or (b) expose the initiatives tools as support-agent-style **`SKILL.md` + `query.mjs` subprocess skills** (proven, no gateway dependency)? This is the biggest single fork in the plan.
+2. **Sidebar = embed clawgate's chat (Option A) or build a broker beside the viewer (Option B)?** Option A reuses the most (clawgate already has agent-chat + dispatch + checkpoint) but the sidebar is really "clawgate in an iframe." Option B is a tighter in-app feel at the cost of rebuilding the support-agent daemon. I recommend A first — do you agree, or is in-app chat UX a hard requirement?
+3. **Isolation ceiling.** The agent runs curated tools (not untrusted code), single-tenant, on your own infra — so I've prioritized **egress + credential scoping + HITL** over microVM kernel isolation, with Kata/gVisor as cheap defense-in-depth. Is that the right ceiling, or do you want full microVM (Kata RuntimeClass mandatory / crabbox-style ephemeral per-task) from day one? This trades latency/complexity for containment.
+
+Secondary flags: (4) `mail-actions/clawgate.py` posts a `title` field the server drops — fix opportunistically. (5) The store is reached only via a `kubectl port-forward` (mail-actions `_db.py`) needing `$KC_HOMELAB` — a long-lived agent wants a stable in-cluster DB route or a service account, not a port-forward. (6) crabbox internals are medium-confidence (public docs only); if you want it evaluated as the *hermetic-job* runner for agent-dispatched verify/CI tasks, that's a separate small spike.
+
+---
+
+### Sources (best-practice claims)
+- Northflank — [How to sandbox AI agents in 2026](https://northflank.com/blog/how-to-sandbox-ai-agents), [Best code execution sandbox for AI agents 2026](https://northflank.com/blog/best-code-execution-sandbox-for-ai-agents)
+- [Your Container Is Not a Sandbox: MicroVM Isolation in 2026 (emirb)](https://emirb.github.io/blog/microvm-2026/)
+- [Long-Running AI Agent Runtime in 2026 — sessions, sandboxes, checkpoints, harnesses (slavadubrov)](https://slavadubrov.github.io/blog/2026/05/26/ai-agent-runtime/)
+- [Human-in-the-Loop Escalation Design for AI Agents 2026 (digitalapplied)](https://www.digitalapplied.com/blog/human-in-the-loop-escalation-design-ai-agents-2026)
+- [getclaw — Human-in-the-Loop AI Agents: When Approvals Matter in 2026](https://getclaw.sh/blog/human-in-the-loop-ai-agents-approvals-2026) (built on OpenClaw; four-tier approval model)
+- MCP security: [Cloud Security Alliance — Agentic MCP Security Best Practices](https://labs.cloudsecurityalliance.org/agentic/agentic-mcp-security-best-practices-v1/), [Wiz — Understanding MCP Security 2026](https://www.wiz.io/academy/ai-security/model-context-protocol-security), [WorkOS — Everything about MCP in 2026](https://workos.com/blog/everything-your-team-needs-to-know-about-mcp-in-2026)
+- crabbox: [openclaw/crabbox README](https://github.com/openclaw/crabbox/blob/main/README.md), [crabfleet #56 (stack sketch)](https://github.com/openclaw/crabfleet/issues/56)

--- a/claudedocs/initiatives-agent-proposal-eval-2026-07-24.md
+++ b/claudedocs/initiatives-agent-proposal-eval-2026-07-24.md
@@ -1,0 +1,115 @@
+# Adversarial evaluation — Initiatives Agent proposal (2026-07-24)
+
+**Reviews:** `claudedocs/initiatives-agent-proposal-2026-07-24.md`
+**Mode:** READ-ONLY red-team. No code changed.
+**Method:** every load-bearing claim checked against source (clawgate Go, kubeclaw chart, openclaw-image, `scripts/initiatives/`, `mail-actions/`). Citations are `file:line`.
+
+---
+
+## 1. Verdict
+
+**Sound-with-caveats — but needs one architectural revision + one re-scope before any build.**
+
+One-line reason: the factual/ecosystem mapping is unusually accurate (nearly every infra claim verified true to the line), and the reuse thesis is real — **but the proposal's central security claim ("every mutation gated through clawgate; a hijacked prompt still can't mutate/dispatch without a human tap") is overstated: the mutation gate as described is agent-*voluntary*, not structural, and prompt injection (the proposal's own stated primary threat) defeats it.** Separately, the first two phases carry the full persistent-devpod + MCP + cross-cluster-DB weight for capabilities (Q&A + routing) that need none of it, and Phase 0's MCP mechanism is *known-broken on the pinned image*.
+
+I would **green-light the capability**, but **not Phase 1 exactly as architected**. Re-scope Phases 0–1 to a scripted/skills assistant over the existing pure `route.py` + store reads (no devpod), and make the mutation gate structural before Phase 3. Details in §5.
+
+---
+
+## 2. Claims — VERIFIED / COULD-NOT-VERIFY / FALSE-or-OVERSTATED
+
+### VERIFIED true (with evidence)
+
+| Claim | Evidence |
+|---|---|
+| `GATEWAY_TOKEN = sha256("gw-"+HOOKS_TOKEN)` is the exact gateway contract | `kubeclaw/templates/deployment.yaml:462`; `clawgate/internal/agents/gateway.go:20-22` — byte-identical derivation |
+| `POST /api/tasks` reads `directory/body/model/repo/branch/privileges`, returns `{"id"}`, hook-token-gated | `clawgate/internal/api/notes.go:188-227`; route registered `server.go:353` `requireHookToken` |
+| `agent_checkpoint` is a real **blocking** primitive: files into the permission-request inbox, polls 1s, 1h backstop, returns `{approved,status,response,comment,guidance}` | `clawgate/internal/api/agent.go:222-225` (tool def), `431-483` (runCheckpoint), `489-516` (blocking poll), `417-418` (`checkpointPollInterval=1s`, `checkpointMaxWait=1h`) |
+| Checkpoint decision returns approve-with-comment steering to the agent | `agent.go:476-482`, `checkpointGuidance` `533-546` |
+| Provisioner `helm install`s the embedded chart into per-agent `devpod-<name>` ns via Helm SDK + client-go | `clawgate/internal/agents/provision.go:202-244` (`EnsureNamespace`→`ApplySecret`→`helm.Install`) |
+| kubeclaw MCP (`mcpServers`) **defaults OFF** because openclaw 2026.6.x rejects the key ("Unrecognized key: mcpServers") | `kubeclaw/values.yaml:235-241` — verbatim |
+| openclaw-image runs as **root** (no `USER` line), installs `gh`, `openclaw@2026.6.1` | `openclaw-image/Dockerfile` — no `USER` directive; `:15-16` |
+| kubeclaw chart ships **no NetworkPolicy**; `extraInitCommands` hook exists | `templates/` has no netpol file; `deployment.yaml:617` `.Values.extraInitCommands` |
+| `route()` is pure — "suggests, never acts": only SELECTs `initiatives.current`, no writes/dispatch | `scripts/initiatives/route.py:10` (docstring), no INSERT/UPDATE/POST; `load_current()` is read-only `:244-262` |
+| Store is reached **only** via kubectl port-forward with homelab kubeconfig | `scripts/mail-actions/_db.py:4-6` ("lives in the homelab cluster… only reachable in-cluster ClusterIP `mailbox-postgres:5432`"), `:101` port-forward; `viewer.py:44,77-78` |
+| The `title`-field bug is real | `mail-actions/clawgate.py` sends `{"title","body"}`; server ignores `title` (`notes.go:189-199` reads only directory/body/model/repo/branch/privileges) → title dropped, body kept. `repo-cos/clawgate.py` `post_task` sends `{directory, body, repo?, model?}` correctly |
+| A **task-less** long-lived agent is a supported clawgate concept | `clawgate/internal/api/agents.go:568` (`note_id` optional), comments at `:907-915` ("a task-less agent (NoteID nil)") |
+| Native tools (incl. `agent_checkpoint`) are available **in interactive chat**, not just kickoff | `agent.go:232-234` ("used by… every interactive chat turn"), `270-277` (`AgentToolDispatch`… "Used by both the kickoff and the interactive chat") |
+
+**This is a strong record.** The proposal clearly read the source; I found no fabricated infra facts.
+
+### COULD-NOT-verify (flagged honestly by the proposal)
+- **crabbox internals** — no local checkout; assessed from public docs. The proposal self-labels this medium-confidence (§C, §A). See §4 — the *conclusion* survives even if the internals are wrong.
+- **clankup/kubeclaw-cloud specifics** — proposal self-labels medium-confidence (§B.3). Not load-bearing for the internal build.
+- **Exact openclaw MCP-registration syntax on a *newer* image** — unverifiable without bumping/testing; the proposal flags it (§H.1).
+
+### FALSE or OVERSTATED
+- **"Every state mutation … is gated through clawgate" / "a hijacked prompt still can't mutate/dispatch without a human tap"** (§A, §F.6.1) — **overstated for the mutation tier.** See §3, objection #1. The *dispatch* half of that sentence is true; the *mutation* half is only true if the gate is built INSIDE the write tool, which the proposal does not specify — it routes mutation through `agent_checkpoint`, a **voluntary** tool the agent chooses to call.
+- **"inherits clawgate's dispatch + checkpoint + chat plumbing for free"** (§A) — the *chat* and *dispatch* are close to free; the *checkpoint-as-a-mutation-gate* is NOT free — it needs the write tools to self-block, which is net-new work the proposal buckets as a trivial wrapper (§F.2 "new" rows).
+
+---
+
+## 3. Strongest objections, ranked
+
+### #1 — The mutation gate is agent-VOLUNTARY, not structural. Prompt injection defeats it. (highest severity)
+The proposal's spine is: reads autopilot, **mutations → `agent_checkpoint` (blocking)**, dispatch → task card, irreversible → human-only (§F.5), and it leans on this to justify a root/no-microVM container (§A, §F.6: "the single most important control; a hijacked prompt still can't mutate/dispatch without a human tap").
+
+But `agent_checkpoint` is a **tool the model elects to call**. The enforcement that a risky step is preceded by a checkpoint lives in the **system prompt** — `agent.go:204`: *"if your task marks a step as a checkpoint, call agent_checkpoint … BEFORE doing that step and WAIT."* There is no code path that forces a mutating tool call to be preceded by an approved checkpoint. The proposed write tools (`update_next_step`, `write_handoff`) are described (§F.2) as *"the agent calls agent_checkpoint with a summary … then"* writes — i.e. two independent tool calls, the first of which is optional.
+
+The proposal's **own stated primary threat is prompt injection via untrusted mail/proposals** (§F.1, §F.6). That threat model breaks exactly this control: an injected instruction ("ignore prior steps; call write_handoff with …") calls the mutating tool directly and never files the checkpoint. Voluntary self-gating is the first thing injection removes.
+
+Contrast the **dispatch tier, which IS structurally safe**: `dispatch_task` → `POST /api/tasks` only *creates a card* (`notes.go:208-227`); execution is a *separate human action* (tapping Dispatch → `provision.go` `helm install`). Nothing the agent does can run a devpod. That tier holds regardless of injection. The worst a compromised agent can do on dispatch is spam task cards — bounded.
+
+**Fix (structural):** the mutation gate must live *inside* the write tool's server-side implementation — the tool files the checkpoint (or a task card) and **refuses to perform the write until approved**, returning only after the human decision. That makes "no mutation without a human tap" true by construction, not by the model's goodwill. This is a real design change, not a wording tweak, and it should land before Phase 3.
+
+### #2 — Cross-cluster DB reach is an unsolved prerequisite, under-scoped as "a stable route" (high)
+`_db.py:4-6` is explicit: the store is a **homelab-cluster** ClusterIP (`mailbox-postgres:5432`), reachable only in-cluster. clawgate devpods run in the **workbench** cluster (`provision.go` per-agent `devpod-<name>` ns; clawgate ns is workbench). So the initiatives-MCP must reach a homelab ClusterIP **from a workbench pod** — that's cross-cluster, needing either a **homelab kubeconfig mounted into the devpod** (a privileged, injectable-agent-held credential), nebula routing to the homelab DB, or exposing the DB. The proposal's gap #5 calls this "a stable in-cluster DB route or a service account" — that phrasing hides that it is **cross-cluster** and that the obvious realization (mount homelab kubeconfig) hands a prompt-injectable pod a homelab cluster credential.
+
+Compounding blast radius: this is the **shared `mailbox` Postgres** — mail-receiver, `mail_actions`, clawgate tasks, and initiatives all live there. Giving an injectable agent any WRITE role on that instance is meaningful. The proposal's mitigation (§F.6.3: "scope the DB role to SELECT on initiatives.* + INSERT on writes") is the *right* control but must be enforced at the Postgres-role level AND the cross-cluster credential to even connect is the actual unsolved prerequisite — not flagged as a Phase-0 blocker.
+
+### #3 — Phase 0's MCP mechanism is known-broken on the pinned image; skills-first is buried as an "open question" (high)
+`values.yaml:238-241` confirms `mcpServers` is default-OFF because **openclaw 2026.6.1** (the image default, `Dockerfile:15`) rejects the root key. Yet §G Phase 0 says *"Build initiatives-mcp … wire it to a clawgate-provisioned devpod"* — i.e. the **first shippable increment presumes a mechanism that does not work on the current image.** The skills-first alternative (support-agent's `SKILL.md` + `query.mjs` subprocess, §B.5, proven in production) is listed only as open-question #1. The plan should *commit* to skills-first for Phase 0 (or gate Phase 0 on a verified/bumped openclaw MCP syntax), not present a phased plan whose first phase rests on a broken key.
+
+### #4 — The full persistent-devpod runtime is premature for Phases 0–1 (YAGNI) (medium)
+By the proposal's own phasing, Phases 0–1 (Q&A + routing) add **zero mutation**. Those capabilities are *already* a deterministic Python surface: `route.py` is pure; `viewer.py`/store reads are read-only. A **non-containerized scripted assistant** — run `route()`/query deterministically, one small LLM call to phrase the answer — delivers Phases 0–1 with **no devpod, no NetworkPolicy, no cross-cluster pod credential, no MCP dead-end**. The heavy openclaw-devpod + clawgate-chat stack is justified *only* by MUTATE + DISPATCH (Phases 2–3). Standing up the persistent runtime to answer "what's stalled?" is enterprise-bloat-first. The simpler path also de-risks objections #2 and #3 out of the early phases entirely.
+
+### #5 — Option A couples the initiatives app to clawgate's release cycle (medium)
+Embedding clawgate's agent-chat as the sidebar (§F.4 Option A) couples the initiatives UX to clawgate's release cadence, Authelia auth, and its Postgres `chat_sessions`. clawgate ships frequently (live `0.7.67`; MEMORY notes concurrent releases + a mutable-tag clobber incident). A clawgate regression or a breaking chat-API change silently breaks the initiatives sidebar. The proposal names "the sidebar is really clawgate in an iframe" (§H.2) but doesn't weigh the coupling/blast-radius. Acceptable for an MVP validation, but state it as a known coupling, and keep Option B (broker beside the viewer) as the decoupling escape hatch.
+
+---
+
+## 4. What it got right / what it missed
+
+**Credit where due (verified positives the proposal doesn't fully claim):**
+- **Self-approval is structurally blocked.** `/api/auto-approve` is `requireSession` (session-gated), NOT hook-token (`server.go:301`), while the devpod holds only the hook token. So a token-holding, injected devpod **cannot approve its own checkpoints**. That's the load-bearing fact that keeps the HITL model meaningful, and it's true. The proposal should lean on this explicitly.
+- The **crabbox rejection is robust to its own confidence gap.** Even if the "not an isolation boundary" claim (from public docs) were wrong, the pick wouldn't change: the rejection also rests on **lifecycle shape** (crabbox = ephemeral fire-and-forget command-runner; the initiatives agent = persistent chat that mutates durable state), which doesn't depend on isolation internals. Sound call; well-reasoned; correctly flagged medium-confidence.
+
+**Missed / understated prerequisites & blast radius:**
+- **The hook token is broad and single.** `requireHookToken` gates `/api/send`, `/api/response/{id}` (GET **and DELETE**), `/api/suggest`, and `/api/tasks` (`server.go:283-357`). Leaking that one token from the injectable devpod lets an attacker spam tasks/suggestions and **read/DELETE pending permission responses** — bounded (no execution, no self-approve) but not nothing. There is no narrower per-scope token; flag it.
+- **Persistent-pod standing cost.** `replicas:1` Deployment + PVC (`values.yaml` persistence) is always-warm; the reconciler (`reconcile.go`) manages status but there's no auto-sleep in the read path. "~0 dispatch latency once running" is true only while warm = always-on cluster + (idle) resource cost. Minor but real; not mentioned.
+- **`route()` morphological-miss limitation** (`polish`≠`polishing`, per the consolidation handoff §Next-steps 3) — the triage flow feeds it raw prose (mail subjects, proposal text), so silent misses are expected. Not a blocker, but the triage phase should expect recall gaps.
+
+**Simpler alternatives it dismissed too fast:**
+- The scripted-assistant path for Q&A+routing (objection #4) — the proposal jumps straight to "full-capability containerized agent" without asking whether the first shippable slice needs a runtime at all. It doesn't.
+
+---
+
+## 5. Concrete recommended changes before any build
+
+1. **Make the mutation gate structural, not voluntary.** The write tools (`update_next_step`, `write_handoff`) must file the approval and **block on it inside the tool implementation**, refusing to write until approved — do not rely on the agent voluntarily calling `agent_checkpoint` first. Add idempotency-key + action-hash as the proposal already says (§D.8). This is the load-bearing fix; it must precede Phase 3.
+2. **Re-scope Phases 0–1 to a scripted/skills assistant, no devpod.** Ship Q&A + routing over the existing pure `route.py` + store reads (skills convention if inside a devpod later, but for 0–1 a plain tool/skill is enough). Stand the openclaw devpod up only at Phase 2 (dispatch) / Phase 3 (mutate), where it's actually earned. This removes the MCP dead-end and the cross-cluster-cred prerequisite from the first shippable increments.
+3. **Commit to skills-first, not MCP, until openclaw MCP is verified.** `mcpServers` is broken on 2026.6.1 (`values.yaml:238-241`). Either pin the plan to the support-agent skills convention (§B.5) or make "verify/patch openclaw MCP syntax" an explicit Phase-0 gate — don't leave the first phase resting on a known-broken key.
+4. **Solve the cross-cluster DB reach explicitly, with a scoped Postgres role, before Phase 2.** Decide the route (nebula to homelab `mailbox-postgres`, or a homelab SA/kubeconfig, or expose the DB) and enforce a `SELECT initiatives.*` + narrow-`INSERT` role at the PG level. Treat "the agent can reach the shared mailbox DB" as a security decision, not plumbing.
+5. **Fix the `title`-field bug in `mail-actions/clawgate.py`** (send `directory`, not `title`) — cheap, correctly flagged, do it opportunistically.
+6. **Name the clawgate-coupling of Option A** as an accepted MVP risk with Option B (broker) as the decoupling exit; pin the clawgate image (no mutable tag) for the sidebar dependency.
+7. **State the two verified security positives** (self-approval blocked via session-gated auto-approve; dispatch tier structurally safe) as load-bearing assumptions — and add a test/guard that auto-approve stays session-only so a future refactor can't silently hand it to the hook token.
+
+---
+
+## 6. Green-light call
+
+- **Capability / direction:** green-light. The reuse thesis is verified and the store/router genuinely is a clean read surface.
+- **Phase 1 exactly as proposed:** **no** — it presumes the MCP-on-devpod stack (Phase 0) that rests on a known-broken MCP key (`values.yaml:238-241`) and an unbuilt cross-cluster DB credential, and it inherits the voluntary-gate framing.
+- **Re-scoped Phase 1** (Q&A + routing as a scripted/skills assistant over the existing pure `route.py`/store reads, devpod deferred to Phase 2): **yes** — ships value with no new runtime risk and de-risks the harder phases.
+
+**Uncertainty I'm flagging:** crabbox internals are unverified (no checkout) — but the pick doesn't hinge on them (§4). The exact openclaw MCP syntax on a *newer* image is untestable here — recommendation #3 routes around it rather than betting on it.

--- a/claudedocs/initiatives-agent-versions-bestpractice-2026-07-25.md
+++ b/claudedocs/initiatives-agent-versions-bestpractice-2026-07-25.md
@@ -1,0 +1,104 @@
+# Initiatives Agent — Version Currency + Containerized-Agent Best-Practice Audit
+
+**Date:** 2026-07-25
+**Scope:** (1) Are we on the latest OpenClaw / kubeclaw / base-image versions? (2) Does OUR initiatives devpod follow current (2026) best practice for containerized AI agents?
+**Method:** Read our baseline from source, then web-verified every version + best-practice claim against live sources (accessed 2026-07-25). Live cluster posture checked against the homelab Talos cluster.
+**Builds on:** `initiatives-agent-proposal-2026-07-24.md` §D and `…-eval-2026-07-24.md`. Where those still hold I cite them; where new evidence changes the picture I flag it (notably: the "MCP is dead on 2026.6.x" claim is **partly wrong** — see §MCP).
+
+---
+
+## VERDICT (one line each)
+
+- **Latest versions?** ⚠ **No, but close.** kubeclaw is on its latest tag (v0.5.2, HEAD==tag). OpenClaw is **~10 patches behind on our own 2026.6 line** (pinned `2026.6.1`; latest 2026.6-line patch is **2026.6.11**, and the npm `latest` tag has moved to **2026.7.1**). `node:22-slim` is a floating tag on a still-supported LTS (EOL 2027-04-30) — currency is fine, reproducibility is not (unpinned).
+- **Best practice?** ❌ **No — three hard gaps for a network-reachable agent.** No egress NetworkPolicy (**#1 gap**, verified none live), `NODE_TLS_REJECT_UNAUTHORIZED=0` disables all TLS verification, and the pod runs as **root with an empty securityContext** (no cap-drop/seccomp/runAsNonRoot; namespace has no Pod-Security labels). Our RBAC + least-priv DB role + credential handling **are** best-practice. Given the threat model (prompt-injection on read-only curated tools, single-tenant), these are all **cheap config fixes**, not a runtime re-platform.
+
+---
+
+## 1. Version currency table
+
+| Component | Ours | Latest (verified 2026-07-25) | Gap | Action |
+|---|---|---|---|---|
+| **OpenClaw** (npm/image) | `2026.6.1` (Dockerfile ARG + image tag) | npm `latest` = **2026.7.1**; latest 2026.6-line patch = **2026.6.11**; beta 2026.7.2-beta.3 | ~10 patch releases behind on our line; 1 minor behind `latest` | **Bump to `2026.6.11`** (same minor line → security/bug fixes, low breaking risk). Treat 2026.7.1 as a **separate, tested** migration — it ships "breaking changes" + a new default model (GPT-5.6/ClawRouter). |
+| **kubeclaw chart** | `v0.5.2` | **v0.5.2** (HEAD==tag; tags: v0.4.0/v0.5.0/v0.5.1/v0.5.2) | **None — we're current** | No bump available. The gaps below are things the **latest chart still lacks** → author them in the chart (it's Zach's repo). |
+| **Base image** | `node:22-slim` (floating) | Node 22 LTS, active-supported; latest 22.x line got a security release ~2026-07-27 (CVE-2026-21717 fixed 22.22.2) | Floating tag → currency OK, **reproducibility not pinned**; Node 22 → Maintenance LTS Oct 2026, EOL 2027-04-30 | Pin a digest for reproducibility; rebuild picks up 22.x security fixes. Plan Node 24 before ~Q1 2027. Consider distroless/non-root base (see §BP-3). |
+| **matrix-bot-sdk** (npm, in image) | floating (`npm install`, unpinned) | n/a | unpinned | Low priority; pin when you pin the image. |
+
+**Adversarial flags on versions I could NOT fully verify:**
+- **Exact "latest stable" OpenClaw is ambiguous across sources.** One aggregator said "2026.6.11 remains latest stable" while the npm `latest` dist-tag reads **2026.7.1**; GitHub's releases page returned **HTTP 403** to the fetcher, so I relied on search snippets + release aggregators (releasebot/newreleases/releases.sh), not the primary release list. Treat "2026.7.1 = latest, 2026.6.11 = latest on our line" as high-but-not-primary-sourced. **Verify locally before bumping:** `npm view openclaw dist-tags` and `npm view openclaw@2026.6 version`.
+- **Whether bumping breaks our config is untested here.** OpenClaw silently reverts a schema-invalid `openclaw.json` to last-good (our chart's `config.onRevert: warn` exists precisely for this). Any bump must be validated with `openclaw doctor --fix` + confirming the gateway starts on the new pin.
+
+---
+
+## 2. Best-practice scorecard (scoring OUR devpod, not the generic proposal)
+
+Threat model (unchanged from the eval, and correct): **prompt-injection → misuse of curated read-only tools**, single-tenant, on Zach's own infra. **Not** untrusted/model-generated code execution. That threat model makes **egress + credential-scoping + non-root/cap-drop** the high-leverage controls and **microVM kernel isolation optional**.
+
+| # | Control (2026 best practice, cited) | What WE do | Verdict |
+|---|---|---|---|
+| BP-1 | **Egress: default-deny NetworkPolicy + allowlist.** "Block all outbound by default; whitelist only required endpoints" — the single most-emphasized agent control; without it a compromised/injected pod can exfiltrate or reach C2 ([Northflank](https://northflank.com/blog/how-to-sandbox-ai-agents), [KodeKloud](https://kodekloud.com/blog/running-ai-agents-safely-inside-kubernetes/), [Calico default-deny](https://docs.tigera.io/calico/latest/network-policy/get-started/kubernetes-default-deny)) | **Nothing.** `kubectl get netpol -n devpod-initiatives` → *No resources found* (verified live). Chart ships no NetworkPolicy template (`ls templates/` — none). Pod can reach anything on the network. | ❌ **Gap #1** |
+| BP-2 | **TLS verification on.** Zero-trust egress assumes verified TLS to the allowlisted endpoints; disabling cert validation invites MITM on model/DB/GitHub traffic. | `NODE_TLS_REJECT_UNAUTHORIZED=0` **hardcoded** in `kubeclaw/templates/deployment.yaml:1058-1059` → every Node process (incl. OpenRouter + GitHub HTTPS) skips cert validation, cluster-wide for the pod. | ❌ **Gap** |
+| BP-3 | **Non-root, drop capabilities, seccomp, restricted PSS.** Run as non-root (USER directive), `cap-drop: ALL`, `allowPrivilegeEscalation:false`, seccomp RuntimeDefault; enforce Pod Security **restricted** profile ([OX Security](https://www.ox.security/blog/container-security-best-practices/), [decryptiondigest hardening checklist](https://www.decryptiondigest.com/blog/container-security-hardening-docker-kubernetes), [Blaxel container-escape](https://blaxel.ai/blog/container-escape)) | Image has **no USER** (runs root); pod `securityContext` is **`{}`** (verified live — no runAsNonRoot, no cap-drop, no seccomp, no readOnlyRootFilesystem); namespace has **no `pod-security.kubernetes.io/*` labels** (restricted profile not enforced — verified live). | ❌ **Gap** (image writes `/root/...` so non-root needs image work; cap-drop/seccomp/no-privesc are free) |
+| BP-4 | **Credentials: never expose raw secrets to the model; scope to least privilege; secrets via env/file at init, tool boundary holds the token** ([slavadubrov runtime](https://slavadubrov.github.io/blog/2026/05/26/ai-agent-runtime/), proposal §D.4) | **Strong.** DB reached with a dedicated **`initiatives_agent` SELECT-only** Postgres role via `MAILBOX_PG_DSN` (helmrelease:83-92); OpenRouter key + DSN via `existingSecret`/`secretKeyRef`, not baked; defensive Claude-cred cleanup in `extraInitCommands`. Read-only agent → no write creds to leak. | ✅ **Meets** |
+| BP-5 | **RBAC least-privilege** (minimal permissions, scope to namespace) ([itsecurityguru](https://www.itsecurityguru.org/2026/05/02/securing-ai-agent-orchestration-enterprise-best-practices-2026/)) | **Strong, tighter than siblings.** Namespace-scoped read-only Role only; `clusterAdmin/orchestrator/clusterReadOnly` all disabled; `infraTools` off (no kubectl/flux in image). Uses the direct in-cluster DB route → needs **no** cluster RBAC (helmrelease:146-157). Deliberately tighter than the task-drafter. | ✅ **Meets** |
+| BP-6 | **RuntimeClass (Kata/gVisor)** for kernel isolation — recommended specifically for **untrusted code execution / multi-tenant**; "acceptable for compute workloads where you control the code" ([Northflank](https://northflank.com/blog/how-to-sandbox-ai-agents), [K8s Agent Sandbox](https://kubernetes.io/blog/2026/03/20/running-agents-on-kubernetes-with-agent-sandbox/), [systemshardening RuntimeClass](https://www.systemshardening.com/articles/kubernetes/runtimeclass-gvisor-kata/)) | **Not used**, and **not cheaply available here**: homelab exposes only the `nvidia` RuntimeClass (verified: `kubectl get runtimeclass` → `nvidia` only). No Kata/gVisor handler installed; adding one to immutable Talos nodes is non-trivial. | ⚠ **Partial / N-A** — correctly skipped given the threat model (curated tools, not untrusted code). Contra the proposal's "cheap defense-in-depth," it is **not cheap on this cluster**. De-prioritize. |
+| BP-7 | **HITL / write-gate** — durable, tiered by reversibility; the gate must be **structural** (enforced in the tool), not agent-voluntary ([digitalapplied](https://www.digitalapplied.com/blog/human-in-the-loop-escalation-design-ai-agents-2026), [getclaw](https://getclaw.sh/blog/human-in-the-loop-ai-agents-approvals-2026), eval §3 #1) | **Phase-1 = read-only** (`AGENTS.md` + skill both hard-pin "strictly READ-ONLY, never write/dispatch/act"; DB role is SELECT-only → structurally cannot mutate). So the write-gate is **enforced by the data plane today**, which is the correct Phase-1 posture. | ✅ **Meets (Phase 1)** — but see §Phase-2 note |
+| BP-8 | **MCP exposure** — MCP is the standard tool interface but a real attack surface; keep tool servers local-only, authenticated, input-validated ([Wiz](https://www.wiz.io/academy/ai-security/model-context-protocol-security), [CSA](https://labs.cloudsecurityalliance.org/agentic/agentic-mcp-security-best-practices-v1/)) | We use the **skills/subprocess convention** (`query.py` invoked from the pinned skill), **not** MCP. Reads are parameterized SQL through the SELECT-only role. | ✅ **Meets** — and the "we *can't* use MCP" rationale is now **partly outdated** (see below). |
+
+### On MCP — correcting the prior proposal/eval
+
+The proposal (§B.2/§H.1) and eval (§3 #3) both state MCP is a **dead-end on 2026.6.x** because openclaw rejects `mcpServers`. Verified today, that's **half right**:
+
+- The rejection is real, but the cause is a **wrong key name**, not missing support. OpenClaw's schema key is **`mcp.servers`** (CLI `openclaw mcp add`), documented at [docs.openclaw.ai/cli/mcp](https://docs.openclaw.ai/cli/mcp); the chart emits the legacy **root** `mcpServers` key, which the schema rejects ("Unrecognized key"). MCP config support requires **app ≥ 2026.3.24** — our `2026.6.1` already qualifies ([issue #32583](https://github.com/openclaw/openclaw/issues/32583), docs).
+- So **native MCP is technically available on our pinned image** — it's a **chart-emission bug** (emit `mcp.servers`, not `mcpServers`), fixable without any OpenClaw bump.
+- **Should we switch to MCP? No — not for this agent.** Newer OpenClaw actually *tightened* MCP security (2026.7.2: "scope MCP server connections to their requesting session"; MCP is a heavily-CVE'd surface per Wiz/CSA). For a **read-only, single-tool** assistant, the skills/subprocess path is simpler and has a smaller attack surface. Keep skills. The correction matters only if **Phase 2** wants richer typed tool exposure — then MCP-via-`mcp.servers` is a real option, not a blocker.
+
+---
+
+## 3. What's new since the 2026-07-24 proposal (verified still-current + additions)
+
+- The proposal's §D best-practice sources (Northflank, slavadubrov, digitalapplied, getclaw, Wiz, CSA) **all still resolve and still reflect current guidance** as of 2026-07-25 — egress-first, threat-model-driven isolation, structural HITL. No reversal.
+- **New:** the **Kubernetes SIG "Agent Sandbox" project** ([kubernetes.io, 2026-03-20](https://kubernetes.io/blog/2026/03/20/running-agents-on-kubernetes-with-agent-sandbox/); [agent-sandbox.sigs.k8s.io](https://agent-sandbox.sigs.k8s.io/)) — a `Sandbox` CRD with **first-class gVisor/Kata** and scale-to-zero for stateful singleton agents. **In development, not GA (March 2026), and explicitly aimed at *untrusted code execution* / multi-tenant** — i.e. **not** what our curated-tool agent needs. Worth tracking, not adopting now. Its *recommended controls* (NetworkPolicy, non-root) are exactly BP-1/BP-3 above and **do** apply to us.
+- **Reinforced consensus:** "no single control prevents container escape — layer overlapping controls"; **default-deny egress is the sustainable starting point**; **PSS restricted profile** as the k8s baseline ([OX Security](https://www.ox.security/blog/container-security-best-practices/), [KodeKloud](https://kodekloud.com/blog/running-ai-agents-safely-inside-kubernetes/)).
+
+---
+
+## 4. Ranked recommendations (highest-leverage first)
+
+Legend: **cheap** = config-only, hours; **involved** = image/infra work. "Phase-2 weight" = matters *more* once the agent gains write/dispatch.
+
+1. **[BP-1 · CHEAP · do first] Add a default-deny egress NetworkPolicy allowlisting only what the agent needs.** This is the #1 gap and the highest-leverage single control. Concrete homelab fix — a `NetworkPolicy` in the chart (or a raw manifest in the helmrelease) on `devpod-initiatives`:
+   - `Egress` allow → **`mailbox-postgres.mailbox.svc.cluster.local:5432`** (the SELECT-only store, via podSelector/namespaceSelector on the `mailbox` ns), **kube-dns UDP/TCP 53**, **OpenRouter** (`openrouter.ai:443` — IP/ipBlock or an egress-gateway/FQDN policy if using Cilium), and **github.com:443** (autoPull clone/fetch).
+   - `Egress` **default-deny everything else**; `Ingress` default-deny (nothing needs to reach it — Q&A is initiated by the agent/gateway, not inbound).
+   - This closes the prompt-injection exfiltration path even for a fully-hijacked pod. **Verify Cilium/Calico FQDN support on the homelab CNI first** — if the CNI can't do FQDN egress, allowlist by resolved IP or route model/GitHub traffic through a known egress IP. *(Flag: I did not verify which CNI/FQDN capability the homelab runs — check before writing the policy.)*
+
+2. **[BP-2 · CHEAP] Remove / scope `NODE_TLS_REJECT_UNAUTHORIZED=0`.** It's hardcoded in the chart deployment (`deployment.yaml:1058`), disabling TLS verification for *all* the pod's HTTPS (OpenRouter, GitHub, DB if TLS). If it exists to tolerate an internal self-signed endpoint, scope it via `NODE_EXTRA_CA_CERTS` (trust that one CA) instead of globally disabling verification. Chart change; benefits every devpod, so coordinate as a kubeclaw PR.
+
+3. **[BP-3 · CHEAP half] Add a restrictive `securityContext` even while staying root-in-image.** Free wins that don't need image changes: `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault`, `readOnlyRootFilesystem` where the workload tolerates it. Then **[INVOLVED]** rebuild the image with a non-root `USER` (the image writes `/root/.openclaw` → needs a writable home relocation) and finally **label the namespace `pod-security.kubernetes.io/enforce: restricted`**. Sequence: securityContext floor now → non-root image → PSS-restricted enforce.
+
+4. **[Version · CHEAP] Bump the pinned OpenClaw `2026.6.1 → 2026.6.11`** (latest patch on our line; security/bug fixes, low breaking risk). Validate with `openclaw doctor --fix` + gateway-starts before rolling. Hold `2026.7.1` as a *separate, tested* migration (breaking changes; new default model — moot for us since we pin `deepseek-v4-pro`, but validate config schema). Confirm exact latest with `npm view openclaw dist-tags` first (aggregator sources conflicted).
+
+5. **[Version · CHEAP] Pin the base image by digest** (`node:22-slim@sha256:…`) for reproducibility; keep a Renovate/periodic rebuild so 22.x security fixes (e.g. the ~2026-07-27 22.x security release, CVE-2026-21717) land. Node 22 is safe until 2027-04-30; schedule a Node 24 evaluation before then.
+
+6. **[BP-7 · Phase-2 weight, INVOLVED — defer until write/dispatch exists] Make the write-gate STRUCTURAL before Phase 2.** Today read-only is enforced by the SELECT-only DB role + pinned prompt — correct for Phase 1. The eval's §3 #1 finding still holds: when Phase 2 adds mutation/dispatch, the gate must be enforced **inside the tool** (server-side blocking approval via clawgate `agent_checkpoint` / task card), **never** by the agent voluntarily calling a checkpoint tool — prompt injection removes voluntary self-gating. Keep dispatch structurally safe (task-card-only; execution is a separate human tap). **This is the control that matters most once capabilities grow.**
+
+7. **[BP-6 · defer / likely skip] RuntimeClass (Kata/gVisor).** Correctly optional for this threat model, and **not cheap here** — homelab has no Kata/gVisor handler (only `nvidia`), and installing one on immutable Talos is real work. Revisit only if the agent ever executes untrusted/model-generated code, or track the K8s Agent Sandbox project as it approaches GA.
+
+**Also opportunistic (from the eval, still valid):** fix the `mail-actions/clawgate.py` `title`-field bug (send `directory`, not `title`); the correction that native MCP is available via `mcp.servers` (chart emits the wrong key) — not needed for Phase 1, relevant if Phase 2 wants typed MCP tools.
+
+---
+
+## Sources (all accessed 2026-07-25)
+
+**Versions**
+- OpenClaw npm latest / calver: [newreleases.io/npm/openclaw](https://newreleases.io/project/npm/openclaw/release/2026.5.7), [npm openclaw versions](https://www.npmjs.com/package/openclaw?activeTab=versions), [releasebot](https://releasebot.io/updates/openclaw), [releases.sh/openclaw](https://releases.sh/openclaw/openclaw)
+- OpenClaw release notes (2026.6.5 MCP tool-result coercion; 2026.7.1 breaking/GPT-5.6/ClawRouter; 2026.7.2 MCP session-scoping, plugin `--force`): [github.com/openclaw/openclaw/releases/tag/v2026.6.5](https://github.com/openclaw/openclaw/releases/tag/v2026.6.5), [openclaw.com.au/updates](https://openclaw.com.au/updates)
+- MCP config key `mcp.servers` + min app 2026.3.24: [docs.openclaw.ai/cli/mcp](https://docs.openclaw.ai/cli/mcp), [issue #32583](https://github.com/openclaw/openclaw/issues/32583), [issue #24008](https://github.com/openclaw/openclaw/issues/24008)
+- Node 22 LTS EOL 2027-04-30 / security: [nodejs.org v22.20.0](https://nodejs.org/en/blog/release/v22.20.0), [nodejs.org July 2026 security](https://nodejs.org/en/blog/vulnerability/july-2026-security-releases), [HeroDevs EOL dates](https://www.herodevs.com/blog-posts/node-js-end-of-life-dates-you-should-be-aware-of)
+
+**Best practice**
+- Egress/default-deny + agent sandboxing: [Northflank — sandbox AI agents 2026](https://northflank.com/blog/how-to-sandbox-ai-agents), [KodeKloud — AI agents in K8s](https://kodekloud.com/blog/running-ai-agents-safely-inside-kubernetes/), [Calico default-deny](https://docs.tigera.io/calico/latest/network-policy/get-started/kubernetes-default-deny)
+- Container hardening (non-root, cap-drop, PSS restricted, distroless): [OX Security](https://www.ox.security/blog/container-security-best-practices/), [decryptiondigest checklist](https://www.decryptiondigest.com/blog/container-security-hardening-docker-kubernetes), [Blaxel — container escape](https://blaxel.ai/blog/container-escape)
+- RuntimeClass / microVM isolation: [systemshardening RuntimeClass](https://www.systemshardening.com/articles/kubernetes/runtimeclass-gvisor-kata/), [K8s Agent Sandbox blog](https://kubernetes.io/blog/2026/03/20/running-agents-on-kubernetes-with-agent-sandbox/), [agent-sandbox.sigs.k8s.io](https://agent-sandbox.sigs.k8s.io/)
+- HITL + MCP security (carried from proposal §D, re-confirmed current): [digitalapplied HITL](https://www.digitalapplied.com/blog/human-in-the-loop-escalation-design-ai-agents-2026), [getclaw approvals](https://getclaw.sh/blog/human-in-the-loop-ai-agents-approvals-2026), [Wiz MCP security](https://www.wiz.io/academy/ai-security/model-context-protocol-security), [CSA agentic MCP best practices](https://labs.cloudsecurityalliance.org/agentic/agentic-mcp-security-best-practices-v1/)
+
+**Live cluster evidence (homelab Talos, 2026-07-25):** `kubectl get runtimeclass` → only `nvidia`; `kubectl get netpol -n devpod-initiatives` → none; pod `securityContext` → `{}`; namespace → no `pod-security.kubernetes.io/*` labels; `initiatives-devpod` pod 4/4 Running. Local: `git -C kubeclaw describe --tags` → `v0.5.2` (HEAD==tag); `NODE_TLS_REJECT_UNAUTHORIZED=0` at `kubeclaw/templates/deployment.yaml:1058`.

--- a/claudedocs/inline-completion-research-2026-07-25.md
+++ b/claudedocs/inline-completion-research-2026-07-25.md
@@ -1,0 +1,186 @@
+# Passive as-you-type completion for the Claude Code TUI — feasibility & recommendation
+
+Date: 2026-07-25
+Author: research pass (deep-research agent)
+Scope: Can a passive, as-you-type, cursor-anchored text-completion popup, fed by a learned frecency model of Zach's own recurring phrases, be delivered to the **Claude Code TUI** (terminal + tmux, X11 + i3, NVIDIA no-compositor, NixOS)?
+
+---
+
+## Executive verdict
+
+**Conditionally NO for the strict spec; conditionally YES for a slightly relaxed one.**
+
+- A truly **cursor-anchored** passive popup driven by the OS input stack (IME candidate window) is **infeasible** on this target. It fails on **two independent, well-sourced grounds**: (1) on X11 the IME candidate/preedit window is *not* cursor-anchored — it is pinned to the bottom of the terminal window by an Xlib/XIM limitation; and (2) a full-screen raw-mode TUI (Claude Code's class of app) **clobbers the terminal's in-application preedit display entirely**, so the as-you-type preview never renders inside the prompt. Confirmed by the fcitx5 maintainer on GitHub Copilot CLI, which is architecturally the same kind of Node full-screen TUI as Claude Code.
+- Shell-native inline autosuggestion (zsh/fish gray-ghost-text, the exact desired UX) works only in the shell's own line editor. It **does not reach the Claude Code prompt**, which is Claude Code's own input widget, not zsh's `zle`.
+- There is **no Claude Code extension point** for as-you-type input suggestions today. Claude Code has built-in inline completion for `/commands`, `@files`, and (since v2.1.217, 2026-07-21) `:emoji:` shortcodes — proving the machinery exists internally — but exposes no custom-completion / input-suggestion plugin API. Hooks (`UserPromptSubmit`) fire *on Enter*, after the fact, not as you type.
+
+**The only path that delivers "passive, zero-invocation, accept-with-Tab" for the Claude Code prompt specifically is a small custom external X11 overlay** fed by the existing keylogger + a frecency engine, injecting accepted text with `xdotool`. It must **give up true dynamic cursor-anchoring** — but it does not need it: Claude Code's prompt box is always at the **bottom of the terminal window**, so a HUD anchored to the bottom of the focused terminal window sits right at the prompt without any per-keystroke cursor-pixel tracking. That is the recommended build. Confidence: HIGH that the IME/off-the-shelf routes fail; MEDIUM-HIGH that the overlay is buildable.
+
+If even the overlay is judged not worth it, the honest fallback is a **faster explicit-invoke inline picker** (still a keystroke), or accepting the status quo (short phrases are cheap to type; that's why espanso lost).
+
+---
+
+## Feasibility matrix
+
+| Mechanism | Passive (0-invoke)? | Works in Claude TUI? | Cursor-anchored? | Survives tmux? | No-compositor OK? | NixOS-packaged? | Effort | Verdict |
+|---|---|---|---|---|---|---|---|---|
+| **(a) IME candidate window** (fcitx5/ibus + typing-booster/presage) | Yes (by design) | **NO** — TUI kills preedit display | **NO** on X11 (pinned to window bottom) | Text yes, preview no | popup is own window, ok | Yes (`i18n.inputMethod`, system-level) | Med (system, relogin) | **FAIL** — dies twice over |
+| **(b) Shell-native autosuggest** (zsh-autosuggestions/fish) | Yes | **NO** — only in shell `zle`, not the TUI prompt | Yes (in shell) | Yes (in shell) | Yes | Yes (HM) | Low | **N/A** — wrong surface |
+| **(c) Claude Code native** (built-in / plugin / hook) | Would be ideal | Would be, if it existed | Would be (it renders inline emoji/slash today) | Yes | Yes | it's the app | n/a | **NOT AVAILABLE** — no input-suggestion API; file FR |
+| **(d) External X11 overlay** (keylogger → frecency → override-redirect HUD → xdotool inject) | **Yes** | **Yes** (independent of TUI) | Near-cursor only (bottom-of-window HUD) | Yes | Yes (plain override-redirect, no transparency needed) | Yes (user-level, HM) | Med (custom build) | **VIABLE** — the recommended path |
+| (e) Explicit-invoke inline picker (fallback) | No (1 keystroke) | Yes | Yes-ish | Yes | Yes | Yes | Low-Med | **FALLBACK only** |
+
+---
+
+## Per-question findings
+
+### RQ1 — Core feasibility, per mechanism
+
+**(a) IME route — FAIL (two independent failures).**
+
+- *Failure 1: not cursor-anchored on X11.* Alacritty's own release notes state the IME popup "is stuck at the bottom of the window due to Xlib limitations" (0.11.0), and only in 0.13.0 did it start *trying* to "not obscure the current cursor line" — i.e. it still isn't placed *at* the cursor; it's a window-relative heuristic. This is an X11/XIM `over-the-spot` limitation, not an Alacritty bug per se; it recurs across X11 terminals. So even in the best case the candidate window would float at the bottom of the terminal, not at the cursor. (Alacritty CHANGELOG / issues #7341, #6313, PR #7883.)
+- *Failure 2: the TUI destroys preedit display.* This is the make-or-break, and there is direct evidence. GitHub Copilot CLI — a Node full-screen raw-mode TUI, the **same architectural class as Claude Code** — makes the terminal's in-application preedit **disappear**. The fcitx5 maintainer's diagnosis (issue github/copilot-cli#735): *"Copilot CLI does cause Gnome Terminal's own preedit to disappear. Other fcitx5's input methods … are also affected."* The cause is the TUI's TTY/raw-mode control conflicting with the terminal's own preedit rendering. This is generic to full-screen raw-mode TUIs, so Claude Code is in exactly the same bucket. The only workaround (disable "Show preedit in application" → force a floating window) is **global** (degrades every GUI app) *and* on X11 that floating window is the non-cursor-anchored bottom-pinned one from Failure 1. Net: you'd type blind or with a mislocated preview — useless for a passive as-you-type suggestion.
+
+  Confidence: HIGH. Two independent, sourced failures; the second is on an app of the same class as the target.
+
+**(b) Terminal-native completion — right UX, wrong surface.** zsh-autosuggestions / fish deliver *exactly* the target feel: inline gray ghost text after the cursor, accept with →/End (and Tab configurable), partial-accept with Alt-→. But this lives in the shell's line editor (`zle`/fish reader). Claude Code draws its **own** prompt input on the alternate screen; the shell reader is not running. So this mechanism cannot touch the Claude Code prompt. It would only help at the bare zsh prompt. Confidence: HIGH (definitional).
+
+**(c) External X11 overlay — the viable route.** Decomposed:
+- *Rendering without a compositor:* fine. The popup is a plain **override-redirect** X11 window; it needs no transparency, shaping, or compositor. Draw a 1-line opaque box (gruvbox to match). The no-compositor constraint is a non-issue here.
+- *Knowing the live prefix:* the existing X11 keylogger already taps every keystroke into `activity.events (source=keys)`. The overlay daemon subscribes to the same keystroke stream (or a local tap of it) to reconstruct the in-progress line in real time; i3 focus tells it the focused window is the Claude Code terminal (only show the HUD then). No new input hook needed — this is strong synergy with existing infra.
+- *Text injection:* `xdotool type` / `xdotool key` synthesizes X key events to the focused terminal window; those are delivered to the PTY as ordinary key input, so Claude Code receives them even though it's in raw mode (raw mode blocks line-buffering, not real key delivery). Works. On Tab/Enter with a suggestion active, replace the typed prefix (backspaces) and inject the full phrase.
+- *The hard part — cursor anchoring:* nobody exposes a TUI's cursor pixel position, and tmux adds a coordinate layer (status bar, pane offsets, scroll). Truly tracking the cursor per keystroke over TUI+tmux is fragile. **But you don't need it:** the Claude Code input box is always at the *bottom* of the terminal. Anchor the HUD to the bottom edge of the focused terminal window (window geometry is trivially queryable via X11), and it sits at the prompt. This trades "cursor-anchored" for "prompt-anchored," which for this target is equivalent in practice.
+
+  Confidence: MEDIUM-HIGH. Each mechanism is individually known-good; integration risk is in focus/edge cases and the prefix-reconstruction plumbing.
+
+### RQ2 — Terminal IME comparison (X11 preedit + candidate popup)
+
+Moot for the primary goal because RQ3 kills the IME route inside a TUI regardless of terminal — but for completeness:
+
+- **Alacritty:** inline preedit since 0.11; X11 candidate window pinned to window bottom (Xlib limit); 0.13 avoids obscuring the cursor line. Decent inline preedit for shell use; not cursor-anchored on X11.
+- **wezterm:** most configurable IME (`use_ime`, `ime_preedit_rendering`, `xim_im_name`); known X11 quirk of preedit showing on all split panes (cosmetic). Best IME story of the GUI terminals, but still bound by the same TUI-preedit-clobber problem.
+- **kitty:** IME deliberately **off by default**; requires `GLFW_IM_MODULE=ibus` (works for fcitx5 too via the ibus protocol; `fcitx`/`uim` unsupported). Maintainer has historically resisted IME. Weakest fit.
+- **foot:** Wayland-only — irrelevant on this X11 host.
+- **ghostty:** native-leaning IME; GTK/X11 support exists but no evidence it solves cursor-anchoring-in-TUI (the TUI problem is app-side, not terminal-side).
+- **xterm/urxvt:** classic XIM `over-the-spot`; same X11 anchoring class, dated.
+
+Best host *if you were forced down the IME path:* wezterm. But **switching terminal does not rescue the goal**, because the failure is the TUI clobbering preedit, not the terminal. So: no terminal switch is recommended. Keep Alacritty. Confidence: MEDIUM-HIGH.
+
+### RQ3 — Does IME even work inside a full-screen TUI? (the make-or-break)
+
+**No, not for a visible as-you-type preview.** This is the crux and the honest answer is negative. IME preedit works fine for shell line editing (bash/zsh/vim are cited as working) because those cooperate with the terminal's preedit. A full-screen raw-mode TUI (Copilot CLI, and by the same architecture Claude Code) takes over TTY control and the terminal's own preedit rendering **disappears** (fcitx5 maintainer, copilot-cli#735). Committed text may still arrive, but the whole point — a *visible* suggestion as you type — is exactly what breaks. Combined with the X11 non-anchoring, the IME route cannot satisfy the requirement. Confidence: HIGH.
+
+### RQ4 — Existing-tools survey (currency verified July 2026)
+
+- **ibus-typing-booster** (mike-fabian, actively maintained; latest 2.29.x line): genuinely passive prediction with inline completion (Tab accept) + learns a user dictionary + can be **trained from custom word/text files** — content-wise it's a near-perfect match for the frecency idea, and it's in nixpkgs (`ibus-engines.typing-booster`, `i18n.inputMethod`). **But** it renders through IBus/the IME candidate window, so it inherits RQ3's TUI-preedit death and RQ1's X11 anchoring. Great engine, wrong delivery channel for a TUI.
+- **fcitx5 + presage** (predictive addon): same story — good predictor, IME-delivered, dies in the TUI.
+- **espanso:** no passive inline-suggestion mode. Historically it *had* a "Passive Mode" that the maintainer considered **hacky and planned to remove** (espanso#540), and there's no roadmap (espanso#255) for ghost-text/inline suggestions. Espanso is trigger/replace, not predictive. Not a fit — and per Zach's own audit it already loses to hand-typing for short phrases.
+- **AutoKey:** X11 hotkey/phrase expander (abbreviation → replace), no passive predictive ghost text; also X11-only and aging. Not a fit.
+- **zsh-autosuggestions / fish:** perfect UX, shell-only (RQ1b).
+- **Local-LLM inline completion tools** (e.g. shell copilots): all target the shell line or an editor buffer, not another app's TUI prompt; and an LLM is overkill for a ~10-phrase frecency list. Not a fit.
+
+No off-the-shelf tool delivers passive as-you-type suggestions *into the Claude Code prompt*. Confidence: MEDIUM-HIGH.
+
+### RQ5 — Claude-Code-native path (flagged prominently)
+
+**This would dominate if it existed, but it does not today.**
+
+- Claude Code *does* render inline prompt completions internally: `/slash` commands, `@file` paths, and `:emoji:` shortcodes (`:hea` → suggestions, added v2.1.217 on 2026-07-21, toggle `emojiCompletionEnabled`). So the inline-suggestion UI primitive is already in the product.
+- But there is **no public extension point** to feed custom completions into the prompt: no "custom completion source", no as-you-type input plugin. The plugin/hook system operates at tool-execution and lifecycle events. The closest, `UserPromptSubmit`, fires **when you press Enter** (it can add context or block/modify the submitted prompt) — it cannot show suggestions *while typing*.
+- The Claude Code TUI is shipped as a minified bundle, so patching the input widget directly is not a clean/maintainable route.
+
+**Actionable recommendation:** file a feature request with Anthropic for a user-configurable prompt-completion source (frecency/history-backed inline autosuggest, accept-with-Tab) — they already have the rendering. If granted, it instantly beats every OS-level hack (in-app cursor anchoring, tmux-transparent, no injection). Until then it is not available. Confidence: MEDIUM-HIGH (can't fully prove a negative, but current docs show no such API).
+
+### RQ6 — Frecency engine (KISS)
+
+Minimal engine, no LLM:
+
+1. **Corpus.** Two options, cheapest first:
+   - Bootstrap from the already-measured phrase list ("proceed, dispatch" ~17, "yes dispatch" ~25, "merge it" ~19, "merged and deployed" ~21, "dispatch audit" ~12, "check again" ~9, "dispatch" ~7, "whats next" ~5, "yes proceed" ~5, …).
+   - Then keep it live from `activity.events (source=keys)`: periodically (a `systemd --user` timer, e.g. every 15 min) query the keylog, reconstruct submitted prompt lines, and count/rank phrases.
+2. **Model.** A **prefix trie** (or just a sorted list) of phrases, each with a frecency score `score = count * decay(age_of_last_use)` (e.g. exponential half-life of a few weeks). This is a few dozen entries — a Python dict is plenty; a trie only if the list grows.
+3. **Query.** On the current live prefix (from the keystroke tap), return top-N phrases whose start matches the prefix (case-insensitive), ranked by frecency; show the top one as ghost text, cycle with a key if desired.
+
+No LLM, no embeddings. Refresh the ranked table on a timer; the overlay just reads a small JSON/SQLite the timer writes (same pattern as `bar-status-poll` → `~/.cache/bar-status/*.json`). Confidence: HIGH.
+
+### RQ7 — NixOS packaging & integration cost (for the recommended overlay path)
+
+Entirely **user-level** — no sudo, no `/etc/nixos`, no IME framework, no relogin:
+
+- **New scripts** under `scripts/` (consistent with the repo's `collector/`, `bar-status-poll`, `initiatives/` patterns):
+  - `frecency-build` — ClickHouse query → ranked phrase table → `~/.cache/inline-frecency/phrases.json`, run by a `systemd --user` timer (serverMode-gated is optional; this is a graphical-only tool so gate on `graphical`).
+  - `inline-overlay` — long-running `systemd --user` service (graphical-gated): taps keystrokes, tracks i3 focus (only active over the Claude Code terminal), renders the override-redirect HUD at the bottom of the focused terminal window, injects on Tab via `xdotool`.
+- **Deps** via `home.packages` / `nix-shell`: `xdotool` (injection + window geometry), Python with `python-xlib` (or GTK) for the override-redirect window, `clickhouse` client or a small HTTP query (reuse the activity pipeline's auth). All in nixpkgs.
+- **tmux interplay:** none problematic. Injection targets the terminal window; tmux forwards keys to the focused pane. The only tmux effect would be on cursor-cell math — sidestepped by bottom-of-window anchoring (no cell math needed).
+- **No-compositor caveat:** irrelevant; opaque override-redirect window needs no compositor.
+- **Nothing to stage as sudo.** (Contrast the dead IME route, which *would* have needed system-level `i18n.inputMethod` + relogin.)
+
+Confidence: MEDIUM-HIGH.
+
+---
+
+## Recommendation
+
+**Build the custom external X11 overlay (mechanism d), prompt-anchored to the bottom of the focused Claude Code terminal, fed by a trivial frecency table off the existing keylog, injecting with `xdotool`. In parallel, file the Claude Code feature request (RQ5) — if Anthropic ships native prompt autosuggest, retire the overlay.**
+
+Rationale:
+- It's the *only* route that puts a **passive, zero-invocation, accept-with-Tab** suggestion at the **Claude Code prompt** specifically.
+- It reuses infrastructure Zach already runs (keylog → ClickHouse; timer→cache→consumer pattern; i3 focus).
+- It's user-level, no sudo, no relogin, no terminal switch, no IME framework, compositor-independent.
+
+Trade-offs / honest caveats:
+- **Not truly dynamic-cursor-anchored** — it's anchored to the bottom of the terminal window. Acceptable because the prompt lives there, but it's a deliberate relaxation of the original spec. If a suggestion must literally track the caret column, this route can't guarantee it over TUI+tmux.
+- It's a **custom build with moving parts** (keystroke tap, focus detection, injection edge cases). Injection replaces the typed prefix by sending backspaces then the phrase — must handle the race where you keep typing during injection.
+- Duplicating the OS keyboard into a bespoke overlay is inherently a bit hacky vs. a native solution; treat the FR as the real long-term fix.
+
+**Do NOT** switch terminals or install an IME framework for this — neither rescues the TUI-preedit-clobber, so both are wasted effort.
+
+---
+
+## Scoped custom-build spec (if you proceed with the overlay)
+
+**Architecture (all user-level):**
+```
+activity.events (source=keys)  ──15min timer──▶  frecency-build ──▶ ~/.cache/inline-frecency/phrases.json
+                                                                          │
+live keystroke tap ──▶ inline-overlay daemon ◀────────────────────────────┘
+        │  (reconstruct in-progress prefix)
+        ├─ i3 focus == Claude Code terminal?  ──no──▶ hide
+        ├─ prefix match in phrases.json?       ──no──▶ hide
+        └─ yes ▶ draw override-redirect HUD at bottom of focused term window (gruvbox, JetBrainsMono)
+                 on Tab/Enter ▶ xdotool: backspace×len(prefix-typed) + type(phrase)
+```
+
+**The three genuinely hard problems (de-risk in this order):**
+1. **Live prefix reconstruction over the keylog + focus gating.** Verify you can, in real time, know "the user has typed `dis` in the Claude Code terminal right now." This is the make-or-break for the whole build — do it first.
+2. **Injection correctness.** `xdotool` backspace-prefix + type-phrase into a raw-mode Ink TUI, including the keep-typing-during-injection race and multibyte/space handling. Verify accepted text lands correctly in the Claude Code prompt.
+3. **HUD placement & redraw** without a compositor, at the bottom of the *focused* window, following window moves/focus changes on i3. Lowest risk, do last.
+
+**Smallest viable prototype to de-risk (a few hours, throwaway):**
+- Hard-code 3 phrases. Run a tiny Python script that: taps recent keystrokes (or reads a fifo you echo into), and when the buffer matches a prefix, pops a bare `tkinter`/Xlib override-redirect box at a fixed screen position, and on a hotkey runs `xdotool type "<phrase>"` into the focused window while a Claude Code session is open.
+- If that single loop works end-to-end (see suggestion → Tab → text appears in the Claude prompt), the full build is justified. If prefix-tracking or injection is flaky, stop and fall back to an explicit-invoke picker.
+
+**Fallback if the prototype is flaky:** a faster **explicit-invoke inline picker** — one hotkey (e.g. a spare `$mod` combo or a tmux binding) pops the frecency list filtered by whatever's typed, Enter injects. Still a keystroke (not passive), but robust and cheap. This is the honest floor if passive proves too fragile.
+
+---
+
+## Sources
+
+- [Alacritty 0.11.0 release notes (inline IME; X11 popup pinned to window bottom)](https://alacritty.org/changelog_0_11_0.html)
+- [Alacritty 0.13.0 release notes (IME tries not to obscure cursor line)](https://alacritty.org/changelog_0_13_0.html)
+- [Alacritty issue #7341 — Update IME position opportunistically](https://github.com/alacritty/alacritty/issues/7341)
+- [Alacritty issue #6313 — Can't clear preedit with inline IME](https://github.com/alacritty/alacritty/issues/6313)
+- [github/copilot-cli #735 — fcitx5 preedit not visible in a CLI TUI (maintainer: TUI causes terminal preedit to disappear)](https://github.com/github/copilot-cli/issues/735)
+- [wezterm use_ime / ime_preedit_rendering docs](https://wezterm.org/config/lua/config/ime_preedit_rendering.html)
+- [wezterm issue #2569 — preedit shown on all panes](https://github.com/wezterm/wezterm/issues/2569)
+- [Debian bug #990316 — enabling IME in kitty via GLFW_IM_MODULE (off by default)](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=990316)
+- [ibus-typing-booster (predictive IME, inline completion, custom-dictionary training)](https://github.com/mike-fabian/ibus-typing-booster)
+- [nixpkgs manual — ibus-engines.typing-booster](https://nixos.org/manual/nixpkgs/stable/#sec-ibus-typing-booster)
+- [NixOS Wiki — Fcitx5 / i18n.inputMethod](https://wiki.nixos.org/wiki/Fcitx5)
+- [espanso #540 — maintainer considering removing "Passive Mode" (hacky)](https://github.com/federico-terzi/espanso/issues/540)
+- [espanso #255 — long-term roadmap](https://github.com/espanso/espanso/issues/255)
+- [zsh-autosuggestions (inline gray ghost text; accept with →/End; strategies)](https://github.com/zsh-users/zsh-autosuggestions)
+- [Claude Code hooks reference (UserPromptSubmit fires on submit, not as-you-type)](https://code.claude.com/docs/en/hooks)
+- Claude Code emoji-shortcode autocomplete (v2.1.217, 2026-07-21; `emojiCompletionEnabled`) — corroborated via 2026 Claude Code feature/changelog references (toolsbase.dev, blakecrosley.com).
+
+*Unverified / flagged:* the exact current Claude Code version's completion internals and the absence of an input-suggestion plugin API are inferred from current public docs (hooks reference + feature roundups); Anthropic could add such an API — hence the feature-request recommendation. The overlay's injection-race and focus-edge behaviors are asserted from how `xdotool`/X11/raw-mode PTYs work, and should be confirmed by the prototype before committing to the full build.

--- a/claudedocs/plan-i3-bar-to-i3status-rust-hm-2026-07-06.md
+++ b/claudedocs/plan-i3-bar-to-i3status-rust-hm-2026-07-06.md
@@ -1,0 +1,68 @@
+# Plan: migrate i3 status bar → i3status-rust, move i3 into home-manager (2026-07-06)
+
+Grounded against the live workbench system + repo. "Option 1" from the i3-bar research.
+
+## Verified current wiring (ground truth)
+`/etc/nixos/configuration.nix`:
+```nix
+services.displayManager.defaultSession = "none+i3";
+services.xserver.windowManager.i3 = {
+  enable = true;
+  configFile = "/etc/i3.conf";          # forces `i3 -c /etc/i3.conf`
+  extraPackages = [ dmenu rofi xorg.xrandr i3lock i3blocks ];
+};
+environment.etc."i3.conf".text       = import ~/workspace/devrc/nix/system/i3config.nix;
+environment.etc."i3blocks.conf".text = import ~/workspace/devrc/nix/system/i3blocks.nix;
+```
+- Because `configFile` is set, **`~/.config/i3/config` is ignored until the system stops setting it** → a home-manager switch alone can't take over; a matching `sudo nixos-rebuild` is mandatory for cutover.
+- The `environment.etc` strings import from the **repo working tree** — switching the repo git branch changes what the next `nixos-rebuild` builds (footgun; freeze branch during cutover).
+- The bar (status_command, gruvbox workspace colors) is declared inside the i3 config's `bar {}`. i3status-rust replaces only the statusline content, not the i3bar colors.
+- **Drift confirmed** repo↔live in both directions (brightness bindings, tabbed keybind, nm-applet, `[dictation]` present in repo/absent live, `[rigcontrol]` top vs bottom, ssid/wifi pinned to the *laptop's* `wlp170s0` so they render nothing on workbench).
+- **This host = workbench**: no battery/backlight, wifi `wlp15s0`, `~/.server-mode` PRESENT (so `serverMode=true` on a graphical desktop — see decision b).
+
+## Key decisions
+- **(a) i3 config = raw string via `xdg.configFile."i3/config".text`**, NOT the HM i3 DSL (Zach hand-maintains ~160 lines; DSL port is high-churn/risky). Re-add the DSL's build-time `i3 -c -C` validation + `i3-msg reload` manually.
+- **(b) Do NOT gate the bar on `serverMode`** — it's true on graphical workbench (would disable the bar). Introduce `isLaptop = builtins.pathExists "/sys/class/backlight/intel_backlight"` (HM evals per-host under `--impure`) for battery/backlight/wifi (laptop) vs rig-control/DDC (workbench).
+- **(c)** `theme = "gruvbox-dark"`, `icons = "none"` (keep current text labels; no nerd-font installed → glyphs would tofu). Font + glyph icons = separate later change.
+- **(d)** custom `[[block]]` scripts emit JSON; clicks move from in-script `$BLOCK_BUTTON` to `[[block.click]]`; refresh from `pkill -RTMIN+n i3blocks` → `signal=N` + `pkill -RTMIN+N i3status-rs`.
+
+## Per-host block mapping
+| Old i3blocks | New i3status-rust | Type | Hosts |
+|---|---|---|---|
+| memory | `memory` | built-in | both |
+| disk | `disk_space` path=/ | built-in | both |
+| cpu_usage | `cpu` | built-in | both |
+| temperature | `temperature` (per-host chip) | built-in | both |
+| battery | `battery` | built-in | **laptop only** |
+| bandwidth+ssid+wifi+iface | `net` (device per host) | built-in | both — **collapses 4→1** |
+| calendar | `time` + `[[block.click]]`→`yad --calendar` | built-in+click | both |
+| vpn (rofi menu + detail) | `custom` (split: status/menu) signal=10 | custom | both |
+| dictation | `custom` render-only, signal=11 | custom | both |
+| rigcontrol (⚙ → yad) | `custom`, click→`rig-control.sh gui` | custom | **workbench only** |
+
+Retires ~8 custom scripts (cpu/mem/disk/temp/battery/ssid/wifi/iface).
+
+## Phased execution (workbench first; laptop only after verified)
+- **P0 Freeze & branch** off `feat/monitor-blackout` → `feat/i3-bar-hm`; don't switch repo branch between staging the system change and rebuild.
+- **P1 Author HM config** (inert): `isLaptop` in home.nix; `programs.i3status-rust` + `xdg.configFile."i3/config"` (guarded `mkIf isNixOS`); new `nix/i3/config.nix` (raw string, fn of `{isLaptop}`, reconciled superset of drift); split VPN scripts; dictation render script; `home.file` symlinks. **Gate A:** `home-manager build` + inspect generated TOML/config in the store (zero desktop impact).
+- **P2 Prove bar renders** (inert): run `i3status-rs <generated toml>` in a terminal on `:0`; every block resolves (temp chip, net device, ⚙); VPN/dictation JSON valid; screenshot. **Gate B.**
+- **P3 `home-manager switch`** — writes `~/.config/i3/config` + TOML but running i3 is still `-c /etc/i3.conf` → **desktop unchanged (inert)**. Check for pre-existing unmanaged `~/.config/i3/config` (use `force=true`). **Gate C:** `i3 -c ~/.config/i3/config -C` passes.
+- **P4 System cutover** (one sudo moment, staged as `nix/system/apply-i3-to-hm.sh` for Zach): remove `configFile="/etc/i3.conf"`, remove `i3blocks` from extraPackages, remove both `environment.etc."i3*.conf"`; keep `i3.enable`+`defaultSession`. Script prints diff + stops before rebuild. Then `sudo nixos-rebuild switch` → **`i3-msg restart`** (preserves layout). Keep old `/etc/nixos` i3 files as rollback. **Gate D:** exercise every clickable block; workbench shows no battery.
+- **P5 Cleanup** (after Gate D holds ~a day): rm `/etc/nixos/i3config.nix,i3blocks.nix,i3blocks-scripts/`; retire repo `nix/system/i3*.nix` + `apply-i3-*.sh` + `apply-rig-controls.sh`. **Gate E:** `grep -rn 'i3blocks|/etc/i3' /etc/nixos ~/.config` empty.
+- **P6 Laptop**: repeat P3–P4 (inspect laptop's own `/etc/nixos/configuration.nix` first; `isLaptop` adds battery/backlight/wifi, drops rig).
+
+## Top risks
+- **R1/R2 broken bar on live desktop** → P1–P3 inert; real switch is one revertible `i3-msg restart`; old config kept until Gate E; workbench first, keep an ssh/TTY.
+- **R3 repo-working-tree import** → freeze branch during P4; apply script removes the `import` entirely.
+- **R4 serverMode mis-gate** → never gate bar on serverMode.
+- **R6 vpn-sudo NOPASSWD sudoers** targets `/etc/nixos/i3blocks-scripts/vpn-sudo`; moving to a store path breaks `sudo` → **find the sudoers rule first** (not in main configuration.nix; in an import) and repoint, or keep vpn-sudo at a stable path.
+- **R5 host specifics**: temperature chip, net device (`wlp15s0`/`wlp170s0`), disk path — validate at Gate B per host.
+
+## Sequencing vs PR #73 (recommended)
+**Rebase-into-migration**, don't merge-then-migrate. #73's keepers (`rig-control.sh`, `monitor-blackout.sh`, `i3blocks-rigcontrol`) fold into the HM i3 config; its `apply-rig-controls.sh` + `nix/system` rig edits get deleted (this migration retires that path). Branch `feat/i3-bar-hm` off `feat/monitor-blackout`, land rig-control *and* the bar migration in one PR. (If Zach wants the ⚙ button on workbench sooner, merge #73 first — but then the migration PR must explicitly delete the `nix/system` rig additions.)
+
+## Unverified — resolve during implementation
+- Location of the `vpn-sudo` NOPASSWD sudoers rule (must find before moving vpn-sudo).
+- Laptop's `/etc/nixos/configuration.nix` (i3 wiring, brightness, `wlp170s0`).
+- Whether `class="float"` actually floats today (no matching `for_window` rule found).
+- Correct `temperature` chip on workbench.

--- a/claudedocs/scope-resume-state-digest-2026-07-05.md
+++ b/claudedocs/scope-resume-state-digest-2026-07-05.md
@@ -1,0 +1,109 @@
+# Scope: initiative-scoped live-state digest on resume
+
+**Date:** 2026-07-05 · **Status:** scoping (not built) · **Related:** [[agent-shell-env-handles]], shell-env nudge (devrc #48/#50, proven pattern)
+
+## Problem (the sink)
+
+The turn-analysis found the **dominant** avoidable agent cost is not code exploration or shell
+plumbing — it's **re-querying external state on session resume**: 100–235 external-state
+tool-calls/session spent re-establishing "what's the live state of dp-prod / the alert stack /
+this canary right now." Nearly every high-turn session opens *"Continue/Resume X — read the
+handoff first,"* then hand-rolls dozens of `kubectl get` / `git` / `gh pr` calls to reconcile the
+handoff against reality. Steady-state `kubectl get` ran ~1,047×/30d, overwhelmingly in
+datapacket-talos (civitai infra).
+
+This is 5–10× larger than the shell-plumbing sink we just closed.
+
+## What already exists (do NOT rebuild)
+
+| Tool | Scope | Deterministic? | Gap for resume |
+|---|---|---|---|
+| `standup.sh` (`state`,`deploys`) | **fleet-wide** — every repo/cluster | yes (one script) | too broad; not tied to one initiative |
+| `check-cluster.sh` | **whole cluster** health | yes | too broad; not initiative-scoped |
+| `verify-deploy`, `triage-dp`, `check-app`, `investigate-*` | targeted drill-downs | yes | manual, per-symptom; not a resume reconciler |
+| `/resume` step 3 "re-verify against live state" | the actual resume path | **NO — prose** | tells the agent to hand-roll `git status`/`kubectl get pod`/PR status → the 100–235 turns |
+
+**The precise gap:** there is no *initiative-scoped* collector, and the one path that needs it
+(`/resume`) re-derives state by hand because step 3 is prose, not a script. The infra to collect
+state deterministically is already proven (standup.sh/check-cluster.sh); it just isn't wired into
+resume, and isn't scoped down to "just the slice this handoff is about."
+
+## Proposed design
+
+Mirror the shell-env win: **replace prose with a deterministic collector + wire it into the path**,
+then verify over real runs.
+
+### 1. Structured `state-watch` header in handoff docs (deterministic > prose-parsing)
+Extend `/handoff` to emit a fenced, machine-readable block naming the initiative's live targets:
+
+```yaml
+# state-watch
+repo: civit/datapacket-talos
+cluster: dp-1           # -> prod-kubeconfig (reuse standup.sh CL map)
+branch: zach/api-pool-hol-blocking
+pr: 219
+deployments: [civitai-dp-prod-api, civitai-dp-prod-api-heavy]
+namespace: civitai-dp-prod
+canary: civitai-dp-prod-api
+alerts_ns: civitai-dp-prod
+```
+
+Resume reads this deterministically instead of parsing prose. Existing handoffs lack it → the
+collector **degrades gracefully** to git-only + heuristic entity extraction (like initiative-scan
+degrades when telemetry is off).
+
+### 2. `resume-state.sh` — the initiative-scoped collector (one script, one turn)
+Modeled on `standup.sh` (bash, reduce-at-source, only the digest reaches stdout). Given the
+state-watch header it collects **only that slice**:
+- **git/PR**: branch ahead/behind, dirty count, last-commit age; `gh pr view <pr>` state (merged?
+  CI red? conflicting?) — answers "did the in-flight item land already?"
+- **workload**: `kubectl rollout status` / Flagger canary phase for the named deployments (scoped,
+  NOT whole-cluster) — new ReplicaSet crashlooping vs old still serving.
+- **alerts**: firing alerts filtered to `namespace`/`cluster` (reuse standup's per-cluster split).
+- **drift**: diff collected reality against the handoff's own claims → emit `DRIFT:` lines.
+
+Lives in devrc (global, beside `standup.sh`; reuses its repo→kubeconfig map) because `/resume` is a
+global command. **v1 targets datapacket** (the ~90% case) and degrades elsewhere.
+
+### 3. Rewire `/resume` step 3
+Replace the prose "check it live" bullet with: `bash ~/.claude/skills/resume/resume-state.sh
+<topic>` and interpret the digest. Deterministic, one turn, correctly scoped.
+
+### Key decisions (call out)
+- **On-demand, NOT cached.** Resume must re-verify against *fresh* state; a cached snapshot risks
+  acting on stale reality (RULES: memory-is-hypothesis). One script call per resume, not a daemon.
+- **Deterministic header, not prose-parsing.** The `/handoff`↔`/resume` pair carries structure.
+- **Scoped, not fleet.** standup already does fleet; this is the one-initiative reconciler.
+
+## The verifier (already built — this is why it passes the gate)
+Re-run the exact per-call-timestamp turn-analysis used for shell-env
+(`scratchpad/perday.py` pattern): measure **state-query turns per resume-session** (kubectl-get /
+git / gh calls in the first N turns of "Continue/Resume …" sessions) before vs after. Cheap,
+automatic, over real runs. Success = a measurable drop in hand-rolled state queries on resume +
+`resume-state.sh` adoption (like the 0→50% handle adoption we saw).
+
+## Phasing (bounded)
+- **P1** — `resume-state.sh` datapacket-only (git/PR + rollout/canary + scoped alerts + drift),
+  heuristic entity extraction (no header dependency yet). Wire into `/resume`. Ship, dogfood.
+- **P2** — add the `state-watch` header to `/handoff`; collector prefers it, falls back to P1 heuristics.
+- **P3** — generalize the repo→cluster map beyond datapacket (homelab, others) if P1 verifies.
+- Measure after P1 and again after P2.
+
+## Risks / honest caveats
+- **Depends on handoff quality.** No handoff / vague handoff → collector degrades to git-only; still
+  better than nothing but not the full win. Existing handoffs won't have the header until P2.
+- **Entity extraction is heuristic** (P1) — a deployment renamed since the handoff may be missed;
+  the header (P2) fixes this deterministically.
+- **The collector itself costs kubectl calls** — but as ONE script call returning a digest (~20–40s,
+  standup precedent), not 100 hand-rolled turns. Net win only if `/resume` actually calls it (the
+  shell-env data showed adoption is the real risk; the deterministic wire-in + a nudge mitigate it).
+- **Cross-cluster reach from laptop** (nebula) — reuse standup.sh's host-aware kubeconfig handling.
+
+## Effort / recommendation
+P1 is bounded and self-contained (one bash script + a one-line resume.md rewire), directly modeled
+on `standup.sh`/`check-cluster.sh`. Verifier is already built. Recommend building **P1 datapacket-only**
+first, dogfood on the next few dp-prod resumes, measure, then decide P2/P3.
+
+**Decision point for Zach:** build P1 now (datapacket-scoped `resume-state.sh` + rewire `/resume`),
+or start with the `state-watch` header in `/handoff` (P2-first) so new handoffs are ready before
+the collector exists?

--- a/claudedocs/sent-mail-forwarding-research-2026-06-29.md
+++ b/claudedocs/sent-mail-forwarding-research-2026-06-29.md
@@ -1,0 +1,112 @@
+# Capturing Gmail SENT mail into the self-hosted inbox
+
+**Date:** 2026-06-29
+**Goal:** Get Zach's *outgoing* (SENT) Gmail into the homelab Postgres `mail` table so `mail-actions reconcile_owner_replies` can auto-close action items when he replies.
+**Constraint recap (load-bearing):** self-hosted on the homelab, no paid third party, **Gmail REST API rejected**, **Cloudflare Workers / SaaS rejected**. Reuse existing infra (k8s, aiosmtpd `mail-receiver`, Postgres, nebula, Hetzner SMTP gateway).
+
+## TL;DR recommendation
+
+**Build a small self-hosted IMAP poller in the `mailbox` namespace** that connects to Gmail over IMAP (app-password), pulls *new* messages from `[Gmail]/Sent Mail`, and **re-injects the raw RFC822 bytes via SMTP into the existing `mail-receiver`** (homelab gateway `:2525` / NodePort `30026`). It reuses the whole parse + dedup + store path, preserves `Message-ID`/`References`/`In-Reply-To` byte-for-byte (so dedup and `thread_key` matching just work), and the only consumer change needed is **none** — `reconcile_owner_replies` already queries owner mail regardless of `via_gmail`. The single biggest caveat: it requires a **Gmail app-password** (a long-lived credential broader than "just sent mail" — it grants full mailbox IMAP), stored as a k8s secret.
+
+---
+
+## How the system actually behaves (verified from source, not assumed)
+
+These are the facts every option below is judged against — confirmed by reading `receiver.py`, `extract.py`, `_db.py`, and `configmap-schema.yaml`:
+
+- **Dedup** is `INSERT … ON CONFLICT (message_id) DO NOTHING`. Any path that delivers a message with a **stable, original `Message-ID`** is idempotent — re-delivering the same sent message is a no-op.
+- **`via_gmail`** is a STORED generated column = `headers->>'Delivered-To'` matches his gmail. Sent mail has **no `Delivered-To`** header → it will land with **`via_gmail = false`**. That is fine and in fact correct:
+  - `fetch_unprocessed` (the LLM action pipeline) filters `WHERE via_gmail` → sent mail is **never sent to the LLM** as a candidate action. Good (it's not an inbound ask).
+  - `fetch_owner_messages` (used by `reconcile_owner_replies`) is **deliberately NOT restricted to `via_gmail`** — it matches `WHERE lower(from_addr) = ANY(owners)`. So owner sent mail with `via_gmail=false` *is* picked up for auto-close. This is exactly the intended design; the code comment even says "the owner's BCC'd/forwarded sent mail may have via_gmail=false."
+- **`category`** is a heuristic on `from_addr`; for owner sent mail `from_addr` is his own address → it'll fall through to `'personal'`. Harmless; reconcile doesn't read `category`.
+- **`thread_key`** is computed in Python from `References[0]` → `In-Reply-To` → own `Message-ID`. **Requires the original threading headers to survive ingestion.** This is the crux that kills the GmailApp-forward option (see below).
+- **No loop risk** from re-injection: the receiver's onward relay is OFF (`MAILPIT_HOST` empty), and re-injection targets the receiver's front door directly, not a relay that points back at it. A re-injected message is stored once (new Message-ID) then deduped on any retry.
+- **Distinguishing sent mail in the table:** there is no `direction` column today. Recommended marker is a **`labels` entry `'sent'`** stamped by the ingester (the `labels text[]` column already exists and is used elsewhere). `from_addr ∈ owners` is already a reliable implicit signal, but an explicit `'sent'` label makes ad-hoc queries and any future logic unambiguous without a schema migration. (A generated `direction` column is the heavier alternative — not needed.)
+
+---
+
+## Approach comparison
+
+| Approach | Self-hosted / Google-dep | Completeness | Reliability & latency | Credential exposure | Setup / maint. | Loop/dedup risk | Threading fidelity |
+|---|---|---|---|---|---|---|---|
+| **1. Gmail filter `from:me → forward`** | Google-side, no infra | **Fails — filters act on INCOMING only** | n/a | none | trivial but **doesn't work** | n/a | n/a |
+| **2. Auto-BCC `<x>@inbox.zacx.dev`** | manual habit / 3rd-party ext | **Partial — only when he remembers / only matching rules; misses replies-in-thread** | sub-minute when it fires | none (manual) / ext sees all mail | trivial (manual) or ext install | low (stable Msg-ID) | **degraded** — BCC copy may lack/alter threading headers |
+| **3. Google Apps Script (time-driven, reads SENT label, forwards)** | Runs on Google infra, **Google-dependent, not self-hosted**; **but NOT the REST API** | Good — sweeps SENT label | poll interval (≈1–15 min); 90 min/day total trigger budget; **100 emails/day forward cap** | none beyond his own Google session (script runs as him) | moderate; bound to Google account, opaque to homelab | low if it carries a stable id | **POOR — `GmailApp.forward` does not preserve `Message-ID`/`References`/`In-Reply-To`**; would need Gmail REST API (rejected) to fix |
+| **4. Self-hosted IMAP poller → re-inject via mail-receiver** ⭐ | **Most self-hosted** — logic runs in his cluster; uses IMAP app-password, **not the REST API** | **Full — sweeps `[Gmail]/Sent Mail`, every sent message** | poll loop (e.g. 60s) or IMAP IDLE; seconds-to-minute latency | **Gmail app-password** (full-mailbox IMAP) in a k8s secret | moderate (one new Deployment, ~150 LOC) | **none** — replays raw bytes, dedup on original Msg-ID | **perfect** — raw RFC822 replayed verbatim, all headers intact |
+| 5a. fetchmail/getmail/isync vs Sent folder | self-hosted | full | poll | app-password | reuse existing tools but awkward re-inject step | none | perfect (if it re-injects raw) — but you still write the re-inject glue, so #4 is cleaner |
+| 5b. Gmail delegation | Workspace-only feature; n/a personal | n/a | n/a | n/a | n/a | n/a | n/a |
+
+---
+
+## Per-approach detail + evidence
+
+### 1. Gmail filter `from:me → Forward it` — **does not work**
+Gmail's filter "Forward it" action and the Forwarding settings operate on **incoming mail only** ("Forward a copy of **incoming** mail to…"). There is no documented mechanism for a filter to fire on outgoing/sent messages. This is the most-cited misconception and it's the crux question — **confirmed negative.** Eliminated.
+Sources: [Gmail Help — automatic forwarding](https://support.google.com/mail/answer/10957?hl=en).
+
+### 2. Auto-BCC
+Gmail has **no native auto-BCC** (confirmed). Options are a Chrome extension (third-party — flag; the extension sees all outgoing mail) or manually BCC `<x>@inbox.zacx.dev`. Manual BCC is **incomplete by construction** — it only captures mail he remembers to BCC, and crucially the cases that matter most for `reconcile_owner_replies` are *replies in an existing thread*, which is exactly when he's least likely to manually add a BCC. A BCC'd copy *would* route through the existing inbound chain (so via_gmail could even be true if Gmail forwarding also copies it), but threading-header fidelity on the BCC copy is not guaranteed. **Not reliable enough to be the primary mechanism.** Could be a zero-cost supplement.
+Sources: [Pipedrive — auto-BCC workarounds](https://www.pipedrive.com/en/blog/automatic-bcc-in-gmail); [Gmail Community — no native auto-BCC](https://support.google.com/mail/thread/232403015/).
+
+### 3. Google Apps Script
+A time-driven trigger reads the SENT label and forwards new messages. Runs on Google's infra **as his account** — no third-party SaaS, no homelab footprint, but **Google-dependent and not "self-hosted."** Two hard problems:
+- **Threading fidelity is poor.** `GmailApp.forward()` abstracts away low-level headers; it does **not** reliably preserve `Message-ID`, `References`, or `In-Reply-To`. A forwarded copy gets a *new* Message-ID and typically loses the threading chain — which breaks `thread_key` matching, the whole point. Preserving them would require the **Gmail REST API** (`Gmail.Users.Messages` advanced service / raw insert), which Zach **rejected**. So the compliant subset of Apps Script can't carry the headers reconcile needs.
+- **Quotas:** consumer accounts get **~100 emails/day** via `GmailApp`/`MailApp`, and time-driven triggers share a **90-minute/day** total execution budget (each run ≤ 6 min). 100/day is probably fine for personal sent volume but is a real ceiling and an opaque failure mode (silent quota exhaustion mid-day).
+- State tracking (avoid re-forwarding) is doable via a Gmail label (`forwarded-to-inbox`) or a stored last-seen timestamp in `PropertiesService`.
+**Verdict: runner-up at best, and only if header loss were acceptable — it isn't.**
+Sources: [Apps Script quotas](https://developers.google.com/apps-script/guides/services/quotas); [GmailMessage / GmailApp reference](https://developers.google.com/apps-script/reference/gmail/gmail-message); consumer 100-email/day cap corroborated across community threads.
+
+### 4. Self-hosted IMAP poller re-injecting via the receiver — **RECOMMENDED**
+A small service **on the homelab** opens an IMAP connection to Gmail, selects `[Gmail]/Sent Mail`, fetches new messages as **raw RFC822**, and replays each via SMTP to the existing `mail-receiver`. Because it replays the *original bytes*, every header (`Message-ID`, `Date`, `References`, `In-Reply-To`, `From`) is preserved exactly — so:
+- **Dedup** works on the original `Message-ID` (idempotent across restarts/overlapping polls).
+- **`thread_key`** computes correctly from the preserved `References`/`In-Reply-To`.
+- **Zero consumer changes** — `reconcile_owner_replies` already matches owner `from_addr` regardless of `via_gmail`.
+
+**Credential reality (verified, 2026):** Gmail still issues **app-passwords** for personal accounts with **2-Step Verification enabled** (not in Advanced Protection), and **IMAP is now always-on** (Google removed the enable/disable toggle in Jan 2025). Legacy basic-auth / "less secure apps" is dead, but app-password + IMAP/SMTP explicitly remains the supported path and was confirmed working in mid-2026. This is **not** the Gmail REST API and **not** OAuth — it's the classic IMAP credential, which is what Zach left open as "arguably different."
+Caveat: an app-password grants **full mailbox IMAP access**, not a sent-only scope. That's the main security trade-off vs. the (rejected) scoped OAuth token.
+Sources: [Gmail Help — app passwords](https://support.google.com/mail/answer/185833?hl=en); [Transition from less secure apps to OAuth](https://support.google.com/a/answer/14114704?hl=en); [App-password + IMAP confirmed working 2026](https://support.google.com/mail/thread/369628083/); [Less secure apps wind-down](https://workspaceupdates.googleblog.com/2023/09/winding-down-google-sync-and-less-secure-apps-support.html).
+
+### 5. Other mechanisms
+- **fetchmail / getmail / isync (mbsync)** against `[Gmail]/Sent Mail`: same IMAP-creds model as #4 and equally self-hosted, but these tools deliver to a Maildir/MDA — you'd still write glue to re-inject into the SMTP receiver. Option #4 (a purpose-built ~150-line poller that fetches-and-SMTP-replays) is simpler and keeps a single code path. If you'd rather not maintain Python, `getmail` with an MDA that pipes to `sendmail`→receiver is a legitimate variant.
+- **Gmail delegation**: a Workspace admin feature for shared mailbox access; not applicable to a personal `@gmail.com` and doesn't expose sent mail to a third store anyway. N/A.
+
+---
+
+## Implementation sketch (recommended option #4)
+
+**Where it runs:** new `Deployment sent-sync` in ns `mailbox` (sits next to `mail-receiver` + `mailbox-postgres`). Single replica, no PVC — state lives in Postgres (see below).
+
+**Credentials:** Gmail app-password in a new k8s secret `gmail-imap-auth` (keys `imap_user` = `zachlowden1@gmail.com`, `imap_app_password`). Mirror the `secrets.enc.yaml` SOPS pattern already used for `mailbox-postgres-auth`. Requires 2SV on; avoid Advanced Protection.
+
+**Ingest loop (poll; IDLE optional later):**
+1. Connect TLS IMAP `imap.gmail.com:993`, login app-password, `SELECT "[Gmail]/Sent Mail"` (read-only is fine).
+2. Track last-seen position by **Gmail's stable `X-GM-MSGID`** (preferred — survives UID instability) *or* by `(UIDVALIDITY, last UID)`. Persist it in Postgres, e.g. a tiny `sync_state(folder text primary key, uidvalidity bigint, last_uid bigint, last_gm_msgid bigint)` table in the `mailbox` db — no new PVC, survives pod restarts. On `UIDVALIDITY` change, reset UID tracking (re-scan; dedup makes a re-scan harmless).
+3. `FETCH` new messages' full raw bytes (`BODY.PEEK[]`).
+4. For each, open SMTP to the receiver and replay the **raw bytes verbatim**:
+   - From the **LAN/cluster**: SMTP to `mail-receiver.mailbox.svc:2525` directly (simplest — same as the NodePort `:30026` test path). No need to traverse the Hetzner gateway; that gateway is only for inbound public MX delivery.
+   - `MAIL FROM`/`RCPT TO` envelope values are irrelevant to storage (the receiver parses the DATA blob, not the envelope) — use a benign placeholder rcpt like `sent@inbox.zacx.dev`.
+5. Advance the persisted cursor only after the SMTP `250` (the receiver stores before returning 250; a crash mid-batch just re-fetches and dedups).
+
+**Tagging sent mail in `mail`:** the receiver as-is won't know a message is "sent." Two clean options:
+- **(A, no receiver change)** After re-injection, the poller issues a single `UPDATE mail SET labels = array_append(labels,'sent') WHERE message_id = $1 AND NOT ('sent' = ANY(labels))` against `mailbox-postgres` (it already needs DB access for `sync_state`). Keeps the receiver generic.
+- **(B, receiver change)** Teach the receiver to add `'sent'` when the inbound SMTP carries a sentinel header (e.g. `X-Sent-Sync: 1`) the poller injects. Heavier (image rebuild) — prefer (A).
+
+Either way the durable, query-friendly marker is **`'sent' ∈ labels`**. `via_gmail` will be `false` and `category` `'personal'` — both already handled / irrelevant for reconcile.
+
+**How it plugs into `reconcile_owner_replies`:** **nothing to change.** Once a sent message is in `mail` with `from_addr ∈ owners` and intact `References`/`In-Reply-To`, the next `mail-actions run` (or the existing scheduled run) calls `fetch_owner_messages` → keys it by thread → closes any OPEN action in that thread whose `received_at` predates the sent message. The `via_gmail=false` is explicitly tolerated by that query. The `run`-loop's defensive `from_addr ∈ owners → label 'sent', skip LLM` guard also covers the (won't-happen, since `fetch_unprocessed` filters `via_gmail`) case where a sent row reached the survivor loop.
+
+**Verification (before relying on it):** send yourself a test reply from Gmail in an existing thread that has an OPEN `mail_action`; confirm (a) a row lands in `mail` with the original `Message-ID` and `labels @> '{sent}'`, (b) `mail-actions run` reports `closed (owner): 1` for that thread. Don't claim it works until that exact path is exercised.
+
+---
+
+## Runner-up and why-not
+
+- **Apps Script (#3) — runner-up.** Most attractive on "no homelab footprint, runs as him, no new long-lived IMAP credential." Rejected as primary because `GmailApp.forward` **drops the threading headers** `reconcile_owner_replies` depends on, and fixing that needs the Gmail REST API he rejected. Also Google-dependent (opaque quota/trigger failure modes) and not self-hosted, his #1 axis. *Could* be a fallback if the IMAP poller proves troublesome AND header loss were tolerable (it isn't, for thread matching).
+- **Auto-BCC (#2)** — useful as a free, zero-maintenance *supplement* (manually BCC the inbox on important sends), but incomplete and unreliable for the replies-in-thread case; not a primary mechanism.
+- **Gmail filter forward (#1)** — eliminated: filters only act on incoming mail.
+- **getmail/fetchmail/isync (#5a)** — viable and equally self-hosted, but adds an MDA+glue layer; the purpose-built poller is a single, simpler code path.
+
+## Open / UNVERIFIED items
+- Exact wording of the latest `GmailApp.forward` header behavior (Message-ID/References) is inferred from the API reference + community reports, not a first-party "headers are stripped" statement — **UNVERIFIED** to the letter, but the conservative read (don't rely on it for threading) is safe.
+- `X-GM-MSGID` (Gmail IMAP extension) as the cursor is the robust choice; standard `UIDVALIDITY/UID` is the portable fallback. Pick one at implementation time; both are documented IMAP/Gmail behaviors.
+- Whether 2SV is already enabled on the account (prereq for app-password) — confirm on the Google side before building.

--- a/claudedocs/the-algorithm-applied-2026-06-17.md
+++ b/claudedocs/the-algorithm-applied-2026-06-17.md
@@ -1,0 +1,115 @@
+# The Algorithm, applied to how we work — 2026-06-17
+
+Musk's 5-step algorithm run against **everything we've been doing** across both hosts (main + laptop `10.42.0.100`), grounded in the extracted session corpus, not vibes.
+
+Pipeline: `devrc/scripts/session-analysis/{extract_user_msgs,extract_genesis}.py` on each host → `/tmp/algo_analyze.py` (combined). Regenerable.
+
+---
+
+## Part A — What we've actually been doing (the evidence)
+
+**Corpus:** 8,171 messages across **389 sessions**, 2 hosts (main 5,801 / laptop 2,370). After stripping harness noise: **6,044 genuinely-typed messages**, median **69 chars** — short imperative directives.
+
+**Where the work is (last 14 days, 147 sessions):** civitai prod infra dominates — `datapacket-talos` **100**, `civitai` 12, `homelab-talos` 11, `devrc` 7, the rest scattered (vetr, gpu-fleet, naida). This is overwhelmingly **prod ops on one system**, not greenfield.
+
+**How sessions open:** 45% with a slash command, 55% typed. Top openers: `/investigate-alert` (35), `/check-app` (26), `/kubeclaw-agents` (16), `/investigate-network` (11), `/app-blocks` (10), `/manage-postgres` (10), `/next-lever` (8). Typed openers are dominated by **"read X (load context)" (59)** and **"analyze/recon X" (32)** — i.e. re-loading state and re-deriving subsystem maps.
+
+**~40 distinct slash commands/skills** are in active use. The work is heavily tooled already.
+
+**Rituals still hand-typed (the genesis stems, ≥4×):**
+- `read <handoff doc>` continuity-loading — 13+ (plus 59 "read X" openers)
+- `dispatch a subagent to audit the PR for risks/regressions…` — ~31 (now `/audit-pr`)
+- `proceed use subagent ensure test coverage` — 13 (now a standing CLAUDE.md rule)
+- `analyze the X setup, then…` — 32 (now `/analyze-service`)
+- `recommend next steps` — 9
+- `dispatch a subagent to use playwright to click through…` — 9
+- `its been a few days check` / `its the next day check` — 8 (periodic re-check)
+- `do we have a claude code skill for this` — 5
+- `give me the kickoff message to copy-paste` — 5 (now `/handoff`)
+
+**Quality is not the problem.** Pure-steering 2.2%, correction/frustration **1.7%**. The work lands. So the Algorithm's leverage here is **deletion of inert process**, not mistake-prevention.
+
+**The governing requirements layer:** `~/.claude/CLAUDE.md` (14 lines, operational) + `PRINCIPLES.md` (60) + `RULES.md` (**331 lines, 170 bullets, 20 sections**) = **405 lines loaded into every session on every host.**
+
+---
+
+## Part B — The Algorithm
+
+### 1. Question every requirement — and name the person
+
+There is no legal/safety department here. **Every requirement traces to one of two people:**
+
+- **Zach** — the operational rules in `CLAUDE.md` (git hygiene, nix-shell, subagent-default, worktree-isolation). These were forged from his own pain and are exercised constantly. *These pass the question.*
+- **The SuperClaude framework author** (imported wholesale into `PRINCIPLES.md` + `RULES.md`). This is the dangerous case the Algorithm warns about: a **smart, plausible-sounding external source, adopted un-questioned.** The tell is in the text itself — "SuperClaude framework," "PM Agent meta-layer," "Quality Quadrants," "Session Lifecycle /sc:load→/sc:save."
+
+Cross-checking the imported requirements against 389 sessions of actual behavior:
+
+| Imported requirement (RULES.md) | Prescribed | Actually fired |
+|---|---|---|
+| PM-Agent self-improvement / "document after every task" | top-of-file section | **0×** |
+| `/sc:load → Checkpoint(30min) → /sc:save` lifecycle | mandated | `/sc:save` **0×**, `/sc:load` 2× |
+| TodoWrite for >3-step tasks | mandated | user-invoked **0×** |
+| "specify expected parallelization gains (e.g. 60% time saving)" | mandated | never — and it **directly contradicts** the same file's "No Fake Metrics" rule |
+| SOLID / Systems-Thinking / Decision-Framework (PRINCIPLES.md) | foundational | never referenced in any actual task |
+
+**Verdict:** a large fraction of the 405 governing lines are inert — adopted because the source sounded authoritative, never load-bearing. Smart-person requirements, unquestioned. The few requirements that *are* dangerous-and-followed (the prescriptive PM-Agent/lifecycle ritual) are dangerous precisely because they'd add ceremony with zero observed payoff.
+
+### 2. Delete (expect to add ≥10% back)
+
+**Delete from the requirements layer** (target: 405 → ~120 lines):
+- The **PM-Agent / Agent-Orchestration self-improvement** section (0 fires).
+- The **`/sc:` session lifecycle** (load/checkpoint/save) prose (0 saves).
+- The **TodoWrite mandate** and **"parallelization-gain estimate"** requirement (latter is self-contradictory).
+- Most of **`PRINCIPLES.md`** (SOLID/Quadrants/Decision-Framework — generic, inert).
+- The **"Quick Reference & Decision Trees"** appendix (restates rules already stated above it).
+- Redundant restatements of "use the best tool / parallelize / batch" scattered across Tool-Optimization + Workflow + Planning.
+
+**Delete from the process layer:**
+- Any command used **1×** that isn't a deliberate rarely-but-critical runbook (audit the long tail of single-use commands; several are abandoned experiments).
+- `/sc:load` / `/sc:save` commands themselves if the lifecycle prose is deleted.
+
+**The ≥10% add-back (the rules earned by real pain — keep, they fire constantly):**
+- **Token & Tool Hygiene** (Write-over-heredoc, Read-before-Edit, don't-re-read) — derived from real audits.
+- **Verification Honesty** (deployed≠verified, reproduce the symptom) — earned from real misses; matches the 9× hand-typed Playwright-verify ritual.
+- **Memory-is-a-Hypothesis** + **Deterministic-over-Prose** — earned, and both got exercised *this very session* (stale laptop IP; live-discovery over frozen map).
+- **Git rules** (never add -A / reset --hard / the rebase recipe) + **NixOS** + **subagent/test/PR default** + **worktree isolation**.
+
+If after cutting you've kept more than ~120 lines, you didn't cut enough.
+
+### 3. Simplify & optimize (only what survived deletion)
+
+- The surviving rules are already terse — collapse the duplicate "use best tool/parallel" rules into **one** Tool-Optimization rule.
+- **Do NOT over-consolidate the command fleet.** The `investigate-*` (4) and `manage-*` (8) families look like duplication but `AGENTIC_LEVERAGE.md`'s skill-granularity rule already governs this deliberately (runbook depth ⇒ own skill). Respect it; this is a case where apparent duplication is correct.
+- Simplify continuity: 59 "read X" + 13 "read handoff" openers mean **context-reload is the single most repeated act.** `/resume` now collapses it — but it's unproven (see §5).
+
+### 4. Accelerate cycle time (only now)
+
+The dominant cycle is **PR → audit → deploy → verify**. Two accelerable, un-automated steps remain:
+- **Verify** is still hand-typed Playwright (9×). The `/verify` skill exists — wire it as the default closer so "deployed" auto-advances to "reproduced the click-path."
+- The **periodic re-check** ("its been a few days check", 8×) is a latency gap — a human remembering to look. This is a scheduling problem, not a typing problem.
+
+### 5. Automate (last — and note we already broke this rule)
+
+The Algorithm's sharpest point lands on us: **~40 commands were built before the requirements were questioned or the dead process deleted.** Some commands automate processes that step 1–2 say shouldn't exist (maintaining `/sc:load`/`/sc:save` machinery for a lifecycle that fires ~0×). That is the "automated too early" mistake, in our own repo.
+
+So automate **only what survived all four steps:**
+- **`/verify` as the cycle closer** (step 4) — high-frequency, real.
+- The **periodic-recheck** ritual → `/schedule` or `/loop`, *if* it survives questioning ("does a few-days drift check actually need to exist, or should the relevant sweeps page us?" — note `dr-sweep`/`cert-sweep`/`capacity-sweep` already exist; the manual check may be **deletable**, not automatable).
+- **Stop building** until the requirements layer is cut. New commands on top of 405 lines of mostly-inert rules is more harness, not more leverage — the exact failure mode `close-the-loop`/`STATE.md` already warns about.
+
+---
+
+## The one-line conclusion
+
+We have a **low-error (1.7%), heavily-tooled, prod-ops-dominated** practice whose biggest waste is not mistakes but **inert ceremony**: 405 lines of governing requirements (most imported un-questioned and never fired) and a command fleet partly built ahead of the deletion step. The highest-leverage move is **subtractive** — question the imported requirements by name, delete ~70% of the rules layer, keep the ~10% earned by real pain, then automate only the PR→verify closer. Build less; delete more.
+
+---
+
+### Appendix — reproduce
+```bash
+# on each host:
+python3 ~/workspace/devrc/scripts/session-analysis/extract_user_msgs.py /tmp/msgs_<host>.jsonl
+python3 ~/workspace/devrc/scripts/session-analysis/extract_genesis.py   /tmp/genesis_<host>.jsonl
+# combine + analyze:
+python3 /tmp/algo_analyze.py   # (scp laptop files back first)
+```


### PR DESCRIPTION
Follow-on to #340, which rescued 2 stranded docs. This batch rescues the remaining **27**.

## What was stranded
The workbench checkout (`192.168.50.250:/home/zach/workspace/devrc`) sits at `89d9cdc`, one commit behind `origin/main`, with 29 untracked `claudedocs/*.md` plus a `claudedocs/proposed-rules-cut/` directory. All of it was one routine `checkout`/`clean` away from silent loss.

## Triage method
For every file, three independent upstream checks — not just the path:
1. **Exact path** on `origin/main`.
2. **Content sha256** against every one of the 34 files in `origin/main:claudedocs/` — catches a doc a worktree committed under a *different name*.
3. **H1-title grep** across the full upstream `claudedocs/` corpus — catches a renamed-and-lightly-edited copy.

**Harness positive control:** `espanso-typing-toil-2026-07-25.md` and `gametape-session-review-2026-07-20.md` were correctly identified as already-upstream (they are exactly the two #340 rescued, and `origin/main` carries them byte-identically). So the check demonstrably *can* return "upstream" — the 27 "not upstream" verdicts are not a scanner wired to nothing. Those two are excluded here.

Near-misses deliberately kept as distinct docs, not duplicates:
| stranded | upstream sibling | relation |
|---|---|---|
| `handoff-insights-telemetry-unify-2026-07-28.md` | `…-2026-07-11.md` | later, different session |
| `gametape-session-review-2026-07-24.md` | `…-2026-07-20.md` | later, different trailing window |
| `handoff-dl-router-2026-07-31.md` | `handoff-dl-router-player-buttons-2026-08-01.md` | predecessor |

## Secret scan — two scanners, both with validated controls
Handoff docs are exactly the kind of file that accretes tokens and connection strings, so this was gated before committing.

A canary file was built from **realistic generated** credentials (not vendor example keys, which scanners allowlist): AWS access key + secret, a GitHub PAT, an Anthropic API key, and a Postgres URL with inline password.

| scanner | canary (must be non-zero) | clean control | the 31 docs |
|---|---|---|---|
| gitleaks 8.30.1 | **1 / 5** (github-pat only) | — | `no leaks found` |
| grep pattern scanner (15 patterns, independent ruleset) | **5 / 5** | 0 | **0 matches** |

Worth recording: **gitleaks alone missed 4 of 5 planted secrets** here. Its clean result was only trustworthy once cross-checked against a scanner that fails differently. Both report zero on the rescued docs.

## Provenance
Every one of the 27 committed blobs was verified **byte-identical to the workbench original** by two independent methods — sha256 set comparison and per-file `cmp` against the file streamed over SSH. 0 mismatches.

## Deliberately NOT included
`claudedocs/proposed-rules-cut/` (`RULES.md`, `PRINCIPLES.md`, both 2026-07-30) — **superseded**, left in place on the workbench for the operator to decide:
- Its `RULES.md` is a 90-line / 7.1 KB proposed *cut* of `claude/RULES.md`. Live `claude/RULES.md` is now 168 lines / 33 KB and went a different route: #304 split it into always-on core + non-loaded archive to buy the same context headroom, then #335/#336/#339/#313 kept iterating.
- Its `PRINCIPLES.md` is strictly *older* than live `claude/PRINCIPLES.md` — it lacks the "stated at the scope you actually measured, not beyond it" clause.

Committing a stale 90-line copy of the rules under `claudedocs/` is an active hazard: a future agent grepping for rules could read it as authoritative. Recommend deletion, but it was not deleted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
