### PR TITLE
docs(drift): record WHAT #406 measured, from the rescued second fix

### DIFF
--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -1348,19 +1348,38 @@ def test_the_timer_is_gated_by_the_master_switch_and_the_service_is_not():
 
     🔴 This test used to also assert `enableDriftDeadman = false;` — "the master
     switch must ship OFF, enabling a timer is a live change to a host and belongs
-    in its own supervised deploy". #406 IS that supervised deploy: it measured
-    both preconditions rather than arguing them, and set the switch to `true`.
-    It changed `nix/home.nix` and nothing else, so the assertion outlived its own
-    premise and left `main` RED — `collected=7785 passed=7783 failed=1`, the only
-    failure in either tier.
+    in its own supervised deploy". #406 IS that supervised deploy. It changed
+    `nix/home.nix` and nothing else, so the assertion outlived its own premise and
+    left `main` RED — `collected=7785 passed=7783 failed=1`, the only failure in
+    either tier.
+
+    WHAT #406 MEASURED, because it is the part worth keeping. The switch had sat
+    false since #367 behind two preconditions a scratch clone structurally cannot
+    test:
+
+      1. the ssh leg reaches the laptop from a systemd-user context (a user unit
+         has no ssh-agent) — a hand-run did it for real and found GENUINE drift
+         on its first run: the laptop 1 commit behind origin/main, rc 10;
+      2. the failure toast actually DISPLAYS — and this one was **FALSE** at
+         first. dunst was paused with 286 notifications queued, so the toast was
+         sent, exited 0, and was silently binned. Four rounds of auditing had
+         confirmed the script hands systemd the right exit code and that
+         OnFailure was wired; none of them could see that the notifier's output
+         went nowhere.
+
+    (2) is why the flag waited, and it is the reason to distrust a green here: a
+    timer alerting into a paused queue manufactures the appearance of coverage
+    over exactly the failure it exists to catch.
 
     A process rule ("do the enabling in its own deploy") is not a property a unit
     test can hold, and the one that tried became a gate everybody would have to
     merge through. What IS testable, and is what the gating actually depends on,
-    is that the switch is still declared EXPLICITLY — if it were deleted or left
-    to a default, `lib.optionals (serverMode && enableDriftDeadman)` would either
-    fail to evaluate or silently stop meaning anything, and the structural
-    assertion above would keep passing while gating nothing.
+    is that the switch is still declared EXPLICITLY and exactly once — deleted,
+    defaulted, or bound twice, `lib.optionals (serverMode && enableDriftDeadman)`
+    either fails to evaluate or quietly stops meaning anything while the
+    structural assertion above keeps passing and gates nothing. Deliberately
+    agnostic about the VALUE: pinning that again would re-break the gate the next
+    time someone legitimately changes it.
     """
     block = _drift_service_block()
     assert "mkIf" not in block, (


### PR DESCRIPTION
docs(drift): record WHAT #406 measured, from the rescued second fix

Two sessions independently fixed the same #406 red. #407 landed and kept the
stronger assertion; the other was found uncommitted in the workbench base clone,
blocking `ship.sh` with rc=7, and was preserved on
`rescue/drift-test-wip-from-workbench` (`e39fb1f`) before upstream's copy was
taken. Its assertion was the weaker of the two — `"enableDriftDeadman" in
HOME_NIX`, which a comment mentioning the name also satisfies, and which does not
notice the name being bound twice — but its EXPLANATION was better, and that is
what this carries over.

What it adds: which two preconditions #406 measured, and that one of them was
**FALSE** when first measured. dunst was paused with 286 notifications queued, so
the failure toast was sent, exited 0, and was silently binned. Four rounds of
auditing had confirmed the exit code and the OnFailure wiring; none could see
that the notifier's output went nowhere. That is the reason to distrust a green
on this path, and it was recorded nowhere the next reader would look.

Both claims re-checked against #406's own commit message rather than copied on
trust — the 286-queued figure is the original observation, distinct from the
`waiting=240` in its post-#381 re-measurement, and both are stated in their own
context.

Docstring-only, proved rather than asserted: parsing both trees and comparing the
dumps with docstrings stripped shows the executable AST is IDENTICAL to
`origin/main`. `test_drift_check.py` 160 passed.
