### PR TITLE
fix(espanso): tighten the :acq expansion wording

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -150,7 +150,7 @@ in
           # interface — and the old search_terms (ask/clarify/questions/elicit/…)
           # contained none of the words he actually types: feedback, dispatch,
           # process. Lead the label with "feedback" and add those three terms.
-          { trigger = ":acq"; replace = "dispatch subagent to process feedback\nask me clarifying questions and recommend anything you think would be useful to include before dispatching (include complete test coverage)"; label = "Process feedback: dispatch subagent + ask clarifying questions"; search_terms = ["feedback" "dispatch" "process" "ask" "clarify" "clarifying" "questions" "elicit" "scope" "include"]; }
+          { trigger = ":acq"; replace = "dispatch subagent to process feedback\nask clarifying questions and recommend anything useful to include before dispatching (include complete test coverage)"; label = "Process feedback: dispatch subagent + ask clarifying questions"; search_terms = ["feedback" "dispatch" "process" "ask" "clarify" "clarifying" "questions" "elicit" "scope" "include"]; }
           { trigger = ":kickoff"; replace = "give me the kickoff message to copy paste to next session"; label = "Kickoff message for next session"; search_terms = ["kickoff" "kick off" "next session" "copy paste" "handoff" "message"]; }
           # Added 2026-08-05 via /espanso-audit — both are WHOLE-STANDALONE-MESSAGE
           # shaped, the one shape that has stuck (:eos 72 fires, :kickoff 38); every


### PR DESCRIPTION
## What

One-line change to the `:acq` espanso snippet in `nix/home.nix`:

```diff
-replace = "…ask me clarifying questions and recommend anything you think would be useful to include before dispatching…"
+replace = "…ask clarifying questions and recommend anything useful to include before dispatching…"
```

Same intent, tighter imperative. `trigger`, `label` and `search_terms` are **untouched**, so `/espanso-audit`'s per-snippet fire counts remain attributable to the same snippet across the change.

## Provenance

Author-confirmed as intended. It was sitting **uncommitted in the workbench's devrc checkout** (mtime 2026-08-09 21:24), found while clearing an unrelated untracked blocker after #368.

## Why it was worth rescuing now rather than later

`nix/home.nix` is one of the files the two commits the workbench is behind (#367, #368) also touch. Left uncommitted, it would have failed the next `ship.sh` with **rc=7 `cannot-fast-forward (local changes in the way)`** and skipped that host — the same silent-skip class as the divergence rescued in #366, arriving by a different door.

## Verification

- Patch applies cleanly to `origin/main`; `git diff` confirms **exactly one line** changed.
- `nix-instantiate --parse nix/home.nix` → OK (syntax only; no build or switch was run).
- Nothing deployed.

## ⚠ Overlaps an in-flight branch

`fix/drift-deadman-audit` also edits `nix/home.nix` (the drift-deadman service/timer block, ~line 1839+). This change is at ~line 140, so a textual conflict is unlikely — but a clean git merge is not a clean merge. **Test-merge the two rather than reasoning about it** before landing the second one.

## After merge

The workbench's copy stays "modified" until that host is reconciled — and being byte-identical to the merged version is *not* enough to let a fast-forward through (see #366, where six identical files still blocked `--keep`). It needs `git checkout HEAD -- nix/home.nix` there before the next ship.