### PR TITLE
audit(notifications): rank the ~330/day toast stream; size the recall buffer to match (40 -> 300)

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -242,7 +242,29 @@ in
         width = "(0, 420)";
         # Cap the visible stack + keep a recall buffer (dunstctl history-pop).
         notification_limit = 4;
-        history_length = 40;
+        # RECALL BUFFER sized against the MEASURED notification rate, not a guess.
+        # Audited 2026-08-11 on the workbench: ~330 notifications/day reach dunst
+        # (claude-notify ~193/day from its own log; cpu-monitor + earlyoom ~137/day
+        # combined, split by cross-checking `journalctl --user -u systembus-notify`
+        # against dunst's per-notification icon warning). At the previous value of
+        # 40 the buffer therefore held under THREE HOURS of traffic.
+        #
+        # That is the recall path for anything DND swallowed, and it is the only
+        # one: a paused notification sits in the `waiting` queue, which dunst 1.13.2
+        # exposes only as a COUNT (`dunstctl count waiting`) — its contents cannot
+        # be enumerated or recovered. History is what `$mod+n` (history-pop) and
+        # scripts/notif-center read.
+        #
+        # Measured consequence of 40: on the workbench the history was 38/40
+        # `system-notify` (earlyoom OOM-kill toasts, which arrive in bursts of 100+
+        # during a single kill episode), having evicted everything else — including
+        # the `notify-failure` deadman toasts that PR #381 exists to protect. One
+        # OOM burst was enough to flush the entire recall buffer.
+        #
+        # This does NOT suppress or reduce anything; it only widens the window in
+        # which a swallowed notification can still be recovered. Cost is a few
+        # hundred structs in dunst's memory. Reverting is this one line.
+        history_length = 300;
         stack_duplicates = true;      # collapse repeats into one with a counter
         show_indicators = false;      # no "(x more)" / action hints — calmer
         # Mouse: left dismisses the current toast, middle fires its action then


### PR DESCRIPTION
Audit of the desktop notification stream on both NixOS hosts, prompted by dunst sitting paused for days with a growing `waiting` queue (29 → 41 → 286 → 244).

**The code change here is one line + comment, and it suppresses nothing.** Every actual noise reduction is a written proposal below for you to accept or reject — none of them were unambiguous enough to ship.

---

## 1. Ranked attribution (workbench)

| # | Producer | appname | notifications/day | Basis |
|---|---|---|---|---|
| 1 | **claude-notify** ("turn finished") | `claude` | **~193 mean** (162 median, 7–386) | MEASURED |
| 2 | **cpu-monitor** | `cpu-monitor` | **~90 mean** (7–235, bursty) | MEASURED (derived) |
| 3 | **earlyoom** via systembus-notify | `system-notify` | **~47 mean** — but **0 on 6 of 9 days**, then 53 / 163 / 208 | MEASURED |
| 4 | bar-status edge toasts | `bar-status` | ~0 steady state; **one 156-toast burst** on 08-11 12:25–13:14 | MEASURED |
| 5 | notify-failure (deadman) | `notify-failure` | ~1 (3,1,1,1,3 over 5 days) | MEASURED — **keep, do not touch** |
| 6 | keylog-spin-capture | — | 0 | MEASURED |
| 7 | `.zshrc` civitai release | — | **UNKNOWN**, inferred ≤ a few/week | **INFERRED — not measured** |

Total ≈ **330/day**.

### Counting methods, and what each is blind to

- **claude-notify — its own log** `~/.claude/claude-notify.log` (2584 lines, 08-02 → 08-11), one line per *actual fire*, split on `desktop=True`. Blind spots: records **dispatch, not delivery** (`dunstify`'s exit code is never checked); log starts 08-02 so no earlier history; workbench only.
- **earlyoom — `journalctl --user -u systembus-notify`**, 415 notifications in 9 days, summary always `earlyoom`. This is a direct per-notification log, so it is the trustworthy one.
- **cpu-monitor — derived by subtraction, and this is the part worth scrutinising.** My first attempt counted dunst's `WARNING: Icon 'utilities-system-monitor' not found` lines and attributed them all to cpu-monitor, because cpu-monitor is the only thing in the repo that requests that icon. **That was wrong**: `systembus-notify` (the bridge that delivers earlyoom's system-bus signal to the session bus) hard-codes *both* `utilities-system-monitor` and the appname `system-notify` in its binary. The icon counter was measuring the two producers summed. cpu-monitor's figure here is `icon warnings − systembus-notify count`, per day:

  | day | icon warnings | earlyoom | ⇒ cpu-monitor |
  |---|---|---|---|
  | 08-03 | 235 | 0 | 235 |
  | 08-04 | 173 | 53 | 120 |
  | 08-05 | 209 | 0 | 209 |
  | 08-06 | 284 | 163 | 121 |
  | 08-07 | 22 | 0 | 22 |
  | 08-09 | 11 | 0 | 11 |
  | 08-10 | 32 | 0 | 32 |
  | 08-11 | 215 | 208 | 7 |

  Cross-checked independently for 08-11 by matching each icon-warning *second* against `journalctl -u earlyoom` kill seconds: 198 of 215 matched, residual 17 — agreeing with the 7 above to within boundary effects. Blind spot: assumes exactly one WARNING per notification, which I could not directly verify (see §4).

