### PR TITLE
docs(clawgate): fix the two kubeconfig commands that fail on this host, and slim SKILL.md under 12 KB

### DIFF
--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -5,184 +5,163 @@ description: "Operate clawgate — the self-hosted Claude Code approval UI (plus
 
 # clawgate operations
 
-Self-hosted Go + htmx + Tailwind PWA that routes Claude Code permission prompts to Zach's phone for
-approve / approve-with-comment / deny (it replaced the dead Telegram notify-bot). It has since grown
-into the **agent dispatch loop**: Tasks/Repos/Agents tabs on Postgres, agent self-service + privilege
-profiles + an Operator, runbooks with approval checkpoints, and a machine Task API that producers
-(task-spec drafter, repo-cos, mail-actions) post work into for one-tap Dispatch.
+Self-hosted Go + htmx PWA routing Claude Code permission prompts to Zach's phone for approve /
+approve-with-comment / deny. It has since grown into the **agent dispatch loop**: Tasks/Repos/Agents
+on Postgres, agent self-service + privilege profiles + an Operator, runbooks with approval gates,
+and a machine Task API producers post work into for one-tap Dispatch.
 
-🔴 **Authoritative point-in-time state is `/home/zach/workspace/homelab-talos/containers/clawgate/HANDOFF.md` — read it first.**
+🔴 **Point-in-time state: `/home/zach/workspace/homelab-talos/containers/clawgate/HANDOFF.md` —
+GREP it for the section you need, never read it whole (~190 KB / ~46k tokens, lower half superseded).**
 
-⚠ **This skill can be AHEAD of the code.** 0.7.72 was fully documented here weeks before it was
-committed to `trunk`. Before building on or deploying a documented feature, verify it's really in
-trunk: check the LIVE pin + `git grep` the feature. Don't trust the doc.
+⚠ **This skill drifts from the code in BOTH directions** — 0.7.72 was documented here weeks before
+it reached `trunk`; on 2026-08-12 it was six releases BEHIND (live 0.7.85). Never treat a doc claim
+as evidence: check the LIVE pin + `git grep` the feature.
 
 ## Reference files
-Repo-absolute at `/home/zach/workspace/devrc/claude/skills/clawgate/reference/`; also deployed to
-`~/.claude/skills/clawgate/reference/` after a home-manager switch.
+`devrc/claude/skills/clawgate/reference/` (also `~/.claude/skills/clawgate/` after a switch).
 
 | file | read it when |
 |---|---|
-| `reference/deploy.md` | **building + shipping a version** — full runbook, manifest-vs-code trap, CSS-cwd trap, chart sync |
-| `reference/task-api.md` | **writing/debugging a producer** — Task API surface, tag grammar, auth model, token consumers |
-| `reference/agent-dispatch.md` | dispatching/debugging the agent loop (`POST /agents`, sandbox fixture, silent non-start) |
-| `reference/extension.md` | you changed the browser extension, or need to know which build is really loaded |
-| `reference/changelog.md` | *when* a feature landed or why an old decision was made (0.2.x → 0.7.79) |
-| `reference/architecture.md` | changing agents / repos / runbooks / privilege / native tools / env / e2e |
-| `reference/internals.md` | changing Go code — markdown renderer, the two `taskTitle`s, migrations |
-| `reference/telemetry.md` | metrics/logs missing, adding an event, or a red CI check |
-| `reference/troubleshooting.md` | something is broken — symptom index (push, PWA icon, stale SW, RBAC, agent model) |
-| `reference/hooks.md` | `PermissionRequest` semantics, installing hooks on another host, the Stop / 💡 path |
-| `reference/agent-hardening.md` | locking down a kubeclaw agent devpod (securityContext, netpol, FQDN allowlist) |
-| `reference/element-references.md` | a task body has extension-picked element references to find in source |
+| `deploy.md` | **building + shipping a version**: manifest-vs-code + CSS-cwd traps; chart sync |
+| `task-api.md` | **writing/debugging a producer**; tag grammar; access model |
+| `agent-dispatch.md` | debugging the agent loop; `POST /agents`; the sandbox fixture; a silent non-start |
+| `extension.md` | you changed the browser extension, or need to know which build is loaded |
+| `changelog.md` | *when* a feature landed / why an old decision stands (0.2.x → 0.7.79; live is ahead) |
+| `architecture.md` | changing agents / repos / runbooks / privilege / native tools / env / e2e |
+| `internals.md` | changing Go code: markdown renderer, the two `taskTitle`s, migrations |
+| `telemetry.md` | metrics/logs missing; adding an event; a red CI check |
+| `troubleshooting.md` | symptom index: push, PWA icon, stale SW, RBAC, kubeconfig, agent model |
+| `hooks.md` | `PermissionRequest` semantics; the defer gates; installing hooks elsewhere; Stop / 💡 |
+| `agent-hardening.md` | locking down a **homelab** kubeclaw devpod (netpol needs Cilium) |
+| `element-references.md` | a task body carries extension-picked element references |
 
-Session memories: `clawgate-phase2` · `clawgate-phase3` · `clawgate-runbooks` ·
-`clawgate-loop-validation` · `clawgate-version-before-build` · `authelia-passkey-sso` ·
-`openclaw-exec-sandbox-strips-env`.
+Memories: `clawgate-phase2` · `clawgate-phase3` · `clawgate-runbooks` ·
+`clawgate-loop-validation` · `authelia-passkey-sso`.
 
 ## Key facts (verify against current state before asserting)
 
 | Thing | Value |
 |---|---|
