### PR TITLE
feat(drift): passive drift deadman for the two-host fleet + one shared host-identity predicate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,11 @@ there. Only what's specific to this repo, where a working tree is also a **deplo
   healthy. 2026-08-06: two un-pushed commits on the workbench blocked it for hours, and the
   regrowth timer would have fired on 08-11 running the very bug the undelivered commit fixed.
   **Read every per-host line of `ship.sh`, not the final verdict** — one skip hides among
-  greens, and it prints its own rc legend on failure.
+  greens, and it prints its own rc legend on failure. Recurred 2026-08-09 (three un-pushed
+  commits, rescued as #366) — because **nothing runs `ship.sh` on a schedule**, so the only
+  detector was a human shipping something unrelated. `scripts/drift-check.sh` is the passive
+  deadman for exactly this: READ-ONLY (fetch + report, never fixes), same rc vocabulary as
+  `ship.sh`, run it any time by hand or via the `drift-check` systemd-user timer.
 - **Recovering a diverged host** — preserve, verify, *then* move the pointer:
   `git branch <topic> HEAD && git push -u origin <topic>` on that host → confirm the shas are
   on origin **from a different host** → `git reset --keep origin/main` (`--keep` refuses

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -18,6 +18,16 @@ let
   # DDL/insert path (snapshot #1 wrote 23 rows to prod, telemetry-on, and the DSN role
   # is confirmed to have CREATE SCHEMA). The timer runs hourly (see the timer below).
   enableInitiativesSync = true;
+  # Drift-deadman master switch (scripts/drift-check.sh) — gates ONLY whether the
+  # timer is wired into timers.target. The SERVICE definition is always emitted, so
+  # `systemctl --user start drift-check` works by hand on either host regardless.
+  # 🔴 Deliberately OFF at merge: the deadman was built + validated against scratch
+  # clones only, and enabling a timer is a live change to a host's behaviour. Flip to
+  # true in a separate, supervised deploy after one hand-run on the workbench proves
+  # the ssh leg reaches the laptop from a systemd-user context (a user unit has no
+  # ssh-agent, so the laptop key must be usable non-interactively — the one thing
+  # scratch clones structurally cannot test).
+  enableDriftDeadman = false;
   # Graphical host = runs X/i3 (both current NixOS hosts do; only a genuinely headless
   # box would not). Approximated as isNixOS, mirroring graphical.nix — deliberately NOT
   # !serverMode, which is true on the graphical workbench.
@@ -1811,6 +1821,84 @@ in
     };
     Install = {
       WantedBy = [ "timers.target" ];
+    };
+  };
+
+  # ── PASSIVE DRIFT DEADMAN (scripts/drift-check.sh) ───────────────────────────
+  # The gap this closes: `scripts/ship.sh` converges both hosts correctly, and a
+  # host it cannot fast-forward is SKIPPED and left as found (rc=8). But NOTHING
+  # RUNS SHIP ON A SCHEDULE — so a skipped host silently stops receiving every
+  # change while looking completely healthy. That has now happened twice
+  # (2026-08-06, 2026-08-09), both times found only because a human happened to
+  # ship something unrelated and read the per-host lines.
+  #
+  # This unit is the thing that looks when nobody is looking. It is READ-ONLY: it
+  # fetches (remote-tracking refs only) and reports. It never checks out, merges,
+  # fast-forwards, rebases, resets, or runs home-manager — enforced statically by
+  # scripts/tests/test_drift_check.py.
+  #
+  # ALERTING: no new notification mechanism. The script exits non-zero on drift,
+  # the unit enters `failed`, and the EXISTING OnFailure=notify-failure@%n.service
+  # turns that into the same sticky critical dunst toast every other important
+  # user unit already uses. The toast names the unit; the rc legend + per-host
+  # lines are in `journalctl --user -u drift-check`.
+  #
+  # The service is emitted UNCONDITIONALLY (any host can run it by hand); only the
+  # TIMER's timers.target wiring is gated — see enableDriftDeadman above.
+  systemd.user.services.drift-check = {
+    Unit = {
+      Description = "Passive drift deadman — is either devrc host silently no longer receiving changes?";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+      OnFailure = [ "notify-failure@%n.service" ];
+    };
+    Service = {
+      Type = "oneshot";
+      # Two `git fetch`es plus one ssh round trip. The ConnectTimeout inside the
+      # script is 10s, so this ceiling only ever fires on a wedged fetch; the
+      # cgroup is killed and the timer re-arms on the next OnUnitActiveSec.
+      TimeoutStartSec = 180;
+      Environment = [
+        # iproute2 is load-bearing, not incidental: `ip -4 -o addr show` is how
+        # local_ipv4s identifies WHICH host this is (both report hostname `nixos`).
+        # Without it detection returns "unknown" and the script exits 6.
+        "PATH=${lib.makeBinPath [ pkgs.git pkgs.openssh pkgs.iproute2 pkgs.bash pkgs.coreutils pkgs.gawk pkgs.gnused pkgs.gnugrep ]}"
+        "HOME=%h"
+      ];
+      ExecStart = "${pkgs.bash}/bin/bash %h/workspace/devrc/scripts/drift-check.sh";
+      # Re-run the unit when either the checker or the shared host-identity
+      # predicate changes.
+      X-Restart-Triggers = [
+        "${../scripts/drift-check.sh}"
+        "${../scripts/lib/host-role.sh}"
+      ];
+    };
+  };
+
+  # 6-hourly, not daily. The choice is bounded by the incident: on 2026-08-06 the
+  # workbench was blocked "for hours"; on 2026-08-09 three commits sat un-pushed
+  # long enough for a whole day's changes to miss that host. Daily would leave a
+  # ~24h window in which every merge silently misses a host — which is the failure
+  # itself, only shorter. 6h caps it at a quarter of that for 4 ssh+fetch round
+  # trips a day, a cost too small to be worth trading against. Anything tighter
+  # buys little: a human ships several times a day anyway, and the toast would
+  # start reading as noise. OnStartupSec gives one prompt run after login (the
+  # laptop is intermittent, so "just resumed" is exactly when it should look).
+  # No Persistent — it only applies to OnCalendar timers, not monotonic ones.
+  systemd.user.timers.drift-check = {
+    Unit = {
+      Description = "Periodic timer for the passive devrc drift deadman";
+    };
+    Timer = {
+      OnStartupSec = "10min";
+      OnUnitActiveSec = "6h";
+    };
+    Install = {
+      # 🔴 The master switch acts HERE and only here: with enableDriftDeadman
+      # false the unit file still exists (so it can be started/inspected by hand)
+      # but is wired into nothing, so no routine `ship.sh` can silently start a
+      # timer nobody has supervised once.
+      WantedBy = lib.optionals (serverMode && enableDriftDeadman) [ "timers.target" ];
     };
   };
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -104,6 +104,8 @@ Click actions for those blocks:
 | `run-tests.sh` | **single source of truth** for running the Python suites |
 | `run-node-tests.sh` | single source of truth for running the `.mjs` suites |
 | `ship.sh` | converge BOTH NixOS hosts (workbench + laptop) to `origin/main`, then verify |
