### PR TITLE
espanso-audit: verdict matrix, replay/lint/verify-deploy, and close two silent zeros

### DIFF
--- a/claude/commands/espanso-audit.md
+++ b/claude/commands/espanso-audit.md
@@ -1,56 +1,77 @@
 ---
 name: espanso-audit
-description: "Re-run the espanso snippet usage audit — mine Claude transcripts on BOTH hosts for which expansions fire vs. which short phrases get hand-typed, then recommend removals/shortenings/additions. Use to periodically tune the espanso workflow snippets in nix/home.nix."
+description: "Re-run the espanso snippet usage audit — cross real keylog fire counts against transcript demand for a per-snippet keep/retune/prune VERDICT, then tune the snippets in nix/home.nix."
 argument-hint: "[--since YYYY-MM-DD]   (default: since the last config change)"
 allowed-tools: Bash, Read, Edit, Write
 ---
 
-# /espanso-audit — tune the espanso workflow snippets from real usage
+# /espanso-audit — tune the espanso snippets from real usage
 
-Goal: kill the hand-rebuilt "which snippets do I actually use" archaeology. **Two signals** (espanso erases both trigger AND expansion on firing, so neither alone suffices):
-- **PRIMARY — keylog TRUE fires.** The X11 keylogger's `EspansoDetector` (`scripts/collector/keylog/espanso_detect.py`) detects espanso usage AT CAPTURE TIME from raw keystrokes and writes one `source=keys, kind=espanso` row per fire to ClickHouse. This is the real per-trigger fire count (direct + Ctrl+Space-search). **FORWARD-ONLY** — no data before the detector deployed. Honest caveat: "keystrokes ended with a trigger" ≈ "espanso fired" except in per-app-disabled contexts.
-- **SECONDARY — transcript miner (ADD-CANDIDATES).** Its unique durable value is the inverse view: recurring SHORT phrases you hand-type that are NOT yet snippets (candidates to ADD). Its per-trigger "hits" CONFLATE fire vs hand-typing → ambiguous cross-check only, not truth.
+Espanso erases BOTH the trigger and the expansion when it fires, so no single
+signal works. `scripts/session-analysis/espanso-usage.py` crosses two:
 
-Args: `$ARGUMENTS` (optional `--since YYYY-MM-DD`).
+- **FIRES** — the keylogger's `EspansoDetector` records every fire at CAPTURE
+  TIME into ClickHouse (`source=keys, kind=espanso`), host-tagged, so ONE query
+  covers both hosts. Forward-only: no data before the detector deployed.
+- **DEMAND** — transcript occurrences of each expansion. It cannot tell a fire
+  from hand-typing or a clipboard paste, and that is the point: *0 fires +
+  demand* means undiscoverable, not dead.
 
-## Critical topology (read first — it's bitten before)
+It prints a **VERDICT + action per snippet** — read that column instead of
+re-deriving keep/kill by hand. `DEAD` is the ONLY prune verdict; a zero-fire
+snippet is far more often `UNFINDABLE` (retune `label`/`search_terms`).
 
-espanso runs on **BOTH hosts** since 2026-07-06 / PR #83 (the workbench was un-gated from serverMode — it IS graphical; espanso/dunst now key off the `graphical` predicate, not `!serverMode`). The old "laptop-only" rule is retired. So:
-- **Combine** both hosts' `~/.claude/projects` counts — an expansion fires on whichever host you typed it on (you type on the workbench directly; and when you SSH laptop→workbench, laptop-espanso expands *before* the text travels and it lands in workbench transcripts). Summing both hosts is the true usage; never treat them as separate.
-- **Deploy target is BOTH hosts** (`scripts/ship.sh`) — no longer just the laptop.
-- Note the miner drifts from the live config and can silently misreport (2026-07-06: a stale `:aep` substring read 0; `:eos`/`:acq` were untracked). Always re-sync `SNIPPETS` before trusting counts (step 2).
+Args: `$ARGUMENTS` (optional `--since YYYY-MM-DD`; default = the last espanso
+config change — `git -C ~/workspace/devrc log -1 --format=%cd --date=short -- nix/home.nix`).
 
-## What to do
+## Run it
 
-1. **Pick the window.** Default `--since` to the date espanso config last changed (check `git -C /home/zach/workspace/devrc log -1 --format=%cd --date=short -- nix/home.nix`, or ask). Short windows are fine — the user drives this all day, so even ~1 week is real signal.
+Needs PyYAML plus the ClickHouse READER creds (SOPS → env only; see the script
+header):
 
-2. **Sync the miner first.** `scripts/session-analysis/espanso-usage.py`'s `SNIPPETS` dict drifts from the live config. Diff it against the `services.espanso` block in `nix/home.nix` and update detection substrings BEFORE running, or counts will be wrong. Pick a *distinctive* substring of each expansion; mark snippets whose expansion equals a phrase the user hand-types as `ambiguous=True` (their counts conflate snippet + manual typing).
+```bash
+nix-shell -p python3Packages.pyyaml --run \
+  "python3 ~/workspace/devrc/scripts/session-analysis/espanso-usage.py --since DATE"
+```
 
-3. **PRIMARY: keylog TRUE fires (do this first).** Export the ClickHouse reader creds (`CLICKHOUSE_URL/USER/PASSWORD` from SOPS — see the header of `espanso-usage.py` / `activity-scan.py`), then:
-   ```bash
-   python3 /home/zach/workspace/devrc/scripts/session-analysis/espanso-usage.py --since DATE --source keys
-   ```
-   This is the authoritative per-trigger fire count (direct + search). If it prints "(no keylog espanso events yet — detection is forward-only …)" the detector hasn't collected enough since deploy — fall back to the transcript signal and note the window is short. The keylog rows are host-tagged in CH (`host` column) so a single query already covers both hosts; no SSH needed for this signal.
+1. default → FIRES + ADD-CANDIDATES + the VERDICT matrix.
+2. `--terms` / `--replay` → what he actually typed into the search bar, and
+   whether each term resolves to one snippet, none, or several.
+3. `--lint` → offline, no creds. Flags a snippet that NO term resolves uniquely
+   to: `_attribute` returns None on ambiguity, so it can never fire from the
+   search UI.
+4. Propose changes, then run **`--replay --config <candidate base.yml>` as a
+   PRE-SHIP gate** — prove the new `search_terms` resolve BEFORE shipping.
+5. Edit `services.espanso` in `nix/home.nix` on a branch → PR → merge →
+   `scripts/ship.sh`.
+6. `--verify-deploy` → both hosts: deployed trigger set, `espanso` active, and
+   the detector-staleness check.
 
-4. **SECONDARY: transcript ADD-CANDIDATES.** Run the transcript miner on both hosts for the "phrases with no snippet" view (the per-trigger transcript hits are an AMBIGUOUS cross-check, not truth — prefer the keylog fires above):
-   ```bash
-   python3 /home/zach/workspace/devrc/scripts/session-analysis/espanso-usage.py --since DATE --source transcript --host workbench
-   ssh -o ConnectTimeout=5 zach@10.42.0.100 'python3 - --since DATE --source transcript --host laptop' < /home/zach/workspace/devrc/scripts/session-analysis/espanso-usage.py
-   ```
-   (`--source both` — the default — shows keylog first, then the transcript sections.)
+The tool never reports an unmeasured signal as a zero: an unreachable
+ClickHouse, or a config it cannot parse, is a loud banner and **exit 3**. Do not
+prune anything from a run that printed one.
 
-5. **Combine + interpret.** Use the keylog fire counts as the usage truth; use the transcript ADD-CANDIDATES for what to add. Then apply the recipe:
-   - **Paths** (`:cc :cdp :hlt …`) — almost always earn their keep; rarely touch.
-   - **The recurring lesson:** a workflow snippet that expands to a **long steering paragraph goes UNFIRED** — the user hand-types the short phrase instead. Cross-reference each zero/low-fire prompt snippet against the "recurring short user messages" section: if the short form of its intent is being hand-typed a lot, that's the signal. (Measured 2026-06-23 `:rns`, again 2026-06-30 → PR #37.)
-   - **Verdict per snippet:** keep-long (used + sticks, e.g. `:eos`/`:acq`), **shorten back** to the hand-typed form (zero fires + short-form demand — option (a); steering already lives in RULES.md / `/verify` / `/audit-pr`), repoint-to-skill (option (b)), remove (dead, no demand), or add (high-frequency phrase with no snippet).
-   - Honest caveat to always state: keyword-packing is a probabilistic nudge, and new triggers need habit-formation time — but **zero fires + active short-form hand-typing** is strong signal the trigger→habit transfer failed.
+## What the tool cannot tell you
 
-6. **Implement (if the user picks changes).** Edit the `services.espanso` block in `nix/home.nix` on a feature branch. The keylog detector auto-parses the LIVE config, so new/changed triggers are detected on the next `home-manager switch` with NO code change — but still re-sync the transcript miner's `SNIPPETS` (the ADD-CANDIDATE cross-check) to whatever you changed. Validate: `nix-instantiate --parse nix/home.nix` + check no trigger is a prefix of another (espanso longest-matches; the keylog detector mirrors that, emitting the shorter prefix). PR → merge → **`scripts/ship.sh`** converges both hosts.
-
-7. **Verify honestly.** After ship, confirm each host's deployed `~/.config/espanso/match/base.yml` carries the new replace strings (note: home-manager emits `replace` before `trigger`) and `systemctl --user is-active espanso` (both hosts now run it). The one thing you **cannot** verify over SSH is the actual keystroke expansion — hand that final check to the user (type a trigger, watch it expand).
+- **Keep/kill is SHAPE, not length.** A whole standalone message survives
+  (`:eos` is 700+ chars and the top firer at 72); a mid-sentence fragment dies
+  (`:ds`, `:rns`, `:pst`, `:rnx` — all pruned despite heavy hand-typing of their
+  phrase). Read ADD-CANDIDATES for standalone-shaped phrases.
+- **~97% of fires go through the Ctrl+Space SEARCH UI**, so `label` +
+  `search_terms` ARE the interface. A zero-fire snippet is usually a
+  discoverability bug, not a content one (`:acq`, 2026-08-05).
+- DEMAND reads the LOCAL transcripts only; re-run on the other host if you need
+  its demand. Retune-vs-prune is a judgement call, so the tool never edits
+  `nix/home.nix`. The keystroke expansion itself can only be checked by the user
+  typing a trigger.
 
 Notes:
-- Edit `claude/commands/*.md` and `nix/home.nix` in the repo, NOT `~/.claude/*` (read-only nix-store symlinks). New command/script files must be `git add`ed before a switch (flakes only see tracked files).
-- Background: [[espanso-usage-audit]] memory; the snippets live inline in `nix/home.nix` (`services.espanso.matches.base`).
+- Edit `claude/commands/*.md` + `nix/home.nix` in the repo, NOT `~/.claude/*`
+  (read-only nix-store symlinks). New files must be `git add`ed before a switch.
+- `keylog.service` pins the espanso config store paths in `X-Restart-Triggers`
+  (#347), so an espanso-only switch DOES restart the detector; `--verify-deploy`
+  re-checks it at runtime anyway.
+- Background: [[espanso-usage-audit]] memory; snippets live inline in
+  `nix/home.nix` (`services.espanso.matches.base`).
 
-Pair: `/find-session espanso` (recover prior audit sessions), `/devrc-dx` (broader dotfiles DX).
+Pair: `/find-session espanso` · `/devrc-dx`.

--- a/scripts/session-analysis/espanso-usage.py
+++ b/scripts/session-analysis/espanso-usage.py
@@ -1,106 +1,393 @@
 #!/usr/bin/env python3
-"""Espanso usage audit — TWO complementary signals.
+"""Espanso usage audit — fires, demand, and a prune/keep VERDICT per snippet.
 
 Espanso, on firing, BACKSPACES the trigger away and pastes the replacement via
 the CLIPBOARD, so BOTH the trigger and its expansion are ERASED from any stored
 text. That breaks naive counting two different ways, hence two signals:
 
-  1. PRIMARY — keylog (TRUE fires).  The X11 keylogger's `EspansoDetector`
+  1. FIRES (primary) — the X11 keylogger's `EspansoDetector`
      (scripts/collector/keylog/espanso_detect.py) detects espanso usage AT
      CAPTURE TIME from the raw keystroke stream, BEFORE espanso reacts, and
      emits one `source=keys, kind=espanso` row per fire into ClickHouse. This is
      the real per-trigger fire count, split direct vs Ctrl+Space-search. It is
-     FORWARD-ONLY: there is no historical data before the detector was deployed.
-     Honest caveat: direct fires are high-fidelity but can rarely over-count if a
-     trigger string is assembled via a mouse-repositioned caret (key events only)
-     or in a per-app espanso-disabled context; search rows are best-effort /
-     inferred. Still far better than phrase-counting.
+     FORWARD-ONLY: there is no data before the detector was deployed.
 
-  2. SECONDARY — transcript miner (ADD-CANDIDATES).  Because the expansion IS
-     what Claude sees, mining `~/.claude/projects/**/*.jsonl` cannot reliably
-     tell a snippet fire from hand-typing (the two produce identical text). Its
-     durable, UNIQUE value is the inverse view: recurring SHORT phrases you type
-     that are NOT yet snippets — i.e. candidates to ADD. The per-trigger
-     "hits" it reports are kept only as a rough, ambiguous cross-check.
+  2. DEMAND (secondary) — transcript occurrences of each expansion's text.
+     Because the expansion IS what Claude sees, this CANNOT distinguish a fire
+     from hand-typing or a clipboard paste — which is exactly why it is useful
+     next to the fire count: *0 fires + high demand* means the snippet exists,
+     is wanted, and is UNDISCOVERABLE, not dead. A clipboard paste produces no
+     keystrokes at all, so this is the only signal that can see one.
 
-Credentials for the keylog signal (read-only reader, from env — NEVER hardcoded;
+The VERDICT matrix crosses the two (plus unattributed-search-term evidence) into
+one action per snippet — see `classify()`.
+
+🔴 Two silent zeros this tool refuses to produce:
+  * an unreachable/rejecting ClickHouse is NOT "0 fires" (exit 3, loud banner);
+  * an unparseable espanso config (e.g. PyYAML missing from the interpreter) is
+    NOT "0 snippets" (exit 3, loud banner). Run under
+    `nix-shell -p python3Packages.pyyaml` if the banner says PyYAML is missing.
+
+Credentials for the fires signal (read-only reader, from env — NEVER hardcoded;
 same pattern as activity-scan.py / validation/chquery.py):
-  export CLICKHOUSE_URL=http://192.168.50.94:30123
-  export CLICKHOUSE_USER=activity_reader
-  export CLICKHOUSE_PASSWORD=<reader-password>   # from SOPS
+  export CLICKHOUSE_URL=... CLICKHOUSE_USER=... CLICKHOUSE_PASSWORD=<from SOPS>
 
-Usage: espanso-usage.py [--since YYYY-MM-DD] [--source keys|transcript|both]
-                        [--root PATH] [--host LABEL]
-  --source   which signal(s) to show (default: both; keylog shown first)
+Usage:
+  espanso-usage.py [--since YYYY-MM-DD] [--source keys|transcript|both]
+                   [--root PATH] [--host LABEL]
+  espanso-usage.py --terms [--since ...]        raw search-term breakdown
+  espanso-usage.py --replay [--config PATH]     do observed terms resolve?
+  espanso-usage.py --lint [--config PATH]       offline ambiguity check (no creds)
+  espanso-usage.py --verify-deploy [--remote T] post-ship check, both hosts
 """
-import json, os, re, glob, collections, sys
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
 from pathlib import Path
 
-# --- args ---
-SINCE = None
-ROOT = os.path.expanduser("~/.claude/projects")
-HOST = ""
-SOURCE = "both"
-_a = sys.argv[1:]
-while _a:
-    k = _a.pop(0)
-    if k == "--since":    SINCE = _a.pop(0)
-    elif k == "--root":   ROOT = os.path.expanduser(_a.pop(0))
-    elif k == "--host":   HOST = _a.pop(0)
-    elif k == "--source": SOURCE = _a.pop(0)
-    else:
-        sys.stderr.write(f"unknown arg: {k}\n"); sys.exit(2)
-if SOURCE not in ("keys", "transcript", "both"):
-    sys.stderr.write("--source must be keys|transcript|both\n"); sys.exit(2)
+_SCRIPTS = Path(__file__).resolve().parent.parent
+for _rel in ("validation", "collector/keylog", "collector/claude"):
+    _dir = str(_SCRIPTS / _rel)
+    if _dir not in sys.path:
+        sys.path.insert(0, _dir)
+
+import chquery as Q                                    # noqa: E402
+import espanso_triggers as ET                          # noqa: E402
+# `_WORD_RE` is the detector's OWN label tokenizer. Re-spelling it here (with a
+# regex that kept hyphens) invented "self-miss" findings for every hyphenated
+# label word, so import the one the matcher actually uses.
+from espanso_detect import EspansoDetector, _WORD_RE as LABEL_WORD_RE  # noqa: E402
+# ONE definition of the harness-boilerplate prefixes, shared with the claude
+# activity source. The local copy this file used to carry had drifted to the
+# WRONG CASING ("[request interrupted"), letting ~85% of interruption markers
+# through into the ADD-CANDIDATE counts. Import, never re-spell.
+from tailer import _BOILERPLATE_PREFIXES as _SHARED_BOILERPLATE  # noqa: E402
+# Same reason: ONE definition of "which files are real transcripts" (it skips
+# the synthetic `subagents/` + `wf_*` dirs, where a dispatched prompt is COPIED
+# and would otherwise be counted again as demand).
+from _shared import iter_transcripts                    # noqa: E402
+
+try:  # PyYAML is not in the ambient python3 on this host — measured, guarded.
+    import yaml as _yaml
+except Exception:  # pragma: no cover - exercised only where PyYAML is missing
+    _yaml = None
 
 
 # --------------------------------------------------------------------------- #
-# PRIMARY signal — keylog TRUE fires from ClickHouse (source=keys, kind=espanso)
+# Constants
 # --------------------------------------------------------------------------- #
-def keylog_section(since):
-    """Print the per-trigger TRUE-fire table from the keylog espanso rows.
+ESPANSO_BASE_REL = ".config/espanso/match/base.yml"
+KEYLOG_UNIT = "keylog.service"
+ESPANSO_UNIT = "espanso"
+# The laptop, over nebula (same target the ship.sh/`:sshln` snippet uses).
+DEFAULT_REMOTE = "zach@10.42.0.100"
 
-    Degrades gracefully: if ClickHouse is unreachable OR there are zero espanso
-    rows yet (detection is forward-only), print a clear note and return — the
-    transcript section still runs.
+# Boilerplate matched case-INSENSITIVELY: the shared tuple is spelled the way
+# the collector sees it, but transcripts carry both casings (measured 2026-08-05:
+# 389 "[Request interrupted" vs 47 lowercase). `[Image: original …` is a
+# transcript-render artefact the collector never sees, so it is ADDED here
+# rather than forked — the shared tuple stays the source of truth for the rest.
+BOILERPLATE_PREFIXES = tuple(p.lower() for p in _SHARED_BOILERPLATE) + (
+    "[image: original",
+)
+
+# DEMAND detection substrings: a distinctive fragment of each snippet's
+# expansion, used to count transcript occurrences. Hand-maintained — a snippet
+# whose expansion is text-detectable but MISSING here is reported UNPROBED, not
+# DEAD, so a forgotten entry can never read as "no demand".
+DEMAND_TEXTS = {
+    # paths
+    ":hlt":   ["homelab-talos"],
+    ":kuc":   ["workspace/kubeclaw"],
+    ":cc":    ["civit/civitai "],
+    ":cdp":   ["civit/datapacket-talos"],
+    ":cgf":   ["civitai-gpu-fleet"],
+    ":cmo":   ["civitai-orchestration"],
+    ":csc":   ["civitai-spine-controller"],
+    ":cpk":   ["datapacket-talos/prod-kubeconfig"],
+    ":subk":  ["submodel-dc-03-a-kubeconfig"],
+    # workflow prompts. :eos was rewritten 2026-08-04 (#325) — match BOTH the
+    # pre-rewrite text and the eviction-half rewrite, because transcripts from
+    # earlier in any window still carry the old wording.
+    ":eos":     ["may need updating", "write the handoff first"],
+    ":acq":     ["recommend anything you think would be useful to include"],
+    ":kickoff": ["kickoff message to copy paste to next session"],
+    ":rna":     ["recommend next actions"],
+    ":lr":      ["limit restored, resume agent"],
+    ":mt":      ["tee up what we can do in the meantime"],
+}
+# Substrings that DISQUALIFY a demand hit (one expansion containing another).
+DEMAND_EXCLUDE = {":cdp": ["prod-kubeconfig"]}
+
+# An unattributed search term counts as evidence FOR a snippet only if it is
+# long enough to be a real query and specific enough to mean something. A 1-2
+# char term ("c", "f") matches half the snippet set through `search_terms`
+# substrings and is noise, not evidence.
+UNATTR_EVIDENCE_MIN_LEN = 3
+UNATTR_EVIDENCE_MAX_MATCHES = 4
+
+UNATTRIBUTED = ""            # `text` column value for an unattributed search
+UNATTRIBUTED_LABEL = "(unattributed search)"
+
+# Verdicts
+HEALTHY = "HEALTHY"
+UNFINDABLE = "UNFINDABLE"
+UNATTRIBUTABLE = "UNATTRIBUTABLE"
+KEYLOG_ONLY = "KEYLOG-ONLY"
+UNPROBED = "UNPROBED"
+DEAD = "DEAD"
+RETIRED = "RETIRED"
+
+VERDICT_ACTION = {
+    HEALTHY:        "keep",
+    UNFINDABLE:     "RETUNE label/search_terms — do NOT prune (demand is proven)",
+    UNATTRIBUTABLE: "do NOT prune — real searches match it but resolve ambiguously",
+    KEYLOG_ONLY:    "expansion is not text-detectable; fires are the ONLY signal",
+    UNPROBED:       "no DEMAND_TEXTS entry — demand UNMEASURED, cannot judge",
+    DEAD:           "prune",
+    RETIRED:        "fired in-window but no longer in the config",
+}
+
+
+# --------------------------------------------------------------------------- #
+# Loud failure types — a signal we could not MEASURE is never a zero
+# --------------------------------------------------------------------------- #
+class Unmeasured(RuntimeError):
+    """A signal could not be measured. Distinct from a measured zero."""
+
+    def __init__(self, message, *, reason=""):
+        super().__init__(message)
+        self.reason = reason
+
+
+class FiresUnmeasured(Unmeasured):
+    """ClickHouse was unreachable / rejected the query / is unconfigured."""
+
+
+class ConfigUnavailable(Unmeasured):
+    """The espanso config could not be read or parsed into a trigger set."""
+
+
+# --------------------------------------------------------------------------- #
+# Config loading (never degrades to an empty trigger set)
+# --------------------------------------------------------------------------- #
+def default_config_path() -> str:
+    return os.path.join(os.path.expanduser("~"), ESPANSO_BASE_REL)
+
+
+def parse_config_text(text, *, origin="config") -> ET.TriggerSet:
+    """Parse a base.yml body into a TriggerSet, or raise ConfigUnavailable.
+
+    `espanso_triggers.load_triggers` deliberately degrades to an EMPTY
+    TriggerSet on any error, because the keylogger must never crash. For an
+    AUDIT that degradation is the silent zero itself — 0 triggers would classify
+    every snippet as missing — so this wrapper turns each failure mode into a
+    loud exception instead.
     """
-    print("## PRIMARY — keylog TRUE fires (source=keys, kind=espanso)\n")
+    if _yaml is None:
+        raise ConfigUnavailable(
+            f"cannot parse {origin}: PyYAML is not available in this interpreter. "
+            "Re-run under: nix-shell -p python3Packages.pyyaml --run '...'",
+            reason="pyyaml")
     try:
-        sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "validation"))
-        import chquery as Q  # noqa: E402
-        conn = Q.CHConn.from_env()
-        client = Q.CHClient(conn)
+        data = _yaml.safe_load(text)
     except Exception as e:
-        print(f"(keylog signal unavailable — {e.__class__.__name__}: {e})")
-        print("(set CLICKHOUSE_URL/USER/PASSWORD; detection is forward-only)\n")
-        return
+        raise ConfigUnavailable(f"cannot parse {origin}: {e.__class__.__name__}: {e}",
+                                reason="parse") from e
+    if not isinstance(data, dict):
+        raise ConfigUnavailable(f"cannot parse {origin}: not a YAML mapping",
+                                reason="parse")
+    ts = ET.load_triggers(data)
+    if not ts.triggers:
+        raise ConfigUnavailable(f"{origin} parsed but declares ZERO triggers",
+                                reason="empty")
+    return ts
+
+
+def load_config(path=None) -> ET.TriggerSet:
+    p = path or default_config_path()
+    try:
+        text = Path(p).read_text(encoding="utf-8")
+    except OSError as e:
+        raise ConfigUnavailable(f"cannot read {p}: {e.__class__.__name__}: {e}",
+                                reason="io") from e
+    return parse_config_text(text, origin=p)
+
+
+# --------------------------------------------------------------------------- #
+# Pure classification
+# --------------------------------------------------------------------------- #
+_TEMPLATE_RE = re.compile(r"\{\{.*?\}\}")
+_SHELL_RE = re.compile(r"^(ssh|scp|kubectl|curl|sudo)\s", re.I)
+
+
+def expansion_kind(replace) -> str:
+    """Classify an expansion by whether it can EVER appear in a transcript.
+
+    'template' — espanso var ({{date}}, {{clip}}, {{uuid}}): the output varies
+                 and is indistinguishable from ordinary text.
+    'shell'    — a command pasted into a terminal, never into a chat message.
+    'typo'     — a bare single-word correction (dashbaord -> dashboard): the
+                 output is an ordinary English word, so counting it is noise.
+    'text'     — a real phrase/path; transcript occurrences ARE demand evidence.
+    """
+    r = (replace or "").strip()
+    if not r:
+        return "empty"
+    if _TEMPLATE_RE.search(r):
+        return "template"
+    if _SHELL_RE.match(r):
+        return "shell"
+    if " " not in r and "/" not in r:
+        return "typo"
+    return "text"
+
+
+def is_text_detectable(replace) -> bool:
+    return expansion_kind(replace) == "text"
+
+
+def classify(*, fires, demand, term_evidence, text_detectable, in_config=True) -> str:
+    """One snippet's verdict. Pure — no ClickHouse, no filesystem.
+
+    ORDER IS LOAD-BEARING and each branch must stay reachable:
+      RETIRED        not in the live config at all (only historical fires).
+      HEALTHY        it fires. Nothing else can override that.
+      UNFINDABLE     0 fires but proven demand -> the search UI can't find it.
+      UNATTRIBUTABLE 0 fires, no/unmeasurable demand, but real search terms
+                     match it (they resolved ambiguously, so `_attribute`
+                     returned None by design). Checked BEFORE KEYLOG-ONLY so a
+                     non-text-detectable snippet with term evidence (the :ssh*
+                     case) is not filed under "no signal".
+      KEYLOG-ONLY    the expansion cannot appear in text at all.
+      UNPROBED       text-detectable but no DEMAND_TEXTS entry -> UNMEASURED.
+      DEAD           measured zero on every signal. The only prune verdict.
+    """
+    if not in_config:
+        return RETIRED
+    if fires > 0:
+        return HEALTHY
+    if demand is not None and demand > 0:
+        return UNFINDABLE
+    if term_evidence > 0:
+        return UNATTRIBUTABLE
+    if not text_detectable:
+        return KEYLOG_ONLY
+    if demand is None:
+        return UNPROBED
+    return DEAD
+
+
+def term_evidence(unattributed_terms, ts):
+    """Unattributed search terms -> {trigger: weight} + per-trigger detail.
+
+    `unattributed_terms` is [(term, count), ...]. Matching reuses the REAL
+    `EspansoDetector._term_matches` (an instance method that only reads
+    `self.ts`) rather than a reimplementation, so a rules change in the detector
+    can never silently diverge from this report.
+    """
+    det = EspansoDetector(ts)
+    weight = collections.Counter()
+    detail = collections.defaultdict(list)
+    for term, count in unattributed_terms:
+        t = (term or "").strip().lower()
+        if len(t) < UNATTR_EVIDENCE_MIN_LEN:
+            continue
+        matches = [trig for trig in ts.triggers if det._term_matches(t, trig)]
+        if not matches or len(matches) > UNATTR_EVIDENCE_MAX_MATCHES:
+            continue
+        for trig in matches:
+            weight[trig] += int(count or 0)
+            detail[trig].append((t, int(count or 0), len(matches)))
+    return weight, detail
+
+
+def build_verdicts(ts, fires_per, demand, evidence):
+    """One row per snippet (config order), plus RETIRED rows for triggers that
+    only exist in the fire data. `demand` maps trigger -> int or None."""
+    rows = []
+    for trig in ts.triggers:
+        meta = ts.meta.get(trig) or {}
+        f = fires_per.get(trig) or {}
+        total = int(f.get("direct", 0)) + int(f.get("search", 0))
+        detectable = is_text_detectable(meta.get("replace"))
+        d = demand.get(trig) if demand is not None else None
+        ev = int(evidence.get(trig, 0))
+        rows.append({
+            "trigger": trig,
+            "fires": total,
+            "direct": int(f.get("direct", 0)),
+            "search": int(f.get("search", 0)),
+            "demand": d,
+            "term_evidence": ev,
+            "kind": expansion_kind(meta.get("replace")),
+            "verdict": classify(fires=total, demand=d, term_evidence=ev,
+                                text_detectable=detectable),
+        })
+    for trig, f in sorted(fires_per.items()):
+        if trig == UNATTRIBUTED or trig in ts.meta:
+            continue
+        total = int(f.get("direct", 0)) + int(f.get("search", 0))
+        rows.append({
+            "trigger": trig, "fires": total,
+            "direct": int(f.get("direct", 0)), "search": int(f.get("search", 0)),
+            "demand": None, "term_evidence": 0, "kind": "retired",
+            "verdict": classify(fires=total, demand=None, term_evidence=0,
+                                text_detectable=False, in_config=False),
+        })
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# FIRES — keylog rows from ClickHouse
+# --------------------------------------------------------------------------- #
+def _host_filter(host):
+    return f" AND host = {Q.sql_quote(host)}" if host else ""
+
+
+def q_fires(since=None, host=None, table="activity.events") -> str:
     where = "source = 'keys' AND kind = 'espanso'"
     if since:
         where += f" AND ts >= {Q.sql_quote(since)}"
-    sql = (
+    where += _host_filter(host)
+    return (
         "SELECT text AS trigger, "
         "JSONExtractString(payload, 'method') AS method, "
         "JSONExtractBool(payload, 'inferred') AS inferred, "
         "count() AS fires "
-        f"FROM {conn.fq_table} WHERE {where} "
+        f"FROM {table} WHERE {where} "
         "GROUP BY trigger, method, inferred ORDER BY fires DESC, trigger"
     )
-    try:
-        rows = client.rows(sql)
-    except Exception as e:
-        print(f"(ClickHouse query failed — {e.__class__.__name__}: {e})")
-        print("(no keylog espanso events yet — detection is forward-only; "
-              "collecting since deploy)\n")
-        return
-    if not rows:
-        print("(no keylog espanso events yet — detection is forward-only; "
-              "collecting since deploy)\n")
-        return
-    # Aggregate per trigger with a direct/search split.
+
+
+def q_terms(since=None, host=None, table="activity.events") -> str:
+    where = ("source = 'keys' AND kind = 'espanso' AND "
+             "JSONExtractString(payload, 'method') = 'search'")
+    if since:
+        where += f" AND ts >= {Q.sql_quote(since)}"
+    where += _host_filter(host)
+    return (
+        "SELECT text AS trigger, "
+        "JSONExtractString(payload, 'search_term') AS term, "
+        "count() AS n "
+        f"FROM {table} WHERE {where} "
+        "GROUP BY trigger, term ORDER BY n DESC, term"
+    )
+
+
+def aggregate_fires(rows):
+    """Fire rows -> ({trigger: {direct, search, inferred}}, total)."""
     per = collections.defaultdict(lambda: {"direct": 0, "search": 0, "inferred": False})
     total = 0
     for r in rows:
-        trig = r.get("trigger") or "(unattributed search)"
+        trig = r.get("trigger") or UNATTRIBUTED
         method = r.get("method") or "direct"
         fires = int(r.get("fires") or 0)
         total += fires
@@ -108,80 +395,137 @@ def keylog_section(since):
         bucket["direct" if method == "direct" else "search"] += fires
         if r.get("inferred"):
             bucket["inferred"] = True
-    print(f"# total fires: {total}\n")
-    print(f"{'trigger':22} {'direct':>7} {'search':>7} {'total':>7}  note")
-    order = sorted(per, key=lambda t: (-(per[t]['direct'] + per[t]['search']), t))
+    return dict(per), total
+
+
+def split_terms(rows):
+    """Term rows -> (attributed [(term, trigger, n)], unattributed [(term, n)])."""
+    attributed, unattributed = [], []
+    for r in rows:
+        term = r.get("term") or ""
+        n = int(r.get("n") or 0)
+        trig = r.get("trigger") or ""
+        if trig:
+            attributed.append((term, trig, n))
+        else:
+            unattributed.append((term, n))
+    return attributed, unattributed
+
+
+def open_client():
+    """Build a CHClient from the env, or raise FiresUnmeasured."""
+    try:
+        conn = Q.CHConn.from_env()
+    except RuntimeError as e:
+        raise FiresUnmeasured(f"ClickHouse NOT CONFIGURED — {e}",
+                              reason="unconfigured") from e
+    return Q.CHClient(conn), conn
+
+
+def gather_fires(client, since=None, host=None, table="activity.events"):
+    """Run both keylog queries. Raises FiresUnmeasured — NEVER returns a zero
+    for a server that was unreachable or that rejected the query.
+
+    🔴 The predecessor wrapped this in `except Exception` and printed "(no keylog
+    espanso events yet)", so a down ClickHouse read as 0 fires for EVERY snippet
+    and the next audit pruned live ones. chquery's taxonomy exists precisely to
+    tell "could not reach" from "rejected my query"; both are UNMEASURED here,
+    and they are reported with different text.
+    """
+    try:
+        fire_rows = client.rows(q_fires(since, host, table))
+        term_rows = client.rows(q_terms(since, host, table))
+    except Q.CHUnreachable as e:
+        raise FiresUnmeasured(f"ClickHouse UNREACHABLE — {e}",
+                              reason="unreachable") from e
+    except Q.CHQueryError as e:
+        raise FiresUnmeasured(f"ClickHouse REJECTED the query — {e}",
+                              reason="query") from e
+    per, total = aggregate_fires(fire_rows)
+    attributed, unattributed = split_terms(term_rows)
+    return {"per": per, "total": total, "fire_rows": fire_rows,
+            "attributed": attributed, "unattributed": unattributed}
+
+
+def unmeasured_banner(exc, what="FIRES"):
+    return [
+        "",
+        "!" * 72,
+        f"!! {what} UNMEASURED — {exc}",
+        "!! This is NOT a measurement of zero. Do NOT prune anything from this run.",
+        "!" * 72,
+        "",
+    ]
+
+
+def render_fires(data):
+    out = ["## FIRES — keylog TRUE fires (source=keys, kind=espanso)", ""]
+    per, total = data["per"], data["total"]
+    if not per:
+        out.append("(0 espanso rows in this window — detection is forward-only, so a "
+                   "window that predates the detector's deploy is EXPECTED to be empty)")
+        out.append("")
+        return out
+    out.append(f"# total fires: {total}")
+    out.append("")
+    out.append(f"{'trigger':22} {'direct':>7} {'search':>7} {'total':>7}  note")
+    order = sorted(per, key=lambda t: (-(per[t]["direct"] + per[t]["search"]), t))
     for t in order:
         b = per[t]
         tot = b["direct"] + b["search"]
         note = "search=inferred attribution" if b["search"] else ""
-        print(f"{t:22} {b['direct']:>7} {b['search']:>7} {tot:>7}  {note}")
-    print()
+        name = UNATTRIBUTED_LABEL if t == UNATTRIBUTED else t
+        out.append(f"{name:22} {b['direct']:>7} {b['search']:>7} {tot:>7}  {note}")
+    out.append("")
+    return out
 
 
 # --------------------------------------------------------------------------- #
-# SECONDARY signal — transcript miner (ADD-CANDIDATES + ambiguous cross-check)
+# DEMAND — transcript occurrences (the LOCAL filesystem only)
 # --------------------------------------------------------------------------- #
-# trigger -> (kind, [include substrs] | None, [exclude substrs], ambiguous?)
-# include=None => not text-detectable (date/clipboard/typo-correction).
-SNIPPETS = {
-    ":date":     ("date", None, [], False),
-    ":time":     ("date", None, [], False),
-    # paths
-    ":hlt":   ("path", ["homelab-talos"], [], False),
-    ":kuc":   ("path", ["workspace/kubeclaw"], [], False),
-    ":cc":    ("path", ["civit/civitai "], [], False),
-    ":cdp":   ("path", ["civit/datapacket-talos"], ["prod-kubeconfig"], False),
-    ":cgf":   ("path", ["civitai-gpu-fleet"], [], False),
-    ":cmo":   ("path", ["civitai-orchestration"], [], False),
-    ":csc":   ("path", ["civitai-spine-controller"], [], False),
-    ":cpk":   ("path", ["datapacket-talos/prod-kubeconfig"], [], False),
-    ":subk":  ("path", ["submodel-dc-03-a-kubeconfig"], [], False),
-    # ssh connect — pasted into a terminal, never appears in a transcript
-    # (not text-detectable; keylog is the only fire signal, same as :aep)
-    ":sshwn": ("ssh", None, [], False),
-    ":sshwl": ("ssh", None, [], False),
-    ":sshln": ("ssh", None, [], False),
-    ":sshll": ("ssh", None, [], False),
-    # workflow prompts (current expansions)
-    # (removed 2026-07-25 via /espanso-audit — all keylog-evidence-backed:
-    #  zero-fire: :rnx :pst :aep :nday :fhrs :fdays;
-    #  typing-toil (shortcut existed but long form hand-typed instead):
-    #  :ds [1 fire vs 94 typed], :rns [1 vs 20] —
-    #  see claudedocs/espanso-typing-toil-2026-07-25.md)
-    # (removed 2026-08-05 via /espanso-audit — 0 keylog fires over 20 days:
-    #  :nixos :iso :datetime "reocmmend")
-    # :eos expansion rewritten 2026-08-04 (#325) — match BOTH the pre-rewrite text
-    # ("…identify skills … that may need updating") and the eviction-half rewrite.
-    ":eos":     ("prompt", ["may need updating", "write the handoff first"], [], False),
-    ":acq":     ("prompt", ["recommend anything you think would be useful to include"], [], False),
-    ":kickoff": ("prompt", ["kickoff message to copy paste to next session"], [], False),
-    # added 2026-08-05 via /espanso-audit — whole-standalone-message shaped, the
-    # only shape that sticks; typing-stream demand 81 / 68 rows respectively.
-    # NOTE :rna is deliberately "actions", NOT the pruned :rns's "steps" (3 rows).
-    ":rna":     ("prompt", ["recommend next actions"], [], False),
-    ":lr":      ("prompt", ["limit restored, resume agent"], [], False),
-    # added 2026-08-05 via /espanso-audit — whole-standalone-message shaped;
-    # 8 genuine instances over ~3 weeks (5 standalone), heavy typing toil.
-    # Include substring is the OPENER, which is distinctive enough on its own —
-    # the rest of the expansion is long and gets paraphrased when hand-typed.
-    ":mt":      ("prompt", ["tee up what we can do in the meantime"], [], False),
-    # utilities / typo-correction — output not distinguishable
-    ":uuid":     ("util", None, [], False),
-    ":clip":     ("util", None, [], False),
-    "dashbaord": ("typo", None, [], False),
-}
+def local_host_label(env=None, env_file=None) -> str:
+    """This machine's ACTIVITY_HOST label, or "" when it cannot be resolved.
 
-WORD = re.compile(r"[a-z][a-z'\-]+")
-KNOWN_EXPANSIONS = [m for _, subs, _, _ in SNIPPETS.values() if subs for m in subs]
+    `hostname` is "nixos" on BOTH hosts, so it is useless here; the collector's
+    env file is the source of truth the telemetry itself is stamped with.
+    """
+    e = os.environ if env is None else env
+    v = (e.get("ACTIVITY_HOST") or "").strip().lower()
+    if v in ("workbench", "laptop"):
+        return v
+    path = env_file or os.path.expanduser("~/.config/activity-collector/env")
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("ACTIVITY_HOST="):
+            val = line[len("ACTIVITY_HOST="):].strip()
+            if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+                val = val[1:-1]
+            val = val.strip().lower()
+            return val if val in ("workbench", "laptop") else ""
+    return ""
 
 
 def norm(s):
     return " ".join(s.lower().split())
 
 
+def is_boilerplate(s) -> bool:
+    """True when a message is harness boilerplate, not something the user typed."""
+    low = (s or "").lower()
+    return any(low.startswith(p) for p in BOILERPLATE_PREFIXES)
+
+
 def human_text(o):
+    """The user-typed text of one transcript line, or None if it is not one."""
     if o.get("type") != "user":
+        return None
+    # Harness-synthesised turns, and the sidechain copies of a dispatched
+    # prompt: not something the user typed, and counting them inflated DEMAND.
+    if o.get("isMeta") or o.get("isSidechain"):
         return None
     m = o.get("message", {})
     c = m.get("content")
@@ -201,26 +545,34 @@ def human_text(o):
     s = txt.strip()
     if not s:
         return None
-    low = s.lower()
     if s.startswith("<command-") or "<local-command-stdout>" in s \
-       or s.startswith("[request interrupted") or low.startswith("caveat:") \
-       or s.startswith("<system-reminder") or "tool_use_id" in s:
+       or s.startswith("<system-reminder") or "tool_use_id" in s \
+       or is_boilerplate(s):
         return None
     return s
 
 
-def transcript_section(since, root, host):
-    counts = {t: 0 for t in SNIPPETS}
-    sessions_hit = {t: set() for t in SNIPPETS}
-    last_seen = {t: None for t in SNIPPETS}
+def scan_transcripts(root, since=None, demand_texts=None, exclude=None):
+    """Count per-snippet demand + recurring short messages over local transcripts."""
+    demand_texts = DEMAND_TEXTS if demand_texts is None else demand_texts
+    exclude = DEMAND_EXCLUDE if exclude is None else exclude
+    known = [sub for subs in demand_texts.values() for sub in subs]
+
+    counts = {t: 0 for t in demand_texts}
+    sessions_hit = {t: set() for t in demand_texts}
+    last_seen = {t: None for t in demand_texts}
     short_msgs = collections.Counter()
-    phrase_counter = collections.Counter()
     total_user_msgs = 0
     files_scanned = 0
+    # Resuming/forking a session can write a NEW transcript file that REPLAYS
+    # earlier messages, so dedupe on the message uuid exactly as tailer.py does.
+    # Measured a no-op over the 2026-07-25..08-05 window (identical counts with
+    # and without) — kept as a guard, not as a correction.
+    seen = set()
 
-    for fp in glob.glob(os.path.join(root, "**", "*.jsonl"), recursive=True):
+    for fp, stem in iter_transcripts([root]):
         files_scanned += 1
-        sid = os.path.basename(fp)[:8]
+        sid = stem[:8]
         try:
             with open(fp, errors="ignore") as fh:
                 for line in fh:
@@ -236,79 +588,540 @@ def transcript_section(since, root, host):
                     s = human_text(o)
                     if s is None:
                         continue
+                    uid = o.get("uuid")
+                    if isinstance(uid, str) and uid:
+                        if uid in seen:
+                            continue
+                        seen.add(uid)
                     total_user_msgs += 1
                     low = s.lower()
-                    for t, (kind, subs, excl, _amb) in SNIPPETS.items():
-                        if not subs:
-                            continue
-                        if any(sub in low for sub in subs) and not any(e in low for e in excl):
+                    for t, subs in demand_texts.items():
+                        excl = exclude.get(t) or []
+                        if any(sub in low for sub in subs) and \
+                           not any(e in low for e in excl):
                             counts[t] += 1
                             sessions_hit[t].add(sid)
                             if ts and (last_seen[t] is None or ts > last_seen[t]):
                                 last_seen[t] = ts
                     if len(s) <= 140 and not s.startswith("/"):
                         n = norm(s)
-                        if not any(e in n for e in KNOWN_EXPANSIONS):
-                            if len(n) >= 3:
-                                short_msgs[n] += 1
-                            words = WORD.findall(n)
-                            for k in (4, 5):
-                                for i in range(len(words) - k + 1):
-                                    phrase_counter[" ".join(words[i:i+k])] += 1
+                        if len(n) >= 3 and not any(e in n for e in known):
+                            short_msgs[n] += 1
         except Exception:
             continue
 
-    print(f"# transcript files scanned: {files_scanned}   "
-          f"human user messages: {total_user_msgs}\n")
+    return {"files": files_scanned, "messages": total_user_msgs,
+            "demand": counts, "sessions": {t: len(v) for t, v in sessions_hit.items()},
+            "last_seen": last_seen, "short": short_msgs}
 
-    print("## SECONDARY — transcript ADD-CANDIDATES (short phrases, no snippet)\n")
-    STOP_EXACT = {"yes", "ok", "okay", "y", "continue", "go", "proceed", "do it",
-                  "yes do it", "no", "thanks", "thank you", "good", "nice", "next",
-                  "stop", "wait", "k", "yep", "yes please", "sure", "perfect"}
-    print("### Recurring short user messages NOT already snippets (>=3 hits)\n")
-    for msg, n in short_msgs.most_common(120):
+
+STOP_EXACT = {"yes", "ok", "okay", "y", "continue", "go", "proceed", "do it",
+              "yes do it", "no", "thanks", "thank you", "good", "nice", "next",
+              "stop", "wait", "k", "yep", "yes please", "sure", "perfect"}
+
+
+def render_demand(scan, host_label):
+    out = [f"# transcript files scanned: {scan['files']}   "
+           f"human user messages: {scan['messages']}   "
+           f"(LOCAL filesystem — host: {host_label or 'UNRESOLVED'})", ""]
+    out.append("## ADD-CANDIDATES — recurring short messages that are NOT snippets")
+    out.append("   keep/kill predictor is SHAPE, not length: a whole standalone")
+    out.append("   message sticks, a mid-sentence fragment does not.")
+    out.append("")
+    for msg, n in scan["short"].most_common(120):
         if n < 3:
             break
         if msg in STOP_EXACT or len(msg) < 8:
             continue
-        print(f"{n:4}  {msg[:110]}")
-
-    print("\n### Recurring 4-5 word phrases (candidate building blocks, >=6 hits)\n")
-    shown = 0
-    for ph, n in phrase_counter.most_common(400):
-        if n < 6:
-            break
-        if any(e.startswith(ph[:15]) for e in KNOWN_EXPANSIONS):
-            continue
-        print(f"{n:4}  {ph}")
-        shown += 1
-        if shown >= 40:
-            break
-
-    print("\n### Ambiguous transcript cross-check (CONFLATES fire + hand-typing)\n")
-    print(f"{'trigger':12} {'kind':7} {'hits':>6} {'sessions':>9}  {'last-seen':10} note")
-    order = sorted(SNIPPETS, key=lambda t: (-counts[t], t))
-    for t in order:
-        kind, subs, excl, amb = SNIPPETS[t]
-        if subs is None:
-            print(f"{t:12} {kind:7} {'   n/a':>6} {'      n/a':>9}  {'-':10} not text-detectable")
-        else:
-            note = "AMBIGUOUS (conflates hand-typing)" if amb else ""
-            print(f"{t:12} {kind:7} {counts[t]:>6} {len(sessions_hit[t]):>9}  {(last_seen[t] or '-'):10} {note}")
+        out.append(f"{n:4}  {msg[:110]}")
+    out.append("")
+    return out
 
 
 # --------------------------------------------------------------------------- #
-def main():
-    hdr = "# espanso usage"
-    if HOST:  hdr += f" — host={HOST}"
-    if SINCE: hdr += f" — since {SINCE}"
-    print(hdr + "\n")
+# VERDICT rendering
+# --------------------------------------------------------------------------- #
+def render_verdicts(rows):
+    out = ["## VERDICT — prune/keep matrix", ""]
+    out.append(f"{'trigger':12} {'fires':>6} {'demand':>7} {'term-ev':>8} "
+               f"{'kind':9} {'verdict':15} action")
+    order = {HEALTHY: 0, UNFINDABLE: 1, UNATTRIBUTABLE: 2, KEYLOG_ONLY: 3,
+             UNPROBED: 4, DEAD: 5, RETIRED: 6}
+    for r in sorted(rows, key=lambda r: (order.get(r["verdict"], 9),
+                                         -r["fires"], r["trigger"])):
+        d = "n/a" if r["demand"] is None else str(r["demand"])
+        out.append(f"{r['trigger']:12} {r['fires']:>6} {d:>7} {r['term_evidence']:>8} "
+                   f"{r['kind']:9} {r['verdict']:15} {VERDICT_ACTION[r['verdict']]}")
+    out.append("")
+    tally = collections.Counter(r["verdict"] for r in rows)
+    out.append("  " + "  ".join(f"{k}={tally[k]}" for k in sorted(tally)))
+    out.append("")
+    return out
 
-    if SOURCE in ("keys", "both"):
-        keylog_section(SINCE)
-    if SOURCE in ("transcript", "both"):
-        transcript_section(SINCE, ROOT, HOST)
+
+# --------------------------------------------------------------------------- #
+# TERMS / REPLAY / LINT
+# --------------------------------------------------------------------------- #
+def _q(term, width=28):
+    """Quote a search term so leading/trailing spaces are VISIBLE — 'ssh ' and
+    'ssh' are different rows and must not render identically."""
+    return f"{term!r}"[:width].ljust(width)
+
+
+def render_terms(fires, ts):
+    out = ["## TERMS — raw Ctrl+Space search-term breakdown", ""]
+    out.append("### attributed")
+    out.append(f"{'n':>5}  {'term':28} -> trigger")
+    for term, trig, n in sorted(fires["attributed"], key=lambda r: (-r[2], r[0])):
+        out.append(f"{n:>5}  {_q(term)} -> {trig}")
+    unattr_total = sum(n for _, n in fires["unattributed"])
+    out.append("")
+    out.append(f"### unattributed ({unattr_total} fires over "
+               f"{len(fires['unattributed'])} distinct terms)")
+    out.append("   `_attribute` returns None whenever a term matches 0 or >=2 "
+               "snippets — by design.")
+    out.append(f"{'n':>5}  {'term':28} competing snippets (current config)")
+    det = EspansoDetector(ts) if ts is not None else None
+    for term, n in sorted(fires["unattributed"], key=lambda r: (-r[1], r[0])):
+        if det is None:
+            out.append(f"{n:>5}  {_q(term)} (config unavailable)")
+            continue
+        t = (term or "").strip().lower()
+        matches = [x for x in ts.triggers if det._term_matches(t, x)] if t else []
+        out.append(f"{n:>5}  {_q(term)} "
+                   f"{len(matches)}: {' '.join(matches) if matches else '-'}")
+    out.append("")
+    return out
+
+
+def replay_terms(term_counts, ts):
+    """[(term, count)] -> replay rows through the REAL detector matching rules."""
+    det = EspansoDetector(ts)
+    rows = []
+    for term, count in term_counts:
+        t = (term or "").strip().lower()
+        matches = [x for x in ts.triggers if det._term_matches(t, x)] if t else []
+        rows.append({
+            "term": term, "count": int(count or 0), "n_matches": len(matches),
+            "matches": matches, "resolves_to": det._attribute(term),
+        })
+    return rows
+
+
+def render_replay(rows, config_path):
+    out = [f"## REPLAY — observed search terms vs {config_path}", "",
+           "   Uses the REAL EspansoDetector matching rules (imported, not "
+           "re-spelled).",
+           "   A term that resolves to None fired NOTHING: 0 matches = "
+           "undiscoverable,", "   >=2 = ambiguous.", ""]
+    out.append(f"{'n':>5}  {'term':28} {'#':>3}  resolves-to   matches")
+    for r in sorted(rows, key=lambda r: (-r["count"], r["term"])):
+        res = r["resolves_to"] or "-NONE-"
+        out.append(f"{r['count']:>5}  {_q(r['term'])} {r['n_matches']:>3}  "
+                   f"{res:12}  {' '.join(r['matches'])}")
+    unresolved = sum(r["count"] for r in rows if not r["resolves_to"])
+    total = sum(r["count"] for r in rows)
+    out.append("")
+    out.append(f"  resolves: {total - unresolved}/{total} fires; "
+               f"{unresolved} would still land nowhere.")
+    out.append("")
+    return out
+
+
+def declared_terms(ts, trig):
+    """Every term a snippet can be FOUND by: its search_terms verbatim, plus the
+    words of its label as the DETECTOR tokenizes them."""
+    meta = ts.meta.get(trig) or {}
+    terms = set()
+    for st in meta.get("search_terms") or []:
+        t = (st or "").strip().lower()
+        if t:
+            terms.add(t)
+    for w in LABEL_WORD_RE.findall((meta.get("label") or "").lower()):
+        if len(w) >= UNATTR_EVIDENCE_MIN_LEN:
+            terms.add(w)
+    return terms
+
+
+def lint(ts):
+    """Offline findings, worst first.
+
+    `unreachable` is the one that matters: `_attribute` returns None whenever a
+    term matches >=2 snippets, so a snippet with NO uniquely-resolving term
+    cannot be reached through the search UI AT ALL — which is how the four
+    :ssh* snippets read as dead while being searched for weekly. The old
+    "no trigger is a prefix of another" check is kept, but it has never fired.
+    """
+    findings = []
+    det = EspansoDetector(ts)
+    for a in ts.triggers:
+        for b in ts.triggers:
+            if a != b and b.startswith(a):
+                findings.append({"kind": "prefix", "trigger": a,
+                                 "message": f"{a!r} is a prefix of {b!r} — espanso "
+                                            f"fires the SHORTER one first"})
+
+    matches_of = {}
+
+    def _matches(term):
+        if term not in matches_of:
+            matches_of[term] = [x for x in ts.triggers if det._term_matches(term, x)]
+        return matches_of[term]
+
+    owners = collections.defaultdict(set)
+    for trig in ts.triggers:
+        terms = declared_terms(ts, trig)
+        if not terms:
+            findings.append({"kind": "undiscoverable", "trigger": trig,
+                             "message": "no search_terms AND no label — reachable "
+                                        "only by typing the trigger verbatim"})
+            continue
+        unique = []
+        for t in sorted(terms):
+            owners[t].add(trig)
+            m = _matches(t)
+            if trig not in m:
+                findings.append({"kind": "self-miss", "trigger": trig,
+                                 "message": f"own term {t!r} does NOT match itself"})
+            elif len(m) == 1:
+                unique.append(t)
+        if terms and not unique:
+            findings.append({"kind": "unreachable", "trigger": trig,
+                             "message": "NO declared term resolves uniquely to it — "
+                                        "every search that reaches it is ambiguous, "
+                                        "so it can never fire from the search UI"})
+    for term in sorted(owners):
+        m = _matches(term)
+        if len(m) > 1:
+            findings.append({"kind": "ambiguous", "trigger": ",".join(sorted(owners[term])),
+                             "message": f"term {term!r} matches {len(m)} snippets: "
+                                        f"{' '.join(m)}"})
+    return findings
+
+
+_LINT_ORDER = {"unreachable": 0, "self-miss": 1, "undiscoverable": 2,
+               "prefix": 3, "ambiguous": 4}
+
+
+def render_lint(findings, config_path):
+    out = [f"## LINT — offline discoverability check ({config_path})", "",
+           "   `_attribute` returns None when a term matches >=2 snippets, so an",
+           "   AMBIGUOUS term is a search that silently fires nothing — and a",
+           "   snippet with no unique term is UNREACHABLE from the search UI.", ""]
+    if not findings:
+        out.append("  (no findings)")
+        out.append("")
+        return out
+    for f in sorted(findings, key=lambda f: (_LINT_ORDER.get(f["kind"], 9),
+                                             f["trigger"])):
+        out.append(f"  [{f['kind']:14}] {f['trigger']:22} {f['message']}")
+    out.append("")
+    tally = collections.Counter(f["kind"] for f in findings)
+    out.append("  " + "  ".join(f"{k}={tally[k]}" for k in sorted(tally)))
+    out.append("")
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# --verify-deploy
+# --------------------------------------------------------------------------- #
+def make_local_runner(timeout=20):
+    def run(argv):
+        try:
+            p = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+        except FileNotFoundError:
+            return 127, ""
+        except subprocess.TimeoutExpired:
+            return 124, ""
+        return p.returncode, (p.stdout or "").strip()
+    return run
+
+
+def make_ssh_runner(target, timeout=25):
+    def run(argv):
+        cmd = ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes", target,
+               " ".join(shlex.quote(a) for a in argv)]
+        try:
+            p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        except FileNotFoundError:
+            return 127, ""
+        except subprocess.TimeoutExpired:
+            return 124, ""
+        return p.returncode, (p.stdout or "").strip()
+    return run
+
+
+def _unix_ts(value):
+    """Parse systemd's `--timestamp=unix` value ('@1785986153') -> int or None."""
+    s = (value or "").strip()
+    if s.startswith("@"):
+        s = s[1:]
+    return int(s) if s.isdigit() else None
+
+
+def check_host(label, run, cfg_path, *, expect=(), expect_absent=()):
+    """Gather one host's deploy state. Pure w.r.t. I/O: everything goes through
+    `run(argv) -> (rc, stdout)`, so tests inject a fake runner."""
+    res = {"host": label, "problems": [], "notes": [], "triggers": None,
+           "config_mtime": None, "keylog_start": None, "espanso": "unknown",
+           "keylog_state": "unknown"}
+
+    rc, out = run(["stat", "-c", "%Y", cfg_path])
+    if rc == 0 and out.strip().isdigit():
+        res["config_mtime"] = int(out.strip())
+    else:
+        res["problems"].append(f"cannot stat {cfg_path} (rc={rc})")
+
+    rc, out = run(["systemctl", "--user", "is-active", ESPANSO_UNIT])
+    res["espanso"] = out.strip() or "unknown"
+    if res["espanso"] != "active":
+        res["problems"].append(f"espanso.service is {res['espanso']!r}, not 'active'")
+
+    rc, out = run(["systemctl", "--user", "show", "-P", "ActiveEnterTimestamp",
+                   "--timestamp=unix", KEYLOG_UNIT])
+    res["keylog_start"] = _unix_ts(out) if rc == 0 else None
+
+    rc, out = run(["systemctl", "--user", "show", "-P", "SubState", KEYLOG_UNIT])
+    res["keylog_state"] = out.strip() or "unknown"
+    if res["keylog_state"] != "running":
+        res["problems"].append(
+            f"{KEYLOG_UNIT} SubState is {res['keylog_state']!r}, not 'running' — "
+            "no fires are being recorded at all")
+
+    rc, out = run(["cat", cfg_path])
+    if rc != 0:
+        res["problems"].append(f"cannot read {cfg_path} (rc={rc})")
+    else:
+        try:
+            ts = parse_config_text(out, origin=f"{label}:{cfg_path}")
+            res["triggers"] = list(ts.triggers)
+        except ConfigUnavailable as e:
+            # NOT "0 triggers" — an unparseable config is unknown, not empty.
+            res["problems"].append(f"CONFIG UNPARSEABLE: {e}")
+
+    if res["triggers"] is not None:
+        missing = [t for t in expect if t not in res["triggers"]]
+        present = [t for t in expect_absent if t in res["triggers"]]
+        if missing:
+            res["problems"].append(f"expected trigger(s) MISSING: {' '.join(missing)}")
+        if present:
+            res["problems"].append(
+                f"trigger(s) expected to be GONE are still deployed: {' '.join(present)}")
+
+    # 🔴 Staleness. keylog loads the trigger set ONCE at process init, so a
+    # detector older than the config is matching against triggers that no longer
+    # exist — new snippets then read 0 fires and the next audit prunes them.
+    if res["config_mtime"] is not None and res["keylog_start"] is not None:
+        drift = res["keylog_start"] - res["config_mtime"]
+        if drift < 0:
+            res["problems"].append(
+                f"🔴 STALE DETECTOR: {KEYLOG_UNIT} started {-drift}s BEFORE the "
+                f"espanso config was written. It is matching an OLD trigger set, so "
+                f"new snippets will read 0 fires. Fix: systemctl --user restart keylog")
+        else:
+            res["notes"].append(
+                f"detector started {drift}s after the config was written "
+                "(timestamp proxy — there is no IPC to ask the running process "
+                "which trigger set it loaded)")
+    else:
+        res["problems"].append(
+            "cannot compare detector start vs config mtime — staleness UNKNOWN")
+    return res
+
+
+def render_verify(results):
+    out = ["## VERIFY-DEPLOY", ""]
+    for r in results:
+        ok = "OK" if not r["problems"] else "PROBLEM"
+        out.append(f"### {r['host']}  [{ok}]")
+        ntrig = "UNKNOWN" if r["triggers"] is None else str(len(r["triggers"]))
+        out.append(f"  espanso={r['espanso']}  keylog={r['keylog_state']}  "
+                   f"triggers={ntrig}")
+        for n in r["notes"]:
+            out.append(f"  - {n}")
+        for p in r["problems"]:
+            out.append(f"  !! {p}")
+        out.append("")
+    known = [r for r in results if r["triggers"] is not None]
+    if len(known) == 2:
+        a, b = known
+        only_a = sorted(set(a["triggers"]) - set(b["triggers"]))
+        only_b = sorted(set(b["triggers"]) - set(a["triggers"]))
+        if only_a or only_b:
+            out.append("### host DIVERGENCE (ship.sh should make these identical)")
+            if only_a:
+                out.append(f"  only on {a['host']}: {' '.join(only_a)}")
+            if only_b:
+                out.append(f"  only on {b['host']}: {' '.join(only_b)}")
+        else:
+            out.append(f"### both hosts carry the SAME {len(a['triggers'])} triggers")
+        out.append("")
+    elif len(known) < 2:
+        out.append("### host comparison SKIPPED — fewer than two configs parsed")
+        out.append("")
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Espanso snippet usage audit — fires, demand, verdicts.")
+    p.add_argument("--since", default=None, metavar="YYYY-MM-DD",
+                   help="window start (inclusive)")
+    p.add_argument("--source", default="both", choices=("keys", "transcript", "both"),
+                   help="which signal(s) to gather (default: both)")
+    p.add_argument("--root", default="~/.claude/projects",
+                   help="transcript root for the DEMAND signal")
+    p.add_argument("--host", default=None,
+                   help="restrict the FIRES query to one ACTIVITY_HOST label")
+    p.add_argument("--terms", action="store_true",
+                   help="raw search-term breakdown instead of the report")
+    p.add_argument("--replay", action="store_true",
+                   help="resolve observed search terms through the real detector")
+    p.add_argument("--lint", action="store_true",
+                   help="offline discoverability/ambiguity check (no creds needed)")
+    p.add_argument("--config", default=None, metavar="PATH",
+                   help="base.yml to load (default: the live one). With --replay "
+                        "this is a PRE-SHIP gate on a candidate config.")
+    p.add_argument("--verify-deploy", action="store_true",
+                   help="post-ship check of both hosts, incl. detector staleness")
+    p.add_argument("--remote", default=DEFAULT_REMOTE,
+                   help=f"ssh target for the second host (default {DEFAULT_REMOTE})")
+    p.add_argument("--no-remote", action="store_true",
+                   help="--verify-deploy: check only this host")
+    p.add_argument("--expect", default="", metavar="T,T",
+                   help="--verify-deploy: triggers that MUST be deployed")
+    p.add_argument("--expect-absent", default="", metavar="T,T",
+                   help="--verify-deploy: triggers that must be GONE")
+    return p.parse_args(argv)
+
+
+def _csv(s):
+    return [x.strip() for x in (s or "").split(",") if x.strip()]
+
+
+def _run_verify(a, out):
+    results = [check_host("local", make_local_runner(),
+                          default_config_path(),
+                          expect=_csv(a.expect), expect_absent=_csv(a.expect_absent))]
+    if not a.no_remote and a.remote:
+        results.append(check_host(a.remote, make_ssh_runner(a.remote),
+                                  ESPANSO_BASE_REL,
+                                  expect=_csv(a.expect),
+                                  expect_absent=_csv(a.expect_absent)))
+    out.extend(render_verify(results))
+    return 4 if any(r["problems"] for r in results) else 0
+
+
+def main(argv=None) -> int:
+    a = parse_args(argv)
+    out = []
+    rc = 0
+
+    # ---- modes that need no ClickHouse ----
+    if a.verify_deploy:
+        rc = _run_verify(a, out)
+        print("\n".join(out))
+        return rc
+
+    if a.lint:
+        try:
+            ts = load_config(a.config)
+        except ConfigUnavailable as e:
+            print("\n".join(unmeasured_banner(e, what="CONFIG")))
+            return 3
+        out.extend(render_lint(lint(ts), a.config or default_config_path()))
+        print("\n".join(out))
+        return 0
+
+    # ---- B2: --host is a REAL filter on the fires query only. The DEMAND
+    # signal reads the LOCAL filesystem, so stamping another host's label on it
+    # would mislabel the data; refuse rather than mislabel. ----
+    wants_transcripts = a.source in ("transcript", "both") and not (a.terms or a.replay)
+    local = local_host_label()
+    if a.host and wants_transcripts and local and local.lower() != a.host.lower():
+        print(f"espanso-usage: --host {a.host} filters the FIRES query, but the "
+              f"DEMAND signal reads the LOCAL transcripts of {local!r}. Run this on "
+              f"{a.host} for its transcripts, or add --source keys.", file=sys.stderr)
+        return 2
+
+    hdr = "# espanso usage"
+    if a.since:
+        hdr += f" — since {a.since}"
+    if a.host:
+        hdr += f" — fires filtered to host={a.host}"
+    out.append(hdr)
+    out.append("")
+
+    # ---- config (needed for verdicts / terms / replay) ----
+    ts, cfg_err = None, None
+    try:
+        ts = load_config(a.config)
+    except ConfigUnavailable as e:
+        cfg_err = e
+
+    # ---- FIRES ----
+    fires, fires_err = None, None
+    if a.source in ("keys", "both") or a.terms or a.replay:
+        try:
+            client, conn = open_client()
+            fires = gather_fires(client, a.since, a.host, conn.fq_table)
+        except FiresUnmeasured as e:
+            fires_err = e
+
+    if a.terms or a.replay:
+        if fires_err is not None:
+            out.extend(unmeasured_banner(fires_err))
+            print("\n".join(out))
+            return 3
+        if cfg_err is not None:
+            out.extend(unmeasured_banner(cfg_err, what="CONFIG"))
+            print("\n".join(out))
+            return 3
+        if a.terms:
+            out.extend(render_terms(fires, ts))
+        if a.replay:
+            terms = [(t, n) for t, n in fires["unattributed"]]
+            terms += [(t, n) for t, _trig, n in fires["attributed"]]
+            out.extend(render_replay(replay_terms(terms, ts),
+                                     a.config or default_config_path()))
+        print("\n".join(out))
+        return 0
+
+    if a.source in ("keys", "both"):
+        if fires_err is not None:
+            out.extend(unmeasured_banner(fires_err))
+            rc = 3
+        else:
+            out.extend(render_fires(fires))
+
+    # ---- DEMAND ----
+    scan = None
+    if a.source in ("transcript", "both"):
+        scan = scan_transcripts(os.path.expanduser(a.root), a.since)
+        out.extend(render_demand(scan, local))
+
+    # ---- VERDICT ----
+    if a.source != "both":
+        out.append("(VERDICT matrix needs BOTH signals — omit --source to get it)")
+        out.append("")
+    elif cfg_err is not None:
+        out.extend(unmeasured_banner(cfg_err, what="CONFIG"))
+        rc = 3
+    elif fires_err is not None:
+        out.append("(VERDICT matrix SKIPPED — fires were not measured; classifying "
+                   "on an unmeasured signal is how live snippets get pruned)")
+        out.append("")
+    else:
+        demand = {t: scan["demand"].get(t) for t in DEMAND_TEXTS}
+        weight, _detail = term_evidence(fires["unattributed"], ts)
+        out.extend(render_verdicts(build_verdicts(ts, fires["per"], demand, weight)))
+
+    print("\n".join(out))
+    return rc
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/session-analysis/tests/test_espanso_usage.py
+++ b/scripts/session-analysis/tests/test_espanso_usage.py
@@ -1,0 +1,725 @@
+"""Unit tests for espanso-usage.py — the verdict classifier + every silent zero.
+
+No live ClickHouse and no PyYAML: fake `activity.events` rows go through a
+FakeClient (the test_adoption_scan.py style), and trigger sets are built from
+pre-loaded dicts, which `espanso_triggers.load_triggers` accepts natively.
+
+🔴 The reassuring answer this tool produces is a ZERO ("0 fires", "0 demand",
+"no findings"), and a zero is indistinguishable from a harness wired to nothing.
+So every counting/classification section here is exercised with a POSITIVE
+CONTROL in the same test as its zero: the assertions come in pairs, `N` on a
+case that MUST count and `0` on the case under test.
+"""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "espanso-usage.py"
+_spec = importlib.util.spec_from_file_location("espanso_usage", SCRIPT)
+M = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(M)
+
+ET = M.ET
+Q = M.Q
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures — the real 2026-08-05 snippet SHAPES (values are placeholders; the
+# fields are pairwise distinct so a wrong-field bug cannot pass by coincidence).
+# --------------------------------------------------------------------------- #
+EOS = {"trigger": ":eos",
+       "replace": "reflect on work done and key learnings this session, then "
+                  "write the handoff FIRST",
+       "label": "End-of-session ritual: handoff first",
+       "search_terms": ["end", "ritual", "wrap"]}
+ACQ = {"trigger": ":acq",
+       "replace": "dispatch subagent to process feedback\nask me clarifying "
+                  "questions and recommend anything you think would be useful",
+       "label": "Process feedback: dispatch subagent",
+       "search_terms": ["feedback", "clarify"]}
+SSHWN = {"trigger": ":sshwn", "replace": "ssh user@198.51.100.10",
+         "label": "SSH workbench (nebula)",
+         "search_terms": ["ssh", "workbench", "nebula"]}
+SSHWL = {"trigger": ":sshwl", "replace": "ssh user@198.51.100.11",
+         "label": "SSH workbench (LAN)",
+         "search_terms": ["ssh", "workbench", "lan"]}
+SSHLN = {"trigger": ":sshln", "replace": "ssh user@198.51.100.12",
+         "label": "SSH laptop (nebula)",
+         "search_terms": ["ssh", "laptop", "nebula"]}
+SSHLL = {"trigger": ":sshll", "replace": "ssh user@198.51.100.13",
+         "label": "SSH laptop (LAN)",
+         "search_terms": ["ssh", "laptop", "lan"]}
+DATE = {"trigger": ":date", "replace": "{{mydate}}", "label": "Today's date",
+        "search_terms": ["today", "calendar"]}
+TYPO = {"trigger": "dashbaord", "replace": "dashboard"}
+DEADSNIP = {"trigger": ":zqx", "replace": "an expansion nobody has ever wanted",
+            "label": "Dead snippet", "search_terms": ["zqx"]}
+PATHSNIP = {"trigger": ":hlt", "replace": "/w/homelab-talos ",
+            "label": "homelab-talos path", "search_terms": ["infra"]}
+
+ALL_MATCHES = [EOS, ACQ, SSHWN, SSHWL, SSHLN, SSHLL, DATE, TYPO, DEADSNIP,
+               PATHSNIP]
+SSH_FAMILY = [SSHWN, SSHWL, SSHLN, SSHLL]
+
+
+def _ts(matches=None):
+    return ET.load_triggers({"matches": list(matches or ALL_MATCHES)})
+
+
+def _fire(trigger, method, fires, host="workbench", inferred=False):
+    return {"trigger": trigger, "method": method, "inferred": inferred,
+            "fires": fires, "host": host}
+
+
+def _term(trigger, term, n, host="workbench"):
+    return {"trigger": trigger, "term": term, "n": n, "host": host}
+
+
+class FakeClient:
+    """Answers the two keylog queries from fabricated rows, and HONOURS the
+    `host = '...'` predicate so a host test is behavioural, not just textual."""
+
+    def __init__(self, fire_rows=(), term_rows=()):
+        self.fire_rows = list(fire_rows)
+        self.term_rows = list(term_rows)
+        self.seen = []
+
+    def rows(self, sql):
+        self.seen.append(sql)
+        src = self.fire_rows if "GROUP BY trigger, method, inferred" in sql \
+            else self.term_rows
+        import re as _re
+        m = _re.search(r"host = '([^']*)'", sql)
+        if m:
+            src = [r for r in src if r.get("host") == m.group(1)]
+        return [{k: v for k, v in r.items() if k != "host"} for r in src]
+
+
+class BoomClient:
+    def __init__(self, exc):
+        self.exc = exc
+
+    def rows(self, sql):
+        raise self.exc
+
+
+def _patch_client(monkeypatch, client):
+    conn = Q.CHConn(url="http://x", user="u", password="p")
+    monkeypatch.setattr(M, "open_client", lambda: (client, conn))
+
+
+# --------------------------------------------------------------------------- #
+# expansion_kind / is_text_detectable
+# --------------------------------------------------------------------------- #
+def test_expansion_kind_covers_every_non_detectable_shape():
+    assert M.expansion_kind("{{mydate}}") == "template"
+    assert M.expansion_kind("ssh user@198.51.100.10") == "shell"
+    assert M.expansion_kind("dashboard") == "typo"
+    assert M.expansion_kind("/w/homelab-talos ") == "text"
+    assert M.expansion_kind("recommend next actions") == "text"
+    # positive control on the predicate: exactly one of these is detectable
+    kinds = [M.is_text_detectable(x["replace"]) for x in
+             (DATE, SSHWN, TYPO, PATHSNIP)]
+    assert kinds == [False, False, False, True]
+
+
+# --------------------------------------------------------------------------- #
+# classify() — one literal expectation per verdict class
+# --------------------------------------------------------------------------- #
+def test_classify_healthy_when_it_fires():
+    assert M.classify(fires=72, demand=0, term_evidence=0,
+                      text_detectable=True) == "HEALTHY"
+
+
+def test_classify_unfindable_is_the_acq_case():
+    """:acq 2026-08-05 — 0 fires, 36 real pastes. Pruning it would be wrong."""
+    assert M.classify(fires=0, demand=36, term_evidence=0,
+                      text_detectable=True) == "UNFINDABLE"
+
+
+def test_classify_unattributable_is_the_sshwn_case():
+    """:sshwn — not text-detectable, 0 fires, but 13 unattributed terms match
+    it. Checked BEFORE the KEYLOG-ONLY branch, or it reads as 'no signal'."""
+    assert M.classify(fires=0, demand=None, term_evidence=13,
+                      text_detectable=False) == "UNATTRIBUTABLE"
+
+
+def test_classify_keylog_only_is_the_date_case():
+    assert M.classify(fires=0, demand=None, term_evidence=0,
+                      text_detectable=False) == "KEYLOG-ONLY"
+
+
+def test_classify_dead_needs_every_signal_measured_and_zero():
+    assert M.classify(fires=0, demand=0, term_evidence=0,
+                      text_detectable=True) == "DEAD"
+
+
+def test_classify_unprobed_when_demand_was_never_measured():
+    """A text-detectable snippet with no DEMAND_TEXTS entry is UNMEASURED, and
+    must never be reported DEAD — that is how a new snippet gets pruned."""
+    assert M.classify(fires=0, demand=None, term_evidence=0,
+                      text_detectable=True) == "UNPROBED"
+
+
+def test_classify_retired_for_a_trigger_no_longer_in_the_config():
+    assert M.classify(fires=1, demand=None, term_evidence=0,
+                      text_detectable=False, in_config=False) == "RETIRED"
+
+
+def test_every_verdict_has_an_action_string():
+    for v in (M.HEALTHY, M.UNFINDABLE, M.UNATTRIBUTABLE, M.KEYLOG_ONLY,
+              M.UNPROBED, M.DEAD, M.RETIRED):
+        assert M.VERDICT_ACTION[v]
+
+
+def test_classify_branch_order_each_branch_is_reachable():
+    """Every branch must be reachable — an earlier one always winning would make
+    a later verdict dead code that no single-case test can detect."""
+    seen = {
+        M.classify(fires=1, demand=5, term_evidence=5, text_detectable=True),
+        M.classify(fires=0, demand=5, term_evidence=5, text_detectable=True),
+        M.classify(fires=0, demand=0, term_evidence=5, text_detectable=True),
+        M.classify(fires=0, demand=None, term_evidence=0, text_detectable=False),
+        M.classify(fires=0, demand=None, term_evidence=0, text_detectable=True),
+        M.classify(fires=0, demand=0, term_evidence=0, text_detectable=True),
+        M.classify(fires=0, demand=0, term_evidence=0, text_detectable=True,
+                   in_config=False),
+    }
+    assert seen == {"HEALTHY", "UNFINDABLE", "UNATTRIBUTABLE", "KEYLOG-ONLY",
+                    "UNPROBED", "DEAD", "RETIRED"}
+
+
+# --------------------------------------------------------------------------- #
+# term_evidence — POSITIVE CONTROL on a counting section
+# --------------------------------------------------------------------------- #
+def test_term_evidence_counts_real_multiword_terms_and_ignores_noise():
+    ts = _ts()
+    # positive control: 'ssh work' is a real observed query and matches both
+    # workbench ssh snippets -> non-zero for each.
+    weight, detail = M.term_evidence([("ssh work", 5)], ts)
+    assert weight[":sshwn"] == 5 and weight[":sshwl"] == 5
+    assert detail[":sshwn"][0][2] == 2          # it matched 2 snippets
+    # under test: a 1-char term matches half the config through search_terms
+    # substrings and is noise -> zero, NOT because the harness is inert.
+    noise, _ = M.term_evidence([("c", 9)], ts)
+    assert sum(noise.values()) == 0
+
+
+def test_term_evidence_drops_terms_that_match_too_many_snippets():
+    """Measured at 4 snippets and at 5 — LITERAL counts, not `cap` and `cap+1`.
+
+    Two earlier drafts of this test were vacuous: the first used a 1-char term,
+    which MIN_LEN rejected before the cap ever ran; the second expressed both
+    points as `cap`/`cap+1`, so raising the constant to 9999 still passed.
+    """
+    def _shared(n):
+        return ET.load_triggers({"matches": [
+            {"trigger": f":w{i}", "replace": "a phrase", "label": "x",
+             "search_terms": ["sharedterm"]} for i in range(n)]})
+
+    assert sum(M.term_evidence([("sharedterm", 7)], _shared(4))[0].values()) == 28
+    assert sum(M.term_evidence([("sharedterm", 7)], _shared(5))[0].values()) == 0
+    # and a real observed term at the boundary is still counted
+    assert M.term_evidence([("ssh", 4)], _ts())[0][":sshwn"] == 4
+
+
+def test_evidence_thresholds_are_pinned_to_the_real_config_shape():
+    """Literal values, tied to WHY they are those values: the largest legitimate
+    ambiguity in the live config is the 4-member :ssh* family, and the shortest
+    real observed query is 3 chars ('ssh', 'gpu', 'pro')."""
+    assert M.UNATTR_EVIDENCE_MAX_MATCHES == 4
+    assert M.UNATTR_EVIDENCE_MIN_LEN == 3
+
+
+# --------------------------------------------------------------------------- #
+# aggregate_fires / split_terms — POSITIVE CONTROL
+# --------------------------------------------------------------------------- #
+def test_aggregate_fires_splits_direct_and_search():
+    per, total = M.aggregate_fires([
+        _fire(":eos", "search", 72, inferred=True),
+        _fire("dashbaord", "direct", 5),
+        _fire("", "search", 46, inferred=True),
+    ])
+    assert total == 123
+    assert per[":eos"] == {"direct": 0, "search": 72, "inferred": True}
+    assert per["dashbaord"]["direct"] == 5
+    assert per[M.UNATTRIBUTED]["search"] == 46
+    # zero under test, with the positive control above proving it can move
+    empty_per, empty_total = M.aggregate_fires([])
+    assert empty_total == 0 and empty_per == {}
+
+
+def test_split_terms_separates_attributed_from_unattributed():
+    attributed, unattributed = M.split_terms([
+        _term(":eos", "rit", 72), _term("", "ssh work", 5)])
+    assert attributed == [("rit", ":eos", 72)]
+    assert unattributed == [("ssh work", 5)]
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 B1 — an unreachable/rejecting ClickHouse must NEVER read as zero fires
+# --------------------------------------------------------------------------- #
+def test_gather_fires_raises_on_unreachable_instead_of_returning_zero():
+    with pytest.raises(M.FiresUnmeasured) as ei:
+        M.gather_fires(BoomClient(Q.CHUnreachable("connection refused")))
+    assert ei.value.reason == "unreachable"
+
+
+def test_gather_fires_distinguishes_a_rejected_query():
+    with pytest.raises(M.FiresUnmeasured) as ei:
+        M.gather_fires(BoomClient(Q.CHQueryError("Code: 241", code=241)))
+    assert ei.value.reason == "query"
+
+
+def test_main_unreachable_is_loud_and_is_not_the_no_events_wording(
+        monkeypatch, capsys):
+    _patch_client(monkeypatch, BoomClient(Q.CHUnreachable("refused")))
+    rc = M.main(["--source", "keys"])
+    out = capsys.readouterr().out
+    assert rc == 3
+    assert "FIRES UNMEASURED" in out and "UNREACHABLE" in out
+    assert "Do NOT prune" in out
+    # the exact wording the predecessor printed for a DOWN server
+    assert "no keylog espanso events yet" not in out
+
+
+def test_main_rejected_query_reads_differently_from_unreachable(
+        monkeypatch, capsys):
+    _patch_client(monkeypatch, BoomClient(Q.CHQueryError("Code: 241")))
+    rc = M.main(["--source", "keys"])
+    out = capsys.readouterr().out
+    assert rc == 3 and "REJECTED" in out and "UNREACHABLE" not in out
+
+
+def test_main_measured_zero_says_forward_only_and_exits_zero(
+        monkeypatch, capsys):
+    """POSITIVE-CONTROL PAIR: the same code path with rows present prints a
+    table and a total; with no rows it prints the forward-only note. A measured
+    zero and an unmeasured one must not look alike."""
+    _patch_client(monkeypatch, FakeClient([_fire(":eos", "search", 7)], []))
+    assert M.main(["--source", "keys"]) == 0
+    hot = capsys.readouterr().out
+    assert "total fires: 7" in hot
+
+    _patch_client(monkeypatch, FakeClient([], []))
+    assert M.main(["--source", "keys"]) == 0
+    cold = capsys.readouterr().out
+    assert "0 espanso rows in this window" in cold and "FIRES UNMEASURED" not in cold
+
+
+# --------------------------------------------------------------------------- #
+# B2 — --host reaches the SQL *and* changes the answer
+# --------------------------------------------------------------------------- #
+def test_host_predicate_reaches_both_queries():
+    assert "host = 'laptop'" in M.q_fires(host="laptop")
+    assert "host = 'laptop'" in M.q_terms(host="laptop")
+    assert "host" not in M.q_fires()
+
+
+def test_host_filter_is_behavioural_not_just_spelled():
+    rows = [_fire(":eos", "search", 11, host="laptop"),
+            _fire(":eos", "search", 3, host="workbench")]
+    client = FakeClient(rows, [])
+    lap = M.gather_fires(client, host="laptop")
+    wb = M.gather_fires(client, host="workbench")
+    none = M.gather_fires(client, host="nosuchhost")
+    assert lap["total"] == 11 and wb["total"] == 3        # positive controls
+    assert none["total"] == 0                              # zero under test
+
+
+def test_since_is_quoted_into_the_where_clause():
+    assert "ts >= '2026-07-25'" in M.q_fires(since="2026-07-25")
+
+
+def test_host_mismatch_refuses_rather_than_mislabelling(monkeypatch, capsys):
+    """--host used to be printed in the header and then ignored, so
+    `--host laptop` stamped a workbench-local transcript scan as laptop data."""
+    monkeypatch.setattr(M, "local_host_label", lambda *a, **k: "workbench")
+    rc = M.main(["--host", "laptop"])
+    assert rc == 2
+    assert "reads the LOCAL transcripts" in capsys.readouterr().err
+
+
+def test_host_matching_local_label_is_allowed(monkeypatch, capsys):
+    monkeypatch.setattr(M, "local_host_label", lambda *a, **k: "workbench")
+    _patch_client(monkeypatch, FakeClient([_fire(":eos", "search", 2)], []))
+    assert M.main(["--host", "workbench", "--source", "keys"]) == 0
+    assert "fires filtered to host=workbench" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# B3/B4/B5 — boilerplate filtering, sharing the collector's constant
+# --------------------------------------------------------------------------- #
+def test_boilerplate_prefixes_come_from_the_shared_constant():
+    for shared in M._SHARED_BOILERPLATE:
+        assert shared.lower() in M.BOILERPLATE_PREFIXES
+
+
+def test_capital_r_request_interrupted_is_filtered():
+    """Measured 2026-08-05: 389 capital-R vs 47 lowercase in the transcripts.
+    The old filter tested the lowercase spelling only."""
+    assert M.is_boilerplate("[Request interrupted by user]")
+    assert M.is_boilerplate("[Request interrupted by user for tool use]")
+    assert M.is_boilerplate("[request interrupted by user]")
+
+
+def test_capital_i_image_marker_is_filtered():
+    assert M.is_boilerplate(
+        "[Image: original 3434x1346, displayed at 2000x784. Multiply "
+        "coordinates by 1.717]")
+
+
+def test_boilerplate_filter_keeps_real_messages():
+    """Positive control: the filter must not eat ordinary short messages."""
+    assert not M.is_boilerplate("recommend next actions")
+    assert not M.is_boilerplate("merge it")
+
+
+def _write_transcript(dirpath, name, messages):
+    p = Path(dirpath) / name
+    lines = []
+    for i, m in enumerate(messages):
+        obj = {"type": "user", "uuid": f"{name}-{i}",
+               "timestamp": m.get("ts", "2026-08-01T10:00:00Z"),
+               "message": {"role": "user", "content": m["text"]}}
+        for k in ("isMeta", "isSidechain"):
+            if m.get(k):
+                obj[k] = True
+        lines.append(json.dumps(obj))
+    p.write_text("\n".join(lines) + "\n")
+    return p
+
+
+def test_scan_transcripts_counts_demand_and_excludes_boilerplate(tmp_path):
+    _write_transcript(tmp_path, "s1.jsonl", [
+        {"text": "recommend next actions"},                    # :rna demand
+        {"text": "recommend next actions"},
+        {"text": "[Request interrupted by user]"},             # capital-R noise
+        {"text": "[Image: original 100x100, displayed at 50x50.]"},
+        {"text": "merge it"},                                   # add-candidate
+    ])
+    scan = M.scan_transcripts(str(tmp_path))
+    # POSITIVE CONTROL: the demand counter moved for a snippet that IS present
+    assert scan["demand"][":rna"] == 2
+    # ...and stayed at zero for one that is not (harness proven live above)
+    assert scan["demand"][":mt"] == 0
+    assert scan["messages"] == 3          # 5 lines - 2 boilerplate
+    short = dict(scan["short"])
+    assert short.get("merge it") == 1
+    assert not any("request interrupted" in k for k in short)
+    assert not any(k.startswith("[image:") for k in short)
+
+
+def test_scan_transcripts_skips_meta_and_sidechain_copies(tmp_path):
+    _write_transcript(tmp_path, "s2.jsonl", [
+        {"text": "tee up what we can do in the meantime"},
+        {"text": "tee up what we can do in the meantime", "isSidechain": True},
+        {"text": "tee up what we can do in the meantime", "isMeta": True},
+    ])
+    scan = M.scan_transcripts(str(tmp_path))
+    assert scan["demand"][":mt"] == 1     # 1 real, 2 copies dropped
+
+
+def test_scan_transcripts_honours_since(tmp_path):
+    _write_transcript(tmp_path, "s3.jsonl", [
+        {"text": "recommend next actions", "ts": "2026-07-01T10:00:00Z"},
+        {"text": "recommend next actions", "ts": "2026-08-01T10:00:00Z"},
+    ])
+    assert M.scan_transcripts(str(tmp_path))["demand"][":rna"] == 2
+    assert M.scan_transcripts(str(tmp_path), since="2026-07-15")["demand"][":rna"] == 1
+
+
+def test_scan_transcripts_excludes_the_containing_expansion(tmp_path):
+    """:cdp's path is a prefix of :cpk's — a :cpk paste must not count as :cdp."""
+    _write_transcript(tmp_path, "s4.jsonl", [
+        {"text": "look at /w/civit/datapacket-talos/prod-kubeconfig please"},
+    ])
+    scan = M.scan_transcripts(str(tmp_path))
+    assert scan["demand"][":cpk"] == 1
+    assert scan["demand"][":cdp"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# build_verdicts over the real 2026-08-05 shapes
+# --------------------------------------------------------------------------- #
+def test_build_verdicts_reproduces_the_2026_08_05_reading():
+    ts = _ts()
+    fires = {":eos": {"direct": 0, "search": 72},
+             "dashbaord": {"direct": 5, "search": 0},
+             ":rns": {"direct": 0, "search": 1},        # pruned -> RETIRED
+             "": {"direct": 0, "search": 46}}
+    demand = {":eos": 71, ":acq": 36, ":zqx": 0, ":hlt": 344}
+    evidence, _ = M.term_evidence([("ssh work", 13)], ts)
+    rows = {r["trigger"]: r for r in
+            M.build_verdicts(ts, fires, demand, evidence)}
+    assert rows[":eos"]["verdict"] == "HEALTHY" and rows[":eos"]["fires"] == 72
+    assert rows["dashbaord"]["verdict"] == "HEALTHY"
+    assert rows[":acq"]["verdict"] == "UNFINDABLE"
+    assert rows[":sshwn"]["verdict"] == "UNATTRIBUTABLE"
+    assert rows[":sshwn"]["term_evidence"] == 13
+    assert rows[":date"]["verdict"] == "KEYLOG-ONLY"
+    assert rows[":zqx"]["verdict"] == "DEAD"
+    assert rows[":hlt"]["verdict"] == "HEALTHY" or rows[":hlt"]["fires"] == 0
+    assert rows[":rns"]["verdict"] == "RETIRED"
+    assert M.UNATTRIBUTED not in rows      # the unattributed bucket is not a snippet
+
+
+def test_build_verdicts_marks_a_missing_demand_probe_unprobed():
+    ts = _ts([PATHSNIP])
+    rows = M.build_verdicts(ts, {}, {}, {})
+    assert rows[0]["verdict"] == "UNPROBED"
+
+
+def test_render_verdicts_prints_the_action_column():
+    ts = _ts([ACQ])
+    text = "\n".join(M.render_verdicts(M.build_verdicts(ts, {}, {":acq": 36}, {})))
+    assert "UNFINDABLE" in text and "do NOT prune" in text
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 config silent zero — an unparseable config is not "0 snippets"
+# --------------------------------------------------------------------------- #
+class _FakeYaml:
+    @staticmethod
+    def safe_load(text):
+        return json.loads(text)
+
+
+def test_parse_config_text_raises_when_pyyaml_is_missing(monkeypatch):
+    monkeypatch.setattr(M, "_yaml", None)
+    with pytest.raises(M.ConfigUnavailable) as ei:
+        M.parse_config_text("matches: []")
+    assert ei.value.reason == "pyyaml"
+
+
+def test_parse_config_text_raises_on_zero_triggers(monkeypatch):
+    """`load_triggers` degrades to an empty TriggerSet by design (the keylogger
+    must not crash). For an AUDIT that degradation IS the silent zero."""
+    monkeypatch.setattr(M, "_yaml", _FakeYaml)
+    with pytest.raises(M.ConfigUnavailable) as ei:
+        M.parse_config_text(json.dumps({"matches": []}))
+    assert ei.value.reason == "empty"
+
+
+def test_parse_config_text_positive_control(monkeypatch):
+    monkeypatch.setattr(M, "_yaml", _FakeYaml)
+    ts = M.parse_config_text(json.dumps({"matches": [EOS, DATE]}))
+    assert ts.triggers == [":eos", ":date"]
+
+
+def test_load_config_raises_on_a_missing_file(tmp_path):
+    with pytest.raises(M.ConfigUnavailable) as ei:
+        M.load_config(str(tmp_path / "nope.yml"))
+    assert ei.value.reason == "io"
+
+
+def test_main_lint_reports_config_unavailable_loudly(monkeypatch, capsys):
+    monkeypatch.setattr(M, "load_config",
+                        lambda p=None: (_ for _ in ()).throw(
+                            M.ConfigUnavailable("boom", reason="pyyaml")))
+    rc = M.main(["--lint"])
+    assert rc == 3
+    assert "CONFIG UNMEASURED" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# lint
+# --------------------------------------------------------------------------- #
+def _kinds(findings):
+    return {f["kind"] for f in findings}
+
+
+def test_lint_flags_a_family_with_no_uniquely_resolving_term():
+    """The :ssh* case: in the real 4-way family every declared term is shared
+    with a sibling ('ssh' with all, 'workbench'/'lan'/'nebula'/'laptop' with
+    one), so `_attribute` returns None for all of them and none can ever fire
+    from the search UI. Two of the four would still each have a unique term —
+    the defect only exists at the full family size."""
+    findings = M.lint(_ts(SSH_FAMILY))
+    unreachable = {f["trigger"] for f in findings if f["kind"] == "unreachable"}
+    assert unreachable == {":sshwn", ":sshwl", ":sshln", ":sshll"}
+    pair = {f["trigger"] for f in M.lint(_ts([SSHWN, SSHWL]))
+            if f["kind"] == "unreachable"}
+    assert pair == set()
+
+
+def test_lint_positive_control_and_clean_config():
+    # positive control: the ambiguity check DOES fire on a colliding pair
+    assert "ambiguous" in _kinds(M.lint(_ts([SSHWN, SSHWL])))
+    # under test: a config whose terms are disjoint yields nothing
+    assert M.lint(_ts([EOS, PATHSNIP])) == []
+
+
+def test_lint_flags_a_snippet_with_no_label_and_no_search_terms():
+    findings = M.lint(_ts([TYPO]))
+    assert [f["kind"] for f in findings] == ["undiscoverable"]
+
+
+def test_lint_flags_a_trigger_that_is_a_prefix_of_another():
+    findings = M.lint(_ts([DATE, {"trigger": ":datetime", "replace": "x y",
+                                  "label": "Date and time",
+                                  "search_terms": ["stamp"]}]))
+    assert "prefix" in _kinds(findings)
+
+
+def test_lint_uses_the_detectors_own_label_tokenizer():
+    """A hyphenated label word must not be reported as a self-miss: the detector
+    splits the label on non-alphanumerics, so 'homelab-talos' is never a token."""
+    assert "self-miss" not in _kinds(M.lint(_ts([PATHSNIP])))
+
+
+# --------------------------------------------------------------------------- #
+# replay
+# --------------------------------------------------------------------------- #
+def test_replay_resolves_zero_one_and_many_matches():
+    ts = _ts()
+    rows = {r["term"]: r for r in M.replay_terms(
+        [("ritual", 3), ("ssh work", 5), ("qqqqq", 1)], ts)}
+    assert rows["ritual"]["resolves_to"] == ":eos"      # positive control
+    assert rows["ritual"]["n_matches"] == 1
+    assert rows["ssh work"]["n_matches"] == 2 and rows["ssh work"]["resolves_to"] is None
+    assert rows["qqqqq"]["n_matches"] == 0 and rows["qqqqq"]["resolves_to"] is None
+
+
+def test_replay_against_a_candidate_config_is_a_preship_gate():
+    """The point of --config: prove a NEW search_terms list resolves BEFORE
+    shipping it. The same term is ambiguous under the old config and unique
+    under the candidate."""
+    old = _ts([SSHWN, SSHWL])
+    candidate = _ts([SSHWN, dict(SSHWL, search_terms=["lan"], label="LAN box")])
+    assert M.replay_terms([("workbench", 1)], old)[0]["resolves_to"] is None
+    assert M.replay_terms([("workbench", 1)], candidate)[0]["resolves_to"] == ":sshwn"
+
+
+def test_render_replay_reports_how_many_fires_land_nowhere():
+    text = "\n".join(M.render_replay(
+        M.replay_terms([("ritual", 3), ("ssh work", 5)], _ts()), "cfg"))
+    assert "resolves: 3/8 fires" in text and "5 would still land nowhere" in text
+
+
+# --------------------------------------------------------------------------- #
+# --verify-deploy, incl. the 🔴 keylog staleness guard
+# --------------------------------------------------------------------------- #
+CFG_TEXT = json.dumps({"matches": [EOS, DATE]})
+
+
+def _runner(*, cfg_mtime, keylog_start, espanso="active", keylog_sub="running",
+            cfg_text=CFG_TEXT, fail=()):
+    def run(argv):
+        if argv[0] in fail:
+            return 1, ""
+        if argv[0] == "stat":
+            return 0, str(cfg_mtime)
+        if argv[0] == "cat":
+            return 0, cfg_text
+        if argv[:3] == ["systemctl", "--user", "is-active"]:
+            return 0, espanso
+        if "ActiveEnterTimestamp" in argv:
+            return 0, f"@{keylog_start}"
+        if "SubState" in argv:
+            return 0, keylog_sub
+        return 1, ""
+    return run
+
+
+def _problems(res):
+    return " | ".join(res["problems"])
+
+
+def test_verify_deploy_stale_detector_is_a_loud_problem(monkeypatch):
+    """POSITIVE-CONTROL PAIR for the staleness guard: a detector that started
+    BEFORE the config is a problem; one that started after is not."""
+    monkeypatch.setattr(M, "_yaml", _FakeYaml)
+    stale = M.check_host("h", _runner(cfg_mtime=2000, keylog_start=1000), "cfg")
+    assert "STALE DETECTOR" in _problems(stale)
+    assert "restart keylog" in _problems(stale)
+    fresh = M.check_host("h", _runner(cfg_mtime=1000, keylog_start=2000), "cfg")
+    assert fresh["problems"] == []
+    assert any("1000s after" in n for n in fresh["notes"])
+
+
+def test_verify_deploy_flags_a_stopped_espanso_and_keylog(monkeypatch):
+    monkeypatch.setattr(M, "_yaml", _FakeYaml)
+    res = M.check_host("h", _runner(cfg_mtime=1, keylog_start=2,
+                                    espanso="inactive", keylog_sub="dead"), "cfg")
+    assert "espanso.service is 'inactive'" in _problems(res)
+    assert "not 'running'" in _problems(res)
+
+
+def test_verify_deploy_expectations_are_structural(monkeypatch):
+    monkeypatch.setattr(M, "_yaml", _FakeYaml)
+    run = _runner(cfg_mtime=1, keylog_start=2)
+    ok = M.check_host("h", run, "cfg", expect=[":eos"], expect_absent=[":gone"])
+    assert ok["problems"] == []                      # positive control
+    bad = M.check_host("h", run, "cfg", expect=[":mt"], expect_absent=[":date"])
+    assert "MISSING: :mt" in _problems(bad)
+    assert "still deployed: :date" in _problems(bad)
+
+
+def test_verify_deploy_unparseable_config_is_not_zero_triggers(monkeypatch):
+    monkeypatch.setattr(M, "_yaml", None)
+    res = M.check_host("h", _runner(cfg_mtime=1, keylog_start=2), "cfg")
+    assert res["triggers"] is None
+    assert "CONFIG UNPARSEABLE" in _problems(res)
+
+
+def test_verify_deploy_unknown_timestamps_are_a_problem_not_a_pass(monkeypatch):
+    monkeypatch.setattr(M, "_yaml", _FakeYaml)
+    res = M.check_host("h", _runner(cfg_mtime=1, keylog_start=2, fail=("stat",)),
+                       "cfg")
+    assert "staleness UNKNOWN" in _problems(res)
+
+
+def test_unix_ts_parses_systemd_output():
+    assert M._unix_ts("@1785986153") == 1785986153
+    assert M._unix_ts("1785986153") == 1785986153
+    assert M._unix_ts("n/a") is None
+
+
+def test_render_verify_reports_host_divergence(monkeypatch):
+    monkeypatch.setattr(M, "_yaml", _FakeYaml)
+    a = M.check_host("a", _runner(cfg_mtime=1, keylog_start=2), "cfg")
+    b = M.check_host("b", _runner(cfg_mtime=1, keylog_start=2,
+                                  cfg_text=json.dumps({"matches": [EOS]})), "cfg")
+    text = "\n".join(M.render_verify([a, b]))
+    assert "host DIVERGENCE" in text and ":date" in text
+    same = "\n".join(M.render_verify([a, a]))
+    assert "both hosts carry the SAME 2 triggers" in same
+
+
+def test_main_verify_deploy_exit_code_signals_a_problem(monkeypatch, capsys):
+    monkeypatch.setattr(M, "_yaml", _FakeYaml)
+    monkeypatch.setattr(M, "make_local_runner",
+                        lambda *a, **k: _runner(cfg_mtime=2000, keylog_start=1))
+    assert M.main(["--verify-deploy", "--no-remote"]) == 4
+    assert "STALE DETECTOR" in capsys.readouterr().out
+    monkeypatch.setattr(M, "make_local_runner",
+                        lambda *a, **k: _runner(cfg_mtime=1, keylog_start=2000))
+    assert M.main(["--verify-deploy", "--no-remote"]) == 0
+
+
+# --------------------------------------------------------------------------- #
+# misc
+# --------------------------------------------------------------------------- #
+def test_local_host_label_prefers_env_then_collector_file(tmp_path):
+    assert M.local_host_label(env={"ACTIVITY_HOST": "LapTop"}) == "laptop"
+    f = tmp_path / "env"
+    f.write_text('FOO=1\nACTIVITY_HOST="workbench"\n')
+    assert M.local_host_label(env={}, env_file=str(f)) == "workbench"
+    assert M.local_host_label(env={}, env_file=str(tmp_path / "absent")) == ""
+
+
+def test_parse_args_keeps_every_legacy_flag():
+    a = M.parse_args(["--since", "2026-01-01", "--source", "transcript",
+                      "--root", "/tmp/x", "--host", "laptop"])
+    assert (a.since, a.source, a.root, a.host) == \
+        ("2026-01-01", "transcript", "/tmp/x", "laptop")
+
+
+def test_bad_source_is_rejected():
+    with pytest.raises(SystemExit):
+        M.parse_args(["--source", "nope"])


### PR DESCRIPTION
Tier 1 of the `/espanso-audit` tooling review, plus the command-doc rewrite.

## Why

`espanso-usage.py`'s headline answer is a **zero**, and two of its zeros were
*unmeasured*, not measured:

| | before | after |
|---|---|---|
| ClickHouse unreachable | `(no keylog espanso events yet — detection is forward-only …)` → reads as **0 fires for every snippet**, next audit prunes live ones | loud banner, `UNREACHABLE` vs `REJECTED` wording, **exit 3**, verdict matrix skipped |
| espanso config unparseable | `load_triggers` degrades to an empty TriggerSet by design → **0 snippets**. Measured: PyYAML is **not** in the ambient `python3` on this host, so a hand-run audit hits this | loud banner + the `nix-shell -p python3Packages.pyyaml` remedy, **exit 3** |

## New

- **VERDICT matrix** (the headline): `HEALTHY` / `UNFINDABLE` / `UNATTRIBUTABLE`
  / `KEYLOG-ONLY` / `UNPROBED` / `DEAD` / `RETIRED`, one action per snippet,
  derived from the live config. `KEYLOG-ONLY` falls out automatically from the
  expansion shape (`{{template}}` / shell command / bare typo-fix), so that
  metadata is no longer hand-maintained.
- `--terms` — attributed vs unattributed search terms, with the snippets each
  unattributed term competes between.
- `--replay [--config PATH]` — resolves observed terms through the **real**
  `EspansoDetector._term_matches` / `_attribute` (imported, never re-spelled).
  With a candidate config it is a **pre-ship gate**.
- `--lint` — offline, no creds. Replaces the never-firing trigger-prefix check
  with the one that matters: a snippet **no term resolves uniquely to** is
  UNREACHABLE from the search UI.
- `--verify-deploy` — both hosts: deployed trigger set (parsed, not grepped),
  espanso active, keylog running, host divergence, and the **keylog staleness**
  check (a detector older than the config is matching an old trigger set).

## Fixed

- **B2** `--host` was accepted, printed in the header, then ignored. It now
  filters the fires query for real, and a `--host` contradicting the local
  `ACTIVITY_HOST` is **refused** rather than mislabelling a local scan.
- **B3/B4/B5** the boilerplate filter tested `"[request interrupted"` lowercase;
  measured **389 capital-R vs 47 lowercase**. Now imports
  `_BOILERPLATE_PREFIXES` from the claude collector (one rule, one place),
  matches case-insensitively, and adds `[Image: original …`. `iter_transcripts`
  is imported too, so the synthetic `subagents/`/`wf_*` dirs stop double-counting
  a dispatched prompt as demand (4350 → 496 files scanned).
- **B6** argv was parsed at module import → the file could not be imported under
  pytest and had **zero** tests. Now argparse + `main(argv=None)`; every legacy
  flag is preserved and pinned by a test.
- The near-worthless "recurring 4-5 word phrases" section is deleted.

## Verified against real data (window 2026-07-25 → today)

Reproduces the 2026-08-05 audit: `:eos` **72**, `:kickoff` **38**, `dashbaord`
**5 direct**, **46 unattributed**. Verdicts: `:acq` UNFINDABLE (0 fires, 105
transcript occurrences), the four `:ssh*` UNATTRIBUTABLE (0 fires, 9–13
unattributed terms match them), `:date` KEYLOG-ONLY, `:rns` RETIRED.
`--lint` flags exactly the four `:ssh*` as UNREACHABLE. `--verify-deploy` ran
against both hosts over ssh and caught a live divergence.

## Tests

60 new tests, green in **both** tiers (with and without PyYAML). Every counting
section carries a **positive control** beside its zero. 30 mutations were run
against the guards; the first sweep left **one survivor** — the evidence
match-cap was shadowed by the min-length check so the branch never executed —
and the test was rebuilt around literal counts until all 30 die.

⚠ `nix build .#checks.x86_64-linux.pytests` is **already red on `main`**:
`scripts/tests` fails 144 tests at `cc762e3` (mostly `FileNotFoundError:
/usr/bin/env` in the sandbox). Identical 144 here; `scripts/session-analysis/tests`
goes 301 → 361, all passing.

Doc: **7,183 → 3,899 B**. Two deletions remove instructions that were *wrong* —
the "a long steering paragraph goes UNFIRED, shorten it back" recipe (`:eos` is
700+ chars and the single most-fired snippet) and the trigger-prefix check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
