### PR TITLE
feat(session-manager): a `waiting` signal, so "is anything waiting on me" stops costing 13 tails and returning a sample

### DIFF
--- a/claude/skills/session-manager/SKILL.md
+++ b/claude/skills/session-manager/SKILL.md
@@ -1,148 +1,120 @@
 ---
 name: session-manager
-description: "Live cross-host view of every tmux window on workbench + laptop — which have Claude Code running, what each is doing, how stale it is, plus recent agent sessions from ClickHouse. JSON-first, read-only. Use for: active sessions, what's running where, tmux state across both hosts, cross-host session status, tail a tmux window, which windows are stale/idle/busy."
+description: "Live cross-host view of every tmux window on workbench + laptop — which have Claude Code running, what each is doing, which ones are WAITING ON A HUMAN (asked a question / blocked on a modal / out of context), how stale it is, plus the clawgate approval queue and recent agent sessions from ClickHouse. JSON-first, read-only. Use for: is anything waiting on me, active sessions, what's running where, tmux state across both hosts, cross-host session status, tail a tmux window, which windows are stale/idle/busy/blocked."
 ---
 
 # session-manager — cross-host tmux + agent activity
 
-`scripts/session-manager`. One-shot, read-only, `--json`-first. It is the **queryable
-counterpart to `agent-ops`**, which is the always-on local tmux popup with no JSON API and
-no cross-host reach.
-
-## Run it
+`scripts/session-manager`. One-shot, **read-only**, `--json`-first, both hosts.
 
 ```bash
-python3 $DEVRC/scripts/session-manager                       # table, both hosts
-python3 $DEVRC/scripts/session-manager --json                # agent-readable
-python3 $DEVRC/scripts/session-manager --host workbench --no-ch   # fast + offline
-python3 $DEVRC/scripts/session-manager list                  # tmux only, no ClickHouse
-python3 $DEVRC/scripts/session-manager detail scratch7:3     # one window + its prompt history
-python3 $DEVRC/scripts/session-manager tail scratch7:3 --lines 200   # --host defaults to LOCAL
+python3 $DEVRC/scripts/session-manager --json                      # everything
+python3 $DEVRC/scripts/session-manager --host workbench --no-ch    # fast + offline
+python3 $DEVRC/scripts/session-manager detail scratch7:3           # one window + prompts
+python3 $DEVRC/scripts/session-manager tail scratch7:3 --plain     # scrollback, no ANSI
 ```
 
-`detail` additionally runs the per-session prompt-history query for that window's
-`claude_session_id` and attaches it as `session_history` (skipped, with a stated reason,
-under `--no-ch` or when the window carries no session id). See
-`reference/clickhouse-queries.md`.
-
-🔴 **Read `session_history.reason` — only one of its answers is a measured absence.** A
-single hardcoded reason used to answer every no-session-id case, so one `detail --json`
-could print `LIVE COUNT UNMEASURED` and then assert a *measured* absence over that same
-unmeasured set. The reason now branches on what was actually measured: `--no-ch`,
-`--no-fuzzyclaw` (the files were never read), **any** matched window is on a **remote** host
-(fuzzyclaw is local-only — and with the default `--host all` a `session:index` that exists on
-both machines yields a row from each, so this fires on a *mixed* row set too), the
-intersection **never ran**, the slot was **contested and all claimants dropped**, an
-**unrecognised** `fuzzyclaw.status`, or — the one genuine measured absence — *"no live
-fuzzyclaw task file joined to it"*, which is reached only when the status is `ok`. Every
-other reason says **"this is NOT a measured absence"** in so many words.
+🔴 **Rows are at `report["hosts"][<"workbench"|"laptop">]["windows"]`** — not at the top
+level. Roll-ups: `summary.waiting`, `summary.status[bucket]` (`{claude, shell, total}`),
+`blocked_on_me`.
 
 | flag | effect |
 |---|---|
 | `--json` | JSON (default is a table) |
-| `--host workbench\|laptop\|all` | default `all` |
-| `--claude-only` | drop non-Claude windows (see below); no effect on `tail`, which says so on stderr |
+| `--host workbench\|laptop\|all` | default `all`; `tail` resolves `all` to LOCAL |
+| `--claude-only` | drop non-Claude rows; every count then describes the FILTERED set, and `summary.excluded_non_claude` says how many went |
+| `--no-ch` | skip ClickHouse — the client is never constructed |
+| `--no-capture` | skip the pane scrape; **every** `waiting_probable` becomes `null` |
+| `--fuzzyclaw` / `--no-fuzzyclaw` | the task-file join is **OFF by default** (see below) |
+| `--plain` | `tail` only: strip ANSI at the source instead of `sed`-ing it out |
 | `--stale-threshold <secs>` | default 3600; `age >= threshold` is stale |
-| `--no-ch` | skip ClickHouse — the client is never even constructed |
-| `--no-fuzzyclaw` | skip the task files |
 | `--lines N` | `tail` scrollback depth (default 100) |
 
-## 🔴 A MIXED count is never published as a bare number
+## 🔴 `waiting_probable` — is anything waiting on a HUMAN
 
-The headline question is *"is anything waiting on me"*, and `idle` answered it
-with agents and bare shells added together: measured 2026-08-11, 61 windows gave
-`idle: 17` = **12 agent windows + 5 bare shells**, both rendered `● idle`. The
-row data was always right (every row carries `claude`); the roll-up and the
-table conflated. So:
+`status: idle` merges four states that need four different actions. Each Claude pane is
+scraped (one batched `capture-pane` per host) for three signals, and every row carries the
+**matched line** so you can disagree with it:
 
-```json
-"summary": {
-  "total_sessions": 61, "claude": 41, "shell": 20,
-  "status": {"idle": {"claude": 12, "shell": 5, "total": 17}, "busy": {…},
-             "stale": {…}, "unknown": {…}}
-}
-```
+| signal | means | do |
+|---|---|---|
+| `trailing_question` | the agent's last sentence ends in `?` | answer it |
+| `selection_menu` | `❯ 1./2./3.` modal is up | press a key |
+| `context_exhausted` | `ctx: 0%` | `/clear` it |
 
-🔴 **The flat `summary["idle"|"busy"|"stale"|"unknown"]` integers are GONE** —
-a deliberate break, in the loud direction. Keeping them would have left every
-reader on the mixed number while the fix sat in keys they never learned about;
-`summary["status"]["idle"]["total"]` is the same number and you have to type
-`total` to get it. The table gained a **KIND** column (`claude`/`shell`, read off
-the boolean, not spelled into the status word) and a
-`by status (claude+shell): idle=12+5 …` footer.
+🔴 **`waiting_probable: false` means "these three were looked for and none matched" — NOT
+"this window needs nothing."** Recall is partial by construction: measured on 40 live panes
+2026-08-12, a window parked on `Press Enter to continue…` matches none of them, and text
+typed at the `❯` prompt is deliberately **excluded** (a window one Enter away reads `no` —
+see `reference/waiting-signal.md` for the evidence and what would justify turning it on).
 
-All four buckets split, not just `idle`. `unknown` was 15/15 non-claude in that
-measurement, which is a snapshot: a claude row lands in `unknown` as soon as its
-title carries no glyph — which every REMOTE claude window does whenever the
-glyph is absent, since it has no age either.
+🔴 **`waiting_probable: null` is not `false`.** Read `waiting_status`: `ok` (scraped),
+`not_claude` (never scraped — the signals are Claude-TUI shapes and a shell's last line
+ending in `?` would be a false positive), `uncaptured` (the batch ran, this pane was not in
+it), `skipped` / `error`. `summary.waiting.probable` is likewise **`null`, never `0`**, when
+nothing was scraped — the one sentence this tool must never emit is "nothing is waiting on
+you" off a look that never happened.
 
-## `--claude-only`
+## 🔴 `blocked_on_me` — the clawgate approval queue
 
-Drops non-Claude rows on **every** host. 20 of 61 rows were shells the operator
-never asked about, so this is a straight token cut for the agent path.
+Read from the bar poller's cache. It is here because an accurate cross-reference once cost
+real signal: a dogfooding agent read that `agent-ops` has no JSON API, correctly preferred
+this script, never opened agent-ops, and **missed 11 pending approvals — four of them
+credential-exposure or cross-user-data-leak.**
 
-🔴 **Every summary count then describes the FILTERED set** — `total_sessions`,
-`claude`, `shell`, `status.*` — and `summary.excluded_non_claude` says how many
-rows were dropped (it is `null`, not `0`, when the filter never ran). That
-direction is the safe one: counting the unfiltered set would publish
-`total_sessions: 20` beside an empty table and **exit 0**. Counting the filtered
-set makes "no agent windows here" a real measured zero — **exit 3** — with the
-dropped count proving the host was not empty.
+- **`count` is the measurement; `detail` is not.** The cached detail string truncates
+  (names ~6 ids however many are pending) and has dropped `ready_for_review` items —
+  finished work awaiting review. Nothing here parses it.
+- Four states: `ok` / `stale` (cache older than 300s — the poller writes every 45s) /
+  `absent` / `unparseable`. The last three publish **`count: null`, never `0`**.
+- **For WHICH tasks, open `agent-ops`** (`$mod+i`, tmux `prefix+A`, or the ▦ bar button). It
+  has the enumerated queue with titles, open PRs, and a `/proc` walk that finds a `claude`
+  buried under a wrapper shell. This script has the count; that one has the list. They are
+  complements, not substitutes.
 
-## The two caveats are in the OUTPUT, not just in this file
+## The caveats are in the OUTPUT, not just in this file
 
-`report["caveats"]` (structured) + two footer lines in the table, printed
-unconditionally:
+`report["caveats"]` (structured) + three footer lines in the table, printed
+unconditionally — an agent that runs the script cold never reads this file:
 
