### PR TITLE
fix(guard): one apostrophe in a heredoc body disabled every argv check (scanner half of #396)

### DIFF
--- a/scripts/claude-hooks/guard_core.py
+++ b/scripts/claude-hooks/guard_core.py
@@ -77,6 +77,16 @@ one extra step -- write the message to a file and use `git commit -F <file>` --
 which RULES already prefers over heredocs. That is a better trade than a
 security guard with a rotating cast of bypasses.
 
+🔴 NEITHER IS THE HEREDOC HANDLING IN `_scan` (2026-08-11). It LIFTS a heredoc
+body out of the surrounding quote state and then parses it as commands exactly
+as before — nothing is blanked, nothing is declared inert, and `bash <<EOF` keeps
+every deny it had. It exists because the opposite of the reverted helper was also
+a bug: the scanner tracked quote state THROUGH the body, so one apostrophe in a
+commit message (`don't`) opened a quote that never closed and swallowed every
+command AFTER the heredoc. Measured on the shipped guard — `git commit`,
+`git stash`, `git reset --hard`, `git clean -fd`, `talosctl reset`, `mkfs`,
+`dd of=/dev/sdc` and `pkill -f` all resolved ALLOW behind one apostrophe.
+
 🔴 The argv-based checks below are NOT a return of that helper, and the
 distinction is load-bearing. They never BLANK bytes and never decide which parts
 of a string are inert. They tokenise, and a quoted `-m` argument is simply ONE
@@ -407,17 +417,130 @@ _WRAPPER_POSITIONAL = {"timeout": 1, "chrt": 1}
 _SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "ash", "busybox"}
 
 
