### PR TITLE
fix(standup): the fleet verdict's two zeroes were a parse bug, not a short repo list (#417 C + D3)

### DIFF
--- a/claude/skills/initiative-scan/SKILL.md
+++ b/claude/skills/initiative-scan/SKILL.md
@@ -1,13 +1,34 @@
 ---
 name: initiative-scan
 description: "Run the on-demand cross-repo initiative scan — every initiative with its momentum (active/slowing/stalled), last-touched, commits/PRs, next-step and the live tmux session hosting it; also snapshots/restores the tmux workspace across a reboot. Use for \"what am I working on\", \"what's in flight\", \"what's stalled\", \"where did I leave X\", \"which session is X in\". The durable board is `initiatives`."
-argument-hint: "[--days N] [--repo PATH] [--json] [--tmux] | snapshot | restore [--dry-run] | show — defaults to --days 4 --tmux"
+argument-hint: "[--days N] [--repo PATH] [--json] [--tmux] | snapshot | restore [--dry-run] | show — runs scripts/session-analysis/initiative-scan.py; defaults to --days 4 --tmux"
 allowed-tools: Bash
 ---
 
 # initiative-scan — on-demand initiative + progress ledger
 
-Runs the read-only `initiative-scan` report and presents it. This is the durable, cross-session counterpart to the live **agent-ops dashboard** (`$mod+i` / tmux `prefix+A` / the ▦ bar button — `scripts/agent-ops`), which only shows sessions open right now. (The old `tmux-initiatives.sh` Alt+i HUD was removed 2026-07 — the agent-ops dashboard supersedes it.) Args: `$ARGUMENTS` (passed through to the script; default `--days 4`).
+🔴 **There is no `initiative-scan` binary — `which initiative-scan` finds nothing.** It is a
+python script, and it does **not** live under `scripts/initiatives/` (that path is the
+*durable board*, a different subsystem with its own `initiatives` skill). The one file is:
+
+```bash
+python3 ~/workspace/devrc/scripts/session-analysis/initiative-scan.py --days 4 --tmux
+```
+
+Plain `python3` is correct and sufficient — `requests` is only needed with telemetry ON (step
+1), and `nix-shell` wrapping is what makes a repo `flake.nix` shellHook print a greeting in
+front of the JSON. Use `--json` for machine-readable output.
+
+Runs the read-only report and presents it. This is the durable, cross-session counterpart to the live **agent-ops dashboard** (`$mod+i` / tmux `prefix+A` / the ▦ bar button — `scripts/agent-ops`), which only shows sessions open right now. (The old `tmux-initiatives.sh` Alt+i HUD was removed 2026-07 — the agent-ops dashboard supersedes it.) Args: `$ARGUMENTS` (passed through to the script; default `--days 4`).
+
+## 🔴 What the numbers mean before you repeat any of them
+- **`momentum: active` means the initiative's handoff doc was TOUCHED recently — not that work is moving.** It is recency of touch, never % done. An initiative can read `active` with `commits: 0` and `open_prs: []` and have had nothing happen for a week.
+- **Three flags in the report say which zeroes are measurements and which are "not wired up here". Read them before quoting a zero:**
+  - `telemetry_available: false` → ClickHouse is unset/unreachable; momentum came from handoff + git + sessions only.
+  - `gh_available: false` → **every `open_prs: []` and `merged_prs: 0` is UNMEASURED, not zero.** The PR fetch returns `[]` on any failure, so without this flag the two are identical.
+  - `tmux_enabled: false` → no `--tmux`, or no tmux server; the session-linking column is absent, not empty.
+  - `commits_unknown: true` on an initiative → its branch refs were unresolvable, so `commits: 0` there means "could not count", not "no commits".
+- The text renderer appends an explicit NOTE for the telemetry-off and gh-unavailable cases; the `--json` output carries the raw booleans.
 
 For the **durable, queryable** version of this data — the Postgres store, the 15-min sync, the
 LLM recaps, the workbench viewer/board and its `/api/ask` assistant — use the **`initiatives`**
@@ -36,11 +57,13 @@ python3 ~/workspace/devrc/scripts/tmux-session-restore.py <snapshot|restore|show
    ```
    - **Host note:** `192.168.50.94:30123` is the workbench LAN endpoint. On the **laptop** (no `~/.server-mode` marker, nebula-only) that's unreachable → the report runs **telemetry-OFF** (still useful from handoff + git). To get telemetry there, point `CLICKHOUSE_URL` at the laptop's nebula CH endpoint — see the `activity` skill.
 
-2. **Run the scan** (substitute `$ARGUMENTS`, or `--days 4 --tmux` if none):
+2. **Run the scan** (substitute `$ARGUMENTS`, or `--days 4 --tmux` if none). With step 1's
+   creds exported you need `requests`, so wrap it; **without** them run the plain `python3`
+   form at the top of this file instead — it is faster and avoids the shellHook-chatter trap.
    ```bash
    nix-shell -p 'python3.withPackages(p:[p.requests])' --run \
      'python ~/workspace/devrc/scripts/session-analysis/initiative-scan.py --days 4 --tmux'
    ```
    - **`--tmux`** links each initiative to the live tmux session(s) hosting it — `[tmux:8,scratch7]` vs `[no session]` — by matching the claude pane's title (its session summary) against the initiative slug/title, scoped by the pane's cwd→repo. It also lists **live claude sessions with no matched initiative** (open work the ledger doesn't cover). Best-effort: on a host with no tmux server the column is silently omitted. This is the durable ledger fused with the same live-session view the agent-ops dashboard renders. Drop `--tmux` if `$ARGUMENTS` explicitly overrides.
 
-3. **Present the output as-is** — it's already a ranked, skimmable report grouped by repo. Optionally lead with a one-line read: which initiatives are ●ACTIVE vs the most notable ○stalled one, and any next-step that looks owed. **Do not editorialize beyond the data** — momentum is *recency of touch, NOT % done*, and both initiative↔commit and initiative↔tmux-session linking are heuristic (see the script's honesty notes; a multi-topic pane title may attach to one of several co-hosted initiatives).
+3. **Present the output as-is** — it's already a ranked, skimmable report grouped by repo. Optionally lead with a one-line read: which initiatives are ●ACTIVE vs the most notable ○stalled one, and any next-step that looks owed. **Do not editorialize beyond the data** — momentum is *recency of touch, NOT % done* (see the section above), and both initiative↔commit and initiative↔tmux-session linking are heuristic (see the script's honesty notes; a multi-topic pane title may attach to one of several co-hosted initiatives). If you quote a count, carry the flag that scopes it: "0 open PRs (gh available)" is a measurement, "0 open PRs" off a `gh_available: false` run is not.

--- a/claude/skills/standup/SKILL.md
+++ b/claude/skills/standup/SKILL.md
@@ -14,7 +14,7 @@ bash ~/.claude/skills/standup/standup.sh [all|repos|deploys|alerts|state|initiat
 ```
 
 All logic lives in the script (every run identical, token-efficient, correctly attributed). Scopes:
