### PR TITLE
feat(browser-bridge): a 15-min heartbeat, because no budget can tell "unused" from "down"

### DIFF
--- a/claude/skills/activity/SKILL.md
+++ b/claude/skills/activity/SKILL.md
@@ -70,6 +70,14 @@ Per-source detail that matters when querying:
   stream), `session-summary` (Layer A rollups), `session-insight` (Layer B facets).
 - `i3` — `window::focus` + `workspace::focus` → `i3-source`; captures attention even when
   NOT typing. Carries `app`=WM_CLASS + `payload.workspace`.
+- `browser-bridge` — TWO kinds, and the distinction is load-bearing. `kind=cmd` is one row
+  per agent-driven browser command — the **usage** signal `adoption-scan.py` counts.
+  `kind=heartbeat` is machine-generated every 15 min by the bridge daemon itself
+  (`payload.connected` = is an extension attached), and exists ONLY so the deadman has a
+  cadence to measure. 🔴 **Filter `kind='cmd'` in any usage/adoption query** — counting both
+  reports ~96 phantom uses/day. Before the heartbeat (< 2026-08-11) the source emitted on
+  commands only, so its silence was unbounded and it false-alarmed as DEAD whenever Zach
+  simply hadn't browsed; do not "fix" a browser-bridge DEAD verdict by raising a budget.
 
 **Browser extension is NOT fully nix-managed.** Hand-loaded unpacked in Brave (the laptop's
 daily browser) from `~/.local/share/activity-browser-ext/` — a real-file copy, since

--- a/scripts/agent-ops
+++ b/scripts/agent-ops
@@ -350,30 +350,34 @@ def _load_chquery():
     return mod
 
 
-def machine_cadence_sql_filter():
+def machine_cadence_sql_filter(cadence=None):
     """`AND NOT (...)` excluding every MACHINE_CADENCE pair the deadman declares.
 
-    Returns "" when the set is empty (nothing emits on a timer -> nothing to
-    exclude). Raises if deadman.py cannot be imported; the caller turns that into
-    the panel's error marker, which is the honest outcome — silently falling back
-    to an unfiltered query would put a "fresh 15 min ago" next to a bridge that
-    cannot execute anything.
+    🔴 BOTH the pairs AND the predicate's RENDERING come from deadman — this
+    function only wraps them. An earlier version imported the pairs but re-spelled
+    the `" OR ".join` here, and that copy was immediately wrong in the same way
+    the original was (joining with AND makes `NOT (A AND B)` exclude nothing),
+    reachable the day a second timer-driven emitter is added. Single-sourcing the
+    data is not enough; the expression has to be single-sourced too.
 
-    That raise adds NO new failure mode: the only caller already loads
-    validation/chquery.py from the same DEVRC_DIR one line earlier, so a checkout
-    that cannot satisfy this import could not have satisfied that one either.
+    Returns "" when the set is empty (nothing emits on a timer -> nothing to
+    exclude), which still yields valid SQL at the call site. `cadence` overrides
+    the imported set for tests.
+
+    Raises if deadman.py cannot be imported; the caller turns that into the
+    panel's error marker, which is the honest outcome — silently falling back to
+    an unfiltered query would put a "fresh 15 min ago" next to a bridge that
+    cannot execute anything. Note the asymmetry with chquery, whose absence is a
+    silent no-refresh: this one is LOUD.
     """
     import importlib.util
     spec = importlib.util.spec_from_file_location("_ao_deadman", DEADMAN_PATH)
     mod = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
-    pairs = tuple(mod.MACHINE_CADENCE)
-    if not pairs:
-        return ""
-    terms = " OR ".join("(source = '%s' AND kind = '%s')" % (s, k)
-                        for s, k in pairs)
-    return "AND NOT (%s) " % terms
+    pairs = tuple(mod.MACHINE_CADENCE) if cadence is None else tuple(cadence)
+    pred = mod.cadence_predicate_sql(pairs)
+    return "AND NOT (%s) " % pred if pred else ""
 
 
 def read_env_file(path):

--- a/scripts/agent-ops
+++ b/scripts/agent-ops
@@ -377,9 +377,15 @@ def query_telemetry_freshness(timeout=TELEM_QUERY_TIMEOUT):
     conn = Q.CHConn.from_env(env)  # raises if CLICKHOUSE_URL is absent
     conn.timeout = float(timeout)
     client = Q.CHClient(conn)
+    # Machine-generated heartbeats are excluded: browser-bridge emits one every
+    # 900s whether or not it can execute anything, so counting them would make
+    # this column read "fresh 15 min ago" for a bridge with no extension attached.
+    # Freshness here means OPERATOR-driven activity (same distinction deadman.py
+    # makes with MACHINE_CADENCE).
     sql = (
         "SELECT source, dateDiff('second', max(ts), now()) AS age_secs "
         "FROM %s WHERE ts > now() - INTERVAL 2 DAY "
+        "AND kind != 'heartbeat' "
         "GROUP BY source ORDER BY source" % conn.fq_table)
     rows = client.rows(sql)
     out = {}

--- a/scripts/agent-ops
+++ b/scripts/agent-ops
@@ -127,6 +127,12 @@ CLAWGATE_ENV = os.path.join(HOME, ".claude", "clawgate.env")
 # the Local-health telemetry-freshness query. Reuses the collector's env for the
 # endpoint/creds; never hardcodes a new one.
 CHQUERY_PATH = os.path.join(DEVRC_DIR, "scripts", "validation", "chquery.py")
+# The deadman owns the ONE definition of "which (source, kind) pairs are machine
+# generated rather than operator-driven" (MACHINE_CADENCE). This panel needs the
+# same predicate, so it IMPORTS it rather than re-spelling it — a second copy
+# would silently disagree the day a timer-driven emitter is added, and the
+# deadman's own 🔴 note tells maintainers about exactly one place to edit.
+DEADMAN_PATH = os.path.join(DEVRC_DIR, "scripts", "collector", "deadman.py")
 
 # Scratchpad codename table — THE single source of truth for session<->codename
 # (scripts/tmux-scratch-slots.sh). Mirror how the bash/py consumers resolve it:
@@ -344,6 +350,32 @@ def _load_chquery():
     return mod
 
 
+def machine_cadence_sql_filter():
+    """`AND NOT (...)` excluding every MACHINE_CADENCE pair the deadman declares.
+
+    Returns "" when the set is empty (nothing emits on a timer -> nothing to
+    exclude). Raises if deadman.py cannot be imported; the caller turns that into
+    the panel's error marker, which is the honest outcome — silently falling back
+    to an unfiltered query would put a "fresh 15 min ago" next to a bridge that
+    cannot execute anything.
+
+    That raise adds NO new failure mode: the only caller already loads
+    validation/chquery.py from the same DEVRC_DIR one line earlier, so a checkout
+    that cannot satisfy this import could not have satisfied that one either.
+    """
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("_ao_deadman", DEADMAN_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    pairs = tuple(mod.MACHINE_CADENCE)
+    if not pairs:
+        return ""
+    terms = " OR ".join("(source = '%s' AND kind = '%s')" % (s, k)
+                        for s, k in pairs)
+    return "AND NOT (%s) " % terms
+
+
 def read_env_file(path):
     """Parse a KEY=VALUE env file (# comments, blank lines) → dict. {} on failure.
     Same shape the collector/systemd EnvironmentFile uses."""
@@ -377,16 +409,16 @@ def query_telemetry_freshness(timeout=TELEM_QUERY_TIMEOUT):
     conn = Q.CHConn.from_env(env)  # raises if CLICKHOUSE_URL is absent
     conn.timeout = float(timeout)
     client = Q.CHClient(conn)
-    # Machine-generated heartbeats are excluded: browser-bridge emits one every
+    # Machine-generated rows are excluded: browser-bridge emits a heartbeat every
     # 900s whether or not it can execute anything, so counting them would make
     # this column read "fresh 15 min ago" for a bridge with no extension attached.
-    # Freshness here means OPERATOR-driven activity (same distinction deadman.py
-    # makes with MACHINE_CADENCE).
+    # Freshness here means OPERATOR-driven activity — the predicate is IMPORTED
+    # from deadman.MACHINE_CADENCE, not re-spelled (see machine_cadence_sql_filter).
     sql = (
         "SELECT source, dateDiff('second', max(ts), now()) AS age_secs "
         "FROM %s WHERE ts > now() - INTERVAL 2 DAY "
-        "AND kind != 'heartbeat' "
-        "GROUP BY source ORDER BY source" % conn.fq_table)
+        "%sGROUP BY source ORDER BY source"
+        % (conn.fq_table, machine_cadence_sql_filter()))
     rows = client.rows(sql)
     out = {}
     for r in rows:

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -93,6 +93,10 @@ Config (env):
                                  burst would rate_limit EVERY /cmd forever)
     BROWSER_BRIDGE_MAX_QUEUE     per-instance pending-command cap (default 32;
                                  0 → unlimited). Over-cap /cmd → HTTP 429.
+    BROWSER_BRIDGE_HEARTBEAT_S   seconds between liveness telemetry heartbeats
+                                 (default 900; 0 → disabled). See
+                                 HEARTBEAT_INTERVAL_S for why the source needs a
+                                 cadence at all.
 """
 from __future__ import annotations
 
@@ -337,6 +341,27 @@ OWNER_TTL_S = float(os.environ.get("BROWSER_BRIDGE_OWNER_TTL", "900"))
 RATE_PER_SEC = float(os.environ.get("BROWSER_BRIDGE_RATE_PER_SEC", "5"))
 BURST = float(os.environ.get("BROWSER_BRIDGE_BURST", "20"))
 MAX_QUEUE = int(os.environ.get("BROWSER_BRIDGE_MAX_QUEUE", "32"))
+
+# Liveness heartbeat interval, in seconds. 0 (or negative) disables the thread.
+#
+# WHY A HEARTBEAT EXISTS AT ALL. Every other browser-bridge event is emitted by a
+# handled COMMAND, so the source has no cadence: it emits when an agent drives it
+# and is otherwise silent for as long as nobody does. That makes it undetectable
+# by the activity pipeline's deadman check (scripts/collector/deadman.py), which
+# decides "dead" by comparing silence against a MEASURED per-source budget —
+# there is no budget that separates "unused" from "down" when normal silence is
+# unbounded. Measured 2026-08-11: laptop/browser-bridge had been silent 30.9
+# ACTIVE hours, 2.2x the worst lull in its own 14-day history, purely because the
+# operator had not run a browser task; the check called it DEAD and was right by
+# its own definition and useless by ours.
+#
+# 900s = 3 of the deadman's 5-minute buckets, so a live bridge emits ~96 rows/day
+# and its p99 active-gap collapses to ~3 buckets. The budget then bottoms out on
+# that module's 2-ACTIVE-HOUR floor: silence beyond ~2 active hours means the
+# unit is genuinely not running, and no amount of not-using-the-browser can
+# produce it. Cheap enough to be uninteresting (one local spool append) and
+# bounded by the same best-effort contract as every other emit.
+HEARTBEAT_INTERVAL_S = float(os.environ.get("BROWSER_BRIDGE_HEARTBEAT_S", "900"))
 
 # Host-side i3 foregrounding for the `activate` op (see i3_foreground below).
 # The Chrome-side activate (chrome.tabs.update{active}+windows.update{focused})
@@ -838,7 +863,8 @@ def _emulate_extra(body) -> dict:
 
 
 def emit_cmd_event(op: str, key: str, outcome: str, duration_ms: int,
-                   domain: str = "", exit_code: int = 0, extra: dict = None) -> None:
+                   domain: str = "", exit_code: int = 0, extra: dict = None,
+                   kind: str = "cmd") -> None:
     """Append ONE metadata-only activity event for a handled command.
 
     Best-effort + fire-and-forget: any failure is swallowed so telemetry can
