### PR TITLE
feat: install clawgatectl, and make the clawgate skill document the API that exists

### DIFF
--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -10,7 +10,7 @@ approve-with-comment / deny. It has since grown into the **agent dispatch loop**
 on Postgres, agent self-service + privilege profiles + an Operator, runbooks with approval gates,
 and a machine Task API producers post work into for one-tap Dispatch.
 
-🔴 **Point-in-time state: `/home/zach/workspace/homelab-talos/containers/clawgate/HANDOFF.md` —
+🔴 **Point-in-time state: `~/workspace/homelab-talos/containers/clawgate/HANDOFF.md` —
 GREP it for the section you need, never read it whole (~190 KB, lower half superseded).**
 
 ⚠ **This skill drifts from the code in BOTH directions** — once documented weeks EARLY, and six
@@ -27,10 +27,10 @@ live pin, `git grep` for the feature.
 | `agent-dispatch.md` | debugging the agent loop; `POST /agents`; the sandbox fixture; a silent non-start |
 | `extension.md` | you changed the extension, or need to know which build is loaded |
 | `changelog.md` | *when* a feature landed / why an old decision stands |
-| `architecture.md` | changing agents / repos / runbooks / privilege / native tools / env / e2e |
+| `architecture.md` | changing agents / repos / runbooks / privilege / native tools / e2e |
 | `internals.md` | changing Go code: markdown renderer, the two `taskTitle`s, migrations |
 | `telemetry.md` | metrics/logs missing; adding an event; a red CI check |
-| `troubleshooting.md` | symptom index: push, PWA icon, stale SW, RBAC, kubeconfig, agent model |
+| `troubleshooting.md` | symptoms: push, PWA icon, stale SW, RBAC, kubeconfig, agent model |
 | `hooks.md` | `PermissionRequest` semantics; the defer gates; installing hooks elsewhere; Stop / 💡 |
 | `agent-hardening.md` | locking down a **homelab** kubeclaw devpod (netpol needs Cilium) |
 | `element-references.md` | a task body carries extension-picked element refs |
@@ -50,7 +50,7 @@ Memories: `clawgate-phase2` · `clawgate-phase3` · `clawgate-runbooks` ·
 | LAN URL (hook + UI) | `http://192.168.50.250:30302` (NodePort) — **OPEN, no auth**; machine endpoints still need the token |
 | Public / nebula URL | `https://clawgate.zacx.dev` behind **Authelia passkey** (portal `login.zacx.dev`); laptop `http://10.42.0.10:8109` (homelab gateway) |
 | Hook events | `PermissionRequest` (`CLAWGATE_REMOTE_APPROVAL=off`) + `Stop` (async, `CLAWGATE_SUGGEST=off`), both in `~/.claude/settings.json`, ON by default. 🔴 The `Stop` array also carries **two** unrelated hooks (`tmux/task-hook.sh`, `claude-notify.py`) — **preserve both** |
-| 🔴 Machine client | **`clawgatectl`**, on PATH after a switch (devrc `nix/pkgs/tools/clawgatectl.nix`). **Exactly six commands**: `health` · `agent ls` · `agent resolve <name> [--id]` · `task ls/get/create`. Reads `clawgate.env` itself (no token in argv), JSON on stdout only, exit codes 0–8. **Every other route is still curl.** `task-api.md` |
+| 🔴 Machine client | **`clawgatectl`** (devrc `nix/pkgs/tools/clawgatectl.nix`; on PATH after a switch, but **absent on a host whose homelab-talos checkout predates it — the laptop today**). **Exactly six commands**: `health` · `agent ls` · `agent resolve <name> [--id]` · `task ls/get/create`. Reads `clawgate.env` itself (no token in argv); JSON on stdout only; rc 0–8. **Every other route is still curl.** `task-api.md` |
 
 🔴 **clawgate has NO human auth of its own** (since 0.7.37): `requireSession` is a pass-through no-op,
 so **the LAN NodePort is fully unauthenticated** — including `DELETE /tasks/{id}` and 🔴 **`POST
@@ -69,7 +69,7 @@ clawgatectl health   # live version + uptime; rc 6 = unreachable, rc 8 = you hit
 ```
 
 ## send a test
-⚠ **No `clawgatectl` verb for `/api/send`** — stays curl, token preamble included. Creates a real
+⚠ **No `clawgatectl` verb for `/api/send`** — stays curl, preamble included. Creates a real
 pending request (card + Web Push) via the hook token on the open LAN NodePort; for delivery tail
 logs for `push: delivered ... to N device(s)`.
 ```bash
@@ -103,7 +103,7 @@ $CLAWGATE_HOOK_TOKEN` or `X-Clawgate-Token`. Statuses are exactly `open` / `in_p
 `ready_for_review` / `complete` — no `dismissed`; dismissing deletes.
 
 🔴 **Two paths delete a task, both TEARING DOWN its live dispatched agent pod** (shared
-`dismissTask` → `Provisioner.Destroy`; **no in-progress guard, deliberately**): `DELETE
+`dismissTask`; **no in-progress guard, deliberately**): `DELETE
 /api/tasks/{id}`, unauthenticated on the LAN (above), and 🔴 **its automated twin the idle-task
 reaper** — the daily sweep dismisses any task untouched for **7d**, and `CLAWGATE_TASK_TTL` is
 **unset in the deployment** so that default is LIVE (`off`/`0` disables).
@@ -121,7 +121,7 @@ create** — a load-bearing wire contract producers key their retry on.
 superseded within two days, twice. `agent-dispatch.md` has the sandbox fixture, the agent
 image's absent toolchain and the dispatch `curl`. Durable facts only:
 - **The loop DOES close unattended** (two real runs). "The 5-minute kickoff deadline is why it never
-  worked" is a DEAD theory — don't reopen it.
+  worked" is DEAD — don't reopen it.
 - **`POST /agents` is FORM-ENCODED, not JSON** (hence no `clawgatectl` verb), behind the no-op
   `requireSession` → **no auth on the LAN NodePort**. 🔴 A future webhook needs a **separate
   hostname**, never a path bypass on `clawgate.zacx.dev` — that puts dispatch on the open internet.
@@ -139,7 +139,7 @@ image's absent toolchain and the dispatch `curl`. Durable facts only:
   not evidence of an outage.
 - `hooks.md`: the full gate list, the exact JSON, why an approver comment is **record-only**.
 
-## 🔴 gotchas (don't relearn these)
+## 🔴 gotchas
 - 🔴 **Public routing rule**: clawgate runs on WORKBENCH but is fronted by the homelab + production
   nebula gateways, whose nginx must `proxy_pass` to the **NodePort IP `http://192.168.50.250:30302`**
   — NOT a `.svc.cluster.local` name, which doesn't resolve there and **crashes nginx, taking down ALL

--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -11,51 +11,53 @@ on Postgres, agent self-service + privilege profiles + an Operator, runbooks wit
 and a machine Task API producers post work into for one-tap Dispatch.
 
 🔴 **Point-in-time state: `/home/zach/workspace/homelab-talos/containers/clawgate/HANDOFF.md` —
-GREP it for the section you need, never read it whole (~190 KB / ~46k tokens, lower half superseded).**
+GREP it for the section you need, never read it whole (~190 KB, lower half superseded).**
 
-⚠ **This skill drifts from the code in BOTH directions** — 0.7.72 was documented here weeks before
-it reached `trunk`; on 2026-08-12 it was six releases BEHIND (live 0.7.85). Never treat a doc claim
-as evidence: check the LIVE pin + `git grep` the feature.
+⚠ **This skill drifts from the code in BOTH directions** — once documented weeks EARLY, and six
+releases BEHIND on 2026-08-12. Never treat a doc claim as evidence: `clawgatectl health` for the
+live pin, `git grep` for the feature.
 
 ## Reference files
-`devrc/claude/skills/clawgate/reference/` (also `~/.claude/skills/clawgate/` after a switch).
+`devrc/claude/skills/clawgate/reference/` (→ `~/.claude/skills/clawgate/` after a switch).
 
 | file | read it when |
 |---|---|
 | `deploy.md` | **building + shipping a version**: manifest-vs-code + CSS-cwd traps; chart sync |
-| `task-api.md` | **writing/debugging a producer**; tag grammar; access model |
+| `task-api.md` | **writing/debugging a producer**; `clawgatectl` + exit codes; **the 22-route `/api/*` inventory with its auth**; tag grammar |
 | `agent-dispatch.md` | debugging the agent loop; `POST /agents`; the sandbox fixture; a silent non-start |
