### PR TITLE
espanso: add :mt (meantime), and make keylog restart on an espanso-config change

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -137,6 +137,24 @@ in
           # bar for "recom" on 2026-07-27 hunting for exactly this, and found nothing.
           { trigger = ":rna"; replace = "recommend next actions"; label = "Recommend next actions"; search_terms = ["recommend" "recom" "next" "actions" "rank" "leverage"]; }
           { trigger = ":lr"; replace = "limit restored, resume agent"; label = "Limit restored — resume agent"; search_terms = ["limit" "restored" "resume" "agent" "continue" "quota"]; }
+          # Added 2026-08-05 via /espanso-audit. WHOLE-STANDALONE-MESSAGE shaped,
+          # which is the ONLY shape that has ever stuck here (:eos 72 fires,
+          # :kickoff 38); every mid-sentence FRAGMENT snippet has since been
+          # pruned (:ds :rns :pst :rnx :aep :nday :fhrs :fdays). SHAPE, not
+          # length, is the predictor — :ds's phrase was hand-typed 94× and the
+          # snippet still only ever fired once.
+          # Measured demand: 8 genuine instances over ~3 weeks across the keylog
+          # typing stream + transcripts, 5 of them standing ALONE as a whole
+          # message, and typed with heavy toil ("in th eme meantime",
+          # "meatimmeantime", "wahwhat can youwe rudo").
+          # His vocabulary is meantime / while that runs / tee up / queue up /
+          # in parallel — "meanwhile" has ZERO hits, so it is deliberately NOT a
+          # search term. 168 of 173 fires go through the Ctrl+Space SEARCH UI,
+          # so `label` + `search_terms` ARE the interface: the label leads with
+          # the word he'd search, and the multi-word terms exist so his real
+          # queries ("in the meantime", "what can we do") tokenize onto this
+          # snippet (see espanso_detect._term_matches).
+          { trigger = ":mt"; replace = "tee up what we can do in the meantime: identify work that is INDEPENDENT of what is currently running — nothing touching the same files — then dispatch it in parallel with complete test coverage. if we are actually blocked until that finishes, say so plainly instead of inventing filler work."; label = "Meantime: tee up independent parallel work while that runs"; search_terms = ["meantime" "in the meantime" "while" "while that runs" "parallel" "queue" "queue up" "tee" "tee up" "wait" "blocked" "idle" "what can we do"]; }
           # Removed 2026-07-25 via /espanso-audit — all keylog-evidence-backed:
           #  ZERO-FIRE set — 0 keylog fires + short-form hand-typing; steering already in
           #   RULES.md / slash-commands: :rnx, :pst ("proceed, dispatch" typed 40+×),
@@ -1320,7 +1338,22 @@ in
       # Remove once the spin is fixed and verified idle-at-~0%.
       CPUQuota = "30%";
       # Restart on a script-only change (see activity-collector for rationale).
