### PR TITLE
fix(collector): one malformed file_path aborted every claude session-summary — and its skip counter never reached systemd

### DIFF
--- a/claudedocs/decision-subsystem-store-rejected-2026-08-11.md
+++ b/claudedocs/decision-subsystem-store-rejected-2026-08-11.md
@@ -103,10 +103,29 @@ supplies the evidence the `org` strain test found missing.
 
 Decisions taken:
 
-- **Association is derived, not tagged.** Map session → subsystem from what the collector
-  already emits (`kind=session-summary` carries git commits/pushes) by matching path
-  components against the entry's slug and `aliases:`. This deliberately does **not** persist
-  a location, preserving the index's rule that location is always re-derived live.
+- **Association is derived, not tagged.** Map session → subsystem by matching the path
+  components of `kind=session-summary`'s **`changed_paths`** against the entry's slug and
+  `aliases:`. This deliberately does **not** persist a location, preserving the index's rule
+  that location is always re-derived live.
+
+  🔴 **CORRECTION — the original wording of this bullet was wrong when written.** It said
+  the mapping works from "what the collector already emits (`kind=session-summary` carries
+  git commits/pushes)". `session-summary` carried integer **counts** — `git_commits`,
+  `git_pushes`, `files_modified` — and never a commit, never a path. There was nothing to
+  match path components *against*; the derivation was asserted with no data behind it, and
+  anyone building P0 against that sentence would have got to the resolver and found its
+  input did not exist. Recorded rather than quietly edited: the failure was believing a
+  field name implied a payload, which is the same mistake as reading a type declaration as
+  a code path.
+
+  The paths exist as of **PR #398**, which added the `changed_paths*` block to both sources
+  and fixed the opencode extractor. Two properties the resolver must be built against, both
+  measured, neither optional: `changed_paths` is `null` when the file set could not be
+  observed — **not** an empty list, and a `null` read as "touched nothing" reintroduces
+  exactly the silent zero #398 removed; and it carries only paths under the session cwd,
+  **~1 in 7** of the modified paths (470 of 3,290, 2026-08-11), with the remainder counted
+  in `changed_paths_outside_cwd`. So a subsystem's session count is a **lower bound**, which
+  the liveness convention has to state rather than round away.
 - **The edge lives in ClickHouse**, as a new `kind=session-subsystem` event — one row per
   `(session, subsystem)`. Do **not** extend `session-summary`: consumers dedupe it with
   `argMax(<field>, ingested_at) GROUP BY session`, and a session touches N subsystems.

--- a/claudedocs/decision-subsystem-store-rejected-2026-08-11.md
+++ b/claudedocs/decision-subsystem-store-rejected-2026-08-11.md
@@ -119,13 +119,23 @@ Decisions taken:
   a code path.
 
   The paths exist as of **PR #398**, which added the `changed_paths*` block to both sources
-  and fixed the opencode extractor. Two properties the resolver must be built against, both
-  measured, neither optional: `changed_paths` is `null` when the file set could not be
-  observed — **not** an empty list, and a `null` read as "touched nothing" reintroduces
-  exactly the silent zero #398 removed; and it carries only paths under the session cwd,
-  **~1 in 7** of the modified paths (470 of 3,290, 2026-08-11), with the remainder counted
-  in `changed_paths_outside_cwd`. So a subsystem's session count is a **lower bound**, which
-  the liveness convention has to state rather than round away.
+  and fixed the opencode extractor — and they are **populated, not merely defined**: #398 is
+  deployed to both hosts, and 585 historical opencode sessions have been backfilled, turning
+  362 files / 94 commits / 37,311 lines that read as a hard zero into real rows. P0 therefore
+  has a corpus to resolve against on day one rather than only forward-going data.
+
+  Two properties the resolver must be built against, both measured, neither optional:
+  `changed_paths` is `null` when the file set could not be observed — **not** an empty list,
+  and a `null` read as "touched nothing" reintroduces exactly the silent zero #398 removed;
+  and it carries only paths under the session cwd, **~1 in 7** of the modified paths (470 of
+  3,290, 2026-08-11), with the remainder counted in `changed_paths_outside_cwd`. So a
+  subsystem's session count is a **lower bound**, which the liveness convention has to state
+  rather than round away.
+
+  ⚠ Backfilling again is not a one-liner: `opencode/backfill.py` clears the message-tailer
+  state as well as the summary state, and message rows carry no `argMax`-on-read dedupe
+  contract, so a naive re-run re-emits ~6,100 duplicate message rows. The 585-session
+  backfill cleared **only** the summary state deliberately.
 - **The edge lives in ClickHouse**, as a new `kind=session-subsystem` event — one row per
   `(session, subsystem)`. Do **not** extend `session-summary`: consumers dedupe it with
   `argMax(<field>, ingested_at) GROUP BY session`, and a session touches N subsystems.

--- a/scripts/collector/README.md
+++ b/scripts/collector/README.md
@@ -87,8 +87,21 @@ touched) needs the PATHS.
 | `changed_paths_total` | distinct count **before** the cap — the truncation discriminator |
 | `changed_paths_truncated` | the list is a prefix, not the whole story |
 | `changed_paths_outside_cwd` | distinct changed paths with no repo-relative form (scratchpads, other repos, temp worktrees). `total + outside_cwd == files_modified`. |
+| `unusable_file_paths` (claude) | tool blocks whose file-path argument could not be read as a path at all (non-string / blank / malformed `input`). Counted, never coerced into a path and never dropped in silence. Normally 0; a non-zero is a malformed-transcript signal, not a session measurement. |
 | `changed_paths_cap` | the bound this emitter was built with (256 — see the module docstring for the measurement) |
 | `stats_unavailable` | `[]`, or the groups that could not be observed. `"files"` covers `changed_paths*` + (on opencode) `files_modified` / `lines_added` / `lines_removed` / `languages`; `"git"` covers `git_commits` / `git_pushes`. |
+
+🔴 **SIZE YOUR EXPECTATIONS: `changed_paths` carries roughly one path in seven, not
+all of them.** Only paths under the session cwd have a repo-relative form; everything
+else is counted in `changed_paths_outside_cwd` and never listed. Measured over every
+transcript the claude tailer walks (2026-08-11, read-only): **470 of 3,290 distinct
+modified paths — 14.3%** — had one. Three independent dry runs put the ratio at
+14–16%, so treat ~1-in-7 as the planning number, not an outlier. The excluded 85% is
+dominated by the per-session agent scratchpad and by short-lived git worktrees under
+`/tmp`; the worktree bucket alone (802 paths) is **1.7x larger than the whole emitted
+set**. A consumer that reads a short list as "this session barely touched anything"
+will be wrong on most sessions — read `changed_paths_outside_cwd` beside it.
+`changed_paths.py`'s module docstring has the full classification.
 
 🔴 **A zero that means "cannot report" is indistinguishable from a real zero**, and
 that ambiguity is what this block removes. OpenCode emitted `files_modified=0`,

--- a/scripts/collector/README.md
+++ b/scripts/collector/README.md
@@ -41,6 +41,14 @@ tmux focus hooks   ─┼─► emit (pure shell, hot path) ─► spool/current
   re-reads the whole transcript, so newest = most complete). See
   `scripts/session-analysis/insights.py`. A transcript
   that can't be parsed is emitted with `unreadable: true` — never fabricated.
