### PR TITLE
fix(drift): unreachable != drift — audit fixes for the drift deadman (#367)

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1834,14 +1834,33 @@ in
   #
   # This unit is the thing that looks when nobody is looking. It is READ-ONLY: it
   # fetches (remote-tracking refs only) and reports. It never checks out, merges,
-  # fast-forwards, rebases, resets, or runs home-manager — enforced statically by
-  # scripts/tests/test_drift_check.py.
+  # fast-forwards, rebases, resets, or runs home-manager.
+  #
+  # scripts/tests/test_drift_check.py enforces that statically, via an ALLOWLIST
+  # of read-only git subcommands anchored at every command separator (`;`, `&&`,
+  # `||`, `|`, `$(`) — not the first-word keyword grep it started as, which
+  # missed `git update-ref`, `git config`, `git worktree add`, `rm -rf "$repo"`
+  # and anything after a `&&`. The one file the script writes is its
+  # consecutive-unreachable counter under $XDG_STATE_HOME/drift-check, and that
+  # is itself pinned by an asserted ledger of redirection targets.
   #
   # ALERTING: no new notification mechanism. The script exits non-zero on drift,
   # the unit enters `failed`, and the EXISTING OnFailure=notify-failure@%n.service
   # turns that into the same sticky critical dunst toast every other important
   # user unit already uses. The toast names the unit; the rc legend + per-host
   # lines are in `journalctl --user -u drift-check`.
+  #
+  # 🔴 WHAT DOES **NOT** TOAST: an unreachable remote. This timer is serverMode-
+  # gated, i.e. it runs on the WORKBENCH ONLY, so its remote leg always ssh's to
+  # the LAPTOP — which is routinely shut, asleep or off-LAN. Failing the unit on
+  # that would fire the same sticky critical toast as a genuine rc 8 up to 4× a
+  # day, and a permanently-red gate trains you to click through the one alert
+  # that must keep its meaning. The script therefore REPORTS an unreachable
+  # remote every run but only escalates to rc 13 after
+  # DRIFT_UNREACHABLE_ESCALATE consecutive misses (default 4 ≈ 24h at this
+  # cadence), resetting the moment the host answers. Below that threshold the
+  # remote leg contributes nothing to the exit code — so a local rc 8 with the
+  # laptop shut still exits 8, still fails the unit, and still toasts.
   #
   # The service is emitted UNCONDITIONALLY (any host can run it by hand); only the
   # TIMER's timers.target wiring is gated — see enableDriftDeadman above.
@@ -1882,8 +1901,12 @@ in
   # itself, only shorter. 6h caps it at a quarter of that for 4 ssh+fetch round
   # trips a day, a cost too small to be worth trading against. Anything tighter
   # buys little: a human ships several times a day anyway, and the toast would
-  # start reading as noise. OnStartupSec gives one prompt run after login (the
-  # laptop is intermittent, so "just resumed" is exactly when it should look).
+  # start reading as noise. OnStartupSec gives one prompt run 10min after the
+  # user manager starts — i.e. after a WORKBENCH reboot. (An earlier version of
+  # this comment justified it with the laptop having "just resumed"; that cannot
+  # happen. The timer is serverMode-gated and the ~/.server-mode marker exists
+  # only on the workbench, so this timer never runs on the laptop at all — the
+  # laptop is only ever the far end of the ssh leg.)
   # No Persistent — it only applies to OnCalendar timers, not monotonic ones.
   systemd.user.timers.drift-check = {
     Unit = {

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -22,13 +22,24 @@
 #               7 untracked files — including a handoff doc for the stranded work.
 #
 # ── PASSIVE MEANS PASSIVE ─────────────────────────────────────────────────────
-# 🔴 This script must NEVER mutate either host's working state. It may `git
-# fetch` (which writes only remote-tracking refs, never the working tree, the
-# index, or any local branch). It must NEVER checkout, switch, merge,
-# fast-forward, rebase, reset, stash, clean, commit, or run `home-manager`.
-# A deadman that repairs is a deployer with no supervision; a deadman that
-# reports is a deadman. `scripts/tests/test_drift_check.py` enforces this
-# statically against this file's executable lines.
+# 🔴 This script must NEVER mutate either host's CHECKOUT. It may `git fetch`
+# (which writes remote-tracking refs, never the working tree, the index, or any
+# local branch — though note `fetch` does trigger git's own `gc --auto`, so
+# "this script never causes a gc" would be a claim it cannot make). It must
+# NEVER checkout, switch, merge, fast-forward, rebase, reset, stash, clean,
+# commit, or run `home-manager`. A deadman that repairs is a deployer with no
+# supervision; a deadman that reports is a deadman.
+#
+# `scripts/tests/test_drift_check.py` enforces that STATICALLY, and the scanner
+# is an ALLOWLIST, not a keyword blocklist: every `git` invocation in executable
+# code must be one of a fixed set of read-only subcommands, and the check is
+# anchored at each COMMAND SEPARATOR (`;`, `&&`, `||`, `|`, `$(`), not at the
+# start of the line — so `say "hi" && git checkout main` is caught.
+#
+# THE ONE FILE THIS SCRIPT WRITES is the consecutive-unreachable counter under
+# $DRIFT_STATE_DIR (default $XDG_STATE_HOME/drift-check). It lives outside every
+# repo, and `test_the_only_files_the_deadman_writes_are_the_streak_counters`
+# holds that ledger.
 #
 # ── HOST IDENTITY ─────────────────────────────────────────────────────────────
 # Both machines report hostname `nixos`, so identity comes from local IPv4
@@ -43,6 +54,8 @@
 # take (5 conflicted-tree, 7 cannot-ff, 9 switch-failed, 11 verify-failed) are
 # left UNUSED rather than repurposed.
 #
+#   2   usage error (unknown flag, non-integer tunable, or a flag combination
+#       that would check nothing at all)
 #   3   repo missing on that host
 #   4   git fetch failed, or origin/main is missing / HEAD unborn
 #   6   local host could not be identified (see detect_role)
@@ -50,7 +63,26 @@
 #       commits). 🔴 THE DANGEROUS ONE — ship.sh will skip this host forever.
 #   10  DRIFT — local `main` is BEHIND origin/main (just needs a ship)
 #   12  DRIFT — the checkout is not ON branch `main`
-#   13  host unreachable (ssh failed / timed out)
+#   13  remote host unreachable for $DRIFT_UNREACHABLE_ESCALATE CONSECUTIVE runs
+#
+# ── UNREACHABLE IS NOT DRIFT (the alerting policy) ────────────────────────────
+# 🔴 The timer runs on the WORKBENCH ONLY (gated on the ~/.server-mode marker in
+# nix/home.nix), so its remote leg always ssh's to the LAPTOP — a machine that is
+# routinely shut, asleep, or off-LAN. If every such run failed the unit, the
+# operator would get the same sticky critical toast as a genuine rc 8 up to 4×
+# a day, and would learn to ignore the one alert that must keep its meaning.
+#
+# So an unreachable remote is REPORTED on every run but only ESCALATES to rc 13
+# after $DRIFT_UNREACHABLE_ESCALATE consecutive misses (default 4 = ~24h at the
+# 6h cadence). The streak is persisted in $DRIFT_STATE_DIR and is RESET the
+# moment the host answers — including when it answers with drift.
+#
+# 🔴 This is deliberately the only softening. Below the threshold the remote leg
+# contributes NOTHING to the exit code — it does not mask the local leg, so a
+# local rc 8 with an unreachable laptop still exits 8, still fails the unit and
+# still toasts (`test_local_rc8_still_wins_when_the_remote_is_unreachable`). And
+# if the streak cannot be persisted at all, "how long" is unknowable and the run
+# escalates immediately rather than going quiet.
 #
 # When several hosts fail, the exit code is the MOST SEVERE, not the first —
 # this differs from ship.sh on purpose. ship.sh keeps the first non-zero because
@@ -58,7 +90,10 @@
 # is reading a timer's output, so the single number it hands to systemd must be
 # the worst thing found, or an un-pushed workbench could hide behind a merely
 # behind laptop. Severity order (worst first):
-#     8  >  13  >  4  >  3  >  12  >  10
+#     8  >  13  >  6  >  4  >  3  >  12  >  10
+# (6 is unreachable through this path today — the script exits 6 directly before
+# any per-host leg runs — but the order is documented for every code it owns,
+# and severity() ranks it rather than falling through to the unknown-code slot.)
 # Per-host lines are ALWAYS printed for every host, whatever the code.
 #
 # Untracked files are counted and listed per host as INFORMATION only — they
@@ -76,11 +111,19 @@
 #   REMOTE_SSH   ssh target for the OTHER host (default derived from role)
 #   LAPTOP_SSH   back-compat: applies ONLY when the remote host is the laptop
 #   DRIFT_REPO   repo path checked on the LOCAL host (default $HOME/workspace/devrc)
-#   DRIFT_UNTRACKED_MAX  max untracked paths listed per host (default 10)
+#   DRIFT_UNTRACKED_MAX  max untracked paths listed per host (default 10, integer)
+#   DRIFT_UNREACHABLE_ESCALATE  consecutive unreachable runs before rc 13 (default 4)
+#   DRIFT_STATE_DIR  where the unreachable streak is persisted
+#                    (default ${XDG_STATE_HOME:-$HOME/.local/state}/drift-check)
 set -uo pipefail
 
 # --- Host identity: SOURCED, never copied (see header) ------------------------
-_drift_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)/lib/host-role.sh"
+# The source path is symlink-resolved: invoked through a symlink, an unresolved
+# ${BASH_SOURCE[0]} would look for lib/ next to the SYMLINK and not find it.
+_drift_self="${BASH_SOURCE[0]}"
+_drift_resolved="$(readlink -f "$_drift_self" 2>/dev/null || true)"
+[ -n "$_drift_resolved" ] && _drift_self="$_drift_resolved"
+_drift_lib="$(cd "$(dirname "$_drift_self")" 2>/dev/null && pwd)/lib/host-role.sh"
 if [ ! -r "$_drift_lib" ]; then
   echo "drift-check: cannot read $_drift_lib — host identity cannot be resolved." >&2
   exit 6
@@ -95,6 +138,23 @@ fi
 
 DRIFT_REPO="${DRIFT_REPO:-$HOME/workspace/devrc}"
 DRIFT_UNTRACKED_MAX="${DRIFT_UNTRACKED_MAX:-10}"
+DRIFT_UNREACHABLE_ESCALATE="${DRIFT_UNREACHABLE_ESCALATE:-4}"
+DRIFT_STATE_DIR="${DRIFT_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/drift-check}"
+
+# 🔴 Both tunables are INTERPOLATED INTO A SCRIPT THAT RUNS ON THE OTHER HOST
+# (piped to `bash -s` over ssh), so a non-integer value is remote code execution
+# on a machine this script is otherwise forbidden to touch. Operator-controlled,
+# hence low exploitability — but it is a passivity hole on the far side of the
+# ssh hop, which the static scanner structurally cannot see. Validate here; the
+# printf below ALSO uses %q, deliberately belt-and-braces.
+require_int() { # require_int <name> <value>
+  case "$2" in
+    ''|*[!0-9]*) echo "drift-check: $1 must be a non-negative integer, got: $2" >&2; exit 2 ;;
+  esac
+}
+require_int DRIFT_UNTRACKED_MAX "$DRIFT_UNTRACKED_MAX"
+require_int DRIFT_UNREACHABLE_ESCALATE "$DRIFT_UNREACHABLE_ESCALATE"
+
 DO_LOCAL=1
 DO_REMOTE=1
 for a in "$@"; do
@@ -107,6 +167,16 @@ for a in "$@"; do
     *) echo "unknown arg: $a" >&2; exit 2 ;;
   esac
 done
