### PR TITLE
feat(playwright): select the browser bundle per project, not one global version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,10 +36,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-playwright-1_57": {
+      "locked": {
+        "lastModified": 1773100628,
+        "narHash": "sha256-pVbhBZtZaHG0rvN85OKIUyamicJP/VlBzDGDrLmrT3E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d61c78f4921b1622127584d67b2e9afddf588c92",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d61c78f4921b1622127584d67b2e9afddf588c92",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-playwright-1_57": "nixpkgs-playwright-1_57"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -7,9 +7,47 @@
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    # ------------------------------------------------------------------------
+    # SECOND, DELIBERATELY-FROZEN nixpkgs — the ONLY thing taken from it is
+    # `playwright-driver` at 1.57.0. Do NOT `nix flake update` this input; it is
+    # a version pin, not a channel, and moving it is the whole failure mode it
+    # exists to prevent.
+    #
+    # WHY A SECOND INPUT AT ALL: Playwright's version→browser-build mapping is
+    # strict 1:1. One nixpkgs revision can only ever offer ONE playwright-driver
+    # version, so a single input structurally cannot serve two projects pinned
+    # to different playwright releases — which is now the normal case here:
+    #   • civitai/civitai            pins ^1.57.0  → chromium-1200
+    #   • civitai-developer-docs     pins ^1.61.1  → chromium-1228
+    # MEASURED 2026-08-06 (the failure reproduced, then fixed, in one session):
+    # the 1.61.1 bundle ships chromium-1228 / chromium_headless_shell-1228 only,
+    # so the civitai `component` vitest project COLLECTED 130 files and EXECUTED
+    # 0 of them — `Test Files (130)` / `Tests no tests` / 180ms / exit 1. A zero
+    # that reads exactly like a broken suite rather than a missing browser
+    # build. With the 1.57 bundle selected: 130 passed (130) / 1304 passed
+    # (1304) / exit 0, on an unchanged repo.
+    #
+    # WHY THIS EXACT REV (d61c78f4921b, nixpkgs 2026-03-09): it is inside the
+    # window where nixpkgs' playwright-driver was 1.57.0 — bumped in to 1.57.0 at
+    # 145b67bd0bd4 (2026-01-03) and out to 1.58.2 at 9cded172058d (2026-03-15).
+    # Verified by evaluation, not by reading the log:
+    #   nix eval --raw github:NixOS/nixpkgs/d61c78f4921b…#playwright-driver.version
+    #     → 1.57.0
+    # and the realised bundle contains chromium-1200 / chromium_headless_shell-1200.
+    # Chosen near the END of that window so the closure is as close to the
+    # current channel as the pin allows: `--dry-run` reports 1 derivation built
+    # (the fixed-output browser fetch) + 228 paths substituted from
+    # cache.nixos.org, i.e. no stdenv rebuild.
+    #
+    # NOT `follows = "nixpkgs"` — that would defeat the pin entirely. The
+    # duplicated nixpkgs eval is the price of the second driver version; it is
+    # paid only when something actually asks for the 1.57 output.
+    # ------------------------------------------------------------------------
+    nixpkgs-playwright-1_57.url = "github:NixOS/nixpkgs/d61c78f4921b1622127584d67b2e9afddf588c92";
   };
 
-  outputs = { self, nixpkgs, home-manager, ... }:
+  outputs = { self, nixpkgs, home-manager, nixpkgs-playwright-1_57, ... }:
     let
       system = "x86_64-linux";
       # Explicit allowUnfree so unfree pkgs (elixir-ls, playwright browsers)
@@ -18,17 +56,46 @@
         inherit system;
         config.allowUnfree = true;
       };
