### PR TITLE
fix(handoff): the kickoff block pointed at the doc, so /resume never ran and the index was never read

### DIFF
--- a/claude/skills/handoff/SKILL.md
+++ b/claude/skills/handoff/SKILL.md
@@ -55,10 +55,11 @@ Topic argument (optional): `$ARGUMENTS`. If empty, infer a short kebab-case topi
 
 3. **Output a kickoff block** (fenced, ready to copy-paste into the next session) of the form:
    ```
-   Continue the <topic> work. Canonical handoff (read first):
-     <repo>/claudedocs/handoff-<topic>.md
+   /resume — continue the <topic> work. Canonical handoff (read first): <repo>/claudedocs/handoff-<topic>.md
    <one-line of the single most important next action>
    ```
+
+   🔴 **The block MUST begin with a literal `/resume`, and that is not decoration.** MEASURED 2026-08-13: a kickoff emitted as plain prose (`Continue the <topic> work. Canonical handoff (read first): …`) was pasted into the next session, and that session made **zero** calls to `subsystem_recall.py` / `subsystem_touch.py` — `/resume` was never invoked and the skill did **not** auto-fire, despite "pick up where we left off" matching its description almost verbatim. So `/resume` step 4 — the index READ — never ran, and the entry written by *this* step an hour earlier, describing the very subsystem that session was working on, was never seen. A kickoff that only *points at* a doc gets the doc read and the index skipped. Typing the command is what makes the read deterministic instead of luck.
 
    🔴 **Emit this BEFORE step 4's confirm gate, unconditionally.** The kickoff block is the deliverable; step 4 blocks on a y/N, and a user who walks away from that prompt must still have got it.
 

--- a/claudedocs/handoff-subsystem-store.md
+++ b/claudedocs/handoff-subsystem-store.md
@@ -1,97 +1,238 @@
-# Handoff: subsystem-store — 2026-08-12
+# Handoff: subsystem-store — 2026-08-13
 
 ## Goal
 A durable store for subsystem data + history with clean Claude Code integration.
-**Built, deployed, and now measurably working.** What remains is a short list of stale
-claims and one open measurement.
+**Built, deployed, verified end to end.** The read half is now cheap enough to run every
+`/resume` and searchable. What remains is a short list of decisions, not a build.
 
 ## State now
 
