### PR TITLE
fix(rig-control): brightness restore after sleep + stale-restore cancellation (rescued from an un-pushed workbench main)

### DIFF
--- a/scripts/monitor-blackout.sh
+++ b/scripts/monitor-blackout.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 DDC=$(command -v ddcutil) || { echo "ddcutil not found on PATH" >&2; exit 1; }
 UNIT=monitor-blackout-restore
 STATE="${XDG_RUNTIME_DIR:-/tmp}/monitor-blackout.state"   # "bus:brightness"
+FADE_PID_FILE="${XDG_RUNTIME_DIR:-/tmp}/monitor-blackout.fade.pid"
 
 # Number of fade steps and inter-step delay for fade transitions.
 # ~560ms per ddcutil call (hard floor at --sleep-multiplier 0.1), so 15 steps
@@ -44,8 +45,14 @@ get_brightness() { # $1=bus  -> current VCP 0x10 value
   "$DDC" --bus "$1" getvcp 10 --brief 2>/dev/null | awk '{print $4}'
 }
 
-set_brightness() { # $1=bus $2=value
-  "$DDC" --bus "$1" setvcp 10 "$2" --noverify 2>/dev/null
+set_brightness() { # $1=bus $2=value  — retries 3x on DDC-CI failure (this LG panel is flaky)
+  local bus="$1" val="$2" attempt
+  for attempt in 1 2 3; do
+    "$DDC" --bus "$bus" setvcp 10 "$val" --noverify 2>/dev/null && return 0
+    sleep 0.5
+  done
+  echo "DDC-CI setvcp failed after 3 attempts on bus $bus (val=$val)" >&2
+  return 1
 }
 
 cancel_timer() {
@@ -54,8 +61,11 @@ cancel_timer() {
 }
 
 schedule_restore() { # $1=bus $2=original_brightness $3=duration
+  # Write saved brightness so `restore` can read it; use the script itself
+  # (with retry + 0-default) instead of raw ddcutil.
+  printf '%s:%s\n' "$1" "$2" > "$STATE"
   systemd-run --user --unit="$UNIT" --on-active="$3" --timer-property=AccuracySec=1s \
-    "$DDC" --bus "$1" setvcp 10 "$2" >/dev/null
+    "$0" restore >/dev/null
 }
 
 # --- actions ---------------------------------------------------------------
@@ -77,9 +87,25 @@ blackout() {
 
 restore() {
   cancel_timer
+  # Kill any running background fade (sleep was triggered but wake came before it finished)
+  if [ -f "$FADE_PID_FILE" ]; then
+    local fpid
+    fpid=$(cat "$FADE_PID_FILE" 2>/dev/null || true)
+    rm -f "$FADE_PID_FILE"
+    if [ -n "$fpid" ] && kill -0 "$fpid" 2>/dev/null; then
+      kill "$fpid" 2>/dev/null || true
+      sleep 0.5
+    fi
+  fi
+  # Cancel again — a fade that completes between first cancel and kill may have
+  # re-created the timer via schedule_restore.
+  cancel_timer
   local bus="" cur=""
   [ -f "$STATE" ] && IFS=: read -r bus cur < "$STATE" || true
-  bus="${bus:-$(detect_bus || true)}"; cur="${cur:-60}"
+  bus="${bus:-$(detect_bus || true)}"
+  # Saved brightness of 0 means blackout read while monitor was already dark
+  # (race with prior fade) — fall back to a usable default instead of staying dark.
+  [ -n "$cur" ] && [ "$cur" != "0" ] || cur=60
   [ -n "$bus" ] || { echo "no DDC/CI monitor detected" >&2; exit 1; }
   set_brightness "$bus" "$cur"
   rm -f "$STATE"
@@ -90,9 +116,8 @@ fade_to_zero() { # $1=bus $2=from_brightness
   local bus="$1" from="$2" to=0 i val
   for (( i=0; i<=FADE_STEPS; i++ )); do
     val=$(( from + (to - from) * i / FADE_STEPS ))
-    set_brightness "$bus" "$val" &
+    set_brightness "$bus" "$val"
     sleep "$FADE_DELAY"
-    wait
   done
 }
 
@@ -100,9 +125,8 @@ fade_from_zero() { # $1=bus $2=to_brightness
   local bus="$1" to="$2" from=0 i val
   for (( i=0; i<=FADE_STEPS; i++ )); do
     val=$(( from + (to - from) * i / FADE_STEPS ))
-    set_brightness "$bus" "$val" &
+    set_brightness "$bus" "$val"
     sleep "$FADE_DELAY"
-    wait
   done
 }
 
@@ -113,8 +137,11 @@ fade_blackout() {
   cur=$(get_brightness "$bus") || true
   [ -n "${cur:-}" ] || { echo "could not read brightness on bus $bus" >&2; exit 1; }
   printf '%s:%s\n' "$bus" "$cur" > "$STATE"
+  echo "$$" > "$FADE_PID_FILE"
 
   fade_to_zero "$bus" "$cur"
+
+  rm -f "$FADE_PID_FILE"
 
   cancel_timer
   schedule_restore "$bus" "$cur" "$dur"
@@ -125,7 +152,8 @@ fade_restore() {
   cancel_timer
   local bus="" cur=""
   [ -f "$STATE" ] && IFS=: read -r bus cur < "$STATE" || true
-  bus="${bus:-$(detect_bus || true)}"; cur="${cur:-60}"
+  bus="${bus:-$(detect_bus || true)}"
+  [ -n "$cur" ] && [ "$cur" != "0" ] || cur=60
   [ -n "$bus" ] || { echo "no DDC/CI monitor detected" >&2; exit 1; }
 
   fade_from_zero "$bus" "$cur"

--- a/scripts/monitor-blackout.sh
+++ b/scripts/monitor-blackout.sh
@@ -57,6 +57,7 @@ set_brightness() { # $1=bus $2=value  — retries 3x on DDC-CI failure (this LG 
 
 cancel_timer() {
   systemctl --user stop    "${UNIT}.timer"   2>/dev/null || true
+  systemctl --user kill    "${UNIT}.service" 2>/dev/null || true
   systemctl --user reset-failed "${UNIT}.service" "${UNIT}.timer" 2>/dev/null || true
 }
 
@@ -64,6 +65,9 @@ schedule_restore() { # $1=bus $2=original_brightness $3=duration
   # Write saved brightness so `restore` can read it; use the script itself
   # (with retry + 0-default) instead of raw ddcutil.
   printf '%s:%s\n' "$1" "$2" > "$STATE"
+  # Aggressively cancel any existing timer — stale pre-fix timers share the
+  # same unit name and can race with this creation.
+  cancel_timer
   systemd-run --user --unit="$UNIT" --on-active="$3" --timer-property=AccuracySec=1s \
     "$0" restore >/dev/null
 }

--- a/scripts/rig-control.sh
+++ b/scripts/rig-control.sh
@@ -68,7 +68,7 @@ do_sleep() {
 do_wake() {
   echo "awake" > "$STATE_FILE"
   rgb_on
-  restore_bg
+  restore
   notify "Wake mode activated"
 }
 


### PR DESCRIPTION
Rescues two commits that existed **only** on the workbench's local `main` and on no remote ref.

## Why this PR exists

`~/workspace/devrc` on the workbench was 2 commits ahead of `origin/main`, on `main`, with neither commit pushed anywhere. Per `CLAUDE.md` → *Git discipline*, `scripts/ship.sh` converges with `merge --ff-only`, so a diverged host is **skipped and left as found** — it silently stops receiving every future change while still looking healthy. That state also blocked deploying an unrelated in-flight PR to the very host it targets.

This is the documented recovery, first half: preserve and push before moving any pointer. The `git reset --keep origin/main` step is **deliberately not done yet** — another session has uncommitted work in that checkout right now.

## What's here

- `1cb7fbc` fix(rig-control): reliable brightness restore after sleep — `scripts/monitor-blackout.sh`, `scripts/rig-control.sh`
- `69363a0` fix(rig-control): aggressive timer cancellation prevents stale restores — `scripts/monitor-blackout.sh`

Both authored 2026-08-06.

## Review note

These commits have **never been gated against the tree they now land in** — they were committed directly to a local `main` and bypassed PR review and CI. That is the reason this is a PR rather than a push to `main`.

Not reviewed as part of this rescue: `claudedocs/handoff-rig-control-brightness.md` is untracked in that working tree and appears to belong to the same effort. It was deliberately left alone rather than swept into this branch, since it is another session's working state. It is unsaved work in the `RULES.md` sense and should be committed or PR'd by whoever owns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
