### PR TITLE
fix(gate): unbreak the pytests gate — red on main since 2026-08-04, 4 causes

### DIFF
--- a/scripts/collector/keylog/tests/test_espanso_detect.py
+++ b/scripts/collector/keylog/tests/test_espanso_detect.py
@@ -536,14 +536,23 @@ def test_live_scraper_observes_the_real_config():
     Without this, a regex that silently matched NOTHING would make every guard
     below vacuously true (empty trigger set → nothing to contradict). Pin a
     non-trivial count and two long-standing snippets with known metadata.
+
+    The pinned metadata is READ OFF nix/home.nix, never off the scraper's own
+    output — deriving it from the implementation is exactly what would make this
+    control vacuous. (`:date` used to be the metadata pin; #351 pruned that
+    snippet, so the pin moved to `:sshwn`, added in #134 and untouched since,
+    whose `search_terms` list is longer and therefore a stricter test of the
+    list-splitting regex.)
     """
     base = _live_base()
     trigs = [m["trigger"] for m in base["matches"]]
     assert len(trigs) >= 20, f"scraper found only {len(trigs)} snippets: {trigs}"
     assert len(set(trigs)) == len(trigs), "duplicate trigger in nix/home.nix"
-    assert ":date" in trigs and "dashbaord" in trigs
+    assert ":sshwn" in trigs and "dashbaord" in trigs
     by_trig = {m["trigger"]: m for m in base["matches"]}
-    assert by_trig[":date"]["search_terms"] == ["today", "calendar"]
+    assert by_trig[":sshwn"]["search_terms"] == [
+        "ssh", "workbench", "wb", "nebula", "mesh", "remote"]
+    assert by_trig[":sshwn"]["label"] == "SSH workbench (nebula)"
     assert by_trig[":kickoff"]["label"] == "Kickoff message for next session"
 
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -344,6 +344,28 @@ EXPECTED_SKIPS=(
   # REPO_COS_LIVE_DRIFT_CHECK=1.
   "scripts/repo-cos/tests|live-store drift check is opt-in"
 )
+# CONDITIONAL, on the SAME predicate the tests use (see the header note above).
+# `scripts/tests/test_skill_audit.py` carries two regression pins against the
+# LIVE datapacket-talos skill corpus — a separate, PRIVATE clone that cannot
+# exist in the nix sandbox and may be absent on a dev host. Both call
+# `pytest.skip("datapacket-talos clone not present")` off exactly this
+# `is_dir()` check, so the pin mirrors it: present → the tests RUN and nothing is
+# pinned; absent → two accounted skips. #332 added them without this entry, and
+# the gate was RED on main from 2026-08-04 to 2026-08-06 on the unpinned-skip
+# guard alone, independently of any failing test.
+#
+# ⚠ This is a WEAK shape and the runner says so a few lines down: a check keyed
+# to an out-of-repo path is structurally unobservable in the tier that gates
+# merges. It is pinned rather than deleted because on a host with the clone it
+# is the highest-value assertion in that file. If it ever needs re-pointing,
+# re-point it at something tracked IN THIS REPO instead of widening this entry.
+_SKILL_CORPUS=/home/zach/workspace/civit/datapacket-talos/.claude/skills
+if [ ! -d "$_SKILL_CORPUS" ]; then
+  EXPECTED_SKIPS+=(
+    "scripts/tests|datapacket-talos clone not present"
+    "scripts/tests|datapacket-talos clone not present"
+  )
+fi
 # ⚠ REMOVED, deliberately — do not re-add. test_scrub.py's drift guard used to
 # compare scrub.py's SECRET_PATTERNS against the DEPLOYED hook
 # (`Path.home()/".claude"/"hooks"/"bash-guard.py"`) and skip when that file was

--- a/scripts/testlib/shebang_scan.py
+++ b/scripts/testlib/shebang_scan.py
@@ -27,16 +27,43 @@ from pathlib import Path
 _HB = chr(35) + chr(33)
 NEEDLES = (chr(34) + _HB, chr(39) + _HB)
 
+# Assembled from character codes for the SAME self-match reason as the shebang
+# needles above — spelling it as a quoted literal makes this file its own first
+# offender (observed the moment shape 3 was added).
+_SL = chr(47)
+_ENV = _SL + "usr" + _SL + "bin" + _SL + "env"
+# The literal path as a standalone quoted token — i.e. an argv element, not
+# prose. Built the same character-code way, for the same self-match reason.
+_ARGV_NEEDLES = (chr(34) + _ENV + chr(34), chr(39) + _ENV + chr(39))
+
 
 def line_is_offender(lineno: int, line: str) -> bool:
-    """True when `line` embeds a quoted shebang.
+    """True when `line` carries the hazard in any of its THREE shapes.
 
     Line 1 is always exempt: that is the module's OWN shebang, and pytest
     imports test modules rather than exec'ing them, so it never runs.
+
+    🔴 Shapes 2 and 3 were added 2026-08-06. Shape 1 alone (a shebang directly
+    behind a quote) is what a ONE-LINE stub body looks like, and it was the only
+    shape this scan could see — so the guard watched `93caa3a` add
+    `scripts/tests/test_{rig_control,monitor_blackout}.py` and stayed green while
+    they put 27 tests red in the sandbox for two days. Both wrote their stub
+    bodies as MULTI-LINE `textwrap.dedent` blocks, where the shebang starts its
+    own line with no quote in front of it, and both additionally exec'd
+    `[<env>, "bash", …]` as an argv, which is not a shebang at all and raises
+    FileNotFoundError before any stub is even reached.
+
+      1. quoted shebang   — `write_text("<hb>/usr/bin/env bash\\n…")`
+      2. bare shebang line — the first line inside a multi-line string literal
+      3. quoted argv token — `subprocess.run(["<env>", "bash", …])`
     """
     if lineno == 1:
         return False
