### PR TITLE
fix(tests): the toast that escaped came from the seam test itself — guard the launch, not the attribute

### DIFF
--- a/scripts/testlib/launcher_scan.py
+++ b/scripts/testlib/launcher_scan.py
@@ -161,6 +161,74 @@ def _path_values(module: ast.Module):
                 yield node, node.args[1]
 
 
+def _loader_constants(call: ast.Call, module: ast.Module, depth: int = 0) -> set:
+    """Every string constant a loader call's arguments can resolve to.
+
+    One level of variable indirection, for the same measured reason `_inherits`
+    resolves it: `SourceFileLoader("_bar_status_poll", str(path))` with
+    `path = REPO / "scripts" / "bar-status-poll"` assigned above is the shape
+    `test_bar_url.py` actually uses, and a direct-constants-only scan reports it
+    as loading nothing.
+    """
+    out = set()
+    for sub in ast.walk(call):
+        if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+            out.add(sub.value)
+        if depth < 1 and isinstance(sub, ast.Name):
+            for other in ast.walk(module):
+                if isinstance(other, ast.Assign) and any(
+                        isinstance(t, ast.Name) and t.id == sub.id
+                        for t in other.targets):
+                    for deep in ast.walk(other.value):
+                        if isinstance(deep, ast.Constant) and isinstance(
+                                deep.value, str):
+                            out.add(deep.value)
+    return out
+
+
+# The call shapes this suite uses to execute an extensionless `scripts/<name>`
+# as a Python module. They have no `.py` suffix, so they are never `import`ed.
+_LOADER_FUNCS = ("_load", "SourceFileLoader", "spec_from_file_location",
+                 "spec_from_loader")
+
+
+def module_loaders(tests_dir: Path, script_name: str) -> dict[str, list[int]]:
+    """`{test file: [line…]}` for every test file that LOADS `scripts/<script_name>`.
+
+    🔴 WHY THIS EXISTS — a per-FILE fixture protects exactly one file.
+    `test_bar_status.py` carries an autouse fixture that patches the poller's
+    `_toast_runner` seam, and that fixture is bound to the module object THAT
+    FILE loaded. Another file loading the same script gets a DIFFERENT module
+    object with a live `_toast_runner`, and inherits none of the protection —
+    two such files exist today. So the set of loaders is a RELATIONSHIP the
+    guard has to pin: it must go red when the set GROWS (a new unprotected
+    reacher) as well as when it SHRINKS.
+
+    Deliberately narrower than a text search for the name: `test_no_real_
+    launchers.py` and `test_subsystem_resolver.py` both spell "bar-status-poll"
+    as data without ever executing it, and counting those would train everyone
+    to widen the ledger instead of reading it.
+    """
+    found: dict[str, list[int]] = {}
+    for py in sorted(Path(tests_dir).glob("test_*.py")):
+        text = py.read_text(encoding="utf-8")
+        try:
+            module = ast.parse(text)
+        except SyntaxError:  # pragma: no cover — a broken test file fails elsewhere
+            continue
+        for node in ast.walk(module):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = (func.id if isinstance(func, ast.Name)
+                    else func.attr if isinstance(func, ast.Attribute) else None)
+            if name not in _LOADER_FUNCS:
+                continue
+            if script_name in _loader_constants(node, module):
+                found.setdefault(py.name, []).append(node.lineno)
+    return found
+
+
 def path_clobbers(tests_dir: Path) -> list[tuple[str, int, str]]:
     """`(file, lineno, source)` for every PATH assignment that DROPS the ambient PATH.
 

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -28,8 +28,15 @@ What is asserted, and why each is not enough alone:
     made that deletion invisible.
   * THE SEAM    — the real hazard paths (monitor-blackout's `systemd-run`
     scheduling and its `cancel_timer` systemctl storm, rig-control's `openrgb` +
-    `notify-send`) land in the stub log. A component-scoped check would pass
-    with the fixture deleted as long as some stub file existed somewhere.
+    `notify-send`, and bar-status-poll's `fire_toast`) land in the stub log. A
+    component-scoped check would pass with the fixture deleted as long as some
+    stub file existed somewhere.
+  * THE TOAST   — `fire_toast` is driven FOR REAL, in a subprocess, with its
+    seam UNPATCHED. That is the launch that escaped to the operator's desktop
+    on 2026-08-11, and it escaped precisely because the file that owns it
+    protects itself with a monkeypatch on the seam the test exists to bypass.
+    The set of test files that LOAD the poller is pinned alongside it: each gets
+    its own module object, so a per-file patch covers exactly one of them.
   * THE LEDGER  — pinned against the TREE (`testlib.launcher_scan`), not only
     against itself. `dunstctl`, `rofi` and `yad` were all reachable while the
     self-pinned list said the set was complete.
@@ -694,6 +701,129 @@ def test_rig_control_notify_and_rgb_reach_the_stub(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
+# The bar-status TOAST seam — the third real hazard path, and the one a
+# per-file fixture structurally cannot hold
+# --------------------------------------------------------------------------- #
+# Loads `scripts/bar-status-poll` the way the suite's own tests do and calls
+# `fire_toast` FOR REAL: no `runner=` injection, no patched `_toast_runner`, and
+# the session-bus precondition satisfied so the call cannot short-circuit before
+# reaching the launcher. Run as a SUBPROCESS on purpose — an in-process probe
+# could be credited to some other test's monkeypatch, and the property under
+# test is the one that survives a fresh interpreter: the PATH.
+_TOAST_PROBE = '''\
+import importlib.machinery, importlib.util, sys
+loader = importlib.machinery.SourceFileLoader("_poll_toast_seam", sys.argv[1])
+spec = importlib.util.spec_from_loader("_poll_toast_seam", loader)
+mod = importlib.util.module_from_spec(spec)
+loader.exec_module(mod)
+print("DISPATCHED=%s" % mod.fire_toast("critical", "SEAMPROBESUMMARY",
+                                       "SEAMPROBEBODY"))
+'''
+
+
+def test_the_bar_status_toast_reaches_the_stub_not_the_desktop(tmp_path):
+    """🔴 THE POSITIVE CONTROL: a test that genuinely TRIES to toast the operator.
+
+    This is the launch that actually escaped. MEASURED on the workbench, in the
+    user journal at 2026-08-11 13:14:58:
+
+        Started [systemd-run] …/bash -c "a=$(dunstify -a bar-status -u \\"$1\\"
+        \\"$2\\" \\"$3\\")" bar-status critical sum body
+
+    — the literal fixture arguments of `test_bar_status.py`'s seam test, on a
+    real desktop. It escaped because that file's protection is a monkeypatch of
+    `poll._toast_runner`, and the whole point of the seam test is to run
+    `fire_toast` in a state where it may NOT route through that attribute. A
+    patch on a seam cannot stop a launch that bypasses the seam; only something
+    below the process boundary can, which is what the PATH fixture is.
+
+    So this test does the forbidden thing deliberately and asserts the stub
+    caught it. `DISPATCHED=True` is load-bearing as its own positive control: if
+    `fire_toast` returned False it skipped at the session-bus check and never
+    reached a launcher, and an empty log would prove nothing at all.
+
+    Fails in BOTH tiers without the fixture: on the dev host the real
+    `systemd-run` takes the call and the log stays empty; in the sandbox there
+    is no `systemd-run`, `fire_toast` swallows the OSError, `DISPATCHED=False`
+    and the assertion below names that instead.
+    """
+    stub_dir = _stub_dir_from_env()
+    poller = SCRIPTS / "bar-status-poll"
+    before = len(nolaunch.recorded(stub_dir))
+
+    env = dict(os.environ)
+    # Satisfy `_borrow_desktop_env` so it returns immediately and the bus check
+    # passes — otherwise the toast is skipped and this test measures nothing.
+    env["DISPLAY"] = ":0"
+    env["DBUS_SESSION_BUS_ADDRESS"] = "unix:path=/dev/null"
+    env["XAUTHORITY"] = str(tmp_path / "xauth")
+    env["DEVRC_DIR"] = str(SCRIPTS.parent)
+    env["HOME"] = str(tmp_path)
+    p = subprocess.run([sys.executable, "-B", "-c", _TOAST_PROBE, str(poller)],
+                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                       text=True, timeout=60, env=env)
+    assert p.returncode == 0, p.stdout
+    assert "DISPATCHED=True" in p.stdout, (
+        "fire_toast did not reach a launcher at all, so an empty stub log would "
+        f"be meaningless — it returned early:\n{p.stdout}")
+
+    new = nolaunch.recorded(stub_dir)[before:]
+    launched = [ln for ln in new if ln.startswith("systemd-run ")]
+    assert len(launched) == 1, (
+        "bar-status-poll's fire_toast did not land in the stub — it reached a "
+        f"REAL systemd-run and put a toast on someone's screen. recorded: {new}")
+    assert "dunstify -a bar-status" in launched[0], launched[0]
+    assert "SEAMPROBESUMMARY" in launched[0] and "SEAMPROBEBODY" in launched[0], \
+        launched[0]
+
+
+# 🔴 A RELATIONSHIP, not a component. `test_bar_status.py`'s autouse fixture
+# patches the `_toast_runner` of the module object THAT FILE loaded; a different
+# file loading the same script gets its own module object with a live launcher
+# and inherits nothing. Two such files exist and neither patches the seam — the
+# PATH fixture is their ONLY protection, which is exactly why this set has to be
+# pinned in both directions rather than left to whoever adds the next one.
+POLLER_LOADING_TESTS = {
+    "test_bar_status.py":  "patches poll._toast_runner (autouse, whole file) AND "
+                           "is covered by the PATH fixture",
+    "test_airvpn_menu.py": "loads the poller for its airvpn parsers only; does "
+                           "NOT patch the toast seam — PATH fixture only",
+    "test_bar_url.py":     "loads the poller for _bar_url_action; does NOT patch "
+                           "the toast seam — PATH fixture only",
+}
+
+
+def test_every_test_file_that_loads_the_poller_is_pinned():
+    """A NEW file loading `bar-status-poll` is a new unprotected toast reacher.
+
+    Grows-or-shrinks, for the reason `ACKNOWLEDGED_UNSTUBBED` is bound to a file
+    set: a ledger that only says "these names are fine" absorbs the next reacher
+    silently. The fix when this goes red is to read the new file and decide
+    whether the PATH fixture is enough for it — not to append a line.
+    """
+    found = launcher_scan.module_loaders(SCRIPTS / "tests", "bar-status-poll")
+    assert set(found) == set(POLLER_LOADING_TESTS), (
+        "the set of test files that LOAD scripts/bar-status-poll changed.\n"
+        f"  pinned: {sorted(POLLER_LOADING_TESTS)}\n"
+        f"  tree:   {sorted(found)}\n"
+        "Each one gets its own module object, so test_bar_status.py's autouse "
+        "_toast_runner patch does NOT cover it; the PATH fixture is what does.")
+
+
+def test_the_module_loader_scan_can_actually_find_something(tmp_path):
+    """Positive control for the scan itself — a zero from a scan wired to
+    nothing is indistinguishable from a zero that means "no loaders"."""
+    (tmp_path / "test_decoy.py").write_text(
+        '_load("bar-status-poll", "x")\n', encoding="utf-8")
+    (tmp_path / "test_mentions_only.py").write_text(
+        'DATA = {"service": "bar-status-poll"}\n', encoding="utf-8")
+    found = launcher_scan.module_loaders(tmp_path, "bar-status-poll")
+    assert set(found) == {"test_decoy.py"}, (
+        f"the scan sees a loader but not a bare mention; got {found}")
+    assert launcher_scan.module_loaders(tmp_path, "no-such-script") == {}
+
+
+# --------------------------------------------------------------------------- #
 # The PATH-clobber sites the fixture CANNOT cover
 # --------------------------------------------------------------------------- #
 # (file, lineno-independent needle, why it is safe today)
@@ -947,3 +1077,76 @@ def test_the_seam_assertion_is_what_makes_the_seam_test_red(tmp_path):
         "with the seam assertion neutered the test is STILL red, so it is red "
         f"for some other reason and proves nothing about this assertion.\n"
         f"{mutant.stdout}")
+
+
+# --------------------------------------------------------------------------- #
+# MUTATION: the poller ledger must not be relaxable into exempting everything
+# --------------------------------------------------------------------------- #
+_LEDGER_TEST = "test_every_test_file_that_loads_the_poller_is_pinned"
+# Self-match, assembled: spelled whole, `src.count()` below would be 2.
+_LEDGER_NEEDLE = "assert set(found) == set(POLLER_LOADING_TESTS)" + ", ("
+
+# Minimal files carrying the LOADER SHAPE the scan looks for — enough for
+# `module_loaders` to report them, without dragging in the real suites.
+_FAKE_LOADER = '_load("bar-status-poll", "m")\n'
+
+
+def _ledger_harness(tmp_path, source: str) -> Path:
+    """A tests dir holding the three pinned loaders PLUS one new reacher.
+
+    The extra file is the event the ledger exists to notice: a new test file
+    that loads the poller, and therefore does NOT inherit `test_bar_status.py`'s
+    per-file `_toast_runner` patch.
+    """
+    root = tmp_path / "scripts"
+    tests = root / "tests"
+    tests.mkdir(parents=True)
+    (root / "testlib").symlink_to(SCRIPTS / "testlib")
+    (tests / "conftest.py").write_text(_HARNESS_CONFTEST, encoding="utf-8")
+    for name in (*POLLER_LOADING_TESTS, "test_a_brand_new_reacher.py"):
+        (tests / name).write_text(_FAKE_LOADER, encoding="utf-8")
+    target = tests / "test_no_real_launchers.py"
+    target.write_text(source, encoding="utf-8")
+    return target
+
+
+def test_the_ledger_equality_is_what_makes_a_new_reacher_red(tmp_path):
+    """🔴 A ledger relaxed to a SUBSET absorbs the next reacher in silence.
+
+    MEASURED as a surviving mutant before this test existed: changing the
+    ledger's `==` to `>=` and adding a new poller-loading test file left the
+    whole guard file green — the exact "acknowledgement absorbs a new reacher"
+    failure that `ACKNOWLEDGED_UNSTUBBED` was already bound to file sets for.
+
+    Run as a PAIR, because "the mutant went green" means nothing without a
+    control that went red for the RIGHT reason:
+
+      control : `==` + an extra reacher in the tree -> RED, naming the ledger
+      mutant  : `>=` + the same tree               -> GREEN
+
+    Nothing can launch in either half: the harness conftest still puts a working
+    stub dir first on PATH, and these nested files only parse source.
+    """
+    src = Path(__file__).read_text(encoding="utf-8")
+    assert src.count(_LEDGER_NEEDLE) == 1, (
+        f"expected exactly one ledger assertion to mutate, found "
+        f"{src.count(_LEDGER_NEEDLE)} — the mutation would not land where intended")
+
+    def run(where, source):
+        target = _ledger_harness(tmp_path / where, source)
+        return _run_nested(f"{target}::{_LEDGER_TEST}",
+                           tmp_path / where / "basetemp")
+
+    control = run("control", src)
+    assert control.returncode != 0 and "1 failed" in control.stdout, (
+        "the CONTROL half did not go red, so the mutant going green would prove "
+        f"nothing.\n{control.stdout}")
+    assert "test_a_brand_new_reacher.py" in control.stdout, (
+        "the control went red without naming the new reacher, so it is red for "
+        f"some other reason.\n{control.stdout}")
+
+    mutant = run("mutant", src.replace(
+        _LEDGER_NEEDLE, "assert set(found) >= set(POLLER_LOADING_TESTS)" + ", ("))
+    assert mutant.returncode == 0, (
+        "with the ledger relaxed to a subset the test is STILL red, so it is "
+        f"red for some other reason and proves nothing.\n{mutant.stdout}")


### PR DESCRIPTION
## Which call path actually escaped — observed, not inferred

Workbench user journal, **2026-08-11 13:14:58**:

```
Started [systemd-run] /nix/store/…-bash-5.3p15/bin/bash -c
  "a=\$(dunstify -a bar-status -u \"\$1\" \"\$2\" \"\$3\")" bar-status critical sum body
```

— the literal fixture arguments of `test_bar_status.py:1151`, on a real desktop. It sits inside a **49-minute burst of 158 `bar-status` toasts** (12:25:45 → 13:14:58), which decomposes as:

| content | count |
|---|---|
| `low "New mail action"` | 54 |
| `normal "clawgate: task awaiting"` (`2 task(s) awaiting: #1, #2`) | 53 |
| `critical "🔴 Telemetry source DEAD"` (`laptop/keys silent 9h`) | 50 |
| `critical sum body` — the seam test's own arguments | 1 |

The three repeated ones are **exactly the toasts `test_bar_status.py`'s fixture docstring names** as the pre-fixture escape, and their peak rate is ~47/minute — impossible for the 45s `bar-status-poll.timer` (73 service starts in that hour), and only possible because each run used a fresh `BAR_STATUS_DIR`, so the rising-edge latch was always clear.

**It was not "a test forgot to mock".** Session transcripts from that window show base-ref red/green measurement sandboxes (`git show cb050e4:scripts/bar-status-poll`, `68566b7`, `9b8d440` staged into scratchpad trees). Measured at each of those revisions:

| revision | `_toast_runner` seam | `fire_toast` routes through it | autouse fixture in the test file | `scripts/tests/conftest.py` |
|---|---|---|---|---|
| `cb050e4` / `68566b7` / `9b8d440` (Aug 11) | **absent** | **no — inlines `subprocess.run`** | **absent** | **absent** |
| `a67f795` (Aug 11 13:56) | present | yes | present (8 refs) | absent |

So the mechanism is: **`test_bar_status.py` run in a tree state where `fire_toast` does not route through `_toast_runner`.** That is not an accident of the harness — it is the state the seam test *exists to detect*, and the state every red-first or mutation measurement of it must create. A monkeypatch on `poll._toast_runner` is structurally incapable of stopping a launch that bypasses `_toast_runner`; only something below the process boundary can.

**Reproduced byte-for-byte.** Mutating `fire_toast` to inline `subprocess.run`, then running only the seam test:

| variant | seam test | real launches recorded |
|---|---|---|
| `conftest.py` **removed** | RED, its own message | **1** — `systemd-run … bash -c a=$(dunstify -a bar-status …) bar-status critical sum body` |
| `conftest.py` **present** | RED, its own message | **0** |

The escaping argv is identical to the journal line. Both halves stay red, which is the point: the guard makes the red *safe to measure*, it does not remove it.

## Relationship to #399

**#399 is MERGED** (`4c83cbd`, 2026-08-12 01:52Z) — it was open when this task was written. This PR **extends its mechanism**; it is based on current `origin/main` and adds no second guard. #399's PATH fixture is already what stops the escape above; what was missing is that `test_bar_status.py` was in neither its file list nor its seam ledger — *a count of declarations is not a count of instances*.

## What this adds

* **`test_the_bar_status_toast_reaches_the_stub_not_the_desktop`** — the third seam case beside monitor-blackout and rig-control. Drives `fire_toast` **for real** in a subprocess (not in-process, so no other test's monkeypatch can be credited), seam unpatched, session bus satisfied, and asserts the launch landed in the stub log carrying `dunstify -a bar-status`.
* **`launcher_scan.module_loaders()` + `POLLER_LOADING_TESTS`** — a RELATIONSHIP, not a component. Three files load the poller and each gets its **own module object**: `test_bar_status.py` (has the fixture), `test_airvpn_menu.py` and `test_bar_url.py` (**do not** — the PATH fixture is their only protection). Fails when the set grows *or* shrinks.
* **`test_the_ledger_equality_is_what_makes_a_new_reacher_red`** — nested control/mutant pair, the shape this file already uses for the seam assertion.

## Positive control that the guard FIRES

`DISPATCHED=True` is asserted *inside* the toast test: if `fire_toast` returns early at the session-bus check it never reaches a launcher, and an empty stub log would read as success. Mutant **M7** (no bus reachable, `_borrow_desktop_env` neutered) → the test goes **RED naming exactly that**, not an unrelated error.

The guard has also been watched to fire with a real escape behind it: mutants **M1/M2/M3** each produced **real launches** at a recording interceptor while the guard went red — the failure is about the reach, not bookkeeping.

## Mutation battery — 8 mutants, all KILLED, weighted away from deletion

Full `scripts/` tree staged per variant, `__pycache__` purged, `python3 -B`, `PYTHONDONTWRITEBYTECODE=1`, an independent recording interceptor first on PATH.

| mutant | result | real launches | verdict |
|---|---|---|---|
| control (unmutated) | 70 passed | 0 | — |
| **M1** PATH prepend **commented out, text preserved** | 45 failed | **39** | KILLED |
| **M2** stub dir appended **LAST** (on PATH, shadows nothing) | 45 failed | **39** | KILLED |
| **M3** `systemd-run` removed from the ledger | 4 failed, incl. the toast test | **4** | KILLED |
| **M4** ledger `==` → `>=` **+ a new poller-loading file** | 1 failed (`…ledger_equality…`) | 0 | KILLED |
| **M4b** same new reacher, ledger intact | 1 failed (`…loads_the_poller_is_pinned`) | 0 | KILLED |
| **M5** loader-scan glob narrowed to `test_bar_*.py` (silently covers less) | 3 failed | 0 | KILLED |
| **M6** loader-scan returns `{}` (wired to nothing) | 3 failed | 0 | KILLED |
| **M7** no bus reachable → probe measures nothing | 1 failed (the toast test) | 0 | KILLED |

**M4 was a genuine survivor on the first pass** — `>=` plus a new reacher left the whole guard file green. That is what `test_the_ledger_equality_is_what_makes_a_new_reacher_red` was added for.

**Harness correction, stated because it invalidated the first battery:** the first run staged only *some* top-level scripts, so `ACKNOWLEDGED_UNSTUBBED`'s file-set binding made the **control itself red** and every mutant unreadable. Fixed by staging the full `scripts/` tree; all numbers above are from the corrected run.

## Whole-suite zero-toasts pair

On the **laptop** (`192.168.50.155`), whose dunst is *not* paused. Read-only against dunst — nothing flushed, cleared, dismissed or unpaused. The workbench's paused queue was never touched.

🔴 **The first instrument was dead and said so on its own control.** Counting `[systemd-run]` journal descriptions returned **0 for a toast that definitely fired** — the laptop does not log them the way the workbench does. A second attempt read `dunstctl count history` too soon (measured latency: **~6s**). Only the third is validated:

| | notifications | `bar-status` entries |
|---|---|---|
| **positive control** (one real toast via `fire_toast`'s exact `systemd-run --setenv` argv) | **+1** | **+1** |
| **whole `scripts/tests` run** | **+0** | **+0** |

Independently, the recording interceptor logged **`ESCAPED_TOTAL=0`** across the full run — and that instrument is positively controlled by M1/M2 above (39 launches each).

Run content, counted rather than read from an exit code: **2633 passed, 0 failed, 0 skipped, 0 timeout panics / INTERNALERROR**, 198.7s.

## Both tiers

| tier | `origin/main` | this branch |
|---|---|---|
| `nix build .#checks.x86_64-linux.pytests` | PASS — TOTAL 8192 / 8191 passed / 1 skipped / 0 failed | PASS — TOTAL **8196** / 8195 / 1 / 0 |
| ↳ `scripts/tests` | collected=2629 passed=2629 **skipped=0** floor=2579 | collected=**2633** passed=2633 **skipped=0** floor=2579 |
| `nix-shell` dev-host tier (`pytest`, `pyyaml`, `requests`, `logrotate`) | test_bar_status.py: 140 passed, 0 real launches | full suite: 2633 passed, 0 skipped, 0 real launches |

Attribution measured, not computed: the guard file collects **66 → 70**, and `scripts/tests` moves **2629 → 2633** — the whole delta, on that file's own line. No floor change; `EXPECTED_SKIPS` untouched.

## 🔴 Deliberately left OPEN — a bigger gap this PR does NOT close

A full audit of every test file found **one structural gap far larger than the one fixed here, and I am flagging it rather than changing it unilaterally**: `scripts/run-tests.sh:723` runs **one `pytest` process per target directory**, and the nolaunch fixture is a *session*-scoped conftest in `scripts/tests/`. So **the guard covers 1 of 17 pytest targets.** The other 16 run in separate interpreters with an untouched ambient PATH. Closing it (a repo-root `conftest.py`, or the guard installed per-target by the runner) touches every suite in the repo and belongs in a change someone reviews on purpose.

Measured reaches in that unprotected space — **none is firing today**, each is held by one in-file line:

* `scripts/browser-bridge/server.py:2055-2075` resolves `i3-msg` by **absolute path** (`/run/current-system/sw/bin/i3-msg`) — a PATH stub is powerless against it. Held only by the autouse `_disable_i3` fixture at `tests/test_server.py:138`.
* `scripts/validation/replay.py:225` spawns bare `xdotool`. Held only by `monkeypatch.delenv("DISPLAY")` at `tests/test_replay_assert.py:45`.
* `scripts/claude-hooks/tests/test_claude_notify.py` drives a hook that really spawns `dunstify`/`notify-send`; held by its own prepended stub dir — **and it is collected by no gate** (`run-tests.sh` names only `test_guard_core.py` from that directory).
* `scripts/tests/test_release_wrapper.sh:67` **prepends** stubs to the ambient PATH and stubs only `git`/`npm`/`notify-send`; no guard, and referenced by no runner or gate.

Audit results for the rest, stated as "none": **no** test anywhere uses `shell=True`, `os.system`, `os.exec*`, `os.spawn*`, `pty.spawn` or `Popen(executable=)`; **no** `env=dict(PATH=…)` or `env.setdefault("PATH", …)`; the only full PATH replacements are `test_rig_control.py:199` (`/usr/bin/false` — a file, resolves nothing) and `collector/tests/test_ch_regrowth.py:1092` (child invokes no launcher); every module-level `shutil.which` captured before the fixture resolves `bash`/`jq`/`grep`/`git`, never a launcher; the node suites contain zero `child_process` usage.

Also still open from #399 and unchanged here: `hazard_hits` matches literal names over the top level of `scripts/` only; the two PATH-clobber sites are pinned, not protected; `systemctl` read verbs still execute for real.

## Not verified

* **The workbench.** Everything in the zero-toasts pair was measured on the laptop, deliberately — the workbench's dunst is paused with queued user notifications and was not touched. The journal forensics are workbench-side and read-only.
* **The exact identity of the 13:14:58 run.** The tree state is measured (seam bypassed) and reproduced byte-for-byte; *which* sandbox invocation produced it is inferred from transcripts in the window, not from a per-process record.
* **A 9th mutant (M8)** — "DISPATCHED precondition deleted" — was constructed self-contradictorily (I removed the precondition *and* inverted the launch assertion) and went red for the wrong reason. It is **not counted**; M7 carries that claim.
* This PR leaves **4 `bar-status` positive-control toasts in the laptop's dunst history**. Nothing was cleared — clearing would have destroyed user data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
