### PR TITLE
docs(clawgate): the extension load paths are two git checkouts, not the flat copy the skill described

### DIFF
--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -181,6 +181,8 @@ absent toolchain, the `curl` form): `reference/agent-dispatch.md`.
   hot-reload). 🔴 **Brave has MULTIPLE PROFILES that load extensions independently and can point at
   DIFFERENT paths** — one profile was left a version behind exactly this way; checking the profile in
   front of you proves nothing, and agents can't read `brave://`, so use the `Preferences`-JSON sweep
-  in `reference/extension.md`. 🔴 **Never `git restore --source=<ref> --worktree` a subtree to
-  "freshen" a stale checkout** — identical content still BLOCKS `merge --ff-only`, and any later
-  checkout silently reverts it. `~/clawgate-extension` + `sync-clawgate-extension.sh` are RETIRED.
+  in `reference/extension.md` — which also verifies the HOTKEYS, since a reload silently left
+  `Ctrl+Shift+E` unbound in two profiles. 🔴 **Never `git restore --source=<ref> --worktree` a
+  subtree to "freshen" a stale checkout** — identical content still BLOCKS an `--ff-only` merge that
+  touches that path, and any later checkout silently reverts it. `~/clawgate-extension` is deleted;
+  `sync-clawgate-extension.sh` still exists in homelab-talos but is NOT the delivery path.

--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -174,11 +174,13 @@ absent toolchain, the `curl` form): `reference/agent-dispatch.md`.
   🔴 **But `clawgate-ci` does NOT run Playwright — browser-layer changes are UNGATED by CI.** Run
   `make e2e` locally and **count** the results: `tasks.spec.ts` `test.skip`s the whole file without
   Docker, so a "green" run can mean 17 tests never executed.
-- 🔴 **The browser extension does NOT ship via Flux — merging to `trunk` deploys NOTHING**, and it
-  runs on **TWO hosts** that each load it unpacked **in place from a git checkout**: workbench
-  `~/workspace/homelab-talos/containers/clawgate/extension` (the dirty base clone) and laptop
-  (`zach@192.168.50.155`) `~/workspace/clawgate-extension/containers/clawgate/extension` (a
-  worktree). Deploying = advance BOTH checkouts + reload each `brave://extensions` (no hot-reload).
-  🔴 **`~/clawgate-extension` + `scripts/sync-clawgate-extension.sh` are a DEAD path — nothing loads
-  that directory**, yet `--check` reports a reassuring "in sync" while both browsers run something
-  else. Only Brave's own "Loaded from" line is authority → `reference/extension.md`.
+- 🔴 **The browser extension does NOT ship via Flux — merging to `trunk` deploys NOTHING.** Brave
+  loads it unpacked **in place from a git worktree**, at the same path on **BOTH hosts** (workbench +
+  laptop `zach@192.168.50.155`): `~/workspace/clawgate-extension/containers/clawgate/extension`
+  (branch `clawgate-ext-local`). Deploy = `merge --ff-only origin/trunk` on both + reload Brave (no
+  hot-reload). 🔴 **Brave has MULTIPLE PROFILES that load extensions independently and can point at
+  DIFFERENT paths** — one profile was left a version behind exactly this way; checking the profile in
+  front of you proves nothing, and agents can't read `brave://`, so use the `Preferences`-JSON sweep
+  in `reference/extension.md`. 🔴 **Never `git restore --source=<ref> --worktree` a subtree to
+  "freshen" a stale checkout** — identical content still BLOCKS `merge --ff-only`, and any later
+  checkout silently reverts it. `~/clawgate-extension` + `sync-clawgate-extension.sh` are RETIRED.

--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -174,8 +174,11 @@ absent toolchain, the `curl` form): `reference/agent-dispatch.md`.
   🔴 **But `clawgate-ci` does NOT run Playwright — browser-layer changes are UNGATED by CI.** Run
   `make e2e` locally and **count** the results: `tasks.spec.ts` `test.skip`s the whole file without
   Docker, so a "green" run can mean 17 tests never executed.
-- 🔴 **The browser extension does NOT ship via Flux — merging to `trunk` deploys NOTHING.** Brave
-  loads it unpacked from a flat copy at `~/clawgate-extension` **on the workbench**, and does not
-  hot-reload it. **A missing `.synced-from` stamp means someone hand-copied it out of band** — that
-  is how a build that never passed CI ran live for ~11 hours while `trunk` looked clean. Check the
-  stamp before trusting any claim about which build is loaded → `reference/extension.md`.
+- 🔴 **The browser extension does NOT ship via Flux — merging to `trunk` deploys NOTHING**, and it
+  runs on **TWO hosts** that each load it unpacked **in place from a git checkout**: workbench
+  `~/workspace/homelab-talos/containers/clawgate/extension` (the dirty base clone) and laptop
+  (`zach@192.168.50.155`) `~/workspace/clawgate-extension/containers/clawgate/extension` (a
+  worktree). Deploying = advance BOTH checkouts + reload each `brave://extensions` (no hot-reload).
+  🔴 **`~/clawgate-extension` + `scripts/sync-clawgate-extension.sh` are a DEAD path — nothing loads
+  that directory**, yet `--check` reports a reassuring "in sync" while both browsers run something
+  else. Only Brave's own "Loaded from" line is authority → `reference/extension.md`.