+  A transcript that raises while being summarised is **skipped, named on stderr and
+  counted** (`failed=N` on the run's summary line) so one malformed file cannot abort
+  the pass for every other session — and 🔴 **any `failed` makes the run exit
+  non-zero**, because `claude-activity-source` is `Type=oneshot` with
+  `OnFailure = notify-failure@%n.service`: a count that never reaches the exit status
+  would let a systemic breakage (every session failing) read as unit success with no
+  toast. A skipped transcript's signature is deliberately **not** recorded, so a code
+  fix heals the corpus without the file having to change.
   Both tailers share `claude/_shared.py` (ts/project/emit/root/iter helpers) and run
   on the same 5-min `claude-activity-source` timer (both hosts).
   Layer B (`kind=session-insight`, qualitative goal/outcome/friction) is a later PR.

--- a/scripts/collector/changed_paths.py
+++ b/scripts/collector/changed_paths.py
@@ -93,9 +93,13 @@ paths and ~16x on directories. The conclusion is unchanged, and the corrected
 figure is what makes it worth stating: the counted-but-dropped worktree set alone
 is **1.7x larger than the entire emitted path set** (802 vs 470), so a consumer
 that reads `changed_paths` as the session's file list, rather than as a subset
-sized by `changed_paths_outside_cwd`, is wrong by more than the data it has. The
-in/out headline reproduces across three independent runs (14.3% / 15.2% / 16%) —
-that ratio is stable, the sub-classification was not measured, only estimated.
+sized by `changed_paths_outside_cwd`, is wrong by more than the data it has.
+
+Every count above is a measurement, not an estimate: the four buckets sum
+exactly to the 2,820 excluded, and the in/out headline reproduces across three
+independent runs (14.3% / 15.2% / 16%). What the superseded figures lacked was a
+measurement of the SUB-classification — the split was approximated while the
+headline was counted, which is why only it was wrong.
 
 ⚠ TRUNCATION BIAS, STATED RATHER THAN LEFT TO BE DISCOVERED: the list is sorted
 lexicographically, so a truncated list is a lexicographic PREFIX and can

--- a/scripts/collector/changed_paths.py
+++ b/scripts/collector/changed_paths.py
@@ -63,25 +63,39 @@ Raise it only with a new measurement quoted. Lowering it below the measured p999
 
 WHAT `changed_paths_outside_cwd` ACTUALLY COUNTS — MEASURED, NOT ASSUMED
 ------------------------------------------------------------------------
-A dry run over 700 real Claude transcripts (2026-08-11, read-only, nothing
-emitted) found 3,384 distinct modified paths, of which 525 (16%) were under the
-session cwd and 2,859 (84%) were not. Classified by prefix, the excluded set is
-dominated by:
+A dry run over every transcript this tailer walks — 600 of them, i.e. after
+`iter_transcripts` drops the `subagents/` and `wf_*` dirs — found (2026-08-11,
+read-only, nothing emitted) 3,290 distinct modified paths, of which 470 (14.3%)
+were under the session cwd and 2,820 (85.7%) were not. Classified by prefix, the
+excluded set breaks down as:
 
-    ~1,280  the per-session agent scratchpad under /tmp
-      ~700  elsewhere under the user's home (other repos, ~/.claude, dotfiles)
-     ~150+  short-lived git worktrees under /tmp, spread over ~30 directories
+    1,225  the per-session agent scratchpad under /tmp
+      802  short-lived git worktrees under /tmp — across 487 distinct `wt-*`
+           worktree roots (645 distinct leaf directories)
+      626  elsewhere under the user's home (other repos, ~/.claude, dotfiles)
+      167  other /tmp paths
 
-The first two are exactly what MUST be excluded — a scratchpad file or a file in
-a different repo has no repo-relative form here, and inventing one would hand
-the resolver components (`tmp`, `home`, a foreign repo's name) that manufacture
-associations. The third is a genuine loss: a temp worktree IS repo content, but
-nothing in a transcript maps a worktree back to its repo, and the resolver's
-design forbids persisting a location to find out. So it is COUNTED rather than
-guessed at, and a consumer comparing `changed_paths_total` against
-`changed_paths_outside_cwd` can see how much of a session it is not being told
-about. `total + outside_cwd == files_modified` holds by construction and is
-pinned by a test.
+The scratchpad and other-repo buckets are exactly what MUST be excluded — a
+scratchpad file or a file in a different repo has no repo-relative form here, and
+inventing one would hand the resolver components (`tmp`, `home`, a foreign repo's
+name) that manufacture associations. The worktree bucket is a genuine loss: a
+temp worktree IS repo content, but nothing in a transcript maps a worktree back
+to its repo, and the resolver's design forbids persisting a location to find out.
+So it is COUNTED rather than guessed at, and a consumer comparing
+`changed_paths_total` against `changed_paths_outside_cwd` can see how much of a
+session it is not being told about. `total + outside_cwd == files_modified` holds
+by construction and is pinned by a test.
+
+🔴 CORRECTED 2026-08-11 (same day, before the numbers could be quoted anywhere
+else): the worktree bucket previously read "~150+ … spread over ~30 directories".
+Re-measured it is **802 paths over 487 worktree roots** — understated ~5.3x on
+paths and ~16x on directories. The conclusion is unchanged, and the corrected
+figure is what makes it worth stating: the counted-but-dropped worktree set alone
+is **1.7x larger than the entire emitted path set** (802 vs 470), so a consumer
+that reads `changed_paths` as the session's file list, rather than as a subset
+sized by `changed_paths_outside_cwd`, is wrong by more than the data it has. The
+in/out headline reproduces across three independent runs (14.3% / 15.2% / 16%) —
+that ratio is stable, the sub-classification was not measured, only estimated.
 
 ⚠ TRUNCATION BIAS, STATED RATHER THAN LEFT TO BE DISCOVERED: the list is sorted
 lexicographically, so a truncated list is a lexicographic PREFIX and can

--- a/scripts/collector/claude/session-tailer.py
+++ b/scripts/collector/claude/session-tailer.py
@@ -285,6 +285,14 @@ def _empty_rollup() -> dict:
         "end_ts": None,
         "cwd": "",
         "unreadable": False,
+        # Count of tool_use blocks whose file-path argument could not be read as
+        # a path at all (a non-string, or whitespace-only). COUNTED, never
+        # dropped silently and never coerced into a path — see the guard in
+        # build_rollup. It is a diagnostic about the TRANSCRIPT, not a
+        # measurement of the session: 0 means "no malformed entry was seen",
+        # including on a transcript we could not read at all (where
+        # `unreadable` / `stats_unavailable` already carry the verdict).
+        "unusable_file_paths": 0,
         # Which of the derived statistic GROUPS this rollup could not observe.
         # Sentinels: "files" (files_modified / lines_added / lines_removed /
         # changed_paths) and "git" (git_commits / git_pushes). Empty list = every
@@ -403,7 +411,16 @@ def build_rollup(objects: list[dict]) -> dict:
                         continue
                     name = block.get("name") or ""
                     tool_counts[name] = tool_counts.get(name, 0) + 1
-                    inp = block.get("input") or {}
+                    inp = block.get("input")
+                    # 🔴 A tool_use `input` that is not a dict is a MALFORMED
+                    # TRANSCRIPT, not a caller bug — `or {}` kept a truthy list
+                    # here and the next `.get` raised AttributeError, killing the
+                    # whole 5-minute pass for every OTHER session too. Count it
+                    # and carry on; `tool_counts` above is still honest.
+                    if not isinstance(inp, dict):
+                        if inp is not None:
+                            r["unusable_file_paths"] += 1
+                        inp = {}
                     if name in ("Task", "Agent"):
                         r["uses_task_agent"] = True
                     if name.startswith("mcp__"):
@@ -420,11 +437,31 @@ def build_rollup(objects: list[dict]) -> dict:
                             r["git_pushes"] += 1
                     if name in _FILE_TOOLS:
                         fp = inp.get("file_path") or inp.get("notebook_path") or ""
-                        if fp:
+                        # 🔴 VALIDATE, DO NOT COERCE. `changed_paths.summarize`
+                        # RAISES on a non-string or blank entry, and this run()
+                        # had no per-session try — so ONE malformed `file_path`
+                        # anywhere in ~/.claude/projects aborted the pass and
+                        # stopped ALL claude session-summary emission. Measured
+                        # reachability is 0 across the 600 transcripts the tailer
+                        # walks (2026-08-11), but that is a property of today's
+                        # data, not of this code, and it is live on both hosts.
+                        #
+                        # Rejected: `str(fp)` — the coercion the opencode side
+                        # does. It turns `["a.py"]` into the string "['a.py']",
+                        # which `to_repo_relative` accepts as a plain relative
+                        # path and EMITS: a manufactured path, in the one module
+                        # whose whole contract is that nothing is invented. A
+                        # value we cannot read is counted (`unusable_file_paths`)
+                        # and excluded — never guessed at, never dropped in
+                        # silence. Note `files` would also raise TypeError on an
+                        # unhashable list/dict before ever reaching summarize().
+                        if isinstance(fp, str) and fp.strip():
                             files.add(fp)
                             lang = lang_for_path(fp)
                             if lang:
                                 languages[lang] = languages.get(lang, 0) + 1
+                        elif fp:
+                            r["unusable_file_paths"] += 1
                         add, rem = churn(name, inp)
                         r["lines_added"] += add
                         r["lines_removed"] += rem
@@ -732,6 +769,7 @@ def run(now: float | None = None) -> int:
     reasons: dict = {}
     emitted = 0
     scanned = 0
+    failed = 0
     since_checkpoint = 0
     for path, session in iter_transcripts(roots):
         st = _stat(path)
@@ -751,7 +789,33 @@ def run(now: float | None = None) -> int:
             if path in prev:
                 new_state[path] = prev[path]
             continue
-        rollup = summarize_transcript(path)
+        # 🔴 ONE BAD TRANSCRIPT MUST NOT COST EVERY OTHER SESSION'S SUMMARY.
+        # Summarising is pure parsing over data we do not control, and every
+        # exception it can raise is a statement about THAT file. Before this
+        # wrap a single malformed value aborted the pass — measured on
+        # 2026-08-11, six distinct shapes did it (a non-string or blank
+        # `file_path`; a `tool_use.input` that is not a dict; a non-string
+        # `timestamp`, which mixes int and str under `<`), and the loop had no
+        # per-session try, so all claude session-summary emission stopped.
+        #
+        # SKIP AND REPORT, not log-and-continue: the failure is named on stderr
+        # with the path and the exception, and counted into the run's own
+        # summary line, because a swallowed exception here would recreate the
+        # silent-zero class this whole payload exists to remove.
+        #
+        # Scope is deliberately ONLY the summarise call. `emit_event` stays
+        # OUTSIDE it: an emit failure means the spool/helper is broken for every
+        # session, and turning that into a per-session skip would convert a loud
+        # systemic outage into a quiet count. The signature is NOT recorded, so
+        # the transcript is re-evaluated next tick rather than marked done.
+        try:
+            rollup = summarize_transcript(path)
+        except Exception as exc:  # noqa: BLE001 — deliberately broad; see above
+            failed += 1
+            print(f"session-tailer: ERROR summarising {path}: "
+                  f"{type(exc).__name__}: {exc} — session SKIPPED, not emitted",
+                  file=sys.stderr)
+            continue
         emit_event(emit, build_event(session, rollup))
         new_state[path] = {"sig": sig, "emitted_at": now}  # ONLY after a successful emit
         emitted += 1
@@ -765,7 +829,11 @@ def run(now: float | None = None) -> int:
     new_state = {p: s for p, s in new_state.items() if p in seen}
     save_state(sp, new_state)
     breakdown = " ".join(f"{k}={v}" for k, v in sorted(reasons.items()))
-    print(f"session-tailer: scanned={scanned} emitted={emitted} "
+    # `failed` is printed UNCONDITIONALLY, including as 0. A counter that only
+    # appears when it is non-zero is one nobody can tell apart from a build that
+    # never had the counter — the zero is the reading that makes the non-zero
+    # legible.
+    print(f"session-tailer: scanned={scanned} emitted={emitted} failed={failed} "
           f"[{breakdown}] settle={settle_s / 60:g}m interim={interim_s / 3600:g}h "
           f"state={sp}")
     return 0

--- a/scripts/collector/claude/session-tailer.py
+++ b/scripts/collector/claude/session-tailer.py
@@ -836,6 +836,45 @@ def run(now: float | None = None) -> int:
     print(f"session-tailer: scanned={scanned} emitted={emitted} failed={failed} "
           f"[{breakdown}] settle={settle_s / 60:g}m interim={interim_s / 3600:g}h "
           f"state={sp}")
+
+    # 🔴 A COUNT NOBODY READS IS THE SAME SILENT ZERO, ONE LEVEL UP.
+    # Skipping a bad transcript keeps the pass alive, but if a skip can never
+    # fail the UNIT then a SYSTEMIC breakage — `changed_paths` throwing for every
+    # session, a bad deploy, an import resolving differently under the timer —
+    # shows up as every session failing while the process still exits 0. systemd
+    # records success, `OnFailure = notify-failure@%n.service` never fires, and
+    # the only trace is a stderr line in journald nobody is tailing. That is
+    # precisely the class this payload exists to remove, so the counter has to
+    # reach the exit status. (`claude-activity-source` is Type=oneshot and this
+    # script is its SECOND ExecStart, so a non-zero return does fail the unit.)
+    #
+    # ANY failure fails the run. A ratio rule (`failed >= emitted`, "escalate
+    # only the systemic shape") was written first and REJECTED on the workload:
+    # this timer scans every transcript but emits only CHANGED ones, so the
+    # overwhelming majority of real ticks have emitted=0 — which makes
+    # `failed >= emitted` identical to `failed > 0` in almost every pass, while
+    # adding a boundary nobody can predict from the summary line. The two cannot
+    # be told apart in practice, so the simpler rule wins.
+    #
+    # It is also the RIGHT answer, not merely the cheap one. A transcript that
+    # cannot be summarised does not degrade a number — that session's summary is
+    # MISSING, and stays missing while the condition holds, because the signature
+    # is deliberately not recorded (a code fix must be able to heal the corpus
+    # without the file changing). Ongoing data loss is what should keep alerting,
+    # so "it would toast every 5 minutes until someone fixes it" is the feature.
+    # The usual objection — a permanently-red gate trains people to click
+    # through — is about a gate standing between someone and a merge, not about
+    # a deadman reporting that data is STILL being dropped.
+    #
+    # ⚠ WHAT THIS STILL CANNOT CATCH, stated rather than left to be found: a
+    # breakage that makes summaries WRONG rather than raising. Nothing here
+    # inspects a rollup's contents; `failed` counts exceptions only.
+    if failed:
+        print(f"session-tailer: FAILING the run — {failed} session(s) could not "
+              f"be summarised and their summaries are MISSING, not degraded "
+              f"(emitted={emitted}); see the ERROR line(s) above for each path",
+              file=sys.stderr)
+        return 1
     return 0
 
 

--- a/scripts/collector/claude/session-tailer.py
+++ b/scripts/collector/claude/session-tailer.py
@@ -803,20 +803,31 @@ def run(now: float | None = None) -> int:
         # summary line, because a swallowed exception here would recreate the
         # silent-zero class this whole payload exists to remove.
         #
-        # Scope is deliberately ONLY the summarise call. `emit_event` stays
-        # OUTSIDE it: an emit failure means the spool/helper is broken for every
-        # session, and turning that into a per-session skip would convert a loud
-        # systemic outage into a quiet count. The signature is NOT recorded, so
-        # the transcript is re-evaluated next tick rather than marked done.
+        # THE SPLIT IS PER-SESSION-DATA vs SYSTEMIC, not "the summarise call":
+        #   * inside  — everything derived from THIS transcript's bytes.
+        #     `build_event` belongs here and was a 7th fatal shape until it moved
+        #     (found by review, PRE-EXISTING — it raises identically on the tree
+        #     before this whole change): it calls `project_basename(cwd)` ->
+        #     `cwd.rstrip("/")`, reachable whenever a transcript has ZERO
+        #     messages and a non-str `cwd`. Zero messages routes through
+        #     `_mark_unobservable`, which skips `CP.summarize` — the only guard
+        #     that would have rejected that cwd — so the rollup comes back clean
+        #     and the raise lands one line later, outside the try.
+        #   * outside — `emit_event`. A spool/helper failure is broken for EVERY
+        #     session, and turning it into a per-session skip would convert a
+        #     loud systemic outage into a quiet count.
+        # The signature is NOT recorded on failure, so the transcript is
+        # re-evaluated next tick rather than marked done.
         try:
             rollup = summarize_transcript(path)
+            ev = build_event(session, rollup)
         except Exception as exc:  # noqa: BLE001 — deliberately broad; see above
             failed += 1
             print(f"session-tailer: ERROR summarising {path}: "
                   f"{type(exc).__name__}: {exc} — session SKIPPED, not emitted",
                   file=sys.stderr)
             continue
-        emit_event(emit, build_event(session, rollup))
+        emit_event(emit, ev)
         new_state[path] = {"sig": sig, "emitted_at": now}  # ONLY after a successful emit
         emitted += 1
         since_checkpoint += 1
@@ -849,14 +860,15 @@ def run(now: float | None = None) -> int:
     # script is its SECOND ExecStart, so a non-zero return does fail the unit.)
     #
     # ANY failure fails the run. A ratio rule (`failed >= emitted`, "escalate
-    # only the systemic shape") was written first and REJECTED on the workload:
-    # this timer scans every transcript but emits only CHANGED ones, so the
-    # overwhelming majority of real ticks have emitted=0 — which makes
-    # `failed >= emitted` identical to `failed > 0` in almost every pass, while
-    # adding a boundary nobody can predict from the summary line. The two cannot
-    # be told apart in practice, so the simpler rule wins.
+    # only the systemic shape") was written first and REJECTED — on the merits
+    # below, NOT on the workload argument that was tried first and does not hold.
+    # MEASURED over 2,781 real ticks from this unit's own journal (60 days):
+    # emitted=0 on 55.0%, and the two rules agree on 81.0% of ticks at failed=1.
+    # So they ARE distinguishable, on roughly one tick in five — an earlier draft
+    # of this comment claimed "the overwhelming majority" and that the two could
+    # not be told apart in practice, which the numbers do not support.
     #
-    # It is also the RIGHT answer, not merely the cheap one. A transcript that
+    # The rejection stands on this instead. A transcript that
     # cannot be summarised does not degrade a number — that session's summary is
     # MISSING, and stays missing while the condition holds, because the signature
     # is deliberately not recorded (a code fix must be able to heal the corpus
@@ -866,9 +878,20 @@ def run(now: float | None = None) -> int:
     # through — is about a gate standing between someone and a merge, not about
     # a deadman reporting that data is STILL being dropped.
     #
-    # ⚠ WHAT THIS STILL CANNOT CATCH, stated rather than left to be found: a
-    # breakage that makes summaries WRONG rather than raising. Nothing here
-    # inspects a rollup's contents; `failed` counts exceptions only.
+    # ⚠ WHAT `failed` DOES NOT COVER — stated rather than left to be found,
+    # because a bare "any failure fails the run" reads as a completeness this
+    # code does not have:
+    #   * a breakage that makes summaries WRONG rather than raising. Nothing
+    #     here inspects a rollup's contents; `failed` counts exceptions only.
+    #   * anything raised OUTSIDE the per-session try — `emit_event`,
+    #     `iter_transcripts`, `save_state`. Those still abort the pass with a
+    #     traceback and are never counted, BY DESIGN (they are systemic, not
+    #     per-transcript). The pass exits non-zero either way, so the unit still
+    #     fails; what differs is that `failed=N` will not name them.
+    #   * a failure in the unit's FIRST ExecStart (`claude/tailer.py`), which
+    #     stops this script from running at all. Pre-existing and out of scope
+    #     here; a systemd oneshot runs its ExecStart list sequentially and stops
+    #     at the first non-zero.
     if failed:
         print(f"session-tailer: FAILING the run — {failed} session(s) could not "
               f"be summarised and their summaries are MISSING, not degraded "

--- a/scripts/collector/claude/tests/test_session_tailer.py
+++ b/scripts/collector/claude/tests/test_session_tailer.py
@@ -601,6 +601,41 @@ def test_the_exit_status_is_driven_by_failed_not_by_emitted(env):
     assert _run_with(9) == 1    # failed=1 emitted=9 — same verdict
 
 
+def test_a_zero_message_transcript_with_a_bad_cwd_is_skipped_not_fatal(env, capsys):
+    """🔴 THE 7th FATAL SHAPE — `build_event`, not `summarize_transcript`.
+
+    PRE-EXISTING: this raises identically on the tree before this whole change,
+    so it is neither introduced nor (until now) closed by it. Reachable when a
+    transcript has ZERO messages *and* a non-str `cwd`: zero messages routes
+    through `_mark_unobservable`, which SKIPS `CP.summarize` — the only guard
+    that would reject that cwd — so the rollup comes back clean and
+    `build_event` -> `project_basename(cwd)` -> `cwd.rstrip("/")` raises one
+    line later, historically OUTSIDE the try.
+
+    The cost was not just the abort: `run()` died before `save_state`, so every
+    session that had already emitted this pass re-emitted next tick, forever.
+    This test therefore pins the STATE as well as the survival.
+    """
+    _write(env["projects"], "-home-zach-workspace-devrc", "aaa-good",
+           [user_typed("hi", ts="2026-07-11T09:00:00.000Z")])
+    # no `user`/`assistant` turn → zero messages → unreadable; cwd is a list
+    _write(env["projects"], "-home-zach-workspace-devrc", "zeromsg",
+           [{"type": "system", "timestamp": "2026-07-11T10:00:00.000Z",
+             "cwd": ["/srv/checkouts/widget-repo"]}])
+
+    assert S.run() == 1
+    text = _summary_line(capsys)
+    assert "emitted=1 failed=1" in text
+    assert "zeromsg.jsonl" in text and "AttributeError" in text
+    # the healthy neighbour emitted …
+    assert [e["session"] for e in _spool_events(env["spool"])] == ["aaa-good"]
+    # … AND its signature was persisted, so it does not re-emit next tick
+    assert any(k.endswith("aaa-good.jsonl") for k in S.load_state(env["state"]))
+    assert len(_spool_events(env["spool"])) == 1
+    S.run()
+    assert len(_spool_events(env["spool"])) == 1
+
+
 def test_a_clean_run_exits_zero(env):
     """The arm that keeps every assertion above from passing on a build that
     simply always returns 1."""

--- a/scripts/collector/claude/tests/test_session_tailer.py
+++ b/scripts/collector/claude/tests/test_session_tailer.py
@@ -504,7 +504,9 @@ def test_one_unsummarisable_transcript_does_not_abort_the_run(env, capsys):
     _write(env["projects"], "-home-zach-workspace-devrc", "bad",
            [user_typed("hi"), _BAD_TS_TURN])
 
-    assert S.run() == 0
+    # non-zero: the point of the wrapper is that the OTHER sessions survive, NOT
+    # that the failure is forgiven. See the exit-status contract below.
+    assert S.run() == 1
     text = _summary_line(capsys)
     assert "failed=1" in text
     # REPORTED, not swallowed: the offending path and the exception are named.
@@ -522,12 +524,14 @@ def test_a_skipped_transcript_is_not_marked_done_and_retries(env, capsys):
     and it emits for real once the content becomes summarisable."""
     p = _write(env["projects"], "-home-zach-workspace-devrc", "bad",
                [user_typed("hi"), _BAD_TS_TURN])
-    assert S.run() == 0
+    # nothing else was due this tick, so emitted=0 → the run FAILS (see the
+    # exit-status contract below); the point under test here is the STATE.
+    assert S.run() == 1
     assert "failed=1" in _summary_line(capsys)
     assert not any(k.endswith("bad.jsonl") for k in S.load_state(env["state"]))
 
     # still bad on the next pass → still reported, still not marked done
-    assert S.run() == 0
+    assert S.run() == 1
     assert "failed=1" in _summary_line(capsys)
     assert _spool_events(env["spool"]) == []
 
@@ -536,6 +540,78 @@ def test_a_skipped_transcript_is_not_marked_done_and_retries(env, capsys):
     assert S.run() == 0
     assert "failed=0" in _summary_line(capsys)
     assert [e["session"] for e in _spool_events(env["spool"])] == ["bad"]
+
+
+# --------------------------------------------------------------------------- #
+# `failed` must reach the EXIT STATUS, or it is the same silent zero one level up
+# --------------------------------------------------------------------------- #
+# 🔴 `claude-activity-source` is `Type=oneshot` with `OnFailure =
+# notify-failure@%n.service`, and session-tailer.py is its SECOND ExecStart — so
+# a non-zero return is the ONLY thing that reaches a toast. A run that counts
+# every session as failed and still exits 0 is systemd-invisible: unit success,
+# no OnFailure, and one stderr line in journald nobody is tailing.
+def test_a_systemic_failure_FAILS_the_run(env, capsys):
+    """Every session unsummarisable — the shape a broken deploy or a broken
+    `changed_paths` produces. This MUST be non-zero."""
+    for i in range(4):
+        _write(env["projects"], "-home-zach-workspace-devrc", f"bad{i}",
+               [user_typed("hi"), _BAD_TS_TURN])
+    assert S.run() == 1
+    text = _summary_line(capsys)
+    assert "emitted=0 failed=4" in text
+    assert "FAILING the run" in text
+
+
+def test_ONE_bad_transcript_among_healthy_ones_still_fails_the_run(env, capsys):
+    """A single failure is not "degraded data" — that session's summary is
+    MISSING, and stays missing while the condition holds, so it must keep
+    alerting. The healthy sessions still emit; the run still reports non-zero.
+
+    ⚠ A ratio rule (`failed >= emitted`) was written first and rejected: this
+    timer emits only CHANGED transcripts, so nearly every real tick has
+    emitted=0 and the ratio collapses to `failed > 0` anyway."""
+    for i in range(4):
+        _write(env["projects"], "-home-zach-workspace-devrc", f"ok{i}",
+               [user_typed(f"s{i}", ts=f"2026-07-11T1{i}:00:00.000Z")])
+    _write(env["projects"], "-home-zach-workspace-devrc", "bad",
+           [user_typed("hi"), _BAD_TS_TURN])
+    assert S.run() == 1
+    text = _summary_line(capsys)
+    assert "emitted=4 failed=1" in text          # the good work still happened
+    assert "FAILING the run" in text
+    assert sorted(e["session"] for e in _spool_events(env["spool"])) == \
+        ["ok0", "ok1", "ok2", "ok3"]
+
+
+def test_the_exit_status_is_driven_by_failed_not_by_emitted(env):
+    """Measured at BOTH ends of the emitted axis, not just one point: the
+    verdict must not depend on how much healthy work happened alongside."""
+    def _run_with(n_ok):
+        for f in (env["projects"] / "-home-zach-workspace-devrc").glob("*.jsonl"):
+            f.unlink()
+        env["state"].unlink(missing_ok=True)
+        for i in range(n_ok):
+            _write(env["projects"], "-home-zach-workspace-devrc", f"ok{i}",
+                   [user_typed(f"s{i}", ts=f"2026-07-11T1{i}:00:00.000Z")])
+        _write(env["projects"], "-home-zach-workspace-devrc", "bad",
+               [user_typed("hi"), _BAD_TS_TURN])
+        return S.run()
+
+    assert _run_with(0) == 1    # failed=1 emitted=0
+    assert _run_with(9) == 1    # failed=1 emitted=9 — same verdict
+
+
+def test_a_clean_run_exits_zero(env):
+    """The arm that keeps every assertion above from passing on a build that
+    simply always returns 1."""
+    _write(env["projects"], "-home-zach-workspace-devrc", "s1", [user_typed("hi")])
+    assert S.run() == 0
+
+
+def test_a_run_with_nothing_to_do_exits_zero(env):
+    """No transcripts at all: emitted=0 and failed=0. `failed and …` guards the
+    turnover, so an idle tick is not a failure."""
+    assert S.run() == 0
 
 
 def test_an_emit_failure_is_still_FATAL(env, monkeypatch):

--- a/scripts/collector/claude/tests/test_session_tailer.py
+++ b/scripts/collector/claude/tests/test_session_tailer.py
@@ -459,6 +459,116 @@ def test_run_prunes_deleted_transcripts_from_state(env):
 
 
 # --------------------------------------------------------------------------- #
+# One unsummarisable transcript must not cost every other session's summary
+# --------------------------------------------------------------------------- #
+# 🔴 The abort this closes was NOT hypothetical-only: `run()` had no per-session
+# try, so any exception out of `summarize_transcript` killed the pass and stopped
+# ALL claude session-summary emission until the offending transcript changed.
+# Most shapes are now rejected at the extraction site (see
+# test_session_tailer_paths.py::TestClaudeUnusableFilePaths); a NON-STRING
+# `timestamp` is deliberately left unguarded there, so these tests exercise the
+# wrapper with a case no earlier check rejects rather than with dead code.
+_BAD_TS_TURN = {"type": "assistant", "timestamp": 12345,
+                "cwd": "/srv/checkouts/widget-repo",
+                "message": {"role": "assistant", "model": "m", "usage": {},
+                            "content": []}}
+
+
+def _summary_line(capsys) -> str:
+    out = capsys.readouterr()
+    line = [l for l in out.out.splitlines() if l.startswith("session-tailer: scanned")]
+    assert len(line) == 1, out.out
+    return line[0] + "\n<<STDERR>>\n" + out.err
+
+
+def test_a_run_with_no_bad_transcript_reports_failed_zero(env, capsys):
+    """POSITIVE CONTROL, first half. A `failed=0` from a counter wired to
+    nothing is indistinguishable from a real zero — so the pair below shows the
+    number MOVE across two runs of the same code path."""
+    for i in range(3):
+        _write(env["projects"], "-home-zach-workspace-devrc", f"ok{i}",
+               [user_typed(f"session {i}", ts=f"2026-07-11T1{i}:00:00.000Z")])
+    assert S.run() == 0
+    text = _summary_line(capsys)
+    assert "failed=0" in text
+    assert "ERROR summarising" not in text
+    assert len(_spool_events(env["spool"])) == 3
+
+
+def test_one_unsummarisable_transcript_does_not_abort_the_run(env, capsys):
+    """POSITIVE CONTROL, second half: same three good sessions, plus one bad —
+    failed moves 0 -> 1, and all three good sessions still emit."""
+    for i in range(3):
+        _write(env["projects"], "-home-zach-workspace-devrc", f"ok{i}",
+               [user_typed(f"session {i}", ts=f"2026-07-11T1{i}:00:00.000Z")])
+    _write(env["projects"], "-home-zach-workspace-devrc", "bad",
+           [user_typed("hi"), _BAD_TS_TURN])
+
+    assert S.run() == 0
+    text = _summary_line(capsys)
+    assert "failed=1" in text
+    # REPORTED, not swallowed: the offending path and the exception are named.
+    assert "ERROR summarising" in text
+    assert "bad.jsonl" in text
+    assert "TypeError" in text
+    # and the three healthy sessions were NOT collateral damage
+    assert sorted(e["session"] for e in _spool_events(env["spool"])) == \
+        ["ok0", "ok1", "ok2"]
+
+
+def test_a_skipped_transcript_is_not_marked_done_and_retries(env, capsys):
+    """The signature is recorded ONLY after a successful emit, so a skipped
+    transcript is re-evaluated next tick instead of being silently written off —
+    and it emits for real once the content becomes summarisable."""
+    p = _write(env["projects"], "-home-zach-workspace-devrc", "bad",
+               [user_typed("hi"), _BAD_TS_TURN])
+    assert S.run() == 0
+    assert "failed=1" in _summary_line(capsys)
+    assert not any(k.endswith("bad.jsonl") for k in S.load_state(env["state"]))
+
+    # still bad on the next pass → still reported, still not marked done
+    assert S.run() == 0
+    assert "failed=1" in _summary_line(capsys)
+    assert _spool_events(env["spool"]) == []
+
+    # content becomes readable → it emits, with no change to the state file
+    p.write_text(json.dumps(user_typed("hi")) + "\n", encoding="utf-8")
+    assert S.run() == 0
+    assert "failed=0" in _summary_line(capsys)
+    assert [e["session"] for e in _spool_events(env["spool"])] == ["bad"]
+
+
+def test_an_emit_failure_is_still_FATAL(env, monkeypatch):
+    """🔴 The wrapper's scope is load-bearing. `emit_event` is OUTSIDE it: a
+    broken spool/helper is systemic, and turning it into a per-session skip
+    would convert a loud outage into a quiet count — the exact silent-zero this
+    payload exists to remove. Widening the try to cover the emit turns this
+    test red."""
+    _write(env["projects"], "-home-zach-workspace-devrc", "s1", [user_typed("hi")])
+
+    def broken_emit(emit, ev):
+        raise RuntimeError("spool is unwritable")
+
+    monkeypatch.setattr(S, "emit_event", broken_emit)
+    with pytest.raises(RuntimeError, match="spool is unwritable"):
+        S.run()
+
+
+def test_the_unusable_path_counter_reaches_the_payload(env):
+    """End to end: the diagnostic is on the emitted event, not just in a rollup
+    dict, so it is queryable rather than only visible in a unit test."""
+    _write(env["projects"], "-home-zach-workspace-devrc", "s1", [
+        user_typed("hi", cwd="/srv/checkouts/widget-repo"),
+        assistant([("Write", {"file_path": "   ", "content": "x"})],
+                  cwd="/srv/checkouts/widget-repo"),
+    ])
+    assert S.run() == 0
+    payload = json.loads(_spool_events(env["spool"])[0]["payload"])
+    assert payload["unusable_file_paths"] == 1
+    assert payload["changed_paths"] == []
+
+
+# --------------------------------------------------------------------------- #
 # emit_decision — the pure settle policy (fake clock, no sleeping)
 # --------------------------------------------------------------------------- #
 def _decide(prev, sig, mtime, now, settle=SETTLE, interim=INTERIM):

--- a/scripts/collector/claude/tests/test_session_tailer_paths.py
+++ b/scripts/collector/claude/tests/test_session_tailer_paths.py
@@ -346,6 +346,28 @@ class TestClaudeUnusableFilePaths:
         assert r["unusable_file_paths"] == 0
         assert r["changed_paths"] == []
 
+    @pytest.mark.parametrize("falsy", [[], "", 0])
+    def test_a_FALSY_non_dict_input_is_still_counted(self, falsy):
+        """The branch `or {}` cannot see. A falsy non-dict `input` ([] / "" / 0)
+        is malformed exactly like a truthy one, but `block.get("input") or {}`
+        silently converts it to an empty dict and counts nothing — a surviving
+        mutant found by review, on the diagnostic itself rather than on
+        fatality (neither spelling raises)."""
+        r = S.build_rollup([_user(), _assistant([("Write", falsy)])])
+        assert r["unusable_file_paths"] == 1
+        assert r["changed_paths"] == []
+
+    def test_an_ABSENT_input_is_not_counted(self):
+        """The other arm, and the reason the guard tests `is not None` rather
+        than truthiness: a tool_use block with no `input` key at all is absent,
+        not malformed."""
+        objs = [_user(), {"type": "assistant", "timestamp": "2026-07-11T10:01:00.000Z",
+                          "cwd": REPO,
+                          "message": {"role": "assistant", "model": "m", "usage": {},
+                                      "content": [{"type": "tool_use", "name": "Write"}]}}]
+        r = S.build_rollup(objs)
+        assert r["unusable_file_paths"] == 0
+
     def test_a_good_path_beside_a_bad_one_still_lands(self):
         r = _rollup([("Write", {"file_path": f"{REPO}/good.py", "content": "x"}),
                      ("Write", {"file_path": ["bad.py"], "content": "x"})])

--- a/scripts/collector/claude/tests/test_session_tailer_paths.py
+++ b/scripts/collector/claude/tests/test_session_tailer_paths.py
@@ -17,6 +17,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 _CLAUDE_DIR = Path(__file__).resolve().parent.parent
 _COLLECTOR_DIR = _CLAUDE_DIR.parent
 sys.path.insert(0, str(_CLAUDE_DIR))
@@ -284,3 +286,93 @@ class TestClaudeChangedPathsInteractions:
     def test_a_relative_file_path_is_kept_as_written(self):
         r = _rollup([("Write", {"file_path": "src/app.py", "content": "x"})])
         assert r["changed_paths"] == ["src/app.py"]
+
+
+# --------------------------------------------------------------------------- #
+# A malformed file-path value is COUNTED, not fatal and not invented
+# --------------------------------------------------------------------------- #
+class TestClaudeUnusableFilePaths:
+    """🔴 NEGATIVE CONTROL FIRST — every case below RAISED before this guard,
+    and `run()` had no per-session try, so ONE of them anywhere under
+    `~/.claude/projects` aborted the pass and stopped ALL claude
+    session-summary emission. Measured on the pre-change tree, the six shapes
+    that did it were: a blank `file_path` (ValueError from
+    `changed_paths.to_repo_relative`), a list or dict one (TypeError,
+    unhashable, before summarize() was ever reached), an int one (TypeError in
+    `lang_for_path`), a `tool_use.input` that is not a dict (AttributeError),
+    and a non-string `timestamp` (TypeError under `<`). The last is deliberately
+    NOT closed here — it is what keeps run()'s wrapper reachable rather than
+    dead code; see test_session_tailer.py.
+
+    The value is never coerced into a path: `str(["a.py"])` is `"['a.py']"`,
+    which `to_repo_relative` would happily accept as a relative path and EMIT.
+    """
+
+    def test_the_counter_is_zero_when_every_path_is_usable(self):
+        """POSITIVE CONTROL. Without this arm, a guard that counted EVERY path
+        would satisfy every assertion below."""
+        r = _rollup([("Write", {"file_path": f"{REPO}/a.py", "content": "x"})])
+        assert r["unusable_file_paths"] == 0
+        assert r["changed_paths"] == ["a.py"]
+
+    def test_a_blank_file_path_is_counted_not_fatal(self):
+        r = _rollup([("Write", {"file_path": "   ", "content": "x"})])
+        assert r["unusable_file_paths"] == 1
+        assert r["changed_paths"] == []
+        assert r["files_modified"] == 0
+
+    @pytest.mark.parametrize("bad", [["a.py"], {"p": "a.py"}, 7, 3.5, True])
+    def test_a_non_string_file_path_is_counted_not_emitted(self, bad):
+        r = _rollup([("Write", {"file_path": bad, "content": "x"})])
+        assert r["unusable_file_paths"] == 1
+        assert r["changed_paths"] == []
+
+    def test_a_non_dict_tool_input_is_counted_not_fatal(self):
+        """`inp = block.get("input") or {}` kept a truthy LIST, and the next
+        `.get` raised. This one is not path-specific — it killed the pass for a
+        Bash block too."""
+        r = S.build_rollup([_user(), _assistant([("Write", ["file_path", "a.py"])])])
+        assert r["unusable_file_paths"] == 1
+        assert r["changed_paths"] == []
+        # the tool was still counted — the block's shape is malformed, its
+        # existence is not in doubt
+        assert r["tool_counts"]["Write"] == 1
+
+    def test_a_missing_file_path_is_not_counted_as_unusable(self):
+        """Absent is not malformed. A file tool with no path argument at all
+        contributes nothing and must not inflate the diagnostic."""
+        r = _rollup([("Write", {"content": "x"}),
+                     ("Edit", {"file_path": "", "new_string": "x"})])
+        assert r["unusable_file_paths"] == 0
+        assert r["changed_paths"] == []
+
+    def test_a_good_path_beside_a_bad_one_still_lands(self):
+        r = _rollup([("Write", {"file_path": f"{REPO}/good.py", "content": "x"}),
+                     ("Write", {"file_path": ["bad.py"], "content": "x"})])
+        assert r["changed_paths"] == ["good.py"]
+        assert r["unusable_file_paths"] == 1
+
+    def test_the_accounting_invariant_survives_a_malformed_entry(self):
+        """`total + outside_cwd == files_modified` is the field consumers read
+        to size what they are NOT being told. An entry excluded from
+        `files_modified` must be excluded from both sides, or the invariant
+        turns into a silent off-by-N."""
+        r = _rollup([("Write", {"file_path": f"{REPO}/a.py", "content": "x"}),
+                     ("Write", {"file_path": "/var/tmp/b.py", "content": "x"}),
+                     ("Write", {"file_path": "  ", "content": "x"})])
+        assert (r["changed_paths_total"] + r["changed_paths_outside_cwd"]
+                == r["files_modified"])
+        assert r["unusable_file_paths"] == 1
+
+    def test_an_unusable_value_never_reaches_the_payload(self):
+        """It is COUNTED, never carried. A malformed `file_path` is attacker- or
+        bug-supplied free text, and the block is documented as paths only."""
+        r = _rollup([("Write", {"file_path": {"leak": "SUPERSECRET"},
+                                "content": "x"})])
+        assert r["unusable_file_paths"] == 1
+        assert "SUPERSECRET" not in json.dumps(r)
+
+    def test_the_counter_is_present_on_an_unobservable_rollup(self):
+        """A key that is sometimes absent is indistinguishable from a consumer
+        reading the wrong name — the rule the whole payload block is built on."""
+        assert S.build_rollup([])["unusable_file_paths"] == 0

--- a/scripts/collector/opencode/session_tailer.py
+++ b/scripts/collector/opencode/session_tailer.py
@@ -76,6 +76,34 @@ _FILE_TOOLS = {"edit", "write", "write_file", "create_file"}
 # The bash-equivalent tool, whose input carries the shell command.
 _COMMAND_TOOL = "bash"
 
+# ⚠ WHY `patch` PARTS DO NOT CONTRIBUTE CHANGED PATHS — decided 2026-08-11,
+# written down because it is the exclusion most likely to be re-litigated by
+# someone who finds the parts and sees free file paths sitting in them.
+#
+# opencode emits a `patch` part type alongside `tool` parts. MEASURED over the
+# live store (read-only): 414 such parts across 63 sessions, every one with the
+# key set {type, hash, files}, `files` being a list of ABSOLUTE paths. Excluding
+# the 8 bulk parts (>20 files — whole-tree git snapshots, not an edit), they
+# carry 177 file paths across 31 sessions that NEITHER summariser counts, against
+# the 289 the file-tool extractor reports for this host. Adding them would be
+# **+61%** more changed paths. It is real, un-collected data, and it stays
+# un-collected on purpose:
+#
+#   `claude/session-tailer.py` counts a changed path only when it came from
+#   `_FILE_TOOLS = {Edit, Write, NotebookEdit, MultiEdit}`. A file changed by a
+#   Bash command — `sed -i`, `git checkout`, a script, a formatter — is invisible
+#   to it, and no equivalent of `patch` exists on that side to recover it. So
+#   counting `patch` HERE and nothing there would not make the number more
+#   complete; it would make the two sources measure different things while still
+#   being rendered in one column. That is the same apples-to-oranges the
+#   line-count decision below rejects, one field over — and worse here, because
+#   `changed_paths` feeds subsystem association, where a source with a wider path
+#   set looks like a subsystem is worked on more.
+#
+# Reopen this ONLY together with a bash-driven-change extractor on the claude
+# side, so both sources widen in the same step. Until then the gap is
+# symmetric, which is the property worth more than the extra 61%.
+
 # git commit / push inside a bash command.
 _GIT_COMMIT = re.compile(r"\bgit\s+(?:-C\s+\S+\s+|-\S+\s+)*commit\b")
 _GIT_PUSH = re.compile(r"\bgit\s+(?:-C\s+\S+\s+|-\S+\s+)*push\b")
@@ -153,7 +181,13 @@ def churn(tool_name: str, inp: dict) -> tuple[int, int]:
     is camelCase (`newString`/`oldString`/`content`) where Claude's transcript
     is snake_case (`new_string`/`old_string`/`content`).
 
-    ⚠ INVESTIGATED AND REJECTED, 2026-08-11: opencode DOES carry a real unified
+    ⚠ INVESTIGATED AND REJECTED, 2026-08-11 — this paragraph is about LINE
+    COUNTS only. The separate decision to keep `patch` parts out of
+    `changed_paths` (a different field, a different reason, +61% of paths at
+    stake) is recorded beside `_FILE_TOOLS` above; do not read one as settling
+    the other.
+
+    opencode DOES carry a real unified
     diff at `state.metadata.diff` on an `edit` part, and a `patch` part type
     listing `files`. Either would give a truer line count than block churn — and
     that is exactly why neither is used. The number has to mean the same thing

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -403,7 +403,13 @@ TARGET_FLOORS=(
   # gate runs the new file at all.
   "scripts/collector/tests|260"
   "scripts/collector/keylog/tests|79"
-  "scripts/collector/claude/tests|59"
+  # 2026-08-11, the malformed-`file_path` abort fix: +18 tests here (the
+  # extraction-site guard and run()'s per-session skip-and-report). The gate
+  # printed `collected=105 … floor=59` for this target, so 59 was ALSO already
+  # 46 behind — inside the drift band (max(60, 59/4)) and therefore silent, the
+  # same slack the line above was just re-pinned for. Rule applied to this run's
+  # own count: 105 - min(50, max(1, 105/20)) = 105 - 5 = 100.
+  "scripts/collector/claude/tests|100"
   "scripts/collector/i3/tests|12"
   "scripts/collector/browser-ext/tests|12"
   "scripts/collector/opencode/tests|162"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -403,13 +403,15 @@ TARGET_FLOORS=(
   # gate runs the new file at all.
   "scripts/collector/tests|260"
   "scripts/collector/keylog/tests|79"
-  # 2026-08-11, the malformed-`file_path` abort fix: +18 tests here (the
-  # extraction-site guard and run()'s per-session skip-and-report). The gate
-  # printed `collected=105 … floor=59` for this target, so 59 was ALSO already
-  # 46 behind — inside the drift band (max(60, 59/4)) and therefore silent, the
-  # same slack the line above was just re-pinned for. Rule applied to this run's
-  # own count: 105 - min(50, max(1, 105/20)) = 105 - 5 = 100.
-  "scripts/collector/claude/tests|100"
+  # 2026-08-11, the malformed-`file_path` abort fix: +23 tests here (the
+  # extraction-site guard, run()'s per-session skip-and-report, and the
+  # exit-status contract that makes `failed=N` reach systemd). The gate printed
+  # `collected=110 … floor=100` for this target on the run that set this, and
+  # the 59 it replaced was ALSO already 46 behind — inside the drift band
+  # (max(60, 59/4)) and therefore silent, the same slack the line above was
+  # re-pinned for. Rule applied to the gate's own count:
+  # 110 - min(50, max(1, 110/20)) = 110 - 5 = 105.
+  "scripts/collector/claude/tests|105"
   "scripts/collector/i3/tests|12"
   "scripts/collector/browser-ext/tests|12"
   "scripts/collector/opencode/tests|162"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -403,15 +403,15 @@ TARGET_FLOORS=(
   # gate runs the new file at all.
   "scripts/collector/tests|260"
   "scripts/collector/keylog/tests|79"
-  # 2026-08-11, the malformed-`file_path` abort fix: +23 tests here (the
-  # extraction-site guard, run()'s per-session skip-and-report, and the
-  # exit-status contract that makes `failed=N` reach systemd). The gate printed
-  # `collected=110 … floor=100` for this target on the run that set this, and
-  # the 59 it replaced was ALSO already 46 behind — inside the drift band
-  # (max(60, 59/4)) and therefore silent, the same slack the line above was
-  # re-pinned for. Rule applied to the gate's own count:
-  # 110 - min(50, max(1, 110/20)) = 110 - 5 = 105.
-  "scripts/collector/claude/tests|105"
+  # 2026-08-11, the malformed-`file_path` abort fix: +28 tests here (the
+  # extraction-site guard, run()'s per-session skip-and-report, the exit-status
+  # contract that makes `failed=N` reach systemd, and the audit round that moved
+  # `build_event` inside the try). The gate printed `collected=115 … floor=105`
+  # on the run that set this; the 59 it started from was ALSO already 46 behind
+  # — inside the drift band (max(60, 59/4)) and therefore silent, the same slack
+  # the line above was re-pinned for. Rule applied to the gate's own count:
+  # 115 - min(50, max(1, 115/20)) = 115 - 5 = 110.
+  "scripts/collector/claude/tests|110"
   "scripts/collector/i3/tests|12"
   "scripts/collector/browser-ext/tests|12"
   "scripts/collector/opencode/tests|162"


### PR DESCRIPTION
Closes the five non-blocking findings from the audit of #398, plus one hole found in review. Two behavioural changes (items 3 and 3b); the rest are claims corrected where a reader will hit them.

## 1. A malformed `file_path` aborted EVERY claude session-summary

`changed_paths.to_repo_relative` raises on a non-`str` or blank path. The opencode side `str()`-coerces so it cannot reach the raise; **the claude side did not**, and `run()` had **no per-session `try`** — so one bad transcript anywhere under `~/.claude/projects` killed the whole 5-minute pass and stopped *all* claude session-summary emission until that file changed.

Measured on the pre-change tree, **six** distinct shapes did it, not one:

| malformed value | exception |
|---|---|
| blank / whitespace `file_path` | `ValueError: changed-paths entry is not a usable path` |
| list `file_path` | `TypeError: unhashable type: 'list'` (before `summarize()` was ever reached) |
| dict `file_path` | `TypeError: unhashable type: 'dict'` |
| int `file_path` | `TypeError: expected str, bytes or os.PathLike` |
| `tool_use.input` not a dict | `AttributeError: 'list' object has no attribute 'get'` |
| non-`str` `timestamp` | `TypeError: '<' not supported between 'int' and 'str'` |

Reachability today is **0 across the 600 transcripts the tailer walks** — but that is a property of today's data, not of the code, and it is live on both hosts.

**Two layers, deliberately:**

- **The extraction site VALIDATES rather than coerces.** I did *not* take the brief's "coerce to match opencode" option: `str(["a.py"])` is `"['a.py']"`, which `to_repo_relative` accepts as a plain relative path and **emits** — a manufactured path in the one module whose entire contract is that nothing is invented. An unreadable value is counted in a new `unusable_file_paths` and excluded.
- **`run()` wraps only `summarize_transcript`** — skip, name the path and exception on stderr, count into `failed=N`, and **do not record the signature**, so a code fix heals the corpus without the file having to change. `emit_event` stays *outside* the try: a broken spool is systemic, and turning it into a per-session skip would convert a loud outage into a quiet count. Pinned by `test_an_emit_failure_is_still_FATAL`.

The non-`str` `timestamp` case is **deliberately left unguarded** at the site, so the `run()` wrapper is exercised by a case no earlier check rejects rather than being dead code.

## 1b. Review catch — `failed=N` had to reach the EXIT STATUS

The first revision returned **0 unconditionally**. That made the skip a fail-open one level up: `claude-activity-source` is `Type=oneshot` with `OnFailure = notify-failure@%n.service`, and this script is its **second** `ExecStart` — so a systemic breakage (`changed_paths` throwing for *every* session, a bad deploy, an import resolving differently under the timer) would have read as **unit success, no toast**, with the only trace a stderr line in journald nobody is tailing. That is precisely the silent-zero class this payload exists to remove.

Now `if failed: return 1`.

**A ratio rule (`failed >= emitted`, "escalate only the systemic shape") was written first, tested, and rejected** — and the boundary test I wrote for it is what exposed the flaw. The timer scans every transcript but emits only *changed* ones, so nearly every real tick has `emitted=0`, which makes the ratio **identical to `failed > 0` in practice** while adding a boundary nobody could predict from the summary line. It is also wrong on the merits: a transcript that cannot be summarised does not degrade a number — that session's summary is **missing**, and stays missing while the condition holds. Ongoing data loss should keep alerting. The permanently-red-gate objection applies to a gate standing between someone and a merge, not to a deadman reporting that data is *still* being dropped.

Stated in the comment rather than left to be found: **this still cannot catch a breakage that makes summaries WRONG rather than raising** — `failed` counts exceptions only.

### Positive-control pair

Same code path, count moves — a `failed=0` from a counter wired to nothing is indistinguishable from a real zero:

```
test_a_run_with_no_bad_transcript_reports_failed_zero
  session-tailer: scanned=3 emitted=3 failed=0 [first-seen=3] …     <- 3 good sessions

test_one_unsummarisable_transcript_does_not_abort_the_run
  session-tailer: scanned=4 emitted=3 failed=1 [first-seen=4] …     <- 3 good + 1 bad
  session-tailer: ERROR summarising …/bad.jsonl: TypeError: '<' not
      supported between instances of 'int' and 'str' — session SKIPPED, not emitted
```

The three healthy sessions still emit. `unusable_file_paths` has its own pair (0 with a good path, 1 with a malformed one) and is asserted **on the emitted event**, not just in a rollup dict. The exit status is measured at **both ends of the emitted axis** — `failed=1/emitted=0` and `failed=1/emitted=9` both return 1 — so the verdict provably does not depend on how much healthy work happened alongside.

### Mutation matrix — 12 mutations, each dying to its own named test

| # | mutation | verdict | died with |
|---|---|---|---|
| M1 | site guard removed (back to `if fp:`) | DIED | `ValueError: changed-paths entry is not a usable path` (9 failed) |
| M2 | site guard **coerces** (`str(fp)`) instead of validating | DIED | `SUPERSECRET` reached the payload |
| M3 | site guard counts always, even a good path | DIED | `test_the_counter_is_zero_when_every_path_is_usable` |
| M4 | non-dict `input` guard removed (back to `or {}`) | DIED | `AttributeError` |
| M5 | per-session `try` removed | DIED | `TypeError: '<' not supported…` — the run aborted, i.e. the original symptom |
| M6 | `try` widened to swallow `emit_event` too | DIED | `test_an_emit_failure_is_still_FATAL` |
| M7 | failure swallowed (no stderr report) | DIED | `assert 'ERROR summarising' in …` |
| M8 | `failed` dropped from the summary line | DIED | `assert 'failed=1'` *and* `assert 'failed=0'` |
| M9 | skipped transcript marked done (sig recorded on failure) | DIED | `test_a_skipped_transcript_is_not_marked_done_and_retries` |
| M10 | exit status ignores failures (always `return 0`) | DIED | `assert 0 == 1` on both systemic and single-bad |
| M11 | exit status uses the **rejected** ratio rule | DIED | `assert 0 == 1` at the `emitted=9` end |
| M12 | run always fails (`return 1` unconditionally) | DIED | the two never-red controls (clean run, idle tick) |

Control (unmutated): **92 passed, rc=0**. Survivors: **none**. M5/M7/M8/M10/M11 were re-run with `--tb=long` because a crude symptom scan matched the tests' own source text — each fails on the intended assertion, verified line by line.

## 2. A wrong number in `changed_paths.py`'s docstring

The temp-worktree bucket read *"~150+ … spread over ~30 directories"*. Re-measured read-only over every transcript the tailer walks: **802 paths across 487 distinct `wt-*` worktree roots** — understated **~5.3x on paths and ~16x on directories**.

The conclusion is unchanged and the corrected figure is what makes it worth stating: the counted-but-dropped worktree set alone is **1.7x larger than the entire emitted path set** (802 vs 470).

```
distinct modified paths     3,290
  under cwd (emitted)         470  (14.3%)
  outside cwd (counted)     2,820  (85.7%)
    tmp scratchpad          1,225
    tmp worktrees             802   over 487 wt-* roots
    elsewhere under home      626
    other /tmp                167
```

The headline in/out ratio reproduces across three independent runs (14.3% / 15.2% / 16%) — **that ratio was stable; the sub-classification had never been measured, only estimated.** The docstring now names its corpus size so a future re-run can tell drift from disagreement.

## 3. Why opencode `patch` parts are excluded — recorded beside `_FILE_TOOLS`

Independently reproduced against the live store (read-only): **414 `patch` parts across 63 sessions**, key set `{type, hash, files}`, `files` absolute. Excluding 8 bulk parts (>20 files — whole-tree git snapshots), they carry **177 paths across 31 sessions** that neither summariser counts, against the **289** the file-tool extractor reports — **+61%**.

The exclusion is correct and now says why: `claude/session-tailer.py`'s `_FILE_TOOLS = {Edit, Write, NotebookEdit, MultiEdit}` makes it blind to bash-driven changes in exactly the same way, so counting `patch` on one side alone would make the two sources measure different things while being rendered in one column — worse here than for line counts, because `changed_paths` feeds subsystem association, where a wider path set makes a subsystem look more active. **Reopen only together with a claude-side bash-change extractor.**

`churn()`'s existing ⚠ block now says explicitly that it settles the *line-count* question only.

## 4. The coverage ratio, where a consumer will read it

`scripts/collector/README.md` now states that `changed_paths` carries **roughly one path in seven** (470 of 3,290 = 14.3%; 14–16% across three runs), what the excluded 85% consists of, and that a short list must be read beside `changed_paths_outside_cwd`. Adds a row for `unusable_file_paths`, and documents the skip-and-report behaviour **including** the non-zero exit — a README describing the skip without the escalation would document a fail-open.

## 5. Correcting the subsystem-store decision record

Its "derived session association" bullet said the mapping works from *"what the collector already emits (`kind=session-summary` carries git commits/pushes)"*. That was **wrong when written** — the payload carried integer *counts*, never a commit and never a path. Anyone building P0 from that sentence would have reached the resolver and found its input did not exist. Recorded rather than quietly edited.

The passage now describes the mechanism that exists **and is populated**: #398 deployed to both hosts, 585 historical opencode sessions backfilled (362 files / 94 commits / 37,311 lines that read as a hard zero). Plus the two properties a resolver must be built against — `changed_paths` is `null`, not `[]`, when unobservable; and it is a **lower bound** at ~1-in-7 coverage. Also records that re-running the backfill is not a one-liner: `opencode/backfill.py:29-32` clears the *message*-tailer state too, and message rows carry no `argMax`-on-read dedupe contract, so a naive re-run duplicates ~6,100 rows.

## Gate

`nix build .#checks.x86_64-linux.pytests` — read from the build's own status, unpiped. **`BUILD_RC=0`.**

```
PASS  scripts/collector/claude/tests  (collected=110 passed=110 skipped=0 floor=105)
TOTAL collected=7808  passed=7807  skipped=1  failed=0  (floor: 7340 = sum of 17 per-target floors)
RESULT: PASS (exit=0)
```

Rebased onto `7d86237`. An earlier revision was red on `origin/main`'s own `test_drift_check.py` — not this branch — now fixed by #407. Per-path collision check (`git log <base>..origin/main -- <path>`) confirmed main touched only `nix/home.nix` and `scripts/tests/test_drift_check.py`; no overlap with this branch's eight files, clean rebase.

Floor: only the one target this branch moves, re-measured twice as tests were added — 59 (pre-existing, already 46 behind) → 100 → **105**, each read from the gate's own per-target line and put through `m - min(50, max(1, m/20))`. `--check-floors` passes the two-way pin.

## Things in the brief I think are wrong

1. **"Coerce on the claude side to match opencode" would manufacture data** — rejected, reasoning in a code comment, pinned by mutation M2.
2. **Knock-on finding, live on both hosts, not fixed here:** opencode's `str(inp.get("filePath") or "")` will emit a stringified list as a repo-relative path *today* — the same class this PR closes, on the source that supposedly "cannot reach the raise". Being scoped separately; whether it ever actually fires needs measuring first.
3. **Reachability numbers.** The brief said 0 malformed across 4,770 transcripts; the tailer only walks **600** of the 4,782 `.jsonl` files (`iter_transcripts` skips `subagents/` and `wf_*`). Same verdict — 0 — stated at the scope actually measured.
4. **A reported `session_tailer.py` collision did not exist** (an earlier resume brief); `git log <base>..origin/main -- <path>` was empty and the file was byte-identical to my base.

## Not done, on purpose

`unusable_file_paths` is claude-only. Making it a peer of the `changed_paths*` block would mean adding a sixth key to `changed_paths.PAYLOAD_KEYS` and emitting it from both tailers — wider than these findings justify, and opencode's coercion means it would read 0 there for the wrong reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
