### PR TITLE
feat(activity): scheduled ClickHouse regrowth check — the 112 GB fix can no longer revert silently

### DIFF
--- a/claude/skills/activity/SKILL.md
+++ b/claude/skills/activity/SKILL.md
@@ -187,6 +187,35 @@ Creds come from `~/.config/activity-collector/env` (the collector's own file) un
   toast. One workbench runner covers BOTH hosts because it reads the shared table. See the
   `bar` skill.
 
+## regrowth check — "is the ClickHouse store growing back?"
+`scripts/collector/ch_regrowth.py` (+ `run-regrowth-check.sh`, the sops/kubeconfig wrapper).
+2026-08-03 the store was cut **112.4 GB → 82.1 MB** after `system.trace_log` hit 3.77
+BILLION rows in ~5 weeks; the fix was a Flux config change (logger trace→warning, four
+query-profiler log tables removed, 7d/14d TTLs, merge pool 32→8). **Nothing else would
+notice that silently reverting.** Read-only; **workbench-only** systemd user timer
+`ch-regrowth-check`, **monthly on the 11th**, `Persistent=true`.
+```bash
+scripts/collector/run-regrowth-check.sh            # or: systemctl --user start ch-regrowth-check
+# from the laptop (nebula), by hand:
+KUBECONFIG=~/.kube/homelab-nebula.yaml CH_REGROWTH_URL=http://10.42.0.10:30123 \
+  scripts/collector/run-regrowth-check.sh
+```
+- Asserts: `du(store)` >2 GiB ALARM / >1 GiB WARN · any `*_0` table (a TTL applied to an
+  existing `*_log` RENAMES the old one aside, which then keeps its rows with **NO TTL
+  forever**) · `trace_log`/`text_log`/`latency_log`/`processors_profile_log` existing at all
+  · any table >250 MiB · **TTL effectiveness** — `min(event_time)` younger than TTL+1d
+  (the only check that tests the MECHANISM, not today's outcome).
+- Exit **0 ok · 1 ALARM · 2 CANNOT TELL · 3 WARN**. Every non-zero is a unit failure →
+  the existing `OnFailure=notify-failure@` sticky toast. Verdict + every number it read
+  lands in `~/.cache/ch-regrowth/status.json`.
+- 🔴 **`du` sits ~40% above the live `total_bytes` sum by design** (8-slot merge pool
+  leaves inactive parts around). That gap is NOT a leak — do not re-derive an alarm from it.
+- 🔴 Its reassuring answers are all ZEROS, so `ok` is gated on positive controls (listing
+  non-empty, `activity.events` present, >0 `*_log` matches, >0 tables over 1 MiB, ≥1 TTL
+  target measured). Any failure state — `not-configured`/`unreachable`/`query-failed`/
+  `exec-failed`/`no-data` — is LOUD and is never `ok`. Read its module docstring before
+  changing any threshold; every one is derived from a named measurement.
+
 ## troubleshoot a stalled source
 1. `journalctl --user -u <service> -n 30` — `urlopen timed out` = can't reach CH (check the
    endpoint matches the host: laptop must use the nebula IP).

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -2155,7 +2155,14 @@ in
       # kubectl must not wedge the timer — the cgroup is killed and the next
       # OnCalendar re-arms. Measured end-to-end against the live store
       # 2026-08-06: ~10s over nebula (the slower path).
-      TimeoutStartSec = 180;
+      #
+      # 180 -> 240 when the checker gained retries: a transient HTTP 500 (the
+      # observed `Code: 241 MEMORY_LIMIT_EXCEEDED`) is now retried with backoff
+      # and the TTL union falls back to one query per table. ch_regrowth.py
+      # bounds that itself with COLLECT_BUDGET_SECONDS = 120 — no new attempt
+      # STARTS past 120s — so the worst case is 120 + one in-flight 30s query +
+      # the `du` exec. 240 leaves margin over that without hiding a real hang.
+      TimeoutStartSec = 240;
       Environment = [
         "PATH=${lib.makeBinPath [ pkgs.python312 pkgs.kubectl pkgs.sops pkgs.bash pkgs.coreutils ]}"
         "KUBECONFIG=%h/workspace/homelab-talos/homelab-kubeconfig"

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -2109,6 +2109,88 @@ in
     };
   };
 
+  # ClickHouse regrowth check for the activity store.
+  #
+  # 2026-08-03 the store was cut 112.4 GB -> 82.1 MB after `system.trace_log`
+  # accumulated 3.77 BILLION rows in ~5 weeks. The fix was a Flux config change
+  # (logger trace -> warning, four query-profiler log tables removed, 7d/14d
+  # TTLs, merge pool 32 -> 8). 🔴 NOBODY WILL NOTICE IF THAT SILENTLY STOPS
+  # WORKING — a revert or a TTL that quietly stops binding reproduces the same
+  # outcome, and the only symptom is a disk filling up months later. Hence a
+  # timer. See scripts/collector/ch_regrowth.py for what is asserted, the
+  # measured baseline behind every threshold, and why every error path is LOUD
+  # rather than a clean-looking zero.
+  #
+  # WORKBENCH-ONLY (gated on serverMode), same discriminator and same rationale
+  # as mail-actions-archive / initiatives-sync above: the committed homelab
+  # kubeconfig points at the LAN API (192.168.50.94:6443) and the `kubectl exec
+  # ... du` reading needs it. The laptop is nebula-only AND has an open,
+  # unresolved nebula fault that makes these ClickHouse queries intermittently
+  # stall to timeout (claudedocs/handoff-agent-setup-audit.md, investigation 1)
+  # — a check that flakes is a check that gets ignored, which is the exact
+  # failure mode this is built to avoid. A laptop run is still possible BY HAND:
+  # KUBECONFIG=~/.kube/homelab-nebula.yaml CH_REGROWTH_URL=http://10.42.0.10:30123
+  # scripts/collector/run-regrowth-check.sh
+  #
+  # NOTIFICATION: no new mechanism. The wrapper exits non-zero for ALARM (1),
+  # CANNOT-TELL (2) and WARN (3), so any of the three is a unit failure and the
+  # existing OnFailure=notify-failure@%n.service turns it into a sticky critical
+  # toast (scripts/notify-failure.sh). The verdict — including every number it
+  # read — is also written to ~/.cache/ch-regrowth/status.json for after the
+  # fact. `SuccessExitStatus` is deliberately NOT set: exit 2 ("cannot tell")
+  # must toast too, because a check that could not measure is not a clean store.
+  #
+  # Minimal user-unit env, so PATH is explicit: python312 (the checker), kubectl
+  # (the du exec), sops (the run-time admin-password decrypt), bash/coreutils.
+  systemd.user.services.ch-regrowth-check = lib.mkIf serverMode {
+    Unit = {
+      Description = "ClickHouse regrowth check for the activity store (read-only)";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+      OnFailure = [ "notify-failure@%n.service" ];
+    };
+    Service = {
+      Type = "oneshot";
+      # Hard ceiling: three SELECTs and one `kubectl exec du`. A half-hung
+      # kubectl must not wedge the timer — the cgroup is killed and the next
+      # OnCalendar re-arms. Measured end-to-end against the live store
+      # 2026-08-06: ~10s over nebula (the slower path).
+      TimeoutStartSec = 180;
+      Environment = [
+        "PATH=${lib.makeBinPath [ pkgs.python312 pkgs.kubectl pkgs.sops pkgs.bash pkgs.coreutils ]}"
+        "KUBECONFIG=%h/workspace/homelab-talos/homelab-kubeconfig"
+        "HOME=%h"
+      ];
+      ExecStart = "${pkgs.bash}/bin/bash %h/workspace/devrc/scripts/collector/run-regrowth-check.sh";
+      # Re-run the unit when either half of the check changes.
+      X-Restart-Triggers = [
+        "${../scripts/collector/run-regrowth-check.sh}"
+        "${../scripts/collector/ch_regrowth.py}"
+      ];
+    };
+  };
+
+  # Monthly on the 11th. The date is not arbitrary: the 7-day TTLs first have
+  # anything to act on around 2026-08-10 (no TTL had fired even ONCE when this
+  # was written — every row was younger than its own TTL), so the first firing
+  # on 2026-08-11 is the first run that can observe the bounding mechanism
+  # actually working, and monthly is the steady state after that.
+  # Persistent=true so a run missed with the host off fires on next boot —
+  # which matters precisely because the growth is slow and unattended.
+  systemd.user.timers.ch-regrowth-check = lib.mkIf serverMode {
+    Unit = {
+      Description = "Monthly timer for the ClickHouse regrowth check";
+    };
+    Timer = {
+      OnCalendar = "*-*-11 09:00:00";
+      Persistent = true;
+      RandomizedDelaySec = 900;
+    };
+    Install = {
+      WantedBy = [ "timers.target" ];
+    };
+  };
+
   # Post-reboot claude session restore — fires ~45s after login so
   # tmux-continuum has time to restore the session layout first, then this
   # service resumes claude conversations in each window.  Idempotent: skips