--- a/claude/skills/clawgate/reference/extension.md
+++ b/claude/skills/clawgate/reference/extension.md
@@ -4,22 +4,77 @@ Read when: you changed the clawgate browser extension, or you need to know **whi
 loaded** in Zach's Brave.
 
 ## 🔴 The extension does NOT ship via Flux — merging to `trunk` deploys NOTHING
-Brave loads it unpacked from a **flat copy** at `~/clawgate-extension` **on the workbench** (that is
-where Zach's Brave runs — `localhost:8972` civitai-manager answers there, not on the desktop).
+It runs on **TWO hosts**, and each Brave loads it **unpacked, in place, from a git checkout** —
+never a flat copy. Deploying it therefore means *advancing that checkout* and reloading Brave.
 
-Delivery is `scripts/sync-clawgate-extension.sh` (`--check` = drift only, rc 1 on drift), and
-**Brave does not hot-reload unpacked extensions** — a sync without a `brave://extensions` ↻ leaves
-the OLD build running. After adding a command, also check `brave://extensions/shortcuts`: Brave
-routinely leaves newly-added hotkeys unbound on an in-place reload.
+| host | ssh | Brave's "Loaded from" | what that path is |
+|---|---|---|---|
+| **workbench** | this host / `192.168.50.250` | `~/workspace/homelab-talos/containers/clawgate/extension` | the **permanently-dirty base clone** |
+| **laptop** | `zach@192.168.50.155` | `~/workspace/clawgate-extension/containers/clawgate/extension` | a **linked worktree** of the laptop's `homelab-talos`, branch `clawgate-ext-local` |
+
+**Both hosts must be updated — updating one leaves the other on the old build.** Measured
+2026-08-12: PR #305 (ext 1.5.0) was merged to `trunk` and **both** hosts were still running 1.4.0.
+
+### 🔴 `~/clawgate-extension` and `scripts/sync-clawgate-extension.sh` are a DEAD path — do not use them
+The script mirrors trunk into a flat `~/clawgate-extension`. **Nothing loads that directory.** It
+exists only on the workbench (the laptop has no such dir at all), and its `.synced-from` stamp keeps
+reporting a tidy `in sync — matches origin/trunk` **while both browsers run something else entirely**
+— a green check on a directory no browser reads. It cost a full sync + reload cycle that changed
+nothing before the real paths were found. Treat a clean `--check` as **no evidence** about what is
+loaded; the only authority is Brave's own "Loaded from" line on `brave://extensions`.
+(The `.synced-from` provenance rule below still applies to any flat copy that *is* wired up.)
+
+### Deploying a merged extension change
+```bash
+# LAPTOP — clean worktree, just fast-forward it
+ssh zach@192.168.50.155 'git -C ~/workspace/clawgate-extension fetch -q origin trunk &&
+  git -C ~/workspace/clawgate-extension merge --ff-only origin/trunk'
+
+# WORKBENCH — the base clone usually CANNOT be fast-forwarded (see below), so take the
+# subtree only. --worktree keeps the index clean so it can't be committed by accident.
+git -C ~/workspace/homelab-talos fetch -q origin trunk
+git -C ~/workspace/homelab-talos restore --source=origin/trunk --worktree -- containers/clawgate/extension
+
+# VERIFY per host — version at the REAL load path, and identity against trunk
+jq -r .version ~/workspace/homelab-talos/containers/clawgate/extension/manifest.json
+git -C ~/workspace/homelab-talos diff --stat origin/trunk -- containers/clawgate/extension  # empty = identical
+```
+Then **reload on `brave://extensions` on BOTH hosts** — Brave does not hot-reload unpacked
+extensions, so a checkout update without a ↻ leaves the OLD build running. After adding a
+`commands` entry, also check `brave://extensions/shortcuts`: Brave routinely leaves newly-added
+hotkeys unbound on an in-place reload.
+
+⚠ **Why the workbench gets the surgical `restore` and not a merge:** `~/workspace/homelab-talos`
+there is the base clone CLAUDE.md documents as chronically behind (14 commits on 2026-08-12), and
+`merge --ff-only` **refuses** whenever incoming commits touch files that are locally modified or
+would overwrite untracked ones — on 2026-08-12 that was 4 collisions with live media-stack WIP.
+Check before assuming a merge is available:
+```bash
+git -C ~/workspace/homelab-talos diff --name-only HEAD..origin/trunk | sort > /tmp/in.txt
+comm -12 /tmp/in.txt <(git -C ~/workspace/homelab-talos status -s | awk '{print $2}' | sort)  # any output = merge will refuse
+```
+The `restore` leaves the subtree showing as ` M` against a stale HEAD. That is expected and
+**self-healing** — the content already equals `origin/trunk`, so the modification disappears the
+moment the base clone catches up. 🔴 But it is also **silently revertible**: any later
+`git restore`/`checkout` over that path drops the extension back to the stale HEAD version, i.e.
+back to the old build, with no error. Re-check the manifest version after any such operation.
+
+🟡 **The workbench arrangement is the fragile one and is worth fixing**: because Brave loads the
+base clone directly, the deployed extension is hostage to that clone's drift. The laptop's
+dedicated-worktree setup is the coherent pattern. Repointing workbench Brave at its own worktree
+needs Zach in the Brave UI (remove + re-add unpacked, then re-check shortcuts) — **open item, not
+yet done.**
 
 ## 🔴 A missing `.synced-from` stamp means someone hand-copied it out of band
 That is exactly how a build that never passed CI ran live for ~11 hours while `trunk` looked clean —
-copied straight from a working tree, so `clawgate-ci` never saw it. Check the stamp before trusting
-any claim about which build is loaded:
+copied straight from a working tree, so `clawgate-ci` never saw it. For a git-checkout load path the
+equivalent check is the checkout's own commit and cleanliness:
 
 ```bash
-ssh 192.168.50.250 'cat ~/clawgate-extension/.synced-from; grep "\"version\"" ~/clawgate-extension/manifest.json'
-ssh 192.168.50.250 '~/workspace/homelab-talos/scripts/sync-clawgate-extension.sh --check'
+git -C ~/workspace/homelab-talos log --oneline -1
+git -C ~/workspace/homelab-talos status -s -- containers/clawgate/extension   # empty = no out-of-band edits
+ssh zach@192.168.50.155 'git -C ~/workspace/clawgate-extension log --oneline -1;
+  git -C ~/workspace/clawgate-extension status -s'
 ```
 
 ## ⚠ Serving a scratch test page TO that Brave

--- a/claude/skills/clawgate/reference/extension.md
+++ b/claude/skills/clawgate/reference/extension.md
@@ -36,29 +36,67 @@ false at the same time.
 
 ### The machine-readable check — this is the authority for an agent
 Agents **cannot read `brave://` pages**, so "look at brave://extensions" is not a check you can run.
-Chrome/Brave record unpacked extensions in each profile's `Preferences` JSON with `location: 4`:
+Chrome/Brave record unpacked extensions in each profile's `Preferences` JSON with `location: 4`.
+
+🔴 **Do NOT filter this by a path substring, and do not try to filter it by extension NAME.** An
+unpacked entry in `Preferences` carries **no manifest at all** — the keys are `path`, `location`,
+`commands`, `permissions`… and nothing else identifying (measured 2026-08-12; a `.value.manifest.name`
+filter matches **zero** entries and reports a confident "not loaded" for every profile). And a
+`grep clawgate` on the path is exactly blind to the case you most need to catch: the extension loaded
+from an unexpected directory. So **list every unpacked extension in every profile** and read the
+paths yourself:
 
 ```bash
 for p in ~/.config/BraveSoftware/Brave-Browser/*/Preferences; do
   prof=$(basename "$(dirname "$p")")
-  out=$(jq -r '.extensions.settings // {} | to_entries[]
+  if ! out=$(jq -r '.extensions.settings // {} | to_entries[]
         | select(.value.location==4)
-        | "\(.value.path)  disabled=\(.value.disable_reasons // [] | length)"' "$p" 2>/dev/null | grep -i clawgate)
-  [ -n "$out" ] && printf '[%s] %s\n' "$prof" "$out"
+        | "    \(.value.path)  disabled=\(.value.disable_reasons // [] | length)"' "$p"); then
+    printf '[%s] !! Preferences unreadable\n' "$prof"
+  elif [ -n "$out" ]; then printf '[%s]\n%s\n' "$prof" "$out"
+  else printf '[%s] (no unpacked extensions)\n' "$prof"
+  fi
 done
 jq -r '.profile.last_active_profiles' ~/.config/BraveSoftware/Brave-Browser/"Local State"
 ```
-Quote `"$(dirname "$p")"` — profile dirs contain spaces (`Profile 2`), and an unquoted command
-substitution silently reports it as `Profile`.
+Every profile prints a line, so a profile that is silently missing the extension is visible as such
+rather than absent from the output. Don't add `2>/dev/null` — a locked or half-written `Preferences`
+must not read as "no extensions". Quote `"$(dirname "$p")"`: profile dirs contain spaces
+(`Profile 2`), and an unquoted command substitution silently reports it as `Profile`.
 
-Cross-check the version actually on disk at each path that comes back:
-`jq -r .version <path>/manifest.json`. An extension's ID is `sha256` of its absolute load path, so
-two profiles pointing at different paths are genuinely two different installs.
+For the laptop, pipe the same script over ssh rather than trying to escape it inline:
+```bash
+ssh zach@192.168.50.155 'bash -s' <<'SWEEP'
+  ...same loop...
+SWEEP
+```
+
+Cross-check the version on disk at each path that comes back: `jq -r .version <path>/manifest.json`.
+An extension's ID is `sha256` of its absolute load path (hex mapped `0-f`→`a-p`), so two profiles
+pointing at different paths are genuinely two separate installs, not one shared one.
+
+### Verifying the HOTKEYS survived — also machine-readable
+Brave records per-extension bindings on the same entry, and this is where the "reload silently
+dropped a hotkey" trap becomes visible. `was_assigned: true` means the accelerator is actually bound;
+a command **missing** from the map was never registered in that profile at all.
+
+```bash
+jq -r '.extensions.settings // {} | to_entries[]
+  | select((.value.path? // "")|test("clawgate-extension"))
+  | .value.commands // {} | to_entries[]
+  | "\(.key): key=\(.value.suggested_key // "UNSET") assigned=\(.value.was_assigned // false)"' \
+  ~/.config/BraveSoftware/Brave-Browser/*/Preferences
+```
+Expect `open-capture` = `Ctrl+Shift+K` and `open-capture-pick` = `Ctrl+Shift+E`, both
+`assigned=true`, **in every profile that loads the extension**. Measured 2026-08-12 right after a
+repoint: workbench `Default` had `open-capture-pick` at `assigned=false` and laptop `Profile 1` was
+missing the command entirely — i.e. the picker hotkey was dead in two places while the extension
+itself reported perfectly healthy. Re-bind at `brave://extensions/shortcuts`.
 
 ## Deploying a merged extension change
 
 ```bash
-# BOTH hosts — the worktree is clean and dedicated, so this always fast-forwards
+# BOTH hosts — the worktree is dedicated and normally clean, so this fast-forwards
 git -C ~/workspace/clawgate-extension fetch -q origin trunk
 git -C ~/workspace/clawgate-extension merge --ff-only origin/trunk
 ssh zach@192.168.50.155 'git -C ~/workspace/clawgate-extension fetch -q origin trunk &&
@@ -73,9 +111,19 @@ ssh zach@192.168.50.155 'jq -r .version ~/workspace/clawgate-extension/container
 ```
 
 Then **reload in every Brave profile on both hosts** — Brave does not hot-reload unpacked
-extensions, so advancing the checkout without a ↻ leaves the OLD build running. After adding a
-`commands` entry, check `brave://extensions/shortcuts` too: Brave routinely leaves newly-added
-hotkeys unbound on an in-place reload. Confirm with the profile sweep above, not by eye.
+extensions, so advancing the checkout without a ↻ leaves the OLD build running. Confirm with the
+profile sweep and the hotkey check above, not by eye.
+
+**If `merge --ff-only` refuses**, someone committed on `clawgate-ext-local` or edited the extension
+in place; the worktree is no longer a pure mirror of `trunk`. Do NOT reach for a subtree `restore`
+(see the trap below). Diagnose and pick one:
+```bash
+git -C ~/workspace/clawgate-extension status -s                                  # uncommitted edits?
+git -C ~/workspace/clawgate-extension log --oneline origin/trunk..HEAD           # local commits?
+```
+Uncommitted junk you don't want → `git restore -- <paths>` those paths, then ff. Local commits worth
+keeping → push them as a PR and ff once merged. Either genuinely stale → recreate the worktree from
+scratch (see below); it holds no state worth preserving.
 
 ## 🔴 Never "fix" a stale checkout by restoring a subtree from another ref
 
@@ -88,10 +136,14 @@ the opposite:
   (`Your local changes to the following files would be overwritten by merge`) — it **blocks** the
   very re-sync `homelab-talos/CLAUDE.md` prescribes, rather than dissolving into it. Verified in an
   isolated repo with both controls (ff proven to work clean first, content proven identical).
+  ⚠ **Precisely:** it blocks a merge that *touches the restored path*. A merge whose incoming range
+  leaves that path alone still fast-forwards, and `restore --source=<ref> --staged --worktree`
+  (index moved too) does not block at all. That is cold comfort — in the case that motivates the
+  shortcut, the path changed upstream **by definition**, which is why you were restoring it.
 - It is **silently revertible**: any later `git restore`/`checkout` over that path drops the tree
   back to the stale version, rc 0, no output — i.e. redeploys the old build with no error.
-- It permanently trips the out-of-band check above, so a "correctly deployed" host reads as
-  hand-tampered forever.
+- It permanently trips a clean-tree check on the clone you did it to, so a "correctly deployed" host
+  reads as hand-tampered forever.
 
 If a checkout is behind, advance the checkout. If it can't be advanced, load from one that can —
 which is why the worktree exists.
@@ -109,13 +161,21 @@ add it in Brave: `brave://extensions` → Load unpacked →
 `~/workspace/clawgate-extension/containers/clawgate/extension`, **in each profile**, then re-check
 `brave://extensions/shortcuts`.
 
-## ⚠ Historical: `~/clawgate-extension` and `sync-clawgate-extension.sh` are RETIRED
+## ⚠ Historical: `~/clawgate-extension` and `sync-clawgate-extension.sh` are NOT the delivery path
 Delivery used to be an rsync into a flat copy at `~/clawgate-extension` via
-`homelab-talos/scripts/sync-clawgate-extension.sh`. **Both are gone** (flat copy deleted
-2026-08-12). The failure worth remembering: the script's `--check` kept reporting a confident
+`homelab-talos/scripts/sync-clawgate-extension.sh`.
+
+- The **flat copy is deleted** (2026-08-12, both hosts). Nothing recreates it.
+- The **script still exists** at `homelab-talos/scripts/sync-clawgate-extension.sh` and is still
+  documented as live in `scripts/README.md`, `containers/clawgate/extension/README.md` and
+  `claudedocs/handoff-clawgate-ext-2026-07-30.md` (plus a 12 KB test). **Retiring it is a pending
+  follow-up in that repo** — until then, treat every one of those references as stale and **do not
+  run it**: with its destination gone it would either fail or recreate a directory no profile loads.
+
+The failure worth remembering: the script's `--check` kept reporting a confident
 `in sync — matches origin/trunk` about a directory **no profile loaded**, so a green check coexisted
-with every browser running an older build. If you find a doc or script still referencing either,
-it is stale. **A tool's clean verdict is a fact about the tool's target, not about what is running.**
+with every browser running an older build. **A tool's clean verdict is a fact about the tool's
+target, not about what is running.**
 
 ## ⚠ Serving a scratch test page TO that Brave
 The workbench firewall `allowedTCPPorts` is a short allowlist

--- a/claude/skills/clawgate/reference/extension.md
+++ b/claude/skills/clawgate/reference/extension.md
@@ -4,78 +4,118 @@ Read when: you changed the clawgate browser extension, or you need to know **whi
 loaded** in Zach's Brave.
 
 ## 🔴 The extension does NOT ship via Flux — merging to `trunk` deploys NOTHING
-It runs on **TWO hosts**, and each Brave loads it **unpacked, in place, from a git checkout** —
-never a flat copy. Deploying it therefore means *advancing that checkout* and reloading Brave.
 
-| host | ssh | Brave's "Loaded from" | what that path is |
-|---|---|---|---|
-| **workbench** | this host / `192.168.50.250` | `~/workspace/homelab-talos/containers/clawgate/extension` | the **permanently-dirty base clone** |
-| **laptop** | `zach@192.168.50.155` | `~/workspace/clawgate-extension/containers/clawgate/extension` | a **linked worktree** of the laptop's `homelab-talos`, branch `clawgate-ext-local` |
+Brave loads it **unpacked, in place, from a git checkout**. Deploying it means *advancing that
+checkout* and reloading Brave. It runs on **two hosts**, at the **same path on both**:
 
-**Both hosts must be updated — updating one leaves the other on the old build.** Measured
-2026-08-12: PR #305 (ext 1.5.0) was merged to `trunk` and **both** hosts were still running 1.4.0.
+```
+~/workspace/clawgate-extension/containers/clawgate/extension
+```
 
-### 🔴 `~/clawgate-extension` and `scripts/sync-clawgate-extension.sh` are a DEAD path — do not use them
-The script mirrors trunk into a flat `~/clawgate-extension`. **Nothing loads that directory.** It
-exists only on the workbench (the laptop has no such dir at all), and its `.synced-from` stamp keeps
-reporting a tidy `in sync — matches origin/trunk` **while both browsers run something else entirely**
-— a green check on a directory no browser reads. It cost a full sync + reload cycle that changed
-nothing before the real paths were found. Treat a clean `--check` as **no evidence** about what is
-loaded; the only authority is Brave's own "Loaded from" line on `brave://extensions`.
-(The `.synced-from` provenance rule below still applies to any flat copy that *is* wired up.)
+That path is a **linked worktree** of the host's `homelab-talos` clone, on a local branch
+`clawgate-ext-local` tracking `origin/trunk`. Hosts: **workbench** (this host / `192.168.50.250`)
+and **laptop** (`ssh zach@192.168.50.155`). Both must be updated — doing one leaves the other on the
+old build.
 
-### Deploying a merged extension change
+A worktree is used deliberately, **not** the `homelab-talos` base clone. The base clone is
+permanently dirty and chronically behind (14 commits on 2026-08-12), so loading it directly makes
+the deployed extension hostage to that drift — and it cannot be fast-forwarded while its WIP
+collides. The worktree advances with a plain `merge --ff-only` regardless of what the base clone is
+doing.
+
+## 🔴 Brave has MULTIPLE PROFILES, and each loads extensions independently
+
+Checking one profile proves nothing about the others. On 2026-08-12 the workbench had **4 profiles,
+2 of them active** (`Default` + `Profile 2`), loading the clawgate extension **from two different
+paths** — one from the worktree, one from the base clone. Repointing `Default` left `Profile 2`
+(then the `last_used` one) still on the old path. Symptom: the version you see depends on which
+profile's window you happen to be looking at, and "I reloaded it and it's still old" is true and
+false at the same time.
+
+**Every profile must be repointed and reloaded, not just the one in front of you.**
+
+### The machine-readable check — this is the authority for an agent
+Agents **cannot read `brave://` pages**, so "look at brave://extensions" is not a check you can run.
+Chrome/Brave record unpacked extensions in each profile's `Preferences` JSON with `location: 4`:
+
 ```bash
-# LAPTOP — clean worktree, just fast-forward it
+for p in ~/.config/BraveSoftware/Brave-Browser/*/Preferences; do
+  prof=$(basename "$(dirname "$p")")
+  out=$(jq -r '.extensions.settings // {} | to_entries[]
+        | select(.value.location==4)
+        | "\(.value.path)  disabled=\(.value.disable_reasons // [] | length)"' "$p" 2>/dev/null | grep -i clawgate)
+  [ -n "$out" ] && printf '[%s] %s\n' "$prof" "$out"
+done
+jq -r '.profile.last_active_profiles' ~/.config/BraveSoftware/Brave-Browser/"Local State"
+```
+Quote `"$(dirname "$p")"` — profile dirs contain spaces (`Profile 2`), and an unquoted command
+substitution silently reports it as `Profile`.
+
+Cross-check the version actually on disk at each path that comes back:
+`jq -r .version <path>/manifest.json`. An extension's ID is `sha256` of its absolute load path, so
+two profiles pointing at different paths are genuinely two different installs.
+
+## Deploying a merged extension change
+
+```bash
+# BOTH hosts — the worktree is clean and dedicated, so this always fast-forwards
+git -C ~/workspace/clawgate-extension fetch -q origin trunk
+git -C ~/workspace/clawgate-extension merge --ff-only origin/trunk
 ssh zach@192.168.50.155 'git -C ~/workspace/clawgate-extension fetch -q origin trunk &&
   git -C ~/workspace/clawgate-extension merge --ff-only origin/trunk'
 
-# WORKBENCH — the base clone usually CANNOT be fast-forwarded (see below), so take the
-# subtree only. --worktree keeps the index clean so it can't be committed by accident.
-git -C ~/workspace/homelab-talos fetch -q origin trunk
-git -C ~/workspace/homelab-talos restore --source=origin/trunk --worktree -- containers/clawgate/extension
-
-# VERIFY per host — version at the REAL load path, and identity against trunk
-jq -r .version ~/workspace/homelab-talos/containers/clawgate/extension/manifest.json
-git -C ~/workspace/homelab-talos diff --stat origin/trunk -- containers/clawgate/extension  # empty = identical
-```
-Then **reload on `brave://extensions` on BOTH hosts** — Brave does not hot-reload unpacked
-extensions, so a checkout update without a ↻ leaves the OLD build running. After adding a
-`commands` entry, also check `brave://extensions/shortcuts`: Brave routinely leaves newly-added
-hotkeys unbound on an in-place reload.
-
-⚠ **Why the workbench gets the surgical `restore` and not a merge:** `~/workspace/homelab-talos`
-there is the base clone CLAUDE.md documents as chronically behind (14 commits on 2026-08-12), and
-`merge --ff-only` **refuses** whenever incoming commits touch files that are locally modified or
-would overwrite untracked ones — on 2026-08-12 that was 4 collisions with live media-stack WIP.
-Check before assuming a merge is available:
-```bash
-git -C ~/workspace/homelab-talos diff --name-only HEAD..origin/trunk | sort > /tmp/in.txt
-comm -12 /tmp/in.txt <(git -C ~/workspace/homelab-talos status -s | awk '{print $2}' | sort)  # any output = merge will refuse
-```
-The `restore` leaves the subtree showing as ` M` against a stale HEAD. That is expected and
-**self-healing** — the content already equals `origin/trunk`, so the modification disappears the
-moment the base clone catches up. 🔴 But it is also **silently revertible**: any later
-`git restore`/`checkout` over that path drops the extension back to the stale HEAD version, i.e.
-back to the old build, with no error. Re-check the manifest version after any such operation.
-
-🟡 **The workbench arrangement is the fragile one and is worth fixing**: because Brave loads the
-base clone directly, the deployed extension is hostage to that clone's drift. The laptop's
-dedicated-worktree setup is the coherent pattern. Repointing workbench Brave at its own worktree
-needs Zach in the Brave UI (remove + re-add unpacked, then re-check shortcuts) — **open item, not
-yet done.**
-
-## 🔴 A missing `.synced-from` stamp means someone hand-copied it out of band
-That is exactly how a build that never passed CI ran live for ~11 hours while `trunk` looked clean —
-copied straight from a working tree, so `clawgate-ci` never saw it. For a git-checkout load path the
-equivalent check is the checkout's own commit and cleanliness:
-
-```bash
-git -C ~/workspace/homelab-talos log --oneline -1
-git -C ~/workspace/homelab-talos status -s -- containers/clawgate/extension   # empty = no out-of-band edits
-ssh zach@192.168.50.155 'git -C ~/workspace/clawgate-extension log --oneline -1;
+# VERIFY per host — version on disk + identity against trunk + tree is clean
+jq -r .version ~/workspace/clawgate-extension/containers/clawgate/extension/manifest.json
+git -C ~/workspace/clawgate-extension diff --stat origin/trunk -- containers/clawgate/extension  # empty = identical
+git -C ~/workspace/clawgate-extension status -s     # empty = no out-of-band edits
+ssh zach@192.168.50.155 'jq -r .version ~/workspace/clawgate-extension/containers/clawgate/extension/manifest.json;
   git -C ~/workspace/clawgate-extension status -s'
 ```
+
+Then **reload in every Brave profile on both hosts** — Brave does not hot-reload unpacked
+extensions, so advancing the checkout without a ↻ leaves the OLD build running. After adding a
+`commands` entry, check `brave://extensions/shortcuts` too: Brave routinely leaves newly-added
+hotkeys unbound on an in-place reload. Confirm with the profile sweep above, not by eye.
+
+## 🔴 Never "fix" a stale checkout by restoring a subtree from another ref
+
+The tempting shortcut when a checkout is behind is
+`git restore --source=origin/trunk --worktree -- <subdir>`. **Do not.** It looks self-healing and is
+the opposite:
+
+- Git compares worktree ↔ **index**, never worktree ↔ merge target. Content that is byte-identical
+  to `origin/trunk` is still "a local change", so `git merge --ff-only origin/trunk` **aborts**
+  (`Your local changes to the following files would be overwritten by merge`) — it **blocks** the
+  very re-sync `homelab-talos/CLAUDE.md` prescribes, rather than dissolving into it. Verified in an
+  isolated repo with both controls (ff proven to work clean first, content proven identical).
+- It is **silently revertible**: any later `git restore`/`checkout` over that path drops the tree
+  back to the stale version, rc 0, no output — i.e. redeploys the old build with no error.
+- It permanently trips the out-of-band check above, so a "correctly deployed" host reads as
+  hand-tampered forever.
+
+If a checkout is behind, advance the checkout. If it can't be advanced, load from one that can —
+which is why the worktree exists.
+
+## Setting up a new host (or a replacement worktree)
+
+```bash
+git -C ~/workspace/homelab-talos fetch -q origin trunk
+git -C ~/workspace/homelab-talos worktree add ~/workspace/clawgate-extension \
+    -b clawgate-ext-local origin/trunk
+```
+`.envrc` is **tracked in `homelab-talos`**, so it arrives with the checkout — do NOT copy one in or
+overwrite it (the global "worktrees don't inherit `.envrc`" rule does not apply to this repo). Then
+add it in Brave: `brave://extensions` → Load unpacked →
+`~/workspace/clawgate-extension/containers/clawgate/extension`, **in each profile**, then re-check
+`brave://extensions/shortcuts`.
+
+## ⚠ Historical: `~/clawgate-extension` and `sync-clawgate-extension.sh` are RETIRED
+Delivery used to be an rsync into a flat copy at `~/clawgate-extension` via
+`homelab-talos/scripts/sync-clawgate-extension.sh`. **Both are gone** (flat copy deleted
+2026-08-12). The failure worth remembering: the script's `--check` kept reporting a confident
+`in sync — matches origin/trunk` about a directory **no profile loaded**, so a green check coexisted
+with every browser running an older build. If you find a doc or script still referencing either,
+it is stale. **A tool's clean verdict is a fact about the tool's target, not about what is running.**
 
 ## ⚠ Serving a scratch test page TO that Brave
 The workbench firewall `allowedTCPPorts` is a short allowlist

--- a/claudedocs/chrome-extensions-inventory.md
+++ b/claudedocs/chrome-extensions-inventory.md
@@ -20,19 +20,23 @@ projects). All are Manifest V3.
 | **Structured Downloader** `1.0` | `~/workspace/gogram/gogram-extension` | nested in `gogram` repo | Structured downloader (downloads/storage/clipboard/scripting) for gogram | standalone load-unpacked | active |
 | **Structured Downloader (old)** `1.0` | `~/workspace/gogram/gogram-extension-old` | nested in `gogram` repo | Prior version of the above | none | **cruft — superseded** (see below) |
 | **Stock Chat Assistant** `1.0` | `~/workspace/portfolio-chat-fe/browser-extension` | nested in `portfolio-chat-fe` repo | Analyze stock tickers from any website | standalone load-unpacked | unknown (project side-extension) |
