### PR TITLE
docs(decision): the reopening gate tripped, and it was measuring the writer not the demand

### DIFF
--- a/claudedocs/decision-subsystem-store-rejected-2026-08-11.md
+++ b/claudedocs/decision-subsystem-store-rejected-2026-08-11.md
@@ -91,9 +91,36 @@ Recorded because each was believed, argued from, and then measured false:
 
 ## The falsifiable gate for revisiting
 
-Reopen the design when the index holds **≥5 entries outside its current single scope** or
-**≥5 entries of a non-infra type**. Both counters read zero, and have for the life of the
-store. At that point there is a corpus to design against instead of a hypothesis.
+🔴 **SUPERSEDED 2026-08-13 — the original gate TRIPPED, and it was the wrong question.**
+Both of its conditions are now met, so leaving it stated as-is would have a reader check a
+gate that has already fired and conclude nothing had changed. The original text was:
+
+> Reopen the design when the index holds **≥5 entries outside its current single scope** or
+> **≥5 entries of a non-infra type**. Both counters read zero, and have for the life of the
+> store. At that point there is a corpus to design against instead of a hypothesis.
+
+Measured by `subsystem_touch.py --census` on 2026-08-13 — **29 entries across 5 scopes**
+(`civitai` 1 · `civitai-app-starters` 1 · `datapacket-talos` 25 · `devrc` 1 ·
+`homelab-talos` 1), of which **8 carry `created_by: handoff`**. Against the anchor recorded
+before any second writer existed — **21 entries · 1 scope · 21 unstamped** — that is 4
+scopes that did not exist and 8 entries no infra-recon command could have written.
+
+**Why the original gate was the wrong question.** Its "no demand" premise was CIRCULAR: the
+only writer at the time was `/analyze-service`, an infra-recon command pointed at two
+cluster repos, so only infra entries in one scope *could* exist. "Nothing non-infra exists"
+is not evidence of no demand when nothing is able to create one. The counters were measuring
+the writer, not the demand.
+
+**The question that actually binds is COVERAGE** — does the index cover the repos where work
+happens? That was the constraint the original measurement found: of 290 path-carrying
+sessions, 12 were in the one indexed scope, and 7 of those resolved — a 58% hit rate *inside*
+covered scope, against near-total blindness outside it. Coverage has moved from 1 of ~12
+active repos to **5**. The corpus the gate was waiting for now exists.
+
+**This does not reopen the rejected design.** The narrower rejections stand on their own
+evidence and are unaffected by any of the above: no `type:` taxonomy, no dependency graph,
+no opt-in multi-verb CRUD. What is refuted is only the "no demand" half. Re-read "What the
+strain test actually found" before proposing any of the three.
 
 ## What replaced the premise: derived session association
 

--- a/scripts/lib/subsystem_touch.py
+++ b/scripts/lib/subsystem_touch.py
@@ -3080,12 +3080,19 @@ def report_json(report: TouchReport) -> dict:
 class Census:
     """Counts that answer "did entries accrue outside infra recon?".
 
-    The decision doc's reopening gate is a COUNT ("≥5 entries outside its
-    current single scope"), so the instrument for it must be a count too — not a
-    recollection of which sessions felt productive. This reads the store
-    read-only and reports the raw numbers; it deliberately renders no verdict,
-    because the threshold lives in the decision doc and restating it here would
-    be the same number in two places.
+    The decision doc's reopening gate is a COUNT, so the instrument for it must
+    be a count too — not a recollection of which sessions felt productive. This
+    reads the store read-only and reports the raw numbers; it deliberately
+    renders no verdict, because the criterion lives in the decision doc and
+    restating it here would be the same claim in two places.
+
+    ⚠ That gate TRIPPED and was superseded on 2026-08-13: its original
+    entries-outside-one-scope threshold was met, and it was the wrong question
+    anyway — the binding constraint is COVERAGE (does the index cover the repos
+    where work happens). The per-scope numbers below are still exactly what a
+    coverage question reads, so this class is unchanged. Do not copy the new
+    criterion here either; see
+    `claudedocs/decision-subsystem-store-rejected-2026-08-11.md`.
     """
 
     total: int

--- a/scripts/tests/test_subsystem_touch.py
+++ b/scripts/tests/test_subsystem_touch.py
@@ -981,8 +981,12 @@ class TestCensus:
         assert c.total == 5
 
     def test_it_counts_per_scope_which_is_what_the_gate_asks(self, store: Path) -> None:
-        """The decision doc's reopening gate is "≥5 entries outside its current
-        single scope" — a per-scope count, so the instrument reports one."""
+        """The decision doc's reopening gate reads a per-scope count, so the
+        instrument reports one. The original entries-outside-one-scope threshold
+        was met and superseded on 2026-08-13 by a COVERAGE question (does the
+        index cover the repos where work happens); both read this same per-scope
+        breakdown, so this test is unchanged. The criterion itself stays in the
+        decision doc and is deliberately not restated here."""
         c = st.census(store)
         assert c.by_scope == {SCOPE: 4, OTHER_SCOPE: 1}
         assert c.scopes_with_stamped_entries[OTHER_SCOPE] == {"handoff": 1}


### PR DESCRIPTION
## The problem

`claudedocs/decision-subsystem-store-rejected-2026-08-11.md` stated:

> Reopen the design when the index holds **≥5 entries outside its current single scope** or **≥5 entries of a non-infra type**. Both counters read zero, and have for the life of the store.

Measured today with the instrument the doc itself points at (`subsystem_touch.py --census`):

```
29 entries
  by scope:      civitai 1 · civitai-app-starters 1 · datapacket-talos 25 · devrc 1 · homelab-talos 1
  by created_by: handoff 8 · unstamped 21
```

Against the anchor recorded *before any second writer existed* — **21 entries · 1 scope · 21 unstamped** — both conditions are met and exceeded. A reader checking that gate today would have found a sentence asserting the opposite of what the tool prints, in a document whose whole job is to govern a future decision.

## Why the gate was the wrong question anyway

Its "no demand" premise was **circular**. The only writer at the time was `/analyze-service`, an infra-recon command pointed at two cluster repos — so only infra entries in one scope *could* exist. "Nothing non-infra exists" is not evidence of no demand when nothing is able to create one. The counters measured the **writer**, not the demand.

The constraint the original measurement actually found was **coverage**: of 290 path-carrying sessions, 12 were in the one indexed scope and 7 of those resolved — a 58% hit rate *inside* covered scope against near-total blindness outside it. Coverage has moved from **1 to 5** repos.

The original wording is quoted verbatim in the doc rather than deleted, so the history stays legible.

## Scope — this does NOT reopen the rejected design

The narrower rejections stand on their own evidence and are untouched: no `type:` taxonomy, no dependency graph, no opt-in multi-verb CRUD. Only the "no demand" half is refuted.

## Two docstrings restated the threshold

`subsystem_touch.py`'s `Census` and one test docstring both copied "≥5 entries outside its current single scope" verbatim — including the `Census` docstring that argues restating it "would be the same number in two places". Both now point at the decision doc instead of carrying a criterion. **No behaviour change**: the per-scope census is exactly what a coverage question reads too, so the test is unchanged.

## Gate

```
TOTAL collected=9127  passed=9126  skipped=1  failed=0
PASS  scripts/tests  (collected=3564 passed=3564 skipped=0 floor=3428)
RESULT: PASS (exit=0)
```

No floor change; the gate printed no replacement number. The diff is markdown and docstrings only, so collection cannot move — no test was added or removed, and no red-at-base matrix applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)