### PR TITLE
test(skill-audit): re-point two out-of-repo pins at fixtures tracked in this repo

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -344,28 +344,21 @@ EXPECTED_SKIPS=(
   # REPO_COS_LIVE_DRIFT_CHECK=1.
   "scripts/repo-cos/tests|live-store drift check is opt-in"
 )
-# CONDITIONAL, on the SAME predicate the tests use (see the header note above).
-# `scripts/tests/test_skill_audit.py` carries two regression pins against the
-# LIVE datapacket-talos skill corpus — a separate, PRIVATE clone that cannot
-# exist in the nix sandbox and may be absent on a dev host. Both call
-# `pytest.skip("datapacket-talos clone not present")` off exactly this
-# `is_dir()` check, so the pin mirrors it: present → the tests RUN and nothing is
-# pinned; absent → two accounted skips. #332 added them without this entry, and
-# the gate was RED on main from 2026-08-04 to 2026-08-06 on the unpinned-skip
-# guard alone, independently of any failing test.
+# ⚠ REMOVED, deliberately — do not re-add. `scripts/tests/test_skill_audit.py`
+# carried two regression pins against the LIVE datapacket-talos skill corpus, a
+# separate PRIVATE clone that cannot exist in the nix sandbox and may be absent
+# on a dev host. Both skipped off an `is_dir()` check on an absolute out-of-repo
+# path, and this entry existed to pin those two environment-dependent skips.
+# (#332 added the tests without the entry, and the gate was RED on main from
+# 2026-08-04 to 2026-08-06 on the unpinned-skip guard alone.)
 #
-# ⚠ This is a WEAK shape and the runner says so a few lines down: a check keyed
-# to an out-of-repo path is structurally unobservable in the tier that gates
-# merges. It is pinned rather than deleted because on a host with the clone it
-# is the highest-value assertion in that file. If it ever needs re-pointing,
-# re-point it at something tracked IN THIS REPO instead of widening this entry.
-_SKILL_CORPUS=/home/zach/workspace/civit/datapacket-talos/.claude/skills
-if [ ! -d "$_SKILL_CORPUS" ]; then
-  EXPECTED_SKIPS+=(
-    "scripts/tests|datapacket-talos clone not present"
-    "scripts/tests|datapacket-talos clone not present"
-  )
-fi
+# Same defect as the test_scrub.py case below: a check keyed to a path outside
+# the repo is structurally unobservable in the tier that gates merges, so it
+# means one thing on a dev host and nothing at all here. Re-pointed 2026-08-06
+# at synthetic fixtures TRACKED IN THIS REPO
+# (scripts/tests/fixtures/skill_audit/), so those pins now RUN in every tier and
+# NEVER skip — which is why there is nothing left to pin.
+#
 # ⚠ REMOVED, deliberately — do not re-add. test_scrub.py's drift guard used to
 # compare scrub.py's SECRET_PATTERNS against the DEPLOYED hook
 # (`Path.home()/".claude"/"hooks"/"bash-guard.py"`) and skip when that file was