+| `drift-check.sh` | **passive deadman** — is either host silently no longer receiving changes? READ-ONLY: fetches and reports, never fixes. Distinct rc per condition (8 un-pushed/diverged, 10 behind, 12 not-on-main, 3/4 cannot-evaluate, 13 unreachable), aligned with `ship.sh`'s legend. Runs unattended as the `drift-check` systemd-user timer; drift ⇒ non-zero ⇒ the existing `notify-failure@` dunst toast |
+| `lib/host-role.sh` | the ONE host-identity predicate (both hosts report hostname `nixos`, so identity comes from local IPv4s). Sourced by `ship.sh` **and** `drift-check.sh` — never copied |
 
 ## Subsystems
 

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# drift-check — PASSIVE deadman for the devrc two-host fleet.
+#
+# Answers ONE question, unattended, on a timer: "is either host silently no
+# longer receiving changes?" It REPORTS. It never fixes.
+#
+# ── WHY THIS EXISTS ───────────────────────────────────────────────────────────
+# `scripts/ship.sh` converges both hosts and is correct: a host it cannot
+# fast-forward is SKIPPED and left exactly as found (rc=8 skipped:diverged). But
+# NOTHING RUNS SHIP ON A SCHEDULE. So a host that starts getting skipped stops
+# receiving every subsequent change while continuing to look completely healthy —
+# same commits in `git log`, same green `home-manager` generation, no error
+# anywhere. The only detector was "a human happens to ship something and reads
+# the per-host lines".
+#
+# That has now happened twice:
+#   2026-08-06  two un-pushed commits on the workbench blocked it for hours; the
+#               regrowth timer would have fired on 08-11 running the very bug the
+#               undelivered commit fixed.
+#   2026-08-09  THREE un-pushed commits on the workbench (rescued as #366), found
+#               only because someone shipped something unrelated. Alongside them,
+#               7 untracked files — including a handoff doc for the stranded work.
+#
+# ── PASSIVE MEANS PASSIVE ─────────────────────────────────────────────────────
+# 🔴 This script must NEVER mutate either host's working state. It may `git
+# fetch` (which writes only remote-tracking refs, never the working tree, the
+# index, or any local branch). It must NEVER checkout, switch, merge,
+# fast-forward, rebase, reset, stash, clean, commit, or run `home-manager`.
+# A deadman that repairs is a deployer with no supervision; a deadman that
+# reports is a deadman. `scripts/tests/test_drift_check.py` enforces this
+# statically against this file's executable lines.
+#
+# ── HOST IDENTITY ─────────────────────────────────────────────────────────────
+# Both machines report hostname `nixos`, so identity comes from local IPv4
+# addresses. That predicate is NOT reimplemented here — it is sourced from
+# scripts/lib/host-role.sh, the same file ship.sh sources. A second copy would
+# drift and be wrong, which is exactly how ship.sh's host detection was broken
+# before (it hardcoded "local == workbench" and SSH'd to itself).
+#
+# ── EXIT CODES ────────────────────────────────────────────────────────────────
+# Deliberately aligned with ship.sh so the two read consistently: a code means
+# the same thing in both, and codes ship.sh owns for actions this script does not
+# take (5 conflicted-tree, 7 cannot-ff, 9 switch-failed, 11 verify-failed) are
+# left UNUSED rather than repurposed.
+#
+#   3   repo missing on that host
+#   4   git fetch failed, or origin/main is missing / HEAD unborn
+#   6   local host could not be identified (see detect_role)
+#   8   DRIFT — local `main` has DIVERGED or is AHEAD of origin/main (un-pushed
+#       commits). 🔴 THE DANGEROUS ONE — ship.sh will skip this host forever.
+#   10  DRIFT — local `main` is BEHIND origin/main (just needs a ship)
+#   12  DRIFT — the checkout is not ON branch `main`
+#   13  host unreachable (ssh failed / timed out)
+#
+# When several hosts fail, the exit code is the MOST SEVERE, not the first —
+# this differs from ship.sh on purpose. ship.sh keeps the first non-zero because
+# every host's line is printed anyway and a human is reading them live. Nobody
+# is reading a timer's output, so the single number it hands to systemd must be
+# the worst thing found, or an un-pushed workbench could hide behind a merely
+# behind laptop. Severity order (worst first):
+#     8  >  13  >  4  >  3  >  12  >  10
+# Per-host lines are ALWAYS printed for every host, whatever the code.
+#
+# Untracked files are counted and listed per host as INFORMATION only — they
+# never change the exit code. They are the same loss class (work sitting on one
+# host that no other host and no backup has) and cost nothing to report.
+#
+# ── USAGE ─────────────────────────────────────────────────────────────────────
+#   scripts/drift-check.sh                 # check this host + the other one
+#   scripts/drift-check.sh --no-remote     # this host only (no ssh)
+#   scripts/drift-check.sh --no-local      # the other host only
+#   scripts/drift-check.sh --detect-role   # print detected local role, exit 0
+#
+# Env overrides:
+#   SHIP_ROLE    force the local role (workbench|laptop) — shared with ship.sh
+#   REMOTE_SSH   ssh target for the OTHER host (default derived from role)
+#   LAPTOP_SSH   back-compat: applies ONLY when the remote host is the laptop
+#   DRIFT_REPO   repo path checked on the LOCAL host (default $HOME/workspace/devrc)
+#   DRIFT_UNTRACKED_MAX  max untracked paths listed per host (default 10)
+set -uo pipefail
+
+# --- Host identity: SOURCED, never copied (see header) ------------------------
+_drift_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)/lib/host-role.sh"
+if [ ! -r "$_drift_lib" ]; then
+  echo "drift-check: cannot read $_drift_lib — host identity cannot be resolved." >&2
+  exit 6
+fi
+# shellcheck source=lib/host-role.sh
+. "$_drift_lib"
+
+if [ "${1:-}" = "--detect-role" ]; then
+  if [ "$#" -ge 2 ]; then detect_role "$2"; else detect_role "$(local_ipv4s | tr '\n' ' ')"; fi
+  exit 0
+fi
+
+DRIFT_REPO="${DRIFT_REPO:-$HOME/workspace/devrc}"
+DRIFT_UNTRACKED_MAX="${DRIFT_UNTRACKED_MAX:-10}"
+DO_LOCAL=1
+DO_REMOTE=1
+for a in "$@"; do
+  case "$a" in
+    --no-remote|--no-laptop) DO_REMOTE=0 ;;
+    --no-local)  DO_LOCAL=0 ;;
+    --detect-role) : ;;   # handled above
+    # Print the contiguous comment block after the shebang (no line numbers to drift).
+    -h|--help)   awk 'NR>1 { if (/^#/) print; else exit }' "$0"; exit 0 ;;
+    *) echo "unknown arg: $a" >&2; exit 2 ;;
+  esac
+done
+
+LOCAL_ROLE="$(resolve_local_role)"
+if [ "$LOCAL_ROLE" != workbench ] && [ "$LOCAL_ROLE" != laptop ]; then
+  echo "drift-check: could not identify this host (role='$LOCAL_ROLE')." >&2
+  echo "  local IPv4s: $(local_ipv4s | tr '\n' ' ')" >&2
+  echo "  expected a workbench ($WORKBENCH_IP_PRIMARY) or laptop ($LAPTOP_IP_PRIMARY) address." >&2
+  echo "  override with SHIP_ROLE=workbench|laptop to force." >&2
+  exit 6
+fi
+REMOTE_ROLE="$(remote_role_of "$LOCAL_ROLE")"
+REMOTE_SSH="$(remote_ssh_of "$LOCAL_ROLE")"
+
+# severity <rc> -> a comparable number; higher = worse. Unknown codes rank above
+# every known one so a NEW failure mode can never be silently outranked into
+# invisibility by a merely-behind host.
+severity() {
+  case "${1:-0}" in
+    0)  echo 0 ;;
+    8)  echo 70 ;;
+    13) echo 60 ;;
+    4)  echo 55 ;;
+    3)  echo 50 ;;
+    12) echo 40 ;;
+    10) echo 30 ;;
+    *)  echo 99 ;;
+  esac
+}
+
+# ── The per-host CHECK routine ────────────────────────────────────────────────
+# Run identically on each host: locally via `bash -c`, remotely by PIPING it to
+# `bash -s` over ssh. It is piped rather than inlined because BOTH hosts' login
+# shell is zsh, and zsh does not word-split an unbraced `$var` — an inlined
+# multi-command script silently behaves differently there. `bash -s` removes the
+# interpreter from the equation entirely.
+#
+# READ-ONLY BY CONSTRUCTION: the only git commands here are `fetch`, `rev-parse`,
+# `rev-list`, `symbolic-ref`, `show-ref`, `ls-files` and `log`. `fetch` writes
+# remote-tracking refs only.
+CHECK='
+set -uo pipefail
+repo="${DRIFT_REPO:-$HOME/workspace/devrc}"
+label="${DRIFT_LABEL:-host}"
+maxu="${DRIFT_UNTRACKED_MAX:-10}"
+say() { echo "[$label] $*"; }
+
+[ -d "$repo/.git" ] || [ -f "$repo/.git" ] || { say "no repo at $repo"; exit 3; }
+cd "$repo" || { say "no repo at $repo"; exit 3; }
+
+git fetch origin -q 2>/dev/null || { say "git fetch failed — cannot evaluate drift"; exit 4; }
+target=$(git rev-parse -q --verify origin/main) || {
+  say "no origin/main after a successful fetch — remote/branch misconfigured."
+  say "  check: git -C $repo remote -v ; git -C $repo branch -r"
+  exit 4
+}
+
+# --- INFORMATION (never affects the exit code) --------------------------------
+untracked=$(git ls-files --others --exclude-standard 2>/dev/null)
+if [ -n "$untracked" ]; then
+  n=$(printf "%s\n" "$untracked" | wc -l | tr -d " ")
+  say "untracked: $n file(s) — present on this host only, in no commit and no backup"
+  printf "%s\n" "$untracked" | head -n "$maxu" | sed "s|^|[$label]     - |"
+  [ "$n" -gt "$maxu" ] && say "    ... and $(( n - maxu )) more"
+else
+  say "untracked: 0"
+fi
+
+# --- Which branch is checked out? ---------------------------------------------
+branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || echo DETACHED)
+off_main=0
+if [ "$branch" != "main" ]; then
+  off_main=1
+  say "DRIFT — checkout is on '"'"'$branch'"'"', not on branch main."
+  say "  ship.sh will move it, but anything committed there is invisible to origin/main."
+fi
+
+# --- Where is the LOCAL main branch relative to origin/main? ------------------
+# Checked whatever is checked out: local main can be diverged while HEAD sits on
+# some feature branch, and that is still a host that will be skipped forever.
+if ! git show-ref --verify --quiet refs/heads/main; then
+  say "DRIFT — no local main branch exists in this checkout."
+  exit 12
+fi
+main=$(git rev-parse -q --verify refs/heads/main) || {
+  say "cannot resolve refs/heads/main"; exit 4; }
+
+counts=$(git rev-list --left-right --count origin/main...main 2>/dev/null) || {
+  say "cannot compare main to origin/main"; exit 4; }
+behind=$(printf "%s" "$counts" | awk "{print \$1}")
+ahead=$(printf "%s" "$counts" | awk "{print \$2}")
+
+if [ "${ahead:-0}" -gt 0 ]; then
+  # AHEAD or DIVERGED — the dangerous one. ship.sh cannot fast-forward this host,
+  # so it is skipped on EVERY future run and silently stops receiving changes.
+  if [ "${behind:-0}" -gt 0 ]; then
+    say "🔴 DRIFT — local main has DIVERGED: $ahead un-pushed commit(s), $behind behind."
+  else
+    say "🔴 DRIFT — local main is AHEAD by $ahead un-pushed commit(s)."
+  fi
+  say "  ship.sh SKIPS this host (rc=8) and will keep skipping it — it is receiving NOTHING."
+  git log --oneline --no-decorate origin/main..main 2>/dev/null | head -n 10 | sed "s|^|[$label]     + |"
+  say "  rescue (on that host): git branch <topic> main && git push -u origin <topic>"
+  say "  then confirm from ANOTHER host, then: git reset --keep origin/main   (never --hard)"
+  exit 8
+fi
+
+if [ "${behind:-0}" -gt 0 ]; then
+  say "DRIFT — local main is BEHIND origin/main by $behind commit(s) — needs a ship."
+  say "  fix: scripts/ship.sh"
+  exit 10
+fi
+
+if [ "$off_main" = 1 ]; then exit 12; fi
+
+say "✅ clean — on branch main, main == origin/main ($target)"
+exit 0
+'
+
+rc=0
+note_rc() { # note_rc <rc> — keep the MOST SEVERE code seen (see header)
+  local new="$1"
+  [ "$new" = 0 ] && return 0
+  if [ "$(severity "$new")" -gt "$(severity "$rc")" ]; then rc="$new"; fi
+}
+
+if [ "$DO_LOCAL" = 1 ]; then
+  echo "=== local ($LOCAL_ROLE) ==="
+  DRIFT_REPO="$DRIFT_REPO" DRIFT_LABEL="$LOCAL_ROLE" \
+    DRIFT_UNTRACKED_MAX="$DRIFT_UNTRACKED_MAX" \
+    bash -c "$CHECK"
+  note_rc "$?"
+  echo
+fi
+
+if [ "$DO_REMOTE" = 1 ]; then
+  echo "=== remote ($REMOTE_ROLE — $REMOTE_SSH) ==="
+  # DRIFT_REPO is deliberately NOT forwarded: it is a local override, and the
+  # remote host's repo lives at its own $HOME/workspace/devrc.
+  # `bash -s` (piped, not inlined) — see the CHECK header re: zsh.
+  printf 'DRIFT_LABEL=%s\nDRIFT_UNTRACKED_MAX=%s\n%s\n' \
+    "$REMOTE_ROLE" "$DRIFT_UNTRACKED_MAX" "$CHECK" \
+    | ssh -o ConnectTimeout=10 -o BatchMode=yes "$REMOTE_SSH" bash -s
+  remrc=$?
+  # ssh itself exits 255 on a connection/auth failure — that is "we could not
+  # look", which for a deadman must be LOUD, never a green.
+  if [ "$remrc" = 255 ]; then
+    echo "[$REMOTE_ROLE] UNREACHABLE — ssh to $REMOTE_SSH failed or timed out."
+    echo "[$REMOTE_ROLE]   drift on that host CANNOT be evaluated — this is not a pass."
+    remrc=13
+  fi
+  note_rc "$remrc"
+  echo
+fi
+
+if [ "$rc" = 0 ]; then
+  echo "drift-check: no drift — both hosts on branch main at origin/main."
+else
+  echo "drift-check: DRIFT (rc=$rc) — see per-host lines above."
+  echo "  rc3=no-repo  rc4=fetch/origin-main-unavailable  rc6=host-unidentified"
+  echo "  rc8=DIVERGED/AHEAD:un-pushed-commits(ship.sh will skip this host forever)"
+  echo "  rc10=behind(needs a ship)  rc12=not-on-branch-main  rc13=host-unreachable"
+fi
+exit "$rc"

