### PR TITLE
search-tool-nudge: stop recommending Grep/Glob in sessions that don't have them

### DIFF
--- a/scripts/claude-hooks/search-tool-nudge.py
+++ b/scripts/claude-hooks/search-tool-nudge.py
@@ -20,10 +20,15 @@ Design constraints, in priority order:
      doing non-search work).
   3. Once per KIND per session (two kinds: content-search, file-search), so a session
      sees at most two of these ever.
+  4. NEVER recommend a tool this session does not have. Grep/Glob are not present in
+     every session — the harness answers a call to a missing one with
+     `Error: No such tool available: Grep. …`. A nudge pointing at a tool that cannot
+     be called is pure token cost AND trains the operator to ignore the hook, which
+     degrades it for the sessions where it IS actionable. See "Availability" below.
 
 Fail-open: any error -> exit 0 silently; it must never break the Bash tool.
 """
-import sys, json, os, re, shlex
+import sys, json, os, re, shlex, glob
 
 HOME = os.path.expanduser("~")
 CACHE_DIR = f"{HOME}/.cache/claude-search-tool-nudge"
@@ -51,6 +56,51 @@ HINTS = {
         "Glob(pattern=\"**/*.py\", path=\"…\")",
     ),
 }
+
+# The native tool each kind points at. Suppression is per-TOOL, not per-session-wide:
+# a session that has only ever PROVEN Grep missing still gets its one Glob nudge, which
+# then proves Glob too if it is also gone. Costs at most one extra nudge and keeps the
+# claim scoped to what was actually observed.
+NATIVE_TOOL = {CONTENT: "Grep", FILES: "Glob"}
+
+# --------------------------------------------------------------------------- #
+# Availability
+#
+# The PostToolUse payload does NOT enumerate the session's tools, and the wording of
+# the unavailability error is NOT in the claude-code bundle (checked: 2.1.220 contains
+# neither "Grep is not available" nor "via the Bash tool instead") — the tool set is
+# decided server-side, so there is no local config file to consult. The only observable
+# is the transcript: when the model calls a tool the session lacks, the harness writes
+#
+#   {"type":"user","message":{"role":"user","content":[{"type":"tool_result",
+#     "content":"<tool_use_error>Error: No such tool available: Grep. Grep is not
+#      available in this session — search file contents with `grep` via the Bash tool
+#      instead.</tool_use_error>",
+#     "is_error":true,"tool_use_id":"…"}]}, …}
+#
+# So availability is INFERRED, and only ever in the safe direction: silence a tool once
+# this session has proven it missing. Known gap, stated rather than papered over — the
+# signal only exists once the model has ATTEMPTED the tool. A session that never reaches
+# for Grep (because it can see Grep is not in its tool list) produces no signal and keeps
+# getting the nudge. Nothing else the hook receives distinguishes that case.
+#
+# 🔴 The match is STRUCTURAL, not spelled: only a tool_result block with `is_error` true
+# whose text STARTS with the marker counts. That matters — this very error text also
+# appears in the parent transcript as ordinary prose (quoted inside an Agent tool_use
+# prompt, and inside a subagent's final report, both `is_error` false). A substring grep
+# over the raw transcript would match those and silence a session whose tools work fine.
+# --------------------------------------------------------------------------- #
+UNAVAILABLE_MARKER = b"No such tool available: "
+_UNAVAILABLE_RE = re.compile(r"^Error: No such tool available: ([A-Za-z][A-Za-z0-9_]*)")
+# Cheap by construction: the scan runs at most once per KIND per session, because the
+# outcome either way is written to the state file and short-circuits every later call.
+# That bound needs a session_id to key the state file on — the harness always sends one
+# (it and transcript_path come from the same payload builder), so the unbounded shape is
+# "transcript_path but no session_id", which the harness does not produce.
+# Measured on the largest transcript on this host — 66.5 MB — a full byte-prefiltered
+# pass costs 73 ms; a typical transcript is under 1 MB. The cap bounds the pathological
+# case; hitting it just means "no signal", i.e. nudge exactly as before.
+MAX_SCAN_BYTES = 64 * 1024 * 1024
 
 
 def _strip_heredocs(cmd):
@@ -280,24 +330,146 @@ def analyze(cmd):
     return kinds
 
 
-def _already_nudged(session, kind):
-    """Per-session dedupe: each kind is suggested at most once. Fail-open on IO error."""
-    if not session:
-        return False
+def _error_texts(rec):
+    """Yield the text of every tool_result block in `rec` that the harness marked as an
+    ERROR. Anything else — assistant tool_use inputs, ordinary tool output, a subagent's
+    report — is deliberately not a witness (see the Availability note above)."""
+    msg = rec.get("message")
+    content = msg.get("content") if isinstance(msg, dict) else None
+    if not isinstance(content, list):
+        return
+    for block in content:
+        if not isinstance(block, dict) or not block.get("is_error"):
+            continue
+        c = block.get("content")
+        if isinstance(c, list):  # some versions wrap it as [{"type":"text","text":…}]
+            c = "".join(b.get("text", "") for b in c if isinstance(b, dict))
+        if not isinstance(c, str):
+            continue
+        yield c.replace("<tool_use_error>", "").replace("</tool_use_error>", "").strip()
+
+
+def _scan_transcript(path, wanted, budget):
+    """Names from `wanted` that `path` records as unavailable. Byte-prefiltered so all
+    but a handful of lines are rejected without a JSON parse.
+
+    Honest scope note, same convention as _newlines_to_separators above: the prefilter
+    is a pure performance optimisation and a mutation sweep confirms it SURVIVES
+    deletion — semantics are identical either way, only the cost changes (json.loads on
+    every line of a multi-MB transcript vs a substring test). Kept for the cost.
+    """
+    found = set()
+    with open(path, "rb") as fh:
+        for raw in fh:
+            budget[0] -= len(raw)
+            if budget[0] < 0:
+                break
+            if UNAVAILABLE_MARKER not in raw:
+                continue
+            try:
+                rec = json.loads(raw)
+            except Exception:
+                continue
+            if not isinstance(rec, dict):
+                continue
+            for text in _error_texts(rec):
+                m = _UNAVAILABLE_RE.match(text)
+                if m and m.group(1) in wanted:
+                    found.add(m.group(1))
+                    if found >= wanted:
+                        return found
+    return found
+
+
+def _transcript_paths(data):
+    """Transcripts that can witness THIS agent's tool errors, most specific first.
+
+    `transcript_path` is derived from the SESSION id, which a subagent shares with its
+    parent — so a subagent's own tool errors are NOT in it. They live in the per-agent
+    transcript, whose layout is (verified on disk, and in the claude-code 2.1.220
+    bundle's `K0()`):
+        <project>/<session>.jsonl                        <- transcript_path
+        <project>/<session>/subagents/[<nested>/]agent-<agent_id>.jsonl
+    """
+    tp = data.get("transcript_path")
+    if not isinstance(tp, str) or not tp.endswith(".jsonl"):
+        return []
+    paths = []
+    agent = data.get("agent_id")
+    if isinstance(agent, str) and re.fullmatch(r"[A-Za-z0-9_.-]{1,64}", agent):
+        base = os.path.join(tp[: -len(".jsonl")], "subagents")
+        direct = os.path.join(base, "agent-%s.jsonl" % agent)
+        if os.path.isfile(direct):
+            paths.append(direct)
+        else:  # nested agent-spawned-agent case
+            paths.extend(sorted(glob.glob(os.path.join(base, "**", "agent-%s.jsonl" % agent),
+                                          recursive=True))[:2])
+    if os.path.isfile(tp):
+        paths.append(tp)
+    return paths
+
+
+def _unavailable_native_tools(data, wanted):
+    """Which of `wanted` this session has PROVEN unavailable.
+
+    Fail-open, in exactly two places — both individually reachable, so neither is an
+    unkillable belt-and-braces guard: a malformed payload that breaks path resolution,
+    and a transcript that cannot be read. Either yields no signal, i.e. the nudge is
+    delivered exactly as it was before this hook learned about availability.
+    """
+    found = set()
+    budget = [MAX_SCAN_BYTES]
+    try:
+        paths = _transcript_paths(data)
+    except Exception:
+        return found
+    for p in paths:
+        try:
+            found |= _scan_transcript(p, wanted - found, budget)
+        except Exception:
+            continue
+        if found >= wanted or budget[0] < 0:
+            break
+    return found
+
+
+def _state_path(data):
+    """Per-session state file, scoped per AGENT too.
+
+    A subagent shares its parent's session_id but not necessarily its tool set, so a
+    subagent that proves Grep missing must not silence the parent's still-actionable
+    nudge. A payload with no agent_id keys exactly as before.
+    """
+    session = data.get("session_id") or ""
+    if not isinstance(session, str) or not session:
+        return None
+    agent = data.get("agent_id")
+    key = session + ("@" + agent if isinstance(agent, str) and agent else "")
+    return os.path.join(CACHE_DIR, re.sub(r"[^A-Za-z0-9_.-]", "_", key))
+
+
+def _read_state(path):
+    """Tokens recorded for this session: a KIND already nudged, or `no:<Tool>` for a
+    native tool proven unavailable. Fail-open on IO error."""
+    if not path:
+        return set()
+    try:
+        with open(path) as fh:
+            return set(fh.read().split())
+    except Exception:
+        return set()
+
+
+def _append_state(path, tokens):
+    if not path or not tokens:
+        return
     try:
         os.makedirs(CACHE_DIR, exist_ok=True)
-        f = os.path.join(CACHE_DIR, re.sub(r"[^A-Za-z0-9_.-]", "_", session))
-        seen = set()
-        if os.path.exists(f):
-            with open(f) as fh:
-                seen = set(fh.read().split())
-        if kind in seen:
-            return True
-        with open(f, "a") as fh:
-            fh.write(kind + "\n")
-        return False
+        with open(path, "a") as fh:
+            for t in tokens:
+                fh.write(t + "\n")
     except Exception:
-        return False
+        pass
 
 
 def main():
@@ -306,15 +478,36 @@ def main():
     except Exception:
         sys.exit(0)
     try:
-        if data.get("tool_name") != "Bash":
+        if not isinstance(data, dict) or data.get("tool_name") != "Bash":
             sys.exit(0)
         cmd = (data.get("tool_input") or {}).get("command", "")
         if not cmd:
             sys.exit(0)
-        session = data.get("session_id") or ""
-        fresh = [k for k in analyze(cmd) if not _already_nudged(session, k)]
+        kinds = analyze(cmd)
+        if not kinds:
+            sys.exit(0)
+
+        state_path = _state_path(data)
+        state = _read_state(state_path)
+        fresh = [k for k in kinds if k not in state]
         if not fresh:
             sys.exit(0)
+
+        # Don't recommend a tool this session has proven it doesn't have. The scan is
+        # reached at most once per kind: whichever way it goes, the outcome is recorded
+        # below and every later call short-circuits on the state file.
+        blocked = {t for t in NATIVE_TOOL.values() if "no:" + t in state}
+        unknown = {NATIVE_TOOL[k] for k in fresh} - blocked
+        if unknown:
+            newly = _unavailable_native_tools(data, unknown)
+            if newly:
+                blocked |= newly
+                _append_state(state_path, ["no:" + t for t in sorted(newly)])
+        fresh = [k for k in fresh if NATIVE_TOOL[k] not in blocked]
+        if not fresh:
+            sys.exit(0)
+
+        _append_state(state_path, fresh)
         lines = "\n".join(f"  • {HINTS[k][0]} → {HINTS[k][1]}" for k in fresh)
         nudge = (
             "search-tool: that Bash call was a tree search. The native tools do the same "

--- a/scripts/claude-hooks/search-tool-nudge.py
+++ b/scripts/claude-hooks/search-tool-nudge.py
@@ -111,7 +111,25 @@ _UNAVAILABLE_RE = re.compile(r"Error: No such tool available: ([A-Za-z][A-Za-z0-
 # host, so a cold read is slower by an unmeasured factor. Even at 10x the floor, 1 GiB is
 # a few seconds, once per kind per session, and truncation fails OPEN: nudge delivered.
 # Overridable so the truncation boundary itself is testable rather than assumed.
-MAX_SCAN_BYTES = int(os.environ.get("SEARCH_TOOL_NUDGE_MAX_SCAN_BYTES") or 1024 * 1024 * 1024)
+#
+# 🔴 The override is parsed DEFENSIVELY, because this runs at import time — outside
+# main()'s try — so an exception here escapes as a non-zero exit with a traceback on
+# EVERY Bash call in that session, which is exactly what the module docstring promises
+# never happens. A bare int() on the raw value made a single typo in a shell profile
+# (`...=abc`) enough to do that. Anything unparseable or non-positive falls back to the
+# default. Known and accepted: Python's int() also accepts underscore separators, so
+# "1_0" parses as 10 rather than being rejected — harmless, because a too-SMALL cap only
+# truncates the scan, which fails open and delivers the nudge.
+def _scan_cap(default):
+    try:
+        raw = os.environ.get("SEARCH_TOOL_NUDGE_MAX_SCAN_BYTES")
+        value = int(raw) if raw else default
+        return value if value > 0 else default
+    except Exception:
+        return default
+
+
+MAX_SCAN_BYTES = _scan_cap(1024 * 1024 * 1024)
 
 # --------------------------------------------------------------------------- #
 # Per-session state, and the claim protocol
@@ -138,8 +156,8 @@ MAX_SCAN_BYTES = int(os.environ.get("SEARCH_TOOL_NUDGE_MAX_SCAN_BYTES") or 1024 
 #     Deliberate: one lost nudge is far cheaper than N duplicates.
 #
 # Tokens: a KIND ("content"/"files") = nudge handled; "no:<Tool>" = that tool proven
-# unavailable. ":" is not filename-safe, so tokens map to filenames via a fixed injective
-# encoding over the closed token set.
+# unavailable. They are stored VERBATIM as filenames — ":" is a legal filename byte on
+# Linux, so no encoding step is involved (see _token_file).
 # --------------------------------------------------------------------------- #
 STATE_ROOT = f"{CACHE_DIR}/s"
 
@@ -489,8 +507,12 @@ def _state_dir(data):
     cannot appear INSIDE a sanitized component. That is what makes the key injective:
     joining sanitized parts with any character the sanitizer can emit (e.g. "_") would
     make session="a" + agent="b" collide with session="a_b" alone, and the first would
-    then silence the second. Residual, pre-existing and NOT introduced here: two raw
-    session ids that sanitize to the same string still alias (real ids are UUIDs).
+    then silence the second.
+
+    Residual aliasing, stated at its real scope: two raw session ids that sanitize to the
+    same string alias. The character-substitution half of that is pre-existing; the [:120]
+    TRUNCATION half is new here and is mine, not inherited. Both are unreachable with the
+    UUID/hex ids the harness actually sends.
     """
     session = data.get("session_id") or ""
     if not isinstance(session, str) or not session:
@@ -535,8 +557,18 @@ def _claim(state_dir, token):
     """
     if not state_dir:
         return True
+    # 🔴 The two steps have SEPARATE handlers on purpose. `makedirs(exist_ok=True)` also
+    # raises FileExistsError — when the path is an existing regular file or symlink, not
+    # a directory (e.g. a leftover from the pre-directory state layout). Sharing one
+    # handler with the open below made that indistinguishable from "lost the race", so
+    # the hook returned False and the nudge vanished for the whole session: fail CLOSED,
+    # contradicting both this docstring and the module comment. Only the O_EXCL open may
+    # ever mean "someone else got there first".
     try:
         os.makedirs(state_dir, exist_ok=True)
+    except Exception:
+        return True
+    try:
         os.close(os.open(_token_file(state_dir, token),
                          os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600))
         return True

--- a/scripts/claude-hooks/search-tool-nudge.py
+++ b/scripts/claude-hooks/search-tool-nudge.py
@@ -91,16 +91,57 @@ NATIVE_TOOL = {CONTENT: "Grep", FILES: "Glob"}
 # over the raw transcript would match those and silence a session whose tools work fine.
 # --------------------------------------------------------------------------- #
 UNAVAILABLE_MARKER = b"No such tool available: "
-_UNAVAILABLE_RE = re.compile(r"^Error: No such tool available: ([A-Za-z][A-Za-z0-9_]*)")
-# Cheap by construction: the scan runs at most once per KIND per session, because the
-# outcome either way is written to the state file and short-circuits every later call.
-# That bound needs a session_id to key the state file on — the harness always sends one
-# (it and transcript_path come from the same payload builder), so the unbounded shape is
-# "transcript_path but no session_id", which the harness does not produce.
-# Measured on the largest transcript on this host — 66.5 MB — a full byte-prefiltered
-# pass costs 73 ms; a typical transcript is under 1 MB. The cap bounds the pathological
-# case; hitting it just means "no signal", i.e. nudge exactly as before.
-MAX_SCAN_BYTES = 64 * 1024 * 1024
+# NO `^` in the pattern: `.match()` already anchors at the start, so a `^` here would be
+# a second, redundant anchor — and a redundant guard is one a mutation sweep can delete
+# without any test noticing. One anchor, and it is `.match` (NOT `.search`): an is_error
+# tool_result that merely CONTAINS the marker — a failed Bash call whose stderr quotes it
+# — must not suppress. Pinned by "marker mid-text in a real error does NOT suppress".
+_UNAVAILABLE_RE = re.compile(r"Error: No such tool available: ([A-Za-z][A-Za-z0-9_]*)")
+
+# Scan cost bound. The scan is O(bytes) and runs at most once per KIND per session (see
+# the claim protocol below), so the cap exists only to bound a pathological or corrupt
+# transcript, NOT the normal case.
+#
+# Why 1 GiB and not something snug: the previous value (64 MiB) was chosen just above the
+# largest transcript then on this host (63.4 MiB = 99.1% of it) — i.e. one long session
+# away from silently truncating, which would have looked exactly like "no signal". A cap
+# whose whole job is to catch the pathological case must not sit inside the normal range.
+# Throughput measured on that 63.4 MiB file, 5 runs: 52-102 ms, i.e. 0.8-1.6 ms/MiB with
+# a WARM page cache. That is a FLOOR, not a bound — caches could not be dropped on this
+# host, so a cold read is slower by an unmeasured factor. Even at 10x the floor, 1 GiB is
+# a few seconds, once per kind per session, and truncation fails OPEN: nudge delivered.
+# Overridable so the truncation boundary itself is testable rather than assumed.
+MAX_SCAN_BYTES = int(os.environ.get("SEARCH_TOOL_NUDGE_MAX_SCAN_BYTES") or 1024 * 1024 * 1024)
+
+# --------------------------------------------------------------------------- #
+# Per-session state, and the claim protocol
+#
+# 🔴 Concurrency is the normal case here, not an edge: parallel subagents share one
+# session, so several hook processes run at once. The old layout — one state FILE per
+# session, read-modify-write — raced, and this hook's transcript scan sits between the
+# read and the write, which widens the window from microseconds to tens of milliseconds.
+# MEASURED, 12 truly-concurrent invocations against a 66.5 MB transcript: 10-11 duplicate
+# nudges (base hook, no scan: 0-2). N copies of the nudge in one turn is precisely the
+# "trains the operator to ignore it" failure this hook exists to avoid.
+#
+# So state is a DIRECTORY per session and each token is an empty marker FILE created with
+# O_CREAT|O_EXCL — an atomic test-and-set, no lock, so nothing can block the Bash call.
+# The kind is claimed BEFORE the transcript is scanned, which means exactly one process
+# per kind scans and exactly one can emit; the losers exit silently and pay nothing.
+#
+# What is actually guaranteed, stated precisely because the old comment overclaimed:
+#   * at most ONE nudge per kind per session, including under concurrency, as long as
+#     the state directory is writable and on a POSIX filesystem (O_EXCL);
+#   * if state is UNWRITABLE the hook fails OPEN — it may nudge more than once, exactly
+#     as the pre-existing hook did, rather than swallow the nudge or raise;
+#   * a process that claims a kind and then dies burns that kind's nudge for the session.
+#     Deliberate: one lost nudge is far cheaper than N duplicates.
+#
+# Tokens: a KIND ("content"/"files") = nudge handled; "no:<Tool>" = that tool proven
+# unavailable. ":" is not filename-safe, so tokens map to filenames via a fixed injective
+# encoding over the closed token set.
+# --------------------------------------------------------------------------- #
+STATE_ROOT = f"{CACHE_DIR}/s"
 
 
 def _strip_heredocs(cmd):
@@ -433,43 +474,76 @@ def _unavailable_native_tools(data, wanted):
     return found
 
 
-def _state_path(data):
-    """Per-session state file, scoped per AGENT too.
+def _sanitize(part):
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", part)[:120]
+
+
+def _state_dir(data):
+    """Per-session state directory, scoped per AGENT too.
 
     A subagent shares its parent's session_id but not necessarily its tool set, so a
     subagent that proves Grep missing must not silence the parent's still-actionable
-    nudge. A payload with no agent_id keys exactly as before.
+    nudge.
+
+    🔴 The components are joined with "@", which `_sanitize` maps to "_" and therefore
+    cannot appear INSIDE a sanitized component. That is what makes the key injective:
+    joining sanitized parts with any character the sanitizer can emit (e.g. "_") would
+    make session="a" + agent="b" collide with session="a_b" alone, and the first would
+    then silence the second. Residual, pre-existing and NOT introduced here: two raw
+    session ids that sanitize to the same string still alias (real ids are UUIDs).
     """
     session = data.get("session_id") or ""
     if not isinstance(session, str) or not session:
         return None
     agent = data.get("agent_id")
-    key = session + ("@" + agent if isinstance(agent, str) and agent else "")
-    return os.path.join(CACHE_DIR, re.sub(r"[^A-Za-z0-9_.-]", "_", key))
+    parts = [_sanitize(session)]
+    if isinstance(agent, str) and agent:
+        parts.append(_sanitize(agent))
+    return os.path.join(STATE_ROOT, "@".join(parts))
 
 
-def _read_state(path):
-    """Tokens recorded for this session: a KIND already nudged, or `no:<Tool>` for a
-    native tool proven unavailable. Fail-open on IO error."""
-    if not path:
+def _token_file(state_dir, token):
+    # Tokens are stored verbatim: ":" is a legal filename byte on Linux (the only OS
+    # these hooks run on), so an encode/decode pair here would be complexity that
+    # nothing can observe — a mutation sweep deletes either half without any test
+    # noticing, which is the definition of a guard not worth shipping.
+    return os.path.join(state_dir, token)
+
+
+def _read_state(state_dir):
+    """Tokens already recorded: a KIND handled, or `no:<Tool>` proven unavailable.
+    Fail-open — an unreadable/absent directory reads as "nothing recorded yet"."""
+    if not state_dir:
         return set()
     try:
-        with open(path) as fh:
-            return set(fh.read().split())
+        return set(os.listdir(state_dir))
     except Exception:
         return set()
 
 
-def _append_state(path, tokens):
-    if not path or not tokens:
-        return
+def _claim(state_dir, token):
+    """Atomically claim `token` for this process. True iff THIS process created it.
+
+    O_CREAT|O_EXCL is a single atomic test-and-set, so of N concurrent hook processes
+    exactly one gets True. It never blocks — there is no lock to wait on, which is why
+    this cannot hang a Bash call.
+
+    Fails OPEN, and that direction is deliberate: if the state directory cannot be
+    written we return True (proceed, possibly duplicating a nudge) rather than False
+    (silently swallow it). Duplicating restores the pre-existing behaviour; swallowing
+    would be a new failure mode invisible to the operator.
+    """
+    if not state_dir:
+        return True
     try:
-        os.makedirs(CACHE_DIR, exist_ok=True)
-        with open(path, "a") as fh:
-            for t in tokens:
-                fh.write(t + "\n")
+        os.makedirs(state_dir, exist_ok=True)
+        os.close(os.open(_token_file(state_dir, token),
+                         os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600))
+        return True
+    except FileExistsError:
+        return False
     except Exception:
-        pass
+        return True
 
 
 def main():
@@ -487,27 +561,39 @@ def main():
         if not kinds:
             sys.exit(0)
 
-        state_path = _state_path(data)
-        state = _read_state(state_path)
-        fresh = [k for k in kinds if k not in state]
+        state_dir = _state_dir(data)
+        # Fast path, NOT a correctness guard — honest scope note, same convention as the
+        # byte prefilter: a mutation sweep confirms this read SURVIVES deletion, because
+        # the atomic claim below already rejects an already-handled kind. It is kept so
+        # the overwhelmingly common case (kind already handled) costs one listdir instead
+        # of a mkdir + open, on a hook that runs after every Bash call.
+        fresh = [k for k in kinds if k not in _read_state(state_dir)]
         if not fresh:
             sys.exit(0)
 
-        # Don't recommend a tool this session has proven it doesn't have. The scan is
-        # reached at most once per kind: whichever way it goes, the outcome is recorded
-        # below and every later call short-circuits on the state file.
-        blocked = {t for t in NATIVE_TOOL.values() if "no:" + t in state}
-        unknown = {NATIVE_TOOL[k] for k in fresh} - blocked
-        if unknown:
-            newly = _unavailable_native_tools(data, unknown)
-            if newly:
-                blocked |= newly
-                _append_state(state_path, ["no:" + t for t in sorted(newly)])
-        fresh = [k for k in fresh if NATIVE_TOOL[k] not in blocked]
+        # 🔴 CLAIM BEFORE SCANNING. Everything past this point is done by exactly one
+        # process per kind, so concurrent invocations cannot each emit a nudge AND
+        # cannot each read the whole transcript. The losers exit silently, paying nothing.
+        fresh = [k for k in fresh if _claim(state_dir, k)]
         if not fresh:
             sys.exit(0)
 
-        _append_state(state_path, fresh)
+        # Don't recommend a tool this session has proven it doesn't have.
+        newly = _unavailable_native_tools(data, {NATIVE_TOOL[k] for k in fresh})
+        if newly:
+            # A DIAGNOSTIC breadcrumb, deliberately not load-bearing: the kind marker
+            # claimed above is what enforces once-per-kind, so nothing reads this back.
+            # It exists so `ls ~/.cache/claude-search-tool-nudge/s/<session>/` answers
+            # "why did the nudge go quiet in this session" without re-deriving it. An
+            # earlier revision DID branch on it; that branch was unreachable once the
+            # claim moved ahead of the scan, and shipping an unreachable branch is how
+            # a guard gets believed. Removed rather than left in as decoration.
+            for t in sorted(newly):
+                _claim(state_dir, "no:" + t)
+            fresh = [k for k in fresh if NATIVE_TOOL[k] not in newly]
+        if not fresh:
+            sys.exit(0)
+
         lines = "\n".join(f"  • {HINTS[k][0]} → {HINTS[k][1]}" for k in fresh)
         nudge = (
             "search-tool: that Bash call was a tree search. The native tools do the same "

--- a/scripts/claude-hooks/tests/test_search_tool_nudge.py
+++ b/scripts/claude-hooks/tests/test_search_tool_nudge.py
@@ -16,7 +16,7 @@ reassuring answer here is a ZERO (no false positives):
 
 Run: python3 scripts/claude-hooks/tests/test_search_tool_nudge.py
 """
-import os, sys, glob, json, shutil, subprocess, tempfile, importlib.util
+import os, sys, glob, json, time, shutil, subprocess, tempfile, threading, importlib.util
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 HOOK = os.path.join(HERE, "..", "search-tool-nudge.py")
@@ -161,11 +161,34 @@ def run(payload):
     return p.returncode, p.stdout.strip()
 
 
+STATE_ROOT = os.path.join(HOME, ".cache", "claude-search-tool-nudge", "s")
+# Every test session id starts with one of these, and the suite wipes their state dirs
+# both before and after. 🔴 This suite MUST be idempotent: state that survives a run
+# makes the NEXT run fail, which during a mutation sweep reads as "mutant killed" for
+# every mutant — a broken harness reporting a perfect score. Guarded below by
+# re-running the whole file and asserting the second run is identical.
+TEST_SID_PREFIXES = ("test-session-search-nudge-", "test-search-nudge-", "test-search-nudge-collide")
+
+
+def clear_test_state():
+    for pref in TEST_SID_PREFIXES:
+        for p in glob.glob(os.path.join(STATE_ROOT, pref + "*")):
+            shutil.rmtree(p, ignore_errors=True)
+        # Also the LEGACY layout (one flat FILE per session, pre-dating the state dir).
+        # Not housekeeping: without it, running this file against an older revision of
+        # the hook leaves state the newer cleanup cannot see, and the next run reads as
+        # "everything suppressed" — which is exactly how a contaminated measurement gets
+        # mistaken for 44 regressions.
+        for p in glob.glob(os.path.join(os.path.dirname(STATE_ROOT), pref + "*")):
+            if os.path.isfile(p):
+                try:
+                    os.remove(p)
+                except OSError:
+                    pass
+
+
+clear_test_state()
 sid = "test-session-search-nudge-DO-NOT-COLLIDE"
-cache = os.path.join(HOME, ".cache", "claude-search-tool-nudge",
-                     "".join(c if c.isalnum() or c in "_.-" else "_" for c in sid))
-if os.path.exists(cache):
-    os.remove(cache)
 
 rc, out = run({"tool_name": "Bash", "session_id": sid,
                "tool_input": {"command": "grep -r TODO src/"}})
@@ -198,8 +221,7 @@ check("io non-bash silent", (rc5, out5), (0, ""))
 p = subprocess.run([sys.executable, HOOK], input="not json", capture_output=True, text=True)
 check("io malformed rc", p.returncode, 0)
 
-if os.path.exists(cache):
-    os.remove(cache)
+clear_test_state()
 
 # --------------------------------------------------------------------------- #
 # AVAILABILITY SUPPRESSION — never recommend a tool this session does not have.
@@ -217,19 +239,44 @@ TMP = tempfile.mkdtemp(prefix="search-tool-nudge-tests-")
 SESSIONS = []
 
 
+def internal(name):
+    """Resolve a hook internal, recording a LOUD failure if it is missing.
+
+    Not a skip: a check that quietly vanishes when the symbol is gone is worse than no
+    check. This also lets the whole file run against an OLDER revision of the hook — the
+    missing symbols report as red and every other check still executes, which is what
+    makes a per-check red/green matrix across revisions possible at all.
+    """
+    obj = getattr(mod, name, None)
+    check("hook exposes %s" % name, obj is not None, True)
+    return obj
+
+
+def _san(part):
+    return "".join(c if c.isalnum() or c in "_.-" else "_" for c in part)[:120]
+
+
 def cache_path(sid, agent=None):
-    key = sid + ("@" + agent if agent else "")
-    return os.path.join(HOME, ".cache", "claude-search-tool-nudge",
-                        "".join(c if c.isalnum() or c in "_.-" else "_" for c in key))
+    """The hook's per-session state DIRECTORY. Components are sanitized individually and
+    joined with a literal "@" — see _state_dir's note on why that separator is the thing
+    that makes the key injective."""
+    key = "@".join([_san(sid)] + ([_san(agent)] if agent else []))
+    return os.path.join(STATE_ROOT, key)
+
+
+def recorded_tokens(sid, agent=None):
+    try:
+        return sorted(os.listdir(cache_path(sid, agent)))
+    except OSError:
+        return []
 
 
 def session(name):
-    """A fresh session id whose cache file is cleared now and removed at exit."""
+    """A fresh session id whose state dir is cleared now and removed at exit."""
     sid = "test-search-nudge-%s-DO-NOT-COLLIDE" % name
     SESSIONS.append(sid)
-    for p in (cache_path(sid), cache_path(sid, "agentX"), cache_path(sid, "agentY")):
-        if os.path.exists(p):
-            os.remove(p)
+    for p in glob.glob(os.path.join(STATE_ROOT, _san(sid) + "*")):
+        shutil.rmtree(p, ignore_errors=True)
     return sid
 
 
@@ -307,6 +354,15 @@ check("Grep unavailable suppresses the content nudge", fire(sid, "grep -r TODO s
 # fires. Pins the scope of the claim — a session-wide flag would silence this too.
 check("Glob nudge still fires when only Grep was proven gone",
       fire(sid, "find . -name '*.py'", gone), True)
+# The same distinction inside ONE command that earns BOTH kinds: the Grep half must be
+# dropped and the Glob half still delivered. A session-wide "any tool missing -> stay
+# silent" passes every check above and fails only here.
+sid = session("grep-gone-both")
+gone2 = transcript("grep-gone-both", [unavailable_record("Grep")])
+rc_b, out_b = run({"tool_name": "Bash", "session_id": sid, "transcript_path": gone2,
+                   "tool_input": {"command": "grep -r foo . && find . -name '*.md'"}})
+check("one command, both kinds: only the unavailable half is dropped",
+      ("Glob tool" in out_b, "Grep tool" in out_b), (True, False))
 
 # --- Both proven unavailable -> both suppressed. -------------------------------
 sid = session("both-gone")
@@ -317,13 +373,14 @@ check("both tools gone: files suppressed", fire(sid, "find . -name '*.py'", both
 # --- The verdict is CACHED: a later call with no transcript at all stays quiet. -
 # Proves the short-circuit works (and that the scan is not re-run on every call).
 check("suppression persists once recorded", fire(sid, "grep -R other .", None), False)
-# ...and it is cached as a TOOL VERDICT, not by spending the nudge budget. Asserted on
-# the state file because the behavioural check above cannot tell the two apart: a hook
-# that simply emitted both nudges and marked both kinds used would also fall silent
-# here. Pre-change this file reads ["content", "files"].
-recorded = sorted(open(cache_path(sid)).read().split()) if os.path.exists(cache_path(sid)) else []
-check("suppression records a tool verdict, not a spent nudge budget",
-      recorded, ["no:Glob", "no:Grep"])
+# ...and it is cached as a TOOL VERDICT, not merely by spending the nudge budget.
+# Asserted on the state dir because the behavioural check above cannot tell the two
+# apart: a hook that simply emitted both nudges and marked both kinds used would also
+# fall silent here. Pre-change this reads ["content", "files"] with no verdict at all.
+# (The kinds ARE present too — a kind is claimed before the scan, so that the scan runs
+# once and only one process can emit; see the claim protocol.)
+check("suppression records a tool verdict alongside the spent kinds",
+      recorded_tokens(sid), ["content", "files", "no:Glob", "no:Grep"])
 
 # --- STRUCTURAL, not spelled: the same TEXT in a non-error position must not ----
 # suppress. This is the real transcript hazard — the error wording appears verbatim
@@ -351,6 +408,28 @@ prose = transcript("prose", [
 ])
 check("quoted error prose does NOT suppress", fire(sid, "grep -r TODO src/", prose), True)
 
+# --- ANCHORED: the marker must START the error text, not merely appear in it. --
+# A genuinely failed Bash call whose stderr quotes the marker is an is_error result, so
+# is_error alone does not separate it — only the anchor does. Kills `.match -> .search`;
+# there is deliberately no `^` in the pattern for a mutant to delete for free.
+sid = session("mid-text")
+midtext = transcript("mid-text", [{
+    "type": "user", "message": {"role": "user", "content": [{
+        "type": "tool_result", "is_error": True, "tool_use_id": "toolu_z",
+        "content": "grep: exit 2\nlog line: Error: No such tool available: Grep. "
+                   "Grep is not available in this session"}]}}])
+check("marker mid-text in a real error does NOT suppress",
+      fire(sid, "grep -r TODO src/", midtext), True)
+
+# --- The list-form content branch is real, not speculative. -------------------
+sid = session("list-form")
+listform = transcript("list-form", [{
+    "type": "user", "message": {"role": "user", "content": [{
+        "type": "tool_result", "is_error": True, "tool_use_id": "toolu_l",
+        "content": [{"type": "text",
+                     "text": "Error: No such tool available: Grep. gone."}]}]}}])
+check("list-form error content is understood", fire(sid, "grep -r TODO src/", listform), False)
+
 # --- A DIFFERENT tool being unavailable must not suppress Grep/Glob. -----------
 sid = session("other-tool")
 other = transcript("other-tool", [unavailable_record("WebFetch")])
@@ -372,6 +451,53 @@ check("subagent suppression does not leak to the parent session",
 agent_transcript(parent, "agentY", BENIGN_RECORDS)
 check("subagent suppression does not leak to a sibling agent",
       fire(sid, "grep -r TODO src/", parent, agent_id="agentY"), True)
+
+# A NESTED agent (an agent spawned by an agent) lives one level deeper; the glob
+# fallback is what finds it. Without it this transcript is never consulted.
+sid = session("nested-agent")
+nested_parent = transcript("nested-agent", BENIGN_RECORDS)
+nested_dir = os.path.join(nested_parent[: -len(".jsonl")], "subagents", "outer")
+os.makedirs(nested_dir, exist_ok=True)
+with open(os.path.join(nested_dir, "agent-inner1.jsonl"), "w") as fh:
+    fh.write(json.dumps(unavailable_record("Grep")) + "\n")
+check("nested subagent transcript is found via the glob fallback",
+      fire(sid, "grep -r TODO src/", nested_parent, agent_id="inner1"), False)
+
+# --- agent_id VALIDATION, asserted on the RESOLVED SCAN TARGET. ---------------
+# The outcome alone cannot see this: `_transcript_paths` is called directly so the
+# assertion is about which files would be READ, not about whether a nudge appeared.
+# A glob metacharacter is the realistic leak — unvalidated, "*" makes the fallback
+# glob match a SIBLING agent's transcript and inherit its verdict.
+sid = session("agent-glob")
+sib_parent = transcript("agent-glob", BENIGN_RECORDS)
+agent_transcript(sib_parent, "realsibling", [unavailable_record("Grep")])
+_paths = internal("_transcript_paths")
+check("a glob metacharacter in agent_id resolves to NO extra scan target",
+      _paths({"transcript_path": sib_parent, "agent_id": "*"}) if _paths else None,
+      [sib_parent])
+check("...and a traversal in agent_id resolves to no extra scan target either",
+      _paths({"transcript_path": sib_parent, "agent_id": "../../etc"}) if _paths else None,
+      [sib_parent])
+# Behavioural companion: it must not inherit the sibling's verdict.
+check("agent_id='*' does not inherit a sibling's suppression",
+      fire(sid, "grep -r TODO src/", sib_parent, agent_id="*"), True)
+
+# --- STATE KEY IS INJECTIVE ---------------------------------------------------
+# session="…a" + agent="b" must not share a state dir with session="…a_b" alone.
+# Joining sanitized components with any character the sanitizer can EMIT (e.g. "_")
+# makes these collide, and the first call then silences the second.
+# The pair has to be EXACT for the collision to exist, so these ids are built raw
+# rather than through session(): X with agent "b", versus the session literally named
+# X_b. sanitize(X + "@" + "b") == "X_b" == sanitize("X_b") — one state dir for both.
+X = "test-search-nudge-collide"
+for _sid in (X, X + "_b"):
+    SESSIONS.append(_sid)
+for _p in glob.glob(os.path.join(STATE_ROOT, X + "*")):
+    shutil.rmtree(_p, ignore_errors=True)
+check("state key: agent-scoped call nudges",
+      fire(X, "grep -r TODO src/", None, agent_id="b"), True)
+check("state key: the session that ALIASES it still gets its own nudge",
+      fire(X + "_b", "grep -r TODO src/", None), True)
 
 # --- FAIL OPEN: every detection failure leaves behaviour exactly as before. ----
 sid = session("missing-file")
@@ -412,6 +538,145 @@ sid = session("no-transcript-key")
 check("payload without transcript_path -> nudge unchanged (legacy shape)",
       fire(sid, "grep -r TODO src/", None), True)
 
+# --- SCAN CAP: truncation fails OPEN, and the boundary is pinned at 2 points. --
+# Measured at both ends rather than one: a cap that admits the error line exactly, and
+# one byte less. Without both, an off-by-one on the comparison is invisible.
+cap_records = BENIGN_RECORDS + [unavailable_record("Grep")]
+cap_file = transcript("cap", cap_records)
+with open(cap_file, "rb") as fh:
+    _cap_bytes = fh.read()
+EXACT = len(_cap_bytes)  # budget that admits the final (error) line in full
+
+
+def fire_with_cap_agent(sid, cap, transcript_path, agent_id=None):
+    payload = {"tool_name": "Bash", "session_id": sid, "transcript_path": transcript_path,
+               "tool_input": {"command": "grep -r TODO src/"}}
+    if agent_id is not None:
+        payload["agent_id"] = agent_id
+    p = subprocess.run([sys.executable, HOOK], input=json.dumps(payload),
+                       capture_output=True, text=True,
+                       env=dict(os.environ, SEARCH_TOOL_NUDGE_MAX_SCAN_BYTES=str(cap)))
+    check("cap rc 0", p.returncode, 0)
+    return bool(p.stdout.strip())
+
+
+def fire_with_cap(sid, cap, transcript_path):
+    return fire_with_cap_agent(sid, cap, transcript_path)
+
+
+sid = session("cap-exact")
+check("cap exactly covering the error line still detects it",
+      fire_with_cap(sid, EXACT, cap_file), False)
+sid = session("cap-short")
+check("cap one byte short truncates and fails OPEN (nudge delivered)",
+      fire_with_cap(sid, EXACT - 1, cap_file), True)
+sid = session("cap-tiny")
+check("a tiny cap fails OPEN rather than suppressing",
+      fire_with_cap(sid, 1, cap_file), True)
+
+# --- CONCURRENCY: at most ONE nudge per kind per session, under real parallelism.
+# 12 processes released by a shared barrier so their read-modify-write windows overlap.
+# Measured pre-fix on this exact harness: 10-11 duplicates against a large transcript.
+sid = session("concurrent")
+conc_transcript = transcript("concurrent", BENIGN_RECORDS * 400)
+
+
+def _one(_i, out, idx, barrier):
+    p = subprocess.Popen([sys.executable, HOOK], stdin=subprocess.PIPE,
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    # 🔴 Let every child finish interpreter startup and block on stdin BEFORE the
+    # barrier releases. Without this the ~30 ms of Python start-up staggers the
+    # workers by far more than the ~1 ms of hook work, so they serialise and the
+    # race never happens — a concurrency test that cannot observe a broken claim.
+    # Measured: with the stagger, deleting O_EXCL still produced exactly 1 nudge.
+    time.sleep(0.6)
+    barrier.wait()
+    stdout, _e = p.communicate(json.dumps(
+        {"tool_name": "Bash", "session_id": sid, "transcript_path": conc_transcript,
+         "tool_input": {"command": "grep -r TODO src/"}}))
+    out[idx] = (p.returncode, stdout.strip())
+
+
+NPROC = 12
+_out = [None] * NPROC
+_barrier = threading.Barrier(NPROC)
+_threads = [threading.Thread(target=_one, args=(i, _out, i, _barrier)) for i in range(NPROC)]
+for _t in _threads:
+    _t.start()
+for _t in _threads:
+    _t.join()
+check("concurrency: every invocation exits 0",
+      [rc for rc, _ in _out], [0] * NPROC)
+check("concurrency: exactly one nudge across %d parallel invocations" % NPROC,
+      sum(1 for _rc, o in _out if o), 1)
+
+# --- The claim PRIMITIVE, asserted directly. ----------------------------------
+# 🔴 The end-to-end check above cannot see a broken claim: with the claim placed ahead
+# of the scan the read->claim window is microseconds wide, so O_EXCL can be deleted and
+# 12 racing processes STILL produce one nudge (measured — that mutant survived the
+# end-to-end test). The atomicity is therefore pinned where it actually lives.
+_claim = internal("_claim")
+_claimdir = os.path.join(TMP, "claimdir")
+check("claim: first caller wins", _claim(_claimdir, "content") if _claim else None, True)
+check("claim: second caller loses (O_EXCL test-and-set)",
+      _claim(_claimdir, "content") if _claim else None, False)
+check("claim: a different token is independent",
+      _claim(_claimdir, "files") if _claim else None, True)
+# Fail OPEN, not closed: an unwritable state dir must let the nudge through (the
+# pre-existing behaviour) rather than silently swallow it.
+_ro = os.path.join(TMP, "readonly")
+os.makedirs(_ro, exist_ok=True)
+os.chmod(_ro, 0o500)
+if not os.access(_ro, os.W_OK):
+    check("claim: unwritable state dir fails OPEN",
+          _claim(os.path.join(_ro, "sess"), "content") if _claim else None, True)
+os.chmod(_ro, 0o700)
+check("claim: no state dir at all fails OPEN", _claim(None, "content") if _claim else None, True)
+
+# 🔴 The claim's ANSWER must be honoured by main(), not just computed. Proving that
+# needs a state where the marker EXISTS but the directory listing does NOT show it —
+# otherwise the cheap `_read_state` fast-path filters the kind first and the claim is
+# never consulted, so "ignore the claim result" is invisible. A write+execute but
+# NOT readable directory is exactly that state: listdir() fails (fail-open -> "nothing
+# recorded"), while open(O_EXCL) on the existing marker still raises FileExistsError.
+# Deterministic — the alternative, inferring it from the 12-way race, is flaky: that
+# mutant was killed on one sweep and survived the next.
+sid = session("claim-honoured")
+_cdir = cache_path(sid)
+os.makedirs(_cdir, exist_ok=True)
+open(os.path.join(_cdir, "content"), "w").close()
+os.chmod(_cdir, 0o300)
+if not os.access(_cdir, os.R_OK):
+    check("the claim's answer is honoured (marker present, listing blind)",
+          fire(sid, "grep -r TODO src/", None), False)
+os.chmod(_cdir, 0o700)
+
+# --- Scan ORDER is load-bearing, not cosmetic. --------------------------------
+# Most-specific-first only shows up when the budget cannot cover both files: the
+# subagent's own transcript must be read BEFORE the parent's, or a large parent eats
+# the budget and the agent's own verdict is never seen.
+sid = session("scan-order")
+order_parent = transcript("scan-order", BENIGN_RECORDS * 300)
+agent_transcript(order_parent, "agentO", [unavailable_record("Grep")])
+_agent_len = os.path.getsize(os.path.join(order_parent[: -len(".jsonl")], "subagents",
+                                          "agent-agentO.jsonl"))
+check("agent transcript is scanned before the parent (budget covers only one)",
+      fire_with_cap_agent(sid, _agent_len, order_parent, "agentO"), False)
+
+# --- Only a .jsonl is treated as a transcript. --------------------------------
+sid = session("not-jsonl")
+_notjson = os.path.join(TMP, "notatranscript.txt")
+with open(_notjson, "w") as fh:
+    fh.write(json.dumps(unavailable_record("Grep")) + "\n")
+check("a non-.jsonl transcript_path is not scanned", fire(sid, "grep -r TODO src/", _notjson), True)
+
+# --- State key components are sanitized (no directory escape). ----------------
+_sdir = internal("_state_dir")
+_root = internal("STATE_ROOT")
+check("a traversal in session/agent ids cannot escape the state root",
+      os.path.dirname(_sdir({"session_id": "../../escape", "agent_id": "../x"}))
+      if (_sdir and _root) else None, _root)
+
 for i, bad in enumerate((123, [], {"a": 1}, "", "/not/a/jsonl", "/etc")):
     # A wrong-typed / non-jsonl transcript_path must never crash and never suppress.
     sid = session("badtype%d" % i)
@@ -426,15 +691,17 @@ for i, bad_agent in enumerate((123, [], "../../etc", "a/b", "")):
     rc, out = run(payload)
     check("bad agent_id %r -> nudge unchanged" % (bad_agent,), (rc, bool(out)), (0, True))
 
-for p in glob.glob(os.path.join(HOME, ".cache", "claude-search-tool-nudge",
-                                "test-search-nudge-*")):
-    try:
-        os.remove(p)
-    except OSError:
-        pass
+clear_test_state()
+leaked = sorted(os.path.basename(p) for pref in TEST_SID_PREFIXES
+                for p in glob.glob(os.path.join(STATE_ROOT, pref + "*")))
+# 🔴 IDEMPOTENCE GUARD. State left behind by one run makes the NEXT run fail — and during
+# a mutation sweep that reads as "every mutant killed", including mutants that change
+# nothing. That is exactly what happened while writing this file: a 31/31 perfect score
+# from a harness that was simply dirty. Cheap to assert, so assert it.
+check("no test state leaks into the next run", leaked, [])
 shutil.rmtree(TMP, ignore_errors=True)
 
-MIN_CHECKS = 100  # floor: a suite that silently shrinks is a vacuous green
+MIN_CHECKS = 135  # floor: a suite that silently shrinks is a vacuous green
 if fails:
     print("FAIL:")
     for f in fails:

--- a/scripts/claude-hooks/tests/test_search_tool_nudge.py
+++ b/scripts/claude-hooks/tests/test_search_tool_nudge.py
@@ -420,6 +420,19 @@ midtext = transcript("mid-text", [{
                    "Grep is not available in this session"}]}}])
 check("marker mid-text in a real error does NOT suppress",
       fire(sid, "grep -r TODO src/", midtext), True)
+# 🔴 SAME LINE, no newline before the marker. The fixture above is not enough on its
+# own: `.` does not cross newlines, so a mutant that loosens the pattern to
+# `.*No such tool available: (…)` still fails to match it and survives. This is the
+# realistic shape — a failed command whose own stderr quotes the marker on one line —
+# and under that mutant it is FALSELY SUPPRESSED.
+sid = session("mid-line")
+midline = transcript("mid-line", [{
+    "type": "user", "message": {"role": "user", "content": [{
+        "type": "tool_result", "is_error": True, "tool_use_id": "toolu_z1",
+        "content": "Command failed with exit code 2: hook.py: Error: No such tool "
+                   "available: Grep. (matched 0 files)"}]}}])
+check("marker mid-LINE in a real error does NOT suppress",
+      fire(sid, "grep -r TODO src/", midline), True)
 
 # --- The list-form content branch is real, not speculative. -------------------
 sid = session("list-form")
@@ -499,6 +512,24 @@ check("state key: agent-scoped call nudges",
 check("state key: the session that ALIASES it still gets its own nudge",
       fire(X + "_b", "grep -r TODO src/", None), True)
 
+# 🔴 Pin the PROPERTY, not the separator's spelling. The pair above only exercises the
+# "_" alias, so widening the sanitizer's allowed set to include "@" keeps it green while
+# silently reintroducing exactly the non-injectivity it was written to catch: the key
+# is injective only because "@" cannot survive _sanitize.
+_san_fn = internal("_sanitize")
+check("the join separator cannot survive sanitization",
+      _san_fn("@") if _san_fn else None, "_")
+# ...and the behavioural pair that "@" makes collide if the property is broken.
+Y = "test-search-nudge-atcollide"
+for _sid in (Y, Y + "@b"):
+    SESSIONS.append(_sid)
+for _p in glob.glob(os.path.join(STATE_ROOT, Y + "*")):
+    shutil.rmtree(_p, ignore_errors=True)
+check("state key: '@' pair — agent-scoped call nudges",
+      fire(Y, "grep -r TODO src/", None, agent_id="b"), True)
+check("state key: '@' pair — the raw '@' session still gets its own nudge",
+      fire(Y + "@b", "grep -r TODO src/", None), True)
+
 # --- FAIL OPEN: every detection failure leaves behaviour exactly as before. ----
 sid = session("missing-file")
 check("nonexistent transcript path -> nudge unchanged",
@@ -574,11 +605,64 @@ sid = session("cap-tiny")
 check("a tiny cap fails OPEN rather than suppressing",
       fire_with_cap(sid, 1, cap_file), True)
 
+# 🔴 The override is read at IMPORT time, outside main()'s try. An unparseable value
+# there escapes as a non-zero exit with a traceback on EVERY Bash call in the session —
+# the one thing the module docstring promises never happens, and a typo in a shell
+# profile is enough to trigger it. Every junk shape must exit 0 AND still nudge.
+for _i, _bad in enumerate(("abc", "", "  ", "-1", "0", "1e9", "9" * 400, "12abc", "0x10")):
+    sid = session("cap-junk-%d" % _i)
+    _p = subprocess.run(
+        [sys.executable, HOOK],
+        input=json.dumps({"tool_name": "Bash", "session_id": sid,
+                          "tool_input": {"command": "grep -r TODO src/"}}),
+        capture_output=True, text=True,
+        env=dict(os.environ, SEARCH_TOOL_NUDGE_MAX_SCAN_BYTES=_bad))
+    check("junk scan-cap %r: exit 0, no traceback, nudge delivered" % _bad,
+          (_p.returncode, "Traceback" in _p.stderr, bool(_p.stdout.strip())),
+          (0, False, True))
+
+# ...and a junk value must FALL BACK to the default, not silently disable detection.
+# Asserting "no crash" alone cannot see that: with a non-positive cap accepted verbatim,
+# every scan truncates on its first line, which also fails open and also nudges — the
+# same observable, a completely different reason. Only a transcript that SHOULD suppress
+# separates them.
+for _i, _bad in enumerate(("0", "-1", "abc")):
+    sid = session("cap-fallback-%d" % _i)
+    _p = subprocess.run(
+        [sys.executable, HOOK],
+        input=json.dumps({"tool_name": "Bash", "session_id": sid, "transcript_path": gone,
+                          "tool_input": {"command": "grep -r TODO src/"}}),
+        capture_output=True, text=True,
+        env=dict(os.environ, SEARCH_TOOL_NUDGE_MAX_SCAN_BYTES=_bad))
+    check("junk scan-cap %r falls back to the default (detection still works)" % _bad,
+          (_p.returncode, bool(_p.stdout.strip())), (0, False))
+
 # --- CONCURRENCY: at most ONE nudge per kind per session, under real parallelism.
 # 12 processes released by a shared barrier so their read-modify-write windows overlap.
 # Measured pre-fix on this exact harness: 10-11 duplicates against a large transcript.
 sid = session("concurrent")
-conc_transcript = transcript("concurrent", BENIGN_RECORDS * 400)
+# 🔴 Fixture SIZE is what makes this check able to fail on broken code, and it is not a
+# free parameter. Pre-fix, the race window IS the transcript scan sitting between the
+# state read and the state write, so it scales with the file. At ~100 KB the check was
+# flaky against the pre-fix hook — 11 runs gave 2,3,3,3,3,5,5,6,10 duplicates and ONCE
+# gave 1, i.e. GREEN on code that was broken. A test that can pass on the bug it exists
+# to catch is not a test. Sized so the window is milliseconds, not microseconds; the
+# post-fix hook claims before scanning, so it pays this scan exactly once. Measured
+# after: reliably red on the pre-fix hook, 5 runs of 5.
+#
+# Scope of that claim, so nobody later "fixes" the remainder: this is reliable against
+# the pre-fix hook, whose window IS the scan. It stays a coin flip (2/5) against base
+# main, which never reads a transcript at all — that race is genuinely microseconds wide
+# and NO fixture size widens it. Base main's narrow race is a real but separate defect,
+# and this check is not the instrument for it.
+CONC_BYTES = 8 * 1024 * 1024
+conc_transcript = os.path.join(TMP, "concurrent-big.jsonl")
+_filler = {"type": "assistant", "message": {"role": "assistant", "content": [
+    {"type": "text", "text": "x" * 400}]}}
+with open(conc_transcript, "w") as fh:
+    _line = json.dumps(_filler) + "\n"
+    for _ in range(CONC_BYTES // len(_line)):
+        fh.write(_line)
 
 
 def _one(_i, out, idx, barrier):
@@ -628,10 +712,36 @@ _ro = os.path.join(TMP, "readonly")
 os.makedirs(_ro, exist_ok=True)
 os.chmod(_ro, 0o500)
 if not os.access(_ro, os.W_OK):
-    check("claim: unwritable state dir fails OPEN",
+    # The state dir cannot be CREATED -> the makedirs handler.
+    check("claim: unwritable parent (dir cannot be created) fails OPEN",
           _claim(os.path.join(_ro, "sess"), "content") if _claim else None, True)
 os.chmod(_ro, 0o700)
+# The state dir EXISTS but the marker cannot be created -> the open()'s generic handler,
+# a different branch entirely. Without this the two are conflated and "fail closed on a
+# generic error" survives: every existing test reaches the makedirs handler instead.
+_ro2 = os.path.join(TMP, "readonly-existing")
+os.makedirs(_ro2, exist_ok=True)
+os.chmod(_ro2, 0o500)
+if not os.access(_ro2, os.W_OK):
+    check("claim: existing but unwritable state dir fails OPEN",
+          _claim(_ro2, "content") if _claim else None, True)
+os.chmod(_ro2, 0o700)
 check("claim: no state dir at all fails OPEN", _claim(None, "content") if _claim else None, True)
+# 🔴 makedirs(exist_ok=True) ALSO raises FileExistsError — when the path is a regular
+# file or a symlink rather than a directory (a leftover flat state file from the old
+# layout is exactly that). Sharing one handler with the O_EXCL open made that
+# indistinguishable from "lost the race", so the nudge vanished for the whole session:
+# fail CLOSED, contradicting the docstring. Each blocker is checked separately because
+# they reach makedirs by different routes.
+for _label, _mk in (
+    ("regular file", lambda p: open(p, "w").close()),
+    ("dangling symlink", lambda p: os.symlink(os.path.join(TMP, "nonexistent"), p)),
+    ("symlink to a file", lambda p: (open(p + ".t", "w").close(), os.symlink(p + ".t", p))),
+):
+    _blocked = os.path.join(TMP, "blocked-" + _label.replace(" ", "-"))
+    _mk(_blocked)
+    check("claim: state path is a %s -> fails OPEN" % _label,
+          _claim(_blocked, "content") if _claim else None, True)
 
 # 🔴 The claim's ANSWER must be honoured by main(), not just computed. Proving that
 # needs a state where the marker EXISTS but the directory listing does NOT show it —
@@ -701,7 +811,7 @@ leaked = sorted(os.path.basename(p) for pref in TEST_SID_PREFIXES
 check("no test state leaks into the next run", leaked, [])
 shutil.rmtree(TMP, ignore_errors=True)
 
-MIN_CHECKS = 135  # floor: a suite that silently shrinks is a vacuous green
+MIN_CHECKS = 160  # floor: a suite that silently shrinks is a vacuous green
 if fails:
     print("FAIL:")
     for f in fails:

--- a/scripts/claude-hooks/tests/test_search_tool_nudge.py
+++ b/scripts/claude-hooks/tests/test_search_tool_nudge.py
@@ -16,7 +16,7 @@ reassuring answer here is a ZERO (no false positives):
 
 Run: python3 scripts/claude-hooks/tests/test_search_tool_nudge.py
 """
-import os, sys, json, subprocess, importlib.util
+import os, sys, glob, json, shutil, subprocess, tempfile, importlib.util
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 HOOK = os.path.join(HERE, "..", "search-tool-nudge.py")
@@ -201,7 +201,240 @@ check("io malformed rc", p.returncode, 0)
 if os.path.exists(cache):
     os.remove(cache)
 
-MIN_CHECKS = 55  # floor: a suite that silently shrinks is a vacuous green
+# --------------------------------------------------------------------------- #
+# AVAILABILITY SUPPRESSION — never recommend a tool this session does not have.
+#
+# The hook infers availability from the transcript, because nothing it receives
+# enumerates the session's tools and the unavailability wording is server-side (not in
+# the claude-code bundle). Each scenario below gets its OWN session id so one scenario's
+# cache file cannot decide another's outcome.
+#
+# The pairing that makes these readable: every "suppressed" assertion is preceded by the
+# SAME payload shape against a transcript with no error record, asserted to FIRE. A
+# passing "no nudge" is otherwise indistinguishable from a harness wired to nothing.
+# --------------------------------------------------------------------------- #
+TMP = tempfile.mkdtemp(prefix="search-tool-nudge-tests-")
+SESSIONS = []
+
+
+def cache_path(sid, agent=None):
+    key = sid + ("@" + agent if agent else "")
+    return os.path.join(HOME, ".cache", "claude-search-tool-nudge",
+                        "".join(c if c.isalnum() or c in "_.-" else "_" for c in key))
+
+
+def session(name):
+    """A fresh session id whose cache file is cleared now and removed at exit."""
+    sid = "test-search-nudge-%s-DO-NOT-COLLIDE" % name
+    SESSIONS.append(sid)
+    for p in (cache_path(sid), cache_path(sid, "agentX"), cache_path(sid, "agentY")):
+        if os.path.exists(p):
+            os.remove(p)
+    return sid
+
+
+def unavailable_record(tool):
+    """The record the harness really writes — shape copied from a live transcript
+    (claude-code 2.1.220), including the <tool_use_error> wrapper and is_error."""
+    return {
+        "type": "user",
+        "isSidechain": False,
+        "message": {"role": "user", "content": [{
+            "type": "tool_result",
+            "content": ("<tool_use_error>Error: No such tool available: %s. %s is not "
+                        "available in this session — search file contents with "
+                        "`grep` via the Bash tool instead.</tool_use_error>" % (tool, tool)),
+            "is_error": True,
+            "tool_use_id": "toolu_01FAKE",
+        }]},
+        "toolUseResult": "Error: No such tool available: %s." % tool,
+    }
+
+
+BENIGN_RECORDS = [
+    {"type": "user", "message": {"role": "user", "content": [
+        {"type": "tool_result", "content": "ok", "is_error": False, "tool_use_id": "t1"}]}},
+    {"type": "assistant", "message": {"role": "assistant", "content": [
+        {"type": "text", "text": "looking at the code"}]}},
+]
+
+
+def transcript(name, records):
+    """Write a transcript at the REAL on-disk layout, so the subagent-path derivation
+    (<project>/<session>.jsonl + <project>/<session>/subagents/agent-<id>.jsonl) is
+    exercised rather than assumed."""
+    d = os.path.join(TMP, name)
+    os.makedirs(d, exist_ok=True)
+    p = os.path.join(d, "sess.jsonl")
+    with open(p, "w") as fh:
+        for r in records:
+            fh.write(json.dumps(r) + "\n")
+    return p
+
+
+def agent_transcript(main_path, agent_id, records):
+    d = os.path.join(main_path[: -len(".jsonl")], "subagents")
+    os.makedirs(d, exist_ok=True)
+    p = os.path.join(d, "agent-%s.jsonl" % agent_id)
+    with open(p, "w") as fh:
+        for r in records:
+            fh.write(json.dumps(r) + "\n")
+    return p
+
+
+def fire(sid, cmd, transcript_path=None, agent_id=None):
+    """Run the real hook and report whether it emitted a nudge."""
+    payload = {"tool_name": "Bash", "session_id": sid, "tool_input": {"command": cmd}}
+    if transcript_path is not None:
+        payload["transcript_path"] = transcript_path
+    if agent_id is not None:
+        payload["agent_id"] = agent_id
+    rc, out = run(payload)
+    check("suppression rc 0 (%s)" % sid.split("-")[3], rc, 0)
+    return bool(out)
+
+
+# --- POSITIVE CONTROL: a transcript with no error record must still nudge. -----
+sid = session("clean")
+clean = transcript("clean", BENIGN_RECORDS)
+check("clean transcript still nudges (positive control)", fire(sid, "grep -r TODO src/", clean), True)
+
+# --- NEGATIVE: Grep proven unavailable -> the CONTENT nudge is suppressed. -----
+sid = session("grep-gone")
+gone = transcript("grep-gone", BENIGN_RECORDS + [unavailable_record("Grep")])
+check("Grep unavailable suppresses the content nudge", fire(sid, "grep -r TODO src/", gone), False)
+# Per-TOOL, not session-wide: only Grep was proven missing, so the Glob nudge still
+# fires. Pins the scope of the claim — a session-wide flag would silence this too.
+check("Glob nudge still fires when only Grep was proven gone",
+      fire(sid, "find . -name '*.py'", gone), True)
+
+# --- Both proven unavailable -> both suppressed. -------------------------------
+sid = session("both-gone")
+both = transcript("both-gone", [unavailable_record("Grep"), unavailable_record("Glob")])
+check("both tools gone: content suppressed", fire(sid, "grep -r TODO src/", both), False)
+check("both tools gone: files suppressed", fire(sid, "find . -name '*.py'", both), False)
+
+# --- The verdict is CACHED: a later call with no transcript at all stays quiet. -
+# Proves the short-circuit works (and that the scan is not re-run on every call).
+check("suppression persists once recorded", fire(sid, "grep -R other .", None), False)
+# ...and it is cached as a TOOL VERDICT, not by spending the nudge budget. Asserted on
+# the state file because the behavioural check above cannot tell the two apart: a hook
+# that simply emitted both nudges and marked both kinds used would also fall silent
+# here. Pre-change this file reads ["content", "files"].
+recorded = sorted(open(cache_path(sid)).read().split()) if os.path.exists(cache_path(sid)) else []
+check("suppression records a tool verdict, not a spent nudge budget",
+      recorded, ["no:Glob", "no:Grep"])
+
+# --- STRUCTURAL, not spelled: the same TEXT in a non-error position must not ----
+# suppress. This is the real transcript hazard — the error wording appears verbatim
+# inside an Agent tool_use prompt and inside a subagent's report, both is_error false.
+sid = session("prose")
+_echoed = unavailable_record("Grep")["message"]["content"][0]["content"]
+prose = transcript("prose", [
+    {"type": "assistant", "message": {"role": "assistant", "content": [{
+        "type": "tool_use", "id": "toolu_x", "name": "Agent",
+        "input": {"prompt": "the harness said: Error: No such tool available: Grep. "
+                            "Grep is not available in this session — fix the hook"}}]}},
+    {"type": "user", "message": {"role": "user", "content": [{
+        "type": "tool_result", "is_error": False, "tool_use_id": "toolu_x",
+        "content": "report: Error: No such tool available: Grep. (quoted, not an error)"}]}},
+    # 🔴 The one that actually pins `is_error` as the discriminator: a tool_result whose
+    # text is BYTE-IDENTICAL to the real error record's, differing ONLY in the flag.
+    # This is what a Bash call that prints a transcript record produces — i.e. exactly
+    # what debugging this hook does. Without it, dropping the is_error check survives:
+    # the other two fixtures are rejected by the leading anchor instead, so they exercise
+    # the regex anchor, not the structural guard.
+    {"type": "user", "message": {"role": "user", "content": [{
+        "type": "tool_result", "is_error": False, "tool_use_id": "toolu_y",
+        "content": _echoed}]},
+     "toolUseResult": _echoed},
+])
+check("quoted error prose does NOT suppress", fire(sid, "grep -r TODO src/", prose), True)
+
+# --- A DIFFERENT tool being unavailable must not suppress Grep/Glob. -----------
+sid = session("other-tool")
+other = transcript("other-tool", [unavailable_record("WebFetch")])
+check("an unrelated missing tool does not suppress", fire(sid, "grep -r TODO src/", other), True)
+
+# --- SUBAGENT SCOPING ---------------------------------------------------------
+# transcript_path is derived from the SESSION id, which a subagent shares with its
+# parent — so a subagent's own errors are only in its per-agent transcript.
+sid = session("subagent")
+parent = transcript("subagent", BENIGN_RECORDS)
+agent_transcript(parent, "agentX", [unavailable_record("Grep")])
+check("subagent's own transcript is consulted",
+      fire(sid, "grep -r TODO src/", parent, agent_id="agentX"), False)
+# ...and it must NOT leak: the parent session (same session_id, no agent_id) reads only
+# the parent transcript, which is clean, so its nudge is still delivered.
+check("subagent suppression does not leak to the parent session",
+      fire(sid, "grep -r TODO src/", parent), True)
+# ...nor to a SIBLING agent whose own transcript is clean.
+agent_transcript(parent, "agentY", BENIGN_RECORDS)
+check("subagent suppression does not leak to a sibling agent",
+      fire(sid, "grep -r TODO src/", parent, agent_id="agentY"), True)
+
+# --- FAIL OPEN: every detection failure leaves behaviour exactly as before. ----
+sid = session("missing-file")
+check("nonexistent transcript path -> nudge unchanged",
+      fire(sid, "grep -r TODO src/", os.path.join(TMP, "nope", "sess.jsonl")), True)
+
+sid = session("garbage")
+garbage = os.path.join(TMP, "garbage.jsonl")
+with open(garbage, "w") as fh:
+    fh.write("not json\n{\"truncated\": \n\x00\x01binary\n")
+check("unparseable transcript -> nudge unchanged", fire(sid, "grep -r TODO src/", garbage), True)
+
+sid = session("is-a-dir")
+check("transcript path is a directory -> nudge unchanged", fire(sid, "grep -r TODO src/", TMP), True)
+
+sid = session("unreadable")
+unreadable = os.path.join(TMP, "unreadable.jsonl")
+with open(unreadable, "w") as fh:
+    fh.write(json.dumps(unavailable_record("Grep")) + "\n")
+os.chmod(unreadable, 0o000)
+# Skipped under a uid that ignores the mode (root in some CI images) — asserting there
+# would pin the sandbox's uid, not the hook.
+if not os.access(unreadable, os.R_OK):
+    check("unreadable transcript -> nudge unchanged", fire(sid, "grep -r TODO src/", unreadable), True)
+os.chmod(unreadable, 0o644)
+
+sid = session("nul-byte")
+# Reaches the OTHER fail-open branch — the one around path RESOLUTION rather than the
+# one around reading. Getting there needs both an agent_id and a NUL: os.path.isfile()
+# swallows ValueError and returns False (checked — a NUL path alone proves nothing),
+# but the nested-subagent glob does not: `scandir: embedded null character in path`.
+# Without that handler the exception escapes into main()'s catch-all, which exits 0
+# silently — so a detection ERROR would have become a silent SUPPRESSION.
+check("embedded NUL in transcript_path -> nudge unchanged",
+      fire(sid, "grep -r TODO src/", "/tmp/a\x00b.jsonl", agent_id="agentZ"), True)
+
+sid = session("no-transcript-key")
+check("payload without transcript_path -> nudge unchanged (legacy shape)",
+      fire(sid, "grep -r TODO src/", None), True)
+
+for i, bad in enumerate((123, [], {"a": 1}, "", "/not/a/jsonl", "/etc")):
+    # A wrong-typed / non-jsonl transcript_path must never crash and never suppress.
+    sid = session("badtype%d" % i)
+    check("bad transcript_path %r -> nudge unchanged" % (bad,),
+          fire(sid, "grep -r TODO src/", bad), True)
+
+# Same for a wrong-typed agent_id (a `..` traversal must not become a scan target).
+for i, bad_agent in enumerate((123, [], "../../etc", "a/b", "")):
+    sid = session("badagent%d" % i)
+    payload = {"tool_name": "Bash", "session_id": sid, "agent_id": bad_agent,
+               "transcript_path": clean, "tool_input": {"command": "grep -r TODO src/"}}
+    rc, out = run(payload)
+    check("bad agent_id %r -> nudge unchanged" % (bad_agent,), (rc, bool(out)), (0, True))
+
+for p in glob.glob(os.path.join(HOME, ".cache", "claude-search-tool-nudge",
+                                "test-search-nudge-*")):
+    try:
+        os.remove(p)
+    except OSError:
+        pass
+shutil.rmtree(TMP, ignore_errors=True)
+
+MIN_CHECKS = 100  # floor: a suite that silently shrinks is a vacuous green
 if fails:
     print("FAIL:")
     for f in fails:
@@ -212,4 +445,5 @@ if len(ran) < MIN_CHECKS:
     sys.exit(1)
 print(f"all search-tool-nudge tests passed ({len(ran)} checks: "
       f"{len(MUST_FIRE)} must-fire, {len(BENIGN)} benign, "
-      f"1 harness negative control, 1 benign-counter positive control)")
+      f"1 harness negative control, 1 benign-counter positive control, "
+      f"{len(SESSIONS)} availability-suppression scenarios)")


### PR DESCRIPTION
## The bug, observed first-hand

A `Grep` call in a live session came back with

```
Error: No such tool available: Grep. Grep is not available in this session —
search file contents with `grep` via the Bash tool instead.
```

and `search-tool-nudge.py` went on firing **twice afterwards**, telling the model to use
Grep. An unfollowable nudge is pure token cost on every tree-search Bash call *and* it
trains the operator to ignore the hook — which degrades it for the sessions where it IS
actionable.

## Mechanism, and why this one

Availability has to be **inferred**. Two things checked before committing to that:

* the PostToolUse payload does not enumerate the session's tools;
* the wording of the unavailability error is **not in the claude-code bundle** — 2.1.220
  contains neither `Grep is not available` nor `via the Bash tool instead`. The tool set
  is decided **server-side**, so there is no local config file a hook could read.

That leaves the transcript. `transcript_path` is on the base hook payload for every event
(confirmed in the bundle: the shared builder returns `{session_id, transcript_path, cwd,
prompt_id, permission_mode, agent_id, agent_type}` and each event schema extends it).

On a call that would nudge, scan the transcript for a `tool_result` block with `is_error`
true whose text **starts with** `Error: No such tool available: <Tool>`. Record the
outcome in a per-session state directory; every later call short-circuits.

| property | why |
|---|---|
| **Structural, not spelled** — only `is_error` blocks count | the same error text appears in the parent transcript as prose: quoted in an `Agent` tool_use prompt, and in a subagent's report. A substring grep would silence a session whose tools work fine. |
| **Anchored** — `.match`, not `.search` | a genuinely *failed* Bash call whose stderr quotes the marker is also an `is_error` result. `is_error` alone does not separate it; only the anchor does. |
| **Per-TOOL, not session-wide** | a session that has only *proven* Grep missing still gets its one Glob nudge. Within a single command earning both kinds, only the unavailable half is dropped. |
| **Per-AGENT, not just per-session** | `transcript_path` derives from the SESSION id, which a subagent shares with its parent — a subagent's errors live only in `<session>/subagents/[…/]agent-<id>.jsonl`. Scan target and state key both include `agent_id`. |

**Fail-open throughout.** A missing, unreadable, malformed, wrong-typed or non-`.jsonl`
transcript yields no signal and the nudge is delivered exactly as before. Both fail-open
handlers are individually *reachable*, each killed by its own mutant.

## 🔴 Concurrency — the audit's headline finding, and it was mine

The first commit **widened an existing race**. State was a per-session FILE updated
read-modify-write, and the new transcript scan sits between the read and the write,
stretching the window from microseconds to tens of milliseconds. Parallel subagents share
one session, so this is the normal case here.

Measured with 12 truly-concurrent invocations against a 66.5 MB transcript. The harness
matters: workers are released by a shared barrier **after every child has reached its
stdin read** — without that wait, ~30 ms of interpreter start-up staggers them by far more
than the ~1 ms of hook work and the race simply never happens.

| revision | duplicate nudges (12 workers, 3 runs) |
|---|---|
| base main `1daca5c` | 0, 0, 1 |
| `6d3d6a3` (first commit) | **11, 11, 11** |
| **HEAD `cf08829`** | **0, 0, 0** — and 0, 0, 0 at 32 workers |

**Fix:** state is a **directory** per session; each token is an empty marker file created
with `O_CREAT|O_EXCL` — an atomic test-and-set, no lock, so nothing can block a Bash call.
The kind is claimed **before** the transcript is scanned, so exactly one process per kind
scans and exactly one can emit; losers exit silently having paid nothing.

The comment now states what is actually guaranteed, and what is not: an unwritable state
directory fails **open** and may duplicate (as the pre-existing hook did) rather than
swallow the nudge; a process that claims a kind and then dies burns that kind for the
session — one lost nudge being far cheaper than N duplicates.

## Other audit items

* **Anchor** was untested *and* doubly specified — `^` plus `.match` meant a mutant could
  delete either for free. Now one anchor, pinned by a mid-text fixture.
* **State key was non-injective**: `sanitize(session + "@" + agent)` mapped `@` to `_`, so
  `session="a"`+`agent="b"` collided with `session="a_b"`, and the first silenced the
  second. Components are now sanitized individually and joined with a literal `@`, which
  no sanitized component can contain. (Residual and pre-existing: two raw session ids that
  sanitize identically still alias. Real ids are UUIDs.)
* **Scan cap was about to trip** — 64 MiB against a largest-transcript of 63.4 MiB, 99.1%,
  one long session from silent truncation. Now 1 GiB with the reasoning written down, and
  overridable via `SEARCH_TOOL_NUDGE_MAX_SCAN_BYTES` so the boundary is testable. Pinned at
  two points: a cap admitting the error line exactly, and one byte less.
* **A comment claimed coverage the assertion didn't have** — "a `..` traversal must not
  become a scan target" was asserting the *nudge outcome*, which still passed with the
  validation deleted. It now asserts the **resolved scan target** via `_transcript_paths`,
  using a glob metacharacter: the realistic leak, where an unvalidated `agent_id` makes the
  fallback glob match a **sibling** agent's transcript and inherit its verdict.
* **Two dead branches removed** rather than shipped as decoration, both exposed by the
  sweep: the `no:<Tool>` short-circuit (unreachable once the claim moved ahead of the scan)
  and the token filename encode/decode pair (`:` is a legal filename byte on Linux). The
  `no:<Tool>` record is kept and relabelled for what it is — a diagnostic breadcrumb, not
  load-bearing.

## Red / green matrix

150 checks (was 57 before this PR), floor 55 → 135. The **final** file is run unmodified
against each revision: internals resolve through `internal()`, which records a **loud
failure** when a symbol is missing rather than crashing, so older revisions run end to end
and every check reports its own verdict.

Each revision is run **5 times**, because a check that is red on only some runs against
broken code is not coverage — it is a coin flip, and repetition is what makes that visible
instead of averaging it into one reassuring number.

| revision | reliably red | flaky |
|---|---|---|
| **HEAD `8b08673`** | **0 red / 174 checks**, 5 of 5 | 0 |
| `cf08829` (previous round) | **11** — this round's coverage | 0 |
| `6d3d6a3` (first commit) | **21** | 0 |
| base main `1daca5c` | **33** | 1 |

Red at `cf08829` (what this round earns): the three `_claim` fail-closed blockers
(regular file / dangling symlink / symlink-to-file), the five junk scan-cap shapes, the
sanitizer property, the `@` behavioural pair, and the same-line anchor fixture.

Red at `6d3d6a3`: the claim primitive, the concurrency check, both cap truncation points,
the state-verdict contents and the aliasing state key.

Red at base main: suppression itself, per-tool behaviour within one command, list-form
error content, all three subagent-scoping checks, the nested-agent glob, the
resolved-scan-target checks, and the exact-cap check.

**The one remaining flake is inherent and is documented in the test**: the concurrency
check is a coin flip (2/5) against base main, which never reads a transcript, so that race
is genuinely microseconds wide and no fixture size widens it. It is reliably red (5/5)
against `6d3d6a3`, whose window *is* the scan — which is the regression it exists to catch.

### Count reconciliation

The delta audit measured **14** red at `6d3d6a3` and **24** at `1daca5c`; the previous body
said 13 and 23. Both discrepancies have **one cause** — the flaky concurrency check, green
on the run I measured and red on theirs. The auditor's numbers were right. Fixed at the
source (fixture enlarged from ~100 KB to 8 MiB, now 0 flaky there) rather than by
restating the number.

**Honest labelling:** of the 53 checks added in the first round, **46 passed at base** —
those are **invariant guards**, not regression coverage. They pin behaviour that was already
correct (the benign set, the fail-open cases, the anchor, the IO contract). Several are what
kill mutants — but they are not evidence that this PR fixed something.

## Mutation battery — 37 mutants, 35 killed, stable across two consecutive runs

Survivors, both **semantics-preserving** and both now labelled as such in the code:

* `M7` drop the byte prefilter — pure performance, identical semantics.
* `M32` ignore the `_read_state` fast path — the atomic claim already rejects a handled
  kind, so the read is a cost optimisation, not a correctness guard.

The previous body claimed *"10 mutants, 9 killed"*. That number **overstated the coverage
that existed**: a differently-constructed sweep found genuine untested guards behind it
(the anchor, the list-form branch, `agent_id` validation, the nested glob, scan order, and
the budget cap). All are now covered.

Three findings the rebuilt battery produced that re-running the old one would not have:

1. **The first rebuild scored 31/31 — from a broken harness.** The suite left state behind,
   so every run after the first failed, which reads as "every mutant killed", including
   mutants that change nothing. The **PERF-ONLY control is what exposed it**: a sweep where
   even the no-op dies is measuring the harness, not the code. The suite is now idempotent
   (verified over consecutive runs) and asserts its own cleanliness as a check.
2. **"Ignore the claim result" was killed on one sweep and survived the next** — a flaky
   kill is not a kill. It is now pinned deterministically: a write+execute but *unreadable*
   state directory makes `listdir` fail (fail-open) while the marker still exists, which is
   the only state where the claim's answer is observable.
3. **The end-to-end concurrency test could not see a deleted `O_EXCL` at all**, because the
   fix makes the read→claim window microseconds wide. Atomicity is therefore pinned on the
   primitive directly, where it lives.

Both mutants the **delta audit** found surviving now die **at their own assertion**:

| mutant | dies at |
|---|---|
| `A13` regex prefixed with `.*` | `marker mid-LINE in a real error does NOT suppress` |
| `A16` sanitizer allows `@` | `the join separator cannot survive sanitization` |
| `A1` makedirs shares the FileExistsError handler | `claim: state path is a regular file -> fails OPEN` |

Two further survivors on this battery's first pass were **real gaps, now closed**:

* Accepting a **non-positive cap verbatim** was indistinguishable from the fallback —
  both fail open, both nudge. Only a transcript that *should* suppress separates them.
* **"Fail closed on a generic claim error"** survived because every existing test reached
  the `makedirs` handler. An **existing but unwritable** state dir reaches the `open()`
  handler instead.

## Known gap — stated, not papered over

The signal only exists **once the model has attempted the tool**. A session that never
reaches for Grep — because it can see Grep is not in its tool list — produces no signal and
keeps getting the nudge. Nothing in the payload distinguishes that case and there is no
local source of truth. The self-healing path is the one that fired in the observed bug:
model tries Grep once, gets the error, nudge goes quiet for the session.

## Measurements, stated at the scope actually measured

Scan throughput: **52–102 ms over 5 runs** on the 63.4 MiB transcript — 0.8–1.6 ms/MiB with
a **warm page cache**. Caches could not be dropped on this host, so that is a **floor, not
a bound**; a cold read is slower by an unmeasured factor. Even at 10× the floor the 1 GiB
cap is a few seconds, once per kind per session, and truncation fails open.

## Fix round 2 — five defects the delta audit found, all self-inflicted

Every one was introduced by the two previous commits. Two broke the file's own documented
contract. Each verified through the **real hook process**, not an internal call:

| # | defect | `cf08829` | `8b08673` |
|---|---|---|---|
| 🟡1 | `_claim` **failed CLOSED** — `makedirs(exist_ok=True)` also raises `FileExistsError` when the path is a regular file or symlink (a leftover flat state file is exactly that), sharing the handler that means "lost the race". Nudge gone for the whole session. | `nudged=False` | `nudged=True` |
| 🟡2 | The scan-cap env override raised at **import time**, outside `main()`'s try — `…=abc` exited 1 with a traceback on *every* Bash call. Precisely what the docstring promises never happens. | `rc=1`, traceback | `rc=0`, nudge delivered |
| 🟡3 | A header comment still described the token encode/decode pair the previous commit deleted. | stale | corrected |
| 🟡4 | Widening the sanitizer to allow `@` left the suite **150/150 green** while reinstating the non-injectivity fixed last round — the test pinned the `_`-join *spelling*, not the property. | mutant survives | `A16` killed |
| 🟡5 | The anchor fixture put the marker after a `\n`, and `.` does not cross newlines, so a `.*`-loosened regex survived. | mutant survives | `A13` killed |

Fixes 1 and 2 are the ones that mattered: both turn a *detection* problem into a *silent
behaviour* problem, and both contradicted comments sitting a few lines away.

**Also — a flaky test, fixed rather than tolerated.** The in-suite concurrency check was
timing-dependent: against `6d3d6a3` it gave 2,3,3,3,3,5,5,6,10 duplicates over 11 runs and
**once gave 1**, i.e. green on broken code. Its fixture was ~100 KB, but the pre-fix race
window *is* the transcript scan, so it scales with file size. Enlarged to 8 MiB → reliably
red, 5 runs of 5.

## End-to-end against the real transcript

```
base main 1daca5c    nudged: True   -> • Grep tool → Grep(pattern="…", …)
HEAD 8b08673         nudged: False
```

## CI

`nix build .#checks.x86_64-linux.pytests`: `test_search_tool_nudge.py (script) PASS`, and
`TOTAL collected=6051 passed=5904 skipped=3 failed=144` — **byte-identical to the same
build at base `1daca5c`**, so this change adds no failures.

## 🔴 Pre-existing red gate on `main` — separate from this PR

Verified by building the gate from a clean clone of `main` at `1daca5c`: identical
`144 failed`.

* `scripts/tests/test_opencode_config.py` — **117 failures**, high-blast-radius commands
  resolving to `allow` where the tests require `ask` (`kubectl delete pod`,
  `kubectl apply -f`, `kubectl get secret -o yaml`). A permission-safety assertion, not a
  cosmetic one. The base clone has uncommitted `scripts/opencode/opencode.jsonc` edits, so
  someone may already be mid-fix.
* `test_rig_control.py` (32) and `test_monitor_blackout.py` (22) — `FileNotFoundError:
  /usr/bin/env`; `patchShebangs` only rewrites executable files.

Left alone deliberately: out of scope, and a concurrent agent is working in that area.

## Deploy

**Merging does not deploy this.** `~/.claude/hooks/search-tool-nudge.py` is a nix-store
symlink, so after merge it needs `scripts/ship.sh` (or `home-manager switch --flake
~/workspace/devrc --impure` for one host). No hook re-registration needed.

One transition note: this changes the on-disk state layout from a flat file per session to
a directory per session under `…/claude-search-tool-nudge/s/`. Sessions live at switch time
simply start fresh; the old flat files are inert and ignored.

## Follow-ups the auditor raised, not fixed here (agreed out of scope)

`is_error` truthiness accepting a non-empty string; the Grep-legacy capture-stop nit; the
post-materialisation budget decrement (peak RSS unbounded on a single giant line); unbounded
`CACHE_DIR` growth — now one directory per session rather than one file, so the inode count
grows faster and this is worth a cheap reaper; the spelled traversal guard in the tests; and
the `chmod` without `try/finally` in the tests. No disagreement on any of them.

One correction rather than a deferral: the `_state_dir` docstring called the residual key
aliasing "pre-existing and NOT introduced here". The character-substitution half is; the
`[:120]` **truncation** half is mine. Now stated at its real scope. Both are unreachable
with the UUID/hex ids the harness actually sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