+
+# Refuse the combination that looks at nothing. Without this, `--no-local
+# --no-remote` printed "no drift — both hosts on branch main at origin/main" and
+# exited 0 having checked neither host: a green from a checker wired to nothing,
+# which is precisely the failure this whole subsystem exists to prevent.
+if [ "$DO_LOCAL" = 0 ] && [ "$DO_REMOTE" = 0 ]; then
+  echo "drift-check: --no-local and --no-remote together check NOTHING." >&2
+  echo "  refusing to print a pass for a run that looked at no host." >&2
+  exit 2
+fi
 
 LOCAL_ROLE="$(resolve_local_role)"
 if [ "$LOCAL_ROLE" != workbench ] && [ "$LOCAL_ROLE" != laptop ]; then
@@ -127,6 +197,11 @@ severity() {
     0)  echo 0 ;;
     8)  echo 70 ;;
     13) echo 60 ;;
+    # 6 cannot arrive here today (the script exits 6 before any host leg runs),
+    # but it is a code this file OWNS, and an owned code with no case would rank
+    # 99 — above rc 8 — which is the wrong answer for "I could not identify the
+    # local host" versus "a host has un-pushed commits".
+    6)  echo 58 ;;
     4)  echo 55 ;;
     3)  echo 50 ;;
     12) echo 40 ;;
@@ -155,7 +230,14 @@ say() { echo "[$label] $*"; }
 [ -d "$repo/.git" ] || [ -f "$repo/.git" ] || { say "no repo at $repo"; exit 3; }
 cd "$repo" || { say "no repo at $repo"; exit 3; }
 
-git fetch origin -q 2>/dev/null || { say "git fetch failed — cannot evaluate drift"; exit 4; }
+# The stderr of git fetch is CAPTURED AND REPRINTED, never discarded: rc 4 is a
+# recurring code (key rotation, DNS, host-key churn) and for a unit whose only
+# output is the journal, that message is the ONLY diagnostic there will ever be.
+fetch_err=$(git fetch origin -q 2>&1) || {
+  say "git fetch failed — cannot evaluate drift"
+  printf "%s\n" "$fetch_err" | sed "s|^|[$label]   git: |"
+  exit 4
+}
 target=$(git rev-parse -q --verify origin/main) || {
   say "no origin/main after a successful fetch — remote/branch misconfigured."
   say "  check: git -C $repo remote -v ; git -C $repo branch -r"
@@ -179,7 +261,10 @@ off_main=0
 if [ "$branch" != "main" ]; then
   off_main=1
   say "DRIFT — checkout is on '"'"'$branch'"'"', not on branch main."
-  say "  ship.sh will move it, but anything committed there is invisible to origin/main."
+  # 🔴 NO VERDICT HERE. Whether ship.sh will move this checkout back to main
+  # depends on the state of local main, which has not been computed yet: if main
+  # is AHEAD, ship.sh skips the host entirely and moves nothing. The advisory is
+  # therefore printed at each exit point below, where it can be true.
 fi
 
 # --- Where is the LOCAL main branch relative to origin/main? ------------------
@@ -206,10 +291,34 @@ if [ "${ahead:-0}" -gt 0 ]; then
     say "🔴 DRIFT — local main is AHEAD by $ahead un-pushed commit(s)."
   fi
   say "  ship.sh SKIPS this host (rc=8) and will keep skipping it — it is receiving NOTHING."
+  if [ "$off_main" = 1 ]; then
+    say "  the checkout is ALSO off main (on '"'"'$branch'"'"') and ship.sh will NOT move it back:"
+    say "  it skips this host before touching the checkout at all."
+  fi
   git log --oneline --no-decorate origin/main..main 2>/dev/null | head -n 10 | sed "s|^|[$label]     + |"
   say "  rescue (on that host): git branch <topic> main && git push -u origin <topic>"
   say "  then confirm from ANOTHER host, then: git reset --keep origin/main   (never --hard)"
   exit 8
+fi
+
+# 🔴 ORDER IS LOAD-BEARING, in BOTH directions.
+#   * off-main is checked AFTER the ahead/diverged block, because un-pushed
+#     commits on main while HEAD sits on a feature branch are the rc 8 shape —
+#     hoisting this above the ahead block reports rc 12 and the FALSE advisory
+#     "ship.sh will move it" for a host ship.sh would skip forever.
+#     (`test_off_main_with_diverged_main_is_rc8` is the regression pin.)
+#   * off-main is checked BEFORE the behind block, because the severity table
+#     this file publishes ranks 12 above 10; returning 10 for a host that is BOTH
+#     off main and behind would contradict its own ordering.
+if [ "$off_main" = 1 ]; then
+  if [ "${behind:-0}" -gt 0 ]; then
+    say "  local main is also BEHIND by $behind — ship.sh can still fast-forward it and"
+    say "  land the checkout back on main; anything committed on '"'"'$branch'"'"' stays invisible to origin/main."
+  else
+    say "  ship.sh will land the checkout back on main; anything committed on"
+    say "  '"'"'$branch'"'"' is invisible to origin/main."
+  fi
+  exit 12
 fi
 
 if [ "${behind:-0}" -gt 0 ]; then
@@ -217,8 +326,6 @@ if [ "${behind:-0}" -gt 0 ]; then
   say "  fix: scripts/ship.sh"
   exit 10
 fi
-
-if [ "$off_main" = 1 ]; then exit 12; fi
 
 say "✅ clean — on branch main, main == origin/main ($target)"
 exit 0
@@ -231,13 +338,46 @@ note_rc() { # note_rc <rc> — keep the MOST SEVERE code seen (see header)
   if [ "$(severity "$new")" -gt "$(severity "$rc")" ]; then rc="$new"; fi
 }
 
+# --- What did this run actually LOOK at? --------------------------------------
+# Tracked so the summary can never again claim "both hosts" for a run that
+# checked one, or none.
+CHECKED=""
+UNCHECKED=""
+mark_checked()   { CHECKED="${CHECKED:+$CHECKED, }$1"; }
+mark_unchecked() { UNCHECKED="${UNCHECKED:+$UNCHECKED, }$1"; }
+
+# --- Consecutive-unreachable streak (see "UNREACHABLE IS NOT DRIFT" above) -----
+# The ONLY file this script writes, and it lives outside every repo.
+_streak_file() { printf '%s\n' "$DRIFT_STATE_DIR/unreachable-${1:-remote}"; }
+
+streak_bump() { # streak_bump <role> -> new streak, or -1 if it cannot be persisted
+  local f prev next
+  f="$(_streak_file "$1")"
+  mkdir -p "$DRIFT_STATE_DIR" 2>/dev/null || { echo -1; return 0; }
+  prev="$(cat "$f" 2>/dev/null || true)"
+  case "$prev" in ''|*[!0-9]*) prev=0 ;; esac
+  next=$(( prev + 1 ))
+  printf '%s\n' "$next" > "$f" 2>/dev/null || { echo -1; return 0; }
+  echo "$next"
+}
+
+streak_reset() { # streak_reset <role> — the host answered; the run of misses ends
+  local f
+  f="$(_streak_file "$1")"
+  [ -d "$DRIFT_STATE_DIR" ] || return 0
+  printf '0\n' > "$f" 2>/dev/null || true
+}
+
 if [ "$DO_LOCAL" = 1 ]; then
   echo "=== local ($LOCAL_ROLE) ==="
   DRIFT_REPO="$DRIFT_REPO" DRIFT_LABEL="$LOCAL_ROLE" \
     DRIFT_UNTRACKED_MAX="$DRIFT_UNTRACKED_MAX" \
     bash -c "$CHECK"
   note_rc "$?"
+  mark_checked "$LOCAL_ROLE (local)"
   echo
+else
+  mark_unchecked "$LOCAL_ROLE (local, --no-local)"
 fi
 
 if [ "$DO_REMOTE" = 1 ]; then
@@ -245,27 +385,65 @@ if [ "$DO_REMOTE" = 1 ]; then
   # DRIFT_REPO is deliberately NOT forwarded: it is a local override, and the
   # remote host's repo lives at its own $HOME/workspace/devrc.
   # `bash -s` (piped, not inlined) — see the CHECK header re: zsh.
-  printf 'DRIFT_LABEL=%s\nDRIFT_UNTRACKED_MAX=%s\n%s\n' \
+  # %q, not %s — these two values are executed on ANOTHER host (see require_int).
+  printf 'DRIFT_LABEL=%q\nDRIFT_UNTRACKED_MAX=%q\n%s\n' \
     "$REMOTE_ROLE" "$DRIFT_UNTRACKED_MAX" "$CHECK" \
     | ssh -o ConnectTimeout=10 -o BatchMode=yes "$REMOTE_SSH" bash -s
   remrc=$?
   # ssh itself exits 255 on a connection/auth failure — that is "we could not
-  # look", which for a deadman must be LOUD, never a green.
+  # look". For a deadman that must never read as a pass... but it must not read
+  # as DRIFT either: see "UNREACHABLE IS NOT DRIFT" in the header.
   if [ "$remrc" = 255 ]; then
-    echo "[$REMOTE_ROLE] UNREACHABLE — ssh to $REMOTE_SSH failed or timed out."
-    echo "[$REMOTE_ROLE]   drift on that host CANNOT be evaluated — this is not a pass."
+    echo "[$REMOTE_ROLE] ssh to $REMOTE_SSH failed or timed out."
     remrc=13
   fi
