### PR TITLE
docs(handoff): subsystem-store — the census refuted the rejection's circular half

### DIFF
--- a/claudedocs/handoff-subsystem-store.md
+++ b/claudedocs/handoff-subsystem-store.md
@@ -2,102 +2,105 @@
 
 ## Goal
 A durable store for subsystem data + history with clean Claude Code integration.
-**Now fulfilled end to end**: the store exists, is versioned and contained, and a
-second writer riding `/handoff` has written its first entry in a new scope. What
-remains is a measurement — whether entries keep accruing — not a build.
+**Built, deployed, and now measurably working.** What remains is a short list of stale
+claims and one open measurement.
 
 ## State now
 
-- **Branch/PR:** `main`, clean tracked tree. All work below merged and deployed to both hosts.
+- **Branch:** `main`, clean tracked tree (1 behind origin at time of writing).
+- **`main` is green.** An earlier revision of this doc called it RED; that was wrong — see the resolved note below.
 - **DONE this session** (squash shas on `main`):
-  - `#361` — index becomes a **per-scope git repo**, hourly autocommit, no remote, `ProtectSystem=strict` / `ProtectHome=tmpfs` / `PrivateTmp` / `PrivateNetwork` / `InaccessiblePaths=/dev/shm`.
-  - `#362` — schema repairs: optional kind-qualified filenames, **ambiguity errors rather than shadows**, `sensitivity:` fail-safe default, `repo:`→`scope:`, the **liveness convention**.
-  - `#375` — decision record for the rejected store design.
-  - `#378` — `scripts/lib/subsystem_resolver.py`.
-  - `#398` — both summarisers emit `changed_paths`; opencode's extractor fixed (read tool inputs top-level; they nest under `state.input`, camelCase).
-  - `#408` — six fatal shapes guarded in the claude tailer; `run()` propagates failure (it returned 0 unconditionally, disabling the unit's only alerting channel).
-  - `#415` (`3fd97fd`) — `scripts/lib/subsystem_touch.py` + `/handoff` step 4: **the second writer**.
-  - `#421` (`e7c1007`) — `--session <uuid>` path source, read from the session's own transcript.
-  - `#424` (`7994ba1`) — `--pr <n>[,…]` path source, **the only one that can see a subagent's work**.
-  - Closed as superseded: `#364` (by #366), `#410` (by #407).
-- **IN FLIGHT:** `#418` — the previous revision of this doc, still OPEN. This file supersedes it; push to the same branch (`docs/handoff-subsystem-store`) rather than opening a second PR.
-- **Deploy:** both hosts converged and switched. Verified live, not assumed.
-- **Backfill:** 585 historical opencode sessions re-emitted (362 files, 94 commits, 37,311 lines that had read as zero).
+  - `#361` per-scope git store + contained hourly autocommit · `#362` schema repairs · `#375` decision record · `#378` resolver · `#398` `changed_paths` + the opencode extractor fix · `#408` failure propagation in the claude tailer
+  - `#415` **the `/handoff` writer** · `#421` `--session` · `#424` `--pr` · `#432` `--commit`
+  - `#426` **the read half** (`subsystem_recall.py` + `/resume` wiring) · `#429` show existing bullets before an append, + the new-scope versioning clause
+  - Closed as superseded: `#364` (by #366), `#410` (by #407)
+- **IN FLIGHT:** `#418` — an older revision of this doc, still OPEN. This supersedes it; push to the same branch (`docs/handoff-subsystem-store`), do not open a second PR.
+- **Deploy:** both hosts converged and switched throughout. The `#432` skill half needs a `ship.sh` to reach either host (`scripts/` is read from the repo and is already current).
 
-### The loop closed — measured, not asserted
-- `--pr` over this session's 9 merged PRs → **23 paths**, every PR reconciled (`N reported, N read`).
-- The first entry written: `~/.claude/analyze-service-index/devrc/opencode.md`.
-- Re-running the identical command then flipped `scope-absent` → **`resolved`**, matching `via filename 'opencode'` on 3 real paths.
-- **Census moved off its anchor:** `22 entries · datapacket-talos 21 + devrc 1 · created_by handoff 1 · unstamped 21` (anchor was `21 / 1 scope / 21 unstamped`).
-- The autocommit **bootstrapped the new scope on first sight**: `initialised a new repository (branch trunk, no remote)` → `committed 660d1ee`. Both scopes: `datapacket-talos` 3 commits, `devrc` 1 commit, **0 remotes each**.
-- 🔴 **The identity-seeding fallback fired for the first time ever** — `analyze-service index <analyze-service-index@localhost>`. It had never been exercised because the pre-existing scope carries a repo-**local** git identity; a brand-new scope has none and `GIT_CONFIG_GLOBAL=/dev/null` hides the global one. That code path was written in #361 and only proved itself today.
+### The measurement that was the whole point
+Falsifiability anchor, recorded before any writer existed: **21 entries · 1 scope · 21 unstamped.**
+
+```
+27 entries
+  by scope:      civitai 1 · civitai-app-starters 1 · datapacket-talos 24 · devrc 1
+  by created_by: handoff 6 · unstamped 21
+```
+
+**Six entries created by the `/handoff` writer across four scopes**, three of which did not
+exist before. Entries are accruing outside infra recon, which is exactly what the rejected
+design's evidence said would never happen — because the only writer at the time was an
+infra-recon command. That reasoning was circular and this is the refutation.
 
 ## Open investigations — live diagnosis state
 
+### RESOLVED — the `st_blocks` failure was a flake, and my diagnosis of it was wrong
+Kept because the *mistake* is the durable part, not the bug.
+
+- **What I saw:** `test_st_blocks_CANNOT_see_a_fallocated_partial` failing `assert 16896 == 16904` on two consecutive sandbox runs of pristine `main`, while the same suite passed `991/991` run directly on the host.
+- **What I concluded, wrongly:** a structural sandbox-vs-host split — "green where it is observed, red where it gates" — and I wrote `main is RED` into this doc's state section.
+- **What it actually was:** a **flake**. Another session measured 1 red in 5 runs, with the assertion's **operands reversed between reports** — the tell I never looked for. `#435` (`73e15f8`) landed the real fix: *"st_blocks equality pinned allocator luck, not the code under test."* The defect was real; the diagnosis was not.
+- **The lesson:** two runs plus one contrasting environment is not enough to call a structural split. `claude/RULES.md` says distinguish a flake by wall time and by *whose* time moved, **not by one re-run** — I effectively did two, found a story that fit, and stopped. A cheap third and fourth run would have refuted it.
+
 ### The reopening gate in the decision record asks the wrong question
 - **Symptom:** `claudedocs/decision-subsystem-store-rejected-2026-08-11.md` says revisit at "≥5 entries outside the current single scope, or ≥5 non-infra entries".
-- **Observed:** P1's measurement showed the binding constraint is **coverage**, not entry class. Of 290 path-carrying sessions, **12** were in the one indexed scope and 7 of those resolved — a **58% hit rate inside covered scope**. The resolver works; the index covered ~4% of the repos worked in.
-- **Leading hypothesis:** the gate should read "does the index cover the repos where work happens" — was 1 of ~12, now 2 of ~12.
-- **Next probe:** none. This is a one-paragraph edit to that document.
+- **Observed:** both conditions are now **met** — 3 entries outside the original scope, 6 non-infra by writer. And the gate was the wrong question anyway: the binding constraint measured was **coverage** (of 290 path-carrying sessions, 12 were in the one indexed scope; 7 of those resolved — a **58% hit rate inside covered scope**).
+- **Leading hypothesis:** it should read "does the index cover the repos where work happens" — was 1 of ~12, now 4 of ~12.
+- **Next probe:** none. One-paragraph edit.
 
 ### 155 of 290 path-carrying sessions have `cwd` basename literally `empty`
-- **Symptom:** grouping `session-summary` rows by the last component of the `cwd` **column** returns `empty` for 155 of 290 sessions carrying ≥1 changed path.
-- **Observed:** `cwd = 'empty'` is false for all (not the literal string); the bucket is `depth=4`, i.e. `/a/b/empty`; basename query returns exactly `empty 4 155`; `countIf(repo='')` is **0** for both sources.
-- **Ruled out:** `cwd` absent or empty (measured 0 both sources). Reading `cwd` from the *payload* — **my error**: opencode's payload has no `cwd` field; it is a top-level **column**.
-- **Leading hypothesis:** an opencode default/placeholder working directory. Unconfirmed.
-- **Next probe:** `SELECT DISTINCT cwd FROM activity.events WHERE kind='session-summary' AND splitByChar('/', trimBoth(cwd))[-1]='empty' LIMIT 5`, then look at that directory on disk.
-- **Why it matters:** those sessions can never resolve to a subsystem — 53% of the corpus permanently excluded. Changes no verdict already reached.
+- **Observed:** `cwd = 'empty'` false for all (not the literal string); bucket is `depth=4`, i.e. `/a/b/empty`; `countIf(repo='')` is **0** for both sources.
+- **Ruled out:** `cwd` absent/empty. Reading `cwd` from the *payload* — my error; opencode's payload has no `cwd`, it is a top-level **column**.
+- **Next probe:** `SELECT DISTINCT cwd FROM activity.events WHERE kind='session-summary' AND splitByChar('/', trimBoth(cwd))[-1]='empty' LIMIT 5`, then inspect that directory on disk.
 
 ### opencode can emit a stringified list as a repo-relative path
-- **Symptom:** `str(inp.get("filePath") or "")` — `str(["a.py"])` is `"['a.py']"`, which `to_repo_relative` **accepts** and emits. Manufactured data in the module whose contract is that nothing is invented.
-- **Observed:** searched the emitted corpus for that shape — **zero occurrences**. The path exists; it has never fired.
-- **Ruled out:** that #408's claude-side fix covers it — it does not. #408 deliberately **validates and skips** rather than coercing, precisely because coercion manufactures data.
+- **Observed:** `str(["a.py"])` is `"['a.py']"`, which `to_repo_relative` accepts and emits. Searched the emitted corpus: **zero occurrences** — the path exists, has never fired.
+- **Ruled out:** that `#408`'s claude-side fix covers it. It does not; `#408` validates-and-skips rather than coercing, precisely because coercion manufactures data.
 - **Next probe:** decide validate-and-skip on the opencode side, or a documented known-limitation.
 
 ## Next steps (ranked)
 
-1. **Correct the reopening gate** in the decision record (above). One paragraph; it is the durable record and currently misleads.
+1. **Correct the reopening gate** in the decision record — both its conditions are now met and it is still the wrong question.
 2. **Merge `#418`** after pushing this revision to its branch.
-3. **Watch the census.** `python3 scripts/lib/subsystem_touch.py --census`. It has moved once. If `created_by: handoff` entries do not keep accruing across repos over the next few weeks, the writer is not sticking and should be reconsidered — the same discipline that killed the original design.
-4. **Investigate the `empty` cwd bucket** (probe above).
-5. **Decide the opencode stringified-path question.**
-6. **The floors line in `scripts/run-tests.sh` has now conflicted on eight consecutive PRs** (twice on one). Per-target floors (#397) removed the base-dependent global total but made every test-adding PR touch the table. Worth measuring separately.
-7. **Worktree debt** — 17+ agent worktrees under `.claude/worktrees/`.
+3. **Watch the census.** `python3 scripts/lib/subsystem_touch.py --census`. It has moved 21→27 across 4 scopes with 6 handoff-written entries. If that stalls, the writer is not sticking.
+4. Investigate the `empty` cwd bucket; decide the opencode stringified-path question.
+5. **The floors line in `scripts/run-tests.sh` has conflicted on ~9 consecutive PRs.** Per-target floors (`#397`) removed the base-dependent global total but made every test-adding PR touch the table. Worth measuring separately.
+6. **Worktree debt** — 20+ agent worktrees under `.claude/worktrees/`.
 
 ## Gotchas / decisions / dead-ends
 
-- 🔴 **A large subsystem store was proposed and REJECTED on measurement** — no `type:`-driven sections, no dependency graph, no multi-verb CRUD. Read `decision-subsystem-store-rejected-2026-08-11.md` before re-proposing.
-- 🔴 **But the "no demand" half was CIRCULAR, and that was my error.** The only writer was an infra-recon command pointed at two cluster repos, so only infra entries in one scope *could* exist. `#415` closes exactly that. The surviving arguments are narrower: the `type:` taxonomy and graph were unjustified, and an opt-in multi-verb CRUD would not have stuck.
-- **Adoption, measured across 17 commands:** six have never been invoked once. The lesson is not "opt-in fails" but **opt-in survives when it rides a ritual already performed, and dies when it *is* the ritual**.
-- **Three path sources, blind in different directions — never merge their outputs.** git window: misses work that merged during the session. `--session`: misses **subagent** work (`isSidechain` excluded — 196 of 733 file-tool calls) and `Bash`-written files. `--pr`: sees subagents, but is the **branch union** — another session's commits, hand-made ones — and misses anything that never reached a PR. The flags are mutually exclusive on purpose.
-- **`gh pr view --json files` silently truncates at 100** while `changedFiles` reports the truth. Guarded cap-agnostically by `len(paths) < changedFiles`. My own verification missed it because I checked against a 4-file PR — one measurement, generalised.
-- **`--show-toplevel` was rejected deliberately:** it would make every agent worktree its own scope, sharding the store into hundreds of one-entry scopes.
-- **Working-tree residue, not branch age, dominates git-window over-reporting** — a live run returned 6 of 6 paths belonging to other sessions.
-- 🔴 **The store must never gain a remote**; no line of it may reach a public repo. `devrc` is PUBLIC. Each scope's `README.md` is authoritative over any command file.
-- **Instrument validation kept being the actual finding.** Five mutation harnesses this session produced wrong verdicts before correction — a stale `.pyc`; a sweep whose `git checkout --` reverted the change under test; a parser regex-matching a traceback body; one environment-dependent on the pytest launch directory; one that overwrote the repo's `conftest.py`. A green sweep is a claim about the harness until a control proves otherwise.
-- **`FETCH_HEAD` is repo-global** and is clobbered by concurrent sessions here — it produced one false verification. Resolve to an explicit remote-tracking ref and assert the sha.
-- **`git diff --stat <branch>..origin/main` renders the branch's own edits with inverted sign.** I misread that as a collision and told an agent so. `git log <base>..origin/main -- <path>` is the right question.
-- **zsh eats `:s`/`:h`/`:p` after an unbraced `$VAR` in a git ref** — `$B:scripts/...` silently reads the wrong thing. Brace it.
+- 🔴 **A large subsystem store was proposed and REJECTED on measurement** (no `type:` taxonomy, no dependency graph, no multi-verb CRUD). Read `decision-subsystem-store-rejected-2026-08-11.md` before re-proposing. **But its "no demand" half was CIRCULAR** — the only writer was infra-scoped, so only infra entries could exist. The census above is the refutation.
+- **Four path sources, blind in different directions — never merge their outputs.** git window: misses work merged during the session. `--session`: misses **subagent** work (`isSidechain` excluded, 196 of 733 file-tool calls) and `Bash`-written files, and is blind in worktree-mandated repos (25 paths outside cwd, 0 inside). `--pr`: sees subagents, but is the **branch union**, and misses direct pushes — **144 of 200** recent `datapacket-talos` trunk commits carry no `(#N)`. `--commit`: the primitive the others reduce to. The flags are argparse-exclusive on purpose.
+- **`Edit` vs `Write` on an entry, MEASURED:** `Write` silently loses a concurrent append; `Edit` is **bounded**, so the other bullet survives. 🔴 It does **not** reliably fail loudly — an earlier version of this rationale said it did and was wrong. The real safeguard is **re-read and re-apply to current bytes**; never treat "no error" as evidence you were alone.
+- **A brand-new scope is `git init`ed, identity-seeded and committed by the store's own hourly timer** — measured twice. Do not create the repo yourself; an entry there is unversioned for up to an hour, which is the normal window.
+- **`gh pr view --json files` silently truncates at 100** while `changedFiles` reports the truth. Guarded cap-agnostically. My own verification missed it by checking a 4-file PR.
+- **`git diff-tree` exits 0 and prints nothing** for a merge, a root commit, a blob and a tree — git's own silent zeros, each closed before the diff runs.
+- 🔴 **The store must never gain a remote**; no line of it may reach a public repo. `devrc` is PUBLIC. Each scope's `README.md` is authoritative.
+- **Instrument validation kept being the actual finding.** Six mutation harnesses this session produced wrong verdicts before correction — a stale `.pyc`; a sweep whose `git checkout --` reverted the change under test; a parser regex-matching a traceback body; one environment-dependent on the pytest launch directory; one that overwrote the repo's `conftest.py`; one whose anchor matched twice, silently retiring its own guard.
+- **Floor deltas must be attributed to the branch, not the target's movement.** Three near-misses: `+118` measured `+68`; `+68` was really `+64`; `+124` was really `+109`.
+- **`FETCH_HEAD` is repo-global** and clobbered by concurrent sessions — it produced one false verification here.
+- **`git diff --stat <branch>..origin/main` renders the branch's own edits with inverted sign.** Use `git log <base>..origin/main -- <path>`.
+- **zsh eats `:s`/`:h`/`:p` after an unbraced `$VAR` in a git ref.** Brace it.
+- **`git -C $VAR` defeats the bash-guard's repo detection** — it judges the caller's directory instead. Pass an absolute path.
 
 ## How to verify
 
 ```bash
 D=/home/zach/workspace/devrc
-# the writer, both sources (read-only; the tool never writes)
-python3 $D/scripts/lib/subsystem_touch.py --repo $D --session <your-scratchpad-uuid>
-python3 $D/scripts/lib/subsystem_touch.py --repo $D --pr <n>[,<n>...]
-
+# all four windows (read-only; the tool never writes)
+python3 $D/scripts/lib/subsystem_touch.py --repo $D --session <scratchpad-uuid>
+python3 $D/scripts/lib/subsystem_touch.py --repo $D --pr <n>[,...]
+python3 $D/scripts/lib/subsystem_touch.py --repo $D --commit <sha>[,...]
+# the read half
+python3 $D/scripts/lib/subsystem_recall.py --repo $D
 # the falsifiability counter — anchor was 21 / 1 scope / 21 unstamped
 python3 $D/scripts/lib/subsystem_touch.py --census
 
-# both scopes versioned, contained, and with NO remote
-for s in datapacket-talos devrc; do
+# every scope versioned, contained, NO remote
+for s in $(ls -d ~/.claude/analyze-service-index/*/ | xargs -n1 basename); do
   T=~/.claude/analyze-service-index/$s
   echo "$s: $(git -C $T rev-list --count HEAD) commits, $(git -C $T remote -v | wc -l) remotes"
 done
-systemctl --user show analyze-service-index-commit.service \
-  -p ProtectSystem -p ProtectHome -p PrivateNetwork -p InaccessiblePaths --no-pager
 
-# the authoritative gate (the local tier cannot reach the floor on this host)
-nix build .#checks.x86_64-linux.pytests --no-link --print-build-logs 2>&1 | grep -E 'TOTAL collected|RESULT'
+# the authoritative gate
+nix build .#checks.x86_64-linux.pytests --no-link --print-build-logs 2>&1 | grep -E 'TOTAL collected|RESULT|FAIL'
 ```

--- a/claudedocs/handoff-subsystem-store.md
+++ b/claudedocs/handoff-subsystem-store.md
@@ -1,0 +1,91 @@
+# Handoff: subsystem-store — 2026-08-12
+
+## Goal
+A durable store for subsystem data + history with clean Claude Code integration.
+The store, its schema, its versioning and now a second writer all exist and are
+deployed. What is unproven is whether entries actually **accrue** outside infra
+recon — that is a measurement, deliberately left to run.
+
+## State now
+
+- **Branch/PR:** `main`, clean tracked tree. Everything below is merged and deployed to both hosts.
+- **DONE this session** (squash shas on `main`):
+  - `#361` — the recon index is a **per-scope git repo**, hourly autocommit, no remote, under `ProtectSystem=strict` / `ProtectHome=tmpfs` / `PrivateTmp` / `PrivateNetwork` / `InaccessiblePaths=/dev/shm`.
+  - `#362` — schema repairs: optional kind-qualified filenames, **ambiguity errors rather than shadows**, `sensitivity:` with a fail-safe default, `repo:`→`scope:` with non-repo scopes, and the **liveness convention** (persist the derivation method, never the reading).
+  - `#375` — the decision record for the rejected design.
+  - `#378` — `scripts/lib/subsystem_resolver.py`, the path→subsystem resolver.
+  - `#398` — both summarisers emit `changed_paths`; opencode's extractor fixed (it read tool inputs from the part's top level; they live under `state.input`, camelCase).
+  - `#408` — six fatal shapes guarded in the claude tailer, and `run()` now **propagates failure** (it returned 0 unconditionally, silently disabling the unit's only alerting channel).
+  - `#415` (`3fd97fd`) — **the second writer**: `scripts/lib/subsystem_touch.py` + `/handoff` step 4.
+  - Closed as superseded: `#364` (by #366), `#410` (by #407).
+- **Deploy status:** both hosts converged and switched. Verified live, not assumed —
+  the deployed handoff skill carries all three of its new clauses, the autocommit
+  timer fired 10 min before this doc was written, and the claude tailer fired 2 min before.
+- **Backfill:** 585 historical opencode sessions re-emitted (362 files, 94 commits,
+  37,311 lines that previously read as zero). Message streams verified unchanged.
+- **Store right now:** 21 entries, **1 scope**, 3 commits, clean, **0 remotes**.
+- **Census baseline (the falsifiability anchor):** `21 entries · 1 scope · 21 unstamped`.
+
+## Open investigations — live diagnosis state
+
+### 155 of 290 path-carrying sessions have `cwd` basename literally `empty`
+- **Symptom + exact repro:** grouping session-summary rows by the last component of the `cwd` **column** returns `empty` for 155 of 290 sessions that carry ≥1 changed path.
+- **Observed (with values):** `is_literal_empty=0` for all rows (so `cwd` is not the string `empty`); the bucket is `depth=4`, i.e. `/a/b/empty`. Basename query returns exactly `empty  4  155`. `countIf(repo='')` is **0** for both sources, so it is not an empty string.
+- **Ruled out:** `cwd` being absent or empty (measured 0 for both sources). Reading `cwd` from the *payload* — that was **my error**: opencode's payload has no `cwd` field at all; it is a top-level **column**.
+- **Leading hypothesis:** an opencode default/placeholder working directory. Unconfirmed.
+- **Next probe:** `SELECT DISTINCT cwd FROM activity.events WHERE kind='session-summary' AND splitByChar('/', trimBoth(cwd))[-1]='empty' LIMIT 5` — then look at what that directory actually is on disk.
+- **Why it matters:** those sessions can never resolve to a subsystem, so they are 53% of the corpus permanently excluded. It does not change any verdict already reached.
+
+### The decision record's reopening gate asks the wrong question
+- **Symptom:** `claudedocs/decision-subsystem-store-rejected-2026-08-11.md` says revisit at "≥5 entries outside the current single scope, or ≥5 non-infra entries".
+- **Observed:** the P1 measurement showed the binding constraint is **coverage**: of 290 path-carrying sessions, **12** are in the one indexed scope, and 7 of those resolved — a **58% hit rate inside covered scope**. The resolver works; the index covers ~4% of the repos worked in.
+- **Leading hypothesis:** the gate should read "does the index cover the repos where work happens" — currently 1 of ~12.
+- **Next probe:** none needed; this is an edit to that document.
+
+### opencode can emit a stringified list as a repo-relative path
+- **Symptom:** `str(inp.get("filePath") or "")` — `str(["a.py"])` is `"['a.py']"`, which `to_repo_relative` **accepts** and emits. Manufactured data in the one module whose contract is that nothing is invented.
+- **Observed:** searched the emitted corpus for that shape — **zero occurrences**. The path exists; it has never fired.
+- **Ruled out:** that #408's claude-side fix covers it — it does not; #408 deliberately *validates and skips* on the claude side rather than coercing, precisely because coercion manufactures data.
+- **Next probe:** decide whether to validate-and-skip on the opencode side to match, or leave a documented known-limitation.
+
+## Next steps (ranked)
+
+1. **Correct the reopening gate** in `decision-subsystem-store-rejected-2026-08-11.md` to the coverage question. One edit; it is the durable record and currently misleads.
+2. **Let the writer run and watch the census.** `python3 scripts/lib/subsystem_touch.py --census`. Baseline is `21 / 1 scope / 21 unstamped`. If `created_by: handoff` entries do not appear across several repos within a few weeks, the need is narrower than it looks and the writer should be reconsidered — same discipline that killed the original design.
+3. **Investigate the `empty` cwd bucket** (probe above).
+4. **Decide the opencode stringified-path question** (validate-and-skip vs documented limitation).
+5. **Worktree debt** — 17+ agent worktrees under `.claude/worktrees/`, several from this session's agents.
+
+## Gotchas / decisions / dead-ends
+
+- 🔴 **A large subsystem store was proposed and REJECTED on measurement** — no `type:`-driven sections, no dependency graph, no multi-verb CRUD. After eight weeks: 20 entries, **0 non-infra**, **1 scope**, **0 dependency edges**. A hand-authored `process` and `org` entry showed `type:` selected nothing. Do not rebuild it; read the decision record first.
+- 🔴 **But "no demand" was partly circular reasoning, and that was my error.** The only writer was an infra-recon command pointed at two cluster repos, so of course only infra entries in one scope existed. "Nothing non-infra exists" is not evidence of no demand when nothing can create one. `#415` closes exactly that gap. The arguments that *do* survive are narrower: the `type:` taxonomy and graph were unjustified, and an opt-in multi-verb CRUD would not have stuck.
+- **Adoption, measured across 17 commands:** six have never been invoked once. The lesson is **not** "opt-in fails" — it is that **opt-in survives when it rides a ritual already performed, and dies when it *is* the ritual**. `/analyze-service` stuck (29 invocations) because its index write is a free side-effect of recon. `#415` rides `/handoff` for the same reason.
+- **Paths come from git, bounded to the branch, and the bound is printed on every output path.** Telemetry's `changed_paths` is the honest per-*session* source but does not exist yet when `/handoff` fires. The core takes paths as an argument so telemetry can feed it later.
+- **`--show-toplevel` was rejected deliberately:** it would make **every agent worktree its own scope**, sharding the store into hundreds of unresolvable one-entry scopes. With dozens of concurrent worktrees here that is the normal case.
+- **Working-tree residue, not branch age, is the dominant over-reporting source** — on a live run, 6 of 6 paths were other sessions' stale untracked files. `--exclude` is wired into the skill's command line; it is manageable, not solved.
+- **A top-ranked `scripts` or `claudedocs` nomination is honest, not a bug** — it genuinely covers several paths in one subtree. The confirm gate is what rejects it.
+- 🔴 **`~/.claude/analyze-service-index/` must never gain a remote** and no line of it may reach a public repo. `devrc` is PUBLIC. Each scope's `README.md` is authoritative over any command file.
+- **Instrument validation kept being the actual finding.** Four separate mutation harnesses in this session produced wrong verdicts before being corrected — one reused a stale `.pyc`, one ran against uncommitted work whose `git checkout --` silently reverted the change under test, one mis-scored six kills by regex-matching a traceback body, one was environment-dependent on the pytest launch directory. A green sweep is a claim about the harness until proven otherwise.
+- **`FETCH_HEAD` is repo-global** and is clobbered by concurrent sessions in this shared checkout — it produced one false verification here. Resolve to an explicit remote-tracking ref and assert the sha.
+- **`git diff --stat <branch>..origin/main` renders the branch's own edits with inverted sign.** I misread that as "main collided with my files" and told an agent so; it was wrong. `git log <base>..origin/main -- <path>` is the right question.
+
+## How to verify
+
+```bash
+# the writer, end to end (read-only; never writes)
+python3 /home/zach/workspace/devrc/scripts/lib/subsystem_touch.py --repo /home/zach/workspace/devrc
+
+# the falsifiability counter
+python3 /home/zach/workspace/devrc/scripts/lib/subsystem_touch.py --census
+
+# the store is versioned, contained, and has NO remote
+S=~/.claude/analyze-service-index/datapacket-talos
+git -C $S rev-list --count HEAD; git -C $S remote -v | wc -l   # commits; MUST be 0
+systemctl --user list-timers 'analyze-service-index-commit*' --no-pager
+systemctl --user show analyze-service-index-commit.service \
+  -p ProtectSystem -p ProtectHome -p PrivateNetwork -p InaccessiblePaths --no-pager
+
+# the authoritative gate (the local tier cannot reach the floor on this host)
+nix build .#checks.x86_64-linux.pytests --no-link --print-build-logs 2>&1 | grep -E 'TOTAL collected|RESULT'
+```

--- a/claudedocs/handoff-subsystem-store.md
+++ b/claudedocs/handoff-subsystem-store.md
@@ -2,87 +2,99 @@
 
 ## Goal
 A durable store for subsystem data + history with clean Claude Code integration.
-The store, its schema, its versioning and now a second writer all exist and are
-deployed. What is unproven is whether entries actually **accrue** outside infra
-recon — that is a measurement, deliberately left to run.
+**Now fulfilled end to end**: the store exists, is versioned and contained, and a
+second writer riding `/handoff` has written its first entry in a new scope. What
+remains is a measurement — whether entries keep accruing — not a build.
 
 ## State now
 
-- **Branch/PR:** `main`, clean tracked tree. Everything below is merged and deployed to both hosts.
+- **Branch/PR:** `main`, clean tracked tree. All work below merged and deployed to both hosts.
 - **DONE this session** (squash shas on `main`):
-  - `#361` — the recon index is a **per-scope git repo**, hourly autocommit, no remote, under `ProtectSystem=strict` / `ProtectHome=tmpfs` / `PrivateTmp` / `PrivateNetwork` / `InaccessiblePaths=/dev/shm`.
-  - `#362` — schema repairs: optional kind-qualified filenames, **ambiguity errors rather than shadows**, `sensitivity:` with a fail-safe default, `repo:`→`scope:` with non-repo scopes, and the **liveness convention** (persist the derivation method, never the reading).
-  - `#375` — the decision record for the rejected design.
-  - `#378` — `scripts/lib/subsystem_resolver.py`, the path→subsystem resolver.
-  - `#398` — both summarisers emit `changed_paths`; opencode's extractor fixed (it read tool inputs from the part's top level; they live under `state.input`, camelCase).
-  - `#408` — six fatal shapes guarded in the claude tailer, and `run()` now **propagates failure** (it returned 0 unconditionally, silently disabling the unit's only alerting channel).
-  - `#415` (`3fd97fd`) — **the second writer**: `scripts/lib/subsystem_touch.py` + `/handoff` step 4.
+  - `#361` — index becomes a **per-scope git repo**, hourly autocommit, no remote, `ProtectSystem=strict` / `ProtectHome=tmpfs` / `PrivateTmp` / `PrivateNetwork` / `InaccessiblePaths=/dev/shm`.
+  - `#362` — schema repairs: optional kind-qualified filenames, **ambiguity errors rather than shadows**, `sensitivity:` fail-safe default, `repo:`→`scope:`, the **liveness convention**.
+  - `#375` — decision record for the rejected store design.
+  - `#378` — `scripts/lib/subsystem_resolver.py`.
+  - `#398` — both summarisers emit `changed_paths`; opencode's extractor fixed (read tool inputs top-level; they nest under `state.input`, camelCase).
+  - `#408` — six fatal shapes guarded in the claude tailer; `run()` propagates failure (it returned 0 unconditionally, disabling the unit's only alerting channel).
+  - `#415` (`3fd97fd`) — `scripts/lib/subsystem_touch.py` + `/handoff` step 4: **the second writer**.
+  - `#421` (`e7c1007`) — `--session <uuid>` path source, read from the session's own transcript.
+  - `#424` (`7994ba1`) — `--pr <n>[,…]` path source, **the only one that can see a subagent's work**.
   - Closed as superseded: `#364` (by #366), `#410` (by #407).
-- **Deploy status:** both hosts converged and switched. Verified live, not assumed —
-  the deployed handoff skill carries all three of its new clauses, the autocommit
-  timer fired 10 min before this doc was written, and the claude tailer fired 2 min before.
-- **Backfill:** 585 historical opencode sessions re-emitted (362 files, 94 commits,
-  37,311 lines that previously read as zero). Message streams verified unchanged.
-- **Store right now:** 21 entries, **1 scope**, 3 commits, clean, **0 remotes**.
-- **Census baseline (the falsifiability anchor):** `21 entries · 1 scope · 21 unstamped`.
+- **IN FLIGHT:** `#418` — the previous revision of this doc, still OPEN. This file supersedes it; push to the same branch (`docs/handoff-subsystem-store`) rather than opening a second PR.
+- **Deploy:** both hosts converged and switched. Verified live, not assumed.
+- **Backfill:** 585 historical opencode sessions re-emitted (362 files, 94 commits, 37,311 lines that had read as zero).
+
+### The loop closed — measured, not asserted
+- `--pr` over this session's 9 merged PRs → **23 paths**, every PR reconciled (`N reported, N read`).
+- The first entry written: `~/.claude/analyze-service-index/devrc/opencode.md`.
+- Re-running the identical command then flipped `scope-absent` → **`resolved`**, matching `via filename 'opencode'` on 3 real paths.
+- **Census moved off its anchor:** `22 entries · datapacket-talos 21 + devrc 1 · created_by handoff 1 · unstamped 21` (anchor was `21 / 1 scope / 21 unstamped`).
+- The autocommit **bootstrapped the new scope on first sight**: `initialised a new repository (branch trunk, no remote)` → `committed 660d1ee`. Both scopes: `datapacket-talos` 3 commits, `devrc` 1 commit, **0 remotes each**.
+- 🔴 **The identity-seeding fallback fired for the first time ever** — `analyze-service index <analyze-service-index@localhost>`. It had never been exercised because the pre-existing scope carries a repo-**local** git identity; a brand-new scope has none and `GIT_CONFIG_GLOBAL=/dev/null` hides the global one. That code path was written in #361 and only proved itself today.
 
 ## Open investigations — live diagnosis state
 
-### 155 of 290 path-carrying sessions have `cwd` basename literally `empty`
-- **Symptom + exact repro:** grouping session-summary rows by the last component of the `cwd` **column** returns `empty` for 155 of 290 sessions that carry ≥1 changed path.
-- **Observed (with values):** `is_literal_empty=0` for all rows (so `cwd` is not the string `empty`); the bucket is `depth=4`, i.e. `/a/b/empty`. Basename query returns exactly `empty  4  155`. `countIf(repo='')` is **0** for both sources, so it is not an empty string.
-- **Ruled out:** `cwd` being absent or empty (measured 0 for both sources). Reading `cwd` from the *payload* — that was **my error**: opencode's payload has no `cwd` field at all; it is a top-level **column**.
-- **Leading hypothesis:** an opencode default/placeholder working directory. Unconfirmed.
-- **Next probe:** `SELECT DISTINCT cwd FROM activity.events WHERE kind='session-summary' AND splitByChar('/', trimBoth(cwd))[-1]='empty' LIMIT 5` — then look at what that directory actually is on disk.
-- **Why it matters:** those sessions can never resolve to a subsystem, so they are 53% of the corpus permanently excluded. It does not change any verdict already reached.
-
-### The decision record's reopening gate asks the wrong question
+### The reopening gate in the decision record asks the wrong question
 - **Symptom:** `claudedocs/decision-subsystem-store-rejected-2026-08-11.md` says revisit at "≥5 entries outside the current single scope, or ≥5 non-infra entries".
-- **Observed:** the P1 measurement showed the binding constraint is **coverage**: of 290 path-carrying sessions, **12** are in the one indexed scope, and 7 of those resolved — a **58% hit rate inside covered scope**. The resolver works; the index covers ~4% of the repos worked in.
-- **Leading hypothesis:** the gate should read "does the index cover the repos where work happens" — currently 1 of ~12.
-- **Next probe:** none needed; this is an edit to that document.
+- **Observed:** P1's measurement showed the binding constraint is **coverage**, not entry class. Of 290 path-carrying sessions, **12** were in the one indexed scope and 7 of those resolved — a **58% hit rate inside covered scope**. The resolver works; the index covered ~4% of the repos worked in.
+- **Leading hypothesis:** the gate should read "does the index cover the repos where work happens" — was 1 of ~12, now 2 of ~12.
+- **Next probe:** none. This is a one-paragraph edit to that document.
+
+### 155 of 290 path-carrying sessions have `cwd` basename literally `empty`
+- **Symptom:** grouping `session-summary` rows by the last component of the `cwd` **column** returns `empty` for 155 of 290 sessions carrying ≥1 changed path.
+- **Observed:** `cwd = 'empty'` is false for all (not the literal string); the bucket is `depth=4`, i.e. `/a/b/empty`; basename query returns exactly `empty 4 155`; `countIf(repo='')` is **0** for both sources.
+- **Ruled out:** `cwd` absent or empty (measured 0 both sources). Reading `cwd` from the *payload* — **my error**: opencode's payload has no `cwd` field; it is a top-level **column**.
+- **Leading hypothesis:** an opencode default/placeholder working directory. Unconfirmed.
+- **Next probe:** `SELECT DISTINCT cwd FROM activity.events WHERE kind='session-summary' AND splitByChar('/', trimBoth(cwd))[-1]='empty' LIMIT 5`, then look at that directory on disk.
+- **Why it matters:** those sessions can never resolve to a subsystem — 53% of the corpus permanently excluded. Changes no verdict already reached.
 
 ### opencode can emit a stringified list as a repo-relative path
-- **Symptom:** `str(inp.get("filePath") or "")` — `str(["a.py"])` is `"['a.py']"`, which `to_repo_relative` **accepts** and emits. Manufactured data in the one module whose contract is that nothing is invented.
+- **Symptom:** `str(inp.get("filePath") or "")` — `str(["a.py"])` is `"['a.py']"`, which `to_repo_relative` **accepts** and emits. Manufactured data in the module whose contract is that nothing is invented.
 - **Observed:** searched the emitted corpus for that shape — **zero occurrences**. The path exists; it has never fired.
-- **Ruled out:** that #408's claude-side fix covers it — it does not; #408 deliberately *validates and skips* on the claude side rather than coercing, precisely because coercion manufactures data.
-- **Next probe:** decide whether to validate-and-skip on the opencode side to match, or leave a documented known-limitation.
+- **Ruled out:** that #408's claude-side fix covers it — it does not. #408 deliberately **validates and skips** rather than coercing, precisely because coercion manufactures data.
+- **Next probe:** decide validate-and-skip on the opencode side, or a documented known-limitation.
 
 ## Next steps (ranked)
 
-1. **Correct the reopening gate** in `decision-subsystem-store-rejected-2026-08-11.md` to the coverage question. One edit; it is the durable record and currently misleads.
-2. **Let the writer run and watch the census.** `python3 scripts/lib/subsystem_touch.py --census`. Baseline is `21 / 1 scope / 21 unstamped`. If `created_by: handoff` entries do not appear across several repos within a few weeks, the need is narrower than it looks and the writer should be reconsidered — same discipline that killed the original design.
-3. **Investigate the `empty` cwd bucket** (probe above).
-4. **Decide the opencode stringified-path question** (validate-and-skip vs documented limitation).
-5. **Worktree debt** — 17+ agent worktrees under `.claude/worktrees/`, several from this session's agents.
+1. **Correct the reopening gate** in the decision record (above). One paragraph; it is the durable record and currently misleads.
+2. **Merge `#418`** after pushing this revision to its branch.
+3. **Watch the census.** `python3 scripts/lib/subsystem_touch.py --census`. It has moved once. If `created_by: handoff` entries do not keep accruing across repos over the next few weeks, the writer is not sticking and should be reconsidered — the same discipline that killed the original design.
+4. **Investigate the `empty` cwd bucket** (probe above).
+5. **Decide the opencode stringified-path question.**
+6. **The floors line in `scripts/run-tests.sh` has now conflicted on eight consecutive PRs** (twice on one). Per-target floors (#397) removed the base-dependent global total but made every test-adding PR touch the table. Worth measuring separately.
+7. **Worktree debt** — 17+ agent worktrees under `.claude/worktrees/`.
 
 ## Gotchas / decisions / dead-ends
 
-- 🔴 **A large subsystem store was proposed and REJECTED on measurement** — no `type:`-driven sections, no dependency graph, no multi-verb CRUD. After eight weeks: 20 entries, **0 non-infra**, **1 scope**, **0 dependency edges**. A hand-authored `process` and `org` entry showed `type:` selected nothing. Do not rebuild it; read the decision record first.
-- 🔴 **But "no demand" was partly circular reasoning, and that was my error.** The only writer was an infra-recon command pointed at two cluster repos, so of course only infra entries in one scope existed. "Nothing non-infra exists" is not evidence of no demand when nothing can create one. `#415` closes exactly that gap. The arguments that *do* survive are narrower: the `type:` taxonomy and graph were unjustified, and an opt-in multi-verb CRUD would not have stuck.
-- **Adoption, measured across 17 commands:** six have never been invoked once. The lesson is **not** "opt-in fails" — it is that **opt-in survives when it rides a ritual already performed, and dies when it *is* the ritual**. `/analyze-service` stuck (29 invocations) because its index write is a free side-effect of recon. `#415` rides `/handoff` for the same reason.
-- **Paths come from git, bounded to the branch, and the bound is printed on every output path.** Telemetry's `changed_paths` is the honest per-*session* source but does not exist yet when `/handoff` fires. The core takes paths as an argument so telemetry can feed it later.
-- **`--show-toplevel` was rejected deliberately:** it would make **every agent worktree its own scope**, sharding the store into hundreds of unresolvable one-entry scopes. With dozens of concurrent worktrees here that is the normal case.
-- **Working-tree residue, not branch age, is the dominant over-reporting source** — on a live run, 6 of 6 paths were other sessions' stale untracked files. `--exclude` is wired into the skill's command line; it is manageable, not solved.
-- **A top-ranked `scripts` or `claudedocs` nomination is honest, not a bug** — it genuinely covers several paths in one subtree. The confirm gate is what rejects it.
-- 🔴 **`~/.claude/analyze-service-index/` must never gain a remote** and no line of it may reach a public repo. `devrc` is PUBLIC. Each scope's `README.md` is authoritative over any command file.
-- **Instrument validation kept being the actual finding.** Four separate mutation harnesses in this session produced wrong verdicts before being corrected — one reused a stale `.pyc`, one ran against uncommitted work whose `git checkout --` silently reverted the change under test, one mis-scored six kills by regex-matching a traceback body, one was environment-dependent on the pytest launch directory. A green sweep is a claim about the harness until proven otherwise.
-- **`FETCH_HEAD` is repo-global** and is clobbered by concurrent sessions in this shared checkout — it produced one false verification here. Resolve to an explicit remote-tracking ref and assert the sha.
-- **`git diff --stat <branch>..origin/main` renders the branch's own edits with inverted sign.** I misread that as "main collided with my files" and told an agent so; it was wrong. `git log <base>..origin/main -- <path>` is the right question.
+- 🔴 **A large subsystem store was proposed and REJECTED on measurement** — no `type:`-driven sections, no dependency graph, no multi-verb CRUD. Read `decision-subsystem-store-rejected-2026-08-11.md` before re-proposing.
+- 🔴 **But the "no demand" half was CIRCULAR, and that was my error.** The only writer was an infra-recon command pointed at two cluster repos, so only infra entries in one scope *could* exist. `#415` closes exactly that. The surviving arguments are narrower: the `type:` taxonomy and graph were unjustified, and an opt-in multi-verb CRUD would not have stuck.
+- **Adoption, measured across 17 commands:** six have never been invoked once. The lesson is not "opt-in fails" but **opt-in survives when it rides a ritual already performed, and dies when it *is* the ritual**.
+- **Three path sources, blind in different directions — never merge their outputs.** git window: misses work that merged during the session. `--session`: misses **subagent** work (`isSidechain` excluded — 196 of 733 file-tool calls) and `Bash`-written files. `--pr`: sees subagents, but is the **branch union** — another session's commits, hand-made ones — and misses anything that never reached a PR. The flags are mutually exclusive on purpose.
+- **`gh pr view --json files` silently truncates at 100** while `changedFiles` reports the truth. Guarded cap-agnostically by `len(paths) < changedFiles`. My own verification missed it because I checked against a 4-file PR — one measurement, generalised.
+- **`--show-toplevel` was rejected deliberately:** it would make every agent worktree its own scope, sharding the store into hundreds of one-entry scopes.
+- **Working-tree residue, not branch age, dominates git-window over-reporting** — a live run returned 6 of 6 paths belonging to other sessions.
+- 🔴 **The store must never gain a remote**; no line of it may reach a public repo. `devrc` is PUBLIC. Each scope's `README.md` is authoritative over any command file.
+- **Instrument validation kept being the actual finding.** Five mutation harnesses this session produced wrong verdicts before correction — a stale `.pyc`; a sweep whose `git checkout --` reverted the change under test; a parser regex-matching a traceback body; one environment-dependent on the pytest launch directory; one that overwrote the repo's `conftest.py`. A green sweep is a claim about the harness until a control proves otherwise.
+- **`FETCH_HEAD` is repo-global** and is clobbered by concurrent sessions here — it produced one false verification. Resolve to an explicit remote-tracking ref and assert the sha.
+- **`git diff --stat <branch>..origin/main` renders the branch's own edits with inverted sign.** I misread that as a collision and told an agent so. `git log <base>..origin/main -- <path>` is the right question.
+- **zsh eats `:s`/`:h`/`:p` after an unbraced `$VAR` in a git ref** — `$B:scripts/...` silently reads the wrong thing. Brace it.
 
 ## How to verify
 
 ```bash
-# the writer, end to end (read-only; never writes)
-python3 /home/zach/workspace/devrc/scripts/lib/subsystem_touch.py --repo /home/zach/workspace/devrc
+D=/home/zach/workspace/devrc
+# the writer, both sources (read-only; the tool never writes)
+python3 $D/scripts/lib/subsystem_touch.py --repo $D --session <your-scratchpad-uuid>
+python3 $D/scripts/lib/subsystem_touch.py --repo $D --pr <n>[,<n>...]
 
-# the falsifiability counter
-python3 /home/zach/workspace/devrc/scripts/lib/subsystem_touch.py --census
+# the falsifiability counter — anchor was 21 / 1 scope / 21 unstamped
+python3 $D/scripts/lib/subsystem_touch.py --census
 
-# the store is versioned, contained, and has NO remote
-S=~/.claude/analyze-service-index/datapacket-talos
-git -C $S rev-list --count HEAD; git -C $S remote -v | wc -l   # commits; MUST be 0
-systemctl --user list-timers 'analyze-service-index-commit*' --no-pager
+# both scopes versioned, contained, and with NO remote
+for s in datapacket-talos devrc; do
+  T=~/.claude/analyze-service-index/$s
+  echo "$s: $(git -C $T rev-list --count HEAD) commits, $(git -C $T remote -v | wc -l) remotes"
+done
 systemctl --user show analyze-service-index-commit.service \
   -p ProtectSystem -p ProtectHome -p PrivateNetwork -p InaccessiblePaths --no-pager
 


### PR DESCRIPTION
Session handoff for the subsystem-store arc. **Revised in place** — this branch previously carried an earlier revision whose state section said `main` is **RED**. That was wrong; see below.

## What shipped

`#361` per-scope git store + contained hourly autocommit · `#362` schema repairs · `#375` decision record · `#378` resolver · `#398` `changed_paths` + the opencode extractor fix · `#408` failure propagation in the claude tailer · `#415` the `/handoff` writer · `#421` `--session` · `#424` `--pr` · `#432` `--commit` · `#426` the read half · `#429` show-existing-bullets. Closed as superseded: `#364`, `#410`.

## The measurement the arc existed to produce

Falsifiability anchor, recorded before any writer existed: **21 entries · 1 scope · 21 unstamped.**

```
27 entries
  by scope:      civitai 1 · civitai-app-starters 1 · datapacket-talos 24 · devrc 1
  by created_by: handoff 6 · unstamped 21
```

Six entries across four scopes, three of which did not exist before. The rejected design's **"no demand" half was circular** — the only writer at the time was an infra-recon command, so only infra entries *could* exist. This is the refutation. The narrower rejections (no `type:` taxonomy, no dependency graph, no multi-verb CRUD) still stand on their own evidence.

## The correction, kept because the mistake is the durable part

The previous revision on this branch concluded a **structural sandbox-vs-host split** from `test_st_blocks_CANNOT_see_a_fallocated_partial` failing on two consecutive sandbox runs while passing on the host, and wrote `main is RED`.

It was a **flake**. Another session measured 1 red in 5 runs with the assertion's operands **reversed between reports** — the tell never looked for. `#435` landed the real fix: *st_blocks equality pinned allocator luck, not the code under test.* The defect was real; the diagnosis was not. Two runs plus one contrasting environment is not enough to call a structural split, and `RULES.md` already says to distinguish a flake by wall time and by *whose* time moved, not by one re-run.

## Also recorded

- Four path sources, blind in different directions, never to be merged: the git window misses work merged mid-session; `--session` misses subagent turns (196 of 733 file-tool calls), `Bash`-written files, and worktree-mandated repos; `--pr` is the branch union and misses direct pushes (144 of 200 recent trunk commits carry no `(#N)`); `--commit` is the primitive.
- **`Edit` vs `Write` on an entry, measured:** `Write` silently loses a concurrent append; `Edit` is bounded so the other bullet survives — but it does **not** reliably fail loudly. An earlier rationale said it did and was wrong.
- Six mutation harnesses produced wrong verdicts before correction. Instrument validation kept being the actual finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)