### PR TITLE
fix(dunst): let unit-failure toasts defeat do-not-disturb

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -276,6 +276,53 @@ in
       fullscreen_suppress = {
         fullscreen = "suppress";
       };
+      # DEADMAN BYPASS — the ONE class of toast that must defeat do-not-disturb.
+      #
+      # WHY: `notify-failure` toasts are the only signal that an important user
+      # unit died. Measured 2026-08-10 on the workbench: dunst `is-paused=true`
+      # with 30 notifications queued behind it, and `drift-check.service` sitting
+      # in `failed` (status 10, genuine drift) — the OnFailure handler ran, sent
+      # its toast, and the toast went into the WAITING queue and was never shown.
+      # It is not even in `dunstctl history` (history only holds toasts that were
+      # DISPLAYED then dismissed/expired), so the failure was invisible in every
+      # surface a human looks at. DND is a state Zach deliberately enters via the
+      # bar's bell button, so "just unpause it" is not a fix.
+      #
+      # TWO INDEPENDENT SUPPRESSORS had to be defeated — measured, not assumed:
+      #
+      #  1. PAUSE LEVEL. `dunstctl set-paused true` (what the bar button runs)
+      #     sets pause level **100**, the maximum. dunst(5) says a notification
+      #     shows when its override_pause_level is "greater than" the pause
+      #     level, which would make 100 unbeatable. THAT IS WRONG — the
+      #     implementation compares >=. Measured on dunst 1.13.2 at pause
+      #     level 100: override_pause_level=100 -> displayed 0->1, waiting 0->0;
+      #     override_pause_level=99 -> displayed 0->0, waiting 0->1. So 100 is
+      #     both necessary and sufficient; anything less is silently swallowed.
+      #
+      #  2. FULLSCREEN SUPPRESSION. `fullscreen_suppress` above is FILTERLESS, so
+      #     it also matches this toast and routes it straight to history whenever
+      #     any fullscreen window is focused — a second, independent way for a
+      #     deadman alert to vanish (observed dropping real toasts on the laptop).
+      #     `fullscreen = "show"` opts this one rule back out.
+      #
+      # ORDERING MATTERS: home-manager renders these sections alphabetically and
+      # dunst applies rules in file order, last-write-wins. The `zz_` prefix
+      # guarantees this rule is applied AFTER `fullscreen_suppress` regardless of
+      # what rules are added later. scripts/tests/test_dunst_dnd_bypass.py pins
+      # both the values and that ordering.
+      #
+      # SCOPE: keyed on appname, which scripts/notify-failure.sh sets via
+      # `notify-send -a notify-failure`. That is ALL unit-failure toasts, not an
+      # opt-in subset — justified by the measured firing rate (7 activations in
+      # ~6 months of laptop journal, 1 in 9 days of workbench journal), which is
+      # far too low to make DND feel broken. Deliberately NOT keyed on
+      # `urgency = critical`: other tools send critical toasts, and those must
+      # still respect DND.
+      zz_notify_failure_bypass = {
+        appname = "notify-failure";
+        override_pause_level = 100;
+        fullscreen = "show";
+      };
     };
   };
 