-    return any(n in line for n in NEEDLES)
+    if any(n in line for n in NEEDLES):
+        return True
+    if line.lstrip().startswith(_HB) and _ENV in line:
+        return True
+    return any(n in line for n in _ARGV_NEEDLES)
 
 
 def scan_file(path: Path) -> list[tuple[int, str]]:
@@ -64,3 +91,14 @@ def offending_source_line(interp: str = "/usr/bin/env bash") -> str:
     Assembled the same way as the needles, for the same self-match reason.
     """
     return "p.write_text(" + chr(34) + _HB + interp + chr(34) + ")"
+
+
+def offending_bare_shebang_line(interp: str = "/usr/bin/env bash") -> str:
+    """Shape 2: a shebang opening its own line inside a multi-line literal."""
+    return "        " + _HB + interp
+
+
+def offending_argv_line() -> str:
+    """Shape 3: the interpreter path as a standalone quoted argv element."""
+    return ("subprocess.run([" + chr(34) + _ENV + chr(34) + ", "
+            + chr(34) + "bash" + chr(34) + ", str(S)])")

--- a/scripts/tests/test_monitor_blackout.py
+++ b/scripts/tests/test_monitor_blackout.py
@@ -133,6 +133,13 @@ def test_restore_uses_default_brightness_when_no_state(tmp_path):
 # CLI: status subcommand
 # --------------------------------------------------------------------------- #
 def test_status_no_timer(tmp_path):
+    # 🔴 ddcutil too, not just systemctl. monitor-blackout.sh resolves ddcutil at
+    # line 20 — BEFORE it dispatches a subcommand — and exits 1 with "ddcutil not
+    # found on PATH" when it is absent, so `status` needs the stub as much as the
+    # brightness paths do. This test claimed to be OFFLINE while silently
+    # depending on the dev host having a real ddcutil; the sandbox does not, and
+    # the FileNotFoundError this suite used to die on hid that for two days.
+    _make_ddcutil_stub(tmp_path)
     systemctl = _make_systemctl_stub(tmp_path)
     path = str(tmp_path) + ":" + os.environ.get("PATH", "")
 

--- a/scripts/tests/test_monitor_blackout.py
+++ b/scripts/tests/test_monitor_blackout.py
@@ -6,6 +6,7 @@ mocked ddcutil and systemctl commands.
     run:  pytest scripts/tests/test_monitor_blackout.py
 """
 import os
+import shutil
 import subprocess
 import sys
 import textwrap
@@ -16,6 +17,23 @@ import pytest
 SCRIPTS = Path(__file__).resolve().parents[1]
 MB = SCRIPTS / "monitor-blackout.sh"
 
+sys.path.insert(0, str(SCRIPTS))
+
+from testlib.mockbin import write_exec  # noqa: E402
+
+# 🔴 Resolve the interpreter ONCE, from the ambient environment, to an absolute
+# path. Two traps this avoids:
+#   * `/usr/bin/env` does not exist in the nix build sandbox — the authoritative
+#     gate — so an argv whose first element is that literal path raises
+#     FileNotFoundError there while passing on the dev host (see
+#     scripts/testlib/mockbin.py for the same trap in stub shebangs).
+#   * a bare "bash" argv is looked up in the PATH of the env= passed to
+#     subprocess, and every test below overrides PATH with a stub directory —
+#     which would make the interpreter itself unfindable.
+_BASH = shutil.which("bash")
+if _BASH is None:  # pragma: no cover — both tiers ship bash
+    raise RuntimeError("bash not found on PATH; this suite cannot run hermetically")
+
 
 def _run(*args, env=None):
     """Run monitor-blackout.sh as a subprocess."""
@@ -23,7 +41,7 @@ def _run(*args, env=None):
     if env:
         full_env.update(env)
     return subprocess.run(
-        ["/usr/bin/env", "bash", str(MB), *args],
+        [_BASH, str(MB), *args],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
         timeout=30, env=full_env,
     )
@@ -33,10 +51,12 @@ def _make_ddcutil_stub(tmp_path, brightness="75"):
     """Create a ddcutil stub that responds to getvcp 10.
     Output format: 'VCP <hex> <current> <max>' — awk $4 = max, $3 = current.
     The script's get_brightness uses awk $4, so stub outputs brightness in $4.
+
+    testlib.mockbin owns the shebang (/bin/sh) — a `#!/usr/bin/env bash` stub
+    cannot exec in the nix build sandbox, and patchShebangs cannot reach a file
+    a test writes at runtime.
     """
-    stub = tmp_path / "ddcutil"
-    stub.write_text(textwrap.dedent(f"""\
-        #!/usr/bin/env bash
+    return write_exec(tmp_path / "ddcutil", textwrap.dedent(f"""\
         echo "$@" >> "{tmp_path / 'ddcutil.log'}"
         case "$*" in
             *detect*) echo "i2c-5" ;;
@@ -44,23 +64,17 @@ def _make_ddcutil_stub(tmp_path, brightness="75"):
             *) echo "ok" ;;
         esac
     """))
-    stub.chmod(0o755)
-    return stub
 
 
 def _make_systemctl_stub(tmp_path):
     """Create a systemctl stub that simulates timer management."""
-    stub = tmp_path / "systemctl"
-    stub.write_text(textwrap.dedent(f"""\
-        #!/usr/bin/env bash
+    return write_exec(tmp_path / "systemctl", textwrap.dedent(f"""\
         echo "$@" >> "{tmp_path / 'systemctl.log'}"
         case "$*" in
             *is-active*) exit 3 ;;  # no timer active
             *) exit 0 ;;
         esac
     """))
-    stub.chmod(0o755)
-    return stub
 
 
 # --------------------------------------------------------------------------- #
@@ -216,16 +230,13 @@ def test_blackout_custom_duration(tmp_path):
 # --------------------------------------------------------------------------- #
 def test_blackout_fails_when_no_monitor(tmp_path):
     # Stub ddcutil that responds to detect but with no valid buses
