### PR TITLE
docs(CLAUDE.md): git discipline for a repo whose working tree is a deploy target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,27 @@ Personal dev-environment config (zsh, tmux, neovim, i3, scripts) for the workben
 - **Quick syntax check** before switching: `nix-instantiate --parse <file>.nix >/dev/null`.
 - **NEVER `sudo nixos-rebuild` from Claude** — can't sudo non-interactively. System-level changes must be staged as an apply script for the user to run (see the `laptop` skill's `stage-system` pattern). home-manager (user-level) is fine.
 
+## Git discipline
+Portable rules (`git add -A`, `reset --hard`, `stash`, worktree isolation, feature-branches,
+base-clone re-sync, stranded docs) are in **`claude/RULES.md` → "Git Workflow"** — read them
+there. Only what's specific to this repo, where a working tree is also a **deploy target**:
+
+- 🔴 **Never commit to `main` in EITHER host checkout** (`~/workspace/devrc`, workbench *or*
+  laptop). `ship.sh` converges with `merge --ff-only`, so a diverged host is **skipped and
+  left as found** — it then silently stops receiving every future change while still looking
+  healthy. 2026-08-06: two un-pushed commits on the workbench blocked it for hours, and the
+  regrowth timer would have fired on 08-11 running the very bug the undelivered commit fixed.
+  **Read every per-host line of `ship.sh`, not the final verdict** — one skip hides among
+  greens, and it prints its own rc legend on failure.
+- **Recovering a diverged host** — preserve, verify, *then* move the pointer:
+  `git branch <topic> HEAD && git push -u origin <topic>` on that host → confirm the shas are
+  on origin **from a different host** → `git reset --keep origin/main` (`--keep` refuses
+  rather than destroys; never `--hard`). Open a PR for `<topic>`: rescued commits have never
+  been gated against the tree they now land in.
+- **A failed switch is usually a pre-existing FOREIGN file, not a nix error.** `home.file`
+  won't clobber a real file it doesn't manage and `force = true` does not override that. Tell:
+  read-only, 1969 mtime (an old store copy). Look at it, copy it aside, remove, re-switch.
+
 ## Server / headless mode
 - `~/.server-mode` marker toggles graphical bits: `headless-mode` (disables dunst/espanso) vs `graphical-mode` (re-enables), both run a home-manager switch. A host may be in server mode — check for the marker before assuming a GUI.
 
@@ -49,5 +70,5 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
 - 🔴 **This repo is PUBLIC.** Never commit a real media-library path, directory name, filename, route log, or a real third-party hostname used as an example.
 
 ## Conventions
-- Never `git add -A` — stage files individually.
-- Commit + push so both hosts (workbench + laptop) can `git pull` then `home-manager switch`.
+- Git: see **Git discipline** above (and `claude/RULES.md` → "Git Workflow" for the portable rules).
+- Land work on `main` via PR, then `scripts/ship.sh` — never `git pull` + switch per host by hand.


### PR DESCRIPTION
Adds a **Git discipline** section to `CLAUDE.md`, modelled on the `datapacket-talos` pattern — numbered critical rules, each carrying the incident that produced it — scoped to what is specific to *this* repo, where a working tree is also a **deploy target**.

## The rule that earned its place

Measured today. Two un-pushed commits sat on the **workbench checkout's `main`**. `ship.sh` converges with a fast-forward-only merge, so it skipped that host and left it exactly as found — correct behaviour, and the refusal is the intended signal. But the host then **silently stopped receiving every subsequent change while still reporting as healthy**.

That host runs the ClickHouse regrowth timer, due to fire **2026-08-11**. Without intervention it would have run pre-fix code containing the exact defect the undelivered commit fixed: a degraded read reporting `state=ok`, exit 0. The check would have produced a green toast and a false "all within bound" on the one observation it exists to make.

What makes it worth a rule rather than a note is the shape of the failure: **one skip line prints among green ones, and the final verdict doesn't surface it.** Hence "read every per-host line, not the final verdict."

## What is deliberately NOT here

`CLAUDE.md` loads every session, so additions are paid forever. Two things were cut from the first draft:

- **The portable git rules** — `git add -A`, `reset --hard`, `stash`, worktree isolation, feature branches, base-clone re-sync, stranded docs. These already ship globally via `claude/RULES.md` → "Git Workflow". Replaced with a pointer, after verifying that section exists and contains the base-clone re-sync and stranded-docs rules I was about to duplicate.
- **`ship.sh`'s rc legend** — the script prints it on failure. Restating it here is precisely the "read the numbers there, never restate them" norm this repo enforces for the two byte-capped docs.

First draft was **+3,489 bytes**; this is **+1,659** after cutting both. The old two-line Conventions block is slimmed, since the new section covers it.

## Verification

Claims checked against source, not memory:

| claim | check |
|---|---|
| `ship.sh` converges with a fast-forward-only merge | present in `scripts/ship.sh` |
| `ship.sh` prints its own rc legend on failure | present |
| `RULES.md` has a "Git Workflow" section | present |
| …and covers base-clone re-sync + stranded docs | both present — confirms the pointer, and the dedupe |
| the recovery recipe is actually runnable | `reset --keep` is **allowed** by `bash-guard.py`; the destructive variant is **denied**. Verified by running the hook. |

That last one mattered: the section recommends `reset --keep`, and had the guard blocked it the doc would be advising something impossible.

Gate: `nix build .#checks.x86_64-linux.pytests` → **6507 collected / 6506 passed / 1 skipped / 0 failed** (floor 5600).

## Not verified

This is documentation — it changes no behaviour, and there is no automated check that a rule in `CLAUDE.md` is *followed*. The recovery recipe was executed once today by hand (that is where it comes from), but it is not covered by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