@@ -846,6 +872,13 @@ def emit_cmd_event(op: str, key: str, outcome: str, duration_ms: int,
     `extra` merges additional METADATA-ONLY keys into the payload (used by the
     throttle path for {reason, sess} — a fixed reason string + a coarse session
     hash, never page content).
+
+    🔴 `kind` defaults to "cmd" and MUST stay that way for operator-driven
+    commands: `kind='cmd'` is the USAGE signal downstream — session-analysis/
+    adoption-scan.py queries source='browser-bridge' AND kind='cmd' to answer
+    "is the browser skill actually used". Anything the SERVER emits on its own
+    (the heartbeat) has to carry a different kind, or ~96 machine-generated rows
+    a day would read as operator usage and the adoption number becomes a lie.
     """
     try:
         se = _load_spool_emit()
@@ -859,7 +892,7 @@ def emit_cmd_event(op: str, key: str, outcome: str, duration_ms: int,
             payload.update(extra)
         se.emit({
             "source": "browser-bridge",
-            "kind": "cmd",
+            "kind": kind,
             "text": domain or op,
             "duration_ms": int(duration_ms),
             "exit_code": int(exit_code),
@@ -882,6 +915,71 @@ def _emit_diag_event(op: str, t0: float) -> None:
     emit_cmd_event(op=op, key="", outcome="ok",
                    duration_ms=int((time.monotonic() - t0) * 1000),
                    domain="", exit_code=0)
+
+
+# --------------------------------------------------------------------------- #
+# Liveness heartbeat (see HEARTBEAT_INTERVAL_S for WHY this exists)
+# --------------------------------------------------------------------------- #
+def emit_heartbeat_event(registry) -> None:
+    """Emit ONE liveness event: `source=browser-bridge, kind=heartbeat`.
+
+    Deliberately NOT kind="cmd" — see the contract on emit_cmd_event's `kind`.
+
+    The payload carries whether an extension is currently connected, which makes
+    the row strictly more useful than a bare "the process is up": the bridge is
+    two halves, and the half that actually breaks in practice is the extension
+    end (a silent drop, an un-reloaded build). `Registry.connected` is the ONE
+    definition of live in this process, so asking it here cannot disagree with
+    what /health reports — and it drives the edge-triggered instance_lost logging
+    on a timer instead of only when traffic happens to arrive.
+
+    Metadata-only and best-effort like every other emit: a bool and a count, no
+    URL/domain/title/content, and nothing here may raise into the caller.
+    """
+    try:
+        connected = bool(registry.connected)
+        live = len(registry.snapshot())
+    except Exception:  # noqa: BLE001 — a registry problem must not kill the thread.
+        connected, live = False, 0
+    emit_cmd_event(op="heartbeat", key="", outcome="ok", duration_ms=0,
+                   domain="", exit_code=0, kind="heartbeat",
+                   extra={"connected": connected, "instances": live})
+
+
+def run_heartbeat(registry, interval: float, stop: threading.Event,
+                  emit=None) -> None:
+    """Emit a heartbeat NOW, then every `interval` seconds until `stop` is set.
+
+    Emitting immediately (rather than after the first sleep) is what makes a
+    restart observable promptly: the deadman's silence measurement resets as soon
+    as the unit comes back, so a bounce is not indistinguishable from an outage
+    for the first interval.
+
+    `stop.wait(interval)` rather than `time.sleep` so shutdown is immediate
+    instead of blocking a service stop for up to 15 minutes. `emit` is injectable
+    for tests.
+    """
+    emit = emit or emit_heartbeat_event
+    while True:
+        try:
+            emit(registry)
+        except Exception:  # noqa: BLE001 — strictly best-effort, and this thread
+            pass           # must outlive a transient emitter failure.
+        if stop.wait(interval):
+            return
+
+
+def start_heartbeat(registry, interval: float = None):
+    """Start the heartbeat thread. Returns (thread, stop_event), or (None, None)
+    when disabled (interval <= 0 — the documented escape hatch)."""
+    interval = HEARTBEAT_INTERVAL_S if interval is None else interval
+    if interval <= 0:
+        return None, None
+    stop = threading.Event()
+    t = threading.Thread(target=run_heartbeat, args=(registry, interval, stop),
+                         name="browser-bridge-heartbeat", daemon=True)
+    t.start()
+    return t, stop
 
 
 # --------------------------------------------------------------------------- #
@@ -2576,13 +2674,17 @@ def main(argv=None) -> int:
                           poll_timeout, ping_timeout)
     log("listening", host=host, port=port, token_file=str(token_file),
         cmd_timeout=cmd_timeout, poll_timeout=poll_timeout,
-        ping_timeout=ping_timeout)
+        ping_timeout=ping_timeout,
+        heartbeat_s=HEARTBEAT_INTERVAL_S)
     _warn_poll_timeout_vs_extension_budget(poll_timeout)
+    _hb_thread, hb_stop = start_heartbeat(registry)
     try:
         server.serve_forever()
     except KeyboardInterrupt:
         pass
     finally:
+        if hb_stop is not None:
+            hb_stop.set()
         server.server_close()
     return 0
 

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -925,20 +925,31 @@ def emit_heartbeat_event(registry) -> None:
 
     Deliberately NOT kind="cmd" — see the contract on emit_cmd_event's `kind`.
 
-    The payload carries whether an extension is currently connected, which makes
-    the row strictly more useful than a bare "the process is up": the bridge is
-    two halves, and the half that actually breaks in practice is the extension
-    end (a silent drop, an un-reloaded build). `Registry.connected` is the ONE
-    definition of live in this process, so asking it here cannot disagree with
-    what /health reports — and it drives the edge-triggered instance_lost logging
-    on a timer instead of only when traffic happens to arrive.
+    WHAT THE ROW PROVES, STATED HONESTLY. The deadman consumes only the row's
+    EXISTENCE, so what this detects is "the bridge process is running". The
+    `connected` field is DIAGNOSTIC METADATA, not an alarm: no consumer branches
+    on it today, so a bridge whose extension has silently dropped still reads
+    alive to the deadman. That gap is not a regression — nothing detected an
+    extension drop before either (the operator found out when a command failed) —
+    but do not describe this heartbeat as covering it. Wiring an alarm to
+    `connected` is a separate change with its own consumer.
+
+    It is still worth emitting: it makes a drop visible in `activity.events`
+    afterwards, and reading `Registry.connected` here drives the edge-triggered
+    instance_lost logging on a timer instead of only when traffic arrives.
+    `Registry.connected` is the ONE definition of live in this process, so this
+    cannot disagree with what /health reports.
 
     Metadata-only and best-effort like every other emit: a bool and a count, no
     URL/domain/title/content, and nothing here may raise into the caller.
     """
     try:
-        connected = bool(registry.connected)
-        live = len(registry.snapshot())
+        # ONE lock acquisition, not two: `connected` is just `bool(live)` over
+        # the same snapshot, and taking the lock twice could report a bool and a
+        # count from two different instants.
+        live_instances = registry.snapshot()
+        live = len(live_instances)
+        connected = bool(live)
     except Exception:  # noqa: BLE001 — a registry problem must not kill the thread.
         connected, live = False, 0
     emit_cmd_event(op="heartbeat", key="", outcome="ok", duration_ms=0,
@@ -2677,7 +2688,7 @@ def main(argv=None) -> int:
         ping_timeout=ping_timeout,
         heartbeat_s=HEARTBEAT_INTERVAL_S)
     _warn_poll_timeout_vs_extension_budget(poll_timeout)
-    _hb_thread, hb_stop = start_heartbeat(registry)
+    _heartbeat, hb_stop = start_heartbeat(registry)  # daemon thread; stopped below
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -6674,8 +6674,7 @@ def test_start_heartbeat_disabled_at_zero_interval():
 def test_start_heartbeat_runs_and_stops():
     """The thread is real, is a daemon (a stuck heartbeat must never hold up
     shutdown), and stops promptly when the stop event is set."""
-    spool_before = S.HEARTBEAT_INTERVAL_S
-    t, stop = S.start_heartbeat(_FakeRegistry(), 0.01)
+    t, stop = S.start_heartbeat(_FakeRegistry(), 0.05)
     try:
         assert t is not None and t.daemon is True
         assert t.is_alive()
@@ -6683,25 +6682,106 @@ def test_start_heartbeat_runs_and_stops():
         stop.set()
         t.join(timeout=2.0)
     assert not t.is_alive(), "heartbeat thread did not stop"
-    assert S.HEARTBEAT_INTERVAL_S == spool_before
 
 
-def test_heartbeat_uses_the_real_registry_connected_definition(telemetry):
+def test_heartbeat_tracks_registry_liveness_across_the_stale_boundary(telemetry):
     """Structural: the heartbeat must read the SAME liveness definition /health
     reports (Registry.connected), not a second one that can disagree.
 
-    A live FakeExtension → connected True; after it stops and the instance goes
-    stale → False. Exercised through the real Registry, so a divergent definition
-    would have to break this test to exist.
+    Asserting only the connected=True side is a SPELLED guard, not a structural
+    one: a divergent definition that ignores staleness (e.g. `_instances or
+    connected`) satisfies it and survives. So this drives a REAL Registry across
+    the CONNECT_STALE_S boundary with an injected clock and pins BOTH sides —
+    the transition is the part a second definition cannot fake.
     """
     spool_dir = telemetry
-    srv, registry = _serve(poll_timeout=1.0)
-    ext = FakeExtension(srv, instance_id="hb-1", label="hb")
-    ext.start()
-    try:
-        assert _wait_count(srv, 1) is not None
-        S.emit_heartbeat_event(registry)
-        p = json.loads(_wait_events(spool_dir, 1)[0]["payload"])
-        assert p["connected"] is True and p["instances"] >= 1, p
-    finally:
-        ext.stop(); srv.shutdown(); srv.server_close()
+    clock = [1000.0]
+    reg = S.Registry(clock=lambda: clock[0])
+    # wait_timeout=0, NOT the usual _register_live(0.01): poll() derives its
+    # deadline from the INJECTED clock, so under a frozen clock any positive
+    # timeout spins forever. Zero registers the instance and returns immediately.
+    assert reg.poll("hb-1", "hb", 0) is None
+
+    S.emit_heartbeat_event(reg)
+    p = json.loads(_wait_events(spool_dir, 1)[0]["payload"])
+    assert p["connected"] is True and p["instances"] == 1, p
+    assert reg.connected is True, "fixture precondition"
+
+    clock[0] += S.CONNECT_STALE_S + 1        # the instance goes stale
+    assert reg.connected is False, "fixture precondition"
+    S.emit_heartbeat_event(reg)
+    p2 = json.loads(_wait_events(spool_dir, 2)[1]["payload"])
+    assert p2["connected"] is False and p2["instances"] == 0, p2
+
+
+def test_heartbeat_interval_keeps_the_deadman_budget_on_the_floor(telemetry):
+    """🔴 SEAM GUARD — the emitter's interval vs the consumer's bucket size.
+
+    HEARTBEAT_INTERVAL_S is the one load-bearing number in this feature, and
+    nothing in server.py can tell whether it is still small enough to do its job:
+    that is decided by deadman.py's BUCKET_SECONDS and FLOOR_BUCKETS, in another
+    tree. Left unpinned, `900` -> `90000` is a silent no-op — the heartbeat keeps
+    emitting, every test stays green, and the source goes back to being
+    undetectable.
+
+    So this imports the real consumer and asserts the RELATIONSHIP: the cadence
+    must be frequent enough that a live bridge's worst gap stays far under the
+    budget floor. It also pins the >0 default, because 0 disables the feature
+    entirely.
+    """
+    import importlib.util
+    dm_py = (Path(__file__).resolve().parents[2] / "collector" / "deadman.py")
+    spec = importlib.util.spec_from_file_location("deadman_seam", dm_py)
+    DM = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(DM)
+
+    assert S.HEARTBEAT_INTERVAL_S > 0, \
+        "the default must not disable the feature"
+    buckets_per_beat = S.HEARTBEAT_INTERVAL_S / DM.BUCKET_SECONDS
+    assert buckets_per_beat <= DM.FLOOR_BUCKETS / 4, (
+        f"heartbeat every {buckets_per_beat:.1f} deadman buckets is too sparse "
+        f"against a {DM.FLOOR_BUCKETS}-bucket floor — the budget will no longer "
+        "sit on the floor and the source becomes undetectable again")
+
+    # And the pair is actually declared machine-cadence downstream, or the
+    # heartbeat inflates every other source's active time (see MACHINE_CADENCE).
+    assert ("browser-bridge", "heartbeat") in DM.MACHINE_CADENCE, \
+        "deadman no longer treats the heartbeat as machine-cadence"
+
+
+def test_main_actually_starts_and_stops_the_heartbeat(monkeypatch, tmp_path):
+    """🔴 The wiring, not just the parts. Every other test here exercises
+    run_heartbeat/start_heartbeat directly, so `start_heartbeat(registry)` could
+    be deleted from main() and the whole suite stays green while the feature is
+    completely inert on both hosts.
+
+    Drives the real main() with a stub server whose serve_forever returns, and
+    asserts the thread was started with the real registry AND stopped on the way
+    out (a leaked heartbeat would keep emitting after a shutdown).
+    """
+    started, stopped = [], []
+
+    class _StubServer:
+        def serve_forever(self):
+            return None
+
+        def server_close(self):
+            return None
+
+    class _StubStop:
+        def set(self):
+            stopped.append(True)
+
+    def _fake_start(registry, interval=None):
+        started.append(registry)
+        return object(), _StubStop()
+
+    monkeypatch.setenv("BROWSER_BRIDGE_TOKEN_FILE", str(tmp_path / "token"))
+    monkeypatch.setattr(S, "build_server", lambda *a, **kw: _StubServer())
+    monkeypatch.setattr(S, "start_heartbeat", _fake_start)
+
+    assert S.main([]) == 0
+    assert len(started) == 1, "main() did not start the heartbeat"
+    assert isinstance(started[0], S.Registry), \
+        "the heartbeat was not given the server's own registry"
+    assert stopped == [True], "main() did not stop the heartbeat on shutdown"

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -6493,3 +6493,215 @@ def test_poll_budget_warning_still_claims_extension_0_4_0_plus():
     major, minor, _ = (int(x) for x in manifest["version"].split("."))
     assert (major, minor) >= (0, 4), \
         f"manifest {manifest['version']} no longer satisfies 0.4.0+"
+
+
+# --------------------------------------------------------------------------- #
+# Liveness heartbeat
+#
+# WHY: browser-bridge only ever emitted on a handled COMMAND, so the source had
+# no cadence and its silence was unbounded — which made the activity deadman
+# check (scripts/collector/deadman.py) structurally unable to tell "the operator
+# has not run a browser task" from "the bridge is down". Measured 2026-08-11:
+# laptop/browser-bridge silent 30.9 ACTIVE hours, 2.2x its own worst 14-day lull,
+# flagged DEAD while the unit was healthy and simply unused.
+#
+# The tests below pin the three things that make the heartbeat a fix rather than
+# a code change: it EMITS on a cadence, it is NOT counted as operator usage, and
+# it cannot take the server down.
+# --------------------------------------------------------------------------- #
+class _FakeRegistry:
+    """Minimal Registry stand-in: just the two attributes the heartbeat reads."""
+
+    def __init__(self, connected=True, instances=1, boom=False):
+        self._connected = connected
+        self._instances = instances
+        self._boom = boom
+
+    @property
+    def connected(self):
+        if self._boom:
+            raise RuntimeError("registry exploded")
+        return self._connected
+
+    def snapshot(self):
+        if self._boom:
+            raise RuntimeError("registry exploded")
+        return [{"key": "k%d" % i} for i in range(self._instances)]
+
+
+def test_heartbeat_emits_a_metadata_only_liveness_event(telemetry):
+    """The row the deadman needs: source=browser-bridge, a cadence kind, and a
+    payload that says whether the EXTENSION half is connected."""
+    spool_dir = telemetry
+    assert _read_events(spool_dir) == [], "negative control: 0 before"
+
+    S.emit_heartbeat_event(_FakeRegistry(connected=True, instances=2))
+
+    evs = _wait_events(spool_dir, 1)
+    assert len(evs) == 1, f"expected exactly one event, got {evs}"
+    e = evs[0]
+    assert e["source"] == "browser-bridge"
+    assert e["kind"] == "heartbeat"
+    assert e["text"] == "heartbeat"
+    assert e["exit_code"] == "0"
+    p = json.loads(e["payload"])
+    assert p == {"op": "heartbeat", "key": "", "outcome": "ok",
+                 "connected": True, "instances": 2}, p
+
+
+def test_heartbeat_reports_a_disconnected_extension(telemetry):
+    """The positive control for the field that carries the information: a bridge
+    whose extension half is gone must report connected=False, or the heartbeat
+    degenerates into 'the process is up' and hides the failure that actually
+    happens (a silent extension drop)."""
+    spool_dir = telemetry
+    S.emit_heartbeat_event(_FakeRegistry(connected=False, instances=0))
+    e = _wait_events(spool_dir, 1)[0]
+    p = json.loads(e["payload"])
+    assert p["connected"] is False and p["instances"] == 0, p
+
+
+def test_heartbeat_is_not_counted_as_operator_usage(telemetry):
+    """🔴 SEAM GUARD — server.py's emit vs adoption-scan.py's usage query.
+
+    Neither module can see the other, and each is 'correct' alone: adoption-scan
+    counts source='browser-bridge' AND kind='cmd' to answer "is the browser skill
+    actually used". A heartbeat emitted as kind='cmd' would add ~96 machine rows
+    a day and report a skill nobody touched as heavily used.
+
+    So this asserts the RELATIONSHIP, against the real spec adoption-scan ships
+    with — not a copy of the string. It fails if either side moves.
+    """
+    import importlib.util
+    scan_py = (Path(__file__).resolve().parents[2]
+               / "session-analysis" / "adoption-scan.py")
+    spec = importlib.util.spec_from_file_location("adoption_scan_seam", scan_py)
+    A = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(A)
+
+    specs = [s for s in A.REGISTRY if s.get("source") == "browser-bridge"]
+    assert specs, "adoption-scan no longer tracks browser-bridge — re-check this seam"
+    counted_kinds = {s.get("kind") for s in specs}
+    assert counted_kinds == {"cmd"}, \
+        f"adoption-scan's browser-bridge kinds changed to {counted_kinds}"
+
+    spool_dir = telemetry
+    S.emit_heartbeat_event(_FakeRegistry())
+    e = _wait_events(spool_dir, 1)[0]
+    assert e["kind"] not in counted_kinds, \
+        ("the heartbeat is being counted as operator usage by adoption-scan — "
+         f"emitted kind={e['kind']!r}, counted={counted_kinds}")
+
+
+def test_heartbeat_repeats_on_the_interval(telemetry):
+    """The cadence itself: the loop keeps emitting until stopped."""
+    calls = []
+    stop = threading.Event()
+
+    def _emit(reg):
+        calls.append(time.monotonic())
+        if len(calls) >= 3:
+            stop.set()
+
+    S.run_heartbeat(_FakeRegistry(), 0.01, stop, emit=_emit)
+    assert len(calls) >= 3, calls
+
+
+def test_heartbeat_emits_BEFORE_its_first_sleep():
+    """A restart must reset the deadman's silence promptly, so the FIRST emit
+    happens before the first sleep — not one interval later.
+
+    🔴 The interval here is deliberately LONG relative to the assertion window.
+    An earlier version of this test used 0.01s and a <0.05s bound, which PASSED
+    against a mutant that slept first — at a 10ms interval the two orderings are
+    indistinguishable. The gap between interval and bound IS the guard: emit-first
+    returns in microseconds, sleep-first cannot return in under `interval`.
+    """
+    interval = 2.0
+    bound = 0.5
+    assert interval > 2 * bound, "the mutant must not fit inside the bound"
+    calls = []
+    stop = threading.Event()
+
+    def _emit(reg):
+        calls.append(time.monotonic())
+        stop.set()          # one emit is all this test needs
+
+    t0 = time.monotonic()
+    S.run_heartbeat(_FakeRegistry(), interval, stop, emit=_emit)
+    elapsed = time.monotonic() - t0
+    assert len(calls) == 1, calls
+    assert elapsed < bound, \
+        (f"first heartbeat took {elapsed:.2f}s with a {interval}s interval — "
+         "the loop is sleeping before its first emit")
+
+
+def test_run_heartbeat_survives_an_emitter_that_raises():
+    """MUTATION-PROOF for the loop's try/except: one bad emit must not kill the
+    thread, or a transient spool problem silently ends the cadence forever and
+    the deadman then reports the bridge dead for the rest of its uptime."""
+    calls = []
+    stop = threading.Event()
+
+    def _emit(reg):
+        calls.append(1)
+        if len(calls) >= 3:
+            stop.set()
+        raise RuntimeError("spool exploded")
+
+    S.run_heartbeat(_FakeRegistry(), 0.01, stop, emit=_emit)  # must not raise
+    assert len(calls) >= 3, f"loop died after {len(calls)} emit(s)"
+
+
+def test_emit_heartbeat_survives_a_broken_registry(telemetry):
+    """A registry that raises must still produce a row: the event's PURPOSE is to
+    prove the process is alive, so degrading to connected=False beats emitting
+    nothing (which would read as the process being dead)."""
+    spool_dir = telemetry
+    S.emit_heartbeat_event(_FakeRegistry(boom=True))
+    e = _wait_events(spool_dir, 1)[0]
+    p = json.loads(e["payload"])
+    assert e["kind"] == "heartbeat"
+    assert p["connected"] is False and p["instances"] == 0, p
+
+
+def test_start_heartbeat_disabled_at_zero_interval():
+    """The documented escape hatch: BROWSER_BRIDGE_HEARTBEAT_S=0 starts nothing."""
+    t, stop = S.start_heartbeat(_FakeRegistry(), 0)
+    assert t is None and stop is None
+
+
+def test_start_heartbeat_runs_and_stops():
+    """The thread is real, is a daemon (a stuck heartbeat must never hold up
+    shutdown), and stops promptly when the stop event is set."""
+    spool_before = S.HEARTBEAT_INTERVAL_S
+    t, stop = S.start_heartbeat(_FakeRegistry(), 0.01)
+    try:
+        assert t is not None and t.daemon is True
+        assert t.is_alive()
+    finally:
+        stop.set()
+        t.join(timeout=2.0)
+    assert not t.is_alive(), "heartbeat thread did not stop"
+    assert S.HEARTBEAT_INTERVAL_S == spool_before
+
+
+def test_heartbeat_uses_the_real_registry_connected_definition(telemetry):
+    """Structural: the heartbeat must read the SAME liveness definition /health
+    reports (Registry.connected), not a second one that can disagree.
+
+    A live FakeExtension → connected True; after it stops and the instance goes
+    stale → False. Exercised through the real Registry, so a divergent definition
+    would have to break this test to exist.
+    """
+    spool_dir = telemetry
+    srv, registry = _serve(poll_timeout=1.0)
+    ext = FakeExtension(srv, instance_id="hb-1", label="hb")
+    ext.start()
+    try:
+        assert _wait_count(srv, 1) is not None
+        S.emit_heartbeat_event(registry)
+        p = json.loads(_wait_events(spool_dir, 1)[0]["payload"])
+        assert p["connected"] is True and p["instances"] >= 1, p
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -6759,7 +6759,7 @@ def test_main_actually_starts_and_stops_the_heartbeat(monkeypatch, tmp_path):
     asserts the thread was started with the real registry AND stopped on the way
     out (a leaked heartbeat would keep emitting after a shutdown).
     """
-    started, stopped = [], []
+    started, stopped, served = [], [], []
 
     class _StubServer:
         def serve_forever(self):
@@ -6772,16 +6772,23 @@ def test_main_actually_starts_and_stops_the_heartbeat(monkeypatch, tmp_path):
         def set(self):
             stopped.append(True)
 
+    def _fake_build(host, port, registry, *a, **kw):
+        served.append(registry)      # capture WHICH registry the server got
+        return _StubServer()
+
     def _fake_start(registry, interval=None):
         started.append(registry)
         return object(), _StubStop()
 
     monkeypatch.setenv("BROWSER_BRIDGE_TOKEN_FILE", str(tmp_path / "token"))
-    monkeypatch.setattr(S, "build_server", lambda *a, **kw: _StubServer())
+    monkeypatch.setattr(S, "build_server", _fake_build)
     monkeypatch.setattr(S, "start_heartbeat", _fake_start)
 
     assert S.main([]) == 0
     assert len(started) == 1, "main() did not start the heartbeat"
-    assert isinstance(started[0], S.Registry), \
-        "the heartbeat was not given the server's own registry"
+    # IDENTITY, not isinstance: `start_heartbeat(Registry())` — a fresh registry
+    # instead of the server's — passes a type check while making the heartbeat
+    # report connected=False / instances=0 forever.
+    assert started[0] is served[0], \
+        "the heartbeat was given a different Registry than the server's"
     assert stopped == [True], "main() did not stop the heartbeat on shutdown"

--- a/scripts/collector/README.md
+++ b/scripts/collector/README.md
@@ -47,10 +47,17 @@ tmux focus hooks   ─┼─► emit (pure shell, hot path) ─► spool/current
 - **External emitters** (write to the same spool, live outside this dir):
   `browser-ext/receiver.py` (`source=browser, kind=nav` — page nav/scroll from the
   collector's MV3 extension) and the **browser-bridge server**
-  (`scripts/browser-bridge/server.py`, `source=browser-bridge, kind=cmd` — one
-  best-effort, metadata-only event per Claude-driven browser command:
-  op/instance-key/outcome/latency + bare domain, **never** page content). Both
-  reuse `keylog/spool_emit.py` for the v1 line format.
+  (`scripts/browser-bridge/server.py`), which emits TWO kinds:
+  `kind=cmd` — one best-effort, metadata-only event per Claude-driven browser
+  command (op/instance-key/outcome/latency + bare domain, **never** page content);
+  this is the **usage** signal `session-analysis/adoption-scan.py` counts, so
+  filter on it in any adoption query.
+  `kind=heartbeat` — machine-generated every 900s by the bridge daemon
+  (`payload.connected`), so the source has a cadence the deadman can measure.
+  🔴 It is declared in `deadman.py`'s `MACHINE_CADENCE`, which keeps it OUT of the
+  host's active-time definition — a timer-driven emitter counted as operator
+  activity makes every idle source on the host read DEAD overnight.
+  Both reuse `keylog/spool_emit.py` for the v1 line format.
 - `tests/` — pytest unit + round-trip coverage (mocks the HTTP endpoint).
 
 ## Spool / emit line contract (v1)

--- a/scripts/collector/deadman.py
+++ b/scripts/collector/deadman.py
@@ -187,6 +187,21 @@ UNKNOWN_STATES = frozenset(
 # --------------------------------------------------------------------------- #
 # Query
 # --------------------------------------------------------------------------- #
+def cadence_predicate_sql(cadence=MACHINE_CADENCE) -> str:
+    """A ClickHouse boolean matching any MACHINE_CADENCE pair; "" when empty.
+
+    🔴 THE ONE PLACE this predicate is RENDERED, not just the one place the pairs
+    are declared. Exported because scripts/agent-ops needs the same predicate for
+    its freshness panel: a second copy of the `" OR ".join` immediately grew the
+    same latent bug (joining with AND makes `NOT (A AND B)` exclude NOTHING),
+    which is only reachable once a second pair exists -- i.e. it would have gone
+    unnoticed until exactly the moment MACHINE_CADENCE's own note tells a
+    maintainer to add one. Single-sourcing the DATA was not enough.
+    """
+    return " OR ".join("(source = '%s' AND kind = '%s')" % (s, k)
+                       for s, k in cadence)
+
+
 def _operator_count_expr(cadence=MACHINE_CADENCE) -> str:
     """`countIf(...)` counting only OPERATOR-driven events in the bucket.
 
@@ -194,11 +209,10 @@ def _operator_count_expr(cadence=MACHINE_CADENCE) -> str:
     empty cadence set degrades to plain count() -- i.e. the pre-heartbeat
     behaviour, which is the correct answer when nothing emits on a timer.
     """
-    if not cadence:
+    pred = cadence_predicate_sql(cadence)
+    if not pred:
         return "count()"
-    terms = " OR ".join("(source = '%s' AND kind = '%s')" % (s, k)
-                        for s, k in cadence)
-    return "countIf(NOT (%s))" % terms
+    return "countIf(NOT (%s))" % pred
 
 
 def bucket_query(days: int = BASELINE_DAYS, bucket_seconds: int = BUCKET_SECONDS,

--- a/scripts/collector/deadman.py
+++ b/scripts/collector/deadman.py
@@ -28,9 +28,13 @@ MEASURED per (host, source) rather than declared:
 
   1. Bucket every event into 5-minute buckets, per host and source
      (one GROUP BY — ~11k rows for 14 days across both hosts, measured).
-  2. A host's ACTIVE buckets = the buckets in which ANY source on that host
-     emitted. Overnight and away-from-desk time simply is not in this set, so an
-     on-demand source is not punished for the operator being asleep.
+  2. A host's ACTIVE buckets = the buckets in which any OPERATOR-DRIVEN source on
+     that host emitted. Overnight and away-from-desk time simply is not in this
+     set, so an on-demand source is not punished for the operator being asleep.
+     🔴 "Operator-driven" is not decoration: a timer-driven emitter is excluded
+     (MACHINE_CADENCE), because one source ticking 24/7 would otherwise mark the
+     whole night ACTIVE and make every idle source on the host read DEAD by
+     morning. Measured, with numbers, at MACHINE_CADENCE.
   3. For each (host, source), the historical gap between consecutive emitting
      buckets is counted IN ACTIVE BUCKETS. Its Nth percentile (default p99) is
      that source's own normal worst-case silence.
@@ -136,6 +140,33 @@ FLOOR_BUCKETS = 24
 # alarm, while still bounding a pathological budget.
 CAP_BUCKETS = 576
 
+# --------------------------------------------------------------------------- #
+# MACHINE-CADENCE EMITTERS — rows that prove a SOURCE is alive but do NOT prove
+# the OPERATOR is present.
+#
+# 🔴 This distinction is load-bearing for every OTHER source on the host, which
+# is what makes it easy to get wrong. `active_by_host` is built from any source's
+# buckets, so a source that emits around the clock marks overnight and
+# away-from-desk buckets ACTIVE for everyone — and idle sources then accrue
+# "active" silence while the operator is asleep. Measured 2026-08-11 against the
+# real 14-day table, sweeping the evaluation point hourly over 5 days with a
+# synthetic 900s heartbeat injected on the workbench: SIX pairs that never alarm
+# today go DEAD (i3 47/121 sampled hours, tmux 47, keys 45, opencode 28, zsh 22,
+# claude 19), including a 20-hour continuous false DEAD on workbench/keys across
+# a Saturday the operator was away. It does not self-correct with more history:
+# p99 sits just under the nightly gaps because there are only ~14 of them among
+# ~1300.
+#
+# So a (source, kind) listed here contributes to its OWN pair's liveness and is
+# excluded from the host's active-time definition.
+#
+# 🔴 ADDING A TIMER-DRIVEN EMITTER ANYWHERE IN THE PIPELINE MEANS ADDING IT HERE.
+# The test that would catch the omission is
+# test_a_machine_cadence_source_does_not_make_idle_sources_look_dead — it uses a
+# day/night fixture, because a fixture with no idle time is structurally blind to
+# this entire class of bug (the first version of these tests was).
+MACHINE_CADENCE = (("browser-bridge", "heartbeat"),)
+
 DEFAULT_ENV_FILE = "~/.config/activity-collector/env"
 DEFAULT_TIMEOUT = 8.0
 
@@ -156,43 +187,81 @@ UNKNOWN_STATES = frozenset(
 # --------------------------------------------------------------------------- #
 # Query
 # --------------------------------------------------------------------------- #
+def _operator_count_expr(cadence=MACHINE_CADENCE) -> str:
+    """`countIf(...)` counting only OPERATOR-driven events in the bucket.
+
+    Built from MACHINE_CADENCE so the SQL and the Python cannot drift apart. An
+    empty cadence set degrades to plain count() -- i.e. the pre-heartbeat
+    behaviour, which is the correct answer when nothing emits on a timer.
+    """
+    if not cadence:
+        return "count()"
+    terms = " OR ".join("(source = '%s' AND kind = '%s')" % (s, k)
+                        for s, k in cadence)
+    return "countIf(NOT (%s))" % terms
+
+
 def bucket_query(days: int = BASELINE_DAYS, bucket_seconds: int = BUCKET_SECONDS,
-                 database: str = "activity", table: str = "events") -> str:
+                 database: str = "activity", table: str = "events",
+                 cadence=MACHINE_CADENCE) -> str:
     """The ONE query the check runs: per host/source/bucket event counts.
 
     Deliberately a plain GROUP BY rather than a window function -- all of the
     gap/percentile work happens in `evaluate`, which is pure and therefore
     testable against a fixture with no ClickHouse anywhere near it.
+
+    FIVE columns, and the fifth is the whole point: `n` counts everything the
+    pair emitted (so a heartbeat still proves ITS source alive), while `n_op`
+    counts only operator-driven events (so a heartbeat does NOT mark the bucket
+    as operator-active for every other source on the host). See MACHINE_CADENCE.
     """
     return (
         "SELECT host, source, "
         "toUnixTimestamp(toStartOfInterval(ts, INTERVAL %d SECOND)) AS b, "
-        "count() AS n "
+        "count() AS n, %s AS n_op "
         "FROM %s.%s WHERE ts > now() - INTERVAL %d DAY "
         "GROUP BY host, source, b ORDER BY host, source, b FORMAT TSV"
-        % (int(bucket_seconds), database, table, int(days))
+        % (int(bucket_seconds), _operator_count_expr(cadence), database, table,
+           int(days))
     )
 
 
 def parse_buckets(text: str):
-    """TSV -> [(host, source, bucket_epoch, n)]. Raises ValueError on junk.
+    """TSV -> [(host, source, bucket_epoch, n, n_op)]. Raises ValueError on junk.
 
-    Strict on purpose. Silently dropping unparseable lines would let a changed
-    output format read as "fewer rows" and, at the limit, as "no staleness" --
-    the exact way a parsed-output harness lies (RULES.md: a tool's output format
-    is a dependency you did not pin).
+    Accepts BOTH widths, and the width is decided by the FIRST non-empty line and
+    then enforced for the whole file:
+      5 fields  the current query (n_op = operator-driven events in the bucket)
+      4 fields  a pre-heartbeat capture or hand-written fixture -> n_op = n,
+                which is exactly right for a table in which nothing emitted on a
+                timer.
+    A file may not MIX the two: a width that changes mid-file is a format change
+    or a corrupted capture, and inferring per-line would be the silent-drop
+    failure this parser exists to avoid.
+
+    Strict on purpose otherwise. Silently dropping unparseable lines would let a
+    changed output format read as "fewer rows" and, at the limit, as "no
+    staleness" -- the exact way a parsed-output harness lies (RULES.md: a tool's
+    output format is a dependency you did not pin).
     """
     rows = []
+    width = None
     for lineno, line in enumerate(text.splitlines(), 1):
         if not line.strip():
             continue
         parts = line.split("\t")
-        if len(parts) != 4:
-            raise ValueError("line %d: expected 4 tab-separated fields, got %d"
-                             % (lineno, len(parts)))
-        host, source, b, n = parts
+        if width is None:
+            if len(parts) not in (4, 5):
+                raise ValueError("line %d: expected 4 or 5 tab-separated fields, "
+                                 "got %d" % (lineno, len(parts)))
+            width = len(parts)
+        elif len(parts) != width:
+            raise ValueError("line %d: field count changed mid-file (%d, expected "
+                             "%d) — refusing to guess" % (lineno, len(parts), width))
+        host, source, b, n = parts[:4]
+        n_op = parts[4] if width == 5 else n
         try:
-            rows.append((host, source, int(b), int(n)))
+            rows.append((host, source, int(b), int(n), int(n_op)))
         except ValueError:
             raise ValueError("line %d: non-integer bucket/count: %r" % (lineno, line))
     return rows
@@ -253,13 +322,25 @@ def evaluate(rows, now=None, *, bucket_seconds: int = BUCKET_SECONDS,
                 "newest_event_age_minutes": None,
                 "detail": "query returned no rows — cannot tell"}
 
+    # ACTIVE time is OPERATOR time. A bucket joins the host's active set only if
+    # something the operator drove landed in it -- a machine-cadence emitter
+    # (MACHINE_CADENCE) proves its own source alive and nothing more. Without
+    # this split, one 24/7 emitter makes every idle source on the host accrue
+    # active silence overnight and read DEAD; see MACHINE_CADENCE for the
+    # measurement.
+    #
+    # A 4-tuple row (no operator count) is treated as all-operator: that is the
+    # pre-heartbeat table and every hand-built fixture, where it is correct.
     active_by_host = collections.defaultdict(set)
     buckets_by_pair = collections.defaultdict(set)
-    for host, src, b, _n in rows:
-        active_by_host[host].add(b)
+    for row in rows:
+        host, src, b, n = row[0], row[1], row[2], row[3]
+        n_op = row[4] if len(row) > 4 else n
         buckets_by_pair[(host, src)].add(b)
+        if n_op > 0:
+            active_by_host[host].add(b)
 
-    newest = max(b for _h, _s, b, _n in rows)
+    newest = max(r[2] for r in rows)
 
     sources = []
     for (host, src), bset in sorted(buckets_by_pair.items()):

--- a/scripts/collector/tests/test_deadman.py
+++ b/scripts/collector/tests/test_deadman.py
@@ -651,6 +651,19 @@ def test_operator_count_expression_matches_the_cadence_table():
     q2 = D.bucket_query(cadence=(("a", "beat"), ("b", "tick")))
     assert "(source = 'a' AND kind = 'beat') OR (source = 'b' AND kind = 'tick')" in q2, q2
     assert " AND (source = 'b'" not in q2, "cadence terms joined with AND: %s" % q2
+
+
+def test_cadence_predicate_is_exported_for_the_other_consumer():
+    """`cadence_predicate_sql` is PUBLIC on purpose: scripts/agent-ops renders the
+    same predicate for its freshness panel and imports this rather than
+    re-spelling it. A local copy there was immediately wrong in the same way
+    (AND-joined), so this pins the contract that consumer depends on."""
+    assert D.cadence_predicate_sql(()) == ""
+    one = D.cadence_predicate_sql((("x", "beat"),))
+    assert one == "(source = 'x' AND kind = 'beat')", one
+    two = D.cadence_predicate_sql((("x", "beat"), ("y", "tick")))
+    assert two == ("(source = 'x' AND kind = 'beat') OR "
+                   "(source = 'y' AND kind = 'tick')"), two
     # Empty cadence degrades to the pre-heartbeat query, which is the right
     # answer when nothing emits on a timer.
     assert "count() AS n_op" in D.bucket_query(cadence=())

--- a/scripts/collector/tests/test_deadman.py
+++ b/scripts/collector/tests/test_deadman.py
@@ -12,6 +12,7 @@ path. A harness that could only ever produce 0 would fail those tests.
 Run: pytest scripts/collector/tests/test_deadman.py
 """
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -608,12 +609,48 @@ def test_the_operator_column_survives_the_WHOLE_path_tsv_to_verdict():
     assert _pair(v, "browser-bridge")["evaluated"] is True
 
 
+def test_the_query_check_ACTUALLY_SENDS_carries_the_operator_column():
+    """🔴 The production path. Every other `check()` test injects a fake fetch
+    that IGNORES its query argument, so nothing asserted what SQL the live check
+    sends — and `bucket_query(..., cadence=())` at the call site would produce a
+    5-wide TSV with n_op == n, i.e. the original bug, on the only path
+    bar-status-poll ever uses, with the suite green.
+    """
+    seen = {}
+
+    def fake_fetch(url, user, password, query, timeout):
+        seen["query"] = query
+        return "h1\tkeys\t100\t3\t3\n"
+
+    D.check(env={"CLICKHOUSE_URL": "http://x", "CLICKHOUSE_USER": "u",
+                 "CLICKHOUSE_PASSWORD": "p"},
+            env_file="/nonexistent", fetch=fake_fetch)
+    q = seen.get("query", "")
+    # 🔴 The countIf must be the expression aliased AS n_op, not merely PRESENT
+    # somewhere in the query. A substring check for "AS n_op" is satisfied by
+    # "AS n_op_unused" — a mutant that aliased the filtered count aside and put a
+    # raw count() in the n_op position passed exactly that check.
+    assert re.search(r"countIf\(NOT \(.+?\)\) AS n_op(?!\w)", q), \
+        ("check() did not send the machine-cadence filter as the n_op column — "
+         "cadence rows would count as operator activity: %r" % q)
+    for src, kind in D.MACHINE_CADENCE:
+        assert "source = '%s' AND kind = '%s'" % (src, kind) in q, q
+
+
 def test_operator_count_expression_matches_the_cadence_table():
     """The SQL and the Python must not drift: the query's countIf is BUILT from
     MACHINE_CADENCE, so a pair added to the tuple appears in the SQL."""
     q = D.bucket_query(cadence=(("browser-bridge", "heartbeat"),))
     assert "countIf(NOT ((source = 'browser-bridge' AND kind = 'heartbeat')))" in q
     assert "AS n_op" in q
+
+    # 🔴 TWO entries, because the module's own note tells maintainers to add
+    # them: the terms must be OR-joined. With AND, `countIf(NOT (A AND B))`
+    # excludes NOTHING (measured against the live table: 206760 of 206760 rows
+    # counted), so a second cadence emitter would silently reinstate the bug.
+    q2 = D.bucket_query(cadence=(("a", "beat"), ("b", "tick")))
+    assert "(source = 'a' AND kind = 'beat') OR (source = 'b' AND kind = 'tick')" in q2, q2
+    assert " AND (source = 'b'" not in q2, "cadence terms joined with AND: %s" % q2
     # Empty cadence degrades to the pre-heartbeat query, which is the right
     # answer when nothing emits on a timer.
     assert "count() AS n_op" in D.bucket_query(cadence=())

--- a/scripts/collector/tests/test_deadman.py
+++ b/scripts/collector/tests/test_deadman.py
@@ -662,7 +662,8 @@ def test_operator_count_expression_matches_the_cadence_table():
     # survived this file until this assertion existed; it died only in the
     # browser-bridge suite, which is not where a deadman reader would look).
     #
-    # 🔴 THESE THREE ASSERTIONS BELONG TO *THIS* TEST. A later insertion once
+    # 🔴 THE MOVED BLOCK (the empty-cadence assert above, plus the two below)
+    # BELONGS TO *THIS* TEST. A later insertion once
     # landed inside this function and carried them into the next one, so the
     # guard above lived under a test named for something else — and deleting that
     # other test would have silently deleted this guard.

--- a/scripts/collector/tests/test_deadman.py
+++ b/scripts/collector/tests/test_deadman.py
@@ -86,12 +86,37 @@ def test_budget_is_capped():
 # parse_buckets — strict on purpose
 # --------------------------------------------------------------------------- #
 def test_parse_buckets_happy():
-    rows = D.parse_buckets("h1\tkeys\t100\t3\nh1\ti3\t100\t1\n")
-    assert rows == [("h1", "keys", 100, 3), ("h1", "i3", 100, 1)]
+    """5 fields: the current query. The 5th is the OPERATOR-driven count.
+
+    🔴 Every number here is DISTINCT on purpose. An earlier version used n == n_op
+    (3, 3), which made "carry the operator column" and "ignore it and reuse n"
+    byte-identical — a mutant that dropped the 5th field survived the whole
+    suite. A fixture of equal values cannot tell two implementations apart.
+    """
+    rows = D.parse_buckets("h1\tkeys\t100\t7\t5\nh1\ti3\t200\t3\t0\n")
+    assert rows == [("h1", "keys", 100, 7, 5), ("h1", "i3", 200, 3, 0)]
+    assert rows[1][4] == 0 and rows[1][3] == 3, \
+        "the operator count must survive the parse independently of the total"
+
+
+def test_parse_buckets_accepts_a_legacy_four_field_capture():
+    """A pre-heartbeat capture (or a hand-written fixture) has no operator column.
+    Treating it as all-operator is exactly right for a table in which nothing
+    emitted on a timer — and it keeps old captures replayable through --tsv."""
+    rows = D.parse_buckets("h1\tkeys\t100\t3\n")
+    assert rows == [("h1", "keys", 100, 3, 3)]
+
+
+def test_parse_buckets_rejects_a_width_that_changes_mid_file():
+    """Inferring per-line would be the silent-drop failure this parser exists to
+    prevent: a truncated or concatenated capture would parse as 'fewer events'
+    and decay into 'no staleness'."""
+    with pytest.raises(ValueError):
+        D.parse_buckets("h1\tkeys\t100\t3\t3\nh1\ti3\t100\t1\n")
 
 
 def test_parse_buckets_skips_blank_lines():
-    assert D.parse_buckets("\n\nh1\tkeys\t100\t3\n\n") == [("h1", "keys", 100, 3)]
+    assert D.parse_buckets("\n\nh1\tkeys\t100\t3\t3\n\n") == [("h1", "keys", 100, 3, 3)]
 
 
 def test_parse_buckets_rejects_wrong_field_count():
@@ -99,6 +124,8 @@ def test_parse_buckets_rejects_wrong_field_count():
     # decaying into "no staleness".
     with pytest.raises(ValueError):
         D.parse_buckets("h1\tkeys\t100\n")
+    with pytest.raises(ValueError):
+        D.parse_buckets("h1\tkeys\t100\t3\t3\t9\n")
 
 
 def test_parse_buckets_rejects_non_integer():
@@ -409,6 +436,37 @@ def test_cli_text_render_shows_the_table(tmp_path):
 # tested there; this is the other half of that seam.
 # --------------------------------------------------------------------------- #
 HEARTBEAT_STEP = 3  # 900s / BUCKET_SECONDS -- one heartbeat every 3 buckets
+# The interval<->bucket relationship this number encodes is pinned against the
+# emitter's real constant in scripts/browser-bridge/tests/test_server.py
+# (test_heartbeat_interval_keeps_the_deadman_budget_on_the_floor), so this stays
+# a readable fixture constant instead of a second, silently-drifting definition.
+
+
+def workday_table(now_bucket, days=6, awake_h=10):
+    """A REALISTIC host: `awake_h` hours of operator activity per day, then idle.
+
+    🔴 This fixture exists because `healthy_table` has NO idle time, and a
+    fixture with no idle time is structurally blind to every bug about what
+    counts as active time — which is precisely the bug that shipped in the first
+    version of the heartbeat (see MACHINE_CADENCE in deadman.py). Any test about
+    machine-cadence emitters must use THIS one.
+    """
+    rows = []
+    per_day = 24 * 3600 // B
+    awake = awake_h * 3600 // B
+    day0 = now_bucket - (days - 1) * per_day * B
+    for d in range(days):
+        start = day0 + d * per_day * B
+        rows += contiguous("h1", "keys", start, awake)
+        rows += contiguous("h1", "i3", start, awake)
+    return rows
+
+
+def cadence_rows(host, source, start, end, step=HEARTBEAT_STEP):
+    """A machine-cadence emitter ticking from `start` to `end` regardless of
+    whether anyone is at the desk. n=1, n_op=0 — the shape the real query emits
+    for a MACHINE_CADENCE pair."""
+    return [(host, source, b, 1, 0) for b in range(start, end + 1, step * B)]
 
 
 def _pair(verdict, source, host="h1"):
@@ -460,6 +518,115 @@ def test_heartbeat_cadence_collapses_the_budget_to_the_floor():
     assert rec["budget_buckets"] == D.FLOOR_BUCKETS, rec
     assert rec["budget_active_hours"] == 2.0, rec
     assert rec["dead"] is False, "a beating heartbeat must never read as dead"
+
+
+def test_a_machine_cadence_source_does_not_make_idle_sources_look_dead():
+    """🔴 THE REGRESSION TEST for the flaw the first version of this change had.
+
+    A 24/7 emitter must not convert the operator's night into ACTIVE time. When
+    it did, six real pairs flipped to DEAD in a sweep over live data — including
+    a 20-hour continuous false DEAD on workbench/keys across a Saturday the
+    operator was away.
+
+    Evaluated at 06:00 — eight hours into an idle stretch — which is exactly the
+    moment the 45-second bar poller would ask, and exactly the moment the broken
+    version cried wolf.
+    """
+    rows = workday_table(NOW_BUCKET, days=6, awake_h=10)
+    last_awake = max(b for (_h, s, b, *_r) in rows if s == "keys")
+    now = last_awake + 8 * 3600            # 8 idle hours later
+    rows += cadence_rows("h1", "browser-bridge",
+                         min(b for (_h, _s, b, *_r) in rows), now)
+
+    v = D.evaluate(rows, now=now + 60)
+    dead = sorted("%s/%s" % (s["host"], s["source"]) for s in v["dead"])
+    assert dead == [], (
+        "a machine-cadence emitter made idle operator sources read DEAD: %s"
+        % dead)
+
+    # ... and the negative control: the SAME table with the heartbeat counted as
+    # operator activity (n_op=1) is how the bug manifests. If this stops failing,
+    # the assertion above has stopped meaning anything.
+    as_operator = [r for r in rows if r[1] != "browser-bridge"]
+    as_operator += [(r[0], r[1], r[2], r[3], 1) for r in rows
+                    if r[1] == "browser-bridge"]
+    v_bad = D.evaluate(as_operator, now=now + 60)
+    assert v_bad["count"] > 0, \
+        ("the control did not reproduce the bug — this fixture can no longer "
+         "distinguish the fix from its absence")
+
+
+def test_a_cadence_source_is_still_judged_on_its_own_liveness():
+    """Excluding heartbeats from ACTIVE time must not exclude them from the
+    source's OWN liveness — otherwise the fix for finding #1 would silently undo
+    the fix this whole change exists for."""
+    rows = workday_table(NOW_BUCKET, days=6, awake_h=10)
+    lo = min(b for (_h, _s, b, *_r) in rows)
+    last_awake = max(b for (_h, s, b, *_r) in rows if s == "keys")
+
+    alive = rows + cadence_rows("h1", "browser-bridge", lo, last_awake)
+    rec = _pair(D.evaluate(alive, now=last_awake + 60), "browser-bridge")
+    assert rec["evaluated"] is True, rec
+    assert rec["budget_buckets"] == D.FLOOR_BUCKETS, rec
+    assert rec["dead"] is False, rec
+
+    # Stopped one full workday earlier -> more than FLOOR_BUCKETS of OPERATOR
+    # time has passed since, so it must alarm.
+    stopped = rows + cadence_rows("h1", "browser-bridge", lo,
+                                  last_awake - 6 * 3600)
+    rec2 = _pair(D.evaluate(stopped, now=last_awake + 60), "browser-bridge")
+    assert rec2["dead"] is True, rec2
+
+
+def test_the_operator_column_survives_the_WHOLE_path_tsv_to_verdict():
+    """🔴 END-TO-END across the parse boundary, because every other test in this
+    section hands `evaluate` ready-made tuples and therefore cannot see the parser
+    throwing the operator count away.
+
+    That gap was real: a mutant making parse_buckets reuse `n` for `n_op` — which
+    reinstates the original bug on live data, since the check only ever reads the
+    table through this function — survived the entire 360-test suite.
+    """
+    rows = workday_table(NOW_BUCKET, days=6, awake_h=10)
+    last_awake = max(b for (_h, s, b, *_r) in rows if s == "keys")
+    now = last_awake + 8 * 3600
+    cadence = cadence_rows("h1", "browser-bridge",
+                           min(b for (_h, _s, b, *_r) in rows), now)
+
+    # Serialise to the EXACT 5-column TSV the query emits, then read it back the
+    # only way the live check ever does.
+    tsv = "".join("h1\t%s\t%d\t%d\t%d\n" % (r[1], r[2], r[3], 1) for r in rows)
+    tsv += "".join("h1\t%s\t%d\t%d\t%d\n" % (r[1], r[2], r[3], 0) for r in cadence)
+
+    parsed = D.parse_buckets(tsv)
+    assert any(r[1] == "browser-bridge" and r[4] == 0 for r in parsed), \
+        "the parser dropped the operator column"
+
+    v = D.evaluate(parsed, now=now + 60)
+    dead = sorted("%s/%s" % (s["host"], s["source"]) for s in v["dead"])
+    assert dead == [], "idle sources read DEAD after a round-trip through the parser: %s" % dead
+    assert _pair(v, "browser-bridge")["evaluated"] is True
+
+
+def test_operator_count_expression_matches_the_cadence_table():
+    """The SQL and the Python must not drift: the query's countIf is BUILT from
+    MACHINE_CADENCE, so a pair added to the tuple appears in the SQL."""
+    q = D.bucket_query(cadence=(("browser-bridge", "heartbeat"),))
+    assert "countIf(NOT ((source = 'browser-bridge' AND kind = 'heartbeat')))" in q
+    assert "AS n_op" in q
+    # Empty cadence degrades to the pre-heartbeat query, which is the right
+    # answer when nothing emits on a timer.
+    assert "count() AS n_op" in D.bucket_query(cadence=())
+
+    # 🔴 The live table must NOT be empty, asserted before the loop below — an
+    # emptied MACHINE_CADENCE makes that loop iterate zero times and pass, and it
+    # is exactly the edit that reinstates the bug (a mutant emptying the tuple
+    # survived this file until this assertion existed; it died only in the
+    # browser-bridge suite, which is not where a deadman reader would look).
+    assert ("browser-bridge", "heartbeat") in D.MACHINE_CADENCE, \
+        "the browser-bridge heartbeat is no longer declared machine-cadence"
+    for src, kind in D.MACHINE_CADENCE:
+        assert src in D.bucket_query() and kind in D.bucket_query()
 
 
 def test_a_stopped_heartbeat_is_dead_within_the_floor():

--- a/scripts/collector/tests/test_deadman.py
+++ b/scripts/collector/tests/test_deadman.py
@@ -390,3 +390,91 @@ def test_cli_text_render_shows_the_table(tmp_path):
     p = _run_cli(["--tsv", str(tsv), "--now", str(NOW_BUCKET + 60)])
     assert "budget_h" in p.stdout
     assert "keys" in p.stdout
+
+
+# --------------------------------------------------------------------------- #
+# The heartbeat contract — why browser-bridge grew a cadence
+#
+# An on-demand source (browser-bridge, tool) emits only when an agent drives it,
+# so its normal silence is UNBOUNDED and no measured budget can separate "unused"
+# from "down". Measured 2026-08-11: laptop/browser-bridge was silent 30.9 ACTIVE
+# hours -- 2.2x the worst lull in its own 14-day history, and 2x what even a
+# K=4 budget would have allowed -- purely because nobody had run a browser task.
+# Raising the budget could not fix that; giving the source a CADENCE could.
+#
+# These two tests pin the before/after as DATA, so the claim "a 15-minute
+# heartbeat collapses the budget onto the 2-active-hour floor" is checked rather
+# than asserted in a commit message. The heartbeat emitter itself lives in
+# scripts/browser-bridge/server.py (run_heartbeat / HEARTBEAT_INTERVAL_S) and is
+# tested there; this is the other half of that seam.
+# --------------------------------------------------------------------------- #
+HEARTBEAT_STEP = 3  # 900s / BUCKET_SECONDS -- one heartbeat every 3 buckets
+
+
+def _pair(verdict, source, host="h1"):
+    recs = [s for s in verdict["sources"]
+            if s["source"] == source and s["host"] == host]
+    assert recs, "pair %s/%s missing from the verdict" % (host, source)
+    return recs[0]
+
+
+def test_command_only_source_earns_an_unbounded_budget():
+    """THE BEFORE CASE (the negative control for the fix): a source that emits in
+    rare bursts gets a budget so wide it cannot mean anything.
+
+    This is the shape browser-bridge had. The test asserts the PROBLEM exists, so
+    that the after-case below is a measured contrast and not a lone green."""
+    n = 400
+    start = NOW_BUCKET - (n - 1) * B
+    rows = healthy_table(NOW_BUCKET, n)
+    # Five short bursts separated by long idle stretches. Five (not three) so the
+    # pair clears MIN_BASELINE_BUCKETS and is actually JUDGED — at 15 buckets it
+    # is skipped as insufficient-baseline and the test proves nothing.
+    for offset in (0, 90, 180, 270, 350):
+        rows += contiguous("h1", "bursty", start + offset * B, 5)
+    assert 5 * 5 >= D.MIN_BASELINE_BUCKETS, "fixture no longer clears the baseline"
+    v = D.evaluate(rows, now=NOW_BUCKET + 60)
+    rec = _pair(v, "bursty")
+    assert rec["evaluated"] is True
+    assert rec["budget_active_hours"] > 8.0, \
+        ("a burst-only source should earn a budget far above the floor — got "
+         "%r; if this ever drops, the after-case below proves nothing"
+         % rec["budget_active_hours"])
+
+
+def test_heartbeat_cadence_collapses_the_budget_to_the_floor():
+    """THE AFTER CASE: the same source emitting every 3rd bucket (900s) has a p99
+    active-gap of ~3 buckets, so its budget bottoms out on FLOOR_BUCKETS.
+
+    That is the whole point of the heartbeat: at a 2-ACTIVE-HOUR budget, silence
+    means the unit is not running, and no amount of not-using-the-browser can
+    manufacture it."""
+    n = 400
+    start = NOW_BUCKET - (n - 1) * B
+    rows = healthy_table(NOW_BUCKET, n)
+    rows += contiguous("h1", "browser-bridge", start, n // HEARTBEAT_STEP,
+                       step=HEARTBEAT_STEP)
+    v = D.evaluate(rows, now=NOW_BUCKET + 60)
+    rec = _pair(v, "browser-bridge")
+    assert rec["evaluated"] is True
+    assert rec["budget_buckets"] == D.FLOOR_BUCKETS, rec
+    assert rec["budget_active_hours"] == 2.0, rec
+    assert rec["dead"] is False, "a beating heartbeat must never read as dead"
+
+
+def test_a_stopped_heartbeat_is_dead_within_the_floor():
+    """The positive control for the pair above: the SAME cadenced source, stopped
+    just over the floor, must flip to DEAD through the same code path.
+
+    Without this, the green above is indistinguishable from a check that can only
+    ever say 'ok'."""
+    n = 400
+    start = NOW_BUCKET - (n - 1) * B
+    stopped_at = n - (D.FLOOR_BUCKETS + 5)   # silent for floor+5 active buckets
+    rows = healthy_table(NOW_BUCKET, n)
+    rows += contiguous("h1", "browser-bridge", start,
+                       stopped_at // HEARTBEAT_STEP, step=HEARTBEAT_STEP)
+    v = D.evaluate(rows, now=NOW_BUCKET + 60)
+    rec = _pair(v, "browser-bridge")
+    assert rec["dead"] is True, rec
+    assert v["count"] == 1 and v["state"] == D.STATE_OK, v

--- a/scripts/collector/tests/test_deadman.py
+++ b/scripts/collector/tests/test_deadman.py
@@ -652,6 +652,25 @@ def test_operator_count_expression_matches_the_cadence_table():
     assert "(source = 'a' AND kind = 'beat') OR (source = 'b' AND kind = 'tick')" in q2, q2
     assert " AND (source = 'b'" not in q2, "cadence terms joined with AND: %s" % q2
 
+    # Empty cadence degrades to the pre-heartbeat query, which is the right
+    # answer when nothing emits on a timer.
+    assert "count() AS n_op" in D.bucket_query(cadence=())
+
+    # 🔴 The live table must NOT be empty, asserted before the loop below — an
+    # emptied MACHINE_CADENCE makes that loop iterate zero times and pass, and it
+    # is exactly the edit that reinstates the bug (a mutant emptying the tuple
+    # survived this file until this assertion existed; it died only in the
+    # browser-bridge suite, which is not where a deadman reader would look).
+    #
+    # 🔴 THESE THREE ASSERTIONS BELONG TO *THIS* TEST. A later insertion once
+    # landed inside this function and carried them into the next one, so the
+    # guard above lived under a test named for something else — and deleting that
+    # other test would have silently deleted this guard.
+    assert ("browser-bridge", "heartbeat") in D.MACHINE_CADENCE, \
+        "the browser-bridge heartbeat is no longer declared machine-cadence"
+    for src, kind in D.MACHINE_CADENCE:
+        assert src in D.bucket_query() and kind in D.bucket_query()
+
 
 def test_cadence_predicate_is_exported_for_the_other_consumer():
     """`cadence_predicate_sql` is PUBLIC on purpose: scripts/agent-ops renders the
@@ -664,19 +683,10 @@ def test_cadence_predicate_is_exported_for_the_other_consumer():
     two = D.cadence_predicate_sql((("x", "beat"), ("y", "tick")))
     assert two == ("(source = 'x' AND kind = 'beat') OR "
                    "(source = 'y' AND kind = 'tick')"), two
-    # Empty cadence degrades to the pre-heartbeat query, which is the right
-    # answer when nothing emits on a timer.
-    assert "count() AS n_op" in D.bucket_query(cadence=())
-
-    # 🔴 The live table must NOT be empty, asserted before the loop below — an
-    # emptied MACHINE_CADENCE makes that loop iterate zero times and pass, and it
-    # is exactly the edit that reinstates the bug (a mutant emptying the tuple
-    # survived this file until this assertion existed; it died only in the
-    # browser-bridge suite, which is not where a deadman reader would look).
-    assert ("browser-bridge", "heartbeat") in D.MACHINE_CADENCE, \
-        "the browser-bridge heartbeat is no longer declared machine-cadence"
-    for src, kind in D.MACHINE_CADENCE:
-        assert src in D.bucket_query() and kind in D.bucket_query()
+    # The DEFAULT argument is what a future consumer will reach for, and no
+    # caller exercises it today (a mutant defaulting it to () survived).
+    assert D.cadence_predicate_sql() == D.cadence_predicate_sql(D.MACHINE_CADENCE)
+    assert D.cadence_predicate_sql() != ""
 
 
 def test_a_stopped_heartbeat_is_dead_within_the_floor():

--- a/scripts/tests/test_agent_ops.py
+++ b/scripts/tests/test_agent_ops.py
@@ -740,15 +740,20 @@ def test_telemetry_freshness_excludes_machine_cadence_rows():
         ao.DEADMAN_PATH = orig_path
 
     assert out == {"zsh": 7}, out
-    # 🔴 Assert the SQL's SHAPE, not just that the clause appears somewhere in
-    # it. A substring check passes for a mangled concatenation
-    # ("INTERVAL 2 DAYAND NOT (...)") and for a clause placed after GROUP BY —
-    # both invalid ClickHouse, and both survived a suite that only checked
-    # presence.
+    # 🔴 SHAPE **AND** CONTENT, in one assertion. Each alone has a blind spot,
+    # and picking one is not a trade — it is a hole:
+    #   * presence-only (`clause in sql`) passes for a mangled concatenation
+    #     ("INTERVAL 2 DAYAND NOT (...)") or a clause placed after GROUP BY,
+    #     both invalid ClickHouse;
+    #   * shape-only (`AND NOT \(.+?\)`) accepts ANY predicate body, so a call
+    #     site excluding the WRONG pair — say zsh/cmd, which would delete real
+    #     operator activity from this panel — passes.
+    # Interpolating the helper's real output binds the emitted SQL to it.
     assert re.search(
-        r"INTERVAL 2 DAY AND NOT \(.+?\) GROUP BY source ORDER BY source$",
-        sent["sql"]), \
-        "the exclusion is missing or misplaced in the emitted SQL: %s" % sent["sql"]
+        r"INTERVAL 2 DAY " + re.escape(clause.strip())
+        + r" GROUP BY source ORDER BY source$", sent["sql"]), \
+        ("the exclusion is missing, misplaced, or excludes a different pair than "
+         "the helper produced: %s" % sent["sql"])
 
 
 def test_machine_cadence_filter_renders_multiple_pairs_with_OR():
