### PR TITLE
fix(rig-control): brightness restore after sleep + kill orphaned fade children

### DIFF
--- a/scripts/claude-hooks/tests/test_guard_core.py
+++ b/scripts/claude-hooks/tests/test_guard_core.py
@@ -409,6 +409,93 @@ def test_add_all_and_reset_hard_now_agree_about_the_global_option_hop():
 
 
 # --------------------------------------------------------------------------- #
+# 1c. 🔴 `git add <specific-files>` stays allowed
+#
+# Closes a false positive from the opencode.jsonc deny glob `"*git*add ."` which
+# matched `git add clusters/foo.yaml` (glob `*` consumed the path, `.` matched
+# the dot in `foo.yaml`). The guard_core.py argv parser is correct —
+# _stages_everything() properly tokenizes arguments and only flags `-A`, `--all`,
+# `.`, `..`, `*`, `$PWD` — but the glob backstop over-blocked.
+#
+# After the fix (removing `"*git*add ."` from opencode.jsonc), these cases
+# exercise guard_core.py directly to pin that specific-file staging stays allowed.
+# --------------------------------------------------------------------------- #
+ADD_ALL_DENY = [
+    "git add -A",
+    "git add --all",
+    "git add .",
+    "git add ..",
+    "git add *",
+    "git add -Av",
+    "git add -A -- foo",
+    "git -C /tmp/x add -A",
+    "VAR=1 git add .",
+    "sudo git add .",
+    "sudo -n git -C /tmp/x add -A",
+    "env git add .",
+    "timeout 60 git add .",
+    "bash -c 'git add .'",
+    "echo ok && git add .",
+    "cd /tmp && git add .",
+]
+
+ADD_ALL_ALLOW = [
+    "git add clusters/foo.yaml",
+    "git add src/main.py",
+    "git add -p",
+    "git add --interactive",
+    "git add clusters/workbench/apps/media-stack/kustomization.yaml",
+    "git -C /tmp/x add src/main.py",
+    "VAR=1 git add src/main.py",
+    "sudo git add src/main.py",
+    "git status",
+    "git diff",
+]
+
+
+@pytest.mark.parametrize("command", ADD_ALL_DENY)
+def test_git_add_all_denies_all_staging_spelling(command):
+    """DENY cases — commands that stage the whole tree must be caught.
+
+    These exercise check_git_add_all directly and via evaluate() under both
+    policies (the check is in both claude-code and opencode).
+    """
+    assert gc.check_git_add_all(command) is not None, f"check_git_add_all missed: {command!r}"
+    assert gc.evaluate(command, "claude-code") is not None, f"evaluate missed (claude-code): {command!r}"
+    assert gc.evaluate(command, "opencode") is not None, f"evaluate missed (opencode): {command!r}"
+
+
+@pytest.mark.parametrize("command", ADD_ALL_ALLOW)
+def test_git_add_specific_files_stays_allowed(command):
+    """ALLOW cases — staging specific files must not be blocked.
+
+    This is the false positive that motivated removing `"*git*add ."` from
+    opencode.jsonc. The argv parser in _stages_everything() correctly
+    distinguishes `-A`/`.` from specific file paths; pin it here so a
+    regression cannot re-introduce the glob's over-matching.
+    """
+    assert gc.check_git_add_all(command) is None, f"check_git_add_all false-positived: {command!r}"
+    assert gc.evaluate(command, "claude-code") is None, f"evaluate false-positived (claude-code): {command!r}"
+    assert gc.evaluate(command, "opencode") is None, f"evaluate false-positived (opencode): {command!r}"
+
+
+def test_git_add_escape_hatch_message_stays_denied():
+    """The escape hatch: merely QUOTING `git add .` in a message still denies.
+
+    check_git_add_all matches raw text, so a commit message mentioning the
+    blocked shape is caught — the same deliberate false-positive convention
+    the other checks follow. The deny message includes the escape hatch
+    (Write tool + commit -F / --body-file).
+    """
+    cmd = 'git commit -m "never use git add ."'
+    reason = gc.check_git_add_all(cmd)
+    assert reason is not None, "quoted mention of git add . must still be caught"
+    assert "commit -F" in reason
+    assert "--body-file" in reason
+    assert "Write tool" in reason
+
+
+# --------------------------------------------------------------------------- #
 # 2. the parser
 # --------------------------------------------------------------------------- #
 @pytest.mark.parametrize("text,expected_first_argv", [

--- a/scripts/monitor-blackout.sh
+++ b/scripts/monitor-blackout.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 DDC=$(command -v ddcutil) || { echo "ddcutil not found on PATH" >&2; exit 1; }
 UNIT=monitor-blackout-restore
 STATE="${XDG_RUNTIME_DIR:-/tmp}/monitor-blackout.state"   # "bus:brightness"
+FADE_PID_FILE="${XDG_RUNTIME_DIR:-/tmp}/monitor-blackout.fade.pid"
 
 # Number of fade steps and inter-step delay for fade transitions.
 # ~560ms per ddcutil call (hard floor at --sleep-multiplier 0.1), so 15 steps
@@ -44,8 +45,14 @@ get_brightness() { # $1=bus  -> current VCP 0x10 value
   "$DDC" --bus "$1" getvcp 10 --brief 2>/dev/null | awk '{print $4}'
 }
 
-set_brightness() { # $1=bus $2=value
-  "$DDC" --bus "$1" setvcp 10 "$2" --noverify 2>/dev/null
+set_brightness() { # $1=bus $2=value  — retries 3x on DDC-CI failure (this LG panel is flaky)
+  local bus="$1" val="$2" attempt
+  for attempt in 1 2 3; do
+    "$DDC" --bus "$bus" setvcp 10 "$val" --noverify 2>/dev/null && return 0
+    sleep 0.5
+  done
+  echo "DDC-CI setvcp failed after 3 attempts on bus $bus (val=$val)" >&2
+  return 1
 }
 
 cancel_timer() {
@@ -77,9 +84,22 @@ blackout() {
 
 restore() {
   cancel_timer
+  # Kill any running background fade (sleep was triggered but wake came before it finished)
+  if [ -f "$FADE_PID_FILE" ]; then
+    local fpid
+    fpid=$(cat "$FADE_PID_FILE" 2>/dev/null || true)
+    rm -f "$FADE_PID_FILE"
+    if [ -n "$fpid" ] && kill -0 "$fpid" 2>/dev/null; then
+      kill "$fpid" 2>/dev/null || true
+      sleep 0.5
+    fi
+  fi
   local bus="" cur=""
   [ -f "$STATE" ] && IFS=: read -r bus cur < "$STATE" || true
-  bus="${bus:-$(detect_bus || true)}"; cur="${cur:-60}"
+  bus="${bus:-$(detect_bus || true)}"
+  # Saved brightness of 0 means blackout read while monitor was already dark
+  # (race with prior fade) — fall back to a usable default instead of staying dark.
+  [ -n "$cur" ] && [ "$cur" != "0" ] || cur=60
   [ -n "$bus" ] || { echo "no DDC/CI monitor detected" >&2; exit 1; }
   set_brightness "$bus" "$cur"
   rm -f "$STATE"
@@ -92,7 +112,7 @@ fade_to_zero() { # $1=bus $2=from_brightness
     val=$(( from + (to - from) * i / FADE_STEPS ))
     set_brightness "$bus" "$val" &
     sleep "$FADE_DELAY"
-    wait
+    wait || true
   done
 }
 
@@ -102,7 +122,7 @@ fade_from_zero() { # $1=bus $2=to_brightness
     val=$(( from + (to - from) * i / FADE_STEPS ))
     set_brightness "$bus" "$val" &
     sleep "$FADE_DELAY"
-    wait
+    wait || true
   done
 }
 
@@ -113,9 +133,11 @@ fade_blackout() {
   cur=$(get_brightness "$bus") || true
   [ -n "${cur:-}" ] || { echo "could not read brightness on bus $bus" >&2; exit 1; }
   printf '%s:%s\n' "$bus" "$cur" > "$STATE"
+  echo "$$" > "$FADE_PID_FILE"
 
   fade_to_zero "$bus" "$cur"
 
+  rm -f "$FADE_PID_FILE"
   cancel_timer
   schedule_restore "$bus" "$cur" "$dur"
   echo "Monitor faded to black (bus $bus, was $cur/100). Auto-restore in $dur — or: $0 restore"
@@ -125,7 +147,8 @@ fade_restore() {
   cancel_timer
   local bus="" cur=""
   [ -f "$STATE" ] && IFS=: read -r bus cur < "$STATE" || true
-  bus="${bus:-$(detect_bus || true)}"; cur="${cur:-60}"
+  bus="${bus:-$(detect_bus || true)}"
+  [ -n "$cur" ] && [ "$cur" != "0" ] || cur=60
   [ -n "$bus" ] || { echo "no DDC/CI monitor detected" >&2; exit 1; }
 
   fade_from_zero "$bus" "$cur"

--- a/scripts/monitor-blackout.sh
+++ b/scripts/monitor-blackout.sh
@@ -61,8 +61,11 @@ cancel_timer() {
 }
 
 schedule_restore() { # $1=bus $2=original_brightness $3=duration
+  # Write saved brightness so `restore` can read it; use the script itself
+  # (with retry + 0-default) instead of raw ddcutil.
+  printf '%s:%s\n' "$1" "$2" > "$STATE"
   systemd-run --user --unit="$UNIT" --on-active="$3" --timer-property=AccuracySec=1s \
-    "$DDC" --bus "$1" setvcp 10 "$2" >/dev/null
+    "$0" restore >/dev/null
 }
 
 # --- actions ---------------------------------------------------------------
@@ -107,22 +110,20 @@ restore() {
 }
 
 fade_to_zero() { # $1=bus $2=from_brightness
-  local bus="$1" from="$2" to=0 i val
-  for (( i=0; i<=FADE_STEPS; i++ )); do
+  local bus="$1" from="$2" to=0 val i
+  for i in $(seq 0 $FADE_STEPS); do
     val=$(( from + (to - from) * i / FADE_STEPS ))
-    set_brightness "$bus" "$val" &
+    set_brightness "$bus" "$val"
     sleep "$FADE_DELAY"
-    wait || true
   done
 }
 
 fade_from_zero() { # $1=bus $2=to_brightness
-  local bus="$1" to="$2" from=0 i val
-  for (( i=0; i<=FADE_STEPS; i++ )); do
+  local bus="$1" to="$2" from=0 val i
+  for i in $(seq 0 $FADE_STEPS); do
     val=$(( from + (to - from) * i / FADE_STEPS ))
-    set_brightness "$bus" "$val" &
+    set_brightness "$bus" "$val"
     sleep "$FADE_DELAY"
-    wait || true
   done
 }
 

--- a/scripts/opencode/opencode.jsonc
+++ b/scripts/opencode/opencode.jsonc
@@ -285,7 +285,10 @@
       // guard_core.py's "opencode" policy, which parses argv.
       "*git*add -A*": "deny",
       "*git*add --all*": "deny",
-      "*git*add .": "deny",
+      // `*git*add .` removed 2026-08-05: false-positived on `git add <specific-files>`
+      // (glob `*` consumed the path, `.` matched any dot). guard_core.py's
+      // check_git_add_all handles this case via argv parsing (_stages_everything),
+      // and the remaining deny patterns catch the worst cases.
       "*git*stash*": "deny",
       "*git*reset --hard*": "deny",
       "*git*clean -f*": "deny",

--- a/scripts/rig-control.sh
+++ b/scripts/rig-control.sh
@@ -68,7 +68,7 @@ do_sleep() {
 do_wake() {
   echo "awake" > "$STATE_FILE"
   rgb_on
-  restore_bg
+  restore
   notify "Wake mode activated"
 }
 


### PR DESCRIPTION
## Rescued from a diverged shared checkout

These two commits were authored in an earlier session directly on `main` **in the workbench checkout** and never pushed. They are moved onto a branch here unmodified — same SHAs, same authorship, no rebase, no squash.

| commit | subject |
|---|---|
| `3a9cae1` | fix(rig-control): reliable brightness restore after sleep |
| `a8e82d6` | fix(rig-control): kill orphaned fade children, harden timer restore |

**Why this had to happen:** the workbench's `main` had diverged from `origin/main`, so `ship.sh` correctly **skipped that host** on every deploy (rc8 = `skipped:diverged`). That host stopped converging — and it is the host that runs the ClickHouse regrowth timer due to fire 2026-08-11. The divergence was silently blocking a scheduled check from receiving its own bug fix.

The commits are preserved on this branch and were verified present on origin from a second host before the workbench's `main` was moved back. Nothing was rebased, force-pushed, or discarded; the workbench's untracked files were left exactly as found.

## Why this wants review rather than a straight fast-forward

`scripts/claude-hooks/tests/test_guard_core.py` and `scripts/monitor-blackout.sh` were **also touched by #356**, which unbroke the pytests gate. Per-PR review structurally cannot see a cross-PR interaction, so these changes have never been gated against the tree they now land in. That is exactly what this PR is for.

## Not yet verified

I have **not** run the gate on this branch or on the merged tree, and I did not write these changes. Before merging, the merged tree (`main` + this branch) should be built and counted:

```
nix build .#checks.x86_64-linux.pytests --no-link --print-build-logs
```

`main` is currently green at `collected=6507 passed=6506 skipped=1 failed=0`. Note that an empty `nix build` output means the derivation was **cached**, not that nothing ran — read it with `nix log` rather than treating silence as success.

Two loose ends in the workbench checkout, left alone deliberately because they may be live work:
`claudedocs/handoff-rig-control-brightness.md` and `claudedocs/proposed-rules-cut/` are untracked there. Docs written into a working tree are unsaved work, one routine checkout away from silent deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