-- `claude_detection` — `pane_current_command =~ /claude/`; a claude under a
-  wrapper shell reads as `shell`.
-- `fuzzyclaw_scope` — `local_host_only`; the `null_fields_on_remote_rows` ledger
-  (`fuzzyclaw`, `claude_session_id`, `age_secs`) is pinned by a test against a
-  real remote row **and** against the equivalent local row, so it cannot drift
-  into naming fields that are always null.
-
-An agent that runs the script cold never reads this file; a caveat that lives
-only here protects only the readers who already knew.
+- `claude_detection` — `pane_current_command =~ /claude/`; a claude under a wrapper shell
+  reads as `shell` (shallower than agent-ops' `/proc` walk, which is not reachable over SSH).
+- `fuzzyclaw_scope` — `local_host_only`; a REMOTE row carries null `fuzzyclaw` /
+  `claude_session_id` / `age_secs` and is never labelled `stale`.
+- `waiting_signal` — the enumerated signal set, the claude-rows-only scope, and the
+  prompt-text exclusion with its reason.
 
 ## 🔴 Read the exit code — the two zeroes are different facts
 
 | code | meaning |
 |---|---|
 | `0` | ran, found windows (**including** a partial scan where one host was unreachable) |
-| `2` | usage / malformed `<session>:<window>` target / **`tail`: the host answered and there is no such window** |
-| `3` | every requested host answered and the answer is a **real zero** (for `tail`: the window exists and its scrollback is empty; under `--claude-only`: zero **agent** windows — read `summary.excluded_non_claude` before concluding the host is idle) |
+| `2` | usage / bad `<session>:<window>` / **`tail`: the host answered, no such window** |
+| `3` | every requested host answered and the answer is a **real zero** |
 | `4` | **no** host could be reached — the zero is unmeasured, not measured |
-| `5` | **`tail` only**: the host answered and there is **no tmux server** on it, so no window exists there |
+| `5` | **`tail` only**: the host answered and there is **no tmux server** on it |
 
-🔴 For `tail`, "no such window" is **exit 2**, not 4. The host answered; calling it
-unreachable states a false fact and sends you to debug SSH over a typo. `tail`'s JSON
-carries `reachable` *and* `found` — `found: null` means the host never answered, so it has
-said nothing about whether the target exists. `--json` prints that payload on **every** exit
-path, 0/2/3/4/5, not only on success — the failure exits are precisely where the
-discriminants are worth reading. The human sentence goes to stderr, so stdout stays parseable.
+Rationale, and why 5 had to be split out of 3: `reference/exit-codes.md`.
 
-🔴 **Exit 5 exists because 3 was carrying two facts.** `tmux` saying *"no server running"*
-is a **reachable** host, so `tail` used to take the success branch and publish
-`found: true, text: ""` → exit 3 — identical to a window that exists with an empty
-scrollback, which is the only thing exit 3 is documented to mean. A down server now gets
-`found: false, no_server: true` and its own code. It is deliberately **not** exit 2 (the
-target may be spelled perfectly — the repair is starting tmux, not fixing a typo) and not
-exit 4 (the host *did* answer).
+Same discipline inside the payload: `hosts.<n>.reachable`/`.error` describe the
+**`list-panes`** call, `.windows_measured`/`.windows_error` the **`list-windows`** call, and
+`.captures_measured`/`.captures_status` the **capture batch** — three independent
+measurements, and one succeeding says nothing about the others. `clickhouse.status` must be
+`ok` before `rows: []` is believable. **Never read a bare count without its status.**
 
-`--host` defaults to `all`, which is meaningless for a command targeting one window, so
-`tail` resolves it to the **local** host. That default is recorded, not silent:
-`host_defaulted: true` in the JSON, and the not-found message names the host searched and
-how to search the other one.
+## fuzzyclaw is OFF by default
 
-Same discipline inside the payload. `hosts.<name>.reachable` + `.error` are always present;
-`clickhouse.status` is one of `ok` / `unreachable` / `query_error` / `unavailable` /
-`skipped`, so `rows: []` is only believable when it is `ok`; `fuzzyclaw` reports
-`files_seen` / `files_live` / `files_unparseable`, so "no live tasks" is distinguishable
-from "no task files". Never read a bare count without its status.
+Measured 2026-08-12: **29 live of 401 files, 363 stale, 9 slot-mismatched — and every one of
+the 29 live rows read `paused`**, including a window demonstrably running an agent. 29 table
+rows, zero contribution, from a source `CLAUDE.md` marks UNTRUSTED. Opt in with
+`--fuzzyclaw`; `--no-fuzzyclaw` still works and now names the default. Off, every count is
+`null` rather than `0`.
 
-Under `--no-fuzzyclaw` **every one of those counts is `null`, not `0`** — the directory is
-never opened, so a `0` would be a fabricated measurement. `status: "skipped"` discriminates
-it, but a discriminated lie is still a lie in the count.
+The intersection guard is unchanged and still runs when you opt in — a task file survives
+only when its `window_id` is live **and** that live window's real `(session, index)` equals
+the one the file recorded. Why that relationship (not mere existence) is the guard, what the
+slot-conflict drop does and does not still catch, and the field ledger:
+`reference/fuzzyclaw-guard.md`.
 
 ## Where everything lives
 
@@ -150,112 +122,24 @@ it, but a discriminated lie is still a lie in the count.
 |---|---|
 | `scripts/session-manager` | the script |
 | `scripts/tests/test_session_manager.py` | the hermetic suite (mocks tmux, SSH, CH, FS) |
-| `scripts/tmux-scratch-slots.sh` | codename table (`~/.config/tmux/scratch-slots.sh` deployed) |
-| `scripts/validation/chquery.py` | shared CH client — a LIBRARY, imported by `sys.path` insert |
+| `scripts/tmux-scratch-slots.sh` | codename table |
+| `scripts/validation/chquery.py` | shared CH client — a LIBRARY, `sys.path`-inserted |
 | `~/.config/activity-collector/env` | CH endpoint + creds (never hardcoded) |
-| `~/.tmux/tasks/*.json` | fuzzyclaw task files |
+| `~/.cache/bar-status/clawgate.json` | the blocked-on-me cache (`scripts/bar-status-poll`) |
+| `~/.tmux/tasks/*.json` | fuzzyclaw task files (UNTRUSTED) |
 
-Details: `reference/clickhouse-queries.md`, `reference/cross-host.md`.
-
-## 🔴 fuzzyclaw is only usable intersected with LIVE windows — and the guard pins a RELATIONSHIP
-
-`CLAUDE.md` marks `~/.tmux/tasks/*.json` UNTRUSTED. Measured on the workbench 2026-08-11:
-**400 files, 44 live windows, 357 stale (89%), 11 slot-mismatched, 32 live, 0 unparseable.**
-The failure mode is staleness, not corruption — so it is filterable, and
-`filter_live_tasks()` does the filtering against
-`tmux list-windows -a -F '#{window_id}|#{window_index}|#{session_name}'`.
-
-A task file survives only when **both** hold:
-
-```
-window_id is live   AND   that live window's real (session, index) == the file's
-```
-
-🔴 **Existence alone is not enough, and checking only existence was a real defect here.** An
-earlier revision keyed the guard on `window_id` but joined the task onto a pane row by
-`(tmux_session, window_index)` — two independent facts, never checked against each other.
-`renumber-windows` is `on`, so indexes shift under live windows: of the 43 files that passed
-the id-only guard, only **32** still sat in the slot they recorded, **7** named a slot now
-held by a *different* live window, and **5** slots were claimed by more than one survivor
-(silently last-wins). Two rendered rows carried another window's `claude_session_id` — the
-one carrier of the session id into ClickHouse — so a `detail` would have pulled a stranger's
-prompt history.
-
-Consequences, all pinned by tests:
-
-- rejections are counted **separately**: `files_stale` (the window is gone) vs
-  `files_mismatched` (alive, but somewhere else now). Collapsing them hides a renumber storm.
-- a slot two files both claim resolves to **nothing**. `index_tasks_by_window()` drops it and
-  reports it under `fuzzyclaw.slot_conflicts`; attaching an arbitrary one of two
-  contradictory records is worse than attaching none, because it reads as measured data.
-  🔴 **What that drop still catches is narrower than the "5 contested slots" above — but it
-  is not empty.** Gone for good: two *distinct* live window ids contending for one slot (a
-  slot belongs to exactly one window, so `list-windows` cannot report it) — that was the
-  shape produced by the *old id-only* guard. **Still reachable: two task files carrying the
-  same `window_id`.** The files are `<index>.json`, not `<window_id>.json`, so nothing
-  enforces one file per window, and `CLAUDE.md` marks the directory UNTRUSTED — the
-  400-files/400-distinct-ids reading of 2026-08-11 is a snapshot of that writer, not an
-  invariant. Both duplicates pass the relationship guard and collide, and the conflict
-  renders; a test drives that case through `gather()`. Note that `claimants` counts *files*
-  while `window_ids` is deduplicated, so `claimants: 2, window_ids: ["@41"]` is exactly this
-  case — duplicate files for one window, not contention — and the rendered line states both
-  numbers so it cannot be misread.
-- every row carries `window_id`, so the join is auditable in the output:
-  `row.window_id == row.fuzzyclaw.window_id` for every joined row. 🔴 That holds **by
-  construction, not by luck** — both sides derive from the same `list-windows` snapshot — so
-  it is documentation of the join, **not a defence**, and re-checking it at runtime would be
-  an unreachable guard. It does **not** cover the one skew that is genuinely reachable:
-  `list-panes` and `list-windows` are two non-atomic calls, so with `renumber-windows on` a
-  window can move between them and a row can pair one snapshot's pane data with the other's
-  window id. The pane format carries no `window_id`, so nothing catches that. **Unguarded,
-  and named rather than implied away.**
-- `filter_live_tasks()` **rejects a bare set of ids with a `TypeError`** rather than
-  degrading to the old existence-only check.
-
-Same precedent and rationale as `scripts/tmux-scratch-status.sh:28-34`. If you add a second
-consumer of these files, intersect there too — do not copy the fields out raw.
-
-The task-file key set consumed is pinned as a **field ledger** (`FUZZYCLAW_FIELDS`, 11 keys
-including `transcript_path`, which the original spec omitted). It fails the suite when the
-set grows *or* shrinks.
-
-## 🔴 The third zero: `fuzzyclaw.status`
-
-The live-window set is **measured or `None`**, never a fabricated empty set. When it was not
-measured, `fuzzyclaw.status` is `"unmeasured"` and `files_live` is `null` — *not* `0`, and
-never `"ok"`. Two ways to get there, both of which used to report
-`files_seen: 400, files_live: 0, status: "ok"`:
-
-| cause | what you see |
-|---|---|
-| `--host laptop` — the local host is never scanned, so its windows are never listed | `fuzzyclaw.error` names the unscanned local host |
-| `list-panes` succeeded but `list-windows` failed | `hosts.<n>.windows_measured: false` + `windows_error`; `live_window_ids: null` |
-
-`hosts.<n>.reachable`/`.error` describe the **`list-panes`** call; `.windows_measured`/
-`.windows_error` describe the **`list-windows`** call. They are independent measurements —
-one succeeding says nothing about the other.
-
-## Honest limits — do not describe these as working
-
-(The first two are now also carried in the output — see "The two caveats" above.)
-
-- Claude detection is `pane_current_command =~ /claude/`, **shallower** than agent-ops'
-  `/proc` descendant walk. `/proc` is not reachable over SSH, so a deeper local check would
-  make the two hosts report by different rules.
-- fuzzyclaw is read on the **local host only** (the files are local state). A remote row
-  therefore has `fuzzyclaw: null`, `claude_session_id: null` and `age_secs: null`, and is
-  classified busy/idle from the title glyph alone — it is never labelled `stale`, because
-  no age was measured.
-- `tail --stream` is **not implemented** — one-shot `capture-pane` only.
-- `signal` / `kill` are **not implemented**, deliberately. This tool never writes to,
-  signals, or kills a window. Adding a destructive verb needs its own PR and its own guards.
+Reference: `waiting-signal.md`, `exit-codes.md`, `fuzzyclaw-guard.md`,
+`clickhouse-queries.md`, `cross-host.md`.
 
 ## Gotchas
 
-- Both hosts report `hostname` as `nixos`. The local host label comes from `ACTIVITY_HOST`
-  (env, then the collector env file), defaulting to `workbench`.
-- `tmux` exiting non-zero with *"no server running"* is a **reachable** host with zero
-  windows, not an unreachable one. The script already separates them; keep it that way.
-- zsh reserves `status` — use `rc=`/`out=`. Use `git -C <path>`, never `cd <repo> &&`.
-- Merged ≠ deployed: this file only reaches `~/.claude/skills/` on a `home-manager switch`
-  / `ship.sh`. The script itself runs straight from the repo checkout.
+- Both hosts report `hostname` as `nixos`. The local label comes from `ACTIVITY_HOST` (env,
+  then the collector env file), defaulting to `workbench`.
+- `tmux` saying *"no server running"* is a **reachable** host with zero windows, not an
+  unreachable one. Keep the two separate.
+- `signal` / `kill` are **not implemented, deliberately.** This tool never writes to,
+  signals or kills a window — which is the only reason it is safe to point at a live machine
+  holding 40+ windows of real work. A `waiting` flag is a read; acting on it is not. A
+  destructive verb needs its own PR and its own guards.
+- Merged ≠ deployed: this file only reaches `~/.claude/skills/` on a `home-manager switch` /
+  `ship.sh`. The script itself runs straight from the repo checkout.

--- a/claude/skills/session-manager/reference/exit-codes.md
+++ b/claude/skills/session-manager/reference/exit-codes.md
@@ -1,0 +1,60 @@
+# Exit-code rationale
+
+The table is in the SKILL body. This is the *why*, kept out of the always-on cost.
+
+## The contract
+
+"Ran, found nothing" and "could not run" MUST be distinct. A caller reading success off a
+truncated run is the whole hazard the exit contract exists for.
+
+| code | meaning |
+|---|---|
+| `0` | the scan ran and produced ≥1 window row — **including** a partial scan where one host was unreachable |
+| `2` | bad arguments / malformed target; for `tail`, the host answered and there is no such window |
+| `3` | every requested host answered and the answer is a real, measured `0` |
+| `4` | no requested host could be reached — the `0` is unmeasured |
+| `5` | `tail` only: the host answered and there is no tmux **server** on it |
+
+## Why `tail`'s "no such window" is 2, not 4
+
+The host answered. Reporting it as unreachable states a false fact about the host and sends
+the operator to debug SSH over a typo. `tail`'s JSON carries `reachable` **and** `found`, and
+`found: null` means the host never answered — so it has said nothing about whether the target
+exists.
+
+`--json` prints that payload on **every** exit path (0/2/3/4/5), not only on success. It used
+to print only on success, so exits 2, 4 and 5 wrote nothing to stdout while the docs
+documented their payload; a machine consumer got an empty stdout on exactly the three
+outcomes the discriminants exist to tell apart, and could only re-derive them by parsing
+English off stderr. The human sentence still goes to stderr, so stdout stays parseable.
+
+## Why exit 5 had to be split out of 3
+
+`tmux` saying *"no server running"* is a **reachable** host — correct for a whole-host scan,
+where it means a live host with zero windows. But `tail` then took the success branch and
+published `found: true, text: ""` → exit 3, which is identical to *the window exists and its
+scrollback is empty*, the one thing exit 3 is documented to mean. Two different facts, one
+exit code, and the doc matched neither.
+
+A down server now gets `found: false, no_server: true` and its own code. Deliberately **not**
+exit 2 (the target may be spelled perfectly — the repair is starting tmux, not fixing a typo)
+and **not** exit 4 (the host *did* answer).
+
+The no-server branch must come **first** in `tail_window`, before the plain `reachable`
+return, or it is unreachable.
+
+## `--host` defaulting under `tail`
+
+`--host` defaults to `all`, which is meaningless for a command targeting one window, so
+`tail` resolves it to the **local** host. The default is recorded, not silent:
+`host_defaulted: true` in the JSON, and the not-found message names the host searched plus
+how to search the other one. In plain-text mode it goes to stderr, so piping the scrollback
+is unaffected.
+
+## `--claude-only` and exit 3
+
+Under `--claude-only`, every summary count describes the **filtered** set. That is the safe
+direction: counting the unfiltered set would publish `total_sessions: 20` beside an empty
+table and **exit 0** — "ran, found windows" over nothing printed. Counting the filtered set
+makes the same run a real measured zero (**exit 3**), because zero *agent* windows is what
+was asked, and `summary.excluded_non_claude` keeps it from reading as an empty host.

--- a/claude/skills/session-manager/reference/fuzzyclaw-guard.md
+++ b/claude/skills/session-manager/reference/fuzzyclaw-guard.md
@@ -1,0 +1,101 @@
+# The fuzzyclaw intersection guard, and the slot-conflict archaeology
+
+Loaded only when someone touches the task-file join. `--fuzzyclaw` is **opt-in** since
+2026-08-12 (29 live rows of 401 files, all reading `paused`, zero contribution to any
+answer) — but the guard below still runs whenever it is turned on, and its tests still gate
+every commit.
+
+## The guard pins a RELATIONSHIP, not two independent facts
+
+`CLAUDE.md` marks `~/.tmux/tasks/*.json` UNTRUSTED. Measured on the workbench 2026-08-11:
+**400 files, 44 live windows, 357 stale (89%), 11 slot-mismatched, 32 live, 0 unparseable.**
+The failure mode is staleness, not corruption — so it is filterable.
+
+A task file survives only when **both** hold:
+
+```
+window_id is live   AND   that live window's real (session, index) == the file's
+```
+
+measured against `tmux list-windows -a -F '#{window_id}|#{window_index}|#{session_name}'`.
+
+🔴 **Existence alone is not enough, and checking only existence was a real defect here.** An
+earlier revision keyed the guard on `window_id` but joined the task onto a pane row by
+`(tmux_session, window_index)` — two independent facts, never checked against each other, and
+that split was documented as "deliberate". `renumber-windows` is `on`, so indexes shift under
+live windows all day: of the 43 files that passed the id-only guard, only **32** still sat in
+the slot they recorded, **7** named a slot now held by a *different* live window, and **5**
+slots were claimed by more than one survivor (silently last-wins). Two rendered rows carried
+another window's `claude_session_id` — the one carrier of the session id into ClickHouse — so
+a `detail` would have pulled a stranger's prompt history.
+
+## Consequences, all pinned by tests
+
+- Rejections are counted **separately**: `files_stale` (the window is gone) vs
+  `files_mismatched` (alive, but somewhere else now). Collapsing them hides a renumber storm.
+- A slot two files both claim resolves to **nothing**. `index_tasks_by_window()` drops it and
+  reports it under `fuzzyclaw.slot_conflicts`; attaching an arbitrary one of two
+  contradictory records is worse than attaching none, because it reads as measured data.
+- Every row carries `window_id`, so the join is auditable in the output:
+  `row.window_id == row.fuzzyclaw.window_id` for every joined row.
+- `filter_live_tasks()` **rejects a bare set of ids with a `TypeError`** rather than
+  degrading to the old existence-only check.
+- The consumed key set is a **field ledger** (`FUZZYCLAW_FIELDS`, 11 keys including
+  `transcript_path`, which the original spec omitted), asserted to fail when the set grows
+  *or* shrinks.
+
+## 🔴 What the slot-conflict drop still catches — narrower than the story above, but not empty
+
+- **GUARANTEED GONE:** two *distinct* live window ids contending for one slot. A slot belongs
+  to exactly one window, so `list-windows` cannot report it. That was the shape produced by
+  the *old id-only* guard, and it is the shape the 5 contested slots had.
+- **STILL REACHABLE:** two task files carrying the **same** `window_id`. The files are
+  `<index>.json`, not `<window_id>.json`, so nothing on disk enforces one file per window,
+  and the directory is UNTRUSTED. Both duplicates pass the relationship guard (each resolves
+  to the one slot their shared id really holds), collide at the index, and the conflict is
+  dropped and rendered. A test drives that case end-to-end through `gather()`.
+
+`claimants` counts **files** while `window_ids` is deduplicated, so `claimants: 2,
+window_ids: ["@41"]` is exactly the duplicate-files case — not contention — and the rendered
+line prints both numbers so it cannot be misread. The 400-files/400-distinct-ids reading of
+2026-08-11 is a snapshot of an untrusted writer, not an invariant; do not read it forward.
+
+## What the `row.window_id == row.fuzzyclaw.window_id` invariant does NOT buy
+
+It holds **by construction, not by luck** — both sides derive from the same `list-windows`
+snapshot — so it is documentation of the join, **not a defence**, and re-checking it at
+runtime would be an unreachable guard. It does not cover the one skew that is genuinely
+reachable: `list-panes` and `list-windows` are two non-atomic calls, so with
+`renumber-windows on` a window can move between them and a row can pair one snapshot's pane
+data with the other's window id. The pane format carries no `window_id`, so nothing catches
+that. **Unguarded, and named rather than implied away.**
+
+## The third zero: `fuzzyclaw.status`
+
+The live-window set is **measured or `None`**, never a fabricated empty set. When it was not
+measured, `status` is `"unmeasured"` and `files_live` is `null` — *not* `0`, and never
+`"ok"`. Two ways to get there, both of which used to report
+`files_seen: 400, files_live: 0, status: "ok"`:
+
+| cause | what you see |
+|---|---|
+| `--host laptop` — the local host is never scanned, so its windows are never listed | `fuzzyclaw.error` names the unscanned local host |
+| `list-panes` succeeded but `list-windows` failed | `hosts.<n>.windows_measured: false` + `windows_error`; `live_window_ids: null` |
+
+Under `--no-fuzzyclaw` (now the default) **every one of those counts is `null`, not `0`** —
+the directory is never opened, so a `0` would be a fabricated measurement. `status:
+"skipped"` discriminates it, but a discriminated lie is still a lie in the count.
+
+Same precedent and rationale as `scripts/tmux-scratch-status.sh:28-34`. If you add a second
+consumer of these files, intersect there too — do not copy the fields out raw.
+
+## The mixed-count split (2026-08-11), for context
+
+The headline question is *"is anything waiting on me"*, and `idle` answered it with agents
+and bare shells added together: 61 windows gave `idle: 17` = **12 agent windows + 5 bare
+shells**, both rendered `● idle`. The row data was always right (every row carries `claude`);
+the roll-up and the table conflated. The flat `summary["idle"|"busy"|"stale"|"unknown"]`
+integers are **gone** — a deliberate break in the loud direction, since keeping them would
+have left every reader on the mixed number while the fix sat in keys they never learned
+about. `summary["status"]["idle"]["total"]` is the same number and you have to type `total`
+to get it. All four buckets split, not just `idle`.

--- a/claude/skills/session-manager/reference/waiting-signal.md
+++ b/claude/skills/session-manager/reference/waiting-signal.md
@@ -1,0 +1,132 @@
+# `waiting_probable` — how the signal is derived, and what it deliberately misses
+
+Loaded only when someone is changing the detector. The SKILL body has what a consumer needs.
+
+## Why it exists
+
+`status: idle` merged four states that need four different actions:
+
+| real state | what you'd do |
+|---|---|
+| finished cleanly, awaiting instruction | give it work |
+| asked a direct question | answer it |
+| hard-blocked on a modal | press a key |
+| out of context (`ctx: 0%`) | `/clear` it |
+
+Two blind dogfood runs, given only *"what is being worked on, is anything waiting on me?"*,
+could only answer the last three by `tail`-ing windows and reading English prose — 13 of 40
+windows, ~30% of the run's tokens. The answer was a sample, not a sweep.
+
+## How the panes are captured
+
+**One tmux invocation per host**, not one per pane — 40 panes over SSH would be 40 round
+trips. tmux takes a `;`-separated command list in a single call and `display-message -p`
+writes to the same stdout, so the batch is:
+
+```
+tmux display-message -p -t %11 'SMCAP<nonce>#{pane_id}SMCAP' \; capture-pane -p -t %11 \
+     display-message -p -t %68 'SMCAP<nonce>#{pane_id}SMCAP' \; capture-pane -p -t %68 …
+```
+
+Three things about that line are load-bearing:
+
+- 🔴 **The pane id arrives via `#{pane_id}`, never our own interpolation.** A tmux format
+  string is strftime-expanded, so a literal `%68` in it is **not** a pane id — it is `%B`
+  (full month name) padded to width 68. Verified on live tmux 2026-08-12:
+  `tmux display-message -p 'A%68B'` prints `A`, 62 spaces, `August`. The marker would
+  silently lose the very id it exists to carry. Pinned by
+  `test_the_marker_never_interpolates_a_pane_id_into_a_tmux_format`.
+- **A per-run hex nonce**, so a pane cannot forge a marker: its scrollback would have to
+  contain a string generated after it was drawn.
+- **Only Claude panes are captured.** The signals are Claude Code TUI shapes; scraping a bare
+  zsh would only invent false positives out of whatever its scrollback happens to hold. Those
+  rows are `not_claude`, never `false`. The gate is asserted on the *argv*, because reading it
+  off the row cannot distinguish "not scraped" from "scraped and suppressed".
+- **No `-e`**, so the capture carries no ANSI at all.
+
+The argv is asserted against an **allowlist** of subcommands (`tmux`, `display-message`,
+`capture-pane`), not a denylist — a denylist passes for every mutating verb nobody named.
+
+## The three signals
+
+Evaluated independently on the full capture; none short-circuits another. A pane really can
+match two at once (an agent that asks a question and then puts up a modal).
+
+**`selection_menu`** — a line matching `^\s*❯\s*\d+\.\s+\S`, **plus at least one other
+numbered option**. The second option is what stops the signal firing on ordinary prose:
+agents quote menus back at the operator all day, and a live modal always has ≥2 choices.
+
+**`context_exhausted`** — `\bctx:\s*0%`. Anchored so `ctx: 10%`, `ctx: 20%`, `ctx: 100%` and
+`ctx: 0.4%` do **not** match; a substring test on `0%` would recommend `/clear` to every
+window whose context happens to end in a zero. Measured at the boundary and on both sides.
+
+**`trailing_question`** — the **last assistant line** ends in `?`. Finding that line is the
+whole difficulty, and it is done **structurally**:
+
+1. Claude Code draws the input box between two box-drawing rules. Cut there — everything from
+   the box down is chrome, including the `❯` input line, `ctx: NN%`, and `⏸ manual mode on`.
+   (A modal *replaces* the box, so a lone trailing rule cuts only itself.)
+2. Strip the between-turn status lines off the bottom: `✻ Baked for 13m 17s`,
+   `* Calculating… (47s · …)`, `※ recap: …`, the braille spinner. The sparkle/spinner half
+   reuses `busy_from_title`'s table, so a glyph cannot be a spinner to one function and prose
+   to the other.
+
+Keyword-matching the chrome instead would break the moment upstream restyles a footer, and
+would let a footer that ends in `?` read as a question. Both traps are live: a real pane
+shows `new task? /clear to save 342.1k tokens`, and the user's own submitted prompt is
+echoed into the scrollback as `❯ …?`.
+
+## 🔴 Text typed at the `❯` prompt is EXCLUDED — the evidence
+
+A dogfood run saw four windows with dimmed text at the prompt (`merge 131`, `clean up the
+worktrees`, …) and read them as unsent instructions one Enter away, flagging honestly that it
+could not rule out placeholder text. Investigated against `claude-code 2.1.220` on
+2026-08-12.
+
+**Dimness is the wrong question.** What separates the readings is *position*, and
+`capture-pane` reports position perfectly well. From the bundle:
+
+- **A placeholder cannot coexist with typed text.** The hint hook returns early on a
+  non-empty buffer (`if(e!=="")return`), and the renderer gates on `t.length===0 && …`. So
+  "placeholder vs draft" is not a real ambiguity.
+- **A queued message is not in the box either.** The submit handler clears the buffer on
+  enqueue (`onInputChange("")`, `setCursorOffset(0)`, `clearBuffer()`), and queued messages
+  render as their own 2-column-indented block **above** the input box's top border.
+
+So in principle: text between the two rules ⇒ typed but unsent ⇒ genuinely waiting.
+
+**It is still excluded, for three reasons:**
+
+1. Both invariants are read off a **minified** bundle at **one** version. Upstream restyles
+   this surface.
+2. The case they rule out — a live queued message — was **never observed**: zero hits across
+   29 Claude panes and ~250k lines of scrollback, on a scan whose positive control passed
+   (89–130 column-0 chevrons per pane). Keying a signal on an unobserved negative means its
+   failure mode is a **false `waiting` row**, arriving exactly when the operator most trusts
+   the output.
+3. Under that same source read, typing while an agent works has **three** outcomes, not one:
+   queue, *interrupt the turn* (`hasInterruptibleToolInProgress` → `abort`), or drop as
+   `mode_not_queueable`. "Text in the box" is not even a single-meaning observation.
+
+Excluding costs **recall**, which is the safe direction, and the caveat says so in the
+output. **To turn it on**, someone has to observe a live queued message and confirm it
+renders outside the box — then the discriminator is: box line non-empty and not `ESC[2m`
+(which needs `capture-pane -e`, i.e. dropping the plain capture).
+
+## Known misses, stated rather than implied away
+
+- `Login successful. Press Enter to continue…` — a real hard block on 2 of 40 panes
+  2026-08-12. None of the three signals catches it.
+- An agent that offers rather than asks (*"Say the word and I'll open the PR"*) — no `?`.
+- A `claude` under a wrapper shell reads as `shell`, so it is never scraped
+  (`caveat[claude_detection]`).
+
+## Calibration, 2026-08-12
+
+Run against all 40 live panes on the workbench: **7 flagged of 29 Claude panes** — 3
+`selection_menu` (two resume prompts, one option list), 4 `trailing_question` — and 11
+`not_claude`. Every flagged row was independently confirmed by reading the pane. Zero false
+positives.
+
+Suite: **positive control 3 flagged of 5 realistic panes; negative control 0.** Twenty
+mutants, each killed on its own named assertion.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -413,7 +413,18 @@ TARGET_FLOORS=(
   # main (now carrying the line above) + this branch. Same method — the gate's
   # measurement of the MERGED tree, not arithmetic across the conflict:
   #   _suggested_floor 2535 = 2535 - min(50, max(1, 126)) = 2485.
-  "scripts/tests|2485"
+  #
+  # 2026-08-12, the session-manager `waiting` signal + blocked-on-me: 2535 ->
+  # 2613 collected (+78, all in scripts/tests/test_session_manager.py: 293 ->
+  # 371). Same method as every line above — the AUTHORITATIVE gate's own
+  # printed count (`nix build .#checks.x86_64-linux.pytests`:
+  # `scripts/tests collected=2613`) put through the gate's own function:
+  #   _suggested_floor 2613 = 2613 - min(50, max(1, 130)) = 2613 - 50 = 2563.
+  # 🔴 A sibling branch also adds tests here, so this line WILL conflict and
+  # `rerere` has mis-replayed exactly it before. Resolve by re-running the gate
+  # on the MERGED tree and copying the number it prints — never by arithmetic
+  # across the two sides.
+  "scripts/tests|2563"
   # 2026-08-11, the session-summary changed-paths work: 230 -> 273 collected,
   # +43 for scripts/collector/tests/test_changed_paths.py (the shared
   # `changed_paths*` module). The gate printed this replacement itself —

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -424,7 +424,12 @@ TARGET_FLOORS=(
   # the first gate run here reported the OLD 2535 because an untracked test is
   # silently absent from the flake source. If this line conflicts with another
   # branch, re-run the gate on the MERGED tree and copy what it prints.
-  "scripts/tests|2501"
+  #
+  # 2026-08-12, the waiting-signal branch, doing exactly what the line above
+  # says: 2551 -> 2629 collected on main + this branch, measured by the gate on
+  # the MERGED tree rather than computed from either side of the conflict.
+  #   _suggested_floor 2629 = 2629 - min(50, max(1, 131)) = 2629 - 50 = 2579.
+  "scripts/tests|2579"
   # 2026-08-11, the session-summary changed-paths work: 230 -> 273 collected,
   # +43 for scripts/collector/tests/test_changed_paths.py (the shared
   # `changed_paths*` module). The gate printed this replacement itself —

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -9,19 +9,38 @@ Today that requires stitching `agent-ops` (local-only popup, no JSON API),
 `tmux list-panes -a` per host, a manual `curl` at ClickHouse, and the fuzzyclaw
 task files.
 
-RELATIONSHIP TO agent-ops
--------------------------
+RELATIONSHIP TO agent-ops — READ BOTH, THEY ARE NOT SUBSTITUTES
+---------------------------------------------------------------
 `agent-ops` is the always-on tmux popup. This is its queryable/programmatic
 counterpart: one-shot, `--json`-first, and cross-host. It deliberately does NOT
 share agent-ops' `/proc` BFS — see "HONEST LIMITS" below.
+
+🔴 That description used to end there, and its MEASURED EFFECT was losing
+signal. A dogfooding agent read "agent-ops has no JSON API and no cross-host
+reach", correctly concluded this script was the better tool, never opened
+agent-ops — and so missed the ELEVEN pending clawgate approvals only agent-ops
+showed, four of them credential-exposure or cross-user-data-leak. An accurate
+cross-reference steered a reader away from the highest-stakes signal on the
+machine. Two fixes, both applied:
+
+  * the pending count is now read HERE (`report["blocked_on_me"]`, and a
+    `▸ BLOCKED ON ME` section printed in every state including unmeasured), so
+    the headline question does not depend on remembering another tool;
+  * agent-ops remains the place to see WHICH tasks, and is pointed AT rather
+    than away from. It has what this cannot: the enumerated queue with titles,
+    open PRs, and the /proc walk that finds a `claude` under a wrapper shell.
 
 ARCHITECTURE
 ------------
 Every fact-producing function is either PURE or takes an injected runner /
 client / clock, so the whole test suite is hermetic: it never runs tmux, never
 opens a socket, and never touches a real window. The impure edge is exactly
-three seams — `_default_runner` (subprocess), `make_ch_client` (HTTP), and
-`_read_text` (filesystem).
+FOUR seams — `_default_runner` (subprocess), `make_ch_client` (HTTP),
+`_read_text` (filesystem), and `_read_blocked_text` (the clawgate bar cache).
+The last is deliberately its OWN name rather than a `_read_text` call: the
+suite forbids each edge by replacing it with a raiser, and an edge that shares
+a function with a legitimate one cannot be forbidden without breaking the
+other. See `_read_blocked_text`.
 
 🔴 SILENT-ZERO DISCIPLINE (the reason for most of the shape here)
 -----------------------------------------------------------------
@@ -124,7 +143,33 @@ HONEST LIMITS (stated, not implied away — AND CARRIED IN THE OUTPUT as
     `last_activity`). Remote rows are still classified busy/idle from the pane
     title glyph.
   * `tail --stream` is NOT implemented. Only the one-shot `capture-pane` dump.
-  * `signal` / `kill` are NOT implemented — deliberately deferred.
+  * `signal` / `kill` are NOT implemented — deliberately deferred. This script
+    is READ-ONLY BY CONSTRUCTION, which is the only reason it is safe to point
+    at a live machine holding 40+ windows of real work. `waiting_probable` is a
+    READ; acting on it is not, and does not belong here.
+  * `waiting_probable` scrapes THREE enumerated signals off a TUI upstream can
+    restyle at will, on claude rows only. `false` means "these three did not
+    match", never "this window needs nothing" — measured 2026-08-12, a window
+    parked on `Press Enter to continue…` matches none of them. See
+    CAVEATS["waiting_signal"], carried in the output.
+
+🔴 THE JSON SHAPE, because a consumer that has to guess it wastes a call
+--------------------------------------------------------------------------
+Window rows are NOT at the top level. They live at:
+
+    report["hosts"][<"workbench"|"laptop">]["windows"]  -> [row, ...]
+
+and the roll-ups a caller usually wants are:
+
+    report["summary"]["waiting"]        {"probable", "measured", "unmeasured",
+                                         "per_signal", "unmeasured_reasons"}
+    report["summary"]["status"][b]      {"claude", "shell", "total"} per bucket
+    report["blocked_on_me"]             {"status", "count", ...}
+
+Each row carries: host, session, window_index, window_id, window_name,
+codename, pane_id, path, command, task, claude, busy, age_secs, status,
+waiting_probable, waiting_signals, waiting_status, claude_session_id,
+fuzzyclaw, panes. The row ledger is pinned by a test.
 """
 from __future__ import annotations
 
@@ -136,6 +181,7 @@ import shlex
 import subprocess
 import sys
 import time
+import uuid
 from datetime import datetime, timezone
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
@@ -205,6 +251,103 @@ DEFAULT_TAIL_LINES = 100
 
 CLAUDE_RE = re.compile(r"claude", re.IGNORECASE)
 
+# --------------------------------------------------------------------------- #
+# 🔴 BLOCKED-ON-ME (the clawgate approval queue), read from the bar poller's
+# cache. `agent-ops` is the only other surface that shows this, and a dogfood
+# agent that (correctly) rejected agent-ops for having no JSON API therefore
+# missed 11 pending approvals, four of them credential-exposure or
+# cross-user-data-leak. So the count lives here too.
+#
+# 🔴 `count` IS THE MEASUREMENT; `detail` IS NOT. The cached detail string
+# truncates — "11 task(s) awaiting: #171, #170, #169, #168, #160, #165" names
+# SIX of eleven — and the dropped tail has included `ready_for_review` items,
+# i.e. finished work awaiting review. Nothing here ever parses `detail` for a
+# count; it is carried verbatim and labelled truncated.
+#
+# The cache is written by `scripts/bar-status-poll` every 45s. Anything older
+# than MAX_AGE cannot be called a current measurement, so it is published with
+# `status: "stale"` rather than as a fresh number — and an ABSENT cache is
+# `count: None`, never 0. A missing file rendering as a measured zero is the
+# exact failure this whole script exists to refuse.
+# --------------------------------------------------------------------------- #
+BLOCKED_CACHE = os.path.join(HOME, ".cache", "bar-status", "clawgate.json")
+BLOCKED_CACHE_MAX_AGE = 300         # 5x the 45s poll interval
+BLOCKED_DETAIL_NOTE = ("`detail` TRUNCATES (it names ~6 ids however many are "
+                       "pending) and has dropped ready_for_review items — read "
+                       "`count`, or `agent-ops` / the clawgate API for the "
+                       "full queue")
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE `waiting` SIGNAL. `status: idle` merges four states that need four
+# different actions: finished-and-awaiting-instruction, asked-a-direct-question,
+# hard-blocked-on-a-modal, and out-of-context. Only the first is idle in any
+# useful sense; a dogfood agent had to `tail` 13 of 40 windows and read English
+# prose to tell them apart, which is a sample, not a sweep.
+#
+# 🔴 IT IS `waiting_PROBABLE`, AND IT SHIPS THE MATCHED LINE. These are screen-
+# scrapes of a TUI that upstream can restyle at any time, so the row carries the
+# evidence and a consumer judges it. A bare boolean would be a verdict this
+# cannot honestly issue.
+#
+# 🔴 THE SIGNAL SET IS ENUMERATED AND CLOSED. `waiting_probable: False` means
+# "these three were looked for and none matched" — NOT "this window needs
+# nothing". Measured on 40 live panes 2026-08-12, two windows sat on `Login
+# successful. Press Enter to continue…`, a real hard block that NONE of these
+# three signals catches. Recall is deliberately partial; the enumeration is
+# published in `caveats` so a consumer knows exactly what was looked for.
+#
+# 🔴 TEXT AT THE `❯` PROMPT IS DELIBERATELY *NOT* A SIGNAL, AND THE REASON IS
+# NOT "we could not tell" — investigated 2026-08-12, and the honest answer is
+# more specific than that. Recorded here because the next person WILL want to
+# add it, and the case against is evidential, not a shrug.
+#
+#   * DIMNESS IS THE WRONG QUESTION. What separates the readings is POSITION,
+#     not colour, and `capture-pane` reports position perfectly well.
+#   * A placeholder hint CANNOT coexist with typed text — the renderer returns
+#     early on a non-empty buffer (`if(e!=="")return`). So "placeholder vs
+#     draft" is not a real ambiguity.
+#   * A QUEUED message is not in the box either: the submit handler clears the
+#     buffer on enqueue and queued messages render as their own indented block
+#     ABOVE the top border.
+#
+# 🔴 SO WHY STILL EXCLUDED? Both invariants above are read off a MINIFIED
+# bundle at ONE version (claude-code 2.1.220), and the case they rule out —
+# a live queued message — was NEVER OBSERVED: zero hits across 29 Claude panes
+# and ~250k lines of scrollback. Keying a signal on an unobserved negative
+# means its failure mode is a FALSE `waiting` row, arriving exactly when the
+# operator most trusts the output. And under that same source read, typing
+# while an agent works has THREE outcomes, not one (queue / interrupt the turn
+# / drop as `mode_not_queueable`), so "text in the box" is not even a
+# single-meaning observation.
+#
+# Excluding costs RECALL, which is the safe direction and is stated in the
+# caveat. `reference/waiting-signal.md` carries the full evidence and the exact
+# observation that would justify turning it on.
+# --------------------------------------------------------------------------- #
+# A horizontal rule. Claude Code draws the input box with box-drawing rules, so
+# this is how the CHROME at the bottom of a pane is found structurally instead
+# of by matching the words it happens to contain.
+_RULE_RE = re.compile(r"^\s*[─-╿]{20,}\s*$")   # box-drawing block
+# `❯ 1. Retitle + post nudge (Recommended)` — the SELECTED option of a modal.
+_MENU_SELECTED_RE = re.compile(r"^\s*❯\s*\d+\.\s+\S")
+# Any option line, selected or not. Requiring a SECOND one is what keeps a lone
+# `❯ 1.` in ordinary scrollback prose from reading as a live modal.
+_MENU_OPTION_RE = re.compile(r"^\s*(?:❯\s*)?\d+\.\s+\S")
+# `ctx: 0%` in the footer. Anchored on the literal 0 followed by `%`, so
+# `ctx: 10%` and `ctx: 0.4%` do not match.
+_CTX_ZERO_RE = re.compile(r"\bctx:\s*0%")
+WAITING_SIGNALS = ("selection_menu", "context_exhausted", "trailing_question")
+
+# 🔴 The per-pane capture batch. ONE tmux invocation per host captures every
+# Claude pane's visible screen, with a `display-message` marker between them —
+# 40 separate `capture-pane` calls over SSH would be 40 round trips.
+#
+# The marker carries a per-run NONCE because `#{pane_id}` alone is content a
+# pane could print. `%` is NOT safe in a tmux format string (it is strftime: a
+# literal `%68` expands to a width-68 month name), which is why the id arrives
+# via `#{pane_id}` and `-t`, never interpolated by us.
+CAPTURE_MARK_PREFIX = "SMCAP"
+
 # The four status buckets, in one place. Every roll-up iterates THIS tuple, so a
 # bucket cannot exist in `classify_status` and be missing from the summary.
 STATUS_BUCKETS = ("busy", "idle", "stale", "unknown")
@@ -238,12 +381,47 @@ CAVEATS = {
                  "the title glyph alone. Do not read a remote row's absent "
                  "task as a measured absence."),
     },
+    # 🔴 The third limit, and the one most likely to be over-read: `waiting`
+    # is a SCREEN SCRAPE of a TUI, and its signal set is CLOSED. Carried in the
+    # payload so a `--json` consumer can enumerate what was looked for instead
+    # of inferring it from a boolean.
+    "waiting_signal": {
+        "method": "capture_pane_regex",
+        "signals": list(WAITING_SIGNALS),
+        "scope": "claude_rows_only",
+        "excluded": {
+            "prompt_buffer_text": (
+                "Text at the `❯` input prompt is NOT a signal. It is "
+                "distinguishable in principle — by POSITION, not by dimness: "
+                "a placeholder cannot coexist with typed text, and a queued "
+                "message renders above the input box rather than in it. But "
+                "both invariants are read off a minified bundle at ONE version "
+                "(claude-code 2.1.220) and the queued case was never observed "
+                "live (0 hits across 29 panes), so keying on it would trust an "
+                "unobserved negative whose failure mode is a FALSE `waiting` "
+                "row. Excluded; costs recall, not precision."),
+        },
+        "note": ("`waiting_probable: false` means these signals were looked "
+                 "for and none matched — NOT that the window needs nothing. "
+                 "Recall is partial by construction: measured on 40 live panes "
+                 "2026-08-12, a window parked on `Press Enter to continue…` "
+                 "matches none of them. `waiting_probable: null` means the "
+                 "pane was never captured; read `waiting_status` for which."),
+    },
 }
 
 # Claude Code renders a leading status glyph in the pane_title: a BRAILLE
 # spinner while working, a "sparkle" at rest. Same taxonomy as agent-ops.
 _BRAILLE_LO, _BRAILLE_HI = 0x2800, 0x28FF
 _SPARKLE_GLYPHS = frozenset("✳✻✽✶✷✢✺❋✱*")
+
+# Lines Claude Code prints BELOW the last assistant text and above the input
+# box: `✻ Baked for 13m 17s`, `* Calculating… (47s · …)`, `※ recap: …`, and the
+# braille spinner. They are stripped before "the last assistant line" is taken,
+# or the trailing-question test reads a status line instead of the answer. The
+# spinner/sparkle half is the SAME taxonomy `busy_from_title` uses — one table,
+# so a glyph cannot be a spinner to one function and prose to the other.
+_STATUS_PREFIXES = _SPARKLE_GLYPHS | frozenset("※")
 
 # `tmux` says this on stderr and exits non-zero when no server is running. That
 # is a REACHABLE host with zero windows — collapsing it into "unreachable" is
@@ -429,6 +607,211 @@ def busy_from_title(title: str):
 def pane_is_claude(pane) -> bool:
     """Shallow, UNIFORM Claude detection — see HONEST LIMITS in the header."""
     return bool(CLAUDE_RE.search((pane or {}).get("command", "") or ""))
+
+
+# =========================================================================== #
+# PURE — the `waiting` signal (pane screen-scrape)
+# =========================================================================== #
+def capture_mark(nonce: str) -> str:
+    """The per-run marker FORMAT handed to `tmux display-message`.
+
+    🔴 `#{pane_id}` — never our own interpolation of the id. A tmux format
+    string is strftime-expanded, so a literal `%68` becomes a width-68 month
+    name ("August", right-padded to 68 columns), and the marker silently loses
+    the id it exists to carry. Verified against live tmux 2026-08-12.
+    """
+    return "%s%s#{pane_id}%s" % (CAPTURE_MARK_PREFIX, nonce, CAPTURE_MARK_PREFIX)
+
+
+def capture_mark_re(nonce: str):
+    """The matching parser for `capture_mark`. Derived from the SAME nonce and
+    prefix, so the writer and the reader cannot drift apart."""
+    p = re.escape(CAPTURE_MARK_PREFIX)
+    return re.compile(r"^%s%s(%%\d+)%s$" % (p, re.escape(nonce), p))
+
+
+def capture_argv(pane_ids, nonce) -> list:
+    """ONE tmux argv that captures EVERY given pane, marker-delimited.
+
+    40 panes over SSH is 40 round trips if each gets its own call; tmux takes a
+    `;`-separated command list in a single invocation, and `display-message -p`
+    writes to the same stdout, so the whole host costs one subprocess.
+
+    `[]` for an empty pane list — an argv of a bare `tmux` would run tmux's
+    default command, which is emphatically not a read.
+
+    The NONCE is why a pane cannot forge a marker: its own scrollback would have
+    to contain a hex string generated after it was drawn.
+    """
+    ids = [p for p in (pane_ids or ()) if p]
+    if not ids:
+        return []
+    mark = capture_mark(nonce)
+    argv = ["tmux"]
+    for i, pid in enumerate(ids):
+        if i:
+            argv.append(";")
+        argv += ["display-message", "-p", "-t", pid, mark,
+                 ";", "capture-pane", "-p", "-t", pid]
+    return argv
+
+
+def parse_captures(raw, nonce) -> dict:
+    """Split a marker-delimited capture batch into {pane_id: text}.
+
+    Text appearing BEFORE the first marker is discarded: it belongs to no pane,
+    and attributing it to one would be a guess.
+    """
+    rx = capture_mark_re(nonce)
+    out, cur = {}, None
+    for line in (raw or "").splitlines():
+        m = rx.match(line)
+        if m:
+            cur = m.group(1)
+            out.setdefault(cur, [])
+        elif cur is not None:
+            out[cur].append(line)
+    return {k: "\n".join(v) for k, v in out.items()}
+
+
+def _is_status_line(line) -> bool:
+    """A blank line, or one of Claude Code's between-turn status lines."""
+    t = (line or "").strip()
+    if not t:
+        return True
+    return t[0] in _STATUS_PREFIXES or _is_braille(t[0])
+
+
+def last_assistant_line(text):
+    """The last line of ASSISTANT PROSE in a captured pane, or None.
+
+    🔴 STRUCTURAL, not keyword-matched. Claude Code draws its input box between
+    two box-drawing rules, so everything from that box down is chrome —
+    including the `❯` input line itself, the `ctx: NN%` footer, and
+    `⏸ manual mode on`. Finding the chrome by the WORDS it contains would break
+    the moment upstream restyles a footer, and would also let a footer that
+    happens to end in `?` (`new task? /clear to save 342.1k tokens` is on screen
+    right now) read as a question the agent asked.
+
+    So: cut at the rules, then strip the between-turn status lines
+    (`✻ Baked for 13m 17s`, `* Calculating…`, `※ recap:`) off the bottom. What
+    is left is what the agent last SAID.
+
+    A pane with no rule at all (a modal replaces the input box, and a bare shell
+    never draws one) keeps its whole body — for a modal the menu signal is the
+    one that fires anyway.
+    """
+    lines = (text or "").splitlines()
+    rules = [i for i, l in enumerate(lines) if _RULE_RE.match(l)]
+    if rules:
+        cut = rules[-1]
+        # Two rules a line or three apart are the input box, and the input line
+        # between them is chrome. A lone trailing rule is something else (a
+        # modal's separator), so only that last line is cut.
+        if len(rules) >= 2 and rules[-1] - rules[-2] <= 3:
+            cut = rules[-2]
+        lines = lines[:cut]
+    while lines and _is_status_line(lines[-1]):
+        lines.pop()
+    return lines[-1] if lines else None
+
+
+def detect_waiting(text) -> dict:
+    """Screen-scrape ONE captured pane for the three `waiting` signals.
+
+    Returns `{"probable": bool, "signals": [{"signal", "line"}, ...]}`. Every
+    hit ships THE MATCHED LINE, because the caller has to be able to disagree.
+
+    The three are INDEPENDENT — each is evaluated on the full capture and none
+    short-circuits another, so a pane can (and a real one did) match a menu and
+    a question at once. An early `return` on the first hit would have made the
+    other two unreachable and their tests vacuous.
+    """
+    lines = (text or "").splitlines()
+    signals = []
+
+    # 1. HARD BLOCK ON A MODAL. `❯ 1. …` plus a second numbered option. The
+    #    second option is load-bearing: a lone `❯ 1.` occurs in ordinary prose
+    #    (an agent quoting a menu back at you), a two-option list does not.
+    selected = next((l for l in lines if _MENU_SELECTED_RE.match(l)), None)
+    if selected is not None:
+        if sum(1 for l in lines if _MENU_OPTION_RE.match(l)) >= 2:
+            signals.append({"signal": "selection_menu",
+                            "line": selected.strip()})
+
+    # 2. OUT OF CONTEXT. `ctx: 0%` — the window cannot make progress until it is
+    #    `/clear`ed, whatever its spinner says.
+    ctx = next((l for l in lines if _CTX_ZERO_RE.search(l)), None)
+    if ctx is not None:
+        signals.append({"signal": "context_exhausted", "line": ctx.strip()})
+
+    # 3. ASKED A DIRECT QUESTION. The last thing the agent SAID ends in `?`.
+    last = last_assistant_line(text)
+    if last is not None and last.rstrip().endswith("?"):
+        signals.append({"signal": "trailing_question", "line": last.strip()})
+
+    return {"probable": bool(signals), "signals": signals}
+
+
+def read_blocked_on_me(path=None, reader=None, now=None,
+                       max_age=BLOCKED_CACHE_MAX_AGE) -> dict:
+    """The clawgate approval queue's pending COUNT, status-discriminated.
+
+    🔴 FOUR outcomes, never two. `absent` / `unparseable` publish `count: None`,
+    because a queue nobody measured is not an empty queue — and this tool exists
+    to refuse exactly that substitution. `stale` publishes the number it found
+    AND says it cannot be called current: the bar poller writes every 45s, so a
+    cache older than `max_age` describes a queue that may since have changed.
+
+    🔴 `detail` IS NEVER PARSED. It truncates to ~6 ids however many are
+    pending, and the ids it drops have included `ready_for_review` work. It is
+    carried verbatim, labelled `detail_truncated: True`, and `count` is the
+    only number anything reads.
+    """
+    now = time.time() if now is None else now
+    path = BLOCKED_CACHE if path is None else path
+    reader = reader or _read_blocked_text
+    base = {"source": "bar_status_cache", "path": path, "count": None,
+            "detail": None, "detail_truncated": True,
+            "detail_note": BLOCKED_DETAIL_NOTE, "cache_age_secs": None,
+            "max_age_secs": max_age, "error": None}
+    text = reader(path)
+    if text is None:
+        base["status"] = "absent"
+        base["error"] = ("no bar-status cache at this path — the clawgate queue "
+                         "was NOT measured; this is not zero pending")
+        return base
+    try:
+        obj = json.loads(text)
+    except (ValueError, TypeError) as e:
+        base["status"] = "unparseable"
+        base["error"] = f"{type(e).__name__}: {e}"
+        return base
+    if not isinstance(obj, dict) or not isinstance(obj.get("count"), int) \
+            or isinstance(obj.get("count"), bool):
+        base["status"] = "unparseable"
+        base["error"] = ("cache carries no integer `count` — nothing here is a "
+                         "measurement of the queue")
+        return base
+    base["count"] = obj["count"]
+    base["detail"] = obj.get("detail")
+    ts = obj.get("ts")
+    if not isinstance(ts, (int, float)) or isinstance(ts, bool):
+        # A count whose age cannot be established is not a fresh count. Saying
+        # so is the conservative direction; calling it `ok` is a guess.
+        base["status"] = "stale"
+        base["error"] = ("cache carries no numeric `ts`, so its freshness "
+                         "cannot be established")
+        return base
+    age = max(0.0, now - float(ts))
+    base["cache_age_secs"] = age
+    if age > max_age:
+        base["status"] = "stale"
+        base["error"] = (f"cache is {int(age)}s old (> {max_age}s); the poller "
+                         "writes every 45s, so this count may be out of date")
+        return base
+    base["status"] = "ok"
+    return base
 
 
 def classify_status(busy, age_secs, threshold) -> str:
@@ -654,7 +1037,8 @@ def index_tasks_by_window(tasks) -> dict:
 # =========================================================================== #
 def fold_windows(panes, host, codenames=None, task_index=None,
                  threshold=DEFAULT_STALE_THRESHOLD, now=None,
-                 slot_window_ids=None) -> list:
+                 slot_window_ids=None, captures=None,
+                 capture_status="skipped") -> list:
     """Collapse panes into one row per (session, window_index).
 
     A window is `claude` if ANY of its panes is; the row's task/busy/pane_id
@@ -686,6 +1070,14 @@ def fold_windows(panes, host, codenames=None, task_index=None,
     pair one snapshot's pane data with the other's window id. The pane format
     carries no `window_id`, so nothing here can catch that. UNGUARDED, and
     named so no one reads the invariant above as covering it.
+
+    🔴 `captures` IS `None`-VS-`{}`, and the difference is the whole point.
+    `None` means no capture batch ran on this host, so every row's
+    `waiting_probable` is `None` carrying `capture_status` (`skipped`/`error`).
+    `{}` means the batch RAN, so a row missing from it is `uncaptured` — its own
+    fact, not the host's. A non-Claude row is `not_claude`: only Claude panes are
+    captured, so `waiting_probable: False` on a bare zsh would be a verdict
+    about a pane nobody looked at.
     """
     now = time.time() if now is None else now
     codenames = codenames or {}
@@ -711,6 +1103,20 @@ def fold_windows(panes, host, codenames=None, task_index=None,
             if last is not None:
                 age = max(0.0, now - last)
         busy = busy_from_title(lead.get("title", ""))
+        is_claude = any(pane_is_claude(p) for p in members)
+        # 🔴 The waiting fields, resolved through the None-vs-{} distinction
+        # above. `probable` is None on every path where nothing was scraped.
+        if not is_claude:
+            w_status, w_probable, w_signals = "not_claude", None, None
+        elif captures is None:
+            w_status, w_probable, w_signals = capture_status, None, None
+        elif lead.get("pane_id") not in captures:
+            w_status, w_probable, w_signals = "uncaptured", None, None
+        else:
+            det = detect_waiting(captures[lead.get("pane_id")])
+            w_status = "ok"
+            w_probable = det["probable"]
+            w_signals = det["signals"]
         rows.append({
             "host": host,
             "session": session,
@@ -722,15 +1128,61 @@ def fold_windows(panes, host, codenames=None, task_index=None,
             "path": lead.get("path", ""),
             "command": lead.get("command", ""),
             "task": strip_status_glyph(lead.get("title", "")),
-            "claude": any(pane_is_claude(p) for p in members),
+            "claude": is_claude,
             "busy": busy,
             "age_secs": age,
             "status": classify_status(busy, age, threshold),
+            # 🔴 `waiting_probable` is a TRI-STATE. True/False are measurements;
+            # None means this pane was not scraped, and `waiting_status` says
+            # which of the four reasons. `waiting_signals` is None (not []) on
+            # those same paths — an empty list is "looked, found nothing".
+            "waiting_probable": w_probable,
+            "waiting_signals": w_signals,
+            "waiting_status": w_status,
             "claude_session_id": (task or {}).get("claude_session"),
             "fuzzyclaw": task,
             "panes": len(members),
         })
     return rows
+
+
+def _waiting_rollup(rows) -> dict:
+    """The `waiting` roll-up. Kept beside `summarize` and derived from
+    WAITING_SIGNALS so a new signal cannot be counted per-row and invisible in
+    the total.
+
+    🔴 `probable` is None when NOTHING was measured. `--no-capture`, a failed
+    capture batch, or a host of nothing but bare shells all produce zero
+    scraped panes, and publishing `probable: 0` for those says "I looked at
+    every window and none needs you" about a look that never happened. That is
+    the one sentence this tool must never emit.
+    """
+    measured = [r for r in rows if r.get("waiting_status") == "ok"]
+    per_signal = {s: 0 for s in WAITING_SIGNALS}
+    for r in measured:
+        for sig in (r.get("waiting_signals") or ()):
+            name = sig.get("signal")
+            per_signal[name] = per_signal.get(name, 0) + 1
+    return {
+        "probable": (sum(1 for r in measured if r.get("waiting_probable"))
+                     if measured else None),
+        "measured": len(measured),
+        "unmeasured": sum(1 for r in rows
+                          if r.get("waiting_probable") is None),
+        "per_signal": per_signal if measured else None,
+        # WHY a row went unmeasured, so "0 waiting" can be read against what
+        # was skipped rather than against the row total.
+        "unmeasured_reasons": _count_by(
+            r.get("waiting_status") for r in rows
+            if r.get("waiting_probable") is None),
+    }
+
+
+def _count_by(values) -> dict:
+    out = {}
+    for v in values:
+        out[v] = out.get(v, 0) + 1
+    return out
 
 
 def summarize(report) -> dict:
@@ -791,6 +1243,18 @@ def summarize(report) -> dict:
         # which of skipped / unmeasured / ok produced it.
         "fuzzyclaw_live": report["fuzzyclaw"].get("files_live"),
         "fuzzyclaw_status": report["fuzzyclaw"].get("status"),
+        # 🔴 The headline roll-up, under the SAME rule as every count above:
+        # `probable` is None when `measured` is 0, because "0 windows are
+        # waiting" and "0 windows were scraped" are different facts and the
+        # first is the one an operator will act on. `per_signal` is derived from
+        # the WAITING_SIGNALS tuple, so a signal cannot exist in
+        # `detect_waiting` and be missing from the summary.
+        "waiting": _waiting_rollup(rows),
+        # The clawgate approval queue, count + discriminant, never one alone.
+        "blocked_on_me": {
+            "count": (report.get("blocked_on_me") or {}).get("count"),
+            "status": (report.get("blocked_on_me") or {}).get("status"),
+        },
         # Hosts whose `list-windows` did not answer even though `list-panes`
         # did. Their rows carry no window_id and, if local, no fuzzyclaw join.
         "windows_unmeasured": sorted(
@@ -817,6 +1281,22 @@ def _read_text(path):
             return fh.read()
     except OSError:
         return None
+
+
+def _read_blocked_text(path):
+    """🔴 A SEAM OF ITS OWN, not a call to `_read_text`, and that is the point.
+
+    The hermetic suite forbids each impure edge by replacing it with a raiser,
+    so an edge that shares a function with a legitimate one cannot be forbidden
+    without breaking the other. `_read_text` is used by `local_host_label` on
+    real tmp files inside tests; the blocked-cache read is the one that would
+    reach `~/.cache` on a live workbench. It was doing exactly that — a golden
+    test picked up the operator's real pending count (12) mid-run, which is a
+    non-hermetic read AND a value that changes under the suite's feet.
+
+    Separate name, separately raisable, one line of indirection.
+    """
+    return _read_text(path)
 
 
 def _default_runner(argv, timeout):
@@ -963,10 +1443,11 @@ def ch_query(client, sql) -> dict:
 # GATHER — the one assembly point
 # =========================================================================== #
 def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
-           use_fuzzyclaw=True, threshold=DEFAULT_STALE_THRESHOLD, now=None,
+           use_fuzzyclaw=False, threshold=DEFAULT_STALE_THRESHOLD, now=None,
            ch_client_factory=None, fuzzyclaw_texts=None,
            codenames=None, ch_sql=SQL_RECENT_SESSIONS,
-           claude_only=False) -> dict:
+           claude_only=False, use_capture=True, capture_nonce=None,
+           blocked_reader=None, blocked_path=None) -> dict:
     """Build the whole report. Every source is injectable, so this is the
     function the hermetic suite exercises end-to-end.
 
@@ -976,11 +1457,25 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
     def time, so patching the module attribute would not be honoured here — the
     test suite's "no real network" guard would have been silently bypassed on
     exactly the path (`main()` -> `gather()`) that has no injection point.
+
+    🔴 `use_fuzzyclaw` DEFAULTS TO FALSE. Measured on this host 2026-08-12: 29
+    live of 401 files, 363 stale, 9 slot-mismatched — and every one of those 29
+    live rows read `paused`, including a window demonstrably running an agent.
+    29 table rows, zero contribution to any answer, from a source `CLAUDE.md`
+    marks UNTRUSTED. Opt in with `--fuzzyclaw`; the intersection guard and all
+    of its tests are untouched and still run when you do. Off, the section's
+    status is `skipped` and every count is None, so the absence is never
+    rendered as a measured zero.
     """
     now = time.time() if now is None else now
     local_host = local_host or local_host_label()
     hosts = [h for h in hosts if h in HOST_NAMES]
     codenames = load_scratch_codenames() if codenames is None else codenames
+    # A fresh hex nonce per run: a pane cannot print a marker built from a
+    # string that did not exist when it was drawn. Injectable so the suite is
+    # deterministic.
+    capture_nonce = (uuid.uuid4().hex if capture_nonce is None
+                     else str(capture_nonce))
 
     # --- fuzzyclaw (LOCAL host only — the task files are local state) --------
     if use_fuzzyclaw:
@@ -1011,6 +1506,10 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
         # rather than on whether a key exists.
         "filters": {"claude_only": bool(claude_only),
                     "excluded_non_claude": None},
+        # 🔴 The clawgate approval queue. Filled in below; the skeleton carries
+        # a `status` from the first byte so no code path can publish a bare
+        # count. See `read_blocked_on_me` for the four outcomes.
+        "blocked_on_me": {"status": "skipped", "count": None},
         # 🔴 The two limits that change what these rows MEAN, carried in the
         # payload rather than left in the skill body. See CAVEATS.
         "caveats": CAVEATS,
@@ -1026,10 +1525,41 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
     local_live_windows = None
     local_windows_error = None
     raw_panes, slot_ids = {}, {}
+    captures, capture_status = {}, {}
     for host in hosts:
         panes_res = run_tmux(TMUX_PANES_ARGV, host, local_host, runner=runner)
         wins_res = run_tmux(TMUX_WINDOWS_ARGV, host, local_host, runner=runner)
         raw_panes[host] = panes_res["stdout"]
+
+        # --- 🔴 the capture batch: ONE tmux call per host, CLAUDE PANES ONLY --
+        # The signals are Claude Code TUI shapes, so scraping a bare zsh would
+        # only invent false positives out of whatever its scrollback happens to
+        # contain. Those rows are reported `not_claude`, never `False`.
+        #
+        # `captures[host] is None` means the batch did not run or did not
+        # answer; `{}` means it ran and this host had no Claude panes. The two
+        # are different facts and `fold_windows` renders them differently.
+        host_panes = parse_panes(panes_res["stdout"])
+        claude_ids = [p["pane_id"] for p in host_panes
+                      if pane_is_claude(p) and p.get("pane_id")]
+        if not use_capture:
+            captures[host], capture_status[host] = None, "skipped"
+        elif not panes_res["reachable"]:
+            # Nothing to capture and nothing measured — the host said nothing.
+            captures[host], capture_status[host] = None, "error"
+        elif not claude_ids:
+            # MEASURED and genuinely empty: we know every pane on this host and
+            # none of them is Claude. `{}`, not None.
+            captures[host], capture_status[host] = {}, "ok"
+        else:
+            cap_res = run_tmux(capture_argv(claude_ids, capture_nonce),
+                               host, local_host, runner=runner)
+            if cap_res["reachable"]:
+                captures[host] = parse_captures(cap_res["stdout"],
+                                                capture_nonce)
+                capture_status[host] = "ok"
+            else:
+                captures[host], capture_status[host] = None, "error"
         # 🔴 The two calls are INDEPENDENT measurements. `reachable`/`error`
         # describe list-panes; `windows_measured`/`windows_error` describe
         # list-windows. Reading one off the other is how a failed list-windows
@@ -1045,6 +1575,14 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
             "windows_measured": windows_measured,
             "windows_error": wins_res["error"],
             "live_window_ids": (sorted(live) if live is not None else None),
+            # A THIRD independent measurement, reported separately from the
+            # other two for the same reason they are separate from each other:
+            # `list-panes` succeeding says nothing about whether the capture
+            # batch answered.
+            "captures_measured": captures[host] is not None,
+            "captures_status": capture_status[host],
+            "captures_seen": (len(captures[host])
+                              if captures[host] is not None else None),
         }
         if host == local_host:
             local_live_windows = live
@@ -1077,7 +1615,9 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
             # and no age. Stated, not implied away.
             task_index=(task_index if host == local_host else {}),
             threshold=threshold, now=now,
-            slot_window_ids=slot_ids.get(host))
+            slot_window_ids=slot_ids.get(host),
+            captures=captures.get(host),
+            capture_status=capture_status.get(host, "skipped"))
 
     # --- 🔴 --claude-only: drop the shells, and COUNT what was dropped -------
     # The summary then describes the RENDERED set, which is the safe direction:
@@ -1094,6 +1634,14 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
             excluded += len(entry["windows"]) - len(kept)
             entry["windows"] = kept
         report["filters"]["excluded_non_claude"] = excluded
+
+    # --- 🔴 blocked-on-me: the clawgate approval queue ------------------------
+    # A local file read, so it costs nothing and runs unconditionally. The
+    # reader is resolved AT CALL TIME (same reason as `ch_client_factory`
+    # above): binding `_read_text` as a default would make the seam unpatchable
+    # on the one path — `main()` -> `gather()` — with no injection point.
+    report["blocked_on_me"] = read_blocked_on_me(
+        path=blocked_path, reader=blocked_reader, now=now)
 
     # --- ClickHouse ----------------------------------------------------------
     if use_ch:
@@ -1139,6 +1687,56 @@ def _trunc(s, n):
     return s if len(s) <= n else s[: n - 1] + "…"
 
 
+def _fmt_waiting(row) -> str:
+    """The WAIT cell. `?` is NOT `no` — an unscraped pane must not read as a
+    measured "nothing needed here"."""
+    p = row.get("waiting_probable")
+    if p is None:
+        return "?%s" % (row.get("waiting_status") or "unmeasured")
+    if not p:
+        return "no"
+    return "YES " + ",".join(s.get("signal", "?")
+                             for s in (row.get("waiting_signals") or ()))
+
+
+def render_blocked_on_me(blocked) -> list:
+    """🔴 The clawgate queue, with the count and its discriminant on one line.
+
+    Printed unconditionally and in every state, because the failure this closes
+    is a reader who never learned the queue exists. An `absent` cache prints
+    LOUDER than a real zero, not quieter: a missing file rendering as "nothing
+    is blocked on you" is the exact substitution this script refuses everywhere
+    else.
+    """
+    b = blocked or {}
+    st = b.get("status")
+    count, out = b.get("count"), []
+    if st == "ok":
+        if count:
+            out.append(f"▸ BLOCKED ON ME: {count} clawgate task(s) pending "
+                       f"approval/review")
+            out.append("  ⚠ this is a COUNT. " + BLOCKED_DETAIL_NOTE)
+            if b.get("detail"):
+                out.append(f"  cached detail (TRUNCATED): "
+                           f"{_trunc(b.get('detail'), 100)}")
+        else:
+            out.append("▸ BLOCKED ON ME: 0 clawgate tasks pending "
+                       f"(cache {int(b.get('cache_age_secs') or 0)}s old — "
+                       "a measured zero)")
+    elif st == "stale":
+        out.append(f"▸ BLOCKED ON ME: UNMEASURED (stale cache) — last known "
+                   f"count {count}")
+        out.append(f"  {_trunc(b.get('error'), 110)}")
+        out.append("  (this is NOT a current count; check agent-ops or the "
+                   "clawgate API)")
+    else:
+        out.append(f"▸ BLOCKED ON ME: UNMEASURED [{st}]")
+        out.append(f"  {_trunc(b.get('error') or 'unknown reason', 110)}")
+        out.append("  (this is NOT zero pending approvals — the queue was "
+                   "never read. `agent-ops` shows it live)")
+    return out
+
+
 def render_table(report) -> str:
     """Human-readable frame. MUST survive zero sessions and an unreachable host
     (pinned by a test) and MUST show a failed ClickHouse query as a failure
@@ -1181,19 +1779,44 @@ def render_table(report) -> str:
         # agent and `● idle` on a bare zsh prompt were the same six characters
         # before this.
         out.append("  HOST       SESSION       WIN  CODENAME   TASK"
-                   "                          KIND    STATUS    AGE")
-        out.append("  " + "─" * 104)
+                   "                          KIND    STATUS    AGE   WAIT")
+        out.append("  " + "─" * 112)
         for r in rows:
             out.append(
                 "  {:<9}  {:<12}  {:<3}  {:<9}  {:<30}  {:<6}  {:<8}  "
-                "{:<4}".format(
+                "{:<4}  {}".format(
                     _trunc(r.get("host"), 9), _trunc(r.get("session"), 12),
                     _trunc(r.get("window_index"), 3),
                     _trunc(r.get("codename") or "—", 9),
                     _trunc(r.get("task") or "—", 30),
                     "claude" if r.get("claude") else "shell",
                     _STATUS_GLYPH.get(r.get("status"), "?"),
-                    _fmt_age(r.get("age_secs"))))
+                    _fmt_age(r.get("age_secs")),
+                    _fmt_waiting(r)))
+        # 🔴 The matched line, printed under the table for every flagged row.
+        # A boolean column tells an operator a window needs them; only the
+        # EVIDENCE tells them whether to believe it, and which of the four very
+        # different actions (answer / press a key / `/clear` / give it work) is
+        # the right one. Suppressing it would leave the plain-text reader with
+        # strictly less than the `--json` reader for no saving.
+        flagged = [r for r in rows if r.get("waiting_probable")]
+        if flagged:
+            out.append("")
+            out.append("  ⚠ WAITING — the matched line, so you can disagree "
+                       "with it:")
+            for r in flagged:
+                for sig in (r.get("waiting_signals") or ()):
+                    out.append("    {}:{}:{}  [{}]  {}".format(
+                        r.get("host"), r.get("session"),
+                        r.get("window_index"), sig.get("signal"),
+                        _trunc(sig.get("line"), 90)))
+    out.append("")
+
+    # 🔴 BLOCKED ON ME — printed ALWAYS, including when it was not measured.
+    # This section exists because a dogfood agent, correctly reading that
+    # `agent-ops` has no JSON API, never opened it and so missed 11 pending
+    # approvals — four of them credential-exposure or cross-user-data-leak.
+    out.extend(render_blocked_on_me(report.get("blocked_on_me")))
     out.append("")
 
     ch = report.get("clickhouse") or {}
@@ -1220,7 +1843,11 @@ def render_table(report) -> str:
     fz = report.get("fuzzyclaw") or {}
     fz_st = fz.get("status")
     if fz_st == "skipped":
-        out.append("▸ FUZZYCLAW TASKS (skipped: --no-fuzzyclaw)")
+        # The default is now OFF, so the message names the flag that turns it
+        # ON. Saying "--no-fuzzyclaw" here told a reader a flag they never
+        # passed was responsible.
+        out.append("▸ FUZZYCLAW TASKS (skipped — opt in with --fuzzyclaw; "
+                   "every count is null, not 0)")
     elif fz_st == "unmeasured":
         # 🔴 The third zero. `files_live` is None, not 0, and must read as
         # "not measured" rather than as "measured and empty".
@@ -1269,6 +1896,26 @@ def render_table(report) -> str:
         "{}={}+{}".format(b, (st.get(b) or {}).get("claude", 0),
                           (st.get(b) or {}).get("shell", 0))
         for b in STATUS_BUCKETS))
+    # 🔴 The headline number, and it is allowed to be "unmeasured". `probable`
+    # is None whenever no pane was scraped, and printing `waiting=0` there would
+    # answer the question this tool exists for with a measurement nobody took.
+    w = summ.get("waiting") or {}
+    if w.get("probable") is None:
+        out.append("  waiting: UNMEASURED — 0 of {} window(s) scraped ({})"
+                   .format(w.get("measured", 0) + w.get("unmeasured", 0),
+                           ", ".join("{}={}".format(k, v) for k, v in
+                                     sorted((w.get("unmeasured_reasons")
+                                             or {}).items())) or "no reason"))
+    else:
+        out.append("  waiting: {} probable of {} scraped ({} unscraped: {})"
+                   .format(w["probable"], w.get("measured", 0),
+                           w.get("unmeasured", 0),
+                           ", ".join("{}={}".format(k, v) for k, v in
+                                     sorted((w.get("unmeasured_reasons")
+                                             or {}).items())) or "none"))
+        out.append("  by signal: " + "  ".join(
+            "{}={}".format(s, (w.get("per_signal") or {}).get(s, 0))
+            for s in WAITING_SIGNALS))
     if summ.get("claude_only"):
         # The filter is stated where the counts are, because it changed them.
         out.append("  FILTER --claude-only: {} non-claude window(s) excluded "
@@ -1302,7 +1949,18 @@ def render_caveats(report) -> list:
     cav = (report or {}).get("caveats") or CAVEATS
     det = cav.get("claude_detection") or {}
     fz = cav.get("fuzzyclaw_scope") or {}
+    wt = cav.get("waiting_signal") or {}
     return [
+        # 🔴 The signal set is ENUMERATED in the footer, because `WAIT: no` is
+        # the cell a reader will over-trust. Naming the three things that were
+        # looked for is what turns it from "nothing needed here" into "none of
+        # these three matched", which is all it ever meant.
+        "  caveat[waiting_signal]: `waiting_probable` is a screen-scrape for "
+        "{} ONLY, on claude rows only — `false` means none matched, NOT that "
+        "the window needs nothing; text typed at the `❯` prompt is "
+        "deliberately EXCLUDED, so a window one Enter away reads `no` "
+        "(reference/waiting-signal.md)".format(
+            "/".join(wt.get("signals") or WAITING_SIGNALS)),
         "  caveat[claude_detection]: KIND is `pane_current_command =~ /{}/` — "
         "shallower than agent-ops' /proc walk; a claude under a wrapper shell "
         "reads as `shell`".format(det.get("pattern", "claude")),
@@ -1355,9 +2013,23 @@ def validate_target(target: str) -> str:
     return t
 
 
-def tail_argv(target, lines=DEFAULT_TAIL_LINES):
-    return ["tmux", "capture-pane", "-t", validate_target(target),
-            "-p", "-e", "-S", f"-{int(lines)}"]
+def tail_argv(target, lines=DEFAULT_TAIL_LINES, plain=False):
+    """🔴 `-e` (keep ANSI) is what `--plain` drops, at the SOURCE.
+
+    Every consumer of `tail` was piping the output through the same
+    `sed 's/\\x1b\\[[0-9;]*m//g'` — a strip that is easy to get subtly wrong
+    (OSC and CSI sequences that are not SGR survive that pattern) and that
+    every caller re-invented. `tmux capture-pane` without `-e` never emits the
+    escapes in the first place, so there is nothing to strip. Same defect class
+    fixed in `agent-ops` in #413; the fix did not generalise to this sibling
+    because the two do not share a capture path.
+
+    The default stays `-e` so an existing caller's bytes do not change under it.
+    """
+    argv = ["tmux", "capture-pane", "-t", validate_target(target), "-p"]
+    if not plain:
+        argv.append("-e")
+    return argv + ["-S", f"-{int(lines)}"]
 
 
 # 🔴 `tmux` says this when the HOST answered fine and the TARGET does not exist.
@@ -1371,7 +2043,7 @@ _NO_SUCH_TARGET_RE = re.compile(
 
 
 def tail_window(target, host, local_host, runner=None,
-                lines=DEFAULT_TAIL_LINES) -> dict:
+                lines=DEFAULT_TAIL_LINES, plain=False) -> dict:
     """Capture one window's scrollback.
 
     FOUR outcomes, never two: `reachable=False` (the host said nothing),
