### PR TITLE
fix(tests): unbreak main — retire the spent ship-OFF gate #406 left behind

### DIFF
--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -1355,9 +1355,28 @@ def test_the_timer_is_gated_by_the_master_switch_and_the_service_is_not():
     assert "lib.optionals (serverMode && enableDriftDeadman) [ \"timers.target\" ]" in timer, (
         "the timer's WantedBy is not gated by the master switch:\n" + timer
     )
-    assert "enableDriftDeadman = false;" in HOME_NIX, (
-        "the master switch must ship OFF — enabling a timer is a live change to a "
-        "host and belongs in its own supervised deploy"
+    # The "must ship OFF" assertion that stood here was a TEMPORARY gate, and #406
+    # is the supervised deploy it demanded. It is retired rather than flipped.
+    #
+    # The flag sat false from #367 until both preconditions its own comment named
+    # were measured on a real host: (1) the ssh leg reaching the laptop from a
+    # systemd-user context, which found GENUINE drift on its first hand-run; and
+    # (2) the failure toast actually DISPLAYING — which was FALSE at first, because
+    # dunst was paused with 286 notifications queued, so the toast was sent, exited
+    # 0, and was silently binned. Four audit rounds had confirmed the exit code and
+    # the OnFailure wiring; none could see the notifier's output going nowhere.
+    # A timer alerting into a paused queue is worse than no timer — it manufactures
+    # the appearance of coverage over exactly the failure it exists to catch.
+    #
+    # What still needs pinning is the WIRING, not the value. The timer's WantedBy
+    # (asserted above) consults this flag, so deleting or renaming it silently
+    # un-gates the timer; that is the live hazard. Re-pinning the value would
+    # re-freeze a decision already made with evidence, and would make this test
+    # fail every time someone legitimately toggles it.
+    assert re.search(r"^\s*enableDriftDeadman = (true|false);", HOME_NIX, re.M), (
+        "enableDriftDeadman is no longer declared as a boolean literal — the "
+        "timer's WantedBy gate asserted above consults it by name, so removing "
+        "or renaming it un-gates the timer without any other test noticing"
     )
 
 


### PR DESCRIPTION
🔴 **`main` has been RED since #406.** Nothing can merge through a green gate until this lands.

Measured on pristine `origin/main` (`24b30a2`):

```
FAIL  scripts/tests  (collected=2255 passed=2254 skipped=0 failed=1 errors=0)
TOTAL collected=7785  passed=7783  skipped=1  failed=1   RESULT: FAIL (exit=1)
```

One failure across all 17 targets: `test_drift_check.py::test_the_timer_is_gated_by_the_master_switch_and_the_service_is_not`.

## Cause

The test asserted `"enableDriftDeadman = false;" in HOME_NIX`, with the reason *"the master switch must ship OFF — enabling a timer is a live change to a host and belongs in its own supervised deploy."*

**#406 is that supervised deploy.** It flipped the flag to `true` and did not retire the gate demanding it stay off.

## Why retire the gate rather than revert the switch

#406's own commit records that the flag sat false from #367 **because its comment demanded two things scratch clones structurally cannot test**, and that both were then measured on a real host:

1. The ssh leg reaching the laptop from a systemd-user context — a hand-run did it for real and found **genuine drift on its first run** (laptop 1 commit behind, rc 10, unit failed, `OnFailure` triggered).
2. The failure toast actually **displaying** — which was **false at first**: dunst was paused with 286 notifications queued, so the toast was sent, exited 0, and was silently binned. Four rounds of auditing had confirmed the exit code and the `OnFailure` wiring; none could see that the notifier's output went nowhere. Closed by #381, then re-measured against the deployed dunstrc: `displayed` moved 0→1 while `waiting` held at 240, so it displayed rather than queued.

That is a decision made with evidence, not an oversight. The assertion was a temporary gate that has been satisfied — so it is **retired, not flipped**.

## What replaces it

The live hazard is the **wiring**, not the value. The timer's `WantedBy` (asserted immediately above) consults this flag *by name*, so deleting or renaming it silently un-gates the timer with no other test noticing. The replacement pins exactly that and is deliberately agnostic to the value, so a legitimate toggle in either direction no longer breaks the suite.

Mutation-checked:

| mutation | result |
|---|---|
| unmutated (control) | **PASS** |
| flag deleted | **FAIL** |
| flag renamed | **FAIL** |
| flag set to `false` | **PASS** — value deliberately not pinned |

`nix/home.nix` restored byte-identical after each; no production file is changed by this PR.

## Verification

```
TOTAL collected=7785  passed=7784  skipped=1  failed=0  (floor: 7294)   RESULT: PASS (exit=0)
```

Test-only change — no behaviour, no deploy. The local tier cannot reach the floor on this host, so only the flake tier is meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