-- **Branch:** `main`, clean tracked tree (1 behind origin at time of writing).
-- **`main` is green.** An earlier revision of this doc called it RED; that was wrong — see the resolved note below.
-- **DONE this session** (squash shas on `main`):
-  - `#361` per-scope git store + contained hourly autocommit · `#362` schema repairs · `#375` decision record · `#378` resolver · `#398` `changed_paths` + the opencode extractor fix · `#408` failure propagation in the claude tailer
-  - `#415` **the `/handoff` writer** · `#421` `--session` · `#424` `--pr` · `#432` `--commit`
-  - `#426` **the read half** (`subsystem_recall.py` + `/resume` wiring) · `#429` show existing bullets before an append, + the new-scope versioning clause
-  - Closed as superseded: `#364` (by #366), `#410` (by #407)
-- **IN FLIGHT:** `#418` — an older revision of this doc, still OPEN. This supersedes it; push to the same branch (`docs/handoff-subsystem-store`), do not open a second PR.
-- **Deploy:** both hosts converged and switched throughout. The `#432` skill half needs a `ship.sh` to reach either host (`scripts/` is read from the repo and is already current).
+- **Branch:** `main` at `6eaeb61`, clean tracked tree (4 untracked: `.envrc`, `.opencode/`,
+  `claudedocs/proposed-rules-cut/`, `nix/system/apply-nebula-443.sh.LOCAL-preserved-2026-08-02`).
+- **Merged this session:** `#436` step-4 probe-first + cwd-mismatch routing · `#418` the
+  previous revision of this doc · `#440` the recall **digest** · `#441` the reopening-gate
+  correction · `#442` `--search` + the 100-cap paginated index.
+  (`#437` clawgatectl, `#438` clickup, `#439` clawgate stuck-detector landed from other sessions.)
+- **Deploy:** `ship.sh rc=0` — both hosts converged and **verified**, 429 (workbench) / 391
+  (laptop) managed artifacts checked, **0 dangling on either**. `drift-check.sh` clean.
+- **`/resume` step 4 verified end to end** against the deployed artifact, not the repo:
+  `~/.claude/skills/resume/SKILL.md` resolves into `/nix/store/…-devrc-claude-skills/` and is
+  `cmp`-identical to `origin/main`. Everything dirty is untracked, so the flake source *is*
+  `origin/main`.
 
-### The measurement that was the whole point
-Falsifiability anchor, recorded before any writer existed: **21 entries · 1 scope · 21 unstamped.**
-
+### The numbers that were the point
 ```
-27 entries
-  by scope:      civitai 1 · civitai-app-starters 1 · datapacket-talos 24 · devrc 1
-  by created_by: handoff 6 · unstamped 21
+30 entries
+  by scope:      civitai 1 · civitai-app-starters 1 · datapacket-talos 26 · devrc 1 · homelab-talos 1
+  by created_by: analyze-service 1 · handoff 8 · unstamped 21
 ```
+Anchor recorded before any second writer existed: **21 entries · 1 scope · 21 unstamped.**
+Five scopes now, three of which did not exist this morning.
 
-**Six entries created by the `/handoff` writer across four scopes**, three of which did not
-exist before. Entries are accruing outside infra recon, which is exactly what the rejected
-design's evidence said would never happen — because the only writer at the time was an
-infra-recon command. That reasoning was circular and this is the refutation.
+**`/resume` step 4 cost: 7,871 → ~1,212 tokens (84.6% less) AND strictly more complete** —
+lists all entries instead of hiding 13 of 25 behind a `--limit 12`.
 
 ## Open investigations — live diagnosis state
 
-### RESOLVED — the `st_blocks` failure was a flake, and my diagnosis of it was wrong
-Kept because the *mistake* is the durable part, not the bug.
+### `--session` throws away 112 cleanly-attributable paths, and its refusal states a falsehood
+- **Symptom + exact repro:** a session whose cwd is repo A but whose edits are absolute paths
+  into repo B is refused: `subsystem-touch: transcript cwd does not match: session <id> ran in
+  <A>, but --repo resolves to <B>.` Reported twice in one day by two different agents.
+- **Observed (with values):** the refusal's stated reason — *"Every path in a transcript is
+  relative to the session's own cwd"* (`subsystem_touch.py:1404`) — is **false**. Paths come
+  from the tool call's `file_path`, which is absolute when the caller passed one;
+  `changed_paths.py:270 to_repo_relative()` already accepts absolutes and buckets
+  outside-cwd ones into `outside`, of which only `len(outside)` is emitted (`:280`).
+  Measured over 120 recent transcripts: **1,072 distinct file-tool paths, 945 outside cwd
+  (88%)** — 602 agent scratchpad, 143 temp worktree (only 32 still on disk), **112 another
+  real repo under `~/workspace` (absolute, unambiguous)**, 54 other, 34 home/dotfiles.
+  Independently corroborates the extractor's own 2026-08-11 figure (470 of 3,290 under cwd,
+  14.3%).
+- **Ruled out:** that this is the "four blind windows" story. In the first report the session
+  had **1 file-tool call in 158 records** (the handoff doc itself), 0 subagent turns, 0
+  file-writing `Bash` — no window was hiding work. In the second the agent correctly fell
+  through to `--commit` and wrote a good first entry for `homelab-talos`. **Both agents
+  behaved correctly; the guard's outcome was right and its stated reason was wrong.**
+- **Leading hypothesis:** the guard's safety property (never read an A-relative path as
+  B-relative) is sound and must stay. It over-refuses only because it discards absolute paths
+  that resolve under `--repo`, which need no inference at all. Would take the session window
+  from 127 to 239 attributable paths.
+- **Next probe:** none needed to decide — the yield is measured. Implement: correct the
+  message, then report only paths that are `os.path.isabs()` **and** resolve under
+  `_toplevel(repo)`. Do **not** design around the 143 temp-worktree paths: mostly
+  unrecoverable, and 38 such worktrees were removed this session.
 
