### PR TITLE
fix(opencode): unbreak the 117-red permission gate — a blind sed flattened 52 `ask` values to `allow`

### DIFF
--- a/scripts/opencode/opencode.jsonc
+++ b/scripts/opencode/opencode.jsonc
@@ -190,8 +190,8 @@
 
     // Ask before burning a long unproductive loop, and before reaching outside
     // the project directory.
-    "doom_loop": "allow",
-    "external_directory": "allow",
+    "doom_loop": "ask",
+    "external_directory": "ask",
 
     "bash": {
       "*": "allow",
@@ -205,77 +205,77 @@
       // rather than prompting. Anything irreversible belongs in guard_core.py.
 
       // --- git ---
-      "*git*push*": "allow",
-      "*git*commit*": "allow",
-      "*git*rebase*": "allow",
-      "*git*checkout*": "allow",
-      "*git*restore*": "allow",
-      "*git*branch -D*": "allow",
-      "*git*worktree remove*": "allow",
-      "*gh*pr merge*": "allow",
+      "*git*push*": "ask",
+      "*git*commit*": "ask",
+      "*git*rebase*": "ask",
+      "*git*checkout*": "ask",
+      "*git*restore*": "ask",
+      "*git*branch -D*": "ask",
+      "*git*worktree remove*": "ask",
+      "*gh*pr merge*": "ask",
 
       // --- kubernetes / gitops ---
-      "*kubectl*delete*": "allow",
-      "*kubectl*apply*": "allow",
-      "*kubectl*patch*": "allow",
-      "*kubectl*scale*": "allow",
-      "*kubectl*drain*": "allow",
-      "*kubectl*edit*": "allow",
-      "*kubectl*replace*": "allow",
-      "*kubectl*exec*": "allow",
-      "*kubectl*cp*": "allow",
-      "*kubectl*rollout undo*": "allow",
+      "*kubectl*delete*": "ask",
+      "*kubectl*apply*": "ask",
+      "*kubectl*patch*": "ask",
+      "*kubectl*scale*": "ask",
+      "*kubectl*drain*": "ask",
+      "*kubectl*edit*": "ask",
+      "*kubectl*replace*": "ask",
+      "*kubectl*exec*": "ask",
+      "*kubectl*cp*": "ask",
+      "*kubectl*rollout undo*": "ask",
       // `get secret -o yaml` prints every value base64-encoded, i.e. plaintext.
-      "*kubectl*secret*": "allow",
-      "*helm*upgrade*": "allow",
-      "*helm*uninstall*": "allow",
-      "*helm*rollback*": "allow",
-      "*flux*suspend*": "allow",
-      "*flux*resume*": "allow",
-      "*flux*delete*": "allow",
+      "*kubectl*secret*": "ask",
+      "*helm*upgrade*": "ask",
+      "*helm*uninstall*": "ask",
+      "*helm*rollback*": "ask",
+      "*flux*suspend*": "ask",
+      "*flux*resume*": "ask",
+      "*flux*delete*": "ask",
 
       // --- talos --- (the RESET verb is enforced by guard_core.py, which is
       // the only layer that catches `talosctl -n <ip> reset`. This broad ask is
       // friction for every other node-level verb.)
-      "*talosctl*": "allow",
+      "*talosctl*": "ask",
 
       // --- secrets to plaintext ---
-      "*sops*-d*": "allow",
-      "*sops*--decrypt*": "allow",
-      "*sops*exec-env*": "allow",
-      "*age*-d*": "allow",
-      "*age*--decrypt*": "allow",
+      "*sops*-d*": "ask",
+      "*sops*--decrypt*": "ask",
+      "*sops*exec-env*": "ask",
+      "*age*-d*": "ask",
+      "*age*--decrypt*": "ask",
 
       // --- whole-system state ---
-      "*nixos-rebuild*": "allow",
-      "*home-manager*switch*": "allow",
-      "*nix-collect-garbage*": "allow",
-      "*nix*profile remove*": "allow",
+      "*nixos-rebuild*": "ask",
+      "*home-manager*switch*": "ask",
+      "*nix-collect-garbage*": "ask",
+      "*nix*profile remove*": "ask",
       // Only the MUTATING systemctl verbs. `systemctl status`/`list-timers` are
       // read-only and high-frequency — gating those is pure prompt fatigue,
       // which trains the operator to click through the ones that matter.
-      "*systemctl*start*": "allow",
-      "*systemctl*stop*": "allow",
-      "*systemctl*restart*": "allow",
-      "*systemctl*enable*": "allow",
-      "*systemctl*disable*": "allow",
-      "*systemctl*daemon-reload*": "allow",
+      "*systemctl*start*": "ask",
+      "*systemctl*stop*": "ask",
+      "*systemctl*restart*": "ask",
+      "*systemctl*enable*": "ask",
+      "*systemctl*disable*": "ask",
+      "*systemctl*daemon-reload*": "ask",
 
       // --- privilege escalation: gate the WRAPPER itself ---
-      "sudo*": "allow",
-      "*sudo *": "allow",
-      "*doas *": "allow",
+      "sudo*": "ask",
+      "*sudo *": "ask",
+      "*doas *": "ask",
 
       // --- filesystem blast radius ---
-      "*chmod -R*": "allow",
-      "*chown -R*": "allow",
-      "*rm*-r*": "allow",
+      "*chmod -R*": "ask",
+      "*chown -R*": "ask",
+      "*rm*-r*": "ask",
       // `dd` stays ANCHORED / operand-scoped on purpose: a leading-`*` `"*dd *"`
       // also matches `git add src/` (…"add "…), and gating every `git add` is
       // exactly the prompt fatigue that trains an operator to click through.
-      "dd *": "allow",
-      "*dd if=*": "allow",
-      "*dd of=*": "allow",
+      "dd *": "ask",
+      "*dd if=*": "ask",
+      "*dd of=*": "ask",
 
       // ================= DENY: naive-spelling backstop ONLY ================ //
       // 🔴 READ THE HEADER. These are NOT airtight and are NOT the control.

--- a/scripts/tests/test_opencode_config.py
+++ b/scripts/tests/test_opencode_config.py
@@ -520,6 +520,19 @@ MUST_ASK = [
     "talosctl upgrade --image x",
     "dd if=/dev/zero of=/dev/sda",
     "sudo something-unlisted",
+    # 🔴 FOUND BY MUTATION TESTING, not by review. Deleting `"*sudo *": "ask"`
+    # left the suite 465-GREEN, because the only sudo row above starts with
+    # `sudo` and is caught redundantly by the ANCHORED `"sudo*"`. The infix rule
+    # is load-bearing for exactly one shape — sudo in NON-LEADING position — and
+    # nothing exercised it. `doas` was worse: it has no anchored counterpart, so
+    # `"*doas *"` was its only gate and had no test case at all.
+    # MEASURED on the restored config: each row below matches `*sudo *`/`*doas *`
+    # and NOTHING else (bar the two catch-alls), so each one kills a distinct
+    # deletion mutant. The `VAR=…` prefix is the house style, which is precisely
+    # why this shape is the one that must not be allow.
+    "FOO=1 sudo something-unlisted",
+    "doas something-unlisted",
+    "FOO=1 doas something-unlisted",
 ]
 
 # Read-only, high-frequency. If these start prompting, the operator is trained
@@ -711,8 +724,29 @@ def test_all_asks_precede_all_denies():
 
     `*talosctl reset*: deny` only wins over `*talosctl*: ask` because it comes
     later. Interleaving them, or sorting the block, silently downgrades denies.
+
+    🔴 THE NON-VACUITY GUARD BELOW IS LOAD-BEARING — it is not defensive padding.
+    MEASURED: at 1fb8c2b a blind `ask`->`allow` sed emptied the ask block (50 ->
+    0 asks) and THIS TEST STILL PASSED, because `last_ask` falls back to -1 and
+    every `first_deny` beats -1. It sat green through the entire 117-failure
+    outage, asserting an ordering over an empty set. `test_every_dangerous_
+    pattern_is_prefix_tolerant` went vacuous the same way and for the same
+    reason: it filters on `v != "allow"`, so a wiped ask block leaves it
+    inspecting only the deny block. One wipe silently defanged two tests, so the
+    floor is asserted HERE, once, rather than restated at each vacuous site.
+
+    The floor is a LITERAL, not derived from the config: 50 ask rules were
+    measured after the restoration. 40 leaves room to prune ten deliberately
+    while still failing loudly on a mass flip.
     """
     items = list(load_config()["permission"]["bash"].items())[1:]
+    asks = [k for k, v in items if v == "ask"]
+    assert len(asks) >= 40, (
+        f"only {len(asks)} `ask` rules in the bash block (50 measured after the "
+        f"1fb8c2b restoration, floor 40). A collapse to near-zero is the "
+        f"signature of a blanket ask->allow rewrite, which ALSO makes this "
+        f"test's ordering assertion and the prefix-tolerance test vacuous."
+    )
     last_ask = max((i for i, (_, v) in enumerate(items) if v == "ask"), default=-1)
     first_deny = min((i for i, (_, v) in enumerate(items) if v == "deny"), default=len(items))
     assert first_deny > last_ask, (


### PR DESCRIPTION
## Verdict: the CONFIG regressed. The test is correct and was never touched.

`scripts/tests/test_opencode_config.py` has been **117-red on `main`** since `1fb8c2b`. Both rival mechanisms were tested; (a) wins outright.

### What ruled out "the test encodes a policy that was intentionally changed"

| evidence | result |
|---|---|
| Test + config authored in the **same** commit `e21985a` | that commit carried **52 `"ask"` values** — the test was authored *green* |
| Test file's last change is `fadd843` (2026-08-02) | an **ancestor** of the sed commit `1fb8c2b` (2026-08-05). `git diff fadd843 HEAD -- <testfile>` is **empty** |
| `"ask"` count by revision | `e21985a`=52, `1fb8c2b^`=52, `1fb8c2b`=**0** |
| **Decisive:** replay HEAD's test file against `1fb8c2b^`'s config | **`465 passed, 0 failed`** |

Swapping *only* the config file flips the suite from 117F/348P to 465P/0F. The config is the sole variable, so the test cannot be encoding a changed policy — nothing about it changed.

### The mechanism: a blind `sed`, not a policy decision

`1fb8c2b` applied a blanket `"ask"` → `"allow"` substitution. It was mechanical, not deliberate:

- It rewrote a prose comment into the tautology ``"allow"` costs exactly what `"allow"` costs`. **#341 (`c94d0a6`) already ruled that line collateral damage and restored it** — but fixed only the comment. This PR finishes the job on the **values**.
- It flipped `doom_loop`/`external_directory`, whose own adjacent comment still reads *"Ask before burning a long unproductive loop"*.
- Every section header still says `ASK: friction on mutation families` and `🔴 These are FRICTION, not enforcement` — claims the values contradicted.
- Its message claims only *"loosen git/kubectl … for faster iteration"*, but the sed also hit **sudo/doas, dd, nixos-rebuild, home-manager, talosctl, sops/age decryption, systemctl, chmod/chown -R**.
- **It changed zero test files while changing the policy a test pins.** A deliberate policy change would have had to update `MUST_ASK`.

Security impact while red: `nixos-rebuild switch`, `dd if=/dev/zero of=/dev/sda`, `talosctl shutdown`, `sops -d`, and every `sudo`/`doas` wrapper resolved to a **silent `allow`** on the primary opencode agent.

## The fix

52 values restored to their authored state, derived **mechanically**: a line is restored iff `1fb8c2b^` says `"ask"` at that index and HEAD says `"allow"` and the lines are otherwise byte-identical. The only other difference — the `deepseek-v4-pro` → `mimo-v2.5` model bump — is deliberate and was **left alone**.

> 🔴 **Not one glob pattern was changed.** The diff is 52 insertions / 52 deletions, every line a pure value flip, verified mechanically. Mid-pattern wildcards are a known injection sink in this repo, so the gate was emphatically **not** fixed by widening one.

**No conflict with the in-flight `git add` work:** this diff does not touch lines 286–288 (`"*git*add -A*"`, `"*git*add --all*"`, `"*git*add ."`). Removing the `"*git*add .": "deny"` line stays clean — all asks still precede all denies, and the ask floor is unaffected.

## Two further defects found while fixing the first

**1. A test that passed through the entire outage.** `test_all_asks_precede_all_denies` was **green all 117-red days**: with zero asks, `last_ask` falls back to `-1` and every `first_deny` beats `-1` — it asserted an ordering over an empty set. `test_every_dangerous_pattern_is_prefix_tolerant` went vacuous the same way (it filters `v != "allow"`, so a wiped ask block leaves it inspecting only denies). **One wipe silently defanged two tests.** A non-vacuity floor (`>= 40` asks; **50** measured, pinned as a literal) is now asserted once, in the ordering test.

**2. A surviving mutant.** Deleting `"*sudo *": "ask"` left the suite **465-GREEN**. The only sudo row in `MUST_ASK` starts with `sudo` and was caught redundantly by the *anchored* `"sudo*"`, so the infix rule — the one covering sudo in **non-leading** position, i.e. the `VAR=…` house style — was never exercised. `doas` was worse: `"*doas *"` is its only gate and had **no test case at all**. Three rows added; each kills a distinct deletion mutant.

## Counts

| | collected | passed | failed | skipped |
|---|---|---|---|---|
| `test_opencode_config.py` before | 465 | 348 | **117** | 0 |
| `test_opencode_config.py` after | 480 | **480** | **0** | 0 |
| CI gate `nix build .#checks…pytests` before | 6051 | 5904 | **144** | 3 |
| CI gate after | **6066** | 6036 | **27** | 3 |

`144 − 27 = 117` — exactly the failures fixed. `6051 → 6066` (+15) confirms the new rows **are collected by the CI gate**, which asserts collected-test floors.

### Red/green matrix (base `1daca5c`)

| assertion | base | HEAD |
|---|---|---|
| non-vacuity ask floor | 🔴 `only 0 ask rules in the bash block` | 🟢 |
| `FOO=1 sudo something-unlisted` | 🔴 `resolves 'allow', expected 'ask'` | 🟢 |
| `doas something-unlisted` | 🔴 | 🟢 |
| `FOO=1 doas something-unlisted` | 🔴 | 🟢 |

All four are genuine regression coverage — none is an invariant guard.

### Mutation results — 6/6 killed (negative control: 0 failures, 465 passed)

| mutant | caught by | note |
|---|---|---|
| flip one value (`*nixos-rebuild*` → allow) | `dangerous_command_family_is_gated` + 3 | |
| **reorder precedence** (deny above ask) | `all_asks_precede_all_denies` **only** | correct attribution — nothing else fires |
| **comment a rule out** (token stays present) | outcome tests | text-matching checks stay blind, as intended |
| **mass `ask`→`allow`** (the historical bug) | 118 failed | the **+1 over the historical 117** is `all_asks_precede_all_denies` — proof the vacuity is closed |
| delete `"*sudo *"` | — | **SURVIVED before this PR**; now killed |
| delete `"*doas *"` | — | now killed |

## Still red — pre-existing, unrelated

The CI gate does **not** go green with this PR. **27 failures remain, all in `scripts/tests/test_monitor_blackout.py`**, all `FileNotFoundError: '/usr/bin/env'` — the nix sandbox has no `/usr/bin/env` and `patchShebangs` does not reach the script that file drives. Identical at base (`144 = 117 + 27`), untouched by this PR, and out of scope.

Also pre-existing: 2 unpinned skips in `test_skill_audit.py` (*datapacket-talos clone not present*), which trip the runner's skip pin. Present at base (`skipped=3` both runs).

## 🔴 One decision for you

`1fb8c2b`'s message states an intent to *"loosen git/kubectl permission rules from ask to allow for faster iteration"*. This PR restores **all** 52 values, because the sed was demonstrably blind and its blast radius vastly exceeded that stated intent — restoring the authored state is the only defensible baseline, and it is what makes the gate honest again.

But if that loosening intent is **real**, note the cost it was buying: per this config's own header, **`opencode run` AUTO-REJECTS an `ask`**. So `"*git*commit*": "ask"` means an *unattended* opencode agent can no longer commit. If you want that back, it should be re-applied as a **deliberate, narrow change with `MUST_ASK` updated in the same commit** — not left as sed collateral. Say the word and I will do it as a follow-up; I did not want to bake a policy choice into a regression fix.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