@@ -1389,7 +2061,8 @@ def tail_window(target, host, local_host, runner=None,
     exists and its scrollback is empty", the one thing that code is documented
     to mean. Two different facts, one exit code, and the doc matched neither.
     """
-    res = run_tmux(tail_argv(target, lines), host, local_host, runner=runner)
+    res = run_tmux(tail_argv(target, lines, plain=plain), host, local_host,
+                   runner=runner)
     if res.get("no_server"):
         # The host answered. There is no tmux server, so there is no such
         # window — but the reason is not a bad target, and saying so keeps the
@@ -1430,7 +2103,25 @@ def build_parser():
                    default=DEFAULT_STALE_THRESHOLD)
     p.add_argument("--no-ch", action="store_true",
                    help="skip ClickHouse entirely (the client is never built)")
-    p.add_argument("--no-fuzzyclaw", action="store_true")
+    # 🔴 fuzzyclaw is OPT-IN. See `gather`'s docstring for the measurement.
+    # `--no-fuzzyclaw` is KEPT and still means off — it is now the default, so
+    # every existing invocation keeps its exact behaviour. Passing both is not
+    # an error: the explicit "off" wins and `main` says so on stderr, because a
+    # silently-ignored flag is how a caller concludes it was honoured.
+    p.add_argument("--fuzzyclaw", action="store_true",
+                   help="opt IN to the fuzzyclaw task join (default off: "
+                        "measured 29 live of 401 files, all 29 reading "
+                        "`paused`, on a source CLAUDE.md marks UNTRUSTED)")
+    p.add_argument("--no-fuzzyclaw", action="store_true",
+                   help="explicitly off — now the DEFAULT; kept so existing "
+                        "callers keep working. Wins over --fuzzyclaw.")
+    p.add_argument("--no-capture", action="store_true",
+                   help="skip the per-host pane capture. Every row's "
+                        "waiting_probable is then null (never false) and "
+                        "summary.waiting.probable is null, never 0.")
+    p.add_argument("--plain", action="store_true",
+                   help="tail: strip ANSI at the source (drops tmux's -e) "
+                        "instead of making every caller sed it out")
     p.add_argument("--claude-only", action="store_true",
                    help="scan/list/detail: drop non-Claude windows. Every "
                         "summary count then describes the FILTERED set, and "
@@ -1446,6 +2137,13 @@ def main(argv=None):
         sys.argv[1:] if argv is None else list(argv))
     hosts = HOST_NAMES if args.host == "all" else (args.host,)
     local = local_host_label()
+    # Explicit-off WINS, and the collision is reported rather than resolved in
+    # silence — the caller asked for two incompatible things and gets told
+    # which one ran.
+    if args.fuzzyclaw and args.no_fuzzyclaw:
+        print("(--no-fuzzyclaw and --fuzzyclaw both given: OFF wins)",
+              file=sys.stderr)
+    use_fuzzyclaw = bool(args.fuzzyclaw) and not args.no_fuzzyclaw
 
     if args.subcommand == "tail":
         # `tail` targets ONE window by name, so there is nothing to filter. A
@@ -1467,8 +2165,12 @@ def main(argv=None):
         # names the host actually searched plus how to search the other one.
         host_defaulted = args.host not in HOST_NAMES
         host = local if host_defaulted else args.host
-        res = tail_window(args.target, host, local, lines=args.lines)
+        res = tail_window(args.target, host, local, lines=args.lines,
+                          plain=args.plain)
         res["host_defaulted"] = host_defaulted
+        # The consumer has to know whether `text` carries escapes; a JSON
+        # reader cannot tell an ANSI-free pane from a stripped one.
+        res["plain"] = bool(args.plain)
 
         def _tail_json():
             """🔴 `--json` must print on the FAILURE paths too.
@@ -1525,9 +2227,12 @@ def main(argv=None):
                       file=sys.stderr)
         return EXIT_OK if res["text"].strip() else EXIT_EMPTY
 
