### PR TITLE
fix(cpu-monitor): ignore Farthest Frontier — keyed on the comm, not the game

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1333,7 +1333,15 @@ in
         # case-insensitive substring match on the busy process's command.
         # COMMA-separated (a space gets split by systemd's Environment= parsing
         # and silently drops entries). Add more, e.g. "anno,logd,steam,lmkd".
-        "CPU_MON_IGNORE=anno,logd"
+        #
+        # 🔴 MATCH THE `comm`, NOT THE GAME'S NAME. Linux truncates comm to 15
+        # chars, so Farthest Frontier appears as "Farthest Fronti" — an entry of
+        # "frontier" would never match anything and would look like it worked.
+        # The comm also contains a SPACE, and is_ignored splits on spaces as well
+        # as commas, so a two-word entry becomes two independent substrings.
+        # Hence the single distinctive first token. Verified against 12 real
+        # alerts on the workbench, all reading "Runaway process: Farthest Fronti".
+        "CPU_MON_IGNORE=anno,logd,farthest"
       ];
       ExecStart = "${pkgs.bash}/bin/bash %h/.config/cpu-monitor/cpu-monitor.sh";
       Restart = "always";

--- a/scripts/tests/test_cpu_monitor_ignore.py
+++ b/scripts/tests/test_cpu_monitor_ignore.py
@@ -1,0 +1,112 @@
+"""IGNORE-list tests for cpu-monitor — specifically the comm-truncation trap.
+
+WHY THIS FILE EXISTS. Linux truncates a process comm to 15 chars, so
+"Farthest Frontier" reaches cpu-monitor as "Farthest Fronti". An entry keyed on
+the GAME'S NAME rather than on the comm — "frontier", the intuitive choice —
+matches nothing, looks like it worked, and the alerts simply keep arriving while
+the reader blames the threshold. `is_ignored` also splits on spaces as well as
+commas, so a two-word entry silently becomes two independent substrings, one of
+which is the dead one.
+
+Measured 2026-08-12: 12 real alerts on the workbench, every one reading
+"⚠ Runaway process: Farthest Fronti".
+
+HOW THESE DRIVE REAL CODE: same prelude-sourcing harness as
+test_cpu_monitor_volume.py — everything above the script's `while :;` loop is
+sourced into a shell and the REAL `is_ignored` is called.
+`test_the_prelude_really_contains_is_ignored` is the positive control on that
+extraction; without it a broken extraction would make every NOMATCH assertion
+below pass for the wrong reason.
+"""
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # scripts/
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+# _HERE is scripts/tests, so parents[0] is scripts/ and parents[1] is the repo root.
+_SCRIPTS = Path(_HERE).resolve().parents[0]
+_ROOT = Path(_HERE).resolve().parents[1]
+_SCRIPT = _SCRIPTS / "cpu-monitor.sh"
+
+# Verbatim from dunst history on the workbench — ALREADY truncated by the kernel.
+_REAL_COMM = "Farthest Fronti"
+
+
+def _prelude():
+    """Everything above the infinite sampling loop, so the real functions can be
+    sourced without the script running forever."""
+    src = _SCRIPT.read_text()
+    cut = src.index("while :;")
+    return src[:cut]
+
+
+def _ignored(comm, ignore, tmp_path):
+    script = tmp_path / "harness.sh"
+    script.write_text(
+        _prelude()
+        + '\nif is_ignored "%s"; then echo MATCH; else echo NOMATCH; fi\n' % comm)
+    e = dict(os.environ)
+    for k in list(e):
+        if k.startswith("CPU_MON_"):
+            e.pop(k)
+    e["CPU_MON_IGNORE"] = ignore
+    p = subprocess.run(["bash", str(script)], env=e, capture_output=True,
+                       text=True, timeout=60)
+    assert p.returncode == 0, p.stderr
+    assert "MATCH" in p.stdout or "NOMATCH" in p.stdout, \
+        "harness produced no verdict: %r / %s" % (p.stdout, p.stderr)
+    return "MATCH" in p.stdout and "NOMATCH" not in p.stdout
+
+
+def test_the_prelude_really_contains_is_ignored():
+    """POSITIVE CONTROL on the extraction. If this captured nothing, every
+    NOMATCH assertion below would be vacuously true."""
+    assert "is_ignored()" in _prelude()
+
+
+def test_is_ignored_can_say_NO(tmp_path):
+    """POSITIVE CONTROL on the matcher: it must be capable of NOT matching, or
+    'the game is ignored' proves nothing."""
+    assert not _ignored(_REAL_COMM, "anno,logd", tmp_path)
+
+
+def test_is_ignored_can_say_YES(tmp_path):
+    """...and capable of matching, against an entry that is not under test."""
+    assert _ignored("Anno1800.exe", "anno,logd", tmp_path)
+
+
+def test_farthest_matches_the_TRUNCATED_comm(tmp_path):
+    assert _ignored(_REAL_COMM, "anno,logd,farthest", tmp_path)
+
+
+def test_frontier_does_NOT_match_the_truncated_comm(tmp_path):
+    """The entire reason the entry is 'farthest'. 'frontier' is the intuitive
+    choice and it is silently dead — pinned so nobody 'tidies' the list into
+    uselessness."""
+    assert not _ignored(_REAL_COMM, "anno,logd,frontier", tmp_path)
+
+
+def test_a_two_word_entry_is_split_and_cannot_be_relied_on(tmp_path):
+    """Documents the OTHER half of the trap: is_ignored splits on spaces, so
+    'farthest frontier' is two substrings, and it only appears to work because
+    the first one happens to match on its own."""
+    assert _ignored(_REAL_COMM, "farthest frontier", tmp_path)
+    assert not _ignored(_REAL_COMM, "frontier fronti_no_match", tmp_path)
+
+
+def test_the_DEPLOYED_ignore_list_actually_covers_the_game(tmp_path):
+    """SEAM: nix/home.nix owns the deployed value, cpu-monitor.sh owns the
+    matcher. Each is fine in isolation; the PAIR is what has to hold. Read the
+    real value out of home.nix rather than restating it here, so editing one
+    side without the other goes red."""
+    home_nix = _ROOT / "nix" / "home.nix"
+    src = home_nix.read_text()
+    m = re.search(r'"CPU_MON_IGNORE=([^"]*)"', src)
+    assert m, "CPU_MON_IGNORE not found in nix/home.nix — the seam moved"
+    deployed = m.group(1)
+    assert _ignored(_REAL_COMM, deployed, tmp_path), (
+        "the DEPLOYED CPU_MON_IGNORE=%r does not match %r" % (deployed, _REAL_COMM))