-| Source | `/home/zach/workspace/homelab-talos/containers/clawgate/` (Go module `github.com/zacxdev/clawgate`) |
-| Hook scripts | `hook/clawgate-hook.sh` (PermissionRequest → `/api/send`) + `hook/clawgate-stop-hook.sh` (Stop → `/api/suggest`, async/fail-safe) |
-| Hook config | `~/.claude/clawgate.env` (`CLAWGATE_API_URL`, `CLAWGATE_HOOK_TOKEN`) — shared by both hooks |
-| Cluster | homelab-talos **workbench**, namespace `clawgate` |
-| 🔴 kubeconfig is PER-HOST — never hardcode it; `ls` both, take the one that EXISTS | Measured 2026-08-02 on both hosts: laptop `.155` → `~/workspace/homelab-infra/workbench-kubeconfig`; workbench `.250` → `~/workspace/homelab-talos/workbench-kubeconfig`. The other is **absent** on each host, so a missing file means "wrong host", not "wrong doc". (Origin was renamed homelab-talos → homelab-infra; the local repo dir is still `~/workspace/homelab-talos` — repo checkout ≠ kubeconfig dir.) Both hosts are hostname `nixos`; the IP or `browser whoami` disambiguates. |
-| Image | `harbor.homelab.lan/library/clawgate:<ver>` (the live pinned tag is in the deployment) |
-| Deploy manifest | `homelab-talos/clusters/workbench/apps/clawgate/deployment.yaml` (Flux GitOps from branch `trunk`) |
-| LAN URL (hook + UI) | `http://192.168.50.250:30302` (NodePort) / `clawgate.workbench.lan` — **OPEN, no auth** (trusted LAN); machine endpoints still need the bearer token |
-| Public URL (phone) | `https://clawgate.zacx.dev` — fronted by **Authelia 4.39 passwordless passkey** (portal `login.zacx.dev`, user `zach`) |
-| Nebula URL (laptop) | `http://10.42.0.10:8109` (homelab gateway → clawgate; hook-token auth) |
-| Hook events | `PermissionRequest` (kill-switch `CLAWGATE_REMOTE_APPROVAL=off`) + `Stop` (async, kill-switch `CLAWGATE_SUGGEST=off`) — both in `~/.claude/settings.json`, ON by default; the `Stop` array also carries an unrelated tmux task-hook (**preserve it**) |
+| Source | `~/workspace/homelab-talos/containers/clawgate/` (module `github.com/zacxdev/clawgate`) |
+| Hook scripts | `hook/clawgate-hook.sh` (PermissionRequest → `/api/send`) + `hook/clawgate-stop-hook.sh` (Stop → `/api/suggest`); both read `~/.claude/clawgate.env` (`CLAWGATE_API_URL`, `CLAWGATE_HOOK_TOKEN`) |
+| Cluster | **workbench**, ns `clawgate`; dispatched agents land in ns **`devpod-<agent-name>`** |
+| 🔴 kubeconfig is PER-HOST — never hardcode one; `ls` both, take the one that EXISTS | workbench `.250` → `~/workspace/homelab-talos/workbench-kubeconfig`; laptop `.155` → `~/workspace/homelab-infra/workbench-kubeconfig`. The other is **absent** on each host. Why, plus telling the hosts apart: `troubleshooting.md`. |
+| Image / manifest | `harbor.homelab.lan/library/clawgate:<ver>`, pinned in `clusters/workbench/apps/clawgate/deployment.yaml` (Flux from `trunk`) |
+| LAN URL (hook + UI) | `http://192.168.50.250:30302` (NodePort) — **OPEN, no auth**; machine endpoints still need the token |
+| Public / nebula URL | `https://clawgate.zacx.dev` behind **Authelia passkey** (portal `login.zacx.dev`); laptop `http://10.42.0.10:8109` via the homelab gateway |
+| Hook events | `PermissionRequest` (`CLAWGATE_REMOTE_APPROVAL=off`) + `Stop` (async, `CLAWGATE_SUGGEST=off`), both in `~/.claude/settings.json`, ON by default. 🔴 The `Stop` array also carries **two** unrelated hooks (`tmux/task-hook.sh`, `claude-notify.py`) — **preserve both** |
 
-🔴 **clawgate has NO human auth of its own** (since 0.7.37): `requireSession` is a literal
-pass-through no-op (`internal/api/auth.go`), so **the LAN NodePort is fully unauthenticated —
-including `DELETE /tasks/{id}`**; `requireHookToken` is **enforce-when-set**, so an empty
-`CLAWGATE_HOOK_TOKEN` opens the machine endpoints too. Publicly, Authelia's passkey is the only
-gate. Full access model + the three `CLAWGATE_HOOK_TOKEN` consumers and their rotation coupling:
-`reference/task-api.md`.
+🔴 **clawgate has NO human auth of its own** (since 0.7.37): `requireSession` is a pass-through no-op,
+so **the LAN NodePort is fully unauthenticated** — including `DELETE /tasks/{id}` and 🔴 **`POST
+/api/auto-approve-all`**, which arms a timed global window auto-approving **every** future request in
+**every** project *and* sweeps the pending queue (checkpoints excepted). `requireHookToken` is
+**enforce-when-set**: an empty token opens the machine endpoints too. Model: `task-api.md`.
 
 ---
 
 ## status
 ```bash
-KC=/home/zach/workspace/homelab-infra/workbench-kubeconfig   # PER-HOST — see Key facts
+KC=$(ls /home/zach/workspace/homelab-{talos,infra}/workbench-kubeconfig 2>/dev/null | head -1)  # PER-HOST
 kubectl --kubeconfig $KC -n clawgate get pods -l app=clawgate -o wide
-kubectl --kubeconfig $KC -n clawgate get pod -l app=clawgate -o jsonpath='{.items[0].spec.containers[0].image}{"\n"}'   # live image/version
-curl -sf --max-time 5 http://192.168.50.250:30302/health; echo                                                          # LAN health
-# pending count + push subscription count (from logs):
-kubectl --kubeconfig $KC -n clawgate logs deploy/clawgate --tail=200 | grep -iE 'subscription stored|delivered' | tail -3
+curl -sf --max-time 5 http://192.168.50.250:30302/health; echo   # LAN health + live version
 ```
 
 ## send a test
-Creates a real pending request (card + Web Push), via the hook token on the open LAN NodePort:
+Creates a real pending request (card + Web Push) via the hook token on the open LAN NodePort; for
+delivery, tail logs for `push: delivered ... to N device(s)`.
 ```bash
-B=http://192.168.50.250:30302
 HOOK=$(grep '^CLAWGATE_HOOK_TOKEN=' ~/.claude/clawgate.env | cut -d= -f2)
-curl -sf -X POST "$B/api/send" -H 'Content-Type: application/json' -H "Authorization: Bearer $HOOK" \
-  -d '{"type":"permission","tool":"Bash","command":"echo test","host":"nixos-desktop","project":"clawgate","context":["clawgate self-test"]}' | jq .
+curl -sf -X POST http://192.168.50.250:30302/api/send -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $HOOK" \
+  -d '{"type":"permission","tool":"Bash","command":"echo test","host":"nixos","project":"clawgate"}' | jq .
 ```
-To confirm native delivery, tail logs for `push: delivered ... to N device(s)`.
 
-## logs (push / SSE / subscription activity)
+## logs (push / SSE / subscriptions)
 ```bash
-KC=/home/zach/workspace/homelab-infra/workbench-kubeconfig   # PER-HOST — see Key facts
-kubectl --kubeconfig $KC -n clawgate logs -f deploy/clawgate | grep --line-buffered -iE 'subscription stored|delivered|push:|request created|decision recorded|could not'
+KC=$(ls /home/zach/workspace/homelab-{talos,infra}/workbench-kubeconfig 2>/dev/null | head -1)  # PER-HOST
+kubectl --kubeconfig $KC -n clawgate logs -f deploy/clawgate | grep --line-buffered -iE 'subscription|delivered|push:|request created|decision recorded|could not'
 ```
-(For a live watch that notifies the user as events arrive, use the Monitor tool with this command.)
+(Run under the Monitor tool for a live watch that notifies the user as events land.)
 
 ## deploy a new version