--- a/scripts/lib/host-role.sh
+++ b/scripts/lib/host-role.sh
@@ -1,0 +1,98 @@
+# shellcheck shell=bash
+# host-role.sh — canonical per-host identity for the devrc two-host fleet.
+#
+# 🔴 SINGLE SOURCE OF TRUTH. Both NixOS hosts report hostname `nixos`, so nothing
+# can tell them apart by name. This file owns the ONE predicate that can: derive
+# the physical host from its local IPv4 addresses. Every consumer SOURCES this —
+# `scripts/ship.sh` (the converger) and `scripts/drift-check.sh` (the passive
+# deadman) — because a second copy of this predicate WILL drift and be wrong.
+#
+# It already has been wrong once, expensively: ship.sh originally hardcoded
+# "local == workbench" plus an SSH target that was actually the laptop's own
+# address, so running it on the laptop mislabelled the laptop as workbench and
+# SSH'd to itself while the real workbench was never converged.
+#
+# SOURCE-ONLY, no side effects. Sourcing this defines variables + functions and
+# does nothing else — it must stay safe to pull into any script at any point.
+# For a standalone probe it is ALSO directly executable:
+#     bash scripts/lib/host-role.sh --detect-role ["<ip ip ...>"]
+# printing workbench|laptop|unknown (with no IP list: this machine's own).
+
+# --- Canonical per-host identity ----------------------------------------------
+# Primary signal: the stable LAN address (192.168.50.x) — reliable across boots.
+# Secondary signal: the 10.42.x address (less stable) — fallback only.
+WORKBENCH_IP_PRIMARY="192.168.50.250"
+WORKBENCH_IP_SECONDARY="10.42.0.30"
+LAPTOP_IP_PRIMARY="192.168.50.155"
+LAPTOP_IP_SECONDARY="10.42.0.100"
+WORKBENCH_SSH_DEFAULT="zach@192.168.50.250"
+LAPTOP_SSH_DEFAULT="zach@192.168.50.155"
+
+# detect_role <space-or-comma-separated ipv4 list> -> workbench|laptop|unknown
+# Pure + testable: takes an IP list as input (no live-machine calls), so it can
+# be unit-tested with injected addresses. Precedence is deterministic:
+#   1. primary LAN addresses (192.168.50.x) are matched before secondary ones;
+#   2. within a pass, WORKBENCH is matched before LAPTOP — so an (unexpected)
+#      list carrying BOTH hosts' primary addresses resolves to "workbench".
+detect_role() {
+  local ips="${1:-}"
+  ips="${ips//,/ }"
+  local ip
+  for ip in $ips; do [ "$ip" = "$WORKBENCH_IP_PRIMARY" ] && { echo workbench; return 0; }; done
+  for ip in $ips; do [ "$ip" = "$LAPTOP_IP_PRIMARY" ]    && { echo laptop;    return 0; }; done
+  for ip in $ips; do [ "$ip" = "$WORKBENCH_IP_SECONDARY" ] && { echo workbench; return 0; }; done
+  for ip in $ips; do [ "$ip" = "$LAPTOP_IP_SECONDARY" ]    && { echo laptop;    return 0; }; done
+  echo unknown
+  return 0
+}
+
+# local_ipv4s — global-scope IPv4 addresses of THIS machine, one per line
+# (scope global drops 127.0.0.1). Used as detect_role's input at runtime.
+local_ipv4s() {
+  ip -4 -o addr show scope global 2>/dev/null | awk '{print $4}' | cut -d/ -f1
+}
+
+# resolve_local_role — the role of THIS machine, honouring an explicit override.
+# $SHIP_ROLE (shared with ship.sh, deliberately: one override for one fleet)
+# wins when set; otherwise detection runs. Prints workbench|laptop|unknown.
+resolve_local_role() {
+  if [ -n "${SHIP_ROLE:-}" ]; then echo "$SHIP_ROLE"; return 0; fi
+  detect_role "$(local_ipv4s | tr '\n' ' ')"
+}
+
+# remote_role_of <local-role> -> the OTHER host's role (empty if unknown).
+remote_role_of() {
+  case "${1:-}" in
+    workbench) echo laptop ;;
+    laptop)    echo workbench ;;
+    *)         echo "" ;;
+  esac
+}
+
+# remote_ssh_of <local-role> -> ssh target of the OTHER host.
+# $REMOTE_SSH overrides unconditionally. $LAPTOP_SSH is a back-compat override
+# that applies ONLY when the remote host actually IS the laptop — applying it
+# from the laptop would point at the laptop itself.
+remote_ssh_of() {
+  if [ -n "${REMOTE_SSH:-}" ]; then echo "$REMOTE_SSH"; return 0; fi
+  case "${1:-}" in
+    workbench) echo "${LAPTOP_SSH:-$LAPTOP_SSH_DEFAULT}" ;;
+    laptop)    echo "$WORKBENCH_SSH_DEFAULT" ;;
+    *)         echo "" ;;
+  esac
+}
+
+# Standalone probe mode — only when EXECUTED, never when sourced.
+# ${BASH_SOURCE[0]} == $0 exactly when this file is the script being run.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  case "${1:-}" in
+    --detect-role)
+      # With an explicit (even empty) IP-list arg, detect from it (testable);
+      # with no second arg, detect from THIS machine's own addresses.
+      if [ "$#" -ge 2 ]; then detect_role "$2"; else detect_role "$(local_ipv4s | tr '\n' ' ')"; fi
+      exit 0 ;;
+    *)
+      echo "host-role.sh: source me, or run: bash $0 --detect-role [\"<ip ip ...>\"]" >&2
+      exit 2 ;;
+  esac
+fi

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -91,38 +91,18 @@
 set -uo pipefail
 
 # --- Canonical per-host identity (both hosts share hostname `nixos`) -----------