-| **clawgate task capture** `1.5.0` | `~/workspace/clawgate-extension/containers/clawgate/extension` | worktree of `homelab-talos` (`clawgate-ext-local`) | Hotkey → capture overlay → durable clawgate Task card | **load-unpacked from that worktree, on BOTH hosts and in EVERY Brave profile** — NOT shipped by Flux or the clawgate container; see the `clawgate` skill's `reference/extension.md` | active |
+| **clawgate task capture** `1.5.0` | `~/workspace/clawgate-extension/containers/clawgate/extension` | worktree of `homelab-talos` (`clawgate-ext-local`) | Hotkey → capture overlay → durable clawgate Task card | **load-unpacked from that worktree, on BOTH hosts** — NOT shipped by Flux or the clawgate container. Loaded in a SUBSET of profiles (2 of 5 on workbench, 2 of 6 on laptop as of 2026-08-12) and each must be reloaded separately; enumerate them with the sweep in the `clawgate` skill's `reference/extension.md` rather than assuming | active |
 
 ## Notes / non-extensions
 - **`~/workspace/scrape-video/manifest.json` is NOT a browser extension.** It's a
   `url_to_file` data map for a Go video-scraper CLI (`main.go`/`scrape.go`/`go.mod`
   in the same dir). Excluded from the table; noted so it isn't mistaken for one.