-def split_commands(text):
-    """Split shell text into command segments, respecting quotes.
+# A heredoc tag as bash accepts it unquoted. Quoted tags (`<<'EOF'`, `<<"EOF"`)
+# are read by _read_heredoc_tag directly.
+_HEREDOC_TAG = re.compile(r"[A-Za-z0-9_.-]+")
 
-    Also yields the BODY of every `$( … )` / backtick substitution as its own
-    text, because a substitution body really does execute. Linear scan — no
-    regex, so no backtracking to worry about on a guard that runs per call.
+# Bound on re-parsing nested bodies (a heredoc inside a heredoc inside …), the
+# same bound `commands()` puts on `bash -c` recursion.
+_BODY_RECURSION_LIMIT = 3
+
+# How many times `_scan` will re-read a tail that an UNTERMINATED quote hid. One
+# pass per unbalanced quote character; the cap only exists so text engineered to
+# be full of them cannot make a per-Bash-call hook quadratic.
+_QUOTE_RECOVERY_LIMIT = 16
+
+
+def _read_heredoc_tag(text, k):
+    """`(tag, index-after-tag)` at position `k`, or `(None, k)`.
+
+    Handles `<<EOF`, `<<'EOF'`, `<<"EOF"` and `<<\\EOF` — the four spellings, all
+    of which name the same terminator line.
     """
-    segs, subs = [], []
+    n = len(text)
+    if k >= n:
+        return None, k
+    if text[k] in ("'", '"'):
+        q = text[k]
+        j = text.find(q, k + 1)
+        if j == -1:
+            return None, k
+        return text[k + 1:j], j + 1
+    if text[k] == "\\":
+        k += 1
+    m = _HEREDOC_TAG.match(text, k)
+    if not m:
+        return None, k
+    return m.group(0), m.end()
+
+
+def _consume_heredocs(text, i, pending):
+    """Read the bodies of the heredocs opened on the line that just ended.
+
+    Returns `(index-after-the-last-body, [body-text, …])`. Multiple heredocs on
+    one line (`cmd <<A <<B`) are consumed in the order they were opened, which is
+    bash's order. A body with no terminator runs to end-of-text — also bash's
+    behaviour, and the fail-CLOSED direction here, since the text is still
+    scanned as commands rather than dropped.
+    """
+    bodies, n = [], len(text)
+    for tag, strip_tabs in pending:
+        lines = []
+        while i < n:
+            j = text.find("\n", i)
+            line = text[i:j] if j != -1 else text[i:]
+            nxt = (j + 1) if j != -1 else n
+            probe = line.lstrip("\t") if strip_tabs else line
+            if probe.rstrip("\r") == tag:
+                i = nxt
+                break
+            lines.append(line)
+            i = nxt
+        bodies.append("\n".join(lines))
+    return i, bodies
+
+
+def _scan(text, _lift=True, _recovery=0):
+    """`([segment-text, …], [substitution-body, …], [heredoc-body, …])`.
+
+    (`_scan_raw` is the same walk returning a fourth element, `diverged` — see
+    there. This wrapper is what tests and readers should use.)
+
+    🔴 `_lift=False` REPRODUCES THE SHIPPED SCANNER EXACTLY — heredoc operators
+    are ordinary characters and an unterminated quote is not recovered from. It
+    is not vestigial and it is not dead code: `split_commands` runs BOTH modes
+    and unions the results, which is what makes this change additive by
+    CONSTRUCTION instead of by assertion. Read the argument there before removing
+    it; a 20,000-input fuzz found four inputs where lifting ALONE lost a deny.
+
+    🔴 HEREDOC BODIES ARE LIFTED OUT OF THE SCAN, and that is a BUG FIX, not a
+    tidy-up. The scanner tracks quote state character by character, and a heredoc
+    body is ordinary prose — so a single apostrophe in a commit message
+    (`don't`, `it's`) OPENED a quote that never closed, and every command after
+    the heredoc was swallowed into that quoted buffer instead of being emitted as
+    its own segment. Measured against the shipped guard, cwd on `main`:
+
+        DENY   cat > /tmp/m <<EOF / do not stage / EOF / git commit -m x
+        ALLOW  cat > /tmp/m <<EOF / don't stage  / EOF / git commit -m x
+        ALLOW  …same apostrophe body… / git stash push -m wip
+        ALLOW  …same apostrophe body… / talosctl -n 1.2.3.4 reset
+
+    i.e. one apostrophe in a message body silently disabled EVERY argv check for
+    the rest of the command line. The two cases differ only in that apostrophe,
+    which is the control that names the mechanism.
+
+    🔴 This is NOT the reverted `_strip_message_text()` helper the DESIGN NOTE
+    forbids, and the difference is the one that matters: nothing is BLANKED and
+    nothing is decided to be inert. The bodies are still returned, still parsed
+    as commands, and still checked — so `bash <<EOF` (a body that really does
+    execute) keeps exactly the coverage it has today, and a body that merely
+    QUOTES a banned command still denies via the documented escape hatch. All
+    that changes is that a body can no longer corrupt the parse of the commands
+    AROUND it.
+    """
+    return _scan_raw(text, _lift, _recovery)[:3]
+
+
+def _scan_raw(text, _lift=True, _recovery=0):
+    """`_scan` plus `diverged` — True when this walk did something the SHIPPED
+    scanner would not have: consumed a heredoc operator, or re-read a tail an
+    unterminated quote hid.
+
+    `diverged is False` is a PROOF that `_lift=True` and `_lift=False` produced
+    the same segments, which is what lets `split_commands` skip the second scan
+    for the ~everything that contains neither a heredoc nor an odd quote. It is
+    computed rather than guessed for a reason: a textual precondition like
+    "`<<` in text or an odd quote count" is UNSOUND — `"'" 'x` leaves an
+    unterminated `'` with an EVEN count of them, so a guard keyed on parity
+    would silently skip the union on exactly the shape it exists for.
+    """
+    segs, subs, bodies = [], [], []
+    diverged = False
     buf = []
     i, n = 0, len(text)
     quote = None
+    quote_at = None
+    pending = []
     while i < n:
         c = text[i]
         if quote:
@@ -431,7 +554,8 @@ def split_commands(text):
         if c == "\\" and i + 1 < n:
             buf.append(c); buf.append(text[i + 1]); i += 2; continue
         if c in ("'", '"'):
-            quote = c; buf.append(c); i += 1; continue
+            quote = c; quote_at = i
+            buf.append(c); i += 1; continue
         if c == "`":
             j = text.find("`", i + 1)
             if j == -1:
@@ -440,16 +564,43 @@ def split_commands(text):
             i = j + 1
             continue
         if c == "$" and i + 1 < n and text[i + 1] == "(":
-            depth, j = 1, i + 2
-            while j < n and depth:
+            sdepth, j = 1, i + 2
+            while j < n and sdepth:
                 if text[j] == "(":
-                    depth += 1
+                    sdepth += 1
                 elif text[j] == ")":
-                    depth -= 1
+                    sdepth -= 1
                 j += 1
-            subs.append(text[i + 2:j - 1 if depth == 0 else n])
+            subs.append(text[i + 2:j - 1 if sdepth == 0 else n])
             i = j
             continue
+        # 🔴 A here-STRING (`<<<`) has no body and no terminator line, so it is
+        # consumed WHOLE. Testing `not startswith("<<<")` inside the heredoc
+        # branch is not enough and was measured wrong: the scan also visits the
+        # SECOND `<`, where `<<<x` reads as `<<` + tag `x` and the entire rest of
+        # the text is swallowed as an unterminated body. Skipping all three
+        # characters is the only place that cannot be re-entered. (No quote,
+        # paren or separator character is skipped, so legacy mode is unaffected —
+        # asserted by the legacy-equivalence fuzz.)
+        if text.startswith("<<<", i):
+            buf.append("<<<"); i += 3; continue
+        # A heredoc OPERATOR (`<<TAG`, `<<-TAG`, `<<'TAG'`, `<<\TAG`).
+        if _lift and text.startswith("<<", i):
+            j = i + 2
+            strip_tabs = False
+            if j < n and text[j] == "-":
+                strip_tabs = True
+                j += 1
+            k = j
+            while k < n and text[k] in " \t":
+                k += 1
+            tag, after = _read_heredoc_tag(text, k)
+            if tag is not None:
+                buf.append(text[i:after])     # keep the operator in the segment
+                pending.append((tag, strip_tabs))
+                diverged = True
+                i = after
+                continue
         if c in "()":                 # subshell parens are not part of argv
             segs.append("".join(buf)); buf = []; i += 1; continue
         matched = None
@@ -458,10 +609,95 @@ def split_commands(text):
                 matched = op
                 break
         if matched:
-            segs.append("".join(buf)); buf = []; i += len(matched); continue
+            segs.append("".join(buf)); buf = []
+            i += len(matched)
+            if matched == "\n" and pending:
+                i, opened = _consume_heredocs(text, i, pending)
+                bodies.extend(opened)
+                pending = []
+            continue
         buf.append(c); i += 1
     segs.append("".join(buf))
-    return [s for s in segs + subs if s.strip()]
+    # 🔴 AN UNTERMINATED QUOTE MUST NOT BLIND THE REST OF THE SCAN. A lone
+    # apostrophe — in a heredoc body, a `-m` message, any prose the model wrote —
+    # opens a quote that never closes, and everything after it lands inside ONE
+    # quoted buffer. `_tokenise` then falls back to a whitespace split whose
+    # argv[0] is a word from the prose, so every argv check silently stops
+    # matching. Found by this change's own non-regression test, on a body that
+    # REALLY executes (`bash <<'EOF' / it's fine / git stash push -m wip / EOF`),
+    # where lifting the heredoc out was not enough because the corruption then
+    # happened INSIDE the body's own parse.
+    #
+    # An unterminated quote is a malformed command the shell itself would reject,
+    # so there is no "correct" reading to preserve. Re-scanning the tail with the
+    # offending quote treated as an ordinary character is purely ADDITIVE — it
+    # can only surface argv the first pass buried — which is the only direction a
+    # guard may err in. Each pass consumes at least the quote character, so it
+    # terminates; the limit only bounds adversarial input full of odd quotes.
+    if _lift and quote is not None and quote_at is not None:
+        # The quote was never closed, so the segments after it are a fact about
+        # the corruption, not about the command — `diverged` regardless of
+        # whether the recovery budget is left to act on it.
+        diverged = True
+        if _recovery < _QUOTE_RECOVERY_LIMIT:
+            r_segs, r_subs, r_bodies, _ = _scan_raw(
+                text[quote_at + 1:], _lift, _recovery + 1)
+            segs.extend(r_segs)
+            subs.extend(r_subs)
+            bodies.extend(r_bodies)
+    return segs, subs, bodies, diverged
+
+
+def split_commands(text, _depth=0):
+    """Split shell text into command segments, respecting quotes.
+
+    Also yields the BODY of every `$( … )` / backtick substitution and of every
+    HEREDOC as its own text, because a substitution body really does execute and
+    a heredoc body may (`bash <<EOF`). Linear scan — no regex, so no backtracking
+    to worry about on a guard that runs per call.
+
+    🔴 THE SHIPPED PARSE IS KEPT, NOT REPLACED — `_scan(text, _lift=False)` is
+    the byte-for-byte old scanner, and its segments are unioned in. This is the
+    load-bearing line of the whole change, and it is here because ASSERTING
+    additivity was not enough:
+
+    Lifting a heredoc body out CHANGES THE QUOTE STATE of everything after it,
+    and the old parse's corrupt state sometimes exposed argv the clean parse
+    hides behind a quote that now balances differently. Measured, 20,000 random
+    inputs, verdicts from the full 15-check policy: lifting alone turned FOUR
+    DENYs into ALLOWs. One of them —
+
+        '-m' || <<-EOF / it's / EOF / "won't && clean; bash `mkfs.ext4` …
+
+    — denied on the shipped guard because its runaway quote happened to leave
+    the backtick substitution unquoted, and allowed on the lift-only scanner
+    because the same bytes now sit inside a balanced-looking quote. Neither
+    parse is "right" about text bash itself rejects as unterminated; a guard
+    must simply not lose the deny. Taking the union makes "this can only make
+    more argv visible, never fewer" TRUE BY CONSTRUCTION rather than by
+    argument, so no future fuzz seed can find a fifth case.
+
+    The second scan is SKIPPED when the first one reports `diverged is False` —
+    a proof, not a heuristic, that the two modes produced identical segments
+    (see `_scan_raw`). So an ordinary command line, which is ~every call this
+    hook sees, pays one scan exactly as it does today; only text carrying a
+    heredoc or an unterminated quote pays for both.
+    """
+    segs, subs, bodies, diverged = _scan_raw(text)
+    out = segs + subs
+    for body in bodies:
+        out.extend(split_commands(body, _depth + 1)
+                   if _depth < _BODY_RECURSION_LIMIT else [body])
+    if diverged:
+        legacy_segs, legacy_subs, _, _ = _scan_raw(text, _lift=False)
+        out.extend(legacy_segs)
+        out.extend(legacy_subs)
+    seen, kept = set(), []
+    for s in out:
+        if s.strip() and s not in seen:
+            seen.add(s)
+            kept.append(s)
+    return kept
 
 
 def _tokenise(seg):

--- a/scripts/claude-hooks/tests/test_guard_core.py
+++ b/scripts/claude-hooks/tests/test_guard_core.py
@@ -2384,3 +2384,273 @@ def test_resolve_dir_is_the_single_path_resolver(tmp_path, monkeypatch):
     assert gc._resolve_dir(str(on_main / ".git"), None) == str(on_main)
     assert gc._resolve_dir("/definitely/not/here", None) is None
     assert gc._resolve_dir(None, None) is None
+
+
+# =========================================================================== #
+# --- 9. 🔴 ONE APOSTROPHE IN A HEREDOC BODY DISABLED EVERY ARGV CHECK ------- #
+#
+# A heredoc body is PROSE, and the scanner tracked quote state through it. A
+# lone apostrophe (`don't`, `it's`) opened a quote that never closed, so every
+# command AFTER the heredoc was swallowed into that quoted buffer and never
+# parsed as its own segment. `_tokenise` then fell back to a whitespace split
+# whose argv[0] is a word from the message, and every argv check silently
+# stopped matching — not just the commit one. Measured on the shipped guard,
+# eight families, all ALLOW; all DENY with the apostrophe removed.
+#
+# Every test in this section was watched RED against the pre-change
+# guard_core.py and GREEN after. The fix is in `_scan`: heredoc bodies are
+# LIFTED out of the surrounding quote state (and then parsed as commands exactly
+# as before — nothing is blanked), and an unterminated quote from ANY source
+# re-scans its own tail.
+# =========================================================================== #
+
+@pytest.mark.parametrize("victim", [
+    "git commit -m x",                      # commit-to-main
+    "git stash push -m wip",                # …and every other argv check
+    "git -C /tmp reset --hard origin/main",
+    "git clean -fd",
+    "talosctl -n 1.2.3.4 reset",
+    "mkfs.ext4 /dev/sdc",
+    "dd if=/dev/zero of=/dev/sdc",
+    "pkill -f e2e/run.sh",
+])
+def test_a_heredoc_body_cannot_swallow_the_command_after_it(tmp_path, victim):
+    """🔴 THE REGRESSION. Measured ALLOW on the shipped guard for every victim
+    below — one apostrophe in a message body disabled the ENTIRE argv half of
+    the guard for the rest of the command line, including three
+    irreversible-action families.
+
+    Parametrised across families on purpose: the bug was in the SHARED scanner,
+    so a single-check test would have understated it as a commit-to-main quirk.
+    """
+    repo = _mkrepo(tmp_path / "r", branch="main")
+    cmd = f"cat > /tmp/m.txt <<EOF\nfix: don't blindly stage\nEOF\n{victim}"
+    assert gc.evaluate(cmd, "claude-code", str(repo)) is not None, cmd
+
+
+def test_the_apostrophe_is_the_discriminator_not_the_heredoc(tmp_path):
+    """🔴 The control that NAMES the mechanism. The two commands differ by ONE
+    character. Without this pair, "heredocs break the guard" and "an unbalanced
+    quote breaks the guard" are indistinguishable — and it is the second that is
+    true, which is why the fix is in the scanner rather than a heredoc special
+    case. The balanced arm is the one that DENIED before the change: if it ever
+    starts allowing, this test has stopped discriminating anything.
+    """
+    repo = _mkrepo(tmp_path / "r", branch="main")
+    balanced = "cat > /tmp/m <<EOF\ndo not stage\nEOF\ngit commit -m x"
+    unbalanced = "cat > /tmp/m <<EOF\ndon't stage\nEOF\ngit commit -m x"
+    assert gc.evaluate(balanced, "claude-code", str(repo)) is not None
+    assert gc.evaluate(unbalanced, "claude-code", str(repo)) is not None
+    # …and at the parser, which is where the difference actually lived: the
+    # victim must come back as its OWN segment, not glued into a prose blob.
+    assert any(s.strip() == "git commit -m x"
+               for s in gc.split_commands(unbalanced)), gc.split_commands(unbalanced)
+
+
+def test_a_heredoc_body_that_really_EXECUTES_is_still_checked(tmp_path):
+    """🔴 NON-REGRESSION, and the line separating this fix from the reverted
+    `_strip_message_text()` helper the module docstring forbids. That helper
+    BLANKED bodies, so `bash <<EOF` stopped being checked at all. Nothing is
+    blanked here: the body is lifted out of the surrounding quote state and then
+    parsed as commands exactly as before, so a body that really runs still
+    denies — including one whose own prose carries the apostrophe, which is the
+    case that proved lifting alone was not enough (the corruption then happened
+    INSIDE the body's own parse).
+    """
+    repo = _mkrepo(tmp_path / "r", branch="main")
+    for cmd in ["bash <<EOF\ngit stash push -m wip\nEOF",
+                "bash <<EOF\ntalosctl -n 1.2.3.4 reset\nEOF",
+                "bash <<EOF\nit's fine\ngit stash push -m wip\nEOF"]:
+        assert gc.evaluate(cmd, "claude-code", str(repo)) is not None, cmd
+
+
+def test_a_body_documenting_a_ban_still_denies_via_the_escape_hatch(tmp_path):
+    """The deliberate false positive the DESIGN NOTE accepts, re-asserted
+    through the new path. Lifting a body must not turn it into inert text — a
+    body LINE that IS a banned command is still parsed as that command and
+    denied, whether or not it would ever execute, and the deny still carries the
+    documented way out.
+
+    The `never run …` arm is the boundary, and it is ALLOW on the shipped guard
+    too: the checks key on argv[0], so prose that merely MENTIONS a command is
+    not one. Asserted rather than assumed, because "a body is still checked" and
+    "any body containing the word is denied" are different claims and only the
+    first is true.
+    """
+    repo = _mkrepo(tmp_path / "r", branch="main")
+    reason = gc.evaluate("cat > /tmp/doc.md <<EOF\ngit stash\nEOF",
+                         "claude-code", str(repo))
+    assert reason is not None
+    assert "Only QUOTING this command" in reason
+    assert gc.evaluate("cat > /tmp/doc.md <<EOF\nnever run git stash here\nEOF",
+                       "claude-code", str(repo)) is None
+
+
+@pytest.mark.parametrize("cmd,expect_body", [
+    ("cat <<'EOF'\nbody line\nEOF", "body line"),
+    ('cat <<"EOF"\nbody line\nEOF', "body line"),
+    ("cat <<EOF\nbody line\nEOF", "body line"),
+    ("cat <<\\EOF\nbody line\nEOF", "body line"),
+    ("cat <<-EOF\n\tbody line\n\tEOF", "\tbody line"),
+    ("cat <<EOF\nbody line", "body line"),            # unterminated -> runs to EOF
+])
+def test_scan_lifts_every_heredoc_spelling_out_as_a_body(cmd, expect_body):
+    """The tag parser, per spelling — all five name the same terminator. `<<-`
+    strips leading TABS from the terminator LINE only; the body text itself is
+    preserved, because the guard reads it as commands and must not invent
+    whitespace changes."""
+    _segs, _subs, bodies = gc._scan(cmd)
+    assert bodies == [expect_body], (cmd, bodies)
+
+
+@pytest.mark.parametrize("cmd", [
+    'cat <<< "x"; git stash push -m wip',
+    'cat <<< "x"\ngit stash push -m wip',
+    "cat <<<x\ngit stash push -m wip",
+    "cat <<<EOF\ngit stash push -m wip",
+    "grep foo <<<$VAR\ntalosctl -n 1.2.3.4 reset",
+])
+def test_a_here_STRING_is_not_a_heredoc(cmd):
+    """🔴 `<<<` has no body and no terminator line. Reading it as one consumes
+    the rest of the text as an unterminated body — the exact failure this change
+    fixes, reintroduced in a new place.
+
+    The three bare-word arms are the ones that matter, and they are why the
+    here-string is skipped WHOLE rather than excluded inside the heredoc branch:
+    a `not startswith("<<<")` test only protects the FIRST `<`, and the scan
+    visits the second one too, where `<<<x` reads as `<<` + tag `x`. Measured
+    on the first draft of this change — and on PR #396 — as a body swallowing
+    everything after it.
+    """
+    segs, _subs, bodies = gc._scan(cmd)
+    assert bodies == [], (cmd, bodies)
+    assert any(s.strip().startswith(("git stash", "talosctl")) for s in segs), segs
+
+
+def test_two_heredocs_on_one_line_are_consumed_in_order():
+    """bash reads the bodies in the order the operators appear. Swapping them
+    would mis-attribute the first while still looking additive."""
+    segs, _subs, bodies = gc._scan("diff <<A <<B\nfirst\nA\nsecond\nB\ngit stash")
+    assert bodies == ["first", "second"]
+    assert any("git stash" in s for s in segs)
+
+
+def test_an_unterminated_quote_does_not_blind_the_tail(tmp_path):
+    """The second half of the fix, with NO heredoc in sight — the swallow needs
+    only an ODD number of quote characters. Both arms below were measured ALLOW
+    on the shipped guard.
+
+    Note the near-miss third arm, which was ALREADY denied and is here as the
+    control: `isn't … done` closes its own quote by accident, so the tail was
+    never buried. An unpaired quote is the trigger, not an apostrophe.
+    """
+    repo = _mkrepo(tmp_path / "r", branch="main")
+    assert gc.evaluate("echo 'oops; talosctl -n 1.2.3.4 reset",
+                       "claude-code", str(repo)) is not None
+    assert gc.evaluate('echo "half open; talosctl -n 1.2.3.4 reset',
+                       "claude-code", str(repo)) is not None
+    assert gc.evaluate("echo 'it isn't done; talosctl -n 1.2.3.4 reset",
+                       "claude-code", str(repo)) is not None
+
+
+# --- 9a. 🔴 THE UNION — why the shipped parse is KEPT, not replaced --------- #
+
+def test_the_shipped_parse_is_kept_so_a_lift_cannot_lose_a_deny(tmp_path):
+    """🔴 THE MUTATION TARGET OF THIS WHOLE CHANGE, and the reason
+    `_scan(_lift=False)` exists.
+
+    Lifting a heredoc body out CHANGES THE QUOTE STATE of everything after it.
+    The old scanner's runaway quote sometimes left a `$( )`/backtick
+    substitution UNQUOTED — and therefore visible — where the clean parse leaves
+    the same bytes inside a quote that now balances. Neither reading is "right"
+    about text bash itself rejects; a guard simply must not lose the deny.
+
+    These four inputs were found by a 20,000-input verdict fuzz and are the ONLY
+    four it found. Their red/green baselines are NOT origin/main — they DENY
+    there, which is the whole point — they are RED against a scanner that lifts
+    heredocs WITHOUT keeping the shipped parse (measured: all four ALLOW). They
+    are green here because `split_commands` unions the shipped parse back in.
+    Delete that union, or make legacy mode lift heredocs, and these go red.
+    """
+    repo = _mkrepo(tmp_path / "r", branch="main")
+    for cmd in [
+        "'stash' | <<-EOF\nadd\n-f\nit's\nEOF\n | of=/dev/sdc & $(cat); "
+        "<<< it's && 'mkfs.ext4' && FOO=1 || e2e/run.sh || pkill | ",
+
+        "'origin/main'; `e2e/run.sh` | <<-EOF\npkill\n-f\ngit\ndon't\nEOF\n; "
+        "( x won't ) || ( env clean cat ) | <<-EOF\n\nEOF\n\n\"mkfs.ext4\" | "
+        "<<-EOF\n\nEOF\n | '-fd' ",
+
+        "'-m' || <<-EOF\nit's\nEOF\n\n\"won't && clean; bash `mkfs.ext4`\n"
+        "'cat'; $(won't -f mkfs.ext4)\n",
+
+        "'-fd'; <<\"MSG\"\ncommit\nMSG\n && <<< mkfs.ext4 || <<-EOF\nbash\n"
+        "--all\n--all\nmkfs.ext4\nEOF\n & \"/tmp/m\" && \"-m\"\n'-C' & <<MSG\n"
+        "bash\nhi\nif=/dev/zero\nls\nMSG\n\n'commit'; ",
+    ]:
+        assert gc.evaluate(cmd, "opencode", str(repo)) is not None, cmd
+
+
+def test_legacy_scan_mode_is_the_shipped_scanner(tmp_path):
+    """`_lift=False` must stay the OLD behaviour, or the union above stops being
+    a union of anything. Pinned by the two properties that define it: it emits
+    NO heredoc bodies, and it does not recover from an unterminated quote — so
+    the tail really is buried in one segment, exactly as it ships today."""
+    cmd = "cat <<EOF\ndon't stage\nEOF\ngit commit -m x"
+    l_segs, _l_subs, l_bodies = gc._scan(cmd, _lift=False)
+    assert l_bodies == [], "legacy mode must not lift heredoc bodies"
+    assert not any(s.strip() == "git commit -m x" for s in l_segs), \
+        "legacy mode must still bury the tail — that IS the bug being fixed"
+    # …and the lifted mode, on the same input, must differ. Without this the
+    # assertions above could both hold on a scanner that does nothing at all.
+    segs, _subs, bodies = gc._scan(cmd)
+    assert bodies == ["don't stage"]
+    assert any(s.strip() == "git commit -m x" for s in segs)
+
+
+@pytest.mark.parametrize("cmd,expect", [
+    ("git status", False),
+    ("echo 'a && b'; ls", False),
+    ("cat <<< \"x\"; git stash", False),        # a here-string is not a heredoc
+    ("cat <<EOF\nx\nEOF", True),                 # a heredoc operator
+    ("echo 'oops; talosctl reset", True),        # an unterminated quote
+    ('"\'" \'x', True),                          # …with an EVEN count of them
+])
+def test_diverged_is_true_whenever_the_two_parses_differ(cmd, expect):
+    """🔴 `diverged is False` is what `split_commands` skips the second scan on,
+    so a False negative there silently removes the union — the whole safety
+    property — with every test still green. Pinned against the real comparison.
+
+    The last case is why this is COMPUTED and not a textual heuristic: `"'" 'x`
+    leaves an unterminated `'` while containing an EVEN number of them, so a
+    guard keyed on quote parity would score it "balanced" and skip the union on
+    exactly the shape it exists for.
+    """
+    segs, subs, bodies, diverged = gc._scan_raw(cmd)
+    lsegs, lsubs, lbodies, _ = gc._scan_raw(cmd, _lift=False)
+    really = (segs, subs, bodies) != (lsegs, lsubs, lbodies)
+    assert really is expect, (cmd, segs, lsegs)
+    assert diverged is expect, (cmd, diverged)
+
+
+def test_split_commands_still_returns_the_shipped_segments(tmp_path):
+    """The union is a SUPERSET, asserted at the seam rather than argued in a
+    docstring: everything the legacy scan produces is in the output."""
+    for cmd in ["cat <<EOF\ndon't stage\nEOF\ngit commit -m x",
+                "echo 'a && b'",
+                "ls; talosctl reset",
+                "git commit -m 'unterminated"]:
+        legacy_segs, legacy_subs, _ = gc._scan(cmd, _lift=False)
+        out = gc.split_commands(cmd)
+        for s in legacy_segs + legacy_subs:
+            if s.strip():
+                assert s in out, (cmd, s, out)
+
+
+def test_body_recursion_and_quote_recovery_are_bounded():
+    """A nesting bomb must not spin a hook that fires on every Bash call."""
+    text = "x"
+    for _ in range(12):
+        text = f"bash <<EOF\n{text}\nEOF"
+    gc.split_commands(text)          # must return
+    gc.split_commands("'" * 4000)    # …and so must pathological quoting


### PR DESCRIPTION
**This is the scanner half of #396, extracted so it can ship on its own.** #396
bundles it with a rewrite of how the guard decides which repo/branch a command
acts on; an adversarial audit found four DENY→ALLOW regressions in that half.
This PR carries **only** the scanner fix, which closes a bypass that is deployed
right now.

## The bypass

A heredoc body is prose, and `split_commands` tracked quote state through it. A
lone apostrophe (`don't`, `it's`) opened a quote that never closed, so every
command **after** the heredoc was swallowed into that quoted buffer and never
parsed. `_tokenise` then fell back to a whitespace split whose `argv[0]` is a
word from the message, and every argv check silently stopped matching.

Measured on the shipped core (`origin/main`), cwd = a clone on `main`. The two
arms differ by **one character**:

```
cat > /tmp/m <<EOF
fix: don't blindly stage        <- vs "fix: blindly stage nothing"
EOF
<victim>
```

| victim | with the apostrophe | without |
|---|---|---|
| `git commit -m x` | **ALLOW** | DENY |
| `git stash push -m wip` | **ALLOW** | DENY |
| `git -C /tmp reset --hard origin/main` | **ALLOW** | DENY |
| `git clean -fd` | **ALLOW** | DENY |
| `talosctl -n 1.2.3.4 reset` | **ALLOW** | DENY |
| `mkfs.ext4 /dev/sdc` | **ALLOW** | DENY |
| `dd if=/dev/zero of=/dev/sdc` | **ALLOW** | DENY |
| `pkill -f e2e/run.sh` | **ALLOW** | DENY |

Three of those are irreversible-action families.

## What changed

- `_scan` recognises the heredoc operator (`<<TAG`, `<<-TAG`, quoted and
  backslash-escaped tags) and **lifts the body out of the surrounding quote
  state**. Nothing is blanked: bodies are still returned, still parsed as
  commands, still checked — so `bash <<EOF` keeps every deny it had (asserted).
  This is **not** the reverted `_strip_message_text()` helper the module
  docstring forbids; the distinction is argued at the definition.
- A here-**string** (`<<<`) is consumed **whole** rather than excluded inside
  the heredoc branch. Testing `not startswith("<<<")` there is not enough — the
  scan also visits the **second** `<`, where `<<<x` reads as `<<` + tag `x` and
  swallows the rest of the text as an unterminated body. Measured on #396's head
  as well: `cat <<<x\ngit stash …` produces a spurious body there.
- An unterminated quote from **any** source re-scans its own tail. Lifting alone
  was not enough for `bash <<EOF / it's fine / git stash push -m wip / EOF`,
  where the corruption then happens inside the body's *own* parse.
- 🔴 `split_commands` **unions the shipped parse back in**, gated on a computed
  `diverged` flag.

## 🔴 Why the shipped parse is KEPT — a correction to #396

#396 states the change "can only make **more** argv visible, never fewer".
That is true of `split_commands`' own output, and **false at the seam that
matters**. Lifting a body out changes the quote state of everything after it,
and the old parse's corrupt state sometimes left a `$( )`/backtick substitution
**unquoted, and therefore visible**, where the clean parse leaves the same bytes
inside a quote that now balances differently.

A 20,000-input fuzz comparing **verdicts** from the full 15-check policy found
**four** inputs where lifting alone turns a DENY into an ALLOW. (Comparing argv
*sets* does not find them and is the wrong yardstick: the base scanner
legitimately emits heredoc terminator lines and the corrupted whole-tail blob,
both of which *should* disappear.) One of the four:

```
'-m' || <<-EOF / it's / EOF / "won't && clean; bash `mkfs.ext4` …
```

Neither parse is "right" about text bash itself rejects as unterminated; a guard
simply must not lose the deny. Taking the union makes the additivity claim
**true by construction**, so no future fuzz seed can find a fifth case. All four
inputs are pinned as a regression test and the union is mutation-covered.

The second scan is **skipped** when the first reports `diverged is False` — a
proof, not a heuristic, that both modes produced identical segments. A textual
precondition would be unsound: `"'" 'x` leaves an unterminated `'` with an
**even** count of them.

## Verification

**24 new tests.** Same test file against `origin/main`'s `guard_core.py`:
**35 failed / 1309 passed**, of which **4 are pre-existing artefacts** of running
the file without its sibling hook/plugin scripts (confirmed by running the
*unmodified* test file the same way) — so **31 genuine reds**, all green here.

| gate | result |
|---|---|
| `scripts/run-tests.sh --set hermetic` | `collected=7305 passed=7304 skipped=1 failed=0` · **RESULT: PASS** |
| `test_guard_core.py` | **collected=1344, passed=1344** (floor 1260, ceiling 1575 — no floor bump due) |
| `test_bash_guard.py` | `RESULT: all good` |

Fuzz — 20,000 inputs each, **positive control reported beside every zero**:

| fuzz | result | positive control |
|---|---|---|
| verdict, base vs this (seeds 20260811 / 1 / 777) | **DENY→ALLOW = 0** | ALLOW→DENY = 270 / 259 / 274 |
| argv-set additivity | **LOST = 0** | GAINED = 5026 inputs |
| legacy-mode ≡ `origin/main`'s `split_commands` | **MISMATCHES = 0** | lifted mode really differed on 10088 |

**15 semantic mutants, all KILLED**, each by a named test — including *drop the
union* (#396's shape), *the divergence gate under-reports a heredoc*, *…an
unterminated quote*, *legacy mode also lifts*, *bodies lifted but never
returned*, *two heredocs come back reversed*, *recovery restarts at the quote so
it makes no progress*, and both here-string mutants.

**Control battery**, 39 cases, real `git init` fixtures, `evaluate(cmd,
"claude-code", cwd)`:

- **29 negative controls all DENY** — bare commit on `main`/`trunk`, `--amend`,
  commit via heredoc, via heredoc **with** an apostrophe, `git -C <repo-on-trunk>
  commit` from a topic cwd, `cd`/subshell/`bash -c`/`GIT_DIR=` hops into `main`,
  `git stash`, `git reset --hard`, `git clean -fd`, `git add --all`, `pkill -f`,
  each also in its "after an apostrophe heredoc" spelling, plus `bash <<EOF`
  bodies that really execute.
- **10 positive controls unchanged from `origin/main`.** In particular the three
  worktree spellings #396 exists to unblock — `(cd $WT && git commit)`,
  `git -C "$VAR" commit`, and `-C` via a sourced env file — **still DENY here**.
  That is the branch-resolution half and is deliberately **not** in this PR.

**Parse cost** (`commands()`, min of 7 × 200 reps): ordinary command lines are
unchanged because `diverged=False` skips the second scan — `git status`
0.050 → 0.049 ms, a `git -C "$WT" …` worktree recipe 0.077 → 0.092 ms. Text that
carries a heredoc pays for both scans: 10-line 0.143 → 0.258 ms, 400-line
5.09 → 9.18 ms.

## 🔴 Not live

`~/.claude/hooks/guard_core.py` resolves into `/nix/store` — a home-manager
`home.file` **copy**, not an out-of-store symlink. Merging this changes nothing
on either host until someone runs `home-manager switch`. **None was run as part
of this work.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