-# Primary signal: the stable LAN address (192.168.50.x) — reliable across boots.
-# Secondary signal: the 10.42.x address (less stable) — fallback only.
-WORKBENCH_IP_PRIMARY="192.168.50.250"
-WORKBENCH_IP_SECONDARY="10.42.0.30"
-LAPTOP_IP_PRIMARY="192.168.50.155"
-LAPTOP_IP_SECONDARY="10.42.0.100"
-WORKBENCH_SSH_DEFAULT="zach@192.168.50.250"
-LAPTOP_SSH_DEFAULT="zach@192.168.50.155"
-
-# detect_role <space-or-comma-separated ipv4 list> -> workbench|laptop|unknown
-# Pure + testable: takes an IP list as input (no live-machine calls), so it can
-# be unit-tested with injected addresses. Precedence is deterministic:
-#   1. primary LAN addresses (192.168.50.x) are matched before secondary ones;
-#   2. within a pass, WORKBENCH is matched before LAPTOP — so an (unexpected)
-#      list carrying BOTH hosts' primary addresses resolves to "workbench".
-detect_role() {
-  local ips="${1:-}"
-  ips="${ips//,/ }"
-  local ip
-  for ip in $ips; do [ "$ip" = "$WORKBENCH_IP_PRIMARY" ] && { echo workbench; return 0; }; done
-  for ip in $ips; do [ "$ip" = "$LAPTOP_IP_PRIMARY" ]    && { echo laptop;    return 0; }; done
-  for ip in $ips; do [ "$ip" = "$WORKBENCH_IP_SECONDARY" ] && { echo workbench; return 0; }; done
-  for ip in $ips; do [ "$ip" = "$LAPTOP_IP_SECONDARY" ]    && { echo laptop;    return 0; }; done
-  echo unknown
-  return 0
-}
-
-# local_ipv4s — global-scope IPv4 addresses of THIS machine, one per line
-# (scope global drops 127.0.0.1). Used as detect_role's input at runtime.
-local_ipv4s() {
-  ip -4 -o addr show scope global 2>/dev/null | awk '{print $4}' | cut -d/ -f1
-}
+# 🔴 detect_role / local_ipv4s / the IP + SSH constants are SOURCED from
+# scripts/lib/host-role.sh, not defined here. scripts/drift-check.sh (the passive
+# drift deadman) needs the IDENTICAL predicate, and a second copy of it would
+# drift and be wrong — which is precisely how host identity used to be broken
+# (see the "Host identity" paragraph in the header). One rule, one place.
+_ship_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)/lib/host-role.sh"
+if [ ! -r "$_ship_lib" ]; then
+  echo "ship: cannot read $_ship_lib — host identity cannot be resolved." >&2
+  exit 6
+fi
+# shellcheck source=lib/host-role.sh
+. "$_ship_lib"
 
 # Hidden mode: print the role detected from an injected IP list (for tests) or,
 # with no list, from this machine's own addresses. Prints role, exits 0.
@@ -151,10 +131,7 @@ for a in "$@"; do
 done
 
 # --- Resolve local role (detection, override-able) + derive the remote target --
-SHIP_ROLE="${SHIP_ROLE:-}"
-if [ -z "$SHIP_ROLE" ]; then
-  SHIP_ROLE="$(detect_role "$(local_ipv4s | tr '\n' ' ')")"
-fi
+SHIP_ROLE="$(resolve_local_role)"
 if [ "$SHIP_ROLE" != workbench ] && [ "$SHIP_ROLE" != laptop ]; then
   echo "ship: could not identify this host (role='$SHIP_ROLE')." >&2
   echo "  local IPv4s: $(local_ipv4s | tr '\n' ' ')" >&2
@@ -163,15 +140,11 @@ if [ "$SHIP_ROLE" != workbench ] && [ "$SHIP_ROLE" != laptop ]; then
   exit 6
 fi
 