-- **The `clawgate task capture` extension is tracked in the `homelab-talos` repo**
-  and therefore appears in THREE checked-out git worktrees of that repo with
-  identical content — they are the SAME project, not three projects:
-  - `~/workspace/clawgate-extension/containers/clawgate/extension` (branch `clawgate-ext-local`) — the one listed above
-  - `~/workspace/clawgate-deploy/containers/clawgate/extension` (branch `clawgate-0.7.77`) — deploy worktree
-  - `~/workspace/homelab-trunk/containers/clawgate/extension` (branch `clawgate-ext-capture`) — see cleanup candidates
-  Confirmed via `git -C ~/workspace/homelab-talos worktree list`.
+- **The `clawgate task capture` extension is tracked in the `homelab-talos` repo**, so it appears
+  under every checked-out worktree of that repo with identical content — those are the SAME project,
+  not several projects. Only one of them is the load path:
+  - `~/workspace/clawgate-extension/containers/clawgate/extension` (branch `clawgate-ext-local`) —
+    **the load path**, the one listed above
+  - ⚠ **Re-verified 2026-08-12:** the `~/workspace/clawgate-deploy` (`clawgate-0.7.77`) and
+    `~/workspace/homelab-trunk` (`clawgate-ext-capture`) worktrees previously listed here **no longer
+    exist** — absent from disk and from `git worktree list`. The cleanup-candidate entry below that
+    hands you a `worktree remove ~/workspace/homelab-trunk` will fail; it is already done.
+  Re-check with `git -C ~/workspace/homelab-talos worktree list` rather than trusting this list —
+  it went stale once already.
 
 ## Cleanup candidates (FLAGGED — NOT deleted)
 Nothing was deleted. Each below is a candidate with the reason + a suggested SAFE