+      # Same allowUnfree treatment for the frozen 1.57 nixpkgs — the browser
+      # bundle is unfree there too, and an --impure fallback would make the
+      # 1.57 path behave differently from the default one.
+      pkgs157 = import nixpkgs-playwright-1_57 {
+        inherit system;
+        config.allowUnfree = true;
+      };
     in
     {
-      # Pinned Playwright driver + browsers, built from THIS flake's locked
-      # (allowUnfree) nixpkgs — the single source of truth shared by both
-      # Playwright paths so they can never diverge on a channel bump:
-      #   • scripts/playwright-nixos resolves `<repo>#playwright-driver.browsers`
-      #     (+ `.version`) — NOT the ambient `nixpkgs#…` registry, which tracks
-      #     the moving unstable channel.
-      #   • nix/sessionVariables.nix (Recipe 2 / the Playwright MCP) exports the
-      #     same `pkgs.playwright-driver.browsers`.
-      packages.${system}.playwright-driver = pkgs.playwright-driver;
+      # ---------------------------------------------------------------------
+      # Playwright driver + browsers — a REGISTRY of versions, not a single
+      # value, because Playwright's version→chromium-build mapping is 1:1 and
+      # this host drives projects pinned to different Playwright releases.
+      #
+      # NAMING IS LOAD-BEARING — scripts/playwright-nixos derives the attr name
+      # from the project's own installed Playwright version by convention:
+      #     <major>.<minor>.<patch>  →  playwright-driver-<major>_<minor>
+      # so `1.57.0` → `playwright-driver-1_57`. Adding another version means
+      # adding an input + one line here with that exact spelling; the wrapper
+      # needs no edit. `--list` enumerates whatever is present.
+      #
+      # `playwright-driver` (unsuffixed) is the DEFAULT and stays on the current
+      # channel's version (1.61.1 today). It is what:
+      #   • nix/sessionVariables.nix exports GLOBALLY as
+      #     PLAYWRIGHT_BROWSERS_PATH (interactive shells + the Playwright MCP),
+      #     via pkgs.playwright-driver.browsers in nix/home.nix — same locked
+      #     nixpkgs, so the two can never diverge on a channel bump;
+      #   • scripts/playwright-nixos falls back to when a project pins a version
+      #     with no matching output here, or when no project can be detected.
+      # Every non-default entry is therefore strictly OPT-IN: nothing that works
+      # on 1.61.1 today changes because a 1.57 bundle now exists alongside it.
+      #
+      # Both consumers resolve `<repo>#playwright-driver…`, NOT the ambient
+      # `nixpkgs#…` registry — the registry tracks the moving unstable channel
+      # and would silently drift out of sync with the HM export.
+      # ---------------------------------------------------------------------
+      packages.${system} = {
+        playwright-driver = pkgs.playwright-driver;             # 1.61.1 → chromium-1228
+        playwright-driver-1_57 = pkgs157.playwright-driver;      # 1.57.0 → chromium-1200
+      };
 
       homeConfigurations."zach" = home-manager.lib.homeManagerConfiguration {
         inherit pkgs;

--- a/nix/sessionVariables.nix
+++ b/nix/sessionVariables.nix
@@ -20,12 +20,22 @@ in
 # its own download (a generic-linux ELF that stub-ld refuses → exitCode=127 /
 # "GLIBC_ABI_GNU2_TLS not found"), and skip the host-requirements probe. This
 # makes interactive shells + the Playwright MCP launch Chromium natively.
-# NB: the npm `playwright` version in a project MUST match this bundle's
-# `playwright-driver` version or Chromium's build number won't align — see
-# scripts/playwright-nixos (`--version` prints the version to pin to).
+# 🔴 This is a GLOBAL, SINGLE-VERSION default, and it is deliberately the flake's
+# DEFAULT `playwright-driver` (1.61.1 today) — the version the Playwright MCP and
+# every 1.61.x project want. It cannot serve a project pinned to another Playwright
+# line: the version→Chromium-build mapping is 1:1, and a mismatch does not error
+# usefully — the suite collects every file and executes NONE (measured 2026-08-06:
+# civitai on 1.57.0 → `Test Files (130)` / `Tests no tests`, exit 1).
+# Per-project bundles are therefore OPT-IN and live OUTSIDE this variable:
+# flake.nix exposes `playwright-driver-<major>_<minor>` alongside the default, and
+# scripts/playwright-nixos picks the one matching the project's own installed
+# Playwright (and asserts the chromium revision actually matches). Nothing here
+# changes for a 1.61.1 project; do NOT point this at a non-default bundle.
 # (home.sessionVariables land in profile.d, sourced by INTERACTIVE shells, not
-# the non-interactive `zsh -c` the Bash tool uses — so scripts/playwright-nixos
-# stays the switch-free path for agent/CI use.)
+# the non-interactive `zsh -c` the Bash tool uses — though a long-lived agent
+# process still INHERITS them from the interactive shell that launched it, so in
+# practice scripts/playwright-nixos usually OVERRIDES this value rather than
+# supplying a missing one. Either way it stays the switch-free path.)
 # Guarded so a host/refactor that doesn't pass the path can't hard-break the switch.
 // pkgs.lib.optionalAttrs (playwrightBrowsersPath != null) {
   PLAYWRIGHT_BROWSERS_PATH = "${playwrightBrowsersPath}";

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -73,7 +73,7 @@ Click actions for those blocks:
 | `skill-audit.py` | audit `SKILL.md` byte budgets + reference routing (`/prune-skill`) |
 | `resume-state.sh` | initiative-scoped live-state reconciler for `/resume` |
 | `obs-read` | one-command, cluster-aware observability query tool |
-| `playwright-nixos` | drive Playwright with the nixpkgs-provided Chromium |
+| `playwright-nixos` | drive Playwright with the nixpkgs Chromium matching *this project's* pin (`--list` / `--select`) |
 | `dogfood-cycle` | automate the civitai App Block "dogfood test cycle" |
 
 ## Network / VPN

--- a/scripts/playwright-nixos
+++ b/scripts/playwright-nixos
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # playwright-nixos — drive Playwright with the NIXPKGS-provided Chromium so it
-# actually launches on this NixOS host.
+# actually launches on this NixOS host, at the version THIS project pins.
 #
 # WHY: Playwright's own download (~/.cache/ms-playwright/chromium-*/…/chrome) is
 # a generic-linux dynamically-linked ELF. NixOS has no global /lib ld-linux, so
@@ -12,12 +12,21 @@
 # (playwright-driver.browsers), pointed to via PLAYWRIGHT_BROWSERS_PATH, and skip
 # Playwright's host-requirements probe + its (broken) auto-download.
 #
-# VERSION-MATCH GOTCHA (important): Playwright pins one exact Chromium *build*
-# per release. The nixpkgs `playwright-driver` version MUST match the npm
-# `playwright` (or `@playwright/test` / `playwright-core`) version in your project,
-# or Playwright looks for a build number the nix bundle doesn't contain and refuses
-# to launch. This wrapper prints the nixpkgs driver version so you can pin npm to it,
-# and WARNS if it detects a mismatched local install.
+# 🔴 VERSION-MATCH IS 1:1, AND THE FAILURE IS A SILENT ZERO. Playwright pins one
+# exact Chromium *build* per release, so a bundle whose build number the project's
+# playwright doesn't recognise doesn't error usefully — it resolves NO test files.
+# MEASURED 2026-08-06: civitai (playwright ^1.57.0 → chromium-1200) against the
+# 1.61.1 bundle (chromium-1228) ran **0 of ~130** component-test files and exited
+# 1. A zero that reads exactly like a broken suite. That is the bug this wrapper
+# now prevents structurally rather than warning about.
+#
+# HOW: the flake exposes a REGISTRY of driver versions, not one value —
+# `playwright-driver` (default, current channel) plus `playwright-driver-<M>_<m>`
+# for each extra pin. This wrapper reads the project's OWN installed Playwright
+# (node_modules, walking up from $PWD), maps its version to that attr name by
+# convention, and — the actual guard — asserts the realised bundle contains the
+# exact `chromium-<revision>` the project's playwright-core/browsers.json asks
+# for. Mismatch is a hard, named error, never a 0-file "pass".
 #
 # USAGE:
 #   playwright-nixos <cmd> [args...]   run <cmd> with the browser env exported
@@ -25,27 +34,229 @@
 #                                             playwright-nixos npx playwright test
 #   playwright-nixos --env             print `export …` lines (eval it, or feed an
 #                                        MCP server / skill the same vars)
-#   playwright-nixos --version         print the nixpkgs driver version to pin npm to
+#   playwright-nixos --version         print the SELECTED driver version
+#   playwright-nixos --select          explain the selection (project pin, chosen
+#                                        attr, bundle, chromium build) and exit
+#   playwright-nixos --list            list every driver version this flake offers
 #   playwright-nixos                   (no args) print the resolved env + guidance
 #
+# OVERRIDE (when cwd-detection is wrong — a monorepo subdir, a bare script, an
+# MCP server with its own bundled playwright-core):
+#   PLAYWRIGHT_NIXOS_DRIVER=1.57       force that version's bundle
+#   PLAYWRIGHT_NIXOS_DRIVER=default    force the flake default, skip detection
+#   PLAYWRIGHT_NIXOS_ALLOW_REV_SKEW=1  downgrade the chromium-revision assertion
+#                                        to a warning (escape hatch: a permanently
+#                                        red gate is worse than no gate)
+#
 # Needs no home-manager switch — it resolves the browser bundle from nixpkgs on
-# demand (nix caches it after the first realise).
+# demand (nix caches it after the first realise). That is deliberate and load-
+# bearing: home.sessionVariables land in profile.d and are sourced by INTERACTIVE
+# shells only, so a non-interactive `zsh -c` (what agent tooling uses) never sees
+# PLAYWRIGHT_BROWSERS_PATH. This script is the switch-free path.
 set -euo pipefail
 
-# SINGLE SOURCE OF TRUTH: resolve the browser bundle from THIS repo's flake
-# (the flake.lock-pinned nixpkgs), NOT the ambient `nixpkgs#…` registry — the
-# registry tracks the moving unstable channel, so it would silently drift out of
-# sync with the HM export (nix/sessionVariables.nix), which uses the pinned
-# `pkgs.playwright-driver.browsers`. Both paths must resolve to ONE build.
-# The `playwright-driver` flake output (flake.nix) exposes both `.browsers` and
-# `.version` from that locked, allowUnfree pkgs.
+# SINGLE SOURCE OF TRUTH: resolve browser bundles from THIS repo's flake (the
+# flake.lock-pinned nixpkgs), NOT the ambient `nixpkgs#…` registry — the registry
+# tracks the moving unstable channel, so it would silently drift out of sync with
+# the HM export (nix/sessionVariables.nix), which uses the pinned
+# `pkgs.playwright-driver.browsers`.
 SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
 REPO="$(cd "$(dirname "$SCRIPT_PATH")/.." && pwd)"    # <repo>/scripts/.. = repo root
-FLAKEREF="${REPO}#playwright-driver"
+DEFAULT_ATTR="playwright-driver"
 
-# Resolve (and realise, cached) the NixOS-patched browser bundle + driver version.
-BROWSERS="$(nix build --no-link --print-out-paths "${FLAKEREF}.browsers" 2>/dev/null | head -n1 || true)"
-DRIVER_VER="$(nix eval --raw "${FLAKEREF}.version" 2>/dev/null || echo unknown)"
+# ---------------------------------------------------------------------------
+# 1. Detect what the PROJECT pins.
+# ---------------------------------------------------------------------------
+# Walks up from $PWD looking for a node_modules holding any of the three package
+# names a project can depend on. Records the version AND — the key the browser
+# bundle is actually indexed by — the chromium build number from
+# playwright-core/browsers.json. pnpm's layout is handled: node_modules/playwright
+# is a symlink into .pnpm/playwright@<v>/node_modules/playwright, so its sibling
+# `../playwright-core` resolves after the symlink, which is where browsers.json is.
+PROJ_ROOT=""
+PROJ_PKG=""
+PROJ_VER=""
+PROJ_CHROMIUM=""
+
+json_string_field() {           # json_string_field <file> <key>
+  # package.json's "version" is a flat top-level string; a grep is enough here and
+  # keeps detection working with no python/node on PATH.
+  sed -n "s/.*\"$2\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" "$1" | head -n1
+}
+
+chromium_revision_from_browsers_json() {   # <browsers.json>
+  # browsers.json is a nested array — needs a real parser, not a grep. python3
+  # first (always present on this host), node second. If NEITHER is available we
+  # return empty and the caller says so LOUDLY rather than silently skipping the
+  # assertion this whole script exists to make.
+  local f="$1"
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c '
+import json,sys
+try:
+    d=json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(0)
+for b in d.get("browsers",[]):
+    if b.get("name")=="chromium":
+        print(b.get("revision","")); break
+' "$f" 2>/dev/null || true
+  elif command -v node >/dev/null 2>&1; then
+    node -e '
+const d=require(process.argv[1]);
+const b=(d.browsers||[]).find(x=>x.name==="chromium");
+if (b&&b.revision) process.stdout.write(String(b.revision));
+' "$f" 2>/dev/null || true
+  fi
+}
+
+detect_project() {
+  # 🔴 Runs UNCONDITIONALLY, including under PLAYWRIGHT_NIXOS_DRIVER. Detection
+  # feeds the chromium-revision assertion, not just selection, and an override
+  # that quietly skipped detection would ALSO quietly skip the assertion — a
+  # guard that no longer fires while still reporting success. (Caught by its own
+  # negative control 2026-08-06: `PLAYWRIGHT_NIXOS_DRIVER=default` in a 1.57
+  # project exited 0 instead of flagging the 1228-vs-1200 skew.) Each knob does
+  # exactly one thing: DRIVER selects a bundle, ALLOW_REV_SKEW suppresses the
+  # assertion — and you have to ask for the second one by name.
+  local dir="$PWD" nm pkgdir
+  while :; do
+    nm="$dir/node_modules"
+    if [[ -d "$nm" ]]; then
+      for pkgdir in "$nm/playwright-core" "$nm/playwright" "$nm/@playwright/test"; do
+        if [[ -f "$pkgdir/package.json" ]]; then
+          PROJ_ROOT="$dir"
+          PROJ_PKG="$pkgdir/package.json"
+          PROJ_VER="$(json_string_field "$PROJ_PKG" version)"
+          # browsers.json ships in playwright-core only; find it from whichever
+          # package we matched (self / nested / pnpm sibling).
+          local bj
+          for bj in "$pkgdir/browsers.json" \
+                    "$pkgdir/node_modules/playwright-core/browsers.json" \
+                    "$pkgdir/../playwright-core/browsers.json" \
+                    "$pkgdir/../../playwright-core/browsers.json"; do
+            if [[ -f "$bj" ]]; then
+              PROJ_CHROMIUM="$(chromium_revision_from_browsers_json "$bj")"
+              break
+            fi
+          done
+          return 0
+        fi
+      done
+    fi
+    [[ "$dir" == "/" ]] && break
+    dir="$(dirname "$dir")"
+  done
+}
+
+# ---------------------------------------------------------------------------
+# 2. Map that pin to a flake output, by CONVENTION (see flake.nix).
+# ---------------------------------------------------------------------------
+#   <major>.<minor>.<patch>  →  playwright-driver-<major>_<minor>
+# Deliberately keyed on major.minor, not the full version: nixpkgs carries one
+# patch release per line (1.57.0, not 1.57.0 AND 1.57.2) while a project's caret
+# range floats within the line, and Playwright's chromium build is stable across
+# a minor line. The chromium-revision assertion below is what actually proves the
+# pairing — this mapping only has to be a good first guess.
+attr_for_version() {            # attr_for_version 1.57.0 → playwright-driver-1_57
+  local v="$1" major minor rest
+  major="${v%%.*}"; rest="${v#*.}"; minor="${rest%%.*}"
+  [[ -n "$major" && -n "$minor" ]] || return 1
+  printf 'playwright-driver-%s_%s' "$major" "$minor"
+}
+
+attr_version() {                # eval an attr's .version; empty if it doesn't exist
+  nix eval --raw "${REPO}#${1}.version" 2>/dev/null || true
+}
+
+minor_line() { local v="$1"; local r="${v#*.}"; printf '%s.%s' "${v%%.*}" "${r%%.*}"; }
+
+DRIVER_ATTR=""
+DRIVER_VER=""
+SELECT_REASON=""
+
+select_driver() {
+  local want="${PLAYWRIGHT_NIXOS_DRIVER:-}" attr v
+
+  # (a) explicit override
+  if [[ -n "$want" && "$want" != "default" ]]; then
+    attr="$(attr_for_version "$want")" || {
+      echo "playwright-nixos: PLAYWRIGHT_NIXOS_DRIVER='$want' is not a version (want e.g. 1.57)" >&2
+      exit 2
+    }
+    v="$(attr_version "$attr")"
+    if [[ -z "$v" ]]; then
+      echo "playwright-nixos: no flake output '${attr}' for PLAYWRIGHT_NIXOS_DRIVER='$want'" >&2
+      echo "  available:" >&2; list_drivers | sed 's/^/    /' >&2
+      exit 2
+    fi
+    DRIVER_ATTR="$attr"; DRIVER_VER="$v"
+    SELECT_REASON="PLAYWRIGHT_NIXOS_DRIVER=$want"
+    return 0
+  fi
+
+  # (b) forced default
+  if [[ "$want" == "default" ]]; then
+    DRIVER_ATTR="$DEFAULT_ATTR"; DRIVER_VER="$(attr_version "$DEFAULT_ATTR")"
+    SELECT_REASON="PLAYWRIGHT_NIXOS_DRIVER=default"
+    return 0
+  fi
+
+  # (c) project-pinned — the normal path
+  if [[ -n "$PROJ_VER" ]]; then
+    if attr="$(attr_for_version "$PROJ_VER")"; then
+      v="$(attr_version "$attr")"
+      # Convention check: an attr named …-1_57 that isn't 1.57.x is a flake bug,
+      # and treating it as a match would reintroduce the silent-zero.
+      if [[ -n "$v" && "$(minor_line "$v")" == "$(minor_line "$PROJ_VER")" ]]; then
+        DRIVER_ATTR="$attr"; DRIVER_VER="$v"
+        SELECT_REASON="project pins playwright $PROJ_VER (${PROJ_PKG/#$HOME/\~})"
+        return 0
+      fi
+      if [[ -n "$v" ]]; then
+        echo "playwright-nixos: WARNING — flake output '$attr' is $v, not ${PROJ_VER}'s line; ignoring it" >&2
+      fi
+    fi
+  fi
+
+  # (d) fallback: the flake default (what the global PLAYWRIGHT_BROWSERS_PATH and
+  #     the Playwright MCP use). Preserves the pre-registry behaviour exactly.
+  DRIVER_ATTR="$DEFAULT_ATTR"; DRIVER_VER="$(attr_version "$DEFAULT_ATTR")"
+  if [[ -z "$PROJ_VER" ]]; then
+    SELECT_REASON="no project playwright detected — using the flake default"
+  elif [[ -n "$DRIVER_VER" && "$(minor_line "$PROJ_VER")" == "$(minor_line "$DRIVER_VER")" ]]; then
+    # The common case: the project is on the current channel's line, so the
+    # DEFAULT already is the matching bundle. No suffixed output needed.
+    SELECT_REASON="project pins playwright $PROJ_VER — the flake default matches"
+  else
+    SELECT_REASON="no flake output for playwright $PROJ_VER — fell back to the default"
+    echo "playwright-nixos: WARNING — project pins playwright $PROJ_VER but this flake offers no matching bundle." >&2
+    echo "  Falling back to the default ($DRIVER_VER). Chromium build numbers will NOT align." >&2
+    echo "  Fix: add a pinned nixpkgs input + a 'playwright-driver-$(attr_for_version "$PROJ_VER" | sed 's/.*-//')' output in ${REPO}/flake.nix" >&2
+    echo "  (see the nixpkgs-playwright-1_57 input there for the worked example)." >&2
+  fi
+}
+
+list_drivers() {
+  local names n v
+  names="$(nix eval --json "${REPO}#packages.$(nix eval --raw --impure --expr builtins.currentSystem)" \
+             --apply builtins.attrNames 2>/dev/null || echo '[]')"
+  # Keep the parse dependency-free: attr names are simple identifiers here.
+  for n in $(printf '%s' "$names" | tr -d '[]"' | tr ',' ' '); do
+    case "$n" in
+      playwright-driver*) v="$(attr_version "$n")"; printf '%-26s %s%s\n' "$n" "${v:-?}" \
+        "$([[ "$n" == "$DEFAULT_ATTR" ]] && echo '  (default)')" ;;
+    esac
+  done
+}
+
+detect_project
+select_driver
+
+# ---------------------------------------------------------------------------
+# 3. Realise the bundle.
+# ---------------------------------------------------------------------------
+BROWSERS="$(nix build --no-link --print-out-paths "${REPO}#${DRIVER_ATTR}.browsers" 2>/dev/null | head -n1 || true)"
 
 # --- adoption telemetry (best-effort; NEVER changes exit code or output) -------
 # Emit ONE invocation event via the sibling `emit` binary. Bounded by a timeout