--- a/scripts/collector/ch_regrowth.py
+++ b/scripts/collector/ch_regrowth.py
@@ -1,0 +1,826 @@
+#!/usr/bin/env python3
+"""Regrowth check for the homelab ClickHouse behind `activity.events`.
+
+WHY THIS EXISTS
+---------------
+2026-08-03: the store was cut from **112.4 GB -> 82.1 MB**. The cause was
+`system.trace_log` — 3.77 BILLION rows accumulated in ~5 weeks because the
+server logger was at `trace` and the query-profiler log tables had no TTL.
+
+Two fixes landed:
+  A1  TRUNCATE (one-time, done).
+  A2  a Flux change to the ClickHouse config: logger trace -> warning;
+      `text_log` / `trace_log` / `latency_log` / `processors_profile_log`
+      REMOVED; 7d TTLs on `metric_log` / `asynchronous_metric_log`, 14d on
+      `query_log` / `part_log`; background merge pool 32 -> 8 slots.
+
+🔴 NOBODY WILL NOTICE IF A2 SILENTLY STOPS WORKING. That is the entire reason
+this file exists. A config revert, a chart bump that restores the upstream
+defaults, or a TTL that quietly stops binding all reproduce the same 112 GB
+outcome, and the only symptom is a disk filling up months later. So this runs on
+a timer and is LOUD on failure.
+
+MEASURED BASELINE (read-only, 2026-08-06, ~3 days post-fix)
+-----------------------------------------------------------
+  du -sk /var/lib/clickhouse/store    541,224 KiB  (528.5 MiB)
+  sum of system.tables total_bytes    ~207 MiB
+  tables in system.tables (non-schema) 120
+  non-empty tables                     7 -- metric_log 86.7 MB / 306k rows,
+                                       asynchronous_metric_log 75.6 MB / 70.5M,
+                                       activity.events 34.3 MB / 527k,
+                                       query_log 6.8 MB, part_log 4.1 MB,
+                                       error_log 1.8 MB, query_metric_log 600 KB
+  tables named `%_0`                   0
+  trace_log/text_log/latency_log/processors_profile_log   ABSENT
+  oldest row (metric_log/part_log/asynchronous_metric_log) ~3.55 days
+
+🔴 THE `du` GAP IS NOT A LEAK. `du` sits persistently ~40% above the live
+`total_bytes` sum because the merge pool was cut 32 -> 8, so inactive parts are
+cleaned more slowly. Do NOT re-derive an alarm from that gap; the thresholds
+below are on `du` itself, sized against the projected steady state of
+~400 MiB live / ~550-700 MiB of `du`.
+
+🔴 NO TTL HAD FIRED EVEN ONCE when this check was written — every system-log row
+was younger than its own 7-day TTL. The mechanism that is supposed to bound
+growth had NEVER been observed working. First real evidence: 2026-08-10 (7d) and
+2026-08-17 (14d). Check 5 below is the only one that tests the MECHANISM rather
+than today's outcome, and it is the one that matters on those dates.
+
+WHAT IS ASSERTED
+----------------
+  1. du(/var/lib/clickhouse/store) > 2 GiB -> ALARM; > 1 GiB -> WARN.
+  2. any table named `%_0` -> ALARM. Applying a `<ttl>` to a `*_log` makes
+     ClickHouse RENAME the old table to `<name>_0` and start a fresh one. The
+     renamed table KEEPS ITS ROWS WITH NO TTL, FOREVER — a silent regrowth
+     vector that looks like nothing at all. Baseline is 0.
+  3. `trace_log` / `text_log` / `latency_log` / `processors_profile_log` exists
+     -> ALARM. A config revert is the likeliest cause and IS the 112 GB
+     mechanism.
+  4. any single table > 250 MiB -> ALARM.
+  5. TTL EFFECTIVENESS: min(event_time) younger than TTL + 1 day, per table
+     (metric_log / asynchronous_metric_log: 8d; query_log / part_log: 15d).
+     Rows older than the TTL surviving means the TTL is not binding.
+
+🔴 A ZERO FROM A BROKEN CLIENT MUST NEVER READ AS A CLEAN STORE
+---------------------------------------------------------------
+Every reassuring answer this check can give is a ZERO — zero orphans, zero
+forbidden tables, zero oversized tables. A zero is exactly what a mistyped table
+name, a failed auth, a missing pod or a harness wired to nothing also produces.
+So, following `deadman.py`:
+
+  * Every non-evaluable condition gets its OWN state and none of them is `ok`:
+    `not-configured`, `unreachable`, `query-failed`, `exec-failed`, `no-data`.
+    There is no code path on which an error produces a healthy verdict.
+  * `ok` carries POSITIVE CONTROLS. The verdict refuses to be `ok` unless the
+    read demonstrably CAN observe the things it is counting:
+      - the listing came back non-empty, AND
+      - the SENTINEL table `activity.events` is in it (proves we read the right
+        server, not an empty/other one), AND
+      - suffix matching found >0 tables ending `_log` (proves the exact
+        code path used for the `_0` orphan test can match at all), AND
+      - the size comparison found >0 tables over PROBE_BYTES (1 MiB) (proves
+        the byte comparison used for the 250 MiB test can fire at all), AND
+      - at least one TTL target table was actually measured.
+    Each control's OBSERVED NUMBER is reported next to the zero it validates,
+    so the output reads "9 tables over 1 MiB / 0 over 250 MiB" rather than a
+    bare "0". A zero alone is never presented as evidence.
+
+READ-ONLY. This module issues SELECTs and one `du`. No TTL change, no TRUNCATE,
+no DROP, no INSERT — there is no write path in this file.
+
+CLI
+---
+    python3 ch_regrowth.py                  # live check, human table
+    python3 ch_regrowth.py --json
+    python3 ch_regrowth.py --reading FILE   # evaluate a captured/seeded reading
+                                            #   (the control harness: seed a
+                                            #   bad store and watch it go RED)
+    python3 ch_regrowth.py --capture FILE   # live read -> save the raw reading
+
+Exit codes: 0 = ok · 1 = ALARM · 2 = CANNOT TELL · 3 = WARN.
+Every non-zero code is a systemd unit failure, which the existing
+`OnFailure=notify-failure@%n.service` turns into a sticky critical toast. That
+includes 2: "cannot tell" is louder than silence, on purpose.
+Never raises.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+# --------------------------------------------------------------------------- #
+# Thresholds. Each is sized against the measured baseline in the docstring.
+# --------------------------------------------------------------------------- #
+MIB = 1024 ** 2
+GIB = 1024 ** 3
+
+# du(store). Measured 528.5 MiB at +3d; projected steady state 550-700 MiB.
+# 1 GiB is ~1.5x the top of that projection (leading indicator, not yet a
+# problem); 2 GiB is ~3x it and cannot be reached by normal operation.
+DU_WARN_BYTES = 1 * GIB
+DU_ALARM_BYTES = 2 * GIB
+
+# Largest live table measured 86.7 MiB (metric_log). 250 MiB is ~3x that and
+# below anything that could plausibly be a healthy system log under the 7d TTL.
+TABLE_ALARM_BYTES = 250 * MIB
+
+# POSITIVE CONTROL for the size comparison: a threshold that MUST match. 7
+# tables were over 1 MiB at baseline. If nothing clears this, the byte
+# comparison is not observing anything and the 250 MiB zero means nothing.
+TABLE_PROBE_BYTES = 1 * MIB
+
+# The four tables A2 removed. Any of them existing again = config revert.
+FORBIDDEN_TABLES = ("trace_log", "text_log", "latency_log",
+                    "processors_profile_log")
+FORBIDDEN_DATABASE = "system"
+
+# Orphan suffix left behind when a TTL is applied to an existing *_log table.
+ORPHAN_SUFFIX = "_0"
+# POSITIVE CONTROL for suffix matching: 14 tables ended in `_log` at baseline.
+PROBE_SUFFIX = "_log"
+
+# POSITIVE CONTROL for "we read the right server". This table is the entire
+# point of the store; if it is missing, the read is not trustworthy.
+SENTINEL_TABLE = ("activity", "events")
+
+# TTL + 1 day of slack (ClickHouse evaluates TTL during merges, not instantly).
+TTL_MAX_AGE_DAYS = {
+    "metric_log": 8,                  # 7d TTL
+    "asynchronous_metric_log": 8,     # 7d TTL
+    "query_log": 15,                  # 14d TTL
+    "part_log": 15,                   # 14d TTL
+}
+TTL_DATABASE = "system"
+
+STORE_PATH = "/var/lib/clickhouse/store"
+DEFAULT_NAMESPACE = "activity"
+DEFAULT_WORKLOAD = "deploy/clickhouse"
+DEFAULT_CONTAINER = "clickhouse"
+DEFAULT_TIMEOUT = 30.0
+DEFAULT_STATUS_PATH = "~/.cache/ch-regrowth/status.json"
+
+STATE_OK = "ok"
+STATE_WARN = "warn"
+STATE_ALARM = "alarm"
+STATE_NO_DATA = "no-data"
+STATE_UNREACHABLE = "unreachable"
+STATE_QUERY_FAILED = "query-failed"
+STATE_EXEC_FAILED = "exec-failed"
+STATE_NOT_CONFIGURED = "not-configured"
+
+# 🔴 Every state that is NOT a measurement of the store. None of these is `ok`
+# and none of them exits 0.
+UNKNOWN_STATES = frozenset((STATE_NO_DATA, STATE_UNREACHABLE,
+                            STATE_QUERY_FAILED, STATE_EXEC_FAILED,
+                            STATE_NOT_CONFIGURED))
+
+EXIT_OK = 0
+EXIT_ALARM = 1
+EXIT_UNKNOWN = 2
+EXIT_WARN = 3
+
+
+# --------------------------------------------------------------------------- #
+# Queries
+# --------------------------------------------------------------------------- #
+def listing_query() -> str:
+    """Every table on the server, with rows + on-disk bytes.
+
+    ONE query drives checks 2, 3 and 4 plus all three listing positive
+    controls — deliberately, so a single successful read either validates all
+    of them or fails all of them together. Separate per-check queries would let
+    one silently return nothing while the others looked fine.
+
+    `ifNull(...)` because views/system engines report NULL bytes; they are kept
+    in the listing anyway so an orphan of ANY engine is still caught.
+    """
+    return (
+        "SELECT database, name, engine, ifNull(total_rows, 0), "
+        "ifNull(total_bytes, 0) "
+        "FROM system.tables "
+        "WHERE database NOT IN ('INFORMATION_SCHEMA', 'information_schema') "
+        "ORDER BY ifNull(total_bytes, 0) DESC FORMAT TSV"
+    )
+
+
+def now_query() -> str:
+    """Server clock. Ages are measured against the SERVER, never the host, so a
+    skewed workbench clock cannot manufacture or hide a stale-TTL alarm."""
+    return "SELECT toUnixTimestamp(now()) FORMAT TSV"
+
+
+def ttl_query(present_tables) -> str:
+    """min(event_time) per TTL target, restricted to targets actually present.
+
+    Built from the listing rather than hardcoded: querying a table that does not
+    exist errors the WHOLE union, which would turn a legitimately-absent table
+    into `query-failed` for every other one.
+    """
+    parts = []
+    for name in sorted(present_tables):
+        parts.append(
+            "SELECT '%s' AS t, count() AS c, "
+            "toUnixTimestamp(min(event_time)) AS m FROM %s.%s"
+            % (name, TTL_DATABASE, name)
+        )
+    return " UNION ALL ".join(parts) + " FORMAT TSV"
+
+
+def du_argv(namespace: str = DEFAULT_NAMESPACE,
+            workload: str = DEFAULT_WORKLOAD,
+            container: str = DEFAULT_CONTAINER,
+            path: str = STORE_PATH):
+    """`du -sk`, NOT `du -sb`: the server image is alpine/busybox and busybox du
+    has no `-b`. `-k` (KiB) is portable across busybox and coreutils. Verified
+    against the live pod 2026-08-06."""
+    return ["kubectl", "-n", namespace, "exec", workload, "-c", container,
+            "--", "du", "-sk", path]
+
+
+# --------------------------------------------------------------------------- #
+# Parsing
+# --------------------------------------------------------------------------- #
+def parse_listing(text: str):
+    rows = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        f = line.split("\t")
+        if len(f) < 5:
+            raise ValueError("listing row has %d fields, want 5: %r"
+                             % (len(f), line[:120]))
+        rows.append({"database": f[0], "name": f[1], "engine": f[2],
+                     "rows": int(f[3]), "bytes": int(f[4])})
+    return rows
+
+
+def parse_ttl(text: str):
+    out = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        f = line.split("\t")
+        if len(f) < 3:
+            raise ValueError("ttl row has %d fields, want 3: %r"
+                             % (len(f), line[:120]))
+        out.append({"table": f[0], "rows": int(f[1]),
+                    "min_event_ts": int(f[2])})
+    return out
+
+
+def parse_du_kib(text: str) -> int:
+    """`du -sk` prints `<kib>\\t<path>`. Returns BYTES."""
+    first = text.strip().split("\n")[0]
+    field = first.split()[0]
+    return int(field) * 1024
+
+
+def human_bytes(n) -> str:
+    if n is None:
+        return "-"
+    n = float(n)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if abs(n) < 1024.0 or unit == "TiB":
+            return "%.1f %s" % (n, unit) if unit != "B" else "%d B" % n
+        n /= 1024.0
+    return "%.1f TiB" % n
+
+
+# --------------------------------------------------------------------------- #
+# Evaluation — PURE. Takes a reading, returns a verdict. No I/O, never raises.
+# --------------------------------------------------------------------------- #
+def evaluate(reading, now=None) -> dict:
+    """Evaluate a reading dict:
+
+        {"du_bytes": int, "tables": [...], "ttl": [...], "server_now": int}
+
+    Returns a verdict dict. `now` overrides the clock for tests.
+    """
+    findings = []
+    tables = list(reading.get("tables") or [])
+    ttl_rows = list(reading.get("ttl") or [])
+    du_bytes = reading.get("du_bytes")
+    now = (now if now is not None
+           else reading.get("server_now") or int(time.time()))
+
+    # ---- POSITIVE CONTROLS -------------------------------------------------
+    # Computed FIRST and reported alongside every zero they validate.
+    tables_seen = len(tables)
+    sentinel_present = any(t["database"] == SENTINEL_TABLE[0]
+                           and t["name"] == SENTINEL_TABLE[1] for t in tables)
+    probe_suffix = [qualify(t) for t in tables
+                    if t["name"].endswith(PROBE_SUFFIX)]
+    probe_size = [qualify(t) for t in tables
+                  if t["bytes"] > TABLE_PROBE_BYTES]
+
+    controls = {
+        "tables_seen": tables_seen,
+        "sentinel": "%s.%s" % SENTINEL_TABLE,
+        "sentinel_present": sentinel_present,
+        "probe_suffix_pattern": "*%s" % PROBE_SUFFIX,
+        "probe_suffix_matches": len(probe_suffix),
+        "probe_size_threshold": TABLE_PROBE_BYTES,
+        "probe_size_matches": len(probe_size),
+        "ttl_tables_measured": 0,   # filled in below
+    }
+
+    # ---- 1. store size -----------------------------------------------------
+    if du_bytes is None:
+        return _unknown(STATE_EXEC_FAILED,
+                        "no du reading — store size was never measured",
+                        controls=controls)
+    if du_bytes >= DU_ALARM_BYTES:
+        findings.append({
+            "check": "store-size", "level": "alarm",
+            "detail": "du(%s) = %s >= alarm threshold %s"
+                      % (STORE_PATH, human_bytes(du_bytes),
+                         human_bytes(DU_ALARM_BYTES)),
+            "observed": du_bytes, "threshold": DU_ALARM_BYTES})
+    elif du_bytes >= DU_WARN_BYTES:
+        findings.append({
+            "check": "store-size", "level": "warn",
+            "detail": "du(%s) = %s >= warn threshold %s"
+                      % (STORE_PATH, human_bytes(du_bytes),
+                         human_bytes(DU_WARN_BYTES)),
+            "observed": du_bytes, "threshold": DU_WARN_BYTES})
+
+    # ---- listing-derived checks need a listing we can trust ----------------
+    if tables_seen == 0:
+        return _unknown(STATE_NO_DATA,
+                        "table listing came back EMPTY — cannot distinguish a "
+                        "clean store from a failed read",
+                        controls=controls, du_bytes=du_bytes)
+    if not sentinel_present:
+        return _unknown(STATE_NO_DATA,
+                        "sentinel table %s.%s absent from a %d-row listing — "
+                        "this is not the activity store, or the read is wrong"
+                        % (SENTINEL_TABLE[0], SENTINEL_TABLE[1], tables_seen),
+                        controls=controls, du_bytes=du_bytes)
+    if not probe_suffix:
+        return _unknown(STATE_NO_DATA,
+                        "positive control FAILED: 0 tables end in '%s' in a "
+                        "%d-row listing, so the suffix match used for the '%s' "
+                        "orphan test is not observing anything — its zero is "
+                        "meaningless"
+                        % (PROBE_SUFFIX, tables_seen, ORPHAN_SUFFIX),
+                        controls=controls, du_bytes=du_bytes)
+    if not probe_size:
+        return _unknown(STATE_NO_DATA,
+                        "positive control FAILED: 0 tables exceed %s in a "
+                        "%d-row listing, so the byte comparison used for the "
+                        "%s test is not observing anything — its zero is "
+                        "meaningless"
+                        % (human_bytes(TABLE_PROBE_BYTES), tables_seen,
+                           human_bytes(TABLE_ALARM_BYTES)),
+                        controls=controls, du_bytes=du_bytes)
+
+    # ---- 2. `%_0` orphan tables -------------------------------------------
+    orphans = [qualify(t) for t in tables
+               if t["name"].endswith(ORPHAN_SUFFIX)]
+    if orphans:
+        findings.append({
+            "check": "orphan-tables", "level": "alarm",
+            "detail": "%d table(s) named '*%s' exist: %s — applying a TTL "
+                      "RENAMES the old table aside and it then keeps its rows "
+                      "with NO TTL forever"
+                      % (len(orphans), ORPHAN_SUFFIX, ", ".join(orphans)),
+            "observed": orphans})
+
+    # ---- 3. forbidden log tables resurrected -------------------------------
+    forbidden = [qualify(t) for t in tables
+                 if t["database"] == FORBIDDEN_DATABASE
+                 and t["name"] in FORBIDDEN_TABLES]
+    if forbidden:
+        findings.append({
+            "check": "forbidden-tables", "level": "alarm",
+            "detail": "%d removed log table(s) exist again: %s — likeliest "
+                      "cause is a ClickHouse config revert, which IS the "
+                      "112 GB mechanism"
+                      % (len(forbidden), ", ".join(forbidden)),
+            "observed": forbidden})
+
+    # ---- 4. oversized single table -----------------------------------------
+    oversized = [{"table": qualify(t), "bytes": t["bytes"], "rows": t["rows"]}
+                 for t in tables if t["bytes"] > TABLE_ALARM_BYTES]
+    if oversized:
+        findings.append({
+            "check": "table-size", "level": "alarm",
+            "detail": "%d table(s) exceed %s: %s"
+                      % (len(oversized), human_bytes(TABLE_ALARM_BYTES),
+                         ", ".join("%s (%s)" % (o["table"],
+                                                human_bytes(o["bytes"]))
+                                   for o in oversized)),
+            "observed": oversized})
+
+    # ---- 5. TTL effectiveness ----------------------------------------------
+    # The ONLY check that tests the MECHANISM. If a row older than the TTL is
+    # still there, the TTL is not binding and the store WILL regrow.
+    present_targets = sorted(
+        t["name"] for t in tables
+        if t["database"] == TTL_DATABASE and t["name"] in TTL_MAX_AGE_DAYS)
+    ttl_report = []
+    measured = 0
+    by_name = {r["table"]: r for r in ttl_rows}
+    for name in present_targets:
+        row = by_name.get(name)
+        if row is None:
+            ttl_report.append({"table": name, "rows": None,
+                               "age_days": None,
+                               "max_age_days": TTL_MAX_AGE_DAYS[name],
+                               "stale": False, "reason": "not-queried"})
+            continue
+        if row["rows"] == 0:
+            # An empty table has no oldest row; min() would report the epoch.
+            # Not evidence either way — and NOT counted as measured.
+            ttl_report.append({"table": name, "rows": 0, "age_days": None,
+                               "max_age_days": TTL_MAX_AGE_DAYS[name],
+                               "stale": False, "reason": "empty"})
+            continue
+        age_days = (now - row["min_event_ts"]) / 86400.0
+        stale = age_days > TTL_MAX_AGE_DAYS[name]
+        measured += 1
+        ttl_report.append({"table": name, "rows": row["rows"],
+                           "age_days": round(age_days, 2),
+                           "max_age_days": TTL_MAX_AGE_DAYS[name],
+                           "stale": stale, "reason": "measured"})
+        if stale:
+            findings.append({
+                "check": "ttl-effectiveness", "level": "alarm",
+                "detail": "%s.%s oldest row is %.2f days old, past its %d-day "
+                          "bound — the TTL is NOT binding"
+                          % (TTL_DATABASE, name, age_days,
+                             TTL_MAX_AGE_DAYS[name]),
+                "observed": {"table": name, "age_days": round(age_days, 2),
+                             "max_age_days": TTL_MAX_AGE_DAYS[name],
+                             "rows": row["rows"]}})
+
+    controls["ttl_tables_measured"] = measured
+    if measured == 0:
+        return _unknown(STATE_NO_DATA,
+                        "positive control FAILED: 0 of %d TTL target table(s) "
+                        "yielded a measurable oldest row, so the TTL check "
+                        "proved nothing — a clean verdict here would be a "
+                        "harness reporting on itself"
+                        % len(present_targets),
+                        controls=controls, du_bytes=du_bytes,
+                        tables_total_bytes=sum(t["bytes"] for t in tables),
+                        ttl=ttl_report)
+
+    alarms = sum(1 for f in findings if f["level"] == "alarm")
+    warns = sum(1 for f in findings if f["level"] == "warn")
+    state = STATE_ALARM if alarms else (STATE_WARN if warns else STATE_OK)
+
+    largest = max(tables, key=lambda t: t["bytes"])
+    return {
+        "state": state,
+        "alarms": alarms,
+        "warns": warns,
+        "findings": findings,
+        "controls": controls,
+        "measurements": {
+            "du_bytes": du_bytes,
+            "du_human": human_bytes(du_bytes),
+            "tables_total_bytes": sum(t["bytes"] for t in tables),
+            "tables_seen": tables_seen,
+            "non_empty_tables": sum(1 for t in tables if t["bytes"] > 0),
+            "largest_table": qualify(largest),
+            "largest_table_bytes": largest["bytes"],
+            "orphan_count": len(orphans),
+            "forbidden_count": len(forbidden),
+            "oversized_count": len(oversized),
+            "ttl": ttl_report,
+        },
+        "detail": _summarize(state, findings, du_bytes, controls),
+    }
+
+
+def qualify(t) -> str:
+    return "%s.%s" % (t["database"], t["name"])
+
+
+def _summarize(state, findings, du_bytes, controls) -> str:
+    if state == STATE_OK:
+        # 🔴 Report the CONTROL NUMBER next to every zero it validates. A bare
+        # "0 orphans" is indistinguishable from a check wired to nothing.
+        return ("store %s; 0 orphan '*%s' tables (control: %d tables matched "
+                "'*%s'); 0 forbidden log tables; 0 tables over %s (control: %d "
+                "tables over %s); %d TTL target(s) measured, all within bound"
+                % (human_bytes(du_bytes), ORPHAN_SUFFIX,
+                   controls["probe_suffix_matches"], PROBE_SUFFIX,
+                   human_bytes(TABLE_ALARM_BYTES),
+                   controls["probe_size_matches"],
+                   human_bytes(TABLE_PROBE_BYTES),
+                   controls["ttl_tables_measured"]))
+    return "; ".join(f["detail"] for f in findings)
+
+
+def _unknown(state, detail, *, controls=None, du_bytes=None, **extra) -> dict:
+    v = {
+        "state": state,
+        "alarms": 0,
+        "warns": 0,
+        "findings": [],
+        "controls": controls or {},
+        "measurements": {"du_bytes": du_bytes,
+                         "du_human": human_bytes(du_bytes)},
+        "detail": detail,
+    }
+    v["measurements"].update(extra)
+    return v
+
+
+# --------------------------------------------------------------------------- #
+# Collection
+# --------------------------------------------------------------------------- #
+def http_query(url: str, user: str, password: str, query: str,
+               timeout: float = DEFAULT_TIMEOUT) -> str:
+    """POST a SELECT to ClickHouse over HTTP.
+
+    Credentials go in the Authorization header, NEVER in argv — a password on a
+    command line lands in the process list and shell history.
+    """
+    req = urllib.request.Request(url.rstrip("/") + "/",
+                                 data=query.encode("utf-8"), method="POST")
+    import base64
+    token = base64.b64encode(("%s:%s" % (user, password)).encode()).decode()
+    req.add_header("Authorization", "Basic " + token)
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return r.read().decode("utf-8", "replace")
+
+
+def run_du(argv, timeout: float = DEFAULT_TIMEOUT) -> str:
+    p = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+    if p.returncode != 0:
+        raise RuntimeError("exit %d: %s"
+                           % (p.returncode,
+                              (p.stderr or p.stdout).strip()[:200]))
+    return p.stdout
+
+
+def resolve_config(env=None) -> dict:
+    env = os.environ if env is None else env
+    return {
+        "url": env.get("CH_REGROWTH_URL") or env.get("CLICKHOUSE_URL") or "",
+        "user": env.get("CH_REGROWTH_USER")
+        or env.get("CLICKHOUSE_USER") or "default",
+        "password": env.get("CH_REGROWTH_PASSWORD")
+        or env.get("CLICKHOUSE_PASSWORD") or "",
+        "namespace": env.get("CH_REGROWTH_NAMESPACE", DEFAULT_NAMESPACE),
+        "workload": env.get("CH_REGROWTH_WORKLOAD", DEFAULT_WORKLOAD),
+        "container": env.get("CH_REGROWTH_CONTAINER", DEFAULT_CONTAINER),
+    }
+
+
+def collect(env=None, timeout: float = DEFAULT_TIMEOUT,
+            query=None, du=None) -> dict:
+    """Take a live reading. Returns {"reading": {...}} or {"error": (state, detail)}.
+
+    `query(url, user, password, sql, timeout) -> str` and `du(argv, timeout)
+    -> str` are injectable so EVERY failure branch is testable offline. Never
+    raises.
+    """
+    cfg = resolve_config(env)
+    query = query or http_query
+    du = du or run_du
+
+    if not cfg["url"] or not cfg["password"]:
+        missing = []
+        if not cfg["url"]:
+            missing.append("CH_REGROWTH_URL")
+        if not cfg["password"]:
+            missing.append("CH_REGROWTH_PASSWORD")
+        return {"error": (STATE_NOT_CONFIGURED,
+                          "missing %s — the check cannot run, and MUST NOT "
+                          "report a clean store" % "/".join(missing))}
+
+    def _q(sql):
+        return query(cfg["url"], cfg["user"], cfg["password"], sql, timeout)
+
+    # --- server clock (also the liveness probe) ---
+    try:
+        now_text = _q(now_query())
+    except Exception as e:  # noqa: BLE001 — an unreachable server is NOT clean
+        return {"error": (STATE_UNREACHABLE,
+                          "ClickHouse unreachable: %s" % str(e)[:200])}
+    try:
+        server_now = int(now_text.strip().split("\n")[0])
+    except Exception as e:  # noqa: BLE001
+        return {"error": (STATE_QUERY_FAILED,
+                          "unparseable now() response: %s" % str(e)[:200])}
+
+    # --- table listing ---
+    try:
+        listing_text = _q(listing_query())
+    except Exception as e:  # noqa: BLE001
+        return {"error": (STATE_UNREACHABLE,
+                          "listing query failed: %s" % str(e)[:200])}
+    try:
+        tables = parse_listing(listing_text)
+    except Exception as e:  # noqa: BLE001
+        return {"error": (STATE_QUERY_FAILED,
+                          "unparseable listing: %s" % str(e)[:200])}
+
+    # --- TTL ages, for the targets that actually exist ---
+    present = sorted(t["name"] for t in tables
+                     if t["database"] == TTL_DATABASE
+                     and t["name"] in TTL_MAX_AGE_DAYS)
+    ttl_rows = []
+    if present:
+        try:
+            ttl_text = _q(ttl_query(present))
+        except Exception as e:  # noqa: BLE001
+            return {"error": (STATE_UNREACHABLE,
+                              "ttl query failed: %s" % str(e)[:200])}
+        try:
+            ttl_rows = parse_ttl(ttl_text)
+        except Exception as e:  # noqa: BLE001
+            return {"error": (STATE_QUERY_FAILED,
+                              "unparseable ttl response: %s" % str(e)[:200])}
+
+    # --- du(store) via kubectl exec ---
+    argv = du_argv(cfg["namespace"], cfg["workload"], cfg["container"])
+    try:
+        du_text = du(argv, timeout)
+    except Exception as e:  # noqa: BLE001 — a failed exec is NOT a small store
+        return {"error": (STATE_EXEC_FAILED,
+                          "kubectl exec du failed: %s" % str(e)[:200])}
+    try:
+        du_bytes = parse_du_kib(du_text)
+    except Exception as e:  # noqa: BLE001
+        return {"error": (STATE_EXEC_FAILED,
+                          "unparseable du output: %s" % str(e)[:200])}
+
+    return {"reading": {"du_bytes": du_bytes, "tables": tables,
+                        "ttl": ttl_rows, "server_now": server_now,
+                        "captured_at": int(time.time())}}
+
+
+def check(env=None, now=None, timeout: float = DEFAULT_TIMEOUT,
+          query=None, du=None) -> dict:
+    """Full live check. Returns a verdict; NEVER raises and NEVER returns `ok`
+    on any error path."""
+    got = collect(env=env, timeout=timeout, query=query, du=du)
+    if "error" in got:
+        state, detail = got["error"]
+        return _unknown(state, detail)
+    return evaluate(got["reading"], now=now)
+
+
+# --------------------------------------------------------------------------- #
+# Output
+# --------------------------------------------------------------------------- #
+def exit_code(verdict) -> int:
+    state = verdict["state"]
+    if state in UNKNOWN_STATES:
+        return EXIT_UNKNOWN
+    if state == STATE_ALARM:
+        return EXIT_ALARM
+    if state == STATE_WARN:
+        return EXIT_WARN
+    return EXIT_OK
+
+
+def render_text(v: dict) -> str:
+    m = v.get("measurements", {})
+    c = v.get("controls", {})
+    lines = [
+        "ch-regrowth: %s   alarms=%d warns=%d"
+        % (v["state"].upper(), v.get("alarms", 0), v.get("warns", 0)),
+        "detail: %s" % v.get("detail", ""),
+        "",
+        "store du:        %s (warn %s / alarm %s)"
+        % (m.get("du_human", "-"), human_bytes(DU_WARN_BYTES),
+           human_bytes(DU_ALARM_BYTES)),
+    ]
+    if m.get("tables_total_bytes") is not None:
+        lines.append("live table bytes: %s  (du sits ~40%% higher by design — "
+                     "8-slot merge pool leaves inactive parts around)"
+                     % human_bytes(m["tables_total_bytes"]))
+    if m.get("tables_seen") is not None:
+        lines.append("tables:          %s seen, %s non-empty, largest %s (%s)"
+                     % (m.get("tables_seen"), m.get("non_empty_tables"),
+                        m.get("largest_table"),
+                        human_bytes(m.get("largest_table_bytes"))))
+        lines.append("counts:          orphan '*%s'=%s  forbidden=%s  over %s=%s"
+                     % (ORPHAN_SUFFIX, m.get("orphan_count"),
+                        m.get("forbidden_count"),
+                        human_bytes(TABLE_ALARM_BYTES),
+                        m.get("oversized_count")))
+    if c:
+        lines.append("")
+        lines.append("positive controls (a zero above is only meaningful if "
+                     "these are non-zero):")
+        lines.append("  listing rows            = %s" % c.get("tables_seen"))
+        lines.append("  sentinel %-14s= %s"
+                     % (c.get("sentinel", "?"), c.get("sentinel_present")))
+        lines.append("  tables matching '%s'  = %s   (vs orphan '*%s' = %s)"
+                     % (c.get("probe_suffix_pattern", "?"),
+                        c.get("probe_suffix_matches"), ORPHAN_SUFFIX,
+                        m.get("orphan_count")))
+        lines.append("  tables over %-11s = %s   (vs over %s = %s)"
+                     % (human_bytes(c.get("probe_size_threshold")),
+                        c.get("probe_size_matches"),
+                        human_bytes(TABLE_ALARM_BYTES),
+                        m.get("oversized_count")))
+        lines.append("  TTL tables measured     = %s"
+                     % c.get("ttl_tables_measured"))
+    if m.get("ttl"):
+        lines.append("")
+        lines.append("%-26s %12s %10s %10s  %s"
+                     % ("ttl target", "rows", "oldest_d", "bound_d", "verdict"))
+        for r in m["ttl"]:
+            lines.append("%-26s %12s %10s %10s  %s"
+                         % (r["table"],
+                            "-" if r["rows"] is None else r["rows"],
+                            "-" if r["age_days"] is None
+                            else "%.2f" % r["age_days"],
+                            r["max_age_days"],
+                            "STALE" if r["stale"] else r.get("reason", "ok")))
+    if v.get("findings"):
+        lines.append("")
+        for f in v["findings"]:
+            lines.append("[%s] %s: %s"
+                         % (f["level"].upper(), f["check"], f["detail"]))
+    return "\n".join(lines)
+
+
+def write_status(verdict, path: str = DEFAULT_STATUS_PATH) -> str:
+    """Atomically write the verdict so it is discoverable after the fact."""
+    p = os.path.expanduser(path)
+    os.makedirs(os.path.dirname(p), exist_ok=True)
+    payload = dict(verdict)
+    payload["checked_at"] = int(time.time())
+    tmp = p + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+    os.replace(tmp, p)
+    return p
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        description="ClickHouse regrowth check for the activity store")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--reading", metavar="FILE",
+                    help="evaluate this captured/seeded reading JSON instead "
+                         "of querying the cluster (the control harness)")
+    ap.add_argument("--capture", metavar="FILE",
+                    help="write the raw live reading here (for seeding tests)")
+    ap.add_argument("--now", type=int, help="override 'now' (unix seconds)")
+    ap.add_argument("--status-file", default=DEFAULT_STATUS_PATH)
+    ap.add_argument("--no-status-file", action="store_true")
+    ap.add_argument("--print-queries", action="store_true")
+    args = ap.parse_args(argv)
+
+    if args.print_queries:
+        sys.stdout.write(now_query() + "\n" + listing_query() + "\n"
+                         + ttl_query(sorted(TTL_MAX_AGE_DAYS)) + "\n")
+        return EXIT_OK
+
+    if args.reading:
+        try:
+            with open(args.reading) as f:
+                reading = json.load(f)
+            verdict = evaluate(reading, now=args.now)
+        except Exception as e:  # noqa: BLE001
+            verdict = _unknown(STATE_QUERY_FAILED,
+                               "unreadable reading file: %s" % str(e)[:200])
+    else:
+        got = collect()
+        if "error" in got:
+            state, detail = got["error"]
+            verdict = _unknown(state, detail)
+        else:
+            if args.capture:
+                with open(args.capture, "w") as f:
+                    json.dump(got["reading"], f, indent=2)
+            verdict = evaluate(got["reading"], now=args.now)
+
+    if not args.no_status_file:
+        try:
+            write_status(verdict, args.status_file)
+        except Exception as e:  # noqa: BLE001 — a status-file failure must not
+            # mask the verdict, but must be visible.
+            sys.stderr.write("ch-regrowth: could not write status file: %s\n"
+                             % str(e)[:200])
+
+    sys.stdout.write((json.dumps(verdict, indent=2, sort_keys=True)
+                      if args.json else render_text(verdict)) + "\n")
+    return exit_code(verdict)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:  # noqa: BLE001 — an unexpected crash is CANNOT TELL
+        sys.stderr.write("ch-regrowth: %s\n" % e)
+        sys.exit(EXIT_UNKNOWN)

--- a/scripts/collector/ch_regrowth.py
+++ b/scripts/collector/ch_regrowth.py
@@ -57,9 +57,35 @@ WHAT IS ASSERTED
      -> ALARM. A config revert is the likeliest cause and IS the 112 GB
      mechanism.
   4. any single table > 250 MiB -> ALARM.
-  5. TTL EFFECTIVENESS: min(event_time) younger than TTL + 1 day, per table
-     (metric_log / asynchronous_metric_log: 8d; query_log / part_log: 15d).
+  5. TTL EFFECTIVENESS: min(event_time) younger than TTL + 3 days, per table
+     (metric_log / asynchronous_metric_log: 10d; query_log / part_log: 17d).
      Rows older than the TTL surviving means the TTL is not binding.
+
+🔴 THE `du` EXIT CODE IS NOT A VERDICT ON THE MEASUREMENT. A live store creates
+and removes `tmp_merge_*` directories constantly, so busybox `du` exits 1 when
+one vanishes mid-walk — WHILE STILL PRINTING THE CORRECT TOTAL on stdout.
+Observed on 3 of 20 live runs. `run_du` therefore parses stdout FIRST and only
+consults the exit code when stdout yields no usable total. Treating exit != 0 as
+fatal turned ~15% of runs into a CANNOT TELL that is indistinguishable from a
+real ALARM, with no measurement at all until the next month.
+
+🔴 A TRANSIENT QUERY FAILURE IS NOT AN ANSWER EITHER. The pod's 2.5 GiB ceiling
+is still reached by background merges, and the TTL union returned `HTTP 500 /
+Code: 241 MEMORY_LIMIT_EXCEEDED` on 2 of 20 live runs. Queries are therefore
+retried (QUERY_ATTEMPTS, backed off), and if the union still fails it falls back
+to ONE QUERY PER TABLE.
+
+🔴 THE RETRY IS THE FIX; THE SPLIT IS A CHEAP EXTRA. Measured against
+`system.query_log` 2026-08-06 over 26 real executions: the union peaks at
+8.44 MB and a per-table query at 4.23 MB — a real ~2x cut, but BOTH are
+rounding error against the 2.5 GiB ceiling. The ceiling was reached by
+BACKGROUND MERGES eating the total budget, not by this query's own footprint.
+So do not expect the split to prevent an OOM; it removes this query as a
+contributor and gives the retry a second, smaller shape to try.
+
+Retries NEVER weaken the fail-closed property: the last attempt re-raises the
+original exception, so an exhausted retry produces a non-`ok` state and exit 2
+exactly as a single attempt did.
 
 🔴 A ZERO FROM A BROKEN CLIENT MUST NEVER READ AS A CLEAN STORE
 ---------------------------------------------------------------
@@ -149,14 +175,34 @@ PROBE_SUFFIX = "_log"
 # point of the store; if it is missing, the read is not trustworthy.
 SENTINEL_TABLE = ("activity", "events")
 
-# TTL + 1 day of slack (ClickHouse evaluates TTL during merges, not instantly).
+# TTL + 3 days of slack. ClickHouse evaluates TTL during MERGES, and TTL deletes
+# ARE merges — run by the same 8-slot pool, inside the same 2.5 GiB budget that
+# has already thrown MEMORY_LIMIT_EXCEEDED. A merge backlog of a few hours is
+# normal operation, not a regrowth signal, and +1 day left only ~0.6 days of
+# margin on the very first scheduled run.
+#
+# 🔴 THIS CANNOT MAKE THE CHECK VACUOUS, because the check runs MONTHLY. A TTL
+# that genuinely stops binding grows the oldest row without bound: by the next
+# run it is ~30+ days old, far past either bound. Widening from TTL+1d to TTL+3d
+# only moves which MERGE LAG is tolerated; it does not move which FAILURE is
+# caught. A permanently-red check nobody believes would be the worse outcome.
 TTL_MAX_AGE_DAYS = {
-    "metric_log": 8,                  # 7d TTL
-    "asynchronous_metric_log": 8,     # 7d TTL
-    "query_log": 15,                  # 14d TTL
-    "part_log": 15,                   # 14d TTL
+    "metric_log": 10,                 # 7d TTL
+    "asynchronous_metric_log": 10,    # 7d TTL
+    "query_log": 17,                  # 14d TTL
+    "part_log": 17,                   # 14d TTL
 }
 TTL_DATABASE = "system"
+
+# Transient-failure retry budget for the HTTP queries. 3 attempts, backed off,
+# is enough to ride out a merge-driven memory spike (the observed failure) while
+# keeping the worst case well inside the systemd start timeout.
+QUERY_ATTEMPTS = 3
+QUERY_BACKOFF_SECONDS = (2.0, 5.0)
+# Wall-clock ceiling on the whole collection, so retries + per-table fallbacks
+# can never approach the unit's TimeoutStartSec (240s). No new attempt STARTS
+# past this; one already in flight can still run out its own `timeout`.
+COLLECT_BUDGET_SECONDS = 120.0
 
 STORE_PATH = "/var/lib/clickhouse/store"
 DEFAULT_NAMESPACE = "activity"
@@ -330,55 +376,32 @@ def evaluate(reading, now=None) -> dict:
         "ttl_tables_measured": 0,   # filled in below
     }
 
+    # 🔴 EVERY CHECK RUNS BEFORE ANY GATE RETURNS. The gates below decide
+    # whether the reading is EVALUABLE; they must not decide what was FOUND.
+    # Running them first destroyed the diagnosis on exactly the reading that
+    # needed it most: rename every `*_log` to `*_log_0` — the orphan regrowth
+    # vector check 2 exists to catch — and nothing ends in `_log` any more, so
+    # the suffix gate returned "0 tables end in `_log`" and the orphans were
+    # never even looked for. The orphan population destroyed its own positive
+    # control. So: accumulate findings first, then gate, and carry the findings
+    # THROUGH the gate. The verdict stays unknown and the exit code stays 2 —
+    # what changes is that the reason is still in the report.
+
     # ---- 1. store size -----------------------------------------------------
-    if du_bytes is None:
-        return _unknown(STATE_EXEC_FAILED,
-                        "no du reading — store size was never measured",
-                        controls=controls)
-    if du_bytes >= DU_ALARM_BYTES:
+    if du_bytes is not None and du_bytes >= DU_ALARM_BYTES:
         findings.append({
             "check": "store-size", "level": "alarm",
             "detail": "du(%s) = %s >= alarm threshold %s"
                       % (STORE_PATH, human_bytes(du_bytes),
                          human_bytes(DU_ALARM_BYTES)),
             "observed": du_bytes, "threshold": DU_ALARM_BYTES})
-    elif du_bytes >= DU_WARN_BYTES:
+    elif du_bytes is not None and du_bytes >= DU_WARN_BYTES:
         findings.append({
             "check": "store-size", "level": "warn",
             "detail": "du(%s) = %s >= warn threshold %s"
                       % (STORE_PATH, human_bytes(du_bytes),
                          human_bytes(DU_WARN_BYTES)),
             "observed": du_bytes, "threshold": DU_WARN_BYTES})
-
-    # ---- listing-derived checks need a listing we can trust ----------------
-    if tables_seen == 0:
-        return _unknown(STATE_NO_DATA,
-                        "table listing came back EMPTY — cannot distinguish a "
-                        "clean store from a failed read",
-                        controls=controls, du_bytes=du_bytes)
-    if not sentinel_present:
-        return _unknown(STATE_NO_DATA,
-                        "sentinel table %s.%s absent from a %d-row listing — "
-                        "this is not the activity store, or the read is wrong"
-                        % (SENTINEL_TABLE[0], SENTINEL_TABLE[1], tables_seen),
-                        controls=controls, du_bytes=du_bytes)
-    if not probe_suffix:
-        return _unknown(STATE_NO_DATA,
-                        "positive control FAILED: 0 tables end in '%s' in a "
-                        "%d-row listing, so the suffix match used for the '%s' "
-                        "orphan test is not observing anything — its zero is "
-                        "meaningless"
-                        % (PROBE_SUFFIX, tables_seen, ORPHAN_SUFFIX),
-                        controls=controls, du_bytes=du_bytes)
-    if not probe_size:
-        return _unknown(STATE_NO_DATA,
-                        "positive control FAILED: 0 tables exceed %s in a "
-                        "%d-row listing, so the byte comparison used for the "
-                        "%s test is not observing anything — its zero is "
-                        "meaningless"
-                        % (human_bytes(TABLE_PROBE_BYTES), tables_seen,
-                           human_bytes(TABLE_ALARM_BYTES)),
-                        controls=controls, du_bytes=du_bytes)
 
     # ---- 2. `%_0` orphan tables -------------------------------------------
     orphans = [qualify(t) for t in tables
@@ -461,6 +484,45 @@ def evaluate(reading, now=None) -> dict:
                              "rows": row["rows"]}})
 
     controls["ttl_tables_measured"] = measured
+
+    # ---- GATES: is this reading EVALUABLE at all? --------------------------
+    # Each carries `findings` so a diagnosis already made is not thrown away.
+    # The state stays a CANNOT-TELL state and `exit_code` still returns 2 —
+    # the goal is preserving what was seen, not upgrading the verdict.
+    gate_extra = {"controls": controls, "du_bytes": du_bytes,
+                  "findings": findings}
+    if du_bytes is None:
+        return _unknown(STATE_EXEC_FAILED,
+                        "no du reading — store size was never measured",
+                        **gate_extra)
+    if tables_seen == 0:
+        return _unknown(STATE_NO_DATA,
+                        "table listing came back EMPTY — cannot distinguish a "
+                        "clean store from a failed read",
+                        **gate_extra)
+    if not sentinel_present:
+        return _unknown(STATE_NO_DATA,
+                        "sentinel table %s.%s absent from a %d-row listing — "
+                        "this is not the activity store, or the read is wrong"
+                        % (SENTINEL_TABLE[0], SENTINEL_TABLE[1], tables_seen),
+                        **gate_extra)
+    if not probe_suffix:
+        return _unknown(STATE_NO_DATA,
+                        "positive control FAILED: 0 tables end in '%s' in a "
+                        "%d-row listing, so the suffix match used for the '%s' "
+                        "orphan test is not observing anything — its zero is "
+                        "meaningless"
+                        % (PROBE_SUFFIX, tables_seen, ORPHAN_SUFFIX),
+                        **gate_extra)
+    if not probe_size:
+        return _unknown(STATE_NO_DATA,
+                        "positive control FAILED: 0 tables exceed %s in a "
+                        "%d-row listing, so the byte comparison used for the "
+                        "%s test is not observing anything — its zero is "
+                        "meaningless"
+                        % (human_bytes(TABLE_PROBE_BYTES), tables_seen,
+                           human_bytes(TABLE_ALARM_BYTES)),
+                        **gate_extra)
     if measured == 0:
         return _unknown(STATE_NO_DATA,
                         "positive control FAILED: 0 of %d TTL target table(s) "
@@ -468,9 +530,8 @@ def evaluate(reading, now=None) -> dict:
                         "proved nothing — a clean verdict here would be a "
                         "harness reporting on itself"
                         % len(present_targets),
-                        controls=controls, du_bytes=du_bytes,
                         tables_total_bytes=sum(t["bytes"] for t in tables),
-                        ttl=ttl_report)
+                        ttl=ttl_report, **gate_extra)
 
     alarms = sum(1 for f in findings if f["level"] == "alarm")
     warns = sum(1 for f in findings if f["level"] == "warn")
@@ -520,16 +581,30 @@ def _summarize(state, findings, du_bytes, controls) -> str:
     return "; ".join(f["detail"] for f in findings)
 
 
-def _unknown(state, detail, *, controls=None, du_bytes=None, **extra) -> dict:
+def _unknown(state, detail, *, controls=None, du_bytes=None, findings=None,
+             **extra) -> dict:
+    """Build a CANNOT-TELL verdict, CARRYING any findings already made.
+
+    🔴 An unevaluable reading is not an empty one. A store that is 5 GiB, or has
+    `trace_log` back at 100 GiB, and ALSO trips a positive control is both
+    things at once — dropping the findings turned a confirmed ALARM into a bare
+    "no-data" and lost the only sentence that said what was wrong.
+
+    The STATE is unchanged, and `exit_code` maps every state in UNKNOWN_STATES
+    to 2 regardless of `alarms`, so this reports more without verdict-shopping.
+    """
+    findings = list(findings or [])
     v = {
         "state": state,
-        "alarms": 0,
-        "warns": 0,
-        "findings": [],
+        "alarms": sum(1 for f in findings if f["level"] == "alarm"),
+        "warns": sum(1 for f in findings if f["level"] == "warn"),
+        "findings": findings,
         "controls": controls or {},
         "measurements": {"du_bytes": du_bytes,
                          "du_human": human_bytes(du_bytes)},
-        "detail": detail,
+        "detail": (detail if not findings
+                   else "%s | findings preserved: %s"
+                        % (detail, "; ".join(f["detail"] for f in findings))),
     }
     v["measurements"].update(extra)
     return v
@@ -555,12 +630,65 @@ def http_query(url: str, user: str, password: str, query: str,
 
 
 def run_du(argv, timeout: float = DEFAULT_TIMEOUT) -> str:
+    """Run `du -sk <store>` and return its stdout.
+
+    🔴 STDOUT IS PARSED FIRST; THE EXIT CODE IS ONLY THE TIEBREAK. A live
+    ClickHouse store creates and removes `tmp_merge_*` directories continuously,
+    so `du` routinely races one and exits 1 with
+
+        du: /var/lib/clickhouse/store/.../tmp_merge_202608_...: No such file or
+        directory
+
+    on stderr — WHILE PRINTING THE CORRECT TOTAL on stdout. Verified in-pod:
+    `du -sk <store> /nonexistent` exits 1 and still prints the total. Raising on
+    the exit code discarded a perfectly good measurement on 3 of 20 live runs.
+
+    So: a partial walk that still produced a total is a MEASUREMENT (returned,
+    with the stderr noted on our own stderr for the journal). A run that
+    produced NO usable total is a FAILURE and still raises — which is what makes
+    the caller report exec-failed / exit 2 rather than a small store.
+    """
     p = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
-    if p.returncode != 0:
-        raise RuntimeError("exit %d: %s"
+    try:
+        parse_du_kib(p.stdout)
+        usable = True
+    except Exception:  # noqa: BLE001 — no total on stdout, whatever the code
+        usable = False
+    if not usable:
+        raise RuntimeError("exit %d, no usable total on stdout: %s"
                            % (p.returncode,
                               (p.stderr or p.stdout).strip()[:200]))
+    if p.returncode != 0:
+        sys.stderr.write(
+            "ch-regrowth: du exited %d but printed a usable total; treating the "
+            "partial walk as a measurement (%s)\n"
+            % (p.returncode, (p.stderr or "").strip()[:200]))
     return p.stdout
+
+
+def _is_transient(exc) -> bool:
+    """Is this failure worth retrying?
+
+    A 5xx (the observed `Code: 241 MEMORY_LIMIT_EXCEEDED` arrives as HTTP 500),
+    a 429, or a connection-level error is a server that is momentarily unable,
+    not a server that has answered. Those are retried.
+
+    NOT retried: a 4xx (a wrong password does not become right on attempt 3) and
+    a TIMEOUT (it already spent the full per-query budget once). Both stay
+    exactly as loud as they were.
+    """
+    if isinstance(exc, urllib.error.HTTPError):
+        return exc.code >= 500 or exc.code == 429
+    # A read that already burned the full per-query timeout is NOT retried: the
+    # retry would burn it again, and the unit has a hard TimeoutStartSec. Every
+    # failure worth retrying here fails FAST, which is what keeps the worst case
+    # bounded.
+    if isinstance(exc, (TimeoutError, subprocess.TimeoutExpired)):
+        return False
+    if isinstance(exc, urllib.error.URLError) and isinstance(
+            getattr(exc, "reason", None), TimeoutError):
+        return False
+    return isinstance(exc, (urllib.error.URLError, ConnectionError, OSError))
 
 
 def resolve_config(env=None) -> dict:
@@ -578,16 +706,20 @@ def resolve_config(env=None) -> dict:
 
 
 def collect(env=None, timeout: float = DEFAULT_TIMEOUT,
-            query=None, du=None) -> dict:
+            query=None, du=None, sleep=None, clock=None) -> dict:
     """Take a live reading. Returns {"reading": {...}} or {"error": (state, detail)}.
 
     `query(url, user, password, sql, timeout) -> str` and `du(argv, timeout)
-    -> str` are injectable so EVERY failure branch is testable offline. Never
-    raises.
+    -> str` are injectable so EVERY failure branch is testable offline; `sleep`
+    and `clock` are injectable so the retry schedule is testable without
+    sleeping. Never raises.
     """
     cfg = resolve_config(env)
     query = query or http_query
     du = du or run_du
+    sleep = sleep or time.sleep
+    clock = clock or time.monotonic
+    deadline = clock() + COLLECT_BUDGET_SECONDS
 
     if not cfg["url"] or not cfg["password"]:
         missing = []
@@ -599,8 +731,34 @@ def collect(env=None, timeout: float = DEFAULT_TIMEOUT,
                           "missing %s — the check cannot run, and MUST NOT "
                           "report a clean store" % "/".join(missing))}
 
-    def _q(sql):
-        return query(cfg["url"], cfg["user"], cfg["password"], sql, timeout)
+    def _q(sql, attempts=QUERY_ATTEMPTS):
+        """Query with backoff on TRANSIENT failures only.
+
+        🔴 THE RETRY CANNOT SOFTEN THE VERDICT. The last attempt re-raises the
+        original exception unchanged, so every caller's `except` — and therefore
+        every unreachable/query-failed state and exit 2 — behaves exactly as it
+        did with one attempt. There is no path on which exhausting the retries
+        produces a reading, let alone an `ok`.
+        """
+        last = None
+        for attempt in range(1, attempts + 1):
+            try:
+                return query(cfg["url"], cfg["user"], cfg["password"], sql,
+                             timeout)
+            except Exception as e:  # noqa: BLE001
+                last = e
+                if attempt >= attempts or not _is_transient(e):
+                    raise
+                back = QUERY_BACKOFF_SECONDS[
+                    min(attempt - 1, len(QUERY_BACKOFF_SECONDS) - 1)]
+                if clock() + back >= deadline:
+                    raise
+                sys.stderr.write(
+                    "ch-regrowth: transient query failure (attempt %d/%d), "
+                    "retrying in %.0fs: %s\n"
+                    % (attempt, attempts, back, str(e)[:200]))
+                sleep(back)
+        raise last  # pragma: no cover — the loop above always raises or returns
 
     # --- server clock (also the liveness probe) ---
     try:
@@ -635,8 +793,36 @@ def collect(env=None, timeout: float = DEFAULT_TIMEOUT,
         try:
             ttl_text = _q(ttl_query(present))
         except Exception as e:  # noqa: BLE001
-            return {"error": (STATE_UNREACHABLE,
-                              "ttl query failed: %s" % str(e)[:200])}
+            # 🔴 LAST RESORT, NOT A SOFTENING. The union is the query that
+            # returned `Code: 241` twice in 20 live runs. MEASURED over 26 real
+            # executions: union peaks at 8.44 MB, per-table at 4.23 MB — a real
+            # ~2x cut, but both are trivial against the 2.5 GiB ceiling that
+            # background merges exhaust, so this is a second shape to try, not
+            # a cure. The retry above is the actual fix. If every per-table read
+            # ALSO fails we return unreachable exactly as before; and if only
+            # some succeed, the `ttl_tables_measured` positive control still
+            # governs — zero measured targets is no-data / exit 2, never `ok`.
+            if not (len(present) > 1 and _is_transient(e)):
+                return {"error": (STATE_UNREACHABLE,
+                                  "ttl query failed: %s" % str(e)[:200])}
+            sys.stderr.write("ch-regrowth: TTL union exhausted its retries "
+                             "(%s); falling back to one query per table\n"
+                             % str(e)[:200])
+            parts = []
+            for name in present:
+                if clock() >= deadline:
+                    break
+                try:
+                    parts.append(_q(ttl_query([name]), attempts=1))
+                except Exception:  # noqa: BLE001 — that target goes UNMEASURED
+                    continue       # (reason "not-queried"), never assumed fine
+            if not parts:
+                return {"error": (STATE_UNREACHABLE,
+                                  "ttl query failed (union and all %d "
+                                  "per-table fallbacks): %s"
+                                  % (len(present), str(e)[:200]))}
+            ttl_text = "".join(p if p.endswith("\n") else p + "\n"
+                               for p in parts)
         try:
             ttl_rows = parse_ttl(ttl_text)
         except Exception as e:  # noqa: BLE001
@@ -662,10 +848,11 @@ def collect(env=None, timeout: float = DEFAULT_TIMEOUT,
 
 
 def check(env=None, now=None, timeout: float = DEFAULT_TIMEOUT,
-          query=None, du=None) -> dict:
+          query=None, du=None, sleep=None, clock=None) -> dict:
     """Full live check. Returns a verdict; NEVER raises and NEVER returns `ok`
     on any error path."""
-    got = collect(env=env, timeout=timeout, query=query, du=du)
+    got = collect(env=env, timeout=timeout, query=query, du=du, sleep=sleep,
+                  clock=clock)
     if "error" in got:
         state, detail = got["error"]
         return _unknown(state, detail)

--- a/scripts/collector/run-regrowth-check.sh
+++ b/scripts/collector/run-regrowth-check.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Scheduled ClickHouse regrowth check for the activity store — systemd wrapper.
+#
+# Provisions the admin credential at RUN TIME (sops decrypt, NO plaintext secret
+# at rest) and runs scripts/collector/ch_regrowth.py. See that file's docstring
+# for what is asserted and why; this wrapper is only credential + endpoint
+# plumbing.
+#
+# 🔴 EVERY GUARD HERE FAILS CLOSED. This is the deliberate opposite of
+# scripts/initiatives/run-sync.sh, whose sops block is best-effort because a
+# telemetry-off scan is still useful. Here a missing age key / absent repo /
+# missing sops / empty decrypt means THE STORE WAS NOT MEASURED, and a check
+# that cannot measure must never look like a check that measured a clean store.
+# So each failure exits 2 (CANNOT TELL), which systemd records as a unit failure
+# and OnFailure=notify-failure@%n.service turns into a sticky critical toast.
+#
+# Exit codes are ch_regrowth.py's, passed through unchanged:
+#   0 ok · 1 ALARM · 2 CANNOT TELL · 3 WARN
+#
+# Run by hand or via systemd: systemctl --user start ch-regrowth-check.service
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXIT_UNKNOWN=2
+
+die_unknown() {
+  echo "ch-regrowth: $* — CANNOT TELL (the store was NOT measured; this is not a clean result)" >&2
+  exit "$EXIT_UNKNOWN"
+}
+
+# KUBECONFIG for the `kubectl exec ... du` reading. The unit sets it too; keep a
+# default so the wrapper works from an interactive shell. The workbench reaches
+# the homelab API directly over the LAN; a laptop/off-LAN run needs
+# KUBECONFIG=~/.kube/homelab-nebula.yaml and CH_REGROWTH_URL on the nebula IP.
+export KUBECONFIG="${KUBECONFIG:-${HOME}/workspace/homelab-talos/homelab-kubeconfig}"
+
+# ClickHouse HTTP endpoint. Workbench LAN NodePort by default; overridable.
+export CH_REGROWTH_URL="${CH_REGROWTH_URL:-http://192.168.50.94:30123}"
+# `default` is the admin user; system-table reads need it (the activity_reader
+# grant is scoped to activity.*).
+export CH_REGROWTH_USER="${CH_REGROWTH_USER:-default}"
+
+HOMELAB_REPO="${HOMELAB:-${HOME}/workspace/homelab-talos}"
+AGE_KEY="${SOPS_AGE_KEY_FILE:-${HOMELAB_REPO}/.secrets/age.key}"
+SECRETS_REL="clusters/homelab/apps/activity/secrets.enc.yaml"
+
+if [ -z "${CH_REGROWTH_PASSWORD:-}" ]; then
+  [ -r "$AGE_KEY" ] || die_unknown "age key not readable ($AGE_KEY)"
+  [ -d "${HOMELAB_REPO}/.git" ] || die_unknown "homelab-talos repo absent ($HOMELAB_REPO)"
+  command -v sops >/dev/null 2>&1 || die_unknown "sops not on PATH"
+
+  SECRETS_PATH="${HOMELAB_REPO}/${SECRETS_REL}"
+  [ -r "$SECRETS_PATH" ] || die_unknown "encrypted secrets not readable ($SECRETS_PATH)"
+
+  # --extract keeps the secret off argv; it is passed to python via the
+  # environment, which is readable only by this uid.
+  PW="$(SOPS_AGE_KEY_FILE="$AGE_KEY" sops -d \
+        --extract '["stringData"]["admin-password"]' "$SECRETS_PATH" 2>/dev/null)" || PW=""
+  [ -n "$PW" ] || die_unknown "admin-password decrypt yielded empty"
+  export CH_REGROWTH_PASSWORD="$PW"
+  unset PW
+fi
+
+command -v kubectl >/dev/null 2>&1 || die_unknown "kubectl not on PATH"
+
+exec python3 "${SCRIPT_DIR}/ch_regrowth.py" "$@"

--- a/scripts/collector/tests/test_ch_regrowth.py
+++ b/scripts/collector/tests/test_ch_regrowth.py
@@ -34,6 +34,7 @@ import os
 import shutil
 import subprocess
 import sys
+import urllib.error
 from pathlib import Path
 
 import pytest
@@ -288,10 +289,16 @@ def test_negative_control_stale_oldest_row_alarms(table, bound):
 
 @pytest.mark.parametrize("table,bound", sorted(R.TTL_MAX_AGE_DAYS.items()))
 def test_ttl_bound_is_per_table_and_measured_at_both_sides(table, bound):
-    """A single midpoint would not catch a table wired to the wrong bound: at
-    7.9 days `query_log` (15d) must be fine while `metric_log` (8d) must be
-    fine too, but at 8.1 days they must DIVERGE."""
-    for age_days, expect_stale in ((bound - 0.1, False), (bound + 0.1, True)):
+    """Measured on BOTH sides of each table's own bound, and EXACTLY ON it.
+
+    A single midpoint would not catch a table wired to the wrong bound; and
+    without the exact-boundary point, `age_days > bound` and `age_days >= bound`
+    are indistinguishable — a surviving mutant until this case was added.
+    Exactly-at-bound must NOT be stale: the bound is already TTL + 3 days of
+    merge slack, so the first second past it is the first real evidence."""
+    for age_days, expect_stale in ((bound - 0.1, False),
+                                   (bound, False),
+                                   (bound + 0.1, True)):
         ttl = baseline_ttl()
         for row in ttl:
             if row["table"] == table:
@@ -302,11 +309,13 @@ def test_ttl_bound_is_per_table_and_measured_at_both_sides(table, bound):
         assert stale is expect_stale, (table, age_days)
 
 
-def test_the_8d_and_15d_bounds_actually_differ():
-    """Pins that the two TTL tiers are not collapsed to one number: at 10 days
-    old, the 7d-TTL tables are STALE and the 14d-TTL tables are not."""
-    ten_days = NOW - 10 * 86400
-    ttl = [dict(r, min_event_ts=ten_days) for r in baseline_ttl()]
+def test_the_two_ttl_tiers_actually_differ():
+    """Pins that the two TTL tiers are not collapsed to one number: at 12 days
+    old, the 7d-TTL tables (bound 10d) are STALE and the 14d-TTL tables (bound
+    17d) are not."""
+    assert sorted(set(R.TTL_MAX_AGE_DAYS.values())) == [10, 17]
+    twelve_days = NOW - 12 * 86400
+    ttl = [dict(r, min_event_ts=twelve_days) for r in baseline_ttl()]
     v = R.evaluate(baseline_reading(ttl=ttl), now=NOW)
     stale = {r["table"] for r in v["measurements"]["ttl"] if r["stale"]}
     assert stale == {"metric_log", "asynchronous_metric_log"}
@@ -368,6 +377,38 @@ def test_a_listing_that_cannot_match_the_suffix_is_no_data_not_ok():
     assert R.exit_code(v) == R.EXIT_UNKNOWN
 
 
+def test_the_probe_size_control_needs_a_table_STRICTLY_over_the_threshold():
+    """Measured ON the threshold and one byte above it. Without the exact
+    boundary point `> TABLE_PROBE_BYTES` and `>=` are indistinguishable, and a
+    control that counts a table sitting exactly ON its probe is weaker than it
+    claims — this gate is what licenses the 250 MiB zero."""
+    on_boundary = [tbl("activity", "events", rows=1, size=R.TABLE_PROBE_BYTES),
+                   tbl("system", "metric_log", rows=1,
+                       size=R.TABLE_PROBE_BYTES)]
+    v = R.evaluate(baseline_reading(tables=on_boundary), now=NOW)
+    assert v["controls"]["probe_size_matches"] == 0
+    assert v["state"] == R.STATE_NO_DATA
+    assert "0 tables exceed" in v["detail"], v["detail"]
+
+    above = [dict(t, bytes=R.TABLE_PROBE_BYTES + 1) for t in on_boundary]
+    v2 = R.evaluate(baseline_reading(tables=above), now=NOW)
+    assert v2["controls"]["probe_size_matches"] == 2
+
+
+def test_an_alarm_outranks_a_warn_found_in_the_same_reading():
+    """🔴 A 1.5 GiB store is a WARN and a resurrected `trace_log` is an ALARM.
+    Reporting the WARN would exit 3 instead of 1 and understate the worst thing
+    found — the two levels had never been seeded together."""
+    tables = baseline_tables() + [tbl("system", "trace_log", rows=1,
+                                      size=5 * R.MIB)]
+    v = R.evaluate(baseline_reading(du_bytes=int(1.5 * R.GIB), tables=tables),
+                   now=NOW)
+    assert v["warns"] == 1, v["findings"]
+    assert v["alarms"] == 1, v["findings"]
+    assert v["state"] == R.STATE_ALARM
+    assert R.exit_code(v) == R.EXIT_ALARM
+
+
 def test_a_listing_where_nothing_clears_1mib_is_no_data_not_ok():
     tables = [tbl("activity", "events", rows=1, size=1024),
               tbl("system", "metric_log", rows=1, size=512)]
@@ -388,9 +429,21 @@ def test_empty_listing_is_no_data_not_a_clean_store():
 
 def test_missing_sentinel_table_is_no_data():
     """Reading a real-but-WRONG ClickHouse would produce a plausible listing
-    with no `activity.events`. That is not a clean activity store."""
+    with no `activity.events`. That is not a clean activity store.
+
+    🔴 THE FIXTURE MUST NOT COLLAPSE. The predicate is `database == 'activity'
+    AND name == 'events'`; with no other `activity.*` table and no other table
+    called `events` in the listing, `AND` and `OR` compute the SAME answer and
+    the fixture cannot tell them apart — an `and`->`or` mutant survived on
+    exactly that. So both non-default siblings are seeded here: matching only
+    the database, and matching only the name, must each still be a miss.
+    """
     tables = [t for t in baseline_tables()
               if not (t["database"] == "activity" and t["name"] == "events")]
+    tables += [tbl("activity", "other", rows=7, size=3 * R.MIB),
+               tbl("system", "events", rows=9, size=4 * R.MIB)]
+    assert any(t["database"] == "activity" for t in tables)
+    assert any(t["name"] == "events" for t in tables)
     v = R.evaluate(baseline_reading(tables=tables), now=NOW)
     assert v["state"] == R.STATE_NO_DATA
     assert "sentinel" in v["detail"]
@@ -546,6 +599,348 @@ def test_no_error_path_can_produce_a_healthy_state():
         assert v["state"] not in (R.STATE_OK, R.STATE_WARN, R.STATE_ALARM)
         assert R.exit_code(v) == R.EXIT_UNKNOWN != 0
         assert v["alarms"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 `du` PARTIAL WALK — the observed 15% false CANNOT-TELL (audit #1a)
+#
+# 3 of 20 live runs exited 2 because busybox `du` returned 1 after racing a
+# `tmp_merge_*` directory that vanished mid-walk — WHILE PRINTING THE CORRECT
+# TOTAL. These are the only tests that drive `run_du` through a REAL subprocess;
+# every other error test injects a fake `du`, which is exactly why the
+# returncode guard had zero coverage.
+# --------------------------------------------------------------------------- #
+PARTIAL_DU_ARGV = [
+    sys.executable, "-c",
+    "import sys\n"
+    "print('541224\\t/var/lib/clickhouse/store')\n"
+    "sys.stderr.write('du: /var/lib/clickhouse/store/ede/tmp_merge_202608_"
+    "17463_29293_234: No such file or directory\\n')\n"
+    "sys.exit(1)\n",
+]
+
+
+def test_run_du_partial_walk_is_a_measurement_not_a_failure():
+    """🔴 THE REGRESSION. Non-zero exit + a usable total on stdout is a
+    MEASUREMENT. Before the fix this raised and the whole month's run became a
+    CANNOT-TELL indistinguishable from a real ALARM."""
+    out = R.run_du(PARTIAL_DU_ARGV)
+    assert R.parse_du_kib(out) == 541224 * 1024
+
+
+def test_run_du_partial_walk_against_the_real_du_binary(tmp_path):
+    """The same case driven through the actual `du` binary rather than a
+    simulation — `du -sk <dir> <missing>` is the shape confirmed in-pod."""
+    du = shutil.which("du")
+    assert du, "coreutils du must be on PATH for this test to mean anything"
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / "part.bin").write_bytes(b"x" * 300_000)
+    argv = [du, "-sk", str(store), str(tmp_path / "tmp_merge_gone")]
+
+    # Positive control for the FIXTURE: prove this argv really does exit
+    # non-zero and really does print a total, or the test below is vacuous.
+    p = subprocess.run(argv, capture_output=True, text=True)
+    assert p.returncode != 0, "fixture is vacuous: du exited 0"
+    assert p.stdout.strip(), "fixture is vacuous: du printed no total"
+
+    assert R.parse_du_kib(R.run_du(argv)) >= 292 * 1024
+
+
+def test_run_du_still_raises_when_there_is_no_usable_total():
+    """🔴 FAIL-CLOSED HALF. Parsing stdout first must not turn a genuinely
+    failed exec into a small store: no total on stdout still raises, which is
+    what makes the caller report exec-failed / exit 2."""
+    argv = [sys.executable, "-c",
+            "import sys; sys.stderr.write('kubectl: pod not found\\n');"
+            " sys.exit(1)"]
+    with pytest.raises(RuntimeError) as e:
+        R.run_du(argv)
+    assert "exit 1" in str(e.value)
+    assert "pod not found" in str(e.value)
+
+
+def test_run_du_raises_on_a_zero_exit_that_printed_nothing_usable():
+    """The other half of the same guard: a clean exit is not a measurement
+    either if nothing parseable came out."""
+    argv = [sys.executable, "-c", "print('du: Permission denied')"]
+    with pytest.raises(RuntimeError):
+        R.run_du(argv)
+
+
+def test_partial_du_walk_reaches_a_measured_verdict_end_to_end():
+    """The finding as the operator experiences it: the whole check, with a `du`
+    that exits 1 mid-walk, must produce a real verdict — not exit 2."""
+    v = R.check(env=GOOD_ENV, now=NOW,
+                query=fake_query_factory(good_responses()),
+                du=lambda argv, timeout: R.run_du(PARTIAL_DU_ARGV, timeout))
+    assert v["state"] == R.STATE_OK, v["detail"]
+    assert v["measurements"]["du_bytes"] == 541224 * 1024
+    assert R.exit_code(v) == R.EXIT_OK
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 TRANSIENT QUERY FAILURE — the other half of the 15% (audit #1b)
+#
+# The TTL union returned `HTTP 500 / Code: 241 MEMORY_LIMIT_EXCEEDED` on 2 of 20
+# live runs: the pod's 2.5 GiB ceiling reached by background merges. Retry —
+# without ever letting an exhausted retry reach `ok`.
+# --------------------------------------------------------------------------- #
+def memory_limit_500():
+    return urllib.error.HTTPError(
+        "http://ch.invalid:8123/", 500, "Internal Server Error", {}, None)
+
+
+def flaky_query(responses, fail_on, failures, exc_factory=memory_limit_500):
+    """Fail the first `failures` calls whose SQL contains `fail_on`, then
+    answer normally. Records every call so attempt COUNTS are assertable."""
+    calls = []
+
+    def q(url, user, password, sql, timeout):
+        calls.append(sql)
+        if fail_on in sql:
+            if sum(1 for c in calls if fail_on in c) <= failures:
+                raise exc_factory()
+        for needle, reply in responses.items():
+            if needle in sql:
+                return reply
+        raise AssertionError("unexpected query: %s" % sql[:80])
+
+    q.calls = calls
+    return q
+
+
+def test_transient_500_is_retried_and_the_check_recovers():
+    """🔴 THE REGRESSION. Two 500s then success must yield a real verdict, and
+    must be shown to have actually retried (2 extra calls, 2 real backoffs) —
+    otherwise this passes on a fake that never failed."""
+    slept = []
+    q = flaky_query(good_responses(), "UNION ALL", 2)
+    v = R.check(env=GOOD_ENV, now=NOW, query=q, du=ok_du, sleep=slept.append)
+    assert v["state"] == R.STATE_OK, v["detail"]
+    assert sum(1 for c in q.calls if "UNION ALL" in c) == 3
+    assert slept == list(R.QUERY_BACKOFF_SECONDS)
+    assert v["controls"]["ttl_tables_measured"] == 4
+
+
+@pytest.mark.parametrize("fail_on", ["now()", "system.tables"])
+def test_transient_500_is_retried_on_every_query_not_just_the_union(fail_on):
+    slept = []
+    q = flaky_query(good_responses(), fail_on, 1)
+    v = R.check(env=GOOD_ENV, now=NOW, query=q, du=ok_du, sleep=slept.append)
+    assert v["state"] == R.STATE_OK, v["detail"]
+    assert len(slept) == 1
+
+
+def test_exhausted_retries_still_fail_closed():
+    """🔴 THE FAIL-CLOSED HALF, and the reason a retry is safe here at all. When
+    every attempt 500s the verdict must be UNREACHABLE and exit 2 — never `ok`,
+    never a fall-through."""
+    slept = []
+    q = flaky_query(good_responses(), "now()", 99)
+    v = R.check(env=GOOD_ENV, now=NOW, query=q, du=ok_du, sleep=slept.append)
+    assert v["state"] == R.STATE_UNREACHABLE
+    assert v["state"] not in (R.STATE_OK, R.STATE_WARN)
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+    assert sum(1 for c in q.calls if "now()" in c) == R.QUERY_ATTEMPTS
+    assert len(slept) == R.QUERY_ATTEMPTS - 1
+
+
+def test_a_4xx_is_not_retried_because_it_is_a_durable_answer():
+    """A rotated password does not become right on attempt 3. Retrying a 401
+    would only spend the unit's start timeout — and must not mute it either."""
+    slept = []
+    err = urllib.error.HTTPError("http://ch.invalid:8123/", 401,
+                                 "Unauthorized", {}, None)
+    q = flaky_query(good_responses(), "now()", 99, exc_factory=lambda: err)
+    v = R.check(env=GOOD_ENV, now=NOW, query=q, du=ok_du, sleep=slept.append)
+    assert v["state"] == R.STATE_UNREACHABLE
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+    assert sum(1 for c in q.calls if "now()" in c) == 1
+    assert slept == []
+
+
+def test_a_timeout_is_not_retried_because_it_already_spent_its_budget():
+    slept = []
+    q = flaky_query(good_responses(), "now()", 99,
+                    exc_factory=lambda: TimeoutError("timed out"))
+    v = R.check(env=GOOD_ENV, now=NOW, query=q, du=ok_du, sleep=slept.append)
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+    assert sum(1 for c in q.calls if "now()" in c) == 1
+    assert slept == []
+
+
+def per_table_ttl_query(union_exc=memory_limit_500, ok_tables=None):
+    """A server on which the TTL UNION always 500s (the memory ceiling) but the
+    per-table queries in `ok_tables` succeed."""
+    rows = {r["table"]: r for r in baseline_ttl()}
+    ok_tables = rows.keys() if ok_tables is None else ok_tables
+    calls = []
+
+    def q(url, user, password, sql, timeout):
+        calls.append(sql)
+        if "now()" in sql:
+            return "%d\n" % NOW
+        if "FROM system.tables" in sql:
+            return listing_tsv(baseline_tables())
+        if "UNION ALL" in sql:
+            raise union_exc()
+        for name in rows:
+            if sql.startswith("SELECT '%s'" % name):
+                if name not in ok_tables:
+                    raise union_exc()
+                return ttl_tsv([rows[name]])
+        raise AssertionError("unexpected query: %s" % sql[:80])
+
+    q.calls = calls
+    return q
+
+
+def test_ttl_union_falls_back_to_one_query_per_table():
+    """The union aggregates all four targets at once and is what hit the 2.5 GiB
+    ceiling. Splitting it is the last resort before CANNOT TELL."""
+    q = per_table_ttl_query()
+    v = R.check(env=GOOD_ENV, now=NOW, query=q, du=ok_du, sleep=lambda s: None)
+    assert v["state"] == R.STATE_OK, v["detail"]
+    assert v["controls"]["ttl_tables_measured"] == 4
+    assert sum(1 for c in q.calls if "UNION ALL" in c) == R.QUERY_ATTEMPTS
+    assert sum(1 for c in q.calls
+               if "UNION ALL" not in c and " AS t," in c) == 4
+
+
+def test_a_partial_per_table_fallback_measures_what_it_can():
+    """Two targets answer, two do not. The two that answered are real
+    measurements; the two that did not are `not-queried`, never assumed fine."""
+    q = per_table_ttl_query(ok_tables={"metric_log", "query_log"})
+    v = R.check(env=GOOD_ENV, now=NOW, query=q, du=ok_du, sleep=lambda s: None)
+    assert v["controls"]["ttl_tables_measured"] == 2
+    unmeasured = {r["table"] for r in v["measurements"]["ttl"]
+                  if r["reason"] == "not-queried"}
+    assert unmeasured == {"asynchronous_metric_log", "part_log"}
+
+
+def test_a_fallback_that_measures_nothing_is_cannot_tell_not_ok():
+    """🔴 The fallback cannot create a clean verdict out of nothing — and must
+    say WHICH thing failed, so `unreachable` is pinned rather than merely
+    'some non-ok state'."""
+    q = per_table_ttl_query(ok_tables=set())
+    v = R.check(env=GOOD_ENV, now=NOW, query=q, du=ok_du, sleep=lambda s: None)
+    assert v["state"] == R.STATE_UNREACHABLE
+    assert v["state"] not in (R.STATE_OK, R.STATE_WARN)
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+    assert "per-table fallbacks" in v["detail"], v["detail"]
+
+
+def test_the_retry_schedule_is_pinned_to_literal_values():
+    """🔴 Asserting `slept == list(QUERY_BACKOFF_SECONDS)` elsewhere reads the
+    constant back and would hold for a schedule of zeros. Pin the numbers."""
+    assert R.QUERY_ATTEMPTS == 3
+    assert R.QUERY_BACKOFF_SECONDS == (2.0, 5.0)
+    assert len(R.QUERY_BACKOFF_SECONDS) == R.QUERY_ATTEMPTS - 1
+    assert all(s > 0 for s in R.QUERY_BACKOFF_SECONDS)
+    # The whole retry budget must stay well inside the unit's TimeoutStartSec.
+    assert sum(R.QUERY_BACKOFF_SECONDS) * 3 < R.COLLECT_BUDGET_SECONDS
+
+
+def test_no_retry_starts_once_the_collection_budget_is_spent():
+    """The retries are bounded by wall clock, not just by attempt count — a
+    unit killed at TimeoutStartSec mid-retry reports nothing at all."""
+    slept = []
+    # tick 1 sets the deadline; every later read is already past it.
+    ticks = iter([0.0] + [R.COLLECT_BUDGET_SECONDS + 1.0] * 40)
+    q = flaky_query(good_responses(), "now()", 99)
+    v = R.check(env=GOOD_ENV, now=NOW, query=q, du=ok_du, sleep=slept.append,
+                clock=lambda: next(ticks))
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+    assert v["state"] == R.STATE_UNREACHABLE
+    assert slept == [], "a retry started past the budget"
+    assert sum(1 for c in q.calls if "now()" in c) == 1
+
+
+def test_a_non_transient_ttl_failure_does_not_reach_the_fallback():
+    """An unparseable/programming error is a durable answer, not a memory
+    spike; splitting the query would only repeat it four times."""
+    q = flaky_query(good_responses(), "UNION ALL", 99,
+                    exc_factory=lambda: RuntimeError("syntax error"))
+    v = R.check(env=GOOD_ENV, now=NOW, query=q, du=ok_du, sleep=lambda s: None)
+    assert v["state"] == R.STATE_UNREACHABLE
+    assert sum(1 for c in q.calls if " AS t," in c and "UNION ALL" not in c) == 0
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 A CONFIRMED ALARM MUST SURVIVE AN UNEVALUABLE READING (audit #2)
+#
+# The gates decide whether a reading is EVALUABLE. They must not decide what was
+# FOUND. Previously every one of them returned a fresh verdict with
+# `findings: []`, so a 5 GiB store or a resurrected 100 GiB `trace_log` vanished
+# from the report the moment any positive control also tripped.
+# --------------------------------------------------------------------------- #
+def test_the_orphan_population_no_longer_destroys_its_own_diagnosis():
+    """🔴 THE SHARPEST CASE. Applying a TTL to an existing `*_log` renames it to
+    `*_log_0`. Do that to ALL of them and NOTHING ends in `_log` any more — so
+    the suffix positive control trips, on precisely the regrowth vector the
+    orphan check exists to catch. The verdict is still CANNOT TELL (exit 2), but
+    the 20 orphans must be named."""
+    tables = [tbl(t["database"],
+                  t["name"] + "_0" if t["name"].endswith("_log") else t["name"],
+                  t["engine"], t["rows"], t["bytes"])
+              for t in baseline_tables()]
+    assert not any(t["name"].endswith("_log") for t in tables)
+    orphans = [t for t in tables if t["name"].endswith("_0")]
+    assert len(orphans) == 14, len(orphans)
+
+    v = R.evaluate(baseline_reading(tables=tables), now=NOW)
+    assert v["state"] == R.STATE_NO_DATA          # verdict unchanged
+    assert R.exit_code(v) == R.EXIT_UNKNOWN       # exit code unchanged
+    assert checks_named(v, "orphan-tables"), v    # DIAGNOSIS preserved
+    assert v["alarms"] == 1
+    assert "metric_log_0" in v["detail"]
+    assert "suffix match" in v["detail"]          # and the gate's own reason
+    assert "metric_log_0" in R.render_text(v)
+
+
+def test_a_store_size_alarm_survives_an_empty_listing():
+    """`du` says 5 GiB and the listing came back empty. Both facts matter; the
+    5 GiB used to disappear."""
+    v = R.evaluate(baseline_reading(du_bytes=5 * R.GIB, tables=[]), now=NOW)
+    assert v["state"] == R.STATE_NO_DATA
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+    assert checks_named(v, "store-size")
+    assert v["alarms"] == 1
+    assert "5.0 GiB" in v["detail"]
+    assert "came back EMPTY" in v["detail"]
+
+
+def test_a_resurrected_trace_log_survives_zero_measurable_ttl_targets():
+    """`trace_log` back at 100 GiB — the literal 112 GB mechanism — while every
+    TTL target reads empty. Reporting only `no-data` here was the worst case."""
+    tables = baseline_tables() + [tbl("system", "trace_log",
+                                      rows=3_770_000_000, size=100 * R.GIB)]
+    ttl = [dict(r, rows=0) for r in baseline_ttl()]
+    v = R.evaluate(baseline_reading(tables=tables, ttl=ttl), now=NOW)
+    assert v["state"] == R.STATE_NO_DATA
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+    assert checks_named(v, "forbidden-tables")
+    assert "system.trace_log" in v["detail"]
+    assert v["alarms"] >= 1
+
+
+def test_a_missing_du_reading_no_longer_hides_the_listing_findings():
+    """The `du` exec failed AND `trace_log` is back. The exec failure is the
+    state; the resurrection is still the news."""
+    tables = baseline_tables() + [tbl("system", "trace_log", rows=1,
+                                      size=90 * R.GIB)]
+    v = R.evaluate(baseline_reading(du_bytes=None, tables=tables), now=NOW)
+    assert v["state"] == R.STATE_EXEC_FAILED
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+    assert checks_named(v, "forbidden-tables")
+
+
+def test_an_unknown_verdict_with_no_findings_still_reports_zero_alarms():
+    """The counterpart control: carrying findings must not invent them."""
+    v = R._unknown(R.STATE_NO_DATA, "synthetic")
+    assert v["findings"] == [] and v["alarms"] == 0 and v["warns"] == 0
+    assert "findings preserved" not in v["detail"]
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/collector/tests/test_ch_regrowth.py
+++ b/scripts/collector/tests/test_ch_regrowth.py
@@ -1,0 +1,728 @@
+"""Tests for the ClickHouse regrowth check (scripts/collector/ch_regrowth.py).
+
+ALL OFFLINE — every test builds a synthetic reading and calls the pure
+`evaluate`, or injects fake `query`/`du` callables into `check`. No cluster is
+contacted and nothing is written.
+
+🔴 WHY THIS FILE IS SHAPED THE WAY IT IS
+----------------------------------------
+Every reassuring answer this check can give is a ZERO: zero orphan tables, zero
+forbidden tables, zero oversized tables, zero stale TTL targets. A zero is
+exactly what a harness wired to nothing also produces. So this file NEVER
+asserts a zero on its own:
+
+  * NEGATIVE CONTROLS (`test_negative_*`) feed a known-BAD store — oversized,
+    a `*_0` orphan present, a resurrected `trace_log`, a stale oldest row — and
+    assert the checker goes RED, with THAT check's own name in the finding, and
+    with the right exit code. A harness that cannot go red proves nothing.
+  * POSITIVE CONTROLS (`test_positive_control_*`) assert the counting code path
+    produces a NON-ZERO on a fixture that must move it, using the SAME code
+    path that reports the zero. The pair is asserted together in
+    `test_control_pair_*` so the zero always arrives with its own evidence.
+  * ERROR PATHS (`test_error_*`) assert that auth failure, an unreachable
+    server, an unparseable response and a failed `kubectl exec` each produce a
+    CANNOT-TELL state and a non-zero exit — never `ok`.
+
+The baseline fixture uses the REAL numbers measured against the live store on
+2026-08-06 (see the module docstring), so "clean" means clean against reality
+rather than against a hand-picked shape.
+
+Run: pytest scripts/collector/tests/test_ch_regrowth.py
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import ch_regrowth as R  # noqa: E402
+
+MODULE = Path(__file__).resolve().parent.parent / "ch_regrowth.py"
+
+# Measured on the live store 2026-08-06 (server clock 1786034311).
+NOW = 1786034311
+OLDEST = 1785727742          # ~3.55 days before NOW
+DU_BASELINE = 541224 * 1024  # `du -sk` -> 528.5 MiB
+
+MEASURED_NON_EMPTY = [
+    ("system", "metric_log", "MergeTree", 306363, 86680883),
+    ("system", "asynchronous_metric_log", "MergeTree", 70479746, 75617527),
+    ("activity", "events", "MergeTree", 526982, 34284751),
+    ("system", "query_log", "MergeTree", 41186, 6789151),
+    ("system", "part_log", "MergeTree", 48286, 4094133),
+    ("system", "error_log", "MergeTree", 3100503, 1845104),
+    ("system", "query_metric_log", "MergeTree", 1389, 600088),
+]
+
+# Empty-but-existing `*_log` tables the live server also lists. They matter:
+# they are what makes the `*_log` suffix positive control non-trivial.
+MEASURED_EMPTY_LOGS = [
+    "asynchronous_insert_log", "backup_log", "blob_storage_log", "crash_log",
+    "opentelemetry_span_log", "query_thread_log", "query_views_log",
+    "s3queue_log",
+]
+
+
+def tbl(database, name, engine="MergeTree", rows=0, size=0):
+    return {"database": database, "name": name, "engine": engine,
+            "rows": rows, "bytes": size}
+
+
+def baseline_tables():
+    rows = [tbl(d, n, e, r, b) for d, n, e, r, b in MEASURED_NON_EMPTY]
+    rows += [tbl("system", n) for n in MEASURED_EMPTY_LOGS]
+    # A handful of non-log system views, to make the listing realistic.
+    rows += [tbl("system", n, "SystemNumbers") for n in
+             ("numbers", "one", "tables", "columns", "parts")]
+    return rows
+
+
+def baseline_ttl(oldest=OLDEST):
+    return [
+        {"table": "metric_log", "rows": 306363, "min_event_ts": oldest},
+        {"table": "asynchronous_metric_log", "rows": 70479746,
+         "min_event_ts": oldest + 1},
+        {"table": "query_log", "rows": 41186, "min_event_ts": oldest + 5},
+        {"table": "part_log", "rows": 48286, "min_event_ts": oldest + 2},
+    ]
+
+
+def baseline_reading(**over):
+    r = {"du_bytes": DU_BASELINE, "tables": baseline_tables(),
+         "ttl": baseline_ttl(), "server_now": NOW}
+    r.update(over)
+    return r
+
+
+def checks_named(verdict, name):
+    return [f for f in verdict["findings"] if f["check"] == name]
+
+
+# --------------------------------------------------------------------------- #
+# The baseline is clean — and this is the ONLY test allowed to assert that.
+# Everything else exists to prove this green is not vacuous.
+# --------------------------------------------------------------------------- #
+def test_measured_baseline_is_ok():
+    v = R.evaluate(baseline_reading(), now=NOW)
+    assert v["state"] == R.STATE_OK, v["detail"]
+    assert v["alarms"] == 0
+    assert v["warns"] == 0
+    assert R.exit_code(v) == R.EXIT_OK
+
+
+def test_baseline_reports_the_numbers_it_read_not_just_a_verdict():
+    v = R.evaluate(baseline_reading(), now=NOW)
+    m = v["measurements"]
+    assert m["du_bytes"] == DU_BASELINE
+    assert m["du_human"] == "528.5 MiB"
+    assert m["tables_seen"] == len(baseline_tables())
+    assert m["largest_table"] == "system.metric_log"
+    assert m["largest_table_bytes"] == 86680883
+    assert m["non_empty_tables"] == len(MEASURED_NON_EMPTY)
+    # The rendered text must carry the measurements too, not only a word.
+    text = R.render_text(v)
+    assert "528.5 MiB" in text
+    assert "system.metric_log" in text
+
+
+# --------------------------------------------------------------------------- #
+# 1. store size
+# --------------------------------------------------------------------------- #
+def test_negative_control_store_over_2gib_alarms():
+    v = R.evaluate(baseline_reading(du_bytes=3 * R.GIB), now=NOW)
+    assert v["state"] == R.STATE_ALARM
+    f = checks_named(v, "store-size")
+    assert len(f) == 1 and f[0]["level"] == "alarm"
+    assert f[0]["observed"] == 3 * R.GIB
+    assert R.exit_code(v) == R.EXIT_ALARM
+
+
+def test_negative_control_store_over_1gib_warns():
+    v = R.evaluate(baseline_reading(du_bytes=int(1.5 * R.GIB)), now=NOW)
+    assert v["state"] == R.STATE_WARN
+    assert checks_named(v, "store-size")[0]["level"] == "warn"
+    # A WARN is still a non-zero exit, so the systemd OnFailure toast fires.
+    assert R.exit_code(v) == R.EXIT_WARN != 0
+
+
+@pytest.mark.parametrize("du,expect", [
+    (R.DU_WARN_BYTES - 1, R.STATE_OK),
+    (R.DU_WARN_BYTES, R.STATE_WARN),
+    (R.DU_ALARM_BYTES - 1, R.STATE_WARN),
+    (R.DU_ALARM_BYTES, R.STATE_ALARM),
+])
+def test_store_size_thresholds_at_both_boundaries(du, expect):
+    """Measured at each boundary AND one byte below it — a single midpoint
+    measurement would not distinguish `>` from `>=`."""
+    assert R.evaluate(baseline_reading(du_bytes=du), now=NOW)["state"] == expect
+
+
+# --------------------------------------------------------------------------- #
+# 2. `*_0` orphan tables — the silent regrowth vector
+# --------------------------------------------------------------------------- #
+def test_negative_control_orphan_table_alarms():
+    tables = baseline_tables() + [
+        tbl("system", "metric_log_0", rows=999_999, size=40 * R.MIB)]
+    v = R.evaluate(baseline_reading(tables=tables), now=NOW)
+    assert v["state"] == R.STATE_ALARM
+    f = checks_named(v, "orphan-tables")
+    assert len(f) == 1
+    assert "system.metric_log_0" in f[0]["observed"]
+    assert v["measurements"]["orphan_count"] == 1
+    assert R.exit_code(v) == R.EXIT_ALARM
+
+
+def test_orphan_alarms_even_when_empty_and_small():
+    """The hazard is the table EXISTING with no TTL, not its current size — it
+    grows silently forever after."""
+    tables = baseline_tables() + [tbl("system", "trace_log_0")]
+    v = R.evaluate(baseline_reading(tables=tables), now=NOW)
+    assert v["state"] == R.STATE_ALARM
+    assert v["measurements"]["orphan_count"] == 1
+
+
+def test_control_pair_orphan_count_moves_off_zero():
+    """🔴 THE PAIR. Same code path, same fixture: 0 on the clean store, 2 with
+    orphans seeded. A zero from a checker that could only ever say zero would
+    fail the second half of this."""
+    clean = R.evaluate(baseline_reading(), now=NOW)
+    seeded = R.evaluate(baseline_reading(
+        tables=baseline_tables() + [tbl("system", "metric_log_0"),
+                                    tbl("system", "query_log_0")]), now=NOW)
+    assert clean["measurements"]["orphan_count"] == 0
+    assert seeded["measurements"]["orphan_count"] == 2
+    assert clean["state"] == R.STATE_OK
+    assert seeded["state"] == R.STATE_ALARM
+
+
+# --------------------------------------------------------------------------- #
+# 3. resurrected forbidden log tables — the actual 112 GB mechanism
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("name", list(R.FORBIDDEN_TABLES))
+def test_negative_control_each_forbidden_table_alarms(name):
+    tables = baseline_tables() + [tbl("system", name, rows=1)]
+    v = R.evaluate(baseline_reading(tables=tables), now=NOW)
+    assert v["state"] == R.STATE_ALARM, name
+    f = checks_named(v, "forbidden-tables")
+    assert len(f) == 1 and "system.%s" % name in f[0]["observed"]
+    assert R.exit_code(v) == R.EXIT_ALARM
+
+
+def test_forbidden_check_is_scoped_to_the_system_database():
+    """A user table that happens to be called `text_log` in another database is
+    not the config revert this check is looking for."""
+    tables = baseline_tables() + [tbl("activity", "text_log", rows=5)]
+    v = R.evaluate(baseline_reading(tables=tables), now=NOW)
+    assert v["measurements"]["forbidden_count"] == 0
+    assert v["state"] == R.STATE_OK
+
+
+def test_control_pair_forbidden_count_moves_off_zero():
+    clean = R.evaluate(baseline_reading(), now=NOW)
+    seeded = R.evaluate(baseline_reading(
+        tables=baseline_tables() + [tbl("system", "trace_log", rows=3_770_000_000,
+                                        size=100 * R.GIB)]), now=NOW)
+    assert clean["measurements"]["forbidden_count"] == 0
+    assert seeded["measurements"]["forbidden_count"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# 4. oversized single table
+# --------------------------------------------------------------------------- #
+def test_negative_control_table_over_250mib_alarms():
+    tables = baseline_tables() + [
+        tbl("system", "metric_log2", rows=1, size=300 * R.MIB)]
+    v = R.evaluate(baseline_reading(tables=tables), now=NOW)
+    assert v["state"] == R.STATE_ALARM
+    f = checks_named(v, "table-size")
+    assert f[0]["observed"][0]["table"] == "system.metric_log2"
+    assert R.exit_code(v) == R.EXIT_ALARM
+
+
+@pytest.mark.parametrize("size,expect_count", [
+    (R.TABLE_ALARM_BYTES - 1, 0),
+    (R.TABLE_ALARM_BYTES, 0),
+    (R.TABLE_ALARM_BYTES + 1, 1),
+])
+def test_table_size_threshold_at_the_boundary(size, expect_count):
+    tables = baseline_tables() + [tbl("system", "big_log", rows=1, size=size)]
+    v = R.evaluate(baseline_reading(tables=tables), now=NOW)
+    assert v["measurements"]["oversized_count"] == expect_count
+
+
+def test_control_pair_oversize_probe_vs_alarm_count():
+    """🔴 THE PAIR the preliminary manual run used: validate the >250 MiB query
+    that returns nothing by running the SAME comparison at >1 MiB, which must
+    return rows. Report both numbers, never the zero alone."""
+    v = R.evaluate(baseline_reading(), now=NOW)
+    # 6 of the 7 non-empty tables clear 1 MiB (query_metric_log is 586 KiB).
+    expected = sum(1 for _, _, _, _, b in MEASURED_NON_EMPTY
+                   if b > R.TABLE_PROBE_BYTES)
+    assert expected == 6
+    assert v["controls"]["probe_size_matches"] == expected > 0
+    assert v["measurements"]["oversized_count"] == 0
+    assert "%d" % v["controls"]["probe_size_matches"] in R.render_text(v)
+
+
+# --------------------------------------------------------------------------- #
+# 5. TTL effectiveness — the only check that tests the MECHANISM
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("table,bound", sorted(R.TTL_MAX_AGE_DAYS.items()))
+def test_negative_control_stale_oldest_row_alarms(table, bound):
+    ttl = baseline_ttl()
+    for row in ttl:
+        if row["table"] == table:
+            row["min_event_ts"] = NOW - int((bound + 2) * 86400)
+    v = R.evaluate(baseline_reading(ttl=ttl), now=NOW)
+    assert v["state"] == R.STATE_ALARM, (table, v["detail"])
+    f = checks_named(v, "ttl-effectiveness")
+    assert len(f) == 1
+    assert f[0]["observed"]["table"] == table
+    assert f[0]["observed"]["age_days"] > bound
+    assert R.exit_code(v) == R.EXIT_ALARM
+
+
+@pytest.mark.parametrize("table,bound", sorted(R.TTL_MAX_AGE_DAYS.items()))
+def test_ttl_bound_is_per_table_and_measured_at_both_sides(table, bound):
+    """A single midpoint would not catch a table wired to the wrong bound: at
+    7.9 days `query_log` (15d) must be fine while `metric_log` (8d) must be
+    fine too, but at 8.1 days they must DIVERGE."""
+    for age_days, expect_stale in ((bound - 0.1, False), (bound + 0.1, True)):
+        ttl = baseline_ttl()
+        for row in ttl:
+            if row["table"] == table:
+                row["min_event_ts"] = NOW - int(age_days * 86400)
+        v = R.evaluate(baseline_reading(ttl=ttl), now=NOW)
+        stale = [r for r in v["measurements"]["ttl"]
+                 if r["table"] == table][0]["stale"]
+        assert stale is expect_stale, (table, age_days)
+
+
+def test_the_8d_and_15d_bounds_actually_differ():
+    """Pins that the two TTL tiers are not collapsed to one number: at 10 days
+    old, the 7d-TTL tables are STALE and the 14d-TTL tables are not."""
+    ten_days = NOW - 10 * 86400
+    ttl = [dict(r, min_event_ts=ten_days) for r in baseline_ttl()]
+    v = R.evaluate(baseline_reading(ttl=ttl), now=NOW)
+    stale = {r["table"] for r in v["measurements"]["ttl"] if r["stale"]}
+    assert stale == {"metric_log", "asynchronous_metric_log"}
+    assert v["state"] == R.STATE_ALARM
+    assert len(checks_named(v, "ttl-effectiveness")) == 2
+
+
+def test_empty_ttl_target_is_not_evidence_and_is_not_stale():
+    """min() over an empty table reports the epoch. That must not read as a
+    62-year-old row (a false ALARM) — nor be counted as a measurement."""
+    ttl = baseline_ttl()
+    ttl[0].update(rows=0, min_event_ts=0)
+    v = R.evaluate(baseline_reading(ttl=ttl), now=NOW)
+    row = [r for r in v["measurements"]["ttl"] if r["table"] == "metric_log"][0]
+    assert row["stale"] is False
+    assert row["reason"] == "empty"
+    assert v["controls"]["ttl_tables_measured"] == 3
+    assert v["state"] == R.STATE_OK
+
+
+def test_control_pair_ttl_measured_count_moves():
+    clean = R.evaluate(baseline_reading(), now=NOW)
+    none_measured = R.evaluate(
+        baseline_reading(ttl=[dict(r, rows=0) for r in baseline_ttl()]),
+        now=NOW)
+    assert clean["controls"]["ttl_tables_measured"] == 4
+    # 🔴 Zero measurable TTL targets is CANNOT TELL, never a clean store.
+    assert none_measured["controls"]["ttl_tables_measured"] == 0
+    assert none_measured["state"] == R.STATE_NO_DATA
+    assert R.exit_code(none_measured) == R.EXIT_UNKNOWN
+
+
+# --------------------------------------------------------------------------- #
+# POSITIVE CONTROLS — a zero is never trusted without one
+# --------------------------------------------------------------------------- #
+def test_positive_control_suffix_matching_observes_something():
+    v = R.evaluate(baseline_reading(), now=NOW)
+    # 14 `*_log` tables on the live server: 6 non-empty + 8 empty.
+    expected = len(MEASURED_EMPTY_LOGS) + sum(
+        1 for _, n, _, _, _ in MEASURED_NON_EMPTY if n.endswith("_log"))
+    assert v["controls"]["probe_suffix_matches"] == expected > 0
+    assert v["measurements"]["orphan_count"] == 0
+
+
+def test_a_listing_that_cannot_match_the_suffix_is_no_data_not_ok():
+    """If NOTHING in the listing ends in `_log`, the suffix comparison is not
+    observing anything, so `0 orphans` is meaningless. That must be CANNOT
+    TELL — this is the 'harness wired to nothing' case."""
+    tables = [tbl("activity", "events", rows=1, size=34 * R.MIB),
+              tbl("activity", "other", rows=1, size=2 * R.MIB)]
+    v = R.evaluate(baseline_reading(tables=tables), now=NOW)
+    assert v["state"] == R.STATE_NO_DATA
+    # 🔴 Pin THIS guard's own message. Every later gate (size, sentinel, TTL)
+    # also returns no-data on this fixture, so asserting the STATE alone leaves
+    # the test green with the suffix control deleted — measured, it survived a
+    # mutation sweep until this line was added.
+    assert "suffix match" in v["detail"], v["detail"]
+    assert "positive control FAILED" in v["detail"]
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+
+
+def test_a_listing_where_nothing_clears_1mib_is_no_data_not_ok():
+    tables = [tbl("activity", "events", rows=1, size=1024),
+              tbl("system", "metric_log", rows=1, size=512)]
+    v = R.evaluate(baseline_reading(tables=tables), now=NOW)
+    assert v["state"] == R.STATE_NO_DATA
+    assert "positive control FAILED" in v["detail"]
+
+
+def test_empty_listing_is_no_data_not_a_clean_store():
+    v = R.evaluate(baseline_reading(tables=[]), now=NOW)
+    assert v["state"] == R.STATE_NO_DATA
+    assert v["state"] != R.STATE_OK
+    # Same reason as the suffix test above: the sentinel gate would also catch
+    # an empty listing, so pin the empty-listing guard's own wording.
+    assert "came back EMPTY" in v["detail"], v["detail"]
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+
+
+def test_missing_sentinel_table_is_no_data():
+    """Reading a real-but-WRONG ClickHouse would produce a plausible listing
+    with no `activity.events`. That is not a clean activity store."""
+    tables = [t for t in baseline_tables()
+              if not (t["database"] == "activity" and t["name"] == "events")]
+    v = R.evaluate(baseline_reading(tables=tables), now=NOW)
+    assert v["state"] == R.STATE_NO_DATA
+    assert "sentinel" in v["detail"]
+
+
+def test_missing_du_reading_is_exec_failed_not_ok():
+    v = R.evaluate(baseline_reading(du_bytes=None), now=NOW)
+    assert v["state"] == R.STATE_EXEC_FAILED
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+
+
+# --------------------------------------------------------------------------- #
+# ERROR PATHS — none may report a healthy store
+# --------------------------------------------------------------------------- #
+def fake_query_factory(responses, fail_on=None, exc=None):
+    """`responses` maps a substring of the SQL -> reply text."""
+    def q(url, user, password, sql, timeout):
+        if fail_on and fail_on in sql:
+            raise (exc or RuntimeError("boom"))
+        for needle, reply in responses.items():
+            if needle in sql:
+                return reply
+        raise AssertionError("unexpected query: %s" % sql[:80])
+    return q
+
+
+def listing_tsv(rows):
+    return "\n".join("\t".join(str(x) for x in
+                               (r["database"], r["name"], r["engine"],
+                                r["rows"], r["bytes"])) for r in rows) + "\n"
+
+
+def ttl_tsv(rows):
+    return "\n".join("\t".join(str(x) for x in
+                               (r["table"], r["rows"], r["min_event_ts"]))
+                     for r in rows) + "\n"
+
+
+def good_responses():
+    return {"now()": "%d\n" % NOW,
+            "system.tables": listing_tsv(baseline_tables()),
+            "UNION ALL": ttl_tsv(baseline_ttl())}
+
+
+GOOD_ENV = {"CH_REGROWTH_URL": "http://ch.invalid:8123",
+            "CH_REGROWTH_PASSWORD": "pw"}
+
+
+def ok_du(argv, timeout):
+    return "%d\t/var/lib/clickhouse/store\n" % (DU_BASELINE // 1024)
+
+
+def test_injected_happy_path_is_ok():
+    """The harness's OWN negative control: prove this injection path CAN reach
+    `ok`, so the failure tests below are failing for their stated reason and
+    not because the fake wiring is broken."""
+    v = R.check(env=GOOD_ENV, now=NOW,
+                query=fake_query_factory(good_responses()), du=ok_du)
+    assert v["state"] == R.STATE_OK, v["detail"]
+    assert R.exit_code(v) == R.EXIT_OK
+
+
+@pytest.mark.parametrize("env,missing", [
+    ({}, "CH_REGROWTH_URL"),
+    ({"CH_REGROWTH_URL": "http://x"}, "CH_REGROWTH_PASSWORD"),
+    ({"CH_REGROWTH_PASSWORD": "pw"}, "CH_REGROWTH_URL"),
+])
+def test_error_not_configured_is_never_ok(env, missing):
+    v = R.check(env=env, now=NOW,
+                query=fake_query_factory(good_responses()), du=ok_du)
+    assert v["state"] == R.STATE_NOT_CONFIGURED
+    assert missing in v["detail"]
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+
+
+def test_error_auth_failure_is_never_ok():
+    """A 401 from a wrong/rotated password must be LOUD, not an empty result
+    set that reads as a clean store."""
+    import urllib.error
+    err = urllib.error.HTTPError("http://ch.invalid:8123/", 401,
+                                 "Unauthorized", {}, None)
+    v = R.check(env=GOOD_ENV, now=NOW,
+                query=fake_query_factory(good_responses(), fail_on="now()",
+                                         exc=err),
+                du=ok_du)
+    assert v["state"] == R.STATE_UNREACHABLE
+    assert v["state"] not in (R.STATE_OK, R.STATE_WARN)
+    assert "401" in v["detail"] or "Unauthorized" in v["detail"]
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+
+
+@pytest.mark.parametrize("fail_on", ["now()", "system.tables", "UNION ALL"])
+def test_error_any_failing_query_is_unreachable_not_ok(fail_on):
+    v = R.check(env=GOOD_ENV, now=NOW,
+                query=fake_query_factory(good_responses(), fail_on=fail_on),
+                du=ok_du)
+    assert v["state"] == R.STATE_UNREACHABLE
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+
+
+@pytest.mark.parametrize("bad", [
+    {"now()": "not-a-number\n"},
+    {"system.tables": "only\ttwo\n"},
+    {"UNION ALL": "metric_log\tnope\n"},
+])
+def test_error_unparseable_response_is_query_failed_not_ok(bad):
+    responses = good_responses()
+    responses.update(bad)
+    v = R.check(env=GOOD_ENV, now=NOW,
+                query=fake_query_factory(responses), du=ok_du)
+    assert v["state"] == R.STATE_QUERY_FAILED
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+
+
+def test_error_empty_response_body_is_never_ok():
+    """🔴 The exact 'zero from a broken client' shape: the server answers, but
+    with nothing. An empty listing must not read as a clean store."""
+    responses = good_responses()
+    responses["system.tables"] = ""
+    v = R.check(env=GOOD_ENV, now=NOW,
+                query=fake_query_factory(responses), du=ok_du)
+    assert v["state"] == R.STATE_NO_DATA
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+
+
+def test_error_kubectl_exec_failure_is_never_ok():
+    """A missing pod / bad kubeconfig makes `du` fail. That must NOT be read as
+    a small store."""
+    def bad_du(argv, timeout):
+        raise RuntimeError("exit 1: Error from server (NotFound): "
+                           "deployments.apps \"clickhouse\" not found")
+    v = R.check(env=GOOD_ENV, now=NOW,
+                query=fake_query_factory(good_responses()), du=bad_du)
+    assert v["state"] == R.STATE_EXEC_FAILED
+    assert "NotFound" in v["detail"]
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+
+
+def test_error_unparseable_du_is_exec_failed():
+    def weird_du(argv, timeout):
+        return "du: /var/lib/clickhouse/store: Permission denied\n"
+    v = R.check(env=GOOD_ENV, now=NOW,
+                query=fake_query_factory(good_responses()), du=weird_du)
+    assert v["state"] == R.STATE_EXEC_FAILED
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+
+
+def test_no_error_path_can_produce_a_healthy_state():
+    """Belt and braces: sweep every unknown state and assert none of them is
+    `ok`/`warn` and all of them exit non-zero."""
+    for state in R.UNKNOWN_STATES:
+        v = R._unknown(state, "synthetic")
+        assert v["state"] not in (R.STATE_OK, R.STATE_WARN, R.STATE_ALARM)
+        assert R.exit_code(v) == R.EXIT_UNKNOWN != 0
+        assert v["alarms"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# Parsing / query construction
+# --------------------------------------------------------------------------- #
+def test_du_is_parsed_as_kib_because_busybox_has_no_dash_b():
+    assert R.parse_du_kib("541224\t/var/lib/clickhouse/store\n") == 541224 * 1024
+    assert R.parse_du_kib("12 /x\n") == 12 * 1024
+    assert R.du_argv()[-3:] == ["du", "-sk", R.STORE_PATH]
+
+
+def test_ttl_query_only_names_tables_that_exist():
+    """Querying an absent table errors the WHOLE union, which would turn one
+    legitimately-absent table into query-failed for all four."""
+    sql = R.ttl_query(["metric_log", "part_log"])
+    assert "system.metric_log" in sql and "system.part_log" in sql
+    assert "query_log" not in sql
+    assert sql.count("UNION ALL") == 1
+
+
+def test_listing_query_keeps_null_byte_tables():
+    """Views report NULL bytes; they stay in the listing so an orphan of ANY
+    engine is still caught."""
+    sql = R.listing_query()
+    assert "ifNull(total_bytes, 0)" in sql
+    assert "engine" not in sql.split("FROM")[1]  # no engine filter in WHERE
+
+
+def test_collect_never_puts_the_password_in_argv():
+    """The credential goes in an HTTP header and the environment, never a
+    command line."""
+    seen = []
+
+    def spy_du(argv, timeout):
+        seen.append(argv)
+        return ok_du(argv, timeout)
+
+    R.check(env={"CH_REGROWTH_URL": "http://ch.invalid",
+                 "CH_REGROWTH_PASSWORD": "s3cr3t-do-not-leak"},
+            now=NOW, query=fake_query_factory(good_responses()), du=spy_du)
+    assert seen, "du was never invoked"
+    for argv in seen:
+        assert not any("s3cr3t" in a for a in argv)
+
+
+# --------------------------------------------------------------------------- #
+# CLI — exercised as a real subprocess, including the exit code
+# --------------------------------------------------------------------------- #
+def run_cli(args, reading=None, tmp_path=None):
+    argv = [sys.executable, str(MODULE), "--no-status-file"] + args
+    if reading is not None:
+        p = tmp_path / "reading.json"
+        p.write_text(json.dumps(reading))
+        argv += ["--reading", str(p)]
+    return subprocess.run(argv, capture_output=True, text=True)
+
+
+def test_cli_clean_reading_exits_zero(tmp_path):
+    r = run_cli(["--json", "--now", str(NOW)], baseline_reading(), tmp_path)
+    assert r.returncode == R.EXIT_OK, r.stdout + r.stderr
+    assert json.loads(r.stdout)["state"] == R.STATE_OK
+
+
+def test_cli_bad_reading_exits_one(tmp_path):
+    """🔴 The negative control at the process boundary — the layer systemd
+    actually reads."""
+    bad = baseline_reading(du_bytes=5 * R.GIB,
+                           tables=baseline_tables()
+                           + [tbl("system", "trace_log", rows=3_770_000_000,
+                                  size=110 * R.GIB)])
+    r = run_cli(["--json", "--now", str(NOW)], bad, tmp_path)
+    assert r.returncode == R.EXIT_ALARM
+    v = json.loads(r.stdout)
+    assert v["state"] == R.STATE_ALARM
+    assert {f["check"] for f in v["findings"]} >= {"store-size",
+                                                   "forbidden-tables",
+                                                   "table-size"}
+
+
+def test_cli_unreadable_reading_exits_two(tmp_path):
+    p = tmp_path / "nope.json"
+    r = subprocess.run([sys.executable, str(MODULE), "--no-status-file",
+                        "--json", "--reading", str(p)],
+                       capture_output=True, text=True)
+    assert r.returncode == R.EXIT_UNKNOWN
+    assert json.loads(r.stdout)["state"] in R.UNKNOWN_STATES
+
+
+def test_cli_unconfigured_live_run_exits_two(tmp_path):
+    """No CH_REGROWTH_URL in a scrubbed env: the live path must refuse, not
+    report a clean store."""
+    r = subprocess.run([sys.executable, str(MODULE), "--no-status-file",
+                        "--json"],
+                       capture_output=True, text=True,
+                       env={"PATH": "/usr/bin:/bin", "HOME": str(tmp_path)})
+    assert r.returncode == R.EXIT_UNKNOWN
+    assert json.loads(r.stdout)["state"] == R.STATE_NOT_CONFIGURED
+
+
+def test_cli_writes_a_discoverable_status_file(tmp_path):
+    p = tmp_path / "sub" / "status.json"
+    reading = tmp_path / "reading.json"
+    reading.write_text(json.dumps(baseline_reading()))
+    r = subprocess.run([sys.executable, str(MODULE), "--reading", str(reading),
+                        "--now", str(NOW), "--status-file", str(p)],
+                       capture_output=True, text=True)
+    assert r.returncode == R.EXIT_OK, r.stdout + r.stderr
+    v = json.loads(p.read_text())
+    assert v["state"] == R.STATE_OK
+    assert v["measurements"]["du_bytes"] == DU_BASELINE
+    assert v["checked_at"] > 0
+
+
+# --------------------------------------------------------------------------- #
+# Deployment wiring — the check is worthless if it is not actually scheduled
+# --------------------------------------------------------------------------- #
+HOME_NIX = MODULE.parent.parent.parent / "nix" / "home.nix"
+
+
+@pytest.fixture(scope="module")
+def home_nix():
+    assert HOME_NIX.is_file(), HOME_NIX
+    return HOME_NIX.read_text()
+
+
+def test_unit_and_timer_are_workbench_only(home_nix):
+    """The laptop's unresolved nebula fault makes these queries stall, and a
+    flaky check gets ignored. Both halves must be serverMode-gated."""
+    for unit in ("systemd.user.services.ch-regrowth-check",
+                 "systemd.user.timers.ch-regrowth-check"):
+        assert unit in home_nix, unit
+        line = [l for l in home_nix.splitlines() if unit in l][0]
+        assert "lib.mkIf serverMode" in line, line
+
+
+def test_timer_fires_monthly_on_the_11th_and_catches_up(home_nix):
+    block = home_nix.split("systemd.user.timers.ch-regrowth-check")[1][:600]
+    assert 'OnCalendar = "*-*-11 09:00:00"' in block
+    # A missed run with the host off must fire on next boot — the growth this
+    # watches for is slow and unattended.
+    assert "Persistent = true" in block
+
+
+def test_failure_is_surfaced_through_the_existing_notify_path(home_nix):
+    """No new notification mechanism: the repo's OnFailure -> notify-failure@
+    template (scripts/notify-failure.sh) is what makes an ALARM loud."""
+    block = home_nix.split("systemd.user.services.ch-regrowth-check")[1][:2000]
+    assert 'OnFailure = [ "notify-failure@%n.service" ]' in block
+    # 🔴 SuccessExitStatus would swallow exit 2 (CANNOT TELL) and exit 3 (WARN),
+    # turning "could not measure" into a silent success. It must not be set.
+    assert "SuccessExitStatus" not in block
+
+
+def test_unit_runs_the_committed_wrapper_with_its_deps_on_path(home_nix):
+    block = home_nix.split("systemd.user.services.ch-regrowth-check")[1][:2000]
+    assert "scripts/collector/run-regrowth-check.sh" in block
+    for dep in ("pkgs.python312", "pkgs.kubectl", "pkgs.sops"):
+        assert dep in block, dep
+    # X-Restart-Triggers must cover BOTH halves, or a change to one ships
+    # without re-running the unit.
+    assert "../scripts/collector/ch_regrowth.py" in block
+    assert "../scripts/collector/run-regrowth-check.sh" in block
+
+
+def test_wrapper_fails_closed_when_the_age_key_is_missing(tmp_path):
+    """🔴 The wrapper's own negative control. A sops decrypt it cannot do must
+    exit 2 (CANNOT TELL), NOT 0 — the opposite of run-sync.sh's best-effort
+    block, and the reason that difference is commented in both files."""
+    wrapper = MODULE.parent / "run-regrowth-check.sh"
+    bash = shutil.which("bash")
+    assert bash, "bash must be on PATH — this test drives the REAL wrapper"
+    # PATH is inherited on purpose: the age-key guard is the FIRST check in the
+    # wrapper, so this exercises it regardless of whether sops/kubectl exist.
+    r = subprocess.run([bash, str(wrapper)], capture_output=True, text=True,
+                       env={"PATH": os.environ.get("PATH", ""),
+                            "HOME": str(tmp_path),
+                            "HOMELAB": str(tmp_path / "absent"),
+                            "SOPS_AGE_KEY_FILE": str(tmp_path / "no.key")})
+    assert r.returncode == R.EXIT_UNKNOWN, r.stdout + r.stderr
+    assert "CANNOT TELL" in r.stderr


### PR DESCRIPTION
## Why

On **2026-08-03** the ClickHouse store behind `activity.events` was cut **112.4 GB → 82.1 MB** after `system.trace_log` accumulated **3.77 billion rows in ~5 weeks**. Two fixes landed: **A1** the truncate, **A2** a Flux config change (logger `trace`→`warning`; `text_log`/`trace_log`/`latency_log`/`processors_profile_log` removed; 7d/14d TTLs; merge pool 32→8 slots).

**Nothing in the pipeline would notice A2 silently reverting.** A config revert, a chart bump restoring upstream defaults, or a TTL that quietly stops binding all reproduce the same outcome, and the only symptom is a disk filling up months later. This PR adds the check that notices, on a timer, loud on failure.

🔴 **No TTL had fired even once when this was written** — every system-log row was younger than its own 7-day TTL, so the mechanism that is supposed to bound growth had never been observed working. First real evidence lands **2026-08-10** (7d) and **2026-08-17** (14d). Check 5 below is the one that will matter on those dates.

## What it asserts (read-only — SELECTs and one `du`; no TTL change, no TRUNCATE, no DROP)

| # | check | threshold |
|---|---|---|
| 1 | `du /var/lib/clickhouse/store` | > 2 GiB **ALARM**, > 1 GiB **WARN** |
| 2 | any table named `*_0` | **ALARM** (baseline 0) |
| 3 | `trace_log` / `text_log` / `latency_log` / `processors_profile_log` exists | **ALARM** |
| 4 | any single table > 250 MiB | **ALARM** |
| 5 | **TTL effectiveness** — `min(event_time)` age | **ALARM** past 8d (`metric_log`, `asynchronous_metric_log`) / 15d (`query_log`, `part_log`) |

Check 2 is the non-obvious one: applying a `<ttl>` to an existing `*_log` makes ClickHouse **rename the old table to `<name>_0`** and start a fresh one. The renamed table keeps its rows **with no TTL, forever** — a silent regrowth vector that looks like nothing at all.

Check 5 is the only one that tests the **mechanism** rather than today's outcome.

🔴 The `du` gap is **not** a leak. `du` sits persistently ~40% above the live `total_bytes` sum because the merge pool was cut 32→8, so inactive parts clear more slowly. Thresholds are on `du` itself, sized against the projected steady state (~400 MiB live / 550–700 MiB of `du`). This is stated in the module docstring so nobody re-derives an alarm from the gap.

## 🔴 A zero from a broken client must never read as a clean store

Every reassuring answer this check can give is a **zero** — zero orphans, zero forbidden tables, zero oversized tables. A zero is exactly what a mistyped table name, a failed auth, a missing pod or a harness wired to nothing also produces. Following `deadman.py`:

* Every non-evaluable condition gets its **own state**, and none of them is `ok`: `not-configured`, `unreachable`, `query-failed`, `exec-failed`, `no-data`. There is no code path on which an error yields a healthy verdict, and none of them exits 0.
* `ok` carries **positive controls** and refuses to be reached unless the read demonstrably *can* observe what it is counting:
  * the listing came back non-empty, **and**
  * the sentinel `activity.events` is in it (proves this is the right server), **and**
  * suffix matching found >0 tables ending `_log` — the same code path that reports 0 orphan `*_0` tables, **and**
  * the byte comparison found >0 tables over 1 MiB — the same comparison that reports 0 tables over 250 MiB, **and**
  * ≥1 TTL target was actually measured.
* Each control's **observed number is printed next to the zero it validates**. The output reads `0 orphan '*_0' tables (control: 14 tables matched '*_log')`, never a bare zero. This is the same pairing the preliminary manual run used (query at >1 MiB returns 6 rows, validating the >250 MiB query that returns none).

Credentials are decrypted at run time via `sops` (no plaintext at rest) and passed by **environment and HTTP header, never argv**. The wrapper's guards **fail closed** (exit 2) — deliberately the opposite of `run-sync.sh`'s best-effort sops block, and commented as such in both files: a telemetry-off scan is still useful, but a check that could not measure must never look like a check that measured a clean store.

## Scheduling

`systemd.user.{services,timers}.ch-regrowth-check`, following the `mail-actions-archive` / `initiatives-sync` shape.

* **`OnCalendar = "*-*-11 09:00:00"`, `Persistent = true`** — `systemd-analyze calendar` confirms next elapse **2026-08-11**, then 09-11, 10-11, monthly. The 11th is not arbitrary: it is the first date on which the 7-day TTLs have anything to act on. `Persistent` so a run missed with the host off fires on next boot, which matters precisely because this growth is slow and unattended.
* **Workbench-only**, via the existing `serverMode` gate. The laptop is nebula-only and has an open, unresolved nebula fault that makes these queries intermittently stall to timeout (`claudedocs/handoff-agent-setup-audit.md`, investigation 1). A check that flakes is a check that gets ignored — the exact failure mode this exists to prevent. A laptop run is still possible by hand and the command is in the unit comment and the skill.
* **No new notification mechanism.** Exit `0 ok · 1 ALARM · 2 CANNOT TELL · 3 WARN`; every non-zero is a unit failure, and the existing `OnFailure = notify-failure@%n.service` turns it into a sticky critical toast. `SuccessExitStatus` is deliberately **not** set — exit 2 must toast too. The verdict plus every number read also lands in `~/.cache/ch-regrowth/status.json`.

## Verification

**Live, read-only, against the real store** (over nebula, from the laptop):

```
ch-regrowth: OK   alarms=0 warns=0
store du:        523.7 MiB (warn 1.0 GiB / alarm 2.0 GiB)
live table bytes: 200.3 MiB
tables:          120 seen, 7 non-empty, largest system.metric_log (82.7 MiB)
counts:          orphan '*_0'=0  forbidden=0  over 250.0 MiB=0
positive controls (a zero above is only meaningful if these are non-zero):
  listing rows            = 120
  sentinel activity.events= True
  tables matching '*_log'  = 14   (vs orphan '*_0' = 0)
  tables over 1.0 MiB     = 6   (vs over 250.0 MiB = 0)
  TTL tables measured     = 4
