### PR TITLE
🔴 DO-NOT-MERGE-YET: airvpn killswitch — close the fail-open, stop root-sourcing the site config, fix the apply/doc order

### DIFF
--- a/claude/skills/bar/airvpn.md
+++ b/claude/skills/bar/airvpn.md
@@ -91,22 +91,40 @@ not see forwarded pod traffic, and LAN + nebula survive — but you will blackho
 egress. Check first:
 
 ```
-ip link show airvpn >/dev/null 2>&1 && echo TUNNEL-UP || echo TUNNEL-DOWN-DO-NOT-ARM
+ip -br link show airvpn 2>/dev/null | grep -qw UP \
+  && sudo wg show airvpn latest-handshakes | grep -qv '\b0$' \
+  && echo TUNNEL-UP || echo TUNNEL-NOT-READY-DO-NOT-ARM
 ```
+
+🔴 **EXISTENCE IS NOT UP-NESS.** `ip link show airvpn` alone succeeds for an interface left
+behind by a half-failed `wg-quick up` — a state in which `wg show … fwmark` still fails and
+arming still blackholes you. The check above requires the link to be **UP** *and* wg to report
+a **non-zero handshake**, i.e. a peer that has actually answered.
 
 **Instant bail, from the LAN session, at any point:** `sudo nft delete table inet airvpn_ks`.
 
 1. Run it from a **LAN session** (192.168.50.x — always allowed = your recovery path) held open.
 2. Site config exists: `sudo test -f /etc/airvpn-updown.env && sudo stat -c '%U:%G %a' /etc/airvpn-updown.env`
    → expect `root:root 600`. Create it first if not (Procedures step 1).
-3. **Install the edited helper** — without this you are testing the OLD script:
+3. **Install the edited helper** — without this you are testing the OLD script.
+   🔴 **Confirm the right branch is checked out FIRST** — the whole reason this step exists is
+   that the deployed helper was found byte-identical to `main` while the PR was open:
+   `git -C ~/workspace/devrc status -sb | head -1` → expect the branch under test, clean.
+   Then:
    `sudo install -m 0755 -o root -g root ~/workspace/devrc/scripts/airvpn-updown /etc/nixos/i3blocks-scripts/airvpn-updown`
 4. `sudo /etc/nixos/i3blocks-scripts/airvpn-updown check-env` → **`lighthouse=<ip> state=ok`**.
    `state=unreadable-by-uid-…` means you dropped the `sudo`, not that the file is wrong.
 5. Re-arm: `sudo /etc/nixos/i3blocks-scripts/airvpn-updown up airvpn`
 6. `journalctl -t airvpn-updown -n5` → **`up: killswitch ARMED(primary) … lighthouse=<ip>`**.
-   `ARMED(fallback)` = the primary ruleset did not load. `NOT-ARMED` = **the uplink is
-   unfiltered**. `lighthouse=UNSET` = the site config was missing, rejected or malformed.
+   Anything else is a STOP:
+   - 🔴 `ARMED(fallback)` → **BAIL NOW** (`sudo nft delete table inet airvpn_ks`). The blanket
+     fallback has **no `meta mark` accept**, so wg's own encrypted packets are dropped and the
+     tunnel dies. Do not continue to step 10 — you will get a confusing `curl` failure instead
+     of a diagnosed one.
+   - 🔴 `STALE(previous)` → **BAIL NOW.** Both loads failed and an OLDER table survived; it was
+     built for a different endpoint/fwmark and does not match this tunnel.
+   - 🔴 `NOT-ARMED` → the uplink is **unfiltered**. Fix the load error before going further.
+   - `lighthouse=UNSET` → the site config was missing, rejected or malformed (step 2/4).
 7. 🔴 **`ip route get <lighthouse-ip>`** — the ONLY step that observes the `/32` bypass, i.e.
    the thing A-1 is about. `via <lan-gw> dev <phys>` = the bypass is present;
    `dev airvpn` = it is GONE and lighthouse traffic is inside the tunnel.
@@ -119,15 +137,49 @@ ip link show airvpn >/dev/null 2>&1 && echo TUNNEL-UP || echo TUNNEL-DOWN-DO-NOT
 10. Exit IP is the tunnel: `curl -s https://ipinfo.io/json` → **CA** and an AirVPN `org`,
     NOT your home ISP's IP/org. (This repo is PUBLIC — the home IP is deliberately not
     written down here; compare against the same command with the tunnel DOWN.)