-- **What I saw:** `test_st_blocks_CANNOT_see_a_fallocated_partial` failing `assert 16896 == 16904` on two consecutive sandbox runs of pristine `main`, while the same suite passed `991/991` run directly on the host.
-- **What I concluded, wrongly:** a structural sandbox-vs-host split — "green where it is observed, red where it gates" — and I wrote `main is RED` into this doc's state section.
-- **What it actually was:** a **flake**. Another session measured 1 red in 5 runs, with the assertion's **operands reversed between reports** — the tell I never looked for. `#435` (`73e15f8`) landed the real fix: *"st_blocks equality pinned allocator luck, not the code under test."* The defect was real; the diagnosis was not.
-- **The lesson:** two runs plus one contrasting environment is not enough to call a structural split. `claude/RULES.md` says distinguish a flake by wall time and by *whose* time moved, **not by one re-run** — I effectively did two, found a story that fit, and stopped. A cheap third and fourth run would have refuted it.
-
-### The reopening gate in the decision record asks the wrong question
-- **Symptom:** `claudedocs/decision-subsystem-store-rejected-2026-08-11.md` says revisit at "≥5 entries outside the current single scope, or ≥5 non-infra entries".
-- **Observed:** both conditions are now **met** — 3 entries outside the original scope, 6 non-infra by writer. And the gate was the wrong question anyway: the binding constraint measured was **coverage** (of 290 path-carrying sessions, 12 were in the one indexed scope; 7 of those resolved — a **58% hit rate inside covered scope**).
-- **Leading hypothesis:** it should read "does the index cover the repos where work happens" — was 1 of ~12, now 4 of ~12.
-- **Next probe:** none. One-paragraph edit.
-
-### 155 of 290 path-carrying sessions have `cwd` basename literally `empty`
-- **Observed:** `cwd = 'empty'` false for all (not the literal string); bucket is `depth=4`, i.e. `/a/b/empty`; `countIf(repo='')` is **0** for both sources.
-- **Ruled out:** `cwd` absent/empty. Reading `cwd` from the *payload* — my error; opencode's payload has no `cwd`, it is a top-level **column**.
-- **Next probe:** `SELECT DISTINCT cwd FROM activity.events WHERE kind='session-summary' AND splitByChar('/', trimBoth(cwd))[-1]='empty' LIMIT 5`, then inspect that directory on disk.
-
-### opencode can emit a stringified list as a repo-relative path
-- **Observed:** `str(["a.py"])` is `"['a.py']"`, which `to_repo_relative` accepts and emits. Searched the emitted corpus: **zero occurrences** — the path exists, has never fired.
-- **Ruled out:** that `#408`'s claude-side fix covers it. It does not; `#408` validates-and-skips rather than coercing, precisely because coercion manufactures data.
-- **Next probe:** decide validate-and-skip on the opencode side, or a documented known-limitation.
+### The >2-page index shape has never existed in real data
+- **Symptom:** three shipped defects in `#442`'s pagination, all invisible to a green
+  3,679-test suite.
+- **Observed:** largest real scope is 26 entries against a 100-line cap, so the feature's own
+  boundary was unreachable from live data. Found only by building a synthetic 150- and
+  250-entry scope. Root cause of the worst one: the truncation notice was gated on
+  `listing_total > len(listing)` — *"this page is not the whole index"*, true on the last page
+  too — so page 2 of 2 announced 100 phantom entries and routed to `--page 3`.
+- **Ruled out:** that a green gate says anything here. It was green through all three.
+- **Next probe:** when any scope crosses 100 entries, re-run the four page cases against the
+  real store (`--page 1/2/last/past-end`) rather than trusting the synthetic tests.
 
 ## Next steps (ranked)
 
