### PR TITLE
espanso: retune for the search UI, add :rna/:lr, prune 4 dead, fix multi-word attribution

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -79,16 +79,13 @@ in
     matches = {
       base = {
         matches = [
-          # Date/time with labels for search bar (ALT+SPACE)
+          # Date/time with labels for search bar (CTRL+SPACE)
           { trigger = ":date"; replace = "{{mydate}}"; label = "Today's date"; search_terms = ["today" "calendar"]; vars = [{ name = "mydate"; type = "date"; params = { format = "%Y-%m-%d"; }; }]; }
           { trigger = ":time"; replace = "{{mytime}}"; label = "Current time"; search_terms = ["now" "clock"]; vars = [{ name = "mytime"; type = "date"; params = { format = "%H:%M"; }; }]; }
-          { trigger = ":datetime"; replace = "{{mydt}}"; label = "Date and time"; search_terms = ["timestamp"]; vars = [{ name = "mydt"; type = "date"; params = { format = "%Y-%m-%d %H:%M"; }; }]; }
-          { trigger = ":iso"; replace = "{{myiso}}"; label = "ISO 8601 timestamp"; search_terms = ["utc" "rfc"]; vars = [{ name = "myiso"; type = "date"; params = { format = "%Y-%m-%dT%H:%M:%S%z"; }; }]; }
 
           # Paths - labeled for autocomplete
           { trigger = ":hlt"; replace = "${workspace}/homelab-talos "; label = "homelab-talos path"; search_terms = ["infra"]; }
           { trigger = ":kuc"; replace = "${workspace}/kubeclaw "; label = "kubeclaw path"; search_terms = ["kubeclaw"]; }
-          { trigger = ":nixos"; replace = "/etc/nixos/configuration.nix"; label = "nixos config"; search_terms = ["nixos" "configuration"]; }
 
           # SSH connect
           { trigger = ":sshwn"; replace = "ssh zach@10.42.0.30"; label = "SSH workbench (nebula)"; search_terms = ["ssh" "workbench" "wb" "nebula" "mesh" "remote"]; }
@@ -97,8 +94,9 @@ in
           { trigger = ":sshll"; replace = "ssh zach@192.168.50.155"; label = "SSH laptop (LAN)"; search_terms = ["ssh" "laptop" "framewo" "lan" "local"]; }
 
           # hot singles
+          # (dashbaord is the ONLY snippet with real direct-trigger traffic:
+          #  5 of the 5 non-search fires in 2026-07-25→08-05 were this typo-fix.)
           { trigger = "dashbaord"; replace = "dashboard"; }
-          { trigger = "reocmmend"; replace = "recommend"; }
 
           # Workflows
           # (:whn removed 2026-07-06 — 0 fires over the audit window, superseded by
@@ -117,8 +115,28 @@ in
           # a snippet enforces nothing; the gate is what makes it stick. See
           # /prune-skill + scripts/skill-audit.py.
           { trigger = ":eos"; replace = "reflect on work done and key learnings this session, then write the handoff FIRST — all session narrative, status and what-shipped goes THERE, never into a skill. Then extract only the durable reusable lessons, and name the single skill or doc that should own each. Then dispatch subagent to fold them in under these rules: report each target file's byte size before and after; every edit must be net-neutral or smaller — evict, merge or demote something stale in the SAME edit; never append a dated session block to a SKILL.md; collapse a retraction to a one-line do-not-re-derive tell rather than preserving the superseded belief; if a file is over budget with nowhere to demote to, say so instead of appending. Then give me the kickoff message."; label = "End-of-session ritual: handoff first → durable lessons only → net-neutral skill edits"; search_terms = ["end" "session" "wrap" "handoff" "skills" "review" "update" "docs" "ritual" "prune" "evict" "bloat"]; }
-          { trigger = ":acq"; replace = "dispatch subagent to process feedback\nask me clarifying questions and recommend anything you think would be useful to include before dispatching (include complete test coverage)"; label = "Ask clarifying questions + suggest additions"; search_terms = ["ask" "clarify" "clarifying" "questions" "elicit" "scope" "include"]; }
+          # 2026-08-05 /espanso-audit — DISCOVERABILITY fix, not a content fix.
+          # :acq fired ZERO times in the 20-day window, yet its expansion appears
+          # in 36 genuine user messages (clipboard-pasted from elsewhere) — so
+          # demand is proven and the TEXT is deliberately untouched. The keystroke
+          # stream shows the opener "dispatch to process feedback:" hand-typed 12×,
+          # twice trailing a mistyped ":acc"/":accc". Root cause: 168 of 173 fires
+          # go through the Ctrl+Space SEARCH UI, so `label` + `search_terms` ARE the
+          # interface — and the old search_terms (ask/clarify/questions/elicit/…)
+          # contained none of the words he actually types: feedback, dispatch,
+          # process. Lead the label with "feedback" and add those three terms.
+          { trigger = ":acq"; replace = "dispatch subagent to process feedback\nask me clarifying questions and recommend anything you think would be useful to include before dispatching (include complete test coverage)"; label = "Process feedback: dispatch subagent + ask clarifying questions"; search_terms = ["feedback" "dispatch" "process" "ask" "clarify" "clarifying" "questions" "elicit" "scope" "include"]; }
           { trigger = ":kickoff"; replace = "give me the kickoff message to copy paste to next session"; label = "Kickoff message for next session"; search_terms = ["kickoff" "kick off" "next session" "copy paste" "handoff" "message"]; }
+          # Added 2026-08-05 via /espanso-audit — both are WHOLE-STANDALONE-MESSAGE
+          # shaped, the one shape that has stuck (:eos 72 fires, :kickoff 38); every
+          # mid-sentence FRAGMENT snippet has been pruned (:ds, :rns, :pst, :rnx).
+          # Typing-stream demand: "recommend next actions" 81 rows (25 of them that
+          # phrase standing ALONE as a whole message); "limit restored, resume agent"
+          # 68 rows. NOTE the noun: the pruned :rns said "recommend next STEPS" and
+          # was typed only 3× — the real demand is "actions". He also searched the
+          # bar for "recom" on 2026-07-27 hunting for exactly this, and found nothing.
+          { trigger = ":rna"; replace = "recommend next actions"; label = "Recommend next actions"; search_terms = ["recommend" "recom" "next" "actions" "rank" "leverage"]; }
+          { trigger = ":lr"; replace = "limit restored, resume agent"; label = "Limit restored — resume agent"; search_terms = ["limit" "restored" "resume" "agent" "continue" "quota"]; }
           # Removed 2026-07-25 via /espanso-audit — all keylog-evidence-backed:
           #  ZERO-FIRE set — 0 keylog fires + short-form hand-typing; steering already in
           #   RULES.md / slash-commands: :rnx, :pst ("proceed, dispatch" typed 40+×),
@@ -128,8 +146,19 @@ in
           #   prefixes don't stick for a search-first espanso user):
           #   :ds (1 fire vs 94 hand-typed; duplicates the RULES "dispatch subagent" default),
           #   :rns (1 vs 20; overlaps /resume). See claudedocs/espanso-typing-toil-2026-07-25.md.
+          # Removed 2026-08-05 via /espanso-audit — 0 keylog fires each over the
+          #  20 days 2026-07-25→08-05 (:nixos — this host's config is a flake in
+          #  ~/workspace/devrc, so /etc/nixos/configuration.nix is a dead path;
+          #  :iso and :datetime — :date+:time cover it; "reocmmend" — the typo
+          #  never recurred, unlike "dashbaord" which is still the ONLY snippet
+          #  with direct-trigger traffic). Kept despite showing 0 ATTRIBUTED
+          #  fires: the four :ssh* plus :cgf/:subk — their searches are MULTI-WORD
+          #  ("ssh work", "ssh lap", "civit prod") and the detector's _term_matches
+          #  could not attribute a term containing a space (fixed in the same
+          #  commit), so 19+ of the 46 unattributed rows are theirs. Unattributable
+          #  ≠ dead — do not prune them on the old numbers.
 
-          { trigger = ":cc"; replace = "${workspace}/civit/civitai "; label = "civitai main repo path"; search_terms = ["civitai" "repo" "web"]; }
+          { trigger = ":cc"; replace = "${workspace}/civit/civitai "; label = "civitai main web app repo path"; search_terms = ["civitai" "repo" "web" "app"]; }
           { trigger = ":cdp"; replace = "${workspace}/civit/datapacket-talos "; label = "civitai datapacket-talos path"; search_terms = ["civitai"]; }
           { trigger = ":cgf"; replace = "${workspace}/civit/civitai-gpu-fleet "; label = "civitai gpu-fleet path"; search_terms = ["civitai"]; }
           { trigger = ":cmo"; replace = "${workspace}/civit/civitai-orchestration "; label = "civitai-orchestration path"; search_terms = ["civitai" "orchestration"]; }

--- a/scripts/collector/keylog/espanso_detect.py
+++ b/scripts/collector/keylog/espanso_detect.py
@@ -253,14 +253,32 @@ class EspansoDetector:
         return matched[0] if len(matched) == 1 else None
 
     def _term_matches(self, term, trig):
+        """True when EVERY whitespace-separated token of `term` matches `trig`.
+
+        Multi-word queries are how the search UI is actually driven: the
+        /espanso-audit of 2026-08-05 found 46 of 173 keylog rows unattributed,
+        19+ of them multi-word ("ssh work", "ssh lap", "ss wor", "civit prod").
+        The old rule tested the WHOLE term as a substring of a single word, so
+        any term containing a space could never match ANY snippet — which made
+        the four :ssh* snippets and :cgf/:subk read as dead when they are not.
+        A single-token term takes exactly the old path (all() over one token).
+        """
+        tokens = (term or "").split()
+        if not tokens:
+            return False
         meta = self.ts.meta.get(trig) or {}
-        if term in trig.lower():
+        return all(self._token_matches(tok, trig, meta) for tok in tokens)
+
+    @staticmethod
+    def _token_matches(token, trig, meta):
+        """One token vs one snippet, by the original (pre-2026-08-05) rules."""
+        if token in trig.lower():
             return True
         label = (meta.get("label") or "").lower()
         for w in _WORD_RE.findall(label):
-            if term in w:
+            if token in w:
                 return True
         for st in meta.get("search_terms") or []:
-            if isinstance(st, str) and term in st.lower():
+            if isinstance(st, str) and token in st.lower():
                 return True
         return False

--- a/scripts/collector/keylog/tests/test_espanso_detect.py
+++ b/scripts/collector/keylog/tests/test_espanso_detect.py
@@ -352,3 +352,117 @@ def test_notify_navigation_leaves_search_mode_intact():
     evs = list(d.feed_char("\n", app=APP, session=SESS, now=8.0))
     assert len(evs) == 1
     assert evs[0].search_term == "today"
+
+
+# -- FIX 3: MULTI-WORD search terms ------------------------------------------
+# The /espanso-audit run of 2026-08-05 found 46 of 173 keylog espanso rows
+# unattributed, and 19+ of them were MULTI-WORD queries: "ssh work", "ssh lap",
+# "ss wor", "ssh worc", "civit prod". `_term_matches` required the whole term to
+# be a substring of a SINGLE word (of the trigger, of a label word, or of one
+# search_term), so a term containing a space could never match ANY snippet — the
+# four :ssh* snippets and :cgf/:subk therefore read as dead when they are not.
+# Fix: tokenize on whitespace and require EVERY token to match by the old rules.
+# These fixtures carry the REAL labels/search_terms from nix/home.nix.
+SSH_BASE = {"matches": [
+    {"label": "SSH workbench (nebula)", "replace": "...", "trigger": ":sshwn",
+     "search_terms": ["ssh", "workbench", "wb", "nebula", "mesh", "remote"]},
+    {"label": "SSH workbench (LAN)", "replace": "...", "trigger": ":sshwl",
+     "search_terms": ["ssh", "workbench", "wb", "lan", "local"]},
+    {"label": "SSH laptop (nebula)", "replace": "...", "trigger": ":sshln",
+     "search_terms": ["ssh", "laptop", "framewo", "nebula", "mesh", "remote"]},
+    {"label": "SSH laptop (LAN)", "replace": "...", "trigger": ":sshll",
+     "search_terms": ["ssh", "laptop", "framewo", "lan", "local"]},
+]}
+
+CIVIT_BASE = {"matches": [
+    {"label": "civitai main web app repo path", "replace": "...", "trigger": ":cc",
+     "search_terms": ["civitai", "repo", "web", "app"]},
+    {"label": "civitai datapacket-talos path", "replace": "...", "trigger": ":cdp",
+     "search_terms": ["civitai"]},
+    {"label": "civitai gpu-fleet path", "replace": "...", "trigger": ":cgf",
+     "search_terms": ["civitai"]},
+    {"label": "civitai dp prod kubeconfig path", "replace": "...", "trigger": ":cpk",
+     "search_terms": ["civitai"]},
+    {"label": "civitai submodel dc 03 kubeconfig path", "replace": "...",
+     "trigger": ":subk",
+     "search_terms": ["civitai", "gpu", "submodel", "dc 03"]},
+]}
+
+
+def _det_for(base):
+    return EspansoDetector(ET.load_triggers(base, DEFAULT))
+
+
+def test_multiword_term_matches_each_workbench_ssh_snippet():
+    # RED before the fix: "ssh work" is not a substring of any single word, so
+    # _term_matches returned False for EVERY trigger. Now both workbench
+    # snippets match ("ssh" ⊂ the trigger, "work" ⊂ label word "workbench").
+    d = _det_for(SSH_BASE)
+    assert d._term_matches("ssh work", ":sshwn") is True
+    assert d._term_matches("ssh work", ":sshwl") is True
+    # ...and the LAPTOP ones legitimately do not — no "work" anywhere in them.
+    assert d._term_matches("ssh work", ":sshln") is False
+    assert d._term_matches("ssh work", ":sshll") is False
+
+
+def test_multiword_ssh_work_stays_ambiguous_by_design():
+    # HONEST result: "ssh work" now matches TWO snippets (nebula + LAN), and
+    # _attribute's "exactly one match else None" rule is deliberately unchanged,
+    # so the row still lands trigger=None. The win is that the term is no longer
+    # a GUARANTEED zero-match — a disambiguating token resolves it (below).
+    d = _det_for(SSH_BASE)
+    assert d._attribute("ssh work") is None
+    assert d._attribute("ssh work lan") == ":sshwl"
+    assert d._attribute("ssh work nebula") == ":sshwn"
+
+
+def test_multiword_ssh_lap_matches_only_laptop_snippets():
+    d = _det_for(SSH_BASE)
+    assert d._term_matches("ssh lap", ":sshln") is True
+    assert d._term_matches("ssh lap", ":sshll") is True
+    assert d._term_matches("ssh lap", ":sshwn") is False
+
+
+def test_multiword_civit_prod_attributes_uniquely():
+    # RED before the fix (returned None). "civit" ⊂ "civitai", "prod" ⊂ the
+    # label word "prod" — and ONLY :cpk carries "prod", so it resolves.
+    d = _det_for(CIVIT_BASE)
+    assert d._attribute("civit prod") == ":cpk"
+
+
+def test_multiword_end_to_end_through_search_ui():
+    d = _det_for(CIVIT_BASE)
+    d.feed_search_open(app=APP, session=SESS, now=0.0)
+    _type(d, "civit prod", now=1.0)
+    evs = list(d.feed_char("\n", app=APP, session=SESS, now=20.0))
+    assert len(evs) == 1
+    assert evs[0].trigger == ":cpk"
+    assert evs[0].search_term == "civit prod"
+    assert evs[0].method == "search" and evs[0].inferred is True
+
+
+def test_multiword_all_tokens_required():
+    # Every token must match — one bogus token disqualifies the snippet.
+    d = _det_for(CIVIT_BASE)
+    assert d._term_matches("civit zzzzz", ":cpk") is False
+    assert d._attribute("civit zzzzz") is None
+
+
+def test_single_word_term_behaviour_unchanged():
+    # The single-token path must be byte-for-byte the old semantics.
+    d = _det_for(CIVIT_BASE)
+    assert d._term_matches("prod", ":cpk") is True
+    assert d._term_matches("prod", ":cc") is False
+    assert d._attribute("prod") == ":cpk"
+    assert d._attribute("civitai") is None      # matches all 5 → ambiguous
+    assert d._attribute("submodel") == ":subk"
+    # ...and on the original fixture set too.
+    d2 = _det()
+    assert d2._attribute("leverage") == ":rnx"
+    assert d2._attribute("date") is None
+    assert d2._attribute("zzzzz") is None
+
+
+def test_multiword_term_with_extra_whitespace_is_tokenized():
+    d = _det_for(CIVIT_BASE)
+    assert d._attribute("  civit   prod  ") == ":cpk"

--- a/scripts/session-analysis/espanso-usage.py
+++ b/scripts/session-analysis/espanso-usage.py
@@ -127,12 +127,9 @@ def keylog_section(since):
 SNIPPETS = {
     ":date":     ("date", None, [], False),
     ":time":     ("date", None, [], False),
-    ":datetime": ("date", None, [], False),
-    ":iso":      ("date", None, [], False),
     # paths
     ":hlt":   ("path", ["homelab-talos"], [], False),
     ":kuc":   ("path", ["workspace/kubeclaw"], [], False),
-    ":nixos": ("path", ["/etc/nixos/configuration.nix"], [], False),
     ":cc":    ("path", ["civit/civitai "], [], False),
     ":cdp":   ("path", ["civit/datapacket-talos"], ["prod-kubeconfig"], False),
     ":cgf":   ("path", ["civitai-gpu-fleet"], [], False),
@@ -152,14 +149,22 @@ SNIPPETS = {
     #  typing-toil (shortcut existed but long form hand-typed instead):
     #  :ds [1 fire vs 94 typed], :rns [1 vs 20] —
     #  see claudedocs/espanso-typing-toil-2026-07-25.md)
-    ":eos":     ("prompt", ["identify skills that may need updating"], [], False),
+    # (removed 2026-08-05 via /espanso-audit — 0 keylog fires over 20 days:
+    #  :nixos :iso :datetime "reocmmend")
+    # :eos expansion rewritten 2026-08-04 (#325) — match BOTH the pre-rewrite text
+    # ("…identify skills … that may need updating") and the eviction-half rewrite.
+    ":eos":     ("prompt", ["may need updating", "write the handoff first"], [], False),
     ":acq":     ("prompt", ["recommend anything you think would be useful to include"], [], False),
     ":kickoff": ("prompt", ["kickoff message to copy paste to next session"], [], False),
+    # added 2026-08-05 via /espanso-audit — whole-standalone-message shaped, the
+    # only shape that sticks; typing-stream demand 81 / 68 rows respectively.
+    # NOTE :rna is deliberately "actions", NOT the pruned :rns's "steps" (3 rows).
+    ":rna":     ("prompt", ["recommend next actions"], [], False),
+    ":lr":      ("prompt", ["limit restored, resume agent"], [], False),
     # utilities / typo-correction — output not distinguishable
     ":uuid":     ("util", None, [], False),
     ":clip":     ("util", None, [], False),
     "dashbaord": ("typo", None, [], False),
-    "reocmmend": ("typo", None, [], False),
 }
 
 WORD = re.compile(r"[a-z][a-z'\-]+")


### PR DESCRIPTION
`/espanso-audit` over **2026-07-25 → 2026-08-05**, measured from the keylog stream (`source=keys, kind=espanso`) plus the raw `kind=typing` keystrokes.

## The finding that drives everything else

| signal | value |
|---|---|
| total espanso fires in window | 173 |
| via the **Ctrl+Space search UI** | **168** |
| direct-trigger | 5 — *all* of them `dashbaord` |
| direct `:`-trigger fires since the detector deployed (20 days) | **0** |
| the only 3 direct `:`-trigger fires ever | within 5 s on 2026-07-16 22:12 = deploy-day testing |

So `label` + `search_terms` **are** the entire interface. The trigger string is nearly irrelevant. Every change below tunes the search surface, not the trigger.

### Fires in window

| trigger | fires | search term used |
|---|---:|---|
| `:eos` | 72 | "rit" |
| `:kickoff` | 38 | "kick" / "kic" |
| `dashbaord` | 5 | (direct) |
| `:kuc` `:cc` `:cmo` `:csc` | 2 each | |
| `:cdp` `:cpk` `:hlt` `:rns` | 1 each | |
| everything else | 0 | |
| **unattributed search rows** | **46** | see the detector bug below |

## 1. `:acq` — a discoverability failure, not a content failure

**0 fires**, yet its expansion appears in **36 genuine user messages** (clipboard-pasted from elsewhere), and the keystroke stream shows the opener `dispatch to process feedback:` **hand-typed 12×**, twice trailing a mistyped `:acc`/`:accc`.

Demand is proven, so the **expansion text is untouched**. The root cause is that its `search_terms` (`ask`/`clarify`/`clarifying`/`questions`/`elicit`/`scope`/`include`) contain **none** of the words he actually types — *feedback*, *dispatch*, *process*. Those three are added; the label now leads with "feedback".

## 2. Added `:rna` and `:lr` — the shape that sticks

The predictor learned from the pruning history: snippets that are a **WHOLE STANDALONE MESSAGE** stick (`:eos` 72, `:kickoff` 38); mid-sentence **FRAGMENTS** die (`:ds`, `:rns`, `:pst`, `:rnx` — all previously pruned). Both additions are standalone-message shaped.

| new | expansion | typing-stream demand |
|---|---|---|
| `:rna` | `recommend next actions` | **81 rows**, 25 of them that phrase standing *alone* as a whole message |
| `:lr` | `limit restored, resume agent` | **68 rows** |

**Note the noun.** The previously-removed `:rns` said "recommend next **steps**" and was typed only **3×** — the real demand is "**actions**". He also searched the bar for `"recom"` on 2026-07-27 hunting for exactly this, and found nothing.

## 3. Pruned — 0 fires each over the 20-day window

| removed | why |
|---|---|
| `:nixos` | this host is a flake in `~/workspace/devrc`; `/etc/nixos/configuration.nix` is a dead path |
| `:iso`, `:datetime` | `:date` + `:time` cover it |
| `reocmmend` | the typo never recurred — unlike `dashbaord`, still the only snippet with direct-trigger traffic |

Removing `:datetime` also clears the last **prefix collision** in the set (`:date` was a prefix of it).

**Deliberately KEPT despite 0 attributed fires:** the four `:ssh*` plus `:cgf`/`:subk` — see below. Unattributable ≠ dead.

## 4. Detector measurement bug — multi-word search terms could never attribute

`scripts/collector/keylog/espanso_detect.py::_term_matches` required the whole search term to be a substring of a **single word** (of the trigger, of a label word, or of one `search_term`). Any term containing a space therefore matched **nothing, ever**.

**19+ of the 46 unattributed rows are multi-word**: `ssh work`, `ssh lap`, `ss wor`, `ssh worc`, `civit prod`. That is precisely why the four `:ssh*` snippets and `:cgf`/`:subk` looked dead.

The fix tokenizes on whitespace and requires **every** token to match by the existing per-token rules. A single-token term takes exactly the old path.

**`_attribute`'s "exactly one match else None" rule is unchanged — and `"ssh work"` still returns `None`**, because it legitimately matches *both* `:sshwn` and `:sshwl`. That multi-match behaviour is asserted explicitly rather than bent. The win is that the term is no longer a *guaranteed* zero-match: `ssh work lan` → `:sshwl`, `ssh work nebula` → `:sshwn`, and `civit prod` → `:cpk`.

## Verification

**Red → green on the detector fix** (8 new cases in `test_espanso_detect.py`, built from the **real** labels/`search_terms` in `nix/home.nix`):

- at `47daab8` (pre-change): `6 failed, 2 passed` — the 2 passes are the deliberate invariant guards pinning unchanged single-token behaviour.
- at HEAD: `8 passed`.

Other gates:

- `nix-instantiate --parse nix/home.nix` → clean (rc=0)
- **prefix/suffix collision check** over all 23 triggers → **0 collisions**; `:lr` and `:rna` have no prefix, suffix, or reverse relation with anything in the set. Harness positive-controlled against the pre-change file, which correctly reports `:date` is a prefix of `:datetime`.
- `pytest scripts/collector/keylog/tests/ -q` → **69 passed**
- transcript miner still runs after the `SNIPPETS` re-sync, and independently corroborates the additions: `:rna` 76 hits / 45 sessions, `:lr` 66 / 36, `:acq` 109 / 34 — and `:cgf` 45, `:subk` 3, confirming those are alive.

## Also

`scripts/session-analysis/espanso-usage.py`'s `SNIPPETS` is re-synced to the new set, including the `:eos` include-substrings that the 2026-08-04 (#325) expansion rewrite invalidated (the stale single substring `"identify skills that may need updating"` no longer appears in the expansion).

Not deployed — no `home-manager switch` / `ship.sh` run; that is yours after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