-| `extension.md` | you changed the browser extension, or need to know which build is loaded |
-| `changelog.md` | *when* a feature landed / why an old decision stands (0.2.x → 0.7.79; live is ahead) |
+| `extension.md` | you changed the extension, or need to know which build is loaded |
+| `changelog.md` | *when* a feature landed / why an old decision stands |
 | `architecture.md` | changing agents / repos / runbooks / privilege / native tools / env / e2e |
 | `internals.md` | changing Go code: markdown renderer, the two `taskTitle`s, migrations |
 | `telemetry.md` | metrics/logs missing; adding an event; a red CI check |
 | `troubleshooting.md` | symptom index: push, PWA icon, stale SW, RBAC, kubeconfig, agent model |
 | `hooks.md` | `PermissionRequest` semantics; the defer gates; installing hooks elsewhere; Stop / 💡 |
 | `agent-hardening.md` | locking down a **homelab** kubeclaw devpod (netpol needs Cilium) |
-| `element-references.md` | a task body carries extension-picked element references |
+| `element-references.md` | a task body carries extension-picked element refs |
 
 Memories: `clawgate-phase2` · `clawgate-phase3` · `clawgate-runbooks` ·
 `clawgate-loop-validation` · `authelia-passkey-sso`.
 
-## Key facts (verify against current state before asserting)
+## Key facts (verify before asserting)
 
 | Thing | Value |
 |---|---|
 | Source | `~/workspace/homelab-talos/containers/clawgate/` (module `github.com/zacxdev/clawgate`) |
-| Hook scripts | `hook/clawgate-hook.sh` (PermissionRequest → `/api/send`) + `hook/clawgate-stop-hook.sh` (Stop → `/api/suggest`); both read `~/.claude/clawgate.env` (`CLAWGATE_API_URL`, `CLAWGATE_HOOK_TOKEN`) |
-| Cluster | **workbench**, ns `clawgate`; dispatched agents land in ns **`devpod-<agent-name>`** |
-| 🔴 kubeconfig is PER-HOST — never hardcode one; `ls` both, take the one that EXISTS | workbench `.250` → `~/workspace/homelab-talos/workbench-kubeconfig`; laptop `.155` → `~/workspace/homelab-infra/workbench-kubeconfig`. The other is **absent** on each host. Why, plus telling the hosts apart: `troubleshooting.md`. |
+| Hook scripts | `hook/clawgate-hook.sh` (PermissionRequest → `/api/send`) + `hook/clawgate-stop-hook.sh` (Stop → `/api/suggest`); both read `~/.claude/clawgate.env` |
+| Cluster | **workbench**, ns `clawgate`; dispatched agents in ns **`devpod-<agent-name>`** |
+| 🔴 kubeconfig is PER-HOST — never hardcode; `ls` both, take the one that EXISTS | workbench `.250` → `~/workspace/homelab-talos/workbench-kubeconfig`; laptop `.155` → `~/workspace/homelab-infra/workbench-kubeconfig`. The other is **absent** on each host. Telling the hosts apart: `troubleshooting.md`. |
 | Image / manifest | `harbor.homelab.lan/library/clawgate:<ver>`, pinned in `clusters/workbench/apps/clawgate/deployment.yaml` (Flux from `trunk`) |
 | LAN URL (hook + UI) | `http://192.168.50.250:30302` (NodePort) — **OPEN, no auth**; machine endpoints still need the token |
-| Public / nebula URL | `https://clawgate.zacx.dev` behind **Authelia passkey** (portal `login.zacx.dev`); laptop `http://10.42.0.10:8109` via the homelab gateway |
+| Public / nebula URL | `https://clawgate.zacx.dev` behind **Authelia passkey** (portal `login.zacx.dev`); laptop `http://10.42.0.10:8109` (homelab gateway) |
 | Hook events | `PermissionRequest` (`CLAWGATE_REMOTE_APPROVAL=off`) + `Stop` (async, `CLAWGATE_SUGGEST=off`), both in `~/.claude/settings.json`, ON by default. 🔴 The `Stop` array also carries **two** unrelated hooks (`tmux/task-hook.sh`, `claude-notify.py`) — **preserve both** |