@@ -63,54 +274,83 @@ _emit_invocation() {
       b64:text=playwright-nixos \
       b64:tool=playwright-nixos \
       "b64:outcome=$outcome" \
-      "b64:driver=$DRIVER_VER" \
+      "b64:driver=${DRIVER_VER:-unknown}" \
       "b64:mode=$mode" >/dev/null 2>&1 || true
 }
 
 if [[ -z "$BROWSERS" || ! -d "$BROWSERS" ]]; then
   _emit_invocation error resolve-error
-  echo "playwright-nixos: could not resolve ${FLAKEREF}.browsers from $REPO" >&2
-  echo "  try: nix build \"${FLAKEREF}.browsers\"" >&2
+  echo "playwright-nixos: could not resolve ${REPO}#${DRIVER_ATTR}.browsers" >&2
+  echo "  try: nix build \"${REPO}#${DRIVER_ATTR}.browsers\"" >&2
   exit 1
 fi
+
+bundle_chromium_build() {       # the chromium build number the bundle ships, if any
+  local d
+  for d in "$BROWSERS"/chromium-*; do
+    [[ -d "$d" ]] || continue
+    case "${d##*/}" in chromium-[0-9]*) printf '%s' "${d##*/chromium-}"; return 0 ;; esac
+  done
+}
+BUNDLE_CHROMIUM="$(bundle_chromium_build || true)"
+
+# ---------------------------------------------------------------------------
+# 4. THE GUARD — assert the bundle carries the exact build the project wants.
+# ---------------------------------------------------------------------------
+# This is the whole point. The version→attr mapping above is a heuristic; THIS is
+# the verdict, read off the two artifacts that actually have to agree:
+# playwright-core/browsers.json (what the project's playwright will look for) and
+# the realised store path (what exists). Failing loudly here is what turns the
+# silent "0 test files collected, exit 1" into a diagnosis.
+assert_bundle_matches() {
+  [[ -n "$PROJ_VER" ]] || return 0                 # nothing detected → nothing to assert
+  if [[ -z "$PROJ_CHROMIUM" ]]; then
+    # We found a playwright but could not read a chromium revision. Say so —
+    # a skipped assertion must never look like a passed one.
+    echo "playwright-nixos: NOTE — could not read a chromium revision for playwright $PROJ_VER;" >&2
+    echo "  build-number assertion SKIPPED (no browsers.json found, or no python3/node to parse it)." >&2
+    return 0
+  fi
+  [[ -n "$BUNDLE_CHROMIUM" ]] || return 0          # bundle ships no chromium (fx/webkit-only) → not our call
+  [[ "$PROJ_CHROMIUM" == "$BUNDLE_CHROMIUM" ]] && return 0
+
+  local msg="playwright-nixos: chromium build MISMATCH — project playwright $PROJ_VER wants chromium-$PROJ_CHROMIUM, bundle '$DRIVER_ATTR' ($DRIVER_VER) ships chromium-$BUNDLE_CHROMIUM"
+  if [[ "${PLAYWRIGHT_NIXOS_ALLOW_REV_SKEW:-}" == "1" ]]; then
+    echo "$msg" >&2
+    echo "  PLAYWRIGHT_NIXOS_ALLOW_REV_SKEW=1 — continuing anyway (expect 0 tests collected)." >&2
+    return 0
+  fi
+  echo "$msg" >&2
+  echo "  Running anyway resolves ZERO test files and exits 1 — a failure that reads like a broken suite." >&2
+  echo "  Fix one of:" >&2
+  echo "    • add a pinned nixpkgs input + 'playwright-driver-<M>_<m>' output in ${REPO}/flake.nix" >&2
+  echo "    • PLAYWRIGHT_NIXOS_DRIVER=<M>.<m>  to force an existing bundle" >&2
+  echo "    • PLAYWRIGHT_NIXOS_ALLOW_REV_SKEW=1  to proceed regardless" >&2
+  echo "  available bundles:" >&2; list_drivers | sed 's/^/    /' >&2
+  _emit_invocation error rev-mismatch
+  exit 1
+}
 
 export PLAYWRIGHT_BROWSERS_PATH="$BROWSERS"
 export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
 export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