-🔴 **homelab-talos is GitOps from `trunk`: committing IS deploying the MANIFEST — but NOT container
-CODE, and the difference is silent.** `deployment.yaml` pins an immutable literal tag and there is
-**no Flux image automation**, so a commit under `containers/clawgate/**` reconciles cleanly and
-**changes nothing that is running**. Only a pin bump after a build+push deploys. `git log` on `trunk`
-is NOT evidence a code change is live; the live pin and `/health` are.
-
-🔴 **ONE commit path: a dedicated git WORKTREE off `origin/trunk`** — never the main checkout, which
-is permanently dirty (`.sops.yaml`, secrets, WIP). **Never `git add -A`**; stage explicit clawgate
-paths.
-
-**Load `reference/deploy.md` before you build or ship anything** — the full runbook
-(version-from-the-live-pin, test gate, build/push, pin bump, reconcile, cleanup, base-clone re-sync),
-the CSS-cwd trap that fakes ~25 e2e failures, the pristine-trunk baseline rule, and the chart-sync
-trap.
+🔴 **GitOps from `trunk`: committing deploys the MANIFEST, not container CODE — silently.** The
+manifest pins an immutable literal tag with **no Flux image automation**, so a commit under
+`containers/clawgate/**` reconciles cleanly and **changes nothing that is running**. `git log` is NOT
+evidence the code is live; the live pin and `/health` are. **Load `deploy.md` first** —
+version-from-the-live-pin, the ONE commit path (a worktree off `origin/trunk`; never `git add -A`),
+test gate, build/push, pin bump, the CSS-cwd trap that fakes ~25 e2e failures, the chart-sync trap.
 
 ## machine (hook-token) Task API
-Producers post Tasks/cards under `/api/tasks*` (+ `/api/notify`, `/api/tags`) with
-`Authorization: Bearer $CLAWGATE_HOOK_TOKEN` or `X-Clawgate-Token`. Statuses are exactly `open` /
-`in_progress` / `ready_for_review` / `complete` — there is **no `dismissed`**; dismissing deletes.
+Producers post under `/api/tasks*` (+ `/api/notify`, `/api/tags`) with `Authorization: Bearer
+$CLAWGATE_HOOK_TOKEN` or `X-Clawgate-Token`. Statuses are exactly `open` / `in_progress` /
+`ready_for_review` / `complete` — no `dismissed`; dismissing deletes.
 
-🔴 **`DELETE /api/tasks/{id}` shares `dismissTask`, so it TEARS DOWN a live dispatched agent pod**
-(`Provisioner.Destroy`). There is **no in-progress guard — deliberately**. Delete a dispatched task
-only if you mean to kill its agent.
+🔴 **Two paths delete a task, both TEARING DOWN its live dispatched agent pod** (shared
+`dismissTask` → `Provisioner.Destroy`; **no in-progress guard, deliberately**):
+- `DELETE /api/tasks/{id}` — unauthenticated on the LAN (above).
+- 🔴 **the idle-task reaper — its automated twin**: the daily sweep dismisses any task untouched for
+  `defaultTaskReapAfter` = **7d**, and `CLAWGATE_TASK_TTL` is **unset in the deployment**, so that
+  default is LIVE — an abandoned dispatch loses its agent pod after a week (`off`/`0` disables).
 
 ⚠ **Tags are hard-validated: one invalid tag or unknown `runbook:` is a hard 400 that fails the whole
-create** — and that 400 is a load-bearing wire contract producers key their retry on.
-⚠ **A task body may contain browser-extension element references** — do NOT search the selector
-first; work domain/path → adjacent text → selector → accessible name
-(`reference/element-references.md`).
+create** — a load-bearing wire contract producers key their retry on.
+⚠ **A task body may carry extension-picked element references** — never search the selector first
+(`element-references.md`).
 
-**Writing or debugging a producer? Load `reference/task-api.md`** — the full op table with per-op
-semantics and status codes, the 409/immutability rules, the comment-author allowlist, provenance
-headers, the tag grammar, and the auth/access model.
+**Writing/debugging a producer? Load `task-api.md`** — per-op semantics + status codes,
+409/immutability, the comment-author allowlist, provenance headers, the tag grammar.
 
 ## agent dispatch
-🔴 **Current STATUS of the loop lives in `containers/clawgate/HANDOFF.md`, not here** — status claims
-written into this skill have been superseded within two days, twice. Durable facts only:
-- **The loop DOES close unattended** (verified 2026-07-30/31, two runs, 138 s / 149 s, clone → PR →
-  `ready_for_review`). "The 5-minute kickoff deadline is why it never worked" is a DEAD theory — it
-  was dormant because nothing was dispatched. Don't open with "make the timeout configurable".
+🔴 **Current STATUS of the loop lives in `HANDOFF.md`, not here** — status claims written here have
+been superseded within two days, twice. `agent-dispatch.md` has the sandbox fixture, the agent
+image's absent toolchain and the `curl` form. Durable facts only:
+- **The loop DOES close unattended** (two real runs). "The 5-minute kickoff deadline is why it never
+  worked" is a DEAD theory — don't reopen it.
 - **`POST /agents` is FORM-ENCODED, not JSON**, behind the no-op `requireSession` → **no auth on the
-  LAN NodePort**. 🔴 `clawgate.zacx.dev` is protected ONLY by the Authelia edge, so any future
-  webhook needs a **separate hostname**, never a path bypass there — a bypass puts unauthenticated
-  agent dispatch on the internet.
-- ⚠ **A dispatch that cannot START fails SILENTLY** — task stays `in_progress`, `kicked_off` stays
-  `false`, nothing surfaces it. **Read the POD LOGS first**; the clawgate-side "gateway not ready
-  after 3m0s" message is the symptom, not the cause, and is not a provisioning flake.
-
-Running or debugging a dispatch (the `ZacxDev/clawgate-loop-sandbox` fixture, the agent image's
-absent toolchain, the `curl` form): `reference/agent-dispatch.md`.
+  LAN NodePort**. 🔴 `clawgate.zacx.dev` is gated ONLY at the Authelia edge, so a future webhook needs
+  a **separate hostname** — a path bypass there puts agent dispatch on the open internet.
+- ⚠ **A dispatch that cannot START surfaces almost nothing.** `provisioningStuckTimeout` (15m,
+  `internal/agents/reconcile.go`) marks the **agent** `error`, but the **task stays `in_progress`**,
+  `kicked_off` stays `false`, and nothing pushes. **Read the AGENT POD LOGS first — ns
+  `devpod-<agent-name>`, not ns `clawgate`.** The clawgate-side "gateway not ready after 3m0s" is a
+  symptom, not the cause, and not a provisioning flake.
 
 ## hook management
-- The PermissionRequest hook is global + on by default. Disable for one session: launch with
-  `CLAWGATE_REMOTE_APPROVAL=off`. Inspect: `jq '.hooks.PermissionRequest' ~/.claude/settings.json`.
-- Hook test suite:
-  `cd /home/zach/workspace/homelab-talos/containers/clawgate && nix-shell -p bats jq --run 'bats hook/tests/clawgate-hook.bats'`.
-- **Fail-safe by design**: any error / timeout / unreachable server → the hook defers to the
-  terminal, i.e. behaves as if it were absent. A clawgate outage never blocks Claude Code.
-- Full `PermissionRequest` semantics (exact JSON, why an approver comment is **record-only** with no
-  channel back to the model), installing the hooks on another host, and the Stop / 💡 Suggestions
-  hook incl. its `bats hook/tests/clawgate-stop-hook.bats` suite: `reference/hooks.md`.
+- On by default, global. Off for one session: `CLAWGATE_REMOTE_APPROVAL=off`. Inspect:
+  `jq '.hooks.PermissionRequest' ~/.claude/settings.json`.
+- Tests, from `containers/clawgate/`: `nix-shell -p bats jq --run 'bats hook/tests/*.bats'`.
+- **Fail-safe by design**: any error / timeout / unreachable server → defer to the terminal, as if
+  the hook were absent; a clawgate outage never blocks Claude Code. ⚠ It also defers **without ever
+  contacting the server** when `permission_mode` is `bypassPermissions`/`plan`, or the tool is
+  `AskUserQuestion` — so "no card appeared" is not evidence of an outage.
+- `hooks.md`: the full gate list, the exact JSON, why an approver comment is **record-only**,
+  installing hooks on another host, and the Stop / 💡 hook.
 
