### PR TITLE
fix(guard): the command's own assignment must beat an ambient export of that name

### DIFF
--- a/scripts/claude-hooks/guard_core.py
+++ b/scripts/claude-hooks/guard_core.py
@@ -1272,6 +1272,12 @@ def _env_file_vars(raw, base, known):
     return out
 
 
+# The value a POISONED name resolves to: a path that cannot be a directory on
+# any host. Under `/dev/null/` so `os.path.isdir` answers False rather than
+# raising — a NUL byte would crash the check it is meant to fail.
+_UNRESOLVABLE = "/dev/null/guard-unresolvable"
+
+
 def _command_vars(cmd, base):
     """Shell variables this command line SETS, as far as they can be evaluated.
 
@@ -1329,6 +1335,18 @@ def _command_vars(cmd, base):
         if i < len(toks) and toks[i] in _SOURCE_CMDS and i + 1 < len(toks):
             sourced.append(toks[i + 1])
 
+    # 🔴 A POISONED NAME IS PINNED UNRESOLVABLE, not merely left absent. Since
+    # `cvars` is consulted BEFORE the environment, "absent" would mean "fall
+    # through to `expandvars`" — so a name the command assigned ambiguously would
+    # quietly resolve to a stale ambient export of that name, reintroducing the
+    # guard-vs-shell disagreement the ordering exists to remove, by the back
+    # door. The command DID assign this name; the guard just cannot say to what,
+    # and the honest answer is "unknown", never "whatever it used to mean".
+    # Pinned by test_an_ambiguous_name_does_not_fall_through_to_the_ambient_value
+    # — written expecting it to pass, and it did not.
+    for name in poisoned:
+        vals[name] = _UNRESOLVABLE
+
     # A sourced file is the LOWER layer: an assignment written in the command
     # text itself is more specific and wins, and a poisoned name stays poisoned.
     for raw in sourced:
@@ -1341,16 +1359,34 @@ def _command_vars(cmd, base):
 def _resolve_dir(value, base, cvars=None):
     """A command-supplied path -> an existing directory, or None.
 
