### PR TITLE
feat(subsystem-touch): a PR path source — the only one that can see a SUBAGENT's work

### DIFF
--- a/claude/skills/handoff/SKILL.md
+++ b/claude/skills/handoff/SKILL.md
@@ -76,9 +76,23 @@ Topic argument (optional): `$ARGUMENTS`. If empty, infer a short kebab-case topi
 
    `--exclude` drops the doc **you just wrote in step 2** — it is in *both* windows (untracked in git's, a `Write` tool call in the session's), and without it `claudedocs` is a nomination on every single run. It **never writes**; it resolves the changed paths against the store and reports. Scope is derived from the repo you are in (worktree-stable), so entries accrue where the work happened.
 
-   **Read the `caveat:` line before you write anything** — it states what the chosen window structurally cannot see, and the two sources are blind in *opposite* directions. The session window in particular does **not** include what a **subagent** edited, or files written by a `Bash` command; if the session's real work happened in a dispatched subagent, expect a thin path set and say so rather than inventing entries.
+   **Read the `caveat:` line before you write anything** — it states what the chosen window structurally cannot see, and the sources are blind in *opposite* directions. The session window in particular does **not** include what a **subagent** edited, or files written by a `Bash` command; if the session's real work happened in a dispatched subagent, expect a thin path set and say so rather than inventing entries.
 
-   🔴 **Any non-zero exit ⇒ print the stderr line verbatim and write NOTHING.** Exit 3 covers a missing store, a malformed entry, an unusable path and a git failure alike; none of them is a reading. Do **not** fall back to recollection — an entry written from memory is exactly the unverifiable content this store must not accumulate.
+   🔴 **If you landed any PRs this session, run it a SECOND time over them** — you know exactly which ones, and nothing else in the toolchain does:
+
+   ```
+   python3 /home/zach/workspace/devrc/scripts/lib/subsystem_touch.py --repo <repo> --pr <n>[,<n>...]
+   ```
+
+   This is the **only** source that sees a **subagent's** work. Delegating implementation to a subagent is the standing default here, and a subagent's turns are a *separate* transcript that `--session` excludes by construction — so on exactly the sessions worth recording, the session window shows the docs you wrote and none of the code. A PR's file list does not care which agent, session or tool wrote the bytes.
+
+   🔴 **A PR's file list is what the BRANCH LANDED, not what this session touched — never describe it as this session's work.** It is the union of every commit on the branch, so it includes another session's commits, hand-made ones, and older work on a long-lived branch; and it omits anything you did that never reached a PR. When you write a journal bullet from a `--pr` run, attribute it to the branch or the PR, not to "this session".
+
+   🔴 **Run it twice; never merge the two path sets.** The flags are mutually exclusive and the tool refuses the combination on purpose: a single merged set would carry one caveat that is wrong about half its members, and you would lose the one fact that decides whether a bullet is honest. Two runs, two caveats, each read on its own.
+
+   Closed-unmerged PRs are refused by name — their files exist in no tree. `OPEN` and `MERGED` are both accepted, so a PR still in review counts. The `gh` call can fail in ways nothing local can (`gh` missing, not authenticated, network down, rate-limited, a truncated file list); every one exits non-zero with its own named line, and **none of them ever returns an empty path set**, so an empty result from this source always means the PRs genuinely listed no files.
+
+   🔴 **Any non-zero exit ⇒ print the stderr line verbatim and write NOTHING.** Exit 3 covers a missing store, a malformed entry, an unusable path, a git failure and every `gh`/pull-request failure alike; none of them is a reading. Do **not** fall back to recollection — an entry written from memory is exactly the unverifiable content this store must not accumulate.
 
    Otherwise read `status=` and act on that case:
 

--- a/scripts/lib/subsystem_touch.py
+++ b/scripts/lib/subsystem_touch.py
@@ -33,10 +33,19 @@ nomination, and the census that makes the experiment falsifiable.
 
 WHERE THE PATHS COME FROM, AND WHY
 ----------------------------------
-Two real sources, in preference order: the SESSION's own transcript, falling
-back to GIT. The reporting core takes paths as an argument and has never heard
-of either, which is what let the second one be added without touching the
-matching logic.
+Three real sources: the SESSION's own transcript, the PULL REQUESTS a branch
+landed, and GIT. The reporting core takes paths as an argument and has never
+heard of any of them, which is what let the second and third be added without
+touching the matching logic.
+
+🔴 THEY ANSWER TWO DIFFERENT QUESTIONS, AND THE DIFFERENCE IS NOT A NUANCE.
+`--session` answers "what did THIS SESSION touch". `--pr` answers "what did THIS
+BRANCH LAND". Git's window is a third thing again (this branch's uncommitted +
+committed work, whoever authored it). They are not three approximations of one
+quantity — a PR's file list is the UNION of every commit on its branch, so it
+contains another session's commits, a subagent's, and hand-made ones, while a
+session transcript contains exactly one session's turns and nobody else's. Each
+`caveat` says which question its own window answers; see `PathSource.caveat`.
 
 🔴 GIT WAS THE ORIGINAL SOURCE AND IS STRUCTURALLY BLIND TO THE BEST SESSIONS.
 On its first real invocation this tool captured NOTHING from the session it was
@@ -56,6 +65,18 @@ working pattern, so the source that cannot see it is the one that has to change.
     edits (a separate transcript — measured at 196 of 733 file-tool calls across
     the 40 most recent transcripts), files written by a Bash command rather than
     a file tool, and paths outside the session cwd (counted, never dropped).
+  * PULL REQUESTS (`--pr <n>[,<n>...]`) — the only source that sees a SUBAGENT's
+    work. The standing default in this environment is to DELEGATE non-trivial
+    work to a subagent, and a subagent's turns are a separate transcript the
+    session source excludes by construction (196 of 733 file-tool calls,
+    measured) — so on exactly the sessions worth recording, the session window
+    is thin and the implementation is invisible. `gh pr view <n> --json files`
+    is immune to all three blind spots at once: it does not care which session,
+    which agent, or which tool wrote the bytes, and merged work still counts.
+    🔴 What it buys in coverage it pays for in ATTRIBUTION: it over-reports in
+    the exact direction the session source under-reports, and it cannot tell you
+    which. That is why it is a separate flag with a separate caveat rather than
+    a widening of `--session`, and why the two do not compose (see below).
   * GIT (`--paths-from git`, the default) — FALLBACK. Deterministic, re-runnable,
     already built and tested, and honest about a window that is bounded to the
     BRANCH rather than the session:
@@ -73,6 +94,31 @@ caveat's "what this BRANCH touched, NOT what this SESSION touched" is false in
 the OTHER direction once the source is per-session — it would understate a
 window that is exactly what it disclaims. `PathSource.caveat` branches per
 source; every renderer prints it, on every output path.
+
+🔴 THE SOURCES DO NOT COMPOSE — ONE QUESTION PER RUN, ENFORCED BY ARGPARSE.
+`--session`, `--transcript`, `--pr` and `--paths-from` are mutually exclusive.
+Unioning `--session` with `--pr` was considered and REJECTED, and the reason is
+the caveat rather than the paths:
+
+  * A union has ONE `caveat` line describing a set assembled from two windows
+    with opposite biases. It would have to assert session attribution for some
+    members and deny it for others, in one sentence, with no way for a reader to
+    tell which is which. This module's own rule — "a single hedging sentence
+    covering both sources would be wrong about both" — already forbids that
+    shape for two sources; a union makes it unavoidable rather than optional.
+  * The consumer's decision is per-path. `/handoff` proposes a dated journal
+    bullet against a curated, client-confidential, unbacked-up store. "This
+    session worked on X" and "some session moved X on this branch" are different
+    claims and only one of them belongs in a work-history bullet. A merged set
+    destroys exactly the fact needed to choose.
+  * It matches the refusal already enforced for `--session` + `--paths-from`,
+    which is the SAME shape: two windows, one answer. Composing here while
+    refusing there would leave the module inconsistent about its own principle.
+
+The composition that IS available is honest and needs no code: RUN IT TWICE,
+once per source, and read two reports each carrying its own caveat. That keeps
+attribution intact, which the union destroys. `/handoff` step 4 does exactly
+that.
 
 🔴 A SESSION ID IS VALIDATED, NOT TRUSTED, AND A FAILURE NEVER FALLS BACK TO GIT.
 There is no session-id environment variable, so the id arrives as an argument
@@ -99,6 +145,7 @@ CONTRACT SUMMARY
     derive_scope(repo_root, git_common_dir)   -> str
     collect_session_paths(repo, session=…)    -> PathSource      (PREFERRED)
     find_transcript(session)                  -> Path
+    collect_pr_paths(repo, numbers, fetch=…)  -> PathSource      (runs gh)
     collect_git_paths(repo)                   -> PathSource      (runs git)
     caller_supplied(paths)                    -> PathSource      (pure)
     nominate(assoc, index, *, min_paths, limit)
@@ -128,6 +175,24 @@ and, for the session source — each FATAL, none falling back to git:
     "transcript unreadable"             TranscriptUnreadableError
     "transcript cwd does not match"     TranscriptCwdMismatchError
 
+and, for the PR source — the first source that leaves this machine, so the first
+with an ENVIRONMENTAL failure surface. Each is FATAL, none falls back, and none
+of them can return an empty path set:
+
+    "repo has no usable github remote"         RepoRemoteError
+    "gh cli not found"                         GhMissingError
+    "gh is not authenticated"                  GhAuthError
+    "github api rate limit"                    GhRateLimitError
+    "github api call failed"                   GhApiError   (the FALLBACK: any
+                                               unrecognised gh failure, network
+                                               included, lands here rather than
+                                               being mapped to something specific)
+    "pull request not found"                   PrNotFoundError
+    "pull request belongs to another repository"  PrRepoMismatchError
+    "pull request is closed unmerged"          PrNotLandedError
+    "pull request response is malformed"       PrResponseMalformedError
+    "pull request file list is truncated"      PrFileListTruncatedError
+
 🔴 THE FAILURE MODE IS A CONFIDENT ZERO. "Nothing to record" is the observable
 that the most causes share: no paths, an unknown scope, a matcher wired to
 nothing, entries reached but below threshold, and a genuinely untouched index
@@ -143,6 +208,7 @@ path behind it.
 from __future__ import annotations
 
 import argparse
+import collections.abc as _abc
 import json
 import os
 import subprocess