--- a/claudedocs/chrome-extensions-inventory.md
+++ b/claudedocs/chrome-extensions-inventory.md
@@ -20,7 +20,7 @@ projects). All are Manifest V3.
 | **Structured Downloader** `1.0` | `~/workspace/gogram/gogram-extension` | nested in `gogram` repo | Structured downloader (downloads/storage/clipboard/scripting) for gogram | standalone load-unpacked | active |
 | **Structured Downloader (old)** `1.0` | `~/workspace/gogram/gogram-extension-old` | nested in `gogram` repo | Prior version of the above | none | **cruft — superseded** (see below) |
 | **Stock Chat Assistant** `1.0` | `~/workspace/portfolio-chat-fe/browser-extension` | nested in `portfolio-chat-fe` repo | Analyze stock tickers from any website | standalone load-unpacked | unknown (project side-extension) |
-| **clawgate task capture** `1.1.0` | `~/workspace/clawgate-extension/containers/clawgate/extension` | worktree of `homelab-talos` (`clawgate-ext-local`) | Hotkey → capture overlay → durable clawgate Task card | packaged/deployed via the clawgate container | active |
+| **clawgate task capture** `1.5.0` | `~/workspace/clawgate-extension/containers/clawgate/extension` | worktree of `homelab-talos` (`clawgate-ext-local`) | Hotkey → capture overlay → durable clawgate Task card | **load-unpacked from that worktree, on BOTH hosts and in EVERY Brave profile** — NOT shipped by Flux or the clawgate container; see the `clawgate` skill's `reference/extension.md` | active |
 
 ## Notes / non-extensions
 - **`~/workspace/scrape-video/manifest.json` is NOT a browser extension.** It's a