--- a/scripts/tests/test_dunst_dnd_bypass.py
+++ b/scripts/tests/test_dunst_dnd_bypass.py
@@ -1,0 +1,139 @@
+"""Tests for the dunst DND-bypass rule that lets unit-failure toasts through.
+
+THE DEFECT THIS PINS (measured 2026-08-10 on the workbench): dunst was paused
+(`is-paused=true`, pause level 100) with 30 notifications queued behind it, and
+`drift-check.service` was sitting in `failed`. The OnFailure handler ran and sent
+its toast — and the toast went into the WAITING queue, was never displayed, and
+never even reached `dunstctl history` (history only records toasts that were
+DISPLAYED then dismissed/expired). The alert existed and no human could see it.
+
+TWO independent suppressors have to be defeated, so there are two value asserts:
+
+  * `override_pause_level = 100` — the bar's DND button runs
+    `dunstctl set-paused true`, which sets pause level 100 (the maximum).
+    dunst(5) documents the comparison as "greater than", which would make 100
+    unbeatable; the implementation actually compares >=. Measured on dunst
+    1.13.2 at pause level 100: override 100 -> displayed 0->1; override 99 ->
+    displayed 0->0, waiting 0->1. 100 is necessary AND sufficient.
+
+  * `fullscreen = "show"` — the filterless `fullscreen_suppress` rule also
+    matches this toast and would route it straight to history whenever a
+    fullscreen window is focused.
+
+Plus an ORDERING assert and a SEAM assert (see the individual docstrings). These
+are structural, not spelled: they assert the parsed key/value pairs of the named
+rule, so an unrelated occurrence of the word "show" or "100" elsewhere in the
+file cannot satisfy them.
+"""
+import os
+import re
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_HOME_NIX = os.path.join(_HERE, "..", "..", "nix", "home.nix")
+_HANDLER = os.path.join(_HERE, "..", "notify-failure.sh")
+_BYPASS_RULE = "zz_notify_failure_bypass"
+_SUPPRESS_RULE = "fullscreen_suppress"
+
+
+def _read(path):
+    with open(path) as fh:
+        return fh.read()
+
+
+def _dunst_rule(name):
+    """Return {key: value} for the dunst rule `name` in services.dunst.settings.
+
+    Parses the `<name> = { ... };` attrset body and strips nix comments, so a
+    value that only appears in a comment cannot satisfy an assertion.
+    """
+    src = _read(_HOME_NIX)
+    m = re.search(
+        r"^\s*" + re.escape(name) + r"\s*=\s*\{(.*?)^\s*\};",
+        src, re.DOTALL | re.MULTILINE)
+    assert m, "dunst rule %r not found in nix/home.nix" % name
+    body = re.sub(r"#.*$", "", m.group(1), flags=re.MULTILINE)
+    out = {}
+    for key, val in re.findall(r"(\w+)\s*=\s*([^;]+);", body):
+        out[key] = val.strip().strip('"')
+    return out
+
+
+def _rules_setting(key):
+    """Names of every dunst rule in nix/home.nix whose body sets `key`.
+
+    Derived from the file, so this tracks rules added later rather than a list
+    baked into the test.
+    """
+    src = _read(_HOME_NIX)
+    m = re.search(r"services\.dunst\s*=\s*\{(.*?)^  \};", src, re.DOTALL | re.MULTILINE)
+    assert m, "services.dunst block not found in nix/home.nix"
+    block = re.sub(r"#.*$", "", m.group(1), flags=re.MULTILINE)
+    names = set()
+    for name, body in re.findall(r"^      (\w+)\s*=\s*\{(.*?)^      \};",
+                                 block, re.DOTALL | re.MULTILINE):
+        if re.search(r"^\s*" + re.escape(key) + r"\s*=", body, re.MULTILINE):
+            names.add(name)
+    return names
+
+
+def test_bypass_rule_beats_max_pause_level():
+    """override_pause_level must be exactly 100 — the level `set-paused true` sets.
+
+    Not >=99, not "some positive number": 99 was measured to QUEUE at level 100.
+    """
+    rule = _dunst_rule(_BYPASS_RULE)
+    assert rule.get("override_pause_level") == "100", (
+        "override_pause_level must be 100; `dunstctl set-paused true` sets pause "
+        "level 100 and dunst compares >=, so anything lower is silently queued. "
+        "got: %r" % rule.get("override_pause_level"))
+
+
+def test_bypass_rule_opts_out_of_fullscreen_suppression():
+    """The filterless fullscreen_suppress rule must not swallow this toast."""
+    rule = _dunst_rule(_BYPASS_RULE)
+    assert rule.get("fullscreen") == "show", (
+        "fullscreen must be \"show\"; the filterless %s rule otherwise routes "
+        "this toast straight to history whenever a fullscreen window is focused. "
+        "got: %r" % (_SUPPRESS_RULE, rule.get("fullscreen")))
+
+
+def test_bypass_rule_is_applied_after_fullscreen_suppress():
+    """Ordering guard: home-manager renders sections alphabetically; dunst applies
+    rules in file order with last-write-wins. If this rule ever sorted BEFORE
+    `fullscreen_suppress`, that rule's `fullscreen = "suppress"` would overwrite
+    our `fullscreen = "show"` and the toast would vanish under fullscreen again —
+    with every value assertion above still green. Pins the RELATIONSHIP, not the
+    name.
+    """
+    competing = _rules_setting("fullscreen") - {_BYPASS_RULE}
+    assert competing, (
+        "expected at least one other rule to set `fullscreen` (%r); if that rule "
+        "was removed this guard is no longer measuring anything" % _SUPPRESS_RULE)
+    assert _BYPASS_RULE in _rules_setting("fullscreen"), (
+        "%r must itself set `fullscreen` for this ordering guard to apply" % _BYPASS_RULE)
+    later = sorted(competing)[-1]
+    assert _BYPASS_RULE > later, (
+        "%r must sort AFTER every other dunst rule that sets `fullscreen` (last "
+        "one wins); %r sorts later and would overwrite it. home-manager emits "
+        "dunstrc sections in alphabetical order." % (_BYPASS_RULE, later))
+
+
+def test_appname_seam_between_handler_and_rule():
+    """SEAM: the rule matches on appname; the handler SETS that appname.
+
+    Each side is independently correct and independently tested, and renaming
+    either one silently disables the bypass with no test failing — the toast
+    would still be sent, still be critical, and still never be shown. This is the
+    only assertion that fails when the two disagree, so it pins the relationship
+    rather than either component.
+    """
+    rule = _dunst_rule(_BYPASS_RULE)
+    appname = rule.get("appname")
+    assert appname, "bypass rule must key on an appname"
+
+    handler = _read(_HANDLER)
+    sent = re.findall(r"notify-send[^\n]*?-a\s+(\S+)", handler)
+    assert sent, "no `notify-send -a <appname>` found in notify-failure.sh"
+    assert all(a == appname for a in sent), (
+        "dunst bypass rule matches appname=%r but notify-failure.sh sends -a %r; "
+        "the DND bypass would silently never match" % (appname, sorted(set(sent))))


### PR DESCRIPTION
## The defect

A `drift-check.service` failure **could not reach a human**, even though every internal link worked.

Measured on the workbench 2026-08-10:

```
drift-check.service   ActiveState=failed  Result=exit-code  ExecMainStatus=10   (genuine drift)
journal               "Triggering OnFailure= dependencies"
notify-failure@drift-check.service.service   Result=success  ExecMainStatus=0   (no "(no desktop session)")
dunstctl is-paused          -> true
dunstctl get-pause-level    -> 100
dunstctl count displayed    -> 0
dunstctl count waiting      -> 30
```

The toast was sent and went into the **waiting queue**. It is absent from `dunstctl history` because history only holds notifications that were *displayed then dismissed/expired*. So the alert was invisible in every surface a human looks at. DND is a state Zach deliberately enters via the bar's bell button, so "just unpause it" is not a fix.

## What dunst 1.13.2 actually supports (verified, not assumed)

Source: the **installed** man pages for the running build — `/nix/store/zs1qqpsw9b24c4qqng53ji50ry7isvvk-dunst-1.13.2-man/share/man/man{1,5}/dunst.{1,5}.gz` and `man dunstctl` — plus direct measurement against the running daemon.

- `dunst.5` **global** `default_pause_level` (0–100, default 0) and **rule** `override_pause_level` (0–100, default 0) both exist. ✅
- `dunstctl get-pause-level` / `set-pause-level` exist. ✅
- `dunstctl set-paused true` is documented as "with maximum pause level of 100" — **measured: it sets level 100.**

🔴 **The man page is wrong about the comparison, and it matters.** `dunst.5` says a notification appears when its `override_pause_level` is *"greater than"* the pause level. If true, level 100 would be unbeatable and this whole approach would be dead. **The implementation compares `>=`.** Measured at pause level 100 on the running 1.13.2:

| rule `override_pause_level` | dunst pause level | displayed | waiting | result |
|---|---|---|---|---|
| **100** | 100 | 0 → **1** | 0 → 0 | **displays** |
| 99 | 100 | 0 → 0 | 0 → **1** | queued |

So `100` is both **necessary and sufficient**. Anything lower is silently swallowed. I designed against the measurement, not the doc.

### A second, independent suppressor I did not expect

While testing I hit `Dropping notification` in the dunst journal — the existing **`fullscreen_suppress`** rule is **filterless**, so it matches the failure toast too and routes it *straight to history* whenever a fullscreen window is focused. That is a completely separate way for a deadman alert to vanish, and it was dropping real toasts on the laptop (observed at 17:14, 17:38, 20:20 on Aug 10 against an unrelated fullscreen Brave window). Fixing only the pause level would have left this hole open. The rule therefore also sets `fullscreen = "show"`.

## The change

One dunst rule in `nix/home.nix`. **`scripts/notify-failure.sh` is unchanged** — it already sends `-a notify-failure`, so this is a purely config-level, deterministic fix with no new script logic and no behaviour change for the other 16 units wired to `OnFailure=notify-failure@%n.service` beyond their toasts now being visible.

```nix
zz_notify_failure_bypass = {
  appname = "notify-failure";
  override_pause_level = 100;
  fullscreen = "show";
};
```

`zz_` prefix is load-bearing: home-manager emits dunstrc sections **alphabetically** and dunst applies rules **last-write-wins**, so this must sort after `fullscreen_suppress` or that rule's `suppress` overwrites our `show`. Verified against the actually-rendered artifact built from this branch:

```
$ nix build --impure '.#homeConfigurations."zach".config.xdg.configFile."dunst/dunstrc".source'
[fullscreen_suppress] ... [global] ... [urgency_*] ... [zz_notify_failure_bypass]   <- last
```
and the diff against the currently-deployed dunstrc is **only** the new 4-line rule, nothing else.

## Scoping decision: ALL `notify-failure` toasts, not an opt-in subset

**Decided from measured firing rate, not intuition.** The risk of the broad option is noise → the user disables the whole mechanism, which is strictly worse than the bug. So I measured how often this toast actually fires:

| host | notify-failure activations | journal span |
|---|---|---|
| laptop | **7** | 2026-02-12 → 2026-08-10 (~6 months; 6 of them in the last 18 days) |
| workbench | **1** | 2026-08-02 → 2026-08-10 (9 days) |

At worst ~1 every 3 days, and that is the *upper* end of a recent cluster. That is far below any rate that would make DND feel broken. An opt-in allowlist would buy nothing against that noise budget while adding a maintenance edge where a newly-wired critical unit is silently *not* covered — reintroducing exactly this bug's failure mode by default. So: broad, but bounded.

**Deliberately NOT keyed on `urgency = critical`.** Other tools send critical toasts; those must still respect DND. Keying on the appname that `notify-failure.sh` itself sets keeps the bypass to exactly the unit-failure class, and the seam test below pins that contract.

## Verification

### 1. Positive control — executed, with dunst paused

Pause level 100 (what the bar button sets), rule loaded:

```
override_pause_level=100 @level100:  displayed 0 -> 1 | waiting 0 -> 0
```

The number moved. A zero that stayed zero is the defect, so this is the assertion that matters.

### 2. Negative control — DND is still DND

Same paused window, an ordinary toast:

```
appname=some-other-app @level100:    displayed 0 -> 0 | waiting 0 -> 1
```

Queued, not shown. This is a bypass, not a disabled DND. Boundary also pinned: `override_pause_level=99` at level 100 queues (`displayed 0->0, waiting 0->1`).

### 3. End-to-end through the REAL failure path (not a synthetic notify-send)

`DRIFT_REPO` pointed at a diverged throwaway `/tmp` clone (local `main` 1 commit behind `origin/main`), dunst paused at level 100, PR's rendered dunstrc loaded:

```
ahead/behind (origin/main...main): 1  0
systemctl --user start drift-check.service     -> rc=1
  ActiveState=failed Result=exit-code ExecMainStatus=10
  journal: "drift-check: DRIFT (rc=10)"  /  "Triggering OnFailure= dependencies"
  notify-failure@drift-check.service.service   LoadState=loaded Result=success ExecMainStatus=0
  journal: "Finished Desktop toast when the user unit drift-check.service fails."

BEFORE: displayed=0 waiting=1
AFTER:  displayed=1 waiting=1
```

And — because "a notification was sent" is not the claim — a screenshot of the actual screen confirms the toast **rendered**: a red critical box reading *"⚠ drift-check.service failed / A user unit entered the failed state. / journalctl --user -u drift-check.service -e"*, with a `(1 more)` indicator for the negative-control toast that stayed suppressed.

(Trap noted from the task and respected: the instance is `notify-failure@drift-check.service.service` — `%n` already includes `.service`. Querying the shorter name reports a reassuring `Result=success ExecMainStatus=0` for a unit that does not exist.)

### 4. Tests — proven RED before green, then mutation-swept

`scripts/tests/test_dunst_dnd_bypass.py` (4 tests). Against pre-change `nix/home.nix` from `origin/main`: **3 failed, 1 passed**. The one that passed was a vacuous constant comparison, so I rewrote it to derive the competing rule set from the file. Post-change: **4 passed**.

Every guard mutation-tested — each mutation produced **exactly one** failure, with **that guard's own** message (not a neighbour's):

| mutation | tests failed | red guard |
|---|---|---|
| `override_pause_level` 100 → 99 | 1 | `test_bypass_rule_beats_max_pause_level` |
| bypass `fullscreen` `"show"` → `"suppress"` | 1 | `test_bypass_rule_opts_out_of_fullscreen_suppression` |
| competing rule renamed to sort *after* the bypass | 1 | `test_bypass_rule_is_applied_after_fullscreen_suppress` |
| handler `-a notify-failure` → `-a notify-fail` | 1 | `test_appname_seam_between_handler_and_rule` |