+    if args.plain:
+        print("(--plain applies to `tail` only)", file=sys.stderr)
     report = gather(hosts=hosts, local_host=local,
                     use_ch=(not args.no_ch and args.subcommand != "list"),
-                    use_fuzzyclaw=not args.no_fuzzyclaw,
+                    use_fuzzyclaw=use_fuzzyclaw,
+                    use_capture=not args.no_capture,
                     threshold=args.stale_threshold,
                     claude_only=args.claude_only)
 

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -63,8 +63,39 @@ def _no_real_socket(monkeypatch):
     monkeypatch.setattr(sm, "make_ch_client", _boom)
 
 
+@pytest.fixture(autouse=True)
+def _no_real_blocked_cache(monkeypatch):
+    """🔴 THE THIRD GUARD, added because it caught a live breach.
+
+    `gather()` reads the clawgate bar-status cache, and with no guard the
+    golden-schema test silently picked up the OPERATOR'S REAL pending count
+    (12) off `~/.cache/bar-status/clawgate.json` mid-run. That is two defects
+    at once: a suite that reaches the machine it runs on, and an assertion
+    whose expected value changes whenever the operator approves something.
+
+    It is a SEPARATE seam from `_read_text` on purpose — three tests below
+    legitimately read real tmp files through `_read_text`, so forbidding that
+    function wholesale would have forced them to be weakened instead.
+    """
+    def _boom(path):
+        raise _Forbidden(f"test tried to read the real blocked cache: {path!r}")
+    monkeypatch.setattr(sm, "_read_blocked_text", _boom)
+
+
+@pytest.fixture
+def absent_blocked_cache(monkeypatch):
+    """Opt-in fake for the `main()` -> `gather()` path, which has NO injection
+    point for the clawgate cache.
+
+    Requested by name rather than made autouse, so the raiser above stays the
+    default: a new end-to-end test that forgets this fails loudly instead of
+    quietly reading `~/.cache` on whatever machine the suite runs on.
+    """
+    monkeypatch.setattr(sm, "_read_blocked_text", lambda path: None)
+
+
 def test_hermeticity_fixture_is_actually_installed():
-    """POSITIVE CONTROL on the two autouse guards above.
+    """POSITIVE CONTROL on the three autouse guards above.
 
     Without this, a fixture that stopped applying would disarm every safety
     claim in this file's docstring while the suite stayed green.
@@ -73,6 +104,26 @@ def test_hermeticity_fixture_is_actually_installed():
         sm._default_runner(["tmux", "kill-server"], 1)
     with pytest.raises(_Forbidden):
         sm.make_ch_client()
+    with pytest.raises(_Forbidden):
+        sm._read_blocked_text(sm.BLOCKED_CACHE)
+
+
+def test_the_blocked_cache_seam_is_separate_from_the_general_file_reader():
+    """🔴 The guard above is only real if the two seams are actually distinct.
+
+    If `read_blocked_on_me` were changed to call `_read_text` directly, the
+    autouse raiser would stop covering it and every later test would be free to
+    read the live machine again — with the suite still green, because the
+    positive control above only proves the raiser is INSTALLED, not that the
+    code path goes through it. So prove the path: with the seam patched and no
+    reader injected, the read must raise.
+    """
+    with pytest.raises(_Forbidden):
+        sm.read_blocked_on_me()
+    # ...and an INJECTED reader must bypass the seam entirely, or every test
+    # below is testing the raiser rather than the parser.
+    got = sm.read_blocked_on_me(path="/nope", reader=lambda p: None)
+    assert got["status"] == "absent"
 
 
 def test_the_default_ch_factory_is_resolved_at_CALL_time_not_bound_as_a_default():
@@ -276,6 +327,9 @@ def base_gather(**kw):
         now=NOW,
         fuzzyclaw_texts=[json.dumps(TASK_LIVE), json.dumps(TASK_STALE)],
         codenames={"scratch7": "Grove", "scratch2": "Vapor"},
+        # The clawgate cache: absent by default, so no test inherits a value
+        # that depends on the operator's real queue. Override per test.
+        blocked_reader=lambda p: None,
     )
     defaults.update(kw)
     return _REAL_GATHER(**defaults)
@@ -1382,7 +1436,14 @@ def test_the_measured_and_unmeasured_fuzzyclaw_zeroes_are_DIFFERENT_OUTPUT():
 
     a, b = sm.render_table(unmeasured), sm.render_table(measured_zero)
     assert a != b
-    assert "UNMEASURED" in a and "UNMEASURED" not in b
+    # 🔴 Anchored on the FUZZYCLAW banner, not the bare word. "UNMEASURED" is
+    # now also how the `waiting` roll-up spells its own unmeasured case, so a
+    # substring test on the word alone stopped discriminating the two sections
+    # it was written to discriminate — it would have passed on a report whose
+    # fuzzyclaw zero was silently fabricated, as long as `waiting` said
+    # UNMEASURED somewhere else on the page.
+    assert "LIVE COUNT UNMEASURED" in a
+    assert "LIVE COUNT UNMEASURED" not in b
 
 
 def test_scanning_ONLY_the_remote_host_never_fabricates_a_fuzzyclaw_zero():
@@ -1440,12 +1501,13 @@ def test_json_golden_schema_and_values():
     assert blob["stale_threshold_secs"] == 3600
     assert set(blob) == {"ts", "local_host", "stale_threshold_secs", "hosts",
                          "clickhouse", "fuzzyclaw", "filters", "caveats",
-                         "summary"}
+                         "summary", "blocked_on_me"}
     assert set(blob["hosts"]) == {"workbench", "laptop"}
 
     wb = blob["hosts"]["workbench"]
     assert set(wb) == {"reachable", "error", "ssh_target", "windows",
-                       "live_window_ids", "windows_measured", "windows_error"}
+                       "live_window_ids", "windows_measured", "windows_error",
+                       "captures_measured", "captures_status", "captures_seen"}
     assert wb["ssh_target"] is None
     assert wb["live_window_ids"] == ["@41", "@52", "@63"]
     assert wb["windows_measured"] is True
@@ -1467,6 +1529,13 @@ def test_json_golden_schema_and_values():
         "busy": True,
         "age_secs": 1800.0,
         "status": "busy",
+        # 🔴 The capture batch RAN (make_runner answers it) but its output
+        # carries no markers, so this pane is `uncaptured` — measured absence
+        # of THIS pane's text, not a measured "nothing is waiting". Both the
+        # boolean and the signal list are None, never False/[].
+        "waiting_probable": None,
+        "waiting_signals": None,
+        "waiting_status": "uncaptured",
         "claude_session_id": "11111111-2222-4333-8444-555555555555",
         "fuzzyclaw": {
             "task": "task-alpha-text",
@@ -1519,6 +1588,20 @@ def test_json_golden_schema_and_values():
         "fuzzyclaw_live": 1,
         "fuzzyclaw_status": "ok",
         "windows_unmeasured": [],
+        # 🔴 LITERAL, and it is the unmeasured shape: the capture batch ran but
+        # returned no markers, so 0 of 3 rows were scraped. `probable` is None
+        # and `per_signal` is None — a `0` on either would be this report
+        # answering "is anything waiting on me" with a look nobody took.
+        # `unmeasured_reasons` says WHICH rows and why, so the None is
+        # actionable rather than merely honest.
+        "waiting": {
+            "probable": None, "measured": 0, "unmeasured": 3,
+            "per_signal": None,
+            "unmeasured_reasons": {"uncaptured": 2, "not_claude": 1},
+        },
+        # The clawgate queue was never read (no reader injected in this
+        # fixture's environment), so the count is None with its discriminant.
+        "blocked_on_me": {"count": None, "status": "absent"},
     }
 
 
@@ -1638,7 +1721,12 @@ def test_no_fuzzyclaw_flag_skips_the_source_and_says_so():
     assert report["summary"]["fuzzyclaw_status"] == "skipped"
     row = report["hosts"]["workbench"]["windows"][0]
     assert row["fuzzyclaw"] is None and row["claude_session_id"] is None
-    assert "skipped: --no-fuzzyclaw" in sm.render_table(report)
+    # The banner names the flag that turns the source ON, because OFF is now
+    # the default: telling a reader "--no-fuzzyclaw" blamed a flag they never
+    # passed for an absence they did not ask for.
+    rendered = sm.render_table(report)
+    assert "opt in with --fuzzyclaw" in rendered
+    assert "--no-fuzzyclaw" not in rendered
 
 
 def test_the_skipped_and_measured_fuzzyclaw_zeroes_are_DIFFERENT_FACTS():
@@ -2821,7 +2909,7 @@ def test_detail_history_no_ch_still_wins_over_the_reason_selection():
 
 
 def test_a_detail_json_never_claims_a_measured_absence_it_did_not_measure(
-        monkeypatch, capsys):
+        monkeypatch, capsys, absent_blocked_cache):
     """🔴 END-TO-END, the exact contradiction the auditor read in ONE payload:
     `LIVE COUNT UNMEASURED` in the report and a measured absence beside it."""
     monkeypatch.setattr(sm, "local_host_label", lambda *a, **k: "workbench")
@@ -2831,8 +2919,11 @@ def test_a_detail_json_never_claims_a_measured_absence_it_did_not_measure(
     monkeypatch.setattr(sm, "read_fuzzyclaw_texts",
                         lambda *a, **k: [json.dumps(TASK_LIVE)])
     monkeypatch.setattr(sm, "load_scratch_codenames", lambda *a, **k: {})
+    # 🔴 `--fuzzyclaw` is now REQUIRED to reach this code path at all: the join
+    # is opt-in, so without it the status would be `skipped` and this test
+    # would pass vacuously against a source that was never read.
     sm.main(["detail", "scratch7:3", "--host", "workbench", "--json",
-             "--no-ch"])
+             "--no-ch", "--fuzzyclaw"])
     blob = json.loads(capsys.readouterr().out)
     assert blob["fuzzyclaw"]["status"] == "unmeasured"
     assert blob["fuzzyclaw"]["files_live"] is None