-1. **Correct the reopening gate** in the decision record — both its conditions are now met and it is still the wrong question.
-2. **Merge `#418`** after pushing this revision to its branch.
-3. **Watch the census.** `python3 scripts/lib/subsystem_touch.py --census`. It has moved 21→27 across 4 scopes with 6 handoff-written entries. If that stalls, the writer is not sticking.
-4. Investigate the `empty` cwd bucket; decide the opencode stringified-path question.
-5. **The floors line in `scripts/run-tests.sh` has conflicted on ~9 consecutive PRs.** Per-target floors (`#397`) removed the base-dependent global total but made every test-adding PR touch the table. Worth measuring separately.
-6. **Worktree debt** — 20+ agent worktrees under `.claude/worktrees/`.
+1. **DIFFED AND DECIDED — NOT EXECUTED.** All 23 diffed, see "Worktree verdict" below: 22 DROP,
+   1 KEEP (`#355`), and one salvage the guess would have missed. 🔴 **The drops have NOT been
+   run** — 24 worktrees were still present at 2026-08-13 13:10 (a `git worktree list` count
+   above that includes any agent worktrees created since). **Do step 2 BEFORE executing any
+   drop:** `ea82146` is inside the DROP set and holds the only copy of the two rules.
+2. **Salvage two rules from `zach/rules-multiagent-lessons` (`ea82146`), then drop it.**
+   `cross-repo-worktree` and `sibling-agent-kill` are absent from BOTH `claude/RULES.md` and
+   `claude/RULES-ARCHIVE.md` on `main` — see the verdict section for the measurement. Needs a
+   branch + PR, and both must fit under the `test_rules_size.py` ceiling (read the constants
+   there; budget an eviction in the same commit).
+3. **Fix the `--session` cwd-mismatch message and add the absolute-path window** (above).
+4. **Watch the census.** `python3 scripts/lib/subsystem_touch.py --census`. 21→30 across 5
+   scopes with 8 handoff-written and now 1 `analyze-service`-written. If it stalls, the
+   writers are not sticking.
+5. Investigate the `empty` cwd bucket (155 of 290 path-carrying sessions, `depth=4`,
+   `/a/b/empty`); decide the opencode stringified-path question (`str(["a.py"])` is accepted
+   by `to_repo_relative`; zero occurrences in the emitted corpus — the path exists, has never
+   fired).
+6. **The floors line in `scripts/run-tests.sh`** has conflicted on ~9 consecutive PRs. Worth
+   measuring separately.
+
+## Worktree verdict — 2026-08-13, all 23 diffed
+
+**Method, and why the obvious diff is the wrong one.** `git diff origin/main <head>` is
+dominated by what **main** added since the branch forked — it reported 100–500 changed files
+for branches that touched 3, and reads as "lots of unique work" when the arrow points the
+other way. The measurement that answers the question is: **take the lines the branch ITSELF
+added (`merge-base..head`), and count how many are present in main's current tree.** Script
+kept at `scratchpad/landed.sh`.
+
+🔴 **The instrument was validated before its verdicts were read** — positive control
+`c8b9f8d` (`#442`, known merged) → **100%**; negative control `ed17f4f` (`#355`, never
+merged) → **2%**. It discriminates. The first run of it was also *wrong* (`grep -c` emitting
+`0` twice into an arithmetic context) and the negative control is what exposed that.
+🔴 A **low score is not proof of lost work** — reworded, restructured and *retired-path*
+content all score low. Every head under ~95% was opened and read; the verdict below is from
+the reading, not the number. Two grep traps fired during that reading and were caught by
+controls: `\|` under `grep -E` (literal, not alternation) and a `&&`-chain whose "file does
+not exist" message actually meant "count was 0".
+
+### Ancestry collapses 5 outright (no diffing needed)
+`91aaa21`, `52fd995` are plain `main` commits, 0 own commits. `a901486` ⊂ `9d61558` ⊂
+`80fb7f1`; `aa8fff4` ⊂ `8cb8692`; `191a336` ⊂ `5bce915`.
+
+### DROP — 22
+| worktree | head | evidence |
+|---|---|---|
+| `devrc-perm-junk` | `6974089` | `#380` merged; **100%** of its 371 added lines in main |
+| `devrc-resume-handoff` | `d2e02d4` | `#326` merged; **99%** — the only gap is `claude/commands/resume.md`, a path main **retired** |
+| `devrc-skilldocs` | `42f4022` | `#213` merged. Its 2 later commits fixed a stale "73 pass / 2 skip" e2e figure — **main's clawgate SKILL.md contains no `73` at all**, the sentence was rewritten. Fix is moot |
+| `agent-a0604347…` | `c8b9f8d` | `#442` merged; **100%** |
+| `agent-a0fc45cd…` (`p377-docfix`) | `191a336` | **99%**; also a strict ancestor of `integration-v2` |
+| `agent-a1d607f8…` (`fix361-worktree`) | `51cc025` | **99%**. Residual is *older wording* — its `die "git is not on PATH"` is in main as `die "the version-control binary is not on PATH"` |
+| `agent-ae800ad6…` (`fix361-round3`) | `a5e1f98` | **99%**; same — main's `commit.sh` has `ASI_IGNORED`/`ASI_CANDFILE`/`ASI_SORTED`/`ASI_NOHOOKS`/`cleanup()` and is the newer copy |
+| `agent-aa81bad9…` (`pr362-fix-83`) | `9404ab4` | scored **0%** only because it edits retired `claude/commands/`. Every marker of its store-safety spec is in `claude/skills/analyze-service/SKILL.md` — incl. the literal sha `60e6d9d` |
+| `agent-af19599e…` (`integration-v2`) | `5bce915` | **99%** of 4,036 added lines; an integration branch of `#377`/`#391`/`#384`/`#392`, all landed |
+| `agent-a3847d8a…`, `agent-acc29d9b…` | `91aaa21`, `52fd995` | 0 own commits — plain `main` checkouts |
+| `agent-a3c74c3d…` | `0ada9b8` | **92%**; script+tests 100%, SKILL.md restructured into `reference/*.md` |
+| `agent-a463578a…` | `80fb7f1` | **95%**; the 66 residual script lines are the superseded busy/idle/stale counter model. Its headline case IS in main — `_NO_SERVER_RE` + the doc at `scripts/session-manager:62,1432` |
+| `agent-a4f43a71…` | `ac35b32` | **99%**; 7 residual lines are prose reflow |
+| `agent-a5abb942…`, `agent-a91600df…`, `agent-af945752…` | `aa8fff4`, `a901486`, `9d61558` | strict ancestors of heads already dropped |
+| `agent-a688672b…` | `8cb8692` | **100%** |
+| `agent-a9bbee8b…` | `6b86d64` | **97%**; residual is the **pre-rename** `AGENT_IDLE_THRESHOLD_SECS`, which landed in `#439` as `STUCK_THRESHOLD_SECS` |
+| `…/scratchpad/wt-436` | `6e16ed1` | **100%** |
+| `/tmp/sa2` | `a41f3e5` | `#332` merged; **85%**. Residual is `claude/commands/prune-skill.md` (retired) plus `test_real_skills_classify_…`, a corpus test pinned to `manage-alerts`/`app-blocks` — skills that do not exist here |
+
+### KEEP — 1
+- `agent-ad6f8275…` / `airvpn-killswitch-env` `ed17f4f` — **`#355`, OPEN, marked
+  🔴 DO-NOT-MERGE-YET**. 1,607 added lines, **2%** in main. Genuinely unlanded, deliberately.
+
+### SALVAGE then drop — 1 (the case the "superseded intermediate" guess would have lost)
+`devrc-rules-lessons` / `zach/rules-multiagent-lessons` `ea82146` — `#313` **merged**, and it
+scores **1%** by bytes, which means nothing: RULES.md is continuously reworded. Measured by
+**anchor** instead, 20 of its 22 lessons are in main. Two are not, in **either** `RULES.md`
+or `RULES-ARCHIVE.md`:
+
+- 🔴 **`cross-repo-worktree`** — `isolation: "worktree"` builds the worktree from your
+  **CURRENT** repo, not the repo the task names. Dispatch at a different repo than your cwd
+  and every agent silently gets a worktree of the wrong one, with no error. Tell: an agent
+  reporting that a file named in its brief does not exist.
+- 🔴 **`sibling-agent-kill`** — filter resolved PIDs by `/proc/<pid>/cwd` to your own
+  worktree before killing; a box-wide `-f` pattern reaches a *sibling agent's* processes. One
+  auditor clearing its own hung run killed ~15 PIDs and destroyed another agent's in-flight
+  test run, whose next attempt collapsed with 0 files collected and exit 144 — both readable
+  as code defects. Main's `pgrep`/`pkill` bullet stops at `/proc/<pid>/cmdline`.
+
+Two near-misses, deliberately NOT salvaged: `cheap-control` and `count-tests` anchors are
+gone but their rule text is in main (`count-tests` → `count-not-exit-code`); `stale-gate-base`
+survives compressed inside the `merged-tree` bullet as "check how far behind main a PR is".
+
+🔴 **Removing a DETACHED worktree makes its commits unreachable and GC-able** — the 8
+detached heads have no branch ref holding them. Tag them before removal if any of the
+"superseded" calls above is to stay reversible:
+`git tag preserved/<name> <sha>` for `0ada9b8 80fb7f1 ac35b32 aa8fff4 8cb8692 a901486
+6b86d64 9d61558`. Branch-backed worktrees are safe to `git worktree remove` — the ref keeps
+the commits.
 
 ## Gotchas / decisions / dead-ends
 
