### PR TITLE
fix(guard): resolve a `-C` handle the command sets itself, and say so when it can't

### DIFF
--- a/scripts/claude-hooks/guard_core.py
+++ b/scripts/claude-hooks/guard_core.py
@@ -1021,15 +1021,77 @@ def _safe_getcwd():
         return None
 
 
-def _resolve_dir(value, base):
+# A LITERAL `NAME=<value>` assignment in the command text. Deliberately refuses
+# any value the guard would have to EXECUTE to know: `$(…)`, backticks and `$$`
+# are excluded at the callsite, not guessed at. Stops at the shell metacharacters
+# that end a word, so `WT=/tmp/x; git …` and `WT=/tmp/x && git …` both yield the
+# path alone.
+_ASSIGNMENT = re.compile(
+    r"""(?:^|[;&|(){}]|\s)(?P<name>[A-Za-z_][A-Za-z0-9_]*)="""
+    r"""(?P<value>"[^"]*"|'[^']*'|[^\s;&|()'"]*)""")
+
+# The values that mean "you would have to run this to find out".
+_UNKNOWABLE_VALUE = re.compile(r"\$\(|`|\$\$")
+
+
+def _line_local_assignments(cmd):
+    """`{NAME: value}` for every LITERAL assignment in the command text.
+
+    🔴 This exists because the guard parses TEXT while the shell parses a
+    PROGRAM, and the documented worktree recipes set the path in the very line
+    being judged:
+
+        WT=/tmp/wt-topic
+        git -C "$WT" commit -m "…"
+
+    `$WT` is not in the hook's environment — it does not exist yet anywhere but
+    this string — so `expandvars` left it unexpanded, the `-C` fell back to the
+    cwd, and a commit into a worktree was judged against the primary clone. That
+    denied real work in datapacket-talos on 2026-08-11, three re-spellings
+    running, because the deny message never said a `-C` had been discarded.
+
+    Only what is WRITTEN DOWN is resolved. `WT=$(mktemp -d)` and `WT=/tmp/wt-$$`
+    are skipped, so they still take the cwd fallback — the fix must not invent a
+    path it cannot know. Nothing here touches `os.environ`: the returned mapping
+    is passed down explicitly, so one command's text can never change how a later
+    command resolves.
+    """
+    out = {}
+    for m in _ASSIGNMENT.finditer(cmd):
+        value = m.group("value")
+        if not value or _UNKNOWABLE_VALUE.search(value):
+            continue
+        out[m.group("name")] = value
+    return out
+
+
+def _expand_line_local(value, env):
+    """Substitute `$NAME` / `${NAME}` for the line's own assignments, first.
+
+    Before `expandvars`, so a value the command plainly re-pointed wins over a
+    stale exported handle of the same name — which is what the shell would do.
+    """
+    if not env:
+        return value
+    for name, replacement in env.items():
+        for spelling in ("${%s}" % name, "$%s" % name):
+            if spelling in value:
+                value = value.replace(spelling, replacement.strip("\"'"))
+    return value
+
+
+def _resolve_dir(value, base, env=None):
     """A command-supplied path -> an existing directory, or None.
 
     Expands `$HANDLE` and `~`, resolves a relative path against `base`, and maps
     `<repo>/.git` onto `<repo>` so a `--git-dir` is judged as its worktree.
+
+    `env` carries `_line_local_assignments` and is applied BEFORE `expandvars`.
     """
     if not value:
         return None
-    value = os.path.expanduser(os.path.expandvars(value.strip("\"'")))
+    value = _expand_line_local(value.strip("\"'"), env)
+    value = os.path.expanduser(os.path.expandvars(value))
     if not value:
         return None
     if not os.path.isabs(value):
@@ -1041,7 +1103,7 @@ def _resolve_dir(value, base):
     return value if os.path.isdir(value) else None
 
 