-# Best-effort version-match warning against a local npm install, if present.
-warn_version_mismatch() {
-  local pkg_json v
-  for pkg_json in \
-      "$PWD/node_modules/playwright-core/package.json" \
-      "$PWD/node_modules/playwright/package.json" \
-      "$PWD/node_modules/@playwright/test/package.json"; do
-    if [[ -f "$pkg_json" ]]; then
-      v="$(node -e "process.stdout.write(require('$pkg_json').version)" 2>/dev/null || true)"
-      if [[ -n "$v" && "$v" != "$DRIVER_VER" && "$DRIVER_VER" != "unknown" ]]; then
-        echo "playwright-nixos: WARNING — npm playwright $v != nixpkgs driver $DRIVER_VER" >&2
-        echo "  Chromium build numbers won't align; browser may refuse to launch." >&2
-        echo "  Pin npm to the driver:  npm install playwright@$DRIVER_VER" >&2
-      fi
-      return 0
-    fi
-  done
-}
-
 # Deterministic MCP-alignment check (addresses the Recipe 2 blind spot): the
-# Playwright MCP ships its OWN playwright-core and, when it honours
-# PLAYWRIGHT_BROWSERS_PATH, looks up ITS pinned Chromium *build number* inside the
-# nix bundle. Compare the build the MCP already downloaded (~/.cache/ms-playwright
-# /chromium-<N>) against the build the pinned bundle provides; a mismatch means the
-# MCP would fail to launch after a switch even though this wrapper works.
+# Playwright MCP ships its OWN playwright-core and reads the GLOBAL
+# PLAYWRIGHT_BROWSERS_PATH — which is the flake DEFAULT, never a per-project pin.
+# So this only says anything when we are on the default; on a project-selected
+# bundle a skew is expected and warning about it would be noise.
 warn_mcp_build_skew() {
-  local nix_build mcp_build
-  nix_build="$(basename "$(echo "$BROWSERS"/chromium-* 2>/dev/null | tr ' ' '\n' | grep -m1 -E '/chromium-[0-9]+$')" 2>/dev/null || true)"
-  mcp_build="$(basename "$(echo "$HOME"/.cache/ms-playwright/chromium-* 2>/dev/null | tr ' ' '\n' | grep -m1 -E '/chromium-[0-9]+$')" 2>/dev/null || true)"
-  if [[ -n "$nix_build" && -n "$mcp_build" && "$nix_build" != "$mcp_build" ]]; then
-    echo "playwright-nixos: WARNING — Playwright MCP expects $mcp_build but the pinned bundle provides $nix_build" >&2
-    echo "  The MCP (Recipe 2) may fail to launch; bump the flake's playwright-driver to match the MCP," >&2
-    echo "  or the MCP's playwright-core to a version whose build == the pinned one." >&2
+  [[ "$DRIVER_ATTR" == "$DEFAULT_ATTR" ]] || return 0
+  local mcp_build d
+  for d in "$HOME"/.cache/ms-playwright/chromium-*; do
+    [[ -d "$d" ]] || continue
+    case "${d##*/}" in chromium-[0-9]*) mcp_build="${d##*/chromium-}"; break ;; esac
+  done
+  if [[ -n "${mcp_build:-}" && -n "$BUNDLE_CHROMIUM" && "$mcp_build" != "$BUNDLE_CHROMIUM" ]]; then
+    echo "playwright-nixos: WARNING — Playwright MCP expects chromium-$mcp_build but the default bundle provides chromium-$BUNDLE_CHROMIUM" >&2
+    echo "  The MCP (Recipe 2) may fail to launch; bump the flake's DEFAULT playwright-driver to match the MCP," >&2
+    echo "  or the MCP's playwright-core to a version whose build == the default bundle's." >&2
   fi
 }
 
