### PR TITLE
fix(activity): a DEGRADED ClickHouse read reported success — exit 0 on 1 of 4 TTL targets

### DIFF
--- a/claude/skills/activity/SKILL.md
+++ b/claude/skills/activity/SKILL.md
@@ -43,11 +43,9 @@ stamps `host` from `ACTIVITY_HOST`.
 | Schema columns | `ts DateTime64(3) (UTC), host, source, kind, project, cwd, session, app, text, duration_ms, exit_code, payload(JSON), ingested_at` |
 
 ### The sources — MEASURED, not declared
-🔴 This table said "six sources" and got two things wrong; both were measured on
-2026-08-03 against `activity.events` and corrected. **Do not re-derive the
-expected-present set from prose — run `python3 ~/workspace/devrc/scripts/collector/deadman.py`,
-which derives it from the table.** Live pairs: **9 sources on the laptop, 8 on the
-workbench, 17 pairs total.**
+🔴 **Do not re-derive the expected-present set from prose** — run
+`python3 ~/workspace/devrc/scripts/collector/deadman.py`, which derives it from the table.
+Live pairs (measured 2026-08-03): **9 sources on the laptop, 8 on the workbench, 17 total.**
 
 | source | what | laptop | workbench |
 |---|---|---|---|
@@ -89,13 +87,10 @@ inject post-reload). Manifest **v1.4.0**. When a file is DELETED upstream (e.g. 
   `$__timeFilter` / range comparisons (they're UTC, aligned with `now()`).
 - **Both hosts are hostname `nixos`** → without `ACTIVITY_HOST` in the env, every row
   collides on `host=nixos`. Set it per host.
-- 🔴 **CORRECTED 2026-08-03 — "keylog + browser + i3 are GUI-only → laptop only; the
-  workbench is headless" was FALSE and had been for a long time.** Measured against
-  `activity.events`: the workbench emits **i3 (41,001 rows) and keys (37,376 rows)**, both
-  fresh. The workbench runs a real X/i3 session; only the **Brave activity extension** is
-  laptop-only, so `browser` is the single source with 0 workbench rows. Anything that
-  decides "is this source expected here?" must read the TABLE, not this file — which is why
-  `deadman.py` derives the expected set from measured baselines instead of a hand-kept list.
+- 🔴 **Never decide "is this source expected on this host?" from prose.** "keylog + browser
+  + i3 are GUI-only → laptop-only; the workbench is headless" was FALSE for a long time —
+  the workbench runs a real X/i3 session (see the source table above). Read the TABLE;
+  `deadman.py` derives the expected set from measured baselines, not a hand-kept list.
 - **Full-content keylogging** → `activity.events` holds secrets. That is WHY the store is a
   dedicated authed ClickHouse, not the shared LAN-open clickstack. Treat reader/writer creds
   as sensitive.
@@ -189,11 +184,11 @@ Creds come from `~/.config/activity-collector/env` (the collector's own file) un
 
 ## regrowth check — "is the ClickHouse store growing back?"
 `scripts/collector/ch_regrowth.py` (+ `run-regrowth-check.sh`, the sops/kubeconfig wrapper).
-2026-08-03 the store was cut **112.4 GB → 82.1 MB** after `system.trace_log` hit 3.77
-BILLION rows in ~5 weeks; the fix was a Flux config change (logger trace→warning, four
-query-profiler log tables removed, 7d/14d TTLs, merge pool 32→8). **Nothing else would
-notice that silently reverting.** Read-only; **workbench-only** systemd user timer
-`ch-regrowth-check`, **monthly on the 11th**, `Persistent=true`.
+2026-08-03 the store was cut **112.4 GB → 82.1 MB** (`system.trace_log`: 3.77 BILLION rows
+in ~5 weeks); the Flux fix = logger trace→warning, four query-profiler log tables removed,
+7d/14d TTLs, merge pool 32→8. **Nothing else would notice that silently reverting.**
+Read-only; **workbench-only** timer `ch-regrowth-check`, **monthly on the 11th**,
+`Persistent=true`.
 ```bash
 scripts/collector/run-regrowth-check.sh            # or: systemctl --user start ch-regrowth-check
 # from the laptop (nebula), by hand:
@@ -203,18 +198,23 @@ KUBECONFIG=~/.kube/homelab-nebula.yaml CH_REGROWTH_URL=http://10.42.0.10:30123 \
 - Asserts: `du(store)` >2 GiB ALARM / >1 GiB WARN · any `*_0` table (a TTL applied to an
   existing `*_log` RENAMES the old one aside, which then keeps its rows with **NO TTL
   forever**) · `trace_log`/`text_log`/`latency_log`/`processors_profile_log` existing at all
-  · any table >250 MiB · **TTL effectiveness** — `min(event_time)` younger than TTL+1d
-  (the only check that tests the MECHANISM, not today's outcome).
-- Exit **0 ok · 1 ALARM · 2 CANNOT TELL · 3 WARN**. Every non-zero is a unit failure →
-  the existing `OnFailure=notify-failure@` sticky toast. Verdict + every number it read
-  lands in `~/.cache/ch-regrowth/status.json`.
+  · any table >250 MiB · **TTL effectiveness** — `min(event_time)` younger than **TTL+3d**
+  (**10d** / **17d**; the only check that tests the MECHANISM, not today's outcome) · **TTL
+  coverage** — fewer targets measured than present → WARN.
+- Exit **0 ok · 1 ALARM · 2 CANNOT TELL · 3 WARN (incl. a DEGRADED/partial read)**. Every
+  non-zero is a unit failure → the existing `OnFailure=notify-failure@` sticky toast.
+  Verdict + every number it read lands in `~/.cache/ch-regrowth/status.json`.
+- Transient failures (5xx/429/connection — the pod's 2.5 GiB ceiling returns `Code: 241`
+  under merge load) are retried; the TTL union then falls back to one retried query per
+  table, wall-clock bounded. Exhausted retries stay CANNOT TELL.
 - 🔴 **`du` sits ~40% above the live `total_bytes` sum by design** (8-slot merge pool
   leaves inactive parts around). That gap is NOT a leak — do not re-derive an alarm from it.
 - 🔴 Its reassuring answers are all ZEROS, so `ok` is gated on positive controls (listing
-  non-empty, `activity.events` present, >0 `*_log` matches, >0 tables over 1 MiB, ≥1 TTL
-  target measured). Any failure state — `not-configured`/`unreachable`/`query-failed`/
-  `exec-failed`/`no-data` — is LOUD and is never `ok`. Read its module docstring before
-  changing any threshold; every one is derived from a named measurement.
+  non-empty, `activity.events` present, >0 `*_log` matches, >0 tables over 1 MiB, **all**
+  present TTL targets measured — 1-of-4 measured is exit 3, not a clean store). Any failure
+  state — `not-configured`/`unreachable`/`query-failed`/`exec-failed`/`no-data` — is LOUD
+  and never `ok`. Read its module docstring before changing a threshold; each is derived
+  from a named measurement.
 
 ## troubleshoot a stalled source
 1. `journalctl --user -u <service> -n 30` — `urlopen timed out` = can't reach CH (check the

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -2158,10 +2158,20 @@ in
       #
       # 180 -> 240 when the checker gained retries: a transient HTTP 500 (the
       # observed `Code: 241 MEMORY_LIMIT_EXCEEDED`) is now retried with backoff
-      # and the TTL union falls back to one query per table. ch_regrowth.py
-      # bounds that itself with COLLECT_BUDGET_SECONDS = 120 — no new attempt
-      # STARTS past 120s — so the worst case is 120 + one in-flight 30s query +
-      # the `du` exec. 240 leaves margin over that without hiding a real hang.
+      # and the TTL union falls back to one query per table (which retries too).
+      # ch_regrowth.py bounds that itself with COLLECT_BUDGET_SECONDS = 120 — no
+      # RETRY starts past 120s, and the per-table fallback loop breaks there.
+      #
+      # 🔴 WORST CASE IS 187s, NOT ~180. This comment used to say "120 + one
+      # in-flight 30s query + the du exec", which understates it by a whole
+      # query phase: only RETRIES are deadline-gated, so after ONE phase burns
+      # its full budget (3 x 30s + 2s + 5s = 97s) each of the three remaining
+      # phases still gets one ungated 30s attempt — 97 + 90 = 187. The
+      # conclusion holds (187 < 240), but do not re-derive the margin from the
+      # old sentence. This number is not asserted from a comment:
+      # test_the_collection_budget_is_pinned_to_the_units_timeout SIMULATES the
+      # adversary that maximises wall clock and reads THIS `TimeoutStartSec`
+      # out of this file, so the two cannot drift apart.
       TimeoutStartSec = 240;
       Environment = [
         "PATH=${lib.makeBinPath [ pkgs.python312 pkgs.kubectl pkgs.sops pkgs.bash pkgs.coreutils ]}"

--- a/scripts/collector/ch_regrowth.py
+++ b/scripts/collector/ch_regrowth.py
@@ -60,6 +60,15 @@ WHAT IS ASSERTED
   5. TTL EFFECTIVENESS: min(event_time) younger than TTL + 3 days, per table
      (metric_log / asynchronous_metric_log: 10d; query_log / part_log: 17d).
      Rows older than the TTL surviving means the TTL is not binding.
+  6. TTL COVERAGE: fewer targets measured than are PRESENT -> WARN (exit 3).
+     🔴 A DEGRADED READ IS NOT A CLEAN ONE. Check 5 is per-table, so a target
+     that never answered is simply absent from the verdict — and the table most
+     likely to keep failing its own `min(event_time)` is the LARGEST one, i.e.
+     precisely the one that would be regrowing. "1 of 4 measured, all within
+     bound" exiting 0 would let the single most diagnostic target drop out
+     silently. It is deliberately a WARN and not an ALARM: nothing was OBSERVED
+     to be wrong, and it stays distinct from CANNOT-TELL (exit 2), which is what
+     ZERO measured targets still produces.
 
 🔴 THE `du` EXIT CODE IS NOT A VERDICT ON THE MEASUREMENT. A live store creates
 and removes `tmp_merge_*` directories constantly, so busybox `du` exits 1 when
@@ -81,7 +90,12 @@ to ONE QUERY PER TABLE.
 rounding error against the 2.5 GiB ceiling. The ceiling was reached by
 BACKGROUND MERGES eating the total budget, not by this query's own footprint.
 So do not expect the split to prevent an OOM; it removes this query as a
-contributor and gives the retry a second, smaller shape to try.
+contributor and gives the retry a second, smaller shape to try. The per-table
+fallback gets the SAME retry budget as the union (it used to get one attempt, so
+the target most likely to fail — the largest — had the fewest chances). That
+does not widen the worst case: no retry STARTS past COLLECT_BUDGET_SECONDS, and
+the fallback loop itself breaks at that deadline, so the whole collection is
+bounded by one full retry budget plus one in-flight query per remaining phase.
 
 Retries NEVER weaken the fail-closed property: the last attempt re-raises the
 original exception, so an exhausted retry produces a non-`ok` state and exit 2
@@ -200,8 +214,18 @@ TTL_DATABASE = "system"
 QUERY_ATTEMPTS = 3
 QUERY_BACKOFF_SECONDS = (2.0, 5.0)
 # Wall-clock ceiling on the whole collection, so retries + per-table fallbacks
-# can never approach the unit's TimeoutStartSec (240s). No new attempt STARTS
-# past this; one already in flight can still run out its own `timeout`.
+# can never approach the unit's TimeoutStartSec. No RETRY starts past this, and
+# the per-table fallback loop breaks at it; a query already in flight can still
+# run out its own `timeout`.
+#
+# 🔴 THIS NUMBER IS COUPLED TO `TimeoutStartSec` IN nix/home.nix, AND THE
+# COUPLING IS ASSERTED, NOT COMMENTED. A comment cannot fail. The worst case is
+# ONE phase burning its whole retry budget (QUERY_ATTEMPTS * DEFAULT_TIMEOUT +
+# every backoff = 97s — after which no later retry can start) plus ONE ungated
+# first attempt for each remaining phase (listing, ttl, du = 3 * 30s) = 187s.
+# `test_the_collection_budget_is_pinned_to_the_units_timeout` MEASURES that by
+# simulating the adversary rather than restating the arithmetic, and reads
+# `TimeoutStartSec` out of nix/home.nix rather than re-declaring it here.
 COLLECT_BUDGET_SECONDS = 120.0
 
 STORE_PATH = "/var/lib/clickhouse/store"
@@ -374,6 +398,7 @@ def evaluate(reading, now=None) -> dict:
         "probe_size_threshold": TABLE_PROBE_BYTES,
         "probe_size_matches": len(probe_size),
         "ttl_tables_measured": 0,   # filled in below
+        "ttl_targets_present": 0,   # filled in below
     }
 
     # 🔴 EVERY CHECK RUNS BEFORE ANY GATE RETURNS. The gates below decide
@@ -484,6 +509,35 @@ def evaluate(reading, now=None) -> dict:
                              "rows": row["rows"]}})
 
     controls["ttl_tables_measured"] = measured
+    controls["ttl_targets_present"] = len(present_targets)
+
+    # ---- 6. TTL COVERAGE — a DEGRADED read must not report success ---------
+    # 🔴 THE CONTROL MUST AFFECT THE VERDICT, NOT JUST THE REPORT. Reporting
+    # `ttl_tables_measured` while letting the state stay `ok` produced exit 0
+    # with the detail "1 TTL target(s) measured, all within bound" — a green
+    # unit built on three targets that never answered. And the target most
+    # likely to keep failing its own `min(event_time)` is the LARGEST one, i.e.
+    # the one that would be regrowing, so the most diagnostic reading is the
+    # one that silently drops out.
+    #
+    # WARN, not ALARM: nothing was OBSERVED to be wrong. Distinct from
+    # CANNOT-TELL: zero measured targets is still `no-data` / exit 2 below.
+    unmeasured = [r for r in ttl_report if r["reason"] != "measured"]
+    if unmeasured:
+        findings.append({
+            "check": "ttl-coverage", "level": "warn",
+            "detail": "only %d of %d present TTL target(s) yielded a "
+                      "measurable oldest row (%s) — the TTL verdict covers "
+                      "less than the store, and an unmeasured target is NOT "
+                      "evidence that its TTL is binding"
+                      % (measured, len(present_targets),
+                         ", ".join("%s: %s" % (r["table"], r["reason"])
+                                   for r in unmeasured)),
+            "observed": {"measured": measured,
+                         "present": len(present_targets),
+                         "unmeasured": [{"table": r["table"],
+                                         "reason": r["reason"]}
+                                        for r in unmeasured]}})
 
     # ---- GATES: is this reading EVALUABLE at all? --------------------------
     # Each carries `findings` so a diagnosis already made is not thrown away.
@@ -571,13 +625,16 @@ def _summarize(state, findings, du_bytes, controls) -> str:
         # "0 orphans" is indistinguishable from a check wired to nothing.
         return ("store %s; 0 orphan '*%s' tables (control: %d tables matched "
                 "'*%s'); 0 forbidden log tables; 0 tables over %s (control: %d "
-                "tables over %s); %d TTL target(s) measured, all within bound"
+                "tables over %s); %d of %d TTL target(s) measured, all within "
+                "bound"
                 % (human_bytes(du_bytes), ORPHAN_SUFFIX,
                    controls["probe_suffix_matches"], PROBE_SUFFIX,
                    human_bytes(TABLE_ALARM_BYTES),
                    controls["probe_size_matches"],
                    human_bytes(TABLE_PROBE_BYTES),
-                   controls["ttl_tables_measured"]))
+                   controls["ttl_tables_measured"],
+                   controls.get("ttl_targets_present",
+                                controls["ttl_tables_measured"])))
     return "; ".join(f["detail"] for f in findings)
 
 
@@ -801,7 +858,9 @@ def collect(env=None, timeout: float = DEFAULT_TIMEOUT,
             # a cure. The retry above is the actual fix. If every per-table read
             # ALSO fails we return unreachable exactly as before; and if only
             # some succeed, the `ttl_tables_measured` positive control still
-            # governs — zero measured targets is no-data / exit 2, never `ok`.
+            # governs — zero measured targets is no-data / exit 2, and FEWER
+            # measured than present is the check-6 WARN / exit 3. Neither is
+            # `ok`. A partial answer is a degraded read, not a clean store.
             if not (len(present) > 1 and _is_transient(e)):
                 return {"error": (STATE_UNREACHABLE,
                                   "ttl query failed: %s" % str(e)[:200])}
@@ -810,10 +869,23 @@ def collect(env=None, timeout: float = DEFAULT_TIMEOUT,
                              % str(e)[:200])
             parts = []
             for name in present:
+                # 🔴 THE ONLY THING STOPPING THIS LOOP FROM OUTLIVING THE UNIT.
+                # Nothing inside the loop is bounded by attempt count alone: a
+                # per-table read gets the full retry budget, and a slow one can
+                # burn `timeout` per attempt. This break is what makes the
+                # TimeoutStartSec argument true — the loop starts no NEW target
+                # past the budget, so the overrun is at most one in-flight
+                # query. Reached (with targets left unqueried) by
+                # `test_the_fallback_stops_starting_new_targets_at_the_deadline`.
                 if clock() >= deadline:
                     break
                 try:
-                    parts.append(_q(ttl_query([name]), attempts=1))
+                    # Same retry budget as the union. It used to be ONE attempt,
+                    # which gave the fewest chances to the target most likely to
+                    # fail its own `min(event_time)`: the LARGEST one — the one
+                    # that would be regrowing. The deadline above, not the
+                    # attempt count, is what bounds this.
+                    parts.append(_q(ttl_query([name])))
                 except Exception:  # noqa: BLE001 — that target goes UNMEASURED
                     continue       # (reason "not-queried"), never assumed fine
             if not parts:
@@ -915,8 +987,9 @@ def render_text(v: dict) -> str:
                         c.get("probe_size_matches"),
                         human_bytes(TABLE_ALARM_BYTES),
                         m.get("oversized_count")))
-        lines.append("  TTL tables measured     = %s"
-                     % c.get("ttl_tables_measured"))
+        lines.append("  TTL tables measured     = %s of %s present"
+                     % (c.get("ttl_tables_measured"),
+                        c.get("ttl_targets_present")))
     if m.get("ttl"):
         lines.append("")
         lines.append("%-26s %12s %10s %10s  %s"

--- a/scripts/collector/tests/test_ch_regrowth.py
+++ b/scripts/collector/tests/test_ch_regrowth.py
@@ -31,6 +31,7 @@ Run: pytest scripts/collector/tests/test_ch_regrowth.py
 """
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -325,7 +326,12 @@ def test_the_two_ttl_tiers_actually_differ():
 
 def test_empty_ttl_target_is_not_evidence_and_is_not_stale():
     """min() over an empty table reports the epoch. That must not read as a
-    62-year-old row (a false ALARM) — nor be counted as a measurement."""
+    62-year-old row (a false ALARM) — nor be counted as a measurement.
+
+    It is also not a clean read: 3 of 4 targets measured is degraded TTL
+    coverage, so the verdict is WARN / exit 3 (check 6), not `ok`. What this
+    test pins is that the EMPTY table is not STALE — the coverage warn is a
+    separate finding and must not be an `ttl-effectiveness` alarm."""
     ttl = baseline_ttl()
     ttl[0].update(rows=0, min_event_ts=0)
     v = R.evaluate(baseline_reading(ttl=ttl), now=NOW)
@@ -333,7 +339,9 @@ def test_empty_ttl_target_is_not_evidence_and_is_not_stale():
     assert row["stale"] is False
     assert row["reason"] == "empty"
     assert v["controls"]["ttl_tables_measured"] == 3
-    assert v["state"] == R.STATE_OK
+    assert checks_named(v, "ttl-effectiveness") == []
+    assert v["state"] == R.STATE_WARN
+    assert R.exit_code(v) == R.EXIT_WARN
 
 
 def test_control_pair_ttl_measured_count_moves():
@@ -810,13 +818,17 @@ def test_ttl_union_falls_back_to_one_query_per_table():
 
 def test_a_partial_per_table_fallback_measures_what_it_can():
     """Two targets answer, two do not. The two that answered are real
-    measurements; the two that did not are `not-queried`, never assumed fine."""
+    measurements; the two that did not are `not-queried`, never assumed fine —
+    and the run as a whole is DEGRADED, so it exits 3 rather than reporting a
+    clean store off half a reading."""
     q = per_table_ttl_query(ok_tables={"metric_log", "query_log"})
     v = R.check(env=GOOD_ENV, now=NOW, query=q, du=ok_du, sleep=lambda s: None)
     assert v["controls"]["ttl_tables_measured"] == 2
     unmeasured = {r["table"] for r in v["measurements"]["ttl"]
                   if r["reason"] == "not-queried"}
     assert unmeasured == {"asynchronous_metric_log", "part_log"}
+    assert v["state"] == R.STATE_WARN
+    assert R.exit_code(v) == R.EXIT_WARN
 
 
 def test_a_fallback_that_measures_nothing_is_cannot_tell_not_ok():
@@ -838,8 +850,11 @@ def test_the_retry_schedule_is_pinned_to_literal_values():
     assert R.QUERY_BACKOFF_SECONDS == (2.0, 5.0)
     assert len(R.QUERY_BACKOFF_SECONDS) == R.QUERY_ATTEMPTS - 1
     assert all(s > 0 for s in R.QUERY_BACKOFF_SECONDS)
-    # The whole retry budget must stay well inside the unit's TimeoutStartSec.
-    assert sum(R.QUERY_BACKOFF_SECONDS) * 3 < R.COLLECT_BUDGET_SECONDS
+    # 🔴 The budget's coupling to TimeoutStartSec is NOT asserted here. It used
+    # to be, as `sum(QUERY_BACKOFF_SECONDS) * 3 < COLLECT_BUDGET_SECONDS` —
+    # i.e. `21 < budget`, true of anything >= 22, so the budget could be set to
+    # 100000.0 with the suite still green. The real coupling is measured in
+    # `test_the_collection_budget_is_pinned_to_the_units_timeout`.
 
 
 def test_no_retry_starts_once_the_collection_budget_is_spent():
@@ -855,6 +870,45 @@ def test_no_retry_starts_once_the_collection_budget_is_spent():
     assert v["state"] == R.STATE_UNREACHABLE
     assert slept == [], "a retry started past the budget"
     assert sum(1 for c in q.calls if "now()" in c) == 1
+
+
+def per_table_flaky(failures_by_table):
+    """The UNION always 500s; each per-table read 500s its first
+    `failures_by_table[name]` times and then answers."""
+    rows = {r["table"]: r for r in baseline_ttl()}
+    calls, seen = [], {}
+
+    def q(url, user, password, sql, timeout):
+        calls.append(sql)
+        if "now()" in sql:
+            return "%d\n" % NOW
+        if "FROM system.tables" in sql:
+            return listing_tsv(baseline_tables())
+        if "UNION ALL" in sql:
+            raise memory_limit_500()
+        name = sql.split("'")[1]
+        seen[name] = seen.get(name, 0) + 1
+        if seen[name] <= failures_by_table.get(name, 0):
+            raise memory_limit_500()
+        return ttl_tsv([rows[name]])
+
+    q.calls, q.seen = calls, seen
+    return q
+
+
+def test_the_per_table_fallback_gets_the_same_retry_budget_as_the_union():
+    """🔴 THE REGRESSION. The fallback used to run each target with
+    `attempts=1` — no retry at all — which handed the FEWEST chances to the
+    target most likely to keep failing its own `min(event_time)`: the largest
+    table, i.e. the one that would be regrowing. Measured as call counts on a
+    target that recovers on its LAST allowed attempt."""
+    q = per_table_flaky({"metric_log": R.QUERY_ATTEMPTS - 1})
+    v = R.check(env=GOOD_ENV, now=NOW, query=q, du=ok_du, sleep=lambda s: None)
+    assert q.seen["metric_log"] == R.QUERY_ATTEMPTS
+    # ... and the recovery is what keeps the reading complete.
+    assert v["controls"]["ttl_tables_measured"] == 4
+    assert v["state"] == R.STATE_OK, v["detail"]
+    assert R.exit_code(v) == R.EXIT_OK
 
 
 def test_a_non_transient_ttl_failure_does_not_reach_the_fallback():
@@ -1066,6 +1120,32 @@ def home_nix():
     return HOME_NIX.read_text()
 
 
+def nix_block(home_nix_text, key):
+    """The nix attribute block for `key`, cut at the next TOP-LEVEL comment.
+
+    🔴 NOT a fixed character count. These tests used `[:2000]`, and adding a
+    comment INSIDE the unit pushed `ExecStart` past the window — turning a
+    wiring assertion red for a reason with nothing to do with the wiring, and
+    (worse, in the other direction) it could equally have pushed a forbidden
+    `SuccessExitStatus` out of a "must not contain" assertion's view. Every
+    comment inside a unit is indented 4+ spaces, so a line beginning `\\n  # `
+    is the next top-level thing and a reliable terminator.
+    """
+    assert key in home_nix_text, key
+    after = home_nix_text.split(key)[1]
+    end = after.find("\n  # ")
+    return after if end < 0 else after[:end]
+
+
+def test_the_nix_block_helper_actually_bounds_the_unit(home_nix):
+    """POSITIVE + NEGATIVE control for the helper the wiring tests rely on: it
+    must contain the unit's own last field and NOT the next unit's."""
+    block = nix_block(home_nix, "systemd.user.services.ch-regrowth-check")
+    assert "X-Restart-Triggers" in block          # the unit's last field
+    assert "systemd.user.timers" not in block     # ...and not the next unit
+    assert 0 < len(block) < len(home_nix)
+
+
 def test_unit_and_timer_are_workbench_only(home_nix):
     """The laptop's unresolved nebula fault makes these queries stall, and a
     flaky check gets ignored. Both halves must be serverMode-gated."""
@@ -1077,7 +1157,7 @@ def test_unit_and_timer_are_workbench_only(home_nix):
 
 
 def test_timer_fires_monthly_on_the_11th_and_catches_up(home_nix):
-    block = home_nix.split("systemd.user.timers.ch-regrowth-check")[1][:600]
+    block = nix_block(home_nix, "systemd.user.timers.ch-regrowth-check")
     assert 'OnCalendar = "*-*-11 09:00:00"' in block
     # A missed run with the host off must fire on next boot — the growth this
     # watches for is slow and unattended.
@@ -1087,7 +1167,7 @@ def test_timer_fires_monthly_on_the_11th_and_catches_up(home_nix):
 def test_failure_is_surfaced_through_the_existing_notify_path(home_nix):
     """No new notification mechanism: the repo's OnFailure -> notify-failure@
     template (scripts/notify-failure.sh) is what makes an ALARM loud."""
-    block = home_nix.split("systemd.user.services.ch-regrowth-check")[1][:2000]
+    block = nix_block(home_nix, "systemd.user.services.ch-regrowth-check")
     assert 'OnFailure = [ "notify-failure@%n.service" ]' in block
     # 🔴 SuccessExitStatus would swallow exit 2 (CANNOT TELL) and exit 3 (WARN),
     # turning "could not measure" into a silent success. It must not be set.
@@ -1095,7 +1175,7 @@ def test_failure_is_surfaced_through_the_existing_notify_path(home_nix):
 
 
 def test_unit_runs_the_committed_wrapper_with_its_deps_on_path(home_nix):
-    block = home_nix.split("systemd.user.services.ch-regrowth-check")[1][:2000]
+    block = nix_block(home_nix, "systemd.user.services.ch-regrowth-check")
     assert "scripts/collector/run-regrowth-check.sh" in block
     for dep in ("pkgs.python312", "pkgs.kubectl", "pkgs.sops"):
         assert dep in block, dep
@@ -1121,3 +1201,400 @@ def test_wrapper_fails_closed_when_the_age_key_is_missing(tmp_path):
                             "SOPS_AGE_KEY_FILE": str(tmp_path / "no.key")})
     assert r.returncode == R.EXIT_UNKNOWN, r.stdout + r.stderr
     assert "CANNOT TELL" in r.stderr
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 A DEGRADED READ IS NOT A CLEAN ONE (check 6)
+#
+# The per-table fallback measures what it can. Reporting `ttl_tables_measured`
+# while letting the state stay `ok` gave exit 0 with the detail "1 TTL target(s)
+# measured, all within bound" — a green unit built on three targets that never
+# answered. The control has to affect the VERDICT, not just the report.
+# --------------------------------------------------------------------------- #
+def partial_ttl_reading(measured_tables):
+    """A reading in which only `measured_tables` answered — exactly the shape
+    the per-table fallback leaves behind when some targets keep failing."""
+    return baseline_reading(
+        ttl=[r for r in baseline_ttl() if r["table"] in measured_tables])
+
+
+def test_a_partial_ttl_read_warns_instead_of_reporting_success():
+    """🔴 THE REGRESSION, at its worst point: ONE of four targets answered and
+    every other check is clean."""
+    v = R.evaluate(partial_ttl_reading({"metric_log"}), now=NOW)
+    assert v["controls"]["ttl_tables_measured"] == 1
+    assert v["controls"]["ttl_targets_present"] == 4
+    assert v["state"] == R.STATE_WARN
+    assert R.exit_code(v) == R.EXIT_WARN
+    f = checks_named(v, "ttl-coverage")
+    assert len(f) == 1 and f[0]["level"] == "warn"
+    # Pin THIS finding's own numbers and its own wording: asserting only the
+    # state would stay green if some other check started warning instead.
+    assert "1 of 4" in f[0]["detail"], f[0]["detail"]
+    assert {u["table"] for u in f[0]["observed"]["unmeasured"]} == {
+        "asynchronous_metric_log", "part_log", "query_log"}
+    # The old, false headline must be gone — not merely outranked.
+    assert "all within bound" not in v["detail"], v["detail"]
+
+
+def test_full_partial_none_and_stale_ttl_reads_are_four_DIFFERENT_verdicts():
+    """🔴 The WARN must not collapse into ALARM or into CANNOT-TELL. Four
+    readings that differ ONLY in their TTL rows must produce four distinct
+    (state, exit) pairs — a single point could not tell them apart."""
+    stale_ttl = [dict(r, min_event_ts=NOW - 40 * 86400) for r in baseline_ttl()]
+    got = [(R.evaluate(reading, now=NOW)["state"],
+            R.exit_code(R.evaluate(reading, now=NOW)))
+           for reading in (baseline_reading(),
+                           partial_ttl_reading({"metric_log"}),
+                           partial_ttl_reading(set()),
+                           baseline_reading(ttl=stale_ttl))]
+    assert got == [(R.STATE_OK, R.EXIT_OK),
+                   (R.STATE_WARN, R.EXIT_WARN),
+                   (R.STATE_NO_DATA, R.EXIT_UNKNOWN),
+                   (R.STATE_ALARM, R.EXIT_ALARM)]
+    assert len({s for s, _ in got}) == 4
+    assert len({c for _, c in got}) == 4
+
+
+def test_a_stale_row_outranks_the_coverage_warn():
+    """A degraded read that ALSO caught a non-binding TTL is an ALARM. The WARN
+    must not downgrade the worst thing found."""
+    ttl = [dict(r) for r in baseline_ttl() if r["table"] in ("metric_log",
+                                                            "part_log")]
+    ttl[0]["min_event_ts"] = NOW - 40 * 86400
+    v = R.evaluate(baseline_reading(ttl=ttl), now=NOW)
+    assert v["warns"] == 1 and v["alarms"] == 1, v["findings"]
+    assert v["state"] == R.STATE_ALARM
+    assert R.exit_code(v) == R.EXIT_ALARM
+
+
+def test_zero_measured_targets_is_still_cannot_tell_not_merely_a_warn():
+    """🔴 The fail-closed boundary the WARN must not erode. Nothing measured is
+    CANNOT TELL (exit 2) — a louder verdict than degraded coverage."""
+    v = R.evaluate(partial_ttl_reading(set()), now=NOW)
+    assert v["state"] == R.STATE_NO_DATA
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+    assert "positive control FAILED" in v["detail"]
+    # ...and the coverage finding is carried through the gate, not dropped.
+    assert checks_named(v, "ttl-coverage")
+
+
+def test_a_degraded_fallback_read_exits_three_end_to_end():
+    """The same thing as the operator meets it: a live-shaped run whose union
+    500s and whose per-table reads mostly fail."""
+    q = per_table_ttl_query(ok_tables={"metric_log"})
+    v = R.check(env=GOOD_ENV, now=NOW, query=q, du=ok_du, sleep=lambda s: None)
+    assert v["controls"]["ttl_tables_measured"] == 1
+    assert v["state"] == R.STATE_WARN
+    assert R.exit_code(v) == R.EXIT_WARN
+    assert checks_named(v, "ttl-coverage")
+
+
+def test_cli_degraded_ttl_read_exits_three(tmp_path):
+    """At the process boundary — the layer systemd actually reads, and where
+    exit 3 becomes the OnFailure toast."""
+    r = run_cli(["--json", "--now", str(NOW)],
+                partial_ttl_reading({"metric_log"}), tmp_path)
+    assert r.returncode == R.EXIT_WARN, r.stdout + r.stderr
+    v = json.loads(r.stdout)
+    assert v["state"] == R.STATE_WARN
+    assert "ttl-coverage" in {f["check"] for f in v["findings"]}
+
+
+def test_the_coverage_control_pair_reports_both_numbers():
+    """The zero-with-its-evidence rule applied to coverage: `ok` must state how
+    many of how many were measured, never a bare count."""
+    v = R.evaluate(baseline_reading(), now=NOW)
+    assert v["state"] == R.STATE_OK
+    assert "4 of 4 TTL target(s) measured" in v["detail"], v["detail"]
+    assert "4 of 4 present" in R.render_text(v)
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE FALLBACK'S DEADLINE BREAK — the guard the TimeoutStartSec argument
+# leans on, and which no test reached (mutating it to `if False:` was green).
+# --------------------------------------------------------------------------- #
+class AdvanceableClock:
+    """A clock the fake server moves, so the deadline is crossed by simulated
+    elapsed time rather than by a scripted tick sequence that could just as
+    easily be crossing it somewhere else."""
+
+    def __init__(self):
+        self.t = 0.0
+
+    def __call__(self):
+        return self.t
+
+
+def deadline_tripping_query(clock, jump_after=1):
+    """UNION always 500s. Per-table reads answer, but the `jump_after`-th one
+    pushes the clock past COLLECT_BUDGET_SECONDS on its way out."""
+    rows = {r["table"]: r for r in baseline_ttl()}
+    calls = []
+
+    def per_table_calls():
+        return [c for c in calls if "UNION ALL" not in c and " AS t," in c]
+
+    def q(url, user, password, sql, timeout):
+        calls.append(sql)
+        if "now()" in sql:
+            return "%d\n" % NOW
+        if "FROM system.tables" in sql:
+            return listing_tsv(baseline_tables())
+        if "UNION ALL" in sql:
+            raise memory_limit_500()
+        name = sql.split("'")[1]
+        if len(per_table_calls()) >= jump_after:
+            clock.t = R.COLLECT_BUDGET_SECONDS + 1.0
+        return ttl_tsv([rows[name]])
+
+    q.calls, q.per_table_calls = calls, per_table_calls
+    return q
+
+
+def test_the_fallback_stops_starting_new_targets_at_the_deadline():
+    """🔴 REACHABILITY, not just breakability. The first per-table read SUCCEEDS
+    and spends the budget; the remaining three are then never ATTEMPTED — which
+    is this guard's own observable behaviour and nothing else's:
+
+      * no earlier gate rejects this case — the run reaches a real verdict with
+        a real `du` reading, not a CANNOT-TELL;
+      * the three unqueried targets are `not-queried` because they were never
+        SENT, not because they failed (the fake would have answered them);
+      * with the break removed, all four are queried and the verdict is `ok`,
+        so this test fails on the count, not on a different guard's error.
+    """
+    clock = AdvanceableClock()
+    q = deadline_tripping_query(clock)
+    v = R.check(env=GOOD_ENV, now=NOW, query=q, du=ok_du, sleep=lambda s: None,
+                clock=clock)
+
+    per_table = q.per_table_calls()
+    assert len(per_table) == 1, per_table
+    assert "'asynchronous_metric_log'" in per_table[0]
+    for name in ("metric_log", "part_log", "query_log"):
+        assert not any("'%s'" % name in c for c in per_table), name
+
+    assert v["controls"]["ttl_tables_measured"] == 1
+    assert {r["table"] for r in v["measurements"]["ttl"]
+            if r["reason"] == "not-queried"} == {"metric_log", "part_log",
+                                                 "query_log"}
+    # A degraded reading, not an unevaluable one — the break is on the path to a
+    # verdict, so a test that only checked for "some non-ok state" would also
+    # pass with the break deleted.
+    assert v["state"] == R.STATE_WARN
+    assert R.exit_code(v) == R.EXIT_WARN
+
+
+def test_the_deadline_break_fixture_can_reach_every_target():
+    """POSITIVE CONTROL for the fixture above: with the clock never advanced,
+    the SAME fake answers all four targets. Without this, `1 per-table call`
+    could just as well mean the fake was broken."""
+    clock = AdvanceableClock()
+    q = deadline_tripping_query(clock, jump_after=99)
+    v = R.check(env=GOOD_ENV, now=NOW, query=q, du=ok_du, sleep=lambda s: None,
+                clock=clock)
+    assert len(q.per_table_calls()) == 4
+    assert v["controls"]["ttl_tables_measured"] == 4
+    assert v["state"] == R.STATE_OK, v["detail"]
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE COLLECTION BUDGET IS COUPLED TO `TimeoutStartSec` — MEASURED
+#
+# The old assertion was `sum(QUERY_BACKOFF_SECONDS) * 3 < COLLECT_BUDGET_SECONDS`
+# -> `21 < budget`, satisfied by any value >= 22: setting the budget to 100000.0
+# left the whole suite green. That is a comment wearing an assert's clothes.
+# These simulate the adversary that MAXIMISES wall clock and compare the result
+# with the TimeoutStartSec actually written in nix/home.nix — read from there,
+# not restated here, so the two cannot drift apart.
+# --------------------------------------------------------------------------- #
+def unit_timeout_start_sec(home_nix_text):
+    block = nix_block(home_nix_text, "systemd.user.services.ch-regrowth-check")
+    m = re.search(r"TimeoutStartSec\s*=\s*(\d+)", block)
+    assert m, "TimeoutStartSec not found in the ch-regrowth-check unit"
+    return float(m.group(1))
+
+
+class WallClockSim:
+    """Every attempt burns `cost(phase)` seconds and fails TRANSIENTLY whenever
+    a retry would still be permitted — forcing the retry — and succeeds
+    otherwise. That is the worst case by construction: a phase that failed when
+    no retry was permitted would END the collection early, i.e. sooner."""
+
+    def __init__(self, cost, always_fail=()):
+        self.t = 0.0
+        self.cost = cost
+        self.always_fail = set(always_fail)
+        self.attempts = {}
+        self.deadline = R.COLLECT_BUDGET_SECONDS   # the clock starts at 0.0
+
+    def clock(self):
+        return self.t
+
+    def sleep(self, seconds):
+        self.t += seconds
+
+    @staticmethod
+    def phase(sql):
+        if "now()" in sql:
+            return "now"
+        if "FROM system.tables" in sql:
+            return "listing"
+        if "UNION ALL" in sql:
+            return "union"
+        return "per-table:" + sql.split("'")[1]
+
+    def query(self, url, user, password, sql, timeout):
+        ph = self.phase(sql)
+        self.t += self.cost(ph, timeout)
+        n = self.attempts[ph] = self.attempts.get(ph, 0) + 1
+        if ph.split(":")[0] in self.always_fail:
+            raise memory_limit_500()
+        if n < R.QUERY_ATTEMPTS:
+            back = R.QUERY_BACKOFF_SECONDS[
+                min(n - 1, len(R.QUERY_BACKOFF_SECONDS) - 1)]
+            if self.t + back < self.deadline:
+                raise memory_limit_500()
+        if ph == "now":
+            return "%d\n" % NOW
+        if ph == "listing":
+            return listing_tsv(baseline_tables())
+        if ph == "union":
+            return ttl_tsv(baseline_ttl())
+        name = ph.split(":", 1)[1]
+        return ttl_tsv([r for r in baseline_ttl() if r["table"] == name])
+
+    def du(self, argv, timeout):
+        self.t += self.cost("du", timeout)
+        return ok_du(argv, timeout)
+
+
+def test_the_collection_budget_is_pinned_to_the_units_timeout(home_nix):
+    """🔴 THE COUPLING, MEASURED. One phase burns its whole retry budget
+    (3 * 30s + 2s + 5s = 97s), after which no LATER retry can start because
+    `clock() + backoff >= deadline`; each remaining phase (listing, ttl, du)
+    then gets exactly one ungated 30s attempt. 97 + 90 = 187s against a
+    TimeoutStartSec of 240."""
+    # Literal pins: reading a constant back would hold for any value.
+    assert R.COLLECT_BUDGET_SECONDS == 120.0
+    assert R.DEFAULT_TIMEOUT == 30.0
+
+    sim = WallClockSim(cost=lambda ph, timeout: timeout)
+    v = R.check(env=GOOD_ENV, now=NOW, query=sim.query, du=sim.du,
+                sleep=sim.sleep, clock=sim.clock)
+    # POSITIVE CONTROLS for the sim: it must have driven the check all the way
+    # to a verdict AND actually retried. A sim that fell over early would report
+    # a reassuringly small elapsed time.
+    assert v["state"] == R.STATE_OK, v["detail"]
+    assert sim.attempts["now"] == R.QUERY_ATTEMPTS
+    assert sim.attempts["listing"] == 1
+    assert sim.t == 187.0, sim.attempts
+
+    limit = unit_timeout_start_sec(home_nix)
+    assert limit > 0
+    assert sim.t < limit, (sim.t, limit)
+
+
+def test_the_per_table_fallback_cannot_outlive_the_units_timeout(home_nix):
+    """The other shape: the union fails fast (as `Code: 241` does) and the
+    fallback runs, each target retrying. The loop's deadline break is what
+    bounds this — the overrun past the budget is one in-flight query."""
+    sim = WallClockSim(
+        cost=lambda ph, timeout: (0.0 if ph in ("now", "listing", "union")
+                                  else timeout),
+        always_fail=("union",))
+    v = R.check(env=GOOD_ENV, now=NOW, query=sim.query, du=sim.du,
+                sleep=sim.sleep, clock=sim.clock)
+    assert sim.attempts["union"] == R.QUERY_ATTEMPTS
+    assert [k for k in sim.attempts if k.startswith("per-table:")], sim.attempts
+    assert v["state"] == R.STATE_WARN, v["detail"]   # 2 of 4 measured
+    # 21s of fast-failing retries across now/listing/union, then two per-table
+    # targets at 30s+ each, the second of which starts at 118s and overruns the
+    # budget; the third is never started. 148 + one 30s `du` = 178.
+    assert sim.t == 178.0, sim.attempts
+    assert sim.t < unit_timeout_start_sec(home_nix)
+
+
+def test_the_wallclock_sim_would_notice_an_unbounded_budget(home_nix):
+    """🔴 NEGATIVE CONTROL FOR THE HARNESS. Point the same sim at a budget that
+    no longer bounds anything (the `COLLECT_BUDGET_SECONDS = 100000.0` mutation
+    the old assertion could not see) and it must blow past TimeoutStartSec. A
+    coupling test that cannot go red proves nothing about the coupling."""
+    real = R.COLLECT_BUDGET_SECONDS
+    try:
+        R.COLLECT_BUDGET_SECONDS = 100000.0
+        sim = WallClockSim(cost=lambda ph, timeout: timeout)
+        R.check(env=GOOD_ENV, now=NOW, query=sim.query, du=sim.du,
+                sleep=sim.sleep, clock=sim.clock)
+    finally:
+        R.COLLECT_BUDGET_SECONDS = real
+    assert R.COLLECT_BUDGET_SECONDS == 120.0
+    assert sim.t > unit_timeout_start_sec(home_nix), sim.t
+
+
+# --------------------------------------------------------------------------- #
+# `_is_transient` — which failures are worth a retry
+#
+# All three of these mutate in the FAIL-CLOSED direction, so none was a live
+# risk; all three were untested, so the sweep could not see them.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("exc", [
+    ConnectionResetError("Connection reset by peer"),
+    ConnectionRefusedError("Connection refused"),
+    urllib.error.URLError("[Errno 111] Connection refused"),
+    OSError("[Errno 101] Network is unreachable"),
+])
+def test_a_connection_level_failure_is_retried(exc):
+    """A pod restart — the COMMONEST transient here — arrives as a connection
+    error, not an HTTP status. Nothing asserted that it is retried."""
+    assert R._is_transient(exc) is True, exc
+
+
+def test_a_pod_restart_mid_check_is_retried_end_to_end():
+    """The same thing through `check`, so the branch is proven REACHED and not
+    merely correct in isolation."""
+    slept = []
+    q = flaky_query(good_responses(), "UNION ALL", 2,
+                    exc_factory=lambda: ConnectionResetError(
+                        "Connection reset by peer"))
+    v = R.check(env=GOOD_ENV, now=NOW, query=q, du=ok_du, sleep=slept.append)
+    assert v["state"] == R.STATE_OK, v["detail"]
+    assert sum(1 for c in q.calls if "UNION ALL" in c) == R.QUERY_ATTEMPTS
+    assert slept == list(R.QUERY_BACKOFF_SECONDS)
+
+
+def test_a_urlerror_wrapping_a_timeout_is_not_retried():
+    """🔴 A URLError IS an OSError, so the catch-all would retry it. A read that
+    already burned the full per-query budget must not burn it again — that is
+    what keeps the worst case bounded."""
+    exc = urllib.error.URLError(TimeoutError("timed out"))
+    assert R._is_transient(exc) is False
+    # And a URLError wrapping anything else still IS retried, so this is a
+    # guard about timeouts and not a blanket refusal of URLError.
+    assert R._is_transient(urllib.error.URLError(OSError("reset"))) is True
+
+    slept = []
+    q = flaky_query(good_responses(), "now()", 99, exc_factory=lambda: exc)
+    v = R.check(env=GOOD_ENV, now=NOW, query=q, du=ok_du, sleep=slept.append)
+    assert R.exit_code(v) == R.EXIT_UNKNOWN
+    assert sum(1 for c in q.calls if "now()" in c) == 1
+    assert slept == []
+
+
+def test_a_429_is_retried_and_the_other_4xx_are_not():
+    """429 is a server saying "later", not a server that has answered."""
+    def http(code):
+        return urllib.error.HTTPError("http://ch.invalid:8123/", code,
+                                      "status %d" % code, {}, None)
+
+    assert R._is_transient(http(429)) is True
+    assert R._is_transient(http(500)) is True
+    for code in (400, 401, 403, 404, 428, 430):
+        assert R._is_transient(http(code)) is False, code
+
+    slept = []
+    q = flaky_query(good_responses(), "now()", 2, exc_factory=lambda: http(429))
+    v = R.check(env=GOOD_ENV, now=NOW, query=q, du=ok_du, sleep=slept.append)
+    assert v["state"] == R.STATE_OK, v["detail"]
+    assert sum(1 for c in q.calls if "now()" in c) == R.QUERY_ATTEMPTS


### PR DESCRIPTION
Four follow-up findings on the ClickHouse regrowth check (#354). ⏰ The timer's
first-ever real firing is **2026-08-11 09:01 CDT** — the first run that can
observe whether the TTLs actually bind, which is the entire reason the check
exists. This needs to be merged **and deployed** before then.

## 1. 🔴 A degraded read reported SUCCESS

If the TTL union failed and the per-table fallback only got answers for *some*
targets, the verdict was `state=ok`, **exit 0**, detail
`"1 TTL target(s) measured, all within bound"`. The `ttl_tables_measured`
positive control was *reported* but did not affect the *verdict*.

Why it is the important one: the table most likely to persistently fail its own
`min(event_time)` is the **largest** one — i.e. the one that would be regrowing
— and per-table fallbacks ran with `attempts=1`, no retry at all. So the single
most diagnostic target was the one most likely to drop out, leaving a green
unit.

**Fix:** `measured < len(present_targets)` emits a warn-level `ttl-coverage`
finding → **exit 3**. Deliberately distinct from ALARM (1: something was
*observed* to be wrong) and from CANNOT-TELL (2: **zero** measured targets is
still `no-data`).

The per-table fallback also gets the union's retry budget. **Measured before
claimed:** the simulation test shows this does *not* widen the worst case,
because the deadline — not the attempt count — is what bounds the fallback.

## 2. The fallback's deadline break was unreachable in tests

`if clock() >= deadline: break` — mutating it to `if False:` left all 92 tests
green, and it is the guard the `TimeoutStartSec` safety argument leans on.

Reachability, not just breakability: the new test drives a case **no earlier
gate rejects** — the first target *succeeds* and spends the budget, the run
reaches a real verdict with a real `du` reading, and the remaining three targets
are never **attempted** (not "failed"). That is this guard's own observable
behaviour; with the break deleted all four are queried and the verdict is `ok`,
so the test fails on the count rather than on some other guard's error. A
fixture positive control proves the same fake *can* answer all four.

## 3. `COLLECT_BUDGET_SECONDS` was coupled to `TimeoutStartSec` by comment only

Setting it to `100000.0` left the suite green: the only assertion was
`sum(QUERY_BACKOFF_SECONDS) * 3 < COLLECT_BUDGET_SECONDS` → `21 < budget`, true
of any value ≥ 22.

Replaced with a **simulation of the adversary that maximises wall clock**,
compared against the `TimeoutStartSec` read out of `nix/home.nix` (one rule, one
place) — plus a **negative control** that points the same simulation at an
unbounded budget and asserts it blows past the unit timeout, so the coupling
test is proven able to go red.

Measured worst case **187 s** (one phase burning its full 3-attempt budget at
97 s, then three phases × one ungated 30 s first attempt) and **178 s** through
the per-table fallback, against `TimeoutStartSec = 240`.

The nix comment said `"120 + one in-flight 30s query + the du exec"` (~180) —
that understates it by one whole query phase, because only *retries* are
deadline-gated. Conclusion holds; comment fixed.

## 4. A false claim in an always-loaded-on-trigger doc

`claude/skills/activity/SKILL.md` still said `min(event_time)` younger than
**TTL+1d**; the bounds were widened to **TTL+3d** (10d / 17d). Also now
documents the retry / per-table fallback and the exit-3 degraded state.
**Net +1 byte** — the duplicated 2026-08-03 source-correction prose was evicted
in the same edit rather than only appending.

## 5. Three unproven guards in `_is_transient`

All mutate fail-closed, so no live risk, but all were untested: the
connection-level catch-all (a **pod restart** — the commonest transient — had no
test that it is retried), the `URLError(reason=TimeoutError)` guard, and
`exc.code == 429`. Tested, unit + end-to-end.

## Also

The nix wiring tests read the unit through a fixed `[:2000]` window, so adding a
comment inside the unit pushed `ExecStart` out of view and turned a wiring
assertion red for an unrelated reason — and could equally have pushed a
forbidden `SuccessExitStatus` out of a "must not contain" assertion's view.
Replaced with a helper that cuts at the next top-level attribute, with its own
positive/negative controls.

## Not regressed

- **Fail-closed holds.** Exhausted retries still produce a non-clean verdict and
  exit 2; no path reaches `ok` on a read that failed.
- Host gating (`lib.mkIf serverMode`), `OnCalendar = "*-*-11 09:00:00"` and
  secret handling untouched.
- Exit semantics unchanged: `0 ok · 1 ALARM · 2 CANNOT TELL · 3 WARN`, every
  non-zero routed to the failure toast.

## Verification

**Red/green matrix** — 12 tests **red at `origin/main`** (the pre-fix
`ch_regrowth.py`, unchanged since `3d04ad5`), **green at HEAD**:

```
test_a_partial_ttl_read_warns_instead_of_reporting_success
test_full_partial_none_and_stale_ttl_reads_are_four_DIFFERENT_verdicts
test_a_stale_row_outranks_the_coverage_warn
test_zero_measured_targets_is_still_cannot_tell_not_merely_a_warn
test_a_degraded_fallback_read_exits_three_end_to_end
test_cli_degraded_ttl_read_exits_three
test_the_coverage_control_pair_reports_both_numbers
test_the_fallback_stops_starting_new_targets_at_the_deadline
test_the_per_table_fallback_gets_the_same_retry_budget_as_the_union
test_the_per_table_fallback_cannot_outlive_the_units_timeout
test_a_partial_per_table_fallback_measures_what_it_can        (extended)
test_empty_ttl_target_is_not_evidence_and_is_not_stale        (extended)
```

**Labelled INVARIANT GUARDS** — green pre-fix, so *not* regression coverage;
added to close mutation gaps: the three `_is_transient` tests,
`test_the_deadline_break_fixture_can_reach_every_target`,
`test_the_collection_budget_is_pinned_to_the_units_timeout`,
`test_the_wallclock_sim_would_notice_an_unbounded_budget`,
`test_the_nix_block_helper_actually_bounds_the_unit`.

**Mutation battery — 70 mutants, 70 KILLED, 0 survived, 0 unapplied.** Full
re-run (a review fix resets the gate), not just mutants for what changed;
constructed differently from the previous sweep — grouped by *kind* (constants,
boundary operators, boolean logic, guard deletion, control flow, exit mapping)
and extended to 3 **nix** mutants. Includes a negative control (the unmutated
copy must be green — it was, 113 passed) and an **exactly-once** assertion on
every replacement pattern, so a mutant that silently matched zero times cannot
masquerade as killed.

The same battery run against **`origin/main`** (pre-fix module *and* pre-fix
tests) — measured, not asserted — gives **54 killed / 10 SURVIVED / 6 not
applicable**:

```
SURVIVED at origin/main, KILLED at HEAD (10):
  budget-unbounded  budget-doubled  default-timeout-huge  exit-warn-is-alarm
  http-429-dropped  http-429-to-431  fallback-deadline-break
  transient-conn-catchall  transient-urlerror-timeout  nix-timeout-too-small

NOT APPLICABLE at origin/main — the code does not exist there (6):
  coverage-lt-to-ne  coverage-warn-deleted  coverage-warn-to-info
  coverage-count-reported-only  fallback-attempts-one
  summarize-hides-coverage        (all KILLED at HEAD)
```

`exit-warn-is-alarm` surviving is the finding-1 hole in miniature: nothing
distinguished exit 3 from exit 1, because every assertion read the constant back
instead of pinning the number.

**Gates (counted, not exit codes)**

```
nix build .#checks.x86_64-linux.pytests
  TOTAL collected=6507  passed=6506  skipped=1  failed=0  (floor: 5600)
  RESULT: PASS                      # the runner's final line
  no test removed: 0 deleted `def test_` in the diff

nix build .#checks.x86_64-linux.nodetests
  TOTAL suites=3 files=30 tests=1024 pass=1024 fail=0 skipped=0  (floor: 970)
  RESULT: PASS

nix-instantiate --parse nix/home.nix   OK
```

**NOT deployed.** `home-manager switch` is the operator's step — and it must
happen before 2026-08-11 09:01 CDT, or the first firing runs the old code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