### The blind spot that mattered most

**The icon-warning method is structurally incapable of seeing the largest producer.** dunst only logs when a notification requests an icon it cannot find. `claude-notify`, `systembus-notify` and `bar-status` set **no icon**; only cpu-monitor does. Any share derived from those warnings is a census of one producer, not a distribution. The #1 entry above was found only by reading claude-notify's own log.

### What I could NOT measure

- **The `waiting` queue's contents.** dunst 1.13.2 exposes it only as a count — `dunstctl count waiting`. No `dunstctl` subcommand, no `org.dunstproject.cmd0` method, and no `--json` form enumerates it. So the per-producer composition of the 244 queued notifications is **unknown**, not estimated. Everything above is measured at the *producers*, not at the queue.
- **Why 244 and not ~2000.** ~330/day measured against a queue that has been paused for days does not reconcile with 244, and the count has gone *down* (286 → 244). Either the queue is capped or evicts, or the pause is more recent than it appears. I did not determine which.
- **When and why DND was switched on.** dunst restarted 08-05 12:05 and a restart resets pause state, so it was set manually after that — via `$mod+Shift+n` or the bar's bell button, neither of which logs. I cannot tell you whether it was deliberate, or switched on once and forgotten. **Worth asking yourself**, because it decides whether any of this matters.

---

## 2. Signal/noise per producer, and proposals

Axes used: actionable? needed *now*? already visible elsewhere? would its absence be noticed?

### #1 claude-notify — ~193/day — the reason to care

Fires on `Stop`/`SubagentStop` when a turn ran ≥60s, with a 60s per-session cooldown. Low urgency, no icon. Notably it **already has a phone fallback**: when the desktop toast is *not* dispatched it POSTs to clawgate instead — so the information has a second route today.

- Actionable: yes, weakly — "go look at that session".
- Needed now: yes, that is the whole point.
- Visible elsewhere: **yes** — tmux window state, the agent-ops dashboard (`$mod+i`), and the clawgate push.
- Absence noticed: **yes**, this is the one you would actually miss.

This is not noise in kind — it is noise in *volume*, and it is the single thing most likely to have caused DND to be switched on. It is also entirely a taste call, so **no code here**. Options, cheapest first:

- **(a) Raise `CLAUDE_NOTIFY_MIN_SECONDS`** from 60s. At 60s nearly every real turn qualifies. 300s would cut volume hard while keeping "the long one finished" — which is the case you actually walk away from. Lost: pings for 1–5 minute turns.
- **(b) Raise `CLAUDE_NOTIFY_COOLDOWN_SECONDS`** from 60s. With many concurrent sessions the per-session cooldown does nothing to cap the aggregate. A *global* cooldown, or a coalescing "3 sessions finished" summary, would. Lost: per-session identity in the toast.
- **(c) Route to the bar instead of a toast** — a count pill of finished-since-last-look, cleared on click. Highest effort; loses nothing and is the only option that genuinely reduces interruption to zero without reducing information.

Both (a) and (b) are single env vars on the systemd unit — trivially reversible.

### #2 cpu-monitor — ~90/day

Three triggers (load ≥48 on 24 cores, single process ≥95%, package ≥88°C), each with a 600s cooldown.

**The cooldown does not bound the rate.** Re-alerting within an episode is cooldown-limited, but a *new* episode alerts immediately (`if [ "$load_alerting" -eq 0 ] || [ elapsed -ge COOLDOWN ]`). So a flapping signal produces unbounded alerts, and each recovery additionally fires an uncapped low-urgency "✓ back to normal" toast. On a box whose job is running builds, agents and `go test`, the runaway trigger flaps continuously — which is why the daily figure ranges 7 → 235 rather than sitting at the 144/day the cooldown implies.

- Actionable: rarely. The condition is usually the box doing its job.
- Needed now: no.
- Visible elsewhere: yes — the bar's load/temp blocks, `htop`.
- Absence noticed: the **temperature** one would be; load/runaway would not.

**Proposal (not shipped):** keep the temperature trigger as-is; give the load and runaway triggers a *daily* cap or drop their "✓ back to normal" clear toasts entirely (those are pure recovery chatter with no action attached). Do **not** simply raise thresholds — that hides the thermal case too. Lost if you drop the clears: confirmation that a spike ended, which the bar already shows continuously.