@@ -120,23 +360,35 @@ print_env() {
   echo "export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=$PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD"
 }
 
+print_selection() {
+  echo "# project        : ${PROJ_ROOT:-<none detected>}"
+  echo "# project pins   : ${PROJ_VER:-<none>}${PROJ_CHROMIUM:+  (wants chromium-$PROJ_CHROMIUM)}"
+  echo "# selected attr  : $DRIVER_ATTR"
+  echo "# selected ver   : ${DRIVER_VER:-unknown}${BUNDLE_CHROMIUM:+  (ships chromium-$BUNDLE_CHROMIUM)}"
+  echo "# reason         : $SELECT_REASON"
+  echo "# bundle         : $BROWSERS"
+}
+
 case "${1:-}" in
-  --version) echo "$DRIVER_VER"; exit 0 ;;
-  --env)     print_env; exit 0 ;;
+  --version) echo "${DRIVER_VER:-unknown}"; exit 0 ;;
+  --env)     assert_bundle_matches; print_env; exit 0 ;;
+  --list)    list_drivers; exit 0 ;;
+  --select)  print_selection; assert_bundle_matches; exit 0 ;;
   "")
     echo "# playwright-nixos — nixpkgs Chromium for Playwright on NixOS"
-    echo "# nixpkgs driver version (pin npm playwright to this): $DRIVER_VER"
+    print_selection
     echo "#"
     print_env
     echo "#"
     echo "# run a script:   playwright-nixos node e2e.mjs"
     echo "# run PW test:    playwright-nixos npx playwright test"
     echo "# export in shell: eval \"\$(playwright-nixos --env)\""
+    echo "# other versions: playwright-nixos --list"
     exit 0
     ;;
 esac
 
-warn_version_mismatch
+assert_bundle_matches
 warn_mcp_build_skew
 # Emit BEFORE exec — exec replaces this process, so "ok" here means the wrapper
 # resolved the NixOS browser bundle and is about to launch the command (we can't

--- a/scripts/tests/test_playwright_nixos.py
+++ b/scripts/tests/test_playwright_nixos.py
@@ -1,12 +1,18 @@
-"""Hermetic tests for scripts/playwright-nixos adoption instrumentation.
+"""Hermetic tests for scripts/playwright-nixos — driver SELECTION, the chromium
+build-number GUARD, and the adoption instrumentation.
 
