### PR TITLE
feat(drift): enable the deadman — both preconditions measured, not argued

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -21,13 +21,17 @@ let
   # Drift-deadman master switch (scripts/drift-check.sh) — gates ONLY whether the
   # timer is wired into timers.target. The SERVICE definition is always emitted, so
   # `systemctl --user start drift-check` works by hand on either host regardless.
-  # 🔴 Deliberately OFF at merge: the deadman was built + validated against scratch
-  # clones only, and enabling a timer is a live change to a host's behaviour. Flip to
-  # true in a separate, supervised deploy after one hand-run on the workbench proves
-  # the ssh leg reaches the laptop from a systemd-user context (a user unit has no
-  # ssh-agent, so the laptop key must be usable non-interactively — the one thing
-  # scratch clones structurally cannot test).
-  enableDriftDeadman = false;
+  # ON since 2026-08-11. Both preconditions were MEASURED on the workbench, not
+  # argued — each is a thing scratch clones structurally cannot test:
+  #   1. the ssh leg reaches the laptop from a systemd-user context (no ssh-agent):
+  #      a hand-run of drift-check.service found REAL drift (laptop 1 behind), rc 10.
+  #   2. the failure toast actually DISPLAYS. It did not, at first — dunst was paused
+  #      with 286 notifications queued, so the alert was sent and silently binned.
+  #      #381 fixed that; re-measured here as displayed 0 -> 1 with waiting UNCHANGED
+  #      while paused=true, driven by a real unit failure (rc 8) on a throwaway clone.
+  # (2) is why this flag waited: a timer alerting into a paused queue is WORSE than no
+  # timer, because it manufactures the appearance of coverage.
+  enableDriftDeadman = true;
   # Graphical host = runs X/i3 (both current NixOS hosts do; only a genuinely headless
   # box would not). Approximated as isNixOS, mirroring graphical.nix — deliberately NOT
   # !serverMode, which is true on the graphical workbench.


### PR DESCRIPTION
## What

Flips `enableDriftDeadman` to `true`, wiring `drift-check.timer` into `timers.target` (6-hourly). The service definition was already emitted unconditionally, so this is the only behavioural change.

## Why now

The flag has been `false` since #367 because its own comment demanded two things scratch clones structurally cannot test. Both are now **measured on the workbench**.

### 1. The ssh leg works from a systemd-user context

A user unit has no ssh-agent, so the laptop key had to be usable non-interactively. A hand-run of `drift-check.service` did it for real — and found **genuine drift on its first run**: the laptop 1 commit behind `origin/main`, `rc 10`, unit `failed`, `Triggering OnFailure=` in the journal.

### 2. The failure toast actually displays — this is the one that mattered

It was **false** at first. Dunst was paused with **286 notifications queued**, so the toast was sent, the notifier exited 0, and it was silently binned. Four rounds of auditing had verified the script hands systemd the right exit code and that `OnFailure` was wired; none of them could see that the notifier's *output* went nowhere. #381 closed it — along with a second, independent suppressor nobody knew about (`fullscreen_suppress` was filterless and routed these toasts straight to history whenever any fullscreen window had focus).

Re-measured here against the **deployed** dunstrc, not the repo:

```
deployed: appname="notify-failure" / fullscreen="show" / override_pause_level=100
BEFORE:   paused=true  displayed=0  waiting=240
unit:     SubState=failed  ExecMainStatus=8     ← diverged/un-pushed shape
AFTER:    paused=true  displayed=1  waiting=240
```

`displayed` moved and `waiting` did not — displayed, not queued. Driven by a real unit failure against a throwaway `/tmp` clone; neither real checkout was touched, `DRIFT_REPO` was unset afterwards, and the pause state was left exactly as found.

**(2) is why this waited.** A timer alerting into a paused queue is worse than no timer — it manufactures the appearance of coverage over precisely the failure it exists to catch.

## Origin

The whole chain traces to a real incident: the workbench sat with 3 un-pushed commits on `main`, so `ship.sh` skipped it with `rc=8` every time, and it silently stopped receiving changes. Nothing ran `ship.sh` on a schedule, so nobody noticed until an unrelated deploy surfaced it. Second occurrence — the same failure is recorded in `CLAUDE.md` for 2026-08-06.

## Residual, stated plainly

- **The timer has still never fired on its own schedule.** Every run so far has been hand-started. The first autonomous run is the remaining unknown.
- The unit will legitimately go red whenever the laptop has been off ~24h (4 consecutive unreachable checks at 6h). That is by design, and it will toast.
- Hand-running `drift-check.sh` shares the streak counter with the timer, so manual runs while the laptop is off can push it over threshold on their own.

## Rollback

Set the flag back to `false` and `ship.sh`. The service definition remains either way, so `systemctl --user start drift-check` keeps working by hand.