-    Expands `$HANDLE` (from the environment first, then from `cvars` — the
-    variables the command line itself sets) and `~`, resolves a relative path
-    against `base`, and maps `<repo>/.git` onto `<repo>` so a `--git-dir` is
-    judged as its worktree.
+    Expands `$HANDLE` (from `cvars` — the variables the command line itself sets
+    — FIRST, then from the hook process's environment) and `~`, resolves a
+    relative path against `base`, and maps `<repo>/.git` onto `<repo>` so a
+    `--git-dir` is judged as its worktree.
+
+    🔴 THAT ORDER IS THE WHOLE POINT AND IT USED TO BE THE OTHER WAY ROUND.
+    `expandvars` reads the hook's OWN environment, which on this host carries
+    pre-exported handles (`$DEVRC`, `$DATAPACKET`, …). When a command re-points
+    one of those names at a different directory, the shell uses the command's
+    value and the guard used the ambient one — so the two disagreed about which
+    repo was being committed in, in BOTH directions. Measured against the
+    previous order, ambient `$WT` and a command that reassigns it:
+
+        ambient=<feature repo>, command `WT=<repo on main>; git -C "$WT" commit`
+            -> ALLOW, and the commit really does land on main   (FAIL-OPEN)
+        ambient=<repo on main>, command `WT=<feature repo>; git -C "$WT" commit`
+            -> DENY, blocking work that was never on main       (false positive)
+
+    A shell evaluates the assignment it just executed, not a stale export of the
+    same name; so does this now. `cvars` is already fail-closed about what it
+    will evaluate (a name assigned twice, or to anything containing `$`, is
+    dropped), so preferring it cannot resolve a value the guard had to guess.
     """
     if not value:
         return None
-    value = os.path.expandvars(value.strip("\"'"))
+    value = _subst_vars(value.strip("\"'"), cvars)
     if "$" in value:
-        value = _subst_vars(value, cvars)
+        value = os.path.expandvars(value)
     value = os.path.expanduser(value)
     if not value:
         return None

--- a/scripts/claude-hooks/tests/test_guard_core.py
+++ b/scripts/claude-hooks/tests/test_guard_core.py
@@ -2513,6 +2513,64 @@ def test_variable_resolution_never_turns_a_blocked_repo_into_an_allowed_one(tmp_
         f". {env}\ngit -C \"$WT\" commit -m x", str(wt)) is not None
 
 
+def test_the_commands_own_assignment_beats_an_AMBIENT_export_of_that_name(
+        tmp_path, monkeypatch):
+    """🔴 Both directions of a precedence bug, and one of them FAILS OPEN.
+
+    `expandvars` reads the hook process's own environment, and this host exports
+    handles (`$DEVRC`, `$DATAPACKET`, …) that a command can perfectly well
+    reassign. Resolving the ambient value first meant the guard and the shell
+    disagreed about which repo was being committed in. Measured against that
+    order, with `WT` exported AND reassigned in the command:
+
+        ambient=<feature>, command re-points at <main>  -> ALLOW  (fail-open:
+            the commit really does land on main)
+        ambient=<main>, command re-points at <feature>  -> DENY   (false
+            positive on work that was never on main)
+
+    A shell uses the assignment it just executed. The fail-open half is the one
+    that matters: it is a silent commit onto a main branch, which is the entire
+    hazard this check exists for.
+    """
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    on_feat = _mkrepo(tmp_path / "feat-repo", branch="feat/x")
+    innocent = _mkrepo(tmp_path / "cwd-repo", branch="feat/cwd")
+
+    monkeypatch.setenv("WT", str(on_feat))          # ambient says "harmless"
+    assert gc.check_git_commit_to_main(             # …command says otherwise
+        f'WT={on_main}; git -C "$WT" commit -m x', str(innocent)) is not None
+
+    monkeypatch.setenv("WT", str(on_main))          # ambient says "blocked"
+    assert gc.check_git_commit_to_main(             # …command says otherwise
+        f'WT={on_feat}; git -C "$WT" commit -m x', str(innocent)) is None
+
+
+def test_an_ambient_handle_still_resolves_when_the_command_sets_nothing(
+        tmp_path, monkeypatch):
+    """The non-regression half: preferring `cvars` must not stop reading the
+    environment at all. A handle the hook really does inherit, and that the
+    command never reassigns, still resolves to the repo it names."""
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    on_feat = _mkrepo(tmp_path / "feat-repo", branch="feat/x")
+    monkeypatch.setenv("SOME_REPO_HANDLE", str(on_main))
+    assert gc.check_git_commit_to_main(
+        'git -C "$SOME_REPO_HANDLE" commit -m x', str(on_feat)) is not None
+
+
+def test_an_ambiguous_name_does_not_fall_through_to_the_ambient_value(
+        tmp_path, monkeypatch):
+    """🔴 The interaction between this precedence and `cvars`' own fail-closed
+    rule. A name assigned TWICE is deliberately dropped from `cvars` — it must
+    then take the cwd fallback, NOT quietly resolve to an ambient export of the
+    same name, which would reintroduce exactly the disagreement above by the
+    back door."""
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    on_feat = _mkrepo(tmp_path / "feat-repo", branch="feat/x")
+    monkeypatch.setenv("WT", str(on_feat))          # ambient looks harmless
+    cmd = f'WT={on_main}\nWT={on_feat}\ngit -C "$WT" commit -m x'
+    assert gc.check_git_commit_to_main(cmd, str(on_main)) is not None
+
+
 def test_a_variable_assigned_twice_is_not_guessed(tmp_path):
     """Ambiguity falls back to the cwd rather than picking a winner. Two
     different literals for one name means the guard does not know the value, and


### PR DESCRIPTION
Follow-on to #396, which made `git -C "$WT" commit` resolvable at all. One
ordering detail in it is wrong in both directions, and one of them fails open.

`_resolve_dir` ran `os.path.expandvars` FIRST and consulted `cvars` — the
variables the command line itself sets — only for what was left. This host
exports handles (`$DEVRC`, `$DATAPACKET`, …) that a command can perfectly well
reassign, and when one does, the shell uses the command's value while the guard
used the ambient one. Measured against the shipped order, `WT` both exported and
reassigned, cwd on an innocent topic branch:

    ambient=<feature repo>, command `WT=<repo on main>; git -C "$WT" commit`
        -> ALLOW, and the commit really does land on main        FAIL-OPEN
    ambient=<repo on main>, command `WT=<feature repo>; git -C "$WT" commit`
        -> DENY, blocking work that was never on main            false positive

`cvars` is consulted first now. It is already fail-closed about what it will
evaluate — a name assigned twice, or to anything containing `$`, is dropped — so
preferring it cannot resolve a value the guard had to guess.

Swapping the order alone opened a second hole, which its own test caught before
this shipped: a POISONED name was merely absent from `cvars`, and absent now
means "fall through to `expandvars`", so an ambiguously-assigned name quietly
resolved to a stale ambient export of itself — the same guard-vs-shell
disagreement by the back door. Poisoned names are now pinned to an unresolvable
sentinel (under `/dev/null/`, so `isdir` answers False rather than raising, which
a NUL byte would). The command DID assign the name; the guard just cannot say to
what, and the honest answer is "unknown", never "whatever it used to mean".

VERIFICATION

- 3 new tests. Red-at-base measured in ONE tree with only guard_core.py swapped
  for origin/main's: the 2 defect tests RED, the non-regression test GREEN —
  the shape that shows they pin the defect and not the fixture.
- Mutation sweep, 4 mutants, all KILLED, each by the test written for it:
  ordering reverted; poisoned names left absent; the sentinel pointed somewhere
  that exists; the environment never consulted at all (that last one guards the
  non-regression half — an ambient handle the command does NOT reassign must
  still resolve).
- `nix build .#checks.x86_64-linux.pytests` PASS — 7424 collected, 7423 passed,
  1 pinned skip; guard suite 1357 over a floor of 1260.
- Driven through the REAL bash-guard.py adapter over 8 cases against live repos:
  2 negative controls still deny, 1 positive control still allows, the 3 worktree
  shapes allow, 2 must-still-deny cases hold. 8/8.

Supersedes #401, which reimplemented #396's literal-assignment resolution before
that landed; only this precedence defect survived the comparison.

NOT deployed — `~/.claude/hooks/guard_core.py` is a home.file copy, so #396 and
this both stay inert until `home-manager switch` / `ship.sh`. That gap is why the
guard was still denying the mandated worktree recipe today, hours after #396
merged.