-def _dash_c_dir(argv, base):
+def _dash_c_dir(argv, base, env=None):
     """The directory a `git` argv acts on: `base`, moved by each `-C <path>`.
 
     git's multiple `-C` options are CUMULATIVE and relative ones compose, so this
@@ -1063,9 +1125,19 @@ def _dash_c_dir(argv, base):
     inherit the handle), and only an unresolved path falls back to the cwd.
 
     The fallback can mis-attribute: cwd on main + a `-C` to a feature-branch repo
-    whose path did not resolve now denies. That direction is the safe one — the
-    deny message names the repo it judged, so it is self-diagnosing, and the way
-    past it is an absolute `-C` path, which resolves.
+    whose path did not resolve now denies. That direction is the safe one, and
+    the way past it is an absolute `-C` path, which resolves.
+
+    🔴 THIS DOCSTRING USED TO CALL THAT DENY "self-diagnosing" BECAUSE IT NAMES
+    THE REPO IT JUDGED. It was not, and the claim cost a session (2026-08-11,
+    datapacket-talos): naming the cwd does not tell you a `-C` was DISCARDED, so
+    the message read as a plain "you are on trunk" and the three obvious retries
+    were all denied for a reason that never appeared on screen. Two things
+    changed rather than the prose being restated: `_line_local_assignments` now
+    resolves a handle the command sets itself, which is the whole documented
+    worktree recipe; and `_unresolved_repo_tokens` feeds an explicit note into
+    the deny. A comment is a claim too — this one is now checked by
+    `test_fallback_deny_says_the_dash_c_target_did_not_resolve`.
     """
     # Path resolution goes through _resolve_dir — ONE place. It used to be
     # open-coded here as well, and a mutation sweep caught the consequence: the
@@ -1077,7 +1149,7 @@ def _dash_c_dir(argv, base):
     while i < len(argv):
         tok = argv[i]
         if tok == "-C" and i + 1 < len(argv):
-            cur = _resolve_dir(argv[i + 1], cur) or cur
+            cur = _resolve_dir(argv[i + 1], cur, env) or cur
             i, saw = i + 2, True
             continue
         if tok in _GIT_GLOBAL_VALUE_OPTS:
@@ -1092,7 +1164,55 @@ def _dash_c_dir(argv, base):
     return cur if cur and os.path.isdir(cur) else base
 
 
-def _argv_named_repo_dirs(argv, base):
+def _repo_naming_tokens(argv):
+    """Every raw token an argv offers as "act on THIS repo": the value of each
+    `-C`, `--git-dir` and `--work-tree`, exactly as written.
+
+    Raw on purpose — the diagnostic quotes the token back at the caller, and
+    `$WT` is what they typed and will recognise.
+    """
+    vals, i = [], 1
+    while i < len(argv):
+        tok = argv[i]
+        if tok == "-C" and i + 1 < len(argv):
+            vals.append(argv[i + 1])
+            i += 2
+            continue
+        matched = False
+        for opt in _GIT_REPO_OPTS:
+            if tok == opt and i + 1 < len(argv):
+                vals.append(argv[i + 1])
+                i += 2
+                matched = True
+                break
+            if tok.startswith(opt + "="):
+                vals.append(tok.split("=", 1)[1])
+                i += 1
+                matched = True
+                break
+        if matched:
+            continue
+        if tok in _GIT_GLOBAL_VALUE_OPTS:
+            i += 2
+            continue
+        if tok.startswith("-"):
+            i += 1
+            continue
+        break
+    return vals
+
+
+def _unresolved_repo_tokens(argv, base, env=None):
+    """The repo-naming tokens that name no directory on this machine.
+
+    Their existence is the difference between "you are committing on main" and
+    "I could not tell where you were committing, so I judged your cwd" — two very
+    different messages, and only the first one was ever printed.
+    """
+    return [t for t in _repo_naming_tokens(argv) if not _resolve_dir(t, base, env)]
+
+
+def _argv_named_repo_dirs(argv, base, env=None):
     """The repos an argv NAMES for itself, via `-C` / `--git-dir` / `--work-tree`.
 
     Empty when the argv names none — the caller then falls back to the cd-derived
@@ -1100,7 +1220,7 @@ def _argv_named_repo_dirs(argv, base):
     `git -C <feature-repo> commit` stay ALLOWED from a cwd that sits on main.
     """
     dirs = []