ttl target                         rows   oldest_d    bound_d  verdict
asynchronous_metric_log        70602338       3.55          8  measured
metric_log                       306900       3.55          8  measured
part_log                          48473       3.55         15  measured
query_log                         41300       3.55         15  measured
EXIT=0
```

**Negative controls — the REAL captured reading re-seeded with each fault, through the real CLI:**

| seeded fault | exit | state | findings |
|---|---|---|---|
| *(unseeded control)* | 0 | ok | – |
| store 3 GiB | 1 | alarm | store-size |
| store 1.5 GiB | 3 | warn | store-size |
| orphan `system.metric_log_0` | 1 | alarm | orphan-tables |
| `trace_log` resurrected | 1 | alarm | forbidden-tables, table-size |
| `metric_log` 400 MiB | 1 | alarm | table-size |
| `metric_log` oldest row 20d | 1 | alarm | ttl-effectiveness |
| `query_log` oldest row 20d | 1 | alarm | ttl-effectiveness |
| empty listing | 2 | no-data | – |

**Positive control pairs** (reported as pairs, never as a lone zero): 14 `*_log` matches vs 0 `*_0` orphans · 6 tables over 1 MiB vs 0 over 250 MiB · 4 TTL targets measured. Seeded orphans move the count 0 → 2 through the same code path.

**Error paths**: auth failure (HTTP 401), unreachable server, unparseable response, empty response body, `kubectl exec` NotFound and unparseable `du` each produce a CANNOT-TELL state and a non-zero exit. A dedicated test sweeps every unknown state and asserts none is `ok`/`warn`/`alarm` and all exit non-zero. The injection harness has its own negative control — a test proving the fake wiring *can* reach `ok`, so the failure tests fail for their stated reason.

**Mutation sweep** (a suite never watched to fail proves nothing):
* **Checker: 20/20 mutants killed**, with the sweep's own negative control reported (unmutated copy: 64 passed). Two mutants **survived the first run** and were fixed: `pc-suffix-gate` and `pc-empty-listing` were green only because a *later* gate returned the same `no-data` state, so the tests passed with the guard deleted. Each now pins **that guard's own message**, and both then died.
* **Nix wiring: 8/8 killed** — dropping either `serverMode` gate, changing `OnCalendar` to daily, dropping `Persistent`, dropping `OnFailure`, adding `SuccessExitStatus`, dropping `sops` from the unit PATH, and dropping the `.py` `X-Restart-Trigger` each turn the suite red.

**Authoritative gate** — `nix build .#checks.x86_64-linux.pytests --no-link --print-build-logs`:

| | collected | passed | failed | skipped |
|---|---|---|---|---|
| this branch | **6228** | **6197** | 28 | 3 |
| `main` (control) | 6160 | 6129 | 28 | 3 |

**+68 collected, +68 passed, zero new failures, zero new skips.** Floor 5600, cleared.

🔴 **The 28 failures and the 2 unpinned skips are PRE-EXISTING and reproduce identically on `main`** — I ran the same gate against the unmodified base clone before drawing any conclusion. 27 are `FileNotFoundError: '/usr/bin/env'` in the nix sandbox (`monitor-blackout` / `rig-control` tests shelling out through a shebang) and 1 is an espanso `:date` trigger assertion in `scripts/collector/keylog/tests`. Both are unrelated to this change and out of scope here, but the gate is **currently red on `main`** and someone should unbreak it.

`nix-instantiate --parse nix/home.nix` passes. All new files are explicitly staged.

## 🔴 What is NOT verified

* **The timer is not deployed.** No `home-manager switch` was run — that is the operator's step. Deployed ≠ verified, and neither has happened.
* **No TTL expiry has been observed.** Every measurement above was taken at ~3.5 days of data age, so check 5 has only ever been exercised against *seeded* stale rows, never a real TTL boundary. The first genuine evidence is the **2026-08-11** run.
* The live run was made from the **laptop over nebula**; the unit will run on the **workbench over the LAN**, a different network path and kubeconfig than the one exercised.

<!-- generated with Claude Code -->