-  note_rc "$remrc"
+
+  if [ "$remrc" = 13 ]; then
+    streak="$(streak_bump "$REMOTE_ROLE")"
+    echo "[$REMOTE_ROLE] UNREACHABLE — drift on that host was NOT evaluated. This is not a pass."
+    if [ "$streak" -lt 0 ]; then
+      echo "[$REMOTE_ROLE]   the consecutive-miss counter under $DRIFT_STATE_DIR could not be"
+      echo "[$REMOTE_ROLE]   persisted, so 'for how long' is unknowable — ESCALATING (rc 13)."
+      note_rc 13
+      mark_unchecked "$REMOTE_ROLE (remote, UNREACHABLE — streak unknown, escalated)"
+    elif [ "$streak" -ge "$DRIFT_UNREACHABLE_ESCALATE" ]; then
+      echo "[$REMOTE_ROLE]   🔴 $streak CONSECUTIVE unreachable checks (threshold $DRIFT_UNREACHABLE_ESCALATE) —"
+      echo "[$REMOTE_ROLE]   that is no longer 'the laptop is shut'. ESCALATING (rc 13)."
+      note_rc 13
+      mark_unchecked "$REMOTE_ROLE (remote, UNREACHABLE x$streak — escalated)"
+    else
+      echo "[$REMOTE_ROLE]   $streak/$DRIFT_UNREACHABLE_ESCALATE consecutive — NOT escalated: a laptop that is"
+      echo "[$REMOTE_ROLE]   off, asleep or off-LAN is the expected cause and must not look like drift."
+      echo "[$REMOTE_ROLE]   At $DRIFT_UNREACHABLE_ESCALATE consecutive misses this becomes rc 13 and fails the unit."
+      mark_unchecked "$REMOTE_ROLE (remote, UNREACHABLE $streak/$DRIFT_UNREACHABLE_ESCALATE — not yet escalated)"
+    fi
+  else
+    # It answered — with a verdict, good or bad. The run of misses is over.
+    streak_reset "$REMOTE_ROLE"
+    note_rc "$remrc"
+    mark_checked "$REMOTE_ROLE (remote)"
+  fi
   echo
+else
+  mark_unchecked "$REMOTE_ROLE (remote, --no-remote)"
 fi
 
+# 🔴 The summary states WHAT WAS CHECKED. It previously said "both hosts on
+# branch main at origin/main" regardless — including for a --no-remote run that
+# looked at one host, and for a --no-local --no-remote run that looked at none.
 if [ "$rc" = 0 ]; then
-  echo "drift-check: no drift — both hosts on branch main at origin/main."
+  if [ -n "$CHECKED" ]; then
+    echo "drift-check: no drift on the host(s) CHECKED: $CHECKED — each on branch main at origin/main."
+  else
+    echo "drift-check: NO HOST WAS SUCCESSFULLY CHECKED — this is not a clean bill of health."
+  fi
 else
   echo "drift-check: DRIFT (rc=$rc) — see per-host lines above."
+  echo "  checked: ${CHECKED:-none}"
   echo "  rc3=no-repo  rc4=fetch/origin-main-unavailable  rc6=host-unidentified"
   echo "  rc8=DIVERGED/AHEAD:un-pushed-commits(ship.sh will skip this host forever)"
-  echo "  rc10=behind(needs a ship)  rc12=not-on-branch-main  rc13=host-unreachable"
+  echo "  rc10=behind(needs a ship)  rc12=not-on-branch-main"
+  echo "  rc13=remote unreachable for >=$DRIFT_UNREACHABLE_ESCALATE consecutive runs"
 fi
+[ -n "$UNCHECKED" ] && echo "drift-check: NOT checked: $UNCHECKED"
 exit "$rc"

--- a/scripts/lib/host-role.sh
+++ b/scripts/lib/host-role.sh
@@ -1,5 +1,13 @@
+#!/usr/bin/env bash
 # shellcheck shell=bash
 # host-role.sh — canonical per-host identity for the devrc two-host fleet.
+#
+# The shebang is load-bearing despite this file normally being SOURCED: the file
+# is mode 755, so `./scripts/lib/host-role.sh --detect-role` is a thing an
+# operator will do, and without it the kernel hands the file to /bin/sh. Under a
+# dash-ish /bin/sh, ${BASH_SOURCE[0]} expands to the empty string, the
+# executed-not-sourced guard at the bottom never matches, and --detect-role exits
+# 0 having printed NOTHING — a silent no-op from a probe you are trusting.
 #
 # 🔴 SINGLE SOURCE OF TRUTH. Both NixOS hosts report hostname `nixos`, so nothing
 # can tell them apart by name. This file owns the ONE predicate that can: derive

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -96,17 +96,57 @@ set -uo pipefail
 # drift deadman) needs the IDENTICAL predicate, and a second copy of it would
 # drift and be wrong — which is precisely how host identity used to be broken
 # (see the "Host identity" paragraph in the header). One rule, one place.
-_ship_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)/lib/host-role.sh"
-if [ ! -r "$_ship_lib" ]; then
-  echo "ship: cannot read $_ship_lib — host identity cannot be resolved." >&2
-  exit 6
+# The source path is SYMLINK-RESOLVED first. Unresolved, ${BASH_SOURCE[0]} is
+# whatever path invoked us, so running ship.sh through a symlink (~/bin/ship, a
+# PATH shim) would look for lib/ next to the SYMLINK and exit 6 — on the one tool
+# whose whole job is recovering a host that is already broken.
+_ship_self="${BASH_SOURCE[0]}"
+_ship_resolved="$(readlink -f "$_ship_self" 2>/dev/null || true)"
+[ -n "$_ship_resolved" ] && _ship_self="$_ship_resolved"
+_ship_lib="$(cd "$(dirname "$_ship_self")" 2>/dev/null && pwd)/lib/host-role.sh"
+if [ -r "$_ship_lib" ]; then
+  # shellcheck source=lib/host-role.sh
+  . "$_ship_lib"
+else
+  # 🔴 DEGRADED RECOVERY MODE. ship.sh is the tool you reach for when a host is
+  # already broken, so a missing lib must not be an unconditional dead end: it
+  # used to carry inline constants, which made `SHIP_ROLE=workbench ship.sh`
+  # work regardless. That escape hatch is restored — but ONLY as an escape
+  # hatch, and it deliberately duplicates NOTHING that can drift:
+  #   * detect_role is NOT redefined here. It is the predicate that has already
+  #     been wrong once, `test_host_identity_has_exactly_one_definition` pins it
+  #     to exactly one file, and a second copy is the failure mode itself. In
+  #     this mode there is no detection at all — SHIP_ROLE is mandatory.
+  #   * the SSH constants are NOT copied either (ship.sh once shipped an SSH
+  #     target that pointed at the host itself). REMOTE_SSH must be given
+  #     explicitly if the remote leg is wanted.
+  if [ -z "${SHIP_ROLE:-}" ]; then
+    echo "ship: cannot read $_ship_lib — host identity cannot be resolved." >&2
+    echo "  recovery: re-run with an explicit role, e.g." >&2
+    echo "    SHIP_ROLE=workbench $0 --no-remote" >&2
+    echo "    SHIP_ROLE=laptop REMOTE_SSH=zach@<workbench-ip> $0" >&2
+    exit 6
+  fi
+  echo "ship: WARNING — $_ship_lib is missing; running in degraded recovery mode." >&2
+  echo "  role is taken from SHIP_ROLE='$SHIP_ROLE'; no host detection is performed." >&2
+  local_ipv4s()      { :; }
+  resolve_local_role() { echo "${SHIP_ROLE:-unknown}"; }
+  remote_role_of()   { case "${1:-}" in workbench) echo laptop ;; laptop) echo workbench ;; *) echo "" ;; esac; }
+  remote_ssh_of()    { echo "${REMOTE_SSH:-}"; }
+  WORKBENCH_IP_PRIMARY="<lib unavailable>"
+  LAPTOP_IP_PRIMARY="<lib unavailable>"
 fi
-# shellcheck source=lib/host-role.sh
-. "$_ship_lib"
 
 # Hidden mode: print the role detected from an injected IP list (for tests) or,
 # with no list, from this machine's own addresses. Prints role, exits 0.
 if [ "${1:-}" = "--detect-role" ]; then
+  # Detection lives in the lib and is not reimplemented in degraded mode, so this
+  # probe is simply unavailable there — said out loud rather than crashing on an
+  # undefined function.
+  if ! command -v detect_role >/dev/null 2>&1; then
+    echo "ship: --detect-role needs $_ship_lib, which is missing (degraded mode)." >&2
+    exit 6
+  fi
   # With an explicit (even empty) IP-list arg, detect from it (testable);
   # with no second arg, detect from THIS machine's own addresses.
   if [ "$#" -ge 2 ]; then detect_role "$2"; else detect_role "$(local_ipv4s | tr '\n' ' ')"; fi
@@ -145,6 +185,14 @@ fi
 # the remote host really is the laptop (from the laptop it would point at itself).
 REMOTE_ROLE="$(remote_role_of "$SHIP_ROLE")"
 REMOTE_SSH="$(remote_ssh_of "$SHIP_ROLE")"
+
+# In degraded recovery mode the SSH defaults are deliberately absent (see above),
+# so the remote leg needs an explicit target or must be skipped. Say which.
+if [ "$DO_REMOTE" = 1 ] && [ -z "$REMOTE_SSH" ]; then
+  echo "ship: no ssh target for the remote host ($REMOTE_ROLE)." >&2
+  echo "  pass REMOTE_SSH=user@host, or run with --no-remote to converge this host only." >&2
+  exit 6
+fi
 
 # Self-contained converge routine, run identically on each host (local via
 # bash -c, remote via ssh). Single source of truth for the sequence.

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -13,16 +13,22 @@ are not the happy path — they are:
 
   1. rc-PER-CONDITION. Each drift shape must produce its OWN distinct non-zero
      code (8 diverged/ahead, 10 behind, 12 not-on-main, 3 no-repo, 4
-     fetch/origin-main, 13 unreachable). One code for "something is wrong" would
-     be indistinguishable from the un-pushed-commits case that actually bit us
-     twice, which is the only one that needs a rescue-before-reset procedure.
+     fetch/origin-main, 13 unreachable-for-N-consecutive-runs). One code for
+     "something is wrong" would be indistinguishable from the un-pushed-commits
+     case that actually bit us twice, which is the only one that needs a
+     rescue-before-reset procedure.
   2. THE POSITIVE CONTROL. `test_clean_repo_is_green` proves the checker can
      observe the clean case at all. A reassuring rc=0 from a checker wired to
      nothing is indistinguishable from a real green, so the green is only
      meaningful reported alongside the reds above.
-  3. PASSIVITY. Both statically (the forbidden mutating primitives must not
-     appear as CODE) and behaviourally (after a run against a diverged repo the
-     branch, HEAD, worktree and stash stack must all be byte-identical).
+  2b. THE ALERTING POLICY, IN BOTH DIRECTIONS. An unreachable laptop must NOT
+     fail the unit on its own (a permanently-red gate is worse than no gate) —
+     and a genuine rc 8 must still exit non-zero even while the laptop is
+     unreachable, or the softening has simply muted the deadman.
+  3. PASSIVITY. Statically — an ALLOWLIST of read-only git subcommands, anchored
+     at every command separator, plus an asserted ledger of the only file the
+     script writes — and behaviourally: after a run against a diverged repo the
+     branch, HEAD, worktree and stash stack must all be byte-identical.
   4. THE SEAM. drift-check.sh and ship.sh must resolve host identity through the
      SAME sourced predicate. Asserted as a ledger — neither file may define
      detect_role itself, both must source lib/host-role.sh — plus a behavioural
@@ -67,6 +73,7 @@ class Fleet:
         self.work = tmp_path / "work"
         self.home = tmp_path / "home"
         self.bin = tmp_path / "bin"