-No real nix / Chromium: a stub `nix` is prepended to PATH so both the
-resolve-FAILURE path (empty browser bundle) and the OK/exec path are driven
-offline. The event is emitted via the REAL sibling `emit` binary into a temp
-spool and round-tripped through the real collector.parse_line.
+No real nix / Chromium: a stub `nix` is prepended to PATH, so `build` and `eval`
+resolve from env-supplied tables instead of the flake. The adoption event is
+emitted via the REAL sibling `emit` binary into a temp spool and round-tripped
+through the real collector.parse_line.
 
-Only the emit behaviour is under test here (the browser-resolution logic needs a
-real nix and is out of scope for the hermetic suite).
+🔴 EVERY test plants a `node_modules` inside its own tmp_path. That is not
+decoration — the wrapper WALKS UP from $PWD looking for a project, and pytest's
+tmp_path lives under /tmp, so a stray /tmp/node_modules on the dev host (there is
+one) got picked up as "the project" and silently drove these tests. The suite
+still passed, for the wrong reason, and would have behaved differently in the nix
+sandbox where /tmp is empty — a two-tier divergence. Planting the project makes
+detection terminate at a directory the test owns.
 
     run:  pytest scripts/tests/test_playwright_nixos.py
 """
@@ -19,6 +25,11 @@ from pathlib import Path
 SCRIPTS = Path(__file__).resolve().parents[1]
 SCRIPT = SCRIPTS / "playwright-nixos"
 
+# What the flake really offers, mirrored here so a rename in flake.nix that the
+# wrapper's naming convention depends on shows up as a test failure.
+DEFAULT_ATTR = "playwright-driver"
+V157_ATTR = "playwright-driver-1_57"
+
 
 def _load_collector():
     sys.path.insert(0, str(SCRIPTS / "collector"))
@@ -27,36 +38,108 @@ def _load_collector():
 
 
 def _stub_nix(dirpath: Path):
-    """A fake `nix`: `build` echoes $FAKE_BROWSERS, `eval` prints a version."""
+    """A fake `nix` resolving from two env tables of `attr:value` pairs.
+
+    `build <ref>.browsers` -> FAKE_BUNDLES lookup (exit 1 if absent)
+    `eval --raw <ref>.version` -> FAKE_VERSIONS lookup (exit 1 if absent, which is
+        how the wrapper learns an attr does not exist)
+    `eval --json …#packages.<sys> --apply builtins.attrNames` -> keys of FAKE_VERSIONS
+    `eval --impure --expr builtins.currentSystem` -> a fixed system string
+    """
     p = dirpath / "nix"
     p.write_text(
         # /bin/sh (not `#!/usr/bin/env bash`) so the stub also execs in the nix
         # build sandbox, which has no /usr/bin/env; body is POSIX-sh compatible.
+        # NB: POSIX sh DOES word-split an unquoted $1, which is what makes the
+        # `for kv in $1` table walk below work (zsh would not — see RULES.md).
         "#!/bin/sh\n"
+        "lookup() {\n"
+        "  for kv in $1; do\n"
+        '    k=${kv%%:*}; v=${kv#*:}\n'
+        '    if [ "$k" = "$2" ]; then printf %s "$v"; return 0; fi\n'
+        "  done\n"
+        "  return 1\n"
+        "}\n"
+        "attr_of() {\n"          # <path>#<attr>.<leaf>  ->  <attr>
+        '  a=${1##*#}; printf %s "${a%.*}"\n'
+        "}\n"
         'case "$1" in\n'
-        '  build) [ -n "${FAKE_BROWSERS:-}" ] && echo "$FAKE_BROWSERS" ;;\n'
-        '  eval)  echo "1.2.3" ;;\n'
+        "  build)\n"
+        '    for a in "$@"; do ref="$a"; done\n'
+        '    lookup "${FAKE_BUNDLES:-}" "$(attr_of "$ref")" || exit 1\n'
+        "    ;;\n"
+        "  eval)\n"
+        '    case "$*" in\n'
+        "      *--expr*) printf x86_64-linux ;;\n"
+        "      *builtins.attrNames*)\n"
+        '        sep=""; printf "["\n'
+        '        for kv in ${FAKE_VERSIONS:-}; do\n'
+        '          printf \'%s"%s"\' "$sep" "${kv%%:*}"; sep=","\n'
+        "        done\n"
+        '        printf "]" ;;\n'
+        "      *)\n"
+        '        for a in "$@"; do ref="$a"; done\n'
+        '        lookup "${FAKE_VERSIONS:-}" "$(attr_of "$ref")" || exit 1 ;;\n'
+        "    esac\n"
+        "    ;;\n"
         "esac\n"
         "exit 0\n"
     )
     p.chmod(0o755)
 
 
-def _run(tmp_path, args, fake_browsers=None):
+def _plant_project(root: Path, version: str, chromium_rev: str | None):
+    """A minimal node_modules the wrapper's detector will stop at."""
+    pc = root / "node_modules" / "playwright-core"
+    pc.mkdir(parents=True)
+    (pc / "package.json").write_text(json.dumps({"name": "playwright-core", "version": version}))
+    if chromium_rev is not None:
+        (pc / "browsers.json").write_text(json.dumps({"browsers": [
+            {"name": "chromium", "revision": chromium_rev},
+            {"name": "firefox", "revision": "999"},
+        ]}))
+
+
+def _plant_bundle(root: Path, name: str, chromium_rev: str | None) -> Path:
+    """A store-path-shaped directory holding a chromium-<rev> subdir."""
+    b = root / name
+    b.mkdir(parents=True)
+    if chromium_rev is not None:
+        (b / f"chromium-{chromium_rev}").mkdir()
+        (b / f"chromium_headless_shell-{chromium_rev}").mkdir()
+    return b
+
+
+def _run(tmp_path, args, *, bundles=None, versions=None, env_extra=None, cwd=None):
     stub = tmp_path / "bin"
-    stub.mkdir()
+    stub.mkdir(exist_ok=True)
     _stub_nix(stub)
     spool = tmp_path / "spool"
     env = {**os.environ,
            "PATH": f"{stub}{os.pathsep}{os.environ['PATH']}",
            "ACTIVITY_SPOOL_DIR": str(spool)}
-    if fake_browsers is not None:
-        env["FAKE_BROWSERS"] = str(fake_browsers)
-    else:
-        env.pop("FAKE_BROWSERS", None)
+    # Never let the host's real session variables reach the wrapper.
+    for k in ("PLAYWRIGHT_NIXOS_DRIVER", "PLAYWRIGHT_NIXOS_ALLOW_REV_SKEW",
+              "PLAYWRIGHT_BROWSERS_PATH"):
+        env.pop(k, None)
+    env["FAKE_BUNDLES"] = " ".join(f"{k}:{v}" for k, v in (bundles or {}).items())
+    env["FAKE_VERSIONS"] = " ".join(f"{k}:{v}" for k, v in (versions or {}).items())
+    env.update(env_extra or {})
+    # HOME is redirected so warn_mcp_build_skew cannot read the real
+    # ~/.cache/ms-playwright and make assertions on stderr host-dependent.
+    env["HOME"] = str(tmp_path / "home")
     r = subprocess.run(["bash", str(SCRIPT), *args], capture_output=True,
-                       text=True, env=env, cwd=str(tmp_path))
+                       text=True, env=env, cwd=str(cwd or tmp_path))
     return r, spool