--- a/scripts/tests/fixtures/skill_audit/dated_lessons_corpus.md
+++ b/scripts/tests/fixtures/skill_audit/dated_lessons_corpus.md
@@ -1,0 +1,87 @@
+---
+name: dated-lessons-corpus
+description: SYNTHETIC fixture — a skill whose dated headings are durable guidance.
+---
+
+<!--
+FIXTURE, not a real skill. Deliberately NOT named SKILL.md so that running
+`skill-audit.py` on this repo root cannot pick it up as a skill.
+
+Shape being reproduced: the corpus-majority skill. Every heading below either
+cites an ISO date while describing DURABLE operational guidance, or carries no
+date at all. NONE of them is work-status narrative. Expected classification:
+  dated (work-status / EVICT_HISTORY) == []      <- must stay empty
+  lessons (dated but durable)         == 9 blocks
+
+Do not add a heading containing session / changelog / work log / shipped /
+release notes / history: those words are the work-status signal and would move
+a block into the other bucket, which is exactly the conflation this fixture
+exists to detect.
+-->
+
+## Quick start
+
+```bash
+TOOL=./bin/tool
+$TOOL status
+```
+
+## Common silent-failure modes (from the 2026-05-22 audit)
+
+A probe that returns an empty set reports the same thing whether the query was
+wrong or the subject is genuinely idle. Always pair it with a positive control.
+
+## The inert-check defect class (2026-06-01)
+
+A check wired to a field that no longer exists evaluates to false forever. It
+never fires, and a never-firing check is indistinguishable from a healthy one.
+
+## Why the retry budget is per-target, not global (2026-06-14)
+
+A global budget lets one unreachable target consume every retry and starve the
+rest. Measured on the staging rig: one bad target ate 96% of the budget.
+
+## Backoff must be capped (decided 2026-06-20)
+
+Uncapped exponential backoff pushes the next attempt past the eviction window,
+so the work is dropped rather than retried.
+
+### Sub-topic with no date
+
+Nested under a dated parent on purpose — the outermost-only rule means this
+must not be counted as a block of its own.
+
+## Draining a queue safely (2026-06-28)
+
+Stop the producer first. Draining while a producer is live never terminates.
+
+## Reading the saturation panel (2026-07-03)
+
+The panel averages over 5 minutes, so a 30-second spike is invisible on it.
+Use the raw series when investigating a short stall.
+
+## Two timeouts, two meanings (2026-07-11)
+
+The client timeout bounds one attempt; the request deadline bounds the whole
+retry chain. Setting them equal makes the retries unreachable.
+
+## Config precedence (established 2026-07-19)
+
+The per-target override wins over the profile default, which wins over the
+built-in. A value that "does nothing" is nearly always shadowed one level up.
+
+## The idempotency key must cover the payload (2026-07-25)
+
+Keying on the target alone collapses two genuinely different writes into one,
+and the second is silently dropped.
+
+## Ops table
+
+| command | does |
+|---|---|
+| `status` | print health |
+| `drain` | stop the producer, then drain |
+
+## Glossary
+
+Terms used above, with no date anywhere in the heading.

