### PR TITLE
docs: record why the generalized subsystem store was rejected, and what replaced it

### DIFF
--- a/claudedocs/decision-subsystem-store-rejected-2026-08-11.md
+++ b/claudedocs/decision-subsystem-store-rejected-2026-08-11.md
@@ -1,0 +1,140 @@
+# Decision record — the generalized "subsystem" store was proposed and REJECTED
+
+**Status:** rejected on evidence, 2026-08-11. Supersedes an unlanded proposal draft.
+**What shipped instead:** PR #361 (version the recon index + autocommit) and PR #362
+(four schema repairs to `/analyze-service`).
+
+Read this before proposing a subsystem/knowledge store again. The idea is reasonable
+and was investigated properly; it lost on measurement, not on taste.
+
+---
+
+## What was proposed
+
+Generalize the `/analyze-service` index — a per-service markdown *document + journal*
+sheet at `~/.claude/analyze-service-index/<scope>/<service>.md` — into a "subsystem" store
+covering any durable thing (code, data, infra, process, organization, vendor, personal),
+with a deterministic CRUD (`subsys new/ls/show/journal/link/graph/search/…`), a thin skill,
+a `type:` field driving per-class sections and recon recipes, a `depends_on` dependency
+graph, and `/handoff` records migrated into per-subsystem journals.
+
+## Why it was rejected
+
+Four independent evaluations (architecture, verification, adversarial-skeptic, and a
+hand-authored strain test) converged. The corpus numbers are the core of it — measured
+after the index had been in real use for eight weeks:
+
+| Measurement | Value |
+|---|---|
+| Index entries | 20 |
+| Entries of a non-infra `type:` | **0** |
+| Distinct scopes in use | **1** |
+| `depends_on` edges populated | **0** |
+
+So `type:` — the field the proposal called "the mechanism that makes generality real" —
+would have had exactly one value, and `graph` — called "the payoff grep cannot produce" —
+would have had no edges.
+
+**The strain test settled it.** Rather than design for hypothetical classes, one `process`
+and one `org` entry were hand-authored in the *current* schema. Results:
+
+- `type:` **selected nothing.** Both non-infra entries used the same three sections the 20
+  infra entries use. The type-selected extras were infra sections: empty for `org`, and for
+  `process` "Operate" would swallow the entry rather than structure it. Recon recipes turned
+  out to be per-*subsystem*, not per-*class* — which `## Pointers` already covers.
+- `depends_on` drew **zero honest edges.** The candidate edges meant runtime-requires,
+  hosted-in, contains, and consumes-output-of. One `contains` edge from an org node returns
+  that org's entire subsystem list for any blast-radius query.
+- **Addressing collided at n=1.** One slug was the natural address for both a code subsystem
+  and a ritual about it; aliasing around it *shadowed* the future entry, because the resolver
+  matched aliases before declaring a miss.
+- **The sharpest result:** the `org` entry's three most valuable sections came out empty for
+  want of **evidence**, not structure. Nothing in the workspace sourced those facts.
+  Designing a schema for them was premature by exactly one step.
+
+**Adoption was the second problem.** Counted across all transcripts: six of seventeen
+slash-commands have never been invoked once — including one built specifically to detect
+that failure mode, and a deterministic gate, which is the class `subsys` would have joined.
+`/analyze-service` itself *did* stick. The refined lesson is not "opt-in fails" but
+**opt-in survives when it rides an existing ritual and dies when it *is* the ritual.**
+A 13-verb CRUD is the second kind.
+
+**The `/handoff` migration was the most expensive part and the least justified.**
+`session-analysis/initiative-scan.py` consumes `claudedocs/handoff-*.md` at seven sites,
+two of which are path-containment security guards that fail *silently* when handed a path
+outside the repo. The filename-derived base slug is also the stability guarantee behind
+`(repo, slug)` primary keys in the initiatives store, so moving handoffs would have caused
+initiative identity churn — orphaned archive rows and orphaned paid LLM recaps.
+
+## What shipped instead
+
+- **PR #361** — the one real defect the proposal identified: the index was unversioned,
+  unsynced and unbacked-up. It is now a **per-scope git repo** with an hourly `systemd --user`
+  autocommit, no remote, under `ProtectSystem=strict` / `ProtectHome=tmpfs` / `PrivateTmp` /
+  `PrivateNetwork` / `NoNewPrivileges` / `InaccessiblePaths=/dev/shm /dev/mqueue`.
+- **PR #362** — four schema repairs that came from the strain test, not the proposal:
+  optional kind-qualified filenames plus an ambiguity-errors-never-shadows resolver rule;
+  a `sensitivity:` field with a fail-safe default; `repo:` → `scope:` with non-repo scopes
+  permitted and `namespace:` optional; and a **liveness convention** — persist the
+  *derivation method* and what a stale answer looks like, never the current reading.
+
+## Errors in the original draft — do not re-derive them
+
+Recorded because each was believed, argued from, and then measured false:
+
+1. Handoff *authored dates* do **not** feed initiative momentum. `doc_touch_epoch` has zero
+   call sites; the scanner states explicitly that doc freshness must never set `last_touch`.
+2. There are **two** doc loaders, not one — the second globs all `claudedocs/*.md`.
+3. Killing handoff writes would not have made cards `undocumented`; doc-less handoff clusters
+   are dropped entirely and never become cards. The real risk was slug stability (above).
+4. "854 handoffs" conflated all tracked `claudedocs/` files with handoffs. Actual: **207**.
+
+## The falsifiable gate for revisiting
+
+Reopen the design when the index holds **≥5 entries outside its current single scope** or
+**≥5 entries of a non-infra type**. Both counters read zero, and have for the life of the
+store. At that point there is a corpus to design against instead of a hypothesis.
+
+## What replaced the premise: derived session association
+
+The proposal assumed a store you *type into*. The replacement is a store that is *populated
+from telemetry you already collect* — which answers the adoption objection structurally and
+supplies the evidence the `org` strain test found missing.
+
+Decisions taken:
+
+- **Association is derived, not tagged.** Map session → subsystem from what the collector
+  already emits (`kind=session-summary` carries git commits/pushes) by matching path
+  components against the entry's slug and `aliases:`. This deliberately does **not** persist
+  a location, preserving the index's rule that location is always re-derived live.
+- **The edge lives in ClickHouse**, as a new `kind=session-subsystem` event — one row per
+  `(session, subsystem)`. Do **not** extend `session-summary`: consumers dedupe it with
+  `argMax(<field>, ingested_at) GROUP BY session`, and a session touches N subsystems.
+- **The markdown store holds nothing new.** A subsystem's session history is a query. No
+  cache to go stale, and no increase in the exfiltration surface — transcripts are ~3.6 GB.
+- **Orthogonal to initiatives.** A session gets an initiative (thread of work) *and*
+  subsystems (durable things touched). Governing distinction: **a subsystem is a durable
+  thing that exists; an initiative is a thread of work on it.**
+
+🔴 **The resolver must share its normalization with the command** (the `_`→`-` fold added in
+PR #362). Two implementations of one predicate regenerate the same bug at both sites, and
+here the failure is silent — associations simply do not match, and a zero reads as
+"this subsystem had no sessions."
+
+Phasing: **P0** the resolver as a pure, source-agnostic function with tests → **P1** emit the
+edge from the existing 5-min `claude-activity-source` timer → **P2** surface it in the recon
+brief. Layer B (`kind=session-insight`) inherits the dimension when it is built.
+
+**Open, and a correctness prerequisite rather than a nicety:** the edge is Claude-Code-first
+because opencode's session path is a separate tailer over a SQLite store. If a material share
+of work happens in opencode, Claude-only association **systematically under-counts**, and a
+subsystem worked on mostly via opencode looks *dormant* — which would poison the liveness
+convention above. **Measure the opencode session share before wiring anything to liveness.**
+
+## Pointers
+
+- `claude/commands/analyze-service.md` — the schema and write-back protocol, as repaired.
+- `~/.claude/analyze-service-index/<scope>/README.md` — store safety rules (no remote, no
+  stash/reset/clean), authoritative for the store itself.
+- `scripts/analyze-service-index/commit.sh` + the `analyze-service-index-commit` units.
+- `scripts/session-analysis/initiative-scan.py` — the handoff consumers described above.


### PR DESCRIPTION
Replaces an unlanded 13 KB proposal draft with a ~8.5 KB decision record.

## Why this exists

A proposal to generalize the `/analyze-service` index into a general "subsystem" store — deterministic CRUD, `type:`-driven sections, a `depends_on` graph, and `/handoff` records migrated into per-subsystem journals — was investigated by four independent evaluations and **rejected on measurement**.

The draft was never committed. Leaving it uncommitted made it stranded work; committing it as-written would have preserved a design we rejected plus four claims that were measured false. So it is replaced by a record of the decision and the evidence behind it.

## What the evidence was

After eight weeks of real use the index held **20 entries, 0 of a non-infra type, in 1 scope, with 0 `depends_on` edges** — so `type:` (called "the mechanism that makes generality real") would have had one value, and `graph` (called "the payoff grep cannot produce") would have had no edges.

The deciding test was hand-authoring one `process` and one `org` entry in the *current* schema rather than designing for hypothetical classes. `type:` selected nothing, no honest dependency edge existed, addressing collided at n=1, and — the sharpest result — the `org` entry's three most valuable sections came out empty **for want of evidence, not structure**.

## What it records

- The measurements that killed it, so they are not re-litigated.
- **Four claims from the draft that were measured false**, so they are not argued from again — including that handoff authored-dates feed initiative momentum (the function has zero call sites) and that there is one doc loader (there are two).
- A **falsifiable gate** for revisiting: ≥5 entries outside the current single scope, or ≥5 non-infra entries. Both read zero today.
- The design that replaced the premise: **derived session association**, populated from telemetry already collected rather than typed into a CLI — which answers the adoption objection structurally and supplies the evidence the `org` strain test found missing.

## Verification

Both leak gates pass with the file tracked.

Worth noting how that was confirmed, because the first attempt was a false green: `test_no_public_ips.py` reported 33 passed **with a realistic public IP injected** — because these scanners iterate `git ls-files`, so an unstaged file is invisible to them. After `git add`, the same probe correctly failed naming the file and line. The clean run above is from the tracked state, and the probe was restored byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
