### PR TITLE
fix(analyze-service): the bootstrap probe refused outright — unbreak the permanently-red pytests gate

### DIFF
--- a/scripts/analyze-service-index/commit.sh
+++ b/scripts/analyze-service-index/commit.sh
@@ -655,7 +655,24 @@ commit_scope() {
     # git cannot track — a repository bootstrapped and then failed on daily.
     md_probe="$(find "$scope" -type f -name '*.md' -print -quit 2>/dev/null)"
     md_rc=$?
-    if [ "$md_rc" -ne 0 ]; then
+    # 🔴 PROTECT FIRST, ALARM SECOND — HERE TOO, NOT ONLY IN commit_once.
+    # A bad probe rc alone used to `return 1` before `git init` ever ran, which
+    # is the "refuse outright" that commit_once's own header forbids: MEASURED
+    # 2026-08-09 on a NEW scope holding a readable `alpha.md` beside an
+    # unreadable `sub/` (GNU findutils 4.10.0 — `find … -print -quit` exits 1
+    # *and* prints `alpha.md`, because `-quit` does not clear an error that has
+    # already occurred), the scope was left with NO `.git` at all and alpha.md
+    # was never versioned, on that run or any later one. The guard meant to stop
+    # a silent skip was instead causing the data loss it exists to catch, and it
+    # is the un-versioned-forever half that matters — the alarm fired either way.
+    #
+    # So the probe's rc only REFUSES when nothing readable was found. Once a
+    # readable index file exists the repo is bootstrapped and that content is
+    # committed; the incompleteness is not swallowed — `list_candidates` below
+    # re-derives it into ASI_ENUM_RC and `enum_verdict` fails the scope with
+    # "candidate enumeration was INCOMPLETE", on this run and on every clean run
+    # after it, until a chmod lands.
+    if [ "$md_rc" -ne 0 ] && [ -z "$md_probe" ]; then
       echo "${PROG}: ${fail_prefix} could not enumerate *.md files (find rc=${md_rc}) — refusing to report a clean skip" >&2
       return 1
     fi

--- a/scripts/tests/test_analyze_service_index_commit.py
+++ b/scripts/tests/test_analyze_service_index_commit.py
@@ -1351,6 +1351,53 @@ def test_an_unreadable_subdirectory_still_alarms_once_the_tree_is_CLEAN(tmp_path
             f"not test what it claims:\n{p.stdout}")
 
 
+def test_an_unreadable_subdirectory_does_not_stop_a_NEW_scope_being_bootstrapped(tmp_path):
+    """🔴 THE BOOTSTRAP PROBE REFUSED OUTRIGHT, WHICH IS THE DATA LOSS ITSELF.
+
+    `commit_scope`'s "is there anything to bootstrap?" probe treated ANY non-zero
+    `find` rc as a reason to `return 1` *before* `git init` ran. MEASURED
+    2026-08-09 (GNU findutils 4.10.0) on a NEW scope holding a readable
+    `alpha.md` beside an unreadable `sub/`: `find … -print -quit` exits 1 AND
+    prints `alpha.md` — `-quit` does not clear an error that already occurred —
+    so the scope was left with no `.git` at all, run after run, and alpha.md was
+    never versioned. The guard that exists to stop a silent skip was causing the
+    loss it is meant to catch; `commit_once` already says the rule out loud
+    ("Protect first, then alarm") and this path did not follow it.
+
+    This pins the FIRST run specifically — the moment of bootstrap — which is the
+    only run on which the refusal was observable, and asserts BOTH halves:
+    the content is versioned, and the incompleteness is still loud with THIS
+    guard's own message rather than merely a non-zero exit.
+    """
+    store = tmp_path / "store"
+    scope = store / "some-scope"
+    blocked = scope / "sub"
+    blocked.mkdir(parents=True)
+    (scope / "alpha.md").write_text("readable\n", encoding="utf-8")
+    (blocked / "hidden.md").write_text("UNREADABLE\n", encoding="utf-8")
+
+    try:
+        blocked.chmod(0o000)
+        first = _run(store)
+    finally:
+        blocked.chmod(0o755)
+
+    assert (scope / ".git").is_dir(), (
+        f"the scope was never bootstrapped, so its readable content is "
+        f"unversioned forever:\n{first.stdout}\n{first.stderr}")
+    assert "alpha.md" in _git(scope, "ls-files").stdout, (
+        f"readable content was not committed on the bootstrap run:\n"
+        f"{first.stdout}\n{first.stderr}")
+    assert "refusing to report a clean skip" not in first.stderr, (
+        f"the probe still refused outright:\n{first.stderr}")
+    assert first.returncode != 0, (
+        f"protecting the readable content must NOT silence the alarm:\n"
+        f"{first.stdout}")
+    assert "enumeration was INCOMPLETE" in first.stderr, (
+        f"a DIFFERENT guard produced the non-zero exit — this one is still "
+        f"unreached:\n{first.stderr}")
+
+
 def test_the_incomplete_enumeration_alarm_clears_when_the_scope_becomes_readable(tmp_path):
     """🔴 THE OTHER HALF: a red gate nobody can clear trains you to ignore it
     (RULES.md). Making the clean path alarm is only correct if `chmod` silences


### PR DESCRIPTION
## Verdict: the CODE was wrong, the test was right

`scripts/tests/test_analyze_service_index_commit.py::test_an_unreadable_subdirectory_still_alarms_once_the_tree_is_CLEAN`
has failed **in both tiers since it landed** in #361 (`09eb6f4`) — it has never
passed. GitHub Actions is billing-blocked, so the red gate landed unnoticed.

The test's assertion message states the contract: *"the guard must protect first
and alarm second, never refuse outright"*. `commit.sh` genuinely refuses
outright, and `commit_once`'s own header (lines 454-464) already states that
rule for the *other* enumeration site. The bootstrap probe did not follow it.

## Root cause

`commit_scope`, in the `st = 0` ("scope has no repo yet") branch:

```bash
md_probe="$(find "$scope" -type f -name '*.md' -print -quit 2>/dev/null)"
md_rc=$?
if [ "$md_rc" -ne 0 ]; then
  echo "... could not enumerate *.md files (find rc=${md_rc}) — refusing to report a clean skip" >&2
  return 1        # <-- before `git init` ever runs
fi
```

MEASURED on this host (GNU findutils 4.10.0), on a scope holding a readable
`alpha.md` beside an unreadable `sub/`:

```
$ find <scope> -type f -name "*.md" -print -quit 2>/dev/null
rc=1  out=[<scope>/alpha.md]
```

`-quit` does **not** clear an error that already occurred, so the probe returns
rc=1 *while having found readable content*. The scope was therefore left with no
`.git` at all — `git ls-files` in the test failed with `fatal: not a git
repository`, which is why the `alpha.md` assertion was the visible symptom.

Direct run of the script (not via pytest), pre-fix, three consecutive runs:

```
analyze-service-index-commit: scope some-scope: could not enumerate *.md files (find rc=1) — refusing to report a clean skip
script rc=1
$ ls -a <scope>
.  ..  alpha.md  sub          # no .git, run after run
```

The guard that exists to stop a *silent skip* was itself causing the *data loss*
it is meant to catch — permanently, since the refusal happens before bootstrap
so nothing ever gets versioned. The alarm fired either way; the un-versioned half
is the part that mattered.

## Fix

The probe's rc refuses only when nothing readable was found. Once a readable
index file exists, the repo is bootstrapped and that content is committed; the
incompleteness is not swallowed — `list_candidates` below re-derives it into
`ASI_ENUM_RC` and `enum_verdict` fails the scope with "candidate enumeration was
INCOMPLETE", on that run and on every clean run after it, until a `chmod` lands.

Not a loosened check: the "nothing readable found" case still refuses with the
same message (pinned by the pre-existing
`test_an_unreadable_scope_is_not_reported_as_having_no_index_files`, which stays
green), and the alarm on the partial case is still non-zero.

## Behavioural proof (script run directly, not via pytest)

```
run1 rc=1  initialised a new repository (branch trunk, no remote)
           committed fb34ef4 — 1 change(s)
       err candidate enumeration was INCOMPLETE (find rc=1) ...
run2 rc=1  clean — nothing to commit   + enumeration was INCOMPLETE
run3 rc=1  clean — nothing to commit   + enumeration was INCOMPLETE
$ git ls-files
alpha.md
--- after chmod 755 on sub/ ---
rc=0  committed ca6e950
$ git ls-files
alpha.md
sub/hidden.md
```

Readable content protected, alarm loud on every run, and it clears on `chmod` —
not a permanently-red gate.

## Red → green matrix

| | pre-fix `commit.sh` | post-fix |
|---|---|---|
| `test_an_unreadable_subdirectory_still_alarms_once_the_tree_is_CLEAN` | **FAIL** | PASS |
| `test_an_unreadable_subdirectory_does_not_stop_a_NEW_scope_being_bootstrapped` (new) | **FAIL** | PASS |
| `test_an_unreadable_scope_is_not_reported_as_having_no_index_files` | PASS | PASS |

Both failing tests were run against the pre-fix `commit.sh` with the new test
file in place: `2 failed, 1 passed, 80 deselected`.

## Both tiers, with counts

Tier 1 — `nix-shell -p python3Packages.pytest ... --run 'python3 -m pytest scripts/tests -q'`:

| | result |
|---|---|
| at `origin/main` (`4f0346c`) | `1 failed, 1613 passed` |
| this branch | `1615 passed` |

Tier 2 — `nix build .#checks.x86_64-linux.pytests -L`:

| | result |
|---|---|
| at `origin/main` | `FAIL scripts/tests (collected=1614 passed=1613 skipped=0 failed=1)` / `TOTAL collected=6707 passed=6705 skipped=1 failed=1` / `RESULT: FAIL` |
| this branch | `PASS scripts/tests (collected=1615 passed=1615 skipped=0)` / `TOTAL collected=6708 passed=6707 skipped=1 failed=0` / `RESULT: PASS` |

`skipped=0` for `scripts/tests` in both tiers, so nothing here opted out. The one
remaining skip is the pre-existing pinned `repo-cos` live-store drift check.

## Sibling instances

Two other `find` error paths in `commit.sh` were checked:

1. **`list_candidates` (the second enumeration, inside `commit_once`)** — already
   correct: records into `ASI_ENUM_RC`, does not abort. This is the site whose
   comment states the rule the fixed site was violating.
2. **`warn_about_store_root_files`** — discards `find`'s rc entirely, but it is a
   warning-only path and cannot refuse or skip anything. No data-loss shape.

**Found, NOT fixed, deliberately out of scope** — `list_scopes` at the store
root has the *opposite* shape and is a real silent-success hole. Its rc is never
observed (it is consumed by a process substitution), so an unreadable STORE ROOT
enumerates zero scopes and falls through to `seen -eq 0`. MEASURED on this
branch, with a store containing a real scope and `chmod 000` on the store root:

```
find: '<store>': Permission denied
analyze-service-index-commit: no scope directories under <store> — nothing to do
rc=0
```

i.e. exit 0, "nothing to do", forever, over content that exists — precisely the
silent-loss outcome this unit exists to prevent. It is a distinct guard with
distinct semantics (it needs the `list_candidates` write-to-a-file treatment plus
its own test), so it is reported here rather than folded into a PR whose verdict
is about one specific defect. Flagging rather than silently expanding scope.

## Not verified / residual risk

- **The behaviour under the unit's systemd sandbox was not measured.** As the
  script's own header says, every claim about `ProtectHome=tmpfs` etc. is only as
  good as the last `systemd-run --user` measurement, and this change was
  exercised uncontained only. It touches no path/permission semantics the sandbox
  alters, but that is reasoning, not a measurement.
- **The probe's rc/output pairing is a GNU findutils 4.10.0 observation.** A
  `find` whose `-quit` *does* clear the error would take the "nothing readable"
  branch and refuse — the pre-fix behaviour — rather than misbehaving in a new
  way. Worth knowing: this host's interactive `find` is aliased to `bfs`, which
  is breadth-first and returns rc=0 on the same fixture; the script runs under
  bash and gets real GNU `find` from PATH.
- **Nothing was deployed.** No `home-manager switch`, no `ship.sh`, no service
  started or enabled. The live timer still runs the `main` version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