-## 🔴 gotchas (do not relearn the hard way)
+## 🔴 gotchas (don't relearn these)
 - 🔴 **Public routing rule**: clawgate runs on WORKBENCH but is fronted by the homelab + production
-  nebula gateways. The homelab gateway nginx block must `proxy_pass` to the workbench **NodePort IP
-  `http://192.168.50.250:30302`**, NOT a `.svc.cluster.local` name — a cross-cluster DNS name
-  doesn't resolve there and **crashes nginx** (`emerg: host not found in upstream`), **taking down
-  ALL nebula-routed services**. Edit those shared configs additively and carefully; a reload means
-  restarting `nebula-gateway` on **both** clusters (WS/SSE config lives on both). Mechanics:
-  `homelab-talos/claudedocs/nebula-production-to-homelab-routing.md` + `reference/architecture.md`.
-- **The vendored kubeclaw chart is embedded at BUILD time** — a kubeclaw release doesn't reach
-  clawgate-provisioned agents until `make sync-chart` + rebuild + redeploy clawgate, and
-  `make check-chart` silently tests the wrong tree unless `~/workspace/kubeclaw` is synced FIRST
-  (`reference/deploy.md`).
-- **Alloy has no auto-reloader** — if clawgate metrics vanish from homelab Prometheus, restart it
-  first (`reference/telemetry.md`).
-- **Red GitHub Actions checks on `homelab-infra` are NOISE** (billing-blocked repo-wide); the real
-  gate is the Tekton `clawgate-ci` pipeline — see the `tekton` skill before touching CI.
-  🔴 **But `clawgate-ci` does NOT run Playwright — browser-layer changes are UNGATED by CI.** Run
-  `make e2e` locally and **count** the results: `tasks.spec.ts` `test.skip`s the whole file without
-  Docker, so a "green" run can mean 17 tests never executed.
+  nebula gateways, whose nginx block must `proxy_pass` to the workbench **NodePort IP
+  `http://192.168.50.250:30302`** — NOT a `.svc.cluster.local` name, which doesn't resolve there and
+  **crashes nginx, taking down ALL nebula-routed services**. Edit additively; a reload restarts
+  `nebula-gateway` on **both** clusters. Mechanics: `architecture.md`.
+- **The vendored kubeclaw chart is embedded at BUILD time** — a kubeclaw release reaches
+  clawgate-provisioned agents only after `make sync-chart` + rebuild + redeploy, and `make
+  check-chart` silently tests the wrong tree unless `~/workspace/kubeclaw` is synced FIRST.
+- ⚠ **Clawgate-provisioned agents are NOT hardened by default**: chart defaults are
+  `networkPolicy.enabled: false` + `tls.verify: false` (→ `NODE_TLS_REJECT_UNAUTHORIZED=0`). The
+  **container** securityContext IS set (`allowPrivilegeEscalation: false`, seccomp `RuntimeDefault`);
+  only the **pod-level** one is empty. 🔴 That netpol is **Cilium-only** and workbench — where
+  clawgate provisions — has **no Cilium**, so `agent-hardening.md` is a **homelab** playbook.
+- **Alloy has no auto-reloader** — if clawgate metrics vanish from homelab Prometheus, restart Alloy
+  first (`telemetry.md`).
+- **Red GitHub Actions checks on `homelab-infra` are NOISE** (billing-blocked); the real gate is the
+  Tekton `clawgate-ci` pipeline — see the `tekton` skill before touching CI. 🔴 **But `clawgate-ci`
+  does NOT run Playwright — browser-layer changes are UNGATED.** Run `make e2e` locally and
+  **count**: **11 of the 18 spec files, 77 of 113 tests, `test.skip` on `!dockerAvailable()`** — a
+  "green" run without Docker executed barely a third of the suite.
 - 🔴 **The browser extension does NOT ship via Flux — merging to `trunk` deploys NOTHING.** Brave
-  loads it unpacked **in place from a git worktree**, at the same path on **BOTH hosts** (workbench +
-  laptop `zach@192.168.50.155`): `~/workspace/clawgate-extension/containers/clawgate/extension`
-  (branch `clawgate-ext-local`). Deploy = `merge --ff-only origin/trunk` on both + reload Brave (no
-  hot-reload). 🔴 **Brave has MULTIPLE PROFILES that load extensions independently and can point at
-  DIFFERENT paths** — one profile was left a version behind exactly this way; checking the profile in
-  front of you proves nothing, and agents can't read `brave://`, so use the `Preferences`-JSON sweep
-  in `reference/extension.md` — which also verifies the HOTKEYS, since a reload silently left
-  `Ctrl+Shift+E` unbound in two profiles. 🔴 **Never `git restore --source=<ref> --worktree` a
-  subtree to "freshen" a stale checkout** — identical content still BLOCKS an `--ff-only` merge that
-  touches that path, and any later checkout silently reverts it. `~/clawgate-extension` is deleted;
-  `sync-clawgate-extension.sh` still exists in homelab-talos but is NOT the delivery path.
+  loads it unpacked in place from `~/workspace/clawgate-extension/containers/clawgate/extension`
+  (branch `clawgate-ext-local`), same path on **BOTH hosts**; deploy = `merge --ff-only origin/trunk`
+  on both + reload Brave. 🔴 **Brave profiles load extensions independently from DIFFERENT paths, so
+  the profile in front of you proves nothing** — and agents can't read `brave://`. Never call a
+  version or hotkey live without the `Preferences` sweep in `extension.md`, which also carries the 🔴
+  `git restore --worktree` trap.