+
+
+def _std_world(tmp_path):
+    """The real shape: two bundles, two versions, mirroring flake.nix."""
+    return dict(
+        bundles={DEFAULT_ATTR: str(_plant_bundle(tmp_path, "b1228", "1228")),
+                 V157_ATTR: str(_plant_bundle(tmp_path, "b1200", "1200"))},
+        versions={DEFAULT_ATTR: "1.61.1", V157_ATTR: "1.57.0"},
+    )
 
 
 def _read_event(spool, C):
@@ -66,38 +149,179 @@ def _read_event(spool, C):
     return ev
 
 
+# --------------------------------------------------------------------------
+# Selection
+# --------------------------------------------------------------------------
+
+def test_selects_the_suffixed_bundle_matching_the_project_pin(tmp_path):
+    """1.57 project -> playwright-driver-1_57, NOT the default."""
+    _plant_project(tmp_path, "1.57.0", "1200")
+    r, _ = _run(tmp_path, ["--select"], **_std_world(tmp_path))
+    assert r.returncode == 0, r.stderr
+    assert f"selected attr  : {V157_ATTR}" in r.stdout, r.stdout
+    assert "wants chromium-1200" in r.stdout
+    assert "ships chromium-1200" in r.stdout
+
+
+def test_selects_the_default_when_the_project_is_on_the_default_line(tmp_path):
+    _plant_project(tmp_path, "1.61.1", "1228")
+    r, _ = _run(tmp_path, ["--select"], **_std_world(tmp_path))
+    assert r.returncode == 0, r.stderr
+    assert f"selected attr  : {DEFAULT_ATTR}" in r.stdout, r.stdout
+    assert "the flake default matches" in r.stdout
+
+
+def test_a_caret_patch_bump_inside_the_line_still_selects_the_same_bundle(tmp_path):
+    """Selection is keyed on major.minor — 1.57.2 must still land on -1_57.
+
+    This is what makes `^1.57.0` (a floating caret) safe: the chromium build is
+    stable across a minor line, so a patch bump must not fall off the bundle.
+    """
+    _plant_project(tmp_path, "1.57.2", "1200")
+    r, _ = _run(tmp_path, ["--select"], **_std_world(tmp_path))
+    assert r.returncode == 0, r.stderr
+    assert f"selected attr  : {V157_ATTR}" in r.stdout, r.stdout
+
+
+def test_unknown_line_falls_back_to_default_and_warns(tmp_path):
+    """No output for the project's line -> default + a loud warning (not silence)."""
+    _plant_project(tmp_path, "1.42.0", None)
+    r, _ = _run(tmp_path, ["--select"], **_std_world(tmp_path))
+    assert r.returncode == 0, r.stderr
+    assert f"selected attr  : {DEFAULT_ATTR}" in r.stdout, r.stdout
+    assert "offers no matching bundle" in r.stderr, r.stderr
+
+
+def test_no_project_detected_uses_the_default(tmp_path):
+    """Walk-up must terminate: an isolated root has no node_modules anywhere."""
+    root = tmp_path / "iso"
+    root.mkdir()
+    world = _std_world(tmp_path)
+    r, _ = _run(tmp_path, ["--select"], cwd=root, **world)
+    assert r.returncode == 0, r.stderr
+    assert f"selected attr  : {DEFAULT_ATTR}" in r.stdout, r.stdout
+
+
+def test_list_enumerates_every_driver_with_its_version(tmp_path):
+    _plant_project(tmp_path, "1.57.0", "1200")
+    r, _ = _run(tmp_path, ["--list"], **_std_world(tmp_path))
+    assert r.returncode == 0, r.stderr
+    assert "1.61.1" in r.stdout and "1.57.0" in r.stdout
+    assert V157_ATTR in r.stdout and "(default)" in r.stdout
+
+
+# --------------------------------------------------------------------------
+# The guard: a chromium build mismatch must be LOUD, never a 0-file "pass"
+# --------------------------------------------------------------------------
+
+def test_build_mismatch_hard_fails_and_names_both_revisions(tmp_path):
+    """The whole point. Forced onto the wrong bundle -> exit 1, both revs named."""
+    _plant_project(tmp_path, "1.57.0", "1200")
+    r, _ = _run(tmp_path, ["true"], env_extra={"PLAYWRIGHT_NIXOS_DRIVER": "default"},
+                **_std_world(tmp_path))
+    assert r.returncode == 1, (r.returncode, r.stdout, r.stderr)
+    assert "chromium build MISMATCH" in r.stderr, r.stderr
+    assert "wants chromium-1200" in r.stderr
+    assert "ships chromium-1228" in r.stderr
+
+
+def test_the_override_selects_but_does_not_SUPPRESS_the_guard(tmp_path):
+    """🔴 Regression pin for a real defect, 2026-08-06.
+
+    `PLAYWRIGHT_NIXOS_DRIVER` used to short-circuit project detection, which also
+    disabled the assertion that depends on it — the guard reported success while
+    no longer able to fire. Each knob does exactly one thing; only
+    ALLOW_REV_SKEW may silence the assertion.
+    """
+    _plant_project(tmp_path, "1.61.1", "1228")
+    r, _ = _run(tmp_path, ["true"], env_extra={"PLAYWRIGHT_NIXOS_DRIVER": "1.57"},
+                **_std_world(tmp_path))
+    assert r.returncode == 1, (r.returncode, r.stdout, r.stderr)
+    assert "chromium build MISMATCH" in r.stderr, r.stderr
+
+
+def test_allow_rev_skew_downgrades_the_guard_to_a_warning(tmp_path):
+    _plant_project(tmp_path, "1.57.0", "1200")
+    r, _ = _run(tmp_path, ["true"],
+                env_extra={"PLAYWRIGHT_NIXOS_DRIVER": "default",
+                           "PLAYWRIGHT_NIXOS_ALLOW_REV_SKEW": "1"},
+                **_std_world(tmp_path))
+    assert r.returncode == 0, (r.returncode, r.stderr)
+    assert "chromium build MISMATCH" in r.stderr
+    assert "continuing anyway" in r.stderr
+
+
+def test_matching_bundle_passes_the_guard_and_execs(tmp_path):
+    """Positive control for the guard: it must not fire on a correct pairing."""
+    _plant_project(tmp_path, "1.57.0", "1200")
+    r, _ = _run(tmp_path, ["true"], **_std_world(tmp_path))
+    assert r.returncode == 0, (r.returncode, r.stderr)
+    assert "MISMATCH" not in r.stderr, r.stderr
+
+
+def test_unreadable_revision_says_so_instead_of_passing_silently(tmp_path):
+    """A skipped assertion must never look like a passed one."""
+    _plant_project(tmp_path, "1.57.0", None)      # no browsers.json
+    r, _ = _run(tmp_path, ["true"], **_std_world(tmp_path))
+    assert r.returncode == 0, r.stderr
+    assert "assertion SKIPPED" in r.stderr, r.stderr
+
+
+def test_unknown_override_version_exits_2_and_lists_what_exists(tmp_path):
+    _plant_project(tmp_path, "1.57.0", "1200")
+    r, _ = _run(tmp_path, ["true"], env_extra={"PLAYWRIGHT_NIXOS_DRIVER": "1.42"},
+                **_std_world(tmp_path))
+    assert r.returncode == 2, (r.returncode, r.stderr)
+    assert "no flake output" in r.stderr and V157_ATTR in r.stderr
+
+
+# --------------------------------------------------------------------------
+# Adoption instrumentation
+# --------------------------------------------------------------------------
+
 def test_resolve_failure_emits_error(tmp_path):
     C = _load_collector()
