### PR TITLE
fix(tests): the no-real-launcher guard covered 1 of 17 targets — attach it where every target is invoked

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -181,6 +181,16 @@ if [ -z "$ROOT" ]; then
   [ -n "$ROOT" ] || ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fi
 
+# 🔴 `unset CDPATH` BEFORE the first `cd`, and it is not hygiene theatre. With
+# CDPATH set in the caller's environment, `cd <dir>` PRINTS the resolved
+# directory on stdout, so the extremely common shell idiom
+# `HERE=$(cd "$(dirname "$0")" && pwd)` yields a TWO-LINE value. MEASURED on the
+# dev host: scripts/tests/test_release_wrapper.sh (a SHELL_TESTS target below)
+# then read `.zshrc` through that doubled path and died with
+# `FAIL: could not extract _release_run` — a red gate whose message points at
+# the wrong thing entirely. The variable is inherited by every child this runner
+# starts, so unsetting it here is the one place that fixes it for all of them.
+unset CDPATH
 cd "$ROOT" || { echo "run-tests: cannot cd to ROOT=$ROOT" >&2; exit 2; }
 # --- GUARD 1: tool precondition ------------------------------------------------
 # Every binary the suites `skipif` on. Absence must be an ERROR, never a skip.
@@ -663,6 +673,90 @@ if [ ! -w "$HOME" ]; then
   export HOME="$(mktemp -d)"
 fi
 
+# --- GUARD 7: NO TEST MAY REACH A REAL LAUNCHER, IN ANY TARGET -----------------
+# 🔴 THE ENFORCEMENT POINT. Read this before touching anything below it.
+#
+# #399 built the mechanism (`scripts/testlib/nolaunch.py`) and installed it from
+# `scripts/tests/conftest.py`. This script runs ONE pytest process per target,
+# and there are 17 of them plus the hook/shell scripts — so that conftest
+# protected exactly ONE. A count of enforcement DECLARATIONS is not a count of
+# protected INSTANCES (claude/RULES.md), and the escape that produced 158 real
+# desktop toasts in 49 minutes came from a seam test run against a tree where
+# the seam did not exist — a shape that can occur in any target.
+#
+# The fix is attached HERE, at the single place every target is invoked, rather
+# than copied into 17 directories: 17 copies drift, and the 18th target gets
+# none. Three exports and one pytest flag:
+#
+#   * a record-only stub dir, FIRST on PATH for this whole script. Covers every
+#     PATH-resolved launch made by anything this runner starts — including the
+#     NON-pytest targets (HOOK_TESTS, SHELL_TESTS), which have no plugin to load.
+#   * `PYTHONPATH` + `-p testlib.nolaunch_plugin` on the pytest line, so every
+#     pytest target ALSO gets the in-process layer that intercepts ABSOLUTE-path
+#     launches by basename. PATH cannot shadow an absolute path — see
+#     `scripts/browser-bridge/server.py`'s `_I3_MSG_FALLBACKS`, which resolves
+#     `/run/current-system/sw/bin/i3-msg` directly whenever `which` misses.
+#   * `-p` deliberately, NOT `PYTEST_PLUGINS=`: the env var is INHERITED by the
+#     nested pytest sessions that `test_no_real_launchers.py` runs as
+#     control/mutant pairs, which would protect the mutant half and turn those
+#     pins green on their own mutants.
+#
+# The plugin writes ONE `nolaunch(session)` marker line per pytest session, and
+# the accounting below REQUIRES exactly one per pytest target. That is the
+# per-target positive control: a target with no marker is a target this guard
+# never loaded in, and "no marker" is otherwise indistinguishable from the
+# reassuring zero of "nothing tried to launch".
+NOLAUNCH_DIR="$(mktemp -d)"
+if ! PYTHONPATH="$ROOT/scripts${PYTHONPATH:+:$PYTHONPATH}" \
+     python -m testlib.nolaunch "$NOLAUNCH_DIR" >/dev/null 2>&1; then
+  echo "run-tests: FATAL — could not install the no-real-launcher stubs into" >&2
+  echo "  $NOLAUNCH_DIR. Refusing to run: the suites reach systemd-run, dunstify," >&2
+  echo "  openrgb and ddcutil, and without these stubs a green run means real" >&2
+  echo "  transient timers and real toasts on the operator's desktop." >&2
+  exit 2
+fi
+NOLAUNCH_LOG="$NOLAUNCH_DIR/launches.log"
+export PATH="$NOLAUNCH_DIR:$PATH"
+export DEVRC_TEST_LAUNCH_STUB_DIR="$NOLAUNCH_DIR"
+export PYTHONPATH="$ROOT/scripts${PYTHONPATH:+:$PYTHONPATH}"
+
+# 🔴 THE ACKNOWLEDGEMENT LEDGER — "<target>|<reason>". A target listed here is
+# EXPECTED to drive launchers into the stub, and is REQUIRED to: an entry whose
+# target records zero intercepts fails the run. That direction is the point.
+# The mutant that matters is not "the guard is deleted" — it is "the guard
+# silently covers nothing while the suite stays green", and a ledger that only
+# PERMITTED intercepts would be green under exactly that mutant.
+NOLAUNCH_ACK=(
+  "scripts/tests|drives monitor-blackout's systemd-run scheduling, rig-control's openrgb/notify-send and bar-status-poll's fire_toast INTO the stub on purpose — those are the seam tests, and their whole value is that the launch really happens and really lands here"
+)
+# Every intercept from any OTHER target is a finding: a test in that target
+# tried to touch the operator's machine and only this guard stopped it.
+NOLAUNCH_SEEN=()
+
+_nolaunch_lines() { # total lines in the launch log (0 when absent)
+  if [ -f "$NOLAUNCH_LOG" ]; then wc -l < "$NOLAUNCH_LOG" | tr -d ' '; else echo 0; fi
+}
+_nolaunch_slice() { # $1 = first line (1-based), $2 = last line
+  [ -f "$NOLAUNCH_LOG" ] || return 0
+  [ "$2" -ge "$1" ] || return 0
+  sed -n "$1,$2p" "$NOLAUNCH_LOG"
+}
+_nolaunch_ack_reason() {
+  local t="$1" entry
+  for entry in "${NOLAUNCH_ACK[@]}"; do
+    [ "${entry%%|*}" = "$t" ] && { printf '%s' "${entry#*|}"; return 0; }
+  done
+  return 1
+}
+
+# ⚠ The "every NOLAUNCH_ACK entry names a real target" pin is deliberately NOT
+# a runtime check here. It was one, and it PREEMPTED ten existing regression
+# tests that build a runner copy with a substituted target list — an earlier
+# check that always wins, so their own findings became unobservable (the
+# unreachable-guard trap in claude/RULES.md). It lives in
+# `scripts/tests/test_no_real_launchers_all_targets.py`, which parses THIS file,
+# the same way TARGET_FLOORS' two-way pin is tested.
+
 # --- GUARD 2: the pinned expected-skip set -------------------------------------
 # One "<dir>|<reason-regex>" per LEGITIMATELY skipped test. Both halves must match
 # a pytest `SKIPPED [n] <path>:<line>: <reason>` line, and the skip TOTAL must