-if [ "$SHIP_ROLE" = workbench ]; then
-  REMOTE_ROLE=laptop
-  # remote is the laptop -> honor the back-compat LAPTOP_SSH override here.
-  REMOTE_SSH="${REMOTE_SSH:-${LAPTOP_SSH:-$LAPTOP_SSH_DEFAULT}}"
-else
-  REMOTE_ROLE=workbench
-  # remote is the workbench -> LAPTOP_SSH must NOT apply (it is the laptop itself).
-  REMOTE_SSH="${REMOTE_SSH:-$WORKBENCH_SSH_DEFAULT}"
-fi
+# Derived in lib/host-role.sh: remote_role_of flips the role, remote_ssh_of
+# applies $REMOTE_SSH unconditionally and the back-compat $LAPTOP_SSH ONLY when
+# the remote host really is the laptop (from the laptop it would point at itself).
+REMOTE_ROLE="$(remote_role_of "$SHIP_ROLE")"
+REMOTE_SSH="$(remote_ssh_of "$SHIP_ROLE")"
 
 # Self-contained converge routine, run identically on each host (local via
 # bash -c, remote via ssh). Single source of truth for the sequence.

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -1,0 +1,631 @@
+"""Behavioural + structural tests for scripts/drift-check.sh — the PASSIVE
+drift deadman for the two-host devrc fleet.
+
+Everything runs against THROWAWAY git repos built in tmp_path, and every remote
+leg runs against a STUB `ssh` on PATH. Nothing here touches ~/workspace/devrc,
+either real host, the network, or `home-manager`.
+
+WHAT THIS SUITE IS FOR
+----------------------
+A deadman that cannot fire is WORSE than no deadman: it converts "nobody was
+looking" into "something was looking and said fine". So the load-bearing tests
+are not the happy path — they are:
+
+  1. rc-PER-CONDITION. Each drift shape must produce its OWN distinct non-zero
+     code (8 diverged/ahead, 10 behind, 12 not-on-main, 3 no-repo, 4
+     fetch/origin-main, 13 unreachable). One code for "something is wrong" would
+     be indistinguishable from the un-pushed-commits case that actually bit us
+     twice, which is the only one that needs a rescue-before-reset procedure.
+  2. THE POSITIVE CONTROL. `test_clean_repo_is_green` proves the checker can
+     observe the clean case at all. A reassuring rc=0 from a checker wired to
+     nothing is indistinguishable from a real green, so the green is only
+     meaningful reported alongside the reds above.
+  3. PASSIVITY. Both statically (the forbidden mutating primitives must not
+     appear as CODE) and behaviourally (after a run against a diverged repo the
+     branch, HEAD, worktree and stash stack must all be byte-identical).
+  4. THE SEAM. drift-check.sh and ship.sh must resolve host identity through the
+     SAME sourced predicate. Asserted as a ledger — neither file may define
+     detect_role itself, both must source lib/host-role.sh — plus a behavioural
+     check that their `--detect-role` answers agree across a table of IPs. A
+     structural check alone would type-check past a second copy that merely
+     happens to agree today.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from testlib.mockbin import write_exec  # noqa: E402
+
+DRIFT = REPO_ROOT / "scripts" / "drift-check.sh"
+SHIP = REPO_ROOT / "scripts" / "ship.sh"
+HOST_ROLE_LIB = REPO_ROOT / "scripts" / "lib" / "host-role.sh"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("bash") is None,
+    reason="needs git + bash on PATH",
+)
+
+
+# --------------------------------------------------------------------------- #
+# fixture: a throwaway origin + working clone, origin/main one commit ahead
+# --------------------------------------------------------------------------- #
+class Fleet:
+    """origin.git + a `work` clone pinned one commit BEHIND origin/main."""
+
+    def __init__(self, tmp_path):
+        self.root = tmp_path
+        self.origin = tmp_path / "origin.git"
+        self.work = tmp_path / "work"
+        self.home = tmp_path / "home"
+        self.bin = tmp_path / "bin"
+        self.home.mkdir()
+        self.bin.mkdir()
+
+        self.gitconfig = tmp_path / "gitconfig"
+        self.gitconfig.write_text(
+            "[user]\n\tname = t\n\temail = t@t\n[init]\n\tdefaultBranch = main\n"
+        )
+
+        self._run(["git", "init", "-q", "--bare", "-b", "main", str(self.origin)])
+        builder = tmp_path / "builder"
+        self._run(["git", "clone", "-q", str(self.origin), str(builder)])
+        (builder / "f").write_text("base\n")
+        self.git(builder, "checkout", "-q", "-B", "main")
+        self.git(builder, "add", "f")
+        self.git(builder, "commit", "-q", "-m", "base")
+        self.git(builder, "push", "-q", "-u", "origin", "main")
+
+        self._run(["git", "clone", "-q", str(self.origin), str(self.work)])
+        self.git(self.work, "checkout", "-q", "main")
+
+        # origin/main advances: `work` is now exactly 1 BEHIND.
+        (builder / "f").write_text("base\nupstream\n")
+        self.git(builder, "commit", "-q", "-am", "ahead")
+        self.git(builder, "push", "-q", "origin", "main")
+        self.builder = builder
+
+    # -- plumbing ----------------------------------------------------------- #
+    def env(self, **extra):
+        e = dict(os.environ)
+        e.update(
+            HOME=str(self.home),
+            GIT_CONFIG_GLOBAL=str(self.gitconfig),
+            GIT_CONFIG_SYSTEM="/dev/null",
+            GIT_TERMINAL_PROMPT="0",
+            PATH=str(self.bin) + os.pathsep + os.environ.get("PATH", ""),
+        )
+        e.update(extra)
+        return e
+
+    def _run(self, argv):
+        out = subprocess.run(argv, capture_output=True, text=True, env=self.env())
+        assert out.returncode == 0, f"setup {argv} failed: {out.stderr}"
+        return out.stdout.strip()
+
+    def git(self, repo, *args):
+        return self._run(["git", "-C", str(repo), *args])
+
+    # -- state accessors ---------------------------------------------------- #
+    def branch(self):
+        out = subprocess.run(
+            ["git", "-C", str(self.work), "symbolic-ref", "--quiet", "--short", "HEAD"],
+            capture_output=True, text=True, env=self.env(),
+        )
+        return out.stdout.strip() or "DETACHED"
+
+    def head(self):
+        return self.git(self.work, "rev-parse", "HEAD")
+
+    def stash_list(self):
+        return self.git(self.work, "stash", "list")
+
+    def status(self):
+        return self.git(self.work, "status", "--porcelain")
+
+    # -- helpers to build each drift shape ---------------------------------- #
+    def catch_up(self):
+        """Make `work`'s main equal origin/main (the clean state)."""
+        self.git(self.work, "fetch", "origin", "-q")
+        self.git(self.work, "merge", "--ff-only", "-q", "origin/main")
+
+    def add_local_commit(self, msg="un-pushed local work"):
+        p = self.work / ("local-%d.txt" % len(list(self.work.glob("local-*.txt"))))
+        p.write_text(msg + "\n")
+        self.git(self.work, "add", p.name)
+        self.git(self.work, "commit", "-q", "-m", msg)
+
+    # -- the subject under test --------------------------------------------- #
+    def check(self, *args, repo=None, **envextra):
+        env = self.env(
+            SHIP_ROLE="workbench",           # bypass IP detection (no `ip` here)
+            DRIFT_REPO=str(repo or self.work),
+            **envextra,
+        )
+        proc = subprocess.run(
+            ["bash", str(DRIFT), *args],
+            capture_output=True, text=True, env=env,
+        )
+        return proc.returncode, proc.stdout + proc.stderr
+
+    def stub_ssh(self, exit_code, stdout=""):
+        """Install a stub `ssh` on PATH that drains stdin and exits `exit_code`.
+
+        Real ssh exits 255 on a connection/auth failure and otherwise passes the
+        remote command's code through, so both halves of the remote contract are
+        drivable without a network.
+        """
+        body = ["cat >/dev/null"]
+        if stdout:
+            # Single-quoted, with any embedded quote escaped the POSIX way.
+            body.append("echo '%s'" % stdout.replace("'", "'\\''"))
+        body.append("exit %d" % exit_code)
+        write_exec(self.bin / "ssh", "\n".join(body) + "\n")
+
+
+@pytest.fixture
+def fleet(tmp_path):
+    return Fleet(tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# 1. POSITIVE CONTROL — the checker can observe a clean host
+# --------------------------------------------------------------------------- #
+def test_clean_repo_is_green(fleet):
+    """rc=0 on a host that is on main, at origin/main, with nothing untracked.
+
+    🔴 Report this ALONGSIDE the reds below, never alone: a zero from a checker
+    wired to nothing looks exactly like this one.
+    """
+    fleet.catch_up()
+    rc, out = fleet.check("--no-remote")
+    assert rc == 0, out
+    assert "clean" in out
+    assert "no drift" in out
+    assert "untracked: 0" in out
+
+
+# --------------------------------------------------------------------------- #
+# 2. NEGATIVE CONTROLS — one distinct rc per condition
+# --------------------------------------------------------------------------- #
+def test_ahead_unpushed_commits_is_rc8(fleet):
+    """🔴 THE INCIDENT SHAPE: un-pushed commits on local main -> rc 8.
+
+    This is the condition ship.sh reports as `skipped:diverged`, after which the
+    host silently receives nothing forever. It must be distinguishable from
+    merely-behind (rc 10), because only this one needs rescue-then-reset.
+    """
+    fleet.catch_up()
+    fleet.add_local_commit("commit the workbench never pushed")
+    rc, out = fleet.check("--no-remote")
+    assert rc == 8, f"expected rc8, got {rc}\n{out}"
+    assert "AHEAD by 1 un-pushed commit" in out, out
+    # The un-pushed commits must be NAMED — the report has to be actionable
+    # without a second trip to the host.
+    assert "commit the workbench never pushed" in out, out
+    assert "ship.sh SKIPS this host" in out
+    assert "reset --keep" in out and "never --hard" in out
+
+
+def test_diverged_both_ways_is_rc8(fleet):
+    """Ahead AND behind -> still rc 8, reported as DIVERGED with both counts."""
+    fleet.add_local_commit("local side")          # work was already 1 behind
+    rc, out = fleet.check("--no-remote")
+    assert rc == 8, f"expected rc8, got {rc}\n{out}"
+    assert "DIVERGED" in out
+    assert "1 un-pushed commit(s), 1 behind" in out, out
+
+
+def test_behind_only_is_rc10(fleet):
+    """Behind origin/main -> rc 10 (needs a ship), NOT rc 8."""
+    rc, out = fleet.check("--no-remote")
+    assert rc == 10, f"expected rc10, got {rc}\n{out}"
+    assert "BEHIND origin/main by 1 commit" in out, out
+    assert "scripts/ship.sh" in out
+    # Assert on the per-host DIAGNOSIS lines, not the whole output — the trailing
+    # rc legend legitimately contains the words "un-pushed" and "diverged".
+    host_lines = "\n".join(ln for ln in out.splitlines() if ln.startswith("[workbench]"))
+    assert "un-pushed" not in host_lines, f"behind reported as un-pushed\n{out}"
+    assert "DIVERGED" not in host_lines, f"behind reported as diverged\n{out}"
+
+
+def test_not_on_main_is_rc12(fleet):
+    """main == origin/main but the checkout sits on a feature branch -> rc 12."""
+    fleet.catch_up()
+    fleet.git(fleet.work, "checkout", "-q", "-b", "feat/something")
+    rc, out = fleet.check("--no-remote")
+    assert rc == 12, f"expected rc12, got {rc}\n{out}"
+    assert "not on branch main" in out
+    assert "feat/something" in out, out
+
+
+def test_no_local_main_branch_is_rc12(fleet):
+    """A checkout with no local `main` at all -> rc 12, not a crash."""
+    fleet.git(fleet.work, "checkout", "-q", "-b", "only-branch")
+    fleet.git(fleet.work, "branch", "-D", "main")
+    rc, out = fleet.check("--no-remote")
+    assert rc == 12, f"expected rc12, got {rc}\n{out}"
+    assert "no local main branch" in out, out
+
+
+def test_missing_repo_is_rc3(fleet):
+    rc, out = fleet.check("--no-remote", repo=fleet.root / "nope")
+    assert rc == 3, f"expected rc3, got {rc}\n{out}"
+    assert "no repo at" in out
+
+
+def test_missing_origin_main_is_rc4_not_drift(fleet):
+    """A misconfigured remote must not be misreported as divergence."""
+    fleet.git(fleet.origin, "branch", "-m", "main", "master")
+    fleet.git(fleet.work, "update-ref", "-d", "refs/remotes/origin/main")
+    rc, out = fleet.check("--no-remote")
+    assert rc == 4, f"expected rc4, got {rc}\n{out}"
+    assert "no origin/main" in out
+    assert "DRIFT — local main" not in out, f"misclassified as drift\n{out}"
+
+
+def test_fetch_failure_is_rc4(fleet):
+    """An unreachable origin is 'cannot evaluate', never a green."""
+    fleet.git(fleet.work, "remote", "set-url", "origin",
+              str(fleet.root / "does-not-exist.git"))
+    rc, out = fleet.check("--no-remote")
+    assert rc == 4, f"expected rc4, got {rc}\n{out}"
+    assert "git fetch failed" in out
+    assert "no drift" not in out, f"reported green despite being unable to look\n{out}"
+
+
+# --------------------------------------------------------------------------- #
+# 3. The REMOTE leg (stubbed ssh — no network, no real host)
+# --------------------------------------------------------------------------- #
+def test_unreachable_remote_is_rc13(fleet):
+    """ssh's 255 must become a LOUD rc 13, never a pass."""
+    fleet.stub_ssh(255)
+    rc, out = fleet.check("--no-local", REMOTE_SSH="stub@example.invalid")
+    assert rc == 13, f"expected rc13, got {rc}\n{out}"
+    assert "UNREACHABLE" in out
+    assert "this is not a pass" in out
+    assert "no drift" not in out
+
+
+def test_remote_rc_is_passed_through(fleet):
+    """A remote host's own drift code reaches the caller unchanged."""
+    fleet.stub_ssh(8, stdout="[laptop] AHEAD by 3 un-pushed commit(s).")
+    rc, out = fleet.check("--no-local", REMOTE_SSH="stub@example.invalid")
+    assert rc == 8, f"expected rc8, got {rc}\n{out}"
+    assert "3 un-pushed" in out, out
+
+
+def test_worst_code_wins_across_hosts(fleet):
+    """🔴 The aggregation rule: the WORST condition must not hide behind a milder one.
+
+    Local is merely BEHIND (rc 10); the remote has un-pushed commits (rc 8).
+    ship.sh keeps the FIRST non-zero — which here would hand systemd a 10 and
+    describe the incident shape as 'needs a ship'. A timer's single exit code is
+    the only thing anyone reads, so drift-check keeps the most severe.
+    """
+    fleet.stub_ssh(8, stdout="[laptop] AHEAD by 2 un-pushed commit(s).")
+    rc, out = fleet.check(REMOTE_SSH="stub@example.invalid")
+    assert rc == 8, f"expected the WORST code (8), got {rc}\n{out}"
+    # ...and BOTH hosts' lines are still printed — nothing hides.
+    assert "BEHIND origin/main" in out, f"local line missing\n{out}"
+    assert "2 un-pushed" in out, f"remote line missing\n{out}"
+
+
+def test_clean_local_plus_clean_remote_is_green(fleet):
+    """Positive control for the two-host path, including the ssh leg."""
+    fleet.catch_up()
+    fleet.stub_ssh(0, stdout="[laptop] clean")
+    rc, out = fleet.check(REMOTE_SSH="stub@example.invalid")
+    assert rc == 0, f"expected rc0, got {rc}\n{out}"
+    assert "no drift" in out
+
+
+# --------------------------------------------------------------------------- #
+# 4. Untracked files are REPORTED but never change the verdict
+# --------------------------------------------------------------------------- #
+def test_untracked_files_are_listed_but_do_not_fail(fleet):
+    """The 2026-08-09 shape: a stranded handoff doc on an otherwise clean host."""
+    fleet.catch_up()
+    (fleet.work / "claudedocs").mkdir()
+    (fleet.work / "claudedocs" / "handoff-stranded.md").write_text("notes\n")
+    (fleet.work / "scratch.txt").write_text("x\n")
+    rc, out = fleet.check("--no-remote")
+    assert rc == 0, f"untracked files must not change the verdict\n{out}"
+    assert "untracked: 2 file(s)" in out, out
+    assert "claudedocs/handoff-stranded.md" in out, out
+
+
+def test_untracked_listing_is_capped(fleet):
+    fleet.catch_up()
+    for i in range(6):
+        (fleet.work / ("u%d.txt" % i)).write_text("x\n")
+    rc, out = fleet.check("--no-remote", DRIFT_UNTRACKED_MAX="2")
+    assert rc == 0, out
+    assert "untracked: 6 file(s)" in out
+    assert "and 4 more" in out, out
+
+
+# --------------------------------------------------------------------------- #
+# 5. PASSIVITY — behavioural
+# --------------------------------------------------------------------------- #
+def test_run_against_diverged_repo_mutates_nothing(fleet):
+    """🔴 The deadman REPORTS; it never fixes. Nothing about the tree may move."""
+    fleet.catch_up()
+    fleet.add_local_commit("precious un-pushed work")
+    (fleet.work / "f").write_text("base\nupstream\nuncommitted edit\n")
+    (fleet.work / "untracked-wip").write_text("wip\n")
+
+    before = (fleet.branch(), fleet.head(), fleet.status(), fleet.stash_list())
+    rc, out = fleet.check("--no-remote")
+    after = (fleet.branch(), fleet.head(), fleet.status(), fleet.stash_list())
+
+    assert rc == 8, out
+    assert before == after, (
+        "drift-check mutated the working state\n"
+        f"before={before!r}\nafter={after!r}\n{out}"
+    )
+    assert fleet.stash_list() == "", f"stash entry created (repo-GLOBAL!)\n{out}"
+    assert (fleet.work / "untracked-wip").read_text() == "wip\n"
+    assert (fleet.work / "f").read_text().endswith("uncommitted edit\n")
+
+
+def test_run_against_feature_branch_does_not_move_it(fleet):
+    """Unlike ship.sh, drift-check must NOT land the checkout on main."""
+    fleet.catch_up()
+    fleet.git(fleet.work, "checkout", "-q", "-b", "feat/stay-here")
+    rc, out = fleet.check("--no-remote")
+    assert rc == 12, out
+    assert fleet.branch() == "feat/stay-here", f"drift-check moved the branch\n{out}"
+
+
+# --------------------------------------------------------------------------- #
+# 6. PASSIVITY — structural
+# --------------------------------------------------------------------------- #
+FORBIDDEN_PRIMITIVES = (
+    "git checkout", "git switch", "git merge", "git rebase", "git reset",
+    "git stash", "git clean", "git commit", "git push", "git pull",
+    "git cherry-pick", "git branch -", "--autostash", "home-manager",
+)
+
+
+# A line whose FIRST word is a printer can only PRINT the forbidden primitive,
+# not run it — and drift-check's whole value is that it prints the rescue
+# procedure (`git branch … && git push …`, `git reset --keep`) so the operator
+# does not have to go looking for it. The carve-out is withdrawn the moment the
+# line contains a command substitution, which is the one way a printer CAN
+# execute something; `test_scanner_catches_a_substitution_inside_a_message`
+# is the positive control for that half.
+_OUTPUT_ONLY = re.compile(r"^\s*(say|echo|printf)\b")
+
+
+def scan_mutations(text):
+    """Return [(lineno, line, hits)] for every executable line that could MUTATE.
+
+    Comment lines are excluded on purpose — the header DOCUMENTS the ban and the
+    rescue procedure, so a whole-file grep would flag the script's own warning
+    label.
+    """
+    code = [ln for ln in text.splitlines() if ln.strip() and not ln.strip().startswith("#")]
+    out = []
+    for i, ln in enumerate(code, 1):
+        hits = [p for p in FORBIDDEN_PRIMITIVES if p in ln]
+        if not hits:
+            continue
+        if _OUTPUT_ONLY.match(ln) and "$(" not in ln and "`" not in ln:
+            continue
+        out.append((i, ln.strip(), hits))
+    return out
+
+
+def test_drift_check_source_never_mutates():
+    offenders = scan_mutations(DRIFT.read_text())
+    assert offenders == [], (
+        "drift-check.sh is PASSIVE — these lines could mutate a host:\n"
+        + "\n".join(f"  line {i}: {ln}   (matched {h})" for i, ln, h in offenders)
+    )
+    src = DRIFT.read_text()
+    # ...and the read-only primitives must still be the ones doing the work.
+    assert "git fetch origin -q" in src
+    assert "git rev-list --left-right --count" in src
+
+
+def test_scanner_catches_a_bare_mutating_command(tmp_path):
+    """Negative control #1 for the scanner above.
+
+    Without it, `test_drift_check_source_never_mutates` is indistinguishable from
+    a scan wired to nothing — the vacuous-green shape this suite exists to stop.
+    """
+    mutated = DRIFT.read_text() + "\ngit checkout main\n"
+    offenders = scan_mutations(mutated)
+    assert offenders, "the passivity scanner cannot detect an injected mutation"
+    assert any("git checkout main" in ln for _, ln, _ in offenders)
+
+
+def test_scanner_catches_a_substitution_inside_a_message(tmp_path):
+    """Negative control #2 — the carve-out's own boundary.
+
+    The say/echo/printf carve-out exists so the rescue procedure can be PRINTED.
+    A command substitution smuggled into such a line would execute, so the
+    carve-out must not cover it. This is the mutation that a naive
+    "skip all message lines" scanner would sail straight past.
+    """
+    mutated = DRIFT.read_text() + '\nsay "oops $(git reset --hard origin/main)"\n'
+    offenders = scan_mutations(mutated)
+    assert offenders, "the carve-out swallows a command substitution"
+    assert any("git reset" in " ".join(h) for _, _, h in offenders)
+
+
+def test_scanner_carve_out_still_allows_a_plain_message():
+    """...and the carve-out genuinely carves: a pure message line is NOT flagged.
+
+    Proves the two controls above are not passing merely because the scanner
+    flags everything.
+    """
+    assert scan_mutations('say "  fix: git reset --keep origin/main"\n') == []
+
+
+# --------------------------------------------------------------------------- #
+# 7. THE SEAM — one host-identity predicate, shared by both scripts
+# --------------------------------------------------------------------------- #
+def test_host_identity_has_exactly_one_definition():
+    """A LEDGER, not a spot check: assert who defines the predicate and who
+    sources it. Fails when the set GROWS (a second copy reappears) or SHRINKS
+    (a consumer stops sourcing and starts open-coding it).
+
+    Host detection has already been wrong once here — ship.sh hardcoded
+    'local == workbench' and SSH'd to itself. A duplicated predicate is how that
+    returns.
+    """
+    definers = []
+    for path in sorted((REPO_ROOT / "scripts").rglob("*.sh")):
+        text = path.read_text()
+        code = [ln for ln in text.splitlines() if not ln.strip().startswith("#")]
+        if any(ln.strip().startswith("detect_role()") for ln in code):
+            definers.append(path.relative_to(REPO_ROOT).as_posix())
+    assert definers == ["scripts/lib/host-role.sh"], (
+        "host-role detection must be defined in exactly one place; found: %r" % definers
+    )
+
+    for consumer in (DRIFT, SHIP):
+        src = consumer.read_text()
+        assert "lib/host-role.sh" in src, (
+            f"{consumer.name} no longer sources the shared host-identity library"
+        )
+
+
+@pytest.mark.parametrize(
+    "ips,expected",
+    [
+        ("192.168.50.250", "workbench"),
+        ("192.168.50.155", "laptop"),
+        ("10.42.0.30", "workbench"),
+        ("10.42.0.100", "laptop"),
+        ("192.168.50.250 192.168.50.155", "workbench"),
+        ("172.17.0.1 127.0.0.1", "unknown"),
+        ("", "unknown"),
+    ],
+)
+def test_both_scripts_and_the_lib_agree_on_role(ips, expected):
+    """Behavioural half of the seam: a structural 'both source it' check would
+    type-check past a copy that merely happens to agree today."""
+    answers = {}
+    for name, path in (("ship", SHIP), ("drift", DRIFT), ("lib", HOST_ROLE_LIB)):
+        out = subprocess.run(
+            ["bash", str(path), "--detect-role", ips],
+            capture_output=True, text=True, check=True,
+        )
+        answers[name] = out.stdout.strip()
+    assert set(answers.values()) == {expected}, answers
+
+
+def test_host_role_lib_is_side_effect_free_when_sourced(tmp_path):
+    """Sourcing the library must define things and do NOTHING else — it is pulled
+    into ship.sh mid-script, where any stray output or exit would be a landmine.
+    """
+    probe = tmp_path / "probe.sh"
+    probe.write_text(
+        "set -uo pipefail\n"
+        f". {HOST_ROLE_LIB}\n"
+        'printf "MARKER:%s\\n" "$(detect_role 192.168.50.250)"\n'
+    )
+    out = subprocess.run(["bash", str(probe)], capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    assert out.stdout == "MARKER:workbench\n", (
+        f"sourcing produced extra output: {out.stdout!r} / {out.stderr!r}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 8. The systemd wiring in nix/home.nix
+# --------------------------------------------------------------------------- #
+HOME_NIX = (REPO_ROOT / "nix" / "home.nix").read_text()
+
+
+def _drift_service_block() -> str:
+    """The `systemd.user.services.drift-check` block, isolated.
+
+    Pinned by slicing between the service and the timer declaration so an
+    assertion about the service cannot be satisfied by text belonging to some
+    other unit — home.nix declares ~15 of them and they all look alike.
+    """
+    start = HOME_NIX.index("systemd.user.services.drift-check")
+    end = HOME_NIX.index("systemd.user.timers.drift-check")
+    assert start < end
+    return HOME_NIX[start:end]
+
+
+def test_home_nix_declares_the_service_and_the_timer():
+    assert "systemd.user.services.drift-check" in HOME_NIX
+    assert "systemd.user.timers.drift-check" in HOME_NIX
+    block = _drift_service_block()
+    assert "scripts/drift-check.sh" in block, "ExecStart does not run the checker"
+    # The alerting mechanism is the EXISTING one — a non-zero exit puts the unit
+    # in `failed`, and notify-failure@ turns that into the sticky dunst toast.
+    # Without this line the deadman is silent, which is the whole failure it
+    # exists to fix, one level up.
+    assert "notify-failure@%n.service" in block, "drift produces no notification"
+
+
+def test_the_timer_is_gated_by_the_master_switch_and_the_service_is_not():
+    """The switch must act ONLY on the timers.target wiring.
+
+    If it gated the service too, `systemctl --user start drift-check` — the
+    supervised hand-run that is supposed to validate the ssh leg before the timer
+    is ever armed — would not exist on an un-enabled host.
+    """
+    block = _drift_service_block()
+    assert "mkIf" not in block, (
+        "the drift-check SERVICE must be emitted unconditionally so it can be run by hand"
+    )
+    timer = HOME_NIX[HOME_NIX.index("systemd.user.timers.drift-check"):]
+    timer = timer[:timer.index("\n  };") + 5]
+    assert "lib.optionals (serverMode && enableDriftDeadman) [ \"timers.target\" ]" in timer, (
+        "the timer's WantedBy is not gated by the master switch:\n" + timer
+    )
+    assert "enableDriftDeadman = false;" in HOME_NIX, (
+        "the master switch must ship OFF — enabling a timer is a live change to a "
+        "host and belongs in its own supervised deploy"
+    )
+
+
+# cmd -> the nixpkgs attribute that must appear in the unit's makeBinPath list.
+# 🔴 THE SEAM: the script and the unit are tested in different places and neither
+# owns their intersection. `ip` is the sharp one — it is how the script decides
+# WHICH host it is running on (both report hostname `nixos`), so dropping
+# iproute2 from the PATH does not crash anything: detection silently returns
+# "unknown" and the deadman exits 6 forever, from a unit that looks correct.
+UNIT_PATH_REQUIREMENTS = {
+    "git": "pkgs.git",
+    "ssh": "pkgs.openssh",
+    "ip": "pkgs.iproute2",
+    "awk": "pkgs.gawk",
+    "sed": "pkgs.gnused",
+    "head": "pkgs.coreutils",
+    "wc": "pkgs.coreutils",
+    "tr": "pkgs.coreutils",
+    "cut": "pkgs.coreutils",
+}
+
+
+@pytest.mark.parametrize("cmd,attr", sorted(UNIT_PATH_REQUIREMENTS.items()))
+def test_every_command_the_checker_runs_is_on_the_unit_path(cmd, attr):
+    scripts_src = DRIFT.read_text() + HOST_ROLE_LIB.read_text()
+    code = "\n".join(
+        ln for ln in scripts_src.splitlines() if not ln.strip().startswith("#")
+    )
+    assert cmd in code, (
+        f"{cmd!r} is pinned as a PATH requirement but the scripts no longer call "
+        f"it — drop it from UNIT_PATH_REQUIREMENTS (the pin is the accounting)"
+    )
+    assert attr in _drift_service_block(), (
+        f"the drift-check unit's PATH is missing {attr} — {cmd!r} would not resolve "
+        f"under systemd, which has none of the login shell's PATH"
+    )


### PR DESCRIPTION
## The gap

`scripts/ship.sh` is not the problem — it is correct. It converges both hosts, exits with the right per-host codes, and a host it cannot fast-forward is **skipped and left exactly as found** (`rc=8 skipped:diverged`).

The problem is that **nothing runs it on a schedule** (verified: no systemd timer, no cron — `grep -rn ship.sh nix/` finds only comments and an alias). So a host that starts getting skipped silently stops receiving *every* subsequent change while continuing to look completely healthy: same `git log`, same green home-manager generation, no error anywhere.

That has now happened **twice**:

| date | what | how it was found |
|---|---|---|
| 2026-08-06 | two un-pushed commits on the workbench, blocked for hours | a human shipped something else |
| 2026-08-09 | **three** un-pushed commits on the workbench (rescued as #366), plus 7 untracked files incl. `claudedocs/handoff-rig-control-brightness.md` — the handoff doc for the very work that was stranded | a human shipped something else |

## What this adds

**`scripts/drift-check.sh`** — a passive, read-only deadman. Per host (local + remote over ssh) it answers "is this host silently no longer receiving changes?"

🔴 **Passive means passive.** It may `git fetch` (which writes remote-tracking refs only). It never checks out, switches, merges, fast-forwards, rebases, resets, stashes, cleans, commits, pushes, or runs `home-manager`. If it finds drift it **reports**; it never fixes.

Distinct rc per condition, deliberately using **ship.sh's vocabulary** so the two read consistently — a code means the same thing in both, and codes ship.sh owns for actions this script does not take (5 conflicted-tree, 7 cannot-ff, 9 switch-failed, 11 verify-failed) are left **unused** rather than repurposed:

| rc | condition |
|---|---|
| 3 | repo missing on that host |
| 4 | `git fetch` failed, or origin/main missing / HEAD unborn — *cannot evaluate, which is not a pass* |
| 6 | local host could not be identified |
| **8** | 🔴 local `main` **diverged or ahead** (un-pushed commits) — ship.sh will skip this host forever. **The one that bit us, twice.** |
| 10 | local `main` **behind** origin/main — just needs a ship |
| 12 | the checkout is **not on branch `main`** |
| 13 | host **unreachable** (ssh failed/timed out) |

Two deliberate divergences from ship.sh, both documented in the script header:

- **Worst code wins across hosts** (ship.sh keeps the *first* non-zero). Every per-host line still prints, but a timer's single exit code is the only thing anyone reads — an un-pushed workbench must not hide behind a merely-behind laptop and get described as "needs a ship". Severity: `8 > 13 > 4 > 3 > 12 > 10`; an *unknown* code outranks all of them so a new failure mode can never be silently outranked into invisibility.
- **`main` is compared to `origin/main` regardless of what is checked out.** Local `main` can be diverged while HEAD sits on a feature branch, and that is still a host that will be skipped forever.

Untracked files are **counted and listed per host as information only** — they never change the exit code. Same loss class (work that exists on exactly one machine, in no commit and no backup), zero extra cost.

### Shared host detection — `scripts/lib/host-role.sh`

`detect_role` / `local_ipv4s` / the IP + SSH constants moved **out of `ship.sh`** into a sourced library that both scripts pull in. Both machines report hostname `nixos`, so identity comes from local IPv4 addresses — a predicate that has already been wrong here once (ship.sh hardcoded "local == workbench" and SSH'd to itself while the real workbench was never converged). A second copy would drift and be wrong.

`ship.sh`'s behaviour is unchanged — same `--detect-role` mode, same `SHIP_ROLE`/`REMOTE_SSH`/`LAPTOP_SSH` override semantics, same rc 6. **Its own 29 tests pass untouched** (`test_ship_detect_role.py` + `test_ship_converge.py`).

### Alerting — the existing mechanism, no new notifier

Drift ⇒ non-zero exit ⇒ the unit enters `failed` ⇒ the existing **`OnFailure=notify-failure@%n.service`** fires the same sticky `urgency=critical` dunst toast that ~15 other user units already use. The toast names the unit; the rc legend and per-host lines are in `journalctl --user -u drift-check`.

<details><summary>Why not a bar pill, and what one would take</summary>

The `bar` skill's poller (`bar-status-poll`, ~45s) is architecturally "blocks read local files, the poller fetches out-of-band". A drift source does not fit that cadence: it costs a `git fetch` **plus an ssh round trip**, which is 4×/day work, not 45s work — putting it in the poller would add a standing ssh to a live host every 45 seconds.

A pill is still a small, well-defined follow-up if wanted:
1. `drift-check.sh --status-json` writing `~/.cache/bar-status/drift.json` in the poller's schema (`{count, state, detail}`), 0600, atomic-replace — written by the **drift-check timer**, not the poller (the "block reads a local file" invariant is preserved; only the writer differs).
2. `scripts/i3status-drift`, a ~70-line copy of `i3status-telemetry`'s shape (hide-at-zero, `state:"stale"` → invisible — except drift, like telemetry, must render "cannot tell" as `?` rather than empty, since its reassuring answer is a zero).
3. A `driftBlock` in `nix/graphical.nix` with `signal = 18`, workbench-only, plus `SIGNALS["drift"] = 18` in `bar-status-poll` so the existing `pkill -RTMIN+N` refresh path works.
4. The rising-edge latch already exists (`edge_decision` / `read_latch` / `write_latch`) and would be reused, not reimplemented.

I did not build it because the dunst path is the MVP the deadman actually needs, and half of a pill is worse than none.
</details>

### Timer — `nix/home.nix`, **6-hourly**, master switch **OFF**

Why 6h: the incidents bound it. 08-06 blocked the workbench "for hours"; 08-09 let a whole day's changes miss that host. **Daily** leaves a ~24h window in which every merge silently misses a host — which is the failure itself, only shorter. 6h caps it at a quarter of that for **4 fetch+ssh round trips a day**, a cost too small to trade against. Tighter buys little (a human ships several times a day anyway) and the toast starts reading as noise. `OnStartupSec=10min` gives one prompt run after login — the laptop is intermittent, so "just resumed" is exactly when it should look.

Following the `enableInitiativesSync` pattern, with one refinement the task called for: **the switch gates only the timer's `timers.target` wiring**; the *service* is emitted unconditionally so `systemctl --user start drift-check` works by hand on either host.

```nix
enableDriftDeadman = false;   # ships OFF
...
WantedBy = lib.optionals (serverMode && enableDriftDeadman) [ "timers.target" ];
```

🔴 **Nothing in this PR is deployed.** No `ship.sh`, no `home-manager switch`, no timer armed. `enableDriftDeadman = false` is pinned by a test, so a routine deploy cannot silently arm it.

---

# 🔴 Verification

A deadman that cannot fire is worse than no deadman — it converts "nobody was looking" into "something was looking and said fine". So the instrument was validated in both directions, against **throwaway clones in `/tmp`**. Neither real host was mutated.

## Positive control — it can observe the clean case

```
### POSITIVE CONTROL — clean host (on main, at origin/main)
=== local (workbench) ===
[workbench] untracked: 0
[workbench] ✅ clean — on branch main, main == origin/main (d89bad2f44ceb01788217c60603d23f8956248c1)

drift-check: no drift — both hosts on branch main at origin/main.
rc=0
```

This zero is only meaningful **reported alongside the reds below** — a reassuring zero from a checker wired to nothing looks exactly like this one.

## Negative controls — one per rc, each proven to go RED

<details open><summary><b>rc=8 — un-pushed commits (THE incident shape)</b></summary>

```
=== local (workbench) ===
[workbench] untracked: 1 file(s) — present on this host only, in no commit and no backup
[workbench]     - handoff-stranded.md
[workbench] 🔴 DRIFT — local main is AHEAD by 1 un-pushed commit(s).
[workbench]   ship.sh SKIPS this host (rc=8) and will keep skipping it — it is receiving NOTHING.
[workbench]     + 6fd6a76 fix(rig-control): brightness restore after sleep
[workbench]   rescue (on that host): git branch <topic> main && git push -u origin <topic>
[workbench]   then confirm from ANOTHER host, then: git reset --keep origin/main   (never --hard)

drift-check: DRIFT (rc=8) — see per-host lines above.
  rc3=no-repo  rc4=fetch/origin-main-unavailable  rc6=host-unidentified
  rc8=DIVERGED/AHEAD:un-pushed-commits(ship.sh will skip this host forever)
  rc10=behind(needs a ship)  rc12=not-on-branch-main  rc13=host-unreachable
rc=8
```
</details>

<details><summary>rc=8 — diverged both ways</summary>

```
[workbench] untracked: 0
[workbench] 🔴 DRIFT — local main has DIVERGED: 1 un-pushed commit(s), 1 behind.
[workbench]   ship.sh SKIPS this host (rc=8) and will keep skipping it — it is receiving NOTHING.
[workbench]     + 331f066 local-only commit
[workbench]   rescue (on that host): git branch <topic> main && git push -u origin <topic>
[workbench]   then confirm from ANOTHER host, then: git reset --keep origin/main   (never --hard)
rc=8
```
</details>

<details><summary>rc=10 — behind (needs a ship)</summary>

```
[workbench] untracked: 0
[workbench] DRIFT — local main is BEHIND origin/main by 1 commit(s) — needs a ship.
[workbench]   fix: scripts/ship.sh
rc=10
```
Note it is **not** described as un-pushed or diverged — the distinction is the point.
</details>

<details><summary>rc=12 — not on branch main</summary>

```
[workbench] untracked: 0
[workbench] DRIFT — checkout is on 'feat/left-on-a-branch', not on branch main.
[workbench]   ship.sh will move it, but anything committed there is invisible to origin/main.
rc=12
```
</details>

<details><summary>rc=3 / rc=4 — cannot evaluate ≠ green</summary>

```
### rc=3 — repo missing on that host
[workbench] no repo at /tmp/drift-controls/definitely-not-here
rc=3

### rc=4 — git fetch failed
[workbench] git fetch failed — cannot evaluate drift
rc=4
```
Neither prints "no drift". An absence of evidence is reported as an absence of evidence.
</details>

<details open><summary><b>rc=13 — remote unreachable (REAL ssh, unroutable target)</b></summary>

```
=== remote (laptop — nobody@192.0.2.1) ===
ssh: connect to host 192.0.2.1 port 22: Connection timed out
[laptop] UNREACHABLE — ssh to nobody@192.0.2.1 failed or timed out.
[laptop]   drift on that host CANNOT be evaluated — this is not a pass.
rc=13
```
Real `ssh`, real timeout, real 255 → mapped to 13. Not a stub.
</details>

<details><summary>rc=6 — host identity unresolvable</summary>

```
drift-check: could not identify this host (role='nonsense').
  local IPv4s: 192.168.50.155 10.42.0.100
  expected a workbench (192.168.50.250) or laptop (192.168.50.155) address.
  override with SHIP_ROLE=workbench|laptop to force.
rc=6
```
</details>

## Tests — red → green matrix

**41 new tests** in `scripts/tests/test_drift_check.py`, matching the directory's existing pytest style (throwaway git repos in `tmp_path`, isolated `GIT_CONFIG_GLOBAL`, `testlib.mockbin.write_exec` for the stub `ssh`).

Every one was watched fail against a deliberately broken build. **Two sweeps, 13 mutants, 13 killed, and each by the test that owns the behaviour** — not by collateral:

| # | mutation | tests that went RED |
|---|---|---|
| baseline | *(unmutated)* | **41 passed** |
| M1 | rc 8 collapsed into rc 10 (ahead reported as merely behind) | `test_ahead_unpushed_commits_is_rc8`, `test_diverged_both_ways_is_rc8`, `test_run_against_diverged_repo_mutates_nothing` |
| M2 | aggregate FIRST non-zero (ship.sh style) instead of most severe | `test_worst_code_wins_across_hosts` |
| M3 | ssh 255 passed through instead of mapped to rc 13 | `test_unreachable_remote_is_rc13` |
| M4 | fetch failure made non-fatal (the classic silent green) | `test_fetch_failure_is_rc4` |
| M5 | the deadman starts FIXING (`git checkout main` injected) | `test_run_against_feature_branch_does_not_move_it`, `test_drift_check_source_never_mutates` |
| M6 | host detection re-copied into `drift-check.sh` instead of sourced | `test_host_identity_has_exactly_one_definition` + 3 `test_both_scripts_and_the_lib_agree_on_role[…]` |
| M7 | untracked files silently dropped from the report | `test_untracked_files_are_listed_but_do_not_fail`, `test_untracked_listing_is_capped` |
| M8 | "not on main" silently ignored | `test_not_on_main_is_rc12`, `test_run_against_feature_branch_does_not_move_it` |
| M9 | `pkgs.iproute2` dropped from the unit's PATH | `test_every_command_the_checker_runs_is_on_the_unit_path[ip-pkgs.iproute2]` |
| M10 | master switch flipped ON at merge | `test_the_timer_is_gated_by_the_master_switch_and_the_service_is_not` |
| M11 | `WantedBy` ungated (a routine ship would arm the timer) | same |
| M12 | `OnFailure` dropped (drift produces no notification at all) | `test_home_nix_declares_the_service_and_the_timer` |
| M13 | the *service* gated too (no hand-run possible) | `test_the_timer_is_gated_by_the_master_switch_and_the_service_is_not` |

M9 is the seam nobody owns: the script and the systemd unit are tested in different places. `ip` is how the script decides *which host it is* (both report hostname `nixos`), so dropping `iproute2` from the unit PATH crashes nothing — detection silently returns `unknown` and the deadman exits 6 forever from a unit that looks correct.

The passivity scanner has its **own** controls, because it carves out `say`/`echo`/`printf` lines (drift-check deliberately *prints* the rescue procedure, which contains `git push` and `git reset --keep`):

- `test_scanner_catches_a_bare_mutating_command` — an injected `git checkout main` is caught.
- `test_scanner_catches_a_substitution_inside_a_message` — an injected `say "oops $(git reset --hard …)"` is caught; the carve-out withdraws the moment a line contains a command substitution, which is the one way a printer *can* execute something.
- `test_scanner_carve_out_still_allows_a_plain_message` — proves the two above are not passing merely because the scanner flags everything.

## Authoritative gate

Read as **content**, not exit code (the runner's summary is parsed; the counts are quoted):

```
nix build .#checks.x86_64-linux.pytests
  PASS  scripts/tests  (collected=1468 passed=1468 skipped=0)     # 1427 → 1468 (+41)
  TOTAL collected=6561  passed=6560  skipped=1  failed=0  (floor: 5600)
RESULT: PASS
```

The 1 skip is the pre-existing pinned `repo-cos` live-store drift check.

---

# What I could NOT verify — stated plainly

1. **The timer has never fired.** Nothing was deployed: no `ship.sh`, no `home-manager switch`, no `systemctl --user start`. The unit definitions are validated by `nix-instantiate --parse` and by the home.nix pins above — that is a claim about the *config*, not about a running unit.

2. **The ssh leg has not been exercised from a systemd-user context.** What I *did* measure, read-only: `ssh -o BatchMode=yes zach@192.168.50.250 bash -s < script` works from this laptop with **`SSH_AUTH_SOCK` unset** — i.e. it authenticated from `~/.ssh/id_ed25519` with no agent, which is exactly the condition a user unit runs under. Strongly indicated, not proven. **The first hand-run on the workbench is what should validate it**, before `enableDriftDeadman` is flipped:
   ```
   systemctl --user start drift-check ; journalctl --user -u drift-check -e
   ```

3. **The dunst toast has not been seen.** The `notify-failure@` path is reused unmodified and is already in service on ~15 units, and the drift service is wired to it — but I did not force a failure on a live host to watch a toast appear.

4. **No live drift was observed, because there is none right now.** A read-only probe of the workbench (`status` + `rev-list` against its *cached* refs — no fetch, no writes) reports: on branch `main`, `0 behind / 0 ahead`, **7 untracked** — including `claudedocs/handoff-rig-control-brightness.md`. So the 08-09 divergence is genuinely resolved by #366, and the untracked set the deadman would report is exactly the one described. Caveat: with no fetch, "0 behind" is against that host's last-known `origin/main`, not necessarily today's.

5. **The `.mjs` gate (`checks.nodetests`) was not run** — this PR touches no `.mjs` file.