-    stub = tmp_path / "ddcutil"
-    stub.write_text(textwrap.dedent(f"""\
-        #!/usr/bin/env bash
+    write_exec(tmp_path / "ddcutil", textwrap.dedent(f"""\
         echo "$@" >> "{tmp_path / 'ddcutil.log'}"
         case "$*" in
             *detect*) echo "no devices found" ;;
             *) echo "ok" ;;
         esac
     """))
-    stub.chmod(0o755)
     path = str(tmp_path) + ":" + os.environ.get("PATH", "")
 
     r = _run(env={"PATH": path, "XDG_RUNTIME_DIR": str(tmp_path)})

--- a/scripts/tests/test_rig_control.py
+++ b/scripts/tests/test_rig_control.py
@@ -6,6 +6,7 @@ the script via subprocess with stubbed external commands.
     run:  pytest scripts/tests/test_rig_control.py
 """
 import os
+import shutil
 import subprocess
 import sys
 import textwrap
@@ -16,6 +17,23 @@ import pytest
 SCRIPTS = Path(__file__).resolve().parents[1]
 RIG = SCRIPTS / "rig-control.sh"
 
+sys.path.insert(0, str(SCRIPTS))
+
+from testlib.mockbin import write_exec  # noqa: E402
+
+# 🔴 Resolve the interpreter ONCE, from the ambient environment, to an absolute
+# path. Two traps this avoids:
+#   * `/usr/bin/env` does not exist in the nix build sandbox — the authoritative
+#     gate — so an argv whose first element is that literal path raises
+#     FileNotFoundError there while passing on the dev host (see
+#     scripts/testlib/mockbin.py for the same trap in stub shebangs).
+#   * a bare "bash" argv is looked up in the PATH of the env= passed to
+#     subprocess, and some tests below deliberately set PATH to a stub-only
+#     directory — which would make the interpreter itself unfindable.
+_BASH = shutil.which("bash")
+if _BASH is None:  # pragma: no cover — both tiers ship bash
+    raise RuntimeError("bash not found on PATH; this suite cannot run hermetically")
+
 
 def _run(*args, env=None):
     """Run rig-control.sh as a subprocess with optional env overrides."""
@@ -24,22 +42,23 @@ def _run(*args, env=None):
     if env:
         full_env.update(env)
     return subprocess.run(
-        ["/usr/bin/env", "bash", str(RIG), *args],
+        [_BASH, str(RIG), *args],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
         timeout=15, env=full_env,
     )
 
 
 def _make_stub(name, tmp_path, exit_code=0, stdout=""):