--- a/scripts/tests/fixtures/skill_audit/odd_parity_info_string.md
+++ b/scripts/tests/fixtures/skill_audit/odd_parity_info_string.md
@@ -1,0 +1,37 @@
+---
+name: odd-parity-info-string
+description: SYNTHETIC fixture — well-formed CommonMark with ODD fence-marker parity.
+---
+
+<!--
+FIXTURE, not a real skill. Deliberately NOT named SKILL.md.
+
+Shape being reproduced: a documentation block that DISPLAYS a fence marker
+carrying an info string. Under CommonMark a closing fence may not carry an info
+string, so the ```action line below is content, not structure. The file has an
+ODD number of fence markers and is nonetheless perfectly well-formed — the
+exact shape a marker-PARITY heuristic calls "unclosed".
+
+Expected: fence_ok is True, and every `##` heading stays visible.
+-->
+
+## Contract
+
+The tool emits blocks like this — the inner marker is displayed, not opened:
+
+```
+```action
+{"type": "apply_filter", "target": "svc-a"}
+```
+
+## Runbook
+
+```bash
+## this comment is inside a fence and must never register as a heading
+tool apply --target svc-a
+```
+
+## After the fences
+
+If this heading is missing from the audit, the fence walk swallowed the rest of
+the file and every byte weight above it is wrong.

--- a/scripts/tests/fixtures/skill_audit/odd_parity_nested_lang.md
+++ b/scripts/tests/fixtures/skill_audit/odd_parity_nested_lang.md
@@ -1,0 +1,41 @@
+---
+name: odd-parity-nested-lang
+description: SYNTHETIC fixture — a ```lang marker displayed INSIDE an open fence.
+---
+
+<!--
+FIXTURE, not a real skill. Deliberately NOT named SKILL.md.
+
+Shape being reproduced: a heredoc inside a ```bash block that writes out
+another ```bash block. The inner marker carries an info string, so it can
+neither close the outer fence nor open a new one — it is content. ODD marker
+parity, well-formed CommonMark.
+
+This also carries the mechanism behind the original false positive: a shell
+`## 3. …` COMMENT inside the fence. If the fence walk breaks, that comment is
+read as an H2 and silently re-partitions the whole file — so it is written at
+H2 depth deliberately, to land in the `h2` list the test pins.
+
+Expected: fence_ok is True, the shell comment is not a heading, and the
+headings after the fence stay visible.
+-->
+
+## Runbook
+
+```bash
+# 1. write the snippet the docs embed
+cat <<'EOF' > snippet.md
+```bash
+tool status --target svc-a
+EOF
+## 3. state check — NOT a heading, this line is inside the fence
+tool verify
+```
+
+## Still visible
+
+The heading above must survive the fence. So must the one below.
+
+## Also still visible
+
+Tail content.

--- a/scripts/tests/fixtures/skill_audit/work_status_corpus.md
+++ b/scripts/tests/fixtures/skill_audit/work_status_corpus.md
@@ -1,0 +1,65 @@
+---
+name: work-status-corpus
+description: SYNTHETIC fixture — a skill that really has accreted work-status narrative.
+---
+
+<!--
+FIXTURE, not a real skill. Deliberately NOT named SKILL.md.
+
+Shape being reproduced: the one-in-N skill that HAS accreted session narrative
+— many `### Session <date>` blocks hanging as siblings under a single non-dated
+`## Roadmap` parent. Expected classification:
+  dated (work-status / EVICT_HISTORY) == the 5 `Session …` blocks
+  lessons (dated but durable)         == the 1 dated-but-topical block
+
+The two buckets must be DISJOINT here: if a Session block ever shows up under
+lessons, or the durable block under dated, the split has re-merged.
+-->
+
+## Quick start
+
+```bash
+TOOL=./bin/tool
+$TOOL status
+```
+
+## Failure modes (from the 2026-05-22 audit)
+
+Durable guidance that merely cites a date. Must land in `lessons`, never in
+`dated` — evicting this would gut the skill.
+
+## Roadmap
+
+Undated parent. The dated children below are the outermost dated blocks.
+
+### Session 2026-07-01 — first cut
+
+Narrative about a past working session. Belongs in a handoff doc.
+
+### Session 2026-07-08 — wiring the collector
+
+More narrative. Nothing here is guidance a future reader would act on.
+
+#### Session 2026-07-09 — follow-up the next morning
+
+NESTED on purpose. It is already inside the 2026-07-08 block, so counting it as
+a block of its own double-counts its bytes and can push the projected saving
+past the file size. It must NOT appear in the expected list.
+
+### Session 2026-07-15→16 — dogfood + audit
+
+Two-day narrative, arrow form.
+
+### Session 2026-07-22 — fixing the retry path
+
+Narrative.
+
+### Session 2026-07-29 — cleanup
+
+Narrative.
+
+## Ops table
+
+| command | does |
+|---|---|
+| `status` | print health |

--- a/scripts/tests/test_skill_audit.py
+++ b/scripts/tests/test_skill_audit.py
@@ -1,7 +1,9 @@
 """Unit tests for scripts/skill-audit.py — the /prune-skill auditor.
 
-OFFLINE and hermetic: every fixture is written into a tmp_path; nothing under
-~/.claude or any real repo is read.
+OFFLINE and hermetic: every fixture is either written into a tmp_path or tracked
+in this repo under tests/fixtures/skill_audit/. Nothing under ~/.claude, $HOME
+or any out-of-repo clone is read, and no test in this file skips — so it means
+exactly the same thing on a dev host and in the nix build sandbox.
 
 🔴 HARNESS DISCIPLINE (claude/RULES.md, "A harness that COUNTS needs a POSITIVE
 control too"). This auditor's reassuring answers are ZEROS — "0 dated-history
@@ -30,6 +32,13 @@ import pytest
 
 SCRIPTS = Path(__file__).resolve().parents[1]
 AUDIT_PY = SCRIPTS / "skill-audit.py"
+
+# Whole-FILE fixtures, tracked in this repo. The three file-scale pins here used
+# to read SKILL.md files out of a private clone at an absolute path and skip when
+# it was absent — see the tests that use these. They are deliberately NOT named
+# SKILL.md, so running skill-audit.py on this repo root cannot mistake a fixture
+# for a real skill.
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "skill_audit"
 
 
 def _load(name, modname):
@@ -304,29 +313,65 @@ def test_a_dated_work_status_heading_goes_to_work_status_not_lessons(tmp_path):
     assert len(a["dated"]) == 1 and a["lessons"] == []
 
 
-def test_real_skills_classify_the_way_the_corpus_measurement_says():
-    """Regression pin against the live corpus, so the conflation cannot return.
+def test_corpus_shaped_file_of_dated_lessons_reports_zero_work_status():
+    """Whole-file regression pin, so the conflation cannot return.
 
-    Skipped when the clone is absent so the suite stays hermetic. Measured
-    2026-08-04: manage-alerts has ZERO work-status blocks (15 dated lessons),
-    app-blocks has 46 work-status blocks. If manage-alerts ever reports
-    work-status history, the buckets have re-merged.
+    This used to read a live skill corpus out of a separate PRIVATE clone at an
+    absolute out-of-repo path, and skip when that clone was absent — so it meant
+    one thing on a dev host and vanished in the tier that gates merges. Re-pointed
+    2026-08-06 at a synthetic fixture TRACKED IN THIS REPO, reproducing the
+    corpus-majority shape measured 2026-08-04: a skill whose dated headings are
+    all durable guidance. Every value below is a literal read off the fixture,
+    not off the implementation.
+
+    The `dated == []` half is the one that matters: with the buckets merged, all
+    nine lessons land in the evictable pile, which is how a 59% "evictable
+    history" figure was reported for a skill whose largest dated blocks were its
+    most valuable operational content.
     """
