### PR TITLE
fix(rig-control): guard against running from wrong path (rescued from an un-pushed workbench main)

### DIFF
--- a/scripts/monitor-blackout.sh
+++ b/scripts/monitor-blackout.sh
@@ -17,6 +17,16 @@
 #   monitor-blackout.sh get-brightness  # print current VCP 0x10 value (for scripts)
 set -euo pipefail
 
+# Guard: only the canonical copy may create timers / modify brightness.
+# Copies in /tmp (Claude scratchpads, worktrees, mutation tests) must not
+# interfere with the live rig-control flow.
+REAL_SCRIPT="$(readlink -f "$0")"
+CANONICAL="${HOME}/workspace/devrc/scripts/monitor-blackout.sh"
+if [ "$REAL_SCRIPT" != "$CANONICAL" ]; then
+  echo "refusing to run from $REAL_SCRIPT (canonical: $CANONICAL)" >&2
+  exit 1
+fi
+
 DDC=$(command -v ddcutil) || { echo "ddcutil not found on PATH" >&2; exit 1; }
 UNIT=monitor-blackout-restore-v2
 UNIT_LEGACY=monitor-blackout-restore


### PR DESCRIPTION
Rescues one commit that existed **only** on the workbench's local `main` and on no remote ref.

## Why this PR exists

`b2281ca fix(rig-control): guard against running from wrong path` was committed directly to `main` in the workbench checkout and never pushed. Per `CLAUDE.md` → *Git discipline*, `scripts/ship.sh` converges with `merge --ff-only`, so a diverged host is **skipped and left as found** — it silently stops receiving every future change while still looking healthy.

Concretely, this one blocked the deploy of the `/analyze-service` index autocommit timer (#361) to the workbench — the only host that holds that index. The commit was preserved on `rescue/rig-control-wrong-path-guard` and confirmed on origin before `git reset --keep origin/main` moved the pointer; nothing was discarded.

## What's here

- `b2281ca` fix(rig-control): guard against running from wrong path — `scripts/monitor-blackout.sh`, +10 lines

## Review note

This commit has **never been gated against the tree it now lands in** — it bypassed PR review and CI by being committed straight to `main`. That is why this is a PR rather than a push.

## This is the third occurrence

Three rescue branches now exist for the same pattern (`rescue/rig-control-brightness` → landed as #366, `rescue/uncommitted-doc-changes-v2`, and this one). Rig-control work has blocked the two-host deploy twice.

Worth noting that the detection already exists and has just gone live: `scripts/drift-check.sh` (#367, deployed to both hosts as of today) reports `🔴 DRIFT — local main has DIVERGED: N un-pushed commit(s)`. It was merged but not yet deployed when this commit was made, so it could not have caught it. If a fourth occurrence happens now that the deadman is live, that is the signal that detection is not enough and the guard should become preventive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