+| 🔴 Machine client | **`clawgatectl`**, on PATH after a switch (devrc `nix/pkgs/tools/clawgatectl.nix`). **Exactly six commands**: `health` · `agent ls` · `agent resolve <name> [--id]` · `task ls/get/create`. Reads `clawgate.env` itself (no token in argv), JSON on stdout only, exit codes 0–8. **Every other route is still curl.** `task-api.md` |
 
 🔴 **clawgate has NO human auth of its own** (since 0.7.37): `requireSession` is a pass-through no-op,
 so **the LAN NodePort is fully unauthenticated** — including `DELETE /tasks/{id}` and 🔴 **`POST
-/api/auto-approve-all`**, which arms a timed global window auto-approving **every** future request in
-**every** project *and* sweeps the pending queue (checkpoints excepted). `requireHookToken` is
-**enforce-when-set**: an empty token opens the machine endpoints too. Model: `task-api.md`.
+/api/auto-approve-all`** (arms a global window auto-approving **every** future request in **every**
+project *and* sweeps the pending queue; checkpoints excepted). `requireHookToken` is
+**enforce-when-set**: an empty token opens the machine endpoints too. All four wrappers across all
+118 routes: `task-api.md`.
 
 ---
 
@@ -63,12 +65,13 @@ so **the LAN NodePort is fully unauthenticated** — including `DELETE /tasks/{i
 ```bash
 KC=$(ls /home/zach/workspace/homelab-{talos,infra}/workbench-kubeconfig 2>/dev/null | head -1)  # PER-HOST
 kubectl --kubeconfig $KC -n clawgate get pods -l app=clawgate -o wide
-curl -sf --max-time 5 http://192.168.50.250:30302/health; echo   # LAN health + live version
+clawgatectl health   # live version + uptime; rc 6 = unreachable, rc 8 = you hit the public host
 ```
 
 ## send a test
-Creates a real pending request (card + Web Push) via the hook token on the open LAN NodePort; for
-delivery, tail logs for `push: delivered ... to N device(s)`.
+⚠ **No `clawgatectl` verb for `/api/send`** — stays curl, token preamble included. Creates a real
+pending request (card + Web Push) via the hook token on the open LAN NodePort; for delivery tail
+logs for `push: delivered ... to N device(s)`.
 ```bash
 HOOK=$(grep '^CLAWGATE_HOOK_TOKEN=' ~/.claude/clawgate.env | cut -d= -f2)
 curl -sf -X POST http://192.168.50.250:30302/api/send -H 'Content-Type: application/json' \
@@ -78,30 +81,32 @@ curl -sf -X POST http://192.168.50.250:30302/api/send -H 'Content-Type: applicat
 
 ## logs (push / SSE / subscriptions)
 ```bash
-KC=$(ls /home/zach/workspace/homelab-{talos,infra}/workbench-kubeconfig 2>/dev/null | head -1)  # PER-HOST
+# $KC as in `status` above — PER-HOST, never hardcoded
 kubectl --kubeconfig $KC -n clawgate logs -f deploy/clawgate | grep --line-buffered -iE 'subscription|delivered|push:|request created|decision recorded|could not'
 ```
-(Run under the Monitor tool for a live watch that notifies the user as events land.)
+(Run under Monitor for a live watch that notifies as events land.)
 
 ## deploy a new version
-🔴 **GitOps from `trunk`: committing deploys the MANIFEST, not container CODE — silently.** The
-manifest pins an immutable literal tag with **no Flux image automation**, so a commit under
+🔴 **GitOps from `trunk`: committing deploys the MANIFEST, not container CODE — silently.** The pin
+is an immutable literal tag with **no Flux image automation**, so a commit under
 `containers/clawgate/**` reconciles cleanly and **changes nothing that is running**. `git log` is NOT
-evidence the code is live; the live pin and `/health` are. **Load `deploy.md` first** —
-version-from-the-live-pin, the ONE commit path (a worktree off `origin/trunk`; never `git add -A`),
-test gate, build/push, pin bump, the CSS-cwd trap that fakes ~25 e2e failures, the chart-sync trap.
+evidence the code is live; the live pin and `clawgatectl health` are. **Load `deploy.md` first** —
+version-from-the-live-pin, the ONE commit path (worktree off `origin/trunk`; never `git add -A`),
+test gate, build/push, pin bump, the CSS-cwd trap that fakes ~25 e2e failures, chart sync.
 
 ## machine (hook-token) Task API
-Producers post under `/api/tasks*` (+ `/api/notify`, `/api/tags`) with `Authorization: Bearer
+Read/create with `clawgatectl task ls --summary [--status open --tag t --limit n]` · `task get <id>`
+· `task create --body …`; **`--summary`/`--status`/`--limit` filter SERVER-side** — NOT true at
+0.7.85, re-measured live 0.7.87 on 2026-08-13. Every other verb (`PATCH`, `DELETE`, comments,
+`/api/tags`, `/api/projects`, `/api/notify`) is still curl with `Authorization: Bearer
 $CLAWGATE_HOOK_TOKEN` or `X-Clawgate-Token`. Statuses are exactly `open` / `in_progress` /
 `ready_for_review` / `complete` — no `dismissed`; dismissing deletes.
 
 🔴 **Two paths delete a task, both TEARING DOWN its live dispatched agent pod** (shared
-`dismissTask` → `Provisioner.Destroy`; **no in-progress guard, deliberately**):
-- `DELETE /api/tasks/{id}` — unauthenticated on the LAN (above).
-- 🔴 **the idle-task reaper — its automated twin**: the daily sweep dismisses any task untouched for
-  `defaultTaskReapAfter` = **7d**, and `CLAWGATE_TASK_TTL` is **unset in the deployment**, so that
-  default is LIVE — an abandoned dispatch loses its agent pod after a week (`off`/`0` disables).
+`dismissTask` → `Provisioner.Destroy`; **no in-progress guard, deliberately**): `DELETE
+/api/tasks/{id}`, unauthenticated on the LAN (above), and 🔴 **its automated twin the idle-task
+reaper** — the daily sweep dismisses any task untouched for **7d**, and `CLAWGATE_TASK_TTL` is
+**unset in the deployment** so that default is LIVE (`off`/`0` disables).
 
 ⚠ **Tags are hard-validated: one invalid tag or unknown `runbook:` is a hard 400 that fails the whole
 create** — a load-bearing wire contract producers key their retry on.
@@ -109,59 +114,55 @@ create** — a load-bearing wire contract producers key their retry on.
 (`element-references.md`).
 
 **Writing/debugging a producer? Load `task-api.md`** — per-op semantics + status codes,
-409/immutability, the comment-author allowlist, provenance headers, the tag grammar.
+409/immutability, the author allowlist, provenance, tag grammar, the full route×auth inventory.
 
 ## agent dispatch
-🔴 **Current STATUS of the loop lives in `HANDOFF.md`, not here** — status claims written here have
-been superseded within two days, twice. `agent-dispatch.md` has the sandbox fixture, the agent
-image's absent toolchain and the `curl` form. Durable facts only:
+🔴 **Current STATUS of the loop lives in `HANDOFF.md`, not here** — status claims here have been
+superseded within two days, twice. `agent-dispatch.md` has the sandbox fixture, the agent
+image's absent toolchain and the dispatch `curl`. Durable facts only:
 - **The loop DOES close unattended** (two real runs). "The 5-minute kickoff deadline is why it never
   worked" is a DEAD theory — don't reopen it.
-- **`POST /agents` is FORM-ENCODED, not JSON**, behind the no-op `requireSession` → **no auth on the
-  LAN NodePort**. 🔴 `clawgate.zacx.dev` is gated ONLY at the Authelia edge, so a future webhook needs
-  a **separate hostname** — a path bypass there puts agent dispatch on the open internet.
-- ⚠ **A dispatch that cannot START surfaces almost nothing.** `provisioningStuckTimeout` (15m,
-  `internal/agents/reconcile.go`) marks the **agent** `error`, but the **task stays `in_progress`**,
-  `kicked_off` stays `false`, and nothing pushes. **Read the AGENT POD LOGS first — ns
-  `devpod-<agent-name>`, not ns `clawgate`.** The clawgate-side "gateway not ready after 3m0s" is a
-  symptom, not the cause, and not a provisioning flake.
+- **`POST /agents` is FORM-ENCODED, not JSON** (hence no `clawgatectl` verb), behind the no-op
+  `requireSession` → **no auth on the LAN NodePort**. 🔴 A future webhook needs a **separate
+  hostname**, never a path bypass on `clawgate.zacx.dev` — that puts dispatch on the open internet.
+- ⚠ **A dispatch that cannot START surfaces almost nothing** — the agent goes `error` but the task
+  stays `in_progress`, `kicked_off` stays `false`, and nothing pushes. **Read the AGENT POD LOGS
+  first — ns `devpod-<agent-name>`, not ns `clawgate`** (`agent-dispatch.md`).
 
 ## hook management
 - On by default, global. Off for one session: `CLAWGATE_REMOTE_APPROVAL=off`. Inspect:
   `jq '.hooks.PermissionRequest' ~/.claude/settings.json`.
 - Tests, from `containers/clawgate/`: `nix-shell -p bats jq --run 'bats hook/tests/*.bats'`.
-- **Fail-safe by design**: any error / timeout / unreachable server → defer to the terminal, as if
-  the hook were absent; a clawgate outage never blocks Claude Code. ⚠ It also defers **without ever
-  contacting the server** when `permission_mode` is `bypassPermissions`/`plan`, or the tool is
-  `AskUserQuestion` — so "no card appeared" is not evidence of an outage.
-- `hooks.md`: the full gate list, the exact JSON, why an approver comment is **record-only**,
-  installing hooks on another host, and the Stop / 💡 hook.
+- **Fail-safe by design**: any error/timeout/unreachable server → defer to the terminal, so an
+  outage never blocks Claude Code. ⚠ It also defers **without contacting the server** on
+  `permission_mode` `bypassPermissions`/`plan` or tool `AskUserQuestion` — so "no card appeared" is
+  not evidence of an outage.
+- `hooks.md`: the full gate list, the exact JSON, why an approver comment is **record-only**.
 
 ## 🔴 gotchas (don't relearn these)
 - 🔴 **Public routing rule**: clawgate runs on WORKBENCH but is fronted by the homelab + production
-  nebula gateways, whose nginx block must `proxy_pass` to the workbench **NodePort IP
-  `http://192.168.50.250:30302`** — NOT a `.svc.cluster.local` name, which doesn't resolve there and
-  **crashes nginx, taking down ALL nebula-routed services**. Edit additively; a reload restarts
-  `nebula-gateway` on **both** clusters. Mechanics: `architecture.md`.
+  nebula gateways, whose nginx must `proxy_pass` to the **NodePort IP `http://192.168.50.250:30302`**
+  — NOT a `.svc.cluster.local` name, which doesn't resolve there and **crashes nginx, taking down ALL
+  nebula-routed services**. Edit additively; a reload restarts `nebula-gateway` on **both** clusters
+  (`architecture.md`).
 - **The vendored kubeclaw chart is embedded at BUILD time** — a kubeclaw release reaches
-  clawgate-provisioned agents only after `make sync-chart` + rebuild + redeploy, and `make
-  check-chart` silently tests the wrong tree unless `~/workspace/kubeclaw` is synced FIRST.
+  clawgate-provisioned agents only after `make sync-chart` + rebuild + redeploy; `make check-chart`
+  silently tests the wrong tree unless `~/workspace/kubeclaw` is synced FIRST.
 - ⚠ **Clawgate-provisioned agents are NOT hardened by default**: chart defaults are
-  `networkPolicy.enabled: false` + `tls.verify: false` (→ `NODE_TLS_REJECT_UNAUTHORIZED=0`). The
-  **container** securityContext IS set (`allowPrivilegeEscalation: false`, seccomp `RuntimeDefault`);
-  only the **pod-level** one is empty. 🔴 That netpol is **Cilium-only** and workbench — where
-  clawgate provisions — has **no Cilium**, so `agent-hardening.md` is a **homelab** playbook.
+  `networkPolicy.enabled: false` + `tls.verify: false`; only the **pod-level** securityContext is
+  empty (the container's IS set). 🔴 That netpol is **Cilium-only** and workbench — where clawgate
+  provisions — has **no Cilium**, so `agent-hardening.md` is a **homelab** playbook.
 - **Alloy has no auto-reloader** — if clawgate metrics vanish from homelab Prometheus, restart Alloy
   first (`telemetry.md`).
-- **Red GitHub Actions checks on `homelab-infra` are NOISE** (billing-blocked); the real gate is the
-  Tekton `clawgate-ci` pipeline — see the `tekton` skill before touching CI. 🔴 **But `clawgate-ci`
-  does NOT run Playwright — browser-layer changes are UNGATED.** Run `make e2e` locally and
-  **count**: **11 of the 18 spec files, 77 of 113 tests, `test.skip` on `!dockerAvailable()`** — a
-  "green" run without Docker executed barely a third of the suite.
+- **Red GitHub Actions checks on `homelab-infra` are NOISE** (billing-blocked); the real gate is
+  Tekton `clawgate-ci` (see the `tekton` skill). 🔴 **But `clawgate-ci` does NOT run Playwright —
+  browser-layer changes are UNGATED.** Run `make e2e` locally and **count**: without Docker,
+  `test.skip` on `!dockerAvailable()` leaves **11 of 18 spec files / 77 of 113 tests** — barely a
+  third of the suite, reported green.
 - 🔴 **The browser extension does NOT ship via Flux — merging to `trunk` deploys NOTHING.** Brave
-  loads it unpacked in place from `~/workspace/clawgate-extension/containers/clawgate/extension`
-  (branch `clawgate-ext-local`), same path on **BOTH hosts**; deploy = `merge --ff-only origin/trunk`
-  on both + reload Brave. 🔴 **Brave profiles load extensions independently from DIFFERENT paths, so
-  the profile in front of you proves nothing** — and agents can't read `brave://`. Never call a
-  version or hotkey live without the `Preferences` sweep in `extension.md`, which also carries the 🔴
-  `git restore --worktree` trap.
+  loads it unpacked from `~/workspace/clawgate-extension/containers/clawgate/extension` (branch
+  `clawgate-ext-local`, same path on **BOTH hosts**); deploy = `merge --ff-only origin/trunk` on both
+  + reload Brave. 🔴 **Brave profiles load extensions from DIFFERENT paths, so the profile in front of
+  you proves nothing** — and agents can't read `brave://`. Never call a version or hotkey live
+  without the `Preferences` sweep in `extension.md` (which also carries the 🔴 `git restore
+  --worktree` trap).

--- a/claude/skills/clawgate/reference/agent-dispatch.md
+++ b/claude/skills/clawgate/reference/agent-dispatch.md
@@ -34,8 +34,10 @@ PIPELINE, not the toolchain. Node because the agent image is Debian 12 + Node 22
 `ready_for_review` in ~2–3 min.
 
 ## `POST /agents` is FORM-ENCODED, not JSON
-Registered behind `requireSession` — which is a literal pass-through (`internal/api/auth.go`), so on
-the LAN NodePort it needs **no auth**:
+⚠ **There is no `clawgatectl` verb for dispatch and there cannot be a trivial one** — the route is
+form-encoded and answers with an HTML fragment, not JSON, so it stays curl. Registered behind
+`requireSession` — a literal pass-through (`internal/api/auth.go`) — so on the LAN NodePort it needs
+**no auth**:
 
 ```bash
 curl -sS -X POST http://192.168.50.250:30302/agents \
@@ -48,8 +50,9 @@ webhook must live on a **separate hostname**, never a path bypass there — a by
 **unauthenticated agent dispatch** on the internet.
 
 ## ⚠ A dispatch that cannot START fails SILENTLY
-The task stays `in_progress`, `agents.kicked_off` stays `false`, and nothing surfaces it. **Read the
-POD LOGS first**: the clawgate-side message ("gateway for X not ready after 3m0s; leaving
+`provisioningStuckTimeout` (**15m**, `internal/agents/reconcile.go`) marks the **agent** `error` —
+but the task stays `in_progress`, `agents.kicked_off` stays `false`, and nothing surfaces it.
+**Read the POD LOGS first**: the clawgate-side message ("gateway for X not ready after 3m0s; leaving
 provisioning for reconciler to recover") describes the symptom, not the cause, and a reconciler
 cannot recover an unrecoverable pod. Do not read it as a provisioning flake — readiness was ~17–21 s
 on every dispatch that could start.

--- a/claude/skills/clawgate/reference/changelog.md
+++ b/claude/skills/clawgate/reference/changelog.md
@@ -189,5 +189,5 @@ FAB** (per-agent unread → session); session-id-in-URL; a consolidated **auto-a
   JS leak is unfixed (0.7.79 never touched `markdown.go`) — don't trust it. Residual: a backtick
   inside a URL renders a truncated autolink plus literal text (no control byte in the href).
 
-**Live pin as of 2026-07-30: 0.7.79** (`curl -sf http://192.168.50.250:30302/health`). Zach ships
-concurrently — this line is stale by design; always re-check.
+**Live pin as of 2026-08-13: 0.7.87** (`clawgatectl health`). Zach ships concurrently — this line is
+stale by design; always re-check.

--- a/claude/skills/clawgate/reference/deploy.md
+++ b/claude/skills/clawgate/reference/deploy.md
@@ -14,7 +14,7 @@ because the cluster still pulls the old pinned tag. Only step 3's pin bump deplo
 Ground case: the vendored kubeclaw chart re-sync (0.7.0 → 0.7.1, PR #274) merged to `trunk` and sat
 there inert — the chart is `//go:embed`ded into the binary (`internal/agents/embed.go`), so it could
 not reach the cluster until 0.7.82 was built and pushed. **`git log` on `trunk` is NOT evidence a
-code change is live; the live pin and `/health` are.**
+code change is live; the live pin and `clawgatectl health` are.**
 
 ## 🔴 ONE commit path: a dedicated git WORKTREE off `origin/trunk`, ending on `trunk` (= live deploy)
 homelab-talos is GitOps from `trunk` — **committing deploys the manifest** (see above). Do **NOT**
@@ -56,7 +56,7 @@ make e2e   # 83 pass / 2 skip; a fresh worktree npm-installs e2e/node_modules fi
 # 2. build (Dockerfile builds Tailwind CSS then the static Go binary, embeds assets) + smoke + push
 docker build --build-arg VERSION=$VER -t harbor.homelab.lan/library/clawgate:$VER -t harbor.homelab.lan/library/clawgate:latest .
 docker run -d --name cg-smoke -p 8219:8104 harbor.homelab.lan/library/clawgate:$VER && sleep 3   # CLAWGATE_INSECURE_COOKIES is dead — no Go code reads it
-curl -sf http://localhost:8219/health && echo OK; docker rm -f cg-smoke
+clawgatectl --api-url http://localhost:8219 health; docker rm -f cg-smoke   # rc 6 = never came up
 docker push harbor.homelab.lan/library/clawgate:$VER && docker push harbor.homelab.lan/library/clawgate:latest
 
 # 3. bump the pin, stage explicit paths, commit, rebase (clean tree → no autostash), push
@@ -70,7 +70,7 @@ git fetch origin trunk && git rebase origin/trunk && git push origin HEAD:trunk
 KC=/home/zach/workspace/homelab-infra/workbench-kubeconfig   # PER-HOST — see SKILL.md Key facts
 flux --kubeconfig $KC reconcile kustomization clawgate --with-source
 until kubectl --kubeconfig $KC -n clawgate get pod -l app=clawgate -o jsonpath='{.items[0].spec.containers[0].image}' | grep -q "$VER"; do sleep 4; done
-curl -sf http://192.168.50.250:30302/health   # confirm version
+clawgatectl health   # confirm the live version (+ a stderr skew note if it differs)
 
 # 5. clean up the worktree (force: removes gitignored build artifacts too)
 cd /home/zach/workspace/homelab-talos

--- a/claude/skills/clawgate/reference/hooks.md
+++ b/claude/skills/clawgate/reference/hooks.md
@@ -8,7 +8,7 @@ Read when: wiring clawgate's hooks onto a new machine, or debugging the "Suggest
 1. **Reachability decides the API URL.**
    - Homelab LAN → `http://192.168.50.250:30302`.
    - A **nebula** host (10.42.0.x, e.g. the laptop) → **`http://10.42.0.10:8109`** (homelab gateway
-     → clawgate; hook-token auth — `curl .../health` returns 200).
+     → clawgate; hook-token auth — check with `clawgatectl --api-url http://10.42.0.10:8109 health`).
    - ⚠ The public `clawgate.zacx.dev` sits behind Authelia passkey (forward-auth), so **do not use
      it for the machine hook** — use a hook-token-gated path.
 2. Copy the hook script:
@@ -46,8 +46,11 @@ from the 💡 Suggestions tab.
 
 Tests: `bats hook/tests/clawgate-stop-hook.bats`.
 
-Live test:
+Live test — ⚠ **stays curl: `clawgatectl` has no `/api/suggest` verb** (nor `/api/send`), so the
+`B=`/`HOOK=` preamble survives here and only here:
 ```bash
+B=http://192.168.50.250:30302
+HOOK=$(grep '^CLAWGATE_HOOK_TOKEN=' ~/.claude/clawgate.env | cut -d= -f2)
 curl -s -X POST "$B/api/suggest" -H "Authorization: Bearer $HOOK" -H 'Content-Type: application/json' \
   -d '{"session_id":"t1","project":"clawgate","cwd":"/x","message":"done","transcript_tail":"...JSONL..."}'
 ```
@@ -80,9 +83,9 @@ blows `ARG_MAX`) and `curl --data-binary @file`.
 
 (`"behavior"` is `"allow"` or `"deny"`.)
 
-- It has **NO reason/context channel** — an approver comment is **record-only**. Only `PreToolUse`
-  can steer the model, via `additionalContext`. Do not design a feature that relies on feeding an
-  approver's words back into the session through this hook.
+- It has **NO reason/context channel** — an approver comment is **record-only**; only `PreToolUse`
+  can steer the model (`additionalContext`). Never design on feeding an approver's words back into
+  the session through this hook.
 ### Every path that DEFERS (this list is exhaustive; verified against `hook/clawgate-hook.sh` 2026-08-12)
 Two of these defer **before any network call**, so a missing card is not evidence clawgate is down:
 

--- a/claude/skills/clawgate/reference/task-api.md
+++ b/claude/skills/clawgate/reference/task-api.md
@@ -10,7 +10,7 @@ Routes registered in `internal/api/server.go` `registerNotesRoutes`, handlers in
 | op | route | notes |
 |---|---|---|
 | **create** | `POST /api/tasks` | `{directory, title, body, model, repo, branch, privileges, tags}`; `body` required (400); unknown keys silently dropped (no `DisallowUnknownFields`). ⚠ **Response is `{"id":N}` and nothing else** — not the created task; read any field back with `GET /api/tasks/{id}` |
-| **read** | `GET /api/tasks[/{id}]` · `?tag=a&tag=b` | tag filter ANDs; bogus tag → `200 []`. ⚠ **NO `LIMIT`, no status filter** — returns the WHOLE board, newest-`updated_at` first, and `?status=`/`?limit=` are **silently ignored** (measured 0.7.85, 2026-08-11: 10 tasks, 94 KB, ~25k tokens, 57% of it comment bodies). Filter client-side — see "Reading the board cheaply" below. 🔑 **Comments are EMBEDDED in both the list and the single GET** (`comments: [{id,noteId,author,body,createdAt}]`) — there is **no read endpoint**: `GET /api/tasks/{id}/comments` is **405** (POST-only), which reads as "wrong method, keep looking" and sends you hunting for a route that was never there. Attachments are `omitempty` metadata only; bytes come from the session route `GET /tasks/{id}/attachments/{aid}` |
+| **read** | `GET /api/tasks[/{id}]` · `?tag=&status=&limit=&summary=` | ⚠ **RE-MEASURED against live 0.7.87 (2026-08-13): `?status=`, `?limit=` and `?summary=1` are now honoured SERVER-SIDE.** The older claim here that they were "silently ignored" was true at 0.7.85 and is now WRONG — do not re-derive it. Positive control run today: unfiltered `19` tasks vs `--limit 3` → `3`; `--status open` returned only `open`. `tag` ANDs (repeatable), bogus tag → `200 []`; default order newest-`updated_at` first. Unfiltered+unsummarised is still ~25k tokens, so **always pass `--summary` first** (drops bodies/comments/attachments for counts). 🔑 **Comments are EMBEDDED in both the list and the single GET** (`comments: [{id,noteId,author,body,createdAt}]`) — there is **no read endpoint**: `GET /api/tasks/{id}/comments` is **405** (POST-only), which reads as "wrong method, keep looking" and sends you hunting for a route that was never there. Attachments are `omitempty` metadata only; bytes come from the session route `GET /tasks/{id}/attachments/{aid}` |
 | **edit** | `PATCH /api/tasks/{id}` | content + dispatch config + `tags` (replace) / `addTags` / `removeTags` (merge); **status/provenance/created_at immutable**; `tags`+merge together → 400 (0.7.73/0.7.75). ⚠ **The `in_progress` 409 is REFINED, not blanket**: a **descriptive-tag-only** edit SUCCEEDS while in progress (a label is not a spec change). 409 fires only when a non-tag field is present, or any touched tag is a ROUTING tag — and a `tags` **replace** counts the CURRENT set as touched, so it 409s on any task that already has one |
 | **set-status** | `PATCH /api/tasks/{id}/status` | ANY status incl. `complete`; **NO `in_progress` guard**; broadcasts `task.changed` + fires the `ready_for_review` push (0.7.74) |
 | **delete** | `DELETE /api/tasks/{id}` | ⚠ shares `dismissTask`, so it **TEARS DOWN a live dispatched agent pod** (`Provisioner.Destroy`, background best-effort). **No in-progress guard — deliberately** (`TestAPITaskDeleteInProgressAllowed`). Delete a dispatched task only if you mean to kill its agent. `404` if absent — the existence probe is load-bearing, since `DELETE … WHERE id=$1` succeeds with 0 rows (0.7.76) |
@@ -37,25 +37,71 @@ and **`grantProfiles`** (`notes.go`). Round-tripping a GET body into a PATCH sil
 Both are `omitempty`, so on a task that never set them the key is simply absent — which looks
 identical to "the field isn't wired". Confirm against `notes.go`, not against one task's JSON.
 
-## Reading the board cheaply
-The list GET returns everything, every time (~25k tokens today). Select before you read:
-```bash
-B=http://192.168.50.250:30302
-H="Authorization: Bearer $(grep '^CLAWGATE_HOOK_TOKEN=' ~/.claude/clawgate.env | cut -d= -f2)"
+## `clawgatectl` — the machine client (use it instead of curl)
 
-# board summary — ~360 tokens instead of ~27,200
-curl -s -H "$H" "$B/api/tasks" | jq -r '.[] | "\(.id)\t\(.status)\t\(.title // .directory)\t\((.tags//[])|join(","))\t\((.comments//[])|length)c"'
+🔑 **SUPERSEDES the 2026-08-11 note here that "a wrapper CLI was evaluated and rejected".** That
+note has been deleted: `clawgatectl` shipped on 2026-08-12 in
+`containers/clawgate/cmd/clawgatectl`, and `devrc/nix/pkgs/tools/clawgatectl.nix` puts it on PATH
+on both hosts. Its argument against a binary ("a stale binary returns confidently wrong output")
+is answered structurally, not by promising to keep it fresh: response bodies are passed to stdout
+**verbatim**, never re-marshalled, so a field a newer server adds survives; and every command
+prints a one-line `note: server X, clawgatectl built for Y` skew warning **to stderr** when the two
+disagree. What is NOT answered: a route the CLI has never heard of is still a route you must curl.
+
+It reads `CLAWGATE_API_URL` + `CLAWGATE_HOOK_TOKEN` out of `~/.claude/clawgate.env` itself, so the
+`H="Authorization: Bearer $(grep '^CLAWGATE_HOOK_TOKEN=' … | cut -d= -f2)"` preamble that used to
+head every recipe in this skill **is gone** — the token never reaches argv (`/proc` is world
+readable) and never reaches your scrollback.
+
+**Commands that exist. There are no others** — anything else is still curl:
+
+| command | route |
+|---|---|
+| `clawgatectl health` | `GET /health` (open, no token) |
+| `clawgatectl agent ls` | `GET /api/agents` |
+| `clawgatectl agent resolve <name> [--id]` | `GET /api/agents`, matched client-side |
+| `clawgatectl task ls [--tag --status --limit --summary]` | `GET /api/tasks` |
+| `clawgatectl task get <id>` | `GET /api/tasks/{id}` |
+| `clawgatectl task create --body\|--body-file [--title --tag --repo --branch --model --directory --privilege]` | `POST /api/tasks` |
+
+```bash
+# board summary, filtered SERVER-side (MEASURED live 0.7.87, 2026-08-13: 19 tasks unfiltered, 3 with --limit 3)
+clawgatectl task ls --summary --status open --limit 20 \
+  | jq -r '.[] | "\(.id)\t\(.status)\t\(.title // .directory)\t\((.tags//[])|join(","))\t\(.commentCount)c"'
 
 # one task + its comments (comments are ALREADY here — there is no /comments GET)
-curl -s -H "$H" "$B/api/tasks/161" | jq -r '"#\(.id) [\(.status)] \(.title)\n\n\(.body)\n\n--- comments ---", ((.comments//[])[] | "[\(.author) \(.createdAt[0:16])]\n\(.body)")'
+clawgatectl task get 177 \
+  | jq -r '"#\(.id) [\(.status)] \(.title)\n\n\(.body)\n\n--- comments ---", ((.comments//[])[] | "[\(.author) \(.createdAt[0:16])]\n\(.body)")'
 
-# open work only (the server ignores ?status=)
-curl -s -H "$H" "$B/api/tasks" | jq -r '.[] | select(.status=="open") | "\(.id)\t\(.title)"'
+# name -> id: THE read that replaces `SELECT id FROM agents WHERE name=…`
+clawgatectl agent resolve operator --id       # -> 10
+clawgatectl task create --title t --body b    # -> {"id":183}
 ```
-🔑 **A wrapper CLI was evaluated and rejected** (2026-08-11): ~99% of the saving above is the
-`jq` selection, not the client — rendering buys only 12%, and the shorter invocation saves ~105
-tokens against a ~27k payload. A binary would be a second thing to drift from the API, and a
-stale binary returns confidently wrong output where a stale doc at least 405s at you.
+
+**stdout is JSON and nothing else**; diagnostics, skew notes and resolve candidates go to stderr,
+so `| jq` can never be corrupted. Exit codes are the contract — all MEASURED against live 0.7.87
+on 2026-08-13, none inferred:
+
+| rc | meaning | measured trigger |
+|---|---|---|
+| 0 | ok | `health` → `{"status":"ok","version":"0.7.87"}` |
+| 1 | server error (5xx) | — |
+| 2 | usage / **empty path parameter** | `task get ""` → refuses to send, no request leaves the host (an empty id makes `/api/tasks/` → 301 to a DIFFERENT route) |
+| 3 | auth: clawgate rejected the token (**JSON** 401/403) | `--token wrong-token agent ls` |
+| 4 | not found on a known route | `task get 999999` → `task not found`; `agent resolve nope` → candidates on stderr |
+| 5 | conflict (409) | e.g. a non-tag `PATCH` on an `in_progress` task |
+| 6 | network unreachable / timeout | — |
+| 7 | route absent (router's own text/plain 404) → this CLI is newer than the server | — |
+| 8 | **non-JSON where JSON was expected** | `--api-url https://clawgate.zacx.dev agent ls` |
+
+🔴 **clawgatectl is LAN-first, and the public host fails in a shape the design did not predict.**
+Against `https://clawgate.zacx.dev` with `Accept: application/json`, Authelia answers
+**`401` + `Content-Type: text/html`** and a cross-host `Location:` — *not* the 302 a plain curl
+(sending `Accept: */*`) gets. So the discriminator is the **body type, not the status**: a non-JSON
+401/403 means an edge gate answered and you get **exit 8** with "use the LAN URL"; a **JSON**
+401/403 means clawgate itself rejected the token and you get **exit 3**. Confusing the two sends
+you hunting a credential that is fine. `requireSession` needs an interactive passkey — it cannot be
+scripted at all.
 
 **Route-scope distinction:** the session routes (`/tasks/...`, no `/api` prefix) are LAN/UI-only, and
 the agent route `PATCH /agent/task/status` **forbids `complete`** — the machine
@@ -117,9 +163,10 @@ and **no login QR to manage**.
   `https://login.zacx.dev` (user `zach`, already enrolled). Authelia owns auth/SSO now — manage it
   there, not in clawgate. Memory `authelia-passkey-sso`.
 - **LAN** → `http://192.168.50.250:30302` or `clawgate.workbench.lan` — open, no auth.
-- **Hook-token endpoints** are `/api/send`, `/api/notify`, `/api/suggest`, `/api/response/{id}`,
-  `/api/tasks*`, `/api/tags`, `/api/projects`. Secrets are NOT stored in the skill — retrieve it
-  with `grep '^CLAWGATE_HOOK_TOKEN=' ~/.claude/clawgate.env | cut -d= -f2`.
+- **Which endpoints take the hook token is now enumerated exhaustively** — see "The complete
+  machine surface" at the bottom of this file, derived from the checked-in route golden. Never
+  hand-list it from memory: this bullet used to name seven routes out of fifteen, and that partial
+  list is how `GET /api/agents` stayed invisible for months.
 - 🔴 **The `/api/` prefix does NOT mean "needs the token."** `/api/requests`,
   `/api/openrouter/models`, `/api/push/*` and `/api/auto-approve*` sit behind the no-op
   `requireSession` and are **wide open on the LAN NodePort** — and `POST /api/auto-approve` is
@@ -142,12 +189,75 @@ and **no login QR to manage**.
   agent pod is torn down too. `CLAWGATE_TASK_TTL` is **unset in the live deployment** (verified
   2026-08-12), so the 7d default is what is running; `off` or `0` disables the reaper. Measured live 0.7.85, 2026-08-11: `GET /api/requests` → **200
   with no credential**, `GET /api/tasks` → **401**. Never infer exposure from the path prefix.
-- 🔴 **`/operator/*` (11 routes) is a THIRD credential** — `requireOperatorToken` demands the
-  reserved Operator *agent's* hooks token, not the hook token, which gets
-  `401 {"error":"not the operator"}`.
+- 🔴 **`/operator/*` is a THIRD credential** — `requireOperatorToken` demands the reserved Operator
+  *agent's* hooks token, not the hook token, which gets `401 {"error":"not the operator"}`. It
+  covers **11 of the 13** `/operator*` routes; `GET /operator` and `POST /operator/provision` are
+  `requireSession`, i.e. open on the LAN.
 - Everything else (the UI, `/ui/*`) is OPEN — behind Authelia publicly, directly reachable on the
   LAN. The hook never has a cookie; the UI never calls `/api/response/{id}`.
 - 🔴 **"session auth" is not auth**: `requireSession` is a literal pass-through no-op since 0.7.37
   (`internal/api/auth.go`), so **everything on the LAN NodePort is unauthenticated — including
   `DELETE /tasks/{id}`**. And `requireHookToken` is **enforce-when-set**: with `CLAWGATE_HOOK_TOKEN`
   empty the machine endpoints are wide open too.
+
+---
+
+## The complete machine surface — all 22 `/api/*` routes, with auth
+
+🔴 **Read this before concluding a capability does not exist.** The core SKILL.md used to name
+three clawgate routes (`/health`, `/api/send`, `POST /agents`) out of **118 registered**. That gap
+is not cosmetic: it is why `GET /api/agents` went unnoticed and someone reached into Postgres with
+`SELECT id FROM agents WHERE name=…` for a lookup one authenticated GET already answered.
+
+**Source of truth: `containers/clawgate/internal/api/testdata/routes.golden`** — 118 routes, checked
+in, diffed by `TestRoutesMatchGolden` against what `registerRoutes` actually registers, so a route
+added/removed/re-verbed cannot land without a human eyeballing the diff. Regenerate with
+`UPDATE_ROUTES_GOLDEN=1 go test ./internal/api -run TestRoutesMatchGolden`.
+
+🔴 **The golden records PATTERNS ONLY — it is BLIND to auth.** By the time a handler reaches the
+mux it is already wrapped, so `requireHookToken(h)` and `requireSession(h)` are the same type and
+the gate cannot tell them apart. **A route silently moving between wrappers keeps that test green.**
+The auth column below therefore comes from the registration sites in the code, not from the golden,
+and must be re-read there — it is a snapshot, and the golden will not catch it going stale.
+
+**There are FOUR wrappers, not two** (`routes_golden_test.go`; `server.go`'s own comment claimed
+two until it was corrected):
+
+| wrapper | where | what it actually enforces |
+|---|---|---|
+| `requireSession` | `auth.go:40` | 🔴 **NOTHING — the body is literally `return next`.** A pass-through since 0.7.37 |
+| `requireHookToken` | `auth.go:49` | machine bearer (`Authorization: Bearer` or `X-Clawgate-Token`), **enforce-when-set**: an empty `CLAWGATE_HOOK_TOKEN` opens it |
+| `requireOperatorToken` | `operator.go:58` | bearer must be the reserved agent named `Operator` |
+| `requireAgentToken` | `agent.go:30` | bearer resolves to *any* agent; that agent is injected into the request ctx |
+
+### `requireHookToken` — 15 routes (what clawgatectl and every producer use)
+| route | clawgatectl | note |
+|---|---|---|
+| `GET /api/agents` | `agent ls` / `agent resolve` | the roster; **the Postgres-lookup killer** |
+| `GET /api/tasks` | `task ls` | `?tag= &status= &limit= &summary=1`, all server-side at 0.7.87 |
+| `GET /api/tasks/{id}` | `task get` | comments embedded |
+| `POST /api/tasks` | `task create` | returns `{"id":N}` only |
+| `PATCH /api/tasks/{id}` | — curl | content/dispatch/tags; refined `in_progress` 409 |
+| `PATCH /api/tasks/{id}/status` | — curl | any status incl. `complete`; no in-progress guard |
+| `DELETE /api/tasks/{id}` | — curl | ⚠ tears down a live agent pod |
+| `POST /api/tasks/{id}/comments` | — curl | author from `X-Clawgate-Source`, never the body |
+| `GET /api/tags` | — curl | `[{tag,count}]` |
+| `GET /api/projects` | — curl | ⚠ an OBJECT `{"projects":[…]}`, keyed `name` |
+| `POST /api/send` | — curl | the approval card the PermissionRequest hook posts |
+| `POST /api/notify` | — curl | push-only, no approve/deny card |
+| `POST /api/suggest` | — curl | the Stop hook's "Suggested next step" ingest |
+| `GET /api/response/{id}` | — curl | the hook's decision poll |
+| `DELETE /api/response/{id}` | — curl | the hook's cleanup |
+
+### `requireSession` — 7 `/api/*` routes that are **WIDE OPEN on the LAN NodePort**
+`GET /api/requests` · `GET /api/openrouter/models` · `GET /api/push/vapid-public-key` ·
+`POST /api/push/subscribe` · `POST /api/push/unsubscribe` · `POST /api/auto-approve` ·
+🔴🔴 `POST /api/auto-approve-all` (the firehose — see above).
+
+### The other 96 routes
+Not `/api/*` and mostly not machine-facing: `/ui/*` htmx fragments, the page routes, `/agents*`
+(dispatch, **form-encoded**, `requireSession`), `/tasks/*` session routes (incl. `POST /tasks/merge`,
+which has **no `/api` counterpart** — deliberately, since its audit comments are authored `user`),
+`/operator*` (13), and `/agent/*` (4: `GET /agent/task`, `PATCH /agent/task/status`,
+`POST /agent/task/comment`, `POST /agent/privilege/request`) under `requireAgentToken` — the
+in-devpod agent's own surface, where `PATCH /agent/task/status` **forbids `complete`**.

--- a/nix/pkgs/tools/clawgatectl.nix
+++ b/nix/pkgs/tools/clawgatectl.nix
@@ -1,0 +1,74 @@
+# clawgatectl — the machine client for clawgate's JSON API.
+#
+# 🔴 SOURCE REFERENCE STRATEGY: LOCAL PATH, not fetchFromGitHub. Deliberate.
+#
+# The code lives in a DIFFERENT and PRIVATE repo (ZacxDev/homelab-infra, checked
+# out here as ~/workspace/homelab-talos), under containers/clawgate. Fetching it
+# would mean giving the nix builder a GitHub credential — a netrc/access-token
+# in the store or an impure env var — for a binary whose only consumer is the
+# two machines that already have the checkout. So this follows the precedent
+# already set by tmux-fuzzyclaw.nix next door: point at the working tree.
+#
+# What that BUYS: no credentials anywhere, and `git pull` in homelab-talos plus
+# a `home-manager switch` is the whole upgrade path.
+#
+# What it COSTS, stated plainly:
+#   • NOT reproducible on a fresh host that lacks ~/workspace/homelab-talos.
+#     Handled below by the pathExists guard: such a host simply does not get the
+#     binary, instead of failing the whole switch. `clawgatectl: command not
+#     found` on a new machine means "clone homelab-talos, switch again".
+#   • The build reads a LIVE, routinely-dirty working tree. The binary therefore
+#     reflects whatever is in that tree at switch time, NOT what is committed on
+#     trunk. If you need to know which source a deployed clawgatectl came from,
+#     the answer is `git -C ~/workspace/homelab-talos status`, not the git log.
+#   • An uncommitted edit in that tree changes the src hash, so the next switch
+#     rebuilds. That is a cost, not a bug.
+#
+# If clawgatectl ever needs to build on a host without the checkout, the fix is
+# to move it to its own public repo and swap this for fetchFromGitHub — the rest
+# of this derivation is unchanged by that.
+{ pkgs, workspace }:
+
+let
+  version = "0.7.87";
+
+  # The whole Go module, not just cmd/clawgatectl: go.mod/go.sum live at its
+  # root and buildGoModule needs them for the vendor derivation.
+  srcDir = "${workspace}/homelab-talos/containers/clawgate";
+
+  # Guard on go.mod specifically rather than the directory: a bare directory
+  # check would pass for an empty placeholder dir and fail deep inside the Go
+  # build with a much worse error.
+  available = builtins.pathExists "${srcDir}/go.mod";
+
+  clawgatectl = pkgs.buildGoModule {
+    pname = "clawgatectl";
+    inherit version;
+
+    src = pkgs.lib.cleanSource (/. + srcDir);
+
+    # MEASURED by building with a deliberately wrong hash and taking the "got:"
+    # value from the failure. Do not hand-edit: change go.mod/go.sum and this
+    # must be re-derived the same way.
+    vendorHash = "sha256-vJk2z5piIye+YwhsiyHqhUgXzHd6bHsr1kWH7PqUX7k=";
+
+    # Only the CLI. The module also contains the clawgate SERVER, which pulls in
+    # helm and client-go and has no business being built on a laptop.
+    subPackages = [ "cmd/clawgatectl" ];
+
+    # buildVersion is what the CLI compares the live server's /health version
+    # against to print its one-line skew note, and what exit 7 quotes. Stamping
+    # it from `version` keeps the two from drifting apart silently.
+    ldflags = [ "-s" "-w" "-X main.buildVersion=${version}" ];
+
+    meta = with pkgs.lib; {
+      description = "Machine client for the clawgate JSON API";
+      mainProgram = "clawgatectl";
+      # No `license`: the source is a private repo, and asserting
+      # licenses.unfree here would put the package behind allowUnfree for no
+      # benefit — nothing outside these two machines ever evaluates it.
+      platforms = platforms.linux;
+    };
+  };
+in
+pkgs.lib.optionals available [ clawgatectl ]

--- a/nix/pkgs/tools/clawgatectl.nix
+++ b/nix/pkgs/tools/clawgatectl.nix
@@ -36,10 +36,17 @@ let
   # root and buildGoModule needs them for the vendor derivation.
   srcDir = "${workspace}/homelab-talos/containers/clawgate";
 
-  # Guard on go.mod specifically rather than the directory: a bare directory
-  # check would pass for an empty placeholder dir and fail deep inside the Go
-  # build with a much worse error.
-  available = builtins.pathExists "${srcDir}/go.mod";
+  # 🔴 Guard on THIS COMMAND'S OWN SOURCE FILE, not on the repo and not on the
+  # module. "Does the checkout exist" is the wrong question and was MEASURED
+  # wrong on 2026-08-13: the laptop has ~/workspace/homelab-talos (so a
+  # directory check passes) and it has go.mod (so a module check passes), but
+  # its checkout sits at c417af30 — well behind the commit that added
+  # cmd/clawgatectl. Under either weaker guard the derivation would be built and
+  # `subPackages` would fail deep in the Go build, taking down that host's whole
+  # home-manager switch — which ship.sh reports as a SKIPPED host, the failure
+  # mode this repo's CLAUDE.md warns silently stops all future delivery.
+  # Guarding on main.go also covers the empty-placeholder-directory case.
+  available = builtins.pathExists "${srcDir}/cmd/clawgatectl/main.go";
 
   clawgatectl = pkgs.buildGoModule {
     pname = "clawgatectl";

--- a/nix/pkgs/tools/default.nix
+++ b/nix/pkgs/tools/default.nix
@@ -36,3 +36,8 @@ with pkgs; [
   opencode
 ]
 ++ (import ./tmux-fuzzyclaw.nix { inherit pkgs workspace; })
+# clawgatectl — machine client for the clawgate JSON API. Built from the
+# homelab-talos working tree; the file itself explains why that is a local path
+# and not fetchFromGitHub, and it yields [] on a host without that checkout
+# rather than failing the switch.
+++ (import ./clawgatectl.nix { inherit pkgs workspace; })


### PR DESCRIPTION
Two linked changes: put `clawgatectl` on PATH, then make the `clawgate` skill document the API that actually exists.

## 1. Package `clawgatectl` (`nix/pkgs/tools/clawgatectl.nix`)

`clawgatectl` shipped 2026-08-12 in `homelab-talos` (`containers/clawgate/cmd/clawgatectl`) and was on no host's PATH, so every documented way to talk to clawgate was still a curl incantation that first had to re-read the hook token out of `~/.claude/clawgate.env`.

### Source-reference strategy: LOCAL PATH, not `fetchFromGitHub` — chosen deliberately

There *is* an existing `buildGoModule` precedent, contrary to the brief: `nix/pkgs/tools/tmux-fuzzyclaw.nix` already builds from `${workspace}/tmux-fuzzyclaw`. This follows it.

- The source repo (`ZacxDev/homelab-infra`) is **private**, so `fetchFromGitHub` needs a credential in the nix builder — a netrc or token in the store, or an impure env var — for a binary whose only two consumers already have the checkout.
- **The cost, written into a comment at the top of the file rather than left implicit:** not reproducible on a fresh host lacking the checkout; the build reads a *live, routinely dirty* working tree, so the binary reflects that tree at switch time and **not** what is committed on `trunk`; and an uncommitted edit there changes the src hash and forces a rebuild.
- Deliberately **not** added to `flake.outputs.packages`: the src is an absolute path outside the flake, so it needs `--impure`, and `nix flake check` (which `scripts/verify-agent-work` uses as the nix check) evaluates `packages` in pure mode — adding it there would turn a working check red.
- `subPackages = [ "cmd/clawgatectl" ]` keeps the clawgate **server** (helm + client-go) from ever being compiled on a laptop.

### 🔴 The availability guard found a real would-be breakage

The first guard was `pathExists <src>/go.mod`. **The laptop answers yes to that** — it has `~/workspace/homelab-talos` and it has `go.mod` — but its checkout sits at `c417af30`, behind the commit that added `cmd/clawgatectl`. Under that guard the derivation would have been built there, `subPackages` would have failed deep in the Go build, and **that host's entire `home-manager switch` would have failed** — which `ship.sh` reports as a *skipped* host, the silent stop-delivering failure this repo's CLAUDE.md is built around.

Fixed to guard on this command's own source file, `cmd/clawgatectl/main.go`. Verified three ways plus a negative control, all built as derivations:

```
A. up-to-date checkout             -> 1 package
B. no homelab-talos at all         -> 0 packages
C. stale checkout (laptop's shape) -> 0 packages

against fixture C:
  OLD  pathExists <src>/go.mod                  -> true   (would have built, and failed)
  NEW  pathExists <src>/cmd/clawgatectl/main.go -> false  (skips cleanly)
```

### Actually built, not plausible-looking nix

Real `vendorHash = "sha256-vJk2z5piIye+YwhsiyHqhUgXzHd6bHsr1kWH7PqUX7k="`, derived by building with a wrong hash and taking the `got:` value from the failure.

```
$ nix build --impure -f <expr pinning the flake's own nixpkgs> -o result
$ ./result/bin/clawgatectl health
{
  "status": "ok",
  "uptime": 3010.056765209,
  "version": "0.7.87"
}
```

Home-manager generation built **without activating**:
`nix build --impure '<worktree>#homeConfigurations.zach.activationPackage'` → succeeds; `result/home-path/bin/clawgatectl health` returns `0.7.87` from the LAN, and `result/home-files/.claude/skills/clawgate/SKILL.md` is present at 12281 bytes. Nothing was activated.

## 2. Rewrite the `clawgate` skill

**The route gap was the actual defect.** The skill documented **three** clawgate routes (`/health`, `/api/send`, `POST /agents`) out of **118 registered**. That is why `GET /api/agents` stayed invisible and someone fell back to `SELECT id FROM agents WHERE name=…` for a lookup one authenticated GET already answered.

`reference/task-api.md` now carries the complete `/api/*` inventory — all **22** routes, split by which of the **four** auth wrappers guards them (15 `requireHookToken`, 7 the pass-through `requireSession`, i.e. wide open on the LAN NodePort). Paths come from the checked-in `internal/api/testdata/routes.golden`; **auth does not, and cannot** — the golden sees handlers already wrapped, so a route sliding from `requireHookToken` to the no-op `requireSession` keeps that gate green. That limitation is stated next to the table, so the snapshot carries its own expiry.

### curl → `clawgatectl`, but only where a command exists

Six commands exist and no more, and the skill says "exactly six" in those words. These stay curl, each marked as deliberately curl:

| stays curl | why |
|---|---|
| `POST /api/send` | no CLI verb |
| `POST /api/suggest` | no CLI verb |
| `POST /agents` (dispatch) | form-encoded, answers with an HTML fragment — cannot trivially get a JSON verb |
| `GET /static/icons/*` | not JSON |
| Loki / Prometheus queries in `telemetry.md` | not clawgate at all |

Every documented command was **run against live 0.7.87** before being written down, including the failure modes: `task get ""` → rc 2 with no request sent; `task get 999999` → rc 4; `--token wrong-token` → rc 3; `--api-url https://clawgate.zacx.dev` → rc 8; `--api-url http://localhost:8219` → rc 6. A throwaway task was created (`{"id":183}`), read back, and deleted.

### Two stale claims died, both re-measured

- *"`?status=` and `?limit=` are silently ignored"* — true at 0.7.85, **false at 0.7.87**: they filter server-side. Positive control: 19 tasks unfiltered vs 3 with `--limit 3`; `--status open` returned only `open`.
- *"a wrapper CLI was evaluated and rejected" (2026-08-11)* — superseded. Deleted rather than left to contradict the tool now on PATH; its real objection ("a stale binary returns confidently wrong output") is answered in the replacement text by the verbatim stdout passthrough and the stderr skew note.

Also folded in, since it caused real confusion: `clawgatectl` is **LAN-first**. Against the public host, Authelia answers a JSON-accepting client with **401 + `Content-Type: text/html`** and a cross-host `Location` — not the 302 a plain curl gets. The discriminator is the **body type, not the status**: non-JSON 401/403 ⇒ rc 8 "use the LAN URL"; JSON 401/403 ⇒ rc 3, clawgate rejected the token.

### Byte discipline

`SKILL.md` loads on every trigger; `reference/*.md` costs zero until read.

| file | before | after | delta |
|---|---:|---:|---:|
| `SKILL.md` | 12284 | **12281** | **−3** |
| `reference/task-api.md` | 13823 | 21538 | +7715 |
| `reference/agent-dispatch.md` | 3701 | 3979 | +278 |
| `reference/hooks.md` | 5566 | 5820 | +254 |
| `reference/deploy.md` | 9014 | 9073 | +59 |
| `reference/changelog.md` | 13277 | 13252 | −25 |
| 7 other reference files | — | unchanged | 0 |

`SKILL.md` ends **smaller** than it started: the inventory went to `reference/`, and the clawgatectl additions were paid for by compressing prose duplicated in reference files and by evicting the two stale claims. Each growing reference file took a demotion *from* `SKILL.md` in the same edit (`provisioningStuckTimeout` → `agent-dispatch.md`) or a correctness fix (`hooks.md`'s `/api/suggest` snippet referenced `$B` and `$HOOK`, neither of which was ever defined in the file). No dated session-history block was appended anywhere.

## To activate

Neither the binary nor the skill exists on either host until home-manager runs. **I did not run it.** After merge:

```
scripts/ship.sh
```

(single host: `home-manager switch --flake ~/workspace/devrc --impure`). Then `clawgatectl health` should print `0.7.87`.

⚠ **The laptop will not get `clawgatectl` until its `homelab-talos` checkout is pulled forward** — measured today, it is at `c417af30` and has no `cmd/clawgatectl`. The guard makes that a clean absence rather than a failed switch, and the skill's Key-facts row names it so "command not found" there resolves to "pull homelab-talos", not "the package is broken".