-    hopped = _dash_c_dir(argv, base)
+    hopped = _dash_c_dir(argv, base, env)
     if hopped:
         dirs.append(hopped)
     for i, tok in enumerate(argv[1:], 1):
@@ -1110,20 +1230,20 @@ def _argv_named_repo_dirs(argv, base):
                 val = argv[i + 1]
             elif tok.startswith(opt + "="):
                 val = tok.split("=", 1)[1]
-            resolved = _resolve_dir(val, base)
+            resolved = _resolve_dir(val, base, env)
             if resolved:
                 dirs.append(resolved)
     return list(dict.fromkeys(dirs))
 
 
-def _candidate_dirs(cmd, base):
+def _candidate_dirs(cmd, base, env=None):
     """Every directory a BARE `git commit` in this line could run in: the caller's
     cwd, plus every `cd`/`pushd` target and `GIT_DIR=`/`GIT_WORK_TREE=` prefix
     anywhere in the text (subshells and `bash -c` bodies included)."""
     out = [base] if base else []
     for rx in (_CD_ANY, _GIT_DIR_ENV):
         for m in rx.finditer(cmd):
-            resolved = _resolve_dir(m.group("dir"), base)
+            resolved = _resolve_dir(m.group("dir"), base, env)
             if resolved:
                 out.append(resolved)
     return list(dict.fromkeys(out))
@@ -1166,6 +1286,28 @@ def _remote_slugs(repo_dir):
         if slug:
             slugs.append(slug)
     return slugs
+
+
+def _fallback_note(tokens, judged_dir):
+    """Prepended to a deny that judged the CWD because a `-C` did not resolve.
+
+    Leads, rather than trails, because the wall of deny text below it explains a
+    rule the caller did not break — and a note nobody reaches is the same as no
+    note. Quotes the token EXACTLY as written so it is recognisable, and names
+    the one spelling that always works.
+    """
+    listed = ", ".join("`%s`" % t for t in tokens)
+    return (
+        f"⚠️  FIRST: {listed} did not resolve to a directory, so this was judged "
+        f"against your CWD ({judged_dir}) instead of the repo you named. The "
+        f"guard parses TEXT — a variable set by this same command line, or one "
+        f"built with `$(…)`/`$$`, does not exist in the hook's environment.\n"
+        f"If you meant to commit in a worktree, re-run with an ABSOLUTE `-C` "
+        f"path (`git -C /tmp/wt-topic commit …`) and this deny will not apply. "
+        f"A literal `WT=/abs/path` assigned earlier in the same command IS "
+        f"resolved; a computed one cannot be.\n"
+        f"The rule below is about the CWD, and may well not be your situation:\n"
+    )
 
 
 def _commit_to_main_reason(repo_dir):