### #3 earlyoom — ~47/day mean, but 100+ in a single burst

One notification per killed process, with `-g` killing whole process groups: on 08-11, 412 kill lines produced 208 toasts in bursts (111 in a 3-minute window). earlyoom's own internal rate limiter is what keeps it from being worse.

- Actionable: **yes, once per episode** — "your test run was OOM-killed" genuinely explains a mystery failure.
- Needed now: no, the kill already happened.
- Visible elsewhere: **yes, completely** — `journalctl -u earlyoom` keeps every kill permanently, with process, RSS and cmdline.
- Absence noticed: only the *first* one per episode.

This is the clearest "reduce volume without losing information" case: **N kills in one episode → one toast.** The obvious mechanism is a dunst rule on `appname = "system-notify"` setting a stack tag so the burst collapses into a single updating toast.

**I did not ship this, because I could not validate it.** I tried twice on the laptop and both attempts were confounded by the filterless `fullscreen_suppress` rule routing the probes straight to history (a fullscreen Brave window was focused), so `displayed` and `waiting` both read 0 for the tagged *and* untagged control. A zero from a control that never observed anything proves nothing, and I was not willing to ship a behavioural rule on an unvalidated mechanism. It needs a re-test with no fullscreen window focused. Worth noting: history entries were **not** deduplicated by stack tag in that run — so a stack tag would collapse the *display*, not the history crowding that this PR's change addresses.

### #4 bar-status — a real anomaly, deliberately left alone

Steady state is ~0/day: `edge_decision` fires once on a strict rising edge and latches. But on 08-11 there were **156 `dunstify -a bar-status` launches between 12:25 and 13:14** — 47 in a single minute — comprising `"New mail action"` ×53, `"clawgate: task awaiting"` ×53, `"🔴 Telemetry source DEAD"` ×50, plus one launch with the literal argument vector **`bar-status critical sum body`** — i.e. a **test fixture reaching the real desktop**, exactly the hazard `_toast_runner`'s own docstring warns about.

It stopped at 13:14 and has not recurred. **I did not fix this** — I could not reproduce it or establish the mechanism, and a blind fix to a latch I do not understand is how you get a silently disarmed alert. It is the highest-value follow-up here and deserves its own investigation.

### #5 notify-failure — untouched, by design

3,1,1,1,3 over five days. Confirmed to be the source of the `dialog-error` icon warnings (an earlier attribution claiming otherwise, on the grounds that the `notify-failure@*` units showed no activations, was wrong — the units do start; `journalctl --user` shows `Starting Desktop toast when the user unit drift-check.service failed`). Its `override_pause_level=100` bypass is correct and stays.

---

## 3. What this PR actually changes

`history_length` 40 → 300 in `nix/home.nix`, with the measurement recorded in a comment.

Rationale: at ~330 notifications/day a 40-slot buffer held **under three hours**. That buffer is the only recall path for anything DND swallowed, since the `waiting` queue cannot be enumerated. The measured consequence: workbench history was **38/40 `system-notify`** — one earlyoom burst had evicted everything else, including the `notify-failure` deadman toasts that #381 exists to protect.

**What a reader stops learning: nothing.** This drops no notification and suppresses no producer; it only widens the recovery window. Cost is a few hundred structs in dunst memory. Revert is one line.

## 4. Verification

- `scripts/gate.sh --tier both --set hermetic`: **node 1024/1024 PASS**; pytest **7708 passed**.
- Remaining pytest failures are **pre-existing at `origin/main`**, confirmed by running the same targets at the base commit rather than assuming: 3 × `mail-actions/test_archive.py` (missing `minio` module) — identical count and identical tests at base. An earlier run also showed 9 × initiatives failures + a mail-actions collection error, both from a missing `psycopg2`; adding it to the shell turned initiatives fully green (784/784), confirming those too were environment, not code.
- No test pins `history_length`; `notif-center` and `i3status-notifs` read history by id and do not depend on 40.
- **Not verified live**: this needs a `home-manager switch` to take effect, and I did not switch either host. `git pull` alone changes nothing.

## 5. Constraints honoured

- **Workbench dunst was read-only throughout.** No `close-all`, `history-clear`, `set-paused`, or unpause. The 244-item queue is exactly as found.
- Laptop: probes were sent and its pause level was briefly set to 100 and returned to 0. Final state verified `paused=false level=0 waiting=0`, matching baseline. **One caveat worth stating**: my 14 probe entries were removed individually with `history-rm` (never `history-clear`), but while present they evicted **6 old `claude` entries** from the laptop's 40-slot history. Those are unrecoverable. They were low-value "turn finished" toasts, but that is a real, if small, loss I caused.
- Worktree off `origin/main`, never committed to `main`, no `stash`, no `add -A`, no `reset --hard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