-- 🔴 **A large subsystem store was proposed and REJECTED on measurement** (no `type:` taxonomy, no dependency graph, no multi-verb CRUD). Read `decision-subsystem-store-rejected-2026-08-11.md` before re-proposing. **But its "no demand" half was CIRCULAR** — the only writer was infra-scoped, so only infra entries could exist. The census above is the refutation.
-- **Four path sources, blind in different directions — never merge their outputs.** git window: misses work merged during the session. `--session`: misses **subagent** work (`isSidechain` excluded, 196 of 733 file-tool calls) and `Bash`-written files, and is blind in worktree-mandated repos (25 paths outside cwd, 0 inside). `--pr`: sees subagents, but is the **branch union**, and misses direct pushes — **144 of 200** recent `datapacket-talos` trunk commits carry no `(#N)`. `--commit`: the primitive the others reduce to. The flags are argparse-exclusive on purpose.
-- **`Edit` vs `Write` on an entry, MEASURED:** `Write` silently loses a concurrent append; `Edit` is **bounded**, so the other bullet survives. 🔴 It does **not** reliably fail loudly — an earlier version of this rationale said it did and was wrong. The real safeguard is **re-read and re-apply to current bytes**; never treat "no error" as evidence you were alone.
-- **A brand-new scope is `git init`ed, identity-seeded and committed by the store's own hourly timer** — measured twice. Do not create the repo yourself; an entry there is unversioned for up to an hour, which is the normal window.
-- **`gh pr view --json files` silently truncates at 100** while `changedFiles` reports the truth. Guarded cap-agnostically. My own verification missed it by checking a 4-file PR.
-- **`git diff-tree` exits 0 and prints nothing** for a merge, a root commit, a blob and a tree — git's own silent zeros, each closed before the diff runs.
-- 🔴 **The store must never gain a remote**; no line of it may reach a public repo. `devrc` is PUBLIC. Each scope's `README.md` is authoritative.
-- **Instrument validation kept being the actual finding.** Six mutation harnesses this session produced wrong verdicts before correction — a stale `.pyc`; a sweep whose `git checkout --` reverted the change under test; a parser regex-matching a traceback body; one environment-dependent on the pytest launch directory; one that overwrote the repo's `conftest.py`; one whose anchor matched twice, silently retiring its own guard.
-- **Floor deltas must be attributed to the branch, not the target's movement.** Three near-misses: `+118` measured `+68`; `+68` was really `+64`; `+124` was really `+109`.
-- **`FETCH_HEAD` is repo-global** and clobbered by concurrent sessions — it produced one false verification here.
-- **`git diff --stat <branch>..origin/main` renders the branch's own edits with inverted sign.** Use `git log <base>..origin/main -- <path>`.
-- **zsh eats `:s`/`:h`/`:p` after an unbraced `$VAR` in a git ref.** Brace it.
-- **`git -C $VAR` defeats the bash-guard's repo detection** — it judges the caller's directory instead. Pass an absolute path.
+- 🔴 **`nix build` returns a CACHED result silently** — 0-byte log, exit 0, and `grep FAILED`
+  matches nothing. That zero is indistinguishable from "no failures". Use `--rebuild` to force
+  a genuine re-run, but **`--rebuild` errors on a drv that was never built** (`some outputs …
+  are not valid, so checking is not possible`). For a cached drv, `nix log <drv>` *is* the real
+  build output. A valid cached output is itself proof the suite passed — `flake.nix:268` fails
+  the derivation when `run-tests.sh` exits non-zero.
+- 🔴 **A pytest failure does NOT print `FAILED` here.** The runner uses `-q … -rs`
+  (`run-tests.sh:1015`), which overrides the short summary to skips only. Look for
+  `=== FAILURES ===`, the pytest summary line, and `FAIL  <dir>  (… failed=N …)`. Runner lines
+  are prefixed `devrc-pytests>`, so **never anchor a grep at `^`** — that silently matched
+  nothing here and would have read as green.
+- 🔴 **Never pipe `ship.sh` or a gate to `tail`** — the pipe destroys the exit status. Reported
+  `exit 0` over a real `rc=12` this session. Redirect to a file and echo `$?`.
+- 🔴 **`rev-list origin/main..HEAD` is NOT a merged-ness test.** A squash merge never makes the
+  branch head an ancestor, so it stays non-zero forever — it flagged **all 52** worktree
+  branches as unmerged work. Classify by PR state (`gh pr list --state all --json
+  headRefName,state`) or by `git diff origin/main <head>` being empty.
+- 🔴 **A deploy can delete an unmanaged directory.** A `ship.sh` switch removed
+  `~/.claude/skills/clickup` — described in `home.nix:1201` as a *"standalone repo"* and the
+  only copy. Recovered only because `#438` had committed 32 of its files hours earlier; its
+  nested `.git` was **not** captured and is gone. Check what a switch will touch before
+  running one over an unmanaged path.
+- **Four path sources, blind in opposite directions — never merge their outputs.** git window:
+  misses work merged during the session. `--session`: misses **subagent** work (196 of 733
+  file-tool calls), `Bash`-written files, worktree-mandated repos, cross-repo sessions.
+  `--pr`: sees subagents, but is the **branch union** and misses direct pushes (144 of 200
+  recent `datapacket-talos` trunk commits carry no `(#N)`). `--commit`: the primitive the
+  others reduce to. The flags are argparse-exclusive on purpose.
+- **`Edit` vs `Write` on an entry, MEASURED:** `Write` silently loses a concurrent append;
+  `Edit` is bounded so the other bullet survives. 🔴 It does **not** reliably fail loudly — an
+  earlier version of this rationale said it did and was wrong. The real safeguard is
+  **re-read and re-apply to current bytes**.
+- **A brand-new scope is `git init`ed, identity-seeded and committed by the store's own hourly
+  timer** — measured three times now (`homelab-talos` was unversioned when written, 1 commit
+  and 0 remotes an hour later). Do not create the repo yourself.
+- 🔴 **The store must never gain a remote**; no line of it may reach a public repo. `devrc` is
+  PUBLIC. Each scope's `README.md` is authoritative.
+- **The `st_blocks` failure was a flake and the structural-split diagnosis was WRONG** —
+  retracted, do not re-derive. `#435` fixed it. Separately: no stored gate log has **ever**
+  recorded `failed=2` (248 TOTAL lines across 271 logs: values are 0,1,3,20,27,28,29,30,144),
+  and nix keeps only the most recent log per derivation, so a red run later rebuilt green
+  loses its evidence entirely.
 
 ## How to verify
 
 ```bash
 D=/home/zach/workspace/devrc
-# all four windows (read-only; the tool never writes)
+# the read half — digest, index, search (READ-ONLY, never writes, no network, no subprocess)
+python3 $D/scripts/lib/subsystem_recall.py --repo $D
+python3 $D/scripts/lib/subsystem_recall.py --scope datapacket-talos --list
+python3 $D/scripts/lib/subsystem_recall.py --scope datapacket-talos --search "nginx ratelimit"
+python3 $D/scripts/lib/subsystem_recall.py --scope datapacket-talos --search "zzz kryptonite"  # must report NO MATCH + closest candidate
+
+# all four write windows (read-only; the tool never writes)
 python3 $D/scripts/lib/subsystem_touch.py --repo $D --session <scratchpad-uuid>
 python3 $D/scripts/lib/subsystem_touch.py --repo $D --pr <n>[,...]
 python3 $D/scripts/lib/subsystem_touch.py --repo $D --commit <sha>[,...]
-# the read half
-python3 $D/scripts/lib/subsystem_recall.py --repo $D
+
 # the falsifiability counter — anchor was 21 / 1 scope / 21 unstamped
 python3 $D/scripts/lib/subsystem_touch.py --census
 
@@ -101,6 +242,10 @@ for s in $(ls -d ~/.claude/analyze-service-index/*/ | xargs -n1 basename); do
   echo "$s: $(git -C $T rev-list --count HEAD) commits, $(git -C $T remote -v | wc -l) remotes"
 done
 
-# the authoritative gate
-nix build .#checks.x86_64-linux.pytests --no-link --print-build-logs 2>&1 | grep -E 'TOTAL collected|RESULT|FAIL'
+# the authoritative gate — read the CONTENT, never the exit code of a pipe
+nix build .#checks.x86_64-linux.pytests --no-link --print-build-logs > /tmp/gate.log 2>&1; echo "rc=$?"
+grep -aE 'TOTAL +collected|RESULT: (PASS|FAIL)' /tmp/gate.log
+
+# deploy + host parity (read-only deadman)
+scripts/drift-check.sh
 ```