--- a/claude/skills/clawgate/reference/agent-dispatch.md
+++ b/claude/skills/clawgate/reference/agent-dispatch.md
@@ -7,9 +7,17 @@ have produced a PR, a dispatch that never started, the test fixture, `POST /agen
 not here.** Two point-in-time claims were written into the skill on 2026-07-31 and were BOTH
 superseded within two days — the checkpoint/kickoff-deadline breakage (**fixed in 0.7.80**, pinned by
 `provision_kickoff_ctx_test.go` + `checkpoint_test.go`) and the private-clone diagnosis (written
-against vendored chart **0.7.0**; the chart is now **0.7.1**, shipped in clawgate **0.7.82**, and
-clones over **SSH** — the `.gh-token` credential-helper mechanism and its line numbers no longer
-exist). Read HANDOFF before repeating any status claim. What follows is only what does NOT go stale.
+against vendored chart **0.7.0**; the chart is now **0.7.1**, shipped in clawgate **0.7.82**).
+Read HANDOFF before repeating any status claim. What follows is only what does NOT go stale.
+
+🔴 **Agents clone over HTTPS with a token credential helper — NOT over SSH.** A previous revision of
+this file claimed the opposite and that the `.gh-token` helper "no longer exists"; both were wrong.
+Verified on `trunk` 2026-08-12: `internal/agents/provision.go:616` builds
+`https://github.com/%s.git`, and `internal/agents/values.go:25` defines `gitCredentialHelper`, which
+reads the token from `/root/.gh-token` (written at startup from the `GITHUB_TOKEN` Secret env — note
+it does **not** exist yet at clone time, see the comment at `values.go:96`). This matches
+`troubleshooting.md` → "Agent `git push` fails with an empty password". The only `git@github.com` in
+the tree is a commented-out example in the vendored chart's `values.yaml`.
 
 ## The loop DOES close unattended
 Verified 2026-07-30/31 over two deliberate runs (clone → implement → test → branch → commit → push →

--- a/claude/skills/clawgate/reference/agent-hardening.md
+++ b/claude/skills/clawgate/reference/agent-hardening.md
@@ -1,7 +1,16 @@
 # kubeclaw agent-devpod hardening playbook (0.7.x chart values)
 
-Read when: locking down ANY homelab kubeclaw agent (initiatives, task-drafter,
-clawgate-provisioned, …). Harden via first-class chart **values** (0.7.x), **NOT postRenderers**.
+Read when: locking down a kubeclaw agent devpod **on the homelab cluster** (initiatives,
+task-drafter, …). Harden via first-class chart **values** (0.7.x), **NOT postRenderers**.
+
+🔴 **This is a playbook, not a description of what agents already have — and the netpol half does
+not apply to clawgate-provisioned agents at all.** Measured 2026-08-12: the chart defaults are
+`networkPolicy.enabled: false` and `tls.verify: false` (→ `NODE_TLS_REJECT_UNAUTHORIZED=0`), and no
+live `devpod-*` namespace on workbench has a NetworkPolicy. The **container** securityContext IS
+applied by default (`allowPrivilegeEscalation: false` + seccomp `RuntimeDefault`, confirmed on a
+live pod); only **`podSecurityContext`** is `{}`. And because the FQDN allowlist can only be
+expressed as a **CiliumNetworkPolicy**, it is unavailable on **workbench — which has 0 Cilium CRDs**
+and is exactly where clawgate provisions agents. Homelab has Cilium; workbench does not.
 
 - **`securityContext`** — `allowPrivilegeEscalation:false` + seccomp `RuntimeDefault` always. Add
   `capabilities.drop:[ALL]` **ONLY if the image bakes its runtime deps** (no apt/dpkg at init) —
@@ -16,7 +25,9 @@ clawgate-provisioned, …). Harden via first-class chart **values** (0.7.x), **N
 - **Per-agent egress must include**: the **model host** (`openrouter.ai` + `*.openrouter.ai`); any
   **APIs** the agent calls (clickup, etc.); **GitHub** (`github.com` + `*.githubusercontent.com`
   over https, **`:22` if it SSH-clones**, `api.github.com` + `codeload.github.com`); the
