### PR TITLE
fix(analyze-service): an unreadable store root reported "nothing to do" — the silent-zero mirror of #372

### DIFF
--- a/scripts/analyze-service-index/commit.sh
+++ b/scripts/analyze-service-index/commit.sh
@@ -121,8 +121,11 @@
 #   ASI_BRANCH      branch name for a scope this script initialises (default trunk)
 #   ASI_GIT_NAME / ASI_GIT_EMAIL   identity used ONLY when git cannot resolve one
 #
-# Exit codes: 0 = every scope committed or already clean. 1 = at least one scope
-# failed; read the message. It is deliberately never "quietly 0" on an error path.
+# Exit codes: 0 = every scope committed or already clean AND the store root was
+# fully enumerated. 1 = at least one scope failed, or the scope list itself is a
+# partial view of the store (see store_enum_verdict); read the message. It is
+# deliberately never "quietly 0" on an error path — and "no scopes found" counts
+# as 0 only once the walk that found none is known to have SUCCEEDED.
 set -uo pipefail
 
 PROG="analyze-service-index-commit"
@@ -221,16 +224,22 @@ command -v git >/dev/null 2>&1 ||
 # instead of passing in a sandbox and failing on a host with a system gitconfig.
 ASI_NOHOOKS="$(mktemp -d "${TMPDIR:-/tmp}/asi-nohooks.XXXXXX")" ||
   die "could not create the empty hooks directory — refusing to run with hooks live"
-# Candidate enumeration goes to FILES, not pipes, for two independent reasons:
-#   * find's exit code survives (a pipe discards it — see list_candidates);
+# ALL enumeration goes to FILES, not pipes, for two independent reasons:
+#   * find's exit code survives (a pipe discards it — see list_candidates; a
+#     process substitution discards it just as completely — see list_scopes);
 #   * NUL-delimited output survives. `$(…)` silently drops NUL bytes ("warning:
 #     command substitution: ignored null byte in input"), which would corrupt
 #     exactly the framing that makes newline-containing paths safe.
 ASI_CANDFILE="$(mktemp "${TMPDIR:-/tmp}/asi-cands.XXXXXX")" &&
   ASI_SORTED="$(mktemp "${TMPDIR:-/tmp}/asi-sorted.XXXXXX")" &&
-  ASI_IGNORED="$(mktemp "${TMPDIR:-/tmp}/asi-ignored.XXXXXX")" ||
+  ASI_IGNORED="$(mktemp "${TMPDIR:-/tmp}/asi-ignored.XXXXXX")" &&
+  ASI_SCOPEFILE="$(mktemp "${TMPDIR:-/tmp}/asi-scopes.XXXXXX")" &&
+  ASI_SYMFILE="$(mktemp "${TMPDIR:-/tmp}/asi-syms.XXXXXX")" ||
   die "could not create the temporary files this run needs"
-cleanup() { rm -rf "$ASI_NOHOOKS" "$ASI_CANDFILE" "$ASI_SORTED" "$ASI_IGNORED"; }
+cleanup() {
+  rm -rf "$ASI_NOHOOKS" "$ASI_CANDFILE" "$ASI_SORTED" "$ASI_IGNORED" \
+         "$ASI_SCOPEFILE" "$ASI_SYMFILE"
+}
 trap cleanup EXIT
 
 export GIT_CONFIG_NOSYSTEM=1
@@ -285,9 +294,36 @@ fi
 # with zero users. So: both bind lists stay frozen at one entry each, symlinks
 # are refused, and the refusal is LOUD (see list_scope_symlinks). Silence is the
 # one outcome that is not allowed.
+#
+# 🔴 AND THE EXIT CODE IS OBSERVABLE, BECAUSE THE RESULT GOES TO A FILE.
+# This used to be `find … | sort -z` read as `< <(list_scopes)`, and a process
+# substitution discards the function's rc as completely as a pipe discards
+# find's — the two rc-laundering shapes this file has now been bitten by three
+# times. MEASURED 2026-08-10 on this host (GNU findutils 4.10.0; note the
+# INTERACTIVE `find` here is aliased to bfs 4.1.1, which is NOT what a script
+# gets — bfs returns 0 on the same fixture, so an interactive spot-check lies):
+# with the store root at mode 0300 over a real scope holding `svc.md`, find
+# exits 1 and prints nothing, and the run said
+#
+#     "no scope directories under <store> — nothing to do"   (rc=0)
+#
+# i.e. a store that could not be READ was indistinguishable from a store that
+# was EMPTY. That is this file's own header — "an EMPTY RESULT cannot
+# distinguish two mechanisms" — failing on the outermost walk of all.
+#
+# The rc is now returned to the caller, which records it in ASI_SCOPE_ENUM_RC.
+# Note this walk is `-maxdepth 1`, so MEASURED the only reachable failure is the
+# root itself and the list then comes back EMPTY (an unreadable *child* dir does
+# not error a depth-1 walk: rc=0, child still listed). The loop still runs over
+# whatever WAS enumerated rather than aborting on the rc — protect first, alarm
+# second, exactly as commit_once's header and the #372 probe fix require — so a
+# future partial list is committed rather than refused.
 list_scopes() {
+  local out="$1" rc=0
   find "$STORE" -mindepth 1 -maxdepth 1 -type d -not -name '.*' -printf '%f\0' \
-    | sort -z
+    > "$out" || rc=$?
+  sort -z "$out" -o "$out" || return $?
+  return "$rc"
 }
 
 # Symlinks sitting where a scope directory should be. `-type l` under the