### PR DESCRIPTION
## The measurement

`/handoff` step 3 emitted a kickoff block as plain prose:

```
Continue the <topic> work. Canonical handoff (read first):
  <repo>/claudedocs/handoff-<topic>.md
<one-line of the single most important next action>
```

That block was pasted into the next session (transcript `d5db63c4-b3df-42a5-bbde-e06c25254ddd`, 227 records). Measured in that transcript:

- **0** calls to `subsystem_recall.py` or `subsystem_touch.py`
- **0** `<command-name>` blocks — `/resume` was never invoked
- the resume skill did **not** auto-fire, despite *"pick up where we left off"* matching its description almost verbatim
- the 7 incidental `subsystem_recall` mentions are file paths inside diffs and the handoff doc's own "How to verify" block being **read as text**, never executed

So `/resume` step 4 — the index READ — never ran.

## Why that matters more than it looks

`#440` and `#442` made that read **84.6% cheaper** and searchable *for the express purpose* of running on every `/resume`. The very next session, continuing this exact work, read none of it — and the `devrc/subsystem-index` entry written by step 4 **an hour earlier**, describing that session's own subsystem with two bullets about traps in it, sat unread.

A kickoff that only *points at* a doc gets the doc read and the index skipped.

## The fix

The block now begins with a literal `/resume`, which loads the skill deterministically instead of relying on description auto-fire. The measurement is recorded inline in `SKILL.md` so a future reader does not mistake it for cosmetics and revert it.

