### PR TITLE
fix(rig-control): brightness restore after sleep (3 commits rescued from the workbench)

### DIFF
--- a/scripts/monitor-blackout.sh
+++ b/scripts/monitor-blackout.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 DDC=$(command -v ddcutil) || { echo "ddcutil not found on PATH" >&2; exit 1; }
 UNIT=monitor-blackout-restore
 STATE="${XDG_RUNTIME_DIR:-/tmp}/monitor-blackout.state"   # "bus:brightness"
+FADE_PID_FILE="${XDG_RUNTIME_DIR:-/tmp}/monitor-blackout.fade.pid"
 
 # Number of fade steps and inter-step delay for fade transitions.
 # ~560ms per ddcutil call (hard floor at --sleep-multiplier 0.1), so 15 steps
@@ -44,8 +45,14 @@ get_brightness() { # $1=bus  -> current VCP 0x10 value
   "$DDC" --bus "$1" getvcp 10 --brief 2>/dev/null | awk '{print $4}'
 }
 
-set_brightness() { # $1=bus $2=value
-  "$DDC" --bus "$1" setvcp 10 "$2" --noverify 2>/dev/null
+set_brightness() { # $1=bus $2=value  — retries 3x on DDC-CI failure (this LG panel is flaky)
+  local bus="$1" val="$2" attempt
+  for attempt in 1 2 3; do
+    "$DDC" --bus "$bus" setvcp 10 "$val" --noverify 2>/dev/null && return 0
+    sleep 0.5
+  done
+  echo "DDC-CI setvcp failed after 3 attempts on bus $bus (val=$val)" >&2
+  return 1
 }
 
 cancel_timer() {
@@ -54,8 +61,11 @@ cancel_timer() {
 }
 
 schedule_restore() { # $1=bus $2=original_brightness $3=duration
+  # Write saved brightness so `restore` can read it; use the script itself
+  # (with retry + 0-default) instead of raw ddcutil.
+  printf '%s:%s\n' "$1" "$2" > "$STATE"
   systemd-run --user --unit="$UNIT" --on-active="$3" --timer-property=AccuracySec=1s \
-    "$DDC" --bus "$1" setvcp 10 "$2" >/dev/null
+    "$0" restore >/dev/null
 }
 
 # --- actions ---------------------------------------------------------------
@@ -77,9 +87,25 @@ blackout() {
 
 restore() {
   cancel_timer
+  # Kill any running background fade (sleep was triggered but wake came before it finished)
+  if [ -f "$FADE_PID_FILE" ]; then
+    local fpid
+    fpid=$(cat "$FADE_PID_FILE" 2>/dev/null || true)
+    rm -f "$FADE_PID_FILE"
+    if [ -n "$fpid" ] && kill -0 "$fpid" 2>/dev/null; then
+      kill "$fpid" 2>/dev/null || true
+      sleep 0.5
+    fi
+  fi
+  # Cancel again — a fade that completes between first cancel and kill may have
+  # re-created the timer via schedule_restore.
+  cancel_timer
   local bus="" cur=""
   [ -f "$STATE" ] && IFS=: read -r bus cur < "$STATE" || true
-  bus="${bus:-$(detect_bus || true)}"; cur="${cur:-60}"
+  bus="${bus:-$(detect_bus || true)}"
+  # Saved brightness of 0 means blackout read while monitor was already dark
+  # (race with prior fade) — fall back to a usable default instead of staying dark.
+  [ -n "$cur" ] && [ "$cur" != "0" ] || cur=60
   [ -n "$bus" ] || { echo "no DDC/CI monitor detected" >&2; exit 1; }
   set_brightness "$bus" "$cur"
   rm -f "$STATE"
@@ -90,9 +116,8 @@ fade_to_zero() { # $1=bus $2=from_brightness
   local bus="$1" from="$2" to=0 i val
   for (( i=0; i<=FADE_STEPS; i++ )); do
     val=$(( from + (to - from) * i / FADE_STEPS ))
-    set_brightness "$bus" "$val" &
+    set_brightness "$bus" "$val"
     sleep "$FADE_DELAY"
-    wait
   done
 }
 
@@ -100,9 +125,8 @@ fade_from_zero() { # $1=bus $2=to_brightness
   local bus="$1" to="$2" from=0 i val
   for (( i=0; i<=FADE_STEPS; i++ )); do
     val=$(( from + (to - from) * i / FADE_STEPS ))
-    set_brightness "$bus" "$val" &
+    set_brightness "$bus" "$val"
     sleep "$FADE_DELAY"
-    wait
   done
 }
 
@@ -113,8 +137,11 @@ fade_blackout() {
   cur=$(get_brightness "$bus") || true
   [ -n "${cur:-}" ] || { echo "could not read brightness on bus $bus" >&2; exit 1; }
   printf '%s:%s\n' "$bus" "$cur" > "$STATE"
+  echo "$$" > "$FADE_PID_FILE"
 
   fade_to_zero "$bus" "$cur"
+
+  rm -f "$FADE_PID_FILE"
 
   cancel_timer
   schedule_restore "$bus" "$cur" "$dur"
@@ -125,7 +152,8 @@ fade_restore() {
   cancel_timer
   local bus="" cur=""
   [ -f "$STATE" ] && IFS=: read -r bus cur < "$STATE" || true
-  bus="${bus:-$(detect_bus || true)}"; cur="${cur:-60}"
+  bus="${bus:-$(detect_bus || true)}"
+  [ -n "$cur" ] && [ "$cur" != "0" ] || cur=60
   [ -n "$bus" ] || { echo "no DDC/CI monitor detected" >&2; exit 1; }
 
   fade_from_zero "$bus" "$cur"

--- a/scripts/monitor-blackout.sh
+++ b/scripts/monitor-blackout.sh
@@ -57,6 +57,7 @@ set_brightness() { # $1=bus $2=value  — retries 3x on DDC-CI failure (this LG 
 
 cancel_timer() {
   systemctl --user stop    "${UNIT}.timer"   2>/dev/null || true
+  systemctl --user kill    "${UNIT}.service" 2>/dev/null || true
   systemctl --user reset-failed "${UNIT}.service" "${UNIT}.timer" 2>/dev/null || true
 }
 
@@ -64,6 +65,9 @@ schedule_restore() { # $1=bus $2=original_brightness $3=duration
   # Write saved brightness so `restore` can read it; use the script itself
   # (with retry + 0-default) instead of raw ddcutil.
   printf '%s:%s\n' "$1" "$2" > "$STATE"
+  # Aggressively cancel any existing timer — stale pre-fix timers share the
+  # same unit name and can race with this creation.
+  cancel_timer
   systemd-run --user --unit="$UNIT" --on-active="$3" --timer-property=AccuracySec=1s \
     "$0" restore >/dev/null
 }

--- a/scripts/monitor-blackout.sh
+++ b/scripts/monitor-blackout.sh
@@ -18,7 +18,8 @@
 set -euo pipefail
 
 DDC=$(command -v ddcutil) || { echo "ddcutil not found on PATH" >&2; exit 1; }
-UNIT=monitor-blackout-restore
+UNIT=monitor-blackout-restore-v2
+UNIT_LEGACY=monitor-blackout-restore
 STATE="${XDG_RUNTIME_DIR:-/tmp}/monitor-blackout.state"   # "bus:brightness"
 FADE_PID_FILE="${XDG_RUNTIME_DIR:-/tmp}/monitor-blackout.fade.pid"
 
@@ -56,9 +57,12 @@ set_brightness() { # $1=bus $2=value  — retries 3x on DDC-CI failure (this LG 
 }
 
 cancel_timer() {
-  systemctl --user stop    "${UNIT}.timer"   2>/dev/null || true
-  systemctl --user kill    "${UNIT}.service" 2>/dev/null || true
-  systemctl --user reset-failed "${UNIT}.service" "${UNIT}.timer" 2>/dev/null || true
+  local u
+  for u in "$UNIT" "$UNIT_LEGACY"; do
+    systemctl --user stop    "${u}.timer"   2>/dev/null || true
+    systemctl --user kill    "${u}.service" 2>/dev/null || true
+    systemctl --user reset-failed "${u}.service" "${u}.timer" 2>/dev/null || true
+  done
 }
 
 schedule_restore() { # $1=bus $2=original_brightness $3=duration

--- a/scripts/rig-control.sh
+++ b/scripts/rig-control.sh
@@ -68,7 +68,7 @@ do_sleep() {
 do_wake() {
   echo "awake" > "$STATE_FILE"
   rgb_on
-  restore_bg
+  restore
   notify "Wake mode activated"
 }
 


### PR DESCRIPTION
## Why this is a PR and not already merged

These three commits existed **only** on the workbench's local `main`, un-pushed. `scripts/ship.sh` had been skipping that host with `rc=8 skipped:diverged` — so the workbench silently stopped receiving every change while still looking healthy, exactly the failure `CLAUDE.md` → "Git discipline" documents.

Found while shipping an unrelated clawgate doc fix (#365), which is what first surfaced the skip.

## Commits

```
64847b3 fix(rig-control): use new unit name to escape stale pre-fix timers
69363a0 fix(rig-control): aggressive timer cancellation prevents stale restores
1cb7fbc fix(rig-control): reliable brightness restore after sleep
```

## Recovery performed (preserve → verify → move)

Per the documented procedure:

1. `git branch rescue/… HEAD && git push -u origin rescue/…` on the workbench.
2. **Verified from a different host** (the laptop) that all three SHAs are on origin and reachable from the pushed tip — before anything moved.
3. `git reset --keep origin/main`. It initially **refused** (`Entry 'flake.lock' not uptodate`) — the correct signal, not a problem to bulldoze.
4. Investigated rather than forced: all six "modified" tracked files hashed **byte-identical to `origin/main`**. They were not WIP — that work had already landed upstream; they only read as modified because local `main` was 3 behind. Round-tripped them through `HEAD` and re-ran `--keep`, with pre/post `hash-object` proving **zero byte change**. Dirty files were also tarred aside first (`~/devrc-preflight-backup-2026-08-10/`) — copied, never stashed, since the stash stack is repo-global.
5. All 7 untracked files on that host preserved.

## Review note

🔴 **These commits have never been gated against the tree they now land in.** They were written against a `main` that was 3 commits behind, so this needs a real review of `scripts/rig-control.sh`, not a rubber stamp — that is the whole reason the rescue path ends in a PR instead of a push to `main`.

## Loose end, not addressed here

The workbench also carries untracked `claudedocs/handoff-rig-control-brightness.md`, which appears to be the handoff for exactly this work and is one routine `checkout` from silent loss. It should be committed too — flagging rather than sweeping it into this PR unreviewed.