### PR TITLE
feat(subsystem-touch): read the path set from the SESSION's transcript, not the branch window

### DIFF
--- a/claude/skills/handoff/SKILL.md
+++ b/claude/skills/handoff/SKILL.md
@@ -65,10 +65,18 @@ Topic argument (optional): `$ARGUMENTS`. If empty, infer a short kebab-case topi
 4. **Record what this session touched in the subsystem index** (read-only probe, then an opt-in write). The index is the terse *pointer sheet* that outlives this handoff doc; `/analyze-service` was its only writer, so entries existed for infra services in one scope while work spans ~12 repos. This step is the other writer. Run:
 
    ```
-   python3 /home/zach/workspace/devrc/scripts/lib/subsystem_touch.py --repo <repo> --exclude claudedocs/handoff-<topic>.md
+   python3 /home/zach/workspace/devrc/scripts/lib/subsystem_touch.py --repo <repo> --session <session-uuid> --exclude claudedocs/handoff-<topic>.md
    ```
 
-   `--exclude` drops the doc **you just wrote in step 2** — without it the handoff doc is untracked in its own window and `claudedocs` is a nomination on every single run. It **never writes**; it resolves the changed paths against the store and reports. Scope is derived from the repo you are in (worktree-stable), so entries accrue where the work happened.
+   🔴 **`<session-uuid>` is the basename of your scratchpad directory.** Your system prompt names a scratchpad path of the form `/tmp/claude-<n>/<project>/<session-uuid>/scratchpad` — pass that `<session-uuid>` segment, nothing else. There is no environment variable for it, so it can only come from you.
+
+   **Pass it whenever you can.** It reads what *this session* actually edited from its own transcript, which is **independent of git**: a session that landed its work through merged PRs has an empty `git diff HEAD` and a HEAD sitting at the merge-base by the time this step runs, and on this tool's first real invocation that is exactly why it reported nothing. Without `--session` the tool falls back to git's **branch** window — still honest, still tested, but blind to work that has already merged.
+
+   🔴 **Never pass a UUID you are unsure of.** It is validated — the transcript must exist, have been written in the last 30 minutes, and record a `cwd` equal to `--repo` — and a wrong one **fails with a named error rather than silently reporting another session's paths**. Do not retry with a different UUID to make it pass; drop `--session` and use the git window instead.
+
+   `--exclude` drops the doc **you just wrote in step 2** — it is in *both* windows (untracked in git's, a `Write` tool call in the session's), and without it `claudedocs` is a nomination on every single run. It **never writes**; it resolves the changed paths against the store and reports. Scope is derived from the repo you are in (worktree-stable), so entries accrue where the work happened.
+
+   **Read the `caveat:` line before you write anything** — it states what the chosen window structurally cannot see, and the two sources are blind in *opposite* directions. The session window in particular does **not** include what a **subagent** edited, or files written by a `Bash` command; if the session's real work happened in a dispatched subagent, expect a thin path set and say so rather than inventing entries.
 
    🔴 **Any non-zero exit ⇒ print the stderr line verbatim and write NOTHING.** Exit 3 covers a missing store, a malformed entry, an unusable path and a git failure alike; none of them is a reading. Do **not** fall back to recollection — an entry written from memory is exactly the unverifiable content this store must not accumulate.
 

--- a/scripts/lib/subsystem_touch.py
+++ b/scripts/lib/subsystem_touch.py
@@ -655,6 +655,14 @@ def _session_tailer():
     # puts its own PARENT on sys.path, because it is normally run as a script
     # from its own directory. Loaded from here, that directory is not on the path
     # and those imports would fail — so both go on explicitly.
+    #
+    # 🔴 THE ORDER IS THE TAILER'S, NOT A CONVENIENCE. Inserting the collector
+    # root first and the tailer's own directory second leaves the DIRECTORY
+    # AHEAD of the root — which is exactly the constraint the tailer states for
+    # itself ("APPENDED, not inserted at 0: the collector root also holds
+    # `collector.py`, `deadman.py`, `invocation.py` and `ch_regrowth.py`, and
+    # putting it ahead of this file's own directory would let any of those shadow
+    # a sibling module"). Reverse this loop and a sibling can be shadowed.
     for d in (str(mod_path.parent.parent), str(mod_path.parent)):
         if d not in sys.path:
             sys.path.insert(0, d)

--- a/scripts/lib/subsystem_touch.py
+++ b/scripts/lib/subsystem_touch.py
@@ -33,44 +33,55 @@ nomination, and the census that makes the experiment falsifiable.
 
 WHERE THE PATHS COME FROM, AND WHY
 ----------------------------------
-Three candidate sources were available; the choice is GIT, bounded to the
-branch, with the bound stated in the output. Reasoning, so it can be overturned
-with evidence rather than taste:
+Two real sources, in preference order: the SESSION's own transcript, falling
+back to GIT. The reporting core takes paths as an argument and has never heard
+of either, which is what let the second one be added without touching the
+matching logic.
 
-  * TELEMETRY (`kind=session-summary`'s `changed_paths`) is the source P1 of the
-    decision doc will use, and it is the most honest one — it is per-SESSION. It
-    is also unavailable here: `/handoff` fires at the END of a session, before
-    that session has settled or been summarised, so at the moment this runs the
-    row does not exist yet. Waiting for it would move the write off the ritual,
-    which is the exact property that made every other opt-in tool die.
-  * THE AGENT'S OWN MEMORY of what it edited is available and is what a human
-    would use — and is not deterministic. It cannot be re-run to the same
-    answer, cannot be tested, and is precisely the "prose/heuristic" fix
-    `claude/RULES.md` says to prefer a structural one over.
-  * GIT is available immediately, is deterministic, is re-runnable to the same
-    answer, and — the deciding property — `/handoff` step 1 ALREADY runs
-    `git status -sb` / `git log` / `git diff --stat`. So the path set is a free
-    side-effect of recon the ritual performs anyway, which is the same shape
-    that made `/analyze-service`'s index write stick.
+🔴 GIT WAS THE ORIGINAL SOURCE AND IS STRUCTURALLY BLIND TO THE BEST SESSIONS.
+On its first real invocation this tool captured NOTHING from the session it was
+built during, and the reason is not a bug: that session landed all its work
+through merged PRs, so by `/handoff` time `git diff HEAD` was empty and HEAD sat
+at the merge-base. The window was honestly, uselessly empty — and the tool said
+so, which is not the same as being useful. Merging as you go is the BETTER
+working pattern, so the source that cannot see it is the one that has to change.
 
-Git's known weakness is authorship: `git log` does not know which session
-authored a commit. That is not fixed here, it is BOUNDED and DECLARED. The
-window is:
+  * SESSION TRANSCRIPT (`--session <uuid>` / `--transcript <path>`) — PREFERRED.
+    Per-session by construction, and independent of git: it records the edit
+    whether or not the commit survived, merged, or left a branch behind. The
+    extraction is REUSED, not rewritten — `scripts/collector/claude/
+    session-tailer.py` plus `scripts/collector/changed_paths.py` already compute
+    exactly this set for `kind=session-summary`, tested and deployed. Its blind
+    spots are real and are printed in the caveat, not buried here: a SUBAGENT's
+    edits (a separate transcript — measured at 196 of 733 file-tool calls across
+    the 40 most recent transcripts), files written by a Bash command rather than
+    a file tool, and paths outside the session cwd (counted, never dropped).
+  * GIT (`--paths-from git`, the default) — FALLBACK. Deterministic, re-runnable,
+    already built and tested, and honest about a window that is bounded to the
+    BRANCH rather than the session:
 
-    (working tree vs HEAD, incl. untracked)  ∪  (merge-base(HEAD, base)..HEAD)
+        (working tree vs HEAD, incl. untracked)  ∪  (merge-base(HEAD, base)..HEAD)
 
-i.e. uncommitted work plus THIS BRANCH's own commits — under the repo's standing
-feature-branch rule, the closest deterministic proxy for "this session". Every
-report says `window: branch` and every renderer prints the caveat, because
-"what this branch touched" is a strictly weaker claim than "what this session
-touched" and rounding the two together is how a proxy becomes a lie. On a branch
-that IS the base (or a detached HEAD with no base) the commit half is empty and
-the window degrades to `worktree` — SAID, not silently emptied, because an
-empty commit window and a branch with no commits are different facts.
+    On a branch that IS the base the commit half is empty and the window
+    degrades to `worktree` — SAID, not silently emptied.
+  * THE AGENT'S OWN MEMORY of what it edited was rejected outright, and still is:
+    it cannot be re-run to the same answer and cannot be tested, which is the
+    "prose/heuristic" fix `claude/RULES.md` says to prefer a structural one over.
 
-A caller with a better path set may supply one (`--paths-from -`); the reporting
-core takes paths as an argument and has never heard of git. That is what lets P1
-feed the same core from telemetry later without touching this file's logic.
+🔴 EACH SOURCE PRINTS ITS OWN CAVEAT, AND THE OLD ONE IS NOT REUSABLE. The git
+caveat's "what this BRANCH touched, NOT what this SESSION touched" is false in
+the OTHER direction once the source is per-session — it would understate a
+window that is exactly what it disclaims. `PathSource.caveat` branches per
+source; every renderer prints it, on every output path.
+
+🔴 A SESSION ID IS VALIDATED, NOT TRUSTED, AND A FAILURE NEVER FALLS BACK TO GIT.
+There is no session-id environment variable, so the id arrives as an argument
+and can name another session — and "newest transcript by mtime" is not a
+fallback but a coin flip (14 transcripts modified within one 5-minute window,
+measured). Falling back to git on a validation failure would answer a question
+the caller did not ask, using a window that overlaps enough to look right. See
+`collect_session_paths` for the four guards and the order reachability forces
+them into.
 
 
 SCOPE COMES FROM THE REPO, AND A WORKTREE IS NOT ITS OWN REPO
@@ -86,6 +97,8 @@ its base clone agree. See that function; `TestScopeDerivation` is the guard.
 CONTRACT SUMMARY
 ----------------
     derive_scope(repo_root, git_common_dir)   -> str
+    collect_session_paths(repo, session=…)    -> PathSource      (PREFERRED)
+    find_transcript(session)                  -> Path
     collect_git_paths(repo)                   -> PathSource      (runs git)
     caller_supplied(paths)                    -> PathSource      (pure)
     nominate(assoc, index, *, min_paths, limit)
@@ -106,6 +119,15 @@ mutation test — can tell WHICH guard fired rather than merely that one did:
     "invalid repo-relative path" InvalidPathError, re-raised from the resolver
     "git command failed"         GitError
 
+and, for the session source — each FATAL, none falling back to git:
+
+    "session path extractor not found"  ExtractorMissingError
+    "transcript not found"              TranscriptMissingError
+    "transcript id is ambiguous"        TranscriptAmbiguousError
+    "transcript is stale"               TranscriptStaleError
+    "transcript unreadable"             TranscriptUnreadableError
+    "transcript cwd does not match"     TranscriptCwdMismatchError
+
 🔴 THE FAILURE MODE IS A CONFIDENT ZERO. "Nothing to record" is the observable
 that the most causes share: no paths, an unknown scope, a matcher wired to
 nothing, entries reached but below threshold, and a genuinely untouched index
@@ -125,6 +147,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, Mapping, Sequence
@@ -151,15 +174,24 @@ __all__ = [
     "DEFAULT_STORE_ROOT",
     "DEFAULT_NOMINATION_LIMIT",
     "BASE_REF_CANDIDATES",
+    "MAX_TRANSCRIPT_AGE_SECONDS",
     "TouchError",
     "StoreMissingError",
     "GitError",
+    "ExtractorMissingError",
+    "TranscriptMissingError",
+    "TranscriptAmbiguousError",
+    "TranscriptStaleError",
+    "TranscriptUnreadableError",
+    "TranscriptCwdMismatchError",
     "PathSource",
     "Nomination",
     "TouchReport",
     "Census",
     "derive_scope",
     "collect_git_paths",
+    "collect_session_paths",
+    "find_transcript",
     "caller_supplied",
     "nominate",
     "build_report",
@@ -200,6 +232,33 @@ DEFAULT_NOMINATION_LIMIT = 5
 # commits (the diverged-host case CLAUDE.md describes), not empty.
 BASE_REF_CANDIDATES: tuple[str, ...] = ("origin/main", "origin/master", "main", "master")
 
+# 🔴 THE LIVENESS BOUND ON A CALLER-SUPPLIED SESSION ID. There is no session-id
+# environment variable, so the id arrives as an argument and can be WRONG — a
+# uuid copied out of an old handoff doc, or a resumed session's. "Newest by
+# mtime" is not a usable fallback either: MEASURED 2026-08-12 over the live
+# transcript corpus (4,873 files, read-only), 14 were modified within the same
+# 5 minutes. So the id is trusted only after the file it names is shown to be
+# LIVE.
+#
+# 30 minutes, chosen from that same measurement — transcripts within each bound,
+# of 4,873:
+#
+#     5m  14      15m  19      30m  25      1h  36      2h  38      6h  50
+#     24h 210
+#
+# i.e. 30m admits 0.5% of the corpus and rejects 4,848 files, while 24h would
+# admit 8.4x as many. The lower bound comes from the other direction: `/handoff`
+# appends to this transcript on every turn, and step 4 runs one assistant turn
+# after step 3 wrote the doc — seconds to low minutes. 30m is ~1.5 orders of
+# magnitude of headroom over that and still rejects essentially the whole
+# corpus, which is the property that matters: the check must survive a slow turn
+# and still fail a yesterday's-uuid paste.
+#
+# 🔴 DELIBERATELY NOT env-overridable and NOT a CLI flag. A safety bound with an
+# escape hatch is a bound the first inconvenienced caller removes. Tests control
+# it by setting the FIXTURE's mtime, never by widening the constant.
+MAX_TRANSCRIPT_AGE_SECONDS = 1800.0
+
 _SENSITIVITY_FAIL_SAFE = "client-confidential"
 
 
@@ -216,6 +275,71 @@ class StoreMissingError(TouchError):
 
 class GitError(TouchError):
     """A git invocation failed. Sentinel: 'git command failed'."""
+
+
+# --- Session-source errors -----------------------------------------------------
+#
+# 🔴 EVERY ONE OF THESE IS FATAL, AND NONE FALLS BACK TO GIT. A caller that asked
+# "what did SESSION x touch?" and silently got "what this BRANCH touched" has a
+# plausible answer to a question it did not ask — the confident-wrong-answer
+# class this whole module exists to avoid, made worse because the two windows
+# genuinely overlap so the answer looks right. `/handoff` step 4 already treats
+# any non-zero exit as "write nothing", so failing is CHEAPER than guessing.
+#
+# Each carries its own sentinel phrase, so a caller — or a mutation test — can
+# tell WHICH guard fired. No two share a spelling.
+
+
+class ExtractorMissingError(TouchError):
+    """The shared transcript extractor is not on disk.
+
+    Sentinel: 'session path extractor not found'. A broken deploy, not a reading
+    — and a live hazard in THIS repo specifically, where a new file that was
+    never `git add`ed is silently omitted from the flake's deploy.
+    """
+
+
+class TranscriptMissingError(TouchError):
+    """No transcript for the given session id. Sentinel: 'transcript not found'."""
+
+
+class TranscriptAmbiguousError(TouchError):
+    """One id resolved to more than one transcript.
+
+    Sentinel: 'transcript id is ambiguous'. Never observed in the live corpus
+    (0 duplicate stems across 4,873 files, measured 2026-08-12) — but a resolver
+    that PICKS when it cannot tell is how a session's paths get attributed to
+    another session, so it refuses and names the candidates.
+    """
+
+
+class TranscriptStaleError(TouchError):
+    """The transcript's mtime is older than the liveness bound.
+
+    Sentinel: 'transcript is stale'. This is the guard that catches the wrong
+    argument — see `MAX_TRANSCRIPT_AGE_SECONDS` for the bound and its
+    measurement.
+    """
+
+
+class TranscriptUnreadableError(TouchError):
+    """The transcript could not be read as a session at all.
+
+    Sentinel: 'transcript unreadable'. Distinct from "this session changed no
+    files": the extractor reports an unobservable file set as None and an
+    observed-empty one as [], and conflating the two is exactly the defect the
+    shared module was built to prevent.
+    """
+
+
+class TranscriptCwdMismatchError(TouchError):
+    """The transcript's recorded cwd is not the repo under test.
+
+    Sentinel: 'transcript cwd does not match'. Not a formality: the extractor
+    relativizes every path against the SESSION's cwd, so paths from a session
+    rooted elsewhere are repo-relative to the WRONG repo — they would resolve,
+    quietly, against this repo's index.
+    """
 
 
 # --- Scope ---------------------------------------------------------------------
@@ -253,21 +377,42 @@ class PathSource:
     """
 
     kind: str
-    """`git` or `caller`."""
+    """`git`, `session` or `caller`."""
 
     window: str
-    """`branch` (worktree ∪ this branch's commits), `worktree`, or `supplied`."""
+    """`branch` (worktree ∪ this branch's commits), `worktree`, `session`, or `supplied`."""
 
     paths: tuple[str, ...]
     base_ref: str | None = None
     commands: tuple[tuple[str, ...], ...] = ()
     notes: tuple[str, ...] = ()
+    session: str | None = None
+    """The session id, when `kind == "session"`. Part of the caveat, not decoration."""
 
     @property
     def caveat(self) -> str:
-        """The claim this source can actually support. Never widened by a caller."""
+        """The claim this source can actually support. Never widened by a caller.
+
+        🔴 ONE CAVEAT PER SOURCE, AND EACH UNDERSTATES IN ITS OWN DIRECTION. The
+        git caveat's "NOT what this SESSION touched" is not a disclaimer that can
+        be reused: pointed at the session source it would be false in the
+        opposite direction — understating a window that IS per-session. A single
+        hedging sentence covering both would be wrong about both, so each branch
+        names the work its own window structurally cannot see.
+        """
         if self.kind == "caller":
             return "paths were supplied by the caller; provenance is the caller's to state"
+        if self.kind == "session":
+            return (
+                f"session transcript {self.session}: the files THIS SESSION's own turns "
+                f"edited (Edit/Write/NotebookEdit/MultiEdit), relative to the session cwd "
+                f"— independent of git, so work already merged or committed still counts. "
+                f"NOT represented: (a) anything a SUBAGENT edited — its turns are excluded "
+                f"as a separate session, and 196 of 733 file-tool calls across the 40 most "
+                f"recent transcripts were a subagent's (measured 2026-08-12); (b) files "
+                f"written by a Bash command rather than a file tool; (c) paths outside the "
+                f"session cwd, counted in the note above"
+            )
         if self.window == "branch":
             return (
                 f"git: uncommitted work + this branch's own commits since "
@@ -318,6 +463,42 @@ def _nul_list(out: str) -> list[str]:
     return [p for p in out.split("\0") if p]
 
 
+def _filter_excluded(
+    paths: Iterable[str], exclude: Iterable[str]
+) -> tuple[list[str], list[str]]:
+    """(kept, dropped) — dedupe in first-seen order, minus the caller's exclusions.
+
+    🔴 ONE predicate for BOTH real sources. `/handoff` writes its own doc in step
+    2 and asks what changed in step 4, so the doc is in the window either way —
+    it is untracked in git's, and it is a `Write` tool call in the session's. An
+    exclusion honoured by one source and not the other would make the ritual's
+    own artifact a nomination on exactly half the runs, which is the
+    duplicated-predicate shape `claude/RULES.md` says regenerates the same bug at
+    every site.
+
+    Dropped paths are RETURNED, never discarded: the caller counts them into
+    `notes`, because a window that silently shrank is indistinguishable from one
+    that was always small.
+    """
+    excluded = {e.strip() for e in exclude if e and e.strip()}
+    kept: list[str] = []
+    dropped: list[str] = []
+    for p in paths:
+        if p in excluded:
+            if p not in dropped:
+                dropped.append(p)
+        elif p not in kept:
+            kept.append(p)
+    return kept, dropped
+
+
+def _exclusion_note(dropped: Sequence[str]) -> str:
+    return (
+        f"excluded {len(dropped)} caller-named path(s) from the window: "
+        f"{', '.join(dropped)}"
+    )
+
+
 def collect_git_paths(
     repo: str | Path,
     *,
@@ -355,20 +536,12 @@ def collect_git_paths(
     # 🔴 One frame for every command below. See the docstring.
     toplevel = _git(Path(repo), ["rev-parse", "--show-toplevel"]).strip()
     repo = Path(toplevel)
-    excluded = {e.strip() for e in exclude if e.strip()}
     commands: list[tuple[str, ...]] = []
     notes: list[str] = []
-    paths: list[str] = []
-    dropped: list[str] = []
+    raw: list[str] = []
 
     def add(new: Iterable[str]) -> None:
-        for p in new:
-            if p in excluded:
-                if p not in dropped:
-                    dropped.append(p)
-                continue
-            if p not in paths:
-                paths.append(p)
+        raw.extend(new)
 
     worktree_args = ["diff", "--name-only", "-z", "HEAD"]
     commands.append(tuple(worktree_args))
@@ -408,11 +581,12 @@ def collect_git_paths(
             add(_nul_list(_git(repo, branch_args)))
             window = "branch"
 
+    # Filtered ONCE, at the end, over the accumulated window: `_filter_excluded`
+    # dedupes in first-seen order, so this is the same set and the same order the
+    # per-batch filter produced, from one predicate the session source shares.
+    paths, dropped = _filter_excluded(raw, exclude)
     if dropped:
-        notes.append(
-            f"excluded {len(dropped)} caller-named path(s) from the window: "
-            f"{', '.join(dropped)}"
-        )
+        notes.append(_exclusion_note(dropped))
 
     return PathSource(
         kind="git",
@@ -421,6 +595,294 @@ def collect_git_paths(
         base_ref=base_ref,
         commands=tuple(commands),
         notes=tuple(notes),
+    )
+
+
+# --- The session source: paths from the session's OWN transcript ---------------
+#
+# 🔴 THE EXTRACTOR IS REUSED, NOT REWRITTEN. `scripts/collector/claude/
+# session-tailer.py` already turns a transcript into a changed-path set — it is
+# how `changed_paths` on `kind=session-summary` is computed — and
+# `scripts/collector/changed_paths.py` already owns the relativization, the
+# dedupe, the ordering and the cap. Both are tested and deployed on both hosts.
+# A second extractor here would be the duplicated predicate `claude/RULES.md`
+# names, and the first one has ALREADY drifted once in exactly that way: the
+# opencode summariser read key names its store never used and emitted
+# `files_modified=0` for every session for months, green against fixtures built
+# in the same wrong shape. So this file supplies a path and a repo, and takes
+# back the answer.
+#
+# The tailer's filename contains a dash, so it cannot be imported by name; it is
+# loaded by explicit importlib path, the idiom already used for it in
+# `scripts/collector/claude/tests/test_session_tailer.py`.
+
+
+def _session_tailer_path() -> Path:
+    """`scripts/collector/claude/session-tailer.py`, from this file's location.
+
+    Same `.resolve()` idiom as this module's own `sys.path` line above — and
+    unlike the collector's internal imports, safe here: `scripts/lib/` is not a
+    `home.file` target, so this path never runs from `/nix/store`.
+    """
+    return Path(__file__).resolve().parent.parent / "collector" / "claude" / "session-tailer.py"
+
+
+_SESSION_TAILER = None
+
+
+def _session_tailer():
+    """Load the shared tailer once. LAZY on purpose.
+
+    Importing it drags in `changed_paths`, `_shared` and `tailer` and mutates
+    `sys.path`; the git and caller sources must not pay that, and — more to the
+    point — `TestMutationKillMatrix` exec's copies of THIS module, so a heavy
+    module-level import chain would be re-run for every mutant.
+    """
+    global _SESSION_TAILER
+    if _SESSION_TAILER is not None:
+        return _SESSION_TAILER
+
+    import importlib.util
+
+    mod_path = _session_tailer_path()
+    if not mod_path.is_file():
+        raise ExtractorMissingError(
+            f"session path extractor not found: {mod_path} — the transcript source "
+            f"cannot run without it. In this repo that usually means a file was "
+            f"never `git add`ed and the flake omitted it from the deploy."
+        )
+    # The tailer imports its siblings (`_shared`, `tailer`) by BARE NAME and only
+    # puts its own PARENT on sys.path, because it is normally run as a script
+    # from its own directory. Loaded from here, that directory is not on the path
+    # and those imports would fail — so both go on explicitly.
+    for d in (str(mod_path.parent.parent), str(mod_path.parent)):
+        if d not in sys.path:
+            sys.path.insert(0, d)
+    spec = importlib.util.spec_from_file_location("devrc_session_tailer", mod_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise ExtractorMissingError(
+            f"session path extractor not found: {mod_path} could not be loaded as a module"
+        )
+    module = importlib.util.module_from_spec(spec)
+    # Registered BEFORE exec: the tailer defines dataclasses, and `@dataclass`
+    # resolves string annotations through `sys.modules[__module__]`.
+    sys.modules["devrc_session_tailer"] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop("devrc_session_tailer", None)
+        raise
+    _SESSION_TAILER = module
+    return module
+
+
+def find_transcript(session: str, roots: Sequence[str] | None = None) -> Path:
+    """Resolve a session id to its ONE transcript file. Never guesses.
+
+    Roots come from the collector's own `projects_roots()` — one definition of
+    where transcripts live, and it honours `CLAUDE_PROJECTS_DIR` so a test can
+    point the lookup at a fixture tree instead of the real one.
+
+    ⚠ DELIBERATELY DIVERGENT from the tailer's `iter_transcripts`, which skips
+    `subagents/` and `wf_*` directories. That exclusion exists so the telemetry
+    walker does not summarise a subagent's turns twice, under both the parent and
+    itself. Here exactly one id is being resolved, so there is no double count to
+    avoid — and a subagent that runs `/handoff` in its own worktree should get
+    ITS transcript, not a miss. Measured 2026-08-12: 4,254 of 4,873 transcripts
+    live under `subagents/`, and 0 stems appear in more than one directory.
+    """
+    sid = (session or "").strip()
+    # A path separator or a leading dot would make the glob below escape the
+    # roots entirely. Rejected as unusable rather than searched for.
+    if not sid or "/" in sid or os.sep in sid or sid.startswith("."):
+        raise TranscriptMissingError(
+            f"transcript not found: {session!r} is not a usable session id — pass the "
+            f"session UUID, which is the basename of the agent scratchpad directory"
+        )
+    if roots is None:
+        roots = _session_tailer().projects_roots()
+    hits: list[Path] = []
+    for root in roots:
+        for p in sorted(Path(root).glob(f"**/{sid}.jsonl")):
+            if p not in hits:
+                hits.append(p)
+    if not hits:
+        raise TranscriptMissingError(
+            f"transcript not found: no `{sid}.jsonl` under {', '.join(str(r) for r in roots)} "
+            f"— the session id is wrong, or this session's transcript is stored elsewhere"
+        )
+    if len(hits) > 1:
+        raise TranscriptAmbiguousError(
+            f"transcript id is ambiguous: `{sid}` resolves to {len(hits)} files "
+            f"({', '.join(str(h) for h in hits)}); pass --transcript to name one"
+        )
+    return hits[0]
+
+
+def _same_dir(a: str, b: str) -> bool:
+    """Do two directory strings name the same directory?
+
+    Lexical equality first, `realpath` second. The lexical pass is what the
+    extractor itself uses to relativize (deliberately not `realpath`, so a
+    historical session whose cwd no longer exists still resolves); the realpath
+    pass exists only for the symlinked-`$HOME` case, where git's
+    `--show-toplevel` and a transcript's recorded cwd spell one directory two
+    ways. Empty is never equal to anything — `realpath("")` is the process cwd,
+    which would make an unreadable session's empty cwd "match" whatever
+    directory the tool happened to be launched from.
+    """
+    if not a or not b:
+        return False
+    na = os.path.normpath(a).rstrip("/") or "/"
+    nb = os.path.normpath(b).rstrip("/") or "/"
+    if na == nb:
+        return True
+    return os.path.realpath(na) == os.path.realpath(nb)
+
+
+def collect_session_paths(
+    repo: str | Path,
+    *,
+    session: str | None = None,
+    transcript: str | Path | None = None,
+    roots: Sequence[str] | None = None,
+    now: float | None = None,
+    max_age_seconds: float = MAX_TRANSCRIPT_AGE_SECONDS,
+    exclude: Iterable[str] = (),
+) -> PathSource:
+    """What THIS SESSION touched, from its own transcript. Per-session, not per-branch.
+
+    The window git cannot express. `/handoff` fires at the end of a session, and
+    the sessions worth recording are the ones that landed their work through
+    merged PRs — by then `git diff HEAD` is empty and HEAD sits at the
+    merge-base, so the git window is honestly, uselessly, empty. The transcript
+    is not: it records the edit whether or not the commit survived, whether or
+    not it merged, and whether or not the branch still exists.
+
+    🔴 THE ID IS VALIDATED, NEVER TRUSTED, AND A FAILURE NEVER FALLS BACK. There
+    is no session-id environment variable, so this arrives as an argument and can
+    name someone else's session. Four guards, in an order where each is
+    reachable by an input no earlier one rejects:
+
+      1. the transcript RESOLVES        TranscriptMissingError / ...Ambiguous
+      2. its mtime is LIVE              TranscriptStaleError
+      3. it READS as a session          TranscriptUnreadableError
+      4. its cwd IS this repo           TranscriptCwdMismatchError
+
+    (3) must precede (4): an unreadable transcript yields `cwd == ""`, so a cwd
+    check placed first would fire for it and the unreadable case's own test would
+    pass on a neighbour's error — green with the guard it claims to test deleted.
+
+    Falling back to git on any of these would answer a question the caller did
+    not ask, with a window that overlaps enough to look right.
+
+    `now` and `max_age_seconds` are parameters so the liveness check is testable
+    without a clock; neither is reachable from the CLI, deliberately.
+    """
+    tailer = _session_tailer()
+    if transcript is not None:
+        path = Path(transcript)
+        if not path.is_file():
+            raise TranscriptMissingError(
+                f"transcript not found: {path} is not a readable file"
+            )
+    elif session is not None:
+        path = find_transcript(session, roots)
+    else:  # pragma: no cover - the CLI and every caller pass exactly one
+        raise TranscriptMissingError(
+            "transcript not found: neither a session id nor a transcript path was given"
+        )
+    label = session or path.stem
+
+    # --- guard 1b: readable, not merely present ---------------------------------
+    if not os.access(path, os.R_OK):
+        raise TranscriptMissingError(
+            f"transcript not found: {path} exists but is not readable"
+        )
+
+    # --- guard 2: the file is LIVE ----------------------------------------------
+    stamp = now if now is not None else time.time()
+    age = stamp - os.stat(path).st_mtime
+    if age > max_age_seconds:
+        raise TranscriptStaleError(
+            f"transcript is stale: {path} was last written {age / 60:.1f} min ago, "
+            f"bound is {max_age_seconds / 60:.0f} min — this is not the session that "
+            f"is running now, so its paths are another session's. Pass the CURRENT "
+            f"session id (the basename of the agent scratchpad directory)."
+        )
+
+    # --- guard 3: it reads as a session -----------------------------------------
+    # 🔴 The shared extractor. A trailing line that is half-written — the normal
+    # state of a transcript being appended to while it is read — is skipped by
+    # its per-line JSON decode, so a partial write cannot crash the run; and a
+    # transcript it could not read at all comes back with `changed_paths = None`
+    # (the "unobservable" block), NEVER with `[]`. Those two are checked
+    # together here because they are one claim: we do not know this session's
+    # file set. `[]` is a different fact — the session touched nothing — and it
+    # flows through as `looked-at-nothing`.
+    #
+    # ⚠ `unreadable` is REDUNDANT-BUT-KEPT, labelled so a mutation sweep does not
+    # re-derive it as a live guard: the extractor's `_empty_rollup` already
+    # carries the all-None block, and `build_rollup` calls `_mark_unobservable`
+    # whenever it sets `unreadable`, so today `unreadable` IMPLIES
+    # `changed_paths is None` and removing this clause alone is unkillable. It
+    # stays because the two are separate claims in the extractor's own contract,
+    # and an extractor that ever reported one without the other would otherwise
+    # be believed.
+    rollup = tailer.summarize_transcript(str(path))
+    observed = rollup.get("changed_paths")
+    if rollup.get("unreadable") or observed is None:
+        raise TranscriptUnreadableError(
+            f"transcript unreadable: {path} yielded no readable session — the file set "
+            f"is UNKNOWN, which is not the same as empty, so nothing is reported rather "
+            f"than an empty window that reads as 'this session touched nothing'"
+        )
+
+    # --- guard 4: it is THIS repo ------------------------------------------------
+    # The frame, resolved exactly as the git source resolves it: every path the
+    # extractor emits is relative to the session cwd, so unless that cwd IS the
+    # repo root, the paths are repo-relative to a different repo and would
+    # resolve — silently, plausibly — against this repo's index.
+    toplevel = _git(Path(repo), ["rev-parse", "--show-toplevel"]).strip()
+    session_cwd = rollup.get("cwd") or ""
+    if not _same_dir(session_cwd, toplevel):
+        raise TranscriptCwdMismatchError(
+            f"transcript cwd does not match: session {label} ran in "
+            f"{session_cwd or '(no cwd recorded)'}, but --repo resolves to {toplevel}. "
+            f"Every path in a transcript is relative to the session's own cwd, so "
+            f"reporting them against this repo would associate another repo's work here."
+        )
+
+    paths, dropped = _filter_excluded(observed, exclude)
+    notes: list[str] = []
+    total = rollup.get("changed_paths_total")
+    outside = rollup.get("changed_paths_outside_cwd")
+    # 🔴 EMITTED UNCONDITIONALLY, INCLUDING AT ZERO. The caveat below refers to
+    # this count, so it has to be there to refer to — and a stated zero is a
+    # reading, while an absent line is indistinguishable from a counter wired to
+    # nothing (`claude/RULES.md` → "report the pair").
+    notes.append(
+        f"{total} distinct path(s) under the session cwd; {outside} outside it — the "
+        f"latter are COUNTED here and not represented below (a scratchpad file, a "
+        f"temp worktree, or an edit in another repo has no repo-relative form here)"
+    )
+    if rollup.get("changed_paths_truncated"):
+        notes.append(
+            f"🔴 TRUNCATED at the extractor's cap of {rollup.get('changed_paths_cap')} — "
+            f"the list is a lexicographic PREFIX of {total} paths, so a late-sorting "
+            f"subtree may be missing entirely"
+        )
+    if dropped:
+        notes.append(_exclusion_note(dropped))
+    notes.append(f"transcript: {path}")
+
+    return PathSource(
+        kind="session",
+        window="session",
+        paths=tuple(paths),
+        commands=(("rev-parse", "--show-toplevel"),),
+        notes=tuple(notes),
+        session=label,
     )
 
 
@@ -949,6 +1411,7 @@ def report_json(report: TouchReport) -> dict:
             "kind": src.kind,
             "window": src.window,
             "base_ref": src.base_ref,
+            "session": src.session,
             "caveat": src.caveat,
             "notes": list(src.notes),
             "commands": [list(c) for c in src.commands],
@@ -1098,7 +1561,35 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--paths-from",
         default="git",
-        help="`git` (default) or `-` to read repo-relative paths from stdin, one per line",
+        help=(
+            "fallback source when no session is given: `git` (default) or `-` to read "
+            "repo-relative paths from stdin, one per line"
+        ),
+    )
+    # 🔴 MUTUALLY EXCLUSIVE, ENFORCED BY ARGPARSE (exit 2). They name the same
+    # thing two ways, and a caller that passes both has one of them wrong —
+    # picking either would be a guess about which.
+    session_src = p.add_mutually_exclusive_group()
+    session_src.add_argument(
+        "--session",
+        default=None,
+        metavar="UUID",
+        help=(
+            "PREFERRED source: report what THIS SESSION touched, from its own "
+            "transcript. The UUID is the basename of the agent scratchpad directory. "
+            "Validated, never trusted — a wrong or stale id FAILS rather than falling "
+            "back to git."
+        ),
+    )
+    session_src.add_argument(
+        "--transcript",
+        default=None,
+        metavar="PATH",
+        help=(
+            "the session source, naming the transcript file directly instead of "
+            "resolving a UUID. Same validation; use it when --session reports the id "
+            "is ambiguous."
+        ),
     )
     p.add_argument(
         "--exclude",
@@ -1152,7 +1643,29 @@ def main(argv: Sequence[str] | None = None, *, today: str | None = None) -> int:
             print(new_entry_template(normalize_ref(args.template), scope, today=stamp))
             return 0
 
-        if args.paths_from == "git":
+        wants_session = args.session is not None or args.transcript is not None
+        # 🔴 A CONTRADICTION IS REFUSED, NOT RESOLVED. `--paths-from` names the
+        # FALLBACK source, so pairing it with a session request asks for two
+        # different windows at once. Honouring either silently would hand back a
+        # plausible answer to a question the caller did not ask — the same
+        # failure the no-fallback rule above exists to prevent, arriving through
+        # argument parsing instead.
+        if wants_session and args.paths_from != "git":
+            print(
+                "subsystem-touch: --session/--transcript cannot be combined with "
+                "--paths-from; they are different path windows. Drop one.",
+                file=sys.stderr,
+            )
+            return 2
+
+        if wants_session:
+            source = collect_session_paths(
+                repo,
+                session=args.session,
+                transcript=args.transcript,
+                exclude=args.exclude,
+            )
+        elif args.paths_from == "git":
             source = collect_git_paths(repo, exclude=args.exclude)
         elif args.paths_from == "-":
             source = caller_supplied(sys.stdin.read().splitlines())

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -429,7 +429,33 @@ TARGET_FLOORS=(
   # says: 2551 -> 2629 collected on main + this branch, measured by the gate on
   # the MERGED tree rather than computed from either side of the conflict.
   #   _suggested_floor 2629 = 2629 - min(50, max(1, 131)) = 2629 - 50 = 2579.
-  "scripts/tests|2579"
+  #
+  # 2026-08-12, the subsystem-touch SESSION path source: 2629 -> 2697 collected,
+  # +68 in test_subsystem_touch.py (136 -> 204 tests: the session source's
+  # positive-control pair, its five named negative controls, the
+  # partial-trailing-line edge, and one mutation kill per new guard). The gate's
+  # own line on the twice-rebased tree:
+  #   PASS  scripts/tests  (collected=2697 passed=2697 skipped=0)
+  # put through the gate's own function:
+  #   _suggested_floor 2697 = 2697 - min(50, max(1, 134)) = 2697 - 50 = 2647.
+  #
+  # 🔴 THIS BRANCH MEASURED THIS LINE THREE TIMES AND THE FIRST TWO READINGS ARE
+  # VOID — which is the whole argument for re-measuring rather than reconciling.
+  # It read `collected=2603` against a base of 2535; the standup fix moved the
+  # base to 2551 and it re-read 2619; the waiting-signal branch moved it again to
+  # 2629. Only the last reading, taken by the authoritative gate on the tree that
+  # actually exists, is worth anything. What that discipline caught: this branch
+  # had recorded its OWN delta as +118, and the measured figure is +68 — a wrong
+  # number that arithmetic across the conflict would have written straight into
+  # the floor, where nothing would ever have caught it (a floor is a minimum, so
+  # one that is merely too low fails silently forever).
+  #
+  # ⚠ Each rebase so far has been purely additive. That is a RESULT of measuring,
+  # not a licence to assume it: a merge can change collection through a shared
+  # fixture, a colliding parametrize id, or a module that stops importing.
+  #
+  # See the commit message for the gate line this number was copied from.
+  "scripts/tests|2647"
   # 2026-08-11, the session-summary changed-paths work: 230 -> 273 collected,
   # +43 for scripts/collector/tests/test_changed_paths.py (the shared
   # `changed_paths*` module). The gate printed this replacement itself —

--- a/scripts/tests/test_subsystem_touch.py
+++ b/scripts/tests/test_subsystem_touch.py
@@ -1196,6 +1196,39 @@ class TestSkillDocsArePinned:
             "the **first-entry case, not a failure**",
             "scope-absent is the reason this step exists, not an error",
         ),
+        # 🔴 The session source. The module is inert unless the step passes the
+        # token, and there is no environment variable for it — so if these
+        # sentences go, the tool silently reverts to the git window that
+        # captured nothing on its first real run.
+        (
+            "--session <session-uuid>",
+            "the step actually passes the session token",
+        ),
+        (
+            "`<session-uuid>` is the basename of your scratchpad directory",
+            "WHERE the agent gets the token — the one fact it cannot look up",
+        ),
+        (
+            "Never pass a UUID you are unsure of",
+            "the token is validated, and a wrong one must not be retried into passing",
+        ),
+        (
+            "fails with a named error rather than silently reporting another "
+            "session's paths",
+            "the no-fallback contract, stated to its caller",
+        ),
+        (
+            "blind to work that has already merged",
+            "why the git fallback is a fallback",
+        ),
+        (
+            "Read the `caveat:` line before you write anything",
+            "each source understates in its own direction",
+        ),
+        (
+            "does **not** include what a **subagent** edited",
+            "the session window's largest measured blind spot",
+        ),
     ]
 
     def test_EVERY_emitted_status_has_a_bullet_in_the_skill(self) -> None:
@@ -1304,6 +1337,871 @@ class TestNoRealStoreIsRead:
         assert f"~/.claude/{st.DEFAULT_STORE_ROOT.name}" in ANALYZE_DOC.read_text(
             encoding="utf-8"
         )
+
+
+# =============================================================================
+# THE SESSION SOURCE — the window git structurally cannot see.
+# =============================================================================
+#
+# 🔴 WHY IT EXISTS, IN ONE MEASUREMENT: on this tool's FIRST real invocation it
+# captured nothing from the session it was built during, because that session
+# landed all its work through merged PRs — by `/handoff` time `git diff HEAD` was
+# empty and HEAD sat at the merge-base. The tool said so honestly. Honest about
+# seeing nothing and useful are different properties.
+#
+# 🔴 EVERY FIXTURE HERE IS SYNTHETIC. The session id below is invented and is
+# not a real UUID from any host; this repo is PUBLIC. No transcript under
+# `~/.claude/projects/` is read by any test in this file — `TestNoRealTranscript`
+# is the guard, and `CLAUDE_PROJECTS_DIR` is repointed at `tmp_path` for every
+# test that exercises id lookup.
+
+SESSION_ID = "11111111-1111-4111-8111-111111111111"  # invented, not a real session
+OTHER_SESSION_ID = "22222222-2222-4222-8222-222222222222"
+
+
+def _edit_block(file_path: str) -> dict:
+    return {
+        "type": "tool_use",
+        "name": "Edit",
+        "input": {"file_path": file_path, "old_string": "a\n", "new_string": "b\n"},
+    }
+
+
+def _assistant(files, *, cwd: str | None = None, sidechain: bool = False) -> dict:
+    obj = {
+        "type": "assistant",
+        "timestamp": "2026-08-12T10:00:00.000Z",
+        "message": {
+            "role": "assistant",
+            "model": "test-model",
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+            "content": [_edit_block(f) for f in files],
+        },
+    }
+    if cwd is not None:
+        obj["cwd"] = cwd
+    if sidechain:
+        obj["isSidechain"] = True
+    return obj
+
+
+def _write_transcript(
+    path: Path,
+    cwd: str,
+    files,
+    *,
+    sidechain_files=(),
+    trailing_partial: bool = False,
+    only_partial: bool = False,
+    age_seconds: float = 0.0,
+) -> Path:
+    """A synthetic transcript in the real JSONL shape.
+
+    `trailing_partial` cuts the LAST line mid-object, which is the ordinary state
+    of a transcript that is being appended to while it is read — the exact
+    condition `/handoff` creates by running this tool during the session the
+    transcript belongs to.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [json.dumps(_assistant(files, cwd=cwd))]
+    if sidechain_files:
+        lines.append(json.dumps(_assistant(sidechain_files, sidechain=True)))
+    body = "\n".join(lines) + "\n" if lines else ""
+    if only_partial:
+        body = json.dumps(_assistant(files, cwd=cwd))[:80]
+    elif trailing_partial:
+        body += json.dumps(_assistant(["/x/late.py"], cwd=cwd))[:80]
+    path.write_text(body, encoding="utf-8")
+    if age_seconds:
+        t = path.stat().st_mtime - age_seconds
+        os.utime(path, (t, t))
+    return path
+
+
+@pytest.fixture()
+def tailer_cache():
+    """The extractor is cached in a module global; restore it around each test."""
+    saved = st._SESSION_TAILER
+    yield
+    st._SESSION_TAILER = saved
+
+
+@pytest.fixture()
+def projects_root(tmp_path: Path, monkeypatch):
+    """Point the id lookup at a fixture tree. 🔴 Never the real one."""
+    root = tmp_path / "projects" / "-synthetic-project"
+    root.mkdir(parents=True)
+    monkeypatch.setenv("CLAUDE_PROJECTS_DIR", str(tmp_path / "projects"))
+    return root
+
+
+def _session_source(repo: Path, transcript: Path, **kw):
+    return st.collect_session_paths(repo, transcript=transcript, **kw)
+
+
+class TestSessionPositiveControl:
+    """🔴 `claude/RULES.md` → "Positive control — can it ever observe the thing?"
+
+    A reassuring empty path set is indistinguishable from an extractor wired to
+    nothing — which is precisely the bug #398 fixed one source over, where the
+    opencode summariser emitted `files_modified=0` for every session for months
+    while its own tests were green. So the pair is reported: a transcript that
+    MUST yield paths, against a control that MUST yield none, on the same code
+    path with the same shape.
+    """
+
+    UNDER_CWD = ["src/collector/a.py", "src/collector/b.py", "src/collector/c.py"]
+
+    def test_THE_PAIR_nonzero_under_test_zero_on_the_control(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        repo = _init_repo(tmp_path, SCOPE)
+        cwd = str(repo)
+
+        # UNDER TEST: three edits inside the session cwd.
+        pos = _write_transcript(
+            tmp_path / "pos.jsonl", cwd, [f"{cwd}/{p}" for p in self.UNDER_CWD]
+        )
+        # CONTROL: the SAME three filenames at the SAME depth, edited in another
+        # repo entirely. They have no repo-relative form here, so the honest
+        # answer is zero — and it must be zero for that reason, not because
+        # nothing was read.
+        neg = _write_transcript(
+            tmp_path / "neg.jsonl",
+            cwd,
+            [f"{tmp_path}/elsewhere/{p}" for p in self.UNDER_CWD],
+        )
+
+        pos_src = _session_source(repo, pos)
+        neg_src = _session_source(repo, neg)
+
+        assert len(pos_src.paths) == 3, "positive control yielded nothing — wired to nothing"
+        assert len(neg_src.paths) == 0
+        assert sorted(pos_src.paths) == sorted(self.UNDER_CWD)
+
+    def test_the_control_zero_is_ACCOUNTED_for_not_merely_empty(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        """The three dropped paths are COUNTED. An empty list with no count is
+        the silent zero; an empty list beside `3 outside it` is a reading."""
+        repo = _init_repo(tmp_path, SCOPE)
+        cwd = str(repo)
+        neg = _write_transcript(
+            tmp_path / "neg.jsonl",
+            cwd,
+            [f"{tmp_path}/elsewhere/{p}" for p in self.UNDER_CWD],
+        )
+        src = _session_source(repo, neg)
+        assert src.paths == ()
+        assert any("3 outside it" in n for n in src.notes), src.notes
+        assert any("0 distinct path(s) under the session cwd" in n for n in src.notes)
+
+    def test_the_outside_count_is_emitted_AT_ZERO_too(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        """🔴 The caveat refers to this note, so it must always exist to refer
+        to — and a stated zero is a reading, while an absent line is
+        indistinguishable from a counter wired to nothing."""
+        repo = _init_repo(tmp_path, SCOPE)
+        cwd = str(repo)
+        t = _write_transcript(tmp_path / "t.jsonl", cwd, [f"{cwd}/{p}" for p in self.UNDER_CWD])
+        src = _session_source(repo, t)
+        assert any("0 outside it" in n for n in src.notes), src.notes
+
+    def test_the_pair_survives_all_the_way_to_a_REPORT(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        """The extractor and the matcher are two places a zero can come from.
+        Both ends are pinned, so one being wired to nothing cannot hide behind
+        the other."""
+        repo = _init_repo(tmp_path, SCOPE)
+        cwd = str(repo)
+        store = _make_store(tmp_path / "s")
+        pos = _write_transcript(
+            tmp_path / "pos.jsonl", cwd, [f"{cwd}/{p}" for p in self.UNDER_CWD]
+        )
+        # Same count of paths, same depth, same store — only the subsystem
+        # directory differs, and it names nothing.
+        neg = _write_transcript(
+            tmp_path / "neg.jsonl",
+            cwd,
+            [f"{cwd}/src/unlisted-widget/{Path(p).name}" for p in self.UNDER_CWD],
+        )
+        pos_rep = st.build_report(_session_source(repo, pos), store, SCOPE, today=TODAY)
+        neg_rep = st.build_report(_session_source(repo, neg), store, SCOPE, today=TODAY)
+
+        assert pos_rep.status == "resolved"
+        assert [m.entry.ref for m in pos_rep.known] == ["collector"]
+        assert neg_rep.status == "no-match"
+        assert neg_rep.known == ()
+        # …and the negative control is NOT an empty window, which would make the
+        # zero uninformative.
+        assert len(neg_rep.source.paths) == 3
+
+    def test_a_MERGED_session_is_exactly_what_git_cannot_see(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        """🔴 THE MOTIVATING CASE, as a test. The repo is clean and HEAD is at
+        the base ref — the state a session leaves behind when it lands its work
+        through merged PRs. Git's window is empty and says so; the session's is
+        not. Both are run against the SAME repo at the SAME moment."""
+        repo = _init_repo(tmp_path, SCOPE)  # clean tree, on `main`, nothing staged
+        cwd = str(repo)
+        t = _write_transcript(
+            tmp_path / "t.jsonl", cwd, [f"{cwd}/{p}" for p in self.UNDER_CWD]
+        )
+        git_src = st.collect_git_paths(repo)
+        ses_src = _session_source(repo, t)
+
+        assert git_src.paths == (), "the premise is gone: git's window was not empty"
+        assert git_src.window == "worktree"
+        assert len(ses_src.paths) == 3
+        assert ses_src.window == "session"
+
+
+class TestSessionNegativeControls:
+    """Each guard fails with ITS OWN sentinel, reached by an input no EARLIER
+    guard rejects — otherwise a control passes because a neighbour fired, and
+    stays green with the guard it claims to test deleted.
+
+    Every test also asserts the OTHER sentinels are absent, which is what makes
+    "this guard fired" a measurement rather than an inference.
+    """
+
+    SENTINELS = {
+        "missing": "transcript not found",
+        "ambiguous": "transcript id is ambiguous",
+        "stale": "transcript is stale",
+        "unreadable": "transcript unreadable",
+        "cwd": "transcript cwd does not match",
+        "extractor": "session path extractor not found",
+    }
+
+    def _only(self, exc: Exception, key: str) -> None:
+        text = str(exc)
+        assert self.SENTINELS[key] in text, f"expected the {key} sentinel, got: {text}"
+        for other, phrase in self.SENTINELS.items():
+            if other != key:
+                assert phrase not in text, f"the {other} sentinel also fired: {text}"
+
+    def test_no_two_sentinels_share_a_spelling(self) -> None:
+        """The premise of `_only`. Two guards spelled alike would make every
+        assertion above vacuous."""
+        for a, pa in self.SENTINELS.items():
+            for b, pb in self.SENTINELS.items():
+                if a != b:
+                    assert pa not in pb, f"{a} sentinel is a substring of {b}"
+
+    def test_a_nonexistent_session_id_is_MISSING(
+        self, tmp_path: Path, projects_root: Path, tailer_cache
+    ) -> None:
+        with pytest.raises(st.TranscriptMissingError) as exc:
+            st.find_transcript(SESSION_ID)
+        self._only(exc.value, "missing")
+
+    def test_an_id_with_a_separator_is_MISSING_not_searched_for(
+        self, tmp_path: Path, projects_root: Path, tailer_cache
+    ) -> None:
+        """A separator would let the glob escape the roots entirely."""
+        with pytest.raises(st.TranscriptMissingError) as exc:
+            st.find_transcript("../../etc/passwd")
+        self._only(exc.value, "missing")
+
+    def test_two_transcripts_with_ONE_id_is_AMBIGUOUS_not_a_pick(
+        self, tmp_path: Path, projects_root: Path, tailer_cache
+    ) -> None:
+        """Reachable past the missing guard: the file EXISTS — twice."""
+        for sub in ("a", "b"):
+            _write_transcript(
+                projects_root / sub / f"{SESSION_ID}.jsonl", str(tmp_path), ["x.py"]
+            )
+        with pytest.raises(st.TranscriptAmbiguousError) as exc:
+            st.find_transcript(SESSION_ID)
+        self._only(exc.value, "ambiguous")
+
+    def test_a_stale_transcript_is_STALE(self, tmp_path: Path, tailer_cache) -> None:
+        """Reachable past the missing guard: the file exists and is perfectly
+        readable — it is simply not the session that is running now."""
+        repo = _init_repo(tmp_path, SCOPE)
+        t = _write_transcript(
+            tmp_path / "t.jsonl",
+            str(repo),
+            [f"{repo}/src/collector/a.py"],
+            age_seconds=st.MAX_TRANSCRIPT_AGE_SECONDS + 60,
+        )
+        with pytest.raises(st.TranscriptStaleError) as exc:
+            _session_source(repo, t)
+        self._only(exc.value, "stale")
+
+    def test_the_stale_boundary_is_a_boundary_not_a_slope(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        """🔴 Measured at TWO points either side, not one: a bound asserted only
+        from beyond it is equally consistent with a guard that rejects
+        everything."""
+        repo = _init_repo(tmp_path, SCOPE)
+        fresh = _write_transcript(
+            tmp_path / "fresh.jsonl",
+            str(repo),
+            [f"{repo}/src/collector/a.py"],
+            age_seconds=st.MAX_TRANSCRIPT_AGE_SECONDS - 60,
+        )
+        assert _session_source(repo, fresh).paths == ("src/collector/a.py",)
+
+        stale = _write_transcript(
+            tmp_path / "stale.jsonl",
+            str(repo),
+            [f"{repo}/src/collector/a.py"],
+            age_seconds=st.MAX_TRANSCRIPT_AGE_SECONDS + 60,
+        )
+        with pytest.raises(st.TranscriptStaleError):
+            _session_source(repo, stale)
+
+    def test_a_corrupt_transcript_is_UNREADABLE(self, tmp_path: Path, tailer_cache) -> None:
+        """Reachable past missing + stale: the file exists and is fresh; it just
+        is not a session. 🔴 It must NOT come back as an empty path set — that
+        would read as 'this session touched nothing'."""
+        repo = _init_repo(tmp_path, SCOPE)
+        t = tmp_path / "corrupt.jsonl"
+        t.write_text("not json at all\nnor is this\n", encoding="utf-8")
+        with pytest.raises(st.TranscriptUnreadableError) as exc:
+            _session_source(repo, t)
+        self._only(exc.value, "unreadable")
+
+    def test_an_empty_transcript_is_UNREADABLE_not_an_empty_window(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        repo = _init_repo(tmp_path, SCOPE)
+        t = tmp_path / "empty.jsonl"
+        t.write_text("", encoding="utf-8")
+        with pytest.raises(st.TranscriptUnreadableError) as exc:
+            _session_source(repo, t)
+        self._only(exc.value, "unreadable")
+
+    def test_a_FOREIGN_cwd_is_CWD_MISMATCH(self, tmp_path: Path, tailer_cache) -> None:
+        """Reachable past missing + stale + unreadable: the transcript is fresh
+        and reads perfectly — it belongs to a session in another repo."""
+        repo = _init_repo(tmp_path, SCOPE)
+        other = tmp_path / "another-repo"
+        t = _write_transcript(
+            tmp_path / "t.jsonl", str(other), [f"{other}/src/collector/a.py"]
+        )
+        with pytest.raises(st.TranscriptCwdMismatchError) as exc:
+            _session_source(repo, t)
+        self._only(exc.value, "cwd")
+
+    def test_the_cwd_guard_is_reached_by_a_transcript_that_ALSO_reads_fine(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        """🔴 The reachability proof, stated as a measurement: the SAME bytes
+        with the cwd corrected produce a working report. So the guard above
+        fired on the cwd, not on some incidental defect in the fixture."""
+        repo = _init_repo(tmp_path, SCOPE)
+        good = _write_transcript(
+            tmp_path / "good.jsonl", str(repo), [f"{repo}/src/collector/a.py"]
+        )
+        assert _session_source(repo, good).paths == ("src/collector/a.py",)
+
+    def test_a_transcript_with_NO_cwd_is_a_mismatch_not_a_match(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        """`realpath("")` is the process cwd; without the empty-string guard a
+        session that recorded no cwd would "match" whatever directory the tool
+        happened to be launched from."""
+        repo = _init_repo(tmp_path, SCOPE)
+        t = tmp_path / "nocwd.jsonl"
+        t.write_text(json.dumps(_assistant(["/x/a.py"])) + "\n", encoding="utf-8")
+        with pytest.raises(st.TranscriptCwdMismatchError) as exc:
+            _session_source(repo, t)
+        self._only(exc.value, "cwd")
+        assert st._same_dir("", os.getcwd()) is False
+
+    def test_a_missing_EXTRACTOR_names_itself(
+        self, tmp_path: Path, monkeypatch, tailer_cache
+    ) -> None:
+        """A deploy that omitted the shared extractor is a broken environment,
+        not a reading — and in THIS repo a new file that was never `git add`ed is
+        exactly how that happens."""
+        st._SESSION_TAILER = None
+        monkeypatch.setattr(st, "_session_tailer_path", lambda: tmp_path / "gone.py")
+        with pytest.raises(st.ExtractorMissingError) as exc:
+            st._session_tailer()
+        self._only(exc.value, "extractor")
+
+    def test_EVERY_failure_is_a_TouchError_so_the_CLI_exits_nonzero(self) -> None:
+        """🔴 `/handoff` step 4 keys on the exit code alone. A session error that
+        escaped `TouchError` would crash with a traceback — still non-zero, but
+        the skill's contract is that the stderr line is printable verbatim."""
+        for cls in (
+            st.ExtractorMissingError,
+            st.TranscriptMissingError,
+            st.TranscriptAmbiguousError,
+            st.TranscriptStaleError,
+            st.TranscriptUnreadableError,
+            st.TranscriptCwdMismatchError,
+        ):
+            assert issubclass(cls, st.TouchError), cls
+
+
+class TestTranscriptIsBeingAppendedTo:
+    """🔴 The transcript is LIVE while this reads it. `/handoff` runs the tool
+    during the very session the transcript belongs to, so the last line can be a
+    half-written object. Three things must hold, and only the first is obvious.
+    """
+
+    def test_the_fixture_really_IS_partial(self, tmp_path: Path) -> None:
+        """Positive control on the FIXTURE. A 'partial line' test whose last line
+        happens to parse is testing nothing at all."""
+        repo = _init_repo(tmp_path, SCOPE)
+        t = _write_transcript(
+            tmp_path / "t.jsonl",
+            str(repo),
+            [f"{repo}/src/collector/a.py"],
+            trailing_partial=True,
+        )
+        last = t.read_text(encoding="utf-8").splitlines()[-1]
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(last)
+
+    def test_a_partial_trailing_line_does_not_CRASH_the_run(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        repo = _init_repo(tmp_path, SCOPE)
+        t = _write_transcript(
+            tmp_path / "t.jsonl",
+            str(repo),
+            [f"{repo}/src/collector/a.py", f"{repo}/src/collector/b.py"],
+            trailing_partial=True,
+        )
+        src = _session_source(repo, t)  # must not raise
+        assert set(src.paths) == {"src/collector/a.py", "src/collector/b.py"}
+
+    def test_a_partial_line_does_not_SILENTLY_TRUNCATE_the_complete_ones(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        """🔴 The failure that would matter: a decoder that abandons the file at
+        the first bad line would drop every complete line AFTER it. Asserted by
+        comparing against the same transcript without the partial tail — the sets
+        must be equal, so a truncating reader is visible as a smaller set."""
+        repo = _init_repo(tmp_path, SCOPE)
+        files = [f"{repo}/src/collector/{n}.py" for n in ("a", "b", "c")]
+        whole = _write_transcript(tmp_path / "whole.jsonl", str(repo), files)
+        torn = _write_transcript(
+            tmp_path / "torn.jsonl", str(repo), files, trailing_partial=True
+        )
+        assert _session_source(repo, torn).paths == _session_source(repo, whole).paths
+        assert len(_session_source(repo, torn).paths) == 3
+
+    def test_a_transcript_that_is_ONLY_a_partial_line_is_UNREADABLE(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        """The other end of the same edge: nothing parseable at all is UNKNOWN,
+        and must raise rather than report an empty window."""
+        repo = _init_repo(tmp_path, SCOPE)
+        t = _write_transcript(
+            tmp_path / "t.jsonl", str(repo), [f"{repo}/a.py"], only_partial=True
+        )
+        with pytest.raises(st.TranscriptUnreadableError):
+            _session_source(repo, t)
+
+
+class TestTheExtractorIsREUSED:
+    """🔴 #398 already implements transcript → changed-paths, and a second
+    implementation is the duplicated predicate that has ALREADY drifted once
+    here: the opencode summariser read key names its store never used and emitted
+    `files_modified=0` for every session for months, green against fixtures built
+    in the same wrong shape.
+
+    Pinned BEHAVIOURALLY — the tailer is loaded independently and its answer is
+    compared — because a grep for "does this file define an extractor" is the
+    spelled guard that passes while a differently-spelled one drifts.
+    """
+
+    def _tailer(self):
+        claude_dir = ROOT / "scripts" / "collector" / "claude"
+        for d in (str(claude_dir.parent), str(claude_dir)):
+            if d not in sys.path:
+                sys.path.insert(0, d)
+        spec = importlib.util.spec_from_file_location(
+            "independent_session_tailer", claude_dir / "session-tailer.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["independent_session_tailer"] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_the_paths_are_BYTE_FOR_BYTE_the_shared_extractor_s(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        repo = _init_repo(tmp_path, SCOPE)
+        files = [f"{repo}/src/collector/{n}.py" for n in ("c", "a", "b")]
+        t = _write_transcript(tmp_path / "t.jsonl", str(repo), files)
+        rollup = self._tailer().summarize_transcript(str(t))
+        assert list(_session_source(repo, t).paths) == rollup["changed_paths"]
+        assert rollup["changed_paths"], "the comparison is vacuous — the shared side is empty"
+
+    def test_the_cap_and_the_outside_count_come_from_the_shared_module_too(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        repo = _init_repo(tmp_path, SCOPE)
+        t = _write_transcript(
+            tmp_path / "t.jsonl",
+            str(repo),
+            [f"{repo}/src/collector/a.py", f"{tmp_path}/elsewhere/b.py"],
+        )
+        rollup = self._tailer().summarize_transcript(str(t))
+        src = _session_source(repo, t)
+        assert rollup["changed_paths_outside_cwd"] == 1
+        assert any("1 outside it" in n for n in src.notes)
+
+    def test_a_SUBAGENT_s_edits_are_absent_AND_the_caveat_says_so(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        """🔴 The blind spot, measured rather than assumed: the shared extractor
+        skips `isSidechain` turns, so a subagent's edits are not in this window.
+        That is the right call — a subagent typically works in a temp worktree
+        whose paths would inject `.claude/worktrees/agent-<hash>` components and
+        manufacture associations — but it MUST be stated, not discovered."""
+        repo = _init_repo(tmp_path, SCOPE)
+        cwd = str(repo)
+        t = _write_transcript(
+            tmp_path / "t.jsonl",
+            cwd,
+            [f"{cwd}/src/collector/a.py"],
+            sidechain_files=[f"{cwd}/src/status-bar/z.py"],
+        )
+        src = _session_source(repo, t)
+        assert src.paths == ("src/collector/a.py",)
+        assert "src/status-bar/z.py" not in src.paths
+        assert "SUBAGENT" in src.caveat
+
+
+class TestSessionCaveatIsAccuratePerSource:
+    """🔴 The old caveat becomes FALSE IN THE OTHER DIRECTION under a session
+    source: "what this BRANCH touched, NOT what this SESSION touched" would
+    UNDERSTATE a window that is exactly per-session. A single hedging sentence
+    covering both sources would be wrong about both."""
+
+    def test_the_session_caveat_does_not_claim_to_be_a_branch_window(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        repo = _init_repo(tmp_path, SCOPE)
+        t = _write_transcript(tmp_path / "t.jsonl", str(repo), [f"{repo}/a.py"])
+        caveat = _session_source(repo, t).caveat
+        assert "BRANCH" not in caveat
+        assert "NOT what this SESSION touched" not in caveat
+        assert "THIS SESSION's own turns" in caveat
+
+    def test_the_git_caveat_is_UNCHANGED(self, tmp_path: Path) -> None:
+        """The fallback keeps its own honest bound; adding a source must not
+        soften the claim the other one makes."""
+        repo = _init_repo(tmp_path, SCOPE)
+        _run_git(repo, "checkout", "-b", "topic", home=tmp_path)
+        _write(repo, "src/collector/a.py")
+        _run_git(repo, "add", "src", home=tmp_path)
+        _run_git(repo, "commit", "-m", "w", home=tmp_path)
+        assert "NOT what this SESSION touched" in st.collect_git_paths(repo).caveat
+
+    def test_the_session_caveat_names_ALL_THREE_blind_spots(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        """A caveat that names one omission reads as if it were the only one."""
+        repo = _init_repo(tmp_path, SCOPE)
+        t = _write_transcript(tmp_path / "t.jsonl", str(repo), [f"{repo}/a.py"])
+        caveat = _session_source(repo, t).caveat
+        for phrase in ("SUBAGENT", "Bash command", "outside the session cwd"):
+            assert phrase in caveat, phrase
+
+    @pytest.mark.parametrize("status_paths,expect", [
+        (["src/collector/a.py", "src/collector/b.py"], "resolved"),
+        (["docs/a.md", "docs/b.md"], "no-match"),
+        ([], "looked-at-nothing"),
+    ], ids=["resolved", "no-match", "looked-at-nothing"])
+    def test_the_caveat_is_on_EVERY_output_path_of_BOTH_renderers(
+        self, tmp_path: Path, tailer_cache, status_paths, expect
+    ) -> None:
+        """🔴 The property the #415 audit established and this change must keep:
+        the caveat is on every output path and both renderers — including the
+        early-return `looked-at-nothing` branch, which is the one that returns
+        before most of the text is built."""
+        repo = _init_repo(tmp_path, SCOPE)
+        cwd = str(repo)
+        store = _make_store(tmp_path / "s")
+        files = [f"{cwd}/{p}" for p in status_paths] or [f"{tmp_path}/away/x.py"]
+        t = _write_transcript(tmp_path / "t.jsonl", cwd, files)
+        rep = st.build_report(_session_source(repo, t), store, SCOPE, today=TODAY)
+        assert rep.status == expect
+        caveat = rep.source.caveat
+        assert caveat in st.render_text(rep)
+        assert st.report_json(rep)["source"]["caveat"] == caveat
+        assert st.report_json(rep)["source"]["session"] is not None
+
+
+class TestSessionCli:
+    """The CLI is the only surface `/handoff` touches."""
+
+    def _run(self, args, capsys):
+        rc = st.main(args)
+        return rc, capsys.readouterr()
+
+    def _fixture(self, tmp_path: Path, projects_root: Path, **kw):
+        repo = _init_repo(tmp_path, SCOPE)
+        t = _write_transcript(
+            projects_root / f"{SESSION_ID}.jsonl",
+            str(repo),
+            [f"{repo}/src/collector/a.py", f"{repo}/src/collector/b.py"],
+            **kw,
+        )
+        return repo, t, _make_store(tmp_path / "s")
+
+    def test_a_session_uuid_resolves_end_to_end(
+        self, tmp_path: Path, projects_root: Path, tailer_cache, capsys
+    ) -> None:
+        repo, _t, store = self._fixture(tmp_path, projects_root)
+        rc, cap = self._run(
+            ["--repo", str(repo), "--store", str(store), "--session", SESSION_ID,
+             "--today", TODAY, "--json"],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(cap.out)
+        assert payload["source"]["kind"] == "session"
+        assert payload["source"]["window"] == "session"
+        assert payload["source"]["session"] == SESSION_ID
+        assert payload["status"] == "resolved"
+        assert payload["known"][0]["ref"] == "collector"
+
+    def test_transcript_and_session_agree(
+        self, tmp_path: Path, projects_root: Path, tailer_cache, capsys
+    ) -> None:
+        """`--transcript` is the SAME source with the lookup skipped — not a
+        second, laxer path. Both must produce the same window."""
+        repo, t, store = self._fixture(tmp_path, projects_root)
+        base = ["--repo", str(repo), "--store", str(store), "--today", TODAY, "--json"]
+        rc1, c1 = self._run(base + ["--session", SESSION_ID], capsys)
+        rc2, c2 = self._run(base + ["--transcript", str(t)], capsys)
+        assert rc1 == rc2 == 0
+        p1, p2 = json.loads(c1.out), json.loads(c2.out)
+        assert p1["source"]["paths"] == p2["source"]["paths"]
+        assert p2["source"]["kind"] == "session"
+
+    def test_transcript_runs_the_SAME_guards(
+        self, tmp_path: Path, projects_root: Path, tailer_cache, capsys
+    ) -> None:
+        """🔴 If `--transcript` skipped validation it would be the escape hatch
+        that voids the whole check."""
+        repo, t, store = self._fixture(
+            tmp_path, projects_root, age_seconds=st.MAX_TRANSCRIPT_AGE_SECONDS + 60
+        )
+        rc, cap = self._run(
+            ["--repo", str(repo), "--store", str(store), "--transcript", str(t),
+             "--today", TODAY],
+            capsys,
+        )
+        assert rc == 3
+        assert "transcript is stale" in cap.err
+
+    @pytest.mark.parametrize(
+        "kw,sentinel",
+        [
+            ({}, "transcript not found"),
+            ({"age_seconds": st.MAX_TRANSCRIPT_AGE_SECONDS + 60}, "transcript is stale"),
+        ],
+        ids=["missing", "stale"],
+    )
+    def test_a_validation_failure_EXITS_3_and_prints_NOTHING_to_stdout(
+        self, tmp_path: Path, projects_root: Path, tailer_cache, capsys, kw, sentinel
+    ) -> None:
+        """🔴 THE NO-FALLBACK CONTRACT, at the surface `/handoff` reads. A report
+        on stdout beside a non-zero exit is how a fallback would look."""
+        repo, t, store = self._fixture(tmp_path, projects_root, **kw)
+        if sentinel == "transcript not found":
+            t.unlink()
+        rc, cap = self._run(
+            ["--repo", str(repo), "--store", str(store), "--session", SESSION_ID,
+             "--today", TODAY],
+            capsys,
+        )
+        assert rc == 3
+        assert sentinel in cap.err
+        assert cap.out.strip() == "", f"a failure still printed a report: {cap.out!r}"
+
+    def test_the_git_window_is_NEVER_what_a_failed_session_returns(
+        self, tmp_path: Path, projects_root: Path, tailer_cache, capsys
+    ) -> None:
+        """The positive control for the test above: the repo has a REAL git
+        window, so a fallback would have produced a visible, plausible report."""
+        repo, t, store = self._fixture(tmp_path, projects_root)
+        _write(repo, "src/collector/leftover.py")
+        assert st.collect_git_paths(repo).paths, "no git window — the control is vacuous"
+        t.unlink()
+        rc, cap = self._run(
+            ["--repo", str(repo), "--store", str(store), "--session", SESSION_ID,
+             "--today", TODAY],
+            capsys,
+        )
+        assert rc == 3
+        assert "collector" not in cap.out
+
+    def test_session_and_transcript_are_mutually_exclusive(
+        self, tmp_path: Path, projects_root: Path, capsys
+    ) -> None:
+        with pytest.raises(SystemExit) as exc:
+            st.main(["--session", SESSION_ID, "--transcript", "/x/y.jsonl"])
+        assert exc.value.code == 2
+
+    def test_session_plus_paths_from_is_REFUSED_not_resolved(
+        self, tmp_path: Path, projects_root: Path, tailer_cache, capsys
+    ) -> None:
+        """Two different windows asked for at once. Honouring either silently is
+        the same wrong-answer class as falling back."""
+        repo, _t, store = self._fixture(tmp_path, projects_root)
+        rc, cap = self._run(
+            ["--repo", str(repo), "--store", str(store), "--session", SESSION_ID,
+             "--paths-from", "-", "--today", TODAY],
+            capsys,
+        )
+        assert rc == 2
+        assert "cannot be combined with --paths-from" in cap.err
+        assert cap.out.strip() == ""
+
+    def test_git_remains_the_default_when_no_session_is_given(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """The fallback is still the fallback — adding a source must not change
+        what an unchanged call does."""
+        repo = _init_repo(tmp_path, SCOPE)
+        _run_git(repo, "checkout", "-b", "topic", home=tmp_path)
+        _write(repo, "src/collector/a.py")
+        _write(repo, "src/collector/b.py")
+        store = _make_store(tmp_path / "s")
+        rc, cap = self._run(
+            ["--repo", str(repo), "--store", str(store), "--today", TODAY, "--json"],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(cap.out)
+        assert payload["source"]["kind"] == "git"
+        assert payload["source"]["session"] is None
+
+    def test_exclude_applies_to_the_SESSION_window_too(
+        self, tmp_path: Path, projects_root: Path, tailer_cache, capsys
+    ) -> None:
+        """🔴 `/handoff` WRITES its own doc in step 2 with the Write tool, so the
+        doc is in the session window as surely as it is untracked in git's. An
+        exclusion honoured by one source and not the other makes the ritual
+        nominate its own artifact on half the runs."""
+        repo = _init_repo(tmp_path, SCOPE)
+        doc = "claudedocs/handoff-topic.md"
+        _write_transcript(
+            projects_root / f"{SESSION_ID}.jsonl",
+            str(repo),
+            [f"{repo}/src/collector/a.py", f"{repo}/{doc}"],
+        )
+        store = _make_store(tmp_path / "s")
+        rc, cap = self._run(
+            ["--repo", str(repo), "--store", str(store), "--session", SESSION_ID,
+             "--exclude", doc, "--today", TODAY, "--json"],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(cap.out)
+        assert payload["source"]["paths"] == ["src/collector/a.py"]
+        assert any("excluded 1" in n for n in payload["source"]["notes"])
+
+    def test_the_exclusion_is_the_SAME_predicate_as_git_s(
+        self, tmp_path: Path, projects_root: Path, tailer_cache
+    ) -> None:
+        """Structural, not two spellings that happen to agree today: the same
+        helper, reached from both sources."""
+        repo = _init_repo(tmp_path, SCOPE)
+        doc = "claudedocs/handoff-topic.md"
+        _write(repo, doc)
+        _write(repo, "src/collector/a.py")
+        git_src = st.collect_git_paths(repo, exclude=[doc])
+        t = _write_transcript(
+            tmp_path / "t.jsonl", str(repo), [f"{repo}/{doc}", f"{repo}/src/collector/a.py"]
+        )
+        ses_src = _session_source(repo, t, exclude=[doc])
+        assert doc not in git_src.paths and doc not in ses_src.paths
+        assert any("excluded 1" in n for n in git_src.notes)
+        assert any("excluded 1" in n for n in ses_src.notes)
+
+
+class TestSessionSourceNeverWrites:
+    """The store hash either side of the session path, for the same reason
+    `TestNeverWrites` does it for every other mode: the module has no write call
+    site and must acquire none."""
+
+    def test_the_session_report_leaves_the_store_byte_identical(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        repo = _init_repo(tmp_path, SCOPE)
+        store = _make_store(tmp_path / "s")
+        t = _write_transcript(
+            tmp_path / "t.jsonl", str(repo), [f"{repo}/src/collector/{n}.py" for n in "ab"]
+        )
+        before = _tree_hash(store)
+        rep = st.build_report(_session_source(repo, t), store, SCOPE, today=TODAY)
+        st.render_text(rep)
+        json.dumps(st.report_json(rep))
+        assert rep.status == "resolved"
+        assert _tree_hash(store) == before
+
+    def test_the_transcript_itself_is_never_written_either(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        """🔴 `~/.claude/projects/` is LIVE session state. The tool reads it and
+        must never touch it — pinned on bytes AND on mtime, since a read that
+        rewrote identical content would pass a content check alone."""
+        repo = _init_repo(tmp_path, SCOPE)
+        t = _write_transcript(
+            tmp_path / "t.jsonl", str(repo), [f"{repo}/src/collector/a.py"]
+        )
+        before, before_stat = t.read_bytes(), t.stat().st_mtime_ns
+        _session_source(repo, t)
+        assert t.read_bytes() == before
+        assert t.stat().st_mtime_ns == before_stat
+
+
+class TestNoRealTranscript:
+    """🔴 No test in this file may read a real transcript. `~/.claude/projects/`
+    is live session state and this repo is PUBLIC."""
+
+    #: A real v4 UUID's 32 hex digits are ~uniformly random, so it carries ~15-16
+    #: DISTINCT characters. A hand-built fixture id carries 3. The bound below
+    #: cannot be met by accident, which is what makes it a check rather than a
+    #: comment — and `test_the_id_check_can_report_a_REAL_uuid` is its negative
+    #: control, without which a threshold that passes everything looks identical.
+    MAX_DISTINCT_HEX_IN_A_SYNTHETIC_ID = 3
+
+    def test_the_fixture_session_ids_are_not_real(self) -> None:
+        """A real UUID committed here would name one of the user's own sessions."""
+        for sid in (SESSION_ID, OTHER_SESSION_ID):
+            digits = set(sid.replace("-", ""))
+            assert len(digits) <= self.MAX_DISTINCT_HEX_IN_A_SYNTHETIC_ID, (
+                f"{sid} looks like a real UUID, not a synthetic one"
+            )
+
+    def test_the_id_check_can_report_a_REAL_uuid(self) -> None:
+        """Negative control on the check above: a threshold nothing can fail is
+        indistinguishable from no check at all."""
+        import uuid
+
+        real_shaped = str(uuid.uuid4())
+        assert (
+            len(set(real_shaped.replace("-", "")))
+            > self.MAX_DISTINCT_HEX_IN_A_SYNTHETIC_ID
+        )
+
+    def test_the_default_roots_are_outside_this_repo(self, tailer_cache) -> None:
+        for root in st._session_tailer().projects_roots():
+            assert not str(Path(root).resolve()).startswith(str(ROOT))
+
+    def test_the_lookup_honours_the_test_override(self, tmp_path: Path, monkeypatch, tailer_cache) -> None:
+        """The mechanism every test above relies on to stay off the real tree."""
+        monkeypatch.setenv("CLAUDE_PROJECTS_DIR", str(tmp_path))
+        assert st._session_tailer().projects_roots() == [str(tmp_path)]
 
 
 # =============================================================================
@@ -1751,8 +2649,19 @@ class TestMutationKillMatrix:
 
     def test_kills_the_exclusion_accounting(self, tmp_path: Path) -> None:
         """A path that vanishes with no note is a smaller number with no reason."""
+        # Anchored on the assignment ABOVE the `if`, not on the `if` alone: since
+        # the session source shares `_filter_excluded`, `    if dropped:` now
+        # occurs twice and the loader's uniqueness assert caught the ambiguity
+        # rather than letting the mutation land on the wrong occurrence.
         mod = _load_mutant(
-            tmp_path, "m_excl_note", [("    if dropped:", "    if False:")]
+            tmp_path,
+            "m_excl_note",
+            [
+                (
+                    "    paths, dropped = _filter_excluded(raw, exclude)\n    if dropped:",
+                    "    paths, dropped = _filter_excluded(raw, exclude)\n    if False:",
+                )
+            ],
         )
         repo = _init_repo(tmp_path)
         _write(repo, "claudedocs/handoff-topic.md")
@@ -1780,3 +2689,330 @@ class TestMutationKillMatrix:
         )
         assert rep.status == "resolved"
         assert [m.entry.ref for m in rep.known] == ["collector"]
+
+
+# =============================================================================
+# 🔴 MUTATION KILL MATRIX — the SESSION source's guards.
+# =============================================================================
+
+
+def _session_mutant(tmp_path: Path, name: str, replacements, tailer):
+    """A mutant that can reach the session source.
+
+    ⚠ THE INJECTION IS NOT PART OF THE MUTATION. A mutant is written to
+    `tmp_path`, so its `__file__` traversal to `scripts/collector/claude/` lands
+    nowhere and `_session_tailer()` would raise `ExtractorMissingError` for every
+    mutant alike — making every kill below green for the wrong reason. Handing it
+    the already-loaded extractor removes that confound and changes nothing about
+    the guard under test.
+    """
+    mod = _load_mutant(tmp_path, name, replacements)
+    mod._SESSION_TAILER = tailer
+    return mod
+
+
+class TestSessionMutationKillMatrix:
+    """Each session guard deleted on purpose, each dying to ITS OWN test.
+
+    🔴 The confound this class is built around: these guards sit in a CHAIN, and
+    a mutant with one removed usually trips the NEXT one. A kill that merely
+    asserts "something raised" would be green with the guard it names deleted, so
+    every test below asserts the specific sentinel is GONE — and, where the chain
+    would otherwise swallow the effect, that the run now SUCCEEDS with the wrong
+    answer, which is the actual hazard.
+    """
+
+    @pytest.fixture()
+    def tailer(self, tailer_cache):
+        return st._session_tailer()
+
+    def test_the_session_mutant_harness_WORKS(self, tmp_path: Path, tailer) -> None:
+        """Positive control on this class's own loader: an unmutated copy must
+        reach the session source successfully, or every kill is vacuous."""
+        mod = _session_mutant(
+            tmp_path, "ms_noop", [('WRITER_ID = "handoff"', 'WRITER_ID = "handoff"  # noop')], tailer
+        )
+        repo = _init_repo(tmp_path, SCOPE)
+        t = _write_transcript(
+            tmp_path / "t.jsonl", str(repo), [f"{repo}/src/collector/a.py"]
+        )
+        assert mod.collect_session_paths(repo, transcript=t).paths == ("src/collector/a.py",)
+
+    def test_kills_the_STALE_guard(self, tmp_path: Path, tailer) -> None:
+        """Without it a yesterday's-uuid paste is reported as this session's
+        work — silently, and with a perfectly well-formed answer."""
+        mod = _session_mutant(
+            tmp_path, "ms_stale", [("    if age > max_age_seconds:", "    if False:")], tailer
+        )
+        repo = _init_repo(tmp_path, SCOPE)
+        t = _write_transcript(
+            tmp_path / "t.jsonl",
+            str(repo),
+            [f"{repo}/src/collector/a.py"],
+            age_seconds=st.MAX_TRANSCRIPT_AGE_SECONDS * 100,
+        )
+        src = mod.collect_session_paths(repo, transcript=t)
+        assert src.paths == ("src/collector/a.py",), "the stale guard was not the thing removed"
+        with pytest.raises(st.TranscriptStaleError):
+            st.collect_session_paths(repo, transcript=t)
+
+    def test_kills_the_UNREADABLE_guard(self, tmp_path: Path, tailer) -> None:
+        """🔴 Without it an unobservable file set becomes an EMPTY one, and
+        `looked-at-nothing` — a confident 'this session touched nothing' from a
+        transcript that was never read. The chain does not save it: an unreadable
+        transcript has cwd '' and the mutant is shown to die on the NEXT guard,
+        so this asserts the STALE/UNREADABLE sentinel is gone specifically."""
+        mod = _session_mutant(
+            tmp_path,
+            "ms_unread",
+            [('    if rollup.get("unreadable") or observed is None:', "    if False:")],
+            tailer,
+        )
+        repo = _init_repo(tmp_path, SCOPE)
+        t = tmp_path / "corrupt.jsonl"
+        t.write_text("not json\n", encoding="utf-8")
+        with pytest.raises(Exception) as exc:
+            mod.collect_session_paths(repo, transcript=t)
+        assert "transcript unreadable" not in str(exc.value)
+        # The mutant's OWN class — an exec'd copy defines its own exceptions.
+        assert isinstance(exc.value, mod.TranscriptCwdMismatchError)
+        with pytest.raises(st.TranscriptUnreadableError):
+            st.collect_session_paths(repo, transcript=t)
+
+    def test_kills_the_UNREADABLE_guard_where_it_ALONE_stands(
+        self, tmp_path: Path, tailer
+    ) -> None:
+        """🔴 The kill above is reached through the CWD guard, because a corrupt
+        transcript also has no cwd — so on its own it cannot show WHICH guard is
+        load-bearing. This one removes that confound: the extractor is replaced
+        by one that reads the session fine (cwd intact) but reports an
+        UNOBSERVABLE file set, which is the extractor's own contract for "we could
+        not see the files". Nothing downstream rejects that input, so this guard
+        is the only thing standing.
+
+        ⚠ MEASURED, NOT ASSUMED: with the guard removed the run does NOT report a
+        silent empty window — `None` reaches `_filter_excluded` and dies with a
+        bare `TypeError`. That is still a kill, and it is the honest one: the
+        real module fails with a NAMED, printable sentence, and `/handoff` step 4
+        is instructed to print that stderr line verbatim. A traceback is not
+        that.
+        """
+
+        class _Unobservable:
+            """The extractor's own 'we could not observe this' shape."""
+
+            @staticmethod
+            def summarize_transcript(path):
+                r = tailer.summarize_transcript(path)
+                r.update({"changed_paths": None, "changed_paths_total": None,
+                          "changed_paths_outside_cwd": None})
+                return r
+
+            projects_roots = staticmethod(tailer.projects_roots)
+
+        repo = _init_repo(tmp_path, SCOPE)
+        t = _write_transcript(tmp_path / "t.jsonl", str(repo), [f"{repo}/a.py"])
+
+        mod = _session_mutant(
+            tmp_path,
+            "ms_unread2",
+            [('    if rollup.get("unreadable") or observed is None:', "    if False:")],
+            _Unobservable,
+        )
+        with pytest.raises(Exception) as exc:
+            mod.collect_session_paths(repo, transcript=t)
+        assert isinstance(exc.value, TypeError)
+        assert "transcript unreadable" not in str(exc.value)
+
+        # The unmutated module, same input, same replaced extractor: a named
+        # error. This is what proves the guard — not the mutant — is what turns
+        # an unobservable file set into a printable refusal.
+        real = _session_mutant(
+            tmp_path,
+            "ms_unread3",
+            [('WRITER_ID = "handoff"', 'WRITER_ID = "handoff"  # noop')],
+            _Unobservable,
+        )
+        # `real.` and not `st.`: an exec'd copy defines its OWN exception
+        # classes, so `st.TranscriptUnreadableError` would never match and the
+        # assertion would be about module identity rather than behaviour.
+        with pytest.raises(real.TranscriptUnreadableError) as ok:
+            real.collect_session_paths(repo, transcript=t)
+        assert "transcript unreadable" in str(ok.value)
+
+    def test_kills_the_CWD_guard(self, tmp_path: Path, tailer) -> None:
+        """🔴 The most consequential one. Without it, another repo's paths are
+        reported — repo-relative to the WRONG root — and they RESOLVE, producing
+        a fully plausible report attributing someone else's work to this repo."""
+        mod = _session_mutant(
+            tmp_path,
+            "ms_cwd",
+            [("    if not _same_dir(session_cwd, toplevel):", "    if False:")],
+            tailer,
+        )
+        repo = _init_repo(tmp_path, SCOPE)
+        other = tmp_path / "another-repo"
+        t = _write_transcript(
+            tmp_path / "t.jsonl", str(other), [f"{other}/src/collector/a.py"]
+        )
+        leaked = mod.collect_session_paths(repo, transcript=t)
+        assert leaked.paths == ("src/collector/a.py",), "no leak — wrong thing removed"
+        store = _make_store(tmp_path / "s")
+        rep = mod.build_report(leaked, store, SCOPE, today=TODAY, min_paths=1)
+        assert [m.entry.ref for m in rep.known] == ["collector"], (
+            "the leaked path did not even resolve — this kill would be vacuous"
+        )
+        with pytest.raises(st.TranscriptCwdMismatchError):
+            st.collect_session_paths(repo, transcript=t)
+
+    def test_kills_the_EMPTY_CWD_guard_inside_same_dir(self, tmp_path: Path, tailer) -> None:
+        """`realpath("")` is the process cwd, so without the empty check a
+        session that recorded no cwd matches wherever the tool was launched."""
+        mod = _session_mutant(
+            tmp_path, "ms_empty", [("    if not a or not b:", "    if False:")], tailer
+        )
+        assert mod._same_dir("", os.getcwd()) is True
+        assert st._same_dir("", os.getcwd()) is False
+
+    def test_kills_the_MISSING_guard(self, tmp_path: Path, projects_root: Path, tailer) -> None:
+        """Without it an unresolvable id falls off the end of the function."""
+        mod = _session_mutant(
+            tmp_path, "ms_missing", [("    if not hits:", "    if False:")], tailer
+        )
+        with pytest.raises(Exception) as exc:
+            mod.find_transcript(SESSION_ID)
+        assert "transcript not found: no `" not in str(exc.value)
+        with pytest.raises(st.TranscriptMissingError):
+            st.find_transcript(SESSION_ID)
+
+    def test_kills_the_AMBIGUITY_guard(self, tmp_path: Path, projects_root: Path, tailer) -> None:
+        """🔴 Without it the resolver PICKS — silently harvesting whichever
+        transcript sorted first, which is the coin flip this refuses to make."""
+        mod = _session_mutant(
+            tmp_path, "ms_ambig", [("    if len(hits) > 1:", "    if False:")], tailer
+        )
+        for sub in ("a", "b"):
+            _write_transcript(
+                projects_root / sub / f"{SESSION_ID}.jsonl", str(tmp_path), ["x.py"]
+            )
+        picked = mod.find_transcript(SESSION_ID)
+        assert picked.name == f"{SESSION_ID}.jsonl"
+        with pytest.raises(st.TranscriptAmbiguousError):
+            st.find_transcript(SESSION_ID)
+
+    def test_kills_the_SESSION_CAVEAT_branch(self, tmp_path: Path, tailer) -> None:
+        """🔴 With the branch gone the caveat falls through to the GIT text —
+        'what this BRANCH touched, NOT what this SESSION touched' — printed over
+        a per-session window, which understates it in the opposite direction and
+        is the specific wrongness this change exists to remove."""
+        mod = _session_mutant(
+            tmp_path, "ms_caveat", [('        if self.kind == "session":', "        if False:")], tailer
+        )
+        repo = _init_repo(tmp_path, SCOPE)
+        t = _write_transcript(tmp_path / "t.jsonl", str(repo), [f"{repo}/a.py"])
+        wrong = mod.collect_session_paths(repo, transcript=t).caveat
+        assert "NOT what this SESSION touched" in wrong or "uncommitted work only" in wrong
+        assert "THIS SESSION's own turns" not in wrong
+        assert "THIS SESSION's own turns" in st.collect_session_paths(
+            repo, transcript=t
+        ).caveat
+
+    def test_kills_the_SESSION_EXCLUSION(self, tmp_path: Path, tailer) -> None:
+        """The ritual's own artifact leaks back into the window it wrote."""
+        mod = _session_mutant(
+            tmp_path,
+            "ms_excl",
+            [("    paths, dropped = _filter_excluded(observed, exclude)",
+              "    paths, dropped = list(observed), []")],
+            tailer,
+        )
+        repo = _init_repo(tmp_path, SCOPE)
+        doc = "claudedocs/handoff-topic.md"
+        t = _write_transcript(
+            tmp_path / "t.jsonl", str(repo), [f"{repo}/{doc}", f"{repo}/src/collector/a.py"]
+        )
+        assert doc in mod.collect_session_paths(repo, transcript=t, exclude=[doc]).paths
+        assert doc not in st.collect_session_paths(repo, transcript=t, exclude=[doc]).paths
+
+    def test_kills_the_NO_FALLBACK_contract(
+        self, tmp_path: Path, projects_root: Path, tailer, capsys
+    ) -> None:
+        """🔴 THE CENTRAL PROPERTY, mutated directly: a validation failure that
+        falls back to git returns 0 and prints a plausible report — an answer to
+        a question the caller did not ask, from a window that overlaps enough to
+        look right. `/handoff` step 4 keys on the exit code, so this mutant would
+        cause a WRITE."""
+        mod = _session_mutant(
+            tmp_path,
+            "ms_fallback",
+            [
+                (
+                    "    except (TouchError, ResolverError) as exc:\n"
+                    '        print(f"subsystem-touch: {exc}", file=sys.stderr)\n'
+                    "        return 3",
+                    "    except (TouchError, ResolverError) as exc:\n"
+                    '        print(f"subsystem-touch: {exc}", file=sys.stderr)\n'
+                    "        print(render_text(build_report(collect_git_paths(repo), "
+                    "args.store, scope, today=stamp)))\n"
+                    "        return 0",
+                )
+            ],
+            tailer,
+        )
+        repo = _init_repo(tmp_path, SCOPE)
+        _write(repo, "src/collector/a.py")
+        _write(repo, "src/collector/b.py")
+        store = _make_store(tmp_path / "s")
+        argv = ["--repo", str(repo), "--store", str(store), "--session", SESSION_ID,
+                "--today", TODAY]
+
+        capsys.readouterr()
+        assert mod.main(argv) == 0
+        leaked = capsys.readouterr()
+        assert "collector" in leaked.out, "the fallback produced nothing — kill is vacuous"
+
+        assert st.main(argv) == 3
+        real = capsys.readouterr()
+        assert real.out.strip() == ""
+        assert "transcript not found" in real.err
+
+    def test_kills_the_PATHS_FROM_conflict_guard(
+        self, tmp_path: Path, projects_root: Path, tailer, capsys
+    ) -> None:
+        """Without it, `--session X --paths-from -` silently honours ONE of two
+        contradictory windows."""
+        mod = _session_mutant(
+            tmp_path,
+            "ms_conflict",
+            [('        if wants_session and args.paths_from != "git":',
+              "        if False:")],
+            tailer,
+        )
+        repo = _init_repo(tmp_path, SCOPE)
+        _write_transcript(
+            projects_root / f"{SESSION_ID}.jsonl",
+            str(repo),
+            [f"{repo}/src/collector/a.py", f"{repo}/src/collector/b.py"],
+        )
+        store = _make_store(tmp_path / "s")
+        argv = ["--repo", str(repo), "--store", str(store), "--session", SESSION_ID,
+                "--paths-from", "-", "--today", TODAY]
+        capsys.readouterr()
+        assert mod.main(argv) == 0
+        assert st.main(argv) == 2
+        assert "cannot be combined" in capsys.readouterr().err
+
+    def test_kills_the_EXTRACTOR_presence_guard(
+        self, tmp_path: Path, monkeypatch, tailer_cache
+    ) -> None:
+        """Without it a missing extractor dies with an unprintable traceback
+        instead of the sentence `/handoff` is told to print verbatim."""
+        mod = _load_mutant(
+            tmp_path, "ms_extractor", [("    if not mod_path.is_file():", "    if False:")]
+        )
+        mod._SESSION_TAILER = None
+        mod._session_tailer_path = lambda: tmp_path / "gone.py"
+        with pytest.raises(Exception) as exc:
+            mod._session_tailer()
+        assert not isinstance(exc.value, st.ExtractorMissingError)
+        assert "session path extractor not found" not in str(exc.value)


### PR DESCRIPTION
## The measurement this exists for

#415 added a second writer to the subsystem index, riding `/handoff`. **On its first real invocation it captured nothing from the session it was built during.** Not a bug — a structural blind spot. Paths came from git, and that session landed all its work through merged PRs, so by handoff time `git diff HEAD` was empty and HEAD sat at the merge-base. The tool printed *"uncommitted work only — HEAD has no branch window… committed work is NOT represented"*, which is honest. Honest-about-seeing-nothing and useful are different properties, and merging as you go is the *better* working pattern — so the source that cannot see it is the one that changes.

`--session <uuid>` (or `--transcript <path>`) is now the **preferred** source. Git stays the fallback: already built, already tested, honest about its window.

## The extractor is reused, not rewritten

`scripts/collector/claude/session-tailer.py` + `scripts/collector/changed_paths.py` (#398) already compute exactly this set for `kind=session-summary`. A second implementation is the duplicated predicate that **has already drifted once here** — the opencode summariser read key names its store never used and emitted `files_modified=0` for every session for months, green against fixtures built in the same wrong shape. The tailer's filename has a dash, so it is loaded by explicit importlib path, the idiom already used for it in its own test.

`TestTheExtractorIsREUSED` pins this behaviourally: `list(src.paths) == rollup["changed_paths"]` against an independently-loaded tailer, plus an assert that the shared side is non-empty so the comparison cannot be vacuous.

## 🔴 The token is validated, never trusted, and never falls back

There is no session-id environment variable, so the id arrives as an argument and can be wrong. "Newest transcript by mtime" is not a fallback but a coin flip — **14 transcripts modified inside one 5-minute window**, measured over the live corpus (4,873 files, read-only).

Four guards, ordered so each is reachable by an input no earlier one rejects:

| # | guard | sentinel |
|---|---|---|
| 1 | the transcript resolves | `transcript not found` / `transcript id is ambiguous` |
| 2 | its mtime is live | `transcript is stale` |
| 3 | it reads as a session | `transcript unreadable` |
| 4 | its cwd IS this repo | `transcript cwd does not match` |

(3) **must** precede (4): an unreadable transcript has `cwd == ""`, so a cwd check placed first would fire for it and the unreadable case's own test would pass on a neighbour's error — green with the guard it claims to test deleted.

A validation failure exits 3 and prints **no report**. Falling back to git would answer a question the caller did not ask, from a window that overlaps enough to look right; `/handoff` step 4 already treats any non-zero exit as "write nothing".

## The 30-minute bound, measured

Transcripts within each bound, of 4,873:

```
 5m  14      15m  19      30m  25      1h  36      2h  38      6h  50      24h 210
```

30m admits 0.5% of the corpus and rejects 4,848 files; 24h would admit 8.4x as many. The lower edge is reasoned, not measured: `/handoff` appends to this transcript every turn and step 4 runs one assistant turn after step 3, so 30m is ~1.5 orders of magnitude of headroom. **Deliberately not env-overridable and not a CLI flag** — a safety bound with an escape hatch is one the first inconvenienced caller removes. Tests control it via the fixture's mtime.

## The caveat had to change, and could not be reused

`"what this BRANCH touched, NOT what this SESSION touched"` is **false in the other direction** over a per-session window — it would understate it. `PathSource.caveat` now branches per source, and the session branch names all three of its own blind spots:

- 🔴 **a SUBAGENT's edits are excluded** — measured at **196 of 733** file-tool calls across the 40 most recent transcripts. Correct behaviour (a subagent works in a temp worktree whose paths would inject `.claude/worktrees/agent-<hash>` components and manufacture associations), but stated rather than left to be discovered;
- files written by a `Bash` command rather than a file tool;
- paths outside the session cwd — **counted unconditionally, including at zero**, so the caveat always has a number to refer to.

The audit of #415 established that the caveat is on every output path and both renderers. `TestSessionCaveatIsAccuratePerSource` re-pins that across all three statuses, including the early-return `looked-at-nothing` branch.

## Verification

**Live**, against a real session (synthetic store, never the real one):

```
paths: 2 (session, window=session, min_paths=2)
caveat: session transcript <uuid>: the files THIS SESSION's own turns edited …
note: 2 distinct path(s) under the session cwd; 11 outside it — the latter are COUNTED …
```

and the cwd guard fired correctly on a real mismatch (an agent worktree vs. the session's recorded cwd).

**Positive-control pair** — same shape, same depth, same filenames, same store:

| | paths | status | known |
|---|---|---|---|
| under test (edits inside cwd) | **3** | `resolved` | `collector` |
| control (same files, another repo) | **0** | `looked-at-nothing` | — |
| control (inside cwd, names nothing) | 3 | `no-match` | — |

The third row is what separates "extractor wired to nothing" from "matcher wired to nothing".

**Base-vs-HEAD**: the 7 new `/handoff` doc pins are **red at `origin/main`** and green at HEAD; the 28 pre-existing pins stayed green either side. Measured from the committed baseline via `git checkout origin/main -- <paths>`, not against a dirty tree.

**Mutation matrix** — 11 kills, each dying to its own named test, each asserting the *other* sentinels are absent:

`stale` · `unreadable` (×2, one isolating it from the cwd guard) · `cwd` · `_same_dir`'s empty check · `missing` · `ambiguous` · session-caveat branch · session exclusion · **the no-fallback contract** · the `--paths-from` conflict guard · the extractor-presence guard.

The no-fallback mutant is the central one: it returns 0 and prints a plausible git report, which under `/handoff` step 4 would cause a **write**.

⚠ One honest correction: removing the unreadable guard does **not** produce a silent empty window — `None` reaches `_filter_excluded` and dies with a bare `TypeError`. Still a kill, and the test says so; the real module's value is that it fails with a *named, printable* sentence instead.

**Authoritative gate** (`nix build .#checks.x86_64-linux.pytests`), on the current rebase onto `ffa426c`:

```
PASS  scripts/tests  (collected=2697 passed=2697 skipped=0 floor=2647)
TOTAL collected=8260  passed=8259  skipped=1  failed=0
RESULT: PASS (exit=0)
```

Zero new skips (the 1 is the pre-existing pinned repo-cos one). Floor re-pinned 2579 → 2647 from the gate's own per-target line.

### The floors line, re-measured three times

This branch rebased twice (#420, then #419) and **both of its earlier floor readings are void**: `collected=2603` against a base of 2535, then `2619` after the base moved to 2551, then `2697` after it moved to 2629. Only the last describes a tree anyone will run.

Re-measuring instead of adding the deltas **caught a real error in this PR**: the first version of this branch recorded its own delta as `+118`. The measured figure is **`+68`** (`test_subsystem_touch.py` 136 → 204 tests, which is the entire target-level delta). Arithmetic across the conflict would have written that wrong number into the floor and nothing would ever have caught it — a floor is a minimum, so one that is merely *too low* fails silently forever.

Every rebase here happened to be purely additive. That is a *result* of measuring, not a licence to skip it: a merge can change collection through a shared fixture, a colliding parametrize id, or a module that stops importing, none of which are visible from either side of a conflict.

⚠ Worth someone measuring separately, not fixable here: **that line has now conflicted on eight consecutive PRs**, twice on this one. Per-target floors removed the base-dependent global total but made every test-adding PR touch the table.

Worst-case cost, measured: the largest transcript in the corpus (66.5 MB, 3,006 lines) summarises in **0.09 s**; the id glob over 4,852 files takes **0.01 s**.

## Preserved

- **Zero write call sites.** `TestSessionSourceNeverWrites` hashes the store either side of the new mode, and pins the transcript's own bytes *and* mtime — `~/.claude/projects/` is live session state.
- `--exclude` now runs through **one** predicate shared by both sources. The handoff doc is in both windows (untracked in git's, a `Write` call in the session's); an exclusion honoured by one and not the other would make the ritual nominate its own artifact on half the runs.
- No real client path, hostname, session UUID or personal name. Fixture ids are hand-built and a negative control asserts a real UUID would fail the synthetic-id check.

## 🔴 What this does NOT fix — read before merging

**The session source does not see work done by a dispatched subagent**, and that is this user's standing default for non-trivial work. Measured on the very session that produced this PR: the parent transcript reports **2 paths, both docs** — the implementation lives in a subagent's transcript, in a worktree. So a session that delegates will still under-report, just for a different reason than git did.

The caveat says so loudly, and `/handoff` is told to expect a thin set and say so rather than invent entries. But if the goal is "record what this session touched", the remaining gap is subagent attribution, not git. That is the next thing to measure, and it should not be closed by widening the shared extractor — including sidechain turns would inject worktree path components and manufacture associations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