@@ -184,6 +250,18 @@ __all__ = [
     "TranscriptStaleError",
     "TranscriptUnreadableError",
     "TranscriptCwdMismatchError",
+    "RepoRemoteError",
+    "GhMissingError",
+    "GhAuthError",
+    "GhRateLimitError",
+    "GhApiError",
+    "PrNotFoundError",
+    "PrRepoMismatchError",
+    "PrNotLandedError",
+    "PrResponseMalformedError",
+    "PrFileListTruncatedError",
+    "PR_JSON_FIELDS",
+    "PR_ACCEPTED_STATES",
     "PathSource",
     "Nomination",
     "TouchReport",
@@ -191,6 +269,7 @@ __all__ = [
     "derive_scope",
     "collect_git_paths",
     "collect_session_paths",
+    "collect_pr_paths",
     "find_transcript",
     "caller_supplied",
     "nominate",
@@ -274,7 +353,19 @@ class StoreMissingError(TouchError):
 
 
 class GitError(TouchError):
-    """A git invocation failed. Sentinel: 'git command failed'."""
+    """A git invocation failed. Sentinel: 'git command failed'.
+
+    🔴 `stderr` IS CARRIED AS AN ATTRIBUTE, NOT ONLY INSIDE THE MESSAGE, so that a
+    WRAPPING error can quote git's own words WITHOUT embedding this class's
+    sentinel in its own text. `_repo_slug` is that wrapper, and it is where this
+    was found: its `RepoRemoteError` interpolated the whole `GitError`, so its
+    message carried two sentinels at once and "which guard fired" stopped being
+    measurable — `TestPrNegativeControls._only` caught it on the first run.
+    """
+
+    def __init__(self, message: str, *, stderr: str = "") -> None:
+        super().__init__(message)
+        self.stderr = stderr
 
 
 # --- Session-source errors -----------------------------------------------------
@@ -342,6 +433,159 @@ class TranscriptCwdMismatchError(TouchError):
     """
 
 
+# --- PR-source errors ----------------------------------------------------------
+#
+# 🔴 THE FIRST SOURCE THAT LEAVES THIS MACHINE. Every other source reads local
+# disk, so its whole failure surface is "the file is missing" and "the file is
+# malformed". This one crosses a network and an authenticated API, and each new
+# way it can fail is a new way to arrive at ZERO PATHS while looking like a clean
+# read:
+#
+#     gh is not installed · gh is not authenticated · the network is down · the
+#     API errored · the rate limit is exhausted · the PR does not exist · the PR
+#     is in ANOTHER repository · the response is malformed · GitHub silently
+#     TRUNCATED the file list
+#
+# EVERY ONE RAISES, with its own sentinel and a non-zero exit, and NONE returns
+# an empty path set: an empty set is indistinguishable from "this PR changed
+# nothing", which is the confident zero this module exists to refuse. None falls
+# back to git either, for the session source's reason — a plausible answer to a
+# question the caller did not ask is worse than a refusal `/handoff` already
+# knows how to handle (step 4 treats any non-zero exit as "write nothing").
+#
+# No two share a spelling; `TestPrNegativeControls` asserts that as the premise
+# of its `_only` helper, over the session sentinels TOO — a cross-family
+# collision would make both families' controls vacuous.
+
+
+class RepoRemoteError(TouchError):
+    """The repo under `--repo` has no parseable GitHub remote.
+
+    Sentinel: 'repo has no usable github remote'. A PR number is meaningless
+    without the repository it belongs to, and that repository is derived from
+    the local remote rather than assumed — see `_repo_slug`.
+    """
+
+
+class GhMissingError(TouchError):
+    """The `gh` binary is not on PATH. Sentinel: 'gh cli not found'.
+
+    🔴 A LIVE CASE, NOT A DEFENSIVE ONE. `gh` is NOT in `REQUIRED_TOOLS` in
+    `scripts/run-tests.sh` and NOT in `nativeBuildInputs` for the flake's
+    `checks.pytests` — verified 2026-08-12 — so it is absent in the hermetic
+    tier by construction, and may be absent on any host. The tool must degrade
+    with this named error rather than a `FileNotFoundError` traceback, and no
+    test may depend on `gh` existing (which is what `fetch` being injectable is
+    for).
+    """
+
+
+class GhAuthError(TouchError):
+    """`gh` has no usable credentials. Sentinel: 'gh is not authenticated'."""
+
+
+class GhRateLimitError(TouchError):
+    """The GitHub API rate limit is exhausted. Sentinel: 'github api rate limit'.
+
+    Its own error because it is the one failure that is purely temporal: the
+    same command succeeds later, so telling it apart from a real API error is
+    the difference between "wait" and "something is wrong".
+    """
+
+
+class GhApiError(TouchError):
+    """Any other `gh` failure. Sentinel: 'github api call failed'.
+
+    🔴 THE FALLBACK, AND DELIBERATELY THE WIDEST. An unrecognised gh failure —
+    an unreachable network, a 5xx, a TLS problem, a future gh message nobody
+    here has seen — lands HERE rather than being mapped onto a specific
+    diagnosis it might not be. Guessing wrong about WHY would be a confident
+    wrong answer; the sentence carries gh's own stderr verbatim so the reader
+    diagnoses it, not this module.
+    """
+
+
+class PrNotFoundError(TouchError):
+    """No such pull request. Sentinel: 'pull request not found'.
+
+    Also raised for a token that is not a usable PR number at all, following the
+    session source's precedent for an unusable id: the caller passed something
+    that cannot name a PR, and searching for it would be theatre.
+    """
+
+
+class PrRepoMismatchError(TouchError):
+    """The PR belongs to a different repository than `--repo`.
+
+    Sentinel: 'pull request belongs to another repository'.
+
+    🔴 A NUMBER ALONE IS MEANINGLESS ACROSS REPOS — every repo has a #1. Reading
+    another repo's file list here would MANUFACTURE associations: the paths
+    would be well-formed, repo-relative and completely unrelated, and they would
+    resolve against this repo's index without a murmur. The check compares the
+    HOST too, not just `owner/name`: a repo whose origin is on another forge can
+    share `owner/name` with an unrelated GitHub project, and an owner/name-only
+    comparison would call that a match.
+    """
+
+
+class PrNotLandedError(TouchError):
+    """The PR was closed without merging. Sentinel: 'pull request is closed unmerged'.
+
+    🔴 OPEN AND MERGED ARE ACCEPTED; CLOSED-UNMERGED IS NOT, and the asymmetry is
+    the question this source answers — "what did this branch LAND". A merged PR
+    landed. An OPEN one is proposed and is the ordinary case at `/handoff` time,
+    when CI is still running or review has not happened: refusing it would make
+    the tool useless in exactly the moment it is invoked. A CLOSED-unmerged PR
+    was proposed and REJECTED — its paths exist in no tree, so a journal bullet
+    written from them would record a change to a subsystem that never happened.
+    """
+
+
+class PrResponseMalformedError(TouchError):
+    """The API response is not the shape this code reads.
+
+    Sentinel: 'pull request response is malformed'.
+
+    🔴 `files` ABSENT IS NOT `files: []`. The same distinction the session source
+    draws between an unobservable file set and an observed-empty one, at the
+    other end of the pipe: a response missing the key means we do not know what
+    the PR changed, while `[]` means GitHub says it changed nothing. Conflating
+    them turns a broken read into "this PR touched nothing", which is the silent
+    zero again.
+    """
+
+
+class PrFileListTruncatedError(TouchError):
+    """GitHub returned fewer files than the PR actually changed.
+
+    Sentinel: 'pull request file list is truncated'.
+
+    🔴 MEASURED, NOT DEFENSIVE — and this is a LIVE hazard, not a hypothetical.
+    `gh pr view --json files` caps the list at 100 entries while `changedFiles`
+    reports the true count, and it says NOTHING about having done so. Measured
+    2026-08-12 at three points either side of the cap:
+
+        a  39-file PR    changedFiles=39    len(files)=39
+        a 301-file PR    changedFiles=301   len(files)=100
+        a 411-file PR    changedFiles=411   len(files)=100
+
+    So on any PR over the cap the plausible-looking answer is a silent prefix,
+    with a late-sorting subtree missing entirely, no error and no note. The guard
+    is `len(files) < changedFiles`, which is CAP-AGNOSTIC on purpose: pinning the
+    literal 100 would go stale the day GitHub changes it, and the comparison
+    needs no constant at all.
+
+    🔴 IT REFUSES rather than reporting the prefix, which is the OPPOSITE of what
+    the session source does with the extractor's cap (a loud note, then carry
+    on). The difference is what the caller can do about it. The extractor's cap
+    is internal and its paths are still genuinely this session's; here the caller
+    has an exact, provenance-preserving alternative — pipe the paths in with
+    `--paths-from -`, whose caveat says outright that provenance is the caller's
+    to state.
+    """
+
+
 # --- Scope ---------------------------------------------------------------------
 
 
@@ -377,17 +621,34 @@ class PathSource:
     """
 
     kind: str
-    """`git`, `session` or `caller`."""
+    """`git`, `session`, `pr` or `caller`."""
 
     window: str
-    """`branch` (worktree ∪ this branch's commits), `worktree`, `session`, or `supplied`."""
+    """`branch` (worktree ∪ this branch's commits), `worktree`, `session`,
+    `pull-requests`, or `supplied`."""
 
     paths: tuple[str, ...]
     base_ref: str | None = None
     commands: tuple[tuple[str, ...], ...] = ()
+    """🔴 FULL ARGV, PROGRAM INCLUDED. It used to omit the program because every
+    source ran `git` and the renderer hardcoded that word — which became a FALSE
+    provenance line the moment a source ran something else. `commands` exists so
+    a reader can check what was actually asked; a line reading `ran: git pr view
+    421` would be the exact defect it is there to prevent."""
+
     notes: tuple[str, ...] = ()
     session: str | None = None
     """The session id, when `kind == "session"`. Part of the caveat, not decoration."""
+
+    prs: tuple[int, ...] = ()
+    """The pull requests read, when `kind == "pr"`. Part of the caveat."""
+
+    repo_slug: str | None = None
+    """`host/owner/name` the PRs were read from, when `kind == "pr"`.
+
+    In the caveat because "PR #4" is ambiguous across repositories and the whole
+    point of the repository guard is that a bare number names nothing.
+    """
 
     @property
     def caveat(self) -> str:
@@ -402,6 +663,28 @@ class PathSource:
         """
         if self.kind == "caller":
             return "paths were supplied by the caller; provenance is the caller's to state"
+        if self.kind == "pr":
+            # 🔴 THE WORDING IS THE DELIVERABLE. This source answers "what did
+            # this BRANCH LAND", and nothing here may read as session
+            # attribution — a PR's file list is the union of everything on the
+            # branch, so it over-reports in exactly the direction the session
+            # window under-reports, and it cannot say which paths are which.
+            # The last sentence is imperative on purpose: the consumer is an
+            # LLM about to write a dated bullet into a curated store, and
+            # "session" is the word it will reach for unless told not to.
+            listed = ", ".join(f"#{n}" for n in self.prs)
+            return (
+                f"pull request(s) {listed} in {self.repo_slug}: every file GitHub "
+                f"lists on those BRANCHES — what the BRANCH LANDED, NOT what a "
+                f"SESSION touched. A PR's file list is the UNION of every commit "
+                f"on its branch, so it includes commits authored by ANOTHER "
+                f"session, by a SUBAGENT, or by hand, and older work if the branch "
+                f"is long-lived; and it EXCLUDES anything a session did that did "
+                f"not reach one of these PRs. It is blind in the OPPOSITE "
+                f"direction to the session window, which sees exactly one "
+                f"session's turns and nobody else's. Attribute these paths to the "
+                f"BRANCH, never to a session"
+            )
         if self.kind == "session":
             return (
                 f"session transcript {self.session}: the files THIS SESSION's own turns "
@@ -446,7 +729,8 @@ def _git(repo: Path, args: Sequence[str]) -> str:
     if proc.returncode != 0:
         raise GitError(
             f"git command failed ({' '.join(argv)}): exit {proc.returncode}: "
-            f"{proc.stderr.strip() or '(no stderr)'}"
+            f"{proc.stderr.strip() or '(no stderr)'}",
+            stderr=proc.stderr.strip(),
         )
     return proc.stdout
 
@@ -544,11 +828,11 @@ def collect_git_paths(
         raw.extend(new)
 
     worktree_args = ["diff", "--name-only", "-z", "HEAD"]
-    commands.append(tuple(worktree_args))
+    commands.append(("git", *worktree_args))
     add(_nul_list(_git(repo, worktree_args)))
 
     untracked_args = ["ls-files", "--others", "--exclude-standard", "-z"]
-    commands.append(tuple(untracked_args))
+    commands.append(("git", *untracked_args))
     add(_nul_list(_git(repo, untracked_args)))
 
     base_ref: str | None = None
@@ -577,7 +861,7 @@ def collect_git_paths(
             )
         elif merge_base:
             branch_args = ["diff", "--name-only", "-z", f"{merge_base}..HEAD"]
-            commands.append(tuple(branch_args))
+            commands.append(("git", *branch_args))
             add(_nul_list(_git(repo, branch_args)))
             window = "branch"
 
@@ -888,9 +1172,398 @@ def collect_session_paths(
         kind="session",
         window="session",
         paths=tuple(paths),
-        commands=(("rev-parse", "--show-toplevel"),),
+        commands=(("git", "rev-parse", "--show-toplevel"),),
         notes=tuple(notes),
         session=label,
+    )
+
+
+# --- The PR source: paths from what the BRANCH LANDED --------------------------
+#
+# 🔴 READ `PathSource.caveat` FOR WHAT THIS SET IS BEFORE READING WHAT IT DOES.
+# It answers "what did this BRANCH land", NOT "what did this session touch", and
+# the two are not approximations of each other — see the module docstring.
+#
+# 🔴 THE FETCH IS INJECTABLE SO THE GUARDS ARE TESTABLE WITHOUT A NETWORK, AND
+# WITHOUT `gh`. `gh` is NOT in `REQUIRED_TOOLS` in `scripts/run-tests.sh` and NOT
+# in `nativeBuildInputs` for the flake's `checks.pytests` (verified 2026-08-12),
+# so the hermetic tier has no `gh` at all and a test that shelled out would skip
+# — and `run-tests.sh` pins `EXPECTED_SKIPS` exactly, so a new skip breaks the
+# gate on purpose. Every guard below is therefore reached with a fixture payload
+# through `fetch`, and the ONE thing that cannot be: `_gh_fetch_pr` itself, whose
+# classification of gh's own exit codes is pinned separately against the
+# measured stderr strings rather than by running gh.
+
+PR_JSON_FIELDS = "number,url,state,changedFiles,files"
+"""The fields fetched. `changedFiles` is not decoration: it is the ONLY way to
+detect that `files` was truncated — see `PrFileListTruncatedError`."""
+
+PR_ACCEPTED_STATES: tuple[str, ...] = ("OPEN", "MERGED")
+_PR_KNOWN_STATES: tuple[str, ...] = ("OPEN", "MERGED", "CLOSED")
+
+# The remote the repository identity is derived from. Not configurable: a second
+# remote is a second answer to "which repo is this", and picking between them is
+# the kind of guess this module refuses everywhere else.
+_PR_REMOTE = "origin"
+
+
+def _parse_remote_slug(url: str) -> str | None:
+    """`host/owner/name` from a git remote URL, or None if it names no repo.
+
+    🔴 THE HOST IS PART OF THE IDENTITY. Dropping it would let a repo whose
+    origin lives on another forge match an unrelated GitHub project that happens
+    to share `owner/name` — and this function's output is exactly what the
+    repository guard compares, so an owner/name-only slug would make that guard
+    agree with the wrong project.
+
+    Handles the three spellings git actually emits: scp-like
+    (`git@host:owner/name`), ssh URL (`ssh://git@host/owner/name`) and https
+    (`https://host/owner/name`), each with or without a trailing `.git`.
+    """
+    u = (url or "").strip().rstrip("/")
+    if not u:
+        return None
+    if u.endswith(".git"):
+        u = u[: -len(".git")]
+    if "://" not in u and ":" in u:  # scp-like
+        host, _, tail = u.partition(":")
+    else:
+        rest = u.partition("://")[2] or u
+        host, _, tail = rest.partition("/")
+    host = host.rpartition("@")[2].partition(":")[0].strip().lower()
+    parts = [p for p in tail.split("/") if p]
+    if not host or len(parts) < 2 or not parts[-2] or not parts[-1]:
+        return None
+    return f"{host}/{parts[-2]}/{parts[-1]}"
+
+
+def _repo_slug(repo: str | Path) -> str:
+    """The `host/owner/name` a PR number is to be interpreted against.
+
+    DERIVED from the local remote, never assumed and never taken from the
+    caller: a PR number is meaningless without its repository, and the whole
+    point of the repository guard is that the number alone names nothing.
+    """
+    try:
+        url = _git(Path(repo), ["remote", "get-url", _PR_REMOTE]).strip()
+    except GitError as exc:
+        # 🔴 `exc.stderr`, NOT `exc`. Interpolating the whole GitError would put
+        # its sentinel inside this one's message, and a message carrying two
+        # sentinels makes "which guard fired" an inference instead of a
+        # measurement — see `GitError`.
+        raise RepoRemoteError(
+            f"repo has no usable github remote: `{_PR_REMOTE}` could not be read in "
+            f"{repo} ({exc.stderr or 'no detail'}) — a pull request number cannot be "
+            f"resolved without knowing which repository it belongs to"
+        ) from exc
+    slug = _parse_remote_slug(url)
+    if slug is None:
+        raise RepoRemoteError(
+            f"repo has no usable github remote: the `{_PR_REMOTE}` remote of {repo} is "
+            f"{url!r}, which names no host/owner/name — a pull request number cannot "
+            f"be resolved against it"
+        )
+    return slug
+
+
+def _gh_argv(slug: str, number: int) -> tuple[str, ...]:
+    return ("gh", "pr", "view", str(number), "--repo", slug, "--json", PR_JSON_FIELDS)
+
+
+def _classify_gh_failure(rc: int, stderr: str, slug: str, number: int) -> TouchError:
+    """Map a non-zero `gh` exit onto ONE named error. Never onto an empty set.
+
+    ⚠ DECLARED AS PART-HEURISTIC, per `claude/RULES.md` ("if you reach for a
+    prose/keyword patch, say so explicitly"). `gh` exposes exactly ONE
+    distinguishing exit code and returns 1 for everything else, so only the auth
+    case can be read structurally; the rest is keyed on stderr text. MEASURED
+    2026-08-12 against the live binary (gh 2.96.0):
+
+        no credentials at all   rc=4   "please run: gh auth login"
+        bad token               rc=1   "HTTP 401: Bad credentials"
+        unreachable host        rc=1   "error connecting to <host>"
+        nonexistent PR          rc=1   "Could not resolve to a PullRequest"
+
+    🔴 THE ORDER IS FORCED BY OVERLAP, NOT BY TASTE. A rate-limited response is
+    an HTTP 403 that ALSO carries gh's "authenticate with gh auth login" hint, so
+    an auth-first order would swallow it and report a permanent failure for a
+    temporary one. Rate limit is therefore tested first, then not-found, then
+    auth, and everything else falls through.
+
+    🔴 THE FALLBACK IS THE WIDE ONE. An unrecognised failure — the unreachable
+    host above, a 5xx, a gh message written after this was — becomes `GhApiError`
+    carrying gh's stderr verbatim, rather than being guessed onto a specific
+    diagnosis. A wrong explanation of a failure forecloses the next question.
+    """
+    text = (stderr or "").strip()
+    low = text.lower()
+    where = f"(gh pr view {number} --repo {slug}, exit {rc}): {text or '(no stderr)'}"
+    if rc == 4:  # structural: gh's own "not authenticated" exit code
+        return GhAuthError(f"gh is not authenticated {where}")
+    if "rate limit" in low:
+        return GhRateLimitError(f"github api rate limit {where}")
+    if (
+        "could not resolve to a pullrequest" in low
+        or "no pull requests found" in low
+        or "http 404" in low
+    ):
+        return PrNotFoundError(f"pull request not found {where}")
+    if "http 401" in low or "bad credentials" in low or "gh auth login" in low:
+        return GhAuthError(f"gh is not authenticated {where}")
+    return GhApiError(f"github api call failed {where}")
+
+
+def _gh_fetch_pr(slug: str, number: int) -> object:
+    """The live fetcher. The ONLY thing here that touches the network."""
+    argv = list(_gh_argv(slug, number))
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        # 🔴 Not a traceback. `gh` is genuinely absent in the hermetic test tier
+        # and may be absent on any host; `/handoff` prints this line verbatim.
+        raise GhMissingError(
+            f"gh cli not found: `{argv[0]}` is not on PATH, so pull request #{number} "
+            f"in {slug} cannot be read. Install the GitHub CLI, or use a different "
+            f"path source."
+        ) from exc
+    if proc.returncode != 0:
+        raise _classify_gh_failure(proc.returncode, proc.stderr, slug, number)
+    try:
+        return json.loads(proc.stdout)
+    except ValueError as exc:
+        raise PrResponseMalformedError(
+            f"pull request response is malformed: gh exited 0 for #{number} in {slug} "
+            f"but its stdout is not JSON ({exc})"
+        ) from exc
+
+
+def _pr_number(token: object) -> int:
+    """A usable PR number, or a named refusal. Never a search for junk."""
+    t = str(token).strip().lstrip("#")
+    if not (t.isascii() and t.isdigit()) or int(t) < 1:
+        raise PrNotFoundError(
+            f"pull request not found: {token!r} is not a usable pull request number — "
+            f"pass the integer from the PR's URL, e.g. `--pr 421` or `--pr 421,350`"
+        )
+    return int(t)
+
+
+def _slug_from_pr_url(url: object) -> str | None:
+    """`host/owner/name` out of a PR's own `url`, or None.
+
+    This is the PR's OWN account of where it lives, which is what makes the
+    repository check a check rather than a restatement of the argument we passed.
+    """
+    if not isinstance(url, str) or not url.strip():
+        return None
+    rest = url.strip().partition("://")[2] or url.strip()
+    parts = [p for p in rest.split("/") if p]
+    if len(parts) < 3:
+        return None
+    host = parts[0].rpartition("@")[2].partition(":")[0].lower()
+    if not host or not parts[1] or not parts[2]:
+        return None
+    return f"{host}/{parts[1]}/{parts[2]}"
+
+
+def _read_pr_payload(payload: object, *, number: int, slug: str) -> tuple[list[str], str, int]:
+    """(paths, state, changed_files) — or a named error. Never a short set.
+
+    🔴 GUARD ORDER IS REACHABILITY ORDER. Each guard is reached by an input no
+    EARLIER guard rejects, so each one's negative control fails on its OWN
+    sentinel rather than on a neighbour's:
+
+      1. the response is an OBJECT          PrResponseMalformedError
+      2. it is the PR we ASKED for          PrResponseMalformedError
+      3. its `url` names a repository       PrResponseMalformedError
+      4. that repository is THIS one        PrRepoMismatchError
+      5. its state is known                 PrResponseMalformedError
+      6. …and it is not closed-unmerged     PrNotLandedError
+      7. `files` is PRESENT and a list      PrResponseMalformedError
+      8. every entry names a path           PrResponseMalformedError
+      9. `changedFiles` is a count          PrResponseMalformedError
+     10. …and NOTHING WAS CUT               PrFileListTruncatedError
+
+    (4) must precede (7): the point of the repository guard is that another
+    repo's file list is never READ, not merely never reported — a set read first
+    and rejected later has already been in memory next to this repo's index.
+
+    (10) is last because it is the only guard that needs the parsed list to
+    exist; it is also the one that fires on a perfectly valid, perfectly
+    authenticated, perfectly on-topic response. See `PrFileListTruncatedError`.
+    """
+    where = f"pull request #{number} in {slug}"
+    if not isinstance(payload, _abc.Mapping):
+        raise PrResponseMalformedError(
+            f"pull request response is malformed: {where} came back as "
+            f"{type(payload).__name__}, not an object"
+        )
+
+    got = payload.get("number")
+    if isinstance(got, bool) or not isinstance(got, int) or got != number:
+        raise PrResponseMalformedError(
+            f"pull request response is malformed: asked for {where} and got number "
+            f"{got!r} — the response does not describe the pull request requested"
+        )
+
+    got_slug = _slug_from_pr_url(payload.get("url"))
+    if got_slug is None:
+        raise PrResponseMalformedError(
+            f"pull request response is malformed: {where} carries no parseable `url` "
+            f"({payload.get('url')!r}), so the repository it belongs to cannot be "
+            f"checked — and an unchecked repository is exactly what makes a bare "
+            f"number dangerous"
+        )
+    if got_slug.lower() != slug.lower():
+        raise PrRepoMismatchError(
+            f"pull request belongs to another repository: #{number} lives in "
+            f"{got_slug}, but --repo resolves to {slug}. Every repository has a #1, "
+            f"so a number alone names nothing; reading that file list here would "
+            f"associate another project's work with this one."
+        )
+
+    state = payload.get("state")
+    if not isinstance(state, str) or state.strip().upper() not in _PR_KNOWN_STATES:
+        raise PrResponseMalformedError(
+            f"pull request response is malformed: {where} has state {state!r}, which is "
+            f"none of {', '.join(_PR_KNOWN_STATES)} — whether it landed cannot be read"
+        )
+    state = state.strip().upper()
+    if state not in PR_ACCEPTED_STATES:
+        raise PrNotLandedError(
+            f"pull request is closed unmerged: {where} was closed without merging, so "
+            f"its files exist in no tree and nothing landed from it. Drop it from "
+            f"--pr; {' and '.join(PR_ACCEPTED_STATES)} are accepted."
+        )
+
+    files = payload.get("files")
+    if not isinstance(files, list):
+        raise PrResponseMalformedError(
+            f"pull request response is malformed: {where} has no `files` list "
+            f"({files!r}). An ABSENT file list means the changed files are UNKNOWN, "
+            f"which is not the same as a PR that changed nothing — reporting the "
+            f"second for the first is the silent zero this refuses."
+        )
+
+    paths: list[str] = []
+    for i, item in enumerate(files):
+        raw_path = item.get("path") if isinstance(item, _abc.Mapping) else None
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            raise PrResponseMalformedError(
+                f"pull request response is malformed: {where} file entry {i} names no "
+                f"path ({item!r}) — a file list with an unreadable entry is not a "
+                f"shorter file list"
+            )
+        paths.append(raw_path.strip())
+
+    changed = payload.get("changedFiles")
+    if isinstance(changed, bool) or not isinstance(changed, int) or changed < 0:
+        raise PrResponseMalformedError(
+            f"pull request response is malformed: {where} has changedFiles={changed!r}, "
+            f"so whether the file list was truncated cannot be determined — and an "
+            f"undetectable truncation is a silently short path set"
+        )
+    if len(paths) < changed:
+        raise PrFileListTruncatedError(
+            f"pull request file list is truncated: {where} changed {changed} files but "
+            f"the API returned only {len(paths)}. The list is a PREFIX, so a "
+            f"late-sorting subtree may be missing entirely and every count below it "
+            f"would be wrong. Nothing is reported. Supply the paths yourself instead: "
+            f"`git diff --name-only <base>...<head> | subsystem_touch.py --paths-from -`, "
+            f"whose caveat states that provenance is the caller's."
+        )
+    return paths, state, changed
+
+
+def collect_pr_paths(
+    repo: str | Path,
+    numbers: Iterable[object],
+    *,
+    fetch=None,
+    exclude: Iterable[str] = (),
+) -> PathSource:
+    """What the named PULL REQUESTS landed. Per-branch, not per-session.
+
+    The window the other two sources cannot express. `--session` is blind to a
+    SUBAGENT's edits — a separate transcript, 196 of 733 file-tool calls measured
+    — and delegating non-trivial work to a subagent is the standing default here,
+    so on the sessions worth recording the implementation is exactly what the
+    session window misses. Git is blind to anything already merged. A PR's file
+    list is blind to neither.
+
+    🔴 AND IT IS BLIND IN THE OPPOSITE DIRECTION: it is the union of every commit
+    on the branch, including another session's and hand-made ones, and it omits
+    whatever a session did that never reached a PR. `PathSource.caveat` says so
+    in those words, on every output path of both renderers. Do not describe this
+    set as a session's.
+
+    `fetch` is the injection seam: a callable `(slug, number) -> payload`,
+    defaulting to `_gh_fetch_pr`. Every guard in `_read_pr_payload` is reachable
+    through it with a fixture, which is what keeps the suite off the network and
+    off `gh` — neither of which exists in the hermetic tier.
+
+    🔴 `commands` RECORDS THE ARGV ONLY WHEN THE ARGV RAN. With a fetcher
+    injected nothing was executed, so recording `gh pr view …` would be a
+    fabricated provenance line in the field whose entire purpose is to say what
+    was actually asked. An injected run says so in a note instead.
+    """
+    slug = _repo_slug(repo)
+    live = fetch is None
+    fetcher = _gh_fetch_pr if live else fetch
+
+    commands: list[tuple[str, ...]] = []
+    notes: list[str] = []
+    raw: list[str] = []
+    read: list[int] = []
+
+    for token in numbers:
+        n = _pr_number(token)
+        if n in read:
+            notes.append(f"pull request #{n} was named more than once; read once")
+            continue
+        read.append(n)
+        if live:
+            commands.append(_gh_argv(slug, n))
+        paths, state, changed = _read_pr_payload(fetcher(slug, n), number=n, slug=slug)
+        # 🔴 EMITTED UNCONDITIONALLY, INCLUDING AT ZERO. A stated `0 file(s)` is
+        # a reading; an absent line is indistinguishable from a fetcher wired to
+        # nothing (`claude/RULES.md` → "report the pair").
+        notes.append(
+            f"pull request #{n} ({state}): {changed} file(s) reported by the API, "
+            f"{len(paths)} read"
+        )
+        raw.extend(paths)
+
+    if not read:
+        # Reachable via `--pr ,` or `--pr ''`. Falling through would return a
+        # perfectly well-formed report over ZERO pull requests — the confident
+        # zero, arriving through argument parsing.
+        raise PrNotFoundError(
+            "pull request not found: no pull request number was given, so nothing was "
+            "read. `--pr` takes one or more integers, e.g. `--pr 421,350`."
+        )
+    if not live:
+        notes.insert(
+            0,
+            "⚠ paths came from an INJECTED fetcher, not from `gh` — this is a test "
+            "harness, not a live read",
+        )
+
+    paths, dropped = _filter_excluded(raw, exclude)
+    notes.append(
+        f"{len(paths)} distinct path(s) across {len(read)} pull request(s) in {slug}"
+    )
+    if dropped:
+        notes.append(_exclusion_note(dropped))
+
+    return PathSource(
+        kind="pr",
+        window="pull-requests",
+        paths=tuple(paths),
+        commands=tuple(commands),
+        notes=tuple(notes),
+        prs=tuple(read),
+        repo_slug=slug,
     )
 
 
@@ -1308,7 +1981,10 @@ def render_text(report: TouchReport) -> str:
     for note in src.notes:
         out.append(f"  note: {note}")
     for cmd in src.commands:
-        out.append(f"  ran: git {' '.join(cmd)}")
+        # The FULL argv, program included. See `PathSource.commands`: the word
+        # `git` used to be hardcoded here, which made this line a false claim
+        # the moment a source ran something else.
+        out.append(f"  ran: {' '.join(cmd)}")
 
     if report.status == "looked-at-nothing":
         out.append("")
@@ -1420,6 +2096,8 @@ def report_json(report: TouchReport) -> dict:
             "window": src.window,
             "base_ref": src.base_ref,
             "session": src.session,
+            "prs": list(src.prs),
+            "repo_slug": src.repo_slug,
             "caveat": src.caveat,
             "notes": list(src.notes),
             "commands": [list(c) for c in src.commands],
@@ -1570,8 +2248,8 @@ def _build_parser() -> argparse.ArgumentParser:
         "--paths-from",
         default="git",
         help=(
-            "fallback source when no session is given: `git` (default) or `-` to read "
-            "repo-relative paths from stdin, one per line"
+            "fallback source when no --session/--transcript/--pr is given: `git` "
+            "(default) or `-` to read repo-relative paths from stdin, one per line"
         ),
     )
     # 🔴 MUTUALLY EXCLUSIVE, ENFORCED BY ARGPARSE (exit 2). They name the same
@@ -1597,6 +2275,20 @@ def _build_parser() -> argparse.ArgumentParser:
             "the session source, naming the transcript file directly instead of "
             "resolving a UUID. Same validation; use it when --session reports the id "
             "is ambiguous."
+        ),
+    )
+    session_src.add_argument(
+        "--pr",
+        action="append",
+        default=None,
+        metavar="N[,N...]",
+        help=(
+            "report what these PULL REQUESTS landed, via `gh`. A DIFFERENT QUESTION "
+            "from --session: a PR's file list is the union of every commit on its "
+            "branch, so it SEES a subagent's work (which --session cannot) and also "
+            "another session's (which --session correctly excludes). Repeatable and "
+            "comma-separated. Validated against the repo under --repo; OPEN and "
+            "MERGED are accepted, closed-unmerged is refused."
         ),
     )
     p.add_argument(
@@ -1652,15 +2344,17 @@ def main(argv: Sequence[str] | None = None, *, today: str | None = None) -> int:
             return 0
 
         wants_session = args.session is not None or args.transcript is not None
+        wants_pr = args.pr is not None
         # 🔴 A CONTRADICTION IS REFUSED, NOT RESOLVED. `--paths-from` names the
-        # FALLBACK source, so pairing it with a session request asks for two
-        # different windows at once. Honouring either silently would hand back a
-        # plausible answer to a question the caller did not ask — the same
-        # failure the no-fallback rule above exists to prevent, arriving through
-        # argument parsing instead.
-        if wants_session and args.paths_from != "git":
+        # FALLBACK source, so pairing it with a session or PR request asks for
+        # two different windows at once. Honouring either silently would hand
+        # back a plausible answer to a question the caller did not ask — the
+        # same failure the no-fallback rule above exists to prevent, arriving
+        # through argument parsing instead. (`--session` vs `--transcript` vs
+        # `--pr` is enforced one level up, by argparse's exclusive group.)
+        if (wants_session or wants_pr) and args.paths_from != "git":
             print(
-                "subsystem-touch: --session/--transcript cannot be combined with "
+                "subsystem-touch: --session/--transcript/--pr cannot be combined with "
                 "--paths-from; they are different path windows. Drop one.",
                 file=sys.stderr,
             )
@@ -1671,6 +2365,24 @@ def main(argv: Sequence[str] | None = None, *, today: str | None = None) -> int:
                 repo,
                 session=args.session,
                 transcript=args.transcript,
+                exclude=args.exclude,
+            )
+        elif wants_pr:
+            # Flattened here rather than in `collect_pr_paths` so the library
+            # keeps taking a plain sequence of numbers: `--pr 1,2 --pr 3` is a
+            # CLI spelling, not part of the contract.
+            source = collect_pr_paths(
+                repo,
+                # Empty tokens are dropped so `--pr 421,` is the typo it looks
+                # like rather than a second, unusable number — and so `--pr ,`
+                # reaches the "no pull request number was given" guard instead
+                # of the "not a usable number" one, which is a different fact.
+                [
+                    tok
+                    for group in args.pr
+                    for tok in str(group).split(",")
+                    if tok.strip()
+                ],
                 exclude=args.exclude,
             )
         elif args.paths_from == "git":

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -455,7 +455,32 @@ TARGET_FLOORS=(
   # fixture, a colliding parametrize id, or a module that stops importing.
   #
   # See the commit message for the gate line this number was copied from.
-  "scripts/tests|2647"
+  #
+  # 2026-08-12, the subsystem-touch PR path source: 2697 -> 2825 collected,
+  # +128 in test_subsystem_touch.py (204 -> 332 tests: the PR source's
+  # positive-control pair, its ten named negative controls including the
+  # measured `gh` file-list truncation, the gh-failure classifier pinned against
+  # captured stderr, the repo-slug derivation, the caveat's session-vs-branch
+  # wording, the do-not-compose refusals, and one mutation kill per new guard).
+  # The AUTHORITATIVE gate's own line, `nix build .#checks.x86_64-linux.pytests`:
+  #   PASS  scripts/tests  (collected=2825 passed=2825 skipped=0)
+  # put through the gate's OWN function rather than arithmetic:
+  #   _suggested_floor 2825 = 2825 - min(50, max(1, 141)) = 2825 - 50 = 2775.
+  #
+  # ⚠ The recorded delta and the measured one AGREE this time (+128 both ways),
+  # which the line above says not to count on: the check is that 2697 + 128 =
+  # 2825 exactly, i.e. nothing else moved the base since #421 landed. That is a
+  # reading, not an assumption — if this line conflicts with another branch,
+  # re-run the gate on the MERGED tree and copy what it prints. Do not reconcile
+  # the two sides by hand.
+  #
+  # ⚠ ZERO new skips, and no HERMETIC_TARGETS entry needed (scripts/tests is
+  # already a directory target). The new source shells out to `gh`, which is in
+  # NEITHER `REQUIRED_TOOLS` below NOR flake.nix's `nativeBuildInputs` — so its
+  # fetch is injectable and every test drives a fixture. `no_live_gh` in
+  # test_subsystem_touch.py fails any test that reaches the real binary, which
+  # is what keeps this line's `skipped=0` true rather than lucky.
+  "scripts/tests|2775"
   # 2026-08-11, the session-summary changed-paths work: 230 -> 273 collected,
   # +43 for scripts/collector/tests/test_changed_paths.py (the shared
   # `changed_paths*` module). The gate printed this replacement itself —

--- a/scripts/tests/test_subsystem_touch.py
+++ b/scripts/tests/test_subsystem_touch.py
@@ -1229,6 +1229,47 @@ class TestSkillDocsArePinned:
             "does **not** include what a **subagent** edited",
             "the session window's largest measured blind spot",
         ),
+        # 🔴 The PR source. The module is inert unless the step passes the
+        # numbers, and — unlike a session uuid — nothing on the machine knows
+        # them; only the agent that opened the PRs does. If these sentences go,
+        # the one source that can see a subagent's work is never invoked.
+        (
+            "--pr <n>[,<n>...]",
+            "the step actually passes the PRs it landed",
+        ),
+        (
+            "you know exactly which ones, and nothing else in the toolchain does",
+            "WHERE the numbers come from — the fact only the agent has",
+        ),
+        (
+            "only** source that sees a **subagent's** work",
+            "why the PR run exists at all",
+        ),
+        (
+            "A PR's file list is what the BRANCH LANDED, not what this session "
+            "touched — never describe it as this session's work",
+            "🔴 the crux: a PR-derived set must never be given session attribution",
+        ),
+        (
+            "attribute it to the branch or the PR, not to \"this session\"",
+            "the attribution rule stated as an instruction, not a caveat to read",
+        ),
+        (
+            "Run it twice; never merge the two path sets",
+            "the compose decision, stated to the executor",
+        ),
+        (
+            "one caveat that is wrong about half its members",
+            "WHY they do not compose — the reason, not just the rule",
+        ),
+        (
+            "none of them ever returns an empty path set",
+            "the network surface can fail, but never into a silent zero",
+        ),
+        (
+            "Closed-unmerged PRs are refused by name",
+            "which PR states are acceptable input",
+        ),
     ]
 
     def test_EVERY_emitted_status_has_a_bullet_in_the_skill(self) -> None:
@@ -2435,7 +2476,14 @@ class TestMutationKillMatrix:
         to demonstrate, and it made the assertion depend on where pytest was
         launched from. Pinning the cwd to a non-repo fixes the dimension."""
         mod = _load_mutant(
-            tmp_path, "m_git", [("    if proc.returncode != 0:", "    if False:")]
+            tmp_path,
+            "m_git",
+            # 🔴 Anchored on the RAISE as well as the condition. `if
+            # proc.returncode != 0:` alone became AMBIGUOUS when the PR source
+            # added a second subprocess wrapper, and the loader's uniqueness
+            # assert caught it rather than letting the mutation land on the
+            # wrong occurrence.
+            [("    if proc.returncode != 0:\n        raise GitError(", "    if False:\n        raise GitError(")],
         )
         plain = tmp_path / "plain-dir"
         plain.mkdir()
@@ -2454,7 +2502,7 @@ class TestMutationKillMatrix:
             "m_branch",
             [
                 (
-                    "            commands.append(tuple(branch_args))\n"
+                    '            commands.append(("git", *branch_args))\n'
                     "            add(_nul_list(_git(repo, branch_args)))\n"
                     '            window = "branch"',
                     "            pass",
@@ -2984,7 +3032,7 @@ class TestSessionMutationKillMatrix:
         mod = _session_mutant(
             tmp_path,
             "ms_conflict",
-            [('        if wants_session and args.paths_from != "git":',
+            [('        if (wants_session or wants_pr) and args.paths_from != "git":',
               "        if False:")],
             tailer,
         )
@@ -3016,3 +3064,1377 @@ class TestSessionMutationKillMatrix:
             mod._session_tailer()
         assert not isinstance(exc.value, st.ExtractorMissingError)
         assert "session path extractor not found" not in str(exc.value)
+
+
+# =============================================================================
+# THE PR SOURCE — the window that sees a SUBAGENT's work, and only a branch's.
+# =============================================================================
+#
+# 🔴 WHY IT EXISTS, IN ONE MEASUREMENT: the standing default in this environment
+# is to DELEGATE non-trivial work to a subagent, and a subagent's turns live in a
+# SEPARATE transcript that the session source excludes by construction (196 of
+# 733 file-tool calls across the 40 most recent transcripts). So on exactly the
+# sessions worth recording, `--session` reports the docs the parent wrote and
+# none of the implementation. A PR's file list does not care which agent, which
+# session or which tool wrote the bytes.
+#
+# 🔴 AND IT IS BLIND IN THE OPPOSITE DIRECTION, which is what most of the
+# assertions below are spent on: a PR's file list is the UNION of everything on
+# the branch, including another session's commits.
+# `TestPrCaveatAnswersTheRightQuestion` pins the wording that says so, because a
+# set described as a session's is worse than no set at all — it would put another
+# session's work into a dated work-history bullet in a curated,
+# client-confidential store.
+#
+# 🔴 NO TEST BELOW RUNS `gh`, AND NONE CAN. `gh` is NOT in `REQUIRED_TOOLS` in
+# scripts/run-tests.sh and NOT in `nativeBuildInputs` for flake.nix's
+# `checks.pytests` — so the hermetic tier has no `gh` binary, and a test that
+# shelled out would SKIP there, which the gate fails on purpose (EXPECTED_SKIPS
+# is pinned exactly). `no_live_gh` is the structural guard: it intercepts any
+# `gh` argv and fails loudly, so a test that forgot to inject a fetcher cannot
+# quietly become a network test. Real `git` still runs — the repository identity
+# is derived from a real remote on a real repo, and a mock would test the mock.
+#
+# 🔴 EVERY FIXTURE IS SYNTHETIC. `synthetic-org` is not a real GitHub owner and
+# no real PR number, title or body appears here; this repo is PUBLIC.
+
+PR_HOST = "github.com"
+PR_OWNER = "synthetic-org"
+PR_SLUG = f"{PR_HOST}/{PR_OWNER}/{SCOPE}"
+PR_REMOTE = f"git@{PR_HOST}:{PR_OWNER}/{SCOPE}.git"
+
+_UNSET = object()
+
+
+@pytest.fixture(autouse=True)
+def no_live_gh(monkeypatch):
+    """🔴 Structural: a `gh` invocation from ANY test in this file is a failure.
+
+    Autouse over the whole module rather than one class, because the hazard is a
+    test that FORGOT to inject a fetcher — and such a test would by definition
+    not be in the class that remembered. Real `git` passes through untouched.
+    """
+    real = subprocess.run
+
+    def guard(argv, *a, **kw):
+        prog = str(argv[0]) if isinstance(argv, (list, tuple)) and argv else ""
+        assert Path(prog).name != "gh", (
+            f"a test reached the LIVE `gh` binary: {argv!r}. Inject a fetcher — "
+            f"`gh` is absent in the hermetic tier, so this would SKIP there and "
+            f"each tier would be testing a different thing."
+        )
+        return real(argv, *a, **kw)
+
+    monkeypatch.setattr(st.subprocess, "run", guard)
+
+
+def test_the_no_live_gh_guard_can_actually_fire() -> None:
+    """🔴 Positive control on the guard above. A guard nobody has watched fire is
+    indistinguishable from one wired to nothing — and this one's whole job is to
+    be silent."""
+    with pytest.raises(AssertionError) as exc:
+        st.subprocess.run(["gh", "--version"], capture_output=True, text=True)
+    assert "reached the LIVE `gh` binary" in str(exc.value)
+
+
+def test_the_no_live_gh_guard_lets_real_git_through(tmp_path: Path) -> None:
+    """The other half of the pair: a guard that blocked everything would make
+    every git-backed test below fail for the wrong reason."""
+    proc = st.subprocess.run(["git", "--version"], capture_output=True, text=True)
+    assert proc.returncode == 0 and "git version" in proc.stdout
+
+
+def _init_pr_repo(tmp_path: Path, *, remote: str | None = PR_REMOTE) -> Path:
+    """A real git repo whose `origin` names a synthetic GitHub project."""
+    repo = _init_repo(tmp_path, SCOPE)
+    if remote is not None:
+        _run_git(repo, "remote", "add", "origin", remote, home=tmp_path)
+    return repo
+
+
+def _pr_payload(
+    number: int,
+    files,
+    *,
+    slug: str = PR_SLUG,
+    state: str = "MERGED",
+    changed: int | None = None,
+    url: object = _UNSET,
+) -> dict:
+    """A payload in the SHAPE `gh pr view --json` really returns.
+
+    Verified against the live API 2026-08-12: `files` entries carry `path`,
+    `additions`, `deletions` and `changeType`, and `changedFiles` is a sibling
+    integer — which is the only signal that `files` was truncated.
+    """
+    return {
+        "number": number,
+        "url": f"https://{slug}/pull/{number}" if url is _UNSET else url,
+        "state": state,
+        "changedFiles": len(files) if changed is None else changed,
+        "files": [
+            {"path": p, "additions": 1, "deletions": 0, "changeType": "MODIFIED"}
+            for p in files
+        ],
+    }
+
+
+def _fetch(mapping):
+    """An injected fetcher over `{number: payload}`; an Exception value raises."""
+
+    def fetcher(slug, number):
+        got = mapping[number]
+        if isinstance(got, BaseException):
+            raise got
+        return got
+
+    return fetcher
+
+
+def _pr_source(repo: Path, mapping, numbers=None, **kw):
+    return st.collect_pr_paths(
+        repo,
+        numbers if numbers is not None else list(mapping),
+        fetch=_fetch(mapping),
+        **kw,
+    )
+
+
+class TestPrPositiveControl:
+    """🔴 `claude/RULES.md` → "Positive control — can it ever observe the thing?"
+
+    A reassuring empty path set is indistinguishable from a fetcher wired to
+    nothing, and this source has MORE ways to reach an honest-looking zero than
+    any other here — ten of them raise. So the pair is reported: a payload that
+    MUST yield paths against one that MUST yield none, on the same code path,
+    through the same fetcher, in the same shape.
+    """
+
+    UNDER_TEST = ["src/collector/a.py", "src/collector/b.py", "src/collector/c.py"]
+
+    def test_THE_PAIR_nonzero_under_test_zero_on_the_control(self, tmp_path: Path) -> None:
+        repo = _init_pr_repo(tmp_path)
+        pos = _pr_source(repo, {421: _pr_payload(421, self.UNDER_TEST)})
+        # CONTROL: a real, well-formed, MERGED pull request that GitHub says
+        # changed nothing. Identical machinery; the honest answer is zero, and it
+        # must be zero for THAT reason rather than because nothing was read.
+        neg = _pr_source(repo, {350: _pr_payload(350, [])})
+
+        assert len(pos.paths) == 3, "positive control yielded nothing — wired to nothing"
+        assert sorted(pos.paths) == sorted(self.UNDER_TEST)
+        assert len(neg.paths) == 0
+
+    def test_the_control_zero_is_ACCOUNTED_for_not_merely_empty(self, tmp_path: Path) -> None:
+        """An empty list beside `0 file(s) reported by the API` is a reading; an
+        empty list with no count is the silent zero."""
+        repo = _init_pr_repo(tmp_path)
+        src = _pr_source(repo, {350: _pr_payload(350, [])})
+        assert src.paths == ()
+        assert any(
+            "#350 (MERGED): 0 file(s) reported by the API, 0 read" in n for n in src.notes
+        ), src.notes
+        assert any("0 distinct path(s) across 1 pull request(s)" in n for n in src.notes)
+
+    def test_the_per_pr_count_is_emitted_AT_NONZERO_too(self, tmp_path: Path) -> None:
+        """The other half of the pair: a counter that only ever prints 0 is
+        indistinguishable from one wired to a constant."""
+        repo = _init_pr_repo(tmp_path)
+        src = _pr_source(repo, {421: _pr_payload(421, self.UNDER_TEST)})
+        assert any(
+            "#421 (MERGED): 3 file(s) reported by the API, 3 read" in n for n in src.notes
+        ), src.notes
+        assert any("3 distinct path(s) across 1 pull request(s)" in n for n in src.notes)
+
+    def test_the_pair_survives_all_the_way_to_a_REPORT(self, tmp_path: Path) -> None:
+        """The fetcher and the matcher are two places a zero can come from; both
+        ends are pinned so one being wired to nothing cannot hide behind the
+        other."""
+        repo = _init_pr_repo(tmp_path)
+        store = _make_store(tmp_path / "s")
+        pos = _pr_source(repo, {421: _pr_payload(421, self.UNDER_TEST)})
+        # Same count, same depth, same store — only the subsystem directory
+        # differs, and it names nothing.
+        neg = _pr_source(
+            repo,
+            {
+                350: _pr_payload(
+                    350, [f"src/unlisted-widget/{Path(p).name}" for p in self.UNDER_TEST]
+                )
+            },
+        )
+        pos_rep = st.build_report(pos, store, SCOPE, today=TODAY)
+        neg_rep = st.build_report(neg, store, SCOPE, today=TODAY)
+
+        assert pos_rep.status == "resolved"
+        assert [m.entry.ref for m in pos_rep.known] == ["collector"]
+        assert neg_rep.status == "no-match"
+        # …and the negative control is NOT an empty window, which would make the
+        # zero uninformative.
+        assert len(neg_rep.source.paths) == 3
+
+    def test_SEVERAL_prs_union_in_first_seen_order(self, tmp_path: Path) -> None:
+        repo = _init_pr_repo(tmp_path)
+        src = _pr_source(
+            repo,
+            {421: _pr_payload(421, ["a.py", "b.py"]), 350: _pr_payload(350, ["b.py", "c.py"])},
+            numbers=[421, 350],
+        )
+        assert src.paths == ("a.py", "b.py", "c.py")
+        assert src.prs == (421, 350)
+
+    def test_a_repeated_number_is_read_ONCE_and_SAID(self, tmp_path: Path) -> None:
+        repo = _init_pr_repo(tmp_path)
+        src = _pr_source(repo, {421: _pr_payload(421, ["a.py"])}, numbers=[421, 421])
+        assert src.prs == (421,)
+        assert any("named more than once" in n for n in src.notes)
+
+    def test_the_MEASURED_shape_of_a_real_response_is_what_the_fixture_uses(self) -> None:
+        """🔴 A harness fed a textbook fixture proves nothing about live data
+        (`claude/RULES.md`: build the bad case from REALISTIC data). These are the
+        exact keys `gh pr view --json` returned for a real PR on 2026-08-12; if
+        the fixture drifts from them, every control above tests a shape that does
+        not exist."""
+        payload = _pr_payload(1, ["x.py"])
+        assert set(payload) == {"number", "url", "state", "changedFiles", "files"}
+        assert set(payload["files"][0]) == {"path", "additions", "deletions", "changeType"}
+        assert set(st.PR_JSON_FIELDS.split(",")) == set(payload)
+
+    def test_excluded_paths_are_dropped_AND_counted(self, tmp_path: Path) -> None:
+        """The SHARED exclusion predicate, not a third copy of it."""
+        repo = _init_pr_repo(tmp_path)
+        doc = "claudedocs/handoff-topic.md"
+        src = _pr_source(
+            repo, {421: _pr_payload(421, [doc, "src/collector/a.py"])}, exclude=[doc]
+        )
+        assert doc not in src.paths
+        assert "src/collector/a.py" in src.paths
+        assert any("excluded 1 caller-named path(s)" in n for n in src.notes)
+
+    def test_the_store_is_never_written(self, tmp_path: Path) -> None:
+        """The module's central invariant, exercised through the NEW source."""
+        repo = _init_pr_repo(tmp_path)
+        store = _make_store(tmp_path / "s")
+        before = _tree_hash(store)
+        rep = st.build_report(
+            _pr_source(repo, {421: _pr_payload(421, self.UNDER_TEST)}),
+            store,
+            SCOPE,
+            today=TODAY,
+        )
+        st.render_text(rep)
+        json.dumps(st.report_json(rep))
+        assert _tree_hash(store) == before
+
+
+class TestPrNegativeControls:
+    """Each guard fails with ITS OWN sentinel, reached by an input no EARLIER
+    guard rejects — otherwise a control passes because a neighbour fired and
+    stays green with the guard it claims to test deleted.
+
+    🔴 THE SENTINEL MAP SPANS BOTH FAMILIES. A PR sentinel colliding with a
+    session one would make BOTH families' `_only` assertions vacuous, so the
+    premise test runs over the union, not over the PR half alone.
+    """
+
+    SENTINELS = {
+        # session-source sentinels, so a cross-family collision is caught
+        "t-missing": "transcript not found",
+        "t-ambiguous": "transcript id is ambiguous",
+        "t-stale": "transcript is stale",
+        "t-unreadable": "transcript unreadable",
+        "t-cwd": "transcript cwd does not match",
+        "extractor": "session path extractor not found",
+        # base sentinels
+        "store": "store root not found",
+        "git": "git command failed",
+        # PR-source sentinels
+        "remote": "repo has no usable github remote",
+        "gh-missing": "gh cli not found",
+        "gh-auth": "gh is not authenticated",
+        "rate": "github api rate limit",
+        "api": "github api call failed",
+        "notfound": "pull request not found",
+        "mismatch": "pull request belongs to another repository",
+        "closed": "pull request is closed unmerged",
+        "malformed": "pull request response is malformed",
+        "truncated": "pull request file list is truncated",
+    }
+
+    def _only(self, exc: Exception, key: str) -> None:
+        text = str(exc)
+        assert self.SENTINELS[key] in text, f"expected the {key} sentinel, got: {text}"
+        for other, phrase in self.SENTINELS.items():
+            if other != key:
+                assert phrase not in text, f"the {other} sentinel also fired: {text}"
+
+    def test_no_two_sentinels_share_a_spelling(self) -> None:
+        """The premise of `_only`. Two guards spelled alike would make every
+        assertion in this class — and in `TestSessionNegativeControls` — vacuous."""
+        for a, pa in self.SENTINELS.items():
+            for b, pb in self.SENTINELS.items():
+                if a != b:
+                    assert pa not in pb, f"{a} sentinel is a substring of {b}"
+
+    def test_the_sentinel_map_COVERS_every_declared_error(self) -> None:
+        """🔴 A hand-maintained map goes stale silently: a new error class with no
+        entry here would never be asserted ABSENT, and every `_only` above would
+        quietly stop being a measurement for it. Derived from the module's own
+        `__all__` rather than trusted."""
+        declared = {
+            name for name in st.__all__ if name.endswith("Error") and name != "TouchError"
+        }
+        covered = {
+            "RepoRemoteError", "GhMissingError", "GhAuthError", "GhRateLimitError",
+            "GhApiError", "PrNotFoundError", "PrRepoMismatchError", "PrNotLandedError",
+            "PrResponseMalformedError", "PrFileListTruncatedError",
+            "StoreMissingError", "GitError", "ExtractorMissingError",
+            "TranscriptMissingError", "TranscriptAmbiguousError", "TranscriptStaleError",
+            "TranscriptUnreadableError", "TranscriptCwdMismatchError",
+        }
+        assert declared == covered, (
+            "subsystem_touch declares an error class this sentinel map does not "
+            "account for; add it here AND give it its own sentinel entry."
+        )
+        assert len(self.SENTINELS) == len(covered)
+
+    # --- the local guard, before anything leaves the machine ---------------------
+
+    def test_a_repo_with_NO_remote_is_REMOTE(self, tmp_path: Path) -> None:
+        """Reached first of all: a PR number cannot be interpreted without a
+        repository, so nothing is fetched at all."""
+        repo = _init_pr_repo(tmp_path, remote=None)
+        with pytest.raises(st.RepoRemoteError) as exc:
+            _pr_source(repo, {421: _pr_payload(421, ["a.py"])})
+        self._only(exc.value, "remote")
+
+    def test_a_remote_that_names_no_project_is_REMOTE(self, tmp_path: Path) -> None:
+        """Reachable past the no-remote guard: a remote EXISTS, it simply does not
+        name a host/owner/name."""
+        repo = _init_pr_repo(tmp_path, remote="/srv/local-mirror")
+        with pytest.raises(st.RepoRemoteError) as exc:
+            _pr_source(repo, {421: _pr_payload(421, ["a.py"])})
+        self._only(exc.value, "remote")
+
+    def test_the_remote_error_QUOTES_git_without_carrying_gits_SENTINEL(
+        self, tmp_path: Path
+    ) -> None:
+        """🔴 Found by `_only` on this suite's first run, and it is the general
+        lesson: a wrapping error that interpolates the exception it wraps carries
+        TWO sentinels, and "which guard fired" stops being a measurement. So
+        `GitError` exposes `stderr` as an attribute and the wrapper quotes THAT.
+        Both halves are asserted — the diagnostic survives, the sentinel does
+        not."""
+        repo = _init_pr_repo(tmp_path, remote=None)
+        with pytest.raises(st.RepoRemoteError) as exc:
+            _pr_source(repo, {421: _pr_payload(421, ["a.py"])})
+        assert "git command failed" not in str(exc.value)
+        assert "No such remote" in str(exc.value), "git's own diagnostic was lost"
+        assert isinstance(exc.value.__cause__, st.GitError)
+        assert exc.value.__cause__.stderr, "GitError.stderr is empty — nothing to quote"
+
+    def test_the_remote_guard_is_reached_by_a_repo_that_ALSO_works(self, tmp_path: Path) -> None:
+        """🔴 The reachability proof as a measurement: the same fixture with a
+        usable remote produces a working source, so the two above fired on the
+        remote and not on some incidental defect."""
+        repo = _init_pr_repo(tmp_path)
+        assert _pr_source(repo, {421: _pr_payload(421, ["a.py"])}).paths == ("a.py",)
+
+    # --- the argument guard ------------------------------------------------------
+
+    @pytest.mark.parametrize("token", ["abc", "", "-3", "0", "4.2", "١٢"])
+    def test_a_token_that_is_not_a_pr_NUMBER_is_NOTFOUND(self, tmp_path: Path, token) -> None:
+        """Never searched for. Note the last one: `str.isdigit()` is True for
+        Arabic-Indic digits and `int()` accepts them, so an `isdigit()`-only check
+        would silently accept a number nobody typed."""
+        repo = _init_pr_repo(tmp_path)
+        with pytest.raises(st.PrNotFoundError) as exc:
+            st.collect_pr_paths(repo, [token], fetch=_fetch({}))
+        self._only(exc.value, "notfound")
+
+    def test_NO_pr_numbers_at_all_is_NOTFOUND_not_an_empty_report(self, tmp_path: Path) -> None:
+        """🔴 Otherwise: a perfectly well-formed report over ZERO pull requests —
+        the confident zero, arriving through argument parsing."""
+        repo = _init_pr_repo(tmp_path)
+        with pytest.raises(st.PrNotFoundError) as exc:
+            st.collect_pr_paths(repo, [], fetch=_fetch({}))
+        self._only(exc.value, "notfound")
+        assert "no pull request number was given" in str(exc.value)
+
+    # --- the response guards, in reachability order ------------------------------
+
+    def test_a_NON_OBJECT_response_is_MALFORMED(self, tmp_path: Path) -> None:
+        repo = _init_pr_repo(tmp_path)
+        with pytest.raises(st.PrResponseMalformedError) as exc:
+            _pr_source(repo, {421: ["not", "an", "object"]})
+        self._only(exc.value, "malformed")
+
+    def test_a_response_for_ANOTHER_pr_is_MALFORMED(self, tmp_path: Path) -> None:
+        """Reachable past the object guard: a well-formed payload that simply is
+        not the pull request that was asked for."""
+        repo = _init_pr_repo(tmp_path)
+        with pytest.raises(st.PrResponseMalformedError) as exc:
+            _pr_source(repo, {421: _pr_payload(999, ["a.py"])}, numbers=[421])
+        self._only(exc.value, "malformed")
+
+    def test_a_response_with_NO_url_is_MALFORMED(self, tmp_path: Path) -> None:
+        """Reachable past both: right number, everything else intact — the
+        repository simply cannot be checked, and an unchecked repository is what
+        makes a bare number dangerous."""
+        repo = _init_pr_repo(tmp_path)
+        with pytest.raises(st.PrResponseMalformedError) as exc:
+            _pr_source(repo, {421: _pr_payload(421, ["a.py"], url=None)})
+        self._only(exc.value, "malformed")
+
+    def test_ANOTHER_REPOSITORY_is_MISMATCH_not_malformed(self, tmp_path: Path) -> None:
+        """🔴 Reachable past every guard above: the response is well-formed, has
+        the right number and a perfectly good url — it just describes a different
+        project. Every repository has a #1."""
+        repo = _init_pr_repo(tmp_path)
+        with pytest.raises(st.PrRepoMismatchError) as exc:
+            _pr_source(
+                repo,
+                {
+                    421: _pr_payload(
+                        421, ["src/collector/a.py"], slug=f"{PR_HOST}/other-org/other-repo"
+                    )
+                },
+            )
+        self._only(exc.value, "mismatch")
+
+    def test_the_SAME_owner_and_name_on_ANOTHER_HOST_is_MISMATCH(self, tmp_path: Path) -> None:
+        """🔴 The host is part of the identity. A repo mirrored on another forge
+        can share `owner/name` with an unrelated GitHub project, and an
+        owner/name-only comparison would call that a match and read its files."""
+        repo = _init_pr_repo(tmp_path, remote=f"git@git.example.invalid:{PR_OWNER}/{SCOPE}.git")
+        with pytest.raises(st.PrRepoMismatchError) as exc:
+            _pr_source(repo, {421: _pr_payload(421, ["src/collector/a.py"])})
+        self._only(exc.value, "mismatch")
+
+    def test_a_CLOSED_unmerged_pr_is_NOT_LANDED(self, tmp_path: Path) -> None:
+        """Reachable past the repository guard: right repo, right number — the
+        branch was proposed and REJECTED, so its files exist in no tree."""
+        repo = _init_pr_repo(tmp_path)
+        with pytest.raises(st.PrNotLandedError) as exc:
+            _pr_source(repo, {421: _pr_payload(421, ["a.py"], state="CLOSED")})
+        self._only(exc.value, "closed")
+
+    @pytest.mark.parametrize("state", ["MERGED", "OPEN"])
+    def test_MERGED_and_OPEN_are_BOTH_accepted(self, tmp_path: Path, state) -> None:
+        """🔴 Measured at both accepted points, not one. OPEN is the ordinary case
+        at `/handoff` time — CI still running, review not done — and refusing it
+        would make the source useless exactly when it is invoked."""
+        repo = _init_pr_repo(tmp_path)
+        src = _pr_source(repo, {421: _pr_payload(421, ["a.py"], state=state)})
+        assert src.paths == ("a.py",)
+        assert any(f"#421 ({state})" in n for n in src.notes)
+
+    def test_an_UNKNOWN_state_is_MALFORMED_not_silently_accepted(self, tmp_path: Path) -> None:
+        repo = _init_pr_repo(tmp_path)
+        with pytest.raises(st.PrResponseMalformedError) as exc:
+            _pr_source(repo, {421: _pr_payload(421, ["a.py"], state="DRAFTED")})
+        self._only(exc.value, "malformed")
+
+    def test_an_ABSENT_files_key_is_MALFORMED_not_an_empty_pr(self, tmp_path: Path) -> None:
+        """🔴 The distinction this module is built on, at the other end of the
+        pipe: an ABSENT list means the changed files are UNKNOWN, `[]` means
+        GitHub says nothing changed. Reporting the second for the first is the
+        silent zero."""
+        repo = _init_pr_repo(tmp_path)
+        payload = _pr_payload(421, [])
+        del payload["files"]
+        with pytest.raises(st.PrResponseMalformedError) as exc:
+            _pr_source(repo, {421: payload})
+        self._only(exc.value, "malformed")
+
+    def test_an_EMPTY_files_list_is_a_READING_not_an_error(self, tmp_path: Path) -> None:
+        """The other side of the pair above — without it the guard is merely a ban
+        on empty PRs and the distinction it claims to draw is untested."""
+        repo = _init_pr_repo(tmp_path)
+        src = _pr_source(repo, {421: _pr_payload(421, [])})
+        assert src.paths == ()
+        assert src.prs == (421,)
+
+    def test_a_file_entry_with_NO_path_is_MALFORMED(self, tmp_path: Path) -> None:
+        """Reachable past the list guard: `files` is present and IS a list — one
+        entry in it is unreadable, and a list with an unreadable entry is not a
+        shorter list."""
+        repo = _init_pr_repo(tmp_path)
+        payload = _pr_payload(421, ["a.py", "b.py"])
+        payload["files"][1] = {"additions": 1}
+        with pytest.raises(st.PrResponseMalformedError) as exc:
+            _pr_source(repo, {421: payload})
+        self._only(exc.value, "malformed")
+
+    def test_a_missing_changedFiles_is_MALFORMED(self, tmp_path: Path) -> None:
+        """Reachable past every guard above: without the count, truncation is
+        UNDETECTABLE — and an undetectable truncation is a silently short set."""
+        repo = _init_pr_repo(tmp_path)
+        payload = _pr_payload(421, ["a.py"])
+        del payload["changedFiles"]
+        with pytest.raises(st.PrResponseMalformedError) as exc:
+            _pr_source(repo, {421: payload})
+        self._only(exc.value, "malformed")
+
+    def test_a_TRUNCATED_file_list_REFUSES(self, tmp_path: Path) -> None:
+        """🔴 THE MEASURED HAZARD. `gh pr view --json files` caps at 100 while
+        `changedFiles` reports the truth — measured live at 411/100 and 301/100 on
+        2026-08-12, and 39/39 under the cap. Reported as a prefix it would be a
+        plausible, silently wrong answer."""
+        repo = _init_pr_repo(tmp_path)
+        with pytest.raises(st.PrFileListTruncatedError) as exc:
+            _pr_source(
+                repo, {421: _pr_payload(421, [f"f{i}.py" for i in range(100)], changed=411)}
+            )
+        self._only(exc.value, "truncated")
+        assert "changed 411 files but the API returned only 100" in str(exc.value)
+
+    def test_the_truncation_guard_is_a_BOUNDARY_not_a_slope(self, tmp_path: Path) -> None:
+        """🔴 Measured at TWO points, not one: a guard asserted only from beyond
+        the boundary is equally consistent with one that rejects everything. The
+        equal case is the live 39/39 reading."""
+        repo = _init_pr_repo(tmp_path)
+        equal = _pr_source(repo, {421: _pr_payload(421, ["a.py", "b.py"], changed=2)})
+        assert equal.paths == ("a.py", "b.py")
+        with pytest.raises(st.PrFileListTruncatedError):
+            _pr_source(repo, {350: _pr_payload(350, ["a.py", "b.py"], changed=3)})
+
+    def test_MORE_files_than_changedFiles_is_NOT_an_error(self, tmp_path: Path) -> None:
+        """The guard is one-sided on purpose: it detects a SHORT list. A list
+        LONGER than the count is not a truncation, and inventing an error for it
+        would refuse a reading nothing is wrong with."""
+        repo = _init_pr_repo(tmp_path)
+        src = _pr_source(repo, {421: _pr_payload(421, ["a.py", "b.py"], changed=1)})
+        assert src.paths == ("a.py", "b.py")
+
+    # --- the environment guards, through the fetcher -----------------------------
+
+    @pytest.mark.parametrize(
+        "factory,key",
+        [
+            (lambda: st.GhMissingError("gh cli not found: no `gh` on PATH"), "gh-missing"),
+            (lambda: st.GhAuthError("gh is not authenticated: HTTP 401"), "gh-auth"),
+            (lambda: st.GhRateLimitError("github api rate limit: HTTP 403"), "rate"),
+            (lambda: st.GhApiError("github api call failed: error connecting"), "api"),
+            (lambda: st.PrNotFoundError("pull request not found: no such PR"), "notfound"),
+        ],
+        ids=["gh-missing", "gh-auth", "rate-limit", "api-error", "not-found"],
+    )
+    def test_a_fetcher_failure_PROPAGATES_and_never_becomes_an_empty_set(
+        self, tmp_path: Path, factory, key
+    ) -> None:
+        """🔴 THE CENTRAL PROPERTY OF THE NETWORK SURFACE. Every environmental
+        failure reaches the caller as ITS OWN named error — an empty path set
+        would be indistinguishable from "this PR changed nothing"."""
+        repo = _init_pr_repo(tmp_path)
+        with pytest.raises(st.TouchError) as exc:
+            _pr_source(repo, {421: factory()})
+        self._only(exc.value, key)
+
+    def test_EVERY_pr_failure_is_a_TouchError_so_the_CLI_exits_nonzero(self) -> None:
+        """🔴 `/handoff` step 4 keys on the exit code alone, and its contract is
+        that the stderr line is printable verbatim. A traceback is not that."""
+        for cls in (
+            st.RepoRemoteError, st.GhMissingError, st.GhAuthError, st.GhRateLimitError,
+            st.GhApiError, st.PrNotFoundError, st.PrRepoMismatchError, st.PrNotLandedError,
+            st.PrResponseMalformedError, st.PrFileListTruncatedError,
+        ):
+            assert issubclass(cls, st.TouchError), cls
+
+
+class TestGhFetcherClassification:
+    """The one thing a fixture payload cannot reach: `_gh_fetch_pr` reading `gh`'s
+    OWN exit code and stderr.
+
+    🔴 PINNED AGAINST MEASURED STRINGS, NOT INVENTED ONES (`claude/RULES.md`:
+    "build the bad case from REALISTIC data, not a textbook fixture"). Every
+    stderr below was captured from gh 2.96.0 on 2026-08-12 by provoking the real
+    failure; the classifier is then exercised against those bytes with the
+    subprocess seam replaced, so it runs in a tier that has no `gh` at all.
+    """
+
+    MEASURED = [
+        ("no-credentials", 4,
+         "To get started with GitHub CLI, please run:  gh auth login\n"
+         "Alternatively, populate the GH_TOKEN environment variable with a GitHub "
+         "API authentication token.", "GhAuthError"),
+        ("bad-token", 1,
+         "HTTP 401: Bad credentials (https://api.github.com/graphql)\n"
+         "Try authenticating with:  gh auth login", "GhAuthError"),
+        ("unreachable-host", 1,
+         "error connecting to nonexistent.invalid\n"
+         "check your internet connection or https://githubstatus.com", "GhApiError"),
+        ("nonexistent-pr", 1,
+         "GraphQL: Could not resolve to a PullRequest with the number of 999999. "
+         "(repository.pullRequest)", "PrNotFoundError"),
+    ]
+
+    @pytest.mark.parametrize(
+        "label,rc,stderr,expected", MEASURED, ids=[m[0] for m in MEASURED]
+    )
+    def test_the_measured_failures_classify(self, label, rc, stderr, expected) -> None:
+        got = st._classify_gh_failure(rc, stderr, PR_SLUG, 421)
+        assert type(got) is getattr(st, expected), (
+            f"{label} classified as {type(got).__name__}, expected {expected}"
+        )
+        assert stderr.splitlines()[0] in str(got), "gh's own words are not carried through"
+
+    def test_a_RATE_LIMIT_is_not_read_as_an_auth_failure(self) -> None:
+        """🔴 THE ORDERING TRAP, as a test. A 403 rate-limit body ALSO carries
+        gh's "gh auth login" hint, so an auth-first classifier reports a permanent
+        failure for a temporary one and the caller stops retrying."""
+        stderr = (
+            "HTTP 403: API rate limit exceeded for user ID 1. "
+            "(https://api.github.com/graphql)\nTry authenticating with:  gh auth login"
+        )
+        assert type(st._classify_gh_failure(1, stderr, PR_SLUG, 421)) is st.GhRateLimitError
+
+    def test_an_UNRECOGNISED_failure_falls_through_to_the_WIDE_error(self) -> None:
+        """Not guessed onto a specific diagnosis: a wrong explanation of a failure
+        forecloses the next question."""
+        got = st._classify_gh_failure(1, "HTTP 502: upstream exploded", PR_SLUG, 421)
+        assert type(got) is st.GhApiError, "a 502 was mapped onto a narrower diagnosis"
+
+    def test_an_EMPTY_stderr_still_classifies_rather_than_crashing(self) -> None:
+        got = st._classify_gh_failure(1, "", PR_SLUG, 421)
+        assert type(got) is st.GhApiError
+        assert "(no stderr)" in str(got)
+
+    def test_a_MISSING_gh_BINARY_is_named_not_a_traceback(self, monkeypatch) -> None:
+        """🔴 A LIVE CASE: `gh` is absent from `REQUIRED_TOOLS` and from the
+        flake's `nativeBuildInputs`, so the hermetic tier has none. Simulated at
+        the subprocess seam rather than by running anything."""
+
+        def boom(argv, *a, **kw):
+            raise FileNotFoundError(2, "No such file or directory", "gh")
+
+        monkeypatch.setattr(st.subprocess, "run", boom)
+        with pytest.raises(st.GhMissingError) as exc:
+            st._gh_fetch_pr(PR_SLUG, 421)
+        assert "gh cli not found" in str(exc.value)
+
+    def test_a_ZERO_exit_with_NON_JSON_stdout_is_MALFORMED(self, monkeypatch) -> None:
+        """A success that returns rubbish is not a success. Reachable past every
+        exit-code branch: rc IS 0, so only the decode can object."""
+        monkeypatch.setattr(
+            st.subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, "<html>nope</html>", ""),
+        )
+        with pytest.raises(st.PrResponseMalformedError) as exc:
+            st._gh_fetch_pr(PR_SLUG, 421)
+        assert "pull request response is malformed" in str(exc.value)
+
+    def test_the_fetcher_POSITIVE_control(self, monkeypatch) -> None:
+        """🔴 Every case above is a failure; a fetcher that failed on EVERYTHING
+        would pass them all. This is the case that must SUCCEED."""
+        payload = _pr_payload(421, ["src/collector/a.py"])
+        monkeypatch.setattr(
+            st.subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, json.dumps(payload), ""),
+        )
+        assert st._gh_fetch_pr(PR_SLUG, 421)["number"] == 421
+
+    def test_the_argv_asks_for_the_fields_the_reader_READS(self) -> None:
+        """A field dropped from the query but still read would come back as a
+        malformed response on every single run."""
+        argv = st._gh_argv(PR_SLUG, 421)
+        assert argv[0] == "gh" and "--repo" in argv and PR_SLUG in argv
+        assert st.PR_JSON_FIELDS in argv
+        for field_name in ("number", "url", "state", "changedFiles", "files"):
+            assert field_name in st.PR_JSON_FIELDS.split(",")
+
+
+class TestRepoSlugDerivation:
+    """The repository a PR number is interpreted against — DERIVED, never assumed
+    and never taken from the caller."""
+
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            (f"git@{PR_HOST}:{PR_OWNER}/{SCOPE}.git", PR_SLUG),
+            (f"git@{PR_HOST}:{PR_OWNER}/{SCOPE}", PR_SLUG),
+            (f"ssh://git@{PR_HOST}/{PR_OWNER}/{SCOPE}.git", PR_SLUG),
+            (f"https://{PR_HOST}/{PR_OWNER}/{SCOPE}.git", PR_SLUG),
+            (f"https://{PR_HOST}/{PR_OWNER}/{SCOPE}/", PR_SLUG),
+            (f"https://user@{PR_HOST}/{PR_OWNER}/{SCOPE}", PR_SLUG),
+            ("git@git.example.invalid:o/n.git", "git.example.invalid/o/n"),
+            ("/srv/local-mirror", None),
+            ("", None),
+            ("https://github.com/", None),
+        ],
+        ids=["scp", "scp-no-suffix", "ssh-url", "https", "trailing-slash",
+             "https-userinfo", "other-host", "local-path", "empty", "no-project"],
+    )
+    def test_the_spellings_git_actually_emits(self, url, expected) -> None:
+        assert st._parse_remote_slug(url) == expected
+
+    def test_the_HOST_is_part_of_the_slug(self) -> None:
+        """🔴 Two projects sharing owner/name on different forges must not produce
+        the same slug — that is the entire basis of the repository guard."""
+        a = st._parse_remote_slug(f"git@{PR_HOST}:o/n.git")
+        b = st._parse_remote_slug("git@git.example.invalid:o/n.git")
+        assert a is not None and b is not None and a != b
+
+    def test_it_reads_a_REAL_remote(self, tmp_path: Path) -> None:
+        """Real git, not a mock: the derivation is the design decision."""
+        repo = _init_pr_repo(tmp_path)
+        assert st._repo_slug(repo) == PR_SLUG
+
+    def test_a_pr_url_yields_the_SAME_slug_SHAPE_the_remote_does(self) -> None:
+        """🔴 The repository comparison is only meaningful if both sides are built
+        to the same shape — otherwise it would never match and the guard would
+        fire on everything, which is a guard nobody can use."""
+        assert st._slug_from_pr_url(f"https://{PR_SLUG}/pull/421") == PR_SLUG
+        assert st._slug_from_pr_url("nonsense") is None
+        assert st._slug_from_pr_url(None) is None
+
+
+class TestPrCaveatAnswersTheRightQuestion:
+    """🔴 THE CRUX. A PR's file list is NOT a session's, and the caveat is the only
+    thing standing between that fact and an LLM about to write a dated
+    work-history bullet into a curated, client-confidential store."""
+
+    def _caveat(self, tmp_path: Path, **kw) -> str:
+        repo = _init_pr_repo(tmp_path)
+        return _pr_source(repo, {421: _pr_payload(421, ["a.py"])}, **kw).caveat
+
+    def test_it_says_BRANCH_and_never_claims_SESSION_attribution(self, tmp_path: Path) -> None:
+        caveat = self._caveat(tmp_path)
+        assert "what the BRANCH LANDED" in caveat
+        assert "NOT what a SESSION touched" in caveat
+        # …and none of the session source's affirmative language leaks in.
+        assert "THIS SESSION's own turns" not in caveat
+
+    def test_it_names_the_OVER_reporting_the_union_causes(self, tmp_path: Path) -> None:
+        """A caveat naming only the blind spot would read as if over-reporting
+        were not the other half — and over-reporting is the half that puts
+        someone else's work into the journal."""
+        caveat = self._caveat(tmp_path)
+        for phrase in ("UNION of every commit", "ANOTHER session", "SUBAGENT", "by hand"):
+            assert phrase in caveat, phrase
+
+    def test_it_names_what_the_pr_window_CANNOT_see(self, tmp_path: Path) -> None:
+        assert (
+            "EXCLUDES anything a session did that did not reach one of these PRs"
+            in self._caveat(tmp_path)
+        )
+
+    def test_it_names_the_REPOSITORY_and_the_PRS(self, tmp_path: Path) -> None:
+        """"#4" is ambiguous across repositories; the identity is the point."""
+        repo = _init_pr_repo(tmp_path)
+        caveat = _pr_source(
+            repo,
+            {421: _pr_payload(421, ["a.py"]), 350: _pr_payload(350, ["b.py"])},
+            numbers=[421, 350],
+        ).caveat
+        assert "#421, #350" in caveat
+        assert PR_SLUG in caveat
+
+    def test_the_OTHER_sources_caveats_are_UNCHANGED(self, tmp_path: Path) -> None:
+        """Adding a source must not soften the claim another one makes."""
+        repo = _init_pr_repo(tmp_path)
+        _run_git(repo, "checkout", "-b", "topic", home=tmp_path)
+        _write(repo, "src/collector/a.py")
+        _run_git(repo, "add", "src", home=tmp_path)
+        _run_git(repo, "commit", "-m", "w", home=tmp_path)
+        assert "NOT what this SESSION touched" in st.collect_git_paths(repo).caveat
+        assert "provenance is the caller's" in st.caller_supplied(["a.py"]).caveat
+
+    @pytest.mark.parametrize(
+        "paths,expect",
+        [
+            (["src/collector/a.py", "src/collector/b.py"], "resolved"),
+            (["docs/a.md", "docs/b.md"], "no-match"),
+            ([], "looked-at-nothing"),
+        ],
+        ids=["resolved", "no-match", "looked-at-nothing"],
+    )
+    def test_the_caveat_is_on_EVERY_output_path_of_BOTH_renderers(
+        self, tmp_path: Path, paths, expect
+    ) -> None:
+        """🔴 The property the #415 audit established and #421 kept: the caveat is
+        on every output path of both renderers — INCLUDING the early-return
+        `looked-at-nothing` branch, which returns before most of the text is
+        built. A third source must not be the one that breaks it."""
+        repo = _init_pr_repo(tmp_path)
+        store = _make_store(tmp_path / "s")
+        rep = st.build_report(
+            _pr_source(repo, {421: _pr_payload(421, paths)}), store, SCOPE, today=TODAY
+        )
+        assert rep.status == expect
+        caveat = rep.source.caveat
+        assert caveat in st.render_text(rep)
+        payload = st.report_json(rep)
+        assert payload["source"]["caveat"] == caveat
+        assert payload["source"]["prs"] == [421]
+        assert payload["source"]["repo_slug"] == PR_SLUG
+
+
+class TestCommandsAreTheRealArgv:
+    """`PathSource.commands` exists so a reader can check what was ACTUALLY asked.
+    It used to omit the program name because every source ran `git` and the
+    renderer hardcoded that word — which became a FALSE line the moment a source
+    ran something else."""
+
+    def test_the_git_source_records_its_program(self, tmp_path: Path) -> None:
+        repo = _init_pr_repo(tmp_path)
+        _write(repo, "a.py")
+        src = st.collect_git_paths(repo)
+        assert src.commands and all(c[0] == "git" for c in src.commands), src.commands
+
+    def test_the_session_source_records_its_program(
+        self, tmp_path: Path, tailer_cache
+    ) -> None:
+        repo = _init_pr_repo(tmp_path)
+        t = _write_transcript(tmp_path / "t.jsonl", str(repo), [f"{repo}/a.py"])
+        src = st.collect_session_paths(repo, transcript=t)
+        assert src.commands and all(c[0] == "git" for c in src.commands), src.commands
+
+    def test_the_pr_source_records_gh_NOT_git(self, tmp_path: Path, monkeypatch) -> None:
+        """🔴 The regression this fixes: rendered under the old hardcoded `git`,
+        this line read `ran: git gh pr view 421` — a provenance line false about
+        the one thing it exists to report. The LIVE path is what records an argv,
+        so the swap is at the subprocess seam; an injected fetcher records
+        nothing (see below) and could not exercise this at all."""
+        repo = _init_pr_repo(tmp_path)
+        store = _make_store(tmp_path / "s")
+        payload = _pr_payload(421, ["src/collector/a.py", "src/collector/b.py"])
+        real = subprocess.run
+
+        def fake(argv, *a, **kw):
+            if Path(str(argv[0])).name == "gh":
+                return subprocess.CompletedProcess(argv, 0, json.dumps(payload), "")
+            return real(argv, *a, **kw)
+
+        monkeypatch.setattr(st.subprocess, "run", fake)
+        src = st.collect_pr_paths(repo, [421])
+        assert src.commands and src.commands[0][0] == "gh"
+        rendered = st.render_text(st.build_report(src, store, SCOPE, today=TODAY))
+        assert "ran: gh pr view 421" in rendered
+        assert "ran: git gh" not in rendered
+
+    def test_an_INJECTED_fetcher_records_NO_argv_and_SAYS_so(self, tmp_path: Path) -> None:
+        """🔴 With a fetcher injected NOTHING ran, so recording `gh pr view …`
+        would fabricate provenance in the one field whose purpose is to report
+        what was actually executed."""
+        repo = _init_pr_repo(tmp_path)
+        src = _pr_source(repo, {421: _pr_payload(421, ["a.py"])})
+        assert src.commands == ()
+        assert any("INJECTED fetcher" in n for n in src.notes)
+
+
+class TestPrCli:
+    """The CLI is the only surface `/handoff` touches."""
+
+    def _run(self, args, capsys):
+        rc = st.main(args)
+        return rc, capsys.readouterr()
+
+    def _fixture(self, tmp_path: Path):
+        return _init_pr_repo(tmp_path), _make_store(tmp_path / "s")
+
+    def _patched(self, monkeypatch, payloads):
+        """Swap the live fetcher at the module seam the CLI actually reaches. The
+        CLI takes no `fetch` argument deliberately: a production flag that
+        replaces the data source is a flag that can lie."""
+        monkeypatch.setattr(st, "_gh_fetch_pr", _fetch(payloads))
+
+    def test_a_pr_resolves_end_to_end(self, tmp_path: Path, monkeypatch, capsys) -> None:
+        repo, store = self._fixture(tmp_path)
+        self._patched(
+            monkeypatch,
+            {421: _pr_payload(421, ["src/collector/a.py", "src/collector/b.py"])},
+        )
+        rc, cap = self._run(
+            ["--repo", str(repo), "--store", str(store), "--pr", "421",
+             "--today", TODAY, "--json"],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(cap.out)
+        assert payload["source"]["kind"] == "pr"
+        assert payload["source"]["window"] == "pull-requests"
+        assert payload["source"]["prs"] == [421]
+        assert payload["source"]["repo_slug"] == PR_SLUG
+        assert payload["status"] == "resolved"
+        assert payload["known"][0]["ref"] == "collector"
+
+    @pytest.mark.parametrize(
+        "argv_pr", [["--pr", "421,350"], ["--pr", "421", "--pr", "350"]],
+        ids=["comma", "repeated"],
+    )
+    def test_both_spellings_of_several_prs(
+        self, tmp_path: Path, monkeypatch, capsys, argv_pr
+    ) -> None:
+        repo, store = self._fixture(tmp_path)
+        self._patched(
+            monkeypatch,
+            {421: _pr_payload(421, ["src/collector/a.py"]),
+             350: _pr_payload(350, ["src/collector/b.py"])},
+        )
+        rc, cap = self._run(
+            ["--repo", str(repo), "--store", str(store), "--today", TODAY, "--json", *argv_pr],
+            capsys,
+        )
+        assert rc == 0
+        assert json.loads(cap.out)["source"]["prs"] == [421, 350]
+
+    def test_a_trailing_comma_is_the_typo_it_looks_like(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        repo, store = self._fixture(tmp_path)
+        self._patched(monkeypatch, {421: _pr_payload(421, ["a.py"])})
+        rc, cap = self._run(
+            ["--repo", str(repo), "--store", str(store), "--pr", "421,",
+             "--today", TODAY, "--json"],
+            capsys,
+        )
+        assert rc == 0
+        assert json.loads(cap.out)["source"]["prs"] == [421]
+
+    def test_an_EMPTY_pr_argument_exits_3_naming_the_sentinel(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """Reaches the "no number was given" guard rather than the "not a usable
+        number" one — a different fact, and the empty-token filter is what makes
+        it reachable."""
+        repo, store = self._fixture(tmp_path)
+        self._patched(monkeypatch, {})
+        rc, cap = self._run(
+            ["--repo", str(repo), "--store", str(store), "--pr", ",", "--today", TODAY],
+            capsys,
+        )
+        assert rc == 3
+        assert "no pull request number was given" in cap.err
+        assert cap.out.strip() == ""
+
+    @pytest.mark.parametrize(
+        "failure,phrase",
+        [
+            (st.GhMissingError("gh cli not found: nope"), "gh cli not found"),
+            (st.GhAuthError("gh is not authenticated: nope"), "gh is not authenticated"),
+            (st.GhRateLimitError("github api rate limit: nope"), "github api rate limit"),
+            (st.GhApiError("github api call failed: nope"), "github api call failed"),
+            (st.PrNotFoundError("pull request not found: nope"), "pull request not found"),
+            (st.PrRepoMismatchError("pull request belongs to another repository: nope"),
+             "pull request belongs to another repository"),
+            (st.PrNotLandedError("pull request is closed unmerged: nope"),
+             "pull request is closed unmerged"),
+            (st.PrResponseMalformedError("pull request response is malformed: nope"),
+             "pull request response is malformed"),
+            (st.PrFileListTruncatedError("pull request file list is truncated: nope"),
+             "pull request file list is truncated"),
+        ],
+        ids=["gh-missing", "gh-auth", "rate-limit", "api-error", "not-found",
+             "repo-mismatch", "closed", "malformed", "truncated"],
+    )
+    def test_every_failure_exits_3_with_a_PRINTABLE_line_and_NO_report(
+        self, tmp_path: Path, monkeypatch, capsys, failure, phrase
+    ) -> None:
+        """🔴 THE CONTRACT `/handoff` KEYS ON: non-zero, one printable stderr line,
+        and NOTHING on stdout — a report printed beside an error is a report
+        someone will act on."""
+        repo, store = self._fixture(tmp_path)
+        self._patched(monkeypatch, {421: failure})
+        rc, cap = self._run(
+            ["--repo", str(repo), "--store", str(store), "--pr", "421", "--today", TODAY],
+            capsys,
+        )
+        assert rc == 3
+        assert phrase in cap.err
+        assert cap.out.strip() == ""
+
+    def test_a_network_failure_NEVER_falls_back_to_git(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """🔴 THE CENTRAL PROPERTY, inherited from the session source. The repo has
+        real uncommitted work that git WOULD report, so a fallback would produce a
+        full, plausible report — an answer to a question the caller did not ask,
+        and `/handoff` would write from it."""
+        repo, store = self._fixture(tmp_path)
+        _write(repo, "src/collector/a.py")
+        _write(repo, "src/collector/b.py")
+        assert len(st.collect_git_paths(repo).paths) >= 2, "premise gone: git sees nothing"
+        self._patched(monkeypatch, {421: st.GhApiError("github api call failed: down")})
+        rc, cap = self._run(
+            ["--repo", str(repo), "--store", str(store), "--pr", "421", "--today", TODAY],
+            capsys,
+        )
+        assert rc == 3
+        assert cap.out.strip() == ""
+        assert "collector" not in cap.out
+
+    def test_the_text_renderer_prints_the_caveat_and_the_notes(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        repo, store = self._fixture(tmp_path)
+        self._patched(
+            monkeypatch,
+            {421: _pr_payload(421, ["src/collector/a.py", "src/collector/b.py"])},
+        )
+        rc, cap = self._run(
+            ["--repo", str(repo), "--store", str(store), "--pr", "421", "--today", TODAY],
+            capsys,
+        )
+        assert rc == 0
+        assert "caveat: pull request(s) #421" in cap.out
+        assert "what the BRANCH LANDED, NOT what a SESSION touched" in cap.out
+        assert "2 file(s) reported by the API" in cap.out
+
+
+class TestTheSourcesDoNotCompose:
+    """🔴 ONE QUESTION PER RUN. `--session` and `--pr` answer different questions
+    with OPPOSITE biases, and a union would carry ONE caveat line asserting
+    session attribution for some members and denying it for others, with no way
+    to tell which is which. The composition that IS available — run it twice and
+    read two caveats — keeps exactly the attribution a union destroys.
+    """
+
+    @pytest.mark.parametrize(
+        "extra",
+        [["--session", SESSION_ID], ["--transcript", "/nonexistent.jsonl"]],
+        ids=["session", "transcript"],
+    )
+    def test_pr_with_a_session_is_REFUSED_by_argparse(self, tmp_path: Path, extra) -> None:
+        """Exit 2, the same enforcement `--session` vs `--transcript` already uses:
+        they name different windows and picking one would be a guess about which
+        the caller meant."""
+        with pytest.raises(SystemExit) as exc:
+            st.main(["--repo", str(tmp_path), "--pr", "421", *extra])
+        assert exc.value.code == 2
+
+    def test_pr_with_paths_from_is_REFUSED_with_a_printable_line(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        repo = _init_pr_repo(tmp_path)
+        assert st.main(["--repo", str(repo), "--pr", "421", "--paths-from", "-"]) == 2
+        assert "cannot be combined" in capsys.readouterr().err
+
+    def test_the_session_refusal_STILL_names_itself(self, tmp_path: Path, capsys) -> None:
+        """The message was widened to cover `--pr`; it must not have stopped
+        naming the flags it already covered."""
+        repo = _init_pr_repo(tmp_path)
+        assert st.main(["--repo", str(repo), "--session", SESSION_ID, "--paths-from", "-"]) == 2
+        assert "--session/--transcript/--pr" in capsys.readouterr().err
+
+    def test_running_it_TWICE_is_the_supported_composition(
+        self, tmp_path: Path, monkeypatch, projects_root: Path, tailer_cache, capsys
+    ) -> None:
+        """🔴 The decision, as a measurement: two runs give two path sets EACH WITH
+        ITS OWN CAVEAT. The two windows deliberately DISAGREE here — the PR
+        carries an implementation file the session transcript never saw (the
+        subagent case), and the session carries a doc that reached no PR — which
+        is precisely why a union could not describe either honestly."""
+        repo = _init_pr_repo(tmp_path)
+        store = _make_store(tmp_path / "s")
+        _write_transcript(
+            projects_root / f"{SESSION_ID}.jsonl",
+            str(repo),
+            [f"{repo}/claudedocs/handoff-x.md"],
+        )
+        monkeypatch.setattr(
+            st, "_gh_fetch_pr", _fetch({421: _pr_payload(421, ["src/collector/a.py"])})
+        )
+        base = ["--repo", str(repo), "--store", str(store), "--today", TODAY, "--json"]
+
+        assert st.main(base + ["--session", SESSION_ID]) == 0
+        ses = json.loads(capsys.readouterr().out)
+        assert st.main(base + ["--pr", "421"]) == 0
+        pr = json.loads(capsys.readouterr().out)
+
+        assert ses["source"]["paths"] == ["claudedocs/handoff-x.md"]
+        assert pr["source"]["paths"] == ["src/collector/a.py"]
+        # The point: each set arrives with its OWN account of what it is.
+        assert ses["source"]["caveat"] != pr["source"]["caveat"]
+        assert "THIS SESSION's own turns" in ses["source"]["caveat"]
+        assert "what the BRANCH LANDED" in pr["source"]["caveat"]
+        assert ses["source"]["kind"] == "session" and pr["source"]["kind"] == "pr"
+
+
+class TestPrMutationKillMatrix:
+    """Each PR guard deleted on purpose, each dying to ITS OWN test.
+
+    🔴 The confound this class is built around, as in the session chain: these
+    guards run in sequence over one payload, and a mutant with one removed
+    usually trips the NEXT one. A kill that merely asserts "something raised"
+    would be green with the guard it names deleted — so every test below asserts
+    the specific sentinel is GONE and, where the chain would otherwise swallow
+    the effect, that the run now SUCCEEDS with the wrong answer, which is the
+    actual hazard.
+    """
+
+    def test_the_pr_mutant_harness_WORKS(self, tmp_path: Path) -> None:
+        """Positive control on this class's own loader: an unmutated copy must
+        reach the PR source successfully, or every kill below is vacuous."""
+        mod = _load_mutant(
+            tmp_path, "mp_noop", [('WRITER_ID = "handoff"', 'WRITER_ID = "handoff"  # noop')]
+        )
+        repo = _init_pr_repo(tmp_path)
+        src = mod.collect_pr_paths(repo, [421], fetch=_fetch({421: _pr_payload(421, ["a.py"])}))
+        assert src.paths == ("a.py",)
+
+    def test_kills_the_REPOSITORY_guard(self, tmp_path: Path) -> None:
+        """🔴 THE MOST CONSEQUENTIAL ONE. Without it another project's file list is
+        read AND reported — repo-relative, well-formed, entirely unrelated — and
+        it RESOLVES, manufacturing an association out of a bare number."""
+        mod = _load_mutant(
+            tmp_path, "mp_repo",
+            [("    if got_slug.lower() != slug.lower():", "    if False:")],
+        )
+        repo = _init_pr_repo(tmp_path)
+        foreign = {
+            421: _pr_payload(
+                421,
+                ["src/collector/a.py", "src/collector/b.py"],
+                slug=f"{PR_HOST}/other-org/other-repo",
+            )
+        }
+        leaked = mod.collect_pr_paths(repo, [421], fetch=_fetch(foreign))
+        assert leaked.paths == ("src/collector/a.py", "src/collector/b.py"), "wrong thing removed"
+        store = _make_store(tmp_path / "s")
+        rep = mod.build_report(leaked, store, SCOPE, today=TODAY)
+        assert [m.entry.ref for m in rep.known] == ["collector"], (
+            "the leaked paths did not even resolve — this kill would be vacuous"
+        )
+        with pytest.raises(st.PrRepoMismatchError):
+            st.collect_pr_paths(repo, [421], fetch=_fetch(foreign))
+
+    def test_kills_the_HOST_half_of_the_repository_identity(self, tmp_path: Path) -> None:
+        """🔴 Reached by an input the comparison itself accepts. Both slug builders
+        are collapsed to `owner/name`, which is what an owner/name-only identity
+        would look like — and a repo on ANOTHER FORGE then matches an unrelated
+        GitHub project and its file list is read and reported."""
+        mod = _load_mutant(
+            tmp_path,
+            "mp_host",
+            [
+                ('    return f"{host}/{parts[-2]}/{parts[-1]}"',
+                 '    return f"{parts[-2]}/{parts[-1]}"'),
+                ('    return f"{host}/{parts[1]}/{parts[2]}"',
+                 '    return f"{parts[1]}/{parts[2]}"'),
+            ],
+        )
+        repo = _init_pr_repo(tmp_path, remote=f"git@git.example.invalid:{PR_OWNER}/{SCOPE}.git")
+        payloads = {421: _pr_payload(421, ["src/collector/a.py"])}  # a github.com url
+        leaked = mod.collect_pr_paths(repo, [421], fetch=_fetch(payloads))
+        assert leaked.paths == ("src/collector/a.py",), "no leak — wrong thing removed"
+        with pytest.raises(st.PrRepoMismatchError):
+            st.collect_pr_paths(repo, [421], fetch=_fetch(payloads))
+
+    def test_kills_the_TRUNCATION_guard(self, tmp_path: Path) -> None:
+        """🔴 Without it a 411-file PR reports 100 paths and looks perfect. Not a
+        hypothetical: the cap is live and measured."""
+        mod = _load_mutant(
+            tmp_path, "mp_trunc", [("    if len(paths) < changed:", "    if False:")]
+        )
+        repo = _init_pr_repo(tmp_path)
+        payloads = {421: _pr_payload(421, [f"f{i}.py" for i in range(100)], changed=411)}
+        short = mod.collect_pr_paths(repo, [421], fetch=_fetch(payloads))
+        assert len(short.paths) == 100, "the truncation guard was not the thing removed"
+        with pytest.raises(st.PrFileListTruncatedError):
+            st.collect_pr_paths(repo, [421], fetch=_fetch(payloads))
+
+    def test_kills_the_FILES_PRESENCE_guard(self, tmp_path: Path) -> None:
+        """🔴 Without it an ABSENT file list becomes an EMPTY one — a confident
+        "this PR changed nothing" from a response that never described the files.
+
+        ⚠ MEASURED, NOT ASSUMED: with the guard removed the run does not report a
+        tidy empty window, it dies on a bare `TypeError`. That is still a kill and
+        it is the honest one — the real module fails with a NAMED, printable
+        sentence, and `/handoff` is instructed to print that line verbatim."""
+        mod = _load_mutant(
+            tmp_path, "mp_files", [("    if not isinstance(files, list):", "    if False:")]
+        )
+        repo = _init_pr_repo(tmp_path)
+        payload = _pr_payload(421, [])
+        del payload["files"]
+        with pytest.raises(Exception) as exc:
+            mod.collect_pr_paths(repo, [421], fetch=_fetch({421: payload}))
+        assert isinstance(exc.value, TypeError)
+        assert "pull request response is malformed" not in str(exc.value)
+        with pytest.raises(st.PrResponseMalformedError):
+            st.collect_pr_paths(repo, [421], fetch=_fetch({421: payload}))
+
+    def test_kills_the_CLOSED_UNMERGED_guard(self, tmp_path: Path) -> None:
+        """Without it, work that was proposed and REJECTED is reported as landed,
+        and a journal bullet records a change that exists in no tree."""
+        mod = _load_mutant(
+            tmp_path, "mp_closed",
+            [("    if state not in PR_ACCEPTED_STATES:", "    if False:")],
+        )
+        repo = _init_pr_repo(tmp_path)
+        payloads = {421: _pr_payload(421, ["src/collector/a.py"], state="CLOSED")}
+        assert mod.collect_pr_paths(repo, [421], fetch=_fetch(payloads)).paths == (
+            "src/collector/a.py",
+        )
+        with pytest.raises(st.PrNotLandedError):
+            st.collect_pr_paths(repo, [421], fetch=_fetch(payloads))
+
+    def test_kills_the_PR_IDENTITY_guard(self, tmp_path: Path) -> None:
+        """Without it, the answer to "what did #421 land" can be #999's files."""
+        mod = _load_mutant(
+            tmp_path,
+            "mp_num",
+            [("    if isinstance(got, bool) or not isinstance(got, int) or got != number:",
+              "    if False:")],
+        )
+        repo = _init_pr_repo(tmp_path)
+        payloads = {421: _pr_payload(999, ["src/collector/a.py"])}
+        assert mod.collect_pr_paths(repo, [421], fetch=_fetch(payloads)).paths == (
+            "src/collector/a.py",
+        )
+        with pytest.raises(st.PrResponseMalformedError):
+            st.collect_pr_paths(repo, [421], fetch=_fetch(payloads))
+
+    def test_kills_the_EMPTY_PR_LIST_guard(self, tmp_path: Path) -> None:
+        """Without it, ZERO pull requests produce a perfectly well-formed report
+        over nothing — the confident zero arriving through argument parsing."""
+        mod = _load_mutant(tmp_path, "mp_none", [("    if not read:", "    if False:")])
+        repo = _init_pr_repo(tmp_path)
+        src = mod.collect_pr_paths(repo, [], fetch=_fetch({}))
+        assert src.paths == () and src.prs == ()
+        with pytest.raises(st.PrNotFoundError):
+            st.collect_pr_paths(repo, [], fetch=_fetch({}))
+
+    def test_kills_the_PR_NUMBER_guard(self, tmp_path: Path) -> None:
+        """Without it a junk token is handed to the fetcher as if it named a PR."""
+        mod = _load_mutant(
+            tmp_path,
+            "mp_token",
+            [("    if not (t.isascii() and t.isdigit()) or int(t) < 1:", "    if False:")],
+        )
+        repo = _init_pr_repo(tmp_path)
+        with pytest.raises(Exception) as exc:
+            mod.collect_pr_paths(repo, ["not-a-number"], fetch=_fetch({}))
+        assert "pull request not found" not in str(exc.value)
+        with pytest.raises(st.PrNotFoundError):
+            st.collect_pr_paths(repo, ["not-a-number"], fetch=_fetch({}))
+
+    def test_kills_the_REPO_SLUG_guard(self, tmp_path: Path) -> None:
+        """Without it an unparseable remote yields `None` as the repository, and
+        every subsequent comparison is against nothing."""
+        mod = _load_mutant(
+            tmp_path, "mp_slug", [("    if slug is None:", "    if False:")]
+        )
+        repo = _init_pr_repo(tmp_path, remote="/srv/local-mirror")
+        with pytest.raises(Exception) as exc:
+            mod.collect_pr_paths(repo, [421], fetch=_fetch({421: _pr_payload(421, ["a.py"])}))
+        assert "repo has no usable github remote" not in str(exc.value)
+        with pytest.raises(st.RepoRemoteError):
+            st.collect_pr_paths(repo, [421], fetch=_fetch({421: _pr_payload(421, ["a.py"])}))
+
+    def test_kills_the_RATE_LIMIT_ORDERING(self, tmp_path: Path) -> None:
+        """🔴 The ordering, mutated directly. With the rate-limit branch gone a 403
+        rate-limit body — which carries gh's "gh auth login" hint — classifies as
+        a PERMANENT auth failure, and the caller stops retrying something that
+        would succeed in an hour."""
+        mod = _load_mutant(
+            tmp_path, "mp_rate", [('    if "rate limit" in low:', "    if False:")]
+        )
+        stderr = (
+            "HTTP 403: API rate limit exceeded for user ID 1.\n"
+            "Try authenticating with:  gh auth login"
+        )
+        assert type(mod._classify_gh_failure(1, stderr, PR_SLUG, 421)) is mod.GhAuthError
+        assert type(st._classify_gh_failure(1, stderr, PR_SLUG, 421)) is st.GhRateLimitError
+
+    def test_kills_the_GH_MISSING_guard(self, tmp_path: Path, monkeypatch) -> None:
+        """Without it an absent `gh` dies with an unprintable traceback instead of
+        the sentence `/handoff` is told to print verbatim — and `gh` is genuinely
+        absent in the hermetic tier."""
+        mod = _load_mutant(
+            tmp_path,
+            "mp_ghmiss",
+            [("        raise GhMissingError(\n"
+              '            f"gh cli not found: `{argv[0]}` is not on PATH, so pull '
+              'request #{number} "',
+              "        raise ValueError(\n"
+              '            f"neutered: {argv[0]} "')],
+        )
+
+        def boom(argv, *a, **kw):
+            raise FileNotFoundError(2, "No such file or directory", "gh")
+
+        monkeypatch.setattr(mod.subprocess, "run", boom)
+        with pytest.raises(Exception) as exc:
+            mod._gh_fetch_pr(PR_SLUG, 421)
+        assert not isinstance(exc.value, st.GhMissingError)
+        assert "gh cli not found" not in str(exc.value)
+
+    def test_kills_the_PR_CAVEAT_branch(self, tmp_path: Path) -> None:
+        """🔴 With the branch gone the caveat falls through to the GIT text — "what
+        this BRANCH touched, NOT what this SESSION touched" — which is accidentally
+        close enough to read as correct while naming the wrong window, no
+        repository and no pull request at all."""
+        mod = _load_mutant(
+            tmp_path, "mp_caveat", [('        if self.kind == "pr":', "        if False:")]
+        )
+        repo = _init_pr_repo(tmp_path)
+        payloads = {421: _pr_payload(421, ["a.py"])}
+        wrong = mod.collect_pr_paths(repo, [421], fetch=_fetch(payloads)).caveat
+        assert "what the BRANCH LANDED" not in wrong
+        assert "#421" not in wrong
+        assert PR_SLUG not in wrong
+        assert "what the BRANCH LANDED" in st.collect_pr_paths(
+            repo, [421], fetch=_fetch(payloads)
+        ).caveat
+
+    def test_kills_the_FULL_ARGV_renderer(self, tmp_path: Path) -> None:
+        """🔴 The regression the PR source exposed: with `git` hardcoded back into
+        the renderer, a `gh` invocation renders as `ran: git gh pr view 421`."""
+        mod = _load_mutant(
+            tmp_path,
+            "mp_argv",
+            [('        out.append(f"  ran: {\' \'.join(cmd)}")',
+              '        out.append(f"  ran: git {\' \'.join(cmd)}")')],
+        )
+        store = _make_store(tmp_path / "s")
+        src = st.PathSource(
+            kind="pr",
+            window="pull-requests",
+            paths=("src/collector/a.py",),
+            commands=(("gh", "pr", "view", "421"),),
+            prs=(421,),
+            repo_slug=PR_SLUG,
+        )
+        rep = st.build_report(src, store, SCOPE, today=TODAY, min_paths=1)
+        assert "ran: git gh pr view 421" in mod.render_text(rep)
+        assert "ran: gh pr view 421" in st.render_text(rep)
+
+    def test_kills_the_COMMANDS_HONESTY_guard(self, tmp_path: Path) -> None:
+        """🔴 Without it an injected fetcher still records `gh pr view …` — a
+        fabricated provenance line in the one field that exists to report what was
+        actually executed."""
+        mod = _load_mutant(
+            tmp_path,
+            "mp_cmdhonest",
+            [("        if live:\n            commands.append(_gh_argv(slug, n))",
+              "        if True:\n            commands.append(_gh_argv(slug, n))")],
+        )
+        repo = _init_pr_repo(tmp_path)
+        payloads = {421: _pr_payload(421, ["a.py"])}
+        fabricated = mod.collect_pr_paths(repo, [421], fetch=_fetch(payloads))
+        assert fabricated.commands and fabricated.commands[0][0] == "gh"
+        assert st.collect_pr_paths(repo, [421], fetch=_fetch(payloads)).commands == ()
+
+    def test_kills_the_PATHS_FROM_conflict_guard_for_PR(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """Without it, `--pr 421 --paths-from -` silently honours ONE of two
+        contradictory windows."""
+        mod = _load_mutant(
+            tmp_path,
+            "mp_conflict",
+            [('        if (wants_session or wants_pr) and args.paths_from != "git":',
+              "        if False:")],
+        )
+        repo = _init_pr_repo(tmp_path)
+        store = _make_store(tmp_path / "s")
+        monkeypatch.setattr(mod, "_gh_fetch_pr", _fetch({421: _pr_payload(421, ["a.py"])}))
+        argv = ["--repo", str(repo), "--store", str(store), "--pr", "421",
+                "--paths-from", "-", "--today", TODAY]
+        capsys.readouterr()
+        assert mod.main(argv) == 0
+        assert st.main(argv) == 2
+        assert "cannot be combined" in capsys.readouterr().err


### PR DESCRIPTION
Adds `--pr <n>[,<n>...]` to `scripts/lib/subsystem_touch.py`, reusing #421's scaffolding. Third path source; the reporting core still takes paths as an argument and has never heard of any of them.

## Why: three sources, and the first two are blind to how this repo actually works

| source | misses | why |
|---|---|---|
| git | work that MERGED during the session | HEAD ends at the merge-base — #415's first real run captured nothing |
| session (#421) | work done by a **subagent** | a subagent's turns are a separate transcript, excluded by construction — **196 of 733** file-tool calls, measured |
| `--pr` | *(see the caveat below)* | immune to both — a PR's file list does not care which agent, session or tool wrote the bytes |

Delegating non-trivial work to a subagent is the standing default here, so the second row is not an edge case. **#421's own PR is the proof**: its parent transcript reports 2 paths, both docs, while the entire implementation lives in a subagent's transcript.

## The session-vs-branch decision, and the caveat wording

**`--pr` answers "what did this BRANCH LAND", never "what did this session touch"**, and nothing in the output is allowed to imply otherwise. The caveat reads:

> pull request(s) #421, #350 in github.com/…: every file GitHub lists on those **BRANCHES** — what the **BRANCH LANDED**, **NOT** what a **SESSION** touched. A PR's file list is the **UNION** of every commit on its branch, so it includes commits authored by **ANOTHER session**, by a **SUBAGENT**, or **by hand**, and older work if the branch is long-lived; and it **EXCLUDES** anything a session did that did not reach one of these PRs. It is blind in the **OPPOSITE direction** to the session window, which sees exactly one session's turns and nobody else's. **Attribute these paths to the BRANCH, never to a session.**

It is on every output path of both renderers, including the early-return `looked-at-nothing` branch — the property #415's audit established and #421 kept, re-pinned here for the new source.

## The compose decision: **mutually exclusive**, enforced by argparse

Unioning `--session` with `--pr` was considered and **rejected**:

- A union carries **one** caveat line for a set assembled from two windows with **opposite** biases. It would have to assert session attribution for some members and deny it for others, in one sentence, with no way to tell which is which. The module's own rule — "a single hedging sentence covering both sources would be wrong about both" — already forbids that shape.
- **The consumer's decision is per-path.** "This session worked on X" and "some session moved X on this branch" are different claims, and only one belongs in a dated work-history bullet in a curated, client-confidential store. A merged set destroys exactly the fact needed to choose.
- It matches the refusal **already enforced** for `--session` + `--paths-from` — same shape, two windows and one answer. Composing here while refusing there would leave the module inconsistent about its own principle.

**The composition that IS available needs no code: run it twice and read two reports, each with its own caveat.** That keeps the attribution a union destroys. `/handoff` step 4 now instructs exactly that, and `TestTheSourcesDoNotCompose::test_running_it_TWICE_is_the_supported_composition` measures it with two windows that deliberately disagree.

## Accepted input: OPEN and MERGED; CLOSED-unmerged refused by name

An **OPEN** PR is the ordinary case at `/handoff` time (CI running, review pending) — refusing it would make the source useless exactly when it is invoked. A **CLOSED-unmerged** PR was proposed and rejected: its files exist in no tree, so a bullet written from them records a change that never happened.

## 🔴 A measured hazard the brief did not anticipate

**`gh pr view --json files` silently truncates at 100** while `changedFiles` reports the truth. Measured 2026-08-12 at three points either side of the cap:

```
a  39-file PR   changedFiles=39    len(files)=39
a 301-file PR   changedFiles=301   len(files)=100
a 411-file PR   changedFiles=411   len(files)=100
```

The brief verified against #421 (4 files), which is under the cap — so this was invisible from that case. Over the cap, the plausible-looking answer is a silent lexicographic **prefix** with a late-sorting subtree missing entirely. `PrFileListTruncatedError` **refuses** rather than reporting it, with the caller pointed at `--paths-from -`, whose caveat already says provenance is the caller's. The guard is `len(paths) < changedFiles` — **cap-agnostic**, so it needs no constant and cannot go stale when GitHub changes the number. Fired against the live 411-file response before being fixtured.

## The network surface: ten named errors, no silent zero

`repo has no usable github remote` · `gh cli not found` · `gh is not authenticated` · `github api rate limit` · `github api call failed` · `pull request not found` · `pull request belongs to another repository` · `pull request is closed unmerged` · `pull request response is malformed` · `pull request file list is truncated`

Each fatal, each its own sentinel, **none falls back to git**, and **none can return an empty path set** — which would be indistinguishable from "this PR changed nothing".

- Classification is **structural where gh allows** (rc=4 is gh's own auth code) and stderr-keyed where it does not — **declared** as a part-heuristic. Ordering is forced by overlap: a 403 rate-limit body *also* carries gh's `gh auth login` hint, so rate-limit is tested first or a temporary failure reads as a permanent one.
- The **fallback is deliberately the wide one**: an unreachable network or a 5xx becomes `GhApiError` carrying gh's stderr verbatim, never guessed onto a narrower diagnosis.
- Every stderr the classifier is tested against was **captured from gh 2.96.0 by provoking the real failure**, not invented.
- **Repository validation compares HOST as well as owner/name.** A bare number names nothing (every repo has a #1), and a repo mirrored on another forge can share `owner/name` with an unrelated GitHub project. The slug is derived from the local `origin` remote — never from the caller — and checked against the PR's **own `url`**, so it is a check rather than a restatement of the argument passed in.
- `files` **absent** ≠ `files: []` — the same unobservable-vs-observed-empty distinction the session source draws, at the other end of the pipe.

## Tests need neither network nor `gh`

**`gh` is in neither `REQUIRED_TOOLS` nor the flake's `nativeBuildInputs`** — verified, not assumed — so the hermetic tier has no `gh` and a test that shelled out would SKIP, which the gate fails on purpose. The fetch is injectable and every guard is reached with a fixture. **`no_live_gh` is autouse over the whole module** and fails any test reaching the real binary, because the hazard is a test that *forgot* to inject — and such a test would by definition not be in the class that remembered. Both halves of that guard are watched to work. **Zero new skips.**

## Two defects the work itself surfaced, fixed here

- **`render_text` hardcoded `git`** in front of `PathSource.commands`, so a `gh` invocation rendered as `ran: git gh pr view 421` — a false claim in the one field that exists to report what was actually asked. `commands` now carries the full argv for every source.
- **`RepoRemoteError` interpolated the whole `GitError` it wrapped**, so its message carried *two* sentinels and "which guard fired" stopped being a measurement. Caught by `_only` on the suite's first run. `GitError` now exposes `stderr` as an attribute so a wrapper can quote git's words without inheriting its sentinel.

## Verification

- **`nix build .#checks.x86_64-linux.pytests` — PASS, exit 0.** `scripts/tests collected=2825 passed=2825 skipped=0`; `TOTAL collected=8388 passed=8387 skipped=1 failed=0`.
- **Floor re-pinned 2647 → 2775**, from the gate's own per-target line put through the gate's own `_suggested_floor`, not arithmetic across a conflict. `2697 + 128 = 2825` exactly, so nothing else moved the base since #421 — a reading, not an assumption.
- **Positive control, as a pair**: a payload yielding **3** paths against a real MERGED PR that changed nothing yielding **0** — and the zero is *accounted for* by an unconditional `0 file(s) reported by the API, 0 read` note, because an empty list with no count is the silent zero. The pair is pinned again end-to-end at the report level (`resolved` vs `no-match`, same path count).
- **48 of 48 mutation-kill tests re-verified by an independently constructed sweep** that neuters `_load_mutant` to return a *pristine* module: every one goes red, so none is green with the guard it names intact. The sweep carries its own positive control (48 green with mutations real).
- **Live**: `--pr 421,350` returns 43 clean repo-relative paths with no worktree-prefix leakage; the truncation guard fired against a real 411-file response; a nonexistent PR exits **3 with empty stdout**; `--pr` + `--paths-from` exits **2**.

## Pushback on the brief

1. **The 100-file cap is the substantive one** — the brief's verification against #421 could not have seen it, and reported-as-a-prefix it is precisely the silent-short-set class the tool exists to refuse.
2. **"Named errors and no silent fallback" needed a corollary the brief did not state**: a *wrapping* error must not embed the wrapped error's sentinel, or `_only` stops being a measurement. Found by the harness, fixed in `GitError`.
3. **`commands` was already subtly wrong** and only a non-`git` source could expose it — a good argument that adding a second program to a single-program abstraction is worth doing partly *because* of what it reveals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