-- **repos** → open PRs; flags only **your** (`ME`) approved-mergeable / red-CI / conflicting ones.
+- **repos** → open PRs **fleet-wide**; flags only **your** (`ME`) approved-mergeable / red-CI / conflicting ones. The repo set is DISCOVERED (`gh search prs --author=@me`) and unioned with the local checkouts, not hard-coded — `STATUS` names the number of repos it swept, and that count is the scope of the verdict. Read it: `across 28 repos` is a fleet claim, `across 9 LOCAL repos only — fleet discovery FAILED` is not, and a degraded run says `Nothing flagged IN WHAT WAS SCANNED` instead of `All clear`.
 - **deploys** → Flagger canaries mid-wave + deployments not fully ready, per cluster.
 - **alerts** → firing alerts **split by `cluster` label** (so the dp-1 multi-cluster fan-in is never misattributed — submodel-GPU alerts don't get blamed on dp-1 prod), with known-noise filtered.
 - **state** → per-repo *working state* (the "where was I" view, distinct from the action queue): branch · ahead/behind origin · dirty-file count · last-commit age+subject · `⚠unpushed`/`⚠wip` flags · a pointer to each repo's `HANDOFF.md`/`STATE.md` if present. **Cross-host:** workbench `REPOS` read locally, the laptop's `LAPTOP_REPOS` (vetr, naida — tagged `(lap)`) over `ssh`; host-aware, works from either host. Informational — not folded into `ACTIONS`.
@@ -27,7 +27,17 @@ Output is **action-first**: a `STATUS` counts line, an `ACTIONS` block (only ite
 - A "deploy not ready" is often a **stuck new rollout** (new ReplicaSet crashlooping while the old one still serves) — confirm with `/verify-deploy` before alarm; prod may be fine on the old pods.
 - `dp-1 ?f` = its Alertmanager was unreachable this run → `/manage-alerts`.
 
+## Reading the PR counts honestly
+- `ready`/`red`/`conflicting` count **your** PRs; `N open` counts everyone's non-draft open PRs in the swept repos. The line says `— yours` for exactly that reason.
+- `≥N repos … counts are a floor` means `gh search prs` hit its cap (`PR_SEARCH_LIMIT`, default 300). Report it as a floor, never as a total.
+- `X unreadable` means that many repos returned a `gh` error. Those repos contributed **zero** to every count — a low number may be the error, not the fleet.
+- GitHub computes `mergeable` lazily: the first read of a stale PR returns `UNKNOWN`, which is neither mergeable nor conflicting, so the `conflicting` count can rise on a second run minutes later. It is a floor too.
+- `ZacxDev/homebrew-tap` is excluded as release-bot noise (31 of 100 hits in one measured run). The exclusion is an enumerated list in `PR_REPO_EXCLUDE`, printed on the `Filtered:` line — an unknown repo is in scope by default.
+- Cost: one `gh search` call plus one `gh pr list` per repo, run `PR_JOBS`-wide (default 6). Measured 2026-08-12: **9–12s for 28 repos**, against 14.5s for the old 9-repo serial scan.
+
 ## Maintaining it
-- Inventory + tunables are the first ~30 lines of `standup.sh`: `REPOS`, `LAP`/`LAPTOP_REPOS` (cross-host state), `CL_NAMES`/`CL_KC`, `ME=ZacxDev`, `HL_PROM`, `NOISE_RE`. Add a repo/cluster there.
+- Inventory + tunables are the first ~60 lines of `standup.sh`: `REPOS` (a **seed** for discovery, not the scope), `LAP`/`LAPTOP_REPOS` (cross-host state), `CL_NAMES`/`CL_KC`, `ME=ZacxDev`, `HL_PROM`, `NOISE_RE`, `PR_SEARCH_LIMIT`/`PR_JOBS`/`PR_REPO_EXCLUDE`. Add a cluster there; repos with an open PR of yours need no entry.
+- 🔴 **Two defects made this print `0 ready, 0 red` while one in-scope repo held 8 flagged PRs — both are pinned by `scripts/tests/test_standup_pr_sweep.py`, so read that before touching the parse.** (1) Flagged rows are separated by **US (0x1f), never tab** — tab is IFS whitespace, so a run of tabs collapses and an empty `reviewDecision` shifted `author` off the end, dropping every unreviewed PR. (2) `statusCheckRollup` mixes `CheckRun.conclusion` with `StatusContext.state`; reading only `.conclusion` made every failing StatusContext look pending.
+- `gh search prs --checks failure` is a useful independent cross-check but is **not** a superset: measured 2026-08-12 it returned 11 where the sweep found 14, missing four PRs whose only failure was a CheckRun. Treat a disagreement as something to look at, not as the sweep being wrong.
 - Runs under **bash** (sidesteps the zsh gotchas), uses `kubectl --request-timeout` / `curl --max-time` (no external `timeout`/`head`), port-forwards the dp-1 ClusterIP Alertmanager briefly. Missing repos/clusters skip gracefully.
 - If a query shape changes, **fix the script and re-run to verify** (it's deterministic) — don't paper over it with prose here.

--- a/claude/skills/standup/standup.sh
+++ b/claude/skills/standup/standup.sh
@@ -11,6 +11,10 @@ set -uo pipefail
 SCOPE="${1:-all}"
 KT="--request-timeout=12s"
 
+# Local checkouts that seed the PR sweep. This is a SEED, not the scope: the
+# sweep also discovers every other repo you have an open PR in (see PR_SEARCH_*),
+# because STATUS makes a fleet claim and must only make one it measured.
+# Overridable (colon-separated) so the tests can drive a throwaway repo set.
 REPOS=(
   /home/zach/workspace/homelab-talos
   /home/zach/workspace/civit/civitai
@@ -22,6 +26,7 @@ REPOS=(
   /home/zach/workspace/promptver
   /home/zach/workspace/baseball-manitoba-pitch
 )
+[ -n "${STANDUP_REPOS:-}" ] && IFS=: read -r -a REPOS <<< "$STANDUP_REPOS"
 # laptop-only repos (reached over ssh for the # state section)
 LAP="zach@10.42.0.100"
 LAPTOP_REPOS=(
@@ -38,6 +43,17 @@ CL_KC=(
 )
 HL_PROM="http://192.168.50.94:30909"
 ME="ZacxDev"   # only PRs authored by you are surfaced as actions
+# --- fleet widening for the PR sweep -----------------------------------------
+# The repo set is DISCOVERED from your open PRs rather than hard-coded, because
+# the skill's own description promises a fleet sweep and a hard-coded list
+# silently under-reports every repo not on it. One search call, then one
+# `gh pr list` per repo (run concurrently, bounded by PR_JOBS).
+PR_SEARCH_LIMIT="${STANDUP_PR_SEARCH_LIMIT:-300}"
+PR_JOBS="${STANDUP_PR_JOBS:-6}"
+# Release-bot repos: high PR volume, no human signal. An explicitly enumerated
+# list (NOT a pattern) — an unknown repo is in scope by default. Printed on the
+# Filtered: line so an excluded repo is never a silent omission.
+PR_REPO_EXCLUDE=(ZacxDev/homebrew-tap)
 # alertnames that are known/expected noise on dp-1 (filtered from criticals)
 NOISE_RE='TargetDown|KubeHpaMaxedOut'
 # initiative ledger (the cross-session "what's in flight" view, telemetry-OFF for
@@ -46,7 +62,8 @@ ISCAN="/home/zach/workspace/devrc/scripts/session-analysis/initiative-scan.py"
 IDAYS=14
 
 ACT=()        # action lines (need a human)
-PR_OPEN=0 PR_READY=0 PR_RED=0
+PR_OPEN=0 PR_READY=0 PR_RED=0 PR_CONFLICT=0
+PR_REPOS=0 PR_ERR=0 PR_SCOPE="not scanned" PR_DISCOVERY="not scanned" PR_TRUNC=0
 DEP_WAVE=0 DEP_STUCK=0
 INIT_ACTIVE=0 INIT_SLOW=0 INIT_STALL=0
 declare -A CRIT          # cluster -> "name,name"
@@ -54,33 +71,129 @@ declare -A FIRING        # cluster -> count
 
 have(){ command -v "$1" >/dev/null 2>&1; }
 
-scan_prs(){
-  have gh && gh auth status >/dev/null 2>&1 || { echo "  (gh not authed — PRs skipped)"; return; }
+# Records are separated by US (0x1f), NOT tab. Tab is an IFS *whitespace*
+# character, so `IFS=$'\t' read` COLLAPSES a run of tabs — an empty
+# `reviewDecision` (the normal state of a PR nobody has reviewed) shifted every
+# later field left by one, leaving `author` empty, so the `author == $ME` test
+# dropped EVERY such PR. That is what printed "0 ready, 0 red" while a single
+# in-scope repo held 8 flagged PRs. 0x1f is not IFS whitespace: empty fields
+# survive. Do not "simplify" this back to \t.
+US=$'\x1f'
+
+# One `gh pr list` per repo. Emits US-separated records on stdout:
+#   COUNT<US><n-open-non-draft>
+#   FLAG<US><num><US><ci><US><mergeable><US><reviewDecision><US><author>
+#   ERR                                  (repo unreadable — never silently 0)
+_pr_scan_repo(){
+  gh pr list -R "$1" --state open --limit 100 \
+    --json number,mergeable,reviewDecision,statusCheckRollup,isDraft,author \
+    --jq '[.[] | select(.isDraft|not)] as $p
+          | "COUNT\u001f\($p|length)",
+            ($p[]
+             | {n:.number, m:(.mergeable//""), r:(.reviewDecision//""), a:(.author.login//""),
+                # statusCheckRollup mixes two node types: a CheckRun carries
+                # `conclusion`, a StatusContext carries `state` and has
+                # conclusion=null. Reading only `.conclusion` made every
+                # StatusContext FAILURE invisible — 5 genuinely-red PRs in one
+                # repo read as "pending". Normalise both into one verdict.
+                ci:([.statusCheckRollup[]? | (.conclusion // .state // "")]
+                    | if any(.=="FAILURE" or .=="ERROR") then "red"
+                      elif length>0 and all(.=="SUCCESS") then "green" else "pending" end)}
+             | select(.ci=="red" or (.r=="APPROVED" and .m=="MERGEABLE") or .m=="CONFLICTING")
+             | "FLAG\u001f\(.n)\u001f\(.ci)\u001f\(.m)\u001f\(.r)\u001f\(.a)")' \
+    2>/dev/null || echo ERR
+}
+
+# Discover every repo with an open PR of yours, minus the enumerated release-bot
+# repos, unioned with the local checkouts. First line is
+# `META<US><ok|failed><US><0|1 truncated>`; every later line is a slug.
+# The metadata rides stdout because the caller reads this through a process
+# substitution — a variable set here would be set in a SUBSHELL and lost, which
+# is exactly how a degraded scan would come back looking like a fleet sweep.
+_pr_repo_set(){
+  local -a local_slugs=()
+  local d url slug
   for d in "${REPOS[@]}"; do
     [ -d "$d/.git" ] || continue
     url=$(git -C "$d" remote get-url origin 2>/dev/null) || continue
     slug=$(printf '%s' "$url" | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')
-    flagged=$(gh pr list -R "$slug" --state open --json number,mergeable,reviewDecision,statusCheckRollup,isDraft,author \
-      --jq '.[] | select(.isDraft|not)
-            | {n:.number, m:.mergeable, r:.reviewDecision, a:.author.login,
-               ci:([.statusCheckRollup[]?.conclusion]
-                   | if any(.=="FAILURE" or .=="ERROR") then "red"
-                     elif length>0 and all(.=="SUCCESS") then "green" else "pending" end)}
-            | select(.ci=="red" or (.r=="APPROVED" and .m=="MERGEABLE") or .m=="CONFLICTING")
-            | "\(.n)\t\(.ci)\t\(.m)\t\(.r)\t\(.a)"' 2>/dev/null) || { echo "  $slug: skipped (gh err)"; continue; }
-    n=$(gh pr list -R "$slug" --state open --json number --jq 'length' 2>/dev/null || echo 0)
-    PR_OPEN=$((PR_OPEN+n))
-    [ -z "$flagged" ] && continue
-    while IFS=$'\t' read -r num ci m r author; do
-      [ -z "$num" ] && continue
-      [ "$author" = "$ME" ] || continue   # only YOUR PRs count + action (others aren't your concern)
-      [ "$ci" = "red" ] && PR_RED=$((PR_RED+1))
-      { [ "$r" = "APPROVED" ] && [ "$m" = "MERGEABLE" ]; } && PR_READY=$((PR_READY+1))
-      if [ "$r" = "APPROVED" ] && [ "$m" = "MERGEABLE" ]; then ACT+=("$slug PR #$num approved+mergeable → merge"); fi
-      if [ "$ci" = "red" ]; then ACT+=("$slug PR #$num red CI → fix (civitai report-only previews are known-noise)"); fi
-      if [ "$m" = "CONFLICTING" ]; then ACT+=("$slug PR #$num conflicting → rebase"); fi
-    done <<< "$flagged"
+    [ -n "$slug" ] && local_slugs+=("$slug")
   done
+  local found rc disc=ok trunc=0
+  found=$(gh search prs --author=@me --state=open --limit "$PR_SEARCH_LIMIT" \
+            --json repository --jq '.[].repository.nameWithOwner' 2>/dev/null); rc=$?
+  if [ "$rc" -ne 0 ]; then
+    disc=failed; found=""
+  elif [ "$(printf '%s\n' "$found" | grep -c .)" -ge "$PR_SEARCH_LIMIT" ]; then
+    trunc=1
+  fi
+  printf 'META%s%s%s%s\n' "$US" "$disc" "$US" "$trunc"
+  { printf '%s\n' "${local_slugs[@]}"; printf '%s\n' "$found"; } | grep . | sort -u \
+    | while read -r slug; do
+        local skip=0 x
+        for x in "${PR_REPO_EXCLUDE[@]}"; do [ "$slug" = "$x" ] && skip=1; done
+        [ "$skip" = 0 ] && printf '%s\n' "$slug"
+      done
+}
+
+scan_prs(){
+  have gh && gh auth status >/dev/null 2>&1 || { echo "  (gh not authed — PRs skipped)"; PR_SCOPE="gh unavailable"; return; }
+  local -a slugs=()
+  local f1 f2 f3
+  PR_DISCOVERY=failed PR_TRUNC=0
+  while IFS="$US" read -r f1 f2 f3; do
+    if [ "$f1" = META ]; then PR_DISCOVERY="$f2"; PR_TRUNC="${f3:-0}"; continue; fi
+    [ -n "$f1" ] && slugs+=("$f1")
+  done < <(_pr_repo_set)
+  PR_REPOS=${#slugs[@]}
+  [ "$PR_REPOS" = 0 ] && { echo "  (no repos resolved — PRs skipped)"; PR_SCOPE="no repos resolved"; return; }
+
+  # fan out, bounded — one gh call per repo, results to per-repo files so the
+  # parent (not a subshell) does the accumulating.
+  local tmpd; tmpd=$(mktemp -d) || return
+  local -a pids=()
+  local i
+  for i in "${!slugs[@]}"; do
+    _pr_scan_repo "${slugs[$i]}" > "$tmpd/$i.out" &
+    pids+=($!)
+    if [ "${#pids[@]}" -ge "$PR_JOBS" ]; then wait "${pids[0]}" 2>/dev/null; pids=("${pids[@]:1}"); fi
+  done
+  wait
+
+  local kind num ci m r author
+  for i in "${!slugs[@]}"; do
+    slug="${slugs[$i]}"
+    [ -f "$tmpd/$i.out" ] || continue
+    while IFS="$US" read -r kind num ci m r author; do
+      case "$kind" in
+        COUNT) PR_OPEN=$((PR_OPEN + num)) ;;
+        ERR)   echo "  $slug: skipped (gh err)"; PR_ERR=$((PR_ERR+1)) ;;
+        FLAG)
+          [ "$author" = "$ME" ] || continue   # only YOUR PRs count + action (others aren't your concern)
+          if [ "$ci" = "red" ]; then
+            PR_RED=$((PR_RED+1))
+            ACT+=("$slug PR #$num red CI → fix (civitai report-only previews are known-noise)")
+          fi
+          if [ "$r" = "APPROVED" ] && [ "$m" = "MERGEABLE" ]; then
+            PR_READY=$((PR_READY+1))
+            ACT+=("$slug PR #$num approved+mergeable → merge")
+          fi
+          if [ "$m" = "CONFLICTING" ]; then
+            PR_CONFLICT=$((PR_CONFLICT+1))
+            ACT+=("$slug PR #$num conflicting → rebase")
+          fi
+          ;;
+      esac
+    done < "$tmpd/$i.out"
+  done
+  rm -rf "$tmpd"
+
+  # Scope string for STATUS — it must describe what was ACTUALLY measured.
+  PR_SCOPE="$PR_REPOS repos"
+  [ "$PR_TRUNC" = 1 ] && PR_SCOPE="≥$PR_REPOS repos (search capped at $PR_SEARCH_LIMIT — counts are a floor)"
+  [ "$PR_DISCOVERY" = failed ] && PR_SCOPE="$PR_REPOS LOCAL repos only — fleet discovery FAILED"
+  [ "$PR_ERR" -gt 0 ] && PR_SCOPE="$PR_SCOPE, $PR_ERR unreadable"
+  echo "  scanned $PR_REPOS repos ($PR_OPEN open PRs; ${PR_RED} red / ${PR_READY} ready / ${PR_CONFLICT} conflicting are yours)"
 }
 
 scan_deploys(){
@@ -278,11 +391,19 @@ fi
 echo
 INIT_STATUS=""
 { [ "$SCOPE" = all ] || [ "$SCOPE" = initiatives ]; } && INIT_STATUS=" · Initiatives ${INIT_ACTIVE}a/${INIT_SLOW}s/${INIT_STALL}st"
-echo "STATUS: PRs ${PR_OPEN} open (${PR_READY} ready, ${PR_RED} red) · Deploys ${DEP_WAVE} mid-wave/${DEP_STUCK} stuck · Alerts ${ALERT_LINE:-n/a}${INIT_STATUS}"
+PR_STATUS="PRs ${PR_OPEN} open across ${PR_SCOPE} (${PR_READY} ready, ${PR_RED} red, ${PR_CONFLICT} conflicting — yours)"
+{ [ "$SCOPE" = all ] || [ "$SCOPE" = repos ]; } || PR_STATUS="PRs not scanned"
+echo "STATUS: ${PR_STATUS} · Deploys ${DEP_WAVE} mid-wave/${DEP_STUCK} stuck · Alerts ${ALERT_LINE:-n/a}${INIT_STATUS}"
 if [ "${#ACT[@]}" -gt 0 ]; then
   echo "ACTIONS"
   printf '  - %s\n' "${ACT[@]}"
+elif [ "$PR_ERR" -gt 0 ] || [ "$PR_DISCOVERY" = failed ]; then
+  # Never print an unqualified all-clear off a scan that could not see everything.
+  echo "Nothing flagged IN WHAT WAS SCANNED — coverage was degraded (${PR_SCOPE})."
 else
-  echo "All clear — nothing needs you."
+  # ONE branch, and it always names the scope: a `standup.sh alerts` run that
+  # printed a bare "All clear" would be claiming something about the four
+  # sections it never looked at. One path so the phrase is testable.
+  echo "All clear in scope '$SCOPE' — nothing needs you."
 fi
-echo "Filtered: dp-1 fan-in split by cluster · known-noise (${NOISE_RE//|/, }) · KubeJobFailed=accumulated history · submodel-GPU disk = not prod"
+echo "Filtered: dp-1 fan-in split by cluster · known-noise (${NOISE_RE//|/, }) · release-bot repos (${PR_REPO_EXCLUDE[*]}) · KubeJobFailed=accumulated history · submodel-GPU disk = not prod"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -413,7 +413,18 @@ TARGET_FLOORS=(
   # main (now carrying the line above) + this branch. Same method — the gate's
   # measurement of the MERGED tree, not arithmetic across the conflict:
   #   _suggested_floor 2535 = 2535 - min(50, max(1, 126)) = 2485.
-  "scripts/tests|2485"
+  #
+  # 2026-08-12, the standup fleet-scope fix: 2535 -> 2551 collected, +16 for
+  # scripts/tests/test_standup_pr_sweep.py. Same method as every line above —
+  # the AUTHORITATIVE gate's own printed count (`nix build
+  # .#checks.x86_64-linux.pytests` -> `collected=2551`) put through the gate's
+  # own function, NOT arithmetic across a conflict:
+  #   _suggested_floor 2551 = 2551 - min(50, max(1, 127)) = 2551 - 50 = 2501.
+  # ⚠ The new file must be `git add`ed before that measurement means anything:
+  # the first gate run here reported the OLD 2535 because an untracked test is
+  # silently absent from the flake source. If this line conflicts with another
+  # branch, re-run the gate on the MERGED tree and copy what it prints.
+  "scripts/tests|2501"
   # 2026-08-11, the session-summary changed-paths work: 230 -> 273 collected,
   # +43 for scripts/collector/tests/test_changed_paths.py (the shared
   # `changed_paths*` module). The gate printed this replacement itself —
@@ -439,7 +450,11 @@ TARGET_FLOORS=(
   "scripts/dl-router/tests|942"
   "scripts/browser-bridge/tests|469"
   "scripts/validation/tests|97"
-  "scripts/session-analysis/tests|362"
+  # 2026-08-12, initiative-scan's `gh_available` honesty flag: 381 -> 386
+  # collected, +5 for the flag's probe/report/render cases in
+  # test_initiative_scan.py. Gate's own count through the gate's own rule:
+  #   _suggested_floor 386 = 386 - min(50, max(1, 19)) = 386 - 19 = 367.
+  "scripts/session-analysis/tests|367"
   "scripts/session-analysis/session_insight/tests|55"
   "scripts/mail-actions/tests|129"
   "scripts/initiatives/tests|745"

--- a/scripts/session-analysis/initiative-scan.py
+++ b/scripts/session-analysis/initiative-scan.py
@@ -73,6 +73,7 @@ import glob
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -1449,6 +1450,24 @@ def git_recent_commit_subjects(repo: str, branch: str, since_days: int,
     return res[:limit]
 
 
+def gh_available() -> bool:
+    """Can we read PRs at all?
+
+    `gh_open_prs`/`gh_merged_prs` return `[]` on ANY failure, so a repo with no
+    open PRs and a host where `gh` is absent or unauthenticated produce the
+    IDENTICAL `open_prs: []`. That ambiguity is reported (not resolved) via the
+    report's `gh_available` flag: with it False, every PR field in the report is
+    "not wired up here", not "measured zero". One probe per report.
+    """
+    if not shutil.which("gh"):
+        return False
+    try:
+        return subprocess.run(["gh", "auth", "status"], capture_output=True,
+                              timeout=15).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
 def gh_open_prs(repo: str) -> list[dict]:
     """OPEN PRs as [{number, title, headRefName}] — empty on any failure."""
     out = _run([
@@ -2246,13 +2265,16 @@ def attribute_git(initiatives: list[dict], days: int) -> None:
 def build_report(days: int, repos: list[str] | None = None,
                  client=None, projects_root: str = PROJECTS_ROOT,
                  now: float | None = None, include_tmux: bool = False,
-                 panes: list[dict] | None = None) -> dict:
+                 panes: list[dict] | None = None,
+                 gh_ok: bool | None = None) -> dict:
     """Fuse the three sources into a ranked, per-repo report dict.
 
     `client` may be None (telemetry skipped). `repos` None -> auto-discover from the
     session/telemetry cwds + doc globs (session-first discovery). `include_tmux` links
     live tmux sessions to initiatives; `panes` overrides the live `collect_tmux_panes()`
-    read (for tests / reproducibility).
+    read (for tests / reproducibility). `gh_ok` overrides the `gh_available()` probe
+    the same way — a test that stubs `gh_open_prs` must state which world it is in,
+    rather than letting the report's honesty flag depend on the host running it.
     """
     now_epoch = now if now is not None else time.time()
 
@@ -2359,6 +2381,10 @@ def build_report(days: int, repos: list[str] | None = None,
     return {
         "days": days,
         "telemetry_available": telemetry_available,
+        # Says which zeroes are MEASURED and which are "not wired up here":
+        # False means every `open_prs: []` / `merged_prs: 0` in this report is
+        # an absence of data, not an absence of PRs.
+        "gh_available": gh_available() if gh_ok is None else bool(gh_ok),
         "tmux_enabled": tmux_active,
         "tmux_unmatched": tmux_unmatched,
         "repos": repos,
@@ -2487,6 +2513,9 @@ def render(report: dict, now: float | None = None) -> str:
     if not report["telemetry_available"]:
         out.append("\n(NOTE: telemetry OFF — CLICKHOUSE_* unset or unreachable. "
                    "Momentum/recency here come from commits + sessions + handoff mtime only.)")
+    if report.get("gh_available") is False:
+        out.append("\n(NOTE: gh UNAVAILABLE — every 'open PR' / 'merged PR' figure above is "
+                   "NOT MEASURED, not zero. Authenticate `gh` to get real PR counts.)")
     return "\n".join(out)
 
 

--- a/scripts/session-analysis/tests/test_initiative_scan.py
+++ b/scripts/session-analysis/tests/test_initiative_scan.py
@@ -698,9 +698,13 @@ def test_build_report_end_to_end_no_telemetry(tmp_path, monkeypatch):
     monkeypatch.setattr(isc, "collect_session_records", lambda root, d, n=5: [sess])
 
     now = 2_000.0  # last_commit at 1000 -> age 1000s -> active
-    report = isc.build_report(2, repos=[str(repo)], client=None, now=now)
+    # gh_ok is stated, not probed: the PR figures below come from the stub, so the
+    # report's honesty flag must not depend on whether the HOST running the test
+    # happens to have an authenticated `gh`.
+    report = isc.build_report(2, repos=[str(repo)], client=None, now=now, gh_ok=True)
 
     assert report["telemetry_available"] is False
+    assert report["gh_available"] is True
     inis = report["by_repo"][str(repo)]
     assert len(inis) == 1
     ini = inis[0]
@@ -733,11 +737,81 @@ def test_render_emits_trunk_catchall(monkeypatch, tmp_path):
         def rows(self, sql):
             return [{"branch": "main", "cwd": str(repo), "n": 99, "last_ts": "2026-06-30 10:00:00"}]
 
-    report = isc.build_report(14, repos=[str(repo)], client=FakeClient(), now=2_000_000_000.0)
+    report = isc.build_report(14, repos=[str(repo)], client=FakeClient(),
+                              now=2_000_000_000.0, gh_ok=True)
     assert report["telemetry_available"] is True
     txt = isc.render(report, now=2_000_000_000.0)
     assert "unsegmented trunk/main work" in txt
     assert "ev:99" in txt
+
+
+# --------------------------------------------------------------------------- #
+# `gh_available` — telling a MEASURED zero apart from a missing measurement.
+#
+# `gh_open_prs` returns [] on any failure, so `open_prs: []` on a host without an
+# authenticated `gh` is byte-identical to "this initiative genuinely has no open
+# PRs". A blind dogfood run read `open_prs: []` + `commits: 0` across ~33 "active"
+# initiatives and had nothing in the output telling it which of those zeroes were
+# real. The flag does not fix the ambiguity — it REPORTS it.
+# --------------------------------------------------------------------------- #
+def _tiny_report(monkeypatch, tmp_path, **kw):
+    repo = tmp_path / "ghflag"
+    (repo / "claudedocs").mkdir(parents=True)
+    (repo / "claudedocs" / "handoff-thing.md").write_text(
+        "# Handoff: thing\n## Next steps\n1. go\n")
+    monkeypatch.setattr(isc, "git_branches", lambda r: ["main"])
+    monkeypatch.setattr(isc, "git_default_branch", lambda r: "main")
+    monkeypatch.setattr(isc, "gh_open_prs", lambda r: [])
+    monkeypatch.setattr(isc, "gh_merged_prs", lambda r, d: [])
+    monkeypatch.setattr(isc, "collect_session_records", lambda root, d, n=5: [])
+    return isc.build_report(14, repos=[str(repo)], client=None,
+                            now=2_000_000_000.0, **kw)
+
+
+def test_report_carries_gh_available_true(monkeypatch, tmp_path):
+    """POSITIVE side of the pair — the flag must be able to read True."""
+    report = _tiny_report(monkeypatch, tmp_path, gh_ok=True)
+    assert report["gh_available"] is True
+    assert "gh UNAVAILABLE" not in isc.render(report, now=2_000_000_000.0)
+
+
+def test_report_carries_gh_available_false_and_says_so(monkeypatch, tmp_path):
+    """NEGATIVE side — and the rendered report must SAY the PR figures are not
+    measurements, or the flag only helps a reader who already knew to look."""
+    report = _tiny_report(monkeypatch, tmp_path, gh_ok=False)
+    assert report["gh_available"] is False
+    txt = isc.render(report, now=2_000_000_000.0)
+    assert "gh UNAVAILABLE" in txt
+    assert "NOT MEASURED, not zero" in txt
+
+
+def test_gh_available_probe_is_false_without_gh_on_path(monkeypatch):
+    """The default (unstubbed) probe must be able to answer False for real."""
+    monkeypatch.setattr(isc.shutil, "which", lambda name: None)
+    assert isc.gh_available() is False
+
+
+def test_gh_available_probe_is_false_when_auth_fails(monkeypatch):
+    """`gh` present but unauthenticated is exactly the case that produced the
+    ambiguous `[]` — it must not read as available."""
+    monkeypatch.setattr(isc.shutil, "which", lambda name: "/usr/bin/gh")
+
+    class R:
+        returncode = 1
+
+    monkeypatch.setattr(isc.subprocess, "run", lambda *a, **k: R())
+    assert isc.gh_available() is False
+
+
+def test_gh_available_probe_is_true_when_authed(monkeypatch):
+    """Positive control for the probe itself: it can also return True."""
+    monkeypatch.setattr(isc.shutil, "which", lambda name: "/usr/bin/gh")
+
+    class R:
+        returncode = 0
+
+    monkeypatch.setattr(isc.subprocess, "run", lambda *a, **k: R())
+    assert isc.gh_available() is True
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_standup_pr_sweep.py
+++ b/scripts/tests/test_standup_pr_sweep.py
@@ -1,0 +1,446 @@
+"""Behavioural tests for `claude/skills/standup/standup.sh`'s PR sweep.
+
+Everything runs against THROWAWAY git repos in tmp_path and a STUB `gh` on
+PATH. Nothing here touches ~/workspace, GitHub, or any cluster.
+
+WHY THIS SUITE EXISTS
+---------------------
+standup's STATUS line printed `PRs 70 open (0 ready, 0 red)` — a fleet verdict
+with two reassuring zeroes. Both were WRONG, and neither was wrong because the
+repo list was short. Two independent defects manufactured them:
+
+  1. FIELD SHIFT. The flagged-PR rows were tab-separated and read with
+     `IFS=$'\\t' read`. Tab is an IFS *whitespace* character, so a run of tabs
+     collapses into one delimiter: a PR with an empty `reviewDecision` — the
+     normal state of anything nobody has reviewed yet — shifted every later
+     field left, leaving `author` empty, so the `author == $ME` filter dropped
+     it. Measured 2026-08-12: `civitai/talos-infra` alone emitted 8 flagged
+     rows and every one was discarded.
+  2. HALF THE CHECK RESULTS WERE UNREADABLE. `statusCheckRollup` mixes two node
+     types — a CheckRun carries `conclusion`, a StatusContext carries `state`
+     and has `conclusion: null`. The rollup read only `.conclusion`, so a
+     failing StatusContext scored as "pending". Measured the same day: 5
+     genuinely-red PRs in one repo read as green-ish.
+
+A count that cannot rise is indistinguishable from a scan wired to nothing, so
+the load-bearing tests here are the ones that make it RISE:
+
+  * `test_control_pair_red_moves_zero_to_two` is the positive/negative control.
+    It runs the SAME code over a clean fixture and a broken one and asserts the
+    number moves. A bare "it reported 0" proves nothing about either.
+  * Each defect above has its own test, built so the OTHER defect cannot mask
+    it: the field-shift case uses an empty reviewDecision with a CheckRun
+    FAILURE; the StatusContext case uses a NON-empty reviewDecision so it stays
+    red for its own reason even when the separator is wrong.
+  * `test_status_states_the_scope_it_measured` pins the fleet claim itself. The
+    STATUS line has to name the repo count it actually swept.
+  * Degradation must be LOUD: a failed discovery call or an unreadable repo may
+    never render as "All clear — nothing needs you."
+
+`STANDUP_SH` (env) overrides the script under test — that is how the red half
+of the matrix was taken, by pointing it at the pre-change file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from testlib.mockbin import write_exec  # noqa: E402
+
+STANDUP = Path(os.environ.get(
+    "STANDUP_SH", REPO_ROOT / "claude" / "skills" / "standup" / "standup.sh"))
+
+pytestmark = pytest.mark.skipif(
+    not all(shutil.which(b) for b in ("bash", "git", "jq")),
+    reason="needs bash + git + jq on PATH",
+)
+
+# The stub `gh`. It answers exactly the three calls standup makes and applies
+# the REAL jq expression standup passes, so the script's own jq program — where
+# both defects lived — is what runs. A stub that pre-baked the records would
+# test the stub.
+GH_STUB = r"""
+set -u
+fixdir="$GH_FIXTURES"
+sub1="${1:-}"; sub2="${2:-}"
+shift 2 2>/dev/null || true
+repo=""; jqexpr=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -R|--repo) repo="${2:-}"; shift 2 ;;
+    -q|--jq)   jqexpr="${2:-}"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$sub1 $sub2" in
+  "auth status") exit 0 ;;
+  "search prs")
+    [ -n "${GH_FAIL_SEARCH:-}" ] && exit 1
+    jq -r "$jqexpr" "$fixdir/search.json" ;;
+  "pr list")
+    case " ${GH_FAIL_REPOS:-} " in *" $repo "*) exit 1 ;; esac
+    f="$fixdir/$(printf '%s' "$repo" | sed 's#/#__#g').json"
+    [ -f "$f" ] || f="$fixdir/__empty.json"
+    jq -r "$jqexpr" "$f" ;;
+  *) exit 1 ;;
+esac
+"""
+
+
+def pr(number, *, author="ZacxDev", review="", mergeable="MERGEABLE",
+       draft=False, checks=()):
+    """One `gh pr list --json ...` element.
+
+    `checks` items are ("CheckRun", conclusion) or ("StatusContext", state) —
+    the two node shapes GitHub actually returns in statusCheckRollup.
+    """
+    rollup = []
+    for kind, verdict in checks:
+        if kind == "CheckRun":
+            rollup.append({"__typename": "CheckRun", "conclusion": verdict,
+                           "status": "COMPLETED"})
+        else:
+            rollup.append({"__typename": "StatusContext", "conclusion": None,
+                           "state": verdict})
+    return {"number": number, "mergeable": mergeable,
+            "reviewDecision": review, "statusCheckRollup": rollup,
+            "isDraft": draft, "author": {"login": author}}
+
+
+class Harness:
+    """A standup PR sweep wired to fixtures instead of GitHub."""
+
+    def __init__(self, tmp_path):
+        self.root = tmp_path
+        self.bin = tmp_path / "bin"
+        self.fix = tmp_path / "fix"
+        self.bin.mkdir(parents=True, exist_ok=True)
+        self.fix.mkdir(parents=True, exist_ok=True)
+        (self.fix / "__empty.json").write_text("[]", encoding="utf-8")
+        (self.fix / "search.json").write_text("[]", encoding="utf-8")
+        write_exec(self.bin / "gh", GH_STUB)
+        self.local: list[Path] = []
+        self.env_extra: dict[str, str] = {}
+
+    def repo(self, slug, prs, *, local=False):
+        """Register a repo's open-PR fixture; `local` also makes a checkout."""
+        (self.fix / (slug.replace("/", "__") + ".json")).write_text(
+            json.dumps(prs), encoding="utf-8")
+        if local:
+            d = self.root / "repos" / slug.replace("/", "__")
+            d.mkdir(parents=True, exist_ok=True)
+            subprocess.run(["git", "init", "-q", str(d)], check=True)
+            subprocess.run(["git", "-C", str(d), "remote", "add", "origin",
+                            f"https://github.com/{slug}.git"], check=True)
+            self.local.append(d)
+        return self
+
+    def discovered(self, *slugs):
+        """What `gh search prs --author=@me` reports (one row per open PR)."""
+        (self.fix / "search.json").write_text(
+            json.dumps([{"repository": {"nameWithOwner": s}} for s in slugs]),
+            encoding="utf-8")
+        return self
+
+    def run(self, **env_extra):
+        env = dict(os.environ)
+        env["PATH"] = f"{self.bin}:{env['PATH']}"
+        env["GH_FIXTURES"] = str(self.fix)
+        # ":"-joined, and never empty — an empty STANDUP_REPOS would fall back
+        # to the real hard-coded checkouts and leave the sandbox.
+        env["STANDUP_REPOS"] = ":".join(str(p) for p in self.local) or str(
+            self.root / "no-such-repo")
+        env.update(self.env_extra)
+        env.update(env_extra)
+        r = subprocess.run(["bash", str(STANDUP), "repos"], env=env,
+                           capture_output=True, text=True, timeout=180)
+        assert "STATUS:" in r.stdout, f"no STATUS line:\n{r.stdout}\n{r.stderr}"
+        return r.stdout
+
+    @staticmethod
+    def status(out):
+        return next(ln for ln in out.splitlines() if ln.startswith("STATUS:"))
+
+    @staticmethod
+    def counts(out):
+        """(ready, red, conflicting) as the STATUS line reports them.
+
+        Only for tests that are ABOUT the STATUS line. Behavioural tests use
+        `acted()` instead: it reads the ACTIONS block, whose wording predates
+        this change, so a red result there is evidence about the DEFECT rather
+        than about the status format having moved.
+        """
+        import re
+        m = re.search(r"\((\d+) ready, (\d+) red, (\d+) conflicting",
+                      Harness.status(out))
+        assert m, f"STATUS did not carry the three counts: {Harness.status(out)}"
+        return tuple(int(g) for g in m.groups())
+
+    @staticmethod
+    def acted(out, kind):
+        """How many ACTIONS lines of `kind` ('red CI', 'conflicting',
+        'approved+mergeable') the sweep emitted. Format-independent."""
+        return sum(1 for ln in out.splitlines()
+                   if ln.lstrip().startswith("- ") and kind in ln)
+
+
+@pytest.fixture()
+def h(tmp_path):
+    return Harness(tmp_path)
+
+
+# --------------------------------------------------------------------------
+# The control pair. Everything else is only meaningful next to this.
+# --------------------------------------------------------------------------
+
+def test_control_pair_red_moves_zero_to_two(tmp_path):
+    """NEGATIVE control then POSITIVE control, same code, same shape of input.
+
+    A green repo must report 0 red; swapping in two genuinely-failing PRs must
+    make that number MOVE. Reporting only one half of this pair is how a
+    counter wired to nothing passes for a measurement.
+    """
+    clean = Harness(tmp_path / "clean")
+    clean.repo("acme/widgets", [
+        pr(1, checks=[("CheckRun", "SUCCESS")]),
+        pr(2, checks=[("StatusContext", "SUCCESS")]),
+    ], local=True).discovered("acme/widgets")
+    zero = Harness.acted(clean.run(), "red CI")
+
+    broken = Harness(tmp_path / "broken")
+    broken.repo("acme/widgets", [
+        pr(1, checks=[("CheckRun", "FAILURE")]),
+        pr(2, checks=[("StatusContext", "FAILURE")]),
+    ], local=True).discovered("acme/widgets")
+    moved = Harness.acted(broken.run(), "red CI")
+
+    assert zero == 0, f"negative control was not zero: {zero} red actions"
+    assert moved == 2, f"positive control did not reach 2: {moved} red actions"
+
+
+# --------------------------------------------------------------------------
+# Defect 1 — the tab collapse. Empty reviewDecision must not eat the author.
+# --------------------------------------------------------------------------
+
+def test_flagged_pr_with_empty_review_decision_is_counted(h):
+    """The exact shape that produced the false zeroes.
+
+    Empty `reviewDecision` + a real CheckRun FAILURE + CONFLICTING. Under the
+    tab-separated parse the author field came back empty and the row was
+    dropped by the `author == $ME` filter, so this reported 0 red.
+    """
+    h.repo("acme/widgets", [
+        pr(7, review="", mergeable="CONFLICTING",
+           checks=[("CheckRun", "FAILURE")]),
+    ], local=True).discovered("acme/widgets")
+    out = h.run()
+    # Assert the ACTIONS first: that wording is unchanged by this PR, so a red
+    # here is the DEFECT, not the STATUS format moving under the test.
+    assert "acme/widgets PR #7 red CI" in out, out
+    assert "acme/widgets PR #7 conflicting" in out, out
+    assert Harness.counts(out)[1:] == (1, 1), Harness.status(out)
+
+
+def test_author_filter_still_excludes_other_peoples_prs(h):
+    """The field-shift fix must not be a blanket 'count everything'.
+
+    Someone else's red PR is not yours to act on — if this went green whatever
+    the author, the fix would just be the old bug inverted.
+
+    INVARIANT GUARD, not a regression test: the pre-change script also dropped
+    this row (for the wrong reason — it dropped everything). It is here so the
+    fix cannot be "delete the author filter".
+    """
+    h.repo("acme/widgets", [
+        pr(8, author="someone-else", review="", mergeable="CONFLICTING",
+           checks=[("CheckRun", "FAILURE")]),
+    ], local=True).discovered("acme/widgets")
+    out = h.run()
+    assert Harness.acted(out, "red CI") == 0, out
+    assert "#8" not in out
+
+
+# --------------------------------------------------------------------------
+# Defect 2 — StatusContext results were invisible.
+# --------------------------------------------------------------------------
+
+def test_status_context_failure_counts_as_red(h):
+    """A failing StatusContext is red.
+
+    `reviewDecision` is deliberately NON-empty so this case does not depend on
+    the separator fix: it must be red for its own reason, or it would go green
+    for the wrong one.
+    """
+    h.repo("acme/widgets", [
+        pr(9, review="CHANGES_REQUESTED", mergeable="MERGEABLE",
+           checks=[("StatusContext", "FAILURE")]),
+    ], local=True).discovered("acme/widgets")
+    out = h.run()
+    assert "acme/widgets PR #9 red CI" in out, out
+    assert Harness.counts(out)[1] == 1, Harness.status(out)
+
+
+def test_status_context_error_counts_as_red(h):
+    """ERROR is the other failing StatusContext state GitHub emits."""
+    h.repo("acme/widgets", [
+        pr(10, review="CHANGES_REQUESTED",
+           checks=[("StatusContext", "ERROR")]),
+    ], local=True).discovered("acme/widgets")
+    out = h.run()
+    assert "acme/widgets PR #10 red CI" in out, out
+
+
+def test_in_progress_check_run_is_not_red(h):
+    """An in-flight CheckRun has an empty conclusion — that is pending, not red.
+
+    The `// .state // ""` fallback must not turn "still running" into a
+    failure; over-flagging burns the operator's trust as fast as under-flagging.
+    INVARIANT GUARD — the pre-change script also called this pending.
+    """
+    h.repo("acme/widgets", [
+        pr(11, review="CHANGES_REQUESTED", checks=[("CheckRun", "")]),
+    ], local=True).discovered("acme/widgets")
+    assert Harness.acted(h.run(), "red CI") == 0
+
+
+def test_approved_and_mergeable_is_ready(h):
+    """The `ready` counter must also be able to leave zero.
+
+    Mixed: the ACTIONS assertion is an INVARIANT GUARD (an APPROVED PR has a
+    non-empty reviewDecision, so the tab collapse never reached it and the
+    pre-change script emitted this line too). Only the STATUS assertion is new.
+    Counted as coverage of the ready path, not as regression evidence.
+    """
+    h.repo("acme/widgets", [
+        pr(12, review="APPROVED", mergeable="MERGEABLE",
+           checks=[("CheckRun", "SUCCESS")]),
+    ], local=True).discovered("acme/widgets")
+    out = h.run()
+    assert "PR #12 approved+mergeable" in out, out
+    assert Harness.counts(out)[0] == 1, Harness.status(out)
+
+
+# --------------------------------------------------------------------------
+# The fleet claim itself.
+# --------------------------------------------------------------------------
+
+def test_status_states_the_scope_it_measured(h):
+    """STATUS may not assert a fleet fact without naming what it swept."""
+    h.repo("acme/widgets", [pr(1, checks=[("CheckRun", "SUCCESS")])],
+           local=True).discovered("acme/widgets")
+    assert "across 1 repos" in Harness.status(h.run())
+
+
+def test_widened_scan_reaches_a_repo_with_no_local_checkout(h):
+    """The whole point of Unit C: a repo you have no clone of is still swept."""
+    h.repo("acme/widgets", [pr(1, checks=[("CheckRun", "SUCCESS")])],
+           local=True)
+    h.repo("acme/remote-only", [
+        pr(42, review="CHANGES_REQUESTED", checks=[("CheckRun", "FAILURE")]),
+    ])  # NOT local — only discoverable via search
+    h.discovered("acme/widgets", "acme/remote-only")
+    out = h.run()
+    assert "acme/remote-only PR #42 red CI" in out, out
+    assert "across 2 repos" in Harness.status(out)
+
+
+def test_release_bot_repo_is_excluded_and_named(h):
+    """homebrew-tap swamps the signal; excluding it silently would be worse."""
+    h.repo("acme/widgets", [pr(1, checks=[("CheckRun", "SUCCESS")])],
+           local=True)
+    h.repo("ZacxDev/homebrew-tap", [
+        pr(n, review="CHANGES_REQUESTED", checks=[("CheckRun", "FAILURE")])
+        for n in range(100, 130)
+    ])
+    h.discovered("acme/widgets", "ZacxDev/homebrew-tap")
+    out = h.run()
+    assert Harness.acted(out, "red CI") == 0, out
+    assert "across 1 repos" in Harness.status(out)
+    assert "ZacxDev/homebrew-tap" in next(
+        ln for ln in out.splitlines() if ln.startswith("Filtered:"))
+
+
+def test_drafts_are_not_counted_as_open(h):
+    h.repo("acme/widgets", [
+        pr(1, checks=[("CheckRun", "SUCCESS")]),
+        pr(2, draft=True, checks=[("CheckRun", "FAILURE")]),
+    ], local=True).discovered("acme/widgets")
+    out = h.run()
+    assert "PRs 1 open" in Harness.status(out)
+    assert Harness.acted(out, "red CI") == 0
+
+
+# --------------------------------------------------------------------------
+# Degradation must be loud. These are the anti-silent-zero tests.
+# --------------------------------------------------------------------------
+
+def test_failed_discovery_never_reads_as_all_clear(h):
+    """If the fleet sweep could not run, STATUS may not imply it did."""
+    h.repo("acme/widgets", [pr(1, checks=[("CheckRun", "SUCCESS")])],
+           local=True)
+    out = h.run(GH_FAIL_SEARCH="1")
+    assert "fleet discovery FAILED" in Harness.status(out)
+    assert "LOCAL repos only" in Harness.status(out)
+    # "All clear" in ANY spelling, not one exact sentence — a guard that pins a
+    # phrase passes the moment someone rewords the reassurance.
+    assert "All clear" not in out
+    assert "coverage was degraded" in out
+
+
+def test_unreadable_repo_is_reported_not_silently_zero(h):
+    h.repo("acme/widgets", [pr(1, checks=[("CheckRun", "SUCCESS")])],
+           local=True)
+    h.repo("acme/locked", [])
+    h.discovered("acme/widgets", "acme/locked")
+    out = h.run(GH_FAIL_REPOS="acme/locked")
+    assert "acme/locked: skipped (gh err)" in out
+    assert "1 unreadable" in Harness.status(out)
+    assert "All clear" not in out
+
+
+def test_truncated_search_reports_a_floor_not_a_total(h):
+    """At the search cap the repo set is a floor; STATUS has to say so."""
+    h.repo("acme/widgets", [pr(1, checks=[("CheckRun", "SUCCESS")])],
+           local=True)
+    h.repo("acme/second", [])
+    h.discovered("acme/widgets", "acme/second")
+    st = Harness.status(h.run(STANDUP_PR_SEARCH_LIMIT="2"))
+    assert "≥" in st and "floor" in st, st
+
+
+def test_clean_fleet_says_all_clear_and_names_the_scope(h):
+    """Positive control for the all-clear path itself: when coverage really was
+    complete and nothing is flagged, the reassuring line is allowed — but it
+    still names the scope, because a `repos` run says nothing about alerts."""
+    h.repo("acme/widgets", [pr(1, checks=[("CheckRun", "SUCCESS")])],
+           local=True).discovered("acme/widgets")
+    out = h.run()
+    assert "All clear in scope 'repos' — nothing needs you." in out
+
+
+# --------------------------------------------------------------------------
+# Structural: the separator must not regress to a whitespace one.
+# --------------------------------------------------------------------------
+
+def test_record_separator_is_not_ifs_whitespace():
+    """Pins the mechanism, not the spelling of one fix.
+
+    A future edit that "simplifies" the records back to tab/space reintroduces
+    the field shift, and every behavioural test above would have to be read
+    carefully to notice. This fails immediately.
+    """
+    src = STANDUP.read_text(encoding="utf-8")
+    assert "US=$'\\x1f'" in src, "the US record separator is gone"
+    assert 'IFS="$US" read' in src, "flagged rows are no longer read with $US"
+    assert "IFS=$'\\t' read -r num ci m r author" not in src, (
+        "the tab-separated flagged-PR parse is back")


### PR DESCRIPTION
Implements **Unit C** and **Unit D item 3** of `claudedocs/kickoff-waiting-signal.md` (#417).

## Unit C — the fleet verdict

The kickoff's premise was that `0 ready, 0 red` was *true within the 9 hard-coded repos*. It was not. Both zeroes were manufactured, and **widening alone would have re-printed `0 red` across 28 repos** — the exact "same defect in a new shape" this was meant to avoid.

**Defect 1 — field shift.** Flagged rows were tab-separated and read with `IFS=$'\t' read`. Tab is IFS *whitespace*, so a run of tabs collapses into one delimiter. An empty `reviewDecision` — the normal state of any unreviewed PR — shifted every later field left, leaving `author` empty, so the `author == $ME` filter dropped the row. Reproduced on `civitai/talos-infra`, **already in the hard-coded list**: 8 flagged rows emitted, 0 counted.

```
raw:    939<TAB>red<TAB>CONFLICTING<TAB><TAB>ZacxDev
bound:  num=939 ci=red m=CONFLICTING r=[ZacxDev] author=[]   -> dropped
```

**Defect 2 — half the check results were unreadable.** `statusCheckRollup` mixes `CheckRun` (carries `conclusion`) with `StatusContext` (carries `state`, `conclusion: null`). The rollup read only `.conclusion`, so every failing StatusContext scored "pending" — 5 genuinely-red PRs in one repo, including tekton `gitops-ci` failures.

**Then the widening.** Chose **widen _and_ state the scope inline**, not either/or: a scope string is only honest if the number behind it is real, and a widened number is only usable if the reader knows its reach.

- Repo set is **discovered** (`gh search prs --author=@me`) ∪ local checkouts, minus an **enumerated** exclusion list (`ZacxDev/homebrew-tap` — 31 of 100 hits in the dogfood run). Enumerated, not a pattern: an unknown repo is in scope by default, and the exclusion is printed on the `Filtered:` line.
- STATUS names what it swept: `PRs 140 open across 28 repos (0 ready, 15 red, 18 conflicting — yours)`.
- Degrades **loudly**: `LOCAL repos only — fleet discovery FAILED`, `N unreadable`, and `≥N repos … counts are a floor` at the search cap. A run with incomplete coverage prints `Nothing flagged IN WHAT WAS SCANNED`, never "All clear" — and the all-clear itself now names its scope.

**Latency.** The two `gh pr list` calls per repo became one, run `PR_JOBS`-wide (6). **9.6s for 28 repos vs 14.5s for the old serial 9.**

### The control pair
Live, same machine, same minute (2026-08-12):

| measurement | red |
|---|---|
| old code, 9 repos | **0** |
| new code, 28 repos | **15** (+18 conflicting) |
| independent probe `gh search prs --checks failure` | **11** |

The probe is a **lower bound, not a referee**: its 11 are a near-subset of the sweep's set. The extras are PRs whose only failure is a CheckRun — hand-verified on `civitai-app-starters#222` (`Orchestrator catalog drift-check` = FAILURE). The one figure that was already right is `0 ready`, and the probe agrees.

⚠ `mergeable` is computed lazily by GitHub, so the `conflicting` count rose 13 → 20 → 18 across three runs minutes apart. It is a floor too; documented in the skill.

## Unit D3 — the `initiative-scan` path

`which initiative-scan` finds nothing, and `scripts/initiatives/` is a *different subsystem*. The file is `scripts/session-analysis/initiative-scan.py`; a dogfood agent burned 7 of ~26 calls finding it by grepping `standup.sh` for `ISCAN=`. Now in the `argument-hint` and the first line of the body, with the **plain `python3`** invocation (`requests` is only needed telemetry-ON; the `nix-shell` wrapper is what lets a repo `flake.nix` shellHook print chatter in front of the JSON).

Added the semantic note — **`momentum: active` means a handoff doc was touched recently, not that work is moving** — plus a section listing which zeroes are measurements.

That last part was **not documentable as it stood**: `gh_open_prs` returns `[]` on *any* failure, so `open_prs: []` on a host without an authenticated `gh` is byte-identical to "no open PRs". So the report now carries **`gh_available`** beside `telemetry_available`/`tmux_enabled`, and the renderer says the PR figures are `NOT MEASURED, not zero` when it is false. Purely additive: a new key, plus a `gh_ok` override so tests state which world they are in instead of inheriting the host's.

## Verification

**Red/green matrix** — `scripts/tests/test_standup_pr_sweep.py`, 16 tests, stub `gh` + throwaway git repos, no network:

- **13 RED** against `origin/main`'s script + *only* the `STANDUP_REPOS` test seam; **16 green** at HEAD.
- The 3 that pass on base are labelled **INVARIANT GUARDS** in the file (author filter, in-progress ≠ red, and the ACTIONS half of the ready case) and are not counted as regression evidence.
- Behavioural assertions **lead with the ACTIONS block**, whose wording predates this PR, so a red there is the defect rather than the STATUS format moving under the test.

**Mutation sweep** — 6 mutants, each killed by **exactly** the tests it should and no others (none misattributed, none survived):

| mutant | dies on |
|---|---|
| tab separator restored | field-shift test + control pair + structural pin |
| conclusion-only rollup | both StatusContext tests + control pair |
| scope dropped from STATUS | the 3 scope tests |
| degraded run still says all-clear | both degradation tests |
| exclusion list ignored | the release-bot test |
| drafts counted as open | the draft test |

M1 and M2 kill **disjoint** sets — the two fixes are independently reachable, not shadowing each other.

`gh_available`: 5 new + 2 amended tests, RED against `origin/main`'s `initiative-scan.py` in a throwaway tree mirroring the real layout.

**Gate** — `nix build .#checks.x86_64-linux.pytests`: **PASS**, counts read from `nix log`, not an exit code.

```
scripts/tests                  2535 -> 2551 collected
scripts/session-analysis/tests  381 ->  386 collected
TOTAL collected=8114  passed=8113  skipped=1 (pinned)  failed=0
```

⚠ The **first** gate run reported the old 2535 because the new test file was untracked and the flake silently omits untracked files — the repo's own documented trap, hit live. Re-run after `git add`.

**Floors** re-pinned from the gate's own `_suggested_floor`, not arithmetic across a conflict:

```
scripts/tests:                  2551 - min(50, max(1, 127)) = 2501
scripts/session-analysis/tests:  386 - min(50, max(1,  19)) =  367
```

Expect a conflict on the `scripts/tests` line with the sibling Unit A/B/D branch. Resolve by re-running the gate on the **merged** tree and copying what it prints — `rerere` has mis-replayed this exact line before.

## Stated plainly

- **`standup.sh all` is not verified end-to-end.** Its other four sections reach real clusters, the operator's live tmux and ssh, so the suite drives the `repos` scope only. The `all` path shares the single all-clear branch, but the full run was not exercised.
- The `≥N repos … floor` truncation path is tested with a lowered cap, never against a real 300-hit search.
- Cross-host: measured on the workbench only.
- Nothing in this branch touches `scripts/session-manager` or `claude/skills/session-manager/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