@@ -784,8 +789,12 @@ def test_deadman_path_points_at_the_real_sibling():
     the sandbox — so a wrong path would mean a permanent error marker on the
     telemetry panel with nothing to catch it. Unlike CHQUERY_PATH, this one is
     not pre-flighted in maybe_refresh_telemetry."""
-    assert ao.DEADMAN_PATH.endswith(
-        os.path.join("scripts", "collector", "deadman.py")), ao.DEADMAN_PATH
+    # The ROOT as well as the tail: an endswith() check passes for
+    # "/nonexistent/scripts/collector/deadman.py". DEVRC_DIR is the module's own
+    # notion of the checkout, so pinning the full join catches a repoint without
+    # needing the path to exist (it does not, in the check sandbox).
+    assert ao.DEADMAN_PATH == os.path.join(
+        ao.DEVRC_DIR, "scripts", "collector", "deadman.py"), ao.DEADMAN_PATH
     assert os.path.exists(os.path.join(_HERE, "..", "collector", "deadman.py")), \
         "deadman.py is not where DEADMAN_PATH expects it relative to this repo"
 

--- a/scripts/tests/test_agent_ops.py
+++ b/scripts/tests/test_agent_ops.py
@@ -666,6 +666,85 @@ def test_render_telemetry_line_missing_source_shown_dim():
     assert "zsh" in line and "tmux" in line
 
 
+def test_telemetry_freshness_excludes_machine_cadence_rows():
+    """🔴 SEAM GUARD — this panel's freshness vs deadman's MACHINE_CADENCE.
+
+    browser-bridge emits a heartbeat every 900s whether or not it can execute
+    anything, so an unfiltered `max(ts)` reports a bridge with no extension
+    attached as "fresh 15 min ago". Deleting the exclusion from the SQL used to
+    survive the whole suite — nothing here ever read that query.
+
+    The predicate is IMPORTED from deadman rather than re-spelled, so this
+    asserts the relationship against the real tuple: every declared pair must
+    appear in the emitted clause, and an empty tuple must emit nothing (there is
+    then nothing to exclude).
+    """
+    # agent-ops resolves its siblings through DEVRC_DIR (HOME-based) — the right
+    # thing in production, where the deployed script must read the real checkout,
+    # and the same convention CHQUERY_PATH already uses. The nix check sandbox
+    # has no $HOME/workspace/devrc, so point it at THIS tree's copy for the test
+    # rather than changing how production resolves paths.
+    dm_py = os.path.join(_HERE, "..", "collector", "deadman.py")
+    spec = importlib.util.spec_from_file_location("_dm_seam", dm_py)
+    DM = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(DM)
+
+    orig_path = ao.DEADMAN_PATH
+    try:
+        ao.DEADMAN_PATH = dm_py
+        clause = ao.machine_cadence_sql_filter()
+    finally:
+        ao.DEADMAN_PATH = orig_path
+    assert DM.MACHINE_CADENCE, "deadman declares no machine-cadence pairs"
+    assert clause.startswith("AND NOT ("), clause
+    for src, kind in DM.MACHINE_CADENCE:
+        assert "source = '%s' AND kind = '%s'" % (src, kind) in clause, clause
+    # ... and it is genuinely derived, not a constant that happens to match.
+    assert "heartbeat" in clause
+
+    # 🔴 AND THE CALL SITE USES IT. Asserting the helper alone is not enough:
+    # dropping `machine_cadence_sql_filter()` from the SQL survived a suite that
+    # had this test in it, because nothing here read the query the function
+    # actually builds. Drive the real function with a stubbed chquery and read
+    # the SQL it sends.
+    sent = {}
+
+    class _FakeConn:
+        fq_table = "activity.events"
+        timeout = 1.0
+
+        @staticmethod
+        def from_env(_env):
+            return _FakeConn()
+
+    class _FakeClient:
+        def __init__(self, _conn):
+            pass
+
+        @staticmethod
+        def rows(sql):
+            sent["sql"] = sql
+            return [{"source": "zsh", "age_secs": 7}]
+
+    class _FakeQ:
+        CHConn = _FakeConn
+        CHClient = _FakeClient
+
+    orig = ao._load_chquery
+    try:
+        ao._load_chquery = lambda: _FakeQ
+        ao.DEADMAN_PATH = dm_py          # same sandbox reason as above
+        out = ao.query_telemetry_freshness()
+    finally:
+        ao._load_chquery = orig
+        ao.DEADMAN_PATH = orig_path
+
+    assert out == {"zsh": 7}, out
+    assert clause.strip() and clause.strip() in sent["sql"], (
+        "query_telemetry_freshness dropped the machine-cadence exclusion: %s"
+        % sent["sql"])
+
+
 def test_render_telemetry_line_no_rows():
     line = plain(ao._render_telemetry_line({"sources": {}, "generated": 0}))
     assert "telemetry off" in line or "no rows" in line

--- a/scripts/tests/test_agent_ops.py
+++ b/scripts/tests/test_agent_ops.py
@@ -740,9 +740,54 @@ def test_telemetry_freshness_excludes_machine_cadence_rows():
         ao.DEADMAN_PATH = orig_path
 
     assert out == {"zsh": 7}, out
-    assert clause.strip() and clause.strip() in sent["sql"], (
-        "query_telemetry_freshness dropped the machine-cadence exclusion: %s"
-        % sent["sql"])
+    # 🔴 Assert the SQL's SHAPE, not just that the clause appears somewhere in
+    # it. A substring check passes for a mangled concatenation
+    # ("INTERVAL 2 DAYAND NOT (...)") and for a clause placed after GROUP BY —
+    # both invalid ClickHouse, and both survived a suite that only checked
+    # presence.
+    assert re.search(
+        r"INTERVAL 2 DAY AND NOT \(.+?\) GROUP BY source ORDER BY source$",
+        sent["sql"]), \
+        "the exclusion is missing or misplaced in the emitted SQL: %s" % sent["sql"]
+
+
+def test_machine_cadence_filter_renders_multiple_pairs_with_OR():
+    """🔴 `NOT (A AND B)` excludes NOTHING, so an AND-joined predicate silently
+    reverts this panel to reporting a dead bridge as fresh. Only reachable once a
+    SECOND timer-driven emitter exists — which deadman's own note invites — so it
+    must be pinned before that day, not after.
+
+    The rendering now lives in deadman.cadence_predicate_sql and is merely
+    wrapped here; this asserts the wrapper passes a multi-pair set through
+    faithfully.
+    """
+    dm_py = os.path.join(_HERE, "..", "collector", "deadman.py")
+    orig = ao.DEADMAN_PATH
+    try:
+        ao.DEADMAN_PATH = dm_py
+        two = ao.machine_cadence_sql_filter(
+            cadence=(("a", "beat"), ("b", "tick")))
+        empty = ao.machine_cadence_sql_filter(cadence=())
+    finally:
+        ao.DEADMAN_PATH = orig
+
+    assert "(source = 'a' AND kind = 'beat') OR (source = 'b' AND kind = 'tick')" in two, two
+    assert " AND (source = 'b'" not in two, "cadence terms joined with AND: %s" % two
+    # Empty set -> no clause at all, which must still leave valid SQL at the call
+    # site (this branch is otherwise unreachable while MACHINE_CADENCE is
+    # non-empty, so a mutant emitting "AND NOT () " survived without it).
+    assert empty == "", repr(empty)
+
+
+def test_deadman_path_points_at_the_real_sibling():
+    """🟢 The constant itself is never exercised — the seam tests override it for
+    the sandbox — so a wrong path would mean a permanent error marker on the
+    telemetry panel with nothing to catch it. Unlike CHQUERY_PATH, this one is
+    not pre-flighted in maybe_refresh_telemetry."""
+    assert ao.DEADMAN_PATH.endswith(
+        os.path.join("scripts", "collector", "deadman.py")), ao.DEADMAN_PATH
+    assert os.path.exists(os.path.join(_HERE, "..", "collector", "deadman.py")), \
+        "deadman.py is not where DEADMAN_PATH expects it relative to this repo"
 
 
 def test_render_telemetry_line_no_rows():

--- a/scripts/tests/test_agent_ops.py
+++ b/scripts/tests/test_agent_ops.py
@@ -701,6 +701,15 @@ def test_telemetry_freshness_excludes_machine_cadence_rows():
         assert "source = '%s' AND kind = '%s'" % (src, kind) in clause, clause
     # ... and it is genuinely derived, not a constant that happens to match.
     assert "heartbeat" in clause
+    # EQUALITY, not containment. The loop above only proves every declared pair
+    # APPEARS — a helper that ADDS a pair deadman never declared satisfies it,
+    # and since the call-site assertion below binds the SQL to `clause`, both
+    # sides would then be wrong in the same way and stay green. Over-excluding a
+    # source drops real activity from the panel (it reads stale, not falsely
+    # fresh — fail-loud, but still wrong). This still permits the legitimate
+    # maintenance path: adding a real pair to MACHINE_CADENCE moves both sides.
+    assert clause == "AND NOT (%s) " % DM.cadence_predicate_sql(
+        DM.MACHINE_CADENCE), clause
 
     # 🔴 AND THE CALL SITE USES IT. Asserting the helper alone is not enough:
     # dropping `machine_cadence_sql_filter()` from the SQL survived a suite that


### PR DESCRIPTION
> **Body rewritten after audit.** The original version claimed the heartbeat detects a silent extension drop — it does not, and the code now says so explicitly. See [the audit comment](https://github.com/innovation-upstream/devrc/pull/388#issuecomment-5250215543) for what changed and why.

## The report

`deadman.py` flagged `laptop/browser-bridge` **DEAD** (silent 30.8h active, budget 14.2h) while the unit was healthy — the bridge journal since the last reboot had 5 lines, all `listening`, zero `dispatch`. The workbench bridge journal over the same window had 72 lines with `dispatch`/`cmd_ok`, the positive control that the log *does* record commands when they happen. Nobody had driven it.

## Why "raise the budget" was rejected

The ask was to raise the budget. The measurement says that cannot work — the silence was 2.2× anything the source had ever done, and it grows without bound:

| | buckets | active hours |
|---|---|---|
| worst lull ever observed (14d) | 170 | 14.2h |
| silence when it alarmed | 371 | **30.9h** |
| budget at K=2 (shipped) | 170 | 14.2h → DEAD |
| budget at K=4 | 340 | 28.3h → **still DEAD** |
| module CAP | 576 | 48h → buys ~2 days, then re-alarms |

Two other levers measured and rejected: **max-gap instead of p99** (`workbench/keys` carries a 163-bucket max gap from a past outage, which would inflate the most continuous source's budget from 2h to 27h — it converts a past death into permanent blindness), and a **density-derived Bernoulli bound** (comes out *below* the observed p99 for all 17 pairs, because emissions are bursty rather than uniform).

The root cause was in the source: browser-bridge emitted one event per handled command and nothing else, so normal silence is unbounded by construction.

## What this changes

**1. A 900s liveness heartbeat** (`server.py`). 900s = 3 of the deadman's 5-min buckets, so the p99 active-gap collapses to ~3 and the budget bottoms out on the **2-active-hour floor**, where silence means the unit genuinely is not running. `BROWSER_BRIDGE_HEARTBEAT_S=0` disables it. No manual restart on deploy — the unit already has `X-Restart-Triggers` on `server.py`.

`kind="heartbeat"`, **not** `"cmd"`: `adoption-scan.py:149` counts `source='browser-bridge' AND kind='cmd'` as the usage signal, so heartbeats on `kind=cmd` would report ~96 phantom browser-skill uses/day.

**What the row proves, stated honestly:** the deadman consumes only the row's *existence*, so this detects "the bridge process is running". `payload.connected` is diagnostic metadata — nothing branches on it, so a bridge whose extension has silently dropped still reads alive. That gap predates this PR (nothing detected an extension drop before either; you found out when a command failed), and wiring an alarm to it is a separate change with its own consumer.

**2. `MACHINE_CADENCE` in `deadman.py`** — and this is the more important half. `active_by_host` was built from *any* source's buckets, so a 24/7 emitter marks the operator's night ACTIVE for every source on the host, and idle sources then accrue "active" silence while nobody is at the desk. Measured on the real 14-day table, sweeping the evaluation point hourly over 5 days (121 points) — a single evaluation at `now` is always taken while the operator is active and shows nothing:

| pair | as-is | heartbeat as operator | heartbeat as machine-cadence |
|---|---|---|---|
| workbench/i3 | 0 | 47 | 0 |
| workbench/tmux | 0 | 47 | 0 |
| workbench/keys | 0 | 45 | 0 |
| workbench/opencode | 0 | 28 | 0 |
| workbench/zsh | 0 | 22 | 0 |
| workbench/claude | 0 | 19 | 0 |

Six pairs that never alarm today would have gone DEAD, including 20 continuous hours on `workbench/keys` across a Saturday the operator was away. It does not self-correct: p99 sits just under the nightly gaps because there are only ~14 of them among ~1300.

So a `(source, kind)` in `MACHINE_CADENCE` counts toward its **own** pair's liveness and is excluded from the host's active-time definition. The query grew an `n_op` column built *from* that tuple so the SQL cannot drift from the Python; `parse_buckets` accepts 4- or 5-field input (a pre-heartbeat capture is all-operator, which is correct) but refuses a width that changes mid-file rather than guessing. Re-verified on live data: **zero** new dead pairs, `workbench/browser-bridge` alive at 121/121 points.

**3. Consumers.** `agent-ops`' freshness query imports `MACHINE_CADENCE` and excludes those pairs (an unfiltered `max(ts)` reports a bridge with no extension attached as "fresh 15 min ago"). `collector/README.md` documents both kinds.

## Tests

24 new tests. The ones that matter:

- `workday_table` — a fixture with **real idle time**. `healthy_table` fills every bucket, so the entire suite was structurally blind to the dimension the 🔴 bug lives on. The regression test carries its own negative control, so it cannot quietly stop meaning anything.
- Seam guards asserting *relationships* against the real definitions, not copies: heartbeat kind vs `adoption-scan.REGISTRY`; `HEARTBEAT_INTERVAL_S` vs `deadman.BUCKET_SECONDS`/`FLOOR_BUCKETS`; `agent-ops`' filter vs `MACHINE_CADENCE`; the SQL `check()` actually sends.

## Mutation battery — 18 mutants, all killed, five only after a fix

Five survived their first run and are the honest content of this section:

1. **`parse_buckets` reuses `n` for `n_op`** — survived all 360 tests, and would have reinstated the 🔴 bug on live data, since the check only ever reads the table through that function. Cause: a fixture with `n == n_op == 3`, which makes "carry the column" and "ignore it" byte-identical. Values are now pairwise distinct plus a TSV→parse→evaluate test.
2. **empty `MACHINE_CADENCE`** — died in the browser-bridge suite but survived in `test_deadman.py`, where the guard was a `for` loop over the tuple: vacuous when empty.
3. **`check()` sending `cadence=()`** — every `check()` test injected a fake fetch that ignored its query argument, so nothing asserted the production SQL.
4. **cadence terms joined with `AND`** — `countIf(NOT (A AND B))` excludes nothing (206760 of 206760 rows counted against the live table); only reachable once a second cadence pair exists, which the module's own note tells maintainers to add.
5. **`start_heartbeat(Registry())`** — a fresh registry instead of the server's passed an `isinstance` check while making the heartbeat report `connected=False` forever.

Also killed, having survived earlier rounds: `900`→`90000` (a silent no-op with every test green), and deleting `start_heartbeat` from `main()` (feature completely inert, suite green).

## Gates

- `nix build .#checks.x86_64-linux.pytests` → **6766 collected, 6765 passed, 1 skipped, 0 failed** (floor 6745)
- `nix build .#checks.x86_64-linux.nodetests` → rc 0

## Not verified

Live behaviour. `server.py` is a `home.file` copy (`readlink -f` → `/nix/store/…`), so nothing changes on either host until `ship.sh` runs. Post-deploy this needs: heartbeat rows appearing on a 900s cadence on both hosts, and the `laptop/browser-bridge` DEAD verdict clearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdoJTPJPnwrbQjc265rZbm
