### PR TITLE
insights: stop reporting an impossible time total; disclose the Layer-B window + denominator

### DIFF
--- a/scripts/session-analysis/insights.py
+++ b/scripts/session-analysis/insights.py
@@ -130,6 +130,39 @@ QUERY_SECTIONS = {
 
 
 # --------------------------------------------------------------------------- #
+# 🔴 WHY THERE IS NO "HOURS WORKED" FIGURE IN THIS REPORT
+# --------------------------------------------------------------------------- #
+# Layer A's `duration_minutes` is `round((end_ts - start_ts) / 60)` — the span
+# from a session's FIRST message to its LAST (session-tailer.py:372). It is
+# idle-inclusive, and a resumed session's span reaches back arbitrarily far, so
+# Σ duration_minutes is NOT bounded by the report's window and is NOT time spent.
+#
+# MEASURED 2026-08-05 over 2,393 real transcripts touched in a trailing 14d
+# window: Σ duration_minutes = 720,904 min = 12,015.1 h, against the 336 h of
+# wall clock that EXIST in 14 days — a 35.8× overstatement. Ten of those sessions
+# had a span longer than the whole window on their own; the worst was 818.5 h
+# (2026-06-23 → 2026-07-27). The built-in `/insights` reported this same quantity
+# as elapsed time and produced "12224h over a 44-day window" (1,056 h exist).
+#
+# Two mechanisms drive it and NEITHER is recoverable from Layer A:
+#   1. IDLE — a session open across a lunch, a night or a fortnight accrues span
+#      it did not work; there is no keystroke/turn-gap signal in the rollup.
+#   2. OVERLAP — Zach runs many concurrent agent sessions, so spans double-count
+#      the same wall-clock minute across sessions.
+# Clipping spans to the window would fix (1) partially and (2) not at all, and an
+# "active time" estimate would be a number nobody can validate. So the figure is
+# kept, RENAMED off "wall-clock", and printed next to the window's real bound so
+# a reader cannot mistake it for hours worked. `render_html` prints NO time
+# figure at all — see `test_hours_figure_ledger`.
+SESSION_SPAN_CAVEAT = (
+    "spans are IDLE-INCLUSIVE and overlap across concurrent sessions, and a "
+    "resumed session's span reaches back before the window — so this sum is NOT "
+    "bounded by the window and is NOT time worked. Layer A carries no "
+    "active-time signal; this report has no hours-worked figure."
+)
+
+
+# --------------------------------------------------------------------------- #
 # Pure helpers
 # --------------------------------------------------------------------------- #
 def window_seconds(days: int) -> int:
@@ -598,6 +631,11 @@ def aggregate(summary_rows: list[dict], message_rows: list[dict],
         "sessions": len(summary_rows),
         "unreadable_sessions": unreadable,
         "totals": dict(agg),
+        # 🔴 The bound that makes an impossible time total self-evident — see
+        # `SESSION_SPAN_CAVEAT`. `session_span_hours` is Σ per-session span; it is
+        # NOT clipped to the window and NOT bounded by `window_wall_clock_hours`.
+        "session_span_hours": num(agg.get("duration_minutes", 0)) / 60,
+        "window_wall_clock_hours": days * 24,
         "messages": prompt_n + command_n,
         "prompts": prompt_n,
         "commands": command_n,
@@ -735,8 +773,14 @@ def render(data: dict) -> str:
     out.append(f"  tokens:     {total_in:,} in "
                f"({in_fresh:,} fresh + {cache_r:,} cache-read + {cache_w:,} cache-write) "
                f"/ {num(t.get('output_tokens',0)):,} out")
-    dur_h = num(t.get('duration_minutes', 0)) / 60
-    out.append(f"  wall-clock: {dur_h:,.1f}h across sessions (sum of per-session spans)")
+    # 🔴 NOT "wall-clock" — see SESSION_SPAN_CAVEAT. The window's real bound is
+    # printed alongside so an impossible total flags itself.
+    span_h = num(data.get("session_span_hours", num(t.get('duration_minutes', 0)) / 60))
+    bound_h = num(data.get("window_wall_clock_hours", data["days"] * 24))
+    ratio = f" — {span_h / bound_h:,.1f}x MORE THAN EXISTS" if bound_h and span_h > bound_h else ""
+    out.append(f"  session span: {span_h:,.1f}h summed over {data['sessions']} session spans "
+               f"(the {data['days']}d window holds {bound_h:,.0f}h of wall clock{ratio})")
+    out.append(f"   NOTE: {SESSION_SPAN_CAVEAT}")
     out.append(f"  friction:   {t.get('interruptions',0)} interruptions · {t.get('tool_errors',0)} tool errors")
 
     def _bars(title, items, n=8):
@@ -780,6 +824,14 @@ def render(data: dict) -> str:
         out.append("  This report shows ONLY deterministic facts — no fabricated outcomes.")
         return "\n".join(out)
 
+    # 🔴 DENOMINATOR DISCLOSURE. The percentages below are over the Layer-B
+    # population, which is a DIFFERENT set (and a WIDER window) than the
+    # `sessions:` figure in ACTIVITY. The built-in report quoted four session
+    # populations in one document without ever naming which was which.
+    out.append(f"  population: {data['insight_sessions']} session(s) with a Layer-B insight "
+               f"in the trailing {data['insight_days']}d window — the percentages below "
+               f"are over THAT denominator, NOT the {data['sessions']} Layer-A session(s) "
+               f"in the {data['days']}d window above.")
     oc = data["outcomes"] or {}
     total_oc = sum(oc.values()) or 1
     peak = max(oc.values(), default=0)
@@ -885,7 +937,17 @@ def render_html(data: dict) -> str:
                          '<code>session_insight</code> via the activity skill. This report '
                          'shows ONLY deterministic facts — <b>no fabricated outcomes</b>.</p>')
     else:
-        parts = [_html_bars((data["outcomes"] or {}).items(), n=12)]
+        # 🔴 DENOMINATOR + WINDOW DISCLOSURE — the text renderer has carried this
+        # since it was written; the HTML one did not, so a reader saw the page's
+        # "trailing {days}d · {sessions} sessions" subtitle sitting directly above
+        # percentages drawn from a different population over a wider window.
+        parts = [
+            f'<p class="mut">Population: <b>{data["insight_sessions"]}</b> session(s) with a '
+            f'Layer-B insight in the trailing <b>{data["insight_days"]}d</b> window. The '
+            f'percentages below are over THAT denominator — <b>not</b> the '
+            f'{data["sessions"]} Layer-A session(s) in the {data["days"]}d window above.</p>',
+            _html_bars((data["outcomes"] or {}).items(), n=12),
+        ]
         h = data["helpfulness"]
         if h["n"]:
             parts.append(f'<p class="mut">mean Claude-helpfulness '
@@ -899,8 +961,12 @@ def render_html(data: dict) -> str:
                 f'×{a["sessions"]}</span><span class="bt"><i style="width:100%"></i></span>'
                 f'<span class="bv">{html.escape(a["description"][:80])}</span></div>'
                 for a in data["automation"][:10])
+            # Provenance label — parity with render()'s NOTE. These strings are
+            # MODEL-authored free text; without the label the HTML page presented
+            # them beside deterministic counts as if equally measured.
             parts.append(f'<p class="mut" style="margin-top:12px"><b>Automation candidates '
-                         f'(leverage-ranked)</b></p>{rows}')
+                         f'(leverage-ranked)</b> — model-surfaced qualitative candidates, '
+                         f'NOT measured savings.</p>{rows}')
         outcomes_html = "\n".join(parts)
     unreadable_note = ""
     if data["unreadable_sessions"]:
@@ -934,8 +1000,8 @@ table{{width:100%;border-collapse:collapse;font-size:13.5px}}td,th{{text-align:l
 footer{{color:var(--mut);font-size:12px;margin-top:40px;border-top:1px solid var(--line);padding-top:14px}}
 </style></head><body><div class="wrap">
 <h1>Claude Code Insights <span style="color:var(--acc)">· telemetry-native</span></h1>
-<p class="sub">{data['window_start_utc']} → now · trailing {data['days']}d · {html.escape(scope)} ·
-{data['sessions']} sessions · generated {data['generated_utc']}</p>
+<p class="sub">{data['window_start_utc']} → now · Layer A: trailing {data['days']}d · {html.escape(scope)} ·
+{data['sessions']} Layer-A sessions · generated {data['generated_utc']}</p>
 <div class="note">Deterministic view built from <code>activity.events</code> (Layer&nbsp;A
 session rollups + the prompt/command stream). No LLM, no confabulation. The qualitative
 layer (goal/outcome/friction) arrives in PR-2.</div>
@@ -972,7 +1038,7 @@ layer (goal/outcome/friction) arrives in PR-2.</div>
 <tr><th>host</th><th>sessions</th><th>messages</th><th>commits</th><th>out-tokens</th></tr>
 {hosts_rows}
 </table></div>
-<h2>OUTCOMES (qualitative — Layer B)</h2>
+<h2>OUTCOMES (qualitative — Layer B · trailing {data['insight_days']}d)</h2>
 <div class="card">{outcomes_html}</div>
 <footer>Telemetry-native successor to the built-in <code>/insights</code>.
 Regenerate: <code>insights.py --days {data['days']} --html PATH</code>. Source: activity.events.</footer>

--- a/scripts/session-analysis/insights.py
+++ b/scripts/session-analysis/insights.py
@@ -497,6 +497,14 @@ def aggregate_insights(insight_rows: list[dict]) -> dict:
     return {
         "insight_rows": len(insight_rows),
         "insight_sessions": readable,
+        # 🔴 The ACTUAL divisor of the outcome breakdown. It is NOT
+        # `insight_sessions`: the loop above only counts an outcome when
+        # `p.get("outcome")` is truthy, so a row that parses to `{}` (a torn,
+        # empty or non-object payload) is counted READABLE yet contributes no
+        # outcome. Disclosing `insight_sessions` beside a breakdown divided by
+        # this number is the same undisclosed-denominator defect as the span
+        # line. See `outcome_population_note`.
+        "outcome_sessions": sum(outcomes.values()),
         "unreadable_insights": unreadable,
         "outcomes": dict(outcomes.most_common()) if readable else None,
         "session_types": dict(session_types.most_common()),
@@ -663,6 +671,7 @@ def aggregate(summary_rows: list[dict], message_rows: list[dict],
         "insight_days": eff_insight_days,
         "insight_rows": ins["insight_rows"],
         "insight_sessions": ins["insight_sessions"],
+        "outcome_sessions": ins["outcome_sessions"],
         "unreadable_insights": ins["unreadable_insights"],
         "outcomes": ins["outcomes"],
         "session_types": ins["session_types"],
@@ -737,6 +746,28 @@ def _bar(n, peak, width=18):
     if peak <= 0:
         return ""
     return "█" * (max(1, round(n / peak * width)) if n > 0 else 0)
+
+
+def outcome_population_note(data: dict) -> str:
+    """The ONE sentence disclosing the OUTCOMES denominator — shared VERBATIM by
+    `render` and `render_html`.
+
+    🔴 It is a single function, not two format strings, on purpose. This exact
+    predicate has now regenerated the same bug twice on the pair of renderers
+    (the Layer-B window/denominator were disclosed in text but not in HTML; then
+    the HTML count was left unpinned and a wrong-population mutant survived).
+    A duplicated predicate is wrong at N−1 of its N sites — so it gets one site.
+
+    The number named here is `outcome_sessions`, which IS the breakdown's
+    divisor. `insight_sessions` is also named, because the gap between them is
+    the interesting fact: a row that parses to `{}` counts as readable but
+    reports no outcome, so it silently leaves the breakdown."""
+    div = int(num(data.get("outcome_sessions", 0)))
+    readable = int(num(data.get("insight_sessions", 0)))
+    return (f"population: {div} of {readable} readable Layer-B insight(s) in the "
+            f"trailing {data['insight_days']}d window reported an outcome — the "
+            f"outcome breakdown below covers exactly those {div}, NOT the "
+            f"{data['sessions']} Layer-A session(s) in the {data['days']}d window above.")
 
 
 def render_failure_banner(failed: dict) -> list[str]:
@@ -834,15 +865,15 @@ def render(data: dict) -> str:
         out.append("  This report shows ONLY deterministic facts — no fabricated outcomes.")
         return "\n".join(out)
 
-    # 🔴 DENOMINATOR DISCLOSURE. The percentages below are over the Layer-B
+    # 🔴 DENOMINATOR DISCLOSURE. The breakdown below is over the Layer-B
     # population, which is a DIFFERENT set (and a WIDER window) than the
     # `sessions:` figure in ACTIVITY. The built-in report quoted four session
     # populations in one document without ever naming which was which.
-    out.append(f"  population: {data['insight_sessions']} session(s) with a Layer-B insight "
-               f"in the trailing {data['insight_days']}d window — the percentages below "
-               f"are over THAT denominator, NOT the {data['sessions']} Layer-A session(s) "
-               f"in the {data['days']}d window above.")
+    out.append(f"  {outcome_population_note(data)}")
     oc = data["outcomes"] or {}
+    # The disclosed number and the divisor are ONE value — `outcome_sessions`.
+    # `or 1` only guards division by zero, and when it fires `oc` is empty so no
+    # percentage is ever printed against it.
     total_oc = sum(oc.values()) or 1
     peak = max(oc.values(), default=0)
     for name, cnt in oc.items():
@@ -950,12 +981,11 @@ def render_html(data: dict) -> str:
         # 🔴 DENOMINATOR + WINDOW DISCLOSURE — the text renderer has carried this
         # since it was written; the HTML one did not, so a reader saw the page's
         # "trailing {days}d · {sessions} sessions" subtitle sitting directly above
-        # percentages drawn from a different population over a wider window.
+        # a breakdown drawn from a different population over a wider window.
+        # The sentence is `outcome_population_note` VERBATIM — the same string
+        # the text renderer prints, so the two surfaces cannot drift again.
         parts = [
-            f'<p class="mut">Population: <b>{data["insight_sessions"]}</b> session(s) with a '
-            f'Layer-B insight in the trailing <b>{data["insight_days"]}d</b> window. The '
-            f'percentages below are over THAT denominator — <b>not</b> the '
-            f'{data["sessions"]} Layer-A session(s) in the {data["days"]}d window above.</p>',
+            f'<p class="mut">{html.escape(outcome_population_note(data))}</p>',
             _html_bars((data["outcomes"] or {}).items(), n=12),
         ]
         h = data["helpfulness"]

--- a/scripts/session-analysis/insights.py
+++ b/scripts/session-analysis/insights.py
@@ -636,6 +636,13 @@ def aggregate(summary_rows: list[dict], message_rows: list[dict],
         # NOT clipped to the window and NOT bounded by `window_wall_clock_hours`.
         "session_span_hours": num(agg.get("duration_minutes", 0)) / 60,
         "window_wall_clock_hours": days * 24,
+        # 🔴 The span sum's ACTUAL divisor population. The loop above `continue`s
+        # on an unreadable row BEFORE reaching `duration_minutes`, so an
+        # unreadable session contributes no span and must not be counted as one.
+        # `sessions` (= len(summary_rows)) is a DIFFERENT population, and printing
+        # it beside the sum reproduced — inside this very report — the
+        # undisclosed-denominator defect the rest of this file exists to close.
+        "session_span_sessions": len(summary_rows) - unreadable,
         "messages": prompt_n + command_n,
         "prompts": prompt_n,
         "commands": command_n,
@@ -778,7 +785,10 @@ def render(data: dict) -> str:
     span_h = num(data.get("session_span_hours", num(t.get('duration_minutes', 0)) / 60))
     bound_h = num(data.get("window_wall_clock_hours", data["days"] * 24))
     ratio = f" — {span_h / bound_h:,.1f}x MORE THAN EXISTS" if bound_h and span_h > bound_h else ""
-    out.append(f"  session span: {span_h:,.1f}h summed over {data['sessions']} session spans "
+    # NOT data['sessions'] — an unreadable session contributes no span. See
+    # `session_span_sessions`.
+    span_n = data.get("session_span_sessions", data["sessions"] - data["unreadable_sessions"])
+    out.append(f"  session span: {span_h:,.1f}h summed over {span_n} session spans "
                f"(the {data['days']}d window holds {bound_h:,.0f}h of wall clock{ratio})")
     out.append(f"   NOTE: {SESSION_SPAN_CAVEAT}")
     out.append(f"  friction:   {t.get('interruptions',0)} interruptions · {t.get('tool_errors',0)} tool errors")

--- a/scripts/session-analysis/tests/test_insights_quantitative_honesty.py
+++ b/scripts/session-analysis/tests/test_insights_quantitative_honesty.py
@@ -1,0 +1,257 @@
+"""insights — the QUANTITATIVE-HONESTY contract of the rendered report.
+
+Three defect classes were measured in the built-in `/insights` output on
+2026-08-05 and tested against OUR tool. This file pins the two that were REAL:
+
+  H1  IMPOSSIBLE TIME TOTAL. Layer A's `duration_minutes` is
+      `round((end_ts - start_ts) / 60)` — session-tailer.py:372 — an
+      idle-inclusive span, unclipped to the report window. insights.py summed it
+      and printed it as `wall-clock: Nh across sessions`. MEASURED over 2,393
+      real transcripts touched in a trailing 14d window: Σ = 720,904 min =
+      12,015.1 h against the 336 h that EXIST in 14 days (35.8x). Ten individual
+      sessions had a span longer than the whole window.
+
+  H2/H3  UNDISCLOSED WINDOW + DENOMINATOR. Layer B deliberately uses a WIDER
+      window than Layer A (`max(--insight-days or 30, --days)`) and a different
+      session population. `render()` labelled the window but never the
+      denominator; `render_html()` labelled NEITHER — its subtitle said
+      "trailing 14d · 2 sessions" directly above percentages computed over a
+      30d Layer-B population.
+
+Every expected value below is a LITERAL pinned from the fixture arithmetic
+(40,320 min = 672.0 h; a 14d window = 336 h; 672/336 = 2.0x), never read back
+out of the implementation.
+
+The window is NOT applied inconsistently — every Layer-A query uses `win`, the
+Layer-B query uses `iwin` by design, and write.py stamps a session-insight row's
+`ts` with the session's own `end_ts` (write.py:15-18), so the built-in's
+"pooled three older analysis batches" mechanism structurally cannot occur here.
+That is asserted in test_insights.py::test_gather_uses_wider_insight_window.
+"""
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import importlib.util
+
+_SPEC = importlib.util.spec_from_file_location(
+    "insights", os.path.join(os.path.dirname(__file__), "..", "insights.py"))
+I = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(I)
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures — spans chosen so the arithmetic is exact and quotable.
+#   25,000 + 15,320 = 40,320 minutes = 672.0 h
+#   a 14-day window  = 336 h of wall clock
+#   672.0 / 336      = 2.0x
+# --------------------------------------------------------------------------- #
+def _line(text, needle):
+    """The ONE rendered line containing `needle` — with a named failure rather
+    than a bare StopIteration when the line is absent entirely."""
+    hits = [l for l in text.splitlines() if needle in l]
+    assert hits, f"no rendered line contains {needle!r}"
+    assert len(hits) == 1, f"{needle!r} appears on {len(hits)} lines: {hits}"
+    return hits[0]
+
+
+def _summary(session, host, project, payload):
+    return {"session": session, "sess_host": host, "project": project,
+            "ts": "2026-08-01 00:00:00.000", "payload": json.dumps(payload)}
+
+
+def _spans(a_minutes, b_minutes):
+    return [
+        _summary("s1", "workbench", "devrc", {
+            "user_message_count": 4, "assistant_message_count": 40,
+            "duration_minutes": a_minutes, "unreadable": False}),
+        _summary("s2", "laptop", "homelab-talos", {
+            "user_message_count": 2, "assistant_message_count": 20,
+            "duration_minutes": b_minutes, "unreadable": False}),
+    ]
+
+
+def _one_insight():
+    """ONE Layer-B row against TWO Layer-A sessions — so the two denominators
+    are distinguishable in the output (1 vs 2)."""
+    return [{"session": "s1", "payload": json.dumps({
+        "outcome": "fully_achieved", "session_type": "feature_build",
+        "goal_categories": ["infra"], "claude_helpfulness": 5,
+        "friction_counts": {"wrong_approach": 2}, "friction_detail": [],
+        "automation_opportunity": {"present": True, "description": "wrap deploy dance",
+                                   "trigger": "hand-typed switch", "leverage": "high",
+                                   "evidence": "did it by hand"},
+        "recurring_toil": None, "workflow_gap": None, "unreadable": False})}]
+
+
+# --------------------------------------------------------------------------- #
+# H1 — the time figure
+# --------------------------------------------------------------------------- #
+def test_window_wall_clock_bound_is_reported():
+    """REGRESSION. The report must carry the number of hours that ACTUALLY exist
+    in its window, so a span sum can be checked against it without arithmetic."""
+    d = I.aggregate(_spans(25000, 15320), [], [], 14, None)
+    assert d["window_wall_clock_hours"] == 336          # 14 * 24, pinned literally
+    assert d["session_span_hours"] == 672.0             # 40320 / 60, pinned literally
+
+
+def test_span_total_is_not_called_wall_clock():
+    """REGRESSION. `wall-clock` reads as elapsed time actually spent. The figure
+    is Σ(last message − first message), idle-inclusive and overlapping."""
+    d = I.aggregate(_spans(25000, 15320), [], [], 14, None)
+    text = I.render(d)
+    assert "wall-clock:" not in text
+    assert "session span:" in text
+
+
+def test_span_total_is_printed_beside_the_windows_real_bound():
+    """REGRESSION. 672.0h cannot be time worked inside a window holding 336h —
+    the report must print both numbers so that is visible without a calculator."""
+    d = I.aggregate(_spans(25000, 15320), [], [], 14, None)
+    line = _line(I.render(d), "session span:")
+    assert "672.0h" in line
+    assert "336h" in line
+    assert "2.0x MORE THAN EXISTS" in line
+
+
+def test_span_total_carries_the_idle_inclusive_caveat():
+    """REGRESSION. The caveat naming BOTH mechanisms (idle + overlap) must ride
+    with the number, not live only in a source comment."""
+    text = I.render(I.aggregate(_spans(25000, 15320), [], [], 14, None))
+    assert "IDLE-INCLUSIVE" in text
+    assert "overlap across concurrent sessions" in text
+    assert "no hours-worked figure" in text
+
+
+def test_no_impossibility_marker_when_the_span_fits_the_window():
+    """POSITIVE/NEGATIVE CONTROL PAIR for the marker above. A span sum that fits
+    inside the window must NOT be flagged — otherwise the flag in the previous
+    test would be indistinguishable from a marker that is always printed."""
+    d = I.aggregate(_spans(30, 30), [], [], 14, None)   # 60 min = 1.0h << 336h
+    line = _line(I.render(d), "session span:")
+    assert "1.0h" in line and "336h" in line
+    assert "MORE THAN EXISTS" not in line
+    # …and the caveat still rides along, because idle/overlap apply either way.
+    assert "IDLE-INCLUSIVE" in I.render(d)
+
+
+def test_hours_figure_ledger():
+    """SEAM GUARD (pins a RELATIONSHIP, fails if the set grows OR shrinks).
+
+    Exactly ONE renderer emits an hours figure — `render`. `render_html` emits
+    none, which is why it needs no span caveat. If a future change adds an hours
+    stat tile to the HTML page this goes red, forcing the caveat decision to be
+    made again rather than inherited silently."""
+    d = I.aggregate(_spans(25000, 15320), [], _one_insight(), 14, None)
+    hours_rx = re.compile(r"\d[\d,]*\.\d+\s*h\b")
+    emitters = {name for name, out in (("render", I.render(d)),
+                                       ("render_html", I.render_html(d)))
+                if hours_rx.search(out)}
+    assert emitters == {"render"}, (
+        "a renderer's hours-figure status changed; if render_html now prints "
+        "hours it MUST carry SESSION_SPAN_CAVEAT — see insights.py")
+
+
+# --------------------------------------------------------------------------- #
+# H2 / H3 — window + denominator disclosure
+# --------------------------------------------------------------------------- #
+def test_text_report_names_the_layer_b_denominator():
+    """REGRESSION. The outcome percentages are over the Layer-B population (1
+    here), not the ACTIVITY `sessions:` figure (2). Both numbers must appear
+    next to the percentages."""
+    d = I.aggregate(_spans(25000, 15320), [], _one_insight(), 14, None)
+    text = I.render(d)
+    assert d["sessions"] == 2 and d["insight_sessions"] == 1     # fixture sanity
+    pop = _line(text, "population:")
+    assert "1 session(s) with a Layer-B insight" in pop
+    assert "trailing 30d window" in pop
+    assert "2 Layer-A session(s)" in pop
+    assert "in the 14d window above" in pop
+
+
+def test_html_report_labels_the_layer_b_window():
+    """REGRESSION. The HTML page's subtitle claims a 14d window; its OUTCOMES
+    section is drawn from 30d. The heading must say so."""
+    d = I.aggregate(_spans(25000, 15320), [], _one_insight(), 14, None)
+    htm = I.render_html(d)
+    heading = re.search(r"<h2>OUTCOMES[^<]*</h2>", htm).group(0)
+    assert "trailing 30d" in heading
+
+
+def test_html_report_names_the_layer_b_denominator():
+    """REGRESSION. Same disclosure as the text renderer, on the page that had
+    none of it."""
+    htm = I.render_html(I.aggregate(_spans(25000, 15320), [], _one_insight(), 14, None))
+    assert "Population:" in htm
+    assert "session(s) with a Layer-B insight in the trailing <b>30d</b> window" in htm
+    assert "2 Layer-A session(s) in the 14d window above" in htm
+
+
+def test_html_subtitle_scopes_its_session_count_to_layer_a():
+    """REGRESSION. A bare `2 sessions` in the subtitle is the ambiguity that let
+    four populations share one document in the built-in's report."""
+    htm = I.render_html(I.aggregate(_spans(25000, 15320), [], _one_insight(), 14, None))
+    sub = re.search(r'<p class="sub">(.*?)</p>', htm, re.S).group(1)
+    assert "Layer A: trailing 14d" in sub
+    assert "2 Layer-A sessions" in sub
+
+
+def test_html_labels_model_surfaced_candidates_as_unmeasured():
+    """REGRESSION. `render()` has always carried this NOTE; the HTML page
+    rendered model-authored free text beside deterministic counts with no
+    provenance label at all."""
+    htm = I.render_html(I.aggregate(_spans(25000, 15320), [], _one_insight(), 14, None))
+    assert "wrap deploy dance" in htm            # the free text IS rendered…
+    assert "NOT measured savings" in htm         # …and IS labelled as unmeasured
+
+
+def test_layer_b_freetext_is_never_rendered_without_a_provenance_label():
+    """SEAM GUARD across BOTH renderers. Model-authored strings and measured
+    counts share one document; whichever renderer emits the former must also
+    emit the label. Each surface was individually 'fine' — the defect lived in
+    the pair."""
+    d = I.aggregate(_spans(25000, 15320), [], _one_insight(), 14, None)
+    for name, out in (("render", I.render(d)), ("render_html", I.render_html(d))):
+        if "wrap deploy dance" in out:
+            assert "NOT measured savings" in out, f"{name} renders model free text unlabelled"
+
+
+# --------------------------------------------------------------------------- #
+# H4 — the anti-confabulation contract: a DOCUMENTED-LIMIT guard, NOT regression
+# --------------------------------------------------------------------------- #
+def test_anti_confabulation_contract_is_prompt_only_not_validated():
+    """DOCUMENTED-LIMIT GUARD (deliberately not a regression test — nothing was
+    changed here).
+
+    `ANTI_CONFABULATION_CONTRACT` forbids inventing counts/limits, but
+    `validate()` polices STRUCTURE (types, closed enums, the unreadable/reason
+    invariant) — it does not and cannot read prose. A payload carrying the exact
+    two claims the built-in confabulated on 2026-08-05 validates cleanly.
+
+    This is pinned so the limit is discovered by a red test rather than by
+    trusting the contract string, and so anyone adding a content check has to
+    decide it here. A keyword scan was considered and REJECTED: it would pass
+    while the same hazard appears in any other wording (a spelled guard, not a
+    structural one). The real mitigation is the provenance labels asserted
+    above — the report never presents this text as measured."""
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "session_insight"))
+    import schema as S
+
+    confabulated = {
+        "session": "x", "underlying_goal": "g", "goal_categories": ["infra"],
+        "outcome": "not_achieved", "session_type": "investigation",
+        "claude_helpfulness": 1, "friction_counts": {},
+        "friction_detail": ["at least 12 sessions produced nothing but "
+                            "output-token-limit errors"],
+        "primary_success": "",
+        "brief_summary": "A 633-minute session produced no analyzable content.",
+        "automation_opportunity": None, "recurring_toil": None,
+        "workflow_gap": None, "unreadable": False, "unreadable_reason": "",
+    }
+    assert S.validate(confabulated) == []
+    assert S.vocab_warnings(confabulated) == []
+    # The contract text itself must still name the failure mode it forbids.
+    assert "output-token maximum" in S.ANTI_CONFABULATION_CONTRACT
+    assert "MUST NOT invent any count, limit, or metric" in S.ANTI_CONFABULATION_CONTRACT

--- a/scripts/session-analysis/tests/test_insights_quantitative_honesty.py
+++ b/scripts/session-analysis/tests/test_insights_quantitative_honesty.py
@@ -73,9 +73,38 @@ def _spans(a_minutes, b_minutes):
     ]
 
 
+def _unreadable(session):
+    return _summary(session, "workbench", "devrc", {"unreadable": True})
+
+
+def _mixed_readability():
+    """FIVE Layer-A rows: THREE readable (spans 20,160 + 13,440 + 6,720 =
+    40,320 min = 672.0 h) and TWO unreadable.
+
+    Every count in play is pairwise distinct — 5 rows / 2 unreadable / 3 spans /
+    14 days — so an operand swap cannot masquerade as the right answer, and the
+    three span values are distinct too so a summation bug cannot cancel out.
+    The unreadable rows carry NO `duration_minutes`: the aggregate loop
+    `continue`s on them before reaching it, which is precisely why the printed
+    denominator must be 3 and not 5."""
+    return [
+        _summary("r1", "workbench", "devrc", {
+            "user_message_count": 4, "assistant_message_count": 40,
+            "duration_minutes": 20160, "unreadable": False}),
+        _summary("r2", "laptop", "homelab-talos", {
+            "user_message_count": 2, "assistant_message_count": 20,
+            "duration_minutes": 13440, "unreadable": False}),
+        _summary("r3", "workbench", "devrc", {
+            "user_message_count": 1, "assistant_message_count": 10,
+            "duration_minutes": 6720, "unreadable": False}),
+        _unreadable("u1"),
+        _unreadable("u2"),
+    ]
+
+
 def _one_insight():
-    """ONE Layer-B row against TWO Layer-A sessions — so the two denominators
-    are distinguishable in the output (1 vs 2)."""
+    """ONE Layer-B row, used against a Layer-A population of a DIFFERENT size so
+    the two denominators are never interchangeable in an assertion."""
     return [{"session": "s1", "payload": json.dumps({
         "outcome": "fully_achieved", "session_type": "feature_build",
         "goal_categories": ["infra"], "claude_helpfulness": 5,
@@ -84,6 +113,15 @@ def _one_insight():
                                    "trigger": "hand-typed switch", "leverage": "high",
                                    "evidence": "did it by hand"},
         "recurring_toil": None, "workflow_gap": None, "unreadable": False})}]
+
+
+def _four_readable():
+    """FOUR readable Layer-A sessions, for the denominator/window tests. Paired
+    with `_one_insight()` and `days=7` every number in the assertions is
+    pairwise distinct: 4 Layer-A / 1 Layer-B / 7d Layer-A / 30d Layer-B."""
+    return [_summary(f"q{i}", "workbench", "devrc", {
+        "user_message_count": 1, "assistant_message_count": 1,
+        "duration_minutes": 10 * (i + 1), "unreadable": False}) for i in range(4)]
 
 
 # --------------------------------------------------------------------------- #
@@ -137,6 +175,47 @@ def test_no_impossibility_marker_when_the_span_fits_the_window():
     assert "IDLE-INCLUSIVE" in I.render(d)
 
 
+def test_span_denominator_counts_only_sessions_that_contributed_a_span():
+    """REGRESSION (audit round 2, finding 1).
+
+    The span sum's divisor is NOT `len(summary_rows)`: aggregate()'s loop
+    `continue`s on an unreadable row BEFORE reaching `duration_minutes`, so an
+    unreadable session contributes nothing. Printing the all-rows count beside
+    the sum made the report contradict itself two lines apart — `sessions: 5 (2
+    unreadable)` above `summed over 5 session spans` — which is the
+    undisclosed-denominator defect this file exists to close, re-created inside
+    the fix for it.
+
+    Fixture: 5 rows, 2 unreadable, 3 readable spans summing to 40,320 min. The
+    right answer (3) and the wrong one (5) are distinct, as are the days (14)
+    and the unreadable count (2), so no operand swap yields a passing value.
+
+    Split from the render-level test below deliberately: asserting the data key
+    FIRST would KeyError at the pre-fix tip and the rendered line — the thing a
+    reader actually sees — would never be exercised."""
+    d = I.aggregate(_mixed_readability(), [], [], 14, None)
+    assert d["sessions"] == 5
+    assert d["unreadable_sessions"] == 2
+    assert d["session_span_hours"] == 672.0        # 40320 / 60
+    assert d["totals"]["duration_minutes"] == 40320
+    assert d["session_span_sessions"] == 3
+
+
+def test_span_line_discloses_the_readable_denominator():
+    """REGRESSION (audit round 2, finding 1) — the RENDERED half.
+
+    Reaches the span line with NO dependency on the new data key, so it fails on
+    the wrong printed number rather than on a KeyError from an earlier
+    assertion. At the pre-fix tip this line read `summed over 5 session spans`
+    two lines below `sessions: 5 (2 unreadable)` — self-contradicting on one
+    screen."""
+    text = I.render(I.aggregate(_mixed_readability(), [], [], 14, None))
+    assert "sessions:   5  (2 unreadable)" in text
+    line = _line(text, "session span:")
+    assert "672.0h summed over 3 session spans" in line
+    assert "5 session spans" not in line
+
+
 def test_hours_figure_ledger():
     """SEAM GUARD (pins a RELATIONSHIP, fails if the set grows OR shrinks).
 
@@ -157,52 +236,69 @@ def test_hours_figure_ledger():
 # --------------------------------------------------------------------------- #
 # H2 / H3 — window + denominator disclosure
 # --------------------------------------------------------------------------- #
+# All four disclosure tests share one pairwise-distinct case so that NO pair of
+# reported numbers is interchangeable: 4 Layer-A sessions · 1 Layer-B insight ·
+# 7d Layer-A window · 30d Layer-B window.
+def _disclosure_case():
+    return I.aggregate(_four_readable(), [], _one_insight(), 7, None)
+
+
+def test_disclosure_fixture_numbers_are_pairwise_distinct():
+    """INVARIANT GUARD (not regression) — the precondition the four tests below
+    rest on. If these ever collide, a swapped operand starts passing silently."""
+    d = _disclosure_case()
+    nums = [d["sessions"], d["insight_sessions"], d["days"], d["insight_days"]]
+    assert nums == [4, 1, 7, 30]
+    assert len(set(nums)) == len(nums)
+
+
 def test_text_report_names_the_layer_b_denominator():
-    """REGRESSION. The outcome percentages are over the Layer-B population (1
-    here), not the ACTIVITY `sessions:` figure (2). Both numbers must appear
-    next to the percentages."""
-    d = I.aggregate(_spans(25000, 15320), [], _one_insight(), 14, None)
-    text = I.render(d)
-    assert d["sessions"] == 2 and d["insight_sessions"] == 1     # fixture sanity
-    pop = _line(text, "population:")
-    assert "1 session(s) with a Layer-B insight" in pop
-    assert "trailing 30d window" in pop
-    assert "2 Layer-A session(s)" in pop
-    assert "in the 14d window above" in pop
+    """REGRESSION. The outcome percentages are over the Layer-B population (1),
+    not the ACTIVITY `sessions:` figure (4). Both numbers must appear next to
+    the percentages, and both are pinned by VALUE."""
+    pop = _line(I.render(_disclosure_case()), "population:")
+    assert "population: 1 session(s) with a Layer-B insight" in pop
+    assert "in the trailing 30d window" in pop
+    assert "NOT the 4 Layer-A session(s)" in pop
+    assert "in the 7d window above" in pop
 
 
 def test_html_report_labels_the_layer_b_window():
-    """REGRESSION. The HTML page's subtitle claims a 14d window; its OUTCOMES
+    """REGRESSION. The HTML page's subtitle claims a 7d window; its OUTCOMES
     section is drawn from 30d. The heading must say so."""
-    d = I.aggregate(_spans(25000, 15320), [], _one_insight(), 14, None)
-    htm = I.render_html(d)
-    heading = re.search(r"<h2>OUTCOMES[^<]*</h2>", htm).group(0)
+    heading = re.search(r"<h2>OUTCOMES[^<]*</h2>", I.render_html(_disclosure_case())).group(0)
     assert "trailing 30d" in heading
+    assert "trailing 7d" not in heading
 
 
 def test_html_report_names_the_layer_b_denominator():
-    """REGRESSION. Same disclosure as the text renderer, on the page that had
-    none of it."""
-    htm = I.render_html(I.aggregate(_spans(25000, 15320), [], _one_insight(), 14, None))
-    assert "Population:" in htm
-    assert "session(s) with a Layer-B insight in the trailing <b>30d</b> window" in htm
-    assert "2 Layer-A session(s) in the 14d window above" in htm
+    """REGRESSION (strengthened in audit round 2, finding 3).
+
+    The first version asserted only the substring AFTER the count's `</b>`, so
+    swapping `insight_sessions` for `sessions` in render_html left it green
+    while the page printed the Layer-A count as the Layer-B population — the
+    exact asymmetric-surface defect this PR set out to close, re-created in the
+    guard added to close it. Both numbers are now pinned BY VALUE, inside one
+    contiguous match so the count cannot drift away from its own label."""
+    htm = I.render_html(_disclosure_case())
+    assert ("Population: <b>1</b> session(s) with a Layer-B insight in the "
+            "trailing <b>30d</b> window") in htm
+    assert "not</b> the 4 Layer-A session(s) in the 7d window above" in htm
 
 
 def test_html_subtitle_scopes_its_session_count_to_layer_a():
-    """REGRESSION. A bare `2 sessions` in the subtitle is the ambiguity that let
+    """REGRESSION. A bare `4 sessions` in the subtitle is the ambiguity that let
     four populations share one document in the built-in's report."""
-    htm = I.render_html(I.aggregate(_spans(25000, 15320), [], _one_insight(), 14, None))
-    sub = re.search(r'<p class="sub">(.*?)</p>', htm, re.S).group(1)
-    assert "Layer A: trailing 14d" in sub
-    assert "2 Layer-A sessions" in sub
+    sub = re.search(r'<p class="sub">(.*?)</p>', I.render_html(_disclosure_case()), re.S).group(1)
+    assert "Layer A: trailing 7d" in sub
+    assert "4 Layer-A sessions" in sub
 
 
 def test_html_labels_model_surfaced_candidates_as_unmeasured():
     """REGRESSION. `render()` has always carried this NOTE; the HTML page
     rendered model-authored free text beside deterministic counts with no
     provenance label at all."""
-    htm = I.render_html(I.aggregate(_spans(25000, 15320), [], _one_insight(), 14, None))
+    htm = I.render_html(_disclosure_case())
     assert "wrap deploy dance" in htm            # the free text IS rendered…
     assert "NOT measured savings" in htm         # …and IS labelled as unmeasured
 

--- a/scripts/session-analysis/tests/test_insights_quantitative_honesty.py
+++ b/scripts/session-analysis/tests/test_insights_quantitative_honesty.py
@@ -253,12 +253,13 @@ def test_disclosure_fixture_numbers_are_pairwise_distinct():
 
 
 def test_text_report_names_the_layer_b_denominator():
-    """REGRESSION. The outcome percentages are over the Layer-B population (1),
-    not the ACTIVITY `sessions:` figure (4). Both numbers must appear next to
-    the percentages, and both are pinned by VALUE."""
+    """REGRESSION. The outcome breakdown is over the Layer-B population (1), not
+    the ACTIVITY `sessions:` figure (4). Both numbers must appear next to the
+    breakdown, and both are pinned by VALUE."""
     pop = _line(I.render(_disclosure_case()), "population:")
-    assert "population: 1 session(s) with a Layer-B insight" in pop
-    assert "in the trailing 30d window" in pop
+    assert "population: 1 of 1 readable Layer-B insight(s)" in pop
+    assert "in the trailing 30d window reported an outcome" in pop
+    assert "covers exactly those 1" in pop
     assert "NOT the 4 Layer-A session(s)" in pop
     assert "in the 7d window above" in pop
 
@@ -281,9 +282,9 @@ def test_html_report_names_the_layer_b_denominator():
     guard added to close it. Both numbers are now pinned BY VALUE, inside one
     contiguous match so the count cannot drift away from its own label."""
     htm = I.render_html(_disclosure_case())
-    assert ("Population: <b>1</b> session(s) with a Layer-B insight in the "
-            "trailing <b>30d</b> window") in htm
-    assert "not</b> the 4 Layer-A session(s) in the 7d window above" in htm
+    assert ("population: 1 of 1 readable Layer-B insight(s) in the trailing 30d "
+            "window reported an outcome") in htm
+    assert "covers exactly those 1, NOT the 4 Layer-A session(s) in the 7d window above" in htm
 
 
 def test_html_subtitle_scopes_its_session_count_to_layer_a():
@@ -292,6 +293,98 @@ def test_html_subtitle_scopes_its_session_count_to_layer_a():
     sub = re.search(r'<p class="sub">(.*?)</p>', I.render_html(_disclosure_case()), re.S).group(1)
     assert "Layer A: trailing 7d" in sub
     assert "4 Layer-A sessions" in sub
+
+
+# --------------------------------------------------------------------------- #
+# The disclosed denominator MUST be the actual divisor (audit round 3)
+# --------------------------------------------------------------------------- #
+def _outcome_divergence_case():
+    """THREE Layer-B rows: two well-formed (distinct outcomes) and ONE whose
+    payload is a TORN JSON fragment.
+
+    `_parse_payload` returns `{}` for that row; `{}.get("unreadable")` is None —
+    falsy — so aggregate_insights counts it READABLE, while `p.get("outcome")`
+    is None so it contributes NO outcome. Disclosed population 3, actual
+    divisor 2 (distinct, so a swap cannot pass), against 5 Layer-A sessions and
+    a 14d/30d window pair — every number pairwise distinct.
+
+    🔴 REACHABILITY, measured 2026-08-05 — do NOT read this fixture as a claim
+    that the sanctioned pipeline emits such a row. It does not: `validate()`
+    hard-fails a readable payload whose `outcome` is falsy, absent or
+    out-of-enum (checked against None/''/0/False/'unknown_value'/absent), and
+    consolidate.py:97-100 quarantines anything validate() rejects. The route
+    that DOES produce `{}` is a payload that fails to parse as a JSON object —
+    a torn/truncated emit line, an empty payload column, or valid JSON that is
+    not an object — which is exactly what write.py's sub-PIPE_BUF line budget
+    exists to prevent. Frequency in the live table is UNMEASURED. So: the
+    RENDERING defect below is real and red-before/green-after, but its
+    precondition is a malformed row, not routine operation."""
+    good = [
+        {"session": "a", "payload": json.dumps({
+            "outcome": "fully_achieved", "session_type": "feature_build",
+            "goal_categories": ["infra"], "claude_helpfulness": 5,
+            "friction_counts": {}, "friction_detail": [],
+            "automation_opportunity": None, "recurring_toil": None,
+            "workflow_gap": None, "unreadable": False})},
+        {"session": "b", "payload": json.dumps({
+            "outcome": "partially_achieved", "session_type": "bugfix",
+            "goal_categories": ["bugfix"], "claude_helpfulness": 3,
+            "friction_counts": {}, "friction_detail": [],
+            "automation_opportunity": None, "recurring_toil": None,
+            "workflow_gap": None, "unreadable": False})},
+        {"session": "c", "payload": '{"outcome": "fully_ach'},   # torn emit line
+    ]
+    return I.aggregate(_mixed_readability(), [], good, 14, None)
+
+
+def test_outcome_sessions_is_the_breakdowns_actual_divisor():
+    """REGRESSION. `outcome_sessions` must be the number the breakdown is
+    divided by, which is NOT `insight_sessions` when a row parses to `{}`."""
+    d = _outcome_divergence_case()
+    assert d["insight_sessions"] == 3          # the torn row counts as readable
+    assert d["unreadable_insights"] == 0       # …and is NOT flagged unreadable
+    assert d["outcome_sessions"] == 2          # …but reports no outcome
+    assert sum(d["outcomes"].values()) == 2    # the literal divisor
+
+
+def test_text_discloses_the_divisor_not_the_readable_count():
+    """REGRESSION. Two outcomes each render as 50% — a divisor of 2 — so the
+    disclosed number must be 2. Before this fix the line disclosed 3."""
+    d = _outcome_divergence_case()
+    text = I.render(d)
+    pop = _line(text, "population:")
+    assert "population: 2 of 3 readable Layer-B insight(s)" in pop
+    assert "covers exactly those 2" in pop
+    # The rendered percentages prove 2 really is the divisor.
+    assert "1   50%" in _line(text, "fully_achieved")
+    assert "1   50%" in _line(text, "partially_achieved")
+
+
+def test_html_discloses_the_divisor_not_the_readable_count():
+    """REGRESSION — the same guard on the OTHER surface. The asymmetric-surface
+    trap has bitten this PR once already, so both renderers are pinned."""
+    htm = I.render_html(_outcome_divergence_case())
+    assert "population: 2 of 3 readable Layer-B insight(s)" in htm
+    assert "covers exactly those 2" in htm
+    assert "population: 3 of 3" not in htm
+
+
+def test_both_renderers_emit_the_denominator_note_verbatim():
+    """SEAM GUARD — pins the RELATIONSHIP, not either surface.
+
+    The note is one function used by both renderers, so the identical string
+    must appear in both outputs. This fails if either surface starts formatting
+    its own copy, which is the mechanism that produced findings H2/H3 and audit
+    finding 3."""
+    d = _outcome_divergence_case()
+    note = I.outcome_population_note(d)
+    assert "population: 2 of 3 readable Layer-B insight(s)" in note   # pin the value
+    emitters = {name for name, out in (("render", I.render(d)),
+                                       ("render_html", I.render_html(d)))
+                if note in out}
+    assert emitters == {"render", "render_html"}, (
+        f"the shared denominator note is missing from {{'render','render_html'}} - "
+        f"{emitters}; a renderer is formatting its own copy again")
 
 
 def test_html_labels_model_surfaced_candidates_as_unmeasured():


### PR DESCRIPTION
The built-in `/insights` produced three quantitative defect classes on 2026-08-05 (plus one suspected fourth). Our Layer A deliberately mirrors its `session-meta` fields (`session-tailer.py:263`), so each was **tested against our code** rather than assumed inherited.

## Verdict table

| # | Hypothesis | Verdict in OUR tool | Evidence |
|---|---|---|---|
| **H1** | Impossible time totals | 🔴 **REAL — fixed** | `session-tailer.py:372` computes `duration_minutes = round((end_ts − start_ts)/60)` — an idle-inclusive span, unclipped to the window. `insights.py:738` summed it into `wall-clock: {N}h`. **Measured** over 2,393 real transcripts touched in a trailing 14d window: **Σ = 720,904 min = 12,015.1 h against the 336 h that EXIST in 14 days — 35.8×.** 10 sessions had a span longer than the whole window alone; worst 818.5 h (2026-06-23 → 2026-07-27). The built-in's `34849`-minute session reproduces **exactly** through our producer. |
| **H2** | Window arg ignored | 🟡 **NOT PRESENT as a data defect; REAL as disclosure — fixed** | Every Layer-A query uses `win`; Layer B uses the deliberately wider `iwin` (`gather()`, spec §11). `write.py:15-18` stamps a `session-insight` row's `ts` with the **session's own `end_ts`, not emit time**, so the built-in's "pooled three older analysis batches" mechanism **structurally cannot occur here**. But `render_html` never labelled the Layer-B window — its subtitle said `trailing 14d · 2 sessions` directly above percentages computed over 30d. `render()` already labelled it. |
| **H3** | Inconsistent denominators | 🔴 **REAL, both renderers — fixed** | Outcome percentages are over `insight_sessions` (Layer B, wider window); the headline `sessions:` is Layer A. Probe with 2 Layer-A / 1 Layer-B session: neither renderer named the denominator anywhere. |
| **H4** | Confabulated friction claim | 🟡 **PARTIALLY REAL — deliberately not "fixed"; see below** | The contract is embedded (`prepare.py:162`) and that embedding is tested (`test_prepare.py:77`, `test_schema.py:89`). But `validate()` polices **structure** only: a payload carrying the exact two claims the built-in confabulated returns `validate() == []` and `vocab_warnings() == []`. |

## What changed

**H1 — the time figure is labelled, not invented.** Two mechanisms drive the overstatement and *neither* is recoverable from Layer A: **idle** (no turn-gap signal in the rollup) and **overlap** (concurrent agent sessions double-count the same minute). Per the brief, an unvalidatable "active time" estimate was rejected. The figure is renamed off `wall-clock` → `session span`, printed beside the window's real bound with an explicit `Nx MORE THAN EXISTS` marker, and carries `SESSION_SPAN_CAVEAT` naming both mechanisms. `render_html` still prints no time figure at all.

Reproduced end-to-end on the real measured population (2,393 sessions / 720,904 min):

```
base:  wall-clock: 12,015.1h across sessions (sum of per-session spans)

HEAD:  session span: 12,015.1h summed over 2393 session spans
                     (the 14d window holds 336h of wall clock — 35.8x MORE THAN EXISTS)
        NOTE: spans are IDLE-INCLUSIVE and overlap across concurrent sessions, and a
              resumed session's span reaches back before the window — so this sum is NOT
              bounded by the window and is NOT time worked. Layer A carries no
              active-time signal; this report has no hours-worked figure.
```

**H2/H3 — windows and denominators are now stated wherever a number is printed.** Both renderers print the Layer-B population, its window, and the explicit contrast with the Layer-A figure above it. The HTML `OUTCOMES` heading carries `trailing 30d`; the subtitle scopes its count to `Layer-A sessions`.

**H4 — the structural mitigation, not a spelled guard.** `render_html` now labels model-authored free text `NOT measured savings`, which `render()` already did — so the report never presents that text as measured. A keyword scan inside `validate()` was **considered and rejected**: it passes the moment the same hazard is worded differently (a *spelled* guard, not a structural one). The limit is pinned by a documented-limit test so closing it stays a deliberate decision.

## Tests — `tests/test_insights_quantitative_honesty.py` (13 new)

Every expected value is a **literal** pinned from fixture arithmetic (40,320 min = 672.0 h; 14d = 336 h; ratio 2.0×), never read back out of the implementation.

**Red-at-base / green-at-HEAD matrix — measured, not asserted:**

| | base (`main` @ `1daca5c`) | HEAD |
|---|---|---|
| new file | **11 failed, 2 passed** | **13 passed** |

Each of the 11 fails at **its own assertion with its own error** — verified line by line, not inferred from the count (e.g. `test_html_labels_model_surfaced_candidates_as_unmeasured` fails on `NOT measured savings` *after* its `wrap deploy dance` precondition passes, proving the guard is reached).

**The 2 green-at-base are labelled NON-regression and mutation-checked for reachability:**

| mutant | guard | result |
|---|---|---|
| M0 control | both | green |
| M1 `render_html` starts emitting hours (**set grows**) | `test_hours_figure_ledger` | red @ L152, ledger's own message |
| M2 `render` stops emitting hours (**set shrinks**) | `test_hours_figure_ledger` | red @ L152, ledger's own message |
| M3 contract clause stripped | `…contract_is_prompt_only_not_validated` | red @ L256, contract assertion |
| M4 `validate()` gains a content check | `…contract_is_prompt_only_not_validated` | red @ L253, `validate() == []` assertion |
| M5 restored control | both | green |

`test_hours_figure_ledger` is a **seam guard** — it fails in *both* directions, so it cannot pass by a renderer silently gaining or losing an hours figure.

**Counts (counted, never read off an exit code):** 358 pre-existing pass unchanged + 13 new = **371 passed, 0 failed, 0 skipped** locally. In the CI sandbox: `scripts/session-analysis/tests` 314/314, `session_insight/tests` 57/57 — 371, matching.

## ⚠️ The `pytests` gate is ALREADY RED on `main` — not caused by this PR

I ran the control before drawing any conclusion:

| | collected | passed | skipped | **failed** |
|---|---|---|---|---|
| `main` (`1daca5c`) | 6051 | 5904 | 3 | **144** |
| this branch | 6064 | 5917 | 3 | **144** |

**Delta: +13 collected, +13 passed, +0 failed, +0 skipped.** All 144 failures are in `scripts/tests/test_opencode_config.py` (`kubectl delete pod x` resolves `allow`, expected `ask` — and 143 siblings), plus 2 unpinned skips in `test_skill_audit.py` (datapacket-talos clone absent). Untouched by this PR, and the base clone has an uncommitted `M scripts/opencode/opencode.jsonc` suggesting someone is mid-work on exactly that. **Flagging rather than merging through it** — a permanently-red gate trains everyone to click through.

## Found but deliberately NOT fixed

- **Clipping spans to the window, and/or a union-of-overlapping-intervals figure.** Both are computable from Layer A's `start_ts`/`end_ts` and would yield a number *bounded* by the window. Both are still idle-inclusive, so neither answers "hours worked" — they would trade an obviously impossible number for a **plausible-looking** one. Flagged, not built.
- **`validate()` cannot police prose** (H4). Reasoning above; pinned by a test so it is rediscovered deliberately.
- **The 144 pre-existing `test_opencode_config.py` failures.** Different subsystem, apparently already in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