@@ -769,10 +863,16 @@ run_pytest() {
     return 1
   fi
 
-  local log rc
+  local log rc nl_before nl_after
   log="$(mktemp)"
-  python -m pytest "$d" -q -p no:cacheprovider --no-header -rs >"$log" 2>&1
+  nl_before="$(_nolaunch_lines)"
+  # 🔴 `-p testlib.nolaunch_plugin` is GUARD 7 (see its header). It is on THIS
+  # line — the one place every target is invoked — and not in 17 conftests.
+  python -m pytest "$d" -q -p no:cacheprovider -p testlib.nolaunch_plugin \
+    --no-header -rs >"$log" 2>&1
   rc=$?
+  nl_after="$(_nolaunch_lines)"
+  NOLAUNCH_SEEN+=("$d|$(( nl_before + 1 ))|$nl_after")
   cat "$log"
 
   # GUARD 4: parse pytest's summary line. `-q` emits it undecorated, e.g.
@@ -891,12 +991,48 @@ for HOOK_TEST in "${HOOK_TESTS[@]}"; do
     continue
   fi
   echo "=== script $HOOK_TEST ==="
+  nl_before="$(_nolaunch_lines)"
   if python "$HOOK_TEST"; then
     RESULTS+=("PASS  $HOOK_TEST (script)")
   else
     RESULTS+=("FAIL  $HOOK_TEST (script)")
     fail=1
   fi
+  # These are NOT pytest, so they load no plugin: their only protection is the
+  # stub dir this script put first on PATH. They are accounted the same way, and
+  # get no session marker — GUARD 7 requires a marker only from pytest targets.
+  NOLAUNCH_SEEN+=("$HOOK_TEST|$(( nl_before + 1 ))|$(_nolaunch_lines)")
+  echo
+done
+
+# --- SHELL targets -------------------------------------------------------------
+# Bash test scripts. `test_release_wrapper.sh` had been run by NO gate at all
+# since it was written (its own header says `run: bash scripts/tests/
+# test_release_wrapper.sh`, by hand), while creating fake `notify-send`/`git`/
+# `npm` binaries on PATH and driving the real `_release_run` out of `.zshrc`.
+# Nothing forced its stub-prepend to keep inheriting PATH, and nothing ran it.
+# It is here so the guard above covers it too — the stub dir is on PATH for this
+# whole script, so a stub that stopped shadowing lands in the launch log instead
+# of on the operator's desktop.
+SHELL_TESTS=(
+  "scripts/tests/test_release_wrapper.sh"
+)
+for SHELL_TEST in "${SHELL_TESTS[@]}"; do
+  if [ ! -f "$SHELL_TEST" ]; then
+    echo "run-tests: ERROR — shell test '$SHELL_TEST' does not exist (typo, or moved?)." >&2
+    RESULTS+=("FAIL  $SHELL_TEST (missing)")
+    fail=1
+    continue
+  fi
+  echo "=== script $SHELL_TEST ==="
+  nl_before="$(_nolaunch_lines)"
+  if bash "$SHELL_TEST"; then
+    RESULTS+=("PASS  $SHELL_TEST (script)")
+  else
+    RESULTS+=("FAIL  $SHELL_TEST (script)")
+    fail=1
+  fi
+  NOLAUNCH_SEEN+=("$SHELL_TEST|$(( nl_before + 1 ))|$(_nolaunch_lines)")
   echo
 done
 
@@ -961,6 +1097,64 @@ if [ "$TOT_SKIPPED" -ne "${#EXPECTED_SKIPS[@]}" ]; then
   fi
   fail=1
 fi
+
+# --- GUARD 7 (evaluation): per-target launcher accounting ----------------------
+# One line per target, ALWAYS printed — including the zeros. A bare "0 real
+# launches" from a counter nobody has watched move is indistinguishable from a
+# counter wired to nothing, so the acknowledged target's NON-zero count is
+# printed beside every other target's zero, as a pair.
+echo "  ---- launcher intercepts (GUARD 7) ----"
+nolaunch_problems=()
+for t in "${TARGETS[@]}"; do
+  seen=0
+  for entry in "${NOLAUNCH_SEEN[@]}"; do
+    [ "${entry%%|*}" = "$t" ] && seen=1 && break
+  done
+  [ "$seen" -eq 1 ] || nolaunch_problems+=("$t  — never accounted: run_pytest returned before GUARD 7 could measure it")
+done
+
+for entry in "${NOLAUNCH_SEEN[@]}"; do
+  nt="${entry%%|*}"
+  rest="${entry#*|}"
+  nfrom="${rest%%|*}"
+  nto="${rest#*|}"
+  slice="$(_nolaunch_slice "$nfrom" "$nto")"
+  markers=$(printf '%s\n' "$slice" | grep -c '^nolaunch(session)' || true)
+  reads=$(printf '%s\n' "$slice" | grep -c '^systemctl(read)' || true)
+  hits="$(printf '%s\n' "$slice" | grep -vE '^(nolaunch\(session\)|systemctl\(read\)|$)' || true)"
+  nhits=0
+  [ -n "$hits" ] && nhits=$(printf '%s\n' "$hits" | grep -c . || true)
+
+  is_pytest=0
+  for t in "${TARGETS[@]}"; do [ "$t" = "$nt" ] && is_pytest=1 && break; done
+
+  if ack="$(_nolaunch_ack_reason "$nt")"; then
+    echo "    $nt  intercepted=$nhits (ACKNOWLEDGED)  systemctl-reads=$reads  plugin=$markers"
+    # 🔴 The REQUIRED direction: an acknowledged target that intercepts nothing
+    # means the guard is wired to nothing. A ledger that only PERMITTED
+    # intercepts would stay green under the one mutant that matters — the guard
+    # silently covering zero targets.
+    if [ "$nhits" -lt 1 ]; then
+      nolaunch_problems+=("$nt  — acknowledged as a target that DRIVES launchers into the stub, but it intercepted NOTHING. Either the guard stopped being installed, or those seam tests stopped running. Reason on file: $ack")
+    fi
+  else
+    echo "    $nt  intercepted=$nhits  systemctl-reads=$reads  plugin=$markers"
+    if [ "$nhits" -gt 0 ]; then
+      nolaunch_problems+=("$nt  — reached $nhits REAL host launcher(s). They were intercepted and did NOT run; a test in this target tried to touch the operator's machine:"$'\n'"$(printf '%s\n' "$hits" | sed 's/^/           /')")
+    fi
+  fi
+
+  if [ "$is_pytest" -eq 1 ] && [ "$markers" -ne 1 ]; then
+    nolaunch_problems+=("$nt  — the nolaunch plugin emitted $markers session marker(s), expected exactly 1. This target ran WITHOUT the guard, so its zero above means nothing (see GUARD 7's header: -p testlib.nolaunch_plugin on the pytest line).")
+  fi
+done
+
+if [ "${#nolaunch_problems[@]}" -gt 0 ]; then
+  echo "  ERROR: ${#nolaunch_problems[@]} GUARD 7 problem(s):" >&2
+  for p in "${nolaunch_problems[@]}"; do echo "         $p" >&2; done
+  fail=1
+fi
+rm -rf "$NOLAUNCH_DIR"
 
 # GUARD 6. One writer, fed the same value `exit` is about to take, so the
 # printed verdict and the process status cannot disagree — including through a

--- a/scripts/testlib/launcher_scan.py
+++ b/scripts/testlib/launcher_scan.py
@@ -260,3 +260,46 @@ def path_clobbers(tests_dir: Path) -> list[tuple[str, int, str]]:
             src = ast.get_source_segment(text, node) or ""
             out.append((py.name, lineno, " ".join(src.split())[:160]))
     return sorted(out)
+
+
+def absolute_launcher_sites(scripts_root: Path) -> dict[str, list[str]]:
+    """`{relative-path: [literals…]}` for every ABSOLUTE path to a launcher.
+
+    🔴 THE SHAPE NO PATH STUB CAN COVER. A stub directory shadows a launcher by
+    winning the PATH lookup; a literal like
+    `"/run/current-system/sw/bin/i3-msg"` never performs one. That is not
+    hypothetical — `scripts/browser-bridge/server.py`'s `_I3_MSG_FALLBACKS`
+    exists precisely because the browser-bridge systemd --user unit runs with a
+    minimal PATH, and `i3_available()` returns True off it.
+
+    The in-process layer in `testlib.nolaunch_plugin` intercepts these by
+    BASENAME for launches made by the pytest process itself. A launch made by a
+    CHILD process (a shell script execing an absolute path) is covered by
+    NEITHER layer, which is why this scan exists: the set of sites is pinned, so
+    a new one is a decision someone makes in the open rather than a silent hole.
+
+    Scans every `.py` under `scripts_root` (excluding `__pycache__`). It matches
+    STRING LITERALS, so — like `hazard_hits` — it cannot see a path assembled at
+    runtime from pieces. Stated, not implied.
+    """
+    out: dict[str, list[str]] = {}
+    root = Path(scripts_root)
+    for py in sorted(root.rglob("*.py")):
+        if "__pycache__" in py.parts:
+            continue
+        try:
+            module = ast.parse(py.read_text(encoding="utf-8", errors="replace"))
+        except (SyntaxError, OSError):  # pragma: no cover
+            continue
+        found = []
+        for node in ast.walk(module):
+            if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+                continue
+            v = node.value
+            if "/" not in v:
+                continue
+            if v.rsplit("/", 1)[-1] in HAZARD_VOCABULARY:
+                found.append(v)
+        if found:
+            out[str(py.relative_to(root))] = sorted(set(found))
+    return out

--- a/scripts/testlib/nolaunch.py
+++ b/scripts/testlib/nolaunch.py
@@ -263,3 +263,25 @@ def recorded(stub_dir: Path) -> list[str]:
 def blocked_systemctl(stub_dir: Path) -> list[str]:
     """The recorded systemctl calls that were SWALLOWED rather than executed."""
     return [ln for ln in recorded(stub_dir) if ln.startswith("systemctl(blocked)")]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """`python -m testlib.nolaunch <dir>` — install the stubs, print the log path.
+
+    Exists so `scripts/run-tests.sh` can install ONE stub dir for the whole run,
+    before any target starts, and put it first on PATH for everything it
+    invokes — including the targets that are NOT pytest and therefore load no
+    plugin. Same `install()` the plugin calls; the shell needed a door into it,
+    not a second implementation of it.
+    """
+    import sys as _sys
+    args = list(_sys.argv[1:] if argv is None else argv)
+    if len(args) != 1:
+        print("usage: python -m testlib.nolaunch <stub-dir>", file=_sys.stderr)
+        return 2
+    print(install(Path(args[0])))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised via run-tests.sh
+    raise SystemExit(main())

--- a/scripts/testlib/nolaunch_plugin.py
+++ b/scripts/testlib/nolaunch_plugin.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""The ONE place that makes "a test cannot reach a real launcher" true — for
+EVERY pytest target, not for one directory.
+
+🔴 WHAT WAS WRONG WITH THE PREVIOUS SHAPE
+------------------------------------------
+#399 built the mechanism (`testlib/nolaunch.py`) and installed it from
+`scripts/tests/conftest.py`. `scripts/run-tests.sh` runs **one pytest process
+per target directory** and there are 17 of them, so a session-scoped conftest in
+one directory protected **1 of 17**. A guard that reads as systemic covering a
+seventeenth of the surface is the declarations-vs-instances trap from
+claude/RULES.md: the count of enforcement SITES was 1 and looked like enough,
+while the count of protected INSTANCES was 1 of 17.
+
+It was not theoretical. #423's escape (158 real `dunstify` toasts in 49 minutes)
+came from a seam test run against a base-ref sandbox, and the thing that closed
+it was #399's PATH fixture — which existed in exactly one directory.
+
+🔴 WHY A PLUGIN AND NOT 17 CONFTESTS
+-------------------------------------
+Copying a conftest into each target directory would satisfy the coverage count
+and regenerate the bug at 17 sites: 17 copies drift, and the 18th target added
+next month gets none. "One rule, one place" — this module is the rule, and it is
+attached at the single point where every target is invoked
+(`scripts/run-tests.sh`'s `python -m pytest … -p testlib.nolaunch_plugin`), so a
+target added to `HERMETIC_TARGETS` is protected by construction rather than by
+someone remembering.
+
+`scripts/tests/conftest.py` still exists and now loads THIS module, so a bare
+`pytest scripts/tests` outside the runner goes through the same code — one
+implementation, two entry points, no second copy of the logic.
+
+🔴 TWO LAYERS, BECAUSE PATH IS NECESSARY AND DEMONSTRABLY NOT SUFFICIENT
+------------------------------------------------------------------------
+  L1 — PROCESS BOUNDARY (`nolaunch.install()` + PATH[0]).
+       Covers every launch that goes through a PATH lookup, including launches
+       made by CHILD processes (a shell script a test runs, a `subprocess` in
+       production code). This is what run-tests.sh also exports for the
+       NON-pytest targets, which have no plugin to load.
+
+  L2 — IN-PROCESS, BY BASENAME (`_patch_subprocess()`).
+       PATH cannot shadow an ABSOLUTE path. `scripts/browser-bridge/server.py`
+       resolves `i3-msg` through `_I3_MSG_FALLBACKS`
+       (`/run/current-system/sw/bin/i3-msg`, `~/.nix-profile/bin/i3-msg`) when
+       `shutil.which` returns None — which is exactly what happens when a test
+       CLOBBERS PATH. No stub directory can ever shadow that, so L1 is
+       structurally blind to it. L2 keys on the BASENAME of argv[0] instead of
+       on PATH, and rewrites the launch to the stub, so an absolute-path reach
+       lands in the same log as a PATH one.
+
+       Its own limit, stated rather than implied: L2 only sees launches made by
+       THIS python process. A child process that execs an absolute launcher path
+       is invisible to both layers — `testlib.launcher_scan.absolute_launchers()`
+       scans for that shape and pins it instead.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from . import nolaunch
+
+# Published so a test can find the stub dir WITHOUT requesting the fixture —
+# the only way to observe that the protection reached a test that never asked.
+STUB_DIR_ENV = "DEVRC_TEST_LAUNCH_STUB_DIR"
+
+# Written to the launch log once per pytest SESSION. `run-tests.sh` requires
+# exactly one of these per pytest target: it is the per-target positive control
+# for the plugin itself. A guard nobody has watched fire in a given target is
+# indistinguishable from one that does not cover it — and a marker-less target
+# means this plugin never loaded there, which is the failure that would
+# otherwise be a silent zero.
+SESSION_MARKER = "nolaunch(session)"
+
+
+def _log_marker(stub_dir: Path, note: str) -> None:
+    log = nolaunch.log_path(stub_dir)
+    log.parent.mkdir(parents=True, exist_ok=True)
+    with log.open("a", encoding="utf-8") as fh:
+        fh.write(f"{SESSION_MARKER} {note}\n")
+
+
+def _inherited_stub_dir() -> Path | None:
+    """The stub dir `run-tests.sh` already installed, if this session is under it.
+
+    Reusing it rather than making a second one is what lets the runner attribute
+    every intercept to the target that produced it: one log, one dir, one
+    ledger. A session that is NOT under the runner (a bare `pytest …`) gets its
+    own — the protection must not be conditional on the runner.
+    """
+    raw = os.environ.get(STUB_DIR_ENV)
+    if not raw:
+        return None
+    d = Path(raw)
+    # Verified, not trusted: an env var naming a directory that does not carry
+    # the stubs would silently downgrade this session to no protection at all.
+    if not (d / "systemd-run").exists():
+        return None
+    return d
+
+
+# --------------------------------------------------------------------------- #
+# L2 — in-process interception of ABSOLUTE-path launches
+# --------------------------------------------------------------------------- #
+_ORIGINAL_POPEN = subprocess.Popen
+
+
+def _redirect_argv(argv, stub_dir: Path):
+    """Rewrite an absolute-path launcher invocation to the stub. Else None.
+
+    Deliberately narrow — it must not perturb the 7,000 tests that have nothing
+    to do with this:
+      * only a LIST/TUPLE argv (a `shell=True` string goes through /bin/sh,
+        which resolves on PATH, so L1 already owns it);
+      * only when argv[0] contains a path separator (a bare name is a PATH
+        lookup — L1's job, and rewriting it would hide L1 breaking);
+      * only when the BASENAME is a ledgered launcher;
+      * never when it already points into the stub dir.
+    """
+    if not isinstance(argv, (list, tuple)) or not argv:
+        return None
+    first = argv[0]
+    if isinstance(first, bytes):
+        first = os.fsdecode(first)
+    if not isinstance(first, str) or os.sep not in first:
+        return None
+    name = os.path.basename(first)
+    if name not in nolaunch.HOST_LAUNCHERS:
+        return None
+    try:
+        if Path(first).resolve().parent == Path(stub_dir).resolve():
+            return None
+    except OSError:  # pragma: no cover — a path that cannot be resolved
+        pass
+    return [str(Path(stub_dir) / name), *list(argv)[1:]]
+
+
+def _patch_subprocess(stub_dir: Path):
+    """Make `subprocess.Popen` route absolute-path launcher calls to the stub.
+
+    Popen is the choke point: `run`, `call`, `check_call` and `check_output` all
+    go through it, so patching it once covers the whole module rather than four
+    names that must each be remembered.
+    """
+    class _NoLaunchPopen(_ORIGINAL_POPEN):
+        def __init__(self, args, *a, **kw):
+            redirected = _redirect_argv(args, stub_dir)
+            if redirected is not None:
+                log = nolaunch.log_path(stub_dir)
+                with log.open("a", encoding="utf-8") as fh:
+                    fh.write("%s(abs) %s\n" % (os.path.basename(str(args[0])),
+                                               " ".join(str(x) for x in args[1:])))
+                args = redirected
+            super().__init__(args, *a, **kw)
+
+    subprocess.Popen = _NoLaunchPopen
+    return _ORIGINAL_POPEN
+
+
+# --------------------------------------------------------------------------- #
+# The fixture
+# --------------------------------------------------------------------------- #
+@pytest.fixture(scope="session", autouse=True)
+def no_real_launchers(tmp_path_factory):
+    """Prepend a record-only stub dir for every host launcher to PATH.
+
+    Session-scoped and AUTOUSE: protection a test has to remember to ask for is
+    protection the next test forgets — and the test that forgets is the one that
+    fires a toast on someone's desktop. `test_no_real_launchers.py` pins the
+    autouse flag with a control/mutant pair in a nested session, because every
+    test in that file requesting the fixture by name once made deleting the flag
+    completely invisible.
+
+    It composes with per-test stubs rather than fighting them: a test's own stub
+    lives in its `tmp_path`, which still precedes this directory in the child
+    PATH (`test_notify_failure.py` depends on exactly that ordering).
+    """
+    inherited = _inherited_stub_dir()
+    if inherited is not None:
+        stub_dir = inherited
+    else:
+        stub_dir = Path(tmp_path_factory.mktemp("nolaunch"))
+        # install() BEFORE the prepend: the systemctl stub resolves the real
+        # binary through `shutil.which`, so a stub dir already on PATH would
+        # make it exec ITSELF forever. nolaunch.install() asserts on that.
+        nolaunch.install(stub_dir)
+
+    prev_path = os.environ.get("PATH", "")
+    prev_stub = os.environ.get(STUB_DIR_ENV)
+    entries = [p for p in prev_path.split(os.pathsep) if p]
+    # FIRST, unconditionally. A later entry cannot shadow a real binary sitting
+    # in an earlier one, so "on PATH" is not the property that matters —
+    # "before every ambient entry" is.
+    if not entries or entries[0] != str(stub_dir):
+        os.environ["PATH"] = str(stub_dir) + os.pathsep + prev_path
+    os.environ[STUB_DIR_ENV] = str(stub_dir)
+
+    original_popen = _patch_subprocess(stub_dir)
+    _log_marker(stub_dir, " ".join(sys.argv[1:]) or "(no args)")
+    try:
+        yield stub_dir
+    finally:
+        subprocess.Popen = original_popen
+        os.environ["PATH"] = prev_path
+        if prev_stub is None:
+            os.environ.pop(STUB_DIR_ENV, None)
+        else:
+            os.environ[STUB_DIR_ENV] = prev_stub

--- a/scripts/testlib/runner_patch.py
+++ b/scripts/testlib/runner_patch.py
@@ -23,7 +23,30 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 RUN_TESTS = REPO_ROOT / "scripts" / "run-tests.sh"
 
 
-def patch_runner_source(src: str, targets: list[str], floors: dict[str, int]) -> str:
+def _replace_array(src: str, name: str, entries: list[str]) -> str:
+    """Replace a whole `NAME=( … )` bash array literal, asserting the hit.
+
+    Same contract as the two rewrites below: a regex that silently matches
+    nothing leaves the copy identical to the real runner, so the "known-bad
+    state" the caller believes it built never exists and the test passes for a
+    reason unrelated to its subject.
+    """
+    body = "\n".join(f'  "{e}"' for e in entries)
+    patched, n = re.subn(
+        rf"^{name}=\(.*?^\)",
+        f"{name}=(\n{body}\n)" if entries else f"{name}=()",
+        src,
+        count=1,
+        flags=re.S | re.M,
+    )
+    assert n == 1, f"failed to replace {name} in the copied runner"
+    return patched
+
+
+def patch_runner_source(src: str, targets: list[str], floors: dict[str, int], *,
+                        ack: list[str] | None = None,
+                        hook_tests: list[str] | None = None,
+                        shell_tests: list[str] | None = None) -> str:
     """Return `src` with HERMETIC_TARGETS and TARGET_FLOORS replaced wholesale.
 
     Both replacements are asserted to have landed. A silently-unmatched regex
@@ -64,6 +87,17 @@ def patch_runner_source(src: str, targets: list[str], floors: dict[str, int]) ->
         r"^EXPECTED_SKIPS=\(.*?^\)", "EXPECTED_SKIPS=()", patched, count=1, flags=re.S | re.M
     )
     assert n == 1, "failed to empty EXPECTED_SKIPS in the copied runner"
+
+    # GUARD 7's ledger and the two non-pytest target lists. Left ALONE by
+    # default so every existing caller keeps driving the real ones; a caller
+    # that is testing GUARD 7 itself, or that wants a copy which does not pay
+    # for the hook/shell scripts, names them explicitly.
+    if ack is not None:
+        patched = _replace_array(patched, "NOLAUNCH_ACK", ack)
+    if hook_tests is not None:
+        patched = _replace_array(patched, "HOOK_TESTS", hook_tests)
+    if shell_tests is not None:
+        patched = _replace_array(patched, "SHELL_TESTS", shell_tests)
     return patched
 
 
@@ -71,6 +105,7 @@ def runner_with_targets(
     tmp_path: Path,
     targets: list[str],
     floors: dict[str, int] | None = None,
+    **kwargs,
 ) -> Path:
     """Write a patched copy of run-tests.sh into `tmp_path` and return its path.
 
@@ -86,7 +121,8 @@ def runner_with_targets(
         f"targets={sorted(targets)}\nfloors={sorted(floors)}"
     )
     dst = tmp_path / "run-tests.sh"
-    dst.write_text(patch_runner_source(RUN_TESTS.read_text(), targets, floors))
+    dst.write_text(patch_runner_source(RUN_TESTS.read_text(), targets, floors,
+                                       **kwargs))
     return dst
 
 

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -8,68 +8,23 @@ and the authoritative nix-sandbox gate stayed green — the sandbox has none of
 those binaries, so it is structurally blind to the whole class. The full
 measurement and the reasoning live in `scripts/testlib/nolaunch.py`.
 
-ONE mechanism rather than per-file patches: those files build the child PATH as
-`str(tmp_path) + ":" + os.environ["PATH"]`, so prepending a stub directory to
-`os.environ["PATH"]` for the session covers every test that inherits the
-ambient PATH — including tests written tomorrow, which is the half a per-file
-patch cannot do.
-
-It does NOT break tests that legitimately assert on a launcher: a test's own
-stub goes in its `tmp_path`, which sits BEFORE this directory in the child
-PATH, so it still wins (`test_notify_failure.py` depends on exactly that, and
-its graphical case is the positive control that this ordering is right).
+🔴 THE IMPLEMENTATION IS NOT HERE ANY MORE — it is `testlib/nolaunch_plugin.py`,
+and this file only imports it. `scripts/run-tests.sh` runs ONE pytest process
+per target directory and there are 17 of them, so a fixture defined in this
+conftest protected exactly ONE of them; the runner now loads the same module
+with `-p testlib.nolaunch_plugin` for EVERY target. This file remains so that a
+bare `pytest scripts/tests` outside the runner is protected too — by the same
+code, not by a second copy of it. Read that module before changing anything
+here; per-directory copies are precisely what it exists to prevent.
 """
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 
-import pytest
-
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # scripts/
 
-from testlib import nolaunch  # noqa: E402
-
-# 🔴 Published in the ENVIRONMENT, not only as a fixture value, and genuinely
-# read: `test_no_real_launchers.py` uses it in the tests that must NOT request
-# the fixture as a parameter — otherwise turning the autouse flag below off is
-# invisible (measured: identical pass/fail across the whole directory, while the
-# mutant fired real `systemd-run` calls). An earlier revision declared this
-# constant, claimed in a comment that a test read it, and nothing did — the
-# declared-but-never-branched-on shape from claude/RULES.md.
-#
-# ⚠ The word below is a MUTATION SITE: test_autouse_is_what_protects_a_test_
-# that_never_asks asserts it occurs exactly once in this file, so do not spell
-# it again in a comment here (the first attempt did, and the pin went red on its
-# own prose).
-STUB_DIR_ENV = "DEVRC_TEST_LAUNCH_STUB_DIR"
-
-
-@pytest.fixture(scope="session", autouse=True)
-def no_real_launchers(tmp_path_factory):
-    """Prepend a record-only stub dir for every host launcher to PATH.
-
-    Session-scoped and autouse: the protection must not depend on a test
-    remembering to ask for it — a test that forgets is exactly the one that
-    fires a toast on someone's desktop. `install()` runs BEFORE the prepend
-    because the systemctl stub must resolve the REAL binary; see nolaunch.py.
-    """
-    stub_dir = Path(tmp_path_factory.mktemp("nolaunch"))
-    nolaunch.install(stub_dir)
-
-    prev_path = os.environ.get("PATH", "")
-    prev_stub = os.environ.get(STUB_DIR_ENV)
-    # FIRST, unconditionally. A later entry cannot shadow a real binary sitting
-    # in an earlier one, so "on PATH" is not the property that matters — "before
-    # every ambient entry" is.
-    os.environ["PATH"] = str(stub_dir) + os.pathsep + prev_path
-    os.environ[STUB_DIR_ENV] = str(stub_dir)
-    try:
-        yield stub_dir
-    finally:
-        os.environ["PATH"] = prev_path
-        if prev_stub is None:
-            os.environ.pop(STUB_DIR_ENV, None)
-        else:
-            os.environ[STUB_DIR_ENV] = prev_stub
+# Importing a fixture into a conftest REGISTERS it for this directory. That is
+# the whole file: one implementation, two entry points (this import and the
+# runner's `-p` flag), no duplicated logic to drift.
+from testlib.nolaunch_plugin import STUB_DIR_ENV, no_real_launchers  # noqa: E402,F401

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -132,8 +132,13 @@ def test_the_stubbed_launcher_set_is_pinned():
 ACKNOWLEDGED_UNSTUBBED = {
     "systemctl": (
         {"agent-ops", "airvpn-menu", "keylog-spin-capture.sh",
-         "monitor-blackout.sh", "sync-claude-permissions.py"},
+         "monitor-blackout.sh", "run-tests.sh", "sync-claude-permissions.py"},
         "verb-split rather than record-only — see the systemctl tests below. "
+        "run-tests.sh is a THIRD case, re-justified rather than absorbed: its "
+        "only occurrences of the name are GUARD 7's accounting, which counts "
+        "`systemctl(read)` LINES IN THE LAUNCH LOG (`grep -c '^systemctl(read)'`) "
+        "and reports them per target. It never invokes systemctl — it reads the "
+        "record of calls the stub already classified. "
         "sync-claude-permissions.py is a DIFFERENT case from the other four and "
         "is re-justified rather than absorbed: its only occurrence of the name "
         "is the literal string `Bash(systemctl status:*)` inside its CURATED "
@@ -303,17 +308,26 @@ def test_autouse_is_what_protects_a_test_that_never_asks(tmp_path):
     Both halves run the real `scripts/tests/conftest.py`, so this pins the
     shipped file rather than a paraphrase of it.
     """
-    conftest_src = (SCRIPTS / "tests" / "conftest.py").read_text(encoding="utf-8")
+    # 🔴 The fixture MOVED (see conftest.py's header): the implementation now
+    # lives in testlib/nolaunch_plugin.py so that run-tests.sh can load the same
+    # module for all 17 targets with `-p`, instead of 17 conftests. This pin
+    # follows it — it must mutate the SHIPPED file, not a paraphrase, so the
+    # tree is copied rather than symlinked and the copy is what gets mutated.
+    plugin_rel = Path("testlib") / "nolaunch_plugin.py"
+    plugin_src = (SCRIPTS / plugin_rel).read_text(encoding="utf-8")
     needle = "autouse=" + "True"
-    assert conftest_src.count(needle) == 1, (
+    assert plugin_src.count(needle) == 1, (
         f"expected exactly one autouse declaration to mutate, found "
-        f"{conftest_src.count(needle)}")
+        f"{plugin_src.count(needle)}")
+    conftest_src = (SCRIPTS / "tests" / "conftest.py").read_text(encoding="utf-8")
 
-    def _probe_session(where: Path, conftest_text: str):
+    def _probe_session(where: Path, plugin_text: str):
         root = where / "scripts"
         (root / "tests").mkdir(parents=True)
-        (root / "testlib").symlink_to(SCRIPTS / "testlib")
-        (root / "tests" / "conftest.py").write_text(conftest_text, encoding="utf-8")
+        shutil.copytree(SCRIPTS / "testlib", root / "testlib",
+                        ignore=shutil.ignore_patterns("__pycache__"))
+        (root / plugin_rel).write_text(plugin_text, encoding="utf-8")
+        (root / "tests" / "conftest.py").write_text(conftest_src, encoding="utf-8")
         probe = root / "tests" / "test_probe.py"
         probe.write_text(_PROBE_TEST, encoding="utf-8")
         # `_run_nested` strips this session's stub dir from PATH — without that
@@ -322,13 +336,13 @@ def test_autouse_is_what_protects_a_test_that_never_asks(tmp_path):
         # own mutant.
         return _run_nested(str(probe), where / "basetemp")
 
-    control = _probe_session(tmp_path / "control", conftest_src)
+    control = _probe_session(tmp_path / "control", plugin_src)
     assert control.returncode == 0, (
         "a test that never requested the fixture was NOT protected — autouse is "
         f"not doing its job:\n{control.stdout}")
 
     mutant = _probe_session(tmp_path / "mutant",
-                            conftest_src.replace(needle, "autouse=" + "False"))
+                            plugin_src.replace(needle, "autouse=" + "False"))
     assert mutant.returncode != 0, (
         "with autouse removed the probe STILL passed, so nothing here observes "
         f"autouse and the protection is silently opt-in:\n{mutant.stdout}")

--- a/scripts/tests/test_no_real_launchers_all_targets.py
+++ b/scripts/tests/test_no_real_launchers_all_targets.py
@@ -1,0 +1,428 @@
+"""🔴 The guard covers EVERY target, not one directory — and it is reachable.
+
+WHY THIS FILE EXISTS
+--------------------
+#399 built the no-real-launcher mechanism and installed it from
+`scripts/tests/conftest.py`. `scripts/run-tests.sh` runs ONE pytest process per
+target and there are 17 of them, so the guard protected **1 of 17** while
+reading as systemic. `claude/RULES.md` → "a count of DECLARATIONS is not a count
+of INSTANCES": the number that mattered was never the number of conftests.
+
+WHAT IS REGRESSION COVERAGE HERE AND WHAT IS NOT (RULES.md asks for the label):
+
+  * `test_a_target_that_reaches_a_launcher_is_named_and_red` and
+    `test_a_target_running_without_the_plugin_is_named_and_red` are REGRESSION
+    coverage. Both are RED at origin/main — where a target outside
+    `scripts/tests` reaching `notify-send` produces a green run and a real
+    desktop toast — and green here.
+  * `test_the_absolute_path_reach_is_intercepted_in_process` is REGRESSION
+    coverage for the reach a PATH stub structurally cannot cover
+    (`browser-bridge`'s `_I3_MSG_FALLBACKS`). At origin/main the probe binary
+    RUNS; here it does not.
+  * `test_the_acknowledged_target_must_actually_intercept` is the MUTATION test
+    for the mutant that matters: a guard that silently covers ZERO targets while
+    the suite stays green. Nothing else in the tree observes it.
+  * the ledger/target two-way pins and the `-p` flag pin are INVARIANT GUARDS.
+    The bug never violated them; they exist so the enforcement point cannot be
+    narrowed to nothing by an edit that still looks like a guard.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from testlib import nolaunch  # noqa: E402
+from testlib.mockbin import write_exec  # noqa: E402
+from testlib.runner_patch import runner_with_targets, write_pytest_suite  # noqa: E402
+
+RUN_TESTS = SCRIPTS / "run-tests.sh"
+RUNNER_SRC = RUN_TESTS.read_text(encoding="utf-8")
+# 🔴 CODE ONLY. run-tests.sh is 40% commentary and its comments quote the very
+# tokens these pins look for — `python -m pytest`, the plugin flag, the name of
+# the env var that must NOT be used. A pin read off the raw text answers a
+# question about the PROSE. Same reason `test_no_real_launchers.py` assembles
+# its needles from pieces to avoid self-matching.
+RUNNER_CODE = "\n".join(ln for ln in RUNNER_SRC.splitlines()
+                        if not ln.lstrip().startswith("#"))
+
+# Assembled, not spelled, so this file's own text is not a match for the pin in
+# `test_the_plugin_is_loaded_by_flag_not_by_environment`.
+_PLUGIN_ENV_VAR = "PYTEST" + "_PLUGINS"
+_PLUGIN_FLAG = "-p testlib.nolaunch" + "_plugin"
+
+# A probe test that reaches a REAL host launcher by name. This is what a future
+# test in any target might innocently do; the point of the guard is that it
+# becomes a named failure instead of a toast on the operator's desktop.
+_REACHING_TEST = '''\
+import subprocess
+
+
+def test_reaches_a_launcher():
+    subprocess.run(["notify-send", "NOLAUNCH-PROBE", "planted reach"], check=False)
+'''
+
+
+def _run(args: list[str], timeout: int = 600) -> subprocess.CompletedProcess:
+    return subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                          text=True, timeout=timeout, cwd=str(REPO_ROOT))
+
+
+def _pytest_invocations(src: str) -> list[str]:
+    """The lines that actually RUN pytest — not the ones that talk about it.
+
+    `run-tests.sh` both invokes pytest and prints diagnostics quoting the same
+    command, and GUARD 7's own failure message names the plugin flag. Anchoring
+    on "the statement starts with the command" is the difference between reading
+    the code and reading the prose about the code.
+    """
+    return [ln for ln in src.splitlines()
+            if ln.strip().startswith("python -m pytest")
+            and "--version" not in ln]
+
+
+def _bash_array(name: str) -> list[str]:
+    """The entries of a `NAME=( … )` literal in run-tests.sh, unquoted."""
+    m = re.search(rf"^{name}=\((.*?)^\)", RUNNER_SRC, re.S | re.M)
+    assert m, f"{name} not found in run-tests.sh — the pin is reading nothing"
+    out = []
+    for raw in m.group(1).splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.append(line.strip('"'))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# The enforcement point is ONE line, and it is on the line every target uses
+# --------------------------------------------------------------------------- #
+def test_the_single_pytest_invocation_loads_the_plugin():
+    """🔴 The whole design in one assertion: there is exactly ONE `python -m
+    pytest` invocation in the runner, and it carries the plugin.
+
+    That is what makes "all 17 targets" true BY CONSTRUCTION rather than by
+    seventeen copies of a conftest that drift — and it is what makes an
+    18th target protected the day it is added, which is the half a per-directory
+    copy can never do.
+    """
+    invocations = _pytest_invocations(RUNNER_CODE)
+    assert len(invocations) == 1, (
+        "run-tests.sh must invoke pytest from exactly ONE place — the guard is "
+        f"attached to that line. Found {len(invocations)}: {invocations}")
+    assert _PLUGIN_FLAG in invocations[0], (
+        "the single pytest invocation no longer loads the no-real-launcher "
+        f"plugin, so every target runs unprotected:\n  {invocations[0].strip()}")
+
+
+def test_the_plugin_is_loaded_by_flag_not_by_environment():
+    """`-p`, never `PYTEST_PLUGINS=` — and this is not style.
+
+    `PYTEST_PLUGINS` is INHERITED by child processes, and
+    `test_no_real_launchers.py` runs nested pytest sessions as control/mutant
+    pairs whose mutant half MUST be unprotected. Exporting the plugin would
+    protect the mutant and turn those pins green on their own mutants — the
+    "green for the wrong reason" shape from claude/RULES.md.
+    """
+    assert _PLUGIN_ENV_VAR not in RUNNER_CODE, (
+        "run-tests.sh exports PYTEST_PLUGINS; that leaks the guard into the "
+        "nested sessions that must run WITHOUT it")
+
+
+def test_every_acknowledgement_names_a_real_target():
+    """The ledger and the target list pin each other, both ways.
+
+    An acknowledgement that outlives its target is an exemption nobody can see
+    — which is how a wildcard arrives one rename at a time. Kept as a parse of
+    the shipped file rather than a runtime check in the runner, because as a
+    runtime check it PREEMPTED ten existing tests that substitute the target
+    list (an earlier check that always wins; RULES.md → unreachable guards).
+    """
+    targets = _bash_array("HERMETIC_TARGETS")
+    acked = [e.split("|", 1)[0] for e in _bash_array("NOLAUNCH_ACK")]
+    assert acked, "NOLAUNCH_ACK is empty — nothing then requires the guard to fire"
+    unknown = [a for a in acked if a not in targets]
+    assert not unknown, (
+        f"NOLAUNCH_ACK acknowledges targets that are in no target list: {unknown}")
+
+
+def test_the_acknowledgement_is_the_narrowest_it_can_be():
+    """Exactly ONE target may record intercepts, and it is `scripts/tests`.
+
+    A second entry is not forbidden — it is a decision someone has to make in
+    the open. This pin is what stops the ledger being widened quietly until it
+    exempts everything, which is the wildcard mutant one edit at a time.
+    """
+    acked = [e.split("|", 1)[0] for e in _bash_array("NOLAUNCH_ACK")]
+    assert acked == ["scripts/tests"], (
+        "the acknowledgement ledger changed. Every entry is a target allowed to "
+        f"reach a real launcher; there should be exactly one: {acked}")
+
+
+def test_the_non_pytest_targets_are_covered_and_named():
+    """The hook scripts and the shell script are targets too.
+
+    They load no plugin — they are not pytest — so their only protection is the
+    stub dir the runner puts first on PATH for the whole script. That the
+    runner ACCOUNTS them (`NOLAUNCH_SEEN`) is what makes the protection
+    observable rather than assumed.
+    """
+    hooks = _bash_array("HOOK_TESTS")
+    shells = _bash_array("SHELL_TESTS")
+    assert "scripts/claude-hooks/tests/test_claude_notify.py" in hooks
+    assert shells == ["scripts/tests/test_release_wrapper.sh"], shells
+    for rel in hooks + shells:
+        assert (REPO_ROOT / rel).is_file(), f"{rel} is listed but does not exist"
+    # Both loops must feed the accounting, or their zeros mean nothing.
+    assert RUNNER_SRC.count("NOLAUNCH_SEEN+=(") == 3, (
+        "expected exactly three sites to append to NOLAUNCH_SEEN (pytest, hook "
+        "scripts, shell scripts); a loop that stopped accounting reports no "
+        "intercepts for the most reassuring possible reason")
+
+
+# --------------------------------------------------------------------------- #
+# BEHAVIOUR — the guard fires, in a target that is not scripts/tests
+# --------------------------------------------------------------------------- #
+def test_a_target_that_reaches_a_launcher_is_named_and_red(tmp_path):
+    """🔴 PLANT A REACH IN A TARGET, WATCH THE GUARD CATCH IT.
+
+    A throwaway target whose only test calls `notify-send`. At origin/main this
+    is a GREEN run and a real toast; here the run is RED, the target is NAMED,
+    and the intercepted argv is printed. The recorded line is the positive
+    control: a guard that failed the run without recording anything would be
+    reporting something it never observed.
+    """
+    target = tmp_path / "reaching_tests"
+    write_pytest_suite(target, 1, prefix="test_filler")
+    (target / "test_reach.py").write_text(_REACHING_TEST, encoding="utf-8")
+    runner = runner_with_targets(tmp_path, [str(target)], {str(target): 1},
+                                 hook_tests=[], shell_tests=[])
+    proc = _run(["bash", str(runner), str(REPO_ROOT)])
+    out = proc.stdout + proc.stderr
+
+    assert proc.returncode != 0, f"a planted reach produced a PASSING run:\n{out}"
+    assert "GUARD 7 problem" in out, (
+        f"the run failed, but not for the launcher reason:\n{out}")
+    assert str(target) in out, f"the failure did not NAME the target:\n{out}"
+    assert "notify-send NOLAUNCH-PROBE planted reach" in out, (
+        f"the guard reported a reach it never actually recorded:\n{out}")
+
+
+def test_a_target_running_without_the_plugin_is_named_and_red(tmp_path):
+    """🔴 THE MUTANT THAT MATTERS: the guard covering ZERO targets, silently.
+
+    Strip `-p testlib.nolaunch_plugin` from the copy — the shape of every
+    "narrow the glob / comment it out / invert the membership test" mutation,
+    whose whole danger is that the suite stays green. The session marker is what
+    makes it observable: no marker means the guard never loaded there, and
+    without this check that target's `intercepted=0` is indistinguishable from
+    real protection.
+    """
+    target = tmp_path / "plain_tests"
+    write_pytest_suite(target, 2, prefix="test_plain")
+    runner = runner_with_targets(tmp_path, [str(target)], {str(target): 1},
+                                 hook_tests=[], shell_tests=[])
+    src = runner.read_text(encoding="utf-8")
+    code_hits = _pytest_invocations(src)
+    assert len(code_hits) == 1 and _PLUGIN_FLAG in code_hits[0], (
+        f"expected exactly one live site to mutate, found {code_hits}")
+    runner.write_text(
+        src.replace(code_hits[0], code_hits[0].replace(" " + _PLUGIN_FLAG, "")),
+        encoding="utf-8")
+
+    proc = _run(["bash", str(runner), str(REPO_ROOT)])
+    out = proc.stdout + proc.stderr
+    assert proc.returncode != 0, (
+        f"a target that ran with NO guard at all produced a PASSING run:\n{out}")
+    assert "session marker" in out, (
+        f"the run failed, but not because the plugin was missing:\n{out}")
+
+
+def test_the_control_of_that_mutant_is_green(tmp_path):
+    """The positive control for the two tests above: unmutated, a plain target
+    with no reach PASSES. Without this, "the run went red" is satisfied by the
+    runner being red about anything at all."""
+    target = tmp_path / "clean_tests"
+    write_pytest_suite(target, 2, prefix="test_clean")
+    runner = runner_with_targets(tmp_path, [str(target)], {str(target): 1},
+                                 hook_tests=[], shell_tests=[])
+    proc = _run(["bash", str(runner), str(REPO_ROOT)])
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 0, f"the clean control run was not green:\n{out}"
+    assert f"{target}  intercepted=0" in out, (
+        f"the per-target intercept line is missing — the accounting that the "
+        f"other tests read is not actually printed:\n{out}")
+    assert "plugin=1" in out, f"the plugin marker was not recorded:\n{out}"
+
+
+def test_the_acknowledged_target_must_actually_intercept(tmp_path):
+    """🔴 A LEDGER THAT ONLY PERMITS IS GREEN UNDER THE MUTANT THAT MATTERS.
+
+    Acknowledge a target that reaches nothing. If the ledger merely tolerated
+    intercepts, this would pass — and so would a guard that had been narrowed
+    until it covered nothing at all, because "no intercepts anywhere" is the
+    observable those two states SHARE. The required direction is what tells them
+    apart, and it is the reason `scripts/tests` is the acknowledged one: it is
+    the target that provably drives launchers into the stub.
+    """
+    target = tmp_path / "quiet_tests"
+    write_pytest_suite(target, 2, prefix="test_quiet")
+    runner = runner_with_targets(
+        tmp_path, [str(target)], {str(target): 1},
+        ack=[f"{target}|planted acknowledgement for a target that reaches nothing"],
+        hook_tests=[], shell_tests=[])
+    proc = _run(["bash", str(runner), str(REPO_ROOT)])
+    out = proc.stdout + proc.stderr
+    assert proc.returncode != 0, (
+        f"an acknowledged target that intercepted NOTHING was accepted — the "
+        f"ledger cannot tell a live guard from a dead one:\n{out}")
+    assert "intercepted NOTHING" in out, (
+        f"the run failed, but not for the dead-guard reason:\n{out}")
+
+
+def test_the_runner_puts_the_stub_dir_FIRST_not_merely_on_path(tmp_path):
+    """🔴 A SURVIVING MUTANT, closed: `PATH=$PATH:$NOLAUNCH_DIR`.
+
+    "On PATH" is not the property that matters — an entry AFTER the ambient
+    directories shadows nothing. The pytest targets do not observe this (their
+    plugin prepends for itself); the NON-pytest targets do, because the runner's
+    PATH is their ONLY protection.
+
+    Measured without touching a real binary: a DECOY directory carrying its own
+    `notify-send` is placed on PATH before the runner starts. Whoever wins the
+    lookup is then observable — the stub (witness absent, intercepted=1) or the
+    decoy (witness present). Under the mutant the decoy wins, which is exactly
+    what a real launcher would do.
+    """
+    decoy = tmp_path / "decoy"
+    decoy.mkdir()
+    witness = tmp_path / "DECOY-WON"
+    write_exec(decoy / "notify-send", f'printf won > "{witness}"\nexit 0\n')
+
+    shell_test = tmp_path / "shell_probe.sh"
+    shell_test.write_text('notify-send probe-from-a-shell-target\nexit 0\n',
+                          encoding="utf-8")
+    target = tmp_path / "plain_tests"
+    write_pytest_suite(target, 1, prefix="test_plain")
+    runner = runner_with_targets(tmp_path, [str(target)], {str(target): 1},
+                                 hook_tests=[], shell_tests=[str(shell_test)])
+
+    env = {**os.environ, "PATH": f"{decoy}{os.pathsep}{os.environ['PATH']}"}
+    proc = subprocess.run(["bash", str(runner), str(REPO_ROOT)],
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                          text=True, timeout=600, cwd=str(REPO_ROOT), env=env)
+    out = proc.stdout + proc.stderr
+
+    assert not witness.exists(), (
+        "a directory that was on PATH BEFORE the runner started won the lookup, "
+        "so the stub dir is merely ON PATH rather than FIRST — every non-pytest "
+        f"target is unprotected:\n{out}")
+    assert f"{shell_test}  intercepted=1" in out, (
+        f"the shell target's reach was not intercepted and accounted:\n{out}")
+
+
+# --------------------------------------------------------------------------- #
+# The reach a PATH stub structurally CANNOT cover
+# --------------------------------------------------------------------------- #
+def test_the_absolute_path_reach_is_intercepted_in_process(tmp_path,
+                                                           no_real_launchers):
+    """🔴 PATH cannot shadow an ABSOLUTE path — so the guard stops keying on PATH.
+
+    `scripts/browser-bridge/server.py` resolves `i3-msg` through
+    `_I3_MSG_FALLBACKS` (`/run/current-system/sw/bin/i3-msg`,
+    `~/.nix-profile/bin/i3-msg`) whenever `shutil.which` misses — which is
+    exactly what a test that CLOBBERS PATH causes. No stub directory can ever
+    shadow that, in either tier.
+
+    The probe is a real executable of our own named `i3-msg`, invoked by
+    absolute path. Its side effect (a file) is the positive control: if the
+    in-process layer is not there, the file EXISTS — the same measurement at
+    origin/main, where it does.
+    """
+    fake_dir = tmp_path / "elsewhere"
+    fake_dir.mkdir()
+    witness = tmp_path / "IT-RAN"
+    write_exec(fake_dir / "i3-msg", f'printf ran > "{witness}"\nexit 0\n')
+
+    before = len(nolaunch.recorded(no_real_launchers))
+    subprocess.run([str(fake_dir / "i3-msg"), "workspace", "9"], check=False,
+                   capture_output=True)
+
+    assert not witness.exists(), (
+        "the absolute-path launcher RAN. PATH cannot shadow an absolute path, "
+        "so this is the reach the stub dir is structurally blind to")
+    lines = nolaunch.recorded(no_real_launchers)[before:]
+    assert any(ln.startswith("i3-msg(abs)") for ln in lines), (
+        f"nothing was recorded for the absolute-path reach: {lines}")
+
+
+def test_the_absolute_path_sites_are_pinned():
+    """The set of ABSOLUTE launcher paths in the tree, pinned both ways.
+
+    A stub directory cannot shadow these and the in-process layer only covers
+    launches made by the pytest process itself — a CHILD process execing one is
+    covered by NEITHER layer. So the SET is the guard: it fails when it grows
+    (a new hole) and when it shrinks (the scan stopped seeing anything, which
+    would make its reassuring emptiness worthless).
+
+    ⚠ Stated limit, because this pin can be believed too much: the scan matches
+    string LITERALS. `_I3_MSG_FALLBACKS`' second entry is assembled at runtime
+    (`Path.home() / ".nix-profile" / "bin" / "i3-msg"`) and is invisible to it.
+    """
+    from testlib import launcher_scan
+    sites = launcher_scan.absolute_launcher_sites(SCRIPTS)
+    # 🔴 SELF-MATCH, handled explicitly rather than by excluding this file from
+    # the scan. The pin below QUOTES the literals it pins, so this module is
+    # itself a hit — the same trap `shebang_scan` builds its needles from
+    # character codes to avoid. Popping it silently would be an exemption
+    # nobody could see, so it is asserted: if this file's own literals change,
+    # this line goes red too.
+    own = sites.pop("tests/test_no_real_launchers_all_targets.py", None)
+    assert own == ["/run/current-system/sw/bin/i3-msg", "/usr/bin/i3-msg"], (
+        "this file's own quoted literals changed — the pin below and this "
+        f"self-match acknowledgement have drifted apart: {own}")
+    assert sites == {
+        "browser-bridge/server.py": ["/run/current-system/sw/bin/i3-msg"],
+        "browser-bridge/tests/test_server.py": [
+            "/run/current-system/sw/bin/i3-msg", "/usr/bin/i3-msg"],
+    }, (
+        "the set of absolute-path launcher sites changed. Each one is a reach no "
+        "PATH stub can shadow; a new entry needs a decision, not an update.\n"
+        f"{sites}")
+
+
+def test_the_in_process_layer_leaves_ordinary_subprocesses_alone(tmp_path):
+    """The negative control for the interception above.
+
+    A guard that rewrote argv indiscriminately would silently corrupt thousands
+    of unrelated tests, and its damage would read as flakiness. Only a
+    LEDGERED basename at an ABSOLUTE path is touched.
+    """
+    witness = tmp_path / "ordinary-ran"
+    tool = tmp_path / "definitely-not-a-launcher"
+    write_exec(tool, f'printf ran > "{witness}"\nexit 0\n')
+    subprocess.run([str(tool)], check=False, capture_output=True)
+    assert witness.read_text() == "ran"
+
+
+@pytest.mark.parametrize("argv", [
+    (["notify-send", "bare-name"]),              # PATH lookup — L1's job
+    ([]),                                        # degenerate
+])
+def test_the_interception_declines_what_is_not_its_business(argv, tmp_path):
+    """`_redirect_argv` is deliberately narrow; these must not be rewritten.
+
+    A bare name is a PATH lookup, which the stub dir already owns — rewriting it
+    here would HIDE the stub dir having stopped working, which is the one
+    failure this file most needs to stay able to see.
+    """
+    from testlib import nolaunch_plugin
+    assert nolaunch_plugin._redirect_argv(argv, tmp_path) is None

--- a/scripts/tests/test_release_wrapper.sh
+++ b/scripts/tests/test_release_wrapper.sh
@@ -40,11 +40,19 @@ fi
 source "$FN"
 
 # ── fake binaries earlier on PATH ────────────────────────────────────────
+# 🔴 `#!/bin/sh`, NOT `#!/usr/bin/env bash`. This script had never been run by
+# any gate; the first run of it inside `nix build .#checks…pytests` was RED,
+# because the sandbox has no `/usr/bin/env` and all three stubs failed to exec.
+# The damage was not merely red: case 1 ("outside a civitai repo → refuses")
+# went GREEN for the wrong reason — the `git` stub could not run, so
+# `rev-parse --show-toplevel` produced nothing and the guard refused for a
+# reason the test was not measuring. Same trap `scripts/testlib/mockbin.py`
+# exists to stop, in the one file that could not import it (it is bash).
 BIN="$SANDBOX/bin"
 mkdir -p "$BIN"
 
 cat > "$BIN/git" <<'EOF'
-#!/usr/bin/env bash
+#!/bin/sh
 # `git rev-parse --show-toplevel` → the fake repo root (guard input).
 if [ "$1" = "rev-parse" ]; then echo "${FAKE_REPO_ROOT:-}"; exit 0; fi
 printf 'git %s\n' "$*" >> "$ORDER_LOG"   # record fetch (and anything else)
@@ -52,13 +60,13 @@ exit 0
 EOF
 
 cat > "$BIN/npm" <<'EOF'
-#!/usr/bin/env bash
+#!/bin/sh
 printf 'npm %s\n' "$*" >> "$ORDER_LOG"
 exit "${NPM_RC:-0}"
 EOF
 
 cat > "$BIN/notify-send" <<'EOF'
-#!/usr/bin/env bash
+#!/bin/sh
 printf 'notify %s\n' "$*" >> "$ORDER_LOG"
 exit 0
 EOF

--- a/scripts/tests/test_runtime_shebangs.py
+++ b/scripts/tests/test_runtime_shebangs.py
@@ -52,7 +52,15 @@ sys.path.insert(0, str(REPO / "scripts"))
 from testlib import shebang_scan as S  # noqa: E402
 
 SCAN_ROOT = REPO / "scripts"
-PATTERNS = ("test_*.py", "conftest.py")
+# 🔴 `test_*.sh` was ADDED after this scan was measured blind to the one file
+# that carried the defect. `scripts/tests/test_release_wrapper.sh` writes three
+# runtime stubs and gave all three the `/usr/bin/env` shebang; the glob said
+# `test_*.py`, so this guard was structurally incapable of seeing it — the same
+# "narrow the glob until it covers nothing" shape it exists to catch. Nothing
+# noticed for a SECOND reason: no gate ran that file at all until GUARD 7's
+# SHELL_TESTS brought it under `run-tests.sh`, and its first run inside the nix
+# sandbox was RED — with case 1 passing for the wrong reason, which is worse.
+PATTERNS = ("test_*.py", "conftest.py", "test_*.sh")
 
 # --- THE PINNED ALLOWLIST ------------------------------------------------------
 # (relative path, substring the offending line must contain, why it is safe).


### PR DESCRIPTION
`scripts/run-tests.sh` runs **one pytest process per target directory** and there are
**17** of them (plus 5 hook scripts and, now, 1 shell script). #399's mechanism was
installed from `scripts/tests/conftest.py`, so it protected **1 of 17** while reading as
systemic — `claude/RULES.md` → *a count of DECLARATIONS is not a count of INSTANCES*.
This attaches the guard at the single point every target is invoked, and proves it fires
in each one.

---

## The enforcement point

One stub-dir install and one pytest flag, in `scripts/run-tests.sh`:

```bash
python -m testlib.nolaunch "$NOLAUNCH_DIR"     # install once, before any target
export PATH="$NOLAUNCH_DIR:$PATH"              # covers everything this script starts
export PYTHONPATH="$ROOT/scripts:…"
…
python -m pytest "$d" -q -p no:cacheprovider -p testlib.nolaunch_plugin …
```

* **L1 — process boundary.** The record-only stub dir is FIRST on PATH for the whole
  runner, so it covers every PATH-resolved launch, including ones made by *child*
  processes and by the **non-pytest** targets, which have no plugin to load.
* **L2 — in-process, by BASENAME** (`testlib/nolaunch_plugin.py`). PATH cannot shadow an
  absolute path. `browser-bridge/server.py` resolves `i3-msg` through
  `_I3_MSG_FALLBACKS` (`/run/current-system/sw/bin/i3-msg`) whenever `shutil.which`
  misses — which is what a PATH-clobbering test causes. L2 patches `subprocess.Popen`
  (the choke point behind `run`/`call`/`check_output`) and redirects a ledgered basename
  at an absolute path into the stub.
* **GUARD 7 accounting.** The runner attributes every intercept to the target that
  produced it and prints a line per target, always — including the zeros. The plugin
  writes one `nolaunch(session)` marker per pytest session and the runner **requires
  exactly one per pytest target**: a target with no marker never loaded the guard, and
  without that check its `intercepted=0` is indistinguishable from real protection.
* **`NOLAUNCH_ACK`** — one entry (`scripts/tests`), and it is a **requirement, not a
  permission**: an acknowledged target that intercepts *nothing* fails the run. A ledger
  that merely tolerated intercepts would stay green under the only mutant that matters —
  the guard silently covering zero targets.

### Why not a conftest per directory

17 copies drift, and the 18th target added next month gets none — the same
one-rule-many-places shape that regenerates a bug at every site. The runner's pytest line
is the one place that already enumerates every target, so a target added to
`HERMETIC_TARGETS` is protected **by construction**. `scripts/tests/conftest.py` survives
as a 3-line import of the same module, so a bare `pytest scripts/tests` outside the runner
runs the same code — one implementation, two entry points.

`-p` and **not** `PYTEST_PLUGINS=`: the env var is inherited by child processes, and
`test_no_real_launchers.py` runs nested pytest sessions as control/mutant pairs whose
mutant half must be *unprotected*. Exporting it would have turned those hard-won pins
green on their own mutants.

---

## Audit of all 17 targets (+ the 6 non-pytest ones)

"None" is a row, not an omission. Reaches were found in **3** of 17.

| # | target | launcher reachable | route | what held it BEFORE this PR |
|---|---|---|---|---|
| 1 | `scripts/tests` | systemd-run, notify-send, dunstify, dunstctl, rofi, yad, openrgb, ddcutil, xdg-open, systemctl(mutating) | executes the top-level desktop scripts | **structural** — #399's conftest fixture |
| 2 | `scripts/collector/tests` | none | — | n/a (but see the unpinned PATH clobber below) |
| 3 | `scripts/collector/keylog/tests` | none | `espanso` appears only as a *kind* string; no subprocess at all | n/a |
| 4 | `scripts/collector/claude/tests` | none | — | n/a |
| 5 | `scripts/collector/i3/tests` | none | i3 IPC socket only, no `i3-msg` | n/a |
| 6 | `scripts/collector/browser-ext/tests` | none | — | n/a |
| 7 | `scripts/collector/opencode/tests` | none | subprocesses are node/python only | n/a |
| 8 | `scripts/dl-router/tests` | none | `setup-brave-profile.sh` invokes no launcher | n/a |
| 9 | `scripts/browser-bridge/tests` | **i3-msg** | `test_server.py` → `server.py:2109 _resolve_i3_msg()` → `:2114 subprocess.run(argv)` | **one line**: autouse `_disable_i3`, `test_server.py:144` |
| 10 | `scripts/validation/tests` | **xdotool** | `test_replay_assert.py:46` → `replay.py:225 subprocess.run(["xdotool", …], check=True)` | **one line**: `monkeypatch.delenv("DISPLAY")`, `test_replay_assert.py:45`, tripping `replay.py:222` |
| 11 | `scripts/session-analysis/tests` | none reachable | `espanso-usage.py:875` runs `systemctl --user is-active` (read verb) | structural DI — the runner is a parameter |
| 12 | `scripts/session-analysis/session_insight/tests` | none | — | n/a |
| 13 | `scripts/mail-actions/tests` | none | — | n/a |
| 14 | `scripts/initiatives/tests` | none | 27 subprocess sites, all viewer/python | n/a |
| 15 | `scripts/repo-cos/tests` | none | `"espanso-typing-toil"` is a topic label | n/a |
| 16 | `scripts/task-spec-drafter/tests` | none | `Bash(systemd-run:*)` is inside a **deny**-list string | n/a |
| 17 | `scripts/claude-hooks/tests/test_guard_core.py` | none | 20 subprocess sites, all `sys.executable`/`git` | n/a |
| H1-H5 | the 5 `HOOK_TESTS` scripts | **dunstify, notify-send** (`test_claude_notify.py` → `claude-notify.py:152`) | bare names, PATH-resolved | **one line**: its own prepend, `test_claude_notify.py:58` |
| S1 | `scripts/tests/test_release_wrapper.sh` | **notify-send** | writes a stub, drives `_release_run` from `.zshrc` | **one line**: `export PATH="$BIN:$PATH"`, `:67` — **and no gate ran the file at all** |

### Corrections to the brief

* **`test_claude_notify.py` is NOT "collected by no gate at all".** It is run by
  `run-tests.sh:879` in `HOOK_TESTS`, as a script — it is not pytest-collectable (module
  scope asserts + `sys.exit`), so it contributes no counts and has no floor. Its dunstify
  reach is real but held by its own prepend-and-inherit.
* **`test_release_wrapper.sh` does not clobber PATH** — it prepends and inherits. What is
  true is that **no gate ran it**, which is now fixed (see below).
* All four named reaches confirmed otherwise; `browser-bridge`'s is the one no PATH stub
  can cover.

---

## Bringing the shell target under the gate found a live defect

`test_release_wrapper.sh` is now a `SHELL_TESTS` entry, so the runner executes it and it
inherits the stub dir. Its **first run inside `nix build .#checks…pytests` was RED**: all
three of its runtime stubs carried `#!/usr/bin/env bash`, which does not exist in the
sandbox — the exact trap `scripts/testlib/mockbin.py` exists to prevent, in the one file
that cannot import it because it is bash.

Worse than red: **case 1 ("outside a civitai repo → refuses") passed for the wrong
reason** — the `git` stub could not exec, so `rev-parse --show-toplevel` produced nothing
and the guard refused for a reason the test was not measuring.

`scripts/tests/test_runtime_shebangs.py`'s scan could not see it: its glob was
`("test_*.py", "conftest.py")`. That is *"narrow the glob until it covers nothing"* — the
same mutation class as this PR's subject, already live. Glob widened to include
`test_*.sh`; positive control on the pre-fix file: **3 offenders found, 0 after the fix**.

A second, unrelated fix the shell target forced: `unset CDPATH` before the runner's first
`cd`. With CDPATH set, `cd x && pwd` *prints* the directory, so
`HERE=$(cd "$(dirname "$0")" && pwd)` yields a two-line value and the script read
`.zshrc` through a doubled path. One `unset` at the top fixes it for every child.

---

## Per-target positive control — the coverage deliverable

A reach was planted in **every** target at once (a PATH-resolved `notify-send`, plus for
pytest targets an ABSOLUTE-path `i3-msg` pointing at an executable of our own whose only
job is to leave a witness file), and `run-tests.sh` was run once. `intercepted` is the
guard's own accounting; `named` means GUARD 7 printed that target with its argv.

| target | intercepted | plugin marker | named by GUARD 7 | witness (L2 failed?) |
|---|---|---|---|---|
| `scripts/tests` | **74** (71 baseline + 3 planted) | 1 | ACKNOWLEDGED | no |
| `scripts/collector/tests` | 3 | 1 | ✅ | no |
| `scripts/collector/keylog/tests` | 3 | 1 | ✅ | no |
| `scripts/collector/claude/tests` | 3 | 1 | ✅ | no |
| `scripts/collector/i3/tests` | 3 | 1 | ✅ | no |
| `scripts/collector/browser-ext/tests` | 3 | 1 | ✅ | no |
| `scripts/collector/opencode/tests` | 3 | 1 | ✅ | no |
| `scripts/dl-router/tests` | 3 | 1 | ✅ | no |
| `scripts/browser-bridge/tests` | 3 | 1 | ✅ | no |
| `scripts/validation/tests` | 3 | 1 | ✅ | no |
| `scripts/session-analysis/tests` | 3 | 1 | ✅ | no |
| `scripts/session-analysis/session_insight/tests` | 3 | 1 | ✅ | no |
| `scripts/mail-actions/tests` | 3 | 1 | ✅ | no |
| `scripts/initiatives/tests` | 3 | 1 | ✅ | no |
| `scripts/repo-cos/tests` | 3 | 1 | ✅ | no |
| `scripts/task-spec-drafter/tests` | 3 | 1 | ✅ | no |
| `scripts/claude-hooks/tests/test_guard_core.py` | 3 | 1 | ✅ | no |
| `…/test_shell_env_nudge.py` (hook) | 1 | n/a | ✅ | n/a |
| `…/test_search_tool_nudge.py` (hook) | 1 | n/a | ✅ | n/a |
| `…/test_claude_notify.py` (hook) | 1 | n/a | ✅ | n/a |
| `…/test_register_nudge_hook.py` (hook) | 1 | n/a | ✅ | n/a |
| `…/test_bash_guard.py` (hook) | 1 | n/a | ✅ | n/a |
| `scripts/tests/test_release_wrapper.sh` (shell) | 1 | n/a | ✅ | n/a |

`RESULT: FAIL (exit=1)`, **22 GUARD 7 problems**, each naming its target and printing the
argv it tried. **0 witnesses** (L2 held in all 17 pytest targets) and **0 escapes** past
the guard to the recording interceptor (L1 held everywhere). The 3 lines per pytest target
are `notify-send …` (L1), `i3-msg(abs) …` (L2 recording the redirect) and `i3-msg …` (the
stub itself), so the two layers are observed separately, not inferred.

**Reachability, not just breakability:** each red is the GUARD 7 message specifically —
`— reached N REAL host launcher(s)` with the argv — not an earlier check. The
unmutated run of the same tree is green with the same accounting printed
(`intercepted=0 … plugin=1` for all 16), so the red is about the planted reach.

---

## Coverage: what is covered and what is structurally NOT

**Covered**

| reach | layer | evidence |
|---|---|---|
| #2 `validation/replay.py` bare `xdotool` | L1 | target 10 planted-reach row |
| #3 `test_claude_notify.py` `dunstify`/`notify-send` | L1 (runner PATH) | hook row |
| #4 `test_release_wrapper.sh` `notify-send` | L1 (runner PATH) | shell row |
| #1 `browser-bridge` absolute `i3-msg` | **L2** | `test_the_absolute_path_reach_is_intercepted_in_process` — RED at `origin/main` with *"the absolute-path launcher RAN"*, green here |
| any future target added to `HERMETIC_TARGETS` | L1+L2 | by construction — one pytest line |

**Structurally NOT covered — stated, not implied**

1. **A CHILD process that execs an ABSOLUTE launcher path.** L1 keys on PATH, L2 only sees
   launches made by the pytest process itself. Nothing in the tree does this today;
   `launcher_scan.absolute_launcher_sites()` now pins the set of absolute launcher
   literals in the tree (both directions), so a new one is a decision in the open.
2. **A test that CLOBBERS PATH** and then spawns a child that resolves a launcher. The two
   sites in `scripts/tests` remain pinned by #423's AST scan. 🔴 **A third, unpinned site
   exists and this PR does not close it**: `scripts/collector/tests/test_ch_regrowth.py:1092`
   sets `env={"PATH": "/usr/bin:/bin", …}` — a *real* binary directory, unlike the two
   harmless pinned ones. `launcher_scan.path_clobbers()` is only ever run against
   `scripts/tests`. Nothing reaches a launcher through it today (the child spawns nothing);
   it is reported rather than fixed.
3. **A launcher nobody has thought of.** `HOST_LAUNCHERS` and `HAZARD_VOCABULARY` are lists
   of NAMES. Unchanged limit, restated because L2 keys on the same list.
4. **A path assembled at runtime.** `_I3_MSG_FALLBACKS`' second entry is
   `Path.home() / ".nix-profile" / "bin" / "i3-msg"` — invisible to the literal scan (L2
   still intercepts it at launch time, since L2 keys on the basename of the *resolved*
   argv).

`browser-bridge/server.py` is deliberately **not** changed. Its absolute fallback exists
because the browser-bridge `systemd --user` unit runs with a minimal PATH; making
production code test-aware would be the paper-over. The structural fix is that the guard
stops keying on PATH and starts keying on the basename of what is being executed, which is
the property that actually matters.

---

## Mutation battery

Every mutant on a purged copy (`python -B`, `PYTHONDONTWRITEBYTECODE=1`, no `__pycache__`),
weighted away from deletion. Proxy suite: `test_no_real_launchers_all_targets.py` +
`test_no_real_launchers.py`.

🔴 **The first two runs of this battery were invalid and are reported rather than hidden.**
Run 1's *control* was red (a self-match in the new absolute-path pin), which makes every
mutant's red unreadable. Run 2 reported **six survivors that were not mutants at all** —
the edits were passed through an unquoted bash heredoc, so `$` and backslashes were eaten
and six mutations silently no-op'd, each reporting the control's own result. The harness
now applies every mutation from a Python module that **exits non-zero if the edit does not
land**, and prints the byte delta. Instrument before verdict.

| # | mutant | result | killed by |
|---|---|---|---|
| control | unmutated | **85 passed, rc=0** | — (battery readable) |
| m1 | invert the membership test (`if !` on the ack lookup) | KILLED | 3 tests |
| m2 | wildcard exemption (ack matcher always succeeds) | KILLED | 2 tests |
| m3 | drop `-p testlib.nolaunch_plugin` — *the guard covers zero targets* | KILLED | `…_loads_the_plugin`, `…_running_without_the_plugin_is_named_and_red` |
| m4 | comment out the whole GUARD 7 evaluation, text preserved | KILLED | 5 tests |
| m5 | off-by-one the target list (drop the last `HERMETIC_TARGETS` entry) | **SURVIVED the proxy** | killed by the pre-existing `TARGET_FLOORS` two-way pin — measured: `run-tests.sh --check-floors` → `FATAL … pinned in TARGET_FLOORS but in NO target list`, exit 2 |
| m6 | `PATH="$PATH:$NOLAUNCH_DIR"` (on PATH but not FIRST) | **survived, gap CLOSED in this PR** → now KILLED | new `test_the_runner_puts_the_stub_dir_FIRST_not_merely_on_path` |
| m7 | L2 declines everything | KILLED | the absolute-path test |
| m8 | session marker never written | KILLED | the green-control test |
| m9 | the pytest loop stops accounting | KILLED | 5 tests |
| m10 | ack requirement `-lt 1` → `-lt 0` (permission, not requirement) | KILLED | `…_must_actually_intercept` |
| m11 | stubs never installed | KILLED | 47 tests |
| m12 | `autouse=False` on the shared fixture | KILLED | the #423 nested control/mutant pair, repointed at the plugin |
| m13 | `NOLAUNCH_ACK=()` — the ledger emptied | KILLED | 3 tests |
| m14 | invert the intercept check (`-gt 0` → `-lt 0`) | KILLED | `…_is_named_and_red` |

**13 of 14 killed by the new suite. Named survivor: m5**, which the proxy suite does not
observe — it is killed by an existing guard, measured, not assumed.

---

## Whole-run proof, both tiers

Read from summary CONTENT. Escapes are counted by a recording interceptor first on PATH,
which measures what got *past* the guard.

**Counter positive control, same configuration as the run below** (fired by hand
immediately before it): `notify-send` and `systemd-run --unit=positive-control-final
--on-active=9h` → **2 recorded**, and `systemctl --user list-units 'positive-control*'`
**empty** — the counter moves, and nothing real was created. The zeros below are read
against that 2.

| | dev-host tier (`run-tests.sh --set all`) | nix sandbox (`nix build …#checks.x86_64-linux.pytests`) |
|---|---|---|
| `origin/main` | `collected=8392 passed=8391 skipped=1 failed=0` — `RESULT: PASS (exit=0)`; **0 escapes** | `collected=8392 passed=8391 skipped=1 failed=0` — `BUILD_RC=0` |
| this branch | `collected=8407 passed=8406 skipped=1 failed=0` — `RESULT: PASS (exit=0)`; **0 escapes** | `collected=8407 passed=8406 skipped=1 failed=0` — `BUILD_RC=0` |

* escapes past the guard: **0 on this branch, in both tiers**, against the positive control's 2.
* `panic: test timed out`: 0 in both tiers, both revisions (grepped).
* skips: 1, the pinned `repo-cos` opt-in live-drift check — unchanged. **New tests add 0
  skips.**
* every one of the 17 pytest targets printed `plugin=1`, in both tiers.
* **+15 collected** over `origin/main`'s 8392, in BOTH tiers — exactly the 15 tests in
  `test_no_real_launchers_all_targets.py`, and only that file's directory line moves. That
  identity is also the positive control that both gates actually run the new file.
* The acknowledged target's count is non-zero in **both** tiers (dev-host 71, sandbox 48),
  so the required-direction check is live in the tier that gates merges too — it is not a
  dev-host-only assertion.


---

## Not verified

* **The laptop only.** Everything here was measured on the laptop (192.168.50.155). The
  workbench was deliberately untouched: its dunst is paused holding ~240 queued
  notifications that are user data.
* **`browser-bridge`'s real i3-msg path was never driven.** The L2 proof uses an
  executable of our own named `i3-msg`; what is measured is that an absolute-path launch
  of a ledgered basename is intercepted, not that the real `i3-msg` would have raised a
  window.
* **The unpinned PATH clobber at `test_ch_regrowth.py:1092`** is reported, not closed.
* **`launcher_scan.path_clobbers()` is still only run against `scripts/tests`.** Widening
  it to all 17 target directories is a separate change.
* **`PYTHONPATH="$ROOT/scripts"` is now exported for the whole run.** Both tiers are green
  with it, but it is a real change to every suite's import path and nothing pins that it
  cannot shadow a module name in future.
* The `systemctl` split, the ledger and the seam tests from #399/#423 are **unchanged** —
  no seam test was weakened; `test_no_real_launchers.py` still fails when a seam stops
  being routed through, and the autouse pin was repointed at the plugin (measured as a
  control/mutant pair, m12).

---

## Gated on the MERGED tree, not just this branch

`main` moved to `ad93085` while this was in flight, and **#426 also edits
`scripts/run-tests.sh`** (it raised `scripts/tests`' floor 2775 → 2908). GitHub says
`MERGEABLE`/`CLEAN`, but a clean git merge is not a clean merge — a semantic conflict
survives one. So an integration branch was built (`origin/main` + this branch) and the
FULL gate was run on it, in both tiers:

| | dev-host tier | nix sandbox |
|---|---|---|
| merged tree | `collected=8540 passed=8539 skipped=1 failed=0` — `RESULT: PASS (exit=0)`; **0 escapes**; 17× `plugin=1` | `collected=8540 passed=8539 skipped=1 failed=0` — `BUILD_RC=0` |

0 `panic: test timed out`. The floor line both sides touch needed no hand reconciliation:
`scripts/tests` collects 2973 against #426's new floor of 2908, inside the drift ceiling.