-11. **Confirm off-LAN:** `ssh zach@10.42.0.30` still connects (proves the nebula path survived —
-    the LAN test can't cover this).
+11. 🔴 **Confirm OFF-LAN — and this step is worthless unless you run it FROM somewhere else.**
+
+    `10.42.0.30` is the **workbench's own** nebula address. Steps 1–10 put you *on the
+    workbench, on the LAN*, so running `ssh zach@10.42.0.30` there is a **self-ssh**; from
+    another machine on the same LAN it is a same-LAN hop. Neither touches the nebula
+    **direct-punch** path — the one this section's opening line says a LAN-only test cannot
+    reach, and the one that locked the host out in #118.
+
+    Run it **from a genuinely off-LAN host** — the laptop on a phone hotspot / any network that
+    is not `192.168.50.0/24`, reaching the workbench over nebula:
+
+    ```
+    # ON THE LAPTOP (off-LAN), toward the workbench:
+    ip -br addr | grep -q '192\.168\.50\.' && echo "STILL ON THE LAN — this proves nothing"
+    ssh -o ConnectTimeout=10 zach@10.42.0.30 'echo off-lan-ok; hostname'
+    ```
+
+    * **PASS** — `off-lan-ok` plus the workbench's hostname within the timeout. The overlay
+      survived the killswitch, including the direct-punch path.
+    * **FAIL** — timeout, `No route to host`, or a hang. The killswitch is eating nebula
+      transport. **Bail from the LAN session you held open in step 1**:
+      `sudo nft delete table inet airvpn_ks`. That is what step 1 is for.
+    * **INVALID** — the guard line above printed anything. You are on the LAN; the result tells
+      you nothing either way, so do not record it as a pass.
+
+    If no off-LAN host is available, this protocol **cannot be completed** — say so rather than
+    substituting the self-ssh, which passes unconditionally.
 
 ## Debug / bail
 - arm line: `journalctl -t airvpn-updown -n5` →
   `up: killswitch ARMED(primary) (fwmark=…) policing [<nics>], gw=… ep=… lighthouse=<ip>`.
-  Three states: `ARMED(primary)` · `ARMED(fallback)` (degraded — no `meta mark` accept) ·
-  `NOT-ARMED` (**uplink unfiltered**; the kernel is asked with `nft list table`, the line is
-  not written from an exit status).
+  **FOUR states.** The kernel is asked with `nft list table`; the line is never written from an
+  exit status. Only the first is a pass:
+
+  | state | meaning | what to do |
+  |---|---|---|
+  | `ARMED(primary)` | the intended ruleset is installed | continue |
+  | `ARMED(fallback)` | blanket fail-closed ruleset — **no `meta mark` accept, so wg's own encrypted packets are dropped and the tunnel dies** | 🔴 **BAIL** |
+  | `STALE(previous)` | both loads failed; an OLDER table survived the atomic load. Built for a different endpoint/fwmark — it can read as filtering while the tunnel is dead | 🔴 **BAIL** |
+  | `NOT-ARMED` | no table at all — **the uplink is UNFILTERED** | 🔴 fix the load error |
+
+  `STALE(previous)` only became reachable when the load was made atomic: before that, a failed
+  load had already flushed the table, so "both failed" always meant NOT-ARMED.
 - instant bail that KEEPS the tunnel up (drops the killswitch only):
   `sudo nft delete table inet airvpn_ks`.
 - connect / disconnect (NOPASSWD): `sudo /etc/nixos/i3blocks-scripts/airvpn-sudo {up,down}`.

--- a/claude/skills/bar/airvpn.md
+++ b/claude/skills/bar/airvpn.md
@@ -46,18 +46,38 @@ enumerate-internal-networks allow-list first dropped the nebula overlay (would h
 out of the remote host, #118), then dropped k3s apiserver→pod replies and CrashLooped the cluster
 (#126); uplink-only + skuid is leak-equivalent and durable (#122/#128).
 
+🔴 **`/etc/airvpn-updown.env` (root-owned, 0600, untracked) is a PREREQUISITE, not an
+afterthought** — one line, `NEBULA_LIGHTHOUSE=<lighthouse public IP>`. This repo is PUBLIC,
+so the IP is not committed (`scripts/tests/test_no_public_ips.py` enforces that). Without it
+the killswitch still arms, but the lighthouse's direct bypass route + nft accept are omitted
+and the arm line reads `lighthouse=UNSET`. The script **parses** this file (it never sources
+it) and **ignores it** if it is not root/self-owned, if it is group/other-writable, or if the
+value is not an IP — each of those logs a reason. **Check `lighthouse=` after any re-arm**;
+`UNSET` on a host that should have it means the file is missing or was rejected, NOT that the
+change worked.
+`sudo /etc/nixos/i3blocks-scripts/airvpn-updown check-env` prints the resolved value without
+touching a single rule or route.
+
 ## Procedures
-- **Apply / re-apply Phase 2:** `sudo bash ~/workspace/devrc/nix/system/apply-airvpn-host.sh`
-  (secret conf `/etc/wireguard/airvpn.conf` must exist first; installs helpers →
-  `/etc/nixos/i3blocks-scripts/`, copies the module, wires `configuration.nix` `imports`,
-  `nixos-rebuild`). Default-OFF — does NOT bring the tunnel up.
-- **Ship a helper edit (no rebuild):** after editing `scripts/airvpn-{updown,sudo}`, re-install
-  with plain `sudo install -m 0755 -o root -g root ~/workspace/devrc/scripts/airvpn-updown /etc/nixos/i3blocks-scripts/airvpn-updown`
-  (same for `airvpn-sudo`). They're plain scripts and the NOPASSWD sudoers rule points at that
-  path — **no `nixos-rebuild` needed**.
-- **Apply a killswitch edit WITHOUT dropping the tunnel:**
-  `sudo /etc/nixos/i3blocks-scripts/airvpn-updown up airvpn` re-arms in place (flush+reload the
-  `airvpn_ks` table) — no reconnect.
+🔴 **These are in dependency order. Do not reorder them** — the site config has to exist
+before the helper that reads it is installed, or you install and re-arm a degraded killswitch.
+
+1. **Create the site config (FIRST, once per host):**
+   `printf 'NEBULA_LIGHTHOUSE=%s\n' <lighthouse ip> | sudo install -m 0600 -o root -g root /dev/stdin /etc/airvpn-updown.env`
+2. **Apply / re-apply Phase 2:** `NEBULA_LIGHTHOUSE=<ip> sudo -E bash ~/workspace/devrc/nix/system/apply-airvpn-host.sh`
+   (secret conf `/etc/wireguard/airvpn.conf` must exist first; **refuses** unless the site
+   config exists or you pass `NEBULA_LIGHTHOUSE=` / `ALLOW_NO_LIGHTHOUSE=1`; installs helpers →
+   `/etc/nixos/i3blocks-scripts/`, copies the module, wires `configuration.nix` `imports`,
+   `nixos-rebuild`). Default-OFF — does NOT bring the tunnel up.
+3. **Ship a helper edit (no rebuild):** after editing `scripts/airvpn-{updown,sudo}`, re-install
+   with plain `sudo install -m 0755 -o root -g root ~/workspace/devrc/scripts/airvpn-updown /etc/nixos/i3blocks-scripts/airvpn-updown`
+   (same for `airvpn-sudo`). They're plain scripts and the NOPASSWD sudoers rule points at that
+   path — **no `nixos-rebuild` needed**. Step 1 must already be done on this host.
+4. **Apply a killswitch edit WITHOUT dropping the tunnel:**
+   `sudo /etc/nixos/i3blocks-scripts/airvpn-updown up airvpn` re-arms in place (flush+reload the
+   `airvpn_ks` table) — no reconnect. 🔴 Re-arming **deletes the table first**, so a re-arm that
+   fails to load leaves you with the blanket fallback, and a re-arm with a bad site config
+   leaves you with `lighthouse=UNSET`. Read `journalctl -t airvpn-updown -n5` every time.
 
 ## 🔴 Mandatory re-test protocol for ANY killswitch change
 A LAN-only test CANNOT reach the nebula direct-punch lockout mode, so it is NOT sufficient:

--- a/claude/skills/bar/airvpn.md
+++ b/claude/skills/bar/airvpn.md
@@ -80,22 +80,54 @@ before the helper that reads it is installed, or you install and re-arm a degrad
    leaves you with `lighthouse=UNSET`. Read `journalctl -t airvpn-updown -n5` every time.
 
 ## 🔴 Mandatory re-test protocol for ANY killswitch change
-A LAN-only test CANNOT reach the nebula direct-punch lockout mode, so it is NOT sufficient:
+A LAN-only test CANNOT reach the nebula direct-punch lockout mode, so it is NOT sufficient.
+
+🔴 **PRECONDITION — THE TUNNEL MUST ALREADY BE UP.** `airvpn-updown up` arms the killswitch
+against whatever it can see *now*. With the tunnel DOWN, `wg show … fwmark` fails (no
+`meta mark` accept) and there is no endpoint accept, so the chain reduces to
+*allow LAN + gateway + nebula-by-skuid + lighthouse, then **drop***, and **every other
+host-originated packet on a physical NIC is dropped**. It is bounded — the output hook does
+not see forwarded pod traffic, and LAN + nebula survive — but you will blackhole the host's own
+egress. Check first:
+
+```
+ip link show airvpn >/dev/null 2>&1 && echo TUNNEL-UP || echo TUNNEL-DOWN-DO-NOT-ARM
+```
+
+**Instant bail, from the LAN session, at any point:** `sudo nft delete table inet airvpn_ks`.
+
 1. Run it from a **LAN session** (192.168.50.x — always allowed = your recovery path) held open.
-2. Workbench k3s healthy:
+2. Site config exists: `sudo test -f /etc/airvpn-updown.env && sudo stat -c '%U:%G %a' /etc/airvpn-updown.env`
+   → expect `root:root 600`. Create it first if not (Procedures step 1).
+3. **Install the edited helper** — without this you are testing the OLD script:
+   `sudo install -m 0755 -o root -g root ~/workspace/devrc/scripts/airvpn-updown /etc/nixos/i3blocks-scripts/airvpn-updown`
+4. `sudo /etc/nixos/i3blocks-scripts/airvpn-updown check-env` → **`lighthouse=<ip> state=ok`**.
+   `state=unreadable-by-uid-…` means you dropped the `sudo`, not that the file is wrong.
+5. Re-arm: `sudo /etc/nixos/i3blocks-scripts/airvpn-updown up airvpn`
+6. `journalctl -t airvpn-updown -n5` → **`up: killswitch ARMED(primary) … lighthouse=<ip>`**.
+   `ARMED(fallback)` = the primary ruleset did not load. `NOT-ARMED` = **the uplink is
+   unfiltered**. `lighthouse=UNSET` = the site config was missing, rejected or malformed.
+7. 🔴 **`ip route get <lighthouse-ip>`** — the ONLY step that observes the `/32` bypass, i.e.
+   the thing A-1 is about. `via <lan-gw> dev <phys>` = the bypass is present;
+   `dev airvpn` = it is GONE and lighthouse traffic is inside the tunnel.
+   **Step 10 cannot substitute for this**: with a healthy tunnel, lighthouse traffic routed
+   *into* the tunnel still arrives, so the ssh check passes either way.
+8. Workbench k3s healthy:
    `KUBECONFIG=/home/zach/workspace/homelab-talos/workbench-kubeconfig kubectl get pods -A | grep -vE 'Running|Completed'`
    (expect nothing bad).
-3. Nebula overlay intact: `KUBECONFIG=$KC_HOMELAB kubectl get nodes` → **4 nodes**.
-4. Exit IP is the tunnel: `curl -s https://ipinfo.io/json` → **CA** and an AirVPN `org`,
-   NOT your home ISP's IP/org. (This repo is PUBLIC — the home IP is deliberately not
-   written down here; compare against `curl -s https://ipinfo.io/json` with the tunnel
-   DOWN.)
-5. **Confirm off-LAN:** `ssh zach@10.42.0.30` still connects (proves the nebula path survived —
-   the LAN test can't cover this).
+9. Nebula overlay intact: `KUBECONFIG=$KC_HOMELAB kubectl get nodes` → **4 nodes**.
+10. Exit IP is the tunnel: `curl -s https://ipinfo.io/json` → **CA** and an AirVPN `org`,
+    NOT your home ISP's IP/org. (This repo is PUBLIC — the home IP is deliberately not
+    written down here; compare against the same command with the tunnel DOWN.)
+11. **Confirm off-LAN:** `ssh zach@10.42.0.30` still connects (proves the nebula path survived —
+    the LAN test can't cover this).
 
 ## Debug / bail
 - arm line: `journalctl -t airvpn-updown -n5` →
-  `up: killswitch armed (fwmark=…) policing [<nics>] …`.
+  `up: killswitch ARMED(primary) (fwmark=…) policing [<nics>], gw=… ep=… lighthouse=<ip>`.
+  Three states: `ARMED(primary)` · `ARMED(fallback)` (degraded — no `meta mark` accept) ·
+  `NOT-ARMED` (**uplink unfiltered**; the kernel is asked with `nft list table`, the line is
+  not written from an exit status).
 - instant bail that KEEPS the tunnel up (drops the killswitch only):
   `sudo nft delete table inet airvpn_ks`.
 - connect / disconnect (NOPASSWD): `sudo /etc/nixos/i3blocks-scripts/airvpn-sudo {up,down}`.

--- a/nix/system/apply-airvpn-host.sh
+++ b/nix/system/apply-airvpn-host.sh
@@ -18,6 +18,78 @@
 # =============================================================================
 set -euo pipefail
 
+# ---------------------------------------------------------------------------- #
+# ensure_site_env — /etc/airvpn-updown.env, the killswitch's site config.
+# ---------------------------------------------------------------------------- #
+# 🔴 THIS RUNS BEFORE THE HELPERS ARE INSTALLED, ON PURPOSE. `airvpn-updown`
+# reads NEBULA_LIGHTHOUSE from this file; without it the killswitch still arms
+# but silently loses the nebula lighthouse's bypass route and nft accept —
+# a DEGRADED killswitch that looks fine. Installing the helper first and
+# mentioning the file afterwards is how an operator following this top-to-bottom
+# ends up re-arming before the file exists (audit A-3).
+#
+# The wg conf (step 1) is the model: it REFUSES rather than proceeding without
+# the operator's secret. This does the same, with an explicit opt-out for a host
+# that genuinely has no lighthouse.
+#
+#   NEBULA_LIGHTHOUSE=<ip> sudo -E bash nix/system/apply-airvpn-host.sh
+#   ALLOW_NO_LIGHTHOUSE=1  sudo -E bash nix/system/apply-airvpn-host.sh
+#
+# $AIRVPN_SITE_ENV overrides the path (the tests point it at a tmp file).
+ensure_site_env() {
+  local f="${AIRVPN_SITE_ENV:-/etc/airvpn-updown.env}"
+
+  if [[ -f "${f}" ]]; then
+    # Exists: make the ownership/mode true rather than assuming it. Whoever can
+    # write this file names a destination that gets BOTH a main-table bypass
+    # route and an nft accept — a hole punched through the killswitch.
+    chown root:root "${f}" 2>/dev/null || true
+    chmod 0600 "${f}"
+    if ! grep -qE '^[[:space:]]*NEBULA_LIGHTHOUSE[[:space:]]*=[[:space:]]*[0-9A-Fa-f.:]+[[:space:]]*$' "${f}"; then
+      echo "  -> WARNING: ${f} exists but has no plain NEBULA_LIGHTHOUSE=<ip> line." >&2
+      echo "     The killswitch will arm with lighthouse=UNSET. Check it after re-arming:" >&2
+      echo "       journalctl -t airvpn-updown -n5" >&2
+    else
+      echo "  -> ${f} present (root:root 0600)."
+    fi
+    return 0
+  fi
+
+  if [[ -n "${NEBULA_LIGHTHOUSE:-}" ]]; then
+    ( umask 077; printf 'NEBULA_LIGHTHOUSE=%s\n' "${NEBULA_LIGHTHOUSE}" > "${f}" )
+    chown root:root "${f}" 2>/dev/null || true
+    chmod 0600 "${f}"
+    echo "  -> created ${f} (root:root 0600) from \$NEBULA_LIGHTHOUSE."
+    return 0
+  fi
+
+  if [[ -n "${ALLOW_NO_LIGHTHOUSE:-}" ]]; then
+    echo "  -> ${f} absent; ALLOW_NO_LIGHTHOUSE=1 set, continuing." >&2
+    echo "     The killswitch will arm with lighthouse=UNSET — the direct" >&2
+    echo "     un-tunnelled path to the nebula lighthouse is NOT preserved." >&2
+    return 0
+  fi
+
+  cat >&2 <<MSG
+[!] ${f} not found — the killswitch's site config.
+    This repo is PUBLIC, so the nebula lighthouse's public IP is not committed;
+    the killswitch reads it from this root-owned 0600 file. Without it the
+    killswitch still arms, but the lighthouse's bypass route + nft accept are
+    OMITTED — a degraded killswitch that reports success.
+
+    Re-run with the value, or opt out explicitly:
+      NEBULA_LIGHTHOUSE=<lighthouse ip> sudo -E bash nix/system/apply-airvpn-host.sh
+      ALLOW_NO_LIGHTHOUSE=1             sudo -E bash nix/system/apply-airvpn-host.sh
+MSG
+  return 1
+}
+
+# Sourced by the tests (AIRVPN_APPLY_LIB=1) to exercise ensure_site_env without
+# applying anything. When EXECUTED the variable is unset and this is a no-op.
+if [[ -n "${AIRVPN_APPLY_LIB:-}" ]]; then
+  return 0
+fi
+
 if [[ ${EUID} -ne 0 ]]; then
   echo "This must run as root:  sudo bash nix/system/apply-airvpn-host.sh" >&2
   exit 1
@@ -71,7 +143,11 @@ fi
 # ---------------------------------------------------------------------------- #
 # 3. Privileged helpers at the STABLE sudoers-trusted path (never a nix-store path).
 # ---------------------------------------------------------------------------- #
-echo "[3/5] Installing airvpn-sudo + airvpn-updown to ${HELPER_DIR}..."
+echo "[3/5] Killswitch site config + helpers..."
+# 🔴 ORDER IS LOAD-BEARING: the site config must exist BEFORE the helper that
+# reads it is installed (and before anyone re-arms with it). See ensure_site_env.
+ensure_site_env
+echo "  -> installing airvpn-sudo + airvpn-updown to ${HELPER_DIR}..."
 install -d -m 0755 "${HELPER_DIR}"
 install -m 0755 -o root -g root "${REPO}/scripts/airvpn-sudo"   "${HELPER_DIR}/airvpn-sudo"
 install -m 0755 -o root -g root "${REPO}/scripts/airvpn-updown" "${HELPER_DIR}/airvpn-updown"

--- a/scripts/airvpn-updown
+++ b/scripts/airvpn-updown
@@ -125,9 +125,18 @@ site_env_trusted() {
 
 # Extract NEBULA_LIGHTHOUSE and NOTHING else. Last assignment wins, matching
 # what sourcing would have done, without executing anything.
+#
+# 🔴 `|| [[ -n "$line" ]]` IS THE POINT, NOT A TIDY-UP (audit F3). `read` returns
+# non-zero on a final line with no trailing newline, so the plain loop DROPS it.
+# A file whose write was cut short is exactly a file with no final newline — the
+# canonical A-2 shape — and without this the value resolved to empty and fell
+# into the "key simply absent, no noise" branch below. The guard advertised as
+# "loud about a partially-written file" was SILENT for the one shape it is named
+# after. CRLF-without-final-LF has the same root cause; the `\r` then survives
+# into the value and `valid_ip` rejects it loudly, which is the correct outcome.
 site_env_lighthouse() {
     local path="$1" line val=""
-    while IFS= read -r line; do
+    while IFS= read -r line || [[ -n "$line" ]]; do
         [[ "$line" =~ ^[[:space:]]*NEBULA_LIGHTHOUSE[[:space:]]*=(.*)$ ]] || continue
         val="${BASH_REMATCH[1]}"
         val="${val%%#*}"                       # strip a trailing comment
@@ -146,36 +155,70 @@ site_env_lighthouse() {
     printf '%s' "$val"
 }
 
-# A bare IPv4/IPv6 literal and nothing else. Deliberately STRICTER than "does it
-# look like an address": anything that is not exactly an address is rejected,
-# because the value is interpolated into an nft ruleset and a shell-ish or
-# whitespace-carrying value is the fail-open above.
+# A bare, CANONICAL IPv4 dotted quad and nothing else.
+#
+# 🔴 IPv4 ONLY, DELIBERATELY (audit G1). The consumers of this value are
+# `ip daddr ${…}` — an IPv4-family nft match — and
+# `ip route replace ${…} via ${GW}` where `$GW` is the IPv4 default gateway.
+# Neither can express an IPv6 address. The previous version accepted `::`,
+# `:::::`, `0::0::0` and real v6 literals, and every one of them would have
+# passed validation and then failed the nft LOAD — which flushes the table and
+# falls through to `arm_failclosed`, a ruleset with NO `meta mark` accept, so
+# wg's own encrypted packets are dropped and THE TUNNEL DIES. Validating against
+# "is this an address" instead of "can the ruleset express this" is how a
+# validator becomes the outage.
+#
+# 🔴 LEADING ZEROS ARE REJECTED, not normalised. A zero-prefixed octet is OCTAL
+# to `getent`/`inet_aton` and DECIMAL to nft, so accepting one means the route
+# and the firewall rule name different hosts. (Measured: `getent ahostsv4` on a
+# zero-prefixed octet resolves to a different address than nft would match.)
+# `(( 10# … ))` also stops the range check itself from being an accident:
+# without it, an octet like `09` was rejected only by bash erroring with
+# "value too great for base", which is a crash, not a decision.
 valid_ip() {
-    local v="$1"
+    local v="$1" i o
     [[ -n "$v" ]] || return 1
-    if [[ "$v" =~ ^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]]; then
-        local i
-        for i in 1 2 3 4; do (( BASH_REMATCH[i] <= 255 )) || return 1; done
-        return 0
-    fi
-    # IPv6: hex groups and colons only, at least two colons, no zone/scope.
-    [[ "$v" =~ ^[0-9A-Fa-f:]+$ && "$v" == *::* ]] && return 0
-    [[ "$v" =~ ^([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}$ ]] && return 0
-    return 1
+    [[ "$v" =~ ^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]] || return 1
+    for i in 1 2 3 4; do
+        o="${BASH_REMATCH[i]}"
+        # no leading zeros (except the single digit "0" itself)
+        [[ "$o" == "0" || "$o" != 0* ]] || return 1
+        (( 10#$o <= 255 )) || return 1
+    done
+    return 0
 }
 
+# 🔴 EVERY OUTCOME EXCEPT "file is not there at all" LOGS A REASON. This block
+# runs at TOP LEVEL, which in production means inside wg-quick's PostUp as root,
+# and the operator is told to read `lighthouse=` after a re-arm — so an UNSET
+# with no reason is the failure mode that gets misread as success.
 NEBULA_LIGHTHOUSE=""
-if [[ -r "$SITE_ENV" ]] && site_env_trusted "$SITE_ENV"; then
-    _lh="$(site_env_lighthouse "$SITE_ENV")"
-    if [[ -z "$_lh" ]]; then
-        :   # key simply absent — the documented UNSET case, no noise
-    elif valid_ip "$_lh"; then
-        NEBULA_LIGHTHOUSE="$_lh"
-    else
-        # 🔴 The A-2 case. Do NOT interpolate it anywhere.
-        log "ERROR: NEBULA_LIGHTHOUSE in ${SITE_ENV} is not an IP address (${#_lh} chars) — treating as UNSET"
+if [[ -e "$SITE_ENV" || -L "$SITE_ENV" ]]; then
+    # 🔴 -f, NOT -r (audit G4). A FIFO at this path made the read block FOREVER —
+    # measured, unbounded — with wg-quick's PostUp stalled, the interface UP and
+    # the killswitch NOT yet armed: an indefinite fail-OPEN window, and a failure
+    # mode the pre-env-file script did not have because it read no file at all.
+    # A directory emitted a raw `read error: Is a directory` and silently UNSET.
+    if [[ ! -f "$SITE_ENV" ]]; then
+        log "ERROR: ${SITE_ENV} is not a regular file — IGNORING it (lighthouse UNSET)"
+    elif [[ ! -r "$SITE_ENV" ]]; then
+        # audit G3: distinct from absent. Hitting this while running `check-env`
+        # WITHOUT sudo on a correct 0600 root:root host is the expected answer,
+        # and it must say so rather than looking like "you never set it".
+        log "ERROR: ${SITE_ENV} exists but is not readable by uid $(id -u) — lighthouse UNSET (run as root?)"
+    elif site_env_trusted "$SITE_ENV"; then
+        _lh="$(site_env_lighthouse "$SITE_ENV")"
+        if [[ -z "$_lh" ]]; then
+            log "NOTE: ${SITE_ENV} has no NEBULA_LIGHTHOUSE= line — lighthouse UNSET"
+        elif valid_ip "$_lh"; then
+            NEBULA_LIGHTHOUSE="$_lh"
+        else
+            # 🔴 The A-2 case. Do NOT interpolate the value ANYWHERE — it is
+            # attacker-controlled and this line goes to syslog.
+            log "ERROR: NEBULA_LIGHTHOUSE in ${SITE_ENV} is not a canonical IPv4 address (${#_lh} chars) — treating as UNSET"
+        fi
+        unset _lh
     fi
-    unset _lh
 fi
 
 # Nebula binds listen.port:0 → a RANDOM source port, so match its transport by the
@@ -189,6 +232,38 @@ IFACE_FILE="/run/airvpn-iface"
 KS_TABLE="airvpn_ks"
 
 # (log() is defined near the top — its first callers run before this point.)
+
+# --- ATOMIC ruleset replacement (audit F4) ---------------------------------- #
+# 🔴 THIS IS THE STRUCTURAL FIX FOR A-2, and it is smaller than the validator.
+#
+# The old sequence was `nft add table` → `nft flush table` → `nft -f -`: THREE
+# transactions, the first two of which destroy the working killswitch before the
+# third is known to parse. Any failure in the third left the uplink flushed and
+# EMPTY, and the script exited 0. Validating the env value shut one door into
+# that state; it is not the only door. The fallback still interpolates
+# `$NEBULA_USER`, which comes from `id -un nebula-mesh 2>/dev/null || echo
+# nebula-mesh` — that emits the name EVEN WHEN THE ACCOUNT DOES NOT EXIST, and
+# nft must then resolve it via getpwnam at evaluation time. On a fresh host, or
+# after the nebula user is renamed, BOTH rulesets fail and you are back in the
+# original A-2 outcome by a different route.
+#
+# So: ONE `nft -f`. `table … {}` creates the table if it is absent (idempotent),
+# `delete table …` then removes it, and the full definition recreates it — all in
+# a single transaction, so a parse or evaluation failure changes NOTHING and the
+# previous killswitch stays exactly where it was.
+nft_load_atomic() {
+    local body err rc
+    body="$(cat)"
+    err="$(printf 'table inet %s {}\ndelete table inet %s\n%s\n' \
+             "$KS_TABLE" "$KS_TABLE" "$body" | nft -f - 2>&1)"
+    rc=$?
+    (( rc == 0 )) || log "nft load failed: ${err%%$'\n'*}"
+    return $rc
+}
+
+# Ask the KERNEL whether the table is there. A command's exit status is a claim
+# about the command; this is the observation (audit G6).
+ks_present() { nft list table inet "$KS_TABLE" >/dev/null 2>&1; }
 
 # Blanket FAIL-CLOSED ruleset — installed only if the main killswitch nft load
 # fails, so an nft error can never leave the uplink UNFILTERED (fail-open).
@@ -204,17 +279,29 @@ KS_TABLE="airvpn_ks"
 # The LIGHTHOUSE is deliberately ABSENT. It is the one value that comes from a
 # file on disk, it is exactly what a partially-written env file corrupts, and
 # with it in here a bad value took out BOTH the primary ruleset and its
-# fallback (audit A-2). Losing the lighthouse `accept` here costs the direct
-# un-tunnelled path to it; nebula's own transport is still allowed by the
-# `meta skuid` rule above, and the LAN rule keeps a recovery path open. That is
-# the correct trade for a fallback whose whole job is to parse.
+# fallback (audit A-2).
+#
+# 🔴 WHAT REMOVING IT ACTUALLY COSTS — read this carefully, because the obvious
+# reasoning is WRONG and an earlier version of this comment used it.
+#
+#   It is tempting to say "nebula still has egress via `meta skuid`, so we only
+#   lose the direct path". That conflates a FIREWALL decision with a ROUTING
+#   decision. `meta skuid` and `ip daddr <lighthouse>` are both ACCEPT rules in
+#   the same chain; the thing that decides whether lighthouse traffic goes out
+#   un-tunnelled is the main-table `/32` ROUTE, which lives nowhere near this
+#   ruleset and is unaffected by anything here.
+#
+#   So the honest accounting is: removing this line costs NOTHING that the
+#   `meta skuid` rule above was not already granting. `meta skuid` PRECEDES it
+#   in rule order and matches nebula's socket owner regardless of destination,
+#   so the lighthouse `accept` was DOMINATED — a no-op — in both rulesets. What
+#   ever mattered for the lighthouse is the `/32` route, and that is a separate
+#   mechanism with a separate failure mode (see the header, and A-1).
 #
 # The reachability of THIS function is what matters, not its rule count: it runs
-# only when `nft -f -` on the primary ruleset returned non-zero.
+# only when the primary `nft_load_atomic` returned non-zero.
 arm_failclosed() {
-    nft add table inet "$KS_TABLE" 2>/dev/null || true
-    nft flush table inet "$KS_TABLE" 2>/dev/null || true
-    nft -f - <<FB || log "FALLBACK nft load ALSO FAILED — uplink is NOT filtered!"
+    nft_load_atomic <<FB || { log "FALLBACK nft load ALSO FAILED — uplink is NOT filtered!"; return 1; }
 table inet ${KS_TABLE} {
     chain out {
         type filter hook output priority 0; policy accept;
@@ -301,9 +388,9 @@ case "$action" in
             log "ERROR: no physical uplink NIC found — arming FAIL-CLOSED killswitch (internal ifaces only)"
             UPLINK_GUARD='oifname { "lo", "'"${IFACE}"'", "nebula.mesh", "cni0", "flannel.1", "docker0" } accept'
         fi
-        nft add table inet "$KS_TABLE" 2>/dev/null || true
-        nft flush table inet "$KS_TABLE" 2>/dev/null || true
-        nft -f - <<NFT || { log "killswitch nft load FAILED — installing blanket fail-closed fallback"; arm_failclosed; }
+        # 🔴 ONE transaction (see nft_load_atomic). A failure here changes NOTHING
+        # — the previous killswitch, if any, is still installed.
+        if nft_load_atomic <<NFT
 table inet ${KS_TABLE} {
     chain out {
         type filter hook output priority 0; policy accept;
@@ -325,10 +412,29 @@ table inet ${KS_TABLE} {
     }
 }
 NFT
+        then
+            KS_RULESET="primary"
+        else
+            log "killswitch nft load FAILED — installing blanket fail-closed fallback"
+            if arm_failclosed; then KS_RULESET="fallback"; else KS_RULESET="none"; fi
+        fi
+
+        # 🔴 THE LOG LINE BELOW IS THE ONE THE OPERATOR IS TOLD TO READ, so it
+        # must not claim "armed" on the word of a command that returned non-zero
+        # (audit G6 — the old line was unconditional and printed `armed` even
+        # when the primary load AND the fallback had both failed, i.e. exactly
+        # when the uplink was unfiltered). ASK THE KERNEL.
+        if ks_present; then
+            KS_STATE="ARMED(${KS_RULESET})"
+        else
+            KS_STATE="NOT-ARMED"
+            log "🔴 killswitch NOT ARMED — table inet ${KS_TABLE} is ABSENT after load; the uplink is UNFILTERED"
+        fi
         # 🔴 `lighthouse=` is the field to read after a re-arm. UNSET on a host
         # that should have it means the env file is missing/untrusted/malformed,
-        # NOT that the change worked.
-        log "up: killswitch armed (fwmark=${FWMARK:-none}) policing [${PHYS_SET[*]:-FAIL-CLOSED}], gw=${GW:-none} ep=${EP:-?} lighthouse=${NEBULA_LIGHTHOUSE:-UNSET}"
+        # NOT that the change worked. `ip route get <lighthouse>` is the only
+        # check that observes the /32 bypass itself — see the `bar` skill.
+        log "up: killswitch ${KS_STATE} (fwmark=${FWMARK:-none}) policing [${PHYS_SET[*]:-FAIL-CLOSED}], gw=${GW:-none} ep=${EP:-?} lighthouse=${NEBULA_LIGHTHOUSE:-UNSET}"
         ;;
     check-env)
         # READ-ONLY. Touches no nft table, no route, no file. Exists so the env
@@ -336,7 +442,23 @@ NFT
         # its lighthouse bypass — is testable without root and without arming
         # anything. Prints one line; exits 0 when a lighthouse resolved, 1 when
         # it did not.
-        echo "lighthouse=${NEBULA_LIGHTHOUSE:-UNSET} env=${SITE_ENV}"
+        #
+        # 🔴 `state=` distinguishes the outcomes an UNSET can mean (audit G3).
+        # This is the diagnostic the operator is told to trust, and running it
+        # WITHOUT sudo on a correct 0600 root:root host is the likeliest way to
+        # see UNSET — that must read as "you are not root", not as "unset".
+        if [[ -n "$NEBULA_LIGHTHOUSE" ]]; then
+            _st="ok"
+        elif [[ ! -e "$SITE_ENV" && ! -L "$SITE_ENV" ]]; then
+            _st="absent"
+        elif [[ ! -f "$SITE_ENV" ]]; then
+            _st="not-a-regular-file"
+        elif [[ ! -r "$SITE_ENV" ]]; then
+            _st="unreadable-by-uid-$(id -u)"
+        else
+            _st="rejected-or-empty"
+        fi
+        echo "lighthouse=${NEBULA_LIGHTHOUSE:-UNSET} state=${_st} env=${SITE_ENV}"
         [[ -n "$NEBULA_LIGHTHOUSE" ]]
         exit $?
         ;;

--- a/scripts/airvpn-updown
+++ b/scripts/airvpn-updown
@@ -16,7 +16,10 @@
 #   * the VPN ENDPOINT via the original gateway (so the handshake isn't routed into
 #     the tunnel; also what a `switch` refreshes),
 #   * 192.168.50.1 (LAN router / DNS upstream) + the LAN 192.168.50.0/24 direct,
-#   * the nebula Hetzner lighthouse (discovery/relay).
+#   * the nebula lighthouse (discovery/relay) — CONDITIONAL: its public IP is not
+#     committed (this repo is PUBLIC), it is read from /etc/airvpn-updown.env, and
+#     when that is absent/untrusted/malformed this route is OMITTED. See the
+#     NEBULA_LIGHTHOUSE block below, and read `lighthouse=` in the arm line.
 #
 # KILLSWITCH (fail-closed) — POLICES ALL PHYSICAL NICs. The chain's first rule is
 # `oifname != { <all physical NICs> } accept`, so everything leaving via a
@@ -53,12 +56,128 @@ set -uo pipefail
 action="${1:-}"
 IFACE="${2:-airvpn}"
 
+# 🔴 DEFINED FIRST, BEFORE ANY CALLER. The site-config resolution below logs its
+# rejections, and it runs at top level — with this definition further down the
+# file (where it used to be) every one of those calls was `log: command not
+# found`: the guard still failed SAFE, but the REASON was lost, which is the
+# whole value of a guard that silently degrades a killswitch.
+#
+# `check-env` mirrors to stderr as well as syslog: it is an interactive
+# diagnostic, and "why is this UNSET" is the only question it is asked.
+log() {
+    [[ "$action" == "check-env" ]] && echo "airvpn-updown: $*" >&2
+    logger -t airvpn-updown "$*" 2>/dev/null || echo "airvpn-updown: $*" >&2
+}
+
 # The split-tunnel bypass destinations (mirror the old Mullvad conf). Everything
 # INTERNAL (nebula overlay, k3s pod/service CIDRs, CNI bridges) needs no entry here:
 # it egresses a non-physical iface and the killswitch only polices the uplink.
 LAN_ROUTER="192.168.50.1"          # LAN router / DNS upstream
-NEBULA_LIGHTHOUSE="5.161.118.55"   # Hetzner nebula lighthouse (discovery/relay)
 LAN_SUBNET="192.168.50.0/24"       # LAN kept direct
+
+# --- the nebula lighthouse's PUBLIC IP -------------------------------------- #
+# Site-local, and this repo is PUBLIC, so it is NOT committed. It comes from a
+# root-owned, untracked file:
+#     /etc/airvpn-updown.env   ->   NEBULA_LIGHTHOUSE=<lighthouse public IP>
+# ($AIRVPN_UPDOWN_ENV overrides the path; that is also how the tests point at a
+# fixture.) Absent or unusable ⇒ the script STILL ARMS: the lighthouse-specific
+# bypass route and its nft accept are omitted and the arm line says
+# `lighthouse=UNSET`.
+#
+# 🔴 THE FILE IS PARSED, NOT SOURCED, AND THE VALUE IS VALIDATED. Both matter,
+# and both are audit findings against the first version of this change:
+#
+#   (A-4) `. "$SITE_ENV"` executes the file AS ROOT. A stray or malicious
+#   `LAN_SUBNET=`/`IFACE=`/`NEBULA_USER=` line silently clobbers the constants
+#   above — i.e. rewrites the killswitch — and any other shell in it just runs.
+#   So: check owner+mode first, then extract ONLY `NEBULA_LIGHTHOUSE` with a
+#   line-anchored match. Nothing else in the file can affect this script.
+#
+#   (A-2) A malformed value was FAIL-OPEN. It is interpolated into the nft
+#   ruleset, and a truncated/garbage value makes the ruleset a SYNTAX ERROR —
+#   verified with `nft -c`. Because `up` does `nft add table` + `nft flush table`
+#   BEFORE loading, a re-arm with a bad value DELETED a working killswitch and
+#   installed nothing, then exited 0. A partially-written env file was enough.
+#   So an unparseable value is treated as UNSET, loudly.
+SITE_ENV="${AIRVPN_UPDOWN_ENV:-/etc/airvpn-updown.env}"
+
+# Is the env file safe to read? It must not be writable by anyone who is not
+# root or us — whoever can write it can name the destination that gets BOTH a
+# main-table bypass route and an nft `accept`, which is a hole punched through
+# the killswitch on purpose.
+site_env_trusted() {
+    local path="$1" owner mode
+    read -r owner mode < <(stat -c '%u %a' "$path" 2>/dev/null) || return 1
+    [[ -n "$owner" && -n "$mode" ]] || return 1
+    # owner must be root, or us (so a non-root run against a fixture works)
+    if [[ "$owner" != "0" && "$owner" != "$(id -u)" ]]; then
+        log "WARNING: ${path} is owned by uid ${owner} (not root) — IGNORING it"
+        return 1
+    fi
+    # no group- or other-WRITE. `mode` is 3 or 4 octal digits.
+    local perm="${mode: -3}"
+    if (( ${perm:1:1} & 2 )) || (( ${perm:2:1} & 2 )); then
+        log "WARNING: ${path} is group/other-writable (${mode}) — IGNORING it"
+        return 1
+    fi
+    return 0
+}
+
+# Extract NEBULA_LIGHTHOUSE and NOTHING else. Last assignment wins, matching
+# what sourcing would have done, without executing anything.
+site_env_lighthouse() {
+    local path="$1" line val=""
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[[:space:]]*NEBULA_LIGHTHOUSE[[:space:]]*=(.*)$ ]] || continue
+        val="${BASH_REMATCH[1]}"
+        val="${val%%#*}"                       # strip a trailing comment
+        val="${val#"${val%%[![:space:]]*}"}"   # ltrim
+        val="${val%"${val##*[![:space:]]}"}"   # rtrim
+        # Unquote only a BALANCED pair. A lone quote is what a partially-written
+        # file looks like, and stripping it would turn a malformed value into an
+        # empty one — i.e. into the quiet "you didn't set it" case, losing the
+        # signal that the file is truncated (the A-2 scenario).
+        if [[ ${#val} -ge 2 && "$val" == \"*\" ]]; then
+            val="${val:1:${#val}-2}"
+        elif [[ ${#val} -ge 2 && "$val" == \'*\' ]]; then
+            val="${val:1:${#val}-2}"
+        fi
+    done < "$path"
+    printf '%s' "$val"
+}
+
+# A bare IPv4/IPv6 literal and nothing else. Deliberately STRICTER than "does it
+# look like an address": anything that is not exactly an address is rejected,
+# because the value is interpolated into an nft ruleset and a shell-ish or
+# whitespace-carrying value is the fail-open above.
+valid_ip() {
+    local v="$1"
+    [[ -n "$v" ]] || return 1
+    if [[ "$v" =~ ^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]]; then
+        local i
+        for i in 1 2 3 4; do (( BASH_REMATCH[i] <= 255 )) || return 1; done
+        return 0
+    fi
+    # IPv6: hex groups and colons only, at least two colons, no zone/scope.
+    [[ "$v" =~ ^[0-9A-Fa-f:]+$ && "$v" == *::* ]] && return 0
+    [[ "$v" =~ ^([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}$ ]] && return 0
+    return 1
+}
+
+NEBULA_LIGHTHOUSE=""
+if [[ -r "$SITE_ENV" ]] && site_env_trusted "$SITE_ENV"; then
+    _lh="$(site_env_lighthouse "$SITE_ENV")"
+    if [[ -z "$_lh" ]]; then
+        :   # key simply absent — the documented UNSET case, no noise
+    elif valid_ip "$_lh"; then
+        NEBULA_LIGHTHOUSE="$_lh"
+    else
+        # 🔴 The A-2 case. Do NOT interpolate it anywhere.
+        log "ERROR: NEBULA_LIGHTHOUSE in ${SITE_ENV} is not an IP address (${#_lh} chars) — treating as UNSET"
+    fi
+    unset _lh
+fi
+
 # Nebula binds listen.port:0 → a RANDOM source port, so match its transport by the
 # SOCKET OWNER instead of a port. This covers punchy DIRECT peers (to a remote
 # operator's public IP) + relay + lighthouse regardless of port. `id -un` the nebula
@@ -69,13 +188,29 @@ GW_FILE="/run/airvpn-gateway"
 IFACE_FILE="/run/airvpn-iface"
 KS_TABLE="airvpn_ks"
 
-log() { logger -t airvpn-updown "$*" 2>/dev/null || echo "airvpn-updown: $*" >&2; }
+# (log() is defined near the top — its first callers run before this point.)
 
 # Blanket FAIL-CLOSED ruleset — installed only if the main killswitch nft load
-# fails, so an nft error can never leave the uplink UNFILTERED (fail-open). Minimal
-# on purpose (no dynamic PHYS_SET / fwmark / EP substitution that could be what
-# broke the main load): allow internal ifaces + nebula (skuid) + LAN + lighthouse,
-# drop the rest. Keeps the operator reachable while still stopping an internet leak.
+# fails, so an nft error can never leave the uplink UNFILTERED (fail-open).
+#
+# 🔴 NO OPERATOR-SUPPLIED TEXT REACHES THIS RULESET. It is the fallback for "the
+# main load did not parse", so anything that could have BROKEN that parse must
+# not appear here as well, or the fallback fails for the same reason and the
+# uplink ends up with no table at all. Everything interpolated below is derived
+# in-process from the kernel or from constants in this file:
+#   * $IFACE       — argv (wg-quick's %i), a device name
+#   * $NEBULA_USER — `id -un`, a local account name
+#   * $LAN_SUBNET  — a constant above
+# The LIGHTHOUSE is deliberately ABSENT. It is the one value that comes from a
+# file on disk, it is exactly what a partially-written env file corrupts, and
+# with it in here a bad value took out BOTH the primary ruleset and its
+# fallback (audit A-2). Losing the lighthouse `accept` here costs the direct
+# un-tunnelled path to it; nebula's own transport is still allowed by the
+# `meta skuid` rule above, and the LAN rule keeps a recovery path open. That is
+# the correct trade for a fallback whose whole job is to parse.
+#
+# The reachability of THIS function is what matters, not its rule count: it runs
+# only when `nft -f -` on the primary ruleset returned non-zero.
 arm_failclosed() {
     nft add table inet "$KS_TABLE" 2>/dev/null || true
     nft flush table inet "$KS_TABLE" 2>/dev/null || true
@@ -86,7 +221,6 @@ table inet ${KS_TABLE} {
         oifname { "lo", "${IFACE}", "nebula.mesh", "cni0", "flannel.1", "docker0" } accept
         meta skuid "${NEBULA_USER}" accept
         ip daddr ${LAN_SUBNET} accept
-        ip daddr ${NEBULA_LIGHTHOUSE} accept
         drop
     }
 }
@@ -140,7 +274,12 @@ case "$action" in
             EP="$(endpoint_ip)"
             [[ -n "$EP" ]] && ip route replace "$EP" via "$GW" dev "$PHYS" 2>/dev/null || true
             ip route replace "$LAN_ROUTER"        via "$GW" dev "$PHYS" 2>/dev/null || true
-            ip route replace "$NEBULA_LIGHTHOUSE" via "$GW" dev "$PHYS" 2>/dev/null || true
+            # The lighthouse /32 is the ROUTING half of its bypass and is skipped
+            # when unset. 🔴 That is a real loss, not a cosmetic one — see the
+            # header note on `suppress_prefixlength 0`.
+            if [[ -n "$NEBULA_LIGHTHOUSE" ]]; then
+                ip route replace "$NEBULA_LIGHTHOUSE" via "$GW" dev "$PHYS" 2>/dev/null || true
+            fi
             # LAN /24 stays direct via the connected route; assert it explicitly too.
             ip route replace "$LAN_SUBNET" dev "$PHYS" scope link 2>/dev/null || true
         else
@@ -175,7 +314,7 @@ table inet ${KS_TABLE} {
         $( [[ -n "$FWMARK" && "$FWMARK" != "off" ]] && echo "meta mark ${FWMARK} accept" )
         ip daddr ${LAN_SUBNET} accept
         meta skuid "${NEBULA_USER}" accept
-        ip daddr ${NEBULA_LIGHTHOUSE} accept
+        $( [[ -n "$NEBULA_LIGHTHOUSE" ]] && echo "ip daddr ${NEBULA_LIGHTHOUSE} accept" )
         $( [[ -n "$EP" ]] && echo "ip daddr ${EP} accept" )
         $( [[ -n "$GW" ]] && echo "ip daddr ${GW} accept" )
         # link-local + multicast housekeeping stay allowed
@@ -186,11 +325,25 @@ table inet ${KS_TABLE} {
     }
 }
 NFT
-        log "up: killswitch armed (fwmark=${FWMARK:-none}) policing [${PHYS_SET[*]:-FAIL-CLOSED}], gw=${GW:-none} ep=${EP:-?}"
+        # 🔴 `lighthouse=` is the field to read after a re-arm. UNSET on a host
+        # that should have it means the env file is missing/untrusted/malformed,
+        # NOT that the change worked.
+        log "up: killswitch armed (fwmark=${FWMARK:-none}) policing [${PHYS_SET[*]:-FAIL-CLOSED}], gw=${GW:-none} ep=${EP:-?} lighthouse=${NEBULA_LIGHTHOUSE:-UNSET}"
+        ;;
+    check-env)
+        # READ-ONLY. Touches no nft table, no route, no file. Exists so the env
+        # resolution above — the part that decides whether the killswitch keeps
+        # its lighthouse bypass — is testable without root and without arming
+        # anything. Prints one line; exits 0 when a lighthouse resolved, 1 when
+        # it did not.
+        echo "lighthouse=${NEBULA_LIGHTHOUSE:-UNSET} env=${SITE_ENV}"
+        [[ -n "$NEBULA_LIGHTHOUSE" ]]
+        exit $?
         ;;
     down)
         nft delete table inet "$KS_TABLE" 2>/dev/null || true
         for dst in "$NEBULA_LIGHTHOUSE" "$LAN_ROUTER"; do
+            [[ -n "$dst" ]] || continue
             ip route del "$dst" 2>/dev/null || true
         done
         # endpoint bypass /32 (if any) — best-effort cleanup by removing non-default
@@ -200,7 +353,7 @@ NFT
         log "down: killswitch disarmed, bypass routes removed"
         ;;
     *)
-        echo "usage: airvpn-updown {up|down} <iface>" >&2
+        echo "usage: airvpn-updown {up|down|check-env} <iface>" >&2
         exit 1
         ;;
 esac

--- a/scripts/airvpn-updown
+++ b/scripts/airvpn-updown
@@ -132,8 +132,13 @@ site_env_trusted() {
 # canonical A-2 shape — and without this the value resolved to empty and fell
 # into the "key simply absent, no noise" branch below. The guard advertised as
 # "loud about a partially-written file" was SILENT for the one shape it is named
-# after. CRLF-without-final-LF has the same root cause; the `\r` then survives
-# into the value and `valid_ip` rejects it loudly, which is the correct outcome.
+# after.
+#
+# CRLF shares the root cause (a `\r`-only tail is also "no final LF"). 🔴 An
+# earlier version of this comment claimed the `\r` then survives into the value
+# and gets rejected loudly. That was RETRACTED — MEASURED FALSE: the rtrim below
+# strips `\r` (it is `[:space:]`), so a CRLF file resolves CORRECTLY, with or
+# without a final LF. Both tails are pinned in the test suite.
 site_env_lighthouse() {
     local path="$1" line val=""
     while IFS= read -r line || [[ -n "$line" ]]; do
@@ -172,18 +177,32 @@ site_env_lighthouse() {
 # to `getent`/`inet_aton` and DECIMAL to nft, so accepting one means the route
 # and the firewall rule name different hosts. (Measured: `getent ahostsv4` on a
 # zero-prefixed octet resolves to a different address than nft would match.)
-# `(( 10# … ))` also stops the range check itself from being an accident:
-# without it, an octet like `09` was rejected only by bash erroring with
-# "value too great for base", which is a crash, not a decision.
+#
+# 🔴 TWO CHECKS, EACH DOING A DIFFERENT JOB — and an audit caught the earlier
+# comment attributing BOTH to `10#` (M5). With the leading-zero rule running
+# first, `10#` was unreachable and deleting it changed nothing measurable, so a
+# maintainer reading that comment could have removed the check that actually
+# works. The order is now: radix-pinned RANGE check, then the leading-zero
+# rejection. Same verdict for every input; `10#` is now what keeps an octet like
+# `09` from making bash raise "value too great for base" — a crash, not a
+# decision — and a mutant deleting it dies at that assertion.
 valid_ip() {
     local v="$1" i o
     [[ -n "$v" ]] || return 1
     [[ "$v" =~ ^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]] || return 1
     for i in 1 2 3 4; do
         o="${BASH_REMATCH[i]}"
-        # no leading zeros (except the single digit "0" itself)
-        [[ "$o" == "0" || "$o" != 0* ]] || return 1
+        # 🔴 RANGE CHECK FIRST, AND IT IS RADIX-PINNED. Order matters: with the
+        # leading-zero rule first, `10#` was UNREACHABLE — every zero-prefixed
+        # octet was already rejected, so removing `10#` made no behavioural
+        # difference and the guard could not be tested (audit M5). This way an
+        # octet like `09` reaches the arithmetic, where `10#` is what stops bash
+        # raising "value too great for base" — a CRASH rather than a decision.
+        # Both checks still run; only the order changed, so the accept/reject
+        # verdict is identical and the radix guard is now load-bearing.
         (( 10#$o <= 255 )) || return 1
+        # …then reject leading zeros outright (octal to getent, decimal to nft).
+        [[ "$o" == "0" || "$o" != 0* ]] || return 1
     done
     return 0
 }
@@ -301,7 +320,12 @@ ks_present() { nft list table inet "$KS_TABLE" >/dev/null 2>&1; }
 # The reachability of THIS function is what matters, not its rule count: it runs
 # only when the primary `nft_load_atomic` returned non-zero.
 arm_failclosed() {
-    nft_load_atomic <<FB || { log "FALLBACK nft load ALSO FAILED — uplink is NOT filtered!"; return 1; }
+    # 🔴 The old message here said "uplink is NOT filtered!" unconditionally.
+    # After F4 that is FALSE in one corner: a failed load changes nothing, so a
+    # PREVIOUS table can still be installed and filtering. The caller resolves
+    # the real state by asking the kernel (`ks_present`) and logs it; this line
+    # states only what it actually knows — that no NEW ruleset went in.
+    nft_load_atomic <<FB || { log "FALLBACK nft load ALSO FAILED — NO new ruleset was installed (the caller reports whether anything is still in place)"; return 1; }
 table inet ${KS_TABLE} {
     chain out {
         type filter hook output priority 0; policy accept;
@@ -316,7 +340,24 @@ FB
 
 # Original default gateway + physical iface (the default route NOT via the tunnel).
 # Used for the split-tunnel bypass ROUTES (they need one specific gateway).
-orig_gw()   { ip -o route show default 2>/dev/null | grep -v "dev ${IFACE}" | awk '{print $3}' | head -1; }
+#
+# 🔴 `orig_gw` IS VALIDATED, for the same reason the lighthouse is (audit 🟡4).
+# `$GW` reaches the ruleset as `ip daddr ${GW} accept`, exactly like the
+# lighthouse — but it was the only one of the three interpolated addresses with
+# no check on it. On a gateway-less default route (`default dev eth0`, common on
+# a point-to-point or DHCP-less link) `awk '{print $3}'` yields the literal
+# `eth0`, and nft then tries to DNS-RESOLVE that token, as root, inside
+# wg-quick's PostUp — and fails the PRIMARY load, which drops us into the
+# blanket fallback and kills the tunnel. MEASURED with `nft -c`.
+orig_gw()   {
+    local g
+    g="$(ip -o route show default 2>/dev/null | grep -v "dev ${IFACE}" | awk '{print $3}' | head -1)"
+    if [[ -n "$g" ]] && ! valid_ip "$g"; then
+        log "WARNING: default route has no usable IPv4 gateway (got a ${#g}-char non-address) — bypass routes SKIPPED, killswitch still arms"
+        g=""
+    fi
+    printf '%s' "$g"
+}
 orig_if()   { ip -o route show default 2>/dev/null | grep -v "dev ${IFACE}" | awk '{print $5}' | head -1; }
 
 # ALL physical NICs (hardware devices), one name per line. `/sys/class/net/<if>/
@@ -337,8 +378,24 @@ phys_ifaces() {
 }
 
 # The connected peer endpoint IP (for the endpoint bypass /32).
+#
+# 🔴 VALIDATED for the same reason as the gateway (audit 🟡4). Three measured
+# ways this yields something nft cannot use:
+#   * a peer with no endpoint makes `wg show` print the literal `(none)`;
+#   * an IPv6 endpoint survives the `sed` as a mangled hextet run, and the rule
+#     emitted is `ip daddr` — IPv4 family, which cannot express it;
+#   * anything else wg's output format grows in future.
+# Each made the PRIMARY ruleset fail to load → blanket fallback → no `meta mark`
+# accept → the tunnel dies. Rejecting yields the documented degraded-but-safe
+# outcome instead: no endpoint bypass, killswitch still armed.
 endpoint_ip() {
-    wg show "$IFACE" endpoints 2>/dev/null | awk '{print $2}' | sed 's/:[0-9]*$//' | head -1
+    local e
+    e="$(wg show "$IFACE" endpoints 2>/dev/null | awk '{print $2}' | sed 's/:[0-9]*$//' | head -1)"
+    if [[ -n "$e" ]] && ! valid_ip "$e"; then
+        log "WARNING: peer endpoint is not a usable IPv4 address (got a ${#e}-char token) — endpoint bypass SKIPPED"
+        e=""
+    fi
+    printf '%s' "$e"
 }
 
 case "$action" in
@@ -388,8 +445,16 @@ case "$action" in
             log "ERROR: no physical uplink NIC found — arming FAIL-CLOSED killswitch (internal ifaces only)"
             UPLINK_GUARD='oifname { "lo", "'"${IFACE}"'", "nebula.mesh", "cni0", "flannel.1", "docker0" } accept'
         fi
-        # 🔴 ONE transaction (see nft_load_atomic). A failure here changes NOTHING
-        # — the previous killswitch, if any, is still installed.
+        # 🔴 ONE transaction (see nft_load_atomic). A failure of THIS COMMAND
+        # changes nothing — the previous killswitch, if any, survives it.
+        #
+        # 🔴 THAT IS A PROPERTY OF THE COMMAND, NOT OF THE PATH. Four lines down,
+        # `arm_failclosed` REPLACES whatever survived with the blanket fallback —
+        # which has no `meta mark` accept, i.e. the state the `valid_ip` comment
+        # above calls "the tunnel dies". The net end-state is no worse than
+        # before F4, but do not read the atomicity as "a bad load is harmless
+        # end to end". It is not; it is "a bad load does not leave you with
+        # NOTHING while we try the fallback".
         if nft_load_atomic <<NFT
 table inet ${KS_TABLE} {
     chain out {
@@ -424,11 +489,24 @@ NFT
         # (audit G6 — the old line was unconditional and printed `armed` even
         # when the primary load AND the fallback had both failed, i.e. exactly
         # when the uplink was unfiltered). ASK THE KERNEL.
-        if ks_present; then
-            KS_STATE="ARMED(${KS_RULESET})"
-        else
+        #
+        # 🔴 FOUR STATES, NOT THREE — and the fourth is one MY OWN F4 CREATED.
+        # Before the atomic load, "both loads failed" implied the table had
+        # already been flushed, so an absent table (NOT-ARMED) was the only
+        # possible outcome. After F4 a failed load changes nothing, so the
+        # PREVIOUS table survives and `ks_present` is TRUE with `KS_RULESET=none`.
+        # Reporting that as `ARMED(none)` was both meaningless and dangerous: the
+        # surviving ruleset was built for a DIFFERENT endpoint and fwmark, so it
+        # can coexist with a dead tunnel while reading as armed. It is
+        # STALE(previous) — safer than nothing, and not what was asked for.
+        if ! ks_present; then
             KS_STATE="NOT-ARMED"
             log "🔴 killswitch NOT ARMED — table inet ${KS_TABLE} is ABSENT after load; the uplink is UNFILTERED"
+        elif [[ "$KS_RULESET" == "none" ]]; then
+            KS_STATE="STALE(previous)"
+            log "🔴 killswitch STALE — both loads failed; an OLDER table inet ${KS_TABLE} survived (it does NOT match this tunnel's endpoint/fwmark). Re-arm or drop it."
+        else
+            KS_STATE="ARMED(${KS_RULESET})"
         fi
         # 🔴 `lighthouse=` is the field to read after a re-arm. UNSET on a host
         # that should have it means the env file is missing/untrusted/malformed,

--- a/scripts/tests/test_airvpn_updown_env.py
+++ b/scripts/tests/test_airvpn_updown_env.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""`scripts/airvpn-updown` — the site-config resolution that decides whether the
+LIVE killswitch keeps its nebula-lighthouse bypass.
+
+WHAT IS AND IS NOT COVERED HERE — read this before trusting a green run
+----------------------------------------------------------------------
+🔴 These tests exercise the `check-env` path ONLY. `check-env` is read-only: it
+touches no nft table, no route, no file. Nothing here arms, disarms or loads a
+ruleset, and **nothing here is a substitute for the `bar` skill's mandatory
+re-test protocol** (LAN session held open → k3s healthy → 4 nebula nodes → exit
+IP is the tunnel → off-LAN ssh survives). That protocol needs a physically
+reachable host and has NOT been run for this change.
+
+So: green here means "the value resolves and the rejections fire". It does not
+mean the killswitch works.
+
+WHAT THESE ARE REGRESSION TESTS FOR
+-----------------------------------
+Two audit findings against the first version of the env-file change:
+
+  * **A-2, FAIL-OPEN.** A malformed/truncated value (a partially-written env
+    file) was interpolated straight into the nft ruleset, making it a SYNTAX
+    ERROR — and because `up` does `nft add table` + `nft flush table` BEFORE
+    loading, re-arming with a bad value DELETED a working killswitch and
+    installed nothing, then exited 0. The blanket fallback carried the same
+    value, so it failed identically.
+  * **A-4, ROOT-SOURCED CONFIG.** The file was `.`-sourced as root with no
+    owner/mode check and no constraint on what it could set, so a stray
+    `LAN_SUBNET=` / `IFACE=` / `NEBULA_USER=` line rewrote the killswitch's
+    constants, and any other shell in the file simply ran.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "scripts"))
+
+from testlib import mockbin  # noqa: E402
+
+UPDOWN = REPO / "scripts" / "airvpn-updown"
+APPLY = REPO / "nix" / "system" / "apply-airvpn-host.sh"
+
+#: TEST-NET-1/3 (RFC 5737). Reserved for documentation, so these can be written
+#: down in a public repo and are still real, parseable addresses — the point of
+#: a control built from realistic rather than degenerate data.
+GOOD_V4 = "203.0.113.9"
+OTHER_V4 = "192.0.2.7"
+GOOD_V6 = "2001:db8::1"
+
+
+def _bash():
+    import shutil
+    return shutil.which("bash") or "/bin/sh"
+
+
+def check_env(env_file: Path | None, extra=None):
+    """Run `airvpn-updown check-env` and return (rc, stdout, stderr)."""
+    env = dict(os.environ)
+    env.pop("NEBULA_LIGHTHOUSE", None)
+    if env_file is not None:
+        env["AIRVPN_UPDOWN_ENV"] = str(env_file)
+    env.update(extra or {})
+    r = subprocess.run([_bash(), str(UPDOWN), "check-env"],
+                       capture_output=True, text=True, env=env, timeout=30)
+    return r.returncode, r.stdout, r.stderr
+
+
+def write_env(tmp_path, text, mode=0o600, name="airvpn-updown.env") -> Path:
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    p.chmod(mode)
+    return p
+
+
+# --- the happy path ------------------------------------------------------------
+
+def test_a_valid_ipv4_resolves(tmp_path):
+    rc, out, _ = check_env(write_env(tmp_path, f"NEBULA_LIGHTHOUSE={GOOD_V4}\n"))
+    assert rc == 0, out
+    assert f"lighthouse={GOOD_V4}" in out
+
+
+def test_a_valid_ipv6_resolves(tmp_path):
+    rc, out, _ = check_env(write_env(tmp_path, f"NEBULA_LIGHTHOUSE={GOOD_V6}\n"))
+    assert rc == 0, out
+    assert f"lighthouse={GOOD_V6}" in out
+
+
+@pytest.mark.parametrize("body", [
+    'NEBULA_LIGHTHOUSE="%s"\n' % GOOD_V4,
+    "NEBULA_LIGHTHOUSE='%s'\n" % GOOD_V4,
+    "  NEBULA_LIGHTHOUSE  =  %s  \n" % GOOD_V4,
+    "# a comment\n\nNEBULA_LIGHTHOUSE=%s   # trailing\n" % GOOD_V4,
+])
+def test_ordinary_spellings_all_resolve(tmp_path, body):
+    """Sourcing accepted these, so parsing must too — otherwise the change
+    silently degrades a host whose file was written by hand."""
+    rc, out, _ = check_env(write_env(tmp_path, body))
+    assert rc == 0 and f"lighthouse={GOOD_V4}" in out, (rc, out)
+
+
+def test_the_last_assignment_wins(tmp_path):
+    """Matching what sourcing did — a second line is an override, not an error."""
+    rc, out, _ = check_env(write_env(
+        tmp_path, f"NEBULA_LIGHTHOUSE={OTHER_V4}\nNEBULA_LIGHTHOUSE={GOOD_V4}\n"))
+    assert rc == 0 and f"lighthouse={GOOD_V4}" in out, out
+
+
+# --- A-2: a malformed value must be UNSET, never interpolated ------------------
+
+@pytest.mark.parametrize("value,why", [
+    ("5.161.118", "truncated quad — a partially-written file"),
+    ("203.0.113.", "trailing dot"),
+    ("203.0.113.999", "octet > 255"),
+    ("$(id)", "command substitution"),
+    ("`id`", "backticks"),
+    ("203.0.113.9 accept; drop", "an nft rule smuggled in as the value"),
+    ("203.0.113.9 203.0.113.10", "two values"),
+    ("not-an-ip", "prose"),
+    ("203.0.113.9/32", "a CIDR, not a host"),
+    ("2001:db8::1%eth0", "an IPv6 zone/scope suffix"),
+    ('"', "one stray quote — the truncation shape that started this"),
+])
+def test_a_malformed_value_is_treated_as_UNSET_and_says_why(tmp_path, value, why):
+    """🔴 A-2. Every one of these made BOTH the primary ruleset and the blanket
+    fallback fail to parse, and `up` flushes the table BEFORE loading — so a
+    re-arm with any of them removed a working killswitch and installed nothing,
+    exit 0. UNSET is the fail-SAFE outcome, and it must be announced."""
+    rc, out, err = check_env(write_env(tmp_path, f"NEBULA_LIGHTHOUSE={value}\n"))
+    assert rc == 1, (rc, out, err)
+    assert "lighthouse=UNSET" in out, out
+    assert "not an IP address" in err, err
+    # 🔴 The rejected text must NEVER be echoed back — it is attacker-controlled
+    # and the log line goes to syslog.
+    assert value not in out and value not in err, (out, err)
+
+
+def test_an_absent_key_is_UNSET_but_quiet(tmp_path):
+    """Distinct from the case above: 'you did not set it' is the documented
+    default, 'you set it to garbage' is an error. Same safe outcome, different
+    signal — otherwise the operator cannot tell which one they are in."""
+    rc, out, err = check_env(write_env(tmp_path, "SOMETHING_ELSE=1\n"))
+    assert rc == 1 and "lighthouse=UNSET" in out
+    assert "not an IP address" not in err, err
+
+
+def test_a_missing_file_is_UNSET_not_a_crash(tmp_path):
+    rc, out, _ = check_env(tmp_path / "does-not-exist.env")
+    assert rc == 1 and "lighthouse=UNSET" in out, out
+
+
+# --- A-4: the file is parsed, not sourced --------------------------------------
+
+def test_the_file_cannot_clobber_the_killswitchs_own_constants(tmp_path):
+    """🔴 A-4. Sourcing this as root rewrote LAN_SUBNET/IFACE/NEBULA_USER — i.e.
+    rewrote the killswitch. Parsing means only NEBULA_LIGHTHOUSE can be read."""
+    body = ("LAN_SUBNET=0.0.0.0/0\n"
+            "IFACE=eth0\n"
+            "NEBULA_USER=root\n"
+            "LAN_ROUTER=203.0.113.254\n"
+            f"NEBULA_LIGHTHOUSE={GOOD_V4}\n")
+    rc, out, err = check_env(write_env(tmp_path, body))
+    assert rc == 0 and f"lighthouse={GOOD_V4}" in out, (out, err)
+    # none of the other keys leaked into the output the script produces
+    assert "0.0.0.0/0" not in out and "eth0" not in out, out
+
+
+def test_the_file_is_not_executed(tmp_path):
+    """The strongest form: put a side effect in the file. Sourcing runs it;
+    parsing cannot. Driven by a real filesystem effect, not by inspecting the
+    source for a `.` character."""
+    canary = tmp_path / "canary"
+    body = (f"touch {canary}\n"
+            f"NEBULA_LIGHTHOUSE={GOOD_V4}\n")
+    rc, out, _ = check_env(write_env(tmp_path, body))
+    assert rc == 0 and f"lighthouse={GOOD_V4}" in out, out
+    assert not canary.exists(), (
+        "the env file was EXECUTED — it is being sourced, not parsed")
+
+
+@pytest.mark.parametrize("mode", [0o666, 0o622, 0o660, 0o620])
+def test_a_group_or_other_writable_file_is_IGNORED(tmp_path, mode):
+    """Whoever can write this file names a destination that gets BOTH a
+    main-table bypass route AND an nft accept — a hole through the killswitch."""
+    rc, out, err = check_env(
+        write_env(tmp_path, f"NEBULA_LIGHTHOUSE={GOOD_V4}\n", mode=mode))
+    assert rc == 1, (rc, out, err)
+    assert "lighthouse=UNSET" in out, out
+    assert "writable" in err, err
+
+
+@pytest.mark.parametrize("mode", [0o600, 0o400, 0o640, 0o644])
+def test_a_non_writable_mode_is_accepted(tmp_path, mode):
+    """The complement — the check must not be so strict it rejects the modes an
+    operator actually creates. Measured at both ends of the range rather than at
+    the single value the docs suggest."""
+    rc, out, err = check_env(
+        write_env(tmp_path, f"NEBULA_LIGHTHOUSE={GOOD_V4}\n", mode=mode))
+    assert rc == 0, (mode, out, err)
+
+
+def _stat_stub(tmp_path, uid, mode):
+    """A `stat` on PATH that reports a chosen owner/mode.
+
+    🔴 WHY A STUB HERE AND REAL FILES ABOVE. The OWNER branches cannot be built
+    from the filesystem: a test cannot chown, and the two tiers disagree about
+    what exists — the first version of this test walked /etc for a root-owned
+    file, passed on the dev host, and FAILED in the nix build sandbox, which has
+    no /etc/passwd and where everything is owned by the build user. That is the
+    two-tier hazard in RULES.md, found by running both tiers.
+
+    So the decomposition is: real files cover MODE parsing (above), and this
+    stub covers the OWNER comparison — including the foreign-uid branch, which
+    no real filesystem a test controls can produce at all.
+    """
+    bindir = tmp_path / "stubbin"
+    bindir.mkdir(exist_ok=True)
+    mockbin.write_exec(bindir / "stat", f'printf "%s\\n" "{uid} {mode}"\n')
+    return bindir
+
+
+def test_a_root_owned_file_is_ACCEPTED(tmp_path):
+    """The production case: uid 0 owns the file and the caller is not root."""
+    f = write_env(tmp_path, f"NEBULA_LIGHTHOUSE={GOOD_V4}\n")
+    bindir = _stat_stub(tmp_path, 0, 600)
+    rc, out, err = check_env(f, extra={"PATH": f"{bindir}:{os.environ['PATH']}"})
+    assert rc == 0, (rc, out, err)
+    assert f"lighthouse={GOOD_V4}" in out, out
+    assert "IGNORING" not in err, err
+
+
+def test_a_file_owned_by_a_THIRD_party_is_IGNORED(tmp_path):
+    """🔴 The branch that matters most and is hardest to build: the file is
+    owned by neither root nor us. Whoever that is gets to name a destination
+    that receives BOTH a main-table bypass route and an nft `accept`."""
+    f = write_env(tmp_path, f"NEBULA_LIGHTHOUSE={GOOD_V4}\n")
+    stranger = 4242 if os.geteuid() != 4242 else 4243
+    bindir = _stat_stub(tmp_path, stranger, 600)
+    rc, out, err = check_env(f, extra={"PATH": f"{bindir}:{os.environ['PATH']}"})
+    assert rc == 1, (rc, out, err)
+    assert "lighthouse=UNSET" in out, out
+    assert "not root" in err and str(stranger) in err, err
+
+
+def test_the_stat_stub_itself_is_load_bearing(tmp_path):
+    """POSITIVE CONTROL for the two tests above. If the stub were not on PATH —
+    a typo, a PATH that does not take effect — both would exercise the REAL
+    stat and the self-owned accept, and both would still pass for the wrong
+    reason. Drive it with a uid that must produce the OPPOSITE verdict from the
+    file's real owner."""
+    f = write_env(tmp_path, f"NEBULA_LIGHTHOUSE={GOOD_V4}\n")
+    assert f.stat().st_uid == os.geteuid(), "fixture is not self-owned"
+    # real stat would ACCEPT (self-owned 0600); the stub must make it REJECT
+    bindir = _stat_stub(tmp_path, 4242, 600)
+    rc, _out, err = check_env(f, extra={"PATH": f"{bindir}:{os.environ['PATH']}"})
+    assert rc == 1 and "not root" in err, (
+        "the stat stub is not being used — the owner tests prove nothing")
+
+
+# --- the fallback ruleset ------------------------------------------------------
+
+def test_the_blanket_fallback_carries_no_lighthouse():
+    """🔴 A-2, structural half. `arm_failclosed` is the fallback for 'the primary
+    ruleset did not parse'. Any value that could have broken that parse must not
+    appear in it too, or both fail together and the uplink ends up with NO table.
+
+    Asserted on the function BODY, not on the file — a match anywhere else in a
+    600-line script would pass while the fallback stayed broken.
+    """
+    src = UPDOWN.read_text(encoding="utf-8")
+    start = src.index("arm_failclosed() {")
+    end = src.index("\n}\n", src.index("FB\n", start))
+    body = src[start:end]
+    assert "NEBULA_LIGHTHOUSE" not in body, (
+        "the fallback ruleset interpolates the lighthouse again:\n" + body)
+    # and it must still be a real fallback, not an empty one
+    for required in ("meta skuid", "LAN_SUBNET", "drop"):
+        assert required in body, f"the fallback lost its {required} rule"
+
+
+def test_the_comment_describing_the_fallback_matches_the_code():
+    """🔴 A comment is a claim. The previous one said the fallback had 'no
+    dynamic … substitution', which this change made FALSE — and a maintainer
+    reading a stale safety comment is how a guard gets deleted."""
+    src = UPDOWN.read_text(encoding="utf-8")
+    head = src[:src.index("arm_failclosed() {")]
+    tail = head[head.rindex("# Blanket FAIL-CLOSED"):]
+    assert "NO OPERATOR-SUPPLIED TEXT" in tail, (
+        "the fallback's comment no longer states what the code does")
+
+
+# --- the apply script (A-3) ----------------------------------------------------
+
+def apply_lib(tmp_path, site_env: Path, env=None):
+    """Source apply-airvpn-host.sh as a LIBRARY and call ensure_site_env."""
+    e = dict(os.environ, AIRVPN_APPLY_LIB="1", AIRVPN_SITE_ENV=str(site_env))
+    e.pop("NEBULA_LIGHTHOUSE", None)
+    e.pop("ALLOW_NO_LIGHTHOUSE", None)
+    e.update(env or {})
+    r = subprocess.run(
+        [_bash(), "-c", f'. "{APPLY}"; ensure_site_env'],
+        capture_output=True, text=True, env=e, cwd=str(tmp_path), timeout=30)
+    return r.returncode, r.stdout, r.stderr
+
+
+def test_apply_refuses_when_the_site_config_is_absent(tmp_path):
+    """🔴 A-3. A fresh-host apply used to install the helper and never create,
+    chmod or check this file — shipping a silently degraded killswitch."""
+    rc, out, err = apply_lib(tmp_path, tmp_path / "absent.env")
+    assert rc == 1, (rc, out, err)
+    assert "not found" in err and "NEBULA_LIGHTHOUSE=" in err, err
+
+
+def test_apply_creates_the_file_0600_root_owned_from_the_env_var(tmp_path):
+    f = tmp_path / "new.env"
+    rc, out, err = apply_lib(tmp_path, f, env={"NEBULA_LIGHTHOUSE": GOOD_V4})
+    assert rc == 0, (out, err)
+    assert f.read_text().strip() == f"NEBULA_LIGHTHOUSE={GOOD_V4}"
+    assert oct(f.stat().st_mode & 0o777) == "0o600", oct(f.stat().st_mode)
+
+
+def test_apply_tightens_the_mode_of_an_existing_file(tmp_path):
+    """The wg conf gets an explicit chown+chmod at step 1; this file got neither.
+    An existing world-readable one must be fixed, not accepted."""
+    f = write_env(tmp_path, f"NEBULA_LIGHTHOUSE={GOOD_V4}\n", mode=0o666)
+    rc, out, err = apply_lib(tmp_path, f)
+    assert rc == 0, (out, err)
+    assert oct(f.stat().st_mode & 0o777) == "0o600", oct(f.stat().st_mode)
+
+
+def test_apply_warns_when_an_existing_file_has_no_usable_value(tmp_path):
+    f = write_env(tmp_path, "# empty\n")
+    rc, out, err = apply_lib(tmp_path, f)
+    assert rc == 0, (out, err)
+    assert "WARNING" in err and "lighthouse=UNSET" in err, err
+
+
+def test_apply_opt_out_is_explicit_and_says_what_is_lost(tmp_path):
+    rc, out, err = apply_lib(tmp_path, tmp_path / "absent.env",
+                             env={"ALLOW_NO_LIGHTHOUSE": "1"})
+    assert rc == 0, (out, err)
+    assert "lighthouse=UNSET" in err and "NOT preserved" in err, err
+
+
+def test_the_apply_script_provisions_the_env_BEFORE_installing_the_helper():
+    """🔴 A-3, the ORDERING half — and the actual defect. Installing the helper
+    first and mentioning the file afterwards is how an operator following the
+    script top-to-bottom re-arms before the file exists.
+
+    An ordering guard, not a presence guard: swapping the two lines keeps every
+    token in the file and would pass a `grep`-shaped assertion.
+    """
+    src = APPLY.read_text(encoding="utf-8")
+    call = src.index("\nensure_site_env\n")
+    install = src.index('install -m 0755 -o root -g root "${REPO}/scripts/airvpn-updown"')
+    assert call < install, (
+        "ensure_site_env runs AFTER airvpn-updown is installed — a fresh host "
+        "gets a degraded killswitch")
+
+
+def test_the_skill_documents_the_prerequisite_BEFORE_the_install_command():
+    """The same ordering defect in the doc an operator actually follows: the
+    requirement used to be a trailing sentence AFTER the install command."""
+    doc = (REPO / "claude" / "skills" / "bar" / "airvpn.md").read_text(encoding="utf-8")
+    prereq = doc.index("/etc/airvpn-updown.env")
+    install = doc.index("sudo install -m 0755 -o root -g root")
+    assert prereq < install, (
+        "airvpn.md introduces the env file only after telling the operator to "
+        "install and re-arm")
+
+
+# --- the seam ------------------------------------------------------------------
+
+def test_check_env_is_read_only():
+    """`check-env` exists so this file can test the resolution without arming.
+    If it ever grew a side effect, every test above would be running against a
+    live killswitch path. Pin the SHAPE of the branch, structurally."""
+    src = UPDOWN.read_text(encoding="utf-8")
+    start = src.index("    check-env)")
+    end = src.index("        ;;", start)
+    # CODE only — a comment explaining "touches no nft table" would otherwise
+    # satisfy a naive substring search for `nft `, which is the spelled-vs-
+    # structural trap (RULES.md).
+    code = "\n".join(l for l in src[start:end].splitlines()
+                     if not l.strip().startswith("#"))
+    for forbidden in ("nft ", "ip route", "ip rule", "rm -f", "install ",
+                      "> ", ">>"):
+        assert forbidden not in code, (
+            f"check-env is no longer read-only ({forbidden!r}):\n{code}")
+    # …and it must still actually do the one thing it exists for.
+    assert "NEBULA_LIGHTHOUSE" in code and "echo " in code, code
+
+
+def test_the_lighthouse_is_never_a_literal_in_this_repo():
+    """The reason the env file exists at all. `scripts/tests/test_no_public_ips.py`
+    is the repo-wide gate; this is the local seam assertion, so a change that
+    re-inlines the value fails in the file that owns the decision too."""
+    sys.path.insert(0, str(REPO / "scripts"))
+    sys.path.insert(0, str(REPO / "scripts" / "claude-hooks"))
+    from testlib import public_ip_scan as S  # noqa: E402
+    hits = [h for h in S.scan_file(UPDOWN)]
+    assert not hits, f"airvpn-updown carries a routable IP literal again: {hits}"

--- a/scripts/tests/test_airvpn_updown_env.py
+++ b/scripts/tests/test_airvpn_updown_env.py
@@ -125,10 +125,17 @@ def test_a_LEADING_ZERO_octet_is_REJECTED(tmp_path, v4):
     octal value is deliberately not written here — it is a routable address and
     this repo is public; `test_no_public_ips.py` flagged it when it was.)
 
-    `203.0.113.09` was previously rejected only by ACCIDENT — bash raised
-    'value too great for base' inside the arithmetic, which is a crash, not a
-    decision, and would have flipped to ACCEPTED the moment the range check was
-    written `10#$o` without also rejecting the leading zero.
+    A zero-prefixed octet like `…09` was previously rejected only by ACCIDENT —
+    bash raised 'value too great for base' inside the arithmetic, which is a
+    crash, not a decision.
+
+    🔴 ATTRIBUTION, corrected after an audit measured it (M5): what rejects
+    these is the LEADING-ZERO CHECK, which fires first. `10#` is currently
+    UNREACHABLE for zero-prefixed input and makes no behavioural difference —
+    an earlier version of this docstring credited it with the protection, which
+    would have led a maintainer to delete the check that actually works. The
+    assertion below pins the OUTCOME (rejected by a decision, not by a crash),
+    which is true whichever of the two guards fires; it does not attribute.
     """
     rc, out, err = check_env(write_env(tmp_path, f"NEBULA_LIGHTHOUSE={v4}\n"))
     assert rc == 1, (rc, out, err)
@@ -280,6 +287,21 @@ def test_a_FIFO_at_the_env_path_does_not_hang(tmp_path):
         rc, out, err = check_env(fifo, timeout=5)
     except subprocess.TimeoutExpired:  # pragma: no cover - the bug itself
         pytest.fail("reading the env path BLOCKED — G4 has regressed")
+    finally:
+        # 🔴 UNBLOCK ANY SURVIVOR, ALWAYS. `subprocess.run` kills the direct
+        # child on timeout, but a shell blocked in `open()` on a FIFO with no
+        # writer can outlive it — MEASURED IN THE WILD: 30 `check-env`
+        # processes from this suite were found still blocked, the oldest for 77
+        # minutes, after a mutation run that removed the `-f` gate. Opening the
+        # write end non-blocking releases the reader; unlinking stops anything
+        # later from blocking on it again. This runs on the GREEN path too,
+        # where it is a no-op — a cleanup that only fires on failure is a
+        # cleanup that is never exercised.
+        try:
+            os.close(os.open(fifo, os.O_WRONLY | os.O_NONBLOCK))
+        except OSError:
+            pass
+        fifo.unlink(missing_ok=True)
     assert rc == 1, (rc, out, err)
     assert "state=not-a-regular-file" in out, out
     assert "not a regular file" in err, err
@@ -440,7 +462,8 @@ def test_the_stat_stub_itself_is_load_bearing(tmp_path):
 _SENTINEL = "198.51.100.77"   # TEST-NET-2, distinctive, and a valid IPv4
 
 
-def _up_harness(tmp_path, nft_fail="", ks_present=True, lighthouse=_SENTINEL):
+def _up_harness(tmp_path, nft_fail="", ks_present=True, lighthouse=_SENTINEL,
+                extra_path=None):
     """Run `airvpn-updown up airvpn` with every external command stubbed.
 
     Returns (rc, stdout, syslog_text, [captured nft calls]).
@@ -451,10 +474,13 @@ def _up_harness(tmp_path, nft_fail="", ks_present=True, lighthouse=_SENTINEL):
     silently unfalsifiable until it was noticed. The stub writes to a file, the
     way `journalctl -t airvpn-updown` is what the operator actually reads.
     """
+    # `parents=True`: callers pass a per-case SUBDIRECTORY of tmp_path so several
+    # harness runs in one test cannot share (and overwrite) each other's capture.
+    tmp_path.mkdir(parents=True, exist_ok=True)
     bindir = tmp_path / "upbin"
-    bindir.mkdir(exist_ok=True)
+    bindir.mkdir(parents=True, exist_ok=True)
     rec = tmp_path / "nftcalls"
-    rec.mkdir(exist_ok=True)
+    rec.mkdir(parents=True, exist_ok=True)
 
     # nft stub: append argv + stdin to a numbered file, then honour the
     # requested failure mode. `list table` answers the ks_present probe.
@@ -483,7 +509,10 @@ esac
     env = write_env(tmp_path, f"NEBULA_LIGHTHOUSE={lighthouse}\n")
     e = dict(os.environ,
              AIRVPN_UPDOWN_ENV=str(env),
-             PATH=f"{bindir}:{os.environ['PATH']}",
+             # `extra_path` FIRST so a case-specific `ip`/`wg` stub overrides the
+             # default no-op ones, letting a test drive what the producers see.
+             PATH=(f"{extra_path}:" if extra_path else "")
+                  + f"{bindir}:{os.environ['PATH']}",
              NFT_FAIL=nft_fail,
              KS_PRESENT="1" if ks_present else "")
     e.pop("NEBULA_LIGHTHOUSE", None)
@@ -556,21 +585,144 @@ def test_the_load_is_ONE_atomic_transaction(tmp_path):
 
     Mutant Y6 (delete the flush entirely) survived all 44 tests of the previous
     revision, because nothing looked at HOW the ruleset was loaded.
+
+    🔴 BOTH CALLERS, NOT JUST THE PRIMARY (audit 🟡3, mutant M12). This drove
+    `_up_harness` with NO failure injected, so it only ever inspected the primary
+    path — and replacing `arm_failclosed`'s `nft_load_atomic` with the old
+    `add`+`flush`+`load` sequence SURVIVED all 83 tests. That is the
+    "second caller open-codes the old sequence" shape, and it de-atomises
+    precisely the path that runs when things are already going wrong.
     """
-    _rc, _o, _e, calls = _up_harness(tmp_path)
-    argvs = [c.splitlines()[0] for c in calls]
-    assert not any("flush" in a for a in argvs), (
-        "a separate `nft flush` is back — the load is no longer atomic: " + str(argvs))
-    assert not any(a.startswith("ARGV: add table") for a in argvs), (
-        "a separate `nft add table` is back: " + str(argvs))
-    load = [c for c in calls if "STDIN:" in c]
-    assert load, f"no ruleset was loaded via stdin: {argvs}"
-    first = load[0]
-    assert "delete table inet airvpn_ks" in first, (
-        "the replacement is not self-contained — without the in-transaction "
-        "delete this ADDS to the old table instead of replacing it:\n" + first)
-    assert first.index("delete table") < first.index("chain out"), (
-        "the delete must precede the new definition in the same transaction")
+    for label, kwargs in (("primary", {}), ("fallback", {"nft_fail": "first"})):
+        _rc, _o, _e, calls = _up_harness(tmp_path / label, **kwargs)
+        argvs = [c.splitlines()[0] for c in calls]
+        assert not any("flush" in a for a in argvs), (
+            f"[{label}] a separate `nft flush` is back — the load is no longer "
+            f"atomic: {argvs}")
+        assert not any(a.startswith("ARGV: add table") for a in argvs), (
+            f"[{label}] a separate `nft add table` is back: {argvs}")
+
+        loads = [c for c in calls if "chain out" in c]
+        assert loads, f"[{label}] no ruleset was loaded via stdin: {argvs}"
+        # EVERY load must be self-contained, not merely the first.
+        for i, payload in enumerate(loads):
+            assert "delete table inet airvpn_ks" in payload, (
+                f"[{label}] load #{i} is not self-contained — without the "
+                f"in-transaction delete this ADDS to the old table instead of "
+                f"replacing it:\n{payload}")
+            assert payload.index("delete table") < payload.index("chain out"), (
+                f"[{label}] load #{i}: the delete must precede the new "
+                f"definition in the same transaction")
+    # and the fallback path must genuinely have produced a SECOND load, or the
+    # loop above asserted twice about the same thing.
+    _rc, _o, _e, calls = _up_harness(tmp_path / "fb-count", nft_fail="first")
+    assert len([c for c in calls if "chain out" in c]) >= 2, (
+        "the fallback never rendered a ruleset — the fallback half of this test "
+        "was vacuous")
+
+
+@pytest.mark.parametrize("gw_out,label", [
+    ("default dev eth0 \n", "gateway-less default route -> awk yields 'eth0'"),
+    ("default via not-an-ip dev eth0 \n", "junk in the gateway field"),
+    ("default via 2001:db8::1 dev eth0 \n", "IPv6 gateway"),
+])
+def test_a_NON_ADDRESS_gateway_never_reaches_the_ruleset(tmp_path, gw_out, label):
+    """🔴 AUDIT 🟡4. `$GW` is interpolated as `ip daddr ${GW} accept`, exactly
+    like the lighthouse — and it was the only one of the three with NO check.
+
+    On a gateway-less default route (`default dev eth0`) the awk yields the
+    literal `eth0`; nft then tries to DNS-RESOLVE that token, as root, inside
+    wg-quick's PostUp, and FAILS the primary load — which drops into the blanket
+    fallback, which has no `meta mark` accept, which kills the tunnel. This is
+    G1's exact class, one variable over.
+    """
+    bindir = tmp_path / "gwbin"
+    bindir.mkdir(parents=True)
+    mockbin.write_exec(bindir / "ip", f'''
+case "$*" in
+  *"route show default"*) printf '%s' '{gw_out}' ;;
+esac
+exit 0
+''')
+    _rc, _o, syslog, calls = _up_harness(tmp_path, extra_path=bindir)
+    loads = [c for c in calls if "chain out" in c]
+    assert loads, f"no ruleset rendered ({label})"
+    for tok in ("eth0", "not-an-ip", "2001:db8::1"):
+        assert f"ip daddr {tok} accept" not in loads[0], (
+            f"{label}: a non-address reached the ruleset as `ip daddr {tok}`:\n"
+            + loads[0])
+    assert "gw=none" in syslog, syslog
+
+
+def test_a_NON_ADDRESS_endpoint_never_reaches_the_ruleset(tmp_path):
+    """🔴 AUDIT 🟡4, the other producer. `wg show <if> endpoints` prints the
+    literal `(none)` for a peer that has no endpoint, and an IPv6 endpoint
+    survives the `sed` as a mangled hextet run. Both were interpolated straight
+    into `ip daddr` — IPv4 family — and failed the load.
+
+    🔴 THE `ip` STUB IS NOT OPTIONAL HERE. `EP` is only computed inside the
+    `if [[ -n "$GW" && -n "$PHYS" ]]` branch, so with the harness's default
+    no-op `ip` this test never reached `endpoint_ip` at all and passed
+    vacuously — measured: mutant G4b (delete the endpoint validation) SURVIVED
+    it. A real default route is what makes the assertion reachable.
+    """
+    bindir = tmp_path / "epbin"
+    bindir.mkdir(parents=True)
+    mockbin.write_exec(bindir / "ip", '''
+case "$*" in
+  *"route show default"*) printf 'default via 192.0.2.1 dev eth0 \\n' ;;
+esac
+exit 0
+''')
+    mockbin.write_exec(bindir / "wg", '''
+case "$1" in
+  show) case "$3" in
+          endpoints) printf 'PEERKEY\\t(none)\\n' ;;
+          fwmark) printf '0xca6c\\n' ;;
+        esac ;;
+esac
+exit 0
+''')
+    _rc, _o, syslog, calls = _up_harness(tmp_path, extra_path=bindir)
+    loads = [c for c in calls if "chain out" in c]
+    assert loads, "no ruleset rendered"
+    # reachability control: the gateway DID land, so this run really did take
+    # the branch where the endpoint is computed.
+    assert "ip daddr 192.0.2.1 accept" in loads[0], (
+        "the run never reached the branch that computes EP — this test would "
+        "pass vacuously:\n" + loads[0])
+    assert "(none)" not in loads[0], (
+        "wg's literal `(none)` reached the ruleset:\n" + loads[0])
+    assert "ep=?" in syslog or "ep=none" in syslog, syslog
+
+
+def test_positive_control_a_VALID_gateway_and_endpoint_DO_reach_the_ruleset(tmp_path):
+    """🔴 The complement, and the control that keeps the two tests above from
+    passing because nothing was rendered at all. A validator that rejects
+    EVERYTHING is not a validator — feed it good values and require they land."""
+    bindir = tmp_path / "okbin"
+    bindir.mkdir(parents=True)
+    mockbin.write_exec(bindir / "ip", '''
+case "$*" in
+  *"route show default"*) printf 'default via 192.0.2.1 dev eth0 \\n' ;;
+esac
+exit 0
+''')
+    mockbin.write_exec(bindir / "wg", '''
+case "$1" in
+  show) case "$3" in
+          endpoints) printf 'PEERKEY\\t198.51.100.9:1637\\n' ;;
+          fwmark) printf '0xca6c\\n' ;;
+        esac ;;
+esac
+exit 0
+''')
+    _rc, _o, syslog, calls = _up_harness(tmp_path, extra_path=bindir)
+    loads = [c for c in calls if "chain out" in c]
+    assert loads, "no ruleset rendered"
+    assert "ip daddr 192.0.2.1 accept" in loads[0], loads[0]
+    assert "ip daddr 198.51.100.9 accept" in loads[0], loads[0]
+    assert "meta mark 0xca6c accept" in loads[0], loads[0]
 
 
 def test_the_comment_describing_the_fallback_matches_the_code():
@@ -618,6 +770,49 @@ def test_the_arm_line_names_the_FALLBACK_when_that_is_what_is_installed(tmp_path
     `meta mark` accept."""
     _rc, _o, err, _calls = _up_harness(tmp_path, nft_fail="first", ks_present=True)
     assert "killswitch ARMED(fallback)" in err, err
+
+
+def test_both_loads_failing_with_a_SURVIVING_table_reports_STALE(tmp_path):
+    """🔴 THE FOURTH STATE — one my own F4 created, and no test covered it.
+
+    Before the atomic load, "both loads failed" implied the table had already
+    been flushed, so NOT-ARMED was the only reachable outcome. After F4 a failed
+    load changes nothing, so the PREVIOUS table survives and `ks_present` is
+    TRUE while `KS_RULESET` is `none` — which reported as `ARMED(none)`,
+    directly contradicting the `FALLBACK … ALSO FAILED` line immediately above
+    it. Worse than meaningless: the surviving ruleset was built for a DIFFERENT
+    endpoint and fwmark, so it can read as armed while the tunnel is dead.
+    """
+    _rc, _o, syslog, _calls = _up_harness(tmp_path, nft_fail="all", ks_present=True)
+    assert "STALE(previous)" in syslog, syslog
+    assert "ARMED(none)" not in syslog, (
+        "the meaningless fourth state is back: " + syslog)
+    # the two lines must not contradict each other any more
+    assert "uplink is NOT filtered" not in syslog, (
+        "the fallback still claims the uplink is unfiltered while a table "
+        "survives: " + syslog)
+    assert "OLDER table" in syslog and "does NOT match" in syslog, syslog
+
+
+def test_the_four_states_are_pairwise_distinct(tmp_path):
+    """A four-way verdict is only useful if the four are distinguishable. Drive
+    every corner of (load outcome × kernel answer) and require four different
+    strings — a collapse to three is how `ARMED(none)` hid in the first place."""
+    seen = {}
+    for label, kwargs in (
+        ("primary",  {}),
+        ("fallback", {"nft_fail": "first"}),
+        ("stale",    {"nft_fail": "all", "ks_present": True}),
+        ("gone",     {"nft_fail": "all", "ks_present": False}),
+    ):
+        _rc, _o, syslog, _c = _up_harness(tmp_path / label, **kwargs)
+        # the stub replays logger's full argv, so the tag precedes the message
+        line = [l for l in syslog.splitlines() if "up: killswitch " in l]
+        assert len(line) == 1, (label, syslog)
+        seen[label] = line[0].split("up: killswitch ", 1)[1].split()[0]
+    assert len(set(seen.values())) == 4, f"states collapsed: {seen}"
+    assert seen == {"primary": "ARMED(primary)", "fallback": "ARMED(fallback)",
+                    "stale": "STALE(previous)", "gone": "NOT-ARMED"}, seen
 
 
 def test_the_ks_present_probe_is_load_bearing(tmp_path):
@@ -805,7 +1000,14 @@ def test_apply_creates_the_file_0600_root_owned_from_the_env_var(tmp_path):
     f = tmp_path / "new.env"
     rc, out, err = apply_lib(tmp_path, f, env={"NEBULA_LIGHTHOUSE": GOOD_V4})
     assert rc == 0, (out, err)
-    assert f.read_text().strip() == f"NEBULA_LIGHTHOUSE={GOOD_V4}"
+    # 🔴 EXACT BYTES, NOT `.strip()`ed (audit X11). The audit's real X11 mutant
+    # changed this `printf` from `'NEBULA_LIGHTHOUSE=%s\n'` to `'%s'` — dropping
+    # the trailing newline — and SURVIVED, because `.strip()` erases the very
+    # byte F3 is about. A file with no final newline is the canonical
+    # partially-written shape; a fixture that cannot see it is a fixture that
+    # cannot see F3's regression either.
+    assert f.read_bytes() == f"NEBULA_LIGHTHOUSE={GOOD_V4}\n".encode(), (
+        f"exact bytes differ: {f.read_bytes()!r}")
     assert oct(f.stat().st_mode & 0o777) == "0o600", oct(f.stat().st_mode)
 
 
@@ -850,13 +1052,24 @@ def test_the_apply_script_provisions_the_env_BEFORE_installing_the_helper():
 
 def test_the_skill_documents_the_prerequisite_BEFORE_the_install_command():
     """The same ordering defect in the doc an operator actually follows: the
-    requirement used to be a trailing sentence AFTER the install command."""
+    requirement used to be a trailing sentence AFTER the install command.
+
+    🔴 ANCHORED ON THE 🔴 BLOCK'S OWN TEXT (audit X15). The previous version
+    anchored on the substring `/etc/airvpn-updown.env`, which Procedure step 1's
+    own command ALSO contains — so the audit's real X15 mutant, moving the whole
+    prerequisite block to the END of the file, SURVIVED. A guard that can be
+    satisfied by a different occurrence of the same substring is pinning
+    spelling, not order.
+    """
     doc = SKILL_DOC.read_text(encoding="utf-8")
-    prereq = doc.index("/etc/airvpn-updown.env")
+    prereq = doc.index("is a PREREQUISITE, not an\nafterthought")
     install = doc.index("sudo install -m 0755 -o root -g root")
     assert prereq < install, (
         "airvpn.md introduces the env file only after telling the operator to "
         "install and re-arm")
+    # …and the block must still precede the Procedures it is a prerequisite FOR.
+    assert prereq < doc.index("## Procedures"), (
+        "the prerequisite block has been moved out from in front of Procedures")
 
 
 # --- G7: the DURABLE artifact, not just the PR body ---------------------------
@@ -918,12 +1131,81 @@ def test_the_retest_protocol_observes_the_slash32_route_directly():
     assert route < ssh, "the route check must precede the checks it is not implied by"
 
 
+def test_the_off_LAN_step_names_the_SOURCE_host_and_is_not_a_self_ssh():
+    """🔴 P1 — the step the entire do-not-merge banner exists for.
+
+    `10.42.0.30` is the WORKBENCH'S OWN nebula address, and step 1 puts the
+    operator on the LAN. `ssh zach@10.42.0.30` run there is a SELF-SSH; from
+    another LAN host it is a same-LAN hop. Neither exercises the nebula
+    DIRECT-PUNCH path that this section's opening line says a LAN-only test
+    cannot reach — the path that locked the host out in #118. The step carrying
+    the whole "off-LAN" claim never said which host to run it FROM, so followed
+    literally it passed unconditionally.
+    """
+    sec = _protocol_section()
+    tail = sec[sec.index("11."):]
+    # AND, not OR: an earlier version accepted either phrase, so a mutant that
+    # changed "ON THE LAPTOP" to "ON THIS HOST" — i.e. re-created the self-ssh —
+    # SURVIVED on the other half of the disjunction.
+    assert "ON THE LAPTOP" in tail, (
+        "the off-LAN step no longer names the SOURCE host to run it from")
+    assert "off-LAN host" in tail, (
+        "the off-LAN step no longer says the source must be off-LAN")
+    assert "self-ssh" in tail, (
+        "the step no longer explains WHY running it on the workbench is void")
+    # it must tell the operator how to notice they are still on the LAN
+    assert "192" in tail and "STILL ON THE LAN" in tail, (
+        "no guard against running the off-LAN step from the LAN")
+    # …and what a pass and a fail each look like
+    for verdict in ("**PASS**", "**FAIL**", "**INVALID**"):
+        assert verdict in tail, f"the off-LAN step does not define {verdict}"
+    assert "cannot be completed" in tail, (
+        "no instruction for the case where no off-LAN host exists — that is "
+        "when the self-ssh gets substituted")
+
+
+def test_the_precondition_checks_UP_ness_not_mere_existence():
+    """🟢 P3. `ip link show airvpn` succeeds for an interface left behind by a
+    HALF-FAILED `wg-quick up` — a state in which `wg show … fwmark` still fails
+    and arming still blackholes the host. Existence is not up-ness."""
+    sec = _protocol_section()
+    assert "EXISTENCE IS NOT UP-NESS" in sec, sec[:600]
+    assert "grep -qw UP" in sec, "the check does not require the link to be UP"
+    assert "latest-handshakes" in sec, (
+        "the check does not require a peer that has actually answered")
+
+
+def test_the_install_step_tells_the_operator_to_confirm_the_branch():
+    """🟢 P4. G8 exists precisely because the DEPLOYED helper was found
+    byte-identical to `main` while the PR was open. Installing from a checkout
+    without confirming which branch is in it reproduces that."""
+    sec = _protocol_section()
+    install = sec.index("sudo install -m 0755")
+    head = sec[:install]
+    assert "status -sb" in head, (
+        "the install step does not tell the operator to confirm the branch")
+
+
+def test_the_protocol_says_to_BAIL_on_a_degraded_ruleset():
+    """🟡 P5. `ARMED(fallback)` was described as merely 'degraded', while the
+    script's own comment says that state drops wg's encrypted packets and kills
+    the tunnel. With no instruction to bail, the operator walks into step 10's
+    `curl` and gets a confusing failure instead of a diagnosed one."""
+    sec = _protocol_section()
+    six = sec[sec.index("6. `journalctl"):sec.index("7. 🔴")]
+    for state in ("ARMED(fallback)", "STALE(previous)", "NOT-ARMED"):
+        assert state in six, f"step 6 does not mention {state}"
+    assert six.count("BAIL NOW") >= 2, (
+        "step 6 does not tell the operator to bail on a degraded/stale ruleset:\n"
+        + six)
+
+
 def test_the_retest_protocol_reads_the_new_arm_line_fields():
     """The protocol must name the fields this PR added, or it cannot detect the
     failure modes this PR introduces."""
     sec = _protocol_section()
     for token in ("lighthouse=UNSET", "ARMED(primary)", "ARMED(fallback)",
-                  "NOT-ARMED", "state=ok"):
+                  "STALE(previous)", "NOT-ARMED", "state=ok"):
         assert token in sec, f"the protocol never mentions {token}"
 
 
@@ -936,8 +1218,12 @@ def test_the_debug_section_shows_the_CURRENT_arm_line_format():
     assert "lighthouse=" in dbg, "the arm-line example predates this PR"
     assert "killswitch armed (fwmark" not in dbg, (
         "the Debug section still shows the OLD unconditional `armed` wording")
-    for state in ("ARMED(primary)", "ARMED(fallback)", "NOT-ARMED"):
+    for state in ("ARMED(primary)", "ARMED(fallback)", "STALE(previous)",
+                  "NOT-ARMED"):
         assert state in dbg, f"Debug/bail does not explain {state}"
+    assert "FOUR states" in dbg, (
+        "Debug/bail still says THREE states — `STALE(previous)` became "
+        "reachable when the load was made atomic")
 
 
 # --- the seam ------------------------------------------------------------------

--- a/scripts/tests/test_airvpn_updown_env.py
+++ b/scripts/tests/test_airvpn_updown_env.py
@@ -115,7 +115,13 @@ def test_the_last_assignment_wins(tmp_path):
 # --- A-2: a malformed value must be UNSET, never interpolated ------------------
 
 @pytest.mark.parametrize("value,why", [
-    ("5.161.118", "truncated quad — a partially-written file"),
+    # 🔴 TEST-NET-3, deliberately. An earlier revision used the REAL lighthouse's
+    # first three octets here — byte-identical to the prefix of the literal this
+    # PR deletes — which would have narrowed it from "somewhere in Hetzner" to a
+    # /24 in a PUBLIC repo, on merge. Neither gate can catch that: a 3-octet
+    # prefix is not an address, so `is_reportable()` is False by construction.
+    # Every literal in this file must be TEST-NET.
+    ("203.0.113", "truncated quad — a partially-written file"),
     ("203.0.113.", "trailing dot"),
     ("203.0.113.999", "octet > 255"),
     ("$(id)", "command substitution"),

--- a/scripts/tests/test_airvpn_updown_env.py
+++ b/scripts/tests/test_airvpn_updown_env.py
@@ -59,7 +59,7 @@ def _bash():
     return shutil.which("bash") or "/bin/sh"
 
 
-def check_env(env_file: Path | None, extra=None):
+def check_env(env_file: Path | None, extra=None, timeout=30):
     """Run `airvpn-updown check-env` and return (rc, stdout, stderr)."""
     env = dict(os.environ)
     env.pop("NEBULA_LIGHTHOUSE", None)
@@ -67,7 +67,7 @@ def check_env(env_file: Path | None, extra=None):
         env["AIRVPN_UPDOWN_ENV"] = str(env_file)
     env.update(extra or {})
     r = subprocess.run([_bash(), str(UPDOWN), "check-env"],
-                       capture_output=True, text=True, env=env, timeout=30)
+                       capture_output=True, text=True, env=env, timeout=timeout)
     return r.returncode, r.stdout, r.stderr
 
 
@@ -86,10 +86,56 @@ def test_a_valid_ipv4_resolves(tmp_path):
     assert f"lighthouse={GOOD_V4}" in out
 
 
-def test_a_valid_ipv6_resolves(tmp_path):
-    rc, out, _ = check_env(write_env(tmp_path, f"NEBULA_LIGHTHOUSE={GOOD_V6}\n"))
-    assert rc == 0, out
-    assert f"lighthouse={GOOD_V6}" in out
+@pytest.mark.parametrize("v6", [
+    # 🔴 Every v6 here is either a non-address or inside 2001:db8::/32. An
+    # arbitrary 8-group literal is GLOBALLY ROUTABLE and this repo is public;
+    # one slipped in here and `test_no_public_ips.py` caught it in the SANDBOX
+    # tier only, because running this file alone never loads that gate. Then the
+    # COMMENT explaining the mistake re-spelled the same literal and was caught
+    # again — hence the deliberately value-free wording.
+    GOOD_V6, "::", ":::::", "0::0::0", "2001:db8:0:0:0:0:0:1", "fe80::1",
+])
+def test_an_IPv6_value_is_REJECTED_because_the_ruleset_cannot_express_it(tmp_path, v6):
+    """🔴 REVERSED from the previous revision, which asserted v6 RESOLVES.
+
+    That test blessed an outage. The consumers are `ip daddr <v>` (an IPv4-family
+    nft match) and `ip route replace <v> via <IPv4 gateway>`. A v6 value passes a
+    naive "is this an address" check, then fails the nft LOAD — which used to
+    flush the table first and fall through to `arm_failclosed`, a ruleset with no
+    `meta mark` accept, so wg's own encrypted packets are dropped and THE TUNNEL
+    DIES. `::`, `:::::` and `0::0::0` were all accepted too.
+
+    Validate against what the ruleset can EXPRESS, not against what looks like an
+    address. If v6 lighthouses are ever needed, the emitter has to grow an
+    `ip6 daddr` branch and a v6 route first — and this test is where that starts.
+    """
+    rc, out, err = check_env(write_env(tmp_path, f"NEBULA_LIGHTHOUSE={v6}\n"))
+    assert rc == 1, (rc, out, err)
+    assert "lighthouse=UNSET" in out and "state=rejected-or-empty" in out, out
+    assert "not a canonical IPv4 address" in err, err
+
+
+@pytest.mark.parametrize("v4", [
+    "010.0.0.1", "00.0.0.1", "203.0.113.09", "0203.0.113.9", "203.00.113.9",
+])
+def test_a_LEADING_ZERO_octet_is_REJECTED(tmp_path, v4):
+    """🔴 Two consumers disagree about what a zero-prefixed octet means:
+    `getent`/inet_aton read it as OCTAL, nft reads it as decimal. Accepting one
+    means the route and the firewall rule name DIFFERENT hosts. (The resolved
+    octal value is deliberately not written here — it is a routable address and
+    this repo is public; `test_no_public_ips.py` flagged it when it was.)
+
+    `203.0.113.09` was previously rejected only by ACCIDENT — bash raised
+    'value too great for base' inside the arithmetic, which is a crash, not a
+    decision, and would have flipped to ACCEPTED the moment the range check was
+    written `10#$o` without also rejecting the leading zero.
+    """
+    rc, out, err = check_env(write_env(tmp_path, f"NEBULA_LIGHTHOUSE={v4}\n"))
+    assert rc == 1, (rc, out, err)
+    assert "lighthouse=UNSET" in out, out
+    assert "not a canonical IPv4 address" in err, err
+    assert "value too great" not in err, (
+        "rejected by a bash arithmetic CRASH, not by the validator: " + err)
 
 
 @pytest.mark.parametrize("body", [
@@ -135,30 +181,135 @@ def test_the_last_assignment_wins(tmp_path):
 ])
 def test_a_malformed_value_is_treated_as_UNSET_and_says_why(tmp_path, value, why):
     """🔴 A-2. Every one of these made BOTH the primary ruleset and the blanket
-    fallback fail to parse, and `up` flushes the table BEFORE loading — so a
+    fallback fail to parse, and `up` flushed the table BEFORE loading — so a
     re-arm with any of them removed a working killswitch and installed nothing,
     exit 0. UNSET is the fail-SAFE outcome, and it must be announced."""
     rc, out, err = check_env(write_env(tmp_path, f"NEBULA_LIGHTHOUSE={value}\n"))
     assert rc == 1, (rc, out, err)
     assert "lighthouse=UNSET" in out, out
-    assert "not an IP address" in err, err
+    assert "not a canonical IPv4 address" in err, err
     # 🔴 The rejected text must NEVER be echoed back — it is attacker-controlled
     # and the log line goes to syslog.
     assert value not in out and value not in err, (out, err)
 
 
-def test_an_absent_key_is_UNSET_but_quiet(tmp_path):
-    """Distinct from the case above: 'you did not set it' is the documented
-    default, 'you set it to garbage' is an error. Same safe outcome, different
-    signal — otherwise the operator cannot tell which one they are in."""
+# --- F3: the shape A-2 is NAMED for was the one shape the guard was silent on --
+
+@pytest.mark.parametrize("body,expect_ok", [
+    (f"NEBULA_LIGHTHOUSE={GOOD_V4}", True),
+    (f"# note\nNEBULA_LIGHTHOUSE={GOOD_V4}", True),
+    (f"NEBULA_LIGHTHOUSE={OTHER_V4}\nNEBULA_LIGHTHOUSE={GOOD_V4}", True),
+])
+def test_a_file_with_NO_TRAILING_NEWLINE_still_resolves(tmp_path, body, expect_ok):
+    """🔴 F3 — THE regression this whole guard is named after.
+
+    `read` returns non-zero on a final line with no trailing newline, so the
+    plain `while IFS= read -r line` loop DROPPED it. A file whose write was cut
+    short is precisely a file with no final newline, so
+    `NEBULA_LIGHTHOUSE=<ip>` with no `\\n` resolved to EMPTY and fell into the
+    "key simply absent" branch — **UNSET with no log line at all**, while the
+    PR body claimed "an unparseable value is treated as UNSET, loudly… a
+    partially-written env file was enough".
+
+    Mutant X4 (drop the final line) survived all 44 tests of the previous
+    revision. This is the coverage that kills it.
+    """
+    p = tmp_path / "nonl.env"
+    p.write_text(body, encoding="utf-8")  # deliberately no trailing newline
+    p.chmod(0o600)
+    assert not p.read_bytes().endswith(b"\n"), "fixture must have no final newline"
+    rc, out, err = check_env(p)
+    assert rc == 0, (rc, out, err)
+    assert f"lighthouse={GOOD_V4}" in out, out
+
+
+@pytest.mark.parametrize("tail", [b"\r", b"\r\n"])
+def test_CRLF_resolves_rather_than_silently_UNSETTING(tmp_path, tail):
+    """CRLF shares F3's root cause (a `\\r`-only tail is also "no final LF"), and
+    the audit flagged it alongside.
+
+    MEASURED, and the outcome is better than I first assumed: the rtrim already
+    strips `\\r` (it is `[:space:]`), so a CRLF file — with or without a final
+    LF — resolves CORRECTLY rather than being rejected. Both tails are pinned so
+    that stays true; the failure being fixed is SILENCE, and neither of these is
+    silent.
+    """
+    p = tmp_path / "crlf.env"
+    p.write_bytes(f"NEBULA_LIGHTHOUSE={GOOD_V4}".encode() + tail)
+    p.chmod(0o600)
+    rc, out, err = check_env(p)
+    assert rc == 0, (rc, out, err)
+    assert f"lighthouse={GOOD_V4} state=ok" in out, out
+
+
+def test_an_absent_key_says_so_rather_than_saying_nothing(tmp_path):
+    """Distinct from a rejected value: 'you did not set it' vs 'you set it to
+    garbage'. Same safe outcome, different signal — and after F3 BOTH are
+    announced, because a silent UNSET is indistinguishable from a truncated
+    file, which is exactly how F3 hid."""
     rc, out, err = check_env(write_env(tmp_path, "SOMETHING_ELSE=1\n"))
     assert rc == 1 and "lighthouse=UNSET" in out
-    assert "not an IP address" not in err, err
+    assert "state=rejected-or-empty" in out, out
+    assert "has no NEBULA_LIGHTHOUSE= line" in err, err
+    assert "not a canonical IPv4 address" not in err, err
 
 
-def test_a_missing_file_is_UNSET_not_a_crash(tmp_path):
-    rc, out, _ = check_env(tmp_path / "does-not-exist.env")
+def test_a_missing_file_is_UNSET_and_says_ABSENT(tmp_path):
+    rc, out, err = check_env(tmp_path / "does-not-exist.env")
     assert rc == 1 and "lighthouse=UNSET" in out, out
+    assert "state=absent" in out, out
+
+
+# --- G4: a non-regular file must not HANG or emit a raw shell error ------------
+
+def test_a_FIFO_at_the_env_path_does_not_hang(tmp_path):
+    """🔴 G4. The read runs at TOP LEVEL, which in production is inside
+    wg-quick's PostUp as root. A FIFO there blocked FOREVER (measured
+    unbounded), so `wg-quick up` stalled with the interface UP and the
+    killswitch NOT YET ARMED — an indefinite fail-OPEN window, and a NEW
+    failure mode: the pre-env-file script read no file at all.
+
+    The timeout here is the assertion. If this test ever hangs, it has found
+    the bug back.
+    """
+    fifo = tmp_path / "fifo.env"
+    os.mkfifo(fifo, 0o600)
+    try:
+        # A short timeout on purpose: the correct path returns in milliseconds,
+        # and the bug is UNBOUNDED, so waiting longer buys nothing.
+        rc, out, err = check_env(fifo, timeout=5)
+    except subprocess.TimeoutExpired:  # pragma: no cover - the bug itself
+        pytest.fail("reading the env path BLOCKED — G4 has regressed")
+    assert rc == 1, (rc, out, err)
+    assert "state=not-a-regular-file" in out, out
+    assert "not a regular file" in err, err
+
+
+def test_a_DIRECTORY_at_the_env_path_is_rejected_cleanly(tmp_path):
+    """It used to emit a raw `read: 0: read error: Is a directory` and then
+    silently UNSET — a shell error message is not a diagnosis."""
+    d = tmp_path / "dir.env"
+    d.mkdir()
+    rc, out, err = check_env(d)
+    assert rc == 1, (rc, out, err)
+    assert "state=not-a-regular-file" in out, out
+    assert "read error" not in err, ("raw shell error leaked: " + err)
+
+
+# --- G3: unreadable is NOT the same as absent ---------------------------------
+
+def test_an_UNREADABLE_file_says_so_rather_than_looking_UNSET(tmp_path):
+    """🔴 G3. `check-env` is the ONE diagnostic the operator protocol tells you
+    to trust. Running it WITHOUT sudo on a correct 0600 root:root host is the
+    likeliest way to see UNSET, and reporting that identically to 'you never
+    created the file' sends the operator to fix the wrong thing."""
+    if os.geteuid() == 0:  # pragma: no cover - the sandbox runs unprivileged
+        pytest.skip("root can read anything; the distinction is unobservable")
+    p = write_env(tmp_path, f"NEBULA_LIGHTHOUSE={GOOD_V4}\n", mode=0o000)
+    rc, out, err = check_env(p)
+    assert rc == 1, (rc, out, err)
+    assert "state=unreadable-by-uid-" in out, out
+    assert "not readable" in err and "run as root" in err, err
 
 
 # --- A-4: the file is parsed, not sourced --------------------------------------
@@ -269,25 +420,157 @@ def test_the_stat_stub_itself_is_load_bearing(tmp_path):
         "the stat stub is not being used — the owner tests prove nothing")
 
 
-# --- the fallback ruleset ------------------------------------------------------
+# --- the RENDER harness: what the kernel would actually have been handed -------
+#
+# 🔴 WHY THIS EXISTS. The previous revision asserted the fallback "carries no
+# lighthouse" by grepping the function body for the string `NEBULA_LIGHTHOUSE`.
+# That is a SPELLED guard, and the audit's mutant Y1 walked straight past it:
+# assign `_FB_LH="${NEBULA_LIGHTHOUSE}"` OUTSIDE the function and interpolate
+# `${_FB_LH}` inside — the token is gone, the hazard is fully restored, the test
+# is green. RULES.md: "can the guard pass while the hazard exists in a different
+# shape?" It could.
+#
+# So assert the PROPERTY instead: render the rulesets with the lighthouse set to
+# a distinctive sentinel and require that the fallback's actual TEXT does not
+# contain it, whatever route it took to get there.
+#
+# Nothing real is touched. `nft`, `ip`, `wg` and `logger` are all stubs; the stub
+# `nft` records every invocation's argv and stdin, and NEVER commits anything.
 
-def test_the_blanket_fallback_carries_no_lighthouse():
-    """🔴 A-2, structural half. `arm_failclosed` is the fallback for 'the primary
-    ruleset did not parse'. Any value that could have broken that parse must not
-    appear in it too, or both fail together and the uplink ends up with NO table.
+_SENTINEL = "198.51.100.77"   # TEST-NET-2, distinctive, and a valid IPv4
 
-    Asserted on the function BODY, not on the file — a match anywhere else in a
-    600-line script would pass while the fallback stayed broken.
+
+def _up_harness(tmp_path, nft_fail="", ks_present=True, lighthouse=_SENTINEL):
+    """Run `airvpn-updown up airvpn` with every external command stubbed.
+
+    Returns (rc, stdout, syslog_text, [captured nft calls]).
+
+    🔴 `syslog_text`, not stderr. `log()` runs `logger … 2>/dev/null`, so a stub
+    that writes to stderr is DISCARDED by the code under test — which is correct
+    in production (syslog is the sink) and made every arm-line assertion here
+    silently unfalsifiable until it was noticed. The stub writes to a file, the
+    way `journalctl -t airvpn-updown` is what the operator actually reads.
     """
-    src = UPDOWN.read_text(encoding="utf-8")
-    start = src.index("arm_failclosed() {")
-    end = src.index("\n}\n", src.index("FB\n", start))
-    body = src[start:end]
-    assert "NEBULA_LIGHTHOUSE" not in body, (
-        "the fallback ruleset interpolates the lighthouse again:\n" + body)
-    # and it must still be a real fallback, not an empty one
-    for required in ("meta skuid", "LAN_SUBNET", "drop"):
-        assert required in body, f"the fallback lost its {required} rule"
+    bindir = tmp_path / "upbin"
+    bindir.mkdir(exist_ok=True)
+    rec = tmp_path / "nftcalls"
+    rec.mkdir(exist_ok=True)
+
+    # nft stub: append argv + stdin to a numbered file, then honour the
+    # requested failure mode. `list table` answers the ks_present probe.
+    mockbin.write_exec(bindir / "nft", f'''
+n=$(ls "{rec}" | wc -l)
+f="{rec}/$n"
+printf 'ARGV: %s\\n' "$*" > "$f"
+case "$1" in
+  list) [ -n "$KS_PRESENT" ] && exit 0 || exit 1 ;;
+esac
+printf 'STDIN:\\n' >> "$f"
+cat >> "$f"
+case "$NFT_FAIL" in
+  all) exit 1 ;;
+  first) [ "$n" = "0" ] && exit 1 || exit 0 ;;
+  *) exit 0 ;;
+esac
+''')
+    # ip: no default route -> the bypass-route block is skipped entirely, so
+    # nothing is written to /run and no route is ever touched.
+    mockbin.write_exec(bindir / "ip", "exit 0\n")
+    mockbin.write_exec(bindir / "wg", "exit 1\n")
+    syslog = tmp_path / "syslog.txt"
+    mockbin.write_exec(bindir / "logger", f'printf "%s\\n" "$*" >> "{syslog}"\n')
+
+    env = write_env(tmp_path, f"NEBULA_LIGHTHOUSE={lighthouse}\n")
+    e = dict(os.environ,
+             AIRVPN_UPDOWN_ENV=str(env),
+             PATH=f"{bindir}:{os.environ['PATH']}",
+             NFT_FAIL=nft_fail,
+             KS_PRESENT="1" if ks_present else "")
+    e.pop("NEBULA_LIGHTHOUSE", None)
+    r = subprocess.run([_bash(), str(UPDOWN), "up", "airvpn"],
+                       capture_output=True, text=True, env=e, timeout=30)
+    calls = []
+    for i in sorted(rec.iterdir(), key=lambda p: int(p.name)):
+        calls.append(i.read_text())
+    log_text = syslog.read_text(encoding="utf-8") if syslog.exists() else ""
+    return r.returncode, r.stdout, log_text, calls
+
+
+def test_the_syslog_stub_is_load_bearing(tmp_path):
+    """🔴 POSITIVE CONTROL for every arm-line assertion below. They all read
+    `syslog_text`; if the stub never captured anything they would all be
+    assertions against an empty string — which is exactly what happened when the
+    stub wrote to stderr and `log()`'s `2>/dev/null` ate it. Require a non-zero
+    capture before believing any of them."""
+    _rc, _o, syslog, _calls = _up_harness(tmp_path)
+    assert syslog.strip(), "the logger stub captured NOTHING"
+    assert "up: killswitch" in syslog, syslog
+
+
+def test_the_harness_observes_a_real_ruleset(tmp_path):
+    """🔴 POSITIVE CONTROL for everything below. Every assertion that follows is
+    of the form "the sentinel is NOT in the fallback" or "there is no flush" —
+    all satisfiable by a harness that captured nothing at all. Require a
+    NON-ZERO observation first: the primary ruleset must be captured, and it
+    must contain the sentinel (which is the whole point of the primary)."""
+    _rc, _o, _e, calls = _up_harness(tmp_path)
+    assert calls, "the nft stub captured NOTHING — the harness is wired to nothing"
+    body = "\n".join(calls)
+    assert _SENTINEL in body, (
+        "the primary ruleset does not contain the lighthouse the env file set — "
+        "the harness is not reaching the real code path")
+    assert "chain out" in body and "drop" in body, body[:400]
+
+
+def test_the_FALLBACK_ruleset_contains_no_lighthouse_derived_value(tmp_path):
+    """🔴 A-2, asserted as a PROPERTY of the rendered text (kills mutant Y1).
+
+    Force the primary load to fail so `arm_failclosed` runs, then require that
+    the text the fallback handed to nft contains the sentinel NOWHERE — no
+    matter what variable name it travelled under.
+    """
+    _rc, _o, _e, calls = _up_harness(tmp_path, nft_fail="first")
+    # Select the fallback by CONTENT, not by index. Indexing on `calls[1]`
+    # happened to be right for the current implementation and wrong for the
+    # previous one (which issued `add` and `flush` as separate nft calls), so it
+    # went red for an indexing reason rather than for the property — red for the
+    # wrong reason is as misleading as green for the wrong reason.
+    loads = [c for c in calls if "chain out" in c]
+    assert len(loads) >= 2, f"the fallback never rendered a ruleset: {calls}"
+    fallback = loads[-1]
+    assert _SENTINEL not in fallback, (
+        "the FALLBACK ruleset interpolates a lighthouse-derived value — the "
+        "value that can break the primary parse must not be able to break the "
+        "fallback too:\n" + fallback)
+    # …and it must still be a real fallback, not an empty one.
+    for required in ("meta skuid", "chain out", "drop"):
+        assert required in fallback, f"the fallback lost its {required} rule"
+
+
+def test_the_load_is_ONE_atomic_transaction(tmp_path):
+    """🔴 F4. The old sequence was `nft add table` → `nft flush table` → `nft -f`:
+    three transactions, the first two of which DESTROY the working killswitch
+    before the third is known to parse. Any failure then left the uplink flushed
+    and empty at exit 0 — the A-2 outcome by a different door (and reachable
+    without the env file at all, e.g. a `$NEBULA_USER` nft cannot resolve).
+
+    Mutant Y6 (delete the flush entirely) survived all 44 tests of the previous
+    revision, because nothing looked at HOW the ruleset was loaded.
+    """
+    _rc, _o, _e, calls = _up_harness(tmp_path)
+    argvs = [c.splitlines()[0] for c in calls]
+    assert not any("flush" in a for a in argvs), (
+        "a separate `nft flush` is back — the load is no longer atomic: " + str(argvs))
+    assert not any(a.startswith("ARGV: add table") for a in argvs), (
+        "a separate `nft add table` is back: " + str(argvs))
+    load = [c for c in calls if "STDIN:" in c]
+    assert load, f"no ruleset was loaded via stdin: {argvs}"
+    first = load[0]
+    assert "delete table inet airvpn_ks" in first, (
+        "the replacement is not self-contained — without the in-transaction "
+        "delete this ADDS to the old table instead of replacing it:\n" + first)
+    assert first.index("delete table") < first.index("chain out"), (
+        "the delete must precede the new definition in the same transaction")
 
 
 def test_the_comment_describing_the_fallback_matches_the_code():
@@ -299,6 +582,201 @@ def test_the_comment_describing_the_fallback_matches_the_code():
     tail = head[head.rindex("# Blanket FAIL-CLOSED"):]
     assert "NO OPERATOR-SUPPLIED TEXT" in tail, (
         "the fallback's comment no longer states what the code does")
+
+
+# --- G6: the arm line must not claim ARMED when nothing is armed --------------
+
+def test_the_arm_line_reports_NOT_ARMED_when_both_loads_failed(tmp_path):
+    """🔴 G6. The old arm line was UNCONDITIONAL — it printed `killswitch armed`
+    even when the primary load AND `arm_failclosed` had both failed, i.e. exactly
+    when the uplink was unfiltered. This PR adds the `lighthouse=` field to that
+    same line and tells the operator to read it, so the line carrying the new
+    signal was the one that lied. Mutant Y5 (always report a lighthouse) survived
+    the previous revision.
+
+    Driven with both loads failing AND the kernel reporting the table absent.
+    """
+    _rc, _o, err, _calls = _up_harness(tmp_path, nft_fail="all", ks_present=False)
+    assert "NOT-ARMED" in err, err
+    assert "UNFILTERED" in err, err
+    assert "killswitch ARMED" not in err, (
+        "the arm line claims ARMED after both loads failed: " + err)
+
+
+def test_the_arm_line_reports_ARMED_when_the_kernel_says_the_table_is_there(tmp_path):
+    """The complement. A guard that only ever says NOT-ARMED is useless too —
+    measure both ends, not just the failure side."""
+    _rc, _o, err, _calls = _up_harness(tmp_path, ks_present=True)
+    assert "killswitch ARMED(primary)" in err, err
+    assert "NOT-ARMED" not in err, err
+    assert f"lighthouse={_SENTINEL}" in err, err
+
+
+def test_the_arm_line_names_the_FALLBACK_when_that_is_what_is_installed(tmp_path):
+    """Three states, not two: primary / fallback / none. Collapsing fallback into
+    'armed' hides that the uplink is running a degraded ruleset with no
+    `meta mark` accept."""
+    _rc, _o, err, _calls = _up_harness(tmp_path, nft_fail="first", ks_present=True)
+    assert "killswitch ARMED(fallback)" in err, err
+
+
+def test_the_ks_present_probe_is_load_bearing(tmp_path):
+    """POSITIVE CONTROL for the three above: flipping ONLY the kernel's answer,
+    with the loads succeeding, must flip the verdict. If it does not, the arm
+    line is still being written from the load's exit status."""
+    _r1, _o1, ok_err, _c1 = _up_harness(tmp_path, ks_present=True)
+    _r2, _o2, no_err, _c2 = _up_harness(tmp_path, ks_present=False)
+    assert "ARMED(primary)" in ok_err and "NOT-ARMED" in no_err, (ok_err, no_err)
+
+
+# --- G9a: check-env is read-only, asserted as a PROPERTY -----------------------
+
+def test_check_env_performs_no_filesystem_writes(tmp_path):
+    """🔴 BEHAVIOURAL half of the read-only guard.
+
+    The previous version forbade a list of TOKENS in the branch text. Mutants X2
+    (`echo x >/tmp/canary`, no space after `>`) and X3 (`touch /tmp/canary`) both
+    walked past it. Snapshot every byte of a sandbox — including the env file
+    itself, HOME and TMPDIR — and require it identical afterwards.
+    """
+    home = tmp_path / "home"; home.mkdir()
+    tmp = tmp_path / "tmp"; tmp.mkdir()
+    env = write_env(tmp_path, f"NEBULA_LIGHTHOUSE={GOOD_V4}\n")
+
+    def snapshot():
+        out = {}
+        for p in sorted(tmp_path.rglob("*")):
+            if p.is_file():
+                st = p.stat()
+                out[str(p.relative_to(tmp_path))] = (st.st_size, st.st_mode,
+                                                     p.read_bytes())
+            elif p.is_dir():
+                out[str(p.relative_to(tmp_path)) + "/"] = None
+        return out
+
+    before = snapshot()
+    rc, _out, _err = check_env(env, extra={"HOME": str(home), "TMPDIR": str(tmp)})
+    assert rc == 0
+    assert snapshot() == before, "check-env WROTE to the filesystem"
+
+
+def test_check_env_invokes_no_external_command_beyond_a_read_only_set(tmp_path):
+    """🔴 STRUCTURAL half — a WHITELIST, not a blacklist.
+
+    A blacklist is what X2/X3 defeated: any command not thought of passes. Run
+    `check-env` with a PATH whose ONLY entries are recording stubs for a small
+    read-only set, plus a catch-all that FAILS LOUDLY for anything else, and
+    require the run to still succeed. A mutant adding `touch`, `cp`, `tee`,
+    `dd`, `install`, `nft` … cannot find it and the recorded log names it.
+
+    Scoped honestly: this observes commands resolved through PATH. A bash
+    BUILTIN redirection is caught by the behavioural test above instead — the
+    two together cover both shapes.
+    """
+    bindir = tmp_path / "robin"; bindir.mkdir()
+    log = tmp_path / "cmds.log"
+    # the read-only set check-env is allowed to reach
+    for allowed in ("id", "logger", "stat"):
+        real = __import__("shutil").which(allowed) or "/bin/true"
+        mockbin.write_exec(bindir / allowed,
+                           f'printf "%s\\n" "{allowed}" >> "{log}"\nexec {real} "$@"\n')
+    env = write_env(tmp_path, f"NEBULA_LIGHTHOUSE={GOOD_V4}\n")
+    # PATH is ONLY the stub dir: anything else is "command not found".
+    rc, out, err = check_env(env, extra={"PATH": str(bindir)})
+    assert rc == 0, (rc, out, err)
+    assert "command not found" not in err, (
+        "check-env reached a command outside the read-only set: " + err)
+    assert f"lighthouse={GOOD_V4}" in out, out
+
+
+def _check_env_code() -> str:
+    src = UPDOWN.read_text(encoding="utf-8")
+    start = src.index("    check-env)")
+    return "\n".join(l for l in src[start:src.index("        ;;", start)].splitlines()
+                     if not l.strip().startswith("#"))
+
+
+def _write_redirections(code: str) -> list[str]:
+    """Every output redirection in `code` that targets a PATH rather than an fd.
+
+    EXHAUSTIVE over the syntax class, which is what makes this different from
+    the token blacklist it replaces: bash has exactly one way to spell "send
+    output somewhere" (`>` / `>>`), and the only benign form here is a
+    duplication onto an existing descriptor (`>&N`). So this is a whitelist over
+    a closed set, not a guess-list of commands somebody might use.
+    """
+    out = []
+    for line in code.splitlines():
+        i = 0
+        while (i := line.find(">", i)) != -1:
+            rest = line[i + 1:].lstrip(">")
+            if not rest.startswith("&"):
+                out.append(line.strip())
+                break
+            i += 1
+    return out
+
+
+def test_check_env_contains_no_output_redirection_to_a_path():
+    """🔴 THE X2 GAP. The audit's mutant X2 — `echo x >/tmp/canary`, no space
+    after the `>` — survived BOTH behavioural guards above: the sandbox snapshot
+    only sees paths under `tmp_path`, and a bash builtin redirection reaches no
+    command through PATH. A write to an absolute path outside the sandbox is
+    invisible to both.
+
+    Three complementary properties now cover `check-env`:
+      1. it writes nothing into a sandbox           (behavioural)
+      2. it reaches no command outside a read-only set (behavioural, PATH)
+      3. it contains no output redirection to a path   (syntactic, THIS)
+    """
+    offenders = _write_redirections(_check_env_code())
+    assert not offenders, (
+        "check-env writes to a path — it must stay read-only:\n  "
+        + "\n  ".join(offenders))
+
+
+@pytest.mark.parametrize("planted", [
+    'echo x >/tmp/canary',          # X2 exactly: no space after >
+    'echo x > /tmp/canary',         # with a space
+    'echo x >>/tmp/canary',         # append
+    'printf y > "$SITE_ENV"',       # clobbering the input
+])
+def test_positive_control_the_redirection_check_catches_each_write_shape(planted):
+    """🔴 A zero-shaped assertion needs a non-zero control. Feed the checker the
+    exact mutant shapes and require a NON-EMPTY result — otherwise "no
+    offenders" is indistinguishable from a checker that can never find one."""
+    found = _write_redirections(_check_env_code() + "\n        " + planted)
+    assert found, f"the redirection check cannot see {planted!r}"
+
+
+def test_positive_control_the_redirection_check_allows_fd_duplication():
+    """The complement: it must not fire on `>&2`, or the guard is unusable and
+    gets deleted the first time someone legitimately writes to stderr."""
+    assert not _write_redirections('        echo "x" >&2')
+
+
+def test_the_read_only_harness_would_catch_a_side_effect(tmp_path):
+    """🔴 POSITIVE CONTROL for both tests above. Neither is worth anything unless
+    a planted side effect actually trips them — a snapshot that compares two
+    empty dicts, or a PATH that was never narrowed, would pass identically.
+
+    Runs a deliberately-mutated COPY of the script, so the real one is untouched.
+    """
+    mutant = tmp_path / "airvpn-updown-mutant"
+    src = UPDOWN.read_text(encoding="utf-8")
+    canary = tmp_path / "canary"
+    # X3's shape: a real external command with a real side effect.
+    src = src.replace('        echo "lighthouse=${NEBULA_LIGHTHOUSE:-UNSET}',
+                      f'        touch "{canary}"\n        echo "lighthouse=${{NEBULA_LIGHTHOUSE:-UNSET}}')
+    mutant.write_text(src, encoding="utf-8")
+    env = write_env(tmp_path, f"NEBULA_LIGHTHOUSE={GOOD_V4}\n")
+    e = dict(os.environ, AIRVPN_UPDOWN_ENV=str(env))
+    e.pop("NEBULA_LIGHTHOUSE", None)
+    subprocess.run([_bash(), str(mutant), "check-env"],
+                   capture_output=True, text=True, env=e, timeout=30)
+    assert canary.exists(), (
+        "the planted side effect did not happen — this control proves nothing "
+        "about the two tests above")
 
 
 # --- the apply script (A-3) ----------------------------------------------------
@@ -373,7 +851,7 @@ def test_the_apply_script_provisions_the_env_BEFORE_installing_the_helper():
 def test_the_skill_documents_the_prerequisite_BEFORE_the_install_command():
     """The same ordering defect in the doc an operator actually follows: the
     requirement used to be a trailing sentence AFTER the install command."""
-    doc = (REPO / "claude" / "skills" / "bar" / "airvpn.md").read_text(encoding="utf-8")
+    doc = SKILL_DOC.read_text(encoding="utf-8")
     prereq = doc.index("/etc/airvpn-updown.env")
     install = doc.index("sudo install -m 0755 -o root -g root")
     assert prereq < install, (
@@ -381,26 +859,106 @@ def test_the_skill_documents_the_prerequisite_BEFORE_the_install_command():
         "install and re-arm")
 
 
+# --- G7: the DURABLE artifact, not just the PR body ---------------------------
+#
+# 🔴 A PR body is read once, by one person, and then it is gone. The file a
+# future session loads is `claude/skills/bar/airvpn.md`. The previous revision
+# renumbered the Procedures correctly and left the *re-test protocol* untouched —
+# so after merge the durable doc described a protocol that could not detect this
+# PR's own failure mode. These pin the protocol itself.
+
+SKILL_DOC = REPO / "claude" / "skills" / "bar" / "airvpn.md"
+
+
+def _protocol_section() -> str:
+    doc = SKILL_DOC.read_text(encoding="utf-8")
+    start = doc.index("## 🔴 Mandatory re-test protocol")
+    return doc[start:doc.index("\n## ", start + 1)]
+
+
+def test_the_retest_protocol_states_the_tunnel_must_ALREADY_BE_UP():
+    """🔴 F2. MEASURED on the workbench: the `airvpn` interface does not
+    currently exist, so the host is in exactly the state where following this
+    protocol literally blackholes its own egress. Arming with the tunnel down
+    yields a chain with no `meta mark` accept and no endpoint accept, ending in
+    `drop`.
+
+    The precondition and the bail must both be IN the protocol, not inferable
+    from it.
+    """
+    sec = _protocol_section()
+    assert "PRECONDITION" in sec and "TUNNEL MUST ALREADY BE UP" in sec.upper(), sec
+    assert "ip link show airvpn" in sec, "no way to CHECK the precondition"
+    assert "nft delete table inet airvpn_ks" in sec, "no bail in the protocol"
+
+
+def test_the_retest_protocol_installs_the_edited_helper():
+    """🔴 G8. MEASURED: the deployed `/etc/nixos/i3blocks-scripts/airvpn-updown`
+    is byte-identical to `origin/main` — the OLD script, with no `check-env`
+    action. A protocol that says "run check-env" without first saying "install
+    the thing you edited" prints usage and exits 1."""
+    sec = _protocol_section()
+    install = sec.index("sudo install -m 0755")
+    check = sec.index("check-env")
+    assert install < check, (
+        "the protocol runs check-env before installing the edited helper — it "
+        "would be exercising the OLD script")
+
+
+def test_the_retest_protocol_observes_the_slash32_route_directly():
+    """🔴 G8. `ip route get <lighthouse>` is the ONLY step that observes A-1.
+    The off-LAN ssh check cannot substitute: with a healthy tunnel, lighthouse
+    traffic routed INTO the tunnel still arrives, so ssh succeeds whether or not
+    the /32 exists."""
+    sec = _protocol_section()
+    assert "ip route get" in sec, "the protocol never observes the /32 bypass"
+    assert "dev airvpn" in sec, "no stated FAILING reading for the route check"
+    route = sec.index("ip route get")
+    ssh = sec.index("ssh zach@")
+    assert route < ssh, "the route check must precede the checks it is not implied by"
+
+
+def test_the_retest_protocol_reads_the_new_arm_line_fields():
+    """The protocol must name the fields this PR added, or it cannot detect the
+    failure modes this PR introduces."""
+    sec = _protocol_section()
+    for token in ("lighthouse=UNSET", "ARMED(primary)", "ARMED(fallback)",
+                  "NOT-ARMED", "state=ok"):
+        assert token in sec, f"the protocol never mentions {token}"
+
+
+def test_the_debug_section_shows_the_CURRENT_arm_line_format():
+    """A stale example is a claim too. The Debug/bail block still showed the
+    pre-`lighthouse=` format, so an operator comparing against it would see a
+    field they had no reason to expect and no reason to check."""
+    doc = SKILL_DOC.read_text(encoding="utf-8")
+    dbg = doc[doc.index("## Debug / bail"):]
+    assert "lighthouse=" in dbg, "the arm-line example predates this PR"
+    assert "killswitch armed (fwmark" not in dbg, (
+        "the Debug section still shows the OLD unconditional `armed` wording")
+    for state in ("ARMED(primary)", "ARMED(fallback)", "NOT-ARMED"):
+        assert state in dbg, f"Debug/bail does not explain {state}"
+
+
 # --- the seam ------------------------------------------------------------------
 
-def test_check_env_is_read_only():
-    """`check-env` exists so this file can test the resolution without arming.
-    If it ever grew a side effect, every test above would be running against a
-    live killswitch path. Pin the SHAPE of the branch, structurally."""
+def test_check_env_still_does_the_one_thing_it_exists_for():
+    """The read-only PROPERTY is asserted behaviourally and by PATH-whitelist
+    above (`test_check_env_performs_no_filesystem_writes`,
+    `…_invokes_no_external_command_beyond_a_read_only_set`), both with a positive
+    control. The token-blacklist that used to live here was a SPELLED guard and
+    the audit's mutants X2/X3 walked past it — it is deleted rather than kept as
+    reassurance.
+
+    What remains here is the complement: a read-only branch that reads nothing
+    would also pass every test above.
+    """
     src = UPDOWN.read_text(encoding="utf-8")
     start = src.index("    check-env)")
-    end = src.index("        ;;", start)
-    # CODE only — a comment explaining "touches no nft table" would otherwise
-    # satisfy a naive substring search for `nft `, which is the spelled-vs-
-    # structural trap (RULES.md).
-    code = "\n".join(l for l in src[start:end].splitlines()
+    code = "\n".join(l for l in src[start:src.index("        ;;", start)].splitlines()
                      if not l.strip().startswith("#"))
-    for forbidden in ("nft ", "ip route", "ip rule", "rm -f", "install ",
-                      "> ", ">>"):
-        assert forbidden not in code, (
-            f"check-env is no longer read-only ({forbidden!r}):\n{code}")
-    # …and it must still actually do the one thing it exists for.
     assert "NEBULA_LIGHTHOUSE" in code and "echo " in code, code
+    assert "state=" in code, "check-env no longer reports WHY it is UNSET (G3)"
 
 
 def test_the_lighthouse_is_never_a_literal_in_this_repo():

--- a/scripts/tests/test_no_public_ips.py
+++ b/scripts/tests/test_no_public_ips.py
@@ -133,15 +133,6 @@ PENDING_SCRUB = {
         "change owns this file; replacing both with the 1.2.3.4 dummy already "
         "used elsewhere in it closes this and drops the entry.",
     ),
-    "scripts/airvpn-updown": (
-        1,
-        "the same Hetzner lighthouse IP, as the NEBULA_LIGHTHOUSE constant. This "
-        "file is a LIVE fail-closed killswitch on the workbench's uplink, so "
-        "moving the value to a root-owned env file is a runtime change that must "
-        "pass the `bar` skill's mandatory re-test protocol on a physically "
-        "reachable host. It is therefore split into its own PR rather than "
-        "carried here. Merging that PR deletes this entry in the same commit.",
-    ),
 }
 
 


### PR DESCRIPTION
# 🔴 DO NOT MERGE — this needs YOU, on a host you can physically reach

`scripts/airvpn-updown` is a **LIVE fail-closed killswitch** on the workbench's uplink. Every
claim below is from unit tests, `bash -n`, `nft -c` and reading the code. **The `bar` skill's
mandatory re-test protocol has NOT been run and I cannot run it.**

The protocol lives in `claude/skills/bar/airvpn.md` (11 steps, pinned by nine tests). Read it
there, not here.

🔴 **Round 3 fixed the step that the entire banner exists for.** Step 11 said
`ssh zach@10.42.0.30` — the **workbench's own** nebula address — while step 1 puts you on the
LAN. Followed literally that is a **self-ssh**; from another LAN host it is a same-LAN hop.
Neither touches the nebula **direct-punch** path that the section's opening line says a LAN-only
test cannot reach, and that locked the host out in #118. The step carrying the whole "off-LAN"
claim never said which host to run it **from**, so it passed unconditionally. It now names the
source host, carries a still-on-the-LAN guard, defines **PASS / FAIL / INVALID**, and says the
protocol **cannot be completed** without an off-LAN host rather than letting the self-ssh stand
in for one.

---

## Now based on `main`

#350 has merged, so this is **rebased onto current `main` and retargeted to `main`**. The
stacked-parent hazard is gone, and branch CI now shows the truth rather than the pre-existing
breakage #356/#357 fixed. It still deletes the `scripts/airvpn-updown` `PENDING_SCRUB` entry
#350 added — required, because that ratchet fails in both directions.

---

## Round 3 — what the delta audit found

The audit confirmed a lot: F1's scrub verified across 17 encodings over all 702 tracked files;
F3 over 19 byte-level fixtures including every CR shape; **F4's atomicity confirmed, and the
missing-table footgun confirmed real and confirmed guarded** (a bare `delete table` on a missing
table aborts the file with rc=1; `table X {}` + `delete` + definition gives rc=0); G1, G6, G4,
G3 correct and distinct; X2/X3/Y1 all killed at their own assertions. These are the findings
that were **not** sound.

### 🔴 P1 — step 11 (above)

### 🟡 1 — `ARMED(none)`: a FOURTH state my own F4 made reachable

Before the atomic load, "both loads failed" implied the table had already been flushed, so
`NOT-ARMED` was the only reachable outcome. **After F4 the previous table survives**, so
`ks_present` is true with `KS_RULESET=none` — and the arm line read `ARMED(none)` while the
line immediately above it said `FALLBACK … uplink is NOT filtered`, which is now false in that
corner. Worse than meaningless: the surviving ruleset was built for a **different endpoint and
fwmark**, so it can read as armed while the tunnel is dead. No test covered it.

Now `STALE(previous)`, loud, with both contradictory lines fixed. The four states are pinned
**pairwise distinct** across every corner of (load outcome × kernel answer), and the skill's
"three states" list is now a four-row table with a bail column.

### 🟡 3 — M12: the fallback path's atomicity was untested

`test_the_load_is_ONE_atomic_transaction` drove the harness with **no failure injected**, so it
only ever inspected the **primary** path. Open-coding the old `add`+`flush`+`load` inside
`arm_failclosed` **survived all 83 tests** — the "second caller open-codes the old sequence"
shape, de-atomising precisely the path that runs when things are already going wrong. Both
callers are pinned now, **every** rendered load must be self-contained, and a reachability
control proves the fallback actually produced a second load.

### 🟡 4 — `$EP` and `$GW` reached the ruleset with no validation

`valid_ip` — hardened for exactly this — was applied to the lighthouse only. Measured with
`nft -c`: a gateway-less default route (`default dev eth0`) makes the awk yield the literal
`eth0`; a peer with no endpoint makes `wg show` print `(none)`; an IPv6 endpoint survives the
`sed`. Each fails the **primary** load → blanket fallback → no `meta mark` accept → **the
tunnel dies**. nft also tries to **DNS-resolve** these tokens, as root, inside wg-quick's
PostUp. Both producers validate now, with a positive control that valid values still land
(a validator that rejects everything is not a validator).

### 🟡 2 and 🟡 5 — two comments that were false

*"A failure here changes NOTHING"* is true of the **helper** and false of the **composed path**:
four lines later `arm_failclosed` replaces whatever survived with the blanket fallback. And the
`\r` comment still carried the theory I **retracted last round** — measured false, the rtrim
strips it — corrected in the test docstring but not in the script.

### 🟢 M5 — the `10#` radix pin was unreachable, and the comment credited it anyway

The leading-zero check fired first, so deleting `10#` made **zero** behavioural difference.
Rather than ship an untestable guard with corrected prose, the two checks are **reordered**:
radix-pinned range check first, leading-zero second. Identical verdict for every input, and
`10#` is now load-bearing — a mutant deleting it dies on `value too great for base`.

### 🟢 P3 / P4 / P5

The precondition tested **existence, not up-ness** (`ip link show airvpn` succeeds for an
interface left by a half-failed `wg-quick up`, and prints TUNNEL-UP) — it now requires the link
**UP** *and* a non-zero wg handshake. The install step never said to **confirm the branch**,
which is exactly how the deployed helper was found stale. And `ARMED(fallback)` was called
merely "degraded" with no instruction to bail — step 6 now says **BAIL NOW** for both
`ARMED(fallback)` and `STALE(previous)`, so you do not walk into step 10's `curl` and get a
confusing failure instead of a diagnosed one.

### The auditor's real X11 and X15, which my reconstruction had missed

I had guessed these from their IDs and said so. Both were the **G11-shaped** defect and both are
now folded in:

* **X11** — `printf 'NEBULA_LIGHTHOUSE=%s\n'` → `%s` survived because the fixture asserted
  `.strip()`-ed content, erasing the very byte F3 is about. Now **exact bytes**.
* **X15** — moving the whole prerequisite block to the end of the skill file survived because
  `doc.index("/etc/airvpn-updown.env")` is satisfied by Procedure step 1's own command. Now
  anchored on the 🔴 block's own text, plus an assertion that it still precedes `## Procedures`.

### The 30 leaked processes

Thank you for killing those. That was my FIFO fixture: `subprocess.run` kills its direct child
on timeout, but a shell blocked in `open()` on a writer-less FIFO can outlive it, and the X11g
mutant (which removes the `-f` gate) makes that reachable. The fixture now opens the write end
non-blocking and unlinks — **on the green path too**, because a cleanup that only fires on
failure is a cleanup that is never exercised.

---

## 🔴 A-1, restated (unchanged, and still REASONED not measured)

`meta skuid` is a firewall ACCEPT; the dropped `ip route replace <lighthouse> via <gw>` is a
ROUTING bypass, and the first does not restore the second. With `suppress_prefixlength 0`, only
a more-specific main-table route beats the tunnel default, so with the `/32` gone the lighthouse
routes **into** the tunnel. Your audit strengthened this: `meta skuid` **precedes** the
lighthouse `accept`, so that accept was **dominated — a no-op — in both rulesets**. Only the
`/32` ever mattered.

**Scope:** WORKBENCH-ONLY. **REASONED, NOT MEASURED** — I have not observed a routing table with
the `/32` absent. Step 7 (`ip route get <lighthouse>`) is how *you* measure it.

---

## What is measured

**94 tests** (was 85). **Red/green: 12 failed / 82 passed** at `4fa6f4f` (10 distinct test
functions), **94 passed** at HEAD. Both tiers agree.

🔴 **Four of this round's guards are INVARIANT guards, green at base, and I am labelling them
rather than counting them as regression coverage** — their value is mutation-proof, not
base-red:

| guard | why it is green at base | proven by |
|---|---|---|
| `…load_is_ONE_atomic_transaction` (both callers) | the fix was in the TEST; both callers were already atomic | **M12** |
| apply fixture asserting exact bytes | the apply script already wrote the newline | **X11** |
| prereq-ordering anchored on the 🔴 block | the block was already in the right place | **X15** |
| `…LEADING_ZERO_octet_is_REJECTED` | the verdict is unchanged; only the check ORDER moved | **M5** |

**Mutation battery — 32 mutants, 32 killed**, each at its own assertion. Two survived my first
attempt and are worth naming, because both were my own harness being weaker than it looked:

* **G4b** (delete the endpoint validation) survived because `EP` is only computed inside the
  `if [[ -n "$GW" && -n "$PHYS" ]]` branch — with the harness's default no-op `ip`, my endpoint
  test never reached `endpoint_ip` at all. It needed a real default route to become reachable,
  and now carries a control asserting the gateway landed.
* **P1m** (change the off-LAN step's source host back) survived an assertion written as
  `A or B` — the mutant only broke `A`. Now `and`.

| group | mutants | result |
|---|---|---|
| original battery M1–M10 | 10 | 10 killed |
| audit-named survivors X2/X3/X4/X11g/X15g/Y5/Y6/Z1/Z2/Z3/Z4/Z6 | 12 | 12 killed |
| **the auditor's real X11, X15** | 2 | **2 killed** |
| **new: M12, M5, S1, G4a, G4b, P1m, P3m, P4m, P5m** | 9 | **9 killed** |

**Authoritative gate**, re-baselined against current `main` (60e6d9d) — no longer attributing
anything to a pre-existing red gate, since **main is green**:

| | `origin/main` (60e6d9d) | this branch |
|---|---|---|
| collected | 6311 | **6405** (+94) |
| passed | 6310 | **6404** (+94) |
| skipped | 1 | 1 |
| failed | **0** | **0** |
| verdict | `RESULT: PASS` | **`RESULT: PASS`** |

Node tier: **1024/1024, PASS**. `bash -n` clean on both scripts. The local (non-sandbox) tier
shows 26 failures on **both** `main` and this branch — identical set, environment-dependent,
unchanged by this PR.

**Correction accepted:** my `test_browser_agent` "ceiling crossing" diagnosis was **wrong**. Your
measurement (171.04s on main, 171.99s on the merged tree, 481 passed both) does not reproduce
it; the 291.68s run accompanied two real failures from the stale base, so the wall time was
inflated by an assertion timeout, not a budget crossing. Wall-time decomposition was the right
instrument and I drew the wrong conclusion from it.

## What is NOT verified

* The re-test protocol. Not run — the whole of the banner at the top.
* `nft -c`'s **semantic** pass (unprivileged: syntax only).
* The real `up` path against a real kernel. The harness stubs every external command;
  **nothing here arms, disarms, routes or loads a ruleset.**
* The A-1 routing claim, as stated above.
* 🔴 **G10 still stands**: the suite covers env resolution, ruleset RENDERING and arm-state
  derivation — **not the packet-level behaviour of the chain**. Nine behaviour mutants survived
  your earlier audit (inverting the uplink guard, never calling `arm_failclosed`, dropping the
  `/32` route) and this round does not close them. That is the gap the operator protocol exists
  to cover, which is why P1 mattered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