-    """Create a stub script that records calls and exits."""
-    stub = tmp_path / name
-    stub.write_text(textwrap.dedent(f"""\
-        #!/usr/bin/env bash
+    """Create a stub script that records calls and exits.
+
+    testlib.mockbin owns the shebang (/bin/sh) — a `#!/usr/bin/env bash` stub
+    cannot exec in the nix build sandbox, and patchShebangs cannot reach a file
+    a test writes at runtime.
+    """
+    return write_exec(tmp_path / name, textwrap.dedent(f"""\
         echo "$@" >> "{tmp_path / 'calls.log'}"
         exit {exit_code}
     """))
-    stub.chmod(0o755)
-    return stub
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_runtime_shebangs.py
+++ b/scripts/tests/test_runtime_shebangs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""REPO-WIDE structural guard: no test may write `#!/usr/bin/env …` at runtime.
+"""REPO-WIDE structural guard: no test may reach for `/usr/bin/env` at runtime.
 
 WHY
 ---
@@ -20,12 +20,26 @@ defect — the scan could not see it, because the hazard is a property of the
 repo, not of one suite. Directory-scoped guards regenerate the bug in the next
 directory; `claude/RULES.md` → "One rule, one place".
 
+WHY THREE SHAPES
+----------------
+Until 2026-08-06 the scan saw ONE shape: a shebang sitting directly behind a
+quote, which is what a one-line stub body looks like. `93caa3a` then added
+`scripts/tests/test_rig_control.py` and `scripts/tests/test_monitor_blackout.py`
+— 27 tests that went red in the sandbox and stayed red for two days — and this
+guard was green through all of it, because those files carry the hazard in two
+shapes it could not see: a shebang opening its own line inside a multi-line
+`textwrap.dedent` body, and `/usr/bin/env` as a plain argv element (not a
+shebang at all — it raises FileNotFoundError before any stub is reached).
+`testlib.shebang_scan.line_is_offender` enumerates all three; each has its own
+positive control below.
+
 HOW TO SATISFY IT
 -----------------
 Use `testlib.mockbin.write_exec(path, body)` — it owns the shebang (`/bin/sh`)
-and RAISES if a call site supplies its own. Do not add an ALLOWLIST entry to get
-green; the allowlist is for sites that solve the problem a different, verified
-way, and every entry must say which way.
+and RAISES if a call site supplies its own. To EXEC an interpreter, resolve it
+with `shutil.which(...)` once, to an absolute path. Do not add an ALLOWLIST
+entry to get green; the allowlist is for sites that solve the problem a
+different, verified way, and every entry must say which way.
 """
 from __future__ import annotations
 
@@ -73,6 +87,9 @@ ALLOWLIST = [
      "the shebang before writing (see the entry above)"),
     ("scripts/dl-router/tests/test_backfill.py", "root",
      "not a shebang: a dl-router manifest header sentinel being mutated"),
+    ("scripts/claude-hooks/tests/test_guard_core.py", "/usr/bin/doas",
+     "not an argv the test EXECS: a parametrize list of wrapper-binary strings "
+     "fed to gc.evaluate() as text, so the path is never resolved"),
 ]
 
 
@@ -126,6 +143,34 @@ def test_positive_control_the_scan_can_actually_find_an_offender(tmp_path):
                    encoding="utf-8")
     hits = S.scan_tree(tmp_path, "test_*.py")
     assert len(hits) == 1, f"scan is wired to nothing: {hits}"
+    assert hits[0][1] == 2
+
+
+def test_positive_control_the_scan_finds_a_bare_shebang_line(tmp_path):
+    """🔴 POSITIVE CONTROL for shape 2 — the shape that let 27 tests through.
+
+    A multi-line `textwrap.dedent` stub body puts the shebang at the start of
+    its own line, with no quote in front of it. The original one-shape scan
+    could not see that and reported a clean zero for two days.
+    """
+    bad = tmp_path / "test_bad_multiline.py"
+    bad.write_text("body = '''\n" + S.offending_bare_shebang_line() + "\n'''\n",
+                   encoding="utf-8")
+    hits = S.scan_tree(tmp_path, "test_*.py")
+    assert len(hits) == 1, f"scan cannot see a bare shebang line: {hits}"
+    assert hits[0][1] == 2
+
+
+def test_positive_control_the_scan_finds_an_argv_element(tmp_path):
+    """🔴 POSITIVE CONTROL for shape 3 — not a shebang at all.
+
+    `subprocess.run([<env>, "bash", …])` raises FileNotFoundError in the sandbox
+    before any stub is reached. This is what actually produced the 27 failures.
+    """
+    bad = tmp_path / "test_bad_argv.py"
+    bad.write_text("x = 1\n" + S.offending_argv_line() + "\n", encoding="utf-8")
+    hits = S.scan_tree(tmp_path, "test_*.py")
+    assert len(hits) == 1, f"scan cannot see an argv element: {hits}"
     assert hits[0][1] == 2
 
 


### PR DESCRIPTION
## The gate has been RED on `main` since 2026-08-04

`nix build .#checks.x86_64-linux.pytests` is the authoritative merge gate, and roughly a
dozen PRs merged through it while it was failing. A permanently-red gate is worse than no
gate — two agents and Zach each had to hand-diff failing-test-name sets to prove their own
work wasn't the cause.

**Nothing here is skipped, xfailed, deleted or weakened.** The collected count goes UP.

### Counted verdicts (never an exit code)

| tier | ref | counts | verdict |
|---|---|---|---|
| pytests | `main` | `collected=6160 passed=6129 skipped=3 failed=28` | `RESULT: FAIL` |
| pytests | this branch | `collected=6162 passed=6159 skipped=3 failed=0` (floor 5600) | `RESULT: PASS` |
| nodetests | this branch | `suites=3 files=30 tests=1024 pass=1024 fail=0 skipped=0` (floor 970) | `RESULT: PASS` |

Reporting trap, for whoever reads this next: `test_bash_guard.py` prints its own
`RESULT: all good`, which lands **before** the runner's real verdict. A naive
`grep "RESULT:"` returns two subsystems interleaved, hook first. The numbers above come
from the runner's own final `TOTAL`/`RESULT` lines, cross-checked against the per-suite
`SUMMARY` block.

### Failing-test name set, before -> after

Before (28, all gone after):

* `scripts/tests/test_monitor_blackout.py` — 11: `test_no_args_blackout_default_duration`,
  `test_restore_reads_state_and_restores`, `test_restore_uses_default_brightness_when_no_state`,
  `test_status_no_timer`, `test_get_brightness_returns_value`, `test_fade_blackout_saves_state`,
  `test_fade_calls_setvcp_multiple_steps`, `test_fade_restore_reads_state`,
  `test_blackout_custom_duration`, `test_blackout_fails_when_no_monitor`,
  `test_restore_with_corrupt_state`
* `scripts/tests/test_rig_control.py` — 16: `test_unknown_subcommand_exits_2`,
  `test_status_awake_when_no_state`, `test_status_sleeping_when_statefile_says_sleeping`,
  `test_sleep_writes_state_file`, `test_sleep_calls_rgb_off_and_blackout`,
  `test_wake_writes_state_file`, `test_rgb_on_subcommand`, `test_rgb_off_subcommand`,
  `test_blackout_subcommand`, `test_restore_subcommand`,
  `test_sleep_then_status_shows_sleeping`, `test_wake_then_status_shows_awake`,
  `test_gui_exits_nonzero_when_yad_missing`, `test_state_dir_created_on_status`,
  `test_status_with_corrupt_state`, `test_status_with_empty_state`
* `scripts/collector/keylog/tests/test_espanso_detect.py` — 1:
  `test_live_scraper_observes_the_real_config`

After: **empty**.

Added (net +2 collected): `test_positive_control_the_scan_finds_a_bare_shebang_line`,
`test_positive_control_the_scan_finds_an_argv_element`.

### Four causes — the fourth only became visible after the first was fixed

The first branch build came back `collected=6162 passed=6158 skipped=3 failed=1`. The
survivor is a genuine defect the `FileNotFoundError` had been hiding: `test_status_no_timer`
stubbed `systemctl` and nothing else, while `monitor-blackout.sh` resolves `ddcutil` at
line 20 — **before** it dispatches any subcommand — and exits 1 with `ddcutil not found on
PATH`. The test asserted `returncode == 0` against a script that had already bailed. It
passed on a workbench dev host only because a real `ddcutil` is on `PATH` there. The
module docstring says "All OFFLINE: no ddcutil, no systemctl"; that is now true.


**A — 27 x `FileNotFoundError` on the `env` path** (`93caa3a`, 2026-08-04).
Both new suites exec `[<env-path>, "bash", <script>]` as an argv. The nix build sandbox has
no such file, so `subprocess` raises before the script is reached — and their mock stubs
carried the same interpreter in a shebang, which would have failed next. Fixed by resolving
the interpreter **once** via `shutil.which()` to an absolute path, and routing every stub
through `testlib.mockbin.write_exec`, which owns the shebang.

Not a bare `"bash"` argv, deliberately: several of these tests override `PATH` with a
stub-only directory, and `subprocess` does its PATH lookup in the `env=` you pass it — a
bare `"bash"` would make the interpreter itself unfindable.

**B — 1 x `AssertionError`** (`4c3e913`). That commit pruned the `:date` snippet from
`nix/home.nix` without updating the positive control that pinned it. The `:date` clause is
**not** deleted — it exists so a scraper regex that silently matched nothing cannot make
the three guards below it vacuously true. It is re-pointed at `:sshwn` (added in #134,
untouched since), whose `search_terms` list is longer and therefore a *stricter* test of
the list-splitting regex. Pinned values were read off `nix/home.nix`, never off the
scraper's output.

Mutation-checked, both red at the re-pointed assertion: breaking `_NIX_REC` gives
`scraper found only 0 snippets`; breaking `_NIX_TERMS` fails the `search_terms` pin.

**C — 2 unpinned skips** (#332, 2026-08-04 15:44 — actually the *first* breakage of the
day, and not in the original bug report). `test_skill_audit.py` added two regression pins
against the live datapacket-talos skill corpus, a private clone that cannot exist in the
sandbox. Both skip there, neither was pinned, and GUARD 2 failed the run **independently
of any failing test** — `failed=0` alone would not have turned this gate green.

Pinned in `EXPECTED_SKIPS` on exactly the `is_dir()` predicate the tests themselves use,
so on a host **with** the clone the tests still run and nothing is pinned. See "could not
fix" below — this one is honest accounting, not a repair.

### Root cause of A: the guard that existed to prevent it was green throughout

`scripts/tests/test_runtime_shebangs.py` is a repo-wide structural guard whose entire
purpose is making this class impossible. It watched `93caa3a` land and stayed green for
two days, because it could see **one** shape: a shebang directly behind a quote, i.e. a
one-line stub body. Both new files carry the hazard in two shapes it could not see:

1. a shebang opening its own line inside a multi-line `textwrap.dedent` body;
2. the interpreter path as a plain argv element — not a shebang at all, and the shape that
   actually produced all 27 failures.

`testlib.shebang_scan.line_is_offender` now enumerates all three, each with its own
positive control. Measured against `main`'s copies of the two files:

```
WIDENED scan hits on main's files: 6
   test_monitor_blackout.py:26  (argv element)
   test_monitor_blackout.py:39  (bare shebang line)
   test_monitor_blackout.py:55  (bare shebang line)
   test_monitor_blackout.py:221 (bare shebang line)
   test_rig_control.py:27       (argv element)
   test_rig_control.py:37       (bare shebang line)
OLD one-shape scan hits on the same files: 0 []
```

Red at `main`, green at HEAD — and the 0-vs-6 is what shows the *widening* is doing the
work rather than a coincidence.

One allowlist entry added: `test_guard_core.py`'s parametrize list of wrapper-binary
strings, which are fed to `gc.evaluate()` as text and never resolved.

Self-match note: spelling the new needle as a quoted literal made the scanner its own
first offender (observed, then fixed) — it is assembled from character codes like the
others, and `test_this_guards_source_does_not_match_itself` covers it.

### What I could NOT fix

Cause C is **accounted for, not repaired.** Those two `test_skill_audit.py` assertions are
keyed to an out-of-repo absolute path, which is precisely the shape `run-tests.sh`'s own
"REMOVED, deliberately" comment argues against a few lines below the entry I added: a
check keyed to a foreign clone is structurally unobservable in the tier that gates merges.
Making them hermetic would mean vendoring another (private) repo's `SKILL.md` files into
this **public** repo, which is worse. So they are pinned — conditionally, on the test's own
predicate, with the weakness flagged in place. If that check ever needs re-pointing, point
it at something tracked in this repo rather than widening the pin.

Not in scope, but worth a follow-up: `test_rig_control.py` and `test_monitor_blackout.py`
are weak beyond the shebang problem — several tests are `if path.exists(): assert ...` or
bare `assert True`, so they pass whether or not the script did anything. They now *run*;
they do not yet *prove* much.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