## Also in this PR

**The resume session's worktree verdict, rescued.** It was sitting **uncommitted** in the working tree with two agents active in worktrees — the stranded-work hazard `RULES.md` names. Its method is worth keeping: it validated its own instrument against a known-merged control (`c8b9f8d` → 100% of branch-added lines present in main) and a never-merged one (`ed17f4f` → 2%), and two of its own grep bugs were caught by those controls rather than by inspection.

**Its next-step 1 label corrected: `DONE` → `DIFFED AND DECIDED — NOT EXECUTED`.** 22 worktrees are flagged DROP and **none has been dropped**. `ea82146` is inside that set and holds the only copy of two rules — `cross-repo-worktree` and `sibling-agent-kill` — which I verified by grep are absent from **both** `claude/RULES.md` and `claude/RULES-ARCHIVE.md` on `origin/main`. Executing the drops before the salvage would destroy exactly what the salvage exists to rescue.

## Verification

No behaviour change to any tool; this is skill prose plus a handoff doc.

Pins checked before commit, all intact:
- `**Output a kickoff block**` — the anchor `test_the_kickoff_block_precedes_the_confirm_gate` indexes on
- `The kickoff block is the deliverable`
- the `kickoff < index-step < confirm-gate` ordering invariant (measured: 3269 < 4538 < 15021)

Gate on the pushed commit:

```
TOTAL collected=9267  passed=9266  skipped=1  failed=0
PASS  scripts/tests  (collected=3704 passed=3704 skipped=0 floor=3428)
RESULT: PASS (exit=0)
```

No floor change. Collection is unmoved from main, as expected for a markdown-only diff — no red-at-base matrix applies.

**Not deployed.** `claude/skills/` is `home.file`-managed, so both hosts keep the old prose kickoff until `ship.sh` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)