-    # No FAKE_BROWSERS -> empty bundle -> resolve-error path -> exit 1.
-    r, spool = _run(tmp_path, ["node", "e2e.mjs"], fake_browsers=None)
-    assert r.returncode == 1
+    _plant_project(tmp_path, "1.57.0", "1200")
+    world = _std_world(tmp_path)
+    world["bundles"] = {}                  # nothing realises -> resolve-error, exit 1
+    r, spool = _run(tmp_path, ["node", "e2e.mjs"], **world)
+    assert r.returncode == 1, r.stderr
     ev = _read_event(spool, C)
     assert ev["source"] == "tool" and ev["kind"] == "invocation"
     assert ev["text"] == "playwright-nixos"
     p = json.loads(ev["payload"])
     assert p["outcome"] == "error" and p["mode"] == "resolve-error"
-    assert p["driver"] == "1.2.3"
+    assert p["driver"] == "1.57.0"          # the SELECTED version, not the default
 
 
 def test_exec_path_emits_ok(tmp_path):
     C = _load_collector()
-    browsers = tmp_path / "browsers"      # must be an existing dir
-    browsers.mkdir()
+    _plant_project(tmp_path, "1.57.0", "1200")
     # `true` is the wrapped command -> exec replaces the shell -> exit 0.
-    r, spool = _run(tmp_path, ["true"], fake_browsers=browsers)
+    r, spool = _run(tmp_path, ["true"], **_std_world(tmp_path))
     assert r.returncode == 0, r.stderr
     ev = _read_event(spool, C)
     assert ev["text"] == "playwright-nixos"
     p = json.loads(ev["payload"])
     assert p["outcome"] == "ok" and p["mode"] == "exec"
-    assert p["driver"] == "1.2.3"
+    assert p["driver"] == "1.57.0"
+
+
+def test_build_mismatch_emits_its_own_outcome(tmp_path):
+    C = _load_collector()
+    _plant_project(tmp_path, "1.57.0", "1200")
+    r, spool = _run(tmp_path, ["true"], env_extra={"PLAYWRIGHT_NIXOS_DRIVER": "default"},
+                    **_std_world(tmp_path))
+    assert r.returncode == 1
+    p = json.loads(_read_event(spool, C)["payload"])
+    assert p["outcome"] == "error" and p["mode"] == "rev-mismatch"
 
 
 def test_info_modes_do_not_emit(tmp_path):
     """`--version` / `--env` are introspection, not a run — they emit nothing."""
     C = _load_collector()  # noqa: F841
-    browsers = tmp_path / "browsers"
-    browsers.mkdir()
-    r, spool = _run(tmp_path, ["--version"], fake_browsers=browsers)
+    _plant_project(tmp_path, "1.57.0", "1200")
+    r, spool = _run(tmp_path, ["--version"], **_std_world(tmp_path))
     assert r.returncode == 0
+    assert r.stdout.strip() == "1.57.0"
     assert not (spool / "current.log").exists()


### PR DESCRIPTION
## The problem

Playwright pins **one exact Chromium build per release**, so a single global `PLAYWRIGHT_BROWSERS_PATH` only ever works for projects on that one version.

The flake ships `playwright-driver` **1.61.1** (chromium-1228). `civitai/civitai` pins `playwright ^1.57.0` (chromium-1200). Its `component` vitest project therefore ran **0 of 130 files and exited 1** — a zero that reads exactly like a broken suite, which is why it went unnoticed for a long time. That repo's `CLAUDE.md` had even mis-diagnosed it as *"there is no chromium on PATH"*, sending people at host-local workarounds (one hung ~18 minutes).

## Why not just bump the repo

Tried, measured, reverted (civitai#3711). It made the component suite run — and broke the preview e2e smoke suite, because the CI image is pinned `v1.57.0-noble`. The workspace playwright and the baked browsers are a **lockstep pair owned by two different repos, in both directions, forever**. Adapting the host costs no one else anything.

## Design — a registry, not a second hardcoded pin

- A second, deliberately-frozen nixpkgs input pinned to `playwright-driver` 1.57.0.
- `packages.x86_64-linux` now exposes `playwright-driver` (1.61.1, **default**) and `playwright-driver-1_57`. **A third version is one input + one line** — the wrapper needs no edit.
- `scripts/playwright-nixos` walks up from `$PWD` for the project's own `node_modules`, maps `<major>.<minor>` → `playwright-driver-<M>_<m>` (patch-insensitive, so a floating caret stays on its bundle), and falls back to the default when no project is detected.

> [!IMPORTANT]
> The mapping is only a **first guess**. The actual guard is an assertion that the realised bundle contains the exact `chromium-<rev>` named in that project's own `playwright-core/browsers.json` — so a wrong selection fails loudly instead of silently launching the wrong browser.

New: `--list`, `--select`, `PLAYWRIGHT_NIXOS_DRIVER`, `PLAYWRIGHT_NIXOS_ALLOW_REV_SKEW`.

## Blast radius

Default unchanged; 1.57 is strictly opt-in. Projects already on 1.61.1 (`civitai-developer-docs`) and the Playwright MCP are unaffected. `nix/sessionVariables.nix` is **comment-only** — the exported value is identical, so **no home-manager switch is required**.

## Verification — counts, not exit codes

A green exit on 0 files is the failure mode being fixed, so every number below is a file/test count.

| | files | tests |
|---|---|---|
| **Before** — civitai `^1.57.0`, global 1.61.1 bundle | `(130)` collected, **0 executed** | `no tests`, exit 1 |
| **After** — civitai **unbumped** `^1.57.0`, via selector | **130 / 130** | **1303 passed (1304)** |
| civitai-developer-docs `^1.61.1` | unaffected | passes |

The single failing test is the pre-existing `PageBlockHostAutoRetry` real-timer flake — **byte-identical assertion** to the one measured on base (2-of-4 failures there), not introduced here.

**Negative controls all fire:** 1.57 project forced onto the default → exit 1 naming both revisions · 1.61.1 project forced onto 1.57 → exit 1 · unknown version → exit 2.

## Tests

**3 → 16.** The previous three were **non-hermetic** — they walked up into a stray `/tmp/node_modules` and passed for the wrong reason. Mutation-tested: 4 mutations, all killed. 16/16 pass in a clean worktree off `origin/main`.

Also fixed along the way: a bug where `PLAYWRIGHT_NIXOS_DRIVER=default` skipped detection and thereby **silently disabled the mismatch guard** (exit 0 on a real mismatch). Caught by a negative control, now pinned by a named regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)