-    root = Path("/home/zach/workspace/civit/datapacket-talos/.claude/skills")
-    if not root.is_dir():
-        pytest.skip("datapacket-talos clone not present")
-    for name, expect_ws in (("manage-alerts", False), ("app-blocks", True)):
-        p = root / name / "SKILL.md"
-        if not p.is_file():
-            pytest.skip(f"{name} absent")
-        a = sa.audit_one(p)
-        if expect_ws:
-            assert a["dated"], f"{name}: expected work-status blocks, found none"
-        else:
-            assert not a["dated"], (
-                f"{name}: reported {len(a['dated'])} work-status block(s); its dated "
-                "headings are durable lessons, so the buckets have re-merged")
-            assert a["lessons"], f"{name}: expected dated lessons, found none"
+    a = sa.audit_one(FIXTURES / "dated_lessons_corpus.md")
+    assert a["dated"] == [], (
+        f"reported {len(a['dated'])} work-status block(s); every dated heading in "
+        "this fixture is durable guidance, so the buckets have re-merged")
+    assert a["dated_bytes"] == 0
+    assert [t for t, *_ in a["lessons"]] == [
+        "Common silent-failure modes (from the 2026-05-22 audit)",
+        "The inert-check defect class (2026-06-01)",
+        "Why the retry budget is per-target, not global (2026-06-14)",
+        "Backoff must be capped (decided 2026-06-20)",
+        "Draining a queue safely (2026-06-28)",
+        "Reading the saturation panel (2026-07-03)",
+        "Two timeouts, two meanings (2026-07-11)",
+        "Config precedence (established 2026-07-19)",
+        "The idempotency key must cover the payload (2026-07-25)",
+    ]
+
+
+def test_corpus_shaped_file_of_session_narrative_reports_work_status():
+    """The other half of the same pin, and the POSITIVE control for it.
+
+    `dated == []` above is a zero, and a zero is indistinguishable from a
+    detector wired to nothing — so the same detector must be shown to move on a
+    file that genuinely carries session narrative. Same fixture convention:
+    five `### Session <date>` siblings under one undated `## Roadmap`, the
+    arrangement measured on the one corpus skill that really had accreted it.
+
+    The buckets must also be DISJOINT at file scale: the one dated-but-topical
+    heading here belongs to `lessons` and to nothing else.
+    """
+    a = sa.audit_one(FIXTURES / "work_status_corpus.md")
+    ws = [t for t, *_ in a["dated"]]
+    assert ws == [
+        "Session 2026-07-01 — first cut",
+        "Session 2026-07-08 — wiring the collector",
+        "Session 2026-07-15→16 — dogfood + audit",
+        "Session 2026-07-22 — fixing the retry path",
+        "Session 2026-07-29 — cleanup",
+    ]
+    assert a["dated_bytes"] > 0
+    ls = [t for t, *_ in a["lessons"]]
+    assert ls == ["Failure modes (from the 2026-05-22 audit)"]
+    assert not (set(ws) & set(ls))
 
 
 @pytest.mark.parametrize("heading", [
@@ -442,23 +487,40 @@ def test_tilde_fence_is_tracked_and_not_closed_by_backticks(tmp_path):
     assert [t for t, *_ in a["h2"]] == ["Doc", "After"]
 
 
-def test_real_datapacket_skills_are_not_reported_broken():
-    """Regression pin on the two files the parity check falsely accused.
+@pytest.mark.parametrize("fixture,h2", [
+    # The shape the parity check falsely accused in a real support-stack doc:
+    # an outer bare fence displaying a ```action marker.
+    ("odd_parity_info_string.md", ["Contract", "Runbook", "After the fences"]),
+    # The other one: a heredoc inside ```bash that writes out another ```bash
+    # block, alongside the `# 3. …` shell comment that a broken fence walk reads
+    # as an H1 and re-partitions the file on.
+    ("odd_parity_nested_lang.md", ["Runbook", "Still visible", "Also still visible"]),
+])
+def test_odd_marker_parity_wellformed_file_is_not_reported_broken(fixture, h2):
+    """Whole-FILE regression pin on the false-positive class.
 
-    Skipped when that clone is absent so the suite stays hermetic; when it IS
-    present this is the highest-value assertion in the file, because it is the
-    one that would have caught the false positive before it cost a change to a
-    shared production repo.
+    This used to read two SKILL.md files out of a PRIVATE clone at an absolute
+    path and skip when it was absent — so the highest-value assertion in this
+    file was structurally unobservable in the tier that gates merges.
+    Re-pointed 2026-08-06 at synthetic fixtures TRACKED IN THIS REPO that
+    reproduce both accused shapes at file scale.
+
+    The odd-parity assertion is the fixture's own positive control: it is what
+    the parity heuristic tripped on, so if a future edit quietly evens the
+    marker count, this test would still pass while no longer exercising the
+    trap. Pin the property, not just the verdict.
     """
-    root = Path("/home/zach/workspace/civit/datapacket-talos/.claude/skills")
-    if not root.is_dir():
-        pytest.skip("datapacket-talos clone not present")
-    for name in ("app-blocks", "manage-support-stack"):
-        p = root / name / "SKILL.md"
-        if not p.is_file():
-            pytest.skip(f"{name} absent")
-        assert sa.audit_one(p)["fence_ok"] is True, \
-            f"{name}: well-formed under CommonMark; a FAIL here means the fence walk regressed"
+    p = FIXTURES / fixture
+    lines = p.read_text().splitlines(keepends=True)
+    markers = sum(1 for ln in lines if sa.FENCE.match(ln.rstrip("\n")))
+    assert markers % 2 == 1, (
+        f"{fixture} has {markers} fence markers — EVEN parity no longer exercises "
+        "the false positive this fixture exists for; restore an odd marker")
+    a = sa.audit_one(p)
+    assert a["fence_ok"] is True, \
+        f"{fixture}: well-formed under CommonMark; a FAIL here means the fence walk regressed"
+    assert [t for t, *_ in a["h2"]] == h2, \
+        f"{fixture}: the fence walk re-partitioned the file"
 
 
 # --- skill naming ---------------------------------------------------------------


### PR DESCRIPTION
## The problem

`scripts/tests/test_skill_audit.py` carried two regression pins (added by #332)
that read `SKILL.md` files out of a separate **private, out-of-repo clone** at an
absolute path, gated on `is_dir()`, and `pytest.skip`ped when it was absent.

So the gate meant one thing on a dev host and nothing at all in the tier that
gates merges. That is the exact shape `run-tests.sh`'s own "⚠ REMOVED,
deliberately" note argues against for `test_scrub.py`, and it was part of why the
pytests gate went red on `main` on 2026-08-04 and stayed red for two days -- on
the unpinned-skip guard alone. Per RULES.md: a test that skips itself, or passes
by accident of the environment, is worse than no test, because it reports safety.

## What changed

Both pins now run against **synthetic fixtures tracked in this repo**
(`scripts/tests/fixtures/skill_audit/`), so they execute identically on every host
and in the nix sandbox and never skip.

🔴 **No private content is vendored.** The fixtures reconstruct only the
*structural* shapes -- invented prose, no real hostname, path, directory name or
repo content. They are deliberately **not** named `SKILL.md`, so running
`skill-audit.py` on this repo root cannot mistake a fixture for a real skill.

| fixture | shape it reproduces |
|---|---|
| `dated_lessons_corpus.md` | the corpus-majority skill: 9 headings citing ISO dates that are all durable guidance, zero work-status narrative |
| `work_status_corpus.md` | the outlier that really accreted narrative: 5 `### Session <date>` siblings under an undated `## Roadmap`, one of them with a nested `#### Session …`, plus one dated-but-topical block |
| `odd_parity_info_string.md` | an outer bare fence displaying a ` ```action ` marker -- odd marker parity, valid CommonMark |
| `odd_parity_nested_lang.md` | a heredoc inside ` ```bash ` writing out another ` ```bash ` block, plus a `## …` shell comment inside the fence |

### The assertions, before → after (stronger, not weaker)

**Classification pin.** Before: on two live files, `dated` is non-empty for one and
empty for the other, `lessons` non-empty. After: the **exact title lists** in both
buckets on both fixtures, plus `dated_bytes`, bucket disjointness, and
outermost-only nesting at file scale. Split into two tests so the reassuring zero
(`dated == []`) has an explicit positive control -- a zero is otherwise
indistinguishable from a detector wired to nothing.

**Fence-walk pin.** Before: `fence_ok is True` on two live files. After: the same,
plus the `##` headings that must remain visible (a broken walk silently
re-partitions the file), **plus an assertion that the fixture's fence-marker
parity is still ODD** -- odd parity is what the old heuristic tripped on, so
without that guard a future edit could quietly even it out and the test would keep
passing while no longer exercising the false positive.

`run-tests.sh`: the conditional `EXPECTED_SKIPS` entry that existed only to account
for those two environment-dependent skips is removed, with the reasoning recorded
next to the identical `test_scrub.py` case.

## Mutation matrix — 9/9 killed, each with its own assertion message

| # | mutation | result |
|---|---|---|
| M1 | an ISO date counts as work-status (buckets re-merged) | RED — *"reported 9 work-status block(s) … the buckets have re-merged"* |
| M2 | dated-lesson detector wired to nothing | RED — lessons list empty |
| M3 | `\bsessions?\b` removed from `WORK_STATUS_HEADING` | RED — dated list empty |
| M4 | outermost-only nesting rule removed | RED — the nested `Session 2026-07-09` block appears |
| M5 | fence walk reverted to a marker-parity count | RED — *"a FAIL here means the fence walk regressed"* |
| M6 | an info-string marker allowed to close a fence | RED — same |
| M7 | headings inside a fence become visible | RED — *"the fence walk re-partitioned the file"* |
| M8 | fixture drift: odd marker removed from `odd_parity_info_string.md` | RED — *"has 4 fence markers — EVEN parity no longer exercises the false positive"* |
| M9 | fixture drift: same for `odd_parity_nested_lang.md` | RED — same, 2 markers |

Baseline unmutated: 4 passed.

## Gates — counted, not read off an exit code

```
pytests    TOTAL collected=6164  passed=6163  skipped=1  failed=0   RESULT: PASS
nodetests  TOTAL suites=3 files=30 tests=1024 pass=1024 fail=0      RESULT: PASS
```

`main` baseline was `collected=6162 passed=6159 skipped=3`. **Skips 3 → 1**: the two
clone-keyed skips are gone; the one that remains is the pre-existing opt-in
`repo-cos` live-store drift check. Collected +2 (two pins became four tests).

**Hermeticity proof:** the nix sandbox has no access to `$HOME` or any out-of-repo
clone, and the build passes with `scripts/tests` reporting `skipped=0` — the pins
ran there. No absolute out-of-repo path remains in the test file or fixtures (the
only mention is prose in a docstring explaining the history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