-      X-Restart-Triggers = [ "${../scripts/collector/keylog}" ];
+      #
+      # ...AND on an espanso CONFIG-only change. keylog loads the espanso trigger
+      # set ONCE, at process init (keylog.py's ctor → espanso_triggers.load_triggers
+      # over ~/.config/espanso/{match/base.yml,config/default.yml}). Pinning only
+      # the keylog script directory meant an espanso-only edit to this file left
+      # the keylog UNIT DEFINITION byte-identical, so sd-switch did not restart it
+      # and the daemon kept matching the OLD trigger set. Counter-example on
+      # record: d0156c5 (#325, the :eos rewrite) was espanso-only → no restart.
+      # Consequence: a newly added snippet records ZERO fires and the next
+      # /espanso-audit prunes it as dead — a self-reinforcing loop.
+      # `graphical` guard: the espanso HM module only defines these xdg.configFile
+      # entries under `mkIf cfg.enable`, and services.espanso.enable = graphical.
+      X-Restart-Triggers = [ "${../scripts/collector/keylog}" ] ++ lib.optionals graphical [
+        "${config.xdg.configFile."espanso/match/base.yml".source}"
+        "${config.xdg.configFile."espanso/config/default.yml".source}"
+      ];
     };
     Install = {
       WantedBy = [ "graphical-session.target" ];

--- a/scripts/collector/keylog/tests/test_espanso_detect.py
+++ b/scripts/collector/keylog/tests/test_espanso_detect.py
@@ -466,3 +466,168 @@ def test_single_word_term_behaviour_unchanged():
 def test_multiword_term_with_extra_whitespace_is_tokenized():
     d = _det_for(CIVIT_BASE)
     assert d._attribute("  civit   prod  ") == ":cpk"
+
+
+# --------------------------------------------------------------------------- #
+# LIVE-CONFIG guards — these read nix/home.nix, NOT a fixture.
+#
+# Everything above pins detector SEMANTICS against hand-written fixtures. That
+# is structurally blind to the config itself: a fixture keeps asserting whatever
+# was true the day it was typed, so deleting a snippet's search_terms in
+# nix/home.nix leaves every test above green. But `label` + `search_terms` ARE
+# the interface — 168 of 173 measured fires go through the Ctrl+Space search UI
+# — so a snippet whose terms stop resolving is a DEAD snippet, and the next
+# /espanso-audit prunes it for recording zero fires.
+#
+# So these guards parse the real file. It is scraped, not nix-evaluated: every
+# snippet is a single-line `{ trigger = "…"; … }` record, and a regex over that
+# needs no nix binary in the sandbox. A MISSING file FAILS rather than skips —
+# the whole point is that this cannot go quietly green.
+# --------------------------------------------------------------------------- #
+import re  # noqa: E402
+import pytest  # noqa: E402
+
+HOME_NIX = Path(__file__).resolve().parents[4] / "nix" / "home.nix"
+
+_NIX_REC = re.compile(r"^\s*\{\s*trigger\s*=\s*\"((?:[^\"\\]|\\.)*)\"\s*;")
+_NIX_LABEL = re.compile(r"label\s*=\s*\"((?:[^\"\\]|\\.)*)\"\s*;")
+_NIX_REPLACE = re.compile(r"replace\s*=\s*\"((?:[^\"\\]|\\.)*)\"\s*;")
+_NIX_TERMS = re.compile(r"search_terms\s*=\s*\[([^\]]*)\]")
+_NIX_STR = re.compile(r"\"((?:[^\"\\]|\\.)*)\"")
+
+
+def _live_base():
+    """The espanso match set as written in nix/home.nix, in base.yml dict shape.
+
+    CAVEAT: `replace` here is the RAW nix source, so a path snippet reads
+    "${workspace}/…" pre-interpolation. That is fine — the detector never
+    consults `replace` (see `_token_matches`), and the fields it DOES consult
+    (trigger, label, search_terms) were verified byte-identical to the base.yml
+    nix actually generates (2026-08-05, via `nix build …#homeConfigurations.zach
+    .activationPackage` + espanso_triggers.load_triggers over the emitted YAML).
+    """
+    if not HOME_NIX.exists():
+        pytest.fail(f"nix/home.nix not found at {HOME_NIX} — this guard cannot "
+                    f"be allowed to skip; fix the path.")
+    matches = []
+    for line in HOME_NIX.read_text(encoding="utf-8").splitlines():
+        m = _NIX_REC.match(line)
+        if not m:
+            continue
+        lab = _NIX_LABEL.search(line)
+        rep = _NIX_REPLACE.search(line)
+        ter = _NIX_TERMS.search(line)
+        matches.append({
+            "trigger": m.group(1),
+            "replace": rep.group(1) if rep else "",
+            "label": lab.group(1) if lab else "",
+            "search_terms": _NIX_STR.findall(ter.group(1)) if ter else [],
+        })
+    return {"matches": matches}
+
+
+def _live_det():
+    return EspansoDetector(ET.load_triggers(_live_base(), DEFAULT))
+
+
+def test_live_scraper_observes_the_real_config():
+    """POSITIVE CONTROL for the scraper the three guards below depend on.
+
+    Without this, a regex that silently matched NOTHING would make every guard
+    below vacuously true (empty trigger set → nothing to contradict). Pin a
+    non-trivial count and two long-standing snippets with known metadata.
+    """
+    base = _live_base()
+    trigs = [m["trigger"] for m in base["matches"]]
+    assert len(trigs) >= 20, f"scraper found only {len(trigs)} snippets: {trigs}"
+    assert len(set(trigs)) == len(trigs), "duplicate trigger in nix/home.nix"
+    assert ":date" in trigs and "dashbaord" in trigs
+    by_trig = {m["trigger"]: m for m in base["matches"]}
+    assert by_trig[":date"]["search_terms"] == ["today", "calendar"]
+    assert by_trig[":kickoff"]["label"] == "Kickoff message for next session"
+
+
+# The queries the 2026-08-05 /espanso-audit measured him actually typing (plus
+# the single-word prefixes the search bar sees mid-type). EVERY one must land on
+# :mt alone. Goes RED if :mt's search_terms are removed, or if a future snippet
+# makes any of them ambiguous.
+_MT_TERMS = [
+    "meantime", "mean", "while", "parallel", "queue", "tee", "wait",
+    "blocked", "idle", "tee up", "queue up", "in the meantime",
+    "what can we do", "while that runs",
+]
+
+
+def test_live_mt_search_terms_all_resolve_to_mt():
+    d = _live_det()
+    unresolved = {}
+    for term in _MT_TERMS:
+        got = d._attribute(term)
+        if got != ":mt":
+            competing = [t for t in d.ts.triggers if d._term_matches(term, t)]
+            unresolved[term] = (got, competing)
+    assert not unresolved, (
+        "these search terms no longer resolve to :mt "
+        "(term -> (attributed, competing snippets)): " + repr(unresolved)
+    )
+    # "up" alone is a substring of :eos's search_term "update", so the two-token
+    # queries are the ones that could silently drift — assert them explicitly.
+    assert d._attribute("tee up") == ":mt"
+    assert d._attribute("queue up") == ":mt"
+    # ...and the trigger really is present with the label leading on "Meantime".
+    assert ":mt" in d.ts.triggers
+    assert d.ts.meta[":mt"]["label"].lower().startswith("meantime")
+
+
+# Resolutions that held BEFORE :mt existed and must still hold. A new snippet's
+# search_terms are the classic way to make an existing one ambiguous.
+_EXISTING_RESOLUTIONS = [
+    ("rit", ":eos"), ("kick", ":kickoff"), ("kic", ":kickoff"),
+    ("recom", ":rna"), ("recommend", ":rna"),
+    ("limit", ":lr"), ("resume", ":lr"), ("restored", ":lr"),
+    ("feedback", ":acq"), ("dispatch", ":acq"), ("process", ":acq"),
+    ("cc", ":cc"), ("kubecl", ":kuc"), ("spine", ":csc"), ("orch", ":cmo"),
+    ("home", ":hlt"), ("prod", ":cpk"), ("datap", ":cdp"), ("civit prod", ":cpk"),
+]
+
+
+def test_live_existing_resolutions_not_made_ambiguous():
+    d = _live_det()
+    bad = {}
+    for term, want in _EXISTING_RESOLUTIONS:
+        got = d._attribute(term)
+        if got != want:
+            bad[term] = (want, got, [t for t in d.ts.triggers if d._term_matches(term, t)])
+    assert not bad, (
+        "search terms regressed (term -> (expected, actual, matching snippets)): "
+        + repr(bad)
+    )
+
+
+def test_live_triggers_have_no_prefix_or_suffix_collisions():
+    """espanso longest-matches; the detector emits the SHORTEST match.
+
+    Where one trigger is a prefix or suffix of another the two disagree, so the
+    keylog signal misattributes. Pin zero such pairs — and prove the checker can
+    SEE one, so the zero is a real zero and not a check wired to nothing.
+    """
+    def pairs(trigs):
+        found = set()
+        for a in trigs:
+            for b in trigs:
+                if a == b:
+                    continue
+                if a.startswith(b):
+                    found.add((b, a, "prefix"))
+                if a.endswith(b):
+                    found.add((b, a, "suffix"))
+        return found
+
+    live = [m["trigger"] for m in _live_base()["matches"]]
+    # POSITIVE CONTROL: seed a known-bad set and require the checker to report it.
+    control = pairs(live + [":m", "x:mt"])
+    assert (":m", ":mt", "prefix") in control and (":mt", "x:mt", "suffix") in control, (
+        "collision checker failed its positive control — its zero below would "
+        "mean nothing"
+    )
+    assert pairs(live) == set(), f"colliding triggers in nix/home.nix: {pairs(live)}"

--- a/scripts/session-analysis/espanso-usage.py
+++ b/scripts/session-analysis/espanso-usage.py
@@ -161,6 +161,11 @@ SNIPPETS = {
     # NOTE :rna is deliberately "actions", NOT the pruned :rns's "steps" (3 rows).
     ":rna":     ("prompt", ["recommend next actions"], [], False),
     ":lr":      ("prompt", ["limit restored, resume agent"], [], False),
+    # added 2026-08-05 via /espanso-audit — whole-standalone-message shaped;
+    # 8 genuine instances over ~3 weeks (5 standalone), heavy typing toil.
+    # Include substring is the OPENER, which is distinctive enough on its own —
+    # the rest of the expansion is long and gets paraphrased when hand-typed.
+    ":mt":      ("prompt", ["tee up what we can do in the meantime"], [], False),
     # utilities / typo-correction — output not distinguishable
     ":uuid":     ("util", None, [], False),
     ":clip":     ("util", None, [], False),


### PR DESCRIPTION
Adds the `:mt` "meantime" snippet, and fixes the reason a new snippet would have looked dead on arrival.

## 1. `:mt` — tee up independent parallel work

```
tee up what we can do in the meantime: identify work that is INDEPENDENT of what is
currently running — nothing touching the same files — then dispatch it in parallel
with complete test coverage. if we are actually blocked until that finishes, say so
plainly instead of inventing filler work.
```

label: `Meantime: tee up independent parallel work while that runs`

Whole-standalone-message shaped, which is the **only** shape that has ever stuck here (`:eos` 72 fires, `:kickoff` 38). Every mid-sentence FRAGMENT snippet has since been pruned (`:ds` `:rns` `:pst` `:rnx` `:aep` `:nday` `:fhrs` `:fdays`). **Shape, not length, is the predictor** — `:ds`'s phrase was hand-typed 94× and the snippet still only ever fired once.

Measured demand from the 2026-08-05 `/espanso-audit`: **8 genuine instances over ~3 weeks** across the keylog typing stream + transcripts, **5 of them standalone**, typed with heavy toil (`in th eme meantime`, `meatimmeantime`, `wahwhat can youwe rudo`).

**168 of 173 fires go through the Ctrl+Space SEARCH UI**, so `label` + `search_terms` *are* the interface. Terms are his actual vocabulary — meantime / while that runs / tee up / queue up / in parallel. `meanwhile` has **0** hits and is deliberately absent.

## 2. 🔴 `keylog.service` now restarts on an espanso **config** change

`keylog` loads its espanso trigger set **once**, at process init. The unit's `X-Restart-Triggers` pinned only the keylog *script directory*, so an espanso-only edit to `nix/home.nix` left the keylog unit definition byte-identical → sd-switch did not restart it → the daemon kept matching the **old** trigger set. Counter-example on record: `d0156c5` (#325, the `:eos` rewrite) touched `nix/home.nix` alone, so no restart.

Consequence: a newly added snippet records **0 fires**, and the next `/espanso-audit` prunes it as dead. Self-reinforcing.

Fix pins the espanso store paths too, guarded by `graphical` (the HM espanso module only defines those `xdg.configFile` entries under `mkIf cfg.enable`, and `services.espanso.enable = graphical`):

```nix
X-Restart-Triggers = [ "${../scripts/collector/keylog}" ] ++ lib.optionals graphical [
  "${config.xdg.configFile."espanso/match/base.yml".source}"
  "${config.xdg.configFile."espanso/config/default.yml".source}"
];
```

### Demonstrated, not asserted

Built `#homeConfigurations.zach.activationPackage --impure` four times and compared the **generated** `home-files/.config/systemd/user/keylog.service`:

| build | unit form | espanso edit (one extra `search_term` on `:date`) | result |
|---|---|---|---|
| A vs B | **with fix** | B has it | **DIFFER** — `X-Restart-Triggers=…-base.yml` moves `qvz37394…` → `sp01r8z2…` (`diff` exit 1, `cmp` exit 1) |
| C vs D | pre-fix | C has it | **byte-identical** (`cmp` exit 0) — the bug, reproduced |

## 3. Audit tooling kept in sync

`:mt` added to `SNIPPETS` in `scripts/session-analysis/espanso-usage.py` with the opener as its include-substring.

## Validation

- `nix-instantiate --parse nix/home.nix` → OK.
- **Collision sweep** over all 24 live triggers: **0** prefix/suffix pairs. *Positive-controlled* — the same checker reports 4 pairs on a seeded bad set (`:m` / `:mtx` / `x:mt`), so the zero is a real zero.
- **Search-term resolution** (built from the edited `nix/home.nix`, run through `EspansoDetector._attribute`): all 14 of `meantime`, `mean`, `while`, `parallel`, `queue`, `tee`, `wait`, `blocked`, `idle`, `tee up`, `queue up`, `in the meantime`, `what can we do`, `while that runs` → `:mt`, uniquely (1 matching snippet each). `up` is a substring of `:eos`'s `update`, so `tee up` / `queue up` were checked explicitly.
- **No regression** — identical with and without `:mt` in the set: `rit`→`:eos`, `kick`/`kic`→`:kickoff`, `recom`/`recommend`→`:rna`, `limit`/`resume`/`restored`→`:lr`, `feedback`/`dispatch`/`process`→`:acq`, `cc`→`:cc`, `kubecl`→`:kuc`, `spine`→`:csc`, `orch`→`:cmo`, `home`→`:hlt`, `prod`→`:cpk`, `datap`→`:cdp`, `civit prod`→`:cpk`.
- **Cross-checked** the `home.nix` scrape against the `base.yml` nix *actually generates*, parsed by `espanso_triggers.load_triggers` under PyYAML: 24 triggers each, identical trigger/label/search_terms, same 14/14 resolution. (A second tool that fails differently.)
- **keylog suite, both tiers**: `72 passed, 1 skipped` without PyYAML; `73 passed, 0 skipped` under `nix-shell -p python3Packages.pytest python3Packages.pyyaml`.

## New tests — each watched RED

They read `nix/home.nix` itself, not a fixture: a fixture is structurally blind to the config it is meant to guard, and would stay green while the snippet's terms were deleted.

| mutation | failure observed |
|---|---|
| strip `:mt`'s `search_terms` | `test_live_mt_search_terms_all_resolve_to_mt` — `{'queue': (None, []), 'wait': (None, []), 'blocked': (None, []), 'idle': (None, []), 'queue up': …, 'in the meantime': …, 'what can we do': …}` |
| add `"meantime"`+`"prod"` to `:lr` | same test — `{'meantime': (None, [':lr', ':mt']), 'mean': (None, [':lr', ':mt'])}`; **and** `test_live_existing_resolutions_not_made_ambiguous` — `{'prod': (':cpk', None, [':lr', ':cpk'])}` |
| add a colliding `:m` trigger | `test_live_triggers_have_no_prefix_or_suffix_collisions` — `colliding triggers in nix/home.nix: {(':m', ':mt', 'prefix')}` |
| break the scraper regex | **all four** guards fail, including the collision guard's own positive control (`collision checker failed its positive control — its zero below would mean nothing`) — a wired-to-nothing scrape cannot report a vacuous green |

## Not done here

Not deployed — no `home-manager switch` / `ship.sh` was run. After merge, the switch is what installs both the snippet and the restarted keylog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
