### PR TITLE
fix(tests): st_blocks equality pinned allocator luck, not the code under test

### DIFF
--- a/scripts/dl-router/tests/test_dedupe.py
+++ b/scripts/dl-router/tests/test_dedupe.py
@@ -1671,8 +1671,10 @@ def fallocated(path: Path, size: int, *, head: bytes = b"H",
     `os.ftruncate` makes a sparse file, which `st_blocks` catches. This is the
     other shape, and the one qBittorrent actually uses when "pre-allocate disk
     space for all files" is on: `posix_fallocate` reserves REAL extents, so
-    size AND blocks match a finished file exactly. Under "download first and
-    last pieces first" the ends are finished too.
+    the size matches a finished file exactly and the block count matches it to
+    within filesystem metadata overhead -- densely allocated either way, with
+    no hole to give it away. Under "download first and last pieces first" the
+    ends are finished too.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(path, os.O_CREAT | os.O_RDWR | os.O_TRUNC, 0o600)
@@ -1700,14 +1702,35 @@ def test_st_blocks_CANNOT_see_a_fallocated_partial(tmp_path):
     """THE PREMISE of the round-3 blocker, asserted so it cannot rot.
 
     `posix_fallocate` allocates real extents, so the metadata heuristic that
-    caught the sparse variant is blind here: identical size, identical block
-    count, identical head, identical tail.
+    caught the sparse variant is blind here: identical size, identical head,
+    identical tail, and BOTH files densely allocated -- there is no hole left
+    for `st_blocks` to report.
+
+    Density, not EQUAL block counts, is the premise. How many extent-tree
+    metadata blocks a file picks up is a filesystem allocation detail rather
+    than a property of the code under test, and it drifts with tmpdir state:
+    measured on ext4, these two files disagree by exactly one 4K block in
+    roughly 40% of trials, in either direction. Asserting `part.st_blocks ==
+    whole.st_blocks` therefore pinned a coin flip. What actually has to hold
+    -- and what actually blinds the heuristic -- is that NEITHER file is
+    sparse. The sparse variant this contrasts with allocates ~3% of the size
+    it claims; both of these allocate ~100%.
     """
     size = D.HEAD_BYTES + D.TAIL_BYTES + (8 << 20)
     part = fallocated(tmp_path / "part.mkv", size, fill_to=0.4)
     whole = complete_file(tmp_path / "whole.mkv", size)
     assert part.stat().st_size == whole.stat().st_size
-    assert part.stat().st_blocks == whole.stat().st_blocks
+    # Each file is allocated to within 5% (432537 B) of the size it claims.
+    # Measured slack on ext4 is one 4K block, 0.05% of size -- so the band
+    # clears real metadata overhead by ~105x. The sparse variant it must keep
+    # rejecting is 8 MiB short, 97% of its size, which the band rejects by
+    # ~19x. Verified both directions: see the PR's positive control.
+    for label, st in (("partial", part.stat()), ("whole", whole.stat())):
+        allocated = st.st_blocks * 512
+        assert abs(allocated - st.st_size) <= st.st_size // 20, (
+            f"{label} is not densely allocated: {allocated} B allocated "
+            f"against {st.st_size} B of size. If it is short, the file is "
+            f"sparse and the premise of this test no longer holds")
     assert S.App._looks_preallocated(part.stat()) is False
     assert S.App._looks_preallocated(whole.stat()) is False, (
         "the metadata heuristic cannot distinguish these -- that is the point")

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -569,13 +569,15 @@ TARGET_FLOORS=(
   # ELEVEN consecutive PRs — re-run the gate on the MERGED tree and copy what it
   # prints. Do NOT reconcile the two sides by hand.
   #
-  # ⚠ ONE OBSERVED FLAKE, in another target and unrelated to this branch: the
-  # baseline run of UNMODIFIED main reported `FAIL scripts/dl-router/tests` on
-  # test_dedupe.py's `test_st_blocks_CANNOT_see_a_fallocated_partial`
-  # (`assert 16896 == 16904` — st_blocks after `posix_fallocate`, which is
-  # filesystem-dependent). The very next run, on this branch, passed 991/991. So
-  # it is intermittent and host-level, not a regression here; recorded because a
-  # red baseline that nobody writes down is how a real failure gets waved past.
+  # ✅ FIXED — the flake formerly recorded here is gone. It was test_dedupe.py's
+  # `test_st_blocks_CANNOT_see_a_fallocated_partial` reporting
+  # `assert 16896 == 16904`: it pinned st_blocks EQUALITY between a
+  # `posix_fallocate`d file and a fully-written one, which is a filesystem
+  # allocation property (one 4K extent-tree metadata block, taken or not
+  # depending on tmpdir state), not a property of the code under test.
+  # Measured on ext4: the two disagreed in 17 of 40 runs, in either direction.
+  # It now asserts what the test actually needs — that BOTH files are densely
+  # allocated — so it no longer keys on allocator luck.
   "scripts/tests|3100"
   # 2026-08-11, the session-summary changed-paths work: 230 -> 273 collected,
   # +43 for scripts/collector/tests/test_changed_paths.py (the shared


### PR DESCRIPTION
## The defect

`scripts/dl-router/tests/test_dedupe.py::test_st_blocks_CANNOT_see_a_fallocated_partial` asserted:

```python
assert part.stat().st_blocks == whole.stat().st_blocks
```

between a `posix_fallocate`d partial and a fully-written file. That equality is a **filesystem allocation property, not a property of `_looks_preallocated`**. Whether a file picks up one extra 4K extent-tree metadata block depends on tmpdir allocator state at the moment it is created.

It has been blocking unrelated PRs: any branch that shifts enough sandbox state ahead of dl-router in the run order can flip it.

## Baseline — the failure, reproduced

Running the **unmodified pre-change test** 40x on the dev host (ext4):

```
17 failed, 23 passed        (~42% failure rate)
```

Failing in **both directions**, with the exact symptom already recorded as an unexplained baseline flake in `run-tests.sh`:

```
AssertionError: assert 16904 == 16896
AssertionError: assert 16896 == 16904
```

The two files land 8 blocks (one 4 KiB block) apart, either way round.

## The shape chosen

The docstring's real claim is that a fallocated partial is **indistinguishable from a whole file by metadata** — which is why `_looks_preallocated` must return `False` for both. Equal block counts were only ever *supporting evidence*; stating them as exact equality was the bug.

Each file is now asserted to be **densely allocated** — `st_blocks * 512` within 5% of `st_size`:

```python
for label, st in (("partial", part.stat()), ("whole", whole.stat())):
    allocated = st.st_blocks * 512
    assert abs(allocated - st.st_size) <= st.st_size // 20, (...)
```

That is the actual contrast the docstring draws against the **sparse** variant the heuristic *can* catch, which allocates ~3% of the size it claims.

A deliberate note on why this is a two-sided band rather than a floor: `_looks_preallocated` is literally `blocks*512 < size`, so a one-sided floor would have restated the implementation under test and added nothing.

**Margins** (measured, real test constants — `size = 8650752`, tolerance `432537`):

| | value | vs tolerance |
|---|---|---|
| metadata slack, ext4 | 4096 B (0.05%) | cleared by **~105x** |
| sparse variant shortfall | 8388608 B (97%) | rejected by **~19x** |

Neither fragile nor vacuous.

Unchanged: size equality, both `_looks_preallocated` assertions, and all dl-router behaviour. **Test-only** — `_looks_preallocated` itself is untouched. Collected count unchanged (120 in this file, 991 in the target), so no `TARGET_FLOORS` re-pin.

## Verification

**Both tiers, on the committed tree:**

| tier | result |
|---|---|
| `nix build .#checks.x86_64-linux.pytests` | `RESULT: PASS (exit=0)` — `dl-router/tests collected=991 passed=991 floor=942`; TOTAL `collected=8770 passed=8769 failed=0`; 23 PASS lines, 0 FAIL, 0 timeout panics |
| `nix build .#checks.x86_64-linux.nodetests` | `RESULT: PASS (exit=0)` — TOTAL `tests=1024 pass=1024 fail=0` (run because this PR touches shared `run-tests.sh`) |
| dev host, target test x40 | **40 passed** (was 17 failed / 23 passed) |
| dev host, full `dl-router/tests` | 991 passed |

Counts were read from `nix log`, not exit codes — the confirming pytests build resolved to the **same store path** as the earlier fresh build, i.e. cached with empty stdout.

**Teeth — three controls, all watched:**

1. **Mutation A (required).** `_looks_preallocated` → `return True`, so it *does* claim a fallocated partial is preallocated. Test goes red on its **own preserved assertion**, with that assertion's specific error:
   ```
   >  assert S.App._looks_preallocated(part.stat()) is False
   E  AssertionError: assert True is False
   ```
   Reached only *after* the new density loop passes — so attribution is clean and the new code is not what caught it.

2. **Mutation B (positive control on the new assertion).** Swapped the helper's `posix_fallocate` for `ftruncate`, making the files genuinely holey. The **new** assertion goes red on its own line and its own message:
   ```
   E  AssertionError: partial is not densely allocated: 3620864 B allocated
      against 8650752 B of size...
   E  assert 5029888 <= (8650752 // 20)
   ```
   This is the one that matters: a relaxed assertion that can no longer fail would be worse than the fragile one it replaced.

3. **Negative control on the gate itself.** Forced the assertion to `<= -1` and rebuilt the sandbox gate, confirming it can observe a dl-router failure at all:
   ```
   FAIL  scripts/dl-router/tests  (collected=991 passed=990 failed=1)
   RESULT: FAIL (exit=1)
   ```
   Fully reverted; the pushed tree is byte-identical to the commit.

## Also updated

`scripts/run-tests.sh` carried a comment recording this exact flake (`assert 16896 == 16904`) as open and unexplained, concluding it was "intermittent and host-level". That is now diagnosed and closed, so the comment says so rather than describing a live hazard.

## Stated plainly

- I **could not** reproduce the original failure *in the nix sandbox* — it is run-order dependent and the sandbox happened to pass on both pristine main and this branch. The 17/40 baseline is a **dev-host** measurement. The negative control above is what establishes the sandbox gate would report a dl-router failure if one occurred.
- The 5% band and the ~105x / ~19x margins are measured **on ext4 on this host only**. The direction of the argument holds anywhere (metadata overhead is a few blocks; a sparse file is short by orders of magnitude), but the specific ratios are not portable claims.
- The test already assumed a non-compressing filesystem — its fill byte is `b"M"`, which btrfs/zfs compression would collapse, tripping the pre-existing `_looks_preallocated(...) is False` assertions before reaching mine. Pre-existing, unchanged, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