The last is the **seam** guard: the rule matches an appname that the *script* sets. Both sides are independently correct and independently tested, and renaming either silently disables the bypass — the toast would still be sent, still be critical, and still never be shown, with no other test failing.

### 5. Both gate tiers read as content, counted

| | collected | passed | skipped | failed |
|---|---|---|---|---|
| `pytests` on **`origin/main`** (control) | 6743 | 6739 | 1 (pinned) | **3** |
| `pytests` on **this branch** | **6747** | 6743 | 1 (pinned) | **3** |

`+4` collected is the positive control that the gate actually *sees* the new tests. `scripts/tests` goes `collected=1650 → 1654`, **`skipped=0`**.

⚠️ **I caught myself on this**: the first hermetic run reported 6743 because the new test file was untracked and the flake silently omitted it (the `git add` rule in `CLAUDE.md`). The count only moved after committing — worth knowing that an uncommitted new test reads as a clean pass.

The **3 failures are pre-existing on `main`** and unrelated — all `scripts/tests/test_monitor_blackout.py` (lines 148/161/255), reproduced identically on a pristine `origin/main` clone in both tiers. `nodetests` builds clean.

## Recommendation on the queued notifications (your call — I did not act)

The queue is now **30** (was 29 when you measured, so it is still growing).

1. **Do not bulk-flush them.** Unpausing releases all 30 at once into a `notification_limit = 4` stack; you would see four and lose the rest to history with no way to tell which mattered. If you want them, `dunstctl history-pop` repeatedly, or the notif-center rofi list, is the non-destructive way. I left all 30 untouched.
2. **A permanently-paused dunst with a growing queue is itself worth surfacing** — and I'd argue it is the more important of the two findings. DND on the workbench is not a short focus mode; it has been on long enough to accumulate 30. That means *every* non-bypassing alert you own is currently going nowhere, indefinitely, and nothing tells you that. The bar's bell block already reads `is-paused`; making it also show the waiting count (e.g. `󰂛 30`) would turn an invisible state into a visible one. I did **not** build this — it is a separate change and a UI decision that is yours.
3. Worth deciding whether DND on the workbench is intentional-permanent or just never got toggled back.

**I could not enumerate the 30 queued notifications** — dunst exposes no `dunstctl list-waiting`, and `history` does not contain them (they were never displayed). So I cannot tell you whether any *past* unit-failure toast is sitting in there. The single workbench `notify-failure` activation in the retained journal was 2026-08-04.

## State restored

All verification ran on the **laptop** (`192.168.50.155`); the workbench was **read-only probed only**.

- Workbench dunst: **untouched** — still `is-paused=true`, level 100, 30 waiting. Nothing flushed, dismissed, or lost.
- Laptop dunst: back to its baseline `displayed=0 waiting=0 level=0 is-paused=false`, deployed dunstrc reloaded, bypass rule no longer loaded (`grep -c` → 0).
- `systemctl --user unset-environment DRIFT_REPO` → confirmed absent.
- `drift-check.service` `reset-failed` → `ActiveState=inactive Result=success`.
- `drift-check.timer` still `linked` / `inactive` — **never enabled or started**.
- No drop-ins created; both `*.service.d` dirs confirmed absent.
- Throwaway clone removed. Base clone untouched (still `behind 1`, exactly as found); its dirty WIP never touched. No `git stash`, no `git add -A`, no `reset --hard`. Work done in a dedicated worktree, removed after push.
- `enableDriftDeadman` **not** set to true.

## What I could NOT verify

- **This is not deployed.** No `home-manager switch` / `ship.sh` was run, per instructions. The E2E proof used the *rendered* dunstrc built from this branch and loaded via `dunstctl reload` — the same artifact a switch installs, but the switch itself is unproven. **After merge it needs `ship.sh`, and dunst must reload** for the rule to take effect on either host.
- **Verified on the laptop, not the workbench.** Both run the identical dunstrc (same store hash) and the same dunst 1.13.2, so I expect it to transfer — but the workbench's own paused-with-30-queued state was deliberately not disturbed, so the bypass has **not** been exercised there.
- Behaviour if the user sets a pause level **above** 100 is untested; `dunstctl` documents the range as 0–100 and rejects nothing that I probed.
- The `>=` semantics are an **empirical** finding on this build. I did not read the dunst source to confirm the operator, and the documentation asserts the opposite — if a future dunst release "fixes" the docs by changing the code to a true `>`, this rule silently stops working. The pause-level test pins the value but cannot detect a dunst upgrade changing the comparison; only a live re-run would.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