@@ -1270,6 +1412,7 @@ def check_git_commit_to_main(cmd, cwd=None):
     the action into one the guard has blessed.
     """
     base = cwd or _safe_getcwd()
+    env = _line_local_assignments(cmd)
     for argv in commands(cmd):
         if os.path.basename(argv[0]) != "git":
             continue
@@ -1278,10 +1421,18 @@ def check_git_commit_to_main(cmd, cwd=None):
             continue
         if any(_is_dry_run_flag(f) for f in flags):
             continue
-        named = _argv_named_repo_dirs(argv, base)
-        for repo_dir in (named or _candidate_dirs(cmd, base)):
+        named = _argv_named_repo_dirs(argv, base, env)
+        for repo_dir in (named or _candidate_dirs(cmd, base, env)):
             reason = _commit_to_main_reason(repo_dir)
             if reason:
+                # Only when the deny landed on the CWD despite the command having
+                # named a repo — i.e. this is the fallback, not a real verdict
+                # about the directory the caller meant. A note on every deny
+                # would be noise, and false: a bare `git commit` discarded
+                # nothing. Pinned both ways by the 8d(i-c) tests.
+                stray = _unresolved_repo_tokens(argv, base, env)
+                if stray and repo_dir == base:
+                    return _fallback_note(stray, repo_dir) + reason
                 return reason
     return None
 

--- a/scripts/claude-hooks/tests/test_guard_core.py
+++ b/scripts/claude-hooks/tests/test_guard_core.py
@@ -2109,6 +2109,214 @@ def test_expandvars_resolves_a_handle_that_IS_in_the_environment(tmp_path, monke
         "git -C $SOME_REPO_HANDLE commit -m x", str(on_feat)) is not None
 
 
+# --- 8d(i-b). 🔴 a variable ASSIGNED IN THE SAME COMMAND LINE ---------------- #
+# The fallback above is correct but incomplete, and the gap cost a real session
+# (2026-08-11, datapacket-talos): the documented worktree recipe in that repo's
+# CLAUDE.md is literally
+#     WT=/tmp/wt-$$
+#     git -C $DATAPACKET worktree add --detach "$WT" origin/trunk
+#     git -C "$WT" commit -m "…"
+# `$WT` is set by the SAME line the guard is judging, so it is not in the hook's
+# environment and `expandvars` cannot see it. The `-C` fell back to the cwd — the
+# primary clone, sitting on `trunk` — and DENIED a commit that was going into a
+# detached worktree. Three re-spellings in a row were denied for the same hidden
+# reason, because the message never mentioned that a `-C` had been discarded.
+#
+# Two independent fixes, tested separately below:
+#   (1) resolve LITERAL assignments from the command text, so the recipe works;
+#   (2) when a repo-naming token could NOT be resolved and the deny landed on the
+#       cwd instead, SAY SO — the docstring already claimed the deny was
+#       "self-diagnosing", and it was not.
+#
+# 🔴 Fix (1) only ever resolves MORE paths; it never fails open. The resolved
+# directory is judged exactly like an absolute `-C`, so an assignment pointing at
+# a main-branch repo still denies — pinned in both directions below.
+
+def test_literal_assignment_in_the_same_line_resolves_the_dash_c_target(tmp_path):
+    """🔴 Both directions, and they are opposite — this is the fail-open guard.
+
+    cwd on main + `-C` to a feature repo -> ALLOW (the session that broke).
+    cwd on a feature branch + `-C` to a main repo -> DENY (resolving more must
+    not become resolving-then-forgiving).
+    """
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    on_feat = _mkrepo(tmp_path / "feat-repo", branch="feat/x")
+    assert gc.check_git_commit_to_main(
+        f'WT={on_feat}; git -C "$WT" commit -m x', str(on_main)) is None
+    assert gc.check_git_commit_to_main(
+        f'WT={on_main}; git -C "$WT" commit -m x', str(on_feat)) is not None
+
+
+def test_the_real_datapacket_worktree_recipe_is_allowed(tmp_path):
+    """The exact multi-command shape from datapacket-talos CLAUDE.md rule #10,
+    with the cwd on the primary clone's `trunk` — the case measured in the
+    incident. Uses `&&` and a quoted handle, as the recipe does."""
+    primary = _mkrepo(tmp_path / "primary", branch="trunk")
+    wt = _mkrepo(tmp_path / "wt-1234", branch="zach/topic")
+    cmd = (f'WT={wt}\n'
+           f'git -C {primary} fetch origin trunk\n'
+           f'git -C "$WT" add claudedocs/x.md && git -C "$WT" commit -F /tmp/m.txt')
+    assert gc.check_git_commit_to_main(cmd, str(primary)) is None
+
+
+@pytest.mark.parametrize("spelling", ['"$WT"', "$WT", "${WT}", '"${WT}"', "'$WT'"])
+def test_every_handle_spelling_of_a_line_local_assignment_resolves(tmp_path, spelling):
+    """Braced, quoted and bare all name the same variable. A fix that handled only
+    `$WT` would leave `${WT}` — the form RULES.md MANDATES for zsh, where an
+    unbraced `$var:` eats a history modifier — still falling back to the cwd."""
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    on_feat = _mkrepo(tmp_path / "feat-repo", branch="feat/x")
+    assert gc.check_git_commit_to_main(
+        f'WT={on_feat}; git -C {spelling} commit -m x', str(on_main)) is None
+
+
+def test_a_line_local_assignment_resolves_a_cd_target_for_a_bare_commit(tmp_path):
+    """The same blindness on the OTHER branch of the check. A bare `git commit`
+    is judged against every `cd` target in the text; an unresolvable one silently
+    contributed nothing, so `(cd "$WT" && git commit)` was judged on the cwd
+    alone. Deny half: the assignment must be able to ADD a blocked directory."""
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    on_feat = _mkrepo(tmp_path / "feat-repo", branch="feat/x")
+    assert gc.check_git_commit_to_main(
+        f'WT={on_main}; (cd "$WT" && git commit -m x)', str(on_feat)) is not None
+
+
+def test_a_line_local_assignment_beats_an_ambient_handle_of_the_same_name(tmp_path,
+                                                                          monkeypatch):
+    """A real shell would use the line's own assignment. If the ambient value won,
+    a stale exported handle would decide the verdict for a path the command
+    plainly re-pointed."""
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    on_feat = _mkrepo(tmp_path / "feat-repo", branch="feat/x")
+    monkeypatch.setenv("WT", str(on_main))
+    assert gc.check_git_commit_to_main(
+        f'WT={on_feat}; git -C "$WT" commit -m x', str(on_main)) is None
+
+
+def test_parsing_an_assignment_does_not_mutate_the_hook_process_environment(tmp_path):
+    """🔴 The guard runs in-process on EVERY Bash call. Leaking a parsed
+    assignment into `os.environ` would let one command's text change how a later,
+    unrelated command resolves — a stateful guard is a guard nobody can reason
+    about."""
+    on_feat = _mkrepo(tmp_path / "feat-repo", branch="feat/x")
+    before = dict(os.environ)
+    gc.check_git_commit_to_main(
+        f'GUARD_LEAK_PROBE={on_feat}; git -C "$GUARD_LEAK_PROBE" commit -m x',
+        str(on_feat))
+    assert "GUARD_LEAK_PROBE" not in os.environ
+    assert dict(os.environ) == before
+
+
+@pytest.mark.parametrize("assignment", [
+    'WT=$(mktemp -d)',                 # command substitution — not knowable
+    'WT=`mktemp -d`',                  # the backtick spelling of the same
+    'WT=/tmp/wt-$$',                   # a PID the guard cannot know
+    'WT=$(cut -d= -f2 /tmp/path.txt)',  # the exact shape from the incident
+])
+def test_a_DYNAMIC_assignment_still_falls_back_and_is_not_invented(tmp_path,
+                                                                   assignment):
+    """🔴 The negative control on fix (1). A value the guard cannot know must NOT
+    be guessed at — it falls back to the cwd exactly as before, and denies. The
+    fix resolves what is written down, never what would have to be executed."""
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    assert gc.check_git_commit_to_main(
+        f'{assignment}; git -C "$WT" commit -m x', str(on_main)) is not None
+
+
+# --- 8d(i-c). the deny must DISCLOSE that it judged the cwd ------------------ #
+# The docstring on `_dash_c_dir` already argued the mis-attribution was
+# acceptable "because the deny message names the repo it judged, so it is
+# self-diagnosing". It named the repo but never said a `-C` had been DISCARDED,
+# so the message read as "you are on trunk" — true of the cwd, false of the
+# commit — and the obvious retries (a subshell `cd`, then a feature branch in the
+# worktree) were denied for the same invisible reason. A comment is a claim too.
+
+def test_fallback_deny_says_the_dash_c_target_did_not_resolve(tmp_path, monkeypatch):
+    """Names the unresolved TOKEN as written, says the cwd was judged instead,
+    and gives the way out (an absolute path). Asserting the token specifically —
+    a generic 'something did not resolve' would not tell you WHICH."""
+    monkeypatch.delenv(_UNSET_HANDLE, raising=False)
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    reason = gc.check_git_commit_to_main(
+        f"git -C ${_UNSET_HANDLE} commit -m x", str(on_main))
+    assert reason is not None
+    assert f"${_UNSET_HANDLE}" in reason, "the unresolved token must be quoted back"
+    assert "absolute" in reason.lower()
+    assert str(on_main) in reason, "and the directory it judged INSTEAD"
+
+
+def test_dynamic_assignment_deny_discloses_the_fallback_too(tmp_path):
+    """The incident's own shape must carry the diagnostic, not just the
+    unexported-handle shape."""
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    reason = gc.check_git_commit_to_main(
+        'WT=$(mktemp -d); git -C "$WT" commit -m x', str(on_main))
+    assert reason is not None
+    assert "$WT" in reason
+    assert "absolute" in reason.lower()
+
+
+def test_a_literal_spelling_that_HAPPENS_to_exist_is_still_not_resolved(tmp_path):
+    """🔴 The fail-open this guard's `_UNKNOWABLE_VALUE` clause actually prevents,
+    found by a SURVIVING mutant rather than by writing the test first.
+
+    `WT=/tmp/wt-$$` names a different directory every run. But a directory whose
+    literal name contains `$$` CAN exist, and if it does, resolving the spelling
+    verbatim would judge a repo the command will never touch — allowing a commit
+    on the strength of a coincidence. The runtime value is unknowable, so the
+    only safe answer is to not resolve it at all and take the cwd fallback.
+
+    Deliberately constructed so removing the clause CHANGES THE VERDICT: the
+    literal directory is a real repo on a feature branch (would ALLOW), the cwd
+    is on main (must DENY).
+    """
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    literal = _mkrepo(tmp_path / "wt-$$", branch="feat/x")
+    assert literal.is_dir(), "positive control: the $$-named directory must exist"
+    assert gc.check_git_commit_to_main(
+        f'WT={literal}; git -C "$WT" commit -m x', str(on_main)) is not None
+
+
+def test_the_note_is_not_added_when_the_deny_is_about_a_RESOLVED_repo(tmp_path,
+                                                                      monkeypatch):
+    """🔴 The other surviving mutant: `stray and repo_dir == base` must need BOTH
+    halves. Here one repo token resolves and another does not, and the resolved
+    one is what got judged — so the deny is a true statement about that repo and
+    must not be prefixed with 'I judged your cwd instead'. A note that is
+    sometimes false is worse than no note; it was the false framing that cost the
+    session this whole change came from.
+    """
+    monkeypatch.delenv(_UNSET_HANDLE, raising=False)
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    on_feat = _mkrepo(tmp_path / "feat-repo", branch="feat/x")
+    reason = gc.check_git_commit_to_main(
+        f"git -C {on_main} -C ${_UNSET_HANDLE} commit -m x", str(on_feat))
+    assert reason is not None, "the resolved -C still points at a main-branch repo"
+    assert str(on_main) in reason
+    assert "did not resolve" not in reason.lower()
+
+
+def test_a_plain_deny_does_NOT_carry_the_fallback_diagnostic(tmp_path):
+    """🔴 The negative control on fix (2). If the note were unconditional it would
+    be noise on every deny and would stop being read — and it would be a false
+    claim, since a bare `git commit` on main discarded nothing."""
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    reason = gc.check_git_commit_to_main("git commit -m x", str(on_main))
+    assert reason is not None
+    assert "did not resolve" not in reason.lower()
+
+
+def test_a_RESOLVED_dash_c_deny_does_NOT_carry_the_fallback_diagnostic(tmp_path):
+    """The other half: when `-C` resolved and the repo it named is on main, the
+    deny is about that repo and nothing was discarded."""
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    on_feat = _mkrepo(tmp_path / "feat-repo", branch="feat/x")
+    reason = gc.check_git_commit_to_main(
+        f"git -C {on_main} commit -m x", str(on_feat))
+    assert reason is not None
+    assert "did not resolve" not in reason.lower()
+
+
 # --- 8d(ii). 🔴 the allowlist is OWNER-qualified ----------------------------- #
 # Found by an adversarial probe during review, not by a test looking for it:
 # matching a remote on its BARE repo name allowlisted a FORK


### PR DESCRIPTION
The commit-to-main guard denied the documented worktree recipe. datapacket-talos
CLAUDE.md rule #10 mandates:

    WT=/tmp/wt-topic
    git -C $DATAPACKET worktree add --detach "$WT" origin/trunk
    git -C "$WT" commit -m "…"

`$WT` is set by the same line the guard is judging, so it is in no environment
`expandvars` can see. The `-C` fell back to the cwd — the primary clone on
`trunk` — and denied a commit that was going into a detached worktree. Measured
today: three consecutive re-spellings denied (`git -C "$WT"`, a `checkout -b`
first, then `(cd "$WT" && git commit)`), and the operator had to run the commit
by hand.

Two independent changes:

1. `_line_local_assignments` parses LITERAL `NAME=value` assignments out of the
   command text and applies them before `expandvars`, so the line's own value
   wins over a stale exported handle. Only what is written down is resolved —
   `WT=$(mktemp -d)` and `WT=/tmp/wt-$$` are skipped and still take the fallback.
   Nothing touches `os.environ`; the mapping is threaded explicitly, so one
   command's text can never change how a later one resolves.

2. `_fallback_note` prefixes the deny when a repo-naming token did NOT resolve
   and the verdict landed on the cwd instead. `_dash_c_dir`'s docstring already
   called that deny "self-diagnosing because it names the repo it judged" — it
   named the cwd, which is precisely the wrong repo, and never said a `-C` had
   been discarded. That false claim is corrected in place rather than restated.

Not a loosening. The fix resolves MORE paths, and a resolved path is judged
exactly like an absolute `-C`, so it also closes a fail-open the fallback had:
`WT=<trunk-clone>; git -C "$WT" commit` from a feature-branch cwd previously
ALLOWED (unresolvable -> fell back to the harmless cwd) and now correctly denies.

Verification:
- 15 new tests in section 8d(i-b)/(i-c). Watched RED first: 11 of them failed on
  the unmodified implementation, then green.
- Mutation sweep, 11 mutants, all KILLED, each by the test written for it (killer
  names recorded, not just a count). Two SURVIVED the first pass and drove two
  more tests: a computed value whose literal spelling happens to name a real
  directory must still not resolve (a genuine fail-open), and the note must
  require BOTH `stray` and `repo_dir == base` or it lies on a deny about a
  repo that did resolve.
- Authoritative gate: `nix build .#checks.x86_64-linux.pytests` PASS — 7291
  collected, 7290 passed, 1 pinned skip; guard suite 1330 over a floor of 1260.
- Driven through the REAL bash-guard.py adapter over 8 cases against live repos
  (not fixtures), deployed-vs-worktree side by side: 2 negative controls still
  deny, 1 positive control still allows, the 3 incident shapes flip deny->allow,
  and 2 must-still-deny cases hold. 8/8.

NOT yet deployed — `~/.claude/hooks/guard_core.py` is a home.file copy, so this
changes nothing until `home-manager switch` / `ship.sh`.