+        self.state = tmp_path / "state"
         self.home.mkdir()
         self.bin.mkdir()
 
@@ -148,8 +155,13 @@ class Fleet:
         env = self.env(
             SHIP_ROLE="workbench",           # bypass IP detection (no `ip` here)
             DRIFT_REPO=str(repo or self.work),
-            **envextra,
+            # Pinned into tmp_path: the unreachable streak is PERSISTENT state,
+            # and left to its default ($XDG_STATE_HOME/…) these tests would both
+            # write to the operator's real state dir and inherit a streak from
+            # whatever ran before them.
+            DRIFT_STATE_DIR=str(self.state),
         )
+        env.update(envextra)   # per-test overrides win (e.g. a blocked state dir)
         proc = subprocess.run(
             ["bash", str(DRIFT), *args],
             capture_output=True, text=True, env=env,
@@ -247,6 +259,50 @@ def test_not_on_main_is_rc12(fleet):
     assert "feat/something" in out, out
 
 
+def test_off_main_with_diverged_main_is_rc8(fleet):
+    """🔴 REGRESSION PIN for a mutant that the whole 41-test suite survived.
+
+    Shape: HEAD sits on a feature branch AND local `main` has un-pushed commits.
+    That is the rc 8 incident shape — ship.sh skips the host entirely and moves
+    nothing — but it is ALSO 'not on branch main', so the answer depends purely
+    on the ORDER of the two checks in drift-check.sh.
+
+    Hoisting the `off_main -> exit 12` guard above the ahead/behind comparison
+    (a mutant that deletes nothing and moves one line) makes this case report
+    rc 12 with the advice 'ship.sh will move it' — which is FALSE: ship.sh skips
+    this host and it receives nothing, forever. The pre-existing suite stayed
+    green under that mutant (41 passed, 0 failed).
+    """
+    fleet.catch_up()
+    fleet.add_local_commit("un-pushed work stranded on main")
+    fleet.git(fleet.work, "checkout", "-q", "-b", "feat/elsewhere")
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 8, f"off-main + diverged main must be the rc8 shape, got {rc}\n{out}"
+    # ...and the verdict must not tell the operator ship.sh will fix the checkout.
+    assert "ship.sh SKIPS this host" in out, out
+    assert "will NOT move it" in out, out
+    assert "ship.sh will land the checkout back on main" not in out, (
+        "reported that ship.sh will fix a host ship.sh actually skips\n" + out
+    )
+    # The stranded commit is still named — the report must be actionable.
+    assert "un-pushed work stranded on main" in out, out
+
+
+def test_off_main_and_behind_is_rc12_matching_the_published_severity_order(fleet):
+    """off-main AND behind -> rc 12, not rc 10.
+
+    The file publishes `12 > 10` in its own severity table; returning 10 for a
+    host that is both would contradict it, and the aggregate code a timer hands
+    to systemd is derived from that very table.
+    """
+    fleet.git(fleet.work, "checkout", "-q", "-b", "feat/behind-too")  # work is 1 behind
+    rc, out = fleet.check("--no-remote")
+    assert rc == 12, f"expected rc12, got {rc}\n{out}"
+    assert "not on branch main" in out, out
+    assert "also BEHIND by 1" in out, out
+
+
 def test_no_local_main_branch_is_rc12(fleet):
     """A checkout with no local `main` at all -> rc 12, not a crash."""
     fleet.git(fleet.work, "checkout", "-q", "-b", "only-branch")
@@ -282,17 +338,121 @@ def test_fetch_failure_is_rc4(fleet):
     assert "no drift" not in out, f"reported green despite being unable to look\n{out}"
 
 
+def test_fetch_failure_surfaces_gits_own_stderr(fleet):
+    """rc 4 must carry a DIAGNOSIS, not just a verdict.
+
+    The unit's only output is the journal, and rc 4 is the recurring code (key
+    rotation, DNS, host-key churn). Discarding git's stderr — which the original
+    did, with `2>/dev/null` — makes every one of those indistinguishable from
+    every other, on a unit nobody is watching live.
+    """
+    fleet.git(fleet.work, "remote", "set-url", "origin",
+              str(fleet.root / "does-not-exist.git"))
+    rc, out = fleet.check("--no-remote")
+    assert rc == 4, out
+    diag = [ln for ln in out.splitlines() if "] " in ln and " git: " in ln]
+    assert diag, f"git's own error was swallowed; nothing to debug from:\n{out}"
+    assert any(ln.split(" git: ", 1)[1].strip() for ln in diag), (
+        f"the git: prefix is there but carries no message\n{out}"
+    )
+
+
 # --------------------------------------------------------------------------- #
 # 3. The REMOTE leg (stubbed ssh — no network, no real host)
 # --------------------------------------------------------------------------- #
-def test_unreachable_remote_is_rc13(fleet):
-    """ssh's 255 must become a LOUD rc 13, never a pass."""
+def test_unreachable_remote_below_threshold_does_not_fail_the_unit(fleet):
+    """🔴 A SHUT LAPTOP MUST NOT LOOK LIKE DRIFT.
+
+    The timer is serverMode-gated (workbench-only), so its remote leg always
+    ssh's to the laptop — routinely off/asleep/off-LAN. Failing the unit on that
+    fires the SAME sticky critical toast as a genuine rc 8, up to 4× a day, and
+    a permanently-red gate is worse than no gate.
+
+    So: reported loudly in the journal, exit code unaffected.
+    """
     fleet.stub_ssh(255)
     rc, out = fleet.check("--no-local", REMOTE_SSH="stub@example.invalid")
-    assert rc == 13, f"expected rc13, got {rc}\n{out}"
+    assert rc == 0, f"a single unreachable run must not fail the unit, got {rc}\n{out}"
     assert "UNREACHABLE" in out
-    assert "this is not a pass" in out
-    assert "no drift" not in out
+    assert "not a pass" in out, out                  # still not sold as a green
+    assert "1/4 consecutive" in out, out
+    assert "NOT escalated" in out, out
+    # ...and the summary must not claim a clean bill of health for a run that
+    # successfully checked nothing.
+    assert "NO HOST WAS SUCCESSFULLY CHECKED" in out, out
+
+
+def test_unreachable_remote_escalates_after_n_consecutive_runs(fleet):
+    """🔴 THE OTHER DIRECTION: the softening must not make the deadman mute.
+
+    A host that has been unlookable for the whole threshold window is no longer
+    'the laptop is shut' — at that point NOT alerting would be the deadman
+    failing at its one job. Threshold reached -> rc 13 -> unit failed -> toast.
+    """
+    fleet.stub_ssh(255)
+    codes = []
+    for _ in range(4):
+        rc, out = fleet.check("--no-local", REMOTE_SSH="stub@example.invalid",
+                              DRIFT_UNREACHABLE_ESCALATE="3")
+        codes.append(rc)
+    assert codes == [0, 0, 13, 13], f"escalation ladder wrong: {codes}\n{out}"
+    assert "ESCALATING" in out, out
+    assert "CONSECUTIVE unreachable checks" in out, out
+
+
+def test_unreachable_streak_resets_when_the_host_answers(fleet):
+    """The streak counts CONSECUTIVE misses. One successful reach clears it —
+    otherwise a laptop that is merely offline every other day would eventually
+    escalate anyway and the threshold would be meaningless."""
+    fleet.catch_up()
+    fleet.stub_ssh(255)
+    for _ in range(2):
+        rc, _ = fleet.check("--no-local", REMOTE_SSH="stub@example.invalid",
+                            DRIFT_UNREACHABLE_ESCALATE="3")
+        assert rc == 0
+
+    fleet.stub_ssh(0, stdout="[laptop] clean")       # it answers
+    rc, out = fleet.check("--no-local", REMOTE_SSH="stub@example.invalid",
+                          DRIFT_UNREACHABLE_ESCALATE="3")
+    assert rc == 0, out
+
+    fleet.stub_ssh(255)                              # ...and goes away again
+    rc, out = fleet.check("--no-local", REMOTE_SSH="stub@example.invalid",
+                          DRIFT_UNREACHABLE_ESCALATE="3")
+    assert rc == 0, f"the streak did not reset on a successful reach\n{out}"
+    assert "1/3 consecutive" in out, out
+
+
+def test_local_rc8_still_wins_when_the_remote_is_unreachable(fleet):
+    """🔴 THE FAILURE MODE OF THE FIX ABOVE, pinned.
+
+    Softening the unreachable case must not soften anything else. With the
+    laptop shut AND this host carrying un-pushed commits, the run must still
+    exit 8 — non-zero is what puts the unit in `failed`, which is what
+    OnFailure=notify-failure@%n.service turns into the toast.
+    """
+    fleet.catch_up()
+    fleet.add_local_commit("un-pushed while the laptop is shut")
+    fleet.stub_ssh(255)
+    rc, out = fleet.check(REMOTE_SSH="stub@example.invalid")
+    assert rc == 8, f"local drift was masked by the unreachable remote: {rc}\n{out}"
+    assert "ship.sh SKIPS this host" in out, out
+    assert "UNREACHABLE" in out, out                 # both are still reported
+
+
+def test_unreachable_escalates_immediately_when_the_streak_cannot_be_persisted(fleet):
+    """If 'for how long' is unknowable, the run must fail CLOSED (loud), not open.
+
+    A state dir that cannot be created is the one case where the threshold logic
+    has no input at all; going quiet there would be an unbounded silent window.
+    """
+    blocked = fleet.root / "blocked-state"
+    blocked.write_text("not a directory\n")          # mkdir -p will fail on this
+    fleet.stub_ssh(255)
+    rc, out = fleet.check("--no-local", REMOTE_SSH="stub@example.invalid",
+                          DRIFT_STATE_DIR=str(blocked))
+    assert rc == 13, f"expected an immediate escalation, got {rc}\n{out}"
+    assert "could not be" in out and "persisted" in out, out
 
 
 def test_remote_rc_is_passed_through(fleet):
@@ -319,6 +479,61 @@ def test_worst_code_wins_across_hosts(fleet):
     assert "2 un-pushed" in out, f"remote line missing\n{out}"
 
 
+def test_rc8_outranks_an_escalated_rc13(fleet):
+    """The severity TABLE, exercised — killed a surviving mutant.
+
+    `test_worst_code_wins_across_hosts` only ever compares 8 against 10, so a
+    mutant that reranks rc 8 *below* rc 13 survived it. Un-pushed commits are the
+    condition with the rescue-before-reset procedure; an unreachable host is not.
+    The number handed to systemd must be the former.
+    """
+    fleet.catch_up()
+    fleet.add_local_commit("un-pushed, while the laptop has been gone for days")
+    fleet.stub_ssh(255)
+    for _ in range(3):
+        rc, out = fleet.check(REMOTE_SSH="stub@example.invalid",
+                              DRIFT_UNREACHABLE_ESCALATE="2")
+    assert "ESCALATING" in out, out          # the remote really did escalate
+    assert rc == 8, f"an escalated rc13 outranked the un-pushed-commits rc8\n{out}"
+
+
+def test_the_unreachable_streak_is_kept_PER_REMOTE_HOST(fleet):
+    """Killed a surviving mutant: a single shared counter file.
+
+    Today there is one remote per run so a shared file is invisible — but the
+    streak is what decides whether the alert fires, and a counter keyed by
+    nothing would let two hosts' absences add up into an escalation neither one
+    earned. Driven by flipping the LOCAL role, which flips which host is remote.
+    """
+    fleet.stub_ssh(255)
+    for _ in range(2):                       # laptop misses twice
+        rc, out = fleet.check("--no-local", REMOTE_SSH="stub@example.invalid",
+                              SHIP_ROLE="workbench", DRIFT_UNREACHABLE_ESCALATE="3")
+        assert rc == 0, out
+    # Now the OTHER direction: from the laptop, the remote is the workbench.
+    rc, out = fleet.check("--no-local", REMOTE_SSH="stub@example.invalid",
+                          SHIP_ROLE="laptop", DRIFT_UNREACHABLE_ESCALATE="3")
+    assert rc == 0, out
+    assert "1/3 consecutive" in out, (
+        "the workbench inherited the laptop's streak — one shared counter\n" + out
+    )
+
+
+def test_the_remote_payload_is_shell_quoted():
+    """STRUCTURAL, and labelled as such.
+
+    `require_int` already rejects every value that could inject, so swapping %q
+    back to %s is behaviourally invisible to this suite — a mutant that survives
+    every behavioural test. %q is the second layer, and the only way to hold a
+    second layer whose first layer never lets anything through is to assert it
+    is there.
+    """
+    src = DRIFT.read_text()
+    assert "DRIFT_LABEL=%q" in src and "DRIFT_UNTRACKED_MAX=%q" in src, (
+        "the values interpolated into the REMOTE payload are no longer %q-quoted"
+    )
+
+
 def test_clean_local_plus_clean_remote_is_green(fleet):
     """Positive control for the two-host path, including the ssh leg."""
     fleet.catch_up()
@@ -326,6 +541,66 @@ def test_clean_local_plus_clean_remote_is_green(fleet):
     rc, out = fleet.check(REMOTE_SSH="stub@example.invalid")
     assert rc == 0, f"expected rc0, got {rc}\n{out}"
     assert "no drift" in out
+
+
+def test_untracked_max_cannot_inject_a_command_into_the_remote_payload(fleet):
+    """🔴 The tunables are INTERPOLATED INTO A SCRIPT THAT RUNS ON THE OTHER HOST.
+
+    `DRIFT_UNTRACKED_MAX='10; echo INJECTED-COMMAND-RAN'` used to be executed
+    remotely — a passivity hole on the far side of the ssh hop, which the static
+    scanner structurally cannot see (it only reads this file). Operator-supplied,
+    so low exploitability, but a deadman forbidden from touching a host must not
+    contain a path that runs arbitrary commands on it.
+    """
+    fleet.stub_ssh(0, stdout="[laptop] clean")
+    rc, out = fleet.check(
+        "--no-local",
+        REMOTE_SSH="stub@example.invalid",
+        DRIFT_UNTRACKED_MAX="10; echo INJECTED-COMMAND-RAN",
+    )
+    # The marker may legitimately appear INSIDE the rejection message (it quotes
+    # the offending value back). What must never appear is the marker as the
+    # OUTPUT OF A COMMAND — i.e. on a line of its own.
+    ran = [ln for ln in out.splitlines() if ln.strip() == "INJECTED-COMMAND-RAN"]
+    assert not ran, f"remote command injection: the payload executed\n{out}"
+    assert rc == 2, f"a non-integer tunable must be a usage error, got {rc}\n{out}"
+    assert "must be a non-negative integer" in out, out
+
+
+@pytest.mark.parametrize(
+    "var", ["DRIFT_UNTRACKED_MAX", "DRIFT_UNREACHABLE_ESCALATE"]
+)
+def test_non_integer_tunables_are_rejected(fleet, var):
+    rc, out = fleet.check("--no-remote", **{var: "not-a-number"})
+    assert rc == 2, f"{var} was accepted as {'not-a-number'!r}\n{out}"
+    assert var in out, out
+
+
+def test_checking_nothing_is_refused_rather_than_reported_as_a_pass(fleet):
+    """`--no-local --no-remote` used to print 'no drift — both hosts on branch
+    main at origin/main' and exit 0 having looked at neither host: the exact
+    vacuous green this subsystem exists to prevent, from the subsystem itself."""
+    rc, out = fleet.check("--no-local", "--no-remote")
+    assert rc == 2, f"expected a usage error, got {rc}\n{out}"
+    assert "check NOTHING" in out, out
+    assert "no drift" not in out, out
+    assert "both hosts" not in out, out
+
+
+def test_a_single_host_run_does_not_claim_both_hosts(fleet):
+    """The summary must state WHAT WAS CHECKED.
+
+    `--no-remote` on a clean repo previously printed "no drift — both hosts on
+    branch main at origin/main", naming a host the run never contacted. That
+    wording appears in PR #367's own positive-control transcript, where it read
+    as evidence of coverage the run did not have.
+    """
+    fleet.catch_up()
+    rc, out = fleet.check("--no-remote")
+    assert rc == 0, out
+    assert "both hosts" not in out, f"claimed coverage it did not have\n{out}"
+    assert "workbench (local)" in out, out
+    assert "NOT checked" in out and "laptop" in out, out
 
 
 # --------------------------------------------------------------------------- #
@@ -389,47 +664,282 @@ def test_run_against_feature_branch_does_not_move_it(fleet):
 # --------------------------------------------------------------------------- #
 # 6. PASSIVITY — structural
 # --------------------------------------------------------------------------- #
-FORBIDDEN_PRIMITIVES = (
-    "git checkout", "git switch", "git merge", "git rebase", "git reset",
-    "git stash", "git clean", "git commit", "git push", "git pull",
-    "git cherry-pick", "git branch -", "--autostash", "home-manager",
-)
+# 🔴 An ALLOWLIST of read-only git subcommands, NOT a blocklist of mutating ones.
+#
+# The blocklist this replaced ("git checkout", "git reset", …) anchored on the
+# FIRST WORD OF A LINE and enumerated verbs, so it missed every one of:
+#   git restore --staged .        git update-ref refs/heads/main origin/main
+#   git config user.name evil     git gc --prune=now        git prune
+#   git worktree add /tmp/x       git branch new origin/main
+#   git symbolic-ref HEAD refs/heads/other                  rm -rf "$repo"
+#   say "checking" && git checkout main    echo hi; git reset --hard origin/main
+# — while three separate docstrings claimed it enforced passivity. A blocklist of
+# verbs is a game you lose once; an allowlist fails CLOSED on a verb nobody
+# thought of.
+READONLY_GIT_SUBCOMMANDS = frozenset({
+    "fetch",        # writes remote-tracking refs ONLY — the one deliberate write
+    "rev-parse", "rev-list", "show-ref", "ls-files", "log", "show",
+    "status", "diff", "cat-file", "for-each-ref", "merge-base", "describe",
+    "name-rev", "shortlog", "var", "check-ignore", "ls-remote", "count-objects",
+})
+
+# Non-git commands that can destroy or rewrite a host's files. `mkdir` is
+# deliberately absent (it creates, never destroys) and the ONE directory this
+# script creates is pinned separately by the redirection ledger below.
+DESTRUCTIVE_COMMANDS = frozenset({
+    "rm", "mv", "cp", "ln", "dd", "truncate", "tee", "shred", "mkfifo",
+    "chmod", "chown", "chgrp", "install", "rsync",
+    "home-manager", "nixos-rebuild", "nix-env",
+})
+
+# Words that are not the command — strip them and look at what follows.
+_TRANSPARENT = frozenset({
+    "if", "then", "elif", "else", "fi", "while", "until", "for", "do", "done",
+    "case", "esac", "select", "function", "!", "time", "exec", "eval",
+    "command", "builtin", "sudo", "env", "nohup", "xargs", "local", "export",
+    "declare", "readonly", "return", "in",
+})
+
+_PRINTERS = frozenset({"say", "echo", "printf"})
 
 
-# A line whose FIRST word is a printer can only PRINT the forbidden primitive,
-# not run it — and drift-check's whole value is that it prints the rescue
-# procedure (`git branch … && git push …`, `git reset --keep`) so the operator
-# does not have to go looking for it. The carve-out is withdrawn the moment the
-# line contains a command substitution, which is the one way a printer CAN
-# execute something; `test_scanner_catches_a_substitution_inside_a_message`
-# is the positive control for that half.
-_OUTPUT_ONLY = re.compile(r"^\s*(say|echo|printf)\b")
+def _walk(line):
+    """Split ONE shell line into command segments, quote-aware.
+
+    Segments break at every command separator — `;` `&&` `||` `|` `&` `(` `)`
+    `{` `}` — AND at `$(` / backtick, because a command substitution executes
+    even inside double quotes. That last part is why the old first-word anchor
+    was not enough: `say "x" && git checkout main` is two commands, and the
+    second one runs.
+
+    Quoted RUNS are kept in the segment text (so a message's words survive for
+    the human-readable report) but never create separators, which is what lets
+    `say "… git branch <t> && git push …"` stay a single printer segment.
+    """
+    segs, cur = [], []
+    i, n, q = 0, len(line), None
+    while i < n:
+        c = line[i]
+        if q == "'":
+            if c == "'":
+                q = None
+            else:
+                cur.append(c)
+            i += 1
+            continue
+        if q == '"':
+            if c == '"':
+                q = None
+                i += 1
+                continue
+            if c == "$" and line[i:i + 2] == "$(":
+                segs.append("".join(cur)); cur = []; q = None; i += 2
+                continue
+            if c == "`":
+                segs.append("".join(cur)); cur = []; q = None; i += 1
+                continue
+            cur.append(c)
+            i += 1
+            continue
+        # --- unquoted -------------------------------------------------------
+        if c == "\\":
+            i += 2
+            continue
+        if c == "'":
+            q = "'"; i += 1; continue
+        if c == '"':
+            q = '"'; i += 1; continue
+        if line[i:i + 2] == "$(":
+            segs.append("".join(cur)); cur = []; i += 2; continue
+        if c == "`":
+            segs.append("".join(cur)); cur = []; i += 1; continue
+        if c in "();{}&|":
+            segs.append("".join(cur)); cur = []
+            i += 2 if line[i:i + 2] in ("&&", "||") else 1
+            continue
+        cur.append(c)
+        i += 1
+    segs.append("".join(cur))
+    return [s for s in (x.strip() for x in segs) if s]
+
+
+def _command_tokens(seg):
+    """The tokens of a segment with leading assignments/redirections/keywords
+    stripped, so tokens[0] is the command actually being run (or [])."""
+    toks = seg.split()
+    while toks:
+        t = toks[0]
+        if re.fullmatch(r"[A-Za-z_][A-Za-z_0-9]*=.*", t) or re.match(r"^\d?[<>]", t):
+            toks.pop(0); continue
+        if t in _TRANSPARENT:
+            toks.pop(0); continue
+        break
+    return toks
+
+
+def _strip_redirections(toks):
+    """Drop redirection tokens (`2>/dev/null`, `>`, `"$f"`) from an argv list.
+
+    Without this, `git symbolic-ref --quiet --short HEAD 2>/dev/null` looks like
+    it has TWO operands and is misread as the ref-WRITING form."""
+    out, i = [], 0
+    while i < len(toks):
+        t = toks[i]
+        if re.fullmatch(r"\d?[<>]{1,2}", t):
+            i += 2; continue            # separated target
+        if re.match(r"^\d?[<>]", t):
+            i += 1; continue            # attached target
+        out.append(t); i += 1
+    return out
+
+
+def _classify_git(args):
+    args = _strip_redirections(args)
+    if "--autostash" in args:
+        return "git --autostash"
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a in ("-C", "-c", "--git-dir", "--work-tree", "--namespace"):
+            i += 2; continue
+        if a.startswith("-"):
+            i += 1; continue
+        break
+    if i >= len(args):
+        return None                       # bare `git`, or only global flags
+    sub = args[i]
+    operands = [x for x in args[i + 1:] if not x.startswith("-")]
+    if sub == "symbolic-ref":
+        # READ: `git symbolic-ref --quiet --short HEAD`.
+        # WRITE: `git symbolic-ref HEAD refs/heads/other` — same verb, two operands.
+        return None if len(operands) <= 1 else "git symbolic-ref (WRITES a ref)"
+    if sub in READONLY_GIT_SUBCOMMANDS:
+        return None
+    return "git %s (not in the read-only allowlist)" % sub
+
+
+def _classify(seg):
+    toks = _command_tokens(seg)
+    if not toks:
+        return None
+    cmd = toks[0].rsplit("/", 1)[-1]
+    if cmd in _PRINTERS:
+        # A printer can only PRINT — any substitution inside it became its own
+        # segment above, so this carve-out cannot swallow an execution.
+        return None
+    if cmd == "git":
+        return _classify_git(toks[1:])
+    if cmd == "sed" and any(t.startswith("-i") for t in toks[1:]):
+        return "sed -i (in-place edit)"
+    if cmd in DESTRUCTIVE_COMMANDS:
+        return "%s (destructive command)" % cmd
+    return None
 
 
 def scan_mutations(text):
-    """Return [(lineno, line, hits)] for every executable line that could MUTATE.
+    """Return [(lineno, line, reasons)] for every executable segment that could
+    MUTATE a checkout.
 
     Comment lines are excluded on purpose — the header DOCUMENTS the ban and the
     rescue procedure, so a whole-file grep would flag the script's own warning
-    label.
+    label. Line numbers are the file's real ones.
     """
-    code = [ln for ln in text.splitlines() if ln.strip() and not ln.strip().startswith("#")]
     out = []
-    for i, ln in enumerate(code, 1):
-        hits = [p for p in FORBIDDEN_PRIMITIVES if p in ln]
-        if not hits:
+    for i, ln in enumerate(text.splitlines(), 1):
+        s = ln.strip()
+        if not s or s.startswith("#"):
             continue
-        if _OUTPUT_ONLY.match(ln) and "$(" not in ln and "`" not in ln:
-            continue
-        out.append((i, ln.strip(), hits))
+        reasons = []
+        for seg in _walk(ln):
+            r = _classify(seg)
+            if r and r not in reasons:
+                reasons.append(r)
+        if reasons:
+            out.append((i, s, reasons))
     return out
+
+
+# Every command shape the previous first-word scanner MISSED, plus the two it
+# caught. This list IS the finding: a scanner is only worth its docstring once
+# each of these has been watched to flag.
+MUTATION_PROBES = [
+    "git checkout main",
+    "git switch -c other",
+    "git reset --hard origin/main",
+    "git restore --staged .",
+    "git update-ref refs/heads/main origin/main",
+    'git config user.name evil',
+    "git gc --prune=now",
+    "git prune",
+    "git worktree add /tmp/x",
+    "git branch newbranch origin/main",
+    "git symbolic-ref HEAD refs/heads/other",
+    "git clean -fdx",
+    "git stash",
+    "git commit -am wat",
+    "git push --force origin main",
+    "git pull --autostash",
+    "git remote set-url origin evil",
+    "git apply /tmp/patch",
+    "git am /tmp/patch",
+    'rm -rf "$repo"',
+    'mv "$repo" /tmp/gone',
+    'say "checking" && git checkout main',
+    "echo hi; git reset --hard origin/main",
+    'printf "x" || git clean -fdx',
+    'say "note" | git stash',
+    'say "oops $(git reset --hard origin/main)"',
+    "home-manager switch --flake .",
+    'sed -i "s/a/b/" "$repo/f"',
+    'git -C "$repo" checkout main',
+    "if true; then git reset --hard; fi",
+    "for f in x; do rm -rf $f; done",
+]
+
+
+@pytest.mark.parametrize("probe", MUTATION_PROBES)
+def test_scanner_flags_every_known_mutation_shape(probe):
+    """NEGATIVE CONTROL, one case per shape.
+
+    Each probe is appended to the REAL script, so a probe can only be flagged
+    because of itself — the rest of the file is known-clean by
+    `test_drift_check_source_never_mutates`.
+    """
+    offenders = scan_mutations(DRIFT.read_text() + "\n" + probe + "\n")
+    assert offenders, "the passivity scanner does not flag: %s" % probe
+    assert any(probe.strip() == ln for _, ln, _ in offenders), (
+        "flagged something, but not the injected line %r: %r" % (probe, offenders)
+    )
+
+
+# Lines that MUST NOT be flagged. Without these the scanner is indistinguishable
+# from one that flags everything — and a scanner that flags everything gets
+# deleted the first time it blocks a legitimate change.
+BENIGN_PROBES = [
+    'say "  fix: git reset --keep origin/main"',
+    'say "  rescue (on that host): git branch <topic> main && git push -u origin <topic>"',
+    "git fetch origin -q",
+    'fetch_err=$(git fetch origin -q 2>&1)',
+    "git rev-list --left-right --count origin/main...main 2>/dev/null",
+    "branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || echo DETACHED)",
+    "untracked=$(git ls-files --others --exclude-standard 2>/dev/null)",
+    "git show-ref --verify --quiet refs/heads/main",
+    'git log --oneline --no-decorate origin/main..main | head -n 10 | sed "s|^|  + |"',
+    'echo "[$REMOTE_ROLE] UNREACHABLE — ssh failed" ',
+    'mkdir -p "$DRIFT_STATE_DIR" 2>/dev/null',
+]
+
+
+@pytest.mark.parametrize("probe", BENIGN_PROBES)
+def test_scanner_does_not_flag_legitimate_read_only_lines(probe):
+    assert scan_mutations(probe + "\n") == [], probe
 
 
 def test_drift_check_source_never_mutates():
     offenders = scan_mutations(DRIFT.read_text())
     assert offenders == [], (
-        "drift-check.sh is PASSIVE — these lines could mutate a host:\n"
-        + "\n".join(f"  line {i}: {ln}   (matched {h})" for i, ln, h in offenders)
+        "drift-check.sh is PASSIVE — these segments could mutate a host:\n"
+        + "\n".join(f"  line {i}: {ln}   ({h})" for i, ln, h in offenders)
     )
     src = DRIFT.read_text()
     # ...and the read-only primitives must still be the ones doing the work.
@@ -437,39 +947,76 @@ def test_drift_check_source_never_mutates():
     assert "git rev-list --left-right --count" in src
 
 
-def test_scanner_catches_a_bare_mutating_command(tmp_path):
-    """Negative control #1 for the scanner above.
+def test_host_role_lib_never_mutates():
+    """The lib is SOURCED into the deadman, so its passivity is the deadman's."""
+    offenders = scan_mutations(HOST_ROLE_LIB.read_text())
+    assert offenders == [], offenders
 
-    Without it, `test_drift_check_source_never_mutates` is indistinguishable from
-    a scan wired to nothing — the vacuous-green shape this suite exists to stop.
+
+def _unquoted_redirect_targets(line):
+    """Redirection targets appearing OUTSIDE quotes on one line.
+
+    Quote-aware on purpose: `say "… git branch <topic> main …"` contains a `>`
+    that is text, not a redirection, and a naive regex reads it as a write to
+    the file `main`.
     """
-    mutated = DRIFT.read_text() + "\ngit checkout main\n"
-    offenders = scan_mutations(mutated)
-    assert offenders, "the passivity scanner cannot detect an injected mutation"
-    assert any("git checkout main" in ln for _, ln, _ in offenders)
+    targets, i, n, q, prev = [], 0, len(line), None, ""
+    while i < n:
+        c = line[i]
+        if q:
+            if c == q:
+                q = None
+            i += 1; prev = c; continue
+        if c in "'\"":
+            q = c; i += 1; prev = c; continue
+        if c == "#" and prev in ("", " ", "\t"):
+            break                       # trailing comment — not code
+        if c == ">" and prev not in "0123456789&":
+            j = i
+            while j < n and line[j] == ">":
+                j += 1
+            while j < n and line[j] == " ":
+                j += 1
+            k = j
+            while k < n and line[k] not in " \t;|&)":
+                k += 1
+            targets.append(line[j:k])
+            i = k; prev = ">"; continue
+        prev = c
+        i += 1
+    return targets
 
 
-def test_scanner_catches_a_substitution_inside_a_message(tmp_path):
-    """Negative control #2 — the carve-out's own boundary.
+def test_the_only_files_the_deadman_writes_are_the_streak_counters():
+    """LEDGER, not a spot check: every non-/dev/null redirection target in the
+    script, asserted as a set. Fails when it GROWS (a new file gets written) or
+    SHRINKS (the streak counter stops being persisted, which would silently
+    disable the escalation ladder).
 
-    The say/echo/printf carve-out exists so the rescue procedure can be PRINTED.
-    A command substitution smuggled into such a line would execute, so the
-    carve-out must not cover it. This is the mutation that a naive
-    "skip all message lines" scanner would sail straight past.
+    The static command scanner cannot see this: `printf … > "$repo/f"` is a
+    printer as far as it is concerned.
     """
-    mutated = DRIFT.read_text() + '\nsay "oops $(git reset --hard origin/main)"\n'
-    offenders = scan_mutations(mutated)
-    assert offenders, "the carve-out swallows a command substitution"
-    assert any("git reset" in " ".join(h) for _, _, h in offenders)
+    found = set()
+    for ln in DRIFT.read_text().splitlines():
+        s = ln.strip()
+        if not s or s.startswith("#"):
+            continue
+        for t in _unquoted_redirect_targets(ln):
+            if t in ("/dev/null", "&2", "&1", ""):
+                continue
+            found.add(t)
+    assert found == {'"$f"'}, (
+        "drift-check.sh writes files other than the unreachable streak counter: %r" % found
+    )
 
 
-def test_scanner_carve_out_still_allows_a_plain_message():
-    """...and the carve-out genuinely carves: a pure message line is NOT flagged.
-
-    Proves the two controls above are not passing merely because the scanner
-    flags everything.
-    """
-    assert scan_mutations('say "  fix: git reset --keep origin/main"\n') == []
+def test_redirect_ledger_notices_a_new_write():
+    """POSITIVE CONTROL for the ledger — a zero from it would otherwise be
+    indistinguishable from a regex that never matches anything."""
+    assert _unquoted_redirect_targets('printf "x" > "$repo/f"') == ['"$repo/f"']
+    assert _unquoted_redirect_targets('echo hi 2>/dev/null') == []
+    assert _unquoted_redirect_targets(
+        'say "  git branch <topic> main && git push"') == []
 
 
 # --------------------------------------------------------------------------- #
@@ -621,7 +1168,11 @@ def test_every_command_the_checker_runs_is_on_the_unit_path(cmd, attr):
     code = "\n".join(
         ln for ln in scripts_src.splitlines() if not ln.strip().startswith("#")
     )
-    assert cmd in code, (
+    # WORD-BOUNDED, not a raw substring: `"ip" in code` is satisfied by
+    # `pipefail` and `"tr" in code` by `untracked`, so half of this table used to
+    # pass without the command appearing anywhere as a command.
+    present = re.search(r"(?<![\w.-])%s(?![\w.-])" % re.escape(cmd), code) is not None
+    assert present, (
         f"{cmd!r} is pinned as a PATH requirement but the scripts no longer call "
         f"it — drop it from UNIT_PATH_REQUIREMENTS (the pin is the accounting)"
     )
@@ -629,3 +1180,110 @@ def test_every_command_the_checker_runs_is_on_the_unit_path(cmd, attr):
         f"the drift-check unit's PATH is missing {attr} — {cmd!r} would not resolve "
         f"under systemd, which has none of the login shell's PATH"
     )
+
+
+# --------------------------------------------------------------------------- #
+# 9. Recovery ergonomics — ship.sh must still work on a HALF-BROKEN host
+#
+# ship.sh is the tool you run when a host is already wrong. Making it hard-depend
+# on a second file removed the escape hatch that used to exist (the constants
+# were inline), so a missing lib/host-role.sh took out the recovery tool along
+# with everything else.
+# --------------------------------------------------------------------------- #
+def _ship_copy_without_lib(tmp_path):
+    """A copy of ship.sh whose lib/host-role.sh does NOT exist."""
+    d = tmp_path / "brokenhost" / "scripts"
+    d.mkdir(parents=True)
+    (d / "ship.sh").write_text(SHIP.read_text())
+    return d / "ship.sh"
+
+
+def test_ship_without_the_lib_still_honours_an_explicit_role(tmp_path):
+    """SHIP_ROLE must short-circuit detection without needing the lib."""
+    ship = _ship_copy_without_lib(tmp_path)
+    env = dict(os.environ, SHIP_ROLE="workbench", SHIP_REPO=str(tmp_path / "nope"))
+    out = subprocess.run(["bash", str(ship), "--no-remote", "--no-switch"],
+                         capture_output=True, text=True, env=env)
+    combined = out.stdout + out.stderr
+    assert out.returncode != 6, (
+        "SHIP_ROLE no longer overrides a missing lib — the recovery tool is "
+        f"unusable on a host missing one file\n{combined}"
+    )
+    assert "degraded recovery mode" in combined, combined
+
+
+def test_ship_without_the_lib_and_without_a_role_fails_loudly(tmp_path):
+    """The escape hatch is an ESCAPE HATCH: with no role there is no detection
+    (detect_role is deliberately NOT duplicated here), so this must exit 6 and
+    say what to do — not guess a role."""
+    ship = _ship_copy_without_lib(tmp_path)
+    env = {k: v for k, v in os.environ.items() if k != "SHIP_ROLE"}
+    out = subprocess.run(["bash", str(ship), "--no-remote", "--no-switch"],
+                         capture_output=True, text=True, env=env)
+    combined = out.stdout + out.stderr
+    assert out.returncode == 6, combined
+    assert "SHIP_ROLE=workbench" in combined, combined
+
+
+@pytest.mark.parametrize("script", ["ship.sh", "drift-check.sh"])
+def test_invoking_through_a_symlink_still_finds_the_shared_lib(tmp_path, script):
+    """${BASH_SOURCE[0]} is the INVOKING path, not the real one.
+
+    Unresolved, a ~/bin shim or any PATH symlink makes both scripts look for
+    lib/ next to the SYMLINK and exit 6. Latent today (no such symlink exists),
+    but it is exactly the shape that bites during a recovery.
+    """
+    link = tmp_path / ("link-" + script)
+    link.symlink_to(REPO_ROOT / "scripts" / script)
+    out = subprocess.run(["bash", str(link), "--detect-role", "192.168.50.250"],
+                         capture_output=True, text=True)
+    assert out.returncode == 0, out.stdout + out.stderr
+    assert out.stdout.strip() == "workbench", out.stdout + out.stderr
+
+
+def test_host_role_lib_is_safe_to_execute_directly():
+    """It is mode 755, so `./scripts/lib/host-role.sh --detect-role` happens.
+
+    Without a shebang the kernel hands it to /bin/sh; under a dash-ish /bin/sh
+    ${BASH_SOURCE[0]} is EMPTY, the executed-not-sourced guard never matches, and
+    the probe exits 0 having printed nothing — a silent no-op from a tool you are
+    reading an answer out of.
+    """
+    executable = os.access(HOST_ROLE_LIB, os.X_OK)
+    first = HOST_ROLE_LIB.read_text().splitlines()[0]
+    # Assembled from character codes, not written as a literal: a quoted `#!` in
+    # a test file is exactly what `test_runtime_shebangs.py` scans the repo for,
+    # and this line would otherwise report itself as an offender.
+    hashbang = chr(35) + chr(33)
+    assert (not executable) or first.startswith(hashbang), (
+        "host-role.sh is executable but has no shebang; first line: %r" % first
+    )
+    if executable:
+        out = subprocess.run([str(HOST_ROLE_LIB), "--detect-role", "192.168.50.155"],
+                             capture_output=True, text=True)
+        assert out.stdout.strip() == "laptop", (out.returncode, out.stdout, out.stderr)
+
+
+def test_the_timer_rationale_does_not_claim_laptop_behaviour():
+    """A COMMENT IS A CLAIM. The timer is serverMode-gated and ~/.server-mode
+    exists only on the workbench, so the timer never runs on the laptop —
+    OnStartupSec cannot be justified by the laptop 'having just resumed'.
+    """
+    timer_start = HOME_NIX.index("systemd.user.timers.drift-check")
+    rationale = HOME_NIX[max(0, timer_start - 1500):timer_start]
+    assert "laptop is intermittent" not in rationale, (
+        "the OnStartupSec rationale still describes laptop resume behaviour that "
+        "cannot occur — the timer is workbench-only:\n" + rationale
+    )
+    assert "workbench" in rationale.lower(), rationale
+
+
+def test_home_nix_documents_that_an_unreachable_remote_does_not_toast():
+    """The alerting POLICY is the load-bearing part of this unit, and it lives in
+    two files (the script decides, the unit alerts). Pin the unit-side claim so
+    the two cannot silently disagree."""
+    start = HOME_NIX.index("PASSIVE DRIFT DEADMAN")
+    block = HOME_NIX[start:HOME_NIX.index("systemd.user.services.drift-check")]
+    assert "serverMode" in block, "the block never states the timer is workbench-only"
+    assert "DRIFT_UNREACHABLE_ESCALATE" in block, block
+    assert "still exits 8" in block, block


### PR DESCRIPTION
Follow-up to #367 (merged as `fff198f`), fixing the findings of an adversarial audit of it. **Do not merge on my say-so — the whole point below is which claims are proven and which are not.** `enableDriftDeadman` stays `false`; nothing was deployed and no timer was enabled.

## 🔴 The headline: an unreachable remote was going to make this alert meaningless

`nix/home.nix` gates the timer on `serverMode && enableDriftDeadman`. **Verified: `~/.server-mode` exists only on the workbench** (`ls` on both hosts, read-only) — so the timer runs on the workbench alone and its remote leg always ssh's to the **laptop**, which is routinely shut, asleep or off-LAN. That yielded rc 13 → unit `failed` → the *same* sticky `urgency=critical` dunst toast as a genuine rc 8 divergence, up to 4×/day. The toast body names only the unit, so "my laptop is shut" was indistinguishable from "a host is silently receiving nothing". A permanently-red gate trains you to click through the one alert that must keep its meaning.

**New policy.** An unreachable remote is reported loudly in the journal on every run but contributes **nothing to the exit code** until `DRIFT_UNREACHABLE_ESCALATE` (default 4 ≈ 24h at the 6h cadence) *consecutive* misses, at which point it becomes rc 13 and fails the unit. The streak is persisted in `$DRIFT_STATE_DIR` (default `$XDG_STATE_HOME/drift-check`), reset the moment the host answers — with a verdict of any kind — and **fails closed**: if the counter cannot be persisted, "for how long" is unknowable and the run escalates immediately.

Both directions are pinned:

| direction | test |
|---|---|
| a shut laptop must not look like drift | `test_unreachable_remote_below_threshold_does_not_fail_the_unit` |
| a genuinely gone host must still shout | `test_unreachable_remote_escalates_after_n_consecutive_runs` |
| the softening must not mask real drift | `test_local_rc8_still_wins_when_the_remote_is_unreachable` |
| ...nor lose the severity ordering | `test_rc8_outranks_an_escalated_rc13` |
| the streak is genuinely *consecutive* | `test_unreachable_streak_resets_when_the_host_answers` |
| unknowable ⇒ loud, not quiet | `test_unreachable_escalates_immediately_when_the_streak_cannot_be_persisted` |

The stale `OnStartupSec` rationale (which justified it with laptop-resume behaviour that cannot occur — the timer never runs on the laptop) is corrected and pinned by `test_the_timer_rationale_does_not_claim_laptop_behaviour`.

## The surviving mutant from #367

`drift-check.sh`'s `off_main -> exit 12` sat **after** the ahead/behind comparison, and that ordering is what made documented divergence #2 work. Hoisting it above the `ahead` block — a mutant that deletes nothing — makes un-pushed commits on `main` while HEAD is on a feature branch report **rc 12** with the message *"ship.sh will move it"*, which is false: ship.sh skips that host with rc 8 and it receives nothing forever. **#367's full suite stayed green under that mutant (41 passed, 0 failed).**

Fixed, and pinned by `test_off_main_with_diverged_main_is_rc8` — proven RED against the mutant (M01 below), not merely green now. While there: the "ship.sh will move it" advisory now prints at the exit points where it is *true*, and off-main is checked **before** the behind block so off-main + behind returns 12, matching the severity table the file publishes (was 10).

## The passivity scanner was far weaker than three docstrings claimed

It anchored on the **first word of a line**. Replaced with an **allowlist** of read-only git subcommands, anchored at every command separator (`;` `&&` `||` `|` `$(`), quote-aware so the legitimate printed rescue procedure is not flagged. Measured against a 31-shape probe list, running both scanners over the same probes:

```
probes: 31
MISSED by OLD first-word scanner: 20
   - git restore --staged .            - git update-ref refs/heads/main origin/main
   - git config user.name evil         - git gc --prune=now
   - git prune                         - git worktree add /tmp/x
   - git branch newbranch origin/main  - git symbolic-ref HEAD refs/heads/other
   - git remote set-url origin evil    - git apply /tmp/patch
   - git am /tmp/patch                 - rm -rf "$repo"
   - mv "$repo" /tmp/gone              - say "checking" && git checkout main
   - echo hi; git reset --hard         - printf "x" || git clean -fdx
   - say "note" | git stash            - sed -i "s/a/b/" "$repo/f"
   - git -C "$repo" checkout main      - for f in x; do rm -rf $f; done
MISSED by NEW allowlist scanner: 0
false positives OLD: []   false positives NEW: []
```

The claim is now made only at the strength it holds: `drift-check.sh:~24`, `nix/home.nix:~1835` and this PR say *allowlist of read-only git subcommands, anchored at every separator* — and both explicitly carve out the one file the script writes (the streak counter), which the command scanner structurally cannot see. That file is held by a separate **asserted ledger** of every unquoted redirection target (`test_the_only_files_the_deadman_writes_are_the_streak_counters`), with its own positive control.

## The rest

- **Remote injection.** `DRIFT_UNTRACKED_MAX='10; echo INJECTED-COMMAND-RAN'` executed on the *other* host. Now integer-validated (rc 2) **and** `%q`-quoted into the payload.
- **`git fetch` stderr** is captured and re-printed with a `[host]   git: ` prefix instead of being sent to `/dev/null`. rc 4 is recurring (key rotation, DNS) and the journal is the unit's only output.
- **"no drift — both hosts…"** is gone. The summary names what was actually checked and what was not; `--no-local --no-remote` is now a usage error (rc 2) instead of a green over zero hosts.
- **`ship.sh` recovery.** `SHIP_ROLE` short-circuits a missing `lib/host-role.sh` again — deliberately *without* duplicating `detect_role` (the seam ledger still pins one definition) or the SSH constants (`REMOTE_SSH` must be explicit). Both scripts `readlink -f` their own path so a symlink invocation still finds `lib/`.
- **`host-role.sh`** gets a shebang: mode 755 + no shebang ⇒ `/bin/sh` ⇒ `${BASH_SOURCE[0]}` empty ⇒ `--detect-role` exits 0 printing nothing.
- **Nits:** `severity()` ranks rc 6; the header no longer claims the script never gc's (`git fetch` runs `gc --auto`); `UNIT_PATH_REQUIREMENTS` uses a word-bounded match (`"ip" in code` was satisfied by `pipefail`, `"tr"` by `untracked`).

---

## Red → green matrix

Every new/changed guard was run against the **pre-fix sources** (`origin/main` tree + this PR's test file) before being run against the fix. 20 failed there and pass here:

```
test_off_main_with_diverged_main_is_rc8                     RED (rc 12 under M01) -> GREEN
test_off_main_and_behind_is_rc12...                         RED (rc 10)   -> GREEN
test_fetch_failure_surfaces_gits_own_stderr                 RED (no git: line) -> GREEN
test_unreachable_remote_below_threshold_does_not_fail...    RED (rc 13)   -> GREEN
test_unreachable_remote_escalates_after_n_consecutive_runs  RED           -> GREEN
test_unreachable_streak_resets_when_the_host_answers        RED           -> GREEN
test_unreachable_escalates_immediately_when_...persisted    RED           -> GREEN
test_untracked_max_cannot_inject_a_command_into_...         RED (injected) -> GREEN
test_non_integer_tunables_are_rejected[×2]                  RED (rc 0)    -> GREEN
test_checking_nothing_is_refused_rather_than_...            RED (rc 0)    -> GREEN
test_a_single_host_run_does_not_claim_both_hosts            RED           -> GREEN
test_the_only_files_the_deadman_writes_are_...              RED           -> GREEN
test_ship_without_the_lib_still_honours_an_explicit_role    RED (rc 6)    -> GREEN
test_ship_without_the_lib_and_without_a_role_fails_loudly   RED           -> GREEN
test_invoking_through_a_symlink...[ship.sh, drift-check.sh] RED (rc 6)    -> GREEN
test_host_role_lib_is_safe_to_execute_directly              RED           -> GREEN
test_the_timer_rationale_does_not_claim_laptop_behaviour    RED           -> GREEN
test_home_nix_documents_that_an_unreachable_remote...       RED           -> GREEN
```

**Labelled honestly:** `test_local_rc8_still_wins_when_the_remote_is_unreachable` **passes on pre-fix code too** (there, rc 8 already outranked rc 13). It is an *invariant guard* on the new policy, not regression coverage — it is what would have caught the fix over-correcting into silence, and M04 (escalate on every unreachable run) confirms it can go red.

## Post-fix mutant battery — 25 mutants, 25 killed, 0 survivors

Re-run in full after the fixes (a fix round resets the gate). Each mutant deletes nothing semantically invisible: it moves a guard, inverts a comparison, disarms a call while leaving its text in place, rebinds a value, or shifts an rc.

| # | mutant | killed by |
|---|---|---|
| M01 | hoist off-main above the ahead check (**the #367 survivor**) | `test_off_main_with_diverged_main_is_rc8`, `..._and_behind_is_rc12...` |
| M02 | escalation off-by-one (`-ge` → `-gt`) | `test_unreachable_remote_escalates_after_n_consecutive_runs` |
| M03 | escalation neutralised (`note_rc 13` text kept, call disarmed) | same |
| M04 | escalate on **every** unreachable run (the too-loud direction) | 4 tests incl. `..._below_threshold_does_not_fail_the_unit` |
| M05 | ahead/behind operands swapped in `rev-list` | 8 tests |
| M06 | severity: rc 13 outranks rc 8 | `test_rc8_outranks_an_escalated_rc13` |
| M07 | `streak_reset` made a no-op | `test_unreachable_streak_resets_when_the_host_answers` |
| M08 | `require_int` stops matching non-digits | 3 tests |
| M09 | `%q` → `%s` in the remote payload | `test_the_remote_payload_is_shell_quoted` |
| M10 | `git fetch` stderr swallowed again | `test_fetch_failure_surfaces_gits_own_stderr` |
| M11 | summary reverts to "both hosts" | `test_a_single_host_run_does_not_claim_both_hosts` |
| M12 | the check-nothing guard can never fire | `test_checking_nothing_is_refused...` |
| M13 | ship.sh degraded mode removed | `test_ship_without_the_lib_still_honours_an_explicit_role` |
| M14/M15 | symlink resolution disarmed (ship / drift) | `test_invoking_through_a_symlink...` |
| M16 | host-role.sh shebang removed | `test_host_role_lib_is_safe_to_execute_directly` |
| M17 | off-main ranked below behind | `test_off_main_and_behind_is_rc12...`, `test_behind_only_is_rc10` |
| M18 | unpersistable-streak escalation can never fire | `test_unreachable_escalates_immediately_when...` |
| M19 | `git update-ref` injected into the deadman | `test_drift_check_source_never_mutates` |
| M20 | the stale laptop-resume rationale restored | `test_the_timer_rationale_does_not_claim_laptop_behaviour` |
| M21 | `enableDriftDeadman` flipped ON | `test_the_timer_is_gated_by_the_master_switch...` |
| M22 | `OnFailure` dropped from the service | `test_home_nix_declares_the_service_and_the_timer` |
| M23 | streak never increments (`prev + 0`) | 5 tests |
| M24 | streak file no longer keyed by role | `test_the_unreachable_streak_is_kept_PER_REMOTE_HOST` |
| M25 | an unreachable remote counted as CHECKED | `test_unreachable_remote_below_threshold_does_not_fail_the_unit` |

**The first run of this battery had 3 survivors — M06, M09 and M24 — and they are only dead because three tests were added in response.** M09 is killed by a *structural* assertion (`%q` is present in the source), labelled as such in its own docstring: `require_int` already rejects everything that could inject, so the second layer is behaviourally unobservable and there is no honest way to pin it behaviourally.

## Re-derived controls

A second harness, deliberately built differently from the pytest suite (plain bash, real throwaway `/tmp` clones, stub `ssh`) — `18/18 PASS`:

```
clean 0 | ahead 8 | behind 10 | off-main 12 | off-main+behind 12 | off-main+DIVERGED 8
missing repo 3 | fetch failure 4
unreachable 1..3/4 -> 0, 0, 0 | 4/4 -> 13 | remote answers -> 0 (streak reset) | gone again -> 0
rc8 local + unreachable remote -> 8
--no-local --no-remote -> 2 | injection attempt -> 2 (marker appears only inside the rejection message)
```

**Positive control for that harness**: pointed at the *pre-fix* `drift-check.sh` it reports **6 FAILs** (off-main+behind, three unreachable rows, `--no-local --no-remote`, the injection), so its greens are not a harness wired to nothing.

## Suite state

`scripts/tests`: **9 failed, 1523 passed** — the same 9 that are red on `main` (`test_claude_log_rotate.py` ×6, needs `logrotate` on PATH; `test_run_tests_preconditions.py` ×3). `test_drift_check.py` itself: 41 → **105 tests, all passing**. `nix-instantiate --parse nix/home.nix` OK.

## 🔴 What I could NOT verify

1. **The toast itself was never exercised.** I did not start `drift-check.service`, did not trigger `notify-failure@`, and saw no dunst notification. What is verified is that rc 8 is the process exit code (systemd's input) and that `OnFailure = notify-failure@%n.service` is still on the unit (M22). The last link — failed unit → sticky critical toast — is asserted from the existing mechanism's design, **not observed**.
2. **Nothing ran on either real host.** Every run was against throwaway `/tmp` clones with a stub `ssh`. The real ssh leg from a systemd-user context (no ssh-agent) is still unproven — the same gap #367 named as the reason `enableDriftDeadman` is off.
3. **Threshold 4 ≈ 24h is a design choice, not a measurement.** I have no data on how long the laptop is typically unreachable. If it is routinely off for >24h the deadman will escalate on a healthy fleet; tune `DRIFT_UNREACHABLE_ESCALATE` during the supervised enable rather than treating 4 as validated.
4. **The escalation window is a real hole while it is open.** Between miss 1 and miss N a genuinely-diverged unreachable host is invisible. That is the deliberate trade for keeping the toast meaningful, but it is a widened blind spot, not a free win.
5. **The scanner is only as good as the 31 probes.** It is an allowlist, so it fails closed on unknown git verbs, but it still cannot see: writes through a variable-named command, anything on the far side of `ssh`, or anything `bash -c "$CHECK"` does that the segmenter mis-parses. The per-line quote tracking desyncs on a line with unbalanced quotes; that errs toward flagging, never toward silence.
6. **`home-manager switch` was never run.** `nix-instantiate --parse` proves the file parses, not that the module evaluates or that the unit renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