--- a/claudedocs/handoff-browser-bridge-clawgate-2026-08-01.md
+++ b/claudedocs/handoff-browser-bridge-clawgate-2026-08-01.md
@@ -73,5 +73,5 @@
 ## Deploy notes
 
 - **browser-bridge**: rsync extension to `~/.local/share/browser-bridge-ext/` on each host, reload in brave://extensions
-- **clawgate extension**: files live at `~/workspace/homelab-talos/containers/clawgate/extension/`, reload in brave://extensions (Default profile)
+- **clawgate extension**: ⚠ **superseded 2026-08-12** — Brave now loads it from the dedicated worktree `~/workspace/clawgate-extension/containers/clawgate/extension` (branch `clawgate-ext-local`), on **both hosts** and in **every profile that has it**, not from the `homelab-talos` base clone and not just `Default`. Deploy + verification procedure: the `clawgate` skill's `reference/extension.md`.
 - **server.py**: if updated, must kill + restart the server process (nix symlink → `~/.config/browser-bridge/server.py`)


### PR DESCRIPTION
## What this corrects

Measured 2026-08-12 while deploying extension **1.5.0** (clawgate PR #305): **both browsers were still running 1.4.0**, and the delivery path the skill documented could not have fixed it.

Brave loads the extension unpacked **in place from a git checkout**, on **two hosts**:

| host | Brave's "Loaded from" | what it is | state found |
|---|---|---|---|
| workbench | `~/workspace/homelab-talos/containers/clawgate/extension` | the permanently-dirty **base clone** | 14 behind trunk → 1.4.0 |
| laptop `.155` | `~/workspace/clawgate-extension/containers/clawgate/extension` | a **linked worktree**, branch `clawgate-ext-local` | 1 behind trunk → 1.4.0 |

The skill instead described a single flat copy at `~/clawgate-extension`, delivered by `scripts/sync-clawgate-extension.sh`.

## 🔴 That flat copy is loaded by nothing

It exists only on the workbench — the laptop has no such directory at all — and `--check` reports a clean `in sync — matches origin/trunk` **while both browsers run a different build**. A green check on a directory no browser reads. It cost a full sync + reload cycle that changed nothing before the real paths were found.

The doc now says the only authority on which build is loaded is Brave's own "Loaded from" line.

## What the doc now records

- the per-host table above, and that **both** hosts must be updated — doing one leaves the other stale
- per-host update commands, and per-host `brave://extensions` reload
- **why the workbench needs a surgical `git restore --source=origin/trunk --worktree`** of the subtree rather than a merge: its base clone is chronically behind and `merge --ff-only` refuses whenever incoming commits collide with local WIP (4 collisions with live media-stack edits on the day), plus the one-liner to detect that before assuming a merge is available
- that the resulting ` M` state is **self-healing** (content already equals trunk) but **silently revertible** — any later `checkout`/`restore` over that path drops the extension back to the old build with no error
- 🟡 open item: the workbench arrangement is the fragile one, because loading the base clone directly makes the deployed extension hostage to that clone's drift. The laptop's dedicated-worktree pattern is the coherent one; repointing needs Zach in the Brave UI (remove + re-add unpacked, re-check shortcuts).

The `.synced-from` provenance rule is kept — it still applies to any flat copy that *is* wired up — with the git-checkout equivalent added beside it.

## Gate

`nix build .#checks.x86_64-linux.pytests` → **8114 collected, 8113 passed, 1 pinned skip, 0 failed**.

Docs-only, so that is a regression check. The doc's factual claims come from live measurement on both hosts, not from the suite.

## Note

Merging does not deploy this — `~/.claude/skills/` is a `home.file` copy (`readlink -f` terminates in `/nix/store`), so it needs `scripts/ship.sh` / a `home-manager switch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rCBXqoNtXHpvwEsLwBnJz