@@ -296,9 +332,30 @@ list_scopes() {
 # the link becomes INSIDE the sandbox but not what it looks like on the host or
 # in the test suite, so a guard built on it would be unobservable in exactly the
 # environment that has to prove it works.
+#
+# Same file-not-pipe treatment as list_scopes, and for the same reason: a
+# symlinked scope is a NAMED FAILURE, so an enumeration that silently returned
+# nothing would convert that named failure back into the silence it replaced.
 list_scope_symlinks() {
+  local out="$1" rc=0
   find "$STORE" -mindepth 1 -maxdepth 1 -type l -not -name '.*' -printf '%f\0' \
-    | sort -z
+    > "$out" || rc=$?
+  sort -z "$out" -o "$out" || return $?
+  return "$rc"
+}
+
+# --- The store-level analogue of enum_verdict ----------------------------------
+# enum_verdict (below) covers an incomplete walk INSIDE one scope. This covers an
+# incomplete walk OF THE STORE, which is strictly worse: a scope that cannot be
+# listed is never even reached, so not one of the per-scope guards runs and the
+# only remaining signal is this one. Same shape as enum_verdict deliberately —
+# record during the walk, judge afterwards, never refuse up front.
+ASI_SCOPE_ENUM_RC=0
+ASI_SYMLINK_ENUM_RC=0
+store_enum_verdict() {
+  [ "$ASI_SCOPE_ENUM_RC" -eq 0 ] && [ "$ASI_SYMLINK_ENUM_RC" -eq 0 ] && return 0
+  echo "${PROG}: scope enumeration of ${STORE} was INCOMPLETE (find rc: directories=${ASI_SCOPE_ENUM_RC}, symlinks=${ASI_SYMLINK_ENUM_RC}). Every scope that COULD be listed has been processed, so nothing readable was skipped — but the store root itself could not be fully read, so an unknown number of scopes were never even looked at and may hold unversioned index files. A store that cannot be READ must never be reported as a store that is EMPTY. Check the permissions on ${STORE} itself." >&2
+  return 1
 }
 
 # Every *.md on disk in a scope (relative to it), plus everything already
@@ -381,6 +438,17 @@ scope_repo_state() {
 # a failure — a permanently-red gate is worse than no gate (RULES.md), but a
 # silently-unversioned service file is exactly the hazard this work exists to
 # close, so it must be visible.
+#
+# ⚠ THIS ONE DELIBERATELY STILL DISCARDS find's rc, AND THAT IS ARGUED, NOT
+# OVERLOOKED. It walks the IDENTICAL path at the IDENTICAL depth as list_scopes
+# (`find "$STORE" -mindepth 1 -maxdepth 1`), differing only in `-type f` vs
+# `-type d`, so its failure set is exactly list_scopes' failure set: it cannot
+# fail on a run where list_scopes succeeds. Any rc it could report is therefore
+# already reported, loudly and non-zero, by store_enum_verdict — a second alarm
+# for the same fact would be noise, and this path is warning-only with no
+# refuse/skip decision hanging off it. 🔴 That reasoning dies the moment the two
+# walks stop sharing a root or a depth: if you change either one, this needs its
+# own rc check.
 warn_about_store_root_files() {
   local strays
   strays="$(find "$STORE" -mindepth 1 -maxdepth 1 -type f -name '*.md' \
@@ -400,13 +468,19 @@ if [ "$PRINT_PLAN" -eq 1 ]; then
   echo "remote:  none — this script never adds one, never pushes, never fetches"
   echo "staging: explicit pathspecs only — never -A, never --all, never ."
   scopes_found=0
+  # Both walks' rcs are recorded here too. A plan that prints "(none found)" over
+  # a store it could not READ is the same silent zero as the real run's, and it
+  # is the more dangerous of the two: --print-plan is what an operator reaches
+  # for to ask "what is in there?".
+  list_scope_symlinks "$ASI_SYMFILE" || ASI_SYMLINK_ENUM_RC=$?
+  list_scopes "$ASI_SCOPEFILE" || ASI_SCOPE_ENUM_RC=$?
   # Symlinks first, matching the real walk. A plan that quietly omits an entry
   # which WILL fail the next real run describes a store that does not exist.
   while IFS= read -r -d '' name; do
     [ -n "$name" ] || continue
     scopes_found=1
     echo "scope:   ${name}  (SYMLINK — would FAIL; symlinked scopes are not supported)"
-  done < <(list_scope_symlinks)
+  done < "$ASI_SYMFILE"
   while IFS= read -r -d '' name; do
     [ -n "$name" ] || continue
     scopes_found=1
@@ -431,7 +505,14 @@ if [ "$PRINT_PLAN" -eq 1 ]; then
     else
       echo "    (could not enumerate this scope — it would FAIL, not be skipped)"
     fi
-  done < <(list_scopes)
+  done < "$ASI_SCOPEFILE"
+  # The "(none found)" line is only truthful once the walk is known to have
+  # SUCCEEDED. Order matters: the verdict is consulted before the empty-store
+  # sentence is allowed to be printed at all.
+  if ! store_enum_verdict; then
+    echo "scope:   (enumeration INCOMPLETE — the plan above is a PARTIAL view of ${STORE})"
+    exit 1
+  fi
   [ "$scopes_found" -eq 1 ] || echo "scope:   (none found under ${STORE})"
   exit 0
 fi
@@ -805,6 +886,13 @@ warn_about_store_root_files
 failed=()
 seen=0
 
+# 🔴 ENUMERATE BOTH WALKS FIRST, RECORDING EACH rc — THEN PROCESS, THEN JUDGE.
+# Not "enumerate, and bail if the rc is bad": that would recreate #372's refusal
+# one level up, throwing away every scope that WAS listed because one entry of
+# the store root could not be read. Protect first, then alarm.
+list_scope_symlinks "$ASI_SYMFILE" || ASI_SYMLINK_ENUM_RC=$?
+list_scopes "$ASI_SCOPEFILE" || ASI_SCOPE_ENUM_RC=$?
+
 # 🔴 A SYMLINK WHERE A SCOPE SHOULD BE IS A NAMED FAILURE — FIRST, AND ALWAYS.
 # It runs before the directory walk and counts towards `seen` on purpose: a
 # store holding ONLY a symlinked scope would otherwise fall through to the
@@ -822,7 +910,7 @@ while IFS= read -r -d '' name; do
   Fix it by moving the real directory into ${STORE}/${name} — do not re-add \`-L\`
   to the scope walk, which restores the silent version of this bug." >&2
   failed+=("$name")
-done < <(list_scope_symlinks)
+done < "$ASI_SYMFILE"
 
 while IFS= read -r -d '' name; do
   [ -n "$name" ] || continue
@@ -830,9 +918,18 @@ while IFS= read -r -d '' name; do
   if ! commit_scope "${STORE}/${name}" "$name"; then
     failed+=("$name")
   fi
-done < <(list_scopes)
+done < "$ASI_SCOPEFILE"
 
-if [ "$seen" -eq 0 ]; then
+# 🔴 THE CLEAN ZERO IS GATED ON THE WALK HAVING SUCCEEDED — THAT IS THE FIX.
+# "no scope directories — nothing to do", rc=0, was ALSO what an unreadable
+# store root produced (MEASURED 2026-08-10, store at mode 0300 over a real scope
+# holding svc.md): a reassuring zero from a check that could not see anything.
+# So the verdict is consulted BEFORE that sentence may be printed, and an
+# incomplete walk exits non-zero whether or not any scope was reachable.
+enum_incomplete=0
+store_enum_verdict || enum_incomplete=1
+
+if [ "$seen" -eq 0 ] && [ "$enum_incomplete" -eq 0 ]; then
   say "no scope directories under ${STORE} — nothing to do"
   exit 0
 fi
@@ -841,6 +938,13 @@ if [ "${#failed[@]}" -gt 0 ]; then
   die "${#failed[@]} of ${seen} scope(s) FAILED: ${failed[*]}
   The other scopes were still processed. Read the messages above — this unit
   fails rather than reporting a success it did not achieve."
+fi
+
+# The scopes that WERE reachable are done and their content is safe; the run
+# still fails, because "ok — N scope(s) processed" over a store whose scope list
+# is a partial view is a success this run did not achieve.
+if [ "$enum_incomplete" -ne 0 ]; then
+  exit 1
 fi
 
 say "ok — ${seen} scope(s) processed"

--- a/scripts/tests/test_analyze_service_index_commit.py
+++ b/scripts/tests/test_analyze_service_index_commit.py
@@ -1432,6 +1432,218 @@ def test_the_incomplete_enumeration_alarm_clears_when_the_scope_becomes_readable
         f"the previously-unreadable content was still not versioned: {tracked}")
 
 
+def _find_shim_that_fails_the_scope_walk(tmp_path, walk_type="d"):
+    """PATH shim whose `find` runs the REAL find, prints everything it found, and
+    THEN exits 1 — but only for the depth-1 `-type <walk_type>` walk (`d` = the
+    scope-directory walk, `l` = the symlinked-scope walk).
+
+    Parameterised on purpose: the two walks share a root, so a chmod fixture
+    fails BOTH and cannot tell their two recorded rcs apart — a mutation sweep
+    found that dropping the symlink walk's rc capture killed no test. Selecting
+    one walk is what makes each capture independently observable.
+
+    This is the exact shape GNU findutils 4.10.0 produces on the sibling probe
+    (`find … -print -quit` prints its match AND exits 1, because `-quit` does not
+    clear an error that has already occurred), reproduced deterministically at a
+    level where a real permission fixture cannot produce it: MEASURED, a
+    `-maxdepth 1` walk does NOT error on an unreadable CHILD directory, so the
+    only real-world failure of this walk is the root itself, which yields an
+    EMPTY list. The partial list is therefore unreachable with chmod alone — and
+    "process what was enumerated" is precisely the property that must not
+    silently rot into "refuse the whole run", which is #372's bug one level up.
+
+    🔴 Shebang belongs to testlib.mockbin (see _racing_git).
+    """
+    real = shutil.which("find")
+    assert real, "find is not on PATH — the shim would recurse into itself"
+    bindir = tmp_path / f"findbin-{walk_type}"
+    bindir.mkdir(exist_ok=True)
+    write_exec(bindir / "find", (
+        'prev=""\n'
+        'scopewalk=0\n'
+        'for a in "$@"; do\n'
+        f'  if [ "$prev" = "-type" ] && [ "$a" = "{walk_type}" ]; then scopewalk=1; fi\n'
+        '  prev="$a"\n'
+        'done\n'
+        f'{real} "$@"\n'
+        'rc=$?\n'
+        'if [ "$scopewalk" = "1" ]; then exit 1; fi\n'
+        'exit $rc\n'))
+    return f"{bindir}:{os.environ['PATH']}"
+
+
+def test_an_unreadable_store_root_is_not_reported_as_an_empty_store(tmp_path):
+    """🔴 THE SILENT ZERO AT THE OUTERMOST WALK. `list_scopes` was
+    `find … | sort -z`, read as `< <(list_scopes)` — a process substitution
+    discards the function's rc as completely as the pipe discards find's. So a
+    store root that could not be READ enumerated nothing, fell through to the
+    `seen -eq 0` branch, and printed
+
+        "no scope directories under <store> — nothing to do"   (rc=0)
+
+    over content that exists. MEASURED 2026-08-10 against pre-fix commit.sh
+    (GNU findutils 4.10.0 — the `find` a script gets from PATH; note the
+    interactive `find` on this host is aliased to bfs 4.1.1, which returns 0 on
+    the same fixture and would have talked you out of the bug): store at mode
+    0300 over a real `alpha/svc.md`, find rc=1, script rc=0.
+
+    That is the mirror of #372. There an enumeration failure REFUSED legitimate
+    work; here it was discarded entirely and read as "there is nothing to do".
+    Same primitive, opposite failure, both silent.
+
+    🔴 POSITIVE CONTROL IS PART OF THIS TEST, NOT A SEPARATE ONE. This is a bug
+    about a check that cannot see, so a test asserting a zero is worthless until
+    the same fixture has been watched to produce a NON-zero: the readable run
+    below must report 1 scope processed. 1 on the positive control, 0 under test.
+    """
+    store = tmp_path / "store"
+    scope = store / "alpha"
+    scope.mkdir(parents=True)
+    (scope / "svc.md").write_text("real content\n", encoding="utf-8")
+
+    # --- positive control: the fixture CAN produce a non-zero scope count ---
+    control = _run(store)
+    assert control.returncode == 0, f"{control.stdout}\n{control.stderr}"
+    assert "1 scope(s) processed" in control.stdout, (
+        f"the fixture never enumerated a scope even when readable — a zero "
+        f"below would then prove nothing:\n{control.stdout}")
+
+    try:
+        store.chmod(0o300)          # write+search, NOT readable → find rc=1
+        blind = _run(store)
+    finally:
+        store.chmod(0o700)
+
+    assert "nothing to do" not in blind.stdout, (
+        f"a store that could not be READ was reported as a store that is "
+        f"EMPTY:\n{blind.stdout}")
+    assert blind.returncode != 0, (
+        f"an unenumerable store root exited 0:\n{blind.stdout}\n{blind.stderr}")
+    assert "scope enumeration of" in blind.stderr and (
+        "was INCOMPLETE" in blind.stderr), (
+        f"a DIFFERENT guard produced the non-zero exit — this one is still "
+        f"unreached:\n{blind.stderr}")
+
+    healed = _run(store)
+    assert healed.returncode == 0, (
+        f"the alarm did not clear after chmod — a permanently-red gate is worse "
+        f"than no gate:\n{healed.stdout}\n{healed.stderr}")
+    assert "1 scope(s) processed" in healed.stdout
+
+
+def test_a_partial_scope_enumeration_still_commits_the_scopes_it_did_see(tmp_path):
+    """🔴 THE OVER-CORRECTION THIS FIX MUST NOT MAKE. Failing the run on a bad
+    enumeration rc is only half right: doing it BEFORE the walk would refuse
+    every scope that WAS listed because one entry could not be read — which is
+    exactly #372 ("the guard meant to stop a silent skip was causing the loss it
+    exists to catch"), relocated from the scope level to the store level.
+
+    Protect first, then alarm: with a `find` that emits the full list and then
+    exits 1, the scope must still be bootstrapped and committed, AND the run must
+    still fail with the store-level INCOMPLETE message.
+    """
+    store = tmp_path / "store"
+    scope = store / "alpha"
+    scope.mkdir(parents=True)
+    (scope / "svc.md").write_text("real content\n", encoding="utf-8")
+
+    p = _run(store, PATH=_find_shim_that_fails_the_scope_walk(tmp_path))
+
+    assert (scope / ".git").is_dir(), (
+        f"the enumeration rc refused the whole run, so a readable scope was "
+        f"left unversioned — this is #372 one level up:\n"
+        f"{p.stdout}\n{p.stderr}")
+    assert "svc.md" in _git(scope, "ls-files").stdout, (
+        f"the scope was reached but its content was never committed:\n"
+        f"{p.stdout}\n{p.stderr}")
+    assert p.returncode != 0, (
+        f"protecting the readable scope must NOT silence the alarm:\n{p.stdout}")
+    assert "scope enumeration of" in p.stderr and "was INCOMPLETE" in p.stderr, (
+        f"a DIFFERENT guard produced the non-zero exit — this one is still "
+        f"unreached:\n{p.stderr}")
+    assert "ok — 1 scope(s) processed" not in p.stdout, (
+        f"a partial view of the store was reported as a completed run:\n"
+        f"{p.stdout}")
+
+
+def test_the_find_shim_only_fails_the_scope_walk(tmp_path):
+    """Positive/negative control for the shim above. Without it the same fixture
+    exits 0, so the failure in that test is caused by the injected rc and not by
+    the shim breaking `find` for everything (which would make the assertions
+    pass for the wrong reason — the shim is an instrument, and an instrument's
+    verdict is a claim about the instrument until both controls are watched)."""
+    store = tmp_path / "store"
+    scope = store / "alpha"
+    scope.mkdir(parents=True)
+    (scope / "svc.md").write_text("real content\n", encoding="utf-8")
+
+    shimmed = _run(store, PATH=_find_shim_that_fails_the_scope_walk(tmp_path))
+    assert shimmed.returncode != 0, "the shim injected no failure at all"
+
+    fresh = tmp_path / "store2"
+    (fresh / "alpha").mkdir(parents=True)
+    (fresh / "alpha" / "svc.md").write_text("real content\n", encoding="utf-8")
+    plain = _run(fresh)
+    assert plain.returncode == 0 and "1 scope(s) processed" in plain.stdout, (
+        f"the unshimmed control did not pass, so the shimmed failure is not "
+        f"attributable to the shim:\n{plain.stdout}\n{plain.stderr}")
+
+
+def test_a_failed_SYMLINK_walk_alarms_on_its_own(tmp_path):
+    """The symlinked-scope walk records its own rc, and that capture is
+    independently observable rather than riding on the directory walk's.
+
+    Both walks share the store root, so every chmod fixture fails both and a
+    single recorded rc would look sufficient — MEASURED as a surviving mutant
+    ("drop the symlink walk's rc capture", killed no test) before this existed.
+    A symlinked scope is a NAMED FAILURE (see list_scope_symlinks); an
+    enumeration of them that silently returns nothing converts that named
+    failure straight back into the silence it was written to replace.
+    """
+    store = tmp_path / "store"
+    scope = store / "alpha"
+    scope.mkdir(parents=True)
+    (scope / "svc.md").write_text("real content\n", encoding="utf-8")
+
+    p = _run(store, PATH=_find_shim_that_fails_the_scope_walk(tmp_path, "l"))
+
+    assert "svc.md" in _git(scope, "ls-files").stdout, (
+        f"the readable scope was refused rather than protected:\n"
+        f"{p.stdout}\n{p.stderr}")
+    assert p.returncode != 0, (
+        f"a failed symlink walk was swallowed:\n{p.stdout}\n{p.stderr}")
+    assert "symlinks=1" in p.stderr, (
+        f"the symlink walk's rc was not the thing that alarmed — a DIFFERENT "
+        f"guard fired:\n{p.stderr}")
+
+
+def test_print_plan_does_not_describe_an_unreadable_store_as_empty(tmp_path):
+    """--print-plan is what an operator reaches for to ask "what is in there?",
+    so a plan that answers "(none found)" over a store it could not READ is the
+    same silent zero, on the more consulted surface."""
+    store = tmp_path / "store"
+    scope = store / "alpha"
+    scope.mkdir(parents=True)
+    (scope / "svc.md").write_text("real content\n", encoding="utf-8")
+
+    control = _run(store, "--print-plan")
+    assert control.returncode == 0 and "scope:   alpha" in control.stdout, (
+        f"the fixture cannot even list a readable scope:\n{control.stdout}")
+
+    try:
+        store.chmod(0o300)
+        p = _run(store, "--print-plan")
+    finally:
+        store.chmod(0o700)
+
+    assert "none found" not in p.stdout, (
+        f"the plan claimed the store is empty when it could not read it:\n"
+        f"{p.stdout}")
+    assert p.returncode != 0, f"the plan exited 0 over a partial view:\n{p.stdout}"
+    assert "was INCOMPLETE" in p.stderr, (
+        f"a DIFFERENT guard fired — this one is still unreached:\n{p.stderr}")
+
+
 def test_a_scope_name_containing_a_newline_is_one_scope_not_two(tmp_path):
     """🔴 M2. Newline-delimited enumeration split `we\\nird` into two
     nonexistent scopes, each reported "no *.md files — skipping", and the run


### PR DESCRIPTION
A **silent zero** in `scripts/analyze-service-index/commit.sh`, found but deliberately not fixed while closing the sibling bug in #372 (`233c57d`). Mirror image of that one: there an enumeration failure **refused** legitimate work; here the rc is **discarded entirely**, so an enumeration failure reads as "there is nothing to do". Same primitive, opposite failure, both silent.

## 1. Reproduction (pre-fix, captured)

`list_scopes` was `find … | sort -z`, read as `< <(list_scopes)`. A process substitution discards the function's rc as completely as the pipe discards find's.

```
$ mkdir -p store/alpha && echo x > store/alpha/svc.md
$ commit.sh store                       # readable — positive control
… scope alpha: committed 315374d — 1 change(s)
… ok — 1 scope(s) processed             rc=0

$ chmod 0300 store                      # write+search, NOT readable
$ commit.sh store
find: 'store': Permission denied        (×3, on stderr, from find itself)
analyze-service-index-commit: no scope directories under store — nothing to do
rc=0                                    ← ★ the defect
```

`svc.md`, its `.git`, and any number of unlooked-at scopes are sitting right there. Measured 2026-08-10, GNU findutils **4.10.0** — the `find` a script gets from PATH (`/nix/store/…-findutils-4.10.0/bin/find`). This host's *interactive* `find` is aliased to **bfs 4.1.1**, which returns **0** on the same fixture; an interactive spot-check would have talked me out of the bug. Every measurement below was taken by invoking the script under `bash`, i.e. against real GNU find.

Also measured, and it constrains the design: at `-maxdepth 1` the **only** reachable failure of this walk is the root itself, and the list then comes back **empty**. An unreadable *child* directory does **not** error a depth-1 walk (`rc=0`, child still listed) — verified directly. So the partial-list case is unreachable with chmod alone, which matters for how the guard is tested (§5).

## 2. Design rationale — why this alarm shape, not refusal

Argued from what the file already does, not from a new pattern:

* **File, not pipe/procsub.** The comment at the temp-file block already says *"Candidate enumeration goes to FILES, not pipes … find's exit code survives (a pipe discards it)"*. `list_candidates` was fixed exactly this way in #361. The two scope walks now write to `$ASI_SCOPEFILE` / `$ASI_SYMFILE` and **return** the rc; that comment is extended to name the process-substitution shape too, which is the third time this file has been bitten by rc laundering.
* **Record during the walk, judge afterwards.** `enum_verdict` already exists for an incomplete walk *inside* one scope. `store_enum_verdict` is its store-level analogue, same shape, same message register ("was INCOMPLETE"). An incomplete walk *of the store* is strictly worse: an unlisted scope is never reached, so not one per-scope guard runs and this is the only remaining signal.
* **Protect first, then alarm** (`commit_once`'s header, and #372's own fix). Making the rc fatal *before* the loop would recreate #372 one level up — legitimate work refused because one entry could not be read. So both walks run, everything listed is processed and committed, and only then does the run fail. Mutant `refuse-before-the-walk` is in the battery for exactly this, and is killed by the assertion "*the enumeration rc refused the whole run … this is #372 one level up*".
* **The clean zero is gated, not removed.** `"no scope directories — nothing to do"` is still the right answer for a genuinely empty store; it is now only reachable once the walk that found none is known to have **succeeded**. And it clears the moment a `chmod` lands — not a permanently-red gate.
* **`--print-plan` gets the same gate.** A plan that answers `(none found)` over a store it could not read is the same silent zero on the more consulted surface — `--print-plan` is what an operator reaches for to ask "what is in there?". It now prints `(enumeration INCOMPLETE — … PARTIAL view …)` and exits 1.
* **Exit-code header updated.** A comment is a claim; the documented contract now says "no scopes found" counts as 0 only once the walk that found none succeeded.

## 3. Red → green matrix

All five new tests measured against pre-fix `commit.sh` (restored from `origin/main`, script file copied aside and back — no `git stash`), then against HEAD. Red **for the right assertion**, not merely red:

| test | at `origin/main` (`e08dfdb`) | assertion that fired | at HEAD |
|---|---|---|---|
| `test_an_unreadable_store_root_is_not_reported_as_an_empty_store` | **RED** | `a store that could not be READ was reported as a store that is EMPTY` (`'nothing to do' not in …`) | PASS |
| `test_a_partial_scope_enumeration_still_commits_the_scopes_it_did_see` | **RED** | `protecting the readable scope must NOT silence the alarm` (`assert 0 != 0`) | PASS |
| `test_the_find_shim_only_fails_the_scope_walk` | **RED** | `the shim injected no failure at all` (`assert 0 != 0`) | PASS |
| `test_a_failed_SYMLINK_walk_alarms_on_its_own` | **RED** | `a failed symlink walk was swallowed` (`assert p.returncode != 0`) | PASS |
| `test_print_plan_does_not_describe_an_unreadable_store_as_empty` | **RED** | `the plan claimed the store is empty when it could not read it` (`'none found' not in …`) | PASS |

## 4. Positive control

This is a bug about a check that cannot see, so a test asserting a zero is worthless until the same fixture has been watched to produce a non-zero. The control is **inside** each test, not a separate one:

* `test_an_unreadable_store_root_…` runs the fixture **readable first** and asserts `1 scope(s) processed`, then chmods and asserts the blind run. Pair: **1 on the positive control, 0 under test.**
* `test_print_plan_…` asserts `scope:   alpha` appears in the readable plan before asserting `none found` is absent from the blind one.
* `test_the_find_shim_only_fails_the_scope_walk` is the shim's own two-sided control — shimmed run must fail, unshimmed run on an identical fresh fixture must exit 0 with `1 scope(s) processed`, so the failure is attributable to the injected rc rather than to a shim that broke `find` for everything.

## 5. Mutant battery — 11 mutants, weighted away from deletion

Applied to the fixed script, suite re-run each time (`-k` covering the new tests plus the empty-store / absent-store / newline / symlink neighbours):

| mutant | result | killed by |
|---|---|---|
| invert `store_enum_verdict`'s rc test (`-eq` → `-ne`) | KILLED | `…not_reported_as_an_empty_store` |
| swap `&&` → `\|\|` between the two rc checks | KILLED | `…partial_scope_enumeration…` |
| comment the verdict body out, text preserved (`return 0 # [ … ]`) | KILLED | `…not_reported_as_an_empty_store` |
| off-by-one on the rc (`-eq 0` → `-le 1`) | KILLED | `…not_reported_as_an_empty_store` |
| stale value: drop the scope-walk rc capture | KILLED | `…partial_scope_enumeration…` |
| stale value: drop the **symlink**-walk rc capture | KILLED | `test_a_failed_SYMLINK_walk_alarms_on_its_own` |
| `list_scopes` swallows find's rc again (`\|\| rc=0`) | KILLED | `…partial_scope_enumeration…` |
| un-gate the clean zero (drop `&& [ "$enum_incomplete" -eq 0 ]`) | KILLED | `…not_reported_as_an_empty_store` |
| drop the final non-zero exit | KILLED | `…not_reported_as_an_empty_store` |
| **over-correction:** `die` on the enumeration rc before the walk (#372 one level up) | KILLED | `…partial_scope_enumeration…` |
| un-gate `--print-plan` | KILLED | `test_print_plan_does_not_describe…` |

**Survivors: none — but only after a round.** The first sweep left **`drop-symlink-rc-capture` surviving**: both walks share the store root, so every chmod fixture fails both, and the directory walk's rc alone was enough to make every assertion pass. Named rather than hidden, then killed by parameterising the `find` shim on walk type (`-type d` vs `-type l`) so each capture is independently observable, and adding `test_a_failed_SYMLINK_walk_alarms_on_its_own` (asserts `symlinks=1` specifically, not just a non-zero exit).

The `find` shim deserves a note: it runs the **real** find, prints everything, and *then* exits 1 — the same "printed output alongside a non-zero rc" shape GNU find produces on the sibling probe (`-print -quit` prints its match and exits 1). That is the only way to construct the partial list at this level, since §1 measured that chmod cannot produce one at `-maxdepth 1`. It is what makes "process what was enumerated" a *tested* property rather than a hopeful comment.

## 6. Sibling instances of the same discard-the-rc shape

Swept every `find` call site and every rc-laundering shape (`< <(…)`, `$(… | …)`) in the file:

| site | verdict |
|---|---|
| `list_scopes` (L320) | **FIXED** here |
| `list_scope_symlinks` (L338) | **FIXED** here |
| `list_candidates` (L384) | already rc-checked (#361) |
| `md_probe` in `commit_scope` (L734) | already handled (#372) |
| `warn_about_store_root_files` (L451) | **left, with the argument written into the file.** Walks the identical path at the identical depth as `list_scopes` (`find "$STORE" -mindepth 1 -maxdepth 1`), differing only in `-type f` vs `-type d`, so its failure set *is* `list_scopes`' failure set — it cannot fail on a run where `list_scopes` succeeds, and any rc it could report is already reported loudly and non-zero by `store_enum_verdict`. It is warning-only with no refuse/skip decision hanging off it, so a second alarm for the same fact is noise. The comment states that the reasoning dies if the two walks ever stop sharing a root or a depth. |
| `done < <(git status --porcelain -z)` in `commit_once` (L676) | **left, assessed.** Its rc is discarded, but a failing re-read cannot end in a silent success: an empty `uncovered_arr` returns 2, and `commit_scope` immediately re-runs `git status` through `capture` **with the rc checked**, failing there. Not silent, so not touched — flagged here so the next reader does not have to re-derive it. |
| `n_changed="$(printf … \| grep -c .)"` (L615) | a count embedded in a commit message; no decision hangs off it. |

## 7. Both tiers

Read as content and counts, not exit codes.

| | baseline (`origin/main` `e08dfdb`) | this branch |
|---|---|---|
| local `scripts/tests` | **1645 passed**, 0 failed, 0 skipped | **1650 passed**, 0 failed, **0 skipped** (+5 = the new tests) |
| nix `checks.x86_64-linux.pytests` | `RESULT: PASS`, `failed=0`, one pinned skip | `PASS scripts/tests (collected=1650 passed=1650 skipped=0)`; `TOTAL collected=6743 passed=6742 skipped=1 failed=0`; `RESULT: PASS` |

`skipped=0` for `scripts/tests` **in the nix tier** is the load-bearing number: it confirms the new tests actually execute in the sandbox (the `testlib.mockbin` shebang trap that has bitten runtime-written stubs here before).

Baseline note: the brief quoted 1615 for the local tier; I measured **1645** on the base clone at `e08dfdb` myself. The delta is +5 either way — I am reporting my own measurement rather than the remembered one.

## 8. Behavioural proof, running the script directly (not only via pytest)

```
A readable root, first run   → committed, "ok — 1 scope(s) processed"     rc=0
B chmod 0300 (unreadable)    → "scope enumeration of <store> was INCOMPLETE
                                (find rc: directories=1, symlinks=1) …"   rc=1
C --print-plan, unreadable   → same alarm + "(enumeration INCOMPLETE — the
                                plan above is a PARTIAL view …)"          rc=1
D chmod 0700 again           → "clean — nothing to commit", "ok — 1 …"    rc=0
E --print-plan, readable     → "scope:   alpha  (repo)" / "svc.md"        rc=0
F genuinely empty store      → "no scope directories … nothing to do"     rc=0
```

D and F are the two that matter alongside the alarm: the gate clears on `chmod`, and a genuinely empty store is still a clean 0.

## 9. What I could NOT verify

* **A real partial enumeration of the store root.** Measured that GNU find cannot produce one at `-maxdepth 1` via permissions (only the root can fail, and the list then comes back empty). The protect-first property is therefore proven against an **injected** rc via the PATH shim, not against a naturally-occurring partial list. If the walk ever gains depth or `-L`, that becomes a real case and the shim test is what will still be pinning it.
* **Under the unit's systemd sandbox.** Every measurement here is uncontained. The file's own header warns that its containment claims are only as true as the last `systemd-run --user` measurement; nothing in this change touches the sandbox, the bind lists, or the git-subcommand ledger (all their tests still pass), but I did not re-run a contained probe.
* **The live store.** No host was touched — no `home-manager switch`, no `ship.sh`, no unit started, nothing on the workbench. The real timer will pick this up only when it is merged and shipped.
* **`sort -z "$out" -o "$out"`** (in-place sort) is documented-safe in GNU coreutils and passes the whole suite including the newline-in-scope-name test, but I did not construct an adversarial large-input case for it.

## Residual risk

The behaviour change worth a reviewer's eye is that an unreadable store root now **fails the unit** (desktop toast via `OnFailure=`) where it previously exited 0. That is the intent — an unversioned store must be visible — and it clears on `chmod`, so it is not a gate nobody can clear. The `--print-plan` rc change (0 → 1 on an unenumerable store) is the other contract change; a readable store still exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