@@ -3457,7 +3548,7 @@ def test_cli_claude_only_flag_reaches_gather_and_defaults_off(monkeypatch):
 
 
 def test_main_json_end_to_end_carries_the_split_and_the_filter(
-        monkeypatch, capsys):
+        monkeypatch, capsys, absent_blocked_cache):
     """END-TO-END through main(), because every test above injects gather()."""
     monkeypatch.setattr(sm, "local_host_label", lambda *a, **k: "workbench")
     monkeypatch.setattr(sm, "_default_runner",
@@ -3510,7 +3601,8 @@ def test_the_caveats_are_in_the_json_as_structured_fields_not_prose():
     """🔴 KILLS: dropping `caveats` from the report, or reducing it to a
     string a consumer would have to parse."""
     cav = mix_gather()["caveats"]
-    assert set(cav) == {"claude_detection", "fuzzyclaw_scope"}
+    assert set(cav) == {"claude_detection", "fuzzyclaw_scope",
+                        "waiting_signal"}
     det = cav["claude_detection"]
     assert det["method"] == "pane_current_command_regex"
     assert det["pattern"] == sm.CLAUDE_RE.pattern == "claude"
@@ -3547,8 +3639,8 @@ def test_the_remote_null_field_LEDGER_is_true_of_a_real_remote_row():
     assert remote["status"] != "stale"
 
 
-def test_the_caveats_are_printed_in_the_table_UNCONDITIONALLY(monkeypatch,
-                                                              capsys):
+def test_the_caveats_are_printed_in_the_table_UNCONDITIONALLY(
+        monkeypatch, capsys, absent_blocked_cache):
     """🔴 KILLS: printing them only when a remote host is scanned, and dropping
     the footer. An agent that runs this cold gets no skill body."""
     for report in (mix_gather(),                    # local-only scan
@@ -3575,9 +3667,1064 @@ def test_the_caveats_are_printed_in_the_table_UNCONDITIONALLY(monkeypatch,
 
 def test_the_caveat_footer_is_two_lines_and_does_not_touch_the_row_table():
     """Compactness is part of the requirement — a caveat that bloats the table
-    gets deleted by the next person."""
-    assert len(sm.render_caveats(mix_gather())) == 2
+    gets deleted by the next person.
+
+    🔴 ONE LINE PER CAVEAT, derived from CAVEATS rather than pinned to a
+    literal count: a hardcoded `== 2` is a number the next caveat has to edit,
+    and editing it is indistinguishable from silencing a caveat that stopped
+    rendering. The relationship — every structured caveat gets exactly one
+    footer line — is what actually needs pinning, and it fails when the set
+    GROWS *or* SHRINKS.
+    """
+    assert len(sm.render_caveats(mix_gather())) == len(sm.CAVEATS)
+    for key in sm.CAVEATS:
+        assert any(f"caveat[{key}]:" in ln
+                   for ln in sm.render_caveats(mix_gather())), key
     with_cav = sm.render_table(mix_gather()).splitlines()
     row_lines = [ln for ln in with_cav if "hollow" in ln or "ridge" in ln]
     assert len(row_lines) == 2, "one line per window, still"
     assert not any("caveat[" in ln for ln in row_lines)
+
+
+# =========================================================================== #
+# §A — THE `waiting` SIGNAL
+#
+# 🔴 THE FIXTURES BELOW ARE REALISTIC, NOT TOY, AND THAT IS LOAD-BEARING.
+# They reproduce the structure captured off 40 live panes on 2026-08-12: a `❯`
+# echo of the SUBMITTED user prompt in the scrollback, `●`-led assistant turns,
+# a `✻ Baked for …` / `※ recap:` status line, the input box drawn between two
+# box-drawing rules, and a `ctx: NN%` + `⏸ manual mode on` footer. A detector
+# can pass on a textbook three-line fixture and miss every one of those,
+# because the whole difficulty is telling the agent's last SENTENCE from the
+# five kinds of chrome that surround it.
+#
+# 🔴 EVERY STRING IS SYNTHETIC. This repo is PUBLIC and the real panes hold
+# client work; the SHAPES are copied, the words are invented, and the values
+# are pairwise distinct so a test cannot pass by matching the wrong row.
+# =========================================================================== #
+_RULE = "─" * 60
+CAP_NONCE = "deadbeefcafe1234"
+
+
+def _pane(*body):
+    return "\n".join(body)
+
+
+# Genuinely idle: finished cleanly, awaiting instruction. THE NEGATIVE CONTROL.
+# Two traps are built in on purpose:
+#   * the user's own submitted prompt, echoed in the scrollback, ENDS IN `?`
+#   * the footer contains a `?` (`new task? /clear …`) — a real live footer
+# Neither is the agent asking anything, and neither may flag.
+PANE_IDLE = _pane(
+    "❯ can you double-check the fixture ordering?",
+    "",
+    "● Checked. The ordering is stable and the two helpers agree.",
+    "",
+    "  I pushed the change and the branch is green.",
+    "",
+    "✻ Baked for 4m 02s",
+    "",
+    "※ recap: Goal was stabilising fixture order. Done and pushed. "
+    "(disable recaps in /config)",
+    "",
+    _RULE,
+    "❯ ",
+    _RULE,
+    "  ctx: 34%                          new task? /clear to save 120.0k tokens",
+    "  ⏸ manual mode on · ← 2 agents",
+)
+
+# Asked a direct question. Same chrome, one different sentence.
+PANE_QUESTION = _pane(
+    "❯ deploy it",
+    "",
+    "● Deployed. The rollout finished and both replicas are ready.",
+    "",
+    "  Want me to run the post-deploy check before I close this out?",
+    "",
+    "✻ Baked for 1m 18s",
+    "",
+    _RULE,
+    "❯ ",
+    _RULE,
+    "  ctx: 52%",
+    "  ⏸ manual mode on",
+)
+
+# Hard-blocked on a modal. The modal REPLACES the input box, so there is only
+# ONE rule line and the options sit below it — which is why the chrome cut
+# cannot assume a pair.
+PANE_MENU = _pane(
+    "● I can take either route here.",
+    "",
+    "✻ Baked for 9m 41s",
+    "",
+    _RULE,
+    "  This session is 12h 06m old and 88.4k tokens.",
+    "",
+    "  Resuming the full session will consume a large share of your limits.",
+    "",
+    "  ❯ 1. Resume from summary (recommended)",
+    "    2. Resume the full session as-is",
+    "    3. Do not ask me again",
+    "",
+    "  Enter to confirm · Esc to cancel",
+)
+
+# Out of context. NOTHING else about the pane says so — only the footer does,
+# and the agent's last sentence is a perfectly ordinary statement.
+PANE_CTX_ZERO = _pane(
+    "❯ keep going",
+    "",
+    "● Continuing with the migration notes.",
+    "",
+    "  The remaining items are listed in the tracking file.",
+    "",
+    "✻ Baked for 22m 07s",
+    "",
+    _RULE,
+    "❯ ",
+    _RULE,
+    "  ctx: 0%                           new task? /clear to save 610.0k tokens",
+    "  ⏸ manual mode on · ← 3 agents",
+)
+
+# 🔴 THE EXCLUDED CASE — text sitting at the `❯` prompt inside the input box.
+# See CAVEATS["waiting_signal"]["excluded"] and reference/waiting-signal.md.
+# This fixture is mid-turn (live spinner), which is precisely the state where a
+# detector keying on box text would invent a `waiting` row for a window that is
+# working fine.
+PANE_TYPED_AT_PROMPT = _pane(
+    "❯ start the refactor",
+    "",
+    "● Working through the call sites now.",
+    "",
+    "  Three of nine done.",
+    "",
+    "* Calculating… (31s · ↓ 2.1k tokens · esc to interrupt)",
+    "",
+    _RULE,
+    "❯ then open the PR",
+    _RULE,
+    "  ctx: 61%",
+    "  ⏸ manual mode on",
+)
+
+# A bare shell. Its last line ends in `?`, which is exactly why a Claude-shaped
+# detector must never be pointed at one.
+PANE_SHELL = _pane(
+    "$ git status -s",
+    "$ gh pr list",
+    "no open pull requests. run `gh pr create`?",
+)
+
+
+def cap_runner(captures_by_pane, **kw):
+    """A `make_runner` whose capture batch answers with REAL marker framing.
+
+    🔴 This is the instrument for every end-to-end §A test, so it is validated
+    by `test_cap_runner_frames_captures_the_way_the_parser_expects` before any
+    verdict is read off it. A framer that did not frame its output the way
+    `parse_captures` expects would make every pane read `uncaptured`, and a
+    suite asserting "nothing is waiting" against it would be green, unanimous
+    and about nothing.
+    """
+    nonce = kw.pop("nonce", CAP_NONCE)
+    body = "".join(
+        "%s%s%s%s\n%s\n" % (sm.CAPTURE_MARK_PREFIX, nonce, pid,
+                            sm.CAPTURE_MARK_PREFIX, text)
+        for pid, text in captures_by_pane.items())
+    kw.setdefault("local_capture", body)
+    return make_runner(**kw)
+
+
+def test_cap_runner_frames_captures_the_way_the_parser_expects():
+    """POSITIVE CONTROL on the §A instrument, read before any of its verdicts.
+
+    Prove the fake capture output ROUND-TRIPS through the real parser, and that
+    the parser can also come back EMPTY — an instrument that always parsed, or
+    never did, certifies nothing in either direction.
+    """
+    r = cap_runner({"%11": PANE_QUESTION, "%13": PANE_IDLE})
+    raw = r(sm.capture_argv(["%11", "%13"], CAP_NONCE), 5)[1]
+    got = sm.parse_captures(raw, CAP_NONCE)
+    assert set(got) == {"%11", "%13"}
+    assert got["%11"] == PANE_QUESTION
+    assert got["%13"] == PANE_IDLE
+    # ...and the negative control on the parser: a DIFFERENT nonce must find
+    # nothing, or the nonce is decoration and a pane could forge a marker.
+    assert sm.parse_captures(raw, "0000ffff0000ffff") == {}
+
+
+# --------------------------------------------------------------------------- #
+# §A.1 — the capture protocol (ONE tmux call per host, marker-delimited)
+# --------------------------------------------------------------------------- #
+def test_the_marker_never_interpolates_a_pane_id_into_a_tmux_format():
+    """🔴 THE BUG THIS PINS IS SILENT AND WAS MEASURED ON LIVE TMUX.
+
+    A tmux format string is strftime-expanded, so a literal `%68` in it is NOT
+    the pane id — it is `%B` (full month name) padded to width 68. Verified
+    2026-08-12: `tmux display-message -p 'A%68B'` prints `A`, 62 spaces, then
+    `August`. The marker therefore carries the id via `#{pane_id}` and `-t`,
+    never by our own interpolation, and this fails the moment someone
+    "simplifies" it back.
+    """
+    mark = sm.capture_mark("abc123")
+    assert "#{pane_id}" in mark
+    assert "%" not in mark, "a literal % in a tmux format is strftime, not an id"
+    argv = sm.capture_argv(["%68"], "abc123")
+    fmt = argv[argv.index("-t") + 2]
+    assert fmt == mark and "%68" not in fmt
+    # the id travels as a `-t` TARGET, which is not format-expanded
+    assert "%68" in argv
+
+
+def test_capture_argv_is_empty_for_no_panes_rather_than_a_bare_tmux():
+    """🔴 A bare `["tmux"]` is not a no-op — it runs tmux's default command.
+
+    This script is read-only BY CONSTRUCTION, and "the pane list came back
+    empty" is exactly the path where an argv degenerates unnoticed.
+    """
+    assert sm.capture_argv([], "n1") == []
+    assert sm.capture_argv(None, "n1") == []
+    assert sm.capture_argv(["", None], "n1") == []
+
+
+def test_the_capture_argv_contains_only_READ_ONLY_tmux_subcommands():
+    """🔴 THE SAFETY INVARIANT, as an ALLOWLIST rather than a denylist.
+
+    A denylist ("no send-keys") passes for every mutating subcommand nobody
+    thought to name. This enumerates what MAY appear, so a new verb fails
+    closed. `session-manager` gets pointed at a live machine holding 40+
+    windows of the operator's real work; that is only safe while this holds.
+    """
+    argv = sm.capture_argv(["%1", "%2", "%3"], "n2")
+    verbs = {argv[0]}
+    for i, tok in enumerate(argv):
+        if tok == ";":
+            verbs.add(argv[i + 1])
+    assert verbs == {"tmux", "display-message", "capture-pane"}
+    assert argv[1] == "display-message"
+
+
+def test_one_tmux_invocation_covers_every_pane():
+    """The whole reason for the marker protocol: 40 panes over SSH must not be
+    40 round trips."""
+    argv = sm.capture_argv(["%1", "%2", "%3", "%4"], "n3")
+    assert argv.count("capture-pane") == 4
+    assert argv[0] == "tmux" and argv.count("tmux") == 1
+
+
+def test_the_capture_argv_survives_the_ssh_quoting_it_must_pass_through():
+    """The remote side runs a SHELL. The format contains `#`, `{` and `}`, and
+    the command separator is a bare `;` — all of which a shell would eat
+    unquoted. Same hazard and same test shape as the window-format contract."""
+    import shlex
+    argv = sm.capture_argv(["%9"], "n4")
+    assert shlex.split(shlex.join(argv)) == argv
+    wrapped = sm.ssh_wrap(argv)
+    assert wrapped[0] == "ssh" and wrapped[-2] == sm.LAPTOP_SSH_TARGET
+    assert shlex.split(wrapped[-1]) == argv
+
+
+def test_parse_captures_discards_text_before_the_first_marker():
+    """Output belonging to no pane is DROPPED, never attributed to one — tmux
+    can emit a warning ahead of the first command's output."""
+    raw = ("some preamble tmux wrote first\n"
+           f"{sm.CAPTURE_MARK_PREFIX}n5%7{sm.CAPTURE_MARK_PREFIX}\n"
+           "real pane text\n")
+    assert sm.parse_captures(raw, "n5") == {"%7": "real pane text"}
+
+
+def test_parse_captures_is_empty_on_empty_or_unmarked_input():
+    assert sm.parse_captures("", "n6") == {}
+    assert sm.parse_captures(None, "n6") == {}
+    assert sm.parse_captures("no markers at all\njust text\n", "n6") == {}
+
+
+# --------------------------------------------------------------------------- #
+# §A.2 — detect_waiting: three signals, each reachable and each isolated
+# --------------------------------------------------------------------------- #
+def _sigs(text):
+    return {s["signal"] for s in sm.detect_waiting(text)["signals"]}
+
+
+def test_POSITIVE_CONTROL_the_detector_produces_a_NON_ZERO_count():
+    """🔴 MANDATORY. A classifier returning 0 is indistinguishable from one
+    wired to nothing, so the number has to be watched to MOVE.
+
+    Quote this as a PAIR wherever it is reported: N on the positive control,
+    M under test. Here N = 3 flagged of 6 realistic panes.
+    """
+    panes = [PANE_IDLE, PANE_QUESTION, PANE_MENU, PANE_CTX_ZERO,
+             PANE_TYPED_AT_PROMPT]
+    flagged = [p for p in panes if sm.detect_waiting(p)["probable"]]
+    assert len(flagged) == 3, "positive control must be NON-ZERO and exact"
+    assert PANE_QUESTION in flagged
+    assert PANE_MENU in flagged
+    assert PANE_CTX_ZERO in flagged
+
+
+def test_NEGATIVE_CONTROL_a_genuinely_idle_window_is_not_flagged():
+    """🔴 The other half. `PANE_IDLE` carries TWO `?` traps — the user's own
+    submitted prompt echoed into the scrollback, and the live `new task?`
+    footer — and a detector firing on either is worse than none, because it
+    manufactures work at the moment the operator most trusts the output."""
+    got = sm.detect_waiting(PANE_IDLE)
+    assert got["probable"] is False
+    assert got["signals"] == []
+
+
+def test_the_EXCLUDED_case_text_typed_at_the_prompt_never_flags():
+    """🔴 THE OPEN DECISION, settled and pinned.
+
+    A dogfood run read four windows' prompt text as "unsent instructions one
+    Enter away" and could not rule out placeholder chrome. Investigated
+    2026-08-12: it IS distinguishable, by POSITION rather than dimness — a
+    placeholder cannot coexist with typed text, and a queued message renders
+    above the box rather than in it. Both facts are read off a MINIFIED bundle
+    at one version, and the queued case was never observed live (0 hits across
+    29 panes), so the signal would rest on an unobserved negative whose failure
+    mode is a false `waiting` row on a window that is working fine — note this
+    fixture is mid-turn, with a live spinner.
+
+    EXCLUDED. This test fails if anyone adds it back without the observation.
+    """
+    got = sm.detect_waiting(PANE_TYPED_AT_PROMPT)
+    assert got["probable"] is False, "text at the ❯ prompt is not a signal"
+    assert got["signals"] == []
+
+
+def test_signal_trailing_question_fires_ALONE_on_its_own_pane():
+    """Isolation matters: if this pane also matched another signal, a mutation
+    that broke THIS one could still be masked by the other going green."""
+    assert _sigs(PANE_QUESTION) == {"trailing_question"}
+    line = sm.detect_waiting(PANE_QUESTION)["signals"][0]["line"]
+    assert line == "Want me to run the post-deploy check before I close this out?"
+
+
+def test_signal_selection_menu_fires_ALONE_on_its_own_pane():
+    assert _sigs(PANE_MENU) == {"selection_menu"}
+    line = sm.detect_waiting(PANE_MENU)["signals"][0]["line"]
+    assert line == "❯ 1. Resume from summary (recommended)"
+
+
+def test_signal_context_exhausted_fires_ALONE_on_its_own_pane():
+    assert _sigs(PANE_CTX_ZERO) == {"context_exhausted"}
+    line = sm.detect_waiting(PANE_CTX_ZERO)["signals"][0]["line"]
+    assert line.startswith("ctx: 0%")
+
+
+def test_the_signals_are_INDEPENDENT_not_short_circuited():
+    """🔴 REACHABILITY. An early `return` on the first hit would leave the later
+    signals unreachable — and every isolated test above would STILL pass,
+    because each fires first on its own fixture.
+
+    The evaluation order is menu -> ctx -> question, so TWO REALISTIC PAIRS
+    give complete coverage of that class: a return after `menu` kills both of
+    the others (caught by pair 1), and a return after `ctx` kills `question`
+    (caught by pair 2). A return after `question` is a no-op — it is last.
+
+    Pairs, not a triple, because a triple is not a shape live tmux produces: a
+    modal REPLACES the input box, so a pane showing `❯ 1.` has no `ctx: NN%`
+    footer at all. Verified against the live modals on this host 2026-08-12. A
+    fixture asserting an impossible layout would pin the detector against a
+    screen it will never see.
+    """
+    # pair 1 — the agent asks, then puts up the modal. Live shape (a real pane
+    # this run had "…Want me to?" above a resume prompt).
+    menu_and_question = _pane(
+        "● I can take either route here.",
+        "",
+        "  Worth a second pair of eyes before I merge. Want me to?",
+        "",
+        "✻ Baked for 6m 12s",
+        "",
+        _RULE,
+        "  Resuming the full session will consume a large share of your limits.",
+        "",
+        "  ❯ 1. Resume from summary (recommended)",
+        "    2. Resume the full session as-is",
+        "",
+        "  Enter to confirm · Esc to cancel",
+    )
+    assert _sigs(menu_and_question) == {"selection_menu", "trailing_question"}
+
+    # pair 2 — out of context AND asking. Ordinary idle chrome.
+    ctx_and_question = _pane(
+        "● I have run out of room to keep going.",
+        "",
+        "  Do you want me to write the handoff before you clear this?",
+        "",
+        "✻ Baked for 41m 09s",
+        "",
+        _RULE,
+        "❯ ",
+        _RULE,
+        "  ctx: 0%                        new task? /clear to save 610.0k tokens",
+        "  ⏸ manual mode on",
+    )
+    assert _sigs(ctx_and_question) == {"context_exhausted", "trailing_question"}
+
+    # ...and together the two pairs cover every declared signal, so this is not
+    # two tests that happen to exercise the same one.
+    assert (_sigs(menu_and_question) | _sigs(ctx_and_question)
+            == set(sm.WAITING_SIGNALS))
+
+
+def test_every_declared_signal_is_actually_reachable():
+    """🔴 THE LEDGER, both directions. A name in WAITING_SIGNALS no input can
+    produce reads `0` forever and gets mistaken for a measurement; a signal the
+    detector emits but the tuple omits vanishes from every roll-up. Neither is
+    visible from a per-signal test."""
+    produced = set()
+    for pane in (PANE_QUESTION, PANE_MENU, PANE_CTX_ZERO):
+        produced |= _sigs(pane)
+    assert produced == set(sm.WAITING_SIGNALS)
+
+
+@pytest.mark.parametrize("footer,expect", [
+    ("  ctx: 0%", True),
+    ("  ctx: 0%   new task? /clear to save 610.0k tokens", True),
+    ("  ctx: 10%", False),
+    ("  ctx: 20%", False),
+    ("  ctx: 100%", False),
+    ("  ctx: 0.4%", False),
+])
+def test_context_exhausted_matches_ZERO_and_not_its_neighbours(footer, expect):
+    """🔴 Measured AT the boundary and on BOTH sides of it. `ctx: 10%` contains
+    the characters `0%`, so a substring test would fire on every window whose
+    context happens to end in a zero — 10%, 20%, 100%. That is a `/clear`
+    recommendation for a window with plenty of room left."""
+    text = _pane("● done.", "", _RULE, "❯ ", _RULE, footer)
+    assert ("context_exhausted" in _sigs(text)) is expect
+
+
+def test_a_lone_numbered_line_in_prose_is_not_a_modal():
+    """🔴 A SECOND OPTION IS REQUIRED, and this is why. Agents quote menus back
+    at the operator in ordinary prose all day; a live modal always has at least
+    two choices. Without this the signal fires on any transcript containing
+    `❯ 1. …`."""
+    prose = _pane(
+        "● I would have picked the first option:",
+        "",
+        "  ❯ 1. Retitle and post the nudge",
+        "",
+        "  ...but I did not, because you asked me to hold.",
+        "",
+        _RULE, "❯ ", _RULE, "  ctx: 40%",
+    )
+    assert "selection_menu" not in _sigs(prose)
+
+
+def test_a_two_option_modal_IS_a_modal_the_mirror_of_the_test_above():
+    """The positive half — otherwise the test above also passes for a detector
+    that never fires at all."""
+    modal = _pane(
+        "● Proceed?",
+        "",
+        "  ❯ 1. Yes",
+        "    2. No",
+        "",
+        "  Enter to confirm · Esc to cancel",
+    )
+    assert "selection_menu" in _sigs(modal)
+
+
+def test_last_assistant_line_cuts_the_input_box_STRUCTURALLY():
+    """🔴 The chrome is found by the RULES that draw it, not by the words it
+    contains. A keyword cut (`ctx:`, `⏸`, `❯`) breaks the moment upstream
+    restyles a footer — and upstream restyles footers."""
+    assert sm.last_assistant_line(PANE_IDLE) == (
+        "  I pushed the change and the branch is green.")
+    assert sm.last_assistant_line(PANE_QUESTION) == (
+        "  Want me to run the post-deploy check before I close this out?")
+
+
+def test_last_assistant_line_strips_the_between_turn_STATUS_lines():
+    """`✻ Baked for …`, `* Calculating…`, `※ recap:` and the braille spinner sit
+    BELOW the last thing the agent said. Left in place each becomes "the last
+    line", and the question-mark test then reads a status line."""
+    for status in ("✻ Baked for 3m 01s", "* Calculating… (12s · ↓ 900 tokens)",
+                   "※ recap: something happened. (disable recaps in /config)",
+                   "⠙ Thinking…"):
+        text = _pane("● The answer is yes.", "", status, "",
+                     _RULE, "❯ ", _RULE, "  ctx: 44%")
+        assert sm.last_assistant_line(text) == "● The answer is yes.", status
+
+
+def test_last_assistant_line_is_None_when_there_is_no_prose_at_all():
+    assert sm.last_assistant_line("") is None
+    assert sm.last_assistant_line(None) is None
+    assert sm.last_assistant_line(_pane(_RULE, "❯ ", _RULE, "  ctx: 9%")) is None
+
+
+def test_the_detector_alone_CAN_be_fooled_by_a_shell_which_is_why_it_is_gated():
+    """🔴 Stated rather than implied away. `detect_waiting` is shape-matching
+    and a shell whose last line ends in `?` DOES fool it — which is exactly why
+    `gather` never points it at one, and why a non-Claude row is `not_claude`
+    rather than `False`. The guard that matters is the gate, pinned in §A.3;
+    this pins that the gate is load-bearing rather than decorative."""
+    assert sm.detect_waiting(PANE_SHELL)["probable"] is True
+
+
+# --------------------------------------------------------------------------- #
+# §A.3 — the TRI-STATE end to end. `waiting_probable` is True / False / None,
+# and every None carries a `waiting_status` naming which of the four reasons.
+# This is the half that stops a `no` from being manufactured out of a pane
+# nobody looked at.
+# --------------------------------------------------------------------------- #
+def _framed(captures, nonce=CAP_NONCE):
+    return "".join(
+        "%s%s%s%s\n%s\n" % (sm.CAPTURE_MARK_PREFIX, nonce, pid,
+                            sm.CAPTURE_MARK_PREFIX, text)
+        for pid, text in captures.items())
+
+
+def waiting_gather(local=None, remote=None, **kw):
+    """base_gather with BOTH hosts' capture batches really framed.
+
+    %11 is the local Claude pane (scratch7:3) and %21 the remote one
+    (naida-dev:1) in the shared fixtures at the top of this file.
+    """
+    runner = make_runner(
+        local_capture=_framed(local if local is not None else {}),
+        remote_capture=_framed(remote if remote is not None else {}))
+    kw.setdefault("runner", runner)
+    kw.setdefault("capture_nonce", CAP_NONCE)
+    return base_gather(**kw)
+
+
+def _row(report, host, session, widx):
+    for r in report["hosts"][host]["windows"]:
+        if r["session"] == session and r["window_index"] == widx:
+            return r
+    raise AssertionError(f"no row {host} {session}:{widx}")
+
+
+def test_a_waiting_row_carries_the_flag_the_signals_AND_the_matched_line():
+    """END-TO-END: a real pane shape goes in, a judgeable row comes out.
+
+    The MATCHED LINE is the point. `waiting_probable: true` alone is a verdict
+    this cannot honestly issue about a TUI upstream restyles at will — the row
+    ships the evidence so a consumer can disagree with it.
+    """
+    rep = waiting_gather(local={"%11": PANE_QUESTION})
+    row = _row(rep, "workbench", "scratch7", "3")
+    assert row["waiting_probable"] is True
+    assert row["waiting_status"] == "ok"
+    assert [s["signal"] for s in row["waiting_signals"]] == ["trailing_question"]
+    assert row["waiting_signals"][0]["line"].endswith("close this out?")
+
+
+def test_a_scraped_idle_row_is_FALSE_which_is_a_measurement():
+    """The other side of the same coin: `False` is only ever published for a
+    pane that was actually captured and read."""
+    rep = waiting_gather(local={"%11": PANE_IDLE})
+    row = _row(rep, "workbench", "scratch7", "3")
+    assert row["waiting_probable"] is False
+    assert row["waiting_status"] == "ok"
+    assert row["waiting_signals"] == []
+
+
+def test_a_NON_CLAUDE_row_is_never_False_it_is_not_claude():
+    """🔴 A bare zsh is never scraped, so `False` would be a verdict about a
+    pane nobody looked at. `misc:5` is the shell window in the shared fixture.
+
+    The discriminating control is right beside it: the CLAUDE row in the same
+    report, from the same runner, IS measured. If the gate were inverted or
+    absent, one of these two assertions breaks.
+    """
+    rep = waiting_gather(local={"%11": PANE_IDLE})
+    shell = _row(rep, "workbench", "misc", "5")
+    assert shell["claude"] is False
+    assert shell["waiting_probable"] is None
+    assert shell["waiting_signals"] is None
+    assert shell["waiting_status"] == "not_claude"
+    assert _row(rep, "workbench", "scratch7", "3")["waiting_status"] == "ok"
+
+
+def test_a_claude_row_missing_from_a_batch_that_RAN_is_uncaptured():
+    """🔴 `{}` vs `None`. The batch ran and answered; this pane simply is not in
+    it. That is a fact about the PANE, and it must not be reported as the
+    host's failure nor as a measured `no`."""
+    rep = waiting_gather(local={"%99": PANE_QUESTION})   # a different pane
+    row = _row(rep, "workbench", "scratch7", "3")
+    assert row["waiting_probable"] is None
+    assert row["waiting_status"] == "uncaptured"
+    assert rep["hosts"]["workbench"]["captures_measured"] is True
+
+
+def test_no_capture_makes_every_row_None_and_NEVER_False():
+    """🔴 `--no-capture`. Nothing was scraped, so nothing may be reported as
+    scraped — the status is `skipped`, not a quiet `no` on every row."""
+    rep = base_gather(use_capture=False)
+    rows = [r for h in rep["hosts"].values() for r in h["windows"]]
+    assert rows, "fixture must produce rows or this passes vacuously"
+    for r in rows:
+        assert r["waiting_probable"] is None
+        assert r["waiting_signals"] is None
+    claude_rows = [r for r in rows if r["claude"]]
+    assert claude_rows and all(r["waiting_status"] == "skipped"
+                               for r in claude_rows)
+    for host in rep["hosts"].values():
+        assert host["captures_measured"] is False
+        assert host["captures_status"] == "skipped"
+        assert host["captures_seen"] is None
+
+
+def test_a_FAILED_capture_batch_is_error_not_skipped_and_not_a_zero():
+    """🔴 The two unmeasured reasons are DIFFERENT FACTS. `skipped` means the
+    operator asked not to look; `error` means we looked and the host did not
+    answer. Rendering them the same tells an operator their `--no-capture` is
+    responsible for an SSH failure."""
+    runner = make_runner(local_capture_rc=1, local_capture_err="capture died")
+    rep = base_gather(runner=runner, capture_nonce=CAP_NONCE)
+    assert rep["hosts"]["workbench"]["captures_status"] == "error"
+    assert rep["hosts"]["workbench"]["captures_measured"] is False
+    assert rep["hosts"]["workbench"]["captures_seen"] is None
+    row = _row(rep, "workbench", "scratch7", "3")
+    assert row["waiting_probable"] is None and row["waiting_status"] == "error"
+    # ...and the OTHER host's batch, which did answer, is unaffected: one call
+    # failing says nothing about the other.
+    assert rep["hosts"]["laptop"]["captures_status"] == "ok"
+
+
+def test_a_host_with_no_claude_panes_is_a_MEASURED_empty_capture_set():
+    """`{}` with `status: ok` — we know every pane on that host and none of
+    them is Claude. Distinct from `None`, and no tmux capture call is made."""
+    calls = []
+    runner = make_runner(local_panes=(
+        "%13|1003|misc|5|win-charlie|/home/zach/tmp|zsh|plain title"),
+        calls=calls)
+    rep = base_gather(runner=runner, hosts=("workbench",),
+                      capture_nonce=CAP_NONCE)
+    wb = rep["hosts"]["workbench"]
+    assert wb["captures_measured"] is True
+    assert wb["captures_status"] == "ok"
+    assert wb["captures_seen"] == 0
+    assert not any("capture-pane" in " ".join(c) for c in calls), (
+        "no Claude panes means no capture call at all")
+
+
+def test_only_CLAUDE_pane_ids_are_ever_sent_to_the_capture_batch():
+    """🔴 The gate, pinned on the ARGV rather than on the output. A detector
+    that never sees a shell pane cannot invent a signal from one — and reading
+    this off the row alone would not distinguish "not scraped" from "scraped
+    and suppressed"."""
+    calls = []
+    base_gather(runner=make_runner(calls=calls, local_capture=_framed({})),
+                hosts=("workbench",), capture_nonce=CAP_NONCE)
+    cap = [c for c in calls if "capture-pane" in " ".join(c)]
+    assert len(cap) == 1, "one batched call per host"
+    argv = cap[0]
+    assert "%11" in argv, "the claude pane must be captured"
+    assert "%12" not in argv and "%13" not in argv, "shells must not be"
+
+
+# --------------------------------------------------------------------------- #
+# §A.4 — the roll-up. `probable` is None when nothing was scraped.
+# --------------------------------------------------------------------------- #
+def test_the_summary_waiting_count_MOVES_positive_control_and_under_test():
+    """🔴 THE PAIR, in one test, so neither number can be quoted alone.
+
+    A `waiting: 0` from a classifier wired to nothing is indistinguishable from
+    a real 0 — so the same fixture is run twice, once with a pane that MUST
+    flag and once with a pane that must not, and both numbers are asserted.
+    """
+    positive = waiting_gather(local={"%11": PANE_MENU})
+    under_test = waiting_gather(local={"%11": PANE_IDLE})
+    assert positive["summary"]["waiting"]["probable"] == 1     # N
+    assert under_test["summary"]["waiting"]["probable"] == 0   # M
+    # both scraped the same number of panes, so the difference is the SIGNAL
+    # and not the sample.
+    assert (positive["summary"]["waiting"]["measured"]
+            == under_test["summary"]["waiting"]["measured"] == 1)
+
+
+def test_the_summary_waiting_is_None_not_0_when_nothing_was_scraped():
+    """🔴 The sentence this tool must never emit is "nothing is waiting on you"
+    off a look that never happened. `--no-capture` scrapes nothing, so the
+    headline number is None and the renderer says UNMEASURED."""
+    rep = base_gather(use_capture=False)
+    w = rep["summary"]["waiting"]
+    assert w["probable"] is None
+    assert w["per_signal"] is None
+    assert w["measured"] == 0
+    assert w["unmeasured"] == 3
+    assert w["unmeasured_reasons"] == {"skipped": 2, "not_claude": 1}
+
+
+def test_the_per_signal_breakdown_is_derived_from_the_declared_ledger():
+    """🔴 The tuple and the roll-up pin each other. A signal `detect_waiting`
+    emits but WAITING_SIGNALS omits would be counted per-row and invisible in
+    every total; one declared but never emitted reads 0 forever and gets taken
+    for a measurement."""
+    rep = waiting_gather(local={"%11": PANE_CTX_ZERO})
+    per = rep["summary"]["waiting"]["per_signal"]
+    assert set(per) == set(sm.WAITING_SIGNALS)
+    assert per["context_exhausted"] == 1
+    assert per["trailing_question"] == 0 and per["selection_menu"] == 0
+
+
+def test_unmeasured_reasons_distinguishes_the_four_ways_a_row_goes_None():
+    """The None is only actionable if it says WHY. Three reasons in one report:
+    a shell (`not_claude`), a claude pane absent from the batch
+    (`uncaptured`), and a remote host whose batch also answered."""
+    rep = waiting_gather(local={"%99": PANE_IDLE}, remote={"%21": PANE_MENU})
+    reasons = rep["summary"]["waiting"]["unmeasured_reasons"]
+    assert reasons == {"not_claude": 1, "uncaptured": 1}
+    assert rep["summary"]["waiting"]["measured"] == 1     # the remote row
+    assert rep["summary"]["waiting"]["probable"] == 1
+
+
+def test_the_renderer_says_UNMEASURED_rather_than_printing_a_zero():
+    """🔴 The plain-text reader gets the same discipline as the JSON one. A
+    `waiting: 0` line under `--no-capture` is the whole failure in one line of
+    output."""
+    text = sm.render_table(base_gather(use_capture=False))
+    assert "waiting: UNMEASURED" in text
+    assert "waiting: 0 probable" not in text
+    # ...and the measured case really does print a number, or the assertion
+    # above passes for a renderer that never prints the line at all.
+    measured = sm.render_table(waiting_gather(local={"%11": PANE_IDLE}))
+    assert "waiting: 0 probable of 1 scraped" in measured
+
+
+def test_the_renderer_prints_the_matched_line_for_every_flagged_row():
+    """The evidence has to reach the human, not only the `--json` consumer —
+    the four states a `waiting` row can be in need four different actions, and
+    only the matched line says which."""
+    text = sm.render_table(waiting_gather(local={"%11": PANE_MENU}))
+    assert "⚠ WAITING" in text
+    assert "[selection_menu]" in text
+    assert "❯ 1. Resume from summary (recommended)" in text
+    # and an unflagged report must not print the block at all
+    assert "⚠ WAITING" not in sm.render_table(
+        waiting_gather(local={"%11": PANE_IDLE}))
+
+
+def test_the_WAIT_column_never_spells_an_unmeasured_row_as_no():
+    """🔴 `?uncaptured` and `no` are six characters apart and mean opposite
+    things. The cell for an unscraped pane must not be readable as a
+    measurement."""
+    text = sm.render_table(waiting_gather(local={"%99": PANE_IDLE}))
+    row = [ln for ln in text.splitlines() if "scratch7" in ln][0]
+    assert "?uncaptured" in row
+    assert not row.endswith(" no")
+
+
+def test_the_caveat_footer_names_the_three_signals_and_the_exclusion():
+    """The enumeration is what turns `WAIT: no` from "nothing needed here" into
+    "none of these three matched" — which is all it ever meant."""
+    line = [ln for ln in sm.render_caveats(base_gather())
+            if "waiting_signal" in ln][0]
+    for sig in sm.WAITING_SIGNALS:
+        assert sig in line
+    assert "EXCLUDED" in line
+
+
+def test_the_waiting_caveat_is_structured_for_json_consumers_not_prose():
+    cav = base_gather()["caveats"]["waiting_signal"]
+    assert cav["signals"] == list(sm.WAITING_SIGNALS)
+    assert cav["scope"] == "claude_rows_only"
+    assert "prompt_buffer_text" in cav["excluded"]
+    # the exclusion states its REASON, so nobody re-litigates it from scratch
+    assert "never observed" in cav["excluded"]["prompt_buffer_text"]
+
+
+# =========================================================================== #
+# §B — BLOCKED ON ME (the clawgate approval queue)
+#
+# 🔴 The failure this closes was MEASURED, not imagined: a dogfood agent read
+# an accurate line saying `agent-ops` has no JSON API, correctly preferred this
+# script, never opened agent-ops, and so missed 11 pending approvals — four of
+# them credential-exposure or cross-user-data-leak.
+# =========================================================================== #
+def _cache(**kw):
+    body = {"count": 12, "state": "Warning", "ts": NOW - 30,
+            "detail": "12 task(s) awaiting: #172, #171, #170, #169, #168, #160",
+            "source": "clawgate"}
+    body.update(kw)
+    return lambda path: json.dumps(body)
+
+
+def test_a_fresh_cache_is_ok_and_carries_the_count():
+    got = sm.read_blocked_on_me(reader=_cache(), now=NOW)
+    assert got["status"] == "ok"
+    assert got["count"] == 12
+    assert got["cache_age_secs"] == 30
+
+
+def test_an_ABSENT_cache_is_None_and_NEVER_zero():
+    """🔴 THE TOOL'S ENTIRE THESIS, applied to its newest source. A missing file
+    rendering as "nothing is blocked on you" is the exact substitution every
+    other section of this script exists to refuse."""
+    got = sm.read_blocked_on_me(reader=lambda p: None, now=NOW)
+    assert got["status"] == "absent"
+    assert got["count"] is None, "an unread queue is not an empty queue"
+    assert got["error"] and "not measured" in got["error"].lower()
+
+
+def test_an_UNPARSEABLE_cache_is_None_and_says_so():
+    for body in ("{not json", "", "null", "[]", '{"state":"Warning"}',
+                 '{"count":"12"}', '{"count":true}'):
+        got = sm.read_blocked_on_me(reader=lambda p, b=body: b, now=NOW)
+        assert got["status"] == "unparseable", body
+        assert got["count"] is None, body
+
+
+@pytest.mark.parametrize("age,status", [
+    (0, "ok"),
+    (299, "ok"),
+    (300, "ok"),          # the boundary is EXCLUSIVE: 300 is not yet stale
+    (301, "stale"),
+    (4200, "stale"),
+])
+def test_the_staleness_boundary_is_measured_at_more_than_one_point(age, status):
+    """🔴 One measurement is not a claim about a threshold. Measured AT the
+    boundary, one second either side, and well outside it — a comparison that
+    is off by one is invisible from a single point."""
+    got = sm.read_blocked_on_me(reader=_cache(ts=NOW - age), now=NOW)
+    assert got["status"] == status
+    assert got["cache_age_secs"] == age
+
+
+def test_a_STALE_cache_still_carries_its_number_but_never_calls_it_current():
+    """The count is real, just possibly old — dropping it would lose signal,
+    and publishing it as `ok` would fabricate freshness. Both, labelled."""
+    got = sm.read_blocked_on_me(reader=_cache(ts=NOW - 9999), now=NOW)
+    assert got["status"] == "stale"
+    assert got["count"] == 12
+    assert "out of date" in got["error"]
+
+
+@pytest.mark.parametrize("ts", [None, "1786556281", True, [], {}])
+def test_a_cache_whose_AGE_cannot_be_established_is_stale_not_ok(ts):
+    """🔴 The conservative direction. A count whose freshness is unknowable is
+    not a fresh count; calling it `ok` is a guess about the writer."""
+    got = sm.read_blocked_on_me(reader=_cache(ts=ts), now=NOW)
+    assert got["status"] == "stale"
+    assert got["cache_age_secs"] is None
+    assert "freshness" in got["error"]
+
+
+def test_the_detail_string_is_NEVER_parsed_for_a_count():
+    """🔴 THE TRUNCATION TRAP, pinned. The cached `detail` names ~6 ids however
+    many are pending, and the ids it drops have included `ready_for_review`
+    items — finished work awaiting review. So the fixture deliberately
+    DISAGREES with itself: 11 pending, 6 named. Anything deriving the number
+    from the string reports 6 and loses five tasks silently.
+    """
+    reader = _cache(count=11,
+                    detail="11 task(s) awaiting: #171, #170, #169, #168, "
+                           "#160, #165")
+    got = sm.read_blocked_on_me(reader=reader, now=NOW)
+    assert got["count"] == 11, "the count is the measurement, not the string"
+    assert got["detail"].count("#") == 6, "fixture must actually be truncated"
+    assert got["detail_truncated"] is True
+    assert "TRUNCATE" in got["detail_note"].upper()
+
+
+def test_a_real_measured_zero_is_distinguishable_from_an_absent_cache():
+    """🔴 THE DISCRIMINATING CONTROL. Both are "no pending approvals" to a
+    careless reader; only one of them is a measurement, and the renderer must
+    not spell them the same."""
+    zero = sm.read_blocked_on_me(reader=_cache(count=0, detail=None), now=NOW)
+    absent = sm.read_blocked_on_me(reader=lambda p: None, now=NOW)
+    assert zero["status"] == "ok" and zero["count"] == 0
+    assert absent["status"] == "absent" and absent["count"] is None
+    a = "\n".join(sm.render_blocked_on_me(zero))
+    b = "\n".join(sm.render_blocked_on_me(absent))
+    assert a != b
+    assert "a measured zero" in a and "UNMEASURED" not in a
+    assert "UNMEASURED" in b and "NOT zero pending" in b
+
+
+def test_the_blocked_section_is_rendered_in_EVERY_state():
+    """Printed unconditionally, because the failure being closed is a reader
+    who never learned the queue exists. A section that appears only sometimes
+    is one nobody learns to look for."""
+    for reader in (_cache(), _cache(count=0), _cache(ts=NOW - 9999),
+                   lambda p: None, lambda p: "{broken"):
+        rep = base_gather(blocked_reader=reader, now=NOW)
+        text = sm.render_table(rep)
+        assert "▸ BLOCKED ON ME" in text
+
+
+def test_the_rendered_queue_points_the_reader_AT_agent_ops_for_the_full_list():
+    """🔴 Unit B's other half. This script has the COUNT; agent-ops has the
+    enumerated queue with titles. The cross-reference now sends a reader
+    toward it instead of away."""
+    text = sm.render_table(base_gather(blocked_reader=_cache(), now=NOW))
+    assert "12 clawgate task(s) pending" in text
+    assert "agent-ops" in text
+    # and the same is true when the count could NOT be read — that is exactly
+    # when a reader most needs somewhere else to look
+    absent = sm.render_table(base_gather(blocked_reader=lambda p: None))
+    assert "agent-ops" in absent
+
+
+def test_the_summary_carries_the_count_WITH_its_discriminant():
+    """The count never travels alone, in the roll-up any consumer reads first."""
+    ok = base_gather(blocked_reader=_cache(), now=NOW)
+    assert ok["summary"]["blocked_on_me"] == {"count": 12, "status": "ok"}
+    gone = base_gather(blocked_reader=lambda p: None, now=NOW)
+    assert gone["summary"]["blocked_on_me"] == {"count": None,
+                                                "status": "absent"}
+
+
+def test_the_blocked_reader_is_resolved_at_CALL_time_not_bound_as_a_default():
+    """🔴 The same hole `ch_client_factory` had, on a new seam. A default of
+    `blocked_reader=_read_blocked_text` would capture the ORIGINAL function at
+    def time, so the autouse hermeticity raiser would NOT be honoured on the
+    one path with no injection point — `main()` -> `gather()` — and the suite
+    would quietly read the operator's live queue while staying green."""
+    import inspect
+    params = inspect.signature(sm.gather).parameters
+    assert params["blocked_reader"].default is None
+    assert params["blocked_path"].default is None
+    with pytest.raises(_Forbidden):
+        base_gather(blocked_reader=None)
+
+
+def test_the_cache_path_is_the_bar_pollers_and_is_not_hardcoded_elsewhere():
+    """One constant, so the poller and the reader cannot drift apart."""
+    assert sm.BLOCKED_CACHE.endswith("/.cache/bar-status/clawgate.json")
+    seen = {}
+    sm.read_blocked_on_me(reader=lambda p: seen.setdefault("path", p) and None,
+                          now=NOW)
+    assert seen["path"] == sm.BLOCKED_CACHE
+
+
+# =========================================================================== #
+# §D — the four small ones
+# =========================================================================== #
+def test_tail_plain_drops_the_ANSI_flag_at_the_SOURCE():
+    """🔴 `--plain` removes tmux's `-e`, it does not post-process. Every
+    consumer was re-inventing the same `sed 's/\\x1b\\[[0-9;]*m//g'`, which
+    silently leaves behind every escape that is not an SGR. Not emitting them
+    is the fix; stripping them is the workaround."""
+    assert "-e" in sm.tail_argv("scratch7:3")
+    assert "-e" not in sm.tail_argv("scratch7:3", plain=True)
+    # everything else about the call is unchanged, so the default caller's
+    # bytes do not move under them
+    plain = sm.tail_argv("scratch7:3", lines=42, plain=True)
+    assert plain == ["tmux", "capture-pane", "-t", "scratch7:3", "-p",
+                     "-S", "-42"]
+
+
+def test_tail_plain_reaches_the_subprocess_and_is_recorded_in_the_json(
+        monkeypatch, capsys, absent_blocked_cache):
+    """END-TO-END through main(): the flag must change the ARGV, and the JSON
+    must say which mode produced `text` — a consumer cannot tell an ANSI-free
+    pane from a stripped one by looking at it."""
+    calls = []
+    monkeypatch.setattr(sm, "local_host_label", lambda *a, **k: "workbench")
+    monkeypatch.setattr(sm, "_default_runner",
+                        make_runner(calls=calls, local_capture="clean text\n"))
+    assert sm.main(["tail", "scratch7:3", "--host", "workbench", "--plain",
+                    "--json"]) == sm.EXIT_OK
+    blob = json.loads(capsys.readouterr().out)
+    assert blob["plain"] is True
+    assert "-e" not in calls[-1]
+
+    calls.clear()
+    assert sm.main(["tail", "scratch7:3", "--host", "workbench",
+                    "--json"]) == sm.EXIT_OK
+    blob = json.loads(capsys.readouterr().out)
+    assert blob["plain"] is False
+    assert "-e" in calls[-1]
+
+
+def test_fuzzyclaw_is_OFF_by_default_and_publishes_None_not_zero():
+    """🔴 Measured 2026-08-12: 29 live of 401 files, 363 stale, 9
+    slot-mismatched, and every live row reading `paused` — including a window
+    demonstrably running an agent. 29 rows, zero contribution, from a source
+    `CLAUDE.md` marks UNTRUSTED. Off by default; the counts stay None so the
+    absence is never a measured zero."""
+    import inspect
+    assert inspect.signature(sm.gather).parameters["use_fuzzyclaw"].default \
+        is False
+    rep = _REAL_GATHER(hosts=("workbench",), local_host="workbench",
+                       runner=make_runner(), use_ch=False, now=NOW,
+                       codenames={}, blocked_reader=lambda p: None)
+    assert rep["fuzzyclaw"]["status"] == "skipped"
+    assert rep["fuzzyclaw"]["files_seen"] is None
+    assert rep["summary"]["fuzzyclaw_live"] is None
+
+
+@pytest.mark.parametrize("argv,expect_on", [
+    ([], False),
+    (["--fuzzyclaw"], True),
+    (["--no-fuzzyclaw"], False),
+    (["--fuzzyclaw", "--no-fuzzyclaw"], False),
+    (["--no-fuzzyclaw", "--fuzzyclaw"], False),
+])
+def test_the_fuzzyclaw_flags_compose_with_explicit_OFF_winning(
+        monkeypatch, capsys, absent_blocked_cache, argv, expect_on):
+    """🔴 `--no-fuzzyclaw` KEEPS WORKING — it now names the default rather than
+    changing it, so every existing invocation behaves identically. Passing both
+    is not an error; OFF wins and `main` says so, because a silently ignored
+    flag is how a caller concludes it was honoured."""
+    seen = {}
+    monkeypatch.setattr(sm, "local_host_label", lambda *a, **k: "workbench")
+
+    def fake_gather(**kw):
+        seen.update(kw)
+        return _REAL_GATHER(**dict(kw, runner=make_runner(),
+                                   fuzzyclaw_texts=[], codenames={},
+                                   blocked_reader=lambda p: None, now=NOW))
+    monkeypatch.setattr(sm, "gather", fake_gather)
+    sm.main(["scan", "--host", "workbench", "--no-ch", *argv])
+    assert seen["use_fuzzyclaw"] is expect_on
+    err = capsys.readouterr().err
+    assert ("OFF wins" in err) is ("--fuzzyclaw" in argv
+                                   and "--no-fuzzyclaw" in argv)
+
+
+def test_no_capture_flag_reaches_gather(monkeypatch, absent_blocked_cache):
+    seen = {}
+    monkeypatch.setattr(sm, "local_host_label", lambda *a, **k: "workbench")
+
+    def fake_gather(**kw):
+        seen.update(kw)
+        return _REAL_GATHER(**dict(kw, runner=make_runner(), codenames={},
+                                   blocked_reader=lambda p: None, now=NOW))
+    monkeypatch.setattr(sm, "gather", fake_gather)
+    sm.main(["scan", "--host", "workbench", "--no-ch", "--no-capture"])
+    assert seen["use_capture"] is False
+    sm.main(["scan", "--host", "workbench", "--no-ch"])
+    assert seen["use_capture"] is True
+
+
+def test_the_documented_JSON_ROW_PATH_is_where_the_rows_actually_are():
+    """🔴 Unit D.3, pinned rather than merely written down. The skill body
+    detailed `summary` and never said rows live at `hosts.<host>.windows`,
+    which cost a dogfood agent a wasted call. A doc line drifts; an assertion
+    does not.
+    """
+    rep = base_gather()
+    for host in ("workbench", "laptop"):
+        assert isinstance(rep["hosts"][host]["windows"], list)
+    assert rep["hosts"]["workbench"]["windows"], "path must be non-empty here"
+    # the path is stated in the module docstring, so the doc and the code are
+    # checked against each other and not just against a reader's memory
+    assert 'report["hosts"][<"workbench"|"laptop">]["windows"]' in sm.__doc__
+
+
+def test_the_row_FIELD_LEDGER_fails_when_it_grows_or_shrinks():
+    """🔴 Both directions. A field that disappears turns a consumer's read into
+    a permanent None; one that appears undocumented is a contract nobody
+    reviewed. The docstring enumerates them, so it is the docstring that is
+    checked."""
+    row = base_gather()["hosts"]["workbench"]["windows"][0]
+    expected = {
+        "host", "session", "window_index", "window_id", "window_name",
+        "codename", "pane_id", "path", "command", "task", "claude", "busy",
+        "age_secs", "status", "waiting_probable", "waiting_signals",
+        "waiting_status", "claude_session_id", "fuzzyclaw", "panes",
+    }
+    assert set(row) == expected
+    for field in expected:
+        assert field in sm.__doc__, f"{field} is undocumented in the header"


### PR DESCRIPTION
Closes Units **A**, **B** and **D** of `claudedocs/kickoff-waiting-signal.md`. Unit C (`standup`) and D.3 (`initiative-scan`) are a sibling branch.

## Unit A — the `waiting` signal

`status: idle` merged four states needing four different actions. Each Claude pane now gets scraped for three signals, and every row carries `waiting_probable` **plus the matched line** so a consumer can disagree with it:

| signal | means | do |
|---|---|---|
| `trailing_question` | the agent's last sentence ends in `?` | answer it |
| `selection_menu` | a `❯ 1./2./3.` modal is up | press a key |
| `context_exhausted` | `ctx: 0%` | `/clear` it |

**One batched `capture-pane` per host**, not one per pane — 40 panes over SSH would be 40 round trips. The argv is asserted against an **allowlist** of tmux subcommands (`tmux`/`display-message`/`capture-pane`), because a denylist passes for every mutating verb nobody thought to name.

> 🔴 The marker carries the pane id via `#{pane_id}`, never our own interpolation. A tmux format string is strftime-expanded, so a literal `%68` is `%B` padded to width 68 — verified on live tmux: `display-message -p 'A%68B'` prints `A`, 62 spaces, `August`. A per-run nonce means a pane cannot forge a marker.

### `waiting_probable` is a TRI-STATE

`false` = "these three were looked for and none matched", **not** "this window needs nothing" — recall is partial by construction and the signal set ships enumerated in `caveats`. `null` = never scraped, with `waiting_status` saying which of `not_claude` / `uncaptured` / `skipped` / `error`. `summary.waiting.probable` is likewise `null`, never `0`, when nothing was scraped.

## 🔴 The open decision: text at the `❯` prompt — EXCLUDED

Investigated against `claude-code 2.1.220`. **Dimness is the wrong question** — what separates the readings is *position*, and `capture-pane` reports position fine:

- a placeholder **cannot** coexist with typed text (the hint hook returns early on a non-empty buffer, `if(e!=="")return`);
- a queued message is **not in the box** either — the submit handler clears the buffer on enqueue and queued messages render as their own indented block *above* the top border.

So it is distinguishable in principle. **It stays excluded anyway**, for three reasons:

1. Both invariants are read off a **minified** bundle at **one** version.
2. The case they rule out — a live queued message — was **never observed**: 0 hits across 29 Claude panes and ~250k lines of scrollback, on a scan whose positive control passed (89–130 column-0 chevrons/pane).
3. Under that same source read, typing while an agent works has **three** outcomes, not one (queue / interrupt the turn / drop as `mode_not_queueable`).

Keying on an unobserved negative makes the failure mode a **false `waiting` row**, arriving exactly when the operator most trusts the output. Excluding costs **recall**, which is the safe direction, and the caveat line says so in the output. `reference/waiting-signal.md` records the evidence and the exact observation that would justify turning it on.

## Unit B — a path back to the clawgate queue

An **accurate** doc line ("`agent-ops` has no JSON API and no cross-host reach") is what steered a dogfood agent away from the only surface showing the approval queue — missing 11 pending approvals, four of them credential-exposure or cross-user-data-leak. Both halves fixed:

- `report["blocked_on_me"]` + a `▸ BLOCKED ON ME` section printed in **every** state;
- the cross-reference now points **at** `agent-ops` for *which* tasks (it has the enumerated queue, titles, and the `/proc` walk). They are complements, not substitutes.

`count` is the measurement; **`detail` is never parsed** — it names ~6 ids however many are pending and has dropped `ready_for_review` items. Four states: `ok` / `stale` (>300s; the poller writes every 45s) / `absent` / `unparseable`, and the last three publish `count: null`, never `0`.

> The cache read is its own seam (`_read_blocked_text`) rather than a `_read_text` call — the suite forbids each impure edge with a raiser, and three tests legitimately read real tmp files through `_read_text`. **Adding the guard immediately caught a live breach**: the golden-schema test had been picking up the operator's real pending count (12) mid-run.

## Unit D

- **fuzzyclaw OFF by default** (`--fuzzyclaw` opts in; `--no-fuzzyclaw` still works and now *names* the default; passing both → OFF wins, said on stderr). Measured: 29 live of 401 files, 363 stale, 9 slot-mismatched, every live row reading `paused` including a window demonstrably running an agent. The intersection guard and all its tests are untouched and still run when you opt in.
- **`tail --plain`** drops tmux's `-e` at the source. Every consumer was re-inventing the same SGR-only `sed`, which leaves behind every escape that is not an SGR. Same defect class as agent-ops #413; the fix had not generalised to this sibling. Live-verified: `--plain` emits zero `ESC[`, the default keeps them.
- **JSON shape documented AND pinned by a test** — rows live at `hosts.<host>.windows`, plus a row field-ledger test that fails when the set grows *or* shrinks.
- **SKILL.md 261 → 145 lines.** Exit-code rationale → `reference/exit-codes.md`; slot-conflict archaeology → `reference/fuzzyclaw-guard.md`; waiting evidence → `reference/waiting-signal.md`. **The caveats stay in the body** — a dogfood agent credited that section with stopping a false report.

## Verification

**Positive-control pair — 3 flagged of 5 realistic panes, 0 on the idle pane.** The idle fixture carries two `?` traps on purpose: the user's own submitted prompt echoed into the scrollback, and the real `new task? /clear …` footer.

**Live, all 40 workbench panes:** 7 flagged of 29 Claude panes (3 `selection_menu`, 4 `trailing_question`), 11 `not_claude`. Every flagged row independently confirmed by reading the pane — zero false positives. `--no-capture` on the same machine prints `waiting: UNMEASURED — 0 of 40 window(s) scraped`, not a zero.

**Mutation sweep — 20/20 killed, each on its own named assertion**, fresh tree per mutant (`PYTHONDONTWRITEBYTECODE=1`, `python3 -B`, `-p no:cacheprovider`). Covers each signal separately, the `ctx: 0%` boundary, the chrome cut, the tri-state, the roll-up's None, all four cache states, the truncated-`detail` trap, the staleness boundary, `--plain`, the fuzzyclaw default, and the marker/nonce protocol.

> The sweep's **first run reported 0/20** — its own summary parser was broken by a doubled `-q`. The harness was fixed and re-validated before any verdict was read off it.

**Red→green: 61 new tests, all RED at `origin/main`** (188 failed / 183 passed there — the base run neutralises the new autouse fixture, so each test fails on its *own* reason rather than one blanket error), **371 green at HEAD**.

**Gate:** `nix build .#checks.x86_64-linux.{pytests,nodetests}` both **PASS**, counts read from `nix log`, not exit codes.
`scripts/tests` **2535 → 2613** collected (+78, all in `test_session_manager.py`: 293 → 371).

## Floor re-pin

`TARGET_FLOORS` `scripts/tests` **2485 → 2563**, from the gate's own `_suggested_floor` applied to the gate's own printed count:

```
_suggested_floor 2613 = 2613 - min(50, max(1, 2613/20)) = 2613 - 50 = 2563
```

⚠ A sibling branch also adds tests here, so **this line will conflict**, and `rerere` has mis-replayed exactly it before. Resolve by re-running the gate on the **merged** tree and copying the number it prints — never by arithmetic across the two sides.

## Not in scope, deliberately

No `send-keys`, no `kill`, no `signal`. `session-manager` stays read-only by construction, which is the only reason it is safe to point at a live machine holding 40+ windows of real work. A `waiting` flag is a read; acting on it is not.

## Stated, not verified

- **Laptop path untested live** — the laptop was not reachable during this work. The SSH capture path is covered by the hermetic suite (including the `shlex.join` round-trip that the `;` separator and `#{…}` format must survive), but no real remote capture was run.
- **`ctx: 0%` was never seen live** — every pane on the workbench sat between 11% and 78%. That signal is covered by the positive control and a 6-point boundary sweep, not by a live observation.
- **Two known recall misses**, both measured and documented rather than closed: a window parked on `Login successful. Press Enter to continue…` (2 of 40 panes), and an agent that *offers* rather than asks ("Say the word and I'll open the PR").
- **Side finding, out of scope:** the `⏸`/`🔄` window-name markers disagreed with the spinner on two panes (inverted on both), and `busy` from the pane title read `1+0` while at least two panes were visibly working. `busy_from_title` is unchanged by this PR; worth its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