### PR DESCRIPTION
## What

Adds `farthest` to `CPU_MON_IGNORE`. The workbench fired **12 runaway-process alerts** for Farthest Frontier (260–395% CPU, sustained) — expected load for a game, not something to be told about.

## 🔴 Why the entry is `farthest` and not `frontier`

Linux truncates a process comm to 15 chars, so the game reaches cpu-monitor as **`Farthest Fronti`** — verbatim from all 12 alerts in dunst history:

```
⚠ Runaway process: Farthest Fronti :: PID 3231404 at 395.1% CPU for ~1380s
```

An entry of `frontier` therefore matches **nothing**. It looks correct, it reads correct in review, and the alerts keep arriving while the reader blames the threshold. `is_ignored` also splits on **spaces** as well as commas, so a two-word `farthest frontier` is really two independent substrings — it only appears to work because the first one matches on its own.

Both traps are pinned by tests so nobody "tidies" the list into uselessness later.

## Tests

`scripts/tests/test_cpu_monitor_ignore.py`, 7 tests, driving the **real** `is_ignored` via the same prelude-sourcing harness `test_cpu_monitor_volume.py` uses.

- Two **positive controls on the harness**: `is_ignored` must be able to say YES *and* NO. A broken prelude extraction would otherwise make every NOMATCH assertion vacuously true.
- `farthest` matches the truncated comm; `frontier` does not; the two-word entry is shown to be split.
- A **seam test** that reads the deployed value out of `nix/home.nix` rather than restating it. nix owns the value, `cpu-monitor.sh` owns the matcher; each is fine in isolation and only the pair matters, so editing one side without the other goes red.

**Proven RED against the pre-change value** (`anno,logd`): exactly **one** test fails — the seam test, at its own assertion (`:111`) — while the other six stay green, correctly, because they do not depend on the deployed value.

`nix-instantiate --parse` OK.

## What this costs

Runaway alerts naming any process whose comm contains `farthest` will never be shown again. Nothing else on either host matches. Reverting is one token.

## Not deployed by merging

`CPU_MON_IGNORE` is a systemd `Environment=` line, so this needs `ship.sh` + a `home-manager switch` to take effect.