-  **`infraTools` install sources** IF enabled (`dl.k8s.io` / `*.fluxcd.io` / GitHub releases —
+  **`infraTools` install sources** IF enabled (`dl.k8s.io` **plus `cdn.dl.k8s.io`**, which the
+  release redirect lands on, and bare **`fluxcd.io`** — the installer fetches `https://fluxcd.io/install.sh`,
+  and a `matchPattern: *.fluxcd.io` does NOT match the apex; GitHub releases —
   **NOT** `*.debian.org` unless the image apt-installs at init); plus kube-dns + apiserver.
 - 🔴 **`tools.web.search.enabled:false` for any restricted-egress agent.**
   `openclaw doctor --fix` auto-enables a brave/perplexity plugin that npm-fetches

--- a/claude/skills/clawgate/reference/architecture.md
+++ b/claude/skills/clawgate/reference/architecture.md
@@ -47,8 +47,9 @@ with Phase 2 disabled.
     clawgate-provisioned agents until you `make sync-chart` + rebuild + redeploy clawgate.**
     Already-running agents are unaffected — their release was rendered from whatever chart was
     vendored then.
-  - ⚠ **Vendored is at 0.7.0 but kubeclaw is now 0.7.1 → a re-sync+rebuild is PENDING** to pick up
-    0.7.1's networkPolicy fail-loud guards (empty-allowlist protection).
+  - ✅ The re-sync is **DONE**: the vendored `internal/agents/chart/kubeclaw/Chart.yaml` reads
+    `version: 0.7.1` (shipped in clawgate 0.7.82), so 0.7.1's networkPolicy fail-loud guards
+    (empty-allowlist protection) are in the embedded chart. Re-check `Chart.yaml`, not this line.
   - Cards show live status (start/stop/delete) + recent logs; the detail view streams pod logs
     (SSE, collapsed by default) + a chat box (WebSocket → agent gateway
     `:18789 /v1/chat/completions`).
@@ -142,7 +143,9 @@ Plain envs: `CLAWGATE_AGENT_IMAGE_REPO`; `CLAWGATE_AGENT_IMAGE_TAG` (**`2026.5.7
 `openrouter/anthropic/claude-haiku-4.5`); `CLAWGATE_AGENT_CALLBACK_URL` (in-cluster clawgate URL
 for agent self-service; empty → default svc); `CLAWGATE_PUBLIC_URL`; `CLAWGATE_REQUEST_TTL` (5m);
 `CLAWGATE_TASK_TTL` (idle-task reaper, `off`/`0` disables); `CLAWGATE_TAG_AUTODISPATCH` (off);
-`CLAWGATE_FAKE_PROVISIONER` (e2e only); `CLAWGATE_INSECURE_COOKIES` (docker smoke).
+`CLAWGATE_FAKE_PROVISIONER` (e2e only). ⚠ `CLAWGATE_INSECURE_COOKIES` is a **dead env var** — no Go
+code reads it (verified 2026-08-12); it survives only in `README.md` and `HANDOFF.md`, left over from
+the pre-0.7.37 session-cookie model. Setting it does nothing.
 
 **Editing SOPS**: `SOPS_AGE_KEY_FILE=.secrets/age.key sops -e -i <file>` works — `.sops.yaml` was
 reconciled (a `clusters/workbench/apps/clawgate/.*.enc.yaml$` rule exists), so the old

--- a/claude/skills/clawgate/reference/changelog.md
+++ b/claude/skills/clawgate/reference/changelog.md
@@ -5,6 +5,10 @@ is, or whether a behaviour you're seeing is a deliberate old decision. **Not nee
 routine operation** — the core SKILL.md carries everything you need to deploy, drive the
 machine API, or debug.
 
+⚠ **This file stops at 0.7.79 and the product runs ahead of it** (live was **0.7.85** on
+2026-08-12). An absence here is NOT evidence a feature doesn't exist — for anything newer than
+0.7.79, read `containers/clawgate/HANDOFF.md` or `git log` instead.
+
 🔑 **Never derive the next release number from this file** — always from the LIVE
 deployment pin (see the core's deploy section).
 

--- a/claude/skills/clawgate/reference/deploy.md
+++ b/claude/skills/clawgate/reference/deploy.md
@@ -55,7 +55,7 @@ make e2e   # 83 pass / 2 skip; a fresh worktree npm-installs e2e/node_modules fi
 
 # 2. build (Dockerfile builds Tailwind CSS then the static Go binary, embeds assets) + smoke + push
 docker build --build-arg VERSION=$VER -t harbor.homelab.lan/library/clawgate:$VER -t harbor.homelab.lan/library/clawgate:latest .
-docker run -d --name cg-smoke -p 8219:8104 -e CLAWGATE_INSECURE_COOKIES=1 harbor.homelab.lan/library/clawgate:$VER && sleep 3
+docker run -d --name cg-smoke -p 8219:8104 harbor.homelab.lan/library/clawgate:$VER && sleep 3   # CLAWGATE_INSECURE_COOKIES is dead — no Go code reads it
 curl -sf http://localhost:8219/health && echo OK; docker rm -f cg-smoke
 docker push harbor.homelab.lan/library/clawgate:$VER && docker push harbor.homelab.lan/library/clawgate:latest
 

--- a/claude/skills/clawgate/reference/extension.md
+++ b/claude/skills/clawgate/reference/extension.md
@@ -166,11 +166,11 @@ Delivery used to be an rsync into a flat copy at `~/clawgate-extension` via
 `homelab-talos/scripts/sync-clawgate-extension.sh`.
 
 - The **flat copy is deleted** (2026-08-12, both hosts). Nothing recreates it.
-- The **script still exists** at `homelab-talos/scripts/sync-clawgate-extension.sh` and is still
-  documented as live in `scripts/README.md`, `containers/clawgate/extension/README.md` and
-  `claudedocs/handoff-clawgate-ext-2026-07-30.md` (plus a 12 KB test). **Retiring it is a pending
-  follow-up in that repo** — until then, treat every one of those references as stale and **do not
-  run it**: with its destination gone it would either fail or recreate a directory no profile loads.
+- The **script is deleted too** — removed from `trunk` in `a39ed0c5` along with its test
+  (`scripts/tests/test-sync-clawgate-extension.sh`). Retiring it is **DONE, not pending**.
+  `scripts/README.md` and `containers/clawgate/extension/README.md` now describe the removal
+  correctly; the only reference that still reads as live is the historical
+  `claudedocs/handoff-clawgate-ext-2026-07-30.md`, which is a dated record — don't run its commands.
 
 The failure worth remembering: the script's `--check` kept reporting a confident
 `in sync — matches origin/trunk` about a directory **no profile loaded**, so a green check coexisted

--- a/claude/skills/clawgate/reference/hooks.md
+++ b/claude/skills/clawgate/reference/hooks.md
@@ -83,6 +83,16 @@ blows `ARG_MAX`) and `curl --data-binary @file`.
 - It has **NO reason/context channel** — an approver comment is **record-only**. Only `PreToolUse`
   can steer the model, via `additionalContext`. Do not design a feature that relies on feeding an
   approver's words back into the session through this hook.
-- Any non-approve/reject decision (e.g. an `ignore`/dismiss) → the hook **defers to the terminal**.
-- Any error / timeout / unreachable server → **defer** (fail-safe: behaves as if the hook were
-  absent). This is why an outage of clawgate never blocks Claude Code.
+### Every path that DEFERS (this list is exhaustive; verified against `hook/clawgate-hook.sh` 2026-08-12)
+Two of these defer **before any network call**, so a missing card is not evidence clawgate is down:
+
+| # | condition | contacts the server? |
+|---|---|---|
+| 1 | `permission_mode` is `bypassPermissions` or `plan` (`clawgate-hook.sh:67`) — the user already chose to bypass, so don't intercept | **no** |
+| 2 | tool is `AskUserQuestion` (`:79`) — an interactive "pick an option" prompt, not allow/deny-routable | **no** |
+| 3 | any non-approve/reject decision (e.g. an `ignore`/dismiss) | yes |
+| 4 | any error / timeout / unreachable server — fail-safe, behaves as if the hook were absent; this is why a clawgate outage never blocks Claude Code | attempted |
+
+🔴 **Debugging "no card appeared"? Rule out 1 and 2 first** — they produce exactly the same
+observable as an outage, and `log`-lines in the hook (`permission_mode=…; deferring` /
+`is an interactive question prompt`) are the only thing that distinguishes them.

--- a/claude/skills/clawgate/reference/internals.md
+++ b/claude/skills/clawgate/reference/internals.md
@@ -6,11 +6,11 @@ unexpected status back. Not needed to merely operate it.
 ## The markdown renderer (0.7.77) — `internal/ui/markdown.go`
 
 Emitted markup goes into a **vault** keyed by a `\x00`-delimited token (`mdVaultSep`,
-`markdown.go:86`) and is restored in **ONE** `ReplaceAllStringFunc` pass — the renderer used to
+`markdown.go:88`) and is restored in **ONE** `ReplaceAllStringFunc` pass — the renderer used to
 re-parse its own output (two links in a paragraph destroyed each other's attributes, a `_`/`*` in
 a URL corrupted the href, emphasis ran inside code spans). ⚠ **Never make the restore per-item:
 it is quadratic** — 33.5s vs 0.7s on a 195 KB body (`maxTaskBodyLen` = `200_000`), on the path
-that renders **every task's full body on the LIST page** (`internal/ui/notes.go:294`). Guarded by
+that renders **every task's full body on the LIST page** (`internal/ui/notes.go:550`). Guarded by
 `internal/ui/markdown_vault_test.go` (`TestRestoreIsSinglePassAtScale`, 10s bound).
 
 🔑 **The rule that matters: if a client is working around this renderer, fix the RENDERER, not the
@@ -19,14 +19,15 @@ client.** A client-side workaround for this class was wrong three times running.
 ⚠ **Two renderers, two sentinels — don't conflate them.** The Go renderer's sentinel is `\x00`;
 the **JS mirror** in `internal/ui/agents_detail.go` uses a different one, `\uE000` (written here escaped on purpose — a literal U+E000 is invisible to `grep`).
 
-⚠ **`internal/ui/markdown.go:51-54` carries a STALE comment** claiming the JS leak is unfixed;
-0.7.79 fixed it in `agents_detail.go:843`. Residual known bug: a backtick inside a URL renders a
-truncated autolink plus literal text.
+✅ **That comment is no longer stale — this note was.** `internal/ui/markdown.go:51-56` now states
+correctly that the JS mirror's leak was **fixed in 0.7.79** (`agents_detail.go:843`). Read the
+comment, not this paragraph. Residual known bug: a backtick inside a URL renders a truncated
+autolink plus literal text.
 
 ## 🔑 NAME-COLLISION TRAP — there are TWO `taskTitle`s
 `internal/api` has its OWN `taskTitle`, and it is **NOT** `ui.TaskTitle`.
 
-| | `internal/api/push_task.go:359` `taskTitle` | `internal/ui/notes.go:502` `ui.TaskTitle` |
+| | `internal/api/push_task.go:359` `taskTitle` | `internal/ui/notes.go:767` `ui.TaskTitle` |
 |---|---|---|
 | purpose | the **Web-Push notification title** | the **display label** |
 | derives from | first non-empty line of the **body**, markdown-**flattened** through `notificationText()`, truncated | `title` → `directory`, **raw** |
@@ -132,6 +133,6 @@ next number, never edit an existing one.**
 | 0012 | suggestions |
 | 0013 | persisted per-project auto-approve |
 | 0014 | per-Task dispatch config |
-| 0015 | `chat_message_parts` + `chat_messages.kind`/`tool_id`/`tool_name`/`tool_ok` — the STRUCTURED transcript (assistant turn = ordered parts; legacy rows = kind `text`) |
+| 0015 | ⚠ **no new table** — `0015_chat_message_parts.sql` only `ALTER`s `chat_messages`, adding `kind`/`tool_id`/`tool_name`/`tool_ok` for the STRUCTURED transcript (assistant turn = ordered parts; legacy rows = kind `text`). There is **no `chat_message_parts` table**; the filename is not a schema object |
 | 0017 | source provenance |
 | 0018 | `notes.tags TEXT[]` (GIN) + `notes.title TEXT` |

--- a/claude/skills/clawgate/reference/task-api.md
+++ b/claude/skills/clawgate/reference/task-api.md
@@ -123,7 +123,24 @@ and **no login QR to manage**.
 - 🔴 **The `/api/` prefix does NOT mean "needs the token."** `/api/requests`,
   `/api/openrouter/models`, `/api/push/*` and `/api/auto-approve*` sit behind the no-op
   `requireSession` and are **wide open on the LAN NodePort** — and `POST /api/auto-approve` is
-  state-changing on the open side. Measured live 0.7.85, 2026-08-11: `GET /api/requests` → **200
+  state-changing on the open side.
+- 🔴🔴 **`POST /api/auto-approve-all` is the most consequential switch in the app, and it is
+  unauthenticated on the LAN** (`internal/api/server.go:325`, wrapped in the no-op `requireSession`;
+  handler at `:1105`). It accepts **either** a form body or JSON — `enabled` (`true`/`1`/`on`) plus
+  `duration` (the UI offers 1h / 8h / 24h). Enabling it does **two** things, and the second is the
+  one people miss:
+  1. arms a **single global window** that auto-approves every *future* request **in every project**
+     (not per-project — the server logs it as `auto-approve-ALL enabled … (FIREHOSE — every project)`);
+  2. immediately **sweeps the existing pending queue**, approving everything already waiting.
+
+  Runbook **checkpoints** (`store.TypeCheckpoint`) are skipped in the sweep — an approval gate stays
+  a human decision. Disable with `enabled=false`, which clears the window and falls back to the
+  per-project rules. e2e coverage: `e2e/tests/auto-approve-all.spec.ts` (2 tests, **not** Docker-gated).
+- 🔴 **The idle-task reaper is a second unattended destroyer.** `defaultTaskReapAfter = 7d`
+  (`internal/api/server.go:1229`); the daily retention sweep calls `reapIdleTasks` (`:1303`) which
+  calls the **same `dismissTask`** as `DELETE /api/tasks/{id}` (`:1318`) — so an idle task's linked
+  agent pod is torn down too. `CLAWGATE_TASK_TTL` is **unset in the live deployment** (verified
+  2026-08-12), so the 7d default is what is running; `off` or `0` disables the reaper. Measured live 0.7.85, 2026-08-11: `GET /api/requests` → **200
   with no credential**, `GET /api/tasks` → **401**. Never infer exposure from the path prefix.
 - 🔴 **`/operator/*` (11 routes) is a THIRD credential** — `requireOperatorToken` demands the
   reserved Operator *agent's* hooks token, not the hook token, which gets

--- a/claude/skills/clawgate/reference/troubleshooting.md
+++ b/claude/skills/clawgate/reference/troubleshooting.md
@@ -16,10 +16,32 @@ Fully remove the home-screen icon → clear the site's data in the browser → r
 shortcut carrying the browser icon).
 Verify: `curl -s .../static/icons/icon-192.png | file -` should say 8-bit.
 
+## `kubectl --kubeconfig …` fails: no such file (the workbench kubeconfig path)
+**The path is PER-HOST — a missing file means "wrong host", not "wrong doc".** Measured on both
+hosts 2026-08-12:
+
+| host | the file that EXISTS | the other path |
+|---|---|---|
+| workbench `192.168.50.250` | `~/workspace/homelab-talos/workbench-kubeconfig` | absent |
+| laptop `192.168.50.155` | `~/workspace/homelab-infra/workbench-kubeconfig` | absent |
+
+The names differ because the **origin repo** was renamed `homelab-talos` → `homelab-infra` while the
+**local checkout dir** was not renamed on every host — repo checkout name ≠ kubeconfig dir. Both
+hosts report hostname `nixos`, so disambiguate by IP (`ip -4 addr`) or `browser whoami`.
+
+⚠ **`$KC_WORKBENCH` is exported on the workbench only** — it is empty on the laptop even in a login
+shell, so a doc that says "just use `$KC_WORKBENCH`" breaks there. Select the file instead
+(verified verbatim in bash and zsh on both hosts):
+```bash
+KC=$(ls /home/zach/workspace/homelab-{talos,infra}/workbench-kubeconfig 2>/dev/null | head -1)
+```
+
 ## A UI feature "looks broken" for a user but works in incognito/fresh
 **Stale service-worker cache — suspect the SW first.** `app.css` used to be cache-first under a
 never-bumped cache, so returning users kept old CSS missing new classes. Fixed in 0.3.6: `app.css`
-is network-first, cache `clawgate-shell-v2`. A normal reload picks up fresh CSS post-deploy.
+is network-first. **The cache name is bumped per shell change — read it, don't quote it:** it is
+`clawgate-shell-v4` as of 2026-08-12 (`web/static/sw.js:20`), not the `v2` this entry used to name.
+A normal reload picks up fresh CSS post-deploy.
 
 ## Card not removed when resolved in Claude Code
 `DELETE /api/response/{id}` must broadcast resolved (fixed in 0.2.0). The hook DELETEs its request
@@ -27,8 +49,10 @@ on decision/timeout. Card actions are optimistic (removed instantly, POST queued
 a `↻ N` header indicator); SSE reconciles the badge.
 
 ## Stale request cards pile up
-The hook DELETEs on ANY exit (trap) and the server TTL is short (`CLAWGATE_REQUEST_TTL=5m`; the
-hook poll deadline is 170s so nothing legitimate pends longer). Orphans auto-evict within ~5 min.
+The hook DELETEs on ANY exit (trap) and the server TTL is short. ⚠ **`CLAWGATE_REQUEST_TTL=5m` is a
+DEPLOYMENT value, not inherent** — the code default is **1h** (`main.go:68`, `defaultRequestTTL =
+time.Hour`), so a locally-run clawgate evicts after an hour, not five minutes. The hook poll deadline
+is 170s, so nothing legitimate pends longer. On the cluster, orphans auto-evict within ~5 min.
 
 ## `fetch ... URL that includes credentials`
 The page was opened with basic-auth creds in the URL (`https://user:pass@host`). Client fetches


### PR DESCRIPTION
The `clawgate` skill shipped two `kubectl` blocks (`status`, `logs`) that hardcoded
`/home/zach/workspace/homelab-infra/workbench-kubeconfig` — **a path that does not exist on the
workbench**, so both failed there, while the Key-facts row two screens up stated the per-host rule
correctly. That is the failure class this PR exists to close, so **every command left in these docs
was executed verbatim on the host it targets** (see "Verification" below).

## Correctness fixes

| what | was | is |
|---|---|---|
| `status` + `logs` kubeconfig | hardcoded `homelab-infra` path (absent on workbench) | `ls`-both selector, tested in bash **and** zsh on **both** hosts |
| `agent-dispatch.md` clone model | "clones over **SSH**"; `.gh-token` helper "no longer exists" | **HTTPS** — `provision.go:616` = `https://github.com/%s.git`; `values.go:25` defines `gitCredentialHelper` reading `/root/.gh-token` |
| `agent-hardening.md` scope | covers "ANY … including clawgate-provisioned" | scoped to **homelab**; clawgate-provisioned agents get no netpol and `tls.verify:false` |
| Stop hook array | "an unrelated tmux task-hook" | **two** others (`tmux/task-hook.sh`, `claude-notify.py`) |
| e2e skip figure | "17 tests never executed" | **11 of 18 spec files / 77 of 113 tests** on `test.skip(!dockerAvailable())` |
| `sync-clawgate-extension.sh` | "still exists"; retirement "pending" | **deleted from trunk** in `a39ed0c5` |
| silent dispatch | fails "entirely silently" | `provisioningStuckTimeout` (15m) errors the **agent**; the **task** stays `in_progress` |
| changelog range | implied current | stops at **0.7.79**, live is **0.7.85** — said so in the file |
| session memories | 7 listed | 2 do not exist in this project's memory dir |
| vendored chart | re-sync "PENDING" | **done** — `Chart.yaml` = 0.7.1 |
| `CLAWGATE_INSECURE_COOKIES` | documented as live | **dead env var** — no Go code reads it |
| `internals.md` line numbers | `markdown.go:86`, `notes.go:294`, `TaskTitle` @ `:502` | `:88`, `:550`, `:767` |
| migration 0015 | "table `chat_message_parts`" | **no such table** — it only `ALTER`s `chat_messages`; the filename is not a schema object |
| `internals.md` "stale comment" note | says `markdown.go:51-54` is stale | the comment was fixed — **the note is now the stale artifact** |
| FQDN allowlist | `*.fluxcd.io` | bare **`fluxcd.io`** (a matchPattern does not match the apex) + `cdn.dl.k8s.io` |
| SW cache | `clawgate-shell-v2` | **`v4`** (`sw.js:20`) — changed to "read it from source" since it bumps per shell change |
| `CLAWGATE_REQUEST_TTL=5m` | stated as inherent | a **deployment** value; code default is **1h** (`main.go:68`) |

### Two corrections to the audit that produced this list, folded in

- **"no securityContext" was wrong.** The **container** context IS applied by default —
  `allowPrivilegeEscalation: false` + seccomp `RuntimeDefault`, confirmed on a live pod. Only
  `podSecurityContext` is `{}`. Documented precisely rather than repeating the overcorrection.
- **`troubleshooting.md`'s "Needs chart 0.4.0+" is untouched** — a version *floor*, satisfied by 0.7.1.

### One finding beyond the audit
The chart's NetworkPolicy is **Cilium-only**, and **workbench — where clawgate provisions agents —
has 0 Cilium CRDs** (homelab has 11). So that half of the hardening playbook cannot be applied there
at all, not merely "off by default".

## Additions worth their bytes

- 🔴 **`POST /api/auto-approve-all`** — undocumented, and **unauthenticated on the LAN**
  (`server.go:325`, behind the no-op `requireSession`). Arms a timed global window auto-approving
  every future request in **every** project *and* sweeps the existing pending queue; the server logs
  it as `FIREHOSE — every project`. Runbook checkpoints excepted.
- 🔴 **The idle-task reaper** — `defaultTaskReapAfter = 7d` (`server.go:1229`), `CLAWGATE_TASK_TTL`
  **unset in the deployment** so the default is live. Calls the same `dismissTask` as the DELETE, so
  it auto-deletes idle tasks **and tears down their agent pods**.
- Dispatched agent pods live in ns **`devpod-<name>`**, not ns `clawgate`.
- The two hook defer gates that never touch the network (`permission_mode` in
  {`bypassPermissions`,`plan`}, and `AskUserQuestion`) — `hooks.md` read as exhaustive and was not.

## Token efficiency

**`SKILL.md` 14,394 B → 12,284 B**, under the 12,288 B target, *while* absorbing ~1.4 KB of the new
🔴 content above. Demoted to reference files (0 tokens until opened): extension sweep detail, the
deploy GitOps/worktree blocks, the kubeconfig narrative, nebula mechanics, the access model, the
dated loop proof, DELETE depth.

**The biggest lever was not in the skill.** `SKILL.md:14` was a 🔴 instruction to read
`containers/clawgate/HANDOFF.md` **first** — ~190 KB / ~46k tokens, thirteen times the whole skill.
It now says to grep it. Companion PR on `homelab-infra` fixes the file itself.

## Verification — every documented command, run verbatim

| command | host | result |
|---|---|---|
| `status` block | workbench | pod listed, `{"status":"ok",…"version":"0.7.85"}` |
| `status` block | laptop `.155` | identical — the selector resolves to the `homelab-infra` path there |
| kubeconfig selector | both hosts × bash **and** zsh | resolves to the existing file in all 4 combinations |
| `send a test` | workbench | `{"requestId":"req-…"}`; test card deleted afterwards |
| `logs` block | workbench | streamed, grep matched live push/request lines |
| `jq '.hooks.PermissionRequest' …` | workbench | prints the hook entry |
| `bats hook/tests/*.bats` | workbench | **29/29 ok** |
| `deploy.md` smoke `docker run` (minus the dead env var) | workbench | container healthy, `0.7.85` — confirms the removal is safe |

⚠ **`$KC_WORKBENCH` is not the fix** and was not used: it is exported on the workbench only and is
**empty on the laptop even in a login shell**.

## Left unverified (stated so it is not mistaken for clean)
`element-references.md` (entirely), ~9 of 12 `troubleshooting.md` symptom entries, most of
`telemetry.md`, and `changelog.md` beyond its version range. The gap list came from walking the HTTP
routes, **not** the native agent tool definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rCBXqoNtXHpvwEsLwBnJz